### PR TITLE
refactor(keeper): purge retired exact domain lifecycle errors

### DIFF
--- a/lib/keeper/keeper_board_attention_exact_flow.ml
+++ b/lib/keeper/keeper_board_attention_exact_flow.ml
@@ -53,7 +53,6 @@ type 'callback_error execution_error =
   | Exact_execution_failed of attempt_provenance list
   | Provenance_mismatch of string
   | Domain_output_invalid of string
-  | Domain_settlement_failed
 
 type prepared =
   { candidate : Keeper_board_attention_candidate.candidate
@@ -347,7 +346,6 @@ let terminal_outcome = function
   | Error (Exact_execution_failed _) -> Exact_execution_failure
   | Error (Provenance_mismatch _) -> Execution_provenance_mismatch
   | Error (Domain_output_invalid _) -> Invalid_domain_output
-  | Error Domain_settlement_failed -> Exact_execution_failure
 ;;
 
 let observe_terminal prepared result =

--- a/lib/keeper/keeper_board_attention_exact_flow.mli
+++ b/lib/keeper/keeper_board_attention_exact_flow.mli
@@ -63,7 +63,6 @@ type 'callback_error execution_error =
   | Exact_execution_failed of attempt_provenance list
   | Provenance_mismatch of string
   | Domain_output_invalid of string
-  | Domain_settlement_failed
 
 type prepared
 

--- a/lib/keeper/keeper_board_attention_worker.ml
+++ b/lib/keeper/keeper_board_attention_worker.ml
@@ -846,9 +846,6 @@ let execution_disposition partition = function
       (preserve_durable_progress
          partition
          (Partition.Domain_output_invalid detail))
-  | Exact_flow.Domain_settlement_failed ->
-    Execution_blocked
-      (preserve_durable_progress partition Partition.Exact_execution_terminal)
 ;;
 
 let confirm_exact_transition latest_partition operation = function

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -174,7 +174,6 @@ type exact_execution_failure =
   | Exact_callback_persistence_failed of string
   | Oas_execution_failed
   | Exact_flow_progress_failed of string
-  | Exact_domain_settlement_failed
 
 type outward_effect =
   | No_outward_effect
@@ -262,8 +261,6 @@ let extraction_error_to_string = function
       | Oas_execution_failed -> "oas_execution_failed"
       | Exact_flow_progress_failed detail ->
         "flow_progress_failed: " ^ detail
-      | Exact_domain_settlement_failed ->
-        "domain_settlement_failed"
     in
     Printf.sprintf
       "librarian exact execution failed outward_effect=%s cause=%s"

--- a/scripts/check-compaction-exact-flow-boundary.sh
+++ b/scripts/check-compaction-exact-flow-boundary.sh
@@ -50,7 +50,7 @@ check_boundary() {
     || fail "execute_flow_once must require caller-owned semantic validation"
 
   local forbidden_pattern
-  forbidden_pattern='Exact_output\.admit_flow|Exact_output\.admit([^_[:alnum:]]|$)|Exact_output\.(start_attempt|execute_once|receipt_phase|receipt_dispatch_count|execute_flow_once_validated|settle_flow_domain|create_flow_preference_store|make_flow_scope|remove_flow_preference_scope)|Exact_output\.effect_phase|Keeper_exact_flow_scope\.(preference_store|scope)|~preferences:|~scope:|type admitted_slot|is_before_dispatch_zero|ready_plan'
+  forbidden_pattern='Exact_output\.admit_flow|Exact_output\.admit([^_[:alnum:]]|$)|Exact_output\.(start_attempt|execute_once|receipt_phase|receipt_dispatch_count|execute_flow_once_validated)|Exact_output\.effect_phase|type admitted_slot|is_before_dispatch_zero|ready_plan'
   if rg -n "${forbidden_pattern}" "${TARGET}"; then
     fail "MASC-local exact admission/attempt/receipt control flow is forbidden"
   fi
@@ -128,44 +128,11 @@ check_boundary() {
     fail "retired receipt-phase or legacy durable terminal label remains"
   fi
 
-  local retired_event_queue_pattern
-  local event_queue_candidate
-  local event_queue_candidates=()
-  retired_event_queue_pattern='\b(lease_id|lease_sequence|settlement_id|settle_exact|Settle_exact|settle_exact_terminal_after_cancellation|retain_unacked_pending|source_lease_disposition|exact_execution_binding|exact_source_disposition|allow_legacy_durable)\b|lease:|keeper\.event_queue\.state\.v([1-9]|10|11)\b|masc\.keeper_event_queue\.transition\.v1\b|masc\.keeper\.paused-work-disposition\.v[1-4]\b|masc\.keeper_event_queue\.settlement|event-queue-settlements|event-queue-inflight|"event-queue\.json"|"event-queue-transitions\.jsonl"|"paused-work-dispositions"'
-  for event_queue_candidate in \
-    "${REPO_ROOT}/lib/keeper_runtime/keeper_event_queue_state.ml" \
-    "${REPO_ROOT}/lib/keeper_runtime/keeper_event_queue_state.mli" \
-    "${REPO_ROOT}/lib/keeper_runtime/keeper_event_queue_persistence.ml" \
-    "${REPO_ROOT}/lib/keeper_runtime/keeper_event_queue_persistence.mli" \
-    "${REPO_ROOT}/lib/keeper/keeper_registry_event_queue.ml" \
-    "${REPO_ROOT}/lib/keeper/keeper_registry_event_queue.mli" \
-    "${REPO_ROOT}/lib/keeper/keeper_unified_turn.ml" \
-    "${REPO_ROOT}/lib/keeper/keeper_unified_turn.mli" \
-    "${REPO_ROOT}/lib/keeper/keeper_heartbeat_loop.ml" \
-    "${REPO_ROOT}/lib/keeper/keeper_reaction_ledger.ml"
-  do
-    [[ -f "${event_queue_candidate}" ]] \
-      && event_queue_candidates+=("${event_queue_candidate}")
-  done
-  while IFS= read -r event_queue_candidate; do
-    event_queue_candidates+=("${event_queue_candidate}")
-  done < <(
-    find "${REPO_ROOT}/lib/keeper" -maxdepth 1 -type f \
-      \( -name 'keeper_paused_work_*.ml' -o -name 'keeper_paused_work_*.mli' \) \
-      -print \
-      | sort
-  )
-  if (( ${#event_queue_candidates[@]} > 0 )) \
-    && rg -n "${retired_event_queue_pattern}" "${event_queue_candidates[@]}"
-  then
-    fail "retired Event Layer lease or settlement authority remains"
-  fi
-
   echo "[compaction-exact-flow-boundary] OK"
 }
 
 self_test() {
-  local fixture target clean adjacent adjacent_clean alternate event_state retired_module
+  local fixture target clean adjacent adjacent_clean alternate retired_module
   fixture="$(mktemp -d "${TMPDIR:-/tmp}/compaction-exact-flow-boundary.XXXXXX")"
   trap "rm -rf '${fixture}'" EXIT
   mkdir -p "${fixture}/lib/keeper" "${fixture}/lib/keeper_runtime" "${fixture}/test"
@@ -189,29 +156,6 @@ EOF
   MASC_COMPACTION_BOUNDARY_ROOT="${fixture}" \
     MASC_COMPACTION_EXACT_FLOW_TARGET="${target}" \
     "${BASH_SOURCE[0]}" --check-only >/dev/null
-
-  event_state="${fixture}/lib/keeper_runtime/keeper_event_queue_state.ml"
-  printf '%s\n' 'let lease_id = "retired"' >"${event_state}"
-  if
-    MASC_COMPACTION_BOUNDARY_ROOT="${fixture}" \
-      MASC_COMPACTION_EXACT_FLOW_TARGET="${target}" \
-      "${BASH_SOURCE[0]}" --check-only >/dev/null 2>&1
-  then
-    fail "self-test retired Event Layer authority unexpectedly passed"
-  fi
-  rm -f "${event_state}"
-
-  printf '%s\n' \
-    'let snapshot_filename = "event-queue.json"' \
-    >"${fixture}/lib/keeper_runtime/keeper_event_queue_persistence.ml"
-  if
-    MASC_COMPACTION_BOUNDARY_ROOT="${fixture}" \
-      MASC_COMPACTION_EXACT_FLOW_TARGET="${target}" \
-      "${BASH_SOURCE[0]}" --check-only >/dev/null 2>&1
-  then
-    fail "self-test retired Event Layer path unexpectedly passed"
-  fi
-  rm -f "${fixture}/lib/keeper_runtime/keeper_event_queue_persistence.ml"
 
   retired_module="${fixture}/lib/keeper/keeper_exact_disposition_recovery.ml"
   printf '%s\n' 'let _ = ()' >"${retired_module}"
@@ -310,7 +254,7 @@ EOF
   MASC_COMPACTION_EXACT_FLOW_TARGET="${target}" \
     "${BASH_SOURCE[0]}" --check-only >/dev/null
   echo \
-    "[compaction-exact-flow-boundary:self-test] clean=pass event-layer=fail event-module=fail unrelated=pass duplicate=fail missing=fail legacy=fail forbidden=fail projection=fail dynamic=fail carrier=fail restored=pass"
+    "[compaction-exact-flow-boundary:self-test] clean=pass event-module=fail unrelated=pass duplicate=fail missing=fail legacy=fail forbidden=fail projection=fail dynamic=fail carrier=fail restored=pass"
 }
 
 case "${1:-}" in


### PR DESCRIPTION
## 왜

현재 exact flow는 별도 domain lifecycle을 소유하지 않는데, MASC Board/Librarian 오류 합 타입에는 생산자가 없는 옛 variant가 남아 있었습니다. 삭제된 Event Layer 명칭을 막기 위한 부정 목록과 자기테스트도 실행 계약이 아니라 과거 구조를 계속 보존하고 있었습니다.

## 변경

- Board exact flow의 도달 불가능한 오류 variant와 소비 분기 삭제
- Librarian의 도달 불가능한 오류 variant와 문자열 projection 삭제
- compaction boundary에서 퇴역 이름 부정 목록과 그 자기테스트 제거
- 현재 단일 진입점, caller-owned validation, provider/model SSOT의 양성 검사는 유지

런타임 Gate, 호환 alias, decoder, migration은 추가하지 않았습니다. 실제 생성/실행/오류 경로는 변경되지 않습니다.

## 검증

- compaction exact-flow boundary와 self-test 통과
- 변경 OCaml 파일 parser 및 ocamlformat 통과
- git diff --check 통과
- 전체 빌드/테스트 authority는 exact-head PR CI

## Linked radius

#26428도 Librarian 파일을 재작성합니다. 이 PR이 먼저 merge되면 #26428 rebase가 해당 삭제를 흡수해야 하며, 반대 순서라면 이 PR에서 겹친 한 파일을 재검증합니다.
