### PR TITLE
fix(oas-pin): accept proven forward pin drift on shared switch

### DIFF
--- a/scripts/check-oas-pin-forward.sh
+++ b/scripts/check-oas-pin-forward.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Prove that an installed agent_sdk pin SHA moved strictly forward from the
+# SSOT pin SHA: EXPECTED_SHA must be an ancestor of INSTALLED_SHA in the
+# history of TRACK_REF on REMOTE.
+#
+# This is the exact proof used by check-oas-pin.sh on the drift path: the
+# shared opam switch may be pinned ahead of this checkout's recorded pin when
+# a concurrent session on a newer branch repinned agent_sdk.  Forward drift
+# is safe to build against (the CMI CRC guard in dune-local.sh keeps _build
+# consistent with the actually installed interfaces); backward or divergent
+# drift is not.
+#
+# Usage:
+#   scripts/check-oas-pin-forward.sh EXPECTED_SHA INSTALLED_SHA REMOTE TRACK_REF
+#
+# Exit 0: EXPECTED_SHA is an ancestor of INSTALLED_SHA (forward drift proven).
+# Exit 1: not proven — backward, divergent, unreachable, or unverifiable.
+#         Callers must treat this as fail-closed; this script never guesses.
+#
+# Only the TRACK_REF history is fetched (plus whatever it reaches).  An
+# INSTALLED_SHA that is not reachable from TRACK_REF cannot be proven forward
+# and is rejected, matching the ref-reachability policy of check-oas-pin.sh.
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+  echo "usage: $0 EXPECTED_SHA INSTALLED_SHA REMOTE TRACK_REF" >&2
+  exit 2
+fi
+
+expected_sha="$1"
+installed_sha="$2"
+remote="$3"
+track_ref="$4"
+
+[[ "${expected_sha}" =~ ^[0-9a-f]{40}$ ]] || exit 1
+[[ "${installed_sha}" =~ ^[0-9a-f]{40}$ ]] || exit 1
+[[ "${expected_sha}" != "${installed_sha}" ]] || exit 1
+[[ -n "${remote}" && -n "${track_ref}" ]] || exit 1
+
+scratch="$(mktemp -d -t oas-pin-forward.XXXXXX)"
+trap 'rm -rf "${scratch}"' EXIT
+
+if ! GIT_DIR="${scratch}" git init -q --bare; then
+  exit 1
+fi
+if ! GIT_DIR="${scratch}" git fetch -q --no-tags "${remote}" \
+       "+refs/heads/${track_ref}:refs/heads/${track_ref}" 2>/dev/null; then
+  exit 1
+fi
+GIT_DIR="${scratch}" git merge-base --is-ancestor \
+  "${expected_sha}" "${installed_sha}" 2>/dev/null

--- a/scripts/check-oas-pin.sh
+++ b/scripts/check-oas-pin.sh
@@ -266,14 +266,56 @@ if command -v opam >/dev/null 2>&1; then
     installed_pin_ref="$(
       sed -nE 's/.*\(at ([0-9a-f]{40})\).*/\1/p' <<<"${pin_line}"
     )"
+    # Forward-drift acceptance: concurrent sessions share one opam switch,
+    # and opam-pin-external-deps.sh already ratchets the pin forward via the
+    # recorded floor.  When the installed canonical pin moved strictly ahead
+    # of this checkout's recorded SSOT SHA, requiring exact equality would
+    # hard-block every local build (including Keeper Execute builds) until a
+    # repin — a downgrade the floor guard itself refuses.  Accept the drift
+    # only with exact ancestry proof (EXPECTED is an ancestor of INSTALLED on
+    # TRACK_REF); backward or divergent drift still fails closed.  The
+    # ancestry remote prefers an explicitly configured local checkout and
+    # otherwise fetches upstream — this runs only on the drift path, never on
+    # the matching fast path, and an unreachable remote fails closed exactly
+    # as before.
+    pin_forward_remote() {
+      if [[ -n "${local_oas_checkout}" ]] \
+        && git -C "${local_oas_checkout}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        printf '%s' "${local_oas_checkout}"
+      else
+        printf '%s' "${OAS_AGENT_SDK_URL}"
+      fi
+    }
+
+    accept_forward_pin_drift() {
+      local candidate_sha="$1"
+      if bash "${SCRIPT_DIR}/check-oas-pin-forward.sh" \
+           "${OAS_AGENT_SDK_SHA}" "${candidate_sha}" \
+           "$(pin_forward_remote)" "${OAS_AGENT_SDK_TRACK_REF}"; then
+        echo "agent_sdk pin moved forward: installed ${candidate_sha}, expected ${OAS_AGENT_SDK_SHA} (proven descendant on ${OAS_AGENT_SDK_TRACK_REF}) — accepting"
+        return 0
+      fi
+      return 1
+    }
+
     case "${installed_pin_source}" in
       "${expected_opam_pin_source}")
         ;;
-      "git+${OAS_AGENT_SDK_URL}")
-        if [[ "${installed_pin_ref}" != "${OAS_AGENT_SDK_SHA}" ]]; then
-          echo "agent_sdk pin checkout is ${installed_pin_ref:-unknown}, expected ${OAS_AGENT_SDK_SHA}" >&2
+      "git+${OAS_AGENT_SDK_URL}"#*)
+        installed_fragment_sha="${installed_pin_source##*#}"
+        if ! accept_forward_pin_drift "${installed_fragment_sha}"; then
+          echo "agent_sdk pin source is ${installed_pin_source}, expected ${expected_opam_pin_source}" >&2
           echo "repair: bash scripts/opam-pin-external-deps.sh" >&2
           exit 1
+        fi
+        ;;
+      "git+${OAS_AGENT_SDK_URL}")
+        if [[ "${installed_pin_ref}" != "${OAS_AGENT_SDK_SHA}" ]]; then
+          if ! accept_forward_pin_drift "${installed_pin_ref}"; then
+            echo "agent_sdk pin checkout is ${installed_pin_ref:-unknown}, expected ${OAS_AGENT_SDK_SHA}" >&2
+            echo "repair: bash scripts/opam-pin-external-deps.sh" >&2
+            exit 1
+          fi
         fi
         ;;
       git+file://*|file://*)

--- a/test/test_check_oas_pin_forward.sh
+++ b/test/test_check_oas_pin_forward.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Regression test for scripts/check-oas-pin-forward.sh.
+#
+# Covers the exact-ancestry proof used by check-oas-pin.sh to accept a
+# shared opam switch whose agent_sdk pin moved strictly forward from this
+# checkout's recorded SSOT SHA, and to fail closed otherwise.
+#
+# Run: bash test/test_check_oas_pin_forward.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+FORWARD_SCRIPT="${REPO_ROOT}/scripts/check-oas-pin-forward.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+UPSTREAM="${TMP}/upstream"
+mkdir -p "${UPSTREAM}" "${TMP}/hooks-empty"
+git -C "${UPSTREAM}" init -q -b main
+git -C "${UPSTREAM}" config user.email test@example.invalid
+git -C "${UPSTREAM}" config user.name test
+# Isolate from operator-global hooks (e.g. direct-commit-to-main guards).
+git -C "${UPSTREAM}" config core.hooksPath "${TMP}/hooks-empty"
+
+commit_file() {
+  local name="$1"
+  printf '%s\n' "${name}" > "${UPSTREAM}/${name}"
+  git -C "${UPSTREAM}" add "${name}"
+  GIT_COMMITTER_DATE="2026-01-01T00:00:00Z" GIT_AUTHOR_DATE="2026-01-01T00:00:00Z" \
+    git -C "${UPSTREAM}" commit -q -m "${name}"
+  git -C "${UPSTREAM}" rev-parse HEAD
+}
+
+SHA_A="$(commit_file a)"
+SHA_B="$(commit_file b)"
+
+# Divergent commit on a side branch (not reachable from main).
+git -C "${UPSTREAM}" checkout -q -b side "${SHA_A}"
+SHA_C="$(commit_file c)"
+git -C "${UPSTREAM}" checkout -q main
+
+expect_accept() {
+  local desc="$1" expected="$2" installed="$3"
+  if ! bash "${FORWARD_SCRIPT}" "${expected}" "${installed}" "${UPSTREAM}" main; then
+    echo "FAIL: ${desc} — expected acceptance" >&2
+    exit 1
+  fi
+  echo "ok ${desc}"
+}
+
+expect_reject() {
+  local desc="$1" expected="$2" installed="$3" remote="${4:-${UPSTREAM}}"
+  if bash "${FORWARD_SCRIPT}" "${expected}" "${installed}" "${remote}" main; then
+    echo "FAIL: ${desc} — expected fail-closed rejection" >&2
+    exit 1
+  fi
+  echo "ok ${desc}"
+}
+
+expect_accept "case 1 - descendant pin on main is accepted as forward drift" "${SHA_A}" "${SHA_B}"
+expect_reject "case 2 - backward drift is rejected" "${SHA_B}" "${SHA_A}"
+expect_reject "case 3 - divergent pin unreachable from main is rejected" "${SHA_A}" "${SHA_C}"
+expect_reject "case 4 - equal SHAs are not forward drift" "${SHA_A}" "${SHA_A}"
+expect_reject "case 5 - unreachable remote fails closed" "${SHA_A}" "${SHA_B}" "${TMP}/no-such-repo"
+expect_reject "case 6 - malformed installed SHA fails closed" "${SHA_A}" "not-a-sha"
+expect_reject "case 7 - malformed expected SHA fails closed" "not-a-sha" "${SHA_B}"
+
+echo ""
+echo "[check-oas-pin-forward test] PASS - 7/7 cases"


### PR DESCRIPTION
## Problem

The local agent_sdk pin guard (`scripts/check-oas-pin.sh`, invoked by `scripts/dune-local.sh` before every local build) required the installed opam pin to **exactly match** this checkout's recorded SSOT SHA. Concurrent sessions share one opam switch, and `opam-pin-external-deps.sh` already ratchets the pin forward via the recorded floor (`refusing to downgrade below recorded floor`). So when a newer branch's session moves the switch ahead, every build on this checkout hard-fails:

```
[dune-local] agent_sdk pin drift detected — aborting build
```

Observed in production keeper logs (`~/.masc/logs/system_log_2026-07-29.jsonl`): Keeper `executor` `Execute` builds aborting while the switch sat at agent_sdk 0.231.4 (`2add6bf4`) ahead of this checkout's 0.231.3 (`e01940b14`) pin. The prescribed repair (repin to the older SHA) is a downgrade the floor guard itself refuses — the two guards deadlocked.

## Fix

Accept the drift only with **exact ancestry proof**: the recorded SSOT SHA must be an ancestor of the installed SHA on the upstream track ref (`main`). No heuristics, no version-string guessing:

- New `scripts/check-oas-pin-forward.sh`: scratch bare fetch of the track ref + `git merge-base --is-ancestor`. Exit 0 only on proven forward drift; everything else (backward, divergent, unreachable-from-main, unreachable remote, malformed SHA) fails closed exactly as before.
- `check-oas-pin.sh` gains a fragment-SHA case (`git+URL#SHA` with a different SHA) and the existing fragment-less case now tries the same proof before failing.
- Ancestry remote prefers `AGENT_SDK_LOCAL_REPO` (explicit opt-in, offline-friendly) and otherwise fetches upstream — only on the drift path; the matching fast path stays network-free, and offline fails closed identically to today.
- Non-SHA fragments (e.g. branch-name pins) fail closed.

The CMI CRC auto-clean guard in `dune-local.sh` (independent of this check) continues to keep `_build` consistent with whatever agent_sdk is actually installed.

## Validation

- `test/test_check_oas_pin_forward.sh` — 7/7: accepts descendant on main; rejects backward, divergent/unreachable, equal, malformed SHAs, unreachable remote.
- `test/test_opam_pin_downgrade_guard.sh` — 12/12 (no regression).
- Real switch 실측: with agent_sdk 0.231.4 installed and this checkout pinned at 0.231.3, `scripts/check-oas-pin.sh --local-only` now passes with `agent_sdk pin moved forward: installed 2add6bf4…, expected e01940b1… (proven descendant on main) — accepting`.
- `bash -n`, `shellcheck -S warning` (only pre-existing SC2034), `git diff --check` clean.

Draft; do not merge.