### PR TITLE
fix(task): make requires_verification govern submission, not only done

### DIFF
--- a/lib/workspace/workspace_task_classify.ml
+++ b/lib/workspace/workspace_task_classify.ml
@@ -265,21 +265,31 @@ let task_assignee_of_status = Masc_domain.task_assignee_of_status
     will fail to compile. Each branch lists actions that
     [transition_task_r]'s match-arms accept for that status — keep this
     in sync if you add new transitions there. *)
+(* The completion action a working task may take is decided by
+   [requires_verification] alone, so the two are exclusive by construction
+   rather than by two independent conditionals that could both be true. A
+   strict task submits and waits for a completion authority; an advisory task
+   completes directly. Offering [Submit_for_verification] unconditionally let
+   an advisory task enter [AwaitingVerification], which no authority is
+   obligated to resolve and no agent action can leave. *)
+let completion_action ~requires_verification =
+  if requires_verification
+  then Masc_domain.Submit_for_verification
+  else Masc_domain.Done_action
+;;
+
 let valid_next_actions_for_status ~requires_verification
   : Masc_domain.task_status -> Masc_domain.task_action list
   = function
   | Masc_domain.Todo -> [ Masc_domain.Claim; Masc_domain.Release; Masc_domain.Cancel ]
   | Masc_domain.Claimed _ ->
     [ Masc_domain.Start
-    ]
-    @ (if requires_verification then [] else [ Masc_domain.Done_action ])
-    @ [ Masc_domain.Submit_for_verification
+    ; completion_action ~requires_verification
     ; Masc_domain.Release
     ; Masc_domain.Cancel
     ]
   | Masc_domain.InProgress _ ->
-    (if requires_verification then [] else [ Masc_domain.Done_action ])
-    @ [ Masc_domain.Submit_for_verification
+    [ completion_action ~requires_verification
     ; Masc_domain.Release
     ; Masc_domain.Cancel
     ]

--- a/lib/workspace/workspace_task_lifecycle.ml
+++ b/lib/workspace/workspace_task_lifecycle.ml
@@ -5,6 +5,7 @@
 
 type invalid =
   | Verification_submission_required
+  | Verification_not_required
   | Verification_pending_verdict
       (** An [AwaitingVerification] obligation is not claimable by any agent. *)
   | Verdict_authority_identity_required
@@ -129,12 +130,22 @@ let decide
     Error Invalid_transition
   | ( Masc_domain.Submit_for_verification
     , (Masc_domain.Claimed { assignee; _ } | Masc_domain.InProgress { assignee; _}) ) ->
-    if same_agent assignee
-    then
+    (* [requires_verification] governs both completion arms or neither. It
+       already decides whether [Done_action] is legal above; leaving this arm
+       unconditional made [AwaitingVerification] reachable from any task,
+       including the advisory majority whose contract nobody opted into strict
+       verification for. That state has no agent-side exit but [Cancel] and no
+       in-process authority, so an advisory task that submitted waited for a
+       verdict no authority owed it while its own [Done_action] stayed legal
+       and unused. *)
+    if not (same_agent assignee)
+    then Error Invalid_transition
+    else if not requires_verification
+    then Error Verification_not_required
+    else
       ok
         (Masc_domain.AwaitingVerification
            { assignee; submitted_at = now; verification_id = new_verification_id () })
-    else Error Invalid_transition
   | ( Masc_domain.Submit_for_verification
     , ( Masc_domain.Todo
       | Masc_domain.AwaitingVerification _

--- a/lib/workspace/workspace_task_lifecycle.mli
+++ b/lib/workspace/workspace_task_lifecycle.mli
@@ -5,6 +5,12 @@
 
 type invalid =
   | Verification_submission_required
+  | Verification_not_required
+      (** The task's contract did not opt into strict verification, so no
+          completion authority is obligated to judge it. Submitting would move
+          it into [AwaitingVerification], whose only agent-side exit is
+          [Cancel] — an advisory task that submits abandons its own terminal
+          [Done_action] for a verdict nobody owes it. *)
   | Verification_pending_verdict
       (** An [AwaitingVerification] obligation is not claimable by any agent. *)
   | Verdict_authority_identity_required

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -114,6 +114,15 @@ let transition_task_outcome_r
                  (Masc_domain.Task_error.InvalidState
                     "Task completion must be submitted for verification; use \
                      submit_for_verification with evidence"))
+          | Error Workspace_task_lifecycle.Verification_not_required ->
+            Error
+              (Masc_domain.Task
+                 (Masc_domain.Task_error.InvalidState
+                    (Printf.sprintf
+                       "Task %s did not opt into strict verification, so no completion \
+                        authority is obligated to judge it and submitting would leave \
+                        it awaiting a verdict indefinitely; complete it with done"
+                       task_id)))
           | Error Workspace_task_lifecycle.Verification_pending_verdict ->
             Error
               (Masc_domain.Task
@@ -590,6 +599,7 @@ let commit_verdict_r
                         authority identity"))
              | Error Workspace_task_lifecycle.Verification_pending_verdict
              | Error Workspace_task_lifecycle.Verification_submission_required
+             | Error Workspace_task_lifecycle.Verification_not_required
              | Error Workspace_task_lifecycle.Invalid_transition ->
                Error
                  (Masc_domain.Task

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -243,13 +243,15 @@ let create_executing_goal ctx ~goal_id =
   | Ok goal -> goal
   | Error message -> failwith message
 
-let add_goal_linked_task ctx ~goal_id ~title =
+let add_goal_linked_task ?(strict = false) ctx ~goal_id ~title =
   let result =
     Task.Tool.handle_add_task
       ~tool_name:"test_tool"
       ~start_time:0.0
       ctx
-      (`Assoc [ "title", `String title; "goal_id", `String goal_id ])
+      (`Assoc
+        ([ "title", `String title; "goal_id", `String goal_id ]
+         @ if strict then [ "contract", `Assoc [ "strict", `Bool true ] ] else []))
   in
   if not (Tool_result.is_success result) then
     failwith (Tool_result.message result)
@@ -984,7 +986,8 @@ let () = test "handle_transition_submit_does_not_have_a_disable_bypass"
   let ctx = make_test_ctx_with_agent "owner-agent" in
   let _ =
     Task.Tool.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
-      (`Assoc [ ("title", `String "Verification disabled gate") ])
+      (`Assoc
+        [ ("title", `String "Verification disabled gate"); ("contract", `Assoc [ ("strict", `Bool true) ]); ])
   in
   start_task_001 ctx;
   let result =
@@ -1026,7 +1029,8 @@ let () = test "handle_transition_submit_rejects_registered_keeper_alias"
         ~tool_name:"test_tool"
         ~start_time:0.0
         ctx
-        (`Assoc [ ("title", `String "Canonical submit identity") ])
+        (`Assoc
+          [ ("title", `String "Canonical submit identity"); ("contract", `Assoc [ ("strict", `Bool true) ]); ])
     in
     (match
        Workspace.claim_task_r ctx.config ~agent_name:"keeper-executor-agent"
@@ -1471,7 +1475,10 @@ let () = test "handle_transition_done_on_awaiting_verification_is_explicit" (fun
 let () = test "agent verdict verbs remain refused after terminal completion" (fun () ->
   let ctx = make_test_ctx_with_agent "worker" in
   let verifier_ctx = { ctx with Task.Tool.agent_name = "verifier" } in
-  let _ = Workspace.add_task ctx.config ~title:"Already done" ~priority:1 ~description:"" in
+  let _ =
+    Workspace.add_task ctx.config ~contract:(make_task_contract ~strict:true ())
+      ~title:"Already done" ~priority:1 ~description:""
+  in
   let _ = Workspace.claim_task ctx.config ~agent_name:"worker" ~task_id:"task-001" in
   let _ =
     Workspace.transition_task_r
@@ -1524,7 +1531,8 @@ let () = test "operator verdict path replaces verifier agent actions" (fun () ->
     let verifier_ctx = { worker_ctx with Task.Tool.agent_name = "verifier" } in
     let _ =
       Task.Tool.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 worker_ctx
-        (`Assoc [ ("title", `String "Verifier may approve") ])
+        (`Assoc
+          [ ("title", `String "Verifier may approve"); ("contract", `Assoc [ ("strict", `Bool true) ]); ])
     in
     let _ =
       Workspace.claim_task worker_ctx.config ~agent_name:"worker" ~task_id:"task-001"
@@ -1584,6 +1592,7 @@ let () =
        let goal_id = "goal-approved-verification" in
        ignore (create_executing_goal worker_ctx ~goal_id);
        add_goal_linked_task
+         ~strict:true
          worker_ctx
          ~goal_id
          ~title:"Complete through verification";
@@ -2384,7 +2393,13 @@ let () = test "handle_done_todo_rejection_is_tool-neutral" (fun () ->
 (* Test handle_done reports already-done guidance instead of generic not-claimed *)
 let () = test "handle_done_already_done_guidance" (fun () ->
   let ctx = make_test_ctx () in
-  let _ = Task.Tool.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [("title", `String "Done test")]) in
+  let _ =
+    Task.Tool.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc
+        [ ("title", `String "Done test")
+        ; ("contract", `Assoc [ ("strict", `Bool true) ])
+        ])
+  in
   let _ = Workspace.claim_task ctx.config ~agent_name:"other-agent" ~task_id:"task-001" in
   let _ =
     Workspace.transition_task_r ctx.config ~agent_name:"other-agent"

--- a/test/test_tool_workspace_coverage.ml
+++ b/test/test_tool_workspace_coverage.ml
@@ -44,7 +44,37 @@ let set_current_task_ok config ~task_id =
   | Error msg -> failwith msg
 ;;
 
+(* Only a strict contract routes completion through an authority, so a test that
+   needs [AwaitingVerification] must opt in the way production does: an advisory
+   task's [Submit_for_verification] is refused. *)
+let strict_contract : Masc_domain.task_contract =
+  { strict = true
+  ; completion_contract = [ "authority verdict required" ]
+  ; required_evidence = []
+  ; inspect_gate_evidence = []
+  ; verify_gate_evidence = []
+  ; links = { operation_id = None; session_id = None }
+  }
+;;
+
 let complete_task config ~agent_name ~task_id ~notes =
+  let advisory =
+    Workspace.get_tasks_raw config
+    |> List.find_opt (fun (task : Masc_domain.task) -> String.equal task.id task_id)
+    |> Option.map (fun task -> not (Masc_domain.task_requires_verification task))
+    |> Option.value ~default:false
+  in
+  (* Mirror production: only a strict contract routes through the completion
+     authority. An advisory task's [Submit_for_verification] is refused. *)
+  if advisory
+  then (
+    match
+      Workspace.transition_task_r config ~agent_name ~task_id
+        ~action:Masc_domain.Done_action ~notes ()
+    with
+    | Ok _ -> ()
+    | Error error -> failwith (Masc_domain.masc_error_to_string error))
+  else
   match
     Workspace.transition_task_r config ~agent_name ~task_id
       ~action:Masc_domain.Submit_for_verification ~notes ()
@@ -358,7 +388,8 @@ let () =
       let _ = Workspace.init ctx.config ~agent_name:(Some "test-agent") in
       let actual_name = Workspace.resolve_agent_name ctx.config "test-agent" in
       ignore
-        (Workspace.add_task ctx.config ~title:"Awaiting verifier" ~priority:2 ~description:"");
+        (Workspace.add_task ctx.config ~contract:strict_contract ~title:"Awaiting verifier"
+           ~priority:2 ~description:"");
       ignore (Workspace.claim_task ctx.config ~agent_name:actual_name ~task_id:"task-001");
       (match
          Workspace.transition_task_r

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -69,20 +69,44 @@ let contains_warning result =
 
 let contains_error = contains_problem_result
 
+(* Only a strict contract routes completion through an authority, so every test
+   that exercises the verdict boundary must opt in the way production does: an
+   advisory task's [Submit_for_verification] is refused. *)
+let strict_contract : Masc_domain.task_contract =
+  { strict = true
+  ; completion_contract = [ "deliverable verified by a second agent" ]
+  ; (* Declared up front so the strict evidence precheck is satisfied by the
+       contract itself and direct done reaches the verification-lane guard. *)
+    required_evidence = [ "artifact:deliverable" ]
+  ; inspect_gate_evidence = []
+  ; verify_gate_evidence = []
+  ; links = { operation_id = None; session_id = None }
+  }
+
 let transition_done_r config ~agent_name ~task_id ~notes =
   let evidence_notes =
     if String.equal (String.trim notes) ""
     then "test completion evidence"
     else notes
   in
-  match
+  let task_opt =
     Workspace.get_tasks_raw config
     |> List.find_opt (fun (task : Masc_domain.task) -> String.equal task.id task_id)
-  with
-  | Some { task_status = Masc_domain.Done _; _ } ->
+  in
+  let direct_done () =
     Workspace.transition_task_r config ~agent_name ~task_id
       ~action:Masc_domain.Done_action
       ~notes:evidence_notes ()
+  in
+  match task_opt with
+  | Some { task_status = Masc_domain.Done _; _ } -> direct_done ()
+  | Some task when not (Masc_domain.task_requires_verification task) ->
+    (* Mirror production: only a strict contract routes through the completion
+       authority. Submitting an advisory task moved it into
+       [AwaitingVerification], a state no agent action leaves and no authority
+       is obligated to resolve — the FSM refuses that now, so a helper that
+       submitted unconditionally was exercising a path production never takes. *)
+    direct_done ()
   | Some _ | None ->
     (match
        Workspace.transition_task_r config ~agent_name ~task_id
@@ -1129,7 +1153,10 @@ let test_approve_completion_credits_assignee () =
   with_test_env (fun config ->
     with_done_hook_recorder (fun recorded ->
       with_verdict_projection_recorders (fun terminal notifications ->
-      let _ = Workspace.add_task config ~title:"Parity Task" ~priority:1 ~description:"" in
+      let _ =
+        Workspace.add_task config ~contract:strict_contract ~title:"Parity Task"
+          ~priority:1 ~description:""
+      in
       let _ = Workspace.bind_session config ~agent_name:test_agent_a ~capabilities:[] () in
       let _ = Workspace.claim_task config ~agent_name:test_agent_a ~task_id:"task-001" in
       let submitted =
@@ -1169,6 +1196,7 @@ let test_operator_rejection_rebinds_producer () =
     let _ =
       Workspace.add_task
         config
+        ~contract:strict_contract
         ~title:"Rejected Task"
         ~priority:1
         ~description:""
@@ -1230,6 +1258,7 @@ let test_operator_verdict_boundary_is_reachable () =
     let _ =
       Workspace.add_task
         config
+        ~contract:strict_contract
         ~title:"Operator Boundary Task"
         ~priority:1
         ~description:""
@@ -1327,7 +1356,10 @@ let test_operator_verdict_parser_rejects_reasonless_rejection () =
    the producer has to know what to fix. *)
 let test_verdict_rejects_blank_rejection_reason () =
   with_test_env (fun config ->
-    let _ = Workspace.add_task config ~title:"Justification Task" ~priority:1 ~description:"" in
+    let _ =
+      Workspace.add_task config ~contract:strict_contract ~title:"Justification Task"
+        ~priority:1 ~description:""
+    in
     let _ = Workspace.bind_session config ~agent_name:test_agent_a ~capabilities:[] () in
     let _ = Workspace.claim_task config ~agent_name:test_agent_a ~task_id:"task-001" in
     let _ =
@@ -1352,17 +1384,6 @@ let test_verdict_rejects_blank_rejection_reason () =
     | _ -> Alcotest.fail "refused verdict mutated the verification state")
 
 (* === RFC-0323 G-1 (implements RFC-0308): verification-required done guard === *)
-
-let strict_contract : Masc_domain.task_contract =
-  { strict = true
-  ; completion_contract = [ "deliverable verified by a second agent" ]
-  ; (* Declared up front so the strict evidence precheck is satisfied by the
-       contract itself and direct done reaches the verification-lane guard. *)
-    required_evidence = [ "artifact:deliverable" ]
-  ; inspect_gate_evidence = []
-  ; verify_gate_evidence = []
-  ; links = { operation_id = None; session_id = None }
-  }
 
 let test_strict_task_done_requires_verification_submission () =
   with_test_env (fun config ->
@@ -1431,8 +1452,8 @@ let test_audit_orphan_awaiting_verification_tasks () =
   with_test_env (fun config ->
     (
         let _ =
-          Workspace.add_task config ~title:"Verification Orphan Candidate"
-            ~priority:1 ~description:""
+          Workspace.add_task config ~contract:strict_contract
+            ~title:"Verification Orphan Candidate" ~priority:1 ~description:""
         in
         let _ = Workspace.bind_session config ~agent_name:test_agent_a ~capabilities:[] () in
         let _ = Workspace.claim_task config ~agent_name:test_agent_a ~task_id:"task-001" in

--- a/test/test_workspace_coverage.ml
+++ b/test/test_workspace_coverage.ml
@@ -192,19 +192,38 @@ let find_agent_name_by_prefix config prefix =
   | None -> Alcotest.failf "agent with prefix %s not found" prefix
 ;;
 
+(* Only a strict contract routes completion through an authority, so a test that
+   needs [AwaitingVerification] must opt in the way production does: an advisory
+   task's [Submit_for_verification] is refused. *)
+let strict_contract : Masc_domain.task_contract =
+  { strict = true
+  ; completion_contract = [ "authority verdict required" ]
+  ; required_evidence = []
+  ; inspect_gate_evidence = []
+  ; verify_gate_evidence = []
+  ; links = { operation_id = None; session_id = None }
+  }
+;;
+
 let transition_done_r config ~agent_name ~task_id ~notes =
   let evidence_notes =
     if String.equal (String.trim notes) ""
     then "test completion evidence"
     else notes
   in
+  let direct_done () =
+    Workspace.transition_task_r config ~agent_name ~task_id
+      ~action:Masc_domain.Done_action ~notes:evidence_notes ()
+  in
   match
     Workspace.get_tasks_raw config
     |> List.find_opt (fun (task : Masc_domain.task) -> String.equal task.id task_id)
   with
-  | Some { task_status = Masc_domain.Done _; _ } ->
-    Workspace.transition_task_r config ~agent_name ~task_id
-      ~action:Masc_domain.Done_action ~notes:evidence_notes ()
+  | Some { task_status = Masc_domain.Done _; _ } -> direct_done ()
+  | Some task when not (Masc_domain.task_requires_verification task) ->
+    (* Mirror production: only a strict contract routes through the completion
+       authority. An advisory task's [Submit_for_verification] is refused. *)
+    direct_done ()
   | Some _ | None ->
     (match
        Workspace.transition_task_r config ~agent_name ~task_id
@@ -480,7 +499,8 @@ let test_status_hides_stale_agent_current_task_without_writing () =
         | _ -> Alcotest.fail "expected exactly one bound agent"
       in
       let _ =
-        Workspace.add_task config ~title:"Awaiting verifier" ~priority:1 ~description:""
+        Workspace.add_task config ~contract:strict_contract ~title:"Awaiting verifier"
+          ~priority:1 ~description:""
       in
       let _ = Workspace.claim_task config ~agent_name ~task_id:"task-001" in
       (match
@@ -1333,7 +1353,10 @@ let test_transition_invalid () =
 let test_transition_submit_for_verification_requires_notes () =
   (
     with_test_env (fun config ->
-      let _ = Workspace.add_task config ~title:"Test" ~priority:1 ~description:"" in
+      let _ =
+        Workspace.add_task config ~contract:strict_contract ~title:"Test" ~priority:1
+          ~description:""
+      in
       let _ = Workspace.claim_task config ~agent_name:"claude" ~task_id:"task-001" in
       let result =
         Workspace.transition_task_r

--- a/test/test_workspace_task_lifecycle.ml
+++ b/test/test_workspace_task_lifecycle.ml
@@ -60,6 +60,53 @@ let test_claimed_done_requires_verification_submission () =
   |> expect_error L.Verification_submission_required
 ;;
 
+(* The completion action is decided by [requires_verification] alone, so the two
+   completion arms are exclusive. An advisory task that submits would enter
+   [AwaitingVerification] — a state no agent action can leave and no completion
+   authority is obligated to resolve — while its own terminal [Done_action]
+   stayed legal and unused. Six live obligations reached that state this way. *)
+let test_advisory_task_cannot_submit_for_verification () =
+  List.iter
+    (fun task_status ->
+       decide
+         ~requires_verification:false
+         ~same_agent:true
+         ~task_status
+         ~action:D.Submit_for_verification
+         ()
+       |> expect_error L.Verification_not_required)
+    [ in_progress; D.Claimed { assignee = owner; claimed_at = now } ]
+;;
+
+let test_strict_task_still_submits () =
+  match
+    decide ~same_agent:true ~task_status:in_progress ~action:D.Submit_for_verification ()
+  with
+  | Ok { new_status = D.AwaitingVerification { assignee; verification_id; _ }; _ }
+    when String.equal assignee owner && String.equal verification_id "vrf-1" -> ()
+  | Ok _ | Error _ -> failwith "a strict task must still reach AwaitingVerification"
+;;
+
+(* The hint the agent reads must name the one completion action the FSM accepts.
+   Offering both let a keeper pick the arm that traps it. *)
+let test_hint_offers_exactly_one_completion_action () =
+  List.iter
+    (fun (requires_verification, expected) ->
+       List.iter
+         (fun task_status ->
+            let actions =
+              L.valid_next_actions ~same_agent:true ~task_status ~requires_verification
+            in
+            let has action = List.exists (fun a -> a = action) actions in
+            if not (has expected)
+            then failwith "the accepted completion action must be offered";
+            if has (if expected = D.Done_action then D.Submit_for_verification
+                    else D.Done_action)
+            then failwith "the refused completion action must not be offered")
+         [ in_progress; D.Claimed { assignee = owner; claimed_at = now } ])
+    [ false, D.Done_action; true, D.Submit_for_verification ]
+;;
+
 let test_default_done_is_terminal () =
   match
     decide
@@ -184,6 +231,9 @@ let test_awaiting_is_claimable_by_nobody () =
 let () =
   test_done_requires_verification_submission ();
   test_claimed_done_requires_verification_submission ();
+  test_advisory_task_cannot_submit_for_verification ();
+  test_strict_task_still_submits ();
+  test_hint_offers_exactly_one_completion_action ();
   test_default_done_is_terminal ();
   test_verdict_is_not_an_agent_action ();
   test_verdict_requires_authority_and_reason ();


### PR DESCRIPTION
## 문제

`Workspace_task_lifecycle.decide`는 `requires_verification`을 인자로 받아 `Done_action` arm에서는 읽고(`workspace_task_lifecycle.ml:101`), `Submit_for_verification` arm에서는 읽지 않았습니다. 한 파라미터가 한 arm을 지배하고 다른 arm에서 무시됩니다.

결과: **strict가 아닌 task도 `AwaitingVerification`에 진입**할 수 있었습니다. 라이브 backlog 140건 중 `contract.strict = true`는 5건이고 전부 `done`입니다. 나머지 135건은 advisory인데, 그 상태의 출구는 `Cancel`(작업 폐기)뿐이고 in-process completion authority는 없습니다. advisory task가 제출하면 아무 authority도 의무가 없는 verdict를 기다리며, 자기 자신의 종단 `Done_action`은 legal한 채로 쓰이지 않고 남습니다.

실측 — 갇힌 6건 전부 `strict` 필드 자체가 없습니다:

```
task-043 | keeper-executor-agent-agent | 2026-07-30T01:41:36Z
task-049 | keeper-executor-agent-agent | 2026-07-30T00:51:51Z
task-053 | keeper-executor-agent-agent | 2026-07-30T01:02:56Z
task-056 | keeper-kidsnote-agent       | 2026-07-30T06:29:54Z  ← #26425 머지 77분 후
task-059 | keeper-sangsu-agent         | 2026-07-30T01:27:47Z
task-069 | keeper-executor-agent-agent | 2026-07-30T01:56:16Z
```

`valid_next_actions_for_status`(`workspace_task_classify.ml:276,282`)가 `Submit_for_verification`을 **무조건** 제시했기 때문에, agent가 읽는 힌트 자체가 이 경로를 안내했습니다.

## 변경

파라미터가 두 completion arm을 모두 지배하도록 합니다.

- `decide`의 `Submit_for_verification` arm이 `requires_verification`을 읽고, false면 새 typed error `Verification_not_required`를 반환합니다. `AwaitingVerification`을 만드는 transition은 이 arm 하나뿐입니다 (나머지 참조는 destructuring, `types_core.ml:439`는 디스크 역직렬화).
- `valid_next_actions_for_status`가 legal한 completion action **하나**를 같은 술어에서 파생합니다 (`completion_action ~requires_verification`). 두 개의 독립 조건문이 아니라 구조적으로 배타적이라, agent가 읽는 표면이 FSM이 거부하는 arm을 제시할 수 없습니다.
- `transition_task_r`가 새 error를 왜 거부됐는지 이름을 대는 메시지로 매핑합니다 — silent coercion 없이, `done`을 쓰라고 알려줍니다.

Gate를 추가한 것이 아닙니다. gate는 이미 `requires_verification`으로 존재하고, 한 arm이 그것을 우회하고 있었습니다. advisory task의 동작 경로(`Done_action`)는 그대로입니다.

## 테스트

세 파일에 복제된 완료 헬퍼가 strict 여부와 무관하게 submit→approve를 돌고 있었습니다 — **프로덕션이 타지 않는 경로**입니다. `keeper_tool_task_runtime.ml:775-782`과 같이 `task_requires_verification`으로 분기하도록 고쳤고, verdict 경계를 의도적으로 겨냥하는 테스트는 strict contract를 선언합니다.

신규 케이스 3건 (`test_workspace_task_lifecycle.ml`):
- `test_advisory_task_cannot_submit_for_verification` — Claimed/InProgress 양쪽에서 refusal
- `test_strict_task_still_submits` — strict 경로 보존
- `test_hint_offers_exactly_one_completion_action` — 힌트와 FSM 동기화

`Verification_not_required` 생성자는 수정 전에 존재하지 않았으므로, 이 테스트는 구코드에 대해 컴파일 자체가 불가능합니다.

## 로컬 검증

`dune build @check` clean.

| suite | base `407ae5bb92` (무변경) | 이 브랜치 |
|---|---|---|
| test_workspace | 9 failures | **9** |
| test_workspace_coverage | 2 | **2** |
| test_tool_workspace_coverage | 3 | **3** |
| test_tool_task_coverage | 2 | **2** |
| test_workspace_task_lifecycle | pass | **pass** (신규 3건 포함) |

실패 개수와 **실패 테스트 이름**이 base와 동일합니다. 회귀 0. base의 9건은 pre-existing이며 이 변경과 무관합니다 (`board_admin 4-8`, `task_identity 0-1`, `idle_stop_signals 0-1`).

## 범위 밖 (별도 처리 필요)

- **라이브 6건**은 이 코드 변경으로 해제되지 않습니다. 이미 그 상태에 있으므로 `POST /api/v1/verification/verdict`(operator) 처리가 필요합니다. 증거는 실재해 보입니다 (커밋 SHA, 테스트 실행 결과).
- **PR #26425의 미해결 리뷰 스레드 9건** (P1 4 / P2 5). 머지 8분 32초 후 도착해 무응답 상태이고, 머지된 브랜치엔 push할 수 없습니다. 확인된 항목: verdict가 `verification_id`에 바인딩되지 않음, reject 시 `current_task` 무조건 재바인딩, activity payload가 `producer`인데 consumer는 `assignee`를 읽음(`activity_graph_reducer.ml:238`), verdict 경로에서 완료 텔레메트리 미발화, `on_task_mutation_fn` 미호출, reject 사유가 durable audit에 없음.
- **`completion_authority.Auto_judge`** 생산자 0건. `keeper_gate`의 Auto judge는 task가 아니라 **Keeper 도구 호출 한 건**을 판정합니다 (subject가 `pending_approval { keeper_name; tool_name; input_hash; continuation_channel }`, 라이브 `gate/pending.json` 561건 전부 `network_read`/`tool_execute`/`filesystem_write`, task row 0건). 재사용 대상이 아닙니다.
- **`runtime.toml:618`의 고아 assignment** `"verifier" = "ollama_cloud.gemma4-31b-cloud"` — `verifier` keeper는 더 이상 존재하지 않습니다 (라이브 config).

RFC-WAIVED: 이미 전달받는 파라미터를 지키도록 FSM arm 하나를 좁힙니다. credential / identity / operator-control / sandbox / hook / workflow 표면을 건드리지 않습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
