### PR TITLE
refactor(keeper): reuse exact source reference SSOT

### DIFF
--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -684,17 +684,11 @@ let turn_attempt_terminal_operation_id
       ~admitted_revision
       source
   =
-  let source_fingerprint =
-    Keeper_event_queue.stimulus_to_yojson source
-    |> Yojson.Safe.to_string
-    |> Digestif.SHA256.digest_string
-    |> Digestif.SHA256.to_hex
-  in
   Printf.sprintf
     "turn-attempt-terminal:%d:%Ld:%s"
     owner_nonce
     admitted_revision
-    source_fingerprint
+    (source_snapshot_ref source)
 ;;
 
 let ack_pending_source_terminal

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -71,8 +71,10 @@ type pending_selection =
   { source : Keeper_event_queue.stimulus
   ; admitted_revision : int64
   }
-(** One exact durable queue entry. [admitted_revision] identifies the source
-    incarnation without making later unrelated queue changes invalidate it. *)
+(** One exact durable queue entry. [admitted_revision] records the durable
+    transform that admitted the snapshot; entries admitted by the same
+    transform may share it, so exact selection combines it with
+    {!source_snapshot_ref}. *)
 
 type transition_result =
   | Transition_applied of transition_receipt


### PR DESCRIPTION
## 문제

#26468이 exact durable source identity를 도입했지만, `turn_attempt_terminal_operation_id`가 canonical source reference와 동일한 SHA-256 계산을 별도로 복제하고 있었습니다. 또한 `pending_selection.admitted_revision` 문서가 같은 durable transform에서 함께 admitted된 여러 entry도 revision을 공유할 수 있다는 점을 흐렸습니다.

## 변경

- terminal operation ID가 `source_snapshot_ref` SSOT를 직접 사용
- `admitted_revision`은 admission transform을 기록하며 exact selection은 source reference와 조합된다는 계약을 명시

## Blast radius

순수 queue-state 내부 구현과 인터페이스 문서만 변경합니다. Wire/durable schema/행동/Gate/Facade/legacy fallback/migration 코드는 추가하거나 변경하지 않습니다.

## 검증

- `scripts/dune-local.sh build lib/keeper_runtime/masc_keeper_runtime.cmxa`
- `ocamlformat --check lib/keeper_runtime/keeper_event_queue_state.ml lib/keeper_runtime/keeper_event_queue_state.mli`
- `git diff --check origin/main...HEAD`

Follow-up to #26468.