### PR TITLE
fix(keeper): stop treating queued chat as turn authority

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -100,6 +100,21 @@ let rec deferred_runtime_lane = function
     None
 ;;
 
+let run_autonomous_dispatch_unless_chat_waiting ~base_path ~keeper_name f =
+  (* This is the admitted cycle-entry boundary. A waiter already registered on
+     the actual mutex wins; a chat that arrives after this non-suspending check
+     waits behind the already-admitted turn until its typed yield boundary. *)
+  if Keeper_turn_admission.chat_waiting ~base_path ~keeper_name
+  then None
+  else Some (f ())
+;;
+
+module For_testing = struct
+  let run_autonomous_dispatch_unless_chat_waiting =
+    run_autonomous_dispatch_unless_chat_waiting
+  ;;
+end
+
 (* Body of [run_keeper_cycle], runnable only while holding the keeper's
    turn slot ([Keeper_turn_admission]). The post-failure meta re-reads stay
    inside the slot for the same reason as the chat lane: a concurrent turn
@@ -227,13 +242,6 @@ let run_keeper_cycle_with
   =
   let busy_outcome block =
     (match block with
-     | Keeper_turn_admission.Chat_backlog { pending_count; inflight_count } ->
-       Log.Keeper.info
-         "%s: yielding autonomous cycle to chat backlog (pending=%d inflight=%d); \
-          skipping until next heartbeat"
-         meta_after_triage.name
-         pending_count
-         inflight_count
      | Keeper_turn_admission.Shutdown_requested operation_id ->
        Log.Keeper.info
          "%s: autonomous turn admission closed by shutdown operation %s"
@@ -260,36 +268,46 @@ let run_keeper_cycle_with
     Busy { meta = meta_after_triage; block }
   in
   let run_standard_cycle () =
-    run_keeper_cycle_admitted
-      ?exact_execution_guard
-      ~before_dispatch_authority:
-        (fun () -> Keeper_turn_admission.validate_before_dispatch admission_token)
-      ?deferred_runtime_lane
-      ?on_deferred_runtime_consumed
-      ~ctx
-      ~meta_after_triage
-      ~stop
-      ~obs
-      ~turn_decision
-      ~shared_context
-      ~wake
-      ?event_bus
-      ?hitl_resolution
-      ?continuation_delivery_channel
-      ()
+    match
+      run_autonomous_dispatch_unless_chat_waiting
+        ~base_path:ctx.config.base_path
+        ~keeper_name:meta_after_triage.name
+        (fun () ->
+           run_keeper_cycle_admitted
+             ?exact_execution_guard
+             ~before_dispatch_authority:
+               (fun () ->
+                  Keeper_turn_admission.validate_before_dispatch admission_token)
+             ?deferred_runtime_lane
+             ?on_deferred_runtime_consumed
+             ~ctx
+             ~meta_after_triage
+             ~stop
+             ~obs
+             ~turn_decision
+             ~shared_context
+             ~wake
+             ?event_bus
+             ?hitl_resolution
+             ?continuation_delivery_channel
+             ())
+    with
+    | Some outcome -> outcome
+    | None ->
+      Log.Keeper.info
+        ~keeper_name:meta_after_triage.name
+        "yielding autonomous dispatch to a chat already waiting on the turn slot";
+      Skipped meta_after_triage
   in
   match manual_compaction_requested with
   | Some false | None -> run_standard_cycle ()
   | Some true ->
-    (* #24865: a manual-compaction cycle is the remedy for the overflow that
-       wedges chat delivery, so its compaction-only critical section admits
-       past the durable chat backlog ([run_compaction_if_free] inside
-       [run_admitted]) and releases the slot the moment the checkpoint
-       commits. The follow-up turn then re-enters the standard lane below,
-       where a chat backlog wins — the remedy may cut the line, an arbitrary
-       LLM turn may not. [Manual_compaction_applied { followup = Busy _; _ }]
-       settles the
-       stimulus as Ack, so a yielded follow-up does not replay compaction. *)
+    (* The compaction commit and its follow-up use the same actual per-Keeper
+       turn slot. A durable chat receipt is not a second admission fence, so
+       compaction needs no separate bypass lane. If a chat parks while the
+       commit runs, [run_standard_cycle] returns [Skipped] before provider
+       dispatch; the applied outcome still acknowledges the completed
+       compaction instead of replaying it. *)
     (match
        run_manual_compaction
          ?exact_execution_guard

--- a/lib/keeper/keeper_heartbeat_loop_cycle.mli
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.mli
@@ -43,6 +43,17 @@ val manual_compaction_followup_failure
 val deferred_runtime_lane :
   cycle_outcome -> Keeper_turn_driver.deferred_runtime_lane option
 
+module For_testing : sig
+  val run_autonomous_dispatch_unless_chat_waiting
+    :  base_path:string
+    -> keeper_name:string
+    -> (unit -> 'a)
+    -> 'a option
+  (** At the admitted cycle-entry boundary, run the autonomous callback only
+      when no chat is already parked on the keeper's actual turn mutex. A chat
+      arriving after this boundary does not preempt the admitted turn. *)
+end
+
 val run_keeper_cycle
   :  ?exact_execution_guard:Keeper_compaction_llm_summarizer.exact_execution_guard
   -> admission_token:Keeper_turn_admission.token

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -517,7 +517,7 @@ let run_admitted_with
     if already_admitted
     then `Ran ()
     else
-      Keeper_turn_admission.run_compaction_if_free
+      Keeper_turn_admission.run_if_free
         ~base_path:config.base_path
         ~keeper_name:meta.name
         (fun () -> ())
@@ -538,7 +538,7 @@ let run_admitted_with
       if already_admitted
       then `Ran (run ())
       else
-        Keeper_turn_admission.run_compaction_if_free
+        Keeper_turn_admission.run_if_free
           ~base_path:config.base_path
           ~keeper_name:meta.name
           run

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -21,10 +21,6 @@ type in_flight_info =
 
 type autonomous_block =
   | Turn_busy of in_flight_info option
-  | Chat_backlog of
-      { pending_count : int
-      ; inflight_count : int
-      }
   | Shutdown_requested of Keeper_shutdown_types.Operation_id.t
 
 type rejection =
@@ -82,7 +78,6 @@ let lane_to_string = function
 
 let autonomous_block_kind = function
   | Turn_busy _ -> "turn_busy"
-  | Chat_backlog _ -> "chat_backlog"
   | Shutdown_requested _ -> "shutdown_requested"
 ;;
 
@@ -93,11 +88,6 @@ let autonomous_block_to_string = function
       "reason=turn_busy holder_lane=%s holder_started_at=%.17g"
       (lane_to_string lane)
       started_at
-  | Chat_backlog { pending_count; inflight_count } ->
-    Printf.sprintf
-      "reason=chat_backlog pending_count=%d inflight_count=%d"
-      pending_count
-      inflight_count
   | Shutdown_requested operation_id ->
     Printf.sprintf
       "reason=shutdown_requested operation_id=%s"
@@ -116,12 +106,6 @@ let autonomous_block_to_yojson = function
           ]
     in
     `Assoc [ "kind", `String "turn_busy"; "holder", holder_json ]
-  | Chat_backlog { pending_count; inflight_count } ->
-    `Assoc
-      [ "kind", `String "chat_backlog"
-      ; "pending_count", `Int pending_count
-      ; "inflight_count", `Int inflight_count
-      ]
   | Shutdown_requested operation_id ->
     `Assoc
       [ "kind", `String "shutdown_requested"
@@ -318,87 +302,52 @@ let shutdown_rejection_snapshot slot operation_id =
     })
 ;;
 
-let admit_autonomous_with_token ~yield_to_chat_backlog ~base_path ~keeper_name f =
+let admit_autonomous_with_token ~base_path ~keeper_name f =
   let slot = slot_for ~base_path ~keeper_name in
-  (* Yield to deferred work before touching the lock. [waiting > 0] implies
-     the slot is held (a waiter only parks because a turn is in flight), so
-     [try_lock] would fail here anyway; the explicit check keeps the
-     autonomous lane from competing for a slot a parked chat is already
-     queued on. A non-empty [Keeper_chat_queue] means a busy connector
-     (Slack/Discord) or dashboard message is deferred for this keeper but
-     has not parked on the slot; the standard autonomous lane must yield for
-     it too, otherwise a long or back-to-back autonomous turn starves that
-     queue indefinitely (the busy-ACK loop). Reading the queue length is a
-     lock-only, non-suspending peek and is the SSOT signal that closes the
-     gap: the autonomous lane cooperates on the same backlog the consumer
-     drains, so the consumer's [in_flight = None] window opens
-     deterministically instead of racing the next autonomous cycle. Once a
-     receipt is claimed, the actual per-Keeper turn mutex is the authority for
-     whether its chat turn is still executing. An inflight receipt with a free
-     mutex may be between delivery and finalization or stranded after failure;
-     it must not become a second, durable global turn lock.
-
-     [yield_to_chat_backlog:false] (the manual-compaction lane) skips only
-     that queue peek: the backlog yield presumes the chat consumer can make
-     progress, and a context-overflowed keeper violates that premise — its
-     chat turns fail until compaction rewrites the checkpoint, so queueing
-     the compaction cycle behind the backlog inverts the priority and
-     starves both lanes (#24865). *)
+  (* [waiting > 0] means a chat fiber is already parked on the actual turn
+     mutex. Eio.Mutex hands the released slot to that waiter, so the autonomous
+     lane should not compete. A durable queue receipt is deliberately absent
+     here: it records work but does not own execution. The queue consumer is
+     woken after queue/slot transitions and parks on this mutex. A chat that
+     becomes runnable after this admission boundary may wait behind this one
+     admitted autonomous turn; it is not retroactive admission authority. *)
   match peek_shutdown slot with
   | Some operation_id -> `Busy (Shutdown_requested operation_id)
   | None when waiting_count slot > 0 -> `Busy (Turn_busy (peek_info slot))
   | None ->
-    let chat_backlog =
-      if yield_to_chat_backlog
-      then (
-        let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
-        (* Queue persistence/read failures remain typed Chat-boundary
-           failures. They are not evidence of queued work and therefore
-           cannot close an otherwise independent autonomous lane. *)
-        match List.length snapshot.pending, List.length snapshot.inflight with
-        | 0, _ -> None
-        | pending_count, 0 ->
-          Some (Chat_backlog { pending_count; inflight_count = 0 })
-        | _, _ -> None)
-      else None
-    in
-    (match chat_backlog with
-     | Some block -> `Busy block
-     | None ->
-       if Eio.Mutex.try_lock slot.turn_mu
-       then (
-         match run_locked_with_token slot ~lane:Autonomous f with
-         | `Ran value -> `Ran value
-         | `Shutdown_requested operation_id -> `Busy (Shutdown_requested operation_id))
-       else `Busy (Turn_busy (peek_info slot)))
+    if Eio.Mutex.try_lock slot.turn_mu
+    then (
+      match run_locked_with_token slot ~lane:Autonomous f with
+      | `Ran value -> `Ran value
+      | `Shutdown_requested operation_id -> `Busy (Shutdown_requested operation_id))
+    else `Busy (Turn_busy (peek_info slot))
 ;;
 
-let admit_autonomous ~yield_to_chat_backlog ~base_path ~keeper_name f =
+let admit_autonomous ~base_path ~keeper_name f =
   admit_autonomous_with_token
-    ~yield_to_chat_backlog
     ~base_path
     ~keeper_name
     (fun _token -> f ())
 ;;
 
 let run_if_free_with_token ~base_path ~keeper_name f =
-  admit_autonomous_with_token
-    ~yield_to_chat_backlog:true
-    ~base_path
-    ~keeper_name
-    f
+  (* Eio's documented scheduler contract puts the yielding fiber at the back
+     of the runnable queue. A transition-woken consumer already appended to
+     that queue therefore runs first; its [Fiber.fork] inspector runs
+     immediately and registers on the actual mutex before this fiber resumes.
+     A later transition is ordered after this admission attempt and may wait
+     behind this one turn. No durable work is inspected here. *)
+  Eio.Fiber.yield ();
+  admit_autonomous_with_token ~base_path ~keeper_name f
 ;;
 
 let run_if_free ~base_path ~keeper_name f =
-  admit_autonomous ~yield_to_chat_backlog:true ~base_path ~keeper_name f
-;;
-
-let run_compaction_if_free ~base_path ~keeper_name f =
-  admit_autonomous ~yield_to_chat_backlog:false ~base_path ~keeper_name f
+  Eio.Fiber.yield ();
+  admit_autonomous ~base_path ~keeper_name f
 ;;
 
 let run_admin_if_free ~base_path ~keeper_name f =
-  admit_autonomous ~yield_to_chat_backlog:false ~base_path ~keeper_name f
+  admit_autonomous ~base_path ~keeper_name f
 ;;
 
 let run_serialized_with_token ~base_path ~keeper_name f =

--- a/lib/keeper/keeper_turn_admission.mli
+++ b/lib/keeper/keeper_turn_admission.mli
@@ -40,20 +40,6 @@ type in_flight_info =
 
 type autonomous_block =
   | Turn_busy of in_flight_info option
-  | Chat_backlog of
-      { pending_count : int
-      ; inflight_count : int
-      }
-    (** The slot mutex itself is free and pending [Keeper_chat_queue] receipts
-        exist without a currently claimed receipt; the standard autonomous lane
-        yields so the chat consumer can drain them. Inflight receipts are not
-        a second turn lock: an executing chat is fenced by the actual slot,
-        while a stranded/finalizing receipt must not halt unrelated progress.
-        Distinct from [Turn_busy None]
-        (a held slot whose holder has not yet published its info): before
-        this variant existed both cases logged as "holder info not yet
-        published", which mis-directed the #24865 diagnosis toward a stale
-        slot when the durable chat backlog was the actual fence. *)
   | Shutdown_requested of Keeper_shutdown_types.Operation_id.t
 
 val autonomous_block_kind : autonomous_block -> string
@@ -159,51 +145,18 @@ val run_if_free
 
     Also returns [`Busy] without attempting the lock when a chat request is
     already parked on this slot ([chat_waiting] is true, reported as
-    [Turn_busy]), or when a busy connector/dashboard receipt is active in
-    [Keeper_chat_queue] for this keeper (pending or inflight, reported as
-    [Chat_backlog] with the exact counts). Eio.Mutex hands a released slot
-    directly to the next parked waiter, so a new autonomous cycle would not
-    overtake a queued chat regardless; these pre-checks make the yield
-    explicit and keep a heartbeat-scheduled cycle from competing for a slot
-    a dashboard/connector message is already waiting on or queued behind.
-    The [Keeper_chat_queue] half closes the starvation gap where a long or
-    back-to-back autonomous turn could otherwise busy-ACK a connector
-    forever: the autonomous lane yields on the same backlog the consumer
-    drains, so the consumer's [in_flight = None] window opens
-    deterministically. Queue persistence/read errors remain explicit typed
-    failures at the Chat mutation/consumer boundary; because they are not
-    queued work, they do not close this independent autonomous lane. *)
+    [Turn_busy]). Eio.Mutex hands a released slot directly to the parked
+    waiter, so an autonomous cycle cannot overtake it. A durable chat receipt
+    is work state, not admission authority: queue and slot transition observers
+    wake the consumer. Before trying the slot, the standard autonomous lane
+    yields once. Eio specifies that the current fiber moves to the back of the
+    runnable queue, so a consumer woken by an earlier transition runs and parks
+    on the actual mutex first even when other fibers are runnable. Receipt state
+    is never read and never produces [`Busy].
 
-val run_compaction_if_free
-  :  base_path:string
-  -> keeper_name:string
-  -> (unit -> 'a)
-  -> [ `Ran of 'a | `Busy of autonomous_block ]
-(** [run_if_free] for the manual-compaction critical section, differing in
-    exactly one fence: it does not yield to the [Keeper_chat_queue] backlog
-    and therefore never returns [`Busy (Chat_backlog _)].
-
-    Sole sanctioned caller: [Keeper_manual_compaction.run_admitted]. The
-    admitted section must be the compaction commit only — a deterministic
-    checkpoint/FSM operation — never a provider turn; any follow-up turn
-    re-enters [run_if_free] and yields to the backlog. This module cannot
-    name [Keeper_manual_compaction] types without inverting the layering,
-    so the closure stays generic here and the compaction-only shape is
-    enforced at that single wrapper.
-
-    The standard lane's backlog yield assumes the chat consumer can drain
-    the queue. When the keeper's context has overflowed its provider
-    window, chat delivery itself fails until compaction rewrites the
-    checkpoint — so yielding parks the remedy behind the very backlog it
-    is meant to unblock, a priority inversion that starved manual
-    compaction indefinitely (#24865: durable pending receipts fenced every
-    cycle across restarts while the slot mutex stayed free).
-
-    Everything else is unchanged from [run_if_free]: a durable shutdown
-    reservation still fences admission, a parked chat waiter still wins,
-    and a genuinely held slot still returns [`Busy (Turn_busy _)] — this
-    lane never interleaves with an in-flight turn, it only stops queueing
-    behind work that cannot progress. *)
+    The yield is the admission-order boundary, not retroactive preemption. A
+    chat transition published after it may wait behind this one admitted
+    autonomous turn, which still yields cooperatively at typed turn boundaries. *)
 
 val run_admin_if_free
   :  base_path:string

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -153,16 +153,13 @@ let chat_yield_request ~base_path ~keeper_name =
   match Keeper_registry.get ~base_path keeper_name with
   | None -> Error (Printf.sprintf "keeper not registered: %s" keeper_name)
   | Some _ ->
+    (* A parked chat waiter owns the next turn through the actual per-Keeper
+       mutex. A durable receipt is only accepted work: reading it here would
+       recreate the removed backlog Gate inside an already-admitted turn, and
+       a queue read failure could abort unrelated autonomous progress. *)
     if Keeper_turn_admission.chat_waiting ~base_path ~keeper_name
     then Ok (Some Keeper_agent_run.{ reason = Chat_waiting })
-    else
-      match Keeper_chat_queue.has_active_receipts ~keeper_name with
-      | Error error ->
-        Error
-          ("chat queue snapshot failed: "
-           ^ Keeper_chat_queue.mutation_error_to_string error)
-      | Ok true -> Ok (Some Keeper_agent_run.{ reason = Chat_waiting })
-      | Ok false -> Ok None
+    else Ok None
 ;;
 
 let autonomous_yield_request ~base_path ~keeper_name =

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -1893,7 +1893,6 @@ let test_keeper_shutdown_store_isolates_corrupt_owner () =
               corrupt_operation.operation_id
               operation_id)
        | `Busy (Masc.Keeper_turn_admission.Turn_busy _)
-       | `Busy (Masc.Keeper_turn_admission.Chat_backlog _)
        | `Ran () -> fail "corrupt owner admission was reopened");
       match Shutdown_runtime.recover_operation ~config recoverable_operation with
       | Ok recovered ->
@@ -2348,7 +2347,6 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
            true
            (Shutdown_types.Operation_id.equal operation.operation_id operation_id)
       | `Busy (Masc.Keeper_turn_admission.Turn_busy _)
-      | `Busy (Masc.Keeper_turn_admission.Chat_backlog _)
       | `Ran () ->
          fail "shutdown admission fence reopened before finalization"))
 
@@ -2463,10 +2461,7 @@ let test_keeper_shutdown_prepare_failure_rolls_back_fence () =
         fail
           "failed shutdown prepare left the keeper admission fence closed: \
            Turn_busy owns the slot"
-      | `Busy (Masc.Keeper_turn_admission.Chat_backlog _) ->
-        fail
-          "failed shutdown prepare left the keeper admission fence closed: \
-           chat backlog fences the slot")
+      )
 
 let install_pending_summary ~base_path ~keeper_name ~bind_exact =
   Approval_queue.For_testing.reset_runtime_state ();
@@ -2911,7 +2906,6 @@ let test_keeper_shutdown_delivers_dead_tombstone_completion_after_receipt () =
          check bool "pending receipt retains exact admission owner" true
            (Shutdown_types.Operation_id.equal operation_id reserved)
        | `Busy (Masc.Keeper_turn_admission.Turn_busy _)
-       | `Busy (Masc.Keeper_turn_admission.Chat_backlog _)
        | `Ran () -> fail "pending completion reopened admission");
       Masc.Keeper_turn_admission.For_testing.reset ();
       let boot_inventory =
@@ -2941,7 +2935,6 @@ let test_keeper_shutdown_delivers_dead_tombstone_completion_after_receipt () =
          check bool "boot-restored fence keeps exact completion owner" true
            (Shutdown_types.Operation_id.equal operation_id reserved)
        | `Busy (Masc.Keeper_turn_admission.Turn_busy _)
-       | `Busy (Masc.Keeper_turn_admission.Chat_backlog _)
        | `Ran () -> fail "boot recovery reopened pending completion admission");
       Shutdown_finalize.register_completion_handler
         Tombstone_cleanup.handle_completion;

--- a/test/test_keeper_paused_work_operator.ml
+++ b/test/test_keeper_paused_work_operator.ml
@@ -404,19 +404,6 @@ let test_admission_busy_http_json_preserves_typed_detail () =
      |> member "holder"
      |> member "started_at"
      |> to_float);
-  let backlog =
-    admission_error_json
-      (Keeper_turn_admission.Chat_backlog
-         { pending_count = 3; inflight_count = 2 })
-  in
-  Alcotest.(check int)
-    "chat pending count"
-    3
-    (backlog |> member "admission" |> member "pending_count" |> to_int);
-  Alcotest.(check int)
-    "chat inflight count"
-    2
-    (backlog |> member "admission" |> member "inflight_count" |> to_int);
   let operation_id = Keeper_shutdown_types.Operation_id.generate () in
   let shutdown =
     admission_error_json

--- a/test/test_keeper_turn_admission.ml
+++ b/test/test_keeper_turn_admission.ml
@@ -552,6 +552,42 @@ let test_autonomous_yields_to_parked_chat () =
     (not (Keeper_turn_admission.chat_waiting ~base_path ~keeper_name))
 ;;
 
+let test_pre_admission_yield_runs_ready_waiter_with_distractors () =
+  reset ();
+  Printf.printf
+    "Test 8b: pre-admission yield runs a ready chat before retrying the slot\n%!";
+  let ready = Eio.Condition.create () in
+  let distractor_count = ref 0 in
+  let chat_started, set_chat_started = Eio.Promise.create () in
+  let release_chat, set_release_chat = Eio.Promise.create () in
+  Eio.Switch.run (fun sw ->
+    for _ = 1 to 8 do
+      Eio.Fiber.fork ~sw (fun () ->
+        Eio.Condition.await_no_mutex ready;
+        incr distractor_count)
+    done;
+    Eio.Fiber.fork ~sw (fun () ->
+      Eio.Condition.await_no_mutex ready;
+      match
+        Keeper_turn_admission.run_serialized ~base_path ~keeper_name (fun () ->
+          Eio.Promise.resolve set_chat_started ();
+          Eio.Promise.await release_chat)
+      with
+      | `Ran () -> ()
+      | `Rejected _ -> check "ready chat is not rejected" false);
+    Eio.Condition.broadcast ready;
+    (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
+     | `Busy (Keeper_turn_admission.Turn_busy (Some { lane = Chat; _ })) ->
+       check "ready chat owns the slot before autonomous retry" true
+     | `Busy _ | `Ran () ->
+       check "ready chat owns the slot before autonomous retry" false);
+    check "all unrelated runnable fibers also ran before retry"
+      (!distractor_count = 8);
+    check "ready chat entered its turn body"
+      (Eio.Promise.is_resolved chat_started);
+    Eio.Promise.resolve set_release_chat ())
+;;
+
 let test_idle_loop_yields_to_parked_chat () =
   reset ();
   Printf.printf
@@ -598,18 +634,60 @@ let test_idle_loop_yields_to_parked_chat () =
   check "parked chat admitted after the autonomous turn yielded" !chat_ran
 ;;
 
-let test_autonomous_yields_to_queued_connector_message () =
+let test_cycle_dispatch_yields_to_parked_chat () =
   reset ();
   Printf.printf
-    "Test 10: autonomous lane yields while a connector/dashboard message is queued\n%!";
+    "Test 9b: cycle-entry boundary yields to an already parked chat\n%!";
+  let dispatch_ran = ref false in
+  let yielded = ref false in
+  let chat_ran = ref false in
+  Eio.Switch.run (fun sw ->
+    let autonomous_admitted, set_autonomous_admitted = Eio.Promise.create () in
+    let chat_parked, set_chat_parked = Eio.Promise.create () in
+    Eio.Fiber.fork ~sw (fun () ->
+      match
+        Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () ->
+          Eio.Promise.resolve set_autonomous_admitted ();
+          Eio.Promise.await chat_parked;
+          match
+            Keeper_heartbeat_loop_cycle.For_testing
+            .run_autonomous_dispatch_unless_chat_waiting
+              ~base_path ~keeper_name (fun () -> dispatch_ran := true)
+          with
+          | None -> yielded := true
+          | Some () -> ())
+      with
+      | `Ran () -> ()
+      | `Busy _ -> check "autonomous lane admits before the chat parks" false);
+    Eio.Promise.await autonomous_admitted;
+    Eio.Fiber.fork ~sw (fun () ->
+      match
+        Keeper_turn_admission.run_serialized ~base_path ~keeper_name (fun () ->
+          chat_ran := true)
+      with
+      | `Ran () -> ()
+      | `Rejected _ -> check "parked chat is not rejected" false);
+    check
+      "chat is parked on the actual turn mutex"
+      (Keeper_turn_admission.chat_waiting ~base_path ~keeper_name);
+    Eio.Promise.resolve set_chat_parked ());
+  check "cycle dispatch yielded to the parked chat" !yielded;
+  check "provider dispatch did not start before yielding" (not !dispatch_ran);
+  check "parked chat ran after the autonomous slot released" !chat_ran
+;;
+
+let test_pending_receipt_does_not_fence_autonomous_admission () =
+  reset ();
+  Printf.printf
+    "Test 10: a durable chat receipt does not become a second turn gate\n%!";
   (* Sanity: an empty queue lets the autonomous lane run. *)
   (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> 7) with
    | `Ran 7 -> check "run_if_free admits when the chat queue is empty" true
    | `Ran _ | `Busy _ -> check "run_if_free admits when the chat queue is empty" false);
-  (* A busy connector (Slack/Discord) message is deferred on the chat queue
-     without parking on the admission slot, so [chat_waiting] stays false. The
-     autonomous lane must still yield, or a long/back-to-back autonomous turn
-     busy-ACKs the connector forever (the starvation this pins). *)
+  (* A durable receipt records accepted work. It does not own the turn slot:
+     the queue consumer is woken by queue/slot transitions and parks on the
+     actual mutex. An admitted autonomous turn yields at its typed turn
+     boundary only after observing that actual parked waiter. *)
   (match
      Keeper_chat_queue.enqueue ~keeper_name
        { Keeper_chat_queue.content = "deferred slack mention"
@@ -638,10 +716,10 @@ let test_autonomous_yields_to_queued_connector_message () =
     "a queued connector message is not a parked chat"
     (not (Keeper_turn_admission.chat_waiting ~base_path ~keeper_name));
   (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
-   | `Busy _ ->
-     check "run_if_free yields (Busy) while a connector message is queued" true
    | `Ran () ->
-     check "run_if_free must not admit while a connector message is queued" false);
+     check "pending receipt does not fence a free turn slot" true
+   | `Busy _ ->
+     check "pending receipt must not become a second turn gate" false);
   (* Claiming changes the receipt to Inflight but does not make it disappear.
      The actual turn mutex, not that durable receipt, is the execution fence.
      A free mutex plus an inflight receipt must stay progress-capable even when
@@ -680,14 +758,11 @@ let test_autonomous_yields_to_queued_connector_message () =
       | `Completed _ -> ()
       | `Error _ ->
         check "completion commits the terminal receipt" false));
-  (* With the inflight receipt gone, the still-pending chat is again the
-     authoritative backlog and the autonomous lane yields to its consumer. *)
+  (* With the inflight receipt gone, the still-pending receipt remains durable
+     work, not an admission authority. *)
   (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
-   | `Busy (Keeper_turn_admission.Chat_backlog
-       { pending_count = 1; inflight_count = 0 }) ->
-     check "pending-only backlog still has chat priority" true
-   | `Busy _ | `Ran () ->
-     check "pending-only backlog must retain chat priority" false);
+   | `Ran () -> check "pending-only queue keeps autonomous admission live" true
+   | `Busy _ -> check "pending-only queue must not fence admission" false);
   (match Keeper_chat_queue.claim_next ~keeper_name with
    | `Claimed claim ->
      (match
@@ -735,7 +810,6 @@ let test_shutdown_reservation_fences_and_rolls_back () =
        "autonomous lane sees typed shutdown fence"
        (Keeper_shutdown_types.Operation_id.equal reserved operation_id)
    | `Busy (Keeper_turn_admission.Turn_busy _)
-   | `Busy (Keeper_turn_admission.Chat_backlog _)
    | `Ran () ->
      check "autonomous lane cannot cross shutdown fence" false);
   (match Keeper_turn_admission.run_serialized ~base_path ~keeper_name (fun () -> ()) with
@@ -821,74 +895,6 @@ let test_shutdown_reservation_restores_durable_owner () =
     check "registration cannot cross restored fence" false
 ;;
 
-let test_compaction_lane_bypasses_chat_backlog () =
-  reset ();
-  Printf.printf
-    "Test 10b: manual-compaction lane admits despite a durable chat backlog (#24865)\n%!";
-  (match Keeper_chat_queue.enqueue ~keeper_name queued_message with
-   | Ok _ -> ()
-   | Error error ->
-     check
-       ("enqueue succeeds: " ^ Keeper_chat_queue.mutation_error_to_string error)
-       false);
-  (* The standard lane reports the backlog as a typed [Chat_backlog] with the
-     exact counts, not as [Turn_busy None]. Before this variant existed the
-     queue fence logged "holder info not yet published", which mis-directed
-     the #24865 diagnosis toward a stale slot. *)
-  (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
-   | `Busy (Keeper_turn_admission.Chat_backlog { pending_count = 1; inflight_count = 0 })
-     -> check "standard lane reports the backlog as typed Chat_backlog" true
-   | `Busy _ | `Ran () ->
-     check "standard lane reports the backlog as typed Chat_backlog" false);
-  (match
-     Keeper_turn_admission.run_compaction_if_free ~base_path ~keeper_name (fun () -> 7)
-   with
-   | `Ran 7 -> check "compaction lane admits despite a pending receipt" true
-   | `Ran _ | `Busy _ -> check "compaction lane admits despite a pending receipt" false);
-  (* Claiming moves the receipt to inflight. Both autonomous entry points use
-     the actual turn mutex as the execution fence; the durable receipt is not
-     a second global lock. *)
-  (match Keeper_chat_queue.claim_next ~keeper_name with
-   | `Claimed _ -> ()
-   | `Empty | `Already_claimed _ | `Error _ ->
-     check "claim_next claims the queued message" false);
-  (match
-     Keeper_turn_admission.run_compaction_if_free ~base_path ~keeper_name (fun () -> 8)
-   with
-   | `Ran 8 -> check "compaction lane admits despite an inflight receipt" true
-   | `Ran _ | `Busy _ -> check "compaction lane admits despite an inflight receipt" false);
-  (* Once the compaction admission releases the slot, a follow-up standard
-     turn also remains live despite a stranded/finalizing inflight receipt. *)
-  (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
-   | `Ran () ->
-     check "standard lane admits past an inflight receipt after compaction" true
-   | `Busy _ ->
-     check "inflight receipt must not refence standard lane after compaction" false);
-  (* A genuinely held slot still refuses the compaction lane: it must never
-     interleave with an in-flight turn. *)
-  Keeper_turn_admission.For_testing.with_unpublished_turn_lock
-    ~base_path
-    ~keeper_name
-    (fun () ->
-       match
-         Keeper_turn_admission.run_compaction_if_free ~base_path ~keeper_name (fun () -> ())
-       with
-       | `Busy (Keeper_turn_admission.Turn_busy _) ->
-         check "compaction lane still refuses a held slot" true
-       | `Busy _ | `Ran () -> check "compaction lane still refuses a held slot" false);
-  (* A durable shutdown reservation still fences the compaction lane. *)
-  let operation_id = Keeper_shutdown_types.Operation_id.generate () in
-  ignore
-    (Keeper_turn_admission.begin_shutdown ~base_path ~keeper_name ~operation_id
-      : Keeper_turn_admission.begin_shutdown_result);
-  match
-    Keeper_turn_admission.run_compaction_if_free ~base_path ~keeper_name (fun () -> ())
-  with
-  | `Busy (Keeper_turn_admission.Shutdown_requested _) ->
-    check "compaction lane still honors the shutdown fence" true
-  | `Busy _ | `Ran () -> check "compaction lane still honors the shutdown fence" false
-;;
-
 let () =
   Eio_main.run @@ fun _env ->
   test_autonomous_admits_when_chat_persistence_is_not_configured ();
@@ -906,9 +912,10 @@ let () =
   test_exception_releases_slot ();
   test_cancelled_waiter_leaves_queue ();
   test_autonomous_yields_to_parked_chat ();
+  test_pre_admission_yield_runs_ready_waiter_with_distractors ();
   test_idle_loop_yields_to_parked_chat ();
-  test_autonomous_yields_to_queued_connector_message ();
-  test_compaction_lane_bypasses_chat_backlog ();
+  test_cycle_dispatch_yields_to_parked_chat ();
+  test_pending_receipt_does_not_fence_autonomous_admission ();
   test_shutdown_reservation_fences_and_rolls_back ();
   test_shutdown_reservation_restores_durable_owner ();
   if !failures > 0

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -135,8 +135,7 @@ let test_busy_cycle_records_no_turn_status_or_work_heartbeat () =
   let accounting =
     Masc.Keeper_heartbeat_loop.keepalive_cycle_accounting
       (Masc.Keeper_heartbeat_loop.Turn_cycle_busy
-         (Masc.Keeper_turn_admission.Chat_backlog
-            { pending_count = 2; inflight_count = 1 }))
+         (Masc.Keeper_turn_admission.Turn_busy None))
   in
   check bool "busy cycle records no turn status" false accounting.record_turn_status;
   check


### PR DESCRIPTION
## What

- remove the durable `Chat_backlog` admission result and its queue-count policy
- remove the manual-compaction-only admission bypass
- remove the remaining active-receipt read from the already-admitted autonomous cooperative-yield path
- keep the per-Keeper mutex, parked-chat handoff, shutdown fence, and direct-chat post-lock receipt recheck
- let a transition-woken consumer register on the actual mutex before a back-to-back autonomous retry
- skip the admitted cycle at its entry boundary when a chat is already parked, including after manual compaction committed

## Why

A Pending/Inflight receipt is durable work state, not ownership of the Keeper turn. Turning it into admission, cycle-entry, or cooperative-yield authority creates a second lock whose stale or unavailable state can stop Keeper autonomy. This PR never reads receipt state in autonomous admission, cycle entry, or an admitted autonomous turn. The actual mutex and its waiter set remain the serialization and priority authority.

The direct-stream path still performs one post-lock active-receipt check. That check is not autonomous authority: it is the linearization point that prevents a new direct chat from overtaking an earlier queued chat.

## Ordering contract

Eio specifies that `Fiber.yield` moves the current fiber to the back of the runnable queue, `Condition.broadcast` appends ready waiters, and a `Fiber.fork` child runs immediately. A queue transition published before the autonomous admission yield therefore lets the consumer wake loop fork its inspector and register on the actual mutex before the autonomous fiber resumes.

This is an admission-order boundary, not retroactive preemption. A chat published after the admitted cycle-entry check may wait behind that one already-admitted autonomous turn. Once the chat consumer is parked, the typed post-tool boundary observes the actual waiter and yields. No durable receipt becomes a Gate to close either race.

## Dependency

Stacked on #26367. That PR moves Pending -> Inflight inside the admitted turn and makes the queue consumer park on the actual per-Keeper mutex before mutating the receipt. This PR then removes the duplicate durable Gates without reopening the claim-before-admission race.

The latest #26367 head also contains the prerequisite receipt-completion compile repair (`764c9f6`) and its test-constructor repair (`6b86889`). The temporary predecessor-store startup Gate was removed before this head.

## Validation

Exact current head `5f7751b105` on base `bbf0447386`:

- `ocamlformat --check` and parse checks on changed files
- `git diff --check`
- removed-symbol scan for `Chat_backlog`, `yield_to_chat_backlog`, `run_compaction_if_free`, and `has_pending_receipts`: zero matches
- `has_active_receipts` no longer appears in `keeper_unified_turn.ml`; its remaining turn-admission use is direct-chat FIFO linearization only
- focused Dune aliases passed:
  - keeper turn admission
  - chat/autonomous contention
  - heartbeat integration (47/47)
- Test 8b: ready chat acquired the actual mutex before autonomous retry with 8 unrelated runnable fibers
- contention: every receipt admitted, FIFO preserved, chat/autonomous non-overlap preserved
- prior exact-head focused suite also passed chat consumer delivery, busy connector deferred, and paused-work operator
- dependency queue suites passed on clean head: chat coalescing and chat consumer delivery

Local Dune used `MASC_SKIP_PIN_CHECK=1` because the shared opam switch is newer than this branch pin; GitHub CI remains the exact-pin authority.
