### PR TITLE
feat(keeper): provider가 admission하는 직렬화 본문 바이트 관측

### DIFF
--- a/lib/keeper/keeper_memory_os_consolidation_runtime.ml
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.ml
@@ -170,7 +170,7 @@ let consolidate_keeper
   =
   match Runtime.validate_request_body_cap ~runtime_id provider_cfg with
   | Error error -> Provider_config_invalid error
-  | Ok () ->
+  | Ok _ ->
     match Io.read_facts_all_strict ~keeper_id with
     | Error msg -> Unparseable ("consolidation fact store read failed: " ^ msg)
     | Ok facts ->

--- a/lib/keeper/keeper_request_wire_observation.ml
+++ b/lib/keeper/keeper_request_wire_observation.ml
@@ -23,13 +23,17 @@ let () =
     bucket_upper_bounds_bytes
 ;;
 
-let observer ~keeper_name ~runtime_id
+let observer ~keeper_name ~runtime_id ~max_request_body_bytes
   : Agent_sdk.Agent.pre_dispatch_serialization_observer
   =
   fun observation ->
   Otel_metric_store.observe_histogram
     (Keeper_metrics.to_string metric)
-    ~labels:[ "keeper", keeper_name; "runtime_id", runtime_id ]
+    ~labels:
+      [ "keeper", keeper_name
+      ; "runtime_id", runtime_id
+      ; "max_request_body_bytes", string_of_int max_request_body_bytes
+      ]
     (Float.of_int observation.Llm_provider.Request_wire_observer.body_bytes);
   Ok ()
 ;;

--- a/lib/keeper/keeper_request_wire_observation.ml
+++ b/lib/keeper/keeper_request_wire_observation.ml
@@ -1,0 +1,12 @@
+let metric = Keeper_metrics.RuntimeRequestWireBytes
+
+let observer ~keeper_name
+  : Agent_sdk.Agent.pre_dispatch_serialization_observer
+  =
+  fun observation ->
+  Otel_metric_store.observe_histogram
+    (Keeper_metrics.to_string metric)
+    ~labels:[ "keeper", keeper_name ]
+    (Float.of_int observation.Llm_provider.Request_wire_observer.body_bytes);
+  Ok ()
+;;

--- a/lib/keeper/keeper_request_wire_observation.ml
+++ b/lib/keeper/keeper_request_wire_observation.ml
@@ -1,12 +1,35 @@
 let metric = Keeper_metrics.RuntimeRequestWireBytes
 
-let observer ~keeper_name
+(* Powers-of-two byte-scale measurement buckets. These are histogram schema,
+   not admission thresholds: OAS and each runtime's provider configuration
+   remain the only request-size authorities. The finite bounds cover the
+   current 64 KiB, 256 KiB and 1 MiB declared-cap fixtures exactly and retain
+   useful resolution through 8 MiB; the metric store adds +Inf. *)
+let bucket_upper_bounds_bytes =
+  [ 65_536.
+  ; 131_072.
+  ; 262_144.
+  ; 524_288.
+  ; 1_048_576.
+  ; 2_097_152.
+  ; 4_194_304.
+  ; 8_388_608.
+  ]
+;;
+
+let () =
+  Otel_metric_store.register_histogram_buckets
+    (Keeper_metrics.to_string metric)
+    bucket_upper_bounds_bytes
+;;
+
+let observer ~keeper_name ~runtime_id
   : Agent_sdk.Agent.pre_dispatch_serialization_observer
   =
   fun observation ->
   Otel_metric_store.observe_histogram
     (Keeper_metrics.to_string metric)
-    ~labels:[ "keeper", keeper_name ]
+    ~labels:[ "keeper", keeper_name; "runtime_id", runtime_id ]
     (Float.of_int observation.Llm_provider.Request_wire_observer.body_bytes);
   Ok ()
 ;;

--- a/lib/keeper/keeper_request_wire_observation.mli
+++ b/lib/keeper/keeper_request_wire_observation.mli
@@ -1,0 +1,28 @@
+(** Keeper_request_wire_observation — the serialized request body size OAS
+    admitted for one keeper turn.
+
+    Only a refused request reports its size today
+    ([Agent_sdk.Retry.Request_body_too_large] carries [actual_bytes]), so the
+    admitted population is unmeasured and nothing can compare a keeper's real
+    wire size against its runtime's [max_request_body_bytes]. Nothing MASC
+    already computes substitutes:
+    [Keeper_context_core_accessors.serialize_context] covers
+    [{system_prompt, messages}] and excludes tool schemas and every
+    provider-specific stream field, and [last_input_tokens] is a different unit
+    from a byte ceiling — measured 07-28/29, of 3,234 turns that died on the
+    byte cap, 2,964 (91.7%) were under 50% token utilization at that moment.
+
+    OAS invokes this observer after provider-specific serialization, after every
+    stream-field injection, and after its own serialized-body admission check,
+    so [body_bytes] is the exact admitted count. The observation is diagnostic:
+    OAS reports a rejecting or raising callback as typed failure evidence and
+    does not rewrite the provider result. *)
+
+val metric : Keeper_metrics.t
+(** Histogram the admitted byte count lands in, labelled by keeper. *)
+
+val observer :
+  keeper_name:string -> Agent_sdk.Agent.pre_dispatch_serialization_observer
+(** [observer ~keeper_name] records [body_bytes] under {!metric} and admits the
+    observation. It never rejects: this path exists only to measure, and a
+    rejection would manufacture typed failure evidence out of measurement. *)

--- a/lib/keeper/keeper_request_wire_observation.mli
+++ b/lib/keeper/keeper_request_wire_observation.mli
@@ -19,10 +19,14 @@
     does not rewrite the provider result. *)
 
 val metric : Keeper_metrics.t
-(** Histogram the admitted byte count lands in, labelled by keeper. *)
+(** Histogram the admitted byte count lands in, labelled by keeper and the
+    exact runtime whose provider configuration admitted the request. *)
 
 val observer :
-  keeper_name:string -> Agent_sdk.Agent.pre_dispatch_serialization_observer
-(** [observer ~keeper_name] records [body_bytes] under {!metric} and admits the
-    observation. It never rejects: this path exists only to measure, and a
-    rejection would manufacture typed failure evidence out of measurement. *)
+  keeper_name:string ->
+  runtime_id:string ->
+  Agent_sdk.Agent.pre_dispatch_serialization_observer
+(** [observer ~keeper_name ~runtime_id] records [body_bytes] under {!metric}
+    and admits the observation. It never rejects: this path exists only to
+    measure, and a rejection would manufacture typed failure evidence out of
+    measurement. *)

--- a/lib/keeper/keeper_request_wire_observation.mli
+++ b/lib/keeper/keeper_request_wire_observation.mli
@@ -20,13 +20,17 @@
 
 val metric : Keeper_metrics.t
 (** Histogram the admitted byte count lands in, labelled by keeper and the
-    exact runtime whose provider configuration admitted the request. *)
+    exact runtime and body cap whose provider configuration admitted the
+    request. *)
 
 val observer :
   keeper_name:string ->
   runtime_id:string ->
+  max_request_body_bytes:int ->
   Agent_sdk.Agent.pre_dispatch_serialization_observer
-(** [observer ~keeper_name ~runtime_id] records [body_bytes] under {!metric}
-    and admits the observation. It never rejects: this path exists only to
-    measure, and a rejection would manufacture typed failure evidence out of
-    measurement. *)
+(** [observer ~keeper_name ~runtime_id ~max_request_body_bytes] records
+    [body_bytes] under {!metric} and admits the observation. The cap is the
+    value already validated on the final provider config, so a hot-reload that
+    changes a runtime's cap starts a distinct metric series. It never rejects:
+    this path exists only to measure, and a rejection would manufacture typed
+    failure evidence out of measurement. *)

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -249,13 +249,13 @@ let runtime_candidate_missing_request_cap_error error =
 let validate_provider_request_cap ~runtime_id
     (provider_config : Llm_provider.Provider_config.t) =
   match Runtime.validate_request_body_cap ~runtime_id provider_config with
-  | Ok () -> Ok ()
+  | Ok cap -> Ok cap
   | Error error -> Error (runtime_candidate_missing_request_cap_error error)
 
 let resolve_runtime_candidate id =
   match Runtime.get_runtime_by_id id with
   | Some runtime ->
-    let* () =
+    let* _request_body_cap =
       validate_provider_request_cap
         ~runtime_id:runtime.id
         runtime.Runtime.provider_config
@@ -670,7 +670,7 @@ let run_named
          | Error err ->
            Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
            Error err, None
-         | Ok () ->
+         | Ok max_request_body_bytes ->
           let candidate = Runtime_candidate.of_provider_config provider_config in
           (* Cached provider health is observation only. Every eligible runtime
              reaches the real provider boundary; only the resulting typed error
@@ -679,6 +679,7 @@ let run_named
           let try_provider_ctx : Keeper_turn_driver_try_provider.try_provider_ctx =
             { runtime_id = attempt_runtime_id
             ; error_runtime_id
+            ; max_request_body_bytes
             ; base_path
             ; keeper_name
             ; name

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -260,14 +260,8 @@ let run_try_provider
                result. *)
           ; pre_dispatch_serialization_observer =
               Some
-                (fun observation ->
-                  Otel_metric_store.observe_histogram
-                    Keeper_metrics.(to_string RuntimeRequestWireBytes)
-                    ~labels:[ "keeper", ctx.keeper_name ]
-                    (Float.of_int
-                       observation
-                         .Llm_provider.Request_wire_observer.body_bytes);
-                  Ok ())
+                (Keeper_request_wire_observation.observer
+                   ~keeper_name:ctx.keeper_name)
           ; raw_trace = ctx.raw_trace
           ; trace_link = ctx.trace_link
           ; yield_on_tool = ctx.yield_on_tool

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -19,6 +19,7 @@ type try_provider_ctx =
   { (* Runtime identity *)
     runtime_id : string
   ; error_runtime_id : string
+  ; max_request_body_bytes : int
   ; base_path : string
   ; keeper_name : string
   ; name : string
@@ -262,7 +263,8 @@ let run_try_provider
               Some
                 (Keeper_request_wire_observation.observer
                    ~keeper_name:ctx.keeper_name
-                   ~runtime_id:ctx.runtime_id)
+                   ~runtime_id:ctx.runtime_id
+                   ~max_request_body_bytes:ctx.max_request_body_bytes)
           ; raw_trace = ctx.raw_trace
           ; trace_link = ctx.trace_link
           ; yield_on_tool = ctx.yield_on_tool

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -246,6 +246,28 @@ let run_try_provider
           ; event_bus = ctx.event_bus
           ; initial_messages = ctx.initial_messages
           ; model_input_projection = ctx.model_input_projection
+            (* The serialized request body is the quantity the provider admits
+               against [max_request_body_bytes], and today only a refused
+               request reports it: a request that fits is never sized, so the
+               admitted population is unmeasured.
+               [Keeper_context_core_accessors.serialize_context] cannot stand in
+               for it — that covers [{system_prompt, messages}] and excludes
+               tool schemas and every provider-specific stream field. OAS runs
+               this observer after those are injected and after its own
+               admission check, so the value is the exact byte count.
+               Diagnostic only: OAS reports a rejection or a raised callback as
+               typed failure evidence and does not rewrite the provider
+               result. *)
+          ; pre_dispatch_serialization_observer =
+              Some
+                (fun observation ->
+                  Otel_metric_store.observe_histogram
+                    Keeper_metrics.(to_string RuntimeRequestWireBytes)
+                    ~labels:[ "keeper", ctx.keeper_name ]
+                    (Float.of_int
+                       observation
+                         .Llm_provider.Request_wire_observer.body_bytes);
+                  Ok ())
           ; raw_trace = ctx.raw_trace
           ; trace_link = ctx.trace_link
           ; yield_on_tool = ctx.yield_on_tool

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -261,7 +261,8 @@ let run_try_provider
           ; pre_dispatch_serialization_observer =
               Some
                 (Keeper_request_wire_observation.observer
-                   ~keeper_name:ctx.keeper_name)
+                   ~keeper_name:ctx.keeper_name
+                   ~runtime_id:ctx.runtime_id)
           ; raw_trace = ctx.raw_trace
           ; trace_link = ctx.trace_link
           ; yield_on_tool = ctx.yield_on_tool

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -3,6 +3,7 @@
 type try_provider_ctx =
   { runtime_id : string
   ; error_runtime_id : string
+  ; max_request_body_bytes : int
   ; base_path : string
   ; keeper_name : string
   ; name : string

--- a/lib/keeper/keeper_vision_tool.ml
+++ b/lib/keeper/keeper_vision_tool.ml
@@ -327,7 +327,7 @@ let run_candidates_outcome
           { failure_class = Tool_result.Runtime_failure
           ; detail = Runtime.request_body_cap_error_to_string error
           }
-      | Ok () ->
+      | Ok _ ->
         (match
            Keeper_provider_subcall.complete ?override:complete ~sw ~net ~clock
              ~config ~messages ()

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -193,6 +193,7 @@ type t =
   | MemoryOsRecallEpisodesTruncated
   | MemoryOsRecallBytesOverBudget
   | MemoryOsEpisodeRetentionPruned
+  | RuntimeRequestWireBytes
   | RuntimeHttpProbeJsonParseFailures
   | VisionAnalyze
   | VisionCandidateAttempts
@@ -420,6 +421,7 @@ let to_string = function
       "masc_keeper_memory_os_recall_bytes_over_budget_total"
   | MemoryOsEpisodeRetentionPruned ->
       "masc_keeper_memory_os_episode_retention_pruned_total"
+  | RuntimeRequestWireBytes -> "masc_keeper_runtime_request_wire_bytes"
   | RuntimeHttpProbeJsonParseFailures ->
       "masc_runtime_http_probe_json_parse_failures_total"
   | VisionAnalyze -> "masc_keeper_vision_analyze_total"

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -184,6 +184,7 @@ type t =
   | MemoryOsRecallEpisodesTruncated
   | MemoryOsRecallBytesOverBudget
   | MemoryOsEpisodeRetentionPruned
+  | RuntimeRequestWireBytes
   | RuntimeHttpProbeJsonParseFailures
   | VisionAnalyze
   | VisionCandidateAttempts

--- a/lib/otel_metric_store/otel_metric_store_core.ml
+++ b/lib/otel_metric_store/otel_metric_store_core.ml
@@ -94,6 +94,14 @@ let register_histogram_buckets name bounds =
     with_lock (fun () -> Hashtbl.replace histogram_buckets name bounds))
 ;;
 
+let histogram_bound_label bound =
+  let label = Float.to_string bound in
+  let last = String.length label - 1 in
+  if last >= 0 && Char.equal label.[last] '.'
+  then String.sub label 0 last
+  else label
+;;
+
 let inc_counter name ?(labels = []) ?(delta = 1.0) () =
   best_effort (fun () ->
     let key = metric_key name labels in
@@ -194,7 +202,7 @@ let observe_histogram name ?(labels = []) value =
        | Some bounds ->
          List.iter
            (fun bound ->
-              let le = Printf.sprintf "%g" bound in
+              let le = histogram_bound_label bound in
               let bucket_labels = ("le", le) :: labels in
               let bucket_key = metric_key (name ^ "_bucket") bucket_labels in
               if value <= bound

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -551,7 +551,7 @@ let request_body_cap_error_to_string = function
 let validate_request_body_cap ~runtime_id
     (provider_config : Llm_provider.Provider_config.t) =
   match provider_config.max_request_body_bytes with
-  | Some cap when cap > 0 -> Ok ()
+  | Some cap when cap > 0 -> Ok cap
   | None | Some _ ->
     Error (Missing_or_non_positive_request_body_cap { runtime_id })
 ;;
@@ -637,7 +637,7 @@ let validate_keeper_dispatch_request_caps
                 ~runtime_id:runtime.id
                 runtime.provider_config
             with
-            | Ok () -> None
+            | Ok _ -> None
             | Error _ -> Some runtime))
       ids
   with

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -137,10 +137,11 @@ val request_body_cap_error_to_string : request_body_cap_error -> string
 val validate_request_body_cap :
   runtime_id:string
   -> Llm_provider.Provider_config.t
-  -> (unit, request_body_cap_error) result
+  -> (int, request_body_cap_error) result
 (** Pure final-provider-config guard shared by every Keeper provider-call
     boundary. Config admission uses it for statically reachable routes; call
-    sites must invoke it again after feature-local transforms. *)
+    sites must invoke it again after feature-local transforms. The successful
+    value is the exact positive cap validated on that final provider config. *)
 
 (** {1 Lazy default runtime singleton}
 

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -110,6 +110,8 @@ type config =
   description : string option;
   initial_messages : Agent_sdk.Types.message list;
   model_input_projection : Agent_sdk.Agent.model_input_projection option;
+  pre_dispatch_serialization_observer :
+    Agent_sdk.Agent.pre_dispatch_serialization_observer option;
   raw_trace : Agent_sdk.Raw_trace.t option;
   trace_link : (string * string) option;
   enable_thinking : bool option;

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -1003,6 +1003,8 @@ let resume_from_checkpoint
            ~tools:config.tools ?context:config.context
            ~context_fit_admission:prepared_resume.context_fit_admission
            ?model_input_projection:config.model_input_projection
+           ?pre_dispatch_serialization_observer:
+             config.pre_dispatch_serialization_observer
            ~options ~config:prepared_resume.agent_config
            ?checkpoint_sink:config.checkpoint_sink
            ()))

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -86,6 +86,8 @@ type config = Runtime_agent_context.config = {
   description : string option;
   initial_messages : Agent_sdk.Types.message list;
   model_input_projection : Agent_sdk.Agent.model_input_projection option;
+  pre_dispatch_serialization_observer :
+    Agent_sdk.Agent.pre_dispatch_serialization_observer option;
   raw_trace : Agent_sdk.Raw_trace.t option;
   trace_link : (string * string) option;
   enable_thinking : bool option;

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -67,6 +67,17 @@ type config =
   ; model_input_projection : Agent_sdk.Agent.model_input_projection option
     (** Caller-owned projection applied only to provider-bound messages.
         Agent state and checkpoints retain their canonical persisted form. *)
+  ; pre_dispatch_serialization_observer :
+      Agent_sdk.Agent.pre_dispatch_serialization_observer option
+    (** Caller-owned observer for the exact serialized request body, invoked by
+        OAS after every stream-field injection and after the serialized-body
+        admission check. This is the only place MASC can read the byte quantity
+        the provider actually admits against [max_request_body_bytes]:
+        [Keeper_context_core_accessors.serialize_context] measures
+        [{system_prompt, messages}] and excludes tool schemas, and a failed
+        request is the only path that reports a size today. The observation is
+        diagnostic and non-authoritative — OAS reports a rejection or a raised
+        callback as typed failure evidence without rewriting the result. *)
   ; raw_trace : Agent_sdk.Raw_trace.t option
   ; trace_link : (string * string) option
   ; enable_thinking : bool option
@@ -123,6 +134,7 @@ let default_config
   ; description = None
   ; initial_messages = []
   ; model_input_projection = None
+  ; pre_dispatch_serialization_observer = None
   ; raw_trace = None
   ; trace_link = None
   ; enable_thinking = None
@@ -269,6 +281,12 @@ let builder
   let builder =
     match config.model_input_projection with
     | Some project -> Agent_sdk.Builder.with_model_input_projection project builder
+    | None -> builder
+  in
+  let builder =
+    match config.pre_dispatch_serialization_observer with
+    | Some observe ->
+      Agent_sdk.Builder.with_pre_dispatch_serialization_observer observe builder
     | None -> builder
   in
   let builder =

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -58,6 +58,17 @@ type config = {
   description : string option;
   initial_messages : Agent_sdk.Types.message list;
   model_input_projection : Agent_sdk.Agent.model_input_projection option;
+  pre_dispatch_serialization_observer :
+    Agent_sdk.Agent.pre_dispatch_serialization_observer option;
+      (** Observer for the exact serialized request body, invoked by OAS after
+          stream-field injection and after the serialized-body admission check.
+          This is the only reading of the byte quantity admitted against
+          [max_request_body_bytes]:
+          [Keeper_context_core_accessors.serialize_context] covers
+          [{system_prompt, messages}] and excludes tool schemas, and only a
+          refused request reports its size today. Diagnostic and
+          non-authoritative — a rejection or raised callback becomes typed
+          failure evidence and does not rewrite the provider result. *)
   raw_trace : Agent_sdk.Raw_trace.t option;
   trace_link : (string * string) option;
   enable_thinking : bool option;

--- a/test/dune
+++ b/test/dune
@@ -1965,6 +1965,7 @@
 (include stanzas/test_keeper_personality_round_trip.inc)
 
 (include stanzas/test_keeper_post_turn_wirein_order.inc)
+(include stanzas/test_keeper_request_wire_observation.inc)
 
 (include stanzas/test_keeper_receipt_authoritative.inc)
 

--- a/test/stanzas/test_keeper_request_wire_observation.inc
+++ b/test/stanzas/test_keeper_request_wire_observation.inc
@@ -1,0 +1,9 @@
+(test
+ (name test_keeper_request_wire_observation)
+ (modules test_keeper_request_wire_observation)
+ (libraries
+  alcotest
+  masc
+  keeper_metrics
+  masc.otel_metric_store
+  agent_sdk.llm_provider))

--- a/test/test_keeper_request_wire_observation.ml
+++ b/test/test_keeper_request_wire_observation.ml
@@ -3,9 +3,10 @@
     Only a refused request reports its size today, so nothing could compare a
     keeper's real serialized wire size against its runtime's
     [max_request_body_bytes]. These tests pin that the observer records the
-    exact [body_bytes] OAS reports, attributes it to the right keeper, and
-    admits every observation — a rejection would turn measurement into typed
-    failure evidence on the provider path. *)
+    exact [body_bytes] OAS reports, attributes it to the right keeper and
+    runtime, emits byte-scale histogram buckets, and admits every observation
+    — a rejection would turn measurement into typed failure evidence on the
+    provider path. *)
 
 open Alcotest
 
@@ -26,62 +27,121 @@ let observation ~body_bytes : Wire.observation =
 
 let metric_name = Keeper_metrics.to_string Observation.metric
 
+let observe ~keeper_name ~runtime_id body_bytes =
+  Observation.observer ~keeper_name ~runtime_id (observation ~body_bytes)
+;;
+
 (* [observe_histogram] accumulates the observed sum under the bare metric key
    and the observation count under [name ^ "_count"]. *)
-let recorded ~keeper_name =
+let labels ~keeper_name ~runtime_id =
+  [ "keeper", keeper_name; "runtime_id", runtime_id ]
+;;
+
+let recorded ~keeper_name ~runtime_id =
   Otel_metric_store_core.metric_value_or_zero
     metric_name
-    ~labels:[ "keeper", keeper_name ]
+    ~labels:(labels ~keeper_name ~runtime_id)
     ()
 ;;
 
-let observation_count ~keeper_name =
+let observation_count ~keeper_name ~runtime_id =
   Otel_metric_store_core.metric_value_or_zero
     (metric_name ^ "_count")
-    ~labels:[ "keeper", keeper_name ]
+    ~labels:(labels ~keeper_name ~runtime_id)
     ()
 ;;
 
 let test_records_admitted_bytes_for_the_keeper () =
   let keeper_name = "wire-observation-alpha" in
-  let before = recorded ~keeper_name in
+  let runtime_id = "wire-runtime-alpha" in
+  let before = recorded ~keeper_name ~runtime_id in
   check
     (result unit reject)
     "the observation is admitted"
     (Ok ())
-    (Observation.observer ~keeper_name (observation ~body_bytes:524_288));
+    (observe ~keeper_name ~runtime_id 524_288);
   check
     (float 0.5)
     "the exact admitted byte count is recorded"
     (before +. 524_288.)
-    (recorded ~keeper_name);
+    (recorded ~keeper_name ~runtime_id);
   check
     (result unit reject)
     "a second observation is also admitted"
     (Ok ())
-    (Observation.observer ~keeper_name (observation ~body_bytes:1_730_708));
+    (observe ~keeper_name ~runtime_id 1_730_708);
   check
     (float 0.5)
     "observations accumulate"
     (before +. 524_288. +. 1_730_708.)
-    (recorded ~keeper_name);
+    (recorded ~keeper_name ~runtime_id);
   check
     (float 0.5)
     "both observations are counted"
     2.
-    (observation_count ~keeper_name)
+    (observation_count ~keeper_name ~runtime_id)
 ;;
 
 let test_attributes_bytes_to_the_observing_keeper () =
   let alpha = "wire-observation-attribution-alpha" in
   let beta = "wire-observation-attribution-beta" in
-  let beta_before = recorded ~keeper_name:beta in
-  ignore (Observation.observer ~keeper_name:alpha (observation ~body_bytes:262_144));
+  let runtime_id = "wire-runtime-attribution" in
+  let beta_before = recorded ~keeper_name:beta ~runtime_id in
+  ignore (observe ~keeper_name:alpha ~runtime_id 262_144);
   check
     (float 0.5)
     "another keeper's histogram is untouched"
     beta_before
-    (recorded ~keeper_name:beta)
+    (recorded ~keeper_name:beta ~runtime_id)
+;;
+
+let test_separates_runtimes_for_the_same_keeper () =
+  let keeper_name = "wire-observation-runtime-attribution" in
+  let alpha = "wire-runtime-attribution-alpha" in
+  let beta = "wire-runtime-attribution-beta" in
+  let alpha_before = recorded ~keeper_name ~runtime_id:alpha in
+  let beta_before = recorded ~keeper_name ~runtime_id:beta in
+  ignore (observe ~keeper_name ~runtime_id:alpha 262_144);
+  check
+    (float 0.5)
+    "the observing runtime receives the exact byte count"
+    (alpha_before +. 262_144.)
+    (recorded ~keeper_name ~runtime_id:alpha);
+  check
+    (float 0.5)
+    "another runtime's histogram is untouched"
+    beta_before
+    (recorded ~keeper_name ~runtime_id:beta)
+;;
+
+let test_records_byte_scale_histogram_buckets () =
+  let keeper_name = "wire-observation-buckets" in
+  let runtime_id = "wire-runtime-buckets" in
+  let bucket le =
+    Otel_metric_store_core.metric_value_or_zero
+      (metric_name ^ "_bucket")
+      ~labels:(("le", le) :: labels ~keeper_name ~runtime_id)
+      ()
+  in
+  let before_131072 = bucket "131072" in
+  let before_262144 = bucket "262144" in
+  let before_inf = bucket "+Inf" in
+  ignore (observe ~keeper_name ~runtime_id 262_144);
+  check
+    (float 0.5)
+    "smaller bucket excludes observation"
+    before_131072
+    (bucket "131072");
+  check
+    (float 0.5)
+    "matching cap bucket includes observation"
+    (before_262144 +. 1.)
+    (bucket "262144");
+  check
+    (float 0.5)
+    "+Inf bucket includes observation"
+    (before_inf +. 1.)
+    (bucket "+Inf")
 ;;
 
 let test_admits_a_zero_byte_observation () =
@@ -91,9 +151,10 @@ let test_admits_a_zero_byte_observation () =
     (result unit reject)
     "a zero-byte observation is still admitted"
     (Ok ())
-    (Observation.observer
+    (observe
        ~keeper_name:"wire-observation-zero"
-       (observation ~body_bytes:0))
+       ~runtime_id:"wire-runtime-zero"
+       0)
 ;;
 
 let test_metric_name_is_stable () =
@@ -116,6 +177,14 @@ let () =
             "attributes bytes to the observing keeper"
             `Quick
             test_attributes_bytes_to_the_observing_keeper
+        ; test_case
+            "separates runtimes for the same keeper"
+            `Quick
+            test_separates_runtimes_for_the_same_keeper
+        ; test_case
+            "records byte-scale histogram buckets"
+            `Quick
+            test_records_byte_scale_histogram_buckets
         ; test_case
             "admits a zero-byte observation"
             `Quick

--- a/test/test_keeper_request_wire_observation.ml
+++ b/test/test_keeper_request_wire_observation.ml
@@ -169,7 +169,7 @@ let test_records_byte_scale_histogram_buckets () =
   let series =
     { keeper_name = "wire-observation-buckets"
     ; runtime_id = "wire-runtime-buckets"
-    ; max_request_body_bytes = 262_144
+    ; max_request_body_bytes = 2_097_152
     }
   in
   let bucket le =
@@ -178,20 +178,26 @@ let test_records_byte_scale_histogram_buckets () =
       ~labels:(("le", le) :: labels series)
       ()
   in
-  let before_131072 = bucket "131072" in
-  let before_262144 = bucket "262144" in
+  let before_524288 = bucket "524288" in
+  let before_1048576 = bucket "1048576" in
+  let before_rounded_1048576 = bucket "1.04858e+06" in
   let before_inf = bucket "+Inf" in
-  ignore (observe series 262_144);
+  ignore (observe series 1_048_576);
   check
     (float 0.5)
     "smaller bucket excludes observation"
-    before_131072
-    (bucket "131072");
+    before_524288
+    (bucket "524288");
   check
     (float 0.5)
-    "matching cap bucket includes observation"
-    (before_262144 +. 1.)
-    (bucket "262144");
+    "exact MiB bucket includes observation"
+    (before_1048576 +. 1.)
+    (bucket "1048576");
+  check
+    (float 0.5)
+    "rounded MiB label is not emitted"
+    before_rounded_1048576
+    (bucket "1.04858e+06");
   check
     (float 0.5)
     "+Inf bucket includes observation"

--- a/test/test_keeper_request_wire_observation.ml
+++ b/test/test_keeper_request_wire_observation.ml
@@ -1,0 +1,126 @@
+(** The admitted request-body size is recorded per keeper.
+
+    Only a refused request reports its size today, so nothing could compare a
+    keeper's real serialized wire size against its runtime's
+    [max_request_body_bytes]. These tests pin that the observer records the
+    exact [body_bytes] OAS reports, attributes it to the right keeper, and
+    admits every observation — a rejection would turn measurement into typed
+    failure evidence on the provider path. *)
+
+open Alcotest
+
+module Observation = Masc.Keeper_request_wire_observation
+module Wire = Llm_provider.Request_wire_observer
+
+let observation ~body_bytes : Wire.observation =
+  { phase = Wire.Pre_dispatch_serialization
+  ; capture_id = None
+  ; provider = "ollama_cloud"
+  ; model = "deepseek-v4-flash"
+  ; http_codec = "openai_compat"
+  ; stream = true
+  ; body_bytes
+  ; body_sha256 = String.make 64 '0'
+  }
+;;
+
+let metric_name = Keeper_metrics.to_string Observation.metric
+
+(* [observe_histogram] accumulates the observed sum under the bare metric key
+   and the observation count under [name ^ "_count"]. *)
+let recorded ~keeper_name =
+  Otel_metric_store_core.metric_value_or_zero
+    metric_name
+    ~labels:[ "keeper", keeper_name ]
+    ()
+;;
+
+let observation_count ~keeper_name =
+  Otel_metric_store_core.metric_value_or_zero
+    (metric_name ^ "_count")
+    ~labels:[ "keeper", keeper_name ]
+    ()
+;;
+
+let test_records_admitted_bytes_for_the_keeper () =
+  let keeper_name = "wire-observation-alpha" in
+  let before = recorded ~keeper_name in
+  check
+    (result unit reject)
+    "the observation is admitted"
+    (Ok ())
+    (Observation.observer ~keeper_name (observation ~body_bytes:524_288));
+  check
+    (float 0.5)
+    "the exact admitted byte count is recorded"
+    (before +. 524_288.)
+    (recorded ~keeper_name);
+  check
+    (result unit reject)
+    "a second observation is also admitted"
+    (Ok ())
+    (Observation.observer ~keeper_name (observation ~body_bytes:1_730_708));
+  check
+    (float 0.5)
+    "observations accumulate"
+    (before +. 524_288. +. 1_730_708.)
+    (recorded ~keeper_name);
+  check
+    (float 0.5)
+    "both observations are counted"
+    2.
+    (observation_count ~keeper_name)
+;;
+
+let test_attributes_bytes_to_the_observing_keeper () =
+  let alpha = "wire-observation-attribution-alpha" in
+  let beta = "wire-observation-attribution-beta" in
+  let beta_before = recorded ~keeper_name:beta in
+  ignore (Observation.observer ~keeper_name:alpha (observation ~body_bytes:262_144));
+  check
+    (float 0.5)
+    "another keeper's histogram is untouched"
+    beta_before
+    (recorded ~keeper_name:beta)
+;;
+
+let test_admits_a_zero_byte_observation () =
+  (* OAS owns admission; a measurement path must not invent a rejection for an
+     unusual-looking value. *)
+  check
+    (result unit reject)
+    "a zero-byte observation is still admitted"
+    (Ok ())
+    (Observation.observer
+       ~keeper_name:"wire-observation-zero"
+       (observation ~body_bytes:0))
+;;
+
+let test_metric_name_is_stable () =
+  check
+    string
+    "dashboards and alerts key off this name"
+    "masc_keeper_runtime_request_wire_bytes"
+    metric_name
+;;
+
+let () =
+  run
+    "keeper request wire observation"
+    [ ( "admitted bytes"
+      , [ test_case
+            "records the admitted byte count"
+            `Quick
+            test_records_admitted_bytes_for_the_keeper
+        ; test_case
+            "attributes bytes to the observing keeper"
+            `Quick
+            test_attributes_bytes_to_the_observing_keeper
+        ; test_case
+            "admits a zero-byte observation"
+            `Quick
+            test_admits_a_zero_byte_observation
+        ; test_case "metric name is stable" `Quick test_metric_name_is_stable
+        ] )
+    ]
+;;

--- a/test/test_keeper_request_wire_observation.ml
+++ b/test/test_keeper_request_wire_observation.ml
@@ -4,9 +4,9 @@
     keeper's real serialized wire size against its runtime's
     [max_request_body_bytes]. These tests pin that the observer records the
     exact [body_bytes] OAS reports, attributes it to the right keeper and
-    runtime, emits byte-scale histogram buckets, and admits every observation
-    — a rejection would turn measurement into typed failure evidence on the
-    provider path. *)
+    runtime and admitted cap, emits byte-scale histogram buckets, and admits
+    every observation — a rejection would turn measurement into typed failure
+    evidence on the provider path. *)
 
 open Alcotest
 
@@ -27,106 +27,161 @@ let observation ~body_bytes : Wire.observation =
 
 let metric_name = Keeper_metrics.to_string Observation.metric
 
-let observe ~keeper_name ~runtime_id body_bytes =
-  Observation.observer ~keeper_name ~runtime_id (observation ~body_bytes)
+type metric_series =
+  { keeper_name : string
+  ; runtime_id : string
+  ; max_request_body_bytes : int
+  }
+
+let observe series body_bytes =
+  Observation.observer
+    ~keeper_name:series.keeper_name
+    ~runtime_id:series.runtime_id
+    ~max_request_body_bytes:series.max_request_body_bytes
+    (observation ~body_bytes)
 ;;
 
 (* [observe_histogram] accumulates the observed sum under the bare metric key
    and the observation count under [name ^ "_count"]. *)
-let labels ~keeper_name ~runtime_id =
-  [ "keeper", keeper_name; "runtime_id", runtime_id ]
+let labels series =
+  [ "keeper", series.keeper_name
+  ; "runtime_id", series.runtime_id
+  ; "max_request_body_bytes", string_of_int series.max_request_body_bytes
+  ]
 ;;
 
-let recorded ~keeper_name ~runtime_id =
+let recorded series =
   Otel_metric_store_core.metric_value_or_zero
     metric_name
-    ~labels:(labels ~keeper_name ~runtime_id)
+    ~labels:(labels series)
     ()
 ;;
 
-let observation_count ~keeper_name ~runtime_id =
+let observation_count series =
   Otel_metric_store_core.metric_value_or_zero
     (metric_name ^ "_count")
-    ~labels:(labels ~keeper_name ~runtime_id)
+    ~labels:(labels series)
     ()
 ;;
 
 let test_records_admitted_bytes_for_the_keeper () =
-  let keeper_name = "wire-observation-alpha" in
-  let runtime_id = "wire-runtime-alpha" in
-  let before = recorded ~keeper_name ~runtime_id in
+  let series =
+    { keeper_name = "wire-observation-alpha"
+    ; runtime_id = "wire-runtime-alpha"
+    ; max_request_body_bytes = 2_097_152
+    }
+  in
+  let before = recorded series in
   check
     (result unit reject)
     "the observation is admitted"
     (Ok ())
-    (observe ~keeper_name ~runtime_id 524_288);
+    (observe series 524_288);
   check
     (float 0.5)
     "the exact admitted byte count is recorded"
     (before +. 524_288.)
-    (recorded ~keeper_name ~runtime_id);
+    (recorded series);
   check
     (result unit reject)
     "a second observation is also admitted"
     (Ok ())
-    (observe ~keeper_name ~runtime_id 1_730_708);
+    (observe series 1_730_708);
   check
     (float 0.5)
     "observations accumulate"
     (before +. 524_288. +. 1_730_708.)
-    (recorded ~keeper_name ~runtime_id);
+    (recorded series);
   check
     (float 0.5)
     "both observations are counted"
     2.
-    (observation_count ~keeper_name ~runtime_id)
+    (observation_count series)
 ;;
 
 let test_attributes_bytes_to_the_observing_keeper () =
-  let alpha = "wire-observation-attribution-alpha" in
-  let beta = "wire-observation-attribution-beta" in
-  let runtime_id = "wire-runtime-attribution" in
-  let beta_before = recorded ~keeper_name:beta ~runtime_id in
-  ignore (observe ~keeper_name:alpha ~runtime_id 262_144);
+  let alpha =
+    { keeper_name = "wire-observation-attribution-alpha"
+    ; runtime_id = "wire-runtime-attribution"
+    ; max_request_body_bytes = 524_288
+    }
+  in
+  let beta =
+    { alpha with keeper_name = "wire-observation-attribution-beta" }
+  in
+  let beta_before = recorded beta in
+  ignore (observe alpha 262_144);
   check
     (float 0.5)
     "another keeper's histogram is untouched"
     beta_before
-    (recorded ~keeper_name:beta ~runtime_id)
+    (recorded beta)
 ;;
 
 let test_separates_runtimes_for_the_same_keeper () =
-  let keeper_name = "wire-observation-runtime-attribution" in
-  let alpha = "wire-runtime-attribution-alpha" in
-  let beta = "wire-runtime-attribution-beta" in
-  let alpha_before = recorded ~keeper_name ~runtime_id:alpha in
-  let beta_before = recorded ~keeper_name ~runtime_id:beta in
-  ignore (observe ~keeper_name ~runtime_id:alpha 262_144);
+  let alpha =
+    { keeper_name = "wire-observation-runtime-attribution"
+    ; runtime_id = "wire-runtime-attribution-alpha"
+    ; max_request_body_bytes = 524_288
+    }
+  in
+  let beta = { alpha with runtime_id = "wire-runtime-attribution-beta" } in
+  let alpha_before = recorded alpha in
+  let beta_before = recorded beta in
+  ignore (observe alpha 262_144);
   check
     (float 0.5)
     "the observing runtime receives the exact byte count"
     (alpha_before +. 262_144.)
-    (recorded ~keeper_name ~runtime_id:alpha);
+    (recorded alpha);
   check
     (float 0.5)
     "another runtime's histogram is untouched"
     beta_before
-    (recorded ~keeper_name ~runtime_id:beta)
+    (recorded beta)
+;;
+
+let test_separates_changed_caps_for_the_same_runtime () =
+  let old_cap =
+    { keeper_name = "wire-observation-cap-attribution"
+    ; runtime_id = "wire-runtime-cap-attribution"
+    ; max_request_body_bytes = 262_144
+    }
+  in
+  let new_cap = { old_cap with max_request_body_bytes = 524_288 } in
+  let old_before = recorded old_cap in
+  let new_before = recorded new_cap in
+  ignore (observe old_cap 131_072);
+  check
+    (float 0.5)
+    "a different cap series stays untouched"
+    new_before
+    (recorded new_cap);
+  ignore (observe new_cap 262_144);
+  check
+    (float 0.5)
+    "the previous cap series retains only its own sample"
+    (old_before +. 131_072.)
+    (recorded old_cap)
 ;;
 
 let test_records_byte_scale_histogram_buckets () =
-  let keeper_name = "wire-observation-buckets" in
-  let runtime_id = "wire-runtime-buckets" in
+  let series =
+    { keeper_name = "wire-observation-buckets"
+    ; runtime_id = "wire-runtime-buckets"
+    ; max_request_body_bytes = 262_144
+    }
+  in
   let bucket le =
     Otel_metric_store_core.metric_value_or_zero
       (metric_name ^ "_bucket")
-      ~labels:(("le", le) :: labels ~keeper_name ~runtime_id)
+      ~labels:(("le", le) :: labels series)
       ()
   in
   let before_131072 = bucket "131072" in
   let before_262144 = bucket "262144" in
   let before_inf = bucket "+Inf" in
-  ignore (observe ~keeper_name ~runtime_id 262_144);
+  ignore (observe series 262_144);
   check
     (float 0.5)
     "smaller bucket excludes observation"
@@ -147,14 +202,17 @@ let test_records_byte_scale_histogram_buckets () =
 let test_admits_a_zero_byte_observation () =
   (* OAS owns admission; a measurement path must not invent a rejection for an
      unusual-looking value. *)
+  let series =
+    { keeper_name = "wire-observation-zero"
+    ; runtime_id = "wire-runtime-zero"
+    ; max_request_body_bytes = 262_144
+    }
+  in
   check
     (result unit reject)
     "a zero-byte observation is still admitted"
     (Ok ())
-    (observe
-       ~keeper_name:"wire-observation-zero"
-       ~runtime_id:"wire-runtime-zero"
-       0)
+    (observe series 0)
 ;;
 
 let test_metric_name_is_stable () =
@@ -181,6 +239,10 @@ let () =
             "separates runtimes for the same keeper"
             `Quick
             test_separates_runtimes_for_the_same_keeper
+        ; test_case
+            "separates changed caps for the same runtime"
+            `Quick
+            test_separates_changed_caps_for_the_same_runtime
         ; test_case
             "records byte-scale histogram buckets"
             `Quick

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -1685,6 +1685,57 @@ let test_runtime_agent_fresh_projection_precedes_measurement () =
 let test_runtime_agent_resume_projection_precedes_measurement () =
   run_projection_case ~resume:true
 
+let run_pre_dispatch_serialization_observer_case ~resume =
+  let observed_body_bytes = ref [] in
+  let (), requests =
+    with_native_projection_server
+    @@ fun ~sw ~net ~base_url ->
+    let config =
+      { (context_fit_runtime_config base_url) with
+        pre_dispatch_serialization_observer =
+          Some
+            (fun observation ->
+               observed_body_bytes :=
+                 observation.Llm_provider.Request_wire_observer.body_bytes
+                 :: !observed_body_bytes;
+               Ok ())
+      }
+    in
+    let agent =
+      if resume
+      then
+        Runtime_agent.resume_from_checkpoint
+          ~sw
+          ~net
+          ~config
+          ~checkpoint:(context_fit_checkpoint ())
+      else Runtime_agent.build ~sw ~net ~config
+    in
+    let agent =
+      match agent with
+      | Ok agent -> agent
+      | Error error -> fail (Agent_sdk.Error.to_string error)
+    in
+    Fun.protect
+      ~finally:(fun () -> Agent_sdk.Agent.close agent)
+      (fun () ->
+         match Agent_sdk.Agent.run ~sw agent "observe exact request bytes" with
+         | Ok _ -> ()
+         | Error error -> fail (Agent_sdk.Error.to_string error))
+  in
+  let completion_body = List.assoc "/v1/messages" requests in
+  check
+    (list int)
+    "observer receives the exact dispatched body size once"
+    [ String.length completion_body ]
+    (List.rev !observed_body_bytes)
+
+let test_runtime_agent_fresh_observes_pre_dispatch_serialization () =
+  run_pre_dispatch_serialization_observer_case ~resume:false
+
+let test_runtime_agent_resume_observes_pre_dispatch_serialization () =
+  run_pre_dispatch_serialization_observer_case ~resume:true
+
 (* RFC-OAS-026 §4.6: a configured stream-idle deadline with no resolvable clock
    must fail loudly rather than silently disarm the only I2-legitimate
    streaming timeout. *)
@@ -1921,6 +1972,14 @@ let () =
             "resumed projection precedes measurement and dispatch"
             `Quick
             test_runtime_agent_resume_projection_precedes_measurement
+        ; test_case
+            "fresh agent observes exact pre-dispatch serialization"
+            `Quick
+            test_runtime_agent_fresh_observes_pre_dispatch_serialization
+        ; test_case
+            "resumed agent observes exact pre-dispatch serialization"
+            `Quick
+            test_runtime_agent_resume_observes_pre_dispatch_serialization
         ; test_case
             "dashboard runtime provider reachability contracts"
             `Quick


### PR DESCRIPTION
## What changed

- wire OAS's post-serialization observer through both new and resumed runtime-agent construction
- record the exact admitted serialized request body as `masc_keeper_runtime_request_wire_bytes`
- label each histogram series by `keeper`, exact `runtime_id`, and the validated `max_request_body_bytes`
- register byte-scale histogram buckets from 64 KiB through 8 MiB; the metric store supplies `+Inf`
- serialize histogram bounds with their shortest round-trip value so MiB `le` labels match the exact compared bound
- reuse the existing final-provider-config cap validation result, so a hot-reload that changes a runtime's cap starts a distinct series without adding another gate

## Why

Only rejected oversized requests exposed their exact serialized body size. Token counts and MASC's `{system_prompt, messages}` projection cannot substitute because they use a different unit and exclude tool schemas plus provider-specific wire fields.

The metric now covers the admitted population and preserves the exact runtime/cap dimensions needed to compare body distributions with the admission ceiling that applied to each sample.

## Boundary

- diagnostic observation only
- no admission, compaction, retry, failover, or provider-result behavior changes
- no derived headroom field or threshold
- no OAS change
- no facade-from-facade dependency
- the shared histogram formatter also normalizes existing large integer bounds such as `1e+06` to `1000000`; no legacy label is dual-emitted or decoded

## Validation

- `ocamlformat --check` on every changed `.ml`/`.mli`
- `ocamlc -stop-after parsing -c` on every changed `.ml`/`.mli`
- `git diff --check`
- `scripts/ci/check-determinism-contract.sh`
- `scripts/ocaml-structure-ratchet.sh`
- `scripts/check-pr-hygiene.sh --base origin/main --head HEAD`
- focused tests cover exact bytes, keeper/runtime/cap isolation, exact MiB histogram labels, resumed agents, and non-rejecting observation

No local Dune build was used for the latest revision. Full GitHub CI is authoritative.

RFC-WAIVED: no credential, identity, operator-control, sandbox, hook, or workflow subsystem changes.

WORKAROUND-WAIVED: this exposes a physical quantity that existing code could not observe; it does not use telemetry as a substitute for a behavior fix.

Tracks #26397.
