### PR TITLE
fix(keeper): bind turn evidence to serialized requests

### DIFF
--- a/dashboard/src/api/dashboard-turn-records.test.ts
+++ b/dashboard/src/api/dashboard-turn-records.test.ts
@@ -284,6 +284,18 @@ describe('keeper turn record final input composition', () => {
     ])
   })
 
+  it('preserves explicit unavailable composition instead of inventing an empty list', async () => {
+    getMock.mockResolvedValue(payload(entry({
+      input_components: null,
+      request_runtime_profile: 'anthropic.fallback',
+      request_body_bytes: 560_513,
+    })))
+
+    const response = await fetchKeeperTurnRecords('sangsu')
+
+    expect(response.entries[0]?.record.input_components).toBeNull()
+  })
+
   it('rejects rows without the current composition contract', async () => {
     getMock.mockResolvedValue(payload(entry({ input_components: undefined })))
 
@@ -316,6 +328,50 @@ describe('keeper turn record final input composition', () => {
     getMock.mockResolvedValue(payload(entry({
       input_components: [{ component: 'prompt.retry_nudge', bytes: 1 }],
     })))
+
+    await expect(fetchKeeperTurnRecords('sangsu')).rejects.toThrow(
+      '유효하지 않은 keeper turn record payload',
+    )
+  })
+
+  it('rejects duplicate component ids', async () => {
+    const component = { component: 'tool_schemas', bytes: 1 }
+    getMock.mockResolvedValue(payload(entry({
+      input_components: [component, component],
+    })))
+
+    await expect(fetchKeeperTurnRecords('sangsu')).rejects.toThrow(
+      '유효하지 않은 keeper turn record payload',
+    )
+  })
+
+  it('accepts only current unique blocks with lowercase sha256 digests', async () => {
+    getMock.mockResolvedValue(payload(entry({
+      blocks: [{
+        block: 'persona',
+        bytes: 4,
+        digest: 'a'.repeat(64),
+      }],
+    })))
+
+    const response = await fetchKeeperTurnRecords('sangsu')
+    expect(response.entries[0]?.record.blocks).toEqual([{
+      block: 'persona',
+      bytes: 4,
+      digest: 'a'.repeat(64),
+    }])
+  })
+
+  it.each([
+    { blocks: [{ block: 'persona', bytes: 4, digest: 'A'.repeat(64) }] },
+    {
+      blocks: [
+        { block: 'persona', bytes: 4, digest: 'a'.repeat(64) },
+        { block: 'persona', bytes: 5, digest: 'b'.repeat(64) },
+      ],
+    },
+  ])('rejects malformed or duplicate current blocks', async ({ blocks }) => {
+    getMock.mockResolvedValue(payload(entry({ blocks })))
 
     await expect(fetchKeeperTurnRecords('sangsu')).rejects.toThrow(
       '유효하지 않은 keeper turn record payload',

--- a/dashboard/src/api/dashboard-turn-records.ts
+++ b/dashboard/src/api/dashboard-turn-records.ts
@@ -54,7 +54,9 @@ export type TurnRecordEntry = {
   absolute_turn: number
   turn_ref: string
   blocks: TurnBlock[]
-  input_components: TurnInputComponent[]
+  // null means the producer reached no exact composition observation; an
+  // observed empty input remains [].
+  input_components: TurnInputComponent[] | null
   request_runtime_profile: string | null
   request_body_bytes: number | null
   runtime_profile: string
@@ -381,6 +383,7 @@ function decodeTurnBlock(raw: unknown): TurnBlock | null {
   if (
     block === null
     || digest === null
+    || !/^[0-9a-f]{64}$/.test(digest)
     || bytes == null
     || !Number.isSafeInteger(bytes)
     || bytes < 0
@@ -389,7 +392,11 @@ function decodeTurnBlock(raw: unknown): TurnBlock | null {
 }
 
 function decodeTurnBlockList(raw: unknown): TurnBlock[] | null {
-  return decodeArray(raw, decodeTurnBlock)
+  const blocks = decodeArray(raw, decodeTurnBlock)
+  if (blocks === null) return null
+  return new Set(blocks.map(block => block.block)).size === blocks.length
+    ? blocks
+    : null
 }
 
 function decodeTurnInputComponentId(raw: unknown): TurnInputComponentId | null {
@@ -427,7 +434,10 @@ function decodeTurnInputComponents(raw: unknown): TurnInputComponent[] | null {
     }
     components.push({ component, bytes })
   }
-  return components
+  return new Set(components.map(component => component.component)).size
+    === components.length
+    ? components
+    : null
 }
 
 function decodeTurnRecordEntry(raw: unknown): TurnRecordEntry | null {
@@ -467,7 +477,10 @@ function decodeTurnRecordEntry(raw: unknown): TurnRecordEntry | null {
   const runtime_profile = decodeExactNonEmptyString(raw.runtime_profile)
   const ts = asNumber(raw.ts)
   const blocks = decodeTurnBlockList(raw.blocks)
-  const input_components = decodeTurnInputComponents(raw.input_components)
+  const input_components =
+    raw.input_components === null
+      ? null
+      : decodeTurnInputComponents(raw.input_components)
   const request_runtime_profile =
     raw.request_runtime_profile === null
       ? null
@@ -515,7 +528,8 @@ function decodeTurnRecordEntry(raw: unknown): TurnRecordEntry | null {
     || runtime_profile === null
     || ts == null
     || blocks === null
-    || input_components == null
+    || !Object.hasOwn(raw, 'input_components')
+    || input_components === null && raw.input_components !== null
     || !Object.hasOwn(raw, 'request_runtime_profile')
     || request_runtime_profile === null && raw.request_runtime_profile !== null
     || !Object.hasOwn(raw, 'request_body_bytes')

--- a/dashboard/src/components/memory-inspector.test.ts
+++ b/dashboard/src/components/memory-inspector.test.ts
@@ -97,8 +97,8 @@ function turnRecordsPayload() {
         absolute_turn: 7,
         turn_ref: 'trace-a#7',
         blocks: [
-          { block: 'persona', bytes: 1_200, digest: 'aaaa1111bbbb' },
-          { block: 'memory_os_recall', bytes: 800, digest: 'cccc2222dddd' },
+          { block: 'persona', bytes: 1_200, digest: 'a'.repeat(64) },
+          { block: 'memory_os_recall', bytes: 800, digest: 'c'.repeat(64) },
         ],
         input_components: [
           { component: 'prompt.persona', bytes: 1_200 },
@@ -176,6 +176,22 @@ describe('MemoryInspector current snapshot', () => {
     })
     expect(container.textContent).not.toContain('계속 유지할 핵심 기억')
   })
+
+  it('renders unavailable content attribution separately from an observed empty input', async () => {
+    const payload = turnRecordsPayload()
+    Object.assign(payload.entries[0]?.record ?? {}, { input_components: null })
+    stubFetch(payload)
+    const { container } = render(
+      html`<${MemoryInspector} keeper=${keeper} keepers=${[keeper]} onClose=${vi.fn()} />`,
+    )
+
+    await waitFor(() => {
+      expect(container.textContent).toContain(
+        'content 구성 관측 불가 — 빈 입력으로 간주하지 않습니다.',
+      )
+    })
+    expect(container.textContent).toContain('547.4KB wire')
+  })
 })
 
 describe('MemoryInspector pure projections', () => {
@@ -230,7 +246,7 @@ describe('MemoryInspector pure projections', () => {
     ], [{ component: 'prompt.memory_os_recall', bytes: 100 }])
     const emptyTail = row(2, [])
     expect(latestEntryWithBlocks([assembled, emptyTail])).toBe(assembled)
-    expect(latestEntryWithInputComponents([assembled, emptyTail])).toBe(assembled)
+    expect(latestEntryWithInputComponents([assembled, emptyTail])).toBe(emptyTail)
     expect(recentMemoryRecallInjections([assembled, emptyTail])).toEqual([{
       traceId: 'trace',
       turn: 1,

--- a/dashboard/src/components/memory-inspector.ts
+++ b/dashboard/src/components/memory-inspector.ts
@@ -165,7 +165,7 @@ export function latestEntryWithInputComponents(
     if (
       row
       && (
-        row.record.input_components.length > 0
+        row.record.input_components !== null
         || row.record.request_body_bytes != null
       )
     ) return row
@@ -274,9 +274,7 @@ function MemCompoReal({ row }: { row: TurnRecordRow | null }) {
   }
   const inputTok = row.record.input_tokens
   const requestBodyBytes = row.record.request_body_bytes
-  if (totalBytes === 0 && requestBodyBytes == null) {
-    return html`<div class="mem-empty">최종 provider 입력 구성 관측 없음.</div>`
-  }
+  const inputComponentsUnavailable = row.record.input_components === null
   const ctxWin = row.record.context_window
   const pct = inputTok != null && ctxWin != null && ctxWin > 0
     ? Math.round((inputTok / ctxWin) * 100)
@@ -298,8 +296,10 @@ function MemCompoReal({ row }: { row: TurnRecordRow | null }) {
             : null}
         </span>
       </div>
-      ${totalBytes === 0
-        ? html`<div class="mem-empty">wire 측정은 존재하지만 content 구성 관측은 없습니다.</div>`
+      ${inputComponentsUnavailable
+        ? html`<div class="mem-empty">content 구성 관측 불가 — 빈 입력으로 간주하지 않습니다.</div>`
+        : totalBytes === 0
+          ? html`<div class="mem-empty">관측된 content 구성요소가 없습니다.</div>`
         : html`
             <${MemBar} parts=${parts} total=${totalBytes} />
             <div class="mem-legend">

--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -435,17 +435,37 @@ let log_exact_error (entry : pending_approval) operation detail =
    counter [record_outcome] already writes. Render the per-attempt provenance so
    the branch and the slot it died on are recoverable. *)
 let flow_evidence_detail (evidence : Exact_output.flow_evidence) =
-  match evidence.attempts with
-  | [] -> "no candidate attempt was recorded"
-  | attempts ->
-    attempts
-    |> List.map (fun (attempt : Exact_output.flow_attempt_snapshot) ->
+  let attempts =
+    List.map
+      (fun (attempt : Exact_output.flow_attempt_snapshot) ->
       Printf.sprintf
         "slot=%s call_id=%s"
         attempt.visit.identity.candidate_id
         (Exact_output.generation_receipt_snapshot_call_id attempt.receipt
          |> Exact_output.call_id_to_string))
-    |> String.concat "; "
+      evidence.attempts
+  in
+  let advances =
+    List.map
+      (fun (advance : Exact_output.flow_advance_receipt) ->
+         let failed_slot, failure_kind =
+           match advance.failed with
+           | Exact_output.Flow_advance_candidate_rejected rejection ->
+             ( (Exact_output.candidate_rejection_identity rejection).candidate_id
+             , "candidate_rejected" )
+           | Exact_output.Flow_advance_execution_failed { candidate; _ } ->
+             candidate.visit.identity.candidate_id, "execution_failed"
+         in
+         Printf.sprintf
+           "advance=%s->%s kind=%s"
+           failed_slot
+           advance.next.identity.candidate_id
+           failure_kind)
+      evidence.advances
+  in
+  match attempts @ advances with
+  | [] -> "no candidate attempt or advance was recorded"
+  | details -> String.concat "; " details
 ;;
 
 let optional_tokens = function
@@ -521,6 +541,8 @@ let candidate_rejection_detail (rejection : Exact_output.candidate_rejection_rec
      |> rejection_disposition_detail)
 ;;
 
+(* [Flow_exact_execution_failed] is the branch that carries the provider's own
+   verdict, and it was the only flow error settled with no log line at all. *)
 let execution_cause_detail : Exact_output.execution_error_cause -> string = function
   | Attempt_already_started -> "attempt already started"
   | Clock_required_for_timeout -> "clock required for timeout"

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -70,6 +70,12 @@ type raw_trace_sink_outcome =
   | Sink_ready of Agent_sdk.Raw_trace.t
   | Sink_degraded of Agent_sdk.Error.sdk_error
 
+type request_evidence =
+  { wire_observation : Turn_record.request_wire_observation
+  ; prompt_blocks : Turn_record.prompt_block list
+  ; input_messages : Agent_sdk.Types.message list option
+  }
+
 (* What the queue held when the turn decided to yield. The decision itself is
    [pending <> empty], so without this the record says a yield happened and
    nothing about what it yielded to. *)
@@ -664,7 +670,9 @@ let run_turn
     in
     let model_input_projection messages =
       match source_model_input_projection messages with
-      | Error _ as error -> error
+      | Error _ as error ->
+        current_request_input_messages_ref := None;
+        error
       | Ok projected_messages as result ->
         let prompt_context_present =
           Option.is_some acc.Keeper_run_tools.extra_system_context_size
@@ -874,10 +882,14 @@ let run_turn
                              ~body_bytes;
                            request_evidence_ref :=
                              Some
-                               ( { Turn_record.runtime_profile = runtime_id
-                                 ; body_bytes
-                                 }
-                               , !current_request_input_messages_ref ))
+                               { wire_observation =
+                                   { Turn_record.runtime_profile = runtime_id
+                                   ; body_bytes
+                                   }
+                               ; prompt_blocks = acc.prompt_blocks
+                               ; input_messages =
+                                   !current_request_input_messages_ref
+                               })
                       ())
          in
          (* Trace-store failure isolation: [raw_trace_for_dispatch]
@@ -922,13 +934,13 @@ let run_turn
                  let usage = Keeper_context_runtime.usage_of_response result.response in
                  let ctx_composition =
                    match !request_evidence_ref with
-                   | Some (_, Some input_messages) ->
+                   | Some { prompt_blocks; input_messages = Some input_messages; _ } ->
                      Keeper_agent_prompt_metrics.build_ctx_composition_metrics
-                       ~prompt_blocks:acc.prompt_blocks
+                       ~prompt_blocks
                        ~tools
                        ~input_messages
                        ~actual_input_tokens:(Some usage.input_tokens)
-                   | Some (_, None) | None ->
+                   | Some { input_messages = None; _ } | None ->
                      { Keeper_agent_prompt_metrics.actual_input_tokens =
                          (if usage.input_tokens > 0
                           then Some usage.input_tokens
@@ -1149,26 +1161,34 @@ let run_turn
           Runtime.pricing_of_runtime_id runtime_id_string
         in
         let input_components =
-          let segments =
-            match turn_result, !request_evidence_ref with
-            | Ok result, _ ->
-              result.Keeper_agent_result.ctx_composition.segments
-            | Error _, Some (_, Some input_messages) ->
+          match !request_evidence_ref with
+          | Some
+              { prompt_blocks
+              ; input_messages = Some input_messages
+              ; _
+              } ->
+            let segments =
               (Keeper_agent_prompt_metrics.build_ctx_composition_metrics
-                 ~prompt_blocks:acc.prompt_blocks
+                 ~prompt_blocks
                  ~tools
                  ~input_messages
                  ~actual_input_tokens:None)
                 .segments
-            | Error _, (Some (_, None) | None) -> []
-          in
-          List.map
-            (fun
-              (component,
-               (segment :
-                 Keeper_agent_prompt_metrics.prompt_segment_metrics)) ->
-               { Turn_record.component = component; bytes = segment.bytes })
-            segments
+            in
+            Some
+              (List.map
+                 (fun
+                   (component,
+                    (segment :
+                      Keeper_agent_prompt_metrics.prompt_segment_metrics)) ->
+                    { Turn_record.component = component; bytes = segment.bytes })
+                 segments)
+          | Some { input_messages = None; _ } | None -> None
+        in
+        let blocks =
+          match !request_evidence_ref with
+          | Some evidence -> evidence.prompt_blocks
+          | None -> acc.prompt_blocks
         in
         Keeper_turn_record_writer.write
           ~config
@@ -1186,7 +1206,10 @@ let run_turn
           ~price_output_per_million
           ~request_latency_ms
           ~ttfrc_ms
-          ~request_wire_observation:(Option.map fst !request_evidence_ref)
+          ~request_wire_observation:
+            (Option.map
+               (fun evidence -> evidence.wire_observation)
+               !request_evidence_ref)
           ~sampling:
             { temperature = Some temperature
             ; top_p = Runtime.top_p_of_runtime_id runtime_id_string
@@ -1196,7 +1219,7 @@ let run_turn
             }
           ~usage
           ~execution_ids
-          ~blocks:acc.prompt_blocks
+          ~blocks
           ~input_components
           ();
         (* RFC-0233 §2.3 PR-4: project the same record onto the ambient
@@ -1212,8 +1235,7 @@ let run_turn
               , `String
                   (Yojson.Safe.to_string
                      (`List
-                        (List.map Turn_record.prompt_block_to_json
-                           acc.prompt_blocks))) )
+                        (List.map Turn_record.prompt_block_to_json blocks))) )
             ; ( Otel_genai.Attr_key.masc_turn_profile
               , `String runtime_id_string )
             ; ( Otel_genai.Attr_key.masc_turn_execution_ids

--- a/lib/keeper/keeper_turn_record_writer.mli
+++ b/lib/keeper/keeper_turn_record_writer.mli
@@ -23,6 +23,6 @@ val write :
   usage:Turn_record.usage ->
   execution_ids:Ids.Execution_id.t list ->
   blocks:Turn_record.prompt_block list ->
-  input_components:Turn_record.input_component list ->
+  input_components:Turn_record.input_component list option ->
   unit ->
   unit

--- a/lib/types/turn_record.ml
+++ b/lib/types/turn_record.ml
@@ -50,7 +50,7 @@ type t =
   ; absolute_turn : int
   ; turn_ref : Ids.Turn_ref.t
   ; blocks : prompt_block list
-  ; input_components : input_component list
+  ; input_components : input_component list option
   ; runtime_profile : string
   ; model : string option
   ; finish_reason : string option
@@ -114,7 +114,10 @@ let to_json (r : t) : Yojson.Safe.t =
      ; ("turn_ref", Ids.Turn_ref.to_yojson r.turn_ref)
      ; ("blocks", `List (List.map prompt_block_to_json r.blocks))
      ; ( "input_components"
-       , `List (List.map input_component_to_json r.input_components) )
+       , match r.input_components with
+         | Some components ->
+           `List (List.map input_component_to_json components)
+         | None -> `Null )
      ; ("runtime_profile", `String r.runtime_profile)
      ; "request_runtime_profile", request_runtime_profile
      ; "request_body_bytes", request_body_bytes
@@ -175,6 +178,20 @@ let as_nonnegative_int name json =
   then Error (Printf.sprintf "turn_record: field %S is negative" name)
   else Ok value
 
+let as_sha256_digest name json =
+  let* value = as_string name json in
+  let is_lower_hex = function
+    | '0' .. '9' | 'a' .. 'f' -> true
+    | _ -> false
+  in
+  if String.length value = 64 && String.for_all is_lower_hex value
+  then Ok value
+  else
+    Error
+      (Printf.sprintf
+         "turn_record: field %S is not a lowercase sha256 digest"
+         name)
+
 let as_float name = function
   | `Float f -> Ok f
   | `Int i -> Ok (float_of_int i)
@@ -215,9 +232,9 @@ let prompt_block_of_json (json : Yojson.Safe.t) : (prompt_block, string) result 
       let* block_json = require "block" fields in
       let* block_name = as_string "block" block_json in
       let* bytes_json = require "bytes" fields in
-      let* bytes = as_int "bytes" bytes_json in
+      let* bytes = as_nonnegative_int "bytes" bytes_json in
       let* digest_json = require "digest" fields in
-      let* digest = as_string "digest" digest_json in
+      let* digest = as_sha256_digest "digest" digest_json in
       let* block = Prompt_block_id.of_string block_name in
       Ok { block; bytes; digest }
   | _ -> Error "turn_record: block entry is not an object"
@@ -259,14 +276,8 @@ let input_component_of_json
   match json with
   | `Assoc fields ->
       let expected_fields = [ "component"; "bytes" ] in
-      let exact_fields =
-        List.length fields = List.length expected_fields
-        && List.for_all
-             (fun (name, _) -> List.mem name expected_fields)
-             fields
-      in
       let* () =
-        if exact_fields
+        if fields_are_unique_known expected_fields fields
         then Ok ()
         else Error "turn_record: input component fields are not exact"
       in
@@ -284,6 +295,42 @@ let rec collect_results acc = function
       match item with
       | Ok value -> collect_results (value :: acc) rest
       | Error _ as e -> e)
+
+let ensure_unique_blocks blocks =
+  let rec loop seen = function
+    | [] -> Ok blocks
+    | (block : prompt_block) :: rest ->
+      if
+        List.exists
+          (fun (seen_block : prompt_block) ->
+            Prompt_block_id.equal seen_block.block block.block)
+          seen
+      then
+        Error
+          (Printf.sprintf
+             "turn_record: duplicate block %S"
+             (Prompt_block_id.to_string block.block))
+      else loop (block :: seen) rest
+  in
+  loop [] blocks
+
+let ensure_unique_input_components components =
+  let rec loop seen = function
+    | [] -> Ok components
+    | (component : input_component) :: rest ->
+      if
+        List.exists
+          (fun (seen_component : input_component) ->
+            seen_component.component = component.component)
+          seen
+      then
+        Error
+          (Printf.sprintf
+             "turn_record: duplicate input component %S"
+             (input_component_id_to_string component.component))
+      else loop (component :: seen) rest
+  in
+  loop [] components
 
 let of_json (json : Yojson.Safe.t) : (t, string) result =
   match json with
@@ -350,15 +397,24 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
       let* blocks_json = require "blocks" fields in
       let* blocks =
         match blocks_json with
-        | `List items -> collect_results [] (List.map prompt_block_of_json items)
+        | `List items ->
+          let* blocks =
+            collect_results [] (List.map prompt_block_of_json items)
+          in
+          ensure_unique_blocks blocks
         | _ -> Error "turn_record: blocks is not a list"
       in
       let* input_components_json = require "input_components" fields in
       let* input_components =
         match input_components_json with
         | `List items ->
-          collect_results [] (List.map input_component_of_json items)
-        | _ -> Error "turn_record: input_components is not a list"
+          let* components =
+            collect_results [] (List.map input_component_of_json items)
+          in
+          let* components = ensure_unique_input_components components in
+          Ok (Some components)
+        | `Null -> Ok None
+        | _ -> Error "turn_record: input_components is not a list or null"
       in
       let* profile_json = require "runtime_profile" fields in
       let* runtime_profile = as_string "runtime_profile" profile_json in
@@ -439,20 +495,9 @@ type block_diff =
 let find_block blocks id =
   List.find_opt (fun (b : prompt_block) -> Prompt_block_id.equal b.block id) blocks
 
-let dedupe_by_id blocks =
-  List.fold_left
-    (fun acc (b : prompt_block) ->
-      if List.exists (fun (seen : prompt_block) ->
-             Prompt_block_id.equal seen.block b.block)
-           acc
-      then acc
-      else b :: acc)
-    [] blocks
-  |> List.rev
-
 let diff_blocks ~(prev : t) ~(next : t) : block_diff =
-  let prev_blocks = dedupe_by_id prev.blocks in
-  let next_blocks = dedupe_by_id next.blocks in
+  let prev_blocks = prev.blocks in
+  let next_blocks = next.blocks in
   let added =
     List.filter
       (fun (b : prompt_block) -> find_block prev_blocks b.block = None)

--- a/lib/types/turn_record.mli
+++ b/lib/types/turn_record.mli
@@ -6,10 +6,11 @@
     stores. Diffing two consecutive records by [(block, digest)] answers
     "which instruction blocks entered, left, or changed between turns".
 
-    The assembly chain re-runs once per SDK turn inside one keeper turn;
-    [blocks] records the LAST SDK turn's assembly, matching the
-    last-write-wins semantics of the turn context the receipt already
-    uses. *)
+    The assembly chain re-runs once per SDK turn inside one keeper turn.
+    When a request reached the wire boundary, [blocks] and
+    [input_components] describe that same latest serialized request. If no
+    request reached the boundary, [blocks] records the last assembly and
+    [input_components] is [None]. *)
 
 type prompt_block =
   { block : Prompt_block_id.t
@@ -73,11 +74,12 @@ type t =
        chat/board. The decoder rejects a key that does not exactly match the
        row's [trace_id] and [absolute_turn]. *)
   ; blocks : prompt_block list (* assembly order *)
-  ; input_components : input_component list
+  ; input_components : input_component list option
     (* Exact UTF-8/JSON payload bytes attributed to the concrete prompt blocks,
        tool schemas, and content blocks that formed the dispatched input.
        This excludes provider envelope metadata and is therefore shown beside,
-       never substituted for, [request_wire_observation]. *)
+       never substituted for, [request_wire_observation]. [None] means exact
+       attribution was unavailable; an observed empty input is [Some []]. *)
   ; runtime_profile : string
   ; model : string option
     (* RFC-0233 §2.2/§2.3 — boundary-redacted runtime model label, the
@@ -166,8 +168,8 @@ type block_diff =
   }
 
 val diff_blocks : prev:t -> next:t -> block_diff
-(** Blocks are keyed by [block] id; assembly produces at most one block
-    per id, so first occurrence wins if a malformed row repeats one. *)
+(** Blocks are keyed by [block] id. Current rows have unique ids;
+    malformed duplicates are rejected by [of_json]. *)
 
 val entries_with_diffs : t list -> (t * block_diff option) list
 (** Pair each record (oldest-first) with its diff against the previous

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -535,13 +535,33 @@ let test_predispatch_failure_advances_only_to_oas_successor () =
          [ "hitl-unreachable"; "hitl-successor" ]
          (F.resolver_snapshot ~source:"hitl-flow-failover" fixtures);
        let entry = pending_entry ~base_path () in
+       let prepared = prepare_exn entry in
        Worker.For_testing.execute_prepared_flow
          ~net
          ~clock
          ~on_summary:(fun _ -> ())
-         (prepare_exn entry)
+         prepared
        |> require_executed;
        check int "OAS-selected successor posted once" 1 (F.post_count successor);
+       (match (Worker.For_testing.flow_evidence prepared).advances with
+        | [ advance ] ->
+          check string
+            "advance targets the frozen successor"
+            "hitl-successor"
+            advance.next.identity.candidate_id;
+          (match advance.failed with
+           | EO.Flow_advance_execution_failed { candidate; cause; _ } ->
+             check string
+               "advance retains the failed candidate"
+               "hitl-unreachable"
+               candidate.visit.identity.candidate_id;
+             check bool
+               "advance retains the typed transport failure"
+               true
+               (cause = EO.Completion_failed)
+           | EO.Flow_advance_candidate_rejected _ ->
+             fail "transport failure was recorded as a candidate rejection")
+        | _ -> fail "exactly one typed OAS advance should be retained");
        match Q.For_testing.get_pending_entry_unchecked ~id:entry.id with
        | Some
            { exact_attempt =

--- a/test/test_turn_record.ml
+++ b/test/test_turn_record.ml
@@ -31,8 +31,18 @@ let test_block_id_unknown_rejected () =
 
 (* ── TurnRecord codec ─────────────────────────────────── *)
 
-let sample_block block digest =
-  { Turn_record.block; bytes = String.length digest; digest }
+let digest_of_label label =
+  Digestif.SHA256.digest_string label |> Digestif.SHA256.to_hex
+
+let sample_block block label =
+  { Turn_record.block
+  ; bytes = String.length label
+  ; digest = digest_of_label label
+  }
+
+let input_components_or_fail = function
+  | Some components -> components
+  | None -> fail "expected available input components"
 
 let sample_record () : Turn_record.t =
   { execution_ids =
@@ -50,12 +60,13 @@ let sample_record () : Turn_record.t =
       ; sample_block Prompt_block_id.Memory_os_recall "cccc"
       ]
   ; input_components =
-      [ { component = Turn_record.Prompt_block Prompt_block_id.Persona
-        ; bytes = 4
-        }
-      ; { component = Turn_record.Tool_schemas; bytes = 8192 }
-      ; { component = Turn_record.Message_user; bytes = 256 }
-      ]
+      Some
+        [ { component = Turn_record.Prompt_block Prompt_block_id.Persona
+          ; bytes = 4
+          }
+        ; { component = Turn_record.Tool_schemas; bytes = 8192 }
+        ; { component = Turn_record.Message_user; bytes = 256 }
+        ]
   ; runtime_profile = "ollama_cloud.deepseek-v4-flash"
   ; model = Some "deepseek-v4-flash"
   ; finish_reason = Some "completed"
@@ -143,18 +154,18 @@ let test_codec_roundtrip () =
       (List.map
          (fun (component : Turn_record.input_component) ->
             Turn_record.input_component_id_to_string component.component)
-         record.input_components)
+         (input_components_or_fail record.input_components))
       (List.map
          (fun (component : Turn_record.input_component) ->
             Turn_record.input_component_id_to_string component.component)
-         decoded.input_components);
+         (input_components_or_fail decoded.input_components));
     check (list int) "input component bytes preserved"
       (List.map
          (fun (component : Turn_record.input_component) -> component.bytes)
-         record.input_components)
+         (input_components_or_fail record.input_components))
       (List.map
          (fun (component : Turn_record.input_component) -> component.bytes)
-         decoded.input_components);
+         (input_components_or_fail decoded.input_components));
     check string "runtime_profile" record.runtime_profile decoded.runtime_profile;
     check (option string) "model" record.model decoded.model;
     check (option string) "finish_reason" record.finish_reason decoded.finish_reason;
@@ -401,6 +412,80 @@ let test_codec_rejects_input_component_extra_field () =
     check bool "extra field is explicit" true
       (Astring.String.is_infix ~affix:"fields are not exact" message)
 
+let test_codec_preserves_explicit_unavailable_input_components () =
+  let record = { (sample_record ()) with input_components = None } in
+  let json = Turn_record.to_json record in
+  (match json with
+   | `Assoc fields ->
+     check bool "unavailable is serialized as null" true
+       (List.assoc_opt "input_components" fields = Some `Null)
+   | _ -> fail "record did not encode as an object");
+  match Turn_record.of_json json with
+  | Error message -> failf "explicit unavailable failed to decode: %s" message
+  | Ok decoded ->
+    check bool "unavailable survives round-trip" true
+      (decoded.input_components = None)
+
+let replace_blocks blocks =
+  match Turn_record.to_json (sample_record ()) with
+  | `Assoc fields ->
+    `Assoc (("blocks", `List blocks) :: List.remove_assoc "blocks" fields)
+  | other -> other
+
+let valid_block_json ?(bytes = 4) ?(digest = digest_of_label "block") block =
+  `Assoc
+    [ "block", `String (Prompt_block_id.to_string block)
+    ; "bytes", `Int bytes
+    ; "digest", `String digest
+    ]
+
+let test_codec_rejects_malformed_blocks () =
+  let cases =
+    [ ( "negative bytes"
+      , valid_block_json ~bytes:(-1) Prompt_block_id.Persona )
+    ; ( "non-sha256 digest"
+      , valid_block_json ~digest:"abcd" Prompt_block_id.Persona )
+    ; ( "uppercase digest"
+      , valid_block_json
+          ~digest:(String.make 64 'A')
+          Prompt_block_id.Persona )
+    ]
+  in
+  List.iter
+    (fun (label, block) ->
+      match Turn_record.of_json (replace_blocks [ block ]) with
+      | Ok _ -> failf "decoded block with %s" label
+      | Error _ -> ())
+    cases
+
+let test_codec_rejects_duplicate_blocks_and_components () =
+  let persona = valid_block_json Prompt_block_id.Persona in
+  (match Turn_record.of_json (replace_blocks [ persona; persona ]) with
+   | Ok _ -> fail "decoded duplicate prompt blocks"
+   | Error message ->
+     check bool "duplicate block is explicit" true
+       (Astring.String.is_infix ~affix:"duplicate block" message));
+  let duplicate_components =
+    match Turn_record.to_json (sample_record ()) with
+    | `Assoc fields ->
+      let tool_schema =
+        `Assoc
+          [ "component", `String "tool_schemas"
+          ; "bytes", `Int 1
+          ]
+      in
+      `Assoc
+        (( "input_components"
+         , `List [ tool_schema; tool_schema ] )
+         :: List.remove_assoc "input_components" fields)
+    | other -> other
+  in
+  match Turn_record.of_json duplicate_components with
+  | Ok _ -> fail "decoded duplicate input components"
+  | Error message ->
+    check bool "duplicate component is explicit" true
+      (Astring.String.is_infix ~affix:"duplicate input component" message)
+
 let test_codec_rejects_unknown_block () =
   let json =
     match Turn_record.to_json (sample_record ()) with
@@ -411,7 +496,7 @@ let test_codec_rejects_unknown_block () =
              [ `Assoc
                  [ "block", `String "future_block"
                  ; "bytes", `Int 4
-                 ; "digest", `String "dddd"
+                 ; "digest", `String (digest_of_label "dddd")
                  ]
              ] )
          :: List.remove_assoc "blocks" fields)
@@ -582,6 +667,12 @@ let () =
             test_codec_rejects_unknown_input_component
         ; test_case "input component extra field rejected" `Quick
             test_codec_rejects_input_component_extra_field
+        ; test_case "explicit unavailable input components round-trip" `Quick
+            test_codec_preserves_explicit_unavailable_input_components
+        ; test_case "malformed blocks rejected" `Quick
+            test_codec_rejects_malformed_blocks
+        ; test_case "duplicate blocks and components rejected" `Quick
+            test_codec_rejects_duplicate_blocks_and_components
         ; test_case "unknown block is rejected" `Quick
             test_codec_rejects_unknown_block
         ; test_case "unknown fields are rejected" `Quick


### PR DESCRIPTION
## 요약

- request wire 관측 시점의 prompt blocks와 input messages를 하나의 typed snapshot으로 묶어 TurnRecord/OTel/content composition이 동일 serialized request를 가리키게 합니다.
- `input_components`의 관측 불가를 `null`, 관측된 빈 입력을 `[]`로 구분하고 SHA-256/byte count/중복 ID를 fail-closed로 검증합니다.
- HITL summary가 OAS typed exact-output advance를 직접 렌더링합니다. OAS v0.231.10 exact pin은 선행 병합된 #26489의 SSOT를 그대로 소비합니다.

## 경계

- provider/model/text/list-position 휴리스틱을 추가하지 않습니다.
- OAS public contract를 직접 소비하며 shadow codec/facade/migration/fallback을 추가하지 않습니다.
- serialized request가 없으면 composition은 명시적 unavailable이며 빈 입력으로 위조하지 않습니다.

## 검증

- changed OCaml/MLI `ocamlformat --check`: PASS
- changed OCaml/MLI parser check: PASS
- dashboard `tsc --noEmit`: PASS
- focused Vitest 2 files / 37 tests: PASS
- #26489 OAS pin manifest/API-surface checks: PASS
- `git diff --check`: PASS
- 로컬 Dune 미실행; OCaml type/link/build/test 권위는 exact-head PR CI입니다.

[근거] reviewed head `254b5ec30d81bfa9310f666f951d9a58e0c5d0bf`; OAS v0.231.10 CI run `30536256908` SUCCESS; 확인일시 2026-07-30T20:12:00+09:00; 신뢰도 High 했어용
