### PR TITLE
feat(keeper): 압축 streak을 움직인 outcome 기록

### DIFF
--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -510,6 +510,17 @@ let persist_compaction_decision config ~keeper_name ~decision
    pipeline was committing normally still reported compaction_count=0 — one
    keeper carried 88 committed [context_compacted] runtime-manifest records
    against a meta reading 0. *)
+(* Rendering, not classification: the settlement variant is the state machine's
+   own outcome, so the label comes from an exhaustive match instead of being
+   recovered from a message string.  A new variant fails this match at compile
+   time rather than falling into an unlabelled bucket. *)
+let compaction_outcome_label = function
+  | `Committed -> "committed"
+  | `Overflow_episode_committed -> "overflow_episode_committed"
+  | `Failed -> "failed"
+  | `Recovered -> "recovered"
+;;
+
 let persist_compaction_outcome config ~keeper_name ~outcome
   : ([ `Persisted | `No_durable_meta ], string) result
   =
@@ -535,7 +546,17 @@ let persist_compaction_outcome config ~keeper_name ~outcome
       ~merge:(fun ~latest ~caller:_ -> stamp latest)
       config
       (stamp disk_meta)
-    |> Result.map (fun () -> `Persisted)
+    |> Result.map (fun () ->
+      (* Counted here rather than inside [stamp]: a CAS retry re-applies the
+         stamp, so counting there would report one settlement several times.
+         Only a persisted settlement moved the streak, which is what this
+         series answers — which outcome advanced it, and which reset it. *)
+      Otel_metric_store.inc_counter
+        Keeper_metrics.(to_string CompactionSettlements)
+        ~labels:
+          [ "keeper", keeper_name; "outcome", compaction_outcome_label outcome ]
+        ();
+      `Persisted)
 ;;
 
 (* Structural transcript corruption is deterministic current-state damage, not

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -39,6 +39,7 @@ type t =
   | Compactions
   | CompactionRatioChange
   | CompactionSavedTokens
+  | CompactionSettlements
   | EmergencyCompactRatioThreshold
   | OperatorCompact
   | OperatorClear
@@ -250,6 +251,7 @@ let to_string = function
   | Compactions -> "masc_keeper_compactions_total"
   | CompactionRatioChange -> "masc_keeper_compaction_ratio_change"
   | CompactionSavedTokens -> "masc_keeper_compaction_saved_tokens_total"
+  | CompactionSettlements -> "masc_keeper_compaction_settlements_total"
   | EmergencyCompactRatioThreshold ->
     "masc_keeper_emergency_compact_ratio_threshold"
   | OperatorCompact -> "masc_keeper_operator_compact_total"

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -30,6 +30,7 @@ type t =
   | Compactions
   | CompactionRatioChange
   | CompactionSavedTokens
+  | CompactionSettlements
   | EmergencyCompactRatioThreshold
   | OperatorCompact
   | OperatorClear

--- a/test/dune
+++ b/test/dune
@@ -1966,6 +1966,8 @@
 
 (include stanzas/test_keeper_post_turn_wirein_order.inc)
 
+(include stanzas/test_keeper_compaction_settlement_counters.inc)
+
 (include stanzas/test_keeper_receipt_authoritative.inc)
 
 (include stanzas/test_keeper_receipt_authoritative_matrix.inc)

--- a/test/stanzas/test_keeper_compaction_settlement_counters.inc
+++ b/test/stanzas/test_keeper_compaction_settlement_counters.inc
@@ -1,0 +1,6 @@
+; Compaction settlement outcome counters — which outcome moved the streak.
+
+(test
+ (name test_keeper_compaction_settlement_counters)
+ (modules test_keeper_compaction_settlement_counters)
+ (libraries masc_test_deps masc.keeper_metrics masc.otel_metric_store))

--- a/test/test_keeper_compaction_settlement_counters.ml
+++ b/test/test_keeper_compaction_settlement_counters.ml
@@ -1,0 +1,171 @@
+(** Which settlement outcome moved the compaction streak.
+
+    [persist_compaction_outcome] is the one place all four outcomes converge on
+    [compaction_rt], but the outcome was never recorded: the phase-transition
+    log renders a decision string, not the variant, so a live keeper's streak
+    could be seen rising without any way to tell whether a reset came from an
+    overflow-free turn ([`Recovered]) or an operator commit ([`Committed]).
+    These tests pin that every persisted settlement is counted exactly once and
+    carries its own outcome label. *)
+
+open Alcotest
+
+module Meta_store = Masc.Keeper_meta_store
+
+let metric_name = Keeper_metrics.(to_string CompactionSettlements)
+
+let counted ~keeper_name ~outcome =
+  Otel_metric_store_core.metric_value_or_zero
+    metric_name
+    ~labels:[ "keeper", keeper_name; "outcome", outcome ]
+    ()
+;;
+
+let make_meta ~name : Masc.Keeper_meta_contract.keeper_meta =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [ "name", `String name; "trace_id", `String ("trace-" ^ name) ])
+  with
+  | Ok meta -> meta
+  | Error detail -> failf "keeper meta fixture failed: %s" detail
+;;
+
+let with_workspace f =
+  let base_path = Masc_test_deps.setup_test_workspace () in
+  Fun.protect
+    ~finally:(fun () -> Masc_test_deps.cleanup_test_workspace base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       f config)
+;;
+
+let register config ~name =
+  let meta = make_meta ~name in
+  (match Meta_store.write_meta config meta with
+   | Ok () -> ()
+   | Error msg -> failf "could not persist meta for %s: %s" name msg);
+  meta
+;;
+
+let settle config ~name ~outcome =
+  match Meta_store.persist_compaction_outcome config ~keeper_name:name ~outcome with
+  | Ok `Persisted -> ()
+  | Ok `No_durable_meta -> failf "%s has no durable meta to settle against" name
+  | Error msg -> failf "settlement failed for %s: %s" name msg
+;;
+
+(* Each variant gets its own label, so a dashboard can separate a streak reset
+   that came from an overflow-free turn from one an operator forced. *)
+let test_each_outcome_is_labelled () =
+  with_workspace (fun config ->
+    let name = "settlement-labels" in
+    ignore (register config ~name);
+    List.iter
+      (fun (outcome, label) ->
+         let before = counted ~keeper_name:name ~outcome:label in
+         settle config ~name ~outcome;
+         check
+           (float 0.5)
+           (Printf.sprintf "%s is counted under its own label" label)
+           (before +. 1.)
+           (counted ~keeper_name:name ~outcome:label))
+      [ `Committed, "committed"
+      ; `Overflow_episode_committed, "overflow_episode_committed"
+      ; `Failed, "failed"
+      ; `Recovered, "recovered"
+      ])
+;;
+
+(* The streak arithmetic and the counter must agree: four `Failed` settlements
+   are four counted settlements and a streak of four. A count that drifts from
+   the durable value would send an operator looking for a bug that is not
+   there. *)
+let test_count_tracks_the_durable_streak () =
+  with_workspace (fun config ->
+    let name = "settlement-streak" in
+    ignore (register config ~name);
+    let before = counted ~keeper_name:name ~outcome:"failed" in
+    for _ = 1 to 4 do
+      settle config ~name ~outcome:`Failed
+    done;
+    check
+      (float 0.5)
+      "four failed settlements are counted four times"
+      (before +. 4.)
+      (counted ~keeper_name:name ~outcome:"failed");
+    match Meta_store.read_meta config name with
+    | Ok (Some meta) ->
+      check
+        int
+        "the durable streak matches the count"
+        4
+        meta.Masc.Keeper_meta_contract.runtime.compaction_rt.consecutive_failures
+    | Ok None -> fail "keeper meta disappeared mid-test"
+    | Error msg -> failf "meta read failed: %s" msg)
+;;
+
+let test_attributes_the_settlement_to_its_keeper () =
+  with_workspace (fun config ->
+    let alpha = "settlement-alpha" in
+    let beta = "settlement-beta" in
+    ignore (register config ~name:alpha);
+    ignore (register config ~name:beta);
+    let beta_before = counted ~keeper_name:beta ~outcome:"failed" in
+    settle config ~name:alpha ~outcome:`Failed;
+    check
+      (float 0.5)
+      "another keeper's series is untouched"
+      beta_before
+      (counted ~keeper_name:beta ~outcome:"failed"))
+;;
+
+(* No durable meta means no settlement was persisted and no streak moved, so
+   counting one would overstate the population the series describes. *)
+let test_unregistered_keeper_is_not_counted () =
+  with_workspace (fun config ->
+    let name = "settlement-unregistered" in
+    let before = counted ~keeper_name:name ~outcome:"failed" in
+    (match
+       Meta_store.persist_compaction_outcome config ~keeper_name:name ~outcome:`Failed
+     with
+     | Ok `No_durable_meta -> ()
+     | Ok `Persisted -> fail "an unregistered keeper must not persist a settlement"
+     | Error msg -> failf "unexpected settlement error: %s" msg);
+    check
+      (float 0.5)
+      "an unpersisted settlement is not counted"
+      before
+      (counted ~keeper_name:name ~outcome:"failed"))
+;;
+
+let test_metric_name_is_stable () =
+  check
+    string
+    "dashboards and alerts key off this name"
+    "masc_keeper_compaction_settlements_total"
+    metric_name
+;;
+
+let () =
+  run
+    "keeper compaction settlement counters"
+    [ ( "settlement"
+      , [ test_case "each outcome is labelled" `Quick test_each_outcome_is_labelled
+        ; test_case
+            "count tracks the durable streak"
+            `Quick
+            test_count_tracks_the_durable_streak
+        ; test_case
+            "attributes the settlement to its keeper"
+            `Quick
+            test_attributes_the_settlement_to_its_keeper
+        ; test_case
+            "an unregistered keeper is not counted"
+            `Quick
+            test_unregistered_keeper_is_not_counted
+        ; test_case "metric name is stable" `Quick test_metric_name_is_stable
+        ] )
+    ]
+;;


### PR DESCRIPTION
압축 streak을 움직인 outcome이 무엇인지 현재 기록되지 않습니다. `persist_compaction_outcome`의 4변형이 전부 같은 `compaction_rt`에 수렴하는데, 로그에는 결정 **문자열**만 남고 변형은 남지 않습니다.

## 왜 필요한가 (실측)

`~/me/.masc/logs/system_log_2026-07-2{8,9}.jsonl`, `event=compaction_*` 라인:

| 날짜 | 기록된 실패 | 거부(미시도) | 실제 시도 실패 | 성공 |
|---|---|---|---|---|
| 07-28 | 1,953 | 1,946 | 7 | 61 |
| 07-29 | 842 | 828 | 14 | 59 |

kidsnote는 07-29에 이렇게 움직였습니다:

```
01:24:11Z  마지막 거부 (retry suspended)
01:54:31Z  compaction_completed        ← streak 리셋
16:11:26Z  거부, streak=907            ← 재축적
```

**무엇이 01:54의 리셋을 만들었는지 로그로 판정할 수 없습니다.** `` `Recovered ``(overflow 없는 턴이 완료됨)일 수도, `` `Committed ``(operator manual)일 수도 있습니다. 두 경로는 운영상 완전히 다른 의미인데 — 하나는 시스템이 스스로 빠져나온 것이고 다른 하나는 사람이 꺼내준 것 — 구분이 불가능합니다.

이 PR은 그 구분을 만듭니다.

## 변경

`masc_keeper_compaction_settlements_total`, 라벨 `keeper` + `outcome`.

라벨은 exhaustive match로 렌더합니다. 문자열에서 역추론하지 않으며, 변형이 추가되면 컴파일이 막습니다:

```ocaml
let compaction_outcome_label = function
  | `Committed -> "committed"
  | `Overflow_episode_committed -> "overflow_episode_committed"
  | `Failed -> "failed"
  | `Recovered -> "recovered"
;;
```

카운트 위치는 `stamp` 안이 아니라 **영속 성공 지점**입니다. `stamp`은 CAS 재시도 시 다시 적용되므로 거기서 세면 한 settlement이 여러 번 보고됩니다.

## 건드리지 않은 것

제어 흐름, streak 산술, 게이트, 임계값 3, `persist_compaction_outcome`의 반환 타입. 이 diff는 metric 방출만 추가하며 어떤 분기도 이 metric을 읽지 않습니다.

## 검증

- `dune build --root .` 클린
- 신규 테스트 5/5 통과:
  - 4변형 각각이 자기 라벨로 집계됨
  - `` `Failed `` 4회 → 카운트 4 **그리고** durable `consecutive_failures` 4 (둘이 어긋나면 운영자가 없는 버그를 쫓게 됨)
  - keeper별 귀속 (다른 keeper 시계열 불변)
  - durable meta 없는 keeper는 집계되지 않음 (`No_durable_meta`는 streak을 움직이지 않았으므로)
  - metric 이름 고정

## 남는 것

`actual_bytes` / `limit_bytes` 쌍은 이 PR에 넣지 않았습니다. #26387이 provider가 admission하는 실제 body 바이트를 keeper 라벨로 이미 관측하고, limit은 설정값이라 대시보드에서 대조 가능합니다. 분류 지점에 같은 값을 다시 기록하면 SSOT가 둘이 됩니다.

RFC-WAIVED: credential/identity/operator-control/sandbox/hooks/workflow 어느 subsystem도 건드리지 않습니다. settlement 지점의 metric 방출 추가입니다.

WORKAROUND-WAIVED: 이 PR은 알려진 실패를 가시화해 무마하는 텔레메트리가 아닙니다. 오분류 자체의 수정은 #26386이 별도로 하고 있고, 여기서 재는 것은 실패가 아니라 **상태 기계의 4개 정상 outcome**입니다. 이 metric을 읽는 게이트나 분기를 추가하지 않으며, 문자열 분류기도 도입하지 않습니다 (exhaustive match 렌더링).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
