### PR TITLE
fix(keeper): 압축 게이트가 자기 카운터를 밀어 올리는 간선 제거

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -350,6 +350,13 @@ let compaction_outcome_of_cycle_outcome = function
          (Keeper_unified_turn.Compaction_attempt_failed _)
      | Keeper_unified_turn.Follow_failure_route_after_no_compaction _ ->
        Some `Failed
+     | Keeper_unified_turn.Requeue_after_context_compaction
+         (Keeper_unified_turn.Compaction_refused_without_attempt _) ->
+       (* The admission gate declined the trigger before reading a checkpoint or
+          calling the summarizer, so there is no compaction outcome to settle.
+          Counting it advanced the streak the gate itself reads: live keeper
+          kidsnote reached 907 against a threshold of 3. *)
+       None
      | Keeper_unified_turn.Escalate_after_exact_output_terminal _ -> Some `Failed
      | Keeper_unified_turn.Follow_failure_route
      | Keeper_unified_turn.Acknowledge_after_in_turn_handling

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -72,10 +72,16 @@ type compaction_runtime = {
 }
 
 val compaction_retry_escalation_threshold : int
-(** RFC-0351 S0 / #25461: consecutive compaction failures tolerated before the
-    settlement escalates ([Compaction_retry_exhausted]) instead of retrying.
+(** RFC-0351 S0 / #25461: consecutive compaction failures tolerated before
+    [Keeper_post_turn.prepare_compaction] stops admitting reactive triggers.
     Single definition shared by the heartbeat settlement and the
-    status/dashboard projections. *)
+    status/dashboard projections.
+
+    The refusal is not itself a compaction failure — it reads this counter
+    without attempting anything, so settling it as one made the threshold
+    self-fulfilling (live keeper [kidsnote] reached 907 against a threshold of
+    3). It is reported as [Keeper_unified_turn.Compaction_refused_without_attempt]
+    and settles to no compaction outcome. *)
 
 val compaction_retry_suspended : compaction_runtime -> bool
 (** [true] once the persisted failure streak has reached

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -22,6 +22,7 @@ include Keeper_unified_turn_phase_plan
 type in_lane_compaction =
   | Compaction_committed
   | Compaction_attempt_failed of { reason : string }
+  | Compaction_refused_without_attempt of { consecutive_failures : int }
 
 type exact_output_terminal_reason =
   | Exact_lane_unconfigured of { source : Keeper_checkpoint_ref.t }
@@ -208,6 +209,10 @@ type provider_overflow_recovery =
       { trigger : Compaction_trigger.t
       ; reason : string
       }
+  | Provider_overflow_refused_without_attempt of
+      { trigger : Compaction_trigger.t
+      ; consecutive_failures : int
+      }
   | Provider_overflow_retry_with_checkpoint of
       { reason : string
       ; recovery : Keeper_post_turn.compaction_recovery
@@ -306,6 +311,33 @@ let recover_provider_context_overflow_in_lane
          | None -> Provider_overflow_retry_without_checkpoint { trigger; reason }
          | Some recovery -> Provider_overflow_retry_with_checkpoint { reason; recovery })
     in
+    (* The admission gate declined the trigger: no checkpoint was read, no
+       summarizer ran, no compaction was attempted. The overflow itself is real
+       and unresolved, so the observation and the lifecycle release both stand —
+       what must not happen is settling this as a compaction outcome, because
+       that made the gate's own refusal advance the streak the gate reads. *)
+    let refused_without_attempt ~consecutive_failures =
+      let reason =
+        Printf.sprintf
+          "compaction retry suspended after %d consecutive failures"
+          consecutive_failures
+      in
+      record_overflow_failure ~config ~meta ~reason;
+      match release_failed_lifecycle reason with
+      | Error cleanup_error ->
+        Provider_overflow_lifecycle_cleanup_failed
+          { trigger
+          ; reason =
+              Printf.sprintf "%s; lifecycle_cleanup=%s" reason cleanup_error
+          ; source_disposition =
+              Requeue_after_context_compaction
+                (Compaction_refused_without_attempt { consecutive_failures })
+          ; recovery = None
+          }
+      | Ok () ->
+        Provider_overflow_refused_without_attempt
+          { trigger; consecutive_failures }
+    in
     let terminal_no_compaction no_compaction =
       Eio.Cancel.protect (fun () ->
         let error = Keeper_post_turn.No_compaction no_compaction in
@@ -352,11 +384,18 @@ let recover_provider_context_overflow_in_lane
           (lifecycle_dispatch_error_to_string error)
     in
     let failed ({ error; committed } : Keeper_post_turn.prepared_commit_failure) =
-      match committed with
-      | None ->
+      match committed, error with
+      | None, Keeper_post_turn.Retry_suspended { consecutive_failures } ->
+        refused_without_attempt ~consecutive_failures
+      | ( None
+        , ( Keeper_post_turn.Checkpoint_ref_load_failed _
+          | Keeper_post_turn.Checkpoint_cas_failed _
+          | Keeper_post_turn.Checkpoint_candidate_failed _
+          | Keeper_post_turn.Compaction_rejected _
+          | Keeper_post_turn.No_compaction _ ) ) ->
         retry_after_started
           (Keeper_post_turn.compaction_recovery_error_to_string error)
-      | Some recovery ->
+      | Some recovery, _ ->
         Log.Keeper.error
           ~keeper_name:meta.name
           "provider overflow checkpoint committed with failed exact-domain finalization: %s"
@@ -581,6 +620,18 @@ let append_provider_overflow_manifest
     in
     Requeue_after_context_compaction (Compaction_attempt_failed { reason }),
     turn_state
+  | Provider_overflow_refused_without_attempt { trigger = _; consecutive_failures }
+    ->
+    (* No runtime-manifest record: every manifest kind reachable here asserts a
+       compaction ran, and none did. Emitting [Context_compacted] with
+       [compaction_outcome:Retry_without_checkpoint] — what the attempt-failed
+       arm above does — is why 12,777 [compaction_started] transitions
+       reconciled against roughly 401 prepared plans. The refusal stays visible
+       through [record_overflow_failure]'s WARN, the registry phase transition,
+       and the persisted [last_compaction_decision]. *)
+    ( Requeue_after_context_compaction
+        (Compaction_refused_without_attempt { consecutive_failures })
+    , turn_state )
   | Provider_overflow_lifecycle_cleanup_failed
       { trigger; reason; source_disposition; recovery } ->
     let turn_state =

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -124,6 +124,7 @@ val record_streaming_cancelled_observation
 type in_lane_compaction =
   | Compaction_committed
   | Compaction_attempt_failed of { reason : string }
+  | Compaction_refused_without_attempt of { consecutive_failures : int }
 (** Typed outcome of the in-lane provider-overflow compaction behind a
     [Requeue_after_context_compaction] disposition. [Compaction_committed]
     proves the checkpoint durably shrank before the requeue, so the transition
@@ -133,7 +134,17 @@ type in_lane_compaction =
     [Keeper_meta_contract.compaction_retry_escalation_threshold] (RFC-0351 S0,
     #25461 — without the ceiling this lane requeued forever: 284 of 285
     rejections in the 2026-07-21 storm carried trigger=provider_overflow and
-    only the operator's keeper_down ended it). *)
+    only the operator's keeper_down ended it).
+
+    [Compaction_refused_without_attempt] is the admission gate declining the
+    trigger at that same threshold ([Keeper_post_turn.Retry_suspended]): no
+    checkpoint was read, no summarizer ran, and no compaction was attempted, so
+    the transition leaves the streak alone. Settling it as a failure made the
+    gate's own output advance the counter the gate reads — live keeper
+    [kidsnote] reached 907 against a threshold of 3, roughly 99.7% of it from
+    refusals, which left no statistic able to say what drove it there. The
+    ceiling, the threshold, and the LLM-call bound the gate exists for are all
+    unchanged; only this self-feeding edge is cut. *)
 
 type exact_output_terminal_reason = private
   | Exact_lane_unconfigured of { source : Keeper_checkpoint_ref.t }
@@ -156,9 +167,14 @@ type source_disposition =
     [Follow_failure_route_after_no_compaction] follows the same route but
     records that the in-lane provider-overflow compaction terminally declined
     to act ([no_compaction_reason]); the terminal transition advances the
-    compaction-failure streak and replaces the route with
-    [Escalate Compaction_retry_exhausted] at the threshold, because a turn
-    whose context cannot shrink re-overflows deterministically on every retry.
+    compaction-failure streak, because a turn whose context cannot shrink
+    re-overflows deterministically on every retry. It does not replace the
+    route: [Keeper_event_queue_state.Compaction_retry_exhausted] is constructed
+    nowhere outside that module's [of_json], so nothing ever serializes one to
+    decode. What the threshold actually does is make
+    [Keeper_post_turn.prepare_compaction] refuse reactive triggers
+    ([Compaction_refused_without_attempt]); only an operator-committed manual
+    compaction or an overflow-free completed turn lifts it.
     [Escalate_after_exact_output_terminal] consumes the selected source into a
     typed escalation with no successor, so neither the ordinary retry route nor
     another compaction dispatch can run when the exact lane is unconfigured,

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -1294,6 +1294,118 @@ let test_suspended_streak_refuses_reactive_prepare () =
     ]
 ;;
 
+(* Step 0 characterization — the compaction suspension gate is self-feeding.
+
+   [test_suspended_streak_refuses_reactive_prepare] above pins the first hop: at
+   [Keeper_meta_contract.compaction_retry_escalation_threshold] the reactive
+   prepare is refused before any I/O. This test pins the two hops that close the
+   loop — the refusal settles as a compaction failure, and that settlement
+   advances the very counter the gate reads.
+
+   Live evidence for the loop: keeper [kidsnote] reached
+   compaction_consecutive_failures=907 against a threshold of 3
+   (.masc/logs/system_log_2026-07-29.jsonl), so roughly 99.7% of that counter's
+   value came from refusals that never attempted a compaction. While the counter
+   is inflated this way, no statistic can say what actually drove the keeper to
+   the threshold.
+
+   The gate, the threshold, and the LLM-call bound it exists for are unchanged;
+   only the self-feeding edge is cut. The second half of this test pins that a
+   real compaction failure still advances the streak, so the ceiling that
+   #25461 added keeps working. *)
+let test_refusal_does_not_settle_as_compaction_failure () =
+  Eio_main.run @@ fun _env ->
+  let meta =
+    match
+      Masc_test_deps.meta_of_json_fixture
+        (`Assoc
+          [ "name", `String "suspension-settlement"
+          ; "trace_id", `String "trace-suspension-settlement"
+          ; "compaction_consecutive_failures", `Int 3
+          ])
+    with
+    | Ok meta -> meta
+    | Error detail -> failf "suspension-settlement meta fixture: %s" detail
+  in
+  check
+    bool
+    "fixture sits at the suspension threshold"
+    true
+    (Masc.Keeper_meta_contract.compaction_retry_suspended
+       meta.runtime.compaction_rt);
+  (* A refused prepare attempted no compaction, so it settles as nothing. *)
+  let turn_failure_with source_disposition : Masc.Keeper_unified_turn.turn_failure =
+    { error = Agent_sdk.Error.Internal "suspended reactive prepare"
+    ; runtime_id = "suspension-characterization"
+    ; route =
+        Keeper_runtime_failure_route.Retry_after_observed
+          { retry_class = Keeper_runtime_failure_route.Rate_limited
+          ; retry_after = None
+          }
+    ; source_disposition
+    ; deferred_runtime_lane = None
+    }
+  in
+  let settle source_disposition =
+    Masc.Keeper_heartbeat_loop.compaction_outcome_of_cycle_outcome
+      (Some (Cycle.Failed { meta; failure = turn_failure_with source_disposition }))
+  in
+  check
+    bool
+    "a refusal that attempted no compaction settles as nothing"
+    true
+    (settle
+       (Masc.Keeper_unified_turn.Requeue_after_context_compaction
+          (Masc.Keeper_unified_turn.Compaction_refused_without_attempt
+             { consecutive_failures = 3 }))
+     = None);
+  (* The ceiling #25461 added still works: a compaction that ran and made no
+     durable progress still advances the streak. *)
+  check
+    bool
+    "an attempted compaction that made no progress still settles as a failure"
+    true
+    (settle
+       (Masc.Keeper_unified_turn.Requeue_after_context_compaction
+          (Masc.Keeper_unified_turn.Compaction_attempt_failed
+             { reason = "checkpoint candidate rejected" }))
+     = Some `Failed);
+  (* And that settlement is what advances the counter the gate reads. *)
+  let base =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-suspension-settlement-%d" (Unix.getpid ()))
+  in
+  let config = Masc.Workspace.default_config base in
+  (match Masc.Keeper_meta_store.write_meta config meta with
+   | Ok () -> ()
+   | Error detail -> failf "durable meta write: %s" detail);
+  (match
+     Masc.Keeper_meta_store.persist_compaction_outcome
+       config
+       ~keeper_name:meta.name
+       ~outcome:`Failed
+   with
+   | Ok `Persisted -> ()
+   | Ok `No_durable_meta -> fail "settlement found no durable meta to advance"
+   | Error detail -> failf "settlement persist: %s" detail);
+  match Masc.Keeper_meta_store.read_meta config meta.name with
+  | Error detail -> failf "durable meta read-back: %s" detail
+  | Ok None -> fail "durable meta vanished after settlement"
+  | Ok (Some settled) ->
+    check
+      int
+      "an attempted-and-failed compaction advances the streak"
+      4
+      settled.runtime.compaction_rt.consecutive_failures;
+    check
+      bool
+      "and that is what keeps the keeper suspended"
+      true
+      (Masc.Keeper_meta_contract.compaction_retry_suspended
+         settled.runtime.compaction_rt)
+;;
+
 let () =
   run "post-turn durability" [
     "durable compaction", [
@@ -1326,6 +1438,8 @@ let () =
         `Quick test_post_dispatch_non_reducing_output_is_quarantined;
       test_case "suspended streak refuses reactive prepare"
         `Quick test_suspended_streak_refuses_reactive_prepare;
+      test_case "refusal does not settle as a compaction failure"
+        `Quick test_refusal_does_not_settle_as_compaction_failure;
       test_case "missing exact lane is source-bound no-compaction"
         `Quick test_missing_exact_lane_is_source_bound_no_compaction;
     ];


### PR DESCRIPTION
압축 admission 게이트가 자기 거부를 압축 실패로 정산해, 게이트가 읽는 카운터를 게이트 자신이 밀어 올리고 있었습니다. 그 간선 하나만 끊습니다.

## 증상

`keeper_post_turn.ml:739`는 `compaction_consecutive_failures >= 3`이면 reactive trigger를 거부합니다 (`Retry_suspended`, I/O 이전). 그 거부가 8홉을 거쳐 `` `Failed ``로 정산되어 같은 카운터를 +1 합니다.

```
keeper_post_turn.ml:757    Error (Retry_suspended { consecutive_failures })
keeper_post_turn.ml:1078   Commit_failed { error; committed = None }
keeper_unified_turn.ml:385 failed → committed=None만 보고 retry_after_started   ← 결함 지점
keeper_unified_turn.ml:306 Provider_overflow_retry_without_checkpoint
keeper_unified_turn.ml:582 Requeue_after_context_compaction (Compaction_attempt_failed _)
keeper_heartbeat_loop.ml:349  → Some `Failed
keeper_meta_store.ml:526      → consecutive_failures + 1
keeper_meta_contract.ml:69    → >= 3 → 다시 1번으로
```

`failed`가 `error`의 종류를 보지 않는 것이 원인입니다.

## 실측

라이브 로그 `.masc/logs/system_log_2026-07-2{8,9}.jsonl`:

| | 07-27 | 07-28 | 07-29 |
|---|---|---|---|
| `compaction retry suspended` (anchored) | 0 | 974 | 398 |

임계값은 3인데 관측된 최대 streak은 **907** (keeper `kidsnote`). 그 값의 약 99.7%가 압축을 시도조차 하지 않은 거부에서 나왔습니다. 카운터가 이렇게 부풀어 있는 동안에는 **무엇이 keeper를 임계값에 도달시켰는지 어떤 통계로도 읽을 수 없습니다.**

현재형 증거: keeper `verifier`는 로그 마지막 관측(`2026-07-29T16:11:26Z`)에서 34였고, `.masc/keepers/verifier.json`은 지금 `compaction_consecutive_failures: 35`를 읽습니다. `compaction_count: 10`이므로 압축이 성공한 적 있는 keeper이며, 임계값 3의 **11배를 넘긴 채로 계속 오르는 중**입니다.

부수 확인: 이 경로는 `Keeper_runtime_manifest.Context_compacted` + `compaction_outcome:Retry_without_checkpoint` 레코드를 남깁니다. 압축이 없었는데 "압축이 재시도 없이 실패했다"는 영수증입니다. 10일간 `compaction_started` 12,777건이 prepared plan 약 401건과 대조되는 격차의 상당 부분이 여기서 나옵니다.

## 변경

`in_lane_compaction`에 `Compaction_refused_without_attempt of { consecutive_failures : int }`를 추가하고, `failed`가 `compaction_recovery_error`의 6개 생성자를 **전수 열거**해 `Retry_suspended`만 새 경로로 보냅니다. `_ ->` catch-all을 쓰지 않으므로 새 오류 변형이 추가되면 컴파일 에러가 납니다.

- `keeper_heartbeat_loop.ml` — 새 disposition은 `None`으로 정산 (압축 결과가 없으므로 정산할 것이 없음)
- `keeper_unified_turn.ml` — 거부에는 runtime-manifest 레코드를 남기지 않음. 이 지점에서 도달 가능한 manifest 종류는 전부 "압축이 실행됐다"를 주장하는데, 실행되지 않았습니다.

**유지되는 것**: 게이트, 임계값 3, 그것이 막는 LLM 호출 상한, 그리고 `Manual`의 게이트 우회. 거부는 여전히 `record_overflow_failure`의 WARN, 레지스트리 phase 전이, 영속 `last_compaction_decision`으로 보입니다 — 오버플로 자체는 실제로 미해결이므로 그 관측은 참입니다.

## 문서 정정

`keeper_unified_turn.mli:171`과 `keeper_meta_contract.mli:76`은 임계값에서 `Escalate Compaction_retry_exhausted`가 일어난다고 서술합니다. `rg`로 확인한 결과 `Compaction_retry_exhausted`의 유일한 생성 지점은 `keeper_event_queue_state.ml:668`의 `of_json` 내부입니다 — 직렬화하는 쪽이 없으므로 역직렬화될 것도 없습니다. 실제 동작으로 교체했습니다.

## 검증

`test/test_keeper_post_turn_wirein_order.ml`에 `refusal does not settle as a compaction failure` 추가:

1. `Compaction_refused_without_attempt` → `None`
2. `Compaction_attempt_failed` → `` `Failed `` — **#25461이 세운 천장은 그대로 동작**
3. 그 정산이 durable meta의 streak을 3→4로 올리고 suspended를 유지

이 테스트는 먼저 HEAD에서 현행 동작(거부가 `` `Failed ``로 정산)을 단언하는 형태로 작성해 PASS를 확인한 뒤 역전시켰습니다.

`dune build --root .` 클린, `dune build --root . @runtest` 전체 통과.

## 범위 밖

- 카운터가 커밋(`Overflow_episode_committed`)에도 +1 하는 동작은 **건드리지 않았습니다**. `keeper_heartbeat_loop.ml:341-348`이 #25538 실측(920B만 줄인 커밋이 streak을 영구 리셋)을 근거로 의도한 설계이고, 되돌리면 그 사고가 재발합니다. 무엇이 임계값을 채우는지는 이 PR 이후에야 측정 가능해집니다.
- cap 초과로 죽는 턴 자체는 줄지 않습니다. 07-28/29 실측 분포는 cap별로 양봉입니다: `262144` 계급 n=3,362 중앙 초과 5,836B(1.02배), `524288` 계급 n=8,612 중앙 초과 1,206,780B(3.30배). 후자는 canonical history 문제이며 별건입니다.

RFC-WAIVED: credential/identity/operator-control/sandbox/hooks/workflow 문서 중 어느 subsystem도 건드리지 않습니다. 변경 범위는 `lib/keeper/keeper_unified_turn.{ml,mli}`, `lib/keeper/keeper_heartbeat_loop.ml`, `lib/keeper/keeper_meta_contract.mli`, `test/`입니다.

WORKAROUND-WAIVED: 증상 억제가 아니라 잘못된 정산의 제거입니다. 카운터/게이트/임계값을 새로 추가하지 않고, 기존 게이트와 그 비용 상한을 그대로 둔 채 "시도하지 않은 거부"를 압축 결과로 세던 것만 멈춥니다. 텔레메트리는 추가하지 않았고, 문자열 분류기도 없으며(타입 전수 열거), N-of-M 부분 이관도 아닙니다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
