### PR TITLE
test(dune): 삭제된 모듈을 가리키던 stale dep 제거

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -2454,7 +2454,6 @@
  (deps
   ../lib/config_dir_resolver/config_dir_resolver.ml
   ../lib/keeper/keeper_tool_surface_ops.ml
-  ../lib/board_tool_adapter/board_tool_cache.ml
   ../lib/tool_workspace.ml))
 
 ; RFC-0085 PR-12 — Tool_spec list bindings renamed (drop misleading


### PR DESCRIPTION
`test_rfc_0085_pr13_underscore_rename`은 2026-07-28부터 빌드되지 않아 실행된 적이 없습니다. `test/dune`이 삭제된 파일을 `deps`로 선언하고 있습니다.

```
Error: No rule found for lib/board_tool_adapter/board_tool_cache.ml
```

## 언제, 왜

`dd1ce42d37` (#26102, "drop the masc_board_list TTL cache", 2026-07-28)가 `lib/board_tool_adapter/board_tool_cache.ml`을 지우면서 테스트 *소스*는 정리했지만 `test/dune`의 `deps` 줄은 남겼습니다. 소스에는 이유까지 적혀 있습니다:

```ocaml
(** The board_tool_cache row is gone from the table below because the module
    itself was deleted along with the masc_board_list TTL cache. A row here
    asserts the new name is *present* in the file, so keeping it would pin a
    deleted file into existence. *)
```

`renamed_identifiers`는 `config_dir_resolver.ml`, `keeper_tool_surface_ops.ml`, `tool_workspace.ml` 3개만 스캔합니다. 남은 `deps` 줄은 어떤 assertion도 뒷받침하지 않습니다.

## 왜 CI가 못 잡았나

`ci.yml:691` 주석이 이 구조를 이미 인정하고 있습니다:

```
# runtest subset, so a PR that breaks test compilation can land
```

CI Build and Test는 `dune build --root . @default @check @install`과 runtest 서브셋만 빌드합니다. 이 테스트 타깃은 그 서브셋 밖이라, 빌드 불가 상태로 이틀간 green을 유지했습니다. 가드 테스트가 조용히 사라진 것이므로 silent failure입니다.

## 범위

`test/dune` 1줄 삭제. 전수 스캔 결과 같은 상태의 스탠자는 이것 하나입니다:

```bash
rg -o '^\s*\.\./([a-zA-Z0-9_/.-]+\.(ml|mli))' test/dune test/stanzas/*.inc -r '$1' \
  | sort -u | while IFS=: read -r f p; do [ -f "$p" ] || echo "MISSING: $p ($f)"; done
→ MISSING: lib/board_tool_adapter/board_tool_cache.ml (test/dune)   # 유일
```

## 검증

- `dune build --root . @test/runtest`: `No rule found` 0건
- `dune exec --root . test/test_rfc_0085_pr13_underscore_rename.exe`: exit 0, 2/2 통과

## 남기는 문제

CI가 테스트 컴파일 전체를 빌드하지 않는 구조 자체는 이 PR에서 건드리지 않았습니다. 서브셋 확대는 CI 시간 비용이 걸린 별도 결정이라 판단해 게이트를 추가하지 않았습니다. 같은 종류의 stale dep이 재발하면 그때는 call-site 패치가 아니라 빌드 커버리지 쪽에서 근본 수정을 해야 합니다.

RFC-WAIVED: credential/identity/operator-control/sandbox/hooks/workflow 어느 subsystem도 건드리지 않습니다. 삭제된 파일을 가리키는 dune dep 한 줄 제거입니다.

WORKAROUND-WAIVED: 증상 억제가 아니라 실행되지 않던 테스트의 복구입니다. 새 게이트·카운터·문자열 분류기·텔레메트리를 추가하지 않고, 삭제된 파일 참조 한 줄만 제거합니다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
