### PR TITLE
fix(dashboard): stop treating the dispatch record as a keeper reaction

### DIFF
--- a/dashboard/src/components/schedule/queue-drain-status.test.ts
+++ b/dashboard/src/components/schedule/queue-drain-status.test.ts
@@ -40,11 +40,21 @@ describe('queueDrainStatusOf', () => {
   })
 
   it('treats not_found + a recorded keeper reaction as a healthy 완료 (drained), never a miss', () => {
-    for (const reaction of ['matched_consumed_ack', 'matched_turn_started', 'matched_stimulus'] as const) {
+    for (const reaction of ['matched_consumed_ack', 'matched_turn_started'] as const) {
       const status = queueDrainStatusOf(req('not_found', reaction))
       expect(status?.state, `reaction=${reaction}`).toBe('drained')
       expect(status?.label).toBe('완료')
     }
+  })
+
+  it('treats not_found + matched_stimulus as a miss: the stimulus row is only the producer dispatch record', () => {
+    // The stimulus row is written fail-closed at dispatch time, so every
+    // dispatched wake has one. A receipt leaves the queue only via
+    // ack/cancel/drop — stimulus-only means no keeper ever consumed it.
+    const status = queueDrainStatusOf(req('not_found', 'matched_stimulus'))
+    expect(status?.state).toBe('missed')
+    expect(status?.label).toBe('누락 ⚠')
+    expect(status?.tone).toBe('warn')
   })
 
   it('flags a genuine miss only when the wake is in no queue AND the keeper never reacted', () => {
@@ -86,21 +96,24 @@ describe('isCalendarVisible', () => {
     expect(visible('read_error')).toBe(true)
     expect(visible('not_found', 'quarantined')).toBe(true)
     expect(visible('not_found', 'matched_consumed_ack')).toBe(false) // drained
+    expect(visible('not_found', 'matched_stimulus')).toBe(true) // missed — dispatch record only
     expect(visible('unrecognized_receipt')).toBe(false) // indeterminate
   })
 })
 
 describe('countQueueDrainMisses', () => {
-  it('counts only genuine misses (queue=not_found AND reaction=not_found)', () => {
+  it('counts genuine misses (not_found without a keeper reaction), including stimulus-only receipts', () => {
     const requests: DashboardScheduledAutomationRequest[] = [
       req('matched_pending'),
       req('not_found', 'not_found'), // miss
+      req('not_found', 'matched_stimulus'), // miss — dispatch record only
       req('not_found', 'matched_turn_started'), // drained — not a miss
+      req('not_found', 'matched_consumed_ack'), // drained — not a miss
       req('not_found', 'not_found'), // miss
       req('read_error'), // read error — not counted as a miss
       req(null), // no evidence
     ]
-    expect(countQueueDrainMisses(requests)).toBe(2)
+    expect(countQueueDrainMisses(requests)).toBe(3)
   })
 
   it('returns 0 for an empty list', () => {

--- a/dashboard/src/components/schedule/queue-drain-status.ts
+++ b/dashboard/src/components/schedule/queue-drain-status.ts
@@ -13,13 +13,20 @@
 //     post-completion state (a drained wake leaves the
 //     queue), so not_found alone cannot mean "lost".
 //   · keeper_reaction_evidence — did the keeper actually react to the stimulus
-//     (consumed_ack / turn_started / stimulus recorded)? This disambiguates a
+//     (consumed_ack / turn_started)? This disambiguates a
 //     drained-and-handled wake from a genuinely lost one.
 //
-// A genuine miss is ONLY queue=not_found AND reaction=not_found: dispatched, not
-// in the queue, and never recorded as reacted. Every other not_found is a
-// healthy completion. Labeling not_found alone as "missed" would false-alarm on
-// every successful wake.
+// matched_stimulus is NOT a keeper reaction: it is the producer's own dispatch
+// record, written fail-closed when the wake was enqueued
+// (server_schedule_consumers.ml). Because every successfully dispatched wake
+// has it, treating it as "reacted" absorbs every genuine loss into a healthy
+// completion and makes the miss detector structurally inert.
+//
+// A receipt leaves the queue only via ack (normal), cancel, or drop/reset —
+// never silently between dispatch and turn start. So:
+//   · not_found + consumed_ack/turn_started → drained (the keeper handled it)
+//   · not_found + matched_stimulus (or no ledger row at all) → missed
+//     (dispatched, but no keeper ever consumed it)
 
 import type { DashboardScheduledAutomationRequest } from '../../api'
 import type { StatusChipTone } from '../common/status-chip'
@@ -41,10 +48,11 @@ export interface QueueDrainStatus {
 }
 
 // keeper_reaction_evidence statuses that prove the keeper handled the stimulus.
+// matched_stimulus is deliberately absent: it is the producer's dispatch
+// record, not a keeper reaction (see the header note).
 const REACTED: ReadonlySet<string> = new Set([
   'matched_consumed_ack',
   'matched_turn_started',
-  'matched_stimulus',
 ])
 
 const PRESENTATION: Readonly<Record<QueueDrainState, Omit<QueueDrainStatus, 'state'>>> = {
@@ -56,12 +64,13 @@ const PRESENTATION: Readonly<Record<QueueDrainState, Omit<QueueDrainStatus, 'sta
   drained: {
     label: '완료',
     tone: 'neutral',
-    title: '큐에서 빠졌고 keeper 반응이 기록됨 (consumed_ack / turn_started / stimulus)',
+    title: '큐에서 빠졌고 keeper 반응이 기록됨 (consumed_ack / turn_started)',
   },
   missed: {
     label: '누락 ⚠',
     tone: 'warn',
-    title: 'dispatch됐으나 큐에 없고 keeper 반응 기록도 없음 — 실행 누락',
+    title:
+      'dispatch 기록만 남았고 keeper 반응(turn_started/ack)이 없음 — 큐에서 빠졌으나 아무도 소비 안 함',
   },
   read_error: {
     label: '읽기 오류',
@@ -94,6 +103,11 @@ function stateOf(request: DashboardScheduledAutomationRequest): QueueDrainState 
     case 'not_found': {
       const reaction = request.keeper_reaction_evidence?.projection_status
       if (reaction != null && REACTED.has(reaction)) return 'drained'
+      // matched_stimulus means only the producer's dispatch record exists.
+      // A receipt leaves the queue only via ack/cancel/drop, so stimulus-only
+      // is a dispatched wake no keeper ever consumed — a genuine miss, not a
+      // healthy completion.
+      if (reaction === 'matched_stimulus') return 'missed'
       if (reaction === 'not_found') return 'missed'
       if (reaction === 'read_error') return 'read_error'
       if (reaction === 'quarantined') return 'evidence_invalid'
@@ -133,7 +147,8 @@ export function isCalendarVisible(status: QueueDrainStatus): boolean {
 }
 
 /** Count of requests whose last keeper-wake execution is a genuine miss
- * (queue=not_found AND reaction=not_found). Feeds the KPI strip. */
+ * (queue=not_found AND no keeper reaction — matched_stimulus counts as a miss
+ * because it is only the producer's dispatch record). Feeds the KPI strip. */
 export function countQueueDrainMisses(
   requests: readonly DashboardScheduledAutomationRequest[],
 ): number {


### PR DESCRIPTION
## Problem

Queue Drain Status의 `missed` 판정이 구조적으로 발화하지 않고, 실제 drain 누락이 "완료"로 표시됐습니다.

- dispatch 시 producer가 reaction ledger에 stimulus 행을 fail-closed로 기록 (`server_schedule_consumers.ml:571`) — 성공 dispatch엔 항상 존재
- 그런데 TS derivation이 `matched_stimulus`를 "keeper가 처리했다"는 REACTED에 포함 (`queue-drain-status.ts:44-48`)
- 결과: 큐가 reset/wipe/drop으로 사라져도 reaction=matched_stimulus가 남아 칩은 "완료", `missed`는 ledger 파일 자체가 없을 때만 발화 → miss KPI가 구조적으로 0

라이브 확인: 플릿에 없는 죽은 keeper(audit-ghost)의 소비 안 된 wake가 "완료"로 표시되는 상태였습니다.

## Fix

- REACTED는 실제 keeper 반응(`matched_consumed_ack`, `matched_turn_started`)만 유지
- receipt는 ack/cancel/drop으로만 큐를 떠나므로, `not_found + matched_stimulus`(dispatch 기록만 존재)는 아무도 소비하지 않은 wake — `missed`로 판정
- 헤더 주석 정정(기존 주석은 stimulus 행을 keeper 반응으로 오기술), 테스트에 stimulus-only → missed / drained와의 경계 / KPI 카운트 추가

## Out of scope (issue #26430에 기록)

- ack reaction의 maintenance sweep 지연(turn_started는 inline이라 현 miss 판정엔 무해)
- `read_error`의 transient/영속 구분(kind 미반영), miss 판정의 backend metric 부재

## Validation

- schedule 테스트 3개 파일 41/41 pass (vitest)
- `tsc --noEmit` clean

Draft; do not merge.
