### PR TITLE
fix: cost ledger를 실제 runtime identity로 결합

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -823,6 +823,18 @@ jobs:
           oas_pin_targets="@test/runtest-test_keeper_hooks_oas_introspection @test/runtest-test_keeper_execution_join @test/runtest-test_hitl_summary_worker @test/runtest-test_librarian_exact_output_conformance"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${oas_pin_targets}"
 
+      - name: Run model inference metrics suite
+        id: model_inference_metrics_suite
+        if: ${{ always() && steps.build_step.outcome == 'success' }}
+        env:
+          ME_ROOT: /tmp/me
+          CI_TEST_HEARTBEAT_SEC: 15
+          DUNE_JOBS: 1
+        run: |
+          mkdir -p /tmp/me
+          chmod +x scripts/ci-run-tests.sh
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_model_inference_metrics"
+
       - name: Run tool blob retention suite
         id: tool_blob_retention_suite
         if: ${{ always() && steps.build_step.outcome == 'success' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 ## Unreleased
 
-- **Breaking (cost ledger storage/schema)**: `masc-cost` now writes and reports
-  only the current date-split `.masc/costs/YYYY-MM/DD.jsonl` store, matching the
-  Keeper producer and inference-metrics consumer. The retired
-  `.masc/costs.jsonl` reader and writer were removed, and current cost rows
-  require an explicit `usage_missing` boolean. Invalid current-store rows are
-  surfaced and excluded instead of receiving default tokens, cost, model, or
-  timestamp values. No migration or repair path was added.
+- **Breaking (cost ledger storage/schema)**: the Keeper producer, `masc-cost`,
+  and inference metrics now share one current row codec and the date-split
+  `.masc/costs/YYYY-MM/DD.jsonl` store. Automatic rows carry the runtime-owned
+  `(trace_id, keeper_turn_id, oas_turn_ordinal)` identity, so decision/cost
+  observations merge only on exact identity; nearby timestamps and equal token
+  counts no longer act as a deduplication rule. Windowed readers open only the
+  requested day range, and malformed rows, schema violations, or duplicate
+  identities remain explicit diagnostics. No alternate store, field-name
+  decoder, migration, or repair path is present.
 - **Breaking (approval snapshot wire)**: `summary_status.failed.retryable`
   is no longer accepted and discarded while loading pending approvals. Current
   snapshots contain only `status` and `reason`; snapshots carrying the retired

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@
   observations merge only on exact identity; nearby timestamps and equal token
   counts no longer act as a deduplication rule. Windowed readers open only the
   requested day range, and malformed rows, schema violations, or duplicate
-  identities remain explicit diagnostics. No alternate store, field-name
-  decoder, migration, or repair path is present.
+  identities remain explicit diagnostics. The `masc-cost --json` envelope now
+  uses `state` instead of `status`, and `by_agent[]` no longer emits one
+  misleading `model` value for aggregates that can span multiple models. No
+  alternate store, field-name decoder, migration, or repair path is present.
 - **Breaking (approval snapshot wire)**: `summary_status.failed.retryable`
   is no longer accepted and discarded while loading pending approvals. Current
   snapshots contain only `status` and `reason`; snapshots carrying the retired

--- a/bin/dune
+++ b/bin/dune
@@ -97,6 +97,7 @@
   masc_core
   masc.host_config
   masc.config_dir_resolver
+  masc.cost_ledger
   dated_jsonl
   unix
   yojson

--- a/bin/masc_cost.ml
+++ b/bin/masc_cost.ml
@@ -2,17 +2,9 @@
     Track token usage and costs per agent/task. *)
 
 open Printf
+open Cost_ledger
 
-type cost_entry =
-  { agent : string
-  ; task_id : string option
-  ; model : string
-  ; input_tokens : int option
-  ; output_tokens : int option
-  ; cost_usd : float option
-  ; timestamp : string
-  ; ts_unix : float
-  }
+type cost_entry = Cost_ledger.t
 
 type period =
   | Hourly
@@ -25,127 +17,19 @@ type agent_total =
   { agent : string
   ; tokens : int
   ; cost_usd : float
-  ; model : string
   ; usage_missing_entries : int
   }
 
 let ( let* ) = Result.bind
 
-let get_masc_root () =
-  let base_path = Config_dir_resolver.base_path_or_cwd () in
-  Config_dir_resolver.masc_root ~base_path
+let cost_store () =
+  Config_dir_resolver.base_path_or_cwd ()
+  |> fun base_path -> Cost_ledger.store_of_base_path ~base_path
 ;;
-
-let costs_dir () = Filename.concat (get_masc_root ()) "costs"
 
 let nonblank value =
   let trimmed = String.trim value in
   if String.equal trimmed "" then None else Some trimmed
-;;
-
-let required_string fields key =
-  match List.assoc_opt key fields with
-  | Some (`String value) ->
-    (match nonblank value with
-     | Some value -> Ok value
-     | None -> Error (key ^ " must be a non-empty string"))
-  | _ -> Error (key ^ " must be a non-empty string")
-;;
-
-let required_optional_string fields key =
-  match List.assoc_opt key fields with
-  | Some `Null -> Ok None
-  | Some (`String value) ->
-    (match nonblank value with
-     | Some value -> Ok (Some value)
-     | None -> Error (key ^ " must be null or a non-empty string"))
-  | _ -> Error (key ^ " must be null or a non-empty string")
-;;
-
-let required_bool fields key =
-  match List.assoc_opt key fields with
-  | Some (`Bool value) -> Ok value
-  | _ -> Error (key ^ " must be a boolean")
-;;
-
-let required_nonnegative_int fields key =
-  match List.assoc_opt key fields with
-  | Some (`Int value) when value >= 0 -> Ok value
-  | _ -> Error (key ^ " must be a non-negative integer")
-;;
-
-let required_nonnegative_float fields key =
-  let value =
-    match List.assoc_opt key fields with
-    | Some (`Float value) -> Some value
-    | Some (`Int value) -> Some (Float.of_int value)
-    | _ -> None
-  in
-  match value with
-  | Some value when Float.is_finite value && value >= 0.0 -> Ok value
-  | _ -> Error (key ^ " must be a finite non-negative number")
-;;
-
-let required_null fields key =
-  match List.assoc_opt key fields with
-  | Some `Null -> Ok ()
-  | _ -> Error (key ^ " must be null when usage_missing is true")
-;;
-
-let parse_cost_json = function
-  | `Assoc fields ->
-    let* agent = required_string fields "agent" in
-    let* task_id = required_optional_string fields "task_id" in
-    let* model = required_string fields "model" in
-    let* timestamp = required_string fields "timestamp" in
-    let* _source = required_string fields "source" in
-    let* usage_missing = required_bool fields "usage_missing" in
-    let* ts_unix =
-      match Masc_domain.parse_iso8601_opt timestamp with
-      | Some value -> Ok value
-      | None -> Error "timestamp must be a valid ISO-8601 UTC value"
-    in
-    let* input_tokens, output_tokens, cost_usd =
-      if usage_missing
-      then (
-        let* () = required_null fields "input_tokens" in
-        let* () = required_null fields "output_tokens" in
-        let* () = required_null fields "cost_usd" in
-        Ok (None, None, None))
-      else (
-        let* input_tokens = required_nonnegative_int fields "input_tokens" in
-        let* output_tokens = required_nonnegative_int fields "output_tokens" in
-        let* cost_usd = required_nonnegative_float fields "cost_usd" in
-        Ok (Some input_tokens, Some output_tokens, Some cost_usd))
-    in
-    Ok
-      { agent
-      ; task_id
-      ; model
-      ; input_tokens
-      ; output_tokens
-      ; cost_usd
-      ; timestamp
-      ; ts_unix
-      }
-  | _ -> Error "cost row must be a JSON object"
-;;
-
-let cost_json ~agent ~task_id ~model ~input_tokens ~output_tokens ~cost_usd =
-  `Assoc
-    [ "agent", `String agent
-    ; ( "task_id"
-      , match task_id with
-        | Some value -> `String value
-        | None -> `Null )
-    ; "model", `String model
-    ; "input_tokens", `Int input_tokens
-    ; "output_tokens", `Int output_tokens
-    ; "cost_usd", `Float cost_usd
-    ; "usage_missing", `Bool false
-    ; "timestamp", `String (Masc_domain.now_iso ())
-    ; "source", `String "manual_cli"
-    ]
 ;;
 
 let validate_log_input ~agent ~model ~input_tokens ~output_tokens ~cost_usd =
@@ -163,11 +47,35 @@ let validate_log_input ~agent ~model ~input_tokens ~output_tokens ~cost_usd =
 ;;
 
 let log_cost ~agent ~task_id ~model ~input_tokens ~output_tokens ~cost_usd =
-  let store = Dated_jsonl.create ~base_dir:(costs_dir ()) () in
-  Dated_jsonl.append
-    store
-    (cost_json ~agent ~task_id ~model ~input_tokens ~output_tokens ~cost_usd);
-  printf "Cost logged: %s → $%.4f\n" agent cost_usd
+  let now = Time_compat.now () in
+  let row : Cost_ledger.t =
+    { agent
+    ; task_id
+    ; model
+    ; usage =
+        Usage_reported
+          { input_tokens
+          ; output_tokens
+          ; cost_usd
+          }
+    ; timestamp = Masc_domain.iso8601_of_unix_seconds now
+    ; ts_unix = now
+    ; source = Manual_cli
+    }
+  in
+  let store = cost_store () in
+  try
+    Dated_jsonl.append store (Cost_ledger.to_json row);
+    printf "Cost logged: %s → $%.4f\n" agent cost_usd;
+    Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as error -> raise error
+  | exn ->
+    Error
+      (sprintf
+         "failed to append cost row under %s: %s"
+         (Dated_jsonl.base_dir store)
+         (Printexc.to_string exn))
 ;;
 
 let line_label path line_number =
@@ -176,24 +84,45 @@ let line_label path line_number =
   | None -> path
 ;;
 
-let read_costs () =
-  let store = Dated_jsonl.create ~base_dir:(costs_dir ()) () in
+let period_cutoff now = function
+  | Hourly -> now -. 3600.0
+  | Daily -> now -. 86400.0
+  | Weekly -> now -. 604800.0
+  | Monthly -> now -. 2592000.0
+  | All -> 0.0
+;;
+
+let read_costs period =
+  let store = cost_store () in
   let entries = ref [] in
   let invalid_rows = ref 0 in
   let note_invalid location reason =
     incr invalid_rows;
     eprintf "Warning: skipped invalid cost row at %s: %s\n" location reason
   in
-  match
-    Dated_jsonl.iter_all_entries_result store (function
-      | Dated_jsonl.Malformed_json { path; line_number; detail } ->
-        note_invalid (line_label path line_number) detail
-      | Dated_jsonl.Parsed json ->
-        (match parse_cost_json json with
-         | Ok entry -> entries := entry :: !entries
-         | Error reason ->
-           note_invalid (Dated_jsonl.base_dir store) reason))
-  with
+  let consume = function
+    | Dated_jsonl.Malformed_json { path; line_number; detail } ->
+      note_invalid (line_label path line_number) detail
+    | Dated_jsonl.Parsed json ->
+      (match Cost_ledger.of_json json with
+       | Ok entry -> entries := entry :: !entries
+       | Error error ->
+         note_invalid
+           (Dated_jsonl.base_dir store)
+           (Cost_ledger.decode_error_to_string error))
+  in
+  let read_result =
+    match period with
+    | All -> Dated_jsonl.iter_all_entries_result store consume
+    | Hourly | Daily | Weekly | Monthly ->
+      let now = Time_compat.now () in
+      Dated_jsonl.iter_range_entries_result
+        store
+        ~since:(Log.format_utc_date_of (period_cutoff now period))
+        ~until:(Log.format_utc_date_of now)
+        consume
+  in
+  match read_result with
   | Ok () -> Ok (List.rev !entries, !invalid_rows)
   | Error error -> Error (Dated_jsonl.read_error_to_string error)
 ;;
@@ -220,16 +149,11 @@ let period_label = function
 ;;
 
 let filter_by_period period (entries : cost_entry list) =
-  let now = Unix.gettimeofday () in
-  let cutoff =
-    match period with
-    | Hourly -> now -. 3600.0
-    | Daily -> now -. 86400.0
-    | Weekly -> now -. 604800.0
-    | Monthly -> now -. 2592000.0
-    | All -> 0.0
-  in
-  List.filter (fun (entry : cost_entry) -> entry.ts_unix >= cutoff) entries
+  match period with
+  | All -> entries
+  | Hourly | Daily | Weekly | Monthly ->
+    let cutoff = period_cutoff (Time_compat.now ()) period in
+    List.filter (fun (entry : cost_entry) -> entry.ts_unix >= cutoff) entries
 ;;
 
 let filter_by_agent agent (entries : cost_entry list) =
@@ -246,27 +170,22 @@ let filter_by_task task_id (entries : cost_entry list) =
 ;;
 
 let known_tokens (entry : cost_entry) =
-  let input =
-    match entry.input_tokens with
-    | Some value -> value
-    | None -> 0
-  in
-  let output =
-    match entry.output_tokens with
-    | Some value -> value
-    | None -> 0
-  in
-  input + output
+  match entry.usage with
+  | Usage_missing -> 0
+  | Usage_reported { input_tokens; output_tokens; _ } ->
+    input_tokens + output_tokens
 ;;
 
 let known_cost (entry : cost_entry) =
-  match entry.cost_usd with
-  | Some value -> value
-  | None -> 0.0
+  match entry.usage with
+  | Usage_missing -> 0.0
+  | Usage_reported { cost_usd; _ } -> cost_usd
 ;;
 
 let usage_missing (entry : cost_entry) =
-  entry.input_tokens = None || entry.output_tokens = None || entry.cost_usd = None
+  match entry.usage with
+  | Usage_missing -> true
+  | Usage_reported _ -> false
 ;;
 
 let aggregate_by_agent (entries : cost_entry list) =
@@ -280,7 +199,6 @@ let aggregate_by_agent (entries : cost_entry list) =
            { agent = entry.agent
            ; tokens = 0
            ; cost_usd = 0.0
-           ; model = entry.model
            ; usage_missing_entries = 0
            }
        in
@@ -297,10 +215,13 @@ let aggregate_by_agent (entries : cost_entry list) =
          })
     entries;
   Hashtbl.fold (fun _ value acc -> value :: acc) totals []
+  |> List.sort (fun left right ->
+    let by_cost = Float.compare right.cost_usd left.cost_usd in
+    if by_cost <> 0 then by_cost else String.compare left.agent right.agent)
 ;;
 
 let filtered_costs ~agent ~task_id ~period =
-  let* entries, invalid_rows = read_costs () in
+  let* entries, invalid_rows = read_costs period in
   Ok
     ( entries
       |> filter_by_period period
@@ -341,7 +262,6 @@ let print_report ~agent ~task_id ~period =
     printf "╠══════════════════════════════════════════════╣\n";
     printf "║  📊 By Agent:                              \n";
     by_agent
-    |> List.sort (fun left right -> Float.compare right.cost_usd left.cost_usd)
     |> List.iter (fun total ->
       let pct =
         if total_cost > 0.0 then total.cost_usd /. total_cost *. 100.0 else 0.0
@@ -364,7 +284,6 @@ let agent_total_to_json total =
     [ "agent", `String total.agent
     ; "tokens_known", `Int total.tokens
     ; "cost_usd_known", `Float total.cost_usd
-    ; "model", `String total.model
     ; "usage_missing_entries", `Int total.usage_missing_entries
     ]
 ;;
@@ -449,13 +368,17 @@ let run () =
          | Some value -> Some value
          | None -> None
        in
-       log_cost
-         ~agent:(String.trim !agent)
-         ~task_id
-         ~model:(String.trim !model)
-         ~input_tokens:!input_tokens
-         ~output_tokens:!output_tokens
-         ~cost_usd:!cost_usd)
+       (match
+          log_cost
+            ~agent:(String.trim !agent)
+            ~task_id
+            ~model:(String.trim !model)
+            ~input_tokens:!input_tokens
+            ~output_tokens:!output_tokens
+            ~cost_usd:!cost_usd
+        with
+        | Ok () -> ()
+        | Error message -> fatal message))
   | Report ->
     (match period_of_string !period with
      | Error message -> fatal message

--- a/lib/core/json_util.ml
+++ b/lib/core/json_util.ml
@@ -203,14 +203,6 @@ let bool_opt_to_json : bool option -> Yojson.Safe.t = function
 let string_opt_field name (opt : string option) : string * Yojson.Safe.t =
   (name, string_opt_to_json opt)
 
-let assoc_with_status status fields : Yojson.Safe.t =
-  let fields =
-    List.filter (fun (key, _) -> not (String.equal key "status")) fields
-  in
-  `Assoc (("status", `String status) :: fields)
-
-let ok_assoc fields = assoc_with_status "ok" fields
-let error_assoc fields = assoc_with_status "error" fields
 
 (** {1 Assoc field extraction}
 

--- a/lib/core/json_util.mli
+++ b/lib/core/json_util.mli
@@ -67,15 +67,6 @@ val int_option_to_yojson : int option -> Yojson.Safe.t
 val string_option_to_yojson : string option -> Yojson.Safe.t
 (** [string_option_to_yojson] maps [Some s] to [`String s] or [None] to [`Null]. *)
 
-(** [ok_assoc fields] constructs the canonical JSON success envelope.
-    A caller-supplied [status] field is discarded so it cannot override
-    the required ["ok"] status. *)
-val ok_assoc : (string * Yojson.Safe.t) list -> Yojson.Safe.t
-
-(** [error_assoc fields] constructs the canonical JSON error envelope.
-    A caller-supplied [status] field is discarded so it cannot override
-    the required ["error"] status. *)
-val error_assoc : (string * Yojson.Safe.t) list -> Yojson.Safe.t
 
 (** {1 Diagnostic helpers} *)
 

--- a/lib/cost_ledger/cost_ledger.ml
+++ b/lib/cost_ledger/cost_ledger.ml
@@ -1,0 +1,255 @@
+type inference_identity =
+  { trace_id : string
+  ; keeper_turn_id : int
+  ; oas_turn_ordinal : int
+  }
+
+type source =
+  | Manual_cli
+  | Auto_trajectory of inference_identity
+
+type usage =
+  | Usage_missing
+  | Usage_reported of
+      { input_tokens : int
+      ; output_tokens : int
+      ; cost_usd : float
+      }
+
+type t =
+  { agent : string
+  ; task_id : string option
+  ; model : string
+  ; usage : usage
+  ; timestamp : string
+  ; ts_unix : float
+  ; source : source
+  }
+
+type decode_error =
+  { field : string
+  ; expectation : string
+  }
+
+let ( let* ) = Result.bind
+
+let decode_error_to_string error =
+  Printf.sprintf "%s %s" error.field error.expectation
+;;
+
+let invalid field expectation = Error { field; expectation }
+
+let nonblank value =
+  let value = String.trim value in
+  if String.equal value "" then None else Some value
+;;
+
+let required_string fields key =
+  match List.assoc_opt key fields with
+  | Some (`String value) ->
+    (match nonblank value with
+     | Some value -> Ok value
+     | None -> invalid key "must be a non-empty string")
+  | _ -> invalid key "must be a non-empty string"
+;;
+
+let required_nullable_string fields key =
+  match List.assoc_opt key fields with
+  | Some `Null -> Ok None
+  | Some (`String value) ->
+    (match nonblank value with
+     | Some value -> Ok (Some value)
+     | None -> invalid key "must be null or a non-empty string")
+  | _ -> invalid key "must be null or a non-empty string"
+;;
+
+let required_bool fields key =
+  match List.assoc_opt key fields with
+  | Some (`Bool value) -> Ok value
+  | _ -> invalid key "must be a boolean"
+;;
+
+let required_int fields key =
+  match List.assoc_opt key fields with
+  | Some (`Int value) -> Ok value
+  | _ -> invalid key "must be an integer"
+;;
+
+let required_positive_int fields key =
+  let* value = required_int fields key in
+  if value > 0 then Ok value else invalid key "must be a positive integer"
+;;
+
+let required_nonnegative_int fields key =
+  let* value = required_int fields key in
+  if value >= 0 then Ok value else invalid key "must be a non-negative integer"
+;;
+
+let required_finite_float fields key =
+  let value =
+    match List.assoc_opt key fields with
+    | Some (`Float value) -> Some value
+    | Some (`Int value) -> Some (Float.of_int value)
+    | _ -> None
+  in
+  match value with
+  | Some value when Float.is_finite value -> Ok value
+  | _ -> invalid key "must be a finite number"
+;;
+
+let required_null fields key =
+  match List.assoc_opt key fields with
+  | Some `Null -> Ok ()
+  | _ -> invalid key "must be null"
+;;
+
+let source_to_string = function
+  | Manual_cli -> "manual_cli"
+  | Auto_trajectory _ -> "auto_trajectory"
+;;
+
+let compare_inference_identity left right =
+  let by_trace = String.compare left.trace_id right.trace_id in
+  if by_trace <> 0
+  then by_trace
+  else (
+    let by_keeper_turn = Int.compare left.keeper_turn_id right.keeper_turn_id in
+    if by_keeper_turn <> 0
+    then by_keeper_turn
+    else Int.compare left.oas_turn_ordinal right.oas_turn_ordinal)
+;;
+
+let inference_identity row =
+  match row.source with
+  | Manual_cli -> None
+  | Auto_trajectory identity -> Some identity
+;;
+
+let source_of_fields fields =
+  let* source = required_string fields "source" in
+  match source with
+  | "manual_cli" ->
+    let* () = required_null fields "trace_id" in
+    let* () = required_null fields "keeper_turn_id" in
+    let* () = required_null fields "oas_turn_ordinal" in
+    Ok Manual_cli
+  | "auto_trajectory" ->
+    let* trace_id = required_string fields "trace_id" in
+    let* keeper_turn_id = required_positive_int fields "keeper_turn_id" in
+    let* oas_turn_ordinal =
+      required_nonnegative_int fields "oas_turn_ordinal"
+    in
+    Ok (Auto_trajectory { trace_id; keeper_turn_id; oas_turn_ordinal })
+  | _ -> invalid "source" "must be manual_cli or auto_trajectory"
+;;
+
+let usage_of_fields fields source =
+  let* usage_missing = required_bool fields "usage_missing" in
+  if usage_missing
+  then (
+    match source with
+    | Manual_cli -> invalid "usage_missing" "must be false for manual_cli"
+    | Auto_trajectory _ ->
+      let* () = required_null fields "input_tokens" in
+      let* () = required_null fields "output_tokens" in
+      let* () = required_null fields "cost_usd" in
+      Ok Usage_missing)
+  else (
+    let* input_tokens = required_int fields "input_tokens" in
+    let* output_tokens = required_int fields "output_tokens" in
+    let* cost_usd = required_finite_float fields "cost_usd" in
+    match source with
+    | Manual_cli
+      when input_tokens < 0 || output_tokens < 0 || Float.compare cost_usd 0.0 < 0 ->
+      invalid
+        "manual_cli usage"
+        "must contain non-negative token counts and cost_usd"
+    | Manual_cli | Auto_trajectory _ ->
+      Ok (Usage_reported { input_tokens; output_tokens; cost_usd }))
+;;
+
+let of_json = function
+  | `Assoc fields ->
+    let* agent = required_string fields "agent" in
+    let* task_id = required_nullable_string fields "task_id" in
+    let* model = required_string fields "model" in
+    let* timestamp = required_string fields "timestamp" in
+    let* ts_unix =
+      match Masc_domain.parse_iso8601_opt timestamp with
+      | Some value -> Ok value
+      | None -> invalid "timestamp" "must be a valid ISO-8601 value"
+    in
+    let* source = source_of_fields fields in
+    let* usage = usage_of_fields fields source in
+    Ok { agent; task_id; model; usage; timestamp; ts_unix; source }
+  | _ -> invalid "cost row" "must be a JSON object"
+;;
+
+let reserved_fields =
+  [ "agent"
+  ; "task_id"
+  ; "model"
+  ; "input_tokens"
+  ; "output_tokens"
+  ; "cost_usd"
+  ; "usage_missing"
+  ; "timestamp"
+  ; "ts_unix"
+  ; "source"
+  ; "trace_id"
+  ; "keeper_turn_id"
+  ; "oas_turn_ordinal"
+  ]
+;;
+
+let to_json ?(extra_fields = []) row =
+  let input_tokens, output_tokens, cost_usd, usage_missing =
+    match row.usage with
+    | Usage_missing -> `Null, `Null, `Null, true
+    | Usage_reported { input_tokens; output_tokens; cost_usd } ->
+      `Int input_tokens, `Int output_tokens, `Float cost_usd, false
+  in
+  let trace_id, keeper_turn_id, oas_turn_ordinal =
+    match row.source with
+    | Manual_cli -> `Null, `Null, `Null
+    | Auto_trajectory identity ->
+      ( `String identity.trace_id
+      , `Int identity.keeper_turn_id
+      , `Int identity.oas_turn_ordinal )
+  in
+  let extra_fields =
+    List.filter
+      (fun (key, _) -> not (List.mem key reserved_fields))
+      extra_fields
+  in
+  `Assoc
+    ([ "agent", `String row.agent
+     ; "task_id", Json_util.string_opt_to_json row.task_id
+     ; "model", `String row.model
+     ; "input_tokens", input_tokens
+     ; "output_tokens", output_tokens
+     ; "cost_usd", cost_usd
+     ; "usage_missing", `Bool usage_missing
+     ; "timestamp", `String row.timestamp
+     ; "source", `String (source_to_string row.source)
+     ; "trace_id", trace_id
+     ; "keeper_turn_id", keeper_turn_id
+     ; "oas_turn_ordinal", oas_turn_ordinal
+     ]
+     @ extra_fields)
+;;
+
+let directory_name = "costs"
+let dir_of_masc_root masc_root = Filename.concat masc_root directory_name
+
+let dir_of_base_path ~base_path =
+  dir_of_masc_root (Common.masc_dir_from_base_path ~base_path)
+;;
+
+let store_of_masc_root masc_root =
+  Dated_jsonl.create ~base_dir:(dir_of_masc_root masc_root) ()
+;;
+
+let store_of_base_path ~base_path =
+  Dated_jsonl.create ~base_dir:(dir_of_base_path ~base_path) ()
+;;

--- a/lib/cost_ledger/cost_ledger.mli
+++ b/lib/cost_ledger/cost_ledger.mli
@@ -1,0 +1,57 @@
+(** Current cost-ledger row and store contract.
+
+    This module owns the single current wire decoder used by the manual CLI
+    and inference metrics. It does not read or translate alternate stores or
+    field names. *)
+
+(** Runtime-owned identity for one inference. [oas_turn_ordinal] is the exact
+    zero-based ordinal carried by OAS [AfterTurn], not a value reconstructed
+    from a completed-turn count. *)
+type inference_identity =
+  { trace_id : string
+  ; keeper_turn_id : int
+  ; oas_turn_ordinal : int
+  }
+
+type source =
+  | Manual_cli
+  | Auto_trajectory of inference_identity
+
+type usage =
+  | Usage_missing
+  | Usage_reported of
+      { input_tokens : int
+      ; output_tokens : int
+      ; cost_usd : float
+      }
+
+type t =
+  { agent : string
+  ; task_id : string option
+  ; model : string
+  ; usage : usage
+  ; timestamp : string
+  ; ts_unix : float
+  ; source : source
+  }
+
+type decode_error
+
+val decode_error_to_string : decode_error -> string
+val source_to_string : source -> string
+val compare_inference_identity : inference_identity -> inference_identity -> int
+val inference_identity : t -> inference_identity option
+
+val to_json :
+  ?extra_fields:(string * Yojson.Safe.t) list -> t -> Yojson.Safe.t
+(** Serialize the current row. Required contract fields always win over
+    caller-supplied [extra_fields]. *)
+
+val of_json : Yojson.Safe.t -> (t, decode_error) result
+(** Decode only the current row contract. *)
+
+val directory_name : string
+val dir_of_masc_root : string -> string
+val dir_of_base_path : base_path:string -> string
+val store_of_masc_root : string -> Dated_jsonl.t
+val store_of_base_path : base_path:string -> Dated_jsonl.t

--- a/lib/cost_ledger/dune
+++ b/lib/cost_ledger/dune
@@ -1,0 +1,12 @@
+(include_subdirs no)
+
+(library
+ (name masc_cost_ledger)
+ (public_name masc.cost_ledger)
+ (wrapped false)
+ (modules cost_ledger)
+ (libraries
+  dated_jsonl
+  masc_core
+  masc_types
+  yojson))

--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -42,6 +42,10 @@ type non_regular_file_kind =
 
 type read_error =
   | Invalid_offset of { offset : int }
+  | Invalid_date_range of
+      { since : string
+      ; until : string
+      }
   | Not_a_directory of { path : string }
   | Invalid_layout_entry of
       { parent : string
@@ -90,6 +94,11 @@ let non_regular_file_kind_to_string = function
 let read_error_to_string = function
   | Invalid_offset { offset } ->
     Printf.sprintf "dated JSONL recent-read offset must be non-negative: %d" offset
+  | Invalid_date_range { since; until } ->
+    Printf.sprintf
+      "dated JSONL range must be valid and ordered: since=%S until=%S"
+      since
+      until
   | Not_a_directory { path } -> "dated JSONL path is not a directory: " ^ path
   | Invalid_layout_entry { parent; entry; expected } ->
     Printf.sprintf
@@ -166,12 +175,49 @@ let base_dir t = t.base_dir
 
 (** Parse ["YYYY-MM-DD"] into [("YYYY-MM", "DD")].
     Returns [None] for malformed strings. *)
+let year_is_leap year =
+  year mod 4 = 0 && (year mod 100 <> 0 || year mod 400 = 0)
+;;
+
+let days_in_month ~year = function
+  | 1 | 3 | 5 | 7 | 8 | 10 | 12 -> Some 31
+  | 4 | 6 | 9 | 11 -> Some 30
+  | 2 -> Some (if year_is_leap year then 29 else 28)
+  | _ -> None
+;;
+
+let substring_is_ascii_digits value ~position ~length =
+  let rec loop index =
+    if index >= position + length
+    then true
+    else
+      match value.[index] with
+      | '0' .. '9' -> loop (index + 1)
+      | _ -> false
+  in
+  loop position
+;;
+
 let parse_date s =
-  if String.length s < 10 then None
+  if String.length s <> 10
+     || s.[4] <> '-'
+     || s.[7] <> '-'
+     || not (substring_is_ascii_digits s ~position:0 ~length:4)
+     || not (substring_is_ascii_digits s ~position:5 ~length:2)
+     || not (substring_is_ascii_digits s ~position:8 ~length:2)
+  then None
   else
-    let month = String.sub s 0 7 in
-    let day = String.sub s 8 2 in
-    Some (month, day)
+    match
+      int_of_string_opt (String.sub s 0 4),
+      int_of_string_opt (String.sub s 5 2),
+      int_of_string_opt (String.sub s 8 2)
+    with
+    | Some year, Some month, Some day ->
+      (match days_in_month ~year month with
+       | Some maximum when day >= 1 && day <= maximum ->
+         Some (String.sub s 0 7, String.sub s 8 2)
+       | Some _ | None -> None)
+    | _ -> None
 
 (* ── Directory listing (sorted descending) ────────────── *)
 
@@ -247,18 +293,6 @@ let list_directory_result ~missing_is_empty path =
        Error (Io_error { operation = List_directory; path; detail }))
 ;;
 
-let substring_is_ascii_digits value ~position ~length =
-  let rec loop index =
-    if index >= position + length
-    then true
-    else
-      match value.[index] with
-      | '0' .. '9' -> loop (index + 1)
-      | _ -> false
-  in
-  loop position
-;;
-
 let year_and_month_of_directory_name name =
   if String.length name = 7
      && name.[4] = '-'
@@ -276,17 +310,6 @@ let year_and_month_of_directory_name name =
 
 let month_directory_name_is_valid name =
   Option.is_some (year_and_month_of_directory_name name)
-;;
-
-let year_is_leap year =
-  year mod 4 = 0 && (year mod 100 <> 0 || year mod 400 = 0)
-;;
-
-let days_in_month ~year = function
-  | 1 | 3 | 5 | 7 | 8 | 10 | 12 -> Some 31
-  | 4 | 6 | 9 | 11 -> Some 30
-  | 2 -> Some (if year_is_leap year then 29 else 28)
-  | _ -> None
 ;;
 
 let day_file_name_is_valid ~year ~month name =
@@ -875,6 +898,68 @@ let iter_all_entries_result t f =
   in
   let* months = list_month_dirs_result t.base_dir in
   iter_months (List.rev months)
+;;
+
+let iter_range_entries_result t ~since ~until f =
+  let ( let* ) = Result.bind in
+  match parse_date since, parse_date until with
+  | None, _ | _, None -> Error (Invalid_date_range { since; until })
+  | Some (since_month, since_day), Some (until_month, until_day)
+    when String.compare (since_month ^ since_day) (until_month ^ until_day) > 0 ->
+    Error (Invalid_date_range { since; until })
+  | Some (since_month, since_day), Some (until_month, until_day) ->
+    let month_in_range month =
+      String.compare month since_month >= 0
+      && String.compare month until_month <= 0
+    in
+    let day_in_range month day =
+      let day_number = Filename.remove_extension day in
+      not
+        ((String.equal month since_month
+          && String.compare day_number since_day < 0)
+         || (String.equal month until_month
+             && String.compare day_number until_day > 0))
+    in
+    let rec iter_days month month_path = function
+      | [] -> Ok ()
+      | day :: rest ->
+        let* () =
+          if day_in_range month day
+          then
+            iter_json_file_entries_result
+              (Filename.concat month_path day)
+              f
+          else Ok ()
+        in
+        iter_days month month_path rest
+    in
+    let rec iter_months = function
+      | [] -> Ok ()
+      | (month, year, month_number) :: rest ->
+        let month_path = Filename.concat t.base_dir month in
+        let* days =
+          list_directory_result ~missing_is_empty:false month_path
+        in
+        let selected_days =
+          days
+          |> List.filter (day_file_name_is_valid ~year ~month:month_number)
+          |> List.filter (day_in_range month)
+          |> List.rev
+        in
+        let* () = iter_days month month_path selected_days in
+        iter_months rest
+    in
+    let* entries =
+      list_directory_result ~missing_is_empty:true t.base_dir
+    in
+    entries
+    |> List.filter_map (fun month ->
+      match year_and_month_of_directory_name month with
+      | Some (year, month_number) when month_in_range month ->
+        Some (month, year, month_number)
+      | Some _ | None -> None)
+    |> List.rev
+    |> iter_months
 ;;
 
 let iter_range t ~since ~until f =

--- a/lib/dated_jsonl/dated_jsonl.mli
+++ b/lib/dated_jsonl/dated_jsonl.mli
@@ -27,6 +27,10 @@ type non_regular_file_kind =
 
 type read_error =
   | Invalid_offset of { offset : int }
+  | Invalid_date_range of
+      { since : string
+      ; until : string
+      }
   | Not_a_directory of { path : string }
   | Invalid_layout_entry of
       { parent : string
@@ -139,6 +143,19 @@ val iter_all_entries_result :
     iteration. The same closed layout and regular-file boundary as
     {!read_recent_result} applies; storage failures are returned explicitly.
     Missing stores are empty. *)
+
+val iter_range_entries_result :
+  t ->
+  since:string ->
+  until:string ->
+  (recent_entry -> unit) ->
+  (unit, read_error) result
+(** Strict chronological iteration over day files in the inclusive
+    [[since, until]] range. JSON syntax failures are delivered as
+    {!Malformed_json}; invalid ranges and selected-path storage failures are
+    returned explicitly. Entries that are not valid dated paths are outside
+    the requested range and do not gate the read. Files outside the requested
+    day range are not opened. *)
 
 val iter_range : t -> since:string -> until:string -> (Yojson.Safe.t -> unit) -> unit
 (** Streaming variant of {!read_range}. Invalid dates iterate zero rows. *)

--- a/lib/dune
+++ b/lib/dune
@@ -101,6 +101,7 @@
   masc.keeper_types
   masc.keeper_types_profile_sandbox
   masc.keeper_usage_trust
+  masc.cost_ledger
   masc.event_bus_slots
   masc.keeper_compaction_evidence
   masc.keeper_chat_delivery_identity

--- a/lib/keeper/keeper_agent_result.ml
+++ b/lib/keeper/keeper_agent_result.ml
@@ -76,6 +76,7 @@ type run_result =
   ; ctx_composition : ctx_composition_metrics
   ; runtime_observation : Runtime_observation.runtime_observation option
   ; turn_count : int
+  ; final_oas_turn_ordinal : int
   ; usage : Agent_sdk.Types.api_usage
   ; usage_reported : bool
   ; tool_calls : tool_call_detail list

--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -31,6 +31,7 @@ type run_result =
   ; ctx_composition : Keeper_agent_prompt_metrics.ctx_composition_metrics
   ; runtime_observation : Runtime_observation.runtime_observation option
   ; turn_count : int
+  ; final_oas_turn_ordinal : int
   ; usage : Agent_sdk.Types.api_usage
   ; usage_reported : bool
   ; tool_calls : tool_call_detail list

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -563,6 +563,7 @@ let run_turn
       ~context_injector
       ~start_turn_count
       ~generation
+      ~keeper_turn_id:manifest_keeper_turn_id
       ~runtime_id
       ~is_retry
       ~config_root
@@ -648,6 +649,9 @@ let run_turn
     in
     let acc = s.Keeper_run_tools.acc in
     let agent_ref : Agent_sdk.Agent.t option ref = ref None in
+    let final_oas_turn_ordinal_ref =
+      s.Keeper_run_tools.final_oas_turn_ordinal_ref
+    in
     let receipt_turn_count_ref = s.Keeper_run_tools.receipt_turn_count_ref in
     let receipt_model_used_ref = s.Keeper_run_tools.receipt_model_used_ref in
     let receipt_stop_reason_ref = s.Keeper_run_tools.receipt_stop_reason_ref in
@@ -917,37 +921,46 @@ let run_turn
                       with
                       | Error e -> Error e
                       | Ok response_text ->
-                        Keeper_agent_run_finalize_response.finalize
-                          ~config ~meta ~generation ~manifest_keeper_turn_id
-                          ~session ~append_manifest ~model
-                          ~acc
-                          ~actual_keeper_tool_names
-                          ~user_turn_record
-                          ~result ~checkpoint_persistence_error
-                          ~post_turn_t0 ~runtime_id_string
-                          ~history_messages
-                          ~prompt_metrics ~ctx_composition ~usage
-                          ~receipt_response_text_present_ref ~history_assistant_source
-                          ~raw_response_text:response_text
-                          ?continuation_delivery_channel
-                          ~capture_replay_response:
-                            (fun ~response_text ->
-                              (* Phase O observability: capture the exact
-                                 assistant text persisted for next-turn replay,
-                                 after response finalization has applied
-                                 suppression and internal-markup stripping. The
-                                 capture is best-effort and gated by
-                                 MASC_KEEPER_WIRE_CAPTURE. *)
-                              Keeper_wire_capture.capture_response
-                                ~base_path:config.base_path
-                                ~masc_root:(Workspace.masc_root_dir config)
-                                ~keeper_name:meta.name
-                                ~turn_id:manifest_keeper_turn_id
-                                ~sdk_turn:result.turns
-                                ~trace_id:meta.runtime.trace_id
-                                ~response_text
-                                ())
-                          ()))
+                        (match !final_oas_turn_ordinal_ref with
+                         | None ->
+                           Error
+                             (Agent_sdk.Error.Internal
+                                "successful Agent.run returned without an \
+                                 AfterTurn ordinal")
+                         | Some final_oas_turn_ordinal ->
+                           Keeper_agent_run_finalize_response.finalize
+                             ~config ~meta ~generation ~manifest_keeper_turn_id
+                             ~session ~append_manifest ~model
+                             ~acc
+                             ~actual_keeper_tool_names
+                             ~user_turn_record
+                             ~result ~final_oas_turn_ordinal
+                             ~checkpoint_persistence_error
+                             ~post_turn_t0 ~runtime_id_string
+                             ~history_messages
+                             ~prompt_metrics ~ctx_composition ~usage
+                             ~receipt_response_text_present_ref
+                             ~history_assistant_source
+                             ~raw_response_text:response_text
+                             ?continuation_delivery_channel
+                             ~capture_replay_response:
+                               (fun ~response_text ->
+                                 (* Phase O observability: capture the exact
+                                    assistant text persisted for next-turn replay,
+                                    after response finalization has applied
+                                    suppression and internal-markup stripping. The
+                                    capture is best-effort and gated by
+                                    MASC_KEEPER_WIRE_CAPTURE. *)
+                                 Keeper_wire_capture.capture_response
+                                   ~base_path:config.base_path
+                                   ~masc_root:(Workspace.masc_root_dir config)
+                                   ~keeper_name:meta.name
+                                   ~turn_id:manifest_keeper_turn_id
+                                   ~sdk_turn:result.turns
+                                   ~trace_id:meta.runtime.trace_id
+                                   ~response_text
+                                   ())
+                             ())))
                in
        let deferred_retry =
          Option.map

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -292,6 +292,7 @@ let finalize
     ~actual_keeper_tool_names
     ~(user_turn_record : Keeper_run_prompt.user_turn_record)
     ~(result : Runtime_agent.run_result)
+    ~final_oas_turn_ordinal
     ~checkpoint_persistence_error
     ~post_turn_t0
     ~runtime_id_string
@@ -477,6 +478,7 @@ let finalize
       ; ctx_composition
       ; runtime_observation = result.runtime_observation
       ; turn_count = result.turns
+      ; final_oas_turn_ordinal
       ; usage
       ; usage_reported = Option.is_some result.response.usage
       ; tool_calls = List.rev acc.tool_calls

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -133,6 +133,9 @@ let make_hooks
     ~(meta_ref : Keeper_meta_contract.keeper_meta ref)
     ~(turn_ctx_cell : Keeper_tool_call_log.turn_ctx_cell)
     ~(generation : int)
+    ~(trace_id : string)
+    ~(keeper_turn_id : int)
+    ~(on_after_turn_ordinal : int -> unit)
     ?(on_tool_executed :
         tool_name:string -> input:Yojson.Safe.t -> output_text:string ->
         success:bool -> duration_ms:float -> provider:string ->
@@ -172,6 +175,7 @@ let make_hooks
     after_turn = Some (fun event ->
       match event with
       | Agent_sdk.Hooks.AfterTurn { turn; response } ->
+        on_after_turn_ordinal turn;
         record_progress "sdk_after_turn";
         let meta = !meta_ref in
         let model = resolve_after_turn_model ~keeper_name:meta.name ~response in
@@ -345,13 +349,14 @@ let make_hooks
            Trajectory.set_turn acc turn;
            emit_cost_event ~masc_root:acc.masc_root
              ~agent_name:meta.name ~task_id:acc.task_id
+             ~trace_id ~keeper_turn_id ~oas_turn_ordinal:turn ~model:response.model
              ~input_tokens:raw_input_tok ~output_tokens:raw_output_tok
              ~cost_usd:cost_usd_for_event ~usage_missing
              ~cache_creation_input_tokens:raw_cache_creation_input_tokens
              ~cache_read_input_tokens:raw_cache_read_input_tokens
              ~usage_trust
              ?telemetry:response.telemetry
-             ~model:response.model ();
+             ();
            (* 남김없이: persist THIS turn's reasoning (full, untruncated) every
               turn. The prior single post-run capture (Keeper_agent_run) saved
               only the final turn's thinking; turns 1..N-1 were merely counted

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -349,7 +349,7 @@ let make_hooks
            Trajectory.set_turn acc turn;
            emit_cost_event ~masc_root:acc.masc_root
              ~agent_name:meta.name ~task_id:acc.task_id
-             ~trace_id ~keeper_turn_id ~oas_turn_ordinal:turn ~model:response.model
+             ~trace_id ~keeper_turn_id ~oas_turn_ordinal:turn ~model
              ~input_tokens:raw_input_tok ~output_tokens:raw_output_tok
              ~cost_usd:cost_usd_for_event ~usage_missing
              ~cache_creation_input_tokens:raw_cache_creation_input_tokens

--- a/lib/keeper/keeper_hooks_oas.mli
+++ b/lib/keeper/keeper_hooks_oas.mli
@@ -116,6 +116,10 @@ val cache_miss_input_tokens :
 val cost_event_payload :
   agent_name:string ->
   task_id:string option ->
+  trace_id:string ->
+  keeper_turn_id:int ->
+  oas_turn_ordinal:int ->
+  model:string ->
   input_tokens:int ->
   output_tokens:int ->
   cost_usd:float ->
@@ -123,13 +127,17 @@ val cost_event_payload :
   ?cache_read_input_tokens:int ->
   ?usage_missing:bool ->
   ?usage_trust:Keeper_usage_trust.t ->
-  ?telemetry:Agent_sdk.Types.inference_telemetry -> ?model:string -> unit -> Yojson.Safe.t
+  ?telemetry:Agent_sdk.Types.inference_telemetry -> unit -> Yojson.Safe.t
 (** Assemble the structured cost-ledger event without writing it. *)
 
 val emit_cost_event :
   masc_root:string ->
   agent_name:string ->
   task_id:string option ->
+  trace_id:string ->
+  keeper_turn_id:int ->
+  oas_turn_ordinal:int ->
+  model:string ->
   input_tokens:int ->
   output_tokens:int ->
   cost_usd:float ->
@@ -137,8 +145,7 @@ val emit_cost_event :
   ?cache_read_input_tokens:int ->
   ?usage_missing:bool ->
   ?usage_trust:Keeper_usage_trust.t ->
-  ?telemetry:Agent_sdk.Types.inference_telemetry ->
-  ?model:string -> unit -> unit
+  ?telemetry:Agent_sdk.Types.inference_telemetry -> unit -> unit
 (** Append a structured cost-ledger event to [costs/YYYY-MM/DD.jsonl]. *)
 
 (** PR-review / PR-work metric event types live in Keeper_hooks_oas_types
@@ -151,6 +158,9 @@ val make_hooks :
   meta_ref:Keeper_meta_contract.keeper_meta ref ->
   turn_ctx_cell:Keeper_tool_call_log.turn_ctx_cell ->
   generation:int ->
+  trace_id:string ->
+  keeper_turn_id:int ->
+  on_after_turn_ordinal:(int -> unit) ->
   ?on_tool_executed:(tool_name:string ->
                      input:Yojson.Safe.t ->
                      output_text:string ->

--- a/lib/keeper/keeper_hooks_oas_cost_events.ml
+++ b/lib/keeper/keeper_hooks_oas_cost_events.ml
@@ -52,6 +52,10 @@ type assembled_cost_event_payload = {
 let assemble_cost_event_payload
     ~(agent_name : string)
     ~(task_id : string option)
+    ~(trace_id : string)
+    ~(keeper_turn_id : int)
+    ~(oas_turn_ordinal : int)
+    ~(model : string)
     ~(input_tokens : int)
     ~(output_tokens : int)
     ~(cost_usd : float)
@@ -60,7 +64,6 @@ let assemble_cost_event_payload
     ?(usage_missing : bool = false)
     ?usage_trust
     ?(telemetry : Agent_sdk.Types.inference_telemetry option)
-    ?(model : string option)
     () : assembled_cost_event_payload =
   let int_field name = function
     | Some n -> [ (name, `Int n) ]
@@ -112,7 +115,7 @@ let assemble_cost_event_payload
   let key_model_value =
     match canonical_model_id_of_telemetry telemetry with
     | Some canonical_id -> canonical_id
-    | None -> runtime_lane_label
+    | None -> model
   in
   let cost_status_label = cost_status_to_string cost_status in
   let cost_status_reason_label = cost_status_reason cost_status in
@@ -153,32 +156,43 @@ let assemble_cost_event_payload
   let cost_usd_source =
     classify_cost_usd_source ~usage_missing ~runtime_unmetered ~cost_usd
   in
-  let source_auto_trajectory = "auto_trajectory" in
-  let entry = `Assoc ([
-    (key_agent, `String agent_name);
-    ("task_id", Json_util.string_opt_to_json task_id);
-    (key_provider, `String runtime_lane_label);
-    (key_model, `String key_model_value);
-    (key_input_tokens, if usage_missing then `Null else `Int input_tokens);
-    (key_output_tokens, if usage_missing then `Null else `Int output_tokens);
-    (key_cost_usd, if usage_missing then `Null else `Float cost_usd);
-    (* Pricing-observation firewall: a usage_missing turn (no token
-       evidence — includes cost-only usage where only cost_usd was
-       reported) writes `Null`, not `Float x`.  This intentionally
-       changes the ledger for cost-only turns in this PR (not deferred
-       to #25558): a cost observation without token evidence must not
-       enter the ledger as a concrete number. *)
-    (key_cost_status, `String cost_status_label);
-    (key_cost_status_reason, `String cost_status_reason_label);
-    (* #10318: self-describing reason for [cost_usd]'s value. *)
-    (key_cost_usd_source, `String cost_usd_source);
-    (key_usage_missing, `Bool usage_missing);
-    (key_timestamp, `String (Masc_domain.now_iso ()));
-    (key_source, `String source_auto_trajectory);
-  ]
-  @ Keeper_usage_trust.json_fields usage_trust
-  @ cache_token_fields
-  @ wall_tok_s_fields @ telemetry_fields) in
+  let now = Time_compat.now () in
+  let usage =
+    if usage_missing
+    then Cost_ledger.Usage_missing
+    else Cost_ledger.Usage_reported { input_tokens; output_tokens; cost_usd }
+  in
+  let row : Cost_ledger.t =
+    { agent = agent_name
+    ; task_id
+    ; model = key_model_value
+    ; usage
+    ; timestamp = Masc_domain.iso8601_of_unix_seconds now
+    ; ts_unix = now
+    ; source =
+        Cost_ledger.Auto_trajectory
+          { trace_id
+          ; keeper_turn_id
+          ; oas_turn_ordinal
+          }
+    }
+  in
+  let entry =
+    Cost_ledger.to_json
+      ~extra_fields:
+        ([ (key_provider, `String runtime_lane_label)
+         ; (key_cost_status, `String cost_status_label)
+         ; (key_cost_status_reason, `String cost_status_reason_label)
+         ; (key_cost_usd_source, `String cost_usd_source)
+         (* Pricing-observation firewall: a usage-missing turn has no
+            token or cost observation in the current row. *)
+         ]
+         @ Keeper_usage_trust.json_fields usage_trust
+         @ cache_token_fields
+         @ wall_tok_s_fields
+         @ telemetry_fields)
+      row
+  in
   {
     payload = entry;
     provider;
@@ -190,6 +204,10 @@ let assemble_cost_event_payload
 let cost_event_payload
     ~(agent_name : string)
     ~(task_id : string option)
+    ~(trace_id : string)
+    ~(keeper_turn_id : int)
+    ~(oas_turn_ordinal : int)
+    ~(model : string)
     ~(input_tokens : int)
     ~(output_tokens : int)
     ~(cost_usd : float)
@@ -198,11 +216,14 @@ let cost_event_payload
     ?(usage_missing : bool = false)
     ?usage_trust
     ?(telemetry : Agent_sdk.Types.inference_telemetry option)
-    ?(model : string option)
     () : Yojson.Safe.t =
   (assemble_cost_event_payload
      ~agent_name
      ~task_id
+     ~trace_id
+     ~keeper_turn_id
+     ~oas_turn_ordinal
+     ~model
      ~input_tokens
      ~output_tokens
      ~cost_usd
@@ -211,17 +232,16 @@ let cost_event_payload
      ~usage_missing
      ?usage_trust
      ?telemetry
-     ?model
      ()).payload
-
-(** Date-split cost ledger root inside [masc_root].  See
-    [Dated_jsonl] for the [costs/YYYY-MM/DD.jsonl] layout. *)
-let costs_dated_dir masc_root = Filename.concat masc_root "costs"
 
 let emit_cost_event
     ~(masc_root : string)
     ~(agent_name : string)
     ~(task_id : string option)
+    ~(trace_id : string)
+    ~(keeper_turn_id : int)
+    ~(oas_turn_ordinal : int)
+    ~(model : string)
     ~(input_tokens : int)
     ~(output_tokens : int)
     ~(cost_usd : float)
@@ -230,23 +250,16 @@ let emit_cost_event
     ?(usage_missing : bool = false)
     ?usage_trust
     ?(telemetry : Agent_sdk.Types.inference_telemetry option)
-    ?(model : string option)
     () : unit =
-  (* Tier-A perf change: previously appended to a single unbounded
-     [masc_root/costs.jsonl] (14k lines, 7.5MB observed in [<base-path>/.masc]),
-     so every emit grew a hot single-writer file and the reader scanned
-     the entire blob.  Migrated to [Dated_jsonl] under
-     [masc_root/costs/YYYY-MM/DD.jsonl] — same per-day mutex registry
-     used by tracing / coverage_gap / audit appenders, so concurrent
-     keepers serialise on a per-day file rather than a single global
-     one. *)
-  let store =
-    Dated_jsonl.create ~base_dir:(costs_dated_dir masc_root) ()
-  in
+  let store = Cost_ledger.store_of_masc_root masc_root in
   let assembled =
     assemble_cost_event_payload
       ~agent_name
       ~task_id
+      ~trace_id
+      ~keeper_turn_id
+      ~oas_turn_ordinal
+      ~model
       ~input_tokens
       ~output_tokens
       ~cost_usd
@@ -255,7 +268,6 @@ let emit_cost_event
       ~usage_missing
       ?usage_trust
       ?telemetry
-      ?model
       ()
   in
   Otel_metric_store.inc_counter

--- a/lib/keeper/keeper_hooks_oas_cost_events.mli
+++ b/lib/keeper/keeper_hooks_oas_cost_events.mli
@@ -27,6 +27,10 @@ val cache_miss_input_tokens
 val assemble_cost_event_payload
   :  agent_name:string
   -> task_id:string option
+  -> trace_id:string
+  -> keeper_turn_id:int
+  -> oas_turn_ordinal:int
+  -> model:string
   -> input_tokens:int
   -> output_tokens:int
   -> cost_usd:float
@@ -35,13 +39,16 @@ val assemble_cost_event_payload
   -> ?usage_missing:bool
   -> ?usage_trust:Keeper_usage_trust.t
   -> ?telemetry:Agent_sdk.Types.inference_telemetry
-  -> ?model:string
   -> unit
   -> assembled_cost_event_payload
 
 val cost_event_payload
   :  agent_name:string
   -> task_id:string option
+  -> trace_id:string
+  -> keeper_turn_id:int
+  -> oas_turn_ordinal:int
+  -> model:string
   -> input_tokens:int
   -> output_tokens:int
   -> cost_usd:float
@@ -50,16 +57,17 @@ val cost_event_payload
   -> ?usage_missing:bool
   -> ?usage_trust:Keeper_usage_trust.t
   -> ?telemetry:Agent_sdk.Types.inference_telemetry
-  -> ?model:string
   -> unit
   -> Yojson.Safe.t
-
-val costs_dated_dir : string -> string
 
 val emit_cost_event
   :  masc_root:string
   -> agent_name:string
   -> task_id:string option
+  -> trace_id:string
+  -> keeper_turn_id:int
+  -> oas_turn_ordinal:int
+  -> model:string
   -> input_tokens:int
   -> output_tokens:int
   -> cost_usd:float
@@ -68,6 +76,5 @@ val emit_cost_event
   -> ?usage_missing:bool
   -> ?usage_trust:Keeper_usage_trust.t
   -> ?telemetry:Agent_sdk.Types.inference_telemetry
-  -> ?model:string
   -> unit
   -> unit

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -64,6 +64,7 @@ type agent_setup = Keeper_run_tools_hooks.agent_setup =
   ; gate_replay_evidence : Keeper_gate_replay.model_evidence option
   ; acc : hook_accumulator
   ; all_tool_names : string list
+  ; final_oas_turn_ordinal_ref : int option ref
   ; receipt_turn_count_ref : int option ref
   ; receipt_model_used_ref : string option ref
   ; receipt_stop_reason_ref : Runtime_agent.stop_reason option ref

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -60,6 +60,7 @@ type agent_setup =
   ; gate_replay_evidence : Keeper_gate_replay.model_evidence option
   ; acc : hook_accumulator
   ; all_tool_names : string list
+  ; final_oas_turn_ordinal_ref : int option ref
   ; receipt_turn_count_ref : int option ref
   ; receipt_model_used_ref : string option ref
   ; receipt_stop_reason_ref : Runtime_agent.stop_reason option ref
@@ -84,6 +85,7 @@ val prepare_agent_setup
   -> context_injector:Agent_sdk.Hooks.context_injector
   -> start_turn_count:int
   -> generation:int
+  -> keeper_turn_id:int
   -> runtime_id:string
   -> is_retry:bool
   -> config_root:string

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -20,6 +20,7 @@ type agent_setup =
   ; gate_replay_evidence : Keeper_gate_replay.model_evidence option
   ; acc : hook_accumulator
   ; all_tool_names : string list
+  ; final_oas_turn_ordinal_ref : int option ref
   ; receipt_turn_count_ref : int option ref
   ; receipt_model_used_ref : string option ref
   ; receipt_stop_reason_ref : Runtime_agent.stop_reason option ref
@@ -39,11 +40,12 @@ type ctx =
   ; config : Workspace.config
   ; keeper_tools_cleanup : unit -> unit
   ; terminal_effect_state : unit -> Keeper_tools_oas.terminal_effect_state
-  ; manifest_keeper_turn_id : int option
+  ; keeper_turn_id : int
   ; meta : Keeper_meta_contract.keeper_meta
   ; turn_ctx_cell : Keeper_tool_call_log.turn_ctx_cell
     (* RFC-0225 §3.3: per-run carrier; written by the pre-request hook
        below, read by the post-tool hooks in Keeper_hooks_oas. *)
+  ; final_oas_turn_ordinal_ref : int option ref
   ; receipt_turn_count_ref : int option ref
   ; receipt_model_used_ref : string option ref
   ; receipt_stop_reason_ref : Runtime_agent.stop_reason option ref
@@ -148,9 +150,10 @@ let assemble_hooks
   let config = ctx.config in
   let keeper_tools_cleanup = ctx.keeper_tools_cleanup in
   let terminal_effect_state = ctx.terminal_effect_state in
-  let manifest_keeper_turn_id = ctx.manifest_keeper_turn_id in
+  let keeper_turn_id = ctx.keeper_turn_id in
   let meta = ctx.meta in
   let turn_ctx_cell = ctx.turn_ctx_cell in
+  let final_oas_turn_ordinal_ref = ctx.final_oas_turn_ordinal_ref in
   let receipt_turn_count_ref = ctx.receipt_turn_count_ref in
   let receipt_model_used_ref = ctx.receipt_model_used_ref in
   let receipt_stop_reason_ref = ctx.receipt_stop_reason_ref in
@@ -179,6 +182,9 @@ let assemble_hooks
         ~meta_ref
         ~turn_ctx_cell
         ~generation
+        ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+        ~keeper_turn_id
+        ~on_after_turn_ordinal:(fun turn -> final_oas_turn_ordinal_ref := Some turn)
         ?trajectory_acc
         ~on_tool_executed:
           (fun
@@ -280,7 +286,7 @@ let assemble_hooks
              ~duration_ms:(int_of_float (Float.round duration_ms))
              ~typed_outcome
              ~provider
-             ~keeper_turn_id:manifest_keeper_turn_id
+             ~keeper_turn_id:(Some keeper_turn_id)
              ~oas_turn:acc.current_turn
              ~task_id
              ()))
@@ -421,7 +427,7 @@ let assemble_hooks
                   ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
                   ~generation
                   ~turn
-                  ?keeper_turn_id:manifest_keeper_turn_id
+                  ~keeper_turn_id
                   ?task_id:
                     (Option.map Keeper_id.Task_id.to_string acc.meta.current_task_id)
                   ~goal_ids:meta.active_goal_ids
@@ -529,22 +535,19 @@ let assemble_hooks
                 (* Phase O observability: capture the effective OAS request
                    boundary after keeper-owned context injection has finalized
                    [extra_system_context]. *)
-                Option.iter
-                  (fun turn_id ->
-                     Keeper_wire_capture.capture_request
-                       ~base_path:config.base_path
-                       ~masc_root:(Workspace.masc_root_dir config)
-                       ~keeper_name:meta.name
-                       ~turn_id
-                       ~trace_id:meta.runtime.trace_id
-                       ~sdk_turn:turn
-                       ~system_prompt:turn_system_prompt
-                       ~extra_system_context:ctx
-                       ~user_message
-                       ~history_messages:messages
-                       ~tools
-                       ())
-                  manifest_keeper_turn_id;
+                Keeper_wire_capture.capture_request
+                  ~base_path:config.base_path
+                  ~masc_root:(Workspace.masc_root_dir config)
+                  ~keeper_name:meta.name
+                  ~turn_id:keeper_turn_id
+                  ~trace_id:meta.runtime.trace_id
+                  ~sdk_turn:turn
+                  ~system_prompt:turn_system_prompt
+                  ~extra_system_context:ctx
+                  ~user_message
+                  ~history_messages:messages
+                  ~tools
+                  ();
                 Eio.Fiber.yield ();
                 Agent_sdk.Hooks.AdjustParams
                   { current_params with
@@ -581,6 +584,7 @@ let assemble_hooks
       ; gate_replay_evidence
       ; acc
       ; all_tool_names
+      ; final_oas_turn_ordinal_ref
       ; receipt_turn_count_ref
       ; receipt_model_used_ref
       ; receipt_stop_reason_ref

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -107,6 +107,7 @@ let prepare_agent_setup
       ~(context_injector : Agent_sdk.Hooks.context_injector)
       ~(start_turn_count : int)
       ~(generation : int)
+      ~(keeper_turn_id : int)
       ~(runtime_id : string)
       ~(is_retry : bool)
       ~(config_root : string)
@@ -121,16 +122,11 @@ let prepare_agent_setup
   =
   let ( let* ) = Result.bind in
   let runtime_id_string = runtime_id in
-  let manifest_keeper_turn_id =
-    match runtime_manifest_context with
-    | Some ctx -> ctx.Keeper_runtime_manifest.manifest_keeper_turn_id
-    | None -> None
-  in
   let ctx_snapshot = ctx_work in
   let gate_history, gate_history_omitted = gate_history_slice history_messages in
   let gate_context =
     Keeper_gate_causal_context.create
-      ~turn_id:manifest_keeper_turn_id
+      ~turn_id:(Some keeper_turn_id)
       ~initial:
         (gate_causal_initial
            ~gate_history
@@ -378,6 +374,7 @@ let prepare_agent_setup
     in
     ()
   in
+  let final_oas_turn_ordinal_ref : int option ref = ref None in
   let receipt_turn_count_ref : int option ref = ref None in
   let receipt_model_used_ref : string option ref = ref None in
   let receipt_stop_reason_ref : Runtime_agent.stop_reason option ref =
@@ -418,9 +415,10 @@ let prepare_agent_setup
     ; config
     ; keeper_tools_cleanup
     ; terminal_effect_state
-    ; manifest_keeper_turn_id
+    ; keeper_turn_id
     ; meta
     ; turn_ctx_cell
+    ; final_oas_turn_ordinal_ref
     ; receipt_turn_count_ref
     ; receipt_model_used_ref
     ; receipt_stop_reason_ref

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -334,6 +334,7 @@ let append_decision_record
                 ("resolved_model_id", `Null);
                 ("outcome", `String "success");
                 ("turn_count", `Int r.turn_count);
+                ("oas_turn_ordinal", `Int r.final_oas_turn_ordinal);
                 ("stop_reason", `String stop_reason_str);
                 ("usage_reported", `Bool r.usage_reported);
                 ("telemetry_reported", `Bool telemetry_reported);

--- a/lib/model_inference_metrics/dune
+++ b/lib/model_inference_metrics/dune
@@ -16,6 +16,7 @@
  (public_name masc.model_inference_metrics)
  (wrapped false)
  (libraries
+  masc.cost_ledger
   dated_jsonl
   digestif
   eio

--- a/lib/model_inference_metrics/model_inference_metrics.mli
+++ b/lib/model_inference_metrics/model_inference_metrics.mli
@@ -117,6 +117,7 @@ type model_stats = {
 type cost_read_diagnostics = {
   malformed_rows : int;
   schema_violation_rows : int;
+  identity_conflict_rows : int;
 }
 
 type cost_read_result =

--- a/lib/model_inference_metrics/model_inference_metrics_aggregate.ml
+++ b/lib/model_inference_metrics/model_inference_metrics_aggregate.ml
@@ -388,9 +388,8 @@ let aggregate_buckets ~base_path ~window_min ~bucket_min =
 ;;
 
 (* ── Runtime-lane rollup ────────────────────────────────────
-   Legacy provider strings are not reconstructed here.  Public dashboard
-   projections keep aggregate throughput/latency evidence while model/provider
-   identity is represented by neutral runtime lanes.
+   Public dashboard projections keep aggregate throughput/latency evidence
+   while model/provider identity is represented by neutral runtime lanes.
 
    All means are [entry_count]-weighted. Latency percentiles are
    approximations — averaging per-model p50/p95 does not produce a

--- a/lib/model_inference_metrics/model_inference_metrics_entry.ml
+++ b/lib/model_inference_metrics/model_inference_metrics_entry.ml
@@ -127,6 +127,7 @@ type latency_bucket =
 type cost_read_diagnostics =
   { malformed_rows : int
   ; schema_violation_rows : int
+  ; identity_conflict_rows : int
   }
 
 type cost_read_result =
@@ -162,14 +163,15 @@ type provider_stats =
 type raw_entry =
   { model : string
   ; provider : string option
+  ; inference_identity : Cost_ledger.inference_identity option
   ; ts_unix : float
   ; outcome : string
   ; stop_reason : string option
   ; turn_lane : string option
   ; tok_per_sec : float option
   ; prompt_tok_per_sec : float option
-  ; (* Hardware decode rate when present in telemetry; None for legacy entries
-     and non-Ollama providers whose backend doesn't populate inference_timings. *)
+  ; (* Hardware decode rate when present in telemetry; None when the provider
+       does not populate inference_timings. *)
     hw_decode_tok_per_sec : float option
   ; peak_memory_gb : float option
   ; (* Per-turn thinking_enabled as sent to the model (adaptive classifier output).
@@ -211,10 +213,12 @@ type parse_error =
   | Out_of_window                  (* ts_unix older than [since_unix] *)
   | No_telemetry_object            (* decisions.jsonl entry without telemetry { ... } *)
   | Missing_outcome                (* telemetry.outcome absent on success-branch row *)
+  | Missing_usage_reported
+  | Missing_telemetry_reported
   | Missing_success_model          (* no selected_model / model_used / runtime_id *)
+  | Missing_success_inference_identity
   | Missing_error_model_attribution (* no candidate_models / runtime_id on error turn *)
-  | Missing_cost_model             (* cost row without "model" field *)
-  | Missing_cost_usage_missing     (* costs row without current usage_missing boolean *)
+  | Invalid_current_cost_row of Cost_ledger.decode_error
 
 let parse_error_label = function
   | Not_assoc -> "not_assoc"
@@ -222,10 +226,17 @@ let parse_error_label = function
   | Out_of_window -> "out_of_window"
   | No_telemetry_object -> "no_telemetry_object"
   | Missing_outcome -> "missing_outcome"
+  | Missing_usage_reported -> "missing_usage_reported"
+  | Missing_telemetry_reported -> "missing_telemetry_reported"
   | Missing_success_model -> "missing_success_model"
+  | Missing_success_inference_identity -> "missing_success_inference_identity"
   | Missing_error_model_attribution -> "missing_error_model_attribution"
-  | Missing_cost_model -> "missing_cost_model"
-  | Missing_cost_usage_missing -> "missing_cost_usage_missing"
+  | Invalid_current_cost_row _ -> "invalid_current_cost_row"
+;;
+
+let parse_error_detail = function
+  | Invalid_current_cost_row error -> Cost_ledger.decode_error_to_string error
+  | error -> parse_error_label error
 ;;
 
 (* [Out_of_window] and [Not_assoc] are routine in mixed jsonl streams; we never
@@ -236,10 +247,12 @@ let parse_error_is_schema_violation = function
   | Out_of_window | Not_assoc | No_telemetry_object -> false
   | Missing_ts_unix
   | Missing_outcome
+  | Missing_usage_reported
+  | Missing_telemetry_reported
   | Missing_success_model
+  | Missing_success_inference_identity
   | Missing_error_model_attribution
-  | Missing_cost_model
-  | Missing_cost_usage_missing -> true
+  | Invalid_current_cost_row _ -> true
 ;;
 
 (* ── Percentile / list helpers ──────────────────────────── *)
@@ -342,12 +355,8 @@ let json_string_list_field key (fields : (string * Yojson.Safe.t) list) =
 
 (* ── Usage trust inference ──────────────────────────────── *)
 
-(* [usage_reported] is now an [option]: [None] means the row carried no
-   [usage_reported] field at all (older jsonl rows or providers that don't
-   emit it). The pre-existing semantics treated absent and explicit-[false]
-   identically as "missing" — we preserve that with [None | Some false ->
-   "missing"], but make the absent case distinguishable for future tightening
-   without rewriting trust inference. *)
+(* [None] means the current row did not establish whether usage was reported.
+   The parser decides whether that omission is valid for its source contract. *)
 let infer_usage_trust_from_fields
       fields
       ~(usage_reported : bool option)
@@ -373,18 +382,10 @@ let infer_usage_trust_from_fields
       (match output_tokens with
        | Some n when n < 0 -> add "negative_output_tokens"
        | _ -> ());
-      (match
-         match json_int_field_opt "cache_creation_tokens" fields with
-         | Some _ as value -> value
-         | None -> json_int_field_opt "cache_creation_input_tokens" fields
-       with
+      (match json_int_field_opt "cache_creation_tokens" fields with
        | Some n when n < 0 -> add "negative_cache_creation_tokens"
        | _ -> ());
-      (match
-         match json_int_field_opt "cache_read_tokens" fields with
-         | Some _ as value -> value
-         | None -> json_int_field_opt "cache_read_input_tokens" fields
-       with
+      (match json_int_field_opt "cache_read_tokens" fields with
        | Some n when n < 0 -> add "negative_cache_read_tokens"
        | _ -> ());
       (match json_int_field_opt "reasoning_tokens" fields with

--- a/lib/model_inference_metrics/model_inference_metrics_entry.mli
+++ b/lib/model_inference_metrics/model_inference_metrics_entry.mli
@@ -104,6 +104,7 @@ type latency_bucket =
 type cost_read_diagnostics =
   { malformed_rows : int
   ; schema_violation_rows : int
+  ; identity_conflict_rows : int
   }
 
 type cost_read_result =
@@ -135,6 +136,7 @@ type provider_stats =
 type raw_entry =
   { model : string
   ; provider : string option
+  ; inference_identity : Cost_ledger.inference_identity option
   ; ts_unix : float
   ; outcome : string
   ; stop_reason : string option
@@ -172,12 +174,15 @@ type parse_error =
   | Out_of_window
   | No_telemetry_object
   | Missing_outcome
+  | Missing_usage_reported
+  | Missing_telemetry_reported
   | Missing_success_model
+  | Missing_success_inference_identity
   | Missing_error_model_attribution
-  | Missing_cost_model
-  | Missing_cost_usage_missing
+  | Invalid_current_cost_row of Cost_ledger.decode_error
 
 val parse_error_label : parse_error -> string
+val parse_error_detail : parse_error -> string
 val parse_error_is_schema_violation : parse_error -> bool
 val percentile : float array -> float -> float
 val average_opt : float array -> float option

--- a/lib/model_inference_metrics/model_inference_metrics_json.ml
+++ b/lib/model_inference_metrics/model_inference_metrics_json.ml
@@ -42,13 +42,16 @@ let bucket_metric_to_json (b : bucket_metric) : Yojson.Safe.t =
 let cost_read_to_json = function
   | Ok diagnostics ->
     `Assoc
-      [ "status", `String "ok"
+      [ "state", `String "available"
       ; "malformed_rows", `Int diagnostics.malformed_rows
       ; "schema_violation_rows", `Int diagnostics.schema_violation_rows
+      ; "identity_conflict_rows", `Int diagnostics.identity_conflict_rows
       ]
   | Error error ->
-    Json_util.error_assoc
-      [ "detail", `String (Dated_jsonl.read_error_to_string error) ]
+    `Assoc
+      [ "state", `String "unavailable"
+      ; "detail", `String (Dated_jsonl.read_error_to_string error)
+      ]
 ;;
 
 let model_stats_to_json ?(model_label = public_runtime_label) (s : model_stats)
@@ -276,8 +279,8 @@ let compute_cost_latency_json ~base_path ~window_minutes : Yojson.Safe.t =
         [ "agent", `String (public_runtime_lane_label m.model_id)
         ; "in_tok", `Int (Option.value ~default:0 m.total_input_tokens)
         ; "out_tok", `Int (Option.value ~default:0 m.total_output_tokens)
-        (* sound-partial: allow missing cost in legacy rows; absence means zero
-           observed spend, not a provider/model routing choice. *)
+        (* Absence means zero observed spend, not a provider/model routing
+           choice. *)
         ; "cost", `Float (Option.value ~default:0.0 m.total_cost_usd)
         ; "p50_ms", Json_util.float_opt_to_json m.p50_latency_ms
         ; "p95_ms", Json_util.float_opt_to_json m.p95_latency_ms

--- a/lib/model_inference_metrics/model_inference_metrics_parser.ml
+++ b/lib/model_inference_metrics/model_inference_metrics_parser.ml
@@ -16,6 +16,8 @@
 
 open Model_inference_metrics_entry
 
+let ( let* ) = Result.bind
+
 (* ── Model attribution helpers ──────────────────────────── *)
 
 let provider_opt_of_fields ~(model : string) (fields : (string * Yojson.Safe.t) list)
@@ -25,28 +27,10 @@ let provider_opt_of_fields ~(model : string) (fields : (string * Yojson.Safe.t) 
   None
 ;;
 
-let private_provider_hint_of_fields (fields : (string * Yojson.Safe.t) list) =
-  let read key =
-    match List.assoc_opt key fields with
-    | Some (`String raw) ->
-      let trimmed = String.trim raw in
-      if String.equal trimmed "" then None else Some trimmed
-    | _ -> None
-  in
-  match read "provider_kind" with
-  | Some _ as provider_kind -> provider_kind
-  | None -> read "provider"
-;;
-
 let runtime_model_attribution_of_fields (fields : (string * Yojson.Safe.t) list) =
   match json_string_field_opt "runtime_id" fields with
-  | Some runtime_id ->
-    Some ((fun s -> s) runtime_id ^ " (runtime)")
-  | None ->
-    (match json_string_field_opt "runtime_id" fields with
-     | Some runtime_id ->
-       Some ((fun s -> s) runtime_id ^ " (legacy runtime)")
-     | None -> None)
+  | Some runtime_id -> Some (runtime_id ^ " (runtime)")
+  | None -> None
 ;;
 
 let assoc_fields_opt key fields =
@@ -70,6 +54,31 @@ let first_candidate_model field_sets =
        | Some (`List (`String m :: _)) -> Some m
        | _ -> None)
     field_sets
+;;
+
+let success_inference_identity fields telemetry_fields =
+  match
+    json_string_field_opt "trace_id" fields,
+    json_int_field_opt "turn_id" fields,
+    json_int_field_opt "oas_turn_ordinal" telemetry_fields
+  with
+  | Some trace_id, Some keeper_turn_id, Some oas_turn_ordinal
+    when (not (String.equal (String.trim trace_id) ""))
+         && keeper_turn_id > 0
+         && oas_turn_ordinal >= 0 ->
+    Ok
+      (Some
+         { Cost_ledger.trace_id = trace_id
+         ; keeper_turn_id
+         ; oas_turn_ordinal
+         })
+  | _ -> Error Missing_success_inference_identity
+;;
+
+let required_bool_field fields key error =
+  match json_bool_field_opt key fields with
+  | Some value -> Ok value
+  | None -> Error error
 ;;
 
 (* ── decisions.jsonl parser ─────────────────────────────── *)
@@ -107,7 +116,7 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix
            | None -> []
          in
          let model_attribution_field_sets = tfields :: provider_context_fields in
-         let outcome_opt = first_json_string_field_opt "outcome" [ tfields; fields ] in
+         let outcome_opt = json_string_field_opt "outcome" tfields in
          (* Check if this is an error turn (telemetry.outcome = "error") *)
          let is_error =
            match outcome_opt with
@@ -130,9 +139,22 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix
            match model_result with
            | Error _ as e -> e
            | Ok model ->
+           let* usage_reported =
+             required_bool_field
+               tfields
+               "usage_reported"
+               Missing_usage_reported
+           in
+           let* telemetry_reported =
+             required_bool_field
+               tfields
+               "telemetry_reported"
+               Missing_telemetry_reported
+           in
            let provider = provider_opt_of_fields ~model tfields in
            Ok
              { model
+             ; inference_identity = None
              ; ts_unix = ts
              ; outcome = "error"
              ; stop_reason = json_string_field_opt "stop_reason" tfields
@@ -153,8 +175,8 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix
              ; cost_usd = None
              ; tool_call_count = outer_tool_call_count
              ; tools_used = outer_tools_used
-             ; usage_reported = json_bool_field_opt "usage_reported" tfields
-             ; telemetry_reported = json_bool_field_opt "telemetry_reported" tfields
+             ; usage_reported = Some usage_reported
+             ; telemetry_reported = Some telemetry_reported
              ; usage_trust = json_string_field_opt "usage_trust" tfields
              ; usage_anomaly_reasons =
                  json_string_list_field "usage_anomaly_reasons" tfields
@@ -166,12 +188,10 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix
              ; streaming_inter_chunk_avg_ms = json_float_field_opt "streaming_inter_chunk_avg_ms" tfields
              })
          else (
-           (* Success turns: full telemetry parsing.
-              Model attribution is structural: prefer explicit selected/model
-              fields, then fall back to the runtime route when the row proves
-              the route but OAS did not surface the concrete model. This keeps
-              null-model historical rows from being repeatedly dropped without
-              reintroducing the old "unknown" bucket. *)
+           (* Success turns: full telemetry parsing. Model attribution is
+              structural: prefer the explicit selected/model fields, then use
+              the current runtime route when OAS did not surface a concrete
+              model. *)
            let model_result : (string, parse_error) result =
              match first_json_string_field_opt "selected_model" model_attribution_field_sets with
              | Some s -> Ok s
@@ -193,6 +213,18 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix
            match model_result with
            | Error _ as e -> e
            | Ok model ->
+           let* usage_reported_value =
+             required_bool_field
+               tfields
+               "usage_reported"
+               Missing_usage_reported
+           in
+           let* telemetry_reported_value =
+             required_bool_field
+               tfields
+               "telemetry_reported"
+               Missing_telemetry_reported
+           in
            let provider = provider_opt_of_fields ~model tfields in
            let tok_per_sec_raw = json_float_field_opt "tokens_per_second" tfields in
            let prompt_tok_per_sec =
@@ -214,19 +246,15 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix
                | Some (`Int n) when n > 0 -> Some (Float.of_int n)
                | _ -> None
              in
-             match read "peak_memory_gb" with
-             | Some _ as v -> v
-             | None -> read "peak_memory"
+	             read "peak_memory_gb"
            in
            let latency_ms = json_positive_float_field_opt "request_latency_ms" tfields in
            let input_tokens_raw = json_int_field_opt "input_tokens" tfields in
            let output_tokens_raw = json_int_field_opt "output_tokens" tfields in
            let cache_read_tokens_raw = json_int_field_opt "cache_read_tokens" tfields in
-           let cache_creation_tokens_raw =
-             match json_int_field_opt "cache_creation_tokens" tfields with
-             | Some _ as v -> v
-             | None -> json_int_field_opt "cache_creation_input_tokens" tfields
-           in
+	           let cache_creation_tokens_raw =
+	             json_int_field_opt "cache_creation_tokens" tfields
+	           in
            let reasoning_tokens_raw = json_int_field_opt "reasoning_tokens" tfields in
            let fallback_applied =
              match List.assoc_opt "fallback_applied" tfields with
@@ -242,19 +270,7 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix
              | Some (`Bool b) -> Some b
              | _ -> None
            in
-           let usage_reported =
-             match json_bool_field_opt "usage_reported" tfields with
-             | Some _ as value -> value
-             | None ->
-               if
-                 input_tokens_raw <> None
-                 || output_tokens_raw <> None
-                 || cache_read_tokens_raw <> None
-                 || reasoning_tokens_raw <> None
-                 || cost_usd_raw <> None
-               then Some true
-               else None
-           in
+           let usage_reported = Some usage_reported_value in
            let usage_trust, usage_anomaly_reasons =
              infer_usage_trust_from_fields
                tfields
@@ -262,29 +278,24 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix
                ~input_tokens:input_tokens_raw
                ~output_tokens:output_tokens_raw
            in
-           let telemetry_reported =
-             match json_bool_field_opt "telemetry_reported" tfields with
-             | Some _ as value -> value
-             | None ->
-               if
-                 tok_per_sec_raw <> None
-                 || prompt_tok_per_sec <> None
-                 || hw_decode_tok_per_sec <> None
-                 || peak_memory_gb <> None
-                 || latency_ms <> None
-               then Some true
-               else None
-           in
+           let telemetry_reported = Some telemetry_reported_value in
            (* Outcome must be present. Previous code defaulted to "success",
               which silently classified parse failures as successful turns —
               CRITICAL for cost/error-rate accounting. *)
-           match outcome_opt with
-           | None -> Error Missing_outcome
-           | Some outcome ->
-           Ok
-             { model
-             ; ts_unix = ts
-             ; outcome
+	           match outcome_opt with
+	           | None -> Error Missing_outcome
+	           | Some outcome ->
+	             let inference_identity =
+	               if String.equal outcome "success"
+	               then success_inference_identity fields tfields
+	               else Ok None
+	             in
+	             Result.map
+	               (fun inference_identity ->
+	                  { model
+	             ; inference_identity
+	             ; ts_unix = ts
+	             ; outcome
              ; stop_reason = json_string_field_opt "stop_reason" tfields
              ; turn_lane = json_string_field_opt "turn_lane" tfields
              ; tok_per_sec = tok_per_sec_raw
@@ -312,8 +323,9 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix
              ; is_error = false
              ; streaming_ttfrc_ms = json_float_field_opt "streaming_ttfrc_ms" tfields
              ; streaming_inter_chunk_count = json_int_field_opt "streaming_inter_chunk_count" tfields
-             ; streaming_inter_chunk_avg_ms = json_float_field_opt "streaming_inter_chunk_avg_ms" tfields
-             })
+	             ; streaming_inter_chunk_avg_ms = json_float_field_opt "streaming_inter_chunk_avg_ms" tfields
+	             })
+	               inference_identity)
        | _ -> Error No_telemetry_object)
     | _ -> Error Not_assoc)
 ;;
@@ -327,136 +339,93 @@ let read_hw_decode_tok_per_sec (fields : (string * Yojson.Safe.t) list) =
   | _ -> None
 ;;
 
-let canonical_cost_model_id ~(provider : string option) model =
-  let provider_key =
-    match provider with
-    | None -> None
-    | Some raw -> Runtime_provider_labels.canonical_provider_label raw
-  in
-  match provider_key with
-  | None -> model
-  | Some provider_key ->
-    let prefix = provider_key ^ ":" in
-    if String.starts_with ~prefix model then model else prefix ^ model
-;;
-
 let parse_cost_entry (json : Yojson.Safe.t) ~since_unix
   : (raw_entry, parse_error) result
   =
-  match json with
-  | `Assoc fields ->
-    let ts =
-      match Safe_ops.json_float_opt "ts_unix" json with
-      | Some v -> Some v
+  match Cost_ledger.of_json json with
+  | Error error -> Error (Invalid_current_cost_row error)
+  | Ok row when row.ts_unix < since_unix -> Error Out_of_window
+  | Ok row ->
+    let fields =
+      match json with
+      | `Assoc fields -> fields
+      | _ -> []
+    in
+    let usage_reported, input_tokens, output_tokens, cost_usd =
+      match row.usage with
+      | Cost_ledger.Usage_missing -> false, None, None, None
+      | Cost_ledger.Usage_reported { input_tokens; output_tokens; cost_usd } ->
+        true, Some input_tokens, Some output_tokens, Some cost_usd
+    in
+    let cache_read_tokens =
+      if usage_reported then json_int_field_opt "cache_read_tokens" fields else None
+    in
+    let cache_creation_tokens =
+      if usage_reported
+      then json_int_field_opt "cache_creation_tokens" fields
+      else None
+    in
+    let usage_trust, usage_anomaly_reasons =
+      infer_usage_trust_from_fields
+        fields
+        ~usage_reported:(Some usage_reported)
+        ~input_tokens
+        ~output_tokens
+    in
+    let latency_ms = json_positive_float_field_opt "request_latency_ms" fields in
+    let tok_per_sec =
+      match json_positive_float_field_opt "tokens_per_second" fields with
+      | Some _ as value -> value
       | None ->
-        (match List.assoc_opt "timestamp" fields with
-         | Some (`String s) -> Masc_domain.parse_iso8601_opt s
+        (match output_tokens, latency_ms with
+         | Some output_tokens, Some latency_ms when output_tokens > 0 ->
+           Some (Float.of_int output_tokens /. (latency_ms /. 1000.0))
          | _ -> None)
     in
-    (match ts with
-     | None -> Error Missing_ts_unix
-     | Some ts when ts < since_unix -> Error Out_of_window
-     | Some ts ->
-       (* Cost rows without a [model] field cannot be attributed; previous
-          code defaulted to "unknown" which collapsed every such row into a
-          single bucket and broke per-model cost accounting. *)
-       (match json_string_field_opt "model" fields with
-        | None -> Error Missing_cost_model
-        | Some raw_model ->
-       let provider = provider_opt_of_fields ~model:raw_model fields in
-       let model =
-         canonical_cost_model_id
-           ~provider:(private_provider_hint_of_fields fields)
-           raw_model
-       in
-       (match json_bool_field_opt "usage_missing" fields with
-        | None -> Error Missing_cost_usage_missing
-        | Some usage_missing ->
-       let usage_reported = not usage_missing in
-       let input_tokens_raw =
-         if usage_missing then None else json_int_field_opt "input_tokens" fields
-       in
-       let output_tokens_raw =
-         if usage_missing then None else json_int_field_opt "output_tokens" fields
-       in
-       let cache_read_tokens_raw =
-         match json_int_field_opt "cache_read_tokens" fields with
-         | Some _ as v -> v
-         | None -> json_int_field_opt "cache_read_input_tokens" fields
-       in
-       let usage_trust, usage_anomaly_reasons =
-         infer_usage_trust_from_fields
-           fields
-           ~usage_reported:(Some usage_reported)
-           ~input_tokens:input_tokens_raw
-           ~output_tokens:output_tokens_raw
-       in
-       let latency_ms = json_positive_float_field_opt "request_latency_ms" fields in
-       let tok_per_sec_raw =
-         match json_float_field_opt "tokens_per_second" fields with
-         | Some v when v > 0.0 -> Some v
-         | _ ->
-           (match output_tokens_raw, latency_ms with
-            | Some out, Some latency when out > 0 && latency > 0.0 ->
-              Some (Float.of_int out /. (latency /. 1000.0))
-            | _ -> None)
-       in
-       let cache_creation_tokens_raw =
-         match json_int_field_opt "cache_creation_tokens" fields with
-         | Some _ as v -> v
-         | None -> json_int_field_opt "cache_creation_input_tokens" fields
-       in
-       let prompt_tok_per_sec =
-         match List.assoc_opt "prompt_per_second" fields with
-         | Some (`Float f) when f > 0.0 -> Some f
-         | Some (`Int n) when n > 0 -> Some (Float.of_int n)
-         | _ -> None
-       in
-       let hw_decode_tok_per_sec = read_hw_decode_tok_per_sec fields in
-       let peak_memory_gb =
-         match json_float_field_opt "peak_memory_gb" fields with
-         | Some v when v > 0.0 -> Some v
-         | _ -> None
-       in
-       let telemetry_reported =
-         tok_per_sec_raw <> None
-         || prompt_tok_per_sec <> None
-         || hw_decode_tok_per_sec <> None
-         || peak_memory_gb <> None
-         || latency_ms <> None
-       in
-       Ok
-         { model
-         ; ts_unix = ts
-         ; outcome = "success"
-         ; stop_reason = None
-         ; turn_lane = None
-         ; tok_per_sec = tok_per_sec_raw
-         ; provider
-         ; prompt_tok_per_sec
-         ; hw_decode_tok_per_sec
-         ; peak_memory_gb
-         ; thinking_enabled = None
-         ; latency_ms
-         ; input_tokens = input_tokens_raw
-         ; output_tokens = output_tokens_raw
-         ; cache_read_tokens = cache_read_tokens_raw
-         ; cache_creation_tokens = cache_creation_tokens_raw
-         ; reasoning_tokens = json_int_field_opt "reasoning_tokens" fields
-         ; fallback_applied = false
-         ; cost_usd = json_float_field_opt "cost_usd" fields
-         ; tool_call_count = 0
-         ; tools_used = []
-         ; usage_reported = Some usage_reported
-         ; telemetry_reported = Some telemetry_reported
-         ; usage_trust
-         ; usage_anomaly_reasons
-         ; coverage_reason = None
-         ; coverage_stage = Some "costs_jsonl"
-         ; is_error = false
-         ; streaming_ttfrc_ms = None
-         ; streaming_inter_chunk_count = None
-         ; streaming_inter_chunk_avg_ms = None
-         })))
-  | _ -> Error Not_assoc
+    let prompt_tok_per_sec =
+      json_positive_float_field_opt "prompt_per_second" fields
+    in
+    let hw_decode_tok_per_sec = read_hw_decode_tok_per_sec fields in
+    let peak_memory_gb = json_positive_float_field_opt "peak_memory_gb" fields in
+    let telemetry_reported =
+      tok_per_sec <> None
+      || prompt_tok_per_sec <> None
+      || hw_decode_tok_per_sec <> None
+      || peak_memory_gb <> None
+      || latency_ms <> None
+    in
+    Ok
+      { model = row.model
+      ; provider = provider_opt_of_fields ~model:row.model fields
+      ; inference_identity = Cost_ledger.inference_identity row
+      ; ts_unix = row.ts_unix
+      ; outcome = "success"
+      ; stop_reason = None
+      ; turn_lane = None
+      ; tok_per_sec
+      ; prompt_tok_per_sec
+      ; hw_decode_tok_per_sec
+      ; peak_memory_gb
+      ; thinking_enabled = None
+      ; latency_ms
+      ; input_tokens
+      ; output_tokens
+      ; cache_read_tokens
+      ; cache_creation_tokens
+      ; reasoning_tokens = json_int_field_opt "reasoning_tokens" fields
+      ; fallback_applied = false
+      ; cost_usd
+      ; tool_call_count = 0
+      ; tools_used = []
+      ; usage_reported = Some usage_reported
+      ; telemetry_reported = Some telemetry_reported
+      ; usage_trust
+      ; usage_anomaly_reasons
+      ; coverage_reason = None
+      ; coverage_stage = Some "cost_ledger"
+      ; is_error = false
+      ; streaming_ttfrc_ms = None
+      ; streaming_inter_chunk_count = None
+      ; streaming_inter_chunk_avg_ms = None
+      }
 ;;

--- a/lib/model_inference_metrics/model_inference_metrics_reader.ml
+++ b/lib/model_inference_metrics/model_inference_metrics_reader.ml
@@ -232,19 +232,12 @@ let merge_decision_and_cost_entries decisions costs =
        match decisions, costs with
        | [ decision ], [ cost ] ->
          merge_exact_inference decision cost :: entries, identity_conflict_rows
+       | [ decision ], [] -> decision :: entries, identity_conflict_rows
+       | [], [ cost ] -> cost :: entries, identity_conflict_rows
+       | [], [] -> entries, identity_conflict_rows
        | _ ->
-         let duplicate_identity =
-           List.length decisions > 1 || List.length costs > 1
-         in
-         let identity_conflict_rows =
-           if duplicate_identity
-           then identity_conflict_rows + List.length decisions + List.length costs
-           else identity_conflict_rows
-         in
-         List.rev_append
-           decisions
-           (List.rev_append costs entries),
-         identity_conflict_rows)
+         ( entries
+         , identity_conflict_rows + List.length decisions + List.length costs ))
     buckets
     (unkeyed, 0)
 ;;
@@ -259,7 +252,7 @@ let read_all_entries ~base_path ~since_unix =
     if identity_conflict_rows > 0
     then
       Log.Model_inference_metrics.warn
-        "cost ledger exact identity conflict: rows=%d action=preserved"
+        "cost ledger exact identity conflict: rows=%d action=excluded"
         identity_conflict_rows;
     entries, Ok { diagnostics with identity_conflict_rows }
   | Error error ->

--- a/lib/model_inference_metrics/model_inference_metrics_reader.ml
+++ b/lib/model_inference_metrics/model_inference_metrics_reader.ml
@@ -28,6 +28,7 @@ let read_all_decisions ~base_path ~since_unix : raw_entry list =
       |> Array.to_list
       |> List.filter (fun f ->
         String.length f > 16 && Filename.check_suffix f ".decisions.jsonl")
+      |> List.sort String.compare
     in
     List.concat_map
       (fun fname ->
@@ -51,23 +52,29 @@ let read_all_decisions ~base_path ~since_unix : raw_entry list =
          | Eio.Cancel.Cancelled _ as exn ->
            let bt = Printexc.get_raw_backtrace () in
            Printexc.raise_with_backtrace exn bt
-         | _ -> [])
+         | exn ->
+           Log.Model_inference_metrics.error
+             "decisions.jsonl read failed: path=%s detail=%s"
+             path
+             (Printexc.to_string exn);
+           [])
       files)
 ;;
 
 let read_cost_entries_dated ~base_path ~since_unix
   : (raw_entry list * cost_read_diagnostics, Dated_jsonl.read_error) result
   =
-  let dir = Filename.concat (Common.masc_dir_from_base_path ~base_path) "costs" in
-  if not (Sys.file_exists dir)
-  then Ok ([], { malformed_rows = 0; schema_violation_rows = 0 })
-  else (
-    let store = Dated_jsonl.create ~base_dir:dir () in
-    let entries = ref [] in
-    let malformed_rows = ref 0 in
-    let schema_violation_rows = ref 0 in
-    match
-      Dated_jsonl.iter_all_entries_result store (function
+  let store = Cost_ledger.store_of_base_path ~base_path in
+  let entries = ref [] in
+  let malformed_rows = ref 0 in
+  let schema_violation_rows = ref 0 in
+  let now = Time_compat.now () in
+  match
+    Dated_jsonl.iter_range_entries_result
+      store
+      ~since:(Log.format_utc_date_of since_unix)
+      ~until:(Log.format_utc_date_of now)
+      (function
         | Dated_jsonl.Parsed json ->
           (match parse_cost_entry json ~since_unix with
            | Ok entry -> entries := entry :: !entries
@@ -75,8 +82,9 @@ let read_cost_entries_dated ~base_path ~since_unix
            | Error err ->
              incr schema_violation_rows;
              Log.Model_inference_metrics.warn
-               "costs/dated schema drop: reason=%s"
-               (parse_error_label err))
+               "cost ledger schema drop: reason=%s detail=%s"
+               (parse_error_label err)
+               (parse_error_detail err))
         | Dated_jsonl.Malformed_json { path; line_number; detail } ->
           incr malformed_rows;
           let location =
@@ -85,55 +93,175 @@ let read_cost_entries_dated ~base_path ~since_unix
             | None -> path
           in
           Log.Model_inference_metrics.warn
-            "costs/dated malformed row: %s detail=%s"
+            "cost ledger malformed row: %s detail=%s"
             location
             detail)
-    with
-    | Ok () ->
-      Ok
-        ( List.rev !entries
-        , { malformed_rows = !malformed_rows
-          ; schema_violation_rows = !schema_violation_rows
-          } )
-    | Error error -> Error error)
+  with
+  | Ok () ->
+    Ok
+      ( List.rev !entries
+      , { malformed_rows = !malformed_rows
+        ; schema_violation_rows = !schema_violation_rows
+        ; identity_conflict_rows = 0
+        } )
+  | Error error -> Error error
 ;;
 
 let read_cost_entries ~base_path ~since_unix =
   read_cost_entries_dated ~base_path ~since_unix
 ;;
 
-let same_int_opt a b =
-  match a, b with
-  | Some x, Some y -> x = y
-  | _ -> false
+module Inference_identity_map = Map.Make (struct
+    type t = Cost_ledger.inference_identity
+
+    let compare = Cost_ledger.compare_inference_identity
+  end)
+
+type identity_bucket =
+  { decisions : raw_entry list
+  ; costs : raw_entry list
+  }
+
+let empty_identity_bucket = { decisions = []; costs = [] }
+
+let value_or ~preferred ~fallback =
+  match preferred with
+  | Some _ -> preferred
+  | None -> fallback
 ;;
 
-let same_inference_sample a b =
-  String.equal a.model b.model
-  && Float.abs (a.ts_unix -. b.ts_unix) <= 5.0
-  && same_int_opt a.input_tokens b.input_tokens
-  && same_int_opt a.output_tokens b.output_tokens
+let merge_exact_inference decision cost =
+  { model = cost.model
+  ; provider = value_or ~preferred:cost.provider ~fallback:decision.provider
+  ; inference_identity = cost.inference_identity
+  ; ts_unix = cost.ts_unix
+  ; outcome = decision.outcome
+  ; stop_reason = decision.stop_reason
+  ; turn_lane = decision.turn_lane
+  ; tok_per_sec =
+      value_or ~preferred:cost.tok_per_sec ~fallback:decision.tok_per_sec
+  ; prompt_tok_per_sec =
+      value_or
+        ~preferred:cost.prompt_tok_per_sec
+        ~fallback:decision.prompt_tok_per_sec
+  ; hw_decode_tok_per_sec =
+      value_or
+        ~preferred:cost.hw_decode_tok_per_sec
+        ~fallback:decision.hw_decode_tok_per_sec
+  ; peak_memory_gb =
+      value_or ~preferred:cost.peak_memory_gb ~fallback:decision.peak_memory_gb
+  ; thinking_enabled = decision.thinking_enabled
+  ; latency_ms = value_or ~preferred:cost.latency_ms ~fallback:decision.latency_ms
+  ; input_tokens =
+      value_or ~preferred:cost.input_tokens ~fallback:decision.input_tokens
+  ; output_tokens =
+      value_or ~preferred:cost.output_tokens ~fallback:decision.output_tokens
+  ; cache_read_tokens =
+      value_or
+        ~preferred:cost.cache_read_tokens
+        ~fallback:decision.cache_read_tokens
+  ; cache_creation_tokens =
+      value_or
+        ~preferred:cost.cache_creation_tokens
+        ~fallback:decision.cache_creation_tokens
+  ; reasoning_tokens =
+      value_or
+        ~preferred:cost.reasoning_tokens
+        ~fallback:decision.reasoning_tokens
+  ; fallback_applied = decision.fallback_applied
+  ; cost_usd = value_or ~preferred:cost.cost_usd ~fallback:decision.cost_usd
+  ; tool_call_count = decision.tool_call_count
+  ; tools_used = decision.tools_used
+  ; usage_reported =
+      value_or
+        ~preferred:cost.usage_reported
+        ~fallback:decision.usage_reported
+  ; telemetry_reported =
+      value_or
+        ~preferred:cost.telemetry_reported
+        ~fallback:decision.telemetry_reported
+  ; usage_trust =
+      value_or ~preferred:cost.usage_trust ~fallback:decision.usage_trust
+  ; usage_anomaly_reasons =
+      List.sort_uniq
+        String.compare
+        (decision.usage_anomaly_reasons @ cost.usage_anomaly_reasons)
+  ; coverage_reason = decision.coverage_reason
+  ; coverage_stage = decision.coverage_stage
+  ; is_error = decision.is_error
+  ; streaming_ttfrc_ms = decision.streaming_ttfrc_ms
+  ; streaming_inter_chunk_count = decision.streaming_inter_chunk_count
+  ; streaming_inter_chunk_avg_ms = decision.streaming_inter_chunk_avg_ms
+  }
+;;
+
+let add_identity_entry ~is_decision (buckets, unkeyed) entry =
+  match entry.inference_identity with
+  | None -> buckets, entry :: unkeyed
+  | Some identity ->
+    let bucket =
+      match Inference_identity_map.find_opt identity buckets with
+      | Some bucket -> bucket
+      | None -> empty_identity_bucket
+    in
+    let bucket =
+      if is_decision
+      then { bucket with decisions = entry :: bucket.decisions }
+      else { bucket with costs = entry :: bucket.costs }
+    in
+    Inference_identity_map.add identity bucket buckets, unkeyed
 ;;
 
 let merge_decision_and_cost_entries decisions costs =
-  let decision_shadowed_by_cost d =
-    d.tok_per_sec = None
-    && List.exists (fun c -> c.tok_per_sec <> None && same_inference_sample d c) costs
+  let buckets, unkeyed =
+    List.fold_left
+      (add_identity_entry ~is_decision:true)
+      (Inference_identity_map.empty, [])
+      decisions
   in
-  let decisions_kept =
-    List.filter (fun d -> not (decision_shadowed_by_cost d)) decisions
+  let buckets, unkeyed =
+    List.fold_left
+      (add_identity_entry ~is_decision:false)
+      (buckets, unkeyed)
+      costs
   in
-  let cost_duplicate_of_decision c =
-    List.exists (fun d -> d.tok_per_sec <> None && same_inference_sample d c) decisions
-  in
-  decisions_kept @ List.filter (fun c -> not (cost_duplicate_of_decision c)) costs
+  Inference_identity_map.fold
+    (fun _identity bucket (entries, identity_conflict_rows) ->
+       let decisions = List.rev bucket.decisions in
+       let costs = List.rev bucket.costs in
+       match decisions, costs with
+       | [ decision ], [ cost ] ->
+         merge_exact_inference decision cost :: entries, identity_conflict_rows
+       | _ ->
+         let duplicate_identity =
+           List.length decisions > 1 || List.length costs > 1
+         in
+         let identity_conflict_rows =
+           if duplicate_identity
+           then identity_conflict_rows + List.length decisions + List.length costs
+           else identity_conflict_rows
+         in
+         List.rev_append
+           decisions
+           (List.rev_append costs entries),
+         identity_conflict_rows)
+    buckets
+    (unkeyed, 0)
 ;;
 
 let read_all_entries ~base_path ~since_unix =
   let decisions = read_all_decisions ~base_path ~since_unix in
   match read_cost_entries ~base_path ~since_unix with
   | Ok (costs, diagnostics) ->
-    merge_decision_and_cost_entries decisions costs, Ok diagnostics
+    let entries, identity_conflict_rows =
+      merge_decision_and_cost_entries decisions costs
+    in
+    if identity_conflict_rows > 0
+    then
+      Log.Model_inference_metrics.warn
+        "cost ledger exact identity conflict: rows=%d action=preserved"
+        identity_conflict_rows;
+    entries, Ok { diagnostics with identity_conflict_rows }
   | Error error ->
     Log.Model_inference_metrics.error
       "costs/dated read failed: %s"

--- a/lib/operator/operator_control_context_snapshot.ml
+++ b/lib/operator/operator_control_context_snapshot.ml
@@ -123,6 +123,7 @@ let keeper_context_snapshot_of_meta config (meta : Keeper_meta_contract.keeper_m
 
 let dated_jsonl_read_error_code = function
   | Dated_jsonl.Invalid_offset _ -> "invalid_offset"
+  | Dated_jsonl.Invalid_date_range _ -> "invalid_date_range"
   | Dated_jsonl.Not_a_directory _ -> "not_a_directory"
   | Dated_jsonl.Invalid_layout_entry _ -> "invalid_layout_entry"
   | Dated_jsonl.Non_regular_file _ -> "non_regular_file"
@@ -130,7 +131,8 @@ let dated_jsonl_read_error_code = function
 ;;
 
 let dated_jsonl_read_error_path = function
-  | Dated_jsonl.Invalid_offset _ -> None
+  | Dated_jsonl.Invalid_offset _
+  | Dated_jsonl.Invalid_date_range _ -> None
   | Dated_jsonl.Not_a_directory { path }
   | Dated_jsonl.Non_regular_file { path; _ }
   | Dated_jsonl.Io_error { path; _ } -> Some path

--- a/lib/server/server_routes_http_routes_provider_runs.ml
+++ b/lib/server/server_routes_http_routes_provider_runs.ml
@@ -150,7 +150,7 @@ let empty_model_metrics_json ~window ~bucket_min =
     ; "bucket_minutes", `Int bucket_min
     ; "total_entries", `Int 0
     ; "total_error_entries", `Int 0
-    ; "cost_ledger_read", `Assoc [ "status", `String "pending" ]
+    ; "cost_ledger_read", `Assoc [ "state", `String "pending" ]
     ; "latency_buckets", `List []
     ; "models", `List []
     ]
@@ -165,7 +165,7 @@ let empty_cost_latency_json ~window =
     ; "p95", `Null
     ; "total_cost_usd", `Float 0.0
     ; "window_minutes", `Int window
-    ; "cost_ledger_read", `Assoc [ "status", `String "pending" ]
+    ; "cost_ledger_read", `Assoc [ "state", `String "pending" ]
     ; "generated_at", `Float (Unix.gettimeofday ())
     ]
 

--- a/lib/tool_types/tool_args.ml
+++ b/lib/tool_types/tool_args.ml
@@ -99,7 +99,11 @@ let error_code_to_string = function
     but returning the unserialized [Yojson.Safe.t] node so it can be
     composed into a larger structure or returned as
     [(Yojson.Safe.t, _) result]. *)
-let error_assoc = Json_util.error_assoc
+let without_status_field fields =
+  List.filter (fun (key, _) -> not (String.equal key "status")) fields
+
+let error_assoc fields : Yojson.Safe.t =
+  `Assoc (("status", `String "error") :: without_status_field fields)
 
 (** Build a JSON error response string: [\{"status":"error","message":"..."\}] *)
 let error_response message =
@@ -129,7 +133,8 @@ let error_response_typed ~code message =
     sub-payloads, or [(Yojson.Safe.t, string) result] pipelines that
     serialize at a later stage.  Same field-order guarantee as
     [ok_response]: status is prepended to the head of the [`Assoc]. *)
-let ok_assoc = Json_util.ok_assoc
+let ok_assoc fields : Yojson.Safe.t =
+  `Assoc (("status", `String "ok") :: without_status_field fields)
 
 (** Build a JSON OK response string with additional fields. *)
 let ok_response fields =

--- a/scripts/lint/no-inline-error-envelope.sh
+++ b/scripts/lint/no-inline-error-envelope.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # lint-no-inline-error-envelope — block inline `("status", `String "error")`
-# in lib/. Mirrors no-inline-ok-envelope. Use Json_util.error_assoc or the
-# Tool_args response/result helpers instead.
+# in lib/. Mirrors no-inline-ok-envelope. Use Tool_args.error_response /
+# error_response_with / error_assoc / error_result instead.
 
 set -euo pipefail
 
@@ -9,7 +9,8 @@ cd "$(git rev-parse --show-toplevel)"
 
 ALLOWLIST=(
   # SSOT definition — canonical helpers themselves.
-  "lib/core/json_util.ml"
+  # Moved to lib/tool_types/ in RFC-0086 PR-2H (PR #15531).
+  "lib/tool_types/tool_args.ml"
 
   # T27 alias backstop (sibling-include runtime for tool_local_runtime_*.ml).
   "lib/tool_local_runtime_core.ml"
@@ -63,7 +64,7 @@ while IFS= read -r match; do
     continue
   fi
 
-  echo "ERROR: inline error-envelope literal (use Json_util.error_assoc or a Tool_args error helper): $match"
+  echo "ERROR: inline error-envelope literal (use Tool_args.error_response / error_response_with / error_assoc / error_result): $match"
   count=$((count + 1))
 done < "$matches_file"
 
@@ -73,7 +74,7 @@ if [[ $count -gt 0 ]]; then
   echo "Migration guide:"
   echo "  - Returns string (msg only)?  Tool_args.error_response msg"
   echo "  - Returns string (+ fields)?  Tool_args.error_response_with fields"
-  echo "  - Returns Yojson.Safe.t?      Json_util.error_assoc fields"
+  echo "  - Returns Yojson.Safe.t?      Tool_args.error_assoc fields"
   echo "  - Returns Tool_result.t?      Tool_args.error_result ~tool_name ~start_time msg"
   exit 1
 fi

--- a/scripts/lint/no-inline-ok-envelope.sh
+++ b/scripts/lint/no-inline-ok-envelope.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # no-inline-ok-envelope.sh — Block inline `("status", `String "ok")` literals
-# in lib/. Use Json_util.ok_assoc or Tool_args response/result helpers instead.
+# in lib/. Use Tool_args.ok_response / ok_assoc / ok_result instead.
 #
 # Rationale: T27/T28/T29 consolidated 11+ inline ok-envelope sites into
 # Tool_args SSOT helpers. Without a lint guard, the inline pattern
@@ -8,7 +8,7 @@
 # remaining intentional sites can be misread as license to add more.
 #
 # Allowlisted files fall into three categories:
-#   1. SSOT definition itself (json_util.ml).
+#   1. SSOT definition itself (tool_args.ml).
 #   2. T27 alias backstop for sibling-include runtime
 #      (tool_local_runtime_core.ml).
 #   3. Tier B/C intentional inline sites where wire format reordering
@@ -21,7 +21,8 @@ cd "$(git rev-parse --show-toplevel)"
 
 ALLOWLIST=(
   # SSOT definition — the canonical helper itself.
-  "lib/core/json_util.ml"
+  # Moved to lib/tool_types/ in RFC-0086 PR-2H (PR #15531).
+  "lib/tool_types/tool_args.ml"
 
   # T27 alias backstop. sibling tool_local_runtime_*.ml modules
   # consume `json_ok` / `json_error` via `include Tool_local_runtime_core`;

--- a/test/test_cost_token_decouple.ml
+++ b/test/test_cost_token_decouple.ml
@@ -82,6 +82,10 @@ let payload
   H.cost_event_payload
     ~agent_name:"test_agent"
     ~task_id:None
+    ~trace_id:"test-trace"
+    ~keeper_turn_id:1
+    ~oas_turn_ordinal:0
+    ~model:"test-model"
     ~input_tokens
     ~output_tokens
     ~cost_usd
@@ -130,6 +134,8 @@ let test_trusted_tokens_positive_cost_unchanged () =
   (* Regression guard: the always-trusted path is unaffected. *)
   let p =
     H.cost_event_payload ~agent_name:"test_agent" ~task_id:None
+      ~trace_id:"test-trace" ~keeper_turn_id:1 ~oas_turn_ordinal:0
+      ~model:"test-model"
       ~input_tokens:100 ~output_tokens:50 ~cost_usd:0.0042
       ~usage_trust:Trust.Usage_trusted ()
   in
@@ -138,7 +144,9 @@ let test_trusted_tokens_positive_cost_unchanged () =
   check string "trusted positive cost => computed" "computed"
     (string_field p "cost_usd_source");
   check string "trusted positive cost => reported" "reported"
-    (string_field p "cost_status")
+    (string_field p "cost_status");
+  check int "zero-based OAS ordinal is retained" 0
+    (int_field p "oas_turn_ordinal")
 
 let test_trusted_tokens_include_cache_delta () =
   let p =
@@ -232,6 +240,10 @@ let test_native_decode_rate_uses_current_field_only () =
     H.cost_event_payload
       ~agent_name:"test_agent"
       ~task_id:None
+      ~trace_id:"test-trace"
+      ~keeper_turn_id:1
+      ~oas_turn_ordinal:0
+      ~model:"test-model"
       ~input_tokens:10
       ~output_tokens:5
       ~cost_usd:0.0

--- a/test/test_dated_jsonl.ml
+++ b/test/test_dated_jsonl.ml
@@ -532,6 +532,10 @@ let test_iter_all_entries_result_continues_after_malformed () =
     "01"
     [ "not-json"; {|{"i":2}|} ];
   write_dated_file dir "2026-02" "02" [ {|{"i":3}|} ];
+  Fs_compat.append_file (Filename.concat dir ".DS_Store") "not dated";
+  Fs_compat.append_file
+    (Filename.concat (Filename.concat dir "2026-02") ".DS_Store")
+    "not dated";
   let path = Filename.concat (Filename.concat dir "2026-02") "01.jsonl" in
   let store = Dated_jsonl.create ~base_dir:dir () in
   let seen = ref [] in
@@ -567,6 +571,69 @@ let test_iter_all_entries_result_surfaces_typed_io_error () =
   | Error error ->
     failf "unexpected strict stream error: %s" (Dated_jsonl.read_error_to_string error)
   | Ok () -> fail "strict stream treated base file as an empty store"
+;;
+
+let test_iter_range_entries_result_reads_only_requested_days () =
+  let dir = tmpdir "dated_jsonl_iter_range_entries_result" in
+  write_dated_file dir "2026-01" "31" [ {|{"i":1}|} ];
+  write_dated_file
+    dir
+    "2026-02"
+    "01"
+    [ "not-json"; {|{"i":2}|} ];
+  write_dated_file dir "2026-02" "02" [ {|{"i":3}|} ];
+  let path = Filename.concat (Filename.concat dir "2026-02") "01.jsonl" in
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  let seen = ref [] in
+  (match
+     Dated_jsonl.iter_range_entries_result
+       store
+       ~since:"2026-02-01"
+       ~until:"2026-02-01"
+       (fun entry -> seen := entry :: !seen)
+   with
+   | Ok () -> ()
+   | Error error ->
+     failf
+       "strict range iteration failed: %s"
+       (Dated_jsonl.read_error_to_string error));
+  match List.rev !seen with
+  | [ Dated_jsonl.Malformed_json
+        { path = malformed_path; line_number = Some 1; _ }
+    ; Dated_jsonl.Parsed json
+    ] ->
+    check string "range malformed path" path malformed_path;
+    check int "only requested day parsed" 2 (json_i json)
+  | entries ->
+    failf
+      "expected malformed + parsed requested-day stream, got %d entries"
+      (List.length entries)
+;;
+
+let test_iter_range_entries_result_rejects_invalid_range () =
+  let store =
+    Dated_jsonl.create
+      ~base_dir:(tmpdir "dated_jsonl_iter_range_invalid")
+      ()
+  in
+  let rejects ~name ~since ~until =
+    match Dated_jsonl.iter_range_entries_result store ~since ~until ignore with
+    | Error (Dated_jsonl.Invalid_date_range _) -> ()
+    | Error error ->
+      failf
+        "%s: unexpected strict range error: %s"
+        name
+        (Dated_jsonl.read_error_to_string error)
+    | Ok () -> failf "%s: strict range accepted invalid dates" name
+  in
+  rejects
+    ~name:"reversed"
+    ~since:"2026-02-02"
+    ~until:"2026-02-01";
+  rejects
+    ~name:"invalid calendar day"
+    ~since:"2026-02-30"
+    ~until:"2026-02-30"
 ;;
 
 let test_iter_range_chronological () =
@@ -739,6 +806,10 @@ let () =
             test_iter_all_entries_result_continues_after_malformed;
           test_case "strict entry iteration surfaces typed I/O" `Quick
             test_iter_all_entries_result_surfaces_typed_io_error;
+          test_case "strict range reads only requested days" `Quick
+            test_iter_range_entries_result_reads_only_requested_days;
+          test_case "strict range rejects invalid range" `Quick
+            test_iter_range_entries_result_rejects_invalid_range;
           test_case "iter_range chronological" `Quick test_iter_range_chronological;
         ] );
       ( "prune",

--- a/test/test_keeper_hooks_oas_introspection.ml
+++ b/test/test_keeper_hooks_oas_introspection.ml
@@ -91,7 +91,15 @@ let make_runtime_hooks () : Agent_sdk.Hooks.hooks =
   let config = Masc.Workspace.default_config base_path in
   let meta_ref = make_meta_ref "hook-introspection-keeper" in
   let turn_ctx_cell = Masc.Keeper_tool_call_log.create_turn_ctx_cell () in
-  Masc.Keeper_hooks_oas.make_hooks ~config ~meta_ref ~turn_ctx_cell ~generation:0 ()
+  Masc.Keeper_hooks_oas.make_hooks
+    ~config
+    ~meta_ref
+    ~turn_ctx_cell
+    ~generation:0
+    ~trace_id:"introspection-trace"
+    ~keeper_turn_id:1
+    ~on_after_turn_ordinal:ignore
+    ()
 
 let runtime_slots_of (hooks : Agent_sdk.Hooks.hooks) =
   [

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -820,6 +820,7 @@ let () =
     ; ctx_composition
     ; runtime_observation = None
     ; turn_count = 1
+    ; final_oas_turn_ordinal = 0
     ; usage = Masc.Inference_utils.zero_usage
     ; usage_reported = true
     ; tool_calls = []

--- a/test/test_model_inference_metrics.ml
+++ b/test/test_model_inference_metrics.ml
@@ -49,6 +49,14 @@ let iso_of_unix ts =
     (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
     tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
 
+let inference_identity_values ?identity_seed ~model ~ts () =
+  let seed =
+    match identity_seed with
+    | Some seed -> seed
+    | None -> Printf.sprintf "%s|%.6f" model ts
+  in
+  "trace-" ^ Digest.to_hex (Digest.string seed), 1, 0
+
 let write_costs base entries =
   let costs_dir = Filename.concat base ".masc/costs" in
   let store = Dated_jsonl.create ~base_dir:costs_dir () in
@@ -79,24 +87,6 @@ let append_raw_line path line =
        output_string oc line;
        output_char oc '\n')
 
-let write_retired_costs base entries =
-  let masc_dir = Filename.concat base ".masc" in
-  let rec mkdir_p dir =
-    if not (Sys.file_exists dir) then begin
-      mkdir_p (Filename.dirname dir);
-      Unix.mkdir dir 0o755
-    end
-  in
-  mkdir_p masc_dir;
-  let path = Filename.concat masc_dir "costs.jsonl" in
-  let oc = open_out path in
-  Fun.protect ~finally:(fun () -> close_out oc) (fun () ->
-    List.iter (fun json ->
-      output_string oc (Yojson.Safe.to_string json);
-      output_char oc '\n'
-    ) entries
-  )
-
 let now_unix () = Unix.gettimeofday ()
 
 let recent_hour_bucket_timestamp () =
@@ -120,11 +110,14 @@ let contains_substring haystack needle =
     in
     loop 0
 
-let success_entry ~model ~ts ?(input_tokens=100) ?(output_tokens=50)
+let success_entry ~model ~ts ?identity_seed ?(input_tokens=100) ?(output_tokens=50)
     ?(cache_read_tokens=0) ?(cache_creation_tokens=0)
     ?(latency_ms=500) ?prompt_per_second ?peak_memory_gb
     ?provider ?provider_kind ?usage_trust ?(usage_anomaly_reasons=[])
     ?(cost_usd=0.01) ?(tools_used=[]) () =
+  let trace_id, keeper_turn_id, oas_turn_ordinal =
+    inference_identity_values ?identity_seed ~model ~ts ()
+  in
   let extra_telemetry_fields =
     (match prompt_per_second with
      | Some v -> [("prompt_per_second", `Float v)]
@@ -156,11 +149,17 @@ let success_entry ~model ~ts ?(input_tokens=100) ?(output_tokens=50)
   in
   `Assoc [
     ("ts_unix", `Float ts);
+    ("trace_id", `String trace_id);
+    ("turn_id", `Int keeper_turn_id);
     ("tool_call_count", `Int (List.length tools_used));
     ("tools_used", `List (List.map (fun s -> `String s) tools_used));
     ("telemetry", `Assoc ([
       ("model_used", `String model);
       ("outcome", `String "success");
+      ("turn_count", `Int 1);
+      ("oas_turn_ordinal", `Int oas_turn_ordinal);
+      ("usage_reported", `Bool true);
+      ("telemetry_reported", `Bool true);
       ("tokens_per_second", `Float (Float.of_int output_tokens /. (Float.of_int latency_ms /. 1000.0)));
       ("request_latency_ms", `Int latency_ms);
       ("input_tokens", `Int input_tokens);
@@ -173,9 +172,12 @@ let success_entry ~model ~ts ?(input_tokens=100) ?(output_tokens=50)
     ] @ extra_telemetry_fields));
   ]
 
-let cost_entry ~model ~ts ?(input_tokens=100) ?(output_tokens=50)
+let cost_entry ~model ~ts ?identity_seed ?(input_tokens=100) ?(output_tokens=50)
     ?(latency_ms=500) ?tokens_per_second ?provider
     ?(provider_kind="ollama") () =
+  let trace_id, keeper_turn_id, oas_turn_ordinal =
+    inference_identity_values ?identity_seed ~model ~ts ()
+  in
   let tok_fields =
     match tokens_per_second with
     | Some v -> [("tokens_per_second", `Float v)]
@@ -189,6 +191,7 @@ let cost_entry ~model ~ts ?(input_tokens=100) ?(output_tokens=50)
   `Assoc ([
     ("timestamp", `String (iso_of_unix ts));
     ("agent", `String "keeper");
+    ("task_id", `Null);
     ("provider_kind", `String provider_kind);
     ("model", `String model);
     ("input_tokens", `Int input_tokens);
@@ -196,6 +199,9 @@ let cost_entry ~model ~ts ?(input_tokens=100) ?(output_tokens=50)
     ("cost_usd", `Float 0.0);
     ("usage_missing", `Bool false);
     ("source", `String "auto_trajectory");
+    ("trace_id", `String trace_id);
+    ("keeper_turn_id", `Int keeper_turn_id);
+    ("oas_turn_ordinal", `Int oas_turn_ordinal);
     ("request_latency_ms", `Int latency_ms);
   ] @ provider_fields @ tok_fields)
 
@@ -213,6 +219,8 @@ let error_entry ~runtime_id ~ts ?provider () =
       ("candidate_models", `List [`String "claude"; `String "model-b"]);
       ("error_category", `String "timeout");
       ("outcome", `String "error");
+      ("usage_reported", `Bool false);
+      ("telemetry_reported", `Bool false);
     ]);
   ]
 
@@ -223,6 +231,9 @@ let success_entry_without_usage ~model ~ts ?provider
     ?turn_lane
     ?stop_reason
     () =
+  let trace_id, keeper_turn_id, oas_turn_ordinal =
+    inference_identity_values ~model ~ts ()
+  in
   let extra_fields =
     match provider with
     | Some value -> [ ("provider", `String value) ]
@@ -245,18 +256,27 @@ let success_entry_without_usage ~model ~ts ?provider
   in
   `Assoc [
     ("ts_unix", `Float ts);
+    ("trace_id", `String trace_id);
+    ("turn_id", `Int keeper_turn_id);
     ("tool_call_count", `Int 0);
     ("tools_used", `List []);
     ("telemetry", `Assoc ([
       ("model_used", `String model);
       ("outcome", `String "success");
+      ("turn_count", `Int 1);
+      ("oas_turn_ordinal", `Int oas_turn_ordinal);
       ("fallback_applied", `Bool false);
     ] @ extra_fields @ diag_fields));
   ]
 
 let success_entry_without_model ~runtime_id ~ts ?(tool_count = 1) () =
+  let trace_id, keeper_turn_id, oas_turn_ordinal =
+    inference_identity_values ~model:runtime_id ~ts ()
+  in
   `Assoc [
     ("ts_unix", `Float ts);
+    ("trace_id", `String trace_id);
+    ("turn_id", `Int keeper_turn_id);
     ("tool_call_count", `Int tool_count);
     ("tools_used", `List [ `String "keeper_board_comment" ]);
     ( "telemetry",
@@ -265,6 +285,8 @@ let success_entry_without_model ~runtime_id ~ts ?(tool_count = 1) () =
         ("selected_model", `Null);
         ("runtime_id", `String runtime_id);
         ("outcome", `String "success");
+        ("turn_count", `Int 1);
+        ("oas_turn_ordinal", `Int oas_turn_ordinal);
         ("stop_reason", `String "completed");
         ("usage_reported", `Bool false);
         ("telemetry_reported", `Bool false);
@@ -275,8 +297,21 @@ let success_entry_without_model ~runtime_id ~ts ?(tool_count = 1) () =
   ]
 
 let sparse_provider_context_entry ~outcome ~runtime_id ~ts () =
+  let trace_id, keeper_turn_id, oas_turn_ordinal =
+    inference_identity_values ~model:runtime_id ~ts ()
+  in
+  let identity_fields =
+    if String.equal outcome "success"
+    then
+      [ "turn_count", `Int 1
+      ; "oas_turn_ordinal", `Int oas_turn_ordinal
+      ]
+    else []
+  in
   `Assoc [
     ("ts_unix", `Float ts);
+    ("trace_id", `String trace_id);
+    ("turn_id", `Int keeper_turn_id);
     ("outcome", `String outcome);
     ("tool_call_count", `Int 0);
     ("tools_used", `List []);
@@ -287,7 +322,7 @@ let sparse_provider_context_entry ~outcome ~runtime_id ~ts () =
         ("candidate_models", `List []);
       ] );
     ( "telemetry",
-      `Assoc [
+      `Assoc ([
         ("model_used", `Null);
         ("selected_model", `Null);
         ("usage_reported", `Bool false);
@@ -300,7 +335,7 @@ let sparse_provider_context_entry ~outcome ~runtime_id ~ts () =
              then "error_turn"
              else "missing_usage_and_inference") );
         ("fallback_applied", `Bool false);
-      ] );
+      ] @ identity_fields) );
   ]
 
 let check_hw_decode_field ~name json expected =
@@ -312,17 +347,26 @@ let check_hw_decode_field ~name json expected =
   | Error _ -> fail (name ^ ": telemetry row did not parse")
 ;;
 
-let test_hw_decode_parser_uses_current_field_only () =
+let test_hw_decode_parser_reads_current_field () =
   let ts = now_unix () in
+  let trace_id, keeper_turn_id, oas_turn_ordinal =
+    inference_identity_values ~model:"model" ~ts ()
+  in
   let row key =
     `Assoc
       [ "ts_unix", `Float ts
+      ; "trace_id", `String trace_id
+      ; "turn_id", `Int keeper_turn_id
       ; "tool_call_count", `Int 0
       ; "tools_used", `List []
       ; ( "telemetry"
         , `Assoc
             [ "model_used", `String "model"
             ; "outcome", `String "success"
+            ; "turn_count", `Int 1
+            ; "oas_turn_ordinal", `Int oas_turn_ordinal
+            ; "usage_reported", `Bool false
+            ; "telemetry_reported", `Bool true
             ; "fallback_applied", `Bool false
             ; key, `Float 42.0
             ] )
@@ -331,14 +375,10 @@ let test_hw_decode_parser_uses_current_field_only () =
   check_hw_decode_field
     ~name:"current field"
     (row "hw_decode_tokens_per_second")
-    (Some 42.0);
-  check_hw_decode_field
-    ~name:"retired alias ignored"
-    (row "provider_tokens_per_second")
-    None
+    (Some 42.0)
 ;;
 
-let test_cost_parser_uses_current_hw_decode_field_only () =
+let test_cost_parser_reads_current_hw_decode_field () =
   let ts = now_unix () in
   let row key =
     match cost_entry ~model:"model" ~ts () with
@@ -351,11 +391,7 @@ let test_cost_parser_uses_current_hw_decode_field_only () =
       check (option (float 0.001)) name expected entry.hw_decode_tok_per_sec
     | Error _ -> fail (name ^ ": cost row did not parse")
   in
-  parse
-    "current cost field"
-    (row "hw_decode_tokens_per_second")
-    (Some 42.0);
-  parse "retired cost alias ignored" (row "provider_tokens_per_second") None
+  parse "current cost field" (row "hw_decode_tokens_per_second") (Some 42.0)
 ;;
 
 let test_cost_parser_requires_usage_missing () =
@@ -367,7 +403,7 @@ let test_cost_parser_requires_usage_missing () =
     | _ -> fail "cost entry must be an object"
   in
   match Model_inference_metrics_parser.parse_cost_entry row ~since_unix:0.0 with
-  | Error Model_inference_metrics_entry.Missing_cost_usage_missing -> ()
+  | Error (Model_inference_metrics_entry.Invalid_current_cost_row _) -> ()
   | Error error ->
     fail
       ("wrong parse error: "
@@ -422,7 +458,7 @@ let test_single_model_success () =
     check bool "tok/s > 0" true
       (Option.value ~default:0.0 s.avg_tok_per_sec > 0.0))
 
-let test_provider_kind_is_not_reconstructed_from_legacy_fields () =
+let test_provider_kind_is_not_reconstructed () =
   let base = test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
     let path = make_keeper_dir base "kinded" in
@@ -451,7 +487,7 @@ let test_canonical_provider_label_delegates_to_oas_provider_config () =
     (Runtime_provider_labels.canonical_provider_label "  AnThRoPiC  ");
   check (option string) "blank provider kind" None
     (Runtime_provider_labels.canonical_provider_label "   ");
-  check (option string) "historical custom provider" (Some "custom-provider")
+  check (option string) "custom provider" (Some "custom-provider")
     (Runtime_provider_labels.canonical_provider_label "Custom-Provider")
 
 let test_usage_labels_never_suppress_raw_aggregates () =
@@ -491,11 +527,11 @@ let test_usage_labels_never_suppress_raw_aggregates () =
           recent.re_input_tokens = Some 1_721_506)
         s.recent_entries
     in
-    check (option string) "legacy trust label retained as provenance"
+    check (option string) "trust label retained as provenance"
       (Some "untrusted") large.re_usage_trust;
     check (option int) "large input remains visible" (Some 1_721_506)
       large.re_input_tokens;
-    check (list string) "legacy anomaly reason retained as provenance"
+    check (list string) "anomaly reason retained as provenance"
       ["input_tokens_gt_1m"] large.re_usage_anomaly_reasons;
     let negative =
       List.find
@@ -845,7 +881,7 @@ let test_provider_context_attribution_survives_sparse_telemetry () =
     check int "success count" 1 s.success_count;
     check int "error count" 1 s.error_count)
 
-let test_costs_jsonl_backfills_wall_tok_per_sec () =
+let test_cost_ledger_backfills_wall_tok_per_sec () =
   let base = test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
     let ts = now_unix () in
@@ -855,14 +891,14 @@ let test_costs_jsonl_backfills_wall_tok_per_sec () =
     ];
     let agg = M.compute ~base_path:base ~window_minutes:60 in
     let s = List.hd agg.models in
-    check string "cost model" "ollama:qwen3.6:27b-coding-nvfp4" s.model_id;
+    check string "cost model" "qwen3.6:27b-coding-nvfp4" s.model_id;
     check int "one cost entry" 1 s.entry_count;
     check (option (float 0.001)) "wall tok/sec from cost latency"
       (Some 200.0) s.avg_tok_per_sec;
     check int "usage sample" 1 s.usage_sample_count;
     check int "telemetry sample" 1 s.telemetry_sample_count)
 
-let test_costs_jsonl_disambiguates_matching_model_names_by_provider () =
+let test_cost_model_field_is_not_rewritten_from_provider () =
   let base = test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
     let ts = now_unix () in
@@ -873,28 +909,14 @@ let test_costs_jsonl_disambiguates_matching_model_names_by_provider () =
         ~input_tokens:20 ~output_tokens:10 ();
     ];
     let agg = M.compute ~base_path:base ~window_minutes:60 in
-    check int "provider-qualified model buckets" 2 (List.length agg.models);
-    let ids = List.map (fun (s : M.model_stats) -> s.model_id) agg.models |> List.sort compare in
-    check
-      (list string)
-      "private provider keys stay distinct"
-      (* sorted: "anthropic" < "ollama" after the anthropic->anthropic de-cipher *)
-      ["anthropic:shared-model"; "ollama:shared-model"]
-      ids;
-    let token_totals =
-      agg.models
-      |> List.map (fun (s : M.model_stats) ->
-        s.model_id, Option.value ~default:0 s.total_input_tokens)
-      |> List.sort (fun (left, _) (right, _) -> compare left right)
-    in
-    check
-      (list (pair string int))
-      "tokens are not merged across provider lanes"
-      (* sorted by model_id: "anthropic" < "ollama" after anthropic->anthropic *)
-      ["anthropic:shared-model", 20; "ollama:shared-model", 10]
-      token_totals)
+    check int "one model bucket" 1 (List.length agg.models);
+    let stats = List.hd agg.models in
+    check string "model field remains authoritative" "shared-model" stats.model_id;
+    check int "both rows retained" 2 stats.entry_count;
+    check (option int) "tokens aggregate without provider rewrite" (Some 30)
+      stats.total_input_tokens)
 
-let test_costs_jsonl_zero_latency_is_missing () =
+let test_cost_ledger_zero_latency_is_missing () =
   let base = test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
     let ts = now_unix () in
@@ -923,7 +945,7 @@ let test_costs_jsonl_zero_latency_is_missing () =
     in
     check int "zero latency skipped from buckets" 0 bucket_total)
 
-let test_costs_jsonl_dedupes_matching_decision_sample () =
+let test_exact_identity_merges_decision_and_cost () =
   let base = test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
     let path = make_keeper_dir base "dedupe" in
@@ -938,28 +960,71 @@ let test_costs_jsonl_dedupes_matching_decision_sample () =
     ];
     let agg = M.compute ~base_path:base ~window_minutes:60 in
     let s = List.hd agg.models in
-    check int "matching cost sample deduped" 1 s.entry_count;
-    check (option (float 0.001)) "decision tok/sec preserved"
-      (Some 100.0) s.avg_tok_per_sec)
+    check int "exactly matching rows merged" 1 s.entry_count;
+    check (option (float 0.001)) "cost observation supplies wall tok/sec"
+      (Some 200.0) s.avg_tok_per_sec;
+    check int "decision tool fields survive merge" 0 s.total_tool_calls)
+;;
 
-let test_retired_single_file_cost_store_is_ignored () =
+let test_nearby_equal_usage_without_identity_match_stays_distinct () =
   let base = test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+    let path = make_keeper_dir base "nearby-distinct" in
     let ts = now_unix () in
-    write_retired_costs
-      base
-      [ cost_entry ~model:"retired-single-file" ~ts () ];
+    write_decisions
+      path
+      [ success_entry
+          ~model:"same-model"
+          ~ts
+          ~input_tokens:100
+          ~output_tokens:50
+          () ];
     write_costs
       base
-      [ cost_entry ~model:"current-dated-store" ~ts () ];
+      [ cost_entry
+          ~model:"same-model"
+          ~ts:(ts -. 1.0)
+          ~input_tokens:100
+          ~output_tokens:50
+          () ];
     let agg = M.compute ~base_path:base ~window_minutes:60 in
-    check int "only current store row is loaded" 1 agg.total_entries;
     let stats = List.hd agg.models in
-    check
-      string
-      "retired single-file row ignored"
-      "ollama:current-dated-store"
-      stats.model_id)
+    check int "both exact identities remain" 2 stats.entry_count)
+;;
+
+let test_duplicate_exact_identity_is_preserved_and_diagnosed () =
+  let base = test_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+    let path = make_keeper_dir base "identity-conflict" in
+    let ts = now_unix () in
+    write_decisions
+      path
+      [ success_entry
+          ~model:"same-model"
+          ~ts
+          ~identity_seed:"duplicate-identity"
+          () ];
+    write_costs
+      base
+      [ cost_entry
+          ~model:"same-model"
+          ~ts
+          ~identity_seed:"duplicate-identity"
+          ()
+      ; cost_entry
+          ~model:"same-model"
+          ~ts:(ts -. 1.0)
+          ~identity_seed:"duplicate-identity"
+          ()
+      ];
+    let agg = M.compute ~base_path:base ~window_minutes:60 in
+    check int "conflicting rows are not dropped" 3 agg.total_entries;
+    match agg.cost_read with
+    | Error error ->
+      failf "cost store read failed: %s" (Dated_jsonl.read_error_to_string error)
+    | Ok diagnostics ->
+      check int "all conflicting rows diagnosed" 3
+        diagnostics.identity_conflict_rows)
 ;;
 
 let test_cost_read_diagnostics_reach_api () =
@@ -974,12 +1039,14 @@ let test_cost_read_diagnostics_reach_api () =
     append_raw_line (cost_day_file base) "{";
     let json = M.compute ~base_path:base ~window_minutes:60 |> M.to_json in
     let diagnostics = Yojson.Safe.Util.member "cost_ledger_read" json in
-    check string "cost read status" "ok"
-      Yojson.Safe.Util.(diagnostics |> member "status" |> to_string);
+    check string "cost read state" "available"
+      Yojson.Safe.Util.(diagnostics |> member "state" |> to_string);
     check int "malformed rows" 1
       Yojson.Safe.Util.(diagnostics |> member "malformed_rows" |> to_int);
     check int "schema violation rows" 1
-      Yojson.Safe.Util.(diagnostics |> member "schema_violation_rows" |> to_int))
+      Yojson.Safe.Util.(diagnostics |> member "schema_violation_rows" |> to_int);
+    check int "identity conflicts" 0
+      Yojson.Safe.Util.(diagnostics |> member "identity_conflict_rows" |> to_int))
 ;;
 
 let test_cost_read_failure_is_not_empty_success () =
@@ -997,8 +1064,8 @@ let test_cost_read_failure_is_not_empty_success () =
     check int "decision metrics remain available" 1
       Yojson.Safe.Util.(json |> member "total_entries" |> to_int);
     let diagnostics = Yojson.Safe.Util.member "cost_ledger_read" json in
-    check string "cost read status" "error"
-      Yojson.Safe.Util.(diagnostics |> member "status" |> to_string);
+    check string "cost read state" "unavailable"
+      Yojson.Safe.Util.(diagnostics |> member "state" |> to_string);
     check bool "typed read detail is surfaced" true
       (Yojson.Safe.Util.(diagnostics |> member "detail" |> to_string)
        |> contains_substring "not-a-month"))
@@ -1108,14 +1175,24 @@ let test_cost_latency_json_preserves_missing_latency_as_null () =
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
     let path = make_keeper_dir base "cost_latency_missing" in
     let ts = now_unix () in
+    let row_ts = ts -. 10.0 in
+    let trace_id, keeper_turn_id, oas_turn_ordinal =
+      inference_identity_values ~model:"unlatenced-model" ~ts:row_ts ()
+    in
     write_decisions path [
       `Assoc [
-        ("ts_unix", `Float (ts -. 10.0));
+        ("ts_unix", `Float row_ts);
+        ("trace_id", `String trace_id);
+        ("turn_id", `Int keeper_turn_id);
         ("tool_call_count", `Int 0);
         ("tools_used", `List []);
         ("telemetry", `Assoc [
           ("model_used", `String "unlatenced-model");
           ("outcome", `String "success");
+          ("turn_count", `Int 1);
+          ("oas_turn_ordinal", `Int oas_turn_ordinal);
+          ("usage_reported", `Bool true);
+          ("telemetry_reported", `Bool false);
           ("provider", `String "local");
           ("input_tokens", `Int 100);
           ("output_tokens", `Int 50);
@@ -1140,17 +1217,26 @@ let test_cost_latency_json_preserves_missing_latency_as_null () =
 (* ── thinking_fraction tests ─────────────────────── *)
 
 let success_entry_with_thinking ~model ~ts ~thinking_enabled () =
+  let trace_id, keeper_turn_id, oas_turn_ordinal =
+    inference_identity_values ~model ~ts ()
+  in
   let thinking_field = match thinking_enabled with
     | Some b -> [("thinking_enabled", `Bool b)]
     | None -> []
   in
   `Assoc [
     ("ts_unix", `Float ts);
+    ("trace_id", `String trace_id);
+    ("turn_id", `Int keeper_turn_id);
     ("tool_call_count", `Int 0);
     ("tools_used", `List []);
     ("telemetry", `Assoc ([
       ("model_used", `String model);
       ("outcome", `String "success");
+      ("turn_count", `Int 1);
+      ("oas_turn_ordinal", `Int oas_turn_ordinal);
+      ("usage_reported", `Bool true);
+      ("telemetry_reported", `Bool true);
       ("tokens_per_second", `Float 10.0);
       ("request_latency_ms", `Int 500);
       ("input_tokens", `Int 100);
@@ -1229,13 +1315,22 @@ let test_thinking_fraction_json_serialization () =
 (* ── Bucket tests ───────────────────────────────── *)
 
 let success_entry_with_cache ~model ~ts ?(input_tokens=100) ~cache_read () =
+  let trace_id, keeper_turn_id, oas_turn_ordinal =
+    inference_identity_values ~model ~ts ()
+  in
   `Assoc [
     ("ts_unix", `Float ts);
+    ("trace_id", `String trace_id);
+    ("turn_id", `Int keeper_turn_id);
     ("tool_call_count", `Int 0);
     ("tools_used", `List []);
     ("telemetry", `Assoc [
       ("model_used", `String model);
       ("outcome", `String "success");
+      ("turn_count", `Int 1);
+      ("oas_turn_ordinal", `Int oas_turn_ordinal);
+      ("usage_reported", `Bool true);
+      ("telemetry_reported", `Bool true);
       ("tokens_per_second", `Float 10.0);
       ("request_latency_ms", `Int 500);
       ("input_tokens", `Int input_tokens);
@@ -1386,7 +1481,11 @@ let zero_model_stats (model_id : string) ~provider ~entry_count
   }
 
 let successful_cost_read : M.cost_read_result =
-  Ok { malformed_rows = 0; schema_violation_rows = 0 }
+  Ok
+    { malformed_rows = 0
+    ; schema_violation_rows = 0
+    ; identity_conflict_rows = 0
+    }
 
 let test_provider_rollup_empty_aggregate () =
   let agg : M.aggregate =
@@ -1589,6 +1688,7 @@ let test_usage_signal_uses_tokens_not_cost () =
   let entry : Model_inference_metrics_entry.raw_entry =
     { model = "runtime"
     ; provider = None
+    ; inference_identity = None
     ; ts_unix = 0.0
     ; outcome = "success"
     ; stop_reason = None
@@ -1636,7 +1736,7 @@ let () =
       test_case "empty dir" `Quick test_empty_dir;
       test_case "single model success" `Quick test_single_model_success;
       test_case "provider_kind is not reconstructed" `Quick
-        test_provider_kind_is_not_reconstructed_from_legacy_fields;
+        test_provider_kind_is_not_reconstructed;
       test_case "provider labels delegate to OAS Provider_config" `Quick
         test_canonical_provider_label_delegates_to_oas_provider_config;
       test_case "usage labels never suppress raw aggregates" `Quick
@@ -1655,19 +1755,24 @@ let () =
         test_success_without_model_uses_runtime_attribution;
       test_case "provider_context attribution survives sparse telemetry" `Quick
         test_provider_context_attribution_survives_sparse_telemetry;
-      test_case "decision parser uses current hw-decode field only" `Quick
-        test_hw_decode_parser_uses_current_field_only;
-      test_case "cost parser uses current hw-decode field only" `Quick
-        test_cost_parser_uses_current_hw_decode_field_only;
+      test_case "decision parser reads current hw-decode field" `Quick
+        test_hw_decode_parser_reads_current_field;
+      test_case "cost parser reads current hw-decode field" `Quick
+        test_cost_parser_reads_current_hw_decode_field;
       test_case "cost parser requires usage_missing" `Quick
         test_cost_parser_requires_usage_missing;
-      test_case "costs.jsonl backfills wall tok/sec" `Quick test_costs_jsonl_backfills_wall_tok_per_sec;
-      test_case "costs.jsonl disambiguates matching model names by provider" `Quick
-        test_costs_jsonl_disambiguates_matching_model_names_by_provider;
-      test_case "costs.jsonl zero latency stays missing" `Quick test_costs_jsonl_zero_latency_is_missing;
-      test_case "costs.jsonl dedupes matching decision sample" `Quick test_costs_jsonl_dedupes_matching_decision_sample;
-      test_case "retired single-file cost store is ignored" `Quick
-        test_retired_single_file_cost_store_is_ignored;
+      test_case "cost ledger backfills wall tok/sec" `Quick
+        test_cost_ledger_backfills_wall_tok_per_sec;
+      test_case "cost model field is not rewritten from provider" `Quick
+        test_cost_model_field_is_not_rewritten_from_provider;
+      test_case "cost ledger zero latency stays missing" `Quick
+        test_cost_ledger_zero_latency_is_missing;
+      test_case "exact identity merges decision and cost" `Quick
+        test_exact_identity_merges_decision_and_cost;
+      test_case "nearby equal usage stays distinct" `Quick
+        test_nearby_equal_usage_without_identity_match_stays_distinct;
+      test_case "duplicate exact identity is preserved" `Quick
+        test_duplicate_exact_identity_is_preserved_and_diagnosed;
       test_case "cost read diagnostics reach API" `Quick
         test_cost_read_diagnostics_reach_api;
       test_case "cost read failure is not empty success" `Quick

--- a/test/test_model_inference_metrics.ml
+++ b/test/test_model_inference_metrics.ml
@@ -323,6 +323,7 @@ let sparse_provider_context_entry ~outcome ~runtime_id ~ts () =
       ] );
     ( "telemetry",
       `Assoc ([
+        ("outcome", `String outcome);
         ("model_used", `Null);
         ("selected_model", `Null);
         ("usage_reported", `Bool false);
@@ -1059,16 +1060,23 @@ let test_cost_read_failure_is_not_empty_success () =
       keeper_path
       [ success_entry ~model:"decision-model" ~ts:(now_unix ()) () ];
     let costs_dir = Filename.concat base ".masc/costs" in
-    append_raw_line costs_dir "{}";
+    (* A read failure must surface as [unavailable], not empty success:
+       [.masc/costs] as a regular file is present but not listable. *)
+    let masc_dir = Filename.concat base ".masc" in
+    if not (Sys.file_exists masc_dir) then Unix.mkdir masc_dir 0o755;
+    let oc = open_out costs_dir in
+    Fun.protect
+      ~finally:(fun () -> close_out_noerr oc)
+      (fun () -> output_string oc "{}");
     let json = M.compute ~base_path:base ~window_minutes:60 |> M.to_json in
     check int "decision metrics remain available" 1
       Yojson.Safe.Util.(json |> member "total_entries" |> to_int);
     let diagnostics = Yojson.Safe.Util.member "cost_ledger_read" json in
     check string "cost read state" "unavailable"
       Yojson.Safe.Util.(diagnostics |> member "state" |> to_string);
+    let detail = Yojson.Safe.Util.(diagnostics |> member "detail" |> to_string) in
     check bool "typed read detail is surfaced" true
-      (Yojson.Safe.Util.(diagnostics |> member "detail" |> to_string)
-       |> contains_substring costs_dir))
+      (contains_substring detail costs_dir))
 ;;
 
 let test_cost_latency_json_composes_axes_and_percentiles () =

--- a/test/test_model_inference_metrics.ml
+++ b/test/test_model_inference_metrics.ml
@@ -1057,9 +1057,7 @@ let test_cost_read_failure_is_not_empty_success () =
       keeper_path
       [ success_entry ~model:"decision-model" ~ts:(now_unix ()) () ];
     let costs_dir = Filename.concat base ".masc/costs" in
-    Unix.mkdir costs_dir 0o755;
-    let invalid_entry = Filename.concat costs_dir "not-a-month" in
-    Unix.mkdir invalid_entry 0o755;
+    append_raw_line costs_dir "{}";
     let json = M.compute ~base_path:base ~window_minutes:60 |> M.to_json in
     check int "decision metrics remain available" 1
       Yojson.Safe.Util.(json |> member "total_entries" |> to_int);
@@ -1068,7 +1066,7 @@ let test_cost_read_failure_is_not_empty_success () =
       Yojson.Safe.Util.(diagnostics |> member "state" |> to_string);
     check bool "typed read detail is surfaced" true
       (Yojson.Safe.Util.(diagnostics |> member "detail" |> to_string)
-       |> contains_substring "not-a-month"))
+       |> contains_substring costs_dir))
 ;;
 
 let test_cost_latency_json_composes_axes_and_percentiles () =

--- a/test/test_model_inference_metrics.ml
+++ b/test/test_model_inference_metrics.ml
@@ -992,7 +992,7 @@ let test_nearby_equal_usage_without_identity_match_stays_distinct () =
     check int "both exact identities remain" 2 stats.entry_count)
 ;;
 
-let test_duplicate_exact_identity_is_preserved_and_diagnosed () =
+let test_duplicate_exact_identity_is_excluded_and_diagnosed () =
   let base = test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
     let path = make_keeper_dir base "identity-conflict" in
@@ -1018,7 +1018,9 @@ let test_duplicate_exact_identity_is_preserved_and_diagnosed () =
           ()
       ];
     let agg = M.compute ~base_path:base ~window_minutes:60 in
-    check int "conflicting rows are not dropped" 3 agg.total_entries;
+    check int "conflicting identity is excluded" 0 agg.total_entries;
+    check int "conflicting identity creates no aggregate" 0
+      (List.length agg.models);
     match agg.cost_read with
     | Error error ->
       failf "cost store read failed: %s" (Dated_jsonl.read_error_to_string error)
@@ -1769,8 +1771,8 @@ let () =
         test_exact_identity_merges_decision_and_cost;
       test_case "nearby equal usage stays distinct" `Quick
         test_nearby_equal_usage_without_identity_match_stays_distinct;
-      test_case "duplicate exact identity is preserved" `Quick
-        test_duplicate_exact_identity_is_preserved_and_diagnosed;
+      test_case "duplicate exact identity is excluded" `Quick
+        test_duplicate_exact_identity_is_excluded_and_diagnosed;
       test_case "cost read diagnostics reach API" `Quick
         test_cost_read_diagnostics_reach_api;
       test_case "cost read failure is not empty success" `Quick


### PR DESCRIPTION
## 했어용

- Keeper cost row, `masc-cost`, inference metrics가 하나의 current-only `Cost_ledger` codec과 `.masc/costs/YYYY-MM/DD.jsonl` store를 쓰게 했어용.
- OAS `AfterTurn`이 준 실제 0-based ordinal을 그대로 전달해서 `(trace_id, keeper_turn_id, oas_turn_ordinal)` exact identity로만 decision/cost를 결합하게 했어용. 완료 횟수의 `n+1` 보정이나 timestamp/token 휴리스틱은 없앴어용.
- legacy store/field decoder, migration/repair 경로는 추가하지 않았고 관련 대체 해석도 제거했어용.
- 요청 기간 reader는 범위 밖 파일을 열거나 범위 밖 레이아웃으로 현재 통계를 막지 않게 했고, 선택된 파일의 malformed/schema/duplicate identity는 명시적으로 진단하게 했어용.
- `Json_util` status-envelope facade를 되돌리고 `Tool_args`가 필요한 envelope를 직접 소유하게 했어용.

## 원인

OAS runtime의 `AfterTurn.turn`은 0-based 실제 ordinal인데 decision 쪽 완료 횟수와 섞여 첫 호출부터 한 칸 밀렸고, 그 차이를 timestamp/token 근접 매칭으로 덮으면서 다른 row가 합쳐지거나 큰 값이 누락될 수 있었어용.

## 검증

- exact head: `d4f03c47a8c9be030db1a50be3decf79dfa0b5d3`
- 변경 OCaml 35개 파일 `ocamlformat --check` 통과했어용.
- 변경 OCaml 35개 파일 `ocamlc -stop-after parsing` 통과했어용.
- `git diff --check`, error/ok envelope lint, shell syntax, determinism ratchet 통과했어용.
- 요청대로 로컬 Dune은 실행하지 않았고 GitHub CI를 build/test authority로 사용해용.