### PR TITLE
revert(keeper): #26420이 압축된 체크포인트를 재압축 불가 상태로 만듭니다

### DIFF
--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -330,10 +330,12 @@ let eligible_source ~first_user_seen source_index = function
     None
 
 let eligible_sources units =
-  (* The first User message is the exact goal anchor. Later plain User messages
-     are part of the typed conversation state: protecting every one would split
-     a real Keeper history into one tiny window per turn and defeat boundary
-     compaction. *)
+  (* Keep the first User message outside the window because current-format
+     summaries may already sit immediately behind it. Selecting that message
+     would put an eligible source before the summary and make the checkpoint
+     unplannable. Later plain User messages remain part of the typed
+     conversation state: protecting every one would split a real Keeper history
+     into one tiny window per turn and defeat boundary compaction. *)
   let rec loop source_index first_user_seen sources_rev = function
     | [] -> List.rev sources_rev
     | unit_ :: rest ->

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -304,15 +304,16 @@ let cycle_has_tool_protocol messages =
   in
   has_tool_use && has_tool_result
 
-let eligible_source source_index = function
+let eligible_source ~first_user_seen source_index = function
   | Keeper_compaction_unit.Ordinary_message
-      { role = (Agent_sdk.Types.User | Agent_sdk.Types.Assistant) as role
-      ; content
-      ; name = None
-      ; tool_call_id = None
-      ; metadata = []
-      } ->
-    (match message_text_source role content with
+      ({ role = (Agent_sdk.Types.User | Agent_sdk.Types.Assistant)
+       ; content
+       ; name = None
+       ; tool_call_id = None
+       ; metadata = []
+       } as message)
+    when message.role <> Agent_sdk.Types.User || first_user_seen ->
+    (match message_text_source message.role content with
      | Some source -> Some { source_index; payload = Message_text source }
      | None -> None)
   | Keeper_compaction_unit.Closed_tool_cycle messages
@@ -328,23 +329,33 @@ let eligible_source source_index = function
   | Keeper_compaction_unit.Closed_tool_cycle _ ->
     None
 
-(* Every text-bearing unit is eligible; position carries no meaning here.
-
-   The first User message used to be excluded as "the goal anchor". The goal is
-   not in the message list: it is assembled into [system_prompt] every turn, and
-   [Keeper_context_core.serialize_context] keeps that field outside the
-   compacted messages, so nothing in the transcript had to be pinned to preserve
-   it. Across 130 live checkpoints the excluded message was the wake marker
-   "(autonomous wake - the current observation frame is provided per-turn in
-   system context)" 117 times and an ordinary chat line the remaining 13 -- a
-   goal statement zero times.
-
-   The exclusion was not free: [oldest_contiguous_run] stops at the first index
-   gap, so an excluded unit anywhere but index 0 truncated the window to
-   whatever preceded it. Live keeper checkpoints reached 2 selectable units out
-   of 1,156. *)
 let eligible_sources units =
-  List.mapi eligible_source units |> List.filter_map Fun.id
+  (* The first User message is the exact goal anchor. Later plain User messages
+     are part of the typed conversation state: protecting every one would split
+     a real Keeper history into one tiny window per turn and defeat boundary
+     compaction. *)
+  let rec loop source_index first_user_seen sources_rev = function
+    | [] -> List.rev sources_rev
+    | unit_ :: rest ->
+      let source = eligible_source ~first_user_seen source_index unit_ in
+      let first_user_seen =
+        first_user_seen
+        ||
+        match unit_ with
+        | Keeper_compaction_unit.Ordinary_message
+            { role = Agent_sdk.Types.User; _ } -> true
+        | Keeper_compaction_unit.Ordinary_message _
+        | Keeper_compaction_unit.Closed_tool_cycle _ ->
+          false
+      in
+      let sources_rev =
+        match source with
+        | None -> sources_rev
+        | Some source -> source :: sources_rev
+      in
+      loop (source_index + 1) first_user_seen sources_rev rest
+  in
+  loop 0 false [] units
 
 let has_eligible_units units = eligible_sources units <> []
 

--- a/test/test_compaction_llm_summarizer.ml
+++ b/test/test_compaction_llm_summarizer.ml
@@ -107,18 +107,11 @@ let test_oldest_contiguous_typed_window () =
     ]
   in
   let planning_window = window units in
-  (* Index 1 is a User message and is selected like any other text-bearing unit:
-     position carries no meaning. The run still stops at index 5, the metadata
-     barrier, which is a real structural boundary. *)
   Alcotest.(check (list int))
     "only the oldest contiguous eligible run enters planning"
-    [ 1; 2; 3; 4 ]
+    [ 2; 3; 4 ]
     (C.For_testing.planning_window_source_indices planning_window);
-  (* The goal is assembled into [system_prompt] every turn and never enters the
-     compacted message list, so no message has to be pinned to preserve it.
-     Excluding the first User message truncated the window at whatever preceded
-     it -- 2 selectable units out of 1,156 on live checkpoints. *)
-  Alcotest.(check bool) "a lone first User message is selectable" true
+  Alcotest.(check bool) "a lone first User goal stays exact" false
     (C.has_eligible_units [ ordinary (text T.User "goal") ]);
   let wire = wire_of_window planning_window in
   Alcotest.(check bool) "later User state crosses the typed window" true
@@ -137,11 +130,9 @@ let test_media_and_unseen_tail_stay_outside () =
     ]
   in
   let planning_window = window units in
-  (* Index 1 (User) is selectable now; the media cycle at index 3 is still the
-     boundary that ends the run. *)
   Alcotest.(check (list int))
     "media starts an exact protected boundary"
-    [ 1; 2 ]
+    [ 2 ]
     (C.For_testing.planning_window_source_indices planning_window);
   let wire = wire_of_window planning_window in
   Alcotest.(check bool) "oldest source crosses boundary" true
@@ -186,7 +177,7 @@ let test_boundary_plan_validation_is_constant_size () =
   let valid = plan planning_window ~summary:"faithful memory" ~keep_from_unit_index:4 in
   Alcotest.(check (list int))
     "boundary summarizes a prefix without enumeration"
-    [ 1; 2; 3 ]
+    [ 2; 3 ]
     (C.summarized_indices valid);
   Alcotest.(check (list int)) "boundary drops no implicit units" []
     (C.dropped_indices valid);
@@ -197,8 +188,7 @@ let test_boundary_plan_validation_is_constant_size () =
     (Astring.String.is_infix ~affix:"minimal recent suffix" request_wire);
   let invalid =
     [ plan_json ~summary:"" ~keep_from_unit_index:4
-      (* At or below the window's first source: the window now starts at 1. *)
-    ; plan_json ~summary:"x" ~keep_from_unit_index:1
+    ; plan_json ~summary:"x" ~keep_from_unit_index:2
     ; plan_json ~summary:"x" ~keep_from_unit_index:6
     ; `Assoc
         [ S.compaction_plan_field_summary, `String "x"
@@ -254,16 +244,10 @@ let test_apply_preserves_exact_outside_state_and_cycle () =
     | U.Closed_tool_cycle messages -> messages
     | U.Ordinary_message _ -> Alcotest.fail "expected closed cycle"
   in
-  (* The goal is no longer pinned in the message list: it is assembled into
-     [system_prompt] each turn, so the first User message is summarized with the
-     rest of the window. System messages are still outside the window. *)
   match compacted with
-  | system' :: summary :: rest ->
+  | system' :: goal' :: summary :: rest ->
     Alcotest.(check bool) "system stays exact" true (system' = system);
-    Alcotest.(check bool)
-      "the first User message is summarized, not pinned"
-      false
-      (List.mem goal compacted);
+    Alcotest.(check bool) "User goal stays exact" true (goal' = goal);
     Alcotest.(check bool)
       "summary is explicit derived state"
       true
@@ -293,13 +277,11 @@ let test_whole_tool_cycle_is_summarized_atomically () =
   in
   Alcotest.(check (list int))
     "the complete tool cycle is summarized before one exact suffix"
-    [ 1; 2; 3; 4 ]
+    [ 2; 3; 4 ]
     (C.summarized_indices compacted_plan);
-  (* system + summary + tail. The first User message is inside the summary now
-     rather than pinned ahead of it. *)
   Alcotest.(check int)
-    "one summary replaces the window and keeps system and the tail"
-    3
+    "one summary replaces assistant plus complete cycle and keeps the tail"
+    4
     (List.length (C.apply compacted_plan))
 ;;
 
@@ -356,12 +338,9 @@ let test_derived_summary_folds_hierarchically () =
       (Astring.String.is_infix ~affix:"next-user-state" wire);
     Alcotest.(check bool) "later run becomes the next window" true
       (Astring.String.is_infix ~affix:"next-run" wire);
-    (* One unit shorter than before: the first User message is inside the first
-       summary instead of pinned ahead of it, so the fold's keep boundary moves
-       down by one. *)
     let folded =
       C.apply
-        (plan next ~summary:"one rolling memory" ~keep_from_unit_index:4)
+        (plan next ~summary:"one rolling memory" ~keep_from_unit_index:5)
     in
     let summaries =
       List.filter
@@ -384,6 +363,40 @@ let test_derived_summary_folds_hierarchically () =
       (List.exists
          (fun message -> T.text_of_message message = "barrier")
          folded)
+;;
+
+(* #26420 regression. A checkpoint that has already been compacted carries its
+   summary right behind the leading User message, because the first User message
+   is held out of the selection. Making that message selectable puts an eligible
+   source in front of the summary, which [planning_window_for_units] rejects
+   outright -- so an already-compacted checkpoint could never be compacted
+   again. Six of eleven live keeper checkpoints took that shape on 2026-07-30;
+   their windows went from 85-98% of the transcript to a hard error. Any change
+   to selection eligibility has to keep this layout planable. *)
+let test_summary_behind_leading_user_message_still_plans () =
+  let units =
+    [ ordinary
+        (text
+           T.User
+           "(autonomous wake — the current observation frame is provided per-turn in \
+            system context)")
+    ; ordinary
+        (message
+           ~metadata:[ "masc.compaction.bounded_summary", `Bool true ]
+           T.Assistant
+           [ T.Text "already compacted" ])
+    ; ordinary (text T.Assistant "post-summary-one")
+    ; ordinary (text T.Assistant "post-summary-two")
+    ]
+  in
+  match C.For_testing.planning_window_for_units units with
+  | Error message ->
+    Alcotest.failf "an already-compacted checkpoint lost its window: %s" message
+  | Ok window ->
+    Alcotest.(check (list int))
+      "the window resumes after the prior summary"
+      [ 2; 3 ]
+      (C.For_testing.planning_window_source_indices window)
 ;;
 
 let test_multiple_current_summaries_are_rejected () =
@@ -449,6 +462,9 @@ let () =
             test_derived_summary_folds_hierarchically
         ; Alcotest.test_case "multiple current summaries are rejected" `Quick
             test_multiple_current_summaries_are_rejected
+        ; Alcotest.test_case "summary behind a leading User message still plans"
+            `Quick
+            test_summary_behind_leading_user_message_still_plans
         ] )
     ]
 ;;

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -51,11 +51,8 @@ let summarize_response summary =
   exact_response ~summary ~keep_from_unit_index:2
 ;;
 
-(* Below the window's first source. [make_checkpoint] opens with a User message,
-   which is selectable now, so the window starts at unit 0 and the smallest
-   valid keep boundary is 1. *)
 let invalid_boundary_response =
-  exact_response ~summary:"invalid boundary" ~keep_from_unit_index:0
+  exact_response ~summary:"invalid boundary" ~keep_from_unit_index:1
 ;;
 
 let init_runtime_fixture () =


### PR DESCRIPTION
#26420을 되돌립니다. 그 PR이 **이미 한 번 압축된 체크포인트를 영구히 다시 압축할 수 없게** 만듭니다.

## 증상

`~/me/.masc/traces/` 라이브 체크포인트 11건을 같은 스냅샷으로 고정하고 #26420 전후 코드로 각각 측정했습니다. 프로덕션 함수(`Keeper_compaction_unit.partition ~quarantine:true` → `planning_window_for_units`)를 그대로 호출했습니다.

| | 전 (`8c4dae264e`) | 후 (`d7996e3ff9`) |
|---|---|---|
| 창 계산 성공 | **11/11** | 5/11 |
| 창 ≥85% | 9 | 3 |
| **하드 에러** | **0** | **6** |

에러는 전부 `eligible source precedes the current-format compaction summary`입니다. 이건 좁은 창이 아니라 `planning_window_for_units`가 `Error`를 반환하는 상태로, 압축이 아예 계획되지 않습니다.

체크포인트별:

| 체크포인트 | 전 | 후 |
|---|---|---|
| trace-…111840-00000 | 1/3 | 2/3 |
| trace-…111848-00001 | 1/3 | **ERROR** |
| trace-…111861-00002 | 50/52 | 51/52 |
| trace-…111899-00003 | 108/110 | **ERROR** |
| trace-…111911-00004 | 18/21 | **ERROR** |
| trace-…111927-00005 | 1/418 | 2/418 |
| trace-…111940-00006 | 68/70 | **ERROR** |
| trace-…111950-00007 | 1159/1161 | 1160/1161 |
| trace-…5274891-00000 | 129/131 | **ERROR** |
| trace-…9403346-00000 | 133/135 | **ERROR** |
| trace-…6805250-00000 | 50/51 | 51/51 |

## 메커니즘

이미 압축된 체크포인트의 머리 부분은 이 모양입니다 (trace-…111911-00004 실제 내용):

```
0  user       meta=[]                                  "(autonomous wake — the current observation frame …)"
1  assistant   meta=["masc.compaction.bounded_summary"]  "Task-017 completed (PR #26403). …"
2  assistant   meta=["oas.reasoning_source.v2"]          …
```

요약이 index 1에 있는 이유가 바로 #26420이 제거한 그 동작입니다 — 첫 User 메시지를 선정에서 제외했기 때문에 요약이 그 **뒤에** 설치됐습니다.

첫 User 메시지를 적격으로 만들면 index 0의 적격 source가 index 1의 요약보다 앞서게 되고, `planning_window_for_units`의 불변식이 계획 전체를 거부합니다:

```ocaml
if List.exists (fun (source : eligible_source) ->
     source.source_index < prior_summary.source_index) sources
then Error "eligible source precedes the current-format compaction summary"
```

빠져나갈 길이 없습니다. 이 모양을 정리하려면 압축이 필요한데, 압축이 이 모양 때문에 거부됩니다.

## 왜 사전 검증에서 안 잡혔는가

두 군데가 동시에 비었습니다.

1. **측정 표본**: #26420의 127건 전수 측정은 07-29 fleet hard-cut **이전** 워크스페이스 체크포인트였고, current-format 요약을 가진 것이 사실상 없었습니다. 오늘 fleet은 11건 중 6건이 요약을 갖고 있습니다.
2. **테스트**: 기존 fixture가 전부 `index 0 = System, index 1 = User`였습니다. 요약은 항상 System 바로 뒤에 설치되어 **적격 메시지가 요약보다 앞서는 배치가 한 번도 만들어지지 않았습니다.** `test_multiple_current_summaries_are_rejected`는 그 배치를 갖고 있었지만 `Result.is_error`만 확인해서, 거부 사유가 "요약 2개"에서 "순서 위반"으로 바뀌어도 통과했습니다.

## 이 PR이 추가하는 것

`test_summary_behind_leading_user_message_still_plans` — User@0 + 요약@1 배치가 창을 계획할 수 있어야 한다고 고정합니다.

변이 검증: #26420의 lib 변경만 다시 적용하면 이 테스트가 실패합니다.

```
[FAIL]  plan  6  summary behind a leading User message still plans
```

## 검증

- `dune build --root . lib/` 클린
- `test_compaction_llm_summarizer` **11/11** (신규 1건 포함)
- `test_keeper_post_turn_wirein_order` **16/16**
- `test_compaction_exact_output_conformance` **14/14**
- ocamlformat 3파일 OK

## #26420의 원래 근거는 어떻게 되는가

첫 User 메시지가 goal이 아니라는 실측(130건 중 goal 진술 0건, 웨이크 마커 117건)은 그대로 유효합니다. 틀린 것은 **그 가드만 떼면 된다**는 판단이었습니다.

가드는 혼자 서 있지 않았습니다. "요약은 최대 1개이고 모든 적격 source보다 앞서야 한다"는 불변식이 있고, 첫 User 제외는 그 불변식이 성립하도록 요약을 선두에 몰아두는 역할을 겸하고 있었습니다. 앵커를 제거하려면 그 불변식을 먼저 바꿔야 합니다 — #26412에 적어둔 표현(representation) 변경이 선행 조건이라는 것이 이번에 실측으로 확인됐습니다.

되돌린 뒤 남는 상태는 #26420 이전과 동일합니다: 200–600KB 구간 체크포인트의 41.4%에서 창이 좁습니다. 그건 #26412에서 다룹니다.

RFC-WAIVED: credential/identity/operator-control/sandbox/hooks/workflow 어느 subsystem도 건드리지 않습니다. 압축 선정 회귀의 revert입니다.

WORKAROUND-WAIVED: 증상 억제가 아니라 회귀 커밋의 revert + 회귀를 고정하는 테스트 추가입니다. 새 게이트·카운터·문자열 분류기·조건 분기를 추가하지 않습니다.

Reverts #26420. Refs #26412.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
