### PR TITLE
refactor(keeper): use typed proactive outcome state

### DIFF
--- a/lib/keeper/keeper_unified_metrics_result.ml
+++ b/lib/keeper/keeper_unified_metrics_result.ml
@@ -150,10 +150,16 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
                 ^ proactive_cycle_outcome_to_string Proactive_silent
               else "unified:text_response")
            else
-             (* Clear out previous error text if this was a successful reactive cycle *)
-             if String.starts_with ~prefix:"unified:error:" rt.proactive_rt.last_reason
-             then "unified:reactive_success"
-             else rt.proactive_rt.last_reason);
+             (* A successful reactive cycle supersedes a prior typed proactive
+                error. [last_reason] remains display detail only. *)
+             match rt.proactive_rt.last_outcome with
+             | Proactive_error -> "unified:reactive_success"
+             | Proactive_never_started
+             | Proactive_unknown
+             | Proactive_silent
+             | Proactive_text_response
+             | Proactive_tool_use
+             | Proactive_mixed_response -> rt.proactive_rt.last_reason);
         last_preview =
           (if not update_proactive_rt || not is_scheduled_autonomous_cycle
            then rt.proactive_rt.last_preview

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -901,6 +901,40 @@ let () =
     ; tool_surface
     }
   in
+  let reactive_success ~last_outcome ~last_reason =
+    let proactive_rt =
+      { meta.runtime.proactive_rt with last_outcome; last_reason }
+    in
+    let prior = { meta with runtime = { meta.runtime with proactive_rt } } in
+    let observation =
+      Masc.Keeper_deliberation.empty_world_observation ~keeper_name
+    in
+    Masc.Keeper_unified_metrics.update_metrics_from_result
+      prior
+      ~latency_ms:1
+      ~observation
+      ~is_autonomous_turn:false
+      (run_result ())
+  in
+  let updated =
+    reactive_success
+      ~last_outcome:KMC.Proactive_error
+      ~last_reason:"provider failure detail without a classifier prefix"
+  in
+  check
+    "reactive success clears typed proactive error"
+    (String.equal
+       updated.runtime.proactive_rt.last_reason
+       "unified:reactive_success");
+  let error_like_reason = "unified:error:display text is not state" in
+  let updated =
+    reactive_success
+      ~last_outcome:KMC.Proactive_text_response
+      ~last_reason:error_like_reason
+  in
+  check
+    "reactive success ignores error-like reason text"
+    (String.equal updated.runtime.proactive_rt.last_reason error_like_reason);
   let stale_provider_failure =
     Masc.Keeper_registry.Provider_runtime_error
       { code = "api_error_invalid_request"


### PR DESCRIPTION
## What changed

- Replace the `last_reason` prefix classifier with an exhaustive match on the existing typed `proactive_rt.last_outcome`.
- Clear the previous proactive error detail after a successful reactive turn only when the typed outcome is `Proactive_error`.
- Add regression coverage in both directions:
  - a typed error is cleared even when its display detail has no magic prefix;
  - error-looking display text does not control state when the typed outcome is not an error.

## Why

`last_reason` is display detail, but the success path reparsed its `"unified:error:"` prefix as runtime state. The same record already carries the closed `proactive_cycle_outcome` variant, so the string comparison was a duplicate and weaker authority.

This is the first bounded removal under #25851.

## Contract

- No new Gate or admission authority.
- No new facade.
- No schema, legacy reader, compatibility field, or migration code.
- Adding a new `proactive_cycle_outcome` variant now requires an explicit compiler-checked decision in this branch.

## Validation

- `git diff --check origin/main...HEAD` — pass
- `ocamlformat --check lib/keeper/keeper_unified_metrics_result.ml test/test_keeper_terminal_reason_typed.ml` — pass
- Focused target attempted through `scripts/dune-local.sh`, but the host was under concurrent Dune load and high swap pressure; the cold compile was terminated with exit 137 before producing a test result.

Keep this PR draft and `status:do-not-merge` until exact-head GitHub Build and Test is green.
