### PR TITLE
fix(keeper): disambiguate current build records

### DIFF
--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -830,7 +830,7 @@ and retry_auto_judge_entry
            ()
        with
        | Error reason -> Error (reblock reason)
-       | Ok outcome ->
+       | Ok (outcome : auto_judge_drain_outcome) ->
          (match
             List.assoc_opt entry.id outcome.failures,
             outcome.started_id,
@@ -1038,7 +1038,8 @@ and drain_auto_judges ~base_path =
             ~drain_owner:(fun ~base_path ~keeper_name ->
               drain_auto_judge_owner_queue ~base_path ~keeper_name ()
               |> Result.map
-                   (fun outcome -> outcome.started_id, outcome.failures)
+                   (fun (outcome : auto_judge_drain_outcome) ->
+                      outcome.started_id, outcome.failures)
               |> Result.map_error
                    Keeper_approval_queue.storage_error_to_string)
             (Auto_judge_owner_set.elements owners)))
@@ -1403,7 +1404,7 @@ let defer request reason =
         in
         (match drained with
          | Error detail -> Auto_judge_unavailable detail
-         | Ok outcome ->
+         | Ok (outcome : auto_judge_drain_outcome) ->
            (match List.assoc_opt approval_id outcome.failures with
             | Some detail -> Auto_judge_unavailable detail
             | None -> Judge_requested))
@@ -1636,7 +1637,7 @@ module For_testing = struct
     drain_auto_judge_owners_with
       ~drain_owner:(fun ~base_path ~keeper_name ->
         drain_owner ~base_path ~keeper_name
-        |> Result.map (fun outcome ->
+        |> Result.map (fun (outcome : owner_drain_outcome) ->
           outcome.started_id, outcome.failures))
       owners
   ;;

--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -122,7 +122,7 @@ let current_fact_json fact =
     ]
 ;;
 
-let current_selection_json current =
+let current_selection_json (current : current_selection) =
   `Assoc
     [ wire_field_summary, `String current.summary
     ; "facts", `List (List.map current_fact_json current.facts)
@@ -133,7 +133,10 @@ let current_selection_json current =
     ]
 ;;
 
-let format_current_selection_for_prompt = function
+let format_current_selection_for_prompt
+      (current : current_selection option)
+  =
+  match current with
   | None -> Yojson.Safe.pretty_to_string `Null
   | Some current ->
     current_selection_json current |> Yojson.Safe.pretty_to_string

--- a/test/test_keeper_unified_context_overflow.ml
+++ b/test/test_keeper_unified_context_overflow.ml
@@ -188,7 +188,7 @@ let test_byte_axis_forwards_exact_request_wire_observation () =
     (Agent_sdk.Error.Api
        (ContextOverflow { message = "exceeded"; limit = Some 32768 }));
   check
-    (option (pair string int))
+    (option (triple string int int))
     "token-axis refusal does not fabricate request wire bytes"
     None
     !observed


### PR DESCRIPTION
현재 main의 OCaml 레코드 추론 모호성과 overflow 테스트 witness 타입 오류만 좁게 수정합니다.

- auto-judge 내부 drain 결과 타입을 명시
- librarian current selection 타입을 명시
- request-wire 관측값의 실제 triple 타입으로 테스트 수정

로컬 확인: OCaml parse, ocamlformat, git diff --check 통과.
전체 빌드와 테스트의 권위는 PR CI입니다. CI 완료 전 병합 금지.