### PR TITLE
refactor(keeper): collapse compaction commit onto source CAS

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -78,8 +78,6 @@ type compaction_preparation =
   { context : working_context
   ; decision : compaction_decision
   ; evidence : Keeper_compaction_evidence.t option
-  ; post_success_terminalizer :
-      Keeper_compaction_llm_summarizer.post_success_terminalizer option
   }
 
 let compaction_decision_to_string = function
@@ -160,8 +158,6 @@ type requested_compaction =
   { messages : Agent_sdk.Types.message list
   ; exact_execution_evidence :
       Keeper_compaction_llm_summarizer.exact_execution_evidence
-  ; post_success_terminalizer :
-      Keeper_compaction_llm_summarizer.post_success_terminalizer
   ; summarized_message_count : int
   ; dropped_message_count : int
   ; plan_accounting : plan_accounting
@@ -217,19 +213,11 @@ let tool_block_counts messages =
     messages
 ;;
 
-let terminal_rejection terminalizer cause =
-  match
-    Keeper_compaction_llm_summarizer.terminalize_post_success
-      terminalizer
-      cause
-  with
-  | Keeper_compaction_llm_summarizer.Terminalized terminal ->
-    Exact_execution_terminal terminal
-  | Keeper_compaction_llm_summarizer.Terminalization_commit_in_progress _
-  | Keeper_compaction_llm_summarizer.Terminalization_already_committed
-  | Keeper_compaction_llm_summarizer.Terminalization_invariant_failed _ ->
-    summarization_rejection
-      Keeper_compaction_llm_summarizer.Exact_flow_already_started
+let terminal_rejection exact_execution_evidence cause =
+  Exact_execution_terminal
+    (Keeper_compaction_llm_summarizer.exact_execution_terminal
+       ~cause
+       exact_execution_evidence)
 ;;
 
 let requested_messages_with_plan
@@ -258,20 +246,11 @@ let requested_messages_with_plan
        fails too, so rejecting here refuses no compaction that could have
        persisted.
 
-       The observable outcome is deliberately NOT identical to the late
-       failure, and the difference is the point:
-
-       - Late: [commit_prepared_compaction] returns a typed [Commit_failed],
-         which [Keeper_manual_compaction.run_commit] folds into
-         [Manual_compaction_failed] -> [Requeue Context_compaction_retry].
-         The owner loop leaves the selected source pending, so the same doomed
-         request is re-driven every cycle — one summarizer call each time. This
-         is the live livelock: 102 failures and 104 compaction LLM calls in the
-         74 minutes after the #25413 build went live.
-       - Early: the typed [No_compaction] arm of
-         [Keeper_manual_compaction.finish_preparation] becomes
-         [Manual_compaction_not_applied], so the owner loop ACKs the selected
-         source after recording a ledger row and [compaction_rejected] log.
+       Without this precheck, the same canonical validator rejects only at the
+       checkpoint boundary after the exact-output call has already run.
+       [commit_prepared_compaction] now returns that late refusal as typed
+       [Not_committed]; checking here preserves the same feature result while
+       avoiding a provider call that cannot produce a persistable checkpoint.
 
        Terminating is correct here because [validate] rejection is monotone
        under append: appending messages never repairs an existing structural
@@ -303,10 +282,6 @@ let requested_messages_with_plan
            Keeper_compaction_llm_summarizer.completed_exact_execution_evidence
              completed
          in
-         let post_success_terminalizer =
-           Keeper_compaction_llm_summarizer.completed_post_success_terminalizer
-             completed
-         in
          let summarized_indices =
            Keeper_compaction_llm_summarizer.summarized_indices plan
          in
@@ -323,13 +298,12 @@ let requested_messages_with_plan
             then
               Error
                 (terminal_rejection
-                   post_success_terminalizer
+                   exact_execution_evidence
                    Keeper_compaction_outcome.Domain_invalid_output)
             else
               Ok
                 { messages
                 ; exact_execution_evidence
-                ; post_success_terminalizer
                 ; summarized_message_count =
                     selected_message_count
                       units
@@ -412,7 +386,6 @@ let compact_for_request_typed_with
     { context = ctx
     ; decision = Rejected (trigger, reason)
     ; evidence = None
-    ; post_success_terminalizer = None
     }
   | Ok requested ->
     let checkpoint =
@@ -432,7 +405,6 @@ let compact_for_request_typed_with
       { context = ctx
       ; decision = Rejected (trigger, reason)
       ; evidence = None
-      ; post_success_terminalizer = None
       }
     in
     (* Both outcomes are terminal for this attempt, and both used to report
@@ -449,7 +421,7 @@ let compact_for_request_typed_with
        slot_id / call_id / plan fingerprint, which a flat rejection would have dropped
        (keeper_post_turn.ml maps the two shapes to different payloads). *)
     let reject_terminal cause =
-      reject (terminal_rejection requested.post_success_terminalizer cause)
+      reject (terminal_rejection requested.exact_execution_evidence cause)
     in
     if after_bytes = before_bytes
     then reject_terminal Keeper_compaction_outcome.Compaction_produced_no_reduction
@@ -516,19 +488,12 @@ let compact_for_request_typed_with
       in
       match evidence_result with
       | Error error ->
-        (match
-           Keeper_compaction_llm_summarizer.terminalize_post_success
-             requested.post_success_terminalizer
-             Keeper_compaction_outcome.Invalid_structural_evidence
-         with
-         | Keeper_compaction_llm_summarizer.Terminalized terminal ->
-           reject (Invalid_structural_evidence (error, terminal))
-         | Keeper_compaction_llm_summarizer.Terminalization_commit_in_progress _
-         | Keeper_compaction_llm_summarizer.Terminalization_already_committed
-         | Keeper_compaction_llm_summarizer.Terminalization_invariant_failed _ ->
-           reject
-             (summarization_rejection
-                Keeper_compaction_llm_summarizer.Exact_flow_already_started))
+        let terminal =
+          Keeper_compaction_llm_summarizer.exact_execution_terminal
+            ~cause:Keeper_compaction_outcome.Invalid_structural_evidence
+            requested.exact_execution_evidence
+        in
+        reject (Invalid_structural_evidence (error, terminal))
       | Ok evidence ->
         let compacted_ctx = sync_oas_context compacted_ctx in
         Log.Harness.emit
@@ -551,7 +516,6 @@ let compact_for_request_typed_with
         { context = compacted_ctx
         ; decision = Prepared trigger
         ; evidence = Some evidence
-        ; post_success_terminalizer = Some requested.post_success_terminalizer
         })
 ;;
 

--- a/lib/keeper/keeper_compact_policy.mli
+++ b/lib/keeper/keeper_compact_policy.mli
@@ -42,8 +42,6 @@ type compaction_preparation =
   { context : Keeper_context_core.working_context
   ; decision : compaction_decision
   ; evidence : Keeper_compaction_evidence.t option
-  ; post_success_terminalizer :
-      Keeper_compaction_llm_summarizer.post_success_terminalizer option
   }
 
 (** Apply a caller-owned request. Only a valid configured-LLM plan that

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -62,66 +62,9 @@ type attempt_observation =
 type before_dispatch_authority =
   attempt_observation -> (unit, string) result
 
-type post_success_completion =
-  { waiter : unit Eio.Promise.t
-  ; resolve : unit -> unit
-  }
-
-type post_success_phase =
-  | Open
-  | Commit_claimed of post_success_completion
-  | Installed_pending_valid of post_success_completion
-  | Committed of (unit, string) result
-  | Reject_claimed of
-      Keeper_compaction_outcome.exact_execution_terminal
-      * post_success_completion
-  | Rejected of Keeper_compaction_outcome.exact_execution_terminal
-
-type post_success_terminalizer =
-  { attempt_observation : attempt_observation
-  ; disposition_mutex : Eio.Mutex.t
-  ; mutable phase : post_success_phase
-  ; mutable domain_valid_attempts : int
-  ; mutable domain_rejected_attempts : int
-  }
-
-type post_success_terminalization =
-  | Terminalized of Keeper_compaction_outcome.exact_execution_terminal
-  | Terminalization_commit_in_progress of unit Eio.Promise.t
-  | Terminalization_already_committed
-  | Terminalization_invariant_failed of string
-
-type post_success_commit_claim =
-  | Commit_claim_acquired
-  | Commit_claim_in_progress of unit Eio.Promise.t
-  | Commit_claim_already_committed
-  | Commit_claim_rejected of Keeper_compaction_outcome.exact_execution_terminal
-
-type 'a post_success_commit_boundary =
-  | Post_success_commit_result of 'a
-  | Post_success_commit_in_progress of unit Eio.Promise.t
-  | Post_success_commit_already_committed
-  | Post_success_commit_rejected of
-      Keeper_compaction_outcome.exact_execution_terminal
-
-type post_success_phase_snapshot =
-  | Phase_open
-  | Phase_commit_claimed
-  | Phase_installed_pending_valid
-  | Phase_committed
-  | Phase_reject_claimed
-  | Phase_rejected
-
-type post_success_snapshot =
-  { phase : post_success_phase_snapshot
-  ; domain_valid_attempts : int
-  ; domain_rejected_attempts : int
-  }
-
 type completed_plan =
   { plan : compaction_plan
   ; exact_execution_evidence : exact_execution_evidence
-  ; post_success_terminalizer : post_success_terminalizer
   }
 
 type summarization_failure =
@@ -774,237 +717,6 @@ let terminal_of_observation cause (observation : attempt_observation) =
     }
 ;;
 
-let make_post_success_completion () =
-  let waiter, resolver = Eio.Promise.create () in
-  { waiter
-  ; resolve =
-      (fun () ->
-         match Eio.Promise.try_resolve resolver () with
-         | true
-         | false ->
-           ())
-  }
-;;
-
-let terminal_for terminalizer cause =
-  Keeper_compaction_outcome.
-    { cause
-    ; slot_id = terminalizer.attempt_observation.slot_id
-    ; call_id = terminalizer.attempt_observation.call_id
-    ; plan_fingerprint =
-        terminalizer.attempt_observation.receipt_plan_fingerprint
-    ; request_body_sha256 =
-        terminalizer.attempt_observation.receipt_request_body_sha256
-    }
-;;
-
-let with_disposition terminalizer callback =
-  Eio.Mutex.use_rw ~protect:true terminalizer.disposition_mutex callback
-;;
-
-let finish_rejection
-      terminalizer
-      (terminal : Keeper_compaction_outcome.exact_execution_terminal)
-      completion
-  =
-  Eio.Cancel.protect
-  @@ fun () ->
-  with_disposition terminalizer (fun () ->
-    match terminalizer.phase with
-    | Reject_claimed (claimed, _) when claimed = terminal ->
-      terminalizer.phase <- Rejected terminal
-    | Open
-    | Commit_claimed _
-    | Installed_pending_valid _
-    | Committed _
-    | Reject_claimed _
-    | Rejected _ ->
-      ());
-  completion.resolve ();
-  Terminalized terminal
-;;
-
-let claim_post_success_commit_current terminalizer =
-  with_disposition terminalizer (fun () ->
-    match terminalizer.phase with
-    | Open ->
-      let completion = make_post_success_completion () in
-      terminalizer.phase <- Commit_claimed completion;
-      Commit_claim_acquired
-    | Commit_claimed completion
-    | Installed_pending_valid completion ->
-      Commit_claim_in_progress completion.waiter
-    | Committed _ -> Commit_claim_already_committed
-    | Reject_claimed (_, completion) ->
-      Commit_claim_in_progress completion.waiter
-    | Rejected terminal -> Commit_claim_rejected terminal)
-;;
-
-let claim_post_success_commit terminalizer =
-  claim_post_success_commit_current terminalizer
-;;
-
-let with_post_success_commit terminalizer commit =
-  match claim_post_success_commit_current terminalizer with
-  | Commit_claim_acquired ->
-    Post_success_commit_result (commit ())
-  | Commit_claim_in_progress waiter ->
-    Post_success_commit_in_progress waiter
-  | Commit_claim_already_committed ->
-    Post_success_commit_already_committed
-  | Commit_claim_rejected terminal ->
-    Post_success_commit_rejected terminal
-;;
-
-let mark_post_success_checkpoint_installed terminalizer =
-  with_disposition terminalizer (fun () ->
-    match terminalizer.phase with
-    | Commit_claimed completion ->
-      terminalizer.phase <- Installed_pending_valid completion;
-      Ok ()
-    | Open
-    | Installed_pending_valid _
-    | Committed _
-    | Reject_claimed _
-    | Rejected _ ->
-      Error "post-success checkpoint installation has no commit claimant")
-;;
-
-let complete_post_success_commit terminalizer =
-  let completion =
-    with_disposition terminalizer (fun () ->
-      match terminalizer.phase with
-      | Installed_pending_valid completion ->
-        terminalizer.domain_valid_attempts <-
-          terminalizer.domain_valid_attempts + 1;
-        terminalizer.phase <- Committed (Ok ());
-        Ok (Some completion)
-      | Committed result -> Result.map (fun () -> None) result
-      | Open
-      | Commit_claimed _
-      | Reject_claimed _
-      | Rejected _ ->
-        Error
-          "post-success completion has no installed commit claimant")
-  in
-  match completion with
-  | Error _ as error -> error
-  | Ok None -> Ok ()
-  | Ok (Some completion) ->
-    completion.resolve ();
-    Ok ()
-;;
-
-let finish_post_success_commit_failure terminalizer detail =
-  Eio.Cancel.protect
-  @@ fun () ->
-  let completion =
-    with_disposition terminalizer (fun () ->
-      match terminalizer.phase with
-      | Installed_pending_valid completion ->
-        terminalizer.domain_valid_attempts <-
-          terminalizer.domain_valid_attempts + 1;
-        terminalizer.phase <- Committed (Error detail);
-        Ok (Some completion)
-      | Committed result -> Result.map (fun () -> None) result
-      | Open
-      | Commit_claimed _
-      | Reject_claimed _
-      | Rejected _ ->
-        Error
-          "post-success failure has no installed commit claimant")
-  in
-  match completion with
-  | Error _ as error -> error
-  | Ok None -> Ok ()
-  | Ok (Some completion) ->
-    completion.resolve ();
-    Error detail
-;;
-
-let claim_rejection terminalizer ~from_commit cause =
-  with_disposition terminalizer (fun () ->
-    match terminalizer.phase, from_commit with
-    | Open, false ->
-      let terminal = terminal_for terminalizer cause in
-      let completion = make_post_success_completion () in
-      terminalizer.domain_rejected_attempts <-
-        terminalizer.domain_rejected_attempts + 1;
-      terminalizer.phase <- Reject_claimed (terminal, completion);
-      `Own (terminal, completion)
-    | Commit_claimed completion, true ->
-      let terminal = terminal_for terminalizer cause in
-      terminalizer.domain_rejected_attempts <-
-        terminalizer.domain_rejected_attempts + 1;
-      terminalizer.phase <- Reject_claimed (terminal, completion);
-      `Own (terminal, completion)
-    | Reject_claimed (terminal, completion), _ ->
-      `Await (terminal, completion)
-    | Rejected terminal, _ -> `Done terminal
-    | Commit_claimed completion, false
-    | Installed_pending_valid completion, _ ->
-      `Commit_in_progress completion.waiter
-    | Committed _, _ -> `Already_committed
-    | Open, true ->
-      `Invariant "commit claimant rejection observed an open disposition")
-;;
-
-let finish_claimed_rejection terminalizer role =
-  match role with
-  | `Own (terminal, completion) ->
-    finish_rejection terminalizer terminal completion
-  | `Await (terminal, completion) ->
-    Eio.Promise.await completion.waiter;
-    (match
-       with_disposition terminalizer (fun () ->
-         match terminalizer.phase with
-         | Rejected durable when durable = terminal ->
-           Some ()
-         | Open
-         | Commit_claimed _
-         | Installed_pending_valid _
-         | Committed _
-         | Reject_claimed _
-         | Rejected _ ->
-           None)
-     with
-     | Some () -> Terminalized terminal
-     | None ->
-       Terminalization_invariant_failed
-         "post-success reject waiter completed without canonical rejection")
-  | `Done terminal -> Terminalized terminal
-  | `Commit_in_progress waiter -> Terminalization_commit_in_progress waiter
-  | `Already_committed -> Terminalization_already_committed
-  | `Invariant detail -> Terminalization_invariant_failed detail
-;;
-
-let terminalize_claimed_commit terminalizer cause =
-  claim_rejection terminalizer ~from_commit:true cause
-  |> finish_claimed_rejection terminalizer
-;;
-
-let terminalize_post_success (terminalizer : post_success_terminalizer) cause =
-  claim_rejection terminalizer ~from_commit:false cause
-  |> finish_claimed_rejection terminalizer
-;;
-
-let post_success_snapshot terminalizer =
-  with_disposition terminalizer (fun () ->
-    let phase =
-      match terminalizer.phase with
-      | Open -> Phase_open
-      | Commit_claimed _ -> Phase_commit_claimed
-      | Installed_pending_valid _ -> Phase_installed_pending_valid
-      | Committed _ -> Phase_committed
-      | Reject_claimed _ -> Phase_reject_claimed
-      | Rejected _ -> Phase_rejected
-    in
-    { phase
-    ; domain_valid_attempts = terminalizer.domain_valid_attempts
-    ; domain_rejected_attempts = terminalizer.domain_rejected_attempts
-    })
-;;
-
 let exact_execution_evidence (flow_success : Exact_output.flow_success) =
   let success = Exact_output.flow_success_output flow_success in
   let provenance = success.provenance in
@@ -1340,21 +1052,9 @@ let execute_prepared_lane_current
             observation))
   | `Flow (Ok validated) ->
     let flow_success = validated.transport_success in
-    let observation =
-      flow_success
-      |> Exact_output.flow_success_candidate
-      |> observe_flow_attempt_receipt
-    in
     Ok
       { plan = validated.accepted
       ; exact_execution_evidence = exact_execution_evidence flow_success
-      ; post_success_terminalizer =
-          { attempt_observation = observation
-          ; disposition_mutex = Eio.Mutex.create ()
-          ; phase = Open
-          ; domain_valid_attempts = 0
-          ; domain_rejected_attempts = 0
-          }
       }
   in
   project_execution ()
@@ -1446,11 +1146,6 @@ let make
 
 let completed_plan completed = completed.plan
 let completed_exact_execution_evidence completed = completed.exact_execution_evidence
-let completed_post_success_terminalizer completed = completed.post_success_terminalizer
-
-let completed_attempt_observation completed =
-  completed.post_success_terminalizer.attempt_observation
-;;
 
 let exact_execution_evidence_slot_id (evidence : exact_execution_evidence) = evidence.slot_id
 let exact_execution_evidence_call_id (evidence : exact_execution_evidence) = evidence.call_id
@@ -1477,6 +1172,16 @@ let exact_execution_evidence_plan_fingerprint (evidence : exact_execution_eviden
 let exact_execution_evidence_receipt_request_body_sha256
       (evidence : exact_execution_evidence) =
   evidence.receipt_request_body_sha256
+;;
+
+let exact_execution_terminal ~cause (evidence : exact_execution_evidence) =
+  Keeper_compaction_outcome.
+    { cause
+    ; slot_id = evidence.slot_id
+    ; call_id = evidence.call_id
+    ; plan_fingerprint = evidence.plan_fingerprint
+    ; request_body_sha256 = evidence.receipt_request_body_sha256
+    }
 ;;
 
 module For_testing = struct
@@ -1527,6 +1232,4 @@ module For_testing = struct
         candidate.candidate_id)
       evidence.declared_candidate_snapshot
   ;;
-
-  let post_success_snapshot = post_success_snapshot
 end

--- a/lib/keeper/keeper_compaction_llm_summarizer.mli
+++ b/lib/keeper/keeper_compaction_llm_summarizer.mli
@@ -9,41 +9,6 @@ type exact_execution_evidence
 
 type completed_plan
 
-type post_success_terminalizer
-
-type post_success_terminalization =
-  | Terminalized of Keeper_compaction_outcome.exact_execution_terminal
-  | Terminalization_commit_in_progress of unit Eio.Promise.t
-  | Terminalization_already_committed
-  | Terminalization_invariant_failed of string
-
-type post_success_commit_claim =
-  | Commit_claim_acquired
-  | Commit_claim_in_progress of unit Eio.Promise.t
-  | Commit_claim_already_committed
-  | Commit_claim_rejected of Keeper_compaction_outcome.exact_execution_terminal
-
-type 'a post_success_commit_boundary =
-  | Post_success_commit_result of 'a
-  | Post_success_commit_in_progress of unit Eio.Promise.t
-  | Post_success_commit_already_committed
-  | Post_success_commit_rejected of
-      Keeper_compaction_outcome.exact_execution_terminal
-
-type post_success_phase_snapshot =
-  | Phase_open
-  | Phase_commit_claimed
-  | Phase_installed_pending_valid
-  | Phase_committed
-  | Phase_reject_claimed
-  | Phase_rejected
-
-type post_success_snapshot =
-  { phase : post_success_phase_snapshot
-  ; domain_valid_attempts : int
-  ; domain_rejected_attempts : int
-  }
-
 type prepared_lane
 
 type attempt_observation =
@@ -131,48 +96,6 @@ val plan_of_json
 
 val completed_plan : completed_plan -> compaction_plan
 val completed_exact_execution_evidence : completed_plan -> exact_execution_evidence
-val completed_attempt_observation : completed_plan -> attempt_observation
-val completed_post_success_terminalizer : completed_plan -> post_success_terminalizer
-
-val claim_post_success_commit :
-  post_success_terminalizer -> post_success_commit_claim
-
-(** Only the [Open] claimant executes [commit]. *)
-val with_post_success_commit :
-  post_success_terminalizer ->
-  (unit -> 'a) ->
-  'a post_success_commit_boundary
-
-val mark_post_success_checkpoint_installed :
-  post_success_terminalizer -> (unit, string) result
-
-val terminalize_claimed_commit :
-  post_success_terminalizer ->
-  Keeper_compaction_outcome.exact_execution_terminal_cause ->
-  post_success_terminalization
-
-val terminalize_post_success
-  :  post_success_terminalizer
-  -> Keeper_compaction_outcome.exact_execution_terminal_cause
-  -> post_success_terminalization
-(** Close the process-local post-success phase with the retained OAS attempt
-    identity. The first call atomically owns the canonical cause and releases
-    concurrent waiters; later calls return the same terminal even when they
-    propose a different cause. This does not create or persist a second
-    execution claim. *)
-
-val complete_post_success_commit
-  :  post_success_terminalizer
-  -> (unit, string) result
-(** Complete the existing affine post-success phase after the validated
-    compaction checkpoint is durable. *)
-
-val finish_post_success_commit_failure
-  :  post_success_terminalizer
-  -> string
-  -> (unit, string) result
-(** After durable checkpoint installation, conservatively finalize
-    the affine commit and always release its existing completion waiter. *)
 
 val exact_execution_evidence_slot_id : exact_execution_evidence -> string
 val exact_execution_evidence_call_id : exact_execution_evidence -> string
@@ -181,6 +104,13 @@ val exact_execution_evidence_catalog_generation_fingerprint : exact_execution_ev
 val exact_execution_evidence_catalog_evidence_sha256 : exact_execution_evidence -> string
 val exact_execution_evidence_plan_fingerprint : exact_execution_evidence -> string
 val exact_execution_evidence_receipt_request_body_sha256 : exact_execution_evidence -> string
+val exact_execution_terminal
+  :  cause:Keeper_compaction_outcome.exact_execution_terminal_cause
+  -> exact_execution_evidence
+  -> Keeper_compaction_outcome.exact_execution_terminal
+(** Pure typed projection of the OAS receipt identity retained by a successful
+    exact execution. It owns no claim, lock, waiter, or lifecycle state. *)
+
 val apply : compaction_plan -> Agent_sdk.Types.message list
 val summarized_indices : compaction_plan -> int list
 val dropped_indices : compaction_plan -> int list
@@ -202,8 +132,4 @@ module For_testing : sig
 
   val attempt_observations : prepared_lane -> attempt_observation list
   val candidate_snapshot_slot_ids : prepared_lane -> string list
-
-  val post_success_snapshot :
-    post_success_terminalizer -> post_success_snapshot
-
 end

--- a/lib/keeper/keeper_compaction_outcome.mli
+++ b/lib/keeper/keeper_compaction_outcome.mli
@@ -32,8 +32,9 @@ type no_compaction_reason =
           is an operator-actionable precondition failure tied to the durable
           checkpoint source, not a stochastic provider failure. *)
   | Exact_execution_terminal of exact_execution_terminal
-      (** Exact-output execution is affine and terminal. The typed cause plus
-          OAS slot/call identity forbids a second attempt for this source. *)
+      (** Typed outcome of one completed exact-output execution. The retained
+          OAS slot/call identity is evidence only; it creates no second claim,
+          durable replay barrier, or commit authority. *)
 
 type no_compaction =
   { source : Keeper_checkpoint_ref.t

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -169,10 +169,6 @@ let context_budget_json_of_resolution
 
 let apply_post_turn_lifecycle_with_resilience_handles =
   Keeper_post_turn.apply_post_turn_lifecycle_with_resilience_handles
-let recover_latest_checkpoint_for_compaction =
-  Keeper_post_turn.recover_latest_checkpoint_for_compaction
-let prepare_compaction = Keeper_post_turn.prepare_compaction
-let commit_prepared_compaction = Keeper_post_turn.commit_prepared_compaction
 
 let record_lifecycle_dispatch_rejection ~keeper_name ~origin event ~error =
   Otel_metric_store.inc_counter

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -162,30 +162,6 @@ val dispatch_post_turn_lifecycle_events
   -> post_turn_lifecycle
   -> unit
 
-val recover_latest_checkpoint_for_compaction
-  :  ?before_dispatch_authority:
-       Keeper_compaction_llm_summarizer.before_dispatch_authority
-  -> base_path:string
-  -> base_dir:string
-  -> meta:keeper_meta
-  -> trigger:Compaction_trigger.t
-  -> unit
-  -> Keeper_post_turn.prepared_commit_outcome
-
-val prepare_compaction
-  :  ?before_dispatch_authority:
-       Keeper_compaction_llm_summarizer.before_dispatch_authority
-  -> base_path:string
-  -> base_dir:string
-  -> meta:Keeper_meta_contract.keeper_meta
-  -> trigger:Compaction_trigger.t
-  -> unit
-  -> (Keeper_post_turn.prepared_compaction, Keeper_post_turn.compaction_recovery_error) result
-
-val commit_prepared_compaction
-  :  Keeper_post_turn.prepared_compaction
-  -> Keeper_post_turn.prepared_commit_outcome
-
 (** {1 Trace and Board Utilities} *)
 
 val generate_trace_id : ?now:float -> unit -> string

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -30,11 +30,6 @@ type operation_outcome =
   | Compacted of committed
   | No_compaction of Keeper_post_turn.no_compaction
 
-type uncommitted_resolution =
-  | Uncommitted_no_compaction of Keeper_post_turn.no_compaction
-  | Uncommitted_observed_commit of Keeper_post_turn.compaction_recovery
-  | Uncommitted_resolution_failed of Keeper_post_turn.compaction_recovery_error
-
 type pre_install_lifecycle_stage =
   | Operator_request
   | Compaction_started
@@ -235,7 +230,7 @@ let observe_terminal_dispatch_failure ~meta = function
   | Error error ->
     Log.Keeper.error
       ~keeper_name:meta.name
-      "manual compaction terminal lifecycle dispatch failed without reopening the affine request: %s"
+      "manual compaction terminal lifecycle dispatch failed without redispatching the provider request: %s"
       (Keeper_context_runtime.lifecycle_dispatch_error_to_string error)
 ;;
 
@@ -314,38 +309,17 @@ let run_commit ~config ~meta prepared =
          recovery;
        Ok (Compacted { recovery; installation = installed; lifecycle }))
   in
-  let completed = function
-    | Keeper_post_turn.Commit_completion_committed recovery ->
-      committed recovery
-    | Keeper_post_turn.Commit_completion_rejected no_compaction ->
-      terminal no_compaction
-    | Keeper_post_turn.Commit_completion_failed
-        { error; committed = None } ->
-      failed error
-    | Keeper_post_turn.Commit_completion_failed
-        { error; committed = Some recovery } ->
-      Log.Keeper.error
-        ~keeper_name:meta.name
-        "manual compaction observed a committed checkpoint with failed exact-domain finalization: %s"
-        (Keeper_post_turn.compaction_recovery_error_to_string error);
-      committed recovery
-  in
   match Keeper_context_runtime.commit_prepared_compaction prepared with
-  | Keeper_post_turn.Committed recovery
-  | Keeper_post_turn.Already_committed recovery ->
-    committed recovery
-  | Keeper_post_turn.Already_rejected no_compaction ->
-    terminal no_compaction
+  | Keeper_post_turn.Committed recovery -> committed recovery
+  | Keeper_post_turn.Not_committed no_compaction -> terminal no_compaction
   | Keeper_post_turn.Commit_failed { error; committed = None } ->
     failed error
   | Keeper_post_turn.Commit_failed { error; committed = Some recovery } ->
     Log.Keeper.error
       ~keeper_name:meta.name
-      "manual compaction committed checkpoint but exact-domain finalization failed: %s"
+      "manual compaction committed checkpoint but post-install callback failed: %s"
       (Keeper_post_turn.compaction_recovery_error_to_string error);
     committed recovery
-  | Keeper_post_turn.Commit_in_progress waiter ->
-    Eio.Promise.await waiter |> completed
 ;;
 
 let finish_preparation ~config ~meta = function
@@ -400,45 +374,6 @@ let preserve_no_compaction_after_final_admission_busy = function
   | Keeper_compaction_outcome.Invalid_structural_source -> false
 ;;
 
-let resolve_uncommitted = function
-  | Keeper_post_turn.Uncommitted_terminalized no_compaction ->
-    Uncommitted_no_compaction no_compaction
-  | Keeper_post_turn.Uncommitted_already_committed recovery ->
-    Uncommitted_observed_commit recovery
-  | Keeper_post_turn.Uncommitted_failed error ->
-    Uncommitted_resolution_failed error
-  | Keeper_post_turn.Uncommitted_commit_in_progress waiter ->
-    (match Eio.Promise.await waiter with
-     | Keeper_post_turn.Commit_completion_committed recovery ->
-       Uncommitted_observed_commit recovery
-     | Keeper_post_turn.Commit_completion_rejected no_compaction ->
-       Uncommitted_no_compaction no_compaction
-     | Keeper_post_turn.Commit_completion_failed
-         { error; committed = None } ->
-       Uncommitted_resolution_failed error
-     | Keeper_post_turn.Commit_completion_failed
-         { committed = Some recovery; _ } ->
-       Uncommitted_observed_commit recovery)
-;;
-
-let operation_of_observed_commit
-      (recovery : Keeper_post_turn.compaction_recovery)
-  =
-  match recovery.Keeper_post_turn.checkpoint_installation with
-  | Keeper_checkpoint_store.Installed installation ->
-    Ok
-      (Compacted
-         { recovery
-         ; installation
-         ; lifecycle = Completion_applied
-         })
-  | Keeper_checkpoint_store.Not_installed not_installed ->
-    Error
-      (Recovery
-         ( Keeper_post_turn.Checkpoint_cas_failed not_installed.cause
-         , Ok () ))
-;;
-
 let run_admitted_with
       ~append_compaction_manifest
       ~prepare_compaction
@@ -486,38 +421,8 @@ let run_admitted_with
      | `Busy block ->
        (match preparation with
         | Ok prepared ->
-          (match
-             Keeper_post_turn.no_compaction_of_uncommitted_prepared prepared
-             |> resolve_uncommitted
-           with
-           | Uncommitted_no_compaction no_compaction ->
-             `No_compaction no_compaction
-           | Uncommitted_observed_commit recovery ->
-             (match operation_of_observed_commit recovery with
-              | Ok (Compacted committed) ->
-                let manifest =
-                  append_compaction_manifest
-                    ~config
-                    ~base_dir
-                    ~meta
-                    ~installation:committed.installation
-                    ~lifecycle:committed.lifecycle
-                    committed.recovery
-                in
-                observe_manifest ~keeper_name:meta.name manifest;
-                `Applied
-                  { recovery = committed.recovery
-                  ; receipt =
-                      { installation = committed.installation
-                      ; lifecycle = committed.lifecycle
-                      ; manifest
-                      }
-                  }
-              | Ok (No_compaction no_compaction) ->
-                `No_compaction no_compaction
-              | Error failure -> `Compaction_failed failure)
-           | Uncommitted_resolution_failed error ->
-             `Compaction_failed (Recovery (error, Ok ())))
+          `No_compaction
+            (Keeper_post_turn.no_compaction_of_prepared prepared)
         | Error (Keeper_post_turn.No_compaction no_compaction)
           when preserve_no_compaction_after_final_admission_busy no_compaction.reason ->
           `No_compaction no_compaction
@@ -525,42 +430,11 @@ let run_admitted_with
      | `Ran (Error failure) ->
        (match preparation with
         | Ok prepared ->
-          (match
-             Keeper_post_turn.no_compaction_of_uncommitted_prepared
+          `No_compaction
+            (Keeper_post_turn.no_compaction_of_prepared
                ~cause:
                  Keeper_compaction_outcome.Lifecycle_transition_failed_after_dispatch
-               prepared
-             |> resolve_uncommitted
-           with
-           | Uncommitted_no_compaction no_compaction ->
-             `No_compaction no_compaction
-           | Uncommitted_observed_commit recovery ->
-             (match operation_of_observed_commit recovery with
-              | Ok (Compacted committed) ->
-                let manifest =
-                  append_compaction_manifest
-                    ~config
-                    ~base_dir
-                    ~meta
-                    ~installation:committed.installation
-                    ~lifecycle:committed.lifecycle
-                    committed.recovery
-                in
-                observe_manifest ~keeper_name:meta.name manifest;
-                `Applied
-                  { recovery = committed.recovery
-                  ; receipt =
-                      { installation = committed.installation
-                      ; lifecycle = committed.lifecycle
-                      ; manifest
-                      }
-                  }
-              | Ok (No_compaction no_compaction) ->
-                `No_compaction no_compaction
-              | Error observed_failure ->
-                `Compaction_failed observed_failure)
-           | Uncommitted_resolution_failed _ ->
-             `Compaction_failed failure)
+               prepared)
         | Error (Keeper_post_turn.No_compaction no_compaction) ->
           `No_compaction no_compaction
         | Error _ -> `Compaction_failed failure)

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -299,7 +299,7 @@ let run_commit ~config ~meta prepared =
       recovery;
     Ok (Compacted { recovery; installation; lifecycle })
   in
-  match Keeper_context_runtime.commit_prepared_compaction prepared with
+  match Keeper_post_turn.commit_prepared_compaction prepared with
   | Keeper_post_turn.Committed recovery -> committed recovery
   | Keeper_post_turn.Not_committed no_compaction -> terminal no_compaction
   | Keeper_post_turn.Commit_failed { error; committed = None } ->
@@ -458,7 +458,7 @@ let run_admitted
   run_admitted_with
     ~append_compaction_manifest:append_manifest
     ~prepare_compaction:(fun ~base_path ~base_dir ~meta ~trigger ->
-      Keeper_context_runtime.prepare_compaction
+      Keeper_post_turn.prepare_compaction
         ?before_dispatch_authority
         ~base_path
         ~base_dir
@@ -478,7 +478,7 @@ let run_under_admission
   run_admitted_with
     ~append_compaction_manifest:append_manifest
     ~prepare_compaction:(fun ~base_path ~base_dir ~meta ~trigger ->
-      Keeper_context_runtime.prepare_compaction
+      Keeper_post_turn.prepare_compaction
         ?before_dispatch_authority
         ~base_path
         ~base_dir

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -267,47 +267,37 @@ let run_commit ~config ~meta prepared =
     Error (Recovery (error, failure_dispatch))
   in
   let committed (recovery : Keeper_post_turn.compaction_recovery) =
-    (match recovery.checkpoint_installation with
-     | Keeper_checkpoint_store.Not_installed not_installed ->
-       let error = Keeper_post_turn.Checkpoint_cas_failed not_installed.cause in
-       let failure_dispatch =
-         dispatch_failed
-           ~config
-           ~meta
-           (Keeper_post_turn.compaction_recovery_error_to_tag error)
-       in
-       Error (Recovery (error, failure_dispatch))
-     | Keeper_checkpoint_store.Installed installed ->
-       let lifecycle =
-         match
-           Keeper_context_runtime.dispatch_compaction_completed
+    let installation = recovery.checkpoint_installation in
+    let lifecycle =
+      match
+        Keeper_context_runtime.dispatch_compaction_completed
+          ~config
+          ~keeper_name:meta.name
+          ~origin:Keeper_registry.Operator_compact
+      with
+      | Ok () -> Completion_applied
+      | Error completion_error ->
+        Log.Keeper.error
+          ~keeper_name:meta.name
+          "manual compaction completion lifecycle dispatch failed after durable commit; preserving the committed checkpoint and dispatching typed failure cleanup: %s"
+          (Keeper_context_runtime.lifecycle_dispatch_error_to_string
+             completion_error);
+        (match
+           dispatch_failed
              ~config
-             ~keeper_name:meta.name
-             ~origin:Keeper_registry.Operator_compact
+             ~meta
+             "compaction_completed_rejected_after_checkpoint"
          with
-         | Ok () -> Completion_applied
-         | Error completion_error ->
-           Log.Keeper.error
-             ~keeper_name:meta.name
-             "manual compaction completion lifecycle dispatch failed after durable commit; preserving the committed checkpoint and dispatching typed failure cleanup: %s"
-             (Keeper_context_runtime.lifecycle_dispatch_error_to_string
-                completion_error);
-           (match
-              dispatch_failed
-                ~config
-                ~meta
-                "compaction_completed_rejected_after_checkpoint"
-            with
-            | Ok () ->
-              Completion_rejected_failure_dispatched { completion_error }
-            | Error failure_dispatch_error ->
-              Completion_rejected_failure_dispatch_failed
-                { completion_error; failure_dispatch_error })
-       in
-       Keeper_unified_metrics.broadcast_compaction
-         ~name:meta.name
-         recovery;
-       Ok (Compacted { recovery; installation = installed; lifecycle }))
+         | Ok () ->
+           Completion_rejected_failure_dispatched { completion_error }
+         | Error failure_dispatch_error ->
+           Completion_rejected_failure_dispatch_failed
+             { completion_error; failure_dispatch_error })
+    in
+    Keeper_unified_metrics.broadcast_compaction
+      ~name:meta.name
+      recovery;
+    Ok (Compacted { recovery; installation; lifecycle })
   in
   match Keeper_context_runtime.commit_prepared_compaction prepared with
   | Keeper_post_turn.Committed recovery -> committed recovery

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -55,7 +55,7 @@ type post_turn_lifecycle = {
 
 type compaction_recovery = {
   checkpoint : Agent_sdk.Checkpoint.t;
-  checkpoint_installation : Keeper_checkpoint_store.checkpoint_installation;
+  checkpoint_installation : Keeper_checkpoint_store.installed_checkpoint;
   trigger : Compaction_trigger.t;
   evidence : Keeper_compaction_evidence.t;
   turn_generation : int;
@@ -68,7 +68,6 @@ type no_compaction = Keeper_compaction_outcome.no_compaction =
 
 type compaction_recovery_error =
   | Checkpoint_ref_load_failed of Keeper_checkpoint_store.checkpoint_ref_load_error
-  | Checkpoint_cas_failed of Keeper_checkpoint_store.checkpoint_cas_error
   | Checkpoint_candidate_failed of string
   | Compaction_rejected of Keeper_compact_policy.compaction_rejection
   | No_compaction of no_compaction
@@ -88,18 +87,6 @@ let compaction_recovery_error_to_tag = function
   | Checkpoint_ref_load_failed Keeper_checkpoint_store.Ref_not_found ->
     "checkpoint_not_found"
   | Checkpoint_ref_load_failed _ -> "checkpoint_load_failed"
-  | Checkpoint_cas_failed (Keeper_checkpoint_store.Source_changed _) ->
-    "checkpoint_source_changed"
-  | Checkpoint_cas_failed (Source_unavailable _) ->
-    "checkpoint_source_unavailable"
-  | Checkpoint_cas_failed
-      (Candidate_identity_invalid _
-      | Candidate_session_mismatch _
-      | Candidate_generation_mismatch _
-      | Candidate_turn_regressed _) ->
-    "checkpoint_candidate_invalid"
-  | Checkpoint_cas_failed (Commit_not_installed _) ->
-    "checkpoint_commit_not_installed"
   | Checkpoint_candidate_failed _ -> "checkpoint_candidate_failed"
   | Compaction_rejected reason ->
     Keeper_compact_policy.compaction_rejection_to_tag reason
@@ -174,7 +161,6 @@ let checkpoint_cas_error_detail = function
 
 let compaction_recovery_error_to_string = function
   | Checkpoint_ref_load_failed error -> checkpoint_ref_load_error_detail error
-  | Checkpoint_cas_failed error -> checkpoint_cas_error_detail error
   | Checkpoint_candidate_failed detail -> detail
   | Compaction_rejected reason ->
     "compaction rejected: "
@@ -488,7 +474,6 @@ let apply_post_turn_lifecycle_with_resilience_handles
 
 type rejection_disposition =
   | Terminal_no_compaction of Keeper_compaction_outcome.no_compaction_reason
-  | Owner_generation_deferred
   | Nonterminal_rejection
 
 let rejection_disposition = function
@@ -626,7 +611,6 @@ let prepare_compaction_admitted
        (match rejection_disposition reason with
         | Terminal_no_compaction terminal_reason ->
           Error (No_compaction { source = source_ref; reason = terminal_reason })
-        | Owner_generation_deferred
         | Nonterminal_rejection ->
           Error (Compaction_rejected reason))
      | (Keeper_compact_policy.Applied _
@@ -747,10 +731,10 @@ let commit_prepared_compaction_with
     with
     | Ok
         ( saved_checkpoint
-        , (Keeper_checkpoint_store.Installed _ as installation) ) ->
+        , Keeper_checkpoint_store.Installed installed ) ->
       let recovery =
         { checkpoint = saved_checkpoint
-        ; checkpoint_installation = installation
+        ; checkpoint_installation = installed
         ; trigger = prepared_trigger
         ; evidence
         ; turn_generation

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -79,16 +79,9 @@ type prepared_commit_failure =
   ; committed : compaction_recovery option
   }
 
-type prepared_commit_completion =
-  | Commit_completion_committed of compaction_recovery
-  | Commit_completion_rejected of no_compaction
-  | Commit_completion_failed of prepared_commit_failure
-
 type prepared_commit_outcome =
   | Committed of compaction_recovery
-  | Commit_in_progress of prepared_commit_completion Eio.Promise.t
-  | Already_committed of compaction_recovery
-  | Already_rejected of no_compaction
+  | Not_committed of no_compaction
   | Commit_failed of prepared_commit_failure
 
 let compaction_recovery_error_to_tag = function
@@ -530,79 +523,29 @@ type prepared_compaction =
   ; prepared_trigger : Compaction_trigger.t
   ; context : Keeper_context_core.working_context
   ; evidence : Keeper_compaction_evidence.t
-  ; post_success_terminalizer :
-      Keeper_compaction_llm_summarizer.post_success_terminalizer
-  ; commit_waiter : prepared_commit_completion Eio.Promise.t
-  ; publish_commit_completion : prepared_commit_completion -> unit
-  ; canonical_commit_completion :
-      prepared_commit_completion option Atomic.t
   }
 
-type uncommitted_prepared_outcome =
-  | Uncommitted_terminalized of no_compaction
-  | Uncommitted_commit_in_progress of
-      prepared_commit_completion Eio.Promise.t
-  | Uncommitted_already_committed of compaction_recovery
-  | Uncommitted_failed of compaction_recovery_error
-
-let publish_prepared_commit_completion prepared completion =
-  if
-    Atomic.compare_and_set
-      prepared.canonical_commit_completion
-      None
-      (Some completion)
-  then prepared.publish_commit_completion completion
+let exact_execution_terminal_of_evidence
+      cause
+      (evidence : Keeper_compaction_evidence.t)
+  =
+  Keeper_compaction_outcome.
+    { cause
+    ; slot_id = evidence.slot_id
+    ; call_id = evidence.call_id
+    ; plan_fingerprint = evidence.plan_fingerprint
+    ; request_body_sha256 = evidence.receipt_request_body_sha256
+    }
 ;;
 
-let observed_commit_completion prepared =
-  match Atomic.get prepared.canonical_commit_completion with
-  | Some (Commit_completion_committed recovery) ->
-    Already_committed recovery
-  | Some (Commit_completion_rejected no_compaction) ->
-    Already_rejected no_compaction
-  | Some (Commit_completion_failed failure) ->
-    Commit_failed failure
-  | None -> Commit_in_progress prepared.commit_waiter
-;;
-
-let no_compaction_of_uncommitted_prepared
+let no_compaction_of_prepared
       ?(cause = Keeper_compaction_outcome.Commit_admission_unavailable)
       prepared
   =
-  match
-    Keeper_compaction_llm_summarizer.terminalize_post_success
-      prepared.post_success_terminalizer
-      cause
-  with
-  | Keeper_compaction_llm_summarizer.Terminalized terminal ->
-    let no_compaction =
-      { source = prepared.source_ref
-      ; reason = Keeper_compaction_outcome.Exact_execution_terminal terminal
-      }
-    in
-    publish_prepared_commit_completion
-      prepared
-      (Commit_completion_rejected no_compaction);
-    Uncommitted_terminalized no_compaction
-  | Keeper_compaction_llm_summarizer.Terminalization_commit_in_progress _ ->
-    Uncommitted_commit_in_progress prepared.commit_waiter
-  | Keeper_compaction_llm_summarizer.Terminalization_already_committed ->
-    (match observed_commit_completion prepared with
-     | Already_committed recovery ->
-       Uncommitted_already_committed recovery
-     | Commit_in_progress waiter ->
-       Uncommitted_commit_in_progress waiter
-     | Commit_failed failure -> Uncommitted_failed failure.error
-     | Already_rejected no_compaction ->
-       Uncommitted_terminalized no_compaction
-     | Committed recovery ->
-       Uncommitted_already_committed recovery)
-  | Keeper_compaction_llm_summarizer.Terminalization_invariant_failed detail ->
-    let error = Checkpoint_candidate_failed detail in
-    publish_prepared_commit_completion
-      prepared
-      (Commit_completion_failed { error; committed = None });
-    Uncommitted_failed error
+  let terminal = exact_execution_terminal_of_evidence cause prepared.evidence in
+  { source = prepared.source_ref
+  ; reason = Keeper_compaction_outcome.Exact_execution_terminal terminal
+  }
 ;;
 
 let prepare_compaction_admitted
@@ -660,13 +603,8 @@ let prepare_compaction_admitted
         ~trigger
         ctx
     in
-    (match
-       preparation.decision,
-       preparation.evidence,
-       preparation.post_success_terminalizer
-     with
-     | Keeper_compact_policy.Prepared _, None, _
-     | Keeper_compact_policy.Prepared _, _, None ->
+    (match preparation.decision, preparation.evidence with
+     | Keeper_compact_policy.Prepared _, None ->
        (* Prepared-without-evidence is a planner invariant violation (a bug),
           not a deterministic no-op: it must surface as a visible failure,
           never produce a durable terminal no-compaction outcome. *)
@@ -674,10 +612,7 @@ let prepare_compaction_admitted
          (Checkpoint_candidate_failed
             "compaction preparation completed without structural evidence \
              (planner invariant violation)")
-     | Keeper_compact_policy.Prepared prepared_trigger,
-       Some evidence,
-       Some post_success_terminalizer ->
-       let commit_waiter, commit_resolver = Eio.Promise.create () in
+     | Keeper_compact_policy.Prepared prepared_trigger, Some evidence ->
        Ok
          { session
          ; source_ref
@@ -686,18 +621,8 @@ let prepare_compaction_admitted
          ; prepared_trigger
          ; context = preparation.context
          ; evidence
-         ; post_success_terminalizer
-         ; commit_waiter
-         ; publish_commit_completion =
-             (fun completion ->
-                ignore
-                  (Eio.Promise.try_resolve
-                     commit_resolver
-                     completion
-                   : bool))
-         ; canonical_commit_completion = Atomic.make None
          }
-     | Keeper_compact_policy.Rejected (_, reason), _, _ ->
+     | Keeper_compact_policy.Rejected (_, reason), _ ->
        (match rejection_disposition reason with
         | Terminal_no_compaction terminal_reason ->
           Error (No_compaction { source = source_ref; reason = terminal_reason })
@@ -706,7 +631,7 @@ let prepare_compaction_admitted
           Error (Compaction_rejected reason))
      | (Keeper_compact_policy.Applied _
        | Keeper_compact_policy.Not_requested
-       | Keeper_compact_policy.Skipped_no_checkpoint) as decision, _, _ ->
+       | Keeper_compact_policy.Skipped_no_checkpoint) as decision, _ ->
        (* Reaching recovery with a non-preparation decision is an invariant
           violation: surface it as a visible failure with the decision
           detail, never as a hidden terminal no-compaction. *)
@@ -787,8 +712,6 @@ let prepare_compaction
 
 let commit_prepared_compaction_with
     ?(after_checkpoint_installed = fun () -> ())
-    ?(complete_post_success_commit =
-      Keeper_compaction_llm_summarizer.complete_post_success_commit)
     ~save_oas_checkpoint_if_source
     (prepared : prepared_compaction)
   : prepared_commit_outcome =
@@ -802,216 +725,104 @@ let commit_prepared_compaction_with
       ; prepared_trigger
       ; context
       ; evidence
-      ; post_success_terminalizer
-      ; _
       } =
     prepared
   in
   let commit_failure ?committed error =
     Commit_failed { error; committed }
   in
-  let publish_owner outcome =
-    let completion =
-      match outcome with
-      | Committed recovery -> Commit_completion_committed recovery
-      | Already_rejected no_compaction ->
-        Commit_completion_rejected no_compaction
-      | Commit_failed failure -> Commit_completion_failed failure
-      | Commit_in_progress _
-      | Already_committed _ ->
-        invalid_arg "non-owner prepared commit outcome cannot be published"
-    in
-    publish_prepared_commit_completion prepared completion;
-    outcome
+  let not_committed cause =
+    Not_committed (no_compaction_of_prepared ~cause prepared)
   in
-  let terminalized_outcome = function
-    | Keeper_compaction_llm_summarizer.Terminalized terminal ->
-      Already_rejected
-        { source = source_ref
-        ; reason = Keeper_compaction_outcome.Exact_execution_terminal terminal
-        }
-    | Keeper_compaction_llm_summarizer.Terminalization_commit_in_progress _ ->
-      commit_failure
-        (Checkpoint_candidate_failed
-           "post-success commit terminalization is already in progress")
-    | Keeper_compaction_llm_summarizer.Terminalization_already_committed ->
-      commit_failure
-        (Checkpoint_candidate_failed
-           "commit owner observed an already-committed terminalization")
-    | Keeper_compaction_llm_summarizer.Terminalization_invariant_failed detail ->
-      commit_failure (Checkpoint_candidate_failed detail)
-  in
-  let terminalize_claimed cause =
-    Keeper_compaction_llm_summarizer.terminalize_claimed_commit
-      post_success_terminalizer
-      cause
-    |> terminalized_outcome
-    |> publish_owner
-  in
-  let installed_recovery = ref None in
-  let commit_claimed () =
-    try
-     match
-       save_oas_checkpoint_if_source
-         ~multimodal_policy:retry_meta.multimodal_policy
-         ~keeper_name:retry_meta.name
-         ~session
-         ~agent_name:retry_meta.agent_name
-         ~ctx:context
-         ~generation:turn_generation
-         ~expected_source_ref:source_ref
-     with
-     | Ok
-         ( saved_checkpoint
-         , (Keeper_checkpoint_store.Installed _ as installation) ) ->
-       let recovery =
-         { checkpoint = saved_checkpoint
-         ; checkpoint_installation = installation
-         ; trigger = prepared_trigger
-         ; evidence
-         ; turn_generation
-         }
-       in
-       installed_recovery := Some recovery;
-       Eio.Cancel.protect
-       @@ fun () ->
-       (match
-          Keeper_compaction_llm_summarizer
-          .mark_post_success_checkpoint_installed
-            post_success_terminalizer
-        with
-        | Error detail ->
-          publish_owner
-            (commit_failure
-               ~committed:recovery
-               (Checkpoint_candidate_failed detail))
-        | Ok () ->
-          after_checkpoint_installed ();
-          (match
-           complete_post_success_commit post_success_terminalizer
-           with
-           | Error detail ->
-             let terminal_detail =
-               match
-                 Keeper_compaction_llm_summarizer
-                 .finish_post_success_commit_failure
-                   post_success_terminalizer
-                   detail
-               with
-               | Ok () -> detail
-               | Error terminal_detail -> terminal_detail
-             in
-             publish_owner
-               (commit_failure
-                  ~committed:recovery
-                  (Checkpoint_candidate_failed terminal_detail))
-           | Ok () ->
-             (try
-                Otel_metric_store.inc_counter
-                  Keeper_metrics.(to_string Compactions)
-                  ~labels:[ "keeper", retry_meta.name ]
-                  ()
-              with
-              | exn ->
-                log_keeper_exn
-                  ~label:"compaction committed metric emission"
-                  exn);
-             publish_owner (Committed recovery)))
-     | Ok
-         ( _
-         , Keeper_checkpoint_store.Not_installed
-             { cause = Keeper_checkpoint_store.Source_changed actual; _ } ) ->
-       Log.Keeper.warn
-         "compaction checkpoint source changed: %s"
-         (checkpoint_ref_detail actual);
-       terminalize_claimed Keeper_compaction_outcome.Checkpoint_source_changed
-     | Ok
-         (_, Keeper_checkpoint_store.Not_installed { cause = cas_error; _ })
-     | Error (Persistence_error cas_error) ->
-       let detail = checkpoint_cas_error_detail cas_error in
-       Log.Keeper.error "compaction checkpoint save failed: %s" detail;
-       Otel_metric_store.inc_counter
-         Keeper_metrics.(to_string CheckpointFailures)
-         ~labels:
-           [ "keeper", retry_meta.agent_name
-           ; ( "operation"
-             , Keeper_checkpoint_failure_operation.(to_label Compaction_save) )
-         ]
-         ();
-       terminalize_claimed Keeper_compaction_outcome.Checkpoint_persistence_failed
-     | Error (Tool_history_invalid _) ->
-       terminalize_claimed
-         Keeper_compaction_outcome.Invalid_structural_source_after_dispatch
+  try
+    match
+      save_oas_checkpoint_if_source
+        ~multimodal_policy:retry_meta.multimodal_policy
+        ~keeper_name:retry_meta.name
+        ~session
+        ~agent_name:retry_meta.agent_name
+        ~ctx:context
+        ~generation:turn_generation
+        ~expected_source_ref:source_ref
     with
-    | Eio.Cancel.Cancelled _ as exn ->
-      let raw_bt = Printexc.get_raw_backtrace () in
-      (match !installed_recovery with
-       | None ->
-         Eio.Cancel.protect (fun () ->
-          ignore
-            (terminalize_claimed
-               Keeper_compaction_outcome.Exact_execution_cancelled));
-         Printexc.raise_with_backtrace exn raw_bt
-       | Some recovery ->
-         Eio.Cancel.protect (fun () ->
-          let detail =
-            "post-install compaction finalization was cancelled: "
-            ^ Printexc.to_string exn
-          in
-          let terminal_detail =
-            match
-              Keeper_compaction_llm_summarizer
-              .finish_post_success_commit_failure
-                post_success_terminalizer
-                detail
-            with
-            | Ok () -> detail
-            | Error terminal_detail -> terminal_detail
-          in
-          publish_owner
-            (commit_failure
-               ~committed:recovery
-               (Checkpoint_candidate_failed terminal_detail))))
-    | exn ->
-      let detail = Printexc.to_string exn in
-      log_keeper_exn ~label:"compaction checkpoint save exception" exn;
-      (match !installed_recovery with
-       | Some recovery ->
-         let terminal_detail =
-           match
-             Keeper_compaction_llm_summarizer
-             .finish_post_success_commit_failure
-               post_success_terminalizer
-               ("post-install compaction finalization raised: " ^ detail)
-           with
-           | Ok () -> detail
-           | Error terminal_detail -> terminal_detail
-         in
-         publish_owner
-           (commit_failure
-              ~committed:recovery
-              (Checkpoint_candidate_failed
-                 terminal_detail))
-       | None ->
-         Log.Keeper.error
-           "compaction checkpoint save exception became terminal: %s"
-           detail;
-         terminalize_claimed
-           Keeper_compaction_outcome.Checkpoint_persistence_failed)
-  in
-  match
-    Keeper_compaction_llm_summarizer.with_post_success_commit
-      prepared.post_success_terminalizer
-      commit_claimed
+    | Ok
+        ( saved_checkpoint
+        , (Keeper_checkpoint_store.Installed _ as installation) ) ->
+      let recovery =
+        { checkpoint = saved_checkpoint
+        ; checkpoint_installation = installation
+        ; trigger = prepared_trigger
+        ; evidence
+        ; turn_generation
+        }
+      in
+      (try
+         Eio.Cancel.protect
+         @@ fun () ->
+         after_checkpoint_installed ();
+         (try
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string Compactions)
+              ~labels:[ "keeper", retry_meta.name ]
+              ()
+          with
+          | exn ->
+            log_keeper_exn
+              ~label:"compaction committed metric emission"
+              exn);
+         Committed recovery
+       with
+       | Eio.Cancel.Cancelled _ as exn ->
+         commit_failure
+           ~committed:recovery
+           (Checkpoint_candidate_failed
+              ("post-install compaction callback was cancelled: "
+               ^ Printexc.to_string exn))
+       | exn ->
+         let detail = Printexc.to_string exn in
+         log_keeper_exn
+           ~label:"post-install compaction callback"
+           exn;
+         commit_failure
+           ~committed:recovery
+           (Checkpoint_candidate_failed
+              ("post-install compaction callback raised: " ^ detail)))
+    | Ok
+        ( _
+        , Keeper_checkpoint_store.Not_installed
+            { cause = Keeper_checkpoint_store.Source_changed actual; _ } ) ->
+      Log.Keeper.warn
+        "compaction checkpoint source changed: %s"
+        (checkpoint_ref_detail actual);
+      not_committed Keeper_compaction_outcome.Checkpoint_source_changed
+    | Ok
+        (_, Keeper_checkpoint_store.Not_installed { cause = cas_error; _ })
+    | Error (Persistence_error cas_error) ->
+      let detail = checkpoint_cas_error_detail cas_error in
+      Log.Keeper.error "compaction checkpoint save failed: %s" detail;
+      Otel_metric_store.inc_counter
+        Keeper_metrics.(to_string CheckpointFailures)
+        ~labels:
+          [ "keeper", retry_meta.agent_name
+          ; ( "operation"
+            , Keeper_checkpoint_failure_operation.(to_label Compaction_save) )
+          ]
+        ();
+      not_committed Keeper_compaction_outcome.Checkpoint_persistence_failed
+    | Error (Tool_history_invalid _) ->
+      not_committed
+        Keeper_compaction_outcome.Invalid_structural_source_after_dispatch
   with
-  | Keeper_compaction_llm_summarizer.Post_success_commit_result result ->
-    result
-  | Keeper_compaction_llm_summarizer.Post_success_commit_in_progress _ ->
-    Commit_in_progress prepared.commit_waiter
-  | Keeper_compaction_llm_summarizer.Post_success_commit_already_committed ->
-    observed_commit_completion prepared
-  | Keeper_compaction_llm_summarizer.Post_success_commit_rejected _ ->
-    observed_commit_completion prepared
+  | Eio.Cancel.Cancelled _ as exn ->
+    let raw_bt = Printexc.get_raw_backtrace () in
+    Printexc.raise_with_backtrace exn raw_bt
+  | exn ->
+    let detail = Printexc.to_string exn in
+    log_keeper_exn ~label:"compaction checkpoint save exception" exn;
+    Log.Keeper.error
+      "compaction checkpoint save exception became terminal: %s"
+      detail;
+    not_committed Keeper_compaction_outcome.Checkpoint_persistence_failed
 ;;
 
 let commit_prepared_compaction prepared =
@@ -1023,27 +834,15 @@ let commit_prepared_compaction prepared =
 module For_testing = struct
   let commit_prepared_compaction_with_history
         ?after_checkpoint_installed
-        ?complete_post_success_commit
         ~save_oas_history
         prepared
     =
     commit_prepared_compaction_with
       ?after_checkpoint_installed
-      ?complete_post_success_commit
       ~save_oas_checkpoint_if_source:
         (Keeper_context_core.For_testing.save_oas_checkpoint_if_source_with_history
            ~save_oas_history)
       prepared
-  ;;
-
-  let post_success_snapshot prepared =
-    Keeper_compaction_llm_summarizer.For_testing.post_success_snapshot
-      prepared.post_success_terminalizer
-  ;;
-
-  let claim_post_success_commit prepared =
-    Keeper_compaction_llm_summarizer.claim_post_success_commit
-      prepared.post_success_terminalizer
   ;;
 end
 

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -62,16 +62,9 @@ type prepared_commit_failure =
   ; committed : compaction_recovery option
   }
 
-type prepared_commit_completion =
-  | Commit_completion_committed of compaction_recovery
-  | Commit_completion_rejected of no_compaction
-  | Commit_completion_failed of prepared_commit_failure
-
 type prepared_commit_outcome =
   | Committed of compaction_recovery
-  | Commit_in_progress of prepared_commit_completion Eio.Promise.t
-  | Already_committed of compaction_recovery
-  | Already_rejected of no_compaction
+  | Not_committed of no_compaction
   | Commit_failed of prepared_commit_failure
 
 val compaction_recovery_error_to_tag : compaction_recovery_error -> string
@@ -118,15 +111,8 @@ type prepared_compaction
     source CAS, not the turn slot, is the interleaving guard. The token is
     opaque and owns the exact Keeper identity and commit policy captured at
     preparation; callers cannot construct it or combine a plan with another
-    Keeper's metadata. It also owns the real post-dispatch observation and
-    durable terminalizer used by every uncommitted terminal path. *)
-
-type uncommitted_prepared_outcome =
-  | Uncommitted_terminalized of no_compaction
-  | Uncommitted_commit_in_progress of
-      prepared_commit_completion Eio.Promise.t
-  | Uncommitted_already_committed of compaction_recovery
-  | Uncommitted_failed of compaction_recovery_error
+    Keeper's metadata. The exact execution identity is retained as immutable
+    structural evidence, with no second claim or lifecycle state. *)
 
 (** Phase 1: load the durable source and run the policy + LLM planner.
     Admission-free by contract; the caller must not hold the keeper's turn
@@ -149,35 +135,22 @@ val commit_prepared_compaction :
 module For_testing : sig
   val commit_prepared_compaction_with_history :
     ?after_checkpoint_installed:(unit -> unit) ->
-    ?complete_post_success_commit:
-      (Keeper_compaction_llm_summarizer.post_success_terminalizer ->
-       (unit, string) result) ->
     save_oas_history:
       (session_dir:string -> Agent_sdk.Checkpoint.t -> unit) ->
     prepared_compaction ->
     prepared_commit_outcome
-
-  val post_success_snapshot :
-    prepared_compaction ->
-    Keeper_compaction_llm_summarizer.post_success_snapshot
-
-  val claim_post_success_commit :
-    prepared_compaction ->
-    Keeper_compaction_llm_summarizer.post_success_commit_claim
 end
 
-(** Affine disposition for a prepared exact-output result that cannot enter
-    its commit admission. A reject owner durably quarantines; a commit loser
-    receives the canonical completion waiter/evidence and must not redispatch
-    the provider. *)
-val no_compaction_of_uncommitted_prepared :
+(** Pure typed outcome for a prepared exact-output result that cannot enter
+    its commit admission. The retained execution identity is projected without
+    another claim, lock, persistence write, or provider dispatch. *)
+val no_compaction_of_prepared :
   ?cause:Keeper_compaction_outcome.exact_execution_terminal_cause ->
-  prepared_compaction -> uncommitted_prepared_outcome
+  prepared_compaction -> no_compaction
 
 (** Reload the canonical OAS checkpoint and apply an explicit typed
     compaction request. Composition of {!prepare_compaction} and
-    {!commit_prepared_compaction}; all affine ownership outcomes remain
-    explicit. *)
+    {!commit_prepared_compaction}; the source CAS is the commit authority. *)
 val recover_latest_checkpoint_for_compaction :
   ?before_dispatch_authority:
     Keeper_compaction_llm_summarizer.before_dispatch_authority ->

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -30,7 +30,7 @@ type post_turn_lifecycle =
     Manual and provider-overflow callers consume the same result. *)
 type compaction_recovery =
   { checkpoint : Agent_sdk.Checkpoint.t
-  ; checkpoint_installation : Keeper_checkpoint_store.checkpoint_installation
+  ; checkpoint_installation : Keeper_checkpoint_store.installed_checkpoint
   ; trigger : Compaction_trigger.t
   ; evidence : Keeper_compaction_evidence.t
   ; turn_generation : int
@@ -43,7 +43,6 @@ type no_compaction = Keeper_compaction_outcome.no_compaction =
 
 type compaction_recovery_error =
   | Checkpoint_ref_load_failed of Keeper_checkpoint_store.checkpoint_ref_load_error
-  | Checkpoint_cas_failed of Keeper_checkpoint_store.checkpoint_cas_error
   | Checkpoint_candidate_failed of string
   | Compaction_rejected of Keeper_compact_policy.compaction_rejection
   | No_compaction of no_compaction

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -383,26 +383,15 @@ let recover_provider_context_overflow_in_lane
       | Some recovery, _ ->
         Log.Keeper.error
           ~keeper_name:meta.name
-          "provider overflow checkpoint committed with failed exact-domain finalization: %s"
+          "provider overflow checkpoint committed but post-install callback failed: %s"
           (Keeper_post_turn.compaction_recovery_error_to_string error);
         applied recovery
     in
-    let rec commit_outcome = function
-      | Keeper_post_turn.Committed recovery
-      | Keeper_post_turn.Already_committed recovery ->
-        applied recovery
-      | Keeper_post_turn.Already_rejected no_compaction ->
+    let commit_outcome = function
+      | Keeper_post_turn.Committed recovery -> applied recovery
+      | Keeper_post_turn.Not_committed no_compaction ->
         terminal_no_compaction no_compaction
       | Keeper_post_turn.Commit_failed failure -> failed failure
-      | Keeper_post_turn.Commit_in_progress waiter ->
-        commit_completion (Eio.Promise.await waiter)
-    and commit_completion = function
-      | Keeper_post_turn.Commit_completion_committed recovery ->
-        applied recovery
-      | Keeper_post_turn.Commit_completion_rejected no_compaction ->
-        terminal_no_compaction no_compaction
-      | Keeper_post_turn.Commit_completion_failed failure ->
-        failed failure
     in
     (match dispatch "context_overflow_detected" overflow_event with
      | Error reason ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -374,7 +374,6 @@ let recover_provider_context_overflow_in_lane
         refused_without_attempt ~consecutive_failures
       | ( None
         , ( Keeper_post_turn.Checkpoint_ref_load_failed _
-          | Keeper_post_turn.Checkpoint_cas_failed _
           | Keeper_post_turn.Checkpoint_candidate_failed _
           | Keeper_post_turn.Compaction_rejected _
           | Keeper_post_turn.No_compaction _ ) ) ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -452,7 +452,7 @@ let recover_provider_context_overflow_in_lane
              (try
                 commit_outcome
                   (
-                  recover_latest_checkpoint_for_compaction
+                  Keeper_post_turn.recover_latest_checkpoint_for_compaction
                     ~before_dispatch_authority:before_compaction_dispatch
                     ~base_path:config.base_path
                     ~base_dir

--- a/test/test_compaction_exact_output_conformance.ml
+++ b/test/test_compaction_exact_output_conformance.ml
@@ -157,16 +157,6 @@ let completed_exn = function
   | Error _ -> Alcotest.fail "compaction flow execution failed"
 ;;
 
-let terminalized_exn = function
-  | C.Terminalized terminal -> terminal
-  | C.Terminalization_commit_in_progress _ ->
-    Alcotest.fail "terminalization unexpectedly lost to a commit claimant"
-  | C.Terminalization_already_committed ->
-    Alcotest.fail "terminalization unexpectedly observed a committed checkpoint"
-  | C.Terminalization_invariant_failed detail ->
-    Alcotest.failf "terminalization invariant failed: %s" detail
-;;
-
 let captured_observation_exn label = function
   | Some observation -> observation
   | None -> Alcotest.failf "%s did not observe an OAS attempt identity" label
@@ -881,79 +871,6 @@ let test_admission_rejection_then_cancellation_propagates () =
 ;;
 
 
-let test_post_success_commit_claim_blocks_reject () =
-  run_eio
-  @@ fun ~sw ~net ~clock ->
-  let keeper_name = "keeper-post-success-commit-wins" in
-  let slot_id = "post-success-commit-wins" in
-  let server = F.start_server ~sw ~net ~clock (F.Reply valid_response) in
-  let snapshot =
-    F.resolver_snapshot
-      ~source:"masc post-success commit wins"
-      [ { id = slot_id; base_url = server.base_url } ]
-  in
-  let registry = publish_exn ~slot_ids:[ slot_id ] snapshot in
-  let prepared = prepare_exn ~keeper_name ~registry () in
-  let completed =
-    execute_prepared_lane
-      ~keeper_name
-      ~net
-      ~clock
-      prepared
-    |> completed_exn
-  in
-  let terminalizer = C.completed_post_success_terminalizer completed in
-  (match C.claim_post_success_commit terminalizer with
-   | C.Commit_claim_acquired -> ()
-   | C.Commit_claim_in_progress _
-   | C.Commit_claim_already_committed
-   | C.Commit_claim_rejected _ ->
-     Alcotest.fail "open post-success disposition did not grant commit claim");
-  (match C.mark_post_success_checkpoint_installed terminalizer with
-   | Ok () -> ()
-   | Error detail -> Alcotest.failf "installed commit mark failed: %s" detail);
-  let completion =
-    match
-      C.terminalize_post_success
-        terminalizer
-        Keeper_compaction_outcome.Commit_admission_unavailable
-    with
-    | C.Terminalization_commit_in_progress waiter -> waiter
-    | C.Terminalized _
-    | C.Terminalization_already_committed
-    | C.Terminalization_invariant_failed _ ->
-      Alcotest.fail "reject crossed an installed commit claim"
-  in
-  let pending = C.For_testing.post_success_snapshot terminalizer in
-  Alcotest.(check bool)
-    "installed checkpoint remains pending valid"
-    true
-    (pending.phase = C.Phase_installed_pending_valid);
-  Alcotest.(check int) "reject has not run" 0 pending.domain_rejected_attempts;
-  (match C.complete_post_success_commit terminalizer with
-   | Ok () -> ()
-   | Error detail ->
-     Alcotest.failf "post-success completion failed: %s" detail);
-  Eio.Promise.await completion;
-  (match
-     C.terminalize_post_success
-       terminalizer
-       Keeper_compaction_outcome.Checkpoint_persistence_failed
-   with
-   | C.Terminalization_already_committed -> ()
-   | C.Terminalized _
-   | C.Terminalization_commit_in_progress _
-   | C.Terminalization_invariant_failed _ ->
-     Alcotest.fail "committed checkpoint was downgraded by a later reject");
-  let committed = C.For_testing.post_success_snapshot terminalizer in
-  Alcotest.(check bool)
-    "post-success disposition is committed"
-    true
-    (committed.phase = C.Phase_committed);
-  Alcotest.(check int) "Domain_valid runs once" 1 committed.domain_valid_attempts;
-  Alcotest.(check int) "Domain_rejected never runs" 0 committed.domain_rejected_attempts
-;;
-
 let () =
   Alcotest.run
     "compaction exact-flow conformance"
@@ -1014,10 +931,6 @@ let () =
             "admission rejection then cancellation propagates"
             `Quick
             test_admission_rejection_then_cancellation_propagates
-        ; Alcotest.test_case
-            "commit claim blocks reject after install"
-            `Quick
-            test_post_success_commit_claim_blocks_reject
         ] )
       (* The "affinity and non-sharing" group held only cases whose functions
          #25993 removed; its registrations were left behind and the group is now

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -704,23 +704,19 @@ let test_prepare_commit_source_cas () =
                (Post_turn.compaction_recovery_error_to_string
                   (Post_turn.No_compaction no_compaction)))
     in
-    (match recovery.checkpoint_installation with
-     | Masc.Keeper_checkpoint_store.Installed installed ->
-       check bool
-         "history cancellation remains typed after install"
-         true
-         (List.exists
-            (function
-              | Masc.Keeper_checkpoint_store.History_write_failed
-                  (Eio.Cancel.Cancelled _, backtrace) ->
-                Printexc.raw_backtrace_length backtrace > 0
-                && string_contains
-                     ~needle:"raise_history_cancellation"
-                     (Printexc.raw_backtrace_to_string backtrace)
-              | _ -> false)
-            installed.auxiliary)
-     | Masc.Keeper_checkpoint_store.Not_installed _ ->
-       fail "history cancellation downgraded the installed checkpoint");
+    check bool
+      "history cancellation remains typed after install"
+      true
+      (List.exists
+         (function
+           | Masc.Keeper_checkpoint_store.History_write_failed
+               (Eio.Cancel.Cancelled _, backtrace) ->
+             Printexc.raw_backtrace_length backtrace > 0
+             && string_contains
+                  ~needle:"raise_history_cancellation"
+                  (Printexc.raw_backtrace_to_string backtrace)
+           | _ -> false)
+         recovery.checkpoint_installation.auxiliary);
     (* Both tokens were prepared from the same source. The first commit
        advances it; the second token now proves that source CAS alone rejects
        the stale candidate. *)

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -974,7 +974,7 @@ let test_post_dispatch_non_reducing_output_is_terminal () =
 (* RFC-0351 S0 / #25461: once the persisted failure streak suspends
    compaction retries, a reactive prepare must be refused before any
    checkpoint I/O — each new stimulus used to pay one full prepare
-   (checkpoint load + summarizer LLM call) before its escalation settled.
+   (checkpoint load + summarizer LLM call) before its escalation completed.
    The fixture base_dir holds no checkpoint, so any prepare that passes the
    gate deterministically fails with [Checkpoint_ref_load_failed Ref_not_found];
    returning [Retry_suspended] instead proves the refusal fired first. *)

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -286,17 +286,7 @@ let test_atomic_cycle_and_normalization_cross_evidence_gate () =
         check int (name ^ " dispatches exactly once") 1
           (Exact_fixture.post_count server);
         match preparation.decision, preparation.evidence with
-        | Compact_policy.Prepared Compaction_trigger.Manual, Some _ ->
-          (match preparation.post_success_terminalizer with
-           | None -> failf "%s lost its post-success terminalizer" name
-           | Some terminalizer ->
-             (match
-                Summarizer.terminalize_post_success
-                  terminalizer
-                  Keeper_compaction_outcome.Domain_invalid_output
-              with
-              | Summarizer.Terminalized _ -> ()
-              | _ -> failf "%s could not close its exact attempt" name))
+        | Compact_policy.Prepared Compaction_trigger.Manual, Some _ -> ()
         | _ -> failf "%s did not cross the structural evidence gate" name
       in
       run_case
@@ -708,14 +698,11 @@ let test_prepare_commit_source_cas () =
              failf
                "commit of a fresh prepared plan failed: %s"
                (Post_turn.compaction_recovery_error_to_string error)
-           | Post_turn.Already_rejected no_compaction ->
+           | Post_turn.Not_committed no_compaction ->
              failf
                "fresh prepared plan was rejected: %s"
                (Post_turn.compaction_recovery_error_to_string
-                  (Post_turn.No_compaction no_compaction))
-           | Post_turn.Commit_in_progress _
-           | Post_turn.Already_committed _ ->
-             fail "fresh prepared plan did not own its commit")
+                  (Post_turn.No_compaction no_compaction)))
     in
     (match recovery.checkpoint_installation with
      | Masc.Keeper_checkpoint_store.Installed installed ->
@@ -734,29 +721,13 @@ let test_prepare_commit_source_cas () =
             installed.auxiliary)
      | Masc.Keeper_checkpoint_store.Not_installed _ ->
        fail "history cancellation downgraded the installed checkpoint");
-    let committed_snapshot =
-      Post_turn.For_testing.post_success_snapshot prepared
-    in
-    check bool
-      "installed history cancellation leaves the affine phase committed"
-      true
-      (committed_snapshot.phase
-       = Masc.Keeper_compaction_llm_summarizer.Phase_committed);
-    check int
-      "history cancellation retains one Domain_valid completion"
-      1
-      committed_snapshot.domain_valid_attempts;
-    check int
-      "history cancellation performs no Domain_rejected completion"
-      0
-      committed_snapshot.domain_rejected_attempts;
     (* Both tokens were prepared from the same source. The first commit
-       advances it; the second token now proves the source-CAS rejection
-       without violating the same-token affine commit contract. *)
+       advances it; the second token now proves that source CAS alone rejects
+       the stale candidate. *)
     (match
        Post_turn.commit_prepared_compaction stale_prepared
      with
-     | Post_turn.Already_rejected
+     | Post_turn.Not_committed
          { reason =
              Keeper_compaction_outcome.Exact_execution_terminal
                { cause = Keeper_compaction_outcome.Checkpoint_source_changed
@@ -767,7 +738,7 @@ let test_prepare_commit_source_cas () =
          } ->
        check bool "stale prepared terminal retains slot" true (String.trim slot_id <> "");
        check bool "stale prepared terminal retains call" true (String.trim call_id <> "")
-     | Post_turn.Already_rejected no_compaction ->
+     | Post_turn.Not_committed no_compaction ->
        failf
          "stale prepared value returned an unexpected rejection: %s"
          (Post_turn.compaction_recovery_error_to_string
@@ -776,19 +747,11 @@ let test_prepare_commit_source_cas () =
        failf
          "stale prepared value failed with the wrong error: %s"
          (Post_turn.compaction_recovery_error_to_string error)
-     | Post_turn.Committed _
-     | Post_turn.Already_committed _ ->
-       fail "stale prepared value committed past the source CAS"
-     | Post_turn.Commit_in_progress _ ->
-       fail "stale prepared value did not reach canonical rejection"))
+     | Post_turn.Committed _ ->
+       fail "stale prepared value committed past the source CAS"))
 ;;
 
-let run_post_install_failure
-      ~name
-      ?complete_post_success_commit
-      ?(cancel_after_install = false)
-      ()
-  =
+let test_post_install_cancellation_returns_committed_failure () =
   Eio_main.run @@ fun env ->
   Masc_test_deps.init_eio_clock env;
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -801,6 +764,7 @@ let run_post_install_failure
       Runtime.For_testing.restore runtime_snapshot;
       Masc_test_deps.cleanup_test_workspace base_path)
     (fun () ->
+       let name = "post-install-cancellation" in
        let meta = make_meta ~name () in
        let config = Masc.Workspace.default_config base_path in
        ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
@@ -855,34 +819,12 @@ let run_post_install_failure
              "prepare failed: %s"
              (Post_turn.compaction_recovery_error_to_string error)
        in
-       let internal_waiter = ref None in
-       let outer_waiter = ref None in
        let outcome =
          Post_turn.For_testing.commit_prepared_compaction_with_history
            ~after_checkpoint_installed:(fun () ->
-             (match
-                Post_turn.For_testing.claim_post_success_commit prepared
-              with
-              | Summarizer.Commit_claim_in_progress waiter ->
-                internal_waiter := Some waiter;
-                (match Post_turn.commit_prepared_compaction prepared with
-                 | Post_turn.Commit_in_progress waiter ->
-                   outer_waiter := Some waiter
-                 | Post_turn.Committed _
-                 | Post_turn.Commit_failed _
-                 | Post_turn.Already_committed _
-                 | Post_turn.Already_rejected _ ->
-                   fail "installed commit did not expose its outer waiter")
-              | Summarizer.Commit_claim_acquired
-              | Summarizer.Commit_claim_already_committed
-              | Summarizer.Commit_claim_rejected _ ->
-                fail "installed commit did not expose its affine waiter");
-             if cancel_after_install
-             then
-               raise
-                 (Eio.Cancel.Cancelled
-                    (Failure "injected post-install compaction cancellation")))
-           ?complete_post_success_commit
+             raise
+               (Eio.Cancel.Cancelled
+                  (Failure "injected post-install compaction cancellation")))
            ~save_oas_history:(fun ~session_dir:_ _ -> ())
            prepared
        in
@@ -891,80 +833,12 @@ let run_post_install_failure
         | Post_turn.Commit_failed { committed = None; _ } ->
           fail "post-install failure lost the durable recovery"
         | Post_turn.Committed _
-        | Post_turn.Commit_in_progress _
-        | Post_turn.Already_committed _
-        | Post_turn.Already_rejected _ ->
+        | Post_turn.Not_committed _ ->
           fail "post-install failure did not publish typed commit failure");
-       (match !internal_waiter with
-        | Some waiter -> Eio.Promise.await waiter
-        | None -> fail "post-install failure did not capture the commit waiter");
-       (match !outer_waiter with
-        | Some waiter ->
-          (match Eio.Promise.await waiter with
-           | Post_turn.Commit_completion_failed
-               { committed = Some _; _ } ->
-             ()
-           | Post_turn.Commit_completion_failed { committed = None; _ }
-           | Post_turn.Commit_completion_committed _
-           | Post_turn.Commit_completion_rejected _ ->
-             fail "outer waiter did not retain the durable failed commit")
-        | None -> fail "post-install failure did not capture the outer waiter");
-       let snapshot = Post_turn.For_testing.post_success_snapshot prepared in
-       check bool
-         "post-install failure closes the affine commit phase"
-         true
-         (snapshot.phase = Summarizer.Phase_committed);
        check int
-         "post-install failure attempts Domain_valid exactly once"
+         "post-install cancellation performs no provider redispatch"
          1
-         snapshot.domain_valid_attempts;
-       check int
-         "post-install failure never rejects the installed checkpoint"
-         0
-         snapshot.domain_rejected_attempts;
-       check int
-         "post-install finalization performs no provider redispatch"
-         1
-         (Exact_fixture.post_count exact_server);
-       (match
-          Post_turn.For_testing.claim_post_success_commit prepared
-        with
-        | Summarizer.Commit_claim_already_committed -> ()
-        | Summarizer.Commit_claim_acquired
-        | Summarizer.Commit_claim_in_progress _
-        | Summarizer.Commit_claim_rejected _ ->
-          fail "closed Domain_valid failure admitted another claimant");
-       (match Post_turn.commit_prepared_compaction prepared with
-        | Post_turn.Commit_failed { committed = Some _; _ } -> ()
-        | Post_turn.Commit_failed { committed = None; _ }
-        | Post_turn.Committed _
-        | Post_turn.Commit_in_progress _
-        | Post_turn.Already_committed _
-        | Post_turn.Already_rejected _ ->
-          fail "closed Domain_valid failure lost its canonical outer result"))
-;;
-
-let test_post_install_domain_valid_error_resolves_waiters () =
-  run_post_install_failure
-    ~name:"post-install-domain-valid-error"
-    ~complete_post_success_commit:
-      (fun _ -> Error "injected post-success completion error")
-    ()
-;;
-
-let test_post_install_domain_valid_exception_resolves_waiters () =
-  run_post_install_failure
-    ~name:"post-install-domain-valid-exception"
-    ~complete_post_success_commit:
-      (fun _ -> raise (Failure "injected post-success completion exception"))
-    ()
-;;
-
-let test_post_install_cancellation_returns_committed_failure () =
-  run_post_install_failure
-    ~name:"post-install-cancellation"
-    ~cancel_after_install:true
-    ()
+         (Exact_fixture.post_count exact_server))
 ;;
 
 let test_invalid_structural_evidence_after_dispatch_is_terminal () =
@@ -1393,10 +1267,6 @@ let () =
         `Quick test_malformed_structure_preserves_checkpoint;
       test_case "prepare/commit source CAS"
         `Quick test_prepare_commit_source_cas;
-      test_case "post-install Domain_valid error resolves waiters"
-        `Quick test_post_install_domain_valid_error_resolves_waiters;
-      test_case "post-install Domain_valid exception resolves waiters"
-        `Quick test_post_install_domain_valid_exception_resolves_waiters;
       test_case "post-install cancellation returns committed failure"
         `Quick test_post_install_cancellation_returns_committed_failure;
       test_case "ephemeral plan accounting mismatch is post-dispatch terminal"


### PR DESCRIPTION
## 왜

#26432가 보이는 옛 lifecycle 오류를 제거했지만, compaction 성공 뒤에는 post_success_terminalizer / Commit_claimed / waiter 상태기계가 남아 있었어요. 이 상태가 막는 mismatch는 같은 process-local prepared_compaction을 두 소비자가 동시에 commit/reject하는 경우뿐입니다. 실제 production caller는 prepared 값을 공유하지 않고 checkpoint source CAS가 stale/interleaved source의 권위입니다.

## 변경

- post-success phase, mutex, claim, waiter, completion counter 전체 삭제
- exact receipt identity는 immutable evidence에서 typed terminal로 순수 projection
- commit은 checkpoint source CAS를 직접 한 번 수행하고 Committed / Not_committed / 실제 post-install failure만 반환
- committed recovery의 설치 타입을 Installed 값으로 좁혀 impossible Not_installed / Checkpoint_cas_failed 분기 삭제
- manual/unified caller의 중복 wait/observed-commit 분기 삭제
- Keeper_context_runtime의 compaction re-export를 제거하고 실제 소유 모듈 Keeper_post_turn을 직접 호출
- 같은 prepared 값을 재사용해 경합을 만들던 테스트와 제거된 상태기계 전용 waiter 테스트 삭제
- 서로 다른 두 prepared 결과 중 stale source를 CAS가 막는 실제 테스트와 post-install cancellation 증명은 유지

legacy decoder, migration, 별도 durable commit authority, 추가 Gate는 만들지 않았어요.

## 검증

- 변경 OCaml 파일 ocamlformat 및 parser 통과
- compaction exact-flow boundary 통과
- 제거 대상 상태/claim 표면 및 결합 표현 작업 트리 검색 0건
- ignore-without-comment diff check 및 git diff --check 통과
- 로컬 Dune은 실행하지 않았고 전체 build/test authority는 exact-head PR CI입니다.

## 반경

#26432 병합 직후 최신 main에서 분리했어요. OAS exact execution과 before-dispatch source/lifecycle authority는 유지하고, MASC의 중복 post-success state와 facade indirection만 제거합니다.