### PR TITLE
fix(keeper): keep source and compaction lanes live

### DIFF
--- a/docs/rfc/RFC-0353-failure-classification-boundary.md
+++ b/docs/rfc/RFC-0353-failure-classification-boundary.md
@@ -22,7 +22,7 @@
 
 **공통점**: 재시도 가능성이 타입이 아니라 (a) catch-all, (b) 문자열 관례(`"retryable …"`), (c) 다른 축과의 결합(`InvalidRequest` 하나가 재시도와 회전을 동시에 차단)으로 결정된다.
 
-† **#25443 은 형태 A 가 아니다 (2026-07-21 재분류, 2026-07-30 current-state 정정).** typed rejection 구분은 compaction domain 안에서 보존되며 event queue는 pending source와 ACK만 소유한다. `No_compaction`과 compaction outcome을 위한 queue transition이나 decoder는 없다. reactive retry ceiling은 `Keeper_post_turn` admission에서 I/O 전에 판단하고, 실제 attempt outcome만 `Keeper_meta_store.persist_compaction_outcome`으로 streak에 반영한다. 행을 삭제하지 않고 남기는 이유는 같은 증상이 형태 A로 오분류되기 쉽다는 점 자체가 §2의 근거이기 때문이다.
+† **#25443 은 형태 A 가 아니다 (2026-07-21 재분류, 2026-07-30 current-state 정정).** typed rejection 구분은 compaction domain 안에서 보존되며 event queue는 pending source와 ACK만 소유한다. `No_compaction`과 compaction outcome을 위한 queue transition이나 decoder는 없다. reactive compaction은 durable checkpoint가 줄었을 때만 source를 재개하며, 실패 횟수나 retry ceiling을 별도 권한으로 저장하지 않는다. 행을 삭제하지 않고 남기는 이유는 같은 증상이 형태 A로 오분류되기 쉽다는 점 자체가 §2의 근거이기 때문이다.
 
 ### 1.2 형태 B — 실패 사유가 소실 → 진단 불가, 이어서 로그 강등으로 은폐
 

--- a/docs/rfc/RFC-compaction-deterministic-floor.md
+++ b/docs/rfc/RFC-compaction-deterministic-floor.md
@@ -59,17 +59,15 @@ Path (`lib/keeper/keeper_unified_turn.ml`):
 - If that returns `Error _` (any `compaction_rejection`), the code takes
   `retry_after_started` → `record_overflow_failure` +
   `release_failed_lifecycle (Compaction_failed)` → returns
-  `Provider_overflow_retry_without_checkpoint`.
-- The consumer (`keeper_unified_turn.ml:309`) maps that to
-  `Requeue_after_context_compaction` — **the source stimulus is requeued with
-  the same, still-over-limit context.**
+  `Provider_overflow_failed_without_checkpoint`.
+- The consumer acknowledges the selected source as a terminal failed turn.
+  `Requeue_after_context_compaction` is reserved for a durably smaller
+  checkpoint.
 
-So on any compaction rejection the next cycle re-overflows and re-attempts the
-same compaction. Nothing between the failures reduces context size. When the
-cause is persistent (the one schema-capable model is weekly-rate-limited), the
-loop does not terminate. This matches the live observation of a keeper emitting
-`compaction_started` repeatedly with zero `compaction_completed`
-(#25062 track; project memory 2026-07-18).
+Before the 2026-07-30 hard cut, any compaction rejection requeued the same,
+still-over-limit source and repeated provider → compactor indefinitely. The
+current source disposition removes that loop without adding another retry
+counter or suspension authority.
 
 ### 1.2 Size reduction is coupled to semantic summarization
 

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -861,14 +861,6 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
               ( "last_compaction_decision",
                 Keeper_meta_contract.compaction_decision_json_or_null
                   m.runtime.compaction_rt.last_decision );
-              ( "compaction_consecutive_failures",
-                `Int m.runtime.compaction_rt.consecutive_failures );
-              (* RFC-0351 S0 / #25461: operator-visible marker that the
-                 reactive compaction admission is suspended for this keeper. *)
-              ( "compaction_retry_suspended",
-                `Bool
-                  (Keeper_meta_contract.compaction_retry_suspended
-                     m.runtime.compaction_rt) );
               ("autoboot_enabled", `Bool m.autoboot_enabled);
               ("proactive_enabled", `Bool m.proactive.enabled);
               ("proactive_count_total", `Int m.runtime.proactive_rt.count_total);

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -80,6 +80,24 @@ let encode_checkpoint_string_off_scheduler (ckpt : Agent_sdk.Checkpoint.t) :
   offload_checkpoint_cpu (fun () -> Agent_sdk.Checkpoint.to_string ckpt)
 
 let keeper_generation_context_key = "keeper_generation"
+let compaction_commit_count_context_key = "masc_compaction_commit_count"
+
+let compaction_commit_count_of_context context =
+  match
+    Agent_sdk.Context.get_scoped
+      context
+      Agent_sdk.Context.Session
+      compaction_commit_count_context_key
+  with
+  | None -> Ok 0
+  | Some (`Int count) when count >= 0 -> Ok count
+  | Some (`Intlit raw) ->
+    (match int_of_string_opt raw with
+     | Some count when count >= 0 -> Ok count
+     | Some _ -> Error "checkpoint compaction commit count is negative"
+     | None -> Error "checkpoint compaction commit count is not an integer")
+  | Some _ -> Error "checkpoint compaction commit count is not an integer"
+;;
 
 let keeper_generation_of_context (context : Agent_sdk.Context.t) : int =
   match

--- a/lib/keeper/keeper_checkpoint_store.mli
+++ b/lib/keeper/keeper_checkpoint_store.mli
@@ -31,6 +31,13 @@ val oas_history_path :
     reader (context core, tests) must reference this value so the key
     cannot drift between sites. *)
 val keeper_generation_context_key : string
+val compaction_commit_count_context_key : string
+
+val compaction_commit_count_of_context :
+  Agent_sdk.Context.t -> (int, string) result
+(** Read the checkpoint-authoritative compaction commit count. Absence means
+    zero for a checkpoint that has not yet been compacted; malformed or
+    negative values fail closed. *)
 
 (** Compose an OAS history archive snapshot id from a checkpoint
     (created_at_ms + keeper_generation suffix). *)

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -955,10 +955,9 @@ let execute_prepared_lane_current
       let raw_bt = Printexc.get_raw_backtrace () in
       (* OAS owns execution state; MASC retains only the source-authority
          observation. Cancellation is fiber teardown, not a compaction result:
-         returning a typed terminal made the heartbeat record a schedule
-         failure and advance the compaction streak even though
-         [Cycle.Cancelled] records neither. Preserve the authorized source and
-         continue the original cancellation. *)
+         returning a typed terminal made the heartbeat record a schedule failure
+         even though [Cycle.Cancelled] records none. Preserve the authorized
+         source and continue the original cancellation. *)
       Option.iter
         (fun observation ->
            Log.Keeper.warn

--- a/lib/keeper/keeper_current_operations.ml
+++ b/lib/keeper/keeper_current_operations.ml
@@ -1,6 +1,6 @@
 type source =
   | Event_queue_pending of
-      { revision : int64
+      { source_incarnation : int64
       ; stimulus : Keeper_event_queue.stimulus
       }
   | Event_queue_outbox of
@@ -54,11 +54,14 @@ type snapshot =
 let project_event_queue_state ~keeper_name state =
   let revision = Keeper_event_queue_state.revision state in
   let pending =
-    Keeper_event_queue_state.pending state
-    |> Keeper_event_queue.to_list
-    |> List.map (fun stimulus ->
+    Keeper_event_queue_state.pending_selections state
+    |> List.map (fun (selection : Keeper_event_queue_state.pending_selection) ->
       { keeper_name
-      ; source = Event_queue_pending { revision; stimulus }
+      ; source =
+          Event_queue_pending
+            { source_incarnation = selection.admitted_revision
+            ; stimulus = selection.source
+            }
       })
   in
   let outbox =
@@ -159,9 +162,9 @@ let outbox_to_yojson (entry : Keeper_event_queue_state.outbox_entry) =
 ;;
 
 let source_to_yojson = function
-  | Event_queue_pending { revision; stimulus } ->
+  | Event_queue_pending { source_incarnation; stimulus } ->
     `Assoc [ "kind", `String "event_queue_pending"
-           ; "revision", `String (Int64.to_string revision)
+           ; "source_incarnation", `String (Int64.to_string source_incarnation)
            ; "value", Keeper_event_queue.stimulus_to_yojson stimulus ]
   | Event_queue_outbox { revision; entry } ->
     `Assoc [ "kind", `String "event_queue_outbox"
@@ -224,7 +227,7 @@ let availability_to_yojson = function
 
 let snapshot_to_yojson snapshot =
   `Assoc
-    [ "schema", `String "keeper.current_operations.v1"
+    [ "schema", `String "keeper.current_operations.v2"
     ; "keeper_name", `String snapshot.keeper_name
     ; "event_queue", availability_to_yojson snapshot.event_queue
     ; "async_requests", availability_to_yojson snapshot.async_requests

--- a/lib/keeper/keeper_current_operations.mli
+++ b/lib/keeper/keeper_current_operations.mli
@@ -2,7 +2,7 @@
 
 type source = private
   | Event_queue_pending of
-      { revision : int64
+      { source_incarnation : int64
       ; stimulus : Keeper_event_queue.stimulus
       }
   | Event_queue_outbox of

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -779,8 +779,10 @@ let is_context_overflow (err : Agent_sdk.Error.sdk_error) : bool =
      needs a bound, add a real counter — do not claim one here without the
      device.
    - context overflow: accounted at the point of detection by
-     [Keeper_turn_runtime_budget.record_overflow_failure], and its in-lane
-     compaction retries are bounded (#25536).
+     [Keeper_turn_runtime_budget.record_overflow_failure]. Its in-lane recovery
+     either commits a smaller checkpoint before requeue or follows the ordinary
+     typed failure route. It has no separate retry counter or suspension
+     authority.
    - 0-byte empty completion: bounded by
      [Keeper_unified_turn_failure]'s per-keeper exemption budget — after
      [empty_completion_exemption_budget] consecutive exempted empty

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -54,7 +54,7 @@ type heartbeat_event_intake = Stimulus_intake.heartbeat_event_intake = {
   pending_board_events : Keeper_world_observation.pending_board_event list;
   consumed_stimulus_count : int;
   consumed_stimuli : Keeper_event_queue.stimulus list;
-  pending_selection : Keeper_event_queue.stimulus option;
+  pending_selection : Keeper_event_queue_state.pending_selection option;
   event_queue_intake_error : Stimulus_intake.event_queue_intake_error option;
   event_queue_triggers : Keeper_world_observation.event_queue_trigger list;
 }
@@ -333,83 +333,44 @@ let manual_compaction_requested_of_stimuli = function
   | [] | [ _ ] | _ :: _ :: _ -> false
 ;;
 
-let compaction_outcome_of_cycle_outcome = function
-  | Some (Cycle.Manual_compaction_applied _) -> Some `Committed
-  | Some (Cycle.Manual_compaction_failed _) -> Some `Failed
-  | Some (Cycle.Failed { failure; _ }) ->
+let rec compaction_outcomes_of_cycle_outcome = function
+  | Cycle.Manual_compaction_applied { receipt; followup } ->
+    `Manual_committed receipt.commit_count
+    :: compaction_outcomes_of_cycle_outcome followup
+  | Cycle.Manual_compaction_failed _ -> [ `Failed ]
+  | Cycle.Failed { failure; _ } ->
     (match failure.Keeper_unified_turn.source_disposition with
-     | Keeper_unified_turn.Requeue_after_context_compaction
-         Keeper_unified_turn.Compaction_committed ->
-       (* #25538: an in-lane commit is still one provider-overflow episode.
-          Advancing (not resetting) the streak is what lets an
-          incompressible floor reach the ceiling; only an overflow-free
-          completed turn — or the operator's manual commit — resets. *)
-       Some `Overflow_episode_committed
-     | Keeper_unified_turn.Requeue_after_context_compaction
-         (Keeper_unified_turn.Compaction_attempt_failed _)
-     | Keeper_unified_turn.Follow_failure_route_after_no_compaction _ ->
-       Some `Failed
-     | Keeper_unified_turn.Requeue_after_context_compaction
-         (Keeper_unified_turn.Compaction_refused_without_attempt _) ->
-       (* The admission gate declined the trigger before reading a checkpoint or
-          calling the summarizer, so there is no compaction outcome to record.
-          Counting it advanced the streak the gate itself reads: live keeper
-          kidsnote reached 907 against a threshold of 3. *)
-       None
-     | Keeper_unified_turn.Acknowledge_after_in_turn_handling -> Some `Failed
+     | Keeper_unified_turn.Requeue_after_context_compaction { commit_count } ->
+       [ `Reactive_committed commit_count ]
+     | Keeper_unified_turn.Acknowledge_after_in_turn_handling -> [ `Failed ]
      | Keeper_unified_turn.Follow_failure_route
-     | Keeper_unified_turn.Pause_after_transcript_corruption _ -> None)
-  | Some (Cycle.Completed _) -> Some `Recovered
-  | Some
-      ( Cycle.Checkpointed _
-      | Cycle.Input_required _
-      | Cycle.Cancelled _
-      | Cycle.Skipped _
-      | Cycle.Busy _
-      | Cycle.Manual_compaction_not_applied _ )
-  | None -> None
+     | Keeper_unified_turn.Pause_after_transcript_corruption _ -> [])
+  | Cycle.Completed _
+  | Cycle.Checkpointed _
+  | Cycle.Input_required _
+  | Cycle.Cancelled _
+  | Cycle.Skipped _
+  | Cycle.Busy _
+  | Cycle.Manual_compaction_not_applied _ ->
+    []
 ;;
 
-type transcript_corruption_commit =
-  | Transcript_pause_persisted
-  | Transcript_pause_and_settlement_persisted
-  | Transcript_pause_persistence_failed of string
-  | Transcript_pause_settlement_failed of string
+let compaction_outcome_label = function
+  | `Manual_committed _ -> "manual_committed"
+  | `Reactive_committed _ -> "reactive_committed"
+  | `Failed -> "failed"
+;;
 
-let commit_transcript_corruption ~stop ~persist_pause ?settle () =
-  Atomic.set stop true;
-  Eio.Cancel.protect (fun () ->
-    let guarded_call ~site call =
-      try call () with
-      | Eio.Cancel.Cancelled _ as exn -> raise exn
-      | exn -> Error (Printf.sprintf "%s raised: %s" site (Printexc.to_string exn))
-    in
-    match guarded_call ~site:"transcript corruption pause CAS" persist_pause with
-    | Error detail -> Transcript_pause_persistence_failed detail
-    | Ok `No_durable_meta ->
-      Transcript_pause_persistence_failed
-        "transcript corruption pause has no durable Keeper metadata"
-    | Ok `Persisted ->
-      (match settle with
-       | None -> Transcript_pause_persisted
-       | Some settle ->
-         (match guarded_call ~site:"transcript corruption settlement" settle with
-          | Ok () -> Transcript_pause_and_settlement_persisted
-          | Error detail -> Transcript_pause_settlement_failed detail)))
+let record_compaction_outcome_metric ~keeper_name outcome =
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string CompactionOutcomes)
+    ~labels:[ "keeper", keeper_name; "outcome", compaction_outcome_label outcome ]
+    ()
 ;;
 
 module For_testing = struct
   let consume_deferred_runtime_lane_hint =
     consume_deferred_runtime_lane_hint
-
-  type nonrec transcript_corruption_commit = transcript_corruption_commit =
-    | Transcript_pause_persisted
-    | Transcript_pause_and_settlement_persisted
-    | Transcript_pause_persistence_failed of string
-    | Transcript_pause_settlement_failed of string
-
-  let commit_transcript_corruption = commit_transcript_corruption
-
 end
 
 (* Pure: post-turn status event derived from the registry turn-failure
@@ -460,7 +421,7 @@ let run_keepalive_unified_turn
         (fun admission_token ->
     let consumed_stimuli = ref [] in
     let pending_selection
-      : Keeper_event_queue.stimulus option ref
+      : Keeper_event_queue_state.pending_selection option ref
       =
       ref None
     in
@@ -784,41 +745,119 @@ let run_keepalive_unified_turn
           Cycle.meta cycle_outcome)
         else meta_after_triage
       in
-      let transcript_corruption_commit =
-        match !cycle_outcome_ref with
-        | Some (Cycle.Failed { failure; _ }) ->
-          (match failure.Keeper_unified_turn.source_disposition with
-           | Keeper_unified_turn.Pause_after_transcript_corruption { detail } ->
-             Log.Keeper.error
-               ~keeper_name:meta_after_triage.name
-               "transcript corruption retained its exact pending source without \
-                pausing the Keeper: %s"
-               detail;
-             None
-           | Keeper_unified_turn.Follow_failure_route
-           | Keeper_unified_turn.Follow_failure_route_after_no_compaction _
-           | Keeper_unified_turn.Requeue_after_context_compaction _
-           | Keeper_unified_turn.Acknowledge_after_in_turn_handling ->
-             None)
-        | Some
-            ( Cycle.Completed _
-            | Cycle.Checkpointed _
-            | Cycle.Input_required _
-            | Cycle.Cancelled _
-            | Cycle.Skipped _
-            | Cycle.Busy _
-            | Cycle.Manual_compaction_applied _
-            | Cycle.Manual_compaction_failed _
-            | Cycle.Manual_compaction_not_applied _ )
-        | None ->
-          None
+      let terminalize_failed_selection ~selection ~detail =
+        match
+          Keeper_registry_event_queue.terminalize_pending_turn_attempt_result
+            ~base_path:ctx.config.base_path
+            meta_after_triage.name
+            ~current_owner_nonce:meta_after_triage.runtime.nonce
+            ~applied_at:(Time_compat.now ())
+            ~selection
+            ~detail
+        with
+        | Error message -> record_event_queue_failure message
+        | Ok
+            ( Keeper_registry_event_queue.Acked _
+            | Keeper_registry_event_queue.Already_acked _ ) ->
+          selection_acked := true;
+          (match
+             fail_schedule_due
+               ~ctx
+               ~error:detail
+               !consumed_stimuli
+           with
+           | Ok () -> ()
+           | Error message -> record_event_queue_failure message)
+        | Ok
+            (Keeper_registry_event_queue.Ack_committed_followup_failed
+               { stage; detail = followup_detail; _ }) ->
+          selection_acked := true;
+          let stage =
+            match stage with
+            | `Checkpoint -> "checkpoint"
+            | `Wal_compaction -> "wal_compaction"
+            | `Projection -> "projection"
+          in
+          record_event_queue_failure
+            (Printf.sprintf
+               "turn-attempt terminal receipt committed but %s follow-up \
+                failed: %s"
+               stage
+               followup_detail)
       in
-      let meta_after_cycle = meta_after_cycle in
-      (if Option.is_none transcript_corruption_commit
-       then
-         match !pending_selection with
-         | None -> ()
-         | Some selection ->
+      let persist_transcript_corruption_pause ~detail =
+        let pause_result =
+          try
+            Keeper_meta_store.persist_transcript_corruption_pause
+              ctx.config
+              ~keeper_name:meta_after_triage.name
+              ~trace_id:meta_after_triage.runtime.trace_id
+              ~generation:meta_after_triage.runtime.nonce
+          with
+          | Eio.Cancel.Cancelled _ as exn -> raise exn
+          | exn ->
+            Error
+              ("transcript corruption pause raised: "
+               ^ Printexc.to_string exn)
+        in
+        match pause_result with
+        | Ok `Persisted -> true
+        | Ok `No_durable_meta ->
+          record_event_queue_failure
+            "transcript corruption pause has no durable Keeper metadata";
+          Log.Keeper.error
+            ~keeper_name:meta_after_triage.name
+            "transcript corruption retained its exact pending source because \
+             the Keeper has no durable metadata: %s"
+            detail;
+          false
+        | Error pause_detail ->
+          record_event_queue_failure
+            ("transcript corruption pause failed: " ^ pause_detail);
+          Log.Keeper.error
+            ~keeper_name:meta_after_triage.name
+            "transcript corruption retained its exact pending source because \
+             the durable pause failed: %s; pause_error=%s"
+            detail
+            pause_detail;
+          false
+      in
+      let commit_transcript_corruption ~detail =
+        Eio.Cancel.protect (fun () ->
+          Atomic.set stop true;
+          if persist_transcript_corruption_pause ~detail
+          then
+            Option.iter
+              (fun selection ->
+                 terminalize_failed_selection
+                   ~selection
+                   ~detail)
+              !pending_selection)
+      in
+      (match !cycle_outcome_ref with
+       | Some (Cycle.Failed { failure; _ }) ->
+         (match failure.Keeper_unified_turn.source_disposition with
+          | Keeper_unified_turn.Pause_after_transcript_corruption { detail } ->
+            commit_transcript_corruption ~detail
+          | Keeper_unified_turn.Follow_failure_route
+          | Keeper_unified_turn.Requeue_after_context_compaction _
+          | Keeper_unified_turn.Acknowledge_after_in_turn_handling ->
+            ())
+       | Some
+           ( Cycle.Completed _
+           | Cycle.Checkpointed _
+           | Cycle.Input_required _
+           | Cycle.Cancelled _
+           | Cycle.Skipped _
+           | Cycle.Busy _
+           | Cycle.Manual_compaction_applied _
+           | Cycle.Manual_compaction_failed _
+           | Cycle.Manual_compaction_not_applied _ )
+       | None ->
+         ());
+      (match !pending_selection with
+       | None -> ()
+       | Some selection ->
            let remove_completed_selection () =
              match
                Keeper_registry_event_queue.ack_pending_result
@@ -837,8 +876,7 @@ let run_keepalive_unified_turn
            match !cycle_outcome_ref with
            | Some
                ( Cycle.Completed _
-               | Cycle.Manual_compaction_applied _
-               | Cycle.Manual_compaction_not_applied _ ) ->
+               | Cycle.Manual_compaction_applied _ ) ->
              (match
                 complete_schedule_due
                   ~ctx
@@ -850,57 +888,63 @@ let run_keepalive_unified_turn
            | Some (Cycle.Failed { failure; _ }) ->
              (match failure.Keeper_unified_turn.source_disposition with
               | Keeper_unified_turn.Acknowledge_after_in_turn_handling ->
-                (match
-                   fail_schedule_due
-                     ~ctx
-                     ~error:
-                       (Agent_sdk.Error.to_string failure.Keeper_unified_turn.error)
-                     !consumed_stimuli
-                 with
-                 | Ok () -> remove_completed_selection ()
-                 | Error message -> record_event_queue_failure message)
+                terminalize_failed_selection
+                  ~selection
+                  ~detail:
+                    (Agent_sdk.Error.to_string
+                       failure.Keeper_unified_turn.error)
               | Keeper_unified_turn.Follow_failure_route
-              | Keeper_unified_turn.Follow_failure_route_after_no_compaction _
               | Keeper_unified_turn.Requeue_after_context_compaction _
               | Keeper_unified_turn.Pause_after_transcript_corruption _ ->
                 ())
+           | Some (Cycle.Manual_compaction_failed { failure; _ }) ->
+             terminalize_failed_selection
+               ~selection
+               ~detail:(Keeper_manual_compaction.failure_to_string failure)
+           | Some (Cycle.Manual_compaction_not_applied { no_compaction; _ }) ->
+             terminalize_failed_selection
+               ~selection
+               ~detail:
+                 (Keeper_post_turn.compaction_recovery_error_to_string
+                    (Keeper_post_turn.No_compaction no_compaction))
            | Some
                ( Cycle.Checkpointed _
                | Cycle.Input_required _
                | Cycle.Cancelled _
                | Cycle.Skipped _
-               | Cycle.Busy _
-               | Cycle.Manual_compaction_failed _ )
+               | Cycle.Busy _ )
            | None ->
              ());
-      (* RFC-0351 S0 / #25461: advance the compaction streak read by the trigger.
-         [Keeper_post_turn] refuses another compaction once the streak reaches
-         [compaction_retry_escalation_threshold]. This update is intentionally
-         independent of Event Queue source selection: every failed compaction
-         must consume retry budget, including cycles with no selected source. *)
-      (let compaction_outcome =
-         compaction_outcome_of_cycle_outcome !cycle_outcome_ref
+      (let compaction_outcomes =
+         match !cycle_outcome_ref with
+         | Some outcome -> compaction_outcomes_of_cycle_outcome outcome
+         | None -> []
        in
-       match compaction_outcome with
-       | None -> ()
-       | Some `Recovered
-         when meta_after_triage.runtime.compaction_rt.consecutive_failures = 0 ->
-         (* Streak already clear: skip the read-modify-write that every healthy
-            completed turn would otherwise pay. *)
-         ()
-       | Some outcome ->
-         (match
-            Keeper_meta_store.persist_compaction_outcome
-              ctx.config
-              ~keeper_name:meta_after_triage.name
-              ~outcome
-          with
-          | Ok (`Persisted | `No_durable_meta) -> ()
-          | Error message ->
-            Log.Keeper.warn
-              "compaction outcome counter not persisted keeper=%s: %s"
-              meta_after_triage.name
-              message));
+       List.iter
+         (function
+           | `Failed ->
+             record_compaction_outcome_metric
+               ~keeper_name:meta_after_triage.name
+               `Failed
+           | (`Manual_committed commit_count as outcome)
+           | (`Reactive_committed commit_count as outcome) ->
+             record_compaction_outcome_metric
+               ~keeper_name:meta_after_triage.name
+               outcome;
+             (match
+                Keeper_meta_store.persist_compaction_commit_projection
+                  ctx.config
+                  ~keeper_name:meta_after_triage.name
+                  ~commit_count
+              with
+              | Ok `Persisted -> ()
+              | Ok `No_durable_meta -> ()
+              | Error message ->
+                Log.Keeper.warn
+                  "compaction commit count not persisted keeper=%s: %s"
+                  meta_after_triage.name
+                  message))
+         compaction_outcomes);
       { meta = meta_after_cycle
       ; cycle_status =
           if !event_queue_failed then Turn_cycle_crashed else Turn_cycle_completed

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -58,7 +58,7 @@ type heartbeat_event_intake = {
   pending_board_events : Keeper_world_observation.pending_board_event list;
   consumed_stimulus_count : int;
   consumed_stimuli : Keeper_event_queue.stimulus list;
-  pending_selection : Keeper_event_queue.stimulus option;
+  pending_selection : Keeper_event_queue_state.pending_selection option;
   event_queue_intake_error :
     Keeper_heartbeat_stimulus_intake.event_queue_intake_error option;
   event_queue_triggers : Keeper_world_observation.event_queue_trigger list;
@@ -145,19 +145,12 @@ type keepalive_turn_outcome = {
 val record_crashed_cycle_failure :
   base_path:string -> keeper_name:string -> exn -> unit
 
-val compaction_outcome_of_cycle_outcome :
-  Keeper_heartbeat_loop_cycle.cycle_outcome option ->
-  [ `Committed | `Overflow_episode_committed | `Failed | `Recovered ] option
-(** Pure mapping from a cycle outcome to the compaction-streak stamp
-    ([Keeper_meta_store.persist_compaction_outcome]). Manual-lane
-    applied/failed outcomes and in-lane provider-overflow dispositions join
-    the same per-keeper streak. The streak counts consecutive
-    provider-overflow episodes (#25538): an in-lane commit maps to
-    [`Overflow_episode_committed] (advances the streak — committed savings
-    under an incompressible floor must still reach the ceiling), a completed
-    overflow-free turn maps to [`Recovered] (resets it), and only the
-    operator's manual commit maps to [`Committed] (count + reset).
-    Outcomes with no compaction involvement return [None]. *)
+val compaction_outcomes_of_cycle_outcome :
+  Keeper_heartbeat_loop_cycle.cycle_outcome ->
+  [ `Manual_committed of int | `Reactive_committed of int | `Failed ] list
+(** Pure mapping from one possibly nested cycle to every compaction
+    commit/failure observation it contains. Only committed outcomes mutate
+    durable compaction state. *)
 
 
 (** Pure: post-turn status event derived from the registry
@@ -230,19 +223,4 @@ module For_testing : sig
     Keeper_turn_driver.deferred_runtime_lane option ref ->
     Keeper_turn_driver.deferred_runtime_lane ->
     bool
-
-  type transcript_corruption_commit =
-    | Transcript_pause_persisted
-    | Transcript_pause_and_settlement_persisted
-    | Transcript_pause_persistence_failed of string
-    | Transcript_pause_settlement_failed of string
-
-  val commit_transcript_corruption :
-    stop:bool Atomic.t ->
-    persist_pause:
-      (unit -> ([ `Persisted | `No_durable_meta ], string) result) ->
-    ?settle:(unit -> (unit, string) result) ->
-    unit ->
-    transcript_corruption_commit
-
 end

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -170,7 +170,7 @@ type heartbeat_event_intake = {
   pending_board_events : Keeper_world_observation.pending_board_event list;
   consumed_stimulus_count : int;
   consumed_stimuli : Keeper_event_queue.stimulus list;
-  pending_selection : Keeper_event_queue.stimulus option;
+  pending_selection : Keeper_event_queue_state.pending_selection option;
   event_queue_intake_error : event_queue_intake_error option;
   event_queue_triggers : Keeper_world_observation.event_queue_trigger list;
 }
@@ -376,8 +376,12 @@ type spent_selection_reconciliation =
   | Spent_schedule_acknowledged
   | Spent_grant_replay_acknowledged
 
-let reconcile_spent_selection ~config ~keeper_name selection =
-  match selection.Keeper_event_queue.payload with
+let reconcile_spent_selection
+      ~config
+      ~keeper_name
+      (selection : Keeper_event_queue_state.pending_selection)
+  =
+  match selection.source.Keeper_event_queue.payload with
   | Schedule_due wake ->
     (* The schedule lock covers both the terminal read and queue ACK. A retry
        must start under the same lock, so either it starts first and this sees
@@ -495,7 +499,7 @@ let heartbeat_event_intake
   let base_path = ctx.config.base_path in
   let keeper_name = meta_after_triage.name in
   let select_pending_matching ready =
-    Keeper_registry_event_queue.peek_when_result
+    Keeper_registry_event_queue.select_when_result
       ~base_path
       keeper_name
       ~ready
@@ -528,7 +532,10 @@ let heartbeat_event_intake
     | Ok None as empty -> empty
     | Ok (Some selection) ->
       (match
-         reconcile_spent_selection ~config:ctx.config ~keeper_name selection
+         reconcile_spent_selection
+           ~config:ctx.config
+           ~keeper_name
+           selection
        with
        | Error message -> Error message
        | Ok Selection_actionable -> Ok (Some selection)
@@ -560,10 +567,10 @@ let heartbeat_event_intake
          consume_single_heartbeat_stimulus
            ~ctx
            ~meta_after_triage
-           selection
+           selection.source
        with
        | Stimulus_consumed observations ->
-         observations, [ selection ], Some selection, None
+         observations, [ selection.source ], Some selection, None
        | Stimulus_retry_later unavailable ->
          [], [], Some selection, Some (Transient_board_read unavailable))
   in

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.mli
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.mli
@@ -83,7 +83,7 @@ type heartbeat_event_intake = {
   pending_board_events : Keeper_world_observation.pending_board_event list;
   consumed_stimulus_count : int;
   consumed_stimuli : Keeper_event_queue.stimulus list;
-  pending_selection : Keeper_event_queue.stimulus option;
+  pending_selection : Keeper_event_queue_state.pending_selection option;
   event_queue_intake_error : event_queue_intake_error option;
   event_queue_triggers : Keeper_world_observation.event_queue_trigger list;
 }
@@ -106,7 +106,7 @@ type spent_selection_reconciliation =
 val reconcile_spent_selection
   :  config:Workspace_utils.config
   -> keeper_name:string
-  -> Keeper_event_queue.stimulus
+  -> Keeper_event_queue_state.pending_selection
   -> (spent_selection_reconciliation, string) result
 (** Acknowledges a selection whose work has already settled elsewhere, so no
     turn is spent re-observing it. Two kinds settle that way.

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -13,6 +13,7 @@ type applied_receipt =
   { installation : Keeper_checkpoint_store.installed_checkpoint
   ; lifecycle : post_install_lifecycle
   ; manifest : (unit, string) result
+  ; commit_count : int
   }
 
 type success =
@@ -442,10 +443,11 @@ let run_admitted_with
        `Applied
          { recovery = committed.recovery
          ; receipt =
-             { installation = committed.installation
-             ; lifecycle = committed.lifecycle
-             ; manifest
-             }
+           { installation = committed.installation
+           ; lifecycle = committed.lifecycle
+           ; manifest
+           ; commit_count = committed.recovery.commit_count
+           }
          }
      | `Ran (Ok (No_compaction no_compaction)) -> `No_compaction no_compaction)
 ;;

--- a/lib/keeper/keeper_manual_compaction.mli
+++ b/lib/keeper/keeper_manual_compaction.mli
@@ -11,6 +11,7 @@ type applied_receipt =
   { installation : Keeper_checkpoint_store.installed_checkpoint
   ; lifecycle : post_install_lifecycle
   ; manifest : (unit, string) result
+  ; commit_count : int
   }
 
 type success =

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -46,24 +46,7 @@ type compaction_runtime =
   ; last_after_tokens : int
   ; last_check_ts : float
   ; last_decision : compaction_runtime_decision
-  ; consecutive_failures : int
-    (* RFC-0351 S0 / #25461: consecutive manual-compaction failures and
-       reactive provider-overflow episodes for this keeper. In-lane recovery
-       advances the streak even when it durably compacts, because the retried
-       turn can still overflow at an incompressible floor. An overflow-free
-       completed turn or an operator-committed manual compaction resets it. At
-       the threshold, reactive preparation is refused without advancing the
-       streak again. *)
   }
-
-(* RFC-0351 S0 / #25461: streak entries tolerated before reactive compaction
-   preparation is refused. Defined next to [consecutive_failures] so admission
-   and the status/dashboard projections that surface the suspended state read
-   one constant. *)
-let compaction_retry_escalation_threshold = 3
-
-let compaction_retry_suspended rt =
-  rt.consecutive_failures >= compaction_retry_escalation_threshold
 
 type proactive_runtime =
   { count_total : int

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -63,32 +63,7 @@ type compaction_runtime = {
   last_after_tokens : int;
   last_check_ts : float;
   last_decision : compaction_runtime_decision;
-  consecutive_failures : int;
-      (** RFC-0351 S0 / #25461: consecutive manual-compaction failures and
-          reactive provider-overflow episodes. A reactive commit advances the
-          streak; an overflow-free completed turn or operator-committed manual
-          compaction resets it. Once it reaches
-          {!compaction_retry_escalation_threshold}, reactive preparation is
-          refused without counting that refusal as another failure. *)
 }
-
-val compaction_retry_escalation_threshold : int
-(** RFC-0351 S0 / #25461: streak entries tolerated before
-    [Keeper_post_turn.prepare_compaction] stops admitting reactive triggers.
-    Single definition shared by reactive admission and status/dashboard
-    projections.
-
-    The refusal is not itself a compaction failure — it reads this counter
-    without attempting anything, so settling it as one made the threshold
-    self-fulfilling (live keeper [kidsnote] reached 907 against a threshold of
-    3). It is reported as [Keeper_unified_turn.Compaction_refused_without_attempt]
-    and produces no persisted compaction outcome. *)
-
-val compaction_retry_suspended : compaction_runtime -> bool
-(** [true] once the persisted streak has reached
-    {!compaction_retry_escalation_threshold}. Reactive preparation is then
-    refused before checkpoint load or summarizer dispatch; the refusal leaves
-    the streak unchanged. *)
 
 type proactive_runtime = {
   count_total : int;

--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -43,8 +43,6 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     ; Last_compaction_ts, `Float rt.compaction_rt.last_ts
     ; Last_compaction_before_tokens, `Int rt.compaction_rt.last_before_tokens
     ; Last_compaction_after_tokens, `Int rt.compaction_rt.last_after_tokens
-    ; ( Compaction_consecutive_failures
-      , `Int rt.compaction_rt.consecutive_failures )
     ; Proactive_count_total, `Int rt.proactive_rt.count_total
     ; Last_proactive_ts, `Float rt.proactive_rt.last_ts
     ; Proactive_visible_count_total, `Int rt.proactive_rt.visible_count_total

--- a/lib/keeper/keeper_meta_json_current_schema.ml
+++ b/lib/keeper/keeper_meta_json_current_schema.ml
@@ -40,7 +40,6 @@ type field =
   | Last_compaction_ts
   | Last_compaction_before_tokens
   | Last_compaction_after_tokens
-  | Compaction_consecutive_failures
   | Proactive_count_total
   | Last_proactive_ts
   | Proactive_visible_count_total
@@ -96,7 +95,6 @@ let all_fields =
   ; Last_compaction_ts
   ; Last_compaction_before_tokens
   ; Last_compaction_after_tokens
-  ; Compaction_consecutive_failures
   ; Proactive_count_total
   ; Last_proactive_ts
   ; Proactive_visible_count_total
@@ -153,7 +151,6 @@ let field_name = function
   | Last_compaction_ts -> "last_compaction_ts"
   | Last_compaction_before_tokens -> "last_compaction_before_tokens"
   | Last_compaction_after_tokens -> "last_compaction_after_tokens"
-  | Compaction_consecutive_failures -> "compaction_consecutive_failures"
   | Proactive_count_total -> "proactive_count_total"
   | Last_proactive_ts -> "last_proactive_ts"
   | Proactive_visible_count_total -> "proactive_visible_count_total"

--- a/lib/keeper/keeper_meta_json_current_schema.mli
+++ b/lib/keeper/keeper_meta_json_current_schema.mli
@@ -30,7 +30,6 @@ type field =
   | Last_compaction_ts
   | Last_compaction_before_tokens
   | Last_compaction_after_tokens
-  | Compaction_consecutive_failures
   | Proactive_count_total
   | Last_proactive_ts
   | Proactive_visible_count_total

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -330,7 +330,6 @@ let decode_current_meta fields =
   let* last_compaction_ts = float_field fields "last_compaction_ts" in
   let* last_compaction_before_tokens = int_field fields "last_compaction_before_tokens" in
   let* last_compaction_after_tokens = int_field fields "last_compaction_after_tokens" in
-  let* compaction_consecutive_failures = int_field fields "compaction_consecutive_failures" in
   let* proactive_count_total = int_field fields "proactive_count_total" in
   let* last_proactive_ts = float_field fields "last_proactive_ts" in
   let* proactive_visible_count_total = int_field fields "proactive_visible_count_total" in
@@ -403,7 +402,6 @@ let decode_current_meta fields =
       ; last_after_tokens = last_compaction_after_tokens
       ; last_check_ts = last_compaction_check_ts
       ; last_decision = compaction_runtime_decision_of_string last_compaction_decision_raw
-      ; consecutive_failures = compaction_consecutive_failures
       }
     in
     let proactive_rt : proactive_runtime =

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -505,51 +505,15 @@ let persist_compaction_decision config ~keeper_name ~decision
     |> Result.map (fun () -> `Persisted)
 ;;
 
-(* RFC-0351 S0 / #25461, #25538: advance the streak that reactive compaction
-   admission reads. Same read/stamp/merge shape as
-   [persist_compaction_decision] so a concurrent CAS re-applies the stamp
-   instead of dropping it.
-
-   Reset semantics (#25538): the streak counts consecutive provider-overflow
-   episodes, and only a turn that completes without overflow — or an
-   operator-committed manual compaction — resets it.  An in-lane (reactive)
-   commit advances the streak instead of resetting it: a committed plan that
-   saves 920B of a checkpoint (0.07%, live measurement) used to reset the
-   counter on every loop iteration, so an incompressible floor never reached
-   the ceiling.
-
-   [`Committed]/[`Overflow_episode_committed] also advance [count].  That
-   field had no writer: it was serialized to meta and rendered by the
-   dashboard while nothing incremented it, so a keeper whose compaction
-   pipeline was committing normally still reported compaction_count=0 — one
-   keeper carried 88 committed [context_compacted] runtime-manifest records
-   against a meta reading 0. *)
-(* Rendering, not classification: the outcome variant is the state machine's
-   own outcome, so the label comes from an exhaustive match instead of being
-   recovered from a message string.  A new variant fails this match at compile
-   time rather than falling into an unlabelled bucket. *)
-let compaction_outcome_label = function
-  | `Committed -> "committed"
-  | `Overflow_episode_committed -> "overflow_episode_committed"
-  | `Failed -> "failed"
-  | `Recovered -> "recovered"
-;;
-
-let persist_compaction_outcome config ~keeper_name ~outcome
+let persist_compaction_commit_projection config ~keeper_name ~commit_count
   : ([ `Persisted | `No_durable_meta ], string) result
   =
+  if commit_count < 0
+  then Error "checkpoint compaction commit count is negative"
+  else
   let stamp (m : Keeper_meta_contract.keeper_meta) =
     Keeper_meta_contract.map_compaction_rt
-      (fun rt ->
-        match outcome with
-        | `Committed -> { rt with count = rt.count + 1; consecutive_failures = 0 }
-        | `Overflow_episode_committed ->
-          { rt with
-            count = rt.count + 1
-          ; consecutive_failures = rt.consecutive_failures + 1
-          }
-        | `Failed -> { rt with consecutive_failures = rt.consecutive_failures + 1 }
-        | `Recovered -> { rt with consecutive_failures = 0 })
+      (fun rt -> { rt with count = max rt.count commit_count })
       m
   in
   match read_meta config keeper_name with
@@ -561,57 +525,11 @@ let persist_compaction_outcome config ~keeper_name ~outcome
       config
       (stamp disk_meta)
     |> Result.map (fun () ->
-      (* Counted here rather than inside [stamp]: a CAS retry re-applies the
-         stamp, so counting there would report one outcome several times.
-         Only a persisted outcome moved the streak, which is what this
-         series answers — which outcome advanced it, and which reset it.
-
-         The [keeper] label stays: keeper names come from the registry and are
-         stable across replacement (a replaced keeper keeps its name and bumps
-         [generation]), so the series count is bounded by fleet size, and
-         "which keeper's compaction is collapsing" is the question this was
-         added to answer. Unbounded accumulation in the metric store is a
-         store-level property shared by every keeper-labelled emission; it does
-         not get fixed by dropping one dimension here. *)
-      Otel_metric_store.inc_counter
-        Keeper_metrics.(to_string CompactionOutcomes)
-        ~labels:
-          [ "keeper", keeper_name; "outcome", compaction_outcome_label outcome ]
-        ();
       Log.Keeper.info
         ~keeper_name
-        "compaction outcome persisted kind=%s"
-        (compaction_outcome_label outcome);
+        "compaction commit projection persisted count=%d"
+        commit_count;
       `Persisted)
-;;
-
-(* Structural transcript corruption is deterministic current-state damage, not
-   a retry class. Persist the typed reset-required latch before the owning
-   lease is terminally settled. A concurrent dead tombstone remains stronger;
-   an ordinary operator/unclassified pause is upgraded to reset-required. *)
-let persist_transcript_corruption_pause config ~keeper_name
-  : ([ `Persisted | `No_durable_meta ], string) result
-  =
-  let stamp (m : Keeper_meta_contract.keeper_meta) =
-    match
-      Keeper_lifecycle_admission.state
-        ~paused:m.paused
-        ~latched_reason:m.latched_reason
-    with
-    | Keeper_lifecycle_admission.Dead_tombstone -> m
-    | Keeper_lifecycle_admission.Active
-    | Keeper_lifecycle_admission.Paused _ ->
-      Keeper_meta_contract.mark_transcript_corruption_reset_required m
-  in
-  match read_meta config keeper_name with
-  | Error msg -> Error msg
-  | Ok None -> Ok `No_durable_meta
-  | Ok (Some disk_meta) ->
-    write_meta_with_merge
-      ~merge:(fun ~latest ~caller:_ -> stamp latest)
-      config
-      (stamp disk_meta)
-    |> Result.map (fun () -> `Persisted)
 ;;
 
 type identity_update_error =
@@ -667,6 +585,42 @@ let update_meta_if_identity
                (match persist_meta config path persisted with
                 | Ok () -> Ok persisted
                 | Error detail -> Error (Identity_write_failed detail))))
+;;
+
+(* Structural transcript corruption is deterministic current-state damage, not
+   a retry class. Persist the typed reset-required latch before the owning
+   event source receives its terminal receipt. A concurrent dead tombstone
+   remains stronger; an ordinary operator/unclassified pause is upgraded to
+   reset-required. *)
+let persist_transcript_corruption_pause
+      config
+      ~keeper_name
+      ~trace_id
+      ~generation
+  : ([ `Persisted | `No_durable_meta ], string) result
+  =
+  let stamp (m : Keeper_meta_contract.keeper_meta) =
+    match
+      Keeper_lifecycle_admission.state
+        ~paused:m.paused
+        ~latched_reason:m.latched_reason
+    with
+    | Keeper_lifecycle_admission.Dead_tombstone -> m
+    | Keeper_lifecycle_admission.Active
+    | Keeper_lifecycle_admission.Paused _ ->
+      Keeper_meta_contract.mark_transcript_corruption_reset_required m
+  in
+  match
+    update_meta_if_identity
+      config
+      ~name:keeper_name
+      ~trace_id
+      ~generation
+      stamp
+  with
+  | Ok _ -> Ok `Persisted
+  | Error Identity_missing -> Ok `No_durable_meta
+  | Error error -> Error (identity_update_error_to_string error)
 ;;
 
 type identity_remove_error =

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -132,9 +132,9 @@ type identity_update_error =
 
 val identity_update_error_to_string : identity_update_error -> string
 
-(** Re-read and CAS-update [name] only while its trace/generation identity
-    matches the shutdown snapshot. Every CAS retry rechecks identity before
-    applying [update], so a replacement generation is never overwritten. *)
+(** Re-read and atomically update [name] only while its trace/generation
+    identity matches the caller's snapshot, so a replacement generation is
+    never overwritten. *)
 val update_meta_if_identity :
   Workspace.config ->
   name:string ->
@@ -239,38 +239,24 @@ val persist_compaction_decision :
   decision:Keeper_meta_contract.compaction_runtime_decision ->
   ([ `Persisted | `No_durable_meta ], string) result
 
-val persist_compaction_outcome :
+val persist_compaction_commit_projection :
   Workspace.config ->
   keeper_name:string ->
-  outcome:
-    [ `Committed | `Overflow_episode_committed | `Failed | `Recovered ] ->
+  commit_count:int ->
   ([ `Persisted | `No_durable_meta ], string) result
-(** Advance the compaction outcome counters on [compaction_rt] using the same
-    read/stamp/merge shape as {!persist_compaction_decision}.
-
-    [`Overflow_episode_committed] (an in-lane reactive commit) increments
-    [count] AND the streak — committed savings under an incompressible floor
-    must still count toward the ceiling (#25538). [`Recovered] (a turn
-    completed without provider overflow) resets the streak; callers skip the
-    write when the streak is already 0.
-
-    [`Committed] increments [count] and resets [consecutive_failures] to 0;
-    [`Failed] increments [consecutive_failures]. The streak is what
-    {!Keeper_meta_contract.compaction_retry_suspended} reads to refuse a
-    failing compaction instead of retrying it without bound (RFC-0351 S0,
-    #25461); [count] had no writer before this despite being serialized and
-    rendered. The metric carries [keeper] and [outcome]: outcome is the closed
-    outcome variant, and keeper names come from the registry and survive
-    replacement, so the series count is bounded by fleet size. The successful
-    persistence log carries the same typed outcome, which is where a single
-    outcome is resolvable by timestamp; the durable per-Keeper counters stay in
-    [compaction_rt]. *)
+(** Reconcile the status projection after a checkpoint compaction commit.
+    The committed checkpoint context is authoritative; this derived field is
+    monotonic so delayed writes cannot regress a newer projection. The caller
+    owns outcome classification and telemetry. *)
 
 val persist_transcript_corruption_pause :
   Workspace.config ->
   keeper_name:string ->
+  trace_id:Keeper_id.Trace_id.t ->
+  generation:int ->
   ([ `Persisted | `No_durable_meta ], string) result
-(** CAS-merge the existing fail-closed pause surface after structural
-    transcript corruption. A dead tombstone remains stronger and every other
+(** Atomically update the existing fail-closed pause surface after structural
+    transcript corruption only while the exact turn trace/generation still owns
+    the Keeper name. A dead tombstone remains stronger and every other
     live/pause state becomes typed reset-required state. No decoder, migration,
     or automatic retry state is created. *)

--- a/lib/keeper/keeper_paused_work_cancellation_transaction.ml
+++ b/lib/keeper/keeper_paused_work_cancellation_transaction.ml
@@ -1,6 +1,6 @@
 type pending_request =
   { source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; owner_nonce : int
   ; operator_operation_id : string
   ; reason : string
@@ -88,7 +88,7 @@ let cancellation_of_pending_request (request : pending_request) :
   Keeper_registry_event_queue.accepted_cancellation
   =
   { source = request.source
-  ; source_revision = request.source_revision
+  ; source_incarnation = request.source_incarnation
   ; owner_nonce = request.owner_nonce
   ; operator_operation_id = request.operator_operation_id
   ; reason = request.reason

--- a/lib/keeper/keeper_paused_work_cancellation_transaction.mli
+++ b/lib/keeper/keeper_paused_work_cancellation_transaction.mli
@@ -7,7 +7,7 @@
 
 type pending_request =
   { source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; owner_nonce : int
   ; operator_operation_id : string
   ; reason : string

--- a/lib/keeper/keeper_paused_work_disposition_receipt.ml
+++ b/lib/keeper/keeper_paused_work_disposition_receipt.ml
@@ -8,13 +8,13 @@ type transfer_owner =
   ; target_trace_id : Keeper_id.Trace_id.t
   ; target_generation : int
   ; source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; continuation_binding : continuation_binding
   }
 
 type source_terminal_operation =
   { source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; source_receipt : Keeper_event_queue_state.source_terminal_receipt
   }
 
@@ -39,7 +39,7 @@ type save_result =
   | Existing of t
 
 let ( let* ) = Result.bind
-let schema = "masc.keeper.paused-work-disposition.v5"
+let schema = "masc.keeper.paused-work-disposition.v6"
 
 let equal left right =
   String.equal left.keeper_name right.keeper_name
@@ -87,8 +87,8 @@ let validate receipt =
       then Error "paused-work transfer source and target Keepers must differ"
       else if transfer.target_generation < 0
       then Error "paused-work transfer target generation must not be negative"
-      else if Int64.compare transfer.source_revision 0L < 0
-      then Error "paused-work transfer source revision must not be negative"
+      else if Int64.compare transfer.source_incarnation 0L < 0
+      then Error "paused-work transfer source incarnation must not be negative"
       else if String.equal (String.trim transfer.source.post_id) ""
       then Error "paused-work transfer source post id must not be empty"
       else if
@@ -97,8 +97,8 @@ let validate receipt =
       then Error "paused-work transfer continuation binding does not match source"
       else Ok ()
     | Ack_source_terminal operation ->
-      if Int64.compare operation.source_revision 0L < 0
-      then Error "paused-work source-terminal revision must not be negative"
+      if Int64.compare operation.source_incarnation 0L < 0
+      then Error "paused-work source-terminal incarnation must not be negative"
       else
         let* exact =
           Keeper_event_queue_state.source_terminal_receipt_of_stimulus
@@ -114,7 +114,7 @@ let sha256 value = Digestif.SHA256.(digest_string value |> to_hex)
 let keeper_dir config keeper_name =
   let root = Workspace.masc_root_dir config in
   Filename.concat
-    (Filename.concat root "paused-work-dispositions-v5")
+    (Filename.concat root "paused-work-dispositions-v6")
     ("keeper-" ^ sha256 keeper_name)
 ;;
 
@@ -140,7 +140,7 @@ let transfer_owner_to_yojson transfer =
     ; "target_trace_id", `String (Keeper_id.Trace_id.to_string transfer.target_trace_id)
     ; "target_generation", `Int transfer.target_generation
     ; "source", Keeper_event_queue.stimulus_to_yojson transfer.source
-    ; "source_revision", `Intlit (Int64.to_string transfer.source_revision)
+    ; "source_incarnation", `Intlit (Int64.to_string transfer.source_incarnation)
     ; "continuation_binding", continuation_binding_to_yojson transfer.continuation_binding
     ]
 ;;
@@ -150,12 +150,14 @@ let source_terminal_receipt_kind = function
   | Keeper_event_queue_state.Background_job_terminal _ ->
     "background_job_terminal"
   | Keeper_event_queue_state.Hitl_terminal _ -> "hitl_terminal"
+  | Keeper_event_queue_state.Turn_attempt_terminal _ ->
+    "turn_attempt_terminal"
 ;;
 
 let source_terminal_operation_to_yojson operation =
   `Assoc
     [ "source", Keeper_event_queue.stimulus_to_yojson operation.source
-    ; "source_revision", `Intlit (Int64.to_string operation.source_revision)
+    ; "source_incarnation", `Intlit (Int64.to_string operation.source_incarnation)
     ; "source_receipt_kind", `String (source_terminal_receipt_kind operation.source_receipt)
     ]
 ;;
@@ -200,13 +202,13 @@ let requested_at_of_yojson = function
   | _ -> Error "paused-work disposition request time must be numeric"
 ;;
 
-let source_revision_of_yojson = function
+let source_incarnation_of_yojson = function
   | `Int value -> Ok (Int64.of_int value)
   | `Intlit value ->
     (match Int64.of_string_opt value with
      | Some value -> Ok value
-     | None -> Error "paused-work disposition source revision is invalid")
-  | _ -> Error "paused-work disposition source revision must be an integer"
+     | None -> Error "paused-work disposition source incarnation is invalid")
+  | _ -> Error "paused-work disposition source incarnation must be an integer"
 ;;
 
 let continuation_binding_of_yojson = function
@@ -226,14 +228,14 @@ let transfer_owner_of_yojson = function
      | [ ("continuation_binding", continuation_binding_json)
        ; ("from_keeper", `String from_keeper)
        ; ("source", source_json)
-       ; ("source_revision", source_revision_json)
+       ; ("source_incarnation", source_incarnation_json)
        ; ("target_generation", `Int target_generation)
        ; ("target_trace_id", `String target_trace_id)
        ; ("to_keeper", `String to_keeper)
        ] ->
        let* target_trace_id = Keeper_id.Trace_id.of_string target_trace_id in
        let* source = Keeper_event_queue.stimulus_of_yojson source_json in
-       let* source_revision = source_revision_of_yojson source_revision_json in
+       let* source_incarnation = source_incarnation_of_yojson source_incarnation_json in
        let* continuation_binding =
          continuation_binding_of_yojson continuation_binding_json
        in
@@ -243,7 +245,7 @@ let transfer_owner_of_yojson = function
          ; target_trace_id
          ; target_generation
          ; source
-         ; source_revision
+         ; source_incarnation
          ; continuation_binding
          }
      | _ -> Error "paused-work transfer fields are not exact")
@@ -254,11 +256,11 @@ let source_terminal_operation_of_yojson = function
   | `Assoc fields ->
     (match sorted fields with
      | [ ("source", source_json)
+       ; ("source_incarnation", source_incarnation_json)
        ; ("source_receipt_kind", `String source_receipt_kind)
-       ; ("source_revision", source_revision_json)
        ] ->
        let* source = Keeper_event_queue.stimulus_of_yojson source_json in
-       let* source_revision = source_revision_of_yojson source_revision_json in
+       let* source_incarnation = source_incarnation_of_yojson source_incarnation_json in
        let* source_receipt =
          Keeper_event_queue_state.source_terminal_receipt_of_stimulus source
        in
@@ -267,7 +269,7 @@ let source_terminal_operation_of_yojson = function
          then Ok ()
          else Error "paused-work source-terminal receipt kind does not match source"
        in
-       Ok { source; source_revision; source_receipt }
+       Ok { source; source_incarnation; source_receipt }
      | _ -> Error "paused-work source-terminal fields are not exact")
   | _ -> Error "paused-work source-terminal operation must be an object"
 ;;

--- a/lib/keeper/keeper_paused_work_disposition_receipt.mli
+++ b/lib/keeper/keeper_paused_work_disposition_receipt.mli
@@ -10,13 +10,13 @@ type transfer_owner =
   ; target_trace_id : Keeper_id.Trace_id.t
   ; target_generation : int
   ; source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; continuation_binding : continuation_binding
   }
 
 type source_terminal_operation =
   { source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; source_receipt : Keeper_event_queue_state.source_terminal_receipt
   }
 

--- a/lib/keeper/keeper_paused_work_operator.ml
+++ b/lib/keeper/keeper_paused_work_operator.ml
@@ -347,7 +347,10 @@ let error_class = function
     `Unavailable
 ;;
 
-let pending_item_to_yojson source =
+let pending_item_to_yojson
+      (selection : Queue_state.pending_selection)
+  =
+  let source = selection.source in
   let source_terminal_receipt_kind =
     match Queue_state.source_terminal_receipt_of_stimulus source with
     | Ok receipt -> `String (Disposition.source_terminal_receipt_kind receipt)
@@ -355,6 +358,7 @@ let pending_item_to_yojson source =
   in
   `Assoc
     [ "source", Queue.stimulus_to_yojson source
+    ; "source_incarnation", `Intlit (Int64.to_string selection.admitted_revision)
     ; ( "continuation_binding"
       , Disposition.continuation_binding_of_source source
         |> Disposition.continuation_binding_to_yojson )
@@ -378,11 +382,11 @@ let inventory_json config ~keeper_name =
       ~keeper_name
     |> Result.map_error (fun detail -> Inventory_queue_read_failed detail)
   in
-  let pending = Queue_state.pending state |> Queue.to_list in
+  let pending = Queue_state.pending_selections state in
   let pause_kind = Keeper_activation_readiness.pause_kind meta in
   Ok
     (`Assoc
-      [ "schema", `String "masc.keeper.paused-work.inventory.v1"
+      [ "schema", `String "masc.keeper.paused-work.inventory.v2"
       ; "operator_request_schema", `String Request.schema
       ; "keeper_name", `String keeper_name
       ; ( "owner"

--- a/lib/keeper/keeper_paused_work_operator_request.ml
+++ b/lib/keeper/keeper_paused_work_operator_request.ml
@@ -16,7 +16,7 @@ type t =
   | Ack_source_terminal of Source_terminal.request
 
 let ( let* ) = Result.bind
-let schema = "masc.keeper.paused-work.operator-request.v3"
+let schema = "masc.keeper.paused-work.operator-request.v4"
 
 let sorted fields =
   List.sort (fun (left, _) (right, _) -> String.compare left right) fields
@@ -69,13 +69,13 @@ let parse_cancel_pending = function
     ; ("reason", `String reason)
     ; ("schema", `String request_schema)
     ; ("source", source_json)
-    ; ("source_revision", source_revision_json)
+    ; ("source_incarnation", source_incarnation_json)
     ; ("source_state", `String "pending")
     ]
     when String.equal request_schema schema ->
     let* source = Queue.stimulus_of_yojson source_json in
-    let* source_revision = int64_of_yojson "source_revision" source_revision_json in
-    let* source_revision = nonnegative_int64 "source_revision" source_revision in
+    let* source_incarnation = int64_of_yojson "source_incarnation" source_incarnation_json in
+    let* source_incarnation = nonnegative_int64 "source_incarnation" source_incarnation in
     let* operator_operation_id =
       nonblank "operator_operation_id" operator_operation_id
     in
@@ -85,7 +85,7 @@ let parse_cancel_pending = function
       (Cancel_pending
          Cancellation.
            { source
-           ; source_revision
+           ; source_incarnation
            ; owner_nonce
            ; operator_operation_id
            ; reason
@@ -100,14 +100,14 @@ let parse_transfer = function
     ; ("owner_nonce", `Int owner_nonce)
     ; ("schema", `String request_schema)
     ; ("source", source_json)
-    ; ("source_revision", source_revision_json)
+    ; ("source_incarnation", source_incarnation_json)
     ; ("target_generation", `Int target_generation)
     ; ("to_keeper", `String to_keeper)
     ]
     when String.equal request_schema schema ->
     let* source = Queue.stimulus_of_yojson source_json in
-    let* source_revision = int64_of_yojson "source_revision" source_revision_json in
-    let* source_revision = nonnegative_int64 "source_revision" source_revision in
+    let* source_incarnation = int64_of_yojson "source_incarnation" source_incarnation_json in
+    let* source_incarnation = nonnegative_int64 "source_incarnation" source_incarnation in
     let* continuation_binding =
       Disposition.continuation_binding_of_yojson continuation_binding_json
     in
@@ -123,7 +123,7 @@ let parse_transfer = function
          ; request =
              Transfer.
                { source
-               ; source_revision
+               ; source_incarnation
                ; owner_nonce
                ; target_generation
                ; continuation_binding
@@ -139,13 +139,13 @@ let parse_source_terminal = function
     ; ("owner_nonce", `Int owner_nonce)
     ; ("schema", `String request_schema)
     ; ("source", source_json)
+    ; ("source_incarnation", source_incarnation_json)
     ; ("source_receipt_kind", `String source_receipt_kind)
-    ; ("source_revision", source_revision_json)
     ]
     when String.equal request_schema schema ->
     let* source = Queue.stimulus_of_yojson source_json in
-    let* source_revision = int64_of_yojson "source_revision" source_revision_json in
-    let* source_revision = nonnegative_int64 "source_revision" source_revision in
+    let* source_incarnation = int64_of_yojson "source_incarnation" source_incarnation_json in
+    let* source_incarnation = nonnegative_int64 "source_incarnation" source_incarnation in
     let* source_receipt = Queue_state.source_terminal_receipt_of_stimulus source in
     let* () =
       if
@@ -163,7 +163,7 @@ let parse_source_terminal = function
       (Ack_source_terminal
          Source_terminal.
            { source
-           ; source_revision
+           ; source_incarnation
            ; owner_nonce
            ; source_receipt
            ; operator_operation_id

--- a/lib/keeper/keeper_paused_work_source_terminal_transaction.ml
+++ b/lib/keeper/keeper_paused_work_source_terminal_transaction.ml
@@ -1,6 +1,6 @@
 type request =
   { source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; owner_nonce : int
   ; source_receipt : Keeper_event_queue_state.source_terminal_receipt
   ; operator_operation_id : string
@@ -108,8 +108,8 @@ let error_to_string error =
 let validate_request request =
   if request.owner_nonce < 0
   then Error "owner generation must not be negative"
-  else if Int64.compare request.source_revision 0L < 0
-  then Error "source revision must not be negative"
+  else if Int64.compare request.source_incarnation 0L < 0
+  then Error "source incarnation must not be negative"
   else if String.equal (String.trim request.source.post_id) ""
   then Error "source post id must not be empty"
   else if String.equal (String.trim request.operator_operation_id) ""
@@ -155,22 +155,17 @@ let validate_source_queue config ~keeper_name request =
       ~keeper_name
     |> Result.map_error (fun detail -> Source_queue_validation_failed detail)
   in
-  if not (Int64.equal (Keeper_event_queue_state.revision state) request.source_revision)
-  then Error (Source_queue_validation_failed "source revision changed")
-  else if Keeper_event_queue_state.transition_outbox state <> []
+  if Keeper_event_queue_state.transition_outbox state <> []
   then Error (Source_queue_validation_failed "source lane has a pending transition outbox")
   else
-    let matching =
-      Keeper_event_queue.to_list (Keeper_event_queue_state.pending state)
-      |> List.filter (fun source ->
-        Keeper_event_queue.stimulus_identity_equal request.source source)
-    in
-    match matching with
-    | [ source ] when source = request.source -> Ok ()
-    | [ _ ] -> Error (Source_queue_validation_failed "source snapshot changed")
-    | [] -> Error (Source_queue_validation_failed "source is not pending")
-    | _ :: _ :: _ ->
-      Error (Source_queue_validation_failed "source identity is duplicated")
+    Keeper_event_queue_state.validate_pending_selection
+      ~selection:
+        { source = request.source
+        ; admitted_revision = request.source_incarnation
+        }
+      state
+    |> Result.map_error (fun detail ->
+      Source_queue_validation_failed detail)
 ;;
 
 let operation_of_receipt receipt =
@@ -190,7 +185,7 @@ let receipt_matches_request ~keeper_name request receipt =
     && Int.equal receipt.expected_generation request.owner_nonce
     && String.equal receipt.operator_operation_id request.operator_operation_id
     && operation.source = request.source
-    && Int64.equal operation.source_revision request.source_revision
+    && Int64.equal operation.source_incarnation request.source_incarnation
     && operation.source_receipt = request.source_receipt
 ;;
 
@@ -200,7 +195,7 @@ let create_receipt config ~keeper_name request =
   let* () = validate_source_queue config ~keeper_name request in
   let operation : Keeper_paused_work_disposition_receipt.source_terminal_operation =
     { source = request.source
-    ; source_revision = request.source_revision
+    ; source_incarnation = request.source_incarnation
     ; source_receipt = request.source_receipt
     }
   in
@@ -221,7 +216,7 @@ let project_receipt config receipt =
   let* operation = operation_of_receipt receipt in
   let source_terminal : Keeper_registry_event_queue.accepted_source_terminal =
     { source = operation.source
-    ; source_revision = operation.source_revision
+    ; source_incarnation = operation.source_incarnation
     ; owner_nonce = receipt.Keeper_paused_work_disposition_receipt.expected_generation
     ; operator_operation_id = receipt.operator_operation_id
     ; source_receipt = operation.source_receipt

--- a/lib/keeper/keeper_paused_work_source_terminal_transaction.mli
+++ b/lib/keeper/keeper_paused_work_source_terminal_transaction.mli
@@ -2,7 +2,7 @@
 
 type request =
   { source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; owner_nonce : int
   ; source_receipt : Keeper_event_queue_state.source_terminal_receipt
   ; operator_operation_id : string

--- a/lib/keeper/keeper_paused_work_transfer_transaction.ml
+++ b/lib/keeper/keeper_paused_work_transfer_transaction.ml
@@ -1,6 +1,6 @@
 type request =
   { source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; owner_nonce : int
   ; target_generation : int
   ; continuation_binding : Keeper_paused_work_disposition_receipt.continuation_binding
@@ -147,8 +147,8 @@ let validate_request ~from_keeper ~to_keeper request =
   then Error "source owner generation must not be negative"
   else if request.target_generation < 0
   then Error "target owner generation must not be negative"
-  else if Int64.compare request.source_revision 0L < 0
-  then Error "source revision must not be negative"
+  else if Int64.compare request.source_incarnation 0L < 0
+  then Error "source incarnation must not be negative"
   else if String.equal (String.trim request.source.post_id) ""
   then Error "source post id must not be empty"
   else if String.equal (String.trim request.operator_operation_id) ""
@@ -209,22 +209,17 @@ let validate_source_queue config ~from_keeper request =
       ~keeper_name:from_keeper
     |> Result.map_error (fun detail -> Source_queue_validation_failed detail)
   in
-  if not (Int64.equal (Keeper_event_queue_state.revision state) request.source_revision)
-  then Error (Source_queue_validation_failed "source revision changed")
-  else if Keeper_event_queue_state.transition_outbox state <> []
+  if Keeper_event_queue_state.transition_outbox state <> []
   then Error (Source_queue_validation_failed "source lane has a pending transition outbox")
   else
-    let matching =
-      Keeper_event_queue.to_list (Keeper_event_queue_state.pending state)
-      |> List.filter (fun source ->
-        Keeper_event_queue.stimulus_identity_equal request.source source)
-    in
-    match matching with
-    | [ source ] when source = request.source -> Ok ()
-    | [ _ ] -> Error (Source_queue_validation_failed "source snapshot changed")
-    | [] -> Error (Source_queue_validation_failed "source is not pending")
-    | _ :: _ :: _ ->
-      Error (Source_queue_validation_failed "source identity is duplicated")
+    Keeper_event_queue_state.validate_pending_selection
+      ~selection:
+        { source = request.source
+        ; admitted_revision = request.source_incarnation
+        }
+      state
+    |> Result.map_error (fun detail ->
+      Source_queue_validation_failed detail)
 ;;
 
 let transfer_of_receipt receipt =
@@ -247,7 +242,7 @@ let receipt_matches_request ~from_keeper ~to_keeper request receipt =
     && String.equal transfer.to_keeper to_keeper
     && Int.equal transfer.target_generation request.target_generation
     && transfer.source = request.source
-    && Int64.equal transfer.source_revision request.source_revision
+    && Int64.equal transfer.source_incarnation request.source_incarnation
     && transfer.continuation_binding = request.continuation_binding
 ;;
 
@@ -263,7 +258,7 @@ let create_receipt config ~from_keeper ~to_keeper request =
     ; target_trace_id = target_meta.runtime.trace_id
     ; target_generation = request.target_generation
     ; source = request.source
-    ; source_revision = request.source_revision
+    ; source_incarnation = request.source_incarnation
     ; continuation_binding = request.continuation_binding
     }
   in
@@ -282,7 +277,7 @@ let accepted_transfer receipt
       (transfer : Keeper_paused_work_disposition_receipt.transfer_owner)
     : Keeper_registry_event_queue.accepted_transfer =
   { source = transfer.Keeper_paused_work_disposition_receipt.source
-  ; source_revision = transfer.source_revision
+  ; source_incarnation = transfer.source_incarnation
   ; owner_nonce = receipt.Keeper_paused_work_disposition_receipt.expected_generation
   ; operator_operation_id = receipt.operator_operation_id
   ; from_keeper = transfer.from_keeper

--- a/lib/keeper/keeper_paused_work_transfer_transaction.mli
+++ b/lib/keeper/keeper_paused_work_transfer_transaction.mli
@@ -2,7 +2,7 @@
 
 type request =
   { source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; owner_nonce : int
   ; target_generation : int
   ; continuation_binding : Keeper_paused_work_disposition_receipt.continuation_binding

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -59,6 +59,7 @@ type compaction_recovery = {
   trigger : Compaction_trigger.t;
   evidence : Keeper_compaction_evidence.t;
   turn_generation : int;
+  commit_count : int;
 }
 
 type no_compaction = Keeper_compaction_outcome.no_compaction =
@@ -71,7 +72,6 @@ type compaction_recovery_error =
   | Checkpoint_candidate_failed of string
   | Compaction_rejected of Keeper_compact_policy.compaction_rejection
   | No_compaction of no_compaction
-  | Retry_suspended of { consecutive_failures : int }
 
 type prepared_commit_failure =
   { error : compaction_recovery_error
@@ -92,7 +92,6 @@ let compaction_recovery_error_to_tag = function
     Keeper_compact_policy.compaction_rejection_to_tag reason
   | No_compaction { reason; _ } ->
     "no_compaction:" ^ Keeper_compaction_outcome.no_compaction_reason_label reason
-  | Retry_suspended _ -> "retry_suspended"
 
 let checkpoint_load_error_detail = function
   | Keeper_checkpoint_store.Not_found -> "checkpoint not found"
@@ -173,12 +172,6 @@ let compaction_recovery_error_to_string = function
       source.turn_count
       source.sha256
       (Keeper_compaction_outcome.no_compaction_reason_to_string reason)
-  | Retry_suspended { consecutive_failures } ->
-    Printf.sprintf
-      "compaction retry suspended after %d consecutive failures; reactive \
-       prepare refused before the summarizer call — an operator-committed \
-       manual compaction resets the streak and lifts the suspension"
-      consecutive_failures
 
 (* ── Tier A6: resilience post-turn wire-in (Cycle 23) ──────────────
    Feature-flag-gated layer that runs before tool emission and
@@ -626,54 +619,17 @@ let prepare_compaction_admitted
                (Keeper_compact_policy.compaction_decision_to_string decision))))
 ;;
 
-(* RFC-0351 S0 / #25461: reactive admission gate in front of the prepare
-   phase. Once the persisted failure streak reaches the escalation threshold
-   reactive preparation is refused before checkpoint load or a summarizer LLM
-   call. The manual trigger passes through on purpose: an operator-committed
-   compaction is the recovery lever — its commit resets the streak and lifts
-   the suspension. *)
 let prepare_compaction_with
       ~compact_for_request
       ~base_dir
       ~(meta : keeper_meta)
       ~(trigger : Compaction_trigger.t)
   : (prepared_compaction, compaction_recovery_error) result =
-  let suspended =
-    Keeper_meta_contract.compaction_retry_suspended meta.runtime.compaction_rt
-  in
-  match trigger with
-  (* The suspension guard follows the trigger's origin, not its axis. The
-     provider token window, serialized byte limit, and serving-admission token
-     evidence are all raised by the turn path itself, so a suspended retry must
-     refuse them or a keeper whose compactions keep failing would keep
-     re-entering compaction on every turn. [Manual] stays exempt: an operator
-     asked for this one, and refusing it would leave no way to intervene. *)
-  | Compaction_trigger.Provider_overflow _
-  | Compaction_trigger.Request_body_over_capacity _
-  | Compaction_trigger.Request_body_refused_by_provider _
-  | Compaction_trigger.Serving_input_capacity
-      (Compaction_trigger.Boundary_unknown _)
-  | Compaction_trigger.Serving_input_capacity
-      (Compaction_trigger.Input_rejected _)
-    when suspended ->
-    Error
-      (Retry_suspended
-         { consecutive_failures =
-             meta.runtime.compaction_rt.consecutive_failures
-         })
-  | Compaction_trigger.Provider_overflow _
-  | Compaction_trigger.Request_body_over_capacity _
-  | Compaction_trigger.Request_body_refused_by_provider _
-  | Compaction_trigger.Serving_input_capacity
-      (Compaction_trigger.Boundary_unknown _)
-  | Compaction_trigger.Serving_input_capacity
-      (Compaction_trigger.Input_rejected _)
-  | Compaction_trigger.Manual ->
-    prepare_compaction_admitted
-      ~compact_for_request
-      ~base_dir
-      ~meta
-      ~trigger
+  prepare_compaction_admitted
+    ~compact_for_request
+    ~base_dir
+    ~meta
+    ~trigger
 ;;
 
 let prepare_compaction
@@ -719,83 +675,119 @@ let commit_prepared_compaction_with
     Not_committed (no_compaction_of_prepared ~cause prepared)
   in
   try
+    let candidate_context = oas_context_of_context context in
     match
-      save_oas_checkpoint_if_source
-        ~multimodal_policy:retry_meta.multimodal_policy
-        ~keeper_name:retry_meta.name
-        ~session
-        ~agent_name:retry_meta.agent_name
-        ~ctx:context
-        ~generation:turn_generation
-        ~expected_source_ref:source_ref
+      Keeper_checkpoint_store.compaction_commit_count_of_context
+        candidate_context
     with
-    | Ok
-        ( saved_checkpoint
-        , Keeper_checkpoint_store.Installed installed ) ->
-      let recovery =
-        { checkpoint = saved_checkpoint
-        ; checkpoint_installation = installed
-        ; trigger = prepared_trigger
-        ; evidence
-        ; turn_generation
+    | Error detail ->
+      Log.Keeper.error
+        ~keeper_name:retry_meta.name
+        "compaction checkpoint has invalid commit count: %s"
+        detail;
+      not_committed Keeper_compaction_outcome.Domain_invalid_output
+    | Ok source_commit_count when source_commit_count = max_int ->
+      Log.Keeper.error
+        ~keeper_name:retry_meta.name
+        "compaction checkpoint commit count is exhausted";
+      not_committed Keeper_compaction_outcome.Domain_invalid_output
+    | Ok source_commit_count ->
+      let commit_count = source_commit_count + 1 in
+      let stamped_context =
+        Agent_sdk.Context.copy ~eio:true candidate_context
+      in
+      Agent_sdk.Context.set_scoped
+        stamped_context
+        Agent_sdk.Context.Session
+        Keeper_checkpoint_store.compaction_commit_count_context_key
+        (`Int commit_count);
+      let commit_context =
+        { checkpoint =
+            { context.checkpoint with context = stamped_context }
         }
       in
-      (try
-         Eio.Cancel.protect
-         @@ fun () ->
-         after_checkpoint_installed ();
-         (try
-            Otel_metric_store.inc_counter
-              Keeper_metrics.(to_string Compactions)
-              ~labels:[ "keeper", retry_meta.name ]
-              ()
-          with
-          | exn ->
-            log_keeper_exn
-              ~label:"compaction committed metric emission"
-              exn);
-         Committed recovery
+      (match
+         save_oas_checkpoint_if_source
+           ~multimodal_policy:retry_meta.multimodal_policy
+           ~keeper_name:retry_meta.name
+           ~session
+           ~agent_name:retry_meta.agent_name
+           ~ctx:commit_context
+           ~generation:turn_generation
+           ~expected_source_ref:source_ref
        with
-       | Eio.Cancel.Cancelled _ as exn ->
-         commit_failure
-           ~committed:recovery
-           (Checkpoint_candidate_failed
-              ("post-install compaction callback was cancelled: "
-               ^ Printexc.to_string exn))
-       | exn ->
-         let detail = Printexc.to_string exn in
-         log_keeper_exn
-           ~label:"post-install compaction callback"
-           exn;
-         commit_failure
-           ~committed:recovery
-           (Checkpoint_candidate_failed
-              ("post-install compaction callback raised: " ^ detail)))
-    | Ok
-        ( _
-        , Keeper_checkpoint_store.Not_installed
-            { cause = Keeper_checkpoint_store.Source_changed actual; _ } ) ->
-      Log.Keeper.warn
-        "compaction checkpoint source changed: %s"
-        (checkpoint_ref_detail actual);
-      not_committed Keeper_compaction_outcome.Checkpoint_source_changed
-    | Ok
-        (_, Keeper_checkpoint_store.Not_installed { cause = cas_error; _ })
-    | Error (Persistence_error cas_error) ->
-      let detail = checkpoint_cas_error_detail cas_error in
-      Log.Keeper.error "compaction checkpoint save failed: %s" detail;
-      Otel_metric_store.inc_counter
-        Keeper_metrics.(to_string CheckpointFailures)
-        ~labels:
-          [ "keeper", retry_meta.agent_name
-          ; ( "operation"
-            , Keeper_checkpoint_failure_operation.(to_label Compaction_save) )
-          ]
-        ();
-      not_committed Keeper_compaction_outcome.Checkpoint_persistence_failed
-    | Error (Tool_history_invalid _) ->
-      not_committed
-        Keeper_compaction_outcome.Invalid_structural_source_after_dispatch
+       | Ok
+           ( saved_checkpoint
+           , Keeper_checkpoint_store.Installed installed ) ->
+         let recovery =
+           { checkpoint = saved_checkpoint
+           ; checkpoint_installation = installed
+           ; trigger = prepared_trigger
+           ; evidence
+           ; turn_generation
+           ; commit_count
+           }
+         in
+         (try
+            Eio.Cancel.protect
+            @@ fun () ->
+            after_checkpoint_installed ();
+            (try
+               Otel_metric_store.inc_counter
+                 Keeper_metrics.(to_string Compactions)
+                 ~labels:[ "keeper", retry_meta.name ]
+                 ()
+             with
+             | exn ->
+               log_keeper_exn
+                 ~label:"compaction committed metric emission"
+                 exn);
+            Committed recovery
+          with
+          | Eio.Cancel.Cancelled _ as exn ->
+            commit_failure
+              ~committed:recovery
+              (Checkpoint_candidate_failed
+                 ("post-install compaction callback was cancelled: "
+                  ^ Printexc.to_string exn))
+          | exn ->
+            let detail = Printexc.to_string exn in
+            log_keeper_exn
+              ~label:"post-install compaction callback"
+              exn;
+            commit_failure
+              ~committed:recovery
+              (Checkpoint_candidate_failed
+                 ("post-install compaction callback raised: "
+                  ^ detail)))
+       | Ok
+           ( _
+           , Keeper_checkpoint_store.Not_installed
+               { cause = Keeper_checkpoint_store.Source_changed actual; _ } ) ->
+         Log.Keeper.warn
+           "compaction checkpoint source changed: %s"
+           (checkpoint_ref_detail actual);
+         not_committed Keeper_compaction_outcome.Checkpoint_source_changed
+       | Ok
+           (_, Keeper_checkpoint_store.Not_installed { cause = cas_error; _ })
+       | Error (Persistence_error cas_error) ->
+         let detail = checkpoint_cas_error_detail cas_error in
+         Log.Keeper.error
+           "compaction checkpoint save failed: %s"
+           detail;
+         Otel_metric_store.inc_counter
+           Keeper_metrics.(to_string CheckpointFailures)
+           ~labels:
+             [ "keeper", retry_meta.agent_name
+             ; ( "operation"
+               , Keeper_checkpoint_failure_operation.(to_label Compaction_save) )
+             ]
+           ();
+         not_committed
+           Keeper_compaction_outcome.Checkpoint_persistence_failed
+       | Error (Tool_history_invalid _) ->
+         not_committed
+           Keeper_compaction_outcome.Invalid_structural_source_after_dispatch)
   with
   | Eio.Cancel.Cancelled _ as exn ->
     let raw_bt = Printexc.get_raw_backtrace () in

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -34,6 +34,7 @@ type compaction_recovery =
   ; trigger : Compaction_trigger.t
   ; evidence : Keeper_compaction_evidence.t
   ; turn_generation : int
+  ; commit_count : int
   } [@@warning "-69"]
 
 type no_compaction = Keeper_compaction_outcome.no_compaction =
@@ -46,15 +47,6 @@ type compaction_recovery_error =
   | Checkpoint_candidate_failed of string
   | Compaction_rejected of Keeper_compact_policy.compaction_rejection
   | No_compaction of no_compaction
-  | Retry_suspended of { consecutive_failures : int }
-      (** RFC-0351 S0 / #25461: the keeper's compaction failure streak reached
-          [Keeper_meta_contract.compaction_retry_escalation_threshold], so a
-          reactive ([Provider_overflow]) prepare is refused before the
-          checkpoint load and the summarizer LLM call. The pending source
-          remains on the ordinary failure route without a fabricated durable
-          escalation.
-          [Manual] prepares bypass the gate: an operator-committed compaction
-          resets the streak and lifts the suspension. *)
 
 type prepared_commit_failure =
   { error : compaction_recovery_error

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -15,7 +15,7 @@ let publish_pending ~base_path name pending =
 
 type accepted_cancellation = Keeper_event_queue_persistence.accepted_cancellation =
   { source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; owner_nonce : int
   ; operator_operation_id : string
   ; reason : string
@@ -23,7 +23,7 @@ type accepted_cancellation = Keeper_event_queue_persistence.accepted_cancellatio
 
 type accepted_transfer = Keeper_event_queue_persistence.accepted_transfer =
   { source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; owner_nonce : int
   ; operator_operation_id : string
   ; from_keeper : string
@@ -34,10 +34,11 @@ type source_terminal_receipt = Keeper_event_queue_persistence.source_terminal_re
   | Fusion_terminal of Keeper_event_queue.fusion_completion
   | Background_job_terminal of Keeper_event_queue.bg_job_completion
   | Hitl_terminal of Keeper_event_queue.hitl_resolution
+  | Turn_attempt_terminal of { detail : string }
 
 type accepted_source_terminal = Keeper_event_queue_persistence.accepted_source_terminal =
   { source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; owner_nonce : int
   ; operator_operation_id : string
   ; source_receipt : source_terminal_receipt
@@ -346,6 +347,16 @@ let peek_when_result ~base_path name ~ready =
       ~ready
 ;;
 
+let select_when_result ~base_path name ~ready =
+  match Keeper_registry.get ~base_path name with
+  | None -> Error (Printf.sprintf "keeper not registered: %s" name)
+  | Some _ ->
+    Keeper_event_queue_persistence.select_when_result
+      ~base_path
+      ~keeper_name:name
+      ~ready
+;;
+
 let validate_pending_selection_result ~base_path name ~selection =
   Keeper_event_queue_persistence.validate_pending_selection_result
     ~base_path
@@ -409,6 +420,30 @@ let ack_pending_source_terminal_result
     ~current_owner_nonce
     ~acked_at
     ~source_terminal
+    ~after_commit:(publish_pending ~base_path name)
+    ()
+  |> Result.map (function
+    | Transition_applied receipt -> Acked receipt
+    | Transition_already_applied receipt -> Already_acked receipt
+    | Transition_committed_followup_failed { receipt; stage; detail } ->
+      Ack_committed_followup_failed { receipt; stage; detail })
+;;
+
+let terminalize_pending_turn_attempt_result
+      ~base_path
+      name
+      ~current_owner_nonce
+      ~applied_at
+      ~selection
+      ~detail
+  =
+  Keeper_event_queue_persistence.terminalize_pending_turn_attempt_result
+    ~base_path
+    ~keeper_name:name
+    ~current_owner_nonce
+    ~applied_at
+    ~selection
+    ~detail
     ~after_commit:(publish_pending ~base_path name)
     ()
   |> Result.map (function

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -8,7 +8,7 @@
 
 type accepted_cancellation = Keeper_event_queue_persistence.accepted_cancellation =
   { source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; owner_nonce : int
   ; operator_operation_id : string
   ; reason : string
@@ -16,7 +16,7 @@ type accepted_cancellation = Keeper_event_queue_persistence.accepted_cancellatio
 
 type accepted_transfer = Keeper_event_queue_persistence.accepted_transfer =
   { source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; owner_nonce : int
   ; operator_operation_id : string
   ; from_keeper : string
@@ -27,10 +27,11 @@ type source_terminal_receipt = Keeper_event_queue_persistence.source_terminal_re
   | Fusion_terminal of Keeper_event_queue.fusion_completion
   | Background_job_terminal of Keeper_event_queue.bg_job_completion
   | Hitl_terminal of Keeper_event_queue.hitl_resolution
+  | Turn_attempt_terminal of { detail : string }
 
 type accepted_source_terminal = Keeper_event_queue_persistence.accepted_source_terminal =
   { source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; owner_nonce : int
   ; operator_operation_id : string
   ; source_receipt : source_terminal_receipt
@@ -69,16 +70,22 @@ val peek_when_result :
   ready:(Keeper_event_queue.stimulus -> bool) ->
   (Keeper_event_queue.stimulus option, string) result
 
+val select_when_result :
+  base_path:string ->
+  string ->
+  ready:(Keeper_event_queue.stimulus -> bool) ->
+  (Keeper_event_queue_state.pending_selection option, string) result
+
 val validate_pending_selection_result :
   base_path:string ->
   string ->
-  selection:Keeper_event_queue.stimulus ->
+  selection:Keeper_event_queue_state.pending_selection ->
   (unit, string) result
 
 val ack_pending_result :
   base_path:string ->
   string ->
-  selection:Keeper_event_queue.stimulus ->
+  selection:Keeper_event_queue_state.pending_selection ->
   (unit, string) result
 
 val cancel_pending_accepted_result :
@@ -110,6 +117,17 @@ val ack_pending_source_terminal_result :
   (source_ack_result, string) result
 (** Commit one exact terminal source ACK and publish the post-commit pending
     projection when the owner is registered. *)
+
+val terminalize_pending_turn_attempt_result :
+  base_path:string ->
+  string ->
+  current_owner_nonce:int ->
+  applied_at:float ->
+  selection:Keeper_event_queue_state.pending_selection ->
+  detail:string ->
+  (source_ack_result, string) result
+(** Commit a source-bearing terminal receipt for one failed admitted turn and
+    publish the post-commit pending projection. *)
 
 (** Enqueue a stimulus on the keeper's event queue. When the keeper is not
     registered yet, persist the stimulus to the durable snapshot so later

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -72,21 +72,18 @@ type status =
 
 type compaction_outcome =
   | Checkpoint_committed
-  | Retry_without_checkpoint
   | Lifecycle_cleanup_failed_without_checkpoint
 
 let compaction_outcome_key = "compaction_outcome"
 
 let compaction_outcome_to_string = function
   | Checkpoint_committed -> "checkpoint_committed"
-  | Retry_without_checkpoint -> "retry_without_checkpoint"
   | Lifecycle_cleanup_failed_without_checkpoint ->
     "lifecycle_cleanup_failed_without_checkpoint"
 ;;
 
 let compaction_outcome_of_string = function
   | "checkpoint_committed" -> Some Checkpoint_committed
-  | "retry_without_checkpoint" -> Some Retry_without_checkpoint
   | "lifecycle_cleanup_failed_without_checkpoint" ->
     Some Lifecycle_cleanup_failed_without_checkpoint
   | _ -> None
@@ -707,9 +704,7 @@ let canonicalize_compaction_evidence ~event_wire decision =
                  (Printf.sprintf
                     "field \"decision.%s\" must appear exactly once"
                     evidence_key))
-          | Some
-              (Retry_without_checkpoint
-              | Lifecycle_cleanup_failed_without_checkpoint) ->
+          | Some Lifecycle_cleanup_failed_without_checkpoint ->
             (match evidence_entries with
              | _ :: _ ->
                Error

--- a/lib/keeper/keeper_runtime_manifest.mli
+++ b/lib/keeper/keeper_runtime_manifest.mli
@@ -75,7 +75,6 @@ type status =
 
 type compaction_outcome =
   | Checkpoint_committed
-  | Retry_without_checkpoint
   | Lifecycle_cleanup_failed_without_checkpoint
 
 (** {1 Own-module vals} *)

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -105,12 +105,6 @@ let handle_keeper_list ctx args : tool_result =
               ("handoff_count_total", `Int trace_history_count);
               ("compaction_count", `Int m.runtime.compaction_rt.count);
               ("last_compaction_saved_tokens", `Int last_compaction_saved_tokens);
-              ( "compaction_consecutive_failures",
-                `Int m.runtime.compaction_rt.consecutive_failures );
-              ( "compaction_retry_suspended",
-                `Bool
-                  (Keeper_meta_contract.compaction_retry_suspended
-                     m.runtime.compaction_rt) );
               ("autoboot_enabled", `Bool m.autoboot_enabled);
               ("proactive_enabled", `Bool m.proactive.enabled);
               ("proactive_count_total", `Int m.runtime.proactive_rt.count_total);

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -216,7 +216,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             last_after_tokens = 0;
             last_check_ts = now_ts;
             last_decision = compaction_runtime_decision_of_string "initialized";
-            consecutive_failures = 0;
           };
           proactive_rt = {
             count_total = 0;

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -19,26 +19,18 @@ include Keeper_unified_turn_types
 
 include Keeper_unified_turn_phase_plan
 
-type in_lane_compaction =
-  | Compaction_committed
-  | Compaction_attempt_failed of { reason : string }
-  | Compaction_refused_without_attempt of { consecutive_failures : int }
-
 type source_disposition =
   | Follow_failure_route
-  | Follow_failure_route_after_no_compaction of
-      { reason : Keeper_compaction_outcome.no_compaction_reason }
-  | Requeue_after_context_compaction of in_lane_compaction
+  | Requeue_after_context_compaction of { commit_count : int }
   | Pause_after_transcript_corruption of { detail : string }
   | Acknowledge_after_in_turn_handling
 
 let source_disposition_after_no_compaction_reason = function
+  | Keeper_compaction_outcome.No_eligible_history
+  | Keeper_compaction_outcome.Invalid_structural_source
   | Keeper_compaction_outcome.Exact_lane_unconfigured
   | Keeper_compaction_outcome.Exact_execution_terminal _ ->
     Acknowledge_after_in_turn_handling
-  | ( Keeper_compaction_outcome.No_eligible_history
-    | Keeper_compaction_outcome.Invalid_structural_source ) as reason ->
-    Follow_failure_route_after_no_compaction { reason }
 ;;
 
 type turn_failure =
@@ -258,13 +250,9 @@ type provider_overflow_recovery =
   | Not_provider_overflow
   | Provider_overflow_applied of Keeper_post_turn.compaction_recovery
   | Provider_overflow_no_compaction of Keeper_post_turn.no_compaction
-  | Provider_overflow_retry_without_checkpoint of
+  | Provider_overflow_failed_without_checkpoint of
       { trigger : Compaction_trigger.t
       ; reason : string
-      }
-  | Provider_overflow_refused_without_attempt of
-      { trigger : Compaction_trigger.t
-      ; consecutive_failures : int
       }
   | Provider_overflow_retry_with_checkpoint of
       { reason : string
@@ -350,45 +338,17 @@ let recover_provider_context_overflow_in_lane
         in
         let source_disposition =
           match recovery with
-          | None ->
+          | None -> Acknowledge_after_in_turn_handling
+          | Some recovery ->
             Requeue_after_context_compaction
-              (Compaction_attempt_failed { reason })
-          | Some _ ->
-            Requeue_after_context_compaction Compaction_committed
+              { commit_count = recovery.Keeper_post_turn.commit_count }
         in
         Provider_overflow_lifecycle_cleanup_failed
           { trigger; reason; source_disposition; recovery }
       | Ok () ->
         (match recovery with
-         | None -> Provider_overflow_retry_without_checkpoint { trigger; reason }
+         | None -> Provider_overflow_failed_without_checkpoint { trigger; reason }
          | Some recovery -> Provider_overflow_retry_with_checkpoint { reason; recovery })
-    in
-    (* The admission gate declined the trigger: no checkpoint was read, no
-       summarizer ran, no compaction was attempted. The overflow itself is real
-       and unresolved, so the observation and the lifecycle release both stand —
-       what must not happen is settling this as a compaction outcome, because
-       that made the gate's own refusal advance the streak the gate reads. *)
-    let refused_without_attempt ~consecutive_failures =
-      let reason =
-        Printf.sprintf
-          "compaction retry suspended after %d consecutive failures"
-          consecutive_failures
-      in
-      record_overflow_failure ~config ~meta ~reason;
-      match release_failed_lifecycle reason with
-      | Error cleanup_error ->
-        Provider_overflow_lifecycle_cleanup_failed
-          { trigger
-          ; reason =
-              Printf.sprintf "%s; lifecycle_cleanup=%s" reason cleanup_error
-          ; source_disposition =
-              Requeue_after_context_compaction
-                (Compaction_refused_without_attempt { consecutive_failures })
-          ; recovery = None
-          }
-      | Ok () ->
-        Provider_overflow_refused_without_attempt
-          { trigger; consecutive_failures }
     in
     let terminal_no_compaction no_compaction =
       Eio.Cancel.protect (fun () ->
@@ -438,8 +398,6 @@ let recover_provider_context_overflow_in_lane
     in
     let failed ({ error; committed } : Keeper_post_turn.prepared_commit_failure) =
       match committed, error with
-      | None, Keeper_post_turn.Retry_suspended { consecutive_failures } ->
-        refused_without_attempt ~consecutive_failures
       | ( None
         , ( Keeper_post_turn.Checkpoint_ref_load_failed _
           | Keeper_post_turn.Checkpoint_candidate_failed _
@@ -463,7 +421,7 @@ let recover_provider_context_overflow_in_lane
     (match dispatch "context_overflow_detected" overflow_event with
      | Error reason ->
        record_overflow_failure ~config ~meta ~reason;
-       Provider_overflow_retry_without_checkpoint { trigger; reason }
+       Provider_overflow_failed_without_checkpoint { trigger; reason }
      | Ok () ->
        (match dispatch "compaction_started" Keeper_state_machine.Compaction_started with
        | Error reason -> retry_after_started reason
@@ -608,7 +566,7 @@ let append_provider_overflow_manifest
       (Keeper_compaction_outcome.no_compaction_reason_label no_compaction.reason);
     (* [No_compaction] is terminal evidence for an explicit manual-compaction
        operation, not successful handling of the product event whose provider
-       turn overflowed. Deterministic no-progress reasons preserve the bounded
+       turn overflowed. Deterministic no-progress reasons preserve the ordinary
        failure route. Effect-boundary and domain-invalid reasons instead become
        an immediate typed escalation: replaying the source could issue a second
        exact-output request after dispatch. *)
@@ -622,7 +580,9 @@ let append_provider_overflow_manifest
         ~recovery
         turn_state
     in
-    Requeue_after_context_compaction Compaction_committed, turn_state
+    ( Requeue_after_context_compaction
+        { commit_count = recovery.Keeper_post_turn.commit_count }
+    , turn_state )
   | Provider_overflow_retry_with_checkpoint { reason; recovery } ->
     let turn_state =
       append_recovery
@@ -632,10 +592,12 @@ let append_provider_overflow_manifest
         turn_state
     in
     (* The checkpoint commit succeeded ([recovery] exists); only the lifecycle
-       completion dispatch failed. The retry reloads a durably smaller
-       checkpoint, so this counts as compaction progress for the streak. *)
-    Requeue_after_context_compaction Compaction_committed, turn_state
-  | Provider_overflow_retry_without_checkpoint { trigger; reason } ->
+       completion dispatch failed. The retry reloads the exact durably smaller
+       checkpoint. *)
+    ( Requeue_after_context_compaction
+        { commit_count = recovery.Keeper_post_turn.commit_count }
+    , turn_state )
+  | Provider_overflow_failed_without_checkpoint { trigger; reason } ->
     let turn_state =
       Keeper_unified_turn_manifest.append_manifest
         ~config
@@ -643,35 +605,19 @@ let append_provider_overflow_manifest
         ~turn_start
         ~turn_state
         ~site:"provider_overflow_compaction_failed"
-        ~status:"retryable_failure"
+        ~status:"failed"
         ~compaction_source:"provider_overflow"
         ~decision:
-          (Keeper_runtime_manifest.with_compaction_outcome
-             ~compaction_outcome:Retry_without_checkpoint
-             (Keeper_runtime_manifest.with_payload_role
-                ~payload_role:Checkpoint
-                (`Assoc
-                  [ "trigger", `String (Compaction_trigger.to_label trigger)
-                  ; "trigger_detail", Compaction_trigger.to_detail_json trigger
-                  ; "requeue_disposition_requested", `Bool true
-                  ; "error", `String reason
-                  ])))
+          (Keeper_runtime_manifest.with_payload_role
+             ~payload_role:Checkpoint
+             (`Assoc
+               [ "trigger", `String (Compaction_trigger.to_label trigger)
+               ; "trigger_detail", Compaction_trigger.to_detail_json trigger
+               ; "error", `String reason
+               ]))
         Keeper_runtime_manifest.Context_compacted
     in
-    Requeue_after_context_compaction (Compaction_attempt_failed { reason }),
-    turn_state
-  | Provider_overflow_refused_without_attempt { trigger = _; consecutive_failures }
-    ->
-    (* No runtime-manifest record: every manifest kind reachable here asserts a
-       compaction ran, and none did. Emitting [Context_compacted] with
-       [compaction_outcome:Retry_without_checkpoint] — what the attempt-failed
-       arm above does — is why 12,777 [compaction_started] transitions
-       reconciled against roughly 401 prepared plans. The refusal stays visible
-       through [record_overflow_failure]'s WARN, the registry phase transition,
-       and the persisted [last_compaction_decision]. *)
-    ( Requeue_after_context_compaction
-        (Compaction_refused_without_attempt { consecutive_failures })
-    , turn_state )
+    Acknowledge_after_in_turn_handling, turn_state
   | Provider_overflow_lifecycle_cleanup_failed
       { trigger; reason; source_disposition; recovery } ->
     let turn_state =

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -121,69 +121,32 @@ val record_streaming_cancelled_observation
   -> unit
   -> unit
 
-type in_lane_compaction =
-  | Compaction_committed
-  | Compaction_attempt_failed of { reason : string }
-  | Compaction_refused_without_attempt of { consecutive_failures : int }
-(** Typed outcome of the in-lane provider-overflow compaction behind a
-    [Requeue_after_context_compaction] disposition. [Compaction_committed]
-    proves the checkpoint durably shrank before the requeue. It still advances
-    the provider-overflow episode streak; only an overflow-free completed turn
-    or an operator-committed manual compaction resets it. The retry reloads the
-    durable progress. [Compaction_attempt_failed] means the recovery made no
-    durable progress and also advances the streak. Once the streak reaches
-    [Keeper_meta_contract.compaction_retry_escalation_threshold], subsequent
-    reactive admission is refused (RFC-0351 S0, #25461 — without the ceiling
-    this lane requeued forever: 284 of 285 rejections in the 2026-07-21 storm
-    carried trigger=provider_overflow and only the operator's keeper_down ended
-    it).
-
-    [Compaction_refused_without_attempt] is the admission gate declining the
-    trigger at that same threshold ([Keeper_post_turn.Retry_suspended]): no
-    checkpoint was read, no summarizer ran, and no compaction was attempted, so
-    the transition leaves the streak alone. Settling it as a failure made the
-    gate's own output advance the counter the gate reads — live keeper
-    [kidsnote] reached 907 against a threshold of 3, roughly 99.7% of it from
-    refusals, which left no statistic able to say what drove it there. The
-    ceiling, the threshold, and the LLM-call bound the gate exists for are all
-    unchanged; only this self-feeding edge is cut. *)
-
 type source_disposition =
   | Follow_failure_route
-  | Follow_failure_route_after_no_compaction of
-      { reason : Keeper_compaction_outcome.no_compaction_reason }
-  | Requeue_after_context_compaction of in_lane_compaction
+  | Requeue_after_context_compaction of { commit_count : int }
   | Pause_after_transcript_corruption of { detail : string }
   | Acknowledge_after_in_turn_handling
 (** A failed turn normally follows its typed retry/rotate/escalate route.
-    [Follow_failure_route_after_no_compaction] follows the same route but
-    records that the in-lane provider-overflow compaction terminally declined
-    to act ([no_compaction_reason]); the terminal transition advances the
-    compaction-failure streak, because a turn whose context cannot shrink
-    re-overflows deterministically on every retry. It does not replace the
-    route. The threshold makes [Keeper_post_turn.prepare_compaction] refuse
-    reactive triggers
-    ([Compaction_refused_without_attempt]); only an operator-committed manual
-    compaction or an overflow-free completed turn lifts it.
     [Requeue_after_context_compaction] preserves the exact source stimulus
-    after MASC handled a typed provider overflow in this Keeper lane; the next
-    cycle reloads the durably compacted checkpoint.
+    only after MASC durably committed a smaller checkpoint; the next cycle
+    reloads that progress.
     [Pause_after_transcript_corruption] is terminal for automatic execution:
     typed transcript admission rejected before provider dispatch, so the
     heartbeat durably pauses the Keeper and consumes the selected source into an
     operator-reset-required escalation with no retry successor.
-    [Acknowledge_after_in_turn_handling] consumes only the source stimulus when
-    the exact compaction path already produced a terminal failure. No second
-    durable escalation is claimed; the cycle remains failed for receipts,
-    counters, and heartbeat freshness. *)
+    [Acknowledge_after_in_turn_handling] ends only this admitted turn attempt
+    when compaction made no durable progress or produced a terminal
+    no-compaction result. The heartbeat removes the runnable selection only
+    through a source-bearing Event Queue WAL receipt; product source authority
+    remains with Board, Goal, Connector, Schedule, or Chat. No second durable
+    escalation is claimed; the cycle remains failed for receipts, counters,
+    and heartbeat freshness. *)
 
 val source_disposition_after_no_compaction_reason
   :  Keeper_compaction_outcome.no_compaction_reason
   -> source_disposition
-(** Compiler-checked partition of no-compaction outcomes. Missing-lane,
-    effect-boundary, and domain-invalid outcomes acknowledge the selected
-    source after the in-turn terminal failure; all other deterministic
-    no-progress outcomes retain the bounded failure route. *)
+(** Every typed no-compaction result terminalizes the selected source. The
+    exhaustive mapping makes new reasons choose source semantics explicitly. *)
 
 type turn_failure =
   { error : Agent_sdk.Error.sdk_error

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -26,7 +26,7 @@ type exact_write_outcome =
 
 type accepted_cancellation = State.accepted_cancellation =
   { source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; owner_nonce : int
   ; operator_operation_id : string
   ; reason : string
@@ -34,7 +34,7 @@ type accepted_cancellation = State.accepted_cancellation =
 
 type accepted_transfer = State.accepted_transfer =
   { source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; owner_nonce : int
   ; operator_operation_id : string
   ; from_keeper : string
@@ -45,10 +45,11 @@ type source_terminal_receipt = State.source_terminal_receipt =
   | Fusion_terminal of Keeper_event_queue.fusion_completion
   | Background_job_terminal of Keeper_event_queue.bg_job_completion
   | Hitl_terminal of Keeper_event_queue.hitl_resolution
+  | Turn_attempt_terminal of { detail : string }
 
 type accepted_source_terminal = State.accepted_source_terminal =
   { source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; owner_nonce : int
   ; operator_operation_id : string
   ; source_receipt : source_terminal_receipt
@@ -76,8 +77,8 @@ type transfer_projection_result = State.transfer_projection_result =
   | Transfer_already_projected
 
 
-let snapshot_filename = "event-queue-v13.json"
-let transition_wal_filename = "event-queue-transitions-v3.jsonl"
+let snapshot_filename = "event-queue-v14.json"
+let transition_wal_filename = "event-queue-transitions-v4.jsonl"
 
 let owner_error_to_string = Owner_lock.resolve_error_to_string
 
@@ -299,7 +300,7 @@ let bump_revision state =
   else Ok (State.with_revision (Int64.succ (State.revision state)) state)
 ;;
 
-let transition_wal_schema = "masc.keeper_event_queue.transition.v3"
+let transition_wal_schema = "masc.keeper_event_queue.transition.v4"
 
 let transition_wal_entry_to_line owner entry =
   `Assoc
@@ -612,7 +613,7 @@ let commit_transform_unlocked
                 bump that absorbed it. Leaving it behind is what latches the
                 owner: the next load replays an already-absorbed row against
                 the advanced revision, [commit_transition] rejects it on
-                [source_revision], and no runtime path can clear it because the
+                [source_incarnation], and no runtime path can clear it because the
                 projector itself starts with [load_state_unlocked] (#26074). *)
              (match compact_transition_wals_unlocked owner with
               | Error _ as error -> error
@@ -817,6 +818,12 @@ let peek_when_result ~base_path ~keeper_name ~ready =
   match load_state_result ~base_path ~keeper_name with
   | Error _ as error -> error
   | Ok state -> Ok (State.peek_when ~ready state)
+;;
+
+let select_when_result ~base_path ~keeper_name ~ready =
+  match load_state_result ~base_path ~keeper_name with
+  | Error _ as error -> error
+  | Ok state -> Ok (State.select_when ~ready state)
 ;;
 
 let validate_pending_selection_result ~base_path ~keeper_name ~selection =
@@ -1041,6 +1048,44 @@ let ack_pending_source_terminal_result
        Error
          (Printf.sprintf
             "event queue pending source-terminal ACK raised keeper=%s: %s"
+            (keeper_name_of_owner owner)
+            (Printexc.to_string exn)))
+;;
+
+let terminalize_pending_turn_attempt_result
+      ?(after_commit = fun _ -> ())
+      ~base_path
+      ~keeper_name
+      ~current_owner_nonce
+      ~applied_at
+      ~selection
+      ~detail
+      ()
+  =
+  match resolve_owner ~base_path ~keeper_name with
+  | Error _ as error -> error
+  | Ok owner ->
+    (try
+       Owner_lock.with_durable_lock owner (fun () ->
+         match load_state_unlocked owner with
+         | Error _ as error -> error
+         | Ok state ->
+           commit_transition_unlocked
+             owner
+             ~after_commit
+             (State.terminalize_pending_turn_attempt
+                ~current_owner_nonce
+                ~applied_at
+                ~selection
+                ~detail)
+             state
+           |> Result.map fst)
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Error
+         (Printf.sprintf
+            "event queue pending turn-attempt terminalization raised keeper=%s: %s"
             (keeper_name_of_owner owner)
             (Printexc.to_string exn)))
 ;;

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -1,11 +1,11 @@
 (** Durable per-Keeper Event Layer state.
 
-    Current writes use the [keeper.event_queue.state.v13]
-    [event-queue-v13.json] envelope: revision, pending stimuli, the latest
+    Current writes use the [keeper.event_queue.state.v14]
+    [event-queue-v14.json] envelope: revision, pending stimuli, the latest
     projected transition, an operation-indexed ledger of older projected
     dispositions, at most one unprojected transition, and durable
     accepted-transfer target projections. Only this schema and the
-    [event-queue-transitions-v3.jsonl] WAL are queue authority. *)
+    [event-queue-transitions-v4.jsonl] WAL are queue authority. *)
 
 type owner_identity
 type owner_identity_error
@@ -35,7 +35,7 @@ type exact_write_outcome =
 
 type accepted_cancellation = Keeper_event_queue_state.accepted_cancellation =
   { source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; owner_nonce : int
   ; operator_operation_id : string
   ; reason : string
@@ -43,7 +43,7 @@ type accepted_cancellation = Keeper_event_queue_state.accepted_cancellation =
 
 type accepted_transfer = Keeper_event_queue_state.accepted_transfer =
   { source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; owner_nonce : int
   ; operator_operation_id : string
   ; from_keeper : string
@@ -54,10 +54,11 @@ type source_terminal_receipt = Keeper_event_queue_state.source_terminal_receipt 
   | Fusion_terminal of Keeper_event_queue.fusion_completion
   | Background_job_terminal of Keeper_event_queue.bg_job_completion
   | Hitl_terminal of Keeper_event_queue.hitl_resolution
+  | Turn_attempt_terminal of { detail : string }
 
 type accepted_source_terminal = Keeper_event_queue_state.accepted_source_terminal =
   { source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; owner_nonce : int
   ; operator_operation_id : string
   ; source_receipt : source_terminal_receipt
@@ -99,17 +100,23 @@ val peek_when_result :
   ready:(Keeper_event_queue.stimulus -> bool) ->
   (Keeper_event_queue.stimulus option, string) result
 
+val select_when_result :
+  base_path:string ->
+  keeper_name:string ->
+  ready:(Keeper_event_queue.stimulus -> bool) ->
+  (Keeper_event_queue_state.pending_selection option, string) result
+
 val validate_pending_selection_result :
   base_path:string ->
   keeper_name:string ->
-  selection:Keeper_event_queue.stimulus ->
+  selection:Keeper_event_queue_state.pending_selection ->
   (unit, string) result
 
 val ack_pending_result :
   ?after_commit:(Keeper_event_queue.t -> unit) ->
   base_path:string ->
   keeper_name:string ->
-  selection:Keeper_event_queue.stimulus ->
+  selection:Keeper_event_queue_state.pending_selection ->
   unit ->
   (unit, string) result
 
@@ -184,6 +191,20 @@ val ack_pending_source_terminal_result :
   (transition_result, string) result
 (** Append and fsync the canonical source-bearing ACK transition before
     checkpointing removal of the exact pending source. *)
+
+val terminalize_pending_turn_attempt_result :
+  ?after_commit:(Keeper_event_queue.t -> unit) ->
+  base_path:string ->
+  keeper_name:string ->
+  current_owner_nonce:int ->
+  applied_at:float ->
+  selection:Keeper_event_queue_state.pending_selection ->
+  detail:string ->
+  unit ->
+  (transition_result, string) result
+(** Atomically construct and commit a source-bearing terminal receipt for one
+    failed admitted turn. The selection carries the exact source incarnation;
+    no caller-provided prose or counter controls admission. *)
 
 val project_transition_outbox_result :
   append_before_retire:(outbox_entry -> (unit, string) result) ->

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -1,6 +1,6 @@
 type accepted_cancellation =
   { source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; owner_nonce : int
   ; operator_operation_id : string
   ; reason : string
@@ -8,7 +8,7 @@ type accepted_cancellation =
 
 type accepted_transfer =
   { source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; owner_nonce : int
   ; operator_operation_id : string
   ; from_keeper : string
@@ -19,10 +19,11 @@ type source_terminal_receipt =
   | Fusion_terminal of Keeper_event_queue.fusion_completion
   | Background_job_terminal of Keeper_event_queue.bg_job_completion
   | Hitl_terminal of Keeper_event_queue.hitl_resolution
+  | Turn_attempt_terminal of { detail : string }
 
 type accepted_source_terminal =
   { source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; owner_nonce : int
   ; operator_operation_id : string
   ; source_receipt : source_terminal_receipt
@@ -45,9 +46,14 @@ type outbox_entry =
   ; stimuli : Keeper_event_queue.stimulus list
   }
 
+type pending_selection =
+  { source : Keeper_event_queue.stimulus
+  ; admitted_revision : int64
+  }
+
 type t =
   { revision : int64
-  ; pending : Keeper_event_queue.t
+  ; pending_entries : pending_selection list
   ; last_transition : transition_receipt option
   ; projected_dispositions : transition_receipt list
   ; transition_outbox : outbox_entry list
@@ -62,11 +68,11 @@ type transfer_projection_result =
   | Transfer_projected
   | Transfer_already_projected
 
-let schema = "keeper.event_queue.state.v13"
+let schema = "keeper.event_queue.state.v14"
 
 let empty =
   { revision = 0L
-  ; pending = Keeper_event_queue.empty
+  ; pending_entries = []
   ; last_transition = None
   ; projected_dispositions = []
   ; transition_outbox = []
@@ -75,7 +81,16 @@ let empty =
 ;;
 
 let revision state = state.revision
-let pending state = state.pending
+let pending_selections state = state.pending_entries
+
+let pending state =
+  List.fold_left
+    (fun queue entry ->
+       Keeper_event_queue.enqueue queue entry.source)
+    Keeper_event_queue.empty
+    state.pending_entries
+;;
+
 let last_transition state = state.last_transition
 
 let disposition_operation_id = function
@@ -95,7 +110,7 @@ let transition_outbox state = state.transition_outbox
 let accepted_transfer_projections state = state.accepted_transfer_projections
 
 let accounted_stimuli state =
-  Keeper_event_queue.to_list state.pending
+  Keeper_event_queue.to_list (pending state)
   @ List.concat_map
       (fun (entry : outbox_entry) -> entry.stimuli)
       state.transition_outbox
@@ -109,39 +124,36 @@ let project_accepted_transfer (transfer : accepted_transfer) state =
   | Some existing when existing = transfer -> Ok (state, Transfer_already_projected)
   | Some _ -> Error "target transfer operation ID conflicts with its durable projection"
   | None ->
-    let same_source (candidate : accepted_transfer) =
-      Keeper_event_queue.stimulus_identity_equal candidate.source transfer.source
+    let matching =
+      accounted_stimuli state
+      |> List.filter (fun candidate ->
+        Keeper_event_queue.stimulus_identity_equal candidate transfer.source)
     in
-    (match List.find_opt same_source state.accepted_transfer_projections with
-     | Some _ ->
-       Error "target transfer source identity was already projected by another operation"
-     | None ->
-       let matching =
-         accounted_stimuli state
-         |> List.filter (fun candidate ->
-           Keeper_event_queue.stimulus_identity_equal candidate transfer.source)
-       in
-       (match matching with
-        | [] ->
-          let pending = Keeper_event_queue.enqueue state.pending transfer.source in
-          Ok
-            ( { state with
-                pending
-              ; accepted_transfer_projections =
-                  state.accepted_transfer_projections @ [ transfer ]
-              }
-            , Transfer_projected )
-        | [ existing ] when existing = transfer.source ->
-          Ok
-            ( { state with
-                accepted_transfer_projections =
-                  state.accepted_transfer_projections @ [ transfer ]
-              }
-            , Transfer_already_projected )
-        | [ _ ] ->
-          Error "target transfer source identity has a different durable snapshot"
-        | _ :: _ :: _ ->
-          Error "target transfer source identity is duplicated in durable state"))
+    (match matching with
+     | [] ->
+       Ok
+         ( { state with
+             pending_entries =
+               state.pending_entries
+               @ [ { source = transfer.source
+                   ; admitted_revision = state.revision
+                   }
+                 ]
+           ; accepted_transfer_projections =
+               state.accepted_transfer_projections @ [ transfer ]
+           }
+         , Transfer_projected )
+     | [ existing ] when existing = transfer.source ->
+       Ok
+         ( { state with
+             accepted_transfer_projections =
+               state.accepted_transfer_projections @ [ transfer ]
+           }
+         , Transfer_already_projected )
+     | [ _ ] ->
+       Error "target transfer source identity has a different durable snapshot"
+     | _ :: _ :: _ ->
+       Error "target transfer source identity is duplicated in durable state")
 ;;
 
 let mark_transition_projected ~transition_id state =
@@ -172,7 +184,33 @@ let mark_transition_projected ~transition_id state =
     Error (Printf.sprintf "event queue transition not found: %s" transition_id)
   | _ :: _ :: _ -> Error "event queue state has multiple unprojected transitions"
 ;;
-let with_pending pending state = { state with pending }
+let with_pending pending state =
+  let rec take_matching source skipped = function
+    | [] -> None, List.rev skipped
+    | entry :: rest
+      when Keeper_event_queue.stimulus_identity_equal entry.source source
+           && entry.source = source ->
+      Some entry, List.rev_append skipped rest
+    | entry :: rest -> take_matching source (entry :: skipped) rest
+  in
+  let rec reconcile available acc = function
+    | [] -> List.rev acc
+    | source :: rest ->
+      let existing, available = take_matching source [] available in
+      let entry =
+        match existing with
+        | Some entry -> entry
+        | None -> { source; admitted_revision = state.revision }
+      in
+      reconcile available (entry :: acc) rest
+  in
+  let pending_entries =
+    Keeper_event_queue.to_list pending
+    |> reconcile state.pending_entries []
+  in
+  { state with pending_entries }
+;;
+
 let with_revision revision state = { state with revision }
 
 let rec queue_contains queue stimulus =
@@ -191,54 +229,49 @@ let enqueue_if_missing queue stimulus =
 
 let transition_outbox_blocked state = state.transition_outbox <> []
 
-let rec dequeue_first_ready ~ready skipped pending =
-  match Keeper_event_queue.dequeue pending with
-  | None -> None
-  | Some (stimulus, rest) when ready stimulus ->
-    Some (stimulus, Keeper_event_queue.prepend_list (List.rev skipped) rest)
-  | Some (stimulus, rest) ->
-    dequeue_first_ready ~ready (stimulus :: skipped) rest
+let rec first_ready_entry ~ready = function
+  | [] -> None
+  | entry :: _ when ready entry.source -> Some entry
+  | _ :: rest -> first_ready_entry ~ready rest
 ;;
 
 let peek_when ~ready state =
-  match dequeue_first_ready ~ready [] state.pending with
-  | None -> None
-  | Some (stimulus, _) -> Some stimulus
+  Option.map
+    (fun entry -> entry.source)
+    (first_ready_entry ~ready state.pending_entries)
 ;;
 
+let select_when ~ready state = first_ready_entry ~ready state.pending_entries
+
 let validate_pending_selection
-      ~(selection : Keeper_event_queue.stimulus)
+      ~(selection : pending_selection)
       state
   =
   let matching =
-    Keeper_event_queue.to_list state.pending
-    |> List.filter (Keeper_event_queue.stimulus_identity_equal selection)
+    state.pending_entries
+    |> List.filter (fun entry ->
+      Keeper_event_queue.stimulus_identity_equal
+        selection.source
+        entry.source)
   in
   match matching with
   | [ actual ] when actual = selection -> Ok ()
-  | [ _ ] -> Error "event queue pending selection typed snapshot changed"
+  | [ { source; _ } ] when source <> selection.source ->
+    Error "event queue pending selection typed snapshot changed"
+  | [ _ ] -> Error "event queue pending selection incarnation changed"
   | [] -> Error "event queue pending selection is no longer present"
   | _ :: _ :: _ ->
     Error "event queue pending selection is present more than once"
 ;;
 
-let ack_pending ~(selection : Keeper_event_queue.stimulus) state =
+let ack_pending ~(selection : pending_selection) state =
   match validate_pending_selection ~selection state with
   | Error _ as error -> error
   | Ok () ->
-    let retained =
-      Keeper_event_queue.to_list state.pending
-      |> List.filter
-           (Fun.negate
-              (Keeper_event_queue.stimulus_identity_equal selection))
+    let pending_entries =
+      List.filter (Fun.negate (( = ) selection)) state.pending_entries
     in
-    let pending =
-      List.fold_left
-        Keeper_event_queue.enqueue
-        Keeper_event_queue.empty
-        retained
-    in
-    Ok { state with pending }
+    Ok { state with pending_entries }
 ;;
 
 let ( let* ) = Result.bind
@@ -275,8 +308,8 @@ let transition_receipt_equal left right =
 let validate_accepted_cancellation (cancellation : accepted_cancellation) =
   if String.equal (String.trim cancellation.source.post_id) ""
   then Error "accepted cancellation source post id must not be empty"
-  else if Int64.compare cancellation.source_revision 0L < 0
-  then Error "accepted cancellation source revision must not be negative"
+  else if Int64.compare cancellation.source_incarnation 0L < 0
+  then Error "accepted cancellation source incarnation must not be negative"
   else if cancellation.owner_nonce < 0
   then Error "accepted cancellation owner generation must not be negative"
   else if String.equal (String.trim cancellation.operator_operation_id) ""
@@ -289,8 +322,8 @@ let validate_accepted_cancellation (cancellation : accepted_cancellation) =
 let validate_accepted_transfer (transfer : accepted_transfer) =
   if String.equal (String.trim transfer.source.post_id) ""
   then Error "accepted transfer source post id must not be empty"
-  else if Int64.compare transfer.source_revision 0L < 0
-  then Error "accepted transfer source revision must not be negative"
+  else if Int64.compare transfer.source_incarnation 0L < 0
+  then Error "accepted transfer source incarnation must not be negative"
   else if transfer.owner_nonce < 0
   then Error "accepted transfer owner generation must not be negative"
   else if String.equal (String.trim transfer.operator_operation_id) ""
@@ -322,20 +355,25 @@ let source_terminal_receipt_of_stimulus source =
     Error "source event does not carry a typed terminal receipt"
 ;;
 
-let validate_accepted_source_terminal source_terminal =
+let validate_accepted_source_terminal
+      (source_terminal : accepted_source_terminal)
+  =
   if String.equal (String.trim source_terminal.source.post_id) ""
   then Error "source-terminal ACK source post id must not be empty"
-  else if Int64.compare source_terminal.source_revision 0L < 0
-  then Error "source-terminal ACK source revision must not be negative"
+  else if Int64.compare source_terminal.source_incarnation 0L < 0
+  then Error "source-terminal ACK source incarnation must not be negative"
   else if source_terminal.owner_nonce < 0
   then Error "source-terminal ACK owner generation must not be negative"
   else if String.equal (String.trim source_terminal.operator_operation_id) ""
   then Error "source-terminal ACK operation id must not be empty"
-  else
-    let* receipt = source_terminal_receipt_of_stimulus source_terminal.source in
-    if receipt = source_terminal.source_receipt
-    then Ok ()
-    else Error "source-terminal ACK receipt does not match source payload"
+  else (
+    match source_terminal.source_receipt with
+    | Turn_attempt_terminal _ -> Ok ()
+    | (Fusion_terminal _ | Background_job_terminal _ | Hitl_terminal _) as expected ->
+      let* receipt = source_terminal_receipt_of_stimulus source_terminal.source in
+      if receipt = expected
+      then Ok ()
+      else Error "source-terminal ACK receipt does not match source payload")
 ;;
 
 let validate_transition = function
@@ -384,10 +422,10 @@ let apply_pending_transition ~applied_at ~transition ~source ~pending state =
     let* () = validate_transition transition in
     let* () = validate_transition_for_stimuli transition [ source ] in
     let receipt = receipt_for_pending_transition ~applied_at ~transition in
+    let state = with_pending pending state in
     Ok
       ( { state with
-          pending
-        ; transition_outbox = [ { receipt; stimuli = [ source ] } ]
+          transition_outbox = [ { receipt; stimuli = [ source ] } ]
         }
       , Transition_applied receipt )
 ;;
@@ -454,14 +492,12 @@ let cancel_pending_accepted
              current_owner_nonce)
     in
     let* () =
-      if Int64.equal state.revision cancellation.source_revision
-      then Ok ()
-      else
-        Error
-          (Printf.sprintf
-             "accepted cancellation source revision changed: expected %Ld, current %Ld"
-             cancellation.source_revision
-             state.revision)
+      validate_pending_selection
+        ~selection:
+          { source = cancellation.source
+          ; admitted_revision = cancellation.source_incarnation
+          }
+        state
     in
     let* () =
       if transition_outbox_blocked state
@@ -469,7 +505,7 @@ let cancel_pending_accepted
       else Ok ()
     in
     let matching, retained =
-      Keeper_event_queue.to_list state.pending
+      Keeper_event_queue.to_list (pending state)
       |> List.partition (fun source ->
         Keeper_event_queue.stimulus_identity_equal cancellation.source source)
     in
@@ -529,14 +565,12 @@ let transfer_pending_accepted
              current_owner_nonce)
     in
     let* () =
-      if Int64.equal state.revision transfer.source_revision
-      then Ok ()
-      else
-        Error
-          (Printf.sprintf
-             "accepted transfer source revision changed: expected %Ld, current %Ld"
-             transfer.source_revision
-             state.revision)
+      validate_pending_selection
+        ~selection:
+          { source = transfer.source
+          ; admitted_revision = transfer.source_incarnation
+          }
+        state
     in
     let* () =
       if transition_outbox_blocked state
@@ -544,7 +578,7 @@ let transfer_pending_accepted
       else Ok ()
     in
     let matching, retained =
-      Keeper_event_queue.to_list state.pending
+      Keeper_event_queue.to_list (pending state)
       |> List.partition (fun source ->
         Keeper_event_queue.stimulus_identity_equal transfer.source source)
     in
@@ -585,6 +619,24 @@ let accepted_pending_source_terminal_ack_replay source_terminal state =
          source_terminal.operator_operation_id)
 ;;
 
+let turn_attempt_terminal_operation_id
+      ~owner_nonce
+      ~admitted_revision
+      source
+  =
+  let source_fingerprint =
+    Keeper_event_queue.stimulus_to_yojson source
+    |> Yojson.Safe.to_string
+    |> Digestif.SHA256.digest_string
+    |> Digestif.SHA256.to_hex
+  in
+  Printf.sprintf
+    "turn-attempt-terminal:%d:%Ld:%s"
+    owner_nonce
+    admitted_revision
+    source_fingerprint
+;;
+
 let ack_pending_source_terminal
       ~current_owner_nonce
       ~applied_at
@@ -608,14 +660,12 @@ let ack_pending_source_terminal
              current_owner_nonce)
     in
     let* () =
-      if Int64.equal state.revision source_terminal.source_revision
-      then Ok ()
-      else
-        Error
-          (Printf.sprintf
-             "source-terminal ACK source revision changed: expected %Ld, current %Ld"
-             source_terminal.source_revision
-             state.revision)
+      validate_pending_selection
+        ~selection:
+          { source = source_terminal.source
+          ; admitted_revision = source_terminal.source_incarnation
+          }
+        state
     in
     let* () =
       if transition_outbox_blocked state
@@ -623,7 +673,7 @@ let ack_pending_source_terminal
       else Ok ()
     in
     let matching, retained =
-      Keeper_event_queue.to_list state.pending
+      Keeper_event_queue.to_list (pending state)
       |> List.partition (fun source ->
         Keeper_event_queue.stimulus_identity_equal source_terminal.source source)
     in
@@ -645,7 +695,57 @@ let ack_pending_source_terminal
          ~transition:ack
          ~source
          ~pending
-         state)
+       state)
+;;
+
+let terminalize_pending_turn_attempt
+      ~current_owner_nonce
+      ~applied_at
+      ~selection
+      ~detail
+      state
+  =
+  let { source; admitted_revision } = selection in
+  let operator_operation_id =
+    turn_attempt_terminal_operation_id
+      ~owner_nonce:current_owner_nonce
+      ~admitted_revision
+      source
+  in
+  match prior_disposition_by_operation_id operator_operation_id state with
+  | Some
+      ({ transition =
+           Ack_source_terminal
+             { source = prior_source
+             ; owner_nonce
+             ; source_receipt = Turn_attempt_terminal _
+             ; _
+             }
+       ; _
+       } as receipt)
+    when Int.equal owner_nonce current_owner_nonce
+         && prior_source = source ->
+    Ok (state, Transition_already_applied receipt)
+  | Some _ ->
+    Error
+      (Printf.sprintf
+         "turn-attempt terminal operation conflict: %s"
+         operator_operation_id)
+  | None ->
+    let* () = validate_pending_selection ~selection state in
+    let source_terminal =
+      { source
+      ; source_incarnation = admitted_revision
+      ; owner_nonce = current_owner_nonce
+      ; operator_operation_id
+      ; source_receipt = Turn_attempt_terminal { detail }
+      }
+    in
+    ack_pending_source_terminal
+      ~current_owner_nonce
+      ~applied_at
+      ~source_terminal
+      state
 ;;
 
 let restore_pending_transition entry state apply =
@@ -723,9 +823,9 @@ let replay_transition_outbox_entry entry state =
 
 let remove_by_post_id post_id state =
   let removed, pending =
-    Keeper_event_queue.remove_by_post_id post_id state.pending
+    Keeper_event_queue.remove_by_post_id post_id (pending state)
   in
-  Keeper_event_queue.uniq_stimuli removed, { state with pending }
+  Keeper_event_queue.uniq_stimuli removed, with_pending pending state
 ;;
 
 let assoc_fields ~context = function
@@ -806,7 +906,7 @@ let transition_to_yojson = function
     `Assoc
       [ "kind", `String "cancel_accepted"
       ; "source", Keeper_event_queue.stimulus_to_yojson cancellation.source
-      ; "source_revision", int64_json cancellation.source_revision
+      ; "source_incarnation", int64_json cancellation.source_incarnation
       ; "owner_nonce", `Int cancellation.owner_nonce
       ; "operator_operation_id", `String cancellation.operator_operation_id
       ; "reason", `String cancellation.reason
@@ -815,27 +915,35 @@ let transition_to_yojson = function
     `Assoc
       [ "kind", `String "transfer_accepted"
       ; "source", Keeper_event_queue.stimulus_to_yojson transfer.source
-      ; "source_revision", int64_json transfer.source_revision
+      ; "source_incarnation", int64_json transfer.source_incarnation
       ; "owner_nonce", `Int transfer.owner_nonce
       ; "operator_operation_id", `String transfer.operator_operation_id
       ; "from_keeper", `String transfer.from_keeper
       ; "to_keeper", `String transfer.to_keeper
       ]
   | Ack_source_terminal source_terminal ->
-    let receipt_kind =
-      match source_terminal.source_receipt with
-      | Fusion_terminal _ -> "fusion_terminal"
-      | Background_job_terminal _ -> "background_job_terminal"
-      | Hitl_terminal _ -> "hitl_terminal"
-    in
-    `Assoc
+    let fields =
       [ "kind", `String "ack_source_terminal"
       ; "source", Keeper_event_queue.stimulus_to_yojson source_terminal.source
-      ; "source_revision", int64_json source_terminal.source_revision
+      ; "source_incarnation", int64_json source_terminal.source_incarnation
       ; "owner_nonce", `Int source_terminal.owner_nonce
       ; "operator_operation_id", `String source_terminal.operator_operation_id
-       ; "source_receipt_kind", `String receipt_kind
-       ]
+      ]
+    in
+    let receipt_fields =
+      match source_terminal.source_receipt with
+      | Fusion_terminal _ ->
+        [ "source_receipt_kind", `String "fusion_terminal" ]
+      | Background_job_terminal _ ->
+        [ "source_receipt_kind", `String "background_job_terminal" ]
+      | Hitl_terminal _ ->
+        [ "source_receipt_kind", `String "hitl_terminal" ]
+      | Turn_attempt_terminal { detail } ->
+        [ "source_receipt_kind", `String "turn_attempt_terminal"
+        ; "detail", `String detail
+        ]
+    in
+    `Assoc (fields @ receipt_fields)
 ;;
 
 let transition_of_yojson json =
@@ -850,7 +958,7 @@ let transition_of_yojson json =
         ~expected:
           [ "kind"
           ; "source"
-          ; "source_revision"
+          ; "source_incarnation"
           ; "owner_nonce"
           ; "operator_operation_id"
           ; "reason"
@@ -859,14 +967,14 @@ let transition_of_yojson json =
     in
     let* source_json = required_field ~context "source" fields in
     let* source = Keeper_event_queue.stimulus_of_yojson source_json in
-    let* source_revision = int64_field ~context "source_revision" fields in
+    let* source_incarnation = int64_field ~context "source_incarnation" fields in
     let* owner_nonce = int_field ~context "owner_nonce" fields in
     let* operator_operation_id =
       string_field ~context "operator_operation_id" fields
     in
     let* reason = string_field ~context "reason" fields in
     let cancellation =
-      { source; source_revision; owner_nonce; operator_operation_id; reason }
+      { source; source_incarnation; owner_nonce; operator_operation_id; reason }
     in
     let* () = validate_accepted_cancellation cancellation in
     Ok (Cancel_accepted cancellation)
@@ -877,7 +985,7 @@ let transition_of_yojson json =
         ~expected:
           [ "kind"
           ; "source"
-          ; "source_revision"
+          ; "source_incarnation"
           ; "owner_nonce"
           ; "operator_operation_id"
           ; "from_keeper"
@@ -887,7 +995,7 @@ let transition_of_yojson json =
     in
     let* source_json = required_field ~context "source" fields in
     let* source = Keeper_event_queue.stimulus_of_yojson source_json in
-    let* source_revision = int64_field ~context "source_revision" fields in
+    let* source_incarnation = int64_field ~context "source_incarnation" fields in
     let* owner_nonce = int_field ~context "owner_nonce" fields in
     let* operator_operation_id =
       string_field ~context "operator_operation_id" fields
@@ -896,7 +1004,7 @@ let transition_of_yojson json =
     let* to_keeper = string_field ~context "to_keeper" fields in
     let transfer =
       { source
-      ; source_revision
+      ; source_incarnation
       ; owner_nonce
       ; operator_operation_id
       ; from_keeper
@@ -906,22 +1014,9 @@ let transition_of_yojson json =
     let* () = validate_accepted_transfer transfer in
     Ok (Transfer_accepted transfer)
   | "ack_source_terminal" ->
-    let* () =
-      exact_fields
-        ~context
-        ~expected:
-          [ "kind"
-          ; "source"
-          ; "source_revision"
-          ; "owner_nonce"
-          ; "operator_operation_id"
-          ; "source_receipt_kind"
-          ]
-        fields
-    in
     let* source_json = required_field ~context "source" fields in
     let* source = Keeper_event_queue.stimulus_of_yojson source_json in
-    let* source_revision = int64_field ~context "source_revision" fields in
+    let* source_incarnation = int64_field ~context "source_incarnation" fields in
     let* owner_nonce = int_field ~context "owner_nonce" fields in
     let* operator_operation_id =
       string_field ~context "operator_operation_id" fields
@@ -929,21 +1024,48 @@ let transition_of_yojson json =
     let* source_receipt_kind =
       string_field ~context "source_receipt_kind" fields
     in
-    let* source_receipt = source_terminal_receipt_of_stimulus source in
-    let expected_kind =
-      match source_receipt with
-      | Fusion_terminal _ -> "fusion_terminal"
-      | Background_job_terminal _ -> "background_job_terminal"
-      | Hitl_terminal _ -> "hitl_terminal"
+    let common_fields =
+      [ "kind"
+      ; "source"
+      ; "source_incarnation"
+      ; "owner_nonce"
+      ; "operator_operation_id"
+      ; "source_receipt_kind"
+      ]
     in
-    let* () =
-      if String.equal source_receipt_kind expected_kind
-      then Ok ()
-      else Error "source-terminal receipt kind does not match source payload"
+    let* source_receipt =
+      match source_receipt_kind with
+      | "turn_attempt_terminal" ->
+        let* () =
+          exact_fields
+            ~context
+            ~expected:("detail" :: common_fields)
+            fields
+        in
+        let* detail = string_field ~context "detail" fields in
+        Ok (Turn_attempt_terminal { detail })
+      | ( "fusion_terminal"
+        | "background_job_terminal"
+        | "hitl_terminal" ) as expected_kind ->
+        let* () = exact_fields ~context ~expected:common_fields fields in
+        let* source_receipt = source_terminal_receipt_of_stimulus source in
+        let* actual_kind =
+          match source_receipt with
+          | Fusion_terminal _ -> Ok "fusion_terminal"
+          | Background_job_terminal _ -> Ok "background_job_terminal"
+          | Hitl_terminal _ -> Ok "hitl_terminal"
+          | Turn_attempt_terminal _ ->
+            Error "source payload produced a non-intrinsic terminal receipt"
+        in
+        if String.equal expected_kind actual_kind
+        then Ok source_receipt
+        else Error "source-terminal receipt kind does not match source payload"
+      | other ->
+        Error (Printf.sprintf "unknown source-terminal receipt kind: %s" other)
     in
     let source_terminal =
       { source
-      ; source_revision
+      ; source_incarnation
       ; owner_nonce
       ; operator_operation_id
       ; source_receipt
@@ -1035,11 +1157,38 @@ let outbox_entry_of_yojson json =
   Ok { receipt; stimuli }
 ;;
 
+let pending_entry_to_yojson entry =
+  `Assoc
+    [ "source", Keeper_event_queue.stimulus_to_yojson entry.source
+    ; "admitted_revision", int64_json entry.admitted_revision
+    ]
+;;
+
+let pending_entry_of_yojson json =
+  let context = "event queue pending entry" in
+  let* fields = assoc_fields ~context json in
+  let* () =
+    exact_fields
+      ~context
+      ~expected:[ "source"; "admitted_revision" ]
+      fields
+  in
+  let* source_json = required_field ~context "source" fields in
+  let* source = Keeper_event_queue.stimulus_of_yojson source_json in
+  let* admitted_revision =
+    int64_field ~context "admitted_revision" fields
+  in
+  if Int64.compare admitted_revision 0L < 0
+  then Error "event queue pending admission revision must not be negative"
+  else Ok { source; admitted_revision }
+;;
+
 let to_yojson state =
   `Assoc
     [ "schema", `String schema
     ; "revision", int64_json state.revision
-    ; "pending", Keeper_event_queue.queue_to_yojson state.pending
+    ; ( "pending"
+      , `List (List.map pending_entry_to_yojson state.pending_entries) )
     ; ( "last_transition"
       , match state.last_transition with
         | None -> `Null
@@ -1071,28 +1220,35 @@ let duplicate_by key values =
   loop [] values
 ;;
 
-let duplicate_transfer_source (transfers : accepted_transfer list) =
-  let rec loop seen (l : accepted_transfer list) =
-    match l with
-    | [] -> None
-    | transfer :: rest ->
-      (match
-         List.find_opt
-           (fun (prior : accepted_transfer) ->
-              Keeper_event_queue.stimulus_identity_equal
-                prior.source
-                transfer.source)
-           seen
-       with
-       | Some prior -> Some (prior, transfer)
-       | None -> loop (transfer :: seen) rest)
+let pending_identity_is_duplicated (entries : pending_selection list) =
+  let rec loop seen = function
+    | [] -> false
+    | entry :: rest ->
+      if
+        List.exists
+          (fun prior ->
+             Keeper_event_queue.stimulus_identity_equal
+               prior.source
+               entry.source)
+          seen
+      then true
+      else loop (entry :: seen) rest
   in
-  loop [] transfers
+  loop [] entries
 ;;
 
 let validate_state state =
   if Int64.compare state.revision 0L < 0
   then Error "event queue revision must not be negative"
+  else if
+    List.exists
+      (fun entry ->
+         Int64.compare entry.admitted_revision 0L < 0
+         || Int64.compare entry.admitted_revision state.revision > 0)
+      state.pending_entries
+  then Error "event queue pending admission revision is outside the durable state"
+  else if pending_identity_is_duplicated state.pending_entries
+  then Error "event queue pending source identity is duplicated"
   else if List.length state.transition_outbox > 1
   then Error "event queue state must contain at most one unprojected transition"
   else if
@@ -1160,9 +1316,7 @@ let validate_state state =
              operation_id)
       | None -> Ok ()
     in
-    (match duplicate_transfer_source state.accepted_transfer_projections with
-     | Some _ -> Error "duplicate target transfer projection source identity"
-     | None -> Ok state)
+    Ok state
 ;;
 
 let of_yojson json =
@@ -1191,8 +1345,9 @@ let of_yojson json =
       fields
   in
   let* revision = int64_field ~context "revision" fields in
-  let* pending_json = required_field ~context "pending" fields in
-  let* pending = Keeper_event_queue.queue_of_yojson pending_json in
+  let* pending_entries =
+    list_field ~context "pending" pending_entry_of_yojson fields
+  in
   let* transition_outbox =
     list_field ~context "transition_outbox" outbox_entry_of_yojson fields
   in
@@ -1218,7 +1373,7 @@ let of_yojson json =
   in
   validate_state
     { revision
-    ; pending
+    ; pending_entries
     ; last_transition
     ; projected_dispositions
     ; transition_outbox

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -1,24 +1,24 @@
 (** Pure durable state machine for one Keeper event queue owner.
 
-    [event-queue-v13.json] is the sole authority for pending stimuli and
+    [event-queue-v14.json] is the sole authority for pending stimuli and
     source-bearing transition projection work. This module performs no I/O;
     persistence supplies the atomic file boundary and publishes [pending] into
     the live registry only after a durable commit. *)
 
 type accepted_cancellation =
   { source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; owner_nonce : int
   ; operator_operation_id : string
   ; reason : string
   }
 (** Exact operator authority for terminally cancelling one accepted event.
-    [source_revision] and [owner_nonce] fence the observed paused owner;
+    [source_incarnation] and [owner_nonce] fence the observed paused owner;
     [operator_operation_id] makes replay/conflict explicit. *)
 
 type accepted_transfer =
   { source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; owner_nonce : int
   ; operator_operation_id : string
   ; from_keeper : string
@@ -33,12 +33,16 @@ type source_terminal_receipt =
   | Fusion_terminal of Keeper_event_queue.fusion_completion
   | Background_job_terminal of Keeper_event_queue.bg_job_completion
   | Hitl_terminal of Keeper_event_queue.hitl_resolution
-(** Closed terminal source families that are intrinsically represented by a
-    durable event payload. No prose or external status inference is admitted. *)
+  | Turn_attempt_terminal of { detail : string }
+(** Closed terminal source evidence. The first three families are intrinsically
+    represented by their durable event payload. [Turn_attempt_terminal] records
+    that one admitted turn ended without durable compaction progress; the exact
+    source remains in the transition receipt instead of being discarded by a
+    raw ACK. [detail] is diagnostic only and carries no transition authority. *)
 
 type accepted_source_terminal =
   { source : Keeper_event_queue.stimulus
-  ; source_revision : int64
+  ; source_incarnation : int64
   ; owner_nonce : int
   ; operator_operation_id : string
   ; source_receipt : source_terminal_receipt
@@ -63,6 +67,13 @@ type outbox_entry =
 
 type t
 
+type pending_selection =
+  { source : Keeper_event_queue.stimulus
+  ; admitted_revision : int64
+  }
+(** One exact durable queue entry. [admitted_revision] identifies the source
+    incarnation without making later unrelated queue changes invalidate it. *)
+
 type transition_result =
   | Transition_applied of transition_receipt
   | Transition_already_applied of transition_receipt
@@ -74,6 +85,9 @@ type transfer_projection_result =
 val empty : t
 val revision : t -> int64
 val pending : t -> Keeper_event_queue.t
+val pending_selections : t -> pending_selection list
+(** FIFO pending entries with their exact source incarnation authority. *)
+
 val last_transition : t -> transition_receipt option
 val projected_dispositions : t -> transition_receipt list
 (** Newest-first projected operator dispositions, including
@@ -94,15 +108,18 @@ val peek_when :
   t ->
   Keeper_event_queue.stimulus option
 
+val select_when :
+  ready:(Keeper_event_queue.stimulus -> bool) -> t -> pending_selection option
+
 val validate_pending_selection :
-  selection:Keeper_event_queue.stimulus ->
+  selection:pending_selection ->
   t ->
   (unit, string) result
 (** Read-only exact immutable selection validation. Unrelated pending entries
     and queue revisions do not invalidate the selected source. *)
 
 val ack_pending :
-  selection:Keeper_event_queue.stimulus ->
+  selection:pending_selection ->
   t ->
   (t, string) result
 (** Compare-and-remove the exact immutable selected stimulus snapshot.
@@ -115,7 +132,7 @@ val cancel_pending_accepted :
   cancellation:accepted_cancellation ->
   t ->
   (t * transition_result, string) result
-(** Atomically apply the exact pending cancellation. The source revision and
+(** Atomically apply the exact pending cancellation. The source incarnation and
     owner generation are checked before removal. The transition is committed
     through a source-bearing WAL outbox entry by persistence. *)
 
@@ -125,7 +142,7 @@ val transfer_pending_accepted :
   transfer:accepted_transfer ->
   t ->
   (t * transition_result, string) result
-(** Atomically apply the exact pending transfer. The source revision and owner
+(** Atomically apply the exact pending transfer. The source incarnation and owner
     generation are checked before removal, and the source-bearing WAL remains
     the replay authority until the target projection completes. *)
 
@@ -135,8 +152,23 @@ val ack_pending_source_terminal :
   source_terminal:accepted_source_terminal ->
   t ->
   (t * transition_result, string) result
-(** ACK one exact pending event only when its closed payload
-    exactly matches [source_terminal.source_receipt]. *)
+(** ACK one exact pending event. Intrinsic product-terminal receipts must match
+    the source payload exactly. A turn-attempt terminal receipt carries the
+    exact source itself; its detail is diagnostic and never admission
+    authority. *)
+
+val terminalize_pending_turn_attempt :
+  current_owner_nonce:int ->
+  applied_at:float ->
+  selection:pending_selection ->
+  detail:string ->
+  t ->
+  (t * transition_result, string) result
+(** End one admitted turn attempt with a deterministic operation identity
+    derived from the exact selected queue snapshot and owner generation.
+    Repeating the same request after WAL projection returns its original
+    receipt, while a later selection of the same source is a new attempt;
+    diagnostic [detail] never participates in admission or idempotency. *)
 
 val accepted_pending_cancellation_replay :
   accepted_cancellation ->
@@ -190,4 +222,4 @@ val to_yojson : t -> Yojson.Safe.t
 val of_yojson : Yojson.Safe.t -> (t, string) result
 
 val schema : string
-(** ["keeper.event_queue.state.v13"] is the only accepted schema. *)
+(** ["keeper.event_queue.state.v14"] is the only accepted schema. *)

--- a/scripts/harness/perf/paused_work_disposition_soak.sh
+++ b/scripts/harness/perf/paused_work_disposition_soak.sh
@@ -26,7 +26,7 @@ RESTART_HOOK="${RESTART_HOOK:-}"
 RUN_ID="${RUN_ID:-paused-work-soak-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
 RUN_DIR="${RUN_DIR:-$REPO_ROOT/logs/paused-work-soak/$RUN_ID}"
 AUTHOR="${AUTHOR:-paused_work_soak}"
-REQUEST_SCHEMA="masc.keeper.paused-work.operator-request.v3"
+REQUEST_SCHEMA="masc.keeper.paused-work.operator-request.v4"
 MIN_ACCEPTANCE_SEC=28800
 
 usage() {
@@ -241,8 +241,8 @@ get_inventory() {
   [[ "$HTTP_LAST_STATUS" == "200" ]] || return 1
   INVENTORY="$HTTP_LAST_BODY"
   jq -e '
-    .schema == "masc.keeper.paused-work.inventory.v1" and
-    .operator_request_schema == "masc.keeper.paused-work.operator-request.v3" and
+    .schema == "masc.keeper.paused-work.inventory.v2" and
+    .operator_request_schema == "masc.keeper.paused-work.operator-request.v4" and
     (.queue.accepted_transfer_projection_count | type) == "number" and
     .queue.accepted_transfer_projection_count >= 0 and
     .queue.accepted_transfer_projection_count == (.queue.accepted_transfer_projection_count | floor)
@@ -317,7 +317,7 @@ post_disposition() {
 receipt_canonical() { jq -S -c '.receipt' <<<"$1"; }
 
 verify_receipt_file() {
-  local keeper="$1" operation_id="$2" root="$MASC_BASE_PATH/.masc/paused-work-dispositions-v5"
+  local keeper="$1" operation_id="$2" root="$MASC_BASE_PATH/.masc/paused-work-dispositions-v6"
   local matches=0 file
   [[ -d "$root" ]] || return 1
   while IFS= read -r -d '' file; do
@@ -410,7 +410,9 @@ while (( $(date +%s) - START_EPOCH < DURATION_SEC )); do
     die "paused source was not retained exactly once for $source_keeper/$post_id" "silent_loss"
   source="$(jq -c --arg post_id "$post_id" '.queue.pending[] | select(.source.post_id == $post_id) | .source' <<<"$INVENTORY")"
   binding="$(jq -c --arg post_id "$post_id" '.queue.pending[] | select(.source.post_id == $post_id) | .continuation_binding' <<<"$INVENTORY")"
-  source_revision="$(jq -r '.queue.revision | tostring' <<<"$INVENTORY")"
+  source_incarnation="$(jq -r --arg post_id "$post_id" \
+    '.queue.pending[] | select(.source.post_id == $post_id) | .source_incarnation | tostring' \
+    <<<"$INVENTORY")"
   operation_id="$RUN_ID/$ITERATIONS/$action"
 
   case "$action" in
@@ -422,20 +424,20 @@ while (( $(date +%s) - START_EPOCH < DURATION_SEC )); do
       ;;
     transfer)
       request="$(jq -cn --arg schema "$REQUEST_SCHEMA" --arg op "$operation_id" \
-        --argjson source "$source" --arg revision "$source_revision" \
+        --argjson source "$source" --arg revision "$source_incarnation" \
         --argjson generation "$source_generation" --argjson target_generation "$target_generation" \
         --arg target "$target_keeper" --argjson binding "$binding" \
-        '{schema:$schema,operation:"transfer_owner",source:$source,source_revision:$revision,
+        '{schema:$schema,operation:"transfer_owner",source:$source,source_incarnation:$revision,
           owner_nonce:$generation,target_generation:$target_generation,to_keeper:$target,
           continuation_binding:$binding,operator_operation_id:$op}')"
       TRANSFER_CASES=$((TRANSFER_CASES + 1))
       ;;
     cancel)
       request="$(jq -cn --arg schema "$REQUEST_SCHEMA" --arg op "$operation_id" \
-        --argjson source "$source" --arg revision "$source_revision" \
+        --argjson source "$source" --arg revision "$source_incarnation" \
         --argjson generation "$source_generation" \
         '{schema:$schema,operation:"cancel_accepted",source_state:"pending",source:$source,
-          source_revision:$revision,owner_nonce:$generation,operator_operation_id:$op,
+          source_incarnation:$revision,owner_nonce:$generation,operator_operation_id:$op,
           reason:"paused-work soak accepted cancellation"}')"
       CANCEL_CASES=$((CANCEL_CASES + 1))
       ;;
@@ -509,11 +511,11 @@ while (( $(date +%s) - START_EPOCH < DURATION_SEC )); do
     --argjson iteration "$ITERATIONS" --arg action "$action" --arg source_keeper "$source_keeper" \
     --arg target_keeper "$( [[ "$action" == "transfer" ]] && printf '%s' "$target_keeper" || printf '')" \
     --arg post_id "$post_id" --arg operation_id "$operation_id" --argjson source "$source" \
-    --argjson source_revision "$source_revision" --argjson owner_nonce "$source_generation" \
+    --argjson source_incarnation "$source_incarnation" --argjson owner_nonce "$source_generation" \
     --argjson restarted "$restarted" --argjson receipt "$first_receipt" \
     '{schema:$schema,run_id:$run_id,iteration:$iteration,action:$action,
       source_keeper:$source_keeper,target_keeper:(if $target_keeper == "" then null else $target_keeper end),
-      post_id:$post_id,operation_id:$operation_id,source:$source,source_revision:$source_revision,
+      post_id:$post_id,operation_id:$operation_id,source:$source,source_incarnation:$source_incarnation,
       owner_nonce:$owner_nonce,restarted:$restarted,receipt:$receipt,
       duplicate_terminal_effects:0,silent_losses:0}' >>"$LEDGER_FILE"
 

--- a/test/deps/masc_test_deps.ml
+++ b/test/deps/masc_test_deps.ml
@@ -97,7 +97,6 @@ let meta_of_json_fixture (json : Yojson.Safe.t) =
         | Schema.Compaction_count
         | Schema.Last_compaction_before_tokens
         | Schema.Last_compaction_after_tokens
-        | Schema.Compaction_consecutive_failures
         | Schema.Proactive_count_total
         | Schema.Proactive_visible_count_total
         | Schema.Consecutive_noop_count

--- a/test/stanzas/test_keeper_compaction_outcome_counters.inc
+++ b/test/stanzas/test_keeper_compaction_outcome_counters.inc
@@ -1,4 +1,4 @@
-; Compaction outcome counters — which outcome moved the streak.
+; Compaction outcome counters and checkpoint-authoritative count projection.
 
 (test
  (name test_keeper_compaction_outcome_counters)

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -3191,7 +3191,7 @@ let test_observed_delivery_preserves_grant_without_replaying_wake () =
        in
        let selection =
          match
-           Event_queue_persistence.peek_when_result
+           Event_queue_persistence.select_when_result
              ~base_path
              ~keeper_name
              ~ready:(fun _ -> true)
@@ -3203,7 +3203,7 @@ let test_observed_delivery_preserves_grant_without_replaying_wake () =
        Reaction_ledger.record_event_queue_turn_started
          ~base_path
          ~keeper_name
-         selection;
+         selection.source;
        (match
           Event_queue_persistence.ack_pending_result
             ~base_path

--- a/test/test_keeper_compaction_outcome_counters.ml
+++ b/test/test_keeper_compaction_outcome_counters.ml
@@ -1,30 +1,8 @@
-(** Which outcome moved the compaction streak.
-
-    [persist_compaction_outcome] is the one place all four outcomes converge on
-    [compaction_rt], but the outcome was never recorded: the phase-transition
-    log renders a decision string, not the variant, so a live keeper's streak
-    could be seen rising without any way to tell whether a reset came from an
-    overflow-free turn ([`Recovered]) or an operator commit ([`Committed]).
-    These tests pin that every persisted outcome is counted exactly once and
-    carries its own label. *)
+(** Durable compaction state records commits, not retry policy. *)
 
 open Alcotest
 
 module Meta_store = Masc.Keeper_meta_store
-
-let metric_name = Keeper_metrics.(to_string CompactionOutcomes)
-
-let counted ~keeper_name ~outcome =
-  Otel_metric_store_core.metric_value_or_zero
-    metric_name
-    ~labels:[ "keeper", keeper_name; "outcome", outcome ]
-    ()
-;;
-
-(* Fleet total across every keeper series, so the aggregate a dashboard reads
-   stays pinned even though the series are split per keeper. *)
-let fleet_total () = Otel_metric_store_core.metric_total metric_name
-;;
 
 let make_meta ~name : Masc.Keeper_meta_contract.keeper_meta =
   match
@@ -46,120 +24,49 @@ let with_workspace f =
        f config)
 ;;
 
-let register config ~name =
-  let meta = make_meta ~name in
-  (match Meta_store.write_meta config meta with
-   | Ok () -> ()
-   | Error msg -> failf "could not persist meta for %s: %s" name msg);
-  meta
-;;
-
-let persist_outcome config ~name ~outcome =
-  match Meta_store.persist_compaction_outcome config ~keeper_name:name ~outcome with
+let persist_commit_projection config ~name ~commit_count =
+  match
+    Meta_store.persist_compaction_commit_projection
+      config
+      ~keeper_name:name
+      ~commit_count
+  with
   | Ok `Persisted -> ()
   | Ok `No_durable_meta -> failf "%s has no durable meta to update" name
-  | Error msg -> failf "outcome persistence failed for %s: %s" name msg
+  | Error msg -> failf "commit persistence failed for %s: %s" name msg
 ;;
 
-(* Each variant gets its own label, so a dashboard can separate a streak reset
-   that came from an overflow-free turn from one an operator forced. *)
-let test_each_outcome_is_labelled () =
+let test_commit_count_tracks_only_durable_commits () =
   with_workspace (fun config ->
-    let name = "outcome-labels" in
-    ignore (register config ~name);
-    List.iter
-      (fun (outcome, label) ->
-         let before = counted ~keeper_name:name ~outcome:label in
-         persist_outcome config ~name ~outcome;
-         check
-           (float 0.5)
-           (Printf.sprintf "%s is counted under its own label" label)
-           (before +. 1.)
-           (counted ~keeper_name:name ~outcome:label))
-      [ `Committed, "committed"
-      ; `Overflow_episode_committed, "overflow_episode_committed"
-      ; `Failed, "failed"
-      ; `Recovered, "recovered"
-      ])
-;;
-
-(* The streak arithmetic and the counter must agree: four persisted [`Failed]
-   outcomes are four counted outcomes and a streak of four. A count that drifts from
-   the durable value would send an operator looking for a bug that is not
-   there. *)
-let test_count_tracks_the_durable_streak () =
-  with_workspace (fun config ->
-    let name = "outcome-streak" in
-    ignore (register config ~name);
-    let before = counted ~keeper_name:name ~outcome:"failed" in
-    for _ = 1 to 4 do
-      persist_outcome config ~name ~outcome:`Failed
-    done;
-    check
-      (float 0.5)
-      "four failed outcomes are counted four times"
-      (before +. 4.)
-      (counted ~keeper_name:name ~outcome:"failed");
+    let name = "compaction-commits" in
+    let meta = make_meta ~name in
+    (match Meta_store.write_meta config meta with
+     | Ok () -> ()
+     | Error msg -> failf "could not persist meta for %s: %s" name msg);
+    persist_commit_projection config ~name ~commit_count:2;
+    persist_commit_projection config ~name ~commit_count:1;
     match Meta_store.read_meta config name with
-    | Ok (Some meta) ->
+    | Ok (Some current) ->
       check
         int
-        "the durable streak matches the count"
-        4
-        meta.Masc.Keeper_meta_contract.runtime.compaction_rt.consecutive_failures
-    | Ok None -> fail "keeper meta disappeared mid-test"
+        "a delayed projection cannot regress the checkpoint count"
+        2
+        current.runtime.compaction_rt.count
+    | Ok None -> fail "keeper meta disappeared after compaction commits"
     | Error msg -> failf "meta read failed: %s" msg)
 ;;
 
-(* Per-keeper attribution is the question the series was added for — which
-   keeper's compaction is collapsing. One keeper's outcome must not move
-   another's series, and the fleet aggregate a dashboard reads is the sum over
-   them, so both readings stay available. *)
-let test_attributes_the_outcome_to_its_keeper () =
+let test_missing_keeper_has_no_commit_state () =
   with_workspace (fun config ->
-    let alpha = "outcome-alpha" in
-    let beta = "outcome-beta" in
-    ignore (register config ~name:alpha);
-    ignore (register config ~name:beta);
-    let alpha_before = counted ~keeper_name:alpha ~outcome:"failed" in
-    let beta_before = counted ~keeper_name:beta ~outcome:"failed" in
-    let fleet_before = fleet_total () in
-    persist_outcome config ~name:alpha ~outcome:`Failed;
-    check
-      (float 0.5)
-      "the persisting keeper's series advances"
-      (alpha_before +. 1.)
-      (counted ~keeper_name:alpha ~outcome:"failed");
-    check
-      (float 0.5)
-      "another keeper's series is untouched"
-      beta_before
-      (counted ~keeper_name:beta ~outcome:"failed");
-    persist_outcome config ~name:beta ~outcome:`Failed;
-    check
-      (float 0.5)
-      "the fleet aggregate is the sum over keepers"
-      (fleet_before +. 2.)
-      (fleet_total ()))
-;;
-
-(* No durable meta means no outcome was persisted and no streak moved, so
-   counting one would overstate the population the series describes. *)
-let test_unregistered_keeper_is_not_counted () =
-  with_workspace (fun config ->
-    let name = "outcome-unregistered" in
-    let before = counted ~keeper_name:name ~outcome:"failed" in
-    (match
-       Meta_store.persist_compaction_outcome config ~keeper_name:name ~outcome:`Failed
-     with
-     | Ok `No_durable_meta -> ()
-     | Ok `Persisted -> fail "an unregistered keeper must not persist an outcome"
-     | Error msg -> failf "unexpected outcome persistence error: %s" msg);
-    check
-      (float 0.5)
-      "an unpersisted outcome is not counted"
-      before
-      (counted ~keeper_name:name ~outcome:"failed"))
+    match
+      Meta_store.persist_compaction_commit_projection
+        config
+        ~keeper_name:"compaction-unregistered"
+        ~commit_count:1
+    with
+    | Ok `No_durable_meta -> ()
+    | Ok `Persisted -> fail "an unregistered keeper must not persist a commit"
+    | Error msg -> failf "unexpected commit persistence error: %s" msg)
 ;;
 
 let test_metric_name_is_stable () =
@@ -167,26 +74,21 @@ let test_metric_name_is_stable () =
     string
     "dashboards and alerts key off this name"
     "masc_keeper_compaction_outcomes_total"
-    metric_name
+    Keeper_metrics.(to_string CompactionOutcomes)
 ;;
 
 let () =
   run
-    "keeper compaction outcome counters"
-    [ ( "outcome"
-      , [ test_case "each outcome is labelled" `Quick test_each_outcome_is_labelled
-        ; test_case
-            "count tracks the durable streak"
+    "keeper compaction commit count"
+    [ ( "commit"
+      , [ test_case
+            "durable count tracks commits"
             `Quick
-            test_count_tracks_the_durable_streak
+            test_commit_count_tracks_only_durable_commits
         ; test_case
-            "attributes the outcome to its keeper"
+            "missing keeper has no commit state"
             `Quick
-            test_attributes_the_outcome_to_its_keeper
-        ; test_case
-            "an unregistered keeper is not counted"
-            `Quick
-            test_unregistered_keeper_is_not_counted
+            test_missing_keeper_has_no_commit_state
         ; test_case "metric name is stable" `Quick test_metric_name_is_stable
         ] )
     ]

--- a/test/test_keeper_current_operations.ml
+++ b/test/test_keeper_current_operations.ml
@@ -81,11 +81,52 @@ let test_terminal_async_entry_is_not_current () =
   | _ -> fail "terminal async entry was projected as a current operation"
 ;;
 
+let test_pending_operations_expose_source_incarnations () =
+  let first = stimulus "source-a" 1.0 in
+  let second = stimulus "source-b" 2.0 in
+  let first_state =
+    S.empty
+    |> S.with_pending (queue [ first ])
+    |> S.with_revision 1L
+  in
+  let state =
+    first_state
+    |> S.with_pending (queue [ first; second ])
+    |> S.with_revision 2L
+  in
+  let operations = O.project_event_queue_state ~keeper_name:"keeper-a" state in
+  let incarnations =
+    operations
+    |> List.map (fun operation ->
+      O.to_yojson operation
+      |> J.member "source"
+      |> J.member "source_incarnation"
+      |> J.to_string)
+  in
+  check (list string)
+    "pending operations retain each source incarnation"
+    [ "0"; "1" ]
+    incarnations;
+  let snapshot =
+    O.project_snapshot
+      ~keeper_name:"keeper-a"
+      ~event_queue:(Ok state)
+      ~async_requests:(Ok [])
+    |> O.snapshot_to_yojson
+  in
+  check string
+    "source-incarnation wire has a new schema"
+    "keeper.current_operations.v2"
+    J.(snapshot |> member "schema" |> to_string)
+;;
+
 let () =
   run "keeper_current_operations"
     [ "projection",
       [ test_case "async active and unavailable" `Quick test_async_active_and_unavailable
       ; test_case "terminal async is not current" `Quick
           test_terminal_async_entry_is_not_current
+      ; test_case "pending source incarnations" `Quick
+          test_pending_operations_expose_source_incarnations
       ] ]
 ;;

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -29,7 +29,7 @@ let rec rm_rf path =
 let snapshot_path ~base_path ~keeper_name =
   Filename.concat
     (Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name)
-    "event-queue-v13.json"
+    "event-queue-v14.json"
 
 let json_field name = function
   | `Assoc fields -> List.assoc_opt name fields
@@ -831,12 +831,12 @@ let () =
       assert (is_empty (Keeper_event_queue_persistence.load ~base_path ~keeper_name)));
 
   (* --- current-only hard cut: the retired v12 filename is not a read,
-         migration, or overwrite source for the v13 queue. --- *)
-  let base_path = temp_dir "keeper-event-queue-v13-hard-cut" in
+         migration, or overwrite source for the v14 queue. --- *)
+  let base_path = temp_dir "keeper-event-queue-v14-hard-cut" in
   Fun.protect
     ~finally:(fun () -> rm_rf base_path)
     (fun () ->
-      let keeper_name = "keeper-event-queue-v13-hard-cut-test" in
+      let keeper_name = "keeper-event-queue-v14-hard-cut-test" in
       let keeper_dir =
         Filename.concat
           (Common.keepers_runtime_dir_of_base ~base_path)
@@ -1025,7 +1025,7 @@ let () =
 
   (* --- A-fix (RFC: keeper-orphan-stimulus-persistence): a consumed stimulus
          is drained from the current queue state on the genuine-ack path. Here
-         the stimulus lives in event-queue-v13.json, mirroring a bootstrap enqueued
+         the stimulus lives in event-queue-v14.json, mirroring a bootstrap enqueued
          by supervisor launch; after ack, [load] must be empty. Without the
          A-fix this returns length 1 and accumulates across restarts. --- *)
   let base_path = temp_dir "keeper-event-queue-ack-drains-pending" in

--- a/test/test_keeper_event_queue_persist_poison.ml
+++ b/test/test_keeper_event_queue_persist_poison.ml
@@ -35,7 +35,7 @@ let rec rm_rf path =
 let snapshot_path ~base_path ~keeper_name =
   Filename.concat
     (Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name)
-    "event-queue-v13.json"
+    "event-queue-v14.json"
 
 let () =
   Eio_main.run @@ fun env ->

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -22,8 +22,9 @@ let post_ids queue =
   Queue.to_list queue |> List.map (fun (item : Queue.stimulus) -> item.post_id)
 ;;
 
-let selection state =
-  State.peek_when ~ready:(fun _ -> true) state |> require_some "pending selection"
+let select state =
+  State.select_when ~ready:(fun _ -> true) state
+  |> require_some "pending selection"
 ;;
 
 let test_peek_keeps_pending_authoritative () =
@@ -32,8 +33,11 @@ let test_peek_keeps_pending_authoritative () =
     |> State.with_revision 7L
     |> State.with_pending (queue [ stimulus "first" 1.0; stimulus "second" 2.0 ])
   in
-  let selected = selection state in
-  Alcotest.(check string) "selected exact head" "first" selected.post_id;
+  let selected = select state in
+  Alcotest.(check string)
+    "selected exact head"
+    "first"
+    selected.source.post_id;
   Alcotest.(check (list string))
     "peek does not dequeue"
     [ "first"; "second" ]
@@ -45,7 +49,7 @@ let test_exact_ack_removes_only_selected_identity () =
   let first = stimulus "approval-a" 1.0 in
   let second = stimulus "approval-b" 2.0 in
   let state = State.with_pending (queue [ first; second ]) State.empty in
-  let selected = selection state in
+  let selected = select state in
   let acked = State.ack_pending ~selection:selected state |> require_ok "exact ack" in
   Alcotest.(check (list string))
     "distinct source remains"
@@ -55,7 +59,7 @@ let test_exact_ack_removes_only_selected_identity () =
 
 let test_failure_without_ack_retains_source () =
   let state = State.with_pending (queue [ stimulus "retry-me" 1.0 ]) State.empty in
-  ignore (selection state);
+  ignore (select state);
   Alcotest.(check (list string))
     "failure or crash performs no queue mutation"
     [ "retry-me" ]
@@ -65,7 +69,7 @@ let test_failure_without_ack_retains_source () =
 let test_unrelated_enqueue_does_not_invalidate_exact_ack () =
   let source = stimulus "source" 1.0 in
   let state = State.with_pending (queue [ source ]) State.empty in
-  let selected = selection state in
+  let selected = select state in
   let changed =
     state
     |> State.with_revision 1L
@@ -81,10 +85,35 @@ let test_unrelated_enqueue_does_not_invalidate_exact_ack () =
     (post_ids (State.pending acked))
 ;;
 
+let test_reinserted_source_invalidates_old_selection () =
+  let source = stimulus "source-aba" 1.0 in
+  let initial = State.with_pending (queue [ source ]) State.empty in
+  let old_selection = select initial in
+  let reinserted =
+    initial
+    |> State.with_pending Queue.empty
+    |> State.with_revision 1L
+    |> State.with_pending (queue [ source ])
+    |> State.with_revision 2L
+  in
+  (match State.ack_pending ~selection:old_selection reinserted with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "old selection consumed a reinserted source");
+  let current_selection = select reinserted in
+  let acked =
+    State.ack_pending ~selection:current_selection reinserted
+    |> require_ok "current source incarnation ACK"
+  in
+  Alcotest.(check (list string))
+    "current source incarnation is removable"
+    []
+    (post_ids (State.pending acked))
+;;
+
 let test_changed_selected_snapshot_fails_closed () =
   let source = stimulus "source" 1.0 in
   let state = State.with_pending (queue [ source ]) State.empty in
-  let selected = selection state in
+  let selected = select state in
   let changed_source = { source with arrived_at = 9.0 } in
   let changed = State.with_pending (queue [ changed_source ]) state in
   (match State.ack_pending ~selection:selected changed with
@@ -96,6 +125,97 @@ let test_changed_selected_snapshot_fails_closed () =
     (post_ids (State.pending changed))
 ;;
 
+let test_turn_attempt_terminal_receipt_preserves_exact_source () =
+  let source = stimulus "failed-turn-source" 1.0 in
+  let initial = State.with_pending (queue [ source ]) State.empty in
+  let selection = select initial in
+  let staged, receipt =
+    match
+      State.terminalize_pending_turn_attempt
+        ~current_owner_nonce:7
+        ~applied_at:2.0
+        ~selection
+        ~detail:""
+        initial
+      |> require_ok "terminalize failed turn source"
+    with
+    | state, State.Transition_applied receipt -> state, receipt
+    | _, State.Transition_already_applied _ ->
+      Alcotest.fail "first turn-attempt terminalization was replayed"
+  in
+  Alcotest.(check (list string))
+    "terminal source leaves runnable pending"
+    []
+    (post_ids (State.pending staged));
+  (match State.transition_outbox staged with
+   | [ { receipt = actual; stimuli = [ retained ] } ] ->
+     Alcotest.(check string)
+       "receipt identity is stable"
+       receipt.transition_id
+       actual.transition_id;
+     Alcotest.(check bool)
+       "exact source survives in the durable receipt"
+       true
+       (retained = source)
+   | _ -> Alcotest.fail "turn-attempt terminal receipt did not retain one source");
+  let projected =
+    State.mark_transition_projected
+      ~transition_id:receipt.transition_id
+      staged
+    |> require_ok "project turn-attempt terminal receipt"
+  in
+  (match
+     State.terminalize_pending_turn_attempt
+       ~current_owner_nonce:7
+       ~applied_at:3.0
+       ~selection
+       ~detail:"different diagnostic"
+       projected
+     |> require_ok "replay projected turn-attempt terminal receipt"
+   with
+   | replayed, State.Transition_already_applied actual ->
+     Alcotest.(check string)
+       "projected replay keeps operation identity"
+       receipt.transition_id
+       actual.transition_id;
+     Alcotest.(check int64)
+       "projected replay does not revise queue"
+       (State.revision projected)
+       (State.revision replayed)
+   | _, State.Transition_applied _ ->
+     Alcotest.fail "projected turn-attempt terminal receipt applied twice");
+  let requeued =
+    projected
+    |> State.with_revision (Int64.succ (State.revision projected))
+    |> State.with_pending (queue [ source ])
+  in
+  let next_selection = select requeued in
+  (match
+     State.terminalize_pending_turn_attempt
+       ~current_owner_nonce:7
+       ~applied_at:4.0
+       ~selection:next_selection
+       ~detail:"later attempt"
+       requeued
+     |> require_ok "terminalize re-enqueued identical source"
+   with
+   | next, State.Transition_applied next_receipt ->
+     Alcotest.(check bool)
+       "later selection receives a distinct operation"
+       false
+       (String.equal receipt.transition_id next_receipt.transition_id);
+     Alcotest.(check (list string))
+       "later identical source is removed"
+       []
+       (post_ids (State.pending next))
+   | _, State.Transition_already_applied _ ->
+     Alcotest.fail "later identical source was mistaken for the prior attempt");
+  State.to_yojson projected
+  |> State.of_yojson
+  |> require_ok "turn-attempt terminal receipt round trip"
+  |> ignore
+;;
+
 let test_projected_disposition_ledger_replays_older_operation () =
   let cancelled_source = stimulus "cancelled-source" 1.0 in
   let transferred_source = stimulus "transferred-source" 2.0 in
@@ -105,7 +225,12 @@ let test_projected_disposition_ledger_replays_older_operation () =
   in
   let cancellation : State.accepted_cancellation =
     { source = cancelled_source
-    ; source_revision = State.revision initial
+    ; source_incarnation =
+        (State.select_when
+           ~ready:(Queue.stimulus_identity_equal cancelled_source)
+           initial
+         |> require_some "select cancellation source")
+          .admitted_revision
     ; owner_nonce = 7
     ; operator_operation_id = "cancel-operation"
     ; reason = "operator cancelled"
@@ -132,7 +257,12 @@ let test_projected_disposition_ledger_replays_older_operation () =
   in
   let transfer : State.accepted_transfer =
     { source = transferred_source
-    ; source_revision = State.revision projected_cancel
+    ; source_incarnation =
+        (State.select_when
+           ~ready:(Queue.stimulus_identity_equal transferred_source)
+           projected_cancel
+         |> require_some "select transfer source")
+          .admitted_revision
     ; owner_nonce = 7
     ; operator_operation_id = "transfer-operation"
     ; from_keeper = "source-keeper"
@@ -209,7 +339,23 @@ let test_current_schema_round_trip () =
   Alcotest.(check (list string))
     "fresh pending survives"
     [ "fresh" ]
-    (post_ids (State.pending decoded))
+    (post_ids (State.pending decoded));
+  let duplicated_pending =
+    match json with
+    | `Assoc fields ->
+      `Assoc
+        (List.map
+           (function
+             | "pending", `List [ entry ] ->
+               "pending", `List [ entry; entry ]
+             | field -> field)
+           fields)
+    | _ -> Alcotest.fail "state codec did not emit an object"
+  in
+  (match State.of_yojson duplicated_pending with
+   | Error _ -> ()
+   | Ok _ ->
+     Alcotest.fail "duplicate pending source identity was accepted")
 ;;
 
 let with_temp_dir prefix f =
@@ -229,7 +375,10 @@ let test_durable_peek_ack_restart () =
       Queue.enqueue pending (stimulus "two" 2.0))
     |> require_ok "seed durable pending";
     let selected =
-      Persistence.peek_when_result ~base_path ~keeper_name ~ready:(fun _ -> true)
+      Persistence.select_when_result
+        ~base_path
+        ~keeper_name
+        ~ready:(fun _ -> true)
       |> require_ok "durable peek"
       |> require_some "durable selection"
     in
@@ -296,6 +445,185 @@ let test_durable_reprioritize_is_revision_fenced () =
     | Ok _ -> Alcotest.fail "stale priority revision was accepted")
 ;;
 
+let test_durable_turn_attempt_terminal_restart () =
+  with_temp_dir "keeper-turn-attempt-terminal" (fun base_path ->
+    let keeper_name = "failed-turn-keeper" in
+    Persistence.update_result ~base_path ~keeper_name (fun pending ->
+      let pending = Queue.enqueue pending (stimulus "failed" 1.0) in
+      Queue.enqueue pending (stimulus "unrelated" 2.0))
+    |> require_ok "seed failed turn pending";
+    let selection =
+      Persistence.select_when_result
+        ~base_path
+        ~keeper_name
+        ~ready:(fun _ -> true)
+      |> require_ok "peek failed turn source"
+      |> require_some "failed turn selection"
+    in
+    Persistence.terminalize_pending_turn_attempt_result
+      ~base_path
+      ~keeper_name
+      ~current_owner_nonce:7
+      ~applied_at:3.0
+      ~selection
+      ~detail:""
+      ()
+    |> require_ok "commit failed turn terminal receipt"
+    |> ignore;
+    let restarted =
+      Persistence.load_state_result ~base_path ~keeper_name
+      |> require_ok "restart failed turn state"
+    in
+    Alcotest.(check (list string))
+      "only unrelated source remains runnable"
+      [ "unrelated" ]
+      (post_ids (State.pending restarted));
+    (match State.transition_outbox restarted with
+     | [ { stimuli = [ retained ]; _ } ] ->
+       Alcotest.(check bool)
+         "restart retains exact failed source in WAL"
+         true
+         (retained = selection.source)
+     | _ ->
+       Alcotest.fail
+         "restart did not retain exactly one source-bearing failed turn receipt");
+    Persistence.project_transition_outbox_result
+      ~append_before_retire:(fun _ -> Ok ())
+      ~base_path
+      ~keeper_name
+    |> require_ok "project failed turn terminal receipt";
+    (match
+       Persistence.terminalize_pending_turn_attempt_result
+         ~base_path
+         ~keeper_name
+         ~current_owner_nonce:7
+         ~applied_at:4.0
+         ~selection
+         ~detail:"replayed after projection"
+         ()
+       |> require_ok "replay projected failed turn after restart"
+     with
+     | Persistence.Transition_already_applied _ -> ()
+     | Persistence.Transition_applied _
+     | Persistence.Transition_committed_followup_failed _ ->
+       Alcotest.fail "projected failed turn replay committed twice");
+    Persistence.update_result ~base_path ~keeper_name (fun pending ->
+      Queue.enqueue pending selection.source)
+    |> require_ok "re-enqueue identical source";
+    (match
+       Persistence.ack_pending_result
+         ~base_path
+         ~keeper_name
+         ~selection
+         ()
+     with
+     | Error _ -> ()
+     | Ok () ->
+       Alcotest.fail "old successful-turn selection ACKed a later incarnation");
+    (match
+       Persistence.terminalize_pending_turn_attempt_result
+         ~base_path
+         ~keeper_name
+         ~current_owner_nonce:7
+         ~applied_at:4.5
+         ~selection
+         ~detail:"stale in-flight attempt"
+         ()
+     with
+     | Ok (Persistence.Transition_already_applied _) -> ()
+     | Ok
+         ( Persistence.Transition_applied _
+         | Persistence.Transition_committed_followup_failed _ )
+     | Error _ ->
+       Alcotest.fail "projected replay did not return its original receipt");
+    let later_selection =
+      Persistence.select_when_result
+        ~base_path
+        ~keeper_name
+        ~ready:(Queue.stimulus_identity_equal selection.source)
+      |> require_ok "select re-enqueued identical source"
+      |> require_some "later identical selection"
+    in
+    (match
+       Persistence.terminalize_pending_turn_attempt_result
+         ~base_path
+         ~keeper_name
+         ~current_owner_nonce:7
+         ~applied_at:5.0
+         ~selection:later_selection
+         ~detail:"later attempt"
+         ()
+       |> require_ok "terminalize later identical source"
+     with
+     | Persistence.Transition_applied _ -> ()
+     | Persistence.Transition_already_applied _
+     | Persistence.Transition_committed_followup_failed _ ->
+       Alcotest.fail "later identical source did not commit a new terminal receipt");
+    let final_pending =
+      Persistence.load_pending_result ~base_path ~keeper_name
+      |> require_ok "reload after later identical source"
+    in
+    Alcotest.(check (list string))
+      "later identical source is removed"
+      [ "unrelated" ]
+      (post_ids final_pending))
+;;
+
+let test_durable_inflight_selection_rejects_reinserted_source () =
+  with_temp_dir "keeper-pending-incarnation" (fun base_path ->
+    let keeper_name = "inflight-keeper" in
+    let source = stimulus "same-source" 1.0 in
+    Persistence.update_result ~base_path ~keeper_name (fun pending ->
+      Queue.enqueue pending source)
+    |> require_ok "seed in-flight source";
+    let stale_selection =
+      Persistence.select_when_result
+        ~base_path
+        ~keeper_name
+        ~ready:(fun _ -> true)
+      |> require_ok "select first source incarnation"
+      |> require_some "first source selection"
+    in
+    Persistence.ack_pending_result
+      ~base_path
+      ~keeper_name
+      ~selection:stale_selection
+      ()
+    |> require_ok "remove first source incarnation";
+    Persistence.update_result ~base_path ~keeper_name (fun pending ->
+      Queue.enqueue pending source)
+    |> require_ok "reinsert exact source";
+    (match
+       Persistence.ack_pending_result
+         ~base_path
+         ~keeper_name
+         ~selection:stale_selection
+         ()
+     with
+     | Error _ -> ()
+     | Ok () -> Alcotest.fail "stale selection ACKed reinserted source");
+    (match
+       Persistence.terminalize_pending_turn_attempt_result
+         ~base_path
+         ~keeper_name
+         ~current_owner_nonce:7
+         ~applied_at:3.0
+         ~selection:stale_selection
+         ~detail:"old in-flight turn"
+         ()
+     with
+     | Error _ -> ()
+     | Ok _ -> Alcotest.fail "stale turn terminalized reinserted source");
+    let pending =
+      Persistence.load_pending_result ~base_path ~keeper_name
+      |> require_ok "reload reinserted source"
+    in
+    Alcotest.(check (list string))
+      "reinserted source remains pending"
+      [ "same-source" ]
+      (post_ids pending))
+;;
+
 let () =
   Alcotest.run
     "keeper pending queue current schema"
@@ -308,9 +636,17 @@ let () =
             `Quick
             test_unrelated_enqueue_does_not_invalidate_exact_ack
         ; Alcotest.test_case
+            "reinserted source rejects old selection"
+            `Quick
+            test_reinserted_source_invalidates_old_selection
+        ; Alcotest.test_case
             "changed selected snapshot fails closed"
             `Quick
             test_changed_selected_snapshot_fails_closed
+        ; Alcotest.test_case
+            "turn-attempt terminal receipt preserves exact source"
+            `Quick
+            test_turn_attempt_terminal_receipt_preserves_exact_source
         ; Alcotest.test_case
             "older projected disposition replays"
             `Quick
@@ -326,6 +662,14 @@ let () =
             "durable reprioritize is revision fenced"
             `Quick
             test_durable_reprioritize_is_revision_fenced
+        ; Alcotest.test_case
+            "durable failed turn receipt restart"
+            `Quick
+            test_durable_turn_attempt_terminal_restart
+        ; Alcotest.test_case
+            "durable in-flight selection rejects reinserted source"
+            `Quick
+            test_durable_inflight_selection_rejects_reinserted_source
         ] )
-    ]
+      ]
 ;;

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3619,11 +3619,6 @@ let test_compaction_snapshots_json_reads_runtime_manifest () =
       |> append
     in
     append_failure
-      ~ts:"2026-06-26T03:03:10Z"
-      ~status:"retryable_failure"
-      ~compaction_outcome:Runtime_manifest.Retry_without_checkpoint
-      ~error:"compaction dispatch failed";
-    append_failure
       ~ts:"2026-06-26T03:03:20Z"
       ~status:"lifecycle_cleanup_failed"
       ~compaction_outcome:Runtime_manifest.Lifecycle_cleanup_failed_without_checkpoint
@@ -3688,7 +3683,7 @@ let test_compaction_snapshots_json_reads_runtime_manifest () =
       "schema"
       "keeper.compaction_snapshots.v1"
       (json_string_field "compaction_snapshots" top "schema");
-    Alcotest.(check int) "count" 5 (json_int_field "compaction_snapshots" top "count");
+    Alcotest.(check int) "count" 4 (json_int_field "compaction_snapshots" top "count");
     Alcotest.(check int)
       "read errors"
       0
@@ -3771,8 +3766,7 @@ let test_compaction_snapshots_json_reads_runtime_manifest () =
            (outcome ^ " has no exact evidence")
            `Null
            (List.assoc "exact_evidence" failed))
-      [ "retry_without_checkpoint", "compaction dispatch failed"
-      ; ( "lifecycle_cleanup_failed_without_checkpoint"
+      [ ( "lifecycle_cleanup_failed_without_checkpoint"
         , "lifecycle cleanup failed" )
       ];
     List.iter

--- a/test/test_keeper_meta_current_schema.ml
+++ b/test/test_keeper_meta_current_schema.ml
@@ -64,8 +64,8 @@ let nullable_field_names =
 
 let test_current_writer_roundtrip_and_keyset () =
   check int
-    "current schema has 54 fields"
-    54
+    "current schema has 53 fields"
+    53
     (List.length Keeper_meta_json.current_field_names);
   let meta =
     match Keeper_meta_json_parse.meta_of_json (current_json ()) with
@@ -148,22 +148,33 @@ let test_every_outside_field_has_one_classification () =
       (current_json () |> replace_field key (`String "ignored-value")))
 ;;
 
+let test_retired_compaction_failure_authority_requires_reset () =
+  expect_rejected
+    "retired compaction failure authority"
+    (current_json ()
+     |> replace_field "compaction_consecutive_failures" (`Int 3))
+;;
+
 let () =
   run
     "keeper_meta_current_schema"
     [ ( "current-schema"
       , [ test_case "writer roundtrip and keyset" `Quick
             test_current_writer_roundtrip_and_keyset
-        ; test_case "all 54 fields are required" `Quick
+        ; test_case "all 53 fields are required" `Quick
             test_every_current_field_is_required
-        ; test_case "all 54 duplicate fields reject" `Quick
+        ; test_case "all 53 duplicate fields reject" `Quick
             test_every_duplicate_is_rejected
-        ; test_case "all 54 fields reject a wrong type" `Quick
+        ; test_case "all 53 fields reject a wrong type" `Quick
             test_every_field_rejects_a_wrong_type
         ; test_case "nullability is exact" `Quick
             test_nullability_is_exact
         ; test_case "outside fields share one classification" `Quick
             test_every_outside_field_has_one_classification
+        ; test_case
+            "retired compaction failure authority requires reset"
+            `Quick
+            test_retired_compaction_failure_authority_requires_reset
         ; test_case "writer rejects non-finite values" `Quick
             test_current_writer_rejects_non_finite_values
         ] )

--- a/test/test_keeper_paused_work_cancellation_transaction.ml
+++ b/test/test_keeper_paused_work_cancellation_transaction.ml
@@ -7,7 +7,6 @@ module State = Keeper_event_queue_state
 module Transaction = Keeper_paused_work_cancellation_transaction
 module Disposition_receipt = Keeper_paused_work_disposition_receipt
 module Resume_transaction = Keeper_paused_work_resume_transaction
-module Heartbeat_testing = Keeper_heartbeat_loop.For_testing
 
 let require_ok label = function
   | Ok value -> value
@@ -97,16 +96,19 @@ let with_pending_lane ?registered ?latched_reason ~paused ~generation f =
     ~paused
     ~generation
     (fun config keeper_name source ->
-       let source_revision =
+       let source_incarnation =
          Persistence.load_state_result
            ~base_path:config.Workspace.base_path
            ~keeper_name
-         |> require_ok "load pending accepted source revision"
-         |> State.revision
+         |> require_ok "load pending accepted source incarnation"
+         |> State.select_when
+              ~ready:(Queue.stimulus_identity_equal source)
+         |> require_some "select pending accepted source"
+         |> fun selection -> selection.admitted_revision
        in
        let request : Transaction.pending_request =
          { source
-         ; source_revision
+         ; source_incarnation
          ; owner_nonce = generation
          ; operator_operation_id = "operator-pending-cancel-1"
          ; reason = "operator rejected exact pending paused work"
@@ -164,7 +166,7 @@ let test_pending_cancellation_commits_exact_remove () =
         | Registry_queue.Transition_applied _
         | Registry_queue.Transition_committed_followup_failed _ -> ()
         | Registry_queue.Transition_already_applied _ ->
-          Alcotest.fail "first pending transaction was already settled");
+          Alcotest.fail "first pending cancellation was already applied");
        let state =
          Persistence.load_state_result
            ~base_path:config.Workspace.base_path
@@ -201,6 +203,91 @@ let test_pending_cancellation_busy_has_zero_mutation () =
        in
        Alcotest.(check int)
          "admission busy retains pending source"
+         1
+         (Queue.length (State.pending state)))
+;;
+
+let test_unrelated_enqueue_preserves_pending_incarnation () =
+  with_pending_lane
+    ~registered:false
+    ~paused:true
+    ~generation:18
+    (fun config keeper_name request ->
+       let unrelated : Queue.stimulus =
+         { post_id = "unrelated-cancellation-source"
+         ; urgency = Queue.Low
+         ; arrived_at = 2.0
+         ; payload = Queue.Bootstrap
+         }
+       in
+       Persistence.update_result
+         ~base_path:config.Workspace.base_path
+         ~keeper_name
+         (fun pending -> Queue.enqueue pending unrelated)
+       |> require_ok "enqueue unrelated cancellation source";
+       let result =
+         Transaction.cancel_pending config ~keeper_name request
+         |> Result.map_error Transaction.error_to_string
+         |> require_ok "cancel selected source after unrelated enqueue"
+       in
+       (match result.transition with
+        | Registry_queue.Transition_applied _
+        | Registry_queue.Transition_committed_followup_failed _ -> ()
+        | Registry_queue.Transition_already_applied _ ->
+          Alcotest.fail "unrelated enqueue replayed pending cancellation");
+       let state =
+         Persistence.load_state_result
+           ~base_path:config.Workspace.base_path
+           ~keeper_name
+         |> require_ok "load cancellation result after unrelated enqueue"
+       in
+       Alcotest.(check int)
+         "only unrelated source remains"
+         1
+         (Queue.length (State.pending state));
+       Alcotest.(check bool)
+         "unrelated cancellation source is preserved"
+         true
+         (State.pending state
+          |> Queue.to_list
+          |> List.exists (Queue.stimulus_identity_equal unrelated)))
+;;
+
+let test_reinserted_source_rejects_old_pending_incarnation () =
+  with_pending_lane
+    ~registered:false
+    ~paused:true
+    ~generation:19
+    (fun config keeper_name request ->
+       let base_path = config.Workspace.base_path in
+       let old_selection : State.pending_selection =
+         { source = request.source
+         ; admitted_revision = request.source_incarnation
+         }
+       in
+       Persistence.ack_pending_result
+         ~base_path
+         ~keeper_name
+         ~selection:old_selection
+         ()
+       |> require_ok "remove old cancellation source incarnation";
+       Persistence.update_result ~base_path ~keeper_name (fun pending ->
+         Queue.enqueue pending request.source)
+       |> require_ok "reinsert cancellation source";
+       (match Transaction.cancel_pending config ~keeper_name request with
+        | Error
+            (Transaction.Failed
+               { cause = Transaction.Queue_commit_failed _; _ }) ->
+          ()
+        | Error error -> Alcotest.fail (Transaction.error_to_string error)
+        | Ok _ ->
+          Alcotest.fail "old cancellation incarnation removed the reinserted source");
+       let state =
+         Persistence.load_state_result ~base_path ~keeper_name
+         |> require_ok "load reinserted cancellation source"
+       in
+       Alcotest.(check int)
+         "reinserted cancellation source remains"
          1
          (Queue.length (State.pending state)))
 ;;
@@ -514,55 +601,6 @@ let test_resume_owner_rejects_transcript_reset_without_receipt () =
        | Error detail -> Alcotest.fail detail)
 ;;
 
-let test_transcript_corruption_pause_precedes_settlement () =
-  let stop = Atomic.make false in
-  let calls = ref [] in
-  let result =
-    Heartbeat_testing.commit_transcript_corruption
-      ~stop
-      ~persist_pause:(fun () ->
-        calls := "pause" :: !calls;
-        Ok `Persisted)
-      ~settle:(fun () ->
-        calls := "settle" :: !calls;
-        Ok ())
-      ()
-  in
-  Alcotest.(check bool) "corrupted fiber is stopped" true (Atomic.get stop);
-  Alcotest.(check (list string))
-    "durable pause commits before terminal settlement"
-    [ "pause"; "settle" ]
-    (List.rev !calls);
-  Alcotest.(check bool)
-    "both commits are reported"
-    true
-    (match result with
-     | Heartbeat_testing.Transcript_pause_and_settlement_persisted -> true
-     | Heartbeat_testing.Transcript_pause_persisted
-     | Heartbeat_testing.Transcript_pause_persistence_failed _
-     | Heartbeat_testing.Transcript_pause_settlement_failed _ ->
-       false)
-;;
-
-let test_unleased_transcript_corruption_only_persists_pause () =
-  let stop = Atomic.make false in
-  let result =
-    Heartbeat_testing.commit_transcript_corruption
-      ~stop
-      ~persist_pause:(fun () -> Ok `Persisted)
-      ()
-  in
-  Alcotest.(check bool)
-    "unleased corruption commits only durable pause"
-    true
-    (match result with
-     | Heartbeat_testing.Transcript_pause_persisted -> true
-     | Heartbeat_testing.Transcript_pause_and_settlement_persisted
-     | Heartbeat_testing.Transcript_pause_persistence_failed _
-     | Heartbeat_testing.Transcript_pause_settlement_failed _ ->
-       false)
-;;
-
 let () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -588,6 +626,14 @@ let () =
             `Quick
             test_pending_cancellation_busy_has_zero_mutation
         ; Alcotest.test_case
+            "unrelated enqueue preserves pending incarnation"
+            `Quick
+            test_unrelated_enqueue_preserves_pending_incarnation
+        ; Alcotest.test_case
+            "reinserted source rejects old pending incarnation"
+            `Quick
+            test_reinserted_source_rejects_old_pending_incarnation
+        ; Alcotest.test_case
             "Resume_owner commits receipt and preserves pending"
             `Quick
             test_resume_owner_commits_receipt_and_preserves_pending
@@ -611,14 +657,6 @@ let () =
             "Resume_owner rejects transcript reset without receipt"
             `Quick
             test_resume_owner_rejects_transcript_reset_without_receipt
-        ; Alcotest.test_case
-            "transcript pause precedes settlement"
-            `Quick
-            test_transcript_corruption_pause_precedes_settlement
-        ; Alcotest.test_case
-            "unleased transcript only persists pause"
-            `Quick
-            test_unleased_transcript_corruption_only_persists_pause
         ] )
     ]
 ;;

--- a/test/test_keeper_paused_work_operator.ml
+++ b/test/test_keeper_paused_work_operator.ml
@@ -73,7 +73,7 @@ let terminal_source () =
 
 let common operation fields =
   `Assoc
-    ([ "schema", `String "masc.keeper.paused-work.operator-request.v3"
+    ([ "schema", `String "masc.keeper.paused-work.operator-request.v4"
      ; "operation", `String operation
      ]
      @ fields)
@@ -112,10 +112,13 @@ let with_source_terminal_lane f =
        Persistence.update_result ~base_path ~keeper_name (fun pending ->
          Queue.enqueue pending source)
        |> require_ok "seed source-terminal event";
-       let source_revision =
+       let source_incarnation =
          Persistence.load_state_result ~base_path ~keeper_name
          |> require_ok "load source-terminal state"
-         |> State.revision
+         |> State.select_when
+              ~ready:(Queue.stimulus_identity_equal source)
+         |> require_some "select source-terminal event"
+         |> fun selection -> selection.admitted_revision
        in
        let source_receipt =
          State.source_terminal_receipt_of_stimulus source
@@ -123,7 +126,7 @@ let with_source_terminal_lane f =
        in
        let request : Keeper_paused_work_source_terminal_transaction.request =
          { source
-         ; source_revision
+         ; source_incarnation
          ; owner_nonce = meta.runtime.nonce
          ; source_receipt
          ; operator_operation_id = "operator-source-terminal-response"
@@ -174,7 +177,7 @@ let test_strict_request_codec () =
       "cancel_accepted"
       [ "source_state", `String "pending"
       ; "source", Queue.stimulus_to_yojson board_source
-      ; "source_revision", int64_json 11L
+      ; "source_incarnation", int64_json 11L
       ; "owner_nonce", `Int 7
       ; "operator_operation_id", `String "operator-cancel"
       ; "reason", `String "operator rejected retained work"
@@ -183,7 +186,10 @@ let test_strict_request_codec () =
   (match Operator.request_of_yojson cancel with
    | Ok (Operator.Cancel_pending request) ->
      Alcotest.(check bool) "cancel source exact" true (request.source = board_source);
-     Alcotest.(check int64) "cancel revision exact" 11L request.source_revision
+     Alcotest.(check int64)
+       "cancel incarnation exact"
+       11L
+       request.source_incarnation
   | Ok _ -> Alcotest.fail "pending cancellation decoded to the wrong operation"
   | Error detail -> Alcotest.fail detail);
   let cancel_with_obsolete_settled_at =
@@ -199,7 +205,7 @@ let test_strict_request_codec () =
     common
       "transfer_owner"
       [ "source", Queue.stimulus_to_yojson terminal_source
-      ; "source_revision", int64_json 12L
+      ; "source_incarnation", int64_json 12L
       ; "owner_nonce", `Int 7
       ; "target_generation", `Int 8
       ; "to_keeper", `String "successor"
@@ -228,7 +234,7 @@ let test_strict_request_codec () =
     common
       "ack_source_terminal"
       [ "source", Queue.stimulus_to_yojson terminal_source
-      ; "source_revision", int64_json 13L
+      ; "source_incarnation", int64_json 13L
       ; "owner_nonce", `Int 7
       ; "source_receipt_kind", `String "hitl_terminal"
       ; "operator_operation_id", `String "operator-source-terminal"
@@ -300,7 +306,7 @@ let test_source_terminal_outcome_is_ack_boundary () =
       (json |> member "receipt" |> member "operation" |> to_string);
     Alcotest.(check (list string))
       "durable source-terminal receipt has the exact hard-cut fields"
-      [ "source"; "source_receipt_kind"; "source_revision" ]
+      [ "source"; "source_incarnation"; "source_receipt_kind" ]
       (source_terminal_fields
        |> List.map fst
        |> List.sort String.compare))

--- a/test/test_keeper_paused_work_source_terminal_transaction.ml
+++ b/test/test_keeper_paused_work_source_terminal_transaction.ml
@@ -53,7 +53,7 @@ let receipt_path config ~keeper_name ~operator_operation_id =
     (Filename.concat
        (Filename.concat
           (Workspace.masc_root_dir config)
-          "paused-work-dispositions-v5")
+          "paused-work-dispositions-v6")
        ("keeper-" ^ sha256 keeper_name))
     ("operation-" ^ sha256 operator_operation_id ^ ".json")
 ;;
@@ -111,14 +111,17 @@ let with_source_terminal_lane f =
        Persistence.update_result ~base_path ~keeper_name (fun pending ->
          Queue.enqueue pending source)
        |> require_ok "seed source-terminal event";
-       let source_revision =
+       let source_incarnation =
          Persistence.load_state_result ~base_path ~keeper_name
-         |> require_ok "load source-terminal revision"
-         |> State.revision
+         |> require_ok "load source-terminal incarnation"
+         |> State.select_when
+              ~ready:(Queue.stimulus_identity_equal source)
+         |> require_some "select source-terminal event"
+         |> fun selection -> selection.admitted_revision
        in
        let request : Transaction.request =
          { source
-         ; source_revision
+         ; source_incarnation
          ; owner_nonce = meta.runtime.nonce
          ; source_receipt = State.Hitl_terminal resolution
          ; operator_operation_id = "operator-source-terminal-1"
@@ -164,7 +167,7 @@ let source_ack_transition_state (request : Transaction.request) state =
   let source_terminal : State.accepted_source_terminal =
     State.
       { source = request.source
-    ; source_revision = request.source_revision
+    ; source_incarnation = request.source_incarnation
     ; owner_nonce = request.owner_nonce
     ; operator_operation_id = request.operator_operation_id
     ; source_receipt = request.source_receipt
@@ -250,7 +253,7 @@ let test_source_ack_identity_survives_checkpoint_reload () =
   with_source_terminal_lane (fun _config _keeper_name _meta request ->
     let initial =
       State.empty
-      |> State.with_revision request.source_revision
+      |> State.with_revision request.source_incarnation
       |> State.with_pending (Queue.enqueue Queue.empty request.source)
     in
     let first, first_result = source_ack_transition_state request initial in
@@ -268,7 +271,9 @@ let test_source_ack_identity_survives_checkpoint_reload () =
       match request.source_receipt with
       | State.Hitl_terminal resolution ->
         { resolution with approval_id = "approval-terminal-2" }
-      | State.Fusion_terminal _ | State.Background_job_terminal _ ->
+      | State.Fusion_terminal _
+      | State.Background_job_terminal _
+      | State.Turn_attempt_terminal _ ->
         Alcotest.fail "fixture must carry a HITL terminal receipt"
     in
     let second_source : Queue.stimulus =
@@ -278,15 +283,21 @@ let test_source_ack_identity_survives_checkpoint_reload () =
       ; payload = Queue.Hitl_resolved second_resolution
       }
     in
+    let second_state = State.with_pending (Queue.enqueue Queue.empty second_source) reloaded in
+    let second_selection =
+      State.select_when
+        ~ready:(Queue.stimulus_identity_equal second_source)
+        second_state
+      |> require_some "select second source-terminal event"
+    in
     let second_request : Transaction.request =
       { source = second_source
-      ; source_revision = State.revision reloaded
+      ; source_incarnation = second_selection.admitted_revision
       ; owner_nonce = request.owner_nonce
       ; source_receipt = State.Hitl_terminal second_resolution
       ; operator_operation_id = "operator-source-terminal-2"
       }
     in
-    let second_state = State.with_pending (Queue.enqueue Queue.empty second_source) reloaded in
     let _, second_result = source_ack_transition_state second_request second_state in
     let second_receipt =
       match second_result with
@@ -379,6 +390,86 @@ let test_exact_terminal_receipt_acks_pending () =
       (Queue.length (State.pending replayed_state)))
 ;;
 
+let test_unrelated_enqueue_preserves_source_terminal_incarnation () =
+  with_source_terminal_lane (fun config keeper_name _meta request ->
+    let unrelated : Queue.stimulus =
+      { post_id = "unrelated-source-terminal"
+      ; urgency = Queue.Low
+      ; arrived_at = 2.0
+      ; payload = Queue.Bootstrap
+      }
+    in
+    Persistence.update_result
+      ~base_path:config.Workspace.base_path
+      ~keeper_name
+      (fun pending -> Queue.enqueue pending unrelated)
+    |> require_ok "enqueue unrelated source-terminal event";
+    let result =
+      Transaction.ack_pending config ~keeper_name request
+      |> Result.map_error Transaction.error_to_string
+      |> require_ok "ACK source terminal after unrelated enqueue"
+    in
+    check_applied result.projection;
+    let state =
+      Persistence.load_state_result
+        ~base_path:config.Workspace.base_path
+        ~keeper_name
+      |> require_ok "load source-terminal result after unrelated enqueue"
+    in
+    Alcotest.(check int)
+      "only unrelated source-terminal event remains"
+      1
+      (Queue.length (State.pending state));
+    Alcotest.(check bool)
+      "unrelated source-terminal event is preserved"
+      true
+      (State.pending state
+       |> Queue.to_list
+       |> List.exists (Queue.stimulus_identity_equal unrelated)))
+;;
+
+let test_reinserted_source_rejects_old_terminal_incarnation () =
+  with_source_terminal_lane (fun config keeper_name _meta request ->
+    let base_path = config.Workspace.base_path in
+    let old_selection : State.pending_selection =
+      { source = request.source
+      ; admitted_revision = request.source_incarnation
+      }
+    in
+    Persistence.ack_pending_result
+      ~base_path
+      ~keeper_name
+      ~selection:old_selection
+      ()
+    |> require_ok "remove old source-terminal incarnation";
+    Persistence.update_result ~base_path ~keeper_name (fun pending ->
+      Queue.enqueue pending request.source)
+    |> require_ok "reinsert source-terminal event";
+    (match Transaction.ack_pending config ~keeper_name request with
+     | Error { cause = Transaction.Source_queue_validation_failed _; _ } -> ()
+     | Error error -> Alcotest.fail (Transaction.error_to_string error)
+     | Ok _ ->
+       Alcotest.fail "old source-terminal incarnation ACKed the reinserted source");
+    (match
+       Receipt.load
+         config
+         ~keeper_name
+         ~operator_operation_id:request.operator_operation_id
+     with
+     | Ok None -> ()
+     | Ok (Some _) ->
+       Alcotest.fail "old source-terminal incarnation persisted a receipt"
+     | Error detail -> Alcotest.fail detail);
+    let state =
+      Persistence.load_state_result ~base_path ~keeper_name
+      |> require_ok "load reinserted source-terminal event"
+    in
+    Alcotest.(check int)
+      "reinserted source-terminal event remains"
+      1
+      (Queue.length (State.pending state)))
+;;
+
 let test_terminal_ack_replays_after_projection_and_snapshot_reload () =
   with_source_terminal_lane (fun config keeper_name _meta request ->
     let first =
@@ -418,11 +509,11 @@ let test_terminal_ack_replays_after_projection_and_snapshot_reload () =
         (Filename.concat
            (Common.keepers_runtime_dir_of_base ~base_path:config.Workspace.base_path)
            keeper_name)
-        "event-queue-transitions-v3.jsonl"
+        "event-queue-transitions-v4.jsonl"
     in
     let residual_wal_row =
       `Assoc
-        [ "schema", `String "masc.keeper_event_queue.transition.v3"
+        [ "schema", `String "masc.keeper_event_queue.transition.v4"
         ; "base_path", `String config.Workspace.base_path
         ; "keeper_name", `String keeper_name
         ; "outbox_entry", State.outbox_entry_to_yojson outbox_entry
@@ -471,7 +562,9 @@ let test_projected_wal_recovery_allows_next_source_ack () =
       match request.source_receipt with
       | State.Hitl_terminal resolution ->
         { resolution with approval_id = "approval-terminal-after-projection" }
-      | State.Fusion_terminal _ | State.Background_job_terminal _ ->
+      | State.Fusion_terminal _
+      | State.Background_job_terminal _
+      | State.Turn_attempt_terminal _ ->
         Alcotest.fail "fixture must carry a HITL terminal receipt"
     in
     let second_source : Queue.stimulus =
@@ -486,16 +579,7 @@ let test_projected_wal_recovery_allows_next_source_ack () =
       ~keeper_name
       (fun pending -> Queue.enqueue pending second_source)
     |> require_ok "seed second source-terminal event";
-    let first_request =
-      { request with
-        source_revision =
-          (Persistence.load_state_result
-             ~base_path:config.Workspace.base_path
-             ~keeper_name
-           |> require_ok "load first source-terminal revision"
-           |> State.revision)
-      }
-    in
+    let first_request = request in
     let first =
       Transaction.ack_pending config ~keeper_name first_request
       |> Result.map_error Transaction.error_to_string
@@ -523,11 +607,11 @@ let test_projected_wal_recovery_allows_next_source_ack () =
         (Filename.concat
            (Common.keepers_runtime_dir_of_base ~base_path:config.Workspace.base_path)
            keeper_name)
-        "event-queue-transitions-v3.jsonl"
+        "event-queue-transitions-v4.jsonl"
     in
     let residual_wal_row =
       `Assoc
-        [ "schema", `String "masc.keeper_event_queue.transition.v3"
+        [ "schema", `String "masc.keeper_event_queue.transition.v4"
         ; "base_path", `String config.Workspace.base_path
         ; "keeper_name", `String keeper_name
         ; "outbox_entry", State.outbox_entry_to_yojson first_outbox
@@ -544,7 +628,12 @@ let test_projected_wal_recovery_allows_next_source_ack () =
     Alcotest.(check string) "projected WAL is retired during recovery" "" residual_wal;
     let second_request : Transaction.request =
       { source = second_source
-      ; source_revision = State.revision recovered
+      ; source_incarnation =
+          (State.select_when
+             ~ready:(Queue.stimulus_identity_equal second_source)
+             recovered
+           |> require_some "select second recovered source")
+            .admitted_revision
       ; owner_nonce = first_request.owner_nonce
       ; source_receipt = State.Hitl_terminal second_resolution
       ; operator_operation_id = "operator-source-terminal-after-projection"
@@ -630,7 +719,7 @@ let test_retired_v3_receipt_file_is_rejected () =
   with_source_terminal_lane (fun config keeper_name meta request ->
     let operation : Receipt.source_terminal_operation =
       { source = request.source
-      ; source_revision = request.source_revision
+      ; source_incarnation = request.source_incarnation
       ; source_receipt = request.source_receipt
       }
     in
@@ -768,6 +857,14 @@ let () =
             "exact receipt ACKs pending"
             `Quick
             test_exact_terminal_receipt_acks_pending
+        ; Alcotest.test_case
+            "unrelated enqueue preserves source-terminal incarnation"
+            `Quick
+            test_unrelated_enqueue_preserves_source_terminal_incarnation
+        ; Alcotest.test_case
+            "reinserted source rejects old terminal incarnation"
+            `Quick
+            test_reinserted_source_rejects_old_terminal_incarnation
         ; Alcotest.test_case
             "replays after outbox projection and snapshot reload"
             `Quick

--- a/test/test_keeper_paused_work_transfer_transaction.ml
+++ b/test/test_keeper_paused_work_transfer_transaction.ml
@@ -48,7 +48,7 @@ let receipt_path config ~keeper_name ~operator_operation_id =
     (Filename.concat
        (Filename.concat
           (Workspace.masc_root_dir config)
-          "paused-work-dispositions-v5")
+          "paused-work-dispositions-v6")
        ("keeper-" ^ sha256 keeper_name))
     ("operation-" ^ sha256 operator_operation_id ^ ".json")
 ;;
@@ -134,14 +134,17 @@ let with_transfer_lane f =
        Persistence.update_result ~base_path ~keeper_name:from_keeper (fun pending ->
          Queue.enqueue pending source)
        |> require_ok "seed transfer source";
-       let source_revision =
+       let source_incarnation =
          Persistence.load_state_result ~base_path ~keeper_name:from_keeper
-         |> require_ok "load transfer source revision"
-         |> State.revision
+         |> require_ok "load transfer source incarnation"
+         |> State.select_when
+              ~ready:(Queue.stimulus_identity_equal source)
+         |> require_some "select transfer source"
+         |> fun selection -> selection.admitted_revision
        in
        let request : Transaction.request =
          { source
-         ; source_revision
+         ; source_incarnation
          ; owner_nonce = source_meta.runtime.nonce
          ; target_generation = target_meta.runtime.nonce
          ; continuation_binding = Receipt.Routed channel
@@ -168,7 +171,7 @@ let assert_converged config ~from_keeper ~to_keeper source =
     Persistence.load_state_result
       ~base_path:config.Workspace.base_path
       ~keeper_name:from_keeper
-    |> require_ok "load settled source lane"
+    |> require_ok "load transferred source lane"
   in
   Alcotest.(check int)
     "source pending removed"
@@ -230,7 +233,7 @@ let test_retired_v2_receipt_file_is_rejected () =
     ; target_trace_id = target_meta.runtime.trace_id
     ; target_generation = request.target_generation
     ; source = request.source
-    ; source_revision = request.source_revision
+    ; source_incarnation = request.source_incarnation
     ; continuation_binding = request.continuation_binding
     }
   in
@@ -365,7 +368,7 @@ let test_replay_after_target_consumption_has_no_second_effect () =
        has consumed the source, replaying the transfer must not enqueue it
        again. *)
     let selection =
-      Persistence.peek_when_result
+      Persistence.select_when_result
         ~base_path
         ~keeper_name:to_keeper
         ~ready:(fun _ -> true)
@@ -404,6 +407,88 @@ let test_replay_after_target_consumption_has_no_second_effect () =
       (List.length (State.accepted_transfer_projections target)))
 ;;
 
+let test_later_identical_source_transfers_as_new_incarnation () =
+  with_transfer_lane
+  @@ fun config from_keeper to_keeper _source_meta _target_meta request ->
+  let base_path = config.Workspace.base_path in
+  let first =
+    Transaction.transfer_pending config ~from_keeper ~to_keeper request
+    |> Result.map_error Transaction.error_to_string
+    |> require_ok "commit first identical-source transfer"
+  in
+  check_applied ~expected_target:Transaction.Enqueued first.projection;
+  Persistence.project_transition_outbox_result
+    ~append_before_retire:(fun _entry -> Ok ())
+    ~base_path
+    ~keeper_name:from_keeper
+  |> require_ok "project first source transfer";
+  let target_selection =
+    Persistence.select_when_result
+      ~base_path
+      ~keeper_name:to_keeper
+      ~ready:(Queue.stimulus_identity_equal request.source)
+    |> require_ok "select first target incarnation"
+    |> require_some "first target incarnation"
+  in
+  Persistence.ack_pending_result
+    ~base_path
+    ~keeper_name:to_keeper
+    ~selection:target_selection
+    ()
+  |> require_ok "consume first target incarnation";
+  Persistence.update_result ~base_path ~keeper_name:from_keeper (fun pending ->
+    Queue.enqueue pending request.source)
+  |> require_ok "reinsert identical source";
+  let source_selection =
+    Persistence.select_when_result
+      ~base_path
+      ~keeper_name:from_keeper
+      ~ready:(Queue.stimulus_identity_equal request.source)
+    |> require_ok "select later source incarnation"
+    |> require_some "later source incarnation"
+  in
+  let later_request =
+    { request with
+      source_incarnation = source_selection.admitted_revision
+    ; operator_operation_id = "operator-transfer-later-incarnation"
+    }
+  in
+  let later =
+    Transaction.transfer_pending
+      config
+      ~from_keeper
+      ~to_keeper
+      later_request
+    |> Result.map_error Transaction.error_to_string
+    |> require_ok "commit later identical-source transfer"
+  in
+  (match later.commit_status with
+   | Transaction.Committed -> ()
+   | Transaction.Already_committed ->
+     Alcotest.fail "later source incarnation replayed the first transfer");
+  check_applied ~expected_target:Transaction.Enqueued later.projection;
+  let source =
+    Persistence.load_state_result ~base_path ~keeper_name:from_keeper
+    |> require_ok "load source after later transfer"
+  in
+  let target =
+    Persistence.load_state_result ~base_path ~keeper_name:to_keeper
+    |> require_ok "load target after later transfer"
+  in
+  Alcotest.(check int)
+    "later transfer removes its source incarnation"
+    0
+    (Queue.length (State.pending source));
+  Alcotest.(check int)
+    "later transfer enqueues the new target incarnation"
+    1
+    (Queue.length (State.pending target));
+  Alcotest.(check int)
+    "both transfer operations remain replayable"
+    2
+    (List.length (State.accepted_transfer_projections target))
+;;
+
 let test_replay_after_source_ack_projects_target () =
   with_transfer_lane (fun config from_keeper to_keeper source_meta target_meta request ->
     let transfer : Receipt.transfer_owner =
@@ -412,7 +497,7 @@ let test_replay_after_source_ack_projects_target () =
       ; target_trace_id = target_meta.runtime.trace_id
       ; target_generation = request.target_generation
       ; source = request.source
-      ; source_revision = request.source_revision
+      ; source_incarnation = request.source_incarnation
       ; continuation_binding = request.continuation_binding
       }
     in
@@ -434,7 +519,7 @@ let test_replay_after_source_ack_projects_target () =
      | Ok (Error detail) | Error detail -> Alcotest.fail detail);
     let causal : Keeper_registry_event_queue.accepted_transfer =
       { source = request.source
-      ; source_revision = request.source_revision
+      ; source_incarnation = request.source_incarnation
       ; owner_nonce = request.owner_nonce
       ; operator_operation_id = request.operator_operation_id
       ; from_keeper
@@ -462,7 +547,7 @@ let test_replay_after_source_ack_projects_target () =
     assert_converged config ~from_keeper ~to_keeper request.source)
 ;;
 
-let test_stale_source_revision_has_no_receipt_or_target_effect () =
+let test_unrelated_enqueue_preserves_source_incarnation () =
   with_transfer_lane (fun config from_keeper to_keeper _source_meta _target_meta request ->
     let unrelated : Queue.stimulus =
       { post_id = "unrelated"
@@ -475,11 +560,52 @@ let test_stale_source_revision_has_no_receipt_or_target_effect () =
       ~base_path:config.Workspace.base_path
       ~keeper_name:from_keeper
       (fun pending -> Queue.enqueue pending unrelated)
-    |> require_ok "advance source revision";
+    |> require_ok "enqueue unrelated source";
+    let result =
+      Transaction.transfer_pending config ~from_keeper ~to_keeper request
+      |> Result.map_error Transaction.error_to_string
+      |> require_ok "transfer after unrelated enqueue"
+    in
+    check_applied ~expected_target:Transaction.Enqueued result.projection;
+    let source =
+      Persistence.load_state_result
+        ~base_path:config.Workspace.base_path
+        ~keeper_name:from_keeper
+      |> require_ok "load source after unrelated enqueue transfer"
+    in
+    Alcotest.(check int)
+      "unrelated source remains pending"
+      1
+      (Queue.length (State.pending source));
+    Alcotest.(check bool)
+      "unrelated source is preserved"
+      true
+      (State.pending source
+       |> Queue.to_list
+       |> List.exists (Queue.stimulus_identity_equal unrelated)))
+;;
+
+let test_stale_source_incarnation_has_no_receipt_or_target_effect () =
+  with_transfer_lane (fun config from_keeper to_keeper _source_meta _target_meta request ->
+    let base_path = config.Workspace.base_path in
+    let old_selection : State.pending_selection =
+      { source = request.source
+      ; admitted_revision = request.source_incarnation
+      }
+    in
+    Persistence.ack_pending_result
+      ~base_path
+      ~keeper_name:from_keeper
+      ~selection:old_selection
+      ()
+    |> require_ok "remove old source incarnation";
+    Persistence.update_result ~base_path ~keeper_name:from_keeper (fun pending ->
+      Queue.enqueue pending request.source)
+    |> require_ok "reinsert exact source as a new incarnation";
     (match Transaction.transfer_pending config ~from_keeper ~to_keeper request with
      | Error { cause = Transaction.Source_queue_validation_failed _; _ } -> ()
      | Error error -> Alcotest.fail (Transaction.error_to_string error)
-     | Ok _ -> Alcotest.fail "stale source revision committed transfer");
+     | Ok _ -> Alcotest.fail "stale source incarnation committed transfer");
     (match
        Receipt.load
          config
@@ -491,7 +617,7 @@ let test_stale_source_revision_has_no_receipt_or_target_effect () =
      | Error detail -> Alcotest.fail detail);
     let target =
       Persistence.load_state_result
-        ~base_path:config.Workspace.base_path
+        ~base_path
         ~keeper_name:to_keeper
       |> require_ok "load untouched transfer target"
     in
@@ -519,9 +645,21 @@ let () =
             `Quick
             test_transfer_busy_has_zero_mutation
         ; Alcotest.test_case
-            "stale source revision has no effect"
+            "unrelated enqueue preserves source incarnation"
             `Quick
-            test_stale_source_revision_has_no_receipt_or_target_effect
+            test_unrelated_enqueue_preserves_source_incarnation
+        ; Alcotest.test_case
+            "stale source incarnation has no effect"
+            `Quick
+            test_stale_source_incarnation_has_no_receipt_or_target_effect
+        ; Alcotest.test_case
+            "same transfer replay after target consumption has no effect"
+            `Quick
+            test_replay_after_target_consumption_has_no_second_effect
+        ; Alcotest.test_case
+            "later identical source transfers as a new incarnation"
+            `Quick
+            test_later_identical_source_transfers_as_new_incarnation
         ; Alcotest.test_case
             "replay after source ACK projects target"
             `Quick

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -159,7 +159,7 @@ let test_final_admission_busy_requeues_only_pre_dispatch_no_compaction () =
           (exact_terminal Keeper_compaction_outcome.Exact_execution_failed)))
 ;;
 
-let test_exact_no_compaction_acknowledges_without_persistence_facade () =
+let test_no_compaction_terminalizes_the_selected_source () =
   let disposition =
     Masc.Keeper_unified_turn.source_disposition_after_no_compaction_reason
   in
@@ -167,16 +167,13 @@ let test_exact_no_compaction_acknowledges_without_persistence_facade () =
     (fun reason ->
        match disposition reason with
        | Masc.Keeper_unified_turn.Acknowledge_after_in_turn_handling -> ()
-       | _ -> fail "exact terminal no-compaction did not acknowledge its source")
+       | _ -> fail "terminal no-compaction did not acknowledge its source")
     [ Keeper_compaction_outcome.Exact_lane_unconfigured
     ; Keeper_compaction_outcome.Exact_execution_terminal
         (exact_terminal Keeper_compaction_outcome.Exact_execution_failed)
-    ];
-  match disposition Keeper_compaction_outcome.No_eligible_history with
-  | Masc.Keeper_unified_turn.Follow_failure_route_after_no_compaction
-      { reason = Keeper_compaction_outcome.No_eligible_history } ->
-    ()
-  | _ -> fail "pre-dispatch no-compaction lost its ordinary failure route"
+    ; Keeper_compaction_outcome.No_eligible_history
+    ; Keeper_compaction_outcome.Invalid_structural_source
+    ]
 ;;
 
 let make_meta
@@ -704,6 +701,18 @@ let test_prepare_commit_source_cas () =
                (Post_turn.compaction_recovery_error_to_string
                   (Post_turn.No_compaction no_compaction)))
     in
+    check int
+      "checkpoint commit returns its authoritative count"
+      1
+      recovery.commit_count;
+    (match
+       Masc.Keeper_checkpoint_store.compaction_commit_count_of_context
+         recovery.checkpoint.context
+     with
+     | Ok count ->
+       check int "committed checkpoint carries the same count" 1 count
+     | Error detail ->
+       failf "committed checkpoint count is invalid: %s" detail);
     check bool
       "history cancellation remains typed after install"
       true
@@ -744,7 +753,25 @@ let test_prepare_commit_source_cas () =
          "stale prepared value failed with the wrong error: %s"
          (Post_turn.compaction_recovery_error_to_string error)
      | Post_turn.Committed _ ->
-       fail "stale prepared value committed past the source CAS"))
+       fail "stale prepared value committed past the source CAS");
+    (match
+       Masc.Keeper_checkpoint_store.load_oas
+         ~session_dir:session.session_dir
+         ~session_id:session.session_id
+     with
+     | Error _ -> fail "canonical checkpoint disappeared after stale CAS"
+     | Ok checkpoint ->
+       (match
+          Masc.Keeper_checkpoint_store.compaction_commit_count_of_context
+            checkpoint.context
+        with
+        | Ok count ->
+          check int
+            "stale CAS did not advance canonical commit count"
+            1
+            count
+        | Error detail ->
+          failf "canonical checkpoint count is invalid: %s" detail)))
 ;;
 
 let test_post_install_cancellation_returns_committed_failure () =
@@ -971,272 +998,67 @@ let test_post_dispatch_non_reducing_output_is_terminal () =
         (summarize_response (String.make 20_000 'x')))
 ;;
 
-(* RFC-0351 S0 / #25461: once the persisted failure streak suspends
-   compaction retries, a reactive prepare must be refused before any
-   checkpoint I/O — each new stimulus used to pay one full prepare
-   (checkpoint load + summarizer LLM call) before its escalation completed.
-   The fixture base_dir holds no checkpoint, so any prepare that passes the
-   gate deterministically fails with [Checkpoint_ref_load_failed Ref_not_found];
-   returning [Retry_suspended] instead proves the refusal fired first. *)
-let test_suspended_streak_refuses_reactive_prepare () =
+let test_reactive_prepare_has_no_retry_gate () =
   Eio_main.run @@ fun _env ->
-  let meta_with_streak streak =
+  let meta =
     match
       Masc_test_deps.meta_of_json_fixture
         (`Assoc
-          [ "name", `String "prepare-admission"
-          ; "trace_id", `String "trace-prepare-admission"
-          ; "compaction_consecutive_failures", `Int streak
+          [ "name", `String "prepare-without-retry-gate"
+          ; "trace_id", `String "trace-prepare-without-retry-gate"
           ])
     with
     | Ok meta -> meta
-    | Error detail -> failf "prepare-admission meta fixture: %s" detail
+    | Error detail -> failf "prepare fixture: %s" detail
   in
   let base_dir =
     Filename.concat
       (Filename.get_temp_dir_name ())
-      (Printf.sprintf "masc-prepare-admission-%d" (Unix.getpid ()))
+      (Printf.sprintf "masc-prepare-without-retry-gate-%d" (Unix.getpid ()))
   in
-  let prepare ~streak ~trigger =
-    Post_turn.prepare_compaction
-      ~base_path:base_dir
-      ~base_dir
-      ~meta:(meta_with_streak streak)
-      ~trigger
-      ()
-  in
-  let suspended = meta_with_streak 3 in
-  check bool
-    "fixture streak reaches the suspension threshold"
-    true
-    (Masc.Keeper_meta_contract.compaction_retry_suspended
-       suspended.runtime.compaction_rt);
-  (match
-     prepare
-       ~streak:3
-       ~trigger:(Compaction_trigger.Provider_overflow { limit_tokens = None })
-   with
-   | Error (Post_turn.Retry_suspended { consecutive_failures }) ->
-     check int "refusal reports the persisted streak" 3 consecutive_failures
-   | Error error ->
-     failf
-       "suspended reactive prepare reached I/O instead of the admission gate: \
-        %s"
-       (Post_turn.compaction_recovery_error_to_string error)
-   | Ok _ -> fail "suspended reactive prepare produced a prepared compaction");
-  (match prepare ~streak:3 ~trigger:Compaction_trigger.Manual with
-   | Error
-       (Post_turn.Checkpoint_ref_load_failed Masc.Keeper_checkpoint_store.Ref_not_found)
-     ->
-     (* Reached the checkpoint load: the operator lever bypasses the gate. *)
-     ()
-   | Error error ->
-     failf
-       "suspended manual prepare did not reach the checkpoint load: %s"
-       (Post_turn.compaction_recovery_error_to_string error)
-   | Ok _ -> fail "manual prepare on an empty store produced a compaction");
-  (match
-     prepare
-       ~streak:2
-       ~trigger:(Compaction_trigger.Provider_overflow { limit_tokens = None })
-   with
-   | Error
-       (Post_turn.Checkpoint_ref_load_failed Masc.Keeper_checkpoint_store.Ref_not_found)
-     ->
-     (* Below the threshold the reactive path is admitted unchanged. *)
-     ()
-   | Error error ->
-     failf
-       "below-threshold reactive prepare did not reach the checkpoint load: %s"
-       (Post_turn.compaction_recovery_error_to_string error)
-   | Ok _ -> fail "reactive prepare on an empty store produced a compaction");
-  (* The byte axis follows the same gate as the token axis, not the operator lever.
-     Both are raised by the turn path itself, so a suspended keeper must refuse both —
-     the compiler forced that decision when the variant was added (masc#25739) but
-     nothing pinned the answer, and the two plausible wrong answers are opposites:
-     treating it like Manual would let a failing keeper re-enter compaction every turn,
-     while refusing it below the threshold would deny a reduction the token axis is
-     granted. *)
-  let byte_over_capacity =
-    Compaction_trigger.Request_body_over_capacity
-      { actual_bytes = 2_000_000; limit_bytes = 1_048_576 }
-  in
-  (match prepare ~streak:3 ~trigger:byte_over_capacity with
-   | Error (Post_turn.Retry_suspended { consecutive_failures }) ->
-     check int "suspended byte-axis refusal reports the streak" 3 consecutive_failures
-   | Error error ->
-     failf
-       "suspended byte-axis prepare reached I/O instead of the admission gate: %s"
-       (Post_turn.compaction_recovery_error_to_string error)
-   | Ok _ -> fail "suspended byte-axis prepare produced a prepared compaction");
-  (match prepare ~streak:2 ~trigger:byte_over_capacity with
-   | Error
-       (Post_turn.Checkpoint_ref_load_failed Masc.Keeper_checkpoint_store.Ref_not_found)
-     ->
-     (* Below the threshold the byte axis is admitted exactly as the token axis is. *)
-     ()
-   | Error error ->
-     failf
-       "below-threshold byte-axis prepare did not reach the checkpoint load: %s"
-       (Post_turn.compaction_recovery_error_to_string error)
-   | Ok _ -> fail "byte-axis prepare on an empty store produced a compaction");
   List.iter
-    (fun (reason, trigger) ->
-       (match prepare ~streak:3 ~trigger with
-        | Error (Post_turn.Retry_suspended { consecutive_failures }) ->
-          check
-            int
-            ("suspended serving-axis " ^ reason ^ " reports the streak")
-            3
-            consecutive_failures
-        | Error error ->
-          failf
-            "suspended serving-axis %s reached I/O instead of the admission gate: %s"
-            reason
-            (Post_turn.compaction_recovery_error_to_string error)
-        | Ok _ ->
-          failf "suspended serving-axis %s produced a prepared compaction" reason);
-       match prepare ~streak:2 ~trigger with
+    (fun (label, trigger) ->
+       match
+         Post_turn.prepare_compaction
+           ~base_path:base_dir
+           ~base_dir
+           ~meta
+           ~trigger
+           ()
+       with
        | Error
            (Post_turn.Checkpoint_ref_load_failed
               Masc.Keeper_checkpoint_store.Ref_not_found) ->
          ()
        | Error error ->
          failf
-           "below-threshold serving-axis %s did not reach the checkpoint load: %s"
-           reason
+           "%s did not reach the checkpoint source: %s"
+           label
            (Post_turn.compaction_recovery_error_to_string error)
-       | Ok _ ->
-         failf
-           "serving-axis %s prepare on an empty store produced a compaction"
-           reason)
-    [ ( "boundary_unknown"
+       | Ok _ -> failf "%s unexpectedly prepared from an empty store" label)
+    [ ( "provider overflow"
+      , Compaction_trigger.Provider_overflow { limit_tokens = None } )
+    ; ( "request body capacity"
+      , Compaction_trigger.Request_body_over_capacity
+          { actual_bytes = 2_000_000; limit_bytes = 1_048_576 } )
+    ; ( "provider body refusal"
+      , Compaction_trigger.Request_body_refused_by_provider { status = 413 } )
+    ; ( "serving boundary unknown"
       , Compaction_trigger.Serving_input_capacity
           (Compaction_trigger.Boundary_unknown
              { input_tokens = 524_299
              ; accepted_through = 524_298
              ; rejected_from = Some 524_300
              }) )
-    ; ( "input_rejected"
+    ; ( "serving input rejected"
       , Compaction_trigger.Serving_input_capacity
           (Compaction_trigger.Input_rejected
              { input_tokens = 524_300
              ; accepted_through = 524_298
              ; rejected_from = 524_299
              }) )
+    ; "manual", Compaction_trigger.Manual
     ]
-;;
-
-(* Step 0 characterization — the compaction suspension gate is self-feeding.
-
-   [test_suspended_streak_refuses_reactive_prepare] above pins the first hop: at
-   [Keeper_meta_contract.compaction_retry_escalation_threshold] the reactive
-   prepare is refused before any I/O. This test pins the two hops that close the
-   loop — the refusal was recorded as a compaction failure, and that outcome
-   advanced the very counter the gate reads.
-
-   Live evidence for the loop: keeper [kidsnote] reached
-   compaction_consecutive_failures=907 against a threshold of 3
-   (.masc/logs/system_log_2026-07-29.jsonl), so roughly 99.7% of that counter's
-   value came from refusals that never attempted a compaction. While the counter
-   is inflated this way, no statistic can say what actually drove the keeper to
-   the threshold.
-
-   The gate, the threshold, and the LLM-call bound it exists for are unchanged;
-   only the self-feeding edge is cut. The second half of this test pins that a
-   real compaction failure still advances the streak, so the ceiling that
-   #25461 added keeps working. *)
-let test_refusal_records_no_compaction_failure () =
-  Eio_main.run @@ fun _env ->
-  let meta =
-    match
-      Masc_test_deps.meta_of_json_fixture
-        (`Assoc
-          [ "name", `String "suspension-outcome"
-          ; "trace_id", `String "trace-suspension-outcome"
-          ; "compaction_consecutive_failures", `Int 3
-          ])
-    with
-    | Ok meta -> meta
-    | Error detail -> failf "suspension-outcome meta fixture: %s" detail
-  in
-  check
-    bool
-    "fixture sits at the suspension threshold"
-    true
-    (Masc.Keeper_meta_contract.compaction_retry_suspended
-       meta.runtime.compaction_rt);
-  (* A refused prepare attempted no compaction, so it records no outcome. *)
-  let turn_failure_with source_disposition : Masc.Keeper_unified_turn.turn_failure =
-    { error = Agent_sdk.Error.Internal "suspended reactive prepare"
-    ; runtime_id = "suspension-characterization"
-    ; route =
-        Keeper_runtime_failure_route.Retry_after_observed
-          { retry_class = Keeper_runtime_failure_route.Rate_limited
-          ; retry_after = None
-          }
-    ; source_disposition
-    ; deferred_runtime_lane = None
-    }
-  in
-  let outcome_of source_disposition =
-    Masc.Keeper_heartbeat_loop.compaction_outcome_of_cycle_outcome
-      (Some (Cycle.Failed { meta; failure = turn_failure_with source_disposition }))
-  in
-  check
-    bool
-    "a refusal that attempted no compaction records no outcome"
-    true
-    (outcome_of
-       (Masc.Keeper_unified_turn.Requeue_after_context_compaction
-          (Masc.Keeper_unified_turn.Compaction_refused_without_attempt
-             { consecutive_failures = 3 }))
-     = None);
-  (* The ceiling #25461 added still works: a compaction that ran and made no
-     durable progress still advances the streak. *)
-  check
-    bool
-    "an attempted compaction that made no progress records a failure"
-    true
-    (outcome_of
-       (Masc.Keeper_unified_turn.Requeue_after_context_compaction
-          (Masc.Keeper_unified_turn.Compaction_attempt_failed
-             { reason = "checkpoint candidate rejected" }))
-     = Some `Failed);
-  (* Persisting that outcome advances the counter the gate reads. *)
-  let base =
-    Filename.concat
-      (Filename.get_temp_dir_name ())
-      (Printf.sprintf "masc-suspension-outcome-%d" (Unix.getpid ()))
-  in
-  let config = Masc.Workspace.default_config base in
-  (match Masc.Keeper_meta_store.write_meta config meta with
-   | Ok () -> ()
-   | Error detail -> failf "durable meta write: %s" detail);
-  (match
-     Masc.Keeper_meta_store.persist_compaction_outcome
-       config
-       ~keeper_name:meta.name
-       ~outcome:`Failed
-   with
-   | Ok `Persisted -> ()
-   | Ok `No_durable_meta -> fail "outcome found no durable meta to update"
-   | Error detail -> failf "outcome persistence: %s" detail);
-  match Masc.Keeper_meta_store.read_meta config meta.name with
-  | Error detail -> failf "durable meta read-back: %s" detail
-  | Ok None -> fail "durable meta vanished after outcome persistence"
-  | Ok (Some updated_meta) ->
-    check
-      int
-      "an attempted-and-failed compaction advances the streak"
-      4
-      updated_meta.runtime.compaction_rt.consecutive_failures;
-    check
-      bool
-      "and that is what keeps the keeper suspended"
-      true
-      (Masc.Keeper_meta_contract.compaction_retry_suspended
-         updated_meta.runtime.compaction_rt)
 ;;
 
 let () =
@@ -1248,9 +1070,9 @@ let () =
         "final-admission Busy distinguishes pre-dispatch from exact terminal"
         `Quick test_final_admission_busy_requeues_only_pre_dispatch_no_compaction;
       test_case
-        "exact no-compaction acknowledges without persistence facade"
+        "no-compaction terminalizes the selected source"
         `Quick
-        test_exact_no_compaction_acknowledges_without_persistence_facade;
+        test_no_compaction_terminalizes_the_selected_source;
       test_case "regular post-turn does not auto-compact"
         `Quick test_regular_post_turn_does_not_auto_compact;
       test_case
@@ -1269,10 +1091,8 @@ let () =
         `Quick test_invalid_structural_evidence_after_dispatch_is_terminal;
       test_case "non-reducing output is terminal"
         `Quick test_post_dispatch_non_reducing_output_is_terminal;
-      test_case "suspended streak refuses reactive prepare"
-        `Quick test_suspended_streak_refuses_reactive_prepare;
-      test_case "refusal records no compaction failure"
-        `Quick test_refusal_records_no_compaction_failure;
+      test_case "reactive prepare has no retry gate"
+        `Quick test_reactive_prepare_has_no_retry_gate;
       test_case "missing exact lane is source-bound no-compaction"
         `Quick test_missing_exact_lane_is_source_bound_no_compaction;
     ];

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -107,7 +107,7 @@ let write_file path content =
 let event_queue_snapshot_path ~base_path ~keeper_name =
   Filename.concat
     (Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name)
-    "event-queue-v13.json"
+    "event-queue-v14.json"
 ;;
 
 let reaction_ledger_dir ~base_path ~keeper_name =
@@ -523,7 +523,7 @@ let test_fleet_summary_surfaces_durable_event_queue_discovery_error () =
   in
   mkdir_p invalid_keeper_dir;
   write_file
-    (Filename.concat invalid_keeper_dir "event-queue-v13.json")
+    (Filename.concat invalid_keeper_dir "event-queue-v14.json")
     (Yojson.Safe.to_string (Keeper_event_queue.queue_to_yojson Keeper_event_queue.empty));
   let fleet =
     Keeper_reaction_ledger.fleet_summary_json

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -725,7 +725,7 @@ let test_goal_reconciliation_restart_scan_retries_missed_delivery () =
            (Filename.concat
               (Common.keepers_runtime_dir_of_base ~base_path:config.base_path)
               meta.name)
-           "event-queue-v13.json"
+           "event-queue-v14.json"
        in
        Fs_compat.mkdir_p queue_path;
        let failed =
@@ -902,7 +902,13 @@ let test_goal_reconciliation_outbox_identity_rewakes_without_duplicate () =
        in
        let cancellation : Keeper_event_queue_persistence.accepted_cancellation =
          { source = stimulus
-         ; source_revision = Keeper_event_queue_state.revision state
+         ; source_incarnation =
+             (Keeper_event_queue_state.select_when
+                ~ready:(Keeper_event_queue.stimulus_identity_equal stimulus)
+                state
+              |> function
+              | Some selection -> selection.admitted_revision
+              | None -> fail "durable reconciliation source was not selectable")
          ; owner_nonce = 17
          ; operator_operation_id = "goal-reconciliation-outbox-fixture"
          ; reason = "stage source in genuine transition outbox"

--- a/test/test_keeper_runtime_manifest_completeness.ml
+++ b/test/test_keeper_runtime_manifest_completeness.ml
@@ -231,10 +231,7 @@ let test_current_compaction_evidence_read_boundary () =
            (label ^ " cause retained")
            cause
            (restored.decision |> member "error" |> to_string))
-    [ ( "retry without checkpoint"
-      , M.Retry_without_checkpoint
-      , "compaction dispatch failed" )
-    ; ( "lifecycle cleanup without checkpoint"
+    [ ( "lifecycle cleanup without checkpoint"
       , M.Lifecycle_cleanup_failed_without_checkpoint
       , "lifecycle cleanup failed" )
     ];
@@ -263,15 +260,15 @@ let test_current_compaction_evidence_read_boundary () =
              [ Keeper_compaction_evidence.exact_evidence_key
              , unknown_evidence
              ]) )
-    ; ( "evidence on retry without checkpoint"
+    ; ( "evidence on lifecycle cleanup without checkpoint"
       , row
           (decision
-             M.Retry_without_checkpoint
-             [ "error", `String "retry"
+             M.Lifecycle_cleanup_failed_without_checkpoint
+             [ "error", `String "cleanup"
              ; Keeper_compaction_evidence.exact_evidence_key, evidence
              ]) )
-    ; ( "missing retry cause"
-      , row (decision M.Retry_without_checkpoint []) )
+    ; ( "missing lifecycle cleanup cause"
+      , row (decision M.Lifecycle_cleanup_failed_without_checkpoint []) )
     ]
 
 let () =

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -335,7 +335,7 @@ let () =
       meta_fixture_exn
         (`Assoc
           [ "name", `String "corrupted-transcript"
-          ; "agent_name", `String "agent-corrupted-transcript"
+          ; "agent_name", `String (Keeper_identity.keeper_agent_name "corrupted-transcript")
           ; "trace_id", `String "trace-corrupted-transcript"
           ])
     in
@@ -344,6 +344,8 @@ let () =
        KMS.persist_transcript_corruption_pause
          config
          ~keeper_name:meta.name
+         ~trace_id:meta.runtime.trace_id
+         ~generation:meta.runtime.nonce
      with
      | Ok `Persisted -> ()
      | Ok `No_durable_meta ->
@@ -366,6 +368,63 @@ let () =
       "generic resume cannot clear transcript reset-required latch"
       (generic_resume.paused
        && generic_resume.latched_reason = paused.latched_reason))
+;;
+
+let () =
+  with_temp_dir "transcript-corruption-pause-identity" (fun base_path ->
+    let config = Masc.Workspace.default_config base_path in
+    ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+    let original =
+      meta_fixture_exn
+        (`Assoc
+          [ "name", `String "replaced-transcript-owner"
+          ; ( "agent_name"
+            , `String
+                (Keeper_identity.keeper_agent_name
+                   "replaced-transcript-owner") )
+          ; "trace_id", `String "trace-replaced-transcript-owner-old"
+          ])
+    in
+    write_meta_exn config original;
+    let current = read_meta_exn config original.name in
+    let replacement_trace =
+      match
+        Keeper_id.Trace_id.of_string
+          "trace-replaced-transcript-owner-new"
+      with
+      | Ok trace_id -> trace_id
+      | Error detail -> failwith detail
+    in
+    let replacement =
+      { current with
+        runtime =
+          { current.runtime with
+            trace_id = replacement_trace
+          ; nonce = current.runtime.nonce + 1
+          }
+      }
+    in
+    write_meta_exn config replacement;
+    (match
+       KMS.persist_transcript_corruption_pause
+         config
+         ~keeper_name:original.name
+         ~trace_id:original.runtime.trace_id
+         ~generation:original.runtime.nonce
+     with
+     | Error _ -> ()
+     | Ok _ ->
+       check
+         "replaced Keeper identity rejects old transcript pause"
+         false);
+    let retained = read_meta_exn config original.name in
+    check
+      "old transcript lane cannot pause replacement"
+      (not retained.paused
+       && Keeper_id.Trace_id.equal
+            retained.runtime.trace_id
+            replacement_trace
+       && retained.runtime.nonce = replacement.runtime.nonce))
 ;;
 
 let () =

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -354,7 +354,7 @@ let single_occurrence_id (result : Schedule_runner.tick_result) =
 
 let pending_selection_exn ~base_path ~keeper_name =
   match
-    Keeper_event_queue_persistence.peek_when_result
+    Keeper_event_queue_persistence.select_when_result
       ~base_path
       ~keeper_name
       ~ready:(fun _ -> true)
@@ -574,7 +574,7 @@ let test_keeper_wake_durable_enqueue_failure_retries_same_occurrence () =
       "schedule-keeper"
   in
   mkdir_p keeper_owner_path;
-  let queue_path = Filename.concat keeper_owner_path "event-queue-v13.json" in
+  let queue_path = Filename.concat keeper_owner_path "event-queue-v14.json" in
   mkdir_p queue_path;
   let request = create_keeper_wake_schedule config in
   let result = tick_ok config ~now:201.0 in
@@ -651,15 +651,17 @@ let test_cancelled_occurrence_recovery_does_not_enqueue_again () =
         | Error detail -> fail detail
       in
       let generation = entry.meta.runtime.nonce in
+      let selection =
+        Keeper_event_queue_state.select_when
+          ~ready:(fun _ -> true)
+          pending_state
+        |> function
+        | Some selection -> selection
+        | None -> fail "schedule cancellation source was not selectable"
+      in
       let cancellation : Keeper_event_queue_state.accepted_cancellation =
-        { source =
-            (match
-               Keeper_event_queue.to_list
-                 (Keeper_event_queue_state.pending pending_state)
-             with
-             | [ source ] -> source
-             | _ -> fail "schedule cancellation pending lane did not retain one source")
-        ; source_revision = Keeper_event_queue_state.revision pending_state
+        { source = selection.source
+        ; source_incarnation = selection.admitted_revision
         ; owner_nonce = generation
         ; operator_operation_id = "cancel-schedule-occurrence"
         ; reason = "operator cancelled retained schedule work"
@@ -684,7 +686,7 @@ let test_cancelled_occurrence_recovery_does_not_enqueue_again () =
           (Filename.concat
              (Common.keepers_runtime_dir_of_base ~base_path)
              keeper_name)
-          "event-queue-transitions-v3.jsonl"
+          "event-queue-transitions-v4.jsonl"
       in
       check bool "cancellation WAL survives until projection" true
         (Sys.file_exists transition_wal_path
@@ -692,7 +694,7 @@ let test_cancelled_occurrence_recovery_does_not_enqueue_again () =
       (* #26074: projection is driven only by the janitor, so ordinary queue
          traffic races it. An enqueue between the transition and the projection
          bumps the snapshot revision; if the transition WAL is still on disk at
-         that point, every later load replays a row whose [source_revision] no
+         that point, every later load replays a row whose [source_incarnation] no
          longer matches and the owner latches into "reset required" with no
          runtime exit - the projector itself cannot recover because it begins
          with [load_state_unlocked]. Drive that exact interleaving here. *)


### PR DESCRIPTION
## 문제

Keeper가 실제 기능 수행 중 compaction 실패 이력, 전역 queue revision, 별도 pause/settlement 경계에 의해 재진입하지 못하거나 올바른 operator 입력까지 stale로 거부될 수 있었습니다.

## 변경

- compaction retry suspension과 failure-streak 상태를 제거하고, 실제 checkpoint commit이 있을 때만 source turn을 requeue합니다.
- pending queue의 SSOT를 source별 incarnation으로 바꿔 unrelated enqueue가 선택을 무효화하지 않게 하고, remove/reinsert ABA는 정확히 거부합니다.
- transfer replay 권한은 operation ID ledger에 두고, 동일 source가 나중에 다시 들어오면 새 incarnation으로 처리합니다.
- transcript corruption은 동일 trace/generation으로 fence된 durable pause와 exact source terminal을 cancellation-safe하게 기록합니다.
- 구 source_revision 및 paused-work wire schema는 fallback 없이 hard-cut했습니다.

## 검증

- git diff --check
- paused_work_disposition_soak.sh bash -n
- retired wire 및 compaction retry/suspension 생산 코드 잔존 검색 0건
- focused source/event/post-turn 테스트는 재베이스 전 통과
- 최신 main 기준 focused 재빌드와 CI는 진행 중

## 리뷰 초점

- source incarnation이 pending entry 단일 권위인지
- pause -> terminal 효과가 identity fence와 cancellation boundary 안에 있는지
- manual compaction preemption 외에 현재 source를 가로채는 새 gate가 없는지
