### PR TITLE
feat(keeper): show keepers their own recent board posts

### DIFF
--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -521,6 +521,15 @@ let list_posts ?(visibility_filter = None) ?hearth ?author_filter ?exclude_autho
       in
       Board.take limit filtered
 
+let list_recent_posts_matching_author ~author_matches ~limit () =
+  match backend () with
+  | Jsonl store ->
+    Board.search_posts
+      store
+      ~predicate:(fun (post : Board.post) -> author_matches post.author)
+      ~limit:(max 0 limit)
+;;
+
 let current_post_cursor () =
   match backend () with
   | Jsonl store -> Board.current_post_cursor store

--- a/lib/board/board_dispatch.mli
+++ b/lib/board/board_dispatch.mli
@@ -200,6 +200,16 @@ val list_posts :
   unit ->
   Board.post list
 
+val list_recent_posts_matching_author :
+  author_matches:(Board.Agent_id.t -> bool) ->
+  limit:int ->
+  unit ->
+  Board.post list
+(** Full-history author query with predicate-before-limit semantics. Results
+    are newest-first by [created_at]. The typed predicate lets the caller keep
+    canonical identity ownership without routing through the public
+    substring-based author search. *)
+
 val current_post_cursor : unit -> float * string option
 (** Atomic high-water mark for initializing a Board observation cursor. *)
 (** Current Board cursor head without sorting or materializing the full post

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -103,10 +103,9 @@ let keeper_memory_os_recall_max_bytes () : int =
    relevance and novelty remain model decisions; there is no dedup gate.
 
    [max] bounds how many of the keeper's own newest posts the world
-   observation carries per turn. [scan_limit] bounds how many recent board
-   posts (across all authors) the collector scans to find them, so a busy
-   board cannot push the keeper's own posts out of the window. Both default
-   small: this is standing context, not a history dump. *)
+   observation carries per turn. The Board query applies canonical ownership
+   before this result limit, so unrelated traffic cannot hide the keeper's
+   latest post. *)
 let keeper_board_own_recent_max_rp =
   _rp_int ~key:"keeper.board.own_recent.max"
     ~default:(fun () -> int_of_env_default "MASC_KEEPER_BOARD_OWN_RECENT_MAX"
@@ -115,15 +114,6 @@ let keeper_board_own_recent_max_rp =
     ~description:"Own recent board posts injected into the world observation per turn (0 = disable)" ()
 let keeper_board_own_recent_max () : int =
   Runtime_params.get keeper_board_own_recent_max_rp
-
-let keeper_board_own_recent_scan_limit_rp =
-  _rp_int ~key:"keeper.board.own_recent.scan_limit"
-    ~default:(fun () -> int_of_env_default "MASC_KEEPER_BOARD_OWN_RECENT_SCAN_LIMIT"
-                          ~default:200 ~min_v:1 ~max_v:100_000)
-    ~min_v:1 ~max_v:100_000
-    ~description:"Recent board posts scanned to collect the keeper's own posts" ()
-let keeper_board_own_recent_scan_limit () : int =
-  Runtime_params.get keeper_board_own_recent_scan_limit_rp
 let keeper_bootstrap_proactive_warmup_sec_rp =
   _rp_int ~key:"keeper.proactive.warmup_sec"
     ~default:(fun () -> int_of_env_default "MASC_KEEPER_BOOTSTRAP_PROACTIVE_WARMUP_SEC"

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -94,6 +94,36 @@ let keeper_memory_os_recall_max_bytes_rp =
     ~description:"Rendered recall block byte budget; oldest episodes are dropped to fit (0 = unbounded)" ()
 let keeper_memory_os_recall_max_bytes () : int =
   Runtime_params.get keeper_memory_os_recall_max_bytes_rp
+
+(* Own-recent-board-posts self-awareness layer. The board-event collector is
+   cursor-based and filters out self-authored posts, so without this layer a
+   keeper never observes its own published posts in-prompt and can repeat the
+   same content every cycle (observed in production: 23 of 26 posts in one
+   hour were near-duplicates). The layer restores raw observation data only —
+   relevance and novelty remain model decisions; there is no dedup gate.
+
+   [max] bounds how many of the keeper's own newest posts the world
+   observation carries per turn. [scan_limit] bounds how many recent board
+   posts (across all authors) the collector scans to find them, so a busy
+   board cannot push the keeper's own posts out of the window. Both default
+   small: this is standing context, not a history dump. *)
+let keeper_board_own_recent_max_rp =
+  _rp_int ~key:"keeper.board.own_recent.max"
+    ~default:(fun () -> int_of_env_default "MASC_KEEPER_BOARD_OWN_RECENT_MAX"
+                          ~default:5 ~min_v:0 ~max_v:1000)
+    ~min_v:0 ~max_v:1000
+    ~description:"Own recent board posts injected into the world observation per turn (0 = disable)" ()
+let keeper_board_own_recent_max () : int =
+  Runtime_params.get keeper_board_own_recent_max_rp
+
+let keeper_board_own_recent_scan_limit_rp =
+  _rp_int ~key:"keeper.board.own_recent.scan_limit"
+    ~default:(fun () -> int_of_env_default "MASC_KEEPER_BOARD_OWN_RECENT_SCAN_LIMIT"
+                          ~default:200 ~min_v:1 ~max_v:100_000)
+    ~min_v:1 ~max_v:100_000
+    ~description:"Recent board posts scanned to collect the keeper's own posts" ()
+let keeper_board_own_recent_scan_limit () : int =
+  Runtime_params.get keeper_board_own_recent_scan_limit_rp
 let keeper_bootstrap_proactive_warmup_sec_rp =
   _rp_int ~key:"keeper.proactive.warmup_sec"
     ~default:(fun () -> int_of_env_default "MASC_KEEPER_BOOTSTRAP_PROACTIVE_WARMUP_SEC"

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -112,10 +112,8 @@ val keeper_memory_os_recall_max_bytes : unit -> int
 (** Observability-only threshold (see .ml); not itself an enforced drop. *)
 
 (** Own-recent-board-posts self-awareness layer (see .ml): how many of the
-    keeper's own latest posts the world observation carries per turn, and how
-    far back the scan window reaches to find them. *)
+    keeper's own latest posts the world observation carries per turn. *)
 val keeper_board_own_recent_max : unit -> int
-val keeper_board_own_recent_scan_limit : unit -> int
 
 val keeper_bootstrap_proactive_warmup_sec : unit -> int
 val keeper_bootstrap_stagger_step_sec : unit -> int

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -111,6 +111,12 @@ val keeper_memory_os_recall_max_episodes : unit -> int
 val keeper_memory_os_recall_max_bytes : unit -> int
 (** Observability-only threshold (see .ml); not itself an enforced drop. *)
 
+(** Own-recent-board-posts self-awareness layer (see .ml): how many of the
+    keeper's own latest posts the world observation carries per turn, and how
+    far back the scan window reaches to find them. *)
+val keeper_board_own_recent_max : unit -> int
+val keeper_board_own_recent_scan_limit : unit -> int
+
 val keeper_bootstrap_proactive_warmup_sec : unit -> int
 val keeper_bootstrap_stagger_step_sec : unit -> int
 val keeper_bootstrap_retry_interval_sec : unit -> int

--- a/lib/keeper/keeper_context_layers.ml
+++ b/lib/keeper/keeper_context_layers.ml
@@ -9,13 +9,16 @@ type layer_id =
   | Scheduled_automation
   | Pending_mentions
   | Scope_messages
+  | Own_board_posts
   | Board_activity
 
 (* Prefix-cache ordering: emit larger, more stable sections first so providers
    can reuse a longer shared prefix across cycles; highly volatile reactive
    signals stay later in the same user message. [Current_task] sits directly
    after [Active_goals]: the claimed task is standing context that changes on
-   claim/release, not per cycle. *)
+   claim/release, not per cycle. [Own_board_posts] changes only when the
+   keeper itself publishes, so it sits just ahead of the per-cycle reactive
+   [Board_activity]. *)
 let ordered =
   [ Active_goals
   ; Current_task
@@ -25,6 +28,7 @@ let ordered =
   ; Scheduled_automation
   ; Pending_mentions
   ; Scope_messages
+  ; Own_board_posts
   ; Board_activity
   ]
 ;;
@@ -41,7 +45,8 @@ let order_index = function
   | Scheduled_automation -> 5
   | Pending_mentions -> 6
   | Scope_messages -> 7
-  | Board_activity -> 8
+  | Own_board_posts -> 8
+  | Board_activity -> 9
 ;;
 
 let assemble ~content_of =

--- a/lib/keeper/keeper_context_layers.mli
+++ b/lib/keeper/keeper_context_layers.mli
@@ -21,6 +21,7 @@ type layer_id =
   | Scheduled_automation
   | Pending_mentions
   | Scope_messages
+  | Own_board_posts
   | Board_activity
 
 val ordered : layer_id list

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -8,6 +8,13 @@
     Telemetry for removed sections is preserved via decision_audit and
     independent storage paths.
 
+    "Your Recent Board Posts" was later restored as the [Own_board_posts]
+    context layer: raw observation rows (post_id, updated_at, title, preview)
+    with no advisory wording. #6814 was right to remove the scolding text; the
+    side effect was that a keeper could never see its own published posts
+    in-prompt (board events are cursor-based and exclude self-authors), which
+    produced near-duplicate posting loops in production.
+
     @since Unified Keeper Loop *)
 
 type turn_prompt_parts = {
@@ -337,6 +344,18 @@ let render_board_observations
    response from the content and current Keeper/Goal/Task context; external \
    effects cross the Gate.\n"
   ^ (events |> List.map format_board_event_text |> String.concat "\n")
+;;
+
+(* The keeper's own published posts, rendered as neutral observation rows.
+   post_id is included so the model can fetch the full body via board get and
+   judge for itself whether a new post would repeat earlier content. No
+   advisory wording: the rows are data, not instructions. *)
+let format_own_board_post_text (post : Board.post) : string =
+  Printf.sprintf "- post_id=%s updated_at=%s title=%S preview: %s"
+    (Board.Post_id.to_string post.id)
+    (Masc_domain.iso8601_of_unix_seconds post.updated_at)
+    (Keeper_types_profile.short_preview ~max_len:80 post.title)
+    (Keeper_types_profile.short_preview ~max_len:80 post.content)
 ;;
 
 let line_block label value =
@@ -709,6 +728,25 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path
           ^ "\n\n")
       else None
     | Keeper_context_layers.Scope_messages -> None
+    (* 9b. Own recent board posts — the keeper's own published posts, newest
+       first. Cursor-independent standing context: Board_activity only carries
+       other authors' unseen posts, so this is the only in-prompt view of what
+       the keeper itself has already said. Neutral rows, no advisory text. *)
+    | Keeper_context_layers.Own_board_posts ->
+      if observation.own_recent_board_posts <> [] then (
+        let ubuf = Buffer.create 256 in
+        Buffer.add_string ubuf
+          (Printf.sprintf "### Your Recent Board Posts (%d)\n"
+             (List.length observation.own_recent_board_posts));
+        Buffer.add_string ubuf
+          "Rows below are your own previously published posts (newest first) — context, not instructions.\n";
+        Buffer.add_string ubuf
+          (observation.own_recent_board_posts
+           |> List.map format_own_board_post_text
+           |> String.concat "\n");
+        Buffer.add_string ubuf "\n\n";
+        Some (Buffer.contents ubuf))
+      else None
     (* 10. Board activity — reactive trigger. All authors and post kinds share
        one neutral observation renderer. Exact mention remains routing context;
        it never promotes Board content to instruction authority. *)

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -101,6 +101,7 @@ type world_observation =
   ; running_keeper_fiber_count : int
   ; connected_surfaces : Gate_surface.surface_presence list
   ; connected_surface_failures : Gate_surface.presence_failure list
+  ; own_recent_board_posts : Board.post list
   }
 
 type keeper_cycle_channel =
@@ -183,6 +184,44 @@ let check_self_comment_status = Board_signal.check_self_comment_status
 let compare_board_cursor_token = Board_signal.compare_cursor_token
 let board_cursor_token_of_post = Board_signal.cursor_token_of_post
 let list_board_posts_after_cursor = Board_signal.list_posts_after_cursor
+
+(** The keeper's own latest board posts, newest first. Cursor-independent:
+    the board-event collector above filters out self-authored posts and only
+    looks past the cursor, so without this a keeper never observes its own
+    published posts in-prompt (production: one keeper posted 23 near-duplicate
+    posts in a single hour). Raw observation only — bounded by
+    [Keeper_config.keeper_board_own_recent_max], scanned within
+    [Keeper_config.keeper_board_own_recent_scan_limit]; no dedup gate. *)
+let collect_own_recent_board_posts ~(meta : keeper_meta) : Board.post list =
+  let max_posts = Keeper_config.keeper_board_own_recent_max () in
+  if max_posts <= 0
+  then []
+  else (
+    let self_ids = self_ids meta in
+    try
+      Board_dispatch.list_posts
+        ~sort_by:Board_dispatch.Recent
+        ~limit:(Keeper_config.keeper_board_own_recent_scan_limit ())
+        ()
+      |> List.filter (fun (p : Board.post) ->
+           is_self_author ~self_ids (Board.Agent_id.to_string p.author))
+      (* [List.filteri] over [List.take]: a fresh keeper has fewer than
+         [max_posts] posts, and [List.take] raises past the list length. *)
+      |> List.filteri (fun i _ -> i < max_posts)
+    with
+    | exn ->
+      (* Same fail-loud contract as board event collection: counted, warned,
+         re-raised — never an empty list on a storage failure. *)
+      Otel_metric_store.inc_counter
+        Keeper_metrics.(to_string ObservationQueryFailures)
+        ~labels:[ ("operation", Runtime_observation_query_operation.(to_label Board_events)) ]
+        ();
+      Log.Keeper.warn
+        "own recent board posts collection failed keeper=%s: %s"
+        meta.name
+        (Printexc.to_string exn);
+      raise exn)
+;;
 
 let scheduled_automation_item_limit = 5
 
@@ -1077,6 +1116,7 @@ let observe
   ; running_keeper_fiber_count
   ; connected_surfaces = surface_presence.surfaces
   ; connected_surface_failures = surface_presence.failures
+  ; own_recent_board_posts = collect_own_recent_board_posts ~meta
   }
 ;;
 
@@ -1113,6 +1153,7 @@ let observe_direct_keeper_msg ~(config : Workspace.config) ~(meta : keeper_meta)
   ; running_keeper_fiber_count = count_running_keeper_fibers ~config
   ; connected_surfaces = surface_presence.surfaces
   ; connected_surface_failures = surface_presence.failures
+  ; own_recent_board_posts = collect_own_recent_board_posts ~meta
   }
 ;;
 

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -190,8 +190,7 @@ let list_board_posts_after_cursor = Board_signal.list_posts_after_cursor
     looks past the cursor, so without this a keeper never observes its own
     published posts in-prompt (production: one keeper posted 23 near-duplicate
     posts in a single hour). Raw observation only — bounded by
-    [Keeper_config.keeper_board_own_recent_max], scanned within
-    [Keeper_config.keeper_board_own_recent_scan_limit]; no dedup gate. *)
+    [Keeper_config.keeper_board_own_recent_max]; no dedup gate. *)
 let collect_own_recent_board_posts ~(meta : keeper_meta) : Board.post list =
   let max_posts = Keeper_config.keeper_board_own_recent_max () in
   if max_posts <= 0
@@ -199,15 +198,11 @@ let collect_own_recent_board_posts ~(meta : keeper_meta) : Board.post list =
   else (
     let self_ids = self_ids meta in
     try
-      Board_dispatch.list_posts
-        ~sort_by:Board_dispatch.Recent
-        ~limit:(Keeper_config.keeper_board_own_recent_scan_limit ())
+      Board_dispatch.list_recent_posts_matching_author
+        ~author_matches:(fun author ->
+          is_self_author ~self_ids (Board.Agent_id.to_string author))
+        ~limit:max_posts
         ()
-      |> List.filter (fun (p : Board.post) ->
-           is_self_author ~self_ids (Board.Agent_id.to_string p.author))
-      (* [List.filteri] over [List.take]: a fresh keeper has fewer than
-         [max_posts] posts, and [List.take] raises past the list length. *)
-      |> List.filteri (fun i _ -> i < max_posts)
     with
     | exn ->
       (* Same fail-loud contract as board event collection: counted, warned,

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -145,6 +145,13 @@ type world_observation = {
   connected_surface_failures : Gate_surface.presence_failure list;
   (** Connector binding stores that could not be read during presence
       observation. Healthy connector surfaces remain available. *)
+
+  own_recent_board_posts : Board.post list;
+  (** The keeper's own latest board posts, newest first, bounded by
+      [Keeper_config.keeper_board_own_recent_max]. Cursor-independent:
+      [pending_board_events] tracks OTHER authors' unseen posts and advances
+      past them, so without this field a keeper never observes its own
+      published posts in-prompt. Raw observation only — no dedup gate. *)
 }
 
 type keeper_cycle_channel =

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -769,6 +769,39 @@ let test_author_filter_treats_wildcards_literally () =
   Alcotest.(check int) "percent does not match all authors" 0
     (List.length filtered)
 
+let test_recent_author_match_applies_before_limit () =
+  let own =
+    match
+      Board_dispatch.create_post ~author:"exact-owner"
+        ~content:"owned before unrelated traffic"
+        ~post_kind:Board.Human_post ()
+    with
+    | Ok post -> post
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  for index = 1 to 3 do
+    ignore
+      (Board_dispatch.create_post
+         ~author:(Printf.sprintf "unrelated-%d" index)
+         ~content:"newer unrelated traffic"
+         ~post_kind:Board.Human_post
+         ())
+  done;
+  let posts =
+    Board_dispatch.list_recent_posts_matching_author
+      ~author_matches:(fun author ->
+        String.equal (Board.Agent_id.to_string author) "exact-owner")
+      ~limit:1
+      ()
+  in
+  match posts with
+  | [ post ] ->
+    Alcotest.(check string)
+      "newer unrelated posts do not consume the result limit"
+      (Board.Post_id.to_string own.id)
+      (Board.Post_id.to_string post.id)
+  | _ -> Alcotest.fail "expected exactly one matching author post"
+
 let test_legacy_post_without_kind_is_rejected () =
   let post_id = seed_legacy_keeper_post () in
   match Board_dispatch.get_post ~post_id with
@@ -2109,6 +2142,8 @@ let () =
         (with_eio test_list_posts_matches_comment_author);
       Alcotest.test_case "literal wildcard filter" `Quick
         (with_eio test_author_filter_treats_wildcards_literally);
+      Alcotest.test_case "author match precedes recent result limit" `Quick
+        (with_eio test_recent_author_match_applies_before_limit);
       Alcotest.test_case "legacy post without kind is rejected" `Quick
         (with_eio test_legacy_post_without_kind_is_rejected);
     ];

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -325,6 +325,7 @@ let base_observation : WO.world_observation =
   ; running_keeper_fiber_count = 0
   ; connected_surfaces = []
   ; connected_surface_failures = []
+  ; own_recent_board_posts = []
   }
 
 (* ══════════════════════════════════════════════════════════

--- a/test/test_keeper_connector_attention_wake.ml
+++ b/test/test_keeper_connector_attention_wake.ml
@@ -142,6 +142,7 @@ let quiet_obs : WO.world_observation =
   ; running_keeper_fiber_count = 1
   ; connected_surfaces = []
   ; connected_surface_failures = []
+  ; own_recent_board_posts = []
   }
 
 let reasons_of_verdict = function

--- a/test/test_keeper_context_layers.ml
+++ b/test/test_keeper_context_layers.ml
@@ -19,6 +19,7 @@ let all_layers =
     L.Scheduled_automation;
     L.Pending_mentions;
     L.Scope_messages;
+    L.Own_board_posts;
     L.Board_activity;
   ]
 
@@ -67,7 +68,6 @@ let test_assemble_all_present_follows_ordered () =
   let content_of id = Some (string_of_int (L.order_index id)) in
   check string "every layer present -> indices in order" "0123456789"
     (L.assemble ~content_of)
-
 let () =
   run "keeper_context_layers"
     [

--- a/test/test_keeper_lifecycle_global_gate.ml
+++ b/test/test_keeper_lifecycle_global_gate.ml
@@ -111,6 +111,7 @@ let base_obs : WO.world_observation =
   ; running_keeper_fiber_count = 1
   ; connected_surfaces = []
   ; connected_surface_failures = []
+  ; own_recent_board_posts = []
   }
 ;;
 

--- a/test/test_keeper_raw_task_signal_wake.ml
+++ b/test/test_keeper_raw_task_signal_wake.ml
@@ -17,6 +17,7 @@ let base_observation : WO.world_observation =
   ; running_keeper_fiber_count = 1
   ; connected_surfaces = []
   ; connected_surface_failures = []
+  ; own_recent_board_posts = []
   }
 ;;
 

--- a/test/test_keeper_surface_presence_prompt.ml
+++ b/test/test_keeper_surface_presence_prompt.ml
@@ -63,6 +63,7 @@ let base_observation : WO.world_observation =
     running_keeper_fiber_count = 0;
     connected_surfaces = [];
     connected_surface_failures = [];
+    own_recent_board_posts = [];
   }
 
 let meta : Masc.Keeper_meta_contract.keeper_meta =

--- a/test/test_keeper_unified_persona_block.ml
+++ b/test/test_keeper_unified_persona_block.ml
@@ -46,6 +46,7 @@ let base_observation : WO.world_observation =
     running_keeper_fiber_count = 0;
     connected_surfaces = [];
     connected_surface_failures = [];
+    own_recent_board_posts = [];
   }
 
 let make_meta name : Masc.Keeper_meta_contract.keeper_meta =

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -18,6 +18,7 @@ let base_observation : WO.world_observation =
     running_keeper_fiber_count = 0;
     connected_surfaces = [];
     connected_surface_failures = [];
+    own_recent_board_posts = [];
   }
 
 let sample_board_event : WO.pending_board_event =
@@ -484,6 +485,56 @@ let test_turn_effect_record () =
        ~external_delivery_routed:true
      = Masc.Keeper_run_prompt.Meaningful_turn)
 
+let post_id_exn s =
+  match Masc.Board.Post_id.of_string s with
+  | Ok id -> id
+  | Error _ -> Alcotest.fail (Printf.sprintf "invalid post_id fixture: %s" s)
+
+let agent_id_exn s =
+  match Masc.Board.Agent_id.of_string s with
+  | Ok id -> id
+  | Error _ -> Alcotest.fail (Printf.sprintf "invalid agent_id fixture: %s" s)
+
+let sample_own_post : Masc.Board.post =
+  { id = post_id_exn "own-post-1"
+  ; author = agent_id_exn "test-keeper"
+  ; title = "My earlier review"
+  ; body = "Already said this exact thing."
+  ; content = "Already said this exact thing."
+  ; post_kind = Masc.Board.Human_post
+  ; meta_json = None
+  ; visibility = Masc.Board.Public
+  ; created_at = 1_753_300_000.0
+  ; updated_at = 1_753_300_100.0
+  ; expires_at = 1_753_400_000.0
+  ; votes_up = 0
+  ; votes_down = 0
+  ; reply_count = 0
+  ; pinned = false
+  ; hearth = None
+  ; thread_id = None
+  ; origin = None
+  }
+
+let test_own_recent_board_posts_render_in_world_state () =
+  let obs = { base_observation with own_recent_board_posts = [ sample_own_post ] } in
+  let { Masc.Keeper_unified_prompt.world_state; _ } =
+    build_prompt ~meta:minimal_meta obs
+  in
+  check bool "own posts section present" true
+    (contains_sub "### Your Recent Board Posts (1)" world_state);
+  check bool "own post id rendered for board get follow-up" true
+    (contains_sub "own-post-1" world_state);
+  check bool "own post title rendered" true
+    (contains_sub "My earlier review" world_state)
+
+let test_no_own_recent_board_posts_renders_no_section () =
+  let { Masc.Keeper_unified_prompt.world_state; _ } =
+    build_prompt ~meta:minimal_meta base_observation
+  in
+  check bool "own posts section absent when empty" false
+    (contains_sub "Your Recent Board Posts" world_state)
+
 let () =
   run "keeper_unified_verification_surface"
     [
@@ -533,6 +584,12 @@ let () =
           test_case
             "prompt: scheduled wake preserves complete message"
             `Quick test_scheduled_wake_preserves_complete_message;
+          test_case
+            "prompt: own recent board posts render as neutral observation rows"
+            `Quick test_own_recent_board_posts_render_in_world_state;
+          test_case
+            "prompt: no own recent board posts renders no section"
+            `Quick test_no_own_recent_board_posts_renders_no_section;
           test_case
             "invariant: world-state frame never enters the persisted user message"
             `Quick test_world_state_never_in_persisted_user_message;

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -69,6 +69,7 @@ let base_observation : WO.world_observation =
     running_keeper_fiber_count = 0;
     connected_surfaces = [];
     connected_surface_failures = [];
+    own_recent_board_posts = [];
   }
 
 let meta_of_json json =


### PR DESCRIPTION
## Production observation

Keeper `sangsu` published **23 near-duplicate posts in one hour** (11 identical copies of the same movie review, 7 identical self-reports about being in an idle loop) on the live fleet (`~/.masc/board_posts.jsonl`). Baseline measured before this change: **88% duplicate rate**.

## Root cause: four-layer blindness

A keeper cannot see its own published posts anywhere in-prompt:

1. `collect_board_events_with_cursor_policy` is cursor-based (already-seen posts never reappear) **and** filters out self-authored posts (`keeper_world_observation.ml`).
2. #6814 removed the *Your Recent Board Posts* prompt section, arguing telemetry paths exist — but those paths never reach the model.
3. The memory-os librarian episode prompt deliberately **omits board-derivable facts** (`config/prompts/keeper.librarian.episode_extraction.md`), so recall never contains own posts.
4. Checkpoint truncation drops past `board_post` tool calls from history.

Meanwhile the scheduler wakes the keeper every cycle unconditionally and personas are instructed to post to the board — so the model repeats itself with zero visibility. It even posts about being in an idle loop without being able to see that it already posted that.

## Fix: restore the data, keep #6814's intent

Self-awareness as **raw observation rows**, not a gate and not advisory text:

- `world_observation.own_recent_board_posts` — the keeper's own latest posts, newest first, collected **cursor-independently** every observation via the in-memory `Board_dispatch.list_posts` path, matched with the canonical `is_self_author` SSOT. Collection failure is counted (`ObservationQueryFailures`), warned, and re-raised — never a silent empty list.
- New `Own_board_posts` context layer (typed `layer_id`, compiler-forced rendering) rendering neutral rows: `post_id`, `updated_at`, `title`, `preview` — the model can `board get` the full body and judge novelty itself. No string-match dedup, no scolding.
- Live-tunable `Runtime_params` knobs: `keeper.board.own_recent.max` (default 5), `keeper.board.own_recent.scan_limit` (default 200).

## Validation

- `test_keeper_context_layers` 6/6 (new layer in the complete-permutation and ordering proofs).
- `test_keeper_unified_verification_surface` 23/23, including new cases: section renders with post id/title when own posts exist; no section when empty.
- All 8 `world_observation` fixture sites updated; `test_heartbeat_integration` 47/47, `test_keeper_lifecycle_global_gate` 18/18, and the other touched suites pass.
- `test_keeper_unified_persona_block` (1), `test_keeper_connector_attention_wake` (3), `test_keeper_surface_presence_prompt` (3), `test_keeper_wake_turn_context` (3) failures are **pre-existing environment failures** — reproduced identically on a stashed clean tree in this worktree and on the main checkout's existing build.
- `git diff --check`, `ocamlformat --check` on changed files: clean.

Post-merge 실측 plan: compare sangsu's board duplicate rate against the 88% baseline once the fleet runs this build.

Draft; do not merge.