### PR TITLE
docs(memory): refresh adversarial audit evidence

### DIFF
--- a/reports/MASC-LIBRARIAN-MEMORY-OS-ADVERSARIAL-AUDIT-2026-07-30.html
+++ b/reports/MASC-LIBRARIAN-MEMORY-OS-ADVERSARIAL-AUDIT-2026-07-30.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <title>MASC Librarian / Memory OS 적대적 감사 보고서</title>
+  <title>MASC Librarian &amp; Memory OS Adversarial Audit</title>
   <style>
     /* Default styles provided by pandoc.
     ** See https://pandoc.org/MANUAL.html#variables-for-html for config info.
@@ -238,8 +238,179 @@
 </head>
 <body>
 <header id="title-block-header">
-<h1 class="title">MASC Librarian / Memory OS 적대적 감사 보고서</h1>
+<h1 class="title">MASC Librarian &amp; Memory OS Adversarial Audit</h1>
 </header>
+<nav id="TOC" role="doc-toc">
+<ul>
+<li><a href="#masc-librarian-memory-os-적대적-감사-보고서"
+id="toc-masc-librarian-memory-os-적대적-감사-보고서">MASC Librarian /
+Memory OS 적대적 감사 보고서</a>
+<ul>
+<li><a href="#executive-summary" id="toc-executive-summary">1. Executive
+Summary</a></li>
+<li><a href="#감사-범위와-증거-계층" id="toc-감사-범위와-증거-계층">2.
+감사 범위와 증거 계층</a>
+<ul>
+<li><a href="#source" id="toc-source">2.1 Source</a></li>
+<li><a href="#runtime" id="toc-runtime">2.2 Runtime</a></li>
+<li><a href="#ci-변경" id="toc-ci-변경">2.3 CI / 변경</a></li>
+</ul></li>
+<li><a href="#현재-open-pr과의-관계" id="toc-현재-open-pr과의-관계">3.
+현재 Open PR과의 관계</a>
+<ul>
+<li><a href="#a-폐기한-prototype과-oas-경계-결정"
+id="toc-a-폐기한-prototype과-oas-경계-결정">3.0A 폐기한 prototype과 OAS
+경계 결정</a></li>
+<li><a href="#pr-26324가-해결하는-부분"
+id="toc-pr-26324가-해결하는-부분">3.1 PR #26324가 해결하는 부분</a></li>
+<li><a href="#pr-26324가-해결하지-않는-부분"
+id="toc-pr-26324가-해결하지-않는-부분">3.2 PR #26324가 해결하지 않는
+부분</a></li>
+<li><a href="#pr-26410의-정확한-경계"
+id="toc-pr-26410의-정확한-경계">3.3 PR #26410의 정확한 경계</a></li>
+</ul></li>
+<li><a href="#실제-호출-흐름" id="toc-실제-호출-흐름">4. 실제 호출
+흐름</a></li>
+<li><a href="#p0-findings" id="toc-p0-findings">5. P0 Findings</a>
+<ul>
+<li><a href="#p0-1.-persistence-authority가-둘이다"
+id="toc-p0-1.-persistence-authority가-둘이다">P0-1. Persistence
+authority가 둘이다</a></li>
+<li><a href="#p0-2.-legacymigration-surface가-명시적으로-존재한다"
+id="toc-p0-2.-legacymigration-surface가-명시적으로-존재한다">P0-2.
+Legacy/migration surface가 명시적으로 존재한다</a></li>
+<li><a href="#p0-3.-turn-identity-ssot가-실제-데이터에서-깨진다"
+id="toc-p0-3.-turn-identity-ssot가-실제-데이터에서-깨진다">P0-3. Turn
+identity SSOT가 실제 데이터에서 깨진다</a></li>
+<li><a href="#p0-4.-손상된-fact가-무음으로-사라진다"
+id="toc-p0-4.-손상된-fact가-무음으로-사라진다">P0-4. 손상된 fact가
+무음으로 사라진다</a></li>
+<li><a
+href="#p0-5.-context-management가-고정-수치와-문자열-휴리스틱이다"
+id="toc-p0-5.-context-management가-고정-수치와-문자열-휴리스틱이다">P0-5.
+Context management가 고정 수치와 문자열 휴리스틱이다</a></li>
+<li><a
+href="#p0-6.-consolidation이-부분-모델-출력을-파괴적으로-적용한다"
+id="toc-p0-6.-consolidation이-부분-모델-출력을-파괴적으로-적용한다">P0-6.
+Consolidation이 부분 모델 출력을 파괴적으로 적용한다</a></li>
+<li><a
+href="#p0-7.-claim_kind-valid_until과-사망-field가-context와-분리된-authority다"
+id="toc-p0-7.-claim_kind-valid_until과-사망-field가-context와-분리된-authority다">P0-7.
+<code>claim_kind</code>, <code>valid_until</code>과 사망 field가
+context와 분리된 authority다</a></li>
+<li><a
+href="#p0-8.-park와-lease가-keeper-진행을-제약하는-별도-lifecycle이-됐다"
+id="toc-p0-8.-park와-lease가-keeper-진행을-제약하는-별도-lifecycle이-됐다">P0-8.
+<code>park</code>와 <code>lease</code>가 Keeper 진행을 제약하는 별도
+lifecycle이 됐다</a></li>
+<li><a
+href="#p0-9.-settlement가-canonical-terminal-state-위에-두-번째-facade를-만든다"
+id="toc-p0-9.-settlement가-canonical-terminal-state-위에-두-번째-facade를-만든다">P0-9.
+<code>settlement</code>가 canonical terminal state 위에 두 번째 Facade를
+만든다</a></li>
+</ul></li>
+<li><a href="#p1-findings" id="toc-p1-findings">6. P1 Findings</a>
+<ul>
+<li><a
+href="#p1-1.-librarian-snapshot-coalescing으로-의미-있는-turn이-유실될-수-있다"
+id="toc-p1-1.-librarian-snapshot-coalescing으로-의미-있는-turn이-유실될-수-있다">P1-1.
+Librarian snapshot coalescing으로 의미 있는 turn이 유실될 수
+있다</a></li>
+<li><a href="#p1-2.-memory-publication이-transaction이-아니다"
+id="toc-p1-2.-memory-publication이-transaction이-아니다">P1-2. Memory
+publication이 transaction이 아니다</a></li>
+<li><a href="#p1-3.-librarian-prompt-계약이-서로-모순된다"
+id="toc-p1-3.-librarian-prompt-계약이-서로-모순된다">P1-3. Librarian
+prompt 계약이 서로 모순된다</a></li>
+<li><a href="#p1-4.-provenance와-multimodal-정보가-손실된다"
+id="toc-p1-4.-provenance와-multimodal-정보가-손실된다">P1-4.
+Provenance와 multimodal 정보가 손실된다</a></li>
+<li><a
+href="#p1-5.-fleet-wide-serial-maintenance가-keeper-독립성을-침해한다"
+id="toc-p1-5.-fleet-wide-serial-maintenance가-keeper-독립성을-침해한다">P1-5.
+Fleet-wide serial maintenance가 Keeper 독립성을 침해한다</a></li>
+<li><a href="#p1-6.-ledger-관측-필드가-실제-의미와-다르다"
+id="toc-p1-6.-ledger-관측-필드가-실제-의미와-다르다">P1-6. Ledger 관측
+필드가 실제 의미와 다르다</a></li>
+<li><a href="#p1-7.-librarian-실패가-typed-turnhealth-상태가-아니다"
+id="toc-p1-7.-librarian-실패가-typed-turnhealth-상태가-아니다">P1-7.
+Librarian 실패가 typed turn/health 상태가 아니다</a></li>
+</ul></li>
+<li><a href="#n-n3-라이브-흐름" id="toc-n-n3-라이브-흐름">7. N → N+3
+라이브 흐름</a>
+<ul>
+<li><a href="#rondo-autonomous-turns-17721775"
+id="toc-rondo-autonomous-turns-17721775">7.1 Rondo autonomous turns
+1772–1775</a></li>
+<li><a href="#user-input-주변" id="toc-user-input-주변">7.2 User input
+주변</a></li>
+</ul></li>
+<li><a href="#확인된-양호점" id="toc-확인된-양호점">8. 확인된
+양호점</a></li>
+<li><a href="#ocaml-5.5-eio-기준" id="toc-ocaml-5.5-eio-기준">9. OCaml
+5.5 / Eio 기준</a></li>
+<li><a href="#시장-구현-비교" id="toc-시장-구현-비교">10. 시장 구현
+비교</a>
+<ul>
+<li><a href="#채택할-원칙" id="toc-채택할-원칙">10.1 채택할
+원칙</a></li>
+<li><a href="#복제하면-안-되는-것" id="toc-복제하면-안-되는-것">10.2
+복제하면 안 되는 것</a></li>
+</ul></li>
+<li><a href="#목표-아키텍처" id="toc-목표-아키텍처">11. 목표
+아키텍처</a>
+<ul>
+<li><a href="#유일한-조립-수식" id="toc-유일한-조립-수식">11.1 유일한
+조립 수식</a></li>
+<li><a href="#결정론-코드의-권한" id="toc-결정론-코드의-권한">11.2
+결정론 코드의 권한</a></li>
+<li><a href="#llm의-권한" id="toc-llm의-권한">11.3 LLM의 권한</a></li>
+<li><a href="#spatial-namespace" id="toc-spatial-namespace">11.4 Spatial
+namespace</a></li>
+</ul></li>
+<li><a href="#개선-goals와-측정-가능한-tasks"
+id="toc-개선-goals와-측정-가능한-tasks">12. 개선 Goals와 측정 가능한
+Tasks</a>
+<ul>
+<li><a href="#g0.-fresh-state-persistence-ssot"
+id="toc-g0.-fresh-state-persistence-ssot">G0. Fresh-state persistence
+SSOT</a></li>
+<li><a href="#g1.-turn-ledger-ssot" id="toc-g1.-turn-ledger-ssot">G1.
+Turn Ledger SSOT</a></li>
+<li><a href="#g2.-context-assembler" id="toc-g2.-context-assembler">G2.
+Context Assembler</a></li>
+<li><a href="#g3.-per-keeper-librarian-lane"
+id="toc-g3.-per-keeper-librarian-lane">G3. Per-Keeper Librarian
+Lane</a></li>
+<li><a href="#g4.-semantic-memory-policy"
+id="toc-g4.-semantic-memory-policy">G4. Semantic Memory Policy</a></li>
+<li><a href="#g5.-atomic-failure-and-failover"
+id="toc-g5.-atomic-failure-and-failover">G5. Atomic Failure and
+Failover</a></li>
+<li><a href="#g6.-observability" id="toc-g6.-observability">G6.
+Observability</a></li>
+<li><a href="#후속-구현-상태" id="toc-후속-구현-상태">12.1 2026-07-30
+후속 구현 상태</a></li>
+</ul></li>
+<li><a href="#권장-실행-순서" id="toc-권장-실행-순서">13. 권장 실행
+순서</a></li>
+<li><a href="#최종-결론" id="toc-최종-결론">14. 최종 결론</a></li>
+<li><a href="#evidence-record" id="toc-evidence-record">15. Evidence
+Record</a>
+<ul>
+<li><a href="#공통-헤더" id="toc-공통-헤더">15.1 공통 헤더</a></li>
+<li><a href="#근거-evidence" id="toc-근거-evidence">15.2 근거
+(Evidence)</a></li>
+<li><a href="#검증-verification" id="toc-검증-verification">15.3 검증
+(Verification)</a></li>
+<li><a href="#불확실성-uncertainty" id="toc-불확실성-uncertainty">15.4
+불확실성 (Uncertainty)</a></li>
+<li><a href="#적용범위-scope" id="toc-적용범위-scope">15.5 적용범위
+(Scope)</a></li>
+</ul></li>
+</ul></li>
+</ul>
+</nav>
 <h1 id="masc-librarian-memory-os-적대적-감사-보고서">MASC Librarian /
 Memory OS 적대적 감사 보고서</h1>
 <p>작성일: 2026-07-30</p>
@@ -292,6 +463,44 @@ versioned <code>schema</code> 문자열도 함께 제거했다. 새 closed
 decoder는 이 사망 필드가 다시 들어오면 unknown field로 거부한다. 이
 slice는 원자 publication의 선행 정리이며, atomic Memory authority 자체가
 완료됐다는 뜻은 아니다.</p>
+<p>2026-07-30 20:02 KST OAS 경계 재검토에서는 더 앞선 P0 두 개를
+확인했다. 기존 <code>flow_evidence</code>는 성공한
+<code>before_advance</code> 전이를 보존하지 않아 failover 경로를 복원할
+수 없고, HTTP 400 provider 오류 문구를 문자열 문법으로 해석해 typed
+context-overflow 사실으로 승격했다. MASC shadow codec은 OAS private
+invariant의 두 번째 SSOT가 되므로 전량 폐기했다. OAS PR <a
+href="https://github.com/jeong-sik/oas/pull/2892">#2892</a>는 성공한
+transport advance를 동일 atomic progress snapshot에 포함하고 문자열 기반
+분류와 사망 <code>Context_window_refused</code>를 제거했다. 후속 <a
+href="https://github.com/jeong-sik/oas/pull/2896">#2896</a>은 OAS-owned
+current-only validated-flow evidence와 direct
+<code>Agent_sdk.Exact_output</code> adapter를 추가했다. 실제 caller
+역추적 중 <code>No_measurement_dispatch</code> rejection의 terminal
+outcome과 optional measurement receipt가 살아 있는 증거임을 확인해
+과도한 숙청을 되돌렸다. <a
+href="https://github.com/jeong-sik/oas/pull/2899">#2899</a>는 canonical
+JSON을 <code>Yojson.Safe.t</code>로 닫았고, <a
+href="https://github.com/jeong-sik/oas/pull/2903">#2903</a>은 godfile
+증가를 private one-way leaf DAG로 제거했다. 그러나 #2903과
+<code>v0.231.9</code>는 <code>Option.exists</code>의 OCaml 5.4 비호환 및
+shared record label 추론 오류로 full CI가 실패했다. 후속 <a
+href="https://github.com/jeong-sik/oas/pull/2904">#2904</a>, <a
+href="https://github.com/jeong-sik/oas/pull/2906">#2906</a>, <a
+href="https://github.com/jeong-sik/oas/pull/2907">#2907</a>, <a
+href="https://github.com/jeong-sik/oas/pull/2908">#2908</a>이 실제
+domain boundary에 record 타입을 명시하고 5.4-compatible option match로
+교체했다. 이를 모두 포함한 <code>v0.231.10</code> exact release SHA
+<code>1fa61251936758d37c3a33eac07b8d95c5f26d35</code>는 CI run <a
+href="https://github.com/jeong-sik/oas/actions/runs/30536256908"><code>30536256908</code></a>에서
+OCaml 5.4.1/5.5.0, Eio 1.3/1.4, Lint, Format을 모두 통과했다. OAS
+release는 증명됐다. MASC <a
+href="https://github.com/jeong-sik/masc/pull/26489">#26489</a>는 exact
+pin을 main에 반영했고, Draft <a
+href="https://github.com/jeong-sik/masc/pull/26491">#26491</a>은 그 pin
+위에서 typed advance consumer와 serialized-request evidence를 구현했다.
+다만 #26489 exact-head Build/CI Gate는 merge 뒤 취소됐고 #26491
+exact-head CI가 진행 중이며 durable evidence production caller/runtime
+증거는 여전히 별도 차단 상태다.</p>
 <p>가장 중요한 차단 사유는 다음과 같다.</p>
 <ol type="1">
 <li>사용되지 않는 canonical store와 실제 JSONL store가 병존한다.</li>
@@ -327,6 +536,8 @@ base: <code>407ae5bb92509f06bfb6fc5614e8539e230b2902</code></li>
 <code>refactor/memory-current-only-hard-cut-20260730</code></li>
 <li>사망 필드/원자 publication 후속 branch:
 <code>refactor/memory-atomic-publication-20260730</code></li>
+<li>OAS evidence 선행 branch:
+<code>fix/exact-output-evidence-boundary-20260730</code></li>
 <li>current-only 1차 source slice:
 <code>6f8bf76a816d822ca0165b6a8c42986b3d466e5c</code></li>
 <li>TTL authority 제거 2차 source slice:
@@ -379,7 +590,7 @@ build artifact가 없어 실행할 수 없었다. 이를 위해 로컬 Dune buil
 <li>source, CI, merge, deployment, runtime 증거를 서로 분리했다.</li>
 </ul>
 <h2 id="현재-open-pr과의-관계">3. 현재 Open PR과의 관계</h2>
-<p>확인 시각: 2026-07-30 16:05 KST</p>
+<p>확인 시각: 2026-07-30 20:11 KST</p>
 <table>
 <colgroup>
 <col style="width: 20%" />
@@ -427,14 +638,14 @@ claim하는 ordering은 개선한다. 그러나 <code>park</code>를 공식 흐�
 <td><a href="https://github.com/jeong-sik/masc/pull/26428">#26428</a>
 <code>make current memory and provider input observable</code></td>
 <td>직접 충돌</td>
-<td><strong>Draft</strong>, head
-<code>508d77896e12f26652950d68c040830e0cb34691</code>,
-<code>MERGEABLE/BLOCKED</code>, <code>status:do-not-merge</code>,
-<code>reviewed:adversarial-non-pass</code></td>
+<td><strong>Closed</strong>, head
+<code>06764bdd9244409f162a03bf4cdafc5f2d5e79a2</code>,
+<code>status:do-not-merge</code>,
+<code>reviewed:adversarial-non-pass</code>; exact-head CI는 green</td>
 <td>immutable current snapshot/CAS와 provider-input observability 방향은
-유효하다. 그러나 current head에도 TTL/<code>claim_kind</code>/dead
-episode fields/latest-wins/cadence/prompt-local provenance가
-그대로다.</td>
+유효하다. 그러나 TTL/<code>claim_kind</code>/dead episode
+fields/latest-wins/cadence/prompt-local provenance를 포함한 잘못된
+authority가 남았다.</td>
 <td><strong>전체 채택 금지. atomic snapshot/관측성만 분리
 재구성</strong></td>
 </tr>
@@ -464,6 +675,131 @@ exact-head <code>Build and Test</code>, Dashboard, ocamlformat, CI
 Gate가 아직 실행 중이었고 merge 뒤 취소됐다.</td>
 <td><strong>source hard cut은 병합됐으나 exact-head full CI green 증거
 없음. cold cutover·runtime 증명 전 NO-GO</strong></td>
+</tr>
+<tr>
+<td><a href="https://github.com/jeong-sik/masc/pull/26450">#26450</a>
+<code>prepare current-only atomic publication</code></td>
+<td>본 감사 후속 구현</td>
+<td><strong>Merged</strong>, head
+<code>3cf500c78b16e80c17ee1867ac6c4eb3512d27ba</code>, merge commit
+<code>1910149d9e42c7e91b79915157506d695be72f18</code>;
+<code>Build and Test</code>/Dashboard 등 full CI skipped, 다수 check
+cancelled</td>
+<td><code>terminal_marker</code>/versioned dashboard schema를 숙청하고
+Librarian input을 <code>TurnRef</code>로 key했다. atomic revision은
+구현하지 않았다.</td>
+<td><strong>사망 필드 제거는 유효. CI·atomic commit·production caller
+증거 없음</strong></td>
+</tr>
+<tr>
+<td><a href="https://github.com/jeong-sik/masc/pull/26489">#26489</a>
+<code>pin agent sdk v0.231.10</code></td>
+<td>OAS release pin</td>
+<td><strong>Merged</strong>, head
+<code>c146ee46773f1813257dfad18060a679017bc31e</code>, merge commit
+<code>163f375010311b1798faeb42718439adfc1e4a41</code>; exact-head
+Build/CI Gate 취소</td>
+<td>OAS v0.231.10 SHA
+<code>1fa61251936758d37c3a33eac07b8d95c5f26d35</code>를
+manifest/API-surface SSOT에 반영한다.</td>
+<td><strong>source pin은 main 반영. exact-head MASC CI와 runtime proof
+전 NO-GO</strong></td>
+</tr>
+<tr>
+<td><a href="https://github.com/jeong-sik/masc/pull/26491">#26491</a>
+<code>bind turn evidence to serialized requests</code></td>
+<td>typed consumer/observability 후속</td>
+<td><strong>Draft</strong>, head
+<code>254b5ec30d81bfa9310f666f951d9a58e0c5d0bf</code>,
+<code>status:do-not-merge</code>; exact-head CI 진행 중</td>
+<td>#26489 pin 위에서 HITL summary가 typed advance를 직접 소비한다.
+request wire/prompt blocks/messages를 같은 serialized-request
+snapshot으로 묶고 unavailable composition을 <code>null</code>로
+보존한다.</td>
+<td><strong>source 후보 구현. exact-head CI와 durable evidence
+production caller/runtime proof 전 NO-GO</strong></td>
+</tr>
+<tr>
+<td><a href="https://github.com/jeong-sik/oas/pull/2892">OAS #2892</a>
+<code>preserve typed advance evidence</code></td>
+<td>G5 선행 경계</td>
+<td><strong>Merged</strong>, head
+<code>d2a56f315fc452d00a5ed55ea729746c800adfb2</code>, merge commit
+<code>7ce45ee3aa218b49dc13aaaebba1e2698aa22e2c</code>; exact-head CI
+완료 전 merge</td>
+<td>성공한 <code>before_advance</code>를 동일 atomic flow progress에
+기록하고 HTTP 400 오류 문구 기반 context-overflow 승격과 dead variant를
+제거한다.</td>
+<td><strong>source P0 없음. MASC/masc-mcp의 제거된 variant 소비자 hard
+cut 전 pin 금지</strong></td>
+</tr>
+<tr>
+<td><a href="https://github.com/jeong-sik/oas/pull/2896">OAS #2896</a>
+<code>persist validated flow evidence</code></td>
+<td>G5 durable evidence</td>
+<td><strong>Merged</strong>, head
+<code>e89c5d9e57b5e8cd2077468cc2e04fa21d0b09f6</code>, merge commit
+<code>f6cc38056</code>; 최초 CI는 <code>Yojson.Safe.t</code> 추론 오류와
+godfile <code>+1</code>로 실패</td>
+<td>actual mixed flow의 admission rejection → invalid JSON advance →
+semantic rejection → acceptance를 current-only canonical snapshot으로
+보존한다. projector exactly-once, strict decode, integrity 및 re-hashed
+structural tamper test를 추가한다.</td>
+<td><strong>기능 경계 유효. 최초 head는 compile/ratchet 불합격;
+#2899/#2903 후속 필수</strong></td>
+</tr>
+<tr>
+<td><a href="https://github.com/jeong-sik/oas/pull/2899">OAS #2899</a>
+<code>constrain canonical JSON to Safe.t</code></td>
+<td>#2896 compile repair</td>
+<td><strong>Merged</strong>, merge commit <code>b1fe0ec06</code>; OAS
+main <code>0.231.8</code> release 전 포함</td>
+<td>canonicalizer 입력/출력을 명시적 <code>Yojson.Safe.t</code>로 닫아
+<code>Floatlit</code>/<code>Tuple</code>/<code>Variant</code>
+polymorphic variant 추론 오류를 제거한다.</td>
+<td><strong>정확한 compiler root fix. full downstream proof는 #2903 CI와
+pin 이후</strong></td>
+</tr>
+<tr>
+<td><a href="https://github.com/jeong-sik/oas/pull/2903">OAS #2903</a>
+<code>split durable evidence codec leaves</code></td>
+<td>#2896 godfile root fix</td>
+<td><strong>Merged</strong>, head
+<code>22b9f0a07d5d28be81ad73d6899f225b0c9ee0c2</code>, merge commit
+<code>a923fc3889ba62a89cd42d91956d62dc0b674311</code>; ratchet PASS, CI
+run <code>30535040210</code> FAIL</td>
+<td>root가 create/decode/integrity orchestration을 직접 소유하고 types →
+canonical → validation → codec private DAG로 분리한다. pure alias
+facade와 godfile <code>+1</code>을 제거했지만 shared record label 추론이
+닫히지 않았다.</td>
+<td><strong>구조 방향은 유효하나 exact head는 compile 불합격. 단독 pin
+금지</strong></td>
+</tr>
+<tr>
+<td><a href="https://github.com/jeong-sik/oas/pull/2908">OAS
+#2904/#2906/#2907/#2908</a> <code>evidence type repairs</code></td>
+<td>#2903 compile repair chain</td>
+<td><strong>Merged</strong>, final merge
+<code>8d5d30b6a0f1a5175232533a7f5be5f18110ff44</code>; 중간 #2904/#2906
+exact-head CI는 실패</td>
+<td>canonical/codec/validation/consumer의 실제 domain 타입을 명시하고
+OCaml 5.4에 없는 <code>Option.exists</code>를 typed match로
+교체한다.</td>
+<td><strong>중간 merge는 불합격. 네 repair와 #2903을 포함한 v0.231.10
+exact release CI만 green proof</strong></td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/jeong-sik/oas/releases/tag/v0.231.10">OAS
+v0.231.10</a></td>
+<td>release/pin 후보</td>
+<td>SHA <code>1fa61251936758d37c3a33eac07b8d95c5f26d35</code>; CI run
+<code>30536256908</code> SUCCESS</td>
+<td>#2903/#2904/#2906/#2907/#2908 전체를 포함하며 public
+<code>.mli</code> surface 변화 없이 codec leaf와 compile repair를
+묶는다.</td>
+<td><strong>OAS release PASS. MASC #26489/#26491 exact-head CI와
+production caller/runtime proof 전 NO-GO 유지</strong></td>
 </tr>
 <tr>
 <td><a href="https://github.com/jeong-sik/masc/pull/26436">#26436</a>
@@ -500,6 +836,40 @@ authority도 추가 삭제했다.</td>
 </tr>
 </tbody>
 </table>
+<h3 id="a-폐기한-prototype과-oas-경계-결정">3.0A 폐기한 prototype과 OAS
+경계 결정</h3>
+<p>다음 prototype은 적대 검토에서 모두 <strong>do-not-ship</strong>으로
+판정해 commit 전에 전량 삭제했다.</p>
+<ul>
+<li>single-file current snapshot: 최소 receipt 위조, codec exception
+누출, duplicate identity 수용, rename 뒤 durability 세탁, path escape,
+O(n²) rewrite</li>
+<li>immutable revision/CURRENT prototype: canonical multi-turn source를
+표현하지 못하는 episode provenance, ancestry replay, nested symlink
+escape, production caller 부재</li>
+<li>MASC exact-evidence adapter: 약 1,780줄의 OAS shadow codec, OAS에서
+생성 불가능한 상태 decode 허용, selected/admission provenance 결합 누락,
+production caller 0</li>
+</ul>
+<p>결론은 OAS가 자기 private typed invariant에서 <strong>한 번</strong>
+current-only durable projection을 만들고, MASC는
+<code>Agent_sdk.Exact_output</code>을 직접 소비해야 한다는 것이다.
+Decoder는 live execution 타입을 재구성하지 않고 immutable abstract
+snapshot만 복원해야 한다. accepted/rejection polymorphic 값은 caller가
+digest를 임의 전달하지 않고, OAS가 실제 typed 값에 caller-owned
+projector를 정확히 한 번 적용해 결합해야 한다. final flow ledger는 한
+번만 저장하고 prior rejection prefix는 파생해야 하며, rejection마다 전체
+prefix를 중복하면 O(n²)·SSOT 위반이다.</p>
+<p>이 경계는 #2896/#2899/#2903과 #2904/#2906/#2907/#2908 compile
+repair로 source 구현됐고 v0.231.10 exact release CI에서 증명됐다. 특히
+처음 leaf가
+<code>Rejected = No_measurement_dispatch + Measurement_not_required + receipt=None</code>으로
+상태를 과도하게 축소했으나 실제 <code>admit_candidate_request</code>
+caller는 no-dispatch terminal outcome(<code>local_invalid</code>,
+<code>unsupported</code> 등)과 optional terminal receipt를 생성할 수
+있었다. 이것은 죽은 상태가 아니므로 복원했다. 반대로 measurement
+phase/version/visit-count처럼 valid successful transcript에서 항상
+파생되거나 도달 불가능한 durable field는 저장하지 않는다.</p>
 <h3 id="pr-26324가-해결하는-부분">3.1 PR #26324가 해결하는 부분</h3>
 <p>현재 exact-head patch에서 확인한 직접 개선:</p>
 <ul>
@@ -1493,12 +1863,16 @@ substring score, first-100-byte dedupe 잔존</td>
 </tr>
 <tr>
 <td>G5</td>
-<td>public fact/episode reader partial-drop 제거, recall unavailable 및
-dashboard read error 노출, publication phase failure를 typed result로
-분류</td>
-<td><strong>부분 완료</strong> — journal terminal이 publication보다
-앞서고 facts→episode→event partial commit/rollback이 없어 atomic
-revision/failover receipt 미구현</td>
+<td>public fact/episode reader partial-drop 제거, recall
+unavailable/dashboard read error 노출, publication phase failure typed
+result 분류, OAS 성공 transport advance evidence/prose heuristic hard
+cut(#2892), current-only validated-flow snapshot/direct adapter(#2896),
+Safe.t compiler fix(#2899), private leaf split(#2903), typed compile
+repair(#2904/#2906/#2907/#2908)</td>
+<td><strong>부분 완료</strong> — OAS v0.231.10 exact release CI green;
+MASC #26489 exact pin은 main 반영, #26491 typed advance consumer는 CI
+진행 중이며 atomic revision/CURRENT CAS/durable evidence production
+caller/runtime proof 미구현</td>
 </tr>
 <tr>
 <td>G6</td>
@@ -1542,6 +1916,34 @@ config/snapshot/docs/test symbol scan 0</li>
 build artifact가 없어 미실행</li>
 <li>로컬 Dune 미실행; OCaml type/link/build/test는 <strong>CI
 미증명</strong></li>
+<li>OAS #2892 local: touched OCaml 전부 <code>ocamlformat</code>,
+parse-only, <code>git diff --check</code> 통과. Dune 미실행. head
+<code>d2a56f315...</code>은 full CI 전 merge</li>
+<li>OAS #2896 local: mixed four-candidate loopback test, projector
+cardinality, canonical roundtrip, stale-integrity tamper와 re-hashed
+structural tamper를 추가. 최초 CI는 <code>Yojson.Safe.t</code> 타입
+추론과 godfile <code>+1</code>로 실패</li>
+<li>OAS #2899: canonical JSON을 명시적 <code>Yojson.Safe.t</code>로 닫는
+compiler root fix</li>
+<li>OAS #2903 local: root 125L, types 217L, canonical 243L, validation
+primitives 284L, validation 192L, codec 403L;
+parser/format/diff/boundary gate와 code-smell ratchet
+<code>godfile 11 → 11</code> 통과. exact-head CI
+<code>30535040210</code>은 record-label 추론 오류로 실패</li>
+<li>OAS #2904/#2906 중간 exact-head Build/Lint/Eio 실패를 확인한 뒤
+#2907/#2908에서 consumer·codec·validation leaf의 typed boundary와 OCaml
+5.4 option match를 닫음</li>
+<li>OAS v0.231.10 SHA
+<code>1fa61251936758d37c3a33eac07b8d95c5f26d35</code>: CI
+<code>30536256908</code>에서 OCaml 5.4.1/5.5.0 Build &amp; Test, Eio
+1.3/1.4, Lint, Format 전부 성공</li>
+<li>MASC #26489가 OAS v0.231.10 exact pin을 main에 반영했으나 exact-head
+Build/CI Gate는 merge 뒤 취소</li>
+<li>MASC #26491 head
+<code>254b5ec30d81bfa9310f666f951d9a58e0c5d0bf</code>: changed OCaml
+format/parser, dashboard typecheck와 focused 2 files/37 tests, OAS pin
+manifest/API-surface drift check, shell/JSON/diff check 통과. 로컬 Dune
+미실행; exact-head PR CI 진행 중</li>
 </ul>
 <p>Fresh-state cutover blocker:</p>
 <ul>
@@ -1614,7 +2016,7 @@ exact-head <code>Build and Test</code>/<code>CI Gate</code>가 merge 뒤
 <h3 id="공통-헤더">15.1 공통 헤더</h3>
 <ul>
 <li><code>날짜(ISO8601)</code>:
-<code>2026-07-30T16:05:00+09:00</code></li>
+<code>2026-07-30T20:11:00+09:00</code></li>
 <li><code>작성자</code>: <code>Codex</code></li>
 <li><code>결정 ID</code>:
 <code>masc-memory-os-adversarial-audit-20260730</code></li>
@@ -1650,8 +2052,11 @@ startup repo HEAD</li>
 <ul>
 <li><code>항목</code>: 현재 open PR의 finding coverage</li>
 <li><code>출처</code>: <code>gh pr list</code>, <code>gh pr view</code>,
-GitHub changed-file 및 exact file patch</li>
-<li><code>확인일시</code>: <code>2026-07-30T16:05:00+09:00</code></li>
+GitHub changed-file 및 exact file patch; MASC
+#26428/#26440/#26450/#26489/#26491, OAS
+#2892/#2896/#2899/#2903/#2904/#2906/#2907/#2908, OAS CI
+<code>30536256908</code></li>
+<li><code>확인일시</code>: <code>2026-07-30T20:11:00+09:00</code></li>
 <li><code>신뢰도</code>: <code>High</code></li>
 <li><code>제한조건</code>: PR head/check 상태는 이후 push에 따라 변경
 가능</li>
@@ -1660,9 +2065,12 @@ GitHub changed-file 및 exact file patch</li>
 <ul>
 <li><code>항목</code>: OCaml 5.5 memory model과 Eio cancellation/mutex
 기준</li>
-<li><code>출처</code>: OCaml 5.5 official manual, Eio official API
-docs</li>
-<li><code>확인일시</code>: <code>2026-07-30T10:53:00+09:00</code></li>
+<li><code>출처</code>: <a
+href="https://ocaml.org/manual/5.5/index.html">OCaml 5.5 official
+manual</a>, <a
+href="https://ocaml.org/manual/5.5/parallelism.html">OCaml 5.5 parallel
+programming</a>, Eio official API docs</li>
+<li><code>확인일시</code>: <code>2026-07-30T18:29:00+09:00</code></li>
 <li><code>신뢰도</code>: <code>High</code></li>
 <li><code>제한조건</code>: MASC-specific architecture 판정은 공식
 언어/runtime 계약의 적용 결과</li>
@@ -1690,8 +2098,14 @@ JSONL/SQLite aggregate 확인</li>
 동일 heuristic/identity 결함 확인. 후속 worktree의 dead
 Store/field/BasePath hard cut은 변경 OCaml 전체 format/parse, dashboard
 typecheck, focused 7 files/255 tests, Python 24 tests와 static check를
-통과했다. TTL/expiry authority production reference도 제거됐다.
-Dune/CI와 runtime cutover는 미검증.</li>
+통과했다. TTL/expiry authority production reference도 제거됐다. OAS
+#2892/#2896/#2899/#2903과 #2904/#2906/#2907/#2908은 advance evidence,
+provider prose hard cut, validated-flow durable snapshot, Safe.t
+compiler root fix, private leaf split, typed compile repair까지
+진행했다. v0.231.10 exact release CI는 전부 green이다. MASC #26489는
+exact pin을 main에 반영했고 #26491은 typed advance consumer를
+구현했지만, 두 MASC exact-head CI와 durable evidence production
+caller/runtime cutover는 미검증이다.</li>
 </ul>
 <h3 id="불확실성-uncertainty">15.4 불확실성 (Uncertainty)</h3>
 <ul>
@@ -1701,12 +2115,15 @@ SHA</p></li>
 cryptographic deployment identity라고 단정할 수 없음</p></li>
 <li><p><code>추가 확인 필요</code>: build artifact에 commit SHA를
 embed하고 health가 그 값을 직접 반환</p></li>
-<li><p><code>미확인 항목</code>: Draft PR #26440 exact-head CI와 #26428
-current-head fresh CI</p></li>
-<li><p><code>영향</code>: 후속 source finding coverage는 정적 검증됐지만
-merge/deployment readiness는 아직 증명되지 않음</p></li>
-<li><p><code>추가 확인 필요</code>: draft PR push 후 head SHA, required
-checks, unresolved review threads 재확인</p></li>
+<li><p><code>미확인 항목</code>: merge된 MASC #26440/#26450/#26489의
+exact-head full CI, MASC #26491 exact-head CI와 durable evidence
+production caller/runtime proof</p></li>
+<li><p><code>영향</code>: MASC source hard cut은 병합됐지만
+Build/Dashboard가 취소 또는 skipped됐고, failover evidence와 exact pin은
+source에 들어왔지만 MASC runtime의 durable production caller로
+연결됐다는 증거는 없음</p></li>
+<li><p><code>추가 확인 필요</code>: MASC #26489 포함 current-main 및
+#26491 exact-head CI, production caller/N→N+3 restart proof</p></li>
 </ul>
 <h3 id="적용범위-scope">15.5 적용범위 (Scope)</h3>
 <ul>

--- a/reports/MASC-LIBRARIAN-MEMORY-OS-ADVERSARIAL-AUDIT-2026-07-30.html
+++ b/reports/MASC-LIBRARIAN-MEMORY-OS-ADVERSARIAL-AUDIT-2026-07-30.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <title>MASC Librarian &amp; Memory OS Adversarial Audit</title>
+  <title>MASC Librarian / Memory OS 적대적 감사 보고서</title>
   <style>
     /* Default styles provided by pandoc.
     ** See https://pandoc.org/MANUAL.html#variables-for-html for config info.
@@ -238,179 +238,8 @@
 </head>
 <body>
 <header id="title-block-header">
-<h1 class="title">MASC Librarian &amp; Memory OS Adversarial Audit</h1>
+<h1 class="title">MASC Librarian / Memory OS 적대적 감사 보고서</h1>
 </header>
-<nav id="TOC" role="doc-toc">
-<ul>
-<li><a href="#masc-librarian-memory-os-적대적-감사-보고서"
-id="toc-masc-librarian-memory-os-적대적-감사-보고서">MASC Librarian /
-Memory OS 적대적 감사 보고서</a>
-<ul>
-<li><a href="#executive-summary" id="toc-executive-summary">1. Executive
-Summary</a></li>
-<li><a href="#감사-범위와-증거-계층" id="toc-감사-범위와-증거-계층">2.
-감사 범위와 증거 계층</a>
-<ul>
-<li><a href="#source" id="toc-source">2.1 Source</a></li>
-<li><a href="#runtime" id="toc-runtime">2.2 Runtime</a></li>
-<li><a href="#ci-변경" id="toc-ci-변경">2.3 CI / 변경</a></li>
-</ul></li>
-<li><a href="#현재-open-pr과의-관계" id="toc-현재-open-pr과의-관계">3.
-현재 Open PR과의 관계</a>
-<ul>
-<li><a href="#a-폐기한-prototype과-oas-경계-결정"
-id="toc-a-폐기한-prototype과-oas-경계-결정">3.0A 폐기한 prototype과 OAS
-경계 결정</a></li>
-<li><a href="#pr-26324가-해결하는-부분"
-id="toc-pr-26324가-해결하는-부분">3.1 PR #26324가 해결하는 부분</a></li>
-<li><a href="#pr-26324가-해결하지-않는-부분"
-id="toc-pr-26324가-해결하지-않는-부분">3.2 PR #26324가 해결하지 않는
-부분</a></li>
-<li><a href="#pr-26410의-정확한-경계"
-id="toc-pr-26410의-정확한-경계">3.3 PR #26410의 정확한 경계</a></li>
-</ul></li>
-<li><a href="#실제-호출-흐름" id="toc-실제-호출-흐름">4. 실제 호출
-흐름</a></li>
-<li><a href="#p0-findings" id="toc-p0-findings">5. P0 Findings</a>
-<ul>
-<li><a href="#p0-1.-persistence-authority가-둘이다"
-id="toc-p0-1.-persistence-authority가-둘이다">P0-1. Persistence
-authority가 둘이다</a></li>
-<li><a href="#p0-2.-legacymigration-surface가-명시적으로-존재한다"
-id="toc-p0-2.-legacymigration-surface가-명시적으로-존재한다">P0-2.
-Legacy/migration surface가 명시적으로 존재한다</a></li>
-<li><a href="#p0-3.-turn-identity-ssot가-실제-데이터에서-깨진다"
-id="toc-p0-3.-turn-identity-ssot가-실제-데이터에서-깨진다">P0-3. Turn
-identity SSOT가 실제 데이터에서 깨진다</a></li>
-<li><a href="#p0-4.-손상된-fact가-무음으로-사라진다"
-id="toc-p0-4.-손상된-fact가-무음으로-사라진다">P0-4. 손상된 fact가
-무음으로 사라진다</a></li>
-<li><a
-href="#p0-5.-context-management가-고정-수치와-문자열-휴리스틱이다"
-id="toc-p0-5.-context-management가-고정-수치와-문자열-휴리스틱이다">P0-5.
-Context management가 고정 수치와 문자열 휴리스틱이다</a></li>
-<li><a
-href="#p0-6.-consolidation이-부분-모델-출력을-파괴적으로-적용한다"
-id="toc-p0-6.-consolidation이-부분-모델-출력을-파괴적으로-적용한다">P0-6.
-Consolidation이 부분 모델 출력을 파괴적으로 적용한다</a></li>
-<li><a
-href="#p0-7.-claim_kind-valid_until과-사망-field가-context와-분리된-authority다"
-id="toc-p0-7.-claim_kind-valid_until과-사망-field가-context와-분리된-authority다">P0-7.
-<code>claim_kind</code>, <code>valid_until</code>과 사망 field가
-context와 분리된 authority다</a></li>
-<li><a
-href="#p0-8.-park와-lease가-keeper-진행을-제약하는-별도-lifecycle이-됐다"
-id="toc-p0-8.-park와-lease가-keeper-진행을-제약하는-별도-lifecycle이-됐다">P0-8.
-<code>park</code>와 <code>lease</code>가 Keeper 진행을 제약하는 별도
-lifecycle이 됐다</a></li>
-<li><a
-href="#p0-9.-settlement가-canonical-terminal-state-위에-두-번째-facade를-만든다"
-id="toc-p0-9.-settlement가-canonical-terminal-state-위에-두-번째-facade를-만든다">P0-9.
-<code>settlement</code>가 canonical terminal state 위에 두 번째 Facade를
-만든다</a></li>
-</ul></li>
-<li><a href="#p1-findings" id="toc-p1-findings">6. P1 Findings</a>
-<ul>
-<li><a
-href="#p1-1.-librarian-snapshot-coalescing으로-의미-있는-turn이-유실될-수-있다"
-id="toc-p1-1.-librarian-snapshot-coalescing으로-의미-있는-turn이-유실될-수-있다">P1-1.
-Librarian snapshot coalescing으로 의미 있는 turn이 유실될 수
-있다</a></li>
-<li><a href="#p1-2.-memory-publication이-transaction이-아니다"
-id="toc-p1-2.-memory-publication이-transaction이-아니다">P1-2. Memory
-publication이 transaction이 아니다</a></li>
-<li><a href="#p1-3.-librarian-prompt-계약이-서로-모순된다"
-id="toc-p1-3.-librarian-prompt-계약이-서로-모순된다">P1-3. Librarian
-prompt 계약이 서로 모순된다</a></li>
-<li><a href="#p1-4.-provenance와-multimodal-정보가-손실된다"
-id="toc-p1-4.-provenance와-multimodal-정보가-손실된다">P1-4.
-Provenance와 multimodal 정보가 손실된다</a></li>
-<li><a
-href="#p1-5.-fleet-wide-serial-maintenance가-keeper-독립성을-침해한다"
-id="toc-p1-5.-fleet-wide-serial-maintenance가-keeper-독립성을-침해한다">P1-5.
-Fleet-wide serial maintenance가 Keeper 독립성을 침해한다</a></li>
-<li><a href="#p1-6.-ledger-관측-필드가-실제-의미와-다르다"
-id="toc-p1-6.-ledger-관측-필드가-실제-의미와-다르다">P1-6. Ledger 관측
-필드가 실제 의미와 다르다</a></li>
-<li><a href="#p1-7.-librarian-실패가-typed-turnhealth-상태가-아니다"
-id="toc-p1-7.-librarian-실패가-typed-turnhealth-상태가-아니다">P1-7.
-Librarian 실패가 typed turn/health 상태가 아니다</a></li>
-</ul></li>
-<li><a href="#n-n3-라이브-흐름" id="toc-n-n3-라이브-흐름">7. N → N+3
-라이브 흐름</a>
-<ul>
-<li><a href="#rondo-autonomous-turns-17721775"
-id="toc-rondo-autonomous-turns-17721775">7.1 Rondo autonomous turns
-1772–1775</a></li>
-<li><a href="#user-input-주변" id="toc-user-input-주변">7.2 User input
-주변</a></li>
-</ul></li>
-<li><a href="#확인된-양호점" id="toc-확인된-양호점">8. 확인된
-양호점</a></li>
-<li><a href="#ocaml-5.5-eio-기준" id="toc-ocaml-5.5-eio-기준">9. OCaml
-5.5 / Eio 기준</a></li>
-<li><a href="#시장-구현-비교" id="toc-시장-구현-비교">10. 시장 구현
-비교</a>
-<ul>
-<li><a href="#채택할-원칙" id="toc-채택할-원칙">10.1 채택할
-원칙</a></li>
-<li><a href="#복제하면-안-되는-것" id="toc-복제하면-안-되는-것">10.2
-복제하면 안 되는 것</a></li>
-</ul></li>
-<li><a href="#목표-아키텍처" id="toc-목표-아키텍처">11. 목표
-아키텍처</a>
-<ul>
-<li><a href="#유일한-조립-수식" id="toc-유일한-조립-수식">11.1 유일한
-조립 수식</a></li>
-<li><a href="#결정론-코드의-권한" id="toc-결정론-코드의-권한">11.2
-결정론 코드의 권한</a></li>
-<li><a href="#llm의-권한" id="toc-llm의-권한">11.3 LLM의 권한</a></li>
-<li><a href="#spatial-namespace" id="toc-spatial-namespace">11.4 Spatial
-namespace</a></li>
-</ul></li>
-<li><a href="#개선-goals와-측정-가능한-tasks"
-id="toc-개선-goals와-측정-가능한-tasks">12. 개선 Goals와 측정 가능한
-Tasks</a>
-<ul>
-<li><a href="#g0.-fresh-state-persistence-ssot"
-id="toc-g0.-fresh-state-persistence-ssot">G0. Fresh-state persistence
-SSOT</a></li>
-<li><a href="#g1.-turn-ledger-ssot" id="toc-g1.-turn-ledger-ssot">G1.
-Turn Ledger SSOT</a></li>
-<li><a href="#g2.-context-assembler" id="toc-g2.-context-assembler">G2.
-Context Assembler</a></li>
-<li><a href="#g3.-per-keeper-librarian-lane"
-id="toc-g3.-per-keeper-librarian-lane">G3. Per-Keeper Librarian
-Lane</a></li>
-<li><a href="#g4.-semantic-memory-policy"
-id="toc-g4.-semantic-memory-policy">G4. Semantic Memory Policy</a></li>
-<li><a href="#g5.-atomic-failure-and-failover"
-id="toc-g5.-atomic-failure-and-failover">G5. Atomic Failure and
-Failover</a></li>
-<li><a href="#g6.-observability" id="toc-g6.-observability">G6.
-Observability</a></li>
-<li><a href="#후속-구현-상태" id="toc-후속-구현-상태">12.1 2026-07-30
-후속 구현 상태</a></li>
-</ul></li>
-<li><a href="#권장-실행-순서" id="toc-권장-실행-순서">13. 권장 실행
-순서</a></li>
-<li><a href="#최종-결론" id="toc-최종-결론">14. 최종 결론</a></li>
-<li><a href="#evidence-record" id="toc-evidence-record">15. Evidence
-Record</a>
-<ul>
-<li><a href="#공통-헤더" id="toc-공통-헤더">15.1 공통 헤더</a></li>
-<li><a href="#근거-evidence" id="toc-근거-evidence">15.2 근거
-(Evidence)</a></li>
-<li><a href="#검증-verification" id="toc-검증-verification">15.3 검증
-(Verification)</a></li>
-<li><a href="#불확실성-uncertainty" id="toc-불확실성-uncertainty">15.4
-불확실성 (Uncertainty)</a></li>
-<li><a href="#적용범위-scope" id="toc-적용범위-scope">15.5 적용범위
-(Scope)</a></li>
-</ul></li>
-</ul></li>
-</ul>
-</nav>
 <h1 id="masc-librarian-memory-os-적대적-감사-보고서">MASC Librarian /
 Memory OS 적대적 감사 보고서</h1>
 <p>작성일: 2026-07-30</p>
@@ -463,44 +292,6 @@ versioned <code>schema</code> 문자열도 함께 제거했다. 새 closed
 decoder는 이 사망 필드가 다시 들어오면 unknown field로 거부한다. 이
 slice는 원자 publication의 선행 정리이며, atomic Memory authority 자체가
 완료됐다는 뜻은 아니다.</p>
-<p>2026-07-30 20:02 KST OAS 경계 재검토에서는 더 앞선 P0 두 개를
-확인했다. 기존 <code>flow_evidence</code>는 성공한
-<code>before_advance</code> 전이를 보존하지 않아 failover 경로를 복원할
-수 없고, HTTP 400 provider 오류 문구를 문자열 문법으로 해석해 typed
-context-overflow 사실으로 승격했다. MASC shadow codec은 OAS private
-invariant의 두 번째 SSOT가 되므로 전량 폐기했다. OAS PR <a
-href="https://github.com/jeong-sik/oas/pull/2892">#2892</a>는 성공한
-transport advance를 동일 atomic progress snapshot에 포함하고 문자열 기반
-분류와 사망 <code>Context_window_refused</code>를 제거했다. 후속 <a
-href="https://github.com/jeong-sik/oas/pull/2896">#2896</a>은 OAS-owned
-current-only validated-flow evidence와 direct
-<code>Agent_sdk.Exact_output</code> adapter를 추가했다. 실제 caller
-역추적 중 <code>No_measurement_dispatch</code> rejection의 terminal
-outcome과 optional measurement receipt가 살아 있는 증거임을 확인해
-과도한 숙청을 되돌렸다. <a
-href="https://github.com/jeong-sik/oas/pull/2899">#2899</a>는 canonical
-JSON을 <code>Yojson.Safe.t</code>로 닫았고, <a
-href="https://github.com/jeong-sik/oas/pull/2903">#2903</a>은 godfile
-증가를 private one-way leaf DAG로 제거했다. 그러나 #2903과
-<code>v0.231.9</code>는 <code>Option.exists</code>의 OCaml 5.4 비호환 및
-shared record label 추론 오류로 full CI가 실패했다. 후속 <a
-href="https://github.com/jeong-sik/oas/pull/2904">#2904</a>, <a
-href="https://github.com/jeong-sik/oas/pull/2906">#2906</a>, <a
-href="https://github.com/jeong-sik/oas/pull/2907">#2907</a>, <a
-href="https://github.com/jeong-sik/oas/pull/2908">#2908</a>이 실제
-domain boundary에 record 타입을 명시하고 5.4-compatible option match로
-교체했다. 이를 모두 포함한 <code>v0.231.10</code> exact release SHA
-<code>1fa61251936758d37c3a33eac07b8d95c5f26d35</code>는 CI run <a
-href="https://github.com/jeong-sik/oas/actions/runs/30536256908"><code>30536256908</code></a>에서
-OCaml 5.4.1/5.5.0, Eio 1.3/1.4, Lint, Format을 모두 통과했다. OAS
-release는 증명됐다. MASC <a
-href="https://github.com/jeong-sik/masc/pull/26489">#26489</a>는 exact
-pin을 main에 반영했고, Draft <a
-href="https://github.com/jeong-sik/masc/pull/26491">#26491</a>은 그 pin
-위에서 typed advance consumer와 serialized-request evidence를 구현했다.
-다만 #26489 exact-head Build/CI Gate는 merge 뒤 취소됐고 #26491
-exact-head CI가 진행 중이며 durable evidence production caller/runtime
-증거는 여전히 별도 차단 상태다.</p>
 <p>가장 중요한 차단 사유는 다음과 같다.</p>
 <ol type="1">
 <li>사용되지 않는 canonical store와 실제 JSONL store가 병존한다.</li>
@@ -536,8 +327,6 @@ base: <code>407ae5bb92509f06bfb6fc5614e8539e230b2902</code></li>
 <code>refactor/memory-current-only-hard-cut-20260730</code></li>
 <li>사망 필드/원자 publication 후속 branch:
 <code>refactor/memory-atomic-publication-20260730</code></li>
-<li>OAS evidence 선행 branch:
-<code>fix/exact-output-evidence-boundary-20260730</code></li>
 <li>current-only 1차 source slice:
 <code>6f8bf76a816d822ca0165b6a8c42986b3d466e5c</code></li>
 <li>TTL authority 제거 2차 source slice:
@@ -590,7 +379,7 @@ build artifact가 없어 실행할 수 없었다. 이를 위해 로컬 Dune buil
 <li>source, CI, merge, deployment, runtime 증거를 서로 분리했다.</li>
 </ul>
 <h2 id="현재-open-pr과의-관계">3. 현재 Open PR과의 관계</h2>
-<p>확인 시각: 2026-07-30 20:11 KST</p>
+<p>확인 시각: 2026-07-30 16:05 KST</p>
 <table>
 <colgroup>
 <col style="width: 20%" />
@@ -638,14 +427,14 @@ claim하는 ordering은 개선한다. 그러나 <code>park</code>를 공식 흐�
 <td><a href="https://github.com/jeong-sik/masc/pull/26428">#26428</a>
 <code>make current memory and provider input observable</code></td>
 <td>직접 충돌</td>
-<td><strong>Closed</strong>, head
-<code>06764bdd9244409f162a03bf4cdafc5f2d5e79a2</code>,
-<code>status:do-not-merge</code>,
-<code>reviewed:adversarial-non-pass</code>; exact-head CI는 green</td>
+<td><strong>Draft</strong>, head
+<code>508d77896e12f26652950d68c040830e0cb34691</code>,
+<code>MERGEABLE/BLOCKED</code>, <code>status:do-not-merge</code>,
+<code>reviewed:adversarial-non-pass</code></td>
 <td>immutable current snapshot/CAS와 provider-input observability 방향은
-유효하다. 그러나 TTL/<code>claim_kind</code>/dead episode
-fields/latest-wins/cadence/prompt-local provenance를 포함한 잘못된
-authority가 남았다.</td>
+유효하다. 그러나 current head에도 TTL/<code>claim_kind</code>/dead
+episode fields/latest-wins/cadence/prompt-local provenance가
+그대로다.</td>
 <td><strong>전체 채택 금지. atomic snapshot/관측성만 분리
 재구성</strong></td>
 </tr>
@@ -675,131 +464,6 @@ exact-head <code>Build and Test</code>, Dashboard, ocamlformat, CI
 Gate가 아직 실행 중이었고 merge 뒤 취소됐다.</td>
 <td><strong>source hard cut은 병합됐으나 exact-head full CI green 증거
 없음. cold cutover·runtime 증명 전 NO-GO</strong></td>
-</tr>
-<tr>
-<td><a href="https://github.com/jeong-sik/masc/pull/26450">#26450</a>
-<code>prepare current-only atomic publication</code></td>
-<td>본 감사 후속 구현</td>
-<td><strong>Merged</strong>, head
-<code>3cf500c78b16e80c17ee1867ac6c4eb3512d27ba</code>, merge commit
-<code>1910149d9e42c7e91b79915157506d695be72f18</code>;
-<code>Build and Test</code>/Dashboard 등 full CI skipped, 다수 check
-cancelled</td>
-<td><code>terminal_marker</code>/versioned dashboard schema를 숙청하고
-Librarian input을 <code>TurnRef</code>로 key했다. atomic revision은
-구현하지 않았다.</td>
-<td><strong>사망 필드 제거는 유효. CI·atomic commit·production caller
-증거 없음</strong></td>
-</tr>
-<tr>
-<td><a href="https://github.com/jeong-sik/masc/pull/26489">#26489</a>
-<code>pin agent sdk v0.231.10</code></td>
-<td>OAS release pin</td>
-<td><strong>Merged</strong>, head
-<code>c146ee46773f1813257dfad18060a679017bc31e</code>, merge commit
-<code>163f375010311b1798faeb42718439adfc1e4a41</code>; exact-head
-Build/CI Gate 취소</td>
-<td>OAS v0.231.10 SHA
-<code>1fa61251936758d37c3a33eac07b8d95c5f26d35</code>를
-manifest/API-surface SSOT에 반영한다.</td>
-<td><strong>source pin은 main 반영. exact-head MASC CI와 runtime proof
-전 NO-GO</strong></td>
-</tr>
-<tr>
-<td><a href="https://github.com/jeong-sik/masc/pull/26491">#26491</a>
-<code>bind turn evidence to serialized requests</code></td>
-<td>typed consumer/observability 후속</td>
-<td><strong>Draft</strong>, head
-<code>254b5ec30d81bfa9310f666f951d9a58e0c5d0bf</code>,
-<code>status:do-not-merge</code>; exact-head CI 진행 중</td>
-<td>#26489 pin 위에서 HITL summary가 typed advance를 직접 소비한다.
-request wire/prompt blocks/messages를 같은 serialized-request
-snapshot으로 묶고 unavailable composition을 <code>null</code>로
-보존한다.</td>
-<td><strong>source 후보 구현. exact-head CI와 durable evidence
-production caller/runtime proof 전 NO-GO</strong></td>
-</tr>
-<tr>
-<td><a href="https://github.com/jeong-sik/oas/pull/2892">OAS #2892</a>
-<code>preserve typed advance evidence</code></td>
-<td>G5 선행 경계</td>
-<td><strong>Merged</strong>, head
-<code>d2a56f315fc452d00a5ed55ea729746c800adfb2</code>, merge commit
-<code>7ce45ee3aa218b49dc13aaaebba1e2698aa22e2c</code>; exact-head CI
-완료 전 merge</td>
-<td>성공한 <code>before_advance</code>를 동일 atomic flow progress에
-기록하고 HTTP 400 오류 문구 기반 context-overflow 승격과 dead variant를
-제거한다.</td>
-<td><strong>source P0 없음. MASC/masc-mcp의 제거된 variant 소비자 hard
-cut 전 pin 금지</strong></td>
-</tr>
-<tr>
-<td><a href="https://github.com/jeong-sik/oas/pull/2896">OAS #2896</a>
-<code>persist validated flow evidence</code></td>
-<td>G5 durable evidence</td>
-<td><strong>Merged</strong>, head
-<code>e89c5d9e57b5e8cd2077468cc2e04fa21d0b09f6</code>, merge commit
-<code>f6cc38056</code>; 최초 CI는 <code>Yojson.Safe.t</code> 추론 오류와
-godfile <code>+1</code>로 실패</td>
-<td>actual mixed flow의 admission rejection → invalid JSON advance →
-semantic rejection → acceptance를 current-only canonical snapshot으로
-보존한다. projector exactly-once, strict decode, integrity 및 re-hashed
-structural tamper test를 추가한다.</td>
-<td><strong>기능 경계 유효. 최초 head는 compile/ratchet 불합격;
-#2899/#2903 후속 필수</strong></td>
-</tr>
-<tr>
-<td><a href="https://github.com/jeong-sik/oas/pull/2899">OAS #2899</a>
-<code>constrain canonical JSON to Safe.t</code></td>
-<td>#2896 compile repair</td>
-<td><strong>Merged</strong>, merge commit <code>b1fe0ec06</code>; OAS
-main <code>0.231.8</code> release 전 포함</td>
-<td>canonicalizer 입력/출력을 명시적 <code>Yojson.Safe.t</code>로 닫아
-<code>Floatlit</code>/<code>Tuple</code>/<code>Variant</code>
-polymorphic variant 추론 오류를 제거한다.</td>
-<td><strong>정확한 compiler root fix. full downstream proof는 #2903 CI와
-pin 이후</strong></td>
-</tr>
-<tr>
-<td><a href="https://github.com/jeong-sik/oas/pull/2903">OAS #2903</a>
-<code>split durable evidence codec leaves</code></td>
-<td>#2896 godfile root fix</td>
-<td><strong>Merged</strong>, head
-<code>22b9f0a07d5d28be81ad73d6899f225b0c9ee0c2</code>, merge commit
-<code>a923fc3889ba62a89cd42d91956d62dc0b674311</code>; ratchet PASS, CI
-run <code>30535040210</code> FAIL</td>
-<td>root가 create/decode/integrity orchestration을 직접 소유하고 types →
-canonical → validation → codec private DAG로 분리한다. pure alias
-facade와 godfile <code>+1</code>을 제거했지만 shared record label 추론이
-닫히지 않았다.</td>
-<td><strong>구조 방향은 유효하나 exact head는 compile 불합격. 단독 pin
-금지</strong></td>
-</tr>
-<tr>
-<td><a href="https://github.com/jeong-sik/oas/pull/2908">OAS
-#2904/#2906/#2907/#2908</a> <code>evidence type repairs</code></td>
-<td>#2903 compile repair chain</td>
-<td><strong>Merged</strong>, final merge
-<code>8d5d30b6a0f1a5175232533a7f5be5f18110ff44</code>; 중간 #2904/#2906
-exact-head CI는 실패</td>
-<td>canonical/codec/validation/consumer의 실제 domain 타입을 명시하고
-OCaml 5.4에 없는 <code>Option.exists</code>를 typed match로
-교체한다.</td>
-<td><strong>중간 merge는 불합격. 네 repair와 #2903을 포함한 v0.231.10
-exact release CI만 green proof</strong></td>
-</tr>
-<tr>
-<td><a
-href="https://github.com/jeong-sik/oas/releases/tag/v0.231.10">OAS
-v0.231.10</a></td>
-<td>release/pin 후보</td>
-<td>SHA <code>1fa61251936758d37c3a33eac07b8d95c5f26d35</code>; CI run
-<code>30536256908</code> SUCCESS</td>
-<td>#2903/#2904/#2906/#2907/#2908 전체를 포함하며 public
-<code>.mli</code> surface 변화 없이 codec leaf와 compile repair를
-묶는다.</td>
-<td><strong>OAS release PASS. MASC #26489/#26491 exact-head CI와
-production caller/runtime proof 전 NO-GO 유지</strong></td>
 </tr>
 <tr>
 <td><a href="https://github.com/jeong-sik/masc/pull/26436">#26436</a>
@@ -836,40 +500,6 @@ authority도 추가 삭제했다.</td>
 </tr>
 </tbody>
 </table>
-<h3 id="a-폐기한-prototype과-oas-경계-결정">3.0A 폐기한 prototype과 OAS
-경계 결정</h3>
-<p>다음 prototype은 적대 검토에서 모두 <strong>do-not-ship</strong>으로
-판정해 commit 전에 전량 삭제했다.</p>
-<ul>
-<li>single-file current snapshot: 최소 receipt 위조, codec exception
-누출, duplicate identity 수용, rename 뒤 durability 세탁, path escape,
-O(n²) rewrite</li>
-<li>immutable revision/CURRENT prototype: canonical multi-turn source를
-표현하지 못하는 episode provenance, ancestry replay, nested symlink
-escape, production caller 부재</li>
-<li>MASC exact-evidence adapter: 약 1,780줄의 OAS shadow codec, OAS에서
-생성 불가능한 상태 decode 허용, selected/admission provenance 결합 누락,
-production caller 0</li>
-</ul>
-<p>결론은 OAS가 자기 private typed invariant에서 <strong>한 번</strong>
-current-only durable projection을 만들고, MASC는
-<code>Agent_sdk.Exact_output</code>을 직접 소비해야 한다는 것이다.
-Decoder는 live execution 타입을 재구성하지 않고 immutable abstract
-snapshot만 복원해야 한다. accepted/rejection polymorphic 값은 caller가
-digest를 임의 전달하지 않고, OAS가 실제 typed 값에 caller-owned
-projector를 정확히 한 번 적용해 결합해야 한다. final flow ledger는 한
-번만 저장하고 prior rejection prefix는 파생해야 하며, rejection마다 전체
-prefix를 중복하면 O(n²)·SSOT 위반이다.</p>
-<p>이 경계는 #2896/#2899/#2903과 #2904/#2906/#2907/#2908 compile
-repair로 source 구현됐고 v0.231.10 exact release CI에서 증명됐다. 특히
-처음 leaf가
-<code>Rejected = No_measurement_dispatch + Measurement_not_required + receipt=None</code>으로
-상태를 과도하게 축소했으나 실제 <code>admit_candidate_request</code>
-caller는 no-dispatch terminal outcome(<code>local_invalid</code>,
-<code>unsupported</code> 등)과 optional terminal receipt를 생성할 수
-있었다. 이것은 죽은 상태가 아니므로 복원했다. 반대로 measurement
-phase/version/visit-count처럼 valid successful transcript에서 항상
-파생되거나 도달 불가능한 durable field는 저장하지 않는다.</p>
 <h3 id="pr-26324가-해결하는-부분">3.1 PR #26324가 해결하는 부분</h3>
 <p>현재 exact-head patch에서 확인한 직접 개선:</p>
 <ul>
@@ -1863,16 +1493,12 @@ substring score, first-100-byte dedupe 잔존</td>
 </tr>
 <tr>
 <td>G5</td>
-<td>public fact/episode reader partial-drop 제거, recall
-unavailable/dashboard read error 노출, publication phase failure typed
-result 분류, OAS 성공 transport advance evidence/prose heuristic hard
-cut(#2892), current-only validated-flow snapshot/direct adapter(#2896),
-Safe.t compiler fix(#2899), private leaf split(#2903), typed compile
-repair(#2904/#2906/#2907/#2908)</td>
-<td><strong>부분 완료</strong> — OAS v0.231.10 exact release CI green;
-MASC #26489 exact pin은 main 반영, #26491 typed advance consumer는 CI
-진행 중이며 atomic revision/CURRENT CAS/durable evidence production
-caller/runtime proof 미구현</td>
+<td>public fact/episode reader partial-drop 제거, recall unavailable 및
+dashboard read error 노출, publication phase failure를 typed result로
+분류</td>
+<td><strong>부분 완료</strong> — journal terminal이 publication보다
+앞서고 facts→episode→event partial commit/rollback이 없어 atomic
+revision/failover receipt 미구현</td>
 </tr>
 <tr>
 <td>G6</td>
@@ -1916,34 +1542,6 @@ config/snapshot/docs/test symbol scan 0</li>
 build artifact가 없어 미실행</li>
 <li>로컬 Dune 미실행; OCaml type/link/build/test는 <strong>CI
 미증명</strong></li>
-<li>OAS #2892 local: touched OCaml 전부 <code>ocamlformat</code>,
-parse-only, <code>git diff --check</code> 통과. Dune 미실행. head
-<code>d2a56f315...</code>은 full CI 전 merge</li>
-<li>OAS #2896 local: mixed four-candidate loopback test, projector
-cardinality, canonical roundtrip, stale-integrity tamper와 re-hashed
-structural tamper를 추가. 최초 CI는 <code>Yojson.Safe.t</code> 타입
-추론과 godfile <code>+1</code>로 실패</li>
-<li>OAS #2899: canonical JSON을 명시적 <code>Yojson.Safe.t</code>로 닫는
-compiler root fix</li>
-<li>OAS #2903 local: root 125L, types 217L, canonical 243L, validation
-primitives 284L, validation 192L, codec 403L;
-parser/format/diff/boundary gate와 code-smell ratchet
-<code>godfile 11 → 11</code> 통과. exact-head CI
-<code>30535040210</code>은 record-label 추론 오류로 실패</li>
-<li>OAS #2904/#2906 중간 exact-head Build/Lint/Eio 실패를 확인한 뒤
-#2907/#2908에서 consumer·codec·validation leaf의 typed boundary와 OCaml
-5.4 option match를 닫음</li>
-<li>OAS v0.231.10 SHA
-<code>1fa61251936758d37c3a33eac07b8d95c5f26d35</code>: CI
-<code>30536256908</code>에서 OCaml 5.4.1/5.5.0 Build &amp; Test, Eio
-1.3/1.4, Lint, Format 전부 성공</li>
-<li>MASC #26489가 OAS v0.231.10 exact pin을 main에 반영했으나 exact-head
-Build/CI Gate는 merge 뒤 취소</li>
-<li>MASC #26491 head
-<code>254b5ec30d81bfa9310f666f951d9a58e0c5d0bf</code>: changed OCaml
-format/parser, dashboard typecheck와 focused 2 files/37 tests, OAS pin
-manifest/API-surface drift check, shell/JSON/diff check 통과. 로컬 Dune
-미실행; exact-head PR CI 진행 중</li>
 </ul>
 <p>Fresh-state cutover blocker:</p>
 <ul>
@@ -2016,7 +1614,7 @@ exact-head <code>Build and Test</code>/<code>CI Gate</code>가 merge 뒤
 <h3 id="공통-헤더">15.1 공통 헤더</h3>
 <ul>
 <li><code>날짜(ISO8601)</code>:
-<code>2026-07-30T20:11:00+09:00</code></li>
+<code>2026-07-30T16:05:00+09:00</code></li>
 <li><code>작성자</code>: <code>Codex</code></li>
 <li><code>결정 ID</code>:
 <code>masc-memory-os-adversarial-audit-20260730</code></li>
@@ -2052,11 +1650,8 @@ startup repo HEAD</li>
 <ul>
 <li><code>항목</code>: 현재 open PR의 finding coverage</li>
 <li><code>출처</code>: <code>gh pr list</code>, <code>gh pr view</code>,
-GitHub changed-file 및 exact file patch; MASC
-#26428/#26440/#26450/#26489/#26491, OAS
-#2892/#2896/#2899/#2903/#2904/#2906/#2907/#2908, OAS CI
-<code>30536256908</code></li>
-<li><code>확인일시</code>: <code>2026-07-30T20:11:00+09:00</code></li>
+GitHub changed-file 및 exact file patch</li>
+<li><code>확인일시</code>: <code>2026-07-30T16:05:00+09:00</code></li>
 <li><code>신뢰도</code>: <code>High</code></li>
 <li><code>제한조건</code>: PR head/check 상태는 이후 push에 따라 변경
 가능</li>
@@ -2065,12 +1660,9 @@ GitHub changed-file 및 exact file patch; MASC
 <ul>
 <li><code>항목</code>: OCaml 5.5 memory model과 Eio cancellation/mutex
 기준</li>
-<li><code>출처</code>: <a
-href="https://ocaml.org/manual/5.5/index.html">OCaml 5.5 official
-manual</a>, <a
-href="https://ocaml.org/manual/5.5/parallelism.html">OCaml 5.5 parallel
-programming</a>, Eio official API docs</li>
-<li><code>확인일시</code>: <code>2026-07-30T18:29:00+09:00</code></li>
+<li><code>출처</code>: OCaml 5.5 official manual, Eio official API
+docs</li>
+<li><code>확인일시</code>: <code>2026-07-30T10:53:00+09:00</code></li>
 <li><code>신뢰도</code>: <code>High</code></li>
 <li><code>제한조건</code>: MASC-specific architecture 판정은 공식
 언어/runtime 계약의 적용 결과</li>
@@ -2098,14 +1690,8 @@ JSONL/SQLite aggregate 확인</li>
 동일 heuristic/identity 결함 확인. 후속 worktree의 dead
 Store/field/BasePath hard cut은 변경 OCaml 전체 format/parse, dashboard
 typecheck, focused 7 files/255 tests, Python 24 tests와 static check를
-통과했다. TTL/expiry authority production reference도 제거됐다. OAS
-#2892/#2896/#2899/#2903과 #2904/#2906/#2907/#2908은 advance evidence,
-provider prose hard cut, validated-flow durable snapshot, Safe.t
-compiler root fix, private leaf split, typed compile repair까지
-진행했다. v0.231.10 exact release CI는 전부 green이다. MASC #26489는
-exact pin을 main에 반영했고 #26491은 typed advance consumer를
-구현했지만, 두 MASC exact-head CI와 durable evidence production
-caller/runtime cutover는 미검증이다.</li>
+통과했다. TTL/expiry authority production reference도 제거됐다.
+Dune/CI와 runtime cutover는 미검증.</li>
 </ul>
 <h3 id="불확실성-uncertainty">15.4 불확실성 (Uncertainty)</h3>
 <ul>
@@ -2115,15 +1701,12 @@ SHA</p></li>
 cryptographic deployment identity라고 단정할 수 없음</p></li>
 <li><p><code>추가 확인 필요</code>: build artifact에 commit SHA를
 embed하고 health가 그 값을 직접 반환</p></li>
-<li><p><code>미확인 항목</code>: merge된 MASC #26440/#26450/#26489의
-exact-head full CI, MASC #26491 exact-head CI와 durable evidence
-production caller/runtime proof</p></li>
-<li><p><code>영향</code>: MASC source hard cut은 병합됐지만
-Build/Dashboard가 취소 또는 skipped됐고, failover evidence와 exact pin은
-source에 들어왔지만 MASC runtime의 durable production caller로
-연결됐다는 증거는 없음</p></li>
-<li><p><code>추가 확인 필요</code>: MASC #26489 포함 current-main 및
-#26491 exact-head CI, production caller/N→N+3 restart proof</p></li>
+<li><p><code>미확인 항목</code>: Draft PR #26440 exact-head CI와 #26428
+current-head fresh CI</p></li>
+<li><p><code>영향</code>: 후속 source finding coverage는 정적 검증됐지만
+merge/deployment readiness는 아직 증명되지 않음</p></li>
+<li><p><code>추가 확인 필요</code>: draft PR push 후 head SHA, required
+checks, unresolved review threads 재확인</p></li>
 </ul>
 <h3 id="적용범위-scope">15.5 적용범위 (Scope)</h3>
 <ul>

--- a/reports/MASC-LIBRARIAN-MEMORY-OS-ADVERSARIAL-AUDIT-2026-07-30.html
+++ b/reports/MASC-LIBRARIAN-MEMORY-OS-ADVERSARIAL-AUDIT-2026-07-30.html
@@ -240,15 +240,17 @@
 <header id="title-block-header">
 <h1 class="title">MASC Librarian / Memory OS 적대적 감사 보고서</h1>
 </header>
-<h1 id="masc-librarian-memory-os-적대적-감사-보고서">MASC Librarian /
+<h1 id="masc-librarian--memory-os-적대적-감사-보고서">MASC Librarian /
 Memory OS 적대적 감사 보고서</h1>
 <p>작성일: 2026-07-30</p>
 <p>대상 저장소:
 <code>/Users/dancer/me/workspace/yousleepwhen/masc</code></p>
 <p>라이브 상태 루트: <code>/Users/dancer/me/.masc</code> 판정:
 <strong>BLOCK / NO-GO</strong></p>
-<h2 id="executive-summary">1. Executive Summary</h2>
-<p>Librarian과 Memory OS는 라이브 런타임에서 실제로 동작한다.</p>
+<h2 id="1-executive-summary">1. Executive Summary</h2>
+<p>#26500 이전 배포 라이브 런타임에서 Librarian과 Memory OS가 실제로
+동작한 것은 확인했다. 아래 항목은 현재 source나 현재 배포를 뜻하지 않는
+역사 증거다.</p>
 <ul>
 <li>Keeper turn마다 <code>memory_os_recall</code> 블록이 prompt에
 주입된다.</li>
@@ -264,8 +266,13 @@ Memory OS 적대적 감사 보고서</h1>
 아래 runtime 관측은 merge 전 배포의 역사 증거이며, 현재 source가
 배포됐다는 증거가 아니다.</p>
 </blockquote>
-<p>그러나 현재 구현을 production-correct로 승인할 수 없다. 사용자 계약을
-기준으로 <strong>P0 9개, P1 7개</strong>가 확인됐다.</p>
+<p>최초 감사에서는 사용자 계약 기준 <strong>P0 9개, P1 7개</strong>를
+확인했다. #26500 merge 뒤 current <code>origin/main</code>
+<code>0d193fe1422bc943d079ffe12e4b527db5acaff3</code>을 2026-07-30 22:59
+KST에 다시 추적한 source 판정은 P0 9개 중 <strong>해결 5, 부분 해결 1,
+미해결 3</strong>, P1 7개 중 <strong>해결 4, 미해결 3</strong>이다.
+따라서 현재 source blocker는 P0 4개(부분 해결 포함), P1 3개이며
+production-correct 승인은 여전히 불가하다.</p>
 <p>후속 current-only worktree는 dead Store와 Memory
 <code>claim_kind</code>/persisted <code>schema_version</code>/episode
 사망 field를 삭제하고, 모든 public Memory reader, exact journal과
@@ -280,10 +287,12 @@ prompt-local turn과 current trace를 사용하므로 canonical TurnRef가
 <code>valid_for_days</code>/<code>valid_until</code>/<code>Ephemeral</code>,
 expiry GC·sanity sweep·maintenance fiber와 dashboard TTL projection까지
 삭제했다. retired TTL 입력과 persisted field는 closed decoder가
-명시적으로 거부한다. 이 개선은 아직 새 PR CI·배포·fresh-state cutover가
-증명되지 않았고, canonical TurnRef·recency selection·latest-wins·
-echo/dedupe 휴리스틱·비원자 publication이 남으므로 최종 판정은 계속
-NO-GO다.</p>
+명시적으로 거부한다. #26500 post-merge source에서는 단일
+<code>*.memory-current.json</code> snapshot, closed decoder, revision
+CAS와 atomic file replace가 실제 production caller에 연결됐다. 그러나
+canonical fact provenance, substring search와 first-100-byte history
+dedupe, Librarian latest coalescing, chat-waiting/lease와 async
+settlement 중복 authority가 남으므로 최종 판정은 계속 NO-GO다.</p>
 <p>2026-07-30 16:53 KST 후속 hard cut은 production producer가 항상
 <code>None</code>만 기록하던 <code>terminal_marker</code>를 episode
 type/codec/recall/dashboard/viewer/test에서 완전히 제거했다. dashboard의
@@ -292,21 +301,83 @@ versioned <code>schema</code> 문자열도 함께 제거했다. 새 closed
 decoder는 이 사망 필드가 다시 들어오면 unknown field로 거부한다. 이
 slice는 원자 publication의 선행 정리이며, atomic Memory authority 자체가
 완료됐다는 뜻은 아니다.</p>
+<p>2026-07-30 20:02 KST OAS 경계 재검토에서는 G5를 막는 OAS 결함 두 개를
+확인했다. 이 둘은 본 Memory 감사의 P0-1~P0-9 finding count에 추가하지
+않고 cross-boundary supporting defect로 분류한다. 기존
+<code>flow_evidence</code>는 성공한 <code>before_advance</code> 전이를
+보존하지 않아 failover 경로를 복원할 수 없고, HTTP 400 provider 오류
+문구를 문자열 문법으로 해석해 typed context-overflow 사실으로 승격했다.
+MASC shadow codec은 OAS private invariant의 두 번째 SSOT가 되므로 전량
+폐기했다. OAS PR <a
+href="https://github.com/jeong-sik/oas/pull/2892">#2892</a>는 성공한
+transport advance를 동일 atomic progress snapshot에 포함하고 문자열 기반
+분류와 사망 <code>Context_window_refused</code>를 제거했다. 후속 <a
+href="https://github.com/jeong-sik/oas/pull/2896">#2896</a>은 OAS-owned
+current-only validated-flow evidence와 direct
+<code>Agent_sdk.Exact_output</code> adapter를 추가했다. 실제 caller
+역추적 중 <code>No_measurement_dispatch</code> rejection의 terminal
+outcome과 optional measurement receipt가 살아 있는 증거임을 확인해
+과도한 숙청을 되돌렸다. <a
+href="https://github.com/jeong-sik/oas/pull/2899">#2899</a>는 canonical
+JSON을 <code>Yojson.Safe.t</code>로 닫았고, <a
+href="https://github.com/jeong-sik/oas/pull/2903">#2903</a>은 godfile
+증가를 private one-way leaf DAG로 제거했다. 그러나 #2903 merge commit
+<code>a923fc3889ba62a89cd42d91956d62dc0b674311</code>의 exact-main CI
+run <a
+href="https://github.com/jeong-sik/oas/actions/runs/30535040210"><code>30535040210</code></a>은
+<code>rejected.measurement</code>/<code>visit.ordinal</code> shared
+record label 추론 오류로 Build(OCaml 5.4.1/5.5.0)·Lint·Eio 1.3/1.4가
+실패했다. 후속 <a
+href="https://github.com/jeong-sik/oas/pull/2904">#2904</a>(exact-head
+PR run <a
+href="https://github.com/jeong-sik/oas/actions/runs/30535494954"><code>30535494954</code></a>)와
+<a href="https://github.com/jeong-sik/oas/pull/2906">#2906</a>(run <a
+href="https://github.com/jeong-sik/oas/actions/runs/30535658586"><code>30535658586</code></a>)도
+exact-head Build/Lint/Eio가 실패했고, #2901 head
+<code>5597da1ba3b1667779f70d6323b0fa886c0bb15d</code>의 PR run <a
+href="https://github.com/jeong-sik/oas/actions/runs/30534846121"><code>30534846121</code></a>은
+OCaml 5.4.1에 없는 <code>Option.exists</code> unbound와
+<code>flow_visit_ordinal</code> 타입 오류로 실패한 채 merge됐다.
+<code>v0.231.9</code> 태그
+<code>b70b35bb117af1c0597c28f619c187c7fb387bfb</code>의 exact-main CI
+run <a
+href="https://github.com/jeong-sik/oas/actions/runs/30534931823"><code>30534931823</code></a>은
+취소됐고 Code Smell Ratchet run <a
+href="https://github.com/jeong-sik/oas/actions/runs/30534931829"><code>30534931829</code></a>이
+실패해 green release 증거가 없었다. <a
+href="https://github.com/jeong-sik/oas/pull/2907">#2907</a>, <a
+href="https://github.com/jeong-sik/oas/pull/2908">#2908</a>이 실제
+domain boundary에 record 타입을 명시하고 5.4-compatible option match로
+교체했다. 이를 모두 포함한 <code>v0.231.10</code> exact release SHA
+<code>1fa61251936758d37c3a33eac07b8d95c5f26d35</code>는 CI run <a
+href="https://github.com/jeong-sik/oas/actions/runs/30536256908"><code>30536256908</code></a>에서
+OCaml 5.4.1/5.5.0 Build &amp; Test, Eio 1.3/1.4, Lint, Format을 포함한
+13개 job을 모두 통과했다(2026-07-30 22:10 KST
+<code>gh run view</code>/<code>gh release list</code> 재확인, 신뢰도
+High). 이것이 최종 green release SHA다. MASC <a
+href="https://github.com/jeong-sik/masc/pull/26489">#26489</a>는 exact
+pin을 main에 반영했고(merge 시점 exact-head Build/CI Gate는 merge 뒤
+취소), <a
+href="https://github.com/jeong-sik/masc/pull/26491">#26491</a>은 그 pin
+위에서 typed advance consumer와 serialized-request evidence를 구현해
+2026-07-30 21:53 KST에 merge됐다. #26491 exact-head
+<code>41561bd0220fc6afdd1a732ed217f9616ee61a26</code>의 CI(Build and
+Test/Dashboard/ CI Gate 포함)는 전부 green이다. 또한 <a
+href="https://github.com/jeong-sik/masc/pull/26500">#26500</a>(<code>hard-cut minimal current contract</code>,
+merge commit <code>101d9efa1623e62b16b90f4011ff877e5eb49e65</code>)이
+2026-07-30 22:01 KST에 merge돼 main의 current Memory contract를
+<code>*.memory-current.json</code>으로 hard cut했다. 2026-07-30 22:59
+KST post-merge source 재감사에서 old Store/JSONL/episode/event, legacy
+field, partial reader, recency/byte-cap recall, consolidation, TTL
+authority가 production tree에서 제거된 것을 확인했다. durable evidence
+production caller/runtime 증거는 여전히 별도 차단 상태다.</p>
 <p>가장 중요한 차단 사유는 다음과 같다.</p>
 <ol type="1">
-<li>사용되지 않는 canonical store와 실제 JSONL store가 병존한다.</li>
-<li>schema migration과 legacy row 수용 코드가 명시적으로 존재한다.</li>
-<li>동일 TurnRef가 서로 다른 context를 가리키며 user input에는 TurnRef가
-없다.</li>
-<li>손상된 fact row가 recall/search/dashboard에서 무음으로
-사라진다.</li>
-<li>recall과 search가 recency, byte budget, substring, 고정 window로
-의미를 결정한다.</li>
-<li>consolidation이 부분 파싱된 모델 출력을 사용해 거의 전체 memory를
-삭제할 수 있다.</li>
-<li><code>claim_kind</code>, <code>valid_until</code>과 여러 episode
-field가 context에는 기여하지 않으면서 Gate·expiry·merge authority로
-동작한다.</li>
+<li>fact가 canonical source TurnRef/event edge를 보존하지 않고 user
+input의 exact TurnRef 증거도 닫히지 않았다.</li>
+<li>prompt recall은 LLM-selected current snapshot으로 고쳐졌지만
+explicit search와 history 조립에는 substring/token match와
+first-100-byte dedupe가 남는다.</li>
 <li><code>park</code>/<code>lease</code>가 별도 lifecycle 개념으로
 증식해 waiting chat이 autonomous Keeper를 종료시키고, Turn attempt
 identity와 중복되는 authority를 만든다.</li>
@@ -316,17 +387,22 @@ projection contract를 만든다.</li>
 <p>따라서 새 Gate나 retrieval 기능을 추가하기 전에 다음 순서로 기반을
 바로잡아야 한다.</p>
 <p><code>Fresh-state persistence SSOT → Turn identity SSOT → per-Keeper durable Librarian FIFO → atomic revision/failure contract → semantic context projection</code></p>
-<h2 id="감사-범위와-증거-계층">2. 감사 범위와 증거 계층</h2>
-<h3 id="source">2.1 Source</h3>
+<h2 id="2-감사-범위와-증거-계층">2. 감사 범위와 증거 계층</h2>
+<h3 id="21-source">2.1 Source</h3>
 <ul>
 <li>집중 정적 감사 SHA:
 <code>8c4dae264e6b1d03708029718f868efbb3c2613b</code></li>
 <li>2026-07-30 16:17 KST current <code>origin/main</code> 및 rebase
 base: <code>407ae5bb92509f06bfb6fc5614e8539e230b2902</code></li>
+<li>2026-07-30 22:59 KST #26500 post-merge 재감사
+<code>origin/main</code>:
+<code>0d193fe1422bc943d079ffe12e4b527db5acaff3</code></li>
 <li>후속 구현 branch:
 <code>refactor/memory-current-only-hard-cut-20260730</code></li>
 <li>사망 필드/원자 publication 후속 branch:
 <code>refactor/memory-atomic-publication-20260730</code></li>
+<li>OAS evidence 선행 branch:
+<code>fix/exact-output-evidence-boundary-20260730</code></li>
 <li>current-only 1차 source slice:
 <code>6f8bf76a816d822ca0165b6a8c42986b3d466e5c</code></li>
 <li>TTL authority 제거 2차 source slice:
@@ -337,7 +413,7 @@ base: <code>407ae5bb92509f06bfb6fc5614e8539e230b2902</code></li>
 merge/reopen하지 않고 새 branch와 Draft PR로 증명한다. 어느 slice도
 main/CI/runtime 상태로 간주하지 않는다.</li>
 </ul>
-<h3 id="runtime">2.2 Runtime</h3>
+<h3 id="22-runtime">2.2 Runtime</h3>
 <ul>
 <li>PID: <code>25820</code></li>
 <li>listener: <code>127.0.0.1:8935</code></li>
@@ -354,7 +430,7 @@ main/CI/runtime 상태로 간주하지 않는다.</li>
 값은 binary-embedded commit 증거가 아니다. 실행 시작 시 repo HEAD와
 binary mtime은 일치하지만 정확한 deployed binary SHA는 미증명으로
 남긴다.</p>
-<h3 id="ci-변경">2.3 CI / 변경</h3>
+<h3 id="23-ci--변경">2.3 CI / 변경</h3>
 <ul>
 <li>최초 감사에서는 코드 수정이나 runtime mutation을 하지 않았다.</li>
 <li>후속 구현 worktree에서는 dead Store, Memory <code>claim_kind</code>,
@@ -378,16 +454,10 @@ build artifact가 없어 실행할 수 없었다. 이를 위해 로컬 Dune buil
 않으며 새 PR CI에서 증명한다.</li>
 <li>source, CI, merge, deployment, runtime 증거를 서로 분리했다.</li>
 </ul>
-<h2 id="현재-open-pr과의-관계">3. 현재 Open PR과의 관계</h2>
-<p>확인 시각: 2026-07-30 16:05 KST</p>
+<h2 id="3-현재-open-pr과의-관계">3. 현재 Open PR과의 관계</h2>
+<p>확인 시각: 2026-07-30 22:10 KST(#26491/#26500 merge와 OAS CI chain을
+<code>gh</code>로 재확인)</p>
 <table>
-<colgroup>
-<col style="width: 20%" />
-<col style="width: 20%" />
-<col style="width: 20%" />
-<col style="width: 20%" />
-<col style="width: 20%" />
-</colgroup>
 <thead>
 <tr>
 <th>PR</th>
@@ -427,14 +497,14 @@ claim하는 ordering은 개선한다. 그러나 <code>park</code>를 공식 흐�
 <td><a href="https://github.com/jeong-sik/masc/pull/26428">#26428</a>
 <code>make current memory and provider input observable</code></td>
 <td>직접 충돌</td>
-<td><strong>Draft</strong>, head
-<code>508d77896e12f26652950d68c040830e0cb34691</code>,
-<code>MERGEABLE/BLOCKED</code>, <code>status:do-not-merge</code>,
-<code>reviewed:adversarial-non-pass</code></td>
+<td><strong>Closed</strong>, head
+<code>06764bdd9244409f162a03bf4cdafc5f2d5e79a2</code>,
+<code>status:do-not-merge</code>,
+<code>reviewed:adversarial-non-pass</code>; exact-head CI는 green</td>
 <td>immutable current snapshot/CAS와 provider-input observability 방향은
-유효하다. 그러나 current head에도 TTL/<code>claim_kind</code>/dead
-episode fields/latest-wins/cadence/prompt-local provenance가
-그대로다.</td>
+유효하다. 그러나 TTL/<code>claim_kind</code>/dead episode
+fields/latest-wins/cadence/prompt-local provenance를 포함한 잘못된
+authority가 남았다.</td>
 <td><strong>전체 채택 금지. atomic snapshot/관측성만 분리
 재구성</strong></td>
 </tr>
@@ -464,6 +534,165 @@ exact-head <code>Build and Test</code>, Dashboard, ocamlformat, CI
 Gate가 아직 실행 중이었고 merge 뒤 취소됐다.</td>
 <td><strong>source hard cut은 병합됐으나 exact-head full CI green 증거
 없음. cold cutover·runtime 증명 전 NO-GO</strong></td>
+</tr>
+<tr>
+<td><a href="https://github.com/jeong-sik/masc/pull/26450">#26450</a>
+<code>prepare current-only atomic publication</code></td>
+<td>본 감사 후속 구현</td>
+<td><strong>Merged</strong>, head
+<code>3cf500c78b16e80c17ee1867ac6c4eb3512d27ba</code>, merge commit
+<code>1910149d9e42c7e91b79915157506d695be72f18</code>;
+<code>Build and Test</code>/Dashboard 등 full CI skipped, 다수 check
+cancelled</td>
+<td><code>terminal_marker</code>/versioned dashboard schema를 숙청하고
+Librarian input을 <code>TurnRef</code>로 key했다. atomic revision은
+구현하지 않았다.</td>
+<td><strong>사망 필드 제거는 유효. CI·atomic commit·production caller
+증거 없음</strong></td>
+</tr>
+<tr>
+<td><a href="https://github.com/jeong-sik/masc/pull/26489">#26489</a>
+<code>pin agent sdk v0.231.10</code></td>
+<td>OAS release pin</td>
+<td><strong>Merged</strong>, head
+<code>c146ee46773f1813257dfad18060a679017bc31e</code>, merge commit
+<code>163f375010311b1798faeb42718439adfc1e4a41</code>; exact-head
+Build/CI Gate 취소</td>
+<td>OAS v0.231.10 SHA
+<code>1fa61251936758d37c3a33eac07b8d95c5f26d35</code>를
+manifest/API-surface SSOT에 반영한다.</td>
+<td><strong>source pin은 main 반영. exact-head MASC CI와 runtime proof
+전 NO-GO</strong></td>
+</tr>
+<tr>
+<td><a href="https://github.com/jeong-sik/masc/pull/26491">#26491</a>
+<code>bind turn evidence to serialized requests</code></td>
+<td>typed consumer/observability 후속</td>
+<td><strong>Merged</strong>, head
+<code>41561bd0220fc6afdd1a732ed217f9616ee61a26</code>, merge commit
+<code>8c84975577338aa2a78f21161c0c121b1038b531</code>, 2026-07-30 21:53
+KST merge; exact-head Build and Test/Dashboard/CI Gate 등 전부
+green(2026-07-30 22:10 KST 확인)</td>
+<td>#26489 pin 위에서 HITL summary가 typed advance를 직접 소비한다.
+request wire/prompt blocks/messages를 같은 serialized-request
+snapshot으로 묶고 unavailable composition을 <code>null</code>로
+보존한다.</td>
+<td><strong>source 병합 + exact-head CI green. durable evidence
+production caller/runtime proof 전 NO-GO</strong></td>
+</tr>
+<tr>
+<td><a href="https://github.com/jeong-sik/masc/pull/26500">#26500</a>
+<code>hard-cut minimal current contract</code></td>
+<td>본 감사 후속 구현</td>
+<td><strong>Merged</strong>, head
+<code>ae2f017ed462024f8fe07928d33bbf07af5f6724</code>, merge commit
+<code>101d9efa1623e62b16b90f4011ff877e5eb49e65</code>, 2026-07-30 22:01
+KST merge</td>
+<td>current Memory contract를 exact
+<code>claim</code>/<code>category</code>/<code>first_seen</code>의
+<code>*.memory-current.json</code>으로 hard cut하고 model-authored
+identity/TTL/recency ranking/<code>score</code>를 제거한다.
+migration/compat reader 없음</td>
+<td><strong>main 반영. 22:59 KST post-merge source 재감사 완료: P0
+5건/P1 4건 해결, P0 1건 부분 해결, P0 3건/P1 3건 미해결</strong></td>
+</tr>
+<tr>
+<td><a href="https://github.com/jeong-sik/oas/pull/2892">OAS #2892</a>
+<code>preserve typed advance evidence</code></td>
+<td>G5 선행 경계</td>
+<td><strong>Merged</strong>, head
+<code>d2a56f315fc452d00a5ed55ea729746c800adfb2</code>, merge commit
+<code>7ce45ee3aa218b49dc13aaaebba1e2698aa22e2c</code>; exact-head CI
+완료 전 merge</td>
+<td>성공한 <code>before_advance</code>를 동일 atomic flow progress에
+기록하고 HTTP 400 오류 문구 기반 context-overflow 승격과 dead variant를
+제거한다.</td>
+<td><strong>source P0 없음. MASC/masc-mcp의 제거된 variant 소비자 hard
+cut 전 pin 금지</strong></td>
+</tr>
+<tr>
+<td><a href="https://github.com/jeong-sik/oas/pull/2896">OAS #2896</a>
+<code>persist validated flow evidence</code></td>
+<td>G5 durable evidence</td>
+<td><strong>Merged</strong>, head
+<code>e89c5d9e57b5e8cd2077468cc2e04fa21d0b09f6</code>, merge commit
+<code>f6cc38056</code>; 최초 CI는 <code>Yojson.Safe.t</code> 추론 오류와
+godfile <code>+1</code>로 실패</td>
+<td>actual mixed flow의 admission rejection → invalid JSON advance →
+semantic rejection → acceptance를 current-only canonical snapshot으로
+보존한다. projector exactly-once, strict decode, integrity 및 re-hashed
+structural tamper test를 추가한다.</td>
+<td><strong>기능 경계 유효. 최초 head는 compile/ratchet 불합격;
+#2899/#2903 후속 필수</strong></td>
+</tr>
+<tr>
+<td><a href="https://github.com/jeong-sik/oas/pull/2899">OAS #2899</a>
+<code>constrain canonical JSON to Safe.t</code></td>
+<td>#2896 compile repair</td>
+<td><strong>Merged</strong>, merge commit <code>b1fe0ec06</code>; OAS
+main <code>0.231.8</code> release 전 포함</td>
+<td>canonicalizer 입력/출력을 명시적 <code>Yojson.Safe.t</code>로 닫아
+<code>Floatlit</code>/<code>Tuple</code>/<code>Variant</code>
+polymorphic variant 추론 오류를 제거한다.</td>
+<td><strong>정확한 compiler root fix. full downstream proof는 #2903 CI와
+pin 이후</strong></td>
+</tr>
+<tr>
+<td><a href="https://github.com/jeong-sik/oas/pull/2903">OAS #2903</a>
+<code>split durable evidence codec leaves</code></td>
+<td>#2896 godfile root fix</td>
+<td><strong>Merged</strong>, head
+<code>22b9f0a07d5d28be81ad73d6899f225b0c9ee0c2</code>, merge commit
+<code>a923fc3889ba62a89cd42d91956d62dc0b674311</code>; ratchet PASS,
+exact-main CI run <a
+href="https://github.com/jeong-sik/oas/actions/runs/30535040210"><code>30535040210</code></a>
+FAIL</td>
+<td>root가 create/decode/integrity orchestration을 직접 소유하고 types →
+canonical → validation → codec private DAG로 분리한다. pure alias
+facade와 godfile <code>+1</code>을 제거했지만 shared record label
+추론(<code>rejected.measurement</code>, <code>visit.ordinal</code>)이
+닫히지 않았다.</td>
+<td><strong>구조 방향은 유효하나 exact head는 compile 불합격. 단독 pin
+금지</strong></td>
+</tr>
+<tr>
+<td><a href="https://github.com/jeong-sik/oas/pull/2908">OAS
+#2904/#2906/#2907/#2908</a> <code>evidence type repairs</code></td>
+<td>#2903 compile repair chain</td>
+<td><strong>Merged</strong>, final merge
+<code>8d5d30b6a0f1a5175232533a7f5be5f18110ff44</code>; 중간 #2904/#2906
+exact-head PR CI(run <a
+href="https://github.com/jeong-sik/oas/actions/runs/30535494954"><code>30535494954</code></a>/<a
+href="https://github.com/jeong-sik/oas/actions/runs/30535658586"><code>30535658586</code></a>)는
+실패. 선행 #2901 head <code>5597da1b…</code>의 PR run <a
+href="https://github.com/jeong-sik/oas/actions/runs/30534846121"><code>30534846121</code></a>도
+<code>Option.exists</code>(OCaml 5.4.1
+unbound)·<code>flow_visit_ordinal</code> 오류로 실패한 채 merge됐고,
+<code>v0.231.9</code> 태그 <code>b70b35bb…</code>의 exact-main CI run <a
+href="https://github.com/jeong-sik/oas/actions/runs/30534931823"><code>30534931823</code></a>은
+취소·ratchet run <a
+href="https://github.com/jeong-sik/oas/actions/runs/30534931829"><code>30534931829</code></a>
+실패로 green 없음</td>
+<td>canonical/codec/validation/consumer의 실제 domain 타입을 명시하고
+OCaml 5.4에 없는 <code>Option.exists</code>를 typed match로
+교체한다.</td>
+<td><strong>중간 merge는 불합격. 네 repair와 #2903을 포함한 v0.231.10
+exact release CI만 green proof</strong></td>
+</tr>
+<tr>
+<td><a
+href="https://github.com/jeong-sik/oas/releases/tag/v0.231.10">OAS
+v0.231.10</a></td>
+<td>release/pin 후보</td>
+<td>SHA <code>1fa61251936758d37c3a33eac07b8d95c5f26d35</code>; CI run <a
+href="https://github.com/jeong-sik/oas/actions/runs/30536256908"><code>30536256908</code></a>
+SUCCESS(13/13 jobs, 2026-07-30 22:10 KST 재확인)</td>
+<td>#2903/#2904/#2906/#2907/#2908 전체를 포함하며 public
+<code>.mli</code> surface 변화 없이 codec leaf와 compile repair를
+묶는다.</td>
+<td><strong>OAS release PASS — 최종 green release SHA. MASC #26489 pin과
+#26491 exact-head CI는 green, production caller/runtime proof 전 NO-GO
+유지</strong></td>
 </tr>
 <tr>
 <td><a href="https://github.com/jeong-sik/masc/pull/26436">#26436</a>
@@ -500,7 +729,41 @@ authority도 추가 삭제했다.</td>
 </tr>
 </tbody>
 </table>
-<h3 id="pr-26324가-해결하는-부분">3.1 PR #26324가 해결하는 부분</h3>
+<h3 id="30a-폐기한-prototype과-oas-경계-결정">3.0A 폐기한 prototype과
+OAS 경계 결정</h3>
+<p>다음 prototype은 적대 검토에서 모두 <strong>do-not-ship</strong>으로
+판정해 commit 전에 전량 삭제했다.</p>
+<ul>
+<li>single-file current snapshot: 최소 receipt 위조, codec exception
+누출, duplicate identity 수용, rename 뒤 durability 세탁, path escape,
+O(n²) rewrite</li>
+<li>immutable revision/CURRENT prototype: canonical multi-turn source를
+표현하지 못하는 episode provenance, ancestry replay, nested symlink
+escape, production caller 부재</li>
+<li>MASC exact-evidence adapter: 약 1,780줄의 OAS shadow codec, OAS에서
+생성 불가능한 상태 decode 허용, selected/admission provenance 결합 누락,
+production caller 0</li>
+</ul>
+<p>결론은 OAS가 자기 private typed invariant에서 <strong>한 번</strong>
+current-only durable projection을 만들고, MASC는
+<code>Agent_sdk.Exact_output</code>을 직접 소비해야 한다는 것이다.
+Decoder는 live execution 타입을 재구성하지 않고 immutable abstract
+snapshot만 복원해야 한다. accepted/rejection polymorphic 값은 caller가
+digest를 임의 전달하지 않고, OAS가 실제 typed 값에 caller-owned
+projector를 정확히 한 번 적용해 결합해야 한다. final flow ledger는 한
+번만 저장하고 prior rejection prefix는 파생해야 하며, rejection마다 전체
+prefix를 중복하면 O(n²)·SSOT 위반이다.</p>
+<p>이 경계는 #2896/#2899/#2903과 #2904/#2906/#2907/#2908 compile
+repair로 source 구현됐고 v0.231.10 exact release CI에서 증명됐다. 특히
+처음 leaf가
+<code>Rejected = No_measurement_dispatch + Measurement_not_required + receipt=None</code>으로
+상태를 과도하게 축소했으나 실제 <code>admit_candidate_request</code>
+caller는 no-dispatch terminal outcome(<code>local_invalid</code>,
+<code>unsupported</code> 등)과 optional terminal receipt를 생성할 수
+있었다. 이것은 죽은 상태가 아니므로 복원했다. 반대로 measurement
+phase/version/visit-count처럼 valid successful transcript에서 항상
+파생되거나 도달 불가능한 durable field는 저장하지 않는다.</p>
+<h3 id="31-pr-26324가-해결하는-부분">3.1 PR #26324가 해결하는 부분</h3>
 <p>현재 exact-head patch에서 확인한 직접 개선:</p>
 <ul>
 <li><code>keeper_memory_os_consolidation_runtime.ml</code> 전체
@@ -517,40 +780,51 @@ authority도 추가 삭제했다.</td>
 </ul>
 <p>따라서 본 보고서의 <strong>P0-6 destructive consolidation</strong>은
 #26324 merge로 제거됐다.</p>
-<h3 id="pr-26324가-해결하지-않는-부분">3.2 PR #26324가 해결하지 않는
-부분</h3>
-<p>merge된 main에 그대로 남는 항목:</p>
+<h3 id="32-26500-post-merge-source-재감사">3.2 #26500 post-merge source
+재감사</h3>
+<p>대상은 <code>origin/main</code>
+<code>0d193fe1422bc943d079ffe12e4b527db5acaff3</code>이며 2026-07-30
+22:59 KST에 entrypoint → typed store → recall/search/dashboard consumer
+→ caller를 다시 추적했다.</p>
+<p>해결된 source finding:</p>
 <ul>
-<li><code>Keeper_memory_os_store</code>와 JSONL store의 이중
-authority</li>
-<li>persisted record의 <code>schema_version</code></li>
-<li><code>Persisted_claim_kind_absent</code> legacy row 수용</li>
-<li>optional <code>claim_kind</code></li>
-<li>사용되지 않는
-<code>MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT</code></li>
-<li>lenient <code>read_facts_all</code>의 malformed-row
-<code>filter_map</code></li>
-<li>500/500/65,536-byte recall truncation</li>
-<li>recency selection</li>
-<li>32-turn recall echo window</li>
-<li>cadence/message-window/inert-turn skip</li>
-<li>substring search와 first-100-byte dedupe</li>
-<li>Librarian <code>Replace_latest</code> coalescing</li>
-<li>TurnRef 중복과 null user TurnRef</li>
-<li>facts → episode → event 비원자 publication</li>
-<li>spatial namespace/ACL 부재</li>
+<li><strong>P0-1:</strong> dead <code>Keeper_memory_os_store</code>와
+JSONL facts/episode/event authority가 사라지고 production
+read/write/Librarian/dashboard가 <code>Keeper_memory_os_current</code>
+한 snapshot을 사용한다.</li>
+<li><strong>P0-2/P0-7:</strong> Memory <code>schema_version</code>,
+<code>claim_kind</code>, TTL/expiry, episode 사망 field와 compatibility
+reader가 current contract에서 제거됐다.</li>
+<li><strong>P0-4:</strong> snapshot은 closed whole-object decode이며 한
+fact 오류도 전체 typed read error로 노출된다.</li>
+<li><strong>P0-6:</strong> destructive consolidation producer/caller가
+삭제됐다.</li>
+<li><strong>P1-2/P1-3/P1-5/P1-6:</strong> facts/episode/event 다단
+publication과 모순된 episode prompt, fleet consolidation, episode/store
+오표기 ledger가 current path에서 제거됐다. revision CAS와 atomic
+snapshot replace가 실제 writer에 연결됐다.</li>
 </ul>
-<p>후속 audit worktree는 이 목록 중 dead
-<code>Keeper_memory_os_store</code>, Memory <code>claim_kind</code>,
-persisted Memory <code>schema_version</code>, serialization-only episode
-fields, global slot facade, lenient reader뿐 아니라
-<code>valid_for_days</code>/<code>valid_until</code>/<code>Ephemeral</code>,
-expiry GC·sanity sweep·maintenance·TTL dashboard를 삭제했다. retired
-row/field는 current decoder가 명시적으로 거부한다. 이는 아직
-main/CI/runtime 증거가 아니며, recall budget/recency, echo/dedupe,
-latest-wins, production Memory authority·atomic receipt·Turn identity
-문제는 그대로 남는다.</p>
-<h3 id="pr-26410의-정확한-경계">3.3 PR #26410의 정확한 경계</h3>
+<p>남은 source finding:</p>
+<ul>
+<li><strong>P0-3:</strong> Librarian input에는 typed
+<code>Turn_ref</code>가 있지만 fact schema에는 source TurnRef/event
+edge가 없고 user input exact join 증거도 닫히지 않았다.</li>
+<li><strong>P0-5(부분):</strong> automatic recall은 LLM-selected current
+facts 전체를 그대로 주입하도록 고쳐졌다. 그러나
+<code>keeper_memory_search</code>는 substring/token match를, history
+조립은 first-100-byte dedupe를 사용한다.</li>
+<li><strong>P0-8/P0-9:</strong> <code>Yielded_to_chat_waiting</code>,
+chat waiting authority, queue <code>lease_id</code>,
+<code>worker_settlement</code>/<code>Status_settlement</code>/
+<code>Settlement_projection_error</code>가 그대로 남는다.</li>
+<li><strong>P1-1/P1-4/P1-7:</strong> Librarian
+<code>Replace_latest</code> coalescing, tool/multimodal placeholder와
+fact provenance 손실, log/metric-only Librarian failure가 남는다.</li>
+</ul>
+<p>[근거] <code>git rev-parse origin/main</code>, <code>rg</code>
+production caller scan, 위 exact files; 확인일시
+2026-07-30T22:59:03+09:00; 신뢰도 High.</p>
+<h3 id="33-pr-26410의-정확한-경계">3.3 PR #26410의 정확한 경계</h3>
 <p>#26410은 다음 측면에서 유용하다.</p>
 <ul>
 <li>chat/autonomous admission authority를 turn mutex 하나로 축소</li>
@@ -591,31 +865,27 @@ FSM이다.</p>
 별도 domain concept가 되어서는 안 된다. Busy Keeper는 현재 활동을
 계속하고, 수신 acknowledgement 또는 다음 event tail로 입력을 소비해야
 한다.</p>
-<h2 id="실제-호출-흐름">4. 실제 호출 흐름</h2>
+<h2 id="4-실제-호출-흐름">4. 실제 호출 흐름</h2>
 <pre class="mermaid"><code>flowchart TD
-    A[Keeper turn admission] --&gt; B[Memory OS JSONL read]
-    B --&gt; C[recency/count/byte selection]
+    A[Keeper turn admission] --&gt; B[current snapshot strict read]
+    B --&gt; C[all LLM-selected current facts]
     C --&gt; D[memory_os_recall prompt injection]
     D --&gt; E[OAS agent run: thinking/tools]
     E --&gt; F[checkpoint + TurnRecord]
     F --&gt; G{meaningful turn?}
     G --&gt;|No| H[Librarian skip]
-    G --&gt;|Yes| I[per-Keeper Librarian drain]
-    I --&gt;|busy| J[keep only latest snapshot]
+    G --&gt;|Yes| I[per-Keeper Librarian latest drain]
+    I --&gt;|busy| J[replace pending latest closure]
     I --&gt; K{cadence due?}
-    K --&gt;|Yes| L[OAS exact-output Librarian]
-    L --&gt; M[32-turn echo + claim identity merge]
-    M --&gt; N[facts JSONL rewrite]
-    N --&gt; O[episode file append]
-    O --&gt; P[event JSONL append]
-    P --&gt; B
+    K --&gt;|Yes| L[OAS exact-output current selection]
+    L --&gt; M[retained IDs + new claims validation]
+    M --&gt; N[revision CAS + atomic snapshot replace]
+    N --&gt; B
 
-    Q[600s maintenance] --&gt; R[serial all-Keeper consolidation]
-    R --&gt; S[prompt-only JSON provider call]
-    S --&gt; T[partial plan salvage/apply]
-    T --&gt; N</code></pre>
-<h2 id="p0-findings">5. P0 Findings</h2>
-<h3 id="p0-1.-persistence-authority가-둘이다">P0-1. Persistence
+    Q[explicit memory write] --&gt; R[exact identity upsert]
+    R --&gt; N</code></pre>
+<h2 id="5-p0-findings">5. P0 Findings</h2>
+<h3 id="p0-1-persistence-authority가-둘이다">P0-1. Persistence
 authority가 둘이다</h3>
 <p><code>lib/keeper/keeper_memory_os_store.mli:1</code>은 자신을
 <code>Canonical, fresh-state-only Memory OS persistence</code>로
@@ -641,7 +911,7 @@ publish</li>
 worktree에서 삭제했다. 이로써 거짓 canonical authority는 제거됐지만,
 <code>Keeper_memory_os_io</code>의 facts/episode/event publication이
 아직 하나의 atomic commit/receipt가 아니므로 G0 완료는 아니다.</p>
-<h3 id="p0-2.-legacymigration-surface가-명시적으로-존재한다">P0-2.
+<h3 id="p0-2-legacymigration-surface가-명시적으로-존재한다">P0-2.
 Legacy/migration surface가 명시적으로 존재한다</h3>
 <p><code>lib/keeper/keeper_memory_os_types.mli:5</code>:</p>
 <blockquote>
@@ -672,10 +942,13 @@ journal도 <code>-v2-</code> filename과 version field를 제거하고, 각
 state마다 허용 field가 다른 closed typed shape로 바꿨다. journal의
 trace/generation 불일치, unknown/duplicate field, malformed candidate
 evidence는 provider dispatch 전에 typed setup failure로 거부한다. 과거
-journal을 읽거나 옮기는 compatibility/migration 경로는 없다. 다만 live
-root가 모두 retired schema이므로 fresh-state cold reset/reseed와 새
-schema write→restart→recall 증거 전에는 배포할 수 없다.</p>
-<h3 id="p0-3.-turn-identity-ssot가-실제-데이터에서-깨진다">P0-3. Turn
+journal을 읽거나 옮기는 compatibility/migration 경로는 없다. #26500 이후
+production reader는 retired fact/episode/event 파일을 읽지 않으므로 기존
+Keeper 디렉터리 reset이나 migration은 필요하지 않다. 배포 승인은 old
+runtime을 정지한 뒤 새 binary가 exact
+<code>*.memory-current.json</code>만 write→restart→recall하는지 확인하는
+current-path runtime proof로 제한한다.</p>
+<h3 id="p0-3-turn-identity-ssot가-실제-데이터에서-깨진다">P0-3. Turn
 identity SSOT가 실제 데이터에서 깨진다</h3>
 <p>동일 <code>(trace_id, absolute_turn)</code>에 서로 다른 prompt block
 digest가 여러 번 append됐다.</p>
@@ -698,7 +971,7 @@ digest가 여러 번 append됐다.</p>
 전파</li>
 <li>timestamp fuzzy join 금지</li>
 </ul>
-<h3 id="p0-4.-손상된-fact가-무음으로-사라진다">P0-4. 손상된 fact가
+<h3 id="p0-4-손상된-fact가-무음으로-사라진다">P0-4. 손상된 fact가
 무음으로 사라진다</h3>
 <p><code>lib/keeper/keeper_memory_os_io.ml:489-506</code>:</p>
 <ul>
@@ -726,8 +999,7 @@ context로 렌더링하고, dashboard와 fleet health는
 consumer도 item을 <code>filter</code>하지 않고 closed payload 전체를
 거부한다. 마지막 성공 projection과 stale generation/commit receipt는
 아직 없으므로 G5/G6 전체 완료는 아니다.</p>
-<h3
-id="p0-5.-context-management가-고정-수치와-문자열-휴리스틱이다">P0-5.
+<h3 id="p0-5-context-management가-고정-수치와-문자열-휴리스틱이다">P0-5.
 Context management가 고정 수치와 문자열 휴리스틱이다</h3>
 <p>현재 recall:</p>
 <ul>
@@ -799,8 +1071,7 @@ state 7–30</li>
 포함</li>
 <li>원 ledger/store를 수정하거나 대체하지 않음</li>
 </ul>
-<h3
-id="p0-6.-consolidation이-부분-모델-출력을-파괴적으로-적용한다">P0-6.
+<h3 id="p0-6-consolidation이-부분-모델-출력을-파괴적으로-적용한다">P0-6.
 Consolidation이 부분 모델 출력을 파괴적으로 적용한다</h3>
 <p><code>lib/keeper/keeper_memory_os_consolidation.ml:108-190</code>:</p>
 <ul>
@@ -824,19 +1095,12 @@ Consolidation이 부분 모델 출력을 파괴적으로 적용한다</h3>
 후보다. 그러나 #26324가 merge되기 전에는 live P0이며, merge 이후에도
 나머지 P0는 그대로다.</p>
 <h3
-id="p0-7.-claim_kind-valid_until과-사망-field가-context와-분리된-authority다">P0-7.
+id="p0-7-claim_kind-valid_until과-사망-field가-context와-분리된-authority다">P0-7.
 <code>claim_kind</code>, <code>valid_until</code>과 사망 field가
 context와 분리된 authority다</h3>
 <p><code>claim_kind</code>와 <code>valid_until</code>은 dead field는
 아니다. 오히려 더 위험하게 load-bearing policy field다.</p>
 <table>
-<colgroup>
-<col style="width: 20%" />
-<col style="width: 20%" />
-<col style="width: 20%" />
-<col style="width: 20%" />
-<col style="width: 20%" />
-</colgroup>
 <thead>
 <tr>
 <th>Field</th>
@@ -929,10 +1193,11 @@ producer/codec/test에서 삭제했다. 두 번째 hard-cut은
 <code>Ephemeral</code>, expiry GC, dry-run, sanity sweep, maintenance
 fiber와 TTL dashboard를 삭제했다. retired TTL field와 category는 current
 decoder에서 거부된다. 따라서 <strong>source finding은
-해결</strong>됐지만, fresh-state cutover와 새 exact-head CI/runtime
-증거가 없어 release finding은 아직 해결되지 않았다.</p>
+해결</strong>됐지만, 새 exact-head CI와 current snapshot
+write→restart→recall runtime 증거가 없어 release finding은 아직 해결되지
+않았다.</p>
 <h3
-id="p0-8.-park와-lease가-keeper-진행을-제약하는-별도-lifecycle이-됐다">P0-8.
+id="p0-8-park와-lease가-keeper-진행을-제약하는-별도-lifecycle이-됐다">P0-8.
 <code>park</code>와 <code>lease</code>가 Keeper 진행을 제약하는 별도
 lifecycle이 됐다</h3>
 <p>현재 흐름:</p>
@@ -964,7 +1229,7 @@ model/runtime exit authority에서 제거</li>
 종료하지 않음</li>
 </ul>
 <h3
-id="p0-9.-settlement가-canonical-terminal-state-위에-두-번째-facade를-만든다">P0-9.
+id="p0-9-settlement가-canonical-terminal-state-위에-두-번째-facade를-만든다">P0-9.
 <code>settlement</code>가 canonical terminal state 위에 두 번째 Facade를
 만든다</h3>
 <p><code>Keeper_msg_async.worker_settlement</code>은 다음 variant를
@@ -995,9 +1260,9 @@ commit 결과 하나로 축소해야 한다.</p>
 <code>settlement_durability</code>, <code>settlement_origin</code>,
 <code>Settlement_projection_error</code>라는 별도 vocabulary와 callback
 Facade는 삭제한다.</p>
-<h2 id="p1-findings">6. P1 Findings</h2>
+<h2 id="6-p1-findings">6. P1 Findings</h2>
 <h3
-id="p1-1.-librarian-snapshot-coalescing으로-의미-있는-turn이-유실될-수-있다">P1-1.
+id="p1-1-librarian-snapshot-coalescing으로-의미-있는-turn이-유실될-수-있다">P1-1.
 Librarian snapshot coalescing으로 의미 있는 turn이 유실될 수 있다</h3>
 <p><code>keeper_memory_lane.ml:279-295</code>는 in-flight 1개와 latest
 1개만 유지한다. 세 번째 submission은 기존 latest closure를
@@ -1012,7 +1277,7 @@ Librarian snapshot coalescing으로 의미 있는 turn이 유실될 수 있다</
 버린다. 각 meaningful turn이
 <code>committed | intentionally skipped | retryable failure</code> 중
 무엇이 됐는지 증명할 수 없다.</p>
-<h3 id="p1-2.-memory-publication이-transaction이-아니다">P1-2. Memory
+<h3 id="p1-2-memory-publication이-transaction이-아니다">P1-2. Memory
 publication이 transaction이 아니다</h3>
 <p>현재 순서:</p>
 <ol type="1">
@@ -1027,7 +1292,7 @@ publication이 transaction이 아니다</h3>
 <li>missing event</li>
 <li>cursor와 실제 store 불일치</li>
 </ul>
-<h3 id="p1-3.-librarian-prompt-계약이-서로-모순된다">P1-3. Librarian
+<h3 id="p1-3-librarian-prompt-계약이-서로-모순된다">P1-3. Librarian
 prompt 계약이 서로 모순된다</h3>
 <p><code>config/prompts/keeper.librarian.episode_extraction.md</code>:</p>
 <ul>
@@ -1039,8 +1304,8 @@ per-Keeper</li>
 <li>source code/git/board에서 derivable한지 판단하라고 하지만 Librarian
 input에는 해당 source authority가 없음</li>
 </ul>
-<h3 id="p1-4.-provenance와-multimodal-정보가-손실된다">P1-4.
-Provenance와 multimodal 정보가 손실된다</h3>
+<h3 id="p1-4-provenance와-multimodal-정보가-손실된다">P1-4. Provenance와
+multimodal 정보가 손실된다</h3>
 <ul>
 <li>tool result는 id/error placeholder</li>
 <li>tool call은 id/name placeholder</li>
@@ -1063,14 +1328,14 @@ capacity+1 메시지와 ToolResult ID를 사용한 회귀가 이를 고정한다
 <code>Turn_ref</code>, multimodal payload, spatial namespace는 아직
 없으므로 finding은 부분 해결이다.</p>
 <h3
-id="p1-5.-fleet-wide-serial-maintenance가-keeper-독립성을-침해한다">P1-5.
+id="p1-5-fleet-wide-serial-maintenance가-keeper-독립성을-침해한다">P1-5.
 Fleet-wide serial maintenance가 Keeper 독립성을 침해한다</h3>
 <p>모든 Keeper consolidation을 같은 runtime 후보열에 대해 순차 실행한다.
 한 Keeper/provider가 느리면 뒤 Keeper 전체가 지연된다. 이는 Lane Per
 Keeper와 “하나가 멈추면 모두 멈추지 않는다”는 계약에 어긋난다.</p>
 <p>#26324가 periodic consolidation을 제거하면 해당 serial loop는
 사라진다.</p>
-<h3 id="p1-6.-ledger-관측-필드가-실제-의미와-다르다">P1-6. Ledger 관측
+<h3 id="p1-6-ledger-관측-필드가-실제-의미와-다르다">P1-6. Ledger 관측
 필드가 실제 의미와 다르다</h3>
 <p><code>keeper_recall_injection_ledger.ml:383</code>:</p>
 <div class="sourceCode" id="cb4"><pre
@@ -1086,7 +1351,7 @@ dashboard는 sangsu episode 223개를 보고했지만 ledger는 166개를
 wire는 decoder가 거부하며, Keeper/read-error identity 중복과 두 집합의
 교차도 거부한다. 위 <code>n_episodes_in_store</code> ledger 오표기는
 아직 남아 있으므로 이 finding은 부분 해결이다.</p>
-<h3 id="p1-7.-librarian-실패가-typed-turnhealth-상태가-아니다">P1-7.
+<h3 id="p1-7-librarian-실패가-typed-turnhealth-상태가-아니다">P1-7.
 Librarian 실패가 typed turn/health 상태가 아니다</h3>
 <p><code>run_best_effort</code>는 실패를 log/metric에 남기지만 caller에
 typed terminal result를 반환하지 않는다.</p>
@@ -1099,18 +1364,12 @@ typed terminal result를 반환하지 않는다.</p>
 <p>그러나 <code>/health</code>에 per-Keeper Librarian
 pending/failure/oldest-age 상태가 없다. 로그 수준에서는 보이지만 runtime
 contract 수준에서는 사실상 silent하다.</p>
-<h2 id="n-n3-라이브-흐름">7. N → N+3 라이브 흐름</h2>
+<h2 id="7-n--n3-라이브-흐름">7. N → N+3 라이브 흐름</h2>
 <p>민감한 원문은 읽거나 보고서에 기록하지 않았다. prompt block size와
 digest, typed outcome, store count만 비교했다.</p>
-<h3 id="rondo-autonomous-turns-17721775">7.1 Rondo autonomous turns
+<h3 id="71-rondo-autonomous-turns-17721775">7.1 Rondo autonomous turns
 1772–1775</h3>
 <table>
-<colgroup>
-<col style="width: 25%" />
-<col style="width: 25%" />
-<col style="width: 25%" />
-<col style="width: 25%" />
-</colgroup>
 <thead>
 <tr>
 <th>Turn</th>
@@ -1162,13 +1421,13 @@ digest, typed outcome, store count만 비교했다.</p>
 <li>user input과 assistant turn의 exact identity</li>
 <li>failover 후 어느 runtime 결과가 authoritative한지</li>
 </ul>
-<h3 id="user-input-주변">7.2 User input 주변</h3>
+<h3 id="72-user-input-주변">7.2 User input 주변</h3>
 <p>Rondo 1686–1689에서 dashboard user input 직후 persona/dynamic
 digest가 direct-chat 값으로 바뀌고 다음 turn에서 autonomous 값으로
 돌아오는 흐름은 확인했다.</p>
 <p>하지만 user row가 <code>turn_ref=null</code>이므로 “이 입력이 정확히
 turn #1687을 열었다”는 계약 수준 증명은 불가능하다.</p>
-<h2 id="확인된-양호점">8. 확인된 양호점</h2>
+<h2 id="8-확인된-양호점">8. 확인된 양호점</h2>
 <ul>
 <li>scoped Memory hot path에서 MASC → OAS 의존만 확인했다.</li>
 <li>OAS → MASC 역방향 참조는 발견되지 않았다.</li>
@@ -1183,8 +1442,8 @@ turn #1687을 열었다”는 계약 수준 증명은 불가능하다.</p>
 <p>단, 마지막 항목은 horizon policy가 제거됐다는 의미가 아니다.
 <code>valid_for_days</code>, TTL, recency, 32-turn window가 같은 역할을
 수행한다.</p>
-<h2 id="ocaml-5.5-eio-기준">9. OCaml 5.5 / Eio 기준</h2>
-<p>OCaml 5.5 공식 문서 기준:</p>
+<h2 id="9-ocaml-54--eio-기준">9. OCaml 5.4 / Eio 기준</h2>
+<p>OCaml 5.4 공식 문서 기준:</p>
 <ul>
 <li>Domain은 OS thread와 1:1인 heavyweight parallel unit이다.</li>
 <li>immutable value는 domain 사이에서 자유롭게 공유할 수 있다.</li>
@@ -1217,8 +1476,8 @@ Cancel</a></li>
 href="https://ocaml-multicore.github.io/eio/eio/Eio/Fiber/index.html">Eio
 Fiber</a></li>
 </ul>
-<h2 id="시장-구현-비교">10. 시장 구현 비교</h2>
-<h3 id="채택할-원칙">10.1 채택할 원칙</h3>
+<h2 id="10-시장-구현-비교">10. 시장 구현 비교</h2>
+<h3 id="101-채택할-원칙">10.1 채택할 원칙</h3>
 <p>Hermes Agent:</p>
 <ul>
 <li>post-turn single-worker FIFO</li>
@@ -1248,7 +1507,7 @@ compaction architecture</a></p>
 <li>성공 commit 후에만 cursor advance</li>
 <li>main-agent direct writer와 background writer authority 분리</li>
 </ul>
-<h3 id="복제하면-안-되는-것">10.2 복제하면 안 되는 것</h3>
+<h3 id="102-복제하면-안-되는-것">10.2 복제하면 안 되는 것</h3>
 <ul>
 <li>Hermes prefetch failure의 empty context/log-only degrade</li>
 <li>OpenClaw score/recency/threshold dreaming과 legacy migration</li>
@@ -1258,8 +1517,8 @@ threshold</li>
 </ul>
 <p>시장 구현은 invariant의 참고 자료일 뿐 MASC의 사용자 계약보다 상위
 authority가 아니다.</p>
-<h2 id="목표-아키텍처">11. 목표 아키텍처</h2>
-<h3 id="유일한-조립-수식">11.1 유일한 조립 수식</h3>
+<h2 id="11-목표-아키텍처">11. 목표 아키텍처</h2>
+<h3 id="111-유일한-조립-수식">11.1 유일한 조립 수식</h3>
 <pre class="text"><code>Prompt(N) =
   latest_committed_memory_revision
   + immutable_turn_events(memory_revision.covers_through_seq + 1 .. N)</code></pre>
@@ -1270,7 +1529,7 @@ authority가 아니다.</p>
 <li>Librarian이 느리거나 실패해도 Keeper main turn 진행</li>
 <li>restart 후 같은 cursor/watermark에서 재개</li>
 </ul>
-<h3 id="결정론-코드의-권한">11.2 결정론 코드의 권한</h3>
+<h3 id="112-결정론-코드의-권한">11.2 결정론 코드의 권한</h3>
 <ul>
 <li>event identity와 ordering</li>
 <li>namespace와 ACL</li>
@@ -1279,7 +1538,7 @@ authority가 아니다.</p>
 <li>atomic commit</li>
 <li>explicit typed failure</li>
 </ul>
-<h3 id="llm의-권한">11.3 LLM의 권한</h3>
+<h3 id="113-llm의-권한">11.3 LLM의 권한</h3>
 <pre class="text"><code>Create
 Update existing_fact_id
 Supersede existing_fact_id
@@ -1294,7 +1553,7 @@ Noop</code></pre>
 <li>policy revision</li>
 <li>created/committed timestamp</li>
 </ul>
-<h3 id="spatial-namespace">11.4 Spatial namespace</h3>
+<h3 id="114-spatial-namespace">11.4 Spatial namespace</h3>
 <p>최소 exact tuple:</p>
 <pre class="text"><code>keeper
 × connector
@@ -1304,9 +1563,9 @@ Noop</code></pre>
 × actor</code></pre>
 <p>다른 공간의 기억 공유는 typed explicit relation으로만 허용한다. 동일
 문구 또는 유사 embedding만으로 namespace를 합치지 않는다.</p>
-<h2 id="개선-goals와-측정-가능한-tasks">12. 개선 Goals와 측정 가능한
+<h2 id="12-개선-goals와-측정-가능한-tasks">12. 개선 Goals와 측정 가능한
 Tasks</h2>
-<h3 id="g0.-fresh-state-persistence-ssot">G0. Fresh-state persistence
+<h3 id="g0-fresh-state-persistence-ssot">G0. Fresh-state persistence
 SSOT</h3>
 <p>Tasks:</p>
 <ol type="1">
@@ -1322,7 +1581,7 @@ SSOT</h3>
 <li>compatibility/migration branch 0개</li>
 <li>facts/episodes/events commit receipt 1개</li>
 </ul>
-<h3 id="g1.-turn-ledger-ssot">G1. Turn Ledger SSOT</h3>
+<h3 id="g1-turn-ledger-ssot">G1. Turn Ledger SSOT</h3>
 <p>Tasks:</p>
 <ol type="1">
 <li><code>Input_ref</code>, <code>Turn_ref</code>,
@@ -1339,7 +1598,7 @@ row에 전파</li>
 <li>null user TurnRef 0</li>
 <li>duplicate TurnRef 0</li>
 </ul>
-<h3 id="g2.-context-assembler">G2. Context Assembler</h3>
+<h3 id="g2-context-assembler">G2. Context Assembler</h3>
 <p>Tasks:</p>
 <ol type="1">
 <li><code>memory revision + uncovered event tail</code> 단일 조립</li>
@@ -1354,8 +1613,7 @@ row에 전파</li>
 <li>tool call/result 분리 0</li>
 <li>private channel leakage 0</li>
 </ul>
-<h3 id="g3.-per-keeper-librarian-lane">G3. Per-Keeper Librarian
-Lane</h3>
+<h3 id="g3-per-keeper-librarian-lane">G3. Per-Keeper Librarian Lane</h3>
 <p>Tasks:</p>
 <ol type="1">
 <li><code>Replace_latest</code> 제거</li>
@@ -1382,7 +1640,7 @@ slice로 구현</li>
 <li>waiting chat 때문에 current autonomous run이 종료되는 경우 0</li>
 <li>separate lease/settlement identity 0</li>
 </ul>
-<h3 id="g4.-semantic-memory-policy">G4. Semantic Memory Policy</h3>
+<h3 id="g4-semantic-memory-policy">G4. Semantic Memory Policy</h3>
 <p>Tasks:</p>
 <ol type="1">
 <li>typed <code>Create|Update|Supersede|Forget|Noop</code></li>
@@ -1403,7 +1661,7 @@ slice로 구현</li>
 <li>paraphrase, contradiction, correction fixture 통과</li>
 <li>restart 전후 동일 causal decision</li>
 </ul>
-<h3 id="g5.-atomic-failure-and-failover">G5. Atomic Failure and
+<h3 id="g5-atomic-failure-and-failover">G5. Atomic Failure and
 Failover</h3>
 <p>Tasks:</p>
 <ol type="1">
@@ -1421,7 +1679,7 @@ Failover</h3>
 <li>invalid candidate 이후 configured fallback 동작과 provenance
 증명</li>
 </ul>
-<h3 id="g6.-observability">G6. Observability</h3>
+<h3 id="g6-observability">G6. Observability</h3>
 <p>Tasks:</p>
 <ol type="1">
 <li>TurnRecord에 memory revision ID, source range, Librarian receipt ID
@@ -1437,13 +1695,9 @@ generation</li>
 <li>misleading store count field 0</li>
 <li>log-only Librarian terminal failure 0</li>
 </ul>
-<h3 id="후속-구현-상태">12.1 2026-07-30 후속 구현 상태</h3>
+<h3 id="121-2026-07-30-후속-구현-상태">12.1 2026-07-30 후속 구현
+상태</h3>
 <table>
-<colgroup>
-<col style="width: 33%" />
-<col style="width: 33%" />
-<col style="width: 33%" />
-</colgroup>
 <thead>
 <tr>
 <th>Goal</th>
@@ -1454,20 +1708,19 @@ generation</li>
 <tbody>
 <tr>
 <td>G0</td>
-<td>dead <code>Keeper_memory_os_store</code>/전용 test/stanza 삭제,
-production Memory file entrypoint를 explicit <code>keepers_dir</code>
-하나로 통일, Recall/search/status/write/Librarian/dashboard/maintenance
-GC의 <code>episode-bundle → facts</code> 순서 정합화</td>
-<td><strong>부분 완료</strong> — facts/episode/event atomic
-commit/receipt 미구현; test-only ambient IO facade 정리 필요</td>
+<td>#26500에서 dead Store/JSONL facts·episode·event를 삭제하고
+read/write/Librarian/dashboard를 exact
+<code>*.memory-current.json</code> snapshot 하나로 연결. closed decoder,
+revision CAS, atomic replace 사용</td>
+<td><strong>source 완료</strong> — fresh-state deployment/runtime
+proof는 별도 미완료</td>
 </tr>
 <tr>
 <td>G1</td>
-<td>duplicate/null TurnRef 원인과 admission-time durable binding 위치
-추적 완료; dashboard TurnRecord는 canonical
-<code>${trace_id}#${absolute_turn}</code>을 강제</td>
-<td><strong>미완료</strong> — Librarian source provenance는 prompt-local
-turn/current trace라 canonical TurnRef가 아님</td>
+<td>Librarian input과 snapshot source는 typed
+<code>${trace_id}#${absolute_turn}</code>/trace/generation을 사용</td>
+<td><strong>미완료</strong> — 개별 fact source TurnRef/event edge와 user
+input exact join 없음</td>
 </tr>
 <tr>
 <td>G2</td>
@@ -1477,28 +1730,25 @@ turn/current trace라 canonical TurnRef가 아님</td>
 <tr>
 <td>G3</td>
 <td>latest-wins와 park/lease/settlement를 서로 다른 SSOT로 분해;
-Librarian exact journal은 current-only closed state/trace/generation,
-trace-scoped restart fence, canonical path identity로 강화</td>
+Librarian writer는 closed current snapshot과 revision CAS를 사용</td>
 <td><strong>부분 완료</strong> — lossless per-Keeper FIFO/outbox
 미구현</td>
 </tr>
 <tr>
 <td>G4</td>
-<td>Memory <code>claim_kind</code>, <code>open_items</code>, episode
-<code>constraints</code>, <code>preserved_tool_refs</code>,
-<code>valid_for_days</code>/<code>valid_until</code>/<code>Ephemeral</code>와
-expiry authority 제거</td>
-<td><strong>부분 완료</strong> — echo window, recency/byte cap,
-substring score, first-100-byte dedupe 잔존</td>
+<td>claim/TTL/episode authority와 deterministic recall ranking·byte
+cap·echo window 제거. LLM current selection을 그대로 recall</td>
+<td><strong>부분 완료</strong> — explicit search substring/token match와
+first-100-byte history dedupe 잔존</td>
 </tr>
 <tr>
 <td>G5</td>
-<td>public fact/episode reader partial-drop 제거, recall unavailable 및
-dashboard read error 노출, publication phase failure를 typed result로
-분류</td>
-<td><strong>부분 완료</strong> — journal terminal이 publication보다
-앞서고 facts→episode→event partial commit/rollback이 없어 atomic
-revision/failover receipt 미구현</td>
+<td>current snapshot closed read, revision CAS/atomic replace,
+unavailable/dashboard read error, OAS typed evidence chain과 MASC direct
+consumer</td>
+<td><strong>부분 완료</strong> — OAS v0.231.10 exact release와 #26491
+exact-head CI green. power-loss durability receipt와 production runtime
+proof 미구현</td>
 </tr>
 <tr>
 <td>G6</td>
@@ -1542,26 +1792,75 @@ config/snapshot/docs/test symbol scan 0</li>
 build artifact가 없어 미실행</li>
 <li>로컬 Dune 미실행; OCaml type/link/build/test는 <strong>CI
 미증명</strong></li>
+<li>OAS #2892 local: touched OCaml 전부 <code>ocamlformat</code>,
+parse-only, <code>git diff --check</code> 통과. Dune 미실행. head
+<code>d2a56f315...</code>은 full CI 전 merge</li>
+<li>OAS #2896 local: mixed four-candidate loopback test, projector
+cardinality, canonical roundtrip, stale-integrity tamper와 re-hashed
+structural tamper를 추가. 최초 CI는 <code>Yojson.Safe.t</code> 타입
+추론과 godfile <code>+1</code>로 실패</li>
+<li>OAS #2899: canonical JSON을 명시적 <code>Yojson.Safe.t</code>로 닫는
+compiler root fix</li>
+<li>OAS #2903 local: root 125L, types 217L, canonical 243L, validation
+primitives 284L, validation 192L, codec 403L;
+parser/format/diff/boundary gate와 code-smell ratchet
+<code>godfile 11 → 11</code> 통과. exact-main CI <a
+href="https://github.com/jeong-sik/oas/actions/runs/30535040210"><code>30535040210</code></a>은
+<code>rejected.measurement</code>/<code>visit.ordinal</code>
+record-label 추론 오류로 Build(5.4.1/5.5.0)·Lint·Eio 1.3/1.4 실패</li>
+<li>OAS #2904/#2906 중간 exact-head Build/Lint/Eio 실패(PR run <a
+href="https://github.com/jeong-sik/oas/actions/runs/30535494954"><code>30535494954</code></a>,
+<a
+href="https://github.com/jeong-sik/oas/actions/runs/30535658586"><code>30535658586</code></a>)와
+선행 #2901 head <code>5597da1b…</code>의 PR run <a
+href="https://github.com/jeong-sik/oas/actions/runs/30534846121"><code>30534846121</code></a>
+실패(<code>Option.exists</code> OCaml 5.4.1 unbound,
+<code>flow_visit_ordinal</code> 타입 오류)를 확인한 뒤 #2907/#2908에서
+consumer·codec·validation leaf의 typed boundary와 OCaml 5.4 option
+match를 닫음. <code>v0.231.9</code> 태그 <code>b70b35bb…</code>의
+exact-main CI run <a
+href="https://github.com/jeong-sik/oas/actions/runs/30534931823"><code>30534931823</code></a>은
+취소, Code Smell Ratchet run <a
+href="https://github.com/jeong-sik/oas/actions/runs/30534931829"><code>30534931829</code></a>
+실패로 green release 증거 없음</li>
+<li>OAS v0.231.10 SHA
+<code>1fa61251936758d37c3a33eac07b8d95c5f26d35</code>: CI <a
+href="https://github.com/jeong-sik/oas/actions/runs/30536256908"><code>30536256908</code></a>에서
+OCaml 5.4.1/5.5.0 Build &amp; Test, Eio 1.3/1.4, Lint, Format 포함 13/13
+jobs 성공 — 최종 green release SHA(2026-07-30 22:10 KST
+<code>gh run view</code>/ <code>gh release list</code> 재확인, 신뢰도
+High)</li>
+<li>MASC #26489가 OAS v0.231.10 exact pin을 main에 반영했으나 merge 시점
+exact-head Build/CI Gate는 merge 뒤 취소. 이후 #26491 exact-head green
+CI가 동일 pin 포함 tree의 Build/Dashboard를 증명</li>
+<li>MASC #26491은 2026-07-30 21:53 KST merge(head
+<code>41561bd0220fc6afdd1a732ed217f9616ee61a26</code>, merge commit
+<code>8c849755…</code>). exact-head CI(Build and Test/Dashboard/CI Gate
+등) 전부 green(2026-07-30 22:10 KST <code>gh pr view 26491</code> 확인).
+로컬 Dune 미실행</li>
+<li>MASC #26500(<code>hard-cut minimal current contract</code>)은
+2026-07-30 22:01 KST merge(merge commit
+<code>101d9efa1623e62b16b90f4011ff877e5eb49e65</code>). current Memory
+contract를 <code>*.memory-current.json</code>으로 hard cut. 잔여 source
+pin/caller/heuristic은 2026-07-30 22:59 KST post-merge 재감사 결과를
+사용한다.</li>
 </ul>
-<p>Fresh-state cutover blocker:</p>
+<p>Current-snapshot deployment proof:</p>
 <ul>
-<li>2026-07-30 16:05 KST live <code>*.facts.jsonl</code>은 10 files/174
-rows이며 <strong>174 rows 전부</strong> <code>schema_version</code>, 68
-rows가 <code>valid_until</code>을 갖는다.</li>
-<li>live episode JSON은 1,957 files이며 전부
-<code>schema_version</code>과
-<code>open_items|constraints|preserved_tool_refs</code> 중 적어도 하나를
-갖는다.</li>
-<li>새 closed decoder는 10/10 fact store와 1,957/1,957 episode files를
-거부한다. 호환 reader나 migration을 추가하지 않는다.</li>
-<li>old runtime이 계속 retired row를 쓰므로 reset-before-stop은 race다.
-배포 승인은
-<code>old runtime stop → exact &lt;base_path&gt;/.masc/config/keepers cold archive/reset → new binary start → health/recall/write/restart proof</code>의
-한 cold-cut 절차가 필요하다.</li>
-<li>이 operational proof/runbook은 아직 diff에 없다. 따라서 source
-hard-cut과 별개로 release는 <strong>P0 BLOCK</strong>이다.</li>
+<li>2026-07-30 16:05 KST에 관측한 <code>*.facts.jsonl</code>과
+episode/event 파일은 merge 전 runtime의 역사 증거다. #26500 이후 current
+source에는 해당 reader가 없으므로 이 파일들의 존재는 decoder failure나
+Keeper 디렉터리 reset 조건이 아니다.</li>
+<li>호환 reader, migration, repairer는 추가하지 않는다. retired 파일을
+current authority로 복구하거나 변환하는 운영 단계도 두지 않는다.</li>
+<li>배포 승인은
+<code>old runtime stop → new binary start → exact &lt;base_path&gt;/.masc/config/keepers/*.memory-current.json write → restart → health/recall proof</code>로
+확인한다. unrelated Keeper state 삭제는 금지한다.</li>
+<li>이 current-path runtime proof는 아직 없다. 따라서 source hard-cut과
+별개로 release는 <strong>P0 BLOCK</strong>이지만, blocker는 cold reset이
+아니라 미검증 deployment다.</li>
 </ul>
-<h2 id="권장-실행-순서">13. 권장 실행 순서</h2>
+<h2 id="13-권장-실행-순서">13. 권장 실행 순서</h2>
 <ol type="1">
 <li>G0 Fresh-state SSOT</li>
 <li>G1 Turn identity</li>
@@ -1573,7 +1872,7 @@ hard-cut과 별개로 release는 <strong>P0 BLOCK</strong>이다.</li>
 </ol>
 <p>G0/G1 이전에 새로운 retrieval, dedupe, Gate, TTL을 추가하면 잘못된
 authority와 identity 위에 기능을 더 쌓게 된다.</p>
-<h2 id="최종-결론">14. 최종 결론</h2>
+<h2 id="14-최종-결론">14. 최종 결론</h2>
 <p>현재 MASC Librarian/Memory OS는 “실제로 호출되는 prototype” 단계를
 넘었고, 후속 source slice에서 TTL/horizon authority까지 제거했지만, 다음
 조건을 충족하지 못한다.</p>
@@ -1610,11 +1909,12 @@ exact-head <code>Build and Test</code>/<code>CI Gate</code>가 merge 뒤
 <p>따라서 Memory OS 개선은 하나의 거대한 호환 PR이 아니라, 위 Goal
 순서대로 fresh-state hard cut을 적용한 좁고 독립적인 PR들로 진행해야
 한다.</p>
-<h2 id="evidence-record">15. Evidence Record</h2>
-<h3 id="공통-헤더">15.1 공통 헤더</h3>
+<h2 id="15-evidence-record">15. Evidence Record</h2>
+<h3 id="151-공통-헤더">15.1 공통 헤더</h3>
 <ul>
 <li><code>날짜(ISO8601)</code>:
-<code>2026-07-30T16:05:00+09:00</code></li>
+<code>2026-07-30T23:28:01+09:00</code>(#26500 post-merge source 재감사와
+current-snapshot deployment 판정 반영)</li>
 <li><code>작성자</code>: <code>Codex</code></li>
 <li><code>결정 ID</code>:
 <code>masc-memory-os-adversarial-audit-20260730</code></li>
@@ -1623,18 +1923,18 @@ exact-head <code>Build and Test</code>/<code>CI Gate</code>가 merge 뒤
 <code>/Users/dancer/me/.masc</code></li>
 <li><code>결정 상태</code>: <code>보류 — BLOCK / NO-GO</code></li>
 </ul>
-<h3 id="근거-evidence">15.2 근거 (Evidence)</h3>
-<h4 id="source-1">Source</h4>
+<h3 id="152-근거-evidence">15.2 근거 (Evidence)</h3>
+<h4 id="source">Source</h4>
 <ul>
 <li><code>항목</code>: Librarian/Memory OS current source contract</li>
 <li><code>출처</code>: <code>git rev-parse origin/main</code>,
 <code>git diff HEAD</code>, production caller scan</li>
-<li><code>확인일시</code>: <code>2026-07-30T16:14:00+09:00</code></li>
+<li><code>확인일시</code>: <code>2026-07-30T22:59:03+09:00</code></li>
 <li><code>신뢰도</code>: <code>High</code></li>
 <li><code>제한조건</code>: 후속 2개 source slice와 report update는 아직
 새 Draft PR CI 전</li>
 </ul>
-<h4 id="runtime-1">Runtime</h4>
+<h4 id="runtime">Runtime</h4>
 <ul>
 <li><code>항목</code>: live recall, Librarian, consolidation, Turn
 identity</li>
@@ -1650,19 +1950,26 @@ startup repo HEAD</li>
 <ul>
 <li><code>항목</code>: 현재 open PR의 finding coverage</li>
 <li><code>출처</code>: <code>gh pr list</code>, <code>gh pr view</code>,
-GitHub changed-file 및 exact file patch</li>
-<li><code>확인일시</code>: <code>2026-07-30T16:05:00+09:00</code></li>
+GitHub changed-file 및 exact file patch; MASC
+#26428/#26440/#26450/#26489/#26491/#26500, OAS
+#2892/#2896/#2899/#2901/#2903/#2904/#2906/#2907/#2908, OAS CI
+<code>30535040210</code>/<code>30535494954</code>/<code>30535658586</code>/<code>30534846121</code>/
+<code>30534931823</code>/<code>30534931829</code>/<code>30536256908</code></li>
+<li><code>확인일시</code>: <code>2026-07-30T22:10:00+09:00</code></li>
 <li><code>신뢰도</code>: <code>High</code></li>
 <li><code>제한조건</code>: PR head/check 상태는 이후 push에 따라 변경
 가능</li>
 </ul>
-<h4 id="ocaml-eio">OCaml / Eio</h4>
+<h4 id="ocaml--eio">OCaml / Eio</h4>
 <ul>
-<li><code>항목</code>: OCaml 5.5 memory model과 Eio cancellation/mutex
+<li><code>항목</code>: OCaml 5.4 memory model과 Eio cancellation/mutex
 기준</li>
-<li><code>출처</code>: OCaml 5.5 official manual, Eio official API
-docs</li>
-<li><code>확인일시</code>: <code>2026-07-30T10:53:00+09:00</code></li>
+<li><code>출처</code>: <a
+href="https://ocaml.org/manual/5.4/index.html">OCaml 5.4 official
+manual</a>, <a
+href="https://ocaml.org/manual/5.4/parallelism.html">OCaml 5.4 parallel
+programming</a>, Eio official API docs</li>
+<li><code>확인일시</code>: <code>2026-07-30T18:29:00+09:00</code></li>
 <li><code>신뢰도</code>: <code>High</code></li>
 <li><code>제한조건</code>: MASC-specific architecture 판정은 공식
 언어/runtime 계약의 적용 결과</li>
@@ -1678,7 +1985,7 @@ implementation</li>
 <li><code>제한조건</code>: 로컬 claude-code는 upstream-current 주장
 아님</li>
 </ul>
-<h3 id="검증-verification">15.3 검증 (Verification)</h3>
+<h3 id="153-검증-verification">15.3 검증 (Verification)</h3>
 <ul>
 <li><code>1차</code>: current source entrypoint, producer, typed
 consumer, caller 추적</li>
@@ -1690,10 +1997,25 @@ JSONL/SQLite aggregate 확인</li>
 동일 heuristic/identity 결함 확인. 후속 worktree의 dead
 Store/field/BasePath hard cut은 변경 OCaml 전체 format/parse, dashboard
 typecheck, focused 7 files/255 tests, Python 24 tests와 static check를
-통과했다. TTL/expiry authority production reference도 제거됐다.
-Dune/CI와 runtime cutover는 미검증.</li>
+통과했다. TTL/expiry authority production reference도 제거됐다. OAS
+#2892/#2896/#2899/#2903과 #2904/#2906/#2907/#2908은 advance evidence,
+provider prose hard cut, validated-flow durable snapshot, Safe.t
+compiler root fix, private leaf split, typed compile repair까지
+진행했다. 중간 exact CI chain(#2903 main run <code>30535040210</code>,
+#2904/#2906 PR run <code>30535494954</code>/ <code>30535658586</code>,
+#2901 PR run <code>30534846121</code>, <code>v0.231.9</code> main run
+<code>30534931823</code> 취소 + ratchet <code>30534931829</code> 실패)은
+모두 불합격이었고, v0.231.10 exact release CI <code>30536256908</code>만
+13/13 jobs green이다(2026-07-30 22:10 KST 재확인). MASC #26489는 exact
+pin을 main에 반영했고 #26491은 typed advance consumer를 green exact-head
+CI로 merge했다(2026-07-30 21:53 KST). #26500 minimal current contract도
+merge됐다(2026-07-30 22:01 KST). #26500 이후
+<code>0d193fe1422bc943d079ffe12e4b527db5acaff3</code> source를 재감사해
+original P0 5건/P1 4건 해결, P0 1건 부분 해결, P0 3건/P1 3건 미해결로
+재분류했다. durable evidence production caller/runtime cutover는
+미검증이다.</li>
 </ul>
-<h3 id="불확실성-uncertainty">15.4 불확실성 (Uncertainty)</h3>
+<h3 id="154-불확실성-uncertainty">15.4 불확실성 (Uncertainty)</h3>
 <ul>
 <li><p><code>미확인 항목</code>: 실행 binary에 embedded된 exact git
 SHA</p></li>
@@ -1701,14 +2023,19 @@ SHA</p></li>
 cryptographic deployment identity라고 단정할 수 없음</p></li>
 <li><p><code>추가 확인 필요</code>: build artifact에 commit SHA를
 embed하고 health가 그 값을 직접 반환</p></li>
-<li><p><code>미확인 항목</code>: Draft PR #26440 exact-head CI와 #26428
-current-head fresh CI</p></li>
-<li><p><code>영향</code>: 후속 source finding coverage는 정적 검증됐지만
-merge/deployment readiness는 아직 증명되지 않음</p></li>
-<li><p><code>추가 확인 필요</code>: draft PR push 후 head SHA, required
-checks, unresolved review threads 재확인</p></li>
+<li><p><code>미확인 항목</code>: merge된 MASC #26440/#26450/#26489의
+exact-head full CI, durable evidence production caller/runtime
+proof</p></li>
+<li><p><code>영향</code>: MASC source hard cut은 병합됐지만
+#26440/#26450/#26489의 Build/Dashboard가 취소 또는 skipped됐고(#26491
+exact-head CI는 2026-07-30 22:10 KST 기준 green), failover evidence와
+exact pin은 source에 들어왔지만 MASC runtime의 durable production
+caller로 연결됐다는 증거는 없음. #26500 post-merge source 재감사는
+완료했지만 deployed runtime proof는 아님</p></li>
+<li><p><code>추가 확인 필요</code>: production caller/N→N+3 restart 및
+deployed-runtime proof</p></li>
 </ul>
-<h3 id="적용범위-scope">15.5 적용범위 (Scope)</h3>
+<h3 id="155-적용범위-scope">15.5 적용범위 (Scope)</h3>
 <ul>
 <li><code>영향 받는 영역</code>: Keeper turn identity, Librarian lane,
 Memory persistence, recall/context assembly, chat admission, async

--- a/reports/MASC-LIBRARIAN-MEMORY-OS-ADVERSARIAL-AUDIT-2026-07-30.md
+++ b/reports/MASC-LIBRARIAN-MEMORY-OS-ADVERSARIAL-AUDIT-2026-07-30.md
@@ -9,7 +9,8 @@
 
 ## 1. Executive Summary
 
-Librarian과 Memory OS는 라이브 런타임에서 실제로 동작한다.
+#26500 이전 배포 라이브 런타임에서 Librarian과 Memory OS가 실제로 동작한 것은
+확인했다. 아래 항목은 현재 source나 현재 배포를 뜻하지 않는 역사 증거다.
 
 - Keeper turn마다 `memory_os_recall` 블록이 prompt에 주입된다.
 - post-turn Librarian이 episode와 fact를 기록한다.
@@ -20,8 +21,11 @@ Librarian과 Memory OS는 라이브 런타임에서 실제로 동작한다.
 > `a8683ea2ccc26c168664e114dbc0b01b8e1ed770`으로 merge됐다. 아래 runtime
 > 관측은 merge 전 배포의 역사 증거이며, 현재 source가 배포됐다는 증거가 아니다.
 
-그러나 현재 구현을 production-correct로 승인할 수 없다. 사용자 계약을 기준으로
-**P0 9개, P1 7개**가 확인됐다.
+최초 감사에서는 사용자 계약 기준 **P0 9개, P1 7개**를 확인했다. #26500 merge 뒤
+current `origin/main` `0d193fe1422bc943d079ffe12e4b527db5acaff3`을
+2026-07-30 22:59 KST에 다시 추적한 source 판정은 P0 9개 중 **해결 5, 부분 해결 1,
+미해결 3**, P1 7개 중 **해결 4, 미해결 3**이다. 따라서 현재 source blocker는
+P0 4개(부분 해결 포함), P1 3개이며 production-correct 승인은 여전히 불가하다.
 
 후속 current-only worktree는 dead Store와 Memory `claim_kind`/persisted
 `schema_version`/episode 사망 field를 삭제하고, 모든 public Memory reader,
@@ -33,9 +37,12 @@ trace를 사용하므로 canonical TurnRef가 아니다. 파일 I/O는 productio
 `episode-bundle → facts` 락 순서를 적용했다. 두 번째 hard-cut은
 `valid_for_days`/`valid_until`/`Ephemeral`, expiry GC·sanity sweep·maintenance
 fiber와 dashboard TTL projection까지 삭제했다. retired TTL 입력과 persisted field는
-closed decoder가 명시적으로 거부한다. 이 개선은 아직 새 PR CI·배포·fresh-state
-cutover가 증명되지 않았고, canonical TurnRef·recency selection·latest-wins·
-echo/dedupe 휴리스틱·비원자 publication이 남으므로 최종 판정은 계속 NO-GO다.
+closed decoder가 명시적으로 거부한다. #26500 post-merge source에서는 단일
+`*.memory-current.json` snapshot, closed decoder, revision CAS와 atomic file replace가
+실제 production caller에 연결됐다. 그러나 canonical fact provenance, substring
+search와 first-100-byte history dedupe, Librarian latest coalescing,
+chat-waiting/lease와 async settlement 중복 authority가 남으므로 최종 판정은 계속
+NO-GO다.
 
 2026-07-30 16:53 KST 후속 hard cut은 production producer가 항상 `None`만
 기록하던 `terminal_marker`를 episode type/codec/recall/dashboard/viewer/test에서
@@ -45,7 +52,9 @@ echo/dedupe 휴리스틱·비원자 publication이 남으므로 최종 판정은
 publication의 선행 정리이며, atomic Memory authority 자체가 완료됐다는 뜻은
 아니다.
 
-2026-07-30 20:02 KST OAS 경계 재검토에서는 더 앞선 P0 두 개를 확인했다. 기존
+2026-07-30 20:02 KST OAS 경계 재검토에서는 G5를 막는 OAS 결함 두 개를 확인했다.
+이 둘은 본 Memory 감사의 P0-1~P0-9 finding count에 추가하지 않고 cross-boundary
+supporting defect로 분류한다. 기존
 `flow_evidence`는 성공한 `before_advance` 전이를 보존하지 않아 failover 경로를
 복원할 수 없고, HTTP 400 provider 오류 문구를 문자열 문법으로 해석해 typed
 context-overflow 사실으로 승격했다. MASC shadow codec은 OAS private invariant의 두
@@ -98,23 +107,20 @@ CI Gate 포함)는 전부 green이다. 또한
 current contract`, merge commit
 `101d9efa1623e62b16b90f4011ff877e5eb49e65`)이 2026-07-30 22:01 KST에 merge돼
 main의 current Memory contract를 `*.memory-current.json`으로 hard cut했다.
-따라서 본 보고서의 잔여 heuristic/pin/caller 증거 목록은 #26500 이전 main
-기준이며, durable evidence production caller/runtime 증거는 여전히 별도 차단
-상태다(2026-07-30 22:10 KST `gh pr view` 확인, 신뢰도 High).
+2026-07-30 22:59 KST post-merge source 재감사에서 old Store/JSONL/episode/event,
+legacy field, partial reader, recency/byte-cap recall, consolidation, TTL authority가
+production tree에서 제거된 것을 확인했다. durable evidence production
+caller/runtime 증거는 여전히 별도 차단 상태다.
 
 가장 중요한 차단 사유는 다음과 같다.
 
-1. 사용되지 않는 canonical store와 실제 JSONL store가 병존한다.
-2. schema migration과 legacy row 수용 코드가 명시적으로 존재한다.
-3. 동일 TurnRef가 서로 다른 context를 가리키며 user input에는 TurnRef가 없다.
-4. 손상된 fact row가 recall/search/dashboard에서 무음으로 사라진다.
-5. recall과 search가 recency, byte budget, substring, 고정 window로 의미를 결정한다.
-6. consolidation이 부분 파싱된 모델 출력을 사용해 거의 전체 memory를 삭제할 수 있다.
-7. `claim_kind`, `valid_until`과 여러 episode field가 context에는 기여하지 않으면서
-   Gate·expiry·merge authority로 동작한다.
-8. `park`/`lease`가 별도 lifecycle 개념으로 증식해 waiting chat이 autonomous Keeper를
+1. fact가 canonical source TurnRef/event edge를 보존하지 않고 user input의 exact
+   TurnRef 증거도 닫히지 않았다.
+2. prompt recall은 LLM-selected current snapshot으로 고쳐졌지만 explicit search와
+   history 조립에는 substring/token match와 first-100-byte dedupe가 남는다.
+3. `park`/`lease`가 별도 lifecycle 개념으로 증식해 waiting chat이 autonomous Keeper를
    종료시키고, Turn attempt identity와 중복되는 authority를 만든다.
-9. `settlement`가 canonical terminal request 위에 두 번째 projection contract를 만든다.
+4. `settlement`가 canonical terminal request 위에 두 번째 projection contract를 만든다.
 
 따라서 새 Gate나 retrieval 기능을 추가하기 전에 다음 순서로 기반을 바로잡아야 한다.
 
@@ -129,6 +135,8 @@ main의 current Memory contract를 `*.memory-current.json`으로 hard cut했다.
   `8c4dae264e6b1d03708029718f868efbb3c2613b`
 - 2026-07-30 16:17 KST current `origin/main` 및 rebase base:
   `407ae5bb92509f06bfb6fc5614e8539e230b2902`
+- 2026-07-30 22:59 KST #26500 post-merge 재감사 `origin/main`:
+  `0d193fe1422bc943d079ffe12e4b527db5acaff3`
 - 후속 구현 branch:
   `refactor/memory-current-only-hard-cut-20260730`
 - 사망 필드/원자 publication 후속 branch:
@@ -193,7 +201,7 @@ binary SHA는 미증명으로 남긴다.
 | [#26450](https://github.com/jeong-sik/masc/pull/26450) `prepare current-only atomic publication` | 본 감사 후속 구현 | **Merged**, head `3cf500c78b16e80c17ee1867ac6c4eb3512d27ba`, merge commit `1910149d9e42c7e91b79915157506d695be72f18`; `Build and Test`/Dashboard 등 full CI skipped, 다수 check cancelled | `terminal_marker`/versioned dashboard schema를 숙청하고 Librarian input을 `TurnRef`로 key했다. atomic revision은 구현하지 않았다. | **사망 필드 제거는 유효. CI·atomic commit·production caller 증거 없음** |
 | [#26489](https://github.com/jeong-sik/masc/pull/26489) `pin agent sdk v0.231.10` | OAS release pin | **Merged**, head `c146ee46773f1813257dfad18060a679017bc31e`, merge commit `163f375010311b1798faeb42718439adfc1e4a41`; exact-head Build/CI Gate 취소 | OAS v0.231.10 SHA `1fa61251936758d37c3a33eac07b8d95c5f26d35`를 manifest/API-surface SSOT에 반영한다. | **source pin은 main 반영. exact-head MASC CI와 runtime proof 전 NO-GO** |
 | [#26491](https://github.com/jeong-sik/masc/pull/26491) `bind turn evidence to serialized requests` | typed consumer/observability 후속 | **Merged**, head `41561bd0220fc6afdd1a732ed217f9616ee61a26`, merge commit `8c84975577338aa2a78f21161c0c121b1038b531`, 2026-07-30 21:53 KST merge; exact-head Build and Test/Dashboard/CI Gate 등 전부 green(2026-07-30 22:10 KST 확인) | #26489 pin 위에서 HITL summary가 typed advance를 직접 소비한다. request wire/prompt blocks/messages를 같은 serialized-request snapshot으로 묶고 unavailable composition을 `null`로 보존한다. | **source 병합 + exact-head CI green. durable evidence production caller/runtime proof 전 NO-GO** |
-| [#26500](https://github.com/jeong-sik/masc/pull/26500) `hard-cut minimal current contract` | 본 감사 후속 구현 | **Merged**, head `ae2f017ed462024f8fe07928d33bbf07af5f6724`, merge commit `101d9efa1623e62b16b90f4011ff877e5eb49e65`, 2026-07-30 22:01 KST merge | current Memory contract를 exact `claim`/`category`/`first_seen`의 `*.memory-current.json`으로 hard cut하고 model-authored identity/TTL/recency ranking/`score`를 제거한다. migration/compat reader 없음 | **main 반영. 본 보고서의 잔여 증거 목록은 #26500 이전 main 기준이므로 post-merge 재감사 필요** |
+| [#26500](https://github.com/jeong-sik/masc/pull/26500) `hard-cut minimal current contract` | 본 감사 후속 구현 | **Merged**, head `ae2f017ed462024f8fe07928d33bbf07af5f6724`, merge commit `101d9efa1623e62b16b90f4011ff877e5eb49e65`, 2026-07-30 22:01 KST merge | current Memory contract를 exact `claim`/`category`/`first_seen`의 `*.memory-current.json`으로 hard cut하고 model-authored identity/TTL/recency ranking/`score`를 제거한다. migration/compat reader 없음 | **main 반영. 22:59 KST post-merge source 재감사 완료: P0 5건/P1 4건 해결, P0 1건 부분 해결, P0 3건/P1 3건 미해결** |
 | [OAS #2892](https://github.com/jeong-sik/oas/pull/2892) `preserve typed advance evidence` | G5 선행 경계 | **Merged**, head `d2a56f315fc452d00a5ed55ea729746c800adfb2`, merge commit `7ce45ee3aa218b49dc13aaaebba1e2698aa22e2c`; exact-head CI 완료 전 merge | 성공한 `before_advance`를 동일 atomic flow progress에 기록하고 HTTP 400 오류 문구 기반 context-overflow 승격과 dead variant를 제거한다. | **source P0 없음. MASC/masc-mcp의 제거된 variant 소비자 hard cut 전 pin 금지** |
 | [OAS #2896](https://github.com/jeong-sik/oas/pull/2896) `persist validated flow evidence` | G5 durable evidence | **Merged**, head `e89c5d9e57b5e8cd2077468cc2e04fa21d0b09f6`, merge commit `f6cc38056`; 최초 CI는 `Yojson.Safe.t` 추론 오류와 godfile `+1`로 실패 | actual mixed flow의 admission rejection → invalid JSON advance → semantic rejection → acceptance를 current-only canonical snapshot으로 보존한다. projector exactly-once, strict decode, integrity 및 re-hashed structural tamper test를 추가한다. | **기능 경계 유효. 최초 head는 compile/ratchet 불합격; #2899/#2903 후속 필수** |
 | [OAS #2899](https://github.com/jeong-sik/oas/pull/2899) `constrain canonical JSON to Safe.t` | #2896 compile repair | **Merged**, merge commit `b1fe0ec06`; OAS main `0.231.8` release 전 포함 | canonicalizer 입력/출력을 명시적 `Yojson.Safe.t`로 닫아 `Floatlit`/`Tuple`/`Variant` polymorphic variant 추론 오류를 제거한다. | **정확한 compiler root fix. full downstream proof는 #2903 CI와 pin 이후** |
@@ -247,39 +255,41 @@ phase/version/visit-count처럼 valid successful transcript에서 항상 파생�
 
 따라서 본 보고서의 **P0-6 destructive consolidation**은 #26324 merge로 제거됐다.
 
-### 3.2 PR #26324가 해결하지 않는 부분
+### 3.2 #26500 post-merge source 재감사
 
-> 2026-07-30 22:10 KST 갱신: 아래 잔여 목록은 #26500 merge 이전 main 기준이다.
-> #26500(merge commit `101d9efa…`)이 current Memory contract를
-> `*.memory-current.json`으로 hard cut하고 model-authored identity/TTL/recency
-> ranking/`score`를 제거했으므로, main 기준 잔여 항목은 post-merge 재감사가
-> 필요하다(출처: `gh pr view 26500 -R jeong-sik/masc`, 신뢰도 High).
+대상은 `origin/main`
+`0d193fe1422bc943d079ffe12e4b527db5acaff3`이며 2026-07-30 22:59 KST에
+entrypoint → typed store → recall/search/dashboard consumer → caller를 다시 추적했다.
 
-merge된 main에 그대로 남는 항목:
+해결된 source finding:
 
-- `Keeper_memory_os_store`와 JSONL store의 이중 authority
-- persisted record의 `schema_version`
-- `Persisted_claim_kind_absent` legacy row 수용
-- optional `claim_kind`
-- 사용되지 않는 `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT`
-- lenient `read_facts_all`의 malformed-row `filter_map`
-- 500/500/65,536-byte recall truncation
-- recency selection
-- 32-turn recall echo window
-- cadence/message-window/inert-turn skip
-- substring search와 first-100-byte dedupe
-- Librarian `Replace_latest` coalescing
-- TurnRef 중복과 null user TurnRef
-- facts → episode → event 비원자 publication
-- spatial namespace/ACL 부재
+- **P0-1:** dead `Keeper_memory_os_store`와 JSONL facts/episode/event authority가
+  사라지고 production read/write/Librarian/dashboard가
+  `Keeper_memory_os_current` 한 snapshot을 사용한다.
+- **P0-2/P0-7:** Memory `schema_version`, `claim_kind`, TTL/expiry, episode 사망
+  field와 compatibility reader가 current contract에서 제거됐다.
+- **P0-4:** snapshot은 closed whole-object decode이며 한 fact 오류도 전체 typed
+  read error로 노출된다.
+- **P0-6:** destructive consolidation producer/caller가 삭제됐다.
+- **P1-2/P1-3/P1-5/P1-6:** facts/episode/event 다단 publication과 모순된 episode
+  prompt, fleet consolidation, episode/store 오표기 ledger가 current path에서
+  제거됐다. revision CAS와 atomic snapshot replace가 실제 writer에 연결됐다.
 
-후속 audit worktree는 이 목록 중 dead `Keeper_memory_os_store`, Memory
-`claim_kind`, persisted Memory `schema_version`, serialization-only episode fields,
-global slot facade, lenient reader뿐 아니라 `valid_for_days`/`valid_until`/`Ephemeral`,
-expiry GC·sanity sweep·maintenance·TTL dashboard를 삭제했다. retired row/field는
-current decoder가 명시적으로 거부한다. 이는 아직 main/CI/runtime 증거가 아니며,
-recall budget/recency, echo/dedupe, latest-wins, production Memory authority·atomic
-receipt·Turn identity 문제는 그대로 남는다.
+남은 source finding:
+
+- **P0-3:** Librarian input에는 typed `Turn_ref`가 있지만 fact schema에는 source
+  TurnRef/event edge가 없고 user input exact join 증거도 닫히지 않았다.
+- **P0-5(부분):** automatic recall은 LLM-selected current facts 전체를 그대로
+  주입하도록 고쳐졌다. 그러나 `keeper_memory_search`는 substring/token match를,
+  history 조립은 first-100-byte dedupe를 사용한다.
+- **P0-8/P0-9:** `Yielded_to_chat_waiting`, chat waiting authority, queue
+  `lease_id`, `worker_settlement`/`Status_settlement`/
+  `Settlement_projection_error`가 그대로 남는다.
+- **P1-1/P1-4/P1-7:** Librarian `Replace_latest` coalescing, tool/multimodal
+  placeholder와 fact provenance 손실, log/metric-only Librarian failure가 남는다.
+
+[근거] `git rev-parse origin/main`, `rg` production caller scan, 위 exact files;
+확인일시 2026-07-30T22:59:03+09:00; 신뢰도 High.
 
 ### 3.3 PR #26410의 정확한 경계
 
@@ -327,27 +337,23 @@ concept가 되어서는 안 된다. Busy Keeper는 현재 활동을 계속하고
 
 ```mermaid
 flowchart TD
-    A[Keeper turn admission] --> B[Memory OS JSONL read]
-    B --> C[recency/count/byte selection]
+    A[Keeper turn admission] --> B[current snapshot strict read]
+    B --> C[all LLM-selected current facts]
     C --> D[memory_os_recall prompt injection]
     D --> E[OAS agent run: thinking/tools]
     E --> F[checkpoint + TurnRecord]
     F --> G{meaningful turn?}
     G -->|No| H[Librarian skip]
-    G -->|Yes| I[per-Keeper Librarian drain]
-    I -->|busy| J[keep only latest snapshot]
+    G -->|Yes| I[per-Keeper Librarian latest drain]
+    I -->|busy| J[replace pending latest closure]
     I --> K{cadence due?}
-    K -->|Yes| L[OAS exact-output Librarian]
-    L --> M[32-turn echo + claim identity merge]
-    M --> N[facts JSONL rewrite]
-    N --> O[episode file append]
-    O --> P[event JSONL append]
-    P --> B
+    K -->|Yes| L[OAS exact-output current selection]
+    L --> M[retained IDs + new claims validation]
+    M --> N[revision CAS + atomic snapshot replace]
+    N --> B
 
-    Q[600s maintenance] --> R[serial all-Keeper consolidation]
-    R --> S[prompt-only JSON provider call]
-    S --> T[partial plan salvage/apply]
-    T --> N
+    Q[explicit memory write] --> R[exact identity upsert]
+    R --> N
 ```
 
 ## 5. P0 Findings
@@ -766,9 +772,9 @@ Rondo 1686–1689에서 dashboard user input 직후 persona/dynamic digest가 di
 단, 마지막 항목은 horizon policy가 제거됐다는 의미가 아니다. `valid_for_days`, TTL,
 recency, 32-turn window가 같은 역할을 수행한다.
 
-## 9. OCaml 5.5 / Eio 기준
+## 9. OCaml 5.4 / Eio 기준
 
-OCaml 5.5 공식 문서 기준:
+OCaml 5.4 공식 문서 기준:
 
 - Domain은 OS thread와 1:1인 heavyweight parallel unit이다.
 - immutable value는 domain 사이에서 자유롭게 공유할 수 있다.
@@ -1023,12 +1029,12 @@ Acceptance:
 
 | Goal | 현재 증거 | 판정 |
 |---|---|---|
-| G0 | dead `Keeper_memory_os_store`/전용 test/stanza 삭제, production Memory file entrypoint를 explicit `keepers_dir` 하나로 통일, Recall/search/status/write/Librarian/dashboard/maintenance GC의 `episode-bundle → facts` 순서 정합화 | **부분 완료** — facts/episode/event atomic commit/receipt 미구현; test-only ambient IO facade 정리 필요 |
-| G1 | duplicate/null TurnRef 원인과 admission-time durable binding 위치 추적 완료; dashboard TurnRecord는 canonical `${trace_id}#${absolute_turn}`을 강제 | **미완료** — Librarian source provenance는 prompt-local turn/current trace라 canonical TurnRef가 아님 |
+| G0 | #26500에서 dead Store/JSONL facts·episode·event를 삭제하고 read/write/Librarian/dashboard를 exact `*.memory-current.json` snapshot 하나로 연결. closed decoder, revision CAS, atomic replace 사용 | **source 완료** — fresh-state deployment/runtime proof는 별도 미완료 |
+| G1 | Librarian input과 snapshot source는 typed `${trace_id}#${absolute_turn}`/trace/generation을 사용 | **미완료** — 개별 fact source TurnRef/event edge와 user input exact join 없음 |
 | G2 | 목표 수식과 N→N+3 acceptance 정의, 구현 없음 | **미완료** |
-| G3 | latest-wins와 park/lease/settlement를 서로 다른 SSOT로 분해; Librarian exact journal은 current-only closed state/trace/generation, trace-scoped restart fence, canonical path identity로 강화 | **부분 완료** — lossless per-Keeper FIFO/outbox 미구현 |
-| G4 | Memory `claim_kind`, `open_items`, episode `constraints`, `preserved_tool_refs`, `valid_for_days`/`valid_until`/`Ephemeral`와 expiry authority 제거 | **부분 완료** — echo window, recency/byte cap, substring score, first-100-byte dedupe 잔존(단, 이 잔존 목록은 #26500 merge 이전 main 기준. #26500이 recency ranking/`score`를 제거했으므로 post-merge 재확인 필요, 2026-07-30 22:10 KST) |
-| G5 | public fact/episode reader partial-drop 제거, recall unavailable/dashboard read error 노출, publication phase failure typed result 분류, OAS 성공 transport advance evidence/prose heuristic hard cut(#2892), current-only validated-flow snapshot/direct adapter(#2896), Safe.t compiler fix(#2899), private leaf split(#2903), typed compile repair(#2904/#2906/#2907/#2908) | **부분 완료** — OAS v0.231.10 exact release CI green(최종 green SHA `1fa61251…`); MASC #26489 exact pin과 #26491 typed advance consumer는 각각 main 반영·exact-head CI green(2026-07-30 22:10 KST 확인). atomic revision/CURRENT CAS/durable evidence production caller/runtime proof 미구현 |
+| G3 | latest-wins와 park/lease/settlement를 서로 다른 SSOT로 분해; Librarian writer는 closed current snapshot과 revision CAS를 사용 | **부분 완료** — lossless per-Keeper FIFO/outbox 미구현 |
+| G4 | claim/TTL/episode authority와 deterministic recall ranking·byte cap·echo window 제거. LLM current selection을 그대로 recall | **부분 완료** — explicit search substring/token match와 first-100-byte history dedupe 잔존 |
+| G5 | current snapshot closed read, revision CAS/atomic replace, unavailable/dashboard read error, OAS typed evidence chain과 MASC direct consumer | **부분 완료** — OAS v0.231.10 exact release와 #26491 exact-head CI green. power-loss durability receipt와 production runtime proof 미구현 |
 | G6 | stale claim-kind projection 제거, versioned `schema`와 사망 `terminal_marker`/`terminal_markers`를 제거한 unversioned closed dashboard contract, per-Keeper read error 추가 | **부분 완료** — receipt/age/stale generation 미구현 |
 
 Focused verification:
@@ -1180,7 +1186,7 @@ fresh-state hard cut을 적용한 좁고 독립적인 PR들로 진행해야 한�
 
 - `항목`: Librarian/Memory OS current source contract
 - `출처`: `git rev-parse origin/main`, `git diff HEAD`, production caller scan
-- `확인일시`: `2026-07-30T16:14:00+09:00`
+- `확인일시`: `2026-07-30T22:59:03+09:00`
 - `신뢰도`: `High`
 - `제한조건`: 후속 2개 source slice와 report update는 아직 새 Draft PR CI 전
 
@@ -1207,9 +1213,9 @@ fresh-state hard cut을 적용한 좁고 독립적인 PR들로 진행해야 한�
 
 #### OCaml / Eio
 
-- `항목`: OCaml 5.5 memory model과 Eio cancellation/mutex 기준
-- `출처`: [OCaml 5.5 official manual](https://ocaml.org/manual/5.5/index.html),
-  [OCaml 5.5 parallel programming](https://ocaml.org/manual/5.5/parallelism.html),
+- `항목`: OCaml 5.4 memory model과 Eio cancellation/mutex 기준
+- `출처`: [OCaml 5.4 official manual](https://ocaml.org/manual/5.4/index.html),
+  [OCaml 5.4 parallel programming](https://ocaml.org/manual/5.4/parallelism.html),
   Eio official API docs
 - `확인일시`: `2026-07-30T18:29:00+09:00`
 - `신뢰도`: `High`
@@ -1242,9 +1248,10 @@ fresh-state hard cut을 적용한 좁고 독립적인 PR들로 진행해야 한�
   release CI `30536256908`만 13/13 jobs green이다(2026-07-30 22:10 KST 재확인).
   MASC #26489는 exact pin을 main에 반영했고 #26491은 typed advance consumer를
   green exact-head CI로 merge했다(2026-07-30 21:53 KST). #26500 minimal
-  current contract도 merge됐다(2026-07-30 22:01 KST). 다만 durable evidence
-  production caller/runtime cutover와 #26500 post-merge 잔여 증거 재감사는
-  미검증이다.
+  current contract도 merge됐다(2026-07-30 22:01 KST). #26500 이후
+  `0d193fe1422bc943d079ffe12e4b527db5acaff3` source를 재감사해 original
+  P0 5건/P1 4건 해결, P0 1건 부분 해결, P0 3건/P1 3건 미해결로 재분류했다.
+  durable evidence production caller/runtime cutover는 미검증이다.
 
 ### 15.4 불확실성 (Uncertainty)
 
@@ -1254,14 +1261,13 @@ fresh-state hard cut을 적용한 좁고 독립적인 PR들로 진행해야 한�
 - `추가 확인 필요`: build artifact에 commit SHA를 embed하고 health가 그 값을 직접 반환
 
 - `미확인 항목`: merge된 MASC #26440/#26450/#26489의 exact-head full CI,
-  durable evidence production caller/runtime proof, #26500 post-merge 잔여 증거
+  durable evidence production caller/runtime proof
 - `영향`: MASC source hard cut은 병합됐지만 #26440/#26450/#26489의
   Build/Dashboard가 취소 또는 skipped됐고(#26491 exact-head CI는 2026-07-30
   22:10 KST 기준 green), failover evidence와 exact pin은 source에 들어왔지만
   MASC runtime의 durable production caller로 연결됐다는 증거는 없음. #26500
-  merge로 본 보고서의 잔여 heuristic 목록도 pre-merge main 기준이 됨
-- `추가 확인 필요`: production caller/N→N+3 restart proof, #26500 이후 main의
-  잔여 pin/caller/heuristic 증거 재감사
+  post-merge source 재감사는 완료했지만 deployed runtime proof는 아님
+- `추가 확인 필요`: production caller/N→N+3 restart 및 deployed-runtime proof
 
 ### 15.5 적용범위 (Scope)
 

--- a/reports/MASC-LIBRARIAN-MEMORY-OS-ADVERSARIAL-AUDIT-2026-07-30.md
+++ b/reports/MASC-LIBRARIAN-MEMORY-OS-ADVERSARIAL-AUDIT-2026-07-30.md
@@ -59,24 +59,48 @@ validated-flow evidence와 direct `Agent_sdk.Exact_output` adapter를 추가했�
 optional measurement receipt가 살아 있는 증거임을 확인해 과도한 숙청을
 되돌렸다. [#2899](https://github.com/jeong-sik/oas/pull/2899)는 canonical JSON을
 `Yojson.Safe.t`로 닫았고, [#2903](https://github.com/jeong-sik/oas/pull/2903)은
-godfile 증가를 private one-way leaf DAG로 제거했다. 그러나 #2903과
-`v0.231.9`는 `Option.exists`의 OCaml 5.4 비호환 및 shared record label 추론
-오류로 full CI가 실패했다. 후속
-[#2904](https://github.com/jeong-sik/oas/pull/2904),
-[#2906](https://github.com/jeong-sik/oas/pull/2906),
+godfile 증가를 private one-way leaf DAG로 제거했다. 그러나 #2903 merge commit
+`a923fc3889ba62a89cd42d91956d62dc0b674311`의 exact-main CI run
+[`30535040210`](https://github.com/jeong-sik/oas/actions/runs/30535040210)은
+`rejected.measurement`/`visit.ordinal` shared record label 추론 오류로
+Build(OCaml 5.4.1/5.5.0)·Lint·Eio 1.3/1.4가 실패했다. 후속
+[#2904](https://github.com/jeong-sik/oas/pull/2904)(exact-head PR run
+[`30535494954`](https://github.com/jeong-sik/oas/actions/runs/30535494954))와
+[#2906](https://github.com/jeong-sik/oas/pull/2906)(run
+[`30535658586`](https://github.com/jeong-sik/oas/actions/runs/30535658586))도
+exact-head Build/Lint/Eio가 실패했고, #2901 head
+`5597da1ba3b1667779f70d6323b0fa886c0bb15d`의 PR run
+[`30534846121`](https://github.com/jeong-sik/oas/actions/runs/30534846121)은
+OCaml 5.4.1에 없는 `Option.exists` unbound와 `flow_visit_ordinal` 타입 오류로
+실패한 채 merge됐다. `v0.231.9` 태그
+`b70b35bb117af1c0597c28f619c187c7fb387bfb`의 exact-main CI run
+[`30534931823`](https://github.com/jeong-sik/oas/actions/runs/30534931823)은
+취소됐고 Code Smell Ratchet run
+[`30534931829`](https://github.com/jeong-sik/oas/actions/runs/30534931829)이
+실패해 green release 증거가 없었다.
 [#2907](https://github.com/jeong-sik/oas/pull/2907),
 [#2908](https://github.com/jeong-sik/oas/pull/2908)이 실제 domain boundary에
 record 타입을 명시하고 5.4-compatible option match로 교체했다. 이를 모두 포함한
 `v0.231.10` exact release SHA
 `1fa61251936758d37c3a33eac07b8d95c5f26d35`는 CI run
 [`30536256908`](https://github.com/jeong-sik/oas/actions/runs/30536256908)에서
-OCaml 5.4.1/5.5.0, Eio 1.3/1.4, Lint, Format을 모두 통과했다. OAS release는
-증명됐다. MASC
+OCaml 5.4.1/5.5.0 Build & Test, Eio 1.3/1.4, Lint, Format을 포함한 13개 job을
+모두 통과했다(2026-07-30 22:10 KST `gh run view`/`gh release list` 재확인,
+신뢰도 High). 이것이 최종 green release SHA다. MASC
 [#26489](https://github.com/jeong-sik/masc/pull/26489)는 exact pin을 main에
-반영했고, Draft [#26491](https://github.com/jeong-sik/masc/pull/26491)은 그 pin
-위에서 typed advance consumer와 serialized-request evidence를 구현했다. 다만
-#26489 exact-head Build/CI Gate는 merge 뒤 취소됐고 #26491 exact-head CI가 진행
-중이며 durable evidence production caller/runtime 증거는 여전히 별도 차단 상태다.
+반영했고(merge 시점 exact-head Build/CI Gate는 merge 뒤 취소),
+[#26491](https://github.com/jeong-sik/masc/pull/26491)은 그 pin 위에서 typed
+advance consumer와 serialized-request evidence를 구현해 2026-07-30 21:53 KST에
+merge됐다. #26491 exact-head
+`41561bd0220fc6afdd1a732ed217f9616ee61a26`의 CI(Build and Test/Dashboard/
+CI Gate 포함)는 전부 green이다. 또한
+[#26500](https://github.com/jeong-sik/masc/pull/26500)(`hard-cut minimal
+current contract`, merge commit
+`101d9efa1623e62b16b90f4011ff877e5eb49e65`)이 2026-07-30 22:01 KST에 merge돼
+main의 current Memory contract를 `*.memory-current.json`으로 hard cut했다.
+따라서 본 보고서의 잔여 heuristic/pin/caller 증거 목록은 #26500 이전 main
+기준이며, durable evidence production caller/runtime 증거는 여전히 별도 차단
+상태다(2026-07-30 22:10 KST `gh pr view` 확인, 신뢰도 High).
 
 가장 중요한 차단 사유는 다음과 같다.
 
@@ -157,7 +181,7 @@ binary SHA는 미증명으로 남긴다.
 
 ## 3. 현재 Open PR과의 관계
 
-확인 시각: 2026-07-30 20:11 KST
+확인 시각: 2026-07-30 22:10 KST(#26491/#26500 merge와 OAS CI chain을 `gh`로 재확인)
 
 | PR | 관련도 | 현재 상태 | 보고서 findings에 대한 효과 | 판정 |
 |---|---|---|---|---|
@@ -168,13 +192,14 @@ binary SHA는 미증명으로 남긴다.
 | [#26440](https://github.com/jeong-sik/masc/pull/26440) `hard-cut retired Memory OS authority` | 본 감사 후속 구현 | **Merged**, head `120dcc8fbc905aa3ea0c4651dc1f0a19fcfb7767`, squash merge `8701b4a9e4cec823c535912374ae11759125f596` | 1·2차 hard-cut과 본 보고서를 main에 반영했다. 그러나 merge 시점에 exact-head `Build and Test`, Dashboard, ocamlformat, CI Gate가 아직 실행 중이었고 merge 뒤 취소됐다. | **source hard cut은 병합됐으나 exact-head full CI green 증거 없음. cold cutover·runtime 증명 전 NO-GO** |
 | [#26450](https://github.com/jeong-sik/masc/pull/26450) `prepare current-only atomic publication` | 본 감사 후속 구현 | **Merged**, head `3cf500c78b16e80c17ee1867ac6c4eb3512d27ba`, merge commit `1910149d9e42c7e91b79915157506d695be72f18`; `Build and Test`/Dashboard 등 full CI skipped, 다수 check cancelled | `terminal_marker`/versioned dashboard schema를 숙청하고 Librarian input을 `TurnRef`로 key했다. atomic revision은 구현하지 않았다. | **사망 필드 제거는 유효. CI·atomic commit·production caller 증거 없음** |
 | [#26489](https://github.com/jeong-sik/masc/pull/26489) `pin agent sdk v0.231.10` | OAS release pin | **Merged**, head `c146ee46773f1813257dfad18060a679017bc31e`, merge commit `163f375010311b1798faeb42718439adfc1e4a41`; exact-head Build/CI Gate 취소 | OAS v0.231.10 SHA `1fa61251936758d37c3a33eac07b8d95c5f26d35`를 manifest/API-surface SSOT에 반영한다. | **source pin은 main 반영. exact-head MASC CI와 runtime proof 전 NO-GO** |
-| [#26491](https://github.com/jeong-sik/masc/pull/26491) `bind turn evidence to serialized requests` | typed consumer/observability 후속 | **Draft**, head `254b5ec30d81bfa9310f666f951d9a58e0c5d0bf`, `status:do-not-merge`; exact-head CI 진행 중 | #26489 pin 위에서 HITL summary가 typed advance를 직접 소비한다. request wire/prompt blocks/messages를 같은 serialized-request snapshot으로 묶고 unavailable composition을 `null`로 보존한다. | **source 후보 구현. exact-head CI와 durable evidence production caller/runtime proof 전 NO-GO** |
+| [#26491](https://github.com/jeong-sik/masc/pull/26491) `bind turn evidence to serialized requests` | typed consumer/observability 후속 | **Merged**, head `41561bd0220fc6afdd1a732ed217f9616ee61a26`, merge commit `8c84975577338aa2a78f21161c0c121b1038b531`, 2026-07-30 21:53 KST merge; exact-head Build and Test/Dashboard/CI Gate 등 전부 green(2026-07-30 22:10 KST 확인) | #26489 pin 위에서 HITL summary가 typed advance를 직접 소비한다. request wire/prompt blocks/messages를 같은 serialized-request snapshot으로 묶고 unavailable composition을 `null`로 보존한다. | **source 병합 + exact-head CI green. durable evidence production caller/runtime proof 전 NO-GO** |
+| [#26500](https://github.com/jeong-sik/masc/pull/26500) `hard-cut minimal current contract` | 본 감사 후속 구현 | **Merged**, head `ae2f017ed462024f8fe07928d33bbf07af5f6724`, merge commit `101d9efa1623e62b16b90f4011ff877e5eb49e65`, 2026-07-30 22:01 KST merge | current Memory contract를 exact `claim`/`category`/`first_seen`의 `*.memory-current.json`으로 hard cut하고 model-authored identity/TTL/recency ranking/`score`를 제거한다. migration/compat reader 없음 | **main 반영. 본 보고서의 잔여 증거 목록은 #26500 이전 main 기준이므로 post-merge 재감사 필요** |
 | [OAS #2892](https://github.com/jeong-sik/oas/pull/2892) `preserve typed advance evidence` | G5 선행 경계 | **Merged**, head `d2a56f315fc452d00a5ed55ea729746c800adfb2`, merge commit `7ce45ee3aa218b49dc13aaaebba1e2698aa22e2c`; exact-head CI 완료 전 merge | 성공한 `before_advance`를 동일 atomic flow progress에 기록하고 HTTP 400 오류 문구 기반 context-overflow 승격과 dead variant를 제거한다. | **source P0 없음. MASC/masc-mcp의 제거된 variant 소비자 hard cut 전 pin 금지** |
 | [OAS #2896](https://github.com/jeong-sik/oas/pull/2896) `persist validated flow evidence` | G5 durable evidence | **Merged**, head `e89c5d9e57b5e8cd2077468cc2e04fa21d0b09f6`, merge commit `f6cc38056`; 최초 CI는 `Yojson.Safe.t` 추론 오류와 godfile `+1`로 실패 | actual mixed flow의 admission rejection → invalid JSON advance → semantic rejection → acceptance를 current-only canonical snapshot으로 보존한다. projector exactly-once, strict decode, integrity 및 re-hashed structural tamper test를 추가한다. | **기능 경계 유효. 최초 head는 compile/ratchet 불합격; #2899/#2903 후속 필수** |
 | [OAS #2899](https://github.com/jeong-sik/oas/pull/2899) `constrain canonical JSON to Safe.t` | #2896 compile repair | **Merged**, merge commit `b1fe0ec06`; OAS main `0.231.8` release 전 포함 | canonicalizer 입력/출력을 명시적 `Yojson.Safe.t`로 닫아 `Floatlit`/`Tuple`/`Variant` polymorphic variant 추론 오류를 제거한다. | **정확한 compiler root fix. full downstream proof는 #2903 CI와 pin 이후** |
-| [OAS #2903](https://github.com/jeong-sik/oas/pull/2903) `split durable evidence codec leaves` | #2896 godfile root fix | **Merged**, head `22b9f0a07d5d28be81ad73d6899f225b0c9ee0c2`, merge commit `a923fc3889ba62a89cd42d91956d62dc0b674311`; ratchet PASS, CI run `30535040210` FAIL | root가 create/decode/integrity orchestration을 직접 소유하고 types → canonical → validation → codec private DAG로 분리한다. pure alias facade와 godfile `+1`을 제거했지만 shared record label 추론이 닫히지 않았다. | **구조 방향은 유효하나 exact head는 compile 불합격. 단독 pin 금지** |
-| [OAS #2904/#2906/#2907/#2908](https://github.com/jeong-sik/oas/pull/2908) `evidence type repairs` | #2903 compile repair chain | **Merged**, final merge `8d5d30b6a0f1a5175232533a7f5be5f18110ff44`; 중간 #2904/#2906 exact-head CI는 실패 | canonical/codec/validation/consumer의 실제 domain 타입을 명시하고 OCaml 5.4에 없는 `Option.exists`를 typed match로 교체한다. | **중간 merge는 불합격. 네 repair와 #2903을 포함한 v0.231.10 exact release CI만 green proof** |
-| [OAS v0.231.10](https://github.com/jeong-sik/oas/releases/tag/v0.231.10) | release/pin 후보 | SHA `1fa61251936758d37c3a33eac07b8d95c5f26d35`; CI run `30536256908` SUCCESS | #2903/#2904/#2906/#2907/#2908 전체를 포함하며 public `.mli` surface 변화 없이 codec leaf와 compile repair를 묶는다. | **OAS release PASS. MASC #26489/#26491 exact-head CI와 production caller/runtime proof 전 NO-GO 유지** |
+| [OAS #2903](https://github.com/jeong-sik/oas/pull/2903) `split durable evidence codec leaves` | #2896 godfile root fix | **Merged**, head `22b9f0a07d5d28be81ad73d6899f225b0c9ee0c2`, merge commit `a923fc3889ba62a89cd42d91956d62dc0b674311`; ratchet PASS, exact-main CI run [`30535040210`](https://github.com/jeong-sik/oas/actions/runs/30535040210) FAIL | root가 create/decode/integrity orchestration을 직접 소유하고 types → canonical → validation → codec private DAG로 분리한다. pure alias facade와 godfile `+1`을 제거했지만 shared record label 추론(`rejected.measurement`, `visit.ordinal`)이 닫히지 않았다. | **구조 방향은 유효하나 exact head는 compile 불합격. 단독 pin 금지** |
+| [OAS #2904/#2906/#2907/#2908](https://github.com/jeong-sik/oas/pull/2908) `evidence type repairs` | #2903 compile repair chain | **Merged**, final merge `8d5d30b6a0f1a5175232533a7f5be5f18110ff44`; 중간 #2904/#2906 exact-head PR CI(run [`30535494954`](https://github.com/jeong-sik/oas/actions/runs/30535494954)/[`30535658586`](https://github.com/jeong-sik/oas/actions/runs/30535658586))는 실패. 선행 #2901 head `5597da1b…`의 PR run [`30534846121`](https://github.com/jeong-sik/oas/actions/runs/30534846121)도 `Option.exists`(OCaml 5.4.1 unbound)·`flow_visit_ordinal` 오류로 실패한 채 merge됐고, `v0.231.9` 태그 `b70b35bb…`의 exact-main CI run [`30534931823`](https://github.com/jeong-sik/oas/actions/runs/30534931823)은 취소·ratchet run [`30534931829`](https://github.com/jeong-sik/oas/actions/runs/30534931829) 실패로 green 없음 | canonical/codec/validation/consumer의 실제 domain 타입을 명시하고 OCaml 5.4에 없는 `Option.exists`를 typed match로 교체한다. | **중간 merge는 불합격. 네 repair와 #2903을 포함한 v0.231.10 exact release CI만 green proof** |
+| [OAS v0.231.10](https://github.com/jeong-sik/oas/releases/tag/v0.231.10) | release/pin 후보 | SHA `1fa61251936758d37c3a33eac07b8d95c5f26d35`; CI run [`30536256908`](https://github.com/jeong-sik/oas/actions/runs/30536256908) SUCCESS(13/13 jobs, 2026-07-30 22:10 KST 재확인) | #2903/#2904/#2906/#2907/#2908 전체를 포함하며 public `.mli` surface 변화 없이 codec leaf와 compile repair를 묶는다. | **OAS release PASS — 최종 green release SHA. MASC #26489 pin과 #26491 exact-head CI는 green, production caller/runtime proof 전 NO-GO 유지** |
 | [#26436](https://github.com/jeong-sik/masc/pull/26436) `enforce current-only Memory OS contracts` | 본 감사 1차 구현 | **Closed**, head `1c4692b806dd34e948afa99ea34d627092e880cc`, `status:do-not-merge`, `reviewed:adversarial-non-pass` | 1차 hard-cut의 CI Meta Guard 문제는 local 2차 slice에서 수정됐고 TTL authority도 추가 삭제했다. | **reopen 금지. 새 exact-head Draft PR로 다시 증명** |
 | [#26389](https://github.com/jeong-sik/masc/pull/26389) `separate Keeper context from turn usage` | 원칙상 인접 | **Merged**, head `bc4ab6d0fde691a4c43e588d549b4a3389e5d31e`, merge commit `407ae5bb92509f06bfb6fc5614e8539e230b2902` | producer 없는 context 추정과 legacy metric surface를 제거한다. | Memory OS persistence/context flow의 직접 수정은 아님 |
 | [#26392](https://github.com/jeong-sik/masc/pull/26392) `cost ledger exact runtime identity` | 원칙상 인접 | **Merged**, head `a332706ec04f49d8ac03e5de684dcf0e11003e3d`, merge commit `e19a05f6ca926eed0de054bd1371ae6f34a075e2` | timestamp/token heuristic 대신 exact identity를 사용한다. | 좋은 선례지만 Memory Turn identity는 수정하지 않음 |
@@ -223,6 +248,12 @@ phase/version/visit-count처럼 valid successful transcript에서 항상 파생�
 따라서 본 보고서의 **P0-6 destructive consolidation**은 #26324 merge로 제거됐다.
 
 ### 3.2 PR #26324가 해결하지 않는 부분
+
+> 2026-07-30 22:10 KST 갱신: 아래 잔여 목록은 #26500 merge 이전 main 기준이다.
+> #26500(merge commit `101d9efa…`)이 current Memory contract를
+> `*.memory-current.json`으로 hard cut하고 model-authored identity/TTL/recency
+> ranking/`score`를 제거했으므로, main 기준 잔여 항목은 post-merge 재감사가
+> 필요하다(출처: `gh pr view 26500 -R jeong-sik/masc`, 신뢰도 High).
 
 merge된 main에 그대로 남는 항목:
 
@@ -996,8 +1027,8 @@ Acceptance:
 | G1 | duplicate/null TurnRef 원인과 admission-time durable binding 위치 추적 완료; dashboard TurnRecord는 canonical `${trace_id}#${absolute_turn}`을 강제 | **미완료** — Librarian source provenance는 prompt-local turn/current trace라 canonical TurnRef가 아님 |
 | G2 | 목표 수식과 N→N+3 acceptance 정의, 구현 없음 | **미완료** |
 | G3 | latest-wins와 park/lease/settlement를 서로 다른 SSOT로 분해; Librarian exact journal은 current-only closed state/trace/generation, trace-scoped restart fence, canonical path identity로 강화 | **부분 완료** — lossless per-Keeper FIFO/outbox 미구현 |
-| G4 | Memory `claim_kind`, `open_items`, episode `constraints`, `preserved_tool_refs`, `valid_for_days`/`valid_until`/`Ephemeral`와 expiry authority 제거 | **부분 완료** — echo window, recency/byte cap, substring score, first-100-byte dedupe 잔존 |
-| G5 | public fact/episode reader partial-drop 제거, recall unavailable/dashboard read error 노출, publication phase failure typed result 분류, OAS 성공 transport advance evidence/prose heuristic hard cut(#2892), current-only validated-flow snapshot/direct adapter(#2896), Safe.t compiler fix(#2899), private leaf split(#2903), typed compile repair(#2904/#2906/#2907/#2908) | **부분 완료** — OAS v0.231.10 exact release CI green; MASC #26489 exact pin은 main 반영, #26491 typed advance consumer는 CI 진행 중이며 atomic revision/CURRENT CAS/durable evidence production caller/runtime proof 미구현 |
+| G4 | Memory `claim_kind`, `open_items`, episode `constraints`, `preserved_tool_refs`, `valid_for_days`/`valid_until`/`Ephemeral`와 expiry authority 제거 | **부분 완료** — echo window, recency/byte cap, substring score, first-100-byte dedupe 잔존(단, 이 잔존 목록은 #26500 merge 이전 main 기준. #26500이 recency ranking/`score`를 제거했으므로 post-merge 재확인 필요, 2026-07-30 22:10 KST) |
+| G5 | public fact/episode reader partial-drop 제거, recall unavailable/dashboard read error 노출, publication phase failure typed result 분류, OAS 성공 transport advance evidence/prose heuristic hard cut(#2892), current-only validated-flow snapshot/direct adapter(#2896), Safe.t compiler fix(#2899), private leaf split(#2903), typed compile repair(#2904/#2906/#2907/#2908) | **부분 완료** — OAS v0.231.10 exact release CI green(최종 green SHA `1fa61251…`); MASC #26489 exact pin과 #26491 typed advance consumer는 각각 main 반영·exact-head CI green(2026-07-30 22:10 KST 확인). atomic revision/CURRENT CAS/durable evidence production caller/runtime proof 미구현 |
 | G6 | stale claim-kind projection 제거, versioned `schema`와 사망 `terminal_marker`/`terminal_markers`를 제거한 unversioned closed dashboard contract, per-Keeper read error 추가 | **부분 완료** — receipt/age/stale generation 미구현 |
 
 Focused verification:
@@ -1032,20 +1063,39 @@ Focused verification:
 - OAS #2899: canonical JSON을 명시적 `Yojson.Safe.t`로 닫는 compiler root fix
 - OAS #2903 local: root 125L, types 217L, canonical 243L, validation primitives
   284L, validation 192L, codec 403L; parser/format/diff/boundary gate와
-  code-smell ratchet `godfile 11 → 11` 통과. exact-head CI `30535040210`은
-  record-label 추론 오류로 실패
-- OAS #2904/#2906 중간 exact-head Build/Lint/Eio 실패를 확인한 뒤
-  #2907/#2908에서 consumer·codec·validation leaf의 typed boundary와 OCaml 5.4
-  option match를 닫음
+  code-smell ratchet `godfile 11 → 11` 통과. exact-main CI
+  [`30535040210`](https://github.com/jeong-sik/oas/actions/runs/30535040210)은
+  `rejected.measurement`/`visit.ordinal` record-label 추론 오류로
+  Build(5.4.1/5.5.0)·Lint·Eio 1.3/1.4 실패
+- OAS #2904/#2906 중간 exact-head Build/Lint/Eio 실패(PR run
+  [`30535494954`](https://github.com/jeong-sik/oas/actions/runs/30535494954),
+  [`30535658586`](https://github.com/jeong-sik/oas/actions/runs/30535658586))와
+  선행 #2901 head `5597da1b…`의 PR run
+  [`30534846121`](https://github.com/jeong-sik/oas/actions/runs/30534846121)
+  실패(`Option.exists` OCaml 5.4.1 unbound, `flow_visit_ordinal` 타입 오류)를
+  확인한 뒤 #2907/#2908에서 consumer·codec·validation leaf의 typed boundary와
+  OCaml 5.4 option match를 닫음. `v0.231.9` 태그 `b70b35bb…`의 exact-main CI
+  run [`30534931823`](https://github.com/jeong-sik/oas/actions/runs/30534931823)은
+  취소, Code Smell Ratchet run
+  [`30534931829`](https://github.com/jeong-sik/oas/actions/runs/30534931829)
+  실패로 green release 증거 없음
 - OAS v0.231.10 SHA `1fa61251936758d37c3a33eac07b8d95c5f26d35`:
-  CI `30536256908`에서 OCaml 5.4.1/5.5.0 Build & Test, Eio 1.3/1.4,
-  Lint, Format 전부 성공
-- MASC #26489가 OAS v0.231.10 exact pin을 main에 반영했으나 exact-head
-  Build/CI Gate는 merge 뒤 취소
-- MASC #26491 head `254b5ec30d81bfa9310f666f951d9a58e0c5d0bf`:
-  changed OCaml format/parser, dashboard typecheck와 focused 2 files/37 tests,
-  OAS pin manifest/API-surface drift check, shell/JSON/diff check 통과. 로컬 Dune
-  미실행; exact-head PR CI 진행 중
+  CI [`30536256908`](https://github.com/jeong-sik/oas/actions/runs/30536256908)에서
+  OCaml 5.4.1/5.5.0 Build & Test, Eio 1.3/1.4, Lint, Format 포함 13/13 jobs
+  성공 — 최종 green release SHA(2026-07-30 22:10 KST `gh run view`/
+  `gh release list` 재확인, 신뢰도 High)
+- MASC #26489가 OAS v0.231.10 exact pin을 main에 반영했으나 merge 시점
+  exact-head Build/CI Gate는 merge 뒤 취소. 이후 #26491 exact-head green CI가
+  동일 pin 포함 tree의 Build/Dashboard를 증명
+- MASC #26491은 2026-07-30 21:53 KST merge(head
+  `41561bd0220fc6afdd1a732ed217f9616ee61a26`, merge commit `8c849755…`).
+  exact-head CI(Build and Test/Dashboard/CI Gate 등) 전부 green(2026-07-30
+  22:10 KST `gh pr view 26491` 확인). 로컬 Dune 미실행
+- MASC #26500(`hard-cut minimal current contract`)은 2026-07-30 22:01 KST
+  merge(merge commit `101d9efa1623e62b16b90f4011ff877e5eb49e65`). current
+  Memory contract를 `*.memory-current.json`으로 hard cut. 본 보고서의 잔여
+  pin/caller/heuristic 증거 목록은 #26500 이전 main 기준(2026-07-30 22:10 KST
+  `gh pr view 26500` 확인, 신뢰도 High)
 
 Fresh-state cutover blocker:
 
@@ -1116,7 +1166,8 @@ fresh-state hard cut을 적용한 좁고 독립적인 PR들로 진행해야 한�
 
 ### 15.1 공통 헤더
 
-- `날짜(ISO8601)`: `2026-07-30T20:11:00+09:00`
+- `날짜(ISO8601)`: `2026-07-30T22:10:00+09:00`(OAS CI chain·#26491/#26500
+  merge 반영 갱신)
 - `작성자`: `Codex`
 - `결정 ID`: `masc-memory-os-adversarial-audit-20260730`
 - `적용 대상`: `/Users/dancer/me/workspace/yousleepwhen/masc`,
@@ -1146,10 +1197,11 @@ fresh-state hard cut을 적용한 좁고 독립적인 PR들로 진행해야 한�
 
 - `항목`: 현재 open PR의 finding coverage
 - `출처`: `gh pr list`, `gh pr view`, GitHub changed-file 및 exact file patch;
-  MASC #26428/#26440/#26450/#26489/#26491,
-  OAS #2892/#2896/#2899/#2903/#2904/#2906/#2907/#2908,
-  OAS CI `30536256908`
-- `확인일시`: `2026-07-30T20:11:00+09:00`
+  MASC #26428/#26440/#26450/#26489/#26491/#26500,
+  OAS #2892/#2896/#2899/#2901/#2903/#2904/#2906/#2907/#2908,
+  OAS CI `30535040210`/`30535494954`/`30535658586`/`30534846121`/
+  `30534931823`/`30534931829`/`30536256908`
+- `확인일시`: `2026-07-30T22:10:00+09:00`
 - `신뢰도`: `High`
 - `제한조건`: PR head/check 상태는 이후 push에 따라 변경 가능
 
@@ -1183,10 +1235,16 @@ fresh-state hard cut을 적용한 좁고 독립적인 PR들로 진행해야 한�
   24 tests와 static check를 통과했다. TTL/expiry authority production reference도
   제거됐다. OAS #2892/#2896/#2899/#2903과 #2904/#2906/#2907/#2908은 advance
   evidence, provider prose hard cut, validated-flow durable snapshot, Safe.t compiler
-  root fix, private leaf split, typed compile repair까지 진행했다. v0.231.10 exact
-  release CI는 전부 green이다. MASC #26489는 exact pin을 main에 반영했고
-  #26491은 typed advance consumer를 구현했지만, 두 MASC exact-head CI와 durable
-  evidence production caller/runtime cutover는 미검증이다.
+  root fix, private leaf split, typed compile repair까지 진행했다. 중간 exact CI
+  chain(#2903 main run `30535040210`, #2904/#2906 PR run `30535494954`/
+  `30535658586`, #2901 PR run `30534846121`, `v0.231.9` main run `30534931823`
+  취소 + ratchet `30534931829` 실패)은 모두 불합격이었고, v0.231.10 exact
+  release CI `30536256908`만 13/13 jobs green이다(2026-07-30 22:10 KST 재확인).
+  MASC #26489는 exact pin을 main에 반영했고 #26491은 typed advance consumer를
+  green exact-head CI로 merge했다(2026-07-30 21:53 KST). #26500 minimal
+  current contract도 merge됐다(2026-07-30 22:01 KST). 다만 durable evidence
+  production caller/runtime cutover와 #26500 post-merge 잔여 증거 재감사는
+  미검증이다.
 
 ### 15.4 불확실성 (Uncertainty)
 
@@ -1196,12 +1254,14 @@ fresh-state hard cut을 적용한 좁고 독립적인 PR들로 진행해야 한�
 - `추가 확인 필요`: build artifact에 commit SHA를 embed하고 health가 그 값을 직접 반환
 
 - `미확인 항목`: merge된 MASC #26440/#26450/#26489의 exact-head full CI,
-  MASC #26491 exact-head CI와 durable evidence production caller/runtime proof
-- `영향`: MASC source hard cut은 병합됐지만 Build/Dashboard가 취소 또는
-  skipped됐고, failover evidence와 exact pin은 source에 들어왔지만 MASC
-  runtime의 durable production caller로 연결됐다는 증거는 없음
-- `추가 확인 필요`: MASC #26489 포함 current-main 및 #26491 exact-head CI,
-  production caller/N→N+3 restart proof
+  durable evidence production caller/runtime proof, #26500 post-merge 잔여 증거
+- `영향`: MASC source hard cut은 병합됐지만 #26440/#26450/#26489의
+  Build/Dashboard가 취소 또는 skipped됐고(#26491 exact-head CI는 2026-07-30
+  22:10 KST 기준 green), failover evidence와 exact pin은 source에 들어왔지만
+  MASC runtime의 durable production caller로 연결됐다는 증거는 없음. #26500
+  merge로 본 보고서의 잔여 heuristic 목록도 pre-merge main 기준이 됨
+- `추가 확인 필요`: production caller/N→N+3 restart proof, #26500 이후 main의
+  잔여 pin/caller/heuristic 증거 재감사
 
 ### 15.5 적용범위 (Scope)
 

--- a/reports/MASC-LIBRARIAN-MEMORY-OS-ADVERSARIAL-AUDIT-2026-07-30.md
+++ b/reports/MASC-LIBRARIAN-MEMORY-OS-ADVERSARIAL-AUDIT-2026-07-30.md
@@ -45,6 +45,39 @@ echo/dedupe 휴리스틱·비원자 publication이 남으므로 최종 판정은
 publication의 선행 정리이며, atomic Memory authority 자체가 완료됐다는 뜻은
 아니다.
 
+2026-07-30 20:02 KST OAS 경계 재검토에서는 더 앞선 P0 두 개를 확인했다. 기존
+`flow_evidence`는 성공한 `before_advance` 전이를 보존하지 않아 failover 경로를
+복원할 수 없고, HTTP 400 provider 오류 문구를 문자열 문법으로 해석해 typed
+context-overflow 사실으로 승격했다. MASC shadow codec은 OAS private invariant의 두
+번째 SSOT가 되므로 전량 폐기했다. OAS PR
+[#2892](https://github.com/jeong-sik/oas/pull/2892)는 성공한 transport advance를
+동일 atomic progress snapshot에 포함하고 문자열 기반 분류와 사망
+`Context_window_refused`를 제거했다. 후속
+[#2896](https://github.com/jeong-sik/oas/pull/2896)은 OAS-owned current-only
+validated-flow evidence와 direct `Agent_sdk.Exact_output` adapter를 추가했다.
+실제 caller 역추적 중 `No_measurement_dispatch` rejection의 terminal outcome과
+optional measurement receipt가 살아 있는 증거임을 확인해 과도한 숙청을
+되돌렸다. [#2899](https://github.com/jeong-sik/oas/pull/2899)는 canonical JSON을
+`Yojson.Safe.t`로 닫았고, [#2903](https://github.com/jeong-sik/oas/pull/2903)은
+godfile 증가를 private one-way leaf DAG로 제거했다. 그러나 #2903과
+`v0.231.9`는 `Option.exists`의 OCaml 5.4 비호환 및 shared record label 추론
+오류로 full CI가 실패했다. 후속
+[#2904](https://github.com/jeong-sik/oas/pull/2904),
+[#2906](https://github.com/jeong-sik/oas/pull/2906),
+[#2907](https://github.com/jeong-sik/oas/pull/2907),
+[#2908](https://github.com/jeong-sik/oas/pull/2908)이 실제 domain boundary에
+record 타입을 명시하고 5.4-compatible option match로 교체했다. 이를 모두 포함한
+`v0.231.10` exact release SHA
+`1fa61251936758d37c3a33eac07b8d95c5f26d35`는 CI run
+[`30536256908`](https://github.com/jeong-sik/oas/actions/runs/30536256908)에서
+OCaml 5.4.1/5.5.0, Eio 1.3/1.4, Lint, Format을 모두 통과했다. OAS release는
+증명됐다. MASC
+[#26489](https://github.com/jeong-sik/masc/pull/26489)는 exact pin을 main에
+반영했고, Draft [#26491](https://github.com/jeong-sik/masc/pull/26491)은 그 pin
+위에서 typed advance consumer와 serialized-request evidence를 구현했다. 다만
+#26489 exact-head Build/CI Gate는 merge 뒤 취소됐고 #26491 exact-head CI가 진행
+중이며 durable evidence production caller/runtime 증거는 여전히 별도 차단 상태다.
+
 가장 중요한 차단 사유는 다음과 같다.
 
 1. 사용되지 않는 canonical store와 실제 JSONL store가 병존한다.
@@ -76,6 +109,8 @@ publication의 선행 정리이며, atomic Memory authority 자체가 완료됐�
   `refactor/memory-current-only-hard-cut-20260730`
 - 사망 필드/원자 publication 후속 branch:
   `refactor/memory-atomic-publication-20260730`
+- OAS evidence 선행 branch:
+  `fix/exact-output-evidence-boundary-20260730`
 - current-only 1차 source slice:
   `6f8bf76a816d822ca0165b6a8c42986b3d466e5c`
 - TTL authority 제거 2차 source slice:
@@ -122,18 +157,56 @@ binary SHA는 미증명으로 남긴다.
 
 ## 3. 현재 Open PR과의 관계
 
-확인 시각: 2026-07-30 16:05 KST
+확인 시각: 2026-07-30 20:11 KST
 
 | PR | 관련도 | 현재 상태 | 보고서 findings에 대한 효과 | 판정 |
 |---|---|---|---|---|
 | [#26324](https://github.com/jeong-sik/masc/pull/26324) `remove periodic full-store consolidation` | 직접 관련 | **Merged**, head `5adc5e7759f83143d12c3170db1835800f3601eb`, merge commit `a8683ea2ccc26c168664e114dbc0b01b8e1ed770` | periodic destructive consolidation 전체를 삭제했다. Librarian input의 ignored `schema_version`, unknown category, retired `kind` decoder 일부도 제거했다. | **P0-6 직접 해결. 나머지 P0/P1은 미해결** |
 | [#26410](https://github.com/jeong-sik/masc/pull/26410) `park chat before claiming receipt` | 직접 재검토 필요 | **Merged**, head `bde47167ea442db9e91b91a61c27832d66485e10`, 2026-07-30 16:03 KST merge | lease-before-admission을 줄이고 pending receipt를 admission 뒤 claim하는 ordering은 개선한다. 그러나 `park`를 공식 흐름으로 만들고 별도 `lease_id` lifecycle을 유지한다. | **merge됐어도 숙청 기준과 충돌. TurnRef/AttemptId 단일 FSM으로 재구성 필요** |
-| [#26428](https://github.com/jeong-sik/masc/pull/26428) `make current memory and provider input observable` | 직접 충돌 | **Draft**, head `508d77896e12f26652950d68c040830e0cb34691`, `MERGEABLE/BLOCKED`, `status:do-not-merge`, `reviewed:adversarial-non-pass` | immutable current snapshot/CAS와 provider-input observability 방향은 유효하다. 그러나 current head에도 TTL/`claim_kind`/dead episode fields/latest-wins/cadence/prompt-local provenance가 그대로다. | **전체 채택 금지. atomic snapshot/관측성만 분리 재구성** |
+| [#26428](https://github.com/jeong-sik/masc/pull/26428) `make current memory and provider input observable` | 직접 충돌 | **Closed**, head `06764bdd9244409f162a03bf4cdafc5f2d5e79a2`, `status:do-not-merge`, `reviewed:adversarial-non-pass`; exact-head CI는 green | immutable current snapshot/CAS와 provider-input observability 방향은 유효하다. 그러나 TTL/`claim_kind`/dead episode fields/latest-wins/cadence/prompt-local provenance를 포함한 잘못된 authority가 남았다. | **전체 채택 금지. atomic snapshot/관측성만 분리 재구성** |
 | [#26435](https://github.com/jeong-sik/masc/pull/26435) `collapse compaction commit onto source CAS` | 직접 인접 | **Merged**, head `5866b26c14b91088349d21033a884ab6f1c65136`, merge commit `07a3d4f19d1f0c9563be01b8b6f8b4c90da14841`; exact-head `Build and Test`/`CI Gate`는 merge 뒤 취소 | compaction terminal projection을 source CAS에 접어 settlement 중복 authority를 줄인다. | **exact-head full CI green 없이 admin merge. Memory facts→episode→event publication/TurnRef/FIFO는 해결하지 않음** |
 | [#26440](https://github.com/jeong-sik/masc/pull/26440) `hard-cut retired Memory OS authority` | 본 감사 후속 구현 | **Merged**, head `120dcc8fbc905aa3ea0c4651dc1f0a19fcfb7767`, squash merge `8701b4a9e4cec823c535912374ae11759125f596` | 1·2차 hard-cut과 본 보고서를 main에 반영했다. 그러나 merge 시점에 exact-head `Build and Test`, Dashboard, ocamlformat, CI Gate가 아직 실행 중이었고 merge 뒤 취소됐다. | **source hard cut은 병합됐으나 exact-head full CI green 증거 없음. cold cutover·runtime 증명 전 NO-GO** |
+| [#26450](https://github.com/jeong-sik/masc/pull/26450) `prepare current-only atomic publication` | 본 감사 후속 구현 | **Merged**, head `3cf500c78b16e80c17ee1867ac6c4eb3512d27ba`, merge commit `1910149d9e42c7e91b79915157506d695be72f18`; `Build and Test`/Dashboard 등 full CI skipped, 다수 check cancelled | `terminal_marker`/versioned dashboard schema를 숙청하고 Librarian input을 `TurnRef`로 key했다. atomic revision은 구현하지 않았다. | **사망 필드 제거는 유효. CI·atomic commit·production caller 증거 없음** |
+| [#26489](https://github.com/jeong-sik/masc/pull/26489) `pin agent sdk v0.231.10` | OAS release pin | **Merged**, head `c146ee46773f1813257dfad18060a679017bc31e`, merge commit `163f375010311b1798faeb42718439adfc1e4a41`; exact-head Build/CI Gate 취소 | OAS v0.231.10 SHA `1fa61251936758d37c3a33eac07b8d95c5f26d35`를 manifest/API-surface SSOT에 반영한다. | **source pin은 main 반영. exact-head MASC CI와 runtime proof 전 NO-GO** |
+| [#26491](https://github.com/jeong-sik/masc/pull/26491) `bind turn evidence to serialized requests` | typed consumer/observability 후속 | **Draft**, head `254b5ec30d81bfa9310f666f951d9a58e0c5d0bf`, `status:do-not-merge`; exact-head CI 진행 중 | #26489 pin 위에서 HITL summary가 typed advance를 직접 소비한다. request wire/prompt blocks/messages를 같은 serialized-request snapshot으로 묶고 unavailable composition을 `null`로 보존한다. | **source 후보 구현. exact-head CI와 durable evidence production caller/runtime proof 전 NO-GO** |
+| [OAS #2892](https://github.com/jeong-sik/oas/pull/2892) `preserve typed advance evidence` | G5 선행 경계 | **Merged**, head `d2a56f315fc452d00a5ed55ea729746c800adfb2`, merge commit `7ce45ee3aa218b49dc13aaaebba1e2698aa22e2c`; exact-head CI 완료 전 merge | 성공한 `before_advance`를 동일 atomic flow progress에 기록하고 HTTP 400 오류 문구 기반 context-overflow 승격과 dead variant를 제거한다. | **source P0 없음. MASC/masc-mcp의 제거된 variant 소비자 hard cut 전 pin 금지** |
+| [OAS #2896](https://github.com/jeong-sik/oas/pull/2896) `persist validated flow evidence` | G5 durable evidence | **Merged**, head `e89c5d9e57b5e8cd2077468cc2e04fa21d0b09f6`, merge commit `f6cc38056`; 최초 CI는 `Yojson.Safe.t` 추론 오류와 godfile `+1`로 실패 | actual mixed flow의 admission rejection → invalid JSON advance → semantic rejection → acceptance를 current-only canonical snapshot으로 보존한다. projector exactly-once, strict decode, integrity 및 re-hashed structural tamper test를 추가한다. | **기능 경계 유효. 최초 head는 compile/ratchet 불합격; #2899/#2903 후속 필수** |
+| [OAS #2899](https://github.com/jeong-sik/oas/pull/2899) `constrain canonical JSON to Safe.t` | #2896 compile repair | **Merged**, merge commit `b1fe0ec06`; OAS main `0.231.8` release 전 포함 | canonicalizer 입력/출력을 명시적 `Yojson.Safe.t`로 닫아 `Floatlit`/`Tuple`/`Variant` polymorphic variant 추론 오류를 제거한다. | **정확한 compiler root fix. full downstream proof는 #2903 CI와 pin 이후** |
+| [OAS #2903](https://github.com/jeong-sik/oas/pull/2903) `split durable evidence codec leaves` | #2896 godfile root fix | **Merged**, head `22b9f0a07d5d28be81ad73d6899f225b0c9ee0c2`, merge commit `a923fc3889ba62a89cd42d91956d62dc0b674311`; ratchet PASS, CI run `30535040210` FAIL | root가 create/decode/integrity orchestration을 직접 소유하고 types → canonical → validation → codec private DAG로 분리한다. pure alias facade와 godfile `+1`을 제거했지만 shared record label 추론이 닫히지 않았다. | **구조 방향은 유효하나 exact head는 compile 불합격. 단독 pin 금지** |
+| [OAS #2904/#2906/#2907/#2908](https://github.com/jeong-sik/oas/pull/2908) `evidence type repairs` | #2903 compile repair chain | **Merged**, final merge `8d5d30b6a0f1a5175232533a7f5be5f18110ff44`; 중간 #2904/#2906 exact-head CI는 실패 | canonical/codec/validation/consumer의 실제 domain 타입을 명시하고 OCaml 5.4에 없는 `Option.exists`를 typed match로 교체한다. | **중간 merge는 불합격. 네 repair와 #2903을 포함한 v0.231.10 exact release CI만 green proof** |
+| [OAS v0.231.10](https://github.com/jeong-sik/oas/releases/tag/v0.231.10) | release/pin 후보 | SHA `1fa61251936758d37c3a33eac07b8d95c5f26d35`; CI run `30536256908` SUCCESS | #2903/#2904/#2906/#2907/#2908 전체를 포함하며 public `.mli` surface 변화 없이 codec leaf와 compile repair를 묶는다. | **OAS release PASS. MASC #26489/#26491 exact-head CI와 production caller/runtime proof 전 NO-GO 유지** |
 | [#26436](https://github.com/jeong-sik/masc/pull/26436) `enforce current-only Memory OS contracts` | 본 감사 1차 구현 | **Closed**, head `1c4692b806dd34e948afa99ea34d627092e880cc`, `status:do-not-merge`, `reviewed:adversarial-non-pass` | 1차 hard-cut의 CI Meta Guard 문제는 local 2차 slice에서 수정됐고 TTL authority도 추가 삭제했다. | **reopen 금지. 새 exact-head Draft PR로 다시 증명** |
 | [#26389](https://github.com/jeong-sik/masc/pull/26389) `separate Keeper context from turn usage` | 원칙상 인접 | **Merged**, head `bc4ab6d0fde691a4c43e588d549b4a3389e5d31e`, merge commit `407ae5bb92509f06bfb6fc5614e8539e230b2902` | producer 없는 context 추정과 legacy metric surface를 제거한다. | Memory OS persistence/context flow의 직접 수정은 아님 |
 | [#26392](https://github.com/jeong-sik/masc/pull/26392) `cost ledger exact runtime identity` | 원칙상 인접 | **Merged**, head `a332706ec04f49d8ac03e5de684dcf0e11003e3d`, merge commit `e19a05f6ca926eed0de054bd1371ae6f34a075e2` | timestamp/token heuristic 대신 exact identity를 사용한다. | 좋은 선례지만 Memory Turn identity는 수정하지 않음 |
+
+### 3.0A 폐기한 prototype과 OAS 경계 결정
+
+다음 prototype은 적대 검토에서 모두 **do-not-ship**으로 판정해 commit 전에
+전량 삭제했다.
+
+- single-file current snapshot: 최소 receipt 위조, codec exception 누출, duplicate
+  identity 수용, rename 뒤 durability 세탁, path escape, O(n²) rewrite
+- immutable revision/CURRENT prototype: canonical multi-turn source를 표현하지 못하는
+  episode provenance, ancestry replay, nested symlink escape, production caller 부재
+- MASC exact-evidence adapter: 약 1,780줄의 OAS shadow codec, OAS에서 생성 불가능한
+  상태 decode 허용, selected/admission provenance 결합 누락, production caller 0
+
+결론은 OAS가 자기 private typed invariant에서 **한 번** current-only durable
+projection을 만들고, MASC는 `Agent_sdk.Exact_output`을 직접 소비해야 한다는 것이다.
+Decoder는 live execution 타입을 재구성하지 않고 immutable abstract snapshot만
+복원해야 한다. accepted/rejection polymorphic 값은 caller가 digest를 임의 전달하지
+않고, OAS가 실제 typed 값에 caller-owned projector를 정확히 한 번 적용해 결합해야
+한다. final flow ledger는 한 번만 저장하고 prior rejection prefix는 파생해야 하며,
+rejection마다 전체 prefix를 중복하면 O(n²)·SSOT 위반이다.
+
+이 경계는 #2896/#2899/#2903과 #2904/#2906/#2907/#2908 compile repair로
+source 구현됐고 v0.231.10 exact release CI에서 증명됐다. 특히 처음 leaf가
+`Rejected = No_measurement_dispatch + Measurement_not_required + receipt=None`으로
+상태를 과도하게 축소했으나 실제 `admit_candidate_request` caller는 no-dispatch
+terminal outcome(`local_invalid`, `unsupported` 등)과 optional terminal receipt를
+생성할 수 있었다. 이것은 죽은 상태가 아니므로 복원했다. 반대로 measurement
+phase/version/visit-count처럼 valid successful transcript에서 항상 파생되거나
+도달 불가능한 durable field는 저장하지 않는다.
 
 ### 3.1 PR #26324가 해결하는 부분
 
@@ -924,7 +997,7 @@ Acceptance:
 | G2 | 목표 수식과 N→N+3 acceptance 정의, 구현 없음 | **미완료** |
 | G3 | latest-wins와 park/lease/settlement를 서로 다른 SSOT로 분해; Librarian exact journal은 current-only closed state/trace/generation, trace-scoped restart fence, canonical path identity로 강화 | **부분 완료** — lossless per-Keeper FIFO/outbox 미구현 |
 | G4 | Memory `claim_kind`, `open_items`, episode `constraints`, `preserved_tool_refs`, `valid_for_days`/`valid_until`/`Ephemeral`와 expiry authority 제거 | **부분 완료** — echo window, recency/byte cap, substring score, first-100-byte dedupe 잔존 |
-| G5 | public fact/episode reader partial-drop 제거, recall unavailable 및 dashboard read error 노출, publication phase failure를 typed result로 분류 | **부분 완료** — journal terminal이 publication보다 앞서고 facts→episode→event partial commit/rollback이 없어 atomic revision/failover receipt 미구현 |
+| G5 | public fact/episode reader partial-drop 제거, recall unavailable/dashboard read error 노출, publication phase failure typed result 분류, OAS 성공 transport advance evidence/prose heuristic hard cut(#2892), current-only validated-flow snapshot/direct adapter(#2896), Safe.t compiler fix(#2899), private leaf split(#2903), typed compile repair(#2904/#2906/#2907/#2908) | **부분 완료** — OAS v0.231.10 exact release CI green; MASC #26489 exact pin은 main 반영, #26491 typed advance consumer는 CI 진행 중이며 atomic revision/CURRENT CAS/durable evidence production caller/runtime proof 미구현 |
 | G6 | stale claim-kind projection 제거, versioned `schema`와 사망 `terminal_marker`/`terminal_markers`를 제거한 unversioned closed dashboard contract, per-Keeper read error 추가 | **부분 완료** — receipt/age/stale generation 미구현 |
 
 Focused verification:
@@ -951,6 +1024,28 @@ Focused verification:
   symbol scan 0
 - `scripts/ci_verify_linked_modules.sh`는 worktree에 CI build artifact가 없어 미실행
 - 로컬 Dune 미실행; OCaml type/link/build/test는 **CI 미증명**
+- OAS #2892 local: touched OCaml 전부 `ocamlformat`, parse-only,
+  `git diff --check` 통과. Dune 미실행. head `d2a56f315...`은 full CI 전 merge
+- OAS #2896 local: mixed four-candidate loopback test, projector cardinality,
+  canonical roundtrip, stale-integrity tamper와 re-hashed structural tamper를 추가.
+  최초 CI는 `Yojson.Safe.t` 타입 추론과 godfile `+1`로 실패
+- OAS #2899: canonical JSON을 명시적 `Yojson.Safe.t`로 닫는 compiler root fix
+- OAS #2903 local: root 125L, types 217L, canonical 243L, validation primitives
+  284L, validation 192L, codec 403L; parser/format/diff/boundary gate와
+  code-smell ratchet `godfile 11 → 11` 통과. exact-head CI `30535040210`은
+  record-label 추론 오류로 실패
+- OAS #2904/#2906 중간 exact-head Build/Lint/Eio 실패를 확인한 뒤
+  #2907/#2908에서 consumer·codec·validation leaf의 typed boundary와 OCaml 5.4
+  option match를 닫음
+- OAS v0.231.10 SHA `1fa61251936758d37c3a33eac07b8d95c5f26d35`:
+  CI `30536256908`에서 OCaml 5.4.1/5.5.0 Build & Test, Eio 1.3/1.4,
+  Lint, Format 전부 성공
+- MASC #26489가 OAS v0.231.10 exact pin을 main에 반영했으나 exact-head
+  Build/CI Gate는 merge 뒤 취소
+- MASC #26491 head `254b5ec30d81bfa9310f666f951d9a58e0c5d0bf`:
+  changed OCaml format/parser, dashboard typecheck와 focused 2 files/37 tests,
+  OAS pin manifest/API-surface drift check, shell/JSON/diff check 통과. 로컬 Dune
+  미실행; exact-head PR CI 진행 중
 
 Fresh-state cutover blocker:
 
@@ -1021,7 +1116,7 @@ fresh-state hard cut을 적용한 좁고 독립적인 PR들로 진행해야 한�
 
 ### 15.1 공통 헤더
 
-- `날짜(ISO8601)`: `2026-07-30T16:05:00+09:00`
+- `날짜(ISO8601)`: `2026-07-30T20:11:00+09:00`
 - `작성자`: `Codex`
 - `결정 ID`: `masc-memory-os-adversarial-audit-20260730`
 - `적용 대상`: `/Users/dancer/me/workspace/yousleepwhen/masc`,
@@ -1050,16 +1145,21 @@ fresh-state hard cut을 적용한 좁고 독립적인 PR들로 진행해야 한�
 #### Pull Requests
 
 - `항목`: 현재 open PR의 finding coverage
-- `출처`: `gh pr list`, `gh pr view`, GitHub changed-file 및 exact file patch
-- `확인일시`: `2026-07-30T16:05:00+09:00`
+- `출처`: `gh pr list`, `gh pr view`, GitHub changed-file 및 exact file patch;
+  MASC #26428/#26440/#26450/#26489/#26491,
+  OAS #2892/#2896/#2899/#2903/#2904/#2906/#2907/#2908,
+  OAS CI `30536256908`
+- `확인일시`: `2026-07-30T20:11:00+09:00`
 - `신뢰도`: `High`
 - `제한조건`: PR head/check 상태는 이후 push에 따라 변경 가능
 
 #### OCaml / Eio
 
 - `항목`: OCaml 5.5 memory model과 Eio cancellation/mutex 기준
-- `출처`: OCaml 5.5 official manual, Eio official API docs
-- `확인일시`: `2026-07-30T10:53:00+09:00`
+- `출처`: [OCaml 5.5 official manual](https://ocaml.org/manual/5.5/index.html),
+  [OCaml 5.5 parallel programming](https://ocaml.org/manual/5.5/parallelism.html),
+  Eio official API docs
+- `확인일시`: `2026-07-30T18:29:00+09:00`
 - `신뢰도`: `High`
 - `제한조건`: MASC-specific architecture 판정은 공식 언어/runtime 계약의 적용 결과
 
@@ -1081,7 +1181,12 @@ fresh-state hard cut을 적용한 좁고 독립적인 PR들로 진행해야 한�
   결함 확인. 후속 worktree의 dead Store/field/BasePath hard cut은 변경 OCaml
   전체 format/parse, dashboard typecheck, focused 7 files/255 tests, Python
   24 tests와 static check를 통과했다. TTL/expiry authority production reference도
-  제거됐다. Dune/CI와 runtime cutover는 미검증.
+  제거됐다. OAS #2892/#2896/#2899/#2903과 #2904/#2906/#2907/#2908은 advance
+  evidence, provider prose hard cut, validated-flow durable snapshot, Safe.t compiler
+  root fix, private leaf split, typed compile repair까지 진행했다. v0.231.10 exact
+  release CI는 전부 green이다. MASC #26489는 exact pin을 main에 반영했고
+  #26491은 typed advance consumer를 구현했지만, 두 MASC exact-head CI와 durable
+  evidence production caller/runtime cutover는 미검증이다.
 
 ### 15.4 불확실성 (Uncertainty)
 
@@ -1090,11 +1195,13 @@ fresh-state hard cut을 적용한 좁고 독립적인 PR들로 진행해야 한�
   identity라고 단정할 수 없음
 - `추가 확인 필요`: build artifact에 commit SHA를 embed하고 health가 그 값을 직접 반환
 
-- `미확인 항목`: Draft PR #26440 exact-head CI와 #26428 current-head fresh CI
-- `영향`: 후속 source finding coverage는 정적 검증됐지만 merge/deployment readiness는
-  아직 증명되지 않음
-- `추가 확인 필요`: draft PR push 후 head SHA, required checks, unresolved review
-  threads 재확인
+- `미확인 항목`: merge된 MASC #26440/#26450/#26489의 exact-head full CI,
+  MASC #26491 exact-head CI와 durable evidence production caller/runtime proof
+- `영향`: MASC source hard cut은 병합됐지만 Build/Dashboard가 취소 또는
+  skipped됐고, failover evidence와 exact pin은 source에 들어왔지만 MASC
+  runtime의 durable production caller로 연결됐다는 증거는 없음
+- `추가 확인 필요`: MASC #26489 포함 current-main 및 #26491 exact-head CI,
+  production caller/N→N+3 restart proof
 
 ### 15.5 적용범위 (Scope)
 

--- a/reports/MASC-LIBRARIAN-MEMORY-OS-ADVERSARIAL-AUDIT-2026-07-30.md
+++ b/reports/MASC-LIBRARIAN-MEMORY-OS-ADVERSARIAL-AUDIT-2026-07-30.md
@@ -410,8 +410,10 @@ commit/receipt가 아니므로 G0 완료는 아니다.
 허용 field가 다른 closed typed shape로 바꿨다. journal의 trace/generation 불일치,
 unknown/duplicate field, malformed candidate evidence는 provider dispatch 전에 typed
 setup failure로 거부한다. 과거 journal을 읽거나 옮기는 compatibility/migration 경로는
-없다. 다만 live root가 모두 retired schema이므로 fresh-state cold reset/reseed와
-새 schema write→restart→recall 증거 전에는 배포할 수 없다.
+없다. #26500 이후 production reader는 retired fact/episode/event 파일을 읽지 않으므로
+기존 Keeper 디렉터리 reset이나 migration은 필요하지 않다. 배포 승인은 old runtime을
+정지한 뒤 새 binary가 exact `*.memory-current.json`만 write→restart→recall하는지
+확인하는 current-path runtime proof로 제한한다.
 
 ### P0-3. Turn identity SSOT가 실제 데이터에서 깨진다
 
@@ -566,8 +568,8 @@ decoder가 거부하는 회귀를 추가했다. `open_items`, episode `constrain
 `valid_for_days`, fact/episode `valid_until`, `Ephemeral`, expiry GC, dry-run,
 sanity sweep, maintenance fiber와 TTL dashboard를 삭제했다. retired TTL field와
 category는 current decoder에서 거부된다. 따라서 **source finding은 해결**됐지만,
-fresh-state cutover와 새 exact-head CI/runtime 증거가 없어 release finding은 아직
-해결되지 않았다.
+새 exact-head CI와 current snapshot write→restart→recall runtime 증거가 없어 release
+finding은 아직 해결되지 않았다.
 
 ### P0-8. `park`와 `lease`가 Keeper 진행을 제약하는 별도 lifecycle이 됐다
 
@@ -1099,23 +1101,21 @@ Focused verification:
   22:10 KST `gh pr view 26491` 확인). 로컬 Dune 미실행
 - MASC #26500(`hard-cut minimal current contract`)은 2026-07-30 22:01 KST
   merge(merge commit `101d9efa1623e62b16b90f4011ff877e5eb49e65`). current
-  Memory contract를 `*.memory-current.json`으로 hard cut. 본 보고서의 잔여
-  pin/caller/heuristic 증거 목록은 #26500 이전 main 기준(2026-07-30 22:10 KST
-  `gh pr view 26500` 확인, 신뢰도 High)
+  Memory contract를 `*.memory-current.json`으로 hard cut. 잔여 source
+  pin/caller/heuristic은 2026-07-30 22:59 KST post-merge 재감사 결과를 사용한다.
 
-Fresh-state cutover blocker:
+Current-snapshot deployment proof:
 
-- 2026-07-30 16:05 KST live `*.facts.jsonl`은 10 files/174 rows이며 **174 rows
-  전부** `schema_version`, 68 rows가 `valid_until`을 갖는다.
-- live episode JSON은 1,957 files이며 전부 `schema_version`과
-  `open_items|constraints|preserved_tool_refs` 중 적어도 하나를 갖는다.
-- 새 closed decoder는 10/10 fact store와 1,957/1,957 episode files를 거부한다.
-  호환 reader나 migration을 추가하지 않는다.
-- old runtime이 계속 retired row를 쓰므로 reset-before-stop은 race다. 배포 승인은
-  `old runtime stop → exact <base_path>/.masc/config/keepers cold archive/reset →
-  new binary start → health/recall/write/restart proof`의 한 cold-cut 절차가 필요하다.
-- 이 operational proof/runbook은 아직 diff에 없다. 따라서 source hard-cut과 별개로
-  release는 **P0 BLOCK**이다.
+- 2026-07-30 16:05 KST에 관측한 `*.facts.jsonl`과 episode/event 파일은 merge 전
+  runtime의 역사 증거다. #26500 이후 current source에는 해당 reader가 없으므로
+  이 파일들의 존재는 decoder failure나 Keeper 디렉터리 reset 조건이 아니다.
+- 호환 reader, migration, repairer는 추가하지 않는다. retired 파일을 current
+  authority로 복구하거나 변환하는 운영 단계도 두지 않는다.
+- 배포 승인은 `old runtime stop → new binary start → exact
+  <base_path>/.masc/config/keepers/*.memory-current.json write → restart → health/recall
+  proof`로 확인한다. unrelated Keeper state 삭제는 금지한다.
+- 이 current-path runtime proof는 아직 없다. 따라서 source hard-cut과 별개로
+  release는 **P0 BLOCK**이지만, blocker는 cold reset이 아니라 미검증 deployment다.
 
 ## 13. 권장 실행 순서
 
@@ -1172,8 +1172,8 @@ fresh-state hard cut을 적용한 좁고 독립적인 PR들로 진행해야 한�
 
 ### 15.1 공통 헤더
 
-- `날짜(ISO8601)`: `2026-07-30T22:10:00+09:00`(OAS CI chain·#26491/#26500
-  merge 반영 갱신)
+- `날짜(ISO8601)`: `2026-07-30T23:28:01+09:00`(#26500 post-merge source 재감사와
+  current-snapshot deployment 판정 반영)
 - `작성자`: `Codex`
 - `결정 ID`: `masc-memory-os-adversarial-audit-20260730`
 - `적용 대상`: `/Users/dancer/me/workspace/yousleepwhen/masc`,


### PR DESCRIPTION
## Summary
- refresh the MD/HTML Librarian and Memory OS adversarial audit on current MASC main
- record OAS #2892/#2896/#2899/#2903 source, CI, merge, and remaining pin/caller evidence separately
- document the two real entrypoint counterexamples that prevented over-purging live no-dispatch outcome/receipt evidence
- preserve the current MASC terminal-marker hard cut and atomic-publication blockers while resolving the old report branch onto main

## Verification
- report conflicts resolved against current `origin/main`
- HTML regenerated from the committed Markdown with pandoc
- `git diff --check` PASS
- HTML opened in Safari

Docs-only. No runtime, migration, compatibility, or legacy code.