### PR TITLE
fix(keeper): preserve paused transfer target identity

### DIFF
--- a/lib/keeper/keeper_event_queue_recovery.ml
+++ b/lib/keeper/keeper_event_queue_recovery.ml
@@ -22,6 +22,10 @@ type projection_error =
       { target_keeper : string
       ; detail : string
       }
+  | Paused_transfer_target_projection_failed of
+      { target_keeper : string
+      ; cause : Keeper_paused_work_transfer_transaction.failure
+      }
   | Ledger_projection_failed of string
   | Unexpected_projection_failure of Eio.Exn.with_bt
 
@@ -74,6 +78,12 @@ let projection_error_to_string = function
       "event queue transfer target projection failed target_keeper=%s: %s"
       target_keeper
       detail
+  | Paused_transfer_target_projection_failed { target_keeper; cause } ->
+    Printf.sprintf
+      "paused-work transfer target projection failed target_keeper=%s: %s"
+      target_keeper
+      (Keeper_paused_work_transfer_transaction.error_to_string
+         { cause; reservation_release = None })
   | Ledger_projection_failed detail ->
     "event queue transition ledger projection failed: " ^ detail
   | Unexpected_projection_failure (exn, backtrace) ->
@@ -144,6 +154,35 @@ let with_owner_claim owner f =
       (fun () -> Owner_claim_acquired (f ()))
 ;;
 
+let wake_transfer_target ~base_path target_keeper =
+  ignore
+    (Keeper_registry.wakeup_running
+       ~intent:Keeper_registry.Broadcast_signal
+       ~base_path
+       target_keeper :
+       Keeper_registry.wakeup_outcome)
+;;
+
+let project_generic_transfer_target_result
+      ~base_path
+      (transfer : Keeper_registry_event_queue.accepted_transfer)
+  =
+  match
+    Keeper_registry_event_queue.project_accepted_transfer_durable_result
+      ~base_path
+      transfer.to_keeper
+      ~transfer
+  with
+  | Keeper_registry_event_queue.Stimulus_enqueued
+  | Keeper_registry_event_queue.Stimulus_already_present ->
+    wake_transfer_target ~base_path transfer.to_keeper;
+    Ok ()
+  | Keeper_registry_event_queue.Stimulus_storage_error detail ->
+    Error
+      (Target_transfer_projection_failed
+         { target_keeper = transfer.to_keeper; detail })
+;;
+
 let project_transfer_target_result ~base_path (entry : Persistence.outbox_entry) =
   match entry.receipt.transition with
   | Persistence.Cancel_accepted _
@@ -151,24 +190,18 @@ let project_transfer_target_result ~base_path (entry : Persistence.outbox_entry)
     Ok ()
   | Persistence.Transfer_accepted transfer ->
     (match
-       Keeper_registry_event_queue.project_accepted_transfer_durable_result
-         ~base_path
-         transfer.to_keeper
+       Keeper_paused_work_transfer_transaction.project_committed_target_if_receipted
+         (Workspace.default_config base_path)
          ~transfer
      with
-     | Keeper_registry_event_queue.Stimulus_enqueued
-     | Keeper_registry_event_queue.Stimulus_already_present ->
-       ignore
-         (Keeper_registry.wakeup_running
-            ~intent:Keeper_registry.Broadcast_signal
-            ~base_path
-            transfer.to_keeper :
-            Keeper_registry.wakeup_outcome);
+     | Ok None -> project_generic_transfer_target_result ~base_path transfer
+     | Ok (Some _) ->
+       wake_transfer_target ~base_path transfer.to_keeper;
        Ok ()
-     | Keeper_registry_event_queue.Stimulus_storage_error detail ->
+     | Error cause ->
        Error
-         (Target_transfer_projection_failed
-            { target_keeper = transfer.to_keeper; detail }))
+         (Paused_transfer_target_projection_failed
+            { target_keeper = transfer.to_keeper; cause }))
 ;;
 
 let project_claimed_owner owner =

--- a/lib/keeper/keeper_event_queue_recovery.mli
+++ b/lib/keeper/keeper_event_queue_recovery.mli
@@ -19,6 +19,10 @@ type projection_error =
       { target_keeper : string
       ; detail : string
       }
+  | Paused_transfer_target_projection_failed of
+      { target_keeper : string
+      ; cause : Keeper_paused_work_transfer_transaction.failure
+      }
   | Ledger_projection_failed of string
   | Unexpected_projection_failure of Eio.Exn.with_bt
 

--- a/lib/keeper/keeper_paused_work_operator.ml
+++ b/lib/keeper/keeper_paused_work_operator.ml
@@ -289,6 +289,7 @@ let error_class = function
           | Transfer.Source_owner_identity_changed
           | Transfer.Target_owner_not_active
           | Transfer.Target_owner_nonce_changed _
+          | Transfer.Target_owner_identity_changed
           | Transfer.Continuation_binding_mismatch
           | Transfer.Source_queue_validation_failed _ )
       ; _

--- a/lib/keeper/keeper_paused_work_transfer_transaction.ml
+++ b/lib/keeper/keeper_paused_work_transfer_transaction.ml
@@ -36,6 +36,7 @@ type failure =
       { expected : int
       ; actual : int
       }
+  | Target_owner_identity_changed
   | Continuation_binding_mismatch
   | Source_queue_validation_failed of string
   | Committed_projection_failed of
@@ -112,6 +113,8 @@ let failure_to_string = function
       "Transfer_owner target generation changed: expected %d, actual %d"
       expected
       actual
+  | Target_owner_identity_changed ->
+    "Transfer_owner target trace identity changed"
   | Continuation_binding_mismatch ->
     "Transfer_owner continuation binding does not match the exact source event"
   | Source_queue_validation_failed detail ->
@@ -358,10 +361,7 @@ let validate_committed_target config transfer =
       (Target_owner_nonce_changed
          { expected = transfer.target_generation; actual = meta.runtime.nonce })
   else if not (Keeper_id.Trace_id.equal meta.runtime.trace_id transfer.target_trace_id)
-  then
-    Error
-      (Committed_projection_failed
-         { stage = Target_enqueue; detail = "target trace identity changed" })
+  then Error Target_owner_identity_changed
   else Ok ()
 ;;
 
@@ -378,6 +378,40 @@ let target_enqueue config receipt transfer =
   | Keeper_registry_event_queue.Stimulus_already_present -> Ok Already_present
   | Keeper_registry_event_queue.Stimulus_storage_error detail ->
     Error (Committed_projection_failed { stage = Target_enqueue; detail })
+;;
+
+let receipt_matches_accepted_transfer
+      receipt
+      (receipt_transfer : Keeper_paused_work_disposition_receipt.transfer_owner)
+      (accepted : Keeper_registry_event_queue.accepted_transfer)
+  =
+  String.equal receipt.Keeper_paused_work_disposition_receipt.keeper_name accepted.from_keeper
+  && Int.equal receipt.expected_generation accepted.owner_nonce
+  && String.equal receipt.operator_operation_id accepted.operator_operation_id
+  && String.equal receipt_transfer.from_keeper accepted.from_keeper
+  && String.equal receipt_transfer.to_keeper accepted.to_keeper
+  && receipt_transfer.source = accepted.source
+  && Int64.equal receipt_transfer.source_incarnation accepted.source_incarnation
+;;
+
+let project_committed_target_if_receipted
+      config
+      ~(transfer : Keeper_registry_event_queue.accepted_transfer)
+  =
+  let* receipt =
+    Keeper_paused_work_disposition_receipt.load
+      config
+      ~keeper_name:transfer.from_keeper
+      ~operator_operation_id:transfer.operator_operation_id
+    |> Result.map_error (fun detail -> Receipt_read_failed detail)
+  in
+  match receipt with
+  | None -> Ok None
+  | Some receipt ->
+    let* receipt_transfer = transfer_of_receipt receipt in
+    if receipt_matches_accepted_transfer receipt receipt_transfer transfer
+    then target_enqueue config receipt receipt_transfer |> Result.map Option.some
+    else Error (Receipt_conflict receipt)
 ;;
 
 let project_receipt config receipt =

--- a/lib/keeper/keeper_paused_work_transfer_transaction.mli
+++ b/lib/keeper/keeper_paused_work_transfer_transaction.mli
@@ -38,6 +38,7 @@ type failure =
       { expected : int
       ; actual : int
       }
+  | Target_owner_identity_changed
   | Continuation_binding_mismatch
   | Source_queue_validation_failed of string
   | Committed_projection_failed of
@@ -70,6 +71,15 @@ type success =
   }
 
 val error_to_string : error -> string
+
+val project_committed_target_if_receipted :
+  Workspace.config ->
+  transfer:Keeper_registry_event_queue.accepted_transfer ->
+  (target_projection option, failure) result
+(** If [transfer] originated from a durable paused-work receipt, validate that
+    receipt's exact target generation and trace before projecting it. [None]
+    means no paused-work receipt owns this generic operator transfer. Receipt
+    conflicts and target identity changes fail closed. *)
 
 val transfer_pending :
   Workspace.config ->

--- a/test/test_keeper_paused_work_transfer_transaction.ml
+++ b/test/test_keeper_paused_work_transfer_transaction.ml
@@ -16,6 +16,22 @@ let require_some label = function
   | None -> Alcotest.failf "%s: expected Some" label
 ;;
 
+let with_strict_executor f =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let pool =
+    Domain_pool.create
+      ~sw
+      ~domain_count:1
+      (Eio.Stdenv.domain_mgr env)
+  in
+  Executor_pool_ref.For_testing.with_pool
+    (Domain_pool.executor_pool pool)
+    f
+;;
+
 let rec remove_tree path =
   if Sys.file_exists path
   then if Sys.is_directory path
@@ -547,6 +563,130 @@ let test_replay_after_source_ack_projects_target () =
     assert_converged config ~from_keeper ~to_keeper request.source)
 ;;
 
+let test_generic_recovery_preserves_receipted_target_identity () =
+  with_transfer_lane
+  @@ fun config from_keeper to_keeper source_meta target_meta request ->
+  let transfer : Receipt.transfer_owner =
+    { from_keeper
+    ; to_keeper
+    ; target_trace_id = target_meta.runtime.trace_id
+    ; target_generation = request.target_generation
+    ; source = request.source
+    ; source_incarnation = request.source_incarnation
+    ; continuation_binding = request.continuation_binding
+    }
+  in
+  let receipt : Receipt.t =
+    { keeper_name = from_keeper
+    ; expected_trace_id = source_meta.runtime.trace_id
+    ; expected_generation = request.owner_nonce
+    ; operator_operation_id = request.operator_operation_id
+    ; requested_at = 2.0
+    ; operation = Receipt.Transfer_owner transfer
+    }
+  in
+  (match
+     Receipt.with_keeper_lock config ~keeper_name:from_keeper (fun lock ->
+       Receipt.save_if_absent lock config receipt)
+   with
+   | Ok (Ok Receipt.Created) -> ()
+   | Ok (Ok (Receipt.Existing _)) -> Alcotest.fail "prepared receipt already existed"
+   | Ok (Error detail) | Error detail -> Alcotest.fail detail);
+  let causal : Keeper_registry_event_queue.accepted_transfer =
+    { source = request.source
+    ; source_incarnation = request.source_incarnation
+    ; owner_nonce = request.owner_nonce
+    ; operator_operation_id = request.operator_operation_id
+    ; from_keeper
+    ; to_keeper
+    }
+  in
+  ignore
+    (Keeper_registry_event_queue.transfer_pending_accepted_result
+       ~base_path:config.Workspace.base_path
+       from_keeper
+       ~current_owner_nonce:request.owner_nonce
+       ~applied_at:receipt.requested_at
+       ~transfer:causal
+     |> require_ok "simulate committed source ACK");
+  ignore
+    (write_meta
+       config
+       ~keeper_name:to_keeper
+       ~trace_id:"trace-restarted-target"
+       ~generation:request.target_generation
+       ~paused:false :
+      Keeper_meta_contract.keeper_meta);
+  (match
+     with_strict_executor
+     @@ fun () ->
+     Keeper_event_queue_recovery.project_owner_result
+       ~base_path:config.Workspace.base_path
+       ~keeper_name:from_keeper
+   with
+   | Error
+       (Keeper_event_queue_recovery.Paused_transfer_target_projection_failed
+          { target_keeper
+          ; cause = Transaction.Target_owner_identity_changed
+          }) ->
+     Alcotest.(check string) "trace failure target" to_keeper target_keeper
+   | Error error ->
+     Alcotest.fail (Keeper_event_queue_recovery.projection_error_to_string error)
+   | Ok _ -> Alcotest.fail "generic recovery ignored the target trace identity");
+  ignore
+    (write_meta
+       config
+       ~keeper_name:to_keeper
+       ~trace_id:(Keeper_id.Trace_id.to_string target_meta.runtime.trace_id)
+       ~generation:(request.target_generation + 1)
+       ~paused:false :
+      Keeper_meta_contract.keeper_meta);
+  (match
+     with_strict_executor
+     @@ fun () ->
+     Keeper_event_queue_recovery.project_owner_result
+       ~base_path:config.Workspace.base_path
+       ~keeper_name:from_keeper
+   with
+   | Error
+       (Keeper_event_queue_recovery.Paused_transfer_target_projection_failed
+          { target_keeper
+          ; cause = Transaction.Target_owner_nonce_changed { expected; actual }
+          }) ->
+     Alcotest.(check string) "generation failure target" to_keeper target_keeper;
+     Alcotest.(check int)
+       "expected target generation"
+       request.target_generation
+       expected;
+     Alcotest.(check int)
+       "current target generation"
+       (request.target_generation + 1)
+       actual
+   | Error error ->
+     Alcotest.fail (Keeper_event_queue_recovery.projection_error_to_string error)
+   | Ok _ -> Alcotest.fail "generic recovery ignored the target generation");
+  let source =
+    Persistence.load_state_result
+      ~base_path:config.Workspace.base_path
+      ~keeper_name:from_keeper
+    |> require_ok "load retained source transition"
+  in
+  let target =
+    Persistence.load_state_result
+      ~base_path:config.Workspace.base_path
+      ~keeper_name:to_keeper
+    |> require_ok "load unchanged target queue"
+  in
+  Alcotest.(check int)
+    "identity failure retains the source outbox"
+    1
+    (List.length (State.transition_outbox source));
+  Alcotest.(check int)
+    "identity failure has no target effect"
+    0
+    (Queue.length (State.pending target))
+;;
+
 let test_unrelated_enqueue_preserves_source_incarnation () =
   with_transfer_lane (fun config from_keeper to_keeper _source_meta _target_meta request ->
     let unrelated : Queue.stimulus =
@@ -664,6 +804,10 @@ let () =
             "replay after source ACK projects target"
             `Quick
             test_replay_after_source_ack_projects_target
+        ; Alcotest.test_case
+            "generic recovery preserves receipted target identity"
+            `Quick
+            test_generic_recovery_preserves_receipted_target_identity
         ] )
     ]
 ;;


### PR DESCRIPTION
## 문제

#26465 병합 뒤 추가된 [P1 review](https://github.com/jeong-sik/masc/pull/26465#discussion_r3681765777) 대응입니다. paused-work source ACK 이후 generic event-queue recovery가 receipt의 target generation/trace를 잃고 이름만으로 새 Keeper incarnation에 전달할 수 있었습니다.

## 변경

- paused-work receipt가 있는 accepted transfer는 receipt projector로 위임합니다.
- target generation/trace가 달라지면 typed failure로 중단하고 source outbox를 유지합니다.
- receipt가 없는 일반 operator transfer만 기존 generic projection을 사용합니다.
- trace 변경과 generation 변경 모두 target effect 없이 source outbox를 보존하는 회귀 테스트를 추가합니다.

## 검증

- `ocamlformat --check`: PASS
- `git diff --check`: PASS
- OCaml parse: PASS
- focused Dune build/test: 미실행 (공용 Dune lock 대기 중이었고 사용자 확인 예정)