### PR TITLE
fix(keeper): project reaction evidence immediately at ack sites

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -828,6 +828,14 @@ let run_keepalive_unified_turn
              with
              | Ok () ->
                selection_acked := true;
+               (* Project the ack transition into the reaction ledger now, so
+                  drained wakes carry consumption evidence before the next
+                  dashboard read instead of waiting for the maintenance sweep
+                  (#26430). Convergent; failure defers to the sweep. *)
+               Keeper_heartbeat_stimulus_intake
+               .project_reaction_evidence_best_effort
+                 ~base_path:ctx.config.base_path
+                 ~keeper_name:meta_after_triage.name;
                mark_connector_attention_ignored_after_turn
                  ~base_path:ctx.config.base_path
                  ~keeper_name:meta_after_triage.name

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -370,6 +370,29 @@ let stimulus_ready_for_intake ~base_path (stimulus : Keeper_event_queue.stimulus
    instead of completing re-reads the same entry on the next cycle and the
    Keeper makes no progress for as long as that entry stays spent. Retire them
    here, before a turn is spent on them. *)
+(* After a successful ack the durable transition sits in the event-queue
+   outbox until the maintenance sweep projects it into the reaction ledger.
+   That lag left drained wakes with dispatch-only evidence, which is exactly
+   the shape the drain-status miss detector must treat as a loss (#26430).
+   Project the outbox now, through the canonical claim-guarded projector, so
+   consumption evidence is durable before the next dashboard read. Failure is
+   logged and left to the sweep — the projection is convergent, not exact-once. *)
+let project_reaction_evidence_best_effort ~base_path ~keeper_name =
+  match
+    Keeper_event_queue_recovery.project_owner_result ~base_path ~keeper_name
+  with
+  | Ok
+      ( Keeper_event_queue_recovery.No_pending_transition
+      | Keeper_event_queue_recovery.Transition_converged
+      | Keeper_event_queue_recovery.Claim_busy ) ->
+    ()
+  | Error error ->
+    Log.Keeper.warn
+      "event queue reaction projection deferred to sweep keeper=%s: %s"
+      keeper_name
+      (Keeper_event_queue_recovery.projection_error_to_string error)
+;;
+
 type spent_selection_reconciliation =
   | Selection_actionable
   | Spent_schedule_acknowledged
@@ -411,7 +434,11 @@ let reconcile_spent_selection ~config ~keeper_name selection =
            with
            | Error message ->
              Error ("schedule terminal reconciliation ack failed: " ^ message)
-           | Ok () -> Ok Spent_schedule_acknowledged)
+           | Ok () ->
+             project_reaction_evidence_best_effort
+               ~base_path:config.Workspace_utils.base_path
+               ~keeper_name;
+             Ok Spent_schedule_acknowledged)
         | Some
             { Schedule_domain.status =
                 ( Schedule_domain.Execution_running
@@ -449,7 +476,11 @@ let reconcile_spent_selection ~config ~keeper_name selection =
         with
         | Error message ->
            Error ("spent grant replay ack failed: " ^ message)
-        | Ok () -> Ok Spent_grant_replay_acknowledged)
+        | Ok () ->
+          project_reaction_evidence_best_effort
+            ~base_path:config.Workspace_utils.base_path
+            ~keeper_name;
+          Ok Spent_grant_replay_acknowledged)
      | Ok
          { state =
              ( Keeper_approval_queue.Resolution_unconsumed

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.mli
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.mli
@@ -119,6 +119,17 @@ val reconcile_spent_selection
     monotonic, so a consumed state cannot revert to usable. A read error leaves
     the selection actionable rather than discarding a possibly live grant. *)
 
+val project_reaction_evidence_best_effort
+  :  base_path:string
+  -> keeper_name:string
+  -> unit
+(** Project the keeper's durable event-queue transition outbox into the
+    reaction ledger through the canonical claim-guarded projector, so a wake
+    acked this turn carries consumption evidence before the next dashboard
+    read instead of waiting for the maintenance sweep (#26430). Convergent and
+    best-effort: [Claim_busy] and projection errors are logged and left to the
+    sweep. *)
+
 (** [heartbeat_event_intake ~ctx ~meta_after_triage
      ~pending_board_events]
     peeks at most one ready Event-Layer stimulus (per RFC-0020 §3 Rule 4)


### PR DESCRIPTION
Closes the remaining MEDIUM of #26430. (원래 이 PR은 HIGH+MEDIUM을 함께 담았으나, 대시보드 절반은 스웜 PR #26438이 먼저 머지 — 이 PR은 OCaml 절반으로 rebase해 좁혔습니다. 검토 head: 83c6e2ea41)

## 왜 지금 급한가

#26438 머지로 stimulus-only 행이 '누락 ⚠'으로 정직하게 발화합니다. 그런데 ack 증거는 여전히 sweep 투영으로만 ledger에 도달하므로, **정상 ack된 wake도 ack~다음 sweep 사이엔 전부 false-'누락'으로 표시**됩니다. main이 지금 이 상태입니다.

## 무엇을 하나

성공 ack 직후 3개 사이트(spent-schedule ack, spent-grant ack, heartbeat drain selection ack)에서 canonical claim-guarded projector(`Keeper_event_queue_recovery.project_owner_result`)를 즉시 호출합니다.

- 두 번째 기록자를 만들지 않음 — 기존 projector 재사용, 증거는 SSOT 유래 (caller가 receipt를 공급하지 않음, mli 계약 그대로)
- 실패는 warn 로그 후 sweep 수렴 (sweep은 안전망으로 유지)
- 기존 turn_started 동기 기록(intake:153)과 동형 패턴

## 검증

Build and Test 완주 후 머지.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
