### PR TITLE
fix(keeper): target exact event source snapshots

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -68,6 +68,9 @@ import {
 import { resetDevTokenBootstrap } from './dev-token'
 import { DEFAULT_GET_TIMEOUT_MS } from '../config/constants'
 
+const EVENT_SOURCE_INCARNATION = '6'
+const EVENT_SOURCE_SNAPSHOT_SHA256 = 'a'.repeat(64)
+
 afterEach(() => {
   vi.useRealTimers()
   vi.clearAllMocks()
@@ -504,6 +507,8 @@ describe('Keeper chat durable receipt API', () => {
   it('combines metadata-only event refs across one stable Admin inventory revision', async () => {
     const item = (queueIndex: number, postId: string) => ({
       queue_index: queueIndex,
+      source_incarnation: EVENT_SOURCE_INCARNATION,
+      source_snapshot_sha256: EVENT_SOURCE_SNAPSHOT_SHA256,
       post_id: postId,
       urgency: 'normal',
       arrived_at_unix: 42,
@@ -569,6 +574,8 @@ describe('Keeper chat durable receipt API', () => {
       next_after: nextAfter,
       pending: [{
         queue_index: queueIndex,
+        source_incarnation: EVENT_SOURCE_INCARNATION,
+        source_snapshot_sha256: EVENT_SOURCE_SNAPSHOT_SHA256,
         post_id: `post-${revision}`,
         urgency: 'normal',
         arrived_at_unix: 42,
@@ -657,6 +664,7 @@ describe('Keeper chat durable receipt API', () => {
       action: 'reprioritize',
       expectedRevision: '7',
       queueIndex: 0,
+      sourceIncarnation: EVENT_SOURCE_INCARNATION,
       urgency: 'immediate',
     })
 
@@ -666,8 +674,9 @@ describe('Keeper chat durable receipt API', () => {
         body: JSON.stringify({
           schema: 'keeper_event_queue.operator.request.v1',
           action: 'reprioritize',
-          expected_revision: '7',
           queue_index: 0,
+          source_incarnation: EVENT_SOURCE_INCARNATION,
+          expected_revision: '7',
           urgency: 'immediate',
         }),
       }),
@@ -695,9 +704,10 @@ describe('Keeper chat durable receipt API', () => {
     try {
       await operateKeeperEventQueue('sangsu', {
         action: 'cancel',
-        expectedRevision: '8',
         operationId: 'operation-9',
         queueIndex: 1,
+        sourceIncarnation: EVENT_SOURCE_INCARNATION,
+        sourceSnapshotSha256: EVENT_SOURCE_SNAPSHOT_SHA256,
         reason: 'operator cancellation',
       })
     } catch (cause) {
@@ -709,9 +719,10 @@ describe('Keeper chat durable receipt API', () => {
       commitState: 'committed',
       operation: {
         action: 'cancel',
-        expectedRevision: '8',
         operationId: 'operation-9',
         queueIndex: 1,
+        sourceIncarnation: EVENT_SOURCE_INCARNATION,
+        sourceSnapshotSha256: EVENT_SOURCE_SNAPSHOT_SHA256,
         reason: 'operator cancellation',
       },
     })
@@ -733,8 +744,9 @@ describe('Keeper chat durable receipt API', () => {
     try {
       await operateKeeperEventQueue('sangsu', {
         action: 'transfer',
-        expectedRevision: '9',
         queueIndex: 2,
+        sourceIncarnation: EVENT_SOURCE_INCARNATION,
+        sourceSnapshotSha256: EVENT_SOURCE_SNAPSHOT_SHA256,
         targetKeeper: 'rondo',
       })
     } catch (cause) {
@@ -746,9 +758,10 @@ describe('Keeper chat durable receipt API', () => {
       commitState: 'unknown',
       operation: {
         action: 'transfer',
-        expectedRevision: '9',
         operationId: '00000000-0000-4000-8000-000000000099',
         queueIndex: 2,
+        sourceIncarnation: EVENT_SOURCE_INCARNATION,
+        sourceSnapshotSha256: EVENT_SOURCE_SNAPSHOT_SHA256,
         targetKeeper: 'rondo',
       },
     })
@@ -758,8 +771,9 @@ describe('Keeper chat durable receipt API', () => {
         body: JSON.stringify({
           schema: 'keeper_event_queue.operator.request.v1',
           action: 'transfer',
-          expected_revision: '9',
           queue_index: 2,
+          source_incarnation: EVENT_SOURCE_INCARNATION,
+          source_snapshot_sha256: EVENT_SOURCE_SNAPSHOT_SHA256,
           operator_operation_id: '00000000-0000-4000-8000-000000000099',
           target_keeper: 'rondo',
         }),

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -786,6 +786,8 @@ export interface KeeperChatPendingMutationResult {
 
 export interface KeeperEventQueuePendingItem {
   queueIndex: number
+  sourceIncarnation: string
+  sourceSnapshotSha256: string
   postId: string
   urgency: 'immediate' | 'normal' | 'low'
   arrivedAt: number
@@ -1141,6 +1143,8 @@ export function parseKeeperEventQueuePendingSnapshot(
       throw new Error('Keeper event pending entry must be an object')
     }
     const queueIndex = asNumber(raw.queue_index)
+    const sourceIncarnation = parseKeeperQueueRevision(raw.source_incarnation)
+    const sourceSnapshotSha256 = asString(raw.source_snapshot_sha256, '')
     const postId = asString(raw.post_id, '').trim()
     const urgency = asString(raw.urgency, '').trim()
     const arrivedAt = asNumber(raw.arrived_at_unix)
@@ -1149,6 +1153,8 @@ export function parseKeeperEventQueuePendingSnapshot(
       typeof queueIndex !== 'number'
       || !Number.isSafeInteger(queueIndex)
       || queueIndex < 0
+      || sourceIncarnation === undefined
+      || !/^[0-9a-f]{64}$/.test(sourceSnapshotSha256)
       || !postId
       || !['immediate', 'normal', 'low'].includes(urgency)
       || typeof arrivedAt !== 'number'
@@ -1160,6 +1166,8 @@ export function parseKeeperEventQueuePendingSnapshot(
     }
     return {
       queueIndex,
+      sourceIncarnation,
+      sourceSnapshotSha256,
       postId,
       urgency: urgency as KeeperEventQueuePendingItem['urgency'],
       arrivedAt,
@@ -1366,13 +1374,13 @@ export async function moveKeeperChatPendingReceiptToEnd(
 }
 
 export type KeeperEventQueueOperatorAction =
-  | { action: 'cancel'; expectedRevision: string; queueIndex: number; reason: string; operationId?: string }
-  | { action: 'transfer'; expectedRevision: string; queueIndex: number; targetKeeper: string; operationId?: string }
-  | { action: 'reprioritize'; expectedRevision: string; queueIndex: number; urgency: 'immediate' | 'normal' | 'low' }
+  | { action: 'cancel'; queueIndex: number; sourceIncarnation: string; sourceSnapshotSha256: string; reason: string; operationId?: string }
+  | { action: 'transfer'; queueIndex: number; sourceIncarnation: string; sourceSnapshotSha256: string; targetKeeper: string; operationId?: string }
+  | { action: 'reprioritize'; expectedRevision: string; queueIndex: number; sourceIncarnation: string; urgency: 'immediate' | 'normal' | 'low' }
 
 export type KeeperEventQueueReplayableAction =
-  | { action: 'cancel'; expectedRevision: string; queueIndex: number; reason: string; operationId: string }
-  | { action: 'transfer'; expectedRevision: string; queueIndex: number; targetKeeper: string; operationId: string }
+  | { action: 'cancel'; queueIndex: number; sourceIncarnation: string; sourceSnapshotSha256: string; reason: string; operationId: string }
+  | { action: 'transfer'; queueIndex: number; sourceIncarnation: string; sourceSnapshotSha256: string; targetKeeper: string; operationId: string }
 
 type PreparedKeeperEventQueueOperatorAction =
   | KeeperEventQueueReplayableAction
@@ -1427,22 +1435,28 @@ export async function operateKeeperEventQueue(
   const common = {
     schema: 'keeper_event_queue.operator.request.v1',
     action: prepared.action,
-    expected_revision: prepared.expectedRevision,
     queue_index: prepared.queueIndex,
+    source_incarnation: prepared.sourceIncarnation,
   }
   const request = prepared.action === 'cancel'
     ? {
         ...common,
+        source_snapshot_sha256: prepared.sourceSnapshotSha256,
         operator_operation_id: prepared.operationId,
         reason: prepared.reason,
       }
     : prepared.action === 'transfer'
       ? {
           ...common,
+          source_snapshot_sha256: prepared.sourceSnapshotSha256,
           operator_operation_id: prepared.operationId,
           target_keeper: prepared.targetKeeper,
         }
-      : { ...common, urgency: prepared.urgency }
+      : {
+          ...common,
+          expected_revision: prepared.expectedRevision,
+          urgency: prepared.urgency,
+        }
   let raw: unknown
   try {
     raw = await post<unknown>(

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -25,8 +25,9 @@ const {
   KeeperEventQueueOperationError: class KeeperEventQueueOperationError extends Error {
     readonly operation: {
       action: 'cancel' | 'transfer'
-      expectedRevision: string
       queueIndex: number
+      sourceIncarnation: string
+      sourceSnapshotSha256: string
       operationId: string
       reason?: string
       targetKeeper?: string
@@ -37,8 +38,9 @@ const {
       message: string,
       operation: {
         action: 'cancel' | 'transfer'
-        expectedRevision: string
         queueIndex: number
+        sourceIncarnation: string
+        sourceSnapshotSha256: string
         operationId: string
         reason?: string
         targetKeeper?: string
@@ -1016,6 +1018,8 @@ describe('KeeperConversationPanel', () => {
       nextAfter: null,
       pending: [{
         queueIndex: 0,
+        sourceIncarnation: '8',
+        sourceSnapshotSha256: 'b'.repeat(64),
         postId: 'board-post-9',
         urgency: 'normal',
         arrivedAt: 41,
@@ -1087,6 +1091,8 @@ describe('KeeperConversationPanel', () => {
       nextAfter: null,
       pending: [{
         queueIndex: 0,
+        sourceIncarnation: '8',
+        sourceSnapshotSha256: 'b'.repeat(64),
         postId: 'board-post-9',
         urgency: 'normal',
         arrivedAt: 41,
@@ -1106,8 +1112,9 @@ describe('KeeperConversationPanel', () => {
     }
     const recoveryOperation = {
       action: 'transfer' as const,
-      expectedRevision: '9',
       queueIndex: 0,
+      sourceIncarnation: '8',
+      sourceSnapshotSha256: 'b'.repeat(64),
       operationId: 'operation-replay-9',
       targetKeeper: 'rondo',
     }

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -869,6 +869,7 @@ function KeeperQueueControlPanel({
                         action: 'reprioritize',
                         expectedRevision: eventSnapshot!.revision,
                         queueIndex: item.queueIndex,
+                        sourceIncarnation: item.sourceIncarnation,
                         urgency,
                       })
                     }}
@@ -883,8 +884,9 @@ function KeeperQueueControlPanel({
                     if (targetKeeper === null) return
                     void mutateEvent(key, {
                       action: 'transfer',
-                      expectedRevision: eventSnapshot!.revision,
                       queueIndex: item.queueIndex,
+                      sourceIncarnation: item.sourceIncarnation,
+                      sourceSnapshotSha256: item.sourceSnapshotSha256,
                       targetKeeper,
                     })
                   }}
@@ -898,8 +900,9 @@ function KeeperQueueControlPanel({
                     if (reason === null) return
                     void mutateEvent(key, {
                       action: 'cancel',
-                      expectedRevision: eventSnapshot!.revision,
                       queueIndex: item.queueIndex,
+                      sourceIncarnation: item.sourceIncarnation,
+                      sourceSnapshotSha256: item.sourceSnapshotSha256,
                       reason,
                     })
                   }}

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -744,6 +744,13 @@ let stimulus_to_yojson (stimulus : stimulus) =
     ; "payload", payload_to_yojson stimulus.payload
     ]
 
+let stimulus_snapshot_sha256 stimulus =
+  stimulus
+  |> stimulus_to_yojson
+  |> Yojson.Safe.to_string
+  |> Digestif.SHA256.digest_string
+  |> Digestif.SHA256.to_hex
+
 let stimulus_of_yojson json =
   let context = "stimulus" in
   let* fields = assoc_fields ~context json in

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -309,6 +309,11 @@ val drain_board_all : t -> stimulus list * t
 val stimulus_to_yojson : stimulus -> Yojson.Safe.t
 (** Stable JSON representation used by MASC-owned durable queue snapshots. *)
 
+val stimulus_snapshot_sha256 : stimulus -> string
+(** SHA-256 of the exact stable stimulus snapshot. Unlike
+    {!stimulus_identity_equal}, this includes display fields and [arrived_at],
+    so an operator coordinate cannot alias another pending row. *)
+
 val stimulus_of_yojson : Yojson.Safe.t -> (stimulus, string) result
 (** Parse a stimulus written by [stimulus_to_yojson]. *)
 

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -625,10 +625,7 @@ let turn_attempt_terminal_operation_id
       source
   =
   let source_fingerprint =
-    Keeper_event_queue.stimulus_to_yojson source
-    |> Yojson.Safe.to_string
-    |> Digestif.SHA256.digest_string
-    |> Digestif.SHA256.to_hex
+    Keeper_event_queue.stimulus_snapshot_sha256 source
   in
   Printf.sprintf
     "turn-attempt-terminal:%d:%Ld:%s"

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -71,8 +71,9 @@ type pending_selection =
   { source : Keeper_event_queue.stimulus
   ; admitted_revision : int64
   }
-(** One exact durable queue entry. [admitted_revision] identifies the source
-    incarnation without making later unrelated queue changes invalidate it. *)
+(** One exact durable queue entry. [admitted_revision] records the durable
+    transform that admitted the snapshot; every source added by one transform
+    can share it, so it is not a unique row identifier. *)
 
 type transition_result =
   | Transition_applied of transition_receipt

--- a/lib/server/server_dashboard_http_keeper_event_queue_operator.ml
+++ b/lib/server/server_dashboard_http_keeper_event_queue_operator.ml
@@ -67,10 +67,16 @@ let pending_page ~after ~limit pending =
     | _ :: rest when index < after ->
       loop (index + 1) remaining page_rev rest
     | _ when remaining = 0 -> List.rev page_rev
-    | stimulus :: rest ->
+    | (selection : Keeper_event_queue_state.pending_selection) :: rest ->
+      let stimulus = selection.source in
       let item =
         `Assoc
           [ "queue_index", `Int index
+          ; ( "source_incarnation"
+            , `String (Int64.to_string selection.admitted_revision) )
+          ; ( "source_snapshot_sha256"
+            , `String
+                (Keeper_event_queue.stimulus_snapshot_sha256 stimulus) )
           ; "post_id", `String stimulus.Keeper_event_queue.post_id
           ; ( "urgency"
             , `String
@@ -88,7 +94,6 @@ let pending_page ~after ~limit pending =
 
 module For_testing = struct
   let pending_page = pending_page
-  let pending_source_at = Execute.pending_source_at
 end
 
 let handle_get state request reqd ~keeper_name =
@@ -119,10 +124,7 @@ let handle_get state request reqd ~keeper_name =
        | Error detail -> error ~status:`Service_unavailable detail
        | Ok queue_state ->
          let revision = Keeper_event_queue_state.revision queue_state in
-         let pending =
-           Keeper_event_queue_state.pending queue_state
-           |> Keeper_event_queue.to_list
-         in
+         let pending = Keeper_event_queue_state.pending_selections queue_state in
          let total_pending = List.length pending in
          let page = pending_page ~after ~limit pending in
          let consumed = after + List.length page in
@@ -145,20 +147,23 @@ let handle_get state request reqd ~keeper_name =
 
 type request = Execute.request =
   | Cancel of
-      { expected_revision : int64
-      ; queue_index : int
+      { queue_index : int
+      ; source_incarnation : int64
+      ; source_snapshot_sha256 : string
       ; operator_operation_id : string
       ; reason : string
       }
   | Transfer of
-      { expected_revision : int64
-      ; queue_index : int
+      { queue_index : int
+      ; source_incarnation : int64
+      ; source_snapshot_sha256 : string
       ; operator_operation_id : string
       ; target_keeper : string
       }
   | Reprioritize of
       { expected_revision : int64
       ; queue_index : int
+      ; source_incarnation : int64
       ; urgency : Keeper_event_queue.urgency
       }
 
@@ -188,6 +193,27 @@ let queue_index fields =
   | `Int queue_index when queue_index >= 0 -> Ok queue_index
   | `Int _ -> Error "queue_index must be non-negative"
   | _ -> Error "queue_index must be an integer"
+;;
+
+let source_incarnation fields =
+  let* value = string_field "source_incarnation" fields in
+  match Int64.of_string_opt value with
+  | Some revision when Int64.compare revision 0L >= 0 -> Ok revision
+  | Some _ | None ->
+    Error "source_incarnation must be a non-negative int64 string"
+;;
+
+let source_snapshot_sha256 fields =
+  let* value = string_field "source_snapshot_sha256" fields in
+  if
+    String.length value = 64
+    && String.for_all
+         (function
+           | '0' .. '9' | 'a' .. 'f' -> true
+           | _ -> false)
+         value
+  then Ok value
+  else Error "source_snapshot_sha256 must be 64 lowercase hexadecimal characters"
 ;;
 
 let operator_operation_id fields =
@@ -230,22 +256,26 @@ let parse body =
     then Error ("unsupported schema: " ^ request_schema)
     else
       let* action = string_field "action" fields in
-      let* expected_revision = expected_revision fields in
       let* queue_index = queue_index fields in
+      let* source_incarnation = source_incarnation fields in
       let common =
         [ "action"
-        ; "expected_revision"
         ; "queue_index"
         ; "schema"
+        ; "source_incarnation"
         ]
       in
       match action with
       | "cancel" ->
         let* () =
           require_exact_fields
-            ("operator_operation_id" :: "reason" :: common)
+            ("operator_operation_id"
+             :: "reason"
+             :: "source_snapshot_sha256"
+             :: common)
             fields
         in
+        let* source_snapshot_sha256 = source_snapshot_sha256 fields in
         let* operator_operation_id = operator_operation_id fields in
         let* reason = string_field "reason" fields in
         if reason = "" || not (String.equal reason (String.trim reason))
@@ -253,17 +283,22 @@ let parse body =
         else
           Ok
             (Cancel
-               { expected_revision
-               ; queue_index
+               { queue_index
+               ; source_incarnation
+               ; source_snapshot_sha256
                ; operator_operation_id
                ; reason
                })
       | "transfer" ->
         let* () =
           require_exact_fields
-            ("operator_operation_id" :: "target_keeper" :: common)
+            ("operator_operation_id"
+             :: "source_snapshot_sha256"
+             :: "target_keeper"
+             :: common)
             fields
         in
+        let* source_snapshot_sha256 = source_snapshot_sha256 fields in
         let* operator_operation_id = operator_operation_id fields in
         let* target_keeper = string_field "target_keeper" fields in
         if not (Keeper_config.validate_name target_keeper)
@@ -271,18 +306,28 @@ let parse body =
         else
           Ok
             (Transfer
-               { expected_revision
-               ; queue_index
+               { queue_index
+               ; source_incarnation
+               ; source_snapshot_sha256
                ; operator_operation_id
                ; target_keeper
                })
       | "reprioritize" ->
-        let* () = require_exact_fields ("urgency" :: common) fields in
+        let* () =
+          require_exact_fields
+            ("expected_revision" :: "urgency" :: common)
+            fields
+        in
+        let* expected_revision = expected_revision fields in
         let* urgency_value = string_field "urgency" fields in
         let* urgency = Keeper_event_queue.urgency_of_string urgency_value in
         Ok
           (Reprioritize
-             { expected_revision; queue_index; urgency })
+             { expected_revision
+             ; queue_index
+             ; source_incarnation
+             ; urgency
+             })
       | value -> Error ("unknown event queue operator action: " ^ value)
 ;;
 
@@ -311,14 +356,15 @@ let handle_post state ~actor request reqd ~keeper_name body =
           ])
     | Ok operation ->
       let config = Mcp_server.workspace_config state in
-      let queue_index, action, operator_operation_id =
+      let queue_index, source_incarnation, action, operator_operation_id =
         match operation with
-        | Cancel { queue_index; operator_operation_id; _ } ->
-          queue_index, "cancel", Some operator_operation_id
-        | Transfer { queue_index; operator_operation_id; _ } ->
-          queue_index, "transfer", Some operator_operation_id
-        | Reprioritize { queue_index; _ } ->
-          queue_index, "reprioritize", None
+        | Cancel { queue_index; source_incarnation; operator_operation_id; _ } ->
+          queue_index, source_incarnation, "cancel", Some operator_operation_id
+        | Transfer
+            { queue_index; source_incarnation; operator_operation_id; _ } ->
+          queue_index, source_incarnation, "transfer", Some operator_operation_id
+        | Reprioritize { queue_index; source_incarnation; _ } ->
+          queue_index, source_incarnation, "reprioritize", None
       in
       let result =
         Execute.run
@@ -358,6 +404,8 @@ let handle_post state ~actor request reqd ~keeper_name body =
                 (([ "keeper_name", `String keeper_name
                   ; "action", `String action
                   ; "queue_index", `Int queue_index
+                  ; ( "source_incarnation"
+                    , `String (Int64.to_string source_incarnation) )
                   ]
                   @ (match operator_operation_id with
                      | Some value ->

--- a/lib/server/server_dashboard_http_keeper_event_queue_operator.mli
+++ b/lib/server/server_dashboard_http_keeper_event_queue_operator.mli
@@ -11,13 +11,8 @@ module For_testing : sig
   val pending_page :
     after:int ->
     limit:int ->
-    Keeper_event_queue.stimulus list ->
+    Keeper_event_queue_state.pending_selection list ->
     Yojson.Safe.t list
-
-  val pending_source_at :
-    queue_index:int ->
-    Keeper_event_queue.t ->
-    Keeper_event_queue.stimulus option
 end
 
 val handle_get :

--- a/lib/server/server_dashboard_http_keeper_event_queue_operator_execute.ml
+++ b/lib/server/server_dashboard_http_keeper_event_queue_operator_execute.ml
@@ -2,25 +2,28 @@ let ( let* ) = Result.bind
 
 type request =
   | Cancel of
-      { expected_revision : int64
-      ; queue_index : int
+      { queue_index : int
+      ; source_incarnation : int64
+      ; source_snapshot_sha256 : string
       ; operator_operation_id : string
       ; reason : string
       }
   | Transfer of
-      { expected_revision : int64
-      ; queue_index : int
+      { queue_index : int
+      ; source_incarnation : int64
+      ; source_snapshot_sha256 : string
       ; operator_operation_id : string
       ; target_keeper : string
       }
   | Reprioritize of
       { expected_revision : int64
       ; queue_index : int
+      ; source_incarnation : int64
       ; urgency : Keeper_event_queue.urgency
       }
 
-let pending_source_at ~queue_index pending =
-  List.nth_opt (Keeper_event_queue.to_list pending) queue_index
+let pending_selection_at ~queue_index pending =
+  List.nth_opt pending queue_index
 ;;
 
 let transition_result_json = function
@@ -67,32 +70,53 @@ type prepared_transfer =
   ; applied_at : float
   }
 
-let resolve_pending_source
-      ~queue_state
-      ~expected_revision
-      ~queue_index
+let exact_selection_matches
+      (selection : Keeper_event_queue_state.pending_selection)
+      ~source_incarnation
   =
-  let observed_revision = Keeper_event_queue_state.revision queue_state in
-  if not (Int64.equal expected_revision observed_revision)
-  then
-    Error
-      (Printf.sprintf
-         "event queue revision mismatch (expected=%Ld observed=%Ld)"
-         expected_revision
-         observed_revision)
-  else
-    match
-      pending_source_at
-        ~queue_index
-        (Keeper_event_queue_state.pending queue_state)
-    with
-    | Some source -> Ok source
-    | None -> Error "event queue selection is no longer pending"
+  Int64.equal selection.admitted_revision source_incarnation
+;;
+
+let resolve_pending_selection
+      ~queue_state
+      ~queue_index
+      ~source_incarnation
+  =
+  match
+    pending_selection_at
+      ~queue_index
+      (Keeper_event_queue_state.pending_selections queue_state)
+  with
+  | Some selection when exact_selection_matches selection ~source_incarnation ->
+    Ok selection
+  | Some _ -> Error "event queue selection no longer matches the observed source"
+  | None -> Error "event queue selection is no longer pending"
+;;
+
+let resolve_exact_pending_selection
+      ~queue_state
+      ~queue_index
+      ~source_incarnation
+      ~source_snapshot_sha256
+  =
+  let* selection =
+    resolve_pending_selection
+      ~queue_state
+      ~queue_index
+      ~source_incarnation
+  in
+  if
+    String.equal
+      (Keeper_event_queue.stimulus_snapshot_sha256 selection.source)
+      source_snapshot_sha256
+  then Ok selection
+  else Error "event queue selection no longer matches the observed source snapshot"
 ;;
 
 let prior_cancellation_for_request
       ~queue_state
-      ~expected_revision
+      ~source_incarnation
+      ~source_snapshot_sha256
       ~operator_operation_id
       ~reason
   =
@@ -105,7 +129,11 @@ let prior_cancellation_for_request
   | Some receipt ->
     (match receipt.transition with
      | Keeper_event_queue_state.Cancel_accepted cancellation
-       when Int64.equal cancellation.source_revision expected_revision
+       when Int64.equal cancellation.source_incarnation source_incarnation
+            && String.equal
+                 (Keeper_event_queue.stimulus_snapshot_sha256
+                    cancellation.source)
+                 source_snapshot_sha256
             && String.equal cancellation.reason reason ->
        Ok (Some { cancellation; applied_at = receipt.applied_at })
      | Keeper_event_queue_state.Cancel_accepted _
@@ -119,20 +147,22 @@ let prior_cancellation_for_request
 let fresh_cancellation_for_request
       ~queue_state
       ~owner_nonce
-      ~expected_revision
       ~queue_index
+      ~source_incarnation
+      ~source_snapshot_sha256
       ~operator_operation_id
       ~reason
   =
-  let* source =
-    resolve_pending_source
+  let* selection =
+    resolve_exact_pending_selection
       ~queue_state
-      ~expected_revision
       ~queue_index
+      ~source_incarnation
+      ~source_snapshot_sha256
   in
   let cancellation : Keeper_registry_event_queue.accepted_cancellation =
-    { source
-    ; source_revision = expected_revision
+    { source = selection.source
+    ; source_incarnation = selection.admitted_revision
     ; owner_nonce
     ; operator_operation_id
     ; reason
@@ -144,7 +174,8 @@ let fresh_cancellation_for_request
 let prior_transfer_for_request
       ~queue_state
       ~keeper_name
-      ~expected_revision
+      ~source_incarnation
+      ~source_snapshot_sha256
       ~operator_operation_id
       ~target_keeper
   =
@@ -157,7 +188,10 @@ let prior_transfer_for_request
   | Some receipt ->
     (match receipt.transition with
      | Keeper_event_queue_state.Transfer_accepted transfer
-       when Int64.equal transfer.source_revision expected_revision
+       when Int64.equal transfer.source_incarnation source_incarnation
+            && String.equal
+                 (Keeper_event_queue.stimulus_snapshot_sha256 transfer.source)
+                 source_snapshot_sha256
             && String.equal transfer.from_keeper keeper_name
             && String.equal transfer.to_keeper target_keeper ->
        Ok (Some { transfer; applied_at = receipt.applied_at })
@@ -173,20 +207,22 @@ let fresh_transfer_for_request
       ~queue_state
       ~keeper_name
       ~owner_nonce
-      ~expected_revision
       ~queue_index
+      ~source_incarnation
+      ~source_snapshot_sha256
       ~operator_operation_id
       ~target_keeper
   =
-  let* source =
-    resolve_pending_source
+  let* selection =
+    resolve_exact_pending_selection
       ~queue_state
-      ~expected_revision
       ~queue_index
+      ~source_incarnation
+      ~source_snapshot_sha256
   in
   let transfer : Keeper_registry_event_queue.accepted_transfer =
-    { source
-    ; source_revision = expected_revision
+    { source = selection.source
+    ; source_incarnation = selection.admitted_revision
     ; owner_nonce
     ; operator_operation_id
     ; from_keeper = keeper_name
@@ -260,14 +296,16 @@ let execute_reprioritization
       ~queue_state
       ~expected_revision
       ~queue_index
+      ~source_incarnation
       ~urgency
   =
-  let* source =
-    resolve_pending_source
+  let* selection =
+    resolve_pending_selection
       ~queue_state
-      ~expected_revision
       ~queue_index
+      ~source_incarnation
   in
+  let source = selection.source in
   let* revision =
     Keeper_registry_event_queue.reprioritize_pending_result
       ~base_path
@@ -309,8 +347,9 @@ let replay_committed_request ~base_path ~keeper_name request =
   match request with
   | Reprioritize _ -> Ok None
   | Cancel
-      { expected_revision
-      ; queue_index = _
+      { queue_index = _
+      ; source_incarnation
+      ; source_snapshot_sha256
       ; operator_operation_id
       ; reason
       } ->
@@ -322,7 +361,8 @@ let replay_committed_request ~base_path ~keeper_name request =
     let* prepared =
       prior_cancellation_for_request
         ~queue_state
-        ~expected_revision
+        ~source_incarnation
+        ~source_snapshot_sha256
         ~operator_operation_id
         ~reason
     in
@@ -332,8 +372,9 @@ let replay_committed_request ~base_path ~keeper_name request =
        execute_cancellation ~base_path ~keeper_name prepared
        |> Result.map Option.some)
   | Transfer
-      { expected_revision
-      ; queue_index = _
+      { queue_index = _
+      ; source_incarnation
+      ; source_snapshot_sha256
       ; operator_operation_id
       ; target_keeper
       } ->
@@ -346,7 +387,8 @@ let replay_committed_request ~base_path ~keeper_name request =
       prior_transfer_for_request
         ~queue_state
         ~keeper_name
-        ~expected_revision
+        ~source_incarnation
+        ~source_snapshot_sha256
         ~operator_operation_id
         ~target_keeper
     in
@@ -371,15 +413,17 @@ let run_admitted_request
   in
   match request with
   | Cancel
-      { expected_revision
-      ; queue_index
+      { queue_index
+      ; source_incarnation
+      ; source_snapshot_sha256
       ; operator_operation_id
       ; reason
       } ->
     let* prior =
       prior_cancellation_for_request
         ~queue_state
-        ~expected_revision
+        ~source_incarnation
+        ~source_snapshot_sha256
         ~operator_operation_id
         ~reason
     in
@@ -390,15 +434,17 @@ let run_admitted_request
         fresh_cancellation_for_request
           ~queue_state
           ~owner_nonce
-          ~expected_revision
           ~queue_index
+          ~source_incarnation
+          ~source_snapshot_sha256
           ~operator_operation_id
           ~reason
     in
     execute_cancellation ~base_path ~keeper_name prepared
   | Transfer
-      { expected_revision
-      ; queue_index
+      { queue_index
+      ; source_incarnation
+      ; source_snapshot_sha256
       ; operator_operation_id
       ; target_keeper
       } ->
@@ -409,7 +455,8 @@ let run_admitted_request
         prior_transfer_for_request
           ~queue_state
           ~keeper_name
-          ~expected_revision
+          ~source_incarnation
+          ~source_snapshot_sha256
           ~operator_operation_id
           ~target_keeper
       in
@@ -422,19 +469,26 @@ let run_admitted_request
             ~queue_state
             ~keeper_name
             ~owner_nonce
-            ~expected_revision
             ~queue_index
+            ~source_incarnation
+            ~source_snapshot_sha256
             ~operator_operation_id
             ~target_keeper
       in
       execute_transfer ~base_path ~keeper_name prepared
-  | Reprioritize { expected_revision; queue_index; urgency } ->
+  | Reprioritize
+      { expected_revision
+      ; queue_index
+      ; source_incarnation
+      ; urgency
+      } ->
     execute_reprioritization
       ~base_path
       ~keeper_name
       ~queue_state
       ~expected_revision
       ~queue_index
+      ~source_incarnation
       ~urgency
 ;;
 

--- a/lib/server/server_dashboard_http_keeper_event_queue_operator_execute.mli
+++ b/lib/server/server_dashboard_http_keeper_event_queue_operator_execute.mli
@@ -1,26 +1,28 @@
 type request =
+  (* Cancellation and transfer combine the admission cohort with an exact
+     snapshot SHA, so an unrelated queue revision change does not invalidate
+     them and a same-cohort index shift cannot alias another row. Reprioritize
+     rewrites queue order and therefore retains the queue-wide CAS revision. *)
   | Cancel of
-      { expected_revision : int64
-      ; queue_index : int
+      { queue_index : int
+      ; source_incarnation : int64
+      ; source_snapshot_sha256 : string
       ; operator_operation_id : string
       ; reason : string
       }
   | Transfer of
-      { expected_revision : int64
-      ; queue_index : int
+      { queue_index : int
+      ; source_incarnation : int64
+      ; source_snapshot_sha256 : string
       ; operator_operation_id : string
       ; target_keeper : string
       }
   | Reprioritize of
       { expected_revision : int64
       ; queue_index : int
+      ; source_incarnation : int64
       ; urgency : Keeper_event_queue.urgency
       }
-
-val pending_source_at :
-  queue_index:int ->
-  Keeper_event_queue.t ->
-  Keeper_event_queue.stimulus option
 
 val run :
   config:Workspace.config ->

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -5,6 +5,7 @@ let () = Mirage_crypto_rng_unix.use_default ()
 module Lib = Masc
 module Auth = Masc.Auth
 module Keeper_chat_queue = Masc.Keeper_chat_queue
+module Keeper_meta_store = Masc.Keeper_meta_store
 module Workspace = Masc.Workspace
 
 open Alcotest
@@ -311,12 +312,15 @@ let test_keeper_chat_recovery_route_is_exact () =
           }
     }
   in
+  let source_selection : Keeper_event_queue_state.pending_selection =
+    { source; admitted_revision = 7L }
+  in
   let pending_json =
     match
       Server_dashboard_http_keeper_event_queue_operator.For_testing.pending_page
         ~after:0
         ~limit:100
-        [ source ]
+        [ source_selection ]
     with
     | [ json ] -> json
     | _ -> fail "event pending projection must return one metadata row"
@@ -328,32 +332,16 @@ let test_keeper_chat_recovery_route_is_exact () =
   check string "event pending projection retains typed payload kind"
     "board_signal"
     (pending_json |> member "payload_kind" |> to_string);
+  check string "event pending projection exposes exact source incarnation"
+    "7"
+    (pending_json |> member "source_incarnation" |> to_string);
+  check string "event pending projection exposes an opaque exact snapshot coordinate"
+    (Keeper_event_queue.stimulus_snapshot_sha256 source)
+    (pending_json |> member "source_snapshot_sha256" |> to_string);
   check bool "event pending projection omits raw payload content" false
     (contains_substring (Yojson.Safe.to_string pending_json) sensitive_content);
   check bool "event pending projection has no raw source object" true
     (pending_json |> member "source" = `Null);
-  let same_post_id_source : Keeper_event_queue.stimulus =
-    { source with urgency = Low; payload = Bootstrap }
-  in
-  let duplicate_post_id_queue =
-    Keeper_event_queue.empty
-    |> fun queue -> Keeper_event_queue.enqueue queue source
-    |> fun queue -> Keeper_event_queue.enqueue queue same_post_id_source
-  in
-  (match
-     Server_dashboard_http_keeper_event_queue_operator.For_testing.pending_source_at
-       ~queue_index:1
-       duplicate_post_id_queue
-   with
-   | Some selected ->
-     check bool
-       "event selection uses revision-fenced queue position, not ambiguous post id"
-       true
-       (Keeper_event_queue.stimulus_identity_equal
-          same_post_id_source
-          selected)
-   | None ->
-     fail "event selection must address duplicate post ids independently");
   let quarantine_path =
     "/api/v1/keepers/idealist/board-attention/quarantines/ba-root-123/recovery"
   in
@@ -396,6 +384,453 @@ let with_test_env f =
           in
           Server_request_authority.with_current request_authority (fun () ->
             f ~env ~sw ~config)))
+
+let test_event_operator_uses_v14_source_incarnation_and_receipt_replay () =
+  with_test_env @@ fun ~env:_ ~sw:_ ~config ->
+  let require_ok label = function
+    | Ok value -> value
+    | Error detail -> failf "%s: %s" label detail
+  in
+  let require_some label = function
+    | Some value -> value
+    | None -> fail (label ^ ": missing value")
+  in
+  let make_meta ~name ~trace_id ~nonce =
+    match
+      Masc_test_deps.meta_of_json_fixture
+        (`Assoc
+          [ "name", `String name
+          ; "agent_name", `String ("keeper-" ^ name ^ "-agent")
+          ; "trace_id", `String trace_id
+          ])
+    with
+    | Error detail -> failf "meta fixture %s: %s" name detail
+    | Ok meta ->
+      { meta with
+        runtime = { meta.runtime with nonce }
+      }
+  in
+  let base_path = config.Workspace.base_path in
+  let cancel_keeper = "event-operator-cancel-source" in
+  let transfer_keeper = "event-operator-transfer-source" in
+  let target_keeper = "event-operator-target" in
+  let cancel_meta =
+    make_meta
+      ~name:cancel_keeper
+      ~trace_id:"event-operator-cancel-source-trace"
+      ~nonce:41
+  in
+  let transfer_meta =
+    make_meta
+      ~name:transfer_keeper
+      ~trace_id:"event-operator-transfer-source-trace"
+      ~nonce:42
+  in
+  let target_meta =
+    make_meta
+      ~name:target_keeper
+      ~trace_id:"event-operator-target-trace"
+      ~nonce:43
+  in
+  let stimulus post_id arrived_at : Keeper_event_queue.stimulus =
+    { post_id
+    ; urgency = Normal
+    ; arrived_at
+    ; payload = Bootstrap
+    }
+  in
+  let predecessor_source = stimulus "event-operator-predecessor" 0.0 in
+  let cancelled_source = stimulus "event-operator-cancel" 1.0 in
+  let alias_source = stimulus "event-operator-alias" 1.5 in
+  let transferred_source = stimulus "event-operator-transfer" 2.0 in
+  let unrelated_source = stimulus "event-operator-unrelated" 3.0 in
+  let load_state keeper_name =
+    Keeper_event_queue_persistence.load_state_result
+      ~base_path
+      ~keeper_name
+    |> require_ok ("load event queue state for " ^ keeper_name)
+  in
+  let enqueue keeper_name (source : Keeper_event_queue.stimulus) =
+    Keeper_event_queue_persistence.update_result
+      ~base_path
+      ~keeper_name
+      (fun pending -> Keeper_event_queue.enqueue pending source)
+    |> require_ok ("enqueue " ^ source.post_id)
+  in
+  let enqueue_batch keeper_name sources =
+    Keeper_event_queue_persistence.update_result
+      ~base_path
+      ~keeper_name
+      (fun pending ->
+        List.fold_left Keeper_event_queue.enqueue pending sources)
+    |> require_ok ("enqueue batch for " ^ keeper_name)
+  in
+  let dequeue_head keeper_name =
+    Keeper_event_queue_persistence.update_result
+      ~base_path
+      ~keeper_name
+      (fun pending ->
+        match Keeper_event_queue.dequeue pending with
+        | Some (_, retained) -> retained
+        | None -> fail ("dequeue head for " ^ keeper_name ^ ": empty queue"))
+    |> require_ok ("dequeue head for " ^ keeper_name)
+  in
+  let result_status json =
+    match Yojson.Safe.Util.member "status" json with
+    | `String status -> status
+    | _ -> fail "event operator result omitted status"
+  in
+  let state = Lib.Mcp_server.For_testing.create_state ~base_path in
+  let post_event_operator ~keeper_name body =
+    let output = Buffer.create 512 in
+    let connection =
+      Httpun.Server_connection.create (fun reqd ->
+        Server_dashboard_http_keeper_event_queue_operator.handle_post
+          state
+          ~actor:"event-operator-test"
+          (Httpun.Reqd.request reqd)
+          reqd
+          ~keeper_name
+          body)
+    in
+    let request =
+      Printf.sprintf
+        "POST /api/v1/keepers/%s/events/operator HTTP/1.1\r\nHost: x\r\nContent-Length: %d\r\n\r\n%s"
+        keeper_name
+        (String.length body)
+        body
+    in
+    let input =
+      Bigstringaf.of_string ~off:0 ~len:(String.length request) request
+    in
+    ignore
+      (Httpun.Server_connection.read_eof
+         connection
+         input
+         ~off:0
+         ~len:(Bigstringaf.length input));
+    let rec drain () =
+      match Httpun.Server_connection.next_write_operation connection with
+      | `Write iovecs ->
+        let bytes =
+          List.fold_left
+            (fun total (iov : Bigstringaf.t Httpun.IOVec.t) ->
+              Buffer.add_string
+                output
+                (Bigstringaf.substring iov.buffer ~off:iov.off ~len:iov.len);
+              total + iov.len)
+            0
+            iovecs
+        in
+        Httpun.Server_connection.report_write_result connection (`Ok bytes);
+        drain ()
+      | `Yield | `Close _ -> ()
+    in
+    drain ();
+    let raw = Buffer.contents output in
+    let response_body =
+      match List.rev (String.split_on_char '\n' raw) with
+      | body :: _ -> String.trim body
+      | [] -> fail "event operator HTTP response has no body"
+    in
+    raw, Yojson.Safe.from_string response_body
+  in
+  let request_body action fields =
+    `Assoc
+      ([ "schema", `String "keeper_event_queue.operator.request.v1"
+       ; "action", `String action
+       ]
+       @ fields)
+    |> Yojson.Safe.to_string
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_registry.For_testing.unregister
+        ~base_path
+        cancel_keeper;
+      Masc.Keeper_registry.For_testing.unregister
+        ~base_path
+        transfer_keeper;
+      Masc.Keeper_registry.For_testing.unregister
+        ~base_path
+        target_keeper)
+    (fun () ->
+       Keeper_meta_store.write_meta config cancel_meta
+       |> require_ok "persist cancellation source keeper metadata";
+       Keeper_meta_store.write_meta config transfer_meta
+       |> require_ok "persist transfer source keeper metadata";
+       Keeper_meta_store.write_meta config target_meta
+       |> require_ok "persist target keeper metadata";
+       ignore
+         (Masc.Keeper_registry.For_testing.register
+            ~base_path
+            cancel_keeper
+            cancel_meta);
+       ignore
+         (Masc.Keeper_registry.For_testing.register
+            ~base_path
+            transfer_keeper
+            transfer_meta);
+       enqueue_batch
+         cancel_keeper
+         [ predecessor_source; cancelled_source; alias_source ];
+       let before_cancel = load_state cancel_keeper in
+       let cancel_selection =
+         Keeper_event_queue_state.pending_selections before_cancel
+         |> fun selections -> List.nth_opt selections 1
+         |> require_some "select cancellation source"
+       in
+       let cancel_source_snapshot_sha256 =
+         Keeper_event_queue.stimulus_snapshot_sha256 cancel_selection.source
+       in
+       let incomplete_cancel_request =
+         request_body
+           "cancel"
+           [ "queue_index", `Int 1
+           ; ( "source_incarnation"
+             , `String (Int64.to_string cancel_selection.admitted_revision) )
+           ; ( "operator_operation_id"
+             , `String "event-operator-incomplete-operation" )
+           ; "reason", `String "missing exact source snapshot"
+           ]
+       in
+       let incomplete_raw, _ =
+         post_event_operator
+           ~keeper_name:cancel_keeper
+           incomplete_cancel_request
+       in
+       check bool "cancel hard-cut rejects an incomplete source coordinate" true
+         (String.starts_with ~prefix:"HTTP/1.1 400" incomplete_raw);
+       let stale_cancel_request =
+         request_body
+           "cancel"
+           [ "queue_index", `Int 1
+           ; ( "source_incarnation"
+             , `String (Int64.to_string cancel_selection.admitted_revision) )
+           ; ( "source_snapshot_sha256"
+             , `String cancel_source_snapshot_sha256 )
+           ; ( "operator_operation_id"
+             , `String "event-operator-cancel-operation" )
+           ; "reason", `String "operator cancelled exact source"
+           ]
+       in
+       dequeue_head cancel_keeper;
+       let shifted_alias =
+         Keeper_event_queue_state.pending_selections (load_state cancel_keeper)
+         |> fun selections -> List.nth_opt selections 1
+         |> require_some "select shifted same-incarnation alias"
+       in
+       check int64 "batch entries share the admitted revision"
+         cancel_selection.admitted_revision
+         shifted_alias.admitted_revision;
+       let stale_raw, stale_response =
+         post_event_operator
+           ~keeper_name:cancel_keeper
+           stale_cancel_request
+       in
+       check bool "shifted same-incarnation coordinate is rejected" true
+         (String.starts_with ~prefix:"HTTP/1.1 409" stale_raw);
+       check bool "shifted coordinate fails on the exact source snapshot" true
+         (match Yojson.Safe.Util.member "error" stale_response with
+          | `String detail -> contains_substring detail "source snapshot"
+          | _ -> false);
+       let refreshed_cancel_selection =
+         Keeper_event_queue_state.pending_selections (load_state cancel_keeper)
+         |> fun selections -> List.nth_opt selections 0
+         |> require_some "refresh cancellation source coordinate"
+       in
+       check bool "refreshed coordinate retains the selected source" true
+         (Keeper_event_queue.stimulus_identity_equal
+            cancel_selection.source
+            refreshed_cancel_selection.source);
+       let cancel_request =
+         request_body
+           "cancel"
+           [ "queue_index", `Int 0
+           ; ( "source_incarnation"
+             , `String
+                 (Int64.to_string
+                    refreshed_cancel_selection.admitted_revision) )
+           ; ( "source_snapshot_sha256"
+             , `String cancel_source_snapshot_sha256 )
+           ; ( "operator_operation_id"
+             , `String "event-operator-cancel-operation" )
+           ; "reason", `String "operator cancelled exact source"
+           ]
+       in
+       enqueue cancel_keeper unrelated_source;
+       let cancel_raw, cancel_response =
+         post_event_operator ~keeper_name:cancel_keeper cancel_request
+       in
+       check bool "cancellation HTTP request succeeds" true
+         (String.starts_with ~prefix:"HTTP/1.1 200" cancel_raw);
+       check bool "cancellation response is successful" true
+         (Yojson.Safe.Util.member "ok" cancel_response = `Bool true);
+       check bool "cancellation removes the exact selected source" false
+         (Keeper_event_queue_state.pending (load_state cancel_keeper)
+          |> Keeper_event_queue.to_list
+          |> List.exists (fun source ->
+            Keeper_event_queue.stimulus_identity_equal
+              cancel_selection.source
+              source));
+       let cancel_result =
+         Yojson.Safe.Util.member "result" cancel_response
+       in
+       check string
+         "cancellation applies once"
+         "applied"
+         (result_status cancel_result);
+       check bool
+         "unrelated enqueue remains pending"
+         true
+         (Keeper_event_queue_state.pending (load_state cancel_keeper)
+          |> Keeper_event_queue.to_list
+          |> List.exists (fun source ->
+            Keeper_event_queue.stimulus_identity_equal
+              unrelated_source
+              source));
+       let after_cancel = load_state cancel_keeper in
+       (match
+          Keeper_event_queue_state.prior_disposition_by_operation_id
+            "event-operator-cancel-operation"
+            after_cancel
+        with
+        | Some
+            { transition =
+                Keeper_event_queue_state.Cancel_accepted cancellation
+            ; _
+            } ->
+          check int64
+            "cancellation persists the selected source incarnation"
+            cancel_selection.admitted_revision
+            cancellation.source_incarnation
+        | Some _ -> fail "cancellation operation stored the wrong transition"
+        | None -> fail "cancellation operation receipt was not durable");
+       let cancel_replay_raw, cancel_replay_response =
+         post_event_operator ~keeper_name:cancel_keeper cancel_request
+       in
+       check bool
+         "cancellation replay HTTP request succeeds"
+         true
+         (String.starts_with ~prefix:"HTTP/1.1 200" cancel_replay_raw);
+       check string
+         "cancellation replay uses the durable receipt"
+         "already_applied"
+         (cancel_replay_response
+          |> Yojson.Safe.Util.member "result"
+          |> result_status);
+       let conflicting_cancel_request =
+         request_body
+           "cancel"
+           [ "queue_index", `Int 0
+           ; ( "source_incarnation"
+             , `String (Int64.to_string cancel_selection.admitted_revision) )
+           ; ( "source_snapshot_sha256"
+             , `String
+                 (Keeper_event_queue.stimulus_snapshot_sha256 alias_source) )
+           ; ( "operator_operation_id"
+             , `String "event-operator-cancel-operation" )
+           ; "reason", `String "operator cancelled exact source"
+           ]
+       in
+       let conflict_raw, conflict_response =
+         post_event_operator
+           ~keeper_name:cancel_keeper
+           conflicting_cancel_request
+       in
+       check bool "conflicting replay returns HTTP conflict" true
+         (String.starts_with ~prefix:"HTTP/1.1 409" conflict_raw);
+       let conflict_detail =
+         match Yojson.Safe.Util.member "error" conflict_response with
+         | `String detail -> detail
+         | _ -> fail "conflicting replay response omitted error"
+       in
+       check bool
+         "operation replay rejects another source snapshot"
+         true
+         (contains_substring conflict_detail "operation ID conflicts");
+       enqueue transfer_keeper transferred_source;
+       let before_transfer = load_state transfer_keeper in
+       let transfer_selection =
+         Keeper_event_queue_state.pending_selections before_transfer
+         |> fun selections -> List.nth_opt selections 0
+         |> require_some "select transfer source"
+       in
+       let transfer_request =
+         request_body
+           "transfer"
+           [ "queue_index", `Int 0
+           ; ( "source_incarnation"
+             , `String (Int64.to_string transfer_selection.admitted_revision) )
+           ; ( "source_snapshot_sha256"
+             , `String
+                 (Keeper_event_queue.stimulus_snapshot_sha256
+                    transfer_selection.source) )
+           ; ( "operator_operation_id"
+             , `String "event-operator-transfer-operation" )
+           ; "target_keeper", `String target_keeper
+           ]
+       in
+       let transfer_raw, transfer_response =
+         post_event_operator ~keeper_name:transfer_keeper transfer_request
+       in
+       if not (String.starts_with ~prefix:"HTTP/1.1 200" transfer_raw)
+       then failf "transfer HTTP request failed: %s" transfer_raw;
+       check bool
+         "transfer response is successful"
+         true
+         (Yojson.Safe.Util.member "ok" transfer_response = `Bool true);
+       let transfer_result =
+         Yojson.Safe.Util.member "result" transfer_response
+       in
+       check string "transfer applies once" "applied"
+         (result_status transfer_result);
+       let after_transfer = load_state transfer_keeper in
+       (match
+          Keeper_event_queue_state.prior_disposition_by_operation_id
+            "event-operator-transfer-operation"
+            after_transfer
+        with
+        | Some
+            { transition =
+                Keeper_event_queue_state.Transfer_accepted transfer
+            ; _
+            } ->
+          check int64
+            "transfer persists the selected source incarnation"
+            transfer_selection.admitted_revision
+            transfer.source_incarnation
+        | Some _ -> fail "transfer operation stored the wrong transition"
+        | None -> fail "transfer operation receipt was not durable");
+       let transfer_replay_raw, transfer_replay_response =
+         post_event_operator ~keeper_name:transfer_keeper transfer_request
+       in
+       check bool
+         "transfer replay HTTP request succeeds"
+         true
+         (String.starts_with ~prefix:"HTTP/1.1 200" transfer_replay_raw);
+       check string
+         "transfer replay uses the durable receipt"
+         "already_applied"
+         (transfer_replay_response
+          |> Yojson.Safe.Util.member "result"
+          |> result_status);
+       let target_pending =
+         load_state target_keeper
+         |> Keeper_event_queue_state.pending
+         |> Keeper_event_queue.to_list
+       in
+       check int "transfer replay projects one target source" 1
+         (List.length target_pending);
+       check bool
+         "target projection contains the exact transferred source"
+         true
+         (match target_pending with
+          | [ source ] ->
+            Keeper_event_queue.stimulus_identity_equal
+              transferred_source
+              source
+          | [] | _ :: _ :: _ -> false))
 
 let test_run_dashboard_compute_without_pool_stays_in_current_domain () =
   with_test_env @@ fun ~env ~sw ~config ->
@@ -2723,6 +3158,8 @@ let () =
             test_keeper_chat_receipt_route_and_json;
           test_case "keeper chat recovery route is exact" `Quick
             test_keeper_chat_recovery_route_is_exact;
+          test_case "event operator keeps v14 source fences across replay" `Quick
+            test_event_operator_uses_v14_source_incarnation_and_receipt_replay;
           test_case "observation metadata does not override terminal contract" `Quick
             test_composite_blocked_uses_terminal_contract_not_observational_metadata;
         ] );


### PR DESCRIPTION
## 문제

#26454의 event queue v14 hard-cut 뒤 #26455가 삭제된 `source_revision`을 참조해 current main의 타입 경계를 깨뜨렸습니다.

단순히 `queue_index + source_incarnation`으로 바꾸는 것도 안전하지 않습니다. `admitted_revision`은 한 durable transform에서 추가된 여러 row가 공유하는 admission cohort이므로, 선행 row 제거 뒤 같은 cohort의 다른 row를 stale index로 오인할 수 있습니다. 반대로 cancel/transfer에 queue-wide `expected_revision`을 추가하면 unrelated append까지 exact-source Feature를 불필요하게 거부합니다.

이 PR은 닫힌 #26458의 Gate/Facade/fixture stack/revert history를 가져오지 않고 `main`에서 clean single commit으로 다시 구성했습니다.

## 변경

- 기존 canonical `stimulus_to_yojson`의 exact snapshot에서 `source_snapshot_sha256`을 파생합니다.
- Admin pending inventory는 `queue_index + source_incarnation + source_snapshot_sha256`만 노출하며 raw payload는 노출하지 않습니다.
- fresh cancel/transfer는 admission cohort와 exact snapshot SHA를 모두 확인합니다.
  - same-cohort index shift는 거부합니다.
  - unrelated append는 exact row 좌표를 바꾸지 않으므로 허용합니다.
- committed replay는 durable operation receipt의 operation ID + source incarnation + source snapshot SHA + action parameters가 모두 같은 경우만 허용합니다.
- reprioritize만 queue ordering을 다시 쓰므로 queue-wide `expected_revision` CAS를 유지합니다.
- Dashboard decoder, action DTO, recovery replay까지 동일한 typed coordinate를 전달합니다.
- private Execute는 private로 유지하며 Facade-from-Facade나 test-only Execute 재수출을 추가하지 않습니다.
- migration, legacy fallback, 새 durable field는 추가하지 않습니다. 기존 durable transition의 full source가 replay authority입니다.

## Blast radius

- `Keeper_event_queue`: 기존 canonical snapshot SHA helper 1개와 기존 중복 SHA 계산 통합
- Admin event pending GET/POST wire
- private Execute fresh/replay comparison
- Dashboard queue control API/UI/recovery
- 관련 OCaml/TypeScript tests

Durable event queue schema, Keeper runtime producer, unrelated Librarian/compaction fixture는 변경하지 않습니다.

## 검증

대상 tree: closed branch의 검증 SHA `ec87718805`와 byte-identical

- `scripts/dune-local.sh build lib/keeper_runtime/masc_keeper_runtime.cmxa` 통과
- `scripts/dune-local.sh build lib/server/masc_server.cmxa test/test_dashboard_http_core.exe` 통과
- exact event operator E2E 통과
  - missing SHA hard-cut 400
  - same-incarnation index shift 409
  - refreshed exact coordinate + unrelated append cancel 성공
  - durable replay 성공 / 다른 snapshot operation ID 충돌
  - transfer target projection 1회
- Dashboard `npx tsc --noEmit --pretty` 통과
- Dashboard focused Vitest 2 files, 92/92 통과
- exact-head GitHub CI 대기

별도 발견:

- schedule ACK/occurrence ordering: #26461
- current-main Librarian TurnRef fixture compile break: #26463 (이 PR에 stack하지 않음)

Closes #26457

[근거] producer `with_pending` -> Admin inventory -> strict POST parser -> private Execute -> durable receipt -> Dashboard caller 역추적 및 위 focused 명령 · 확인 2026-07-30 18:49 KST · 신뢰도 High
