### PR TITLE
fix(masc): repair dune build type errors

### DIFF
--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -523,11 +523,8 @@ let candidate_rejection_detail (rejection : Exact_output.candidate_rejection_rec
 
 (* [Flow_exact_execution_failed] is the branch that carries the provider's own
    verdict, and it was the only flow error settled with no log line at all. *)
-let capacity_refusal_detail : Exact_output.input_capacity_refusal -> string = function
-  | Context_window_refused _ ->
-    "context window refused"
-  | Serialized_request_refused _ ->
-    "serialized request refused"
+let capacity_refusal_detail (refusal : Exact_output.input_capacity_disposition) : string =
+  capacity_disposition_detail refusal
 ;;
 
 let execution_cause_detail : Exact_output.execution_error_cause -> string = function

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -22,6 +22,7 @@ module Tr = Keeper_terminal_reason
 module UTS = Masc.Keeper_unified_turn_success.For_testing
 module KMC = Masc.Keeper_meta_contract
 module KMS = Masc.Keeper_meta_store
+module Keeper_identity = Masc.Keeper_identity
 
 let failures = ref []
 let check name cond = if not cond then failures := name :: !failures

--- a/test/test_librarian_exact_output_conformance.ml
+++ b/test/test_librarian_exact_output_conformance.ml
@@ -999,7 +999,7 @@ let test_prompt_slice_and_provenance_share_one_input () =
             Ids.Turn_ref.make
               ~trace_id:"trace-prompt-provenance-snapshot"
               ~absolute_turn:1
-         ; messages =
+        ; messages =
             text_message "dropped-before-prompt"
             :: tool_result_message
                  ~tool_use_id

--- a/test/test_librarian_exact_output_conformance.ml
+++ b/test/test_librarian_exact_output_conformance.ml
@@ -999,7 +999,7 @@ let test_prompt_slice_and_provenance_share_one_input () =
             Ids.Turn_ref.make
               ~trace_id:"trace-prompt-provenance-snapshot"
               ~absolute_turn:1
-        ; messages =
+         ; messages =
             text_message "dropped-before-prompt"
             :: tool_result_message
                  ~tool_use_id


### PR DESCRIPTION
## Summary
- adapt HITL capacity-refusal detail to the current typed disposition
- qualify Keeper identity at the standalone terminal-reason test boundary
- drop stale event-queue/test fixes already superseded by current main

## Verification
- rebased onto main 39906b5bc9
- ocamlformat --check: pass
- git diff --check: pass
- local Dune intentionally not run; exact-head CI is build authority