### PR TITLE
fix(server): replace assert false with graceful error handling in checkpoint load failure JSON

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api_checkpoints.ml
+++ b/lib/server/server_dashboard_http_keeper_api_checkpoints.ml
@@ -39,8 +39,12 @@ let oas_checkpoint_summary_json
     ]
 ;;
 
-let checkpoint_load_error_json
+(* The fields, not the object: callers that splice this into a larger row need
+   the association list, and taking it back apart from a [Yojson.Safe.t] forced
+   them to handle a shape this function cannot produce. *)
+let checkpoint_load_error_fields
       (error : Keeper_checkpoint_store.checkpoint_load_error)
+  : (string * Yojson.Safe.t) list
   =
   let status, kind, detail =
     match error with
@@ -51,11 +55,16 @@ let checkpoint_load_error_json
     | Sdk_other_error detail ->
       "unavailable", "sdk_other_error", `String detail
   in
-  `Assoc
-    [ "status", `String status
-    ; "error_kind", `String kind
-    ; "error_detail", detail
-    ]
+  [ "status", `String status
+  ; "error_kind", `String kind
+  ; "error_detail", detail
+  ]
+;;
+
+let checkpoint_load_error_json
+      (error : Keeper_checkpoint_store.checkpoint_load_error)
+  =
+  `Assoc (checkpoint_load_error_fields error)
 ;;
 
 let current_checkpoint_error_json
@@ -88,15 +97,7 @@ let checkpoint_load_failure_json
     ; "file_stat", stat_json_of_path path
     ]
   in
-  match checkpoint_load_error_json error with
-  | `Assoc error_fields -> `Assoc (identity_fields @ error_fields)
-  | json ->
-    `Assoc
-      (identity_fields
-       @ [ "status", `String "error"
-         ; "error_kind", `String "unexpected_checkpoint_format"
-         ; "error_detail", json
-         ])
+  `Assoc (identity_fields @ checkpoint_load_error_fields error)
 ;;
 
 let inventory_json (config : Workspace.config) (name : string)

--- a/lib/server/server_dashboard_http_keeper_api_checkpoints.ml
+++ b/lib/server/server_dashboard_http_keeper_api_checkpoints.ml
@@ -90,7 +90,13 @@ let checkpoint_load_failure_json
   in
   match checkpoint_load_error_json error with
   | `Assoc error_fields -> `Assoc (identity_fields @ error_fields)
-  | _ -> assert false
+  | json ->
+    `Assoc
+      (identity_fields
+       @ [ "status", `String "error"
+         ; "error_kind", `String "unexpected_checkpoint_format"
+         ; "error_detail", json
+         ])
 ;;
 
 let inventory_json (config : Workspace.config) (name : string)

--- a/lib/server/server_dashboard_http_keeper_api_checkpoints.mli
+++ b/lib/server/server_dashboard_http_keeper_api_checkpoints.mli
@@ -11,16 +11,9 @@ val oas_checkpoint_summary_json :
   Agent_sdk.Checkpoint.t ->
   Yojson.Safe.t
 
-(** Total dashboard projection of a typed checkpoint load failure, as the
-    fields themselves. Returning the association list keeps callers that splice
-    it into a larger row from having to match a JSON shape this cannot
-    produce. *)
-val checkpoint_load_error_fields :
-  Keeper_checkpoint_store.checkpoint_load_error -> (string * Yojson.Safe.t) list
-
-(** {!checkpoint_load_error_fields} as a standalone object. [Not_found] is a
-    normal missing asset; every other constructor is an unavailable asset with
-    its original categorical kind and detail preserved. *)
+(** Total dashboard projection of a typed checkpoint load failure. [Not_found]
+    is a normal missing asset; every other constructor is an unavailable asset
+    with its original categorical kind and detail preserved. *)
 val checkpoint_load_error_json :
   Keeper_checkpoint_store.checkpoint_load_error -> Yojson.Safe.t
 

--- a/lib/server/server_dashboard_http_keeper_api_checkpoints.mli
+++ b/lib/server/server_dashboard_http_keeper_api_checkpoints.mli
@@ -11,9 +11,16 @@ val oas_checkpoint_summary_json :
   Agent_sdk.Checkpoint.t ->
   Yojson.Safe.t
 
-(** Total dashboard projection of a typed checkpoint load failure. [Not_found]
-    is a normal missing asset; every other constructor is an unavailable asset
-    with its original categorical kind and detail preserved. *)
+(** Total dashboard projection of a typed checkpoint load failure, as the
+    fields themselves. Returning the association list keeps callers that splice
+    it into a larger row from having to match a JSON shape this cannot
+    produce. *)
+val checkpoint_load_error_fields :
+  Keeper_checkpoint_store.checkpoint_load_error -> (string * Yojson.Safe.t) list
+
+(** {!checkpoint_load_error_fields} as a standalone object. [Not_found] is a
+    normal missing asset; every other constructor is an unavailable asset with
+    its original categorical kind and detail preserved. *)
 val checkpoint_load_error_json :
   Keeper_checkpoint_store.checkpoint_load_error -> Yojson.Safe.t
 

--- a/test/test_server_dashboard_http_keeper_api_trace.ml
+++ b/test/test_server_dashboard_http_keeper_api_trace.ml
@@ -449,6 +449,32 @@ let test_checkpoint_load_error_projection_is_total () =
     ~detail:(Some "sdk failure")
 ;;
 
+(* The caller that spliced this projection into a larger row used to take the
+   JSON back apart, with the non-object case as `assert false`. That branch was
+   unreachable because the object form is exactly the fields form; pinning that
+   identity for every constructor is what keeps it unreachable, so no caller has
+   to name a shape this cannot produce. *)
+let test_checkpoint_load_error_object_is_exactly_its_fields () =
+  let module Store = Keeper_checkpoint_store in
+  List.iter
+    (fun error ->
+      let fields = Checkpoints.checkpoint_load_error_fields error in
+      check
+        (of_pp Yojson.Safe.pp)
+        "the object form is the fields form"
+        (`Assoc fields)
+        (Checkpoints.checkpoint_load_error_json error);
+      check bool "the projection is never empty" true (fields <> []);
+      check bool "error_kind is always present" true
+        (List.mem_assoc "error_kind" fields))
+    [ Store.Not_found;
+      Store.Store_error "store unavailable";
+      Store.Parse_error "invalid checkpoint";
+      Store.Io_error "permission denied";
+      Store.Sdk_other_error "sdk failure";
+    ]
+;;
+
 let test_checkpoint_inventory_preserves_partial_load_failures () =
   with_temp_dir @@ fun dir ->
   let config = Workspace.default_config dir in
@@ -574,6 +600,10 @@ let () =
             "projects every typed checkpoint load error"
             `Quick
             test_checkpoint_load_error_projection_is_total
+        ; test_case
+            "the error object is exactly its fields"
+            `Quick
+            test_checkpoint_load_error_object_is_exactly_its_fields
         ; test_case
             "preserves partial history failures with HTTP 200"
             `Quick

--- a/test/test_server_dashboard_http_keeper_api_trace.ml
+++ b/test/test_server_dashboard_http_keeper_api_trace.ml
@@ -462,8 +462,8 @@ let test_checkpoint_load_error_projection_is_always_an_object () =
       check bool "the load-error projection is an object" true
         (match Checkpoints.checkpoint_load_error_json error with
          | `Assoc _ -> true
-         | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _
-         | `Null | `Tuple _ | `Variant _ -> false))
+         | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null
+           -> false))
     [ Store.Not_found;
       Store.Store_error "store unavailable";
       Store.Parse_error "invalid checkpoint";

--- a/test/test_server_dashboard_http_keeper_api_trace.ml
+++ b/test/test_server_dashboard_http_keeper_api_trace.ml
@@ -449,32 +449,6 @@ let test_checkpoint_load_error_projection_is_total () =
     ~detail:(Some "sdk failure")
 ;;
 
-(* The caller that spliced this projection into a larger row used to take the
-   JSON back apart, with the non-object case as `assert false`. That branch was
-   unreachable because the object form is exactly the fields form; pinning that
-   identity for every constructor is what keeps it unreachable, so no caller has
-   to name a shape this cannot produce. *)
-let test_checkpoint_load_error_object_is_exactly_its_fields () =
-  let module Store = Keeper_checkpoint_store in
-  List.iter
-    (fun error ->
-      let fields = Checkpoints.checkpoint_load_error_fields error in
-      check
-        (of_pp Yojson.Safe.pp)
-        "the object form is the fields form"
-        (`Assoc fields)
-        (Checkpoints.checkpoint_load_error_json error);
-      check bool "the projection is never empty" true (fields <> []);
-      check bool "error_kind is always present" true
-        (List.mem_assoc "error_kind" fields))
-    [ Store.Not_found;
-      Store.Store_error "store unavailable";
-      Store.Parse_error "invalid checkpoint";
-      Store.Io_error "permission denied";
-      Store.Sdk_other_error "sdk failure";
-    ]
-;;
-
 let test_checkpoint_inventory_preserves_partial_load_failures () =
   with_temp_dir @@ fun dir ->
   let config = Workspace.default_config dir in
@@ -600,10 +574,6 @@ let () =
             "projects every typed checkpoint load error"
             `Quick
             test_checkpoint_load_error_projection_is_total
-        ; test_case
-            "the error object is exactly its fields"
-            `Quick
-            test_checkpoint_load_error_object_is_exactly_its_fields
         ; test_case
             "preserves partial history failures with HTTP 200"
             `Quick

--- a/test/test_server_dashboard_http_keeper_api_trace.ml
+++ b/test/test_server_dashboard_http_keeper_api_trace.ml
@@ -449,6 +449,29 @@ let test_checkpoint_load_error_projection_is_total () =
     ~detail:(Some "sdk failure")
 ;;
 
+(* The caller that splices this projection into a larger row used to take the
+   JSON back apart, with the non-object case as `assert false`. That branch was
+   unreachable because this projection is an object for every constructor.
+   Pinned through the public entry point so the helper behind it stays private:
+   if the projection ever grows a non-object shape, this fails here instead of
+   resurrecting an impossible case at a call site. *)
+let test_checkpoint_load_error_projection_is_always_an_object () =
+  let module Store = Keeper_checkpoint_store in
+  List.iter
+    (fun error ->
+      check bool "the load-error projection is an object" true
+        (match Checkpoints.checkpoint_load_error_json error with
+         | `Assoc _ -> true
+         | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _
+         | `Null | `Tuple _ | `Variant _ -> false))
+    [ Store.Not_found;
+      Store.Store_error "store unavailable";
+      Store.Parse_error "invalid checkpoint";
+      Store.Io_error "permission denied";
+      Store.Sdk_other_error "sdk failure";
+    ]
+;;
+
 let test_checkpoint_inventory_preserves_partial_load_failures () =
   with_temp_dir @@ fun dir ->
   let config = Workspace.default_config dir in
@@ -574,6 +597,10 @@ let () =
             "projects every typed checkpoint load error"
             `Quick
             test_checkpoint_load_error_projection_is_total
+        ; test_case
+            "the load-error projection is always an object"
+            `Quick
+            test_checkpoint_load_error_projection_is_always_an_object
         ; test_case
             "preserves partial history failures with HTTP 200"
             `Quick


### PR DESCRIPTION
Replace the `assert false` fallback in `checkpoint_load_failure_json` with a structured error object that preserves the checkpoint identity fields and reports `unexpected_checkpoint_format` instead of crashing.

Fixes task-017.