### PR TITLE
fix(keeper): enforce current TurnRecord evidence

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -657,8 +657,8 @@ let run_turn
     let receipt_response_text_present_ref =
       s.Keeper_run_tools.receipt_response_text_present_ref
     in
-    let request_wire_observation_ref = ref None in
-    let request_input_messages_ref = ref None in
+    let request_evidence_ref = ref None in
+    let current_request_input_messages_ref = ref None in
     let source_model_input_projection =
       s.Keeper_run_tools.model_input_projection
     in
@@ -676,9 +676,9 @@ let run_turn
              ~projected_messages
          with
          | Some provider_content ->
-           request_input_messages_ref := Some provider_content
+           current_request_input_messages_ref := Some provider_content
          | None ->
-           request_input_messages_ref := None;
+           current_request_input_messages_ref := None;
            Log.Keeper.warn
              "turn input composition unavailable: keeper=%s trace=%s \
               reason=model_input_projection_rewrote_prefix"
@@ -872,11 +872,12 @@ let run_turn
                              ~runtime_id
                              ~max_request_body_bytes
                              ~body_bytes;
-                           request_wire_observation_ref :=
+                           request_evidence_ref :=
                              Some
-                               { Turn_record.runtime_profile = runtime_id
-                               ; body_bytes
-                               })
+                               ( { Turn_record.runtime_profile = runtime_id
+                                 ; body_bytes
+                                 }
+                               , !current_request_input_messages_ref ))
                       ())
          in
          (* Trace-store failure isolation: [raw_trace_for_dispatch]
@@ -920,14 +921,14 @@ let run_turn
                  in
                  let usage = Keeper_context_runtime.usage_of_response result.response in
                  let ctx_composition =
-                   match !request_input_messages_ref with
-                   | Some input_messages ->
+                   match !request_evidence_ref with
+                   | Some (_, Some input_messages) ->
                      Keeper_agent_prompt_metrics.build_ctx_composition_metrics
                        ~prompt_blocks:acc.prompt_blocks
                        ~tools
                        ~input_messages
                        ~actual_input_tokens:(Some usage.input_tokens)
-                   | None ->
+                   | Some (_, None) | None ->
                      { Keeper_agent_prompt_metrics.actual_input_tokens =
                          (if usage.input_tokens > 0
                           then Some usage.input_tokens
@@ -1149,17 +1150,17 @@ let run_turn
         in
         let input_components =
           let segments =
-            match turn_result, !request_input_messages_ref with
+            match turn_result, !request_evidence_ref with
             | Ok result, _ ->
               result.Keeper_agent_result.ctx_composition.segments
-            | Error _, Some input_messages ->
+            | Error _, Some (_, Some input_messages) ->
               (Keeper_agent_prompt_metrics.build_ctx_composition_metrics
                  ~prompt_blocks:acc.prompt_blocks
                  ~tools
                  ~input_messages
                  ~actual_input_tokens:None)
                 .segments
-            | Error _, None -> []
+            | Error _, (Some (_, None) | None) -> []
           in
           List.map
             (fun
@@ -1185,7 +1186,7 @@ let run_turn
           ~price_output_per_million
           ~request_latency_ms
           ~ttfrc_ms
-          ~request_wire_observation:!request_wire_observation_ref
+          ~request_wire_observation:(Option.map fst !request_evidence_ref)
           ~sampling:
             { temperature = Some temperature
             ; top_p = Runtime.top_p_of_runtime_id runtime_id_string

--- a/lib/keeper/keeper_turn_record_writer.ml
+++ b/lib/keeper/keeper_turn_record_writer.ml
@@ -24,7 +24,7 @@ let write
     ; keeper = keeper_name
     ; trace_id
     ; absolute_turn
-    ; turn_ref = Some (Ids.Turn_ref.make ~trace_id ~absolute_turn)
+    ; turn_ref = Ids.Turn_ref.make ~trace_id ~absolute_turn
     ; blocks
     ; input_components
     ; runtime_profile

--- a/lib/types/prompt_block_id.ml
+++ b/lib/types/prompt_block_id.ml
@@ -1,59 +1,28 @@
 type t =
   | Persona
-  | Continuity
   | Dynamic_context
   | Temporal_summary
-  | Claimed_task_nudge
-  | Retry_nudge
   | Memory_os_recall
-  | Connected_surface
-  | Other of string
 
 let equal a b =
   match a, b with
   | Persona, Persona
-  | Continuity, Continuity
   | Dynamic_context, Dynamic_context
   | Temporal_summary, Temporal_summary
-  | Claimed_task_nudge, Claimed_task_nudge
-  | Retry_nudge, Retry_nudge
-  | Memory_os_recall, Memory_os_recall
-  | Connected_surface, Connected_surface -> true
-  | Other a, Other b -> String.equal a b
-  | ( ( Persona | Continuity | Dynamic_context | Temporal_summary
-      | Claimed_task_nudge | Retry_nudge | Memory_os_recall
-      | Connected_surface | Other _ )
-    , _ ) -> false
+  | Memory_os_recall, Memory_os_recall -> true
+  | (Persona | Dynamic_context | Temporal_summary | Memory_os_recall), _ -> false
 
 let to_string = function
   | Persona -> "persona"
-  | Continuity -> "continuity"
   | Dynamic_context -> "dynamic_context"
   | Temporal_summary -> "temporal_summary"
-  | Claimed_task_nudge -> "claimed_task_nudge"
-  | Retry_nudge -> "retry_nudge"
   | Memory_os_recall -> "memory_os_recall"
-  | Connected_surface -> "connected_surface"
-  | Other name -> name
 
 let of_string = function
-  | "persona" -> Persona
-  | "continuity" -> Continuity
-  | "dynamic_context" -> Dynamic_context
-  | "temporal_summary" -> Temporal_summary
-  | "claimed_task_nudge" -> Claimed_task_nudge
-  | "retry_nudge" -> Retry_nudge
-  | "memory_os_recall" -> Memory_os_recall
-  | "connected_surface" -> Connected_surface
-  | name -> Other name
+  | "persona" -> Ok Persona
+  | "dynamic_context" -> Ok Dynamic_context
+  | "temporal_summary" -> Ok Temporal_summary
+  | "memory_os_recall" -> Ok Memory_os_recall
+  | name -> Error (Printf.sprintf "unknown prompt block id %S" name)
 
-let all_known =
-  [ Persona
-  ; Continuity
-  ; Dynamic_context
-  ; Temporal_summary
-  ; Claimed_task_nudge
-  ; Retry_nudge
-  ; Memory_os_recall
-  ; Connected_surface
-  ]
+let all_known = [ Persona; Dynamic_context; Temporal_summary; Memory_os_recall ]

--- a/lib/types/prompt_block_id.mli
+++ b/lib/types/prompt_block_id.mli
@@ -9,29 +9,21 @@
     [Dynamic_context] is the composite soft-context string built by
     keeper_turn.ml/keeper_run_prompt.ml (continuity snapshot, skill
     route, worktree, telemetry feedback, turn instructions, recent
-    failure memory) — recorded as one block until the producer threads
-    a typed decomposition. [Continuity] and [Connected_surface] exist
-    for that decomposition and for the unified-path user-message block;
-    they have no producer yet. [Other] carries forward-compatible rows
-    read back from disk. *)
+    failure memory) — recorded as one block until a real producer
+    introduces a typed decomposition. Constructors without a producer and
+    open-ended catch-alls are intentionally excluded. *)
 
 type t =
   | Persona
-  | Continuity
   | Dynamic_context
   | Temporal_summary
-  | Claimed_task_nudge
-  | Retry_nudge
   | Memory_os_recall
-  | Connected_surface
-  | Other of string
 
 val equal : t -> t -> bool
 val to_string : t -> string
 
-val of_string : string -> t
-(** Total: unknown names map to [Other name], so old readers survive new
-    writers and disk rows never fail to decode on this field. *)
+val of_string : string -> (t, string) result
+(** Decode the closed current wire vocabulary. Unknown names are rejected. *)
 
 val all_known : t list
-(** Every constructor except [Other] — for exhaustive codec tests. *)
+(** Every current producer-backed constructor, for exhaustive codec tests. *)

--- a/lib/types/turn_record.ml
+++ b/lib/types/turn_record.ml
@@ -48,7 +48,7 @@ type t =
   ; keeper : string
   ; trace_id : string
   ; absolute_turn : int
-  ; turn_ref : Ids.Turn_ref.t option
+  ; turn_ref : Ids.Turn_ref.t
   ; blocks : prompt_block list
   ; input_components : input_component list
   ; runtime_profile : string
@@ -111,6 +111,7 @@ let to_json (r : t) : Yojson.Safe.t =
      ; ("keeper", `String r.keeper)
      ; ("trace_id", `String r.trace_id)
      ; ("absolute_turn", `Int r.absolute_turn)
+     ; ("turn_ref", Ids.Turn_ref.to_yojson r.turn_ref)
      ; ("blocks", `List (List.map prompt_block_to_json r.blocks))
      ; ( "input_components"
        , `List (List.map input_component_to_json r.input_components) )
@@ -118,7 +119,6 @@ let to_json (r : t) : Yojson.Safe.t =
      ; "request_runtime_profile", request_runtime_profile
      ; "request_body_bytes", request_body_bytes
      ]
-    @ opt_field "turn_ref" Ids.Turn_ref.to_yojson r.turn_ref
     @ opt_field "model" (fun v -> `String v) r.model
     @ opt_field "finish_reason" (fun v -> `String v) r.finish_reason
     @ opt_field "context_window" (fun v -> `Int v) r.context_window
@@ -206,7 +206,8 @@ let prompt_block_of_json (json : Yojson.Safe.t) : (prompt_block, string) result 
       let* bytes = as_int "bytes" bytes_json in
       let* digest_json = require "digest" fields in
       let* digest = as_string "digest" digest_json in
-      Ok { block = Prompt_block_id.of_string block_name; bytes; digest }
+      let* block = Prompt_block_id.of_string block_name in
+      Ok { block; bytes; digest }
   | _ -> Error "turn_record: block entry is not an object"
 
 let input_component_id_of_string token =
@@ -232,14 +233,9 @@ let input_component_id_of_string token =
           (String.length prefix)
           (String.length token - String.length prefix)
       in
-      (match
-         List.find_opt
-           (fun known ->
-              Prompt_block_id.equal known (Prompt_block_id.of_string name))
-           Prompt_block_id.all_known
-       with
-       | Some block -> Ok (Prompt_block block)
-       | None ->
+      (match Prompt_block_id.of_string name with
+       | Ok block -> Ok (Prompt_block block)
+       | Error _ ->
          Error
            (Printf.sprintf
               "turn_record: unknown input component %S"
@@ -295,6 +291,16 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
       let* trace_id = as_string "trace_id" trace_json in
       let* turn_json = require "absolute_turn" fields in
       let* absolute_turn = as_int "absolute_turn" turn_json in
+      let* turn_ref_json = require "turn_ref" fields in
+      let* turn_ref = as_turn_ref "turn_ref" turn_ref_json in
+      let expected_turn_ref = Ids.Turn_ref.make ~trace_id ~absolute_turn in
+      let* () =
+        if Ids.Turn_ref.equal turn_ref expected_turn_ref
+        then Ok ()
+        else
+          Error
+            "turn_record: turn_ref does not match trace_id and absolute_turn"
+      in
       let* blocks_json = require "blocks" fields in
       let* blocks =
         match blocks_json with
@@ -326,7 +332,6 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
             "turn_record: request_runtime_profile and request_body_bytes must \
              both be present or both be null"
       in
-      let* turn_ref = opt_member "turn_ref" fields as_turn_ref in
       let* model = opt_member "model" fields as_string in
       let* finish_reason = opt_member "finish_reason" fields as_string in
       let* context_window = opt_member "context_window" fields as_int in

--- a/lib/types/turn_record.mli
+++ b/lib/types/turn_record.mli
@@ -55,7 +55,7 @@ type usage =
        matters against [context_window] below: the fill percentage it denominates is
        read as pressure on the compaction ceiling, and cache-heavy turns and
        genuinely large prompts are different situations with the same numerator.
-       [None] on legacy rows and on turns where the provider reported no usage. *)
+       [None] when the provider reported no usage. *)
   }
 
 type request_wire_observation =
@@ -68,9 +68,9 @@ type t =
   ; keeper : string
   ; trace_id : string
   ; absolute_turn : int
-  ; turn_ref : Ids.Turn_ref.t option
+  ; turn_ref : Ids.Turn_ref.t
     (* RFC-0233 §7 — "<trace_id>#<absolute_turn>" join key for chat/board.
-       [option] so pre-§7 rows decode as [None]. *)
+       The decoder requires it to match [trace_id] and [absolute_turn]. *)
   ; blocks : prompt_block list (* assembly order *)
   ; input_components : input_component list
     (* Exact UTF-8/JSON payload bytes attributed to the concrete prompt blocks,
@@ -81,9 +81,8 @@ type t =
   ; model : string option
     (* RFC-0233 §2.2/§2.3 — boundary-redacted runtime model label, the
        same value the execution receipt surfaces (RFC-0132 redaction
-       SSOT). [option] so error turns and pre-grounding rows decode as
-       [None]; the inspector renders absence rather than a fabricated
-       name. *)
+       SSOT). [None] on error turns before runtime grounding; the inspector
+       renders absence rather than a fabricated name. *)
   ; finish_reason : string option
     (* RFC-0233 §2.3 — keeper turn stop reason, serialized via the
        receipt SSOT [Keeper_execution_receipt.stop_reason_to_string].
@@ -92,8 +91,8 @@ type t =
   ; context_window : int option
     (* RFC-0233 §8 — keeper-resolved effective context budget (tokens) for
        this turn, the denominator the dashboard ctx-fill% uses. [None] on
-       legacy rows or the error path; the inspector renders absence rather
-       than the fabricated 200K. This is the keeper compaction ceiling
+       the error path; the inspector renders absence rather than the
+       fabricated 200K. This is the keeper compaction ceiling
        ([max_context]), NOT the provider's per-request num-ctx cap (an
        Ollama-only transport detail). *)
   ; price_input_per_million : float option
@@ -110,8 +109,8 @@ type t =
        [inference_telemetry.request_latency_ms] (the OAS transport layer
        synthesizes it for every provider — [complete_common.patch_telemetry]
        non-streaming, [complete_stream] streaming — so it is populated
-       whenever a response is produced). [None] on the error path or legacy
-       rows; the inspector renders absence rather than a fabricated duration
+       whenever a response is produced). [None] on the error path; the
+       inspector renders absence rather than a fabricated duration
        for the response-generation phase. Phase-level splits
        (prefill/decode) are deliberately deferred: only the provider's
        native timing objects carry prefill/predicted durations and most
@@ -153,9 +152,8 @@ val to_json : t -> Yojson.Safe.t
 
 val of_json : Yojson.Safe.t -> (t, string) result
 (** Fails loudly on malformed rows (missing fields, unparseable
-    execution ids) instead of repairing them — RFC-0233 §4. Unknown
-    block names decode as [Prompt_block_id.Other] (that field alone is
-    forward-open by design). *)
+    execution ids, unknown block names, or mismatched turn refs) instead
+    of repairing them — RFC-0233 §4. *)
 
 (** Result of diffing two consecutive records by [(block, digest)]. *)
 type block_diff =

--- a/test/test_keeper_runtime_observation_boundaries.ml
+++ b/test/test_keeper_runtime_observation_boundaries.ml
@@ -255,8 +255,8 @@ let test_empty_completion_exemption_budget_is_bounded () =
 let test_extra_system_context_preserves_typed_blocks () =
   let blocks =
     [ Prompt_block_id.Dynamic_context, "dynamic"
-    ; Prompt_block_id.Retry_nudge, "retry"
-    ; Prompt_block_id.Connected_surface, "surface"
+    ; Prompt_block_id.Temporal_summary, "summary"
+    ; Prompt_block_id.Memory_os_recall, "memory"
     ]
   in
   let assembly =
@@ -267,7 +267,7 @@ let test_extra_system_context_preserves_typed_blocks () =
   Alcotest.(check bool) "typed blocks unchanged" true (assembly.blocks = blocks);
   Alcotest.(check (option string))
     "complete source order reaches OAS"
-    (Some "existing\n\ndynamic\n\nretry\n\nsurface")
+    (Some "existing\n\ndynamic\n\nsummary\n\nmemory")
     assembly.extra_system_context
 
 let () =

--- a/test/test_turn_record.ml
+++ b/test/test_turn_record.ml
@@ -11,18 +11,21 @@ let block_id = testable (Fmt.of_to_string Prompt_block_id.to_string) Prompt_bloc
 let test_block_id_roundtrip () =
   List.iter
     (fun block ->
-      check block_id
-        (Printf.sprintf "roundtrip %s" (Prompt_block_id.to_string block))
-        block
-        (Prompt_block_id.of_string (Prompt_block_id.to_string block)))
+      match Prompt_block_id.of_string (Prompt_block_id.to_string block) with
+      | Ok decoded ->
+        check block_id
+          (Printf.sprintf "roundtrip %s" (Prompt_block_id.to_string block))
+          block
+          decoded
+      | Error error -> failf "current block failed to decode: %s" error)
     Prompt_block_id.all_known
 
-let test_block_id_unknown_maps_to_other () =
-  check block_id "unknown name survives as Other"
-    (Prompt_block_id.Other "future_block")
-    (Prompt_block_id.of_string "future_block");
-  check string "Other renders its name" "future_block"
-    (Prompt_block_id.to_string (Prompt_block_id.Other "future_block"))
+let test_block_id_unknown_rejected () =
+  match Prompt_block_id.of_string "future_block" with
+  | Ok _ -> fail "decoded an unknown block id"
+  | Error message ->
+    check bool "unknown block id is explicit" true
+      (Astring.String.is_infix ~affix:"unknown prompt block id" message)
 
 (* ── TurnRecord codec ─────────────────────────────────── *)
 
@@ -38,7 +41,7 @@ let sample_record () : Turn_record.t =
   ; trace_id = "trace-1780648779957-00000"
   ; absolute_turn = 4071
   ; turn_ref =
-      Some (Ids.Turn_ref.make ~trace_id:"trace-1780648779957-00000" ~absolute_turn:4071)
+      Ids.Turn_ref.make ~trace_id:"trace-1780648779957-00000" ~absolute_turn:4071
   ; blocks =
       [ sample_block Prompt_block_id.Persona "aaaa"
       ; sample_block Prompt_block_id.Dynamic_context "bbbb"
@@ -84,8 +87,8 @@ let sample_record () : Turn_record.t =
    input_tokens could not be read as either a cache-heavy turn or a genuinely large
    prompt. context_window denominates the ctx-fill percentage against the compaction
    ceiling, so those two situations look identical on a dashboard while calling for
-   different action. A row that omits them still decodes — legacy rows and turns where
-   the provider reported no usage carry None rather than a fabricated zero. *)
+   different action. A current provider that omits them carries None rather than a
+   fabricated zero. *)
 let test_cache_counts_round_trip_and_stay_optional () =
   let record = sample_record () in
   (match Turn_record.of_json (Turn_record.to_json record) with
@@ -95,8 +98,7 @@ let test_cache_counts_round_trip_and_stay_optional () =
        decoded.usage.cache_creation_input_tokens;
      check (option int) "cache read survives" (Some 15000)
        decoded.usage.cache_read_input_tokens);
-  (* A row written before these fields existed. *)
-  let legacy =
+  let without_cache_counts =
     match Turn_record.to_json record with
     | `Assoc fields ->
       `Assoc
@@ -106,8 +108,8 @@ let test_cache_counts_round_trip_and_stay_optional () =
            fields)
     | other -> other
   in
-  match Turn_record.of_json legacy with
-  | Error e -> failf "legacy row without cache fields failed to decode: %s" e
+  match Turn_record.of_json without_cache_counts with
+  | Error e -> failf "row without cache fields failed to decode: %s" e
   | Ok decoded ->
     check (option int) "absent cache creation decodes as None" None
       decoded.usage.cache_creation_input_tokens;
@@ -130,10 +132,7 @@ let test_codec_roundtrip () =
     check string "trace_id" record.trace_id decoded.trace_id;
     check int "absolute_turn" record.absolute_turn decoded.absolute_turn;
     check bool "turn_ref preserved" true
-      (match record.turn_ref, decoded.turn_ref with
-       | Some a, Some b -> Ids.Turn_ref.equal a b
-       | None, None -> true
-       | Some _, None | None, Some _ -> false);
+      (Ids.Turn_ref.equal record.turn_ref decoded.turn_ref);
     check int "blocks count" 3 (List.length decoded.blocks);
     check bool "blocks preserved in order" true
       (List.for_all2
@@ -228,7 +227,6 @@ let test_codec_optional_fields_absent () =
         ; cache_creation_input_tokens = None
         ; cache_read_input_tokens = None
         }
-    ; turn_ref = None
     }
   in
   let json = Turn_record.to_json record in
@@ -291,8 +289,7 @@ let test_codec_optional_fields_absent () =
       decoded.sampling.temperature;
     check (option (float 0.0001)) "top_p absent" None decoded.sampling.top_p;
     check (option int) "max_tokens absent" None decoded.sampling.max_tokens;
-    check (option int) "input_tokens absent" None decoded.usage.input_tokens;
-    check bool "turn_ref absent" true (decoded.turn_ref = None)
+    check (option int) "input_tokens absent" None decoded.usage.input_tokens
 
 let test_codec_rejects_malformed () =
   (match Turn_record.of_json (`String "not a record") with
@@ -317,7 +314,11 @@ let test_codec_requires_current_observation_fields () =
       | Error message ->
         check bool "missing current field is explicit" true
           (Astring.String.is_infix ~affix:field message))
-    [ "input_components"; "request_runtime_profile"; "request_body_bytes" ]
+    [ "turn_ref"
+    ; "input_components"
+    ; "request_runtime_profile"
+    ; "request_body_bytes"
+    ]
 
 let test_codec_rejects_partial_or_invalid_request_wire_observation () =
   let replace fields =
@@ -385,20 +386,41 @@ let test_codec_rejects_input_component_extra_field () =
     check bool "extra field is explicit" true
       (Astring.String.is_infix ~affix:"fields are not exact" message)
 
-let test_codec_unknown_block_decodes_as_other () =
+let test_codec_rejects_unknown_block () =
   let json =
-    Turn_record.to_json
-      { (sample_record ()) with
-        blocks = [ sample_block (Prompt_block_id.Other "future_block") "dddd" ]
-      }
+    match Turn_record.to_json (sample_record ()) with
+    | `Assoc fields ->
+      `Assoc
+        (( "blocks"
+         , `List
+             [ `Assoc
+                 [ "block", `String "future_block"
+                 ; "bytes", `Int 4
+                 ; "digest", `String "dddd"
+                 ]
+             ] )
+         :: List.remove_assoc "blocks" fields)
+    | other -> other
   in
   match Turn_record.of_json json with
-  | Error e -> failf "decode failed: %s" e
-  | Ok decoded ->
-    (match decoded.blocks with
-     | [ { block; _ } ] ->
-       check block_id "forward-open block id" (Prompt_block_id.Other "future_block") block
-     | _ -> fail "expected exactly one block")
+  | Ok _ -> fail "decoded an unknown block"
+  | Error message ->
+    check bool "unknown block is explicit" true
+      (Astring.String.is_infix ~affix:"unknown prompt block id" message)
+
+let test_codec_rejects_mismatched_turn_ref () =
+  let record =
+    { (sample_record ()) with
+      turn_ref = Ids.Turn_ref.make ~trace_id:"different-trace" ~absolute_turn:4071
+    }
+  in
+  match Turn_record.of_json (Turn_record.to_json record) with
+  | Ok _ -> fail "decoded a mismatched turn_ref"
+  | Error message ->
+    check bool "turn_ref mismatch is explicit" true
+      (Astring.String.is_infix
+         ~affix:"turn_ref does not match trace_id and absolute_turn"
+         message)
 
 (* ── Block diff (RFC §5: exact added/removed set) ─────── *)
 
@@ -409,7 +431,7 @@ let test_diff_added_removed_changed () =
     record_with_blocks
       [ sample_block Prompt_block_id.Persona "aaaa"
       ; sample_block Prompt_block_id.Dynamic_context "bbbb"
-      ; sample_block Prompt_block_id.Retry_nudge "rrrr"
+      ; sample_block Prompt_block_id.Temporal_summary "rrrr"
       ]
   in
   let next =
@@ -423,8 +445,8 @@ let test_diff_added_removed_changed () =
   check (list block_id) "added = exactly memory_os_recall"
     [ Prompt_block_id.Memory_os_recall ]
     (List.map (fun (b : Turn_record.prompt_block) -> b.block) diff.added);
-  check (list block_id) "removed = exactly retry_nudge"
-    [ Prompt_block_id.Retry_nudge ]
+  check (list block_id) "removed = exactly temporal_summary"
+    [ Prompt_block_id.Temporal_summary ]
     (List.map (fun (b : Turn_record.prompt_block) -> b.block) diff.removed);
   check (list block_id) "changed = exactly dynamic_context"
     [ Prompt_block_id.Dynamic_context ]
@@ -444,22 +466,25 @@ let test_entries_with_diffs_same_trace_only () =
     { (record_with_blocks [ sample_block Prompt_block_id.Persona "aaaa" ]) with
       trace_id = "trace-A"
     ; absolute_turn = 1
+    ; turn_ref = Ids.Turn_ref.make ~trace_id:"trace-A" ~absolute_turn:1
     }
   in
   let r2 =
     { (record_with_blocks
          [ sample_block Prompt_block_id.Persona "aaaa"
-         ; sample_block Prompt_block_id.Retry_nudge "rrrr"
+         ; sample_block Prompt_block_id.Temporal_summary "rrrr"
          ])
       with
       trace_id = "trace-A"
     ; absolute_turn = 2
+    ; turn_ref = Ids.Turn_ref.make ~trace_id:"trace-A" ~absolute_turn:2
     }
   in
   let r3 =
     { (record_with_blocks [ sample_block Prompt_block_id.Persona "zzzz" ]) with
       trace_id = "trace-B" (* new generation: diff must be None *)
     ; absolute_turn = 3
+    ; turn_ref = Ids.Turn_ref.make ~trace_id:"trace-B" ~absolute_turn:3
     }
   in
   match Turn_record.entries_with_diffs [ r1; r2; r3 ] with
@@ -467,8 +492,8 @@ let test_entries_with_diffs_same_trace_only () =
     check bool "first record has no predecessor" true (first = None);
     (match second with
      | Some diff ->
-       check (list block_id) "same-trace diff sees the added nudge"
-         [ Prompt_block_id.Retry_nudge ]
+       check (list block_id) "same-trace diff sees the added summary"
+         [ Prompt_block_id.Temporal_summary ]
          (List.map (fun (b : Turn_record.prompt_block) -> b.block) diff.added)
      | None -> fail "expected a diff for the same-trace successor");
     check bool "trace boundary yields no diff" true (third = None)
@@ -509,7 +534,7 @@ let () =
   run "turn_record"
     [ ( "prompt_block_id"
       , [ test_case "all known constructors roundtrip" `Quick test_block_id_roundtrip
-        ; test_case "unknown maps to Other" `Quick test_block_id_unknown_maps_to_other
+        ; test_case "unknown block rejected" `Quick test_block_id_unknown_rejected
         ] )
     ; ( "codec"
       , [ test_case "roundtrip" `Quick test_codec_roundtrip
@@ -526,8 +551,10 @@ let () =
             test_codec_rejects_unknown_input_component
         ; test_case "input component extra field rejected" `Quick
             test_codec_rejects_input_component_extra_field
-        ; test_case "unknown block decodes as Other" `Quick
-            test_codec_unknown_block_decodes_as_other
+        ; test_case "unknown block rejected" `Quick
+            test_codec_rejects_unknown_block
+        ; test_case "mismatched turn_ref rejected" `Quick
+            test_codec_rejects_mismatched_turn_ref
         ] )
     ; ( "block_diff"
       , [ test_case "exact added/removed/changed sets" `Quick


### PR DESCRIPTION
## 문제

#26466 병합본에도 현재 producer가 만들지 않는 prompt block constructor와 unknown catch-all이 남아 있었고, `turn_ref`가 과거 row를 위한 optional field로 decode되고 있었습니다. 또한 provider retry 중 wire bytes와 input composition이 서로 다른 attempt에서 결합될 수 있었습니다.

## 변경

- PromptBlockId를 현재 producer 4종으로 닫고 unknown wire name을 거부
- TurnRecord의 `turn_ref`를 current required derived state로 만들고 trace/turn과 exact 일치 확인
- serialized wire observation과 그 attempt의 input messages를 하나의 evidence snapshot으로 기록
- old compatibility fixture를 제거하고 current contract 회귀 테스트로 교체

## Blast radius

TurnRecord codec·writer·keeper provider-attempt 관측 경계만 변경합니다. queue/admission Gate, legacy decoder, migration, fallback, facade는 추가하지 않습니다.

## 검증

- touched OCaml parser: PASS
- `ocamlformat --check`: PASS
- `git diff --check origin/main...HEAD`: PASS
- legacy/migration/old constructor residue search: 0건
- local Dune: 미실행; exact-head PR CI를 build authority로 사용