### PR TITLE
fix(keeper): park chat before claiming receipt

### DIFF
--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -488,6 +488,7 @@ let run_observed_turn state ~sw ~clock ~handle_turn ~keeper_name observation =
          the lane quarantined when that retry also has uncertain durability.
          Reconcile the persistence state once more, but do not lease a third
          time in this turn. A later explicit wake owns the next attempt. *)
+      (* See [reconcile_claim_failure]: it logs errors before this returns the original. *)
       ignore (reconcile_claim_failure ~keeper_name error : (unit, _) result);
       Error (`Failed error)
   in

--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -229,17 +229,31 @@ let pending_claim_retry_blocked state ~keeper_name ~revision =
     Int64.equal blocked_revision revision
   | Some { retry = Retry_finalization _; _ } | None -> false
 
-let clear_blocked_pending_claim state ~keeper_name =
+let clear_blocked_pending_claim_for_base_path ~base_path ~keeper_name =
   match
     Persistence_blocked.find
-      ~base_path:state.base_path
+      ~base_path
       ~keeper_name
   with
   | Some { retry = Retry_pending_claim _; _ } ->
     Persistence_blocked.clear
-      ~base_path:state.base_path
+      ~base_path
       ~keeper_name
   | Some { retry = Retry_finalization _; _ } | None -> ()
+
+let clear_blocked_pending_claim state ~keeper_name =
+  clear_blocked_pending_claim_for_base_path
+    ~base_path:state.base_path
+    ~keeper_name
+
+let notify_explicit_retry ~base_path ~keeper_name =
+  match Config_dir_resolver.canonical_base_path base_path with
+  | Error error ->
+    Error (Config_dir_resolver.canonical_base_path_error_to_string error)
+  | Ok base_path ->
+    clear_blocked_pending_claim_for_base_path ~base_path ~keeper_name;
+    notify_transition ~keeper_name;
+    Ok ()
 
 let persistence_blocked_status ~base_path ~keeper_name =
   match Config_dir_resolver.canonical_base_path base_path with

--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -483,7 +483,13 @@ let run_observed_turn state ~sw ~clock ~handle_turn ~keeper_name observation =
                 item.receipt_id
             then claim_observation ~may_retry:false retry_observation
             else Error `No_longer_pending))
-    | `Error error -> Error (`Failed error)
+    | `Error error ->
+      (* The one retry is the delivery-attempt bound, not a license to leave
+         the lane quarantined when that retry also has uncertain durability.
+         Reconcile the persistence state once more, but do not lease a third
+         time in this turn. A later explicit wake owns the next attempt. *)
+      ignore (reconcile_claim_failure ~keeper_name error : (unit, _) result);
+      Error (`Failed error)
   in
   let on_admitted () =
     match !claim with

--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -51,15 +51,20 @@ end
 let notify_transition ~keeper_name = Wake_inbox.notify keeper_name
 
 module Preclaim_retry = struct
+  type phase =
+    | Watching
+    | Released
+    | Waiting
+
   let mutex = Stdlib.Mutex.create ()
-  let by_base_path : (string, (string, unit) Hashtbl.t) Hashtbl.t =
+  let by_base_path : (string, (string, phase) Hashtbl.t) Hashtbl.t =
     Hashtbl.create 4
 
   let with_lock f =
     Stdlib.Mutex.lock mutex;
     Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock mutex) f
 
-  let mark ~base_path ~keeper_name =
+  let begin_attempt ~base_path ~keeper_name =
     with_lock (fun () ->
       let keepers =
         match Hashtbl.find_opt by_base_path base_path with
@@ -69,7 +74,7 @@ module Preclaim_retry = struct
           Hashtbl.add by_base_path base_path keepers;
           keepers
       in
-      Hashtbl.replace keepers keeper_name ())
+      Hashtbl.replace keepers keeper_name Watching)
 
   let clear ~base_path ~keeper_name =
     with_lock (fun () ->
@@ -80,16 +85,41 @@ module Preclaim_retry = struct
         if Hashtbl.length keepers = 0
         then Hashtbl.remove by_base_path base_path)
 
-  let take ~base_path ~keeper_name =
+  let remove_empty_base_path ~base_path keepers =
+    if Hashtbl.length keepers = 0
+    then Hashtbl.remove by_base_path base_path
+
+  let observe_release ~base_path ~keeper_name =
     with_lock (fun () ->
       match Hashtbl.find_opt by_base_path base_path with
       | None -> false
       | Some keepers ->
-        let waiting = Hashtbl.mem keepers keeper_name in
-        Hashtbl.remove keepers keeper_name;
-        if Hashtbl.length keepers = 0
-        then Hashtbl.remove by_base_path base_path;
-        waiting)
+        (match Hashtbl.find_opt keepers keeper_name with
+         | None -> false
+         | Some Watching ->
+           Hashtbl.replace keepers keeper_name Released;
+           false
+         | Some Released -> false
+         | Some Waiting ->
+           Hashtbl.remove keepers keeper_name;
+           remove_empty_base_path ~base_path keepers;
+           true))
+
+  let arm ~base_path ~keeper_name =
+    with_lock (fun () ->
+      match Hashtbl.find_opt by_base_path base_path with
+      | None -> false
+      | Some keepers ->
+        (match Hashtbl.find_opt keepers keeper_name with
+         | None -> false
+         | Some Watching ->
+           Hashtbl.replace keepers keeper_name Waiting;
+           false
+         | Some Released ->
+           Hashtbl.remove keepers keeper_name;
+           remove_empty_base_path ~base_path keepers;
+           true
+         | Some Waiting -> false))
 
   let clear_base_path base_path =
     with_lock (fun () -> Hashtbl.remove by_base_path base_path)
@@ -98,7 +128,7 @@ module Preclaim_retry = struct
 end
 
 let notify_slot_transition ~base_path ~keeper_name =
-  if Preclaim_retry.take ~base_path ~keeper_name
+  if Preclaim_retry.observe_release ~base_path ~keeper_name
   then notify_transition ~keeper_name
 
 type turn_outcome =
@@ -516,7 +546,7 @@ let run_observed_turn state ~sw ~clock ~handle_turn ~keeper_name observation =
     Keeper_chat_delivery_identity.Receipt_ids.singleton item.receipt_id
   in
   let claim = ref Claim_not_attempted in
-  Preclaim_retry.mark ~base_path:state.base_path ~keeper_name;
+  Preclaim_retry.begin_attempt ~base_path:state.base_path ~keeper_name;
   let rec claim_observation ~may_retry observation =
     match Keeper_chat_queue.lease_observed observation with
     | `Leased lease -> Ok lease
@@ -570,6 +600,10 @@ let run_observed_turn state ~sw ~clock ~handle_turn ~keeper_name observation =
     | Claim_failed _ ->
       Error (claim_error_to_string !claim)
   in
+  let arm_preclaim_retry () =
+    if Preclaim_retry.arm ~base_path:state.base_path ~keeper_name
+    then notify_transition ~keeper_name
+  in
   let outcome =
     match
       handle_turn
@@ -610,8 +644,10 @@ let run_observed_turn state ~sw ~clock ~handle_turn ~keeper_name observation =
          ; outcome_ref = None
          })
   | Claim_not_attempted, `Returned (Deferred { rejection }) ->
+    arm_preclaim_retry ();
     log_deferred_turn ~keeper_name rejection
   | Claim_not_attempted, (`Returned (Delivered _ | Failed _) | `Raised _) ->
+    arm_preclaim_retry ();
     Log.Keeper.error
       "keeper_chat_consumer: queued handler completed without invoking its admission claim keeper=%s receipt_id=%s; receipt remains Pending"
       keeper_name

--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -390,6 +390,16 @@ let nack_or_warn state ~keeper_name ~lease_id =
   match settle_lease state ~keeper_name ~lease_id Nack with
   | `Settled | `Pending -> ()
 
+let interrupt_or_warn state ~clock ~keeper_name ~lease_id =
+  finalize_or_warn state ~keeper_name ~lease_id
+    (Keeper_chat_queue.Mark_failed
+       { completed_at = Eio.Time.now clock
+       ; kind = Keeper_chat_queue.Interrupted
+       ; detail =
+           "Keeper stopped before this claimed turn completed; its external effect is unknown."
+       ; outcome_ref = None
+       })
+
 (* Kept as a separate helper so a later wake cannot start a new turn while an
    earlier turn's durable ack/nack is still unresolved. *)
 let retry_pending_finalization state ~keeper_name =
@@ -549,7 +559,7 @@ let run_observed_turn state ~sw ~clock ~handle_turn ~keeper_name observation =
       (match !claim with
        | Claim_leased { lease_id; _ } ->
          Eio.Cancel.protect (fun () ->
-             nack_or_warn state ~keeper_name ~lease_id)
+             interrupt_or_warn state ~clock ~keeper_name ~lease_id)
        | Claim_not_attempted | Claim_stale _ | Claim_failed _ -> ());
       raise exn
     | exception exn -> `Raised exn

--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -59,18 +59,12 @@ type turn_outcome =
       }
   | Deferred of { rejection : Keeper_turn_admission.rejection }
 
-type persistence_blocked_operation =
-  | Pending_claim_blocked
-  | Finalize_blocked
-
 type persistence_blocked_status =
-  { operation : persistence_blocked_operation
-  ; lease_id : string option
+  { lease_id : string
   ; error : Keeper_chat_queue.mutation_error
   }
 
 type blocked_retry =
-  | Retry_pending_claim of { blocked_revision : int64 }
   | Retry_finalization of
       { lease_id : string
       ; outcome : Keeper_chat_queue.finalization
@@ -96,21 +90,9 @@ module Persistence_blocked = struct
     with_lock (fun () ->
       Hashtbl.replace entries (key ~base_path ~keeper_name) entry)
 
-  let remember_pending_claim ~base_path ~keeper_name entry =
-    with_lock (fun () ->
-      let key = key ~base_path ~keeper_name in
-      match Hashtbl.find_opt entries key with
-      | Some { retry = Retry_finalization _; _ } -> ()
-      | Some { retry = Retry_pending_claim _; _ } | None ->
-        Hashtbl.replace entries key entry)
-
   let find ~base_path ~keeper_name =
     with_lock (fun () ->
       Hashtbl.find_opt entries (key ~base_path ~keeper_name))
-
-  let clear ~base_path ~keeper_name =
-    with_lock (fun () ->
-      Hashtbl.remove entries (key ~base_path ~keeper_name))
 
   let clear_finalization ~base_path ~keeper_name ~lease_id =
     with_lock (fun () ->
@@ -133,12 +115,8 @@ type dispatch_state = {
 }
 
 type lane_activity =
-  | Dispatchable of
-      { has_active : bool
-      ; revision : int64
-      }
+  | Dispatchable of { has_active : bool }
   | Awaiting_delivery_recovery of Keeper_chat_queue.recovery_evidence
-  | Pending_claim_retry_blocked of int64
 
 let create_dispatch_state ~base_path =
   { base_path = Keeper_registry_types.canonical_base_path_exn base_path
@@ -187,7 +165,7 @@ let pending_finalization state keeper_name =
   with
   | Some { retry = Retry_finalization { lease_id; outcome }; _ } ->
     Some (lease_id, outcome)
-  | Some { retry = Retry_pending_claim _; _ } | None -> None
+  | None -> None
 
 let clear_pending_finalization state ~keeper_name ~lease_id =
   Persistence_blocked.clear_finalization
@@ -199,47 +177,9 @@ let remember_pending_finalization state ~keeper_name ~lease_id ~outcome ~error =
   Persistence_blocked.remember
     ~base_path:state.base_path
     ~keeper_name
-    { status =
-        { operation = Finalize_blocked
-        ; lease_id = Some lease_id
-        ; error
-        }
+    { status = { lease_id; error }
     ; retry = Retry_finalization { lease_id; outcome }
     }
-
-let remember_blocked_pending_claim state ~keeper_name ~blocked_revision ~error =
-  Persistence_blocked.remember_pending_claim
-    ~base_path:state.base_path
-    ~keeper_name
-    { status =
-        { operation = Pending_claim_blocked; lease_id = None; error }
-    ; retry = Retry_pending_claim { blocked_revision }
-    }
-
-let pending_claim_retry_blocked state ~keeper_name ~revision =
-  match
-    Persistence_blocked.find
-      ~base_path:state.base_path
-      ~keeper_name
-  with
-  | Some
-      { retry = Retry_pending_claim { blocked_revision }
-      ; _
-      } ->
-    Int64.equal blocked_revision revision
-  | Some { retry = Retry_finalization _; _ } | None -> false
-
-let clear_blocked_pending_claim state ~keeper_name =
-  match
-    Persistence_blocked.find
-      ~base_path:state.base_path
-      ~keeper_name
-  with
-  | Some { retry = Retry_pending_claim _; _ } ->
-    Persistence_blocked.clear
-      ~base_path:state.base_path
-      ~keeper_name
-  | Some { retry = Retry_finalization _; _ } | None -> ()
 
 let persistence_blocked_status ~base_path ~keeper_name =
   match Config_dir_resolver.canonical_base_path base_path with
@@ -452,6 +392,7 @@ type observed_claim =
   | Claim_not_attempted
   | Claim_leased of Keeper_chat_queue.lease
   | Claim_stale of Keeper_chat_queue.pending_claim_stale
+  | Claim_no_longer_pending
   | Claim_failed of Keeper_chat_queue.mutation_error
 
 let claim_error_to_string = function
@@ -463,6 +404,8 @@ let claim_error_to_string = function
       (Keeper_chat_queue.Receipt_id.to_string receipt_id)
       expected_revision
       observed_revision
+  | Claim_no_longer_pending ->
+    "pending receipt changed while its persistence claim was reconciled"
   | Claim_failed error -> Keeper_chat_queue.mutation_error_to_string error
 
 let finalize_claimed_outcome state ~clock ~keeper_name ~lease_id = function
@@ -482,51 +425,86 @@ let finalize_claimed_outcome state ~clock ~keeper_name ~lease_id = function
     finalize_or_warn state ~keeper_name ~lease_id
       (finalization_of_failed ~clock ~kind ~detail ~outcome_ref)
 
-let handle_claim_failure state ~keeper_name ~observed_revision error =
-  let block_at blocked_revision =
-    remember_blocked_pending_claim state ~keeper_name ~blocked_revision ~error;
-    Log.Keeper.warn
-      "keeper_chat_consumer: admitted receipt claim failed for keeper=%s: %s; lane is persistence_blocked at revision=%Ld until a later durable queue revision"
-      keeper_name
-      (Keeper_chat_queue.mutation_error_to_string error)
-      blocked_revision
-  in
+let reconcile_claim_failure ~keeper_name error =
   match error with
   | (Keeper_chat_queue.Persist_failed
-       { publication = Lease_indeterminate _; _ }
+       { publication =
+           ( Keeper_chat_queue.Not_published
+           | Keeper_chat_queue.Lease_indeterminate _ )
+       ; _
+       }
     | Keeper_chat_queue.Snapshot_unavailable
         { kind = Durability_uncertain; _ }) ->
-    let blocked_revision =
-      Option.value
-        (reconcile_published_transition ~keeper_name error)
-        ~default:observed_revision
-    in
-    block_at blocked_revision
-  | _ -> block_at observed_revision
+    (match Keeper_chat_queue.reconcile_persistence ~keeper_name with
+     | Ok report ->
+       Log.Keeper.info
+         "keeper_chat_consumer: reconciled failed receipt claim keeper=%s revision=%Ld"
+         keeper_name
+         report.revision;
+       Ok ()
+     | Error reconciliation_error ->
+       Log.Keeper.error
+         "keeper_chat_consumer: receipt claim reconciliation failed keeper=%s claim_error=%s reconciliation_error=%s"
+         keeper_name
+         (Keeper_chat_queue.mutation_error_to_string error)
+         (Keeper_chat_queue.mutation_error_to_string reconciliation_error);
+       Error reconciliation_error)
+  | _ ->
+    Log.Keeper.error
+      "keeper_chat_consumer: receipt claim failed without a retryable persistence transition keeper=%s error=%s"
+      keeper_name
+      (Keeper_chat_queue.mutation_error_to_string error);
+    Error error
 
 let run_observed_turn state ~sw ~clock ~handle_turn ~keeper_name observation =
   let item = Keeper_chat_queue.pending_observation_item observation in
-  let observed_revision =
-    Keeper_chat_queue.pending_observation_revision observation
-  in
   let receipt_ids =
     Keeper_chat_delivery_identity.Receipt_ids.singleton item.receipt_id
   in
   let claim = ref Claim_not_attempted in
+  let rec claim_observation ~may_retry observation =
+    match Keeper_chat_queue.lease_observed observation with
+    | `Leased lease -> Ok lease
+    | `Stale stale -> Error (`Stale stale)
+    | `Error error when may_retry ->
+      (match reconcile_claim_failure ~keeper_name error with
+       | Error _ -> Error (`Failed error)
+       | Ok () ->
+         (match Keeper_chat_queue.observe_pending ~keeper_name with
+          | Error retry_error -> Error (`Failed retry_error)
+          | Ok None -> Error `No_longer_pending
+          | Ok (Some retry_observation) ->
+            let retry_item =
+              Keeper_chat_queue.pending_observation_item retry_observation
+            in
+            if
+              Keeper_chat_queue.Receipt_id.equal
+                retry_item.receipt_id
+                item.receipt_id
+            then claim_observation ~may_retry:false retry_observation
+            else Error `No_longer_pending))
+    | `Error error -> Error (`Failed error)
+  in
   let on_admitted () =
     match !claim with
     | Claim_not_attempted ->
-      (match Keeper_chat_queue.lease_observed observation with
-       | `Leased lease ->
+      (match claim_observation ~may_retry:true observation with
+       | Ok lease ->
          claim := Claim_leased lease;
          Ok ()
-       | `Stale stale ->
+       | Error (`Stale stale) ->
          claim := Claim_stale stale;
          Error (claim_error_to_string !claim)
-       | `Error error ->
+       | Error `No_longer_pending ->
+         claim := Claim_no_longer_pending;
+         Error (claim_error_to_string !claim)
+       | Error (`Failed error) ->
          claim := Claim_failed error;
          Error (claim_error_to_string !claim))
-    | Claim_leased _ | Claim_stale _ | Claim_failed _ ->
+    | Claim_leased _
+    | Claim_stale _
+    | Claim_no_longer_pending
+    | Claim_failed _ ->
       Error (claim_error_to_string !claim)
   in
   let outcome =
@@ -544,7 +522,11 @@ let run_observed_turn state ~sw ~clock ~handle_turn ~keeper_name observation =
        | Claim_leased { lease_id; _ } ->
          Eio.Cancel.protect (fun () ->
              cancel_claimed_or_warn state ~clock ~keeper_name ~lease_id)
-       | Claim_not_attempted | Claim_stale _ | Claim_failed _ -> ());
+       | Claim_not_attempted
+       | Claim_stale _
+       | Claim_no_longer_pending
+       | Claim_failed _ ->
+         ());
       raise exn
     | exception exn -> `Raised exn
   in
@@ -571,14 +553,18 @@ let run_observed_turn state ~sw ~clock ~handle_turn ~keeper_name observation =
       "keeper_chat_consumer: queued handler completed without invoking its admission claim keeper=%s receipt_id=%s; receipt remains Pending"
       keeper_name
       (Keeper_chat_queue.Receipt_id.to_string item.receipt_id)
-  | Claim_stale _, _ ->
+  | (Claim_stale _ | Claim_no_longer_pending), _ ->
     Log.Keeper.info
       "keeper_chat_consumer: pending observation changed before admission keeper=%s receipt_id=%s; re-observing lane"
       keeper_name
       (Keeper_chat_queue.Receipt_id.to_string item.receipt_id);
     notify_transition ~keeper_name
   | Claim_failed error, _ ->
-    handle_claim_failure state ~keeper_name ~observed_revision error
+    Log.Keeper.error
+      "keeper_chat_consumer: exact receipt claim failed after one reconciled retry keeper=%s receipt_id=%s error=%s; receipt remains Pending until the next explicit lane transition"
+      keeper_name
+      (Keeper_chat_queue.Receipt_id.to_string item.receipt_id)
+      (Keeper_chat_queue.mutation_error_to_string error)
 
 let run ~sw ~clock ~base_path ~handle_turn =
   let dispatch_state = create_dispatch_state ~base_path in
@@ -591,12 +577,8 @@ let run ~sw ~clock ~base_path ~handle_turn =
   let ready_lane_activity keeper_name =
     match Keeper_chat_queue.lane_status ~keeper_name with
     | Error _ as error -> error
-    | Ok { revision; _ }
-      when pending_claim_retry_blocked
-             dispatch_state ~keeper_name ~revision ->
-      Ok (Pending_claim_retry_blocked revision)
-    | Ok { health = Keeper_chat_queue.Ready; has_active; revision } ->
-      Ok (Dispatchable { has_active; revision })
+    | Ok { health = Keeper_chat_queue.Ready; has_active; _ } ->
+      Ok (Dispatchable { has_active })
     | Ok
         { health =
             Keeper_chat_queue.Delivery_recovery_required
@@ -624,12 +606,8 @@ let run ~sw ~clock ~base_path ~handle_turn =
            report.revision;
          (match Keeper_chat_queue.lane_status ~keeper_name with
           | Error _ as error -> error
-          | Ok { revision; _ }
-            when pending_claim_retry_blocked
-                   dispatch_state ~keeper_name ~revision ->
-            Ok (Pending_claim_retry_blocked revision)
-          | Ok { health = Keeper_chat_queue.Ready; has_active; revision } ->
-            Ok (Dispatchable { has_active; revision })
+          | Ok { health = Keeper_chat_queue.Ready; has_active; _ } ->
+            Ok (Dispatchable { has_active })
           | Ok
               { health =
                   Keeper_chat_queue.Delivery_recovery_required
@@ -665,12 +643,9 @@ let run ~sw ~clock ~base_path ~handle_turn =
           keeper_name
           (Keeper_chat_queue.mutation_error_to_string error);
         release keeper_name
-      | Ok (Pending_claim_retry_blocked _) ->
-        release keeper_name
       | Ok _ when retry_pending_finalization dispatch_state ~keeper_name ->
         release keeper_name
       | Ok (Awaiting_delivery_recovery evidence) ->
-        clear_blocked_pending_claim dispatch_state ~keeper_name;
         Log.Keeper.warn
           "keeper_chat_consumer: lane awaits explicit delivery recovery keeper=%s receipt_id=%s lease_id=%s started_at=%.06f"
           keeper_name
@@ -679,19 +654,14 @@ let run ~sw ~clock ~base_path ~handle_turn =
           evidence.started_at;
         release keeper_name
       | Ok (Dispatchable { has_active = false; _ }) ->
-        clear_blocked_pending_claim dispatch_state ~keeper_name;
         release keeper_name
-      | Ok (Dispatchable { has_active = true; revision }) ->
-        clear_blocked_pending_claim dispatch_state ~keeper_name;
+      | Ok (Dispatchable { has_active = true }) ->
         (match Keeper_chat_queue.observe_pending ~keeper_name with
          | Error error ->
-           remember_blocked_pending_claim dispatch_state ~keeper_name
-             ~blocked_revision:revision ~error;
            Log.Keeper.warn
-             "keeper_chat_consumer: pending head observation failed for keeper=%s: %s; lane is persistence_blocked at revision=%Ld until a later durable queue revision"
+             "keeper_chat_consumer: pending head observation failed for keeper=%s: %s; inspection waits for the next explicit lane transition"
              keeper_name
-             (Keeper_chat_queue.mutation_error_to_string error)
-             revision;
+             (Keeper_chat_queue.mutation_error_to_string error);
            release keeper_name
          | Ok None -> release keeper_name
          | Ok (Some observation) ->

--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -59,14 +59,9 @@ type turn_outcome =
       }
   | Deferred of { rejection : Keeper_turn_admission.rejection }
 
-type lease_finalization =
-  | Finalize of Keeper_chat_queue.finalization
-  | Nack
-
 type persistence_blocked_operation =
   | Pending_claim_blocked
   | Finalize_blocked
-  | Nack_blocked
 
 type persistence_blocked_status =
   { operation : persistence_blocked_operation
@@ -78,7 +73,7 @@ type blocked_retry =
   | Retry_pending_claim
   | Retry_finalization of
       { lease_id : string
-      ; action : lease_finalization
+      ; outcome : Keeper_chat_queue.finalization
       }
 
 module Persistence_blocked = struct
@@ -186,8 +181,8 @@ let pending_finalization state keeper_name =
       ~base_path:state.base_path
       ~keeper_name
   with
-  | Some { retry = Retry_finalization { lease_id; action }; _ } ->
-    Some (lease_id, action)
+  | Some { retry = Retry_finalization { lease_id; outcome }; _ } ->
+    Some (lease_id, outcome)
   | Some { retry = Retry_pending_claim; _ } | None -> None
 
 let clear_pending_finalization state ~keeper_name ~lease_id =
@@ -196,20 +191,16 @@ let clear_pending_finalization state ~keeper_name ~lease_id =
     ~keeper_name
     ~lease_id
 
-let operation_of_finalization = function
-  | Finalize _ -> Finalize_blocked
-  | Nack -> Nack_blocked
-
-let remember_pending_finalization state ~keeper_name ~lease_id ~action ~error =
+let remember_pending_finalization state ~keeper_name ~lease_id ~outcome ~error =
   Persistence_blocked.remember
     ~base_path:state.base_path
     ~keeper_name
     { status =
-        { operation = operation_of_finalization action
+        { operation = Finalize_blocked
         ; lease_id = Some lease_id
         ; error
         }
-    ; retry = Retry_finalization { lease_id; action }
+    ; retry = Retry_finalization { lease_id; outcome }
     }
 
 let remember_blocked_pending_claim state ~keeper_name ~error =
@@ -291,122 +282,81 @@ let reconcile_published_transition ~keeper_name error =
       (Keeper_chat_queue.mutation_error_to_string error)
       (Keeper_chat_queue.mutation_error_to_string reconciliation_error)
 
-let settle_lease state ~keeper_name ~lease_id action =
-  let result =
-    match action with
-    | Finalize outcome ->
-      let rec finalize ~allow_invalid_fallback outcome =
-        match Keeper_chat_queue.finalize ~keeper_name ~lease_id ~outcome with
-        | `Finalized _ ->
-          clear_pending_finalization state ~keeper_name ~lease_id;
-          `Settled
-        | `Unknown_lease ->
-          clear_pending_finalization state ~keeper_name ~lease_id;
-          Log.Keeper.warn
-            "keeper_chat_consumer: finalize found no matching lease=%s for \
-             keeper=%s (already finalized/nacked?)"
-            lease_id
-            keeper_name;
-          `Settled
-        | `Error (Keeper_chat_queue.Invalid_input message)
-          when allow_invalid_fallback ->
-          (match invalid_finalization_fallback message with
-           | Ok fallback ->
-             Log.Keeper.error
-               "keeper_chat_consumer: rejected invalid terminal outcome for \
-                keeper=%s lease=%s: %s; replacing it with a typed internal_error"
-               keeper_name lease_id message;
-             finalize ~allow_invalid_fallback:false fallback
-           | Error error ->
-             let retry_action = Finalize outcome in
-             remember_pending_finalization state ~keeper_name ~lease_id
-               ~action:retry_action ~error;
-             Log.Keeper.error
-               "keeper_chat_consumer: rejected invalid terminal outcome for \
-                keeper=%s lease=%s: %s; typed replacement is unavailable: %s"
-               keeper_name lease_id message
-               (Keeper_chat_queue.mutation_error_to_string error);
-             `Pending)
-        | `Error
-            (Keeper_chat_queue.Persist_failed
-               { publication = Finalize_indeterminate _; _ } as error) ->
-          clear_pending_finalization state ~keeper_name ~lease_id;
-          reconcile_published_transition ~keeper_name error;
-          `Settled
-        | `Error error ->
-          let retry_action = Finalize outcome in
-          remember_pending_finalization state ~keeper_name ~lease_id
-            ~action:retry_action ~error;
-          Log.Keeper.error
-            "keeper_chat_consumer: finalize persist failed for keeper=%s \
-             lease=%s: %s; finalization will retry after the next durable \
-             transition or explicit operator reconciliation"
-            keeper_name
-            lease_id
-            (Keeper_chat_queue.mutation_error_to_string error);
-          `Pending
-      in
-      finalize ~allow_invalid_fallback:true outcome
-    | Nack ->
-      (match Keeper_chat_queue.nack ~keeper_name ~lease_id with
-       | `Requeued _ ->
-         clear_pending_finalization state ~keeper_name ~lease_id;
-         `Settled
-       | `Unknown_lease ->
-         clear_pending_finalization state ~keeper_name ~lease_id;
-         Log.Keeper.warn
-           "keeper_chat_consumer: nack found no matching lease=%s for keeper=%s \
-            (already acked/nacked?)"
-           lease_id
-           keeper_name;
-         `Settled
-       | `Error
-           (Keeper_chat_queue.Persist_failed
-              { publication = Nack_indeterminate _; _ } as error) ->
-         clear_pending_finalization state ~keeper_name ~lease_id;
-         reconcile_published_transition ~keeper_name error;
-         `Settled
-       | `Error error ->
-         remember_pending_finalization state ~keeper_name ~lease_id ~action
-           ~error;
+let settle_lease state ~keeper_name ~lease_id outcome =
+  let rec finalize ~allow_invalid_fallback outcome =
+    match Keeper_chat_queue.finalize ~keeper_name ~lease_id ~outcome with
+    | `Finalized _ ->
+      clear_pending_finalization state ~keeper_name ~lease_id;
+      `Settled
+    | `Unknown_lease ->
+      clear_pending_finalization state ~keeper_name ~lease_id;
+      Log.Keeper.warn
+        "keeper_chat_consumer: finalize found no matching lease=%s for \
+         keeper=%s (already finalized?)"
+        lease_id
+        keeper_name;
+      `Settled
+    | `Error (Keeper_chat_queue.Invalid_input message)
+      when allow_invalid_fallback ->
+      (match invalid_finalization_fallback message with
+       | Ok fallback ->
          Log.Keeper.error
-           "keeper_chat_consumer: nack persist failed for keeper=%s lease=%s: %s; \
-            finalization will retry after the next durable transition or \
-            explicit operator reconciliation"
-           keeper_name
-           lease_id
+           "keeper_chat_consumer: rejected invalid terminal outcome for \
+            keeper=%s lease=%s: %s; replacing it with a typed internal_error"
+           keeper_name lease_id message;
+         finalize ~allow_invalid_fallback:false fallback
+       | Error error ->
+         remember_pending_finalization state ~keeper_name ~lease_id
+           ~outcome ~error;
+         Log.Keeper.error
+           "keeper_chat_consumer: rejected invalid terminal outcome for \
+            keeper=%s lease=%s: %s; typed replacement is unavailable: %s"
+           keeper_name lease_id message
            (Keeper_chat_queue.mutation_error_to_string error);
          `Pending)
+    | `Error
+        (Keeper_chat_queue.Persist_failed
+           { publication = Finalize_indeterminate _; _ } as error) ->
+      clear_pending_finalization state ~keeper_name ~lease_id;
+      reconcile_published_transition ~keeper_name error;
+      `Settled
+    | `Error error ->
+      remember_pending_finalization state ~keeper_name ~lease_id
+        ~outcome ~error;
+      Log.Keeper.error
+        "keeper_chat_consumer: finalize persist failed for keeper=%s \
+         lease=%s: %s; finalization will retry after the next durable \
+         transition or explicit operator reconciliation"
+        keeper_name
+        lease_id
+        (Keeper_chat_queue.mutation_error_to_string error);
+      `Pending
   in
-  result
+  finalize ~allow_invalid_fallback:true outcome
 
 (* Keep these names at the call sites readable: they now retain the decision
    when persistence is temporarily unavailable instead of silently giving up. *)
 let finalize_or_warn state ~keeper_name ~lease_id outcome =
-  match settle_lease state ~keeper_name ~lease_id (Finalize outcome) with
+  match settle_lease state ~keeper_name ~lease_id outcome with
   | `Settled | `Pending -> ()
 
-let nack_or_warn state ~keeper_name ~lease_id =
-  match settle_lease state ~keeper_name ~lease_id Nack with
-  | `Settled | `Pending -> ()
-
-let interrupt_or_warn state ~clock ~keeper_name ~lease_id =
+let cancel_claimed_or_warn state ~clock ~keeper_name ~lease_id =
   finalize_or_warn state ~keeper_name ~lease_id
     (Keeper_chat_queue.Mark_failed
        { completed_at = Eio.Time.now clock
-       ; kind = Keeper_chat_queue.Interrupted
+       ; kind = Keeper_chat_queue.Cancelled
        ; detail =
            "Keeper stopped before this claimed turn completed; its external effect is unknown."
        ; outcome_ref = None
        })
 
 (* Kept as a separate helper so a later wake cannot start a new turn while an
-   earlier turn's durable ack/nack is still unresolved. *)
+   earlier turn's durable finalization is still unresolved. *)
 let retry_pending_finalization state ~keeper_name =
   match pending_finalization state keeper_name with
   | None -> false
-  | Some (lease_id, action) ->
-    (match settle_lease state ~keeper_name ~lease_id action with
+  | Some (lease_id, outcome) ->
+    (match settle_lease state ~keeper_name ~lease_id outcome with
     | `Settled | `Pending -> ());
     true
 
@@ -559,7 +509,7 @@ let run_observed_turn state ~sw ~clock ~handle_turn ~keeper_name observation =
       (match !claim with
        | Claim_leased { lease_id; _ } ->
          Eio.Cancel.protect (fun () ->
-             interrupt_or_warn state ~clock ~keeper_name ~lease_id)
+             cancel_claimed_or_warn state ~clock ~keeper_name ~lease_id)
        | Claim_not_attempted | Claim_stale _ | Claim_failed _ -> ());
       raise exn
     | exception exn -> `Raised exn

--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -229,31 +229,17 @@ let pending_claim_retry_blocked state ~keeper_name ~revision =
     Int64.equal blocked_revision revision
   | Some { retry = Retry_finalization _; _ } | None -> false
 
-let clear_blocked_pending_claim_for_base_path ~base_path ~keeper_name =
+let clear_blocked_pending_claim state ~keeper_name =
   match
     Persistence_blocked.find
-      ~base_path
+      ~base_path:state.base_path
       ~keeper_name
   with
   | Some { retry = Retry_pending_claim _; _ } ->
     Persistence_blocked.clear
-      ~base_path
+      ~base_path:state.base_path
       ~keeper_name
   | Some { retry = Retry_finalization _; _ } | None -> ()
-
-let clear_blocked_pending_claim state ~keeper_name =
-  clear_blocked_pending_claim_for_base_path
-    ~base_path:state.base_path
-    ~keeper_name
-
-let notify_explicit_retry ~base_path ~keeper_name =
-  match Config_dir_resolver.canonical_base_path base_path with
-  | Error error ->
-    Error (Config_dir_resolver.canonical_base_path_error_to_string error)
-  | Ok base_path ->
-    clear_blocked_pending_claim_for_base_path ~base_path ~keeper_name;
-    notify_transition ~keeper_name;
-    Ok ()
 
 let persistence_blocked_status ~base_path ~keeper_name =
   match Config_dir_resolver.canonical_base_path base_path with

--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -64,7 +64,7 @@ type lease_finalization =
   | Nack
 
 type persistence_blocked_operation =
-  | Lease_next_blocked
+  | Pending_claim_blocked
   | Finalize_blocked
   | Nack_blocked
 
@@ -75,7 +75,7 @@ type persistence_blocked_status =
   }
 
 type blocked_retry =
-  | Retry_lease_next
+  | Retry_pending_claim
   | Retry_finalization of
       { lease_id : string
       ; action : lease_finalization
@@ -101,12 +101,12 @@ module Persistence_blocked = struct
     with_lock (fun () ->
       Hashtbl.replace entries (key ~base_path ~keeper_name) entry)
 
-  let remember_lease ~base_path ~keeper_name entry =
+  let remember_pending_claim ~base_path ~keeper_name entry =
     with_lock (fun () ->
       let key = key ~base_path ~keeper_name in
       match Hashtbl.find_opt entries key with
       | Some { retry = Retry_finalization _; _ } -> ()
-      | Some { retry = Retry_lease_next; _ } | None ->
+      | Some { retry = Retry_pending_claim; _ } | None ->
         Hashtbl.replace entries key entry)
 
   let find ~base_path ~keeper_name =
@@ -188,7 +188,7 @@ let pending_finalization state keeper_name =
   with
   | Some { retry = Retry_finalization { lease_id; action }; _ } ->
     Some (lease_id, action)
-  | Some { retry = Retry_lease_next; _ } | None -> None
+  | Some { retry = Retry_pending_claim; _ } | None -> None
 
 let clear_pending_finalization state ~keeper_name ~lease_id =
   Persistence_blocked.clear_finalization
@@ -212,22 +212,22 @@ let remember_pending_finalization state ~keeper_name ~lease_id ~action ~error =
     ; retry = Retry_finalization { lease_id; action }
     }
 
-let remember_blocked_lease state ~keeper_name ~error =
-  Persistence_blocked.remember_lease
+let remember_blocked_pending_claim state ~keeper_name ~error =
+  Persistence_blocked.remember_pending_claim
     ~base_path:state.base_path
     ~keeper_name
     { status =
-        { operation = Lease_next_blocked; lease_id = None; error }
-    ; retry = Retry_lease_next
+        { operation = Pending_claim_blocked; lease_id = None; error }
+    ; retry = Retry_pending_claim
     }
 
-let clear_blocked_lease state ~keeper_name =
+let clear_blocked_pending_claim state ~keeper_name =
   match
     Persistence_blocked.find
       ~base_path:state.base_path
       ~keeper_name
   with
-  | Some { retry = Retry_lease_next; _ } ->
+  | Some { retry = Retry_pending_claim; _ } ->
     Persistence_blocked.clear
       ~base_path:state.base_path
       ~keeper_name
@@ -457,62 +457,133 @@ let log_deferred_turn ~keeper_name
   | Some operation_id ->
       Log.Keeper.info
         "keeper_chat_consumer: admission fenced for keeper=%s by shutdown=%s; \
-         returning the leased receipt to Pending"
+         receipt remains Pending"
         keeper_name
         (Keeper_shutdown_types.Operation_id.to_string operation_id)
   | None ->
       Log.Keeper.info
         "keeper_chat_consumer: admission deferred for keeper=%s waiting=%d \
-         in_flight=%b; returning the leased receipt to Pending"
+         in_flight=%b; receipt remains Pending"
         keeper_name waiting (Option.is_some in_flight)
 
-let run_leased_turn state ~sw ~clock ~handle_turn ~keeper_name ~lease_id
-    ~delivery_key ~queued =
-  match handle_turn ~sw ~keeper_name ~delivery_key ~queued_message:queued with
-  | Deferred { rejection } ->
-      log_deferred_turn ~keeper_name rejection;
-      nack_or_warn state ~keeper_name ~lease_id
-  | Delivered { outcome_ref } ->
-      finalize_or_warn state ~keeper_name ~lease_id
-        (finalization_of_delivered ~clock ~outcome_ref)
-  | Failed { kind; detail; outcome_ref } ->
-      finalize_or_warn state ~keeper_name ~lease_id
-        (finalization_of_failed ~clock ~kind ~detail ~outcome_ref)
-  | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
-  | exception exn ->
-      let detail = Printexc.to_string exn in
-      Log.Keeper.error
-        "keeper_chat_consumer: handle_turn raised for keeper=%s: %s; recording \
-         a terminal internal_error receipt"
-        keeper_name detail;
-      finalize_or_warn state ~keeper_name ~lease_id
-        (Keeper_chat_queue.Mark_failed
-           { completed_at = Eio.Time.now clock
-           ; kind = Keeper_chat_queue.Internal_error
-           ; detail
-           ; outcome_ref = None
-           })
+type observed_claim =
+  | Claim_not_attempted
+  | Claim_leased of Keeper_chat_queue.lease
+  | Claim_stale of Keeper_chat_queue.pending_claim_stale
+  | Claim_failed of Keeper_chat_queue.mutation_error
 
-let dispatch_queued_turn state ~sw ~clock ~handle_turn ~keeper_name ~lease_id
-    ~delivery_key ~queued =
-  Eio.Fiber.fork ~sw (fun () ->
-      try
-        run_leased_turn state ~sw ~clock ~handle_turn ~keeper_name ~lease_id
-          ~delivery_key ~queued;
-        finish_dispatching_and_reschedule state keeper_name
-      with
-      | Eio.Cancel.Cancelled _ as e ->
-          Eio.Cancel.protect (fun () -> nack_or_warn state ~keeper_name ~lease_id);
-          finish_dispatching_and_reschedule state keeper_name;
-          raise e
-      | exn ->
-          nack_or_warn state ~keeper_name ~lease_id;
-          finish_dispatching_and_reschedule state keeper_name;
-          Log.Keeper.error
-            "keeper_chat_consumer: dispatch finalization failed unexpectedly \
-             for keeper=%s: %s"
-            keeper_name
-            (Printexc.to_string exn))
+let claim_error_to_string = function
+  | Claim_not_attempted -> "queue claim callback was not invoked"
+  | Claim_leased _ -> "queue claim callback was invoked more than once"
+  | Claim_stale { receipt_id; expected_revision; observed_revision } ->
+    Printf.sprintf
+      "pending receipt %s changed before admission (expected_revision=%Ld observed_revision=%Ld)"
+      (Keeper_chat_queue.Receipt_id.to_string receipt_id)
+      expected_revision
+      observed_revision
+  | Claim_failed error -> Keeper_chat_queue.mutation_error_to_string error
+
+let finalize_claimed_outcome state ~clock ~keeper_name ~lease_id = function
+  | Deferred { rejection } ->
+    log_deferred_turn ~keeper_name rejection;
+    finalize_or_warn state ~keeper_name ~lease_id
+      (Keeper_chat_queue.Mark_failed
+         { completed_at = Eio.Time.now clock
+         ; kind = Keeper_chat_queue.Internal_error
+         ; detail = "queued turn deferred after its admission claim committed"
+         ; outcome_ref = None
+         })
+  | Delivered { outcome_ref } ->
+    finalize_or_warn state ~keeper_name ~lease_id
+      (finalization_of_delivered ~clock ~outcome_ref)
+  | Failed { kind; detail; outcome_ref } ->
+    finalize_or_warn state ~keeper_name ~lease_id
+      (finalization_of_failed ~clock ~kind ~detail ~outcome_ref)
+
+let handle_claim_failure state ~keeper_name = function
+  | (Keeper_chat_queue.Persist_failed
+       { publication = Lease_indeterminate _; _ }
+    | Keeper_chat_queue.Snapshot_unavailable
+        { kind = Durability_uncertain; _ }) as error ->
+    reconcile_published_transition ~keeper_name error
+  | error ->
+    remember_blocked_pending_claim state ~keeper_name ~error;
+    Log.Keeper.warn
+      "keeper_chat_consumer: admitted receipt claim failed for keeper=%s: %s; lane is persistence_blocked until explicit operator reconciliation or another durable transition"
+      keeper_name
+      (Keeper_chat_queue.mutation_error_to_string error)
+
+let run_observed_turn state ~sw ~clock ~handle_turn ~keeper_name observation =
+  let item = Keeper_chat_queue.pending_observation_item observation in
+  let receipt_ids =
+    Keeper_chat_delivery_identity.Receipt_ids.singleton item.receipt_id
+  in
+  let claim = ref Claim_not_attempted in
+  let on_admitted () =
+    match !claim with
+    | Claim_not_attempted ->
+      (match Keeper_chat_queue.lease_observed observation with
+       | `Leased lease ->
+         claim := Claim_leased lease;
+         Ok ()
+       | `Stale stale ->
+         claim := Claim_stale stale;
+         Error (claim_error_to_string !claim)
+       | `Error error ->
+         claim := Claim_failed error;
+         Error (claim_error_to_string !claim))
+    | Claim_leased _ | Claim_stale _ | Claim_failed _ ->
+      Error (claim_error_to_string !claim)
+  in
+  let outcome =
+    match
+      handle_turn
+        ~sw
+        ~keeper_name
+        ~receipt_ids
+        ~queued_message:item.message
+        ~on_admitted
+    with
+    | outcome -> `Returned outcome
+    | exception (Eio.Cancel.Cancelled _ as exn) ->
+      (match !claim with
+       | Claim_leased { lease_id; _ } ->
+         Eio.Cancel.protect (fun () ->
+             nack_or_warn state ~keeper_name ~lease_id)
+       | Claim_not_attempted | Claim_stale _ | Claim_failed _ -> ());
+      raise exn
+    | exception exn -> `Raised exn
+  in
+  match !claim, outcome with
+  | Claim_leased { lease_id; _ }, `Returned outcome ->
+    finalize_claimed_outcome state ~clock ~keeper_name ~lease_id outcome
+  | Claim_leased { lease_id; _ }, `Raised exn ->
+    let detail = Printexc.to_string exn in
+    Log.Keeper.error
+      "keeper_chat_consumer: admitted handle_turn raised for keeper=%s: %s; recording a terminal internal_error receipt"
+      keeper_name
+      detail;
+    finalize_or_warn state ~keeper_name ~lease_id
+      (Keeper_chat_queue.Mark_failed
+         { completed_at = Eio.Time.now clock
+         ; kind = Keeper_chat_queue.Internal_error
+         ; detail
+         ; outcome_ref = None
+         })
+  | Claim_not_attempted, `Returned (Deferred { rejection }) ->
+    log_deferred_turn ~keeper_name rejection
+  | Claim_not_attempted, (`Returned (Delivered _ | Failed _) | `Raised _) ->
+    Log.Keeper.error
+      "keeper_chat_consumer: queued handler completed without invoking its admission claim keeper=%s receipt_id=%s; receipt remains Pending"
+      keeper_name
+      (Keeper_chat_queue.Receipt_id.to_string item.receipt_id)
+  | Claim_stale _, _ ->
+    Log.Keeper.info
+      "keeper_chat_consumer: pending observation changed before admission keeper=%s receipt_id=%s; re-observing lane"
+      keeper_name
+      (Keeper_chat_queue.Receipt_id.to_string item.receipt_id);
+    notify_transition ~keeper_name
+  | Claim_failed error, _ -> handle_claim_failure state ~keeper_name error
 
 let run ~sw ~clock ~base_path ~handle_turn =
   let dispatch_state = create_dispatch_state ~base_path in
@@ -582,61 +653,11 @@ let run ~sw ~clock ~base_path ~handle_turn =
                     revision
               }))
   in
-  let dispatch_lease keeper_name
-      ({ Keeper_chat_queue.lease_id; item } : Keeper_chat_queue.lease) =
-    let queued = item.message in
-      let delivery_key =
-        [ item.receipt_id ]
-        |> Keeper_chat_delivery_identity.Receipt_ids.of_list
-        |> Result.map (fun receipt_ids ->
-          Keeper_chat_delivery_identity.Queue_receipts receipt_ids)
-        |> Result.map_error
-             Keeper_chat_delivery_identity.Receipt_ids.error_to_string
-      in
-      let admission =
-        Keeper_turn_admission.snapshot_for ~base_path ~keeper_name
-      in
-      (match
-         admission.snapshot_in_flight,
-         admission.snapshot_shutdown_operation_id
-       with
-       | Some _, _ | _, Some _ ->
-         nack_or_warn dispatch_state ~keeper_name ~lease_id;
-         release keeper_name
-       | None, None ->
-         (match delivery_key with
-          | Error detail ->
-            finalize_or_warn dispatch_state ~keeper_name ~lease_id
-              (Keeper_chat_queue.Mark_failed
-                 { completed_at = Eio.Time.now clock
-                 ; kind = Keeper_chat_queue.Internal_error
-                 ; detail
-                 ; outcome_ref = None
-                 });
-            release keeper_name
-          | Ok delivery_key ->
-            (try
-               dispatch_queued_turn dispatch_state ~sw ~clock ~handle_turn
-                 ~keeper_name ~lease_id ~delivery_key ~queued
-             with
-             | Eio.Cancel.Cancelled _ as exception_ ->
-               Eio.Cancel.protect (fun () ->
-                   nack_or_warn dispatch_state ~keeper_name ~lease_id);
-               release keeper_name;
-               raise exception_
-             | exception_ ->
-               nack_or_warn dispatch_state ~keeper_name ~lease_id;
-               release keeper_name;
-               Log.Keeper.warn
-                 "keeper_chat_consumer: dispatch fork failed for keeper=%s: %s"
-                 keeper_name
-                 (Printexc.to_string exception_))))
-  in
   let inspect_keeper keeper_name =
     try
       match ready_lane_activity keeper_name with
       | Error error ->
-        remember_blocked_lease dispatch_state ~keeper_name ~error;
+        remember_blocked_pending_claim dispatch_state ~keeper_name ~error;
         Log.Keeper.error
           "keeper_chat_consumer: lane state unavailable keeper=%s error=%s; lane is persistence_blocked until explicit operator reconciliation or another durable transition"
           keeper_name
@@ -645,7 +666,7 @@ let run ~sw ~clock ~base_path ~handle_turn =
       | Ok _ when retry_pending_finalization dispatch_state ~keeper_name ->
         release keeper_name
       | Ok (Awaiting_delivery_recovery evidence) ->
-        clear_blocked_lease dispatch_state ~keeper_name;
+        clear_blocked_pending_claim dispatch_state ~keeper_name;
         Log.Keeper.warn
           "keeper_chat_consumer: lane awaits explicit delivery recovery keeper=%s receipt_id=%s lease_id=%s started_at=%.06f"
           keeper_name
@@ -654,46 +675,28 @@ let run ~sw ~clock ~base_path ~handle_turn =
           evidence.started_at;
         release keeper_name
       | Ok (Dispatchable false) ->
-        clear_blocked_lease dispatch_state ~keeper_name;
+        clear_blocked_pending_claim dispatch_state ~keeper_name;
         release keeper_name
       | Ok (Dispatchable true) ->
-        clear_blocked_lease dispatch_state ~keeper_name;
-        let admission =
-          Keeper_turn_admission.snapshot_for ~base_path ~keeper_name
-        in
-        (match
-           admission.snapshot_in_flight,
-           admission.snapshot_shutdown_operation_id
-         with
-         | Some _, _ | _, Some _ -> release keeper_name
-         | None, None ->
-           (match Keeper_chat_queue.lease_next ~keeper_name with
-            | `Empty -> release keeper_name
-            | `Already_leased _ -> release keeper_name
-            | `Recovery_required evidence ->
-              Log.Keeper.warn
-                "keeper_chat_consumer: lease boundary observed explicit delivery recovery keeper=%s receipt_id=%s lease_id=%s started_at=%.06f"
-                keeper_name
-                (Keeper_chat_queue.Receipt_id.to_string evidence.receipt_id)
-                evidence.lease_id
-                evidence.started_at;
-              release keeper_name
-            | `Error
-                (Keeper_chat_queue.Persist_failed
-                   { publication = Lease_indeterminate _; _ } as error)
-            | `Error
-                (Keeper_chat_queue.Snapshot_unavailable
-                   { kind = Durability_uncertain; _ } as error) ->
-              reconcile_published_transition ~keeper_name error;
-              release keeper_name
-            | `Error error ->
-              remember_blocked_lease dispatch_state ~keeper_name ~error;
-              Log.Keeper.warn
-                "keeper_chat_consumer: lease_next failed for keeper=%s: %s; lane is persistence_blocked until explicit operator reconciliation or another durable transition"
-                keeper_name
-                (Keeper_chat_queue.mutation_error_to_string error);
-              release keeper_name
-            | `Leased lease -> dispatch_lease keeper_name lease))
+        clear_blocked_pending_claim dispatch_state ~keeper_name;
+        (match Keeper_chat_queue.observe_pending ~keeper_name with
+         | Error error ->
+           remember_blocked_pending_claim dispatch_state ~keeper_name ~error;
+           Log.Keeper.warn
+             "keeper_chat_consumer: pending head observation failed for keeper=%s: %s; lane is persistence_blocked until explicit operator reconciliation or another durable transition"
+             keeper_name
+             (Keeper_chat_queue.mutation_error_to_string error);
+           release keeper_name
+         | Ok None -> release keeper_name
+         | Ok (Some observation) ->
+           run_observed_turn
+             dispatch_state
+             ~sw
+             ~clock
+             ~handle_turn
+             ~keeper_name
+             observation;
+           release keeper_name)
     with
     | Eio.Cancel.Cancelled _ as exception_ ->
       release keeper_name;

--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -50,6 +50,57 @@ end
 
 let notify_transition ~keeper_name = Wake_inbox.notify keeper_name
 
+module Preclaim_retry = struct
+  let mutex = Stdlib.Mutex.create ()
+  let by_base_path : (string, (string, unit) Hashtbl.t) Hashtbl.t =
+    Hashtbl.create 4
+
+  let with_lock f =
+    Stdlib.Mutex.lock mutex;
+    Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock mutex) f
+
+  let mark ~base_path ~keeper_name =
+    with_lock (fun () ->
+      let keepers =
+        match Hashtbl.find_opt by_base_path base_path with
+        | Some keepers -> keepers
+        | None ->
+          let keepers = Hashtbl.create 16 in
+          Hashtbl.add by_base_path base_path keepers;
+          keepers
+      in
+      Hashtbl.replace keepers keeper_name ())
+
+  let clear ~base_path ~keeper_name =
+    with_lock (fun () ->
+      match Hashtbl.find_opt by_base_path base_path with
+      | None -> ()
+      | Some keepers ->
+        Hashtbl.remove keepers keeper_name;
+        if Hashtbl.length keepers = 0
+        then Hashtbl.remove by_base_path base_path)
+
+  let take ~base_path ~keeper_name =
+    with_lock (fun () ->
+      match Hashtbl.find_opt by_base_path base_path with
+      | None -> false
+      | Some keepers ->
+        let waiting = Hashtbl.mem keepers keeper_name in
+        Hashtbl.remove keepers keeper_name;
+        if Hashtbl.length keepers = 0
+        then Hashtbl.remove by_base_path base_path;
+        waiting)
+
+  let clear_base_path base_path =
+    with_lock (fun () -> Hashtbl.remove by_base_path base_path)
+
+  let reset () = with_lock (fun () -> Hashtbl.clear by_base_path)
+end
+
+let notify_slot_transition ~base_path ~keeper_name =
+  if Preclaim_retry.take ~base_path ~keeper_name
+  then notify_transition ~keeper_name
+
 type turn_outcome =
   | Delivered of { outcome_ref : string }
   | Failed of
@@ -200,7 +251,10 @@ module For_testing = struct
   let finish_dispatching_and_reschedule = finish_dispatching_and_reschedule
   let notify_transition = notify_transition
   let take_wake_nonblocking = Wake_inbox.take_nonblocking
-  let reset_wake_inbox = Wake_inbox.reset
+  let reset_wake_inbox () =
+    Wake_inbox.reset ();
+    Preclaim_retry.reset ()
+
   let reset_persistence_blocked = Persistence_blocked.reset
 end
 
@@ -462,6 +516,7 @@ let run_observed_turn state ~sw ~clock ~handle_turn ~keeper_name observation =
     Keeper_chat_delivery_identity.Receipt_ids.singleton item.receipt_id
   in
   let claim = ref Claim_not_attempted in
+  Preclaim_retry.mark ~base_path:state.base_path ~keeper_name;
   let rec claim_observation ~may_retry observation =
     match Keeper_chat_queue.lease_observed observation with
     | `Leased lease -> Ok lease
@@ -493,6 +548,7 @@ let run_observed_turn state ~sw ~clock ~handle_turn ~keeper_name observation =
       Error (`Failed error)
   in
   let on_admitted () =
+    Preclaim_retry.clear ~base_path:state.base_path ~keeper_name;
     match !claim with
     | Claim_not_attempted ->
       (match claim_observation ~may_retry:true observation with
@@ -651,8 +707,10 @@ let run ~sw ~clock ~base_path ~handle_turn =
           (Keeper_chat_queue.mutation_error_to_string error);
         release keeper_name
       | Ok _ when retry_pending_finalization dispatch_state ~keeper_name ->
+        Preclaim_retry.clear ~base_path:dispatch_state.base_path ~keeper_name;
         release keeper_name
       | Ok (Awaiting_delivery_recovery evidence) ->
+        Preclaim_retry.clear ~base_path:dispatch_state.base_path ~keeper_name;
         Log.Keeper.warn
           "keeper_chat_consumer: lane awaits explicit delivery recovery keeper=%s receipt_id=%s lease_id=%s started_at=%.06f"
           keeper_name
@@ -661,6 +719,7 @@ let run ~sw ~clock ~base_path ~handle_turn =
           evidence.started_at;
         release keeper_name
       | Ok (Dispatchable { has_active = false; _ }) ->
+        Preclaim_retry.clear ~base_path:dispatch_state.base_path ~keeper_name;
         release keeper_name
       | Ok (Dispatchable { has_active = true }) ->
         (match Keeper_chat_queue.observe_pending ~keeper_name with
@@ -670,7 +729,9 @@ let run ~sw ~clock ~base_path ~handle_turn =
              keeper_name
              (Keeper_chat_queue.mutation_error_to_string error);
            release keeper_name
-         | Ok None -> release keeper_name
+         | Ok None ->
+           Preclaim_retry.clear ~base_path:dispatch_state.base_path ~keeper_name;
+           release keeper_name
          | Ok (Some observation) ->
            run_observed_turn
              dispatch_state
@@ -713,4 +774,8 @@ let run ~sw ~clock ~base_path ~handle_turn =
     Eio.Fiber.yield ();
     wake_loop ()
   in
-  wake_loop ()
+  Preclaim_retry.clear_base_path dispatch_state.base_path;
+  Fun.protect
+    ~finally:(fun () ->
+      Preclaim_retry.clear_base_path dispatch_state.base_path)
+    wake_loop

--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -70,7 +70,7 @@ type persistence_blocked_status =
   }
 
 type blocked_retry =
-  | Retry_pending_claim
+  | Retry_pending_claim of { blocked_revision : int64 }
   | Retry_finalization of
       { lease_id : string
       ; outcome : Keeper_chat_queue.finalization
@@ -101,7 +101,7 @@ module Persistence_blocked = struct
       let key = key ~base_path ~keeper_name in
       match Hashtbl.find_opt entries key with
       | Some { retry = Retry_finalization _; _ } -> ()
-      | Some { retry = Retry_pending_claim; _ } | None ->
+      | Some { retry = Retry_pending_claim _; _ } | None ->
         Hashtbl.replace entries key entry)
 
   let find ~base_path ~keeper_name =
@@ -133,8 +133,12 @@ type dispatch_state = {
 }
 
 type lane_activity =
-  | Dispatchable of bool
+  | Dispatchable of
+      { has_active : bool
+      ; revision : int64
+      }
   | Awaiting_delivery_recovery of Keeper_chat_queue.recovery_evidence
+  | Pending_claim_retry_blocked of int64
 
 let create_dispatch_state ~base_path =
   { base_path = Keeper_registry_types.canonical_base_path_exn base_path
@@ -183,7 +187,7 @@ let pending_finalization state keeper_name =
   with
   | Some { retry = Retry_finalization { lease_id; outcome }; _ } ->
     Some (lease_id, outcome)
-  | Some { retry = Retry_pending_claim; _ } | None -> None
+  | Some { retry = Retry_pending_claim _; _ } | None -> None
 
 let clear_pending_finalization state ~keeper_name ~lease_id =
   Persistence_blocked.clear_finalization
@@ -203,14 +207,27 @@ let remember_pending_finalization state ~keeper_name ~lease_id ~outcome ~error =
     ; retry = Retry_finalization { lease_id; outcome }
     }
 
-let remember_blocked_pending_claim state ~keeper_name ~error =
+let remember_blocked_pending_claim state ~keeper_name ~blocked_revision ~error =
   Persistence_blocked.remember_pending_claim
     ~base_path:state.base_path
     ~keeper_name
     { status =
         { operation = Pending_claim_blocked; lease_id = None; error }
-    ; retry = Retry_pending_claim
+    ; retry = Retry_pending_claim { blocked_revision }
     }
+
+let pending_claim_retry_blocked state ~keeper_name ~revision =
+  match
+    Persistence_blocked.find
+      ~base_path:state.base_path
+      ~keeper_name
+  with
+  | Some
+      { retry = Retry_pending_claim { blocked_revision }
+      ; _
+      } ->
+    Int64.equal blocked_revision revision
+  | Some { retry = Retry_finalization _; _ } | None -> false
 
 let clear_blocked_pending_claim state ~keeper_name =
   match
@@ -218,7 +235,7 @@ let clear_blocked_pending_claim state ~keeper_name =
       ~base_path:state.base_path
       ~keeper_name
   with
-  | Some { retry = Retry_pending_claim; _ } ->
+  | Some { retry = Retry_pending_claim _; _ } ->
     Persistence_blocked.clear
       ~base_path:state.base_path
       ~keeper_name
@@ -274,13 +291,17 @@ let reconcile_published_transition ~keeper_name error =
     Log.Keeper.info
       "keeper_chat_consumer: reconciled published queue transition keeper=%s revision=%Ld"
       keeper_name
-      report.revision
+      report.revision;
+    Some report.revision
   | Error reconciliation_error ->
     Log.Keeper.error
       "keeper_chat_consumer: published queue transition requires operator reconciliation keeper=%s publication_error=%s reconciliation_error=%s"
       keeper_name
       (Keeper_chat_queue.mutation_error_to_string error)
-      (Keeper_chat_queue.mutation_error_to_string reconciliation_error)
+      (Keeper_chat_queue.mutation_error_to_string reconciliation_error);
+    (match Keeper_chat_queue.lane_status ~keeper_name with
+     | Ok { revision; _ } -> Some revision
+     | Error _ -> None)
 
 let settle_lease state ~keeper_name ~lease_id outcome =
   let rec finalize ~allow_invalid_fallback outcome =
@@ -318,7 +339,8 @@ let settle_lease state ~keeper_name ~lease_id outcome =
         (Keeper_chat_queue.Persist_failed
            { publication = Finalize_indeterminate _; _ } as error) ->
       clear_pending_finalization state ~keeper_name ~lease_id;
-      reconcile_published_transition ~keeper_name error;
+      (match reconcile_published_transition ~keeper_name error with
+       | Some _ | None -> ());
       `Settled
     | `Error error ->
       remember_pending_finalization state ~keeper_name ~lease_id
@@ -460,21 +482,33 @@ let finalize_claimed_outcome state ~clock ~keeper_name ~lease_id = function
     finalize_or_warn state ~keeper_name ~lease_id
       (finalization_of_failed ~clock ~kind ~detail ~outcome_ref)
 
-let handle_claim_failure state ~keeper_name = function
+let handle_claim_failure state ~keeper_name ~observed_revision error =
+  let block_at blocked_revision =
+    remember_blocked_pending_claim state ~keeper_name ~blocked_revision ~error;
+    Log.Keeper.warn
+      "keeper_chat_consumer: admitted receipt claim failed for keeper=%s: %s; lane is persistence_blocked at revision=%Ld until a later durable queue revision"
+      keeper_name
+      (Keeper_chat_queue.mutation_error_to_string error)
+      blocked_revision
+  in
+  match error with
   | (Keeper_chat_queue.Persist_failed
        { publication = Lease_indeterminate _; _ }
     | Keeper_chat_queue.Snapshot_unavailable
-        { kind = Durability_uncertain; _ }) as error ->
-    reconcile_published_transition ~keeper_name error
-  | error ->
-    remember_blocked_pending_claim state ~keeper_name ~error;
-    Log.Keeper.warn
-      "keeper_chat_consumer: admitted receipt claim failed for keeper=%s: %s; lane is persistence_blocked until explicit operator reconciliation or another durable transition"
-      keeper_name
-      (Keeper_chat_queue.mutation_error_to_string error)
+        { kind = Durability_uncertain; _ }) ->
+    let blocked_revision =
+      Option.value
+        (reconcile_published_transition ~keeper_name error)
+        ~default:observed_revision
+    in
+    block_at blocked_revision
+  | _ -> block_at observed_revision
 
 let run_observed_turn state ~sw ~clock ~handle_turn ~keeper_name observation =
   let item = Keeper_chat_queue.pending_observation_item observation in
+  let observed_revision =
+    Keeper_chat_queue.pending_observation_revision observation
+  in
   let receipt_ids =
     Keeper_chat_delivery_identity.Receipt_ids.singleton item.receipt_id
   in
@@ -543,7 +577,8 @@ let run_observed_turn state ~sw ~clock ~handle_turn ~keeper_name observation =
       keeper_name
       (Keeper_chat_queue.Receipt_id.to_string item.receipt_id);
     notify_transition ~keeper_name
-  | Claim_failed error, _ -> handle_claim_failure state ~keeper_name error
+  | Claim_failed error, _ ->
+    handle_claim_failure state ~keeper_name ~observed_revision error
 
 let run ~sw ~clock ~base_path ~handle_turn =
   let dispatch_state = create_dispatch_state ~base_path in
@@ -556,8 +591,12 @@ let run ~sw ~clock ~base_path ~handle_turn =
   let ready_lane_activity keeper_name =
     match Keeper_chat_queue.lane_status ~keeper_name with
     | Error _ as error -> error
-    | Ok { health = Keeper_chat_queue.Ready; has_active; _ } ->
-      Ok (Dispatchable has_active)
+    | Ok { revision; _ }
+      when pending_claim_retry_blocked
+             dispatch_state ~keeper_name ~revision ->
+      Ok (Pending_claim_retry_blocked revision)
+    | Ok { health = Keeper_chat_queue.Ready; has_active; revision } ->
+      Ok (Dispatchable { has_active; revision })
     | Ok
         { health =
             Keeper_chat_queue.Delivery_recovery_required
@@ -585,8 +624,12 @@ let run ~sw ~clock ~base_path ~handle_turn =
            report.revision;
          (match Keeper_chat_queue.lane_status ~keeper_name with
           | Error _ as error -> error
-          | Ok { health = Keeper_chat_queue.Ready; has_active; _ } ->
-            Ok (Dispatchable has_active)
+          | Ok { revision; _ }
+            when pending_claim_retry_blocked
+                   dispatch_state ~keeper_name ~revision ->
+            Ok (Pending_claim_retry_blocked revision)
+          | Ok { health = Keeper_chat_queue.Ready; has_active; revision } ->
+            Ok (Dispatchable { has_active; revision })
           | Ok
               { health =
                   Keeper_chat_queue.Delivery_recovery_required
@@ -617,11 +660,12 @@ let run ~sw ~clock ~base_path ~handle_turn =
     try
       match ready_lane_activity keeper_name with
       | Error error ->
-        remember_blocked_pending_claim dispatch_state ~keeper_name ~error;
         Log.Keeper.error
-          "keeper_chat_consumer: lane state unavailable keeper=%s error=%s; lane is persistence_blocked until explicit operator reconciliation or another durable transition"
+          "keeper_chat_consumer: lane state unavailable keeper=%s error=%s; inspection is deferred until a later transition"
           keeper_name
           (Keeper_chat_queue.mutation_error_to_string error);
+        release keeper_name
+      | Ok (Pending_claim_retry_blocked _) ->
         release keeper_name
       | Ok _ when retry_pending_finalization dispatch_state ~keeper_name ->
         release keeper_name
@@ -634,18 +678,20 @@ let run ~sw ~clock ~base_path ~handle_turn =
           evidence.lease_id
           evidence.started_at;
         release keeper_name
-      | Ok (Dispatchable false) ->
+      | Ok (Dispatchable { has_active = false; _ }) ->
         clear_blocked_pending_claim dispatch_state ~keeper_name;
         release keeper_name
-      | Ok (Dispatchable true) ->
+      | Ok (Dispatchable { has_active = true; revision }) ->
         clear_blocked_pending_claim dispatch_state ~keeper_name;
         (match Keeper_chat_queue.observe_pending ~keeper_name with
          | Error error ->
-           remember_blocked_pending_claim dispatch_state ~keeper_name ~error;
+           remember_blocked_pending_claim dispatch_state ~keeper_name
+             ~blocked_revision:revision ~error;
            Log.Keeper.warn
-             "keeper_chat_consumer: pending head observation failed for keeper=%s: %s; lane is persistence_blocked until explicit operator reconciliation or another durable transition"
+             "keeper_chat_consumer: pending head observation failed for keeper=%s: %s; lane is persistence_blocked at revision=%Ld until a later durable queue revision"
              keeper_name
-             (Keeper_chat_queue.mutation_error_to_string error);
+             (Keeper_chat_queue.mutation_error_to_string error)
+             revision;
            release keeper_name
          | Ok None -> release keeper_name
          | Ok (Some observation) ->

--- a/lib/keeper/keeper_chat_consumer.mli
+++ b/lib/keeper/keeper_chat_consumer.mli
@@ -15,14 +15,6 @@
     running schedules exactly one follow-up inspection. *)
 val notify_transition : keeper_name:string -> unit
 
-(** Clear a pending-claim retry block for the exact BasePath/Keeper lane and
-    wake it once. Queue transition observers must use {!notify_transition};
-    this authority is only for an explicit non-queue state change such as a
-    shutdown rollback or operator retry. Finalization retry state is preserved
-    and consumes the wake through its own exact decision. *)
-val notify_explicit_retry :
-  base_path:string -> keeper_name:string -> (unit, string) result
-
 type persistence_blocked_operation =
   | Pending_claim_blocked
   | Finalize_blocked
@@ -33,9 +25,10 @@ type persistence_blocked_status =
   ; error : Keeper_chat_queue.mutation_error
   }
 
-(** Observe the exact Keeper-local queue mutation that is waiting for an
-    explicit retry trigger. This is operational state, not a retry timer or an
-    admission constraint. *)
+(** Observe the exact Keeper-local queue mutation that is blocked. A
+    pending-claim block is retried only after the durable queue revision
+    advances; this is operational state, not a retry timer or admission
+    constraint. *)
 val persistence_blocked_status :
   base_path:string ->
   keeper_name:string ->

--- a/lib/keeper/keeper_chat_consumer.mli
+++ b/lib/keeper/keeper_chat_consumer.mli
@@ -16,7 +16,7 @@
 val notify_transition : keeper_name:string -> unit
 
 type persistence_blocked_operation =
-  | Lease_next_blocked
+  | Pending_claim_blocked
   | Finalize_blocked
   | Nack_blocked
 
@@ -58,27 +58,33 @@ type turn_outcome =
     release, and explicit operator reconciliation; it performs no fleet-wide
     timer polling.
 
-    Per Keeper wake: when a turn is in flight
-    ([Keeper_turn_admission.in_flight]), queued messages are left to
-    accumulate; once the slot is free, the exact FIFO head receipt is leased
-    ([Keeper_chat_queue.lease_next]) into one typed turn. User-message identity,
-    multimodal blocks, transcript provenance, and receipt correlation are never
-    flattened into a delimiter string. The turn then runs in a Keeper-scoped child fiber, so a slow queued turn for one
-    keeper does not block wake processing or delivery for other keepers.  A
-    keeper-local dispatch gate preserves the single follow-up turn contract
+    Per Keeper wake, the exact FIFO head is observed without changing its
+    durable [Pending] state. [handle_turn] parks on the Keeper turn mutex, then
+    invokes its [on_admitted] callback at the existing execution
+    linearization point. That callback atomically leases only the observed
+    receipt when it is still the FIFO head. Thus a chat waiting behind an
+    autonomous turn is visible to the mutex while remaining restart-safe
+    [Pending].
+
+    User-message identity, multimodal blocks, transcript provenance, and
+    receipt correlation are never flattened into a delimiter string. The turn
+    runs in a Keeper-scoped child fiber, so a slow queued turn for one keeper
+    does not block wake processing or delivery for other keepers. A
+    keeper-local wake coalescer preserves the single follow-up turn contract
     for messages sent during an existing queued turn.
 
     [handle_turn]'s typed terminal outcome is durably finalized as [Delivered]
-    or [Failed]. [Deferred] and structured cancellation nack the unchanged
-    receipt back to [Pending]; [Deferred] is reserved for a typed admission
-    rejection such as an active shutdown fence, so the same accepted receipt is
-    retried after the lane reopens. A lease found after process restart is
-    [Recovery_required] and is never automatically dispatched: an operator must
-    explicitly requeue or cancel its exact receipt/revision/lease evidence. An
-    unexpected handler exception becomes a durable [Internal_error] failure
-    instead of a poison-message retry loop. There is deliberately no second
-    wall-clock watchdog: the turn runtime owns timeout/cancellation and must
-    return the typed outcome.
+    or [Failed]. [Deferred] before the exact claim leaves the receipt unchanged
+    [Pending]; cancellation before the claim does the same, while cancellation
+    after a committed claim nacks that lease back to [Pending]. [Deferred] is
+    reserved for a typed admission rejection such as an active shutdown fence,
+    so the same accepted receipt is retried after the lane reopens. A lease
+    found after process restart is [Recovery_required] and is never
+    automatically dispatched: an operator must explicitly requeue or cancel
+    its exact receipt/revision/lease evidence. An unexpected handler exception
+    becomes a durable [Internal_error] failure instead of a poison-message
+    retry loop. There is deliberately no second wall-clock watchdog: the turn
+    runtime owns timeout/cancellation and must return the typed outcome.
 
     If finalization persistence fails before publication, the exact decision is
     retained and retried before another turn starts after the next durable
@@ -89,14 +95,16 @@ type turn_outcome =
 
     The call runs until [sw] is released.
 
-    [handle_turn] is responsible for creating an event stream,
-    spawning the appropriate delivery adapter, and calling
-    [process_single_turn].  See RFC-0217 §Phase 3. *)
+    [handle_turn] is responsible for creating an event stream, composing the
+    supplied queue-claim [on_admitted] callback with its transcript admission
+    work, and calling [process_single_turn]. It must invoke [on_admitted]
+    exactly once after acquiring the turn slot and before any provider or
+    connector effect. See RFC-0217 §Phase 3. *)
 val run :
   sw:Eio.Switch.t ->
   clock:_ Eio.Time.clock ->
   base_path:string ->
-  handle_turn:(sw:Eio.Switch.t -> keeper_name:string -> delivery_key:Keeper_chat_delivery_identity.delivery_key -> queued_message:Keeper_chat_queue.queued_message -> turn_outcome) ->
+  handle_turn:(sw:Eio.Switch.t -> keeper_name:string -> receipt_ids:Keeper_chat_delivery_identity.Receipt_ids.t -> queued_message:Keeper_chat_queue.queued_message -> on_admitted:(unit -> (unit, string) result) -> turn_outcome) ->
   unit
 
 module For_testing : sig

--- a/lib/keeper/keeper_chat_consumer.mli
+++ b/lib/keeper/keeper_chat_consumer.mli
@@ -9,10 +9,10 @@
 
     @since 2.145.0 *)
 
-(** Wake one Keeper lane after a durable queue mutation, admission release, or
-    explicit operator reconciliation. Repeated pending wakes for the same
-    Keeper are coalesced without a capacity limit; a wake observed while that
-    Keeper is running schedules exactly one follow-up inspection. *)
+(** Wake one Keeper lane after a durable queue mutation, shutdown rollback, or
+    explicit operator action. Repeated pending wakes for the same Keeper are
+    coalesced without a capacity limit; a wake observed while that Keeper is
+    running schedules exactly one follow-up inspection. *)
 val notify_transition : keeper_name:string -> unit
 
 type persistence_blocked_operation =
@@ -86,6 +86,11 @@ type turn_outcome =
     [Internal_error] failure instead of a poison-message retry loop. There is
     deliberately no second wall-clock watchdog: the turn runtime owns
     timeout/cancellation and must return the typed outcome.
+
+    If a Pending claim cannot be published, the consumer reconciles at most
+    once and parks that lane at the resulting durable queue revision. Internal
+    invalidations for the same revision are absorbed; a later durable queue
+    revision re-arms the still-Pending receipt.
 
     If finalization persistence fails before publication, the exact decision is
     retained and retried before another turn starts after the next durable

--- a/lib/keeper/keeper_chat_consumer.mli
+++ b/lib/keeper/keeper_chat_consumer.mli
@@ -15,20 +15,14 @@
     running schedules exactly one follow-up inspection. *)
 val notify_transition : keeper_name:string -> unit
 
-type persistence_blocked_operation =
-  | Pending_claim_blocked
-  | Finalize_blocked
-
 type persistence_blocked_status =
-  { operation : persistence_blocked_operation
-  ; lease_id : string option
+  { lease_id : string
   ; error : Keeper_chat_queue.mutation_error
   }
 
-(** Observe the exact Keeper-local queue mutation that is blocked. A
-    pending-claim block is retried only after the durable queue revision
-    advances; this is operational state, not a retry timer or admission
-    constraint. *)
+(** Observe an exact terminal decision whose durable finalization is blocked.
+    Receipt claims are reconciled and retried inside their already-admitted
+    turn; they do not create process-wide blocked state. *)
 val persistence_blocked_status :
   base_path:string ->
   keeper_name:string ->
@@ -88,10 +82,10 @@ type turn_outcome =
     deliberately no second wall-clock watchdog: the turn runtime owns
     timeout/cancellation and must return the typed outcome.
 
-    If a Pending claim cannot be published, the consumer reconciles at most
-    once and parks that lane at the resulting durable queue revision. Internal
-    invalidations for the same revision are absorbed; a later durable queue
-    revision re-arms the still-Pending receipt.
+    If a Pending claim cannot be published, the consumer reconciles once and
+    retries the exact FIFO head once while it still owns the Keeper turn. A
+    second persistence failure leaves the receipt [Pending] for the next
+    explicit lane transition; no durable-revision gate survives the turn.
 
     If finalization persistence fails before publication, the exact decision is
     retained and retried before another turn starts after the next durable

--- a/lib/keeper/keeper_chat_consumer.mli
+++ b/lib/keeper/keeper_chat_consumer.mli
@@ -15,6 +15,13 @@
     running schedules exactly one follow-up inspection. *)
 val notify_transition : keeper_name:string -> unit
 
+(** Wake a Pending receipt after a turn-slot release or shutdown rollback only
+    when its current consumer attempt ended before invoking the exact claim
+    callback. The registration is one-shot and is cleared before every claim,
+    so a claim persistence failure cannot re-arm itself through its own slot
+    release. *)
+val notify_slot_transition : base_path:string -> keeper_name:string -> unit
+
 type persistence_blocked_status =
   { lease_id : string
   ; error : Keeper_chat_queue.mutation_error

--- a/lib/keeper/keeper_chat_consumer.mli
+++ b/lib/keeper/keeper_chat_consumer.mli
@@ -53,9 +53,9 @@ type turn_outcome =
     boundary instead of escaping through an unobserved child fiber.
 
     Startup performs one inventory of restored queue lanes. Thereafter the
-    consumer is driven only by durable queue transitions, Keeper admission
-    release, and explicit operator reconciliation; it performs no fleet-wide
-    timer polling.
+    consumer is driven only by durable queue transitions, direct Keeper mutex
+    handoff, shutdown rollback, and explicit operator reconciliation; it
+    performs no fleet-wide timer polling.
 
     Per Keeper wake, the exact FIFO head is observed without changing its
     durable [Pending] state. [handle_turn] parks on the Keeper turn mutex, then

--- a/lib/keeper/keeper_chat_consumer.mli
+++ b/lib/keeper/keeper_chat_consumer.mli
@@ -18,7 +18,6 @@ val notify_transition : keeper_name:string -> unit
 type persistence_blocked_operation =
   | Pending_claim_blocked
   | Finalize_blocked
-  | Nack_blocked
 
 type persistence_blocked_status =
   { operation : persistence_blocked_operation
@@ -75,16 +74,18 @@ type turn_outcome =
 
     [handle_turn]'s typed terminal outcome is durably finalized as [Delivered]
     or [Failed]. [Deferred] before the exact claim leaves the receipt unchanged
-    [Pending]; cancellation before the claim does the same, while cancellation
-    after a committed claim nacks that lease back to [Pending]. [Deferred] is
-    reserved for a typed admission rejection such as an active shutdown fence,
-    so the same accepted receipt is retried after the lane reopens. A lease
-    found after process restart is [Recovery_required] and is never
-    automatically dispatched: an operator must explicitly requeue or cancel
-    its exact receipt/revision/lease evidence. An unexpected handler exception
-    becomes a durable [Internal_error] failure instead of a poison-message
-    retry loop. There is deliberately no second wall-clock watchdog: the turn
-    runtime owns timeout/cancellation and must return the typed outcome.
+    [Pending]; cancellation before the claim does the same. Cancellation after
+    a committed claim terminalizes the receipt as [Cancelled], because a
+    provider or tool effect may already have occurred and automatic redelivery
+    could duplicate it. [Deferred] is reserved for a typed admission rejection
+    such as an active shutdown fence, so the same accepted receipt is retried
+    after the lane reopens. A lease found after process restart is
+    [Recovery_required] and is never automatically dispatched: an operator
+    must explicitly requeue or cancel its exact receipt/revision/lease
+    evidence. An unexpected handler exception becomes a durable
+    [Internal_error] failure instead of a poison-message retry loop. There is
+    deliberately no second wall-clock watchdog: the turn runtime owns
+    timeout/cancellation and must return the typed outcome.
 
     If finalization persistence fails before publication, the exact decision is
     retained and retried before another turn starts after the next durable

--- a/lib/keeper/keeper_chat_consumer.mli
+++ b/lib/keeper/keeper_chat_consumer.mli
@@ -15,6 +15,14 @@
     running schedules exactly one follow-up inspection. *)
 val notify_transition : keeper_name:string -> unit
 
+(** Clear a pending-claim retry block for the exact BasePath/Keeper lane and
+    wake it once. Queue transition observers must use {!notify_transition};
+    this authority is only for an explicit non-queue state change such as a
+    shutdown rollback or operator retry. Finalization retry state is preserved
+    and consumes the wake through its own exact decision. *)
+val notify_explicit_retry :
+  base_path:string -> keeper_name:string -> (unit, string) result
+
 type persistence_blocked_operation =
   | Pending_claim_blocked
   | Finalize_blocked

--- a/lib/keeper/keeper_chat_consumer.mli
+++ b/lib/keeper/keeper_chat_consumer.mli
@@ -16,10 +16,11 @@
 val notify_transition : keeper_name:string -> unit
 
 (** Wake a Pending receipt after a turn-slot release or shutdown rollback only
-    when its current consumer attempt ended before invoking the exact claim
-    callback. The registration is one-shot and is cleared before every claim,
-    so a claim persistence failure cannot re-arm itself through its own slot
-    release. *)
+    when its current consumer attempt ends before invoking the exact claim
+    callback. A release observed while the attempt is still running is recorded
+    but not enqueued until that pre-claim outcome is known. The registration is
+    one-shot and is cleared before every claim, so neither the handoff release
+    nor a failed claim's own release can re-arm that claim. *)
 val notify_slot_transition : base_path:string -> keeper_name:string -> unit
 
 type persistence_blocked_status =

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -60,6 +60,18 @@ type lease = {
   item : leased_message;
 }
 
+type pending_observation =
+  { keeper_name : string
+  ; revision : int64
+  ; item : leased_message
+  }
+
+type pending_claim_stale =
+  { receipt_id : Receipt_id.t
+  ; expected_revision : int64
+  ; observed_revision : int64
+  }
+
 type recovery_evidence = {
   receipt_id : Receipt_id.t;
   lease_id : string;
@@ -2561,116 +2573,138 @@ let enqueue ~keeper_name message =
 
 let lease_id () = Random_id.prefixed ~prefix:"lease_" ~bytes:16
 
-let lease_next ~keeper_name =
+let lease_pending_row ~base_path ~path entry row =
+  match row.receipt.state with
+  | Stored_pending message ->
+    let lease_id = lease_id () in
+    let target_row =
+      { row with
+        receipt =
+          { row.receipt with
+            state =
+              Stored_inflight
+                { lease_id
+                ; started_at = Time_compat.now ()
+                ; message
+                }
+          }
+      }
+    in
+    (match
+       make_plan entry
+         ~before_row:(Some row)
+         ~target_row:(Some target_row)
+         ~target_next_sequence:entry.next_sequence
+         ~target_terminal_count:entry.terminal_count
+         ~transition:
+           (Lease_transition { receipt_id = row.receipt.receipt_id; lease_id })
+     with
+     | Error error -> `Error error
+     | Ok plan ->
+       let execution =
+         run_transaction
+           ~ownership_root:base_path
+           ~path
+           ~create_if_missing:false
+           plan
+       in
+       (match apply_transaction_result ~path entry plan execution with
+        | Error error -> `Error error
+        | Ok revision ->
+          `Leased
+            ( { lease_id
+              ; item = { receipt_id = row.receipt.receipt_id; message }
+              }
+            , revision )))
+  | Stored_inflight _
+  | Stored_recovery_required _
+  | Stored_delivered _
+  | Stored_failed _ ->
+    `Error
+      (Snapshot_unavailable
+         (load_error Parse_failed ~path
+            "pending FIFO index contains a non-pending receipt"))
+
+let observe_pending ~keeper_name =
+  match mutation_context ~keeper_name ~create:false with
+  | Error _ as error -> error
+  | Ok (_, _, None) -> Ok None
+  | Ok (_, _, Some entry) ->
+    with_entry_lock keeper_name entry (fun () ->
+        match first_blocking_error entry with
+        | Some error -> Error (Snapshot_unavailable error)
+        | None ->
+          (match entry.recovery_required, entry.inflight with
+           | Some _, _ | _, Some _ -> Ok None
+           | None, None ->
+             (match Sequence_map.min_binding_opt entry.pending with
+              | None -> Ok None
+              | Some (_, row) ->
+                (match row.receipt.state with
+                 | Stored_pending message ->
+                   Ok
+                     (Some
+                        { keeper_name
+                        ; revision = entry.revision
+                        ; item = { receipt_id = row.receipt.receipt_id; message }
+                        })
+                 | Stored_inflight _
+                 | Stored_recovery_required _
+                 | Stored_delivered _
+                 | Stored_failed _ ->
+                   Error
+                     (Snapshot_unavailable
+                        (load_error Parse_failed
+                           "pending FIFO index contains a non-pending receipt"))))))
+
+let pending_observation_item observation = observation.item
+
+let stale_pending_claim observation observed_revision =
+  `Stale
+    { receipt_id = observation.item.receipt_id
+    ; expected_revision = observation.revision
+    ; observed_revision
+    }
+
+let lease_observed observation =
+  let keeper_name = observation.keeper_name in
   match mutation_context ~keeper_name ~create:false with
   | Error error -> `Error error
-  | Ok (_, _, None) -> `Empty
+  | Ok (_, _, None) -> stale_pending_claim observation 0L
   | Ok (base_path, path, Some entry) ->
     let result =
       with_entry_lock keeper_name entry (fun () ->
-          match
-            check_entry_store ~base_path ~path entry
-              ~allow_absent:false
-          with
+          match check_entry_store ~base_path ~path entry ~allow_absent:false with
           | Error error -> `Error error
           | Ok Store_absent ->
             `Error
               (Snapshot_unavailable
                  (load_error Read_failed ~path
-                    "chat queue database is absent during lease"))
+                    "chat queue database is absent during observed lease"))
           | Ok Store_present ->
             (match entry.recovery_required, entry.inflight with
-             | ( Some
-                   { receipt =
-                       { receipt_id
-                       ; state =
-                           Stored_recovery_required
-                             { lease_id; started_at; _ }
-                       }
-                   ; _
-                   }
-               , None ) ->
-               `Recovery_required
-                 ({ receipt_id; lease_id; started_at } : recovery_evidence)
-             | Some _, _ ->
-               `Error
-                 (Snapshot_unavailable
-                    (load_error Parse_failed ~path
-                       "in-memory recovery index contains an invalid active lease"))
-             | None, Some { receipt = { state = Stored_inflight { lease_id; _ }; _ }; _ } ->
-               `Already_leased lease_id
-             | None, Some _ ->
-               `Error
-                 (Snapshot_unavailable
-                    (load_error Parse_failed ~path
-                       "in-memory inflight index contains a non-inflight receipt"))
+             | Some _, _ | _, Some _ ->
+               stale_pending_claim observation entry.revision
              | None, None ->
                (match Sequence_map.min_binding_opt entry.pending with
-                | None -> `Empty
+                | None -> stale_pending_claim observation entry.revision
                 | Some (_, row) ->
-                  (match row.receipt.state with
-                   | Stored_pending message ->
-                     let lease_id = lease_id () in
-                     let target_row =
-                       { row with
-                         receipt =
-                           { row.receipt with
-                             state =
-                               Stored_inflight
-                                 { lease_id
-                                 ; started_at = Time_compat.now ()
-                                 ; message
-                                 }
-                           }
-                       }
-                     in
-                     (match
-                        make_plan entry
-                          ~before_row:(Some row)
-                          ~target_row:(Some target_row)
-                          ~target_next_sequence:entry.next_sequence
-                          ~target_terminal_count:entry.terminal_count
-                          ~transition:
-                            (Lease_transition
-                               { receipt_id = row.receipt.receipt_id; lease_id })
-                      with
-                      | Error error -> `Error error
-                      | Ok plan ->
-                        let execution =
-                          run_transaction
-                            ~ownership_root:base_path
-                            ~path
-                            ~create_if_missing:false
-                            plan
-                        in
-                        (match apply_transaction_result ~path entry plan execution with
-                         | Error error -> `Error error
-                         | Ok revision ->
-                           `Leased
-                             ( { lease_id
-                               ; item =
-                                   { receipt_id = row.receipt.receipt_id; message }
-                               }
-                             , revision )))
-                   | Stored_inflight _
-                   | Stored_recovery_required _
-                   | Stored_delivered _
-                   | Stored_failed _ ->
-                     `Error
-                       (Snapshot_unavailable
-                          (load_error Parse_failed ~path
-                             "pending FIFO index contains a non-pending receipt"))))))
+                  if
+                    not
+                      (Receipt_id.equal
+                         row.receipt.receipt_id
+                         observation.item.receipt_id)
+                  then stale_pending_claim observation entry.revision
+                  else lease_pending_row ~base_path ~path entry row)))
     in
     (match result with
      | `Leased (lease, revision) ->
        notify_transition ~keeper_name ~revision;
        `Leased lease
+     | `Stale _ as stale -> stale
      | `Error error ->
        notify_indeterminate ~keeper_name (Error error);
-       `Error error
-     | `Empty -> `Empty
-     | `Already_leased lease_id -> `Already_leased lease_id
-     | `Recovery_required evidence -> `Recovery_required evidence)
+       `Error error)
 
 let canonical_optional_ref = function
   | None -> Ok None

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -2645,8 +2645,6 @@ let observe_pending ~keeper_name =
                            "pending FIFO index contains a non-pending receipt"))))))
 
 let pending_observation_item observation = observation.item
-let pending_observation_revision (observation : pending_observation) =
-  observation.revision
 
 let stale_pending_claim observation observed_revision =
   `Stale
@@ -2691,9 +2689,7 @@ let lease_observed observation =
        notify_transition ~keeper_name ~revision;
        `Leased lease
      | `Stale _ as stale -> stale
-     | `Error error ->
-       notify_indeterminate ~keeper_name (Error error);
-       `Error error)
+     | `Error error -> `Error error)
 
 let canonical_optional_ref = function
   | None -> Ok None
@@ -3339,14 +3335,7 @@ let reconcile_persistence ~keeper_name =
                        mark_reconciliation_conflict entry ~path
                          "chat queue database matches neither side of the quarantined transaction"))))
       in
-      (match result with
-       | Ok ({ outcome = Reconciled; revision } as report) ->
-         notify_transition ~keeper_name ~revision;
-         Ok report
-       | Ok { outcome = Already_consistent; _ } as result -> result
-       | Error _ as error ->
-         notify_indeterminate ~keeper_name error;
-         error)
+      result
 
 type recovery_cancellation =
   { cancelled_at : float

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -2645,6 +2645,7 @@ let observe_pending ~keeper_name =
                            "pending FIFO index contains a non-pending receipt"))))))
 
 let pending_observation_item observation = observation.item
+let pending_observation_revision observation = observation.revision
 
 let stale_pending_claim observation observed_revision =
   `Stale

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -2645,7 +2645,8 @@ let observe_pending ~keeper_name =
                            "pending FIFO index contains a non-pending receipt"))))))
 
 let pending_observation_item observation = observation.item
-let pending_observation_revision observation = observation.revision
+let pending_observation_revision (observation : pending_observation) =
+  observation.revision
 
 let stale_pending_claim observation observed_revision =
   `Stale

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -113,11 +113,6 @@ type persistence_publication =
       ; receipt_id : Receipt_id.t
       ; lease_id : string
       }
-  | Nack_indeterminate of
-      { revision : int64
-      ; receipt_id : Receipt_id.t
-      ; lease_id : string
-      }
   | Startup_recovery_indeterminate of
       { revision : int64
       ; receipt_id : Receipt_id.t
@@ -185,7 +180,6 @@ type persistence_transition =
   | Enqueue_transition of { receipt_id : Receipt_id.t }
   | Lease_transition of { receipt_id : Receipt_id.t; lease_id : string }
   | Finalize_transition of { receipt_id : Receipt_id.t; lease_id : string }
-  | Nack_transition of { receipt_id : Receipt_id.t; lease_id : string }
   | Startup_recovery_transition of
       { receipt_id : Receipt_id.t
       ; lease_id : string
@@ -204,7 +198,6 @@ let persistence_transition_to_string = function
   | Enqueue_transition _ -> "enqueue"
   | Lease_transition _ -> "lease"
   | Finalize_transition _ -> "finalize"
-  | Nack_transition _ -> "nack"
   | Startup_recovery_transition _ -> "startup_recovery"
   | Recovery_requeue_transition _ -> "recovery_requeue"
   | Recovery_cancel_transition _ -> "recovery_cancel"
@@ -214,7 +207,6 @@ let transition_receipt_id = function
   | Enqueue_transition { receipt_id }
   | Lease_transition { receipt_id; _ }
   | Finalize_transition { receipt_id; _ }
-  | Nack_transition { receipt_id; _ }
   | Startup_recovery_transition { receipt_id; _ }
   | Recovery_requeue_transition { receipt_id; _ }
   | Recovery_cancel_transition { receipt_id; _ }
@@ -225,7 +217,6 @@ let publication_transition = function
   | Enqueue_indeterminate _ -> Some "enqueue"
   | Lease_indeterminate _ -> Some "lease"
   | Finalize_indeterminate _ -> Some "finalize"
-  | Nack_indeterminate _ -> Some "nack"
   | Startup_recovery_indeterminate _ -> Some "startup_recovery"
   | Recovery_requeue_indeterminate _ -> Some "recovery_requeue"
   | Recovery_cancel_indeterminate _ -> Some "recovery_cancel"
@@ -236,7 +227,6 @@ let publication_evidence = function
   | Enqueue_indeterminate { revision; receipt_id }
   | Lease_indeterminate { revision; receipt_id; _ }
   | Finalize_indeterminate { revision; receipt_id; _ }
-  | Nack_indeterminate { revision; receipt_id; _ }
   | Startup_recovery_indeterminate { revision; receipt_id; _ }
   | Recovery_requeue_indeterminate { revision; receipt_id; _ }
   | Recovery_cancel_indeterminate { revision; receipt_id; _ }
@@ -246,7 +236,6 @@ let publication_evidence = function
 let publication_lease_id = function
   | Lease_indeterminate { lease_id; _ }
   | Finalize_indeterminate { lease_id; _ }
-  | Nack_indeterminate { lease_id; _ }
   | Startup_recovery_indeterminate { lease_id; _ }
   | Recovery_requeue_indeterminate { lease_id; _ }
   | Recovery_cancel_indeterminate { lease_id; _ } -> Some lease_id
@@ -2045,8 +2034,6 @@ let indeterminate_publication revision = function
     Lease_indeterminate { revision; receipt_id; lease_id }
   | Finalize_transition { receipt_id; lease_id } ->
     Finalize_indeterminate { revision; receipt_id; lease_id }
-  | Nack_transition { receipt_id; lease_id } ->
-    Nack_indeterminate { revision; receipt_id; lease_id }
   | Startup_recovery_transition { receipt_id; lease_id } ->
     Startup_recovery_indeterminate { revision; receipt_id; lease_id }
   | Recovery_requeue_transition { receipt_id; lease_id } ->
@@ -2804,70 +2791,6 @@ let finalize ~keeper_name ~lease_id ~outcome =
           `Error error
         | `Unknown_lease -> `Unknown_lease))
 
-let nack ~keeper_name ~lease_id =
-  match mutation_context ~keeper_name ~create:false with
-  | Error error -> `Error error
-  | Ok (_, _, None) -> `Unknown_lease
-  | Ok (base_path, path, Some entry) ->
-    let result =
-      with_entry_lock keeper_name entry (fun () ->
-          match
-            check_entry_store ~base_path ~path entry
-              ~allow_absent:false
-          with
-          | Error error -> `Error error
-          | Ok Store_absent ->
-            `Error
-              (Snapshot_unavailable
-                 (load_error Read_failed ~path
-                    "chat queue database is absent during nack"))
-          | Ok Store_present ->
-            (match entry.inflight with
-             | Some
-                 ({ receipt =
-                      { receipt_id
-                      ; state = Stored_inflight current
-                      }
-                  ; _
-                  } as row)
-               when String.equal current.lease_id lease_id ->
-               let target_row =
-                 { row with
-                   receipt =
-                     { receipt_id; state = Stored_pending current.message }
-                 }
-               in
-               (match
-                  make_plan entry
-                    ~before_row:(Some row)
-                    ~target_row:(Some target_row)
-                    ~target_next_sequence:entry.next_sequence
-                    ~target_terminal_count:entry.terminal_count
-                    ~transition:(Nack_transition { receipt_id; lease_id })
-                with
-                | Error error -> `Error error
-                | Ok plan ->
-                  let execution =
-                    run_transaction
-                      ~ownership_root:base_path
-                      ~path
-                      ~create_if_missing:false
-                      plan
-                  in
-                  (match apply_transaction_result ~path entry plan execution with
-                   | Ok revision -> `Requeued (receipt_id, revision)
-                   | Error error -> `Error error))
-             | None | Some _ -> `Unknown_lease))
-    in
-    (match result with
-     | `Requeued (receipt_id, revision) ->
-       notify_transition ~keeper_name ~revision;
-       `Requeued receipt_id
-     | `Error error ->
-       notify_indeterminate ~keeper_name (Error error);
-       `Error error
-     | `Unknown_lease -> `Unknown_lease)
-
 let has_active_receipts ~keeper_name =
   match mutation_context ~keeper_name ~create:false with
   | Error _ as error -> error
@@ -3283,7 +3206,7 @@ let compensate_uncertain_lease entry plan =
       ; before_row = plan.target_row
       ; target_row = Some target_row
       ; transition =
-          Nack_transition
+          Recovery_requeue_transition
             { receipt_id; lease_id = inflight.lease_id }
       }
   | None
@@ -3383,7 +3306,6 @@ let reconcile_persistence ~keeper_name =
                            | Error _ as error -> error))
                      | ( Enqueue_transition _
                        | Finalize_transition _
-                       | Nack_transition _
                        | Startup_recovery_transition _
                        | Recovery_requeue_transition _
                        | Recovery_cancel_transition _
@@ -3394,7 +3316,6 @@ let reconcile_persistence ~keeper_name =
                        Ok { outcome = Reconciled; revision = plan.target_revision }
                      | ( Enqueue_transition _
                        | Finalize_transition _
-                       | Nack_transition _
                        | Startup_recovery_transition _
                        | Recovery_requeue_transition _
                        | Recovery_cancel_transition _

--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -76,6 +76,18 @@ type lease = {
   item : leased_message;
 }
 
+type pending_observation
+(** Immutable observation of the exact FIFO head while it is still [Pending].
+    It carries the queue revision internally for stale-claim diagnostics.
+    [lease_observed] claims only the receipt and payload selected before turn
+    admission. *)
+
+type pending_claim_stale =
+  { receipt_id : Receipt_id.t
+  ; expected_revision : int64
+  ; observed_revision : int64
+  }
+
 type recovery_evidence = {
   receipt_id : Receipt_id.t;
   lease_id : string;
@@ -253,14 +265,25 @@ val enqueue_with_receipt :
     An existing terminal receipt returns [Receipt_already_terminal]; terminal
     rows never retain message bodies and are never overwritten or redispatched. *)
 
-val lease_next :
-  keeper_name:string ->
+val observe_pending :
+  keeper_name:string -> (pending_observation option, mutation_error) result
+(** Observe the exact FIFO head without changing its durable [Pending] state.
+    Returns [None] when the lane has no dispatchable pending head, including
+    while an inflight or recovery-required receipt owns delivery. *)
+
+val pending_observation_item : pending_observation -> leased_message
+
+val lease_observed :
+  pending_observation ->
   [ `Leased of lease
-  | `Empty
-  | `Already_leased of string
-  | `Recovery_required of recovery_evidence
+  | `Stale of pending_claim_stale
   | `Error of mutation_error
   ]
+(** Claim an observed receipt only when it is still the [Pending] FIFO head.
+    Appending receipts behind that head does not invalidate the observation.
+    The transition to [Inflight] is atomic. [`Stale] performs no mutation;
+    callers should re-observe after the durable transition that invalidated
+    the observation. *)
 
 (** Atomically finalize the receipt in the matching lease. Terminal records
     retain correlation metadata but discard message bodies and attachments. *)
@@ -302,7 +325,7 @@ type lane_status = {
 }
 
 (** O(1), memory-only hot-path projection. Consumers should use this instead
-    of materializing [snapshot] before [lease_next]. *)
+    of materializing [snapshot] before [observe_pending]. *)
 val lane_status : keeper_name:string -> (lane_status, mutation_error) result
 
 val snapshot : keeper_name:string -> diagnostic_snapshot

--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -267,6 +267,7 @@ val observe_pending :
     while an inflight or recovery-required receipt owns delivery. *)
 
 val pending_observation_item : pending_observation -> leased_message
+val pending_observation_revision : pending_observation -> int64
 
 val lease_observed :
   pending_observation ->

--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -267,7 +267,6 @@ val observe_pending :
     while an inflight or recovery-required receipt owns delivery. *)
 
 val pending_observation_item : pending_observation -> leased_message
-val pending_observation_revision : pending_observation -> int64
 
 val lease_observed :
   pending_observation ->
@@ -359,7 +358,9 @@ val reconcile_persistence :
     retained transaction plan. A pre-publication projection is replayed; a
     published projection is verified; an uncertain lease is compensated to
     [Pending]. Any third state remains a typed [Reconciliation_failed] conflict
-    for explicit operator action. *)
+    for explicit operator action. Reconciliation itself emits no queue wake:
+    its owning consumer continues from the returned state, so an internal
+    projection repair cannot create a retry loop. *)
 
 type recovery_cancellation =
   { cancelled_at : float

--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -129,11 +129,6 @@ type persistence_publication =
       ; receipt_id : Receipt_id.t
       ; lease_id : string
       }
-  | Nack_indeterminate of
-      { revision : int64
-      ; receipt_id : Receipt_id.t
-      ; lease_id : string
-      }
   | Startup_recovery_indeterminate of
       { revision : int64
       ; receipt_id : Receipt_id.t
@@ -292,16 +287,6 @@ val finalize :
   lease_id:string ->
   outcome:finalization ->
   [ `Finalized of Receipt_id.t
-  | `Unknown_lease
-  | `Error of mutation_error
-  ]
-
-(** Return the receipt in the matching lease to [Pending], preserving its id
-    and FIFO position. *)
-val nack :
-  keeper_name:string ->
-  lease_id:string ->
-  [ `Requeued of Receipt_id.t
   | `Unknown_lease
   | `Error of mutation_error
   ]

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -224,13 +224,6 @@ let run_keeper_cycle_with
   =
   let busy_outcome block =
     (match block with
-     | Keeper_turn_admission.Chat_backlog { pending_count; inflight_count } ->
-       Log.Keeper.info
-         "%s: yielding autonomous cycle to chat backlog (pending=%d inflight=%d); \
-          skipping until next heartbeat"
-         meta_after_triage.name
-         pending_count
-         inflight_count
      | Keeper_turn_admission.Shutdown_requested operation_id ->
        Log.Keeper.info
          "%s: autonomous turn admission closed by shutdown operation %s"
@@ -277,15 +270,9 @@ let run_keeper_cycle_with
   match manual_compaction_requested with
   | Some false | None -> run_standard_cycle ()
   | Some true ->
-    (* #24865: a manual-compaction cycle is the remedy for the overflow that
-       wedges chat delivery, so its compaction-only critical section admits
-       past the durable chat backlog ([run_compaction_if_free] inside
-       [run_admitted]) and releases the slot the moment the checkpoint
-       commits. The follow-up turn then re-enters the standard lane below,
-       where a chat backlog wins — the remedy may cut the line, an arbitrary
-       LLM turn may not. [Manual_compaction_applied { followup = Busy _; _ }]
-       causes the owner loop to ACK the selected stimulus, so a yielded
-       follow-up does not replay compaction. *)
+    (* Manual compaction and its follow-up remain inside the already admitted
+       cycle. The turn mutex is the only live admission authority; durable chat
+       receipts do not add a separate compaction gate. *)
     (match
        run_manual_compaction
          ~before_dispatch_authority:

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -454,7 +454,7 @@ let run_admitted_with
     if already_admitted
     then `Ran ()
     else
-      Keeper_turn_admission.run_compaction_if_free
+      Keeper_turn_admission.run_if_free
         ~base_path:config.base_path
         ~keeper_name:meta.name
         (fun () -> ())
@@ -475,7 +475,7 @@ let run_admitted_with
       if already_admitted
       then `Ran (run ())
       else
-        Keeper_turn_admission.run_compaction_if_free
+        Keeper_turn_admission.run_if_free
           ~base_path:config.base_path
           ~keeper_name:meta.name
           run

--- a/lib/keeper/keeper_paused_work_cancellation_transaction.ml
+++ b/lib/keeper/keeper_paused_work_cancellation_transaction.ml
@@ -219,7 +219,7 @@ let cancel_with_lifecycle
       }
   | Ok None ->
     (match
-       Keeper_turn_admission.run_admin_if_free
+       Keeper_turn_admission.run_if_free
          ~base_path
          ~keeper_name
          acquire

--- a/lib/keeper/keeper_paused_work_source_terminal_transaction.ml
+++ b/lib/keeper/keeper_paused_work_source_terminal_transaction.ml
@@ -346,7 +346,7 @@ let ack_pending_under_admission config ~keeper_name request =
 
 let ack_pending config ~keeper_name request =
   match
-    Keeper_turn_admission.run_admin_if_free
+    Keeper_turn_admission.run_if_free
       ~base_path:config.Workspace.base_path
       ~keeper_name
       (fun () -> ack_pending_under_admission config ~keeper_name request)

--- a/lib/keeper/keeper_paused_work_transfer_transaction.ml
+++ b/lib/keeper/keeper_paused_work_transfer_transaction.ml
@@ -474,7 +474,7 @@ let transfer_pending_under_admission config ~from_keeper ~to_keeper request =
 
 let transfer_pending config ~from_keeper ~to_keeper request =
   match
-    Keeper_turn_admission.run_admin_if_free
+    Keeper_turn_admission.run_if_free
       ~base_path:config.Workspace.base_path
       ~keeper_name:from_keeper
       (fun () ->

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -141,11 +141,14 @@ val handle_keeper_msg :
   ?on_admitted:(unit -> (unit, string) result) ->
   _ Keeper_types_profile.context -> Yojson.Safe.t -> tool_result
 (** [event_bus] is captured at the handler boundary and reused by the admitted
-    turn body. Callers that omit it keep the legacy process/domain fallback, but
+    turn body. Callers that omit it keep the process/domain fallback, but
     async wrappers should pass an explicit value captured before submitting the
     background turn. [on_admission_rejected] receives the typed admission
-    result before the legacy tool error is rendered; queue consumers use it to
-    keep a leased receipt pending without matching diagnostic strings. *)
+    result before the tool error is rendered; queue consumers use it to leave
+    an unclaimed receipt [Pending] without matching diagnostic strings.
+    [on_admitted] runs while the turn slot is held and before the admitted turn
+    body; the queue consumer uses it as the exact Pending-to-Inflight claim
+    boundary. *)
 
 val handle_keeper_delegate :
   ?event_bus:Agent_sdk.Event_bus.t ->

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -290,12 +290,22 @@ let admit_autonomous_with_token ~base_path ~keeper_name f =
   let slot = slot_for ~base_path ~keeper_name in
   match peek_shutdown slot with
   | Some operation_id -> `Busy (Shutdown_requested operation_id)
+  | None when waiting_count slot > 0 -> `Busy (Turn_busy (peek_info slot))
   | None ->
     if Eio.Mutex.try_lock slot.turn_mu
     then (
-      match run_locked_with_token slot ~lane:Autonomous f with
-      | `Ran value -> `Ran value
-      | `Shutdown_requested operation_id -> `Busy (Shutdown_requested operation_id))
+      (* A chat waiter can register between the first check and [try_lock].
+         Recheck while holding the turn mutex so autonomous work cannot
+         overtake a waiter that has already joined this slot. *)
+      if waiting_count slot > 0
+      then (
+        Eio.Mutex.unlock slot.turn_mu;
+        `Busy (Turn_busy (peek_info slot)))
+      else
+        match run_locked_with_token slot ~lane:Autonomous f with
+        | `Ran value -> `Ran value
+        | `Shutdown_requested operation_id ->
+          `Busy (Shutdown_requested operation_id))
     else `Busy (Turn_busy (peek_info slot))
 ;;
 

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -21,10 +21,6 @@ type in_flight_info =
 
 type autonomous_block =
   | Turn_busy of in_flight_info option
-  | Chat_backlog of
-      { pending_count : int
-      ; inflight_count : int
-      }
   | Shutdown_requested of Keeper_shutdown_types.Operation_id.t
 
 type rejection =
@@ -82,7 +78,6 @@ let lane_to_string = function
 
 let autonomous_block_kind = function
   | Turn_busy _ -> "turn_busy"
-  | Chat_backlog _ -> "chat_backlog"
   | Shutdown_requested _ -> "shutdown_requested"
 ;;
 
@@ -93,11 +88,6 @@ let autonomous_block_to_string = function
       "reason=turn_busy holder_lane=%s holder_started_at=%.17g"
       (lane_to_string lane)
       started_at
-  | Chat_backlog { pending_count; inflight_count } ->
-    Printf.sprintf
-      "reason=chat_backlog pending_count=%d inflight_count=%d"
-      pending_count
-      inflight_count
   | Shutdown_requested operation_id ->
     Printf.sprintf
       "reason=shutdown_requested operation_id=%s"
@@ -116,12 +106,6 @@ let autonomous_block_to_yojson = function
           ]
     in
     `Assoc [ "kind", `String "turn_busy"; "holder", holder_json ]
-  | Chat_backlog { pending_count; inflight_count } ->
-    `Assoc
-      [ "kind", `String "chat_backlog"
-      ; "pending_count", `Int pending_count
-      ; "inflight_count", `Int inflight_count
-      ]
   | Shutdown_requested operation_id ->
     `Assoc
       [ "kind", `String "shutdown_requested"
@@ -302,87 +286,32 @@ let shutdown_rejection_snapshot slot operation_id =
     })
 ;;
 
-let admit_autonomous_with_token ~yield_to_chat_backlog ~base_path ~keeper_name f =
+let admit_autonomous_with_token ~base_path ~keeper_name f =
   let slot = slot_for ~base_path ~keeper_name in
-  (* Yield to deferred work before touching the lock. [waiting > 0] implies
-     the slot is held (a waiter only parks because a turn is in flight), so
-     [try_lock] would fail here anyway; the explicit check keeps the
-     autonomous lane from competing for a slot a parked chat is already
-     queued on. A non-empty [Keeper_chat_queue] means a busy connector
-     (Slack/Discord) or dashboard message is deferred for this keeper but
-     has not parked on the slot; the standard autonomous lane must yield for
-     it too, otherwise a long or back-to-back autonomous turn starves that
-     queue indefinitely (the busy-ACK loop). Reading the queue length is a
-     lock-only, non-suspending peek and is the SSOT signal that closes the
-     gap: the autonomous lane cooperates on the same backlog the consumer
-     drains, so the consumer's [in_flight = None] window opens
-     deterministically instead of racing the next autonomous cycle. Once a
-     receipt is leased, the actual per-Keeper turn mutex is the authority for
-     whether its chat turn is still executing. An inflight receipt with a free
-     mutex may be between delivery and finalization or stranded after failure;
-     it must not become a second, durable global turn lock.
-
-     [yield_to_chat_backlog:false] (the manual-compaction lane) skips only
-     that queue peek: the backlog yield presumes the chat consumer can make
-     progress, and a context-overflowed keeper violates that premise — its
-     chat turns fail until compaction rewrites the checkpoint, so queueing
-     the compaction cycle behind the backlog inverts the priority and
-     starves both lanes (#24865). *)
   match peek_shutdown slot with
   | Some operation_id -> `Busy (Shutdown_requested operation_id)
-  | None when waiting_count slot > 0 -> `Busy (Turn_busy (peek_info slot))
   | None ->
-    let chat_backlog =
-      if yield_to_chat_backlog
-      then (
-        let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
-        (* Queue persistence/read failures remain typed Chat-boundary
-           failures. They are not evidence of queued work and therefore
-           cannot close an otherwise independent autonomous lane. *)
-        match List.length snapshot.pending, List.length snapshot.inflight with
-        | 0, _ -> None
-        | pending_count, 0 ->
-          Some (Chat_backlog { pending_count; inflight_count = 0 })
-        | _, _ -> None)
-      else None
-    in
-    (match chat_backlog with
-     | Some block -> `Busy block
-     | None ->
-       if Eio.Mutex.try_lock slot.turn_mu
-       then (
-         match run_locked_with_token slot ~lane:Autonomous f with
-         | `Ran value -> `Ran value
-         | `Shutdown_requested operation_id -> `Busy (Shutdown_requested operation_id))
-       else `Busy (Turn_busy (peek_info slot)))
+    if Eio.Mutex.try_lock slot.turn_mu
+    then (
+      match run_locked_with_token slot ~lane:Autonomous f with
+      | `Ran value -> `Ran value
+      | `Shutdown_requested operation_id -> `Busy (Shutdown_requested operation_id))
+    else `Busy (Turn_busy (peek_info slot))
 ;;
 
-let admit_autonomous ~yield_to_chat_backlog ~base_path ~keeper_name f =
+let admit_autonomous ~base_path ~keeper_name f =
   admit_autonomous_with_token
-    ~yield_to_chat_backlog
     ~base_path
     ~keeper_name
     (fun _token -> f ())
 ;;
 
 let run_if_free_with_token ~base_path ~keeper_name f =
-  admit_autonomous_with_token
-    ~yield_to_chat_backlog:true
-    ~base_path
-    ~keeper_name
-    f
+  admit_autonomous_with_token ~base_path ~keeper_name f
 ;;
 
 let run_if_free ~base_path ~keeper_name f =
-  admit_autonomous ~yield_to_chat_backlog:true ~base_path ~keeper_name f
-;;
-
-let run_compaction_if_free ~base_path ~keeper_name f =
-  admit_autonomous ~yield_to_chat_backlog:false ~base_path ~keeper_name f
-;;
-
-let run_admin_if_free ~base_path ~keeper_name f =
-  admit_autonomous ~yield_to_chat_backlog:false ~base_path ~keeper_name f
+  admit_autonomous ~base_path ~keeper_name f
 ;;
 
 let run_serialized ~base_path ~keeper_name f =

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -290,22 +290,13 @@ let admit_autonomous_with_token ~base_path ~keeper_name f =
   let slot = slot_for ~base_path ~keeper_name in
   match peek_shutdown slot with
   | Some operation_id -> `Busy (Shutdown_requested operation_id)
-  | None when waiting_count slot > 0 -> `Busy (Turn_busy (peek_info slot))
   | None ->
     if Eio.Mutex.try_lock slot.turn_mu
-    then (
-      (* A chat waiter can register between the first check and [try_lock].
-         Recheck while holding the turn mutex so autonomous work cannot
-         overtake a waiter that has already joined this slot. *)
-      if waiting_count slot > 0
-      then (
-        Eio.Mutex.unlock slot.turn_mu;
-        `Busy (Turn_busy (peek_info slot)))
-      else
-        match run_locked_with_token slot ~lane:Autonomous f with
-        | `Ran value -> `Ran value
-        | `Shutdown_requested operation_id ->
-          `Busy (Shutdown_requested operation_id))
+    then
+      match run_locked_with_token slot ~lane:Autonomous f with
+      | `Ran value -> `Ran value
+      | `Shutdown_requested operation_id ->
+        `Busy (Shutdown_requested operation_id)
     else `Busy (Turn_busy (peek_info slot))
 ;;
 

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -286,7 +286,7 @@ let shutdown_rejection_snapshot slot operation_id =
     })
 ;;
 
-let admit_autonomous_with_token ~base_path ~keeper_name f =
+let run_if_free_with_token ~base_path ~keeper_name f =
   let slot = slot_for ~base_path ~keeper_name in
   match peek_shutdown slot with
   | Some operation_id -> `Busy (Shutdown_requested operation_id)
@@ -300,19 +300,11 @@ let admit_autonomous_with_token ~base_path ~keeper_name f =
     else `Busy (Turn_busy (peek_info slot))
 ;;
 
-let admit_autonomous ~base_path ~keeper_name f =
-  admit_autonomous_with_token
+let run_if_free ~base_path ~keeper_name f =
+  run_if_free_with_token
     ~base_path
     ~keeper_name
     (fun _token -> f ())
-;;
-
-let run_if_free_with_token ~base_path ~keeper_name f =
-  admit_autonomous_with_token ~base_path ~keeper_name f
-;;
-
-let run_if_free ~base_path ~keeper_name f =
-  admit_autonomous ~base_path ~keeper_name f
 ;;
 
 let run_serialized ~base_path ~keeper_name f =

--- a/lib/keeper/keeper_turn_admission.mli
+++ b/lib/keeper/keeper_turn_admission.mli
@@ -40,20 +40,6 @@ type in_flight_info =
 
 type autonomous_block =
   | Turn_busy of in_flight_info option
-  | Chat_backlog of
-      { pending_count : int
-      ; inflight_count : int
-      }
-    (** The slot mutex itself is free and pending [Keeper_chat_queue] receipts
-        exist without a currently leased receipt; the standard autonomous lane
-        yields so the chat consumer can drain them. Inflight receipts are not
-        a second turn lock: an executing chat is fenced by the actual slot,
-        while a stranded/finalizing receipt must not halt unrelated progress.
-        Distinct from [Turn_busy None]
-        (a held slot whose holder has not yet published its info): before
-        this variant existed both cases logged as "holder info not yet
-        published", which mis-directed the #24865 diagnosis toward a stale
-        slot when the durable chat backlog was the actual fence. *)
   | Shutdown_requested of Keeper_shutdown_types.Operation_id.t
 
 val autonomous_block_kind : autonomous_block -> string
@@ -152,61 +138,12 @@ val run_if_free
     Exceptions from [f] (including [Eio.Cancel.Cancelled]) release the slot and
     re-raise.
 
-    Also returns [`Busy] without attempting the lock when a chat request is
-    already parked on this slot ([chat_waiting] is true, reported as
-    [Turn_busy]), or when a busy connector/dashboard receipt is active in
-    [Keeper_chat_queue] for this keeper (pending or inflight, reported as
-    [Chat_backlog] with the exact counts). Eio.Mutex hands a released slot
-    directly to the next parked waiter, so a new autonomous cycle would not
-    overtake a queued chat regardless; these pre-checks make the yield
-    explicit and keep a heartbeat-scheduled cycle from competing for a slot
-    a dashboard/connector message is already waiting on or queued behind.
-    The [Keeper_chat_queue] half closes the starvation gap where a long or
-    back-to-back autonomous turn could otherwise busy-ACK a connector
-    forever: the autonomous lane yields on the same backlog the consumer
-    drains, so the consumer's [in_flight = None] window opens
-    deterministically. Queue persistence/read errors remain explicit typed
-    failures at the Chat mutation/consumer boundary; because they are not
-    queued work, they do not close this independent autonomous lane. *)
-
-val run_compaction_if_free
-  :  base_path:string
-  -> keeper_name:string
-  -> (unit -> 'a)
-  -> [ `Ran of 'a | `Busy of autonomous_block ]
-(** [run_if_free] for the manual-compaction critical section, differing in
-    exactly one fence: it does not yield to the [Keeper_chat_queue] backlog
-    and therefore never returns [`Busy (Chat_backlog _)].
-
-    Sole sanctioned caller: [Keeper_manual_compaction.run_admitted]. The
-    admitted section must be the compaction commit only — a deterministic
-    checkpoint/FSM operation — never a provider turn; any follow-up turn
-    re-enters [run_if_free] and yields to the backlog. This module cannot
-    name [Keeper_manual_compaction] types without inverting the layering,
-    so the closure stays generic here and the compaction-only shape is
-    enforced at that single wrapper.
-
-    The standard lane's backlog yield assumes the chat consumer can drain
-    the queue. When the keeper's context has overflowed its provider
-    window, chat delivery itself fails until compaction rewrites the
-    checkpoint — so yielding parks the remedy behind the very backlog it
-    is meant to unblock, a priority inversion that starved manual
-    compaction indefinitely (#24865: durable pending receipts fenced every
-    cycle across restarts while the slot mutex stayed free).
-
-    Everything else is unchanged from [run_if_free]: a durable shutdown
-    reservation still fences admission, a parked chat waiter still wins,
-    and a genuinely held slot still returns [`Busy (Turn_busy _)] — this
-    lane never interleaves with an in-flight turn, it only stops queueing
-    behind work that cannot progress. *)
-
-val run_admin_if_free
-  :  base_path:string
-  -> keeper_name:string
-  -> (unit -> 'a)
-  -> [ `Ran of 'a | `Busy of autonomous_block ]
-(** Serialize paused-owner durable mutation against this same turn slot.
-    Busy is returned before any durable mutation. *)
+    A queued chat observes its receipt while it is [Pending], then enters
+    [run_serialized] before leasing it at the admitted execution boundary.
+    Once parked, Eio.Mutex transfers a released slot directly to that waiter;
+    [try_lock] therefore cannot overtake it. The mutex is the only live turn
+    admission authority. Queue persistence errors remain explicit at the chat
+    consumer boundary and never fence this independent autonomous lane. *)
 
 val chat_waiting : base_path:string -> keeper_name:string -> bool
 (** [true] when at least one chat request is parked on this keeper's slot

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -141,14 +141,7 @@ let chat_yield_request ~base_path ~keeper_name =
   | Some _ ->
     if Keeper_turn_admission.chat_waiting ~base_path ~keeper_name
     then Ok (Some Keeper_agent_run.{ reason = Chat_waiting })
-    else
-      match Keeper_chat_queue.has_active_receipts ~keeper_name with
-      | Error error ->
-        Error
-          ("chat queue snapshot failed: "
-           ^ Keeper_chat_queue.mutation_error_to_string error)
-      | Ok true -> Ok (Some Keeper_agent_run.{ reason = Chat_waiting })
-      | Ok false -> Ok None
+    else Ok None
 ;;
 
 let autonomous_yield_request ~base_path ~keeper_name =

--- a/lib/keeper_chat_delivery_identity/keeper_chat_delivery_identity.ml
+++ b/lib/keeper_chat_delivery_identity/keeper_chat_delivery_identity.ml
@@ -72,6 +72,8 @@ module Receipt_ids = struct
   type t = Receipt_id.t * Receipt_id.t list
   type error = Empty
 
+  let singleton receipt_id = receipt_id, []
+
   let of_list = function
     | [] -> Error Empty
     | first :: rest -> Ok (first, rest)

--- a/lib/keeper_chat_delivery_identity/keeper_chat_delivery_identity.mli
+++ b/lib/keeper_chat_delivery_identity/keeper_chat_delivery_identity.mli
@@ -26,6 +26,7 @@ module Receipt_ids : sig
   type t
   type error = Empty
 
+  val singleton : Receipt_id.t -> t
   val of_list : Receipt_id.t list -> (t, error) result
   val error_to_string : error -> string
   val to_list : t -> Receipt_id.t list

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1654,10 +1654,21 @@ let start_keeper_loops_owned
            re-arm the still-Pending receipt. *)
         Keeper_turn_admission.set_slot_transition_observer
           (Some
-             (fun ~base_path:_ ~keeper_name ~transition ->
+             (fun ~base_path ~keeper_name ~transition ->
                 match transition with
                 | Keeper_turn_admission.Shutdown_rolled_back ->
-                  Keeper_chat_consumer.notify_transition ~keeper_name
+                  (match
+                     Keeper_chat_consumer.notify_explicit_retry
+                       ~base_path
+                       ~keeper_name
+                   with
+                   | Ok () -> ()
+                   | Error error ->
+                     Log.Keeper.error
+                       "keeper chat consumer explicit retry failed after shutdown rollback keeper=%s: %s"
+                       keeper_name
+                       error;
+                     Keeper_chat_consumer.notify_transition ~keeper_name)
                 | Keeper_turn_admission.Turn_released -> ()));
         Ok ()
       with

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1650,25 +1650,14 @@ let start_keeper_loops_owned
                 Keeper_chat_consumer.notify_transition ~keeper_name));
         (* A chat consumer waiting behind a running turn is handed the mutex
            directly, so [Turn_released] needs no second wake. A shutdown
-           rejection does not park on that mutex; rollback must explicitly
-           re-arm the still-Pending receipt. *)
+           rejection happens before the exact claim; rollback only needs to
+           wake the still-Pending receipt. *)
         Keeper_turn_admission.set_slot_transition_observer
           (Some
-             (fun ~base_path ~keeper_name ~transition ->
+             (fun ~base_path:_ ~keeper_name ~transition ->
                 match transition with
                 | Keeper_turn_admission.Shutdown_rolled_back ->
-                  (match
-                     Keeper_chat_consumer.notify_explicit_retry
-                       ~base_path
-                       ~keeper_name
-                   with
-                   | Ok () -> ()
-                   | Error error ->
-                     Log.Keeper.error
-                       "keeper chat consumer explicit retry failed after shutdown rollback keeper=%s: %s"
-                       keeper_name
-                       error;
-                     Keeper_chat_consumer.notify_transition ~keeper_name)
+                  Keeper_chat_consumer.notify_transition ~keeper_name
                 | Keeper_turn_admission.Turn_released -> ()));
         Ok ()
       with

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -200,7 +200,7 @@ let queued_chat_projection (queued_message : Keeper_chat_queue.queued_message) =
 
 (* Queue-consumer turns need the same synthetic
    [Server_routes_http_keeper_stream.keeper_chat_stream_request] built from
-   a dequeued/leased [Keeper_chat_queue.queued_message], and a duplicated
+   an observed Pending [Keeper_chat_queue.queued_message], and a duplicated
    copy would silently drift out of sync with [queued_chat_projection] the
    next time either changes. *)
 let payload_of_queued_message ~keeper_name
@@ -1667,7 +1667,12 @@ let start_keeper_loops_owned
      | Error exn -> raise exn);
     Keeper_chat_consumer.run ~sw ~clock
            ~base_path
-           ~handle_turn:(fun ~sw ~keeper_name ~delivery_key ~queued_message ->
+           ~handle_turn:(fun
+              ~sw
+              ~keeper_name
+              ~receipt_ids
+              ~queued_message
+              ~on_admitted ->
              let open Server_routes_http_keeper_stream in
              let now = Time_compat.now () in
              let run_id =
@@ -1823,8 +1828,12 @@ let start_keeper_loops_owned
                match
                  process_single_turn
                    ~user_row_origin:queued_message.user_row_origin
-                   ~queued_turn:true
-                   ~delivery_key:(Some delivery_key)
+                   ~submission:
+                     (Queued_receipt
+                        { receipt_ids
+                        ; claim = on_admitted
+                        ; execution_sw = sw
+                        })
                    ~state ~clock ~auth_token:None
                    ~thread_id ~continuation_channel ~closed
                    ~client_disconnects:None

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1648,17 +1648,18 @@ let start_keeper_loops_owned
              (fun ~keeper_name ~revision ->
                 Keeper_chat_broadcast.queue_changed ~keeper_name ~revision ();
                 Keeper_chat_consumer.notify_transition ~keeper_name));
-        (* A chat consumer waiting behind a running turn is handed the mutex
-           directly, so [Turn_released] needs no second wake. A shutdown
-           rejection happens before the exact claim; rollback only needs to
-           wake the still-Pending receipt. *)
+        (* A queued turn can fail preflight before it parks on the admission
+           mutex. Both release and shutdown rollback therefore re-arm the
+           still-Pending receipt. [notify_transition] coalesces duplicate
+           wakes for turns that were already handed the mutex directly. *)
         Keeper_turn_admission.set_slot_transition_observer
           (Some
              (fun ~base_path:_ ~keeper_name ~transition ->
                 match transition with
-                | Keeper_turn_admission.Shutdown_rolled_back ->
+                | Keeper_turn_admission.Shutdown_rolled_back
+                | Keeper_turn_admission.Turn_released ->
                   Keeper_chat_consumer.notify_transition ~keeper_name
-                | Keeper_turn_admission.Turn_released -> ()));
+                ));
         Ok ()
       with
       | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -1690,6 +1691,14 @@ let start_keeper_loops_owned
              let agent_name = (queued_chat_projection queued_message).agent_name in
              let events = Keeper_chat_events.create () in
              let closed = ref false in
+             let claim_committed = ref false in
+             let claim () =
+               match on_admitted () with
+               | Ok () as result ->
+                 claim_committed := true;
+                 result
+               | Error _ as result -> result
+             in
              let thread_id = "keeper-consumer:" ^ keeper_name in
              let delivery, delivery_resolver = Eio.Promise.create () in
              let resolve_delivery result =
@@ -1834,7 +1843,7 @@ let start_keeper_loops_owned
                    ~submission:
                      (Queued_receipt
                         { receipt_ids
-                        ; claim = on_admitted
+                        ; claim
                         ; execution_sw = sw
                         })
                    ~state ~clock ~auth_token:None
@@ -1847,9 +1856,18 @@ let start_keeper_loops_owned
                | outcome -> outcome
                | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
                | exception exn ->
-                   Keeper_chat_events.publish events
-                     (Keeper_chat_events.Event_error
-                        { message = Printexc.to_string exn });
+                   if !claim_committed
+                   then
+                     Keeper_chat_events.publish events
+                       (Keeper_chat_events.Event_error
+                          { message = Printexc.to_string exn })
+                   else (
+                     Log.Keeper.error
+                       "keeper_chat_consumer: pre-claim turn setup raised for keeper=%s: %s; terminating local delivery without a connector message"
+                       keeper_name
+                       (Printexc.to_string exn);
+                     Keeper_chat_events.publish events
+                       (Keeper_chat_events.Run_finished { run_id }));
                    let _delivery_outcome = Eio.Promise.await delivery in
                    raise exn
              in

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1648,14 +1648,17 @@ let start_keeper_loops_owned
              (fun ~keeper_name ~revision ->
                 Keeper_chat_broadcast.queue_changed ~keeper_name ~revision ();
                 Keeper_chat_consumer.notify_transition ~keeper_name));
-        (* A freed turn slot (turn released / shutdown rolled back) makes the
-           lane dispatchable again; wake the consumer so any receipt that was
-           deferred while the lane was busy is re-examined. The admission
-           observer is non-blocking and its failures cannot alter admission. *)
+        (* A chat consumer waiting behind a running turn is handed the mutex
+           directly, so [Turn_released] needs no second wake. A shutdown
+           rejection does not park on that mutex; rollback must explicitly
+           re-arm the still-Pending receipt. *)
         Keeper_turn_admission.set_slot_transition_observer
           (Some
-             (fun ~base_path:_ ~keeper_name ~transition:_ ->
-                Keeper_chat_consumer.notify_transition ~keeper_name));
+             (fun ~base_path:_ ~keeper_name ~transition ->
+                match transition with
+                | Keeper_turn_admission.Shutdown_rolled_back ->
+                  Keeper_chat_consumer.notify_transition ~keeper_name
+                | Keeper_turn_admission.Turn_released -> ()));
         Ok ()
       with
       | Eio.Cancel.Cancelled _ as exn -> raise exn

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1649,16 +1649,17 @@ let start_keeper_loops_owned
                 Keeper_chat_broadcast.queue_changed ~keeper_name ~revision ();
                 Keeper_chat_consumer.notify_transition ~keeper_name));
         (* A queued turn can fail preflight before it parks on the admission
-           mutex. Both release and shutdown rollback therefore re-arm the
-           still-Pending receipt. [notify_transition] coalesces duplicate
-           wakes for turns that were already handed the mutex directly. *)
+           mutex. Release and shutdown rollback re-arm only a consumer attempt
+           that has not reached its exact claim callback. *)
         Keeper_turn_admission.set_slot_transition_observer
           (Some
-             (fun ~base_path:_ ~keeper_name ~transition ->
+             (fun ~base_path ~keeper_name ~transition ->
                 match transition with
                 | Keeper_turn_admission.Shutdown_rolled_back
                 | Keeper_turn_admission.Turn_released ->
-                  Keeper_chat_consumer.notify_transition ~keeper_name
+                  Keeper_chat_consumer.notify_slot_transition
+                    ~base_path
+                    ~keeper_name
                 ));
         Ok ()
       with

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -1179,6 +1179,14 @@ and queued_turn_outcome =
       }
   | Deferred of { rejection : Keeper_turn_admission.rejection }
 
+type turn_submission =
+  | Direct_request
+  | Queued_receipt of
+      { receipt_ids : Keeper_chat_delivery_identity.Receipt_ids.t
+      ; claim : unit -> (unit, string) result
+      ; execution_sw : Eio.Switch.t
+      }
+
 let completion_of_worker_settlement ~queued_turn ~staged_completion
     (settlement : Keeper_msg_async.worker_settlement) =
   let queued_failure kind detail =
@@ -1382,19 +1390,28 @@ type translated_keeper_stream_event =
 let empty_keeper_stream_bridge_state = Keeper_chat_oas_stream_bridge.empty_state
 let translate_oas_stream_event = Keeper_chat_oas_stream_bridge.translate
 
-(* [user_row_origin] and [queued_turn] are required labelled arguments. Every
-   caller presents the typed transcript provenance selected at its persistence
-   boundary; this function never infers ownership from a connector label or
-   message content. *)
-let process_single_turn ~user_row_origin ~queued_turn
-    ~delivery_key
+(* [user_row_origin] and [submission] are required labelled arguments. Every
+   caller presents the typed transcript provenance and execution ownership
+   selected at its persistence boundary; this function never infers either
+   from a connector label or message content. *)
+let process_single_turn ~user_row_origin ~submission
     ~state ~clock ~auth_token ~thread_id ~continuation_channel ~closed
     ~client_disconnects
     ~payload ~run_id ~message_id ~agent_name ~submitted_by
     ~(events : Keeper_chat_events.keeper_chat_event Eio.Stream.t) =
+  let queued_turn =
+    match submission with
+    | Direct_request -> false
+    | Queued_receipt _ -> true
+  in
   let base_path = (Mcp_server.workspace_config state).base_path in
   let direct_delivery_checkpoint : Keeper_chat_direct_delivery.t option ref =
     ref None
+  in
+  let queue_claim_failure = ref None in
+  let queue_claim_committed = ref false in
+  let queued_turn_not_started () =
+    queued_turn && not !queue_claim_committed
   in
   let redaction =
     Keeper_secret_redaction.snapshot ~base_path ~keeper_name:payload.name
@@ -1610,16 +1627,11 @@ let process_single_turn ~user_row_origin ~queued_turn
     direct_delivery_checkpoint := Some checkpoint
   in
   let queue_delivery_key () =
-    match queued_turn, delivery_key with
-    | true, Some (Keeper_chat_delivery_identity.Queue_receipts _ as key) ->
-      Ok key
-    | true, Some
-        (Keeper_chat_delivery_identity.Direct_request _
-        | Keeper_chat_delivery_identity.Async_request _) ->
-      Error "queued Keeper turn received a non-queue delivery identity"
-    | true, None ->
-      Error "queued Keeper turn is missing its receipt delivery identity"
-    | false, _ -> Error "non-queued Keeper turn requested queue delivery identity"
+    match submission with
+    | Queued_receipt { receipt_ids; _ } ->
+      Ok (Keeper_chat_delivery_identity.Queue_receipts receipt_ids)
+    | Direct_request ->
+      Error "non-queued Keeper turn requested queue delivery identity"
   in
   let append_queued_user_row_once () =
     let ( let* ) = Result.bind in
@@ -1746,6 +1758,24 @@ let process_single_turn ~user_row_origin ~queued_turn
     | None -> Error "direct Keeper delivery checkpoint is unavailable"
   in
   let on_queue_turn_admitted () =
+    let ( let* ) = Result.bind in
+    let* () =
+      match submission with
+      | Queued_receipt { claim; _ } ->
+        (match claim () with
+         | Ok () ->
+           queue_claim_committed := true;
+           Ok ()
+         | Error detail ->
+           queue_claim_failure := Some detail;
+           Error detail)
+      | Direct_request ->
+        let detail =
+          "direct Keeper turn reached the queued receipt claim boundary"
+        in
+        queue_claim_failure := Some detail;
+        Error detail
+    in
     append_queued_user_row_once ()
   in
   let commit_direct_terminal ~ok ~body ~data transcript_effect =
@@ -1928,27 +1958,8 @@ let process_single_turn ~user_row_origin ~queued_turn
     push_worker_event (Stream_terminal { status; body; queued_outcome });
     persisted
   in
-  let submit_result =
-    match Keeper_msg_async.server_background_switch () with
-    | Error error ->
-        Error
-          (Keeper_msg_async.submit_error_to_json error |> Yojson.Safe.to_string)
-    | Ok background_sw ->
-      let on_accepted =
-        if dashboard_direct_stream
-        then Some on_direct_request_accepted
-        else None
-      in
-      Keeper_msg_async.submit
-        ?on_accepted
-        ~background_sw
-        ~on_worker_aborted
-        ~on_worker_settled:publish_committed_completion
-        ~base_path
-        ~caller:submitted_by
-        ~keeper_name:payload.name
-        ~f:(fun request_sw ->
-        let start_time = Time_compat.now () in
+  let run_turn request_sw =
+    let start_time = Time_compat.now () in
         let finish_projection_failure kind detail =
           let persisted = persist_failure_reply detail in
           let queued_outcome =
@@ -2024,8 +2035,22 @@ let process_single_turn ~user_row_origin ~queued_turn
                  actually emitted. *)
               Error (Printexc.to_string exn)
         in
-        match dispatch_result with
-        | Ok (`Deferred rejection) ->
+        match !queue_claim_failure, dispatch_result with
+        | Some detail, _ ->
+            (* The exact Pending receipt was not claimed. Close the local event
+               projection without emitting [Event_error]: connector adapters
+               treat an empty [Run_finished] as a failed no-op, so no outbound
+               message or transcript row can escape for a turn that never
+               started. The queue consumer retains the typed claim failure and
+               decides whether to re-observe or require reconciliation. *)
+            push_worker_event
+              (Stream_terminal
+                 { status = Stream_cancelled
+                 ; body = detail
+                 ; queued_outcome = None
+                 });
+            Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time detail
+        | None, Ok (`Deferred rejection) ->
             push_worker_event (Stream_queued_turn_deferred rejection);
             Tool_result.make_ok
               ~tool_name:"masc_keeper_msg"
@@ -2036,7 +2061,7 @@ let process_single_turn ~user_row_origin ~queued_turn
                    ; ("admission", admission_rejection_to_json rejection)
                    ])
               ()
-        | Ok (`Queued queued) ->
+        | None, Ok (`Queued queued) ->
             let data =
               dashboard_deferred_chat_to_json ~keeper_name:payload.name queued
             in
@@ -2064,7 +2089,7 @@ let process_single_turn ~user_row_origin ~queued_turn
                     ; queued_outcome = None
                     });
                Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time detail)
-        | Ok (`Ran (true, body)) ->
+        | None, Ok (`Ran (true, body)) ->
           (match canonical_reply_payload_of_body ~redact_text body with
            | Error error ->
              let detail = canonical_reply_payload_error_to_string error in
@@ -2374,7 +2399,7 @@ let process_single_turn ~user_row_origin ~queued_turn
                              ~tool_name:"masc_keeper_msg"
                              ~start_time
                              body)))))
-        | Ok (`Ran (false, err)) ->
+        | None, Ok (`Ran (false, err)) ->
             let persisted = persist_failure_reply err in
             let queued_outcome =
               if not queued_turn then None
@@ -2392,7 +2417,15 @@ let process_single_turn ~user_row_origin ~queued_turn
               (Stream_terminal
                  { status = Stream_error; body = err; queued_outcome });
             Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err
-        | Error err ->
+        | None, Error err when queued_turn_not_started () ->
+            push_worker_event
+              (Stream_terminal
+                 { status = Stream_cancelled
+                 ; body = err
+                 ; queued_outcome = None
+                 });
+            Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err
+        | None, Error err ->
             let persisted = persist_failure_reply err in
             let queued_outcome =
               if not queued_turn then None
@@ -2409,20 +2442,92 @@ let process_single_turn ~user_row_origin ~queued_turn
             push_worker_event
               (Stream_terminal
                  { status = Stream_error; body = err; queued_outcome });
-            Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err)
-        ()
-      |> Result.map_error (fun error ->
-        Keeper_msg_async.submit_error_to_json error |> Yojson.Safe.to_string)
+            Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err
+  in
+  let publish_inline_completion () =
+    match !staged_completion with
+    | Some completion -> publish_completion completion
+    | None ->
+      let detail =
+        "queued Keeper turn ended without staging a terminal projection"
+      in
+      publish_completion
+        (Completion_terminal
+           { status =
+               (if queued_turn_not_started ()
+                then Stream_cancelled
+                else Stream_error)
+           ; body = detail
+           ; queued_outcome =
+               (if queued_turn_not_started ()
+                then None
+                else Some (Failed { kind = Turn_failed; detail }))
+           })
+  in
+  let submit_result =
+    match submission with
+    | Queued_receipt { execution_sw; _ } ->
+      (try
+         Eio.Fiber.fork ~sw:execution_sw (fun () ->
+           (match Eio.Switch.run (fun request_sw -> run_turn request_sw) with
+            | _ -> publish_inline_completion ()
+            | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
+            | exception exn ->
+              let detail = Printexc.to_string exn in
+              push_worker_event
+                (Stream_terminal
+                   { status =
+                       (if queued_turn_not_started ()
+                        then Stream_cancelled
+                        else Stream_error)
+                   ; body = detail
+                   ; queued_outcome =
+                       (if queued_turn_not_started ()
+                        then None
+                        else Some (Failed { kind = Turn_failed; detail }))
+                   });
+              publish_inline_completion ()));
+         Ok `Inline
+       with
+       | Eio.Cancel.Cancelled _ as exn -> raise exn
+       | exn -> Error (Printexc.to_string exn))
+    | Direct_request ->
+      (match Keeper_msg_async.server_background_switch () with
+       | Error error ->
+         Error
+           (Keeper_msg_async.submit_error_to_json error |> Yojson.Safe.to_string)
+       | Ok background_sw ->
+         let on_accepted =
+           if dashboard_direct_stream
+           then Some on_direct_request_accepted
+           else None
+         in
+         Keeper_msg_async.submit
+           ?on_accepted
+           ~background_sw
+           ~on_worker_aborted
+           ~on_worker_settled:publish_committed_completion
+           ~base_path
+           ~caller:submitted_by
+           ~keeper_name:payload.name
+           ~f:run_turn
+           ()
+         |> Result.map (fun outcome -> `Async outcome)
+         |> Result.map_error (fun error ->
+           Keeper_msg_async.submit_error_to_json error |> Yojson.Safe.to_string))
   in
   let request_id, durably_accepted =
     match submit_result with
+    | Ok `Inline -> None, false
     | Ok
+        (`Async
         ({ acceptance = Keeper_msg_async.Durably_accepted; request_id }
-          : Keeper_msg_async.submit_outcome) ->
+          : Keeper_msg_async.submit_outcome)) ->
         Some request_id, true
     | Ok
-        ({ acceptance = Keeper_msg_async.Reconciliation_required _; _ } as
-          outcome) ->
+        (`Async
+          ({ acceptance = Keeper_msg_async.Reconciliation_required _; _ } as
+            outcome)) ->
         let body =
           Keeper_msg_async.submit_outcome_to_json outcome |> Yojson.Safe.to_string
         in
@@ -2434,22 +2539,29 @@ let process_single_turn ~user_row_origin ~queued_turn
              });
         Some outcome.request_id, false
     | Error body ->
-        let persisted = persist_failure_reply body in
         let queued_outcome =
-          if not queued_turn then None
+          if queued_turn_not_started ()
+          then None
           else
-            match persisted with
-            | Ok () -> Some (Failed { kind = Turn_failed; detail = body })
-            | Error persist_error ->
-                Some
-                  (Failed
-                     { kind = Transcript_persist_failed
-                     ; detail = persist_error
-                     })
+            let persisted = persist_failure_reply body in
+            if not queued_turn
+            then None
+            else
+              match persisted with
+              | Ok () -> Some (Failed { kind = Turn_failed; detail = body })
+              | Error persist_error ->
+                  Some
+                    (Failed
+                       { kind = Transcript_persist_failed
+                       ; detail = persist_error
+                       })
         in
         publish_completion
           (Completion_terminal
-             { status = Stream_rejected
+             { status =
+                 (if queued_turn_not_started ()
+                  then Stream_cancelled
+                  else Stream_rejected)
              ; body
              ; queued_outcome
              });
@@ -2609,6 +2721,16 @@ let process_single_turn ~user_row_origin ~queued_turn
         Keeper_chat_events.publish events Text_message_end;
         Keeper_chat_events.publish events (Run_finished { run_id });
         Some (Deferred { rejection })
+    | `Completion (Completion_terminal { body; _ })
+      when queued_turn_not_started () ->
+        let message = redact_text body in
+        publish_terminal
+          ~status:(Request_stream Stream_cancelled)
+          ~message
+          ();
+        Keeper_chat_events.publish events Text_message_end;
+        Keeper_chat_events.publish events (Run_finished { run_id });
+        None
     | `Completion (Completion_dashboard_queued queued) ->
         let message =
           dashboard_deferred_ack_text ~keeper_name:payload.name queued
@@ -3071,8 +3193,7 @@ let handle_keeper_chat_stream ~sw ~clock ~submitted_by state request reqd payloa
              ignore
                (process_single_turn
                   ~user_row_origin:Keeper_chat_store.Needs_append
-                  ~queued_turn:false ~delivery_key:None
-                  ~state ~clock
+                  ~submission:Direct_request ~state ~clock
                   ~auth_token:(auth_token_from_request request)
                   ~thread_id ~continuation_channel ~closed
                   ~client_disconnects:(Some (stream_sw, client_disconnects))

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -2399,6 +2399,14 @@ let process_single_turn ~user_row_origin ~submission
                              ~tool_name:"masc_keeper_msg"
                              ~start_time
                              body)))))
+        | None, Ok (`Ran (false, err)) when queued_turn_not_started () ->
+            push_worker_event
+              (Stream_terminal
+                 { status = Stream_cancelled
+                 ; body = err
+                 ; queued_outcome = None
+                 });
+            Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err
         | None, Ok (`Ran (false, err)) ->
             let persisted = persist_failure_reply err in
             let queued_outcome =

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -175,12 +175,19 @@ type queued_turn_outcome =
       }
   | Deferred of { rejection : Keeper_turn_admission.rejection }
 
+type turn_submission =
+  | Direct_request
+  | Queued_receipt of
+      { receipt_ids : Keeper_chat_delivery_identity.Receipt_ids.t
+      ; claim : unit -> (unit, string) result
+      ; execution_sw : Eio.Switch.t
+      }
+
 val queued_turn_failure_kind_to_string : queued_turn_failure_kind -> string
 
 val process_single_turn :
   user_row_origin:Keeper_chat_store.user_row_origin ->
-  queued_turn:bool ->
-  delivery_key:Keeper_chat_delivery_identity.delivery_key option ->
+  submission:turn_submission ->
   state:Mcp_server.server_state ->
   clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
   auth_token:string option ->
@@ -196,14 +203,19 @@ val process_single_turn :
   events:Keeper_chat_events.keeper_chat_event Eio.Stream.t ->
   queued_turn_outcome option
 (** Execute a single keeper turn, publishing events to the provided
-    event stream. The async keeper_msg worker is always forked under the
-    server root switch and owns a separate per-request cancellation switch.
-    [closed] is a mutable flag that suppresses worker event pushes when
-    set to [true] (used by the SSE adapter when the HTTP stream is
-    closed). [client_disconnects] carries the HTTP stream switch and
-    disconnect signal; it stops only the stream projection and does not
-    cancel the accepted request. [auth_token] is [None] for queue-consumer
-    turns where no HTTP request is available.
+    event stream. Direct HTTP requests enter the durable {!Keeper_msg_async}
+    boundary and run under its server-owned request switch. Queue-consumer
+    turns are already durably owned by {!Keeper_chat_queue}: [Queued_receipt]
+    runs inline under its [execution_sw], parks on the Keeper turn slot, and
+    invokes [claim] for its exact [receipt_ids] only after admission. It does
+    not create a second durable async request. The typed [submission] prevents
+    direct requests from carrying queue claim authority and prevents queued
+    receipts from omitting it. [closed] is a mutable flag that suppresses
+    worker event pushes when set to [true] (used by the SSE adapter when the
+    HTTP stream is closed). [client_disconnects] carries the HTTP stream switch
+    and disconnect signal; it stops only the stream projection and does not
+    cancel an accepted direct request. [auth_token] is [None] for
+    queue-consumer turns where no HTTP request is available.
 
     [user_row_origin] is the durable provenance selected by the accepting
     boundary. [Needs_append] makes this turn own the user row;
@@ -211,18 +223,22 @@ val process_single_turn :
     append. Queue-consumer turns pass the exact provenance stored with their
     receipt instead of deriving ownership from a connector label.
 
-    [queued_turn] (default [false], set [true] only by
-    [Server_bootstrap_loops]'s queue-consumer [handle_turn] wiring) changes
-    terminal handling for [No_visible_reply], an empty [Visible_reply], and
+    [Queued_receipt] (constructed only by [Server_bootstrap_loops]'s
+    queue-consumer [handle_turn] wiring) changes terminal handling for
+    [No_visible_reply], an empty [Visible_reply], and
     [Continuation_checkpoint]. A media-only ordinary reply is delivered even
     when its text is empty. A queued continuation remains a typed failure but
-    retains any streamed media blocks on that durable failure row. With no
-    visible blocks, the interactive HTTP stream keeps recording the user line
+    retains any streamed media blocks on that durable failure row. Its [claim]
+    callback atomically claims the exact observed queue receipt after turn
+    admission and before transcript or provider effects.
+
+    With no visible blocks, the interactive HTTP stream keeps recording the user line
     only ([persist_user_message_only]), matching its existing "the keeper will
     answer on the next turn" semantics; a queued turn instead persists a typed
-    failure row via [persist_failure_reply]. A queued message was already
-    leased from [Keeper_chat_queue] — there is no "next turn" for it to ride
-    along with, so true silence here is terminal, not merely deferred. *)
+    failure row via [persist_failure_reply]. A queued message is claimed from
+    [Keeper_chat_queue] at [claim] — there is no later turn for it
+    to ride along with, so true silence after that claim is terminal, not
+    merely deferred. *)
 
 (** {1 Testing helpers} *)
 

--- a/lib/server_keeper_waiting_inventory.ml
+++ b/lib/server_keeper_waiting_inventory.ml
@@ -330,7 +330,7 @@ let chat_queue_persistence_blocked_rows ~base_path keeper_name =
   | Ok (Some status) ->
     let operation =
       match status.Keeper_chat_consumer.operation with
-      | Keeper_chat_consumer.Lease_next_blocked -> "lease_next"
+      | Keeper_chat_consumer.Pending_claim_blocked -> "pending_claim"
       | Keeper_chat_consumer.Finalize_blocked -> "finalize"
       | Keeper_chat_consumer.Nack_blocked -> "nack"
     in

--- a/lib/server_keeper_waiting_inventory.ml
+++ b/lib/server_keeper_waiting_inventory.ml
@@ -332,7 +332,6 @@ let chat_queue_persistence_blocked_rows ~base_path keeper_name =
       match status.Keeper_chat_consumer.operation with
       | Keeper_chat_consumer.Pending_claim_blocked -> "pending_claim"
       | Keeper_chat_consumer.Finalize_blocked -> "finalize"
-      | Keeper_chat_consumer.Nack_blocked -> "nack"
     in
     [ { keeper_name = Some keeper_name
       ; source = Chat_queue_persistence_blocked

--- a/lib/server_keeper_waiting_inventory.ml
+++ b/lib/server_keeper_waiting_inventory.ml
@@ -328,11 +328,6 @@ let chat_queue_persistence_blocked_rows ~base_path keeper_name =
         (`Assoc [ "message", `String message ])
     ]
   | Ok (Some status) ->
-    let operation =
-      match status.Keeper_chat_consumer.operation with
-      | Keeper_chat_consumer.Pending_claim_blocked -> "pending_claim"
-      | Keeper_chat_consumer.Finalize_blocked -> "finalize"
-    in
     [ { keeper_name = Some keeper_name
       ; source = Chat_queue_persistence_blocked
       ; waiting_on = "operator_reconciliation"
@@ -342,8 +337,8 @@ let chat_queue_persistence_blocked_rows ~base_path keeper_name =
       ; next_action = "reconcile_keeper_chat_queue"
       ; detail =
           `Assoc
-            [ "operation", `String operation
-            ; "lease_id", Json_util.string_opt_to_json status.lease_id
+            [ "operation", `String "finalize"
+            ; "lease_id", `String status.lease_id
             ; "error", Keeper_chat_queue.mutation_error_to_json status.error
             ]
       }

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -1892,9 +1892,8 @@ let test_keeper_shutdown_store_isolates_corrupt_owner () =
            (Shutdown_types.Operation_id.equal
               corrupt_operation.operation_id
               operation_id)
-       | `Busy (Masc.Keeper_turn_admission.Turn_busy _)
-       | `Busy (Masc.Keeper_turn_admission.Chat_backlog _)
-       | `Ran () -> fail "corrupt owner admission was reopened");
+       | `Busy (Masc.Keeper_turn_admission.Turn_busy _) | `Ran () ->
+         fail "corrupt owner admission was reopened");
       match Shutdown_runtime.recover_operation ~config recoverable_operation with
       | Ok recovered ->
         check bool
@@ -2347,9 +2346,7 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
            "shutdown admission fence retains operation identity"
            true
            (Shutdown_types.Operation_id.equal operation.operation_id operation_id)
-      | `Busy (Masc.Keeper_turn_admission.Turn_busy _)
-      | `Busy (Masc.Keeper_turn_admission.Chat_backlog _)
-      | `Ran () ->
+      | `Busy (Masc.Keeper_turn_admission.Turn_busy _) | `Ran () ->
          fail "shutdown admission fence reopened before finalization"))
 
 let test_keeper_shutdown_prepare_joins_not_started_lane () =
@@ -2462,11 +2459,7 @@ let test_keeper_shutdown_prepare_failure_rolls_back_fence () =
       | `Busy (Masc.Keeper_turn_admission.Turn_busy _) ->
         fail
           "failed shutdown prepare left the keeper admission fence closed: \
-           Turn_busy owns the slot"
-      | `Busy (Masc.Keeper_turn_admission.Chat_backlog _) ->
-        fail
-          "failed shutdown prepare left the keeper admission fence closed: \
-           chat backlog fences the slot")
+           Turn_busy owns the slot")
 
 let install_pending_summary ~base_path ~keeper_name ~bind_exact =
   Approval_queue.For_testing.reset_runtime_state ();
@@ -2910,9 +2903,8 @@ let test_keeper_shutdown_delivers_dead_tombstone_completion_after_receipt () =
        | `Busy (Masc.Keeper_turn_admission.Shutdown_requested reserved) ->
          check bool "pending receipt retains exact admission owner" true
            (Shutdown_types.Operation_id.equal operation_id reserved)
-       | `Busy (Masc.Keeper_turn_admission.Turn_busy _)
-       | `Busy (Masc.Keeper_turn_admission.Chat_backlog _)
-       | `Ran () -> fail "pending completion reopened admission");
+       | `Busy (Masc.Keeper_turn_admission.Turn_busy _) | `Ran () ->
+         fail "pending completion reopened admission");
       Masc.Keeper_turn_admission.For_testing.reset ();
       let boot_inventory =
         match Shutdown_store.scan_inventory ~config with
@@ -2940,9 +2932,8 @@ let test_keeper_shutdown_delivers_dead_tombstone_completion_after_receipt () =
        | `Busy (Masc.Keeper_turn_admission.Shutdown_requested reserved) ->
          check bool "boot-restored fence keeps exact completion owner" true
            (Shutdown_types.Operation_id.equal operation_id reserved)
-       | `Busy (Masc.Keeper_turn_admission.Turn_busy _)
-       | `Busy (Masc.Keeper_turn_admission.Chat_backlog _)
-       | `Ran () -> fail "boot recovery reopened pending completion admission");
+       | `Busy (Masc.Keeper_turn_admission.Turn_busy _) | `Ran () ->
+         fail "boot recovery reopened pending completion admission");
       Shutdown_finalize.register_completion_handler
         Tombstone_cleanup.handle_completion;
       let finalized =

--- a/test/test_keeper_busy_connector_deferred.ml
+++ b/test/test_keeper_busy_connector_deferred.ml
@@ -33,6 +33,19 @@ let configure_queue ~base =
   check "chat queue persistence configured without load errors" (report.load_errors = [])
 ;;
 
+let claim_pending_head () =
+  match Keeper_chat_queue.observe_pending ~keeper_name with
+  | Ok (Some observation) ->
+    (match Keeper_chat_queue.lease_observed observation with
+     | `Leased lease -> lease
+     | `Stale _ -> failwith "pending source receipt observation became stale"
+     | `Error error ->
+       failwith (Keeper_chat_queue.mutation_error_to_string error))
+  | Ok None -> failwith "pending source receipt is not observable"
+  | Error error ->
+    failwith (Keeper_chat_queue.mutation_error_to_string error)
+;;
+
 let test_exact_source_identity_converges () =
   Printf.printf
     "Test: durable connector acceptance converges on the producer request id\n%!";
@@ -118,21 +131,18 @@ let test_exact_source_identity_converges () =
        let pending = (Keeper_chat_queue.snapshot ~keeper_name).pending in
        check "active replay keeps one FIFO receipt" (List.length pending = 1);
        check "accepted user transcript row is idempotent" (count_user_lines ~base = 1);
-       (match Keeper_chat_queue.lease_next ~keeper_name with
-        | `Leased lease ->
-          ignore
-            (Keeper_chat_queue.finalize
-               ~keeper_name
-               ~lease_id:lease.lease_id
-               ~outcome:
-                 (Keeper_chat_queue.Mark_delivered
-                    { completed_at = Time_compat.now (); outcome_ref = None })
-             : [ `Finalized of Keeper_chat_queue.Receipt_id.t
-               | `Unknown_lease
-               | `Error of Keeper_chat_queue.mutation_error
-               ])
-        | `Empty | `Already_leased _ | `Recovery_required _ | `Error _ ->
-          check "source receipt leases before terminal replay" false);
+       let lease = claim_pending_head () in
+       ignore
+         (Keeper_chat_queue.finalize
+            ~keeper_name
+            ~lease_id:lease.lease_id
+            ~outcome:
+              (Keeper_chat_queue.Mark_delivered
+                 { completed_at = Time_compat.now (); outcome_ref = None })
+          : [ `Finalized of Keeper_chat_queue.Receipt_id.t
+            | `Unknown_lease
+            | `Error of Keeper_chat_queue.mutation_error
+            ]);
        let terminal = request_of_reply (accept metadata) in
        check
          "terminal replay reports done without redispatch"

--- a/test/test_keeper_chat_admission_contention.ml
+++ b/test/test_keeper_chat_admission_contention.ml
@@ -83,8 +83,9 @@ let message content =
   ; user_row_origin = Keeper_chat_store.Already_persisted_upstream
   }
 
-(* Wire the same transition observers the runtime installs, so the consumer is
-   edge-woken on durable queue mutations and on turn-slot release. *)
+(* Wire the same transition observers the runtime installs. Durable queue
+   mutations wake the consumer; a parked chat turn receives the mutex directly,
+   while shutdown rollback explicitly re-arms a rejected Pending receipt. *)
 let install_observers ~base =
   let canonical = Keeper_registry_types.canonical_base_path_exn base in
   Keeper_chat_queue.set_transition_observer
@@ -93,9 +94,13 @@ let install_observers ~base =
           Keeper_chat_consumer.notify_transition ~keeper_name));
   Keeper_turn_admission.set_slot_transition_observer
     (Some
-       (fun ~base_path ~keeper_name ~transition:_ ->
+       (fun ~base_path ~keeper_name ~transition ->
           if String.equal base_path canonical
-          then Keeper_chat_consumer.notify_transition ~keeper_name))
+          then
+            match transition with
+            | Keeper_turn_admission.Shutdown_rolled_back ->
+              Keeper_chat_consumer.notify_transition ~keeper_name
+            | Keeper_turn_admission.Turn_released -> ()))
 
 exception Budget_reached
 
@@ -204,26 +209,6 @@ let run_contention ~base ~clock ~gap_seconds =
   ; max_active_turns = !max_active_turns
   }
 
-let test_back_to_back_autonomous_does_not_starve_chat () =
-  Printf.printf
-    "Test: back-to-back autonomous turns do not starve the queue consumer\n%!";
-  with_env (fun ~base ~clock ->
-    let result = run_contention ~base ~clock ~gap_seconds:0. in
-    check "every receipt was enqueued" (List.length result.enqueued = receipt_count);
-    check
-      (Printf.sprintf
-         "every receipt was admitted (%d/%d)"
-         (List.length result.admitted)
-         receipt_count)
-      (List.length result.admitted = receipt_count);
-    (* The driver must actually have contended, otherwise the test proves
-       nothing about contention. *)
-    check
-      (Printf.sprintf
-         "autonomous lane ran during the test (%d turns)"
-         result.autonomous_turns)
-      (result.autonomous_turns > 0))
-
 let test_heartbeat_shaped_autonomous_does_not_starve_chat () =
   Printf.printf
     "Test: heartbeat-shaped autonomous cycles do not starve the queue consumer\n%!";
@@ -277,6 +262,13 @@ let test_receipts_are_admitted_in_fifo_order () =
     check "every receipt content is admitted in FIFO order"
       (expected_contents = admitted_contents);
     check "every exact receipt delivery key is admitted in FIFO order" keys_match;
+    (* The driver must actually have contended, otherwise the test proves
+       nothing about autonomous overtaking. *)
+    check
+      (Printf.sprintf
+         "autonomous lane ran during the FIFO test (%d turns)"
+         result.autonomous_turns)
+      (result.autonomous_turns > 0);
     check "chat and autonomous turns never overlap in the slot"
       (result.max_active_turns = 1))
 
@@ -367,11 +359,45 @@ let test_queued_server_turn_has_no_second_durable_request () =
            (Keeper_msg_async.For_testing.reserved_request_id_count () = 0);
          check
            "queued server turn owns no durable async request switch"
-           (Keeper_msg_async.For_testing.active_switch_count () = 0)))
+           (Keeper_msg_async.For_testing.active_switch_count () = 0);
+         let invalid_claim_count = ref 0 in
+         let invalid_payload = { payload with name = "" } in
+         let invalid_outcome =
+           Eio.Switch.run (fun execution_sw ->
+             Server_routes_http_keeper_stream.process_single_turn
+               ~user_row_origin:Keeper_chat_store.Already_persisted_upstream
+               ~submission:
+                 (Queued_receipt
+                    { receipt_ids
+                    ; claim =
+                        (fun () ->
+                           incr invalid_claim_count;
+                           Ok ())
+                    ; execution_sw
+                    })
+               ~state
+               ~clock
+               ~auth_token:None
+               ~thread_id:"queued-pre-claim-rejection"
+               ~continuation_channel
+               ~closed:(ref false)
+               ~client_disconnects:None
+               ~payload:invalid_payload
+               ~run_id:"queued-pre-claim-run"
+               ~message_id:"queued-pre-claim-message"
+               ~agent_name:keeper_name
+               ~submitted_by:keeper_name
+               ~events:(Keeper_chat_events.create ()))
+         in
+         check "pre-claim rejection never invokes the claim callback"
+           (!invalid_claim_count = 0);
+         check "pre-claim rejection leaves no queued turn outcome"
+           (invalid_outcome = None);
+         check "pre-claim rejection emits no transcript effect"
+           (Keeper_chat_store.load ~base_dir:base ~keeper_name:"" = [])))
 
 let () =
   Printf.printf "=== keeper chat/autonomous admission contention ===\n%!";
-  test_back_to_back_autonomous_does_not_starve_chat ();
   test_heartbeat_shaped_autonomous_does_not_starve_chat ();
   test_receipts_are_admitted_in_fifo_order ();
   test_queued_server_turn_has_no_second_durable_request ();

--- a/test/test_keeper_chat_admission_contention.ml
+++ b/test/test_keeper_chat_admission_contention.ml
@@ -84,8 +84,8 @@ let message content =
   }
 
 (* Wire the same transition observers the runtime installs. Durable queue
-   mutations wake the consumer; release and shutdown rollback also re-arm a
-   Pending receipt whose preflight ended before it parked on the mutex. *)
+   mutations wake the consumer; release and shutdown rollback re-arm only a
+   Pending receipt whose current attempt has not reached its exact claim. *)
 let install_observers ~base =
   let canonical = Keeper_registry_types.canonical_base_path_exn base in
   Keeper_chat_queue.set_transition_observer
@@ -100,7 +100,9 @@ let install_observers ~base =
             match transition with
             | Keeper_turn_admission.Shutdown_rolled_back
             | Keeper_turn_admission.Turn_released ->
-              Keeper_chat_consumer.notify_transition ~keeper_name
+              Keeper_chat_consumer.notify_slot_transition
+                ~base_path
+                ~keeper_name
           ))
 
 exception Budget_reached

--- a/test/test_keeper_chat_admission_contention.ml
+++ b/test/test_keeper_chat_admission_contention.ml
@@ -84,8 +84,8 @@ let message content =
   }
 
 (* Wire the same transition observers the runtime installs. Durable queue
-   mutations wake the consumer; a parked chat turn receives the mutex directly,
-   while shutdown rollback explicitly re-arms a rejected Pending receipt. *)
+   mutations wake the consumer; release and shutdown rollback also re-arm a
+   Pending receipt whose preflight ended before it parked on the mutex. *)
 let install_observers ~base =
   let canonical = Keeper_registry_types.canonical_base_path_exn base in
   Keeper_chat_queue.set_transition_observer
@@ -98,9 +98,10 @@ let install_observers ~base =
           if String.equal base_path canonical
           then
             match transition with
-            | Keeper_turn_admission.Shutdown_rolled_back ->
+            | Keeper_turn_admission.Shutdown_rolled_back
+            | Keeper_turn_admission.Turn_released ->
               Keeper_chat_consumer.notify_transition ~keeper_name
-            | Keeper_turn_admission.Turn_released -> ()))
+          ))
 
 exception Budget_reached
 

--- a/test/test_keeper_chat_admission_contention.ml
+++ b/test/test_keeper_chat_admission_contention.ml
@@ -11,9 +11,9 @@
    These tests run the production Keeper_chat_consumer control loop against an
    autonomous driver on the same slot. The provider call is the only thing
    replaced: handle_turn calls Keeper_turn_admission.run_serialized, which is
-   what the production handler reaches (keeper_chat_consumer.ml run_leased_turn
-   -> server_bootstrap_loops.ml handle_turn -> ... -> keeper_turn.ml
-   handle_keeper_invocation -> run_serialized).
+   what the production handler reaches (keeper_chat_consumer.ml observes
+   Pending -> server_bootstrap_loops.ml handle_turn -> process_single_turn ->
+   keeper_turn.ml handle_keeper_invocation -> run_serialized -> exact claim).
 
    The starvation cases pin that every queued receipt is admitted. The FIFO
    case additionally compares the exact receipt delivery keys and contents in
@@ -124,15 +124,33 @@ let run_contention ~base ~clock ~gap_seconds =
     max_active_turns := max !max_active_turns !active_turns;
     Fun.protect ~finally:(fun () -> decr active_turns) body
   in
-  let handle_turn ~sw:_ ~keeper_name:_ ~delivery_key ~queued_message =
+  let handle_turn
+      ~sw:_
+      ~keeper_name:_
+      ~receipt_ids
+      ~queued_message
+      ~on_admitted =
+    let delivery_key =
+      Keeper_chat_delivery_identity.Queue_receipts receipt_ids
+    in
     match
       Keeper_turn_admission.run_serialized ~base_path:base ~keeper_name
         (fun () ->
-           with_active_turn (fun () ->
-             admitted := (delivery_key, queued_message) :: !admitted;
-             Eio.Time.sleep clock (turn_seconds /. 2.)))
+           match on_admitted () with
+           | Error detail ->
+             Keeper_chat_consumer.Failed
+               { kind = Keeper_chat_queue.Internal_error
+               ; detail
+               ; outcome_ref = None
+               }
+           | Ok () ->
+             with_active_turn (fun () ->
+               admitted := (delivery_key, queued_message) :: !admitted;
+               Eio.Time.sleep clock (turn_seconds /. 2.));
+             Keeper_chat_consumer.Delivered
+               { outcome_ref = "contention-turn" })
     with
-    | `Ran () -> Keeper_chat_consumer.Delivered { outcome_ref = "contention-turn" }
+    | `Ran outcome -> outcome
     | `Rejected rejection -> Keeper_chat_consumer.Deferred { rejection }
   in
   (try
@@ -243,14 +261,9 @@ let test_receipts_are_admitted_in_fifo_order () =
     let expected_delivery_keys =
       List.map
         (fun ((receipt : Keeper_chat_queue.enqueue_receipt), _) ->
-           match
-             Keeper_chat_delivery_identity.Receipt_ids.of_list
-               [ receipt.Keeper_chat_queue.receipt_id ]
-           with
-           | Ok receipt_ids ->
-             Keeper_chat_delivery_identity.Queue_receipts receipt_ids
-           | Error Keeper_chat_delivery_identity.Receipt_ids.Empty ->
-             failwith "singleton receipt id list cannot be empty")
+           Keeper_chat_delivery_identity.Queue_receipts
+             (Keeper_chat_delivery_identity.Receipt_ids.singleton
+                receipt.Keeper_chat_queue.receipt_id))
         result.enqueued
     in
     let admitted_delivery_keys = List.map fst result.admitted in
@@ -267,11 +280,101 @@ let test_receipts_are_admitted_in_fifo_order () =
     check "chat and autonomous turns never overlap in the slot"
       (result.max_active_turns = 1))
 
+let test_queued_server_turn_has_no_second_durable_request () =
+  Printf.printf
+    "Test: queued server turn reaches exact claim without a second durable request\n%!";
+  with_env (fun ~base ~clock ->
+    Keeper_msg_async.For_testing.clear ();
+    Fun.protect
+      ~finally:Keeper_msg_async.For_testing.clear
+      (fun () ->
+         let claim_count = ref 0 in
+         let continuation_channel =
+           Keeper_continuation_channel.dashboard
+             ~thread_id:"queued-inline-boundary"
+           |> function
+           | Ok channel -> channel
+           | Error detail -> failwith detail
+         in
+         let payload :
+             Server_routes_http_keeper_stream.keeper_chat_stream_request =
+           { name = keeper_name
+           ; message = "queued inline boundary"
+           ; user_blocks = []
+           ; turn_instructions = None
+           ; surface_context = None
+           ; channel = ""
+           ; channel_user_id = ""
+           ; channel_user_name = ""
+           ; channel_workspace_id = ""
+           ; attachments = []
+           }
+         in
+         let receipt_id =
+           match Keeper_chat_queue.enqueue ~keeper_name (message payload.message) with
+           | Ok receipt -> receipt.Keeper_chat_queue.receipt_id
+           | Error error ->
+             failwith (Keeper_chat_queue.mutation_error_to_string error)
+         in
+         let receipt_ids =
+           Keeper_chat_delivery_identity.Receipt_ids.singleton receipt_id
+         in
+         let state = Mcp_server.For_testing.create_state ~base_path:base in
+         let outcome =
+           Eio.Switch.run (fun execution_sw ->
+             Server_routes_http_keeper_stream.process_single_turn
+               ~user_row_origin:Keeper_chat_store.Already_persisted_upstream
+               ~submission:
+                 (Queued_receipt
+                    { receipt_ids
+                    ; claim =
+                        (fun () ->
+                           incr claim_count;
+                           Error "synthetic exact-claim refusal")
+                    ; execution_sw
+                    })
+               ~state
+               ~clock
+               ~auth_token:None
+               ~thread_id:"queued-inline-boundary"
+               ~continuation_channel
+               ~closed:(ref false)
+               ~client_disconnects:None
+               ~payload
+               ~run_id:"queued-inline-run"
+               ~message_id:"queued-inline-message"
+               ~agent_name:keeper_name
+               ~submitted_by:keeper_name
+               ~events:(Keeper_chat_events.create ()))
+         in
+         check "exact Pending claim callback ran once" (!claim_count = 1);
+         check "claim refusal leaves no queued turn outcome" (outcome = None);
+         check
+           "claim refusal leaves the durable receipt Pending"
+           (match Keeper_chat_queue.lookup_receipt ~keeper_name ~receipt_id with
+            | Ok
+                { receipt =
+                    Some { state = Keeper_chat_queue.Pending; _ }
+                ; _
+                } ->
+              true
+            | Ok _ | Error _ -> false);
+         check
+           "claim refusal emits no transcript effect"
+           (Keeper_chat_store.load ~base_dir:base ~keeper_name = []);
+         check
+           "queued server turn reserved no durable async request id"
+           (Keeper_msg_async.For_testing.reserved_request_id_count () = 0);
+         check
+           "queued server turn owns no durable async request switch"
+           (Keeper_msg_async.For_testing.active_switch_count () = 0)))
+
 let () =
   Printf.printf "=== keeper chat/autonomous admission contention ===\n%!";
   test_back_to_back_autonomous_does_not_starve_chat ();
   test_heartbeat_shaped_autonomous_does_not_starve_chat ();
   test_receipts_are_admitted_in_fifo_order ();
+  test_queued_server_turn_has_no_second_durable_request ();
   if !failures > 0
   then (
     Printf.printf "\n%d check(s) failed\n%!" !failures;

--- a/test/test_keeper_chat_coalescing.ml
+++ b/test/test_keeper_chat_coalescing.ml
@@ -600,8 +600,8 @@ let test_transition_observer_outside_lock_exactly_once () =
     (Result.is_ok second && List.length (Keeper_chat_queue.snapshot ~keeper_name).pending = 2);
   check "failing wake observer was invoked exactly once" (!calls = 2)
 
-let test_uncertain_lease_compensates_and_other_transitions_reconcile () =
-  Printf.printf "Test: lease uncertainty compensates; finalize/nack converge exactly\n%!";
+let test_uncertain_lease_compensates_and_finalize_reconciles () =
+  Printf.printf "Test: lease uncertainty compensates; finalize converges exactly\n%!";
   let lease_case base_path =
     let keeper_name = "lease-uncertain" in
     ignore (configure_clean base_path : Keeper_chat_queue.configure_report);
@@ -663,26 +663,7 @@ let test_uncertain_lease_compensates_and_other_transitions_reconcile () =
      | Ok _ | Error _ ->
        check "finalize reconciliation reapplies exact terminal target" false)
   in
-  with_base "keeper-chat-finalize-uncertain" finalize_case;
-  let nack_case base_path =
-    let keeper_name = "nack-uncertain" in
-    ignore (configure_clean base_path : Keeper_chat_queue.configure_report);
-    ignore (enqueue_exn ~keeper_name (message "requeue me") : Keeper_chat_queue.enqueue_receipt);
-    let lease = lease_exn ~keeper_name in
-    Keeper_chat_queue.For_testing.fail_transaction_at_stages [ Commit_returned ];
-    (match Keeper_chat_queue.nack ~keeper_name ~lease_id:lease.lease_id with
-     | `Error
-         (Keeper_chat_queue.Persist_failed
-            { publication = Keeper_chat_queue.Nack_indeterminate _; _ }) ->
-       check "uncertain nack is typed" true
-     | `Requeued _ | `Unknown_lease | `Error _ -> check "uncertain nack is typed" false);
-    (match Keeper_chat_queue.reconcile_persistence ~keeper_name with
-     | Ok { outcome = Reconciled; _ } ->
-       check "nack reconciliation retains Pending"
-         (List.length (Keeper_chat_queue.snapshot ~keeper_name).pending = 1)
-     | Ok _ | Error _ -> check "nack reconciliation retains Pending" false)
-  in
-  with_base "keeper-chat-nack-uncertain" nack_case
+  with_base "keeper-chat-finalize-uncertain" finalize_case
 
 let test_restart_requires_explicit_recovery_without_journal () =
   Printf.printf
@@ -1072,7 +1053,7 @@ let () =
   test_transaction_publication_boundaries ();
   test_commit_observer_exception_and_cancellation ();
   test_transition_observer_outside_lock_exactly_once ();
-  test_uncertain_lease_compensates_and_other_transitions_reconcile ();
+  test_uncertain_lease_compensates_and_finalize_reconciles ();
   test_restart_requires_explicit_recovery_without_journal ();
   test_legacy_json_is_not_a_queue_authority ();
   test_runtime_root_typed_filename_authority ();

--- a/test/test_keeper_chat_coalescing.ml
+++ b/test/test_keeper_chat_coalescing.ml
@@ -72,21 +72,22 @@ let enqueue_with_receipt_exn ~keeper_name ~receipt_id queued =
       (Keeper_chat_queue.mutation_error_to_string error);
     failwith "enqueue_with_receipt failed"
 
-let lease_exn ~keeper_name =
-  match Keeper_chat_queue.lease_next ~keeper_name with
-  | `Leased lease -> lease
-  | `Empty ->
+let observe_exn ~keeper_name =
+  match Keeper_chat_queue.observe_pending ~keeper_name with
+  | Ok (Some observation) -> observation
+  | Ok None ->
     fail "lease succeeds" "queue was empty";
     failwith "empty lease"
-  | `Already_leased lease_id ->
-    fail "lease succeeds" ("outstanding lease " ^ lease_id);
-    failwith "already leased"
-  | `Recovery_required evidence ->
-    fail
-      "lease succeeds"
-      ("recovery required for "
-       ^ Keeper_chat_queue.Receipt_id.to_string evidence.receipt_id);
-    failwith "recovery required"
+  | Error error ->
+    fail "lease succeeds" (Keeper_chat_queue.mutation_error_to_string error);
+    failwith "lease failed"
+
+let lease_exn ~keeper_name =
+  match Keeper_chat_queue.lease_observed (observe_exn ~keeper_name) with
+  | `Leased lease -> lease
+  | `Stale _ ->
+    fail "lease succeeds" "pending observation became stale";
+    failwith "stale pending observation"
   | `Error error ->
     fail "lease succeeds" (Keeper_chat_queue.mutation_error_to_string error);
     failwith "lease failed"
@@ -319,6 +320,85 @@ let test_pending_cancellation_is_state_guarded () =
       | `Error of Keeper_chat_queue.mutation_error
       ])
 
+let test_observed_pending_claim_is_exact () =
+  Printf.printf
+    "Test: observed pending claim follows the exact FIFO receipt\n%!";
+  with_base "keeper-chat-observed-claim" @@ fun base_path ->
+  let keeper_name = "observed-claim" in
+  ignore (configure_clean base_path : Keeper_chat_queue.configure_report);
+  let first = enqueue_exn ~keeper_name (message "first observed") in
+  let first_observation =
+    match Keeper_chat_queue.observe_pending ~keeper_name with
+    | Ok (Some observation) -> observation
+    | Ok None ->
+      check "first pending head is observable" false;
+      failwith "missing first observation"
+    | Error error ->
+      fail
+        "first pending head is observable"
+        (Keeper_chat_queue.mutation_error_to_string error);
+      failwith "failed first observation"
+  in
+  let second = enqueue_exn ~keeper_name (message "second observed") in
+  let first_lease =
+    match Keeper_chat_queue.lease_observed first_observation with
+    | `Leased lease ->
+      check "tail enqueue does not invalidate the observed FIFO head"
+        (Keeper_chat_queue.Receipt_id.equal
+           lease.item.receipt_id
+           first.receipt_id);
+      lease
+    | `Stale _ | `Error _ ->
+      check "tail enqueue does not invalidate the observed FIFO head" false;
+      failwith "failed exact observed lease"
+  in
+  (match
+     Keeper_chat_queue.finalize
+       ~keeper_name
+       ~lease_id:first_lease.lease_id
+       ~outcome:
+         (Mark_delivered { completed_at = 3.0; outcome_ref = None })
+   with
+   | `Finalized receipt_id ->
+     check "first observed receipt finalizes"
+       (Keeper_chat_queue.Receipt_id.equal receipt_id first.receipt_id)
+   | `Unknown_lease | `Error _ ->
+     check "first observed receipt finalizes" false);
+  let second_observation =
+    match Keeper_chat_queue.observe_pending ~keeper_name with
+    | Ok (Some observation) -> observation
+    | Ok None ->
+      check "second pending head is observable" false;
+      failwith "missing second observation"
+    | Error error ->
+      fail
+        "second pending head is observable"
+        (Keeper_chat_queue.mutation_error_to_string error);
+      failwith "failed second observation"
+  in
+  (match
+     Keeper_chat_queue.cancel_pending
+       ~keeper_name
+       ~receipt_id:second.receipt_id
+       ~cancellation:
+         { cancelled_at = 4.0
+         ; detail = "invalidate the observed pending head"
+         }
+   with
+   | Ok _ -> ()
+   | Error error ->
+     fail
+       "second pending receipt cancellation"
+       (Keeper_chat_queue.mutation_error_to_string error));
+  match Keeper_chat_queue.lease_observed second_observation with
+  | `Stale { receipt_id; expected_revision; observed_revision } ->
+    check "cancelled observation reports the exact receipt"
+      (Keeper_chat_queue.Receipt_id.equal receipt_id second.receipt_id);
+    check "stale observation retains its original revision"
+      (Int64.compare expected_revision observed_revision < 0)
+  | `Leased _ | `Error _ ->
+    check "cancelled observation cannot lease another receipt" false
+
 let expect_enqueue_indeterminate label expected_receipt_id = function
   | Error
       (Keeper_chat_queue.Persist_failed
@@ -526,8 +606,9 @@ let test_uncertain_lease_compensates_and_other_transitions_reconcile () =
     let keeper_name = "lease-uncertain" in
     ignore (configure_clean base_path : Keeper_chat_queue.configure_report);
     ignore (enqueue_exn ~keeper_name (message "lease me") : Keeper_chat_queue.enqueue_receipt);
+    let observation = observe_exn ~keeper_name in
     Keeper_chat_queue.For_testing.fail_transaction_at_stages [ Commit_returned ];
-    (match Keeper_chat_queue.lease_next ~keeper_name with
+    (match Keeper_chat_queue.lease_observed observation with
      | `Error
          (Keeper_chat_queue.Persist_failed
             { publication =
@@ -535,7 +616,7 @@ let test_uncertain_lease_compensates_and_other_transitions_reconcile () =
             ; _
             }) ->
        check "uncertain lease is not returned to a consumer" true
-     | `Leased _ | `Empty | `Already_leased _ | `Recovery_required _ | `Error _ ->
+     | `Leased _ | `Stale _ | `Error _ ->
        check "uncertain lease is not returned to a consumer" false);
     (match Keeper_chat_queue.reconcile_persistence ~keeper_name with
      | Ok { outcome = Reconciled; revision = 3L } ->
@@ -543,9 +624,14 @@ let test_uncertain_lease_compensates_and_other_transitions_reconcile () =
      | Ok _ | Error _ ->
        check "uncertain durable lease compensates to Pending" false);
     check "compensated receipt is leaseable again"
-      (match Keeper_chat_queue.lease_next ~keeper_name with
-       | `Leased _ -> true
-       | `Empty | `Already_leased _ | `Recovery_required _ | `Error _ -> false)
+      (match
+         Keeper_chat_queue.observe_pending ~keeper_name
+       with
+       | Ok (Some observation) ->
+         (match Keeper_chat_queue.lease_observed observation with
+          | `Leased _ -> true
+          | `Stale _ | `Error _ -> false)
+       | Ok None | Error _ -> false)
   in
   with_base "keeper-chat-lease-uncertain" lease_case;
   let finalize_case base_path =
@@ -636,21 +722,15 @@ let test_restart_requires_explicit_recovery_without_journal () =
      check "restart preserves exact lease evidence"
        (String.equal evidence.lease_id lease.lease_id)
    | _ -> check "restart preserves exact lease evidence" false);
-  (match Keeper_chat_queue.lease_next ~keeper_name with
-   | `Recovery_required evidence ->
-     check "recovery-required lane cannot auto-redeliver"
-       (Keeper_chat_queue.Receipt_id.equal evidence.receipt_id receipt.receipt_id
-        && String.equal evidence.lease_id lease.lease_id)
-   | `Leased _ | `Empty | `Already_leased _ | `Error _ ->
-     check "recovery-required lane cannot auto-redeliver" false);
+  check "recovery-required lane cannot auto-redeliver"
+    (Keeper_chat_queue.observe_pending ~keeper_name = Ok None);
   let healthy_keeper = "healthy" in
   ignore
     (enqueue_exn ~keeper_name:healthy_keeper (message "independent") :
       Keeper_chat_queue.enqueue_receipt);
-  check "recovery blocks only its Keeper lane"
-    (match Keeper_chat_queue.lease_next ~keeper_name:healthy_keeper with
-     | `Leased _ -> true
-     | `Empty | `Already_leased _ | `Recovery_required _ | `Error _ -> false);
+  ignore
+    (lease_exn ~keeper_name:healthy_keeper : Keeper_chat_queue.lease);
+  check "recovery blocks only its Keeper lane" true;
   (match
      Keeper_chat_queue.resolve_recovery_required
        ~keeper_name
@@ -701,13 +781,10 @@ let test_restart_requires_explicit_recovery_without_journal () =
       | Ok { revision = 4L; state = Pending; _ } ->
         check "exact operator decision requeues once" true
       | Ok _ | Error _ -> check "exact operator decision requeues once" false));
-  (match Keeper_chat_queue.lease_next ~keeper_name with
-   | `Leased replay ->
-     check "explicit requeue preserves receipt identity"
-       (Keeper_chat_queue.Receipt_id.equal
-          replay.item.receipt_id receipt.receipt_id)
-   | `Empty | `Already_leased _ | `Recovery_required _ | `Error _ ->
-     check "explicit requeue preserves receipt identity" false)
+  let replay = lease_exn ~keeper_name in
+  check "explicit requeue preserves receipt identity"
+    (Keeper_chat_queue.Receipt_id.equal
+       replay.item.receipt_id receipt.receipt_id)
 
 let test_legacy_json_is_not_a_queue_authority () =
   Printf.printf "Test: removed legacy JSON is never inspected as queue state\n%!";
@@ -991,6 +1068,7 @@ let () =
   test_lifecycle_fifo_terminal_pk_and_restart ();
   test_preallocated_receipt_convergence ();
   test_pending_cancellation_is_state_guarded ();
+  test_observed_pending_claim_is_exact ();
   test_transaction_publication_boundaries ();
   test_commit_observer_exception_and_cancellation ();
   test_transition_observer_outside_lock_exactly_once ();

--- a/test/test_keeper_chat_consumer_delivery.ml
+++ b/test/test_keeper_chat_consumer_delivery.ml
@@ -353,7 +353,7 @@ let test_structured_cancellation_terminalizes_claimed_receipt () =
                Some
                  { state =
                      Keeper_chat_queue.Failed
-                       { kind = Keeper_chat_queue.Interrupted; detail; _ }
+                       { kind = Keeper_chat_queue.Cancelled; detail; _ }
                  ; receipt_id
                  }
            ; _

--- a/test/test_keeper_chat_consumer_delivery.ml
+++ b/test/test_keeper_chat_consumer_delivery.ml
@@ -84,6 +84,21 @@ let await_promise ~clock ~seconds promise =
       Eio.Time.sleep clock seconds;
       false)
 
+let await_condition ~clock ~seconds condition =
+  Eio.Fiber.first
+    (fun () ->
+      let rec loop () =
+        if condition ()
+        then true
+        else (
+          Eio.Time.sleep clock 0.01;
+          loop ())
+      in
+      loop ())
+    (fun () ->
+      Eio.Time.sleep clock seconds;
+      false)
+
 let await_receipt ~clock ~seconds ~keeper_name ~receipt_id ~accept =
   Eio.Fiber.first
     (fun () ->
@@ -176,8 +191,39 @@ let start_consumer ~sw ~clock ~base_path ~handle_turn =
        (fun ~base_path:transition_base_path ~keeper_name ~transition:_ ->
           if String.equal transition_base_path canonical_base_path
           then Keeper_chat_consumer.notify_transition ~keeper_name));
+  let handle_admitted_turn
+      ~sw
+      ~keeper_name
+      ~receipt_ids
+      ~queued_message
+      ~on_admitted =
+    let delivery_key =
+      Keeper_chat_delivery_identity.Queue_receipts receipt_ids
+    in
+    match
+      Keeper_turn_admission.run_serialized
+        ~base_path
+        ~keeper_name
+        (fun () ->
+           match on_admitted () with
+           | Ok () ->
+             handle_turn ~sw ~keeper_name ~delivery_key ~queued_message
+           | Error detail ->
+             Keeper_chat_consumer.Failed
+               { kind = Keeper_chat_queue.Internal_error
+               ; detail
+               ; outcome_ref = None
+               })
+    with
+    | `Ran outcome -> outcome
+    | `Rejected rejection -> Keeper_chat_consumer.Deferred { rejection }
+  in
   Eio.Fiber.fork ~sw (fun () ->
-    Keeper_chat_consumer.run ~sw ~clock ~base_path ~handle_turn)
+    Keeper_chat_consumer.run
+      ~sw
+      ~clock
+      ~base_path
+      ~handle_turn:handle_admitted_turn)
 
 exception Stop_consumer
 
@@ -489,8 +535,36 @@ let test_busy_turn_release_wakes_pending_receipt () =
       with
       | None -> Eio.Promise.resolve resolve_release_holder ()
       | Some accepted ->
-        Eio.Fiber.yield ();
+        check "consumer parks on the held turn slot"
+          (await_condition ~clock ~seconds:5.0 (fun () ->
+             Keeper_turn_admission.chat_waiting
+               ~base_path:base
+               ~keeper_name));
         check "consumer never crosses the held turn slot" (!calls = 0);
+        check "parked receipt remains Pending before execution admission"
+          (match
+             Keeper_chat_queue.lookup_receipt
+               ~keeper_name
+               ~receipt_id:accepted.receipt_id
+           with
+           | Ok { receipt = Some { state = Pending; _ }; _ } -> true
+           | Ok
+               { receipt =
+                   None
+                   | Some
+                       { state =
+                           Inflight _
+                           | Recovery_required _
+                           | Delivered _
+                           | Failed _
+                       ; _
+                       }
+               ; _
+               }
+           | Error _ -> false);
+        let waiting_snapshot = Keeper_chat_queue.snapshot ~keeper_name in
+        check "parking does not publish an inflight receipt"
+          (waiting_snapshot.inflight = []);
         Eio.Promise.resolve resolve_release_holder ();
         check "turn release dispatches without fleet polling"
           (match
@@ -500,6 +574,148 @@ let test_busy_turn_release_wakes_pending_receipt () =
            | Some _ -> true
            | None -> false));
     check "busy receipt is delivered exactly once" (!calls = 1))
+
+let test_consumer_cancellation_while_parked_keeps_pending () =
+  Printf.printf
+    "Test: cancelling a parked consumer leaves the exact receipt Pending\n%!";
+  with_env (fun ~base ~clock ->
+    let holder_started, resolve_holder_started = Eio.Promise.create () in
+    let release_holder, resolve_release_holder = Eio.Promise.create () in
+    Eio.Switch.run (fun holder_sw ->
+      Eio.Fiber.fork ~sw:holder_sw (fun () ->
+        ignore
+          (Keeper_turn_admission.run_serialized
+             ~base_path:base
+             ~keeper_name
+             (fun () ->
+                Eio.Promise.resolve resolve_holder_started ();
+                Eio.Promise.await release_holder)
+            : [ `Ran of unit | `Rejected of Keeper_turn_admission.rejection ]));
+      check "cancellation holder owns the lane"
+        (await_promise ~clock ~seconds:5.0 holder_started);
+      match
+        enqueue_checked ~label:"parked cancellation enqueue" ~keeper_name
+          (discord_msg ~content:"stay pending when consumer stops"
+             ~channel_id:"channel-parked-cancel"
+             ~user_id:"user-parked-cancel" ~timestamp:6.3)
+      with
+      | None -> Eio.Promise.resolve resolve_release_holder ()
+      | Some accepted ->
+        let calls = ref 0 in
+        let handle_turn ~sw:_ ~keeper_name:_ ~delivery_key:_ ~queued_message:_ =
+          incr calls;
+          Keeper_chat_consumer.Delivered
+            { outcome_ref = "must-not-run-before-admission" }
+        in
+        with_consumer_switch (fun sw ->
+          start_consumer ~sw ~clock ~base_path:base ~handle_turn;
+          check "consumer parks before cancellation"
+            (await_condition ~clock ~seconds:5.0 (fun () ->
+               Keeper_turn_admission.chat_waiting
+                 ~base_path:base
+                 ~keeper_name)));
+        check "cancelled waiter is removed from the mutex queue"
+          (not
+             (Keeper_turn_admission.chat_waiting
+                ~base_path:base
+                ~keeper_name));
+        check "cancellation before admission invokes no queued turn" (!calls = 0);
+        check "cancellation before admission preserves Pending"
+          (match
+             Keeper_chat_queue.lookup_receipt
+               ~keeper_name
+               ~receipt_id:accepted.receipt_id
+           with
+           | Ok { receipt = Some { state = Pending; _ }; _ } -> true
+           | Ok
+               { receipt =
+                   None
+                   | Some
+                       { state =
+                           Inflight _
+                           | Recovery_required _
+                           | Delivered _
+                           | Failed _
+                       ; _
+                       }
+               ; _
+               }
+           | Error _ -> false);
+        Eio.Promise.resolve resolve_release_holder ()))
+
+let test_pending_cancellation_while_parked_releases_empty_slot () =
+  Printf.printf
+    "Test: cancelling the pending head while parked releases an empty slot\n%!";
+  with_env (fun ~base ~clock ->
+    let holder_started, resolve_holder_started = Eio.Promise.create () in
+    let release_holder, resolve_release_holder = Eio.Promise.create () in
+    let calls = ref 0 in
+    let handle_turn ~sw:_ ~keeper_name:_ ~delivery_key:_ ~queued_message:_ =
+      incr calls;
+      Keeper_chat_consumer.Delivered
+        { outcome_ref = "must-not-run-after-pending-cancel" }
+    in
+    with_consumer_switch (fun sw ->
+      Eio.Fiber.fork ~sw (fun () ->
+        ignore
+          (Keeper_turn_admission.run_serialized
+             ~base_path:base
+             ~keeper_name
+             (fun () ->
+                Eio.Promise.resolve resolve_holder_started ();
+                Eio.Promise.await release_holder)
+            : [ `Ran of unit | `Rejected of Keeper_turn_admission.rejection ]));
+      check "empty-queue holder owns the lane"
+        (await_promise ~clock ~seconds:5.0 holder_started);
+      start_consumer ~sw ~clock ~base_path:base ~handle_turn;
+      match
+        enqueue_checked ~label:"parked pending cancellation enqueue" ~keeper_name
+          (discord_msg ~content:"cancel before admission"
+             ~channel_id:"channel-pending-cancel"
+             ~user_id:"user-pending-cancel" ~timestamp:6.4)
+      with
+      | None -> Eio.Promise.resolve resolve_release_holder ()
+      | Some accepted ->
+        check "consumer parks before pending cancellation"
+          (await_condition ~clock ~seconds:5.0 (fun () ->
+             Keeper_turn_admission.chat_waiting
+               ~base_path:base
+               ~keeper_name));
+        (match
+           Keeper_chat_queue.cancel_pending
+             ~keeper_name
+             ~receipt_id:accepted.receipt_id
+             ~cancellation:
+               { cancelled_at = 6.5
+               ; detail = "cancelled while waiting for Keeper admission"
+               }
+         with
+         | Ok { state = Failed { kind = Cancelled; _ }; _ } ->
+           check "pending cancellation commits a terminal receipt" true
+         | Ok _ | Error _ ->
+           check "pending cancellation commits a terminal receipt" false);
+        Eio.Promise.resolve resolve_release_holder ();
+        check "stale parked observation releases the turn slot"
+          (await_condition ~clock ~seconds:5.0 (fun () ->
+             let snapshot =
+               Keeper_turn_admission.snapshot_for
+                 ~base_path:base
+                 ~keeper_name
+             in
+             Option.is_none snapshot.snapshot_in_flight
+             && not
+                  (Keeper_turn_admission.chat_waiting
+                     ~base_path:base
+                     ~keeper_name)));
+        check "cancelled pending head never reaches the turn handler" (!calls = 0);
+        (match
+           Keeper_turn_admission.run_if_free
+             ~base_path:base
+             ~keeper_name
+             (fun () -> ())
+         with
+         | `Ran () -> check "empty lane admits autonomous work again" true
+         | `Busy _ -> check "empty lane admits autonomous work again" false)))
 
 let test_invalid_delivered_turn_ref_fails_closed () =
   Printf.printf
@@ -674,68 +890,6 @@ let test_shutdown_fence_keeps_receipt_pending_until_rollback () =
       check_terminal_snapshot ~label:"shutdown rollback" ~keeper_name
         ~receipt_id:accepted.receipt_id)
 
-let test_typed_admission_race_nacks_then_retries () =
-  Printf.printf
-    "Test: typed admission race nacks the lease and retries without Failed\n%!";
-  with_env (fun ~base ~clock ->
-    match
-      enqueue_checked ~label:"typed deferral enqueue" ~keeper_name
-        (discord_msg ~content:"retry typed deferral"
-           ~channel_id:"channel-deferral" ~user_id:"user-deferral"
-           ~timestamp:10.0)
-    with
-    | None -> ()
-    | Some accepted ->
-      let operation_id = Keeper_shutdown_types.Operation_id.generate () in
-      let calls = ref 0 in
-      let first_deferred, resolve_first_deferred = Eio.Promise.create () in
-      let second_started, resolve_second_started = Eio.Promise.create () in
-      let release_second, resolve_release_second = Eio.Promise.create () in
-      let handle_turn ~sw:_ ~keeper_name:_ ~delivery_key:_ ~queued_message:_ =
-        incr calls;
-        if !calls = 1
-        then (
-          Eio.Promise.resolve resolve_first_deferred ();
-          Keeper_chat_consumer.Deferred
-            { rejection =
-                { Keeper_turn_admission.waiting = 0
-                ; in_flight = None
-                ; shutdown_operation_id = Some operation_id
-                }
-            })
-        else (
-          Eio.Promise.resolve resolve_second_started ();
-          Eio.Promise.await release_second;
-          Keeper_chat_consumer.Delivered
-            { outcome_ref = "trace-typed-deferral#2" })
-      in
-      with_consumer_switch (fun sw ->
-        start_consumer ~sw ~clock ~base_path:base ~handle_turn;
-        check "first leased attempt returns typed Deferred"
-          (await_promise ~clock ~seconds:5.0 first_deferred);
-        check "typed Deferred returns the same receipt to Pending"
-          (match
-             await_receipt ~clock ~seconds:2.0 ~keeper_name
-               ~receipt_id:accepted.receipt_id ~accept:is_pending
-           with
-           | Some _ -> true
-           | None -> false);
-        check "typed Deferred never creates a terminal Failed receipt"
-          (not (receipt_id_is_terminal ~keeper_name accepted.receipt_id));
-        check "consumer retries the same receipt after deferral"
-          (await_promise ~clock ~seconds:5.0 second_started);
-        Eio.Promise.resolve resolve_release_second ();
-        check "retried receipt reaches Delivered"
-          (match
-             await_receipt ~clock ~seconds:5.0 ~keeper_name
-               ~receipt_id:accepted.receipt_id ~accept:is_delivered
-           with
-           | Some _ -> true
-           | None -> false));
-      check "typed deferral causes one retry and no duplicate turn" (!calls = 2);
-      check_terminal_snapshot ~label:"typed deferral retry" ~keeper_name
-        ~receipt_id:accepted.receipt_id)
-
 let () =
   test_delivery_finalizes_terminal_receipt ();
   test_explicit_failure_finalizes_failed_receipt ();
@@ -743,10 +897,11 @@ let () =
   test_dispatch_is_concurrent_per_keeper ();
   test_finalization_persistence_retry_does_not_redeliver ();
   test_busy_turn_release_wakes_pending_receipt ();
+  test_consumer_cancellation_while_parked_keeps_pending ();
+  test_pending_cancellation_while_parked_releases_empty_slot ();
   test_invalid_delivered_turn_ref_fails_closed ();
   test_invalid_delivery_diagnostic_does_not_block_lane ();
   test_shutdown_fence_keeps_receipt_pending_until_rollback ();
-  test_typed_admission_race_nacks_then_retries ();
   if !failures > 0
   then (
     Printf.printf "FAILED: %d check(s)\n%!" !failures;

--- a/test/test_keeper_chat_consumer_delivery.ml
+++ b/test/test_keeper_chat_consumer_delivery.ml
@@ -193,7 +193,13 @@ let start_consumer ~sw ~clock ~base_path ~handle_turn =
           then
             match transition with
             | Keeper_turn_admission.Shutdown_rolled_back ->
-              Keeper_chat_consumer.notify_transition ~keeper_name
+              (match
+                 Keeper_chat_consumer.notify_explicit_retry
+                   ~base_path:transition_base_path
+                   ~keeper_name
+               with
+               | Ok () -> ()
+               | Error error -> fail error)
             | Keeper_turn_admission.Turn_released -> ()));
   let handle_admitted_turn
       ~sw
@@ -516,9 +522,9 @@ let test_finalization_persistence_retry_does_not_redeliver () =
       check_terminal_snapshot ~label:"retried finalization" ~keeper_name
         ~receipt_id:accepted.receipt_id)
 
-let test_claim_commit_uncertainty_waits_for_new_revision () =
+let test_claim_commit_uncertainty_waits_for_explicit_retry () =
   Printf.printf
-    "Test: claim commit uncertainty waits for a new durable revision\n%!";
+    "Test: claim commit uncertainty waits for an explicit retry\n%!";
   with_env (fun ~base ~clock ->
     match
       enqueue_checked ~label:"claim uncertainty enqueue" ~keeper_name
@@ -546,8 +552,10 @@ let test_claim_commit_uncertainty_waits_for_new_revision () =
                (function
                  | Keeper_chat_queue.For_testing.Commit_invoked ->
                    incr commit_attempts;
-                   Keeper_chat_queue.For_testing.fail_next_commit_with
-                     Commit_busy
+                   if !commit_attempts = 1
+                   then
+                     Keeper_chat_queue.For_testing.fail_next_commit_with
+                       Commit_busy
                  | Transaction_begun
                  | Mutation_applied
                  | Before_commit
@@ -586,29 +594,21 @@ let test_claim_commit_uncertainty_waits_for_new_revision () =
                    }
                | Error _ -> false);
             Keeper_chat_queue.For_testing.set_transaction_stage_observer None;
-            match
-              enqueue_checked ~label:"claim retry revision enqueue" ~keeper_name
-                (discord_msg ~content:"advance durable revision"
-                   ~channel_id:"channel-claim-retry"
-                   ~user_id:"user-claim-retry" ~timestamp:6.2)
-            with
-            | None -> ()
-            | Some second ->
-              check "new revision re-arms the original Pending receipt"
-                (match
-                   await_receipt ~clock ~seconds:5.0 ~keeper_name
-                     ~receipt_id:first.receipt_id ~accept:is_delivered
-                 with
-                 | Some _ -> true
-                 | None -> false);
-              check "the receipt behind it also drains"
-                (match
-                   await_receipt ~clock ~seconds:5.0 ~keeper_name
-                     ~receipt_id:second.receipt_id ~accept:is_delivered
-                 with
-                 | Some _ -> true
-                 | None -> false));
-          check "each committed receipt runs exactly once" (!turns = 2)))
+            (match
+               Keeper_chat_consumer.notify_explicit_retry
+                 ~base_path:base
+                 ~keeper_name
+             with
+             | Ok () -> ()
+             | Error error -> fail error);
+            check "explicit retry re-arms the original Pending receipt"
+              (match
+                 await_receipt ~clock ~seconds:5.0 ~keeper_name
+                   ~receipt_id:first.receipt_id ~accept:is_delivered
+               with
+               | Some _ -> true
+               | None -> false));
+          check "the committed receipt runs exactly once" (!turns = 1)))
 
 let test_busy_turn_hands_mutex_to_pending_receipt () =
   Printf.printf
@@ -1007,7 +1007,7 @@ let () =
   test_structured_cancellation_terminalizes_claimed_receipt ();
   test_dispatch_is_concurrent_per_keeper ();
   test_finalization_persistence_retry_does_not_redeliver ();
-  test_claim_commit_uncertainty_waits_for_new_revision ();
+  test_claim_commit_uncertainty_waits_for_explicit_retry ();
   test_busy_turn_hands_mutex_to_pending_receipt ();
   test_consumer_cancellation_while_parked_keeps_pending ();
   test_pending_cancellation_while_parked_reobserves_next_receipt ();

--- a/test/test_keeper_chat_consumer_delivery.ml
+++ b/test/test_keeper_chat_consumer_delivery.ml
@@ -317,8 +317,8 @@ let test_explicit_failure_finalizes_failed_receipt () =
       check_terminal_snapshot ~label:"explicit failure" ~keeper_name
         ~receipt_id:accepted.receipt_id)
 
-let test_structured_cancellation_nacks_and_preserves_receipt () =
-  Printf.printf "Test: structured cancellation nacks the unchanged receipt\n%!";
+let test_structured_cancellation_terminalizes_claimed_receipt () =
+  Printf.printf "Test: structured cancellation terminalizes the claimed receipt\n%!";
   with_env (fun ~base ~clock ->
     match
       enqueue_checked ~label:"cancellation enqueue" ~keeper_name
@@ -349,30 +349,43 @@ let test_structured_cancellation_nacks_and_preserves_receipt () =
            ~receipt_id:accepted.receipt_id
        with
        | Ok
-           { receipt = Some { state = Keeper_chat_queue.Pending; receipt_id }
+           { receipt =
+               Some
+                 { state =
+                     Keeper_chat_queue.Failed
+                       { kind = Keeper_chat_queue.Interrupted; detail; _ }
+                 ; receipt_id
+                 }
            ; _
            } ->
          check "cancellation preserves the accepted receipt id"
-           (Keeper_chat_queue.Receipt_id.equal receipt_id accepted.receipt_id)
+           (Keeper_chat_queue.Receipt_id.equal receipt_id accepted.receipt_id);
+         check "cancellation records unknown external effect"
+           (String.equal detail
+              "Keeper stopped before this claimed turn completed; its external effect is unknown.")
        | Ok
            { receipt =
                Some
                  { state =
-                     Inflight _ | Recovery_required _ | Delivered _ | Failed _
+                     Pending
+                     | Inflight _
+                     | Recovery_required _
+                     | Delivered _
+                     | Failed _
                  ; _
                  }
              | None
            ; _
            }
        | Error _ ->
-         check "cancellation returns the receipt to Pending" false);
+         check "cancellation terminalizes the claimed receipt" false);
       let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
-      check "cancelled receipt remains pending"
-        (receipt_id_in_active accepted.receipt_id snapshot.pending);
+      check "cancelled receipt is not pending"
+        (not (receipt_id_in_active accepted.receipt_id snapshot.pending));
       check "cancelled receipt is not left inflight"
         (not (receipt_id_in_active accepted.receipt_id snapshot.inflight));
-      check "cancelled receipt is not terminal"
-        (not (receipt_id_is_terminal ~keeper_name accepted.receipt_id)))
+      check "cancelled receipt is terminal"
+        (receipt_id_is_terminal ~keeper_name accepted.receipt_id))
 
 let test_dispatch_is_concurrent_per_keeper () =
   Printf.printf "Test: queued turns dispatch concurrently across keepers\n%!";
@@ -893,7 +906,7 @@ let test_shutdown_fence_keeps_receipt_pending_until_rollback () =
 let () =
   test_delivery_finalizes_terminal_receipt ();
   test_explicit_failure_finalizes_failed_receipt ();
-  test_structured_cancellation_nacks_and_preserves_receipt ();
+  test_structured_cancellation_terminalizes_claimed_receipt ();
   test_dispatch_is_concurrent_per_keeper ();
   test_finalization_persistence_retry_does_not_redeliver ();
   test_busy_turn_release_wakes_pending_receipt ();

--- a/test/test_keeper_chat_consumer_delivery.ml
+++ b/test/test_keeper_chat_consumer_delivery.ml
@@ -199,7 +199,8 @@ let start_consumer ~sw ~clock ~base_path ~handle_turn =
                    ~keeper_name
                with
                | Ok () -> ()
-               | Error error -> fail error)
+               | Error error ->
+                 check_failure "shutdown rollback explicit retry" error)
             | Keeper_turn_admission.Turn_released -> ()));
   let handle_admitted_turn
       ~sw
@@ -600,7 +601,8 @@ let test_claim_commit_uncertainty_waits_for_explicit_retry () =
                  ~keeper_name
              with
              | Ok () -> ()
-             | Error error -> fail error);
+             | Error error ->
+               check_failure "explicit pending-claim retry" error);
             check "explicit retry re-arms the original Pending receipt"
               (match
                  await_receipt ~clock ~seconds:5.0 ~keeper_name

--- a/test/test_keeper_chat_consumer_delivery.ml
+++ b/test/test_keeper_chat_consumer_delivery.ml
@@ -188,9 +188,13 @@ let start_consumer ~sw ~clock ~base_path ~handle_turn =
           Keeper_chat_consumer.notify_transition ~keeper_name));
   Keeper_turn_admission.set_slot_transition_observer
     (Some
-       (fun ~base_path:transition_base_path ~keeper_name ~transition:_ ->
+       (fun ~base_path:transition_base_path ~keeper_name ~transition ->
           if String.equal transition_base_path canonical_base_path
-          then Keeper_chat_consumer.notify_transition ~keeper_name));
+          then
+            match transition with
+            | Keeper_turn_admission.Shutdown_rolled_back ->
+              Keeper_chat_consumer.notify_transition ~keeper_name
+            | Keeper_turn_admission.Turn_released -> ()));
   let handle_admitted_turn
       ~sw
       ~keeper_name
@@ -348,21 +352,18 @@ let test_structured_cancellation_terminalizes_claimed_receipt () =
          Keeper_chat_queue.lookup_receipt ~keeper_name
            ~receipt_id:accepted.receipt_id
        with
-       | Ok
+         | Ok
            { receipt =
                Some
                  { state =
                      Keeper_chat_queue.Failed
-                       { kind = Keeper_chat_queue.Cancelled; detail; _ }
+                       { kind = Keeper_chat_queue.Cancelled; _ }
                  ; receipt_id
                  }
            ; _
            } ->
          check "cancellation preserves the accepted receipt id"
-           (Keeper_chat_queue.Receipt_id.equal receipt_id accepted.receipt_id);
-         check "cancellation records unknown external effect"
-           (String.equal detail
-              "Keeper stopped before this claimed turn completed; its external effect is unknown.")
+           (Keeper_chat_queue.Receipt_id.equal receipt_id accepted.receipt_id)
        | Ok
            { receipt =
                Some
@@ -515,9 +516,9 @@ let test_finalization_persistence_retry_does_not_redeliver () =
       check_terminal_snapshot ~label:"retried finalization" ~keeper_name
         ~receipt_id:accepted.receipt_id)
 
-let test_busy_turn_release_wakes_pending_receipt () =
+let test_busy_turn_hands_mutex_to_pending_receipt () =
   Printf.printf
-    "Test: a busy-turn release wakes the exact pending Keeper lane\n%!";
+    "Test: a busy turn hands its mutex to the exact pending Keeper lane\n%!";
   with_env (fun ~base ~clock ->
     let holder_started, resolve_holder_started = Eio.Promise.create () in
     let release_holder, resolve_release_holder = Eio.Promise.create () in
@@ -579,7 +580,7 @@ let test_busy_turn_release_wakes_pending_receipt () =
         check "parking does not publish an inflight receipt"
           (waiting_snapshot.inflight = []);
         Eio.Promise.resolve resolve_release_holder ();
-        check "turn release dispatches without fleet polling"
+        check "mutex handoff dispatches without fleet polling"
           (match
              await_receipt ~clock ~seconds:5.0 ~keeper_name
                ~receipt_id:accepted.receipt_id ~accept:is_delivered
@@ -656,9 +657,9 @@ let test_consumer_cancellation_while_parked_keeps_pending () =
            | Error _ -> false);
         Eio.Promise.resolve resolve_release_holder ()))
 
-let test_stale_parked_observation_rearms_next_pending_receipt () =
+let test_pending_cancellation_while_parked_reobserves_next_receipt () =
   Printf.printf
-    "Test: a stale parked observation rearms the next pending receipt\n%!";
+    "Test: cancelling the pending head while parked dispatches the next receipt\n%!";
   with_env (fun ~base ~clock ->
     let holder_started, resolve_holder_started = Eio.Promise.create () in
     let release_holder, resolve_release_holder = Eio.Promise.create () in
@@ -668,8 +669,7 @@ let test_stale_parked_observation_rearms_next_pending_receipt () =
         ~(queued_message : Keeper_chat_queue.queued_message) =
       incr calls;
       handled_content := Some queued_message.content;
-      Keeper_chat_consumer.Delivered
-        { outcome_ref = "trace-stale-rearm#1" }
+      Keeper_chat_consumer.Delivered { outcome_ref = "trace-next#4" }
     in
     with_consumer_switch (fun sw ->
       Eio.Fiber.fork ~sw (fun () ->
@@ -697,12 +697,6 @@ let test_stale_parked_observation_rearms_next_pending_receipt () =
              Keeper_turn_admission.chat_waiting
                ~base_path:base
                ~keeper_name));
-        (* Isolate the consumer's stale-observation recovery edge: both
-           production observers are deliberately silent after the consumer
-           has parked, so only [run_observed_turn]'s typed [Claim_stale]
-           transition can schedule the replacement receipt. *)
-        Keeper_chat_queue.set_transition_observer None;
-        Keeper_turn_admission.set_slot_transition_observer None;
         (match
            Keeper_chat_queue.cancel_pending
              ~keeper_name
@@ -716,27 +710,29 @@ let test_stale_parked_observation_rearms_next_pending_receipt () =
            check "pending cancellation commits a terminal receipt" true
          | Ok _ | Error _ ->
            check "pending cancellation commits a terminal receipt" false);
-        (match
-           enqueue_checked ~label:"stale replacement enqueue" ~keeper_name
-             (discord_msg ~content:"run after stale head"
-                ~channel_id:"channel-stale-replacement"
-                ~user_id:"user-stale-replacement" ~timestamp:6.6)
-         with
-         | None -> Eio.Promise.resolve resolve_release_holder ()
-         | Some replacement ->
-           Eio.Promise.resolve resolve_release_holder ();
-           check "stale observation rearms the replacement receipt"
+        let next_receipt =
+          enqueue_checked ~label:"post-cancellation enqueue" ~keeper_name
+            (discord_msg ~content:"run after stale observation"
+               ~channel_id:"channel-after-stale"
+               ~user_id:"user-after-stale" ~timestamp:6.6)
+        in
+        check "cancelled pending head never reaches the turn handler" (!calls = 0);
+        Eio.Promise.resolve resolve_release_holder ();
+        (match next_receipt with
+         | None -> check "next receipt is accepted" false
+         | Some next ->
+           check "next receipt is delivered after the stale observation"
              (match
                 await_receipt ~clock ~seconds:5.0 ~keeper_name
-                  ~receipt_id:replacement.receipt_id ~accept:is_delivered
+                  ~receipt_id:next.receipt_id ~accept:is_delivered
               with
               | Some _ -> true
               | None -> false);
-           check "cancelled head never reaches the turn handler" (!calls = 1);
-           check "only the replacement content is handled"
-             (!handled_content = Some "run after stale head");
-           check_terminal_snapshot ~label:"stale replacement" ~keeper_name
-             ~receipt_id:replacement.receipt_id)))
+           check_terminal_snapshot ~label:"post-cancellation next receipt"
+             ~keeper_name ~receipt_id:next.receipt_id);
+        check "only the next receipt reaches the turn handler" (!calls = 1);
+        check "only the next receipt content is handled"
+          (!handled_content = Some "run after stale observation")))
 
 let test_invalid_delivered_turn_ref_fails_closed () =
   Printf.printf
@@ -917,9 +913,9 @@ let () =
   test_structured_cancellation_terminalizes_claimed_receipt ();
   test_dispatch_is_concurrent_per_keeper ();
   test_finalization_persistence_retry_does_not_redeliver ();
-  test_busy_turn_release_wakes_pending_receipt ();
+  test_busy_turn_hands_mutex_to_pending_receipt ();
   test_consumer_cancellation_while_parked_keeps_pending ();
-  test_stale_parked_observation_rearms_next_pending_receipt ();
+  test_pending_cancellation_while_parked_reobserves_next_receipt ();
   test_invalid_delivered_turn_ref_fails_closed ();
   test_invalid_delivery_diagnostic_does_not_block_lane ();
   test_shutdown_fence_keeps_receipt_pending_until_rollback ();

--- a/test/test_keeper_chat_consumer_delivery.ml
+++ b/test/test_keeper_chat_consumer_delivery.ml
@@ -664,7 +664,8 @@ let test_stale_parked_observation_rearms_next_pending_receipt () =
     let release_holder, resolve_release_holder = Eio.Promise.create () in
     let calls = ref 0 in
     let handled_content = ref None in
-    let handle_turn ~sw:_ ~keeper_name:_ ~delivery_key:_ ~queued_message =
+    let handle_turn ~sw:_ ~keeper_name:_ ~delivery_key:_
+        ~(queued_message : Keeper_chat_queue.queued_message) =
       incr calls;
       handled_content := Some queued_message.content;
       Keeper_chat_consumer.Delivered

--- a/test/test_keeper_chat_consumer_delivery.ml
+++ b/test/test_keeper_chat_consumer_delivery.ml
@@ -516,6 +516,100 @@ let test_finalization_persistence_retry_does_not_redeliver () =
       check_terminal_snapshot ~label:"retried finalization" ~keeper_name
         ~receipt_id:accepted.receipt_id)
 
+let test_claim_commit_uncertainty_waits_for_new_revision () =
+  Printf.printf
+    "Test: claim commit uncertainty waits for a new durable revision\n%!";
+  with_env (fun ~base ~clock ->
+    match
+      enqueue_checked ~label:"claim uncertainty enqueue" ~keeper_name
+        (discord_msg ~content:"wait after uncertain claim"
+           ~channel_id:"channel-claim-uncertain"
+           ~user_id:"user-claim-uncertain" ~timestamp:6.1)
+    with
+    | None -> ()
+    | Some first ->
+      let commit_attempts = ref 0 in
+      let turns = ref 0 in
+      let handle_turn ~sw:_ ~keeper_name:_ ~delivery_key:_ ~queued_message:_ =
+        incr turns;
+        Keeper_chat_consumer.Delivered
+          { outcome_ref =
+              Printf.sprintf "trace-claim-revision#%d" !turns
+          }
+      in
+      Fun.protect
+        ~finally:(fun () ->
+          Keeper_chat_queue.For_testing.set_transaction_stage_observer None)
+        (fun () ->
+          Keeper_chat_queue.For_testing.set_transaction_stage_observer
+            (Some
+               (function
+                 | Keeper_chat_queue.For_testing.Commit_invoked ->
+                   incr commit_attempts;
+                   Keeper_chat_queue.For_testing.fail_next_commit_with
+                     Commit_busy
+                 | Transaction_begun
+                 | Mutation_applied
+                 | Before_commit
+                 | Commit_returned
+                 | Before_rollback
+                 | Before_close ->
+                   ()));
+          with_consumer_switch (fun sw ->
+            start_consumer ~sw ~clock ~base_path:base ~handle_turn;
+            check "uncertain claim reaches COMMIT"
+              (await_condition ~clock ~seconds:5.0 (fun () ->
+                 !commit_attempts >= 1));
+            Eio.Time.sleep clock 0.2;
+            check "same-revision invalidations do not retry the claim"
+              (!commit_attempts = 1);
+            check "turn body does not run before a committed claim" (!turns = 0);
+            check "uncertain claim reconciles back to Pending"
+              (match
+                 Keeper_chat_queue.lookup_receipt
+                   ~keeper_name
+                   ~receipt_id:first.receipt_id
+               with
+               | Ok { receipt = Some { state = Pending; _ }; _ } -> true
+               | Ok
+                   { receipt =
+                       None
+                       | Some
+                           { state =
+                               Inflight _
+                               | Recovery_required _
+                               | Delivered _
+                               | Failed _
+                           ; _
+                           }
+                   ; _
+                   }
+               | Error _ -> false);
+            Keeper_chat_queue.For_testing.set_transaction_stage_observer None;
+            match
+              enqueue_checked ~label:"claim retry revision enqueue" ~keeper_name
+                (discord_msg ~content:"advance durable revision"
+                   ~channel_id:"channel-claim-retry"
+                   ~user_id:"user-claim-retry" ~timestamp:6.2)
+            with
+            | None -> ()
+            | Some second ->
+              check "new revision re-arms the original Pending receipt"
+                (match
+                   await_receipt ~clock ~seconds:5.0 ~keeper_name
+                     ~receipt_id:first.receipt_id ~accept:is_delivered
+                 with
+                 | Some _ -> true
+                 | None -> false);
+              check "the receipt behind it also drains"
+                (match
+                   await_receipt ~clock ~seconds:5.0 ~keeper_name
+                     ~receipt_id:second.receipt_id ~accept:is_delivered
+                 with
+                 | Some _ -> true
+                 | None -> false));
+          check "each committed receipt runs exactly once" (!turns = 2)))
+
 let test_busy_turn_hands_mutex_to_pending_receipt () =
   Printf.printf
     "Test: a busy turn hands its mutex to the exact pending Keeper lane\n%!";
@@ -913,6 +1007,7 @@ let () =
   test_structured_cancellation_terminalizes_claimed_receipt ();
   test_dispatch_is_concurrent_per_keeper ();
   test_finalization_persistence_retry_does_not_redeliver ();
+  test_claim_commit_uncertainty_waits_for_new_revision ();
   test_busy_turn_hands_mutex_to_pending_receipt ();
   test_consumer_cancellation_while_parked_keeps_pending ();
   test_pending_cancellation_while_parked_reobserves_next_receipt ();

--- a/test/test_keeper_chat_consumer_delivery.ml
+++ b/test/test_keeper_chat_consumer_delivery.ml
@@ -173,12 +173,7 @@ let check_terminal_snapshot ~label ~keeper_name ~receipt_id =
   check (label ^ " retains terminal receipt")
     (receipt_id_is_terminal ~keeper_name receipt_id)
 
-(* Tests own the transition-driven fiber explicitly and install the same queue
-   and admission wake fan-in as the production bootstrap. Production runs the
-   blocking loop inside its supervised subsystem boundary. Raising
-   from the switch body gives each test a structured teardown and, when a turn
-   is active, exercises the same cancellation path as server shutdown. *)
-let start_consumer ~sw ~clock ~base_path ~handle_turn =
+let install_transition_observers ~base_path =
   let canonical_base_path =
     Keeper_registry_types.canonical_base_path_exn base_path
   in
@@ -192,10 +187,19 @@ let start_consumer ~sw ~clock ~base_path ~handle_turn =
           if String.equal transition_base_path canonical_base_path
           then
             match transition with
-            | Keeper_turn_admission.Shutdown_rolled_back ->
-              Keeper_chat_consumer.notify_transition ~keeper_name
+            | Keeper_turn_admission.Shutdown_rolled_back
             | Keeper_turn_admission.Turn_released ->
-              Keeper_chat_consumer.notify_transition ~keeper_name));
+              Keeper_chat_consumer.notify_slot_transition
+                ~base_path:transition_base_path
+                ~keeper_name))
+
+(* Tests own the transition-driven fiber explicitly and install the same queue
+   and admission wake fan-in as the production bootstrap. Production runs the
+   blocking loop inside its supervised subsystem boundary. Raising
+   from the switch body gives each test a structured teardown and, when a turn
+   is active, exercises the same cancellation path as server shutdown. *)
+let start_consumer ~sw ~clock ~base_path ~handle_turn =
+  install_transition_observers ~base_path;
   let handle_admitted_turn
       ~sw
       ~keeper_name
@@ -656,6 +660,89 @@ let test_repeated_claim_failure_waits_for_explicit_wake () =
                | None -> false));
           check "the explicitly woken receipt runs exactly once" (!turns = 1)))
 
+let test_preclaim_failure_rearms_on_active_turn_release () =
+  Printf.printf
+    "Test: active turn release re-arms only a pre-claim failure\n%!";
+  with_env (fun ~base ~clock ->
+    match
+      enqueue_checked ~label:"pre-claim release enqueue" ~keeper_name
+        (discord_msg ~content:"retry after active turn release"
+           ~channel_id:"channel-preclaim-release"
+           ~user_id:"user-preclaim-release" ~timestamp:6.22)
+    with
+    | None -> ()
+    | Some accepted ->
+      let holder_started, resolve_holder_started = Eio.Promise.create () in
+      let release_holder, resolve_release_holder = Eio.Promise.create () in
+      let attempts = ref 0 in
+      let handle_turn
+          ~sw:_
+          ~keeper_name
+          ~receipt_ids:_
+          ~queued_message:_
+          ~on_admitted =
+        incr attempts;
+        if !attempts = 1
+        then
+          Keeper_chat_consumer.Failed
+            { kind = Keeper_chat_queue.Internal_error
+            ; detail = "synthetic pre-claim setup failure"
+            ; outcome_ref = None
+            }
+        else
+          match
+            Keeper_turn_admission.run_serialized
+              ~base_path:base
+              ~keeper_name
+              (fun () ->
+                 match on_admitted () with
+                 | Ok () ->
+                   Keeper_chat_consumer.Delivered
+                     { outcome_ref = "trace-preclaim-release#1" }
+                 | Error detail ->
+                   Keeper_chat_consumer.Failed
+                     { kind = Keeper_chat_queue.Internal_error
+                     ; detail
+                     ; outcome_ref = None
+                     })
+          with
+          | `Ran outcome -> outcome
+          | `Rejected rejection -> Keeper_chat_consumer.Deferred { rejection }
+      in
+      with_consumer_switch (fun sw ->
+        Eio.Fiber.fork ~sw (fun () ->
+          ignore
+            (Keeper_turn_admission.run_serialized
+               ~base_path:base
+               ~keeper_name
+               (fun () ->
+                  Eio.Promise.resolve resolve_holder_started ();
+                  Eio.Promise.await release_holder)
+             : [ `Ran of unit | `Rejected of Keeper_turn_admission.rejection ]));
+        check "active turn owns the slot before consumer preflight"
+          (await_promise ~clock ~seconds:5.0 holder_started);
+        install_transition_observers ~base_path:base;
+        Eio.Fiber.fork ~sw (fun () ->
+          Keeper_chat_consumer.run
+            ~sw
+            ~clock
+            ~base_path:base
+            ~handle_turn);
+        check "pre-claim setup failed exactly once before release"
+          (await_condition ~clock ~seconds:5.0 (fun () -> !attempts = 1));
+        Eio.Time.sleep clock 0.2;
+        check "pre-claim failure does not spin while the turn stays active"
+          (!attempts = 1);
+        Eio.Promise.resolve resolve_release_holder ();
+        check "the exact Pending receipt retries after the active turn releases"
+          (match
+             await_receipt ~clock ~seconds:5.0 ~keeper_name
+               ~receipt_id:accepted.receipt_id ~accept:is_delivered
+           with
+           | Some _ -> true
+           | None -> false));
+      check "the release produces exactly one follow-up attempt" (!attempts = 2))
+
 let test_busy_turn_hands_mutex_to_pending_receipt () =
   Printf.printf
     "Test: a busy turn hands its mutex to the exact pending Keeper lane\n%!";
@@ -1060,6 +1147,7 @@ let () =
   test_finalization_persistence_retry_does_not_redeliver ();
   test_claim_commit_uncertainty_retries_lone_receipt ();
   test_repeated_claim_failure_waits_for_explicit_wake ();
+  test_preclaim_failure_rearms_on_active_turn_release ();
   test_busy_turn_hands_mutex_to_pending_receipt ();
   test_consumer_cancellation_while_parked_keeps_pending ();
   test_stale_parked_observation_rearms_next_pending_receipt ();

--- a/test/test_keeper_chat_consumer_delivery.ml
+++ b/test/test_keeper_chat_consumer_delivery.ml
@@ -193,14 +193,7 @@ let start_consumer ~sw ~clock ~base_path ~handle_turn =
           then
             match transition with
             | Keeper_turn_admission.Shutdown_rolled_back ->
-              (match
-                 Keeper_chat_consumer.notify_explicit_retry
-                   ~base_path:transition_base_path
-                   ~keeper_name
-               with
-               | Ok () -> ()
-               | Error error ->
-                 check_failure "shutdown rollback explicit retry" error)
+              Keeper_chat_consumer.notify_transition ~keeper_name
             | Keeper_turn_admission.Turn_released -> ()));
   let handle_admitted_turn
       ~sw
@@ -526,9 +519,9 @@ let test_finalization_persistence_retry_does_not_redeliver () =
       check_terminal_snapshot ~label:"retried finalization" ~keeper_name
         ~receipt_id:accepted.receipt_id)
 
-let test_claim_commit_uncertainty_waits_for_explicit_retry () =
+let test_claim_commit_uncertainty_waits_for_later_revision () =
   Printf.printf
-    "Test: claim commit uncertainty waits for an explicit retry\n%!";
+    "Test: claim commit uncertainty waits for a later durable revision\n%!";
   with_env (fun ~base ~clock ->
     match
       enqueue_checked ~label:"claim uncertainty enqueue" ~keeper_name
@@ -599,21 +592,28 @@ let test_claim_commit_uncertainty_waits_for_explicit_retry () =
                | Error _ -> false);
             Keeper_chat_queue.For_testing.set_transaction_stage_observer None;
             (match
-               Keeper_chat_consumer.notify_explicit_retry
-                 ~base_path:base
-                 ~keeper_name
+               enqueue_checked ~label:"claim retry revision enqueue" ~keeper_name
+                 (discord_msg ~content:"advance the durable revision"
+                    ~channel_id:"channel-claim-retry"
+                    ~user_id:"user-claim-retry" ~timestamp:6.2)
              with
-             | Ok () -> ()
-             | Error error ->
-               check_failure "explicit pending-claim retry" error);
-            check "explicit retry re-arms the original Pending receipt"
-              (match
-                 await_receipt ~clock ~seconds:5.0 ~keeper_name
-                   ~receipt_id:first.receipt_id ~accept:is_delivered
-               with
-               | Some _ -> true
-               | None -> false));
-          check "the committed receipt runs exactly once" (!turns = 1)))
+             | None -> ()
+             | Some second ->
+               check "later revision re-arms the original Pending receipt"
+                 (match
+                    await_receipt ~clock ~seconds:5.0 ~keeper_name
+                      ~receipt_id:first.receipt_id ~accept:is_delivered
+                  with
+                  | Some _ -> true
+                  | None -> false);
+               check "the later receipt remains FIFO behind the retried head"
+                 (match
+                    await_receipt ~clock ~seconds:5.0 ~keeper_name
+                      ~receipt_id:second.receipt_id ~accept:is_delivered
+                  with
+                  | Some _ -> true
+                  | None -> false)));
+          check "both committed receipts run exactly once" (!turns = 2)))
 
 let test_busy_turn_hands_mutex_to_pending_receipt () =
   Printf.printf
@@ -1017,7 +1017,7 @@ let () =
   test_structured_cancellation_terminalizes_claimed_receipt ();
   test_dispatch_is_concurrent_per_keeper ();
   test_finalization_persistence_retry_does_not_redeliver ();
-  test_claim_commit_uncertainty_waits_for_explicit_retry ();
+  test_claim_commit_uncertainty_waits_for_later_revision ();
   test_busy_turn_hands_mutex_to_pending_receipt ();
   test_consumer_cancellation_while_parked_keeps_pending ();
   test_stale_parked_observation_rearms_next_pending_receipt ();

--- a/test/test_keeper_chat_consumer_delivery.ml
+++ b/test/test_keeper_chat_consumer_delivery.ml
@@ -194,7 +194,8 @@ let start_consumer ~sw ~clock ~base_path ~handle_turn =
             match transition with
             | Keeper_turn_admission.Shutdown_rolled_back ->
               Keeper_chat_consumer.notify_transition ~keeper_name
-            | Keeper_turn_admission.Turn_released -> ()));
+            | Keeper_turn_admission.Turn_released ->
+              Keeper_chat_consumer.notify_transition ~keeper_name));
   let handle_admitted_turn
       ~sw
       ~keeper_name
@@ -632,6 +633,18 @@ let test_repeated_claim_failure_waits_for_explicit_wake () =
                with
                | Ok { receipt = Some { state = Pending; _ }; _ } -> true
                | Ok { receipt = None | Some _; _ } | Error _ -> false);
+            check "the repeated uncertain claim is reconciled before return"
+              (match Keeper_chat_queue.lane_status ~keeper_name with
+               | Ok { health = Ready; _ } -> true
+               | Ok
+                   { health =
+                       ( Persistence_reconciliation_required
+                       | Delivery_recovery_required _
+                       | Unavailable _ )
+                   ; _
+                   }
+               | Error _ ->
+                 false);
             Keeper_chat_queue.For_testing.set_transaction_stage_observer None;
             Keeper_chat_consumer.notify_transition ~keeper_name;
             check "a same-revision explicit wake retries the receipt"

--- a/test/test_keeper_chat_consumer_delivery.ml
+++ b/test/test_keeper_chat_consumer_delivery.ml
@@ -519,9 +519,9 @@ let test_finalization_persistence_retry_does_not_redeliver () =
       check_terminal_snapshot ~label:"retried finalization" ~keeper_name
         ~receipt_id:accepted.receipt_id)
 
-let test_claim_commit_uncertainty_waits_for_later_revision () =
+let test_claim_commit_uncertainty_retries_lone_receipt () =
   Printf.printf
-    "Test: claim commit uncertainty waits for a later durable revision\n%!";
+    "Test: claim commit uncertainty retries the lone reconciled receipt\n%!";
   with_env (fun ~base ~clock ->
     match
       enqueue_checked ~label:"claim uncertainty enqueue" ~keeper_name
@@ -562,58 +562,86 @@ let test_claim_commit_uncertainty_waits_for_later_revision () =
                    ()));
           with_consumer_switch (fun sw ->
             start_consumer ~sw ~clock ~base_path:base ~handle_turn;
-            check "uncertain claim reaches COMMIT"
+            check "uncertain claim retries after exact reconciliation"
               (await_condition ~clock ~seconds:5.0 (fun () ->
-                 !commit_attempts >= 1));
+                 !commit_attempts >= 2));
+            check "the original receipt delivers without another queue mutation"
+              (match
+                 await_receipt ~clock ~seconds:5.0 ~keeper_name
+                   ~receipt_id:first.receipt_id ~accept:is_delivered
+               with
+               | Some _ -> true
+               | None -> false));
+          check "the committed receipt runs exactly once" (!turns = 1)))
+
+let test_repeated_claim_failure_waits_for_explicit_wake () =
+  Printf.printf
+    "Test: repeated claim failure stops locally and a same-revision wake retries\n%!";
+  with_env (fun ~base ~clock ->
+    match
+      enqueue_checked ~label:"repeated claim failure enqueue" ~keeper_name
+        (discord_msg ~content:"retry on explicit wake"
+           ~channel_id:"channel-claim-explicit-wake"
+           ~user_id:"user-claim-explicit-wake" ~timestamp:6.2)
+    with
+    | None -> ()
+    | Some accepted ->
+      let commit_attempts = ref 0 in
+      let turns = ref 0 in
+      let handle_turn ~sw:_ ~keeper_name:_ ~delivery_key:_ ~queued_message:_ =
+        incr turns;
+        Keeper_chat_consumer.Delivered
+          { outcome_ref =
+              Printf.sprintf "trace-claim-explicit-wake#%d" !turns
+          }
+      in
+      Fun.protect
+        ~finally:(fun () ->
+          Keeper_chat_queue.For_testing.set_transaction_stage_observer None)
+        (fun () ->
+          Keeper_chat_queue.For_testing.set_transaction_stage_observer
+            (Some
+               (function
+                 | Keeper_chat_queue.For_testing.Commit_invoked ->
+                   incr commit_attempts;
+                   if !commit_attempts <= 2
+                   then
+                     Keeper_chat_queue.For_testing.fail_next_commit_with
+                       Commit_busy
+                 | Transaction_begun
+                 | Mutation_applied
+                 | Before_commit
+                 | Commit_returned
+                 | Before_rollback
+                 | Before_close ->
+                   ()));
+          with_consumer_switch (fun sw ->
+            start_consumer ~sw ~clock ~base_path:base ~handle_turn;
+            check "one admitted turn performs only the reconciled retry"
+              (await_condition ~clock ~seconds:5.0 (fun () ->
+                 !commit_attempts >= 2));
             Eio.Time.sleep clock 0.2;
-            check "same-revision invalidations do not retry the claim"
-              (!commit_attempts = 1);
-            check "turn body does not run before a committed claim" (!turns = 0);
-            check "uncertain claim reconciles back to Pending"
+            check "internal reconciliation creates no retry loop"
+              (!commit_attempts = 2);
+            check "no turn body runs without a committed claim" (!turns = 0);
+            check "the exact receipt remains Pending"
               (match
                  Keeper_chat_queue.lookup_receipt
                    ~keeper_name
-                   ~receipt_id:first.receipt_id
+                   ~receipt_id:accepted.receipt_id
                with
                | Ok { receipt = Some { state = Pending; _ }; _ } -> true
-               | Ok
-                   { receipt =
-                       None
-                       | Some
-                           { state =
-                               Inflight _
-                               | Recovery_required _
-                               | Delivered _
-                               | Failed _
-                           ; _
-                           }
-                   ; _
-                   }
-               | Error _ -> false);
+               | Ok { receipt = None | Some _; _ } | Error _ -> false);
             Keeper_chat_queue.For_testing.set_transaction_stage_observer None;
-            (match
-               enqueue_checked ~label:"claim retry revision enqueue" ~keeper_name
-                 (discord_msg ~content:"advance the durable revision"
-                    ~channel_id:"channel-claim-retry"
-                    ~user_id:"user-claim-retry" ~timestamp:6.2)
-             with
-             | None -> ()
-             | Some second ->
-               check "later revision re-arms the original Pending receipt"
-                 (match
-                    await_receipt ~clock ~seconds:5.0 ~keeper_name
-                      ~receipt_id:first.receipt_id ~accept:is_delivered
-                  with
-                  | Some _ -> true
-                  | None -> false);
-               check "the later receipt remains FIFO behind the retried head"
-                 (match
-                    await_receipt ~clock ~seconds:5.0 ~keeper_name
-                      ~receipt_id:second.receipt_id ~accept:is_delivered
-                  with
-                  | Some _ -> true
-                  | None -> false)));
-          check "both committed receipts run exactly once" (!turns = 2)))
+            Keeper_chat_consumer.notify_transition ~keeper_name;
+            check "a same-revision explicit wake retries the receipt"
+              (match
+                 await_receipt ~clock ~seconds:5.0 ~keeper_name
+                   ~receipt_id:accepted.receipt_id ~accept:is_delivered
+               with
+               | Some _ -> true
+               | None -> false));
+          check "the explicitly woken receipt runs exactly once" (!turns = 1)))
 
 let test_busy_turn_hands_mutex_to_pending_receipt () =
   Printf.printf
@@ -1017,7 +1045,8 @@ let () =
   test_structured_cancellation_terminalizes_claimed_receipt ();
   test_dispatch_is_concurrent_per_keeper ();
   test_finalization_persistence_retry_does_not_redeliver ();
-  test_claim_commit_uncertainty_waits_for_later_revision ();
+  test_claim_commit_uncertainty_retries_lone_receipt ();
+  test_repeated_claim_failure_waits_for_explicit_wake ();
   test_busy_turn_hands_mutex_to_pending_receipt ();
   test_consumer_cancellation_while_parked_keeps_pending ();
   test_stale_parked_observation_rearms_next_pending_receipt ();

--- a/test/test_keeper_chat_consumer_delivery.ml
+++ b/test/test_keeper_chat_consumer_delivery.ml
@@ -660,6 +660,86 @@ let test_repeated_claim_failure_waits_for_explicit_wake () =
                | None -> false));
           check "the explicitly woken receipt runs exactly once" (!turns = 1)))
 
+let test_handoff_release_does_not_rearm_failed_claim () =
+  Printf.printf
+    "Test: a handoff release cannot re-arm the admitted claim it wakes\n%!";
+  with_env (fun ~base ~clock ->
+    match
+      enqueue_checked ~label:"handoff claim failure enqueue" ~keeper_name
+        (discord_msg ~content:"do not retry the failed handoff claim"
+           ~channel_id:"channel-claim-handoff"
+           ~user_id:"user-claim-handoff" ~timestamp:6.21)
+    with
+    | None -> ()
+    | Some accepted ->
+      let holder_started, resolve_holder_started = Eio.Promise.create () in
+      let release_holder, resolve_release_holder = Eio.Promise.create () in
+      let commit_attempts = ref 0 in
+      let turns = ref 0 in
+      let handle_turn ~sw:_ ~keeper_name:_ ~delivery_key:_ ~queued_message:_ =
+        incr turns;
+        Keeper_chat_consumer.Delivered
+          { outcome_ref =
+              Printf.sprintf "trace-claim-handoff#%d" !turns
+          }
+      in
+      Fun.protect
+        ~finally:(fun () ->
+          Keeper_chat_queue.For_testing.set_transaction_stage_observer None)
+        (fun () ->
+          Keeper_chat_queue.For_testing.set_transaction_stage_observer
+            (Some
+               (function
+                 | Keeper_chat_queue.For_testing.Commit_invoked ->
+                   incr commit_attempts;
+                   if !commit_attempts <= 2
+                   then
+                     Keeper_chat_queue.For_testing.fail_next_commit_with
+                       Commit_busy
+                 | Transaction_begun
+                 | Mutation_applied
+                 | Before_commit
+                 | Commit_returned
+                 | Before_rollback
+                 | Before_close ->
+                   ()));
+          with_consumer_switch (fun sw ->
+            Eio.Fiber.fork ~sw (fun () ->
+              ignore
+                (Keeper_turn_admission.run_serialized
+                   ~base_path:base
+                   ~keeper_name
+                   (fun () ->
+                      Eio.Promise.resolve resolve_holder_started ();
+                      Eio.Promise.await release_holder)
+                 : [ `Ran of unit | `Rejected of Keeper_turn_admission.rejection ]));
+            check "active turn owns the slot before the queued claim"
+              (await_promise ~clock ~seconds:5.0 holder_started);
+            start_consumer ~sw ~clock ~base_path:base ~handle_turn;
+            check "queued claim is parked behind the active turn"
+              (await_condition ~clock ~seconds:5.0 (fun () ->
+                 Keeper_turn_admission.chat_waiting
+                   ~base_path:base
+                   ~keeper_name));
+            Eio.Promise.resolve resolve_release_holder ();
+            check "the admitted claim performs only its bounded retry"
+              (await_condition ~clock ~seconds:5.0 (fun () ->
+                 !commit_attempts >= 2));
+            Eio.Time.sleep clock 0.2;
+            check "the handoff release leaves no stale consumer wake"
+              (!commit_attempts = 2);
+            check "no turn body runs without a committed claim" (!turns = 0);
+            Keeper_chat_queue.For_testing.set_transaction_stage_observer None;
+            Keeper_chat_consumer.notify_transition ~keeper_name;
+            check "an explicit wake still retries the Pending receipt"
+              (match
+                 await_receipt ~clock ~seconds:5.0 ~keeper_name
+                   ~receipt_id:accepted.receipt_id ~accept:is_delivered
+               with
+               | Some _ -> true
+               | None -> false));
+          check "the explicit wake runs the receipt exactly once" (!turns = 1)))
+
 let test_preclaim_failure_rearms_on_active_turn_release () =
   Printf.printf
     "Test: active turn release re-arms only a pre-claim failure\n%!";
@@ -1147,6 +1227,7 @@ let () =
   test_finalization_persistence_retry_does_not_redeliver ();
   test_claim_commit_uncertainty_retries_lone_receipt ();
   test_repeated_claim_failure_waits_for_explicit_wake ();
+  test_handoff_release_does_not_rearm_failed_claim ();
   test_preclaim_failure_rearms_on_active_turn_release ();
   test_busy_turn_hands_mutex_to_pending_receipt ();
   test_consumer_cancellation_while_parked_keeps_pending ();

--- a/test/test_keeper_chat_consumer_delivery.ml
+++ b/test/test_keeper_chat_consumer_delivery.ml
@@ -359,18 +359,21 @@ let test_structured_cancellation_terminalizes_claimed_receipt () =
          Keeper_chat_queue.lookup_receipt ~keeper_name
            ~receipt_id:accepted.receipt_id
        with
-         | Ok
+       | Ok
            { receipt =
                Some
                  { state =
                      Keeper_chat_queue.Failed
-                       { kind = Keeper_chat_queue.Cancelled; _ }
+                       { kind = Keeper_chat_queue.Cancelled; detail; _ }
                  ; receipt_id
                  }
            ; _
            } ->
          check "cancellation preserves the accepted receipt id"
-           (Keeper_chat_queue.Receipt_id.equal receipt_id accepted.receipt_id)
+           (Keeper_chat_queue.Receipt_id.equal receipt_id accepted.receipt_id);
+         check "cancellation records unknown external effect"
+           (String.equal detail
+              "Keeper stopped before this claimed turn completed; its external effect is unknown.")
        | Ok
            { receipt =
                Some
@@ -753,9 +756,9 @@ let test_consumer_cancellation_while_parked_keeps_pending () =
            | Error _ -> false);
         Eio.Promise.resolve resolve_release_holder ()))
 
-let test_pending_cancellation_while_parked_reobserves_next_receipt () =
+let test_stale_parked_observation_rearms_next_pending_receipt () =
   Printf.printf
-    "Test: cancelling the pending head while parked dispatches the next receipt\n%!";
+    "Test: a stale parked observation rearms the next pending receipt\n%!";
   with_env (fun ~base ~clock ->
     let holder_started, resolve_holder_started = Eio.Promise.create () in
     let release_holder, resolve_release_holder = Eio.Promise.create () in
@@ -765,7 +768,8 @@ let test_pending_cancellation_while_parked_reobserves_next_receipt () =
         ~(queued_message : Keeper_chat_queue.queued_message) =
       incr calls;
       handled_content := Some queued_message.content;
-      Keeper_chat_consumer.Delivered { outcome_ref = "trace-next#4" }
+      Keeper_chat_consumer.Delivered
+        { outcome_ref = "trace-stale-rearm#1" }
     in
     with_consumer_switch (fun sw ->
       Eio.Fiber.fork ~sw (fun () ->
@@ -793,6 +797,12 @@ let test_pending_cancellation_while_parked_reobserves_next_receipt () =
              Keeper_turn_admission.chat_waiting
                ~base_path:base
                ~keeper_name));
+        (* Isolate the consumer's stale-observation recovery edge: both
+           production observers are deliberately silent after the consumer
+           has parked, so only [run_observed_turn]'s typed [Claim_stale]
+           transition can schedule the replacement receipt. *)
+        Keeper_chat_queue.set_transition_observer None;
+        Keeper_turn_admission.set_slot_transition_observer None;
         (match
            Keeper_chat_queue.cancel_pending
              ~keeper_name
@@ -806,29 +816,27 @@ let test_pending_cancellation_while_parked_reobserves_next_receipt () =
            check "pending cancellation commits a terminal receipt" true
          | Ok _ | Error _ ->
            check "pending cancellation commits a terminal receipt" false);
-        let next_receipt =
-          enqueue_checked ~label:"post-cancellation enqueue" ~keeper_name
-            (discord_msg ~content:"run after stale observation"
-               ~channel_id:"channel-after-stale"
-               ~user_id:"user-after-stale" ~timestamp:6.6)
-        in
-        check "cancelled pending head never reaches the turn handler" (!calls = 0);
-        Eio.Promise.resolve resolve_release_holder ();
-        (match next_receipt with
-         | None -> check "next receipt is accepted" false
-         | Some next ->
-           check "next receipt is delivered after the stale observation"
+        (match
+           enqueue_checked ~label:"stale replacement enqueue" ~keeper_name
+             (discord_msg ~content:"run after stale head"
+                ~channel_id:"channel-stale-replacement"
+                ~user_id:"user-stale-replacement" ~timestamp:6.6)
+         with
+         | None -> Eio.Promise.resolve resolve_release_holder ()
+         | Some replacement ->
+           Eio.Promise.resolve resolve_release_holder ();
+           check "stale observation rearms the replacement receipt"
              (match
                 await_receipt ~clock ~seconds:5.0 ~keeper_name
-                  ~receipt_id:next.receipt_id ~accept:is_delivered
+                  ~receipt_id:replacement.receipt_id ~accept:is_delivered
               with
               | Some _ -> true
               | None -> false);
-           check_terminal_snapshot ~label:"post-cancellation next receipt"
-             ~keeper_name ~receipt_id:next.receipt_id);
-        check "only the next receipt reaches the turn handler" (!calls = 1);
-        check "only the next receipt content is handled"
-          (!handled_content = Some "run after stale observation")))
+           check "cancelled head never reaches the turn handler" (!calls = 1);
+           check "only the replacement content is handled"
+             (!handled_content = Some "run after stale head");
+           check_terminal_snapshot ~label:"stale replacement" ~keeper_name
+             ~receipt_id:replacement.receipt_id)))
 
 let test_invalid_delivered_turn_ref_fails_closed () =
   Printf.printf
@@ -1012,7 +1020,7 @@ let () =
   test_claim_commit_uncertainty_waits_for_explicit_retry ();
   test_busy_turn_hands_mutex_to_pending_receipt ();
   test_consumer_cancellation_while_parked_keeps_pending ();
-  test_pending_cancellation_while_parked_reobserves_next_receipt ();
+  test_stale_parked_observation_rearms_next_pending_receipt ();
   test_invalid_delivered_turn_ref_fails_closed ();
   test_invalid_delivery_diagnostic_does_not_block_lane ();
   test_shutdown_fence_keeps_receipt_pending_until_rollback ();

--- a/test/test_keeper_chat_consumer_delivery.ml
+++ b/test/test_keeper_chat_consumer_delivery.ml
@@ -656,17 +656,19 @@ let test_consumer_cancellation_while_parked_keeps_pending () =
            | Error _ -> false);
         Eio.Promise.resolve resolve_release_holder ()))
 
-let test_pending_cancellation_while_parked_releases_empty_slot () =
+let test_stale_parked_observation_rearms_next_pending_receipt () =
   Printf.printf
-    "Test: cancelling the pending head while parked releases an empty slot\n%!";
+    "Test: a stale parked observation rearms the next pending receipt\n%!";
   with_env (fun ~base ~clock ->
     let holder_started, resolve_holder_started = Eio.Promise.create () in
     let release_holder, resolve_release_holder = Eio.Promise.create () in
     let calls = ref 0 in
-    let handle_turn ~sw:_ ~keeper_name:_ ~delivery_key:_ ~queued_message:_ =
+    let handled_content = ref None in
+    let handle_turn ~sw:_ ~keeper_name:_ ~delivery_key:_ ~queued_message =
       incr calls;
+      handled_content := Some queued_message.content;
       Keeper_chat_consumer.Delivered
-        { outcome_ref = "must-not-run-after-pending-cancel" }
+        { outcome_ref = "trace-stale-rearm#1" }
     in
     with_consumer_switch (fun sw ->
       Eio.Fiber.fork ~sw (fun () ->
@@ -694,6 +696,12 @@ let test_pending_cancellation_while_parked_releases_empty_slot () =
              Keeper_turn_admission.chat_waiting
                ~base_path:base
                ~keeper_name));
+        (* Isolate the consumer's stale-observation recovery edge: both
+           production observers are deliberately silent after the consumer
+           has parked, so only [run_observed_turn]'s typed [Claim_stale]
+           transition can schedule the replacement receipt. *)
+        Keeper_chat_queue.set_transition_observer None;
+        Keeper_turn_admission.set_slot_transition_observer None;
         (match
            Keeper_chat_queue.cancel_pending
              ~keeper_name
@@ -707,28 +715,27 @@ let test_pending_cancellation_while_parked_releases_empty_slot () =
            check "pending cancellation commits a terminal receipt" true
          | Ok _ | Error _ ->
            check "pending cancellation commits a terminal receipt" false);
-        Eio.Promise.resolve resolve_release_holder ();
-        check "stale parked observation releases the turn slot"
-          (await_condition ~clock ~seconds:5.0 (fun () ->
-             let snapshot =
-               Keeper_turn_admission.snapshot_for
-                 ~base_path:base
-                 ~keeper_name
-             in
-             Option.is_none snapshot.snapshot_in_flight
-             && not
-                  (Keeper_turn_admission.chat_waiting
-                     ~base_path:base
-                     ~keeper_name)));
-        check "cancelled pending head never reaches the turn handler" (!calls = 0);
         (match
-           Keeper_turn_admission.run_if_free
-             ~base_path:base
-             ~keeper_name
-             (fun () -> ())
+           enqueue_checked ~label:"stale replacement enqueue" ~keeper_name
+             (discord_msg ~content:"run after stale head"
+                ~channel_id:"channel-stale-replacement"
+                ~user_id:"user-stale-replacement" ~timestamp:6.6)
          with
-         | `Ran () -> check "empty lane admits autonomous work again" true
-         | `Busy _ -> check "empty lane admits autonomous work again" false)))
+         | None -> Eio.Promise.resolve resolve_release_holder ()
+         | Some replacement ->
+           Eio.Promise.resolve resolve_release_holder ();
+           check "stale observation rearms the replacement receipt"
+             (match
+                await_receipt ~clock ~seconds:5.0 ~keeper_name
+                  ~receipt_id:replacement.receipt_id ~accept:is_delivered
+              with
+              | Some _ -> true
+              | None -> false);
+           check "cancelled head never reaches the turn handler" (!calls = 1);
+           check "only the replacement content is handled"
+             (!handled_content = Some "run after stale head");
+           check_terminal_snapshot ~label:"stale replacement" ~keeper_name
+             ~receipt_id:replacement.receipt_id)))
 
 let test_invalid_delivered_turn_ref_fails_closed () =
   Printf.printf
@@ -911,7 +918,7 @@ let () =
   test_finalization_persistence_retry_does_not_redeliver ();
   test_busy_turn_release_wakes_pending_receipt ();
   test_consumer_cancellation_while_parked_keeps_pending ();
-  test_pending_cancellation_while_parked_releases_empty_slot ();
+  test_stale_parked_observation_rearms_next_pending_receipt ();
   test_invalid_delivered_turn_ref_fails_closed ();
   test_invalid_delivery_diagnostic_does_not_block_lane ();
   test_shutdown_fence_keeps_receipt_pending_until_rollback ();

--- a/test/test_keeper_chat_discord.ml
+++ b/test/test_keeper_chat_discord.ml
@@ -168,6 +168,28 @@ let test_terminal_callback_once_for_fallback_post () =
   check_single_ok "fallback terminal result" outcomes;
   check (list string) "one final POST" [ "hello" ] (List.rev !final_posts)
 
+let test_adapter_empty_terminal_is_local_error () =
+  let sends = ref 0 in
+  let outcomes =
+    run_adapter
+      [ Masc.Keeper_chat_events.Run_finished { run_id = "run-empty" } ]
+      ~post_message:(fun ~content:_ ->
+        incr sends;
+        Ok "unexpected-stream-message")
+      ~edit_message:(fun ~message_id:_ ~content:_ ->
+        incr sends;
+        Ok ())
+      ~send_message:(fun ~content:_ ->
+        incr sends;
+        Ok ())
+  in
+  check int "empty terminal makes no Discord call" 0 !sends;
+  match outcomes with
+  | [ Error (Discord_rest_client.Other message) ] ->
+    check bool "empty terminal failure is explicit" true
+      (contains message "contained no text")
+  | _ -> fail "empty terminal settles once with a local delivery error"
+
 let test_terminal_callback_reports_final_patch_failure () =
   let patch_calls = ref 0 in
   let outcomes =
@@ -281,6 +303,8 @@ let () =
             test_final_split_redacts_before_chunking
         ; test_case "callback once for fallback POST" `Quick
             test_terminal_callback_once_for_fallback_post
+        ; test_case "empty terminal is local-only" `Quick
+            test_adapter_empty_terminal_is_local_error
         ; test_case "callback reports final PATCH failure" `Quick
             test_terminal_callback_reports_final_patch_failure
         ; test_case "callback reports overflow failure" `Quick

--- a/test/test_keeper_paused_work_operator.ml
+++ b/test/test_keeper_paused_work_operator.ml
@@ -404,19 +404,6 @@ let test_admission_busy_http_json_preserves_typed_detail () =
      |> member "holder"
      |> member "started_at"
      |> to_float);
-  let backlog =
-    admission_error_json
-      (Keeper_turn_admission.Chat_backlog
-         { pending_count = 3; inflight_count = 2 })
-  in
-  Alcotest.(check int)
-    "chat pending count"
-    3
-    (backlog |> member "admission" |> member "pending_count" |> to_int);
-  Alcotest.(check int)
-    "chat inflight count"
-    2
-    (backlog |> member "admission" |> member "inflight_count" |> to_int);
   let operation_id = Keeper_shutdown_types.Operation_id.generate () in
   let shutdown =
     admission_error_json

--- a/test/test_keeper_paused_work_source_terminal_transaction.ml
+++ b/test/test_keeper_paused_work_source_terminal_transaction.ml
@@ -687,7 +687,7 @@ let test_source_terminal_busy_has_zero_mutation () =
   with_source_terminal_lane (fun config keeper_name _meta request ->
     let base_path = config.Workspace.base_path in
     (match
-       Keeper_turn_admission.run_admin_if_free
+       Keeper_turn_admission.run_if_free
          ~base_path
          ~keeper_name
          (fun () -> Transaction.ack_pending config ~keeper_name request)

--- a/test/test_keeper_paused_work_transfer_transaction.ml
+++ b/test/test_keeper_paused_work_transfer_transaction.ml
@@ -330,7 +330,7 @@ let test_transfer_busy_has_zero_mutation () =
   with_transfer_lane (fun config from_keeper to_keeper _source_meta _target_meta request ->
     let base_path = config.Workspace.base_path in
     (match
-       Keeper_turn_admission.run_admin_if_free
+       Keeper_turn_admission.run_if_free
          ~base_path
          ~keeper_name:from_keeper
          (fun () ->

--- a/test/test_keeper_turn_admission.ml
+++ b/test/test_keeper_turn_admission.ml
@@ -67,6 +67,19 @@ let queued_message : Keeper_chat_queue.queued_message =
   }
 ;;
 
+let claim_pending_head () =
+  match Keeper_chat_queue.observe_pending ~keeper_name with
+  | Ok (Some observation) ->
+    (match Keeper_chat_queue.lease_observed observation with
+     | `Leased lease -> lease
+     | `Stale _ -> failwith "pending observation became stale before claim"
+     | `Error error ->
+       failwith (Keeper_chat_queue.mutation_error_to_string error))
+  | Ok None -> failwith "expected an observable pending receipt"
+  | Error error ->
+    failwith (Keeper_chat_queue.mutation_error_to_string error)
+;;
+
 let test_autonomous_admits_when_chat_persistence_is_not_configured () =
   Keeper_turn_admission.For_testing.reset ();
   Keeper_chat_queue.For_testing.reset ();
@@ -128,7 +141,7 @@ let test_admin_mutation_is_busy_during_admitted_turn () =
       ~base_path
       ~keeper_name
       (fun _token ->
-         Keeper_turn_admission.run_admin_if_free
+         Keeper_turn_admission.run_if_free
            ~base_path
            ~keeper_name
            (fun () -> ()))
@@ -284,12 +297,7 @@ let test_chat_if_free_rechecks_durable_queue_after_stale_peek () =
      check "pending receipt blocks direct admission" true
    | `Busy _ | `Ran () -> check "pending receipt blocks direct admission" false);
   check "pending receipt is not overtaken" (not !direct_ran);
-  let lease =
-    match Keeper_chat_queue.lease_next ~keeper_name with
-    | `Leased lease -> lease
-    | `Empty | `Already_leased _ | `Recovery_required _ | `Error _ ->
-      failwith "expected the committed receipt to lease"
-  in
+  let lease = claim_pending_head () in
   (match
      Keeper_turn_admission.run_chat_if_free ~base_path ~keeper_name (fun () ->
        direct_ran := true)
@@ -598,35 +606,11 @@ let test_idle_loop_yields_to_parked_chat () =
   check "parked chat admitted after the autonomous turn yielded" !chat_ran
 ;;
 
-let test_autonomous_yields_to_queued_connector_message () =
+let test_pending_receipt_is_not_an_admission_authority () =
   reset ();
   Printf.printf
-    "Test 10: autonomous lane yields while a connector/dashboard message is queued\n%!";
-  (* Sanity: an empty queue lets the autonomous lane run. *)
-  (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> 7) with
-   | `Ran 7 -> check "run_if_free admits when the chat queue is empty" true
-   | `Ran _ | `Busy _ -> check "run_if_free admits when the chat queue is empty" false);
-  (* A busy connector (Slack/Discord) message is deferred on the chat queue
-     without parking on the admission slot, so [chat_waiting] stays false. The
-     autonomous lane must still yield, or a long/back-to-back autonomous turn
-     busy-ACKs the connector forever (the starvation this pins). *)
-  (match
-     Keeper_chat_queue.enqueue ~keeper_name
-       { Keeper_chat_queue.content = "deferred slack mention"
-       ; user_blocks = []
-       ; attachments = []
-       ; timestamp = 1.0
-       ; source =
-           Keeper_chat_queue.Slack
-             { channel_id = "C-test"
-             ; user_id = "U-test"
-             ; user_name = "slack-user"
-             ; team_id = Some "T-test"
-             ; thread_ts = Some "171.001"
-             }
-       ; user_row_origin = Keeper_chat_store.Already_persisted_upstream
-       }
-   with
+    "Test 10: a durable pending receipt is not a second admission authority\n%!";
+  (match Keeper_chat_queue.enqueue ~keeper_name queued_message with
    | Ok _ -> ()
    | Error error ->
      check
@@ -635,81 +619,28 @@ let test_autonomous_yields_to_queued_connector_message () =
   let queued = Keeper_chat_queue.snapshot ~keeper_name in
   check "queue depth is 1 after enqueue" (List.length queued.pending = 1);
   check
-    "a queued connector message is not a parked chat"
+    "a pending receipt alone is not a parked chat"
     (not (Keeper_turn_admission.chat_waiting ~base_path ~keeper_name));
-  (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
-   | `Busy _ ->
-     check "run_if_free yields (Busy) while a connector message is queued" true
-   | `Ran () ->
-     check "run_if_free must not admit while a connector message is queued" false);
-  (* Leasing changes the receipt to Inflight but does not make it disappear.
-     The actual turn mutex, not that durable receipt, is the execution fence.
-     A free mutex plus an inflight receipt must stay progress-capable even when
-     a second message is pending — this is the live timeout/orphan shape. *)
-  let lease =
-    match Keeper_chat_queue.lease_next ~keeper_name with
-    | `Leased lease -> Some lease
-    | `Empty | `Already_leased _ | `Recovery_required _ | `Error _ ->
-      check "lease_next leases the queued connector message" false;
-      None
-  in
-  (match Keeper_chat_queue.enqueue ~keeper_name { queued_message with content = "next" } with
-   | Ok _ -> ()
-   | Error error ->
-     check
-       ("second enqueue succeeds: "
-        ^ Keeper_chat_queue.mutation_error_to_string error)
-       false);
-  let inflight = Keeper_chat_queue.snapshot ~keeper_name in
-  check "leased receipt remains visible" (List.length inflight.inflight = 1);
-  check "second receipt remains pending" (List.length inflight.pending = 1);
-  (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
-   | `Ran () ->
-     check "stranded/finalizing inflight receipt does not become a second lock" true
-   | `Busy _ ->
-     check "inflight receipt with a free turn mutex must not halt progress" false);
-  (match lease with
-   | None -> ()
-   | Some lease ->
-     (match
-        Keeper_chat_queue.finalize ~keeper_name ~lease_id:lease.lease_id
-          ~outcome:
-            (Keeper_chat_queue.Mark_delivered
-               { completed_at = 2.0; outcome_ref = None })
-      with
-      | `Finalized _ -> ()
-      | `Unknown_lease | `Error _ ->
-        check "finalize commits the terminal receipt" false));
-  (* With the inflight receipt gone, the still-pending chat is again the
-     authoritative backlog and the autonomous lane yields to its consumer. *)
-  (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
-   | `Busy (Keeper_turn_admission.Chat_backlog
-       { pending_count = 1; inflight_count = 0 }) ->
-     check "pending-only backlog still has chat priority" true
-   | `Busy _ | `Ran () ->
-     check "pending-only backlog must retain chat priority" false);
-  (match Keeper_chat_queue.lease_next ~keeper_name with
-   | `Leased lease ->
-     (match
-        Keeper_chat_queue.finalize
-          ~keeper_name
-          ~lease_id:lease.lease_id
-          ~outcome:
-            (Keeper_chat_queue.Mark_delivered
-               { completed_at = 3.0; outcome_ref = None })
-      with
-      | `Finalized _ -> ()
-      | `Unknown_lease | `Error _ ->
-        check "second finalize commits the terminal receipt" false)
-   | `Empty | `Already_leased _ | `Recovery_required _ | `Error _ ->
-     check "second receipt leases for cleanup" false);
+  (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> 7) with
+   | `Ran 7 -> check "the mutex is the only autonomous admission authority" true
+   | `Ran _ | `Busy _ ->
+     check "a pending receipt must not fence a free turn mutex" false);
+  let lease = claim_pending_head () in
+  (match
+     Keeper_chat_queue.finalize
+       ~keeper_name
+       ~lease_id:lease.lease_id
+       ~outcome:
+         (Keeper_chat_queue.Mark_delivered
+            { completed_at = 3.0; outcome_ref = None })
+   with
+   | `Finalized _ -> ()
+   | `Unknown_lease | `Error _ ->
+     check "cleanup finalize commits the terminal receipt" false);
   let settled = Keeper_chat_queue.snapshot ~keeper_name in
   check
     "queue has no active receipts after finalization"
-    (settled.pending = [] && settled.inflight = []);
-  match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> "ok") with
-  | `Ran "ok" -> check "run_if_free admits again once the queue is drained" true
-  | `Ran _ | `Busy _ -> check "run_if_free admits again once the queue is drained" false
+    (settled.pending = [] && settled.inflight = [])
 ;;
 
 let test_shutdown_reservation_fences_and_rolls_back () =
@@ -734,9 +665,7 @@ let test_shutdown_reservation_fences_and_rolls_back () =
      check
        "autonomous lane sees typed shutdown fence"
        (Keeper_shutdown_types.Operation_id.equal reserved operation_id)
-   | `Busy (Keeper_turn_admission.Turn_busy _)
-   | `Busy (Keeper_turn_admission.Chat_backlog _)
-   | `Ran () ->
+   | `Busy (Keeper_turn_admission.Turn_busy _) | `Ran () ->
      check "autonomous lane cannot cross shutdown fence" false);
   (match Keeper_turn_admission.run_serialized ~base_path ~keeper_name (fun () -> ()) with
    | `Rejected { shutdown_operation_id = Some reserved; _ } ->
@@ -821,74 +750,6 @@ let test_shutdown_reservation_restores_durable_owner () =
     check "registration cannot cross restored fence" false
 ;;
 
-let test_compaction_lane_bypasses_chat_backlog () =
-  reset ();
-  Printf.printf
-    "Test 10b: manual-compaction lane admits despite a durable chat backlog (#24865)\n%!";
-  (match Keeper_chat_queue.enqueue ~keeper_name queued_message with
-   | Ok _ -> ()
-   | Error error ->
-     check
-       ("enqueue succeeds: " ^ Keeper_chat_queue.mutation_error_to_string error)
-       false);
-  (* The standard lane reports the backlog as a typed [Chat_backlog] with the
-     exact counts, not as [Turn_busy None]. Before this variant existed the
-     queue fence logged "holder info not yet published", which mis-directed
-     the #24865 diagnosis toward a stale slot. *)
-  (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
-   | `Busy (Keeper_turn_admission.Chat_backlog { pending_count = 1; inflight_count = 0 })
-     -> check "standard lane reports the backlog as typed Chat_backlog" true
-   | `Busy _ | `Ran () ->
-     check "standard lane reports the backlog as typed Chat_backlog" false);
-  (match
-     Keeper_turn_admission.run_compaction_if_free ~base_path ~keeper_name (fun () -> 7)
-   with
-   | `Ran 7 -> check "compaction lane admits despite a pending receipt" true
-   | `Ran _ | `Busy _ -> check "compaction lane admits despite a pending receipt" false);
-  (* Leasing moves the receipt to inflight. Both autonomous entry points use
-     the actual turn mutex as the execution fence; the durable receipt is not
-     a second global lock. *)
-  (match Keeper_chat_queue.lease_next ~keeper_name with
-   | `Leased _ -> ()
-   | `Empty | `Already_leased _ | `Recovery_required _ | `Error _ ->
-     check "lease_next leases the queued message" false);
-  (match
-     Keeper_turn_admission.run_compaction_if_free ~base_path ~keeper_name (fun () -> 8)
-   with
-   | `Ran 8 -> check "compaction lane admits despite an inflight receipt" true
-   | `Ran _ | `Busy _ -> check "compaction lane admits despite an inflight receipt" false);
-  (* Once the compaction admission releases the slot, a follow-up standard
-     turn also remains live despite a stranded/finalizing inflight receipt. *)
-  (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
-   | `Ran () ->
-     check "standard lane admits past an inflight receipt after compaction" true
-   | `Busy _ ->
-     check "inflight receipt must not refence standard lane after compaction" false);
-  (* A genuinely held slot still refuses the compaction lane: it must never
-     interleave with an in-flight turn. *)
-  Keeper_turn_admission.For_testing.with_unpublished_turn_lock
-    ~base_path
-    ~keeper_name
-    (fun () ->
-       match
-         Keeper_turn_admission.run_compaction_if_free ~base_path ~keeper_name (fun () -> ())
-       with
-       | `Busy (Keeper_turn_admission.Turn_busy _) ->
-         check "compaction lane still refuses a held slot" true
-       | `Busy _ | `Ran () -> check "compaction lane still refuses a held slot" false);
-  (* A durable shutdown reservation still fences the compaction lane. *)
-  let operation_id = Keeper_shutdown_types.Operation_id.generate () in
-  ignore
-    (Keeper_turn_admission.begin_shutdown ~base_path ~keeper_name ~operation_id
-      : Keeper_turn_admission.begin_shutdown_result);
-  match
-    Keeper_turn_admission.run_compaction_if_free ~base_path ~keeper_name (fun () -> ())
-  with
-  | `Busy (Keeper_turn_admission.Shutdown_requested _) ->
-    check "compaction lane still honors the shutdown fence" true
-  | `Busy _ | `Ran () -> check "compaction lane still honors the shutdown fence" false
-;;
-
 let () =
   Eio_main.run @@ fun _env ->
   test_autonomous_admits_when_chat_persistence_is_not_configured ();
@@ -907,8 +768,7 @@ let () =
   test_cancelled_waiter_leaves_queue ();
   test_autonomous_yields_to_parked_chat ();
   test_idle_loop_yields_to_parked_chat ();
-  test_autonomous_yields_to_queued_connector_message ();
-  test_compaction_lane_bypasses_chat_backlog ();
+  test_pending_receipt_is_not_an_admission_authority ();
   test_shutdown_reservation_fences_and_rolls_back ();
   test_shutdown_reservation_restores_durable_owner ();
   if !failures > 0

--- a/test/test_keeper_waiting_inventory.ml
+++ b/test/test_keeper_waiting_inventory.ml
@@ -77,6 +77,23 @@ let ensure_keeper config keeper_name =
   | Error err -> fail ("write keeper meta failed: " ^ err)
 ;;
 
+let claim_pending_head keeper_name =
+  match Keeper_chat_queue.observe_pending ~keeper_name with
+  | Ok (Some observation) ->
+    (match Keeper_chat_queue.lease_observed observation with
+     | `Leased lease -> lease
+     | `Stale _ -> fail "pending chat receipt observation became stale"
+     | `Error error ->
+       fail
+         ("pending chat receipt claim failed: "
+          ^ Keeper_chat_queue.mutation_error_to_string error))
+  | Ok None -> fail "pending chat receipt is not observable"
+  | Error error ->
+    fail
+      ("pending chat receipt observation failed: "
+       ^ Keeper_chat_queue.mutation_error_to_string error)
+;;
+
 let keeper_meta_exn config keeper_name =
   match Keeper_meta_store.read_meta config keeper_name with
   | Ok (Some meta) -> meta
@@ -319,12 +336,7 @@ let test_chat_queue_pending_rows_are_visible () =
              |> to_string)
       | rows -> failf "expected one chat queue row, got %d" (List.length rows)))
   ;
-  let lease =
-    match Keeper_chat_queue.lease_next ~keeper_name with
-    | `Leased lease -> lease
-    | `Empty | `Already_leased _ | `Recovery_required _ | `Error _ ->
-      fail "pending chat receipt should lease"
-  in
+  let lease = claim_pending_head keeper_name in
   let inflight_json = Server_keeper_waiting_inventory.dashboard_json config in
   match find_keeper inflight_json keeper_name with
   | None -> fail "inflight keeper row missing"
@@ -371,12 +383,7 @@ let test_chat_queue_recovery_required_row_is_visible () =
         ("chat queue recovery enqueue failed: "
          ^ Keeper_chat_queue.mutation_error_to_string error)
   in
-  let lease =
-    match Keeper_chat_queue.lease_next ~keeper_name with
-    | `Leased lease -> lease
-    | `Empty | `Already_leased _ | `Recovery_required _ | `Error _ ->
-      fail "chat queue recovery receipt should lease"
-  in
+  let lease = claim_pending_head keeper_name in
   Keeper_chat_queue.For_testing.reset ();
   let report =
     Keeper_chat_queue.configure_persistence

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -135,8 +135,7 @@ let test_busy_cycle_records_no_turn_status_or_work_heartbeat () =
   let accounting =
     Masc.Keeper_heartbeat_loop.keepalive_cycle_accounting
       (Masc.Keeper_heartbeat_loop.Turn_cycle_busy
-         (Masc.Keeper_turn_admission.Chat_backlog
-            { pending_count = 2; inflight_count = 1 }))
+         (Masc.Keeper_turn_admission.Turn_busy None))
   in
   check bool "busy cycle records no turn status" false accounting.record_turn_status;
   check


### PR DESCRIPTION
## Summary

- observe the exact FIFO head while its receipt remains `Pending`, park the chat fiber on the per-Keeper turn mutex, and claim that exact receipt only after admission
- make the turn mutex the single live chat/autonomous admission authority by removing `Chat_backlog`, queue-backed autonomous gates, and the lease-first/facade admission APIs
- keep one autonomous admission core (`run_if_free_with_token`) plus the necessary non-token wrapper; remove the intermediate facade chain
- run queued server turns under the queue consumer switch without creating a second durable `Keeper_msg_async` request
- retain only the direct-chat post-lock active-receipt check that prevents a live direct request from overtaking accepted FIFO work
- keep pre-claim rejection/failure effect-free: no receipt claim, turn outcome, transcript write, or second durable request
- terminalize structured cancellation after an exact claim as typed `Cancelled` with unknown-effect detail, so a provider/tool effect is never automatically redelivered
- on an indeterminate claim, reconcile once and retry the same FIFO receipt once inside the already-admitted turn; a repeated failure remains `Pending` for the next explicit lane transition without a process-wide revision gate or self-wake loop
- remove the obsolete `Nack` queue/store/wire variant instead of retaining a compatibility path
- remove the orphan pending-observation revision accessor and reduce blocked finalization evidence to the exact required lease ID and typed persistence error

No migration, compatibility, or legacy queue path is added. No operator-only retry facade, durable claim gate, retry timer, or heuristic retry counter is introduced.

## Verification

Exact-head focused build:

```sh
scripts/dune-local.sh build \
  test/test_keeper_chat_consumer_delivery.exe \
  test/test_keeper_chat_admission_contention.exe \
  test/test_keeper_chat_coalescing.exe \
  test/test_keeper_turn_admission.exe
```

Passed directly:

- `test_keeper_chat_consumer_delivery.exe`
- `test_keeper_chat_admission_contention.exe`
- `test_keeper_chat_coalescing.exe`
- `test_keeper_turn_admission.exe`
- changed OCaml files: `ocamlformat --check`
- `git diff --check`
- adversarial review of exact SHA `c36b7e17e671c5155aed8782d08d225f5a1ac1b3`: PASS, no P0-P3

Known current-main failure outside this change:

- #26303: removed Keeper meta fields remain in the waiting-inventory test fixture (`sandbox_profile`, `network_mode`)
