### PR TITLE
fix(keeper): isolate Auto Judge owner drain failures

### DIFF
--- a/dashboard/src/api/dashboard-gate.ts
+++ b/dashboard/src/api/dashboard-gate.ts
@@ -339,11 +339,19 @@ export interface SetGateModeResponse {
   previous_mode: GateMode | null
   actor: string
   changed_at: string
-  recovery_status: 'completed' | 'failed' | 'not_requested'
+  recovery_status: 'completed' | 'partial' | 'failed' | 'not_requested'
   recovery_error: string | null
   started: number
   queued: number
+  recovery_failure_count: number
+  recovery_failures: GateModeRecoveryFailure[]
   replaced_read_error?: string
+}
+
+export interface GateModeRecoveryFailure {
+  keeper_name: string
+  approval_id: string | null
+  operator_detail: string
 }
 
 const SET_GATE_MODE_RESPONSE_FIELDS = new Set([
@@ -356,6 +364,8 @@ const SET_GATE_MODE_RESPONSE_FIELDS = new Set([
   'recovery_error',
   'started',
   'queued',
+  'recovery_failure_count',
+  'recovery_failures',
   'replaced_read_error',
 ])
 
@@ -400,7 +410,12 @@ function decodeSetGateModeResponse(raw: unknown, requestedMode: GateMode): SetGa
   if (!changedAt) return gateModeProtocolDrift('changed_at must be a non-empty string')
 
   const status = raw.recovery_status
-  if (status !== 'completed' && status !== 'failed' && status !== 'not_requested') {
+  if (
+    status !== 'completed'
+    && status !== 'partial'
+    && status !== 'failed'
+    && status !== 'not_requested'
+  ) {
     return gateModeProtocolDrift('recovery_status is invalid')
   }
   const recoveryError = raw.recovery_error === null
@@ -410,19 +425,86 @@ function decodeSetGateModeResponse(raw: unknown, requestedMode: GateMode): SetGa
       : gateModeProtocolDrift('recovery_error must be null or a non-empty string')
   const started = nonNegativeSafeInteger(raw.started, 'started')
   const queued = nonNegativeSafeInteger(raw.queued, 'queued')
+  const recoveryFailureCount =
+    nonNegativeSafeInteger(raw.recovery_failure_count, 'recovery_failure_count')
+  if (!Array.isArray(raw.recovery_failures)) {
+    return gateModeProtocolDrift('recovery_failures must be an array')
+  }
+  const recoveryFailures = raw.recovery_failures.map((failure, index) => {
+    if (!isRecord(failure)) {
+      return gateModeProtocolDrift(`recovery_failures[${index}] must be an object`)
+    }
+    const fields = Object.keys(failure)
+    if (
+      fields.length !== 3
+      || !fields.includes('keeper_name')
+      || !fields.includes('approval_id')
+      || !fields.includes('operator_detail')
+    ) {
+      return gateModeProtocolDrift(
+        `recovery_failures[${index}] fields must be exact`,
+      )
+    }
+    const keeperName =
+      typeof failure.keeper_name === 'string' ? failure.keeper_name.trim() : ''
+    const approvalId =
+      failure.approval_id === null
+        ? null
+        : typeof failure.approval_id === 'string' && failure.approval_id.trim() !== ''
+          ? failure.approval_id
+          : gateModeProtocolDrift(
+              `recovery_failures[${index}].approval_id must be null or non-empty`,
+            )
+    const operatorDetail =
+      typeof failure.operator_detail === 'string'
+        ? failure.operator_detail.trim()
+        : ''
+    if (!keeperName || !operatorDetail) {
+      return gateModeProtocolDrift(
+        `recovery_failures[${index}] strings must be non-empty`,
+      )
+    }
+    return {
+      keeper_name: keeperName,
+      approval_id: approvalId,
+      operator_detail: operatorDetail,
+    }
+  })
+  if (recoveryFailures.length !== recoveryFailureCount) {
+    return gateModeProtocolDrift(
+      'recovery_failure_count must equal recovery_failures length',
+    )
+  }
 
-  if (status === 'completed' && (mode !== 'auto_judge' || recoveryError !== null)) {
-    return gateModeProtocolDrift('completed recovery requires auto_judge mode and no error')
+  if (
+    status === 'completed'
+    && (mode !== 'auto_judge' || recoveryError !== null || recoveryFailureCount !== 0)
+  ) {
+    return gateModeProtocolDrift(
+      'completed recovery requires auto_judge mode and no owner failures',
+    )
+  }
+  if (
+    status === 'partial'
+    && (mode !== 'auto_judge' || recoveryError !== null || recoveryFailureCount === 0)
+  ) {
+    return gateModeProtocolDrift(
+      'partial recovery requires auto_judge mode and owner failures',
+    )
   }
   if (status === 'failed'
       && (mode !== 'auto_judge' || recoveryError === null
-        || started !== 0 || queued !== 0)) {
-    return gateModeProtocolDrift('failed recovery requires auto_judge mode, an error, and zero counts')
+        || started !== 0 || queued !== 0 || recoveryFailureCount !== 0)) {
+    return gateModeProtocolDrift(
+      'failed recovery requires auto_judge mode, an error, and zero outcomes',
+    )
   }
   if (status === 'not_requested'
       && (mode === 'auto_judge' || recoveryError !== null
-        || started !== 0 || queued !== 0)) {
-    return gateModeProtocolDrift('not_requested recovery requires a non-auto mode and zero outcome')
+        || started !== 0 || queued !== 0 || recoveryFailureCount !== 0)) {
+    return gateModeProtocolDrift(
+      'not_requested recovery requires a non-auto mode and zero outcomes',
+    )
   }
 
   const replacedReadError = raw.replaced_read_error
@@ -441,6 +523,8 @@ function decodeSetGateModeResponse(raw: unknown, requestedMode: GateMode): SetGa
     recovery_error: recoveryError,
     started,
     queued,
+    recovery_failure_count: recoveryFailureCount,
+    recovery_failures: recoveryFailures,
     ...(typeof replacedReadError === 'string'
       ? { replaced_read_error: replacedReadError }
       : {}),

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -2100,6 +2100,8 @@ describe('setGateMode', () => {
     recovery_error: null,
     started: 1,
     queued: 1,
+    recovery_failure_count: 0,
+    recovery_failures: [],
   } as const
 
   it('posts the exact non-hierarchical Gate mode contract', async () => {
@@ -2126,6 +2128,20 @@ describe('setGateMode', () => {
   })
 
   it.each([
+    {
+      label: 'partial owner recovery',
+      requestedMode: 'auto_judge' as const,
+      response: {
+        ...completedResponse,
+        recovery_status: 'partial',
+        recovery_failure_count: 1,
+        recovery_failures: [{
+          keeper_name: 'keeper-a',
+          approval_id: 'approval-a',
+          operator_detail: 'worker unavailable',
+        }],
+      },
+    },
     {
       label: 'failed recovery',
       requestedMode: 'auto_judge' as const,
@@ -2172,6 +2188,26 @@ describe('setGateMode', () => {
       recovery_status: 'failed',
       started: 0,
       queued: 0,
+    }],
+    ['partial recovery without owner failure', {
+      ...completedResponse,
+      recovery_status: 'partial',
+    }],
+    ['owner failure count mismatch', {
+      ...completedResponse,
+      recovery_status: 'partial',
+      recovery_failure_count: 1,
+    }],
+    ['owner failure with unknown field', {
+      ...completedResponse,
+      recovery_status: 'partial',
+      recovery_failure_count: 1,
+      recovery_failures: [{
+        keeper_name: 'keeper-a',
+        approval_id: null,
+        operator_detail: 'queue unavailable',
+        extra: true,
+      }],
     }],
     ['negative count', { ...completedResponse, started: -1 }],
     ['non-zero not-requested outcome', {

--- a/dashboard/src/components/approvals/approvals-surface.test.ts
+++ b/dashboard/src/components/approvals/approvals-surface.test.ts
@@ -109,6 +109,8 @@ async function loadSurface(
       recovery_error: null,
       started: 0,
       queued: 0,
+      recovery_failure_count: 0,
+      recovery_failures: [],
     })
   const response = hitl
     ? responseWithQueue(

--- a/dashboard/src/components/gate-actions.test.ts
+++ b/dashboard/src/components/gate-actions.test.ts
@@ -34,6 +34,8 @@ const baseResponse = {
   recovery_error: null,
   started: 0,
   queued: 0,
+  recovery_failure_count: 0,
+  recovery_failures: [],
 } as const
 
 beforeEach(() => {
@@ -97,6 +99,30 @@ describe('setKeeperGateMode recovery result', () => {
       'Gate 모드를 Auto Judge(으)로 저장했습니다 · Auto Judge backlog recovery 요청 처리 완료'
       + ' (started 1, queued 1)',
       'success',
+    )
+    expect(mocks.refreshGate).toHaveBeenCalledWith({ force: true })
+  })
+
+  it('reports partial recovery without hiding a healthy owner start', async () => {
+    mocks.setGateMode.mockResolvedValue({
+      ...baseResponse,
+      recovery_status: 'partial',
+      started: 1,
+      queued: 2,
+      recovery_failure_count: 1,
+      recovery_failures: [{
+        keeper_name: 'keeper-a',
+        approval_id: null,
+        operator_detail: 'queue unavailable',
+      }],
+    })
+
+    await setKeeperGateMode('auto_judge')
+
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      'Gate 모드를 Auto Judge(으)로 저장했습니다 · Auto Judge backlog recovery 부분 완료'
+      + ' (started 1, queued 2, failed 1) · keeper-a: queue unavailable',
+      'warning',
     )
     expect(mocks.refreshGate).toHaveBeenCalledWith({ force: true })
   })

--- a/dashboard/src/components/gate-actions.ts
+++ b/dashboard/src/components/gate-actions.ts
@@ -90,6 +90,21 @@ function showGateModeSaved(result: SetGateModeResponse): void {
         'success',
       )
       return
+    case 'partial': {
+      const firstFailure = result.recovery_failures[0]
+      const firstFailureDetail = firstFailure
+        ? ` · ${firstFailure.keeper_name}: ${firstFailure.operator_detail}`
+        : ''
+      showToast(
+        `${saved} · Auto Judge backlog recovery 부분 완료`
+        + ` (started ${result.started.toLocaleString()},`
+        + ` queued ${result.queued.toLocaleString()},`
+        + ` failed ${result.recovery_failure_count.toLocaleString()})`
+        + firstFailureDetail,
+        'warning',
+      )
+      return
+    }
     case 'failed':
       showToast(
         `${saved} · Auto Judge backlog recovery 실패:`

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -587,6 +587,51 @@ type auto_judge_drain_outcome =
   ; blocker : auto_judge_drain_blocker option
   }
 
+type auto_judge_owner_failure =
+  { keeper_name : string
+  ; approval_id : string option
+  ; operator_detail : string
+  }
+
+type auto_judge_workspace_drain_report =
+  { started_ids : string list
+  ; failures : auto_judge_owner_failure list
+  }
+
+let drain_auto_judge_owners_with ~drain_owner owners =
+  let started_ids, failures =
+    List.fold_left
+      (fun (started_ids, failures) (base_path, keeper_name) ->
+         match drain_owner ~base_path ~keeper_name with
+         | Error operator_detail ->
+           ( started_ids
+           , { keeper_name; approval_id = None; operator_detail } :: failures )
+         | Ok (started_id, owner_failures) ->
+           let started_ids =
+             match started_id with
+             | Some approval_id -> approval_id :: started_ids
+             | None -> started_ids
+           in
+           let failures =
+             List.fold_left
+               (fun failures (approval_id, operator_detail) ->
+                  { keeper_name
+                  ; approval_id = Some approval_id
+                  ; operator_detail
+                  }
+                  :: failures)
+               failures
+               owner_failures
+           in
+           started_ids, failures)
+      ([], [])
+      owners
+  in
+  { started_ids = List.rev started_ids
+  ; failures = List.rev failures
+  }
+;;
+
 type hitl_worker_spawner =
   sw:Eio.Switch.t ->
   entry:Keeper_approval_queue.pending_approval ->
@@ -972,7 +1017,8 @@ and drain_auto_judges ~base_path =
       base_path
       detail;
     Error detail
-  | Ok (Keeper_gate_mode.Manual | Keeper_gate_mode.Always_allow) -> Ok []
+  | Ok (Keeper_gate_mode.Manual | Keeper_gate_mode.Always_allow) ->
+    Ok { started_ids = []; failures = [] }
   | Ok Keeper_gate_mode.Auto_judge ->
     (match Keeper_approval_queue.list_pending_entries_for_workspace ~base_path with
      | Error error ->
@@ -987,23 +1033,15 @@ and drain_auto_judges ~base_path =
            Auto_judge_owner_set.empty
            entries
        in
-       let rec drain started_ids = function
-         | [] -> Ok (List.rev started_ids)
-         | (_, keeper_name) :: rest ->
-           (match
+       Ok
+         (drain_auto_judge_owners_with
+            ~drain_owner:(fun ~base_path ~keeper_name ->
               drain_auto_judge_owner_queue ~base_path ~keeper_name ()
-            with
-            | Error error ->
-              Error (Keeper_approval_queue.storage_error_to_string error)
-            | Ok outcome ->
-              let started_ids =
-                match outcome.started_id with
-                | Some id -> id :: started_ids
-                | None -> started_ids
-              in
-              drain started_ids rest)
-       in
-       drain [] (Auto_judge_owner_set.elements owners))
+              |> Result.map
+                   (fun outcome -> outcome.started_id, outcome.failures)
+              |> Result.map_error
+                   Keeper_approval_queue.storage_error_to_string)
+            (Auto_judge_owner_set.elements owners)))
 ;;
 
 type recovered_work =
@@ -1308,6 +1346,7 @@ let resume_persisted_auto_judges =
 type operator_recovery_report =
   { started_ids : string list
   ; queued : int
+  ; failures : auto_judge_owner_failure list
   }
 
 let request_operator_auto_judge_recovery ~base_path =
@@ -1320,8 +1359,8 @@ let request_operator_auto_judge_recovery ~base_path =
      | Error detail -> Error detail
      | Ok () ->
        (match drain_auto_judges ~base_path with
-        | Error detail -> Error detail
-        | Ok started_ids ->
+       | Error detail -> Error detail
+       | Ok drain_report ->
           (match
              Keeper_approval_queue.list_pending_entries_for_workspace ~base_path
            with
@@ -1335,7 +1374,11 @@ let request_operator_auto_judge_recovery ~base_path =
                  0
                  entries
              in
-             Ok { started_ids; queued })))
+             Ok
+               { started_ids = drain_report.started_ids
+               ; queued
+               ; failures = drain_report.failures
+               })))
 ;;
 
 let defer request reason =
@@ -1583,6 +1626,20 @@ module For_testing = struct
 
   let claim_auto_judge = claim_auto_judge
   let release_auto_judge = release_auto_judge
+
+  type owner_drain_outcome =
+    { started_id : string option
+    ; failures : (string * string) list
+    }
+
+  let drain_auto_judge_owners_with ~drain_owner owners =
+    drain_auto_judge_owners_with
+      ~drain_owner:(fun ~base_path ~keeper_name ->
+        drain_owner ~base_path ~keeper_name
+        |> Result.map (fun outcome ->
+          outcome.started_id, outcome.failures))
+      owners
+  ;;
 
   type nonrec hitl_worker_spawner = hitl_worker_spawner
 

--- a/lib/keeper/keeper_gate.mli
+++ b/lib/keeper/keeper_gate.mli
@@ -145,9 +145,21 @@ val retry_blocked_auto_judge :
     mode, authenticated workspace, non-blank operator identity, and exact
     approval row identity must all match. No cadence or restart hook calls it. *)
 
+type auto_judge_owner_failure =
+  { keeper_name : string
+  ; approval_id : string option
+  ; operator_detail : string
+  }
+
+type auto_judge_workspace_drain_report =
+  { started_ids : string list
+  ; failures : auto_judge_owner_failure list
+  }
+
 type operator_recovery_report =
   { started_ids : string list
   ; queued : int
+  ; failures : auto_judge_owner_failure list
   }
 
 (** After an explicit operator selection of Auto Judge, activate one FIFO drain
@@ -187,6 +199,21 @@ module For_testing : sig
 
   val claim_auto_judge : Keeper_approval_queue.pending_approval -> bool
   val release_auto_judge : Keeper_approval_queue.pending_approval -> unit
+
+  type owner_drain_outcome =
+    { started_id : string option
+    ; failures : (string * string) list
+    }
+
+  val drain_auto_judge_owners_with
+    :  drain_owner:
+         (base_path:string ->
+          keeper_name:string ->
+          (owner_drain_outcome, string) result)
+    -> (string * string) list
+    -> auto_judge_workspace_drain_report
+  (** Drain every supplied workspace/Keeper owner even when an earlier owner
+      fails, preserving both successful starts and typed owner-local failures. *)
 
   type hitl_worker_spawner =
     sw:Eio.Switch.t ->

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -378,15 +378,30 @@ type gate_mode_recovery =
   | Recovery_not_requested
 
 let gate_mode_change_json change recovery =
-  let recovery_status, recovery_error, started, queued =
+  let recovery_status, recovery_error, started, queued, recovery_failures =
     match recovery with
     | Recovery_completed report ->
-      ( "completed"
+      ( (if report.failures = [] then "completed" else "partial")
       , `Null
       , List.length report.started_ids
-      , report.queued )
-    | Recovery_failed detail -> "failed", `String detail, 0, 0
-    | Recovery_not_requested -> "not_requested", `Null, 0, 0
+      , report.queued
+      , report.failures )
+    | Recovery_failed detail -> "failed", `String detail, 0, 0, []
+    | Recovery_not_requested -> "not_requested", `Null, 0, 0, []
+  in
+  let recovery_failures_json =
+    `List
+      (List.map
+         (fun (failure : Keeper_gate.auto_judge_owner_failure) ->
+            `Assoc
+              [ "keeper_name", `String failure.keeper_name
+              ; ( "approval_id"
+                , match failure.approval_id with
+                  | Some approval_id -> `String approval_id
+                  | None -> `Null )
+              ; "operator_detail", `String failure.operator_detail
+              ])
+         recovery_failures)
   in
   let `Assoc fields = Keeper_gate_mode.change_json change in
   `Assoc
@@ -394,6 +409,8 @@ let gate_mode_change_json change recovery =
      :: ("recovery_error", recovery_error)
      :: ("started", `Int started)
      :: ("queued", `Int queued)
+     :: ("recovery_failure_count", `Int (List.length recovery_failures))
+     :: ("recovery_failures", recovery_failures_json)
      :: fields)
 ;;
 

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1052,6 +1052,7 @@ let test_gate_mode_change_json_separates_saved_mode_from_recovery () =
       (Server_routes_http_routes_dashboard.For_testing.Recovery_completed
          { Masc.Keeper_gate.started_ids = [ "approval-1" ]
          ; queued = 1
+         ; failures = []
          })
   in
   check string "completed status" "completed"
@@ -1060,6 +1061,32 @@ let test_gate_mode_change_json_separates_saved_mode_from_recovery () =
     (completed |> member "recovery_error" = `Null);
   check int "completed started" 1 (completed |> member "started" |> to_int);
   check int "completed queued" 1 (completed |> member "queued" |> to_int);
+  check int "completed failures" 0
+    (completed |> member "recovery_failure_count" |> to_int);
+  let partial =
+    json
+      (Server_routes_http_routes_dashboard.For_testing.Recovery_completed
+         { Masc.Keeper_gate.started_ids = [ "approval-2" ]
+         ; queued = 1
+         ; failures =
+             [ { keeper_name = "keeper-a"
+               ; approval_id = Some "approval-1"
+               ; operator_detail = "worker unavailable"
+               }
+             ]
+         })
+  in
+  check string "partial status" "partial"
+    (partial |> member "recovery_status" |> to_string);
+  check int "partial started" 1 (partial |> member "started" |> to_int);
+  check int "partial failures" 1
+    (partial |> member "recovery_failure_count" |> to_int);
+  check string "partial failure owner" "keeper-a"
+    (partial
+     |> member "recovery_failures"
+     |> index 0
+     |> member "keeper_name"
+     |> to_string);
   let failed =
     json
       (Server_routes_http_routes_dashboard.For_testing.Recovery_failed

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -804,6 +804,65 @@ let test_terminal_head_does_not_stall_owner_queue () =
          [ blocked_head; follower ])
 ;;
 
+let test_workspace_drain_isolates_owner_failures () =
+  let calls = ref [] in
+  let drain_owner ~base_path ~keeper_name =
+    calls := (base_path, keeper_name) :: !calls;
+    match keeper_name with
+    | "owner-a" -> Error "owner-a queue unavailable"
+    | "owner-b" ->
+      Ok
+        ({ started_id = Some "approval-b"
+         ; failures = []
+         }
+          : Gate.For_testing.owner_drain_outcome)
+    | "owner-c" ->
+      Ok
+        ({ started_id = None
+         ; failures = [ "approval-c", "owner-c worker unavailable" ]
+         }
+          : Gate.For_testing.owner_drain_outcome)
+    | unexpected -> Alcotest.failf "unexpected owner %s" unexpected
+  in
+  let owners =
+    [ "/workspace", "owner-a"
+    ; "/workspace", "owner-b"
+    ; "/workspace", "owner-c"
+    ]
+  in
+  let report =
+    Gate.For_testing.drain_auto_judge_owners_with ~drain_owner owners
+  in
+  Alcotest.(check (list (pair string string)))
+    "every owner is attempted after an earlier failure"
+    owners
+    (List.rev !calls);
+  Alcotest.(check (list string))
+    "healthy owner still starts"
+    [ "approval-b" ]
+    report.started_ids;
+  (match report.failures with
+   | [ workspace_failure; worker_failure ] ->
+     Alcotest.(check string)
+       "workspace failure owner"
+       "owner-a"
+       workspace_failure.keeper_name;
+     Alcotest.(check (option string))
+       "workspace failure has no approval identity"
+       None
+       workspace_failure.approval_id;
+     Alcotest.(check string)
+       "worker failure owner"
+       "owner-c"
+       worker_failure.keeper_name;
+     Alcotest.(check (option string))
+       "worker failure keeps approval identity"
+       (Some "approval-c")
+       worker_failure.approval_id
+   | failures ->
+     Alcotest.failf "expected two owner-local failures, got %d" (List.length failures))
+;;
+
 let test_different_owners_claim_in_parallel () =
   (* Real concurrent proof: fibers race the per-owner claim, so the
      one-winner-per-owner invariant is exercised under actual Atomic
@@ -3639,6 +3698,10 @@ let () =
             "terminal head does not stall the owner queue"
             `Quick
             test_terminal_head_does_not_stall_owner_queue
+        ; Alcotest.test_case
+            "workspace drain isolates owner failures"
+            `Quick
+            test_workspace_drain_isolates_owner_failures
         ; Alcotest.test_case
             "different owners activate in parallel"
             `Quick


### PR DESCRIPTION
## Problem

Workspace Auto Judge recovery stopped at the first owner-local drain error. A broken owner could therefore prevent every later healthy Keeper owner from starting, while the response exposed only one global failure string.

## Fix

- drain every exact workspace/Keeper owner even after an earlier owner fails
- preserve healthy starts and owner-local failures in one typed report
- keep approval identity when a specific worker start fails
- return a closed partial recovery response through the Dashboard API
- decode the new response strictly and show the partial result to the operator

This completes the existing Auto Judge feature path; it adds no Gate, settlement, heuristic, compatibility reader, or facade layer.

## Validation

- ocamlformat --check on all changed OCaml files
- Dashboard tsc --noEmit
- focused Dashboard/API tests: 168 passed
- git diff --check

Local Dune was not run; exact-head CI is the build authority.