### PR TITLE
feat(keeper): expose exact provider input evidence

### DIFF
--- a/dashboard/src/api/dashboard-turn-records.test.ts
+++ b/dashboard/src/api/dashboard-turn-records.test.ts
@@ -19,6 +19,9 @@ function entry(overrides: Record<string, unknown> = {}) {
       ts: 1_700_000_000,
       execution_ids: ['exec-1'],
       blocks: [],
+      input_components: [],
+      request_runtime_profile: null,
+      request_body_bytes: null,
       input_tokens: 1200,
       output_tokens: 340,
       ...overrides,
@@ -71,8 +74,8 @@ afterEach(() => {
 
 // #25779 made the provider cache token counts durable on the turn record, but
 // the decoder rebuilt each entry without them, so they were discarded before
-// reaching the inspector. Absent stays absent — a legacy row must not decode to
-// a fabricated 0.
+// reaching the inspector. Provider absence stays absent rather than becoming a
+// fabricated 0.
 describe('keeper turn record cache token counts', () => {
   it('carries the durable cache counts through the decoder', async () => {
     getMock.mockResolvedValue(
@@ -144,6 +147,16 @@ describe('keeper turn record cache token counts', () => {
     )
   })
 
+  it('rejects an unknown prompt block identity', async () => {
+    getMock.mockResolvedValue(payload(entry({
+      blocks: [{ block: 'future_block', bytes: 1, digest: 'digest' }],
+    })))
+
+    await expect(fetchKeeperTurnRecords('sangsu')).rejects.toThrow(
+      '유효하지 않은 keeper turn record payload',
+    )
+  })
+
   it('rejects a response count that disagrees with the exact decoded rows', async () => {
     const raw = payload(entry())
     raw.count = 2
@@ -201,6 +214,51 @@ describe('keeper turn record cache token counts', () => {
 
   it('rejects a turn_ref that disagrees with trace_id and absolute_turn', async () => {
     getMock.mockResolvedValue(payload(entry({ turn_ref: 'trace-1#8' })))
+
+    await expect(fetchKeeperTurnRecords('sangsu')).rejects.toThrow(
+      '유효하지 않은 keeper turn record payload',
+    )
+  })
+})
+
+describe('keeper turn record final provider input', () => {
+  it('keeps attributed content, wire bytes, and fallback runtime separate', async () => {
+    getMock.mockResolvedValue(payload(entry({
+      input_components: [
+        { component: 'prompt.persona', bytes: 1200 },
+        { component: 'prompt.dynamic_context', bytes: 11 },
+        { component: 'tool_schemas', bytes: 64000 },
+        { component: 'message_tool_result', bytes: 2800 },
+      ],
+      request_runtime_profile: 'anthropic.fallback',
+      request_body_bytes: 560_513,
+    })))
+
+    const response = await fetchKeeperTurnRecords('sangsu')
+
+    expect(response.entries[0]?.record).toMatchObject({
+      input_components: [
+        { component: 'prompt.persona', bytes: 1200 },
+        { component: 'prompt.dynamic_context', bytes: 11 },
+        { component: 'tool_schemas', bytes: 64000 },
+        { component: 'message_tool_result', bytes: 2800 },
+      ],
+      request_runtime_profile: 'anthropic.fallback',
+      request_body_bytes: 560_513,
+    })
+  })
+
+  it.each([
+    { input_components: undefined },
+    { request_runtime_profile: undefined },
+    { request_body_bytes: undefined },
+    { input_components: [{ component: 'history_guess', bytes: 1 }] },
+    { input_components: [{ component: 'prompt.', bytes: 1 }] },
+    { input_components: [{ component: 'prompt.future_block', bytes: 1 }] },
+    { request_runtime_profile: '' },
+    { request_body_bytes: -1 },
+  ])('rejects malformed current contracts: %j', async (override) => {
+    getMock.mockResolvedValue(payload(entry(override)))
 
     await expect(fetchKeeperTurnRecords('sangsu')).rejects.toThrow(
       '유효하지 않은 keeper turn record payload',

--- a/dashboard/src/api/dashboard-turn-records.ts
+++ b/dashboard/src/api/dashboard-turn-records.ts
@@ -5,10 +5,35 @@
 import { get, type AbortableRequestOptions } from './core'
 import { isRecord, asBoolean, asNumber, asNullableString, asString, asRecordArray } from '../components/common/normalize'
 
+export type TurnBlockId =
+  | 'persona'
+  | 'dynamic_context'
+  | 'temporal_summary'
+  | 'memory_os_recall'
+
 export type TurnBlock = {
-  block: string
+  block: TurnBlockId
   bytes: number
   digest: string
+}
+
+export type TurnInputComponentId =
+  | `prompt.${TurnBlockId}`
+  | 'tool_schemas'
+  | 'message_user'
+  | 'message_system'
+  | 'message_assistant_text'
+  | 'message_thinking'
+  | 'message_redacted_thinking'
+  | 'message_tool_use'
+  | 'message_tool_result'
+  | 'message_image'
+  | 'message_document'
+  | 'message_audio'
+
+export type TurnInputComponent = {
+  component: TurnInputComponentId
+  bytes: number
 }
 
 export type TurnRecordEntry = {
@@ -18,10 +43,13 @@ export type TurnRecordEntry = {
   absolute_turn: number
   turn_ref: string
   blocks: TurnBlock[]
+  input_components: TurnInputComponent[]
+  request_runtime_profile: string | null
+  request_body_bytes: number | null
   runtime_profile: string
   // RFC-0233 §2.3 — grounded from the backend turn record (boundary-redacted
-  // model label + keeper stop reason). Absent (undefined) on error turns and
-  // pre-grounding rows; the inspector renders absence, never a fabricated value.
+  // model label + keeper stop reason). Absent (undefined) when an error turn
+  // did not record them; the inspector renders absence, never a fabricated value.
   model?: string
   finish_reason?: string
   temperature?: number
@@ -32,10 +60,9 @@ export type TurnRecordEntry = {
   input_tokens?: number
   output_tokens?: number
   // #25779 made the provider cache counts durable on the turn record
-  // (lib/types/turn_record.ml:79-82 writes them as optional fields). Same
-  // absent-means-absent contract as the neighbours: a legacy row that predates
-  // #25779, or a provider that reports no cache usage, leaves these undefined
-  // and the inspector renders absence rather than a fabricated zero.
+  // (lib/types/turn_record.ml writes them as optional fields). A provider that
+  // reports no cache usage leaves these undefined; the inspector renders
+  // absence rather than a fabricated zero.
   cache_creation_input_tokens?: number
   cache_read_input_tokens?: number
   // RFC-0233 §8 — runtime model metadata. context_window is the keeper-resolved
@@ -266,9 +293,22 @@ export type KeeperCompactionSnapshotsResponse = {
   readonly items: KeeperCompactionSnapshot[]
 }
 
+const TURN_BLOCK_IDS = new Set<TurnBlockId>([
+  'persona',
+  'dynamic_context',
+  'temporal_summary',
+  'memory_os_recall',
+])
+
+function decodeTurnBlockId(raw: unknown): TurnBlockId | null {
+  return typeof raw === 'string' && TURN_BLOCK_IDS.has(raw as TurnBlockId)
+    ? raw as TurnBlockId
+    : null
+}
+
 function decodeTurnBlock(raw: unknown): TurnBlock | null {
   if (!isRecord(raw) || !hasExactKeys(raw, ['block', 'bytes', 'digest'])) return null
-  const block = decodeExactNonEmptyString(raw.block)
+  const block = decodeTurnBlockId(raw.block)
   const digest = decodeExactNonEmptyString(raw.digest)
   const bytes = asNumber(raw.bytes)
   if (
@@ -309,6 +349,43 @@ function decodeTurnBlockList(raw: unknown): TurnBlock[] | null {
   return blocks.every((block): block is TurnBlock => block !== null) ? blocks : null
 }
 
+const TURN_FIXED_INPUT_COMPONENTS = new Set<TurnInputComponentId>([
+  'tool_schemas',
+  'message_user',
+  'message_system',
+  'message_assistant_text',
+  'message_thinking',
+  'message_redacted_thinking',
+  'message_tool_use',
+  'message_tool_result',
+  'message_image',
+  'message_document',
+  'message_audio',
+])
+
+function decodeTurnInputComponentId(raw: unknown): TurnInputComponentId | null {
+  if (typeof raw !== 'string') return null
+  if (TURN_FIXED_INPUT_COMPONENTS.has(raw as TurnInputComponentId)) {
+    return raw as TurnInputComponentId
+  }
+  if (!raw.startsWith('prompt.')) return null
+  const block = decodeTurnBlockId(raw.slice('prompt.'.length))
+  return block === null ? null : `prompt.${block}`
+}
+
+function decodeTurnInputComponents(raw: unknown): TurnInputComponent[] | null {
+  if (!Array.isArray(raw)) return null
+  const components: TurnInputComponent[] = []
+  for (const item of raw) {
+    if (!isRecord(item) || !hasExactKeys(item, ['component', 'bytes'])) return null
+    const component = decodeTurnInputComponentId(item.component)
+    const bytes = decodeNonNegativeSafeInteger(item.bytes)
+    if (component === null || bytes === null) return null
+    components.push({ component, bytes })
+  }
+  return components
+}
+
 function decodeTurnRecordEntry(raw: unknown): TurnRecordEntry | null {
   if (!isRecord(raw) || !hasNoUnknownKeys(raw, [
     'execution_ids',
@@ -317,6 +394,9 @@ function decodeTurnRecordEntry(raw: unknown): TurnRecordEntry | null {
     'absolute_turn',
     'turn_ref',
     'blocks',
+    'input_components',
+    'request_runtime_profile',
+    'request_body_bytes',
     'runtime_profile',
     'model',
     'finish_reason',
@@ -342,6 +422,15 @@ function decodeTurnRecordEntry(raw: unknown): TurnRecordEntry | null {
   const runtime_profile = decodeExactNonEmptyString(raw.runtime_profile)
   const ts = asNumber(raw.ts)
   const blocks = decodeTurnBlockList(raw.blocks)
+  const input_components = decodeTurnInputComponents(raw.input_components)
+  const request_runtime_profile =
+    raw.request_runtime_profile === null
+      ? null
+      : decodeExactNonEmptyString(raw.request_runtime_profile)
+  const request_body_bytes =
+    raw.request_body_bytes === null
+      ? null
+      : decodeNonNegativeSafeInteger(raw.request_body_bytes)
   const turn_ref = decodeExactNonEmptyString(raw.turn_ref)
   const model = decodeOptionalField(raw, 'model', decodeExactNonEmptyString)
   const finish_reason = decodeOptionalField(raw, 'finish_reason', decodeExactNonEmptyString)
@@ -374,6 +463,11 @@ function decodeTurnRecordEntry(raw: unknown): TurnRecordEntry | null {
     || runtime_profile === null
     || ts == null
     || blocks === null
+    || input_components === null
+    || !Object.hasOwn(raw, 'request_runtime_profile')
+    || (request_runtime_profile === null && raw.request_runtime_profile !== null)
+    || !Object.hasOwn(raw, 'request_body_bytes')
+    || (request_body_bytes === null && raw.request_body_bytes !== null)
     || !Array.isArray(raw.execution_ids)
     || !raw.execution_ids.every((id): id is string => typeof id === 'string' && id.length > 0)
     || turn_ref === null
@@ -405,6 +499,9 @@ function decodeTurnRecordEntry(raw: unknown): TurnRecordEntry | null {
     absolute_turn,
     turn_ref,
     blocks,
+    input_components,
+    request_runtime_profile,
+    request_body_bytes,
     runtime_profile,
     model,
     finish_reason,

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -285,7 +285,10 @@ export { fetchKeeperToolCalls } from './dashboard-keeper-tool-calls'
 // ── Keeper turn records (RFC-0233 PR-4) ─────────────────
 
 export type {
+  TurnBlockId,
   TurnBlock,
+  TurnInputComponentId,
+  TurnInputComponent,
   TurnRecordEntry,
   TurnBlockDiff,
   TurnRecordRow,

--- a/dashboard/src/components/keeper-turn-inspector.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector.test.ts
@@ -146,7 +146,10 @@ function turnRecordsWithMemoryOs(): TurnRecordsResponse {
           turn_ref: 'trace-active#41',
           ts: 1_781_587_500,
           runtime_profile: 'local',
-          blocks: [{ block: 'system', bytes: 1200, digest: '1111222233334444' }],
+          blocks: [{ block: 'persona', bytes: 1200, digest: '1111222233334444' }],
+          input_components: [{ component: 'prompt.persona', bytes: 1200 }],
+          request_runtime_profile: 'local',
+          request_body_bytes: 1540,
           execution_ids: [],
         },
         diff_vs_prev: null,
@@ -169,9 +172,17 @@ function turnRecordsWithMemoryOs(): TurnRecordsResponse {
           request_latency_ms: 1234,
           ttfrc_ms: 567.8,
           blocks: [
-            { block: 'system', bytes: 1200, digest: '1111222233334444' },
+            { block: 'persona', bytes: 1200, digest: '1111222233334444' },
             { block: 'memory_os_recall', bytes: 3392, digest: 'aabbccddeeff00112233' },
           ],
+          input_components: [
+            { component: 'prompt.persona', bytes: 1200 },
+            { component: 'prompt.memory_os_recall', bytes: 3392 },
+            { component: 'tool_schemas', bytes: 8400 },
+            { component: 'message_user', bytes: 24 },
+          ],
+          request_runtime_profile: 'local',
+          request_body_bytes: 14_322,
           execution_ids: ['exec-42'],
         },
         diff_vs_prev: {
@@ -418,7 +429,7 @@ describe('KeeperTurnInspector v2 drawer', () => {
       expect(container.querySelector('[data-testid="turn-tab-messages"]')?.classList.contains('on')).toBe(true)
     })
 
-    expect(container.textContent).toContain('모델에 전달된 시퀀스')
+    expect(container.textContent).toContain('연결된 transcript · provider 입력 증거')
 
     fireEvent.click(container.querySelector('[data-testid="turn-tab-meta"]')!)
 
@@ -508,7 +519,7 @@ describe('KeeperTurnInspector v2 drawer', () => {
 
   it('renders finish_reason absence as n/a without fabricating a value', async () => {
     const response = turnRecordsWithMemoryOs()
-    // strip the grounded meta fields → simulate an error turn / pre-grounding row
+    // Strip grounded meta fields to simulate an error turn without observations.
     response.entries[1] = {
       ...response.entries[1]!,
       record: {
@@ -617,7 +628,7 @@ describe('KeeperTurnInspector v2 drawer', () => {
     expect(stats).toContain('280')
     expect(stats).toContain('도구')
     expect(stats).toContain('1')
-    expect(stats).toContain('추정비용')
+    expect(stats).toContain('계산 비용')
     // RFC-0233 §8: turn 42 fixture carries real context_window + prices, so
     // the nullable ctxPct/cost render grounded values — not "미상". Guards the
     // number|null widening against a regression that drops the grounded path.

--- a/dashboard/src/components/keeper-turn-inspector.ts
+++ b/dashboard/src/components/keeper-turn-inspector.ts
@@ -288,8 +288,8 @@ type TurnPhase = {
 
 type TurnDetail = {
   traceId: string
-  tokIn: number
-  tokOut: number
+  tokIn: number | null
+  tokOut: number | null
   // RFC-0233 §8 — null when context_window/price are absent on the record
   // (runtime unknown or operator left runtime.toml unset); render "미상".
   ctxPct: number | null
@@ -334,16 +334,14 @@ function approxTokens(str: string): number {
 }
 
 function buildSystemPrompt(keeperName: string, record: TurnRecordEntry): string {
-  return `당신은 MASC 코디네이션 서버의 keeper "${keeperName}" 입니다.
-runtime · profile : ${record.runtime_profile}
-absolute turn     : T${record.absolute_turn}
-trace id          : ${record.trace_id}
+  return `시스템 프롬프트 원문은 TurnRecord에 저장되지 않습니다.
+keeper        = ${keeperName}
+runtime       = ${record.runtime_profile}
+absolute turn = T${record.absolute_turn}
+trace id      = ${record.trace_id}
 
-원칙
-- 모든 작업은 trace 로 기록한다.
-- 컨텍스트 사용량이 85% 를 넘으면 compact() 를 호출한다.
-- 소유하지 않은 태스크는 핸드오프(HandingOff)로 넘긴다.
-- 답변은 근거(도구 결과·trace)를 함께 제시한다.`
+확인 가능한 값은 context 탭의 prompt block digest/bytes와
+final provider input component bytes입니다. 원문을 복원하거나 추정하지 않습니다.`
 }
 
 function thinkingStateLabel(record: TurnRecordEntry): string {
@@ -364,10 +362,14 @@ function formatCtxWindowK(cw: number | null | undefined): string {
   return cw != null ? `${Math.round(cw / 1000)}K` : '미상'
 }
 
-function buildInjectedCtx(record: TurnRecordEntry, ctxPct: number | null, tokIn: number): string {
+function buildInjectedCtx(
+  record: TurnRecordEntry,
+  ctxPct: number | null,
+  tokIn: number | null,
+): string {
   const ctxLine = ctxPct != null
-    ? `${ctxPct.toFixed(1)}%   (${tokIn.toLocaleString()} / ${record.context_window?.toLocaleString() ?? '미상'} tok)`
-    : `미상   (${tokIn.toLocaleString()} / 미상 tok, runtime 미구성)`
+    ? `${ctxPct.toFixed(1)}%   (${tokIn?.toLocaleString() ?? '미상'} / ${record.context_window?.toLocaleString() ?? '미상'} tok)`
+    : `미상   (${tokIn?.toLocaleString() ?? '미상'} / ${record.context_window?.toLocaleString() ?? '미상'} tok)`
   return `# world snapshot
 fsm.state      = n/a
 model          = ${record.model ?? 'n/a'}
@@ -381,6 +383,14 @@ thinking.budget= ${record.thinking_budget ?? '—'}
 ${record.blocks.length
     ? record.blocks.map(b => `  - ${b.block}  ${b.bytes}B  ${b.digest.slice(0, 12)}`).join('\n')
     : '  (none)'}
+
+# final provider input components
+${record.input_components.length
+    ? record.input_components.map(component => `  - ${component.component}  ${component.bytes}B`).join('\n')
+    : '  (none)'}
+
+request.runtime = ${record.request_runtime_profile ?? 'not observed'}
+request.wire    = ${record.request_body_bytes != null ? `${record.request_body_bytes}B` : 'not observed'}
 
 # tool executions
 ${record.execution_ids.length
@@ -505,18 +515,21 @@ function buildTurnDetail(
   toolEntries: readonly ToolCallEntry[],
 ): TurnDetail {
   const traceId = `${record.trace_id}_${String(record.absolute_turn).padStart(4, '0')}`
-  const tokIn = record.input_tokens ?? Math.max(1, Math.round(record.blocks.reduce((sum, b) => sum + b.bytes, 0) / 4))
-  const tokOut = record.output_tokens ?? 120
+  const tokIn = record.input_tokens ?? null
+  const tokOut = record.output_tokens ?? null
   // RFC-0233 §8 — ctx-fill% and cost grounded in runtime.toml-declared facts.
   // context_window is the keeper-resolved effective budget (replaces the
   // hardcoded 200K); prices are USD/1M from the binding (replace Claude $3/$15).
   // Either is null when the record lacks the fact — the view renders "미상".
   const ctxPct =
-    record.context_window != null && record.context_window > 0
+    tokIn != null && record.context_window != null && record.context_window > 0
       ? Math.min(100, (tokIn / record.context_window) * 100)
       : null
   const cost =
-    record.price_input_per_million != null && record.price_output_per_million != null
+    tokIn != null
+    && tokOut != null
+    && record.price_input_per_million != null
+    && record.price_output_per_million != null
       ? (tokIn * record.price_input_per_million + tokOut * record.price_output_per_million) / 1e6
       : null
   const toolIndex = toolCallIndexByExecutionId(toolEntries)
@@ -776,16 +789,12 @@ function MessagesTab({
   let seq = 0
   const userLines = transcript.kind === 'loaded' ? transcript.data.user : []
   const assistantLines = transcript.kind === 'loaded' ? transcript.data.assistant : []
-  // 2 synthetic (system + context) + real user lines + tools + real assistant
-  // lines. Falls back to one placeholder slot each while loading/absent.
-  const userSlots = userLines.length || 1
-  const assistantSlots = assistantLines.length || 1
-  const messageCount = 2 + userSlots + t.tools.length + assistantSlots
+  const linkedCount = userLines.length + t.tools.length + assistantLines.length
   return html`
     <div class="kti-sec">
       <div class="kti-sec-h">
-        <h4>모델에 전달된 시퀀스</h4>
-        <span class="n">${messageCount} 메시지</span>
+        <h4>연결된 transcript · provider 입력 증거</h4>
+        <span class="n">${linkedCount} 연결 항목</span>
       </div>
       ${transcript.kind === 'loading'
         ? html`<div class="text-2xs text-[var(--color-fg-muted)] px-1 pb-1" data-testid="turn-transcript-loading">전사 불러오는 중…</div>`
@@ -797,7 +806,7 @@ function MessagesTab({
         <div class="kti-msg">
           <div class="kti-msg-h">
             <span class="kti-msg-role system">system</span>
-            <span class="who">시스템 프롬프트</span>
+            <span class="who">시스템 프롬프트 · 원문 미기록</span>
             <span class="seq">#${++seq}</span>
           </div>
           <div class="kti-msg-b mono">${t.systemPrompt}</div>
@@ -805,7 +814,7 @@ function MessagesTab({
         <div class="kti-msg">
           <div class="kti-msg-h">
             <span class="kti-msg-role context">context</span>
-            <span class="who">주입 컨텍스트</span>
+            <span class="who">TurnRecord provider 입력 attribution</span>
             <span class="seq">#${++seq}</span>
           </div>
           <div class="kti-msg-b mono">${t.injectedCtx}</div>
@@ -863,8 +872,8 @@ function ContextTab({ t }: { t: TurnDetail }) {
     <div class="kti-sec">
       <div class="kti-ctx-card">
         <div class="kti-ctx-h">
-          <span class="t">시스템 프롬프트</span>
-          <span class="tok">~${approxTokens(t.systemPrompt)} tok</span>
+          <span class="t">시스템 프롬프트 · 원문 미기록</span>
+          <span class="tok">bytes/digest만 보존</span>
           <${CopyBtn} text=${t.systemPrompt} />
         </div>
         <pre>${t.systemPrompt}</pre>
@@ -873,8 +882,8 @@ function ContextTab({ t }: { t: TurnDetail }) {
     <div class="kti-sec">
       <div class="kti-ctx-card">
         <div class="kti-ctx-h">
-          <span class="t">주입 컨텍스트 · blocks · executions</span>
-          <span class="tok">~${approxTokens(t.injectedCtx)} tok</span>
+          <span class="t">provider 입력 attribution · blocks · executions</span>
+          <span class="tok">실측 byte 구성</span>
           <${CopyBtn} text=${t.injectedCtx} />
         </div>
         <pre>${t.injectedCtx}</pre>
@@ -899,8 +908,11 @@ function MetaTab({ record, t, source }: { record: TurnRecordEntry; t: TurnDetail
         <span class="k">model</span><span class="v">${record.model ?? 'n/a'}</span>
         <span class="k">runtime</span><span class="v">${record.runtime_profile}</span>
         <span class="k">fsm.state</span><span class="v">n/a</span>
-        <span class="k">input tokens</span><span class="v">${t.tokIn.toLocaleString()}</span>
-        <span class="k">output tokens</span><span class="v">${t.tokOut.toLocaleString()}</span>
+        <span class="k">input tokens</span><span class="v">${t.tokIn?.toLocaleString() ?? '미상'}</span>
+        <span class="k">output tokens</span><span class="v">${t.tokOut?.toLocaleString() ?? '미상'}</span>
+        <span class="k">attributed content bytes</span><span class="v">${record.input_components.reduce((sum, component) => sum + component.bytes, 0).toLocaleString()}</span>
+        <span class="k">serialized request bytes</span><span class="v">${record.request_body_bytes?.toLocaleString() ?? '미관측'}</span>
+        <span class="k">request runtime</span><span class="v">${record.request_runtime_profile ?? '미관측'}</span>
         <span class="k">cache read tokens</span><span class="v">${record.cache_read_input_tokens?.toLocaleString() ?? '미상'}</span>
         <span class="k">cache write tokens</span><span class="v">${record.cache_creation_input_tokens?.toLocaleString() ?? '미상'}</span>
         <span class="k">ctx window${record.context_window != null ? '' : ' · 미상'}</span><span class="v">${t.ctxPct != null ? `${t.ctxPct.toFixed(1)}% / ${record.context_window?.toLocaleString() ?? '미상'}` : '미상'}</span>
@@ -1027,18 +1039,18 @@ function TurnDetailDrawer({
           </div>
           <div class="kti-stat">
             <div class="k">입력</div>
-            <div class="v">${(t.tokIn / 1000).toFixed(1)}<small>k</small></div>
+            <div class="v">${t.tokIn != null ? (t.tokIn / 1000).toFixed(1) : '미상'}${t.tokIn != null ? html`<small>k</small>` : null}</div>
           </div>
           <div class="kti-stat">
             <div class="k">출력</div>
-            <div class="v volt">${t.tokOut.toLocaleString()}</div>
+            <div class="v volt">${t.tokOut?.toLocaleString() ?? '미상'}</div>
           </div>
           <div class="kti-stat">
             <div class="k">도구</div>
             <div class="v">${t.tools.length}</div>
           </div>
           <div class="kti-stat">
-            <div class="k">추정비용</div>
+            <div class="k">계산 비용</div>
             <div class="v ok">${t.cost != null ? `$${t.cost.toFixed(2)}` : '미상'}</div>
           </div>
         </div>
@@ -1049,18 +1061,22 @@ function TurnDetailDrawer({
             <span class="ctxpct">${t.ctxPct != null ? `컨텍스트 ${t.ctxPct.toFixed(1)}% / ${formatCtxWindowK(t.contextWindow)}` : '컨텍스트 미상'}</span>
           </div>
           <div class="kti-tok-bar">
-            <span
-              class="seg-in"
-              style=${{ width: `${(t.tokIn / (t.tokIn + t.tokOut)) * 100}%` }}
-            />
-            <span
-              class="seg-out"
-              style=${{ width: `${(t.tokOut / (t.tokIn + t.tokOut)) * 100}%` }}
-            />
+            ${t.tokIn != null && t.tokOut != null && t.tokIn + t.tokOut > 0
+              ? html`
+                <span
+                  class="seg-in"
+                  style=${{ width: `${(t.tokIn / (t.tokIn + t.tokOut)) * 100}%` }}
+                />
+                <span
+                  class="seg-out"
+                  style=${{ width: `${(t.tokOut / (t.tokIn + t.tokOut)) * 100}%` }}
+                />
+              `
+              : null}
           </div>
           <div class="kti-tok-legend">
-            <span class="in"><i></i>입력 <b>${t.tokIn.toLocaleString()}</b></span>
-            <span class="out"><i></i>출력 <b>${t.tokOut.toLocaleString()}</b></span>
+            <span class="in"><i></i>입력 <b>${t.tokIn?.toLocaleString() ?? '미상'}</b></span>
+            <span class="out"><i></i>출력 <b>${t.tokOut?.toLocaleString() ?? '미상'}</b></span>
           </div>
         </div>
 

--- a/dashboard/src/components/memory-inspector.test.ts
+++ b/dashboard/src/components/memory-inspector.test.ts
@@ -7,8 +7,8 @@ import {
   MemoryInspector,
   factCategoryMeta,
   factSelectionReason,
-  latestEntryWithBlocks,
-  memCompositionFromBlocks,
+  latestEntryWithInputComponents,
+  memCompositionFromInputComponents,
   memFmtBytes,
   memFmtTok,
   promptBlockMeta,
@@ -16,7 +16,11 @@ import {
   sortMemoryFactsForReview,
   type MemoryKeeper,
 } from './memory-inspector'
-import { type MemoryOsFact, type TurnRecordRow } from '../api/dashboard'
+import {
+  type MemoryOsFact,
+  type TurnBlockId,
+  type TurnRecordRow,
+} from '../api/dashboard'
 
 afterEach(() => {
   cleanup()
@@ -124,8 +128,16 @@ function turnRecordsPayload() {
             { block: 'persona', bytes: 1200, digest: 'aaaa1111bbbb' },
             { block: 'memory_os_recall', bytes: 800, digest: 'cccc2222dddd' },
             { block: 'dynamic_context', bytes: 400, digest: 'eeee3333ffff' },
-            { block: 'zero_block', bytes: 0, digest: '000000000000' },
+            { block: 'temporal_summary', bytes: 0, digest: '000000000000' },
           ],
+          input_components: [
+            { component: 'prompt.persona', bytes: 1200 },
+            { component: 'prompt.memory_os_recall', bytes: 800 },
+            { component: 'prompt.dynamic_context', bytes: 400 },
+            { component: 'tool_schemas', bytes: 600 },
+          ],
+          request_runtime_profile: 'local',
+          request_body_bytes: 3412,
           execution_ids: [],
           input_tokens: 3500,
           context_window: 200000,
@@ -178,7 +190,7 @@ describe('MemoryInspector — one-keeper scope (real data)', () => {
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/keepers/masc-improver/turn-records?limit=24')
   })
 
-  it('builds the composition bar from real prompt-block bytes (zero blocks dropped)', async () => {
+  it('builds the composition bar from final provider input components', async () => {
     stubFetch()
     const { container } = renderInspector()
     const bar = await waitFor(() => {
@@ -186,11 +198,11 @@ describe('MemoryInspector — one-keeper scope (real data)', () => {
       expect(b).toBeTruthy()
       return b!
     })
-    // 4 blocks in payload, 1 has 0 bytes → 3 segments + 3 legend rows.
-    expect(bar.querySelectorAll('span').length).toBe(3)
-    expect(container.querySelectorAll('.mem-leg').length).toBe(3)
-    // total bytes = 1200+800+400 = 2400, shown as KB; token readout from input_tokens.
-    expect(container.querySelector('.mem-compo-tot')?.textContent).toBe('2.3KB')
+    // 4 non-zero input components → 4 segments + 4 legend rows.
+    expect(bar.querySelectorAll('span').length).toBe(4)
+    expect(container.querySelectorAll('.mem-leg').length).toBe(4)
+    // Attributed bytes and provider token usage stay separate measurements.
+    expect(container.querySelector('.mem-compo-tot')?.textContent).toBe('attributed 2.9KB')
     expect(container.querySelector('.mem-compo-sub')?.textContent).toContain('3.5k tok')
     // block labels come from the Prompt_block_id mirror, not raw tokens.
     expect(container.textContent).toContain('메모리 회상')
@@ -531,37 +543,47 @@ describe('memory view-model helpers', () => {
     expect(memFmtBytes(2 * 1024 * 1024)).toBe('2.0MB')
   })
 
-  it('memCompositionFromBlocks sums real bytes and drops zero-byte blocks', () => {
-    const comp = memCompositionFromBlocks([
-      { block: 'persona', bytes: 1200, digest: 'x' },
-      { block: 'memory_os_recall', bytes: 800, digest: 'y' },
-      { block: 'empty', bytes: 0, digest: 'z' },
+  it('memCompositionFromInputComponents sums real bytes and drops zero-byte components', () => {
+    const comp = memCompositionFromInputComponents([
+      { component: 'prompt.persona', bytes: 1200 },
+      { component: 'prompt.memory_os_recall', bytes: 800 },
+      { component: 'message_user', bytes: 0 },
     ])
     expect(comp.totalBytes).toBe(2000)
-    expect(comp.parts.map(p => p.key)).toEqual(['persona', 'memory_os_recall'])
+    expect(comp.parts.map(p => p.key)).toEqual(['prompt.persona', 'prompt.memory_os_recall'])
     expect(comp.parts[0]?.lbl).toBe('페르소나')
   })
 
-  it('latestEntryWithBlocks skips an empty-block tail turn and returns the last assembled prompt', () => {
-    const mkRow = (turn: number, blocks: { block: string; bytes: number; digest: string }[]): TurnRecordRow => ({
+  it('latestEntryWithInputComponents skips a pre-serialization tail turn', () => {
+    const mkRow = (
+      turn: number,
+      input_components: TurnRecordRow['record']['input_components'],
+    ): TurnRecordRow => ({
       record: {
         keeper: 'k', trace_id: 't', absolute_turn: turn, ts: turn, runtime_profile: 'local',
         turn_ref: `t#${turn}`,
-        blocks, execution_ids: [],
+        blocks: [],
+        input_components,
+        request_runtime_profile: input_components.length > 0 ? 'local' : null,
+        request_body_bytes: input_components.length > 0 ? 100 : null,
+        execution_ids: [],
       },
       diff_vs_prev: null,
     })
-    const assembled = mkRow(1, [{ block: 'persona', bytes: 100, digest: 'd' }])
-    const errorTail = mkRow(2, []) // e.g. an error turn with no prompt blocks
-    // last row has no blocks → fall back to the most recent row that does
-    expect(latestEntryWithBlocks([assembled, errorTail])?.record.absolute_turn).toBe(1)
+    const assembled = mkRow(1, [{ component: 'prompt.persona', bytes: 100 }])
+    const errorTail = mkRow(2, [])
+    expect(latestEntryWithInputComponents([assembled, errorTail])?.record.absolute_turn).toBe(1)
     // empty input → null, not a fabricated row
-    expect(latestEntryWithBlocks([])).toBeNull()
-    expect(latestEntryWithBlocks([errorTail])).toBeNull()
+    expect(latestEntryWithInputComponents([])).toBeNull()
+    expect(latestEntryWithInputComponents([errorTail])).toBeNull()
   })
 
   it('recentMemoryRecallInjections returns newest real memory_os_recall blocks only', () => {
-    const mkRow = (turn: number, block: string, bytes: number): TurnRecordRow => ({
+    const mkRow = (
+      turn: number,
+      block: TurnBlockId,
+      bytes: number,
+    ): TurnRecordRow => ({
       record: {
         keeper: 'k',
         trace_id: `trace-${turn}`,
@@ -570,6 +592,9 @@ describe('memory view-model helpers', () => {
         ts: turn,
         runtime_profile: 'local',
         blocks: [{ block, bytes, digest: `digest-${turn}` }],
+        input_components: [],
+        request_runtime_profile: null,
+        request_body_bytes: null,
         execution_ids: [],
       },
       diff_vs_prev: null,
@@ -585,9 +610,11 @@ describe('memory view-model helpers', () => {
     ])
   })
 
-  it('promptBlockMeta maps known Prompt_block_id tokens and keeps unknown tokens raw', () => {
-    expect(promptBlockMeta('connected_surface').lbl).toBe('연결 표면')
-    expect(promptBlockMeta('some_future_block').lbl).toBe('some_future_block')
+  it('promptBlockMeta maps every current Prompt_block_id token', () => {
+    expect(promptBlockMeta('persona').lbl).toBe('페르소나')
+    expect(promptBlockMeta('dynamic_context').lbl).toBe('동적 컨텍스트')
+    expect(promptBlockMeta('temporal_summary').lbl).toBe('시간 요약')
+    expect(promptBlockMeta('memory_os_recall').lbl).toBe('메모리 회상')
   })
 
   it('factCategoryMeta covers every closed taxonomy arm', () => {

--- a/dashboard/src/components/memory-inspector.ts
+++ b/dashboard/src/components/memory-inspector.ts
@@ -8,7 +8,8 @@
 // salience/uses/lastUsed score fields) is gone.
 //
 // Section data sources (RFC-keeper-memory-panel-real-data §4; hybrid treatment confirmed 2026-06-24):
-//   컨텍스트 구성        ← real prompt-assembly block bytes (entries[latest].blocks)
+//   컨텍스트 구성        ← final provider-bound attributed bytes
+//                          (entries[latest].input_components)
 //   장기 메모리 스토어    ← real memory_os.facts.items (typed category, provenance)
 //   압축 유지·요약        ← real memory_os.episodes.items
 //   최근 회상·주입        ← real memory_os_recall prompt blocks (entries[*].blocks)
@@ -31,6 +32,9 @@ import {
   type MemoryOsFactCategory,
   type MemoryOsSelectionPolicy,
   type TurnBlock,
+  type TurnBlockId,
+  type TurnInputComponent,
+  type TurnInputComponentId,
   type TurnRecordRow,
 } from '../api/dashboard'
 
@@ -72,10 +76,7 @@ export function memFmtBytes(n: number): string {
 }
 
 // ── prompt-block composition (real, from turn_record blocks) ──
-// PROMPT_BLOCK_META mirrors the OCaml Prompt_block_id closed sum
-// (lib/types/prompt_block_id.ml — to_string is the wire SSOT). A token outside
-// the closed set is an `Other name` block; it keeps its raw label so a new
-// block id surfaces verbatim rather than as a silent miscolour.
+// PROMPT_BLOCK_META mirrors the current OCaml Prompt_block_id closed sum.
 interface BlockMeta {
   readonly lbl: string
   readonly color: string
@@ -84,18 +85,14 @@ interface BlockMeta {
   // carries recalled memory; the rest are persona/context/surface.
   readonly mem: boolean
 }
-const PROMPT_BLOCK_META: Readonly<Record<string, BlockMeta>> = {
+const PROMPT_BLOCK_META: Readonly<Record<TurnBlockId, BlockMeta>> = {
   persona: { lbl: '페르소나', color: 'var(--text-dim)', mem: false },
-  continuity: { lbl: '연속성', color: 'var(--info)', mem: false },
   dynamic_context: { lbl: '동적 컨텍스트', color: 'var(--volt)', mem: false },
   temporal_summary: { lbl: '시간 요약', color: 'var(--status-warn)', mem: false },
-  claimed_task_nudge: { lbl: '태스크 넛지', color: 'var(--status-ok)', mem: false },
-  retry_nudge: { lbl: '재시도 넛지', color: 'var(--status-bad)', mem: false },
   memory_os_recall: { lbl: '메모리 회상', color: 'var(--volt-strong)', mem: true },
-  connected_surface: { lbl: '연결 표면', color: 'var(--status-warn)', mem: false },
 }
-export function promptBlockMeta(token: string): BlockMeta {
-  return PROMPT_BLOCK_META[token] ?? { lbl: token, color: 'var(--text-dim)', mem: false }
+export function promptBlockMeta(token: TurnBlockId): BlockMeta {
+  return PROMPT_BLOCK_META[token]
 }
 
 export interface CompositionPart {
@@ -110,28 +107,62 @@ export interface Composition {
   readonly parts: readonly CompositionPart[]
 }
 
-// Composition from a turn's assembled prompt blocks. The bar is a BYTES ratio
-// (each block's real byte size); no token magic, no fabricated parts. Zero-byte
-// blocks are dropped so the legend matches the bar.
-export function memCompositionFromBlocks(blocks: readonly TurnBlock[]): Composition {
-  const parts: CompositionPart[] = blocks
-    .filter(b => b.bytes > 0)
-    .map(b => {
-      const meta = promptBlockMeta(b.block)
-      return { key: b.block, lbl: meta.lbl, bytes: b.bytes, color: meta.color, mem: meta.mem }
+const INPUT_COMPONENT_META: Readonly<
+  Record<TurnInputComponentId, Omit<CompositionPart, 'key' | 'bytes'>>
+> = {
+  'prompt.persona': PROMPT_BLOCK_META.persona,
+  'prompt.dynamic_context': PROMPT_BLOCK_META.dynamic_context,
+  'prompt.temporal_summary': PROMPT_BLOCK_META.temporal_summary,
+  'prompt.memory_os_recall': PROMPT_BLOCK_META.memory_os_recall,
+  tool_schemas: { lbl: '도구 스키마', color: 'var(--info)', mem: false },
+  message_user: { lbl: '메시지 · user', color: 'var(--volt)', mem: false },
+  message_system: { lbl: '메시지 · system', color: 'var(--status-warn)', mem: false },
+  message_assistant_text: { lbl: '메시지 · assistant', color: 'var(--status-ok)', mem: false },
+  message_thinking: { lbl: '메시지 · thinking', color: 'var(--volt-strong)', mem: false },
+  message_redacted_thinking: { lbl: '메시지 · redacted thinking', color: 'var(--status-bad)', mem: false },
+  message_tool_use: { lbl: '메시지 · tool use', color: 'var(--info)', mem: false },
+  message_tool_result: { lbl: '메시지 · tool result', color: 'var(--status-ok)', mem: false },
+  message_image: { lbl: '메시지 · image', color: 'var(--volt-strong)', mem: false },
+  message_document: { lbl: '메시지 · document', color: 'var(--status-warn)', mem: false },
+  message_audio: { lbl: '메시지 · audio', color: 'var(--info)', mem: false },
+}
+
+function inputComponentMeta(
+  component: TurnInputComponentId,
+): Omit<CompositionPart, 'key' | 'bytes'> {
+  return INPUT_COMPONENT_META[component]
+}
+
+// Composition is captured at the final model-input projection boundary. The
+// bar contains disjoint attributed content bytes only; serialized body bytes
+// and provider token usage stay separate measurements.
+export function memCompositionFromInputComponents(
+  components: readonly TurnInputComponent[],
+): Composition {
+  const parts: CompositionPart[] = components
+    .filter(component => component.bytes > 0)
+    .map(component => {
+      const meta = inputComponentMeta(component.component)
+      return {
+        key: component.component,
+        lbl: meta.lbl,
+        bytes: component.bytes,
+        color: meta.color,
+        mem: meta.mem,
+      }
     })
   const totalBytes = parts.reduce((sum, p) => sum + p.bytes, 0)
   return { totalBytes, parts }
 }
 
-// The most recent turn that actually assembled a prompt (has blocks). Entries
-// are append-ordered; an error/empty-block turn at the tail is skipped so the
-// composition reflects the last real prompt assembly — and the header token
-// figures are read from this same row, never a blank tail.
-export function latestEntryWithBlocks(rows: readonly TurnRecordRow[]): TurnRecordRow | null {
+// Entries are append-ordered. Pick the latest request with a captured provider
+// input composition; a pre-serialization error legitimately has none.
+export function latestEntryWithInputComponents(
+  rows: readonly TurnRecordRow[],
+): TurnRecordRow | null {
   for (let i = rows.length - 1; i >= 0; i--) {
     const row = rows[i]
-    if (row && row.record.blocks.length > 0) return row
+    if (row && row.record.input_components.length > 0) return row
   }
   return null
 }
@@ -224,16 +255,16 @@ function latestMemoryRecallBlock(row: TurnRecordRow | null): TurnBlock | null {
 
 function MemBar({ parts, total }: { parts: readonly CompositionPart[]; total: number }) {
   return html`
-    <div class="mem-bar" title="프롬프트 구성 (bytes)">
+    <div class="mem-bar" title="최종 provider 입력 구성 (attributed bytes)">
       ${parts.map(p => html`<span key=${p.key} style=${{ width: `${(p.bytes / total) * 100}%`, background: p.color }}></span>`)}
     </div>`
 }
 
 function MemCompoReal({ row }: { row: TurnRecordRow | null }) {
-  const blocks = row?.record.blocks ?? []
-  const { totalBytes, parts } = memCompositionFromBlocks(blocks)
+  const inputComponents = row?.record.input_components ?? []
+  const { totalBytes, parts } = memCompositionFromInputComponents(inputComponents)
   if (!row || totalBytes === 0) {
-    return html`<div class="mem-empty">조립된 프롬프트 블록 없음 — 활성 컨텍스트 없음.</div>`
+    return html`<div class="mem-empty">관측된 provider 입력 구성 없음.</div>`
   }
   const inputTok = row.record.input_tokens
   const ctxWin = row.record.context_window
@@ -243,11 +274,14 @@ function MemCompoReal({ row }: { row: TurnRecordRow | null }) {
   return html`
     <div class="mem-compo">
       <div class="mem-compo-head">
-        <span class="mono mem-compo-tot">${memFmtBytes(totalBytes)}</span>
+        <span class="mono mem-compo-tot">attributed ${memFmtBytes(totalBytes)}</span>
         <span class="mem-compo-sub">
           ${inputTok != null
             ? html`${memFmtTok(inputTok)} tok${ctxWin != null ? html` / ${memFmtTok(ctxWin)} 윈도우` : null}${pct != null ? html` · ${pct}%` : null}`
-            : html`${parts.length}개 블록`}
+            : html`provider token 미보고`}
+          ${row.record.request_body_bytes != null
+            ? html` · wire ${memFmtBytes(row.record.request_body_bytes)} · ${row.record.request_runtime_profile ?? 'runtime 미상'}`
+            : html` · wire 미관측`}
         </span>
       </div>
       <${MemBar} parts=${parts} total=${totalBytes} />
@@ -437,7 +471,7 @@ function OneKeeperMemoryReal({
   rows: readonly TurnRecordRow[]
 }) {
   const kindFilter = useSignal<string>('all')
-  const latestPromptRow = latestEntryWithBlocks(rows)
+  const latestPromptRow = latestEntryWithInputComponents(rows)
   const facts = sortMemoryFactsForReview(snapshot.facts.items)
   const episodes = snapshot.episodes.items
   const seen = new Set<string>()
@@ -610,7 +644,7 @@ function aggregateMemoryRowFromResponse(
   keeper: MemoryKeeper,
   response: TurnRecordsResponse,
 ): AggregateMemoryRow {
-  const latestPromptRow = latestEntryWithBlocks(response.entries)
+  const latestPromptRow = latestEntryWithInputComponents(response.entries)
   const memoryBlock = latestMemoryRecallBlock(latestPromptRow)
   const latestPrompt = latestPromptRow
     ? `${latestPromptRow.record.trace_id}#${latestPromptRow.record.absolute_turn}`

--- a/lib/keeper/keeper_agent_prompt_metrics.ml
+++ b/lib/keeper/keeper_agent_prompt_metrics.ml
@@ -33,7 +33,7 @@ type prompt_metrics =
 type ctx_composition_metrics =
   { actual_input_tokens : int option
   ; attributed_bytes : int
-  ; segments : (string * prompt_segment_metrics) list
+  ; segments : (Turn_record.input_component_id * prompt_segment_metrics) list
   }
 
 let empty_prompt_segment_metrics =
@@ -98,8 +98,8 @@ let prompt_metrics_to_json (metrics : prompt_metrics) : Yojson.Safe.t =
     ]
 
 let add_segment_metric
-    (totals : (string, prompt_segment_metrics) Hashtbl.t)
-    ~(bucket : string)
+    (totals : (Turn_record.input_component_id, prompt_segment_metrics) Hashtbl.t)
+    ~(bucket : Turn_record.input_component_id)
     (metric : prompt_segment_metrics) : unit =
   let prev =
     match Hashtbl.find_opt totals bucket with
@@ -137,71 +137,109 @@ let metric_of_block
           match block with
           | Agent_sdk.Types.Text text ->
               String.length (Inference_utils.sanitize_text_utf8 text)
+          | Agent_sdk.Types.Thinking { content; _ } ->
+              String.length (Inference_utils.sanitize_text_utf8 content)
+          | Agent_sdk.Types.ReasoningDetails { reasoning_content; details } ->
+              Agent_sdk.Types.reasoning_details_text ~reasoning_content ~details
+              |> Inference_utils.sanitize_text_utf8
+              |> String.length
+          | Agent_sdk.Types.RedactedThinking text ->
+              String.length (Inference_utils.sanitize_text_utf8 text)
+          | Agent_sdk.Types.Image { data; _ }
+          | Agent_sdk.Types.Document { data; _ }
+          | Agent_sdk.Types.Audio { data; _ } -> String.length data
           | Agent_sdk.Types.ToolResult _ ->
               invalid_arg
                 "keeper_agent_prompt_metrics: OAS canonical tool-result projection unavailable"
           | Agent_sdk.Types.ToolUse _ ->
               invalid_arg
-                "keeper_agent_prompt_metrics: OAS canonical tool-call projection unavailable"
-          | _ -> 0))
+                "keeper_agent_prompt_metrics: OAS canonical tool-call projection unavailable"))
   in
   { bytes; fingerprint = None }
 
-let history_bucket_of_block
+let input_component_of_block
     ~(role : Agent_sdk.Types.role)
-    (block : Agent_sdk.Types.content_block) : string =
-  if Option.is_some (Canonical_tool.tool_call_of_block block) then
-    "history_tool_use"
-  else
+    (block : Agent_sdk.Types.content_block) : Turn_record.input_component_id =
+  match
+    Canonical_tool.tool_call_of_block block,
+    Canonical_tool.tool_result_of_block block
+  with
+  | Some _, _ -> Turn_record.Message_tool_use
+  | None, Some _ -> Turn_record.Message_tool_result
+  | None, None -> (
     match block with
-  | Agent_sdk.Types.ToolResult _ -> "history_tool_result"
-  | Agent_sdk.Types.ToolUse _ ->
+    | Agent_sdk.Types.ToolResult _ -> Turn_record.Message_tool_result
+    | Agent_sdk.Types.ToolUse _ ->
       invalid_arg
         "keeper_agent_prompt_metrics: OAS canonical tool-call projection unavailable"
-  | Agent_sdk.Types.Text _ -> (
+    | Agent_sdk.Types.Text _ -> (
       match role with
-      | Agent_sdk.Types.User -> "history_user"
-      | Agent_sdk.Types.Assistant | Agent_sdk.Types.System ->
-          "history_assistant_text"
-      | Agent_sdk.Types.Tool -> "history_tool_result")
-  | Agent_sdk.Types.Thinking _ | Agent_sdk.Types.ReasoningDetails _ ->
-      "history_thinking"
-  | Agent_sdk.Types.RedactedThinking _ -> "history_redacted_thinking"
-  | Agent_sdk.Types.Image _ -> "history_image"
-  | Agent_sdk.Types.Document _ -> "history_document"
-  | Agent_sdk.Types.Audio _ -> "history_audio"
+      | Agent_sdk.Types.User -> Turn_record.Message_user
+      | Agent_sdk.Types.System -> Turn_record.Message_system
+      | Agent_sdk.Types.Assistant -> Turn_record.Message_assistant_text
+      | Agent_sdk.Types.Tool -> Turn_record.Message_tool_result)
+    | Agent_sdk.Types.Thinking _ | Agent_sdk.Types.ReasoningDetails _ ->
+      Turn_record.Message_thinking
+    | Agent_sdk.Types.RedactedThinking _ ->
+      Turn_record.Message_redacted_thinking
+    | Agent_sdk.Types.Image _ -> Turn_record.Message_image
+    | Agent_sdk.Types.Document _ -> Turn_record.Message_document
+    | Agent_sdk.Types.Audio _ -> Turn_record.Message_audio)
 
-let build_ctx_composition_metrics
-    ~(system_prompt : string)
-    ~(dynamic_context : string)
-    ~(memory_context : string)
-    ~(temporal_context : string)
-    ~(user_message : string)
-    ~(history_messages : Agent_sdk.Types.message list)
-    ~(actual_input_tokens : int option) : ctx_composition_metrics =
-  let totals : (string, prompt_segment_metrics) Hashtbl.t = Hashtbl.create 16 in
-  let add_text_segment bucket text =
-    let metric = prompt_segment_metrics_of_text text in
-    if metric.bytes > 0 then add_segment_metric totals ~bucket metric
+let build_input_components
+    ~(system_prompt_block : Turn_record.prompt_block option)
+    ~(tools : Agent_sdk.Tool.t list)
+    ~(input_messages : Agent_sdk.Types.message list)
+  : Turn_record.input_component list =
+  let totals :
+      (Turn_record.input_component_id, prompt_segment_metrics) Hashtbl.t =
+    Hashtbl.create 16
   in
-  add_text_segment "system_prompt" system_prompt;
-  add_text_segment "dynamic_context" dynamic_context;
-  add_text_segment "memory_context" memory_context;
-  add_text_segment "temporal_context" temporal_context;
-  add_text_segment "user_message" user_message;
+  Option.iter
+    (fun (block : Turn_record.prompt_block) ->
+      if block.bytes > 0
+      then
+        add_segment_metric totals
+          ~bucket:(Turn_record.Prompt_block block.block)
+          { bytes = block.bytes; fingerprint = Some block.digest })
+    system_prompt_block;
+  let tool_schema_bytes =
+    List.fold_left
+      (fun total tool ->
+        total
+        + String.length
+            (Yojson.Safe.to_string (Agent_sdk.Tool.schema_to_json tool)))
+      0 tools
+  in
+  if tool_schema_bytes > 0
+  then
+    add_segment_metric totals
+      ~bucket:Turn_record.Tool_schemas
+      { bytes = tool_schema_bytes; fingerprint = None };
   List.iter
     (fun (message : Agent_sdk.Types.message) ->
       List.iter
         (fun block ->
-          let bucket = history_bucket_of_block ~role:message.role block in
+          let bucket = input_component_of_block ~role:message.role block in
           let metric = metric_of_block ~role:message.role block in
           if metric.bytes > 0 then add_segment_metric totals ~bucket metric)
         message.content)
-    history_messages;
+    input_messages;
+  Hashtbl.to_seq totals
+  |> List.of_seq
+  |> List.sort (fun (left, _) (right, _) -> Stdlib.compare left right)
+  |> List.map (fun (component, metric) ->
+    { Turn_record.component; bytes = metric.bytes })
+
+let build_ctx_composition_metrics
+    ~(input_components : Turn_record.input_component list)
+    ~(actual_input_tokens : int option) : ctx_composition_metrics =
   let segments =
-    Hashtbl.to_seq totals
-    |> List.of_seq
-    |> List.sort (fun (left, _) (right, _) -> String.compare left right)
+    List.map
+      (fun (component : Turn_record.input_component) ->
+        ( component.component
+        , { bytes = component.bytes; fingerprint = None } ))
+      input_components
   in
   let attributed_bytes =
     List.fold_left
@@ -227,6 +265,8 @@ let ctx_composition_to_json (metrics : ctx_composition_metrics) : Yojson.Safe.t 
       ( "segments",
         `Assoc
           (List.map
-             (fun (key, value) -> (key, prompt_segment_metrics_to_json value))
+             (fun (key, value) ->
+               ( Turn_record.input_component_id_to_string key
+               , prompt_segment_metrics_to_json value ))
              metrics.segments) );
     ]

--- a/lib/keeper/keeper_agent_prompt_metrics.mli
+++ b/lib/keeper/keeper_agent_prompt_metrics.mli
@@ -29,7 +29,7 @@ type prompt_metrics =
 type ctx_composition_metrics =
   { actual_input_tokens : int option
   ; attributed_bytes : int
-  ; segments : (string * prompt_segment_metrics) list
+  ; segments : (Turn_record.input_component_id * prompt_segment_metrics) list
   }
 
 val empty_prompt_segment_metrics : prompt_segment_metrics
@@ -49,33 +49,22 @@ val prompt_segment_metrics_to_json :
 
 val prompt_metrics_to_json : prompt_metrics -> Yojson.Safe.t
 
-(** Mutate [totals] by adding [metric] into [bucket]. *)
-val add_segment_metric :
-  (string, prompt_segment_metrics) Hashtbl.t ->
-  bucket:string ->
-  prompt_segment_metrics ->
-  unit
+(** Build a disjoint snapshot at the existing model-input projection boundary.
+    [system_prompt_block] is separate because OAS carries it in provider
+    configuration rather than [input_messages]. Dynamic, temporal, and memory
+    prompt blocks remain provenance in [Turn_record.blocks]; their flattened
+    provider representation is counted once in [input_messages] and is not
+    reverse-engineered here. *)
+val build_input_components :
+  system_prompt_block:Turn_record.prompt_block option ->
+  tools:Agent_sdk.Tool.t list ->
+  input_messages:Agent_sdk.Types.message list ->
+  Turn_record.input_component list
 
-(** Project a single [content_block] of [role] to its segment metric. *)
-val metric_of_block :
-  role:Agent_sdk.Types.role ->
-  Agent_sdk.Types.content_block ->
-  prompt_segment_metrics
-
-(** Pick the segment bucket name for a history block. *)
-val history_bucket_of_block :
-  role:Agent_sdk.Types.role -> Agent_sdk.Types.content_block -> string
-
-(** [actual_input_tokens] is provider-reported and only known after a response.
-    It is not attributed to byte segments. [attributed_bytes] sums only the
-    exact textual/JSON components represented by [segments]. *)
+(** Attach provider-reported token usage to a previously captured byte
+    composition. The two units remain separate. *)
 val build_ctx_composition_metrics :
-  system_prompt:string ->
-  dynamic_context:string ->
-  memory_context:string ->
-  temporal_context:string ->
-  user_message:string ->
-  history_messages:Agent_sdk.Types.message list ->
+  input_components:Turn_record.input_component list ->
   actual_input_tokens:int option ->
   ctx_composition_metrics
 

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -249,6 +249,30 @@ let dispatch_after_provider_transcript_admission ~messages ~dispatch =
   | Ok () -> dispatch ()
 ;;
 
+let serialized_request_body_bytes_of_error error =
+  match Keeper_turn_runtime_budget.capacity_refusal_of_error error with
+  | Some
+      (Keeper_turn_runtime_budget.Serialized_request_body { actual_bytes; _ }) ->
+    Some actual_bytes
+  | Some
+      (Keeper_turn_runtime_budget.Provider_context_window _
+      | Keeper_turn_runtime_budget.Provider_request_body_refusal _)
+  | None ->
+    None
+;;
+
+let request_body_bytes_for_error ~observed error =
+  match serialized_request_body_bytes_of_error error with
+  | Some _ as actual -> actual
+  | None -> observed
+;;
+
+type request_observation =
+  { runtime_profile : string option
+  ; body_bytes : int
+  ; input_components : Turn_record.input_component list
+  }
+
 let terminal_effect_boundary_decision = function
   | Keeper_tools_oas.Terminal_effect_open -> Ok Runtime_agent.Continue
   | Keeper_tools_oas.Deferred_tool_result ->
@@ -281,6 +305,7 @@ module For_testing = struct
   let provider_transcript_admission = provider_transcript_admission
   let dispatch_after_provider_transcript_admission =
     dispatch_after_provider_transcript_admission
+  let request_body_bytes_for_error = request_body_bytes_for_error
 end
 
 (** Run a single keeper turn via OAS Agent.run().
@@ -660,6 +685,8 @@ let run_turn
     let receipt_response_text_present_ref =
       s.Keeper_run_tools.receipt_response_text_present_ref
     in
+    let current_request_runtime_profile_ref = ref None in
+    let observed_request_ref : request_observation option ref = ref None in
     (* 8. Run Agent *)
     let record_turn_progress, yield_on_tool, on_yield, on_resume, on_event =
       Turn_helpers.turn_progress_callbacks
@@ -836,6 +863,18 @@ let run_turn
                       ~on_runtime_observation:
                         (fun observation ->
                            receipt_runtime_observation_ref := Some observation)
+                      ~on_request_attempt_started:
+                        (fun ~runtime_id ->
+                           current_request_runtime_profile_ref := Some runtime_id)
+                      ~on_request_body_bytes:
+                        (fun ~runtime_id ~bytes ->
+                           current_request_runtime_profile_ref := Some runtime_id;
+                           observed_request_ref :=
+                             Some
+                               { runtime_profile = Some runtime_id
+                               ; body_bytes = bytes
+                               ; input_components = acc.input_components
+                               })
                       ())
          in
          (* Trace-store failure isolation: [raw_trace_for_dispatch]
@@ -878,14 +917,14 @@ let run_turn
                      ~tool_calls:acc.tool_calls
                  in
                  let usage = Keeper_context_runtime.usage_of_response result.response in
+                 let input_components =
+                   match !observed_request_ref with
+                   | Some observation -> observation.input_components
+                   | None -> []
+                 in
                  let ctx_composition =
-                   build_ctx_composition_metrics
-                     ~system_prompt:turn_system_prompt
-                     ~dynamic_context
-                     ~memory_context
-                     ~temporal_context
-                     ~user_message
-                     ~history_messages
+                   Keeper_agent_prompt_metrics.build_ctx_composition_metrics
+                     ~input_components
                      ~actual_input_tokens:(Some usage.input_tokens)
                  in
                  let completion_observation ()
@@ -1099,6 +1138,33 @@ let run_turn
         let (price_input_per_million, price_output_per_million) =
           Runtime.pricing_of_runtime_id runtime_id_string
         in
+        let request_observation =
+          match turn_result with
+          | Error error -> (
+            match serialized_request_body_bytes_of_error error with
+            | Some actual_bytes ->
+              Some
+                { runtime_profile = !current_request_runtime_profile_ref
+                ; body_bytes = actual_bytes
+                ; input_components = acc.input_components
+                }
+            | None -> !observed_request_ref)
+          | Ok _ -> !observed_request_ref
+        in
+        let request_runtime_profile =
+          Option.bind request_observation (fun observation ->
+            observation.runtime_profile)
+        in
+        let request_body_bytes =
+          Option.map
+            (fun observation -> observation.body_bytes)
+            request_observation
+        in
+        let input_components =
+          match request_observation with
+          | Some observation -> observation.input_components
+          | None -> []
+        in
         Keeper_turn_record_writer.write
           ~config
           ~keeper_name:meta.name
@@ -1115,6 +1181,8 @@ let run_turn
           ~price_output_per_million
           ~request_latency_ms
           ~ttfrc_ms
+          ~request_runtime_profile
+          ~request_body_bytes
           ~sampling:
             { temperature = Some temperature
             ; top_p = Runtime.top_p_of_runtime_id runtime_id_string
@@ -1125,6 +1193,7 @@ let run_turn
           ~usage
           ~execution_ids
           ~blocks:acc.prompt_blocks
+          ~input_components
           ();
         (* RFC-0233 §2.3 PR-4: project the same record onto the ambient
            turn span. Both turn drivers (unified "invoke_agent <keeper>"

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -123,6 +123,11 @@ module For_testing : sig
     -> dispatch:(unit -> ('a, Agent_sdk.Error.sdk_error) result)
     -> ('a, Agent_sdk.Error.sdk_error) result
 
+  val request_body_bytes_for_error
+    :  observed:int option
+    -> Agent_sdk.Error.sdk_error
+    -> int option
+
 end
 
 (** {1 Turn execution} *)

--- a/lib/keeper/keeper_request_wire_observation.ml
+++ b/lib/keeper/keeper_request_wire_observation.ml
@@ -23,10 +23,18 @@ let () =
     bucket_upper_bounds_bytes
 ;;
 
-let observer ~keeper_name ~runtime_id ~max_request_body_bytes
+let observer
+      ?on_request_body_bytes
+      ~keeper_name
+      ~runtime_id
+      ~max_request_body_bytes
   : Agent_sdk.Agent.pre_dispatch_serialization_observer
   =
   fun observation ->
+  Option.iter
+    (fun observe ->
+      observe observation.Llm_provider.Request_wire_observer.body_bytes)
+    on_request_body_bytes;
   Otel_metric_store.observe_histogram
     (Keeper_metrics.to_string metric)
     ~labels:

--- a/lib/keeper/keeper_request_wire_observation.mli
+++ b/lib/keeper/keeper_request_wire_observation.mli
@@ -24,13 +24,17 @@ val metric : Keeper_metrics.t
     request. *)
 
 val observer :
+  ?on_request_body_bytes:(int -> unit) ->
   keeper_name:string ->
   runtime_id:string ->
   max_request_body_bytes:int ->
   Agent_sdk.Agent.pre_dispatch_serialization_observer
-(** [observer ~keeper_name ~runtime_id ~max_request_body_bytes] records
+(** [observer ?on_request_body_bytes ~keeper_name ~runtime_id
+    ~max_request_body_bytes] records
     [body_bytes] under {!metric} and admits the observation. The cap is the
     value already validated on the final provider config, so a hot-reload that
-    changes a runtime's cap starts a distinct metric series. It never rejects:
-    this path exists only to measure, and a rejection would manufacture typed
-    failure evidence out of measurement. *)
+    changes a runtime's cap starts a distinct metric series. The optional
+    callback receives the same exact boundary value before dispatch, including
+    attempts that later return an error. It never rejects: this path exists
+    only to measure, and a rejection would manufacture typed failure evidence
+    out of measurement. *)

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -27,6 +27,7 @@ type hook_accumulator = Keeper_run_tools_hook_accumulator.hook_accumulator =
   ; mutable receipt_actionable_signal :
       Keeper_contract_classifier.actionable_signal option
   ; mutable prompt_blocks : Turn_record.prompt_block list
+  ; mutable input_components : Turn_record.input_component list
   ; mutable extra_system_context_digest : string option
   ; mutable extra_system_context_size : int option
   }

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -27,6 +27,7 @@ type hook_accumulator =
   ; mutable receipt_actionable_signal :
       Keeper_contract_classifier.actionable_signal option
   ; mutable prompt_blocks : Turn_record.prompt_block list
+  ; mutable input_components : Turn_record.input_component list
   ; mutable extra_system_context_digest : string option
   ; mutable extra_system_context_size : int option
   }

--- a/lib/keeper/keeper_run_tools_hook_accumulator.ml
+++ b/lib/keeper/keeper_run_tools_hook_accumulator.ml
@@ -31,6 +31,7 @@ type hook_accumulator =
        [operator_disposition] can replace the [goal_ids = []] proxy. [None]
        until the contract-status write site sets it. *)
   ; mutable prompt_blocks : Turn_record.prompt_block list
+  ; mutable input_components : Turn_record.input_component list
   ; mutable extra_system_context_digest : string option
   ; mutable extra_system_context_size : int option
   }

--- a/lib/keeper/keeper_run_tools_hook_accumulator.mli
+++ b/lib/keeper/keeper_run_tools_hook_accumulator.mli
@@ -11,6 +11,7 @@ type hook_accumulator =
   ; mutable receipt_actionable_signal :
       Keeper_contract_classifier.actionable_signal option
   ; mutable prompt_blocks : Turn_record.prompt_block list
+  ; mutable input_components : Turn_record.input_component list
   ; mutable extra_system_context_digest : string option
   ; mutable extra_system_context_size : int option
   }

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -66,6 +66,27 @@ let project_model_input ~base_path ~gate_replay_evidence messages =
     Keeper_gate_replay.project_model_input ~base_path evidence messages
 ;;
 
+let provider_input_components
+      ~(prompt_blocks : Turn_record.prompt_block list)
+      ~(tools : Agent_sdk.Tool.t list)
+      ~(projected_messages : Agent_sdk.Types.message list)
+  =
+  let system_prompt_block =
+    List.find_opt
+      (fun (block : Turn_record.prompt_block) ->
+        match block.block with
+        | Prompt_block_id.Persona -> true
+        | Prompt_block_id.Dynamic_context
+        | Prompt_block_id.Temporal_summary
+        | Prompt_block_id.Memory_os_recall -> false)
+      prompt_blocks
+  in
+  Keeper_agent_prompt_metrics.build_input_components
+    ~system_prompt_block
+    ~tools
+    ~input_messages:projected_messages
+;;
+
 let relative_path_has_segment_prefix prefix raw =
   String.equal raw prefix || String.starts_with ~prefix:(prefix ^ "/") raw
 ;;
@@ -313,6 +334,7 @@ let assemble_hooks
                   { turn; current_params; messages; last_tool_results; _ } ->
                 let hook_t0 = Time_compat.now () in
                 acc.current_turn <- turn;
+                acc.input_components <- [];
                 (* RFC-0045: signal an SDK-turn boundary so the in-turn FSM
                   fields ([turn_phase], [runtime_state], [decision_stage])
                   are reset before the hook writes [Runtime_selecting] /
@@ -574,10 +596,22 @@ let assemble_hooks
       (* Stored Tool results are already the canonical provider-bound
          representation. Fetching their bytes here would undo externalization
          and make one large result expand every later provider request. *)
-      project_model_input
-        ~base_path:ctx.config.base_path
-        ~gate_replay_evidence
-        messages
+      match
+        project_model_input
+          ~base_path:ctx.config.base_path
+          ~gate_replay_evidence
+          messages
+      with
+      | Error _ as error ->
+        acc.input_components <- [];
+        error
+      | Ok projected as result ->
+        acc.input_components <-
+          provider_input_components
+            ~prompt_blocks:acc.prompt_blocks
+            ~tools
+            ~projected_messages:projected;
+        result
     in
     Ok
       { tools

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -149,6 +149,7 @@ let prepare_agent_setup
         Keeper_execution_receipt.Completion_observation_unknown
     ; receipt_actionable_signal = None
     ; prompt_blocks = []
+    ; input_components = []
     ; extra_system_context_digest = None
     ; extra_system_context_size = None
     }

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -368,6 +368,8 @@ let run_named
     ?trace_link
     ?event_bus
     ?on_runtime_observation
+    ?on_request_attempt_started
+    ?on_request_body_bytes
     ?runtime_manifest_context
     ?runtime_manifest_append
     ?deferred_runtime_lane
@@ -716,6 +718,8 @@ let run_named
             ; on_resume
             ; agent_ref
             ; on_runtime_observation
+            ; on_request_attempt_started
+            ; on_request_body_bytes
             ; event_bus
             ; runtime_manifest_context
             ; runtime_manifest_append

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -114,6 +114,8 @@ val run_named :
   ?trace_link:string * string ->
   ?event_bus:Agent_sdk.Event_bus.t ->
   ?on_runtime_observation:(Runtime_observation.runtime_observation -> unit) ->
+  ?on_request_attempt_started:(runtime_id:string -> unit) ->
+  ?on_request_body_bytes:(runtime_id:string -> bytes:int -> unit) ->
   ?runtime_manifest_context:Keeper_runtime_manifest.turn_context ->
   ?runtime_manifest_append:(Keeper_runtime_manifest.t -> unit) ->
   ?deferred_runtime_lane:deferred_runtime_lane ->

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -62,6 +62,8 @@ type try_provider_ctx =
   ; agent_ref : Agent_sdk.Agent.t option ref option
   ; on_runtime_observation :
       (Runtime_observation.runtime_observation -> unit) option
+  ; on_request_attempt_started : (runtime_id:string -> unit) option
+  ; on_request_body_bytes : (runtime_id:string -> bytes:int -> unit) option
   ; (* Event bus *)
     event_bus : Agent_sdk.Event_bus.t option
   ; runtime_manifest_context : Keeper_runtime_manifest.turn_context option
@@ -190,6 +192,9 @@ let run_try_provider
       ?enable_thinking_override
       candidate
   =
+  Option.iter
+    (fun notify -> notify ~runtime_id:ctx.runtime_id)
+    ctx.on_request_attempt_started;
   (* [enable_thinking_override] lets the caller re-issue the SAME candidate with a
      different thinking policy without mutating [ctx]. RFC-0271 §4.1 uses it for the
      [Retry_no_thinking] recovery arm: a [Thinking_only_no_progress] rejection is
@@ -262,6 +267,11 @@ let run_try_provider
           ; pre_dispatch_serialization_observer =
               Some
                 (Keeper_request_wire_observation.observer
+                   ?on_request_body_bytes:
+                     (Option.map
+                        (fun notify bytes ->
+                          notify ~runtime_id:ctx.runtime_id ~bytes)
+                        ctx.on_request_body_bytes)
                    ~keeper_name:ctx.keeper_name
                    ~runtime_id:ctx.runtime_id
                    ~max_request_body_bytes:ctx.max_request_body_bytes)

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -41,6 +41,8 @@ type try_provider_ctx =
   ; agent_ref : Agent_sdk.Agent.t option ref option
   ; on_runtime_observation :
       (Runtime_observation.runtime_observation -> unit) option
+  ; on_request_attempt_started : (runtime_id:string -> unit) option
+  ; on_request_body_bytes : (runtime_id:string -> bytes:int -> unit) option
   ; event_bus : Agent_sdk.Event_bus.t option
   ; runtime_manifest_context : Keeper_runtime_manifest.turn_context option
   ; runtime_manifest_append : (Keeper_runtime_manifest.t -> unit) option

--- a/lib/keeper/keeper_turn_record_writer.ml
+++ b/lib/keeper/keeper_turn_record_writer.ml
@@ -11,10 +11,13 @@ let write
       ~price_output_per_million
       ~request_latency_ms
       ~ttfrc_ms
+      ~request_runtime_profile
+      ~request_body_bytes
       ~sampling
       ~usage
       ~execution_ids
       ~blocks
+      ~input_components
       ()
   =
   let record : Turn_record.t =
@@ -22,8 +25,9 @@ let write
     ; keeper = keeper_name
     ; trace_id
     ; absolute_turn
-    ; turn_ref = Some (Ids.Turn_ref.make ~trace_id ~absolute_turn)
+    ; turn_ref = Ids.Turn_ref.make ~trace_id ~absolute_turn
     ; blocks
+    ; input_components
     ; runtime_profile
     ; model
     ; finish_reason
@@ -32,6 +36,8 @@ let write
     ; price_output_per_million
     ; request_latency_ms
     ; ttfrc_ms
+    ; request_runtime_profile
+    ; request_body_bytes
     ; sampling
     ; usage
     ; ts = Time_compat.now ()

--- a/lib/keeper/keeper_turn_record_writer.mli
+++ b/lib/keeper/keeper_turn_record_writer.mli
@@ -18,9 +18,12 @@ val write :
   price_output_per_million:float option ->
   request_latency_ms:int option ->
   ttfrc_ms:float option ->
+  request_runtime_profile:string option ->
+  request_body_bytes:int option ->
   sampling:Turn_record.sampling ->
   usage:Turn_record.usage ->
   execution_ids:Ids.Execution_id.t list ->
   blocks:Turn_record.prompt_block list ->
+  input_components:Turn_record.input_component list ->
   unit ->
   unit

--- a/lib/types/prompt_block_id.ml
+++ b/lib/types/prompt_block_id.ml
@@ -1,59 +1,33 @@
 type t =
   | Persona
-  | Continuity
   | Dynamic_context
   | Temporal_summary
-  | Claimed_task_nudge
-  | Retry_nudge
   | Memory_os_recall
-  | Connected_surface
-  | Other of string
 
 let equal a b =
   match a, b with
   | Persona, Persona
-  | Continuity, Continuity
   | Dynamic_context, Dynamic_context
   | Temporal_summary, Temporal_summary
-  | Claimed_task_nudge, Claimed_task_nudge
-  | Retry_nudge, Retry_nudge
-  | Memory_os_recall, Memory_os_recall
-  | Connected_surface, Connected_surface -> true
-  | Other a, Other b -> String.equal a b
-  | ( ( Persona | Continuity | Dynamic_context | Temporal_summary
-      | Claimed_task_nudge | Retry_nudge | Memory_os_recall
-      | Connected_surface | Other _ )
-    , _ ) -> false
+  | Memory_os_recall, Memory_os_recall -> true
+  | (Persona | Dynamic_context | Temporal_summary | Memory_os_recall), _ -> false
 
 let to_string = function
   | Persona -> "persona"
-  | Continuity -> "continuity"
   | Dynamic_context -> "dynamic_context"
   | Temporal_summary -> "temporal_summary"
-  | Claimed_task_nudge -> "claimed_task_nudge"
-  | Retry_nudge -> "retry_nudge"
   | Memory_os_recall -> "memory_os_recall"
-  | Connected_surface -> "connected_surface"
-  | Other name -> name
 
 let of_string = function
-  | "persona" -> Persona
-  | "continuity" -> Continuity
-  | "dynamic_context" -> Dynamic_context
-  | "temporal_summary" -> Temporal_summary
-  | "claimed_task_nudge" -> Claimed_task_nudge
-  | "retry_nudge" -> Retry_nudge
-  | "memory_os_recall" -> Memory_os_recall
-  | "connected_surface" -> Connected_surface
-  | name -> Other name
+  | "persona" -> Ok Persona
+  | "dynamic_context" -> Ok Dynamic_context
+  | "temporal_summary" -> Ok Temporal_summary
+  | "memory_os_recall" -> Ok Memory_os_recall
+  | name -> Error (Printf.sprintf "unknown prompt block %S" name)
 
-let all_known =
+let all =
   [ Persona
-  ; Continuity
   ; Dynamic_context
   ; Temporal_summary
-  ; Claimed_task_nudge
-  ; Retry_nudge
   ; Memory_os_recall
-  ; Connected_surface
   ]

--- a/lib/types/prompt_block_id.mli
+++ b/lib/types/prompt_block_id.mli
@@ -1,4 +1,5 @@
-(** RFC-0233 §2.2 — closed identity for keeper prompt-assembly blocks.
+(** Closed identity for keeper prompt-assembly blocks that have a current
+    producer.
 
     Each constructor names one injection site of the per-turn context
     assembly. Adding a new injection site without extending this variant
@@ -9,29 +10,19 @@
     [Dynamic_context] is the composite soft-context string built by
     keeper_turn.ml/keeper_run_prompt.ml (continuity snapshot, skill
     route, worktree, telemetry feedback, turn instructions, recent
-    failure memory) — recorded as one block until the producer threads
-    a typed decomposition. [Continuity] and [Connected_surface] exist
-    for that decomposition and for the unified-path user-message block;
-    they have no producer yet. [Other] carries forward-compatible rows
-    read back from disk. *)
+    failure memory). *)
 
 type t =
   | Persona
-  | Continuity
   | Dynamic_context
   | Temporal_summary
-  | Claimed_task_nudge
-  | Retry_nudge
   | Memory_os_recall
-  | Connected_surface
-  | Other of string
 
 val equal : t -> t -> bool
 val to_string : t -> string
 
-val of_string : string -> t
-(** Total: unknown names map to [Other name], so old readers survive new
-    writers and disk rows never fail to decode on this field. *)
+val of_string : string -> (t, string) result
+(** Decode the current wire contract. Unknown names fail closed. *)
 
-val all_known : t list
-(** Every constructor except [Other] — for exhaustive codec tests. *)
+val all : t list
+(** Every current constructor. *)

--- a/lib/types/turn_record.ml
+++ b/lib/types/turn_record.ml
@@ -4,6 +4,25 @@ type prompt_block =
   ; digest : string
   }
 
+type input_component_id =
+  | Prompt_block of Prompt_block_id.t
+  | Tool_schemas
+  | Message_user
+  | Message_system
+  | Message_assistant_text
+  | Message_thinking
+  | Message_redacted_thinking
+  | Message_tool_use
+  | Message_tool_result
+  | Message_image
+  | Message_document
+  | Message_audio
+
+type input_component =
+  { component : input_component_id
+  ; bytes : int
+  }
+
 type sampling =
   { temperature : float option
   ; top_p : float option
@@ -24,8 +43,9 @@ type t =
   ; keeper : string
   ; trace_id : string
   ; absolute_turn : int
-  ; turn_ref : Ids.Turn_ref.t option
+  ; turn_ref : Ids.Turn_ref.t
   ; blocks : prompt_block list
+  ; input_components : input_component list
   ; runtime_profile : string
   ; model : string option
   ; finish_reason : string option
@@ -34,6 +54,8 @@ type t =
   ; price_output_per_million : float option
   ; request_latency_ms : int option
   ; ttfrc_ms : float option
+  ; request_runtime_profile : string option
+  ; request_body_bytes : int option
   ; sampling : sampling
   ; usage : usage
   ; ts : float
@@ -52,6 +74,26 @@ let prompt_block_to_json (b : prompt_block) : Yojson.Safe.t =
     ; ("digest", `String b.digest)
     ]
 
+let input_component_id_to_string = function
+  | Prompt_block block -> "prompt." ^ Prompt_block_id.to_string block
+  | Tool_schemas -> "tool_schemas"
+  | Message_user -> "message_user"
+  | Message_system -> "message_system"
+  | Message_assistant_text -> "message_assistant_text"
+  | Message_thinking -> "message_thinking"
+  | Message_redacted_thinking -> "message_redacted_thinking"
+  | Message_tool_use -> "message_tool_use"
+  | Message_tool_result -> "message_tool_result"
+  | Message_image -> "message_image"
+  | Message_document -> "message_document"
+  | Message_audio -> "message_audio"
+
+let input_component_to_json (component : input_component) : Yojson.Safe.t =
+  `Assoc
+    [ "component", `String (input_component_id_to_string component.component)
+    ; "bytes", `Int component.bytes
+    ]
+
 let to_json (r : t) : Yojson.Safe.t =
   `Assoc
     ([ ( "execution_ids"
@@ -59,10 +101,20 @@ let to_json (r : t) : Yojson.Safe.t =
      ; ("keeper", `String r.keeper)
      ; ("trace_id", `String r.trace_id)
      ; ("absolute_turn", `Int r.absolute_turn)
+     ; ("turn_ref", Ids.Turn_ref.to_yojson r.turn_ref)
      ; ("blocks", `List (List.map prompt_block_to_json r.blocks))
+     ; ( "input_components"
+       , `List (List.map input_component_to_json r.input_components) )
+     ; ( "request_body_bytes"
+       , match r.request_body_bytes with
+         | Some bytes -> `Int bytes
+         | None -> `Null )
+     ; ( "request_runtime_profile"
+       , match r.request_runtime_profile with
+         | Some runtime_profile -> `String runtime_profile
+         | None -> `Null )
      ; ("runtime_profile", `String r.runtime_profile)
      ]
-    @ opt_field "turn_ref" Ids.Turn_ref.to_yojson r.turn_ref
     @ opt_field "model" (fun v -> `String v) r.model
     @ opt_field "finish_reason" (fun v -> `String v) r.finish_reason
     @ opt_field "context_window" (fun v -> `Int v) r.context_window
@@ -116,6 +168,15 @@ let as_bool name = function
   | `Bool b -> Ok b
   | _ -> Error (Printf.sprintf "turn_record: field %S is not a bool" name)
 
+let as_nullable_nonnegative_int name = function
+  | `Null -> Ok None
+  | `Int value when value >= 0 -> Ok (Some value)
+  | `Int _ ->
+    Error (Printf.sprintf "turn_record: field %S must be nonnegative" name)
+  | _ ->
+    Error
+      (Printf.sprintf "turn_record: field %S is not an int or null" name)
+
 let as_turn_ref name json =
   match Ids.Turn_ref.of_yojson json with
   | Ok t -> Ok t
@@ -130,8 +191,52 @@ let prompt_block_of_json (json : Yojson.Safe.t) : (prompt_block, string) result 
       let* bytes = as_int "bytes" bytes_json in
       let* digest_json = require "digest" fields in
       let* digest = as_string "digest" digest_json in
-      Ok { block = Prompt_block_id.of_string block_name; bytes; digest }
+      let* block = Prompt_block_id.of_string block_name in
+      Ok { block; bytes; digest }
   | _ -> Error "turn_record: block entry is not an object"
+
+let input_component_id_of_string token =
+  match token with
+  | "tool_schemas" -> Ok Tool_schemas
+  | "message_user" -> Ok Message_user
+  | "message_system" -> Ok Message_system
+  | "message_assistant_text" -> Ok Message_assistant_text
+  | "message_thinking" -> Ok Message_thinking
+  | "message_redacted_thinking" -> Ok Message_redacted_thinking
+  | "message_tool_use" -> Ok Message_tool_use
+  | "message_tool_result" -> Ok Message_tool_result
+  | "message_image" -> Ok Message_image
+  | "message_document" -> Ok Message_document
+  | "message_audio" -> Ok Message_audio
+  | token ->
+    let prefix = "prompt." in
+    if String.starts_with ~prefix token
+    then
+      let name =
+        String.sub token (String.length prefix)
+          (String.length token - String.length prefix)
+      in
+      if String.equal name ""
+      then Error "turn_record: empty prompt input component"
+      else
+        let* block = Prompt_block_id.of_string name in
+        Ok (Prompt_block block)
+    else
+      Error (Printf.sprintf "turn_record: unknown input component %S" token)
+
+let input_component_of_json
+    (json : Yojson.Safe.t) : (input_component, string) result =
+  match json with
+  | `Assoc fields ->
+    let* component_json = require "component" fields in
+    let* component_name = as_string "component" component_json in
+    let* component = input_component_id_of_string component_name in
+    let* bytes_json = require "bytes" fields in
+    let* bytes = as_int "bytes" bytes_json in
+    if bytes < 0
+    then Error "turn_record: input component bytes must be nonnegative"
+    else Ok { component; bytes }
+  | _ -> Error "turn_record: input component entry is not an object"
 
 let rec collect_results acc = function
   | [] -> Ok (List.rev acc)
@@ -162,9 +267,43 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
         | `List items -> collect_results [] (List.map prompt_block_of_json items)
         | _ -> Error "turn_record: blocks is not a list"
       in
+      let* input_components_json = require "input_components" fields in
+      let* input_components =
+        match input_components_json with
+        | `List items ->
+          collect_results [] (List.map input_component_of_json items)
+        | _ -> Error "turn_record: input_components is not a list"
+      in
+      let* request_body_bytes_json = require "request_body_bytes" fields in
+      let* request_body_bytes =
+        as_nullable_nonnegative_int "request_body_bytes" request_body_bytes_json
+      in
+      let* request_runtime_profile_json =
+        require "request_runtime_profile" fields
+      in
+      let* request_runtime_profile =
+        match request_runtime_profile_json with
+        | `Null -> Ok None
+        | `String runtime_profile when not (String.equal runtime_profile "") ->
+          Ok (Some runtime_profile)
+        | `String _ ->
+          Error "turn_record: request_runtime_profile must be nonempty"
+        | _ ->
+          Error
+            "turn_record: field \"request_runtime_profile\" is not a string or null"
+      in
       let* profile_json = require "runtime_profile" fields in
       let* runtime_profile = as_string "runtime_profile" profile_json in
-      let* turn_ref = opt_member "turn_ref" fields as_turn_ref in
+      let* turn_ref_json = require "turn_ref" fields in
+      let* turn_ref = as_turn_ref "turn_ref" turn_ref_json in
+      let expected_turn_ref = Ids.Turn_ref.make ~trace_id ~absolute_turn in
+      let* () =
+        if Ids.Turn_ref.equal turn_ref expected_turn_ref
+        then Ok ()
+        else
+          Error
+            "turn_record: turn_ref does not match trace_id and absolute_turn"
+      in
       let* model = opt_member "model" fields as_string in
       let* finish_reason = opt_member "finish_reason" fields as_string in
       let* context_window = opt_member "context_window" fields as_int in
@@ -194,6 +333,7 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
         ; absolute_turn
         ; turn_ref
         ; blocks
+        ; input_components
         ; runtime_profile
         ; model
         ; finish_reason
@@ -202,6 +342,8 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
         ; price_output_per_million
         ; request_latency_ms
         ; ttfrc_ms
+        ; request_runtime_profile
+        ; request_body_bytes
         ; sampling = { temperature; top_p; max_tokens; thinking_budget; enable_thinking }
         ; usage =
             { input_tokens

--- a/lib/types/turn_record.mli
+++ b/lib/types/turn_record.mli
@@ -17,6 +17,25 @@ type prompt_block =
   ; digest : string (* sha256 hex of the raw block text *)
   }
 
+type input_component_id =
+  | Prompt_block of Prompt_block_id.t
+  | Tool_schemas
+  | Message_user
+  | Message_system
+  | Message_assistant_text
+  | Message_thinking
+  | Message_redacted_thinking
+  | Message_tool_use
+  | Message_tool_result
+  | Message_image
+  | Message_document
+  | Message_audio
+
+type input_component =
+  { component : input_component_id
+  ; bytes : int
+  }
+
 type sampling =
   { temperature : float option
   ; top_p : float option
@@ -36,7 +55,7 @@ type usage =
        matters against [context_window] below: the fill percentage it denominates is
        read as pressure on the compaction ceiling, and cache-heavy turns and
        genuinely large prompts are different situations with the same numerator.
-       [None] on legacy rows and on turns where the provider reported no usage. *)
+       [None] when the provider reported no cache usage. *)
   }
 
 type t =
@@ -44,17 +63,22 @@ type t =
   ; keeper : string
   ; trace_id : string
   ; absolute_turn : int
-  ; turn_ref : Ids.Turn_ref.t option
-    (* RFC-0233 §7 — "<trace_id>#<absolute_turn>" join key for chat/board.
-       [option] so pre-§7 rows decode as [None]. *)
+  ; turn_ref : Ids.Turn_ref.t
+    (* "<trace_id>#<absolute_turn>" join key for chat/board. *)
   ; blocks : prompt_block list (* assembly order *)
+  ; input_components : input_component list
+    (* Exact attributed content bytes for the final provider request of this
+       keeper turn. System prompt, canonical tool schemas, and final projected
+       message content are disjoint buckets. Prompt-assembly provenance remains
+       in [blocks] and is not reverse-engineered from flattened messages.
+       Provider-reported [usage.input_tokens] remains a separate unit;
+       serialization metadata is not invented as content. *)
   ; runtime_profile : string
   ; model : string option
     (* RFC-0233 §2.2/§2.3 — boundary-redacted runtime model label, the
        same value the execution receipt surfaces (RFC-0132 redaction
-       SSOT). [option] so error turns and pre-grounding rows decode as
-       [None]; the inspector renders absence rather than a fabricated
-       name. *)
+       SSOT). [None] when an error turn recorded no model; the inspector
+       renders absence rather than a fabricated name. *)
   ; finish_reason : string option
     (* RFC-0233 §2.3 — keeper turn stop reason, serialized via the
        receipt SSOT [Keeper_execution_receipt.stop_reason_to_string].
@@ -63,8 +87,8 @@ type t =
   ; context_window : int option
     (* RFC-0233 §8 — keeper-resolved effective context budget (tokens) for
        this turn, the denominator the dashboard ctx-fill% uses. [None] on
-       legacy rows or the error path; the inspector renders absence rather
-       than the fabricated 200K. This is the keeper compaction ceiling
+       the error path; the inspector renders absence rather than the
+       fabricated 200K. This is the keeper compaction ceiling
        ([max_context]), NOT the provider's per-request num-ctx cap (an
        Ollama-only transport detail). *)
   ; price_input_per_million : float option
@@ -81,9 +105,9 @@ type t =
        [inference_telemetry.request_latency_ms] (the OAS transport layer
        synthesizes it for every provider — [complete_common.patch_telemetry]
        non-streaming, [complete_stream] streaming — so it is populated
-       whenever a response is produced). [None] on the error path or legacy
-       rows; the inspector renders absence rather than a fabricated duration
-       for the response-generation phase. Phase-level splits
+       whenever a response is produced). [None] on the error path; the
+       inspector renders absence rather than a fabricated duration for the
+       response-generation phase. Phase-level splits
        (prefill/decode) are deliberately deferred: only the provider's
        native timing objects carry prefill/predicted durations and most
        keepers' runtimes do not report them, so emitting them would show
@@ -103,6 +127,15 @@ type t =
        request_latency_ms - ttfrc_ms: that would fabricate a number
        indistinguishable from a measurement (§9.6), so decode stays
        not_recorded until a provider reports it natively. *)
+  ; request_runtime_profile : string option
+    (* Runtime candidate that produced [request_body_bytes]. This remains
+       separate from [runtime_profile], the turn's configured profile, so
+       fallback attribution is not rewritten or guessed. *)
+  ; request_body_bytes : int option
+    (* Exact serialized body size observed after provider-specific request
+       construction. [None] means the turn did not reach that boundary. This
+       is intentionally separate from attributed content bytes and
+       provider-reported token usage. *)
   ; sampling : sampling
   ; usage : usage
   ; ts : float
@@ -110,13 +143,15 @@ type t =
 
 val prompt_block_to_json : prompt_block -> Yojson.Safe.t
 
+val input_component_id_to_string : input_component_id -> string
+val input_component_to_json : input_component -> Yojson.Safe.t
+
 val to_json : t -> Yojson.Safe.t
 
 val of_json : Yojson.Safe.t -> (t, string) result
 (** Fails loudly on malformed rows (missing fields, unparseable
-    execution ids) instead of repairing them — RFC-0233 §4. Unknown
-    block names decode as [Prompt_block_id.Other] (that field alone is
-    forward-open by design). *)
+    execution ids, or unknown prompt block identities) instead of repairing
+    them. *)
 
 (** Result of diffing two consecutive records by [(block, digest)]. *)
 type block_diff =

--- a/test/test_keeper_prompt_metrics.ml
+++ b/test/test_keeper_prompt_metrics.ml
@@ -9,8 +9,10 @@
 open Alcotest
 
 module KAR = Masc.Keeper_agent_run
+module KAPM = Masc.Keeper_agent_prompt_metrics
 module KP = Masc.Keeper_prompt
 module KRP = Masc.Keeper_run_prompt
+module KRTH = Masc.Keeper_run_tools_hooks
 
 let measure_bytes = String.length
 
@@ -302,8 +304,8 @@ let test_user_message_sanitizer_preserves_semantic_content () =
   check bool "preserves useful user request" true
     (has_in sanitized "Please inspect the current board status.")
 
-let test_ctx_composition_splits_history_bytes () =
-  let history_messages =
+let test_ctx_composition_splits_provider_input_bytes () =
+  let input_messages =
     [
       {
         Agent_sdk.Types.role = Agent_sdk.Types.User;
@@ -347,38 +349,110 @@ let test_ctx_composition_splits_history_bytes () =
       };
     ]
   in
+  let system_prompt_block =
+    { Turn_record.block = Prompt_block_id.Persona
+    ; bytes = String.length "System prompt"
+    ; digest = "persona-digest"
+    }
+  in
+  let tool =
+    Agent_sdk.Tool.create
+      ~name:"probe_tool"
+      ~description:"probe tool"
+      ~parameters:[]
+      (fun _input -> Ok { Agent_sdk.Types.content = "ok"; _meta = None })
+  in
+  let input_components =
+    KAPM.build_input_components
+      ~system_prompt_block:(Some system_prompt_block)
+      ~tools:[ tool ]
+      ~input_messages
+  in
   let metrics =
-    KAR.build_ctx_composition_metrics
-      ~system_prompt:"System prompt"
-      ~dynamic_context:"Dynamic context"
-      ~memory_context:"Memory context"
-      ~temporal_context:"Temporal context"
-      ~user_message:"Current user message"
-      ~history_messages
+    KAPM.build_ctx_composition_metrics
+      ~input_components
       ~actual_input_tokens:(Some 1000)
   in
-  let segment_bytes key =
+  let segment_bytes component =
     metrics.segments
-    |> List.assoc_opt key
-    |> Option.map (fun segment -> segment.KAR.bytes)
+    |> List.find_opt (fun (candidate, _) -> candidate = component)
+    |> Option.map (fun (_, segment) -> segment.KAPM.bytes)
     |> Option.value ~default:0
   in
-  check bool "system prompt bucket present" true
-    (segment_bytes "system_prompt" > 0);
-  check bool "history user bucket present" true
-    (segment_bytes "history_user" > 0);
-  check bool "history assistant text bucket present" true
-    (segment_bytes "history_assistant_text" > 0);
-  check bool "history tool use bucket present" true
-    (segment_bytes "history_tool_use" > 0);
-  check bool "history tool result bucket present" true
-    (segment_bytes "history_tool_result" > 0);
+  check int "persona prompt bytes are exact"
+    (String.length "System prompt")
+    (segment_bytes (Turn_record.Prompt_block Prompt_block_id.Persona));
+  check int "tool schema bytes are canonical"
+    (String.length
+       (Yojson.Safe.to_string (Agent_sdk.Tool.schema_to_json tool)))
+    (segment_bytes Turn_record.Tool_schemas);
+  check bool "user message bucket present" true
+    (segment_bytes Turn_record.Message_user > 0);
+  check bool "assistant text bucket present" true
+    (segment_bytes Turn_record.Message_assistant_text > 0);
+  check bool "tool use bucket present" true
+    (segment_bytes Turn_record.Message_tool_use > 0);
+  check bool "tool result bucket present" true
+    (segment_bytes Turn_record.Message_tool_result > 0);
   check (option int) "provider token observation remains separate" (Some 1000)
     metrics.actual_input_tokens;
   check int "total bytes equal segment sum"
-    (List.fold_left (fun total (_, segment) -> total + segment.KAR.bytes) 0
+    (List.fold_left (fun total (_, segment) -> total + segment.KAPM.bytes) 0
        metrics.segments)
     metrics.attributed_bytes
+
+let test_projection_snapshot_counts_flattened_messages_without_recovery () =
+  let dynamic = "dynamic" in
+  let temporal = "temporal" in
+  let context = dynamic ^ "\n\n" ^ temporal in
+  let flattened_context = "opaque context envelope:" ^ context in
+  let message text = Agent_sdk.Types.user_msg text in
+  let prepared_messages =
+    [ message "prior"
+    ; message flattened_context
+    ]
+  in
+  let projected_messages = prepared_messages @ [ message "gate evidence" ] in
+  let prompt_blocks =
+    [ { Turn_record.block = Prompt_block_id.Persona
+      ; bytes = String.length "persona"
+      ; digest = "persona-digest"
+      }
+    ; { Turn_record.block = Prompt_block_id.Dynamic_context
+      ; bytes = String.length dynamic
+      ; digest = "dynamic-digest"
+      }
+    ; { Turn_record.block = Prompt_block_id.Temporal_summary
+      ; bytes = String.length temporal
+      ; digest = "temporal-digest"
+      }
+    ]
+  in
+  let input_components =
+    KRTH.provider_input_components
+      ~prompt_blocks
+      ~tools:[]
+      ~projected_messages
+  in
+  let bytes component =
+    input_components
+    |> List.find_opt (fun (candidate : Turn_record.input_component) ->
+      candidate.component = component)
+    |> Option.map (fun (component : Turn_record.input_component) ->
+      component.bytes)
+    |> Option.value ~default:0
+  in
+  check int "system prompt remains a separate provider component"
+    (String.length "persona")
+    (bytes (Turn_record.Prompt_block Prompt_block_id.Persona));
+  check int "dynamic provenance is not double-counted as a provider component"
+    0
+    (bytes (Turn_record.Prompt_block Prompt_block_id.Dynamic_context));
+  check int "flattened context and projected tail are counted exactly once"
+    (String.length "prior"
+     + String.length flattened_context
+     + String.length "gate evidence")
+    (bytes Turn_record.Message_user)
 
 (* ── Suite ────────────────────────────────────────────── *)
 
@@ -424,7 +498,10 @@ let () =
         ] );
       ( "ctx_composition",
         [
-          test_case "splits history byte buckets" `Quick
-            test_ctx_composition_splits_history_bytes;
+          test_case "splits exact provider input byte buckets" `Quick
+            test_ctx_composition_splits_provider_input_bytes;
+          test_case "projection counts flattened messages without recovery"
+            `Quick
+            test_projection_snapshot_counts_flattened_messages_without_recovery;
         ] );
     ]

--- a/test/test_keeper_request_wire_observation.ml
+++ b/test/test_keeper_request_wire_observation.ml
@@ -221,6 +221,28 @@ let test_admits_a_zero_byte_observation () =
     (observe series 0)
 ;;
 
+let test_forwards_exact_bytes_to_error_surviving_callback () =
+  let observed = ref None in
+  let observation_result =
+    Observation.observer
+      ~on_request_body_bytes:(fun bytes -> observed := Some bytes)
+      ~keeper_name:"wire-observation-callback"
+      ~runtime_id:"wire-runtime-callback"
+      ~max_request_body_bytes:524_288
+      (observation ~body_bytes:333_777)
+  in
+  check
+    (result unit reject)
+    "callback observation admitted"
+    (Ok ())
+    observation_result;
+  check
+    (option int)
+    "callback receives exact pre-dispatch bytes"
+    (Some 333_777)
+    !observed
+;;
+
 let test_metric_name_is_stable () =
   check
     string
@@ -257,6 +279,10 @@ let () =
             "admits a zero-byte observation"
             `Quick
             test_admits_a_zero_byte_observation
+        ; test_case
+            "forwards exact bytes to the turn callback"
+            `Quick
+            test_forwards_exact_bytes_to_error_surviving_callback
         ; test_case "metric name is stable" `Quick test_metric_name_is_stable
         ] )
     ]

--- a/test/test_keeper_runtime_observation_boundaries.ml
+++ b/test/test_keeper_runtime_observation_boundaries.ml
@@ -255,8 +255,8 @@ let test_empty_completion_exemption_budget_is_bounded () =
 let test_extra_system_context_preserves_typed_blocks () =
   let blocks =
     [ Prompt_block_id.Dynamic_context, "dynamic"
-    ; Prompt_block_id.Retry_nudge, "retry"
-    ; Prompt_block_id.Connected_surface, "surface"
+    ; Prompt_block_id.Temporal_summary, "temporal"
+    ; Prompt_block_id.Memory_os_recall, "memory"
     ]
   in
   let assembly =
@@ -267,7 +267,7 @@ let test_extra_system_context_preserves_typed_blocks () =
   Alcotest.(check bool) "typed blocks unchanged" true (assembly.blocks = blocks);
   Alcotest.(check (option string))
     "complete source order reaches OAS"
-    (Some "existing\n\ndynamic\n\nretry\n\nsurface")
+    (Some "existing\n\ndynamic\n\ntemporal\n\nmemory")
     assembly.extra_system_context
 
 let () =

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -207,6 +207,29 @@ let test_repeated_exact_tool_call_boundary () =
        ; tool_call ~input:None "keeper_tasks_list"
        ])
 
+let test_request_body_refusal_overrides_prior_observation () =
+  let error =
+    Agent_sdk.Error.Api
+      (Agent_sdk.Retry.InvalidRequest
+         { message = "serialized request body exceeds the declared limit"
+         ; reason =
+             Agent_sdk.Retry.Request_body_too_large
+               { actual_bytes = 777_777; limit_bytes = 524_288 }
+         })
+  in
+  check (option int) "final typed refusal is authoritative"
+    (Some 777_777)
+    (Masc.Keeper_agent_run.For_testing.request_body_bytes_for_error
+       ~observed:(Some 111_111)
+       error)
+
+let test_non_capacity_error_keeps_latest_serialized_observation () =
+  check (option int) "latest actual serialization survives later failure"
+    (Some 111_111)
+    (Masc.Keeper_agent_run.For_testing.request_body_bytes_for_error
+       ~observed:(Some 111_111)
+       (Agent_sdk.Error.Internal "failed after serialization"))
+
 let test_autonomous_yield_boundary_contract () =
   let module F = Masc.Keeper_agent_run.For_testing in
   let chat : Masc.Keeper_agent_run.autonomous_yield_request =
@@ -583,6 +606,10 @@ let () =
             test_terminal_effect_defer_kinds_remain_distinct;
           test_case "repeated exact tool call boundary" `Quick
             test_repeated_exact_tool_call_boundary;
+          test_case "typed body refusal overrides prior observation" `Quick
+            test_request_body_refusal_overrides_prior_observation;
+          test_case "non-capacity failure keeps latest serialization" `Quick
+            test_non_capacity_error_keeps_latest_serialized_observation;
           test_case "autonomous yield boundary contract" `Quick
             test_autonomous_yield_boundary_contract;
           test_case "terminal effect handler contract" `Quick

--- a/test/test_turn_record.ml
+++ b/test/test_turn_record.ml
@@ -11,23 +11,29 @@ let block_id = testable (Fmt.of_to_string Prompt_block_id.to_string) Prompt_bloc
 let test_block_id_roundtrip () =
   List.iter
     (fun block ->
-      check block_id
-        (Printf.sprintf "roundtrip %s" (Prompt_block_id.to_string block))
-        block
-        (Prompt_block_id.of_string (Prompt_block_id.to_string block)))
-    Prompt_block_id.all_known
+      match Prompt_block_id.of_string (Prompt_block_id.to_string block) with
+      | Ok decoded ->
+        check block_id
+          (Printf.sprintf "roundtrip %s" (Prompt_block_id.to_string block))
+          block
+          decoded
+      | Error error -> failf "known prompt block failed: %s" error)
+    Prompt_block_id.all
 
-let test_block_id_unknown_maps_to_other () =
-  check block_id "unknown name survives as Other"
-    (Prompt_block_id.Other "future_block")
-    (Prompt_block_id.of_string "future_block");
-  check string "Other renders its name" "future_block"
-    (Prompt_block_id.to_string (Prompt_block_id.Other "future_block"))
+let test_block_id_unknown_fails_closed () =
+  match Prompt_block_id.of_string "future_block" with
+  | Ok _ -> fail "decoded an unknown prompt block"
+  | Error error ->
+    check bool "unknown prompt block is explicit" true
+      (Astring.String.is_infix ~affix:"future_block" error)
 
 (* ── TurnRecord codec ─────────────────────────────────── *)
 
 let sample_block block digest =
   { Turn_record.block; bytes = String.length digest; digest }
+
+let sample_component component bytes =
+  { Turn_record.component = component; bytes }
 
 let sample_record () : Turn_record.t =
   { execution_ids =
@@ -38,11 +44,20 @@ let sample_record () : Turn_record.t =
   ; trace_id = "trace-1780648779957-00000"
   ; absolute_turn = 4071
   ; turn_ref =
-      Some (Ids.Turn_ref.make ~trace_id:"trace-1780648779957-00000" ~absolute_turn:4071)
+      Ids.Turn_ref.make
+        ~trace_id:"trace-1780648779957-00000"
+        ~absolute_turn:4071
   ; blocks =
       [ sample_block Prompt_block_id.Persona "aaaa"
       ; sample_block Prompt_block_id.Dynamic_context "bbbb"
       ; sample_block Prompt_block_id.Memory_os_recall "cccc"
+      ]
+  ; input_components =
+      [ sample_component
+          (Turn_record.Prompt_block Prompt_block_id.Persona)
+          4
+      ; sample_component Turn_record.Tool_schemas 2048
+      ; sample_component Turn_record.Message_tool_result 512
       ]
   ; runtime_profile = "ollama_cloud.deepseek-v4-flash"
   ; model = Some "deepseek-v4-flash"
@@ -52,6 +67,8 @@ let sample_record () : Turn_record.t =
   ; price_output_per_million = Some 0.6
   ; request_latency_ms = Some 1234
   ; ttfrc_ms = Some 567.8
+  ; request_runtime_profile = Some "ollama_cloud.deepseek-v4-flash"
+  ; request_body_bytes = Some 560_513
   ; sampling =
       { temperature = Some 0.3
       ; top_p = Some 0.9
@@ -72,8 +89,8 @@ let sample_record () : Turn_record.t =
    input_tokens could not be read as either a cache-heavy turn or a genuinely large
    prompt. context_window denominates the ctx-fill percentage against the compaction
    ceiling, so those two situations look identical on a dashboard while calling for
-   different action. A row that omits them still decodes — legacy rows and turns where
-   the provider reported no usage carry None rather than a fabricated zero. *)
+   different action. A current turn whose provider reports no cache usage omits
+   them and decodes to None rather than a fabricated zero. *)
 let test_cache_counts_round_trip_and_stay_optional () =
   let record = sample_record () in
   (match Turn_record.of_json (Turn_record.to_json record) with
@@ -83,8 +100,7 @@ let test_cache_counts_round_trip_and_stay_optional () =
        decoded.usage.cache_creation_input_tokens;
      check (option int) "cache read survives" (Some 15000)
        decoded.usage.cache_read_input_tokens);
-  (* A row written before these fields existed. *)
-  let legacy =
+  let without_cache_usage =
     match Turn_record.to_json record with
     | `Assoc fields ->
       `Assoc
@@ -94,8 +110,8 @@ let test_cache_counts_round_trip_and_stay_optional () =
            fields)
     | other -> other
   in
-  match Turn_record.of_json legacy with
-  | Error e -> failf "legacy row without cache fields failed to decode: %s" e
+  match Turn_record.of_json without_cache_usage with
+  | Error e -> failf "row without provider cache usage failed to decode: %s" e
   | Ok decoded ->
     check (option int) "absent cache creation decodes as None" None
       decoded.usage.cache_creation_input_tokens;
@@ -118,10 +134,7 @@ let test_codec_roundtrip () =
     check string "trace_id" record.trace_id decoded.trace_id;
     check int "absolute_turn" record.absolute_turn decoded.absolute_turn;
     check bool "turn_ref preserved" true
-      (match record.turn_ref, decoded.turn_ref with
-       | Some a, Some b -> Ids.Turn_ref.equal a b
-       | None, None -> true
-       | Some _, None | None, Some _ -> false);
+      (Ids.Turn_ref.equal record.turn_ref decoded.turn_ref);
     check int "blocks count" 3 (List.length decoded.blocks);
     check bool "blocks preserved in order" true
       (List.for_all2
@@ -130,6 +143,22 @@ let test_codec_roundtrip () =
            && a.bytes = b.bytes
            && String.equal a.digest b.digest)
          record.blocks decoded.blocks);
+    check (list string) "input component ids preserved in order"
+      (List.map
+         (fun (component : Turn_record.input_component) ->
+           Turn_record.input_component_id_to_string component.component)
+         record.input_components)
+      (List.map
+         (fun (component : Turn_record.input_component) ->
+           Turn_record.input_component_id_to_string component.component)
+         decoded.input_components);
+    check (list int) "input component bytes preserved"
+      (List.map
+         (fun (component : Turn_record.input_component) -> component.bytes)
+         record.input_components)
+      (List.map
+         (fun (component : Turn_record.input_component) -> component.bytes)
+         decoded.input_components);
     check string "runtime_profile" record.runtime_profile decoded.runtime_profile;
     check (option string) "model" record.model decoded.model;
     check (option string) "finish_reason" record.finish_reason decoded.finish_reason;
@@ -142,6 +171,10 @@ let test_codec_roundtrip () =
       decoded.request_latency_ms;
     check (option (float 0.0001)) "ttfrc_ms round-trip" record.ttfrc_ms
       decoded.ttfrc_ms;
+    check (option string) "request runtime profile round-trip"
+      record.request_runtime_profile decoded.request_runtime_profile;
+    check (option int) "request_body_bytes round-trip"
+      record.request_body_bytes decoded.request_body_bytes;
     check (option (float 0.0001)) "temperature" record.sampling.temperature
       decoded.sampling.temperature;
     check (option (float 0.0001)) "top_p" record.sampling.top_p
@@ -166,8 +199,10 @@ let test_codec_optional_fields_absent () =
     ; context_window = None
     ; price_input_per_million = None
     ; price_output_per_million = None
-  ; request_latency_ms = None
-  ; ttfrc_ms = None
+    ; request_latency_ms = None
+    ; ttfrc_ms = None
+    ; request_runtime_profile = None
+    ; request_body_bytes = None
     ; sampling =
         { temperature = None
         ; top_p = None
@@ -181,7 +216,6 @@ let test_codec_optional_fields_absent () =
         ; cache_creation_input_tokens = None
         ; cache_read_input_tokens = None
         }
-    ; turn_ref = None
     }
   in
   let json = Turn_record.to_json record in
@@ -205,7 +239,15 @@ let test_codec_optional_fields_absent () =
      check bool "request_latency_ms key omitted when None" false
        (List.mem_assoc "request_latency_ms" fields);
      check bool "ttfrc_ms key omitted when None" false
-       (List.mem_assoc "ttfrc_ms" fields)
+       (List.mem_assoc "ttfrc_ms" fields);
+     check bool "request_body_bytes key remains required" true
+       (List.mem_assoc "request_body_bytes" fields);
+     check bool "request_body_bytes None is explicit null" true
+       (List.assoc_opt "request_body_bytes" fields = Some `Null);
+     check bool "request_runtime_profile key remains required" true
+       (List.mem_assoc "request_runtime_profile" fields);
+     check bool "request_runtime_profile None is explicit null" true
+       (List.assoc_opt "request_runtime_profile" fields = Some `Null)
    | _ -> fail "to_json did not produce an object");
   match Turn_record.of_json json with
   | Error e -> failf "decode failed: %s" e
@@ -222,12 +264,15 @@ let test_codec_optional_fields_absent () =
       decoded.request_latency_ms;
     check (option (float 0.0001)) "ttfrc_ms absent" None
       decoded.ttfrc_ms;
+    check (option int) "request body observation absent" None
+      decoded.request_body_bytes;
+    check (option string) "request runtime profile absent" None
+      decoded.request_runtime_profile;
     check (option (float 0.0001)) "temperature absent" None
       decoded.sampling.temperature;
     check (option (float 0.0001)) "top_p absent" None decoded.sampling.top_p;
     check (option int) "max_tokens absent" None decoded.sampling.max_tokens;
-    check (option int) "input_tokens absent" None decoded.usage.input_tokens;
-    check bool "turn_ref absent" true (decoded.turn_ref = None)
+    check (option int) "input_tokens absent" None decoded.usage.input_tokens
 
 let test_codec_rejects_malformed () =
   (match Turn_record.of_json (`String "not a record") with
@@ -239,20 +284,139 @@ let test_codec_rejects_malformed () =
     check bool "error names the missing field" true
       (Astring.String.is_infix ~affix:"execution_ids" msg)
 
-let test_codec_unknown_block_decodes_as_other () =
+let test_codec_requires_current_input_composition () =
+  let without_components =
+    match Turn_record.to_json (sample_record ()) with
+    | `Assoc fields ->
+      `Assoc (List.remove_assoc "input_components" fields)
+    | other -> other
+  in
+  match Turn_record.of_json without_components with
+  | Ok _ -> fail "decoded a row without current input composition"
+  | Error msg ->
+    check bool "missing current field is explicit" true
+      (Astring.String.is_infix ~affix:"input_components" msg)
+
+let test_codec_requires_turn_ref () =
+  let without_turn_ref =
+    match Turn_record.to_json (sample_record ()) with
+    | `Assoc fields -> `Assoc (List.remove_assoc "turn_ref" fields)
+    | other -> other
+  in
+  match Turn_record.of_json without_turn_ref with
+  | Ok _ -> fail "decoded a row without current turn_ref"
+  | Error msg ->
+    check bool "missing current field is explicit" true
+      (Astring.String.is_infix ~affix:"turn_ref" msg)
+
+let test_codec_rejects_mismatched_turn_ref () =
+  let mismatched =
+    match Turn_record.to_json (sample_record ()) with
+    | `Assoc fields ->
+      `Assoc
+        ( ( "turn_ref"
+          , Ids.Turn_ref.to_yojson
+              (Ids.Turn_ref.make ~trace_id:"other-trace" ~absolute_turn:9) )
+        :: List.remove_assoc "turn_ref" fields )
+    | other -> other
+  in
+  match Turn_record.of_json mismatched with
+  | Ok _ -> fail "decoded a turn_ref that disagrees with its source fields"
+  | Error msg ->
+    check bool "mismatched derived field is explicit" true
+      (Astring.String.is_infix ~affix:"does not match" msg)
+
+let test_codec_requires_current_request_body_observation () =
+  let without_request_body_bytes =
+    match Turn_record.to_json (sample_record ()) with
+    | `Assoc fields ->
+      `Assoc (List.remove_assoc "request_body_bytes" fields)
+    | other -> other
+  in
+  match Turn_record.of_json without_request_body_bytes with
+  | Ok _ -> fail "decoded a row without current request body observation"
+  | Error msg ->
+    check bool "missing current field is explicit" true
+      (Astring.String.is_infix ~affix:"request_body_bytes" msg)
+
+let test_codec_requires_current_request_runtime_profile () =
+  let without_request_runtime_profile =
+    match Turn_record.to_json (sample_record ()) with
+    | `Assoc fields ->
+      `Assoc (List.remove_assoc "request_runtime_profile" fields)
+    | other -> other
+  in
+  match Turn_record.of_json without_request_runtime_profile with
+  | Ok _ -> fail "decoded a row without current request runtime attribution"
+  | Error msg ->
+    check bool "missing current field is explicit" true
+      (Astring.String.is_infix ~affix:"request_runtime_profile" msg)
+
+let test_codec_rejects_invalid_request_body_observation () =
+  let with_request_body_bytes value =
+    match Turn_record.to_json (sample_record ()) with
+    | `Assoc fields ->
+      `Assoc
+        (("request_body_bytes", value)
+         :: List.remove_assoc "request_body_bytes" fields)
+    | other -> other
+  in
+  List.iter
+    (fun value ->
+      match Turn_record.of_json (with_request_body_bytes value) with
+      | Ok _ -> fail "decoded an invalid request body observation"
+      | Error msg ->
+        check bool "invalid current field is explicit" true
+          (Astring.String.is_infix ~affix:"request_body_bytes" msg))
+    [ `Int (-1); `String "560513" ]
+
+let test_codec_rejects_unknown_input_component () =
+  let with_component component =
+    match Turn_record.to_json (sample_record ()) with
+    | `Assoc fields ->
+      `Assoc
+        ( ( "input_components"
+          , `List
+              [ `Assoc
+                  [ "component", `String component
+                  ; "bytes", `Int 1
+                  ]
+              ] )
+        :: List.remove_assoc "input_components" fields )
+    | other -> other
+  in
+  List.iter
+    (fun (component, error_token) ->
+      match Turn_record.of_json (with_component component) with
+      | Ok _ -> failf "decoded unknown input component %s" component
+      | Error msg ->
+        check bool "unknown component is explicit" true
+          (Astring.String.is_infix ~affix:error_token msg))
+    [ "history_guess", "history_guess"
+    ; "prompt.future_block", "future_block"
+    ]
+
+let test_codec_unknown_block_fails_closed () =
   let json =
-    Turn_record.to_json
-      { (sample_record ()) with
-        blocks = [ sample_block (Prompt_block_id.Other "future_block") "dddd" ]
-      }
+    match Turn_record.to_json (sample_record ()) with
+    | `Assoc fields ->
+      `Assoc
+        ( ( "blocks"
+          , `List
+              [ `Assoc
+                  [ "block", `String "future_block"
+                  ; "bytes", `Int 4
+                  ; "digest", `String "dddd"
+                  ]
+              ] )
+        :: List.remove_assoc "blocks" fields )
+    | other -> other
   in
   match Turn_record.of_json json with
-  | Error e -> failf "decode failed: %s" e
-  | Ok decoded ->
-    (match decoded.blocks with
-     | [ { block; _ } ] ->
-       check block_id "forward-open block id" (Prompt_block_id.Other "future_block") block
-     | _ -> fail "expected exactly one block")
+  | Ok _ -> fail "decoded an unknown prompt block"
+  | Error error ->
+    check bool "unknown prompt block is explicit" true
+      (Astring.String.is_infix ~affix:"future_block" error)
 
 (* ── Block diff (RFC §5: exact added/removed set) ─────── *)
 
@@ -263,7 +427,7 @@ let test_diff_added_removed_changed () =
     record_with_blocks
       [ sample_block Prompt_block_id.Persona "aaaa"
       ; sample_block Prompt_block_id.Dynamic_context "bbbb"
-      ; sample_block Prompt_block_id.Retry_nudge "rrrr"
+      ; sample_block Prompt_block_id.Temporal_summary "tttt"
       ]
   in
   let next =
@@ -277,8 +441,8 @@ let test_diff_added_removed_changed () =
   check (list block_id) "added = exactly memory_os_recall"
     [ Prompt_block_id.Memory_os_recall ]
     (List.map (fun (b : Turn_record.prompt_block) -> b.block) diff.added);
-  check (list block_id) "removed = exactly retry_nudge"
-    [ Prompt_block_id.Retry_nudge ]
+  check (list block_id) "removed = exactly temporal_summary"
+    [ Prompt_block_id.Temporal_summary ]
     (List.map (fun (b : Turn_record.prompt_block) -> b.block) diff.removed);
   check (list block_id) "changed = exactly dynamic_context"
     [ Prompt_block_id.Dynamic_context ]
@@ -303,7 +467,7 @@ let test_entries_with_diffs_same_trace_only () =
   let r2 =
     { (record_with_blocks
          [ sample_block Prompt_block_id.Persona "aaaa"
-         ; sample_block Prompt_block_id.Retry_nudge "rrrr"
+         ; sample_block Prompt_block_id.Memory_os_recall "mmmm"
          ])
       with
       trace_id = "trace-A"
@@ -321,8 +485,8 @@ let test_entries_with_diffs_same_trace_only () =
     check bool "first record has no predecessor" true (first = None);
     (match second with
      | Some diff ->
-       check (list block_id) "same-trace diff sees the added nudge"
-         [ Prompt_block_id.Retry_nudge ]
+       check (list block_id) "same-trace diff sees the added recall block"
+         [ Prompt_block_id.Memory_os_recall ]
          (List.map (fun (b : Turn_record.prompt_block) -> b.block) diff.added)
      | None -> fail "expected a diff for the same-trace successor");
     check bool "trace boundary yields no diff" true (third = None)
@@ -363,7 +527,8 @@ let () =
   run "turn_record"
     [ ( "prompt_block_id"
       , [ test_case "all known constructors roundtrip" `Quick test_block_id_roundtrip
-        ; test_case "unknown maps to Other" `Quick test_block_id_unknown_maps_to_other
+        ; test_case "unknown fails closed" `Quick
+            test_block_id_unknown_fails_closed
         ] )
     ; ( "codec"
       , [ test_case "roundtrip" `Quick test_codec_roundtrip
@@ -371,8 +536,21 @@ let () =
             test_cache_counts_round_trip_and_stay_optional
         ; test_case "optional fields absent" `Quick test_codec_optional_fields_absent
         ; test_case "rejects malformed rows" `Quick test_codec_rejects_malformed
-        ; test_case "unknown block decodes as Other" `Quick
-            test_codec_unknown_block_decodes_as_other
+        ; test_case "current input composition required" `Quick
+            test_codec_requires_current_input_composition
+        ; test_case "turn_ref required" `Quick test_codec_requires_turn_ref
+        ; test_case "mismatched turn_ref rejected" `Quick
+            test_codec_rejects_mismatched_turn_ref
+        ; test_case "current request body observation required" `Quick
+            test_codec_requires_current_request_body_observation
+        ; test_case "current request runtime attribution required" `Quick
+            test_codec_requires_current_request_runtime_profile
+        ; test_case "invalid request body observation rejected" `Quick
+            test_codec_rejects_invalid_request_body_observation
+        ; test_case "unknown input component rejected" `Quick
+            test_codec_rejects_unknown_input_component
+        ; test_case "unknown prompt block rejected" `Quick
+            test_codec_unknown_block_fails_closed
         ] )
     ; ( "block_diff"
       , [ test_case "exact added/removed/changed sets" `Quick


### PR DESCRIPTION
## What changed

- Record the exact final projected provider-input composition by typed category at the existing `model_input_projection` boundary.
- Record the actual serialized request-body bytes and the runtime profile that performed the request.
- Keep provider-attributed bytes, wire bytes, and provider token usage as separate measurements.
- Make the current `TurnRecord` contract strict: required `turn_ref`, required input-component evidence, and explicit nullable request observations.
- Reduce prompt-block identity to the four blocks that have real producers today.
- Show the evidence in the dashboard without reconstructing raw prompts or inventing token estimates.

## Why

The closed #26428 mixed provider-input observability with a broad Memory OS rewrite. That direction was discarded. Current Memory authority is owned by #26440 and #26450; this PR does not change librarian, store, recall selection, or memory retention behavior.

OAS may flatten or synthesize provider messages. MASC must not recover semantic provenance by matching strings such as `[system context]`. This implementation captures typed categories before serialization and exact wire bytes at serialization instead.

## Contract

- No new admission Gate or secondary authority.
- No facade-from-facade.
- No legacy reader, fallback field, migration, or compatibility branch.
- Historical TurnRecord rows that do not satisfy the current contract are skipped and counted by the existing API instead of being reinterpreted.
- Raw prompt content is not persisted; only category bytes, digests, request bytes, runtime identity, and provider usage are exposed.

## Validation

- `git diff --check origin/main...HEAD`
- `ocamlformat --check` on the changed OCaml files
- Focused OCaml executables passed before rebasing onto current main: 79 tests
  - `test_turn_record.exe`
  - `test_keeper_prompt_metrics.exe`
  - `test_keeper_request_wire_observation.exe`
  - `test_keeper_turn_outcome.exe`
  - `test_keeper_runtime_observation_boundaries.exe`
- Dashboard TypeScript check passed.
- Targeted dashboard Vitest: 82 tests passed.

Current-main backend verification is blocked by the base commit from #26455:

```text
server_dashboard_http_keeper_event_queue_operator_execute.ml:
accepted_cancellation has no field source_revision
```

#26468 is the active base repair; it superseded the closed #26458. Keep this PR draft and do-not-merge until the base fix is merged, this branch is rebased, and exact-head CI is green.

Replaces the valid observability slice of closed #26428; it does not reopen or reuse that PR.
