### PR TITLE
fix(keeper): recover durable transfer target projections

### DIFF
--- a/lib/keeper/keeper_event_queue_recovery.ml
+++ b/lib/keeper/keeper_event_queue_recovery.ml
@@ -191,6 +191,7 @@ let project_claimed_owner owner =
              Keeper_reaction_ledger.project_event_queue_transition_outbox_result
                ~base_path
                ~keeper_name
+               ~expected_transition_id:entry.receipt.transition_id
            with
            | Ok () -> Ok Transition_converged
            | Error detail -> Error (Ledger_projection_failed detail))))

--- a/lib/keeper/keeper_event_queue_recovery.ml
+++ b/lib/keeper/keeper_event_queue_recovery.ml
@@ -18,6 +18,10 @@ type projection_error =
   | Owner_unavailable of Persistence.owner_identity_error
   | Executor_unavailable of Executor_pool_ref.strict_submit_error
   | Outbox_unavailable of string
+  | Target_transfer_projection_failed of
+      { target_keeper : string
+      ; detail : string
+      }
   | Ledger_projection_failed of string
   | Unexpected_projection_failure of Eio.Exn.with_bt
 
@@ -65,6 +69,11 @@ let projection_error_to_string = function
     ^ Executor_pool_ref.strict_submit_error_to_string error
   | Outbox_unavailable detail ->
     "event queue transition outbox unavailable: " ^ detail
+  | Target_transfer_projection_failed { target_keeper; detail } ->
+    Printf.sprintf
+      "event queue transfer target projection failed target_keeper=%s: %s"
+      target_keeper
+      detail
   | Ledger_projection_failed detail ->
     "event queue transition ledger projection failed: " ^ detail
   | Unexpected_projection_failure (exn, backtrace) ->
@@ -135,6 +144,33 @@ let with_owner_claim owner f =
       (fun () -> Owner_claim_acquired (f ()))
 ;;
 
+let project_transfer_target_result ~base_path (entry : Persistence.outbox_entry) =
+  match entry.receipt.transition with
+  | Persistence.Cancel_accepted _
+  | Persistence.Ack_source_terminal _ ->
+    Ok ()
+  | Persistence.Transfer_accepted transfer ->
+    (match
+       Keeper_registry_event_queue.project_accepted_transfer_durable_result
+         ~base_path
+         transfer.to_keeper
+         ~transfer
+     with
+     | Keeper_registry_event_queue.Stimulus_enqueued
+     | Keeper_registry_event_queue.Stimulus_already_present ->
+       ignore
+         (Keeper_registry.wakeup_running
+            ~intent:Keeper_registry.Broadcast_signal
+            ~base_path
+            transfer.to_keeper :
+            Keeper_registry.wakeup_outcome);
+       Ok ()
+     | Keeper_registry_event_queue.Stimulus_storage_error detail ->
+       Error
+         (Target_transfer_projection_failed
+            { target_keeper = transfer.to_keeper; detail }))
+;;
+
 let project_claimed_owner owner =
   let base_path = Persistence.owner_identity_base_path owner in
   let keeper_name = Persistence.owner_identity_keeper_name owner in
@@ -147,14 +183,17 @@ let project_claimed_owner owner =
   | Ok state ->
     (match Keeper_event_queue_state.transition_outbox state with
      | [] -> Ok No_pending_transition
-     | _ :: _ ->
-       (match
-          Keeper_reaction_ledger.project_event_queue_transition_outbox_result
-            ~base_path
-            ~keeper_name
-        with
-        | Ok () -> Ok Transition_converged
-        | Error detail -> Error (Ledger_projection_failed detail)))
+     | entry :: _ ->
+       (match project_transfer_target_result ~base_path entry with
+        | Error _ as error -> error
+        | Ok () ->
+          (match
+             Keeper_reaction_ledger.project_event_queue_transition_outbox_result
+               ~base_path
+               ~keeper_name
+           with
+           | Ok () -> Ok Transition_converged
+           | Error detail -> Error (Ledger_projection_failed detail))))
 ;;
 
 let project_resolved_owner owner =

--- a/lib/keeper/keeper_event_queue_recovery.mli
+++ b/lib/keeper/keeper_event_queue_recovery.mli
@@ -2,8 +2,9 @@
 
     The process-local owner claim only suppresses overlapping work in this
     process. It is not a durable lease or a physical exactly-once guarantee.
-    Cross-process and crash retries converge through the reaction ledger's
-    stable per-source event ids, then retire the matching durable outbox. *)
+    Cross-process and crash retries converge accepted-transfer target
+    projections and the reaction ledger's stable per-source event ids before
+    retiring the matching durable outbox. *)
 
 type projection_outcome =
   | No_pending_transition
@@ -14,6 +15,10 @@ type projection_error =
   | Owner_unavailable of Keeper_event_queue_persistence.owner_identity_error
   | Executor_unavailable of Executor_pool_ref.strict_submit_error
   | Outbox_unavailable of string
+  | Target_transfer_projection_failed of
+      { target_keeper : string
+      ; detail : string
+      }
   | Ledger_projection_failed of string
   | Unexpected_projection_failure of Eio.Exn.with_bt
 
@@ -63,8 +68,9 @@ val project_owner_result :
   base_path:string ->
   keeper_name:string ->
   (projection_outcome, projection_error) result
-(** Acquire the process-local owner claim, inspect the durable outbox, and
-    invoke the canonical reaction-ledger projector when work is present.
+(** Acquire the process-local owner claim and inspect the durable outbox.
+    Accepted transfers first converge the exact target projection; only then
+    does the canonical reaction-ledger projector retire the source outbox.
     Durable I/O runs outside the claim-table mutex and without cancellation
     masking, and requires the startup executor pool; it is never run inline.
     [Transition_converged] does not identify which process performed the

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -362,12 +362,27 @@ let after_ledger_append_hook :
 
 let after_ledger_append_hook_mutex = Stdlib.Mutex.create ()
 
-let project_event_queue_transition_outbox_result ~base_path ~keeper_name =
+let project_event_queue_transition_outbox_result
+      ~base_path
+      ~keeper_name
+      ~expected_transition_id
+  =
   let ( let* ) = Result.bind in
   Keeper_event_queue_persistence.project_transition_outbox_result
     ~append_before_retire:(fun
         (entry : Keeper_event_queue_state.outbox_entry)
       ->
+      let* () =
+        if String.equal expected_transition_id entry.receipt.transition_id
+        then Ok ()
+        else
+          Error
+            (Printf.sprintf
+               "event queue transition changed before ledger projection keeper=%s expected_transition_id=%s current_transition_id=%s"
+               keeper_name
+               expected_transition_id
+               entry.receipt.transition_id)
+      in
       match entry.stimuli with
       | [] ->
         Error

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -68,13 +68,18 @@ val record_event_queue_turn_started :
     reaction kind so callers cannot manufacture transition evidence. *)
 
 val project_event_queue_transition_outbox_result :
-  base_path:string -> keeper_name:string -> (unit, string) result
+  base_path:string ->
+  keeper_name:string ->
+  expected_transition_id:string ->
+  (unit, string) result
 (** Read the sole durable event-queue transition outbox, append every source in
-    exact order, then retire that same transition. Callers supply no receipt,
-    stimulus, source index, or outbox record, so transition evidence can only
-    originate from the event-queue SSOT. Persistence failures remain explicit
-    [Error]. Retries are logically idempotent through deterministic per-source
-    event ids. *)
+    exact order, then retire that same transition. [expected_transition_id]
+    binds the outbox read to the transfer whose target the recovery caller
+    already projected; a newer transition remains authoritative. Callers
+    supply no receipt, stimulus, source index, or outbox record, so transition
+    evidence can only originate from the event-queue SSOT. Persistence failures
+    remain explicit [Error]. Retries are logically idempotent through
+    deterministic per-source event ids. *)
 
 type event_queue_reaction_evidence =
   { keeper_name : string

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -160,6 +160,56 @@ let project_transition_canonically ~base_path ~keeper_name ~transition_id:_ =
   | Ok _ -> Error "canonical transition projection did not converge"
   | Error _ -> Error "canonical transition projection failed"
 
+let load_queue_state ~base_path ~keeper_name =
+  match
+    Keeper_event_queue_persistence.load_state_result ~base_path ~keeper_name
+  with
+  | Ok state -> state
+  | Error detail -> Alcotest.fail detail
+
+let stage_transfer ~base_path ~from_keeper ~to_keeper ~source ~owner_nonce ~operation_id =
+  (match
+     Masc.Keeper_registry_event_queue.enqueue_stimulus_durable_result
+       ~base_path
+       from_keeper
+       source
+   with
+   | Masc.Keeper_registry_event_queue.Stimulus_enqueued -> ()
+   | _ -> Alcotest.fail "failed to seed transfer recovery source");
+  let selection =
+    load_queue_state ~base_path ~keeper_name:from_keeper
+    |> Keeper_event_queue_state.select_when
+         ~ready:(Keeper_event_queue.stimulus_identity_equal source)
+    |> function
+    | Some selection -> selection
+    | None -> Alcotest.fail "transfer recovery source was not selectable"
+  in
+  let transfer : Keeper_event_queue_persistence.accepted_transfer =
+    { source = selection.source
+    ; source_incarnation = selection.admitted_revision
+    ; owner_nonce
+    ; operator_operation_id = operation_id
+    ; from_keeper
+    ; to_keeper
+    }
+  in
+  (match
+     Masc.Keeper_registry_event_queue.transfer_pending_accepted_result
+       ~base_path
+       from_keeper
+       ~current_owner_nonce:owner_nonce
+       ~applied_at:101.0
+       ~transfer
+   with
+   | Ok (Masc.Keeper_registry_event_queue.Transition_applied _) -> ()
+   | Ok (Masc.Keeper_registry_event_queue.Transition_already_applied _) ->
+     Alcotest.fail "first transfer recovery transition was already applied"
+   | Ok
+       (Masc.Keeper_registry_event_queue.Transition_committed_followup_failed
+          { detail; _ }) ->
+     Alcotest.fail detail
+   | Error detail -> Alcotest.fail detail)
+
 let () =
   let open Keeper_event_queue in
   let board_payload () =
@@ -829,6 +879,109 @@ let () =
       assert (String.equal second.post_id "bootstrap");
       Keeper_event_queue_persistence.persist ~base_path ~keeper_name rest;
       assert (is_empty (Keeper_event_queue_persistence.load ~base_path ~keeper_name)));
+
+  (* --- transfer recovery: the source outbox is not retired until the exact
+         target projection is durable, so a lost HTTP recovery operation is
+         repaired by the canonical maintenance sweep. --- *)
+  let base_path = temp_dir "keeper-event-queue-transfer-recovery" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_registry.For_testing.clear ();
+      rm_rf base_path)
+    (fun () ->
+      let from_keeper = "keeper-transfer-recovery-source" in
+      let to_keeper = "keeper-transfer-recovery-target" in
+      stage_transfer
+        ~base_path
+        ~from_keeper
+        ~to_keeper
+        ~source:board_stim
+        ~owner_nonce:23
+        ~operation_id:"recover-transfer-target";
+      Alcotest.(check int)
+        "source outbox awaits target projection"
+        1
+        (load_queue_state ~base_path ~keeper_name:from_keeper
+         |> Keeper_event_queue_state.transition_outbox
+         |> List.length);
+      Alcotest.(check int)
+        "target is empty before recovery"
+        0
+        (registry_snapshot ~base_path to_keeper |> Keeper_event_queue.length);
+      (match
+         project_transition_canonically
+           ~base_path
+           ~keeper_name:from_keeper
+           ~transition_id:"unused"
+       with
+       | Ok () -> ()
+       | Error detail -> Alcotest.fail detail);
+      let recovered_target = load_queue_state ~base_path ~keeper_name:to_keeper in
+      Alcotest.(check int)
+        "source outbox retires after target projection"
+        0
+        (load_queue_state ~base_path ~keeper_name:from_keeper
+         |> Keeper_event_queue_state.transition_outbox
+         |> List.length);
+      Alcotest.(check int)
+        "target receives the exact transferred source"
+        1
+        (Keeper_event_queue_state.pending recovered_target |> Keeper_event_queue.length);
+      Alcotest.(check int)
+        "target accounts the transfer operation durably"
+        1
+        (Keeper_event_queue_state.accepted_transfer_projections recovered_target
+         |> List.length));
+
+  (* --- transfer recovery failure: target storage failure is typed and keeps
+         the source outbox authoritative for a later retry. --- *)
+  let base_path = temp_dir "keeper-event-queue-transfer-recovery-failure" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_path)
+    (fun () ->
+      let from_keeper = "keeper-transfer-recovery-failure-source" in
+      let to_keeper = "keeper-transfer-recovery-failure-target" in
+      stage_transfer
+        ~base_path
+        ~from_keeper
+        ~to_keeper
+        ~source:board_stim
+        ~owner_nonce:29
+        ~operation_id:"recover-transfer-target-failure";
+      let target_path =
+        Filename.concat
+          (Common.keepers_runtime_dir_of_base ~base_path)
+          to_keeper
+      in
+      write_file target_path "directory blocker";
+      (match
+         with_strict_executor
+         @@ fun () ->
+         Masc.Keeper_event_queue_recovery.project_owner_result
+           ~base_path
+           ~keeper_name:from_keeper
+       with
+       | Error
+           (Masc.Keeper_event_queue_recovery.Target_transfer_projection_failed
+              { target_keeper; detail }) ->
+         Alcotest.(check string)
+           "typed target keeper"
+           to_keeper
+           target_keeper;
+         Alcotest.(check bool)
+           "typed storage detail"
+           true
+           (String.length detail > 0)
+       | Error error ->
+         Alcotest.fail
+           (Masc.Keeper_event_queue_recovery.projection_error_to_string error)
+       | Ok _ -> Alcotest.fail "target storage failure retired the source outbox");
+      Alcotest.(check int)
+        "failed target projection retains source outbox"
+        1
+        (load_queue_state ~base_path ~keeper_name:from_keeper
+         |> Keeper_event_queue_state.transition_outbox
+         |> List.length));
 
   (* --- current-only hard cut: the retired v12 filename is not a read,
          migration, or overwrite source for the v14 queue. --- *)

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -145,9 +145,6 @@ let with_strict_executor f =
     (Domain_pool.executor_pool pool)
     f
 
-(* [claim_single] and [settle_and_project] built and settled leases for the
-   blocks removed above. *)
-
 let project_transition_canonically ~base_path ~keeper_name ~transition_id:_ =
   with_strict_executor
   @@ fun () ->
@@ -982,6 +979,73 @@ let () =
         (load_queue_state ~base_path ~keeper_name:from_keeper
          |> Keeper_event_queue_state.transition_outbox
          |> List.length));
+
+  (* --- a stale recovery worker cannot retire a newer transfer after it
+         projected the target for an earlier transition. --- *)
+  let base_path = temp_dir "keeper-event-queue-transfer-recovery-stale-worker" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_path)
+    (fun () ->
+      let from_keeper = "keeper-transfer-recovery-stale-source" in
+      let to_keeper = "keeper-transfer-recovery-stale-target" in
+      stage_transfer
+        ~base_path
+        ~from_keeper
+        ~to_keeper
+        ~source:board_stim
+        ~owner_nonce:31
+        ~operation_id:"recover-transfer-first";
+      let first_transition_id =
+        match
+          load_queue_state ~base_path ~keeper_name:from_keeper
+          |> Keeper_event_queue_state.transition_outbox
+        with
+        | [ entry ] -> entry.receipt.transition_id
+        | _ -> Alcotest.fail "first transfer did not stage one outbox entry"
+      in
+      (match
+         Masc.Keeper_reaction_ledger.project_event_queue_transition_outbox_result
+           ~base_path
+           ~keeper_name:from_keeper
+           ~expected_transition_id:first_transition_id
+       with
+       | Ok () -> ()
+       | Error detail -> Alcotest.fail detail);
+      stage_transfer
+        ~base_path
+        ~from_keeper
+        ~to_keeper
+        ~source:bootstrap_stim
+        ~owner_nonce:31
+        ~operation_id:"recover-transfer-second";
+      let second_transition_id =
+        match
+          load_queue_state ~base_path ~keeper_name:from_keeper
+          |> Keeper_event_queue_state.transition_outbox
+        with
+        | [ entry ] -> entry.receipt.transition_id
+        | _ -> Alcotest.fail "second transfer did not stage one outbox entry"
+      in
+      (match
+         Masc.Keeper_reaction_ledger.project_event_queue_transition_outbox_result
+           ~base_path
+           ~keeper_name:from_keeper
+           ~expected_transition_id:first_transition_id
+       with
+       | Error _ -> ()
+       | Ok () -> Alcotest.fail "stale recovery retired the newer transfer");
+      let retained_transition_id =
+        match
+          load_queue_state ~base_path ~keeper_name:from_keeper
+          |> Keeper_event_queue_state.transition_outbox
+        with
+        | [ entry ] -> entry.receipt.transition_id
+        | _ -> Alcotest.fail "stale recovery did not preserve one outbox entry"
+      in
+      Alcotest.(check string)
+        "newer transfer remains authoritative"
+        second_transition_id
+        retained_transition_id);
 
   (* --- current-only hard cut: the retired v12 filename is not a read,
          migration, or overwrite source for the v14 queue. --- *)


### PR DESCRIPTION
## 요약

- source v14 transition outbox의 `Transfer_accepted` receipt로 target projection을 maintenance sweep에서 먼저 수렴시킵니다.
- target durable commit 뒤에만 reaction ledger 기록과 source outbox retirement를 허용합니다.
- target 저장 실패는 typed `Target_transfer_projection_failed`로 반환하고 source outbox를 보존합니다.
- 성공·실패 회귀 테스트를 추가했습니다.

## 검증

- `ocamlc -stop-after parsing` (touched OCaml files)
- `ocamlformat --check` (touched OCaml files)
- `git diff --check`
- 로컬 Dune 미실행: PR CI가 build/test 권위입니다.

## Stack

- Base: #26458 exact head `e22ef6712b5acfd7052494ca14af62dbab05512c`
- Resolves #26460 after merge
