### PR TITLE
fix(metrics): bound compaction settlement series

### DIFF
--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -550,10 +550,19 @@ let persist_compaction_outcome config ~keeper_name ~outcome
       (* Counted here rather than inside [stamp]: a CAS retry re-applies the
          stamp, so counting there would report one settlement several times.
          Only a persisted settlement moved the streak, which is what this
-         series answers — which outcome advanced it, and which reset it. *)
+         series answers — which outcome advanced it, and which reset it.
+
+         The [keeper] label stays: keeper names come from the registry and are
+         stable across replacement (a replaced keeper keeps its name and bumps
+         [generation]), so the series count is bounded by fleet size, and
+         "which keeper's compaction is collapsing" is the question this was
+         added to answer. Unbounded accumulation in the metric store is a
+         store-level property shared by every keeper-labelled emission; it does
+         not get fixed by dropping one dimension here. *)
       Otel_metric_store.inc_counter
         Keeper_metrics.(to_string CompactionSettlements)
-        ~labels:[ "outcome", compaction_outcome_label outcome ]
+        ~labels:
+          [ "keeper", keeper_name; "outcome", compaction_outcome_label outcome ]
         ();
       Log.Keeper.info
         ~keeper_name

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -553,9 +553,12 @@ let persist_compaction_outcome config ~keeper_name ~outcome
          series answers — which outcome advanced it, and which reset it. *)
       Otel_metric_store.inc_counter
         Keeper_metrics.(to_string CompactionSettlements)
-        ~labels:
-          [ "keeper", keeper_name; "outcome", compaction_outcome_label outcome ]
+        ~labels:[ "outcome", compaction_outcome_label outcome ]
         ();
+      Log.Keeper.info
+        ~keeper_name
+        "compaction settlement persisted outcome=%s"
+        (compaction_outcome_label outcome);
       `Persisted)
 ;;
 

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -250,7 +250,10 @@ val persist_compaction_outcome :
     {!Keeper_meta_contract.compaction_retry_suspended} reads to refuse a
     failing compaction instead of retrying it without bound (RFC-0351 S0,
     #25461); [count] had no writer before this despite being serialized and
-    rendered. Before #25969 the same ceiling was applied one layer lower, by
+    rendered. The metric is fleet-level and bounded by the closed outcome
+    variant; the per-Keeper outcome is emitted on the successful persistence
+    log and the current per-Keeper counters remain in durable [compaction_rt].
+    Before #25969 the same ceiling was applied one layer lower, by
     [Keeper_heartbeat_loop.settlement_of_cycle_outcome] escalating the lease
     settlement; that function went with the claim/settle model. *)
 

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -250,10 +250,13 @@ val persist_compaction_outcome :
     {!Keeper_meta_contract.compaction_retry_suspended} reads to refuse a
     failing compaction instead of retrying it without bound (RFC-0351 S0,
     #25461); [count] had no writer before this despite being serialized and
-    rendered. The metric is fleet-level and bounded by the closed outcome
-    variant; the per-Keeper outcome is emitted on the successful persistence
-    log and the current per-Keeper counters remain in durable [compaction_rt].
-    Before #25969 the same ceiling was applied one layer lower, by
+    rendered. The metric carries [keeper] and [outcome]: outcome is the closed
+    settlement variant, and keeper names come from the registry and survive
+    replacement, so the series count is bounded by fleet size. The successful
+    persistence log carries the same typed outcome, which is where a single
+    settlement is resolvable by timestamp; the durable per-Keeper counters stay
+    in [compaction_rt]. Before #25969 the same ceiling was applied one layer
+    lower, by
     [Keeper_heartbeat_loop.settlement_of_cycle_outcome] escalating the lease
     settlement; that function went with the claim/settle model. *)
 

--- a/test/test_keeper_compaction_settlement_counters.ml
+++ b/test/test_keeper_compaction_settlement_counters.ml
@@ -14,10 +14,10 @@ module Meta_store = Masc.Keeper_meta_store
 
 let metric_name = Keeper_metrics.(to_string CompactionSettlements)
 
-let counted ~keeper_name ~outcome =
+let counted ~outcome =
   Otel_metric_store_core.metric_value_or_zero
     metric_name
-    ~labels:[ "keeper", keeper_name; "outcome", outcome ]
+    ~labels:[ "outcome", outcome ]
     ()
 ;;
 
@@ -64,13 +64,13 @@ let test_each_outcome_is_labelled () =
     ignore (register config ~name);
     List.iter
       (fun (outcome, label) ->
-         let before = counted ~keeper_name:name ~outcome:label in
+         let before = counted ~outcome:label in
          settle config ~name ~outcome;
          check
            (float 0.5)
            (Printf.sprintf "%s is counted under its own label" label)
            (before +. 1.)
-           (counted ~keeper_name:name ~outcome:label))
+           (counted ~outcome:label))
       [ `Committed, "committed"
       ; `Overflow_episode_committed, "overflow_episode_committed"
       ; `Failed, "failed"
@@ -86,7 +86,7 @@ let test_count_tracks_the_durable_streak () =
   with_workspace (fun config ->
     let name = "settlement-streak" in
     ignore (register config ~name);
-    let before = counted ~keeper_name:name ~outcome:"failed" in
+    let before = counted ~outcome:"failed" in
     for _ = 1 to 4 do
       settle config ~name ~outcome:`Failed
     done;
@@ -94,7 +94,7 @@ let test_count_tracks_the_durable_streak () =
       (float 0.5)
       "four failed settlements are counted four times"
       (before +. 4.)
-      (counted ~keeper_name:name ~outcome:"failed");
+      (counted ~outcome:"failed");
     match Meta_store.read_meta config name with
     | Ok (Some meta) ->
       check
@@ -106,19 +106,30 @@ let test_count_tracks_the_durable_streak () =
     | Error msg -> failf "meta read failed: %s" msg)
 ;;
 
-let test_attributes_the_settlement_to_its_keeper () =
+let test_keeper_names_share_one_bounded_series () =
   with_workspace (fun config ->
     let alpha = "settlement-alpha" in
     let beta = "settlement-beta" in
     ignore (register config ~name:alpha);
     ignore (register config ~name:beta);
-    let beta_before = counted ~keeper_name:beta ~outcome:"failed" in
+    let before = counted ~outcome:"failed" in
     settle config ~name:alpha ~outcome:`Failed;
+    settle config ~name:beta ~outcome:`Failed;
     check
       (float 0.5)
-      "another keeper's series is untouched"
-      beta_before
-      (counted ~keeper_name:beta ~outcome:"failed"))
+      "both keepers increment the same outcome series"
+      (before +. 2.)
+      (counted ~outcome:"failed");
+    let settlement_metrics =
+      Otel_metric_store_core.snapshot ()
+      |> List.filter (fun (metric : Otel_metric_store_core.metric) ->
+        String.equal metric.name metric_name)
+    in
+    check bool "settlement series never carry Keeper identity" true
+      (List.for_all
+         (fun (metric : Otel_metric_store_core.metric) ->
+            not (List.mem_assoc "keeper" metric.labels))
+         settlement_metrics))
 ;;
 
 (* No durable meta means no settlement was persisted and no streak moved, so
@@ -126,7 +137,7 @@ let test_attributes_the_settlement_to_its_keeper () =
 let test_unregistered_keeper_is_not_counted () =
   with_workspace (fun config ->
     let name = "settlement-unregistered" in
-    let before = counted ~keeper_name:name ~outcome:"failed" in
+    let before = counted ~outcome:"failed" in
     (match
        Meta_store.persist_compaction_outcome config ~keeper_name:name ~outcome:`Failed
      with
@@ -137,7 +148,7 @@ let test_unregistered_keeper_is_not_counted () =
       (float 0.5)
       "an unpersisted settlement is not counted"
       before
-      (counted ~keeper_name:name ~outcome:"failed"))
+      (counted ~outcome:"failed"))
 ;;
 
 let test_metric_name_is_stable () =
@@ -158,9 +169,9 @@ let () =
             `Quick
             test_count_tracks_the_durable_streak
         ; test_case
-            "attributes the settlement to its keeper"
+            "keeper names share one bounded series"
             `Quick
-            test_attributes_the_settlement_to_its_keeper
+            test_keeper_names_share_one_bounded_series
         ; test_case
             "an unregistered keeper is not counted"
             `Quick

--- a/test/test_keeper_compaction_settlement_counters.ml
+++ b/test/test_keeper_compaction_settlement_counters.ml
@@ -14,11 +14,16 @@ module Meta_store = Masc.Keeper_meta_store
 
 let metric_name = Keeper_metrics.(to_string CompactionSettlements)
 
-let counted ~outcome =
+let counted ~keeper_name ~outcome =
   Otel_metric_store_core.metric_value_or_zero
     metric_name
-    ~labels:[ "outcome", outcome ]
+    ~labels:[ "keeper", keeper_name; "outcome", outcome ]
     ()
+;;
+
+(* Fleet total across every keeper series, so the aggregate a dashboard reads
+   stays pinned even though the series are split per keeper. *)
+let fleet_total () = Otel_metric_store_core.metric_total metric_name
 ;;
 
 let make_meta ~name : Masc.Keeper_meta_contract.keeper_meta =
@@ -64,13 +69,13 @@ let test_each_outcome_is_labelled () =
     ignore (register config ~name);
     List.iter
       (fun (outcome, label) ->
-         let before = counted ~outcome:label in
+         let before = counted ~keeper_name:name ~outcome:label in
          settle config ~name ~outcome;
          check
            (float 0.5)
            (Printf.sprintf "%s is counted under its own label" label)
            (before +. 1.)
-           (counted ~outcome:label))
+           (counted ~keeper_name:name ~outcome:label))
       [ `Committed, "committed"
       ; `Overflow_episode_committed, "overflow_episode_committed"
       ; `Failed, "failed"
@@ -86,7 +91,7 @@ let test_count_tracks_the_durable_streak () =
   with_workspace (fun config ->
     let name = "settlement-streak" in
     ignore (register config ~name);
-    let before = counted ~outcome:"failed" in
+    let before = counted ~keeper_name:name ~outcome:"failed" in
     for _ = 1 to 4 do
       settle config ~name ~outcome:`Failed
     done;
@@ -94,7 +99,7 @@ let test_count_tracks_the_durable_streak () =
       (float 0.5)
       "four failed settlements are counted four times"
       (before +. 4.)
-      (counted ~outcome:"failed");
+      (counted ~keeper_name:name ~outcome:"failed");
     match Meta_store.read_meta config name with
     | Ok (Some meta) ->
       check
@@ -106,30 +111,36 @@ let test_count_tracks_the_durable_streak () =
     | Error msg -> failf "meta read failed: %s" msg)
 ;;
 
-let test_keeper_names_share_one_bounded_series () =
+(* Per-keeper attribution is the question the series was added for — which
+   keeper's compaction is collapsing. One keeper's settlement must not move
+   another's series, and the fleet aggregate a dashboard reads is the sum over
+   them, so both readings stay available. *)
+let test_attributes_the_settlement_to_its_keeper () =
   with_workspace (fun config ->
     let alpha = "settlement-alpha" in
     let beta = "settlement-beta" in
     ignore (register config ~name:alpha);
     ignore (register config ~name:beta);
-    let before = counted ~outcome:"failed" in
+    let alpha_before = counted ~keeper_name:alpha ~outcome:"failed" in
+    let beta_before = counted ~keeper_name:beta ~outcome:"failed" in
+    let fleet_before = fleet_total () in
     settle config ~name:alpha ~outcome:`Failed;
+    check
+      (float 0.5)
+      "the settling keeper's series advances"
+      (alpha_before +. 1.)
+      (counted ~keeper_name:alpha ~outcome:"failed");
+    check
+      (float 0.5)
+      "another keeper's series is untouched"
+      beta_before
+      (counted ~keeper_name:beta ~outcome:"failed");
     settle config ~name:beta ~outcome:`Failed;
     check
       (float 0.5)
-      "both keepers increment the same outcome series"
-      (before +. 2.)
-      (counted ~outcome:"failed");
-    let settlement_metrics =
-      Otel_metric_store_core.snapshot ()
-      |> List.filter (fun (metric : Otel_metric_store_core.metric) ->
-        String.equal metric.name metric_name)
-    in
-    check bool "settlement series never carry Keeper identity" true
-      (List.for_all
-         (fun (metric : Otel_metric_store_core.metric) ->
-            not (List.mem_assoc "keeper" metric.labels))
-         settlement_metrics))
+      "the fleet aggregate is the sum over keepers"
+      (fleet_before +. 2.)
+      (fleet_total ()))
 ;;
 
 (* No durable meta means no settlement was persisted and no streak moved, so
@@ -137,7 +148,7 @@ let test_keeper_names_share_one_bounded_series () =
 let test_unregistered_keeper_is_not_counted () =
   with_workspace (fun config ->
     let name = "settlement-unregistered" in
-    let before = counted ~outcome:"failed" in
+    let before = counted ~keeper_name:name ~outcome:"failed" in
     (match
        Meta_store.persist_compaction_outcome config ~keeper_name:name ~outcome:`Failed
      with
@@ -148,7 +159,7 @@ let test_unregistered_keeper_is_not_counted () =
       (float 0.5)
       "an unpersisted settlement is not counted"
       before
-      (counted ~outcome:"failed"))
+      (counted ~keeper_name:name ~outcome:"failed"))
 ;;
 
 let test_metric_name_is_stable () =
@@ -169,9 +180,9 @@ let () =
             `Quick
             test_count_tracks_the_durable_streak
         ; test_case
-            "keeper names share one bounded series"
+            "attributes the settlement to its keeper"
             `Quick
-            test_keeper_names_share_one_bounded_series
+            test_attributes_the_settlement_to_its_keeper
         ; test_case
             "an unregistered keeper is not counted"
             `Quick


### PR DESCRIPTION
## 기능 흐름

#26398은 compaction streak을 실제로 움직인 typed outcome을 기록합니다. 다만 `keeper × outcome` label은 Keeper 생성·교체마다 전역 metric store에 삭제되지 않는 새 series를 만들었습니다.

이 PR은 outcome metric을 닫힌 4개 variant의 fleet aggregate로 제한하고, 개별 Keeper outcome은 성공한 durable persistence log에 typed label로 남깁니다. 현재 Keeper별 streak/count SSOT는 기존 durable `compaction_rt`를 그대로 사용합니다.

## 변경

- `masc_keeper_compaction_settlements_total{outcome=...}`만 방출
- 성공한 settlement log에 `keeper_name`과 exhaustive typed outcome 기록
- 서로 다른 Keeper가 같은 bounded outcome series를 공유하고 `keeper` label이 생성되지 않음을 회귀 테스트로 고정
- durable meta가 없는 settlement은 계속 집계하지 않음

Gate, threshold, compatibility decoder, migration code, facade는 추가하지 않았습니다.

## 검증

- changed OCaml `ocamlformat --check`: 통과
- changed OCaml parse: 통과
- `git diff --check`: 통과
- focused Dune wrapper는 다른 세션의 bare `dune build .`를 감지해 안전하게 거부됨
- full GitHub CI가 build authority

Fixes the P2 cardinality regression introduced by #26398.