### PR TITLE
fix(board): require current persistence snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- **Breaking (Board persistence wire)**: Board persistence now accepts only the
+  current JSONL schema. Any invalid or retired row makes the Board backend
+  explicitly `reset-required`; valid rows from a mixed snapshot are never
+  partially published, while Keeper/server startup continues with Board-scoped
+  read/write failures. No migration or compatibility reader is included.
 - **Breaking (approval snapshot wire)**: `summary_status.failed.retryable`
   is no longer accepted and discarded while loading pending approvals. Current
   snapshots contain only `status` and `reason`; snapshots carrying the retired

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -736,7 +736,13 @@ let run_cmd host port cli_base_path =
             Log.Server.info "[Shutdown] Phase 3/4 BOARD: flush starting (timeout=2.0s)";
             (try
               Eio.Time.with_timeout_exn clock 2.0
-                (fun () -> Board_dispatch.flush ())
+                (fun () ->
+                  match Board_dispatch.flush () with
+                  | Ok () -> ()
+                  | Error error ->
+                    Log.Server.warn
+                      "[Shutdown] Phase 3/4 BOARD: unavailable: %s"
+                      (Board.show_board_error error))
             with
             | Eio.Time.Timeout ->
                 Log.Server.warn

--- a/bin/main_stdio_eio.ml
+++ b/bin/main_stdio_eio.ml
@@ -3,6 +3,7 @@
 module Mcp_eio = Masc.Mcp_server_eio
 module Server_startup_state = Masc.Server_startup_state
 module Shutdown_hooks = Masc.Shutdown_hooks
+module Board = Masc.Board
 module Board_dispatch = Masc.Board_dispatch
 
 open Cmdliner
@@ -136,7 +137,14 @@ let run_cmd cli_base_path =
     (Server_bootstrap_loops.start_background_maintenance ~sw ~clock ~env state);
   Fun.protect
     ~finally:(fun () ->
-      (try Board_dispatch.flush () with
+      (try
+         match Board_dispatch.flush () with
+         | Ok () -> ()
+         | Error error ->
+           Log.Misc.warn
+             "shutdown: board flush unavailable: %s"
+             (Board.show_board_error error)
+       with
        | Eio.Cancel.Cancelled _ -> ()
        | exn ->
          Log.Misc.warn

--- a/lib/board/board_core_json.ml
+++ b/lib/board/board_core_json.ml
@@ -133,7 +133,22 @@ let reaction_toggle_result_to_yojson (result : reaction_toggle_result) : Yojson.
     ]
 ;;
 
+let has_exact_fields allowed = function
+  | `Assoc fields ->
+    let keys = List.map fst fields in
+    List.length keys = List.length (List.sort_uniq String.compare keys)
+    && List.for_all (fun key -> List.mem key allowed) keys
+  | _ -> false
+;;
+
 let reaction_of_yojson (json : Yojson.Safe.t) : reaction option =
+  if
+    not
+      (has_exact_fields
+         [ "target_type"; "target_id"; "user_id"; "emoji"; "created_at" ]
+         json)
+  then None
+  else
   match
     ( Safe_ops.json_string_opt "target_type" json
     , Safe_ops.json_string_opt "target_id" json
@@ -145,8 +160,16 @@ let reaction_of_yojson (json : Yojson.Safe.t) : reaction option =
     (match
        reaction_target_type_of_string_opt target_type_raw, Agent_id.of_string user_id_raw
      with
-     | Some target_type, Ok user_id ->
-       Some { target_type; target_id; user_id; emoji; created_at }
+     | Some target_type, Ok user_id
+       when List.exists (String.equal emoji) board_reaction_emojis ->
+       let target_id_is_current =
+         match target_type with
+         | Reaction_post -> Result.is_ok (Post_id.of_string target_id)
+         | Reaction_comment -> Result.is_ok (Comment_id.of_string target_id)
+       in
+       if target_id_is_current
+       then Some { target_type; target_id; user_id; emoji; created_at }
+       else None
      | _ -> None)
   | _ -> None
 ;;

--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -55,6 +55,7 @@ let sort_order_of_string_opt s =
 
 type board_backend =
   | Jsonl of Board.store
+  | Unavailable of Board.board_error
 
 (** Marker carried inside [Active] tracking whether the flusher fiber has
     been spawned for the current backend.  [Eio.Fiber.fork_daemon] returns
@@ -208,8 +209,9 @@ let ensure_flusher_actor store =
         let current = Atomic.get backend_state in
         match current with
         | Uninitialized -> ()
+        | Active (Unavailable _, _) -> ()
         | Active (_, true) -> ()
-        | Active (b, false) ->
+        | Active ((Jsonl _ as b), false) ->
             let cas_won =
               if consume_forced_flusher_start_cas_conflict_for_test () then false
               else Atomic.compare_and_set backend_state current (Active (b, true))
@@ -282,12 +284,22 @@ let init_jsonl () =
   if match Atomic.get backend_state with Active _ -> true | Uninitialized -> false then
     Log.BoardLog.warn "already initialized, ignoring init_jsonl"
   else begin
-    let store = Board.global () in
-    let backend = Active (Jsonl store, false) in
-    if Atomic.compare_and_set backend_state Uninitialized backend then begin
-      ensure_flusher_actor store;
-      Log.BoardLog.info "JSONL backend initialized"
-    end else
+    let backend =
+      match Board.global () with
+      | Ok store -> Active (Jsonl store, false)
+      | Error error -> Active (Unavailable error, false)
+    in
+    if Atomic.compare_and_set backend_state Uninitialized backend then
+      match backend with
+      | Active (Jsonl store, _) ->
+        ensure_flusher_actor store;
+        Log.BoardLog.info "JSONL backend initialized"
+      | Active (Unavailable error, _) ->
+        Log.BoardLog.error
+          "Board backend unavailable: %s"
+          (Board.show_board_error error)
+      | Uninitialized -> assert false
+    else
       Log.BoardLog.warn "already initialized concurrently, ignoring init_jsonl"
   end
 
@@ -304,18 +316,25 @@ let backend () =
   | Active (Jsonl store as backend, _) ->
       ensure_flusher_actor store;
       backend
+  | Active (Unavailable _ as backend, _) -> backend
   | Uninitialized ->
       Log.BoardLog.warn "backend() called before server init, auto-initializing JSONL";
-      let store = Board.global () in
-      let b = Jsonl store in
+      let b =
+        match Board.global () with
+        | Ok store -> Jsonl store
+        | Error error -> Unavailable error
+      in
       let backend_val = Active (b, false) in
       let _ = Atomic.compare_and_set backend_state Uninitialized backend_val in
       match Atomic.get backend_state with
       | Active (Jsonl active_store as active_b, _) ->
           ensure_flusher_actor active_store;
           active_b
+      | Active (Unavailable _ as unavailable, _) -> unavailable
       | Uninitialized ->
-          ensure_flusher_actor store;
+          (match b with
+           | Jsonl store -> ensure_flusher_actor store
+           | Unavailable _ -> ());
           b
 
 let sort_posts_in_memory ~sort_by (posts : Board.post list) =
@@ -380,6 +399,7 @@ let emit_post_created ~(audience : Board.audience) (post : Board.post) =
 let create_post ~author ~content ?title ?body ~post_kind ?meta_json
     ?visibility ?ttl_hours ?hearth ?thread_id ?origin () =
   match backend () with
+  | Unavailable error -> Error error
   | Jsonl store ->
     (match
        Board.create_post_with_audience
@@ -405,6 +425,7 @@ let create_post ~author ~content ?title ?body ~post_kind ?meta_json
 let create_post_once_by_fusion_run_id ~fusion_run_id ~author ~content ~post_kind
     ?meta_json ~visibility ~ttl_hours ~origin () =
   match backend () with
+  | Unavailable error -> Error error
   | Jsonl store ->
     (match
        Board.create_post_once_by_fusion_run_id store ~fusion_run_id ~author
@@ -431,12 +452,14 @@ let create_post_once_by_fusion_run_id ~fusion_run_id ~author ~content ~post_kind
 
 let update_post ~post_id ~editor ~content ?title ?body ?new_author () =
   match backend () with
+  | Unavailable error -> Error error
   | Jsonl store ->
       Board.update_post_with_outcome store ~post_id ~editor ~content ?title
         ?body ?new_author ()
 
 let get_post ~post_id =
   match backend () with
+  | Unavailable error -> Error error
   | Jsonl store -> Board.get_post store ~post_id
 
 let list_posts ?(visibility_filter = None) ?hearth ?author_filter ?exclude_author_filter
@@ -469,6 +492,7 @@ let list_posts ?(visibility_filter = None) ?hearth ?author_filter ?exclude_autho
        | None -> Stdlib.Fun.id)
   in
   match backend () with
+  | Unavailable error -> Error error
   | Jsonl store ->
       let needs_full_scan =
         Option.is_some author_filter
@@ -519,23 +543,27 @@ let list_posts ?(visibility_filter = None) ?hearth ?author_filter ?exclude_autho
                 not (agent_matches_author_filter ~needle post.author))
               filtered
       in
-      Board.take limit filtered
+      Ok (Board.take limit filtered)
 
 let current_post_cursor () =
   match backend () with
-  | Jsonl store -> Board.current_post_cursor store
+  | Unavailable error -> Error error
+  | Jsonl store -> Ok (Board.current_post_cursor store)
 
 let get_comments ~post_id =
   match backend () with
+  | Unavailable error -> Error error
   | Jsonl store -> Board.get_comments store ~post_id
 
 let get_post_and_comments ~post_id ?comment_offset ?comment_limit () =
   match backend () with
+  | Unavailable error -> Error error
   | Jsonl store -> Board.get_post_and_comments store ~post_id ?comment_offset ?comment_limit ()
 
 let add_comment ~post_id ~author ~content ?parent_id
     ?(ttl_hours = Board.Limits.default_ttl_hours) () =
   match backend () with
+  | Unavailable error -> Error error
   | Jsonl store ->
       (match
          Board.add_comment_with_audience store ~post_id ~author ~content ?parent_id
@@ -569,11 +597,13 @@ let add_comment ~post_id ~author ~content ?parent_id
 
 let current_vote_for_post ~voter ~post_id =
   match backend () with
+  | Unavailable error -> Error error
   | Jsonl store -> Board.current_vote_for_post store ~voter ~post_id
 
 let vote ~voter ~post_id ~direction =
   let result =
     match backend () with
+    | Unavailable error -> Error error
     | Jsonl store -> Board.vote store ~voter ~post_id ~direction
   in
   (match result with
@@ -593,11 +623,13 @@ let vote ~voter ~post_id ~direction =
 
 let current_vote_for_comment ~voter ~comment_id =
   match backend () with
+  | Unavailable error -> Error error
   | Jsonl store -> Board.current_vote_for_comment store ~voter ~comment_id
 
 let vote_comment ~voter ~comment_id ~direction =
   let result =
     match backend () with
+    | Unavailable error -> Error error
     | Jsonl store -> Board.vote_comment store ~voter ~comment_id ~direction
   in
   (match result with
@@ -660,6 +692,7 @@ let emit_reaction_board_signal store (toggled : Board.reaction_toggle_result) =
 let toggle_reaction ~target_type ~target_id ~user_id ~emoji =
   let result =
     match backend () with
+    | Unavailable error -> Error error
     | Jsonl store ->
         (match Board.toggle_reaction store ~target_type ~target_id ~user_id ~emoji with
          | Ok toggled as ok ->
@@ -690,38 +723,47 @@ let toggle_reaction ~target_type ~target_id ~user_id ~emoji =
 
 let list_reactions ~target_type ~target_id ?user_id () =
   match backend () with
+  | Unavailable error -> Error error
   | Jsonl store -> Board.list_reactions store ~target_type ~target_id ?user_id ()
 
 let list_reactions_batch ~targets ?user_id () =
   match backend () with
-  | Jsonl store -> Board.list_reactions_batch store ~targets ?user_id ()
+  | Unavailable error -> Error error
+  | Jsonl store -> Ok (Board.list_reactions_batch store ~targets ?user_id ())
 
 let stats () =
   match backend () with
-  | Jsonl store -> Board.stats store
+  | Unavailable error -> Error error
+  | Jsonl store -> Ok (Board.stats store)
 
 let list_comments ?(limit = 1000) () =
   match backend () with
-  | Jsonl store -> Board.list_comments store ~limit ()
+  | Unavailable error -> Error error
+  | Jsonl store -> Ok (Board.list_comments store ~limit ())
 
 let list_hearths () =
   match backend () with
-  | Jsonl store -> Board.list_hearths store
+  | Unavailable error -> Error error
+  | Jsonl store -> Ok (Board.list_hearths store)
 
 let set_thread_id ~post_id ~thread_id =
   match backend () with
+  | Unavailable error -> Error error
   | Jsonl store -> Board.set_thread_id store ~post_id ~thread_id
 
 let set_pinned ~post_id ~pinned =
   match backend () with
+  | Unavailable error -> Error error
   | Jsonl store -> Board.set_pinned store ~post_id ~pinned
 
 let delete_post ~post_id =
   match backend () with
+  | Unavailable error -> Error error
   | Jsonl store -> Board.delete_post store ~post_id
 
 let search ~query ~limit =
   match backend () with
+  | Unavailable error -> Error error
   | Jsonl store ->
       let query_lower = String.lowercase_ascii query in
       let matches_str s =
@@ -733,35 +775,40 @@ let search ~query ~limit =
         || matches_str (Board.Agent_id.to_string p.author)
         || (match p.hearth with Some h -> matches_str h | None -> false)
       in
-      Board.search_posts store ~predicate ~limit
+      Ok (Board.search_posts store ~predicate ~limit)
 
 let flush () =
   match Atomic.get backend_state with
-  | Active (Jsonl store, _) -> Board.flush_dirty store
-  | Uninitialized -> ()
+  | Active (Jsonl store, _) ->
+    Board.flush_dirty store;
+    Ok ()
+  | Active (Unavailable error, _) -> Error error
+  | Uninitialized -> Ok ()
 
 let get_all_karma () =
   match backend () with
-  | Jsonl store -> Board.get_all_karma store
+  | Unavailable error -> Error error
+  | Jsonl store -> Ok (Board.get_all_karma store)
 
 let get_agent_karma ~agent_name =
   match backend () with
-  | Jsonl store -> Board.get_agent_karma store ~agent_name
+  | Unavailable error -> Error error
+  | Jsonl store -> Ok (Board.get_agent_karma store ~agent_name)
 
 let karma_score_for_direction = Board.karma_score_for_direction
 
 let get_karma_ledger ?agent ?(limit = max_int) () =
-  let events =
-    match backend () with
-    | Jsonl store -> Board.build_karma_ledger store
-  in
-  let filtered =
-    match agent with
-    | None -> events
-    | Some name ->
-        List.filter (fun (e : Board.karma_event) -> String.equal e.recipient name) events
-  in
-  Board.take limit filtered
+  match backend () with
+  | Unavailable error -> Error error
+  | Jsonl store ->
+    let events = Board.build_karma_ledger store in
+    let filtered =
+      match agent with
+      | None -> events
+      | Some name ->
+          List.filter (fun (e : Board.karma_event) -> String.equal e.recipient name) events
+    in
+    Ok (Board.take limit filtered)
 
 let post_to_yojson_with_karma (p : Board.post) ~author_karma =
   Board.post_to_yojson_with_karma p ~author_karma
@@ -769,6 +816,7 @@ let post_to_yojson_with_karma (p : Board.post) ~author_karma =
 let backend_name () =
   match Atomic.get backend_state with
   | Active (Jsonl _, _) -> "jsonl"
+  | Active (Unavailable _, _) -> "unavailable"
   | Uninitialized -> "uninitialized"
 
 (* AI curation delegate — thin wrappers around Board_curation *)
@@ -798,21 +846,26 @@ let latest_curation_snapshot () =
 
 let create_sub_board ~slug ~name ~description ~owner ?members ?access () =
   match backend () with
+  | Unavailable error -> Error error
   | Jsonl store ->
       Board.create_sub_board store ~slug ~name ~description ~owner ?members ?access ()
 
 let get_sub_board ~sub_board_id =
   match backend () with
+  | Unavailable error -> Error error
   | Jsonl store -> Board.get_sub_board store ~sub_board_id
 
 let list_sub_boards () =
   match backend () with
-  | Jsonl store -> Board.list_sub_boards store
+  | Unavailable error -> Error error
+  | Jsonl store -> Ok (Board.list_sub_boards store)
 
 let delete_sub_board ~sub_board_id =
   match backend () with
+  | Unavailable error -> Error error
   | Jsonl store -> Board.delete_sub_board store ~sub_board_id
 
 let update_sub_board ~sub_board_id ?name ?description ?members ?access () =
   match backend () with
+  | Unavailable error -> Error error
   | Jsonl store -> Board.update_sub_board store ~sub_board_id ?name ?description ?members ?access ()

--- a/lib/board/board_dispatch.mli
+++ b/lib/board/board_dispatch.mli
@@ -112,7 +112,9 @@ val emit_board_sse_event : board_sse_event -> unit
 
 type board_backend =
   | Jsonl of Board.store
-(** Currently single-variant; new backends would be added here. *)
+  | Unavailable of Board.board_error
+(** [Unavailable] keeps a persistence reset-required outcome inside the Board
+    boundary without aborting Keeper/server startup. *)
 
 val backend : unit -> board_backend
 (** Returns the currently-active backend, lazy-initialising it on
@@ -198,9 +200,10 @@ val list_posts :
   ?exclude_automation:bool ->
   ?limit:int ->
   unit ->
-  Board.post list
+  (Board.post list, Board.board_error) Result.t
 
-val current_post_cursor : unit -> float * string option
+val current_post_cursor :
+  unit -> (float * string option, Board.board_error) Result.t
 (** Atomic high-water mark for initializing a Board observation cursor. *)
 (** Current Board cursor head without sorting or materializing the full post
     history. *)
@@ -222,7 +225,7 @@ val set_pinned :
 val search :
   query:string ->
   limit:int ->
-  Board.post list
+  (Board.post list, Board.board_error) Result.t
 
 val post_to_yojson_with_karma :
   Board.post -> author_karma:int -> Yojson.Safe.t
@@ -249,7 +252,8 @@ val get_post_and_comments :
   unit ->
   (Board.post * Board.comment list, Board.board_error) Result.t
 
-val list_comments : ?limit:int -> unit -> Board.comment list
+val list_comments :
+  ?limit:int -> unit -> (Board.comment list, Board.board_error) Result.t
 
 (** {1 Votes} *)
 
@@ -293,7 +297,9 @@ val list_reactions_batch :
   targets:(Board.reaction_target_type * string) list ->
   ?user_id:string ->
   unit ->
-  ((Board.reaction_target_type * string) * Board.reaction_summary list) list
+  ( ((Board.reaction_target_type * string) * Board.reaction_summary list) list
+  , Board.board_error )
+  Result.t
 
 (** {1 Karma} *)
 
@@ -305,7 +311,7 @@ val get_karma_ledger :
   ?agent:string ->
   ?limit:int ->
   unit ->
-  Board.karma_event list
+  (Board.karma_event list, Board.board_error) Result.t
 (** Return attributed karma events from the active backend.
 
     Events are drawn from the in-memory vote log via
@@ -320,21 +326,24 @@ val get_karma_ledger :
     The rebuild contract: summing [delta] over the unfiltered
     result must equal [get_all_karma ()] for every recipient. *)
 
-val get_all_karma : unit -> (string * int) list
+val get_all_karma :
+  unit -> ((string * int) list, Board.board_error) Result.t
 
-val get_agent_karma : agent_name:string -> int
+val get_agent_karma :
+  agent_name:string -> (int, Board.board_error) Result.t
 
 (** {1 Aggregates} *)
 
-val list_hearths : unit -> (string * int) list
+val list_hearths :
+  unit -> ((string * int) list, Board.board_error) Result.t
 
-val stats : unit -> Yojson.Safe.t
+val stats : unit -> (Yojson.Safe.t, Board.board_error) Result.t
 (** Board snapshot ([post_count] / [comment_count] / per-author /
     per-hearth aggregates) projected to JSON. *)
 
 (** {1 Persistence} *)
 
-val flush : unit -> unit
+val flush : unit -> (unit, Board.board_error) Result.t
 (** Force-flush dirty posts/comments to disk. *)
 
 (** {1 AI curation} *)
@@ -375,7 +384,8 @@ val get_sub_board :
   sub_board_id:string ->
   (Board.sub_board, Board.board_error) Result.t
 
-val list_sub_boards : unit -> Board.sub_board list
+val list_sub_boards :
+  unit -> (Board.sub_board list, Board.board_error) Result.t
 
 val delete_sub_board :
   sub_board_id:string ->

--- a/lib/board/board_sub_board_json.ml
+++ b/lib/board/board_sub_board_json.ml
@@ -3,7 +3,7 @@
    - Access mode <-> string conversion ([sub_board_access] variant).
    - [sub_board] record <-> Yojson.Safe.t (used by HTTP routes, the
      board tool surface, and the JSONL store rewrite path).
-   - Owner-injecting member-list parser (strict + lenient).
+   - Strict owner-injecting member-list parser.
 
    Extracted from [Board_core] (godfile decomp). Pure mapping. *)
 
@@ -59,37 +59,81 @@ let parse_sub_board_members ~owner members =
   loop [] members
 ;;
 
-let parse_sub_board_members_lenient ~owner members =
-  members
-  |> List.filter_map (fun member_name ->
-    match Agent_id.of_string member_name with
-    | Ok member_id -> Some member_id
-    | Error _ -> None)
-  |> fun parsed -> dedupe_agent_ids (owner :: parsed)
+let has_exact_fields allowed = function
+  | `Assoc fields ->
+    let keys = List.map fst fields in
+    List.length keys = List.length (List.sort_uniq String.compare keys)
+    && List.for_all (fun key -> List.mem key allowed) keys
+  | _ -> false
 ;;
 
 let sub_board_of_yojson (json : Yojson.Safe.t) : sub_board option =
   let open Safe_ops in
   match json with
-  | `Assoc _ ->
-    let id_s = json_string_opt "id" json |> Option.value ~default:"" in
-    let slug = json_string_opt "slug" json |> Option.value ~default:"" in
-    let name = json_string_opt "name" json |> Option.value ~default:"" in
-    let description = json_string_opt "description" json |> Option.value ~default:"" in
-    let owner_s = json_string_opt "owner" json |> Option.value ~default:"" in
-    let access_s = json_string_opt "access" json |> Option.value ~default:"open" in
-    let created_at = json_float_opt "created_at" json |> Option.value ~default:0.0 in
-    let post_count = json_int_opt "post_count" json |> Option.value ~default:0 in
-    let member_names = json_string_list "members" json in
+  | `Assoc _
+    when has_exact_fields
+           [ "id"
+           ; "slug"
+           ; "name"
+           ; "description"
+           ; "owner"
+           ; "members"
+           ; "access"
+           ; "created_at"
+           ; "post_count"
+           ]
+           json ->
     (match
-       ( Sub_board_id.of_string id_s
-       , Agent_id.of_string owner_s
-       , sub_board_access_of_string_opt access_s )
+       ( json_string_opt "id" json
+       , json_string_opt "slug" json
+       , json_string_opt "name" json
+       , json_string_opt "description" json
+       , json_string_opt "owner" json
+       , json_member_opt "members" json
+       , json_string_opt "access" json
+       , json_float_opt "created_at" json
+       , json_int_opt "post_count" json )
      with
-     | Ok id, Ok owner, Some access when slug <> "" ->
-       let members = parse_sub_board_members_lenient ~owner member_names in
-       Some
-         { id; slug; name; description; owner; members; access; created_at; post_count }
+     | ( Some id_s
+       , Some slug
+       , Some name
+       , Some description
+       , Some owner_s
+       , Some (`List member_json)
+       , Some access_s
+       , Some created_at
+       , Some post_count ) ->
+       let member_names =
+         List.fold_right
+           (fun item acc ->
+              match item, acc with
+              | `String name, Some names -> Some (name :: names)
+              | _ -> None)
+           member_json
+           (Some [])
+       in
+       (match
+          ( Sub_board_id.of_string id_s
+          , Agent_id.of_string owner_s
+          , sub_board_access_of_string_opt access_s
+          , member_names )
+        with
+        | Ok id, Ok owner, Some access, Some member_names when slug <> "" ->
+          (match parse_sub_board_members ~owner member_names with
+           | Ok members ->
+             Some
+               { id
+               ; slug
+               ; name
+               ; description
+               ; owner
+               ; members
+               ; access
+               ; created_at
+               ; post_count
+               }
+           | Error _ -> None)
+        | _ -> None)
      | _ -> None)
   | _ -> None
 ;;

--- a/lib/board/board_sub_board_json.mli
+++ b/lib/board/board_sub_board_json.mli
@@ -15,9 +15,3 @@ val parse_sub_board_members
   :  owner:Agent_id.t
   -> string list
   -> (Agent_id.t list, board_error) result
-
-(** Same as [parse_sub_board_members] but skips invalid agent ids. *)
-val parse_sub_board_members_lenient
-  :  owner:Agent_id.t
-  -> string list
-  -> Agent_id.t list

--- a/lib/board/board_votes.ml
+++ b/lib/board/board_votes.ml
@@ -29,6 +29,41 @@ let all_vote_directions = [ Up; Down ]
 let valid_vote_direction_strings =
   List.map vote_direction_to_string all_vote_directions
 
+let has_exact_json_fields allowed = function
+  | `Assoc fields ->
+    let keys = List.map fst fields in
+    List.length keys = List.length (List.sort_uniq String.compare keys)
+    && List.for_all (fun key -> List.mem key allowed) keys
+  | _ -> false
+
+let parse_vote_key key =
+  match String.index_opt key ':' with
+  | None -> None
+  | Some i1 ->
+      let kind = String.sub key 0 i1 in
+      let rest1 = String.sub key (i1 + 1) (String.length key - i1 - 1) in
+      (match String.index_opt rest1 ':' with
+      | None -> None
+      | Some i2 ->
+          let target_id = String.sub rest1 0 i2 in
+          let voter =
+            String.sub rest1 (i2 + 1) (String.length rest1 - i2 - 1)
+          in
+          if kind = "" || target_id = "" || voter = "" then None
+          else Some (kind, target_id, voter))
+
+let vote_target_matches_voter ~target ~voter =
+  match parse_vote_key target, Agent_id.of_string voter with
+  | Some (kind, target_id, target_voter), Ok voter_id ->
+    let voter = Agent_id.to_string voter_id in
+    String.equal voter target_voter
+    &&
+    (match kind with
+     | "post" -> Result.is_ok (Post_id.of_string target_id)
+     | "comment" -> Result.is_ok (Comment_id.of_string target_id)
+     | _ -> false)
+  | _ -> false
+
 (* Sound partial parser — case-insensitive, trims whitespace, and
    rejects empty input. Missing direction defaults belong at the tool
    boundary, not in the wire-value parser. *)
@@ -69,9 +104,8 @@ let vote_log_jsonl store =
   Hashtbl.iter
     (fun target (direction, ts) ->
       let voter =
-        match String.rindex_opt target ':' with
-        | Some idx when idx + 1 < String.length target ->
-            String.sub target (idx + 1) (String.length target - idx - 1)
+        match parse_vote_key target with
+        | Some (_, _, voter) -> voter
         | _ -> ""
       in
       let json =
@@ -340,39 +374,76 @@ let load_persisted_votes store =
   if not (Fs_compat.file_exists path) then Ok 0
   else begin
     try
-      let loaded = ref 0 in
-      let lines = Fs_compat.load_jsonl path in
-      List.iter (fun json ->
-        match Safe_ops.json_string_opt "target" json,
-              Safe_ops.json_string_opt "direction" json with
-        | Some target, Some dir_str ->
-          (match vote_direction_of_string_opt dir_str with
-           | None -> ()
-           | Some direction ->
-             (* #10086: legacy rows persisted before this fix may have
-                [ts] overwritten by a prior flush cycle.  Use the
-                recorded value when present; fall back to 0.0 rather
-                than [Time_compat.now ()] — loading a ledger at server
-                start time must NOT advance the ts of every pre-fix
-                vote to "now".  Downstream readers treat ts=0.0 as
-                "unknown cast time". *)
-             let ts =
-               match Safe_ops.json_float_opt "ts" json with
-               | Some t -> t
-               | None -> 0.0
-             in
-             Hashtbl.replace store.vote_log target (direction, ts);
-             Stdlib.incr loaded)
-        | _ -> ()
-      ) lines;
-      if !loaded > 0 then
-        Log.BoardLog.info "loaded %d vote entries from %s" !loaded path
-      else
-        Log.BoardLog.debug "loaded 0 vote entries from %s" path;
-      Ok !loaded
+      let lines, malformed_lines = Fs_compat.load_jsonl_diagnostics path in
+      let rec parse_current line_number acc = function
+        | [] -> Ok (List.rev acc)
+        | json :: rest ->
+          if not (has_exact_json_fields [ "target"; "voter"; "direction"; "ts" ] json)
+          then
+            Error
+              (Persistence_reset_required
+                 (Printf.sprintf
+                    "board votes snapshot is not current schema: path=%s row=%d"
+                    path
+                    line_number))
+          else
+          (match
+             ( Safe_ops.json_string_opt "target" json
+             , Safe_ops.json_string_opt "voter" json
+             , Safe_ops.json_string_opt "direction" json
+             , Safe_ops.json_float_opt "ts" json )
+           with
+           | Some target, Some voter, Some dir_str, Some ts
+             when vote_target_matches_voter ~target ~voter ->
+             (match vote_direction_of_string_opt dir_str with
+              | Some direction ->
+                parse_current (line_number + 1) ((target, direction, ts) :: acc) rest
+              | None ->
+                Error
+                  (Persistence_reset_required
+                     (Printf.sprintf
+                        "board votes snapshot is not current schema: path=%s row=%d"
+                        path
+                        line_number)))
+           | _ ->
+             Error
+               (Persistence_reset_required
+                  (Printf.sprintf
+                     "board votes snapshot is not current schema: path=%s row=%d"
+                     path
+                     line_number)))
+      in
+      (match malformed_lines with
+       | count when count > 0 ->
+         Error
+           (Persistence_reset_required
+              (Printf.sprintf
+                 "board votes snapshot contains malformed JSON: path=%s malformed_rows=%d"
+                 path
+                 count))
+       | _ ->
+      match parse_current 1 [] lines with
+       | Error _ as error -> error
+       | Ok votes ->
+         List.iter
+           (fun (target, direction, ts) ->
+              Hashtbl.replace store.vote_log target (direction, ts))
+           votes;
+         let loaded = List.length votes in
+         if loaded > 0 then
+           Log.BoardLog.info "loaded %d vote entries from %s" loaded path
+         else
+           Log.BoardLog.debug "loaded 0 vote entries from %s" path;
+         Ok loaded)
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
-    | e -> Error (path, e)
+    | e ->
+      Error
+        (Io_error
+           (Printf.sprintf
+              "load votes failed: path=%s reason=%s"
+              path
+              (Printexc.to_string e)))
   end
 
 let load_persisted_reactions store =
@@ -380,30 +451,58 @@ let load_persisted_reactions store =
   if not (Fs_compat.file_exists path) then Ok 0
   else begin
     try
-      let loaded = ref 0 in
-      let lines = Fs_compat.load_jsonl path in
-      List.iter
-        (fun json ->
-           match reaction_of_yojson json with
+      let lines, malformed_lines = Fs_compat.load_jsonl_diagnostics path in
+      let rec parse_current line_number acc = function
+        | [] -> Ok (List.rev acc)
+        | json :: rest ->
+          (match reaction_of_yojson json with
            | Some reaction ->
-               let user_id = Agent_id.to_string reaction.user_id in
-               let key =
-                 reaction_key ~target_type:reaction.target_type
-                   ~target_id:reaction.target_id ~user_id
-                   ~emoji:reaction.emoji
-               in
-               Hashtbl.replace store.reactions key reaction;
-               Stdlib.incr loaded
-           | None -> ())
-        lines;
-      if !loaded > 0 then
-        Log.BoardLog.info "loaded %d reactions from %s" !loaded path
-      else
-        Log.BoardLog.debug "loaded 0 reactions from %s" path;
-      Ok !loaded
+             parse_current (line_number + 1) (reaction :: acc) rest
+           | None ->
+             Error
+               (Persistence_reset_required
+                  (Printf.sprintf
+                     "board reactions snapshot is not current schema: path=%s row=%d"
+                     path
+                     line_number)))
+      in
+      (match malformed_lines with
+       | count when count > 0 ->
+         Error
+           (Persistence_reset_required
+              (Printf.sprintf
+                 "board reactions snapshot contains malformed JSON: path=%s malformed_rows=%d"
+                 path
+                 count))
+       | _ ->
+      match parse_current 1 [] lines with
+       | Error _ as error -> error
+       | Ok reactions ->
+         List.iter
+           (fun (reaction : reaction) ->
+              let user_id = Agent_id.to_string reaction.user_id in
+              let key =
+                reaction_key ~target_type:reaction.target_type
+                  ~target_id:reaction.target_id ~user_id
+                  ~emoji:reaction.emoji
+              in
+              Hashtbl.replace store.reactions key reaction)
+           reactions;
+         let loaded = List.length reactions in
+         if loaded > 0 then
+           Log.BoardLog.info "loaded %d reactions from %s" loaded path
+         else
+           Log.BoardLog.debug "loaded 0 reactions from %s" path;
+         Ok loaded)
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
-    | e -> Error (path, e)
+    | e ->
+      Error
+        (Io_error
+           (Printf.sprintf
+              "load reactions failed: path=%s reason=%s"
+              path
+              (Printexc.to_string e)))
   end
 
 let load_persisted_sub_boards store =
@@ -411,26 +510,54 @@ let load_persisted_sub_boards store =
   if not (Fs_compat.file_exists path) then Ok 0
   else begin
     try
-      let loaded = ref 0 in
-      let lines = Fs_compat.load_jsonl path in
-      List.iter
-        (fun json ->
-           match sub_board_of_yojson json with
-           | Some sb ->
-               let id = Sub_board_id.to_string sb.id in
-               Hashtbl.replace store.sub_boards id sb;
-               Hashtbl.replace store.sub_boards_by_slug sb.slug id;
-               Stdlib.incr loaded
-           | None -> ())
-        lines;
-      if !loaded > 0 then
-        Log.BoardLog.info "loaded %d sub-boards from %s" !loaded path
-      else
-        Log.BoardLog.debug "loaded 0 sub-boards from %s" path;
-      Ok !loaded
+      let lines, malformed_lines = Fs_compat.load_jsonl_diagnostics path in
+      let rec parse_current line_number acc = function
+        | [] -> Ok (List.rev acc)
+        | json :: rest ->
+          (match sub_board_of_yojson json with
+           | Some sub_board ->
+             parse_current (line_number + 1) (sub_board :: acc) rest
+           | None ->
+             Error
+               (Persistence_reset_required
+                  (Printf.sprintf
+                     "board sub-boards snapshot is not current schema: path=%s row=%d"
+                     path
+                     line_number)))
+      in
+      (match malformed_lines with
+       | count when count > 0 ->
+         Error
+           (Persistence_reset_required
+              (Printf.sprintf
+                 "board sub-boards snapshot contains malformed JSON: path=%s malformed_rows=%d"
+                 path
+                 count))
+       | _ ->
+      match parse_current 1 [] lines with
+       | Error _ as error -> error
+       | Ok sub_boards ->
+         List.iter
+           (fun (sb : sub_board) ->
+              let id = Sub_board_id.to_string sb.id in
+              Hashtbl.replace store.sub_boards id sb;
+              Hashtbl.replace store.sub_boards_by_slug sb.slug id)
+           sub_boards;
+         let loaded = List.length sub_boards in
+         if loaded > 0 then
+           Log.BoardLog.info "loaded %d sub-boards from %s" loaded path
+         else
+           Log.BoardLog.debug "loaded 0 sub-boards from %s" path;
+         Ok loaded)
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
-    | e -> Error (path, e)
+    | e ->
+      Error
+        (Io_error
+           (Printf.sprintf
+              "load sub-boards failed: path=%s reason=%s"
+              path
+              (Printexc.to_string e)))
   end
 
 (** {1 Hearth (topic) operations} *)
@@ -621,29 +748,20 @@ let delete_post store ~post_id : (unit, board_error) Result.t =
     [cancel:`Protect] ensures store creation completes even if the
     forcing fiber is cancelled. *)
 
-(* Loaders return [(int, string * exn) result] so the caller is forced to
-   acknowledge persistence-load failures.  Best-effort semantics live here
-   at the call site, not hidden inside the loader bodies. *)
-let log_persistence_result ~kind = function
-  | Ok _ -> ()
-  | Error (path, e) ->
-    Log.BoardLog.error
-      "load %s failed: path=%s reason=%s (continuing with best-effort partial state)"
-      kind path (Printexc.to_string e)
-
 let load_all_persisted store =
-  log_persistence_result ~kind:"posts" (load_persisted_posts store);
-  log_persistence_result ~kind:"comments" (load_persisted_comments store);
+  let ( let* ) = Result.bind in
+  let* _ = load_persisted_posts store in
+  let* _ = load_persisted_comments store in
   recalculate_reply_counts store;
-  log_persistence_result ~kind:"votes" (load_persisted_votes store);
-  log_persistence_result ~kind:"reactions" (load_persisted_reactions store);
-  log_persistence_result ~kind:"sub-boards" (load_persisted_sub_boards store)
+  let* _ = load_persisted_votes store in
+  let* _ = load_persisted_reactions store in
+  let* _ = load_persisted_sub_boards store in
+  Ok ()
 
-let global_lazy : store Eio.Lazy.t ref =
+let global_lazy : (store, board_error) result Eio.Lazy.t ref =
   ref (Eio.Lazy.from_fun ~cancel:`Protect (fun () ->
     let store = create_store () in
-    load_all_persisted store;
-    store))
+    Result.map (fun () -> store) (load_all_persisted store)))
 
 let global () = Eio.Lazy.force !global_lazy
 
@@ -652,8 +770,7 @@ let global () = Eio.Lazy.force !global_lazy
 let reset_global_for_test () =
   global_lazy := Eio.Lazy.from_fun ~cancel:`Protect (fun () ->
     let store = create_store () in
-    load_all_persisted store;
-    store)
+    Result.map (fun () -> store) (load_all_persisted store))
 
 (** Flush any dirty state to disk. Call on shutdown to prevent data loss.
 
@@ -708,22 +825,6 @@ let karma_score_for_direction = function
     Both [<id>] and [<voter>] are safe for the ID character set but
     voter may contain a colon in namespace:agent form, so we split
     only on the first two colons and keep the remainder as voter. *)
-let parse_vote_key key =
-  match String.index_opt key ':' with
-  | None -> None
-  | Some i1 ->
-      let kind = String.sub key 0 i1 in
-      let rest1 = String.sub key (i1 + 1) (String.length key - i1 - 1) in
-      (match String.index_opt rest1 ':' with
-      | None -> None
-      | Some i2 ->
-          let target_id = String.sub rest1 0 i2 in
-          let voter =
-            String.sub rest1 (i2 + 1) (String.length rest1 - i2 - 1)
-          in
-          if kind = "" || target_id = "" || voter = "" then None
-          else Some (kind, target_id, voter))
-
 let canonical_vote_voter voter =
   match Agent_id.of_string voter with
   | Ok agent -> Agent_id.to_string agent

--- a/lib/board/board_votes.mli
+++ b/lib/board/board_votes.mli
@@ -171,13 +171,12 @@ val delete_post :
 
 (** {1 Global store + lifecycle} *)
 
-val global : unit -> store
+val global : unit -> (store, board_error) result
 (** Lazy singleton.  First call constructs the store via
-    {!create_store}, then runs the four loaders
-    ([load_persisted_posts] / [_comments] / [_votes] +
-    [recalculate_reply_counts]) under
+    {!create_store}, validates and loads posts, comments, votes, reactions,
+    and sub-boards, then rebuilds derived reply counts under
     [Eio.Lazy.from_fun ~cancel:`Protect] so a cancelled
-    fiber cannot leave the singleton half-initialised. *)
+    fiber cannot publish a half-initialised singleton. *)
 
 val reset_global_for_test : unit -> unit
 (** Reinstalls a fresh lazy singleton.  Safe to call only

--- a/lib/board/board_votes_json.ml
+++ b/lib/board/board_votes_json.ml
@@ -10,56 +10,115 @@ let record_post_meta_json_read_drop () =
 
 let visibility_of_string = Board_core_classify.visibility_of_string
 
-(* RFC-0233 §7: decode the typed post origin. Parse, don't repair — an absent
-   [origin], a non-object value, or a malformed sub-field all degrade to [None]
-   (per-field for the sub-fields), NEVER dropping the row: origin is provenance
-   metadata, not load-bearing identity (contrast the [meta] row-drop below).
-   [Ids.Turn_ref.of_string] is total and returns [None] on a malformed join
-   key. An all-[None] origin decodes to [None] (no empty record carried). *)
-let post_origin_of_yojson (json : Yojson.Safe.t) : post_origin option =
-  match json with
-  | `Assoc _ ->
-    let turn_ref =
-      match Safe_ops.json_string_opt "turn_ref" json with
-      | Some s -> Ids.Turn_ref.of_string s
-      | None -> None
-    in
-    let source = Safe_ops.json_string_opt "source" json in
-    let fusion_run_id = Safe_ops.json_string_opt "fusion_run_id" json in
-    (match turn_ref, source, fusion_run_id with
-     | None, None, None -> None
-     | _ -> Some { turn_ref; source; fusion_run_id })
+let assoc_member key = function
+  | `Assoc fields -> List.assoc_opt key fields
   | _ -> None
 ;;
 
+let has_exact_fields allowed = function
+  | `Assoc fields ->
+    let keys = List.map fst fields in
+    List.length keys = List.length (List.sort_uniq String.compare keys)
+    && List.for_all (fun key -> List.mem key allowed) keys
+  | _ -> false
+;;
+
+let optional_string_field key fields =
+  match List.assoc_opt key fields with
+  | None -> Ok None
+  | Some (`String value) -> Ok (Some value)
+  | Some _ -> Error ()
+;;
+
+(* RFC-0233 §7: [origin] is optional, but a present value is exact.  Do not
+   erase malformed provenance from a persisted current-schema row. *)
+let post_origin_of_yojson (json : Yojson.Safe.t) : (post_origin, unit) result =
+  match json with
+  | `Assoc fields
+    when has_exact_fields [ "turn_ref"; "source"; "fusion_run_id" ] json ->
+    (match
+       ( optional_string_field "turn_ref" fields
+       , optional_string_field "source" fields
+       , optional_string_field "fusion_run_id" fields )
+     with
+     | Ok turn_ref_raw, Ok source, Ok fusion_run_id ->
+       let turn_ref_result =
+         match turn_ref_raw with
+         | None -> Ok None
+         | Some raw ->
+           (match Ids.Turn_ref.of_string raw with
+            | Some turn_ref -> Ok (Some turn_ref)
+            | None -> Error ())
+       in
+       (match turn_ref_result with
+        | Ok turn_ref -> Ok { turn_ref; source; fusion_run_id }
+        | Error () -> Error ())
+     | _ -> Error ())
+  | _ -> Error ()
+;;
+
 let post_of_yojson (json : Yojson.Safe.t) : post option =
+  let current_fields =
+    [ "id"
+    ; "author"
+    ; "title"
+    ; "body"
+    ; "post_kind"
+    ; "content"
+    ; "visibility"
+    ; "created_at"
+    ; "updated_at"
+    ; "expires_at"
+    ; "votes_up"
+    ; "votes_down"
+    ; "score"
+    ; "reply_count"
+    ; "pinned"
+    ; "hearth"
+    ; "thread_id"
+    ; "origin"
+    ; "classification_reason"
+    ; "meta"
+    ]
+  in
+  if not (has_exact_fields current_fields json)
+  then None
+  else
   match
     ( Safe_ops.json_string_opt "id" json
     , Safe_ops.json_string_opt "author" json
+    , Safe_ops.json_string_opt "title" json
+    , Safe_ops.json_string_opt "body" json
     , Safe_ops.json_string_opt "content" json
     , Safe_ops.json_string_opt "visibility" json
     , Safe_ops.json_float_opt "created_at" json
+    , Safe_ops.json_float_opt "updated_at" json
     , Safe_ops.json_float_opt "expires_at" json )
   with
   | ( Some id_str
     , Some author_str
+    , Some title
+    , Some body
     , Some content
     , Some vis_str
     , Some created_at
+    , Some updated_at
     , Some expires_at ) ->
-    let title_opt = Safe_ops.json_string_opt "title" json in
-    let body_opt = Safe_ops.json_string_opt "body" json in
-    (* Backward compat: default updated_at to created_at if missing *)
-    let updated_at =
-      Safe_ops.json_float_opt "updated_at" json |> Option.value ~default:created_at
+    let votes_up = Safe_ops.json_int_opt "votes_up" json in
+    let votes_down = Safe_ops.json_int_opt "votes_down" json in
+    let score = Safe_ops.json_int_opt "score" json in
+    let reply_count = Safe_ops.json_int_opt "reply_count" json in
+    let fields =
+      match json with
+      | `Assoc fields -> fields
+      | _ -> assert false
     in
-    let votes_up = Safe_ops.json_int ~default:0 "votes_up" json in
-    let votes_down = Safe_ops.json_int ~default:0 "votes_down" json in
-    let reply_count = Safe_ops.json_int ~default:0 "reply_count" json in
-    let hearth = Safe_ops.json_string_opt "hearth" json in
-    let thread_id = Safe_ops.json_string_opt "thread_id" json in
-    (* Missing on legacy rows persisted before the pin field existed -> default false. *)
-    let pinned = Safe_ops.json_bool ~default:false "pinned" json in
+    let hearth_result = optional_string_field "hearth" fields in
+    let thread_id_result = optional_string_field "thread_id" fields in
+    let classification_reason_result =
+      optional_string_field "classification_reason" fields
+    in
+    let pinned = Safe_ops.json_bool_opt "pinned" json in
     let post_kind_opt =
       match Safe_ops.json_string_opt "post_kind" json with
       | Some raw -> post_kind_of_string raw
@@ -70,49 +129,67 @@ let post_of_yojson (json : Yojson.Safe.t) : post option =
       Log.BoardLog.warn
         "dropping persisted board post %s: missing or invalid post_kind"
         id_str;
-    let meta_json =
-      match Safe_ops.json_member_opt "meta" json with
-      | Some (`Assoc _ as meta) -> Some meta
-      | Some _ | None ->
-        (match Safe_ops.json_string_opt "meta_json" json with
-         | Some raw ->
-           (try Some (Yojson.Safe.from_string raw) with
-            | Yojson.Json_error _ ->
-              record_post_meta_json_read_drop ();
-              None)
-         | None -> None)
+    let meta_json_result =
+      match assoc_member "meta" json with
+      | Some (`Assoc _ as meta) -> Ok (Some meta)
+      | None -> Ok None
+      | _ ->
+        record_post_meta_json_read_drop ();
+        Error ()
     in
-    let origin =
-      match Safe_ops.json_member_opt "origin" json with
-      | Some o -> post_origin_of_yojson o
-      | None -> None
+    let origin_result =
+      match assoc_member "origin" json with
+      | None -> Ok None
+      | Some origin_json ->
+        Result.map (fun origin -> Some origin) (post_origin_of_yojson origin_json)
     in
     (match
        ( Post_id.of_string id_str
        , Agent_id.of_string author_str
        , visibility_of_string vis_str
-       , post_kind_opt )
+       , post_kind_opt
+       , votes_up
+       , votes_down
+       , score
+       , reply_count
+       , pinned
+       , hearth_result
+       , thread_id_result
+       , classification_reason_result
+       , meta_json_result
+       , origin_result )
      with
-     | Ok id, Ok author, Some visibility, Some post_kind ->
+     | ( Ok id
+       , Ok author
+       , Some visibility
+       , Some post_kind
+       , Some votes_up
+       , Some votes_down
+       , Some score
+       , Some reply_count
+       , Some pinned
+       , Ok hearth
+       , Ok thread_id
+       , Ok classification_reason
+       , Ok meta_json
+       , Ok origin )
+       when score = votes_up - votes_down && String.equal content body ->
        (match
           normalize_post_payload
             ~content
-            ?title:title_opt
-            ?body:body_opt
+            ~title
+            ~body
             ~post_kind
             ?meta_json
             ()
         with
         | Error (Board_core_payload.Meta_not_assoc _) ->
-          (* Row-level malformed meta_json: drop the row. The legacy
-             code path silently coerced the same payload to an empty
-             meta object at board_core_payload.ml:73, persisting a
-             "successful" row with the original meta vaporised. We
-             now reject the row outright so callers see the load
-             count drop instead of an invisible data shape change. *)
+          (* A malformed current meta object invalidates the persisted row.
+             The all-or-nothing loader converts this [None] into a typed
+             reset-required backend instead of publishing a partial store. *)
           None
         | Ok (title, body, post_kind, meta_json) ->
-          Some
+          let post =
             { id
             ; author
             ; title
@@ -131,54 +208,88 @@ let post_of_yojson (json : Yojson.Safe.t) : post option =
             ; hearth
             ; thread_id
             ; origin
-            })
+            }
+          in
+          if Option.equal String.equal classification_reason
+               (post_classification_reason post)
+          then Some post
+          else None)
      | _ -> None)
   | _ -> None
 ;;
 
 let comment_of_yojson (json : Yojson.Safe.t) : comment option =
+  let current_fields =
+    [ "id"
+    ; "post_id"
+    ; "parent_id"
+    ; "author"
+    ; "content"
+    ; "created_at"
+    ; "expires_at"
+    ; "votes_up"
+    ; "votes_down"
+    ; "score"
+    ]
+  in
+  if not (has_exact_fields current_fields json)
+  then None
+  else
   match
     ( Safe_ops.json_string_opt "id" json
     , Safe_ops.json_string_opt "post_id" json
     , Safe_ops.json_string_opt "author" json
     , Safe_ops.json_string_opt "content" json
     , Safe_ops.json_float_opt "created_at" json
-    , Safe_ops.json_float_opt "expires_at" json )
+    , Safe_ops.json_float_opt "expires_at" json
+    , Safe_ops.json_int_opt "votes_up" json
+    , Safe_ops.json_int_opt "votes_down" json
+    , Safe_ops.json_int_opt "score" json )
   with
   | ( Some id_str
     , Some post_id_str
     , Some author_str
     , Some content
     , Some created_at
-    , Some expires_at ) ->
-    let parent_id_opt = Safe_ops.json_string_opt "parent_id" json in
-    let votes_up = Safe_ops.json_int ~default:0 "votes_up" json in
-    let votes_down = Safe_ops.json_int ~default:0 "votes_down" json in
+    , Some expires_at
+    , Some votes_up
+    , Some votes_down
+    , Some score )
+    when score = votes_up - votes_down ->
+    let parent_id_result =
+      match assoc_member "parent_id" json with
+      | Some `Null -> Ok None
+      | Some (`String value) -> Ok (Some value)
+      | Some _ | None -> Error ()
+    in
     (match
        ( Comment_id.of_string id_str
        , Post_id.of_string post_id_str
        , Agent_id.of_string author_str )
      with
      | Ok id, Ok post_id, Ok author ->
-       let parent_id =
-         match parent_id_opt with
-         | Some s ->
-           (match Comment_id.of_string s with
-            | Ok cid -> Some cid
-            | _ -> None)
-         | None -> None
-       in
-       Some
-         { id
-         ; post_id
-         ; parent_id
-         ; author
-         ; content
-         ; created_at
-         ; expires_at
-         ; votes_up
-         ; votes_down
-         }
+       (match parent_id_result with
+        | Error () -> None
+        | Ok parent_id_opt ->
+          let parent_id_result =
+            match parent_id_opt with
+            | Some s -> Result.map Option.some (Comment_id.of_string s)
+            | None -> Ok None
+          in
+          (match parent_id_result with
+           | Error _ -> None
+           | Ok parent_id ->
+             Some
+               { id
+               ; post_id
+               ; parent_id
+               ; author
+               ; content
+               ; created_at
+               ; expires_at
+               ; votes_up
+               ; votes_down
+               }))
      | _ -> None)
   | _ -> None
 ;;
@@ -191,32 +302,53 @@ let load_persisted_posts store =
     try
       let t0 = Time_compat.now () in
       let now = Time_compat.now () in
-      let loaded = ref 0 in
-      let lines = Fs_compat.load_jsonl path in
-      List.iter
-        (fun json ->
-           match post_of_yojson json with
+      let lines, malformed_lines = Fs_compat.load_jsonl_diagnostics path in
+      let rec parse_current line_number acc = function
+        | [] -> Ok (List.rev acc)
+        | json :: rest ->
+          (match post_of_yojson json with
+           | None ->
+             Error
+               (Persistence_reset_required
+                  (Printf.sprintf
+                     "board posts snapshot is not current schema: path=%s row=%d"
+                     path
+                     line_number))
            | Some p
              when Float.compare p.expires_at 0.0 = 0
                   || Float.compare p.expires_at now > 0 ->
-             Hashtbl.replace store.posts (Post_id.to_string p.id) p;
-             (* RFC-0233 §7: rebuild the origin indexes on load (derive-on-load,
-                mirroring comments_by_post below) so find_post_by_turn_ref /
-                find_post_by_run_id survive a restart without a second persisted
-                SSOT that could drift from the post rows. *)
-             index_post_origin store p;
-             incr loaded
-           | _ -> ())
-        lines;
-      store.post_count := Hashtbl.length store.posts;
-      let elapsed = Time_compat.now () -. t0 in
-      if !loaded > 0
-      then Log.BoardLog.info "loaded %d posts from %s in %.3fs" !loaded path elapsed
-      else Log.BoardLog.debug "loaded 0 posts from %s in %.3fs" path elapsed;
-      Ok !loaded
+             parse_current (line_number + 1) (p :: acc) rest
+           | Some _ -> parse_current (line_number + 1) acc rest)
+      in
+      (match malformed_lines with
+       | count when count > 0 ->
+         Error
+           (Persistence_reset_required
+              (Printf.sprintf
+                 "board posts snapshot contains malformed JSON: path=%s malformed_rows=%d"
+                 path
+                 count))
+       | _ ->
+      match parse_current 1 [] lines with
+       | Error _ as error -> error
+       | Ok posts ->
+         List.iter
+           (fun (p : post) ->
+              Hashtbl.replace store.posts (Post_id.to_string p.id) p;
+              (* Derived indexes are rebuilt only after the complete canonical
+                 snapshot validates, so they cannot expose partial state. *)
+              index_post_origin store p)
+           posts;
+         store.post_count := Hashtbl.length store.posts;
+         let loaded = List.length posts in
+         let elapsed = Time_compat.now () -. t0 in
+         if loaded > 0
+         then Log.BoardLog.info "loaded %d posts from %s in %.3fs" loaded path elapsed
+         else Log.BoardLog.debug "loaded 0 posts from %s in %.3fs" path elapsed;
+         Ok loaded)
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
-    | e -> Error (path, e)
+    | e -> Error (Io_error (Printf.sprintf "load posts failed: path=%s reason=%s" path (Printexc.to_string e)))
 ;;
 
 let load_persisted_comments store =
@@ -227,34 +359,58 @@ let load_persisted_comments store =
     try
       let t0 = Time_compat.now () in
       let now = Time_compat.now () in
-      let loaded = ref 0 in
-      let lines = Fs_compat.load_jsonl path in
-      List.iter
-        (fun json ->
-           match comment_of_yojson json with
+      let lines, malformed_lines = Fs_compat.load_jsonl_diagnostics path in
+      let rec parse_current line_number acc = function
+        | [] -> Ok (List.rev acc)
+        | json :: rest ->
+          (match comment_of_yojson json with
+           | None ->
+             Error
+               (Persistence_reset_required
+                  (Printf.sprintf
+                     "board comments snapshot is not current schema: path=%s row=%d"
+                     path
+                     line_number))
            | Some c
              when Float.compare c.expires_at 0.0 = 0
                   || Float.compare c.expires_at now > 0 ->
-             let cid = Comment_id.to_string c.id in
-             Hashtbl.replace store.comments cid c;
-             let post_key = Post_id.to_string c.post_id in
-             let existing =
-               Hashtbl.find_opt store.comments_by_post post_key
-               |> Option.value ~default:[]
-             in
-             let indexed =
-               if List.exists (String.equal cid) existing then existing else cid :: existing
-             in
-             Hashtbl.replace store.comments_by_post post_key indexed;
-             incr loaded
-           | _ -> ())
-        lines;
-      let elapsed = Time_compat.now () -. t0 in
-      if !loaded > 0
-      then Log.BoardLog.info "loaded %d comments from %s in %.3fs" !loaded path elapsed
-      else Log.BoardLog.debug "loaded 0 comments from %s in %.3fs" path elapsed;
-      Ok !loaded
+             parse_current (line_number + 1) (c :: acc) rest
+           | Some _ -> parse_current (line_number + 1) acc rest)
+      in
+      (match malformed_lines with
+       | count when count > 0 ->
+         Error
+           (Persistence_reset_required
+              (Printf.sprintf
+                 "board comments snapshot contains malformed JSON: path=%s malformed_rows=%d"
+                 path
+                 count))
+       | _ ->
+      match parse_current 1 [] lines with
+       | Error _ as error -> error
+       | Ok comments ->
+         List.iter
+           (fun (c : comment) ->
+              let cid = Comment_id.to_string c.id in
+              Hashtbl.replace store.comments cid c;
+              let post_key = Post_id.to_string c.post_id in
+              let existing =
+                match Hashtbl.find_opt store.comments_by_post post_key with
+                | Some existing -> existing
+                | None -> []
+              in
+              let indexed =
+                if List.exists (String.equal cid) existing then existing else cid :: existing
+              in
+              Hashtbl.replace store.comments_by_post post_key indexed)
+           comments;
+         let loaded = List.length comments in
+         let elapsed = Time_compat.now () -. t0 in
+         if loaded > 0
+         then Log.BoardLog.info "loaded %d comments from %s in %.3fs" loaded path elapsed
+         else Log.BoardLog.debug "loaded 0 comments from %s in %.3fs" path elapsed;
+         Ok loaded)
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
-    | e -> Error (path, e)
+    | e -> Error (Io_error (Printf.sprintf "load comments failed: path=%s reason=%s" path (Printexc.to_string e)))
 ;;

--- a/lib/board/board_votes_json.mli
+++ b/lib/board/board_votes_json.mli
@@ -7,14 +7,13 @@ end
 val visibility_of_string : string -> visibility option
 val post_of_yojson : Yojson.Safe.t -> post option
 val comment_of_yojson : Yojson.Safe.t -> comment option
-val load_persisted_posts : store -> (int, string * exn) result
+val load_persisted_posts : store -> (int, board_error) result
 (** Load posts from disk into [store].  Returns [Ok loaded_count] on success
     (including when the persistence file is absent: [Ok 0]).  Returns
-    [Error (path, cause)] when the file existed but could not be parsed or
-    read.  Caller decides how to surface the failure — earlier behaviour
-    swallowed the exception inside this function, leaving a partially loaded
-    store undistinguishable from a clean one.  [Eio.Cancel.Cancelled] is
+    [Error (Persistence_reset_required _)] when any row is not the current
+    schema and [Error (Io_error _)] when the file cannot be read. No rows are
+    inserted unless the whole snapshot validates. [Eio.Cancel.Cancelled] is
     propagated unchanged. *)
 
-val load_persisted_comments : store -> (int, string * exn) result
+val load_persisted_comments : store -> (int, board_error) result
 (** See {!load_persisted_posts}. *)

--- a/lib/board_tool_adapter/board_tool_format.ml
+++ b/lib/board_tool_adapter/board_tool_format.ml
@@ -67,6 +67,8 @@ let board_error_to_string = function
   | Board.Already_voted s -> Printf.sprintf "Already voted: %s" s
   | Board.Already_exists s -> Printf.sprintf "Already exists: %s" s
   | Board.Unauthorized s -> Printf.sprintf "Unauthorized: %s" s
+  | Board.Persistence_reset_required s ->
+    Printf.sprintf "Board persistence reset required: %s" s
 ;;
 
 let board_error_failure_class = function

--- a/lib/board_tool_adapter/board_tool_handlers.ml
+++ b/lib/board_tool_adapter/board_tool_handlers.ml
@@ -212,8 +212,10 @@ let handle_vote ~tool_name ~start_time args =
 ;;
 
 let handle_stats ~tool_name ~start_time _args : Tool_result.result =
-  let stats = Board_dispatch.stats () in
-  Tool_result.make_ok ~tool_name ~start_time ~data:stats ()
+  match Board_dispatch.stats () with
+  | Ok stats -> Tool_result.make_ok ~tool_name ~start_time ~data:stats ()
+  | Error error ->
+    Board_tool_format.error_of_board_error ~tool_name ~start_time error
 ;;
 
 (** Search posts by keyword. *)
@@ -229,33 +231,36 @@ let handle_search ~tool_name ~start_time args : Tool_result.result =
       ~start_time
       "query required"
   else (
-    let results = Board_dispatch.search ~query ~limit in
-    if Stdlib.List.length results = 0
-    then
-      Tool_result.make_ok
-        ~tool_name
-        ~start_time
-        ~data:(`String (Printf.sprintf "'%s' 검색 결과 없음" query))
-        ()
-    else (
-      let fmt =
-        if compact
-        then Board_tool_format.format_post_compact
-        else Board_tool_format.format_post
-      in
-      let formatted = List.map fmt results in
-      let separator = if compact then "\n" else "\n---\n" in
-      Tool_result.make_ok
-        ~tool_name
-        ~start_time
-        ~data:
-          (`String
-             (Printf.sprintf
-                "'%s' 검색 결과 (%d개):\n\n%s"
-                query
-                (List.length results)
-                (String.concat separator formatted)))
-        ()))
+    match Board_dispatch.search ~query ~limit with
+    | Error error ->
+      Board_tool_format.error_of_board_error ~tool_name ~start_time error
+    | Ok results ->
+      if Stdlib.List.length results = 0
+      then
+        Tool_result.make_ok
+          ~tool_name
+          ~start_time
+          ~data:(`String (Printf.sprintf "'%s' 검색 결과 없음" query))
+          ()
+      else (
+        let fmt =
+          if compact
+          then Board_tool_format.format_post_compact
+          else Board_tool_format.format_post
+        in
+        let formatted = List.map fmt results in
+        let separator = if compact then "\n" else "\n---\n" in
+        Tool_result.make_ok
+          ~tool_name
+          ~start_time
+          ~data:
+            (`String
+               (Printf.sprintf
+                  "'%s' 검색 결과 (%d개):\n\n%s"
+                  query
+                  (List.length results)
+                  (String.concat separator formatted)))
+          ()))
 ;;
 
 (** Vote on comment. *)
@@ -354,73 +359,80 @@ let handle_profile ~tool_name ~start_time args : Tool_result.result =
       ~start_time
       "agent required"
   else (
-    let all_posts : Board.post list = Board_dispatch.list_posts ~limit:1000 () in
-    let norm s = String.lowercase_ascii (String.trim s) in
-    let agent_norm = norm agent in
-    let agent_posts =
-      List.filter
-        (fun (p : Board.post) ->
-           String.equal (norm (Board.Agent_id.to_string p.author)) agent_norm)
-        all_posts
-    in
-    let post_votes =
-      List.fold_left
-        (fun acc (p : Board.post) -> acc + p.votes_up - p.votes_down)
-        0
-        agent_posts
-    in
-    let all_comments : Board.comment list = Board_dispatch.list_comments () in
-    let agent_comments =
-      List.filter
-        (fun (c : Board.comment) ->
-           String.equal (norm (Board.Agent_id.to_string c.author)) agent_norm)
-        all_comments
-    in
-    let comment_votes =
-      List.fold_left
-        (fun acc (c : Board.comment) -> acc + c.votes_up - c.votes_down)
-        0
-        agent_comments
-    in
-    Tool_result.make_ok
-      ~tool_name
-      ~start_time
-      ~data:
-        (`String
-           (Printf.sprintf
-              "**%s** 프로필\n게시물: %d개 (%+d점)\n코멘트: %d개 (%+d점)\n총: %+d점"
-              agent
-              (List.length agent_posts)
-              post_votes
-              (List.length agent_comments)
-              comment_votes
-              (post_votes + comment_votes)))
-      ())
+    match
+      Board_dispatch.list_posts ~limit:1000 (), Board_dispatch.list_comments ()
+    with
+    | Error error, _ | _, Error error ->
+      Board_tool_format.error_of_board_error ~tool_name ~start_time error
+    | Ok all_posts, Ok all_comments ->
+      let norm s = String.lowercase_ascii (String.trim s) in
+      let agent_norm = norm agent in
+      let agent_posts =
+        List.filter
+          (fun (p : Board.post) ->
+             String.equal (norm (Board.Agent_id.to_string p.author)) agent_norm)
+          all_posts
+      in
+      let post_votes =
+        List.fold_left
+          (fun acc (p : Board.post) -> acc + p.votes_up - p.votes_down)
+          0
+          agent_posts
+      in
+      let agent_comments =
+        List.filter
+          (fun (c : Board.comment) ->
+             String.equal (norm (Board.Agent_id.to_string c.author)) agent_norm)
+          all_comments
+      in
+      let comment_votes =
+        List.fold_left
+          (fun acc (c : Board.comment) -> acc + c.votes_up - c.votes_down)
+          0
+          agent_comments
+      in
+      Tool_result.make_ok
+        ~tool_name
+        ~start_time
+        ~data:
+          (`String
+             (Printf.sprintf
+                "**%s** 프로필\n게시물: %d개 (%+d점)\n코멘트: %d개 (%+d점)\n총: %+d점"
+                agent
+                (List.length agent_posts)
+                post_votes
+                (List.length agent_comments)
+                comment_votes
+                (post_votes + comment_votes)))
+        ())
 ;;
 
 (** Hearth list. *)
 let handle_hearth_list ~tool_name ~start_time _args : Tool_result.result =
-  let hearths = Board_dispatch.list_hearths () in
-  if Stdlib.List.length hearths = 0
-  then
-    Tool_result.make_ok
-      ~tool_name
-      ~start_time
-      ~data:(`String "No active hearths.")
-      ()
-  else (
-    let formatted =
-      List.map
-        (fun (name, count) -> Printf.sprintf "**%s** (%d posts)" name count)
-        hearths
-    in
-    Tool_result.make_ok
-      ~tool_name
-      ~start_time
-      ~data:
-        (`String
-           (Printf.sprintf "Active Hearths:\n%s" (String.concat "\n" formatted)))
-      ())
+  match Board_dispatch.list_hearths () with
+  | Error error ->
+    Board_tool_format.error_of_board_error ~tool_name ~start_time error
+  | Ok hearths ->
+    if Stdlib.List.length hearths = 0
+    then
+      Tool_result.make_ok
+        ~tool_name
+        ~start_time
+        ~data:(`String "No active hearths.")
+        ()
+    else (
+      let formatted =
+        List.map
+          (fun (name, count) -> Printf.sprintf "**%s** (%d posts)" name count)
+          hearths
+      in
+      Tool_result.make_ok
+        ~tool_name
+        ~start_time
+        ~data:
+          (`String
+             (Printf.sprintf "Active Hearths:\n%s" (String.concat "\n" formatted)))
+        ())
 ;;
 
 (** {1 Delete / cleanup handlers} *)
@@ -475,9 +487,12 @@ let handle_board_cleanup ~tool_name ~start_time args : Tool_result.result =
     | None -> true
     | Some n -> String_util.contains_substring (String.lowercase_ascii s) n
   in
-  let all_posts =
+  match
     Board_dispatch.list_posts ~sort_by:Board_tool_format.Recent ~limit:500 ()
-  in
+  with
+  | Error error ->
+    Board_tool_format.error_of_board_error ~tool_name ~start_time error
+  | Ok all_posts ->
   let candidates =
     List.filter
       (fun (p : Board.post) ->

--- a/lib/board_tool_adapter/board_tool_post.ml
+++ b/lib/board_tool_adapter/board_tool_post.ml
@@ -244,7 +244,7 @@ let handle_post_list ~tool_name ~start_time args : Tool_result.result =
     (* Fetch exactly what we need: offset posts to skip + limit posts to show.
        Board_dispatch.list_posts already applies visibility/hearth/author filters. *)
     let fetch_limit = limit + offset in
-    let sorted_posts =
+    match
       Board_dispatch.list_posts
         ~visibility_filter
         ?hearth
@@ -255,7 +255,10 @@ let handle_post_list ~tool_name ~start_time args : Tool_result.result =
         ~sort_by
         ~limit:fetch_limit
         ()
-    in
+    with
+    | Error error ->
+      Board_tool_format.error_of_board_error ~tool_name ~start_time error
+    | Ok sorted_posts ->
     let posts =
       if random
       then (

--- a/lib/board_tool_adapter/board_tool_sub_board.ml
+++ b/lib/board_tool_adapter/board_tool_sub_board.ml
@@ -82,25 +82,28 @@ let handle_sub_board_create ~tool_name ~start_time args : Tool_result.result =
 ;;
 
 let handle_sub_board_list ~tool_name ~start_time _args : Tool_result.result =
-  let boards = Board_dispatch.list_sub_boards () in
-  let lines =
-    List.map
-      (fun (sb : Board.sub_board) ->
-         Printf.sprintf
-           "- %s (/%s): %s | %s | %d members | %d posts"
-           sb.name
-           sb.slug
-           sb.description
-           (Board.sub_board_access_to_string sb.access)
-           (List.length sb.members)
-           sb.post_count)
-      boards
-  in
-  Tool_result.make_ok
-    ~tool_name
-    ~start_time
-    ~data:(`String (String.concat "\n" lines))
-    ()
+  match Board_dispatch.list_sub_boards () with
+  | Error error ->
+    Board_tool_format.error_of_board_error ~tool_name ~start_time error
+  | Ok boards ->
+    let lines =
+      List.map
+        (fun (sb : Board.sub_board) ->
+           Printf.sprintf
+             "- %s (/%s): %s | %s | %d members | %d posts"
+             sb.name
+             sb.slug
+             sb.description
+             (Board.sub_board_access_to_string sb.access)
+             (List.length sb.members)
+             sb.post_count)
+        boards
+    in
+    Tool_result.make_ok
+      ~tool_name
+      ~start_time
+      ~data:(`String (String.concat "\n" lines))
+      ()
 ;;
 
 let handle_sub_board_get ~tool_name ~start_time args : Tool_result.result =

--- a/lib/board_types/board_types.ml
+++ b/lib/board_types/board_types.ml
@@ -29,6 +29,10 @@ type board_error =
     (** Actor attempted an owner-gated mutation (e.g. editing a post they
         do not own). Distinct from [Validation_error] so callers can map it
         to a 403-class rejection rather than a generic input error. *)
+  | Persistence_reset_required of string
+    (** The persisted Board snapshot is not the current schema. The Board
+        backend remains unavailable until the operator replaces or removes
+        that snapshot; no partial in-memory store is published. *)
   [@@deriving show]
 
 (** {1 Safe ID Module - Parse Don't Validate} *)

--- a/lib/board_types/board_types.mli
+++ b/lib/board_types/board_types.mli
@@ -28,6 +28,10 @@ type board_error =
     (** Actor attempted an owner-gated mutation (e.g. editing a post they
         do not own). Distinct from [Validation_error] so callers can map it
         to a 403-class rejection rather than a generic input error. *)
+  | Persistence_reset_required of string
+    (** The persisted Board snapshot is not the current schema. The Board
+        backend remains unavailable until the operator replaces or removes
+        that snapshot; no partial in-memory store is published. *)
 [@@deriving show]
 
 (** {1 Safe ID Modules — Parse, Don't Validate} *)

--- a/lib/dashboard/dashboard_http_monitoring.ml
+++ b/lib/dashboard/dashboard_http_monitoring.ml
@@ -113,7 +113,19 @@ let board_monitoring_json ~(now_ts : float) : Yojson.Safe.t * bool =
   let bad_age_s = 21600 in
   let slo_target_age_s = 900 in
   try
-    let posts = Board_dispatch.list_posts ~sort_by:Board_dispatch.Updated ~limit:200 () in
+    match Board_dispatch.list_posts ~sort_by:Board_dispatch.Updated ~limit:200 () with
+    | Error error ->
+      (`Assoc [
+        ("alert_level", `String "bad");
+        ("posts_total", `Null);
+        ("new_posts_24h", `Null);
+        ("unanswered_posts", `Null);
+        ("last_activity_age_s", `Null);
+        ("slo_target_age_s", `Int slo_target_age_s);
+        ("slo_breached", `Bool false);
+        ("error", `String (Board.show_board_error error));
+      ], false)
+    | Ok posts ->
     let total_posts = List.length posts in
     let new_posts_24h =
       List.fold_left

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -709,34 +709,59 @@ let collect_board_events_with_cursor_policy
     let cursor_ts, cursor_post_id =
       Keeper_registry.get_board_cursor ~base_path meta.name
     in
-    let base_cursor =
+    let base_cursor_result =
       if cursor_ts > 0.0
-      then Some (cursor_ts, cursor_post_id)
+      then Ok (Some (cursor_ts, cursor_post_id))
       else (
-        let initial_cursor = Board_dispatch.current_post_cursor () in
-        if advance_cursor
-        then (
-          let ts, post_id = initial_cursor in
-          Keeper_registry.set_board_cursor ~base_path meta.name ts post_id;
-          (match post_id with
-           | Some post_id ->
-             Log.Keeper.info
-               "board cursor initialized at current head for %s: (%f, %s)"
-               meta.name
-               ts
-               post_id
-           | None ->
-             Log.Keeper.info
-               "board cursor initialized at empty current head for %s: (%f, no post)"
-               meta.name
-               ts));
-        None)
+        match Board_dispatch.current_post_cursor () with
+        | Error error -> Error error
+        | Ok (ts, post_id) ->
+          if advance_cursor
+          then (
+            Keeper_registry.set_board_cursor ~base_path meta.name ts post_id;
+            (match post_id with
+             | Some post_id ->
+               Log.Keeper.info
+                 "board cursor initialized at current head for %s: (%f, %s)"
+                 meta.name
+                 ts
+                 post_id
+             | None ->
+               Log.Keeper.info
+                 "board cursor initialized at empty current head for %s: (%f, no post)"
+                 meta.name
+                 ts));
+          Ok None)
     in
-    let posts =
+    match base_cursor_result with
+    | Error error ->
+      Otel_metric_store.inc_counter
+        Keeper_metrics.(to_string ObservationQueryFailures)
+        ~labels:[ ("operation", Runtime_observation_query_operation.(to_label Board_events)) ]
+        ();
+      Log.Keeper.warn
+        "board event collection retained cursor: Board unavailable for keeper=%s: %s"
+        meta.name
+        (Board.show_board_error error);
+      [], 0, 0
+    | Ok base_cursor ->
+    let posts_result =
       match base_cursor with
-      | None -> []
+      | None -> Ok []
       | Some cursor -> list_board_posts_after_cursor cursor
     in
+    match posts_result with
+    | Error error ->
+      Otel_metric_store.inc_counter
+        Keeper_metrics.(to_string ObservationQueryFailures)
+        ~labels:[ ("operation", Runtime_observation_query_operation.(to_label Board_events)) ]
+        ();
+      Log.Keeper.warn
+        "board event collection retained cursor: Board unavailable for keeper=%s: %s"
+        meta.name
+        (Board.show_board_error error);
+      [], 0, 0
+    | Ok posts ->
     let self_ids = self_ids meta in
     let recent =
       List.filter

--- a/lib/keeper/keeper_world_observation_board_signal.ml
+++ b/lib/keeper/keeper_world_observation_board_signal.ml
@@ -84,6 +84,11 @@ let disposition_of_error : Board.board_error -> disposition = function
     (* Not reachable from a read path. An identity/ownership gate rejection
        is deterministic and does not resolve by retrying. *)
     Permanent
+  | Board.Persistence_reset_required _ ->
+    (* The same process keeps the typed unavailable backend until the
+       operator resets the snapshot and restarts. Retrying inside a Keeper
+       turn cannot change that state. *)
+    Permanent
 ;;
 
 let disposition_of_unavailable (unavailable : board_unavailable) =
@@ -192,10 +197,13 @@ let list_posts_after_cursor (cursor_ts, cursor_post_id) =
   let is_after_cursor post =
     compare_cursor_token (cursor_token_of_post post) (cursor_ts, cursor_post_id) > 0
   in
-  Board_dispatch.list_posts ~sort_by:Board_dispatch.Updated ~limit:max_int ()
-  |> List.filter is_after_cursor
-  |> List.sort (fun (a : Board.post) (b : Board.post) ->
-    compare_cursor_token (cursor_token_of_post a) (cursor_token_of_post b))
+  Result.map
+    (fun posts ->
+       posts
+       |> List.filter is_after_cursor
+       |> List.sort (fun (a : Board.post) (b : Board.post) ->
+         compare_cursor_token (cursor_token_of_post a) (cursor_token_of_post b)))
+    (Board_dispatch.list_posts ~sort_by:Board_dispatch.Updated ~limit:max_int ())
 ;;
 
 let text (signal : Board_dispatch.board_signal) =

--- a/lib/keeper/keeper_world_observation_board_signal.mli
+++ b/lib/keeper/keeper_world_observation_board_signal.mli
@@ -61,7 +61,8 @@ val board_stimulus_of_board_signal
 val post_id_string : Board.post -> string
 val compare_cursor_token : float * string -> float * string -> int
 val cursor_token_of_post : Board.post -> float * string
-val list_posts_after_cursor : float * string option -> Board.post list
+val list_posts_after_cursor :
+  float * string option -> (Board.post list, Board.board_error) result
 val text : Board_dispatch.board_signal -> string
 val address_text : Board_dispatch.board_signal -> string
 (** Text authored by the current signal producer and therefore allowed to

--- a/lib/server/server_board_reaction_http.ml
+++ b/lib/server/server_board_reaction_http.ml
@@ -22,6 +22,7 @@ type error_code =
   | Already_voted
   | Already_exists
   | Unauthorized
+  | Persistence_reset_required
 
 type http_status =
   [ `Bad_request
@@ -29,6 +30,7 @@ type http_status =
   | `Forbidden
   | `Internal_server_error
   | `Not_found
+  | `Service_unavailable
   | `Too_many_requests
   ]
 
@@ -51,6 +53,7 @@ let error_code_to_string = function
   | Already_voted -> "already_voted"
   | Already_exists -> "already_exists"
   | Unauthorized -> "unauthorized"
+  | Persistence_reset_required -> "persistence_reset_required"
 ;;
 
 let make_error ?(details = []) ~code ~status message =
@@ -122,6 +125,7 @@ let status_of_board_error = function
   | Board.Post_not_found _ | Board.Comment_not_found _ -> `Not_found
   | Board.Unauthorized _ -> `Forbidden
   | Board.Io_error _ -> `Internal_server_error
+  | Board.Persistence_reset_required _ -> `Service_unavailable
 ;;
 
 let code_and_details_of_board_error = function
@@ -133,6 +137,7 @@ let code_and_details_of_board_error = function
   | Board.Already_voted _ -> Already_voted, []
   | Board.Already_exists _ -> Already_exists, []
   | Board.Unauthorized _ -> Unauthorized, []
+  | Board.Persistence_reset_required _ -> Persistence_reset_required, []
 ;;
 
 let of_board_error board_error =

--- a/lib/server/server_board_reaction_http.mli
+++ b/lib/server/server_board_reaction_http.mli
@@ -14,6 +14,7 @@ type http_status =
   | `Forbidden
   | `Internal_server_error
   | `Not_found
+  | `Service_unavailable
   | `Too_many_requests
   ]
 

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -109,7 +109,7 @@ let dashboard_board_json
          without a second query. total is only emitted when the result fits
          entirely inside the fetched window — otherwise null (unknown). *)
       let probe_fetch = base_fetch + 1 in
-      let posts =
+      match
         Board_dispatch.list_posts
           ?hearth
           ~sort_by
@@ -117,9 +117,16 @@ let dashboard_board_json
           ~exclude_automation
           ?author_filter
           ~limit:probe_fetch
-          ()
-      in
-      let karma_map = Board_dispatch.get_all_karma () in
+          (),
+        Board_dispatch.get_all_karma ()
+      with
+      | Error error, _ | _, Error error ->
+        `Assoc
+          [ "generated_at", `String (Masc_domain.now_iso ())
+          ; "unavailable", `Bool true
+          ; "error", `String (Board.show_board_error error)
+          ]
+      | Ok posts, Ok karma_map ->
       let get_karma author = Option.value ~default:0 (List.assoc_opt author karma_map) in
       let fetched_len = List.length posts in
       let window_end = offset + limit in

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -671,7 +671,15 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
       | `GET, "/api/v1/dashboard/board" ->
           with_h2_public_read h2_reqd (fun _state ->
             let json = dashboard_memory_http_json httpun_request in
-            h2_respond_json_value h2_reqd json ~extra_headers:cors)
+            let status =
+              match json with
+              | `Assoc fields ->
+                (match List.assoc_opt "unavailable" fields with
+                 | Some (`Bool true) -> `Service_unavailable
+                 | _ -> `OK)
+              | _ -> `OK
+            in
+            h2_respond_json_value h2_reqd json ~status ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/gate" ->
           with_h2_public_read h2_reqd (fun state ->

--- a/lib/server/server_h2_gateway_routes_extra.ml
+++ b/lib/server/server_h2_gateway_routes_extra.ml
@@ -40,6 +40,14 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
          h2_respond_auth_error error;
          true)
   in
+  let board_unavailable error =
+    h2_respond_json_value
+      h2_reqd
+      (`Assoc [ ("error", `String (Board.show_board_error error)) ])
+      ~status:`Service_unavailable
+      ~extra_headers:cors;
+    true
+  in
   match httpun_meth, path with
   | `GET, "/api/v1/voice/config" ->
       let status, json = voice_config_payload () in
@@ -68,16 +76,18 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
       let base_fetch = board_fetch_limit ~exclude_system ~exclude_automation ~limit ~offset in
       let voter = board_voter_query httpun_request in
       let blind_votes = bool_query_param httpun_request "blind_votes" ~default:false in
-      let posts =
+      match
         Board_dispatch.list_posts ?hearth ~sort_by ~exclude_system
-          ~exclude_automation ?author_filter ~limit:base_fetch ()
-      in
-      let karma_map = Board_dispatch.get_all_karma () in
+          ~exclude_automation ?author_filter ~limit:base_fetch (),
+        Board_dispatch.get_all_karma ()
+      with
+      | Error error, _ | _, Error error -> board_unavailable error
+      | Ok posts, Ok karma_map ->
       let get_karma author =
         Option.value ~default:0 (List.assoc_opt author karma_map)
       in
       let paged = posts |> drop offset |> take limit in
-      let reaction_rows =
+      match
         board_reactions_batch
           ~targets:
             (List.map
@@ -85,7 +95,9 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
                   (Board.Reaction_post, Board.Post_id.to_string p.id))
                paged)
           ~voter:reaction_actor
-      in
+      with
+      | Error error -> board_unavailable error
+      | Ok reaction_rows ->
       let reactions_for = board_reactions_lookup reaction_rows in
       let contributor_quality_for = board_contributor_quality_lookup ?config () in
       let posts_json = List.map (fun (p : Board.post) ->
@@ -118,14 +130,16 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
       true
 
   | `GET, "/api/v1/board/hearths" ->
-      let hearths = Board_dispatch.list_hearths () in
-      let json = `Assoc [
-        ("hearths", `List (List.map (fun (name, count) ->
-          `Assoc [("name", `String name); ("count", `Int count)]
-        ) hearths));
-      ] in
-      h2_respond_json_value h2_reqd json ~extra_headers:cors;
-      true
+      (match Board_dispatch.list_hearths () with
+       | Error error -> board_unavailable error
+       | Ok hearths ->
+         let json = `Assoc [
+           ("hearths", `List (List.map (fun (name, count) ->
+             `Assoc [("name", `String name); ("count", `Int count)]
+           ) hearths));
+         ] in
+         h2_respond_json_value h2_reqd json ~extra_headers:cors;
+         true)
 
   | `GET, "/api/v1/board/flairs" ->
       let flairs = List.map Board.flair_to_yojson Board.available_flairs in
@@ -134,16 +148,18 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
       true
 
   | `GET, "/api/v1/board/sub-boards" ->
-      let sub_boards = Board_dispatch.list_sub_boards () in
-      let json =
-        `Assoc
-          [
-            ( "sub_boards",
-              `List (List.map Board.sub_board_to_yojson sub_boards) );
-          ]
-      in
-      h2_respond_json_value h2_reqd json ~extra_headers:cors;
-      true
+      (match Board_dispatch.list_sub_boards () with
+       | Error error -> board_unavailable error
+       | Ok sub_boards ->
+         let json =
+           `Assoc
+             [
+               ( "sub_boards",
+                 `List (List.map Board.sub_board_to_yojson sub_boards) );
+             ]
+         in
+         h2_respond_json_value h2_reqd json ~extra_headers:cors;
+         true)
 
   | `GET, "/api/v1/board/karma/ledger" ->
       (* Karma ledger contract endpoint — attributed karma events.
@@ -155,28 +171,30 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
         int_query_param httpun_request "limit" ~default:500
         |> clamp ~min_v:1 ~max_v:5000
       in
-      let events = Board_dispatch.get_karma_ledger ?agent ~limit () in
-      let totals =
-        Board_dispatch.get_all_karma ()
-        |> List.sort (fun (_, a) (_, b) -> compare b a)
-      in
-      let json =
-        `Assoc
-          [
-            ("events", `List (List.map Board.karma_event_to_yojson events));
-            ("count", `Int (List.length events));
-            ("scoring_rule", `String "up=+1,down=0");
-            ( "totals",
-              `List
-                (List.map
-                   (fun (agent_name, k) ->
-                     `Assoc
-                       [ ("agent", `String agent_name); ("karma", `Int k) ])
-                   totals) );
-          ]
-      in
-      h2_respond_json_value h2_reqd json ~extra_headers:cors;
-      true
+      (match
+         Board_dispatch.get_karma_ledger ?agent ~limit (),
+         Board_dispatch.get_all_karma ()
+       with
+       | Error error, _ | _, Error error -> board_unavailable error
+       | Ok events, Ok totals ->
+         let totals = List.sort (fun (_, a) (_, b) -> compare b a) totals in
+         let json =
+           `Assoc
+             [
+               ("events", `List (List.map Board.karma_event_to_yojson events));
+               ("count", `Int (List.length events));
+               ("scoring_rule", `String "up=+1,down=0");
+               ( "totals",
+                 `List
+                   (List.map
+                      (fun (agent_name, k) ->
+                         `Assoc
+                           [ ("agent", `String agent_name); ("karma", `Int k) ])
+                      totals) );
+             ]
+         in
+         h2_respond_json_value h2_reqd json ~extra_headers:cors;
+         true)
 
   | `GET, p
     when String.starts_with ~prefix:"/api/v1/board/" p
@@ -207,15 +225,17 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
         true)
 
   | `GET, "/api/v1/karma" ->
-      let karma_list = Board_dispatch.get_all_karma () in
-      let sorted = List.sort (fun (_, a) (_, b) -> compare b a) karma_list in
-      let json = `Assoc [
-        ("karma", `List (List.map (fun (agent, k) ->
-          `Assoc [("agent", `String agent); ("karma", `Int k)]
-        ) sorted));
-      ] in
-      h2_respond_json_value h2_reqd json ~extra_headers:cors;
-      true
+      (match Board_dispatch.get_all_karma () with
+       | Error error -> board_unavailable error
+       | Ok karma_list ->
+         let sorted = List.sort (fun (_, a) (_, b) -> compare b a) karma_list in
+         let json = `Assoc [
+           ("karma", `List (List.map (fun (agent, k) ->
+             `Assoc [("agent", `String agent); ("karma", `Int k)]
+           ) sorted));
+         ] in
+         h2_respond_json_value h2_reqd json ~extra_headers:cors;
+         true)
 
   | `GET, "/static/css/middleware.css" ->
       (match read_file (playground_asset_path "static/css/middleware.css") with

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -26,6 +26,27 @@ let respond_board_reaction_result request reqd = function
       (Server_board_reaction_http.error_json error)
 ;;
 
+let respond_board_read_result reqd = function
+  | Ok json -> Http.Response.json_value json reqd
+  | Error error ->
+    Http.Response.json_value
+      ~status:`Service_unavailable
+      (`Assoc [ ("error", `String (Board.show_board_error error)) ])
+      reqd
+;;
+
+let respond_cached_board_json reqd json =
+  let status =
+    match json with
+    | `Assoc fields ->
+      (match List.assoc_opt "unavailable" fields with
+       | Some (`Bool true) -> `Service_unavailable
+       | _ -> `OK)
+    | _ -> `OK
+  in
+  Http.Response.json_value ~status json reqd
+;;
+
 let include_moderation_projection ~base_path request =
   match auth_token_from_request request with
   | None -> false
@@ -154,33 +175,38 @@ let board_curation_json () =
   | Some snap -> `Assoc [ ("snapshot", Board_curation.snapshot_to_yojson snap) ]
 
 let board_sub_boards_json () =
-  let sub_boards = Board_dispatch.list_sub_boards () in
-  `Assoc
-    [
-      ( "sub_boards",
-        `List (List.map Board.sub_board_to_yojson sub_boards) );
-    ]
+  Result.map
+    (fun sub_boards ->
+       `Assoc
+         [
+           ( "sub_boards",
+             `List (List.map Board.sub_board_to_yojson sub_boards) );
+         ])
+    (Board_dispatch.list_sub_boards ())
 
 let board_karma_ledger_json req =
   let agent = query_param req "agent" in
   let limit = int_query_param req "limit" ~default:500 |> clamp ~min_v:1 ~max_v:5000 in
-  let events = Board_dispatch.get_karma_ledger ?agent ~limit () in
-  let totals =
+  match
+    Board_dispatch.get_karma_ledger ?agent ~limit (),
     Board_dispatch.get_all_karma ()
-    |> List.sort (fun (_, a) (_, b) -> compare b a)
-  in
-  `Assoc
-    [
-      ("events", `List (List.map Board.karma_event_to_yojson events));
-      ("count", `Int (List.length events));
-      ("scoring_rule", `String "up=+1,down=0");
-      ( "totals",
-        `List
-          (List.map
-             (fun (agent_name, k) ->
-               `Assoc [ ("agent", `String agent_name); ("karma", `Int k) ])
-             totals) );
-    ]
+  with
+  | Error error, _ | _, Error error -> Error error
+  | Ok events, Ok totals ->
+    let totals = List.sort (fun (_, a) (_, b) -> compare b a) totals in
+    Ok
+      (`Assoc
+         [
+           ("events", `List (List.map Board.karma_event_to_yojson events));
+           ("count", `Int (List.length events));
+           ("scoring_rule", `String "up=+1,down=0");
+           ( "totals",
+             `List
+               (List.map
+                  (fun (agent_name, k) ->
+                     `Assoc [ ("agent", `String agent_name); ("karma", `Int k) ])
+                  totals) );
+         ])
 
 type board_context_inference_target_source =
   | Explicit_target
@@ -592,18 +618,24 @@ let add_routes ~sw ~clock router =
              ~ttl:Server_dashboard_http_core_cache.realtime_cache_ttl_s
              (fun () ->
                 Domain_pool_ref.submit_io_or_inline (fun () ->
-                  let posts =
+                  match
                     Board_dispatch.list_posts ?hearth ~sort_by ~exclude_system
-                      ~exclude_automation ?author_filter ~limit:base_fetch ()
-                  in
-                  let karma_map = Board_dispatch.get_all_karma () in
+                      ~exclude_automation ?author_filter ~limit:base_fetch (),
+                    Board_dispatch.get_all_karma ()
+                  with
+                  | Error error, _ | _, Error error ->
+                    `Assoc
+                      [ ("error", `String (Board.show_board_error error))
+                      ; ("unavailable", `Bool true)
+                      ]
+                  | Ok posts, Ok karma_map ->
                   let get_karma author =
                     match List.assoc_opt author karma_map with
                     | Some karma -> karma
                     | None -> 0
                   in
                   let paged = posts |> drop offset |> take limit in
-                  let reaction_rows =
+                  match
                     board_reactions_batch
                       ~targets:
                         (List.map
@@ -611,7 +643,13 @@ let add_routes ~sw ~clock router =
                               (Board.Reaction_post, Board.Post_id.to_string p.id))
                            paged)
                       ~voter:reaction_actor
-                  in
+                  with
+                  | Error error ->
+                    `Assoc
+                      [ ("error", `String (Board.show_board_error error))
+                      ; ("unavailable", `Bool true)
+                      ]
+                  | Ok reaction_rows ->
                   let reactions_for = board_reactions_lookup reaction_rows in
                   let contributor_quality_for =
                     board_contributor_quality_lookup ~config ()
@@ -630,15 +668,15 @@ let add_routes ~sw ~clock router =
                            ~author_karma:(get_karma author) p)
                       paged
                   in
-                  `Assoc [
-                    ("posts", `List posts_json);
-                    ("count", `Int (List.length posts_json));
-                    ("limit", `Int limit);
-                    ("offset", `Int offset);
-                    ("sort_by", `String (board_sort_label sort_by));
-                  ]))
+                    `Assoc [
+                      ("posts", `List posts_json);
+                      ("count", `Int (List.length posts_json));
+                      ("limit", `Int limit);
+                      ("offset", `Int offset);
+                      ("sort_by", `String (board_sort_label sort_by));
+                    ]))
          in
-         Http.Response.json_value json reqd)
+         respond_cached_board_json reqd json)
        ) request reqd)
 
   |> Http.Router.get "/api/v1/board/reactions/catalog" (fun request reqd ->
@@ -700,14 +738,20 @@ let add_routes ~sw ~clock router =
              ~ttl:Server_dashboard_http_core_cache.standard_cache_ttl_s
              (fun () ->
                 Domain_pool_ref.submit_io_or_inline (fun () ->
-                  let hearths = Board_dispatch.list_hearths () in
-                  `Assoc [
-                    ("hearths", `List (List.map (fun (name, count) ->
-                      `Assoc [("name", `String name); ("count", `Int count)]
-                    ) hearths));
-                  ]))
+                  match Board_dispatch.list_hearths () with
+                  | Error error ->
+                    `Assoc
+                      [ ("error", `String (Board.show_board_error error))
+                      ; ("unavailable", `Bool true)
+                      ]
+                  | Ok hearths ->
+                    `Assoc [
+                      ("hearths", `List (List.map (fun (name, count) ->
+                        `Assoc [("name", `String name); ("count", `Int count)]
+                      ) hearths));
+                    ]))
          in
-         Http.Response.json_value json reqd
+         respond_cached_board_json reqd json
        ) request reqd)
 
   |> Http.Router.get "/api/v1/board/curation" (fun request reqd ->
@@ -721,7 +765,7 @@ let add_routes ~sw ~clock router =
        Http.Response.json_value json reqd)
 
   |> Http.Router.get "/api/v1/board/sub-boards" (fun _request reqd ->
-       respond_board_json reqd (board_sub_boards_json ()))
+       respond_board_read_result reqd (board_sub_boards_json ()))
 
   |> Http.Router.post "/api/v1/board/context-inference" (fun request reqd ->
        with_tool_auth ~tool_name:"masc_keeper_delegate"
@@ -871,9 +915,9 @@ let add_routes ~sw ~clock router =
           | Some "curation" ->
               respond_board_json reqd (board_curation_json ())
           | Some "sub-boards" ->
-              respond_board_json reqd (board_sub_boards_json ())
+              respond_board_read_result reqd (board_sub_boards_json ())
           | Some "karma/ledger" ->
-              respond_board_json reqd (board_karma_ledger_json req)
+              respond_board_read_result reqd (board_karma_ledger_json req)
           | Some post_id ->
               let config = Mcp_server.workspace_config state in
               with_optional_board_reaction_actor
@@ -1051,19 +1095,25 @@ let add_routes ~sw ~clock router =
        ) request reqd)
   |> Http.Router.get "/api/v1/karma" (fun request reqd ->
        with_public_read (fun _state _req reqd ->
-         let karma_list = Board_dispatch.get_all_karma () in
-         let sorted = List.sort (fun (_, a) (_, b) -> compare b a) karma_list in
-         let json = `Assoc [
-           ("karma", `List (List.map (fun (agent, k) ->
-             `Assoc [("agent", `String agent); ("karma", `Int k)]
-           ) sorted));
-         ] in
-         Http.Response.json_value json reqd
+         match Board_dispatch.get_all_karma () with
+         | Error error ->
+           Http.Response.json_value
+             ~status:`Service_unavailable
+             (`Assoc [ ("error", `String (Board.show_board_error error)) ])
+             reqd
+         | Ok karma_list ->
+           let sorted = List.sort (fun (_, a) (_, b) -> compare b a) karma_list in
+           let json = `Assoc [
+             ("karma", `List (List.map (fun (agent, k) ->
+               `Assoc [("agent", `String agent); ("karma", `Int k)]
+             ) sorted));
+           ] in
+           Http.Response.json_value json reqd
        ) request reqd)
 
   |> Http.Router.get "/api/v1/board/karma/ledger" (fun request reqd ->
        with_public_read (fun _state req reqd ->
-         respond_board_json reqd (board_karma_ledger_json req)
+         respond_board_read_result reqd (board_karma_ledger_json req)
        ) request reqd)
 
   (* Mention Inbox API *)

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -1079,7 +1079,15 @@ let add_routes ~sw ~clock router =
          let json =
            dashboard_memory_http_json ~config:(Mcp_server.workspace_config state) req
          in
-         Http.Response.json_value ~compress:true ~request:req json reqd
+         let status =
+           match json with
+           | `Assoc fields ->
+             (match List.assoc_opt "unavailable" fields with
+              | Some (`Bool true) -> `Service_unavailable
+              | _ -> `OK)
+           | _ -> `OK
+         in
+         Http.Response.json_value ~status ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.post "/api/v1/dashboard/link-previews" (fun request reqd ->
        with_permission_auth ~permission:Masc_domain.CanReadState

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -1370,27 +1370,34 @@ let readiness_handler _request reqd =
 
 let board_post_detail_json ~include_moderation ~blind_votes ~config ~voter
     ~reaction_actor ~response_format ~post_id =
+  let board_error_response err =
+    let status =
+      match err with
+      | Board.Post_not_found _ | Board.Comment_not_found _ -> `Not_found
+      | Board.Persistence_reset_required _ -> `Service_unavailable
+      | _ -> `Internal_server_error
+    in
+    status,
+    Printf.sprintf
+      {|{"error":"%s"}|}
+      (String.escaped (Board_tool.board_error_to_string err))
+  in
   match Board_dispatch.get_post ~post_id with
-  | Error err ->
+  | Error err -> board_error_response err
       (* Render a human-readable message (e.g. "Post not found: <id>") via the
          shared Board_tool.board_error_to_string, matching the 404 contract in
          the .mli and the convention already used for board errors in
          server_routes_http_routes_activity.ml. The derived [show_board_error]
          leaked the internal OCaml constructor name ("Post_not_found(...)") into
          the public HTTP body. *)
-      (`Not_found, Printf.sprintf {|{"error":"%s"}|}
-         (String.escaped (Board_tool.board_error_to_string err)))
   | Ok post ->
       let author = Board.Agent_id.to_string post.author in
-      let author_karma = Board_dispatch.get_agent_karma ~agent_name:author in
-      let comments =
-        match Board_dispatch.get_comments ~post_id with
-        | Ok cs -> cs
-        | Error err ->
-            Log.Server.warn "board_post_detail: get_comments failed for %s: %s"
-              post_id (Board_types.show_board_error err);
-            []
-      in
+      match
+        Board_dispatch.get_agent_karma ~agent_name:author,
+        Board_dispatch.get_comments ~post_id
+      with
+      | Error err, _ | _, Error err -> board_error_response err
+      | Ok author_karma, Ok comments ->
       let current_vote = board_current_vote_for_post ~voter ~post_id in
       let reaction_targets =
         (Board.Reaction_post, post_id)
@@ -1399,9 +1406,11 @@ let board_post_detail_json ~include_moderation ~blind_votes ~config ~voter
                 (Board.Reaction_comment, Board.Comment_id.to_string comment.id))
              comments
       in
-      let reaction_rows =
+      match
         board_reactions_batch ~targets:reaction_targets ~voter:reaction_actor
-      in
+      with
+      | Error err -> board_error_response err
+      | Ok reaction_rows ->
       let reactions_for = board_reactions_lookup reaction_rows in
       let reactions = reactions_for (Board.Reaction_post, post_id) in
       let contributor_quality =

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -326,7 +326,7 @@ val board_post_detail_json :
   reaction_actor:string option ->
   response_format:Server_board_post_response_format.t ->
   post_id:string ->
-  [> `OK | `Not_found ] * string
+  [> `OK | `Not_found | `Internal_server_error | `Service_unavailable ] * string
 (** [board_post_detail_json ~voter ~reaction_actor ~response_format ~post_id] returns
     [(status, json_string)] for [GET /api/v1/board/<post_id>].
     When [voter] is supplied, post/comment rows include vote state for

--- a/lib/server_utils.ml
+++ b/lib/server_utils.ml
@@ -201,7 +201,7 @@ let board_reactions_for_comment ~voter ~comment_id =
 
 let board_reactions_batch ~targets ~voter =
   match targets with
-  | [] -> []
+  | [] -> Ok []
   | _ -> Board_dispatch.list_reactions_batch ~targets ?user_id:voter ()
 
 let board_reactions_lookup rows =

--- a/lib/server_utils.mli
+++ b/lib/server_utils.mli
@@ -160,7 +160,9 @@ val board_reactions_for_comment :
 val board_reactions_batch :
   targets:(Board.reaction_target_type * string) list ->
   voter:string option ->
-  ((Board.reaction_target_type * string) * Board.reaction_summary list) list
+  ( ((Board.reaction_target_type * string) * Board.reaction_summary list) list
+  , Board.board_error )
+  result
 (** [board_reactions_batch ~targets ~voter] returns dashboard reaction
     summaries for a request's target set using one board-store scan. *)
 

--- a/lib/workspace_metric_hooks.ml
+++ b/lib/workspace_metric_hooks.ml
@@ -280,23 +280,30 @@ let install () =
       || ((not (String.contains author ' ')) && String.ends_with ~suffix:"-probe" author)
     in
     let now = Time_compat.now () in
-    Board_dispatch.list_posts ~sort_by:Board_dispatch.Recent ~limit:5200 ()
-    |> List.fold_left
-         (fun removed (post : Board.post) ->
-            let author = Board.Agent_id.to_string post.author in
-            if
-              board_artifact_author author
-              || (String.equal (String.lowercase_ascii author) "keeper"
-                  && board_artifact_title post.title
-                  && now -. post.updated_at >= stale_system_daily_sec)
-            then (
-              match
-                Board_dispatch.delete_post ~post_id:(Board.Post_id.to_string post.id)
-              with
-              | Ok () -> removed + 1
-              | Error _ -> removed)
-            else removed)
-         0);
+    match Board_dispatch.list_posts ~sort_by:Board_dispatch.Recent ~limit:5200 () with
+    | Error error ->
+      Log.Workspace.warn
+        "board artifact cleanup skipped: %s"
+        (Board.show_board_error error);
+      0
+    | Ok posts ->
+      List.fold_left
+        (fun removed (post : Board.post) ->
+           let author = Board.Agent_id.to_string post.author in
+           if
+             board_artifact_author author
+             || (String.equal (String.lowercase_ascii author) "keeper"
+                 && board_artifact_title post.title
+                 && now -. post.updated_at >= stale_system_daily_sec)
+           then (
+             match
+               Board_dispatch.delete_post ~post_id:(Board.Post_id.to_string post.id)
+             with
+             | Ok () -> removed + 1
+             | Error _ -> removed)
+           else removed)
+        0
+        posts);
 
   Atomic.set Workspace_hooks.activity_emit_fn (fun config ~actor ?subject ~kind ~payload ~tags () ->
     try

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -5,6 +5,10 @@ open Masc
 let () = Mirage_crypto_rng_unix.use_default ()
 let () = Random.self_init ()
 
+let expect_board_ok = function
+  | Ok value -> value
+  | Error error -> Alcotest.fail (Board.show_board_error error)
+
 (** Temp directory for test isolation — set before any Board.global call *)
 let fresh_test_base_path () =
   let dir =
@@ -36,23 +40,31 @@ let block_board_masc_dir_with_file () =
   Fs_compat.save_file masc_dir "not a directory";
   base
 
-let seed_legacy_keeper_post () =
+let seed_mixed_current_and_retired_post_snapshot () =
+  let current_post =
+    expect_board_ok
+      (Board_dispatch.create_post
+         ~author:"current-writer"
+         ~content:"current row must not leak through a mixed snapshot"
+         ~post_kind:Board.Human_post
+         ())
+  in
+  let current_post_id = Board.Post_id.to_string current_post.id in
   let now = Time_compat.now () in
-  let post_id = Printf.sprintf "legacy-keeper-%06x" (Random.bits ()) in
+  let retired_post_id = Printf.sprintf "retired-keeper-%06x" (Random.bits ()) in
   let path = Board.persist_path () in
   let dir = Filename.dirname path in
   Fs_compat.mkdir_p dir;
   let json =
     `Assoc
       [
-        ("id", `String post_id);
+        ("id", `String retired_post_id);
         ("author", `String "dm-keeper");
-        ("title", `String "Legacy keeper");
+        ("title", `String "Retired keeper row");
         ("body", `String "keeper");
         ("content", `String "keeper");
         ("visibility", `String "internal");
         ("created_at", `Float now);
-        ("updated_at", `Float now);
         ("expires_at", `Float 0.0);
         ("votes_up", `Int 0);
         ("votes_down", `Int 0);
@@ -64,7 +76,7 @@ let seed_legacy_keeper_post () =
   Board.reset_global_for_test ();
   Board_dispatch.reset_for_test ();
   Board_dispatch.init_jsonl ();
-  post_id
+  current_post_id, retired_post_id
 
 let keeper_meta name =
   match
@@ -86,6 +98,8 @@ let test_default_backend () =
 let test_backend_returns_jsonl () =
   match Board_dispatch.backend () with
   | Board_dispatch.Jsonl _ -> ()
+  | Board_dispatch.Unavailable error ->
+    Alcotest.fail (Board.show_board_error error)
 
 (** {1 Post CRUD via Dispatch} *)
 
@@ -359,35 +373,6 @@ let test_keeper_signal_hook_cancellation_propagates () =
    with Eio.Cancel.Cancelled _ -> raised := true);
   Alcotest.(check bool) "cancellation propagated" true !raised
 
-let test_dedup_hit_does_not_emit_post_created_fanout () =
-  let keeper_signals = ref 0 in
-  let sse_post_created = ref 0 in
-  Board_dispatch.set_board_signal_hook (fun _ -> incr keeper_signals);
-  Board_dispatch.set_board_sse_hook (function
-    | Board_dispatch.Post_created _ -> incr sse_post_created
-    | _ -> ());
-  let create () =
-    Board_dispatch.create_post ~author:"dedup-agent"
-      ~content:"same post body from one keeper turn"
-      ~post_kind:Board.Automation_post ~hearth:"keepers" ~thread_id:"turn-15650" ()
-  in
-  let first =
-    match create () with
-    | Ok post -> post
-    | Error e -> Alcotest.fail (Board.show_board_error e)
-  in
-  let second =
-    match create () with
-    | Ok post -> post
-    | Error e -> Alcotest.fail (Board.show_board_error e)
-  in
-  Alcotest.(check string)
-    "dedup returns existing post"
-    (Board.Post_id.to_string first.id)
-    (Board.Post_id.to_string second.id);
-  Alcotest.(check int) "keeper signal emitted once" 1 !keeper_signals;
-  Alcotest.(check int) "SSE post_created emitted once" 1 !sse_post_created
-
 let test_create_post_persistence_failure_returns_error_without_fanout () =
   let keeper_signals = ref 0 in
   let sse_post_created = ref 0 in
@@ -413,7 +398,7 @@ let test_create_post_persistence_failure_returns_error_without_fanout () =
   Alcotest.(check int)
     "failed create rolled back in-memory post"
     0
-    (List.length (Board_dispatch.list_posts ~limit:10 ()))
+    (List.length (expect_board_ok (Board_dispatch.list_posts ~limit:10 ())))
 
 let test_structured_post_roundtrip () =
   let meta = `Assoc [("source", `String "keeper_autonomy")] in
@@ -465,43 +450,44 @@ let test_list_posts () =
             ~post_kind:Board.Human_post ());
   ignore (Board_dispatch.create_post ~author:"lister" ~content:"list test 2"
             ~post_kind:Board.Human_post ());
-  let posts = Board_dispatch.list_posts ~limit:10 () in
+  let posts = expect_board_ok (Board_dispatch.list_posts ~limit:10 ()) in
   Alcotest.(check bool) "at least 2 posts" true (List.length posts >= 2)
 
 let test_list_posts_negative_limit_returns_empty () =
   ignore (Board_dispatch.create_post ~author:"negative-limit"
             ~content:"negative limit probe" ~post_kind:Board.Human_post ());
-  let posts = Board_dispatch.list_posts ~limit:(-1) () in
+  let posts = expect_board_ok (Board_dispatch.list_posts ~limit:(-1) ()) in
   Alcotest.(check int) "negative limit closes to empty" 0 (List.length posts)
 
 let test_list_posts_with_sort () =
-  let posts_hot = Board_dispatch.list_posts ~sort_by:Board_dispatch.Hot ~limit:5 () in
-  let posts_recent = Board_dispatch.list_posts ~sort_by:Board_dispatch.Recent ~limit:5 () in
-  let posts_trending = Board_dispatch.list_posts ~sort_by:Board_dispatch.Trending ~limit:5 () in
-  let posts_updated = Board_dispatch.list_posts ~sort_by:Board_dispatch.Updated ~limit:5 () in
-  let posts_discussed = Board_dispatch.list_posts ~sort_by:Board_dispatch.Discussed ~limit:5 () in
+  let posts_hot =
+    expect_board_ok
+      (Board_dispatch.list_posts ~sort_by:Board_dispatch.Hot ~limit:5 ())
+  in
+  let posts_recent =
+    expect_board_ok
+      (Board_dispatch.list_posts ~sort_by:Board_dispatch.Recent ~limit:5 ())
+  in
+  let posts_trending =
+    expect_board_ok
+      (Board_dispatch.list_posts ~sort_by:Board_dispatch.Trending ~limit:5 ())
+  in
+  let posts_updated =
+    expect_board_ok
+      (Board_dispatch.list_posts ~sort_by:Board_dispatch.Updated ~limit:5 ())
+  in
+  let posts_discussed =
+    expect_board_ok
+      (Board_dispatch.list_posts ~sort_by:Board_dispatch.Discussed ~limit:5 ())
+  in
   let counts = List.map List.length [posts_hot; posts_recent; posts_trending; posts_updated; posts_discussed] in
   let all_same = List.for_all (fun c -> c = List.hd counts) counts in
   Alcotest.(check bool) "all sort orders return same count" true all_same
 
-let board_observation_meta name =
-  match
-    Keeper_meta_json_parse.meta_of_json
-      (`Assoc
-        [ "name", `String name
-        ; "agent_name", `String ("keeper-" ^ name ^ "-agent")
-        ; "trace_id", `String ("trace-" ^ name)
-        ; "sandbox_profile", `String "local"
-        ; "network_mode", `String "inherit"
-        ])
-  with
-  | Ok meta -> meta
-  | Error message -> Alcotest.failf "board observation meta failed: %s" message
-
 let test_first_board_observation_starts_at_current_head () =
   let base_path = Sys.getenv "MASC_BASE_PATH" in
   let keeper_name = "cursor-bootstrap" in
-  let meta = board_observation_meta keeper_name in
+  let meta = keeper_meta keeper_name in
   ignore (Keeper_registry.For_testing.register ~base_path keeper_name meta);
   Fun.protect
     ~finally:(fun () -> Keeper_registry.For_testing.unregister ~base_path keeper_name)
@@ -566,7 +552,7 @@ let test_first_board_observation_starts_at_current_head () =
 let test_dashboard_projection_does_not_produce_attention_candidate () =
   let base_path = Sys.getenv "MASC_BASE_PATH" in
   let keeper_name = "projection-read-only" in
-  let meta = board_observation_meta keeper_name in
+  let meta = keeper_meta keeper_name in
   let entry = Keeper_registry.For_testing.register ~base_path keeper_name meta in
   Fun.protect
     ~finally:(fun () -> Keeper_registry.For_testing.unregister ~base_path keeper_name)
@@ -621,8 +607,8 @@ let test_dashboard_projection_does_not_produce_attention_candidate () =
         | Error detail ->
           Alcotest.failf "owner candidate read failed: %s" detail);
        Alcotest.(check bool)
-         "live owner collection woke the Keeper"
-         true
+         "pending judgment does not wake the owner lane"
+         false
          (Atomic.get entry.fiber_wakeup))
 ;;
 
@@ -654,10 +640,12 @@ let test_recent_sort_bypasses_hot_cutoff () =
   in
   let cold_post_id = Board.Post_id.to_string cold_post.id in
   let recent_posts =
-    Board_dispatch.list_posts ~sort_by:Board_dispatch.Recent ~limit:1 ()
+    expect_board_ok
+      (Board_dispatch.list_posts ~sort_by:Board_dispatch.Recent ~limit:1 ())
   in
   let hot_posts =
-    Board_dispatch.list_posts ~sort_by:Board_dispatch.Hot ~limit:1 ()
+    expect_board_ok
+      (Board_dispatch.list_posts ~sort_by:Board_dispatch.Hot ~limit:1 ())
   in
   let recent_post_id =
     match recent_posts with
@@ -689,21 +677,25 @@ let test_list_posts_with_filters () =
             ~post_kind:Board.Automation_post ~meta_json:keeper_meta ());
   let all_posts =
     Board_dispatch.list_posts ~sort_by:Board_dispatch.Recent ~limit:50 ()
+    |> expect_board_ok
     |> List.filter is_scoped_author
   in
   let no_system =
     Board_dispatch.list_posts ~sort_by:Board_dispatch.Recent ~exclude_system:true
       ~limit:50 ()
+    |> expect_board_ok
     |> List.filter is_scoped_author
   in
   let no_automation =
     Board_dispatch.list_posts ~sort_by:Board_dispatch.Recent
       ~exclude_automation:true ~limit:50 ()
+    |> expect_board_ok
     |> List.filter is_scoped_author
   in
   let human_only =
     Board_dispatch.list_posts ~sort_by:Board_dispatch.Recent ~exclude_system:true
       ~exclude_automation:true ~limit:50 ()
+    |> expect_board_ok
     |> List.filter is_scoped_author
   in
   Alcotest.(check int) "all posts" 3 (List.length all_posts);
@@ -747,8 +739,9 @@ let test_list_posts_matches_comment_author () =
    | Ok _ -> ()
    | Error e -> Alcotest.fail (Board.show_board_error e));
   let filtered =
-    Board_dispatch.list_posts ~sort_by:Board_dispatch.Recent
-      ~author_filter:"MATCH-AGENT" ~limit:20 ()
+    expect_board_ok
+      (Board_dispatch.list_posts ~sort_by:Board_dispatch.Recent
+         ~author_filter:"MATCH-AGENT" ~limit:20 ())
   in
   let ids =
     List.map (fun (post : Board.post) -> Board.Post_id.to_string post.id) filtered
@@ -763,18 +756,77 @@ let test_author_filter_treats_wildcards_literally () =
     (Board_dispatch.create_post ~author:"wildcard-alpha"
        ~content:"literal wildcard filter" ~post_kind:Board.Human_post ());
   let filtered =
-    Board_dispatch.list_posts ~sort_by:Board_dispatch.Recent
-      ~author_filter:"%" ~limit:20 ()
+    expect_board_ok
+      (Board_dispatch.list_posts ~sort_by:Board_dispatch.Recent
+         ~author_filter:"%" ~limit:20 ())
   in
   Alcotest.(check int) "percent does not match all authors" 0
     (List.length filtered)
 
-let test_legacy_post_without_kind_is_rejected () =
-  let post_id = seed_legacy_keeper_post () in
-  match Board_dispatch.get_post ~post_id with
-  | Error (Board.Post_not_found _) -> ()
-  | Error e -> Alcotest.fail (Board.show_board_error e)
-  | Ok _ -> Alcotest.fail "legacy post without post_kind must not be classified"
+let test_mixed_snapshot_is_typed_unavailable_without_partial_publish () =
+  let current_post_id, retired_post_id =
+    seed_mixed_current_and_retired_post_snapshot ()
+  in
+  Alcotest.(check string)
+    "backend exposes unavailable state"
+    "unavailable"
+    (Board_dispatch.backend_name ());
+  (match Board_dispatch.backend () with
+   | Board_dispatch.Unavailable (Board.Persistence_reset_required _) -> ()
+   | Board_dispatch.Unavailable error ->
+     Alcotest.failf
+       "expected persistence reset-required, got %s"
+       (Board.show_board_error error)
+   | Board_dispatch.Jsonl _ ->
+     Alcotest.fail "mixed snapshot published a partial Jsonl backend");
+  List.iter
+    (fun post_id ->
+       match Board_dispatch.get_post ~post_id with
+       | Error (Board.Persistence_reset_required _) -> ()
+       | Error error ->
+         Alcotest.failf
+           "expected reset-required for %s, got %s"
+           post_id
+           (Board.show_board_error error)
+       | Ok _ ->
+         Alcotest.failf "mixed snapshot exposed partial post %s" post_id)
+    [ current_post_id; retired_post_id ];
+  let base_path = Sys.getenv "MASC_BASE_PATH" in
+  let keeper_name = "board-reset-required" in
+  let meta = keeper_meta keeper_name in
+  let events, new_count, mention_count =
+    Keeper_world_observation.collect_board_events ~base_path ~meta
+  in
+  Alcotest.(check int)
+    "Keeper continues without partial Board events"
+    0
+    (List.length events);
+  Alcotest.(check int) "unavailable Board has no new count" 0 new_count;
+  Alcotest.(check int) "unavailable Board has no mention count" 0 mention_count;
+  let cursor_ts, cursor_post_id =
+    Keeper_registry.get_board_cursor ~base_path keeper_name
+  in
+  Alcotest.(check (float 0.0))
+    "unavailable Board does not advance Keeper cursor"
+    0.0
+    cursor_ts;
+  Alcotest.(check (option string))
+    "unavailable Board does not publish a cursor post"
+    None
+    cursor_post_id;
+  match
+    Board_dispatch.create_post
+      ~author:"blocked-writer"
+      ~content:"write must remain inside unavailable Board boundary"
+      ~post_kind:Board.Human_post
+      ()
+  with
+  | Error (Board.Persistence_reset_required _) -> ()
+  | Error error ->
+    Alcotest.failf
+      "expected reset-required write, got %s"
+      (Board.show_board_error error)
+  | Ok _ -> Alcotest.fail "unavailable Board accepted a write"
 
 (** {1 Comment Operations} *)
 
@@ -1081,6 +1133,8 @@ let test_vote_persisted_by_flusher_actor () =
         let store =
           match Board_dispatch.backend () with
           | Board_dispatch.Jsonl store -> store
+          | Board_dispatch.Unavailable error ->
+            Alcotest.fail (Board.show_board_error error)
         in
         store.last_flush <- 0.0;
         (match Board_dispatch.get_post ~post_id with
@@ -1334,13 +1388,14 @@ let test_reaction_summary_batch () =
           (Board.Reaction_comment, comment_id, "reactor-b", "👏");
         ];
       let rows =
-        Board_dispatch.list_reactions_batch
-          ~targets:
-            [
-              (Board.Reaction_post, post_id);
-              (Board.Reaction_comment, comment_id);
-            ]
-          ~user_id:"reactor-b" ()
+        expect_board_ok
+          (Board_dispatch.list_reactions_batch
+             ~targets:
+               [
+                 (Board.Reaction_post, post_id);
+                 (Board.Reaction_comment, comment_id);
+               ]
+             ~user_id:"reactor-b" ())
       in
       let summaries_for target =
         List.assoc_opt target rows |> Option.value ~default:[]
@@ -1534,7 +1589,7 @@ let test_reaction_rejects_unsupported_emoji () =
 (** {1 Stats / Search / Hearth} *)
 
 let test_stats () =
-  let stats = Board_dispatch.stats () in
+  let stats = expect_board_ok (Board_dispatch.stats ()) in
   match stats with
   | `Assoc fields ->
       Alcotest.(check bool) "has post_count"
@@ -1544,13 +1599,16 @@ let test_stats () =
 let test_search () =
   ignore (Board_dispatch.create_post ~author:"searcher"
             ~content:"unique_dispatch_search_term" ~post_kind:Board.Human_post ());
-  let results = Board_dispatch.search ~query:"unique_dispatch_search_term" ~limit:10 in
+  let results =
+    expect_board_ok
+      (Board_dispatch.search ~query:"unique_dispatch_search_term" ~limit:10)
+  in
   Alcotest.(check bool) "found search result" true (List.length results >= 1)
 
 let test_hearths () =
   ignore (Board_dispatch.create_post ~author:"hearth-test" ~content:"fire topic"
     ~hearth:"test-hearth" ~post_kind:Board.Human_post ());
-  let hearths = Board_dispatch.list_hearths () in
+  let hearths = expect_board_ok (Board_dispatch.list_hearths ()) in
   Alcotest.(check bool) "has hearths" true (List.length hearths >= 1)
 
 let test_set_thread_id () =
@@ -1634,7 +1692,7 @@ let test_set_pinned_persistence_failure_rolls_back () =
       Alcotest.(check bool) "pinned rolled back" false fetched.pinned
 
 let test_flush () =
-  Board_dispatch.flush ()
+  ignore (expect_board_ok (Board_dispatch.flush ()))
 
 (** {1 Validation} *)
 
@@ -1760,7 +1818,7 @@ let test_sub_board_list () =
             ~owner:"agent-1" ());
   ignore (Board_dispatch.create_sub_board ~slug:"list-b" ~name:"B" ~description:""
             ~owner:"agent-2" ());
-  let all = Board_dispatch.list_sub_boards () in
+  let all = expect_board_ok (Board_dispatch.list_sub_boards ()) in
   Alcotest.(check bool) "has sub-boards" true (List.length all >= 2)
 
 let test_sub_board_slug_conflict () =
@@ -2017,7 +2075,7 @@ let test_sub_board_delete_clears_orphan_hearth () =
    | Ok post ->
        Alcotest.(check (option string)) "post hearth cleared after sub-board delete"
          None post.Board.hearth);
-  Board_dispatch.flush ();
+  ignore (expect_board_ok (Board_dispatch.flush ()));
   Board.reset_global_for_test ();
   Board_dispatch.reset_for_test ();
   Board_dispatch.init_jsonl ();
@@ -2045,6 +2103,7 @@ let test_sub_board_post_count_projection () =
    | Ok sb -> Alcotest.(check int) "derived post_count" 2 sb.Board.post_count);
   let listed =
     Board_dispatch.list_sub_boards ()
+    |> expect_board_ok
     |> List.find_opt (fun sb -> String.equal sb.Board.slug "counted")
   in
   match listed with
@@ -2083,8 +2142,6 @@ let () =
         (with_eio test_keeper_signal_hook_failure_does_not_abort_create_post);
       Alcotest.test_case "keeper hook cancellation propagates" `Quick
         (with_eio test_keeper_signal_hook_cancellation_propagates);
-      Alcotest.test_case "dedup hit does not fan out post_created" `Quick
-        (with_eio test_dedup_hit_does_not_emit_post_created_fanout);
       Alcotest.test_case "create append failure returns error without fanout" `Quick
         (with_eio test_create_post_persistence_failure_returns_error_without_fanout);
       Alcotest.test_case "structured roundtrip" `Quick (with_eio test_structured_post_roundtrip);
@@ -2109,8 +2166,11 @@ let () =
         (with_eio test_list_posts_matches_comment_author);
       Alcotest.test_case "literal wildcard filter" `Quick
         (with_eio test_author_filter_treats_wildcards_literally);
-      Alcotest.test_case "legacy post without kind is rejected" `Quick
-        (with_eio test_legacy_post_without_kind_is_rejected);
+      Alcotest.test_case
+        "mixed current and retired snapshot is typed unavailable"
+        `Quick
+        (with_eio
+           test_mixed_snapshot_is_typed_unavailable_without_partial_publish);
     ];
     "comments", [
       Alcotest.test_case "add and get" `Quick (with_eio test_add_and_get_comments);

--- a/test/test_board_explicit_writes.ml
+++ b/test/test_board_explicit_writes.ml
@@ -3,6 +3,10 @@ open Masc
 let () = Mirage_crypto_rng_unix.use_default ()
 let () = Random.self_init ()
 
+let expect_board_ok = function
+  | Ok value -> value
+  | Error error -> Alcotest.fail (Board.show_board_error error)
+
 let fresh_test_base_path () =
   let dir =
     Filename.concat
@@ -51,7 +55,12 @@ let test_identical_posts_are_distinct_writes () =
   Alcotest.(check int)
     "both persisted"
     2
-    (List.length (Board_dispatch.list_posts ~sort_by:Board_dispatch.Recent ~limit:10 ()))
+    (List.length
+       (expect_board_ok
+          (Board_dispatch.list_posts
+             ~sort_by:Board_dispatch.Recent
+             ~limit:10
+             ())))
 ;;
 
 let test_identical_comments_are_distinct_writes () =

--- a/test/test_board_karma_ledger.ml
+++ b/test/test_board_karma_ledger.ml
@@ -10,6 +10,10 @@ open Masc
 let () = Mirage_crypto_rng_unix.use_default ()
 let () = Random.self_init ()
 
+let expect_board_ok = function
+  | Ok value -> value
+  | Error error -> Alcotest.fail (Board.show_board_error error)
+
 (** Fresh isolated MASC_BASE_PATH for each test *)
 let fresh_test_base_path () =
   let dir =
@@ -84,7 +88,7 @@ let test_down_scores_zero () =
 (** {1 Empty ledger} *)
 
 let test_empty_ledger () =
-  let events = Board_dispatch.get_karma_ledger () in
+  let events = expect_board_ok (Board_dispatch.get_karma_ledger ()) in
   Alcotest.(check int) "empty store gives empty ledger" 0 (List.length events)
 
 (** {1 Single upvote produces one event} *)
@@ -93,7 +97,7 @@ let test_upvote_produces_one_event () =
   let post = create_post_exn ~author:"alice" ~content:"hello" in
   let pid = Board.Post_id.to_string post.id in
   vote_exn ~voter:"bob" ~post_id:pid ~direction:Board.Up;
-  let events = Board_dispatch.get_karma_ledger () in
+  let events = expect_board_ok (Board_dispatch.get_karma_ledger ()) in
   Alcotest.(check int) "one upvote → one karma event" 1 (List.length events);
   let (ev : Board.karma_event) = List.hd events in
   Alcotest.(check string) "recipient is author" "alice" ev.recipient;
@@ -108,7 +112,7 @@ let test_downvote_no_event () =
   let post = create_post_exn ~author:"alice" ~content:"controversial" in
   let pid = Board.Post_id.to_string post.id in
   vote_exn ~voter:"bob" ~post_id:pid ~direction:Board.Down;
-  let events = Board_dispatch.get_karma_ledger () in
+  let events = expect_board_ok (Board_dispatch.get_karma_ledger ()) in
   Alcotest.(check int) "downvote → no karma event" 0 (List.length events)
 
 (** {1 Self-upvotes do NOT produce karma} *)
@@ -117,12 +121,12 @@ let test_self_post_upvote_no_karma () =
   let post = create_post_exn ~author:"alice" ~content:"self vote" in
   let pid = Board.Post_id.to_string post.id in
   vote_exn ~voter:" alice " ~post_id:pid ~direction:Board.Up;
-  let events = Board_dispatch.get_karma_ledger () in
+  let events = expect_board_ok (Board_dispatch.get_karma_ledger ()) in
   Alcotest.(check int) "self post upvote → no karma event" 0 (List.length events);
   Alcotest.(check int) "self post upvote excluded from agent karma" 0
-    (Board_dispatch.get_agent_karma ~agent_name:"alice");
+    (expect_board_ok (Board_dispatch.get_agent_karma ~agent_name:"alice"));
   Alcotest.(check (list (pair string int))) "self post upvote excluded from all karma"
-    [] (Board_dispatch.get_all_karma ());
+    [] (expect_board_ok (Board_dispatch.get_all_karma ()));
   match Board_dispatch.get_post ~post_id:pid with
   | Ok updated ->
       Alcotest.(check int) "self vote still affects board score" 1 updated.votes_up
@@ -143,7 +147,7 @@ let test_comment_upvote_produces_event () =
   in
   let cid = Board.Comment_id.to_string comment.id in
   vote_comment_exn ~voter:"dave" ~comment_id:cid ~direction:Board.Up;
-  let events = Board_dispatch.get_karma_ledger () in
+  let events = expect_board_ok (Board_dispatch.get_karma_ledger ()) in
   Alcotest.(check int) "comment upvote → one karma event" 1 (List.length events);
   let (ev : Board.karma_event) = List.hd events in
   Alcotest.(check string) "recipient is comment author" "charlie" ev.recipient;
@@ -165,10 +169,10 @@ let test_self_comment_upvote_no_karma () =
   in
   let cid = Board.Comment_id.to_string comment.id in
   vote_comment_exn ~voter:" charlie " ~comment_id:cid ~direction:Board.Up;
-  let events = Board_dispatch.get_karma_ledger () in
+  let events = expect_board_ok (Board_dispatch.get_karma_ledger ()) in
   Alcotest.(check int) "self comment upvote → no karma event" 0 (List.length events);
   Alcotest.(check int) "self comment upvote excluded from agent karma" 0
-    (Board_dispatch.get_agent_karma ~agent_name:"charlie")
+    (expect_board_ok (Board_dispatch.get_agent_karma ~agent_name:"charlie"))
 
 (** {1 Multiple voters each produce distinct events} *)
 
@@ -178,7 +182,7 @@ let test_multiple_voters () =
   List.iter
     (fun voter -> vote_exn ~voter ~post_id:pid ~direction:Board.Up)
     [ "v1"; "v2"; "v3" ];
-  let events = Board_dispatch.get_karma_ledger () in
+  let events = expect_board_ok (Board_dispatch.get_karma_ledger ()) in
   Alcotest.(check int) "3 upvotes → 3 events" 3 (List.length events);
   List.iter
     (fun (ev : Board.karma_event) ->
@@ -192,8 +196,12 @@ let test_agent_filter () =
   let post_b = create_post_exn ~author:"bob" ~content:"bob post" in
   vote_exn ~voter:"v" ~post_id:(Board.Post_id.to_string post_a.id) ~direction:Board.Up;
   vote_exn ~voter:"v" ~post_id:(Board.Post_id.to_string post_b.id) ~direction:Board.Up;
-  let alice_events = Board_dispatch.get_karma_ledger ~agent:"alice" () in
-  let bob_events = Board_dispatch.get_karma_ledger ~agent:"bob" () in
+  let alice_events =
+    expect_board_ok (Board_dispatch.get_karma_ledger ~agent:"alice" ())
+  in
+  let bob_events =
+    expect_board_ok (Board_dispatch.get_karma_ledger ~agent:"bob" ())
+  in
   Alcotest.(check int) "alice filter" 1 (List.length alice_events);
   Alcotest.(check int) "bob filter" 1 (List.length bob_events);
   Alcotest.(check string) "alice event recipient" "alice"
@@ -207,7 +215,9 @@ let test_limit () =
   List.iter
     (fun voter -> vote_exn ~voter ~post_id:pid ~direction:Board.Up)
     [ "u1"; "u2"; "u3"; "u4"; "u5" ];
-  let capped = Board_dispatch.get_karma_ledger ~limit:3 () in
+  let capped =
+    expect_board_ok (Board_dispatch.get_karma_ledger ~limit:3 ())
+  in
   Alcotest.(check int) "limit=3 caps result" 3 (List.length capped)
 
 (** {1 Rebuild / replay invariant}
@@ -225,11 +235,13 @@ let test_replay_invariant () =
   ignore (Board_dispatch.vote ~voter:"s" ~post_id:pid ~direction:Board.Down);
   let ledger_totals =
     Board_dispatch.get_karma_ledger ()
+    |> expect_board_ok
     |> Board.totals_of_karma_ledger
     |> List.sort (fun (a, _) (b, _) -> String.compare a b)
   in
   let direct_totals =
     Board_dispatch.get_all_karma ()
+    |> expect_board_ok
     |> List.sort (fun (a, _) (b, _) -> String.compare a b)
   in
   Alcotest.(check (list (pair string int)))
@@ -391,6 +403,8 @@ let test_delete_post_rewrites_persisted_snapshots () =
   let store =
     match Board_dispatch.backend () with
     | Board_dispatch.Jsonl store -> store
+    | Board_dispatch.Unavailable error ->
+      Alcotest.fail (Board.show_board_error error)
   in
   Alcotest.(check bool) "dirty posts cleared after delete" false store.dirty_posts;
   Alcotest.(check bool)
@@ -412,7 +426,9 @@ let test_karma_event_json_fields () =
   let post = create_post_exn ~author:"alice" ~content:"json test" in
   let pid = Board.Post_id.to_string post.id in
   vote_exn ~voter:"bob" ~post_id:pid ~direction:Board.Up;
-  let ev = List.hd (Board_dispatch.get_karma_ledger ()) in
+  let ev =
+    Board_dispatch.get_karma_ledger () |> expect_board_ok |> List.hd
+  in
   let json = Board.karma_event_to_yojson ev in
   let get_string key =
     match json with
@@ -449,7 +465,7 @@ let test_events_sorted_oldest_first () =
      decreasing because each uses the current wall clock. *)
   vote_exn ~voter:"w1" ~post_id:pid ~direction:Board.Up;
   vote_exn ~voter:"w2" ~post_id:pid ~direction:Board.Up;
-  let events = Board_dispatch.get_karma_ledger () in
+  let events = expect_board_ok (Board_dispatch.get_karma_ledger ()) in
   (match events with
    | e1 :: e2 :: _ ->
        Alcotest.(check bool) "older event first" true
@@ -479,13 +495,13 @@ let test_invalidate_propagates_to_next_read () =
   let post1 = create_post_exn ~author:"alice" ~content:"first" in
   let pid1 = Board.Post_id.to_string post1.id in
   vote_exn ~voter:"bob" ~post_id:pid1 ~direction:Board.Up;
-  let karma1 = Board_dispatch.get_all_karma () in
+  let karma1 = expect_board_ok (Board_dispatch.get_all_karma ()) in
   Alcotest.(check int) "alice has 1 karma after first upvote" 1
     (List.assoc_opt "alice" karma1 |> Option.value ~default:0);
   let post2 = create_post_exn ~author:"alice" ~content:"second" in
   let pid2 = Board.Post_id.to_string post2.id in
   vote_exn ~voter:"carol" ~post_id:pid2 ~direction:Board.Up;
-  let karma2 = Board_dispatch.get_all_karma () in
+  let karma2 = expect_board_ok (Board_dispatch.get_all_karma ()) in
   Alcotest.(check int)
     "alice has 2 karma after invalidating vote (cache was rebuilt)" 2
     (List.assoc_opt "alice" karma2 |> Option.value ~default:0)
@@ -503,8 +519,8 @@ let test_concurrent_get_all_karma_returns_same_value env =
   (try
      Eio.Time.with_timeout_exn (Eio.Stdenv.clock env) 5.0 (fun () ->
        Eio.Fiber.both
-         (fun () -> r1 := Board_dispatch.get_all_karma ())
-         (fun () -> r2 := Board_dispatch.get_all_karma ()))
+         (fun () -> r1 := expect_board_ok (Board_dispatch.get_all_karma ()))
+         (fun () -> r2 := expect_board_ok (Board_dispatch.get_all_karma ())))
    with Eio.Time.Timeout ->
      Alcotest.fail
        "concurrent get_all_karma timed out after 5s — likely deadlock \

--- a/test/test_board_persistence_load_contract.ml
+++ b/test/test_board_persistence_load_contract.ml
@@ -1,16 +1,9 @@
 (** Contract test for {!Masc_board_handlers.Masc_board_handlers.Board_votes_json.load_persisted_posts} and
     {!Masc_board_handlers.Masc_board_handlers.Board_votes_json.load_persisted_comments}.
 
-    Prior to this contract change, the loaders had signature
-    [store -> unit] and swallowed any [exn] from the JSONL read into an
-    in-function [Log.BoardLog.error].  Callers could not distinguish a
-    successful "no file" load from a partially-loaded store after an IO
-    failure.
-
-    The current contract returns [(int, string * exn) result] and forces
-    callers to acknowledge failure.  These tests pin the [Ok 0] branch
-    that is exercised on every fresh server start (no persistence file
-    yet). *)
+    The current contract returns [(int, Board.board_error) result]. Missing
+    files are empty current state; malformed JSON or a non-current row makes
+    the complete Board snapshot reset-required. *)
 
 open Masc
 
@@ -30,11 +23,10 @@ let test_load_persisted_posts_missing_file () =
   match Masc_board_handlers.Board_votes_json.load_persisted_posts store with
   | Ok 0 -> ()
   | Ok n -> Alcotest.failf "expected Ok 0 for missing file, got Ok %d" n
-  | Error (path, e) ->
+  | Error error ->
     Alcotest.failf
-      "expected Ok 0 for missing file, got Error (%s, %s)"
-      path
-      (Printexc.to_string e)
+      "expected Ok 0 for missing file, got Error %s"
+      (Board.show_board_error error)
 ;;
 
 let test_load_persisted_comments_missing_file () =
@@ -43,11 +35,72 @@ let test_load_persisted_comments_missing_file () =
   match Masc_board_handlers.Board_votes_json.load_persisted_comments store with
   | Ok 0 -> ()
   | Ok n -> Alcotest.failf "expected Ok 0 for missing file, got Ok %d" n
-  | Error (path, e) ->
+  | Error error ->
     Alcotest.failf
-      "expected Ok 0 for missing file, got Error (%s, %s)"
-      path
-      (Printexc.to_string e)
+      "expected Ok 0 for missing file, got Error %s"
+      (Board.show_board_error error)
+;;
+
+let expect_reset_required = function
+  | Error (Board.Persistence_reset_required _) -> ()
+  | Error error ->
+    Alcotest.failf
+      "expected Persistence_reset_required, got %s"
+      (Board.show_board_error error)
+  | Ok count ->
+    Alcotest.failf "expected Persistence_reset_required, loaded %d rows" count
+;;
+
+let write_malformed_snapshot path =
+  Fs_compat.mkdir_p (Filename.dirname path);
+  Fs_compat.save_file path "{malformed-json}\n"
+;;
+
+let test_load_persisted_posts_malformed_json () =
+  let _dir = fresh_test_base_path () in
+  write_malformed_snapshot (Board.persist_path ());
+  Board_core.create_store ()
+  |> Masc_board_handlers.Board_votes_json.load_persisted_posts
+  |> expect_reset_required
+;;
+
+let test_load_persisted_comments_malformed_json () =
+  let _dir = fresh_test_base_path () in
+  write_malformed_snapshot (Board.comments_path ());
+  Board_core.create_store ()
+  |> Masc_board_handlers.Board_votes_json.load_persisted_comments
+  |> expect_reset_required
+;;
+
+let test_load_persisted_posts_rejects_retired_field () =
+  let _dir = fresh_test_base_path () in
+  let now = Time_compat.now () in
+  let row =
+    `Assoc
+      [ "id", `String "retired-field-row"
+      ; "author", `String "current-writer"
+      ; "title", `String "Current fields plus one retired field"
+      ; "body", `String "body"
+      ; "post_kind", `String "human"
+      ; "content", `String "body"
+      ; "visibility", `String "internal"
+      ; "created_at", `Float now
+      ; "updated_at", `Float now
+      ; "expires_at", `Float 0.0
+      ; "votes_up", `Int 0
+      ; "votes_down", `Int 0
+      ; "score", `Int 0
+      ; "reply_count", `Int 0
+      ; "pinned", `Bool false
+      ; "meta_json", `String "{}"
+      ]
+  in
+  let path = Board.persist_path () in
+  Fs_compat.mkdir_p (Filename.dirname path);
+  Fs_compat.save_file path (Yojson.Safe.to_string row ^ "\n");
+  Board_core.create_store ()
+  |> Masc_board_handlers.Board_votes_json.load_persisted_posts
+  |> expect_reset_required
 ;;
 
 let () =
@@ -63,6 +116,18 @@ let () =
             "comments loader returns Ok 0 when file absent"
             `Quick
             test_load_persisted_comments_missing_file
+        ; Alcotest.test_case
+            "posts loader rejects malformed JSON"
+            `Quick
+            test_load_persisted_posts_malformed_json
+        ; Alcotest.test_case
+            "comments loader rejects malformed JSON"
+            `Quick
+            test_load_persisted_comments_malformed_json
+        ; Alcotest.test_case
+            "posts loader rejects retired fields"
+            `Quick
+            test_load_persisted_posts_rejects_retired_field
         ] )
     ]
 ;;

--- a/test/test_board_post_origin.ml
+++ b/test/test_board_post_origin.ml
@@ -107,28 +107,22 @@ let test_codec_absent_origin () =
   Alcotest.(check bool) "absent origin decodes to None" true (Option.is_none decoded.origin)
 ;;
 
-let test_malformed_origin_preserves_post () =
+let test_malformed_origin_rejects_row () =
   let store = Board_core.create_store () in
   let tr = Ids.Turn_ref.make ~trace_id:"t" ~absolute_turn:1 in
   let post = create store ~origin:(make_origin ~turn_ref:tr ()) ~content:"malformed origin" in
   let json = Board_core.post_to_yojson post in
-  (* origin as a non-object value -> degrade to None, keep the row. *)
+  (* A malformed persisted origin invalidates the complete row; the loader
+     promotes this decoder result to Board reset-required. *)
   (match decode (replace_key json "origin" (`Int 5)) with
-   | Some p -> Alcotest.(check bool) "non-object origin -> None" true (Option.is_none p.origin)
-   | None -> Alcotest.fail "row dropped on non-object origin (must be preserved)");
-  (* malformed turn_ref string -> turn_ref None, but a valid sibling field is
-     kept (per-field degrade, not whole-origin drop, not row drop). *)
+   | None -> ()
+   | Some _ -> Alcotest.fail "non-object origin was accepted");
   let bad_origin =
     `Assoc [ "turn_ref", `String "no-separator"; "source", `String "fusion" ]
   in
   match decode (replace_key json "origin" bad_origin) with
-  | Some p ->
-    (match p.origin with
-     | Some (o : Board.post_origin) ->
-       Alcotest.(check bool) "malformed turn_ref -> None" true (Option.is_none o.turn_ref);
-       Alcotest.(check (option string)) "valid sibling kept" (Some "fusion") o.source
-     | None -> Alcotest.fail "origin fully dropped though source was valid")
-  | None -> Alcotest.fail "row dropped on malformed turn_ref (must be preserved)"
+  | None -> ()
+  | Some _ -> Alcotest.fail "malformed turn_ref was accepted"
 ;;
 
 (* Producer side (RFC-0233 §7): the keeper-authored origin constructor used by
@@ -198,7 +192,8 @@ let test_index_rebuilt_on_load () =
   (match Masc_board_handlers.Board_votes_json.load_persisted_posts store2 with
    | Ok n when n >= 1 -> ()
    | Ok n -> Alcotest.failf "expected >= 1 loaded post, got %d" n
-   | Error (p, e) -> Alcotest.failf "load failed: %s (%s)" p (Printexc.to_string e));
+   | Error error ->
+     Alcotest.failf "load failed: %s" (Board.show_board_error error));
   Alcotest.(check bool) "turn_ref index rebuilt on load" true
     (Option.is_some
        (Board_core.find_post_by_turn_ref store2 ~turn_ref:(Ids.Turn_ref.to_string tr)));
@@ -235,9 +230,9 @@ let () =
       , [ Alcotest.test_case "origin round trip" `Quick (with_eio test_codec_round_trip)
         ; Alcotest.test_case "absent origin -> None" `Quick (with_eio test_codec_absent_origin)
         ; Alcotest.test_case
-            "malformed origin -> None, post preserved"
+            "malformed origin rejects persisted row"
             `Quick
-            (with_eio test_malformed_origin_preserves_post)
+            (with_eio test_malformed_origin_rejects_row)
         ; Alcotest.test_case
             "keeper-authored origin carries turn_ref"
             `Quick

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -14,6 +14,12 @@
 open Alcotest
 open Masc
 
+let board_store_exn () =
+  match Board.global () with
+  | Ok store -> store
+  | Error error -> fail (Board.show_board_error error)
+;;
+
 module Event_queue_persistence_source = Keeper_event_queue_persistence
 module Keeper_event_queue_persistence = struct
   include Event_queue_persistence_source
@@ -140,7 +146,6 @@ let make_meta ?(name = "fusion-keeper") () : Keeper_meta_contract.keeper_meta =
     Masc_test_deps.meta_of_json_fixture
       (`Assoc
          [ ("name", `String name)
-         ; ("agent_name", `String name)
          ; ("trace_id", `String "test-trace-fusion")
          ])
   with
@@ -524,7 +529,7 @@ let test_emit_success_projects_board_chat_and_registry () =
     in
     check bool "emit succeeds" true (Result.is_ok result);
     let post =
-      match Board.find_post_by_run_id (Board.global ()) ~run_id with
+      match Board.find_post_by_run_id (board_store_exn ()) ~run_id with
       | Some post -> post
       | None -> fail "fusion board post should be indexed by typed origin.fusion_run_id"
     in
@@ -619,7 +624,7 @@ let test_emit_success_projects_board_chat_and_registry () =
     in
     check bool "same completion replay succeeds" true (Result.is_ok replay);
     let posts_for_run =
-      Board.list_posts (Board.global ()) ()
+      Board.list_posts (board_store_exn ()) ()
       |> List.filter (fun (candidate : Board.post) ->
         match candidate.origin with
         | Some { fusion_run_id = Some candidate_run_id; _ } ->
@@ -648,7 +653,7 @@ let test_emit_success_projects_board_chat_and_registry () =
     check bool "changed completion replay is rejected" true
       (Result.is_error conflicting_replay);
     check int "conflicting replay keeps one Board post" 1
-      (Board.list_posts (Board.global ()) ()
+      (Board.list_posts (board_store_exn ()) ()
        |> List.filter (fun (candidate : Board.post) ->
          match candidate.origin with
          | Some { fusion_run_id = Some candidate_run_id; _ } ->
@@ -1006,7 +1011,7 @@ let test_tool_handle_async_success_projects_running_then_completed () =
       in
       await_projection ());
     let post =
-      match Board.find_post_by_run_id (Board.global ()) ~run_id with
+      match Board.find_post_by_run_id (board_store_exn ()) ~run_id with
       | Some post -> post
       | None -> fail "background success should create a board post indexed by run_id"
     in

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -1,6 +1,12 @@
 open Alcotest
 open Masc
 
+let board_posts_exn () =
+  match Board_dispatch.list_posts ~limit:10 () with
+  | Ok posts -> posts
+  | Error error -> fail (Board.show_board_error error)
+;;
+
 module Registry_event_queue_source = Keeper_registry_event_queue
 module Keeper_registry_event_queue = struct
   include Registry_event_queue_source
@@ -392,7 +398,7 @@ let test_board_post_schedule_is_rejected_without_mutation () =
      check string "schedule failed" "failed"
        (Schedule_domain.schedule_status_to_string stored.status));
   check int "board remains unchanged" 0
-    (List.length (Board_dispatch.list_posts ~limit:10 ()))
+    (List.length (board_posts_exn ()))
 ;;
 
 let test_keeper_wake_consumer_records_dispatch_without_work_success () =
@@ -478,7 +484,7 @@ let test_keeper_wake_consumer_records_dispatch_without_work_success () =
       | _ -> fail "expected Schedule_due payload"))
   ;
   check int "keeper wake does not create board posts" 0
-    (List.length (Board_dispatch.list_posts ~limit:10 ()));
+    (List.length (board_posts_exn ()));
   let dashboard =
     Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
   in

--- a/test/test_vote_ts_preservation_10086.ml
+++ b/test/test_vote_ts_preservation_10086.ml
@@ -113,7 +113,9 @@ let test_flush_preserves_cast_ts () =
     (before_flush_now > cast_ts +. 0.01);
   (* Force rewrite via the dispatch backend's Jsonl store. *)
   (match Board_dispatch.backend () with
-   | Board_dispatch.Jsonl store -> Board.flush_dirty store);
+   | Board_dispatch.Jsonl store -> Board.flush_dirty store
+   | Board_dispatch.Unavailable error ->
+     Alcotest.fail (Board.show_board_error error));
   let rewrite_rows = read_ts_rows (Board_votes.vote_log_path ()) in
   let rewritten_ts =
     match find_row ~target ~voter rewrite_rows with
@@ -170,7 +172,9 @@ let test_flip_inherits_flip_time () =
       (* Flush now and verify the latest-in-store ts matches the
          flip row's ts (and not the original up ts). *)
       (match Board_dispatch.backend () with
-       | Board_dispatch.Jsonl store -> Board.flush_dirty store);
+       | Board_dispatch.Jsonl store -> Board.flush_dirty store
+       | Board_dispatch.Unavailable error ->
+         Alcotest.fail (Board.show_board_error error));
       let rewrite_rows = read_ts_rows (Board_votes.vote_log_path ()) in
       let rewritten_ts =
         match find_row ~target ~voter rewrite_rows with
@@ -181,6 +185,65 @@ let test_flip_inherits_flip_time () =
         "rewrite persists flip-time (not original up ts, not now)"
         flip_ts rewritten_ts
 
+let test_missing_ts_requires_board_reset () =
+  let post =
+    create_post_exn ~author:"missing-ts-author"
+      ~content:"current post beside a retired vote row"
+  in
+  let post_id = Board.Post_id.to_string post.id in
+  let retired_vote =
+    `Assoc
+      [ "target", `String ("post:" ^ post_id ^ ":missing-ts-voter")
+      ; "voter", `String "missing-ts-voter"
+      ; "direction", `String "up"
+      ]
+  in
+  let vote_path = Board_votes.vote_log_path () in
+  Fs_compat.append_file vote_path (Yojson.Safe.to_string retired_vote ^ "\n");
+  Board.reset_global_for_test ();
+  Board_dispatch.reset_for_test ();
+  Board_dispatch.init_jsonl ();
+  match Board_dispatch.backend () with
+  | Board_dispatch.Unavailable (Board.Persistence_reset_required _) -> ()
+  | Board_dispatch.Unavailable error ->
+    Alcotest.failf
+      "expected Persistence_reset_required, got %s"
+      (Board.show_board_error error)
+  | Board_dispatch.Jsonl _ ->
+    Alcotest.fail "vote row without current ts was accepted"
+;;
+
+let test_namespaced_voter_survives_rewrite_and_restart () =
+  let voter = "keeper:vote-agent" in
+  let post =
+    create_post_exn
+      ~author:"namespaced-vote-author"
+      ~content:"namespaced voter snapshot"
+  in
+  let post_id = Board.Post_id.to_string post.id in
+  let target = "post:" ^ post_id ^ ":" ^ voter in
+  (match Board_dispatch.vote ~voter ~post_id ~direction:Board.Up with
+   | Ok _ -> ()
+   | Error error -> Alcotest.fail (Board.show_board_error error));
+  (match Board_dispatch.backend () with
+   | Board_dispatch.Jsonl store -> Board.flush_dirty store
+   | Board_dispatch.Unavailable error ->
+     Alcotest.fail (Board.show_board_error error));
+  let rows = read_ts_rows (Board_votes.vote_log_path ()) in
+  Alcotest.(check bool)
+    "rewrite preserves the complete namespaced voter"
+    true
+    (Option.is_some (find_row ~target ~voter rows));
+  Board.reset_global_for_test ();
+  Board_dispatch.reset_for_test ();
+  Board_dispatch.init_jsonl ();
+  match Board_dispatch.current_vote_for_post ~voter ~post_id with
+  | Ok (Some Board.Up) -> ()
+  | Ok (Some Board.Down) -> Alcotest.fail "vote direction changed after restart"
+  | Ok None -> Alcotest.fail "namespaced vote disappeared after restart"
+  | Error error -> Alcotest.fail (Board.show_board_error error)
+;;
+
 let () =
   Alcotest.run "vote_ts_preservation_10086"
     [
@@ -190,5 +253,11 @@ let () =
             (with_eio test_flush_preserves_cast_ts);
           Alcotest.test_case "flip inherits flip-time" `Quick
             (with_eio test_flip_inherits_flip_time);
+          Alcotest.test_case "missing ts requires Board reset" `Quick
+            (with_eio test_missing_ts_requires_board_reset);
+          Alcotest.test_case
+            "namespaced voter survives rewrite and restart"
+            `Quick
+            (with_eio test_namespaced_voter_survives_rewrite_and_restart);
         ] );
     ]


### PR DESCRIPTION
## Scope

- require the current Board JSONL schema for posts, comments, votes, reactions, and sub-boards
- make any malformed or retired persisted row produce typed `Persistence_reset_required`
- publish no valid subset from a mixed snapshot
- keep Keeper/server startup running while Board reads and writes fail explicitly
- return HTTP 503 for unavailable Board read surfaces
- preserve current derived fields by validating them against their canonical inputs
- fix vote snapshot rewrite so a namespaced voter such as `keeper:agent` remains intact

There is intentionally no migration, compatibility reader, repair path, or legacy-field fallback.

## Feature and blast-radius checks

- ordinary identical Board writes remain distinct; exact Fusion idempotency stays in `create_post_once_by_fusion_run_id`
- Keeper Board observation returns no partial events and does not advance its cursor while Board is unavailable
- Fusion completion, scheduled wake, Board reactions, karma, sub-board access, and vote timestamp behavior remain covered
- dashboard/tool/H1/H2 callers receive typed errors or 503 instead of an empty successful projection
- derived reply counts and origin indexes are rebuilt only after canonical row validation
- no new facade was added and this change does not add a facade-from-facade path

## Verification

- focused build:
  - `bin/main_eio.exe`
  - `bin/main_stdio_eio.exe`
  - Board dispatch, persistence, origin, karma, explicit-write, schedule, vote, and Fusion test executables
- 153 focused tests passed on the rebased head
- `ocamlformat --check` passed for all changed OCaml files
- `git diff --check` passed

Local focused verification used `MASC_SKIP_PIN_CHECK=1` because the shared switch currently has `agent_sdk 0.231.4` while this repository pins `0.231.3`. CI remains the exact pin/build authority.
