### PR TITLE
fix(keeper): 압축이 첫 User 메시지를 제외하던 휴리스틱 제거

### DIFF
--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -304,16 +304,15 @@ let cycle_has_tool_protocol messages =
   in
   has_tool_use && has_tool_result
 
-let eligible_source ~first_user_seen source_index = function
+let eligible_source source_index = function
   | Keeper_compaction_unit.Ordinary_message
-      ({ role = (Agent_sdk.Types.User | Agent_sdk.Types.Assistant)
-       ; content
-       ; name = None
-       ; tool_call_id = None
-       ; metadata = []
-       } as message)
-    when message.role <> Agent_sdk.Types.User || first_user_seen ->
-    (match message_text_source message.role content with
+      { role = (Agent_sdk.Types.User | Agent_sdk.Types.Assistant) as role
+      ; content
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      } ->
+    (match message_text_source role content with
      | Some source -> Some { source_index; payload = Message_text source }
      | None -> None)
   | Keeper_compaction_unit.Closed_tool_cycle messages
@@ -329,33 +328,23 @@ let eligible_source ~first_user_seen source_index = function
   | Keeper_compaction_unit.Closed_tool_cycle _ ->
     None
 
+(* Every text-bearing unit is eligible; position carries no meaning here.
+
+   The first User message used to be excluded as "the goal anchor". The goal is
+   not in the message list: it is assembled into [system_prompt] every turn, and
+   [Keeper_context_core.serialize_context] keeps that field outside the
+   compacted messages, so nothing in the transcript had to be pinned to preserve
+   it. Across 130 live checkpoints the excluded message was the wake marker
+   "(autonomous wake - the current observation frame is provided per-turn in
+   system context)" 117 times and an ordinary chat line the remaining 13 -- a
+   goal statement zero times.
+
+   The exclusion was not free: [oldest_contiguous_run] stops at the first index
+   gap, so an excluded unit anywhere but index 0 truncated the window to
+   whatever preceded it. Live keeper checkpoints reached 2 selectable units out
+   of 1,156. *)
 let eligible_sources units =
-  (* The first User message is the exact goal anchor. Later plain User messages
-     are part of the typed conversation state: protecting every one would split
-     a real Keeper history into one tiny window per turn and defeat boundary
-     compaction. *)
-  let rec loop source_index first_user_seen sources_rev = function
-    | [] -> List.rev sources_rev
-    | unit_ :: rest ->
-      let source = eligible_source ~first_user_seen source_index unit_ in
-      let first_user_seen =
-        first_user_seen
-        ||
-        match unit_ with
-        | Keeper_compaction_unit.Ordinary_message
-            { role = Agent_sdk.Types.User; _ } -> true
-        | Keeper_compaction_unit.Ordinary_message _
-        | Keeper_compaction_unit.Closed_tool_cycle _ ->
-          false
-      in
-      let sources_rev =
-        match source with
-        | None -> sources_rev
-        | Some source -> source :: sources_rev
-      in
-      loop (source_index + 1) first_user_seen sources_rev rest
-  in
-  loop 0 false [] units
+  List.mapi eligible_source units |> List.filter_map Fun.id
 
 let has_eligible_units units = eligible_sources units <> []
 

--- a/test/test_compaction_llm_summarizer.ml
+++ b/test/test_compaction_llm_summarizer.ml
@@ -107,11 +107,18 @@ let test_oldest_contiguous_typed_window () =
     ]
   in
   let planning_window = window units in
+  (* Index 1 is a User message and is selected like any other text-bearing unit:
+     position carries no meaning. The run still stops at index 5, the metadata
+     barrier, which is a real structural boundary. *)
   Alcotest.(check (list int))
     "only the oldest contiguous eligible run enters planning"
-    [ 2; 3; 4 ]
+    [ 1; 2; 3; 4 ]
     (C.For_testing.planning_window_source_indices planning_window);
-  Alcotest.(check bool) "a lone first User goal stays exact" false
+  (* The goal is assembled into [system_prompt] every turn and never enters the
+     compacted message list, so no message has to be pinned to preserve it.
+     Excluding the first User message truncated the window at whatever preceded
+     it -- 2 selectable units out of 1,156 on live checkpoints. *)
+  Alcotest.(check bool) "a lone first User message is selectable" true
     (C.has_eligible_units [ ordinary (text T.User "goal") ]);
   let wire = wire_of_window planning_window in
   Alcotest.(check bool) "later User state crosses the typed window" true
@@ -130,9 +137,11 @@ let test_media_and_unseen_tail_stay_outside () =
     ]
   in
   let planning_window = window units in
+  (* Index 1 (User) is selectable now; the media cycle at index 3 is still the
+     boundary that ends the run. *)
   Alcotest.(check (list int))
     "media starts an exact protected boundary"
-    [ 2 ]
+    [ 1; 2 ]
     (C.For_testing.planning_window_source_indices planning_window);
   let wire = wire_of_window planning_window in
   Alcotest.(check bool) "oldest source crosses boundary" true
@@ -177,7 +186,7 @@ let test_boundary_plan_validation_is_constant_size () =
   let valid = plan planning_window ~summary:"faithful memory" ~keep_from_unit_index:4 in
   Alcotest.(check (list int))
     "boundary summarizes a prefix without enumeration"
-    [ 2; 3 ]
+    [ 1; 2; 3 ]
     (C.summarized_indices valid);
   Alcotest.(check (list int)) "boundary drops no implicit units" []
     (C.dropped_indices valid);
@@ -188,7 +197,8 @@ let test_boundary_plan_validation_is_constant_size () =
     (Astring.String.is_infix ~affix:"minimal recent suffix" request_wire);
   let invalid =
     [ plan_json ~summary:"" ~keep_from_unit_index:4
-    ; plan_json ~summary:"x" ~keep_from_unit_index:2
+      (* At or below the window's first source: the window now starts at 1. *)
+    ; plan_json ~summary:"x" ~keep_from_unit_index:1
     ; plan_json ~summary:"x" ~keep_from_unit_index:6
     ; `Assoc
         [ S.compaction_plan_field_summary, `String "x"
@@ -244,10 +254,16 @@ let test_apply_preserves_exact_outside_state_and_cycle () =
     | U.Closed_tool_cycle messages -> messages
     | U.Ordinary_message _ -> Alcotest.fail "expected closed cycle"
   in
+  (* The goal is no longer pinned in the message list: it is assembled into
+     [system_prompt] each turn, so the first User message is summarized with the
+     rest of the window. System messages are still outside the window. *)
   match compacted with
-  | system' :: goal' :: summary :: rest ->
+  | system' :: summary :: rest ->
     Alcotest.(check bool) "system stays exact" true (system' = system);
-    Alcotest.(check bool) "User goal stays exact" true (goal' = goal);
+    Alcotest.(check bool)
+      "the first User message is summarized, not pinned"
+      false
+      (List.mem goal compacted);
     Alcotest.(check bool)
       "summary is explicit derived state"
       true
@@ -277,11 +293,13 @@ let test_whole_tool_cycle_is_summarized_atomically () =
   in
   Alcotest.(check (list int))
     "the complete tool cycle is summarized before one exact suffix"
-    [ 2; 3; 4 ]
+    [ 1; 2; 3; 4 ]
     (C.summarized_indices compacted_plan);
+  (* system + summary + tail. The first User message is inside the summary now
+     rather than pinned ahead of it. *)
   Alcotest.(check int)
-    "one summary replaces assistant plus complete cycle and keeps the tail"
-    4
+    "one summary replaces the window and keeps system and the tail"
+    3
     (List.length (C.apply compacted_plan))
 ;;
 
@@ -338,9 +356,12 @@ let test_derived_summary_folds_hierarchically () =
       (Astring.String.is_infix ~affix:"next-user-state" wire);
     Alcotest.(check bool) "later run becomes the next window" true
       (Astring.String.is_infix ~affix:"next-run" wire);
+    (* One unit shorter than before: the first User message is inside the first
+       summary instead of pinned ahead of it, so the fold's keep boundary moves
+       down by one. *)
     let folded =
       C.apply
-        (plan next ~summary:"one rolling memory" ~keep_from_unit_index:5)
+        (plan next ~summary:"one rolling memory" ~keep_from_unit_index:4)
     in
     let summaries =
       List.filter

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -51,8 +51,11 @@ let summarize_response summary =
   exact_response ~summary ~keep_from_unit_index:2
 ;;
 
+(* Below the window's first source. [make_checkpoint] opens with a User message,
+   which is selectable now, so the window starts at unit 0 and the smallest
+   valid keep boundary is 1. *)
 let invalid_boundary_response =
-  exact_response ~summary:"invalid boundary" ~keep_from_unit_index:1
+  exact_response ~summary:"invalid boundary" ~keep_from_unit_index:0
 ;;
 
 let init_runtime_fixture () =


### PR DESCRIPTION
압축이 "첫 User 메시지 = goal anchor"라는 휴리스틱으로 그 메시지를 선정 대상에서 제외합니다. 그 제외가 선정 창을 잘라, 라이브 체크포인트에서 **1,156 유닛 중 2 유닛(0.21%)**만 압축 대상이 됩니다.

## 휴리스틱이 틀렸습니다

goal은 메시지 목록에 없습니다. 매턴 `system_prompt`로 조립되고(측정 12,877 B), `Keeper_context_core.serialize_context`가 `system_prompt`를 messages와 분리해 직렬화하므로 **애초에 압축 대상이 아닙니다.** 보존을 위해 transcript에 고정할 것이 없습니다.

`~/.masc/traces/` 체크포인트 130건에서 제외되던 메시지의 실제 내용:

| 내용 | 건수 |
|---|---|
| `(autonomous wake — the current observation frame is provided per-turn in system context)` | **117 (90%)** |
| 일반 채팅 한 줄 (예: `음 아 미안 https://github.com/... 이거임 ㅋㅋ`) | 13 (10%) |
| **goal 진술** | **0** |

메시지 자신이 "관측 프레임은 system context에 매턴 제공된다"고 말합니다.

## 제외가 창을 자릅니다

`oldest_contiguous_run`은 적격 유닛의 **첫 연속 구간**에서 멈춥니다. 부적격 유닛이 index 0이 아닌 곳에 있으면 그 앞까지만 창이 됩니다.

프로덕션 코드(`Keeper_compaction_unit.partition` + `planning_window_for_units`)를 직접 호출해 `~/.masc/traces/` 127건 전수 측정:

| 체크포인트 크기 | n | 5% 미만 |
|---|---|---|
| < 50KB | 23 | 0 (0.0%) |
| 50–200KB | 46 | 0 (0.0%) |
| **200–600KB** | 58 | **24 (41.4%)** |

막힌 24건의 크기 중앙값은 **287,341 B** — `max_request_body_bytes` 262,144를 막 넘긴 지점입니다. **압축이 가장 필요한 순간의 체크포인트에서 창이 가장 좁습니다.** 막힌 것 중 11/12에서 `window_units == first_user_unit`이었습니다.

## 변경

`eligible_source`에서 `~first_user_seen` 인자와 `when` 가드를 제거했습니다. 조건을 추가한 것이 아니라 **삭제**입니다. `eligible_sources`의 상태 추적 루프도 사라져 `List.mapi ... |> List.filter_map Fun.id`가 됩니다.

```ocaml
-let eligible_source ~first_user_seen source_index = function
-  | Ordinary_message ({ role = (User | Assistant); ... } as message)
-    when message.role <> User || first_user_seen ->
+let eligible_source source_index = function
+  | Ordinary_message { role = (User | Assistant) as role; ... } ->
```

System 메시지, 열린 tool cycle, metadata를 가진 메시지, 구조가 깨진 cycle은 **그대로 부적격**입니다. 바뀌는 것은 첫 User 메시지 하나뿐입니다.

## 효과 (동일 체크포인트 전후 측정)

| | 전 | 후 |
|---|---|---|
| 선정 비중 p50 | 88.37% | **99.28%** |
| 5% 미만 | 12건 | **1건** |
| <5% → ≥90% 회복 | — | **11건** |
| 예시 창 | 2 유닛 | **1,154 유닛** (전체 1,154) |

악화된 체크포인트 1건은 3.59% → 3.19%인데, 창 자체는 12 → 13 유닛으로 늘었습니다(구성이 바뀌어 바이트 비중만 소폭 감소).

## 테스트

계약을 고정하던 단언을 새 계약으로 갱신했습니다. 각각이 의도된 변화임을 확인했습니다:

- `"a lone first User goal stays exact" false` → `"a lone first User message is selectable" true`
- 창 인덱스 기대값 `[2;3;4]` → `[1;2;3;4]` 등 (fixture 6개 모두 index 0=System, 1=User "goal"로 동일한 이동)
- `apply` 결과 형태 `system :: goal :: summary :: rest` → `system :: summary :: rest`
- `test_keeper_post_turn_wirein_order`의 `invalid_boundary_response`를 `keep_from_unit_index:1` → `0`으로 내림. 창 시작이 1→0으로 내려가 1이 유효해졌기 때문이며, "창 시작 이하는 거부"라는 원래 의도를 보존합니다.

검증:

- `dune build --root . lib/` 클린
- `test_compaction_llm_summarizer` 10/10
- `test_compaction_exact_output_conformance` 14/14
- `test_keeper_post_turn_wirein_order` 16/16

## 다른 구현체와의 관계

[Microsoft Agent Framework](https://learn.microsoft.com/en-us/agent-framework/agents/conversations/compaction)를 포함한 참조 구현들은 **System 메시지 + 최근 N 그룹(recency tail)**을 위치로 보호하고 그 이전 전부를 압축 구간으로 삼습니다. 역할·순서로 의미를 추정해 head를 보호하는 구현은 없습니다. 이 PR은 masc를 그 형태에 한 걸음 가깝게 만듭니다.

## 남는 것

창을 자르는 요인이 anchor만은 아닙니다. metadata를 가진 메시지도 같은 방식으로 끊고(막힌 12건 중 1건이 그 경우), 근본적으로는 "요약 최대 1개" 제약이 창을 가장 오래된 구간으로 못박습니다. 그 부분은 표현(representation) 변경이 필요하고 RFC-0351의 컴팩션 사장 여부와 얽혀 있어 이 PR에서 다루지 않습니다. 상세: #26412.

RFC-WAIVED: credential/identity/operator-control/sandbox/hooks/workflow 어느 subsystem도 건드리지 않습니다. 압축 선정 가드 제거입니다.

WORKAROUND-WAIVED: 조건 분기 추가가 아니라 근거 없는 가드의 제거입니다. 새 게이트·카운터·문자열 분류기·텔레메트리를 추가하지 않고, 위치 조건도 넣지 않습니다. CLAUDE.md의 "기존 존재하는 Gate 가 없어도 동작에 문제가 없고, Gate 로 얻는 이득이 압도적으로 분명하지 않다면 해당 Gate 는 숙청 대상이다"에 해당합니다 — 이 가드가 주장하는 이득(goal 보존)은 실측 130건 중 0건입니다.

Closes #26412

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
