### PR TITLE
fix(keeper): hard-cut turn evidence and typed prompt provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MASC
 
 [![OCaml](https://img.shields.io/badge/OCaml-%3E%3D%205.4-orange.svg)](https://ocaml.org/)
-[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.231.4-blue.svg)](https://github.com/jeong-sik/oas)
+[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.231.6-blue.svg)](https://github.com/jeong-sik/oas)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 [한국어 버전](README.ko.md)

--- a/dashboard/src/api/dashboard-turn-records.test.ts
+++ b/dashboard/src/api/dashboard-turn-records.test.ts
@@ -301,4 +301,24 @@ describe('keeper turn record final input composition', () => {
       '유효하지 않은 keeper turn record payload',
     )
   })
+
+  it('rejects prompt blocks without a current producer', async () => {
+    getMock.mockResolvedValue(payload(entry({
+      blocks: [{ block: 'continuity', bytes: 1, digest: 'dead-block' }],
+    })))
+
+    await expect(fetchKeeperTurnRecords('sangsu')).rejects.toThrow(
+      '유효하지 않은 keeper turn record payload',
+    )
+  })
+
+  it('rejects prompt components without a current producer', async () => {
+    getMock.mockResolvedValue(payload(entry({
+      input_components: [{ component: 'prompt.retry_nudge', bytes: 1 }],
+    })))
+
+    await expect(fetchKeeperTurnRecords('sangsu')).rejects.toThrow(
+      '유효하지 않은 keeper turn record payload',
+    )
+  })
 })

--- a/dashboard/src/api/dashboard-turn-records.ts
+++ b/dashboard/src/api/dashboard-turn-records.ts
@@ -6,14 +6,34 @@ import { get, type AbortableRequestOptions } from './core'
 import { isRecord, asBoolean, asNumber, asNullableString, asString, asRecordArray } from '../components/common/normalize'
 import { type TelemetryFreshnessMetadata } from './dashboard-shared'
 
+export type TurnPromptBlockId =
+  | 'persona'
+  | 'dynamic_context'
+  | 'temporal_summary'
+  | 'memory_os_recall'
+
+export type TurnInputComponentId =
+  | `prompt.${TurnPromptBlockId}`
+  | 'tool_schemas'
+  | 'message_user'
+  | 'message_system'
+  | 'message_assistant_text'
+  | 'message_thinking'
+  | 'message_redacted_thinking'
+  | 'message_tool_use'
+  | 'message_tool_result'
+  | 'message_image'
+  | 'message_document'
+  | 'message_audio'
+
 export type TurnBlock = {
-  block: string
+  block: TurnPromptBlockId
   bytes: number
   digest: string
 }
 
 export type TurnInputComponent = {
-  component: string
+  component: TurnInputComponentId
   bytes: number
 }
 
@@ -52,9 +72,9 @@ export type TurnRecordEntry = {
   output_tokens?: number
   // #25779 made the provider cache counts durable on the turn record
   // (lib/types/turn_record.ml:79-82 writes them as optional fields). Same
-  // absent-means-absent contract as the neighbours: a legacy row that predates
-  // #25779, or a provider that reports no cache usage, leaves these undefined
-  // and the inspector renders absence rather than a fabricated zero.
+  // absent-means-absent contract as the neighbours: a provider that reports no
+  // cache usage leaves these undefined and the inspector renders absence rather
+  // than a fabricated zero.
   cache_creation_input_tokens?: number
   cache_read_input_tokens?: number
   // RFC-0233 §8 — runtime model metadata. context_window is the keeper-resolved
@@ -341,9 +361,21 @@ function wholeSecondIsoOfUnixSeconds(raw: number): string | null {
   return date.toISOString().replace('.000Z', 'Z')
 }
 
+function decodeTurnPromptBlockId(raw: unknown): TurnPromptBlockId | null {
+  switch (raw) {
+    case 'persona':
+    case 'dynamic_context':
+    case 'temporal_summary':
+    case 'memory_os_recall':
+      return raw
+    default:
+      return null
+  }
+}
+
 function decodeTurnBlock(raw: unknown): TurnBlock | null {
   if (!isRecord(raw) || !hasExactKeys(raw, ['block', 'bytes', 'digest'])) return null
-  const block = decodeExactNonEmptyString(raw.block)
+  const block = decodeTurnPromptBlockId(raw.block)
   const digest = decodeExactNonEmptyString(raw.digest)
   const bytes = asNumber(raw.bytes)
   if (
@@ -360,36 +392,37 @@ function decodeTurnBlockList(raw: unknown): TurnBlock[] | null {
   return decodeArray(raw, decodeTurnBlock)
 }
 
-const TURN_INPUT_COMPONENTS = new Set([
-  'prompt.persona',
-  'prompt.continuity',
-  'prompt.dynamic_context',
-  'prompt.temporal_summary',
-  'prompt.claimed_task_nudge',
-  'prompt.retry_nudge',
-  'prompt.memory_os_recall',
-  'prompt.connected_surface',
-  'tool_schemas',
-  'message_user',
-  'message_system',
-  'message_assistant_text',
-  'message_thinking',
-  'message_redacted_thinking',
-  'message_tool_use',
-  'message_tool_result',
-  'message_image',
-  'message_document',
-  'message_audio',
-])
+function decodeTurnInputComponentId(raw: unknown): TurnInputComponentId | null {
+  switch (raw) {
+    case 'prompt.persona':
+    case 'prompt.dynamic_context':
+    case 'prompt.temporal_summary':
+    case 'prompt.memory_os_recall':
+    case 'tool_schemas':
+    case 'message_user':
+    case 'message_system':
+    case 'message_assistant_text':
+    case 'message_thinking':
+    case 'message_redacted_thinking':
+    case 'message_tool_use':
+    case 'message_tool_result':
+    case 'message_image':
+    case 'message_document':
+    case 'message_audio':
+      return raw
+    default:
+      return null
+  }
+}
 
 function decodeTurnInputComponents(raw: unknown): TurnInputComponent[] | null {
   if (!Array.isArray(raw)) return null
   const components: TurnInputComponent[] = []
   for (const item of raw) {
     if (!isRecord(item) || !hasExactKeys(item, ['component', 'bytes'])) return null
-    const component = decodeExactNonEmptyString(item.component)
+    const component = decodeTurnInputComponentId(item.component)
     const bytes = decodeNonNegativeSafeInteger(item.bytes)
-    if (component === null || !TURN_INPUT_COMPONENTS.has(component) || bytes === null) {
+    if (component === null || bytes === null) {
       return null
     }
     components.push({ component, bytes })

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -285,6 +285,8 @@ export { fetchKeeperToolCalls } from './dashboard-keeper-tool-calls'
 // ── Keeper turn records (RFC-0233 PR-4) ─────────────────
 
 export type {
+  TurnPromptBlockId,
+  TurnInputComponentId,
   TurnBlock,
   TurnInputComponent,
   TurnRecordEntry,

--- a/dashboard/src/components/agent-detail-memory.ts
+++ b/dashboard/src/components/agent-detail-memory.ts
@@ -3,39 +3,34 @@ import { useSignal } from '@preact/signals'
 import { CollapsibleSection } from './common/collapsible'
 import {
   MemoryInspector,
-  DEFAULT_MEMORY_KEEPERS,
   type MemoryKeeper,
 } from './memory-inspector'
+import type { Keeper } from '../types'
+import { keeperBucket } from './keeper-workspace/keeper-workspace-shared'
 
 interface Props {
   agentName: string
+  keeper?: Keeper | null
 }
 
 function normalizeKeeperName(name: string): string {
   return name.replace(/^keeper-/, '').replace(/-agent$/, '')
 }
 
-// Resolve the MemoryInspector keeper from the surfaced agent. When the agent
-// matches the inspector's ported roster we reuse the fixture keeper (real ctx /
-// status / task counts so the composition math renders); otherwise the keeper
-// id alone is enough — the inspector falls back to empty memory for unknown ids
-// (memory-inspector.ts getKeeperMemory). ctx 0 / status 'off' keeps an unknown
-// keeper's composition bar in the documented "stopped — 활성 컨텍스트 없음" state
-// rather than fabricating window usage.
-function resolveInspectorKeeper(agentName: string): MemoryKeeper {
+function resolveInspectorKeeper(agentName: string, keeper?: Keeper | null): MemoryKeeper {
   const id = normalizeKeeperName(agentName)
-  return (
-    DEFAULT_MEMORY_KEEPERS.find(k => k.id === id) ?? {
-      id,
-      ctx: 0,
-      status: 'off',
-      tasks: 0,
-      traces: 0,
-    }
-  )
+  if (!keeper) return { id, status: 'unknown' }
+  const bucket = keeperBucket(keeper)
+  const status =
+    bucket === 'running' || bucket === 'stuck'
+      ? 'run'
+      : bucket === 'paused'
+        ? 'pause'
+        : 'off'
+  return { id: keeper.name, status }
 }
 
-export function AgentDetailMemory({ agentName }: Props) {
+export function AgentDetailMemory({ agentName, keeper }: Props) {
   const memOpen = useSignal(false)
 
   return html`
@@ -52,7 +47,7 @@ export function AgentDetailMemory({ agentName }: Props) {
       </div>
       ${memOpen.value
         ? html`<${MemoryInspector}
-            keeper=${resolveInspectorKeeper(agentName)}
+            keeper=${resolveInspectorKeeper(agentName, keeper)}
             onClose=${() => { memOpen.value = false }}
           />`
         : null}

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -368,7 +368,7 @@ export function AgentDetailOverlay() {
         <div class="flex flex-col gap-5">
           <${AgentJournalStream} agentName=${agentName} />
           <${AgentTimelineSection} />
-          <${AgentDetailMemory} agentName=${agentName} />
+          <${AgentDetailMemory} agentName=${agentName} keeper=${keeper} />
           <${AgentWorkerBrief} agentName=${agentName} />
           ${agentFitness.value ? html`
             <${CollapsibleSection} title="적합도 (7일)" mountWhenOpen=${true}>

--- a/dashboard/src/components/keeper-detail-ctx-utils.ts
+++ b/dashboard/src/components/keeper-detail-ctx-utils.ts
@@ -18,13 +18,9 @@ export function autonomyHint(count: number | undefined, proactiveEnabled: boolea
 
 export const CTX_SEGMENT_LABELS: Record<string, string> = {
   'prompt.persona': '페르소나',
-  'prompt.continuity': '연속성',
   'prompt.dynamic_context': '턴 컨텍스트',
   'prompt.temporal_summary': '시간 요약',
-  'prompt.claimed_task_nudge': '태스크 넛지',
-  'prompt.retry_nudge': '재시도 넛지',
   'prompt.memory_os_recall': '메모리 회상',
-  'prompt.connected_surface': '연결 표면',
   tool_schemas: '도구 스키마',
   message_user: '메시지 · user',
   message_system: '메시지 · system',
@@ -40,13 +36,9 @@ export const CTX_SEGMENT_LABELS: Record<string, string> = {
 
 export const CTX_SEGMENT_COLORS: Record<string, string> = {
   'prompt.persona': 'var(--amber-bright)',
-  'prompt.continuity': 'var(--cyan)',
   'prompt.dynamic_context': 'var(--purple)',
   'prompt.temporal_summary': 'var(--cyan)',
-  'prompt.claimed_task_nudge': 'var(--color-status-ok)',
-  'prompt.retry_nudge': 'var(--color-status-err)',
   'prompt.memory_os_recall': 'var(--rose-light)',
-  'prompt.connected_surface': 'var(--amber-bright)',
   tool_schemas: 'var(--amber-bright)',
   message_user: 'var(--sky-400)',
   message_system: 'var(--color-fg-muted)',

--- a/dashboard/src/components/keeper-turn-inspector.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector.test.ts
@@ -133,7 +133,7 @@ function turnRecordsWithMemoryOs(): TurnRecordsResponse {
           turn_ref: 'trace-active#41',
           ts: 1_781_587_500,
           runtime_profile: 'local',
-          blocks: [{ block: 'system', bytes: 1200, digest: '1111222233334444' }],
+          blocks: [{ block: 'persona', bytes: 1200, digest: '1111222233334444' }],
           input_components: [],
           request_runtime_profile: null,
           request_body_bytes: null,
@@ -159,7 +159,7 @@ function turnRecordsWithMemoryOs(): TurnRecordsResponse {
           request_latency_ms: 1234,
           ttfrc_ms: 567.8,
           blocks: [
-            { block: 'system', bytes: 1200, digest: '1111222233334444' },
+            { block: 'persona', bytes: 1200, digest: '1111222233334444' },
             { block: 'memory_os_recall', bytes: 3392, digest: 'aabbccddeeff00112233' },
           ],
           input_components: [

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -553,7 +553,6 @@ function toMemoryKeeper(k: Keeper): MemoryKeeper {
         : 'off'
   return {
     id: k.name,
-    ctx: contextRatio(k) ?? 0,
     status,
   }
 }

--- a/dashboard/src/components/memory-inspector.test.ts
+++ b/dashboard/src/components/memory-inspector.test.ts
@@ -20,7 +20,6 @@ import { type MemoryOsFact, type TurnRecordRow } from '../api/dashboard'
 
 const keeper: MemoryKeeper = {
   id: 'masc-improver',
-  ctx: 0,
   status: 'run',
 }
 
@@ -211,7 +210,7 @@ describe('MemoryInspector pure projections', () => {
     expect(memCompositionFromBlocks([
       { block: 'persona', bytes: 1_200, digest: 'a' },
       { block: 'memory_os_recall', bytes: 800, digest: 'b' },
-      { block: 'empty', bytes: 0, digest: 'c' },
+      { block: 'temporal_summary', bytes: 0, digest: 'c' },
     ])).toMatchObject({
       totalBytes: 2_000,
       parts: [{ key: 'persona' }, { key: 'memory_os_recall' }],

--- a/dashboard/src/components/memory-inspector.ts
+++ b/dashboard/src/components/memory-inspector.ts
@@ -31,32 +31,15 @@ import {
   type MemoryOsFactCategory,
   type TurnBlock,
   type TurnInputComponent,
+  type TurnInputComponentId,
+  type TurnPromptBlockId,
   type TurnRecordRow,
 } from '../api/dashboard'
 
-// Minimal keeper shape the inspector reads. Only `id` (the keeper name used as
-// the API key) and `status` (the header dot) are consumed now; `ctx`/`tasks`/
-// `traces` remain for call-site back-compat (they drove the removed fabricated
-// composition and are no longer read).
 export interface MemoryKeeper {
   readonly id: string
-  readonly ctx: number
-  readonly status: string
-  readonly tasks?: number
-  readonly traces?: number
+  readonly status: 'run' | 'pause' | 'off' | 'unknown'
 }
-
-// Keeper roster fallback for the agent-profile mount (agent-detail-memory.ts)
-// when an agent id is outside the live keepers signal. Identity-only — carries
-// no memory content (that is fetched per keeper).
-export const DEFAULT_MEMORY_KEEPERS: readonly MemoryKeeper[] = [
-  { id: 'masc-improver', ctx: 0, status: 'run' },
-  { id: 'nick0cave', ctx: 0, status: 'run' },
-  { id: 'sangsu', ctx: 0, status: 'run' },
-  { id: 'qa-king', ctx: 0, status: 'pause' },
-  { id: 'analyst', ctx: 0, status: 'run' },
-  { id: 'drifter', ctx: 0, status: 'off' },
-]
 
 // ── byte / token formatters ──
 export function memFmtTok(n: number): string {
@@ -73,9 +56,8 @@ export function memFmtBytes(n: number): string {
 
 // ── prompt-block composition (real, from turn_record blocks) ──
 // PROMPT_BLOCK_META mirrors the OCaml Prompt_block_id closed sum
-// (lib/types/prompt_block_id.ml — to_string is the wire SSOT). A token outside
-// the closed set is an `Other name` block; it keeps its raw label so a new
-// block id surfaces verbatim rather than as a silent miscolour.
+// (lib/types/prompt_block_id.ml — to_string is the wire SSOT). Unknown tokens
+// are protocol drift and are rejected at the API decoder.
 interface BlockMeta {
   readonly lbl: string
   readonly color: string
@@ -84,18 +66,14 @@ interface BlockMeta {
   // carries recalled memory; the rest are persona/context/surface.
   readonly mem: boolean
 }
-const PROMPT_BLOCK_META: Readonly<Record<string, BlockMeta>> = {
+const PROMPT_BLOCK_META: Readonly<Record<TurnPromptBlockId, BlockMeta>> = {
   persona: { lbl: '페르소나', color: 'var(--text-dim)', mem: false },
-  continuity: { lbl: '연속성', color: 'var(--info)', mem: false },
   dynamic_context: { lbl: '동적 컨텍스트', color: 'var(--volt)', mem: false },
   temporal_summary: { lbl: '시간 요약', color: 'var(--status-warn)', mem: false },
-  claimed_task_nudge: { lbl: '태스크 넛지', color: 'var(--status-ok)', mem: false },
-  retry_nudge: { lbl: '재시도 넛지', color: 'var(--status-bad)', mem: false },
   memory_os_recall: { lbl: '메모리 회상', color: 'var(--volt-strong)', mem: true },
-  connected_surface: { lbl: '연결 표면', color: 'var(--status-warn)', mem: false },
 }
-export function promptBlockMeta(token: string): BlockMeta {
-  return PROMPT_BLOCK_META[token] ?? { lbl: token, color: 'var(--text-dim)', mem: false }
+export function promptBlockMeta(token: TurnPromptBlockId): BlockMeta {
+  return PROMPT_BLOCK_META[token]
 }
 
 export interface CompositionPart {
@@ -124,7 +102,11 @@ export function memCompositionFromBlocks(blocks: readonly TurnBlock[]): Composit
   return { totalBytes, parts }
 }
 
-const INPUT_COMPONENT_META: Readonly<Record<string, BlockMeta>> = {
+const INPUT_COMPONENT_META: Readonly<Record<TurnInputComponentId, BlockMeta>> = {
+  'prompt.persona': PROMPT_BLOCK_META.persona,
+  'prompt.dynamic_context': PROMPT_BLOCK_META.dynamic_context,
+  'prompt.temporal_summary': PROMPT_BLOCK_META.temporal_summary,
+  'prompt.memory_os_recall': PROMPT_BLOCK_META.memory_os_recall,
   tool_schemas: { lbl: '도구 스키마', color: 'var(--status-warn)', mem: false },
   message_user: { lbl: '사용자 메시지', color: 'var(--info)', mem: false },
   message_system: { lbl: '시스템 메시지', color: 'var(--text-dim)', mem: false },
@@ -138,9 +120,8 @@ const INPUT_COMPONENT_META: Readonly<Record<string, BlockMeta>> = {
   message_audio: { lbl: '오디오', color: 'var(--status-ok)', mem: false },
 }
 
-export function inputComponentMeta(token: string): BlockMeta {
-  if (token.startsWith('prompt.')) return promptBlockMeta(token.slice('prompt.'.length))
-  return INPUT_COMPONENT_META[token] ?? { lbl: token, color: 'var(--text-dim)', mem: false }
+export function inputComponentMeta(token: TurnInputComponentId): BlockMeta {
+  return INPUT_COMPONENT_META[token]
 }
 
 export function memCompositionFromInputComponents(
@@ -549,8 +530,8 @@ function ReadErrors({ snapshot }: { snapshot: MemoryOsTurnRecordSnapshot }) {
   return html`<div class="mem-read-error" role="alert">${'⚠'} 읽기 오류 — ${text}</div>`
 }
 
-function memDotState(status: string): 'ok' | 'idle' | 'bad' {
-  return status === 'run' ? 'ok' : status === 'pause' ? 'idle' : 'bad'
+function memDotState(status: MemoryKeeper['status']): 'ok' | 'idle' | 'bad' {
+  return status === 'run' ? 'ok' : status === 'off' ? 'bad' : 'idle'
 }
 
 function CategoryFilters({
@@ -947,8 +928,9 @@ export interface MemoryInspectorProps {
 export function MemoryInspector({
   keeper,
   onClose,
-  keepers = DEFAULT_MEMORY_KEEPERS,
+  keepers: providedKeepers,
 }: MemoryInspectorProps) {
+  const keepers = providedKeepers ?? [keeper]
   const scope = useSignal<'one' | 'all'>('one')
   // The keeper the one-scope view is bound to. Starts at the opened keeper and can
   // be re-pointed by clicking an aggregate row (전체 → 개별), mirroring the prototype.

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -34,7 +34,7 @@ Keeper는 OAS(OCaml Agent SDK) 위에 구축된다. OAS가 제공하는 핵심 �
 | `Event_bus.t` | 에이전트 간 이벤트 발행/구독 | `oas_events.ml`을 통해 broadcast, heartbeat, board 이벤트 전달 |
 
 <!-- BEGIN GENERATED: oas-pin-manual -->
-OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.4`, runtime pin: `main@2add6bf4a0c7a70dab3b60f82c62643a5bd8a9d6`, declared base version: `v0.231.4`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
+OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.6`, runtime pin: `main@ae4cc55363b12ae47b9090e715c15dabba9f9f16`, declared base version: `v0.231.6`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
 <!-- END GENERATED: oas-pin-manual -->
 
 #### 1.1.1 OAS 환경 변수 경계

--- a/dune-project
+++ b/dune-project
@@ -59,7 +59,7 @@
   ;; ordered multimodal delivery contracts;
   ;; its SHA and rationale live in scripts/oas-agent-sdk-pin.sh (SSOT).
   ;; See check-oas-pin.sh.
-  (agent_sdk (>= 0.231.4))
+  (agent_sdk (>= 0.231.6))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -521,19 +521,13 @@ let candidate_rejection_detail (rejection : Exact_output.candidate_rejection_rec
      |> rejection_disposition_detail)
 ;;
 
-(* [Flow_exact_execution_failed] is the branch that carries the provider's own
-   verdict, and it was the only flow error settled with no log line at all. *)
-let capacity_refusal_detail (refusal : Exact_output.input_capacity_disposition) : string =
-  capacity_disposition_detail refusal
-;;
-
 let execution_cause_detail : Exact_output.execution_error_cause -> string = function
   | Attempt_already_started -> "attempt already started"
   | Clock_required_for_timeout -> "clock required for timeout"
   | Frozen_request_mismatch -> "frozen request mismatch"
   | Completion_failed -> "completion failed"
-  | Input_capacity_refused refusal ->
-    Printf.sprintf "input capacity refused: %s" (capacity_refusal_detail refusal)
+  | Serialized_request_refused { http_status } ->
+    Printf.sprintf "serialized request refused (http_status=%d)" http_status
   | Incomplete_output -> "incomplete output"
   | Missing_output -> "missing output"
   | Ambiguous_output count -> Printf.sprintf "ambiguous output (candidates=%d)" count

--- a/lib/keeper/keeper_agent_prompt_metrics.ml
+++ b/lib/keeper/keeper_agent_prompt_metrics.ml
@@ -50,20 +50,33 @@ let provider_content_messages
       ~(projection_input : Agent_sdk.Types.message list)
       ~(projected_messages : Agent_sdk.Types.message list)
   =
-  if prompt_context_present
-  then
-    (* OAS currently exposes only generic messages here, not typed provenance
-       for its generated prompt-context carrier. Its position is therefore not
-       a contract. Leave attribution unavailable instead of dropping a message
-       by position. *)
-    None
-  else
-    let projection_input_count = List.length projection_input in
-    match split_at projection_input_count [] projected_messages with
-    | Some (projected_prefix, _)
-      when List.equal ( = ) projected_prefix projection_input ->
-      Some projected_messages
-    | Some _ | None -> None
+  let projection_input_count = List.length projection_input in
+  match split_at projection_input_count [] projected_messages with
+  | Some (projected_prefix, projection_suffix)
+    when List.equal ( = ) projected_prefix projection_input ->
+    let rec remove_prompt_context seen rev_retained = function
+      | [] ->
+        if Bool.equal seen prompt_context_present
+        then Some (List.rev rev_retained)
+        else None
+      | (message : Agent_sdk.Types.message) :: rest ->
+        (match
+         Agent_sdk.Types.Extra_system_context_provenance.classify
+             message.metadata
+         with
+         | Agent_sdk.Types.Extra_system_context_provenance.Absent ->
+           remove_prompt_context seen (message :: rev_retained) rest
+         | Agent_sdk.Types.Extra_system_context_provenance.Present
+           when prompt_context_present && not seen ->
+           remove_prompt_context true rev_retained rest
+         | Agent_sdk.Types.Extra_system_context_provenance.Present
+         | Agent_sdk.Types.Extra_system_context_provenance.Invalid
+         | Agent_sdk.Types.Extra_system_context_provenance.Duplicate -> None)
+    in
+    Option.map
+       (fun retained_input -> retained_input @ projection_suffix)
+       (remove_prompt_context false [] projection_input)
+  | Some _ | None -> None
 ;;
 
 let empty_prompt_segment_metrics =

--- a/lib/keeper/keeper_agent_prompt_metrics.mli
+++ b/lib/keeper/keeper_agent_prompt_metrics.mli
@@ -33,11 +33,11 @@ type ctx_composition_metrics =
   }
 
 (** Return concrete provider content messages only when their provenance is
-    unambiguous. OAS currently gives its generated [extra_system_context]
-    carrier no typed identity, so any turn with prompt context returns [None]
-    instead of removing a message by position. Without prompt context,
-    projection-only messages remain included when the projection preserves the
-    exact input prefix; a rewrite or reorder also returns [None]. *)
+    unambiguous. The OAS-generated [extra_system_context] carrier is removed by
+    its typed metadata identity, never by position or content. Its presence must
+    exactly agree with [prompt_context_present]. Projection-only messages remain
+    included when the projection preserves the exact input prefix; a rewrite,
+    reorder, missing carrier, or duplicate/invalid carrier returns [None]. *)
 val provider_content_messages :
   prompt_context_present:bool ->
   projection_input:Agent_sdk.Types.message list ->

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -681,7 +681,7 @@ let run_turn
            current_request_input_messages_ref := None;
            Log.Keeper.warn
              "turn input composition unavailable: keeper=%s trace=%s \
-              reason=model_input_projection_rewrote_prefix"
+              reason=model_input_projection_provenance_unavailable"
              meta.name trace_id);
         result
     in

--- a/lib/types/prompt_block_id.mli
+++ b/lib/types/prompt_block_id.mli
@@ -10,8 +10,9 @@
     keeper_turn.ml/keeper_run_prompt.ml (continuity snapshot, skill
     route, worktree, telemetry feedback, turn instructions, recent
     failure memory) — recorded as one block until a real producer
-    introduces a typed decomposition. Constructors without a producer and
-    open-ended catch-alls are intentionally excluded. *)
+    introduces a typed decomposition. This is a closed current contract:
+    constructors without a producer and forward-compatible catch-alls
+    are intentionally excluded. *)
 
 type t =
   | Persona

--- a/lib/types/turn_record.ml
+++ b/lib/types/turn_record.ml
@@ -143,6 +143,13 @@ let ( let* ) = Result.bind
 
 let member name fields = List.assoc_opt name fields
 
+let fields_are_unique_known known fields =
+  let names = List.map fst fields in
+  List.for_all (fun name -> List.mem name known) names
+  && List.length names
+     = List.length (List.sort_uniq String.compare names)
+;;
+
 let require name fields =
   match member name fields with
   | Some value -> Ok value
@@ -200,6 +207,11 @@ let as_turn_ref name json =
 let prompt_block_of_json (json : Yojson.Safe.t) : (prompt_block, string) result =
   match json with
   | `Assoc fields ->
+      let* () =
+        if fields_are_unique_known [ "block"; "bytes"; "digest" ] fields
+        then Ok ()
+        else Error "turn_record: prompt block fields are not exact"
+      in
       let* block_json = require "block" fields in
       let* block_name = as_string "block" block_json in
       let* bytes_json = require "bytes" fields in
@@ -237,9 +249,7 @@ let input_component_id_of_string token =
        | Ok block -> Ok (Prompt_block block)
        | Error _ ->
          Error
-           (Printf.sprintf
-              "turn_record: unknown input component %S"
-              token))
+           (Printf.sprintf "turn_record: unknown input component %S" token))
     else
       Error
         (Printf.sprintf "turn_record: unknown input component %S" token)
@@ -278,6 +288,41 @@ let rec collect_results acc = function
 let of_json (json : Yojson.Safe.t) : (t, string) result =
   match json with
   | `Assoc fields ->
+      let* () =
+        if
+          fields_are_unique_known
+            [ "execution_ids"
+            ; "keeper"
+            ; "trace_id"
+            ; "absolute_turn"
+            ; "turn_ref"
+            ; "blocks"
+            ; "input_components"
+            ; "runtime_profile"
+            ; "request_runtime_profile"
+            ; "request_body_bytes"
+            ; "model"
+            ; "finish_reason"
+            ; "context_window"
+            ; "price_input_per_million"
+            ; "price_output_per_million"
+            ; "request_latency_ms"
+            ; "ttfrc_ms"
+            ; "temperature"
+            ; "top_p"
+            ; "max_tokens"
+            ; "thinking_budget"
+            ; "enable_thinking"
+            ; "input_tokens"
+            ; "cache_creation_input_tokens"
+            ; "cache_read_input_tokens"
+            ; "output_tokens"
+            ; "ts"
+            ]
+            fields
+        then Ok ()
+        else Error "turn_record: fields are not exact"
+      in
       let* ids_json = require "execution_ids" fields in
       let* execution_ids =
         match ids_json with
@@ -299,7 +344,8 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
         then Ok ()
         else
           Error
-            "turn_record: turn_ref does not match trace_id and absolute_turn"
+             "turn_record: field \"turn_ref\" does not match trace_id and \
+              absolute_turn"
       in
       let* blocks_json = require "blocks" fields in
       let* blocks =

--- a/lib/types/turn_record.mli
+++ b/lib/types/turn_record.mli
@@ -55,7 +55,7 @@ type usage =
        matters against [context_window] below: the fill percentage it denominates is
        read as pressure on the compaction ceiling, and cache-heavy turns and
        genuinely large prompts are different situations with the same numerator.
-       [None] when the provider reported no usage. *)
+       [None] when the provider reported no cache usage. *)
   }
 
 type request_wire_observation =
@@ -69,8 +69,9 @@ type t =
   ; trace_id : string
   ; absolute_turn : int
   ; turn_ref : Ids.Turn_ref.t
-    (* RFC-0233 §7 — "<trace_id>#<absolute_turn>" join key for chat/board.
-       The decoder requires it to match [trace_id] and [absolute_turn]. *)
+    (* RFC-0233 §7 — required "<trace_id>#<absolute_turn>" join key for
+       chat/board. The decoder rejects a key that does not exactly match the
+       row's [trace_id] and [absolute_turn]. *)
   ; blocks : prompt_block list (* assembly order *)
   ; input_components : input_component list
     (* Exact UTF-8/JSON payload bytes attributed to the concrete prompt blocks,
@@ -91,8 +92,8 @@ type t =
   ; context_window : int option
     (* RFC-0233 §8 — keeper-resolved effective context budget (tokens) for
        this turn, the denominator the dashboard ctx-fill% uses. [None] on
-       the error path; the inspector renders absence rather than the
-       fabricated 200K. This is the keeper compaction ceiling
+       the error path; the inspector renders absence rather
+       than the fabricated 200K. This is the keeper compaction ceiling
        ([max_context]), NOT the provider's per-request num-ctx cap (an
        Ollama-only transport detail). *)
   ; price_input_per_million : float option
@@ -151,9 +152,11 @@ val input_component_to_json : input_component -> Yojson.Safe.t
 val to_json : t -> Yojson.Safe.t
 
 val of_json : Yojson.Safe.t -> (t, string) result
-(** Fails loudly on malformed rows (missing fields, unparseable
-    execution ids, unknown block names, or mismatched turn refs) instead
-    of repairing them — RFC-0233 §4. *)
+(** Fails loudly on malformed rows instead of repairing them — RFC-0233 §4.
+    [turn_ref] and provider-input observation fields are required. Unknown or
+    duplicate fields, prompt blocks, or input-component ids, negative byte
+    counts, partial request-runtime/request-bytes pairs, and a [turn_ref]
+    inconsistent with the row identity are rejected. *)
 
 (** Result of diffing two consecutive records by [(block, digest)]. *)
 type block_diff =

--- a/masc.opam
+++ b/masc.opam
@@ -30,7 +30,7 @@ depends: [
   "cohttp-eio" {>= "6.0"}
   "piaf" {= "0.2.0"}
   "eio-ssl" {>= "0.3.0"}
-  "agent_sdk" {>= "0.231.4"}
+  "agent_sdk" {>= "0.231.6"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -11,7 +11,7 @@ homepage: "https://github.com/jeong-sik/masc"
 doc: "https://github.com/jeong-sik/masc"
 bug-reports: "https://github.com/jeong-sik/masc/issues"
 depends: [
-  "agent_sdk" {= "0.231.4"}
+  "agent_sdk" {= "0.231.6"}
   "alcotest" {= "1.9.1" & with-test}
   "ambient-context" {= "0.2"}
   "ambient-context-eio" {= "0.2"}
@@ -218,8 +218,8 @@ build: [
 dev-repo: "git+https://github.com/jeong-sik/masc.git"
 pin-depends: [
   [
-  "agent_sdk.0.231.4"
-  "git+https://github.com/jeong-sik/oas.git#2add6bf4a0c7a70dab3b60f82c62643a5bd8a9d6"
+  "agent_sdk.0.231.6"
+  "git+https://github.com/jeong-sik/oas.git#ae4cc55363b12ae47b9090e715c15dabba9f9f16"
 ]
   [
     "bisect_ppx.2.8.3"

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.4"
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.6"
 # v0.231.0 is a hard-cut wave: checkpoint schema is v9 only (v1-v8
 # rejected; #2867), provider_config.output_schema is removed in favor of
 # response_format = JsonSchema as the single structured-output request state
@@ -47,9 +47,13 @@ readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.4"
 # uses this typed boundary to bound compaction input without duplicating an OAS
 # serializer or inferring byte limits from provider/model names.
 # Previous pin: v0.231.3 (e01940b14).
-readonly OAS_AGENT_SDK_DECLARED_VERSION="0.231.4"
+# v0.231.6 gives the OAS-generated extra_system_context carrier an exact typed
+# metadata identity (#2894). MASC uses that identity to remove only the carrier
+# from provider-content attribution, independent of message position or text.
+# Previous pin: v0.231.4 (2add6bf4a).
+readonly OAS_AGENT_SDK_DECLARED_VERSION="0.231.6"
 # TRACK_REF consumed by check-oas-pin.sh / oas-drift-check.sh /
 # sync-oas-pin-docs.sh; removed by #25579 and restored here (#25584).
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="2add6bf4a0c7a70dab3b60f82c62643a5bd8a9d6"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.231.4"
+readonly OAS_AGENT_SDK_SHA="ae4cc55363b12ae47b9090e715c15dabba9f9f16"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.231.6"

--- a/scripts/oas-api-surface.json
+++ b/scripts/oas-api-surface.json
@@ -1,6 +1,6 @@
 {
-  "pinned_sha": "2add6bf4a0c7a70dab3b60f82c62643a5bd8a9d6",
-  "pinned_version": "v0.231.4",
+  "pinned_sha": "ae4cc55363b12ae47b9090e715c15dabba9f9f16",
+  "pinned_version": "v0.231.6",
   "surfaces": {
     "event_bus_payload_variants": [
       "AgentCompleted",
@@ -116,8 +116,7 @@
       "type:effect_phase:type effect_phase = | Not_started | Before_dispatch | Dispatch_started | Response_received | Terminal",
       "type:provider_trace:type provider_trace",
       "type:raw_response:type raw_response = { body : string ; body_sha256 : string }",
-      "type:input_capacity_refusal:type input_capacity_refusal = | Context_window_refused of { limit_tokens : int option } | Serialized_request_refused of { http_status : int }",
-      "type:execution_error_cause:type execution_error_cause = | Attempt_already_started | Clock_required_for_timeout | Frozen_request_mismatch | Completion_failed | Input_capacity_refused of input_capacity_refusal | Incomplete_output | Missing_output | Ambiguous_output of int | Unexpected_output_content | Invalid_json_output | Internal_non_json_output",
+      "type:execution_error_cause:type execution_error_cause = | Attempt_already_started | Clock_required_for_timeout | Frozen_request_mismatch | Completion_failed | Serialized_request_refused of { http_status : int } | Incomplete_output | Missing_output | Ambiguous_output of int | Unexpected_output_content | Invalid_json_output | Internal_non_json_output",
       "type:execution_error:type execution_error = { call_id : call_id ; receipt : receipt ; cause : execution_error_cause ; raw_response : raw_response option }",
       "type:success:type success = { call_id : call_id ; receipt : receipt ; output : Yojson.Safe.t ; provenance : plan_provenance ; raw_response : raw_response }",
       "type:flow_candidate_identity:type flow_candidate_identity = { candidate_id : string ; catalog_generation : catalog_generation ; catalog_evidence : catalog_evidence ; target_identity : target_identity }",
@@ -196,6 +195,8 @@
       "val:generation_receipt_snapshot_target_identity:val generation_receipt_snapshot_target_identity : generation_receipt_snapshot -> target_identity",
       "type:flow_attempt_receipt:type flow_attempt_receipt = private { visit : flow_candidate_visit ; receipt : receipt }",
       "type:flow_attempt_snapshot:type flow_attempt_snapshot = private { visit : flow_candidate_visit ; receipt : generation_receipt_snapshot }",
+      "type:flow_advance_failure_snapshot:type flow_advance_failure_snapshot = | Flow_advance_candidate_rejected of candidate_rejection_receipt | Flow_advance_execution_failed of { candidate : flow_attempt_snapshot ; cause : execution_error_cause ; raw_response_sha256 : string option }",
+      "type:flow_advance_receipt:type flow_advance_receipt = private { failed : flow_advance_failure_snapshot ; next : flow_candidate_visit }",
       "val:candidate_visit_count_to_int:val candidate_visit_count_to_int : candidate_visit_count -> int",
       "val:measurement_operation_id_to_string:val measurement_operation_id_to_string : measurement_operation_id -> string",
       "val:flow_measurement_receipt_snapshot:val flow_measurement_receipt_snapshot : flow_measurement_receipt -> measurement_receipt_snapshot",
@@ -221,7 +222,7 @@
       "val:candidate_rejection_measurement_dispatch_fact:val candidate_rejection_measurement_dispatch_fact : candidate_rejection_receipt -> measurement_dispatch_fact",
       "val:candidate_rejection_measurement_outcome:val candidate_rejection_measurement_outcome : candidate_rejection_receipt -> measurement_outcome",
       "val:candidate_rejection_disposition:val candidate_rejection_disposition : candidate_rejection_receipt -> candidate_rejection_disposition",
-      "type:flow_evidence:type flow_evidence = private { flow_id : flow_id ; declared_candidate_snapshot : flow_candidate_identity list ; candidate_visit_count : candidate_visit_count ; measurements : measurement_receipt_snapshot list ; admissions : candidate_admission list ; attempts : flow_attempt_snapshot list }",
+      "type:flow_evidence:type flow_evidence = private { flow_id : flow_id ; declared_candidate_snapshot : flow_candidate_identity list ; candidate_visit_count : candidate_visit_count ; measurements : measurement_receipt_snapshot list ; admissions : candidate_admission list ; attempts : flow_attempt_snapshot list ; advances : flow_advance_receipt list }",
       "val:flow_success_candidate:val flow_success_candidate : flow_success -> flow_attempt_receipt",
       "val:flow_success_output:val flow_success_output : flow_success -> success",
       "val:flow_success_evidence:val flow_success_evidence : flow_success -> flow_evidence",

--- a/test/test_keeper_prompt_metrics.ml
+++ b/test/test_keeper_prompt_metrics.ml
@@ -407,9 +407,15 @@ let test_ctx_composition_splits_final_provider_input_bytes () =
 
 let message text : Agent_sdk.Types.message = Agent_sdk.Types.user_msg text
 
-let test_provider_content_messages_requires_typed_prompt_carrier_provenance () =
+let prompt_carrier text =
+  { (message text) with
+    metadata = Agent_sdk.Types.Extra_system_context_provenance.metadata
+  }
+;;
+
+let test_provider_content_messages_removes_typed_prompt_carrier () =
   let history = [ message "history"; message "current user" ] in
-  let prompt_carrier = message "[system context] dynamic and memory blocks" in
+  let prompt_context = prompt_carrier "[system context] dynamic and memory blocks" in
   let gate_evidence = message "typed gate replay payload" in
   let message_texts =
     Option.map
@@ -418,12 +424,24 @@ let test_provider_content_messages_requires_typed_prompt_carrier_provenance () =
   in
   check
     (option (list string))
-    "untyped prompt carrier leaves attribution unavailable"
-    None
+    "typed prompt carrier is removed and projection suffix is retained"
+    (Some [ "history"; "current user"; "typed gate replay payload" ])
     (KAPM.provider_content_messages
        ~prompt_context_present:true
-       ~projection_input:(history @ [ prompt_carrier ])
-       ~projected_messages:(history @ [ prompt_carrier; gate_evidence ])
+       ~projection_input:(history @ [ prompt_context ])
+       ~projected_messages:(history @ [ prompt_context; gate_evidence ])
+     |> message_texts);
+  let middle_input =
+    [ message "history"; prompt_context; message "current user" ]
+  in
+  check
+    (option (list string))
+    "typed identity works independently of carrier position"
+    (Some [ "history"; "current user" ])
+    (KAPM.provider_content_messages
+       ~prompt_context_present:true
+       ~projection_input:middle_input
+       ~projected_messages:middle_input
      |> message_texts);
   check
     (option (list string))
@@ -434,6 +452,40 @@ let test_provider_content_messages_requires_typed_prompt_carrier_provenance () =
        ~projection_input:history
        ~projected_messages:(history @ [ gate_evidence ])
      |> message_texts)
+;;
+
+let test_provider_content_messages_rejects_prompt_carrier_mismatch () =
+  let plain = message "[system context] same text without typed identity" in
+  let marked = prompt_carrier "typed prompt context" in
+  let invalid =
+    match Agent_sdk.Types.Extra_system_context_provenance.metadata with
+    | [ key, _ ] -> { marked with metadata = [ key, `Bool false ] }
+    | _ -> fail "OAS prompt carrier metadata must contain exactly one field"
+  in
+  let duplicate =
+    { marked with
+      metadata =
+        Agent_sdk.Types.Extra_system_context_provenance.metadata
+        @ Agent_sdk.Types.Extra_system_context_provenance.metadata
+    }
+  in
+  let unavailable ~prompt_context_present messages =
+    KAPM.provider_content_messages
+      ~prompt_context_present
+      ~projection_input:messages
+      ~projected_messages:messages
+    |> Option.map List.length
+  in
+  check (option int) "missing typed carrier is rejected" None
+    (unavailable ~prompt_context_present:true [ plain ]);
+  check (option int) "unexpected typed carrier is rejected" None
+    (unavailable ~prompt_context_present:false [ marked ]);
+  check (option int) "multiple typed carriers are rejected" None
+    (unavailable ~prompt_context_present:true [ marked; marked ]);
+  check (option int) "invalid typed carrier is rejected" None
+    (unavailable ~prompt_context_present:true [ invalid ]);
+  check (option int) "duplicate metadata key is rejected" None
+    (unavailable ~prompt_context_present:true [ duplicate ])
 ;;
 
 let test_provider_content_messages_rejects_projection_rewrite () =
@@ -496,10 +548,10 @@ let () =
         [
           test_case "attributes final provider input content" `Quick
             test_ctx_composition_splits_final_provider_input_bytes;
-          test_case
-            "requires typed prompt carrier provenance"
-            `Quick
-            test_provider_content_messages_requires_typed_prompt_carrier_provenance;
+          test_case "removes typed prompt carrier" `Quick
+            test_provider_content_messages_removes_typed_prompt_carrier;
+          test_case "rejects prompt carrier mismatch" `Quick
+            test_provider_content_messages_rejects_prompt_carrier_mismatch;
           test_case
             "rejects projection rewrites"
             `Quick

--- a/test/test_turn_record.ml
+++ b/test/test_turn_record.ml
@@ -5,6 +5,8 @@
 open Alcotest
 
 let block_id = testable (Fmt.of_to_string Prompt_block_id.to_string) Prompt_block_id.equal
+let turn_ref_t =
+  testable (Fmt.of_to_string Ids.Turn_ref.to_string) Ids.Turn_ref.equal
 
 (* ── Prompt_block_id ──────────────────────────────────── *)
 
@@ -83,12 +85,9 @@ let sample_record () : Turn_record.t =
   ; ts = 1781200000.5
   }
 
-(* The cache counts used to be dropped at the writer, so a row with a large
-   input_tokens could not be read as either a cache-heavy turn or a genuinely large
-   prompt. context_window denominates the ctx-fill percentage against the compaction
-   ceiling, so those two situations look identical on a dashboard while calling for
-   different action. A current provider that omits them carries None rather than a
-   fabricated zero. *)
+(* Cache counts distinguish a cache-heavy turn from a genuinely large prompt.
+   A current provider may omit those usage values; absence stays [None] rather
+   than becoming a fabricated zero. *)
 let test_cache_counts_round_trip_and_stay_optional () =
   let record = sample_record () in
   (match Turn_record.of_json (Turn_record.to_json record) with
@@ -98,7 +97,7 @@ let test_cache_counts_round_trip_and_stay_optional () =
        decoded.usage.cache_creation_input_tokens;
      check (option int) "cache read survives" (Some 15000)
        decoded.usage.cache_read_input_tokens);
-  let without_cache_counts =
+  let without_cache_usage =
     match Turn_record.to_json record with
     | `Assoc fields ->
       `Assoc
@@ -108,8 +107,8 @@ let test_cache_counts_round_trip_and_stay_optional () =
            fields)
     | other -> other
   in
-  match Turn_record.of_json without_cache_counts with
-  | Error e -> failf "row without cache fields failed to decode: %s" e
+  match Turn_record.of_json without_cache_usage with
+  | Error e -> failf "row without provider cache usage failed to decode: %s" e
   | Ok decoded ->
     check (option int) "absent cache creation decodes as None" None
       decoded.usage.cache_creation_input_tokens;
@@ -131,8 +130,7 @@ let test_codec_roundtrip () =
     check string "keeper" record.keeper decoded.keeper;
     check string "trace_id" record.trace_id decoded.trace_id;
     check int "absolute_turn" record.absolute_turn decoded.absolute_turn;
-    check bool "turn_ref preserved" true
-      (Ids.Turn_ref.equal record.turn_ref decoded.turn_ref);
+    check turn_ref_t "turn_ref preserved" record.turn_ref decoded.turn_ref;
     check int "blocks count" 3 (List.length decoded.blocks);
     check bool "blocks preserved in order" true
       (List.for_all2
@@ -289,7 +287,9 @@ let test_codec_optional_fields_absent () =
       decoded.sampling.temperature;
     check (option (float 0.0001)) "top_p absent" None decoded.sampling.top_p;
     check (option int) "max_tokens absent" None decoded.sampling.max_tokens;
-    check (option int) "input_tokens absent" None decoded.usage.input_tokens
+    check (option int) "input_tokens absent" None decoded.usage.input_tokens;
+    check turn_ref_t "required turn_ref remains exact" record.turn_ref
+      decoded.turn_ref
 
 let test_codec_rejects_malformed () =
   (match Turn_record.of_json (`String "not a record") with
@@ -319,6 +319,21 @@ let test_codec_requires_current_observation_fields () =
     ; "request_runtime_profile"
     ; "request_body_bytes"
     ]
+
+let test_codec_rejects_mismatched_turn_ref () =
+  let json =
+    match Turn_record.to_json (sample_record ()) with
+    | `Assoc fields ->
+      `Assoc
+        (("turn_ref", `String "different-trace#4071")
+         :: List.remove_assoc "turn_ref" fields)
+    | other -> other
+  in
+  match Turn_record.of_json json with
+  | Ok _ -> fail "decoded a turn_ref that disagrees with row identity"
+  | Error message ->
+    check bool "turn_ref mismatch is explicit" true
+      (Astring.String.is_infix ~affix:"does not match" message)
 
 let test_codec_rejects_partial_or_invalid_request_wire_observation () =
   let replace fields =
@@ -403,24 +418,41 @@ let test_codec_rejects_unknown_block () =
     | other -> other
   in
   match Turn_record.of_json json with
-  | Ok _ -> fail "decoded an unknown block"
+  | Ok _ -> fail "decoded a prompt block without a current producer"
   | Error message ->
     check bool "unknown block is explicit" true
-      (Astring.String.is_infix ~affix:"unknown prompt block id" message)
+      (Astring.String.is_infix ~affix:"future_block" message)
 
-let test_codec_rejects_mismatched_turn_ref () =
-  let record =
-    { (sample_record ()) with
-      turn_ref = Ids.Turn_ref.make ~trace_id:"different-trace" ~absolute_turn:4071
-    }
+let test_codec_rejects_unknown_fields () =
+  let record_json = Turn_record.to_json (sample_record ()) in
+  let with_unknown_record_field =
+    match record_json with
+    | `Assoc fields -> `Assoc (("retired_cursor", `String "old") :: fields)
+    | other -> other
   in
-  match Turn_record.of_json (Turn_record.to_json record) with
-  | Ok _ -> fail "decoded a mismatched turn_ref"
+  (match Turn_record.of_json with_unknown_record_field with
+   | Ok _ -> fail "decoded a turn record with an unknown field"
+   | Error message ->
+     check bool "record field rejection is explicit" true
+       (Astring.String.is_infix ~affix:"fields are not exact" message));
+  let with_unknown_block_field =
+    match record_json with
+    | `Assoc fields ->
+      let blocks =
+        match List.assoc "blocks" fields with
+        | `List (`Assoc block_fields :: rest) ->
+          `List (`Assoc (("retired_rank", `Int 1) :: block_fields) :: rest)
+        | other -> other
+      in
+      `Assoc (("blocks", blocks) :: List.remove_assoc "blocks" fields)
+    | other -> other
+  in
+  match Turn_record.of_json with_unknown_block_field with
+  | Ok _ -> fail "decoded a prompt block with an unknown field"
   | Error message ->
-    check bool "turn_ref mismatch is explicit" true
-      (Astring.String.is_infix
-         ~affix:"turn_ref does not match trace_id and absolute_turn"
-         message)
+    check bool "block field rejection is explicit" true
+      (Astring.String.is_infix ~affix:"prompt block fields are not exact" message)
+;;
 
 (* ── Block diff (RFC §5: exact added/removed set) ─────── *)
 
@@ -501,9 +533,6 @@ let test_entries_with_diffs_same_trace_only () =
 
 (* ── Turn_ref (RFC-0233 §7) ───────────────────────────── *)
 
-let turn_ref_t =
-  testable (Fmt.of_to_string Ids.Turn_ref.to_string) Ids.Turn_ref.equal
-
 let test_turn_ref_roundtrip () =
   let r =
     Ids.Turn_ref.make ~trace_id:"trace-1780648779957-00000" ~absolute_turn:4071
@@ -544,6 +573,8 @@ let () =
         ; test_case "rejects malformed rows" `Quick test_codec_rejects_malformed
         ; test_case "current observation fields required" `Quick
             test_codec_requires_current_observation_fields
+        ; test_case "mismatched turn_ref rejected" `Quick
+            test_codec_rejects_mismatched_turn_ref
         ; test_case "partial or invalid request wire observation rejected"
             `Quick
             test_codec_rejects_partial_or_invalid_request_wire_observation
@@ -551,10 +582,10 @@ let () =
             test_codec_rejects_unknown_input_component
         ; test_case "input component extra field rejected" `Quick
             test_codec_rejects_input_component_extra_field
-        ; test_case "unknown block rejected" `Quick
+        ; test_case "unknown block is rejected" `Quick
             test_codec_rejects_unknown_block
-        ; test_case "mismatched turn_ref rejected" `Quick
-            test_codec_rejects_mismatched_turn_ref
+        ; test_case "unknown fields are rejected" `Quick
+            test_codec_rejects_unknown_fields
         ] )
     ; ( "block_diff"
       , [ test_case "exact added/removed/changed sets" `Quick


### PR DESCRIPTION
## Summary
- pin released OAS v0.231.6 and remove only the typed extra-system-context carrier from provider-content attribution
- reject missing, invalid, duplicate, or unexpected carrier provenance; preserve projection-only Gate evidence
- hard-cut TurnRecord/backend/dashboard vocabularies to current producer-backed fields and reject unknown fields
- remove unused MemoryInspector compatibility fields and fabricated fallback keeper roster
- align OAS exact-output surface changes and serialized-request refusal rendering

## Contract
- no positional or content matching
- no legacy decoder, migration path, or compatibility field
- OAS producer -> MASC projection consumer is the direct typed path

## Verification
- `ocamlformat --check` on touched OCaml files
- `bash scripts/sync-oas-pin-manifests.sh --check`
- `bash scripts/check-oas-pin.sh --local-only`
- `bash scripts/oas-drift-check.sh`
- Dashboard `tsc --noEmit`
- focused Dashboard Vitest: 5 files, 98 tests passed
- local Dune intentionally not run per operator request; CI is build authority

## Related
- OAS provenance: #2894 / v0.231.6
- OAS merged-tree format repair: #2901

[근거] OAS v0.231.6 tag ae4cc55363b12ae47b9090e715c15dabba9f9f16 and MASC origin/main 09a6da50e9, checked 2026-07-30 KST, confidence High.