### PR TITLE
fix(build): align current keeper contracts

### DIFF
--- a/lib/server/server_dashboard_http_keeper_event_queue_operator_execute.ml
+++ b/lib/server/server_dashboard_http_keeper_event_queue_operator_execute.ml
@@ -105,7 +105,7 @@ let prior_cancellation_for_request
   | Some receipt ->
     (match receipt.transition with
      | Keeper_event_queue_state.Cancel_accepted cancellation
-       when Int64.equal cancellation.source_revision expected_revision
+       when Int64.equal cancellation.source_incarnation expected_revision
             && String.equal cancellation.reason reason ->
        Ok (Some { cancellation; applied_at = receipt.applied_at })
      | Keeper_event_queue_state.Cancel_accepted _

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -203,7 +203,8 @@ let message text =
 
 let expect_unexpected_field field json =
   let inp =
-    { Lib.trace_id = "unexpected-field-t"
+    { Lib.turn_ref =
+        Masc.Ids.Turn_ref.make ~trace_id:"unexpected-field-t" ~absolute_turn:1
     ; messages = [ message "current JSON boundary" ]
     }
   in

--- a/test/test_keeper_manual_compaction_preemption.ml
+++ b/test/test_keeper_manual_compaction_preemption.ml
@@ -174,7 +174,7 @@ let test_owner_intake_compacts_then_resumes_source () =
       check string
         "manual compaction is selected ahead of the source"
         Q.manual_compaction_post_id
-        selected.post_id;
+        selected.Keeper_event_queue_state.source.post_id;
       selected
     | None -> fail "manual compaction preemption selected no source"
   in

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -335,7 +335,7 @@ let () =
       meta_fixture_exn
         (`Assoc
           [ "name", `String "corrupted-transcript"
-          ; "agent_name", `String (Keeper_identity.keeper_agent_name "corrupted-transcript")
+          ; "agent_name", `String (Masc.Keeper_identity.keeper_agent_name "corrupted-transcript")
           ; "trace_id", `String "trace-corrupted-transcript"
           ])
     in

--- a/test/test_librarian_exact_output_conformance.ml
+++ b/test/test_librarian_exact_output_conformance.ml
@@ -995,7 +995,9 @@ let test_prompt_slice_and_provenance_share_one_input () =
           (fun index -> text_message (Printf.sprintf "retained-%d" index))
       in
       let input : Librarian.input =
-        { trace_id = "trace-prompt-provenance-snapshot"
+        { Librarian.turn_ref =
+            Ids.Turn_ref.make
+              ~trace_id:"trace-prompt-provenance-snapshot" ~absolute_turn:1
         ; messages =
             text_message "dropped-before-prompt"
             :: tool_result_message


### PR DESCRIPTION
## Summary
- use current event source-incarnation field for replay identity
- construct Librarian inputs with TurnRef
- qualify current queue selection and Keeper identity types

## Verification
- ocamlformat --check: pass
- git diff --check: pass
- focused Dune intentionally not run; CI is build authority