### PR TITLE
fix(dashboard): hard-cut legacy lifecycle cache events

### DIFF
--- a/lib/keeper_registry/keeper_lifecycle_events.ml
+++ b/lib/keeper_registry/keeper_lifecycle_events.ml
@@ -125,3 +125,16 @@ let lifecycle_event_to_string = function
 let lifecycle_event_phase = function
   | Custom_event { phase; _ } -> phase
   | Phase_event p -> Some p
+
+let lifecycle_event_of_wire ~event ~phase =
+  match event_of_string event, phase with
+  | Some verb, None -> Some (Custom_event { verb; phase = None })
+  | Some verb, Some phase ->
+    Option.map
+      (fun phase -> Custom_event { verb; phase = Some phase })
+      (Keeper_state_machine.phase_of_string phase)
+  | None, Some phase when String.equal event phase ->
+    Option.map
+      (fun phase -> Phase_event phase)
+      (Keeper_state_machine.phase_of_string phase)
+  | None, None | None, Some _ -> None

--- a/lib/keeper_registry/keeper_lifecycle_events.mli
+++ b/lib/keeper_registry/keeper_lifecycle_events.mli
@@ -43,3 +43,11 @@ type lifecycle_event =
 val lifecycle_event_to_string : lifecycle_event -> string
 val lifecycle_event_phase :
   lifecycle_event -> Keeper_state_machine.phase option
+
+val lifecycle_event_of_wire :
+  event:string ->
+  phase:string option ->
+  lifecycle_event option
+(** Decode the exact current event-bus contract. Custom events may omit phase;
+    phase events require matching [event] and [phase] labels. Unknown or
+    inconsistent payloads fail closed. *)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1223,7 +1223,19 @@ let start_keeper_loops_owned
                    , Safe_ops.json_string_opt "keeper_name" payload )
                  with
                  | Some event, Some keeper_name ->
-                   Server_dashboard_http.patch_keeper_dependent_caches ~keeper_name ~event
+                   (match
+                      Keeper_lifecycle_events.lifecycle_event_of_wire
+                        ~event
+                        ~phase:(Safe_ops.json_string_opt "phase" payload)
+                    with
+                    | Some event ->
+                      Server_dashboard_http.patch_keeper_dependent_caches
+                        ~keeper_name
+                        ~event
+                    | None ->
+                      Otel_metric_store.inc_counter
+                        "masc_keeper_lifecycle_malformed_total"
+                        ())
                  | None, _ | Some _, None ->
                    (* P3 cleanup: previously malformed lifecycle events
                        (missing `event` or `keeper_name` field) were

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -486,20 +486,11 @@ let dashboard_transport_health_snapshot_json () =
   Server_dashboard_http_cache.cached_surface_json transport_health_cache
 ;;
 
-(* Issue #8396 / #22071: cache patchers project a wire lifecycle event name onto
-   dashboard row fields (keepalive_running / phase / pipeline_stage / paused).
-   Cache rows deserialise from JSON, so the input is a [string]; but the closed
-   custom-event vocabulary ([Keeper_lifecycle_events.t]) is parsed to the typed
-   verb and matched EXHAUSTIVELY in [display_of_custom_event]. Adding a custom
-   lifecycle variant now fails to compile here until its projection is defined —
-   replacing the prior raw-string whitelist that silently dropped new variants
-   to [None] (and an in-doc reference to a coverage test that did not exist).
-
-   Phase-derived names ([running]/[stopped]/[crashed]/[dead]) and legacy operator
-   strings ([paused]/[resumed]) are not custom-event verbs and cross the JSON
-   boundary as raw strings, so they stay string-keyed and fail closed to [None]
-   for unknown input. Coverage over the SSOT vocabulary is pinned by
-   [test/test_dashboard_http_core.ml :: lifecycle_event_cache_patcher_coverage]. *)
+(* Cache patchers project a typed lifecycle transition onto dashboard row fields
+   (keepalive_running / phase / pipeline_stage / paused). Phase-derived events
+   and custom events arrive here only after the event-bus
+   payload has been decoded by [Keeper_lifecycle_events.lifecycle_event_of_wire].
+   The operator pause path constructs [Phase_event Paused] directly. *)
 
 type lifecycle_display =
   { ld_keepalive_running : bool
@@ -507,14 +498,6 @@ type lifecycle_display =
   ; ld_pipeline_stage : string
   ; ld_paused : bool option
   }
-
-type lifecycle_legacy_wire_event =
-  | Legacy_running
-  | Legacy_stopped
-  | Legacy_crashed
-  | Legacy_dead
-  | Legacy_paused
-  | Legacy_resumed
 
 (* Exhaustive over the closed custom-event sum. A new [Keeper_lifecycle_events.t]
    variant breaks this match (no catch-all) until its dashboard projection is
@@ -534,44 +517,34 @@ let display_of_custom_event (verb : Keeper_lifecycle_events.t) : lifecycle_displ
     { ld_keepalive_running = false; ld_phase = "dead"; ld_pipeline_stage = "offline"; ld_paused = Some false }
 ;;
 
-(* Phase-derived + legacy operator strings (not custom-event verbs). Raw-string
-   keyed by necessity (JSON boundary); unknown input fails closed to [None]. *)
-let lifecycle_legacy_wire_event_of_string = function
-  | "running" -> Some Legacy_running
-  | "stopped" -> Some Legacy_stopped
-  | "crashed" -> Some Legacy_crashed
-  | "dead" -> Some Legacy_dead
-  | "paused" -> Some Legacy_paused
-  | "resumed" -> Some Legacy_resumed
-  | _ -> None
-;;
-
-let display_of_phase_or_legacy_event = function
-  | Legacy_running ->
+let display_of_phase_event = function
+  | Keeper_state_machine.Running ->
     Some { ld_keepalive_running = true; ld_phase = "running"; ld_pipeline_stage = "idle"; ld_paused = Some false }
-  | Legacy_stopped ->
+  | Keeper_state_machine.Stopped ->
     Some
       { ld_keepalive_running = false; ld_phase = "stopped"; ld_pipeline_stage = "offline"; ld_paused = None }
-  | Legacy_crashed ->
+  | Keeper_state_machine.Crashed ->
     Some
       { ld_keepalive_running = false; ld_phase = "crashed"; ld_pipeline_stage = "crashed"; ld_paused = Some false }
-  | Legacy_dead ->
+  | Keeper_state_machine.Dead ->
     Some { ld_keepalive_running = false; ld_phase = "dead"; ld_pipeline_stage = "offline"; ld_paused = Some false }
-  | Legacy_paused ->
+  | Keeper_state_machine.Paused ->
     Some { ld_keepalive_running = true; ld_phase = "paused"; ld_pipeline_stage = "paused"; ld_paused = Some true }
-  | Legacy_resumed ->
-    Some { ld_keepalive_running = true; ld_phase = "running"; ld_pipeline_stage = "idle"; ld_paused = Some false }
-
-let display_of_phase_or_legacy_string s =
-  match lifecycle_legacy_wire_event_of_string s with
-  | None -> None
-  | Some event -> display_of_phase_or_legacy_event event
+  | Keeper_state_machine.Offline
+  | Keeper_state_machine.Failing
+  | Keeper_state_machine.Overflowed
+  | Keeper_state_machine.Compacting
+  | Keeper_state_machine.HandingOff
+  | Keeper_state_machine.Draining
+  | Keeper_state_machine.Restarting ->
+    None
 ;;
 
-let lifecycle_display_of_event event =
-  match Keeper_lifecycle_events.event_of_string event with
-  | Some verb -> Some (display_of_custom_event verb)
-  | None -> display_of_phase_or_legacy_string event
+let lifecycle_display_of_event = function
+  | Keeper_lifecycle_events.Custom_event { verb; _ } ->
+    Some (display_of_custom_event verb)
+  | Keeper_lifecycle_events.Phase_event phase ->
+    display_of_phase_event phase
 ;;
 
 let keepalive_running_of_lifecycle_event event =
@@ -608,14 +581,17 @@ let keeper_agent_status_opt row =
 
 let lifecycle_display_for_row row event =
   match
-    ( Keeper_lifecycle_events.event_of_string event
+    ( event
     , Option.bind
         (keeper_top_level_status_opt row)
         Keeper_status_runtime.control_plane_status_of_string_opt )
   with
-  | Some Keeper_lifecycle_events.Reconciled, Some Keeper_status_runtime.Cp_paused ->
-    display_of_phase_or_legacy_event Legacy_paused
-  | Some _, _ | None, _ -> lifecycle_display_of_event event
+  | ( Keeper_lifecycle_events.Custom_event
+        { verb = Keeper_lifecycle_events.Reconciled; _ }
+    , Some Keeper_status_runtime.Cp_paused ) ->
+    display_of_phase_event Keeper_state_machine.Paused
+  | (Keeper_lifecycle_events.Custom_event _ | Keeper_lifecycle_events.Phase_event _), _ ->
+    lifecycle_display_of_event event
 ;;
 
 let control_status_override_of_lifecycle_event row event =
@@ -623,14 +599,12 @@ let control_status_override_of_lifecycle_event row event =
   | Some { ld_paused = Some true; _ } ->
     Some Keeper_status_runtime.Cp_paused
   | Some _ | None ->
-    (match lifecycle_legacy_wire_event_of_string event with
-  | Some Legacy_paused ->
-    Some Keeper_status_runtime.Cp_paused
-  | Some Legacy_resumed ->
+    (match event with
+  | Keeper_lifecycle_events.Phase_event Keeper_state_machine.Running ->
     Some
       (Keeper_status_runtime.Cp_surface
          Keeper_status_runtime.Surface_idle)
-  | Some Legacy_stopped ->
+  | Keeper_lifecycle_events.Phase_event Keeper_state_machine.Stopped ->
     (match
        Option.bind
          (match keeper_top_level_status_opt row with
@@ -641,7 +615,19 @@ let control_status_override_of_lifecycle_event row event =
      | Some Keeper_status_runtime.Cp_paused ->
        Some Keeper_status_runtime.Cp_paused
      | Some (Keeper_status_runtime.Cp_surface _) | None -> None)
-  | Some (Legacy_running | Legacy_crashed | Legacy_dead) | None -> None)
+  | Keeper_lifecycle_events.Custom_event _
+  | Keeper_lifecycle_events.Phase_event
+      ( Keeper_state_machine.Offline
+      | Keeper_state_machine.Failing
+      | Keeper_state_machine.Overflowed
+      | Keeper_state_machine.Compacting
+      | Keeper_state_machine.HandingOff
+      | Keeper_state_machine.Draining
+      | Keeper_state_machine.Paused
+      | Keeper_state_machine.Crashed
+      | Keeper_state_machine.Restarting
+      | Keeper_state_machine.Dead ) ->
+    None)
 ;;
 
 let patched_keeper_status row ~event ~keepalive_running =
@@ -794,7 +780,11 @@ let patch_surface_json_for_running_keepers (config : Workspace.config) = functio
           (fun acc keeper_name ->
              patch_keeper_rows
                ~keeper_name
-               ~event:"reconciled"
+               ~event:
+                 (Keeper_lifecycle_events.Custom_event
+                    { verb = Keeper_lifecycle_events.Reconciled
+                    ; phase = None
+                    })
                ~keepalive_running:true
                acc)
           rows

--- a/lib/server/server_dashboard_http_execution_surfaces.mli
+++ b/lib/server/server_dashboard_http_execution_surfaces.mli
@@ -127,7 +127,9 @@ val invalidate_execution_cache_with_hooks_for_testing :
     callers should use {!invalidate_execution_cache}. *)
 
 val patch_keeper_dependent_caches :
-  keeper_name:string -> event:string -> unit
+  keeper_name:string ->
+  event:Keeper_lifecycle_events.lifecycle_event ->
+  unit
 (** Applies the lifecycle delta to the execution cache and its serialized
     default body. Operator snapshots are never patched in place; their mutation
     paths advance the projection generation and publish a canonical tombstone.
@@ -217,23 +219,22 @@ val dashboard_transport_health_http_json :
 
 (** {1 Lifecycle-event patchers}
 
-    Mapping from SSOT keeper-lifecycle event names
-    (e.g. [started] / [paused] / [resumed]) to the four
-    cache-row fields the dashboard exposes.  Pinned at
-    this boundary because [test/test_types] asserts
-    every SSOT event has an entry in each map (#8396).
-    [None] means "the event does not change this
+    Mapping from typed SSOT keeper-lifecycle transitions
+    to the four cache-row fields the dashboard exposes.
+    [None] means "the transition does not change this
     field". *)
 
 val keepalive_running_of_lifecycle_event :
-  string -> bool option
+  Keeper_lifecycle_events.lifecycle_event -> bool option
 
-val phase_of_lifecycle_event : string -> string option
+val phase_of_lifecycle_event :
+  Keeper_lifecycle_events.lifecycle_event -> string option
 
 val pipeline_stage_of_lifecycle_event :
-  string -> string option
+  Keeper_lifecycle_events.lifecycle_event -> string option
 
-val paused_of_lifecycle_event : string -> bool option
+val paused_of_lifecycle_event :
+  Keeper_lifecycle_events.lifecycle_event -> bool option
 
 val seed_execution_cache_for_test : unit -> unit
 
@@ -242,7 +243,7 @@ val patch_surface_json_for_running_keepers :
 
 val patch_keeper_row :
   keeper_name:string ->
-  event:string ->
+  event:Keeper_lifecycle_events.lifecycle_event ->
   keepalive_running:bool ->
   Yojson.Safe.t ->
   Yojson.Safe.t

--- a/lib/server/server_dashboard_http_keeper_api.mli
+++ b/lib/server/server_dashboard_http_keeper_api.mli
@@ -187,7 +187,10 @@ val extract_keeper_name_for_post : string -> string -> string
 (** {1 Execution surface refresh} *)
 
 val refresh_keeper_execution_surfaces :
-  config:Workspace_utils.config -> name:String.t -> string -> unit
+  config:Workspace_utils.config ->
+  name:String.t ->
+  Keeper_lifecycle_events.lifecycle_event ->
+  unit
 (** Re-read the keeper meta for [name] and update derived caches. *)
 
 val invalidate_keeper_execution_surfaces :

--- a/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
@@ -41,6 +41,9 @@ let tool_detail_json body =
    - Operator control snapshot cache: [Operator_control_snapshot.invalidate_snapshot_cache]
    - Projection cache: [Dashboard_projection_cache.invalidate_snapshot_json] *)
 let refresh_keeper_execution_surfaces ~config ~name event =
+  let event_label =
+    Keeper_lifecycle_events.lifecycle_event_to_string event
+  in
   Operator_control_snapshot.invalidate_snapshot_cache ();
   Dashboard_projection_cache.invalidate_snapshot_json ~config;
   (try Dashboard_cache.invalidate_prefix "execution:" with
@@ -48,7 +51,7 @@ let refresh_keeper_execution_surfaces ~config ~name event =
    | exn ->
        Log.Dashboard.warn
          "keeper %s %s: execution dashboard cache invalidate failed: %s"
-         name event (Printexc.to_string exn));
+         name event_label (Printexc.to_string exn));
   (try
      Dashboard_cache.invalidate_prefix
        (Server_dashboard_http_core.dashboard_shell_cache_prefix config)
@@ -57,7 +60,7 @@ let refresh_keeper_execution_surfaces ~config ~name event =
    | exn ->
        Log.Dashboard.warn
          "keeper %s %s: shell surface cache invalidate failed: %s"
-         name event (Printexc.to_string exn));
+         name event_label (Printexc.to_string exn));
   Server_dashboard_http_execution_surfaces.patch_keeper_dependent_caches
     ~keeper_name:name ~event
 
@@ -296,7 +299,13 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
            Keeper_keepalive.process_directive
              ~agent_name:entry.meta.agent_name
              Keeper_directive.Wakeup;
-           refresh_keeper_execution_surfaces ~config ~name "started";
+           refresh_keeper_execution_surfaces
+             ~config
+             ~name
+             (Keeper_lifecycle_events.Custom_event
+                { verb = Keeper_lifecycle_events.Started
+                ; phase = Some Keeper_state_machine.Running
+                });
            let detail =
              match Keeper_registry.get ~base_path:config.base_path name with
              | Some latest -> Keeper_meta_json.meta_to_json latest.meta
@@ -322,7 +331,13 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
               let post_action_result =
                 if String.equal action "boot"
                 then (
-                  refresh_keeper_execution_surfaces ~config ~name "started";
+                  refresh_keeper_execution_surfaces
+                    ~config
+                    ~name
+                    (Keeper_lifecycle_events.Custom_event
+                       { verb = Keeper_lifecycle_events.Started
+                       ; phase = Some Keeper_state_machine.Running
+                       });
                   Ok ())
                 else (
                   match Keeper_registry.get_phase ~base_path:config.base_path name with
@@ -359,7 +374,11 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
                 | "shutdown" ->
                   if persist_keeper_pause ()
                   then (
-                    refresh_keeper_execution_surfaces ~config ~name "paused";
+                    refresh_keeper_execution_surfaces
+                      ~config
+                      ~name
+                      (Keeper_lifecycle_events.Phase_event
+                         Keeper_state_machine.Paused);
                     Ok ())
                   else Error "paused-state persist failed after shutdown"
                 | _ ->

--- a/lib/server/server_dashboard_http_keeper_api_lifecycle_post.mli
+++ b/lib/server/server_dashboard_http_keeper_api_lifecycle_post.mli
@@ -14,7 +14,10 @@ val handle_keeper_lifecycle_post :
     separate boot transaction. *)
 
 val refresh_keeper_execution_surfaces :
-  config:Workspace.config -> name:string -> string -> unit
+  config:Workspace.config ->
+  name:string ->
+  Keeper_lifecycle_events.lifecycle_event ->
+  unit
 (** Invalidate caches and patch execution-surface dependents after a keeper
     lifecycle transition. *)
 

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -1048,7 +1048,15 @@ let handle_keeper_config_post ~sw ~clock state agent_name req reqd body_str =
                                ~detail
                                ())
                            else (
-                             invalidate_config_surfaces ~config ~name (Some "restarted");
+                             invalidate_config_surfaces
+                               ~config
+                               ~name
+                               (Some
+                                  (Keeper_lifecycle_events.Custom_event
+                                     { verb = Keeper_lifecycle_events.Restarted
+                                     ; phase =
+                                         Some Keeper_state_machine.Running
+                                     }));
                              let (_st, json) =
                                Dashboard_http_keeper.keeper_config_json config
                                  name
@@ -1482,7 +1490,7 @@ let handle_keeper_directive_post ~sw:_ ~clock:_ state _agent_name req reqd body_
               ])
            reqd
        | Ok success ->
-         refresh_keeper_execution_surfaces ~config ~name "resume_owner";
+         invalidate_keeper_execution_surfaces ~config ();
          let response = resume_result_json ~name success in
          (match success.projection with
           | Applied _ ->
@@ -1546,7 +1554,11 @@ let handle_keeper_directive_post ~sw:_ ~clock:_ state _agent_name req reqd body_
             directive;
           (match plain_directive with
            | Plain_pause ->
-             refresh_keeper_execution_surfaces ~config ~name "paused"
+             refresh_keeper_execution_surfaces
+               ~config
+               ~name
+               (Keeper_lifecycle_events.Phase_event
+                  Keeper_state_machine.Paused)
            | Plain_wakeup ->
              invalidate_keeper_execution_surfaces ~config ());
           Http.Response.json_value ~compress:true ~request:req

--- a/lib/server/server_dashboard_http_keeper_api_post.mli
+++ b/lib/server/server_dashboard_http_keeper_api_post.mli
@@ -85,7 +85,10 @@ val handle_keeper_checkpoints_post :
   Mcp_server.server_state -> Httpun.Request.t -> Httpun.Reqd.t -> string -> unit
 
 val refresh_keeper_execution_surfaces :
-  config:Workspace_utils.config -> name:String.t -> string -> unit
+  config:Workspace_utils.config ->
+  name:String.t ->
+  Keeper_lifecycle_events.lifecycle_event ->
+  unit
 val invalidate_keeper_execution_surfaces :
   config:Workspace_utils.config -> unit -> unit
 

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1917,101 +1917,125 @@ let test_telemetry_n_default_is_bounded () =
    docstrings cited coverage tests ([lifecycle_events_ssot] /
    [lifecycle_event_cache_patcher_coverage]) in a test/test_types.ml that does
    not exist. These are the real guards. *)
-let test_lifecycle_event_of_string_roundtrip () =
-  List.iter
+let current_lifecycle_events =
+  List.map
     (fun verb ->
-      let s = Keeper_lifecycle_events.to_string verb in
+      Keeper_lifecycle_events.Custom_event { verb; phase = None })
+    Keeper_lifecycle_events.all_custom_events
+  @ List.map
+      (fun phase -> Keeper_lifecycle_events.Phase_event phase)
+      [
+        Keeper_state_machine.Running;
+        Keeper_state_machine.Stopped;
+        Keeper_state_machine.Crashed;
+        Keeper_state_machine.Dead;
+      ]
+
+let test_lifecycle_event_wire_roundtrip () =
+  List.iter
+    (fun event ->
+      let event_name =
+        Keeper_lifecycle_events.lifecycle_event_to_string event
+      in
+      let phase =
+        Keeper_lifecycle_events.lifecycle_event_phase event
+        |> Option.map Keeper_state_machine.phase_to_string
+      in
       check bool
-        ("event_of_string round-trips " ^ s)
+        ("lifecycle wire round-trips " ^ event_name)
         true
-        (match Keeper_lifecycle_events.event_of_string s with
-         | Some v -> String.equal (Keeper_lifecycle_events.to_string v) s
-         | None -> false))
-    Keeper_lifecycle_events.all_custom_events;
-  check bool "unknown lifecycle event string is None" true
+        (Keeper_lifecycle_events.lifecycle_event_of_wire
+           ~event:event_name
+           ~phase
+         = Some event))
+    current_lifecycle_events;
+  check bool "unknown lifecycle wire event is rejected" true
     (Option.is_none
-       (Keeper_lifecycle_events.event_of_string "no_such_lifecycle_event"));
-  List.iter
-    (fun verb ->
-      check bool
-        ("legacy phase/operator event is not a custom verb: " ^ verb)
-        true
-        (Option.is_none (Keeper_lifecycle_events.event_of_string verb)))
-    [ "running"; "stopped"; "crashed"; "dead"; "paused"; "resumed" ]
+       (Keeper_lifecycle_events.lifecycle_event_of_wire
+          ~event:"no_such_lifecycle_event"
+          ~phase:None));
+  check bool "inconsistent phase event is rejected" true
+    (Option.is_none
+       (Keeper_lifecycle_events.lifecycle_event_of_wire
+          ~event:"running"
+          ~phase:(Some "stopped")))
 
 let test_lifecycle_event_cache_patcher_coverage () =
   (* Every name in the SSOT vocabulary must be classified ([Some]) by all four
      dashboard cache patchers — the coverage the phantom test only promised. The
      custom-event subset is also compiler-enforced via [display_of_custom_event]. *)
   List.iter
-    (fun name ->
+    (fun event ->
+      let name =
+        Keeper_lifecycle_events.lifecycle_event_to_string event
+      in
       check bool
         ("keepalive_running classifies " ^ name)
         true
         (Option.is_some
            (Server_dashboard_http_execution_surfaces.keepalive_running_of_lifecycle_event
-              name));
+              event));
       check bool
         ("phase classifies " ^ name)
         true
         (Option.is_some
-           (Server_dashboard_http_execution_surfaces.phase_of_lifecycle_event name));
+           (Server_dashboard_http_execution_surfaces.phase_of_lifecycle_event event));
       check bool
         ("pipeline_stage classifies " ^ name)
         true
         (Option.is_some
            (Server_dashboard_http_execution_surfaces.pipeline_stage_of_lifecycle_event
-              name));
+              event));
       check bool
         ("paused classifies " ^ name)
-        true
+        (not
+           (event
+            = Keeper_lifecycle_events.Phase_event
+                Keeper_state_machine.Stopped))
         (Option.is_some
-           (Server_dashboard_http_execution_surfaces.paused_of_lifecycle_event name)))
-    Keeper_lifecycle_events.all_event_names
+           (Server_dashboard_http_execution_surfaces.paused_of_lifecycle_event event)))
+    current_lifecycle_events
 
 let test_lifecycle_event_display_values () =
-  (* Pin the exact (keepalive_running, phase, pipeline_stage, paused) projection
-     for every lifecycle event string — including the legacy operator strings
-     [paused] / [resumed] that are outside [all_event_names]. This locks the
-     byte-identity the refactor preserves: a value drift in
-     [display_of_custom_event] or [display_of_phase_or_legacy_string] now fails
-     here instead of silently changing a dashboard row (the coverage test above
-     only asserts [Some], not the value). *)
+  (* Pin the exact typed transition projection. *)
   let cases =
-    [ ("started", true, "running", "idle", Some false);
-      ("restarted", true, "running", "idle", Some false);
-      ("reconciled", true, "running", "idle", Some false);
-      ("running", true, "running", "idle", Some false);
-      ("resumed", true, "running", "idle", Some false);
-      ("paused", true, "paused", "paused", Some true);
-      ("purged", false, "stopped", "offline", Some false);
-      ("admission_denied", false, "offline", "offline", Some false);
-      ("dead_cleaned", false, "dead", "offline", Some false);
-      ("stopped", false, "stopped", "offline", None);
-      ("crashed", false, "crashed", "crashed", Some false);
-      ("dead", false, "dead", "offline", Some false);
+    [
+      ( Keeper_lifecycle_events.Custom_event
+          { verb = Keeper_lifecycle_events.Started; phase = None },
+        true, "running", "idle", Some false );
+      ( Keeper_lifecycle_events.Phase_event Keeper_state_machine.Paused,
+        true, "paused", "paused", Some true );
+      ( Keeper_lifecycle_events.Phase_event Keeper_state_machine.Stopped,
+        false, "stopped", "offline", None );
+      ( Keeper_lifecycle_events.Phase_event Keeper_state_machine.Crashed,
+        false, "crashed", "crashed", Some false );
+      ( Keeper_lifecycle_events.Phase_event Keeper_state_machine.Dead,
+        false, "dead", "offline", Some false );
     ]
   in
   List.iter
-    (fun (name, keepalive, phase, pipeline, paused) ->
+    (fun (event, keepalive, phase, pipeline, paused) ->
+      let name =
+        Keeper_lifecycle_events.lifecycle_event_to_string event
+      in
       check (option bool)
         ("keepalive_running value for " ^ name)
         (Some keepalive)
         (Server_dashboard_http_execution_surfaces.keepalive_running_of_lifecycle_event
-           name);
+           event);
       check (option string)
         ("phase value for " ^ name)
         (Some phase)
-        (Server_dashboard_http_execution_surfaces.phase_of_lifecycle_event name);
+        (Server_dashboard_http_execution_surfaces.phase_of_lifecycle_event event);
       check (option string)
         ("pipeline_stage value for " ^ name)
         (Some pipeline)
         (Server_dashboard_http_execution_surfaces.pipeline_stage_of_lifecycle_event
-           name);
+           event);
       check (option bool)
         ("paused value for " ^ name)
         paused
-        (Server_dashboard_http_execution_surfaces.paused_of_lifecycle_event name))
+        (Server_dashboard_http_execution_surfaces.paused_of_lifecycle_event event))
     cases
 
 (* The [paused] lifecycle event patches with [keepalive_running = true], so the
@@ -2024,7 +2048,8 @@ let test_paused_lifecycle_event_keeps_paused_status () =
   let patched =
     Server_dashboard_http_execution_surfaces.patch_keeper_row
       ~keeper_name:"pause-target"
-      ~event:"paused"
+      ~event:
+        (Keeper_lifecycle_events.Phase_event Keeper_state_machine.Paused)
       ~keepalive_running:true
       (`Assoc [ ("name", `String "pause-target"); ("status", `String "paused") ])
   in
@@ -2033,28 +2058,13 @@ let test_paused_lifecycle_event_keeps_paused_status () =
   check bool "paused flag is set" true
     Yojson.Safe.Util.(patched |> member "paused" |> to_bool)
 
-let test_resumed_lifecycle_event_clears_paused_status () =
-  let patched =
-    Server_dashboard_http_execution_surfaces.patch_keeper_row
-      ~keeper_name:"resume-target"
-      ~event:"resumed"
-      ~keepalive_running:true
-      (`Assoc
-        [ ("name", `String "resume-target")
-        ; ("status", `String "paused")
-        ; ("paused", `Bool true)
-        ])
-  in
-  check string "resumed status is idle" "idle"
-    Yojson.Safe.Util.(patched |> member "status" |> to_string);
-  check bool "resumed flag clears pause" false
-    Yojson.Safe.Util.(patched |> member "paused" |> to_bool)
-
 let test_reconciled_lifecycle_event_preserves_durable_pause () =
   let patched =
     Server_dashboard_http_execution_surfaces.patch_keeper_row
       ~keeper_name:"paused-reconcile-target"
-      ~event:"reconciled"
+      ~event:
+        (Keeper_lifecycle_events.Custom_event
+           { verb = Keeper_lifecycle_events.Reconciled; phase = None })
       ~keepalive_running:true
       (`Assoc
         [ ("name", `String "paused-reconcile-target")
@@ -2079,7 +2089,8 @@ let test_stopped_lifecycle_event_stays_offline () =
   let patched =
     Server_dashboard_http_execution_surfaces.patch_keeper_row
       ~keeper_name:"stop-target"
-      ~event:"stopped"
+      ~event:
+        (Keeper_lifecycle_events.Phase_event Keeper_state_machine.Stopped)
       ~keepalive_running:false
       (`Assoc
         [ ("name", `String "stop-target")
@@ -2096,7 +2107,8 @@ let test_stopped_lifecycle_event_preserves_durable_pause () =
   let patched =
     Server_dashboard_http_execution_surfaces.patch_keeper_row
       ~keeper_name:"paused-stop-target"
-      ~event:"stopped"
+      ~event:
+        (Keeper_lifecycle_events.Phase_event Keeper_state_machine.Stopped)
       ~keepalive_running:false
       (`Assoc
         [ ("name", `String "paused-stop-target")
@@ -2114,7 +2126,9 @@ let test_lifecycle_cache_patch_rejects_missing_or_unknown_status () =
   let patch row =
     Server_dashboard_http_execution_surfaces.patch_keeper_row
       ~keeper_name:"drift-target"
-      ~event:"reconciled"
+      ~event:
+        (Keeper_lifecycle_events.Custom_event
+           { verb = Keeper_lifecycle_events.Reconciled; phase = None })
       ~keepalive_running:true
       row
     |> ignore
@@ -2605,16 +2619,14 @@ let () =
             test_composite_blocked_uses_terminal_contract_not_observational_metadata;
         ] );
       ( "lifecycle event classification (#22071)",
-        [ test_case "event_of_string round-trips to_string" `Quick
-            test_lifecycle_event_of_string_roundtrip;
+        [ test_case "typed wire lifecycle round-trips" `Quick
+            test_lifecycle_event_wire_roundtrip;
           test_case "cache patchers cover the SSOT vocabulary" `Quick
             test_lifecycle_event_cache_patcher_coverage;
           test_case "cache patchers pin byte-identical values" `Quick
             test_lifecycle_event_display_values;
           test_case "paused lifecycle event keeps the paused status" `Quick
             test_paused_lifecycle_event_keeps_paused_status;
-          test_case "resumed lifecycle event clears the paused status" `Quick
-            test_resumed_lifecycle_event_clears_paused_status;
           test_case "reconciled lifecycle event preserves durable pause" `Quick
             test_reconciled_lifecycle_event_preserves_durable_pause;
           test_case "stopped lifecycle event stays offline" `Quick


### PR DESCRIPTION
## Summary

- replace the dashboard cache patcher legacy/raw lifecycle parser with the existing typed `Keeper_lifecycle_events.lifecycle_event`
- decode event-bus `{event, phase}` once at the server bootstrap boundary and reject inconsistent/unknown pairs
- construct typed phase/custom events at direct lifecycle/config/pause entrypoints
- preserve paused reconciliation and terminal stop semantics through current typed status authorities

## Why

Merged #26370 kept `Legacy_*`, `lifecycle_legacy_wire_event_of_string`, and a `resumed` compatibility projection. That violates the current-state hard-cut rule and leaves lifecycle classification split between the typed event authority and a second raw-string facade.

This PR removes that compatibility implementation. It adds no migration or historical-data path.

## Blast radius

Only dashboard execution/continuity cache patching and its direct lifecycle callers change. Keeper scheduling, registry persistence, and lifecycle event production remain owned by their existing authorities.

## Validation

- latest `main@83601fa1c266dbb4c36e9a9832ed4288722995a5`
- `scripts/dune-local.sh build test/test_dashboard_http_core.exe`
- lifecycle event classification focused suite: 9/9
- changed OCaml: `ocamlformat --check`, parser-only check
- `git diff --check`

Source/build evidence is not deployment or live-runtime proof.