### PR TITLE
fix(keeper): make event operator replay exact

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -30,6 +30,7 @@ import {
   fetchQueuedKeeperMessageResult,
   fetchKeeperRuntimeTrace,
   isTerminalQueuedKeeperMessage,
+  KeeperEventQueueOperationError,
   moveKeeperChatPendingReceiptToEnd,
   operateKeeperEventQueue,
   pauseKeeper,
@@ -690,14 +691,79 @@ describe('Keeper chat durable receipt API', () => {
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    await expect(operateKeeperEventQueue('sangsu', {
-      action: 'cancel',
-      expectedRevision: '8',
-      operationId: 'operation-9',
-      queueIndex: 1,
-      reason: 'operator cancellation',
-    })).rejects.toThrow(
+    let observed: unknown
+    try {
+      await operateKeeperEventQueue('sangsu', {
+        action: 'cancel',
+        expectedRevision: '8',
+        operationId: 'operation-9',
+        queueIndex: 1,
+        reason: 'operator cancellation',
+      })
+    } catch (cause) {
+      observed = cause
+    }
+
+    expect(observed).toBeInstanceOf(KeeperEventQueueOperationError)
+    expect(observed).toMatchObject({
+      commitState: 'committed',
+      operation: {
+        action: 'cancel',
+        expectedRevision: '8',
+        operationId: 'operation-9',
+        queueIndex: 1,
+        reason: 'operator cancellation',
+      },
+    })
+    expect((observed as Error).message).toContain(
       'Event queue mutation committed, but target_projection follow-up failed (transition-9)',
+    )
+  })
+
+  it('retains the generated event operation identity when the POST result is unknown', async () => {
+    vi.stubGlobal('crypto', {
+      randomUUID: vi.fn(() => '00000000-0000-4000-8000-000000000099'),
+    })
+    const fetchMock = vi.fn().mockRejectedValue(
+      new TypeError('connection reset after possible commit'),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    let observed: unknown
+    try {
+      await operateKeeperEventQueue('sangsu', {
+        action: 'transfer',
+        expectedRevision: '9',
+        queueIndex: 2,
+        targetKeeper: 'rondo',
+      })
+    } catch (cause) {
+      observed = cause
+    }
+
+    expect(observed).toBeInstanceOf(KeeperEventQueueOperationError)
+    expect(observed).toMatchObject({
+      commitState: 'unknown',
+      operation: {
+        action: 'transfer',
+        expectedRevision: '9',
+        operationId: '00000000-0000-4000-8000-000000000099',
+        queueIndex: 2,
+        targetKeeper: 'rondo',
+      },
+    })
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/keepers/sangsu/events/operator',
+      expect.objectContaining({
+        body: JSON.stringify({
+          schema: 'keeper_event_queue.operator.request.v1',
+          action: 'transfer',
+          expected_revision: '9',
+          queue_index: 2,
+          operator_operation_id: '00000000-0000-4000-8000-000000000099',
+          target_keeper: 'rondo',
+        }),
+      }),
     )
   })
 

--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -581,8 +581,7 @@ describe('Keeper chat durable receipt API', () => {
     await operateKeeperEventQueue('sangsu', {
       action: 'reprioritize',
       expectedRevision: '7',
-      operationId: 'operation-7',
-      postId: 'post-1',
+      queueIndex: 0,
       urgency: 'immediate',
     })
 
@@ -593,8 +592,7 @@ describe('Keeper chat durable receipt API', () => {
           schema: 'keeper_event_queue.operator.request.v1',
           action: 'reprioritize',
           expected_revision: '7',
-          operator_operation_id: 'operation-7',
-          post_id: 'post-1',
+          queue_index: 0,
           urgency: 'immediate',
         }),
       }),
@@ -610,8 +608,8 @@ describe('Keeper chat durable receipt API', () => {
         result: {
           status: 'committed_followup_failed',
           transition_id: 'transition-9',
-          stage: 'projection',
-          detail: 'reaction ledger unavailable',
+          stage: 'target_projection',
+          detail: 'target queue unavailable',
         },
         audit: { recorded: true },
       }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
@@ -622,10 +620,10 @@ describe('Keeper chat durable receipt API', () => {
       action: 'cancel',
       expectedRevision: '8',
       operationId: 'operation-9',
-      postId: 'post-9',
+      queueIndex: 1,
       reason: 'operator cancellation',
     })).rejects.toThrow(
-      'Event queue mutation committed, but projection follow-up failed (transition-9)',
+      'Event queue mutation committed, but target_projection follow-up failed (transition-9)',
     )
   })
 

--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -459,6 +459,47 @@ describe('Keeper chat durable receipt API', () => {
     )
   })
 
+  it('rejects chat pagination revision drift without a fixed retry loop', async () => {
+    const entry = (revision: string, suffix: string) => ({
+      receipt: {
+        schema: 'keeper_chat_queue.receipt.v2',
+        keeper_name: 'sangsu',
+        receipt_id: `chatq_00000000-0000-4000-8000-0000000000${suffix}`,
+        revision,
+        state: { kind: 'pending' },
+      },
+      content: `revision ${revision}`,
+      user_blocks: [],
+      attachments: [],
+      submitted_at: 42,
+    })
+    const envelope = (revision: string, nextAfter: string | null) => ({
+      schema: 'keeper_chat_queue.pending.v1',
+      ok: true,
+      keeper_name: 'sangsu',
+      revision,
+      current_work: null,
+      total_pending: 2,
+      next_after: nextAfter,
+      pending: [entry(revision, revision)],
+    })
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(envelope('22', '41')), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(envelope('23', null)), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchKeeperChatPending('sangsu')).rejects.toThrow(
+      'fetchKeeperChatPending: queue changed during pagination',
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
   it('combines metadata-only event refs across one stable Admin inventory revision', async () => {
     const item = (queueIndex: number, postId: string) => ({
       queue_index: queueIndex,
@@ -515,6 +556,39 @@ describe('Keeper chat durable receipt API', () => {
       '/api/v1/keepers/sangsu/events/pending?limit=100&after=1',
       expect.objectContaining({ headers: expect.any(Object) }),
     )
+  })
+
+  it('rejects event pagination revision drift without a fixed retry loop', async () => {
+    const envelope = (revision: string, queueIndex: number, nextAfter: string | null) => ({
+      schema: 'keeper_event_queue.pending.v1',
+      ok: true,
+      keeper_name: 'sangsu',
+      revision,
+      total_pending: 2,
+      next_after: nextAfter,
+      pending: [{
+        queue_index: queueIndex,
+        post_id: `post-${revision}`,
+        urgency: 'normal',
+        arrived_at_unix: 42,
+        payload_kind: 'bootstrap',
+      }],
+    })
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(envelope('31', 0, '1')), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(envelope('32', 1, null)), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchKeeperEventQueuePending('sangsu')).rejects.toThrow(
+      'fetchKeeperEventQueuePending: queue changed during pagination',
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
   it('sends revision-fenced pending edit and move requests', async () => {

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -1069,48 +1069,44 @@ async function fetchKeeperChatPendingPage(
 export async function fetchKeeperChatPending(
   keeperName: string,
 ): Promise<KeeperChatPendingSnapshot> {
-  for (let attempt = 0; attempt < 3; attempt += 1) {
-    const pending: KeeperChatPendingInput[] = []
-    const seenCursors = new Set<string>()
-    let expectedRevision: string | null = null
-    let currentWork: KeeperChatPendingSnapshot['currentWork'] = null
-    let totalPending = 0
-    let after: string | null = null
-    let revisionChanged = false
-    do {
-      const page = await fetchKeeperChatPendingPage(keeperName, after)
-      if (expectedRevision === null) {
-        expectedRevision = page.revision
-        currentWork = page.currentWork
-        totalPending = page.totalPending
-      } else if (
-        page.revision !== expectedRevision
-        || page.totalPending !== totalPending
-      ) {
-        revisionChanged = true
-        break
-      }
-      pending.push(...page.pending)
-      after = page.nextAfter
-      if (after !== null) {
-        if (seenCursors.has(after)) {
-          throw new Error('fetchKeeperChatPending: repeated page cursor')
-        }
-        seenCursors.add(after)
-      }
-    } while (after !== null)
-    if (!revisionChanged && pending.length === totalPending) {
-      return {
-        keeperName,
-        revision: expectedRevision ?? '0',
-        currentWork,
-        totalPending,
-        nextAfter: null,
-        pending,
-      }
+  const pending: KeeperChatPendingInput[] = []
+  const seenCursors = new Set<string>()
+  let expectedRevision: string | null = null
+  let currentWork: KeeperChatPendingSnapshot['currentWork'] = null
+  let totalPending = 0
+  let after: string | null = null
+  do {
+    const page = await fetchKeeperChatPendingPage(keeperName, after)
+    if (expectedRevision === null) {
+      expectedRevision = page.revision
+      currentWork = page.currentWork
+      totalPending = page.totalPending
+    } else if (
+      page.revision !== expectedRevision
+      || page.totalPending !== totalPending
+    ) {
+      throw new Error('fetchKeeperChatPending: queue changed during pagination')
     }
+    pending.push(...page.pending)
+    after = page.nextAfter
+    if (after !== null) {
+      if (seenCursors.has(after)) {
+        throw new Error('fetchKeeperChatPending: repeated page cursor')
+      }
+      seenCursors.add(after)
+    }
+  } while (after !== null)
+  if (expectedRevision === null || pending.length !== totalPending) {
+    throw new Error('fetchKeeperChatPending: incomplete queue snapshot')
   }
-  throw new Error('fetchKeeperChatPending: queue changed during pagination')
+  return {
+    keeperName,
+    revision: expectedRevision,
+    currentWork,
+    totalPending,
+    nextAfter: null,
+    pending,
+  }
 }
 
 export function parseKeeperEventQueuePendingSnapshot(
@@ -1206,45 +1202,41 @@ async function fetchKeeperEventQueuePendingPage(
 export async function fetchKeeperEventQueuePending(
   keeperName: string,
 ): Promise<KeeperEventQueuePendingSnapshot> {
-  for (let attempt = 0; attempt < 3; attempt += 1) {
-    const pending: KeeperEventQueuePendingItem[] = []
-    const seenCursors = new Set<string>()
-    let expectedRevision: string | null = null
-    let totalPending = 0
-    let after: string | null = null
-    let revisionChanged = false
-    do {
-      const page = await fetchKeeperEventQueuePendingPage(keeperName, after)
-      if (expectedRevision === null) {
-        expectedRevision = page.revision
-        totalPending = page.totalPending
-      } else if (
-        page.revision !== expectedRevision
-        || page.totalPending !== totalPending
-      ) {
-        revisionChanged = true
-        break
-      }
-      pending.push(...page.pending)
-      after = page.nextAfter
-      if (after !== null) {
-        if (seenCursors.has(after)) {
-          throw new Error('fetchKeeperEventQueuePending: repeated page cursor')
-        }
-        seenCursors.add(after)
-      }
-    } while (after !== null)
-    if (!revisionChanged && pending.length === totalPending) {
-      return {
-        keeperName,
-        revision: expectedRevision ?? '0',
-        totalPending,
-        nextAfter: null,
-        pending,
-      }
+  const pending: KeeperEventQueuePendingItem[] = []
+  const seenCursors = new Set<string>()
+  let expectedRevision: string | null = null
+  let totalPending = 0
+  let after: string | null = null
+  do {
+    const page = await fetchKeeperEventQueuePendingPage(keeperName, after)
+    if (expectedRevision === null) {
+      expectedRevision = page.revision
+      totalPending = page.totalPending
+    } else if (
+      page.revision !== expectedRevision
+      || page.totalPending !== totalPending
+    ) {
+      throw new Error('fetchKeeperEventQueuePending: queue changed during pagination')
     }
+    pending.push(...page.pending)
+    after = page.nextAfter
+    if (after !== null) {
+      if (seenCursors.has(after)) {
+        throw new Error('fetchKeeperEventQueuePending: repeated page cursor')
+      }
+      seenCursors.add(after)
+    }
+  } while (after !== null)
+  if (expectedRevision === null || pending.length !== totalPending) {
+    throw new Error('fetchKeeperEventQueuePending: incomplete queue snapshot')
   }
-  throw new Error('fetchKeeperEventQueuePending: queue changed during pagination')
+  return {
+    keeperName,
+    revision: expectedRevision,
+    totalPending,
+    nextAfter: null,
+    pending,
+  }
 }
 
 export async function cancelKeeperChatPendingReceipt(
@@ -1378,33 +1370,89 @@ export type KeeperEventQueueOperatorAction =
   | { action: 'transfer'; expectedRevision: string; queueIndex: number; targetKeeper: string; operationId?: string }
   | { action: 'reprioritize'; expectedRevision: string; queueIndex: number; urgency: 'immediate' | 'normal' | 'low' }
 
+export type KeeperEventQueueReplayableAction =
+  | { action: 'cancel'; expectedRevision: string; queueIndex: number; reason: string; operationId: string }
+  | { action: 'transfer'; expectedRevision: string; queueIndex: number; targetKeeper: string; operationId: string }
+
+type PreparedKeeperEventQueueOperatorAction =
+  | KeeperEventQueueReplayableAction
+  | Extract<KeeperEventQueueOperatorAction, { action: 'reprioritize' }>
+
+export class KeeperEventQueueOperationError extends Error {
+  readonly operation: KeeperEventQueueReplayableAction
+  readonly commitState: 'committed' | 'unknown'
+
+  constructor(
+    message: string,
+    operation: KeeperEventQueueReplayableAction,
+    commitState: 'committed' | 'unknown',
+  ) {
+    super(message)
+    this.name = 'KeeperEventQueueOperationError'
+    this.operation = operation
+    this.commitState = commitState
+  }
+}
+
+function prepareKeeperEventQueueOperatorAction(
+  operation: KeeperEventQueueOperatorAction,
+): PreparedKeeperEventQueueOperatorAction {
+  switch (operation.action) {
+    case 'cancel':
+    case 'transfer':
+      return {
+        ...operation,
+        operationId: operation.operationId ?? crypto.randomUUID(),
+      }
+    case 'reprioritize':
+      return operation
+  }
+}
+
+function keeperEventQueueOperationError(
+  message: string,
+  operation: PreparedKeeperEventQueueOperatorAction,
+  commitState: 'committed' | 'unknown',
+): Error {
+  return operation.action === 'reprioritize'
+    ? new Error(message)
+    : new KeeperEventQueueOperationError(message, operation, commitState)
+}
+
 export async function operateKeeperEventQueue(
   keeperName: string,
   operation: KeeperEventQueueOperatorAction,
 ): Promise<void> {
+  const prepared = prepareKeeperEventQueueOperatorAction(operation)
   const common = {
     schema: 'keeper_event_queue.operator.request.v1',
-    action: operation.action,
-    expected_revision: operation.expectedRevision,
-    queue_index: operation.queueIndex,
+    action: prepared.action,
+    expected_revision: prepared.expectedRevision,
+    queue_index: prepared.queueIndex,
   }
-  const request = operation.action === 'cancel'
+  const request = prepared.action === 'cancel'
     ? {
         ...common,
-        operator_operation_id: operation.operationId ?? crypto.randomUUID(),
-        reason: operation.reason,
+        operator_operation_id: prepared.operationId,
+        reason: prepared.reason,
       }
-    : operation.action === 'transfer'
+    : prepared.action === 'transfer'
       ? {
           ...common,
-          operator_operation_id: operation.operationId ?? crypto.randomUUID(),
-          target_keeper: operation.targetKeeper,
+          operator_operation_id: prepared.operationId,
+          target_keeper: prepared.targetKeeper,
         }
-      : { ...common, urgency: operation.urgency }
-  const raw = await post<unknown>(
-    `/api/v1/keepers/${encodeURIComponent(keeperName)}/events/operator`,
-    request,
-  )
+      : { ...common, urgency: prepared.urgency }
+  let raw: unknown
+  try {
+    raw = await post<unknown>(
+      `/api/v1/keepers/${encodeURIComponent(keeperName)}/events/operator`,
+      request,
+    )
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause)
+    throw keeperEventQueueOperationError(message, prepared, 'unknown')
+  }
   if (
     !isRecord(raw)
     || raw.schema !== 'keeper_event_queue.operator.result.v1'
@@ -1412,7 +1460,11 @@ export async function operateKeeperEventQueue(
     || asString(raw.keeper_name, '').trim() !== keeperName
     || !isRecord(raw.result)
   ) {
-    throw new Error('operateKeeperEventQueue: invalid response envelope')
+    throw keeperEventQueueOperationError(
+      'operateKeeperEventQueue: invalid response envelope',
+      prepared,
+      'unknown',
+    )
   }
   const status = asString(raw.result.status, '').trim()
   if (status === 'committed_followup_failed') {
@@ -1424,21 +1476,35 @@ export async function operateKeeperEventQueue(
       || !['checkpoint', 'wal_compaction', 'projection', 'target_projection'].includes(stage)
       || !detail
     ) {
-      throw new Error('operateKeeperEventQueue: invalid committed failure evidence')
+      throw keeperEventQueueOperationError(
+        'operateKeeperEventQueue: invalid committed failure evidence',
+        prepared,
+        'unknown',
+      )
     }
-    throw new Error(
+    throw keeperEventQueueOperationError(
       `Event queue mutation committed, but ${stage} follow-up failed (${transitionId}): ${detail}`,
+      prepared,
+      'committed',
     )
   }
   if (status === 'applied' || status === 'already_applied') {
     const transitionId = asString(raw.result.transition_id, '').trim()
     const revision = parseKeeperQueueRevision(raw.result.revision)
     if (!transitionId && revision === undefined) {
-      throw new Error('operateKeeperEventQueue: applied result lacks durable identity')
+      throw keeperEventQueueOperationError(
+        'operateKeeperEventQueue: applied result lacks durable identity',
+        prepared,
+        'unknown',
+      )
     }
     return
   }
-  throw new Error('operateKeeperEventQueue: unknown result status')
+  throw keeperEventQueueOperationError(
+    'operateKeeperEventQueue: unknown result status',
+    prepared,
+    'unknown',
+  )
 }
 
 export async function resolveKeeperChatRecovery(

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -1374,9 +1374,9 @@ export async function moveKeeperChatPendingReceiptToEnd(
 }
 
 export type KeeperEventQueueOperatorAction =
-  | { action: 'cancel'; expectedRevision: string; postId: string; reason: string; operationId?: string }
-  | { action: 'transfer'; expectedRevision: string; postId: string; targetKeeper: string; operationId?: string }
-  | { action: 'reprioritize'; expectedRevision: string; postId: string; urgency: 'immediate' | 'normal' | 'low'; operationId?: string }
+  | { action: 'cancel'; expectedRevision: string; queueIndex: number; reason: string; operationId?: string }
+  | { action: 'transfer'; expectedRevision: string; queueIndex: number; targetKeeper: string; operationId?: string }
+  | { action: 'reprioritize'; expectedRevision: string; queueIndex: number; urgency: 'immediate' | 'normal' | 'low' }
 
 export async function operateKeeperEventQueue(
   keeperName: string,
@@ -1386,13 +1386,20 @@ export async function operateKeeperEventQueue(
     schema: 'keeper_event_queue.operator.request.v1',
     action: operation.action,
     expected_revision: operation.expectedRevision,
-    operator_operation_id: operation.operationId ?? crypto.randomUUID(),
-    post_id: operation.postId,
+    queue_index: operation.queueIndex,
   }
   const request = operation.action === 'cancel'
-    ? { ...common, reason: operation.reason }
+    ? {
+        ...common,
+        operator_operation_id: operation.operationId ?? crypto.randomUUID(),
+        reason: operation.reason,
+      }
     : operation.action === 'transfer'
-      ? { ...common, target_keeper: operation.targetKeeper }
+      ? {
+          ...common,
+          operator_operation_id: operation.operationId ?? crypto.randomUUID(),
+          target_keeper: operation.targetKeeper,
+        }
       : { ...common, urgency: operation.urgency }
   const raw = await post<unknown>(
     `/api/v1/keepers/${encodeURIComponent(keeperName)}/events/operator`,
@@ -1414,7 +1421,7 @@ export async function operateKeeperEventQueue(
     const detail = asString(raw.result.detail, '').trim()
     if (
       !transitionId
-      || !['checkpoint', 'wal_compaction', 'projection'].includes(stage)
+      || !['checkpoint', 'wal_compaction', 'projection', 'target_projection'].includes(stage)
       || !detail
     ) {
       throw new Error('operateKeeperEventQueue: invalid committed failure evidence')

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -12,6 +12,7 @@ const {
   editKeeperChatPendingReceipt,
   moveKeeperChatPendingReceiptToEnd,
   operateKeeperEventQueue,
+  KeeperEventQueueOperationError,
 } = vi.hoisted(() => ({
   bootKeeper: vi.fn(),
   shutdownKeeper: vi.fn(),
@@ -21,6 +22,34 @@ const {
   editKeeperChatPendingReceipt: vi.fn(),
   moveKeeperChatPendingReceiptToEnd: vi.fn(),
   operateKeeperEventQueue: vi.fn(),
+  KeeperEventQueueOperationError: class KeeperEventQueueOperationError extends Error {
+    readonly operation: {
+      action: 'cancel' | 'transfer'
+      expectedRevision: string
+      queueIndex: number
+      operationId: string
+      reason?: string
+      targetKeeper?: string
+    }
+    readonly commitState: 'committed' | 'unknown'
+
+    constructor(
+      message: string,
+      operation: {
+        action: 'cancel' | 'transfer'
+        expectedRevision: string
+        queueIndex: number
+        operationId: string
+        reason?: string
+        targetKeeper?: string
+      },
+      commitState: 'committed' | 'unknown',
+    ) {
+      super(message)
+      this.operation = operation
+      this.commitState = commitState
+    }
+  },
 }))
 
 const { invalidateDashboardCache, refreshDashboard } = vi.hoisted(() => ({
@@ -101,6 +130,7 @@ vi.mock('../api/keeper', () => ({
   editKeeperChatPendingReceipt,
   moveKeeperChatPendingReceiptToEnd,
   operateKeeperEventQueue,
+  KeeperEventQueueOperationError,
 }))
 
 vi.mock('../store', async (importOriginal) => {
@@ -1038,6 +1068,100 @@ describe('KeeperConversationPanel', () => {
       expect(panel?.textContent).toContain('맨 뒤로')
       expect(panel?.textContent).toContain('이관')
       expect(panel?.textContent).toContain('취소')
+    })
+  })
+
+  it('replays an ambiguous event mutation with the exact preserved operation identity', async () => {
+    fetchKeeperChatPending.mockResolvedValue({
+      keeperName: 'sangsu',
+      revision: '22',
+      currentWork: null,
+      totalPending: 0,
+      nextAfter: null,
+      pending: [],
+    })
+    fetchKeeperEventQueuePending.mockResolvedValue({
+      keeperName: 'sangsu',
+      revision: '9',
+      totalPending: 1,
+      nextAfter: null,
+      pending: [{
+        queueIndex: 0,
+        postId: 'board-post-9',
+        urgency: 'normal',
+        arrivedAt: 41,
+        payloadKind: 'board_signal',
+      }],
+    })
+    mockedToolsData.value = {
+      keeper_waiting_inventory: {
+        keepers: [{
+          keeper_name: 'sangsu',
+          state: 'busy',
+          waiting_count: 1,
+          sources: { event_queue_pending: 1 },
+          waiting_on: [],
+        }],
+      },
+    }
+    const recoveryOperation = {
+      action: 'transfer' as const,
+      expectedRevision: '9',
+      queueIndex: 0,
+      operationId: 'operation-replay-9',
+      targetKeeper: 'rondo',
+    }
+    operateKeeperEventQueue
+      .mockRejectedValueOnce(new KeeperEventQueueOperationError(
+        'connection reset after possible commit',
+        recoveryOperation,
+        'unknown',
+      ))
+      .mockResolvedValueOnce(undefined)
+    vi.stubGlobal('prompt', vi.fn(() => 'rondo'))
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="Say something" layout="primary" />`,
+      container,
+    )
+    fireEvent.click(await waitFor(() => {
+      const button = container.querySelector('[data-open-keeper-queue-control]')
+      expect(button).not.toBeNull()
+      return button as HTMLElement
+    }))
+    const transfer = await waitFor(() => {
+      const row = container.querySelector('[data-operator-event-row]')
+      const button = [...(row?.querySelectorAll('button') ?? [])]
+        .find(node => node.textContent === '이관')
+      expect(button).not.toBeUndefined()
+      return button as HTMLElement
+    })
+
+    fireEvent.click(transfer)
+
+    const recovery = await waitFor(() => {
+      const node = container.querySelector(
+        '[data-event-operation-recovery="operation-replay-9"]',
+      )
+      expect(node).not.toBeNull()
+      expect(node?.textContent).toContain('commit 결과 확인 필요')
+      return node as HTMLElement
+    })
+    const retry = [...recovery.querySelectorAll('button')]
+      .find(node => node.textContent === '동일 작업 결과 확인·복구')
+    expect(retry).not.toBeUndefined()
+
+    fireEvent.click(retry as HTMLElement)
+
+    await waitFor(() => {
+      expect(operateKeeperEventQueue).toHaveBeenNthCalledWith(
+        2,
+        'sangsu',
+        recoveryOperation,
+      )
+      expect(container.querySelector(
+        '[data-event-operation-recovery="operation-replay-9"]',
+      )).toBeNull()
     })
   })
 

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -93,11 +93,14 @@ import {
   editKeeperChatPendingReceipt,
   fetchKeeperEventQueuePending,
   fetchKeeperChatPending,
+  KeeperEventQueueOperationError,
   moveKeeperChatPendingReceiptToEnd,
   operateKeeperEventQueue,
   type DashboardKeeperWaitingKeeper,
   type KeeperChatPendingSnapshot,
+  type KeeperEventQueueOperatorAction,
   type KeeperEventQueuePendingSnapshot,
+  type KeeperEventQueueReplayableAction,
 } from '../api'
 
 // Mirrors `LANE_REFRESH_MS` in keeper-workspace/keeper-lane-strip.ts. That
@@ -678,6 +681,11 @@ function KeeperQueueControlPanel({
   const [eventSnapshot, setEventSnapshot] = useState<KeeperEventQueuePendingSnapshot | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [pendingAction, setPendingAction] = useState<string | null>(null)
+  const [eventRecoveries, setEventRecoveries] = useState<readonly {
+    operation: KeeperEventQueueReplayableAction
+    commitState: 'committed' | 'unknown'
+    message: string
+  }[]>([])
   const load = async (clearError = true) => {
     try {
       if (clearError) setError(null)
@@ -715,13 +723,34 @@ function KeeperQueueControlPanel({
       setPendingAction(null)
     }
   }
-  const mutateEvent = async (key: string, operation: () => Promise<void>) => {
+  const mutateEvent = async (
+    key: string,
+    operation: KeeperEventQueueOperatorAction,
+  ) => {
     setPendingAction(key)
     try {
-      await operation()
+      await operateKeeperEventQueue(keeperName, operation)
+      if (operation.action !== 'reprioritize' && operation.operationId) {
+        setEventRecoveries(recoveries => recoveries.filter(
+          recovery => recovery.operation.operationId !== operation.operationId,
+        ))
+      }
       await Promise.all([load(), loadTools()])
     } catch (cause) {
       const message = cause instanceof Error ? cause.message : String(cause)
+      if (cause instanceof KeeperEventQueueOperationError) {
+        const recovery = {
+          operation: cause.operation,
+          commitState: cause.commitState,
+          message,
+        }
+        setEventRecoveries(recoveries => [
+          ...recoveries.filter(
+            item => item.operation.operationId !== cause.operation.operationId,
+          ),
+          recovery,
+        ])
+      }
       await Promise.allSettled([load(false), loadTools()])
       setError(message)
       showToast(message, 'error')
@@ -799,6 +828,29 @@ function KeeperQueueControlPanel({
       </div>
       <div class="grid gap-2 border-t border-[var(--color-border-subtle)] pt-3">
         <div class="text-xs font-semibold text-[var(--color-fg-secondary)]">자율 이벤트 대기 ${eventSnapshot?.totalPending ?? 0}</div>
+        ${eventRecoveries.map(recovery => {
+          const operationId = recovery.operation.operationId
+          const key = `event-recovery:${operationId}`
+          return html`
+            <div
+              class="grid gap-1 rounded-[var(--r-0)] border border-[var(--danger-20)] bg-[var(--danger-10)] p-2"
+              data-event-operation-recovery=${operationId}
+            >
+              <div class="text-2xs text-[var(--color-status-err)]">
+                ${recovery.commitState === 'committed' ? 'source commit 완료 · 후속 복구 필요' : 'commit 결과 확인 필요'}
+                · ${recovery.operation.action}
+              </div>
+              <div class="break-words text-3xs text-[var(--color-fg-secondary)]">${recovery.message}</div>
+              <div class="break-all font-mono text-3xs text-[var(--color-fg-muted)]">${operationId}</div>
+              <button
+                type="button"
+                disabled=${pendingAction === key}
+                class="w-fit rounded-[var(--r-0)] border border-[var(--danger-20)] px-2 py-1 text-2xs text-[var(--color-status-err)] disabled:opacity-50"
+                onClick=${() => void mutateEvent(key, recovery.operation)}
+              >동일 작업 결과 확인·복구</button>
+            </div>
+          `
+        })}
         ${eventRows.map(item => {
           const key = `event:${eventSnapshot!.revision}:${item.queueIndex}`
           const busy = pendingAction === key
@@ -813,12 +865,12 @@ function KeeperQueueControlPanel({
                     disabled=${busy}
                     class="rounded-[var(--r-0)] border border-[var(--color-border-default)] px-2 py-1 text-2xs disabled:opacity-50"
                     onClick=${() => {
-                      void mutateEvent(key, () => operateKeeperEventQueue(keeperName, {
+                      void mutateEvent(key, {
                         action: 'reprioritize',
                         expectedRevision: eventSnapshot!.revision,
                         queueIndex: item.queueIndex,
                         urgency,
-                      }))
+                      })
                     }}
                   >${urgency}</button>
                 `)}
@@ -829,12 +881,12 @@ function KeeperQueueControlPanel({
                   onClick=${() => {
                     const targetKeeper = window.prompt('이 이벤트를 넘길 Keeper 이름을 입력하세요.')
                     if (targetKeeper === null) return
-                    void mutateEvent(key, () => operateKeeperEventQueue(keeperName, {
+                    void mutateEvent(key, {
                       action: 'transfer',
                       expectedRevision: eventSnapshot!.revision,
                       queueIndex: item.queueIndex,
                       targetKeeper,
-                    }))
+                    })
                   }}
                 >이관</button>
                 <button
@@ -844,12 +896,12 @@ function KeeperQueueControlPanel({
                   onClick=${() => {
                     const reason = window.prompt('이벤트 취소 이유를 입력하세요.')
                     if (reason === null) return
-                    void mutateEvent(key, () => operateKeeperEventQueue(keeperName, {
+                    void mutateEvent(key, {
                       action: 'cancel',
                       expectedRevision: eventSnapshot!.revision,
                       queueIndex: item.queueIndex,
                       reason,
-                    }))
+                    })
                   }}
                 >취소</button>
               </div>

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -800,7 +800,7 @@ function KeeperQueueControlPanel({
       <div class="grid gap-2 border-t border-[var(--color-border-subtle)] pt-3">
         <div class="text-xs font-semibold text-[var(--color-fg-secondary)]">자율 이벤트 대기 ${eventSnapshot?.totalPending ?? 0}</div>
         ${eventRows.map(item => {
-          const key = `event:${item.postId}`
+          const key = `event:${eventSnapshot!.revision}:${item.queueIndex}`
           const busy = pendingAction === key
           return html`
             <div class="grid gap-1 rounded-[var(--r-0)] border border-[var(--color-border-subtle)] p-2" data-operator-event-row>
@@ -816,7 +816,7 @@ function KeeperQueueControlPanel({
                       void mutateEvent(key, () => operateKeeperEventQueue(keeperName, {
                         action: 'reprioritize',
                         expectedRevision: eventSnapshot!.revision,
-                        postId: item.postId,
+                        queueIndex: item.queueIndex,
                         urgency,
                       }))
                     }}
@@ -832,7 +832,7 @@ function KeeperQueueControlPanel({
                     void mutateEvent(key, () => operateKeeperEventQueue(keeperName, {
                       action: 'transfer',
                       expectedRevision: eventSnapshot!.revision,
-                      postId: item.postId,
+                      queueIndex: item.queueIndex,
                       targetKeeper,
                     }))
                   }}
@@ -847,7 +847,7 @@ function KeeperQueueControlPanel({
                     void mutateEvent(key, () => operateKeeperEventQueue(keeperName, {
                       action: 'cancel',
                       expectedRevision: eventSnapshot!.revision,
-                      postId: item.postId,
+                      queueIndex: item.queueIndex,
                       reason,
                     }))
                   }}

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -730,14 +730,19 @@ let reprioritize_pending_result
     else if Int64.equal observed_revision Int64.max_int
     then Error "event queue revision exhausted"
     else
-      let removed, remaining =
-        Keeper_event_queue.remove_by_post_id
-          source.Keeper_event_queue.post_id
-          (State.pending state)
+      let matching, retained =
+        Keeper_event_queue.to_list (State.pending state)
+        |> List.partition (fun candidate ->
+          Keeper_event_queue.stimulus_identity_equal candidate source)
       in
-      match removed with
-      | [ observed ]
-        when Keeper_event_queue.stimulus_identity_equal observed source ->
+      match matching with
+      | [ observed ] when observed = source ->
+        let remaining =
+          List.fold_left
+            Keeper_event_queue.enqueue
+            Keeper_event_queue.empty
+            retained
+        in
         let updated = { observed with urgency } in
         let pending =
           Keeper_event_queue.enqueue remaining updated
@@ -745,8 +750,8 @@ let reprioritize_pending_result
         in
         Ok (State.with_pending pending state, Int64.succ observed_revision)
       | [] -> Error "event queue source is no longer pending"
-      | [ _ ] -> Error "event queue source identity changed"
-      | _ -> Error "event queue post id is ambiguous")
+      | [ _ ] -> Error "event queue source snapshot changed"
+      | _ -> Error "event queue source identity is duplicated")
 ;;
 
 type enqueue_stimulus_result =

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -83,6 +83,11 @@ val projected_transition_receipts : t -> transition_receipt list
 (** The latest projected transition plus every older operator disposition
     witness retained for exact operation replay. *)
 
+val prior_disposition_by_operation_id :
+  string -> t -> transition_receipt option
+(** Return the unique durable disposition for an operator operation ID from
+    either the current outbox or projected history. *)
+
 val transition_outbox : t -> outbox_entry list
 val accepted_transfer_projections : t -> accepted_transfer list
 

--- a/lib/server/dune
+++ b/lib/server/dune
@@ -8,6 +8,7 @@
   keeper_grpc_heartbeat
   server_grpc_tool_dispatch
   server_dashboard_http_schedule_actions
+  server_dashboard_http_keeper_event_queue_operator_execute
   server_schedule_runner_policy)
  (flags :standard -open Masc)
  (libraries

--- a/lib/server/server_dashboard_http_keeper_event_queue_operator.ml
+++ b/lib/server/server_dashboard_http_keeper_event_queue_operator.ml
@@ -1,6 +1,7 @@
 (** Admin-only durable Keeper event-queue control boundary. *)
 
 module Http = Http_server_eio
+module Execute = Server_dashboard_http_keeper_event_queue_operator_execute
 
 let ( let* ) = Result.bind
 let schema = "keeper_event_queue.operator.request.v1"
@@ -87,6 +88,7 @@ let pending_page ~after ~limit pending =
 
 module For_testing = struct
   let pending_page = pending_page
+  let pending_source_at = Execute.pending_source_at
 end
 
 let handle_get state request reqd ~keeper_name =
@@ -141,23 +143,22 @@ let handle_get state request reqd ~keeper_name =
              ]))
 ;;
 
-type request =
+type request = Execute.request =
   | Cancel of
       { expected_revision : int64
-      ; post_id : string
+      ; queue_index : int
       ; operator_operation_id : string
       ; reason : string
       }
   | Transfer of
       { expected_revision : int64
-      ; post_id : string
+      ; queue_index : int
       ; operator_operation_id : string
       ; target_keeper : string
       }
   | Reprioritize of
       { expected_revision : int64
-      ; post_id : string
-      ; operator_operation_id : string
+      ; queue_index : int
       ; urgency : Keeper_event_queue.urgency
       }
 
@@ -179,6 +180,22 @@ let expected_revision fields =
   match Int64.of_string_opt value with
   | Some revision when Int64.compare revision 0L >= 0 -> Ok revision
   | Some _ | None -> Error "expected_revision must be a non-negative int64 string"
+;;
+
+let queue_index fields =
+  let* value = field "queue_index" fields in
+  match value with
+  | `Int queue_index when queue_index >= 0 -> Ok queue_index
+  | `Int _ -> Error "queue_index must be non-negative"
+  | _ -> Error "queue_index must be an integer"
+;;
+
+let operator_operation_id fields =
+  let* operation_id = string_field "operator_operation_id" fields in
+  if operation_id = ""
+     || not (String.equal operation_id (String.trim operation_id))
+  then Error "operator_operation_id must be non-empty and trimmed"
+  else Ok operation_id
 ;;
 
 let require_exact_fields expected fields =
@@ -214,39 +231,40 @@ let parse body =
     else
       let* action = string_field "action" fields in
       let* expected_revision = expected_revision fields in
-      let* post_id = string_field "post_id" fields in
-      let* () =
-        if post_id = "" || not (String.equal post_id (String.trim post_id))
-        then Error "post_id must be non-empty and trimmed"
-        else Ok ()
-      in
-      let* operator_operation_id = string_field "operator_operation_id" fields in
-      let* () =
-        if operator_operation_id = ""
-           || not (String.equal operator_operation_id (String.trim operator_operation_id))
-        then Error "operator_operation_id must be non-empty and trimmed"
-        else Ok ()
-      in
+      let* queue_index = queue_index fields in
       let common =
         [ "action"
         ; "expected_revision"
-        ; "operator_operation_id"
-        ; "post_id"
+        ; "queue_index"
         ; "schema"
         ]
       in
       match action with
       | "cancel" ->
-        let* () = require_exact_fields ("reason" :: common) fields in
+        let* () =
+          require_exact_fields
+            ("operator_operation_id" :: "reason" :: common)
+            fields
+        in
+        let* operator_operation_id = operator_operation_id fields in
         let* reason = string_field "reason" fields in
         if reason = "" || not (String.equal reason (String.trim reason))
         then Error "reason must be non-empty and trimmed"
         else
           Ok
             (Cancel
-               { expected_revision; post_id; operator_operation_id; reason })
+               { expected_revision
+               ; queue_index
+               ; operator_operation_id
+               ; reason
+               })
       | "transfer" ->
-        let* () = require_exact_fields ("target_keeper" :: common) fields in
+        let* () =
+          require_exact_fields
+            ("operator_operation_id" :: "target_keeper" :: common)
+            fields
+        in
+        let* operator_operation_id = operator_operation_id fields in
         let* target_keeper = string_field "target_keeper" fields in
         if not (Keeper_config.validate_name target_keeper)
         then Error "target_keeper is invalid"
@@ -254,7 +272,7 @@ let parse body =
           Ok
             (Transfer
                { expected_revision
-               ; post_id
+               ; queue_index
                ; operator_operation_id
                ; target_keeper
                })
@@ -264,184 +282,8 @@ let parse body =
         let* urgency = Keeper_event_queue.urgency_of_string urgency_value in
         Ok
           (Reprioritize
-             { expected_revision; post_id; operator_operation_id; urgency })
+             { expected_revision; queue_index; urgency })
       | value -> Error ("unknown event queue operator action: " ^ value)
-;;
-
-let transition_result_json = function
-  | Keeper_registry_event_queue.Transition_applied receipt ->
-    `Assoc
-      [ "status", `String "applied"
-      ; "transition_id", `String receipt.transition_id
-      ]
-  | Keeper_registry_event_queue.Transition_already_applied receipt ->
-    `Assoc
-      [ "status", `String "already_applied"
-      ; "transition_id", `String receipt.transition_id
-      ]
-  | Keeper_registry_event_queue.Transition_committed_followup_failed
-      { receipt; stage; detail } ->
-    `Assoc
-      [ "status", `String "committed_followup_failed"
-      ; "transition_id", `String receipt.transition_id
-      ; ( "stage"
-        , `String
-            (match stage with
-             | `Checkpoint -> "checkpoint"
-             | `Wal_compaction -> "wal_compaction"
-             | `Projection -> "projection") )
-      ; "detail", `String detail
-      ]
-;;
-
-let resolve_pending_source
-      ~base_path
-      ~keeper_name
-      ~expected_revision
-      ~post_id
-  =
-  let* queue_state =
-    Keeper_event_queue_persistence.load_state_result
-      ~base_path
-      ~keeper_name
-  in
-  let observed_revision = Keeper_event_queue_state.revision queue_state in
-  if not (Int64.equal expected_revision observed_revision)
-  then
-    Error
-      (Printf.sprintf
-         "event queue revision mismatch (expected=%Ld observed=%Ld)"
-         expected_revision
-         observed_revision)
-  else
-    let matches =
-      Keeper_event_queue_state.pending queue_state
-      |> Keeper_event_queue.to_list
-      |> List.filter (fun stimulus ->
-        String.equal stimulus.Keeper_event_queue.post_id post_id)
-    in
-    match matches with
-    | [ source ] -> Ok source
-    | [] -> Error "event queue source is no longer pending"
-    | _ -> Error "event queue post id is ambiguous"
-;;
-
-let run_request ~base_path ~keeper_name request =
-  match Keeper_registry.get ~base_path keeper_name with
-  | None -> Error "keeper is not registered"
-  | Some entry ->
-    let owner_nonce = entry.meta.runtime.nonce in
-    (match
-       Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () ->
-         match Keeper_registry.get ~base_path keeper_name with
-         | None -> Error "keeper registration disappeared"
-         | Some current when current.meta.runtime.nonce <> owner_nonce ->
-           Error "keeper owner nonce changed"
-         | Some _ ->
-           let applied_at = Time_compat.now () in
-           let expected_revision, post_id =
-             match request with
-             | Cancel { expected_revision; post_id; _ }
-             | Transfer { expected_revision; post_id; _ }
-             | Reprioritize { expected_revision; post_id; _ } ->
-               expected_revision, post_id
-           in
-           let* source =
-             resolve_pending_source
-               ~base_path
-               ~keeper_name
-               ~expected_revision
-               ~post_id
-           in
-           match request with
-           | Cancel
-               { expected_revision; post_id = _; operator_operation_id; reason } ->
-             Keeper_registry_event_queue.cancel_pending_accepted_result
-               ~base_path
-               keeper_name
-               ~current_owner_nonce:owner_nonce
-               ~applied_at
-               ~cancellation:
-                 { source
-                 ; source_revision = expected_revision
-                 ; owner_nonce
-                 ; operator_operation_id
-                 ; reason
-                 }
-             |> Result.map transition_result_json
-           | Transfer
-               { expected_revision
-               ; post_id = _
-               ; operator_operation_id
-               ; target_keeper
-               } ->
-             if String.equal keeper_name target_keeper
-             then Error "source and target keeper must differ"
-             else
-               let transfer : Keeper_registry_event_queue.accepted_transfer =
-                 { source
-                 ; source_revision = expected_revision
-                 ; owner_nonce
-                 ; operator_operation_id
-                 ; from_keeper = keeper_name
-                 ; to_keeper = target_keeper
-                 }
-               in
-               let* source_result =
-                 Keeper_registry_event_queue.transfer_pending_accepted_result
-                   ~base_path
-                   keeper_name
-                   ~current_owner_nonce:owner_nonce
-                   ~applied_at
-                   ~transfer
-               in
-               let* () =
-                 match
-                   Keeper_registry_event_queue.project_accepted_transfer_durable_result
-                     ~base_path
-                     target_keeper
-                     ~transfer
-                 with
-                 | Keeper_registry_event_queue.Stimulus_enqueued
-                 | Keeper_registry_event_queue.Stimulus_already_present -> Ok ()
-                 | Keeper_registry_event_queue.Stimulus_storage_error detail ->
-                   Error
-                     ("source transfer committed but target projection failed: " ^ detail)
-               in
-               ignore
-                 (Keeper_registry.wakeup_running
-                    ~intent:Keeper_registry.Broadcast_signal
-                    ~base_path
-                    target_keeper :
-                    Keeper_registry.wakeup_outcome);
-               Ok (transition_result_json source_result)
-           | Reprioritize
-               { expected_revision; post_id = _; operator_operation_id = _; urgency } ->
-             let* revision =
-               Keeper_registry_event_queue.reprioritize_pending_result
-                 ~base_path
-                 keeper_name
-                 ~expected_revision
-                 ~source
-                 ~urgency
-             in
-             ignore
-               (Keeper_registry.wakeup_running
-                  ~intent:Keeper_registry.Broadcast_signal
-                  ~base_path
-                  keeper_name :
-                  Keeper_registry.wakeup_outcome);
-             Ok
-               (`Assoc
-                 [ "status", `String "applied"
-                 ; "revision", `String (Int64.to_string revision)
-                 ]))
-     with
-     | `Ran result -> result
-     | `Busy block ->
-       Error
-         ("keeper turn is busy: "
-          ^ Keeper_turn_admission.autonomous_block_to_string block))
 ;;
 
 let handle_post state ~actor request reqd ~keeper_name body =
@@ -469,18 +311,18 @@ let handle_post state ~actor request reqd ~keeper_name body =
           ])
     | Ok operation ->
       let config = Mcp_server.workspace_config state in
-      let post_id, action, operator_operation_id =
+      let queue_index, action, operator_operation_id =
         match operation with
-        | Cancel { post_id; operator_operation_id; _ } ->
-          post_id, "cancel", operator_operation_id
-        | Transfer { post_id; operator_operation_id; _ } ->
-          post_id, "transfer", operator_operation_id
-        | Reprioritize { post_id; operator_operation_id; _ } ->
-          post_id, "reprioritize", operator_operation_id
+        | Cancel { queue_index; operator_operation_id; _ } ->
+          queue_index, "cancel", Some operator_operation_id
+        | Transfer { queue_index; operator_operation_id; _ } ->
+          queue_index, "transfer", Some operator_operation_id
+        | Reprioritize { queue_index; _ } ->
+          queue_index, "reprioritize", None
       in
       let result =
-        run_request
-          ~base_path:config.Workspace.base_path
+        Execute.run
+          ~config
           ~keeper_name
           operation
       in
@@ -497,17 +339,31 @@ let handle_post state ~actor request reqd ~keeper_name body =
            action);
       let audit =
         try
+          let source_details =
+            match result with
+            | Ok (source, _) ->
+              [ "post_id", `String source.Keeper_event_queue.post_id
+              ; ( "payload_kind"
+                , `String
+                    (Keeper_event_queue.payload_kind_label source.payload) )
+              ]
+            | Error _ -> []
+          in
           Audit_log.log_action
             config
             ~agent_id:actor
             ~action:(Audit_log.Custom "keeper_event_queue_operator")
             ~details:
               (`Assoc
-                [ "keeper_name", `String keeper_name
-                ; "action", `String action
-                ; "operator_operation_id", `String operator_operation_id
-                ; "post_id", `String post_id
-                ])
+                (([ "keeper_name", `String keeper_name
+                  ; "action", `String action
+                  ; "queue_index", `Int queue_index
+                  ]
+                  @ (match operator_operation_id with
+                     | Some value ->
+                       [ "operator_operation_id", `String value ]
+                     | None -> []))
+                 @ source_details))
             ~outcome:
               (match result with
                | Ok _ -> Audit_log.Success
@@ -523,7 +379,7 @@ let handle_post state ~actor request reqd ~keeper_name body =
             ]
       in
       match result with
-      | Ok result ->
+      | Ok (_, result) ->
         respond
           (`Assoc
             [ "schema", `String result_schema

--- a/lib/server/server_dashboard_http_keeper_event_queue_operator.mli
+++ b/lib/server/server_dashboard_http_keeper_event_queue_operator.mli
@@ -13,6 +13,11 @@ module For_testing : sig
     limit:int ->
     Keeper_event_queue.stimulus list ->
     Yojson.Safe.t list
+
+  val pending_source_at :
+    queue_index:int ->
+    Keeper_event_queue.t ->
+    Keeper_event_queue.stimulus option
 end
 
 val handle_get :

--- a/lib/server/server_dashboard_http_keeper_event_queue_operator_execute.ml
+++ b/lib/server/server_dashboard_http_keeper_event_queue_operator_execute.ml
@@ -1,0 +1,484 @@
+let ( let* ) = Result.bind
+
+type request =
+  | Cancel of
+      { expected_revision : int64
+      ; queue_index : int
+      ; operator_operation_id : string
+      ; reason : string
+      }
+  | Transfer of
+      { expected_revision : int64
+      ; queue_index : int
+      ; operator_operation_id : string
+      ; target_keeper : string
+      }
+  | Reprioritize of
+      { expected_revision : int64
+      ; queue_index : int
+      ; urgency : Keeper_event_queue.urgency
+      }
+
+let pending_source_at ~queue_index pending =
+  List.nth_opt (Keeper_event_queue.to_list pending) queue_index
+;;
+
+let transition_result_json = function
+  | Keeper_registry_event_queue.Transition_applied receipt ->
+    `Assoc
+      [ "status", `String "applied"
+      ; "transition_id", `String receipt.transition_id
+      ]
+  | Keeper_registry_event_queue.Transition_already_applied receipt ->
+    `Assoc
+      [ "status", `String "already_applied"
+      ; "transition_id", `String receipt.transition_id
+      ]
+  | Keeper_registry_event_queue.Transition_committed_followup_failed
+      { receipt; stage; detail } ->
+    `Assoc
+      [ "status", `String "committed_followup_failed"
+      ; "transition_id", `String receipt.transition_id
+      ; ( "stage"
+        , `String
+            (match stage with
+             | `Checkpoint -> "checkpoint"
+             | `Wal_compaction -> "wal_compaction"
+             | `Projection -> "projection") )
+      ; "detail", `String detail
+      ]
+;;
+
+let transition_receipt = function
+  | Keeper_registry_event_queue.Transition_applied receipt
+  | Keeper_registry_event_queue.Transition_already_applied receipt
+  | Keeper_registry_event_queue.Transition_committed_followup_failed
+      { receipt; _ } ->
+    receipt
+;;
+
+type prepared_cancellation =
+  { cancellation : Keeper_registry_event_queue.accepted_cancellation
+  ; applied_at : float
+  }
+
+type prepared_transfer =
+  { transfer : Keeper_registry_event_queue.accepted_transfer
+  ; applied_at : float
+  }
+
+let resolve_pending_source
+      ~queue_state
+      ~expected_revision
+      ~queue_index
+  =
+  let observed_revision = Keeper_event_queue_state.revision queue_state in
+  if not (Int64.equal expected_revision observed_revision)
+  then
+    Error
+      (Printf.sprintf
+         "event queue revision mismatch (expected=%Ld observed=%Ld)"
+         expected_revision
+         observed_revision)
+  else
+    match
+      pending_source_at
+        ~queue_index
+        (Keeper_event_queue_state.pending queue_state)
+    with
+    | Some source -> Ok source
+    | None -> Error "event queue selection is no longer pending"
+;;
+
+let prior_cancellation_for_request
+      ~queue_state
+      ~expected_revision
+      ~operator_operation_id
+      ~reason
+  =
+  match
+    Keeper_event_queue_state.prior_disposition_by_operation_id
+      operator_operation_id
+      queue_state
+  with
+  | None -> Ok None
+  | Some receipt ->
+    (match receipt.transition with
+     | Keeper_event_queue_state.Cancel_accepted cancellation
+       when Int64.equal cancellation.source_revision expected_revision
+            && String.equal cancellation.reason reason ->
+       Ok (Some { cancellation; applied_at = receipt.applied_at })
+     | Keeper_event_queue_state.Cancel_accepted _
+     | Keeper_event_queue_state.Transfer_accepted _
+     | Keeper_event_queue_state.Ack_source_terminal _ ->
+       Error
+         ("event queue operator operation ID conflicts with cancellation request: "
+          ^ operator_operation_id))
+;;
+
+let fresh_cancellation_for_request
+      ~queue_state
+      ~owner_nonce
+      ~expected_revision
+      ~queue_index
+      ~operator_operation_id
+      ~reason
+  =
+  let* source =
+    resolve_pending_source
+      ~queue_state
+      ~expected_revision
+      ~queue_index
+  in
+  let cancellation : Keeper_registry_event_queue.accepted_cancellation =
+    { source
+    ; source_revision = expected_revision
+    ; owner_nonce
+    ; operator_operation_id
+    ; reason
+    }
+  in
+  Ok { cancellation; applied_at = Time_compat.now () }
+;;
+
+let prior_transfer_for_request
+      ~queue_state
+      ~keeper_name
+      ~expected_revision
+      ~operator_operation_id
+      ~target_keeper
+  =
+  match
+    Keeper_event_queue_state.prior_disposition_by_operation_id
+      operator_operation_id
+      queue_state
+  with
+  | None -> Ok None
+  | Some receipt ->
+    (match receipt.transition with
+     | Keeper_event_queue_state.Transfer_accepted transfer
+       when Int64.equal transfer.source_revision expected_revision
+            && String.equal transfer.from_keeper keeper_name
+            && String.equal transfer.to_keeper target_keeper ->
+       Ok (Some { transfer; applied_at = receipt.applied_at })
+     | Keeper_event_queue_state.Cancel_accepted _
+     | Keeper_event_queue_state.Transfer_accepted _
+     | Keeper_event_queue_state.Ack_source_terminal _ ->
+       Error
+         ("event queue operator operation ID conflicts with transfer request: "
+          ^ operator_operation_id))
+;;
+
+let fresh_transfer_for_request
+      ~queue_state
+      ~keeper_name
+      ~owner_nonce
+      ~expected_revision
+      ~queue_index
+      ~operator_operation_id
+      ~target_keeper
+  =
+  let* source =
+    resolve_pending_source
+      ~queue_state
+      ~expected_revision
+      ~queue_index
+  in
+  let transfer : Keeper_registry_event_queue.accepted_transfer =
+    { source
+    ; source_revision = expected_revision
+    ; owner_nonce
+    ; operator_operation_id
+    ; from_keeper = keeper_name
+    ; to_keeper = target_keeper
+    }
+  in
+  Ok { transfer; applied_at = Time_compat.now () }
+;;
+
+let execute_cancellation ~base_path ~keeper_name prepared =
+  let cancellation = prepared.cancellation in
+  Keeper_registry_event_queue.cancel_pending_accepted_result
+    ~base_path
+    keeper_name
+    ~current_owner_nonce:cancellation.owner_nonce
+    ~applied_at:prepared.applied_at
+    ~cancellation
+  |> Result.map (fun result ->
+    cancellation.source, transition_result_json result)
+;;
+
+let target_projection_failure_json source_result detail =
+  let receipt = transition_receipt source_result in
+  `Assoc
+    [ "status", `String "committed_followup_failed"
+    ; "transition_id", `String receipt.transition_id
+    ; "stage", `String "target_projection"
+    ; "detail", `String detail
+    ]
+;;
+
+let execute_transfer ~base_path ~keeper_name prepared =
+  let transfer = prepared.transfer in
+  let* source_result =
+    Keeper_registry_event_queue.transfer_pending_accepted_result
+      ~base_path
+      keeper_name
+      ~current_owner_nonce:transfer.owner_nonce
+      ~applied_at:prepared.applied_at
+      ~transfer
+  in
+  match source_result with
+  | Keeper_registry_event_queue.Transition_committed_followup_failed _ ->
+    Ok (transfer.source, transition_result_json source_result)
+  | Keeper_registry_event_queue.Transition_applied _
+  | Keeper_registry_event_queue.Transition_already_applied _ ->
+    (match
+       Keeper_registry_event_queue.project_accepted_transfer_durable_result
+         ~base_path
+         transfer.to_keeper
+         ~transfer
+     with
+     | Keeper_registry_event_queue.Stimulus_enqueued
+     | Keeper_registry_event_queue.Stimulus_already_present ->
+       ignore
+         (Keeper_registry.wakeup_running
+            ~intent:Keeper_registry.Broadcast_signal
+            ~base_path
+            transfer.to_keeper :
+            Keeper_registry.wakeup_outcome);
+       Ok (transfer.source, transition_result_json source_result)
+     | Keeper_registry_event_queue.Stimulus_storage_error detail ->
+       Ok
+         ( transfer.source
+         , target_projection_failure_json source_result detail ))
+;;
+
+let execute_reprioritization
+      ~base_path
+      ~keeper_name
+      ~queue_state
+      ~expected_revision
+      ~queue_index
+      ~urgency
+  =
+  let* source =
+    resolve_pending_source
+      ~queue_state
+      ~expected_revision
+      ~queue_index
+  in
+  let* revision =
+    Keeper_registry_event_queue.reprioritize_pending_result
+      ~base_path
+      keeper_name
+      ~expected_revision
+      ~source
+      ~urgency
+  in
+  ignore
+    (Keeper_registry.wakeup_running
+       ~intent:Keeper_registry.Broadcast_signal
+       ~base_path
+       keeper_name :
+       Keeper_registry.wakeup_outcome);
+  Ok
+    ( source
+    , `Assoc
+        [ "status", `String "applied"
+        ; "revision", `String (Int64.to_string revision)
+        ] )
+;;
+
+let validate_fresh_transfer_target config target_keeper =
+  match Keeper_meta_store.read_meta config target_keeper with
+  | Error detail ->
+    Error ("target keeper metadata is unavailable: " ^ detail)
+  | Ok (Some _) -> Ok ()
+  | Ok None ->
+    let configured =
+      Keeper_meta_store.configured_keeper_names config
+      |> List.exists (String.equal target_keeper)
+    in
+    if configured
+    then Ok ()
+    else Error ("target keeper does not exist: " ^ target_keeper)
+;;
+
+let replay_committed_request ~base_path ~keeper_name request =
+  match request with
+  | Reprioritize _ -> Ok None
+  | Cancel
+      { expected_revision
+      ; queue_index = _
+      ; operator_operation_id
+      ; reason
+      } ->
+    let* queue_state =
+      Keeper_event_queue_persistence.load_state_result
+        ~base_path
+        ~keeper_name
+    in
+    let* prepared =
+      prior_cancellation_for_request
+        ~queue_state
+        ~expected_revision
+        ~operator_operation_id
+        ~reason
+    in
+    (match prepared with
+     | None -> Ok None
+     | Some prepared ->
+       execute_cancellation ~base_path ~keeper_name prepared
+       |> Result.map Option.some)
+  | Transfer
+      { expected_revision
+      ; queue_index = _
+      ; operator_operation_id
+      ; target_keeper
+      } ->
+    let* queue_state =
+      Keeper_event_queue_persistence.load_state_result
+        ~base_path
+        ~keeper_name
+    in
+    let* prepared =
+      prior_transfer_for_request
+        ~queue_state
+        ~keeper_name
+        ~expected_revision
+        ~operator_operation_id
+        ~target_keeper
+    in
+    (match prepared with
+     | None -> Ok None
+     | Some prepared ->
+       execute_transfer ~base_path ~keeper_name prepared
+       |> Result.map Option.some)
+;;
+
+let run_admitted_request
+      ~config
+      ~base_path
+      ~keeper_name
+      ~owner_nonce
+      request
+  =
+  let* queue_state =
+    Keeper_event_queue_persistence.load_state_result
+      ~base_path
+      ~keeper_name
+  in
+  match request with
+  | Cancel
+      { expected_revision
+      ; queue_index
+      ; operator_operation_id
+      ; reason
+      } ->
+    let* prior =
+      prior_cancellation_for_request
+        ~queue_state
+        ~expected_revision
+        ~operator_operation_id
+        ~reason
+    in
+    let* prepared =
+      match prior with
+      | Some prepared -> Ok prepared
+      | None ->
+        fresh_cancellation_for_request
+          ~queue_state
+          ~owner_nonce
+          ~expected_revision
+          ~queue_index
+          ~operator_operation_id
+          ~reason
+    in
+    execute_cancellation ~base_path ~keeper_name prepared
+  | Transfer
+      { expected_revision
+      ; queue_index
+      ; operator_operation_id
+      ; target_keeper
+      } ->
+    if String.equal keeper_name target_keeper
+    then Error "source and target keeper must differ"
+    else
+      let* prior =
+        prior_transfer_for_request
+          ~queue_state
+          ~keeper_name
+          ~expected_revision
+          ~operator_operation_id
+          ~target_keeper
+      in
+      let* prepared =
+        match prior with
+        | Some prepared -> Ok prepared
+        | None ->
+          let* () = validate_fresh_transfer_target config target_keeper in
+          fresh_transfer_for_request
+            ~queue_state
+            ~keeper_name
+            ~owner_nonce
+            ~expected_revision
+            ~queue_index
+            ~operator_operation_id
+            ~target_keeper
+      in
+      execute_transfer ~base_path ~keeper_name prepared
+  | Reprioritize { expected_revision; queue_index; urgency } ->
+    execute_reprioritization
+      ~base_path
+      ~keeper_name
+      ~queue_state
+      ~expected_revision
+      ~queue_index
+      ~urgency
+;;
+
+let run_fresh_request ~config ~base_path ~keeper_name request =
+  match Keeper_registry.get ~base_path keeper_name with
+  | None -> Error "keeper is not registered"
+  | Some entry ->
+    let owner_nonce = entry.meta.runtime.nonce in
+    (match
+       Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () ->
+         match Keeper_registry.get ~base_path keeper_name with
+         | None -> Error "keeper registration disappeared"
+         | Some current when current.meta.runtime.nonce <> owner_nonce ->
+           Error "keeper owner nonce changed"
+         | Some _ ->
+           run_admitted_request
+             ~config
+             ~base_path
+             ~keeper_name
+             ~owner_nonce
+             request)
+     with
+     | `Ran result -> result
+     | `Busy block ->
+       Error
+         ("keeper turn is busy: "
+          ^ Keeper_turn_admission.autonomous_block_to_string block))
+;;
+
+let run ~config ~keeper_name request =
+  let base_path = config.Workspace.base_path in
+  let* replay =
+    replay_committed_request ~base_path ~keeper_name request
+  in
+  match replay with
+  | Some result -> Ok result
+  | None ->
+    (match run_fresh_request ~config ~base_path ~keeper_name request with
+     | Ok _ as result -> result
+     | Error original_error ->
+       let* replay =
+         replay_committed_request ~base_path ~keeper_name request
+       in
+       (match replay with
+        | Some result -> Ok result
+        | None -> Error original_error))
+;;

--- a/lib/server/server_dashboard_http_keeper_event_queue_operator_execute.mli
+++ b/lib/server/server_dashboard_http_keeper_event_queue_operator_execute.mli
@@ -1,0 +1,29 @@
+type request =
+  | Cancel of
+      { expected_revision : int64
+      ; queue_index : int
+      ; operator_operation_id : string
+      ; reason : string
+      }
+  | Transfer of
+      { expected_revision : int64
+      ; queue_index : int
+      ; operator_operation_id : string
+      ; target_keeper : string
+      }
+  | Reprioritize of
+      { expected_revision : int64
+      ; queue_index : int
+      ; urgency : Keeper_event_queue.urgency
+      }
+
+val pending_source_at :
+  queue_index:int ->
+  Keeper_event_queue.t ->
+  Keeper_event_queue.stimulus option
+
+val run :
+  config:Workspace.config ->
+  keeper_name:string ->
+  request ->
+  (Keeper_event_queue.stimulus * Yojson.Safe.t, string) result

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -332,6 +332,28 @@ let test_keeper_chat_recovery_route_is_exact () =
     (contains_substring (Yojson.Safe.to_string pending_json) sensitive_content);
   check bool "event pending projection has no raw source object" true
     (pending_json |> member "source" = `Null);
+  let same_post_id_source : Keeper_event_queue.stimulus =
+    { source with urgency = Low; payload = Bootstrap }
+  in
+  let duplicate_post_id_queue =
+    Keeper_event_queue.empty
+    |> fun queue -> Keeper_event_queue.enqueue queue source
+    |> fun queue -> Keeper_event_queue.enqueue queue same_post_id_source
+  in
+  (match
+     Server_dashboard_http_keeper_event_queue_operator.For_testing.pending_source_at
+       ~queue_index:1
+       duplicate_post_id_queue
+   with
+   | Some selected ->
+     check bool
+       "event selection uses revision-fenced queue position, not ambiguous post id"
+       true
+       (Keeper_event_queue.stimulus_identity_equal
+          same_post_id_source
+          selected)
+   | None ->
+     fail "event selection must address duplicate post ids independently");
   let quarantine_path =
     "/api/v1/keepers/idealist/board-attention/quarantines/ba-root-123/recovery"
   in

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -168,6 +168,18 @@ let test_projected_disposition_ledger_replays_older_operation () =
     |> require_ok "reload projected disposition ledger"
   in
   (match
+     State.prior_disposition_by_operation_id
+       cancellation.operator_operation_id
+       reloaded
+   with
+   | Some receipt ->
+     Alcotest.(check string)
+       "older operation is directly recoverable by durable operation identity"
+       cancel_receipt.transition_id
+       receipt.transition_id
+   | None ->
+     Alcotest.fail "older operation disappeared from durable disposition lookup");
+  (match
      State.cancel_pending_accepted
        ~current_owner_nonce:7
        ~applied_at:5.0
@@ -250,8 +262,10 @@ let test_durable_peek_ack_restart () =
 let test_durable_reprioritize_is_revision_fenced () =
   with_temp_dir "keeper-event-reprioritize" (fun base_path ->
     let keeper_name = "priority-keeper" in
-    let first = stimulus "first" 1.0 in
-    let second = stimulus "second" 2.0 in
+    let first = stimulus "shared-post" 1.0 in
+    let second =
+      { (stimulus "shared-post" 2.0) with urgency = Queue.Low }
+    in
     Persistence.update_result ~base_path ~keeper_name (fun pending ->
       let pending = Queue.enqueue pending first in
       Queue.enqueue pending second)
@@ -280,9 +294,14 @@ let test_durable_reprioritize_is_revision_fenced () =
       |> require_ok "restart priority load"
     in
     Alcotest.(check (list string))
-      "priority change survives restart"
-      [ "second"; "first" ]
+      "same post id remains independently addressable"
+      [ "shared-post"; "shared-post" ]
       (post_ids restarted);
+    Alcotest.(check (list (float 0.0)))
+      "priority change preserves the distinct same-post source"
+      [ 2.0; 1.0 ]
+      (Queue.to_list restarted
+       |> List.map (fun (item : Queue.stimulus) -> item.arrived_at));
     match
       Persistence.reprioritize_pending_result
         ~base_path


### PR DESCRIPTION
## 문제

병합된 #26434의 event operator 경계에 두 결함이 남아 있었어용.

- `post_id`는 queue identity가 아닌데 cancel/transfer/reprioritize가 이를 단독 선택자로 사용해 같은 post의 서로 다른 stimulus를 구분하지 못했습니다.
- cancel/transfer는 durable operation receipt를 기록하지만 Dashboard가 operation ID를 오류 뒤 버려 응답 유실·target projection 실패를 동일 작업으로 복구할 수 없었습니다.
- Admin pagination은 revision drift를 정확성 실패로 내지 않고 고정 3회 재시도했습니다.

## 변경

- `revision + queue_index`로 exact typed source를 다시 해석하고, reprioritize는 exact stimulus 하나만 변경합니다.
- cancel/transfer는 durable prior disposition을 admission 전후에 조회해 동일 operation replay를 복구합니다.
- source commit 후 target projection 실패를 typed committed follow-up으로 표면화합니다.
- Dashboard 오류가 정확한 operation ID를 보존하고 사용자가 동일 작업을 명시적으로 재시도할 수 있게 했습니다. 자동 재시도는 없습니다.
- pagination은 한 revision의 완전한 snapshot만 반환하고 drift 시 즉시 실패합니다.

migration, legacy decoder, 새 Gate, facade-from-facade는 추가하지 않았어용.

## 검증

대상 head: `dd781fecb0c4fbf25a5c9ed52dfb1fb98b0199ff`

- changed OCaml parse / ocamlformat check 통과
- OCaml structure / stringly boundary / silent failure ratchet 통과
- Dashboard TypeScript / lint 통과
- 집중 Vitest 4 files / 213 tests 통과
- `git diff --check` 통과
- 로컬 Dune은 실행하지 않았고 CI를 build/test authority로 사용합니다.