### PR TITLE
fix(keeper): drop self-authored board post echo from observation

### DIFF
--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -634,23 +634,43 @@ let pending_board_event_of_stimulus
   (stimulus : Keeper_event_queue.stimulus)
   : (pending_board_event option, Board_signal.board_unavailable) result
   =
+  (* Self-attribution at the observation SSOT. A Board_post_created authored by
+     this keeper is its own action echo, not foreign board activity. Returning
+     None excludes it from the observation's pending_board_events so the keeper
+     does not re-react to its own post. Without this gate the live heartbeat
+     path injects stimulus-derived events verbatim via the [Some] branch of
+     [observe] and re-observes the keeper's freshly-created post as "1 new
+     board activity" every turn, re-triggering a reactive post — a self-trigger
+     loop. This complements the cursor-pull self filter in
+     [collect_board_events_with_cursor_policy], which only runs on the [None]
+     path of [observe]. Comment/reaction signals stay visible: a foreign reply
+     to the keeper's own post is still relevant observation. *)
+  let is_self_post_created_echo (signal : Board_dispatch.board_signal) =
+    match signal.kind with
+    | Board_dispatch.Board_post_created ->
+      is_self_author ~self_ids:(self_ids meta) signal.author
+    | _ -> false
+  in
+  let board_event_of_signal signal =
+    if is_self_post_created_echo signal
+    then Ok None
+    else
+      Result.map
+        (fun ev -> Some ev)
+        (pending_board_event_of_board_signal
+           ~meta
+           ~arrived_at:stimulus.arrived_at
+           signal)
+  in
   match stimulus.payload with
   | Keeper_event_queue.Board_signal bs ->
-    Result.map
-      (fun ev -> Some ev)
-      (pending_board_event_of_board_signal
-         ~meta
-         ~arrived_at:stimulus.arrived_at
-         (Board_signal.board_signal_of_board_stimulus ~post_id:stimulus.post_id bs))
+    board_event_of_signal
+      (Board_signal.board_signal_of_board_stimulus ~post_id:stimulus.post_id bs)
   | Keeper_event_queue.Board_attention attention ->
-    Result.map
-      (fun ev -> Some ev)
-      (pending_board_event_of_board_signal
-         ~meta
-         ~arrived_at:stimulus.arrived_at
-         (Board_signal.board_signal_of_board_stimulus
-            ~post_id:stimulus.post_id
-            attention.signal))
+    board_event_of_signal
+      (Board_signal.board_signal_of_board_stimulus
+         ~post_id:stimulus.post_id
+         attention.signal)
   | Keeper_event_queue.Fusion_completed fc ->
     Ok (Some (pending_board_event_of_fusion_completion ~meta ~arrived_at:stimulus.arrived_at fc))
   | Keeper_event_queue.Bg_completed c ->

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -198,6 +198,67 @@ let () =
     String.equal
       (payload_kind_label (board_attention_payload "candidate-1"))
       "board_attention");
+  let self_meta = event_queue_test_meta "a" "trace-self-board-author" in
+  let self_post_stimulus payload =
+    { post_id = "self-post"
+    ; urgency = Normal
+    ; arrived_at = 3.0
+    ; payload
+    }
+  in
+  let expect_no_self_post_echo label payload =
+    match
+      Masc.Keeper_world_observation.pending_board_event_of_stimulus
+        ~meta:self_meta
+        (self_post_stimulus payload)
+    with
+    | Ok None -> ()
+    | Ok (Some _) -> Alcotest.fail (label ^ " re-observed a self-authored post")
+    | Error unavailable ->
+      Alcotest.fail
+        (label
+         ^ " unexpectedly read Board: "
+         ^ Masc.Keeper_world_observation_board_signal.unavailable_to_string
+             unavailable)
+  in
+  expect_no_self_post_echo "direct board signal" (board_payload ());
+  expect_no_self_post_echo
+    "attention-admitted board signal"
+    (board_attention_payload "self-post-candidate");
+  let self_comment =
+    Board_signal
+      { kind = Comment_added
+      ; author = "a"
+      ; title = "reply"
+      ; content = "a comment is not a post echo"
+      ; hearth = None
+      ; updated_at = None
+      }
+  in
+  (match
+     Masc.Keeper_world_observation.pending_board_event_of_stimulus
+       ~meta:self_meta
+       (self_post_stimulus self_comment)
+   with
+   | Ok (Some _) -> ()
+   | Ok None -> Alcotest.fail "self-authored comment was incorrectly suppressed"
+   | Error unavailable ->
+     Alcotest.fail
+       ("self comment unexpectedly read Board: "
+        ^ Masc.Keeper_world_observation_board_signal.unavailable_to_string
+            unavailable));
+  (match
+     Masc.Keeper_world_observation.pending_board_event_of_stimulus
+       ~meta:(event_queue_test_meta "different-keeper" "trace-foreign-board-author")
+       (self_post_stimulus (board_payload ()))
+   with
+   | Ok (Some _) -> ()
+   | Ok None -> Alcotest.fail "foreign post was incorrectly suppressed"
+   | Error unavailable ->
+     Alcotest.fail
+       ("foreign post unexpectedly read Board: "
+        ^ Masc.Keeper_world_observation_board_signal.unavailable_to_string
+            unavailable));
   (match
      stimulus_of_yojson
        (stimulus_to_yojson


### PR DESCRIPTION
## 배경 (라이브 사고)

sangsu keeper가 15분간 같은 영화 에세이를 21회 반복 작성 (22 post 중 21). 매 턴 `keeper_board_post → pending_board_events=1 → 또 post` 루프.

## 근본 원인

라이브 heartbeat 경로는 stimulus push 경로(observe의 Some branch)를 씁니다. 그런데 stimulus → event 렌더러(`pending_board_event_of_stimulus`)에 **self-attribution 게이트가 없었습니다**. cursor-pull의 self filter(`collect_board_events_with_cursor_policy`, 740-745)은 observe의 None branch에서만 도는데, 라이브는 None을 밟지 않습니다.

결과: keeper가 올린 자기 post가 매 턴 "타인 새 post 1개"로 LLM에 관측 → sangsu instructions("새 글에 반드시 한마디" + "영화 글 올린다")가 매 턴 같은 post를 발화 → 무한 루프.

5각도 병렬 추적 워크플로 + 직접 코드 검증으로 확정:
- ANGLE A/B: identity layer는 정상 (`of_string("sangsu")` == `of_string("keeper-sangsu-agent")`, author="sangsu" 일치). 결함은 delivery/rendering 층.
- ANGLE C: 렌더러(`pending_board_event_of_board_signal`)에 `is_self_author` 호출 0건.
- ANGLE D/E: memory amnesia, cursor 정책은 2차 요인.

## 수정

`pending_board_event_of_stimulus`(`keeper_world_observation.ml:632`)에 `is_self_post_created_echo` 게이트 추가. `Board_post_created` + `is_self_author` → `Ok None`. comment/reaction signal은 유지 (다른 keeper가 내 글에 단 댓글은 여전히 보임).

cursor-pull filter(None branch)과 stimulus renderer(Some branch) 양쪽에 self-attribution이 생겨 경로 무관 일관성 확보.

## 검증

- `dune build --root $WT @install`: 컴파일 통과.
- `dune runtest`: keeper observation 경로 green. mcp_tool_matrix 1 failure는 환경 의존적 (tool registry inconsistency, server-initializing race, persona fixture 부재)이며 본 수정과 무관.
- 회귀 테스트(self → Ok None): stimulus/board_stimulus 생성 helper로 후속 commit 예정.

## 2차 요인 (별도 작업)

이 PR은 루프의 구조적 차단(렌더러 게이트)만 다룹니다. 별도:
- route_for_keeper upstream leak — 왜 자기 signal이 큐에 도달했는지 런타임 규명 필요.
- keeper action-memory amnesia — `used_memory_search=False` 매 턴 (직전 행동 회상 부재).
- persona amplification — sangsu instructions의 반응적 post 규칙.

cursor advance / keeper pause / dedup 같은 증상 억제는 의도적 배제. keeper가 자기 행동 echo를 observation layer에서 식별(SSOT)하도록 근본 복구.

Refs: RFC-0003 (turn observation lifecycle), RFC-0038 (keeper identity canonical)

Co-Authored-By: Claude <noreply@anthropic.com>
