### PR TITLE
refactor(metrics): drop dead TurnFailureStreakPaused metric

### DIFF
--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -111,7 +111,6 @@ type t =
   | WorkspaceInitFailures
   | PresenceSyncFailures
   | StaleStormPaused
-  | TurnFailureStreakPaused
   | CycleExceptions
   | SnapshotReadFailures
   | SnapshotWriteFailures
@@ -328,7 +327,6 @@ let to_string = function
   | WorkspaceInitFailures -> "masc_keeper_workspace_init_failures_total"
   | PresenceSyncFailures -> "masc_keeper_presence_sync_failures_total"
   | StaleStormPaused -> "masc_keeper_stale_storm_paused_total"
-  | TurnFailureStreakPaused -> "masc_keeper_turn_failure_streak_paused_total"
   | CycleExceptions -> "masc_keeper_cycle_exceptions_total"
   | SnapshotReadFailures -> "masc_keeper_snapshot_read_failures_total"
   | SnapshotWriteFailures -> "masc_keeper_snapshot_write_failures_total"

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -102,7 +102,6 @@ type t =
   | WorkspaceInitFailures
   | PresenceSyncFailures
   | StaleStormPaused
-  | TurnFailureStreakPaused
   | CycleExceptions
   | SnapshotReadFailures
   | SnapshotWriteFailures


### PR DESCRIPTION
## 무엇을 바꿨나

사용되지 않는 `TurnFailureStreakPaused` metric constructor와 Prometheus 이름 매핑을 삭제했어용.

## 왜

- 저장소 전체에 increment 호출이 없었어용.
- dashboard, 문서, alert에도 `masc_keeper_turn_failure_streak_paused_total` 참조가 없었어용.
- 실제 자동 pause 로직이 없는 상태에서 절대 발생하지 않는 metric만 남아 운영자가 잘못 해석할 수 있었어용.

## 검증

- exact head: `0b3195231a196293e948a1dd5265a27ef49aab06`
- diff: `keeper_metrics.ml/.mli`의 constructor 및 문자열 매핑 3줄 삭제만 확인했어용.
- repo-wide 정적 검색: 삭제한 constructor/metric 이름 잔존 참조 0건이에용.
- GitHub exact-head `Build and Test`, `CI Gate`, lint/구조 검사를 포함한 필수 CI가 모두 green이에용.
- 로컬 Dune은 실행하지 않았어용. 빌드/테스트 판정은 GitHub CI 결과를 사용했어용.

현재 Draft 상태는 유지했어용.
