### PR TITLE
fix(keeper): join Board worker when heartbeat stops

### DIFF
--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -218,6 +218,12 @@ let launch_supervised_fiber_body
          from a genuine missed-resolution bug. *)
       let cancelled_by_parent = Atomic.make false in
       let cancelled_by_shutdown_request = Atomic.make false in
+      (* Process-local sibling lifetime only: heartbeat completion closes the
+         Board worker without creating durable admission or recovery state. *)
+      let board_worker_stop, resolve_board_worker_stop = Eio.Promise.create () in
+      let stop_board_worker () =
+        ignore (Eio.Promise.try_resolve resolve_board_worker_stop () : bool)
+      in
       let resolve_done ~source value =
         if not (Atomic.get resolved) then
           (* Issue #18335: the keepalive layer (keeper_keepalive.ml:760-791)
@@ -243,28 +249,36 @@ let launch_supervised_fiber_body
                 OAS owns target admission, dispatch, and advancement.
                 Cancellation joins the worker with the Keeper lane. *)
              Eio.Fiber.fork ~sw:lane_sw (fun () ->
-               match
-                 Keeper_board_attention_worker.run
-                   ~sw:lane_sw
-                   ~clock:ctx.clock
-                   ~net:ctx.net
-                   ~base_path
-                   ~keeper_name:meta.name
+               match Eio.Fiber.first
+                 (fun () ->
+                    `Worker
+                      (Keeper_board_attention_worker.run
+                         ~sw:lane_sw
+                         ~clock:ctx.clock
+                         ~net:ctx.net
+                         ~base_path
+                         ~keeper_name:meta.name))
+                 (fun () ->
+                    Eio.Promise.await board_worker_stop;
+                    `Stopped)
                with
-               | Ok () -> ()
-               | Error fatal ->
+               | `Stopped | `Worker (Ok ()) -> ()
+               | `Worker (Error fatal) ->
                  failwith
                    (Keeper_board_attention_worker.fatal_error_to_string fatal));
              (* Keeper lifetime, idle duration, and progress age are
                 observations only. The supervisor runs the lane directly;
                 configured provider/tool boundaries and explicit operator
                 lifecycle events remain independent typed mechanisms. *)
-             Keeper_keepalive.run_heartbeat_loop
-               ~proactive_warmup_sec
-               ctx
-               meta
-               reg.fiber_stop
-               ~wakeup:reg.fiber_wakeup;
+             Eio_guard.protect
+               (fun () ->
+                  Keeper_keepalive.run_heartbeat_loop
+                    ~proactive_warmup_sec
+                    ctx
+                    meta
+                    reg.fiber_stop
+                    ~wakeup:reg.fiber_wakeup)
+               ~finally:stop_board_worker;
              (* A normal return is an explicit stop/shutdown path. Observed
                 idle/progress ages never rewrite it into a crash. *)
                (match

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -1618,6 +1618,66 @@ let test_launch_rejected_terminal_state_does_not_announce_running () =
       check bool "rejected launch closes lane join contract"
         true (Reg.lane_has_exited reg))
 
+let test_supervised_stop_joins_board_attention_worker () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  ensure_test_runtime ();
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Reg.For_testing.clear ();
+      Masc.Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      ignore (Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name));
+      let name = "supervised-board-worker-stop" in
+      let meta = make_meta name in
+      (match Keeper_meta_store.write_meta config meta with
+       | Ok () -> ()
+       | Error err -> fail err);
+      let reg = Reg.register_offline ~base_path:config.base_path name meta in
+      let ctx : _ Keeper_types_profile.context =
+        { config
+        ; agent_name = supervisor_agent_name
+        ; sw
+        ; clock = Eio.Stdenv.clock env
+        ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
+        ; net = Some (Eio.Stdenv.net env)
+        ; publication_recovery_provider =
+            Masc_test_deps.publication_recovery_provider
+              (publication_recovery_registry env sw config)
+        }
+      in
+      (match
+         Masc.Keeper_supervisor_launch.launch_supervised_fiber
+           ~proactive_warmup_sec:0
+           ctx
+           meta
+           reg
+       with
+       | Ok () -> ()
+       | Error error ->
+         fail
+           (Keeper_state_machine.transition_error_to_string error));
+      let joined =
+        Eio.Time.with_timeout_exn ctx.clock 5.0 (fun () ->
+          Masc.Keeper_keepalive.stop_keepalive_and_await
+            ~base_path:config.base_path
+            name)
+      in
+      (match joined with
+       | Masc.Keeper_keepalive.Keeper_not_registered ->
+         fail "supervised Keeper disappeared before joined stop"
+       | Masc.Keeper_keepalive.Keeper_joined { terminal = `Stopped; _ } -> ()
+       | Masc.Keeper_keepalive.Keeper_joined { terminal = `Crashed reason; _ } ->
+         fail ("supervised stop resolved as crashed: " ^ reason));
+      check bool
+        "board-attention sibling joined with supervised lane"
+        true
+        (Reg.lane_has_exited reg))
+
 (* Codex #24135 finding 5: a rejected [Keeper_lane.fork] (parent switch already
    cancelling, or [claim_start] refused) must propagate [Error] from
    [launch_supervised_fiber] and resolve the done promise through the crash
@@ -2138,6 +2198,8 @@ let () =
         test_supervisor_cleanup_suppresses_cancellation_and_classifies_failures;
       test_case "terminal-state launch reject does not announce Running" `Quick
         test_launch_rejected_terminal_state_does_not_announce_running;
+      test_case "supervised stop joins Board worker" `Quick
+        test_supervised_stop_joins_board_attention_worker;
       test_case "lane fork reject does not announce Running" `Quick
         test_launch_fork_rejection_does_not_announce_running;
       test_case "fork reject preserves newer same-name lane" `Quick


### PR DESCRIPTION
## 문제

Keeper heartbeat가 정상 종료되어 `done_p=Stopped`가 된 뒤에도 같은 lane의 Board-attention sibling이 wake 대기 상태로 남았습니다. `lane_has_exited=false`라 supervisor sweep이 unregister/reconcile을 계속 미뤄, bootable Keeper가 `completion_settled` 상태로 영구 정지했습니다.

Live `407ae5bb92`에서 lane-smith, sangsu, taskmaster가 모두 이 상태이며 reaction capacity가 7/10으로 내려간 것을 확인했습니다.

## 변경

- heartbeat 수명에 process-local stop promise를 묶음
- heartbeat가 반환/취소되면 Board worker의 `Eio.Fiber.first` stop branch가 승리해 worker를 취소·join
- durable field, admission gate, lease, settlement 상태는 추가하지 않음
- supervisor stop이 5초 내 `Stopped`와 `lane_has_exited=true`까지 도달하는 회귀 테스트 추가

## 검증

- `git diff --check`: PASS
- `ocamlformat --check lib/keeper/keeper_supervisor_launch.ml test/test_keeper_supervisor.ml`: PASS
- `scripts/dune-local.sh build test/test_keeper_supervisor.exe`: 현재 main 선행 컴파일 회귀로 BLOCKED (`keeper_librarian`, `keeper_memory_os_current`, `keeper_gate`, `server_keeper_waiting_inventory`); #26484 및 후속 main-build 수정 병합 뒤 rebase하여 재실행 예정

현재 PR은 Draft이며 exact-head CI와 배포 runtime 장기 검증 전에는 ready/merge 대상으로 보지 않습니다.