### PR TITLE
fix(keeper): repair current event hard-cut stack

### DIFF
--- a/test/test_keeper_manual_compaction_preemption.ml
+++ b/test/test_keeper_manual_compaction_preemption.ml
@@ -174,7 +174,7 @@ let test_owner_intake_compacts_then_resumes_source () =
       check string
         "manual compaction is selected ahead of the source"
         Q.manual_compaction_post_id
-        selected.post_id;
+        selected.source.post_id;
       selected
     | None -> fail "manual compaction preemption selected no source"
   in
@@ -203,7 +203,7 @@ let test_owner_intake_compacts_then_resumes_source () =
     check string
       "the exact original source resumes after compaction"
       source.post_id
-      selected.post_id
+      selected.source.post_id
   | None -> fail "the original source disappeared after manual compaction"
 ;;
 

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -335,7 +335,10 @@ let () =
       meta_fixture_exn
         (`Assoc
           [ "name", `String "corrupted-transcript"
-          ; "agent_name", `String (Keeper_identity.keeper_agent_name "corrupted-transcript")
+          ; ( "agent_name"
+            , `String
+                (Masc.Keeper_identity.keeper_agent_name
+                   "corrupted-transcript") )
           ; "trace_id", `String "trace-corrupted-transcript"
           ])
     in
@@ -380,7 +383,7 @@ let () =
           [ "name", `String "replaced-transcript-owner"
           ; ( "agent_name"
             , `String
-                (Keeper_identity.keeper_agent_name
+                (Masc.Keeper_identity.keeper_agent_name
                    "replaced-transcript-owner") )
           ; "trace_id", `String "trace-replaced-transcript-owner-old"
           ])


### PR DESCRIPTION
## 원인

current hard-cut 뒤 세 종류의 문제가 한 stack에 남았습니다.

- Librarian.input fixture가 삭제된 trace_id 필드를 구성
- v14 pending selection/wrapped module fixture 및 event selection facade 선언이 current 타입과 불일치
- fresh cancel/transfer가 queue-wide revision fence를 제거해 동일 admitted_revision을 가진 다른 source를 stale queue_index로 오인 가능

## 변경

- Librarian fixture를 Ids.Turn_ref로 정렬
- v14 pending_selection.source 및 wrapped Keeper_identity 경계 사용
- 중복 event selection facade 선언/테스트 제거
- fresh event mutation에 expected_revision + queue_index + source_incarnation fence 적용
- committed replay만 durable operation receipt authority로 snapshot revision을 무시
- migration, fallback, string heuristic, 신규 Facade/Gate 없음

## 검증

- touched OCaml: parser, ocamlformat, git diff check PASS
- Dashboard tsc --noEmit PASS
- focused Vitest: 2 files, 92 tests PASS
- ESLint: configured match 없음으로 4 ignored warnings, error 0
- 로컬 Dune 미실행; GitHub Build and Test를 권위로 사용

## 병합 순서

이 PR은 #26458 브랜치 위의 repair입니다. exact-head CI 통과 후 #26458 브랜치에 먼저 병합하고, 이동한 #26458 head의 전체 CI를 다시 통과시킨 뒤 main에 병합합니다.