### PR TITLE
refactor(memory): prepare current-only atomic publication

### DIFF
--- a/dashboard/src/api/dashboard-turn-records.test.ts
+++ b/dashboard/src/api/dashboard-turn-records.test.ts
@@ -43,7 +43,6 @@ function payload(...entries: ReturnType<typeof entry>[]) {
     health: 'ok',
     stale_reason: null,
     memory_os: {
-      schema: 'keeper.memory_os.recall_observability.v2',
       keeper: 'sangsu',
       source: 'memory_os_files',
       producer: 'keeper_librarian|keeper_memory_os_recall',
@@ -59,7 +58,7 @@ function payload(...entries: ReturnType<typeof entry>[]) {
       episodes_store: '.masc/config/keepers/sangsu/episodes',
       recall_enabled: true,
       read_errors: [],
-      episodes: { shown: 0, terminal_markers: 0, items: [] },
+      episodes: { shown: 0, items: [] },
       facts: { shown: 0, items: [] },
     },
     entries,

--- a/dashboard/src/api/dashboard-turn-records.ts
+++ b/dashboard/src/api/dashboard-turn-records.ts
@@ -78,7 +78,6 @@ export type MemoryOsEpisodeSummary = {
   trace_id: string
   generation: number
   created_at: number
-  terminal_marker: string | null
   claim_count: number
   // Inclusive [lo, hi] absolute-turn span the episode compacted, or null when the
   // record carries none (memory_os_episode_json → Keeper_memory_os_types.episode.source_turn_range).
@@ -151,7 +150,6 @@ export type MemoryOsSelectionPolicy = {
 }
 
 export type MemoryOsTurnRecordSnapshot = {
-  schema: 'keeper.memory_os.recall_observability.v2'
   keeper: string
   source: 'memory_os_files'
   producer: 'keeper_librarian|keeper_memory_os_recall'
@@ -162,7 +160,6 @@ export type MemoryOsTurnRecordSnapshot = {
   read_errors: { scope: string; error: string }[]
   episodes: {
     shown: number
-    terminal_markers: number
     items: MemoryOsEpisodeSummary[]
   }
   facts: {
@@ -530,7 +527,6 @@ function decodeMemoryOsEpisode(raw: unknown): MemoryOsEpisodeSummary | null {
     'trace_id',
     'generation',
     'created_at',
-    'terminal_marker',
     'claim_count',
     'source_turn_range',
     'summary',
@@ -538,7 +534,6 @@ function decodeMemoryOsEpisode(raw: unknown): MemoryOsEpisodeSummary | null {
   const trace_id = decodeExactNonEmptyString(raw.trace_id)
   const generation = asNumber(raw.generation)
   const created_at = asNumber(raw.created_at)
-  const terminal_marker = decodeNullableString(raw.terminal_marker)
   const claim_count = asNumber(raw.claim_count)
   const source_turn_range = raw.source_turn_range === null
     ? null
@@ -550,7 +545,6 @@ function decodeMemoryOsEpisode(raw: unknown): MemoryOsEpisodeSummary | null {
     || !Number.isSafeInteger(generation)
     || generation < 0
     || created_at == null
-    || terminal_marker === undefined
     || claim_count == null
     || !Number.isSafeInteger(claim_count)
     || claim_count < 0
@@ -561,7 +555,6 @@ function decodeMemoryOsEpisode(raw: unknown): MemoryOsEpisodeSummary | null {
     trace_id,
     generation,
     created_at,
-    terminal_marker,
     claim_count,
     source_turn_range,
     summary,
@@ -689,7 +682,7 @@ function decodeMemoryOsSelectionPolicy(raw: unknown): MemoryOsSelectionPolicy | 
 
 function decodeMemoryOsCount(raw: unknown): { shown: number } | null {
   if (!isRecord(raw)) return null
-  if (!hasNoUnknownKeys(raw, ['shown', 'terminal_markers', 'items'])) {
+  if (!hasNoUnknownKeys(raw, ['shown', 'items'])) {
     return null
   }
   const shown = asNumber(raw.shown)
@@ -704,7 +697,6 @@ function decodeMemoryOsCount(raw: unknown): { shown: number } | null {
 function decodeMemoryOsSnapshot(raw: unknown): MemoryOsTurnRecordSnapshot | null {
   if (!isRecord(raw)) return null
   if (!hasExactKeys(raw, [
-    'schema',
     'keeper',
     'source',
     'producer',
@@ -716,9 +708,6 @@ function decodeMemoryOsSnapshot(raw: unknown): MemoryOsTurnRecordSnapshot | null
     'episodes',
     'facts',
   ])) return null
-  const schema = raw.schema === 'keeper.memory_os.recall_observability.v2'
-    ? raw.schema
-    : null
   const keeper = decodeExactNonEmptyString(raw.keeper)
   const source = raw.source === 'memory_os_files' ? raw.source : null
   const producer = raw.producer === 'keeper_librarian|keeper_memory_os_recall'
@@ -733,8 +722,7 @@ function decodeMemoryOsSnapshot(raw: unknown): MemoryOsTurnRecordSnapshot | null
   const factsRaw = isRecord(raw.facts) ? raw.facts : null
   const facts = decodeMemoryOsCount(raw.facts)
   if (
-    schema === null
-    || keeper === null
+    keeper === null
     || source === null
     || producer === null
     || !selection_policy
@@ -750,27 +738,21 @@ function decodeMemoryOsSnapshot(raw: unknown): MemoryOsTurnRecordSnapshot | null
   }
   const episodesCounts = decodeMemoryOsCount(episodesRaw)
   if (!episodesCounts) return null
-  if (!hasExactKeys(episodesRaw, ['shown', 'terminal_markers', 'items'])) {
+  if (!hasExactKeys(episodesRaw, ['shown', 'items'])) {
     return null
   }
   if (!hasExactKeys(factsRaw, ['shown', 'items'])) return null
-  const terminal_markers = asNumber(episodesRaw.terminal_markers)
   const episodes = decodeArray(episodesRaw.items, decodeMemoryOsEpisode)
   const factItems = decodeArray(factsRaw.items, decodeMemoryOsFact)
   if (
-    terminal_markers == null
-    || !Number.isSafeInteger(terminal_markers)
-    || terminal_markers < 0
-    || !episodes
+    !episodes
     || !factItems
   ) return null
   if (
     episodesCounts.shown !== episodes.length
-    || terminal_markers !== episodes.filter(episode => episode.terminal_marker !== null).length
     || facts.shown !== factItems.length
   ) return null
   return {
-    schema,
     keeper,
     source,
     producer,
@@ -781,7 +763,6 @@ function decodeMemoryOsSnapshot(raw: unknown): MemoryOsTurnRecordSnapshot | null
     read_errors,
     episodes: {
       ...episodesCounts,
-      terminal_markers,
       items: episodes,
     },
     facts: {

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -481,7 +481,6 @@ describe('keeper tool telemetry fetchers', () => {
         health: 'ok',
         stale_reason: null,
         memory_os: {
-          schema: 'keeper.memory_os.recall_observability.v2',
           keeper: 'keeper-alpha',
           source: 'memory_os_files',
           producer: 'keeper_librarian|keeper_memory_os_recall',
@@ -497,7 +496,7 @@ describe('keeper tool telemetry fetchers', () => {
           episodes_store: '.masc/config/keepers/keeper-alpha/episodes',
           recall_enabled: true,
           read_errors: [],
-          episodes: { shown: 0, terminal_markers: 0, items: [] },
+          episodes: { shown: 0, items: [] },
           facts: { shown: 0, items: [] },
         },
         entries: [
@@ -752,7 +751,6 @@ describe('decodeMemoryOsFact via fetchKeeperTurnRecords (RFC-keeper-memory-panel
       stale_reason: 'no_entries',
       entries: [],
       memory_os: {
-        schema: 'keeper.memory_os.recall_observability.v2',
         keeper: 'keeper-alpha',
         source: 'memory_os_files',
         producer: 'keeper_librarian|keeper_memory_os_recall',
@@ -768,7 +766,7 @@ describe('decodeMemoryOsFact via fetchKeeperTurnRecords (RFC-keeper-memory-panel
         episodes_store: '.masc/config/keepers/keeper-alpha/episodes',
         recall_enabled: true,
         read_errors: [],
-        episodes: { shown: 0, terminal_markers: 0, items: [] },
+        episodes: { shown: 0, items: [] },
         facts: {
           shown: 2,
           items: [
@@ -830,9 +828,11 @@ describe('decodeMemoryOsFact via fetchKeeperTurnRecords (RFC-keeper-memory-panel
     expect(result.memory_os.facts.items[0]?.claim).toBe('  exact claim bytes  ')
   })
 
-  it('rejects a non-current Memory OS schema token', async () => {
+  it('rejects the retired Memory OS schema field', async () => {
     const payload = turnRecordsPayload()
-    payload.memory_os.schema = 'keeper.memory_os.recall_observability.v0'
+    Object.assign(payload.memory_os, {
+      schema: 'keeper.memory_os.recall_observability.v2',
+    })
     stubTurnRecords(payload)
 
     await expect(fetchKeeperTurnRecords('keeper-alpha')).rejects.toThrow(
@@ -994,12 +994,10 @@ describe('decodeMemoryOsFact via fetchKeeperTurnRecords (RFC-keeper-memory-panel
     const payload = turnRecordsPayload()
     Object.assign(payload.memory_os.episodes, {
       shown: 1,
-      terminal_markers: 0,
       items: [{
         trace_id: 'episode-trace',
         generation: 1,
         created_at: 1_789_000_000,
-        terminal_marker: null,
         claim_count: 0,
         source_turn_range: {
           lo: Number.MAX_SAFE_INTEGER + 1,

--- a/dashboard/src/components/keeper-turn-inspector.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector.test.ts
@@ -96,7 +96,6 @@ function turnRecordsWithMemoryOs(): TurnRecordsResponse {
     count: 2,
     skipped_rows: 0,
     memory_os: {
-      schema: 'keeper.memory_os.recall_observability.v2',
       keeper: 'albini',
       source: 'memory_os_files',
       producer: 'keeper_librarian|keeper_memory_os_recall',
@@ -114,13 +113,11 @@ function turnRecordsWithMemoryOs(): TurnRecordsResponse {
       read_errors: [],
       episodes: {
         shown: 2,
-        terminal_markers: 1,
         items: [
           {
             trace_id: 'trace-active',
             generation: 7,
             created_at: 1_781_583_000,
-            terminal_marker: null,
             claim_count: 2,
             source_turn_range: [1, 6],
             summary: 'Active recall source used by the prompt.',
@@ -129,7 +126,6 @@ function turnRecordsWithMemoryOs(): TurnRecordsResponse {
             trace_id: 'trace-done',
             generation: 3,
             created_at: 1_781_580_000,
-            terminal_marker: 'handoff_complete',
             claim_count: 1,
             source_turn_range: null,
             summary: 'Terminal memory remains visible as source evidence.',
@@ -231,9 +227,8 @@ describe('KeeperMemoryOsRecallPanel', () => {
     expect(text).toContain('latest block')
     expect(text).toContain('3392B')
     expect(text).toContain('ep 2')
-    expect(text).toContain('terminal 1')
     expect(text).toContain('facts 0')
-    expect(text).toContain('terminal=handoff_complete')
+    expect(text).toContain('Terminal memory remains visible as source evidence.')
     expect(text).toContain('facts: .masc/config/keepers/albini.facts.jsonl')
     expect(text).toContain('episodes: .masc/config/keepers/albini/episodes')
   })

--- a/dashboard/src/components/keeper-turn-inspector.ts
+++ b/dashboard/src/components/keeper-turn-inspector.ts
@@ -129,11 +129,6 @@ function MemoryOsEpisodeRow({ episode }: { episode: MemoryOsEpisodeSummary }) {
         <span class="font-mono text-2xs text-[var(--color-fg-default)]">
           ${episode.trace_id} g${episode.generation.toString().padStart(4, '0')}
         </span>
-        ${episode.terminal_marker
-          ? html`<span class="rounded-[var(--r-1)] bg-[var(--accent-12)] px-1.5 py-0.5 text-3xs font-mono text-[var(--color-accent-fg)]">
-              terminal=${episode.terminal_marker}
-            </span>`
-          : null}
         <span class="text-3xs text-[var(--color-fg-disabled)]">${episode.claim_count} claims</span>
       </div>
       <div class="line-clamp-2 text-2xs leading-relaxed text-[var(--color-fg-muted)]">
@@ -173,9 +168,6 @@ function MemoryOsRecallSourcePanel({
         <div class="flex flex-wrap gap-2 text-3xs">
           <span class="font-mono text-[var(--color-fg-muted)]">
             ep ${snapshot.episodes.shown}
-          </span>
-          <span class="font-mono text-[var(--color-fg-muted)]">
-            terminal ${snapshot.episodes.terminal_markers}
           </span>
           <span class="font-mono text-[var(--color-fg-muted)]">
             facts ${snapshot.facts.shown}

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -47,7 +47,6 @@ vi.mock('../../api/dashboard', async (importOriginal) => {
       stale_reason: null,
       coverage_gaps: [],
       memory_os: {
-        schema: 'keeper.memory_os.recall_observability.v2',
         keeper: 'masc-improver',
         source: 'memory_os_files',
         producer: 'keeper_librarian|keeper_memory_os_recall',
@@ -63,7 +62,7 @@ vi.mock('../../api/dashboard', async (importOriginal) => {
         episodes_store: '.masc/config/keepers/masc-improver/episodes',
         recall_enabled: true,
         read_errors: [],
-        episodes: { shown: 0, current: 0, expired: 0, terminal_markers: 0, items: [] },
+        episodes: { shown: 0, current: 0, expired: 0, items: [] },
         facts: { shown: 0, current: 0, expired: 0, items: [] },
       },
       entries: [

--- a/dashboard/src/components/memory-inspector.test.ts
+++ b/dashboard/src/components/memory-inspector.test.ts
@@ -42,7 +42,6 @@ function turnRecordsPayload() {
     health: 'ok',
     stale_reason: null,
     memory_os: {
-      schema: 'keeper.memory_os.recall_observability.v2',
       keeper: 'masc-improver',
       source: 'memory_os_files',
       producer: 'keeper_librarian|keeper_memory_os_recall',
@@ -60,13 +59,11 @@ function turnRecordsPayload() {
       read_errors: [{ scope: 'facts', error: 'fact store decode failed' }],
       episodes: {
         shown: 2,
-        terminal_markers: 2,
         items: [
           {
             trace_id: 'trace-ep1',
             generation: 3,
             created_at: 1_789_900_000,
-            terminal_marker: 'handoff_complete',
             claim_count: 4,
             source_turn_range: { lo: 1, hi: 28 },
             summary: '리텐션 코호트 정의를 정리하고 amplitude 쿼리를 표로 캐시함.',
@@ -75,7 +72,6 @@ function turnRecordsPayload() {
             trace_id: 'trace-diagnostic',
             generation: 4,
             created_at: 1_789_950_000,
-            terminal_marker: 'diagnostic',
             claim_count: 1,
             source_turn_range: null,
             summary: 'provider response diagnostic',
@@ -278,11 +274,10 @@ describe('MemoryInspector — one-keeper scope (real data)', () => {
     expect(container.querySelector('.mem-pin')).toBeFalsy()
   })
 
-  it('renders the compaction section from real episodes (summary + terminal marker)', async () => {
+  it('renders the compaction section from real episodes', async () => {
     stubFetch()
     const { container } = renderInspector()
     await waitFor(() => expect(container.textContent).toContain('리텐션 코호트 정의'))
-    expect(container.textContent).toContain('terminal=handoff_complete')
     expect(container.textContent).toContain('4 claims')
     // source_turn_range projected → episode subtitle shows the compacted turn span.
     expect(container.querySelector('.mem-tl-range')?.textContent).toBe('turn 1–28')

--- a/dashboard/src/components/memory-inspector.ts
+++ b/dashboard/src/components/memory-inspector.ts
@@ -10,7 +10,7 @@
 // Section data sources (RFC-keeper-memory-panel-real-data §4; hybrid treatment confirmed 2026-06-24):
 //   컨텍스트 구성        ← real prompt-assembly block bytes (entries[latest].blocks)
 //   장기 메모리 스토어    ← real memory_os.facts.items (typed category, provenance)
-//   압축 유지·요약        ← real memory_os.episodes.items (summary + terminal_marker)
+//   압축 유지·요약        ← real memory_os.episodes.items
 //   최근 회상·주입        ← real memory_os_recall prompt blocks (entries[*].blocks)
 // Any future-only section must render an honest disclosure rather than fabricated
 // rows (no-stub): disclose absence instead of faking presence.
@@ -529,9 +529,6 @@ function EpisodeRow({ episode }: { episode: MemoryOsEpisodeSummary }) {
         </div>
         <div class="mem-store-meta">
           <span class="mono">${episode.claim_count} claims</span>
-          ${episode.terminal_marker
-            ? html`<span class="mem-tag">terminal=${episode.terminal_marker}</span>`
-            : null}
           <span class="mem-src mono">${episode.trace_id}</span>
         </div>
       </div>

--- a/docs/rfc/RFC-0247-purge-implementation-plan.md
+++ b/docs/rfc/RFC-0247-purge-implementation-plan.md
@@ -113,7 +113,9 @@ The compiler then forces edits at every exhaustive match — exactly the no-sile
 3. A `lesson` claim MUST contain the corrective action (do Y / fix is Z), not just "X failed."
 4. Update the JSON schema `category` enum to include the two tokens.
 
-`terminal_marker` is a distractor — do NOT repurpose it (episode-level, untyped `string`, producer-hardcoded `None` at `keeper_librarian.ml:261`). Success/failure is claim-level and belongs on `category`.
+`terminal_marker` was removed rather than repurposed: it was episode-level,
+untyped, and the producer only emitted `None`. Success/failure remains
+claim-level and belongs on `category`.
 
 ---
 

--- a/docs/rfc/RFC-keeper-memory-panel-real-data.md
+++ b/docs/rfc/RFC-keeper-memory-panel-real-data.md
@@ -90,7 +90,7 @@ that are legitimate against the existing memory model.
 | store — `uses` (`access_count`) | Deleted (RFC-0247). | **Drop.** |
 | store — `lastUsed` (`last_accessed`) | Deleted (RFC-0247). | **Drop** (use `reference_time` age instead). |
 | 핀 고정 사실 (operator pin: by/tag/at) | No mechanism. Pinning = operator judgment annotation; aligns with RFC-0247 ("value is judgment") and is **not** a score. | **New feature, P2** (write path; immutable annotation keyed by `claim_id`). |
-| 회상·주입 타임라인 (op + tok delta) | No per-event log. But episodes ARE real memory-shaping events (`created_at`, `terminal_marker`, `source_turn_range`, `claim_count`); `keeper_compact_audit` holds `before/after_tokens`, `tokens_freed`. | **Adapt/extend, P3**: derive a real timeline from episodes (+ compact audit join). Not a synthetic op log. |
+| 회상·주입 타임라인 (op + tok delta) | No per-event log. But episodes ARE real memory-shaping events (`created_at`, `source_turn_range`, `claim_count`); `keeper_compact_audit` holds `before/after_tokens`, `tokens_freed`. | **Adapt/extend, P3**: derive a real timeline from episodes (+ compact audit join). Not a synthetic op log. |
 | 압축 유지/요약/폐기 (3-column items) | `episode.episode_summary` (summarized), `preserved_tool_refs` (kept refs), `open_items`/`constraints` (kept), `source_turn_range`; compact audit token aggregates. Item-level kept/dropped lists do not exist. | **Adapt, P3**: map to real episode fields; "dropped" derived from range − kept. No fabricated item lists. |
 
 Summary: **2 sections fully real after a 1-field serializer add (composition, store), 1 new legitimate
@@ -229,7 +229,7 @@ fact's identity:
 Replace the fabricated op-timeline with a timeline derived from real events:
 
 - **Episodes** (already served, `memory_os.episodes.items`): each is a compaction/summary boundary —
-  `created_at`, `terminal_marker`, `source_turn_range`, `claim_count`, `summary`. Rendered as
+  `created_at`, `source_turn_range`, `claim_count`, `summary`. Rendered as
   `compact`/`summarize` events.
 - **Compact audit** (`keeper_compact_audit`: `before_tokens`, `after_tokens`, `tokens_freed`): joined
   to give the real token delta per compaction (the design's `tok` column, now measured not invented).

--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -69,8 +69,9 @@ let run
   (* Memory OS librarian extraction: opt-in, provider-backed, best-effort. Its
      own lane unit, separate from [det_write_series] above. *)
   let librarian_series () =
+    let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
     let librarian_input : Keeper_librarian.input =
-      { trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id
+      { turn_ref = Ids.Turn_ref.make ~trace_id ~absolute_turn:turn
       ; messages = librarian_messages
       }
     in

--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -5,7 +5,7 @@ open Keeper_memory_os_types
 module Canonical_tool = Agent_sdk.Canonical_tool
 
 type input =
-  { trace_id : string
+  { turn_ref : Ids.Turn_ref.t
   ; messages : Agent_sdk.Types.message list
   }
 
@@ -239,6 +239,7 @@ let episode_of_json_result ?now ~generation (inp : input) (json : Yojson.Safe.t)
       (* NDT-OK: extraction timestamps are provenance/retention metadata only. *)
       Unix.gettimeofday ()
   in
+  let trace_id = Ids.Turn_ref.trace_id inp.turn_ref in
   match json with
   | `Assoc fields ->
     (match first_unexpected_field ~allowed:wire_episode_fields fields with
@@ -252,14 +253,14 @@ let episode_of_json_result ?now ~generation (inp : input) (json : Yojson.Safe.t)
              (match
                 traverse
                   (fact_of_json
-                     ~trace_id:inp.trace_id
+                     ~trace_id
                      ~messages:inp.messages
                      ~now)
                   claim_items
               with
               | Some claims when claim_identities_are_unique claims ->
                 Ok
-                  { trace_id = inp.trace_id
+                  { trace_id
                   ; generation
                   ; episode_summary
                   ; claims

--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -266,7 +266,6 @@ let episode_of_json_result ?now ~generation (inp : input) (json : Yojson.Safe.t)
                   ; source_turn_range =
                       Keeper_memory_os_types.source_turn_range_of_facts claims
                   ; created_at = now
-                  ; terminal_marker = None
                   }
               | Some _ | None -> Error Claim_schema_mismatch))
         | _ -> Error Missing_required_fields))

--- a/lib/keeper/keeper_librarian.mli
+++ b/lib/keeper/keeper_librarian.mli
@@ -7,7 +7,7 @@
 
 (** Input bundle for one librarian extraction. *)
 type input =
-  { trace_id : string
+  { turn_ref : Ids.Turn_ref.t
   ; messages : Agent_sdk.Types.message list
   }
 

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -4,6 +4,10 @@ module Exact_output = Agent_sdk.Exact_output
 
 let exact_lane_id = "librarian_exact"
 
+let input_trace_id (inp : Keeper_librarian.input) =
+  Ids.Turn_ref.trace_id inp.turn_ref
+;;
+
 let enabled () =
   (* Default on: a keeper without conversation ingestion is the pathology
      the Memory OS exists to fix (2026-06-12 diagnosis, issue #20909).
@@ -894,7 +898,7 @@ let extract_with_exact_output_classified_unlocked
       preflight_exact_flow_state
         ~keepers_dir
         ~keeper_id
-        ~trace_id:inp.trace_id
+        ~trace_id:(input_trace_id inp)
         ~generation
       |> Result.map_error (fun error -> Exact_setup_failed error)
     in
@@ -938,7 +942,7 @@ let extract_with_exact_output_classified_unlocked
         persist_exact_flow_state
           ~keepers_dir
           ~keeper_id
-          ~trace_id:inp.trace_id
+          ~trace_id:(input_trace_id inp)
           ~generation
           Exact_flow_started
         |> Result.map_error (fun detail ->
@@ -956,7 +960,7 @@ let extract_with_exact_output_classified_unlocked
           persist_exact_flow_state
             ~keepers_dir
             ~keeper_id
-            ~trace_id:inp.trace_id
+            ~trace_id:(input_trace_id inp)
             ~generation
             (Exact_candidate_advance_committed
                { candidate = attempt_receipt_json previous
@@ -967,7 +971,7 @@ let extract_with_exact_output_classified_unlocked
         persist_exact_flow_state
           ~keepers_dir
           ~keeper_id
-          ~trace_id:inp.trace_id
+          ~trace_id:(input_trace_id inp)
           ~generation
           (Exact_candidate_bound (attempt_receipt_json candidate))
       in
@@ -985,7 +989,7 @@ let extract_with_exact_output_classified_unlocked
         persist_exact_flow_state
           ~keepers_dir
           ~keeper_id
-          ~trace_id:inp.trace_id
+          ~trace_id:(input_trace_id inp)
           ~generation
           (Exact_candidate_advance_committed
              { candidate = attempt_receipt_json candidate
@@ -1011,7 +1015,7 @@ let extract_with_exact_output_classified_unlocked
       persist_exact_flow_state
         ~keepers_dir
         ~keeper_id
-        ~trace_id:inp.trace_id
+        ~trace_id:(input_trace_id inp)
         ~generation
         (Exact_oas_success (attempt_receipt_json candidate))
     with
@@ -1021,7 +1025,7 @@ let extract_with_exact_output_classified_unlocked
          persist_exact_flow_state
            ~keepers_dir
            ~keeper_id
-           ~trace_id:inp.trace_id
+           ~trace_id:(input_trace_id inp)
            ~generation
            (Exact_domain_valid (attempt_receipt_json candidate))
        with
@@ -1064,7 +1068,7 @@ let extract_with_exact_output_classified_unlocked
          persist_exact_execution_terminal
            ~keepers_dir
            ~keeper_id
-           ~trace_id:inp.trace_id
+           ~trace_id:(input_trace_id inp)
            ~generation
            error
        with
@@ -1094,7 +1098,7 @@ let extract_with_exact_output_classified_unlocked
          persist_exact_flow_state
            ~keepers_dir
            ~keeper_id
-           ~trace_id:inp.trace_id
+           ~trace_id:(input_trace_id inp)
            ~generation
            (Exact_domain_invalid
               { candidate = attempt_receipt_json candidate; parse_error })
@@ -1123,7 +1127,7 @@ let extract_with_exact_output_classified
       ~generation
       inp
   =
-  if String.equal (String.trim inp.Keeper_librarian.trace_id) ""
+  if String.equal (String.trim (input_trace_id inp)) ""
   then Error (Exact_setup_failed Exact_trace_id_invalid)
   else if generation < 0
   then Error (Exact_setup_failed (Exact_generation_invalid generation))
@@ -1234,12 +1238,12 @@ let extract_and_append_with_exact_output_classified
   : (Keeper_memory_os_types.episode, extraction_error) result =
   match clock with
   | None -> Error Execution_clock_unavailable
-  | Some _ when String.equal (String.trim inp.Keeper_librarian.trace_id) "" ->
+  | Some _ when String.equal (String.trim (input_trace_id inp)) "" ->
     Error (Exact_setup_failed Exact_trace_id_invalid)
   | Some _ when generation_floor < 0 ->
     Error (Exact_setup_failed (Exact_generation_invalid generation_floor))
   | Some clock ->
-    let trace_id = inp.Keeper_librarian.trace_id in
+    let trace_id = input_trace_id inp in
     let keepers_dir =
       Config_dir_resolver.keepers_dir_for_base_path ~base_path
     in
@@ -1318,7 +1322,8 @@ let run_best_effort
      (the messages remain in the window for the next due turn). The cadence
      counter is scoped to the active trace so a rollover does not inherit the
      previous trace's schedule. *)
-  if enabled () && cadence_due ~keeper_id ~trace_id:inp.trace_id
+  let trace_id = input_trace_id inp in
+  if enabled () && cadence_due ~keeper_id ~trace_id
   then (
     try
       match Eio_context.get_net_opt (), Eio_context.get_clock_opt () with
@@ -1333,7 +1338,7 @@ let run_best_effort
              inp
          with
          | Ok episode ->
-           cadence_record_success ~keeper_id ~trace_id:inp.trace_id;
+           cadence_record_success ~keeper_id ~trace_id;
            Log.Keeper.info
              ~keeper_name:keeper_id
              "memory os librarian wrote episode trace_id=%s generation=%d claims=%d"
@@ -1346,7 +1351,7 @@ let run_best_effort
              ~labels:[ "keeper", keeper_id; "site", "memory_os_librarian" ]
              ();
            if should_record_cadence_backoff_after_error err
-           then cadence_record_attempt ~keeper_id ~trace_id:inp.trace_id;
+           then cadence_record_attempt ~keeper_id ~trace_id;
            Log.Keeper.warn
              ~keeper_name:keeper_id
              "memory os librarian failed lane=%s: %s; cadence deferred=%b"

--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -30,16 +30,10 @@ let render_fact fact =
 ;;
 
 let render_episode episode =
-  let terminal =
-    match episode.terminal_marker with
-    | None -> ""
-    | Some marker -> Printf.sprintf " terminal=%s" marker
-  in
   Printf.sprintf
-    "- [%s g%04d%s] %s"
+    "- [%s g%04d] %s"
     episode.trace_id
     episode.generation
-    terminal
     episode.episode_summary
 ;;
 

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -24,7 +24,6 @@ let wire_field_source_turn_range = "source_turn_range"
 let wire_field_lo = "lo"
 let wire_field_hi = "hi"
 let wire_field_created_at = "created_at"
-let wire_field_terminal_marker = "terminal_marker"
 
 module Wire_field_set = Set.Make (String)
 
@@ -70,7 +69,6 @@ let episode_wire_fields =
     ; wire_field_claims
     ; wire_field_source_turn_range
     ; wire_field_created_at
-    ; wire_field_terminal_marker
     ]
 ;;
 
@@ -188,7 +186,6 @@ type episode =
   ; claims : fact list
   ; source_turn_range : (int * int) option
   ; created_at : float
-  ; terminal_marker : string option
   }
 
 (* ---------- JSON codecs ---------- *)
@@ -406,8 +403,6 @@ let episode_to_json (e : episode) =
   then invalid_arg "memory episode summary must be non-empty";
   if not (Float.is_finite e.created_at)
   then invalid_arg "memory episode created_at must be finite";
-  if not (optional_non_empty_string e.terminal_marker)
-  then invalid_arg "memory episode terminal_marker must be non-empty";
   if
     not
       (List.for_all
@@ -433,10 +428,7 @@ let episode_to_json (e : episode) =
        , `List (List.rev (List.rev_map fact_to_json e.claims)) )
      ; wire_field_created_at, `Float e.created_at
      ]
-    @ range_json
-    @ (match e.terminal_marker with
-        | Some marker -> [ wire_field_terminal_marker, `String marker ]
-        | None -> []))
+    @ range_json)
 ;;
 
 let facts_of_json values =
@@ -448,13 +440,6 @@ let facts_of_json values =
        | None -> None)
   in
   loop [] values
-;;
-
-let optional_string_json_field key fields =
-  match List.assoc_opt key fields with
-  | None -> Some None
-  | Some (`String value) -> Some (Some value)
-  | Some _ -> None
 ;;
 
 let source_turn_range_field fields =
@@ -480,22 +465,19 @@ let episode_of_json (json : Yojson.Safe.t) =
           | Some (`List claim_items) -> facts_of_json claim_items
           | Some _ | None -> None)
        , source_turn_range_field fields
-       , json_float_field wire_field_created_at fields
-       , optional_string_json_field wire_field_terminal_marker fields )
+       , json_float_field wire_field_created_at fields )
      with
      | ( Some trace_id
        , Some generation
        , Some episode_summary
        , Some claims
        , Some source_turn_range
-       , Some created_at
-       , Some terminal_marker ) ->
+       , Some created_at ) ->
        if
          non_empty_string trace_id
          && generation >= 0
          && non_empty_string episode_summary
          && Float.is_finite created_at
-         && optional_non_empty_string terminal_marker
          && List.for_all
               (fun fact -> String.equal fact.source.trace_id trace_id)
               claims
@@ -508,7 +490,6 @@ let episode_of_json (json : Yojson.Safe.t) =
            ; claims
            ; source_turn_range
            ; created_at
-           ; terminal_marker
            }
        else None
      | _ -> None)

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -26,7 +26,6 @@ val wire_field_source_turn_range : string
 val wire_field_lo : string
 val wire_field_hi : string
 val wire_field_created_at : string
-val wire_field_terminal_marker : string
 
 (** Episode-object fields accepted from the librarian and rendered in retry
     prompts. *)
@@ -101,7 +100,6 @@ type episode =
   ; claims : fact list
   ; source_turn_range : (int * int) option
   ; created_at : float
-  ; terminal_marker : string option
   }
 
 (** Producer identity SSOT. A non-empty [claim_id] is preserved exactly. When it

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -153,10 +153,6 @@ let state_diagram_runtime_fsm_mermaid
     ()
 ;;
 
-let memory_os_count pred xs =
-  List.fold_left (fun count value -> if pred value then count + 1 else count) 0 xs
-;;
-
 let keeper_chat_allowed_trace_ids (m : Keeper_meta_contract.keeper_meta) =
   Keeper_id.Trace_id.to_string m.runtime.trace_id :: m.runtime.trace_history
   |> Json_util.dedupe_keep_order
@@ -189,7 +185,6 @@ let memory_os_episode_json (episode : Keeper_memory_os_types.episode) =
     [ "trace_id", `String episode.trace_id
     ; "generation", `Int episode.generation
     ; "created_at", `Float episode.created_at
-    ; "terminal_marker", json_string_opt episode.terminal_marker
     ; "claim_count", `Int (List.length episode.claims)
     ; ( "source_turn_range"
       , match episode.source_turn_range with
@@ -259,15 +254,8 @@ let memory_os_dashboard_json_unlocked ~keepers_dir ~keeper_id =
     Keeper_memory_os_io.facts_path_for_keepers_dir ~keepers_dir ~keeper_id
   in
   let episodes_store = Filename.concat (Filename.concat keepers_dir keeper_id) "episodes" in
-  let terminal_marker_count =
-    memory_os_count
-      (fun (episode : Keeper_memory_os_types.episode) ->
-         Option.is_some episode.terminal_marker)
-      episodes
-  in
   `Assoc
-    [ "schema", `String "keeper.memory_os.recall_observability.v2"
-    ; "keeper", `String keeper_id
+    [ "keeper", `String keeper_id
     ; "source", `String "memory_os_files"
     ; "producer", `String "keeper_librarian|keeper_memory_os_recall"
     ; ( "selection_policy"
@@ -284,7 +272,6 @@ let memory_os_dashboard_json_unlocked ~keepers_dir ~keeper_id =
     ; ( "episodes"
       , `Assoc
           [ "shown", `Int (List.length episodes)
-          ; "terminal_markers", `Int terminal_marker_count
           ; "items", `List (List.map memory_os_episode_json episodes)
           ] )
     ; ( "facts"

--- a/reports/MASC-LIBRARIAN-MEMORY-OS-ADVERSARIAL-AUDIT-2026-07-30.html
+++ b/reports/MASC-LIBRARIAN-MEMORY-OS-ADVERSARIAL-AUDIT-2026-07-30.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="ko-KR" xml:lang="ko-KR">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
@@ -240,16 +240,14 @@
 <header id="title-block-header">
 <h1 class="title">MASC Librarian / Memory OS 적대적 감사 보고서</h1>
 </header>
-<section id="masc-librarian--memory-os-적대적-감사-보고서"
-class="level1">
-<h1>MASC Librarian / Memory OS 적대적 감사 보고서</h1>
+<h1 id="masc-librarian-memory-os-적대적-감사-보고서">MASC Librarian /
+Memory OS 적대적 감사 보고서</h1>
 <p>작성일: 2026-07-30</p>
 <p>대상 저장소:
 <code>/Users/dancer/me/workspace/yousleepwhen/masc</code></p>
 <p>라이브 상태 루트: <code>/Users/dancer/me/.masc</code> 판정:
 <strong>BLOCK / NO-GO</strong></p>
-<section id="1-executive-summary" class="level2">
-<h2>1. Executive Summary</h2>
+<h2 id="executive-summary">1. Executive Summary</h2>
 <p>Librarian과 Memory OS는 라이브 런타임에서 실제로 동작한다.</p>
 <ul>
 <li>Keeper turn마다 <code>memory_os_recall</code> 블록이 prompt에
@@ -286,6 +284,14 @@ expiry GC·sanity sweep·maintenance fiber와 dashboard TTL projection까지
 증명되지 않았고, canonical TurnRef·recency selection·latest-wins·
 echo/dedupe 휴리스틱·비원자 publication이 남으므로 최종 판정은 계속
 NO-GO다.</p>
+<p>2026-07-30 16:53 KST 후속 hard cut은 production producer가 항상
+<code>None</code>만 기록하던 <code>terminal_marker</code>를 episode
+type/codec/recall/dashboard/viewer/test에서 완전히 제거했다. dashboard의
+<code>terminal_markers</code> 파생 카운트와 실질적인 호환 권한이 없던
+versioned <code>schema</code> 문자열도 함께 제거했다. 새 closed
+decoder는 이 사망 필드가 다시 들어오면 unknown field로 거부한다. 이
+slice는 원자 publication의 선행 정리이며, atomic Memory authority 자체가
+완료됐다는 뜻은 아니다.</p>
 <p>가장 중요한 차단 사유는 다음과 같다.</p>
 <ol type="1">
 <li>사용되지 않는 canonical store와 실제 JSONL store가 병존한다.</li>
@@ -310,11 +316,8 @@ projection contract를 만든다.</li>
 <p>따라서 새 Gate나 retrieval 기능을 추가하기 전에 다음 순서로 기반을
 바로잡아야 한다.</p>
 <p><code>Fresh-state persistence SSOT → Turn identity SSOT → per-Keeper durable Librarian FIFO → atomic revision/failure contract → semantic context projection</code></p>
-</section>
-<section id="2-감사-범위와-증거-계층" class="level2">
-<h2>2. 감사 범위와 증거 계층</h2>
-<section id="21-source" class="level3">
-<h3>2.1 Source</h3>
+<h2 id="감사-범위와-증거-계층">2. 감사 범위와 증거 계층</h2>
+<h3 id="source">2.1 Source</h3>
 <ul>
 <li>집중 정적 감사 SHA:
 <code>8c4dae264e6b1d03708029718f868efbb3c2613b</code></li>
@@ -322,6 +325,8 @@ projection contract를 만든다.</li>
 base: <code>407ae5bb92509f06bfb6fc5614e8539e230b2902</code></li>
 <li>후속 구현 branch:
 <code>refactor/memory-current-only-hard-cut-20260730</code></li>
+<li>사망 필드/원자 publication 후속 branch:
+<code>refactor/memory-atomic-publication-20260730</code></li>
 <li>current-only 1차 source slice:
 <code>6f8bf76a816d822ca0165b6a8c42986b3d466e5c</code></li>
 <li>TTL authority 제거 2차 source slice:
@@ -332,9 +337,7 @@ base: <code>407ae5bb92509f06bfb6fc5614e8539e230b2902</code></li>
 merge/reopen하지 않고 새 branch와 Draft PR로 증명한다. 어느 slice도
 main/CI/runtime 상태로 간주하지 않는다.</li>
 </ul>
-</section>
-<section id="22-runtime" class="level3">
-<h3>2.2 Runtime</h3>
+<h3 id="runtime">2.2 Runtime</h3>
 <ul>
 <li>PID: <code>25820</code></li>
 <li>listener: <code>127.0.0.1:8935</code></li>
@@ -351,9 +354,7 @@ main/CI/runtime 상태로 간주하지 않는다.</li>
 값은 binary-embedded commit 증거가 아니다. 실행 시작 시 repo HEAD와
 binary mtime은 일치하지만 정확한 deployed binary SHA는 미증명으로
 남긴다.</p>
-</section>
-<section id="23-ci--변경" class="level3">
-<h3>2.3 CI / 변경</h3>
+<h3 id="ci-변경">2.3 CI / 변경</h3>
 <ul>
 <li>최초 감사에서는 코드 수정이나 runtime mutation을 하지 않았다.</li>
 <li>후속 구현 worktree에서는 dead Store, Memory <code>claim_kind</code>,
@@ -377,12 +378,16 @@ build artifact가 없어 실행할 수 없었다. 이를 위해 로컬 Dune buil
 않으며 새 PR CI에서 증명한다.</li>
 <li>source, CI, merge, deployment, runtime 증거를 서로 분리했다.</li>
 </ul>
-</section>
-</section>
-<section id="3-현재-open-pr과의-관계" class="level2">
-<h2>3. 현재 Open PR과의 관계</h2>
+<h2 id="현재-open-pr과의-관계">3. 현재 Open PR과의 관계</h2>
 <p>확인 시각: 2026-07-30 16:05 KST</p>
 <table>
+<colgroup>
+<col style="width: 20%" />
+<col style="width: 20%" />
+<col style="width: 20%" />
+<col style="width: 20%" />
+<col style="width: 20%" />
+</colgroup>
 <thead>
 <tr>
 <th>PR</th>
@@ -451,13 +456,14 @@ facts→episode→event publication/TurnRef/FIFO는 해결하지
 <td><a href="https://github.com/jeong-sik/masc/pull/26440">#26440</a>
 <code>hard-cut retired Memory OS authority</code></td>
 <td>본 감사 후속 구현</td>
-<td><strong>Draft</strong>, branch
-<code>refactor/memory-current-only-hard-cut-20260730</code>, current
-<code>origin/main</code> rebase 뒤 <code>MERGEABLE/BLOCKED</code>; CI
-생성 대기</td>
-<td>1·2차 hard-cut과 본 보고서, wire v2/dead facade 보완을 함께
-검증한다.</td>
-<td><strong>cold cutover·CI·runtime 증명 전 do-not-merge</strong></td>
+<td><strong>Merged</strong>, head
+<code>120dcc8fbc905aa3ea0c4651dc1f0a19fcfb7767</code>, squash merge
+<code>8701b4a9e4cec823c535912374ae11759125f596</code></td>
+<td>1·2차 hard-cut과 본 보고서를 main에 반영했다. 그러나 merge 시점에
+exact-head <code>Build and Test</code>, Dashboard, ocamlformat, CI
+Gate가 아직 실행 중이었고 merge 뒤 취소됐다.</td>
+<td><strong>source hard cut은 병합됐으나 exact-head full CI green 증거
+없음. cold cutover·runtime 증명 전 NO-GO</strong></td>
 </tr>
 <tr>
 <td><a href="https://github.com/jeong-sik/masc/pull/26436">#26436</a>
@@ -494,8 +500,7 @@ authority도 추가 삭제했다.</td>
 </tr>
 </tbody>
 </table>
-<section id="31-pr-26324가-해결하는-부분" class="level3">
-<h3>3.1 PR #26324가 해결하는 부분</h3>
+<h3 id="pr-26324가-해결하는-부분">3.1 PR #26324가 해결하는 부분</h3>
 <p>현재 exact-head patch에서 확인한 직접 개선:</p>
 <ul>
 <li><code>keeper_memory_os_consolidation_runtime.ml</code> 전체
@@ -512,9 +517,8 @@ authority도 추가 삭제했다.</td>
 </ul>
 <p>따라서 본 보고서의 <strong>P0-6 destructive consolidation</strong>은
 #26324 merge로 제거됐다.</p>
-</section>
-<section id="32-pr-26324가-해결하지-않는-부분" class="level3">
-<h3>3.2 PR #26324가 해결하지 않는 부분</h3>
+<h3 id="pr-26324가-해결하지-않는-부분">3.2 PR #26324가 해결하지 않는
+부분</h3>
 <p>merge된 main에 그대로 남는 항목:</p>
 <ul>
 <li><code>Keeper_memory_os_store</code>와 JSONL store의 이중
@@ -546,9 +550,7 @@ row/field는 current decoder가 명시적으로 거부한다. 이는 아직
 main/CI/runtime 증거가 아니며, recall budget/recency, echo/dedupe,
 latest-wins, production Memory authority·atomic receipt·Turn identity
 문제는 그대로 남는다.</p>
-</section>
-<section id="33-pr-26410의-정확한-경계" class="level3">
-<h3>3.3 PR #26410의 정확한 경계</h3>
+<h3 id="pr-26410의-정확한-경계">3.3 PR #26410의 정확한 경계</h3>
 <p>#26410은 다음 측면에서 유용하다.</p>
 <ul>
 <li>chat/autonomous admission authority를 turn mutex 하나로 축소</li>
@@ -589,10 +591,7 @@ FSM이다.</p>
 별도 domain concept가 되어서는 안 된다. Busy Keeper는 현재 활동을
 계속하고, 수신 acknowledgement 또는 다음 event tail로 입력을 소비해야
 한다.</p>
-</section>
-</section>
-<section id="4-실제-호출-흐름" class="level2">
-<h2>4. 실제 호출 흐름</h2>
+<h2 id="실제-호출-흐름">4. 실제 호출 흐름</h2>
 <pre class="mermaid"><code>flowchart TD
     A[Keeper turn admission] --&gt; B[Memory OS JSONL read]
     B --&gt; C[recency/count/byte selection]
@@ -615,11 +614,9 @@ FSM이다.</p>
     R --&gt; S[prompt-only JSON provider call]
     S --&gt; T[partial plan salvage/apply]
     T --&gt; N</code></pre>
-</section>
-<section id="5-p0-findings" class="level2">
-<h2>5. P0 Findings</h2>
-<section id="p0-1-persistence-authority가-둘이다" class="level3">
-<h3>P0-1. Persistence authority가 둘이다</h3>
+<h2 id="p0-findings">5. P0 Findings</h2>
+<h3 id="p0-1.-persistence-authority가-둘이다">P0-1. Persistence
+authority가 둘이다</h3>
 <p><code>lib/keeper/keeper_memory_os_store.mli:1</code>은 자신을
 <code>Canonical, fresh-state-only Memory OS persistence</code>로
 선언하고 HEAD를 sole mutable authority로 규정한다.</p>
@@ -644,10 +641,8 @@ publish</li>
 worktree에서 삭제했다. 이로써 거짓 canonical authority는 제거됐지만,
 <code>Keeper_memory_os_io</code>의 facts/episode/event publication이
 아직 하나의 atomic commit/receipt가 아니므로 G0 완료는 아니다.</p>
-</section>
-<section id="p0-2-legacymigration-surface가-명시적으로-존재한다"
-class="level3">
-<h3>P0-2. Legacy/migration surface가 명시적으로 존재한다</h3>
+<h3 id="p0-2.-legacymigration-surface가-명시적으로-존재한다">P0-2.
+Legacy/migration surface가 명시적으로 존재한다</h3>
 <p><code>lib/keeper/keeper_memory_os_types.mli:5</code>:</p>
 <blockquote>
 <p>All records carry a schema_version to support future migrations.</p>
@@ -680,10 +675,8 @@ evidence는 provider dispatch 전에 typed setup failure로 거부한다. 과거
 journal을 읽거나 옮기는 compatibility/migration 경로는 없다. 다만 live
 root가 모두 retired schema이므로 fresh-state cold reset/reseed와 새
 schema write→restart→recall 증거 전에는 배포할 수 없다.</p>
-</section>
-<section id="p0-3-turn-identity-ssot가-실제-데이터에서-깨진다"
-class="level3">
-<h3>P0-3. Turn identity SSOT가 실제 데이터에서 깨진다</h3>
+<h3 id="p0-3.-turn-identity-ssot가-실제-데이터에서-깨진다">P0-3. Turn
+identity SSOT가 실제 데이터에서 깨진다</h3>
 <p>동일 <code>(trace_id, absolute_turn)</code>에 서로 다른 prompt block
 digest가 여러 번 append됐다.</p>
 <ul>
@@ -705,9 +698,8 @@ digest가 여러 번 append됐다.</p>
 전파</li>
 <li>timestamp fuzzy join 금지</li>
 </ul>
-</section>
-<section id="p0-4-손상된-fact가-무음으로-사라진다" class="level3">
-<h3>P0-4. 손상된 fact가 무음으로 사라진다</h3>
+<h3 id="p0-4.-손상된-fact가-무음으로-사라진다">P0-4. 손상된 fact가
+무음으로 사라진다</h3>
 <p><code>lib/keeper/keeper_memory_os_io.ml:489-506</code>:</p>
 <ul>
 <li>JSON parse error → <code>None</code></li>
@@ -734,10 +726,9 @@ context로 렌더링하고, dashboard와 fleet health는
 consumer도 item을 <code>filter</code>하지 않고 closed payload 전체를
 거부한다. 마지막 성공 projection과 stale generation/commit receipt는
 아직 없으므로 G5/G6 전체 완료는 아니다.</p>
-</section>
-<section id="p0-5-context-management가-고정-수치와-문자열-휴리스틱이다"
-class="level3">
-<h3>P0-5. Context management가 고정 수치와 문자열 휴리스틱이다</h3>
+<h3
+id="p0-5.-context-management가-고정-수치와-문자열-휴리스틱이다">P0-5.
+Context management가 고정 수치와 문자열 휴리스틱이다</h3>
 <p>현재 recall:</p>
 <ul>
 <li>max facts 500</li>
@@ -808,10 +799,9 @@ state 7–30</li>
 포함</li>
 <li>원 ledger/store를 수정하거나 대체하지 않음</li>
 </ul>
-</section>
-<section id="p0-6-consolidation이-부분-모델-출력을-파괴적으로-적용한다"
-class="level3">
-<h3>P0-6. Consolidation이 부분 모델 출력을 파괴적으로 적용한다</h3>
+<h3
+id="p0-6.-consolidation이-부분-모델-출력을-파괴적으로-적용한다">P0-6.
+Consolidation이 부분 모델 출력을 파괴적으로 적용한다</h3>
 <p><code>lib/keeper/keeper_memory_os_consolidation.ml:108-190</code>:</p>
 <ul>
 <li>malformed index item을 <code>filter_map</code></li>
@@ -833,15 +823,20 @@ class="level3">
 <p>#26324는 이 subsystem 전체를 삭제하므로 이 finding의 직접 해결
 후보다. 그러나 #26324가 merge되기 전에는 live P0이며, merge 이후에도
 나머지 P0는 그대로다.</p>
-</section>
-<section
-id="p0-7-claim_kind-valid_until과-사망-field가-context와-분리된-authority다"
-class="level3">
-<h3>P0-7. <code>claim_kind</code>, <code>valid_until</code>과 사망
-field가 context와 분리된 authority다</h3>
+<h3
+id="p0-7.-claim_kind-valid_until과-사망-field가-context와-분리된-authority다">P0-7.
+<code>claim_kind</code>, <code>valid_until</code>과 사망 field가
+context와 분리된 authority다</h3>
 <p><code>claim_kind</code>와 <code>valid_until</code>은 dead field는
 아니다. 오히려 더 위험하게 load-bearing policy field다.</p>
 <table>
+<colgroup>
+<col style="width: 20%" />
+<col style="width: 20%" />
+<col style="width: 20%" />
+<col style="width: 20%" />
+<col style="width: 20%" />
+</colgroup>
 <thead>
 <tr>
 <th>Field</th>
@@ -936,12 +931,10 @@ fiber와 TTL dashboard를 삭제했다. retired TTL field와 category는 current
 decoder에서 거부된다. 따라서 <strong>source finding은
 해결</strong>됐지만, fresh-state cutover와 새 exact-head CI/runtime
 증거가 없어 release finding은 아직 해결되지 않았다.</p>
-</section>
-<section
-id="p0-8-park와-lease가-keeper-진행을-제약하는-별도-lifecycle이-됐다"
-class="level3">
-<h3>P0-8. <code>park</code>와 <code>lease</code>가 Keeper 진행을
-제약하는 별도 lifecycle이 됐다</h3>
+<h3
+id="p0-8.-park와-lease가-keeper-진행을-제약하는-별도-lifecycle이-됐다">P0-8.
+<code>park</code>와 <code>lease</code>가 Keeper 진행을 제약하는 별도
+lifecycle이 됐다</h3>
 <p>현재 흐름:</p>
 <ul>
 <li>chat fiber가 turn mutex에서 대기하면
@@ -970,12 +963,10 @@ model/runtime exit authority에서 제거</li>
 <li>incoming chat은 immutable event tail에 쌓고 current turn을 강제
 종료하지 않음</li>
 </ul>
-</section>
-<section
-id="p0-9-settlement가-canonical-terminal-state-위에-두-번째-facade를-만든다"
-class="level3">
-<h3>P0-9. <code>settlement</code>가 canonical terminal state 위에 두
-번째 Facade를 만든다</h3>
+<h3
+id="p0-9.-settlement가-canonical-terminal-state-위에-두-번째-facade를-만든다">P0-9.
+<code>settlement</code>가 canonical terminal state 위에 두 번째 Facade를
+만든다</h3>
 <p><code>Keeper_msg_async.worker_settlement</code>은 다음 variant를
 가진다.</p>
 <ul>
@@ -1004,15 +995,10 @@ commit 결과 하나로 축소해야 한다.</p>
 <code>settlement_durability</code>, <code>settlement_origin</code>,
 <code>Settlement_projection_error</code>라는 별도 vocabulary와 callback
 Facade는 삭제한다.</p>
-</section>
-</section>
-<section id="6-p1-findings" class="level2">
-<h2>6. P1 Findings</h2>
-<section
-id="p1-1-librarian-snapshot-coalescing으로-의미-있는-turn이-유실될-수-있다"
-class="level3">
-<h3>P1-1. Librarian snapshot coalescing으로 의미 있는 turn이 유실될 수
-있다</h3>
+<h2 id="p1-findings">6. P1 Findings</h2>
+<h3
+id="p1-1.-librarian-snapshot-coalescing으로-의미-있는-turn이-유실될-수-있다">P1-1.
+Librarian snapshot coalescing으로 의미 있는 turn이 유실될 수 있다</h3>
 <p><code>keeper_memory_lane.ml:279-295</code>는 in-flight 1개와 latest
 1개만 유지한다. 세 번째 submission은 기존 latest closure를
 <code>Replace_latest</code>로 덮어쓴다.</p>
@@ -1026,10 +1012,8 @@ class="level3">
 버린다. 각 meaningful turn이
 <code>committed | intentionally skipped | retryable failure</code> 중
 무엇이 됐는지 증명할 수 없다.</p>
-</section>
-<section id="p1-2-memory-publication이-transaction이-아니다"
-class="level3">
-<h3>P1-2. Memory publication이 transaction이 아니다</h3>
+<h3 id="p1-2.-memory-publication이-transaction이-아니다">P1-2. Memory
+publication이 transaction이 아니다</h3>
 <p>현재 순서:</p>
 <ol type="1">
 <li>facts rewrite</li>
@@ -1043,9 +1027,8 @@ class="level3">
 <li>missing event</li>
 <li>cursor와 실제 store 불일치</li>
 </ul>
-</section>
-<section id="p1-3-librarian-prompt-계약이-서로-모순된다" class="level3">
-<h3>P1-3. Librarian prompt 계약이 서로 모순된다</h3>
+<h3 id="p1-3.-librarian-prompt-계약이-서로-모순된다">P1-3. Librarian
+prompt 계약이 서로 모순된다</h3>
 <p><code>config/prompts/keeper.librarian.episode_extraction.md</code>:</p>
 <ul>
 <li>cross-Keeper store라고 설명하지만 production store/recall은
@@ -1056,10 +1039,8 @@ per-Keeper</li>
 <li>source code/git/board에서 derivable한지 판단하라고 하지만 Librarian
 input에는 해당 source authority가 없음</li>
 </ul>
-</section>
-<section id="p1-4-provenance와-multimodal-정보가-손실된다"
-class="level3">
-<h3>P1-4. Provenance와 multimodal 정보가 손실된다</h3>
+<h3 id="p1-4.-provenance와-multimodal-정보가-손실된다">P1-4.
+Provenance와 multimodal 정보가 손실된다</h3>
 <ul>
 <li>tool result는 id/error placeholder</li>
 <li>tool call은 id/name placeholder</li>
@@ -1081,19 +1062,16 @@ validator가 동일한 immutable <code>source_input</code>을 공유하며,
 capacity+1 메시지와 ToolResult ID를 사용한 회귀가 이를 고정한다. actual
 <code>Turn_ref</code>, multimodal payload, spatial namespace는 아직
 없으므로 finding은 부분 해결이다.</p>
-</section>
-<section
-id="p1-5-fleet-wide-serial-maintenance가-keeper-독립성을-침해한다"
-class="level3">
-<h3>P1-5. Fleet-wide serial maintenance가 Keeper 독립성을 침해한다</h3>
+<h3
+id="p1-5.-fleet-wide-serial-maintenance가-keeper-독립성을-침해한다">P1-5.
+Fleet-wide serial maintenance가 Keeper 독립성을 침해한다</h3>
 <p>모든 Keeper consolidation을 같은 runtime 후보열에 대해 순차 실행한다.
 한 Keeper/provider가 느리면 뒤 Keeper 전체가 지연된다. 이는 Lane Per
 Keeper와 “하나가 멈추면 모두 멈추지 않는다”는 계약에 어긋난다.</p>
 <p>#26324가 periodic consolidation을 제거하면 해당 serial loop는
 사라진다.</p>
-</section>
-<section id="p1-6-ledger-관측-필드가-실제-의미와-다르다" class="level3">
-<h3>P1-6. Ledger 관측 필드가 실제 의미와 다르다</h3>
+<h3 id="p1-6.-ledger-관측-필드가-실제-의미와-다르다">P1-6. Ledger 관측
+필드가 실제 의미와 다르다</h3>
 <p><code>keeper_recall_injection_ledger.ml:383</code>:</p>
 <div class="sourceCode" id="cb4"><pre
 class="sourceCode ocaml"><code class="sourceCode ocaml"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a>~n_episodes_in_store:(<span class="dt">List</span>.length injected_episode_keys)</span></code></pre></div>
@@ -1108,10 +1086,8 @@ dashboard는 sangsu episode 223개를 보고했지만 ledger는 166개를
 wire는 decoder가 거부하며, Keeper/read-error identity 중복과 두 집합의
 교차도 거부한다. 위 <code>n_episodes_in_store</code> ledger 오표기는
 아직 남아 있으므로 이 finding은 부분 해결이다.</p>
-</section>
-<section id="p1-7-librarian-실패가-typed-turnhealth-상태가-아니다"
-class="level3">
-<h3>P1-7. Librarian 실패가 typed turn/health 상태가 아니다</h3>
+<h3 id="p1-7.-librarian-실패가-typed-turnhealth-상태가-아니다">P1-7.
+Librarian 실패가 typed turn/health 상태가 아니다</h3>
 <p><code>run_best_effort</code>는 실패를 log/metric에 남기지만 caller에
 typed terminal result를 반환하지 않는다.</p>
 <p>라이브 집계:</p>
@@ -1123,15 +1099,18 @@ typed terminal result를 반환하지 않는다.</p>
 <p>그러나 <code>/health</code>에 per-Keeper Librarian
 pending/failure/oldest-age 상태가 없다. 로그 수준에서는 보이지만 runtime
 contract 수준에서는 사실상 silent하다.</p>
-</section>
-</section>
-<section id="7-n--n3-라이브-흐름" class="level2">
-<h2>7. N → N+3 라이브 흐름</h2>
+<h2 id="n-n3-라이브-흐름">7. N → N+3 라이브 흐름</h2>
 <p>민감한 원문은 읽거나 보고서에 기록하지 않았다. prompt block size와
 digest, typed outcome, store count만 비교했다.</p>
-<section id="71-rondo-autonomous-turns-17721775" class="level3">
-<h3>7.1 Rondo autonomous turns 1772–1775</h3>
+<h3 id="rondo-autonomous-turns-17721775">7.1 Rondo autonomous turns
+1772–1775</h3>
 <table>
+<colgroup>
+<col style="width: 25%" />
+<col style="width: 25%" />
+<col style="width: 25%" />
+<col style="width: 25%" />
+</colgroup>
 <thead>
 <tr>
 <th>Turn</th>
@@ -1183,18 +1162,13 @@ digest, typed outcome, store count만 비교했다.</p>
 <li>user input과 assistant turn의 exact identity</li>
 <li>failover 후 어느 runtime 결과가 authoritative한지</li>
 </ul>
-</section>
-<section id="72-user-input-주변" class="level3">
-<h3>7.2 User input 주변</h3>
+<h3 id="user-input-주변">7.2 User input 주변</h3>
 <p>Rondo 1686–1689에서 dashboard user input 직후 persona/dynamic
 digest가 direct-chat 값으로 바뀌고 다음 turn에서 autonomous 값으로
 돌아오는 흐름은 확인했다.</p>
 <p>하지만 user row가 <code>turn_ref=null</code>이므로 “이 입력이 정확히
 turn #1687을 열었다”는 계약 수준 증명은 불가능하다.</p>
-</section>
-</section>
-<section id="8-확인된-양호점" class="level2">
-<h2>8. 확인된 양호점</h2>
+<h2 id="확인된-양호점">8. 확인된 양호점</h2>
 <ul>
 <li>scoped Memory hot path에서 MASC → OAS 의존만 확인했다.</li>
 <li>OAS → MASC 역방향 참조는 발견되지 않았다.</li>
@@ -1209,9 +1183,7 @@ turn #1687을 열었다”는 계약 수준 증명은 불가능하다.</p>
 <p>단, 마지막 항목은 horizon policy가 제거됐다는 의미가 아니다.
 <code>valid_for_days</code>, TTL, recency, 32-turn window가 같은 역할을
 수행한다.</p>
-</section>
-<section id="9-ocaml-55--eio-기준" class="level2">
-<h2>9. OCaml 5.5 / Eio 기준</h2>
+<h2 id="ocaml-5.5-eio-기준">9. OCaml 5.5 / Eio 기준</h2>
 <p>OCaml 5.5 공식 문서 기준:</p>
 <ul>
 <li>Domain은 OS thread와 1:1인 heavyweight parallel unit이다.</li>
@@ -1245,11 +1217,8 @@ Cancel</a></li>
 href="https://ocaml-multicore.github.io/eio/eio/Eio/Fiber/index.html">Eio
 Fiber</a></li>
 </ul>
-</section>
-<section id="10-시장-구현-비교" class="level2">
-<h2>10. 시장 구현 비교</h2>
-<section id="101-채택할-원칙" class="level3">
-<h3>10.1 채택할 원칙</h3>
+<h2 id="시장-구현-비교">10. 시장 구현 비교</h2>
+<h3 id="채택할-원칙">10.1 채택할 원칙</h3>
 <p>Hermes Agent:</p>
 <ul>
 <li>post-turn single-worker FIFO</li>
@@ -1279,9 +1248,7 @@ compaction architecture</a></p>
 <li>성공 commit 후에만 cursor advance</li>
 <li>main-agent direct writer와 background writer authority 분리</li>
 </ul>
-</section>
-<section id="102-복제하면-안-되는-것" class="level3">
-<h3>10.2 복제하면 안 되는 것</h3>
+<h3 id="복제하면-안-되는-것">10.2 복제하면 안 되는 것</h3>
 <ul>
 <li>Hermes prefetch failure의 empty context/log-only degrade</li>
 <li>OpenClaw score/recency/threshold dreaming과 legacy migration</li>
@@ -1291,12 +1258,8 @@ threshold</li>
 </ul>
 <p>시장 구현은 invariant의 참고 자료일 뿐 MASC의 사용자 계약보다 상위
 authority가 아니다.</p>
-</section>
-</section>
-<section id="11-목표-아키텍처" class="level2">
-<h2>11. 목표 아키텍처</h2>
-<section id="111-유일한-조립-수식" class="level3">
-<h3>11.1 유일한 조립 수식</h3>
+<h2 id="목표-아키텍처">11. 목표 아키텍처</h2>
+<h3 id="유일한-조립-수식">11.1 유일한 조립 수식</h3>
 <pre class="text"><code>Prompt(N) =
   latest_committed_memory_revision
   + immutable_turn_events(memory_revision.covers_through_seq + 1 .. N)</code></pre>
@@ -1307,9 +1270,7 @@ authority가 아니다.</p>
 <li>Librarian이 느리거나 실패해도 Keeper main turn 진행</li>
 <li>restart 후 같은 cursor/watermark에서 재개</li>
 </ul>
-</section>
-<section id="112-결정론-코드의-권한" class="level3">
-<h3>11.2 결정론 코드의 권한</h3>
+<h3 id="결정론-코드의-권한">11.2 결정론 코드의 권한</h3>
 <ul>
 <li>event identity와 ordering</li>
 <li>namespace와 ACL</li>
@@ -1318,9 +1279,7 @@ authority가 아니다.</p>
 <li>atomic commit</li>
 <li>explicit typed failure</li>
 </ul>
-</section>
-<section id="113-llm의-권한" class="level3">
-<h3>11.3 LLM의 권한</h3>
+<h3 id="llm의-권한">11.3 LLM의 권한</h3>
 <pre class="text"><code>Create
 Update existing_fact_id
 Supersede existing_fact_id
@@ -1335,9 +1294,7 @@ Noop</code></pre>
 <li>policy revision</li>
 <li>created/committed timestamp</li>
 </ul>
-</section>
-<section id="114-spatial-namespace" class="level3">
-<h3>11.4 Spatial namespace</h3>
+<h3 id="spatial-namespace">11.4 Spatial namespace</h3>
 <p>최소 exact tuple:</p>
 <pre class="text"><code>keeper
 × connector
@@ -1347,12 +1304,10 @@ Noop</code></pre>
 × actor</code></pre>
 <p>다른 공간의 기억 공유는 typed explicit relation으로만 허용한다. 동일
 문구 또는 유사 embedding만으로 namespace를 합치지 않는다.</p>
-</section>
-</section>
-<section id="12-개선-goals와-측정-가능한-tasks" class="level2">
-<h2>12. 개선 Goals와 측정 가능한 Tasks</h2>
-<section id="g0-fresh-state-persistence-ssot" class="level3">
-<h3>G0. Fresh-state persistence SSOT</h3>
+<h2 id="개선-goals와-측정-가능한-tasks">12. 개선 Goals와 측정 가능한
+Tasks</h2>
+<h3 id="g0.-fresh-state-persistence-ssot">G0. Fresh-state persistence
+SSOT</h3>
 <p>Tasks:</p>
 <ol type="1">
 <li><code>Keeper_memory_os_store</code> 채택 또는 삭제 결정</li>
@@ -1367,9 +1322,7 @@ Noop</code></pre>
 <li>compatibility/migration branch 0개</li>
 <li>facts/episodes/events commit receipt 1개</li>
 </ul>
-</section>
-<section id="g1-turn-ledger-ssot" class="level3">
-<h3>G1. Turn Ledger SSOT</h3>
+<h3 id="g1.-turn-ledger-ssot">G1. Turn Ledger SSOT</h3>
 <p>Tasks:</p>
 <ol type="1">
 <li><code>Input_ref</code>, <code>Turn_ref</code>,
@@ -1386,9 +1339,7 @@ row에 전파</li>
 <li>null user TurnRef 0</li>
 <li>duplicate TurnRef 0</li>
 </ul>
-</section>
-<section id="g2-context-assembler" class="level3">
-<h3>G2. Context Assembler</h3>
+<h3 id="g2.-context-assembler">G2. Context Assembler</h3>
 <p>Tasks:</p>
 <ol type="1">
 <li><code>memory revision + uncovered event tail</code> 단일 조립</li>
@@ -1403,9 +1354,8 @@ row에 전파</li>
 <li>tool call/result 분리 0</li>
 <li>private channel leakage 0</li>
 </ul>
-</section>
-<section id="g3-per-keeper-librarian-lane" class="level3">
-<h3>G3. Per-Keeper Librarian Lane</h3>
+<h3 id="g3.-per-keeper-librarian-lane">G3. Per-Keeper Librarian
+Lane</h3>
 <p>Tasks:</p>
 <ol type="1">
 <li><code>Replace_latest</code> 제거</li>
@@ -1432,9 +1382,7 @@ slice로 구현</li>
 <li>waiting chat 때문에 current autonomous run이 종료되는 경우 0</li>
 <li>separate lease/settlement identity 0</li>
 </ul>
-</section>
-<section id="g4-semantic-memory-policy" class="level3">
-<h3>G4. Semantic Memory Policy</h3>
+<h3 id="g4.-semantic-memory-policy">G4. Semantic Memory Policy</h3>
 <p>Tasks:</p>
 <ol type="1">
 <li>typed <code>Create|Update|Supersede|Forget|Noop</code></li>
@@ -1455,9 +1403,8 @@ slice로 구현</li>
 <li>paraphrase, contradiction, correction fixture 통과</li>
 <li>restart 전후 동일 causal decision</li>
 </ul>
-</section>
-<section id="g5-atomic-failure-and-failover" class="level3">
-<h3>G5. Atomic Failure and Failover</h3>
+<h3 id="g5.-atomic-failure-and-failover">G5. Atomic Failure and
+Failover</h3>
 <p>Tasks:</p>
 <ol type="1">
 <li>authoritative strict reader</li>
@@ -1474,9 +1421,7 @@ slice로 구현</li>
 <li>invalid candidate 이후 configured fallback 동작과 provenance
 증명</li>
 </ul>
-</section>
-<section id="g6-observability" class="level3">
-<h3>G6. Observability</h3>
+<h3 id="g6.-observability">G6. Observability</h3>
 <p>Tasks:</p>
 <ol type="1">
 <li>TurnRecord에 memory revision ID, source range, Librarian receipt ID
@@ -1492,10 +1437,13 @@ generation</li>
 <li>misleading store count field 0</li>
 <li>log-only Librarian terminal failure 0</li>
 </ul>
-</section>
-<section id="121-2026-07-30-후속-구현-상태" class="level3">
-<h3>12.1 2026-07-30 후속 구현 상태</h3>
+<h3 id="후속-구현-상태">12.1 2026-07-30 후속 구현 상태</h3>
 <table>
+<colgroup>
+<col style="width: 33%" />
+<col style="width: 33%" />
+<col style="width: 33%" />
+</colgroup>
 <thead>
 <tr>
 <th>Goal</th>
@@ -1554,9 +1502,9 @@ revision/failover receipt 미구현</td>
 </tr>
 <tr>
 <td>G6</td>
-<td>stale claim-kind projection 제거, 축소된 dashboard wire를 새
-<code>keeper.memory_os.recall_observability.v2</code> closed contract로
-고정, per-Keeper read error 추가</td>
+<td>stale claim-kind projection 제거, versioned <code>schema</code>와
+사망 <code>terminal_marker</code>/<code>terminal_markers</code>를 제거한
+unversioned closed dashboard contract, per-Keeper read error 추가</td>
 <td><strong>부분 완료</strong> — receipt/age/stale generation
 미구현</td>
 </tr>
@@ -1570,6 +1518,13 @@ revision/failover receipt 미구현</td>
 <code>ocamlc -stop-after parsing</code> 통과</li>
 <li>dashboard: <code>tsc --noEmit</code> 통과</li>
 <li>dashboard focused Vitest: 7 files, 255 tests 통과</li>
+<li>사망 필드 후속 slice: dashboard <code>tsc --noEmit</code>, focused
+Vitest 5 files / 231 tests 통과</li>
+<li>production tree의
+<code>terminal_marker</code>/<code>terminal_markers</code> 및 versioned
+<code>keeper.memory_os.recall_observability.v2</code> symbol scan 0;
+dashboard 회귀 test는 retired <code>schema</code> 입력을 unknown field로
+거부함을 고정</li>
 <li>Python judge eval: 24 tests, Ruff, Pyright 통과</li>
 <li><code>git diff --check</code> 통과</li>
 <li><code>scripts/check-doc-code-refs.sh</code> 통과</li>
@@ -1606,10 +1561,7 @@ rows가 <code>valid_until</code>을 갖는다.</li>
 <li>이 operational proof/runbook은 아직 diff에 없다. 따라서 source
 hard-cut과 별개로 release는 <strong>P0 BLOCK</strong>이다.</li>
 </ul>
-</section>
-</section>
-<section id="13-권장-실행-순서" class="level2">
-<h2>13. 권장 실행 순서</h2>
+<h2 id="권장-실행-순서">13. 권장 실행 순서</h2>
 <ol type="1">
 <li>G0 Fresh-state SSOT</li>
 <li>G1 Turn identity</li>
@@ -1621,9 +1573,7 @@ hard-cut과 별개로 release는 <strong>P0 BLOCK</strong>이다.</li>
 </ol>
 <p>G0/G1 이전에 새로운 retrieval, dedupe, Gate, TTL을 추가하면 잘못된
 authority와 identity 위에 기능을 더 쌓게 된다.</p>
-</section>
-<section id="14-최종-결론" class="level2">
-<h2>14. 최종 결론</h2>
+<h2 id="최종-결론">14. 최종 결론</h2>
 <p>현재 MASC Librarian/Memory OS는 “실제로 호출되는 prototype” 단계를
 넘었고, 후속 source slice에서 TTL/horizon authority까지 제거했지만, 다음
 조건을 충족하지 못한다.</p>
@@ -1660,11 +1610,8 @@ exact-head <code>Build and Test</code>/<code>CI Gate</code>가 merge 뒤
 <p>따라서 Memory OS 개선은 하나의 거대한 호환 PR이 아니라, 위 Goal
 순서대로 fresh-state hard cut을 적용한 좁고 독립적인 PR들로 진행해야
 한다.</p>
-</section>
-<section id="15-evidence-record" class="level2">
-<h2>15. Evidence Record</h2>
-<section id="151-공통-헤더" class="level3">
-<h3>15.1 공통 헤더</h3>
+<h2 id="evidence-record">15. Evidence Record</h2>
+<h3 id="공통-헤더">15.1 공통 헤더</h3>
 <ul>
 <li><code>날짜(ISO8601)</code>:
 <code>2026-07-30T16:05:00+09:00</code></li>
@@ -1676,11 +1623,8 @@ exact-head <code>Build and Test</code>/<code>CI Gate</code>가 merge 뒤
 <code>/Users/dancer/me/.masc</code></li>
 <li><code>결정 상태</code>: <code>보류 — BLOCK / NO-GO</code></li>
 </ul>
-</section>
-<section id="152-근거-evidence" class="level3">
-<h3>15.2 근거 (Evidence)</h3>
-<section id="source" class="level4">
-<h4>Source</h4>
+<h3 id="근거-evidence">15.2 근거 (Evidence)</h3>
+<h4 id="source-1">Source</h4>
 <ul>
 <li><code>항목</code>: Librarian/Memory OS current source contract</li>
 <li><code>출처</code>: <code>git rev-parse origin/main</code>,
@@ -1690,9 +1634,7 @@ exact-head <code>Build and Test</code>/<code>CI Gate</code>가 merge 뒤
 <li><code>제한조건</code>: 후속 2개 source slice와 report update는 아직
 새 Draft PR CI 전</li>
 </ul>
-</section>
-<section id="runtime" class="level4">
-<h4>Runtime</h4>
+<h4 id="runtime-1">Runtime</h4>
 <ul>
 <li><code>항목</code>: live recall, Librarian, consolidation, Turn
 identity</li>
@@ -1704,9 +1646,7 @@ deployed binary SHA <code>Medium</code></li>
 <li><code>제한조건</code>: health commit은 binary-embedded SHA가 아니라
 startup repo HEAD</li>
 </ul>
-</section>
-<section id="pull-requests" class="level4">
-<h4>Pull Requests</h4>
+<h4 id="pull-requests">Pull Requests</h4>
 <ul>
 <li><code>항목</code>: 현재 open PR의 finding coverage</li>
 <li><code>출처</code>: <code>gh pr list</code>, <code>gh pr view</code>,
@@ -1716,9 +1656,7 @@ GitHub changed-file 및 exact file patch</li>
 <li><code>제한조건</code>: PR head/check 상태는 이후 push에 따라 변경
 가능</li>
 </ul>
-</section>
-<section id="ocaml--eio" class="level4">
-<h4>OCaml / Eio</h4>
+<h4 id="ocaml-eio">OCaml / Eio</h4>
 <ul>
 <li><code>항목</code>: OCaml 5.5 memory model과 Eio cancellation/mutex
 기준</li>
@@ -1729,9 +1667,7 @@ docs</li>
 <li><code>제한조건</code>: MASC-specific architecture 판정은 공식
 언어/runtime 계약의 적용 결과</li>
 </ul>
-</section>
-<section id="market-comparison" class="level4">
-<h4>Market comparison</h4>
+<h4 id="market-comparison">Market comparison</h4>
 <ul>
 <li><code>항목</code>: Hermes/OpenClaw/local claude-code memory/context
 implementation</li>
@@ -1742,10 +1678,7 @@ implementation</li>
 <li><code>제한조건</code>: 로컬 claude-code는 upstream-current 주장
 아님</li>
 </ul>
-</section>
-</section>
-<section id="153-검증-verification" class="level3">
-<h3>15.3 검증 (Verification)</h3>
+<h3 id="검증-verification">15.3 검증 (Verification)</h3>
 <ul>
 <li><code>1차</code>: current source entrypoint, producer, typed
 consumer, caller 추적</li>
@@ -1760,9 +1693,7 @@ typecheck, focused 7 files/255 tests, Python 24 tests와 static check를
 통과했다. TTL/expiry authority production reference도 제거됐다.
 Dune/CI와 runtime cutover는 미검증.</li>
 </ul>
-</section>
-<section id="154-불확실성-uncertainty" class="level3">
-<h3>15.4 불확실성 (Uncertainty)</h3>
+<h3 id="불확실성-uncertainty">15.4 불확실성 (Uncertainty)</h3>
 <ul>
 <li><p><code>미확인 항목</code>: 실행 binary에 embedded된 exact git
 SHA</p></li>
@@ -1777,9 +1708,7 @@ merge/deployment readiness는 아직 증명되지 않음</p></li>
 <li><p><code>추가 확인 필요</code>: draft PR push 후 head SHA, required
 checks, unresolved review threads 재확인</p></li>
 </ul>
-</section>
-<section id="155-적용범위-scope" class="level3">
-<h3>15.5 적용범위 (Scope)</h3>
+<h3 id="적용범위-scope">15.5 적용범위 (Scope)</h3>
 <ul>
 <li><code>영향 받는 영역</code>: Keeper turn identity, Librarian lane,
 Memory persistence, recall/context assembly, chat admission, async
@@ -1790,8 +1719,5 @@ terminal projection</li>
 가능한 설계라면 해당 change를 중단하고 fresh-state authority부터
 재설계</li>
 </ul>
-</section>
-</section>
-</section>
 </body>
 </html>

--- a/reports/MASC-LIBRARIAN-MEMORY-OS-ADVERSARIAL-AUDIT-2026-07-30.md
+++ b/reports/MASC-LIBRARIAN-MEMORY-OS-ADVERSARIAL-AUDIT-2026-07-30.md
@@ -37,6 +37,14 @@ closed decoder가 명시적으로 거부한다. 이 개선은 아직 새 PR CI·
 cutover가 증명되지 않았고, canonical TurnRef·recency selection·latest-wins·
 echo/dedupe 휴리스틱·비원자 publication이 남으므로 최종 판정은 계속 NO-GO다.
 
+2026-07-30 16:53 KST 후속 hard cut은 production producer가 항상 `None`만
+기록하던 `terminal_marker`를 episode type/codec/recall/dashboard/viewer/test에서
+완전히 제거했다. dashboard의 `terminal_markers` 파생 카운트와 실질적인 호환
+권한이 없던 versioned `schema` 문자열도 함께 제거했다. 새 closed decoder는
+이 사망 필드가 다시 들어오면 unknown field로 거부한다. 이 slice는 원자
+publication의 선행 정리이며, atomic Memory authority 자체가 완료됐다는 뜻은
+아니다.
+
 가장 중요한 차단 사유는 다음과 같다.
 
 1. 사용되지 않는 canonical store와 실제 JSONL store가 병존한다.
@@ -66,6 +74,8 @@ echo/dedupe 휴리스틱·비원자 publication이 남으므로 최종 판정은
   `407ae5bb92509f06bfb6fc5614e8539e230b2902`
 - 후속 구현 branch:
   `refactor/memory-current-only-hard-cut-20260730`
+- 사망 필드/원자 publication 후속 branch:
+  `refactor/memory-atomic-publication-20260730`
 - current-only 1차 source slice:
   `6f8bf76a816d822ca0165b6a8c42986b3d466e5c`
 - TTL authority 제거 2차 source slice:
@@ -120,7 +130,7 @@ binary SHA는 미증명으로 남긴다.
 | [#26410](https://github.com/jeong-sik/masc/pull/26410) `park chat before claiming receipt` | 직접 재검토 필요 | **Merged**, head `bde47167ea442db9e91b91a61c27832d66485e10`, 2026-07-30 16:03 KST merge | lease-before-admission을 줄이고 pending receipt를 admission 뒤 claim하는 ordering은 개선한다. 그러나 `park`를 공식 흐름으로 만들고 별도 `lease_id` lifecycle을 유지한다. | **merge됐어도 숙청 기준과 충돌. TurnRef/AttemptId 단일 FSM으로 재구성 필요** |
 | [#26428](https://github.com/jeong-sik/masc/pull/26428) `make current memory and provider input observable` | 직접 충돌 | **Draft**, head `508d77896e12f26652950d68c040830e0cb34691`, `MERGEABLE/BLOCKED`, `status:do-not-merge`, `reviewed:adversarial-non-pass` | immutable current snapshot/CAS와 provider-input observability 방향은 유효하다. 그러나 current head에도 TTL/`claim_kind`/dead episode fields/latest-wins/cadence/prompt-local provenance가 그대로다. | **전체 채택 금지. atomic snapshot/관측성만 분리 재구성** |
 | [#26435](https://github.com/jeong-sik/masc/pull/26435) `collapse compaction commit onto source CAS` | 직접 인접 | **Merged**, head `5866b26c14b91088349d21033a884ab6f1c65136`, merge commit `07a3d4f19d1f0c9563be01b8b6f8b4c90da14841`; exact-head `Build and Test`/`CI Gate`는 merge 뒤 취소 | compaction terminal projection을 source CAS에 접어 settlement 중복 authority를 줄인다. | **exact-head full CI green 없이 admin merge. Memory facts→episode→event publication/TurnRef/FIFO는 해결하지 않음** |
-| [#26440](https://github.com/jeong-sik/masc/pull/26440) `hard-cut retired Memory OS authority` | 본 감사 후속 구현 | **Draft**, branch `refactor/memory-current-only-hard-cut-20260730`, current `origin/main` rebase 뒤 `MERGEABLE/BLOCKED`; CI 생성 대기 | 1·2차 hard-cut과 본 보고서, wire v2/dead facade 보완을 함께 검증한다. | **cold cutover·CI·runtime 증명 전 do-not-merge** |
+| [#26440](https://github.com/jeong-sik/masc/pull/26440) `hard-cut retired Memory OS authority` | 본 감사 후속 구현 | **Merged**, head `120dcc8fbc905aa3ea0c4651dc1f0a19fcfb7767`, squash merge `8701b4a9e4cec823c535912374ae11759125f596` | 1·2차 hard-cut과 본 보고서를 main에 반영했다. 그러나 merge 시점에 exact-head `Build and Test`, Dashboard, ocamlformat, CI Gate가 아직 실행 중이었고 merge 뒤 취소됐다. | **source hard cut은 병합됐으나 exact-head full CI green 증거 없음. cold cutover·runtime 증명 전 NO-GO** |
 | [#26436](https://github.com/jeong-sik/masc/pull/26436) `enforce current-only Memory OS contracts` | 본 감사 1차 구현 | **Closed**, head `1c4692b806dd34e948afa99ea34d627092e880cc`, `status:do-not-merge`, `reviewed:adversarial-non-pass` | 1차 hard-cut의 CI Meta Guard 문제는 local 2차 slice에서 수정됐고 TTL authority도 추가 삭제했다. | **reopen 금지. 새 exact-head Draft PR로 다시 증명** |
 | [#26389](https://github.com/jeong-sik/masc/pull/26389) `separate Keeper context from turn usage` | 원칙상 인접 | **Merged**, head `bc4ab6d0fde691a4c43e588d549b4a3389e5d31e`, merge commit `407ae5bb92509f06bfb6fc5614e8539e230b2902` | producer 없는 context 추정과 legacy metric surface를 제거한다. | Memory OS persistence/context flow의 직접 수정은 아님 |
 | [#26392](https://github.com/jeong-sik/masc/pull/26392) `cost ledger exact runtime identity` | 원칙상 인접 | **Merged**, head `a332706ec04f49d8ac03e5de684dcf0e11003e3d`, merge commit `e19a05f6ca926eed0de054bd1371ae6f34a075e2` | timestamp/token heuristic 대신 exact identity를 사용한다. | 좋은 선례지만 Memory Turn identity는 수정하지 않음 |
@@ -915,7 +925,7 @@ Acceptance:
 | G3 | latest-wins와 park/lease/settlement를 서로 다른 SSOT로 분해; Librarian exact journal은 current-only closed state/trace/generation, trace-scoped restart fence, canonical path identity로 강화 | **부분 완료** — lossless per-Keeper FIFO/outbox 미구현 |
 | G4 | Memory `claim_kind`, `open_items`, episode `constraints`, `preserved_tool_refs`, `valid_for_days`/`valid_until`/`Ephemeral`와 expiry authority 제거 | **부분 완료** — echo window, recency/byte cap, substring score, first-100-byte dedupe 잔존 |
 | G5 | public fact/episode reader partial-drop 제거, recall unavailable 및 dashboard read error 노출, publication phase failure를 typed result로 분류 | **부분 완료** — journal terminal이 publication보다 앞서고 facts→episode→event partial commit/rollback이 없어 atomic revision/failover receipt 미구현 |
-| G6 | stale claim-kind projection 제거, 축소된 dashboard wire를 새 `keeper.memory_os.recall_observability.v2` closed contract로 고정, per-Keeper read error 추가 | **부분 완료** — receipt/age/stale generation 미구현 |
+| G6 | stale claim-kind projection 제거, versioned `schema`와 사망 `terminal_marker`/`terminal_markers`를 제거한 unversioned closed dashboard contract, per-Keeper read error 추가 | **부분 완료** — receipt/age/stale generation 미구현 |
 
 Focused verification:
 
@@ -924,6 +934,11 @@ Focused verification:
   `ocamlformat --check`, `ocamlc -stop-after parsing` 통과
 - dashboard: `tsc --noEmit` 통과
 - dashboard focused Vitest: 7 files, 255 tests 통과
+- 사망 필드 후속 slice: dashboard `tsc --noEmit`, focused Vitest
+  5 files / 231 tests 통과
+- production tree의 `terminal_marker`/`terminal_markers` 및 versioned
+  `keeper.memory_os.recall_observability.v2` symbol scan 0; dashboard 회귀 test는
+  retired `schema` 입력을 unknown field로 거부함을 고정
 - Python judge eval: 24 tests, Ruff, Pyright 통과
 - `git diff --check` 통과
 - `scripts/check-doc-code-refs.sh` 통과

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -579,7 +579,8 @@ let test_episode_provenance_invariants () =
 
 let test_librarian_prompt_renders () =
   let inp : Librarian.input =
-    { Librarian.trace_id = "trace-abc"
+    { Librarian.turn_ref =
+        Ids.Turn_ref.make ~trace_id:"trace-abc" ~absolute_turn:1
     ; messages = [ text_message "Please remember the project constraint." ]
     }
   in
@@ -645,7 +646,10 @@ let test_librarian_prompt_omits_private_blocks () =
     }
   in
   let inp : Librarian.input =
-    { Librarian.trace_id = "trace-abc"; messages = [ msg ] }
+    { Librarian.turn_ref =
+        Ids.Turn_ref.make ~trace_id:"trace-abc" ~absolute_turn:1
+    ; messages = [ msg ]
+    }
   in
   with_prompt_registry (fun () ->
     let prompt = render_librarian_user_prompt inp in
@@ -686,7 +690,8 @@ let valid_librarian_output () =
 
 let test_librarian_rejects_extra_confidence_field () =
   let inp : Librarian.input =
-    { Librarian.trace_id = "trace-extra-confidence"
+    { Librarian.turn_ref =
+        Ids.Turn_ref.make ~trace_id:"trace-extra-confidence" ~absolute_turn:1
     ; messages = [ text_message "turn-indexed memory" ]
     }
   in
@@ -724,7 +729,8 @@ let test_librarian_rejects_extra_confidence_field () =
 
 let test_librarian_rejects_removed_claim_kind_field () =
   let inp : Librarian.input =
-    { Librarian.trace_id = "trace-invalid-kind"
+    { Librarian.turn_ref =
+        Ids.Turn_ref.make ~trace_id:"trace-invalid-kind" ~absolute_turn:1
     ; messages = [ text_message "typed memory" ]
     }
   in
@@ -762,7 +768,8 @@ let test_librarian_rejects_removed_claim_kind_field () =
 
 let test_librarian_rejects_duplicate_json_fields () =
   let inp : Librarian.input =
-    { Librarian.trace_id = "trace-duplicate-fields"
+    { Librarian.turn_ref =
+        Ids.Turn_ref.make ~trace_id:"trace-duplicate-fields" ~absolute_turn:1
     ; messages = [ text_message "duplicate fields are invalid" ]
     }
   in
@@ -810,7 +817,10 @@ let test_librarian_rejects_duplicate_json_fields () =
 
 let test_librarian_rejects_duplicate_claim_identity () =
   let inp : Librarian.input =
-    { Librarian.trace_id = "trace-duplicate-claim-identity"
+    { Librarian.turn_ref =
+        Ids.Turn_ref.make
+          ~trace_id:"trace-duplicate-claim-identity"
+          ~absolute_turn:1
     ; messages =
         [ text_message "first source observation"
         ; text_message "second source observation"
@@ -854,7 +864,8 @@ let test_librarian_rejects_duplicate_claim_identity () =
 
 let test_librarian_generation_override () =
   let inp : Librarian.input =
-    { Librarian.trace_id = "trace-generation-override"
+    { Librarian.turn_ref =
+        Ids.Turn_ref.make ~trace_id:"trace-generation-override" ~absolute_turn:1
     ; messages = [ text_message "turn-indexed memory" ]
     }
   in
@@ -871,7 +882,8 @@ let test_librarian_generation_override () =
 
 let test_librarian_rejects_removed_lifetime_and_category () =
   let inp : Librarian.input =
-    { Librarian.trace_id = "trace-current-only-contract"
+    { Librarian.turn_ref =
+        Ids.Turn_ref.make ~trace_id:"trace-current-only-contract" ~absolute_turn:1
     ; messages = [ text_message "current-only memory" ]
     }
   in
@@ -922,7 +934,8 @@ let test_librarian_rejects_removed_lifetime_and_category () =
 
 let test_librarian_accepts_nullable_claim_fields () =
   let inp : Librarian.input =
-    { Librarian.trace_id = "trace-nullable-claim-fields"
+    { Librarian.turn_ref =
+        Ids.Turn_ref.make ~trace_id:"trace-nullable-claim-fields" ~absolute_turn:1
     ; messages = [ text_message "nullable structured output" ]
     }
   in
@@ -956,7 +969,10 @@ let test_librarian_accepts_nullable_claim_fields () =
 
 let test_librarian_rejects_missing_nullable_claim_fields () =
   let inp : Librarian.input =
-    { Librarian.trace_id = "trace-missing-nullable-claim-fields"
+    { Librarian.turn_ref =
+        Ids.Turn_ref.make
+          ~trace_id:"trace-missing-nullable-claim-fields"
+          ~absolute_turn:1
     ; messages = [ text_message "closed JSON memory contract" ]
     }
   in
@@ -1195,7 +1211,8 @@ let test_memory_os_config_snapshot_surfaces_effective_envs () =
 
 let test_librarian_rejects_out_of_range_source_turn () =
   let inp : Librarian.input =
-    { Librarian.trace_id = "trace-source-turn-out-of-range"
+    { Librarian.turn_ref =
+        Ids.Turn_ref.make ~trace_id:"trace-source-turn-out-of-range" ~absolute_turn:1
     ; messages = [ text_message "Only turn zero exists in this input." ]
     }
   in
@@ -1231,7 +1248,10 @@ let test_librarian_rejects_out_of_range_source_turn () =
 
 let test_librarian_rejects_unrelated_source_tool_call_id () =
   let inp : Librarian.input =
-    { Librarian.trace_id = "trace-unrelated-source-tool-call"
+    { Librarian.turn_ref =
+        Ids.Turn_ref.make
+          ~trace_id:"trace-unrelated-source-tool-call"
+          ~absolute_turn:1
     ; messages = [ text_message "This message contains no tool call." ]
     }
   in
@@ -1285,7 +1305,10 @@ let test_librarian_accepts_exact_source_tool_result_id () =
     }
   in
   let inp : Librarian.input =
-    { Librarian.trace_id = "trace-exact-source-tool-result"
+    { Librarian.turn_ref =
+        Ids.Turn_ref.make
+          ~trace_id:"trace-exact-source-tool-result"
+          ~absolute_turn:1
     ; messages = [ tool_result_message ]
     }
   in
@@ -1328,7 +1351,10 @@ let test_librarian_accepts_exact_source_tool_result_id () =
 
 let test_librarian_rejects_invalid_claims () =
   let inp : Librarian.input =
-    { Librarian.trace_id = "trace-invalid"; messages = [] }
+    { Librarian.turn_ref =
+        Ids.Turn_ref.make ~trace_id:"trace-invalid" ~absolute_turn:1
+    ; messages = []
+    }
   in
   let reject name json =
     let accepted =

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -317,7 +317,6 @@ let episode_fixture ~now ~trace_id ~generation ~summary =
   ; Types.claims = [ fact ]
   ; Types.source_turn_range = Some (0, 0)
   ; Types.created_at = now
-  ; Types.terminal_marker = None
   }
 ;;
 
@@ -338,7 +337,6 @@ let test_json_roundtrip () =
     ; Types.claims = [ f ]
     ; Types.source_turn_range = Some (5, 5)
     ; Types.created_at = now
-    ; Types.terminal_marker = Some "handoff_complete"
     }
   in
   let e2 = Option.get (Types.episode_of_json (Types.episode_to_json e)) in
@@ -346,11 +344,7 @@ let test_json_roundtrip () =
     "episode summary round-trip"
     e.episode_summary
     e2.Types.episode_summary;
-  Alcotest.(check int) "claims length" 1 (List.length e2.Types.claims);
-  Alcotest.(check (option string))
-    "episode terminal_marker round-trip"
-    e.terminal_marker
-    e2.Types.terminal_marker
+  Alcotest.(check int) "claims length" 1 (List.length e2.Types.claims)
 ;;
 
 let test_episode_decoder_rejects_removed_metadata_fields () =
@@ -515,7 +509,6 @@ let test_persisted_memory_decoders_reject_invalid_semantics () =
     ; "generation", `Int (-1)
     ; "episode_summary", `String ""
     ; "created_at", `Float Float.infinity
-    ; "terminal_marker", `String ""
     ; "source_turn_range", `Assoc [ "lo", `Int (-1); "hi", `Int 0 ]
     ; "source_turn_range", `Assoc [ "lo", `Int 2; "hi", `Int 1 ]
     ]
@@ -2036,7 +2029,6 @@ let test_render_if_enabled_renders_persisted_memory () =
           ; Types.claims = [ fact ]
           ; Types.source_turn_range = Some (5, 5)
           ; Types.created_at = now
-          ; Types.terminal_marker = None
           }
         in
         Memory_io.append_episode_bundle ~keeper_id episode;
@@ -2084,7 +2076,6 @@ let test_render_if_enabled_offmain_wrap_is_transparent () =
           ; Types.claims = [ fact ]
           ; Types.source_turn_range = Some (5, 5)
           ; Types.created_at = now
-          ; Types.terminal_marker = None
           }
         in
         Memory_io.append_episode_bundle ~keeper_id episode;
@@ -2139,7 +2130,6 @@ let test_render_if_enabled_keeps_diagnostic_context () =
           ; Types.claims = [ diagnostic_fact ]
           ; Types.source_turn_range = Some (5, 5)
           ; Types.created_at = now
-          ; Types.terminal_marker = Some "diagnostic"
           }
         in
         Memory_io.append_episode_bundle ~keeper_id diagnostic_episode;
@@ -2172,7 +2162,6 @@ let test_render_if_enabled_preserves_empty_claim_episode () =
           ; Types.claims = []
           ; Types.source_turn_range = None
           ; Types.created_at = now
-          ; Types.terminal_marker = None
           }
         in
         Memory_io.append_episode_bundle ~keeper_id episode;
@@ -2365,33 +2354,6 @@ let test_recall_no_prefix_for_plain_fact () =
             (contains "[UNVERIFIED — re-check before acting]" block))))
 ;;
 
-let test_recall_renders_terminal_episode_marker () =
-  with_prompt_registry (fun () ->
-    with_temp_keepers_dir (fun keepers_dir ->
-      let keeper_id = "episode-terminal-keeper" in
-      let now = 1_000_000.0 in
-      let episode =
-        { (episode_fixture
-             ~now
-             ~trace_id:"trace-terminal"
-             ~generation:3
-             ~summary:"terminal handoff summary")
-          with
-          Types.terminal_marker = Some "handoff_complete"
-        }
-      in
-      Memory_io.append_episode_bundle ~keeper_id episode;
-      let ctx = Recall.render_context ~keepers_dir ~keeper_id ~now () in
-      Alcotest.(check bool)
-        "terminal marker is visible in episode line"
-        true
-        (contains "terminal=handoff_complete" ctx);
-      Alcotest.(check bool)
-        "terminal summary still renders"
-        true
-        (contains "terminal handoff summary" ctx)))
-;;
-
 (* Recall preserves every persisted row, including repeated producer identities. *)
 let test_recall_preserves_repeated_claims () =
   with_prompt_registry (fun () ->
@@ -2433,7 +2395,6 @@ let test_recall_preserves_repeated_claims () =
             ]
         ; Types.source_turn_range = Some (1, 9)
         ; Types.created_at = now
-        ; Types.terminal_marker = None
         }
       in
       Memory_io.append_episode_bundle ~keeper_id episode;
@@ -2630,7 +2591,6 @@ let test_recall_context_preserves_semantic_memory_content () =
         ; Types.claims = [ normal_fact; injection_fact ]
         ; Types.source_turn_range = Some (4, 6)
         ; Types.created_at = now
-        ; Types.terminal_marker = None
         }
       in
       Memory_io.append_episode_bundle ~keeper_id episode;
@@ -2694,7 +2654,6 @@ let test_recall_context_preserves_durable_current_rows () =
         ; Types.claims = [ preference_fact ]
         ; Types.source_turn_range = Some (5, 5)
         ; Types.created_at = now
-        ; Types.terminal_marker = None
         }
       in
       let path_episode =
@@ -2704,7 +2663,6 @@ let test_recall_context_preserves_durable_current_rows () =
         ; Types.claims = [ path_fact ]
         ; Types.source_turn_range = Some (7, 7)
         ; Types.created_at = now +. 1.0
-        ; Types.terminal_marker = None
         }
       in
       Memory_io.append_episode_bundle ~keeper_id preference_episode;
@@ -4291,10 +4249,6 @@ let () =
             "plain fact never gets the hard prefix"
             `Quick
             test_recall_no_prefix_for_plain_fact
-        ; Alcotest.test_case
-            "terminal episode marker is rendered"
-            `Quick
-            test_recall_renders_terminal_episode_marker
         ; Alcotest.test_case
             "preserves repeated claim rows"
             `Quick

--- a/test/test_librarian_exact_output_conformance.ml
+++ b/test/test_librarian_exact_output_conformance.ml
@@ -154,7 +154,7 @@ let tool_result_message ~tool_use_id text : Agent_sdk.Types.message =
 ;;
 
 let librarian_input trace_id =
-  { Librarian.trace_id
+  { Librarian.turn_ref = Ids.Turn_ref.make ~trace_id ~absolute_turn:1
   ; messages = [ text_message "Remember the exact-output boundary." ]
   }
 ;;


### PR DESCRIPTION
## Scope

First independently verifiable slice from the Memory OS adversarial audit:

- purge dead episode terminal_marker from the OCaml type, strict codec, producer, recall, dashboard, viewer, and tests
- purge the derived terminal_markers counter
- remove the versioned Memory dashboard schema token; exact field shape remains the current-only contract
- refresh the MD/HTML audit report with #26440 merge/CI evidence

This PR remains draft. Atomic TurnRef-keyed publication, durable Librarian FIFO, canonical provenance, and cold-cut runtime proof are still pending.

## Evidence

- OCaml changed files: ocamlformat --check PASS
- OCaml changed files: parse-only PASS
- dashboard tsc --noEmit PASS
- focused Vitest: 5 files / 231 tests PASS
- git diff --check PASS
- doc code refs PASS
- local Dune not run; CI is the build/type authority

## Safety

- current-only hard cut; no migration or legacy decoder
- no live runtime mutation
- source, CI, merge, and deployed-runtime evidence remain separate