### PR TITLE
fix(keeper): reserve fleet controls for operators

### DIFF
--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -260,7 +260,23 @@ let prepare_agent_setup
          | _ :: _, _
          | [],
            ( Keeper_tool_descriptor.Preferred_public_name
-           | Keeper_tool_descriptor.Internal_name ) -> count)
+           | Keeper_tool_descriptor.Internal_name
+           | Keeper_tool_descriptor.Operator_only ) -> count)
+      0
+      registered_descriptors
+  in
+  let operator_only_count =
+    List.fold_left
+      (fun count (descriptor : Keeper_tool_descriptor.t) ->
+         match
+           Keeper_tool_descriptor.model_schema_errors descriptor
+         , descriptor.keeper_model_projection
+         with
+         | [], Keeper_tool_descriptor.Operator_only -> count + 1
+         | ([], (Keeper_tool_descriptor.Preferred_public_name
+                | Keeper_tool_descriptor.Internal_name
+                | Keeper_tool_descriptor.Transport_alias _))
+         | (_ :: _, _) -> count)
       0
       registered_descriptors
   in
@@ -277,6 +293,7 @@ let prepare_agent_setup
     List.length registered_descriptors
     - List.length model_visible_descriptors
     - transport_alias_count
+    - operator_only_count
     - invalid_schema_count
   in
   let all_tool_names =
@@ -345,6 +362,7 @@ let prepare_agent_setup
                ; "registered_descriptor_count", `Int (List.length registered_descriptors)
                ; "model_visible_descriptor_count", `Int (List.length model_visible_descriptors)
                ; "transport_alias_count", `Int transport_alias_count
+               ; "operator_only_count", `Int operator_only_count
                ; "invalid_schema_count", `Int invalid_schema_count
                ; "unexplained_exclusion_count", `Int unexplained_exclusion_count
                ; ( "all_model_eligible_tools_visible"
@@ -352,11 +370,12 @@ let prepare_agent_setup
                ])));
   Log.Keeper.routine
     "keeper:%s tool visibility: registered=%d visible=%d transport_alias=%d \
-     invalid_schema=%d unexplained=%d"
+     operator_only=%d invalid_schema=%d unexplained=%d"
     meta.name
     (List.length registered_descriptors)
     (List.length all_tool_names)
     transport_alias_count
+    operator_only_count
     invalid_schema_count
     unexplained_exclusion_count;
   let record_tool_assignment ~turn ~tool_list ~lane =

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -20,6 +20,7 @@ type sandbox =
 type keeper_model_projection =
   | Preferred_public_name
   | Internal_name
+  | Operator_only
   | Transport_alias of { projected_by : string }
 
 type keeper_tool_group =
@@ -150,6 +151,7 @@ let sandbox_to_string = function
 let keeper_model_projection_to_string = function
   | Preferred_public_name -> "preferred_public_name"
   | Internal_name -> "internal_name"
+  | Operator_only -> "operator_only"
   | Transport_alias _ -> "transport_alias"
 ;;
 
@@ -594,7 +596,7 @@ let descriptor_with_public_aliases
     @ (match keeper_model_projection with
        | Transport_alias { projected_by } ->
          [ "transport_alias_of", projected_by ]
-       | Preferred_public_name | Internal_name -> [])
+       | Preferred_public_name | Internal_name | Operator_only -> [])
   in
   { id
   ; keeper_model_projection
@@ -1449,7 +1451,7 @@ let masc_misc_descriptor id name description ~readonly =
 let masc_control_descriptor operation =
   let schema = Tool_schemas_misc.control_schema operation in
   cluster_descriptor_with_schema_source
-    ~keeper_model_projection:Internal_name
+    ~keeper_model_projection:Operator_only
     ~input_schema_source:Canonical_registry
     ~input_schema:schema.input_schema
     ~id:("masc.control." ^ Tool_schemas_misc.control_operation_id operation)
@@ -2039,7 +2041,7 @@ let keeper_model_names descriptor =
     [ descriptor.public_name ]
   | [], Internal_name ->
     [ descriptor.internal_name ]
-  | [], Transport_alias _ -> []
+  | [], (Operator_only | Transport_alias _) -> []
 ;;
 
 let keeper_candidate_names descriptor =
@@ -2050,7 +2052,7 @@ let keeper_candidate_names descriptor =
     |> List.sort_uniq String.compare
   | [], Internal_name ->
     [ descriptor.internal_name ]
-  | [], Transport_alias _ -> []
+  | [], (Operator_only | Transport_alias _) -> []
 ;;
 
 let registered_names descriptor =
@@ -2170,7 +2172,7 @@ let route_evidence_json d =
      (match d.keeper_model_projection with
       | Transport_alias { projected_by } ->
         [ "transport_alias_of", `String projected_by ]
-      | Preferred_public_name | Internal_name -> [])
+      | Preferred_public_name | Internal_name | Operator_only -> [])
      @ common_policy_json_fields ~readonly_key:"readonly" policy)
 ;;
 
@@ -2204,6 +2206,6 @@ let discovery_fields d =
    match d.keeper_model_projection with
    | Transport_alias { projected_by } ->
      [ "transport_alias_of", `String projected_by ]
-   | Preferred_public_name | Internal_name -> [])
+   | Preferred_public_name | Internal_name | Operator_only -> [])
   @ examples_field
 ;;

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -24,12 +24,14 @@ type sandbox =
 
 (** One explicit Keeper-model exposure choice per descriptor. Compatibility
     aliases remain routable at transport boundaries but never become a second
-    model-facing name. [Transport_alias] identifies a descriptor whose exact
-    capability is already projected by another descriptor; it is not a
-    subjective visibility policy. *)
+    model-facing name. [Operator_only] keeps a control-plane descriptor
+    available to trusted operator entrypoints without exposing it to the
+    autonomous Keeper model. [Transport_alias] identifies a descriptor whose
+    exact capability is already projected by another descriptor. *)
 type keeper_model_projection =
   | Preferred_public_name
   | Internal_name
+  | Operator_only
   | Transport_alias of { projected_by : string }
 
 (** Typed display group for Keeper capability discovery. *)
@@ -175,12 +177,13 @@ val all_descriptors : unit -> t list
 val model_schema_errors : t -> string list
 
 (** Descriptors with one explicit model-facing projection and a resolved input
-    schema. Only exact transport aliases and missing/structurally invalid schemas
-    are excluded. *)
+    schema. Operator-only controls, exact transport aliases, and
+    missing/structurally invalid schemas are excluded. *)
 val model_visible_descriptors : unit -> t list
 
 (** The sole active Keeper model name. Empty only for an exact
-    [Transport_alias] or a descriptor without a resolved schema. *)
+    [Operator_only], [Transport_alias], or a descriptor without a resolved
+    schema. *)
 val keeper_model_names : t -> string list
 
 (** Names admitted by the Keeper execution/candidate boundary. A preferred

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -168,6 +168,15 @@ let test_keeper_model_projection_is_single_and_unique () =
            (descriptor.id ^ " internal model projection")
            [ descriptor.internal_name ]
            projected
+       | Descriptor.Operator_only ->
+         Alcotest.(check (list string))
+           (descriptor.id ^ " operator-only control has no model projection")
+           []
+           projected;
+         Alcotest.(check (list string))
+           (descriptor.id ^ " operator-only control has no Keeper candidates")
+           []
+           candidates
        | Descriptor.Transport_alias _ ->
          Alcotest.(check (list string))
            (descriptor.id ^ " transport alias has no duplicate model projection")
@@ -184,7 +193,9 @@ let test_transport_aliases_name_exact_visible_projection () =
   all_descriptors ()
   |> List.iter (fun (descriptor : Descriptor.t) ->
     match descriptor.keeper_model_projection with
-    | Descriptor.Preferred_public_name | Descriptor.Internal_name -> ()
+    | Descriptor.Preferred_public_name
+    | Descriptor.Internal_name
+    | Descriptor.Operator_only -> ()
     | Descriptor.Transport_alias { projected_by } ->
       let owners =
         all_descriptors ()
@@ -313,6 +324,7 @@ let test_registered_cluster_model_projections_are_explicit () =
       true
       (descriptor.keeper_model_projection = expected)
   in
+  let keeper_model_names = Policy.keeper_model_tool_names () in
   List.iter
     (fun name -> check_projection name Descriptor.Internal_name)
     [ "masc_runtime_verify"
@@ -325,12 +337,18 @@ let test_registered_cluster_model_projections_are_explicit () =
     ; "masc_library_add"
     ; "masc_library_list"
     ; "masc_library_promote"
-    ; "masc_pause"
-    ; "masc_resume"
     ; "masc_heartbeat"
     ; "masc_gc"
     ; "masc_get_metrics"
     ];
+  List.iter
+    (fun name ->
+       check_projection name Descriptor.Operator_only;
+       Alcotest.(check bool)
+         (name ^ " is absent from the autonomous Keeper model bundle")
+         false
+         (List.mem name keeper_model_names))
+    [ "masc_pause"; "masc_resume" ];
   List.iter
     (fun (name, projected_by) ->
        check_projection name (Descriptor.Transport_alias { projected_by }))


### PR DESCRIPTION
## 문제

Live `407ae5bb92`에서 autonomous Keeper `sangsu`가 모델에 노출된 `masc_pause`를 반복 호출했습니다. 실제 경로는 `Keeper_tool_policy.all_keeper_model_tool_schemas` → descriptor projection → Keeper OAS bundle → `Tool_control.handle_pause` → `Workspace.pause`였고, 개별 Keeper pause가 아니라 전체 Workspace/fleet pause였습니다.

## 변경

- `masc_pause`/`masc_resume` descriptor를 typed `Operator_only` projection으로 분류
- trusted operator/transport descriptor와 실제 handler는 유지
- autonomous Keeper model schema와 execution candidate에서는 두 control을 제거
- 모델 bundle의 실제 schema 이름에서 두 control이 빠지는 회귀 검증 추가
- migration/legacy decoder, settlement 상태, 추가 Gate, facade chain은 만들지 않음

Board sibling lifetime 자체는 이미 #26486에서 heartbeat와 함께 정상 종료되도록 수정됐으며, 이 PR은 그 Feature를 중첩 제약으로 감싸지 않습니다.

## 검증

- `git diff --check`: PASS
- touched OCaml `ocamlformat --check`: PASS
- Dashboard `tsc --noEmit`: PASS
- 로컬 Dune은 사용자 요청에 따라 실행하지 않았고 전체 build/test 권위는 exact-head PR CI입니다.

[근거] live `/health?full=1`, Keeper 로그의 `masc_pause` tool calls, source entrypoint/caller trace, `gh pr view 26486`; 확인일시 2026-07-30T20:10:00+09:00; 신뢰도 High
