### PR TITLE
feat(keeper): complete queue operator visibility

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -345,7 +345,7 @@ describe('Keeper chat durable receipt API', () => {
   it('fetches pending input metadata without materializing attachment bytes', async () => {
     const receiptId = 'chatq_00000000-0000-4000-8000-000000000004'
     const payload = {
-      schema: 'keeper_chat_queue.pending.v1',
+      schema: 'keeper_chat_queue.pending.v2',
       ok: true,
       keeper_name: 'keeper sangsu',
       revision: '11',
@@ -361,6 +361,13 @@ describe('Keeper chat durable receipt API', () => {
           state: { kind: 'pending' },
         },
         content: '[image attached: photo.png]',
+        source: {
+          kind: 'slack',
+          channel_id: 'channel-1',
+          user_id: 'user-1',
+          team_id: 'team-1',
+          thread_ts: '42.1',
+        },
         user_blocks: [{
           type: 'image',
           attachment_id: 'att-1',
@@ -390,6 +397,13 @@ describe('Keeper chat durable receipt API', () => {
 
     expect(result).toEqual(parseKeeperChatPendingSnapshot(payload))
     expect(result.currentWork).toEqual({ lane: 'autonomous', startedAt: 42 })
+    expect(result.pending[0]?.source).toEqual({
+      kind: 'slack',
+      channelId: 'channel-1',
+      userId: 'user-1',
+      teamId: 'team-1',
+      threadTs: '42.1',
+    })
     expect(result.pending[0]?.userBlocks).toEqual([{
       type: 'image',
       attachmentId: 'att-1',
@@ -421,6 +435,7 @@ describe('Keeper chat durable receipt API', () => {
         state: { kind: 'pending' },
       },
       content,
+      source: { kind: 'dashboard', thread_id: 'thread-1' },
       user_blocks: [],
       attachments: [],
       submitted_at: 42,
@@ -429,7 +444,7 @@ describe('Keeper chat durable receipt API', () => {
       pending: ReturnType<typeof entry>[],
       nextAfter: string | null,
     ) => ({
-      schema: 'keeper_chat_queue.pending.v1',
+      schema: 'keeper_chat_queue.pending.v2',
       ok: true,
       keeper_name: 'sangsu',
       revision: '22',
@@ -470,12 +485,17 @@ describe('Keeper chat durable receipt API', () => {
         state: { kind: 'pending' },
       },
       content: `revision ${revision}`,
+      source: {
+        kind: 'discord',
+        channel_id: 'channel-1',
+        user_id: 'user-1',
+      },
       user_blocks: [],
       attachments: [],
       submitted_at: 42,
     })
     const envelope = (revision: string, nextAfter: string | null) => ({
-      schema: 'keeper_chat_queue.pending.v1',
+      schema: 'keeper_chat_queue.pending.v2',
       ok: true,
       keeper_name: 'sangsu',
       revision,

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -759,9 +759,21 @@ export interface KeeperChatPendingAttachment {
   mimeType: string
 }
 
+export type KeeperChatPendingSource =
+  | { kind: 'dashboard'; threadId: string }
+  | { kind: 'discord'; channelId: string; userId: string }
+  | {
+      kind: 'slack'
+      channelId: string
+      userId: string
+      teamId: string | null
+      threadTs: string | null
+    }
+
 export interface KeeperChatPendingInput {
   receipt: KeeperChatReceipt
   content: string
+  source: KeeperChatPendingSource
   attachments: KeeperChatPendingAttachment[]
   userBlocks: KeeperUserInputBlock[]
   submittedAt: number
@@ -960,12 +972,51 @@ function parsePendingUserBlock(value: unknown): KeeperUserInputBlock {
   return { type, attachmentId, name, mimeType, size }
 }
 
+function parsePendingSource(value: unknown): KeeperChatPendingSource {
+  if (!isRecord(value)) {
+    throw new Error('Keeper pending source must be an object')
+  }
+  const kind = asString(value.kind, '').trim()
+  const requiredString = (field: string): string => {
+    const parsed = asString(value[field], '').trim()
+    if (!parsed) throw new Error(`Keeper pending source ${field} is missing`)
+    return parsed
+  }
+  const nullableString = (field: string): string | null => {
+    const raw = value[field]
+    if (raw === null) return null
+    const parsed = asString(raw, '').trim()
+    if (!parsed) throw new Error(`Keeper pending source ${field} is invalid`)
+    return parsed
+  }
+  switch (kind) {
+    case 'dashboard':
+      return { kind, threadId: requiredString('thread_id') }
+    case 'discord':
+      return {
+        kind,
+        channelId: requiredString('channel_id'),
+        userId: requiredString('user_id'),
+      }
+    case 'slack':
+      return {
+        kind,
+        channelId: requiredString('channel_id'),
+        userId: requiredString('user_id'),
+        teamId: nullableString('team_id'),
+        threadTs: nullableString('thread_ts'),
+      }
+    default:
+      throw new Error(`Keeper pending source has unknown kind: ${kind || '<empty>'}`)
+  }
+}
+
 export function parseKeeperChatPendingSnapshot(
   value: unknown,
 ): KeeperChatPendingSnapshot {
   if (
     !isRecord(value)
-    || value.schema !== 'keeper_chat_queue.pending.v1'
+    || value.schema !== 'keeper_chat_queue.pending.v2'
     || value.ok !== true
   ) {
     throw new Error('Keeper pending response has an unsupported schema')
@@ -1010,6 +1061,7 @@ export function parseKeeperChatPendingSnapshot(
     }
     const receipt = parseKeeperChatReceipt(raw.receipt)
     const content = asString(raw.content, '')
+    const source = parsePendingSource(raw.source)
     const submittedAt = asNumber(raw.submitted_at)
     if (
       receipt.keeperName !== keeperName
@@ -1028,7 +1080,7 @@ export function parseKeeperChatPendingSnapshot(
     if (!content.trim() && attachments.length === 0) {
       throw new Error('Keeper pending entry has no input payload')
     }
-    return { receipt, content, attachments, userBlocks, submittedAt }
+    return { receipt, content, source, attachments, userBlocks, submittedAt }
   })
   if (pending.length > totalPending) {
     throw new Error('Keeper pending page exceeds its total count')

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -7,21 +7,25 @@ const {
   bootKeeper,
   shutdownKeeper,
   fetchKeeperChatPending,
+  fetchKeeperChatReceipt,
   fetchKeeperEventQueuePending,
   cancelKeeperChatPendingReceipt,
   editKeeperChatPendingReceipt,
   moveKeeperChatPendingReceiptToEnd,
   operateKeeperEventQueue,
+  resolveKeeperChatRecovery,
   KeeperEventQueueOperationError,
 } = vi.hoisted(() => ({
   bootKeeper: vi.fn(),
   shutdownKeeper: vi.fn(),
   fetchKeeperChatPending: vi.fn(),
+  fetchKeeperChatReceipt: vi.fn(),
   fetchKeeperEventQueuePending: vi.fn(),
   cancelKeeperChatPendingReceipt: vi.fn(),
   editKeeperChatPendingReceipt: vi.fn(),
   moveKeeperChatPendingReceiptToEnd: vi.fn(),
   operateKeeperEventQueue: vi.fn(),
+  resolveKeeperChatRecovery: vi.fn(),
   KeeperEventQueueOperationError: class KeeperEventQueueOperationError extends Error {
     readonly operation: {
       action: 'cancel' | 'transfer'
@@ -125,11 +129,13 @@ vi.mock('../api/keeper', () => ({
   bootKeeper,
   shutdownKeeper,
   fetchKeeperChatPending,
+  fetchKeeperChatReceipt,
   fetchKeeperEventQueuePending,
   cancelKeeperChatPendingReceipt,
   editKeeperChatPendingReceipt,
   moveKeeperChatPendingReceiptToEnd,
   operateKeeperEventQueue,
+  resolveKeeperChatRecovery,
   KeeperEventQueueOperationError,
 }))
 
@@ -266,11 +272,13 @@ describe('KeeperConversationPanel', () => {
     vi.mocked(isKeeperThreadMessageSendInFlight).mockReset()
     vi.mocked(isKeeperThreadMessageSendInFlight).mockReturnValue(false)
     fetchKeeperChatPending.mockReset()
+    fetchKeeperChatReceipt.mockReset()
     fetchKeeperEventQueuePending.mockReset()
     cancelKeeperChatPendingReceipt.mockReset()
     editKeeperChatPendingReceipt.mockReset()
     moveKeeperChatPendingReceiptToEnd.mockReset()
     operateKeeperEventQueue.mockReset()
+    resolveKeeperChatRecovery.mockReset()
   })
 
   afterEach(() => {
@@ -1004,6 +1012,7 @@ describe('KeeperConversationPanel', () => {
           state: { kind: 'pending' },
         },
         content: 'durable queued operator request',
+        source: { kind: 'dashboard', threadId: 'operator-thread-22' },
         userBlocks: [],
         attachments: [],
         submittedAt: 42,
@@ -1065,11 +1074,181 @@ describe('KeeperConversationPanel', () => {
       expect(panel?.getAttribute('role')).toBe('dialog')
       expect(panel?.textContent).toContain('durable queued operator request')
       expect(panel?.textContent).toContain(receiptId)
+      expect(panel?.textContent).toContain('dashboard · thread operator-thread-22')
       expect(panel?.textContent).toContain('board-post-9')
       expect(panel?.textContent).toContain('수정')
       expect(panel?.textContent).toContain('맨 뒤로')
       expect(panel?.textContent).toContain('이관')
       expect(panel?.textContent).toContain('취소')
+    })
+  })
+
+  it('shows exact inflight and recovery evidence and resolves recovery with a fresh receipt fence', async () => {
+    const inflightReceiptId = 'chatq_00000000-0000-4000-8000-000000000031'
+    const recoveryReceiptId = 'chatq_00000000-0000-4000-8000-000000000032'
+    fetchKeeperChatPending.mockResolvedValue({
+      keeperName: 'sangsu',
+      revision: '31',
+      currentWork: { lane: 'interactive', startedAt: 1_785_000_000 },
+      totalPending: 0,
+      nextAfter: null,
+      pending: [],
+    })
+    fetchKeeperEventQueuePending.mockResolvedValue({
+      keeperName: 'sangsu',
+      revision: '31',
+      totalPending: 0,
+      nextAfter: null,
+      pending: [],
+    })
+    fetchKeeperChatReceipt.mockResolvedValue({
+      keeperName: 'sangsu',
+      receiptId: recoveryReceiptId,
+      revision: '32',
+      state: {
+        kind: 'recovery_required',
+        leaseId: 'lease-recovery-32',
+        startedAt: 1_784_999_000,
+        dispatchable: false,
+      },
+    })
+    resolveKeeperChatRecovery.mockResolvedValue({
+      decision: 'requeue_unconfirmed',
+      receipt: {
+        keeperName: 'sangsu',
+        receiptId: recoveryReceiptId,
+        revision: '33',
+        state: { kind: 'pending' },
+      },
+      audit: { recorded: true },
+    })
+    mockedToolsData.value = {
+      keeper_waiting_inventory: {
+        keepers: [{
+          keeper_name: 'sangsu',
+          state: 'busy',
+          waiting_count: 2,
+          sources: {
+            chat_queue_inflight: 1,
+            chat_queue_recovery_required: 1,
+          },
+          current_execution: {
+            turn_phase: 'executing_tools',
+            decision: { stage: 'tool_loop' },
+            runtime: { state: 'running' },
+            latest_tool: { name: 'keeper_board_list', used_at: 1_785_000_010 },
+            run_state: {
+              kind: 'running',
+              wake_kind: 'interactive',
+              stimulus_kinds: ['chat'],
+              active_tool_count: 1,
+            },
+            live_turn: {
+              turn_id: 77,
+              started_at: 1_785_000_000,
+              last_progress_at: 1_785_000_010,
+              last_progress_kind: 'tool_finished',
+              selected_model: 'operator-model',
+              active_tool_count: 1,
+            },
+          },
+          waiting_on: [
+            {
+              source: 'chat_queue_inflight',
+              waiting_on: 'dashboard',
+              next_action: 'keeper_chat_turn_terminal_receipt',
+              detail: {
+                queue_index: 0,
+                receipt_id: inflightReceiptId,
+                message_source: { kind: 'dashboard', thread_id: 'thread-31' },
+                content_length: 23,
+                lifecycle: {
+                  state: 'inflight',
+                  lease_id: 'lease-inflight-31',
+                  started_at: 1_785_000_000,
+                },
+              },
+            },
+            {
+              source: 'chat_queue_recovery_required',
+              waiting_on: 'slack',
+              next_action: 'resolve_keeper_chat_queue_recovery',
+              detail: {
+                queue_index: 0,
+                receipt_id: recoveryReceiptId,
+                message_source: {
+                  kind: 'slack',
+                  channel_id: 'channel-32',
+                  user_id: 'user-32',
+                },
+                content_length: 17,
+                lifecycle: {
+                  state: 'recovery_required',
+                  lease_id: 'lease-recovery-32',
+                  started_at: 1_784_999_000,
+                  dispatchable: false,
+                },
+              },
+            },
+          ],
+        }],
+      },
+    }
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="Say something" layout="primary" />`,
+      container,
+    )
+    fireEvent.click(await waitFor(() => {
+      const button = container.querySelector('[data-open-keeper-queue-control]')
+      expect(button).not.toBeNull()
+      return button as HTMLElement
+    }))
+
+    const panel = await waitFor(() => {
+      const node = container.querySelector('[data-keeper-queue-control-panel]')
+      expect(node?.textContent).toContain('executing_tools')
+      expect(node?.textContent).toContain('tool_loop')
+      expect(node?.textContent).toContain('operator-model')
+      expect(node?.textContent).toContain('keeper_board_list')
+      expect(node?.querySelector(
+        `[data-operator-chat-inflight="${inflightReceiptId}"]`,
+      )).not.toBeNull()
+      expect(node?.querySelector(
+        `[data-operator-chat-recovery="${recoveryReceiptId}"]`,
+      )).not.toBeNull()
+      expect(node?.textContent).toContain('자동 재실행이 차단됐습니다')
+      return node as HTMLElement
+    })
+
+    const recovery = panel.querySelector(
+      `[data-operator-chat-recovery="${recoveryReceiptId}"]`,
+    )
+    const requeue = [...(recovery?.querySelectorAll('button') ?? [])]
+      .find(button => button.textContent === '재대기')
+    expect(requeue).not.toBeUndefined()
+    fireEvent.click(requeue as HTMLElement)
+
+    await waitFor(() => {
+      expect(fetchKeeperChatReceipt).toHaveBeenCalledWith(
+        'sangsu',
+        recoveryReceiptId,
+      )
+      expect(resolveKeeperChatRecovery).toHaveBeenCalledWith(
+        'sangsu',
+        recoveryReceiptId,
+        '32',
+        'lease-recovery-32',
+        { kind: 'requeue_unconfirmed' },
+      )
+    })
+
+    const interrupt = [...panel.querySelectorAll('button')]
+      .find(button => button.textContent === '현재 턴 중단')
+    expect(interrupt).not.toBeUndefined()
+    fireEvent.click(interrupt as HTMLElement)
+    await waitFor(() => {
+      expect(interruptKeeperTurn).toHaveBeenCalledWith('sangsu')
     })
   })
 

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -4,7 +4,7 @@ import { Markdown } from "./common/markdown"
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { keeperDirectChatAccess } from '../lib/keeper-chat-access'
 import { isInFlightDelivery } from '../lib/keeper-delivery'
-import { relativeTime, NO_TIME_INFO } from '../lib/format-time'
+import { formatTimeAgo, relativeTime, NO_TIME_INFO } from '../lib/format-time'
 import { isAbortError } from '../lib/async-state'
 import type {
   ChatBlock,
@@ -91,12 +91,16 @@ import { chatShowInternal, chatShowMetadata } from '../lib/chat-view-prefs'
 import {
   cancelKeeperChatPendingReceipt,
   editKeeperChatPendingReceipt,
+  fetchKeeperChatReceipt,
   fetchKeeperEventQueuePending,
   fetchKeeperChatPending,
   KeeperEventQueueOperationError,
   moveKeeperChatPendingReceiptToEnd,
   operateKeeperEventQueue,
+  resolveKeeperChatRecovery,
   type DashboardKeeperWaitingKeeper,
+  type DashboardKeeperWaitingRow,
+  type KeeperChatPendingSource,
   type KeeperChatPendingSnapshot,
   type KeeperEventQueueOperatorAction,
   type KeeperEventQueuePendingSnapshot,
@@ -561,6 +565,74 @@ function BusyToolbar({
   `
 }
 
+function pendingSourceLabel(source: KeeperChatPendingSource): string {
+  switch (source.kind) {
+    case 'dashboard':
+      return `dashboard · thread ${source.threadId}`
+    case 'discord':
+      return `discord · user ${source.userId} · channel ${source.channelId}`
+    case 'slack':
+      return `slack · user ${source.userId} · channel ${source.channelId}`
+  }
+}
+
+type OperatorChatReceiptEvidence = {
+  receiptId: string
+  queueIndex: number | null
+  source: 'chat_queue_inflight' | 'chat_queue_recovery_required'
+  messageSource: string | null
+  contentLength: number | null
+  startedAt: number | null
+}
+
+function detailRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}
+
+function operatorChatReceiptEvidence(
+  row: DashboardKeeperWaitingRow,
+): OperatorChatReceiptEvidence | null {
+  if (
+    row.source !== 'chat_queue_inflight'
+    && row.source !== 'chat_queue_recovery_required'
+  ) return null
+  const detail = detailRecord(row.detail)
+  const lifecycle = detailRecord(detail?.lifecycle)
+  const receiptId = typeof detail?.receipt_id === 'string'
+    ? detail.receipt_id.trim()
+    : ''
+  if (!receiptId) return null
+  const queueIndex = typeof detail?.queue_index === 'number'
+    && Number.isSafeInteger(detail.queue_index)
+    && detail.queue_index >= 0
+    ? detail.queue_index
+    : null
+  const messageSourceRecord = detailRecord(detail?.message_source)
+  const messageSource = typeof messageSourceRecord?.kind === 'string'
+    ? messageSourceRecord.kind.trim() || null
+    : null
+  const contentLength = typeof detail?.content_length === 'number'
+    && Number.isSafeInteger(detail.content_length)
+    && detail.content_length >= 0
+    ? detail.content_length
+    : null
+  const startedAt = typeof lifecycle?.started_at === 'number'
+    && Number.isFinite(lifecycle.started_at)
+    && lifecycle.started_at >= 0
+    ? lifecycle.started_at
+    : null
+  return {
+    receiptId,
+    queueIndex,
+    source: row.source,
+    messageSource,
+    contentLength,
+    startedAt,
+  }
+}
+
 function ServerQueueStatus({
   busy,
   pendingCount,
@@ -656,11 +728,22 @@ function ServerQueueStatus({
           ? html`
               현재 실행: turn <code>${currentExecution.live_turn.turn_id ?? '-'}</code>
               · phase <code>${currentExecution.turn_phase ?? '-'}</code>
+              ${currentExecution.decision?.stage
+                ? html` · decision <code>${currentExecution.decision.stage}</code>`
+                : null}
+              ${currentExecution.runtime?.state
+                ? html` · runtime <code>${currentExecution.runtime.state}</code>`
+                : null}
               · model <code>${currentExecution.live_turn.selected_model ?? '선택 전'}</code>
               · wake <code>${currentExecution.run_state?.wake_kind ?? 'unknown'}${currentExecution.run_state?.stimulus_kinds?.length ? `:${currentExecution.run_state.stimulus_kinds.join(',')}` : ''}</code>
               · active tools <code>${currentExecution.live_turn.active_tool_count ?? 0}</code>
               · latest tool <code>${currentExecution.latest_tool?.name ?? 'none'}</code>
-              · last progress <code>${currentExecution.live_turn.last_progress_kind ?? 'unknown'}</code>
+              · 시작 <code>${currentExecution.live_turn.started_at === undefined
+                ? 'unknown'
+                : formatTimeAgo(currentExecution.live_turn.started_at)}</code>
+              · 최근 진행 <code>${currentExecution.live_turn.last_progress_kind ?? 'unknown'} / ${currentExecution.live_turn.last_progress_at === undefined
+                ? 'unknown'
+                : formatTimeAgo(currentExecution.live_turn.last_progress_at)}</code>
             `
           : null}
       </div>
@@ -705,17 +788,30 @@ function KeeperQueueControlPanel({
     void load()
   }, [keeperName])
   const eventRows = eventSnapshot?.pending ?? []
+  const activeChatRows = (keeper?.waiting_on ?? [])
+    .map(operatorChatReceiptEvidence)
+    .filter((row): row is OperatorChatReceiptEvidence => row !== null)
+  const inflightRows = activeChatRows.filter(row => row.source === 'chat_queue_inflight')
+  const recoveryRows = activeChatRows.filter(
+    row => row.source === 'chat_queue_recovery_required',
+  )
+  const currentExecution = keeper?.current_execution ?? null
+  const currentWork = snapshot?.currentWork ?? null
   const mutate = async (key: string, operation: () => Promise<unknown>) => {
     setPendingAction(key)
     try {
       await operation()
-      await reconcileKeeperChatReceipts(keeperName)
-      await load()
+      await Promise.all([
+        reconcileKeeperChatReceipts(keeperName),
+        load(),
+        loadTools(),
+      ])
     } catch (cause) {
       const message = cause instanceof Error ? cause.message : String(cause)
       await Promise.allSettled([
         reconcileKeeperChatReceipts(keeperName),
         load(false),
+        loadTools(),
       ])
       setError(message)
       showToast(message, 'error')
@@ -758,6 +854,38 @@ function KeeperQueueControlPanel({
       setPendingAction(null)
     }
   }
+  const resolveRecovery = async (
+    row: OperatorChatReceiptEvidence,
+    decision:
+      | { kind: 'requeue_unconfirmed' }
+      | {
+          kind: 'cancel_unconfirmed'
+          detail: string
+          outcomeRef: null
+        },
+  ) => {
+    await mutate(`recovery:${row.receiptId}`, async () => {
+      const observed = await fetchKeeperChatReceipt(keeperName, row.receiptId)
+      if (observed.state.kind !== 'recovery_required') {
+        throw new Error(
+          `receipt ${row.receiptId} is ${observed.state.kind}, not recovery_required`,
+        )
+      }
+      const result = await resolveKeeperChatRecovery(
+        keeperName,
+        row.receiptId,
+        observed.revision,
+        observed.state.leaseId,
+        decision,
+      )
+      if (!result.audit.recorded) {
+        showToast(
+          `복구 결정은 반영됐지만 audit 기록에 실패했습니다: ${result.audit.error}`,
+          'warning',
+        )
+      }
+    })
+  }
   return html`
     <section
       class="fixed inset-y-0 right-0 z-[120] grid h-dvh w-[min(48rem,100vw)] content-start gap-3 overflow-y-auto border-l border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4 shadow-2xl"
@@ -775,6 +903,89 @@ function KeeperQueueControlPanel({
       ${error
         ? html`<div class="rounded-[var(--r-0)] bg-[var(--danger-10)] p-2 text-2xs text-[var(--color-status-err)]">${error}</div>`
         : null}
+      <div
+        class="grid gap-2 rounded-[var(--r-0)] border border-[var(--color-border-subtle)] p-2"
+        data-operator-current-execution
+      >
+        <div class="flex flex-wrap items-center justify-between gap-2">
+          <div class="text-xs font-semibold text-[var(--color-fg-secondary)]">현재 실행</div>
+          ${(currentExecution?.live_turn || currentWork)
+            ? html`
+                <button
+                  type="button"
+                  disabled=${pendingAction === 'interrupt-current-turn'}
+                  class="rounded-[var(--r-0)] border border-[var(--danger-20)] bg-[var(--danger-10)] px-2 py-1 text-2xs text-[var(--color-status-err)] disabled:opacity-50"
+                  onClick=${() => void mutate('interrupt-current-turn', async () => {
+                    const cancelled = await interruptKeeperTurn(keeperName)
+                    showToast(
+                      cancelled ? '현재 턴을 중단했습니다' : '중단할 실행 중인 턴이 없습니다',
+                      cancelled ? 'success' : 'warning',
+                    )
+                  })}
+                >현재 턴 중단</button>
+              `
+            : null}
+        </div>
+        ${currentExecution?.live_turn
+          ? html`
+              <div class="grid gap-1 text-2xs text-[var(--color-fg-secondary)]">
+                <div>
+                  turn <code>${currentExecution.live_turn.turn_id ?? '-'}</code>
+                  · phase <code>${currentExecution.turn_phase ?? '-'}</code>
+                  · decision <code>${currentExecution.decision?.stage ?? '-'}</code>
+                  · runtime <code>${currentExecution.runtime?.state ?? '-'}</code>
+                </div>
+                <div>
+                  model <code>${currentExecution.live_turn.selected_model ?? '선택 전'}</code>
+                  · wake <code>${currentExecution.run_state?.wake_kind ?? 'unknown'}${currentExecution.run_state?.stimulus_kinds?.length
+                    ? `:${currentExecution.run_state.stimulus_kinds.join(',')}`
+                    : ''}</code>
+                  · active tools <code>${currentExecution.live_turn.active_tool_count ?? 0}</code>
+                </div>
+                <div>
+                  시작 <code>${currentExecution.live_turn.started_at === undefined
+                    ? 'unknown'
+                    : formatTimeAgo(currentExecution.live_turn.started_at)}</code>
+                  · 최근 진행 <code>${currentExecution.live_turn.last_progress_kind ?? 'unknown'} / ${currentExecution.live_turn.last_progress_at === undefined
+                    ? 'unknown'
+                    : formatTimeAgo(currentExecution.live_turn.last_progress_at)}</code>
+                  · latest tool <code>${currentExecution.latest_tool?.name ?? 'none'}</code>
+                </div>
+              </div>
+            `
+          : currentWork
+            ? html`
+                <div class="text-2xs text-[var(--color-fg-secondary)]">
+                  lane <code>${currentWork.lane}</code>
+                  · 시작 <code>${formatTimeAgo(currentWork.startedAt)}</code>
+                  · live turn 상세 투영은 아직 없습니다.
+                </div>
+              `
+            : html`<div class="text-2xs text-[var(--color-fg-muted)]">현재 실행 중인 턴이 없습니다.</div>`}
+        ${inflightRows.map(row => html`
+          <div
+            class="grid gap-1 border-t border-[var(--color-border-subtle)] pt-2 text-2xs text-[var(--color-fg-muted)]"
+            data-operator-chat-inflight=${row.receiptId}
+          >
+            <div class="break-all font-mono text-[var(--color-fg-secondary)]">
+              ${row.receiptId}
+            </div>
+            <div>
+              ${row.queueIndex === null ? '순서 unknown' : `처리 슬롯 #${row.queueIndex + 1}`}
+              · source ${row.messageSource ?? 'unknown'}
+              · content ${row.contentLength ?? 'unknown'} chars
+              · 시작 ${row.startedAt === null ? 'unknown' : formatTimeAgo(row.startedAt)}
+            </div>
+          </div>
+        `)}
+        ${(keeper?.sources?.chat_queue_inflight ?? 0) > inflightRows.length
+          ? html`
+              <div class="text-2xs text-[var(--color-status-warn)]">
+                inflight ${(keeper?.sources?.chat_queue_inflight ?? 0) - inflightRows.length}건의 행 상세가 서버 projection에서 생략됐습니다.
+              </div>
+            `
+          : null}
+      </div>
       <div class="grid gap-2">
         <div class="text-xs font-semibold text-[var(--color-fg-secondary)]">
           채팅 대기 ${snapshot?.pending.length ?? keeper?.sources?.chat_queue_pending ?? 0}
@@ -787,6 +998,9 @@ function KeeperQueueControlPanel({
               <div class="flex flex-wrap items-center justify-between gap-2">
                 <span class="font-mono text-2xs text-[var(--color-fg-muted)]">#${index + 1} · ${key}</span>
                 <span class="text-2xs text-[var(--color-fg-muted)]">${new Date(item.submittedAt * 1000).toLocaleString()}</span>
+              </div>
+              <div class="break-all text-2xs text-[var(--color-fg-muted)]" data-operator-chat-source>
+                ${pendingSourceLabel(item.source)}
               </div>
               <div class="whitespace-pre-wrap break-words text-xs text-[var(--color-fg-primary)]">${item.content}</div>
               <div class="flex flex-wrap gap-1.5">
@@ -827,6 +1041,73 @@ function KeeperQueueControlPanel({
         })}
       </div>
       <div class="grid gap-2 border-t border-[var(--color-border-subtle)] pt-3">
+        <div class="text-xs font-semibold text-[var(--color-fg-secondary)]">
+          배송 복구 확인 필요 ${keeper?.sources?.chat_queue_recovery_required ?? recoveryRows.length}
+        </div>
+        ${recoveryRows.map(row => {
+          const key = `recovery:${row.receiptId}`
+          const busy = pendingAction === key
+          return html`
+            <div
+              class="grid gap-1 rounded-[var(--r-0)] border border-[var(--danger-20)] bg-[var(--danger-10)] p-2"
+              data-operator-chat-recovery=${row.receiptId}
+            >
+              <div class="break-all font-mono text-2xs text-[var(--color-status-err)]">
+                ${row.receiptId}
+              </div>
+              <div class="text-2xs text-[var(--color-fg-secondary)]">
+                이전 배송 결과가 확인되지 않아 자동 재실행이 차단됐습니다.
+                ${row.startedAt === null ? '' : ` · 원래 실행 시작 ${formatTimeAgo(row.startedAt)}`}
+              </div>
+              <div class="text-3xs text-[var(--color-fg-muted)]">
+                ${row.queueIndex === null ? 'queue index unknown' : `queue index ${row.queueIndex}`}
+                · source ${row.messageSource ?? 'unknown'}
+                · content ${row.contentLength ?? 'unknown'} chars
+              </div>
+              <div class="flex flex-wrap gap-1.5">
+                <button
+                  type="button"
+                  disabled=${busy}
+                  class="rounded-[var(--r-0)] border border-[var(--color-border-default)] px-2 py-1 text-2xs disabled:opacity-50"
+                  onClick=${() => void resolveRecovery(row, {
+                    kind: 'requeue_unconfirmed',
+                  })}
+                >재대기</button>
+                <button
+                  type="button"
+                  disabled=${busy}
+                  class="rounded-[var(--r-0)] border border-[var(--danger-20)] px-2 py-1 text-2xs text-[var(--color-status-err)] disabled:opacity-50"
+                  onClick=${() => {
+                    const detail = window.prompt('미확인 배송을 취소하는 이유를 입력하세요.')
+                    if (detail === null) return
+                    const trimmed = detail.trim()
+                    if (!trimmed) {
+                      showToast('취소 이유를 입력해야 합니다.', 'warning')
+                      return
+                    }
+                    void resolveRecovery(row, {
+                      kind: 'cancel_unconfirmed',
+                      detail: trimmed,
+                      outcomeRef: null,
+                    })
+                  }}
+                >미확인 배송 취소</button>
+              </div>
+            </div>
+          `
+        })}
+        ${(keeper?.sources?.chat_queue_recovery_required ?? 0) > recoveryRows.length
+          ? html`
+              <div class="text-2xs text-[var(--color-status-warn)]">
+                복구 필요 ${(keeper?.sources?.chat_queue_recovery_required ?? 0) - recoveryRows.length}건의 행 상세가 서버 projection에서 생략됐습니다.
+              </div>
+            `
+          : null}
+        ${recoveryRows.length === 0
+          ? html`<div class="text-2xs text-[var(--color-fg-muted)]">복구 결정을 기다리는 receipt가 없습니다.</div>`
+          : null}
+      </div>
+      <div class="grid gap-2 border-t border-[var(--color-border-subtle)] pt-3">
         <div class="text-xs font-semibold text-[var(--color-fg-secondary)]">자율 이벤트 대기 ${eventSnapshot?.totalPending ?? 0}</div>
         ${eventRecoveries.map(recovery => {
           const operationId = recovery.operation.operationId
@@ -857,7 +1138,13 @@ function KeeperQueueControlPanel({
           return html`
             <div class="grid gap-1 rounded-[var(--r-0)] border border-[var(--color-border-subtle)] p-2" data-operator-event-row>
               <div class="font-mono text-2xs text-[var(--color-fg-muted)]">#${item.queueIndex + 1} · ${item.postId}</div>
-              <div class="text-2xs text-[var(--color-fg-secondary)]">${item.payloadKind} · ${item.urgency} · ${new Date(item.arrivedAt * 1000).toLocaleString()}</div>
+              <div class="text-2xs text-[var(--color-fg-secondary)]">
+                wake reason ${item.payloadKind} · urgency ${item.urgency}
+                · 도착 ${formatTimeAgo(item.arrivedAt)} (${new Date(item.arrivedAt * 1000).toLocaleString()})
+              </div>
+              <div class="break-all font-mono text-3xs text-[var(--color-fg-muted)]">
+                source ref ${item.sourceRef}
+              </div>
               <div class="flex flex-wrap gap-1.5">
                 ${(['immediate', 'normal', 'low'] as const).map(urgency => html`
                   <button

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -19,6 +19,28 @@ let keeper_suffix_catchup_judge = "/catchup-judge"
 let keeper_chat_receipt_state_json = Keeper_chat_receipt_projection.state_json
 let keeper_chat_receipt_json = Keeper_chat_receipt_projection.receipt_json
 
+let keeper_chat_message_source_json = function
+  | Keeper_chat_queue.Dashboard { thread_id } ->
+    `Assoc
+      [ "kind", `String "dashboard"
+      ; "thread_id", `String thread_id
+      ]
+  | Keeper_chat_queue.Discord { channel_id; user_id } ->
+    `Assoc
+      [ "kind", `String "discord"
+      ; "channel_id", `String channel_id
+      ; "user_id", `String user_id
+      ]
+  | Keeper_chat_queue.Slack { channel_id; user_id; team_id; thread_ts; _ } ->
+    `Assoc
+      [ "kind", `String "slack"
+      ; "channel_id", `String channel_id
+      ; "user_id", `String user_id
+      ; "team_id", Json_util.string_opt_to_json team_id
+      ; "thread_ts", Json_util.string_opt_to_json thread_ts
+      ]
+;;
+
 let cache_key_string_segment value =
   Printf.sprintf "s%d:%s" (String.length value) value
 ;;

--- a/lib/server/server_dashboard_http_keeper_api_types.mli
+++ b/lib/server/server_dashboard_http_keeper_api_types.mli
@@ -33,6 +33,11 @@ val keeper_chat_receipt_json :
   Keeper_chat_queue.receipt_view ->
   Yojson.Safe.t
 
+val keeper_chat_message_source_json :
+  Keeper_chat_queue.message_source -> Yojson.Safe.t
+(** Exact provenance metadata for an operator-visible durable chat input.
+    Message content remains on the queue-specific authenticated surface. *)
+
 (** {1 Dashboard cache keys} *)
 
 val cache_key_string_segment : string -> string

--- a/lib/server/server_dashboard_http_keeper_chat_pending.ml
+++ b/lib/server/server_dashboard_http_keeper_chat_pending.ml
@@ -7,7 +7,7 @@ let operator_permission = Masc_domain.CanAdmin
 let keeper_api_prefix = "/api/v1/keepers/"
 let request_schema = "keeper_chat_queue.pending_cancel.request.v1"
 let cancel_result_schema = "keeper_chat_queue.pending_cancel.result.v1"
-let pending_result_schema = "keeper_chat_queue.pending.v1"
+let pending_result_schema = "keeper_chat_queue.pending.v2"
 let edit_request_schema = "keeper_chat_queue.pending_edit.request.v1"
 let move_request_schema = "keeper_chat_queue.pending_move_to_end.request.v1"
 let mutation_result_schema = "keeper_chat_queue.pending_mutation.result.v1"
@@ -100,6 +100,9 @@ let pending_receipt_json ~keeper_name ~revision
           ~revision
           { Keeper_chat_queue.receipt_id; state } )
     ; "content", `String message.content
+    ; ( "source"
+      , Server_dashboard_http_keeper_api_types.keeper_chat_message_source_json
+          message.source )
     ; "user_blocks", Keeper_multimodal_input.user_blocks_to_yojson message.user_blocks
     ; "attachments", `List (List.map pending_attachment_json message.attachments)
     ; "submitted_at", `Float message.timestamp

--- a/lib/server_keeper_waiting_inventory.ml
+++ b/lib/server_keeper_waiting_inventory.ml
@@ -250,28 +250,6 @@ let chat_queue_source_label = function
   | Keeper_chat_queue.Slack _ -> "slack"
 ;;
 
-let chat_queue_source_json = function
-  | Keeper_chat_queue.Dashboard { thread_id } ->
-    `Assoc
-      [ "kind", `String "dashboard"
-      ; "thread_id", `String thread_id
-      ]
-  | Keeper_chat_queue.Discord { channel_id; user_id } ->
-    `Assoc
-      [ "kind", `String "discord"
-      ; "channel_id", `String channel_id
-      ; "user_id", `String user_id
-      ]
-  | Keeper_chat_queue.Slack { channel_id; user_id; team_id; thread_ts; _ } ->
-    `Assoc
-      [ "kind", `String "slack"
-      ; "channel_id", `String channel_id
-      ; "user_id", `String user_id
-      ; "team_id", Json_util.string_opt_to_json team_id
-      ; "thread_ts", Json_util.string_opt_to_json thread_ts
-      ]
-;;
-
 let chat_queue_active_row ~source ~next_action ~lifecycle_fields keeper_name queue_index
     (receipt : Keeper_chat_queue.active_receipt) =
   let msg = receipt.message in
@@ -289,7 +267,10 @@ let chat_queue_active_row ~source ~next_action ~lifecycle_fields keeper_name que
           ; ( "receipt_id"
             , `String
                 (Keeper_chat_queue.Receipt_id.to_string receipt.receipt_id) )
-          ; "message_source", chat_queue_source_json msg.source
+          ; ( "message_source"
+            , Server_dashboard_http_keeper_api_types
+              .keeper_chat_message_source_json
+                msg.source )
           ; "content_length", `Int (String.length msg.content)
           ; "user_block_count", `Int (List.length msg.user_blocks)
           ; "attachment_count", `Int (List.length msg.attachments)

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -262,6 +262,26 @@ let test_keeper_chat_recovery_route_is_exact () =
     (Masc_domain.has_permission
        Masc_domain.Admin
        Server_dashboard_http_keeper_chat_pending.operator_permission);
+  let pending_source_json =
+    Server_dashboard_http_keeper_api_types.keeper_chat_message_source_json
+      (Keeper_chat_queue.Slack
+         { channel_id = "channel-1"
+         ; user_id = "user-1"
+         ; user_name = "operator"
+         ; team_id = Some "team-1"
+         ; thread_ts = Some "42.1"
+         })
+  in
+  let open Yojson.Safe.Util in
+  check string "pending provenance retains source kind"
+    "slack"
+    (pending_source_json |> member "kind" |> to_string);
+  check string "pending provenance retains submitter identity"
+    "user-1"
+    (pending_source_json |> member "user_id" |> to_string);
+  check string "pending provenance retains channel identity"
+    "channel-1"
+    (pending_source_json |> member "channel_id" |> to_string);
   (match
      Server_dashboard_http_keeper_chat_pending.pending_mutation_route
        ("/api/v1/keepers/idealist/chat/receipts/" ^ receipt_id ^ "/edit")


### PR DESCRIPTION
## 무엇을 닫는가

- durable chat 대기 항목에 dashboard/Discord/Slack 제출 source와 exact receipt를 표시합니다.
- 현재 실행의 phase/decision/runtime/model/tool/시작/최근 progress와 interrupt를 운영자 드로어에 모읍니다.
- inflight receipt를 식별하고 recovery_required receipt를 fresh revision+lease CAS로 재대기 또는 취소할 수 있게 합니다.
- 자율 이벤트는 wake reason, urgency, age, opaque source ref를 표시하고 기존 cancel/transfer/reprioritize 제어를 유지합니다.

## 안전 경계

- pending inventory schema를 v2로 hard-cut하고 source provenance를 typed parser에서 필수로 검증합니다.
- 복구 결정은 화면 snapshot의 lease를 신뢰하지 않고 클릭 시 receipt를 재조회합니다.
- Admin-only operator API와 기존 audit/CAS 경계를 그대로 사용합니다.

## 검증

- dashboard tsc --noEmit
- focused Vitest: 2 files, 93 tests
- Vite production build
- ocamlformat --check (touched OCaml files)
- focused Dune build는 공유 lock 대기 중이며 PR CI가 최종 권위입니다.