### PR TITLE
fix(build): repair main compile after hard-cut drift

### DIFF
--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -523,20 +523,13 @@ let candidate_rejection_detail (rejection : Exact_output.candidate_rejection_rec
 
 (* [Flow_exact_execution_failed] is the branch that carries the provider's own
    verdict, and it was the only flow error settled with no log line at all. *)
-let capacity_refusal_detail : Exact_output.input_capacity_refusal -> string = function
-  | Context_window_refused _ ->
-    "context window refused"
-  | Serialized_request_refused _ ->
-    "serialized request refused"
-;;
-
 let execution_cause_detail : Exact_output.execution_error_cause -> string = function
   | Attempt_already_started -> "attempt already started"
   | Clock_required_for_timeout -> "clock required for timeout"
   | Frozen_request_mismatch -> "frozen request mismatch"
   | Completion_failed -> "completion failed"
-  | Input_capacity_refused refusal ->
-    Printf.sprintf "input capacity refused: %s" (capacity_refusal_detail refusal)
+  | Serialized_request_refused { http_status } ->
+    Printf.sprintf "serialized request refused (http_status=%d)" http_status
   | Incomplete_output -> "incomplete output"
   | Missing_output -> "missing output"
   | Ambiguous_output count -> Printf.sprintf "ambiguous output (candidates=%d)" count

--- a/lib/server/server_dashboard_http_keeper_event_queue_operator_execute.ml
+++ b/lib/server/server_dashboard_http_keeper_event_queue_operator_execute.ml
@@ -132,7 +132,7 @@ let fresh_cancellation_for_request
   in
   let cancellation : Keeper_registry_event_queue.accepted_cancellation =
     { source
-    ; source_revision = expected_revision
+    ; source_incarnation = expected_revision
     ; owner_nonce
     ; operator_operation_id
     ; reason
@@ -157,7 +157,7 @@ let prior_transfer_for_request
   | Some receipt ->
     (match receipt.transition with
      | Keeper_event_queue_state.Transfer_accepted transfer
-       when Int64.equal transfer.source_revision expected_revision
+       when Int64.equal transfer.source_incarnation expected_revision
             && String.equal transfer.from_keeper keeper_name
             && String.equal transfer.to_keeper target_keeper ->
        Ok (Some { transfer; applied_at = receipt.applied_at })
@@ -186,7 +186,7 @@ let fresh_transfer_for_request
   in
   let transfer : Keeper_registry_event_queue.accepted_transfer =
     { source
-    ; source_revision = expected_revision
+    ; source_incarnation = expected_revision
     ; owner_nonce
     ; operator_operation_id
     ; from_keeper = keeper_name

--- a/lib/server/server_dashboard_http_keeper_event_queue_operator_execute.ml
+++ b/lib/server/server_dashboard_http_keeper_event_queue_operator_execute.ml
@@ -105,7 +105,7 @@ let prior_cancellation_for_request
   | Some receipt ->
     (match receipt.transition with
      | Keeper_event_queue_state.Cancel_accepted cancellation
-       when Int64.equal cancellation.source_revision expected_revision
+       when Int64.equal cancellation.source_incarnation expected_revision
             && String.equal cancellation.reason reason ->
        Ok (Some { cancellation; applied_at = receipt.applied_at })
      | Keeper_event_queue_state.Cancel_accepted _

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -203,7 +203,8 @@ let message text =
 
 let expect_unexpected_field field json =
   let inp =
-    { Lib.trace_id = "unexpected-field-t"
+    { Lib.turn_ref =
+        Masc.Ids.Turn_ref.make ~trace_id:"unexpected-field-t" ~absolute_turn:1
     ; messages = [ message "current JSON boundary" ]
     }
   in

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -204,7 +204,7 @@ let message text =
 let expect_unexpected_field field json =
   let inp =
     { Lib.turn_ref =
-        Masc.Ids.Turn_ref.make ~trace_id:"unexpected-field-t" ~absolute_turn:1
+        Ids.Turn_ref.make ~trace_id:"unexpected-field-t" ~absolute_turn:1
     ; messages = [ message "current JSON boundary" ]
     }
   in

--- a/test/test_keeper_manual_compaction_preemption.ml
+++ b/test/test_keeper_manual_compaction_preemption.ml
@@ -174,7 +174,7 @@ let test_owner_intake_compacts_then_resumes_source () =
       check string
         "manual compaction is selected ahead of the source"
         Q.manual_compaction_post_id
-        selected.Keeper_event_queue_state.source.post_id;
+        selected.source.post_id;
       selected
     | None -> fail "manual compaction preemption selected no source"
   in
@@ -203,7 +203,7 @@ let test_owner_intake_compacts_then_resumes_source () =
     check string
       "the exact original source resumes after compaction"
       source.post_id
-      selected.post_id
+      selected.source.post_id
   | None -> fail "the original source disappeared after manual compaction"
 ;;
 

--- a/test/test_keeper_manual_compaction_preemption.ml
+++ b/test/test_keeper_manual_compaction_preemption.ml
@@ -174,7 +174,7 @@ let test_owner_intake_compacts_then_resumes_source () =
       check string
         "manual compaction is selected ahead of the source"
         Q.manual_compaction_post_id
-        selected.post_id;
+        selected.Keeper_event_queue_state.source.post_id;
       selected
     | None -> fail "manual compaction preemption selected no source"
   in

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -380,7 +380,7 @@ let () =
           [ "name", `String "replaced-transcript-owner"
           ; ( "agent_name"
             , `String
-                (Keeper_identity.keeper_agent_name
+                (Masc.Keeper_identity.keeper_agent_name
                    "replaced-transcript-owner") )
           ; "trace_id", `String "trace-replaced-transcript-owner-old"
           ])
@@ -805,7 +805,7 @@ let () =
     meta_fixture_exn
       (`Assoc
         [ "name", `String keeper_name
-        ; "agent_name", `String keeper_name
+        ; "agent_name", `String (Masc.Keeper_identity.keeper_agent_name keeper_name)
         ; "trace_id", `String "trace-checkpoint-turn-persist"
         ])
   in
@@ -848,7 +848,7 @@ let () =
     meta_fixture_exn
       (`Assoc
         [ "name", `String keeper_name
-        ; "agent_name", `String keeper_name
+        ; "agent_name", `String (Masc.Keeper_identity.keeper_agent_name keeper_name)
         ; "trace_id", `String "trace-success-clears-stale-provider-failure"
         ])
   in

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -335,7 +335,7 @@ let () =
       meta_fixture_exn
         (`Assoc
           [ "name", `String "corrupted-transcript"
-          ; "agent_name", `String (Keeper_identity.keeper_agent_name "corrupted-transcript")
+          ; "agent_name", `String (Masc.Keeper_identity.keeper_agent_name "corrupted-transcript")
           ; "trace_id", `String "trace-corrupted-transcript"
           ])
     in

--- a/test/test_librarian_exact_output_conformance.ml
+++ b/test/test_librarian_exact_output_conformance.ml
@@ -995,7 +995,9 @@ let test_prompt_slice_and_provenance_share_one_input () =
           (fun index -> text_message (Printf.sprintf "retained-%d" index))
       in
       let input : Librarian.input =
-        { trace_id = "trace-prompt-provenance-snapshot"
+        { Librarian.turn_ref =
+            Ids.Turn_ref.make
+              ~trace_id:"trace-prompt-provenance-snapshot" ~absolute_turn:1
         ; messages =
             text_message "dropped-before-prompt"
             :: tool_result_message

--- a/test/test_librarian_exact_output_conformance.ml
+++ b/test/test_librarian_exact_output_conformance.ml
@@ -1108,7 +1108,7 @@ let test_fact_upsert_failure_does_not_publish_episode () =
       | Ok _ -> Alcotest.fail "fact upsert failure must block episode publication")))
 ;;
 
-let test_episode_publication_failure_is_typed () =
+let test_episode_corruption_fails_before_publication () =
   with_prompt_registry (fun () ->
     with_temp_keepers_dir (fun keepers_dir ->
       run_eio (fun ~sw ~net ~clock ->
@@ -1129,6 +1129,10 @@ let test_episode_publication_failure_is_typed () =
           Filename.concat keepers_dir keeper_id
           |> Keeper_fs.ensure_dir
         in
+        (* The episodes directory doubles as the generation authority (counter
+           + [trace-gNNNN] scan), so corrupting it fails generation
+           reservation — a typed exact-setup error — before any publication
+           phase runs. *)
         Out_channel.with_open_bin
           (Filename.concat keeper_dir "episodes")
           (fun channel -> output_string channel "not-a-directory");
@@ -1141,20 +1145,22 @@ let test_episode_publication_failure_is_typed () =
         with
         | Error error ->
           Alcotest.(check bool)
-            "episode failure keeps its publication phase"
+            "corrupted episodes authority fails generation reservation"
             true
             (String.starts_with
-               ~prefix:"memory os publication failed phase=episode:"
+               ~prefix:
+                 "exact receipt journal unavailable: generation reservation \
+                  failed:"
                error);
           Alcotest.(check int)
-            "facts were already written before the episode failure"
-            1
+            "no fact was published before the setup failure"
+            0
             (List.length
                (Memory_io.read_facts_all_for_keepers_dir
                   ~keepers_dir
                   ~keeper_id))
         | Ok _ ->
-          Alcotest.fail "episode publication failure escaped its typed result")))
+          Alcotest.fail "corrupted episodes authority escaped its typed result")))
 ;;
 
 let test_event_publication_failure_is_typed () =
@@ -1420,9 +1426,9 @@ let () =
             `Quick
             test_fact_upsert_failure_does_not_publish_episode
         ; Alcotest.test_case
-            "episode publication failure is typed"
+            "corrupted episodes authority fails before publication"
             `Quick
-            test_episode_publication_failure_is_typed
+            test_episode_corruption_fails_before_publication
         ; Alcotest.test_case
             "event publication failure is typed"
             `Quick


### PR DESCRIPTION
## 왜

main이 hard-cut 물결(#26393 큐 hard-cut, #26434/#26440, OAS pin 0.231.4 갱신) 이후 `dune build .`가 6개 파일에서 깨진 상태였어요. CI가 subset만 돌려(#26113) 잡히지 않았습니다. base: main `e53ddedb01`.

## 변경 (전부 현행 타입/API 정합, 새 Gate/Facade/마이그레이션 코드 없음)

- `server_dashboard_http_keeper_event_queue_operator_execute.ml` — `accepted_cancellation`/`accepted_transfer`는 `source_revision`이 아니라 `source_incarnation`을 가짐. operator 멱등 replay 비교를 `source_incarnation`으로 교정 (queue state의 `admitted_revision = cancellation.source_incarnation`와 동일 의미, `keeper_event_queue_state.ml:498`)
- `hitl_summary_worker.ml` — 설치된 OAS(`~/.opam/5.5.0/lib/agent_sdk/llm_provider/exact_output.mli`)에는 `Input_capacity_refused` variant가 없음. 현행 `Serialized_request_refused { http_status }` arm으로 교체
- `test_keeper_manual_compaction_preemption.ml` — `pending_selection.post_id`는 `source` 안으로 이동. `selected.source.post_id` 2곳 + `summary.head`(stimulus) 쪽은 `selected.post_id` 유지
- `test_keeper_terminal_reason_typed.ml` — `Masc.Keeper_identity` 모듈 한정 2곳 + raw `agent_name` fixture 2곳(:808, :851)을 canonical identity(`keeper_agent_name`)로 교정
- `test_keeper_librarian_retry.ml` — `Librarian.input`은 `trace_id`가 아니라 `turn_ref`를 가짐 (`Ids.Turn_ref.make`)
- `test_librarian_exact_output_conformance.ml` — `input`을 `turn_ref`로 이식 + episodes 부패 fixture 현행화: generation 권위가 `episodes/` 스캔(#26466 계열)으로 이동한 뒤에는 `episodes` 파일 부패가 publication 단계가 아니라 generation reservation(exact setup)에서 typed error로 실패함. 테스트를 현행 동작(setup typed error + facts 미기록)에 맞추고 성립하지 않는 `phase=episode` 기대는 숙청

## 검증 (로컬, worktree)

- 대상 6개 `scripts/dune-local.sh build` green
- 테스트 exe 전수 통과: preemption 4/4, terminal_reason OK(matrix 115200 cases), librarian_retry 12/12, exact_output_conformance 18/18
- ocamlformat / `git diff --check` 통과
- 전체 빌드·테스트 권위는 PR CI

## 반경 / 후속

- 같은 패턴의 raw `agent_name` fixture 잔재 15개 파일(런타임 실패 위험, 컴파일은 됨)은 범위가 달라 이슈 #26496으로 분리
- #26435는 이 PR 머지 후 rebase가 필요할 수 있음(브랜치에 같은 깨진 구문 잔존)
- 이전 시도 #26473(closed)의 후속