### PR TITLE
fix(dashboard): render Keeper control waits as status

### DIFF
--- a/dashboard/dev-fixtures/keeper-chat-control-status-fixture.html
+++ b/dashboard/dev-fixtures/keeper-chat-control-status-fixture.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ko" data-skin="v2" data-volt="brass">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MASC - Keeper Chat Control Status Fixture</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/demo/keeper-chat-control-status-fixture.ts"></script>
+</body>
+</html>

--- a/dashboard/src/api/schemas/keeper-chat-history.test.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.test.ts
@@ -23,6 +23,19 @@ describe('safeParseKeeperChatHistoryMessage', () => {
     expect(out?.ts).toBeCloseTo(1_712_000_000.25)
   })
 
+  it('accepts a typed external-effect status block with empty content', () => {
+    const out = safeParseKeeperChatHistoryMessage(
+      validMessage({
+        role: 'assistant',
+        content: '',
+        blocks: [{ t: 'status', kind: 'external_effect_pending' }],
+      }),
+    )
+    expect(out?.blocks).toEqual([
+      { t: 'status', kind: 'external_effect_pending' },
+    ])
+  })
+
   it('accepts unknown role strings (open enum for backend-ahead deploys)', () => {
     const out = safeParseKeeperChatHistoryMessage(
       validMessage({ role: 'tool-result-v2' }),

--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -204,6 +204,10 @@ export const KeeperChatBlockSchema = union([
     run_id: optional(string()),
   }),
   object({
+    t: literal('status'),
+    kind: literal('external_effect_pending'),
+  }),
+  object({
     t: literal('trace'),
     trace: array(KeeperChatTraceStepSchema),
   }),

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -173,8 +173,8 @@ describe('ChatTranscript', () => {
       '[data-chat-control-status="external_effect_pending"]',
     )
     expect(status).not.toBeNull()
-    expect(status?.textContent).toContain('승인 대기')
-    expect(status?.textContent).toContain('자동으로 계속합니다')
+    expect(status?.textContent).toContain('승인 요청됨')
+    expect(status?.textContent).toContain('현재 승인 상태')
     expect(status?.textContent).not.toContain('External effect is awaiting')
     expect(container.querySelector('.chat-bubble')).toBeNull()
 
@@ -185,6 +185,34 @@ describe('ChatTranscript', () => {
     expect(window.location.hash).toContain('command')
     expect(window.location.hash).toContain('view=gate')
     window.location.hash = originalHash
+  })
+
+  it('renders the live turn outcome before the persisted status block arrives', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'gate-wait-live',
+            role: 'assistant',
+            source: 'direct_assistant',
+            label: 'sangsu',
+            text: '',
+            rawText: '',
+            details: { turnOutcome: 'external_effect_pending' },
+          }),
+        ]}
+        emptyText="empty"
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const status = container.querySelector(
+      '[data-chat-control-status="external_effect_pending"]',
+    )
+    expect(status).not.toBeNull()
+    expect(status?.textContent).toContain('승인 요청됨')
+    expect(container.querySelector('.chat-bubble')).toBeNull()
   })
 
   it('renders failure rows as a typed card with collapsed diagnostic detail', async () => {

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -148,6 +148,45 @@ describe('ChatTranscript', () => {
     expect(bubble?.textContent).toContain('✓')
   })
 
+  it('renders a typed external-effect wait as an actionable status, not assistant prose', () => {
+    const originalHash = window.location.hash
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'gate-wait-1',
+            role: 'assistant',
+            source: 'direct_assistant',
+            label: 'sangsu',
+            text: '',
+            rawText: '',
+            blocks: [{ t: 'status', kind: 'external_effect_pending' }],
+          }),
+        ]}
+        emptyText="empty"
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const status = container.querySelector(
+      '[data-chat-control-status="external_effect_pending"]',
+    )
+    expect(status).not.toBeNull()
+    expect(status?.textContent).toContain('승인 대기')
+    expect(status?.textContent).toContain('자동으로 계속합니다')
+    expect(status?.textContent).not.toContain('External effect is awaiting')
+    expect(container.querySelector('.chat-bubble')).toBeNull()
+
+    const openGate = Array.from(status?.querySelectorAll('button') ?? [])
+      .find(button => button.textContent?.includes('승인 화면 열기'))
+    expect(openGate).toBeDefined()
+    fireEvent.click(openGate!)
+    expect(window.location.hash).toContain('command')
+    expect(window.location.hash).toContain('view=gate')
+    window.location.hash = originalHash
+  })
+
   it('renders failure rows as a typed card with collapsed diagnostic detail', async () => {
     const text = 'Keeper request failed: Internal error: [masc_oas_error] {"kind":"accept_rejected","scope":"ollama_cloud.deepseek-v4-flash","reason_kind":"no_usable_progress"}'
     render(

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2573,16 +2573,16 @@ function ChatControlStatusCard({
         </div>
         <div class="min-w-0 flex-1">
           <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
-            <strong class="text-sm font-semibold text-[var(--color-fg-primary)]">승인 대기</strong>
+            <strong class="text-sm font-semibold text-[var(--color-fg-primary)]">승인 요청됨</strong>
             ${timestamp
               ? html`<span class="text-2xs tabular-nums text-[var(--color-fg-muted)]">${timestamp}</span>`
               : null}
           </div>
           <p class="mt-1 text-sm leading-paragraph text-[var(--color-fg-secondary)]">
-            외부 작업을 실행하기 전에 확인이 필요합니다.
+            외부 작업을 실행하기 위한 확인 요청이 기록되었습니다.
           </p>
           <p class="mt-0.5 text-xs leading-paragraph text-[var(--color-fg-muted)]">
-            승인 또는 거절되면 Keeper가 이 대화에서 자동으로 계속합니다.
+            현재 승인 상태는 승인 화면에서 확인할 수 있습니다.
           </p>
           <div class="mt-3 flex flex-wrap gap-2">
             <button

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -10,7 +10,7 @@ import { linkifyHtmlReferences } from './chat-linkify'
 import { UNREAD_DIVIDER_LABEL, unreadDividerAnchorKey } from './unread-divider'
 import { showToast } from '../common/toast'
 import { copyToClipboard } from '../common/copyable-code'
-import { ExternalLink, Mic, Square } from 'lucide-preact'
+import { ArrowRight, ExternalLink, Mic, ShieldCheck, Square } from 'lucide-preact'
 import { prettyJson } from '../tool-call-shared'
 import { useVoiceInput } from './voice-input'
 
@@ -2528,7 +2528,91 @@ const CARD_BLOCK_TYPES: ReadonlySet<ChatBlock['t']> = new Set([
   'broadcast',
   'trace',
   'shell',
+  'status',
 ])
+
+type ChatControlStatus = 'external_effect_pending'
+
+function chatControlStatus(entry: KeeperConversationEntry): ChatControlStatus | null {
+  const persistedStatus = (entry.blocks ?? []).find(
+    (block): block is Extract<ChatBlock, { t: 'status' }> => block.t === 'status',
+  )
+  if (persistedStatus) return persistedStatus.kind
+  return entry.details?.turnOutcome === 'external_effect_pending'
+    ? 'external_effect_pending'
+    : null
+}
+
+function ChatControlStatusCard({
+  entry,
+  action,
+}: {
+  entry: KeeperConversationEntry
+  action?: ChatTranscriptAction
+}) {
+  const status = chatControlStatus(entry)
+  if (status !== 'external_effect_pending') return null
+  const timestamp = timeLabel(entry.timestamp)
+  const supportingBlocks = (entry.blocks ?? []).filter(block => block.t !== 'status')
+
+  return html`
+    <article
+      class="w-full rounded-[var(--r-2)] border border-[var(--warn-35)] bg-[var(--warn-10)] px-4 py-3.5"
+      role="status"
+      aria-live="polite"
+      data-chat-control-status="external_effect_pending"
+      data-chat-entry-id=${entry.id}
+      data-chat-turn-ref=${entry.turnRef ?? undefined}
+    >
+      <div class="flex items-start gap-3">
+        <div
+          class="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-full border border-[var(--warn-35)] bg-[var(--color-bg-surface)] text-[var(--color-status-warn)]"
+          aria-hidden="true"
+        >
+          <${ShieldCheck} size=${18} />
+        </div>
+        <div class="min-w-0 flex-1">
+          <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <strong class="text-sm font-semibold text-[var(--color-fg-primary)]">승인 대기</strong>
+            ${timestamp
+              ? html`<span class="text-2xs tabular-nums text-[var(--color-fg-muted)]">${timestamp}</span>`
+              : null}
+          </div>
+          <p class="mt-1 text-sm leading-paragraph text-[var(--color-fg-secondary)]">
+            외부 작업을 실행하기 전에 확인이 필요합니다.
+          </p>
+          <p class="mt-0.5 text-xs leading-paragraph text-[var(--color-fg-muted)]">
+            승인 또는 거절되면 Keeper가 이 대화에서 자동으로 계속합니다.
+          </p>
+          <div class="mt-3 flex flex-wrap gap-2">
+            <button
+              type="button"
+              class="inline-flex items-center gap-1.5 rounded-[var(--r-1)] border border-[var(--warn-35)] bg-[var(--color-bg-surface)] px-3 py-1.5 text-xs font-semibold text-[var(--color-fg-primary)] transition-colors hover:bg-[var(--color-bg-hover)] ${CHAT_FOCUS_RING}"
+              onClick=${() => navigate('command', { section: 'operations', view: 'gate' })}
+            >
+              승인 화면 열기
+              <${ArrowRight} size=${13} aria-hidden="true" />
+            </button>
+            ${action?.onClick
+              ? html`
+                  <button
+                    type="button"
+                    class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-transparent px-3 py-1.5 text-xs font-medium text-[var(--color-fg-secondary)] transition-colors hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)] ${CHAT_FOCUS_RING}"
+                    onClick=${() => action.onClick?.(entry)}
+                  >
+                    ${action.label ?? '턴 상세'}
+                  </button>
+                `
+              : null}
+          </div>
+        </div>
+      </div>
+      ${supportingBlocks.length > 0
+        ? html`<div class="mt-3"><${ChatBlocks} blocks=${supportingBlocks} fallbackText="" /></div>`
+        : null}
+    </article>
+  `
+}
 
 // Memoized message bubble. A streaming reply re-renders the conversation panel
 // on every SSE event; the transcript reconcile preserves the entry reference of
@@ -2927,6 +3011,32 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
     </article>
   `
 })
+
+function ChatMessageSurface({
+  entry,
+  showMetadata = true,
+  variant = 'default',
+  showSourceBadge = false,
+  action,
+}: {
+  entry: KeeperConversationEntry
+  showMetadata?: boolean
+  variant?: ChatTranscriptVariant
+  showSourceBadge?: boolean
+  action?: ChatTranscriptAction
+}) {
+  return chatControlStatus(entry)
+    ? html`<${ChatControlStatusCard} entry=${entry} action=${action} />`
+    : html`
+        <${ChatMessageBubble}
+          entry=${entry}
+          showMetadata=${showMetadata}
+          variant=${variant}
+          showSourceBadge=${showSourceBadge}
+          action=${action}
+        />
+      `
+}
 
 // Pretty-print a JSON-looking string; leave anything else untouched. Shared by
 // the argument and output renderers so both read consistently.
@@ -3589,7 +3699,7 @@ const TurnWorkBundle = memo(function TurnWorkBundle({
         toolOutputsCoveredThroughMs=${toolOutputsCoveredThroughMs}
         toolOutputHydrationContract=${toolOutputHydrationContract}
       />
-      <${ChatMessageBubble}
+      <${ChatMessageSurface}
         entry=${assistant}
         showMetadata=${showMetadata !== false}
         variant=${variant}
@@ -3788,7 +3898,7 @@ function renderChatTranscriptBody(opts: {
     } else if (unit.entry.role === 'tool') {
       out.push(html`<${ToolCallBubble} key=${unit.entry.id} entry=${unit.entry} />`)
     } else {
-      out.push(html`<${ChatMessageBubble}
+      out.push(html`<${ChatMessageSurface}
         key=${unit.entry.id}
         entry=${unit.entry}
         showMetadata=${showMetadata !== false}

--- a/dashboard/src/demo/keeper-chat-control-status-fixture.ts
+++ b/dashboard/src/demo/keeper-chat-control-status-fixture.ts
@@ -126,7 +126,7 @@ export function ControlStatusFixture() {
             작업 상태는 대화문이 아닙니다
           </h1>
           <p class="mt-2 text-sm" style="color: var(--text-muted);">
-            도구 실행만 있는 턴은 작업 타임라인으로, 승인 대기는 다음 행동이 있는 상태 카드로 표시합니다.
+            도구 실행만 있는 턴은 작업 타임라인으로, 승인 요청은 다음 행동이 있는 상태 카드로 표시합니다.
           </p>
         </header>
         <div

--- a/dashboard/src/demo/keeper-chat-control-status-fixture.ts
+++ b/dashboard/src/demo/keeper-chat-control-status-fixture.ts
@@ -1,0 +1,155 @@
+import '../styles/ds-theme-tokens.css'
+import '../styles/global.css'
+import '../styles/keeper-workspace.css'
+import '../styles/chat-blocks-v2.css'
+
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import type { ToolCallEntry } from '../api/dashboard'
+import { ChatTranscript } from '../components/chat/primitives'
+import { recordToolCallOutputs, resetToolCallOutputs } from '../tool-call-output-store'
+import type { KeeperConversationEntry } from '../types'
+
+const keeperName = 'kidsnote'
+
+const deliveredSurfacePost: ToolCallEntry = {
+  ts: Date.parse('2026-07-30T02:00:01.000Z') / 1000,
+  keeper: keeperName,
+  tool: 'keeper_surface_post',
+  tool_use_id: 'tc-surface-post',
+  input: { surface: 'dashboard' },
+  output: '{"delivered":true}',
+  success: true,
+  duration_ms: 18,
+}
+
+export const controlStatusFixtureEntries: KeeperConversationEntry[] = [
+  {
+    id: 'user-tool-only',
+    role: 'user',
+    source: 'direct_user',
+    label: '사용자',
+    text: '현재 채널에 확인 메시지를 보내줘.',
+    rawText: '현재 채널에 확인 메시지를 보내줘.',
+    timestamp: '2026-07-30T02:00:00.000Z',
+    delivery: 'history',
+    streamState: null,
+    details: null,
+    error: null,
+  },
+  {
+    id: 'tool-tc-surface-post',
+    role: 'tool',
+    source: 'tool_result',
+    label: 'keeper_surface_post',
+    text: '{"surface":"dashboard"}',
+    rawText: '{"surface":"dashboard"}',
+    timestamp: '2026-07-30T02:00:01.000Z',
+    turnRef: 'trace-tool-only#1',
+    delivery: 'history',
+    streamState: null,
+    details: null,
+    error: null,
+  },
+  {
+    id: 'user-gated-effect',
+    role: 'user',
+    source: 'direct_user',
+    label: '사용자',
+    text: '외부 저장소에 변경을 적용해줘.',
+    rawText: '외부 저장소에 변경을 적용해줘.',
+    timestamp: '2026-07-30T02:01:00.000Z',
+    delivery: 'history',
+    streamState: null,
+    details: null,
+    error: null,
+  },
+  {
+    id: 'tool-tc-gated-effect',
+    role: 'tool',
+    source: 'tool_result',
+    label: 'external_change',
+    text: '{"target":"repository"}',
+    rawText: '{"target":"repository"}',
+    timestamp: '2026-07-30T02:01:01.000Z',
+    turnRef: 'trace-gate-wait#2',
+    delivery: 'history',
+    streamState: null,
+    details: null,
+    error: null,
+  },
+  {
+    id: 'assistant-gate-wait',
+    role: 'assistant',
+    source: 'direct_assistant',
+    label: keeperName,
+    text: '',
+    rawText: '',
+    timestamp: '2026-07-30T02:01:02.000Z',
+    turnRef: 'trace-gate-wait#2',
+    delivery: 'history',
+    streamState: null,
+    details: {
+      turnOutcome: 'external_effect_pending',
+    },
+    blocks: [{ t: 'status', kind: 'external_effect_pending' }],
+    error: null,
+  },
+]
+
+const fakeAssistantProseCount = controlStatusFixtureEntries.filter(
+  entry => entry.role === 'assistant' && entry.text.trim().length > 0,
+).length
+const statusCount = controlStatusFixtureEntries.filter(
+  entry => entry.blocks?.some(block => block.t === 'status'),
+).length
+const fixtureStatus =
+  fakeAssistantProseCount === 0 && statusCount === 1 ? 'ok' : 'invalid'
+
+export function ControlStatusFixture() {
+  return html`
+    <main
+      class="min-h-screen px-4 py-8"
+      style="background: var(--bg-deep);"
+      data-keeper-chat-layout="workspace"
+      data-control-status-fixture
+      data-control-status-fixture-status=${fixtureStatus}
+      data-fake-assistant-prose-count=${fakeAssistantProseCount}
+      data-control-status-count=${statusCount}
+    >
+      <section class="mx-auto max-w-[820px]">
+        <header class="mb-5">
+          <p class="font-mono text-2xs uppercase tracking-[0.2em]" style="color: var(--text-dim);">
+            Keeper Chat Control Status Fixture
+          </p>
+          <h1 class="mt-2 text-xl font-semibold" style="color: var(--text-main);">
+            작업 상태는 대화문이 아닙니다
+          </h1>
+          <p class="mt-2 text-sm" style="color: var(--text-muted);">
+            도구 실행만 있는 턴은 작업 타임라인으로, 승인 대기는 다음 행동이 있는 상태 카드로 표시합니다.
+          </p>
+        </header>
+        <div
+          class="kw-chat rounded-[var(--r-2)] border p-4"
+          style="background: var(--bg-panel); border-color: var(--border-main);"
+        >
+          <${ChatTranscript}
+            entries=${controlStatusFixtureEntries}
+            emptyText="No control-status rows"
+            variant="messenger"
+            size="primary"
+            showMetadata=${false}
+            groupToolCalls=${true}
+          />
+        </div>
+      </section>
+    </main>
+  `
+}
+
+const root = document.getElementById('app')
+if (root) {
+  resetToolCallOutputs()
+  recordToolCallOutputs([deliveredSurfacePost])
+  render(html`<${ControlStatusFixture} />`, root)
+}

--- a/dashboard/src/keeper-message.test.ts
+++ b/dashboard/src/keeper-message.test.ts
@@ -203,6 +203,15 @@ describe('normalizeKeeperConversationDetails', () => {
     // Then reply || null: '' is falsy => null
     expect(result!.replyText).toBeNull()
   })
+
+  it('decodes the typed external-effect wait without reply prose', () => {
+    const result = normalizeKeeperConversationDetails({
+      reply: '',
+      turn_outcome: 'external_effect_pending',
+    })
+    expect(result?.turnOutcome).toBe('external_effect_pending')
+    expect(result?.replyText).toBeNull()
+  })
 })
 
 // ================================================================

--- a/dashboard/src/keeper-message.ts
+++ b/dashboard/src/keeper-message.ts
@@ -25,6 +25,8 @@ function normalizeKeeperTurnOutcome(value: unknown): KeeperTurnOutcome | null {
       return 'visible_reply'
     case 'continuation_checkpoint':
       return 'continuation_checkpoint'
+    case 'external_effect_pending':
+      return 'external_effect_pending'
     case 'no_visible_reply':
       return 'no_visible_reply'
     default:
@@ -55,7 +57,9 @@ function normalizeKeeperUsage(raw: unknown): NonNullable<KeeperConversationDetai
 export function keeperTurnOutcomeSuppressesReply(
   outcome: KeeperTurnOutcome | null | undefined,
 ): boolean {
-  return outcome === 'continuation_checkpoint' || outcome === 'no_visible_reply'
+  return outcome === 'continuation_checkpoint'
+    || outcome === 'external_effect_pending'
+    || outcome === 'no_visible_reply'
 }
 
 export function normalizeKeeperConversationDetails(raw: unknown): KeeperConversationDetails | null {

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -1300,6 +1300,23 @@ describe('thread history merge & persistence', () => {
     ])
   })
 
+  it('keeps a typed control-status block when assistant content is empty', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      {
+        role: 'assistant',
+        content: '',
+        ts: 1_780_000_000,
+        blocks: [{ t: 'status', kind: 'external_effect_pending' }],
+      },
+    ])
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.text).toBe('')
+    expect(entries[0]?.blocks).toEqual([
+      { t: 'status', kind: 'external_effect_pending' },
+    ])
+  })
+
   it('still drops rows that have no content and no attachments', () => {
     const entries = chatHistoryEntriesFromRest('echo', [
       { role: 'user', content: '', ts: 1_780_000_000 },

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -536,6 +536,11 @@ function normalizeBlocks(raw: unknown, role: KeeperConversationRole): ChatBlock[
         const html = asString(item.html)
         return html ? { t: 'h4', html } : null
       }
+      if (t === 'status') {
+        return asString(item.kind) === 'external_effect_pending'
+          ? { t: 'status', kind: 'external_effect_pending' }
+          : null
+      }
       if (t === 'ul') {
         const items = normalizeStringArray(item.items)
         return items && items.length > 0 ? { t: 'ul', items } : null

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -683,12 +683,13 @@ interface KeeperConversationUsage {
 }
 
 // RFC-0232 P2: producer-typed turn outcome carried in the reply payload
-// (`turn_outcome`). `continuation_checkpoint` marks the synthetic
-// resume-next-cycle notice; `no_visible_reply` marks a completed runtime
-// turn with no assistant text for the chat surface.
+// (`turn_outcome`). `continuation_checkpoint` marks a resume-next-cycle
+// boundary, `external_effect_pending` marks a durable control wait, and
+// `no_visible_reply` marks a completed runtime turn with no assistant text.
 export type KeeperTurnOutcome =
   | 'visible_reply'
   | 'continuation_checkpoint'
+  | 'external_effect_pending'
   | 'no_visible_reply'
 
 export type KeeperQueueReceiptLifecycle =
@@ -857,6 +858,7 @@ export type ChatBroadcastBlock = { t: 'broadcast'; scope: string; via?: string; 
 // keeper_chat_blocks.ml); ChatFusionCard lazy-fetches the board post by
 // board_post_id and renders its meta_json (panel answers + judge synthesis).
 export type ChatFusionBlock = { t: 'fusion'; board_post_id: string; run_id?: string }
+export type ChatStatusBlock = { t: 'status'; kind: 'external_effect_pending' }
 
 export type ChatBlock =
   | ChatTextBlock
@@ -880,6 +882,7 @@ export type ChatBlock =
   | ChatLinkBlock
   | ChatBroadcastBlock
   | ChatFusionBlock
+  | ChatStatusBlock
 export type KeeperConversationStreamState =
   | 'opening'
   | 'thinking'

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -842,39 +842,49 @@ let dispatch_core ?on_text_snapshot ~submitted_by ~sw ~clock ~proc_mgr ~net
         with Yojson.Json_error _ -> None
       in
       let reply = extract_reply_text body |> redact_text in
-      let connector_reply, blocks =
-        match
-          Keeper_chat_blocks.connector_projection
-            ~turn_outcome:
-              (Keeper_turn_outcome.of_reply_payload payload_json_opt)
-            ~reply
-        with
-        | Connector_text text -> text, None
-        | Connector_status { kind } ->
-          ( Keeper_chat_blocks.status_kind_connector_text kind
-          , Some
-              [ Keeper_chat_blocks.Status
-                  { kind }
-              ] )
-        | Connector_no_visible_reply -> "", None
-      in
-      let structured = Option.map redact_json (extract_structured body) in
-      let stats = match extract_turn_stats body with
-        | Some s -> Some { s with duration_ms }
-        | None -> Some { Gate_protocol.model_used = "runtime"; duration_ms; tokens_used = 0 }
-      in
-      (* RFC-0233 §7: pull the turn's join key out of the same reply payload
-         (parse, don't repair) so the connector assistant row joins to its
-         Turn_record. *)
-      let turn_ref =
-        Keeper_turn_outcome.turn_ref_of_reply_payload
-          payload_json_opt
-      in
-      persist_connector_assistant_reply
-        ~base_dir:config.Workspace.base_path ~keeper_name ~surface
-        ?conversation_id ?turn_ref ?blocks ~reply ();
-      Gate_protocol.Reply
-        { content = connector_reply; structured; stats; message_request = None }
+      (match Keeper_turn_outcome.of_reply_payload payload_json_opt with
+       | Error error ->
+         Gate_protocol.Keeper_error_result
+           (redact_text
+              ("keeper reply contract error: "
+               ^ Keeper_turn_outcome.decode_error_to_string error))
+       | Ok turn_outcome ->
+         let connector_reply, blocks =
+           match
+             Keeper_chat_blocks.connector_projection ~turn_outcome ~reply
+           with
+           | Connector_text text -> text, None
+           | Connector_status { kind } ->
+             ( Keeper_chat_blocks.status_kind_connector_text kind
+             , Some [ Keeper_chat_blocks.Status { kind } ] )
+           | Connector_no_visible_reply -> "", None
+         in
+         let structured = Option.map redact_json (extract_structured body) in
+         let stats =
+           match extract_turn_stats body with
+           | Some s -> Some { s with duration_ms }
+           | None ->
+             Some
+               { Gate_protocol.model_used = "runtime"
+               ; duration_ms
+               ; tokens_used = 0
+               }
+         in
+         (* RFC-0233 §7: pull the turn's join key out of the same reply payload
+            (parse, don't repair) so the connector assistant row joins to its
+            Turn_record. *)
+         let turn_ref =
+           Keeper_turn_outcome.turn_ref_of_reply_payload payload_json_opt
+         in
+         persist_connector_assistant_reply
+           ~base_dir:config.Workspace.base_path ~keeper_name ~surface
+           ?conversation_id ?turn_ref ?blocks ~reply ();
+         Gate_protocol.Reply
+           { content = connector_reply
+           ; structured
+           ; stats
+           ; message_request = None
+           })
   | `Async_ack (_, Some result) | `Streaming (Some result) ->
       Gate_protocol.Keeper_error_result (redact_text (Tool_result.message result))
   | `Async_ack (_, None) | `Streaming None ->

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -620,14 +620,19 @@ let accept_connector ~delivery ~clock ~config ~channel ~channel_user_id
                      (Keeper_chat_queue.mutation_error_to_string error))))))
 
 let persist_connector_assistant_reply ~base_dir ~keeper_name ~surface
-    ?conversation_id ?turn_ref ~reply () =
+    ?conversation_id ?turn_ref ?blocks ~reply () =
   let content = String.trim reply in
-  if content <> "" then begin
+  let has_blocks =
+    match blocks with
+    | Some (_ :: _) -> true
+    | Some [] | None -> false
+  in
+  if content <> "" || has_blocks then begin
     let source = Surface_ref.lane_label surface in
     (* RFC-0233 §7: [turn_ref] is the join key the keeper minted into the
        reply payload, carried onto this connector turn's assistant row. *)
     Keeper_chat_store.append_assistant_message ~base_dir ~keeper_name
-      ~content ~surface ?conversation_id ?turn_ref ();
+      ~content ~surface ?conversation_id ?blocks ?turn_ref ();
     Keeper_chat_broadcast.chat_appended ~keeper_name ~source ~content ()
   end
 
@@ -832,7 +837,27 @@ let dispatch_core ?on_text_snapshot ~submitted_by ~sw ~clock ~proc_mgr ~net
         |> Int64.div 1_000_000L
         |> Int64.to_int
       in
+      let payload_json_opt =
+        try Some (Yojson.Safe.from_string body)
+        with Yojson.Json_error _ -> None
+      in
       let reply = extract_reply_text body |> redact_text in
+      let connector_reply, blocks =
+        match
+          Keeper_chat_blocks.connector_projection
+            ~turn_outcome:
+              (Keeper_turn_outcome.of_reply_payload payload_json_opt)
+            ~reply
+        with
+        | Connector_text text -> text, None
+        | Connector_status { kind } ->
+          ( Keeper_chat_blocks.status_kind_connector_text kind
+          , Some
+              [ Keeper_chat_blocks.Status
+                  { kind }
+              ] )
+        | Connector_no_visible_reply -> "", None
+      in
       let structured = Option.map redact_json (extract_structured body) in
       let stats = match extract_turn_stats body with
         | Some s -> Some { s with duration_ms }
@@ -843,13 +868,13 @@ let dispatch_core ?on_text_snapshot ~submitted_by ~sw ~clock ~proc_mgr ~net
          Turn_record. *)
       let turn_ref =
         Keeper_turn_outcome.turn_ref_of_reply_payload
-          (try Some (Yojson.Safe.from_string body)
-           with Yojson.Json_error _ -> None)
+          payload_json_opt
       in
       persist_connector_assistant_reply
         ~base_dir:config.Workspace.base_path ~keeper_name ~surface
-        ?conversation_id ?turn_ref ~reply ();
-      Gate_protocol.Reply { content = reply; structured; stats; message_request = None }
+        ?conversation_id ?turn_ref ?blocks ~reply ();
+      Gate_protocol.Reply
+        { content = connector_reply; structured; stats; message_request = None }
   | `Async_ack (_, Some result) | `Streaming (Some result) ->
       Gate_protocol.Keeper_error_result (redact_text (Tool_result.message result))
   | `Async_ack (_, None) | `Streaming None ->

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -851,7 +851,8 @@ let dispatch_core ?on_text_snapshot ~submitted_by ~sw ~clock ~proc_mgr ~net
        | Ok turn_outcome ->
          let connector_reply, blocks =
            match
-             Keeper_chat_blocks.connector_projection ~turn_outcome ~reply
+             Keeper_chat_blocks.connector_projection ~turn_outcome
+               ~reply:(Some reply)
            with
            | Connector_text text -> text, None
            | Connector_status { kind } ->

--- a/lib/gate_keeper_backend.mli
+++ b/lib/gate_keeper_backend.mli
@@ -126,13 +126,14 @@ val persist_connector_assistant_reply :
   surface:Surface_ref.t ->
   ?conversation_id:string ->
   ?turn_ref:Ids.Turn_ref.t ->
+  ?blocks:Keeper_chat_blocks.chat_block list ->
   reply:string ->
   unit ->
   unit
 (** Persist a completed connector direct reply on the same chat lane that
     received the inbound user line. The typed [surface] is the sole lane
-    identity; compact broadcast labels are derived from it. Empty replies are
-    ignored.
+    identity; compact broadcast labels are derived from it. Empty replies
+    without typed blocks are ignored.
     [turn_ref] (RFC-0233 §7) is the join key the keeper minted into the
     reply payload, stamped on the assistant row. *)
 

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -30,12 +30,11 @@ let normalize_response_text_for_finalization
       ()
   =
   match run_result.stop_reason with
-  | Runtime_agent.Awaiting_external_effect _ ->
-    Ok Keeper_agent_run_response_text.external_effect_deferred_acknowledgement
-  | Runtime_agent.Completed
+  | Runtime_agent.Awaiting_external_effect _
   | Runtime_agent.Yielded_to_chat_waiting _
   | Runtime_agent.Yielded_to_durable_stimulus _
   | Runtime_agent.Yielded_after_repeated_tool_call _
+  | Runtime_agent.Completed
   | Runtime_agent.InputRequired _ ->
   if
     Keeper_agent_run_response_text.stop_reason_suppresses_visible_response

--- a/lib/keeper/keeper_agent_run_response_text.ml
+++ b/lib/keeper/keeper_agent_run_response_text.ml
@@ -4,17 +4,13 @@ type finalized = {
   response_text : string;
 }
 
-let external_effect_deferred_acknowledgement =
-  "External effect is awaiting Gate approval. The Keeper will continue after the durable resolution."
-;;
-
 let stop_reason_suppresses_visible_response = function
   | Runtime_agent.Yielded_to_chat_waiting _
   | Runtime_agent.Yielded_to_durable_stimulus _
-  | Runtime_agent.Yielded_after_repeated_tool_call _ ->
+  | Runtime_agent.Yielded_after_repeated_tool_call _
+  | Runtime_agent.Awaiting_external_effect _ ->
     true
   | Runtime_agent.Completed
-  | Runtime_agent.Awaiting_external_effect _
   | Runtime_agent.InputRequired _ ->
     false
 ;;

--- a/lib/keeper/keeper_agent_run_response_text.mli
+++ b/lib/keeper/keeper_agent_run_response_text.mli
@@ -4,11 +4,6 @@ type finalized = {
   response_text : string;
 }
 
-(** Deterministic acknowledgement emitted for a Gate-deferred external effect.
-    This is a user-facing completion for the originating chat request; the
-    effect result itself is delivered by the later durable resolution. *)
-val external_effect_deferred_acknowledgement : string
-
 (** [true] for typed control checkpoints and no-output execution observations
     that must not manufacture a chat reply. Their state remains observable
     through typed stop/event surfaces. *)

--- a/lib/keeper/keeper_chat_blocks.ml
+++ b/lib/keeper/keeper_chat_blocks.ml
@@ -85,6 +85,11 @@ type status_kind = External_effect_pending
 
 type status_block = { kind : status_kind }
 
+let status_kind_connector_text = function
+  | External_effect_pending ->
+    "승인 대기: 외부 작업을 실행하기 전에 확인이 필요합니다."
+;;
+
 type trace_tool_status =
   | Trace_tool_pending
   | Trace_tool_ok

--- a/lib/keeper/keeper_chat_blocks.ml
+++ b/lib/keeper/keeper_chat_blocks.ml
@@ -96,16 +96,18 @@ type connector_projection =
   | Connector_no_visible_reply
 
 let connector_projection ~turn_outcome ~reply =
-  match turn_outcome with
-  | Keeper_turn_outcome.External_effect_pending ->
+  match turn_outcome, reply with
+  | Keeper_turn_outcome.External_effect_pending, _ ->
     Connector_status { kind = External_effect_pending }
-  | Keeper_turn_outcome.Visible_reply ->
+  | Keeper_turn_outcome.Visible_reply, Some reply ->
     let reply = String.trim reply in
     if String.equal reply ""
     then Connector_no_visible_reply
     else Connector_text reply
-  | Keeper_turn_outcome.Continuation_checkpoint
-  | Keeper_turn_outcome.No_visible_reply ->
+  | Keeper_turn_outcome.Visible_reply, None ->
+    Connector_no_visible_reply
+  | Keeper_turn_outcome.Continuation_checkpoint, _
+  | Keeper_turn_outcome.No_visible_reply, _ ->
     Connector_no_visible_reply
 ;;
 

--- a/lib/keeper/keeper_chat_blocks.ml
+++ b/lib/keeper/keeper_chat_blocks.ml
@@ -90,6 +90,25 @@ let status_kind_connector_text = function
     "승인 대기: 외부 작업을 실행하기 전에 확인이 필요합니다."
 ;;
 
+type connector_projection =
+  | Connector_text of string
+  | Connector_status of status_block
+  | Connector_no_visible_reply
+
+let connector_projection ~turn_outcome ~reply =
+  match turn_outcome with
+  | Keeper_turn_outcome.External_effect_pending ->
+    Connector_status { kind = External_effect_pending }
+  | Keeper_turn_outcome.Visible_reply ->
+    let reply = String.trim reply in
+    if String.equal reply ""
+    then Connector_no_visible_reply
+    else Connector_text reply
+  | Keeper_turn_outcome.Continuation_checkpoint
+  | Keeper_turn_outcome.No_visible_reply ->
+    Connector_no_visible_reply
+;;
+
 type trace_tool_status =
   | Trace_tool_pending
   | Trace_tool_ok

--- a/lib/keeper/keeper_chat_blocks.ml
+++ b/lib/keeper/keeper_chat_blocks.ml
@@ -81,6 +81,10 @@ type fusion_block = {
   run_id : string;
 }
 
+type status_kind = External_effect_pending
+
+type status_block = { kind : status_kind }
+
 type trace_tool_status =
   | Trace_tool_pending
   | Trace_tool_ok
@@ -129,6 +133,7 @@ type chat_block =
   | Image of image_block
   | Link of link_block
   | Fusion of fusion_block
+  | Status of status_block
   | Trace of trace_block
   | Thinking of thinking_block
 
@@ -260,6 +265,15 @@ let trace_tool_status_to_label = function
   | Trace_tool_pending -> "pending"
   | Trace_tool_ok -> "ok"
   | Trace_tool_err -> "err"
+;;
+
+let status_kind_to_label = function
+  | External_effect_pending -> "external_effect_pending"
+;;
+
+let status_kind_of_label = function
+  | "external_effect_pending" -> Some External_effect_pending
+  | _ -> None
 ;;
 
 let trace_tool_status_of_label = function
@@ -539,6 +553,11 @@ let block_to_yojson = function
       ; ("board_post_id", `String board_post_id)
       ; ("run_id", `String run_id)
       ]
+  | Status { kind } ->
+    `Assoc
+      [ ("t", `String "status")
+      ; ("kind", `String (status_kind_to_label kind))
+      ]
   | Trace { trace } ->
     `Assoc
       [ ("t", `String "trace")
@@ -725,6 +744,9 @@ let block_of_yojson json : chat_block option =
        Option.bind (get_string "board_post_id") (fun board_post_id ->
          let run_id = Option.value (get_string "run_id") ~default:"" in
          Some (Fusion { board_post_id; run_id }))
+     | Some "status" ->
+       Option.bind (get_string "kind") (fun label ->
+         Option.map (fun kind -> Status { kind }) (status_kind_of_label label))
      | Some "trace" ->
        Option.bind (List.assoc_opt "trace" fields) (fun trace_json ->
          Option.bind (trace_steps_of_yojson trace_json) (fun trace ->

--- a/lib/keeper/keeper_chat_blocks.mli
+++ b/lib/keeper/keeper_chat_blocks.mli
@@ -108,6 +108,19 @@ val status_kind_connector_text : status_kind -> string
 (** Channel-facing presentation for a typed status. This is delivery UI text,
     not assistant output, and must not be persisted as assistant content. *)
 
+type connector_projection =
+  | Connector_text of string
+  | Connector_status of status_block
+  | Connector_no_visible_reply
+
+val connector_projection :
+  turn_outcome:Keeper_turn_outcome.t ->
+  reply:string ->
+  connector_projection
+(** Project the producer-typed turn outcome onto connector UI. Status remains a
+    typed block for transcript persistence; only the connector boundary renders
+    it as text. *)
+
 type trace_tool_status =
   | Trace_tool_pending
   | Trace_tool_ok

--- a/lib/keeper/keeper_chat_blocks.mli
+++ b/lib/keeper/keeper_chat_blocks.mli
@@ -100,6 +100,10 @@ type fusion_block = {
   run_id : string;
 }
 
+type status_kind = External_effect_pending
+
+type status_block = { kind : status_kind }
+
 type trace_tool_status =
   | Trace_tool_pending
   | Trace_tool_ok
@@ -160,6 +164,7 @@ type chat_block =
   | Image of image_block
   | Link of link_block
   | Fusion of fusion_block
+  | Status of status_block
   | Trace of trace_block
   | Thinking of thinking_block
 

--- a/lib/keeper/keeper_chat_blocks.mli
+++ b/lib/keeper/keeper_chat_blocks.mli
@@ -115,7 +115,7 @@ type connector_projection =
 
 val connector_projection :
   turn_outcome:Keeper_turn_outcome.t ->
-  reply:string ->
+  reply:string option ->
   connector_projection
 (** Project the producer-typed turn outcome onto connector UI. Status remains a
     typed block for transcript persistence; only the connector boundary renders

--- a/lib/keeper/keeper_chat_blocks.mli
+++ b/lib/keeper/keeper_chat_blocks.mli
@@ -104,6 +104,10 @@ type status_kind = External_effect_pending
 
 type status_block = { kind : status_kind }
 
+val status_kind_connector_text : status_kind -> string
+(** Channel-facing presentation for a typed status. This is delivery UI text,
+    not assistant output, and must not be persisted as assistant content. *)
+
 type trace_tool_status =
   | Trace_tool_pending
   | Trace_tool_ok

--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -342,6 +342,7 @@ let rich_embed_of_chat_block = function
   | Keeper_chat_blocks.Voice _
   | Keeper_chat_blocks.Attach _
   | Keeper_chat_blocks.Fusion _
+  | Keeper_chat_blocks.Status _
   | Keeper_chat_blocks.Trace _
   | Keeper_chat_blocks.Thinking _ -> None
 

--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -570,6 +570,9 @@ let adapter_loop_with_transport ~token ~channel_id ~events ~post_message
     | Image_block { url; caption } ->
         send_image_block ?clock ~token ~channel_id ~url ~caption ();
         loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
+    | Status_block { kind } ->
+        let acc_text = Keeper_chat_blocks.status_kind_connector_text kind in
+        loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
     | Audio_block { token; mime = _; message_text; duration_sec } ->
         send_audio_block ?clock ~token ~channel_id ~base_url ~audio_token:token
           ~message_text ~duration_sec ();

--- a/lib/keeper/keeper_chat_discord.mli
+++ b/lib/keeper/keeper_chat_discord.mli
@@ -50,6 +50,7 @@ val adapter_loop :
       chat-block parser.
     - [Event_error]: sends error text as a new message.
     - [Link_block], [Image_block], [Audio_block]: send rich block embeds
+    - [Status_block]: replace the terminal assistant text with typed status UI
       or messages.
     - [Tool_context_block]: enriches the matching tool embed with argument
       and result summaries on [Tool_call_end].

--- a/lib/keeper/keeper_chat_events.ml
+++ b/lib/keeper/keeper_chat_events.ml
@@ -75,6 +75,7 @@ type keeper_chat_event =
       ; image : string option
       }
   | Image_block of { url : string; caption : string option }
+  | Status_block of Keeper_chat_blocks.status_block
   | Audio_block of
       { token : string
       ; mime : string

--- a/lib/keeper/keeper_chat_events.mli
+++ b/lib/keeper/keeper_chat_events.mli
@@ -83,6 +83,9 @@ type keeper_chat_event =
       ; image : string option
       }
   | Image_block of { url : string; caption : string option }
+  | Status_block of Keeper_chat_blocks.status_block
+      (** Typed control status for channel adapters. It is rendered as channel
+          UI and never reclassified as assistant speech. *)
   | Audio_block of
       { token : string
       ; mime : string

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -186,6 +186,7 @@ let slack_block_of_chat_block = function
   | Keeper_chat_blocks.Voice _
   | Keeper_chat_blocks.Attach _
   | Keeper_chat_blocks.Fusion _
+  | Keeper_chat_blocks.Status _
   | Keeper_chat_blocks.Trace _
   | Keeper_chat_blocks.Thinking _ -> None
 

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -158,6 +158,18 @@ let mermaid_block_json ~source =
     ; ("text", `Assoc [ ("type", `String "mrkdwn"); ("text", `String body) ])
     ]
 
+let status_block_json ({ Keeper_chat_blocks.kind } : Keeper_chat_blocks.status_block) =
+  let body =
+    Keeper_chat_blocks.status_kind_connector_text kind
+    |> redact
+    |> escape_mrkdwn_text
+    |> truncate_block_text
+  in
+  `Assoc
+    [ ("type", `String "section")
+    ; ("text", `Assoc [ ("type", `String "mrkdwn"); ("text", `String body) ])
+    ]
+
 (* ── Content → Slack blocks ──────────────────────────────────────── *)
 
 let slack_block_of_chat_block = function
@@ -363,6 +375,9 @@ let adapter_loop_with_transport
     | Image_block { url; caption } ->
         let block = image_block_json ~url ~caption in
         loop ~acc_text ~acc_blocks:(add_block acc_blocks block) ~run_id_opt
+    | Status_block status ->
+        let block = status_block_json status in
+        loop ~acc_text:"" ~acc_blocks:(add_block acc_blocks block) ~run_id_opt
     | Audio_block { token; mime = _; message_text; duration_sec = _ } ->
         let block = audio_block_json ~base_url ~token ~message_text in
         loop ~acc_text ~acc_blocks:(add_block acc_blocks block) ~run_id_opt

--- a/lib/keeper/keeper_chat_slack.mli
+++ b/lib/keeper/keeper_chat_slack.mli
@@ -71,7 +71,7 @@ val adapter_loop :
     blocks on the event stream until [Run_finished] or [Error], then sends
     the accumulated text (or error message) to the given Slack channel.
 
-    Rich events ([Link_block], [Image_block], [Audio_block],
+    Rich events ([Link_block], [Image_block], [Status_block], [Audio_block],
     [Tool_context_block]) are rendered as Slack Block Kit sections and
     included alongside the final message. [Tool_call_start],
     [Tool_call_args], [Tool_call_args_snapshot], and [Tool_call_end] are

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -381,6 +381,8 @@ let redact_block redaction = function
        decision. This is a structural exclusion of an id field, not a
        string-pattern exception. *)
     Keeper_chat_blocks.Fusion { board_post_id; run_id }
+  | Keeper_chat_blocks.Status { kind } ->
+    Keeper_chat_blocks.Status { kind }
   | Keeper_chat_blocks.Trace { trace } ->
     Keeper_chat_blocks.Trace
       { trace = List.map (redact_trace_step redaction) trace }

--- a/lib/keeper/keeper_invocation_contract.ml
+++ b/lib/keeper/keeper_invocation_contract.ml
@@ -175,6 +175,7 @@ let result_contract_of_status = function
   | Keeper_msg_async.Done { ok = true; data; _ } ->
     (match Keeper_turn_outcome.of_reply_payload data with
      | Keeper_turn_outcome.Continuation_checkpoint -> Yielded
+     | Keeper_turn_outcome.External_effect_pending -> Yielded
      | Keeper_turn_outcome.Visible_reply
      | Keeper_turn_outcome.No_visible_reply -> Completed)
 ;;

--- a/lib/keeper/keeper_invocation_contract.ml
+++ b/lib/keeper/keeper_invocation_contract.ml
@@ -174,10 +174,11 @@ let result_contract_of_status = function
   | Keeper_msg_async.Done { ok = false; _ } -> Failed
   | Keeper_msg_async.Done { ok = true; data; _ } ->
     (match Keeper_turn_outcome.of_reply_payload data with
-     | Keeper_turn_outcome.Continuation_checkpoint -> Yielded
-     | Keeper_turn_outcome.External_effect_pending -> Yielded
-     | Keeper_turn_outcome.Visible_reply
-     | Keeper_turn_outcome.No_visible_reply -> Completed)
+     | Error _ -> Failed
+     | Ok Keeper_turn_outcome.Continuation_checkpoint -> Yielded
+     | Ok Keeper_turn_outcome.External_effect_pending -> Yielded
+     | Ok Keeper_turn_outcome.Visible_reply
+     | Ok Keeper_turn_outcome.No_visible_reply -> Completed)
 ;;
 
 let result_contract entry = result_contract_of_status entry.Keeper_msg_async.status

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -545,9 +545,13 @@ let resolve_keeper_name ctx args =
   resolve_keeper_name_config ~config:ctx.config args
 
 let direct_reply_projection json =
-  Keeper_chat_blocks.connector_projection
-    ~turn_outcome:(Keeper_turn_outcome.of_reply_payload (Some json))
-    ~reply:(Option.value ~default:"" (Json_util.get_string json "reply"))
+  match Keeper_turn_outcome.of_reply_payload (Some json) with
+  | Ok turn_outcome ->
+    Keeper_chat_blocks.connector_projection
+      ~turn_outcome
+      ~reply:(Option.value ~default:"" (Json_util.get_string json "reply"))
+  | Error error ->
+    invalid_arg (Keeper_turn_outcome.decode_error_to_string error)
 ;;
 
 let direct_reply_visible_text json =

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -546,6 +546,17 @@ let resolve_keeper_name ctx args =
 
 let direct_reply_projection json =
   match Keeper_turn_outcome.of_reply_payload (Some json) with
+  | Ok Keeper_turn_outcome.Visible_reply ->
+    let reply =
+      match Json_util.get_string json "reply" with
+      | Some reply -> Some reply
+      | None ->
+        invalid_arg
+          "keeper reply payload is missing reply for visible_reply"
+    in
+    Keeper_chat_blocks.connector_projection
+      ~turn_outcome:Keeper_turn_outcome.Visible_reply
+      ~reply
   | Ok turn_outcome ->
     Keeper_chat_blocks.connector_projection
       ~turn_outcome

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -549,7 +549,7 @@ let direct_reply_projection json =
   | Ok turn_outcome ->
     Keeper_chat_blocks.connector_projection
       ~turn_outcome
-      ~reply:(Option.value ~default:"" (Json_util.get_string json "reply"))
+      ~reply:(Json_util.get_string json "reply")
   | Error error ->
     invalid_arg (Keeper_turn_outcome.decode_error_to_string error)
 ;;

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -544,17 +544,16 @@ let resolve_keeper_name_config ~(config : Workspace.config) args =
 let resolve_keeper_name ctx args =
   resolve_keeper_name_config ~config:ctx.config args
 
+let direct_reply_projection json =
+  Keeper_chat_blocks.connector_projection
+    ~turn_outcome:(Keeper_turn_outcome.of_reply_payload (Some json))
+    ~reply:(Option.value ~default:"" (Json_util.get_string json "reply"))
+;;
+
 let direct_reply_visible_text json =
-  match Keeper_turn_outcome.of_reply_payload (Some json) with
-  | Keeper_turn_outcome.Continuation_checkpoint -> None
-  | Keeper_turn_outcome.External_effect_pending -> None
-  | Keeper_turn_outcome.No_visible_reply -> None
-  | Keeper_turn_outcome.Visible_reply -> (
-      match Json_util.get_string json "reply" with
-      | None -> None
-      | Some reply ->
-          let visible = String.trim reply in
-          if visible = "" then None else Some visible)
+  match direct_reply_projection json with
+  | Keeper_chat_blocks.Connector_text text -> Some text
+  | Connector_status _ | Connector_no_visible_reply -> None
 ;;
 
 let append_direct_chat_pair_if_reply ~(config : Workspace.config) ~name ~args result =
@@ -567,9 +566,16 @@ let append_direct_chat_pair_if_reply ~(config : Workspace.config) ~name ~args re
       Keeper_turn_outcome.turn_ref_of_reply_payload
         (Some (Tool_result.data result))
     in
-    match user_content, direct_reply_visible_text (Tool_result.data result) with
+    let projected_assistant =
+      match direct_reply_projection (Tool_result.data result) with
+      | Keeper_chat_blocks.Connector_text text -> Some (text, None)
+      | Connector_status status ->
+        Some ("", Some [ Keeper_chat_blocks.Status status ])
+      | Connector_no_visible_reply -> None
+    in
+    match user_content, projected_assistant with
     | "", _ | _, None -> ()
-    | _, Some assistant_content ->
+    | _, Some (assistant_content, blocks) ->
         (* Agent-initiated [masc_keeper_msg] path: only the final tool
            result is visible here (no stream events), so no tool lines
            are persisted for this surface. *)
@@ -589,6 +595,7 @@ let append_direct_chat_pair_if_reply ~(config : Workspace.config) ~name ~args re
             ~user_attachments:[]
             ~surface:Surface_ref.Agent
             ~assistant_content
+            ?blocks
             ?turn_ref
             ();
           Keeper_chat_broadcast.chat_appended ~keeper_name:name ~source:"agent"
@@ -601,6 +608,7 @@ let append_direct_chat_pair_if_reply ~(config : Workspace.config) ~name ~args re
             ~keeper_name:name
             ~content:assistant_content
             ~surface:(Surface_ref.Gate { label = channel; address = [] })
+            ?blocks
             ?turn_ref
             ();
           Keeper_chat_broadcast.chat_appended ~keeper_name:name ~source:channel

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -547,6 +547,7 @@ let resolve_keeper_name ctx args =
 let direct_reply_visible_text json =
   match Keeper_turn_outcome.of_reply_payload (Some json) with
   | Keeper_turn_outcome.Continuation_checkpoint -> None
+  | Keeper_turn_outcome.External_effect_pending -> None
   | Keeper_turn_outcome.No_visible_reply -> None
   | Keeper_turn_outcome.Visible_reply -> (
       match Json_util.get_string json "reply" with

--- a/lib/keeper/keeper_turn_outcome.ml
+++ b/lib/keeper/keeper_turn_outcome.ml
@@ -55,25 +55,44 @@ let of_result_surface ~response_text = function
   | Runtime_agent.Awaiting_external_effect _ -> External_effect_pending
   | Runtime_agent.InputRequired _ -> Visible_reply
 
+type decode_error =
+  | Payload_missing
+  | Payload_not_object
+  | Turn_outcome_missing
+  | Turn_outcome_duplicate
+  | Turn_outcome_not_string
+  | Turn_outcome_unknown of string
+
+let decode_error_to_string = function
+  | Payload_missing -> "keeper reply payload is missing"
+  | Payload_not_object -> "keeper reply payload must be an object"
+  | Turn_outcome_missing -> "keeper reply payload is missing turn_outcome"
+  | Turn_outcome_duplicate ->
+    "keeper reply payload contains duplicate turn_outcome fields"
+  | Turn_outcome_not_string ->
+    "keeper reply payload field turn_outcome must be a string"
+  | Turn_outcome_unknown label ->
+    Printf.sprintf "keeper reply payload contains unknown turn_outcome %S" label
+;;
+
 let of_reply_payload payload =
   match payload with
-  | None -> Visible_reply
-  | Some json -> (
-      match Json_util.get_string json wire_key with
-      | None -> Visible_reply
-      | Some label -> (
-          match of_label label with
-          | Some outcome -> outcome
-          | None ->
-              (* Unknown label: report, then fail toward persisting —
-                 the bitten failure mode (#20870) was silent
-                 non-persistence (watermark stall, keeper re-answering
-                 the same message).  Never widen [of_label] itself. *)
-              Log.Keeper.warn
-                "turn_outcome: unknown label %S; treating as \
-                 visible_reply"
-                label;
-              Visible_reply))
+  | None -> Error Payload_missing
+  | Some (`Assoc fields) ->
+    (match
+       List.filter_map
+         (fun (key, value) ->
+            if String.equal key wire_key then Some value else None)
+         fields
+     with
+     | [] -> Error Turn_outcome_missing
+     | [ `String label ] ->
+       (match of_label label with
+        | Some outcome -> Ok outcome
+        | None -> Error (Turn_outcome_unknown label))
+     | [ _ ] -> Error Turn_outcome_not_string
+     | _ -> Error Turn_outcome_duplicate)
+  | Some _ -> Error Payload_not_object
 
 let turn_ref_of_reply_payload payload =
   (* RFC-0233 §7: read the turn's join key the keeper minted into the

--- a/lib/keeper/keeper_turn_outcome.ml
+++ b/lib/keeper/keeper_turn_outcome.ml
@@ -5,24 +5,30 @@
 type t =
   | Visible_reply
   | Continuation_checkpoint
+  | External_effect_pending
   | No_visible_reply
 
 let equal a b =
   match (a, b) with
   | Visible_reply, Visible_reply
   | No_visible_reply, No_visible_reply
+  | External_effect_pending, External_effect_pending
   | Continuation_checkpoint, Continuation_checkpoint ->
       true
-  | (Visible_reply | Continuation_checkpoint | No_visible_reply), _ -> false
+  | (Visible_reply | Continuation_checkpoint | External_effect_pending
+    | No_visible_reply), _ ->
+    false
 
 let to_label = function
   | Visible_reply -> "visible_reply"
   | Continuation_checkpoint -> "continuation_checkpoint"
+  | External_effect_pending -> "external_effect_pending"
   | No_visible_reply -> "no_visible_reply"
 
 let of_label = function
   | "visible_reply" -> Some Visible_reply
   | "continuation_checkpoint" -> Some Continuation_checkpoint
+  | "external_effect_pending" -> Some External_effect_pending
   | "no_visible_reply" -> Some No_visible_reply
   | _ -> None
 
@@ -36,7 +42,7 @@ let of_stop_reason = function
   | Runtime_agent.Yielded_to_durable_stimulus _
   | Runtime_agent.Yielded_after_repeated_tool_call _ ->
     Continuation_checkpoint
-  | Runtime_agent.Awaiting_external_effect _ -> Visible_reply
+  | Runtime_agent.Awaiting_external_effect _ -> External_effect_pending
   | Runtime_agent.InputRequired _ -> Visible_reply
 
 let of_result_surface ~response_text = function
@@ -46,8 +52,7 @@ let of_result_surface ~response_text = function
   | Runtime_agent.Yielded_to_durable_stimulus _
   | Runtime_agent.Yielded_after_repeated_tool_call _ ->
     Continuation_checkpoint
-  | Runtime_agent.Awaiting_external_effect _ ->
-    if String.trim response_text = "" then No_visible_reply else Visible_reply
+  | Runtime_agent.Awaiting_external_effect _ -> External_effect_pending
   | Runtime_agent.InputRequired _ -> Visible_reply
 
 let of_reply_payload payload =

--- a/lib/keeper/keeper_turn_outcome.mli
+++ b/lib/keeper/keeper_turn_outcome.mli
@@ -49,14 +49,20 @@ val of_result_surface : response_text:string -> Runtime_agent.stop_reason -> t
     speech surface. A runtime execution-limit observation does not create a
     MASC lifecycle gate. *)
 
-val of_reply_payload : Yojson.Safe.t option -> t
-(** Decode from a parsed keeper reply payload.  Known labels decode to
-    their declared variant.  Absent payload, absent field, or unknown
-    label decodes to [Visible_reply] (unknown labels are logged at WARN):
-    the bitten failure mode (#20870) was a reply silently {e not}
-    persisted — the lane watermark stalled and the keeper re-answered
-    the same message — so decode failure must fail toward persisting,
-    never toward dropping. *)
+type decode_error =
+  | Payload_missing
+  | Payload_not_object
+  | Turn_outcome_missing
+  | Turn_outcome_duplicate
+  | Turn_outcome_not_string
+  | Turn_outcome_unknown of string
+
+val decode_error_to_string : decode_error -> string
+
+val of_reply_payload : Yojson.Safe.t option -> (t, decode_error) result
+(** Decode the required current [turn_outcome] contract. Missing, malformed,
+    duplicate, or unknown values are explicit errors; there is no legacy
+    visible-reply default. *)
 
 val turn_ref_of_reply_payload : Yojson.Safe.t option -> Ids.Turn_ref.t option
 (** Decode the turn's join key ([turn_ref_wire_key]) from a parsed keeper

--- a/lib/keeper/keeper_turn_outcome.mli
+++ b/lib/keeper/keeper_turn_outcome.mli
@@ -2,25 +2,23 @@
 
     The keeper reply payload declares at the write boundary whether its
     [reply] text is model output ([Visible_reply]), absent from the
-    visible surface ([No_visible_reply]), or the synthetic continuation
-    notice substituted when a run stops at a checkpoint boundary
-    ([Continuation_checkpoint]).  Consumers (lane persistence, stream
+    visible surface ([No_visible_reply]), a continuation boundary
+    ([Continuation_checkpoint]), or a durable external-effect wait
+    ([External_effect_pending]). Consumers (lane persistence, stream
     terminal, direct-reply surface, dashboard) match on the decoded
-    variant; the legacy ["Continuation checkpoint saved;"] prefix sniff
-    is deleted. A typed Gate deferral is instead finalized as a visible,
-    host-authored acknowledgement; it must not be projected as a checkpoint
-    transport failure. *)
+    variant; control state is never synthesized into assistant prose. *)
 
 type t =
   | Visible_reply
   | Continuation_checkpoint
+  | External_effect_pending
   | No_visible_reply
 
 val equal : t -> t -> bool
 
 val to_label : t -> string
 (** Closed wire labels: ["visible_reply"] / ["continuation_checkpoint"] /
-    ["no_visible_reply"]. *)
+    ["external_effect_pending"] / ["no_visible_reply"]. *)
 
 val of_label : string -> t option
 (** Inverse of {!to_label}; [None] on any other string. *)
@@ -46,11 +44,10 @@ val of_result_surface : response_text:string -> Runtime_agent.stop_reason -> t
     [Visible_reply].  This keeps hidden read-only/tool-only runtime turns
     from being reported as user-visible replies while preserving the
     explicit continuation checkpoint outcome for control-yield stops.
-    [Awaiting_external_effect] likewise requires a nonblank response: its
-    producer emits the deterministic Gate acknowledgement so a queued
-    originating request is delivered rather than mistaken for a continuation
-    checkpoint. A runtime execution-limit observation does not create a MASC
-    lifecycle gate. *)
+    [Awaiting_external_effect] is [External_effect_pending] regardless of
+    response text; the dashboard renders that typed state outside the assistant
+    speech surface. A runtime execution-limit observation does not create a
+    MASC lifecycle gate. *)
 
 val of_reply_payload : Yojson.Safe.t option -> t
 (** Decode from a parsed keeper reply payload.  Known labels decode to

--- a/lib/keeper_tooling/keeper_tool_response.ml
+++ b/lib/keeper_tooling/keeper_tool_response.ml
@@ -10,11 +10,7 @@ let normalize_response_text ~(text : string) ~(tool_names : string list) ()
   else (
     match tool_names with
     | [] -> Error "keeper turn completed with no textual reply"
-    | _ ->
-      Ok
-        (Printf.sprintf
-           "No textual reply was produced. Tools invoked: %s."
-           (String.concat ", " tool_names)))
+    | _ -> Ok "")
 ;;
 
 type accept_rejection_kind =

--- a/lib/keeper_tooling/keeper_tool_response.mli
+++ b/lib/keeper_tooling/keeper_tool_response.mli
@@ -1,11 +1,9 @@
 (** Keeper_tool_response - provider response acceptance and keeper reply text
     normalization. *)
 
-(** Keep [text] when non-blank; otherwise synthesize a
-    "No textual reply was produced. Tools invoked: ..." line if [tool_names]
-    is non-empty, else error. The fallback reports only observed invocation;
-    it does not claim that tools succeeded or the turn completed. Hidden
-    reasoning is never user-facing fallback text. *)
+(** Keep [text] when non-blank. A blank tool-only turn remains blank because
+    its tool timeline is the user-facing progress surface; a blank turn with no
+    tools is an error. Hidden reasoning is never user-facing fallback text. *)
 val normalize_response_text
   :  text:string
   -> tool_names:string list

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -2687,6 +2687,13 @@ let process_single_turn ~user_row_origin ~queued_turn
            | None -> ());
           if
             Keeper_turn_outcome.equal turn_outcome
+              Keeper_turn_outcome.External_effect_pending
+          then
+            Keeper_chat_events.publish events
+              (Status_block
+                 { kind = Keeper_chat_blocks.External_effect_pending });
+          if
+            Keeper_turn_outcome.equal turn_outcome
               Keeper_turn_outcome.Continuation_checkpoint
           then
             Keeper_chat_events.publish events
@@ -2990,7 +2997,11 @@ let handle_keeper_chat_stream ~sw ~clock ~submitted_by state request reqd payloa
                     ~tool_call_id:(Some tool_call_id)
                     Tool_call_end)
             then loop ()
-        | Link_block _ | Image_block _ | Audio_block _ | Tool_context_block _ ->
+        | Link_block _
+        | Image_block _
+        | Status_block _
+        | Audio_block _
+        | Tool_context_block _ ->
             (* Connector rich blocks are delivered by non-dashboard adapters;
                the SSE stream already receives the underlying text/audio
                through other events. *)

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -1043,15 +1043,24 @@ let empty_direct_reply_error =
   "Keeper completed without a visible reply; the runtime returned only thinking or internal state."
 
 let direct_reply_terminal_error ?(has_visible_blocks = false) payload_json_opt visible_reply =
-  let turn_outcome = Keeper_turn_outcome.of_reply_payload payload_json_opt in
-  match (turn_outcome, String_util.trim_to_option visible_reply, has_visible_blocks) with
-  | Keeper_turn_outcome.Continuation_checkpoint, _, _ -> None
-  | Keeper_turn_outcome.External_effect_pending, _, _ -> None
-  | Keeper_turn_outcome.No_visible_reply, _, true -> None
-  | Keeper_turn_outcome.Visible_reply, None, true -> None
-  | Keeper_turn_outcome.No_visible_reply, _, false -> Some empty_direct_reply_error
-  | Keeper_turn_outcome.Visible_reply, None, false -> Some empty_direct_reply_error
-  | Keeper_turn_outcome.Visible_reply, Some _, _ -> None
+  match Keeper_turn_outcome.of_reply_payload payload_json_opt with
+  | Error error ->
+    Some
+      ("Keeper reply contract error: "
+       ^ Keeper_turn_outcome.decode_error_to_string error)
+  | Ok turn_outcome ->
+    (match
+       turn_outcome, String_util.trim_to_option visible_reply, has_visible_blocks
+     with
+     | Keeper_turn_outcome.Continuation_checkpoint, _, _ -> None
+     | Keeper_turn_outcome.External_effect_pending, _, _ -> None
+     | Keeper_turn_outcome.No_visible_reply, _, true -> None
+     | Keeper_turn_outcome.Visible_reply, None, true -> None
+     | Keeper_turn_outcome.No_visible_reply, _, false ->
+       Some empty_direct_reply_error
+     | Keeper_turn_outcome.Visible_reply, None, false ->
+       Some empty_direct_reply_error
+     | Keeper_turn_outcome.Visible_reply, Some _, _ -> None)
 
 let persisted_reply_blocks ~turn_outcome media_blocks =
   match turn_outcome, media_blocks with

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -1046,11 +1046,29 @@ let direct_reply_terminal_error ?(has_visible_blocks = false) payload_json_opt v
   let turn_outcome = Keeper_turn_outcome.of_reply_payload payload_json_opt in
   match (turn_outcome, String_util.trim_to_option visible_reply, has_visible_blocks) with
   | Keeper_turn_outcome.Continuation_checkpoint, _, _ -> None
+  | Keeper_turn_outcome.External_effect_pending, _, _ -> None
   | Keeper_turn_outcome.No_visible_reply, _, true -> None
   | Keeper_turn_outcome.Visible_reply, None, true -> None
   | Keeper_turn_outcome.No_visible_reply, _, false -> Some empty_direct_reply_error
   | Keeper_turn_outcome.Visible_reply, None, false -> Some empty_direct_reply_error
   | Keeper_turn_outcome.Visible_reply, Some _, _ -> None
+
+let persisted_reply_blocks ~turn_outcome media_blocks =
+  match turn_outcome, media_blocks with
+  | Keeper_turn_outcome.External_effect_pending, Some media_blocks ->
+    Some
+      (Keeper_chat_blocks.Status
+         { kind = Keeper_chat_blocks.External_effect_pending }
+       :: media_blocks)
+  | Keeper_turn_outcome.External_effect_pending, None ->
+    Some
+      [ Keeper_chat_blocks.Status
+          { kind = Keeper_chat_blocks.External_effect_pending }
+      ]
+  | ( Keeper_turn_outcome.Visible_reply
+    | Keeper_turn_outcome.Continuation_checkpoint
+    | Keeper_turn_outcome.No_visible_reply ), media_blocks ->
+    media_blocks
 
 type keeper_stream_terminal_status =
   | Stream_done
@@ -2066,7 +2084,11 @@ let process_single_turn ~user_row_origin ~queued_turn
                this turn's stream) as reload-visible chat blocks so a dashboard
                reload shows media-only replies too, not just text-bearing
                replies. *)
-            let blocks = accumulated_media_blocks () in
+            let blocks =
+              persisted_reply_blocks
+                ~turn_outcome:canonical_reply.turn_outcome
+                (accumulated_media_blocks ())
+            in
             let has_visible_blocks = Option.is_some blocks in
             (match
                direct_reply_terminal_error ~has_visible_blocks payload_json_opt
@@ -2264,11 +2286,7 @@ let process_single_turn ~user_row_origin ~queued_turn
                                  ~source:chat_source
                                  ();
                                if queued_turn
-                               then
-                                 Ok
-                                   (Some
-                                      (Failed
-                                         { kind = No_visible_reply; detail }))
+                               then Ok (Some (queued_delivery_outcome_of_turn_ref turn_ref))
                                else Ok None)
                         | `Failure ->
                           persist_failure_reply ?turn_ref detail
@@ -2280,6 +2298,9 @@ let process_single_turn ~user_row_origin ~queued_turn
                    | Keeper_turn_outcome.Visible_reply, Some visible_reply ->
                        persist_assistant_reply ~assistant_content:visible_reply
                        |> delivered_after_persist ~content:visible_reply
+                   | Keeper_turn_outcome.External_effect_pending, _ ->
+                       persist_assistant_reply ~assistant_content:""
+                       |> delivered_after_persist
                  in
                  (match delivery_result with
                   | Error persist_error ->
@@ -2643,6 +2664,7 @@ let process_single_turn ~user_row_origin ~queued_turn
           let suppress_terminal_reply =
             match turn_outcome with
             | Keeper_turn_outcome.Continuation_checkpoint
+            | Keeper_turn_outcome.External_effect_pending
             | Keeper_turn_outcome.No_visible_reply ->
                 true
             | Keeper_turn_outcome.Visible_reply -> false
@@ -3130,6 +3152,7 @@ module For_testing = struct
 
   let canonical_reply_payload_of_body = canonical_reply_payload_of_body
   let direct_reply_terminal_error = direct_reply_terminal_error
+  let persisted_reply_blocks = persisted_reply_blocks
   let queued_delivery_outcome_of_turn_ref =
     queued_delivery_outcome_of_turn_ref
   let committed_delivery_outcome = committed_delivery_outcome

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -288,6 +288,10 @@ module For_testing : sig
     (canonical_reply_payload, canonical_reply_payload_error) result
   val direct_reply_terminal_error :
     ?has_visible_blocks:bool -> Yojson.Safe.t option -> string -> string option
+  val persisted_reply_blocks :
+    turn_outcome:Keeper_turn_outcome.t ->
+    Keeper_chat_blocks.chat_block list option ->
+    Keeper_chat_blocks.chat_block list option
   val queued_delivery_outcome_of_turn_ref :
     Ids.Turn_ref.t option -> queued_turn_outcome
   val committed_delivery_outcome :

--- a/scripts/harness_dashboard_keeper_chat_control_status_dom_smoke.py
+++ b/scripts/harness_dashboard_keeper_chat_control_status_dom_smoke.py
@@ -1,0 +1,80 @@
+import os
+
+from playwright.sync_api import Page, sync_playwright
+
+
+FIXTURE_URL = os.environ["FIXTURE_URL"]
+DESKTOP_SCREENSHOT = os.environ["DESKTOP_SCREENSHOT"]
+MOBILE_SCREENSHOT = os.environ["MOBILE_SCREENSHOT"]
+FIXTURE_SELECTOR = (
+    '[data-control-status-fixture-status="ok"]'
+    '[data-fake-assistant-prose-count="0"]'
+    '[data-control-status-count="1"]'
+)
+STATUS_SELECTOR = '[data-chat-control-status="external_effect_pending"]'
+
+
+def verify(page: Page, screenshot: str) -> None:
+    page.goto(FIXTURE_URL, wait_until="networkidle", timeout=20_000)
+    page.wait_for_selector(FIXTURE_SELECTOR, timeout=15_000)
+    status = page.locator(STATUS_SELECTOR)
+    if status.count() != 1:
+        raise RuntimeError(f"expected one control status, got {status.count()}")
+
+    body_text = page.locator("body").inner_text()
+    forbidden = (
+        "No textual reply was produced",
+        "Tools invoked:",
+        "External effect is awaiting Gate approval",
+    )
+    for text in forbidden:
+        if text in body_text:
+            raise RuntimeError(f"internal fallback prose leaked into fixture: {text}")
+
+    if "승인 대기" not in status.inner_text():
+        raise RuntimeError("typed status did not render the user-facing label")
+    if (
+        page.locator('[data-chat-entry-id="assistant-gate-wait"].chat-bubble').count()
+        != 0
+    ):
+        raise RuntimeError("control state rendered as an assistant speech bubble")
+
+    status.get_by_role("button", name="승인 화면 열기").click()
+    page.wait_for_function(
+        "() => location.hash.includes('command') && location.hash.includes('view=gate')",
+        timeout=5_000,
+    )
+    page.screenshot(path=screenshot, full_page=True)
+
+
+with sync_playwright() as playwright:
+    browser = playwright.chromium.launch(headless=True)
+    errors: list[str] = []
+
+    desktop_context = browser.new_context(viewport={"width": 1440, "height": 900})
+    desktop = desktop_context.new_page()
+    desktop.on(
+        "console",
+        lambda message: (
+            errors.append(message.text) if message.type == "error" else None
+        ),
+    )
+    desktop.on("pageerror", lambda error: errors.append(str(error)))
+    verify(desktop, DESKTOP_SCREENSHOT)
+    desktop_context.close()
+
+    mobile_context = browser.new_context(viewport={"width": 390, "height": 844})
+    mobile = mobile_context.new_page()
+    mobile.on(
+        "console",
+        lambda message: (
+            errors.append(message.text) if message.type == "error" else None
+        ),
+    )
+    mobile.on("pageerror", lambda error: errors.append(str(error)))
+    verify(mobile, MOBILE_SCREENSHOT)
+    mobile_context.close()
+
+    browser.close()
+    if errors:
+        raise RuntimeError("browser errors: " + " | ".join(errors))

--- a/scripts/harness_dashboard_keeper_chat_control_status_dom_smoke.py
+++ b/scripts/harness_dashboard_keeper_chat_control_status_dom_smoke.py
@@ -31,7 +31,7 @@ def verify(page: Page, screenshot: str) -> None:
         if text in body_text:
             raise RuntimeError(f"internal fallback prose leaked into fixture: {text}")
 
-    if "승인 대기" not in status.inner_text():
+    if "승인 요청됨" not in status.inner_text():
         raise RuntimeError("typed status did not render the user-facing label")
     if (
         page.locator('[data-chat-entry-id="assistant-gate-wait"].chat-bubble').count()

--- a/scripts/harness_dashboard_keeper_chat_control_status_dom_smoke.sh
+++ b/scripts/harness_dashboard_keeper_chat_control_status_dom_smoke.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DASHBOARD_DIR="${ROOT_DIR}/dashboard"
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-5188}"
+PROXY_TARGET="${MASC_DASHBOARD_PROXY_TARGET:-http://127.0.0.1:8935}"
+FIXTURE_URL="http://${HOST}:${PORT}/dashboard/dev-fixtures/keeper-chat-control-status-fixture.html"
+SERVER_LOG="${TMPDIR:-/tmp}/masc-dashboard-control-status-vite-${PORT}.log"
+DESKTOP_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-control-status-desktop.png"
+MOBILE_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-control-status-mobile.png"
+BROWSER_SCRIPT="${ROOT_DIR}/scripts/harness_dashboard_keeper_chat_control_status_dom_smoke.py"
+
+server_pid=""
+cleanup() {
+  if [[ -n "${server_pid}" ]] && kill -0 "${server_pid}" 2>/dev/null; then
+    kill "${server_pid}" 2>/dev/null || true
+    wait "${server_pid}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+MASC_DASHBOARD_PROXY_TARGET="${PROXY_TARGET}" \
+  pnpm --dir "${DASHBOARD_DIR}" exec vite --host "${HOST}" --port "${PORT}" --strictPort \
+  >"${SERVER_LOG}" 2>&1 &
+server_pid="$!"
+
+for _ in {1..80}; do
+  if curl -fsS "${FIXTURE_URL}" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "${server_pid}" 2>/dev/null; then
+    cat "${SERVER_LOG}" >&2
+    exit 1
+  fi
+  sleep 0.25
+done
+
+curl -fsS "${FIXTURE_URL}" >/dev/null
+
+FIXTURE_URL="${FIXTURE_URL}" \
+DESKTOP_SCREENSHOT="${DESKTOP_SCREENSHOT}" \
+MOBILE_SCREENSHOT="${MOBILE_SCREENSHOT}" \
+python3 "${BROWSER_SCRIPT}"
+
+printf 'keeper chat control-status DOM smoke passed\n'
+printf 'fixture_url=%s\n' "${FIXTURE_URL}"
+printf 'desktop_screenshot=%s\n' "${DESKTOP_SCREENSHOT}"
+printf 'mobile_screenshot=%s\n' "${MOBILE_SCREENSHOT}"

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -200,6 +200,36 @@ let test_persist_connector_assistant_reply_ignores_empty_reply () =
       check int "empty reply does not create chat file" 0
         (List.length (K.load ~base_dir ~keeper_name)))
 
+let test_persist_connector_assistant_reply_records_typed_status () =
+  let base_dir = temp_base_path "gate-keeper-status-reply" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "discord-status-keeper" in
+      let surface =
+        Surface_ref.Gate { label = "discord"; address = [] }
+      in
+      Gate_keeper_backend.persist_connector_assistant_reply ~base_dir
+        ~keeper_name ~surface ~reply:""
+        ~blocks:
+          [ Keeper_chat_blocks.Status
+              { kind = Keeper_chat_blocks.External_effect_pending }
+          ]
+        ();
+      match K.load ~base_dir ~keeper_name with
+      | [ assistant ] ->
+          check string "assistant content stays empty" "" assistant.K.content;
+          (match assistant.K.blocks with
+           | Some
+               [ Keeper_chat_blocks.Status
+                   { kind = Keeper_chat_blocks.External_effect_pending }
+               ] ->
+             ()
+           | Some _ -> fail "connector status changed shape during persistence"
+           | None -> fail "connector status was not persisted")
+      | messages ->
+          failf "expected 1 typed status row, got %d" (List.length messages))
+
 let test_contextualize_message_includes_channel_metadata () =
   let rendered =
     Gate_keeper_backend.contextualize_message
@@ -2797,6 +2827,8 @@ let () =
             test_persist_connector_assistant_reply_records_lane_reply;
           test_case "skips empty connector assistant reply" `Quick
             test_persist_connector_assistant_reply_ignores_empty_reply;
+          test_case "persists typed connector status without prose" `Quick
+            test_persist_connector_assistant_reply_records_typed_status;
           test_case "context envelope includes channel metadata" `Quick
             test_contextualize_message_includes_channel_metadata;
           test_case "stream request accepts connector context" `Quick

--- a/test/test_keeper_chat_blocks.ml
+++ b/test/test_keeper_chat_blocks.ml
@@ -394,6 +394,13 @@ let test_fusion_block_tolerates_missing_run_id () =
   | Some [ B.Fusion { board_post_id = "p-1"; run_id = "" } ] -> ()
   | _ -> Alcotest.fail "fusion block with board_post_id only should decode with empty run_id"
 
+let test_status_block_roundtrip () =
+  let original = [ B.Status { kind = B.External_effect_pending } ] in
+  match B.blocks_of_yojson (B.blocks_to_yojson original) with
+  | Some [ B.Status { kind = B.External_effect_pending } ] -> ()
+  | Some _ -> Alcotest.fail "status block changed shape across round-trip"
+  | None -> Alcotest.fail "blocks_of_yojson rejected valid status block"
+
 (* RFC-0302: the thinking block wire shape is the contract the dashboard
    schema mirrors (t=thinking, content required, redacted omitted when
    false). Pin it so a drift breaks here. *)
@@ -519,6 +526,8 @@ let () =
             test_fusion_block_requires_board_post_id;
           Alcotest.test_case "fusion block tolerates missing run_id" `Quick
             test_fusion_block_tolerates_missing_run_id;
+          Alcotest.test_case "status block roundtrip" `Quick
+            test_status_block_roundtrip;
           Alcotest.test_case "thinking block roundtrip" `Quick
             test_thinking_block_roundtrip;
           Alcotest.test_case "redacted thinking block roundtrip" `Quick

--- a/test/test_keeper_chat_discord.ml
+++ b/test/test_keeper_chat_discord.ml
@@ -235,6 +235,30 @@ let test_error_reply_callback_once () =
   check int "one error POST" 1 !sends;
   check_single_network_error "error POST failure" "error post failed" outcomes
 
+let test_external_effect_status_replaces_assistant_preface () =
+  let sends = ref [] in
+  let outcomes =
+    run_adapter
+      [ Masc.Keeper_chat_events.Run_started
+          { run_id = "run-status"; thread_id = "thread-status" }
+      ; Masc.Keeper_chat_events.Text_delta "assistant preface that must not survive"
+      ; Masc.Keeper_chat_events.Status_block
+          { kind = Masc.Keeper_chat_blocks.External_effect_pending }
+      ; Masc.Keeper_chat_events.Run_finished { run_id = "run-status" }
+      ]
+      ~post_message:(fun ~content:_ ->
+        fail "unstable preface must not be posted")
+      ~edit_message:(fun ~message_id:_ ~content:_ ->
+        fail "no streaming message exists")
+      ~send_message:(fun ~content ->
+        sends := content :: !sends;
+        Ok ())
+  in
+  check_single_ok "typed status terminal result" outcomes;
+  check (list string) "only typed status is delivered"
+    [ "승인 대기: 외부 작업을 실행하기 전에 확인이 필요합니다." ]
+    (List.rev !sends)
+
 let () =
   run "keeper_chat_discord"
     [ ( "streaming-redaction"
@@ -258,6 +282,8 @@ let () =
             test_terminal_callback_reports_overflow_failure
         ; test_case "error reply callback exactly once" `Quick
             test_error_reply_callback_once
+        ; test_case "typed status replaces assistant preface" `Quick
+            test_external_effect_status_replaces_assistant_preface
         ] )
     ; ( "rich-blocks"
       , [ test_case "audio URL uses base URL" `Quick

--- a/test/test_keeper_chat_discord.ml
+++ b/test/test_keeper_chat_discord.ml
@@ -236,7 +236,8 @@ let test_error_reply_callback_once () =
   check_single_network_error "error POST failure" "error post failed" outcomes
 
 let test_external_effect_status_replaces_assistant_preface () =
-  let sends = ref [] in
+  let posts = ref [] in
+  let edits = ref [] in
   let outcomes =
     run_adapter
       [ Masc.Keeper_chat_events.Run_started
@@ -246,18 +247,22 @@ let test_external_effect_status_replaces_assistant_preface () =
           { kind = Masc.Keeper_chat_blocks.External_effect_pending }
       ; Masc.Keeper_chat_events.Run_finished { run_id = "run-status" }
       ]
-      ~post_message:(fun ~content:_ ->
-        fail "unstable preface must not be posted")
-      ~edit_message:(fun ~message_id:_ ~content:_ ->
-        fail "no streaming message exists")
-      ~send_message:(fun ~content ->
-        sends := content :: !sends;
+      ~post_message:(fun ~content ->
+        posts := content :: !posts;
+        Ok "status-message")
+      ~edit_message:(fun ~message_id ~content ->
+        check string "typed status edits the streaming message"
+          "status-message" message_id;
+        edits := content :: !edits;
         Ok ())
+      ~send_message:(fun ~content:_ ->
+        fail "typed status must replace the existing streaming message")
   in
   check_single_ok "typed status terminal result" outcomes;
-  check (list string) "only typed status is delivered"
+  check int "streaming preface is posted once" 1 (List.length !posts);
+  check (list string) "typed status is the terminal message"
     [ "승인 대기: 외부 작업을 실행하기 전에 확인이 필요합니다." ]
-    (List.rev !sends)
+    (List.rev !edits)
 
 let () =
   run "keeper_chat_discord"

--- a/test/test_keeper_chat_slack.ml
+++ b/test/test_keeper_chat_slack.ml
@@ -285,6 +285,31 @@ let test_adapter_empty_terminal_is_error () =
       (contains message "no text or blocks")
   | _ -> fail "empty terminal must settle exactly once with an error"
 
+let test_adapter_external_effect_status_is_terminal_success () =
+  let sends = ref [] in
+  let outcomes =
+    run_adapter
+      [ Masc.Keeper_chat_events.Run_started
+          { run_id = "run-status"; thread_id = "thread-status" }
+      ; Masc.Keeper_chat_events.Text_delta "assistant preface that must not survive"
+      ; Masc.Keeper_chat_events.Status_block
+          { kind = Masc.Keeper_chat_blocks.External_effect_pending }
+      ; Masc.Keeper_chat_events.Run_finished { run_id = "run-status" }
+      ]
+      ~send_plain:(fun ~content:_ -> fail "status uses Slack blocks")
+      ~send_blocks:(fun ~content ~blocks ->
+        sends := (content, blocks) :: !sends;
+        Ok ())
+  in
+  check bool "typed status settles the terminal receipt" true
+    (outcomes = [ Ok () ]);
+  match List.rev !sends with
+  | [ (content, [ block ]) ] ->
+    check string "assistant preface cleared" "" content;
+    check bool "status is visible" true
+      (contains (json_string block) "승인 대기")
+  | _ -> fail "status must produce exactly one Slack block send"
+
 let test_message_body_preserves_reply_thread () =
   let body =
     Masc.Keeper_chat_slack.For_testing.build_message_body
@@ -352,6 +377,8 @@ let () =
             test_protocol_diagnostic_cannot_mask_final_failure
         ; test_case "empty terminal is explicit failure" `Quick
             test_adapter_empty_terminal_is_error
+        ; test_case "typed external-effect status settles successfully" `Quick
+            test_adapter_external_effect_status_is_terminal_success
         ] )
     ; ( "thread-routing"
       , [ test_case "deferred reply keeps thread_ts" `Quick

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -486,7 +486,7 @@ let test_finalization_blank_response_is_typed_accept_rejection () =
        Alcotest.failf "expected typed keeper error, got %s"
          (Agent_sdk.Error.to_string err))
 
-let test_external_effect_finalization_returns_visible_acknowledgement () =
+let test_external_effect_finalization_returns_no_synthetic_prose () =
   let run_result =
     { (run_result ()) with
       stop_reason = Runtime_agent.Awaiting_external_effect { turns_used = 1 }
@@ -501,14 +501,14 @@ let test_external_effect_finalization_returns_visible_acknowledgement () =
       ~tool_names:[]
       ()
   with
-  | Ok acknowledgement ->
+  | Ok response_text ->
     Alcotest.(check string)
-      "external effect acknowledgement"
-      Masc.Keeper_agent_run_response_text.external_effect_deferred_acknowledgement
-      acknowledgement
+      "external effect status stays out of assistant speech"
+      ""
+      response_text
   | Error error ->
     Alcotest.failf
-      "external effect acknowledgement unexpectedly rejected: %s"
+      "external effect typed status unexpectedly rejected: %s"
       (Agent_sdk.Error.to_string error)
 ;;
 
@@ -539,8 +539,8 @@ let test_finalization_does_not_surface_hidden_reasoning () =
      Alcotest.failf "tool fallback should succeed: %s" (Agent_sdk.Error.to_string err)
    | Ok text ->
      Alcotest.(check string)
-       "hidden reasoning is replaced by the generic tool-list fallback"
-       "No textual reply was produced. Tools invoked: masc_schedule_get."
+       "tool-only completion does not fabricate assistant prose"
+       ""
        text;
      Alcotest.(check bool)
        "Thinking content is not user-facing"
@@ -1754,9 +1754,9 @@ let () =
             `Quick
             test_finalization_blank_response_is_typed_accept_rejection;
           Alcotest.test_case
-            "external effect finalization returns visible acknowledgement"
+            "external effect finalization returns no synthetic prose"
             `Quick
-            test_external_effect_finalization_returns_visible_acknowledgement;
+            test_external_effect_finalization_returns_no_synthetic_prose;
           Alcotest.test_case
             "finalization does not surface hidden reasoning"
             `Quick

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -6,8 +6,7 @@
    - the closed label codec (round-trip, unknown -> None),
    - the stop_reason -> outcome mapping (single mapping site),
    - response_text-aware result-surface classification,
-   - payload decode policy: absent/unknown fails toward Visible_reply
-     (the bitten failure mode, #20870, was silent non-persistence),
+   - payload decode policy: absent/malformed/unknown fails closed,
    - prefix deadness: checkpoint-shaped reply TEXT alone never
      classifies as a checkpoint. *)
 
@@ -283,23 +282,42 @@ let test_terminal_effect_handler_contract () =
 
 let payload fields = Some (`Assoc fields)
 
+let decoded_exn payload =
+  match TO.of_reply_payload payload with
+  | Ok outcome -> outcome
+  | Error error -> fail (TO.decode_error_to_string error)
+
+let check_decode_error label expected payload =
+  match TO.of_reply_payload payload with
+  | Error actual -> check bool label true (actual = expected)
+  | Ok actual ->
+    failf "%s: unexpectedly decoded %s" label (TO.to_label actual)
+
 let test_payload_decode () =
-  check outcome "no payload -> visible" TO.Visible_reply
-    (TO.of_reply_payload None);
-  check outcome "field absent -> visible" TO.Visible_reply
-    (TO.of_reply_payload (payload [ ("reply", `String "hi") ]));
+  check_decode_error "no payload fails closed" TO.Payload_missing None;
+  check_decode_error "field absent fails closed" TO.Turn_outcome_missing
+    (payload [ ("reply", `String "hi") ]);
   check outcome "checkpoint label" TO.Continuation_checkpoint
-    (TO.of_reply_payload
+    (decoded_exn
        (payload [ (TO.wire_key, `String "continuation_checkpoint") ]));
   check outcome "visible label" TO.Visible_reply
-    (TO.of_reply_payload
+    (decoded_exn
        (payload [ (TO.wire_key, `String "visible_reply") ]));
   check outcome "no visible reply label" TO.No_visible_reply
-    (TO.of_reply_payload
+    (decoded_exn
        (payload [ (TO.wire_key, `String "no_visible_reply") ]));
-  check outcome "unknown label -> visible (report-and-persist)"
-    TO.Visible_reply
-    (TO.of_reply_payload (payload [ (TO.wire_key, `String "deferred") ]))
+  check_decode_error "unknown label fails closed"
+    (TO.Turn_outcome_unknown "deferred")
+    (payload [ (TO.wire_key, `String "deferred") ]);
+  check_decode_error "duplicate label fails closed" TO.Turn_outcome_duplicate
+    (payload
+       [ (TO.wire_key, `String "visible_reply")
+       ; (TO.wire_key, `String "no_visible_reply")
+       ]);
+  check_decode_error "non-string label fails closed" TO.Turn_outcome_not_string
+    (payload [ (TO.wire_key, `Int 1) ]);
+  check_decode_error "non-object payload fails closed" TO.Payload_not_object
+    (Some (`List []))
 
 let checkpoint_text =
   "Continuation checkpoint saved; keeper remains scheduled for the next \
@@ -311,21 +329,21 @@ let checkpoint_text =
 let test_prefix_is_dead () =
   check outcome "checkpoint-shaped text, declared visible"
     TO.Visible_reply
-    (TO.of_reply_payload
+    (decoded_exn
        (payload
           [ ("reply", `String checkpoint_text);
             (TO.wire_key, `String "visible_reply")
           ]));
   check outcome "ordinary text, declared checkpoint"
     TO.Continuation_checkpoint
-    (TO.of_reply_payload
+    (decoded_exn
        (payload
          [ ("reply", `String "all done");
            (TO.wire_key, `String "continuation_checkpoint")
           ]));
   check outcome "ordinary text, declared no visible reply"
     TO.No_visible_reply
-    (TO.of_reply_payload
+    (decoded_exn
        (payload
           [ ("reply", `String "all done");
             (TO.wire_key, `String "no_visible_reply")
@@ -458,10 +476,14 @@ let test_direct_reply_visible_text () =
           [ ("reply", `String "all done");
             ("turn_outcome", `String "no_visible_reply")
           ]));
-  check (option string) "checkpoint-shaped text without field -> visible"
-    (Some checkpoint_text)
-    (Ops.direct_reply_visible_text
-       (body [ ("reply", `String checkpoint_text) ]));
+  check_raises
+    "missing outcome is a direct-reply contract error"
+    (Invalid_argument "keeper reply payload is missing turn_outcome")
+    (fun () ->
+       ignore
+         (Ops.direct_reply_visible_text
+            (body [ ("reply", `String checkpoint_text) ])
+          : string option));
   check (option string) "declared visible -> reply text" (Some "all done")
     (Ops.direct_reply_visible_text
        (body

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -501,7 +501,7 @@ let test_connector_projection_keeps_external_wait_typed () =
   match
     Masc.Keeper_chat_blocks.connector_projection
       ~turn_outcome:TO.External_effect_pending
-      ~reply:"assistant preface that must not survive"
+      ~reply:(Some "assistant preface that must not survive")
   with
   | Connector_status { kind = External_effect_pending } -> ()
   | Connector_text _ | Connector_no_visible_reply ->

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -475,6 +475,28 @@ let test_direct_reply_visible_text () =
             ("turn_outcome", `String "visible_reply")
           ]))
 
+let test_connector_projection_keeps_external_wait_typed () =
+  match
+    Masc.Keeper_chat_blocks.connector_projection
+      ~turn_outcome:TO.External_effect_pending
+      ~reply:"assistant preface that must not survive"
+  with
+  | Connector_status { kind = External_effect_pending } -> ()
+  | Connector_text _ | Connector_no_visible_reply ->
+    fail "external-effect wait must remain a typed connector status"
+
+let test_direct_reply_projection_keeps_external_wait_typed () =
+  match
+    Ops.direct_reply_projection
+      (body
+         [ ("reply", `String "assistant preface that must not survive")
+         ; ("turn_outcome", `String "external_effect_pending")
+         ])
+  with
+  | Connector_status { kind = External_effect_pending } -> ()
+  | Connector_text _ | Connector_no_visible_reply ->
+    fail "direct reply collapsed external-effect wait into silence"
+
 let () =
   run "keeper_turn_outcome"
     [
@@ -521,5 +543,9 @@ let () =
         [
           test_case "direct_reply_visible_text" `Quick
             test_direct_reply_visible_text;
+          test_case "connector projection keeps external wait typed" `Quick
+            test_connector_projection_keeps_external_wait_typed;
+          test_case "direct reply keeps external wait typed" `Quick
+            test_direct_reply_projection_keeps_external_wait_typed;
         ] );
     ]

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -495,7 +495,16 @@ let test_direct_reply_visible_text () =
        (body
           [ ("reply", `String "   ");
             ("turn_outcome", `String "visible_reply")
-          ]))
+          ]));
+  check_raises
+    "visible outcome without reply is a direct-reply contract error"
+    (Invalid_argument
+       "keeper reply payload is missing reply for visible_reply")
+    (fun () ->
+       ignore
+         (Ops.direct_reply_visible_text
+            (body [ ("turn_outcome", `String "visible_reply") ])
+          : string option))
 
 let test_connector_projection_keeps_external_wait_typed () =
   match

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -23,7 +23,12 @@ let outcome : TO.t testable =
     (fun fmt t -> Format.pp_print_string fmt (TO.to_label t))
     TO.equal
 
-let all = [ TO.Visible_reply; TO.Continuation_checkpoint; TO.No_visible_reply ]
+let all =
+  [ TO.Visible_reply
+  ; TO.Continuation_checkpoint
+  ; TO.External_effect_pending
+  ; TO.No_visible_reply
+  ]
 
 let test_label_round_trip () =
   List.iter
@@ -57,7 +62,7 @@ let test_of_stop_reason () =
   check outcome "durable stimulus yield -> checkpoint" TO.Continuation_checkpoint
     (TO.of_stop_reason
        (Runtime_agent.Yielded_to_durable_stimulus { turns_used = 2 }));
-  check outcome "external effect wait -> visible" TO.Visible_reply
+  check outcome "external effect wait -> typed pending" TO.External_effect_pending
     (TO.of_stop_reason
        (Runtime_agent.Awaiting_external_effect { turns_used = 2 }));
   check outcome "repeated tool yield -> checkpoint" TO.Continuation_checkpoint
@@ -78,28 +83,24 @@ let test_of_result_surface () =
     TO.No_visible_reply
     (TO.of_result_surface ~response_text:"   " Runtime_agent.Completed)
 
-let test_external_effect_wait_acknowledgement_is_visible () =
+let test_external_effect_wait_is_typed_status () =
   let stop_reason = Runtime_agent.Awaiting_external_effect { turns_used = 2 } in
-  let acknowledgement = Response_text.external_effect_deferred_acknowledgement in
-  check bool "external effect acknowledgement is not suppressed" false
+  check bool "external effect prose is suppressed" true
     (Response_text.stop_reason_suppresses_visible_response stop_reason);
-  check bool "external effect acknowledgement is nonblank" true
-    (String.trim acknowledgement <> "");
-  check outcome "external effect acknowledgement reaches chat"
-    TO.Visible_reply
-    (TO.of_result_surface ~response_text:acknowledgement stop_reason)
+  check outcome "external effect remains typed with blank text"
+    TO.External_effect_pending
+    (TO.of_result_surface ~response_text:"" stop_reason)
 
-let test_external_effect_acknowledgement_survives_server_projection () =
-  let acknowledgement = Response_text.external_effect_deferred_acknowledgement in
+let test_external_effect_status_survives_server_projection () =
   let turn_outcome =
     TO.of_result_surface
-      ~response_text:acknowledgement
+      ~response_text:""
       (Runtime_agent.Awaiting_external_effect { turns_used = 2 })
   in
   let turn_ref = Ids.Turn_ref.make ~trace_id:"gate-ack" ~absolute_turn:2 in
   let body =
     `Assoc
-      [ "reply", `String acknowledgement
+      [ "reply", `String ""
       ; TO.wire_key, `String (TO.to_label turn_outcome)
       ; TO.turn_ref_wire_key, Ids.Turn_ref.to_yojson turn_ref
       ]
@@ -113,10 +114,10 @@ let test_external_effect_acknowledgement_survives_server_projection () =
       (Server_routes_http_keeper_stream.canonical_reply_payload_error_to_string
          error)
   | Ok canonical ->
-    check outcome "server preserves visible Gate acknowledgement" TO.Visible_reply
+    check outcome "server preserves typed Gate wait" TO.External_effect_pending
       canonical.turn_outcome;
-    check string "server preserves acknowledgement" acknowledgement canonical.visible_reply;
-    check (option string) "server does not turn acknowledgement into a terminal error"
+    check string "server keeps control status out of reply text" "" canonical.visible_reply;
+    check (option string) "server accepts typed control status without prose"
       None
       (Stream.For_testing.direct_reply_terminal_error
          (Some canonical.payload_json)
@@ -126,11 +127,25 @@ let test_external_effect_acknowledgement_survives_server_projection () =
         (Some canonical.turn_ref)
     with
     | Stream.Delivered { outcome_ref } ->
-      check string "queued delivery keeps the exact Gate turn ref"
+      check string "typed Gate wait keeps the exact turn ref"
         (Ids.Turn_ref.to_string turn_ref)
         outcome_ref
     | Stream.Failed _ | Stream.Deferred _ ->
-      fail "Gate acknowledgement did not remain deliverable for a queued turn"
+      fail "typed Gate wait did not remain deliverable for a queued turn"
+
+let test_external_effect_status_becomes_persisted_chat_block () =
+  match
+    Stream.For_testing.persisted_reply_blocks
+      ~turn_outcome:TO.External_effect_pending
+      None
+  with
+  | Some
+      [ Masc.Keeper_chat_blocks.Status
+          { kind = Masc.Keeper_chat_blocks.External_effect_pending }
+      ] ->
+    ()
+  | Some _ -> fail "typed Gate wait persisted the wrong block shape"
+  | None -> fail "typed Gate wait did not persist a status block"
 
 let test_terminal_effect_defer_kinds_remain_distinct () =
   let expect_yield label state expected =
@@ -472,10 +487,12 @@ let () =
         [
           test_case "of_stop_reason" `Quick test_of_stop_reason;
           test_case "of_result_surface" `Quick test_of_result_surface;
-          test_case "external effect wait acknowledgement is visible" `Quick
-            test_external_effect_wait_acknowledgement_is_visible;
-          test_case "external effect acknowledgement survives server projection" `Quick
-            test_external_effect_acknowledgement_survives_server_projection;
+          test_case "external effect wait is typed status" `Quick
+            test_external_effect_wait_is_typed_status;
+          test_case "external effect status survives server projection" `Quick
+            test_external_effect_status_survives_server_projection;
+          test_case "external effect status becomes persisted chat block" `Quick
+            test_external_effect_status_becomes_persisted_chat_block;
           test_case "terminal effect defer kinds remain distinct" `Quick
             test_terminal_effect_defer_kinds_remain_distinct;
           test_case "repeated exact tool call boundary" `Quick

--- a/test/test_keeper_wire_capture.ml
+++ b/test/test_keeper_wire_capture.ml
@@ -526,8 +526,9 @@ let response_capture_matches_replayed_history_text () =
       with
       | Ok t -> t
       | Error _ ->
-        Alcotest.fail "normalization should synthesize text when tools are present"
+        Alcotest.fail "tool-only normalization should preserve an empty reply"
     in
+    Alcotest.(check string) "tool-only reply stays empty" "" history_text;
     Wire.capture_response
       ~base_path:base
       ~masc_root:base
@@ -540,9 +541,9 @@ let response_capture_matches_replayed_history_text () =
     Alcotest.(check int) "exactly one jsonl written" 1 (List.length files);
     let content = read_file (List.hd files) in
     Alcotest.(check bool)
-      "synthetic replayed history text is captured"
+      "wire capture retains the finalized empty response"
       true
-      (contains ~needle:history_text content);
+      (contains ~needle:"\"response_text\":\"\"" content);
     Alcotest.(check bool)
       "raw whitespace response is not captured as the replayed text"
       false


### PR DESCRIPTION
## Summary

- stop fabricating assistant prose for tool-only Keeper turns
- map OAS `Awaiting_external_effect` to a typed `external_effect_pending` outcome
- hard-cut missing, malformed, and unknown turn outcomes as explicit contract errors
- persist that outcome as a typed chat status block and render a full-width actionable approval card
- project the same typed control wait across Dashboard, Slack, Discord, Gate, and direct-reply transcripts
- keep tool execution in the turn timeline without duplicating it as assistant speech
- add a real-component Playwright fixture for desktop/mobile rendering and Gate navigation

## Why

The Dashboard rendered internal control outcomes as ordinary assistant speech:

- `No textual reply was produced. Tools invoked: keeper_surface_post.`
- `External effect is awaiting Gate approval. The Keeper will continue after the durable resolution.`

That duplicated the tool timeline, exposed internal tool names, and made a durable Gate wait look like a conversational response.

## Boundary

OAS already owns the typed `Runtime_agent.Awaiting_external_effect` stop reason. MASC maps that authority into:

`Runtime_agent.stop_reason` → `Keeper_turn_outcome.External_effect_pending` → `Keeper_chat_blocks.connector_projection` → persisted `Keeper_chat_blocks.Status` → surface-specific status UI.

The connector boundary may render status presentation text, but synthetic assistant prose is not persisted. No provider/model checks or response-string matching are introduced.

## Verification

- `pnpm --dir dashboard typecheck`
- focused Vitest: 4 files, 271 tests passed
- `pyright --outputjson scripts/harness_dashboard_keeper_chat_control_status_dom_smoke.py`
- `ruff check` and `ruff format --check` for the Playwright driver
- manual development regression fixture:
  `./scripts/harness_dashboard_keeper_chat_control_status_dom_smoke.sh`
  - desktop 1440x900
  - mobile 390x844
  - rejects both old fallback strings
  - asserts no assistant bubble for the control wait
  - clicks `승인 화면 열기` and verifies the Gate route
- the same core UI contracts are covered by the Vitest suite that runs in CI;
  the Playwright fixture is not currently wired into a workflow
- `ocamlformat --check` for changed OCaml files
- parser-only checks and `git diff --check`
- `scripts/dune-local.sh build` for the touched focused executables
- focused executable results:
  - Gate backend: 99 tests passed, including empty-content typed status persistence
  - Keeper outcome: 21 tests passed, including common and direct-reply typed projections
  - chat blocks, wire capture, Discord, and Slack suites pass
  - `test_keeper_turn_driver_accept` has one unrelated latest-main failure
    outside this diff, tracked in #26416

Exact-head CI remains the broad OCaml authority.

## Follow-up

- repeated autonomous idle/no-work reports: #26400
- tool-only connector receipt settlement: #26406
- unknown/absent outcome hard-cut is implemented here; close #26413 after merge
- exact approval identity and deep-link: #26415
- direct retry max-context test drift on latest main: #26416
