### PR TITLE
fix(keeper): stop suspending compaction recovery

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -910,12 +910,6 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
                   m.runtime.compaction_rt.last_decision );
               ( "compaction_consecutive_failures",
                 `Int m.runtime.compaction_rt.consecutive_failures );
-              (* RFC-0351 S0 / #25461: operator-visible marker that the
-                 reactive compaction admission is suspended for this keeper. *)
-              ( "compaction_retry_suspended",
-                `Bool
-                  (Keeper_meta_contract.compaction_retry_suspended
-                     m.runtime.compaction_rt) );
               ("autoboot_enabled", `Bool m.autoboot_enabled);
               ("proactive_enabled", `Bool m.proactive.enabled);
               ("proactive_count_total", `Int m.runtime.proactive_rt.count_total);

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -340,22 +340,11 @@ let compaction_outcome_of_cycle_outcome = function
     (match failure.Keeper_unified_turn.source_disposition with
      | Keeper_unified_turn.Requeue_after_context_compaction
          Keeper_unified_turn.Compaction_committed ->
-       (* #25538: an in-lane commit is still one provider-overflow episode.
-          Advancing (not resetting) the streak is what lets an
-          incompressible floor reach the ceiling; only an overflow-free
-          completed turn — or the operator's manual commit — resets. *)
-       Some `Overflow_episode_committed
+       Some `Committed
      | Keeper_unified_turn.Requeue_after_context_compaction
          (Keeper_unified_turn.Compaction_attempt_failed _)
      | Keeper_unified_turn.Follow_failure_route_after_no_compaction _ ->
        Some `Failed
-     | Keeper_unified_turn.Requeue_after_context_compaction
-         (Keeper_unified_turn.Compaction_refused_without_attempt _) ->
-       (* The admission gate declined the trigger before reading a checkpoint or
-          calling the summarizer, so there is no compaction outcome to record.
-          Counting it advanced the streak the gate itself reads: live keeper
-          kidsnote reached 907 against a threshold of 3. *)
-       None
      | Keeper_unified_turn.Acknowledge_after_in_turn_handling -> Some `Failed
      | Keeper_unified_turn.Follow_failure_route
      | Keeper_unified_turn.Pause_after_transcript_corruption _ -> None)
@@ -873,11 +862,9 @@ let run_keepalive_unified_turn
                | Cycle.Manual_compaction_failed _ )
            | None ->
              ());
-      (* RFC-0351 S0 / #25461: advance the compaction streak read by the trigger.
-         [Keeper_post_turn] refuses another compaction once the streak reaches
-         [compaction_retry_escalation_threshold]. This update is intentionally
-         independent of Event Queue source selection: every failed compaction
-         must consume retry budget, including cycles with no selected source. *)
+      (* Persist compaction outcome telemetry independently of Event Queue
+         source selection. The observed failure streak never controls
+         admission; a committed compaction or overflow-free turn clears it. *)
       (let compaction_outcome =
          compaction_outcome_of_cycle_outcome !cycle_outcome_ref
        in

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -147,17 +147,15 @@ val record_crashed_cycle_failure :
 
 val compaction_outcome_of_cycle_outcome :
   Keeper_heartbeat_loop_cycle.cycle_outcome option ->
-  [ `Committed | `Overflow_episode_committed | `Failed | `Recovered ] option
-(** Pure mapping from a cycle outcome to the compaction-streak stamp
+  [ `Committed | `Failed | `Recovered ] option
+(** Pure mapping from a cycle outcome to compaction telemetry
     ([Keeper_meta_store.persist_compaction_outcome]). Manual-lane
     applied/failed outcomes and in-lane provider-overflow dispositions join
-    the same per-keeper streak. The streak counts consecutive
-    provider-overflow episodes (#25538): an in-lane commit maps to
-    [`Overflow_episode_committed] (advances the streak — committed savings
-    under an incompressible floor must still reach the ceiling), a completed
-    overflow-free turn maps to [`Recovered] (resets it), and only the
-    operator's manual commit maps to [`Committed] (count + reset).
-    Outcomes with no compaction involvement return [None]. *)
+    the same per-keeper observation. Any committed compaction maps to
+    [`Committed] (count + failure-streak reset), a completed overflow-free turn
+    maps to [`Recovered] (failure-streak reset), and an attempted compaction
+    without durable progress maps to [`Failed]. Outcomes with no compaction
+    involvement return [None]. *)
 
 
 (** Pure: post-turn status event derived from the registry

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -47,23 +47,10 @@ type compaction_runtime =
   ; last_check_ts : float
   ; last_decision : compaction_runtime_decision
   ; consecutive_failures : int
-    (* RFC-0351 S0 / #25461: consecutive manual-compaction failures and
-       reactive provider-overflow episodes for this keeper. In-lane recovery
-       advances the streak even when it durably compacts, because the retried
-       turn can still overflow at an incompressible floor. An overflow-free
-       completed turn or an operator-committed manual compaction resets it. At
-       the threshold, reactive preparation is refused without advancing the
-       streak again. *)
+    (* Consecutive compaction attempts that failed to commit durable progress.
+       This is observability only: it never grants or refuses admission.
+       Any committed compaction or overflow-free completed turn resets it. *)
   }
-
-(* RFC-0351 S0 / #25461: streak entries tolerated before reactive compaction
-   preparation is refused. Defined next to [consecutive_failures] so admission
-   and the status/dashboard projections that surface the suspended state read
-   one constant. *)
-let compaction_retry_escalation_threshold = 3
-
-let compaction_retry_suspended rt =
-  rt.consecutive_failures >= compaction_retry_escalation_threshold
 
 type proactive_runtime =
   { count_total : int

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -64,31 +64,10 @@ type compaction_runtime = {
   last_check_ts : float;
   last_decision : compaction_runtime_decision;
   consecutive_failures : int;
-      (** RFC-0351 S0 / #25461: consecutive manual-compaction failures and
-          reactive provider-overflow episodes. A reactive commit advances the
-          streak; an overflow-free completed turn or operator-committed manual
-          compaction resets it. Once it reaches
-          {!compaction_retry_escalation_threshold}, reactive preparation is
-          refused without counting that refusal as another failure. *)
+      (** Consecutive compaction attempts that failed to commit durable
+          progress. Observability only: it never grants or refuses admission.
+          Any committed compaction or overflow-free completed turn resets it. *)
 }
-
-val compaction_retry_escalation_threshold : int
-(** RFC-0351 S0 / #25461: streak entries tolerated before
-    [Keeper_post_turn.prepare_compaction] stops admitting reactive triggers.
-    Single definition shared by reactive admission and status/dashboard
-    projections.
-
-    The refusal is not itself a compaction failure — it reads this counter
-    without attempting anything, so settling it as one made the threshold
-    self-fulfilling (live keeper [kidsnote] reached 907 against a threshold of
-    3). It is reported as [Keeper_unified_turn.Compaction_refused_without_attempt]
-    and produces no persisted compaction outcome. *)
-
-val compaction_retry_suspended : compaction_runtime -> bool
-(** [true] once the persisted streak has reached
-    {!compaction_retry_escalation_threshold}. Reactive preparation is then
-    refused before checkpoint load or summarizer dispatch; the refusal leaves
-    the streak unchanged. *)
 
 type proactive_runtime = {
   count_total : int;

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -496,27 +496,21 @@ let persist_compaction_decision config ~keeper_name ~decision
    [persist_compaction_decision] so a concurrent CAS re-applies the stamp
    instead of dropping it.
 
-   Reset semantics (#25538): the streak counts consecutive provider-overflow
-   episodes, and only a turn that completes without overflow — or an
-   operator-committed manual compaction — resets it.  An in-lane (reactive)
-   commit advances the streak instead of resetting it: a committed plan that
-   saves 920B of a checkpoint (0.07%, live measurement) used to reset the
-   counter on every loop iteration, so an incompressible floor never reached
-   the ceiling.
+   [consecutive_failures] is diagnostic state only: an attempted compaction
+   failure advances it, while any committed compaction or overflow-free turn
+   resets it.  It is never an admission authority.
 
-   [`Committed]/[`Overflow_episode_committed] also advance [count].  That
-   field had no writer: it was serialized to meta and rendered by the
-   dashboard while nothing incremented it, so a keeper whose compaction
-   pipeline was committing normally still reported compaction_count=0 — one
-   keeper carried 88 committed [context_compacted] runtime-manifest records
-   against a meta reading 0. *)
+   [`Committed] also advances [count].  That field had no writer: it was
+   serialized to meta and rendered by the dashboard while nothing incremented
+   it, so a keeper whose compaction pipeline was committing normally still
+   reported compaction_count=0 — one keeper carried 88 committed
+   [context_compacted] runtime-manifest records against a meta reading 0. *)
 (* Rendering, not classification: the outcome variant is the state machine's
    own outcome, so the label comes from an exhaustive match instead of being
    recovered from a message string.  A new variant fails this match at compile
    time rather than falling into an unlabelled bucket. *)
 let compaction_outcome_label = function
   | `Committed -> "committed"
-  | `Overflow_episode_committed -> "overflow_episode_committed"
   | `Failed -> "failed"
   | `Recovered -> "recovered"
 ;;
@@ -529,11 +523,6 @@ let persist_compaction_outcome config ~keeper_name ~outcome
       (fun rt ->
         match outcome with
         | `Committed -> { rt with count = rt.count + 1; consecutive_failures = 0 }
-        | `Overflow_episode_committed ->
-          { rt with
-            count = rt.count + 1
-          ; consecutive_failures = rt.consecutive_failures + 1
-          }
         | `Failed -> { rt with consecutive_failures = rt.consecutive_failures + 1 }
         | `Recovered -> { rt with consecutive_failures = 0 })
       m

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -233,28 +233,20 @@ val persist_compaction_decision :
 val persist_compaction_outcome :
   Workspace.config ->
   keeper_name:string ->
-  outcome:
-    [ `Committed | `Overflow_episode_committed | `Failed | `Recovered ] ->
+  outcome:[ `Committed | `Failed | `Recovered ] ->
   ([ `Persisted | `No_durable_meta ], string) result
 (** Advance the compaction outcome counters on [compaction_rt] using the same
     read/stamp/merge shape as {!persist_compaction_decision}.
 
-    [`Overflow_episode_committed] (an in-lane reactive commit) increments
-    [count] AND the streak — committed savings under an incompressible floor
-    must still count toward the ceiling (#25538). [`Recovered] (a turn
-    completed without provider overflow) resets the streak; callers skip the
-    write when the streak is already 0.
-
     [`Committed] increments [count] and resets [consecutive_failures] to 0;
-    [`Failed] increments [consecutive_failures]. The streak is what
-    {!Keeper_meta_contract.compaction_retry_suspended} reads to refuse a
-    failing compaction instead of retrying it without bound (RFC-0351 S0,
-    #25461); [count] had no writer before this despite being serialized and
-    rendered. The metric carries [keeper] and [outcome]: outcome is the closed
-    outcome variant, and keeper names come from the registry and survive
-    replacement, so the series count is bounded by fleet size. The successful
-    persistence log carries the same typed outcome, which is where a single
-    outcome is resolvable by timestamp; the durable per-Keeper counters stay in
+    [`Failed] increments [consecutive_failures]; [`Recovered] resets it. The
+    streak is diagnostic observability only and never controls admission.
+    [count] had no writer before this despite being serialized and rendered.
+    The metric carries [keeper] and [outcome]: outcome is the closed outcome
+    variant, and keeper names come from the registry and survive replacement,
+    so the series count is bounded by fleet size. The successful persistence
+    log carries the same typed outcome, which is where a single outcome is
+    resolvable by timestamp; the durable per-Keeper counters stay in
     [compaction_rt]. *)
 
 val persist_transcript_corruption_pause :

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -72,7 +72,6 @@ type compaction_recovery_error =
   | Checkpoint_candidate_failed of string
   | Compaction_rejected of Keeper_compact_policy.compaction_rejection
   | No_compaction of no_compaction
-  | Retry_suspended of { consecutive_failures : int }
 
 type prepared_commit_failure =
   { error : compaction_recovery_error
@@ -112,7 +111,6 @@ let compaction_recovery_error_to_tag = function
     Keeper_compact_policy.compaction_rejection_to_tag reason
   | No_compaction { reason; _ } ->
     "no_compaction:" ^ Keeper_compaction_outcome.no_compaction_reason_label reason
-  | Retry_suspended _ -> "retry_suspended"
 
 let checkpoint_load_error_detail = function
   | Keeper_checkpoint_store.Not_found -> "checkpoint not found"
@@ -194,12 +192,6 @@ let compaction_recovery_error_to_string = function
       source.turn_count
       source.sha256
       (Keeper_compaction_outcome.no_compaction_reason_to_string reason)
-  | Retry_suspended { consecutive_failures } ->
-    Printf.sprintf
-      "compaction retry suspended after %d consecutive failures; reactive \
-       prepare refused before the summarizer call — an operator-committed \
-       manual compaction resets the streak and lifts the suspension"
-      consecutive_failures
 
 (* ── Tier A6: resilience post-turn wire-in (Cycle 23) ──────────────
    Feature-flag-gated layer that runs before tool emission and
@@ -717,41 +709,13 @@ let prepare_compaction_admitted
                (Keeper_compact_policy.compaction_decision_to_string decision))))
 ;;
 
-(* RFC-0351 S0 / #25461: reactive admission gate in front of the prepare
-   phase. Once the persisted failure streak reaches the escalation threshold
-   reactive preparation is refused before checkpoint load or a summarizer LLM
-   call. The manual trigger passes through on purpose: an operator-committed
-   compaction is the recovery lever — its commit resets the streak and lifts
-   the suspension. *)
 let prepare_compaction_with
       ~compact_for_request
       ~base_dir
       ~(meta : keeper_meta)
       ~(trigger : Compaction_trigger.t)
   : (prepared_compaction, compaction_recovery_error) result =
-  let suspended =
-    Keeper_meta_contract.compaction_retry_suspended meta.runtime.compaction_rt
-  in
   match trigger with
-  (* The suspension guard follows the trigger's origin, not its axis. The
-     provider token window, serialized byte limit, and serving-admission token
-     evidence are all raised by the turn path itself, so a suspended retry must
-     refuse them or a keeper whose compactions keep failing would keep
-     re-entering compaction on every turn. [Manual] stays exempt: an operator
-     asked for this one, and refusing it would leave no way to intervene. *)
-  | Compaction_trigger.Provider_overflow _
-  | Compaction_trigger.Request_body_over_capacity _
-  | Compaction_trigger.Request_body_refused_by_provider _
-  | Compaction_trigger.Serving_input_capacity
-      (Compaction_trigger.Boundary_unknown _)
-  | Compaction_trigger.Serving_input_capacity
-      (Compaction_trigger.Input_rejected _)
-    when suspended ->
-    Error
-      (Retry_suspended
-         { consecutive_failures =
-             meta.runtime.compaction_rt.consecutive_failures
-         })
   | Compaction_trigger.Provider_overflow _
   | Compaction_trigger.Request_body_over_capacity _
   | Compaction_trigger.Request_body_refused_by_provider _

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -47,15 +47,6 @@ type compaction_recovery_error =
   | Checkpoint_candidate_failed of string
   | Compaction_rejected of Keeper_compact_policy.compaction_rejection
   | No_compaction of no_compaction
-  | Retry_suspended of { consecutive_failures : int }
-      (** RFC-0351 S0 / #25461: the keeper's compaction failure streak reached
-          [Keeper_meta_contract.compaction_retry_escalation_threshold], so a
-          reactive ([Provider_overflow]) prepare is refused before the
-          checkpoint load and the summarizer LLM call. The pending source
-          remains on the ordinary failure route without a fabricated durable
-          escalation.
-          [Manual] prepares bypass the gate: an operator-committed compaction
-          resets the streak and lifts the suspension. *)
 
 type prepared_commit_failure =
   { error : compaction_recovery_error

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -124,10 +124,6 @@ let handle_keeper_list ctx args : tool_result =
               ("last_compaction_saved_tokens", `Int last_compaction_saved_tokens);
               ( "compaction_consecutive_failures",
                 `Int m.runtime.compaction_rt.consecutive_failures );
-              ( "compaction_retry_suspended",
-                `Bool
-                  (Keeper_meta_contract.compaction_retry_suspended
-                     m.runtime.compaction_rt) );
               ("autoboot_enabled", `Bool m.autoboot_enabled);
               ("proactive_enabled", `Bool m.proactive.enabled);
               ("proactive_count_total", `Int m.runtime.proactive_rt.count_total);

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -22,7 +22,6 @@ include Keeper_unified_turn_phase_plan
 type in_lane_compaction =
   | Compaction_committed
   | Compaction_attempt_failed of { reason : string }
-  | Compaction_refused_without_attempt of { consecutive_failures : int }
 
 type source_disposition =
   | Follow_failure_route
@@ -194,10 +193,6 @@ type provider_overflow_recovery =
       { trigger : Compaction_trigger.t
       ; reason : string
       }
-  | Provider_overflow_refused_without_attempt of
-      { trigger : Compaction_trigger.t
-      ; consecutive_failures : int
-      }
   | Provider_overflow_retry_with_checkpoint of
       { reason : string
       ; recovery : Keeper_post_turn.compaction_recovery
@@ -295,33 +290,6 @@ let recover_provider_context_overflow_in_lane
          | None -> Provider_overflow_retry_without_checkpoint { trigger; reason }
          | Some recovery -> Provider_overflow_retry_with_checkpoint { reason; recovery })
     in
-    (* The admission gate declined the trigger: no checkpoint was read, no
-       summarizer ran, no compaction was attempted. The overflow itself is real
-       and unresolved, so the observation and the lifecycle release both stand —
-       what must not happen is settling this as a compaction outcome, because
-       that made the gate's own refusal advance the streak the gate reads. *)
-    let refused_without_attempt ~consecutive_failures =
-      let reason =
-        Printf.sprintf
-          "compaction retry suspended after %d consecutive failures"
-          consecutive_failures
-      in
-      record_overflow_failure ~config ~meta ~reason;
-      match release_failed_lifecycle reason with
-      | Error cleanup_error ->
-        Provider_overflow_lifecycle_cleanup_failed
-          { trigger
-          ; reason =
-              Printf.sprintf "%s; lifecycle_cleanup=%s" reason cleanup_error
-          ; source_disposition =
-              Requeue_after_context_compaction
-                (Compaction_refused_without_attempt { consecutive_failures })
-          ; recovery = None
-          }
-      | Ok () ->
-        Provider_overflow_refused_without_attempt
-          { trigger; consecutive_failures }
-    in
     let terminal_no_compaction no_compaction =
       Eio.Cancel.protect (fun () ->
         let error = Keeper_post_turn.No_compaction no_compaction in
@@ -370,8 +338,6 @@ let recover_provider_context_overflow_in_lane
     in
     let failed ({ error; committed } : Keeper_post_turn.prepared_commit_failure) =
       match committed, error with
-      | None, Keeper_post_turn.Retry_suspended { consecutive_failures } ->
-        refused_without_attempt ~consecutive_failures
       | ( None
         , ( Keeper_post_turn.Checkpoint_ref_load_failed _
           | Keeper_post_turn.Checkpoint_cas_failed _
@@ -604,18 +570,6 @@ let append_provider_overflow_manifest
     in
     Requeue_after_context_compaction (Compaction_attempt_failed { reason }),
     turn_state
-  | Provider_overflow_refused_without_attempt { trigger = _; consecutive_failures }
-    ->
-    (* No runtime-manifest record: every manifest kind reachable here asserts a
-       compaction ran, and none did. Emitting [Context_compacted] with
-       [compaction_outcome:Retry_without_checkpoint] — what the attempt-failed
-       arm above does — is why 12,777 [compaction_started] transitions
-       reconciled against roughly 401 prepared plans. The refusal stays visible
-       through [record_overflow_failure]'s WARN, the registry phase transition,
-       and the persisted [last_compaction_decision]. *)
-    ( Requeue_after_context_compaction
-        (Compaction_refused_without_attempt { consecutive_failures })
-    , turn_state )
   | Provider_overflow_lifecycle_cleanup_failed
       { trigger; reason; source_disposition; recovery } ->
     let turn_state =

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -124,29 +124,13 @@ val record_streaming_cancelled_observation
 type in_lane_compaction =
   | Compaction_committed
   | Compaction_attempt_failed of { reason : string }
-  | Compaction_refused_without_attempt of { consecutive_failures : int }
 (** Typed outcome of the in-lane provider-overflow compaction behind a
     [Requeue_after_context_compaction] disposition. [Compaction_committed]
-    proves the checkpoint durably shrank before the requeue. It still advances
-    the provider-overflow episode streak; only an overflow-free completed turn
-    or an operator-committed manual compaction resets it. The retry reloads the
-    durable progress. [Compaction_attempt_failed] means the recovery made no
-    durable progress and also advances the streak. Once the streak reaches
-    [Keeper_meta_contract.compaction_retry_escalation_threshold], subsequent
-    reactive admission is refused (RFC-0351 S0, #25461 — without the ceiling
-    this lane requeued forever: 284 of 285 rejections in the 2026-07-21 storm
-    carried trigger=provider_overflow and only the operator's keeper_down ended
-    it).
-
-    [Compaction_refused_without_attempt] is the admission gate declining the
-    trigger at that same threshold ([Keeper_post_turn.Retry_suspended]): no
-    checkpoint was read, no summarizer ran, and no compaction was attempted, so
-    the transition leaves the streak alone. Settling it as a failure made the
-    gate's own output advance the counter the gate reads — live keeper
-    [kidsnote] reached 907 against a threshold of 3, roughly 99.7% of it from
-    refusals, which left no statistic able to say what drove it there. The
-    ceiling, the threshold, and the LLM-call bound the gate exists for are all
-    unchanged; only this self-feeding edge is cut. *)
+    proves the checkpoint durably shrank before the requeue and resets the
+    observed failure streak. The retry reloads that durable progress.
+    [Compaction_attempt_failed] means the recovery made no durable progress
+    and advances the streak for observability without refusing a later
+    recovery attempt. *)
 
 type source_disposition =
   | Follow_failure_route
@@ -161,10 +145,7 @@ type source_disposition =
     to act ([no_compaction_reason]); the terminal transition advances the
     compaction-failure streak, because a turn whose context cannot shrink
     re-overflows deterministically on every retry. It does not replace the
-    route. The threshold makes [Keeper_post_turn.prepare_compaction] refuse
-    reactive triggers
-    ([Compaction_refused_without_attempt]); only an operator-committed manual
-    compaction or an overflow-free completed turn lifts it.
+    route or refuse later recovery attempts.
     [Requeue_after_context_compaction] preserves the exact source stimulus
     after MASC handled a typed provider overflow in this Keeper lane; the next
     cycle reloads the durably compacted checkpoint.

--- a/test/test_keeper_compaction_outcome_counters.ml
+++ b/test/test_keeper_compaction_outcome_counters.ml
@@ -77,7 +77,6 @@ let test_each_outcome_is_labelled () =
            (before +. 1.)
            (counted ~keeper_name:name ~outcome:label))
       [ `Committed, "committed"
-      ; `Overflow_episode_committed, "overflow_episode_committed"
       ; `Failed, "failed"
       ; `Recovered, "recovered"
       ])
@@ -108,6 +107,29 @@ let test_count_tracks_the_durable_streak () =
         4
         meta.Masc.Keeper_meta_contract.runtime.compaction_rt.consecutive_failures
     | Ok None -> fail "keeper meta disappeared mid-test"
+    | Error msg -> failf "meta read failed: %s" msg)
+;;
+
+let test_committed_compaction_resets_failure_streak () =
+  with_workspace (fun config ->
+    let name = "outcome-commit-reset" in
+    ignore (register config ~name);
+    persist_outcome config ~name ~outcome:`Failed;
+    persist_outcome config ~name ~outcome:`Failed;
+    persist_outcome config ~name ~outcome:`Committed;
+    match Meta_store.read_meta config name with
+    | Ok (Some meta) ->
+      check
+        int
+        "a successful reactive or manual commit resets diagnostic failures"
+        0
+        meta.Masc.Keeper_meta_contract.runtime.compaction_rt.consecutive_failures;
+      check
+        int
+        "the successful commit advances the durable compaction count"
+        1
+        meta.Masc.Keeper_meta_contract.runtime.compaction_rt.count
+    | Ok None -> fail "keeper meta disappeared after committed compaction"
     | Error msg -> failf "meta read failed: %s" msg)
 ;;
 
@@ -179,6 +201,10 @@ let () =
             "count tracks the durable streak"
             `Quick
             test_count_tracks_the_durable_streak
+        ; test_case
+            "committed compaction resets failure streak"
+            `Quick
+            test_committed_compaction_resets_failure_streak
         ; test_case
             "attributes the outcome to its keeper"
             `Quick

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -1101,272 +1101,71 @@ let test_post_dispatch_non_reducing_output_is_terminal () =
         (summarize_response (String.make 20_000 'x')))
 ;;
 
-(* RFC-0351 S0 / #25461: once the persisted failure streak suspends
-   compaction retries, a reactive prepare must be refused before any
-   checkpoint I/O — each new stimulus used to pay one full prepare
-   (checkpoint load + summarizer LLM call) before its escalation settled.
-   The fixture base_dir holds no checkpoint, so any prepare that passes the
-   gate deterministically fails with [Checkpoint_ref_load_failed Ref_not_found];
-   returning [Retry_suspended] instead proves the refusal fired first. *)
-let test_suspended_streak_refuses_reactive_prepare () =
+(* A persisted failure streak is observability, not an admission authority.
+   With no checkpoint installed, every trigger must reach the checkpoint store
+   even when the diagnostic streak is arbitrarily high. *)
+let test_failure_streak_never_refuses_compaction_prepare () =
   Eio_main.run @@ fun _env ->
-  let meta_with_streak streak =
+  let meta =
     match
       Masc_test_deps.meta_of_json_fixture
         (`Assoc
-          [ "name", `String "prepare-admission"
-          ; "trace_id", `String "trace-prepare-admission"
-          ; "compaction_consecutive_failures", `Int streak
+          [ "name", `String "prepare-observability"
+          ; "trace_id", `String "trace-prepare-observability"
+          ; "compaction_consecutive_failures", `Int 907
           ])
     with
     | Ok meta -> meta
-    | Error detail -> failf "prepare-admission meta fixture: %s" detail
+    | Error detail -> failf "prepare-observability meta fixture: %s" detail
   in
   let base_dir =
     Filename.concat
       (Filename.get_temp_dir_name ())
-      (Printf.sprintf "masc-prepare-admission-%d" (Unix.getpid ()))
+      (Printf.sprintf "masc-prepare-observability-%d" (Unix.getpid ()))
   in
-  let prepare ~streak ~trigger =
+  let prepare trigger =
     Post_turn.prepare_compaction
       ~base_path:base_dir
       ~base_dir
-      ~meta:(meta_with_streak streak)
+      ~meta
       ~trigger
       ()
   in
-  let suspended = meta_with_streak 3 in
-  check bool
-    "fixture streak reaches the suspension threshold"
-    true
-    (Masc.Keeper_meta_contract.compaction_retry_suspended
-       suspended.runtime.compaction_rt);
-  (match
-     prepare
-       ~streak:3
-       ~trigger:(Compaction_trigger.Provider_overflow { limit_tokens = None })
-   with
-   | Error (Post_turn.Retry_suspended { consecutive_failures }) ->
-     check int "refusal reports the persisted streak" 3 consecutive_failures
-   | Error error ->
-     failf
-       "suspended reactive prepare reached I/O instead of the admission gate: \
-        %s"
-       (Post_turn.compaction_recovery_error_to_string error)
-   | Ok _ -> fail "suspended reactive prepare produced a prepared compaction");
-  (match prepare ~streak:3 ~trigger:Compaction_trigger.Manual with
-   | Error
-       (Post_turn.Checkpoint_ref_load_failed Masc.Keeper_checkpoint_store.Ref_not_found)
-     ->
-     (* Reached the checkpoint load: the operator lever bypasses the gate. *)
-     ()
-   | Error error ->
-     failf
-       "suspended manual prepare did not reach the checkpoint load: %s"
-       (Post_turn.compaction_recovery_error_to_string error)
-   | Ok _ -> fail "manual prepare on an empty store produced a compaction");
-  (match
-     prepare
-       ~streak:2
-       ~trigger:(Compaction_trigger.Provider_overflow { limit_tokens = None })
-   with
-   | Error
-       (Post_turn.Checkpoint_ref_load_failed Masc.Keeper_checkpoint_store.Ref_not_found)
-     ->
-     (* Below the threshold the reactive path is admitted unchanged. *)
-     ()
-   | Error error ->
-     failf
-       "below-threshold reactive prepare did not reach the checkpoint load: %s"
-       (Post_turn.compaction_recovery_error_to_string error)
-   | Ok _ -> fail "reactive prepare on an empty store produced a compaction");
-  (* The byte axis follows the same gate as the token axis, not the operator lever.
-     Both are raised by the turn path itself, so a suspended keeper must refuse both —
-     the compiler forced that decision when the variant was added (masc#25739) but
-     nothing pinned the answer, and the two plausible wrong answers are opposites:
-     treating it like Manual would let a failing keeper re-enter compaction every turn,
-     while refusing it below the threshold would deny a reduction the token axis is
-     granted. *)
-  let byte_over_capacity =
-    Compaction_trigger.Request_body_over_capacity
-      { actual_bytes = 2_000_000; limit_bytes = 1_048_576 }
-  in
-  (match prepare ~streak:3 ~trigger:byte_over_capacity with
-   | Error (Post_turn.Retry_suspended { consecutive_failures }) ->
-     check int "suspended byte-axis refusal reports the streak" 3 consecutive_failures
-   | Error error ->
-     failf
-       "suspended byte-axis prepare reached I/O instead of the admission gate: %s"
-       (Post_turn.compaction_recovery_error_to_string error)
-   | Ok _ -> fail "suspended byte-axis prepare produced a prepared compaction");
-  (match prepare ~streak:2 ~trigger:byte_over_capacity with
-   | Error
-       (Post_turn.Checkpoint_ref_load_failed Masc.Keeper_checkpoint_store.Ref_not_found)
-     ->
-     (* Below the threshold the byte axis is admitted exactly as the token axis is. *)
-     ()
-   | Error error ->
-     failf
-       "below-threshold byte-axis prepare did not reach the checkpoint load: %s"
-       (Post_turn.compaction_recovery_error_to_string error)
-   | Ok _ -> fail "byte-axis prepare on an empty store produced a compaction");
   List.iter
-    (fun (reason, trigger) ->
-       (match prepare ~streak:3 ~trigger with
-        | Error (Post_turn.Retry_suspended { consecutive_failures }) ->
-          check
-            int
-            ("suspended serving-axis " ^ reason ^ " reports the streak")
-            3
-            consecutive_failures
-        | Error error ->
-          failf
-            "suspended serving-axis %s reached I/O instead of the admission gate: %s"
-            reason
-            (Post_turn.compaction_recovery_error_to_string error)
-        | Ok _ ->
-          failf "suspended serving-axis %s produced a prepared compaction" reason);
-       match prepare ~streak:2 ~trigger with
+    (fun (name, trigger) ->
+       match prepare trigger with
        | Error
            (Post_turn.Checkpoint_ref_load_failed
               Masc.Keeper_checkpoint_store.Ref_not_found) ->
          ()
        | Error error ->
          failf
-           "below-threshold serving-axis %s did not reach the checkpoint load: %s"
-           reason
+           "%s was refused before checkpoint loading: %s"
+           name
            (Post_turn.compaction_recovery_error_to_string error)
        | Ok _ ->
-         failf
-           "serving-axis %s prepare on an empty store produced a compaction"
-           reason)
-    [ ( "boundary_unknown"
+         failf "%s unexpectedly prepared from an empty checkpoint store" name)
+    [ ( "provider overflow"
+      , Compaction_trigger.Provider_overflow { limit_tokens = None } )
+    ; ( "request body over capacity"
+      , Compaction_trigger.Request_body_over_capacity
+          { actual_bytes = 2_000_000; limit_bytes = 1_048_576 } )
+    ; ( "serving boundary unknown"
       , Compaction_trigger.Serving_input_capacity
           (Compaction_trigger.Boundary_unknown
              { input_tokens = 524_299
              ; accepted_through = 524_298
              ; rejected_from = Some 524_300
              }) )
-    ; ( "input_rejected"
+    ; ( "serving input rejected"
       , Compaction_trigger.Serving_input_capacity
           (Compaction_trigger.Input_rejected
              { input_tokens = 524_300
              ; accepted_through = 524_298
              ; rejected_from = 524_299
              }) )
+    ; "manual", Compaction_trigger.Manual
     ]
-;;
-
-(* Step 0 characterization — the compaction suspension gate is self-feeding.
-
-   [test_suspended_streak_refuses_reactive_prepare] above pins the first hop: at
-   [Keeper_meta_contract.compaction_retry_escalation_threshold] the reactive
-   prepare is refused before any I/O. This test pins the two hops that close the
-   loop — the refusal was recorded as a compaction failure, and that outcome
-   advanced the very counter the gate reads.
-
-   Live evidence for the loop: keeper [kidsnote] reached
-   compaction_consecutive_failures=907 against a threshold of 3
-   (.masc/logs/system_log_2026-07-29.jsonl), so roughly 99.7% of that counter's
-   value came from refusals that never attempted a compaction. While the counter
-   is inflated this way, no statistic can say what actually drove the keeper to
-   the threshold.
-
-   The gate, the threshold, and the LLM-call bound it exists for are unchanged;
-   only the self-feeding edge is cut. The second half of this test pins that a
-   real compaction failure still advances the streak, so the ceiling that
-   #25461 added keeps working. *)
-let test_refusal_records_no_compaction_failure () =
-  Eio_main.run @@ fun _env ->
-  let meta =
-    match
-      Masc_test_deps.meta_of_json_fixture
-        (`Assoc
-          [ "name", `String "suspension-outcome"
-          ; "trace_id", `String "trace-suspension-outcome"
-          ; "compaction_consecutive_failures", `Int 3
-          ])
-    with
-    | Ok meta -> meta
-    | Error detail -> failf "suspension-outcome meta fixture: %s" detail
-  in
-  check
-    bool
-    "fixture sits at the suspension threshold"
-    true
-    (Masc.Keeper_meta_contract.compaction_retry_suspended
-       meta.runtime.compaction_rt);
-  (* A refused prepare attempted no compaction, so it records no outcome. *)
-  let turn_failure_with source_disposition : Masc.Keeper_unified_turn.turn_failure =
-    { error = Agent_sdk.Error.Internal "suspended reactive prepare"
-    ; runtime_id = "suspension-characterization"
-    ; route =
-        Keeper_runtime_failure_route.Retry_after_observed
-          { retry_class = Keeper_runtime_failure_route.Rate_limited
-          ; retry_after = None
-          }
-    ; source_disposition
-    ; deferred_runtime_lane = None
-    }
-  in
-  let outcome_of source_disposition =
-    Masc.Keeper_heartbeat_loop.compaction_outcome_of_cycle_outcome
-      (Some (Cycle.Failed { meta; failure = turn_failure_with source_disposition }))
-  in
-  check
-    bool
-    "a refusal that attempted no compaction records no outcome"
-    true
-    (outcome_of
-       (Masc.Keeper_unified_turn.Requeue_after_context_compaction
-          (Masc.Keeper_unified_turn.Compaction_refused_without_attempt
-             { consecutive_failures = 3 }))
-     = None);
-  (* The ceiling #25461 added still works: a compaction that ran and made no
-     durable progress still advances the streak. *)
-  check
-    bool
-    "an attempted compaction that made no progress records a failure"
-    true
-    (outcome_of
-       (Masc.Keeper_unified_turn.Requeue_after_context_compaction
-          (Masc.Keeper_unified_turn.Compaction_attempt_failed
-             { reason = "checkpoint candidate rejected" }))
-     = Some `Failed);
-  (* Persisting that outcome advances the counter the gate reads. *)
-  let base =
-    Filename.concat
-      (Filename.get_temp_dir_name ())
-      (Printf.sprintf "masc-suspension-outcome-%d" (Unix.getpid ()))
-  in
-  let config = Masc.Workspace.default_config base in
-  (match Masc.Keeper_meta_store.write_meta config meta with
-   | Ok () -> ()
-   | Error detail -> failf "durable meta write: %s" detail);
-  (match
-     Masc.Keeper_meta_store.persist_compaction_outcome
-       config
-       ~keeper_name:meta.name
-       ~outcome:`Failed
-   with
-   | Ok `Persisted -> ()
-   | Ok `No_durable_meta -> fail "outcome found no durable meta to update"
-   | Error detail -> failf "outcome persistence: %s" detail);
-  match Masc.Keeper_meta_store.read_meta config meta.name with
-  | Error detail -> failf "durable meta read-back: %s" detail
-  | Ok None -> fail "durable meta vanished after outcome persistence"
-  | Ok (Some updated_meta) ->
-    check
-      int
-      "an attempted-and-failed compaction advances the streak"
-      4
-      updated_meta.runtime.compaction_rt.consecutive_failures;
-    check
-      bool
-      "and that is what keeps the keeper suspended"
-      true
-      (Masc.Keeper_meta_contract.compaction_retry_suspended
-         updated_meta.runtime.compaction_rt)
 ;;
 
 let () =
@@ -1403,10 +1202,8 @@ let () =
         `Quick test_invalid_structural_evidence_after_dispatch_is_terminal;
       test_case "non-reducing output is terminal"
         `Quick test_post_dispatch_non_reducing_output_is_terminal;
-      test_case "suspended streak refuses reactive prepare"
-        `Quick test_suspended_streak_refuses_reactive_prepare;
-      test_case "refusal records no compaction failure"
-        `Quick test_refusal_records_no_compaction_failure;
+      test_case "failure streak never refuses compaction prepare"
+        `Quick test_failure_streak_never_refuses_compaction_prepare;
       test_case "missing exact lane is source-bound no-compaction"
         `Quick test_missing_exact_lane_is_source_bound_no_compaction;
     ];


### PR DESCRIPTION
## 문제

실제 Keeper는 request_body_too_large 뒤 reactive compaction을 성공적으로 commit해도 failure streak를 증가시켰습니다. 두 번의 성공과 한 번의 실패만으로 threshold 3에 도달하면 이후 모든 reactive prepare를 영구 거부했습니다. 그러나 provider 요청 자체는 매 턴 계속 실행되어 비용과 실패 반복은 막지 못하고 복구만 막았습니다.

## 변경

- compaction_retry_suspended admission Gate와 threshold를 제거합니다.
- Retry_suspended 및 refused-without-attempt 상태를 typed turn contract에서 제거합니다.
- 모든 typed compaction trigger가 동일한 prepare 경로로 진입합니다.
- consecutive_failures는 관측 전용 파생 상태로 유지합니다.
- 실제 compaction 실패만 증가시키고, reactive/manual commit 또는 overflow-free recovery가 reset합니다.
- status/dashboard의 suspended 파생 필드를 제거합니다.

마이그레이션이나 legacy compatibility 경로는 추가하지 않았고, 문자열 판별도 사용하지 않았습니다.

## 검증

- scripts/dune-local.sh build test/test_keeper_post_turn_wirein_order.exe test/test_keeper_compaction_outcome_counters.exe
- _build/default/test/test_keeper_post_turn_wirein_order.exe: 15 passed
- _build/default/test/test_keeper_compaction_outcome_counters.exe: 6 passed
- ocamlc parse, ocamlformat --check, git diff --check passed

## 런타임 근거

2026-07-30 KST 현재 배포된 0ea0213b4a 런타임에서 analyst, executor, verifier가 request_body_too_large 뒤 compaction retry suspended after 3 consecutive failures를 반복했습니다. executor는 두 번의 committed compaction 뒤 한 번의 invalid plan으로 streak 3에 도달한 다음 복구만 영구 거부했습니다. 이 PR은 소스/로컬 검증 단계이며 배포 후 동일 live fleet에서 별도 확인이 필요합니다.