### PR TITLE
refactor(keeper): 생성 지점 없는 compaction rejection variant 제거

### DIFF
--- a/lib/keeper/keeper_compact_policy.mli
+++ b/lib/keeper/keeper_compact_policy.mli
@@ -17,8 +17,6 @@ type compaction_rejection =
   | Invalid_compaction_plan
   | Invalid_structure of Keeper_compaction_unit.structural_error
   | No_eligible_history
-  | Structurally_unchanged
-  | Checkpoint_not_reduced
   | Invalid_structural_evidence of
       Keeper_compaction_evidence.decode_error
       * Keeper_event_queue_state.exact_execution_terminal

--- a/lib/keeper/keeper_compact_rejection.ml
+++ b/lib/keeper/keeper_compact_rejection.ml
@@ -12,8 +12,6 @@ type compaction_rejection =
   | Invalid_compaction_plan
   | Invalid_structure of Keeper_compaction_unit.structural_error
   | No_eligible_history
-  | Structurally_unchanged
-  | Checkpoint_not_reduced
   | Invalid_structural_evidence of
       Keeper_compaction_evidence.decode_error
       * Keeper_event_queue_state.exact_execution_terminal
@@ -34,8 +32,6 @@ let compaction_rejection_to_tag = function
   | Invalid_structure error ->
     "invalid_structure:" ^ Keeper_compaction_unit.show_structural_error error
   | No_eligible_history -> "no_eligible_history"
-  | Structurally_unchanged -> "structurally_unchanged"
-  | Checkpoint_not_reduced -> "checkpoint_not_reduced"
   | Invalid_structural_evidence _ -> "invalid_structural_evidence"
 ;;
 

--- a/lib/keeper/keeper_compact_rejection.mli
+++ b/lib/keeper/keeper_compact_rejection.mli
@@ -12,8 +12,6 @@ type compaction_rejection =
   | Invalid_compaction_plan
   | Invalid_structure of Keeper_compaction_unit.structural_error
   | No_eligible_history
-  | Structurally_unchanged
-  | Checkpoint_not_reduced
   | Invalid_structural_evidence of
       Keeper_compaction_evidence.decode_error
       * Keeper_event_queue_state.exact_execution_terminal

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -457,10 +457,7 @@ let preserve_no_compaction_after_final_admission_busy = function
   | Keeper_event_queue_state.Exact_execution_terminal _ -> true
   | Keeper_event_queue_state.Exact_lane_unconfigured
   | Keeper_event_queue_state.No_eligible_history
-  | Keeper_event_queue_state.Invalid_structural_source
-  | Keeper_event_queue_state.Structurally_unchanged
-  | Keeper_event_queue_state.Checkpoint_not_reduced ->
-    false
+  | Keeper_event_queue_state.Invalid_structural_source -> false
 ;;
 
 let resolve_uncommitted = function

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -502,8 +502,6 @@ let rejection_disposition = function
   | Keeper_compact_policy.No_eligible_history ->
     Terminal_no_compaction Keeper_event_queue_state.No_eligible_history
   | Invalid_structure _ -> Terminal_no_compaction Invalid_structural_source
-  | Structurally_unchanged -> Terminal_no_compaction Structurally_unchanged
-  | Checkpoint_not_reduced -> Terminal_no_compaction Checkpoint_not_reduced
   | Exact_execution_terminal terminal ->
     Terminal_no_compaction
       (Keeper_event_queue_state.Exact_execution_terminal terminal)

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -73,8 +73,6 @@ type escalation_reason = Keeper_event_queue_persistence.escalation_reason =
 type no_compaction_reason = Keeper_event_queue_persistence.no_compaction_reason =
   | No_eligible_history
   | Invalid_structural_source
-  | Structurally_unchanged
-  | Checkpoint_not_reduced
   | Exact_lane_unconfigured
   | Exact_execution_terminal of exact_execution_terminal
 

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -64,8 +64,6 @@ type escalation_reason = Keeper_event_queue_persistence.escalation_reason =
 type no_compaction_reason = Keeper_event_queue_persistence.no_compaction_reason =
   | No_eligible_history
   | Invalid_structural_source
-  | Structurally_unchanged
-  | Checkpoint_not_reduced
   | Exact_lane_unconfigured
   | Exact_execution_terminal of exact_execution_terminal
 

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -49,9 +49,7 @@ let source_disposition_after_no_compaction
     Escalate_after_exact_output_terminal
       (Exact_execution_terminal { source; terminal })
   | ( Keeper_event_queue_state.No_eligible_history
-    | Keeper_event_queue_state.Invalid_structural_source
-    | Keeper_event_queue_state.Structurally_unchanged
-    | Keeper_event_queue_state.Checkpoint_not_reduced ) as reason ->
+    | Keeper_event_queue_state.Invalid_structural_source ) as reason ->
     Follow_failure_route_after_no_compaction { reason }
 ;;
 

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -86,8 +86,6 @@ type escalation_reason = State.escalation_reason =
 type no_compaction_reason = State.no_compaction_reason =
   | No_eligible_history
   | Invalid_structural_source
-  | Structurally_unchanged
-  | Checkpoint_not_reduced
   | Exact_lane_unconfigured
   | Exact_execution_terminal of exact_execution_terminal
 

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -96,8 +96,6 @@ type escalation_reason = Keeper_event_queue_state.escalation_reason =
 type no_compaction_reason = Keeper_event_queue_state.no_compaction_reason =
   | No_eligible_history
   | Invalid_structural_source
-  | Structurally_unchanged
-  | Checkpoint_not_reduced
   | Exact_lane_unconfigured
   | Exact_execution_terminal of exact_execution_terminal
 

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -76,8 +76,6 @@ type escalation_reason =
 type no_compaction_reason =
   | No_eligible_history
   | Invalid_structural_source
-  | Structurally_unchanged
-  | Checkpoint_not_reduced
   | Exact_lane_unconfigured
   | Exact_execution_terminal of exact_execution_terminal
 
@@ -928,8 +926,6 @@ let validate_transition = function
       { reason =
           ( No_eligible_history
           | Invalid_structural_source
-          | Structurally_unchanged
-          | Checkpoint_not_reduced
           | Exact_lane_unconfigured )
       ; _
       } ->
@@ -1467,8 +1463,6 @@ let int64_json value = `Intlit (Int64.to_string value)
 let no_compaction_reason_label = function
   | No_eligible_history -> "no_eligible_history"
   | Invalid_structural_source -> "invalid_structural_source"
-  | Structurally_unchanged -> "structurally_unchanged"
-  | Checkpoint_not_reduced -> "checkpoint_not_reduced"
   | Exact_lane_unconfigured -> "exact_lane_unconfigured"
   | Exact_execution_terminal terminal ->
     exact_execution_terminal_cause_label terminal.cause
@@ -1482,8 +1476,6 @@ let no_compaction_reason_to_string = function
 let no_compaction_reason_of_label = function
   | "no_eligible_history" -> Ok No_eligible_history
   | "invalid_structural_source" -> Ok Invalid_structural_source
-  | "structurally_unchanged" -> Ok Structurally_unchanged
-  | "checkpoint_not_reduced" -> Ok Checkpoint_not_reduced
   | "exact_lane_unconfigured" -> Ok Exact_lane_unconfigured
   | reason ->
     (match exact_execution_terminal_cause_of_label reason with
@@ -1838,8 +1830,6 @@ let transition_to_yojson = function
         fields @ [ "exact_execution", exact_execution_terminal_to_yojson terminal ]
       | No_eligible_history
       | Invalid_structural_source
-      | Structurally_unchanged
-      | Checkpoint_not_reduced
       | Exact_lane_unconfigured ->
         fields
     in

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -90,8 +90,6 @@ type escalation_reason =
 type no_compaction_reason =
   | No_eligible_history
   | Invalid_structural_source
-  | Structurally_unchanged
-  | Checkpoint_not_reduced
   | Exact_lane_unconfigured
       (** The configured runtime has no exact-output lane for compaction. This
           is an operator-actionable precondition failure tied to the durable

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -342,6 +342,37 @@ let test_retired_snapshot_and_wal_paths_are_not_read () =
       (In_channel.with_open_bin retired_wal_path In_channel.input_all))
 ;;
 
+(* The exact-output hard cut (#25596, 2026-07-23) removed every site that could
+   build [Structurally_unchanged] or [Checkpoint_not_reduced]; the variants then
+   sat orphaned across twelve files for a week. Deleting them means a record
+   persisted before that cut no longer decodes, so pin that the decoder reports
+   it as a typed error rather than crashing or silently substituting a reason.
+   Live check at removal time: zero such records existed under ~/.masc, and the
+   retired workspace carried the strings only in logs and transition-audit,
+   neither of which has a decode path. *)
+let test_retired_no_compaction_reasons_do_not_decode () =
+  List.iter
+    (fun label ->
+      match State.no_compaction_reason_of_label label with
+      | Ok _ ->
+        Alcotest.failf "retired no-compaction reason %s still decodes" label
+      | Error detail ->
+        Alcotest.(check string)
+          ("retired reason " ^ label ^ " is reported as unknown")
+          ("unknown no-compaction reason: " ^ label)
+          detail)
+    [ "structurally_unchanged"; "checkpoint_not_reduced" ];
+  (* The reasons that survived the cut still decode. *)
+  List.iter
+    (fun label ->
+      match State.no_compaction_reason_of_label label with
+      | Ok _ -> ()
+      | Error detail ->
+        Alcotest.failf "live no-compaction reason %s stopped decoding: %s" label detail)
+    [ "no_eligible_history"; "invalid_structural_source"; "exact_lane_unconfigured" ]
+;;
+
+
 let () =
   Alcotest.run
     "keeper pending queue current schema"
@@ -376,6 +407,10 @@ let () =
             "retired snapshot and WAL paths are not read"
             `Quick
             test_retired_snapshot_and_wal_paths_are_not_read
+        ; Alcotest.test_case
+            "retired no-compaction reasons do not decode"
+            `Quick
+            test_retired_no_compaction_reasons_do_not_decode
         ] )
     ]
 ;;


### PR DESCRIPTION
`Structurally_unchanged` / `Checkpoint_not_reduced`는 생성 지점이 없습니다. 12개 파일에 걸친 선언과 match arm만 남아 있습니다.

## 언제 고아가 됐나

`bcbbf7f2b9` (#25596, "refactor!: hard-cut MASC exact-output runtime flow", 2026-07-23)가 `keeper_compact_policy.ml`에서 마지막 생성 지점 두 곳을 지웠습니다:

```
-            then Error Structurally_unchanged
-    then reject Structurally_unchanged
```

그 이후 7일간 선언만 남았습니다. 로그가 이 시점을 확인해줍니다 — retired 워크스페이스의 07-20/21 로그에는 `reason=structurally_unchanged`가 있고, 현재 워크스페이스 07-28/29에는 0건입니다.

## 현재 상태

`lib/` 전체 34개 출현 중 **match arm이나 선언이 아닌 사용은 0건**입니다:

```
rg -n 'Structurally_unchanged|Checkpoint_not_reduced' lib/ --type ocaml \
  | rg -v '^\S+\.mli:' \
  | awk -F: '{l=$0; sub(/^[^:]*:[0-9]*:/,"",l); if (l !~ /^[[:space:]]*\|/) print}'
→ 0줄
```

## 디코더 삭제 근거

`no_compaction_reason_of_label`의 두 arm을 지우면 그 이전에 영속된 레코드는 디코드되지 않습니다. 삭제 전에 확인했습니다:

| 위치 | 결과 |
|---|---|
| `~/.masc` (repos/playground 제외) | **0건** |
| retired 워크스페이스 | `logs/`, `transition-audit/`에만 존재 |
| `transition-audit` 디코드 경로 | `rg 'transition_audit' lib/ \| rg -i 'read\|load\|of_json\|decode\|parse'` → **없음** |

그리고 디코더의 폴백은 이미 타입화된 에러입니다:

```ocaml
| reason -> ... Error (Printf.sprintf "unknown no-compaction reason: %s" reason)
```

크래시도, 조용한 대체도 아닙니다. 이 동작을 `test_keeper_event_queue_state_v2.ml`에 고정했습니다 — 두 옛 라벨은 정확한 문구의 `Error`를 내고, 살아남은 세 라벨(`no_eligible_history`, `invalid_structural_source`, `exact_lane_unconfigured`)은 계속 디코드됩니다.

## 범위

12파일, -37/+2. 컴파일러 주도 삭제이므로 누락은 빌드 에러로 드러납니다. `dune build --root .` 클린, 해당 테스트 4/4 통과.

`keeper_manual_compaction.ml`와 `keeper_unified_turn.ml` 두 곳은 삭제 대상 줄에 `->` / `) as reason ->`가 붙어 있어 arm 전체를 다시 썼습니다. 남는 생성자의 동작은 동일합니다(둘 다 `false` / `Follow_failure_route_after_no_compaction`).

RFC-WAIVED: credential/identity/operator-control/sandbox/hooks/workflow 중 어느 subsystem도 건드리지 않습니다. 죽은 variant 삭제와 그 디코더 arm 제거뿐입니다.

WORKAROUND-WAIVED: 증상 억제가 아니라 도달 불가능한 코드의 제거입니다. 새 게이트·카운터·문자열 분류기·텔레메트리를 추가하지 않으며, 동작 변화는 "이미 생성되지 않는 라벨이 디코드 시 타입화된 에러가 된다" 하나뿐이고 그것을 테스트로 고정했습니다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
