### PR TITLE
fix(keeper): target exact event sources without queue gates

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -505,6 +505,8 @@ describe('Keeper chat durable receipt API', () => {
     const item = (queueIndex: number, postId: string) => ({
       queue_index: queueIndex,
       post_id: postId,
+      source_ref: (queueIndex === 0 ? 'a' : 'b').repeat(64),
+      source_incarnation: String(queueIndex + 17),
       urgency: 'normal',
       arrived_at_unix: 42,
       payload_kind: 'bootstrap',
@@ -514,7 +516,7 @@ describe('Keeper chat durable receipt API', () => {
       postId: string,
       nextAfter: string | null,
     ) => ({
-      schema: 'keeper_event_queue.pending.v1',
+      schema: 'keeper_event_queue.pending.v2',
       ok: true,
       keeper_name: 'sangsu',
       revision: '31',
@@ -536,7 +538,7 @@ describe('Keeper chat durable receipt API', () => {
     const result = await fetchKeeperEventQueuePending('sangsu')
 
     expect(result).toEqual(parseKeeperEventQueuePendingSnapshot({
-      schema: 'keeper_event_queue.pending.v1',
+      schema: 'keeper_event_queue.pending.v2',
       ok: true,
       keeper_name: 'sangsu',
       revision: '31',
@@ -561,7 +563,7 @@ describe('Keeper chat durable receipt API', () => {
 
   it('rejects event pagination revision drift without a fixed retry loop', async () => {
     const envelope = (revision: string, queueIndex: number, nextAfter: string | null) => ({
-      schema: 'keeper_event_queue.pending.v1',
+      schema: 'keeper_event_queue.pending.v2',
       ok: true,
       keeper_name: 'sangsu',
       revision,
@@ -570,6 +572,8 @@ describe('Keeper chat durable receipt API', () => {
       pending: [{
         queue_index: queueIndex,
         post_id: `post-${revision}`,
+        source_ref: 'c'.repeat(64),
+        source_incarnation: revision,
         urgency: 'normal',
         arrived_at_unix: 42,
         payload_kind: 'bootstrap',
@@ -655,8 +659,8 @@ describe('Keeper chat durable receipt API', () => {
 
     await operateKeeperEventQueue('sangsu', {
       action: 'reprioritize',
-      expectedRevision: '7',
-      queueIndex: 0,
+      sourceIncarnation: '7',
+      sourceRef: 'd'.repeat(64),
       urgency: 'immediate',
     })
 
@@ -664,10 +668,10 @@ describe('Keeper chat durable receipt API', () => {
       '/api/v1/keepers/sangsu/events/operator',
       expect.objectContaining({
         body: JSON.stringify({
-          schema: 'keeper_event_queue.operator.request.v1',
+          schema: 'keeper_event_queue.operator.request.v2',
           action: 'reprioritize',
-          expected_revision: '7',
-          queue_index: 0,
+          source_incarnation: '7',
+          source_ref: 'd'.repeat(64),
           urgency: 'immediate',
         }),
       }),
@@ -695,10 +699,10 @@ describe('Keeper chat durable receipt API', () => {
     try {
       await operateKeeperEventQueue('sangsu', {
         action: 'cancel',
-        expectedRevision: '8',
         operationId: 'operation-9',
-        queueIndex: 1,
         reason: 'operator cancellation',
+        sourceIncarnation: '8',
+        sourceRef: 'e'.repeat(64),
       })
     } catch (cause) {
       observed = cause
@@ -709,10 +713,10 @@ describe('Keeper chat durable receipt API', () => {
       commitState: 'committed',
       operation: {
         action: 'cancel',
-        expectedRevision: '8',
         operationId: 'operation-9',
-        queueIndex: 1,
         reason: 'operator cancellation',
+        sourceIncarnation: '8',
+        sourceRef: 'e'.repeat(64),
       },
     })
     expect((observed as Error).message).toContain(
@@ -733,8 +737,8 @@ describe('Keeper chat durable receipt API', () => {
     try {
       await operateKeeperEventQueue('sangsu', {
         action: 'transfer',
-        expectedRevision: '9',
-        queueIndex: 2,
+        sourceIncarnation: '9',
+        sourceRef: 'f'.repeat(64),
         targetKeeper: 'rondo',
       })
     } catch (cause) {
@@ -746,9 +750,9 @@ describe('Keeper chat durable receipt API', () => {
       commitState: 'unknown',
       operation: {
         action: 'transfer',
-        expectedRevision: '9',
         operationId: '00000000-0000-4000-8000-000000000099',
-        queueIndex: 2,
+        sourceIncarnation: '9',
+        sourceRef: 'f'.repeat(64),
         targetKeeper: 'rondo',
       },
     })
@@ -756,10 +760,10 @@ describe('Keeper chat durable receipt API', () => {
       '/api/v1/keepers/sangsu/events/operator',
       expect.objectContaining({
         body: JSON.stringify({
-          schema: 'keeper_event_queue.operator.request.v1',
+          schema: 'keeper_event_queue.operator.request.v2',
           action: 'transfer',
-          expected_revision: '9',
-          queue_index: 2,
+          source_incarnation: '9',
+          source_ref: 'f'.repeat(64),
           operator_operation_id: '00000000-0000-4000-8000-000000000099',
           target_keeper: 'rondo',
         }),

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -787,6 +787,8 @@ export interface KeeperChatPendingMutationResult {
 export interface KeeperEventQueuePendingItem {
   queueIndex: number
   postId: string
+  sourceRef: string
+  sourceIncarnation: string
   urgency: 'immediate' | 'normal' | 'low'
   arrivedAt: number
   payloadKind: string
@@ -1114,7 +1116,7 @@ export function parseKeeperEventQueuePendingSnapshot(
 ): KeeperEventQueuePendingSnapshot {
   if (
     !isRecord(value)
-    || value.schema !== 'keeper_event_queue.pending.v1'
+    || value.schema !== 'keeper_event_queue.pending.v2'
     || value.ok !== true
   ) {
     throw new Error('Keeper event pending response has an unsupported schema')
@@ -1142,6 +1144,8 @@ export function parseKeeperEventQueuePendingSnapshot(
     }
     const queueIndex = asNumber(raw.queue_index)
     const postId = asString(raw.post_id, '').trim()
+    const sourceRef = asString(raw.source_ref, '').trim()
+    const sourceIncarnation = parseKeeperQueueRevision(raw.source_incarnation)
     const urgency = asString(raw.urgency, '').trim()
     const arrivedAt = asNumber(raw.arrived_at_unix)
     const payloadKind = asString(raw.payload_kind, '').trim()
@@ -1150,6 +1154,8 @@ export function parseKeeperEventQueuePendingSnapshot(
       || !Number.isSafeInteger(queueIndex)
       || queueIndex < 0
       || !postId
+      || !/^[0-9a-f]{64}$/.test(sourceRef)
+      || sourceIncarnation === undefined
       || !['immediate', 'normal', 'low'].includes(urgency)
       || typeof arrivedAt !== 'number'
       || !Number.isFinite(arrivedAt)
@@ -1161,6 +1167,8 @@ export function parseKeeperEventQueuePendingSnapshot(
     return {
       queueIndex,
       postId,
+      sourceRef,
+      sourceIncarnation,
       urgency: urgency as KeeperEventQueuePendingItem['urgency'],
       arrivedAt,
       payloadKind,
@@ -1366,13 +1374,13 @@ export async function moveKeeperChatPendingReceiptToEnd(
 }
 
 export type KeeperEventQueueOperatorAction =
-  | { action: 'cancel'; expectedRevision: string; queueIndex: number; reason: string; operationId?: string }
-  | { action: 'transfer'; expectedRevision: string; queueIndex: number; targetKeeper: string; operationId?: string }
-  | { action: 'reprioritize'; expectedRevision: string; queueIndex: number; urgency: 'immediate' | 'normal' | 'low' }
+  | { action: 'cancel'; sourceRef: string; sourceIncarnation: string; reason: string; operationId?: string }
+  | { action: 'transfer'; sourceRef: string; sourceIncarnation: string; targetKeeper: string; operationId?: string }
+  | { action: 'reprioritize'; sourceRef: string; sourceIncarnation: string; urgency: 'immediate' | 'normal' | 'low' }
 
 export type KeeperEventQueueReplayableAction =
-  | { action: 'cancel'; expectedRevision: string; queueIndex: number; reason: string; operationId: string }
-  | { action: 'transfer'; expectedRevision: string; queueIndex: number; targetKeeper: string; operationId: string }
+  | { action: 'cancel'; sourceRef: string; sourceIncarnation: string; reason: string; operationId: string }
+  | { action: 'transfer'; sourceRef: string; sourceIncarnation: string; targetKeeper: string; operationId: string }
 
 type PreparedKeeperEventQueueOperatorAction =
   | KeeperEventQueueReplayableAction
@@ -1425,10 +1433,10 @@ export async function operateKeeperEventQueue(
 ): Promise<void> {
   const prepared = prepareKeeperEventQueueOperatorAction(operation)
   const common = {
-    schema: 'keeper_event_queue.operator.request.v1',
+    schema: 'keeper_event_queue.operator.request.v2',
     action: prepared.action,
-    expected_revision: prepared.expectedRevision,
-    queue_index: prepared.queueIndex,
+    source_incarnation: prepared.sourceIncarnation,
+    source_ref: prepared.sourceRef,
   }
   const request = prepared.action === 'cancel'
     ? {

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -25,10 +25,10 @@ const {
   KeeperEventQueueOperationError: class KeeperEventQueueOperationError extends Error {
     readonly operation: {
       action: 'cancel' | 'transfer'
-      expectedRevision: string
-      queueIndex: number
       operationId: string
       reason?: string
+      sourceIncarnation: string
+      sourceRef: string
       targetKeeper?: string
     }
     readonly commitState: 'committed' | 'unknown'
@@ -37,10 +37,10 @@ const {
       message: string,
       operation: {
         action: 'cancel' | 'transfer'
-        expectedRevision: string
-        queueIndex: number
         operationId: string
         reason?: string
+        sourceIncarnation: string
+        sourceRef: string
         targetKeeper?: string
       },
       commitState: 'committed' | 'unknown',
@@ -1017,6 +1017,8 @@ describe('KeeperConversationPanel', () => {
       pending: [{
         queueIndex: 0,
         postId: 'board-post-9',
+        sourceIncarnation: '9',
+        sourceRef: 'a'.repeat(64),
         urgency: 'normal',
         arrivedAt: 41,
         payloadKind: 'board_signal',
@@ -1088,6 +1090,8 @@ describe('KeeperConversationPanel', () => {
       pending: [{
         queueIndex: 0,
         postId: 'board-post-9',
+        sourceIncarnation: '9',
+        sourceRef: 'a'.repeat(64),
         urgency: 'normal',
         arrivedAt: 41,
         payloadKind: 'board_signal',
@@ -1106,9 +1110,9 @@ describe('KeeperConversationPanel', () => {
     }
     const recoveryOperation = {
       action: 'transfer' as const,
-      expectedRevision: '9',
-      queueIndex: 0,
       operationId: 'operation-replay-9',
+      sourceIncarnation: '9',
+      sourceRef: 'a'.repeat(64),
       targetKeeper: 'rondo',
     }
     operateKeeperEventQueue

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -768,7 +768,7 @@ function KeeperQueueControlPanel({
       <div class="flex items-center justify-between gap-2">
         <div>
           <div class="text-sm font-semibold text-[var(--color-fg-primary)]">운영자 대기열 제어</div>
-          <div class="text-2xs text-[var(--color-fg-muted)]">durable SSOT · pending만 변경 · revision 충돌 시 거부</div>
+          <div class="text-2xs text-[var(--color-fg-muted)]">서버에 저장된 대기 항목만 안전하게 변경합니다.</div>
         </div>
         <${GhostButton} onClick=${onClose}>닫기<//>
       </div>
@@ -852,7 +852,7 @@ function KeeperQueueControlPanel({
           `
         })}
         ${eventRows.map(item => {
-          const key = `event:${eventSnapshot!.revision}:${item.queueIndex}`
+          const key = `event:${item.sourceRef}`
           const busy = pendingAction === key
           return html`
             <div class="grid gap-1 rounded-[var(--r-0)] border border-[var(--color-border-subtle)] p-2" data-operator-event-row>
@@ -867,8 +867,8 @@ function KeeperQueueControlPanel({
                     onClick=${() => {
                       void mutateEvent(key, {
                         action: 'reprioritize',
-                        expectedRevision: eventSnapshot!.revision,
-                        queueIndex: item.queueIndex,
+                        sourceIncarnation: item.sourceIncarnation,
+                        sourceRef: item.sourceRef,
                         urgency,
                       })
                     }}
@@ -883,8 +883,8 @@ function KeeperQueueControlPanel({
                     if (targetKeeper === null) return
                     void mutateEvent(key, {
                       action: 'transfer',
-                      expectedRevision: eventSnapshot!.revision,
-                      queueIndex: item.queueIndex,
+                      sourceIncarnation: item.sourceIncarnation,
+                      sourceRef: item.sourceRef,
                       targetKeeper,
                     })
                   }}
@@ -898,8 +898,8 @@ function KeeperQueueControlPanel({
                     if (reason === null) return
                     void mutateEvent(key, {
                       action: 'cancel',
-                      expectedRevision: eventSnapshot!.revision,
-                      queueIndex: item.queueIndex,
+                      sourceIncarnation: item.sourceIncarnation,
+                      sourceRef: item.sourceRef,
                       reason,
                     })
                   }}

--- a/lib/keeper/keeper_event_queue_recovery.ml
+++ b/lib/keeper/keeper_event_queue_recovery.ml
@@ -18,6 +18,10 @@ type projection_error =
   | Owner_unavailable of Persistence.owner_identity_error
   | Executor_unavailable of Executor_pool_ref.strict_submit_error
   | Outbox_unavailable of string
+  | Target_transfer_projection_failed of
+      { target_keeper : string
+      ; detail : string
+      }
   | Ledger_projection_failed of string
   | Unexpected_projection_failure of Eio.Exn.with_bt
 
@@ -65,6 +69,11 @@ let projection_error_to_string = function
     ^ Executor_pool_ref.strict_submit_error_to_string error
   | Outbox_unavailable detail ->
     "event queue transition outbox unavailable: " ^ detail
+  | Target_transfer_projection_failed { target_keeper; detail } ->
+    Printf.sprintf
+      "event queue transfer target projection failed target_keeper=%s: %s"
+      target_keeper
+      detail
   | Ledger_projection_failed detail ->
     "event queue transition ledger projection failed: " ^ detail
   | Unexpected_projection_failure (exn, backtrace) ->
@@ -135,6 +144,33 @@ let with_owner_claim owner f =
       (fun () -> Owner_claim_acquired (f ()))
 ;;
 
+let project_transfer_target_result ~base_path (entry : Persistence.outbox_entry) =
+  match entry.receipt.transition with
+  | Persistence.Cancel_accepted _
+  | Persistence.Ack_source_terminal _ ->
+    Ok ()
+  | Persistence.Transfer_accepted transfer ->
+    (match
+       Keeper_registry_event_queue.project_accepted_transfer_durable_result
+         ~base_path
+         transfer.to_keeper
+         ~transfer
+     with
+     | Keeper_registry_event_queue.Stimulus_enqueued
+     | Keeper_registry_event_queue.Stimulus_already_present ->
+       ignore
+         (Keeper_registry.wakeup_running
+            ~intent:Keeper_registry.Broadcast_signal
+            ~base_path
+            transfer.to_keeper :
+            Keeper_registry.wakeup_outcome);
+       Ok ()
+     | Keeper_registry_event_queue.Stimulus_storage_error detail ->
+       Error
+         (Target_transfer_projection_failed
+            { target_keeper = transfer.to_keeper; detail }))
+;;
+
 let project_claimed_owner owner =
   let base_path = Persistence.owner_identity_base_path owner in
   let keeper_name = Persistence.owner_identity_keeper_name owner in
@@ -147,14 +183,18 @@ let project_claimed_owner owner =
   | Ok state ->
     (match Keeper_event_queue_state.transition_outbox state with
      | [] -> Ok No_pending_transition
-     | _ :: _ ->
-       (match
-          Keeper_reaction_ledger.project_event_queue_transition_outbox_result
-            ~base_path
-            ~keeper_name
-        with
-        | Ok () -> Ok Transition_converged
-        | Error detail -> Error (Ledger_projection_failed detail)))
+     | entry :: _ ->
+       (match project_transfer_target_result ~base_path entry with
+        | Error _ as error -> error
+        | Ok () ->
+          (match
+             Keeper_reaction_ledger.project_event_queue_transition_outbox_result
+               ~base_path
+               ~keeper_name
+               ~expected_transition_id:entry.receipt.transition_id
+           with
+           | Ok () -> Ok Transition_converged
+           | Error detail -> Error (Ledger_projection_failed detail))))
 ;;
 
 let project_resolved_owner owner =

--- a/lib/keeper/keeper_event_queue_recovery.mli
+++ b/lib/keeper/keeper_event_queue_recovery.mli
@@ -2,8 +2,9 @@
 
     The process-local owner claim only suppresses overlapping work in this
     process. It is not a durable lease or a physical exactly-once guarantee.
-    Cross-process and crash retries converge through the reaction ledger's
-    stable per-source event ids, then retire the matching durable outbox. *)
+    Cross-process and crash retries converge accepted-transfer target
+    projections and the reaction ledger's stable per-source event ids before
+    retiring the matching durable outbox. *)
 
 type projection_outcome =
   | No_pending_transition
@@ -14,6 +15,10 @@ type projection_error =
   | Owner_unavailable of Keeper_event_queue_persistence.owner_identity_error
   | Executor_unavailable of Executor_pool_ref.strict_submit_error
   | Outbox_unavailable of string
+  | Target_transfer_projection_failed of
+      { target_keeper : string
+      ; detail : string
+      }
   | Ledger_projection_failed of string
   | Unexpected_projection_failure of Eio.Exn.with_bt
 
@@ -63,8 +68,9 @@ val project_owner_result :
   base_path:string ->
   keeper_name:string ->
   (projection_outcome, projection_error) result
-(** Acquire the process-local owner claim, inspect the durable outbox, and
-    invoke the canonical reaction-ledger projector when work is present.
+(** Acquire the process-local owner claim and inspect the durable outbox.
+    Accepted transfers first converge the exact target projection; only then
+    does the canonical reaction-ledger projector retire the source outbox.
     Durable I/O runs outside the claim-table mutex and without cancellation
     masking, and requires the startup executor pool; it is never run inline.
     [Transition_converged] does not identify which process performed the

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -362,12 +362,27 @@ let after_ledger_append_hook :
 
 let after_ledger_append_hook_mutex = Stdlib.Mutex.create ()
 
-let project_event_queue_transition_outbox_result ~base_path ~keeper_name =
+let project_event_queue_transition_outbox_result
+      ~base_path
+      ~keeper_name
+      ~expected_transition_id
+  =
   let ( let* ) = Result.bind in
   Keeper_event_queue_persistence.project_transition_outbox_result
     ~append_before_retire:(fun
         (entry : Keeper_event_queue_state.outbox_entry)
       ->
+      let* () =
+        if String.equal expected_transition_id entry.receipt.transition_id
+        then Ok ()
+        else
+          Error
+            (Printf.sprintf
+               "event queue transition changed before ledger projection keeper=%s expected_transition_id=%s current_transition_id=%s"
+               keeper_name
+               expected_transition_id
+               entry.receipt.transition_id)
+      in
       match entry.stimuli with
       | [] ->
         Error

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -68,13 +68,18 @@ val record_event_queue_turn_started :
     reaction kind so callers cannot manufacture transition evidence. *)
 
 val project_event_queue_transition_outbox_result :
-  base_path:string -> keeper_name:string -> (unit, string) result
+  base_path:string ->
+  keeper_name:string ->
+  expected_transition_id:string ->
+  (unit, string) result
 (** Read the sole durable event-queue transition outbox, append every source in
-    exact order, then retire that same transition. Callers supply no receipt,
-    stimulus, source index, or outbox record, so transition evidence can only
-    originate from the event-queue SSOT. Persistence failures remain explicit
-    [Error]. Retries are logically idempotent through deterministic per-source
-    event ids. *)
+    exact order, then retire that same transition. [expected_transition_id]
+    binds the outbox read to the transfer whose target the recovery caller
+    already projected; a newer transition remains authoritative. Callers
+    supply no receipt, stimulus, source index, or outbox record, so transition
+    evidence can only originate from the event-queue SSOT. Persistence failures
+    remain explicit [Error]. Retries are logically idempotent through
+    deterministic per-source event ids. *)
 
 type event_queue_reaction_evidence =
   { keeper_name : string

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -323,15 +323,13 @@ let snapshot_result ~base_path name =
 let reprioritize_pending_result
       ~base_path
       name
-      ~expected_revision
-      ~source
+      ~selection
       ~urgency
   =
   Keeper_event_queue_persistence.reprioritize_pending_result
     ~base_path
     ~keeper_name:name
-    ~expected_revision
-    ~source
+    ~selection
     ~urgency
     ~after_commit:(publish_pending ~base_path name)
     ()

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -211,8 +211,7 @@ val snapshot_result :
 val reprioritize_pending_result :
   base_path:string ->
   string ->
-  expected_revision:int64 ->
-  source:Keeper_event_queue.stimulus ->
+  selection:Keeper_event_queue_state.pending_selection ->
   urgency:Keeper_event_queue.urgency ->
   (int64, string) result
 

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -714,45 +714,12 @@ let reprioritize_pending_result
       ?(after_commit = fun _ -> ())
       ~base_path
       ~keeper_name
-      ~expected_revision
-      ~source
+      ~selection
       ~urgency
       ()
   =
   commit_transform ~base_path ~keeper_name ~after_commit (fun state ->
-    let observed_revision = State.revision state in
-    if not (Int64.equal expected_revision observed_revision)
-    then
-      Error
-        (Printf.sprintf
-           "event queue revision mismatch (expected=%Ld observed=%Ld)"
-           expected_revision
-           observed_revision)
-    else if Int64.equal observed_revision Int64.max_int
-    then Error "event queue revision exhausted"
-    else
-      let matching, retained =
-        Keeper_event_queue.to_list (State.pending state)
-        |> List.partition (fun candidate ->
-          Keeper_event_queue.stimulus_identity_equal candidate source)
-      in
-      match matching with
-      | [ observed ] when observed = source ->
-        let remaining =
-          List.fold_left
-            Keeper_event_queue.enqueue
-            Keeper_event_queue.empty
-            retained
-        in
-        let updated = { observed with urgency } in
-        let pending =
-          Keeper_event_queue.enqueue remaining updated
-          |> Keeper_event_queue.sort_by_urgency
-        in
-        Ok (State.with_pending pending state, Int64.succ observed_revision)
-      | [] -> Error "event queue source is no longer pending"
-      | [ _ ] -> Error "event queue source snapshot changed"
-      | _ -> Error "event queue source identity is duplicated")
+    State.reprioritize_pending ~selection ~urgency state)
 ;;
 
 type enqueue_stimulus_result =

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -240,14 +240,12 @@ val reprioritize_pending_result :
   ?after_commit:(Keeper_event_queue.t -> unit) ->
   base_path:string ->
   keeper_name:string ->
-  expected_revision:int64 ->
-  source:Keeper_event_queue.stimulus ->
+  selection:Keeper_event_queue_state.pending_selection ->
   urgency:Keeper_event_queue.urgency ->
   unit ->
   (int64, string) result
-(** Revision-fenced priority change for one exact pending stimulus. The
-    immutable source must still be present exactly once; the durable state is
-    rewritten and published atomically. *)
+(** Source-incarnation-fenced priority change. Unrelated queue mutations do
+    not invalidate the selected source. *)
 
 type enqueue_stimulus_result =
   | Enqueued

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -83,6 +83,35 @@ let empty =
 let revision state = state.revision
 let pending_selections state = state.pending_entries
 
+let source_snapshot_ref source =
+  Keeper_event_queue.stimulus_to_yojson source
+  |> Yojson.Safe.to_string
+  |> Digestif.SHA256.digest_string
+  |> Digestif.SHA256.to_hex
+;;
+
+let resolve_pending_selection
+      ~source_ref
+      ~source_incarnation
+      state
+  =
+  let matching =
+    List.filter
+      (fun selection ->
+         String.equal
+           (source_snapshot_ref selection.source)
+           source_ref)
+      state.pending_entries
+  in
+  match matching with
+  | [ selection ]
+    when Int64.equal selection.admitted_revision source_incarnation ->
+    Ok selection
+  | [ _ ] -> Error "event queue source incarnation changed"
+  | [] -> Error "event queue source is no longer pending"
+  | _ -> Error "event queue source reference is ambiguous"
+;;
+
 let pending state =
   List.fold_left
     (fun queue entry ->
@@ -272,6 +301,37 @@ let ack_pending ~(selection : pending_selection) state =
       List.filter (Fun.negate (( = ) selection)) state.pending_entries
     in
     Ok { state with pending_entries }
+;;
+
+let reprioritize_pending
+      ~(selection : pending_selection)
+      ~urgency
+      state
+  =
+  match validate_pending_selection ~selection state with
+  | Error _ as error -> error
+  | Ok () ->
+    if selection.source.urgency = urgency
+    then Ok (state, state.revision)
+    else if Int64.equal state.revision Int64.max_int
+    then Error "event queue revision exhausted"
+    else
+      let next_revision = Int64.succ state.revision in
+      let updated =
+        { source = { selection.source with urgency }
+        ; admitted_revision = next_revision
+        }
+      in
+      let pending_entries =
+        List.map
+          (fun entry -> if entry = selection then updated else entry)
+          state.pending_entries
+      in
+      let state = { state with pending_entries } in
+      let sorted_pending =
+        pending state |> Keeper_event_queue.sort_by_urgency
+      in
+      Ok (with_pending sorted_pending state, next_revision)
 ;;
 
 let ( let* ) = Result.bind

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -88,6 +88,19 @@ val pending : t -> Keeper_event_queue.t
 val pending_selections : t -> pending_selection list
 (** FIFO pending entries with their exact source incarnation authority. *)
 
+val source_snapshot_ref : Keeper_event_queue.stimulus -> string
+(** Stable SHA-256 reference derived from the exact typed source snapshot. It
+    exposes no raw payload bytes; [source_incarnation] separately identifies a
+    later reinsertion of the same snapshot. *)
+
+val resolve_pending_selection :
+  source_ref:string ->
+  source_incarnation:int64 ->
+  t ->
+  (pending_selection, string) result
+(** Resolve one exact pending source without consulting the global queue
+    revision or queue position. *)
+
 val last_transition : t -> transition_receipt option
 val projected_dispositions : t -> transition_receipt list
 (** Newest-first projected operator dispositions, including
@@ -130,6 +143,14 @@ val ack_pending :
 (** Compare-and-remove the exact immutable selected stimulus snapshot.
     Unrelated queue revisions and enqueues are allowed; a missing, duplicated,
     or changed selected identity fails closed. *)
+
+val reprioritize_pending :
+  selection:pending_selection ->
+  urgency:Keeper_event_queue.urgency ->
+  t ->
+  (t * int64, string) result
+(** Change only the exact selected source priority. A real change receives the
+    next source incarnation; unrelated pending entries retain theirs. *)
 
 val cancel_pending_accepted :
   current_owner_nonce:int ->

--- a/lib/server/server_dashboard_http_keeper_event_queue_operator.ml
+++ b/lib/server/server_dashboard_http_keeper_event_queue_operator.ml
@@ -4,9 +4,9 @@ module Http = Http_server_eio
 module Execute = Server_dashboard_http_keeper_event_queue_operator_execute
 
 let ( let* ) = Result.bind
-let schema = "keeper_event_queue.operator.request.v1"
+let schema = "keeper_event_queue.operator.request.v2"
 let result_schema = "keeper_event_queue.operator.result.v1"
-let pending_result_schema = "keeper_event_queue.pending.v1"
+let pending_result_schema = "keeper_event_queue.pending.v2"
 let pending_page_limit = 100
 let prefix = "/api/v1/keepers/"
 let operator_permission = Masc_domain.CanAdmin
@@ -67,11 +67,18 @@ let pending_page ~after ~limit pending =
     | _ :: rest when index < after ->
       loop (index + 1) remaining page_rev rest
     | _ when remaining = 0 -> List.rev page_rev
-    | stimulus :: rest ->
+    | selection :: rest ->
+      let stimulus = selection.Keeper_event_queue_state.source in
       let item =
         `Assoc
           [ "queue_index", `Int index
           ; "post_id", `String stimulus.Keeper_event_queue.post_id
+          ; ( "source_ref"
+            , `String
+                (Keeper_event_queue_state.source_snapshot_ref stimulus) )
+          ; ( "source_incarnation"
+            , `String
+                (Int64.to_string selection.admitted_revision) )
           ; ( "urgency"
             , `String
                 (Keeper_event_queue.urgency_to_string stimulus.urgency) )
@@ -88,7 +95,6 @@ let pending_page ~after ~limit pending =
 
 module For_testing = struct
   let pending_page = pending_page
-  let pending_source_at = Execute.pending_source_at
 end
 
 let handle_get state request reqd ~keeper_name =
@@ -119,10 +125,7 @@ let handle_get state request reqd ~keeper_name =
        | Error detail -> error ~status:`Service_unavailable detail
        | Ok queue_state ->
          let revision = Keeper_event_queue_state.revision queue_state in
-         let pending =
-           Keeper_event_queue_state.pending queue_state
-           |> Keeper_event_queue.to_list
-         in
+         let pending = Keeper_event_queue_state.pending_selections queue_state in
          let total_pending = List.length pending in
          let page = pending_page ~after ~limit pending in
          let consumed = after + List.length page in
@@ -145,20 +148,20 @@ let handle_get state request reqd ~keeper_name =
 
 type request = Execute.request =
   | Cancel of
-      { expected_revision : int64
-      ; queue_index : int
+      { source_ref : string
+      ; source_incarnation : int64
       ; operator_operation_id : string
       ; reason : string
       }
   | Transfer of
-      { expected_revision : int64
-      ; queue_index : int
+      { source_ref : string
+      ; source_incarnation : int64
       ; operator_operation_id : string
       ; target_keeper : string
       }
   | Reprioritize of
-      { expected_revision : int64
-      ; queue_index : int
+      { source_ref : string
+      ; source_incarnation : int64
       ; urgency : Keeper_event_queue.urgency
       }
 
@@ -175,19 +178,25 @@ let string_field name fields =
   | _ -> Error (name ^ " must be a string")
 ;;
 
-let expected_revision fields =
-  let* value = string_field "expected_revision" fields in
+let source_incarnation fields =
+  let* value = string_field "source_incarnation" fields in
   match Int64.of_string_opt value with
-  | Some revision when Int64.compare revision 0L >= 0 -> Ok revision
-  | Some _ | None -> Error "expected_revision must be a non-negative int64 string"
+  | Some incarnation when Int64.compare incarnation 0L >= 0 ->
+    Ok incarnation
+  | Some _ | None ->
+    Error "source_incarnation must be a non-negative int64 string"
 ;;
 
-let queue_index fields =
-  let* value = field "queue_index" fields in
-  match value with
-  | `Int queue_index when queue_index >= 0 -> Ok queue_index
-  | `Int _ -> Error "queue_index must be non-negative"
-  | _ -> Error "queue_index must be an integer"
+let source_ref fields =
+  let* value = string_field "source_ref" fields in
+  if String.length value = 64
+     && String.for_all
+          (function
+            | '0' .. '9' | 'a' .. 'f' -> true
+            | _ -> false)
+          value
+  then Ok value
+  else Error "source_ref must be exactly 64 lowercase hexadecimal characters"
 ;;
 
 let operator_operation_id fields =
@@ -230,13 +239,13 @@ let parse body =
     then Error ("unsupported schema: " ^ request_schema)
     else
       let* action = string_field "action" fields in
-      let* expected_revision = expected_revision fields in
-      let* queue_index = queue_index fields in
+      let* source_ref = source_ref fields in
+      let* source_incarnation = source_incarnation fields in
       let common =
         [ "action"
-        ; "expected_revision"
-        ; "queue_index"
         ; "schema"
+        ; "source_incarnation"
+        ; "source_ref"
         ]
       in
       match action with
@@ -253,8 +262,8 @@ let parse body =
         else
           Ok
             (Cancel
-               { expected_revision
-               ; queue_index
+               { source_ref
+               ; source_incarnation
                ; operator_operation_id
                ; reason
                })
@@ -271,8 +280,8 @@ let parse body =
         else
           Ok
             (Transfer
-               { expected_revision
-               ; queue_index
+               { source_ref
+               ; source_incarnation
                ; operator_operation_id
                ; target_keeper
                })
@@ -282,7 +291,7 @@ let parse body =
         let* urgency = Keeper_event_queue.urgency_of_string urgency_value in
         Ok
           (Reprioritize
-             { expected_revision; queue_index; urgency })
+             { source_ref; source_incarnation; urgency })
       | value -> Error ("unknown event queue operator action: " ^ value)
 ;;
 
@@ -311,14 +320,24 @@ let handle_post state ~actor request reqd ~keeper_name body =
           ])
     | Ok operation ->
       let config = Mcp_server.workspace_config state in
-      let queue_index, action, operator_operation_id =
+      let source_ref, source_incarnation, action, operator_operation_id =
         match operation with
-        | Cancel { queue_index; operator_operation_id; _ } ->
-          queue_index, "cancel", Some operator_operation_id
-        | Transfer { queue_index; operator_operation_id; _ } ->
-          queue_index, "transfer", Some operator_operation_id
-        | Reprioritize { queue_index; _ } ->
-          queue_index, "reprioritize", None
+        | Cancel
+            { source_ref
+            ; source_incarnation
+            ; operator_operation_id
+            ; _
+            } ->
+          source_ref, source_incarnation, "cancel", Some operator_operation_id
+        | Transfer
+            { source_ref
+            ; source_incarnation
+            ; operator_operation_id
+            ; _
+            } ->
+          source_ref, source_incarnation, "transfer", Some operator_operation_id
+        | Reprioritize { source_ref; source_incarnation; _ } ->
+          source_ref, source_incarnation, "reprioritize", None
       in
       let result =
         Execute.run
@@ -357,7 +376,9 @@ let handle_post state ~actor request reqd ~keeper_name body =
               (`Assoc
                 (([ "keeper_name", `String keeper_name
                   ; "action", `String action
-                  ; "queue_index", `Int queue_index
+                  ; "source_ref", `String source_ref
+                  ; ( "source_incarnation"
+                    , `String (Int64.to_string source_incarnation) )
                   ]
                   @ (match operator_operation_id with
                      | Some value ->

--- a/lib/server/server_dashboard_http_keeper_event_queue_operator.mli
+++ b/lib/server/server_dashboard_http_keeper_event_queue_operator.mli
@@ -11,13 +11,8 @@ module For_testing : sig
   val pending_page :
     after:int ->
     limit:int ->
-    Keeper_event_queue.stimulus list ->
+    Keeper_event_queue_state.pending_selection list ->
     Yojson.Safe.t list
-
-  val pending_source_at :
-    queue_index:int ->
-    Keeper_event_queue.t ->
-    Keeper_event_queue.stimulus option
 end
 
 val handle_get :

--- a/lib/server/server_dashboard_http_keeper_event_queue_operator_execute.ml
+++ b/lib/server/server_dashboard_http_keeper_event_queue_operator_execute.ml
@@ -2,26 +2,22 @@ let ( let* ) = Result.bind
 
 type request =
   | Cancel of
-      { expected_revision : int64
-      ; queue_index : int
+      { source_ref : string
+      ; source_incarnation : int64
       ; operator_operation_id : string
       ; reason : string
       }
   | Transfer of
-      { expected_revision : int64
-      ; queue_index : int
+      { source_ref : string
+      ; source_incarnation : int64
       ; operator_operation_id : string
       ; target_keeper : string
       }
   | Reprioritize of
-      { expected_revision : int64
-      ; queue_index : int
+      { source_ref : string
+      ; source_incarnation : int64
       ; urgency : Keeper_event_queue.urgency
       }
-
-let pending_source_at ~queue_index pending =
-  List.nth_opt (Keeper_event_queue.to_list pending) queue_index
-;;
 
 let transition_result_json = function
   | Keeper_registry_event_queue.Transition_applied receipt ->
@@ -69,30 +65,19 @@ type prepared_transfer =
 
 let resolve_pending_source
       ~queue_state
-      ~expected_revision
-      ~queue_index
+      ~source_ref
+      ~source_incarnation
   =
-  let observed_revision = Keeper_event_queue_state.revision queue_state in
-  if not (Int64.equal expected_revision observed_revision)
-  then
-    Error
-      (Printf.sprintf
-         "event queue revision mismatch (expected=%Ld observed=%Ld)"
-         expected_revision
-         observed_revision)
-  else
-    match
-      pending_source_at
-        ~queue_index
-        (Keeper_event_queue_state.pending queue_state)
-    with
-    | Some source -> Ok source
-    | None -> Error "event queue selection is no longer pending"
+  Keeper_event_queue_state.resolve_pending_selection
+    ~source_ref
+    ~source_incarnation
+    queue_state
 ;;
 
 let prior_cancellation_for_request
       ~queue_state
-      ~expected_revision
+      ~source_ref
+      ~source_incarnation
       ~operator_operation_id
       ~reason
   =
@@ -105,7 +90,11 @@ let prior_cancellation_for_request
   | Some receipt ->
     (match receipt.transition with
      | Keeper_event_queue_state.Cancel_accepted cancellation
-       when Int64.equal cancellation.source_revision expected_revision
+       when Int64.equal cancellation.source_incarnation source_incarnation
+            && String.equal
+                 (Keeper_event_queue_state.source_snapshot_ref
+                    cancellation.source)
+                 source_ref
             && String.equal cancellation.reason reason ->
        Ok (Some { cancellation; applied_at = receipt.applied_at })
      | Keeper_event_queue_state.Cancel_accepted _
@@ -119,20 +108,20 @@ let prior_cancellation_for_request
 let fresh_cancellation_for_request
       ~queue_state
       ~owner_nonce
-      ~expected_revision
-      ~queue_index
+      ~source_ref
+      ~source_incarnation
       ~operator_operation_id
       ~reason
   =
-  let* source =
+  let* selection =
     resolve_pending_source
       ~queue_state
-      ~expected_revision
-      ~queue_index
+      ~source_ref
+      ~source_incarnation
   in
   let cancellation : Keeper_registry_event_queue.accepted_cancellation =
-    { source
-    ; source_revision = expected_revision
+    { source = selection.source
+    ; source_incarnation
     ; owner_nonce
     ; operator_operation_id
     ; reason
@@ -144,7 +133,8 @@ let fresh_cancellation_for_request
 let prior_transfer_for_request
       ~queue_state
       ~keeper_name
-      ~expected_revision
+      ~source_ref
+      ~source_incarnation
       ~operator_operation_id
       ~target_keeper
   =
@@ -157,7 +147,11 @@ let prior_transfer_for_request
   | Some receipt ->
     (match receipt.transition with
      | Keeper_event_queue_state.Transfer_accepted transfer
-       when Int64.equal transfer.source_revision expected_revision
+       when Int64.equal transfer.source_incarnation source_incarnation
+            && String.equal
+                 (Keeper_event_queue_state.source_snapshot_ref
+                    transfer.source)
+                 source_ref
             && String.equal transfer.from_keeper keeper_name
             && String.equal transfer.to_keeper target_keeper ->
        Ok (Some { transfer; applied_at = receipt.applied_at })
@@ -173,20 +167,20 @@ let fresh_transfer_for_request
       ~queue_state
       ~keeper_name
       ~owner_nonce
-      ~expected_revision
-      ~queue_index
+      ~source_ref
+      ~source_incarnation
       ~operator_operation_id
       ~target_keeper
   =
-  let* source =
+  let* selection =
     resolve_pending_source
       ~queue_state
-      ~expected_revision
-      ~queue_index
+      ~source_ref
+      ~source_incarnation
   in
   let transfer : Keeper_registry_event_queue.accepted_transfer =
-    { source
-    ; source_revision = expected_revision
+    { source = selection.source
+    ; source_incarnation
     ; owner_nonce
     ; operator_operation_id
     ; from_keeper = keeper_name
@@ -258,22 +252,21 @@ let execute_reprioritization
       ~base_path
       ~keeper_name
       ~queue_state
-      ~expected_revision
-      ~queue_index
+      ~source_ref
+      ~source_incarnation
       ~urgency
   =
-  let* source =
+  let* selection =
     resolve_pending_source
       ~queue_state
-      ~expected_revision
-      ~queue_index
+      ~source_ref
+      ~source_incarnation
   in
   let* revision =
     Keeper_registry_event_queue.reprioritize_pending_result
       ~base_path
       keeper_name
-      ~expected_revision
-      ~source
+      ~selection
       ~urgency
   in
   ignore
@@ -283,7 +276,7 @@ let execute_reprioritization
        keeper_name :
        Keeper_registry.wakeup_outcome);
   Ok
-    ( source
+    ( selection.source
     , `Assoc
         [ "status", `String "applied"
         ; "revision", `String (Int64.to_string revision)
@@ -309,8 +302,8 @@ let replay_committed_request ~base_path ~keeper_name request =
   match request with
   | Reprioritize _ -> Ok None
   | Cancel
-      { expected_revision
-      ; queue_index = _
+      { source_ref
+      ; source_incarnation
       ; operator_operation_id
       ; reason
       } ->
@@ -322,7 +315,8 @@ let replay_committed_request ~base_path ~keeper_name request =
     let* prepared =
       prior_cancellation_for_request
         ~queue_state
-        ~expected_revision
+        ~source_ref
+        ~source_incarnation
         ~operator_operation_id
         ~reason
     in
@@ -332,8 +326,8 @@ let replay_committed_request ~base_path ~keeper_name request =
        execute_cancellation ~base_path ~keeper_name prepared
        |> Result.map Option.some)
   | Transfer
-      { expected_revision
-      ; queue_index = _
+      { source_ref
+      ; source_incarnation
       ; operator_operation_id
       ; target_keeper
       } ->
@@ -346,7 +340,8 @@ let replay_committed_request ~base_path ~keeper_name request =
       prior_transfer_for_request
         ~queue_state
         ~keeper_name
-        ~expected_revision
+        ~source_ref
+        ~source_incarnation
         ~operator_operation_id
         ~target_keeper
     in
@@ -371,15 +366,16 @@ let run_admitted_request
   in
   match request with
   | Cancel
-      { expected_revision
-      ; queue_index
+      { source_ref
+      ; source_incarnation
       ; operator_operation_id
       ; reason
       } ->
     let* prior =
       prior_cancellation_for_request
         ~queue_state
-        ~expected_revision
+        ~source_ref
+        ~source_incarnation
         ~operator_operation_id
         ~reason
     in
@@ -390,15 +386,15 @@ let run_admitted_request
         fresh_cancellation_for_request
           ~queue_state
           ~owner_nonce
-          ~expected_revision
-          ~queue_index
+          ~source_ref
+          ~source_incarnation
           ~operator_operation_id
           ~reason
     in
     execute_cancellation ~base_path ~keeper_name prepared
   | Transfer
-      { expected_revision
-      ; queue_index
+      { source_ref
+      ; source_incarnation
       ; operator_operation_id
       ; target_keeper
       } ->
@@ -409,7 +405,8 @@ let run_admitted_request
         prior_transfer_for_request
           ~queue_state
           ~keeper_name
-          ~expected_revision
+          ~source_ref
+          ~source_incarnation
           ~operator_operation_id
           ~target_keeper
       in
@@ -422,19 +419,19 @@ let run_admitted_request
             ~queue_state
             ~keeper_name
             ~owner_nonce
-            ~expected_revision
-            ~queue_index
+            ~source_ref
+            ~source_incarnation
             ~operator_operation_id
             ~target_keeper
       in
       execute_transfer ~base_path ~keeper_name prepared
-  | Reprioritize { expected_revision; queue_index; urgency } ->
+  | Reprioritize { source_ref; source_incarnation; urgency } ->
     execute_reprioritization
       ~base_path
       ~keeper_name
       ~queue_state
-      ~expected_revision
-      ~queue_index
+      ~source_ref
+      ~source_incarnation
       ~urgency
 ;;
 

--- a/lib/server/server_dashboard_http_keeper_event_queue_operator_execute.ml
+++ b/lib/server/server_dashboard_http_keeper_event_queue_operator_execute.ml
@@ -63,17 +63,6 @@ type prepared_transfer =
   ; applied_at : float
   }
 
-let resolve_pending_source
-      ~queue_state
-      ~source_ref
-      ~source_incarnation
-  =
-  Keeper_event_queue_state.resolve_pending_selection
-    ~source_ref
-    ~source_incarnation
-    queue_state
-;;
-
 let prior_cancellation_for_request
       ~queue_state
       ~source_ref
@@ -114,10 +103,10 @@ let fresh_cancellation_for_request
       ~reason
   =
   let* selection =
-    resolve_pending_source
-      ~queue_state
+    Keeper_event_queue_state.resolve_pending_selection
       ~source_ref
       ~source_incarnation
+      queue_state
   in
   let cancellation : Keeper_registry_event_queue.accepted_cancellation =
     { source = selection.source
@@ -173,10 +162,10 @@ let fresh_transfer_for_request
       ~target_keeper
   =
   let* selection =
-    resolve_pending_source
-      ~queue_state
+    Keeper_event_queue_state.resolve_pending_selection
       ~source_ref
       ~source_incarnation
+      queue_state
   in
   let transfer : Keeper_registry_event_queue.accepted_transfer =
     { source = selection.source
@@ -257,10 +246,10 @@ let execute_reprioritization
       ~urgency
   =
   let* selection =
-    resolve_pending_source
-      ~queue_state
+    Keeper_event_queue_state.resolve_pending_selection
       ~source_ref
       ~source_incarnation
+      queue_state
   in
   let* revision =
     Keeper_registry_event_queue.reprioritize_pending_result

--- a/lib/server/server_dashboard_http_keeper_event_queue_operator_execute.mli
+++ b/lib/server/server_dashboard_http_keeper_event_queue_operator_execute.mli
@@ -1,26 +1,21 @@
 type request =
   | Cancel of
-      { expected_revision : int64
-      ; queue_index : int
+      { source_ref : string
+      ; source_incarnation : int64
       ; operator_operation_id : string
       ; reason : string
       }
   | Transfer of
-      { expected_revision : int64
-      ; queue_index : int
+      { source_ref : string
+      ; source_incarnation : int64
       ; operator_operation_id : string
       ; target_keeper : string
       }
   | Reprioritize of
-      { expected_revision : int64
-      ; queue_index : int
+      { source_ref : string
+      ; source_incarnation : int64
       ; urgency : Keeper_event_queue.urgency
       }
-
-val pending_source_at :
-  queue_index:int ->
-  Keeper_event_queue.t ->
-  Keeper_event_queue.stimulus option
 
 val run :
   config:Workspace.config ->

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -316,7 +316,9 @@ let test_keeper_chat_recovery_route_is_exact () =
       Server_dashboard_http_keeper_event_queue_operator.For_testing.pending_page
         ~after:0
         ~limit:100
-        [ source ]
+        [ Keeper_event_queue_state.
+            { source; admitted_revision = 23L }
+        ]
     with
     | [ json ] -> json
     | _ -> fail "event pending projection must return one metadata row"
@@ -325,6 +327,12 @@ let test_keeper_chat_recovery_route_is_exact () =
   check string "event pending projection retains post identity"
     source.post_id
     (pending_json |> member "post_id" |> to_string);
+  check string "event pending projection retains source incarnation"
+    "23"
+    (pending_json |> member "source_incarnation" |> to_string);
+  check int "event pending projection emits an opaque SHA-256 source ref"
+    64
+    (pending_json |> member "source_ref" |> to_string |> String.length);
   check string "event pending projection retains typed payload kind"
     "board_signal"
     (pending_json |> member "payload_kind" |> to_string);
@@ -340,20 +348,22 @@ let test_keeper_chat_recovery_route_is_exact () =
     |> fun queue -> Keeper_event_queue.enqueue queue source
     |> fun queue -> Keeper_event_queue.enqueue queue same_post_id_source
   in
-  (match
-     Server_dashboard_http_keeper_event_queue_operator.For_testing.pending_source_at
-       ~queue_index:1
-       duplicate_post_id_queue
-   with
-   | Some selected ->
-     check bool
-       "event selection uses revision-fenced queue position, not ambiguous post id"
-       true
-       (Keeper_event_queue.stimulus_identity_equal
-          same_post_id_source
-          selected)
-   | None ->
-     fail "event selection must address duplicate post ids independently");
+  let duplicate_state =
+    Keeper_event_queue_state.empty
+    |> Keeper_event_queue_state.with_revision 23L
+    |> Keeper_event_queue_state.with_pending duplicate_post_id_queue
+  in
+  let selections =
+    Keeper_event_queue_state.pending_selections duplicate_state
+  in
+  let refs =
+    List.map
+      (fun (selection : Keeper_event_queue_state.pending_selection) ->
+         Keeper_event_queue_state.source_snapshot_ref selection.source)
+      selections
+  in
+  check int "duplicate post ids retain two exact source refs" 2
+    (List.sort_uniq String.compare refs |> List.length);
   let quarantine_path =
     "/api/v1/keepers/idealist/board-attention/quarantines/ba-root-123/recovery"
   in

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -145,9 +145,6 @@ let with_strict_executor f =
     (Domain_pool.executor_pool pool)
     f
 
-(* [claim_single] and [settle_and_project] built and settled leases for the
-   blocks removed above. *)
-
 let project_transition_canonically ~base_path ~keeper_name ~transition_id:_ =
   with_strict_executor
   @@ fun () ->
@@ -159,6 +156,56 @@ let project_transition_canonically ~base_path ~keeper_name ~transition_id:_ =
   | Ok Masc.Keeper_event_queue_recovery.Transition_converged -> Ok ()
   | Ok _ -> Error "canonical transition projection did not converge"
   | Error _ -> Error "canonical transition projection failed"
+
+let load_queue_state ~base_path ~keeper_name =
+  match
+    Keeper_event_queue_persistence.load_state_result ~base_path ~keeper_name
+  with
+  | Ok state -> state
+  | Error detail -> Alcotest.fail detail
+
+let stage_transfer ~base_path ~from_keeper ~to_keeper ~source ~owner_nonce ~operation_id =
+  (match
+     Masc.Keeper_registry_event_queue.enqueue_stimulus_durable_result
+       ~base_path
+       from_keeper
+       source
+   with
+   | Masc.Keeper_registry_event_queue.Stimulus_enqueued -> ()
+   | _ -> Alcotest.fail "failed to seed transfer recovery source");
+  let selection =
+    load_queue_state ~base_path ~keeper_name:from_keeper
+    |> Keeper_event_queue_state.select_when
+         ~ready:(Keeper_event_queue.stimulus_identity_equal source)
+    |> function
+    | Some selection -> selection
+    | None -> Alcotest.fail "transfer recovery source was not selectable"
+  in
+  let transfer : Keeper_event_queue_persistence.accepted_transfer =
+    { source = selection.source
+    ; source_incarnation = selection.admitted_revision
+    ; owner_nonce
+    ; operator_operation_id = operation_id
+    ; from_keeper
+    ; to_keeper
+    }
+  in
+  (match
+     Masc.Keeper_registry_event_queue.transfer_pending_accepted_result
+       ~base_path
+       from_keeper
+       ~current_owner_nonce:owner_nonce
+       ~applied_at:101.0
+       ~transfer
+   with
+   | Ok (Masc.Keeper_registry_event_queue.Transition_applied _) -> ()
+   | Ok (Masc.Keeper_registry_event_queue.Transition_already_applied _) ->
+     Alcotest.fail "first transfer recovery transition was already applied"
+   | Ok
+       (Masc.Keeper_registry_event_queue.Transition_committed_followup_failed
+          { detail; _ }) ->
+     Alcotest.fail detail
+   | Error detail -> Alcotest.fail detail)
 
 let () =
   let open Keeper_event_queue in
@@ -829,6 +876,176 @@ let () =
       assert (String.equal second.post_id "bootstrap");
       Keeper_event_queue_persistence.persist ~base_path ~keeper_name rest;
       assert (is_empty (Keeper_event_queue_persistence.load ~base_path ~keeper_name)));
+
+  (* --- transfer recovery: the source outbox is not retired until the exact
+         target projection is durable, so a lost HTTP recovery operation is
+         repaired by the canonical maintenance sweep. --- *)
+  let base_path = temp_dir "keeper-event-queue-transfer-recovery" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_registry.For_testing.clear ();
+      rm_rf base_path)
+    (fun () ->
+      let from_keeper = "keeper-transfer-recovery-source" in
+      let to_keeper = "keeper-transfer-recovery-target" in
+      stage_transfer
+        ~base_path
+        ~from_keeper
+        ~to_keeper
+        ~source:board_stim
+        ~owner_nonce:23
+        ~operation_id:"recover-transfer-target";
+      Alcotest.(check int)
+        "source outbox awaits target projection"
+        1
+        (load_queue_state ~base_path ~keeper_name:from_keeper
+         |> Keeper_event_queue_state.transition_outbox
+         |> List.length);
+      Alcotest.(check int)
+        "target is empty before recovery"
+        0
+        (registry_snapshot ~base_path to_keeper |> Keeper_event_queue.length);
+      (match
+         project_transition_canonically
+           ~base_path
+           ~keeper_name:from_keeper
+           ~transition_id:"unused"
+       with
+       | Ok () -> ()
+       | Error detail -> Alcotest.fail detail);
+      let recovered_target = load_queue_state ~base_path ~keeper_name:to_keeper in
+      Alcotest.(check int)
+        "source outbox retires after target projection"
+        0
+        (load_queue_state ~base_path ~keeper_name:from_keeper
+         |> Keeper_event_queue_state.transition_outbox
+         |> List.length);
+      Alcotest.(check int)
+        "target receives the exact transferred source"
+        1
+        (Keeper_event_queue_state.pending recovered_target |> Keeper_event_queue.length);
+      Alcotest.(check int)
+        "target accounts the transfer operation durably"
+        1
+        (Keeper_event_queue_state.accepted_transfer_projections recovered_target
+         |> List.length));
+
+  (* --- transfer recovery failure: target storage failure is typed and keeps
+         the source outbox authoritative for a later retry. --- *)
+  let base_path = temp_dir "keeper-event-queue-transfer-recovery-failure" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_path)
+    (fun () ->
+      let from_keeper = "keeper-transfer-recovery-failure-source" in
+      let to_keeper = "keeper-transfer-recovery-failure-target" in
+      stage_transfer
+        ~base_path
+        ~from_keeper
+        ~to_keeper
+        ~source:board_stim
+        ~owner_nonce:29
+        ~operation_id:"recover-transfer-target-failure";
+      let target_path =
+        Filename.concat
+          (Common.keepers_runtime_dir_of_base ~base_path)
+          to_keeper
+      in
+      write_file target_path "directory blocker";
+      (match
+         with_strict_executor
+         @@ fun () ->
+         Masc.Keeper_event_queue_recovery.project_owner_result
+           ~base_path
+           ~keeper_name:from_keeper
+       with
+       | Error
+           (Masc.Keeper_event_queue_recovery.Target_transfer_projection_failed
+              { target_keeper; detail }) ->
+         Alcotest.(check string)
+           "typed target keeper"
+           to_keeper
+           target_keeper;
+         Alcotest.(check bool)
+           "typed storage detail"
+           true
+           (String.length detail > 0)
+       | Error error ->
+         Alcotest.fail
+           (Masc.Keeper_event_queue_recovery.projection_error_to_string error)
+       | Ok _ -> Alcotest.fail "target storage failure retired the source outbox");
+      Alcotest.(check int)
+        "failed target projection retains source outbox"
+        1
+        (load_queue_state ~base_path ~keeper_name:from_keeper
+         |> Keeper_event_queue_state.transition_outbox
+         |> List.length));
+
+  (* --- a stale recovery worker cannot retire a newer transfer after it
+         projected the target for an earlier transition. --- *)
+  let base_path = temp_dir "keeper-event-queue-transfer-recovery-stale-worker" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_path)
+    (fun () ->
+      let from_keeper = "keeper-transfer-recovery-stale-source" in
+      let to_keeper = "keeper-transfer-recovery-stale-target" in
+      stage_transfer
+        ~base_path
+        ~from_keeper
+        ~to_keeper
+        ~source:board_stim
+        ~owner_nonce:31
+        ~operation_id:"recover-transfer-first";
+      let first_transition_id =
+        match
+          load_queue_state ~base_path ~keeper_name:from_keeper
+          |> Keeper_event_queue_state.transition_outbox
+        with
+        | [ entry ] -> entry.receipt.transition_id
+        | _ -> Alcotest.fail "first transfer did not stage one outbox entry"
+      in
+      (match
+         Masc.Keeper_reaction_ledger.project_event_queue_transition_outbox_result
+           ~base_path
+           ~keeper_name:from_keeper
+           ~expected_transition_id:first_transition_id
+       with
+       | Ok () -> ()
+       | Error detail -> Alcotest.fail detail);
+      stage_transfer
+        ~base_path
+        ~from_keeper
+        ~to_keeper
+        ~source:bootstrap_stim
+        ~owner_nonce:31
+        ~operation_id:"recover-transfer-second";
+      let second_transition_id =
+        match
+          load_queue_state ~base_path ~keeper_name:from_keeper
+          |> Keeper_event_queue_state.transition_outbox
+        with
+        | [ entry ] -> entry.receipt.transition_id
+        | _ -> Alcotest.fail "second transfer did not stage one outbox entry"
+      in
+      (match
+         Masc.Keeper_reaction_ledger.project_event_queue_transition_outbox_result
+           ~base_path
+           ~keeper_name:from_keeper
+           ~expected_transition_id:first_transition_id
+       with
+       | Error _ -> ()
+       | Ok () -> Alcotest.fail "stale recovery retired the newer transfer");
+      let retained_transition_id =
+        match
+          load_queue_state ~base_path ~keeper_name:from_keeper
+          |> Keeper_event_queue_state.transition_outbox
+        with
+        | [ entry ] -> entry.receipt.transition_id
+        | _ -> Alcotest.fail "stale recovery did not preserve one outbox entry"
+      in
+      Alcotest.(check string)
+        "newer transfer remains authoritative"
+        second_transition_id
+        retained_transition_id);
 
   (* --- current-only hard cut: the retired v12 filename is not a read,
          migration, or overwrite source for the v14 queue. --- *)

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -96,10 +96,26 @@ let test_reinserted_source_invalidates_old_selection () =
     |> State.with_pending (queue [ source ])
     |> State.with_revision 2L
   in
+  let source_ref = State.source_snapshot_ref source in
+  (match
+     State.resolve_pending_selection
+       ~source_ref
+       ~source_incarnation:old_selection.admitted_revision
+       reinserted
+   with
+   | Error _ -> ()
+   | Ok _ ->
+     Alcotest.fail "source ref bypassed the reinserted source incarnation");
   (match State.ack_pending ~selection:old_selection reinserted with
    | Error _ -> ()
    | Ok _ -> Alcotest.fail "old selection consumed a reinserted source");
   let current_selection = select reinserted in
+  ignore
+    (State.resolve_pending_selection
+       ~source_ref
+       ~source_incarnation:current_selection.admitted_revision
+       reinserted
+     |> require_ok "current source ref and incarnation");
   let acked =
     State.ack_pending ~selection:current_selection reinserted
     |> require_ok "current source incarnation ACK"
@@ -408,7 +424,7 @@ let test_durable_peek_ack_restart () =
     Alcotest.(check (list string)) "restart sees only unacked source" [ "two" ] (post_ids restarted))
 ;;
 
-let test_durable_reprioritize_is_revision_fenced () =
+let test_durable_reprioritize_is_source_incarnation_fenced () =
   with_temp_dir "keeper-event-reprioritize" (fun base_path ->
     let keeper_name = "priority-keeper" in
     let first = stimulus "shared-post" 1.0 in
@@ -423,45 +439,69 @@ let test_durable_reprioritize_is_revision_fenced () =
       Persistence.load_state_result ~base_path ~keeper_name
       |> require_ok "load priority state"
     in
-    let revision = State.revision state in
+    let selection =
+      State.select_when
+        ~ready:(Queue.stimulus_identity_equal second)
+        state
+      |> require_some "select exact priority source"
+    in
+    let source_ref = State.source_snapshot_ref selection.source in
+    Persistence.update_result ~base_path ~keeper_name (fun pending ->
+      Queue.enqueue pending (stimulus "unrelated" 3.0))
+    |> require_ok "enqueue unrelated source";
+    let state_after_unrelated =
+      Persistence.load_state_result ~base_path ~keeper_name
+      |> require_ok "load state after unrelated enqueue"
+    in
+    let resolved =
+      State.resolve_pending_selection
+        ~source_ref
+        ~source_incarnation:selection.admitted_revision
+        state_after_unrelated
+      |> require_ok "resolve selection after unrelated enqueue"
+    in
+    Alcotest.(check bool)
+      "opaque source ref resolves the exact same-post source"
+      true
+      (resolved = selection);
+    let revision_before_priority = State.revision state_after_unrelated in
     let applied_revision =
       Persistence.reprioritize_pending_result
         ~base_path
         ~keeper_name
-        ~expected_revision:revision
-        ~source:second
+        ~selection
         ~urgency:Queue.Immediate
         ()
       |> require_ok "reprioritize exact source"
     in
     Alcotest.(check int64)
       "priority change advances revision once"
-      (Int64.succ revision)
+      (Int64.succ revision_before_priority)
       applied_revision;
-    let restarted =
-      Persistence.load_pending_result ~base_path ~keeper_name
+    let restarted_state =
+      Persistence.load_state_result ~base_path ~keeper_name
       |> require_ok "restart priority load"
     in
     Alcotest.(check (list string))
       "same post id remains independently addressable"
-      [ "shared-post"; "shared-post" ]
-      (post_ids restarted);
+      [ "shared-post"; "shared-post"; "unrelated" ]
+      (post_ids (State.pending restarted_state));
     Alcotest.(check (list (float 0.0)))
       "priority change preserves the distinct same-post source"
-      [ 2.0; 1.0 ]
-      (Queue.to_list restarted
+      [ 2.0; 1.0; 3.0 ]
+      (State.pending restarted_state
+       |> Queue.to_list
        |> List.map (fun (item : Queue.stimulus) -> item.arrived_at));
     match
       Persistence.reprioritize_pending_result
         ~base_path
         ~keeper_name
-        ~expected_revision:revision
-        ~source:second
+        ~selection
         ~urgency:Queue.Low
         ()
     with
     | Error _ -> ()
-    | Ok _ -> Alcotest.fail "stale priority revision was accepted")
+    | Ok _ -> Alcotest.fail "stale priority source incarnation was accepted")
 ;;
 
 let test_durable_turn_attempt_terminal_restart () =
@@ -678,9 +718,9 @@ let () =
     ; ( "persistence"
       , [ Alcotest.test_case "durable peek ack restart" `Quick test_durable_peek_ack_restart
         ; Alcotest.test_case
-            "durable reprioritize is revision fenced"
+            "durable reprioritize is source incarnation fenced"
             `Quick
-            test_durable_reprioritize_is_revision_fenced
+            test_durable_reprioritize_is_source_incarnation_fenced
         ; Alcotest.test_case
             "durable failed turn receipt restart"
             `Quick

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -203,7 +203,8 @@ let message text =
 
 let expect_unexpected_field field json =
   let inp =
-    { Lib.trace_id = "unexpected-field-t"
+    { Lib.turn_ref =
+        Ids.Turn_ref.make ~trace_id:"unexpected-field-t" ~absolute_turn:1
     ; messages = [ message "current JSON boundary" ]
     }
   in

--- a/test/test_keeper_manual_compaction_preemption.ml
+++ b/test/test_keeper_manual_compaction_preemption.ml
@@ -174,7 +174,7 @@ let test_owner_intake_compacts_then_resumes_source () =
       check string
         "manual compaction is selected ahead of the source"
         Q.manual_compaction_post_id
-        selected.post_id;
+        selected.source.post_id;
       selected
     | None -> fail "manual compaction preemption selected no source"
   in
@@ -203,7 +203,7 @@ let test_owner_intake_compacts_then_resumes_source () =
     check string
       "the exact original source resumes after compaction"
       source.post_id
-      selected.post_id
+      selected.source.post_id
   | None -> fail "the original source disappeared after manual compaction"
 ;;
 

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -335,7 +335,10 @@ let () =
       meta_fixture_exn
         (`Assoc
           [ "name", `String "corrupted-transcript"
-          ; "agent_name", `String (Keeper_identity.keeper_agent_name "corrupted-transcript")
+          ; ( "agent_name"
+            , `String
+                (Masc.Keeper_identity.keeper_agent_name
+                   "corrupted-transcript") )
           ; "trace_id", `String "trace-corrupted-transcript"
           ])
     in
@@ -380,7 +383,7 @@ let () =
           [ "name", `String "replaced-transcript-owner"
           ; ( "agent_name"
             , `String
-                (Keeper_identity.keeper_agent_name
+                (Masc.Keeper_identity.keeper_agent_name
                    "replaced-transcript-owner") )
           ; "trace_id", `String "trace-replaced-transcript-owner-old"
           ])
@@ -805,7 +808,9 @@ let () =
     meta_fixture_exn
       (`Assoc
         [ "name", `String keeper_name
-        ; "agent_name", `String keeper_name
+        ; ( "agent_name"
+          , `String
+              (Masc.Keeper_identity.keeper_agent_name keeper_name) )
         ; "trace_id", `String "trace-checkpoint-turn-persist"
         ])
   in
@@ -848,7 +853,9 @@ let () =
     meta_fixture_exn
       (`Assoc
         [ "name", `String keeper_name
-        ; "agent_name", `String keeper_name
+        ; ( "agent_name"
+          , `String
+              (Masc.Keeper_identity.keeper_agent_name keeper_name) )
         ; "trace_id", `String "trace-success-clears-stale-provider-failure"
         ])
   in

--- a/test/test_librarian_exact_output_conformance.ml
+++ b/test/test_librarian_exact_output_conformance.ml
@@ -995,7 +995,10 @@ let test_prompt_slice_and_provenance_share_one_input () =
           (fun index -> text_message (Printf.sprintf "retained-%d" index))
       in
       let input : Librarian.input =
-        { trace_id = "trace-prompt-provenance-snapshot"
+        { Librarian.turn_ref =
+            Ids.Turn_ref.make
+              ~trace_id:"trace-prompt-provenance-snapshot"
+              ~absolute_turn:1
         ; messages =
             text_message "dropped-before-prompt"
             :: tool_result_message
@@ -1110,8 +1113,16 @@ let test_episode_publication_failure_is_typed () =
   with_prompt_registry (fun () ->
     with_temp_keepers_dir (fun keepers_dir ->
       run_eio (fun ~sw ~net ~clock ->
+        let keeper_id = "librarian-episode-write-failure-keeper" in
+        let keeper_dir =
+          Filename.concat keepers_dir keeper_id
+          |> Keeper_fs.ensure_dir
+        in
+        let episodes_path = Filename.concat keeper_dir "episodes" in
         let server =
           Fixture.start_server
+            ~on_request_before_reply:(fun () ->
+              Unix.chmod episodes_path 0o500)
             ~sw
             ~net
             ~clock
@@ -1122,28 +1133,27 @@ let test_episode_publication_failure_is_typed () =
             ; base_url = server.base_url
             }
           ];
-        let keeper_id = "librarian-episode-write-failure-keeper" in
-        let keeper_dir =
-          Filename.concat keepers_dir keeper_id
-          |> Keeper_fs.ensure_dir
+        let result =
+          Fun.protect
+            ~finally:(fun () ->
+              if Sys.file_exists episodes_path
+              then Unix.chmod episodes_path 0o700)
+            (fun () ->
+               extract_and_append_with_exact_output
+                 ~clock
+                 ~net
+                 ~keeper_id
+                 (librarian_input "trace-episode-write-failure"))
         in
-        Out_channel.with_open_bin
-          (Filename.concat keeper_dir "episodes")
-          (fun channel -> output_string channel "not-a-directory");
-        match
-          extract_and_append_with_exact_output
-            ~clock
-            ~net
-            ~keeper_id
-            (librarian_input "trace-episode-write-failure")
+        match result
         with
         | Error error ->
-          Alcotest.(check bool)
-            "episode failure keeps its publication phase"
-            true
-            (String.starts_with
-               ~prefix:"memory os publication failed phase=episode:"
-               error);
+          if
+            not
+              (String.starts_with
+                 ~prefix:"memory os publication failed phase=episode:"
+                 error)
+          then Alcotest.failf "unexpected episode publication failure: %s" error;
           Alcotest.(check int)
             "facts were already written before the episode failure"
             1


### PR DESCRIPTION
## 문제

#26455의 event operator는 `queue_index`를 mutation locator로 사용하고, reprioritize에는 전역 `expected_revision` Gate까지 유지합니다. 그래서 무관한 enqueue/선행 항목 제거가 선택한 source와 관계없이 동작을 거부하거나 다른 row를 가리킬 수 있습니다.

#26458은 `source_incarnation`을 추가했지만 position locator와 reprioritize의 전역 Gate를 남겨 같은 문제를 완전히 제거하지 못합니다. #26462는 그 브랜치 위에 current-hard-cut fixture 수리를 쌓아 병합 순서도 오염됩니다.

## 변경

- pending wire를 current-only `keeper_event_queue.pending.v2`로 hard-cut하고 각 항목에 다음 derived metadata를 노출합니다.
  - `source_ref`: exact typed stimulus snapshot의 SHA-256. raw payload는 노출하지 않습니다.
  - `source_incarnation`: 동일 snapshot의 재삽입/재생성을 구분하는 기존 `admitted_revision`.
- cancel/transfer/reprioritize 요청을 current-only `keeper_event_queue.operator.request.v2`로 hard-cut합니다.
- mutation 권한에서 전역 queue revision과 queue position을 모두 제거합니다.
- pure state가 `{source_ref, source_incarnation}`을 exact selection으로 해석하고 persistence가 같은 selection을 다시 검증합니다.
- reprioritize는 선택한 source만 새 incarnation으로 바꾸며 unrelated entries의 incarnation은 유지합니다.
- committed cancel/transfer replay는 operation ID와 exact source snapshot/incarnation/action parameters가 모두 같을 때만 허용합니다.
- Dashboard의 queue index는 표시와 pagination에만 남고 mutation request에는 전달되지 않습니다.
- 삭제된 current-only 타입 경계 뒤에 남은 Librarian `TurnRef`, pending selection, canonical Keeper identity fixture를 정렬했습니다. migration/fallback/legacy field는 추가하지 않았습니다.
- generation reservation 뒤의 episode publication failure를 실제 publication 시점에 주입하도록 낡은 fixture를 수정했습니다.

## Blast radius

- Keeper event queue pure state/persistence/registry
- Admin event pending GET/POST wire와 private Execute boundary
- Dashboard event queue API/UI
- current-hard-cut compile fixtures

새 durable field나 별도 selector SSOT, test-only Execute facade는 없습니다. `source_ref`는 typed source에서 매번 파생되고 `source_incarnation`과 책임이 겹치지 않습니다.

## 검증

대상 head: `bb930bda4a`

- focused Dune build 6 targets: PASS
- event queue state/persistence: 13/13
- manual compaction preemption: 4/4
- terminal reason matrix: 115,200 cases, mismatch 0
- Librarian retry/current boundary: 12/12
- Librarian exact-output conformance: 18/18
- Dashboard event pending projection focused case: 1/1
- Dashboard TypeScript typecheck: PASS
- Dashboard focused Vitest: 92/92
- `git diff --check`: PASS

`test_dashboard_http_core` 전체 실행의 기존 unrelated proof/offline/context-window fixture 4건은 여전히 실패하지만, 이 변경의 event pending projection case는 분리 실행에서 통과합니다. exact-head GitHub Build and Test를 최종 권위로 대기합니다.

Supersedes #26458 and #26462.
Closes #26457.

[근거] current main `e53ddedb0184ce7e87d8aa6bca683fd3c39fa0b8`에서 producer -> pending selection -> HTTP v2 -> Dashboard caller -> private Execute -> pure state -> persistence 역방향 대조 및 위 focused 명령 실행 · 확인 2026-07-30 18:16 KST · 신뢰도 High
