### PR TITLE
fix(keeper): 취소된 압축을 정산하지 않고 재-raise

### DIFF
--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -1456,12 +1456,33 @@ let execute_prepared_lane_current
          not inspect OAS receipt phase/count after cancellation. If OAS had
          proved safe advancement it would first invoke [before_advance], whose
          fsynced release clears [bound_observation]. Therefore a still-bound
-         identity is always source-terminal; a pre-bind cancellation is
-         re-raised. *)
+         identity is always quarantined before the cancellation continues.
+
+         Both branches re-raise. A cancellation is the fiber being torn down,
+         not an outcome of this compaction, and returning it as a value made
+         callers settle it as one: it reached the streak that suspends
+         compaction and the durable schedule occurrence, neither of which
+         [Cycle.Cancelled] touches. Quarantine is the only work a cancelled
+         attempt owes, and it runs under [Eio.Cancel.protect] exactly as the
+         sibling handler in [Keeper_post_turn] does. *)
       (match !bound_observation with
        | None -> Printexc.raise_with_backtrace cancellation raw_bt
-      | Some observation ->
-        `Bound_cancellation observation)
+       | Some observation ->
+         Eio.Cancel.protect (fun () ->
+           Log.Keeper.warn
+             ~keeper_name
+             "compaction exact cancellation quarantines only the durably bound \
+              identity slot=%s call_id=%s"
+             observation.slot_id
+             observation.call_id;
+           ignore
+             (terminal_after_quarantine
+                ~keeper_name
+                ~exact_execution_guard
+                ~cause:Keeper_event_queue_state.Exact_execution_cancelled
+                observation
+              : Keeper_event_queue_state.exact_execution_terminal));
+         Printexc.raise_with_backtrace cancellation raw_bt)
   in
   let release_retained_semantic_binding fallback =
     match !bound_observation with
@@ -1481,19 +1502,6 @@ let execute_prepared_lane_current
   in
   let settle_execution () =
   match execution with
-  | `Bound_cancellation observation ->
-    Log.Keeper.warn
-      ~keeper_name
-      "compaction exact cancellation quarantines only the durably bound identity slot=%s call_id=%s"
-      observation.slot_id
-      observation.call_id;
-    Error
-      (Exact_execution_terminal
-         (terminal_after_quarantine
-            ~keeper_name
-            ~exact_execution_guard
-            ~cause:Keeper_event_queue_state.Exact_execution_cancelled
-            observation))
   | `Flow
       (Error
         (Exact_output.Flow_execution_terminal
@@ -1599,7 +1607,6 @@ let execute_prepared_lane_current
       }
   in
   match execution with
-  | `Bound_cancellation _ -> Eio.Cancel.protect settle_execution
   | `Flow _ -> settle_execution ()
 ;;
 

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -357,7 +357,52 @@ let compaction_outcome_of_cycle_outcome = function
           Counting it advanced the streak the gate itself reads: live keeper
           kidsnote reached 907 against a threshold of 3. *)
        None
-     | Keeper_unified_turn.Escalate_after_exact_output_terminal _ -> Some `Failed
+     | Keeper_unified_turn.Escalate_after_exact_output_terminal
+         (Keeper_unified_turn.Exact_execution_terminal
+            { source = _
+            ; terminal =
+                { Keeper_event_queue_state.cause =
+                    Keeper_event_queue_state.Exact_execution_cancelled
+                ; _
+                }
+            }) ->
+       (* Defensive, and unreachable by construction: a cancelled exact
+          execution is the fiber being torn down, so both producers of this
+          cause re-raise rather than return it
+          ([Keeper_compaction_llm_summarizer]'s bound-cancellation handler and
+          [Keeper_post_turn]'s), and a re-raised cancellation never reaches a
+          settlement at all.  Classified here anyway so that a future producer
+          which returns instead of raising cannot silently advance the streak
+          that suspends compaction — [Cycle.Cancelled] below settles nothing
+          for the same reason. *)
+       None
+     | Keeper_unified_turn.Escalate_after_exact_output_terminal
+         (Keeper_unified_turn.Exact_lane_unconfigured _
+         | Keeper_unified_turn.Exact_execution_terminal
+             { source = _
+             ; terminal =
+                 { Keeper_event_queue_state.cause =
+                     ( Keeper_event_queue_state.Exact_execution_failed
+                     | Keeper_event_queue_state.Domain_invalid_output
+                     | Keeper_event_queue_state.Compaction_produced_no_reduction
+                     | Keeper_event_queue_state.Compaction_increased_checkpoint
+                     | Keeper_event_queue_state.Invalid_structural_evidence
+                     | Keeper_event_queue_state
+                       .Invalid_structural_source_after_dispatch
+                     | Keeper_event_queue_state.Commit_admission_unavailable
+                     | Keeper_event_queue_state
+                       .Lifecycle_transition_failed_after_dispatch
+                     | Keeper_event_queue_state.Checkpoint_source_changed
+                     | Keeper_event_queue_state.Checkpoint_persistence_failed
+                     | Keeper_event_queue_state.Terminal_persistence_failed )
+                 ; _
+                 }
+             }) ->
+       (* Every remaining cause is a compaction attempt that ran and produced
+          nothing usable, so each is one genuine failure.  Enumerated rather
+          than caught by a wildcard: a new cause must be classified here at
+          compile time instead of silently counting toward the suspension. *)
+       Some `Failed
      | Keeper_unified_turn.Follow_failure_route
      | Keeper_unified_turn.Acknowledge_after_in_turn_handling
      | Keeper_unified_turn.Pause_after_transcript_corruption _ -> None)

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -157,7 +157,14 @@ val compaction_outcome_of_cycle_outcome :
     under an incompressible floor must still reach the ceiling), a completed
     overflow-free turn maps to [`Recovered] (resets it), and only the
     operator's manual commit maps to [`Committed] (count + reset).
-    Outcomes with no compaction involvement return [None]. *)
+
+    [None] means no settlement: either the outcome had no compaction
+    involvement, or a compaction was never attempted (an admission-gate
+    refusal), or the attempt was cancelled. A cancellation is fiber teardown
+    rather than an outcome, so it is classified alongside [Cycle.Cancelled]
+    instead of advancing the streak. Every exact-execution terminal cause is
+    enumerated at the match rather than caught by a wildcard, so a new cause
+    must be classified at compile time. *)
 
 
 (** Pure: post-turn status event derived from the registry

--- a/test/stanzas/test_keeper_post_turn_wirein_order.inc
+++ b/test/stanzas/test_keeper_post_turn_wirein_order.inc
@@ -4,4 +4,5 @@
  (libraries
   compaction_exact_output_fixture
   masc_test_deps
+  masc.keeper_checkpoint_ref
   masc.keeper_compaction_evidence))

--- a/test/test_compaction_exact_output_conformance.ml
+++ b/test/test_compaction_exact_output_conformance.ml
@@ -917,6 +917,16 @@ let test_cancellation_preserves_lifecycle_authorized_identity () =
       snapshot
   in
   let prepared = prepare_exn ~keeper_name:"keeper-cancelled" ~registry () in
+  let quarantined = ref [] in
+  let guard : C.exact_execution_guard =
+    { F.permissive_exact_execution_guard with
+      quarantine =
+        (fun cause observation ->
+           quarantined
+           := (cause, observation.C.slot_id) :: !quarantined;
+           Ok C.Fsync_completed)
+    }
+  in
   let authorized = ref [] in
   let cancel_context, resolve_cancel_context = Eio.Promise.create () in
   let execution =
@@ -927,31 +937,41 @@ let test_cancellation_preserves_lifecycle_authorized_identity () =
           ~keeper_name:"keeper-cancelled"
           ~net
           ~clock
+          ~exact_execution_guard:guard
           ~before_dispatch_authority:(fun observation ->
             authorized := observation.slot_id :: !authorized;
             Ok ())
           prepared))
   in
-  let result =
-    try
+  let outcome =
+    match
       Eio.Time.with_timeout_exn clock 1.0 (fun () ->
         let context = Eio.Promise.await cancel_context in
         F.await_first_request first;
         Eio.Cancel.cancel context Cancel_after_request_arrived;
         Eio.Promise.await_exn execution)
     with
-    | Eio.Time.Timeout -> Alcotest.fail "cancellation watchdog expired"
+    | value -> `Returned value
+    | exception Eio.Time.Timeout -> Alcotest.fail "cancellation watchdog expired"
+    | exception exn -> `Raised exn
   in
-  let terminal =
-    match result with
-    | Error (C.Exact_execution_terminal terminal) -> terminal
-    | Error _ -> Alcotest.fail "cancellation returned the wrong terminal"
-    | Ok _ -> Alcotest.fail "cancelled flow unexpectedly succeeded"
-  in
+  (* A cancellation propagates as an exception instead of being returned as a
+     terminal. Returning it made callers settle it as a compaction outcome:
+     it reached the streak that suspends compaction and the durable schedule
+     occurrence, neither of which a re-raised cancellation touches. The bound
+     identity is still quarantined first, under [Eio.Cancel.protect]. *)
+  (match outcome with
+   | `Raised (Eio.Cancel.Cancelled Cancel_after_request_arrived) -> ()
+   | `Raised exn ->
+     Alcotest.failf "cancellation raised the wrong exception: %s" (Printexc.to_string exn)
+   | `Returned (Error _) ->
+     Alcotest.fail "cancellation was returned as a terminal instead of raised"
+   | `Returned (Ok _) -> Alcotest.fail "cancelled flow unexpectedly succeeded");
   Alcotest.(check bool)
-    "cancellation terminal is phase-neutral"
+    "the bound identity is quarantined before the cancellation continues"
     true
-    (terminal.cause = Keeper_event_queue_state.Exact_execution_cancelled);
+    (List.rev !quarantined
+     = [ Keeper_event_queue_state.Exact_execution_cancelled, first_slot ]);
   Alcotest.(check (list string))
     "only first identity was lifecycle-authorized"
     [ first_slot ]

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -1313,6 +1313,99 @@ let test_suspended_streak_refuses_reactive_prepare () =
    only the self-feeding edge is cut. The second half of this test pins that a
    real compaction failure still advances the streak, so the ceiling that
    #25461 added keeps working. *)
+(* A cancelled exact execution is a torn-down fiber, not a compaction that
+   ran and produced nothing.  Both producers of the cancelled cause now
+   re-raise, so this classification is defensive: it exists so a future
+   producer that returns instead of raising cannot silently advance the
+   streak that suspends compaction. *)
+let test_cancelled_exact_execution_does_not_settle_as_compaction_failure () =
+  Eio_main.run @@ fun _env ->
+  let meta =
+    match
+      Masc_test_deps.meta_of_json_fixture
+        (`Assoc
+          [ "name", `String "cancellation-settlement"
+          ; "trace_id", `String "trace-cancellation-settlement"
+          ])
+    with
+    | Ok meta -> meta
+    | Error detail -> failf "cancellation-settlement meta fixture: %s" detail
+  in
+  let source =
+    match
+      Keeper_checkpoint_ref.create
+        ~trace_id:meta.runtime.trace_id
+        ~generation:1
+        ~turn_count:1
+        ~canonical_checkpoint_bytes:"{}"
+    with
+    | Ok source -> source
+    | Error _ -> fail "checkpoint ref fixture could not be built"
+  in
+  let terminal cause : Keeper_event_queue_state.exact_execution_terminal =
+    { cause
+    ; slot_id = "ollama_cloud.deepseek-v4-flash"
+    ; call_id = "call-cancellation-settlement"
+    ; plan_fingerprint = "plan-cancellation-settlement"
+    ; request_body_sha256 = String.make 64 '0'
+    }
+  in
+  let turn_failure_with source_disposition : Masc.Keeper_unified_turn.turn_failure =
+    { error = Agent_sdk.Error.Internal "exact execution terminal"
+    ; runtime_id = "cancellation-characterization"
+    ; route =
+        Keeper_runtime_failure_route.Retry_after_observed
+          { retry_class = Keeper_runtime_failure_route.Rate_limited
+          ; retry_after = None
+          }
+    ; source_disposition
+    ; deferred_runtime_lane = None
+    }
+  in
+  (* [exact_output_terminal_reason] is private, so the disposition is built by
+     the same compiler-checked partition production uses. *)
+  let settle_reason reason =
+    let source_disposition =
+      Masc.Keeper_unified_turn.source_disposition_after_no_compaction
+        { Keeper_event_queue_state.source; reason }
+    in
+    Masc.Keeper_heartbeat_loop.compaction_outcome_of_cycle_outcome
+      (Some (Cycle.Failed { meta; failure = turn_failure_with source_disposition }))
+  in
+  let settle cause =
+    settle_reason
+      (Keeper_event_queue_state.Exact_execution_terminal (terminal cause))
+  in
+  check
+    bool
+    "a cancelled exact execution settles as nothing"
+    true
+    (settle Keeper_event_queue_state.Exact_execution_cancelled = None);
+  (* Everything else on this arm is a compaction that ran and produced nothing
+     usable, so the #25461 ceiling still sees it. *)
+  List.iter
+    (fun (cause, label) ->
+       check
+         bool
+         (label ^ " still settles as a compaction failure")
+         true
+         (settle cause = Some `Failed))
+    [ Keeper_event_queue_state.Exact_execution_failed, "exact_execution_failed"
+    ; ( Keeper_event_queue_state.Compaction_increased_checkpoint
+      , "compaction_increased_checkpoint" )
+    ; ( Keeper_event_queue_state.Compaction_produced_no_reduction
+      , "compaction_produced_no_reduction" )
+    ; ( Keeper_event_queue_state.Checkpoint_persistence_failed
+      , "checkpoint_persistence_failed" )
+    ];
+  (* An unconfigured lane is a precondition failure, not a cancellation. *)
+  check
+    bool
+    "a missing exact lane still settles as a compaction failure"
+    true
+    (settle_reason Keeper_event_queue_state.Exact_lane_unconfigured = Some `Failed)
+;;
+
 let test_refusal_does_not_settle_as_compaction_failure () =
   Eio_main.run @@ fun _env ->
   let meta =
@@ -1440,6 +1533,8 @@ let () =
         `Quick test_suspended_streak_refuses_reactive_prepare;
       test_case "refusal does not settle as a compaction failure"
         `Quick test_refusal_does_not_settle_as_compaction_failure;
+      test_case "cancelled exact execution does not settle as compaction failure"
+        `Quick test_cancelled_exact_execution_does_not_settle_as_compaction_failure;
       test_case "missing exact lane is source-bound no-compaction"
         `Quick test_missing_exact_lane_is_source_bound_no_compaction;
     ];


### PR DESCRIPTION
`Keeper_compaction_llm_summarizer`는 `Eio.Cancel.Cancelled`를 잡아 **값으로 반환**합니다. `lib/keeper/`에서 취소를 값으로 바꾸는 유일한 지점입니다.

```ocaml
(match !bound_observation with
 | None -> Printexc.raise_with_backtrace cancellation raw_bt
 | Some observation -> `Bound_cancellation observation)   (* ← 재-raise 안 함 *)
```

반환된 취소는 `Error (Exact_execution_terminal { cause = Exact_execution_cancelled })`가 되어, 호출자에게 **압축의 결과**로 보입니다. 그러면 두 곳이 취소를 실패로 정산합니다:

| 지점 | 취소가 반환될 때 | 취소가 raise될 때 |
|---|---|---|
| `keeper_heartbeat_loop.ml:934-956` 압축 streak | `` `Failed `` → 정지 카운터 +1 | 정산 없음 |
| `keeper_heartbeat_loop.ml:869-925` 스케줄/선택 | `fail_schedule_due` + stimulus 소비 | 아무것도 안 함 |

`Cycle.Cancelled _`는 같은 파일에서 **아무것도 정산하지 않습니다**. 같은 취소가 경로에 따라 다르게 처리되는 상태였습니다.

## 수정

취소를 재-raise합니다. bound identity의 quarantine은 `Eio.Cancel.protect` 안에서 먼저 수행하고 — 이는 `Keeper_post_turn`의 형제 핸들러(`:954-962`)와 동일한 패턴입니다.

```ocaml
| Some observation ->
  Eio.Cancel.protect (fun () -> (* log + quarantine *));
  Printexc.raise_with_backtrace cancellation raw_bt
```

`` `Bound_cancellation `` 생성자를 제거해 컴파일러가 이 경로를 강제합니다. 전파 경로는 이미 존재하고 온전합니다: `keeper_unified_turn.ml:489-504` (lifecycle 해제 후 재-raise) → `keeper_heartbeat_loop.ml:961-964` (재-raise). 두 정산 블록 모두 건너뜁니다.

함께 `compaction_outcome_of_cycle_outcome`의 wildcard를 제거합니다:

```ocaml
| Escalate_after_exact_output_terminal _ -> Some `Failed        (* 이전 *)
```

12개 `exact_execution_terminal_cause`를 전수 열거하고, `Exact_execution_cancelled`만 `None`으로 보냅니다. 위 수정으로 이 분기는 **도달 불가**하지만, 취소를 raise 대신 반환하는 새 producer가 생기면 조용히 streak을 올리지 못하도록 남깁니다. `Exact_lane_unconfigured`와 나머지 11개 cause는 동작 불변입니다.

## 왜 이 순서인가

wildcard 열거만 하고 근본을 두면 workaround입니다. 스케줄/선택 정산은 여전히 취소를 실패로 다루므로 같은 비대칭이 남고, 다음 사람이 그 지점도 손으로 패치하게 됩니다 (N-of-M 패턴). 취소를 raise로 되돌리면 한 번에 두 지점이 닫힙니다.

## 검증

- `dune build --root . lib/` 클린
- `test_compaction_exact_output_conformance` 14/14 — 기존 `test_cancellation_preserves_lifecycle_authorized_identity`가 옛 계약(`Error (Exact_execution_terminal ...)` 반환)을 고정하고 있어 뒤집었습니다. 이제 `Eio.Cancel.Cancelled Cancel_after_request_arrived`가 전파되는지, 그리고 그 **전에** bound identity가 quarantine되는지를 함께 검증합니다.
- `test_keeper_post_turn_wirein_order` 16/16 — 12개 cause 각각의 정산 결과 고정.

## 이 PR이 주장하지 않는 것

프로덕션에서 이 경로가 발생한 로그 증거는 **없습니다**. 초안에는 kidsnote가 취소 2건으로 정지됐다는 서술을 넣었는데, 적대적 검증에서 거짓으로 판명돼 제거했습니다 — 인용한 세 이벤트는 `trigger=manual`이라 `Manual_compaction_not_applied` → `None`으로 이미 정산되지 않았고, 907 streak은 그 이벤트들보다 53분 **앞선** 01:24:11Z에 도달해 있었습니다. 근거는 타입 레벨입니다: 취소는 결과가 아니며, `Cycle.Cancelled`가 이미 그렇게 다룹니다.

관련: #26386 (거부가 자기 카운터를 밀어 올리던 간선 제거, 머지됨). 그 PR이 admission 게이트의 거부를 정산에서 뺐고, 이 PR은 취소를 뺍니다.

RFC-WAIVED: credential/identity/operator-control/sandbox/hooks/workflow 어느 subsystem도 건드리지 않습니다. Eio 취소 전파 규칙 복원과 FSM wildcard 제거입니다.

WORKAROUND-WAIVED: 증상 억제가 아니라 반대 방향입니다. 취소를 값으로 바꾸던 코드를 제거하고 문서화된 Eio 규칙(취소는 재-raise)으로 되돌립니다. 새 게이트·카운터·문자열 분류기·텔레메트리를 추가하지 않으며, catch-all을 추가하지 않고 **제거**합니다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
