### PR TITLE
fix(runtime): optimize SSE drain clamping and default native streaming

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -348,10 +348,10 @@ end
 (** {1 OAS SSE Bridge Configuration} *)
 
 module Oas_sse = struct
-  (** SSE drain interval (seconds). Default: 2.0. *)
+  (** SSE drain interval (seconds). Default: 0.1s for fast reactive draining. *)
   let drain_interval_sec =
-    let v = get_float ~default:2.0 "MASC_OAS_SSE_DRAIN_INTERVAL_SEC" in
-    if v < 0.1 then 2.0 else v
+    let v = get_float ~default:0.1 "MASC_OAS_SSE_DRAIN_INTERVAL_SEC" in
+    if v < 0.001 then 0.05 else v
 end
 
 (** {1 Lane failover} *)

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -497,7 +497,7 @@ let parse_model_capabilities ~(path : string) (tbl : Otoml.t)
       ; supports_multimodal_inputs = b "supports-multimodal-inputs"
       ; supports_response_format_json = b "supports-response-format-json"
       ; supports_structured_output = b "supports-structured-output"
-      ; supports_native_streaming = b "supports-native-streaming"
+      ; supports_native_streaming = b_default_true "supports-native-streaming"
       ; supports_system_prompt = b "supports-system-prompt"
       ; supports_caching = b "supports-caching"
       ; supports_prompt_caching = b "supports-prompt-caching"


### PR DESCRIPTION
## Summary
- Optimize `MASC_OAS_SSE_DRAIN_INTERVAL_SEC` clamping in `env_config_runtime.ml` so sub-0.1s values are not forcibly clamped to 2.0s sleep.
- Restore `supports_native_streaming` capability default to `true` in `runtime_toml.ml` when unlisted in TOML capabilities.
