### PR TITLE
fix(keeper): project autonomous work into chat

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -1105,6 +1105,7 @@ describe('streamKeeperMessage', () => {
 
     const events: string[] = []
     await streamKeeperMessage('sangsu', 'ping', {
+      requestId: 'kmsg-client-test-1',
       onEvent: event => {
         events.push(event.type)
       },
@@ -1117,6 +1118,7 @@ describe('streamKeeperMessage', () => {
       name: 'sangsu',
       message: 'ping',
       direct_reply: true,
+      request_id: 'kmsg-client-test-1',
     })
     const actorHeader = headers['X-MASC-Agent'] ?? headers['x-masc-agent']
     expect(actorHeader).toBe('dashboard-eager-manta')

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -559,6 +559,7 @@ async function refreshLoopbackDevTokenAfterMismatch(): Promise<boolean> {
 export interface StreamKeeperMessageOptions {
   signal?: AbortSignal
   onEvent: (event: KeeperChatStreamEvent) => void
+  requestId?: string
   attachments?: StreamAttachment[]
   userBlocks?: KeeperUserInputBlock[]
   channel?: string
@@ -589,6 +590,7 @@ export async function streamKeeperMessage(
   {
     signal,
     onEvent,
+    requestId,
     attachments,
     userBlocks,
     channel,
@@ -601,6 +603,13 @@ export async function streamKeeperMessage(
     name,
     message,
     direct_reply: true,
+  }
+  if (requestId !== undefined) {
+    const canonicalRequestId = requestId.trim()
+    if (!canonicalRequestId) {
+      throw new Error('Keeper stream requestId must not be blank')
+    }
+    body.request_id = canonicalRequestId
   }
   if (channel && channel.trim() !== '') {
     body.channel = channel.trim()

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -3287,6 +3287,21 @@ describe('ChatMessageBubble — workspace source badge (C2)', () => {
     expect(badge?.textContent).toContain('월드')
   })
 
+  it('badges autonomous activity when enabled', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[entry({ id: 'a', text: 'task completed', role: 'assistant', source: 'autonomous_activity' })]}
+        emptyText="empty"
+        variant="messenger"
+        showSourceBadge=${true}
+      />`,
+      container,
+    )
+    const badge = container.querySelector('.kw-src-badge.autonomous')
+    expect(badge).not.toBeNull()
+    expect(badge?.textContent).toContain('자율 활동')
+  })
+
   it('leaves an ordinary user turn unbadged', () => {
     render(
       html`<${ChatTranscript}

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -623,6 +623,7 @@ function avatarMonogram(entry: KeeperConversationEntry): string {
 // (world-state injection, internal prompt, tool result, system) and leave the
 // two ordinary cases (direct_user / direct_assistant) unbadged.
 const SOURCE_BADGE: Partial<Record<KeeperConversationSource, { label: string; cls: string }>> = {
+  autonomous_activity: { label: '자율 활동', cls: 'autonomous' },
   world_state_prompt: { label: '월드', cls: 'world' },
   internal_assistant: { label: '내부', cls: 'internal' },
   tool_result: { label: '도구', cls: 'tool' },

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -2201,6 +2201,47 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     expect(keeperActionErrors.value.echo).toContain('network error')
   })
 
+  it('does not reconcile a transport failure as a successful assistant reply', async () => {
+    streamKeeperMessage.mockImplementation(async (
+      _name: string,
+      _message: string,
+      opts: { onEvent: (event: KeeperChatStreamEvent) => void },
+    ) => {
+      opts.onEvent({
+        type: 'CUSTOM',
+        name: 'KEEPER_QUEUE_REQUEST',
+        value: { request_id: 'kmsg_echo_1', status: 'queued' },
+      })
+      throw new TypeError('network error')
+    })
+    fetchKeeperChatHistory.mockResolvedValue([
+      {
+        role: 'user',
+        content: '진행 상황?',
+        ts: 1_781_528_918,
+        kind: 'utterance',
+        delivery_key: { kind: 'direct_request', request_id: 'kmsg_echo_1' },
+      },
+      {
+        role: 'assistant',
+        content: 'Keeper request failed: provider unavailable',
+        ts: 1_781_528_920,
+        kind: 'transport_failure',
+        delivery_key: { kind: 'direct_request', request_id: 'kmsg_echo_1' },
+      },
+    ])
+
+    await expect(sendKeeperThreadMessage('echo', '진행 상황?'))
+      .rejects.toThrow('network error')
+
+    const thread = keeperThreads.value.echo ?? []
+    expect(thread.some(entry => (
+      entry.role === 'assistant'
+      && entry.delivery === 'transport_failure'
+    ))).toBe(false)
+    expect(keeperActionErrors.value.echo).toContain('network error')
+  })
+
   it('resumes a pending request from storage and finalizes the transcript', async () => {
     upsertPendingKeeperChatRequest({
       requestId: 'kmsg_echo_1',

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -2159,6 +2159,47 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     expect(keeperActionErrors.value.echo).toBeNull()
   })
 
+  it('reconciles when the queue event is lost using the client-owned request identity', async () => {
+    let requestedId = ''
+    streamKeeperMessage.mockImplementation(async (
+      _name: string,
+      _message: string,
+      opts: {
+        requestId?: string
+        onEvent: (event: KeeperChatStreamEvent) => void
+      },
+    ) => {
+      requestedId = opts.requestId ?? ''
+      throw new TypeError('network error before queue event')
+    })
+    fetchKeeperChatHistory.mockImplementation(async () => [
+      {
+        role: 'user',
+        content: '진행 상황?',
+        ts: 1_781_528_918,
+        kind: 'utterance',
+        delivery_key: { kind: 'direct_request', request_id: requestedId },
+      },
+      {
+        role: 'assistant',
+        content: '서버에는 답변이 저장됐습니다.',
+        ts: 1_781_528_920,
+        kind: 'utterance',
+        delivery_key: { kind: 'direct_request', request_id: requestedId },
+      },
+    ])
+
+    await sendKeeperThreadMessage('echo', '진행 상황?')
+
+    expect(requestedId).toMatch(/^kmsg-client-[0-9a-f-]+$/)
+    const thread = keeperThreads.value.echo ?? []
+    expect(thread.map(entry => [entry.role, entry.text, entry.delivery])).toEqual([
+      ['user', '진행 상황?', 'history'],
+      ['assistant', '서버에는 답변이 저장됐습니다.', 'history'],
+    ])
+    expect(keeperActionErrors.value.echo).toBeNull()
+  })
+
   it('does not reconcile a failed direct request with autonomous activity', async () => {
     streamKeeperMessage.mockImplementation(async (
       _name: string,

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -2120,27 +2120,85 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     })
   })
 
-  it('reconciles a stream network failure when the server history has the completed reply', async () => {
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date('2026-06-15T13:08:38Z'))
-    try {
-      streamKeeperMessage.mockRejectedValue(new TypeError('network error'))
-      fetchKeeperChatHistory.mockResolvedValue([
-        { role: 'user', content: '진행 상황?', ts: 1_781_528_918 },
-        { role: 'assistant', content: '서버에는 답변이 저장됐습니다.', ts: 1_781_528_920 },
-      ])
+  it('reconciles a stream failure only with the exact direct request identity', async () => {
+    streamKeeperMessage.mockImplementation(async (
+      _name: string,
+      _message: string,
+      opts: { onEvent: (event: KeeperChatStreamEvent) => void },
+    ) => {
+      opts.onEvent({
+        type: 'CUSTOM',
+        name: 'KEEPER_QUEUE_REQUEST',
+        value: { request_id: 'kmsg_echo_1', status: 'queued' },
+      })
+      throw new TypeError('network error')
+    })
+    fetchKeeperChatHistory.mockResolvedValue([
+      {
+        role: 'user',
+        content: '진행 상황?',
+        ts: 1_781_528_918,
+        delivery_key: { kind: 'direct_request', request_id: 'kmsg_echo_1' },
+      },
+      {
+        role: 'assistant',
+        content: '서버에는 답변이 저장됐습니다.',
+        ts: 1_781_528_920,
+        delivery_key: { kind: 'direct_request', request_id: 'kmsg_echo_1' },
+      },
+    ])
 
-      await sendKeeperThreadMessage('echo', '진행 상황?')
+    await sendKeeperThreadMessage('echo', '진행 상황?')
 
-      const thread = keeperThreads.value.echo ?? []
-      expect(thread.map(entry => [entry.role, entry.text, entry.delivery])).toEqual([
-        ['user', '진행 상황?', 'history'],
-        ['assistant', '서버에는 답변이 저장됐습니다.', 'history'],
-      ])
-      expect(keeperActionErrors.value.echo).toBeNull()
-    } finally {
-      vi.useRealTimers()
-    }
+    const thread = keeperThreads.value.echo ?? []
+    expect(thread.map(entry => [entry.role, entry.text, entry.delivery])).toEqual([
+      ['user', '진행 상황?', 'history'],
+      ['assistant', '서버에는 답변이 저장됐습니다.', 'history'],
+    ])
+    expect(pendingKeeperChatRequestsForKeeper('echo')).toEqual([])
+    expect(keeperActionErrors.value.echo).toBeNull()
+  })
+
+  it('does not reconcile a failed direct request with autonomous activity', async () => {
+    streamKeeperMessage.mockImplementation(async (
+      _name: string,
+      _message: string,
+      opts: { onEvent: (event: KeeperChatStreamEvent) => void },
+    ) => {
+      opts.onEvent({
+        type: 'CUSTOM',
+        name: 'KEEPER_QUEUE_REQUEST',
+        value: { request_id: 'kmsg_echo_1', status: 'queued' },
+      })
+      throw new TypeError('network error')
+    })
+    fetchKeeperChatHistory.mockResolvedValue([
+      {
+        role: 'user',
+        content: '진행 상황?',
+        ts: 1_781_528_918,
+        delivery_key: { kind: 'direct_request', request_id: 'kmsg_echo_1' },
+      },
+      {
+        role: 'assistant',
+        content: 'unrelated autonomous result',
+        ts: 1_781_528_920,
+        kind: 'autonomous_activity',
+        delivery_key: {
+          kind: 'autonomous_turn',
+          turn_ref: 'trace-autonomous#42',
+        },
+      },
+    ])
+
+    await expect(sendKeeperThreadMessage('echo', '진행 상황?'))
+      .rejects.toThrow('network error')
+
+    const thread = keeperThreads.value.echo ?? []
+    expect(thread.some(entry => (
+      entry.role === 'assistant' && entry.text === 'unrelated autonomous result'
+    ))).toBe(false)
+    expect(keeperActionErrors.value.echo).toContain('network error')
   })
 
   it('resumes a pending request from storage and finalizes the transcript', async () => {

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -475,10 +475,13 @@ function pendingAssistantEntryId(requestId: string): string {
   return `pending-assistant-${requestId}`
 }
 
-// The live-send placeholders are appended before the server mints the
-// request id; once KEEPER_QUEUE_REQUEST arrives, stamp it onto both rows so
-// a later history merge can reconcile the turn by requestId even when the
-// stream dies before the reply text lands.
+function mintKeeperChatRequestId(): string {
+  return `kmsg-client-${globalThis.crypto.randomUUID()}`
+}
+
+// The live-send placeholders carry the caller-owned canonical request id
+// before the SSE body starts. KEEPER_QUEUE_REQUEST re-stamps the accepted
+// server identity so history reconciliation remains exact if the stream dies.
 function stampPlaceholderRequestId(keeperName: string, entryIds: string[], requestId: string): void {
   for (const entryId of entryIds) {
     updateThreadEntry(keeperName, entryId, entry => (
@@ -1545,6 +1548,12 @@ export async function sendKeeperThreadMessage(
   setRecordValue(keeperStreamStartedAt, keeperName, Date.now())
   const controller = new AbortController()
   setActiveStream(keeperName, assistantId, controller)
+  const recoveryRequestId = mintKeeperChatRequestId()
+  stampPlaceholderRequestId(
+    keeperName,
+    [localId, assistantId],
+    recoveryRequestId,
+  )
   let requestId: string | null = null
   let requestTerminalSeen = false
   let toolCallEnded = false
@@ -1553,6 +1562,7 @@ export async function sendKeeperThreadMessage(
 
     const outcome = await streamKeeperMessage(keeperName, message, {
       signal: controller.signal,
+      requestId: recoveryRequestId,
       attachments,
       userBlocks,
       onEvent: event => {
@@ -1811,7 +1821,7 @@ export async function sendKeeperThreadMessage(
     try {
       const reconciled = await reconcileStreamFailureFromServerHistory(
         keeperName,
-        requestId,
+        requestId ?? recoveryRequestId,
         localId,
         assistantId,
       )

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -444,6 +444,7 @@ function hasServerAssistantForRequest(
   const expectedRequestId = requestId.trim()
   return expectedRequestId !== '' && entries.some(entry => (
     entry.role === 'assistant'
+    && entry.delivery === 'history'
     && entry.requestId?.trim() === expectedRequestId
   ))
 }

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -432,62 +432,32 @@ const QUEUED_KEEPER_REQUEST_LOST_MESSAGE =
   '서버 재시작으로 대기 중이던 요청을 찾을 수 없습니다. 메시지를 다시 보내주세요.'
 const PENDING_KEEPER_CHAT_RESUME_FAILED_MESSAGE =
   '응답을 확인할 수 없어 메시지 복구를 중단했습니다. 다시 보내주세요.'
-const STREAM_FAILURE_HISTORY_SKEW_MS = 30_000
 
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
-function entryTimeMs(entry: KeeperConversationEntry): number | null {
-  if (!entry.timestamp) return null
-  const ms = Date.parse(entry.timestamp)
-  return Number.isFinite(ms) ? ms : null
-}
-
-function hasServerAssistantAfterLocalMessage(
+function hasServerAssistantForRequest(
   entries: readonly KeeperConversationEntry[],
-  message: string,
-  sentAtMs: number | null,
+  requestId: string,
 ): boolean {
-  const expectedText = message.trim()
-  if (!expectedText) return false
-  let matchedUser = false
-
-  for (const entry of entries) {
-    const tsMs = entryTimeMs(entry)
-    if (
-      sentAtMs !== null
-      && tsMs !== null
-      && tsMs < sentAtMs - STREAM_FAILURE_HISTORY_SKEW_MS
-    ) {
-      continue
-    }
-
-    if (entry.role === 'user' && entry.text.trim() === expectedText) {
-      matchedUser = true
-      continue
-    }
-
-    if (matchedUser && entry.role === 'assistant' && entry.text.trim() !== '') {
-      return true
-    }
-  }
-
-  return false
+  const expectedRequestId = requestId.trim()
+  return expectedRequestId !== '' && entries.some(entry => (
+    entry.role === 'assistant'
+    && entry.requestId?.trim() === expectedRequestId
+  ))
 }
 
 async function reconcileStreamFailureFromServerHistory(
   keeperName: string,
-  message: string,
+  requestId: string | null,
   localUserId: string,
   localAssistantId: string,
 ): Promise<boolean> {
-  const localUser = (keeperThreads.value[keeperName] ?? [])
-    .find(entry => entry.id === localUserId) ?? null
-  const sentAtMs = localUser ? entryTimeMs(localUser) : null
+  if (!requestId) return false
   const history = await fetchKeeperChatHistory(keeperName)
   const historyEntries = chatHistoryEntriesFromRest(keeperName, history)
-  if (!hasServerAssistantAfterLocalMessage(historyEntries, message, sentAtMs)) {
+  if (!hasServerAssistantForRequest(historyEntries, requestId)) {
     return false
   }
 
@@ -1840,11 +1810,15 @@ export async function sendKeeperThreadMessage(
     try {
       const reconciled = await reconcileStreamFailureFromServerHistory(
         keeperName,
-        message,
+        requestId,
         localId,
         assistantId,
       )
       if (reconciled) {
+        if (requestId) {
+          removePendingKeeperChatRequest(requestId)
+          releaseActiveStreamRequestId(requestId)
+        }
         setRecordValue(keeperActionErrors, keeperName, null)
         return
       }

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -631,6 +631,29 @@ describe('thread history merge & persistence', () => {
     expect(entries[1]?.externalMessageId).toBe('message-1')
   })
 
+  it('maps an agent-surface assistant row to visible autonomous activity', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      {
+        role: 'assistant',
+        content: 'task-119 구현 및 검증 완료',
+        ts: 1_780_000_001,
+        kind: 'autonomous_activity',
+        turn_ref: 'trace-autonomous#42',
+        delivery_key: {
+          kind: 'autonomous_turn',
+          turn_ref: 'trace-autonomous#42',
+        },
+        surface: { kind: 'agent' },
+      },
+    ])
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.source).toBe('autonomous_activity')
+    expect(entries[0]?.surface).toEqual({ kind: 'agent' })
+    expect(entries[0]?.turnRef).toBe('trace-autonomous#42')
+    expect(isDefaultVisibleConversationEntry(entries[0]!)).toBe(true)
+  })
+
   it('prefers backend stream contracts from REST chat history', () => {
     const entries = chatHistoryEntriesFromRest('echo', [
       {

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -109,6 +109,7 @@ function normalizeConversationSource(
   if (
     source === 'direct_user'
     || source === 'direct_assistant'
+    || source === 'autonomous_activity'
     || source === 'world_state_prompt'
     || source === 'internal_assistant'
     || source === 'tool_result'
@@ -903,7 +904,16 @@ function normalizeHistoryEntry(
   // particular, persisted thinking/trace/fusion blocks may intentionally have
   // no visible `content`; rejecting them here erased completed work on reload.
   if (!rawText && !attachments?.length && !audio && !hasRenderableBlocks) return null
-  const source = normalizeConversationSource(raw.source, role, rawText, previousSource)
+  const declaredSource =
+    role === 'assistant' && asString(raw.kind) === 'autonomous_activity'
+      ? 'autonomous_activity'
+      : raw.source
+  const source = normalizeConversationSource(
+    declaredSource,
+    role,
+    rawText,
+    previousSource,
+  )
   const text = formatKeeperVisibleReply(rawText)
   if (!text && !attachments?.length && !audio && !hasRenderableBlocks) return null
   const timestamp = toIsoTimestamp(raw.ts_unix) ?? toIsoTimestamp(raw.timestamp)

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -1672,6 +1672,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   background: var(--color-bg-surface); border: 1px solid var(--color-border-default);
 }
 .kw-src-badge.world    { color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); }
+.kw-src-badge.autonomous { color: var(--color-status-ok); border-color: rgb(var(--color-status-ok-glow) / 0.4); }
 .kw-src-badge.internal { color: var(--color-fg-muted); }
 .kw-src-badge.tool     { color: var(--color-status-ok); border-color: rgb(var(--color-status-ok-glow) / 0.4); }
 .kw-src-badge.system   { color: var(--color-status-warn); border-color: rgb(var(--color-status-warn-glow) / 0.4); }

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -641,6 +641,7 @@ export const SYSTEM_ACTOR_NAME = 'system' as const
 export type KeeperConversationSource =
   | 'direct_user'
   | 'direct_assistant'
+  | 'autonomous_activity'
   | 'world_state_prompt'
   | 'internal_assistant'
   | 'tool_result'

--- a/lib/keeper/keeper_agent_result.ml
+++ b/lib/keeper/keeper_agent_result.ml
@@ -80,6 +80,7 @@ type run_result =
   ; usage : Agent_sdk.Types.api_usage
   ; usage_reported : bool
   ; tool_calls : tool_call_detail list
+  ; turn_effect_record : Keeper_run_prompt.turn_effect_record
   ; completion_contract_result : Keeper_execution_receipt.completion_contract_result
   ; operator_disposition : operator_disposition option
   ; checkpoint : Agent_sdk.Checkpoint.t option

--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -35,6 +35,7 @@ type run_result =
   ; usage : Agent_sdk.Types.api_usage
   ; usage_reported : bool
   ; tool_calls : tool_call_detail list
+  ; turn_effect_record : Keeper_run_prompt.turn_effect_record
   ; completion_contract_result : Keeper_execution_receipt.completion_contract_result
   ; operator_disposition : operator_disposition option
   ; checkpoint : Agent_sdk.Checkpoint.t option

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -483,6 +483,7 @@ let finalize
       ; usage
       ; usage_reported = Option.is_some result.response.usage
       ; tool_calls = List.rev acc.tool_calls
+      ; turn_effect_record
       ; completion_contract_result
       ; operator_disposition = None
       ; checkpoint = saved_checkpoint

--- a/lib/keeper/keeper_autonomous_chat_projection.ml
+++ b/lib/keeper/keeper_autonomous_chat_projection.ml
@@ -1,0 +1,233 @@
+type intent =
+  { keeper_name : string
+  ; turn_ref : Ids.Turn_ref.t
+  ; content : string
+  }
+
+type append_result =
+  | Appended
+  | Already_present
+
+type issue_stage =
+  | Load_pending
+  | Persist_intent
+  | Append_chat
+  | Retire_intent
+
+type issue =
+  { stage : issue_stage
+  ; detail : string
+  }
+
+type io =
+  { load_pending : unit -> (intent list, string) result
+  ; persist : intent -> (unit, string) result
+  ; append : intent -> (append_result, string) result
+  ; retire : intent -> (unit, string) result
+  ; broadcast : intent -> unit
+  }
+
+let ( let* ) = Result.bind
+let schema = "masc.keeper.autonomous-chat-projection.v1"
+
+let issue_stage_to_string = function
+  | Load_pending -> "load_pending"
+  | Persist_intent -> "persist_intent"
+  | Append_chat -> "append_chat"
+  | Retire_intent -> "retire_intent"
+;;
+
+let issue_to_string issue =
+  Printf.sprintf "%s: %s" (issue_stage_to_string issue.stage) issue.detail
+;;
+
+let validate intent =
+  if String.trim intent.keeper_name = ""
+  then Error "projection keeper name must not be blank"
+  else if String.trim intent.content = ""
+  then Error "projection content must not be blank"
+  else Ok ()
+;;
+
+let to_yojson intent =
+  `Assoc
+    [ "schema", `String schema
+    ; "keeper_name", `String intent.keeper_name
+    ; "turn_ref", `String (Ids.Turn_ref.to_string intent.turn_ref)
+    ; "content", `String intent.content
+    ]
+;;
+
+let of_yojson = function
+  | `Assoc fields ->
+    let keys = fields |> List.map fst |> List.sort String.compare in
+    let expected =
+      [ "content"; "keeper_name"; "schema"; "turn_ref" ]
+    in
+    if keys <> expected
+    then Error "projection intent fields are not exact"
+    else
+      (match
+         List.assoc "schema" fields,
+         List.assoc "keeper_name" fields,
+         List.assoc "turn_ref" fields,
+         List.assoc "content" fields
+       with
+       | `String actual_schema, `String keeper_name, `String turn_ref, `String content
+         when String.equal actual_schema schema ->
+         (match Ids.Turn_ref.of_string turn_ref with
+          | None -> Error "projection intent turn_ref is invalid"
+          | Some turn_ref ->
+            let intent = { keeper_name; turn_ref; content } in
+            let* () = validate intent in
+            Ok intent)
+       | `String _, _, _, _ -> Error "projection intent schema is unsupported"
+       | _ -> Error "projection intent fields have invalid types")
+  | _ -> Error "projection intent must be a JSON object"
+;;
+
+let project_persisted io intent =
+  match io.append intent with
+  | Error detail -> [ { stage = Append_chat; detail } ]
+  | Ok append_result ->
+    (match append_result with
+     | Appended -> io.broadcast intent
+     | Already_present -> ());
+    (match io.retire intent with
+     | Ok () -> []
+     | Error detail -> [ { stage = Retire_intent; detail } ])
+;;
+
+let record_and_project io intent =
+  match validate intent with
+  | Error detail -> [ { stage = Persist_intent; detail } ]
+  | Ok () ->
+    (match io.persist intent with
+     | Error detail -> [ { stage = Persist_intent; detail } ]
+     | Ok () -> project_persisted io intent)
+;;
+
+let retry_pending io =
+  match io.load_pending () with
+  | Error detail -> [ { stage = Load_pending; detail } ]
+  | Ok intents ->
+    List.concat_map (project_persisted io) intents
+;;
+
+let sha256 value = Digestif.SHA256.(digest_string value |> to_hex)
+
+let root_dir base_dir =
+  Filename.concat
+    (Common.masc_dir_from_base_path ~base_path:base_dir)
+    "keeper-chat-projections-v1"
+;;
+
+let keeper_dir ~base_dir keeper_name =
+  Filename.concat
+    (root_dir base_dir)
+    ("keeper-" ^ sha256 keeper_name)
+;;
+
+let intent_path ~base_dir intent =
+  Filename.concat
+    (keeper_dir ~base_dir intent.keeper_name)
+    (sha256 (Ids.Turn_ref.to_string intent.turn_ref) ^ ".json")
+;;
+
+let ensure_projection_dir ~base_dir keeper_name =
+  try
+    ignore (Keeper_fs.ensure_dir (keeper_dir ~base_dir keeper_name) : string);
+    Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printexc.to_string exn)
+;;
+
+let load_intent path =
+  let* json = Safe_ops.read_json_file_safe path in
+  of_yojson json
+;;
+
+let production_io ~base_dir ~keeper_name =
+  let load_pending () =
+    let dir = keeper_dir ~base_dir keeper_name in
+    if not (Fs_compat.file_exists dir)
+    then Ok []
+    else
+      try
+        let names = Fs_compat.read_dir dir in
+        let unexpected =
+          List.find_opt
+            (fun name -> not (String.equal (Filename.extension name) ".json"))
+            names
+        in
+        let* () =
+          match unexpected with
+          | None -> Ok ()
+          | Some name ->
+            Error
+              (Printf.sprintf
+                 "projection outbox contains unexpected entry %S"
+                 name)
+        in
+        let paths =
+          names
+          |> List.sort String.compare
+          |> List.map (Filename.concat dir)
+        in
+        let rec load acc = function
+          | [] -> Ok (List.rev acc)
+          | path :: rest ->
+            let* intent = load_intent path in
+            if String.equal intent.keeper_name keeper_name
+            then load (intent :: acc) rest
+            else Error "projection intent keeper does not match its directory"
+        in
+        load [] paths
+      with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | exn -> Error (Printexc.to_string exn)
+  in
+  let persist intent =
+    let* () = ensure_projection_dir ~base_dir intent.keeper_name in
+    Keeper_fs.save_json_durable_atomic
+      ~ownership_root:(root_dir base_dir)
+      ~pretty:false
+      (intent_path ~base_dir intent)
+      (to_yojson intent)
+    |> Result.map_error Keeper_fs.durable_write_error_to_string
+  in
+  let append intent =
+    let turn_ref = intent.turn_ref in
+    let delivery_key =
+      Keeper_chat_delivery_identity.Autonomous_turn turn_ref
+    in
+    Keeper_chat_store.append_assistant_message_once
+      ~base_dir
+      ~keeper_name:intent.keeper_name
+      ~delivery_key
+      ~content:intent.content
+      ~surface:Surface_ref.Agent
+      ~assistant_kind:Keeper_chat_store.Row_kind.Autonomous_activity
+      ~blocks:(Keeper_chat_blocks.parse_text_to_blocks intent.content)
+      ~turn_ref
+      ()
+    |> Result.map (function
+      | Keeper_chat_store.Appended _ -> Appended
+      | Keeper_chat_store.Already_present _ -> Already_present)
+  in
+  let retire intent =
+    Keeper_fs.remove_file_durable
+      ~ownership_root:(root_dir base_dir)
+      (intent_path ~base_dir intent)
+    |> Result.map_error Keeper_fs.durable_remove_error_to_string
+  in
+  let broadcast intent =
+    Keeper_chat_broadcast.chat_appended
+      ~keeper_name:intent.keeper_name
+      ~source:(Surface_ref.lane_label Surface_ref.Agent)
+      ~content:intent.content
+      ()
+  in
+  { load_pending; persist; append; retire; broadcast }
+;;

--- a/lib/keeper/keeper_autonomous_chat_projection.ml
+++ b/lib/keeper/keeper_autonomous_chat_projection.ml
@@ -5,7 +5,7 @@ type intent =
   }
 
 type append_result =
-  | Appended
+  | Appended of intent
   | Already_present
 
 type issue_stage =
@@ -19,8 +19,13 @@ type issue =
   ; detail : string
   }
 
+type pending_batch =
+  { intents : intent list
+  ; issues : string list
+  }
+
 type io =
-  { load_pending : unit -> (intent list, string) result
+  { load_pending : unit -> (pending_batch, string) result
   ; persist : intent -> (unit, string) result
   ; append : intent -> (append_result, string) result
   ; retire : intent -> (unit, string) result
@@ -91,7 +96,7 @@ let project_persisted io intent =
   | Error detail -> [ { stage = Append_chat; detail } ]
   | Ok append_result ->
     (match append_result with
-     | Appended -> io.broadcast intent
+     | Appended appended_intent -> io.broadcast appended_intent
      | Already_present -> ());
     (match io.retire intent with
      | Ok () -> []
@@ -107,11 +112,38 @@ let record_and_project io intent =
      | Ok () -> project_persisted io intent)
 ;;
 
+let order_pending intents =
+  let compare_intent left right =
+    Int.compare
+      (Ids.Turn_ref.absolute_turn left.turn_ref)
+      (Ids.Turn_ref.absolute_turn right.turn_ref)
+  in
+  let intents = List.sort compare_intent intents in
+  let rec reject_ambiguous_order = function
+    | left :: right :: _
+      when Ids.Turn_ref.absolute_turn left.turn_ref
+           = Ids.Turn_ref.absolute_turn right.turn_ref ->
+      Error
+        (Printf.sprintf
+           "projection intents have ambiguous absolute turn %d"
+           (Ids.Turn_ref.absolute_turn left.turn_ref))
+    | _ :: rest -> reject_ambiguous_order rest
+    | [] -> Ok intents
+  in
+  reject_ambiguous_order intents
+;;
+
 let retry_pending io =
   match io.load_pending () with
   | Error detail -> [ { stage = Load_pending; detail } ]
-  | Ok intents ->
-    List.concat_map (project_persisted io) intents
+  | Ok { intents; issues } ->
+    let load_issues =
+      List.map (fun detail -> { stage = Load_pending; detail }) issues
+    in
+    (match order_pending intents with
+     | Error detail -> load_issues @ [ { stage = Load_pending; detail } ]
+     | Ok intents ->
+       load_issues @ List.concat_map (project_persisted io) intents)
 ;;
 
 let sha256 value = Digestif.SHA256.(digest_string value |> to_hex)
@@ -153,38 +185,48 @@ let production_io ~base_dir ~keeper_name =
   let load_pending () =
     let dir = keeper_dir ~base_dir keeper_name in
     if not (Fs_compat.file_exists dir)
-    then Ok []
+    then Ok { intents = []; issues = [] }
     else
       try
         let names = Fs_compat.read_dir dir in
-        let unexpected =
-          List.find_opt
-            (fun name -> not (String.equal (Filename.extension name) ".json"))
-            names
+        let rec load intents issues = function
+          | [] -> Ok { intents; issues = List.rev issues }
+          | name :: rest ->
+            if not (String.equal (Filename.extension name) ".json")
+            then
+              load
+                intents
+                (Printf.sprintf
+                   "projection outbox contains unexpected entry %S"
+                   name
+                 :: issues)
+                rest
+            else
+              let path = Filename.concat dir name in
+              (match load_intent path with
+               | Error detail ->
+                 load
+                   intents
+                   (Printf.sprintf
+                      "projection outbox entry %S is invalid: %s"
+                      name
+                      detail
+                    :: issues)
+                   rest
+               | Ok intent ->
+                 if String.equal intent.keeper_name keeper_name
+                 then load (intent :: intents) issues rest
+                 else
+                   load
+                     intents
+                     (Printf.sprintf
+                        "projection outbox entry %S belongs to keeper %S"
+                        name
+                        intent.keeper_name
+                      :: issues)
+                     rest)
         in
-        let* () =
-          match unexpected with
-          | None -> Ok ()
-          | Some name ->
-            Error
-              (Printf.sprintf
-                 "projection outbox contains unexpected entry %S"
-                 name)
-        in
-        let paths =
-          names
-          |> List.sort String.compare
-          |> List.map (Filename.concat dir)
-        in
-        let rec load acc = function
-          | [] -> Ok (List.rev acc)
-          | path :: rest ->
-            let* intent = load_intent path in
-            if String.equal intent.keeper_name keeper_name
-            then load (intent :: acc) rest
-            else Error "projection intent keeper does not match its directory"
-        in
-        load [] paths
+        load [] [] names
       with
       | Eio.Cancel.Cancelled _ as exn -> raise exn
       | exn -> Error (Printexc.to_string exn)
@@ -199,22 +241,32 @@ let production_io ~base_dir ~keeper_name =
     |> Result.map_error Keeper_fs.durable_write_error_to_string
   in
   let append intent =
-    let turn_ref = intent.turn_ref in
+    let redaction =
+      Keeper_secret_redaction.snapshot
+        ~base_path:base_dir
+        ~keeper_name:intent.keeper_name
+    in
+    let appended_intent =
+      { intent with
+        content = Keeper_secret_redaction.redact_text redaction intent.content
+      }
+    in
+    let turn_ref = appended_intent.turn_ref in
     let delivery_key =
       Keeper_chat_delivery_identity.Autonomous_turn turn_ref
     in
     Keeper_chat_store.append_assistant_message_once
       ~base_dir
-      ~keeper_name:intent.keeper_name
+      ~keeper_name:appended_intent.keeper_name
       ~delivery_key
-      ~content:intent.content
+      ~content:appended_intent.content
       ~surface:Surface_ref.Agent
       ~assistant_kind:Keeper_chat_store.Row_kind.Autonomous_activity
-      ~blocks:(Keeper_chat_blocks.parse_text_to_blocks intent.content)
+      ~blocks:(Keeper_chat_blocks.parse_text_to_blocks appended_intent.content)
       ~turn_ref
       ()
     |> Result.map (function
-      | Keeper_chat_store.Appended _ -> Appended
+      | Keeper_chat_store.Appended _ -> Appended appended_intent
       | Keeper_chat_store.Already_present _ -> Already_present)
   in
   let retire intent =

--- a/lib/keeper/keeper_autonomous_chat_projection.ml
+++ b/lib/keeper/keeper_autonomous_chat_projection.ml
@@ -136,6 +136,7 @@ let intent_path ~base_dir intent =
 
 let ensure_projection_dir ~base_dir keeper_name =
   try
+    (* fire-and-forget: only the durable directory side effect is needed. *)
     ignore (Keeper_fs.ensure_dir (keeper_dir ~base_dir keeper_name) : string);
     Ok ()
   with

--- a/lib/keeper/keeper_autonomous_chat_projection.mli
+++ b/lib/keeper/keeper_autonomous_chat_projection.mli
@@ -5,7 +5,7 @@ type intent =
   }
 
 type append_result =
-  | Appended
+  | Appended of intent
   | Already_present
 
 type issue_stage =
@@ -19,8 +19,13 @@ type issue =
   ; detail : string
   }
 
+type pending_batch =
+  { intents : intent list
+  ; issues : string list
+  }
+
 type io =
-  { load_pending : unit -> (intent list, string) result
+  { load_pending : unit -> (pending_batch, string) result
   ; persist : intent -> (unit, string) result
   ; append : intent -> (append_result, string) result
   ; retire : intent -> (unit, string) result
@@ -34,8 +39,10 @@ val issue_to_string : issue -> string
     failure leaves the intent durable for {!retry_pending}. *)
 val record_and_project : io -> intent -> issue list
 
-(** Retry all durable intents. Chat append is idempotent by [turn_ref], so a
-    crash after append but before retirement cannot duplicate the row. *)
+(** Retry all valid durable intents in exact absolute-turn order. Invalid
+    entries are reported independently without blocking valid intents. Chat
+    append is idempotent by [turn_ref], so a crash after append but before
+    retirement cannot duplicate the row. *)
 val retry_pending : io -> issue list
 
 val production_io : base_dir:string -> keeper_name:string -> io

--- a/lib/keeper/keeper_autonomous_chat_projection.mli
+++ b/lib/keeper/keeper_autonomous_chat_projection.mli
@@ -1,0 +1,41 @@
+type intent =
+  { keeper_name : string
+  ; turn_ref : Ids.Turn_ref.t
+  ; content : string
+  }
+
+type append_result =
+  | Appended
+  | Already_present
+
+type issue_stage =
+  | Load_pending
+  | Persist_intent
+  | Append_chat
+  | Retire_intent
+
+type issue =
+  { stage : issue_stage
+  ; detail : string
+  }
+
+type io =
+  { load_pending : unit -> (intent list, string) result
+  ; persist : intent -> (unit, string) result
+  ; append : intent -> (append_result, string) result
+  ; retire : intent -> (unit, string) result
+  ; broadcast : intent -> unit
+  }
+
+val issue_stage_to_string : issue_stage -> string
+val issue_to_string : issue -> string
+
+(** Persist the exact intent before attempting the chat append. An append
+    failure leaves the intent durable for {!retry_pending}. *)
+val record_and_project : io -> intent -> issue list
+
+(** Retry all durable intents. Chat append is idempotent by [turn_ref], so a
+    crash after append but before retirement cannot duplicate the row. *)
+val retry_pending : io -> issue list
+
+val production_io : base_dir:string -> keeper_name:string -> io

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -92,29 +92,34 @@ end
    [Utterance] is something the keeper actually said; [Transport_failure]
    is the server persisting a failed request terminal ("Keeper request
    failed: ...") so the operator still sees the failure after a reload.
-   Readers branch on the type: a transport failure is not a self reply —
-   it does not advance the lane watermark, so the user line it failed to
-   answer stays pending until the keeper's next real utterance — and it
-   is never quoted back as the keeper's own words. On disk the field is
-   ["kind"], absent for utterances so pre-existing rows read unchanged. *)
+   [Autonomous_activity] is a Keeper-initiated work result shown to the
+   operator, not a reply to any pending user row. Readers branch on the type:
+   only utterances advance the lane watermark or enter direct-conversation
+   context. On disk the field is ["kind"], absent for utterances so
+   pre-existing rows read unchanged. *)
 module Row_kind = struct
   type t =
     | Utterance
     | Transport_failure
+    | Autonomous_activity
 
   let to_label = function
     | Utterance -> "utterance"
     | Transport_failure -> "transport_failure"
+    | Autonomous_activity -> "autonomous_activity"
 
   let of_label = function
     | "utterance" -> Some Utterance
     | "transport_failure" -> Some Transport_failure
+    | "autonomous_activity" -> Some Autonomous_activity
     | _ -> None
 
   let equal a b =
     match a, b with
-    | Utterance, Utterance | Transport_failure, Transport_failure -> true
-    | (Utterance | Transport_failure), _ -> false
+    | Utterance, Utterance
+    | Transport_failure, Transport_failure
+    | Autonomous_activity, Autonomous_activity -> true
+    | (Utterance | Transport_failure | Autonomous_activity), _ -> false
 end
 
 type stream_lifecycle_event =
@@ -572,7 +577,7 @@ let encode_line ~(role : Role.t) ~content ~ts ?message_id ?attachments ?tool_cal
   let kind_field =
     match kind with
     | Row_kind.Utterance -> []
-    | Row_kind.Transport_failure ->
+    | Row_kind.Transport_failure | Row_kind.Autonomous_activity ->
         [ ("kind", `String (Row_kind.to_label kind)) ]
   in
   let all_fields =
@@ -1917,7 +1922,7 @@ let to_json_array ?base_dir ?trace_block_by_turn_ref
                  failure apart from keeper speech. *)
               @ (match m.kind with
                  | Row_kind.Utterance -> []
-                 | Row_kind.Transport_failure ->
+                 | Row_kind.Transport_failure | Row_kind.Autonomous_activity ->
                      [ ("kind", `String (Row_kind.to_label m.kind)) ])
               @ opt_string_field "tool_call_id" m.tool_call_id
               @ opt_string_field "tool_call_name" m.tool_call_name
@@ -2009,7 +2014,7 @@ let transcript_line_to_json (m : chat_message) : Yojson.Safe.t =
          back as the keeper's own words. *)
     @ (match m.kind with
        | Row_kind.Utterance -> []
-       | Row_kind.Transport_failure ->
+       | Row_kind.Transport_failure | Row_kind.Autonomous_activity ->
            [ ("kind", `String (Row_kind.to_label m.kind)) ]))
 
 let turn_transcript_to_json ~keeper ~turn_ref (t : turn_transcript) :

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -1716,6 +1716,21 @@ let load_page ~base_dir ~keeper_name ?before () : page =
       let popped = Queue.pop q in
       if not (is_tool_message popped) then decr primary_count
     in
+    let same_timestamp (left : chat_message) (right : chat_message) =
+      match left.ts, right.ts with
+      | Some left, Some right -> Float.equal left right
+      | None, None -> true
+      | Some _, None | None, Some _ -> false
+    in
+    let evict_oldest_timestamp_group () =
+      let oldest = Queue.peek q in
+      while
+        not (Queue.is_empty q)
+        && same_timestamp (Queue.peek q) oldest
+      do
+        pop_front ()
+      done
+    in
     List.iter
       (fun line ->
         let trimmed = String.trim line in
@@ -1725,10 +1740,11 @@ let load_page ~base_dir ~keeper_name ?before () : page =
               Queue.push msg q;
               if not (is_tool_message msg) then incr primary_count;
               while
-                !primary_count > max_history
-                || Queue.length q > max_total_lines
+                (!primary_count > max_history
+                 || Queue.length q > max_total_lines)
+                && not (same_timestamp (Queue.peek q) msg)
               do
-                pop_front ()
+                evict_oldest_timestamp_group ()
               done
           | Some _ | None -> ())
       (slice_lines ~path ~from ~upto);

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -4,11 +4,13 @@
     Lines are append-only with timestamps.
 
     Line format:
-    {v {"id":"msg-...","role":"user","content":"hello","ts":1774000000.0} v}
+    {v {"id":"msg-...","role":"user","kind":"utterance",
+        "content":"hello","ts":1774000000.0} v}
 
     Tool-call lines (persisted between the user and assistant lines of a
     turn) carry the executed tool name and accumulated arguments:
-    {v {"id":"msg-...","role":"tool","content":"{\"path\":\"x\"}","ts":...,
+    {v {"id":"msg-...","role":"tool","kind":"utterance",
+        "content":"{\"path\":\"x\"}","ts":...,
         "tool_call_id":"toolu_1","tool_call_name":"Read",
         "surface":{"kind":"dashboard"}} v}
 
@@ -95,8 +97,7 @@ end
    [Autonomous_activity] is a Keeper-initiated work result shown to the
    operator, not a reply to any pending user row. Readers branch on the type:
    only utterances advance the lane watermark or enter direct-conversation
-   context. On disk the field is ["kind"], absent for utterances so
-   pre-existing rows read unchanged. *)
+   context. On disk the field is the required ["kind"]. *)
 module Row_kind = struct
   type t =
     | Utterance
@@ -216,11 +217,8 @@ type chat_message = {
          written before P4 lack the field and read as []; the offline
          backfill tool stamps them. *)
   kind : Row_kind.t;
-      (* Declared by the writer at append.  Absent field (every row
-         written before this field existed) reads as [Utterance]; an
-         unknown label is reported as a persistence read drop and the
-         row reads as [Utterance] (the conservative arm: it renders and
-         advances the watermark like any reply). *)
+      (* Declared by the writer at append. Missing and unknown labels are
+         reported as invalid payloads and the row is rejected. *)
   turn_ref : Ids.Turn_ref.t option;
       (* RFC-0233 §7: "<trace_id>#<absolute_turn>" join key for the turn
          that produced this row.  Stamped by [append_turn] /
@@ -572,14 +570,7 @@ let encode_line ~(role : Role.t) ~content ~ts ?message_id ?attachments ?tool_cal
         ) atts in
         [("attachments", `List att_json)]
   in
-  (* Utterance is the absent-field default so rows written before the
-     [kind] field existed and ordinary rows stay byte-identical. *)
-  let kind_field =
-    match kind with
-    | Row_kind.Utterance -> []
-    | Row_kind.Transport_failure | Row_kind.Autonomous_activity ->
-        [ ("kind", `String (Row_kind.to_label kind)) ]
-  in
+  let kind_field = [ ("kind", `String (Row_kind.to_label kind)) ] in
   let all_fields =
     base_fields
     @ attachment_fields
@@ -1490,22 +1481,22 @@ let parse_line ~file_path (line : string) : chat_message option =
               None)
     in
     let kind =
-      (* Absent field = every row written before [kind] existed; all of
-         those are utterances. Unknown labels are surfaced and read as
-         [Utterance] — the conservative arm (renders and advances the
-         watermark like any reply) rather than silently resurrecting a
-         pending user line. *)
       match opt_string "kind" with
-      | None -> Row_kind.Utterance
+      | None ->
+          report_persistence_read_drop
+            ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+            ~path:file_path
+            ~detail:"chat row missing kind";
+          None
       | Some label -> (
           match Row_kind.of_label label with
-          | Some kind -> kind
+          | Some kind -> Some kind
           | None ->
               report_persistence_read_drop
                 ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
                 ~path:file_path
                 ~detail:(Printf.sprintf "unknown chat row kind %S" label);
-              Row_kind.Utterance)
+              None)
     in
     let turn_ref =
       (* RFC-0233 §7: parse the join key; a malformed value is surfaced as
@@ -1558,8 +1549,9 @@ let parse_line ~file_path (line : string) : chat_message option =
         ~detail:"chat row missing role and readable text/structured payload";
       None)
     else
-      match Role.of_label role_label with
-      | None ->
+      match kind, Role.of_label role_label with
+      | None, _ -> None
+      | Some _, None ->
           (* RFC-0232 P1: an unknown role cannot participate in any lane
              semantics (watermark, pending, rendering); surface it
              instead of carrying an untyped row. *)
@@ -1568,13 +1560,13 @@ let parse_line ~file_path (line : string) : chat_message option =
             ~path:file_path
             ~detail:(Printf.sprintf "unknown chat row role %S" role_label);
           None
-      | Some Role.Tool when tool_call_name = None ->
+      | Some _, Some Role.Tool when tool_call_name = None ->
           report_persistence_read_drop
             ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
             ~path:file_path
             ~detail:"tool chat row missing non-empty tool_call_name";
           None
-      | Some role ->
+      | Some kind, Some role ->
           (match opt_string "id" with
            | None ->
                report_persistence_read_drop
@@ -1917,13 +1909,7 @@ let to_json_array ?base_dir ?trace_block_by_turn_ref
             ] @ (match m.ts with
                  | Some t -> [("ts", `Float t)]
                  | None -> [])
-              (* Dashboard history: surface the writer-declared kind for
-                 non-utterance rows so a reload can tell a transport
-                 failure apart from keeper speech. *)
-              @ (match m.kind with
-                 | Row_kind.Utterance -> []
-                 | Row_kind.Transport_failure | Row_kind.Autonomous_activity ->
-                     [ ("kind", `String (Row_kind.to_label m.kind)) ])
+              @ [ ("kind", `String (Row_kind.to_label m.kind)) ]
               @ opt_string_field "tool_call_id" m.tool_call_id
               @ opt_string_field "tool_call_name" m.tool_call_name
               @ (match m.surface with
@@ -2008,14 +1994,7 @@ let transcript_line_to_json (m : chat_message) : Yojson.Safe.t =
        ("content", `String m.content);
      ]
     @ (match m.ts with Some t -> [ ("ts", `Float t) ] | None -> [])
-      (* Surface the writer-declared kind so the inspector can tell a
-         transport failure apart from a real keeper utterance, exactly as
-         the chat history endpoint does — a failure marker is never quoted
-         back as the keeper's own words. *)
-    @ (match m.kind with
-       | Row_kind.Utterance -> []
-       | Row_kind.Transport_failure | Row_kind.Autonomous_activity ->
-           [ ("kind", `String (Row_kind.to_label m.kind)) ]))
+    @ [ ("kind", `String (Row_kind.to_label m.kind)) ])
 
 let turn_transcript_to_json ~keeper ~turn_ref (t : turn_transcript) :
     Yojson.Safe.t =

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -59,12 +59,16 @@ end
     advance the lane watermark, so the user line it failed to answer
     stays pending until the keeper's next real utterance, and
     observation never quotes it back as the keeper's own words.
+    [Autonomous_activity] is a Keeper-initiated work result projected for
+    operator visibility. It renders in chat but is not a reply to a pending
+    user row and is not quoted back into direct-conversation context.
     Persisted as ["kind"]; the field is absent for utterances, so rows
     written before it existed read unchanged. *)
 module Row_kind : sig
   type t =
     | Utterance
     | Transport_failure
+    | Autonomous_activity
 
   val to_label : t -> string
   val of_label : string -> t option

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -428,6 +428,8 @@ type page = { messages : chat_message list; has_more : bool }
     returned window remain — walk backward by passing the oldest
     returned [ts] as the next [before]. Bounded I/O per call:
     binary-search probes plus one window slice, never a full scan.
+    A page never splits rows sharing its oldest timestamp, so an
+    exclusive [before] cursor cannot skip the other half of one turn.
     Legacy rows without [ts] are unreachable through paging (the tail
     window still serves them). *)
 val load_page :

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -62,8 +62,7 @@ end
     [Autonomous_activity] is a Keeper-initiated work result projected for
     operator visibility. It renders in chat but is not a reply to a pending
     user row and is not quoted back into direct-conversation context.
-    Persisted as ["kind"]; the field is absent for utterances, so rows
-    written before it existed read unchanged. *)
+    Persisted as a required ["kind"] field. *)
 module Row_kind : sig
   type t =
     | Utterance
@@ -188,11 +187,8 @@ type chat_message = {
           those).  Malformed persisted entries are reported as
           persistence read drops and skipped; the row stays valid. *)
   kind : Row_kind.t;
-      (** Declared by the writer at append.  Absent persisted field
-          (every row written before it existed) reads as [Utterance];
-          an unknown label is reported as a persistence read drop and
-          reads as [Utterance] — the conservative arm: the row renders
-          and advances the watermark like any reply. *)
+      (** Declared by the writer at append. A missing or unknown persisted
+          label is reported as an invalid payload and the row is rejected. *)
   turn_ref : Ids.Turn_ref.t option;
       (** RFC-0233 §7: ["<trace_id>#<absolute_turn>"] join key for the turn
           that produced this row.  Stamped by {!append_turn} /

--- a/lib/keeper/keeper_invocation_contract.ml
+++ b/lib/keeper/keeper_invocation_contract.ml
@@ -298,6 +298,12 @@ let delegate_submission_error_to_json request = function
     Keeper_msg_async.access_rejection_to_json rejection
   | Keeper_msg_async.Submit_invalid_keeper_name { reason } ->
     `Assoc [ "error", `String "invalid_target"; "message", `String reason ]
+  | Keeper_msg_async.Submit_request_id_conflict { request_id } ->
+    `Assoc
+      [ "error", `String "request_id_conflict"
+      ; "run_ref", run_ref_to_json (run_ref request request_id)
+      ; "message", `String "request id is already owned by another invocation"
+      ]
   | Keeper_msg_async.Initial_persistence_failed { reason } ->
     `Assoc [ "error", `String "invocation_persistence_failed"; "message", `String reason ]
   | Keeper_msg_async.Acceptance_persistence_failed { request_id; reason } ->

--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -147,6 +147,7 @@ and recovery_record_error_kind =
 type submit_error =
   | Submit_rejected of access_rejection
   | Submit_invalid_keeper_name of { reason : string }
+  | Submit_request_id_conflict of { request_id : string }
   | Initial_persistence_failed of { reason : string }
   | Acceptance_persistence_failed of
       { request_id : string
@@ -692,6 +693,12 @@ let submit_error_to_json = function
     `Assoc
       [ "error", `String "invalid_keeper_name"
       ; "message", `String reason
+      ]
+  | Submit_request_id_conflict { request_id } ->
+    `Assoc
+      [ "error", `String "request_id_conflict"
+      ; "request_id", `String request_id
+      ; "message", `String "request_id is already owned by another request"
       ]
   | Initial_persistence_failed { reason } ->
     `Assoc
@@ -1890,11 +1897,14 @@ let validate_request_store_root ~base_path =
          { reason = Fs_compat.owned_directory_chain_rejection_to_string rejection })
 ;;
 
-let reserve_new_request ~ops ~base_path ~submitted_by ~keeper_name =
-  let rec reserve () =
-    let request_id = ops.generate_request_id () in
+let reserve_new_request ~ops ?requested_request_id ~base_path ~submitted_by
+    ~keeper_name =
+  let rec reserve request_id =
     if not (is_safe_request_id request_id)
-    then reserve ()
+    then
+      (match requested_request_id with
+       | Some _ -> Error (`Rejected Invalid_request_id)
+       | None -> reserve (ops.generate_request_id ()))
     else
       match
         with_store_transition_lock ~base_path ~request_id (fun () ->
@@ -1934,12 +1944,21 @@ let reserve_new_request ~ops ~base_path ~submitted_by ~keeper_name =
           | Located_rejected rejection -> `Rejected rejection)
       with
       | `Reserved reserved -> Ok reserved
-      | `Collision -> reserve ()
-      | `Rejected rejection -> Error rejection
+      | `Collision ->
+        (match requested_request_id with
+         | Some _ -> Error (`Conflict request_id)
+         | None -> reserve (ops.generate_request_id ()))
+      | `Rejected rejection -> Error (`Rejected rejection)
   in
   match validate_request_store_root ~base_path with
-  | Ok () -> reserve ()
-  | Error _ as error -> error
+  | Ok () ->
+    let request_id =
+      match requested_request_id with
+      | Some request_id -> request_id
+      | None -> ops.generate_request_id ()
+    in
+    reserve request_id
+  | Error rejection -> Error (`Rejected rejection)
 ;;
 
 let remove_runtime_tables_if_owned ~release_reservation key transition_lock =
@@ -2158,8 +2177,8 @@ let runtime_cancelled_status () =
     "keeper_msg worker was cancelled by runtime before terminal result"
 ;;
 
-let submit_with_ops ops ?on_accepted ?on_worker_aborted ?on_worker_settled ~background_sw
-    ~base_path ~caller
+let submit_with_ops ops ?requested_request_id ?on_accepted ?on_worker_aborted
+    ?on_worker_settled ~background_sw ~base_path ~caller
     ~(f : request_id:string -> Eio.Switch.t -> tool_result)
     ~keeper_name () :
     (submit_outcome, submit_error) result =
@@ -2171,8 +2190,17 @@ let submit_with_ops ops ?on_accepted ?on_worker_aborted ?on_worker_settled ~back
      | Ok keeper_name_id ->
     let keeper_name = Keeper_id.Keeper_name.to_string keeper_name_id in
     with_keeper_submission_lock ~base_path ~keeper_name:keeper_name_id (fun () ->
-    match reserve_new_request ~ops ~base_path ~submitted_by ~keeper_name with
-    | Error rejection -> Error (Submit_rejected rejection)
+    match
+      reserve_new_request
+        ~ops
+        ?requested_request_id
+        ~base_path
+        ~submitted_by
+        ~keeper_name
+    with
+    | Error (`Rejected rejection) -> Error (Submit_rejected rejection)
+    | Error (`Conflict request_id) ->
+      Error (Submit_request_id_conflict { request_id })
     | Ok (request_id, entry, key, transition_lock) ->
     let reconciliation_outcome reason =
       Ok
@@ -2461,10 +2489,10 @@ let submit_with_ops ops ?on_accepted ?on_worker_aborted ?on_worker_settled ~back
 
 let submit_with_request_id = submit_with_ops production_request_ops
 
-let submit ?on_accepted ?on_worker_aborted ?on_worker_settled ~background_sw
-    ~base_path ~caller ~f ~keeper_name () =
-  submit_with_request_id ?on_accepted ?on_worker_aborted ?on_worker_settled
-    ~background_sw ~base_path ~caller
+let submit ?requested_request_id ?on_accepted ?on_worker_aborted
+    ?on_worker_settled ~background_sw ~base_path ~caller ~f ~keeper_name () =
+  submit_with_request_id ?requested_request_id ?on_accepted ?on_worker_aborted
+    ?on_worker_settled ~background_sw ~base_path ~caller
     ~f:(fun ~request_id:_ request_sw -> f request_sw)
     ~keeper_name ()
 ;;
@@ -2854,9 +2882,9 @@ module For_testing = struct
   let atomic_staging_dir = atomic_staging_dir
   let load_record = load_record
   let recover_lost_disk_records = recover_lost_disk_records
-  let submit ops ?on_accepted ?on_worker_aborted ?on_worker_settled
+  let submit ops ?requested_request_id ?on_accepted ?on_worker_aborted ?on_worker_settled
       ~background_sw ~base_path ~caller ~f ~keeper_name () =
-    submit_with_ops ops ?on_accepted ?on_worker_aborted
+    submit_with_ops ops ?requested_request_id ?on_accepted ?on_worker_aborted
       ?on_worker_settled ~background_sw ~base_path ~caller
       ~f:(fun ~request_id:_ request_sw -> f request_sw)
       ~keeper_name ()

--- a/lib/keeper/keeper_msg_async.mli
+++ b/lib/keeper/keeper_msg_async.mli
@@ -167,6 +167,7 @@ and recovery_record_error_kind =
 type submit_error =
   | Submit_rejected of access_rejection
   | Submit_invalid_keeper_name of { reason : string }
+  | Submit_request_id_conflict of { request_id : string }
   | Initial_persistence_failed of { reason : string }
   | Acceptance_persistence_failed of
       { request_id : string
@@ -294,7 +295,8 @@ val server_background_switch : unit -> (Eio.Switch.t, submit_error) result
     for SSE or other live terminal notifications. Projection exceptions are
     observed and isolated from request truth. *)
 val submit
-  :  ?on_accepted:(string -> (unit, string) result)
+  :  ?requested_request_id:string
+  -> ?on_accepted:(string -> (unit, string) result)
   -> ?on_worker_aborted:(worker_abort_reason -> (unit, string) result)
   -> ?on_worker_settled:(worker_settlement -> unit)
   -> background_sw:Eio.Switch.t
@@ -307,11 +309,14 @@ val submit
 
 (** Same lifecycle and durability contract as {!submit}, but the worker also
     receives the canonical request id generated and accepted by this module.
+    [requested_request_id] lets an HTTP caller retain that identity before its
+    response stream starts; invalid or already-owned ids fail explicitly.
     Use this when a producer's durable artifacts must share that identity;
     callers needing only fire-and-forget execution should keep using
     {!submit}. *)
 val submit_with_request_id
-  :  ?on_accepted:(string -> (unit, string) result)
+  :  ?requested_request_id:string
+  -> ?on_accepted:(string -> (unit, string) result)
   -> ?on_worker_aborted:(worker_abort_reason -> (unit, string) result)
   -> ?on_worker_settled:(worker_settlement -> unit)
   -> background_sw:Eio.Switch.t
@@ -422,6 +427,7 @@ module For_testing : sig
 
   val submit
     :  request_ops
+    -> ?requested_request_id:string
     -> ?on_accepted:(string -> (unit, string) result)
     -> ?on_worker_aborted:(worker_abort_reason -> (unit, string) result)
     -> ?on_worker_settled:(worker_settlement -> unit)

--- a/lib/keeper/keeper_surface_read.ml
+++ b/lib/keeper/keeper_surface_read.ml
@@ -39,7 +39,7 @@ let message_json (m : Store.chat_message) : Yojson.Safe.t =
   let kind_fields =
     match m.kind with
     | Store.Row_kind.Utterance -> []
-    | Store.Row_kind.Transport_failure ->
+    | Store.Row_kind.Transport_failure | Store.Row_kind.Autonomous_activity ->
         [ ("kind", `String (Store.Row_kind.to_label m.kind)) ]
   in
   `Assoc

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -93,13 +93,13 @@ let terminal_outcome_to_log_label = function
   | Terminal_input_required -> "input_required"
 
 let successful_surface_post (detail : Keeper_agent_run.tool_call_detail) =
-  String.equal
-    (Keeper_tool_resolution.canonical_tool_name detail.tool_name)
-    "keeper_surface_post"
-  &&
-  match detail.execution_outcome with
-  | Tool_result.Ok -> true
-  | Tool_result.Error | Tool_result.Unknown -> false
+  match
+    ( Keeper_tool_name.of_string
+        (Keeper_tool_resolution.canonical_tool_name detail.tool_name),
+      detail.execution_outcome )
+  with
+  | Some Keeper_tool_name.Surface_post, Tool_result.Ok -> true
+  | _, _ -> false
 ;;
 
 let should_project_autonomous_chat
@@ -127,6 +127,14 @@ let project_autonomous_chat
       ~has_tool_calls:(result.tool_calls <> [])
       ~surface_already_persisted
   then (
+    let redaction =
+      Keeper_secret_redaction.snapshot
+        ~base_path:config.Workspace.base_path
+        ~keeper_name:meta.name
+    in
+    let response_text =
+      Keeper_secret_redaction.redact_text redaction result.response_text
+    in
     let turn_ref =
       Ids.Turn_ref.make
         ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
@@ -140,10 +148,10 @@ let project_autonomous_chat
         ~base_dir:config.Workspace.base_path
         ~keeper_name:meta.name
         ~delivery_key
-        ~content:result.response_text
+        ~content:response_text
         ~surface:Surface_ref.Agent
         ~assistant_kind:Keeper_chat_store.Row_kind.Autonomous_activity
-        ~blocks:(Keeper_chat_blocks.parse_text_to_blocks result.response_text)
+        ~blocks:(Keeper_chat_blocks.parse_text_to_blocks response_text)
         ~turn_ref
         ()
     with
@@ -151,7 +159,7 @@ let project_autonomous_chat
       Keeper_chat_broadcast.chat_appended
         ~keeper_name:meta.name
         ~source:(Surface_ref.lane_label Surface_ref.Agent)
-        ~content:result.response_text
+        ~content:response_text
         ()
     | Ok (Keeper_chat_store.Already_present _) -> ()
     | Error detail ->

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -92,6 +92,76 @@ let terminal_outcome_to_log_label = function
   | Terminal_checkpoint -> "checkpoint"
   | Terminal_input_required -> "input_required"
 
+let successful_surface_post (detail : Keeper_agent_run.tool_call_detail) =
+  String.equal
+    (Keeper_tool_resolution.canonical_tool_name detail.tool_name)
+    "keeper_surface_post"
+  &&
+  match detail.execution_outcome with
+  | Tool_result.Ok -> true
+  | Tool_result.Error | Tool_result.Unknown -> false
+;;
+
+let should_project_autonomous_chat
+      ~response_text
+      ~has_tool_calls
+      ~surface_already_persisted
+  =
+  String.trim response_text <> ""
+  && has_tool_calls
+  && not surface_already_persisted
+;;
+
+let project_autonomous_chat
+      ~config
+      ~meta
+      ~keeper_turn_id
+      (result : Keeper_agent_run.run_result)
+  =
+  let surface_already_persisted =
+    List.exists successful_surface_post result.tool_calls
+  in
+  if
+    should_project_autonomous_chat
+      ~response_text:result.response_text
+      ~has_tool_calls:(result.tool_calls <> [])
+      ~surface_already_persisted
+  then (
+    let turn_ref =
+      Ids.Turn_ref.make
+        ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+        ~absolute_turn:keeper_turn_id
+    in
+    let delivery_key =
+      Keeper_chat_delivery_identity.Autonomous_turn turn_ref
+    in
+    match
+      Keeper_chat_store.append_assistant_message_once
+        ~base_dir:config.Workspace.base_path
+        ~keeper_name:meta.name
+        ~delivery_key
+        ~content:result.response_text
+        ~surface:Surface_ref.Agent
+        ~assistant_kind:Keeper_chat_store.Row_kind.Autonomous_activity
+        ~blocks:(Keeper_chat_blocks.parse_text_to_blocks result.response_text)
+        ~turn_ref
+        ()
+    with
+    | Ok (Keeper_chat_store.Appended _) ->
+      Keeper_chat_broadcast.chat_appended
+        ~keeper_name:meta.name
+        ~source:(Surface_ref.lane_label Surface_ref.Agent)
+        ~content:result.response_text
+        ()
+    | Ok (Keeper_chat_store.Already_present _) -> ()
+    | Error detail ->
+      Keeper_turn_helpers.report_keeper_cycle_side_effect_issue
+        ~config
+        ~keeper_name:meta.name
+        ~side_effect:"autonomous chat projection"
+        detail)
+;;
+
 let append_metrics_snapshot
       ~config
       ~meta
@@ -524,6 +594,7 @@ module For_testing = struct
 
   let reset_turn_failures_for_stop_reason = reset_turn_failures_for_stop_reason
   let acknowledge_pending_messages = acknowledge_pending_messages
+  let should_project_autonomous_chat = should_project_autonomous_chat
 
   type nonrec cycle_post_action = cycle_post_action =
     | Assign_task
@@ -619,6 +690,11 @@ let handle
     ~lifecycle
     ~wall_tokens_per_second
     ~terminal_outcome;
+  project_autonomous_chat
+    ~config
+    ~meta
+    ~keeper_turn_id
+    result;
   KUM.broadcast_lifecycle_events
     ~name:updated_meta.name
     ~turn_generation:lifecycle.turn_generation

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -104,12 +104,14 @@ let successful_surface_post (detail : Keeper_agent_run.tool_call_detail) =
 
 let should_project_autonomous_chat
       ~response_text
-      ~has_tool_calls
+      ~turn_effect_record
       ~surface_already_persisted
   =
-  String.trim response_text <> ""
-  && has_tool_calls
-  && not surface_already_persisted
+  match turn_effect_record with
+  | Keeper_run_prompt.Inert_autonomous_turn -> false
+  | Keeper_run_prompt.Meaningful_turn ->
+      String.trim response_text <> ""
+      && not surface_already_persisted
 ;;
 
 let project_autonomous_chat
@@ -118,13 +120,30 @@ let project_autonomous_chat
       ~keeper_turn_id
       (result : Keeper_agent_run.run_result)
   =
+  let io =
+    Keeper_autonomous_chat_projection.production_io
+      ~base_dir:config.Workspace.base_path
+      ~keeper_name:meta.name
+  in
+  let report_projection_issues issues =
+    List.iter
+      (fun issue ->
+         Keeper_turn_helpers.report_keeper_cycle_side_effect_issue
+           ~config
+           ~keeper_name:meta.name
+           ~side_effect:"autonomous chat projection"
+           (Keeper_autonomous_chat_projection.issue_to_string issue))
+      issues
+  in
+  Keeper_autonomous_chat_projection.retry_pending io
+  |> report_projection_issues;
   let surface_already_persisted =
     List.exists successful_surface_post result.tool_calls
   in
   if
     should_project_autonomous_chat
       ~response_text:result.response_text
-      ~has_tool_calls:(result.tool_calls <> [])
+      ~turn_effect_record:result.turn_effect_record
       ~surface_already_persisted
   then (
     let redaction =
@@ -140,34 +159,10 @@ let project_autonomous_chat
         ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
         ~absolute_turn:keeper_turn_id
     in
-    let delivery_key =
-      Keeper_chat_delivery_identity.Autonomous_turn turn_ref
-    in
-    match
-      Keeper_chat_store.append_assistant_message_once
-        ~base_dir:config.Workspace.base_path
-        ~keeper_name:meta.name
-        ~delivery_key
-        ~content:response_text
-        ~surface:Surface_ref.Agent
-        ~assistant_kind:Keeper_chat_store.Row_kind.Autonomous_activity
-        ~blocks:(Keeper_chat_blocks.parse_text_to_blocks response_text)
-        ~turn_ref
-        ()
-    with
-    | Ok (Keeper_chat_store.Appended _) ->
-      Keeper_chat_broadcast.chat_appended
-        ~keeper_name:meta.name
-        ~source:(Surface_ref.lane_label Surface_ref.Agent)
-        ~content:response_text
-        ()
-    | Ok (Keeper_chat_store.Already_present _) -> ()
-    | Error detail ->
-      Keeper_turn_helpers.report_keeper_cycle_side_effect_issue
-        ~config
-        ~keeper_name:meta.name
-        ~side_effect:"autonomous chat projection"
-        detail)
+    Keeper_autonomous_chat_projection.record_and_project
+      io
+      { keeper_name = meta.name; turn_ref; content = response_text }
+    |> report_projection_issues)
 ;;
 
 let append_metrics_snapshot

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -29,6 +29,12 @@ module For_testing : sig
     -> Keeper_world_observation.world_observation
     -> Keeper_meta_contract.keeper_meta
 
+  val should_project_autonomous_chat
+    :  response_text:string
+    -> has_tool_calls:bool
+    -> surface_already_persisted:bool
+    -> bool
+
   type cycle_post_action =
     | Assign_task
     | Empty_queue_sleep

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -31,7 +31,7 @@ module For_testing : sig
 
   val should_project_autonomous_chat
     :  response_text:string
-    -> has_tool_calls:bool
+    -> turn_effect_record:Keeper_run_prompt.turn_effect_record
     -> surface_already_persisted:bool
     -> bool
 

--- a/lib/keeper/keeper_world_observation_message_scope.ml
+++ b/lib/keeper/keeper_world_observation_message_scope.ml
@@ -143,7 +143,8 @@ let recent_direct_conversation_of_messages
           }
       | Keeper_chat_store.Role.Assistant ->
         (match m.kind with
-         | Keeper_chat_store.Row_kind.Transport_failure -> None
+         | Keeper_chat_store.Row_kind.Transport_failure
+         | Keeper_chat_store.Row_kind.Autonomous_activity -> None
          | Keeper_chat_store.Row_kind.Utterance ->
            (match m.audio with
             | Some _ -> None
@@ -217,6 +218,9 @@ let acknowledged_turn_refs messages =
         StringSet.add (Ids.Turn_ref.to_string turn_ref) refs
       | Keeper_chat_store.Role.Assistant,
         Keeper_chat_store.Row_kind.Transport_failure,
+        _
+      | Keeper_chat_store.Role.Assistant,
+        Keeper_chat_store.Row_kind.Autonomous_activity,
         _
       | Keeper_chat_store.Role.Assistant,
         Keeper_chat_store.Row_kind.Utterance,

--- a/lib/keeper/keeper_world_observation_message_scope.ml
+++ b/lib/keeper/keeper_world_observation_message_scope.ml
@@ -170,14 +170,31 @@ let recent_direct_conversation_of_messages
 ;;
 
 let collect_recent_direct_conversation
-      ?limit
+      ?(limit = default_recent_direct_limit)
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
       ()
   : recent_direct_line list
   =
-  Keeper_chat_store.load ~base_dir:config.base_path ~keeper_name:meta.name
-  |> recent_direct_conversation_of_messages ?limit
+  let rec collect before newer_lines =
+    let page =
+      Keeper_chat_store.load_page
+        ~base_dir:config.base_path
+        ~keeper_name:meta.name
+        ?before
+        ()
+    in
+    let page_lines =
+      recent_direct_conversation_of_messages ~limit page.messages
+    in
+    let lines = take_last limit (page_lines @ newer_lines) in
+    if List.length lines >= limit || not page.has_more then lines
+    else
+      match List.find_map (fun message -> message.Keeper_chat_store.ts) page.messages with
+      | Some oldest_ts -> collect (Some oldest_ts) lines
+      | None -> lines
+  in
+  if limit <= 0 then [] else collect None []
 ;;
 
 let render_recent_direct_conversation_context

--- a/lib/keeper/keeper_world_observation_message_scope.mli
+++ b/lib/keeper/keeper_world_observation_message_scope.mli
@@ -71,6 +71,8 @@ val collect_recent_direct_conversation
   -> meta:keeper_meta
   -> unit
   -> recent_direct_line list
+(** Page backward through bounded chat history until the direct-conversation
+    limit is filled; autonomous activity does not consume that window. *)
 
 val render_recent_direct_conversation_context
   :  recent_direct_line list

--- a/lib/keeper_catchup_digest.ml
+++ b/lib/keeper_catchup_digest.ml
@@ -360,6 +360,7 @@ let read_chat ~base_dir ~keeper_name ~since ~errs =
       Hashtbl.add seen id ();
       (match kind with
        | Keeper_chat_store.Row_kind.Transport_failure -> incr transport
+       | Keeper_chat_store.Row_kind.Autonomous_activity -> ()
        | Keeper_chat_store.Row_kind.Utterance ->
          (match role with
           | Keeper_chat_store.Role.User | Keeper_chat_store.Role.Assistant ->

--- a/lib/keeper_catchup_digest.mli
+++ b/lib/keeper_catchup_digest.mli
@@ -128,7 +128,7 @@ val build :
     Sources (all filtered to activity strictly after [since_unix]):
     - [chat]: [Keeper_chat_store] paged backward from the tail; utterances
       count as [new_messages], [Row_kind.Transport_failure] rows as
-      [transport_failures].
+      [transport_failures], and autonomous-activity/tool rows are ignored.
     - [turns.completed]: keeper-local [turn-records] day-files.
     - [turns.failed]: activity-events [keeper.turn_failed] for the keeper.
     - [turns.crashes]: [Keeper_crash_persistence] recent crash events.

--- a/lib/keeper_chat_delivery_identity/keeper_chat_delivery_identity.ml
+++ b/lib/keeper_chat_delivery_identity/keeper_chat_delivery_identity.ml
@@ -90,6 +90,7 @@ type delivery_key =
   | Direct_request of Request_id.t
   | Async_request of Request_id.t
   | Queue_receipts of Receipt_ids.t
+  | Autonomous_turn of Ids.Turn_ref.t
 
 type transcript_slot =
   | Accepted_user
@@ -150,6 +151,11 @@ let delivery_key_to_yojson = function
                (fun receipt_id -> `String (Receipt_id.to_string receipt_id))
                (Receipt_ids.to_list receipt_ids)) )
       ]
+  | Autonomous_turn turn_ref ->
+    `Assoc
+      [ "kind", `String "autonomous_turn"
+      ; "turn_ref", Ids.Turn_ref.to_yojson turn_ref
+      ]
 ;;
 
 let delivery_key_of_yojson = function
@@ -205,6 +211,17 @@ let delivery_key_of_yojson = function
          | Error error -> Error (Receipt_ids.error_to_string error)
        in
        Ok (Queue_receipts receipt_ids)
+     | "autonomous_turn" ->
+       let* () =
+         validate_fields
+           ~context:"autonomous turn delivery identity"
+           ~expected:[ "kind"; "turn_ref" ]
+           fields
+       in
+       let* turn_ref = string_field "turn_ref" fields in
+       (match Ids.Turn_ref.of_string turn_ref with
+        | Some turn_ref -> Ok (Autonomous_turn turn_ref)
+        | None -> Error "autonomous turn identity has an invalid turn_ref")
      | _ -> Error (Printf.sprintf "unsupported delivery identity kind %S" kind))
   | _ -> Error "delivery identity must be an object"
 ;;
@@ -222,9 +239,11 @@ let delivery_key_equal left right =
       | [], _ :: _ | _ :: _, [] -> false
     in
     equal_lists (Receipt_ids.to_list left) (Receipt_ids.to_list right)
-  | Direct_request _, (Async_request _ | Queue_receipts _)
-  | Async_request _, (Direct_request _ | Queue_receipts _)
-  | Queue_receipts _, (Direct_request _ | Async_request _) -> false
+  | Autonomous_turn left, Autonomous_turn right -> Ids.Turn_ref.equal left right
+  | Direct_request _, (Async_request _ | Queue_receipts _ | Autonomous_turn _)
+  | Async_request _, (Direct_request _ | Queue_receipts _ | Autonomous_turn _)
+  | Queue_receipts _, (Direct_request _ | Async_request _ | Autonomous_turn _)
+  | Autonomous_turn _, (Direct_request _ | Async_request _ | Queue_receipts _) -> false
 ;;
 
 let delivery_key_file_stem key =
@@ -239,6 +258,7 @@ let delivery_key_file_stem key =
   | Direct_request _ -> "direct-" ^ digest
   | Async_request _ -> "async-" ^ digest
   | Queue_receipts _ -> "queue-" ^ digest
+  | Autonomous_turn _ -> "autonomous-" ^ digest
 ;;
 
 let transcript_slot_to_yojson = function

--- a/lib/keeper_chat_delivery_identity/keeper_chat_delivery_identity.mli
+++ b/lib/keeper_chat_delivery_identity/keeper_chat_delivery_identity.mli
@@ -36,6 +36,7 @@ type delivery_key =
   | Direct_request of Request_id.t
   | Async_request of Request_id.t
   | Queue_receipts of Receipt_ids.t
+  | Autonomous_turn of Ids.Turn_ref.t
 
 type transcript_slot =
   | Accepted_user

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -202,13 +202,19 @@ let queued_chat_projection (queued_message : Keeper_chat_queue.queued_message) =
    [Server_routes_http_keeper_stream.keeper_chat_stream_request] built from
    an observed Pending [Keeper_chat_queue.queued_message], and a duplicated
    copy would silently drift out of sync with [queued_chat_projection] the
-   next time either changes. *)
+   next time either changes.  [request_id] stays [None]: it is the
+   client-requested identity for a fresh direct submission (threaded to
+   [Keeper_msg_async.submit ?requested_request_id] only on the
+   [Direct_request] branch), while a queued turn's durable identity is its
+   [Queued_receipt] receipt ids — [queued_message] carries no request id to
+   retain. *)
 let payload_of_queued_message ~keeper_name
     (queued_message : Keeper_chat_queue.queued_message) :
     Server_routes_http_keeper_stream.keeper_chat_stream_request =
   let projection = queued_chat_projection queued_message in
   { Server_routes_http_keeper_stream.name = keeper_name
   ; message = queued_message.content
+  ; request_id = None
   ; turn_instructions = None
   ; surface_context = None
   ; channel = projection.payload_channel

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -34,6 +34,7 @@ type user_input_block = Keeper_multimodal_input.user_input_block =
 type keeper_chat_stream_request = {
   name : string;
   message : string;
+  request_id : string option;
   user_blocks : user_input_block list;
   turn_instructions : string option;
   surface_context : Yojson.Safe.t option;
@@ -540,6 +541,16 @@ let parse_keeper_chat_stream_request body_str =
         Json_util.get_string_with_default json ~key:"message" ~default:""
         |> String.trim
       in
+      let request_id_result =
+        match Json_util.assoc_member_opt "request_id" json with
+        | None | Some `Null -> Ok None
+        | Some (`String value) ->
+          let value = String.trim value in
+          if value = ""
+          then Error "request_id must not be blank"
+          else Ok (Some value)
+        | Some _ -> Error "request_id must be a string"
+      in
       let channel =
         Json_util.get_string_with_default json ~key:"channel" ~default:""
         |> String.trim
@@ -591,39 +602,45 @@ let parse_keeper_chat_stream_request body_str =
         Error
           "channel and channel_workspace_id are required when connector context is supplied"
       else
-        match
-          Keeper_meta_contract.reject_removed_model_args ~tool_name:"masc_keeper_msg" json
-        with
+        match request_id_result with
         | Error err -> Error err
-        | Ok () -> (
+        | Ok request_id -> (
           match
-            Keeper_config.reject_removed_keeper_msg_input_keys
+            Keeper_meta_contract.reject_removed_model_args
               ~tool_name:"masc_keeper_msg"
               json
           with
           | Error err -> Error err
           | Ok () -> (
-            match user_blocks_result with
+            match
+              Keeper_config.reject_removed_keeper_msg_input_keys
+                ~tool_name:"masc_keeper_msg"
+                json
+            with
             | Error err -> Error err
-            | Ok user_blocks ->
-              let message = message_of_blocks user_blocks in
-              if message = "" then
-                Error "message is required"
-              else
-              Ok
-                {
-                  name;
-                  message;
-                  user_blocks;
-                  turn_instructions;
-                  surface_context;
-                  channel;
-                  channel_user_id;
-                  channel_user_name;
-                  channel_workspace_id;
-                  attachments;
-                }
-          ))
+            | Ok () -> (
+              match user_blocks_result with
+              | Error err -> Error err
+              | Ok user_blocks ->
+                let message = message_of_blocks user_blocks in
+                if message = "" then
+                  Error "message is required"
+                else
+                Ok
+                  {
+                    name;
+                    message;
+                    request_id;
+                    user_blocks;
+                    turn_instructions;
+                    surface_context;
+                    channel;
+                    channel_user_id;
+                    channel_user_name;
+                    channel_workspace_id;
+                    attachments;
+                  }
+            )))
   with Yojson.Json_error e ->
     Error ("invalid json: " ^ e)
 
@@ -2511,6 +2528,7 @@ let process_single_turn ~user_row_origin ~submission
            else None
          in
          Keeper_msg_async.submit
+           ?requested_request_id:payload.request_id
            ?on_accepted
            ~background_sw
            ~on_worker_aborted

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -73,6 +73,7 @@ type user_input_block = Keeper_multimodal_input.user_input_block =
 type keeper_chat_stream_request = {
   name : string;
   message : string;
+  request_id : string option;
   user_blocks : user_input_block list;
   turn_instructions : string option;
   surface_context : Yojson.Safe.t option;
@@ -84,7 +85,9 @@ type keeper_chat_stream_request = {
 }
 (** Parsed payload of a keeper chat-stream HTTP request.
     [message] is the text fallback used by the existing direct keeper
-    path; [user_blocks] preserves semantic text/media input for the
+    path; [request_id], when present, is the caller-owned canonical
+    durable request identity and is validated/reserved before execution.
+    [user_blocks] preserves semantic text/media input for the
     block-aware runtime path. [turn_instructions] and [surface_context]
     are optional copilot context fields; when
     [turn_instructions] is absent but [surface_context]

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -263,14 +263,16 @@ hello from a thread|}
 
 let test_parse_keeper_chat_stream_request_accepts_connector_context () =
   let body =
-    {|{"name":"luna","message":"hello","channel":"discord","channel_user_id":"user-42","channel_user_name":"Alice","channel_workspace_id":"workspace-9"}|}
+    {|{"name":"luna","message":"hello","request_id":"kmsg-client-test-1","channel":"discord","channel_user_id":"user-42","channel_user_name":"Alice","channel_workspace_id":"workspace-9"}|}
   in
   match Server_routes_http_keeper_stream.parse_keeper_chat_stream_request body with
   | Ok payload ->
       check string "channel" "discord" payload.channel;
       check string "user id" "user-42" payload.channel_user_id;
       check string "user name" "Alice" payload.channel_user_name;
-      check string "workspace id" "workspace-9" payload.channel_workspace_id
+      check string "workspace id" "workspace-9" payload.channel_workspace_id;
+      check (option string) "client-owned request identity"
+        (Some "kmsg-client-test-1") payload.request_id
   | Error err -> fail ("expected connector context to parse: " ^ err)
 
 let test_parse_keeper_chat_stream_request_rejects_removed_timeout () =
@@ -639,6 +641,7 @@ let test_keeper_stream_args_preserve_user_blocks () =
   let payload =
     { Server_routes_http_keeper_stream.name = "luna";
       message = "describe this";
+      request_id = None;
       user_blocks =
         [
           Keeper_multimodal_input.User_text "describe this";
@@ -2518,6 +2521,7 @@ let test_chat_surface_of_request_labels_copilot_gate () =
   let payload =
     { Server_routes_http_keeper_stream.name = "luna";
       message = "hello";
+      request_id = None;
       turn_instructions = None;
       surface_context = None;
       user_blocks = [];
@@ -2541,6 +2545,7 @@ let test_chat_speaker_of_request_copilot_is_owner () =
   let payload =
     { Server_routes_http_keeper_stream.name = "luna";
       message = "hello";
+      request_id = None;
       turn_instructions = None;
       surface_context = None;
       user_blocks = [];
@@ -2560,6 +2565,7 @@ let test_chat_speaker_of_request_connector_is_external () =
   let payload =
     { Server_routes_http_keeper_stream.name = "luna";
       message = "hello";
+      request_id = None;
       turn_instructions = None;
       surface_context = None;
       user_blocks = [];

--- a/test/test_keeper_busy_dashboard_deferred.ml
+++ b/test/test_keeper_busy_dashboard_deferred.ml
@@ -24,6 +24,7 @@ let payload ?(name = keeper_name) ?(content = "are you there?") ()
     : Server_routes_http_keeper_stream.keeper_chat_stream_request =
   { name
   ; message = content
+  ; request_id = None
   ; user_blocks = []
   ; turn_instructions = None
   ; surface_context = None

--- a/test/test_keeper_chat_admission_contention.ml
+++ b/test/test_keeper_chat_admission_contention.ml
@@ -295,6 +295,7 @@ let test_queued_server_turn_has_no_second_durable_request () =
              Server_routes_http_keeper_stream.keeper_chat_stream_request =
            { name = keeper_name
            ; message = "queued inline boundary"
+           ; request_id = None
            ; user_blocks = []
            ; turn_instructions = None
            ; surface_context = None

--- a/test/test_keeper_chat_delivery_identity.ml
+++ b/test/test_keeper_chat_delivery_identity.ml
@@ -69,6 +69,24 @@ let test_async_roundtrip () =
        (Identity.delivery_key_file_stem decoded))
 ;;
 
+let test_autonomous_turn_roundtrip () =
+  let turn_ref =
+    Ids.Turn_ref.make ~trace_id:"trace-autonomous-chat" ~absolute_turn:42
+  in
+  let key = Identity.Autonomous_turn turn_ref in
+  let decoded =
+    Identity.delivery_key_to_yojson key
+    |> Identity.delivery_key_of_yojson
+    |> expect_ok
+  in
+  check bool "autonomous turn identity roundtrips" true
+    (Identity.delivery_key_equal key decoded);
+  check bool "autonomous filename namespace is stable" true
+    (String.equal
+       (Identity.delivery_key_file_stem key)
+       (Identity.delivery_key_file_stem decoded))
+;;
+
 let test_transcript_slot_roundtrip () =
   let slots =
     [ Identity.Accepted_user
@@ -137,6 +155,10 @@ let () =
             "queue identity is nonempty"
             `Quick
             test_queue_requires_nonempty_receipts
+        ; test_case
+            "autonomous turn roundtrip"
+            `Quick
+            test_autonomous_turn_roundtrip
         ; test_case
             "transcript slots roundtrip"
             `Quick

--- a/test/test_keeper_chat_direct_delivery.ml
+++ b/test/test_keeper_chat_direct_delivery.ml
@@ -565,6 +565,7 @@ let await_settlement ~ops ~background_sw ~base_path ~request_id =
   let submitted_request_id =
     Keeper_msg_async.For_testing.submit
       ops
+      ~requested_request_id:(Direct.Request_id.to_string request_id)
       ~on_worker_settled:(fun value ->
         if Atomic.compare_and_set delivered false true
         then Eio.Promise.resolve resolve_settlement value)

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -358,6 +358,59 @@ let test_recent_direct_context_omits_transport_failure_as_self_reply () =
       Alcotest.(check bool) "failure text is not a self utterance" false
         (contains_substring rendered "Keeper request failed"))
 
+let test_recent_direct_context_pages_past_autonomous_activity () =
+  let base_dir = temp_base_path "keeper-chat-recent-autonomous-page" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-recent-autonomous-page" in
+      K.append_turn ~base_dir ~keeper_name
+        ~user_content:"remember this direct question"
+        ~user_attachments:[]
+        ~surface:(Masc.Surface_ref.Dashboard { session_id = None })
+        ~assistant_content:"remember this direct answer"
+        ();
+      for absolute_turn = 1 to 105 do
+        let turn_ref =
+          Ids.Turn_ref.make
+            ~trace_id:"trace-autonomous-page"
+            ~absolute_turn
+        in
+        let delivery_key =
+          Keeper_chat_delivery_identity.Autonomous_turn turn_ref
+        in
+        match
+          K.append_assistant_message_once ~base_dir ~keeper_name ~delivery_key
+            ~content:(Printf.sprintf "autonomous activity %d" absolute_turn)
+            ~surface:Masc.Surface_ref.Agent
+            ~assistant_kind:K.Row_kind.Autonomous_activity
+            ~turn_ref
+            ()
+        with
+        | Ok (K.Appended _) -> ()
+        | Ok (K.Already_present _) ->
+          Alcotest.fail "unique autonomous turn unexpectedly already present"
+        | Error detail -> Alcotest.fail detail
+      done;
+      let config = Masc.Workspace.default_config base_dir in
+      let meta = make_meta keeper_name in
+      let lines =
+        MS.collect_recent_direct_conversation
+          ~limit:2
+          ~config
+          ~meta
+          ()
+      in
+      Alcotest.(check (list string))
+        "autonomous rows do not consume the direct-context window"
+        [ "user"; "assistant" ]
+        (recent_roles lines);
+      let rendered = MS.render_recent_direct_conversation_context lines in
+      Alcotest.(check bool) "older direct question remains visible" true
+        (contains_substring rendered "remember this direct question");
+      Alcotest.(check bool) "older direct answer remains visible" true
+        (contains_substring rendered "remember this direct answer"))
+
 let test_recent_direct_context_omits_voice_audio_self_echo () =
   let base_dir = temp_base_path "keeper-chat-recent-voice" in
   Fun.protect
@@ -2208,6 +2261,8 @@ let () =
             test_recent_direct_context_renders_prior_reply_and_tool_evidence;
           Alcotest.test_case "recent context omits transport failure as reply" `Quick
             test_recent_direct_context_omits_transport_failure_as_self_reply;
+          Alcotest.test_case "recent context pages past autonomous activity"
+            `Quick test_recent_direct_context_pages_past_autonomous_activity;
           Alcotest.test_case "recent context omits voice audio self echo" `Quick
             test_recent_direct_context_omits_voice_audio_self_echo;
           Alcotest.test_case "recent context is owner-direct only" `Quick

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -974,6 +974,54 @@ let test_failure_turn_kind_roundtrip () =
       | messages ->
           Alcotest.failf "expected 2 rows, got %d" (List.length messages))
 
+let test_autonomous_activity_is_idempotent_and_not_direct_reply () =
+  let base_dir = temp_base_path "keeper-chat-store-autonomous-activity" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-autonomous-activity" in
+      let turn_ref =
+        Ids.Turn_ref.make ~trace_id:"trace-autonomous" ~absolute_turn:42
+      in
+      let delivery_key =
+        Keeper_chat_delivery_identity.Autonomous_turn turn_ref
+      in
+      let append () =
+        K.append_assistant_message_once ~base_dir ~keeper_name ~delivery_key
+          ~content:"Implemented and verified task-119."
+          ~surface:Masc.Surface_ref.Agent
+          ~assistant_kind:K.Row_kind.Autonomous_activity
+          ~turn_ref
+          ()
+      in
+      (match append () with
+       | Ok (K.Appended _) -> ()
+       | Ok (K.Already_present _) ->
+         Alcotest.fail "autonomous row unexpectedly already present"
+       | Error detail -> Alcotest.fail detail);
+      (match append () with
+       | Ok (K.Already_present _) -> ()
+       | Ok (K.Appended _) ->
+         Alcotest.fail "autonomous row duplicated on retry"
+       | Error detail -> Alcotest.fail detail);
+      match K.load ~base_dir ~keeper_name with
+      | [ activity ] ->
+        Alcotest.(check bool) "typed autonomous kind" true
+          (K.Row_kind.equal activity.kind K.Row_kind.Autonomous_activity);
+        Alcotest.(check int) "not direct-conversation context" 0
+          (MS.recent_direct_conversation_of_messages [ activity ]
+           |> List.length);
+        let open Yojson.Safe.Util in
+        (match K.to_json_array [ activity ] with
+         | `List [ row ] ->
+           Alcotest.(check string) "history kind" "autonomous_activity"
+             (row |> member "kind" |> to_string);
+           Alcotest.(check string) "history surface" "agent"
+             (row |> member "surface" |> member "kind" |> to_string)
+         | _ -> Alcotest.fail "expected one history row")
+      | messages ->
+        Alcotest.failf "expected 1 row, got %d" (List.length messages))
+
 let test_kind_absent_reads_utterance () =
   (* Every row written before the [kind] field existed is an utterance;
      the writer also omits the field for utterances, so ordinary rows
@@ -2120,6 +2168,10 @@ let () =
         [
           Alcotest.test_case "failure turn kind roundtrip" `Quick
             test_failure_turn_kind_roundtrip;
+          Alcotest.test_case
+            "autonomous activity is idempotent and not a direct reply"
+            `Quick
+            test_autonomous_activity_is_idempotent_and_not_direct_reply;
           Alcotest.test_case "absent kind reads utterance" `Quick
             test_kind_absent_reads_utterance;
           Alcotest.test_case "unknown kind reported, reads utterance" `Quick

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -376,7 +376,9 @@ let test_recent_direct_context_pages_past_autonomous_activity () =
         ~surface:(Masc.Surface_ref.Dashboard { session_id = None })
         ~assistant_content:"remember this direct answer"
         ();
-      for absolute_turn = 1 to 105 do
+      (* 2 direct rows + 99 autonomous rows puts the 100-row boundary
+         exactly between the direct user and assistant, which share a ts. *)
+      for absolute_turn = 1 to 99 do
         let turn_ref =
           Ids.Turn_ref.make
             ~trace_id:"trace-autonomous-page"

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -104,15 +104,21 @@ let test_load_records_malformed_row_drops () =
                (`Assoc
                   [ ("id", `String "valid-user")
                   ; ("role", `String "user");
+                    ("kind", `String "utterance");
                     ("content", `String "hello");
                     ("ts", `Float 1.0);
                   ]);
              "{not-json";
-             Yojson.Safe.to_string (`Assoc [("role", `String "assistant")]);
+             Yojson.Safe.to_string
+               (`Assoc
+                  [ ("role", `String "assistant")
+                  ; ("kind", `String "utterance")
+                  ]);
              Yojson.Safe.to_string
                (`Assoc
                   [ ("id", `String "valid-assistant")
                   ; ("role", `String "assistant");
+                    ("kind", `String "utterance");
                     ("content", `String "world");
                     ("ts", `Float 2.0);
                   ]);
@@ -232,8 +238,8 @@ let test_missing_id_rows_are_rejected () =
       let keeper_name = "keeper-chat-missing-id" in
       let path = chat_path ~base_dir ~keeper_name in
       write_file path
-        ({|{"role":"user","content":"hello","ts":1.0}|} ^ "\n"
-        ^ {|{"role":"assistant","content":"world","ts":1.0}|} ^ "\n");
+        ({|{"role":"user","kind":"utterance","content":"hello","ts":1.0}|} ^ "\n"
+        ^ {|{"role":"assistant","kind":"utterance","content":"world","ts":1.0}|} ^ "\n");
       Alcotest.(check int) "rows without current id are dropped" 0
         (K.load ~base_dir ~keeper_name |> List.length))
 
@@ -530,6 +536,7 @@ let test_load_redacts_raw_persisted_secret_rows () =
            (`Assoc
               [ ("id", `String "raw-secret-row")
               ; ("role", `String "assistant");
+                ("kind", `String "utterance");
                 ("content", `String ("old row " ^ secret));
                 ("ts", `Float 1.0) ])
          ^ "\n");
@@ -708,7 +715,7 @@ let test_unknown_speaker_authority_reported_not_guessed () =
       let invalid_payload = Safe_ops.persistence_read_drop_reason_invalid_payload in
       let before = drop_value invalid_payload in
       write_file path
-        ({|{"id":"unknown-authority","role":"user","content":"hi","ts":1.0,"speaker_id":"x","speaker_authority":"admin"}|}
+        ({|{"id":"unknown-authority","role":"user","kind":"utterance","content":"hi","ts":1.0,"speaker_id":"x","speaker_authority":"admin"}|}
         ^ "\n");
       (match K.load ~base_dir ~keeper_name with
        | [ user ] ->
@@ -733,9 +740,9 @@ let test_unknown_role_row_dropped () =
       let invalid_payload = Safe_ops.persistence_read_drop_reason_invalid_payload in
       let before = drop_value invalid_payload in
       write_file path
-        ({|{"id":"role-user","role":"user","content":"hi","ts":1.0}|} ^ "\n"
-        ^ {|{"id":"role-system","role":"system","content":"injected","ts":2.0}|} ^ "\n"
-        ^ {|{"id":"role-assistant","role":"assistant","content":"done","ts":3.0}|} ^ "\n");
+        ({|{"id":"role-user","role":"user","kind":"utterance","content":"hi","ts":1.0}|} ^ "\n"
+        ^ {|{"id":"role-system","role":"system","kind":"utterance","content":"injected","ts":2.0}|} ^ "\n"
+        ^ {|{"id":"role-assistant","role":"assistant","kind":"utterance","content":"done","ts":3.0}|} ^ "\n");
       let messages = K.load ~base_dir ~keeper_name in
       Alcotest.(check (list string)) "unknown role row dropped"
         [ "user"; "assistant" ] (roles messages);
@@ -753,9 +760,9 @@ let test_tool_row_missing_name_dropped () =
       let invalid_payload = Safe_ops.persistence_read_drop_reason_invalid_payload in
       let before = drop_value invalid_payload in
       write_file path
-        ({|{"id":"tool-name-user","role":"user","content":"hi","ts":1.0}|} ^ "\n"
-        ^ {|{"id":"tool-name-missing","role":"tool","content":"{}","ts":1.0,"tool_call_id":"toolu_9"}|} ^ "\n"
-        ^ {|{"id":"tool-name-assistant","role":"assistant","content":"done","ts":1.0}|} ^ "\n");
+        ({|{"id":"tool-name-user","role":"user","kind":"utterance","content":"hi","ts":1.0}|} ^ "\n"
+        ^ {|{"id":"tool-name-missing","role":"tool","kind":"utterance","content":"{}","ts":1.0,"tool_call_id":"toolu_9"}|} ^ "\n"
+        ^ {|{"id":"tool-name-assistant","role":"assistant","kind":"utterance","content":"done","ts":1.0}|} ^ "\n");
       let messages = K.load ~base_dir ~keeper_name in
       Alcotest.(check (list string)) "nameless tool row dropped"
         [ "user"; "assistant" ] (roles messages);
@@ -802,10 +809,10 @@ let test_orphan_leading_tool_lines_trimmed () =
       let keeper_name = "keeper-chat-orphan" in
       let path = chat_path ~base_dir ~keeper_name in
       write_file path
-        ({|{"id":"orphan-tool","role":"tool","content":"{}","ts":1.0,"tool_call_id":"t0","tool_call_name":"Read"}|}
+        ({|{"id":"orphan-tool","role":"tool","kind":"utterance","content":"{}","ts":1.0,"tool_call_id":"t0","tool_call_name":"Read"}|}
         ^ "\n"
-        ^ {|{"id":"orphan-user","role":"user","content":"hi","ts":2.0}|} ^ "\n"
-        ^ {|{"id":"orphan-assistant","role":"assistant","content":"yo","ts":2.0}|} ^ "\n");
+        ^ {|{"id":"orphan-user","role":"user","kind":"utterance","content":"hi","ts":2.0}|} ^ "\n"
+        ^ {|{"id":"orphan-assistant","role":"assistant","kind":"utterance","content":"yo","ts":2.0}|} ^ "\n");
       let messages = K.load ~base_dir ~keeper_name in
       Alcotest.(check (list string)) "leading orphan tool trimmed"
         [ "user"; "assistant" ] (roles messages))
@@ -902,6 +909,7 @@ let test_tail_bounded_load_matches_full_scan_window () =
             (`Assoc
                [ ("id", `String (Printf.sprintf "tail-%04d" i))
                ; ("role", `String role);
+                 ("kind", `String "utterance");
                  ("content", `String (Printf.sprintf "msg-%04d %s" i padding));
                  ("ts", `Float (float_of_int i));
                ])
@@ -938,6 +946,7 @@ let write_numbered_lane ~path ~total ~pad_bytes =
          (`Assoc
             [ ("id", `String (Printf.sprintf "page-%04d" i))
             ; ("role", `String (if i mod 2 = 1 then "user" else "assistant"));
+              ("kind", `String "utterance");
               ("content", `String (Printf.sprintf "msg-%04d %s" i padding));
               ("ts", `Float (float_of_int i));
             ]));
@@ -1075,10 +1084,7 @@ let test_autonomous_activity_is_idempotent_and_not_direct_reply () =
       | messages ->
         Alcotest.failf "expected 1 row, got %d" (List.length messages))
 
-let test_kind_absent_reads_utterance () =
-  (* Every row written before the [kind] field existed is an utterance;
-     the writer also omits the field for utterances, so ordinary rows
-     stay byte-identical to the pre-[kind] format. *)
+let test_utterance_kind_is_explicit () =
   let base_dir = temp_base_path "keeper-chat-store-kind-absent" in
   Fun.protect
     ~finally:(fun () -> try remove_tree base_dir with _ -> ())
@@ -1088,8 +1094,8 @@ let test_kind_absent_reads_utterance () =
         ~user_content:"hello" ~user_attachments:[]
         ~assistant_content:"world" ();
       let raw = read_file (chat_path ~base_dir ~keeper_name) in
-      Alcotest.(check bool) "utterance rows carry no kind field" false
-        (contains_substring raw {|"kind"|});
+      Alcotest.(check bool) "utterance rows carry explicit kind" true
+        (contains_substring raw {|"kind":"utterance"|});
       match K.load ~base_dir ~keeper_name with
       | [ user; asst ] ->
           Alcotest.(check bool) "user reads as utterance" true
@@ -1099,7 +1105,24 @@ let test_kind_absent_reads_utterance () =
       | messages ->
           Alcotest.failf "expected 2 rows, got %d" (List.length messages))
 
-let test_unknown_kind_reported_reads_utterance () =
+let test_missing_kind_is_reported_and_rejected () =
+  let base_dir = temp_base_path "keeper-chat-store-kind-missing" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-kind-missing" in
+      let invalid_payload = Safe_ops.persistence_read_drop_reason_invalid_payload in
+      let before = drop_value invalid_payload in
+      let path = chat_path ~base_dir ~keeper_name in
+      write_file path
+        ({|{"id":"missing-kind","role":"assistant","content":"hi","ts":1.0}|}
+        ^ "\n");
+      Alcotest.(check int) "missing kind row rejected" 0
+        (K.load ~base_dir ~keeper_name |> List.length);
+      Alcotest.(check (float 0.001)) "missing kind reported" 1.0
+        (drop_value invalid_payload -. before))
+
+let test_unknown_kind_is_reported_and_rejected () =
   let base_dir = temp_base_path "keeper-chat-store-kind-unknown" in
   Fun.protect
     ~finally:(fun () -> try remove_tree base_dir with _ -> ())
@@ -1111,15 +1134,10 @@ let test_unknown_kind_reported_reads_utterance () =
       write_file path
         ({|{"id":"unknown-kind","role":"assistant","content":"hi","ts":1.0,"kind":"weird"}|}
         ^ "\n");
-      match K.load ~base_dir ~keeper_name with
-      | [ asst ] ->
-          Alcotest.(check bool)
-            "unknown kind reads as utterance (conservative arm)" true
-            (K.Row_kind.equal asst.kind K.Row_kind.Utterance);
-          Alcotest.(check (float 0.001)) "unknown kind reported" 1.0
-            (drop_value invalid_payload -. before)
-      | messages ->
-          Alcotest.failf "expected 1 row, got %d" (List.length messages))
+      Alcotest.(check int) "unknown kind row rejected" 0
+        (K.load ~base_dir ~keeper_name |> List.length);
+      Alcotest.(check (float 0.001)) "unknown kind reported" 1.0
+        (drop_value invalid_payload -. before))
 
 let audio_path ~base_dir token =
   Filename.concat
@@ -1180,7 +1198,7 @@ let test_audio_clip_expired_persists_roundtrip () =
       let keeper_name = "keeper-chat-audio-expired-rt" in
       let path = chat_path ~base_dir ~keeper_name in
       write_file path
-        ({|{"id":"audio-redact","role":"assistant","content":"hello","ts":1.0,"audio":{|}
+        ({|{"id":"audio-redact","role":"assistant","kind":"utterance","content":"hello","ts":1.0,"audio":{|}
         ^ {|"token":"voice-token-rt","mime":"audio/mpeg","message_text":"hello","expired":true}|}
         ^ "}\n");
       match K.load ~base_dir ~keeper_name with
@@ -1319,7 +1337,7 @@ let test_blocks_roundtrip_and_drop_malformed () =
       let keeper_name = "keeper-chat-blocks-rt" in
       let path = chat_path ~base_dir ~keeper_name in
       write_file path
-        ({|{"id":"block-redact","role":"assistant","content":"hello","ts":1.0,"blocks":[{|}
+        ({|{"id":"block-redact","role":"assistant","kind":"utterance","content":"hello","ts":1.0,"blocks":[{|}
         ^ {|"t":"p","html":"hello"},{"t":"image","src":"https://x.com/a.png","cap":"a"},{|}
         ^ {|"t":"link","url":"https://x.com","title":"x.com","meta":"x.com"},{|}
         ^ {|"t":"unknown","x":1}]}|}
@@ -1542,6 +1560,7 @@ let test_load_redacts_raw_persisted_blocks_and_audio () =
         `Assoc
           [ ("id", `String "raw-rich-secret-row")
           ; ("role", `String "assistant")
+          ; ("kind", `String "utterance")
           ; ("content", `String ("content " ^ secret))
           ; ("ts", `Float 1.0)
           ; ("audio", audio_json)
@@ -1942,7 +1961,7 @@ let test_malformed_stream_lifecycle_reads_none () =
       let invalid_payload = Safe_ops.persistence_read_drop_reason_invalid_payload in
       let before = drop_value invalid_payload in
       write_file path
-        ({|{"id":"bad-lifecycle","role":"assistant","content":"x","ts":1.0,"turn_ref":"trace-life#7","stream_lifecycle":["RUN_STARTED","NOT_A_REAL_EVENT"]}|}
+        ({|{"id":"bad-lifecycle","role":"assistant","kind":"utterance","content":"x","ts":1.0,"turn_ref":"trace-life#7","stream_lifecycle":["RUN_STARTED","NOT_A_REAL_EVENT"]}|}
         ^ "\n");
       (match K.load ~base_dir ~keeper_name with
        | [ m ] ->
@@ -1966,7 +1985,7 @@ let test_turn_ref_malformed_reads_none () =
       let keeper_name = "keeper-chat-turnref-bad" in
       let path = chat_path ~base_dir ~keeper_name in
       write_file path
-        ({|{"id":"bad-turn-ref","role":"assistant","content":"x","ts":1.0,"turn_ref":"no-separator"}|}
+        ({|{"id":"bad-turn-ref","role":"assistant","kind":"utterance","content":"x","ts":1.0,"turn_ref":"no-separator"}|}
         ^ "\n");
       match K.load ~base_dir ~keeper_name with
       | [ m ] ->
@@ -2080,7 +2099,7 @@ let test_delivery_key_malformed_reads_none () =
       in
       let before = drop_value invalid_payload in
       write_file path
-        ({|{"id":"bad-delivery-key","role":"user","content":"x","ts":1.0,"delivery_key":{"kind":"not_a_kind","request_id":"kmsg-1"}}|}
+        ({|{"id":"bad-delivery-key","role":"user","kind":"utterance","content":"x","ts":1.0,"delivery_key":{"kind":"not_a_kind","request_id":"kmsg-1"}}|}
         ^ "\n");
       (match K.load ~base_dir ~keeper_name with
        | [ m ] ->
@@ -2225,10 +2244,12 @@ let () =
             "autonomous activity is idempotent and not a direct reply"
             `Quick
             test_autonomous_activity_is_idempotent_and_not_direct_reply;
-          Alcotest.test_case "absent kind reads utterance" `Quick
-            test_kind_absent_reads_utterance;
-          Alcotest.test_case "unknown kind reported, reads utterance" `Quick
-            test_unknown_kind_reported_reads_utterance;
+          Alcotest.test_case "utterance kind is explicit" `Quick
+            test_utterance_kind_is_explicit;
+          Alcotest.test_case "missing kind is reported and rejected" `Quick
+            test_missing_kind_is_reported_and_rejected;
+          Alcotest.test_case "unknown kind is reported and rejected" `Quick
+            test_unknown_kind_is_reported_and_rejected;
         ] );
       ( "speaker_identity",
         [

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -891,6 +891,7 @@ let () =
     ; usage = Masc.Inference_utils.zero_usage
     ; usage_reported = true
     ; tool_calls = []
+    ; turn_effect_record = Masc.Keeper_run_prompt.Meaningful_turn
     ; completion_contract_result = R.Completion_tool_execution_observed
     ; operator_disposition = None
     ; checkpoint = None

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -15,6 +15,7 @@ open Alcotest
 module WO = Masc.Keeper_world_observation
 module Prompt = Masc.Keeper_unified_prompt
 module Turn = Masc.Keeper_turn
+module ACP = Masc.Keeper_autonomous_chat_projection
 
 let has_repo_prompts root =
   Sys.file_exists (Filename.concat root "config/prompts/keeper.unified.system.md")
@@ -391,30 +392,84 @@ let test_bootstrap_stimulus_keeps_reactive_post_action () =
     Alcotest.fail
       "bootstrap stimulus must not be reclassified from reactive to scheduled"
 
-let test_autonomous_chat_projection_requires_work_evidence () =
+let test_autonomous_chat_projection_uses_typed_turn_effect () =
   let should_project =
     Masc.Keeper_unified_turn_success.For_testing.should_project_autonomous_chat
   in
-  check bool "tool-backed result projects" true
+  check bool "meaningful result projects" true
     (should_project
        ~response_text:"Implemented task-119."
-       ~has_tool_calls:true
+       ~turn_effect_record:Masc.Keeper_run_prompt.Meaningful_turn
        ~surface_already_persisted:false);
-  check bool "idle prose does not project" false
+  check bool "typed inert turn does not project" false
     (should_project
        ~response_text:"No actionable work."
-       ~has_tool_calls:false
+       ~turn_effect_record:Masc.Keeper_run_prompt.Inert_autonomous_turn
        ~surface_already_persisted:false);
   check bool "surface post is not duplicated" false
     (should_project
        ~response_text:"Already posted."
-       ~has_tool_calls:true
+       ~turn_effect_record:Masc.Keeper_run_prompt.Meaningful_turn
        ~surface_already_persisted:true);
-  check bool "blank tool result does not invent speech" false
+  check bool "blank meaningful result does not invent speech" false
     (should_project
        ~response_text:" "
-       ~has_tool_calls:true
+       ~turn_effect_record:Masc.Keeper_run_prompt.Meaningful_turn
        ~surface_already_persisted:false)
+
+let test_autonomous_chat_projection_retries_durable_intent () =
+  let intent : ACP.intent =
+    { keeper_name = "echo"
+    ; turn_ref =
+        Ids.Turn_ref.make ~trace_id:"projection-retry" ~absolute_turn:17
+    ; content = "Implemented task-119."
+    }
+  in
+  let pending = ref [] in
+  let fail_append = ref true in
+  let events = ref [] in
+  let record event = events := event :: !events in
+  let io : ACP.io =
+    { load_pending =
+        (fun () ->
+           record "load";
+           Ok !pending)
+    ; persist =
+        (fun stored ->
+           record "persist";
+           pending := [ stored ];
+           Ok ())
+    ; append =
+        (fun _ ->
+           if !fail_append
+           then (
+             record "append_failed";
+             Error "chat unavailable")
+           else (
+             record "append";
+             Ok ACP.Appended))
+    ; retire =
+        (fun _ ->
+           record "retire";
+           pending := [];
+           Ok ())
+    ; broadcast = (fun _ -> record "broadcast")
+    }
+  in
+  (match ACP.record_and_project io intent with
+   | [ { stage = ACP.Append_chat; _ } ] -> ()
+   | issues ->
+     failf "expected one append issue, got %d" (List.length issues));
+  check int "failed append keeps one durable intent" 1 (List.length !pending);
+  check (list string) "intent is durable before first append"
+    [ "persist"; "append_failed" ]
+    (List.rev !events);
+  fail_append := false;
+  check (list string) "retry succeeds" [] (ACP.retry_pending io |> List.map ACP.issue_to_string);
+  check int "successful retry retires intent" 0 (List.length !pending);
+  check (list string) "retry appends once before retirement"
+    [ "persist"; "append_failed"; "load"; "append"; "broadcast"; "retire" ]
+    (List.rev !events)
 
 let test_preview_does_not_invent_wake_reason () =
   let preview_meta =
@@ -556,8 +611,10 @@ let () =
             test_threaded_stimulus_decision_renders_wake_reason;
           test_case "bootstrap keeps reactive post-action" `Quick
             test_bootstrap_stimulus_keeps_reactive_post_action;
-          test_case "chat projection requires work evidence" `Quick
-            test_autonomous_chat_projection_requires_work_evidence;
+          test_case "chat projection uses typed turn effect" `Quick
+            test_autonomous_chat_projection_uses_typed_turn_effect;
+          test_case "chat projection retries durable intent" `Quick
+            test_autonomous_chat_projection_retries_durable_intent;
           test_case "preview invents no wake reason" `Quick
             test_preview_does_not_invent_wake_reason;
         ] );

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -433,27 +433,27 @@ let test_autonomous_chat_projection_retries_durable_intent () =
     { load_pending =
         (fun () ->
            record "load";
-           Ok !pending)
+           Ok { ACP.intents = !pending; issues = [] })
     ; persist =
         (fun stored ->
            record "persist";
            pending := [ stored ];
            Ok ())
     ; append =
-        (fun _ ->
+        (fun stored ->
            if !fail_append
            then (
              record "append_failed";
              Error "chat unavailable")
            else (
              record "append";
-             Ok ACP.Appended))
+             Ok (ACP.Appended { stored with content = "[REDACTED]" })))
     ; retire =
         (fun _ ->
            record "retire";
            pending := [];
            Ok ())
-    ; broadcast = (fun _ -> record "broadcast")
+    ; broadcast = (fun stored -> record ("broadcast:" ^ stored.content))
     }
   in
   (match ACP.record_and_project io intent with
@@ -468,8 +468,73 @@ let test_autonomous_chat_projection_retries_durable_intent () =
   check (list string) "retry succeeds" [] (ACP.retry_pending io |> List.map ACP.issue_to_string);
   check int "successful retry retires intent" 0 (List.length !pending);
   check (list string) "retry appends once before retirement"
-    [ "persist"; "append_failed"; "load"; "append"; "broadcast"; "retire" ]
+    [ "persist"
+    ; "append_failed"
+    ; "load"
+    ; "append"
+    ; "broadcast:[REDACTED]"
+    ; "retire"
+    ]
     (List.rev !events)
+
+let test_autonomous_chat_projection_orders_and_isolates_pending () =
+  let intent absolute_turn content : ACP.intent =
+    { keeper_name = "echo"
+    ; turn_ref =
+        Ids.Turn_ref.make ~trace_id:"projection-order" ~absolute_turn
+    ; content
+    }
+  in
+  let appended = ref [] in
+  let io : ACP.io =
+    { load_pending =
+        (fun () ->
+           Ok
+             { ACP.intents =
+                 [ intent 19 "later"; intent 18 "earlier" ]
+             ; issues = [ "bad.json is invalid" ]
+             })
+    ; persist = (fun _ -> Ok ())
+    ; append =
+        (fun stored ->
+           appended := Ids.Turn_ref.absolute_turn stored.turn_ref :: !appended;
+           Ok (ACP.Appended stored))
+    ; retire = (fun _ -> Ok ())
+    ; broadcast = (fun _ -> ())
+    }
+  in
+  check
+    (list string)
+    "invalid entry is explicit"
+    [ "load_pending: bad.json is invalid" ]
+    (ACP.retry_pending io |> List.map ACP.issue_to_string);
+  check (list int) "valid intents retain turn order" [ 18; 19 ] (List.rev !appended);
+  appended := [];
+  let ambiguous_io =
+    { io with
+      load_pending =
+        (fun () ->
+           Ok
+             { ACP.intents =
+                 [ { (intent 20 "left") with
+                     turn_ref =
+                       Ids.Turn_ref.make ~trace_id:"left" ~absolute_turn:20
+                   }
+                 ; { (intent 20 "right") with
+                     turn_ref =
+                       Ids.Turn_ref.make ~trace_id:"right" ~absolute_turn:20
+                   }
+                 ]
+             ; issues = []
+             })
+    }
+  in
+  check
+    (list string)
+    "ambiguous order is rejected"
+    [ "load_pending: projection intents have ambiguous absolute turn 20" ]
+    (ACP.retry_pending ambiguous_io |> List.map ACP.issue_to_string);
+  check (list int) "ambiguous intents are not guessed" [] !appended
 
 let test_preview_does_not_invent_wake_reason () =
   let preview_meta =
@@ -615,6 +680,8 @@ let () =
             test_autonomous_chat_projection_uses_typed_turn_effect;
           test_case "chat projection retries durable intent" `Quick
             test_autonomous_chat_projection_retries_durable_intent;
+          test_case "chat projection orders and isolates pending" `Quick
+            test_autonomous_chat_projection_orders_and_isolates_pending;
           test_case "preview invents no wake reason" `Quick
             test_preview_does_not_invent_wake_reason;
         ] );

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -391,6 +391,31 @@ let test_bootstrap_stimulus_keeps_reactive_post_action () =
     Alcotest.fail
       "bootstrap stimulus must not be reclassified from reactive to scheduled"
 
+let test_autonomous_chat_projection_requires_work_evidence () =
+  let should_project =
+    Masc.Keeper_unified_turn_success.For_testing.should_project_autonomous_chat
+  in
+  check bool "tool-backed result projects" true
+    (should_project
+       ~response_text:"Implemented task-119."
+       ~has_tool_calls:true
+       ~surface_already_persisted:false);
+  check bool "idle prose does not project" false
+    (should_project
+       ~response_text:"No actionable work."
+       ~has_tool_calls:false
+       ~surface_already_persisted:false);
+  check bool "surface post is not duplicated" false
+    (should_project
+       ~response_text:"Already posted."
+       ~has_tool_calls:true
+       ~surface_already_persisted:true);
+  check bool "blank tool result does not invent speech" false
+    (should_project
+       ~response_text:" "
+       ~has_tool_calls:true
+       ~surface_already_persisted:false)
+
 let test_preview_does_not_invent_wake_reason () =
   let preview_meta =
     { meta with
@@ -531,6 +556,8 @@ let () =
             test_threaded_stimulus_decision_renders_wake_reason;
           test_case "bootstrap keeps reactive post-action" `Quick
             test_bootstrap_stimulus_keeps_reactive_post_action;
+          test_case "chat projection requires work evidence" `Quick
+            test_autonomous_chat_projection_requires_work_evidence;
           test_case "preview invents no wake reason" `Quick
             test_preview_does_not_invent_wake_reason;
         ] );


### PR DESCRIPTION
## 문제

Unified autonomous/reactive turn은 receipt와 Activity Graph에는 남지만, 모델이 `keeper_surface_post`를 직접 호출하지 않으면 Keeper Chat에서 결과를 볼 수 없었습니다.

## 변경

- tool-backed + visible response인 unified turn을 exact `turn_ref`로 Chat에 자동 투영
- `autonomous_turn` delivery identity로 retry/re-entry 중복 방지
- `kind=autonomous_activity`로 일반 assistant reply와 분리
  - pending user reply watermark를 전진시키지 않음
  - direct-conversation context에 재주입하지 않음
  - catch-up direct-message count에 섞지 않음
- 이미 성공한 `keeper_surface_post`가 있으면 자동 투영을 생략
- 무도구 idle prose는 자동 투영하지 않아 #26400 반복 clutter를 악화시키지 않음
- Dashboard에서 writer-declared kind를 `자율 활동` badge로 표시

## 검증

- `pnpm --dir dashboard typecheck` ✅
- focused Vitest: `keeper-state.test.ts`, `chat/primitives.test.ts` — 210 passed ✅
- touched OCaml files parse check (`ocamlc -stop-after parsing`) ✅
- focused Dune build/test: machine-wide full `@default @check @install` lock 점유 중이라 local 실행 대기; PR CI가 build authority

Refs #26492
Related #26400

[근거] current unified success → chat store → history API → Dashboard typed projection 역추적 + live decision/chat JSONL 교차검증 · 2026-07-30 KST · 신뢰도 High