### PR TITLE
test(otel): histogram bucket le 라벨을 bound에 고정

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -1971,6 +1971,8 @@
 
 (include stanzas/test_keeper_compaction_settlement_counters.inc)
 
+(include stanzas/test_otel_histogram_bucket_labels.inc)
+
 (include stanzas/test_keeper_receipt_authoritative.inc)
 
 (include stanzas/test_keeper_receipt_authoritative_matrix.inc)

--- a/test/stanzas/test_otel_histogram_bucket_labels.inc
+++ b/test/stanzas/test_otel_histogram_bucket_labels.inc
@@ -1,0 +1,6 @@
+; Histogram bucket [le] labels must name the bound the store compared against.
+
+(test
+ (name test_otel_histogram_bucket_labels)
+ (modules test_otel_histogram_bucket_labels)
+ (libraries alcotest masc.otel_metric_store))

--- a/test/test_otel_histogram_bucket_labels.ml
+++ b/test/test_otel_histogram_bucket_labels.ml
@@ -1,0 +1,92 @@
+(** A bucket's [le] label must name the bound the comparison actually used.
+
+    The label is produced from the registered bound, and a lossy rendering
+    makes the exported bucket advertise a threshold the store never compared
+    against: [Printf.sprintf "%g" 1048576.] yields ["1.04858e+06"], which
+    parses back to 1048580. A dashboard reading that label would attribute
+    observations to a bound four bytes away from the real one, and byte-scale
+    bounds are exactly what a request-size histogram registers.
+
+    The expected labels below are written as literals rather than re-derived
+    from the bounds, so a change to the rendering has to be stated here to
+    pass rather than silently agreeing with itself. *)
+
+open Alcotest
+
+let bucket_count ~name ~le =
+  Otel_metric_store_core.metric_value_or_zero
+    (name ^ "_bucket")
+    ~labels:[ "le", le ]
+    ()
+;;
+
+let observe_into ~name ~bounds value =
+  Otel_metric_store_core.register_histogram_buckets name bounds;
+  Otel_metric_store_core.observe_histogram name value
+;;
+
+(* MiB-scale bounds need more than six significant digits, which is where a
+   default [%g] rendering starts losing them. *)
+let test_mib_scale_bounds_keep_their_exact_label () =
+  let name = "masc_test_histogram_mib_bounds" in
+  observe_into ~name ~bounds:[ 262144.; 524288.; 1048576.; 2097152.; 16777216. ] 1.0;
+  List.iter
+    (fun le ->
+       check
+         (float 0.5)
+         (Printf.sprintf "an observation below every bound lands in le=%s" le)
+         1.
+         (bucket_count ~name ~le))
+    [ "262144"; "524288"; "1048576"; "2097152"; "16777216" ]
+;;
+
+(* Sub-second bounds must not pick up a spurious exponent or trailing dot. *)
+let test_fractional_bounds_keep_their_exact_label () =
+  let name = "masc_test_histogram_fractional_bounds" in
+  observe_into ~name ~bounds:[ 0.001; 0.025; 0.5; 1.0; 2.5; 1000. ] 0.0;
+  List.iter
+    (fun le ->
+       check
+         (float 0.5)
+         (Printf.sprintf "an observation below every bound lands in le=%s" le)
+         1.
+         (bucket_count ~name ~le))
+    [ "0.001"; "0.025"; "0.5"; "1"; "2.5"; "1000" ]
+;;
+
+(* Without this, a label that named the wrong threshold would still satisfy the
+   checks above, because nothing would have compared against it. *)
+let test_bounds_below_the_observation_stay_empty () =
+  let name = "masc_test_histogram_boundary" in
+  observe_into ~name ~bounds:[ 1048576.; 2097152. ] 1_500_000.;
+  check
+    (float 0.5)
+    "a bound below the observation stays empty"
+    0.
+    (bucket_count ~name ~le:"1048576");
+  check
+    (float 0.5)
+    "a bound above the observation counts it"
+    1.
+    (bucket_count ~name ~le:"2097152")
+;;
+
+let () =
+  run
+    "otel histogram bucket labels"
+    [ ( "le labels"
+      , [ test_case
+            "MiB-scale bounds keep their exact label"
+            `Quick
+            test_mib_scale_bounds_keep_their_exact_label
+        ; test_case
+            "fractional bounds keep their exact label"
+            `Quick
+            test_fractional_bounds_keep_their_exact_label
+        ; test_case
+            "bounds below the observation stay empty"
+            `Quick
+            test_bounds_below_the_observation_stay_empty
+        ] )
+    ]
+;;


### PR DESCRIPTION
`histogram_bound_label`은 회귀 테스트가 없습니다. `%g`로 되돌려도 아무 체크가 실패하지 않습니다.

## 배경

#26387 리뷰에서 codex가 MiB 스케일 bound의 라벨 정밀도 손실을 지적했고, 그 PR에서 `Printf.sprintf "%g"` → `Float.to_string` 기반 렌더링으로 수정됐습니다 (`0ea0213b4a`). 수정은 맞지만 고정되지 않았습니다.

`%g`의 기본 정밀도는 유효숫자 6자리입니다:

```
1048576 -> "1.04858e+06" -> float_of_string -> 1048580   ← 4바이트 어긋남
2097152 -> "2.09715e+06" -> float_of_string -> 2097150
```

라벨이 광고하는 임계값과 store가 실제로 비교한 임계값이 달라집니다. #26387이 머지되어 `masc_keeper_runtime_request_wire_bytes`가 관측되기 시작했고, 여기에 byte 버킷을 등록하는 것이 자연스러운 다음 단계이므로 정확히 이 범위에 걸립니다.

## 변경

테스트만 추가합니다. `lib/`는 건드리지 않습니다.

관측 가능한 계약(export된 bucket의 `le` 라벨)을 검증하고, 기대 라벨은 bound에서 재유도하지 않고 **리터럴로** 씁니다 — 렌더링을 복제하면 구현이 자기 자신과 일치하는지만 확인하게 됩니다.

3개 테스트:

1. MiB 스케일 bound(`262144` ~ `16777216`)가 정확한 라벨을 유지
2. 소수 bound(`0.001` ~ `1000`)가 지수 표기나 뒤따르는 `.` 없이 유지 — `Float.to_string 1.0`은 `"1."`이므로 뒤 점 제거가 실제로 필요합니다
3. 관측값보다 작은 bound는 비어 있음 — 이게 없으면 잘못된 임계값을 가리키는 라벨도 1·2를 통과합니다(비교가 일어나지 않으므로)

## 검증

- `dune build --root . test/test_otel_histogram_bucket_labels.exe` 클린
- 3/3 통과
- **Mutation test**: `histogram_bound_label`을 `Printf.sprintf "%g"`로 되돌리면 3개 중 2개 실패 (`le=1048576` 버킷 부재, 경계 검사 실패). 원복 후 재실행 green. 테스트가 회귀를 실제로 잡는 것을 확인했습니다.

RFC-WAIVED: credential/identity/operator-control/sandbox/hooks/workflow 어느 subsystem도 건드리지 않습니다. 테스트 추가입니다.

WORKAROUND-WAIVED: 증상 억제가 아니라 이미 수행된 수정에 대한 회귀 고정입니다. 프로덕션 코드 변경 0줄이고, 새 게이트·카운터·문자열 분류기를 추가하지 않습니다.

Closes #26397

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
