### PR TITLE
fix(keeper): let manual compaction preempt source turns

### DIFF
--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -7,8 +7,9 @@
     - per-class string labels used in Otel_metric_store and log lines;
     - per-stimulus consumption ([consume_single_heartbeat_stimulus]);
     - the top-level RFC-0020 §3 Rule 4 draining function
-      ([heartbeat_event_intake]) that selects the earliest ready stimulus
-      without assigning priority to a payload family. *)
+      ([heartbeat_event_intake]) that selects the earliest ready stimulus,
+      except for explicit owner-lane manual compaction. That control-plane
+      request preempts without removing or rewriting the current source. *)
 
 open Keeper_types
 open Keeper_meta_contract
@@ -487,18 +488,39 @@ let heartbeat_event_intake
       ~meta_after_triage
       ~pending_board_events
   =
-(* RFC-0020 §3 Rule 4 — select at most one new Event Layer stimulus per
-     turn. The queue chooses the earliest ready stimulus while preserving
-     every skipped unready entry in place. Board, Connector, HITL, Schedule,
-     Fusion, and Goal inputs therefore share one lane order instead of a
-     payload-family priority hierarchy. *)
+  (* RFC-0020 §3 Rule 4 — select at most one new Event Layer stimulus per
+     turn. Data-plane payloads share one lane order. Explicit manual compaction
+     is the sole control-plane exception: it can run after the current source
+     checkpoints while that exact source stays pending for continuation. *)
   let base_path = ctx.config.base_path in
   let keeper_name = meta_after_triage.name in
-  let select_pending () =
+  let select_pending_matching ready =
     Keeper_registry_event_queue.peek_when_result
       ~base_path
       keeper_name
-      ~ready:(stimulus_ready_for_intake ~base_path)
+      ~ready
+  in
+  let select_pending () =
+    let manual_compaction_ready (stimulus : Keeper_event_queue.stimulus) =
+      match stimulus.payload with
+      | Keeper_event_queue.Manual_compaction_requested -> true
+      | Keeper_event_queue.Board_signal _
+      | Keeper_event_queue.Board_attention _
+      | Keeper_event_queue.Bootstrap
+      | Keeper_event_queue.Fusion_completed _
+      | Keeper_event_queue.Bg_completed _
+      | Keeper_event_queue.Schedule_due _
+      | Keeper_event_queue.Connector_attention _
+      | Keeper_event_queue.Hitl_resolved _
+      | Keeper_event_queue.Goal_assigned _
+      | Keeper_event_queue.Goal_reconciliation_ready _ ->
+        false
+    in
+    match select_pending_matching manual_compaction_ready with
+    | Error _ as error -> error
+    | Ok (Some _) as selected -> selected
+    | Ok None ->
+      select_pending_matching (stimulus_ready_for_intake ~base_path)
   in
   let rec select_pending_after_spent_reconciliation () =
     match select_pending () with

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.mli
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.mli
@@ -1,8 +1,10 @@
 (** Event-Layer stimulus intake for the keeper heartbeat loop.
 
     Selects the earliest ready Event Layer stimulus per turn following
-    RFC-0020 §3 Rule 4. Payload families share one order; an unready input
-    remains queued without blocking later ready work in the same Keeper lane. *)
+    RFC-0020 §3 Rule 4. Payload families share one order except for explicit
+    owner-lane manual compaction, which preempts at a persisted turn boundary
+    without removing the current source. An unready input remains queued
+    without blocking later ready work in the same Keeper lane. *)
 
 open Keeper_types
 open Keeper_meta_contract
@@ -121,9 +123,13 @@ val reconcile_spent_selection
 
 (** [heartbeat_event_intake ~ctx ~meta_after_triage
      ~pending_board_events]
-    peeks at most one ready Event-Layer stimulus (per RFC-0020 §3 Rule 4)
-    and merges its observation with the [pending_board_events] already
-    accumulated by the caller, deduplicating by [post_id]. A
+    peeks at most one ready Event-Layer stimulus (per RFC-0020 §3 Rule 4).
+    A pending [Manual_compaction_requested] is the sole control-plane
+    exception: it is selected ahead of data-plane stimuli so an in-flight
+    source checkpoint can yield, compact, and then resume from the unchanged
+    durable queue. The selected observation is merged with the
+    [pending_board_events] already accumulated by the caller, deduplicating by
+    [post_id]. A
     [Hitl_resolved] stimulus remains queued until its exact approval id has
     left the pending map, while later ready stimuli can still be selected.
     A transient Board read returns no consumed stimuli, keeps the exact

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -168,13 +168,88 @@ let autonomous_yield_request ~base_path ~keeper_name =
                 { reason = Durable_stimulus_waiting summary })))
 ;;
 
+let is_manual_compaction_payload = function
+  | Keeper_event_queue.Manual_compaction_requested -> true
+  | Keeper_event_queue.Board_signal _
+  | Keeper_event_queue.Board_attention _
+  | Keeper_event_queue.Bootstrap
+  | Keeper_event_queue.Fusion_completed _
+  | Keeper_event_queue.Bg_completed _
+  | Keeper_event_queue.Schedule_due _
+  | Keeper_event_queue.Connector_attention _
+  | Keeper_event_queue.Hitl_resolved _
+  | Keeper_event_queue.Goal_assigned _
+  | Keeper_event_queue.Goal_reconciliation_ready _ ->
+    false
+;;
+
+let manual_compaction_preemption_request ~wake ~now pending =
+  let source_can_yield =
+    match wake with
+    | Keeper_registry.Woken (_ :: _ as payloads) ->
+      not (List.exists is_manual_compaction_payload payloads)
+    | Keeper_registry.Proactive_tick | Keeper_registry.Woken [] -> false
+  in
+  if not source_can_yield
+  then None
+  else
+    let stimuli = Keeper_event_queue.to_list pending in
+    match
+      List.find_opt
+        (fun (stimulus : Keeper_event_queue.stimulus) ->
+           is_manual_compaction_payload stimulus.payload)
+        stimuli
+    with
+    | None -> None
+    | Some selected ->
+      let summary = Keeper_agent_run.durable_stimulus_summary ~now pending in
+      Some
+        Keeper_agent_run.
+          { reason =
+              Durable_stimulus_waiting
+                { summary with
+                  head = Some selected
+                ; head_age_sec = Float.max 0. (now -. selected.arrived_at)
+                }
+          }
+;;
+
+let manual_compaction_yield_request ~wake ~base_path ~keeper_name =
+  match Keeper_registry_event_queue.snapshot_result ~base_path keeper_name with
+  | Error _ as error -> error
+  | Ok pending ->
+    let now = Time_compat.now () in
+    let request = manual_compaction_preemption_request ~wake ~now pending in
+    Option.iter
+      (fun (request : Keeper_agent_run.autonomous_yield_request) ->
+         match request.reason with
+         | Keeper_agent_run.Chat_waiting -> ()
+         | Keeper_agent_run.Durable_stimulus_waiting summary ->
+           Log.Keeper.info
+             ~keeper_name
+             "autonomous source turn yields to manual compaction: %s"
+             (Keeper_agent_run.durable_stimulus_summary_to_string summary))
+      request;
+    Ok request
+;;
+
 let autonomous_yield_request_for_wake ~wake ~base_path ~keeper_name =
   match wake with
   (* A nonempty [Woken] is the event queue input already selected for this
-     turn. It may yield for chat delivery, but a queued successor waits until
-     that source reaches its terminal settlement. *)
+     turn. It may yield for chat delivery. An explicit owner-lane manual
+     compaction is the sole successor allowed to preempt at a persisted
+     post-tool boundary; the selected source remains pending and resumes after
+     compaction. Other queued successors still wait for the source terminal. *)
   | Keeper_registry.Woken (_ :: _) ->
-    fun () -> chat_yield_request ~base_path ~keeper_name
+    fun () ->
+      (match chat_yield_request ~base_path ~keeper_name with
+       | Error _ as error -> error
+       | Ok (Some _) as request -> request
+       | Ok None ->
+         manual_compaction_yield_request
+           ~wake
+           ~base_path
+           ~keeper_name)
   | Keeper_registry.Proactive_tick | Keeper_registry.Woken [] ->
     fun () -> autonomous_yield_request ~base_path ~keeper_name
 ;;

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -215,6 +215,16 @@ val turn_success_of_stop_reason
   -> turn_success
 (** Total typed projection used at the successful runtime boundary. *)
 
+val manual_compaction_preemption_request
+  :  wake:Keeper_registry.wake_reason
+  -> now:float
+  -> Keeper_event_queue.t
+  -> Keeper_agent_run.autonomous_yield_request option
+(** Pure post-tool boundary decision for an in-flight source turn. Returns a
+    durable-stimulus yield only when a separate owner-lane manual compaction is
+    pending. The summary names that exact control-plane stimulus as the next
+    source; a turn already consuming manual compaction never yields to itself. *)
+
 val run_keeper_cycle
   :  before_dispatch_authority:(unit -> (unit, string) result)
   -> ?deferred_runtime_lane:Keeper_turn_driver.deferred_runtime_lane

--- a/test/dune
+++ b/test/dune
@@ -752,6 +752,14 @@
  (modules test_keeper_board_unavailable)
  (libraries masc_test_deps))
 
+; #26348: explicit owner-lane manual compaction preempts a checkpointed
+; data-plane source, then the unchanged durable source resumes.
+
+(test
+ (name test_keeper_manual_compaction_preemption)
+ (modules test_keeper_manual_compaction_preemption)
+ (libraries masc_test_deps))
+
 ; Fusion OAS failure-detail tests need Fusion_types constructors from
 ; masc.fusion_core, which is intentionally not re-exported via masc.
 

--- a/test/test_keeper_manual_compaction_preemption.ml
+++ b/test/test_keeper_manual_compaction_preemption.ml
@@ -1,0 +1,234 @@
+open Alcotest
+open Masc
+
+module Q = Keeper_event_queue
+
+let stimulus ~post_id ~urgency ~arrived_at ~payload : Q.stimulus =
+  { post_id; urgency; arrived_at; payload }
+;;
+
+let queue_of stimuli =
+  List.fold_left Q.enqueue Q.empty stimuli
+;;
+
+let test_post_tool_boundary_targets_manual_compaction () =
+  let source =
+    stimulus
+      ~post_id:"source"
+      ~urgency:Q.Normal
+      ~arrived_at:900.
+      ~payload:Q.Bootstrap
+  in
+  let manual =
+    stimulus
+      ~post_id:Q.manual_compaction_post_id
+      ~urgency:Q.Immediate
+      ~arrived_at:990.
+      ~payload:Q.Manual_compaction_requested
+  in
+  let pending = queue_of [ source; manual ] in
+  let request =
+    Keeper_unified_turn.manual_compaction_preemption_request
+      ~wake:(Keeper_registry.Woken [ Q.Bootstrap ])
+      ~now:1000.
+      pending
+  in
+  match request with
+  | Some
+      { Keeper_agent_run.reason =
+          Keeper_agent_run.Durable_stimulus_waiting summary
+      } ->
+    check int "both durable stimuli remain visible" 2 summary.pending_count;
+    (match summary.head with
+     | Some selected ->
+       check string
+         "yield names the control-plane source that runs next"
+         Q.manual_compaction_post_id
+         selected.post_id
+     | None -> fail "manual compaction yield lost its selected source");
+    check (float 0.001) "selected-source age is exact" 10. summary.head_age_sec
+  | Some { reason = Keeper_agent_run.Chat_waiting } ->
+    fail "manual compaction preemption was mislabeled as chat"
+  | None ->
+    fail "pending manual compaction did not preempt the in-flight source"
+;;
+
+let test_manual_compaction_never_preempts_itself () =
+  let manual =
+    stimulus
+      ~post_id:Q.manual_compaction_post_id
+      ~urgency:Q.Immediate
+      ~arrived_at:990.
+      ~payload:Q.Manual_compaction_requested
+  in
+  check bool
+    "current manual compaction source continues"
+    true
+    (Option.is_none
+       (Keeper_unified_turn.manual_compaction_preemption_request
+          ~wake:(Keeper_registry.Woken [ Q.Manual_compaction_requested ])
+          ~now:1000.
+          (queue_of [ manual ])))
+;;
+
+let test_proactive_turn_uses_existing_general_queue_yield () =
+  let manual =
+    stimulus
+      ~post_id:Q.manual_compaction_post_id
+      ~urgency:Q.Immediate
+      ~arrived_at:990.
+      ~payload:Q.Manual_compaction_requested
+  in
+  check bool
+    "manual source preemption is scoped to an in-flight durable source"
+    true
+    (Option.is_none
+       (Keeper_unified_turn.manual_compaction_preemption_request
+          ~wake:Keeper_registry.Proactive_tick
+          ~now:1000.
+          (queue_of [ manual ])))
+;;
+
+let test_meta name =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+         [ "name", `String name
+         ; "agent_name", `String ("keeper-" ^ name ^ "-agent")
+         ; "trace_id", `String ("trace-" ^ name)
+         ])
+  with
+  | Ok meta -> meta
+  | Error detail -> failf "meta fixture failed: %s" detail
+;;
+
+let enqueue_exn ~base_path keeper_name source =
+  match
+    Keeper_registry_event_queue.enqueue_durable_result
+      ~base_path
+      keeper_name
+      source
+  with
+  | Ok () -> ()
+  | Error detail -> failf "durable enqueue failed: %s" detail
+;;
+
+let test_owner_intake_compacts_then_resumes_source () =
+  Eio_main.run
+  @@ fun env ->
+  Masc_test_deps.ensure_rng_initialized ();
+  Masc_test_deps.init_eio_clock env;
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run
+  @@ fun sw ->
+  let base_path = Masc_test_deps.setup_test_workspace () in
+  let keeper_name = "manual-compaction-preemption" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.For_testing.unregister ~base_path keeper_name;
+      Masc_test_deps.cleanup_test_workspace base_path)
+  @@ fun () ->
+  let config = Workspace.default_config base_path in
+  let meta = test_meta keeper_name in
+  ignore
+    (Keeper_registry.For_testing.register
+       ~base_path
+       keeper_name
+       meta);
+  let ctx : _ Keeper_types_profile.context =
+    { config
+    ; agent_name = "manual-compaction-preemption-test"
+    ; sw
+    ; clock = Eio.Stdenv.clock env
+    ; proc_mgr = None
+    ; net = None
+    ; publication_recovery_provider =
+        Masc_test_deps.non_runtime_publication_recovery_provider
+    }
+  in
+  let source =
+    stimulus
+      ~post_id:"durable-source"
+      ~urgency:Q.Normal
+      ~arrived_at:1.
+      ~payload:Q.Bootstrap
+  in
+  let manual =
+    stimulus
+      ~post_id:Q.manual_compaction_post_id
+      ~urgency:Q.Immediate
+      ~arrived_at:2.
+      ~payload:Q.Manual_compaction_requested
+  in
+  enqueue_exn ~base_path keeper_name source;
+  enqueue_exn ~base_path keeper_name manual;
+  let first =
+    Keeper_heartbeat_stimulus_intake.heartbeat_event_intake
+      ~ctx
+      ~meta_after_triage:meta
+      ~pending_board_events:[]
+  in
+  let selected_manual =
+    match first.pending_selection with
+    | Some selected ->
+      check string
+        "manual compaction is selected ahead of the source"
+        Q.manual_compaction_post_id
+        selected.post_id;
+      selected
+    | None -> fail "manual compaction preemption selected no source"
+  in
+  (match
+     Keeper_registry_event_queue.ack_pending_result
+       ~base_path
+       keeper_name
+       ~selection:selected_manual
+   with
+   | Ok () -> ()
+   | Error detail -> failf "manual compaction ACK failed: %s" detail);
+  let after_compaction =
+    match Keeper_registry_event_queue.snapshot_result ~base_path keeper_name with
+    | Ok queue -> queue
+    | Error detail -> failf "queue reload failed: %s" detail
+  in
+  check int "only the original source remains" 1 (Q.length after_compaction);
+  let resumed =
+    Keeper_heartbeat_stimulus_intake.heartbeat_event_intake
+      ~ctx
+      ~meta_after_triage:meta
+      ~pending_board_events:[]
+  in
+  match resumed.pending_selection with
+  | Some selected ->
+    check string
+      "the exact original source resumes after compaction"
+      source.post_id
+      selected.post_id
+  | None -> fail "the original source disappeared after manual compaction"
+;;
+
+let () =
+  run
+    "keeper manual compaction preemption"
+    [ ( "post-tool boundary"
+      , [ test_case
+            "targets queued manual compaction"
+            `Quick
+            test_post_tool_boundary_targets_manual_compaction
+        ; test_case
+            "manual compaction does not preempt itself"
+            `Quick
+            test_manual_compaction_never_preempts_itself
+        ; test_case
+            "proactive turns stay on the general queue-yield path"
+            `Quick
+            test_proactive_turn_uses_existing_general_queue_yield
+        ] )
+    ; ( "owner intake"
+      , [ test_case
+            "compacts first and resumes the exact source"
+            `Quick
+            test_owner_intake_compacts_then_resumes_source
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

- yield a non-manual durable source at the persisted post-tool boundary when an explicit owner-lane manual compaction is pending
- select that manual control-plane stimulus ahead of data-plane FIFO without ACKing or rewriting the current source
- after manual compaction settles, resume the exact original source from the existing durable queue

## Contract

- no request-byte heuristic or new generic Gate
- no legacy/migration field, settlement journal, or second persistence authority
- `event-queue-v13` remains SSOT; the only ordering exception is the explicit `Manual_compaction_requested` control-plane stimulus
- a manual-compaction turn never preempts itself; proactive turns keep the existing general queue-yield path

## Evidence

- live recurrence: 518 completed tool calls, then `request_body_too_large(actual=1049640,limit=1048576)`, followed by immediate retries of the unchanged overflowing source while manual compaction stayed pending
- new regression covers post-tool targeting, self-preemption rejection, proactive-path preservation, and exact-source resume after compaction ACK
- `ocamlformat --check` passed on every changed OCaml file
- `git diff --check` passed
- local Dune intentionally not run per operator direction; exact-head CI is build/test authority

Fixes #26348