### PR TITLE
fix(build): restore current projection boundaries

### DIFF
--- a/lib/keeper/keeper_chat_receipt_projection.ml
+++ b/lib/keeper/keeper_chat_receipt_projection.ml
@@ -1,3 +1,25 @@
+let message_source_json = function
+  | Keeper_chat_queue.Dashboard { thread_id } ->
+    `Assoc
+      [ "kind", `String "dashboard"
+      ; "thread_id", `String thread_id
+      ]
+  | Keeper_chat_queue.Discord { channel_id; user_id } ->
+    `Assoc
+      [ "kind", `String "discord"
+      ; "channel_id", `String channel_id
+      ; "user_id", `String user_id
+      ]
+  | Keeper_chat_queue.Slack { channel_id; user_id; team_id; thread_ts; _ } ->
+    `Assoc
+      [ "kind", `String "slack"
+      ; "channel_id", `String channel_id
+      ; "user_id", `String user_id
+      ; "team_id", Json_util.string_opt_to_json team_id
+      ; "thread_ts", Json_util.string_opt_to_json thread_ts
+      ]
+;;
+
 let state_json = function
   | Keeper_chat_queue.Pending -> `Assoc [ "kind", `String "pending" ]
   | Keeper_chat_queue.Inflight { lease_id; started_at } ->

--- a/lib/keeper/keeper_chat_receipt_projection.mli
+++ b/lib/keeper/keeper_chat_receipt_projection.mli
@@ -4,6 +4,12 @@
     and operator tools use this projection so revision and state semantics
     cannot drift between surfaces. *)
 
+val message_source_json :
+  Keeper_chat_queue.message_source -> Yojson.Safe.t
+(** Exact provenance metadata for an operator-visible durable chat input.
+    Message content and connector display names remain on their authenticated
+    queue-specific surfaces. *)
+
 val state_json : Keeper_chat_queue.receipt_state -> Yojson.Safe.t
 
 val receipt_json :

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -1467,7 +1467,7 @@ let defer request reason =
      | Human_requested | Judge_requested -> Deferred { approval_id; reason })
 ;;
 
-let observe_exact_rule_store_degraded request error =
+let observe_exact_rule_store_degraded (request : request) error =
   let detail = Keeper_approval_queue.rule_store_error_to_string error in
   Log.Keeper.error
     ~keeper_name:request.keeper_name
@@ -1490,7 +1490,10 @@ let observe_exact_rule_store_degraded request error =
     ()
 ;;
 
-let observe_exact_rule_expired request (rule_match : Keeper_approval_queue.rule_match) =
+let observe_exact_rule_expired
+      (request : request)
+      (rule_match : Keeper_approval_queue.rule_match)
+  =
   Log.Keeper.warn
     ~keeper_name:request.keeper_name
     "exact Always Allowed rule %s expired operation=%s; continuing configured Gate mode"

--- a/lib/keeper/keeper_memory_os_current.ml
+++ b/lib/keeper/keeper_memory_os_current.ml
@@ -121,12 +121,16 @@ let facts_of_json = function
         (match fact_of_json value with
          | Some fact ->
            let identity = claim_identity fact in
-           if String_set.mem identity seen
+           if Set_util.StringSet.mem identity seen
            then None
-           else loop (String_set.add identity seen) (fact :: acc) rest
+           else
+             loop
+               (Set_util.StringSet.add identity seen)
+               (fact :: acc)
+               rest
          | None -> None)
     in
-    loop String_set.empty [] values
+    loop Set_util.StringSet.empty [] values
   | _ -> None
 ;;
 

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -19,28 +19,6 @@ let keeper_suffix_catchup_judge = "/catchup-judge"
 let keeper_chat_receipt_state_json = Keeper_chat_receipt_projection.state_json
 let keeper_chat_receipt_json = Keeper_chat_receipt_projection.receipt_json
 
-let keeper_chat_message_source_json = function
-  | Keeper_chat_queue.Dashboard { thread_id } ->
-    `Assoc
-      [ "kind", `String "dashboard"
-      ; "thread_id", `String thread_id
-      ]
-  | Keeper_chat_queue.Discord { channel_id; user_id } ->
-    `Assoc
-      [ "kind", `String "discord"
-      ; "channel_id", `String channel_id
-      ; "user_id", `String user_id
-      ]
-  | Keeper_chat_queue.Slack { channel_id; user_id; team_id; thread_ts; _ } ->
-    `Assoc
-      [ "kind", `String "slack"
-      ; "channel_id", `String channel_id
-      ; "user_id", `String user_id
-      ; "team_id", Json_util.string_opt_to_json team_id
-      ; "thread_ts", Json_util.string_opt_to_json thread_ts
-      ]
-;;
-
 let cache_key_string_segment value =
   Printf.sprintf "s%d:%s" (String.length value) value
 ;;

--- a/lib/server/server_dashboard_http_keeper_api_types.mli
+++ b/lib/server/server_dashboard_http_keeper_api_types.mli
@@ -33,11 +33,6 @@ val keeper_chat_receipt_json :
   Keeper_chat_queue.receipt_view ->
   Yojson.Safe.t
 
-val keeper_chat_message_source_json :
-  Keeper_chat_queue.message_source -> Yojson.Safe.t
-(** Exact provenance metadata for an operator-visible durable chat input.
-    Message content remains on the queue-specific authenticated surface. *)
-
 (** {1 Dashboard cache keys} *)
 
 val cache_key_string_segment : string -> string

--- a/lib/server/server_dashboard_http_keeper_chat_pending.ml
+++ b/lib/server/server_dashboard_http_keeper_chat_pending.ml
@@ -101,7 +101,7 @@ let pending_receipt_json ~keeper_name ~revision
           { Keeper_chat_queue.receipt_id; state } )
     ; "content", `String message.content
     ; ( "source"
-      , Server_dashboard_http_keeper_api_types.keeper_chat_message_source_json
+      , Keeper_chat_receipt_projection.message_source_json
           message.source )
     ; "user_blocks", Keeper_multimodal_input.user_blocks_to_yojson message.user_blocks
     ; "attachments", `List (List.map pending_attachment_json message.attachments)

--- a/lib/server_keeper_waiting_inventory.ml
+++ b/lib/server_keeper_waiting_inventory.ml
@@ -268,8 +268,7 @@ let chat_queue_active_row ~source ~next_action ~lifecycle_fields keeper_name que
             , `String
                 (Keeper_chat_queue.Receipt_id.to_string receipt.receipt_id) )
           ; ( "message_source"
-            , Server_dashboard_http_keeper_api_types
-              .keeper_chat_message_source_json
+            , Keeper_chat_receipt_projection.message_source_json
                 msg.source )
           ; "content_length", `Int (String.length msg.content)
           ; "user_block_count", `Int (List.length msg.user_blocks)

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -263,7 +263,7 @@ let test_keeper_chat_recovery_route_is_exact () =
        Masc_domain.Admin
        Server_dashboard_http_keeper_chat_pending.operator_permission);
   let pending_source_json =
-    Server_dashboard_http_keeper_api_types.keeper_chat_message_source_json
+    Masc.Keeper_chat_receipt_projection.message_source_json
       (Keeper_chat_queue.Slack
          { channel_id = "channel-1"
          ; user_id = "user-1"

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -906,8 +906,22 @@ let () =
       { meta.runtime.proactive_rt with last_outcome; last_reason }
     in
     let prior = { meta with runtime = { meta.runtime with proactive_rt } } in
-    let observation =
-      Masc.Keeper_deliberation.empty_world_observation ~keeper_name
+    let observation : Masc.Keeper_world_observation.world_observation =
+      { pending_messages = []
+      ; pending_board_events = []
+      ; idle_seconds = 0
+      ; active_goals = []
+      ; unclaimed_task_count = 0
+      ; claimable_task_count = 0
+      ; failed_task_count = 0
+      ; scheduled_automation =
+          Masc.Keeper_world_observation.empty_scheduled_automation_observation
+      ; backlog_updated_since_last_scheduled_autonomous = false
+      ; running_keeper_fiber_count = 0
+      ; connected_surfaces = []
+      ; connected_surface_failures = []
+      ; own_recent_board_posts = []
+      }
     in
     Masc.Keeper_unified_metrics.update_metrics_from_result
       prior


### PR DESCRIPTION
## Summary

- Complete record-type disambiguation for exact Gate rule observations.
- Restore duplicate-fact validation through the existing StringSet utility.
- Move durable chat source JSON into Keeper_chat_receipt_projection, the shared typed projection boundary used by parent and server consumers.
- Use the current Keeper_world_observation contract in the terminal-reason test.

## Why

Current main does not build after #26484. The remaining failures are:

- missing String_set in keeper_memory_os_current
- request inferred as auto_judge_owner_failure in keeper_gate
- parent masc library referencing a server-only module
- legacy Keeper_deliberation observation passed to a current world-observation consumer

The chat-source change removes the reverse parent-to-server dependency instead of adding another facade or duplicating the JSON mapping.

## Validation

- ocamlformat check on all changed files
- OCaml parser check on all changed implementation files
- git diff check
- focused Dune build is running in the dedicated worktree

PR CI remains the build and test authority.
