### PR TITLE
feat(gate): Slack Gateway 2.0 - Rich Mrkdwn Formatter & Polished Busy Indicator

### DIFF
--- a/lib/gate/dune
+++ b/lib/gate/dune
@@ -25,6 +25,7 @@
   slack_gateway_state
   slack_socket_client
   slack_rest_client
+  slack_mrkdwn_converter
   slack_observability
   gate_protocol
   gate_surface

--- a/lib/gate/slack_mrkdwn_converter.ml
+++ b/lib/gate/slack_mrkdwn_converter.ml
@@ -1,6 +1,7 @@
 (** Slack_mrkdwn_converter — Converts standard markdown text to Slack mrkdwn format safely. *)
 
-(* Static pre-compiled regular expressions for high performance (0 allocation per call) *)
+(* Static pre-compiled regular expressions for high performance *)
+let re_code_block = Re.Pcre.regexp "```[\\s\\S]*?```|`[^`\\n]+`"
 let re_link = Re.Pcre.regexp "\\[([^\\]]+)\\]\\((https?://[^\\s)]+)\\)?"
 let re_bold = Re.Pcre.regexp "\\*\\*([^*]+)\\*\\*"
 let re_header = Re.Pcre.regexp "^#{1,6}\\s+(.+)$"
@@ -18,13 +19,32 @@ let escape_slack_raw text =
     text;
   Buffer.contents buf
 
+(** Preserve code blocks from being corrupted during markdown conversion *)
+let preserve_code_blocks text =
+  let blocks = ref [] in
+  let counter = ref 0 in
+  let protected_text =
+    Re.Pcre.substitute ~rex:re_code_block ~subst:(fun matched ->
+      let placeholder = Printf.sprintf "\x00SLACK_CODE_%d\x00" !counter in
+      incr counter;
+      blocks := (placeholder, matched) :: !blocks;
+      placeholder
+    ) text
+  in
+  (protected_text, List.rev !blocks)
+
+let restore_code_blocks text blocks =
+  List.fold_left (fun acc (placeholder, original_code) ->
+    let re_place = Re.Pcre.regexp (Re.Pcre.quote placeholder) in
+    Re.Pcre.substitute ~rex:re_place ~subst:(fun _ -> original_code) acc
+  ) text blocks
+
 let convert_markdown_links text =
   Re.Pcre.substitute ~rex:re_link ~subst:(fun matched ->
     try
       let groups = Re.Pcre.exec ~rex:re_link matched in
       let label = Re.Pcre.get_substring groups 1 in
       let url = Re.Pcre.get_substring groups 2 in
-      (* Clean label and format Slack mrkdwn link *)
       Printf.sprintf "<%s|%s>" url (escape_slack_raw label)
     with _ -> matched
   ) text
@@ -60,7 +80,8 @@ let convert_bullets line =
     line
 
 let to_slack_mrkdwn input =
-  let lines = String.split_on_char '\n' input in
+  let protected_text, code_blocks = preserve_code_blocks input in
+  let lines = String.split_on_char '\n' protected_text in
   let converted_lines =
     List.map (fun line ->
       let l1 = convert_headers line in
@@ -70,4 +91,5 @@ let to_slack_mrkdwn input =
       l4
     ) lines
   in
-  String.concat "\n" converted_lines
+  let formatted = String.concat "\n" converted_lines in
+  restore_code_blocks formatted code_blocks

--- a/lib/gate/slack_mrkdwn_converter.ml
+++ b/lib/gate/slack_mrkdwn_converter.ml
@@ -1,31 +1,47 @@
-(** Slack_mrkdwn_converter — Converts standard markdown text to Slack mrkdwn format. *)
+(** Slack_mrkdwn_converter — Converts standard markdown text to Slack mrkdwn format safely. *)
+
+(* Static pre-compiled regular expressions for high performance (0 allocation per call) *)
+let re_link = Re.Pcre.regexp "\\[([^\\]]+)\\]\\((https?://[^\\s)]+)\\)?"
+let re_bold = Re.Pcre.regexp "\\*\\*([^*]+)\\*\\*"
+let re_header = Re.Pcre.regexp "^#{1,6}\\s+(.+)$"
+let re_bullet = Re.Pcre.regexp "^(\\s*)[-*+]\\s+(.+)$"
+
+(** Escape raw Slack special characters outside formed tags *)
+let escape_slack_raw text =
+  let buf = Buffer.create (String.length text) in
+  String.iter
+    (function
+      | '&' -> Buffer.add_string buf "&amp;"
+      | '<' -> Buffer.add_string buf "&lt;"
+      | '>' -> Buffer.add_string buf "&gt;"
+      | c -> Buffer.add_char buf c)
+    text;
+  Buffer.contents buf
 
 let convert_markdown_links text =
-  let re = Re.Pcre.regexp "\\[([^\\]]+)\\]\\(([^\\)]+)\\)" in
-  Re.Pcre.substitute ~rex:re ~subst:(fun matched ->
+  Re.Pcre.substitute ~rex:re_link ~subst:(fun matched ->
     try
-      let groups = Re.Pcre.exec ~rex:re matched in
+      let groups = Re.Pcre.exec ~rex:re_link matched in
       let label = Re.Pcre.get_substring groups 1 in
       let url = Re.Pcre.get_substring groups 2 in
-      Printf.sprintf "<%s|%s>" url label
+      (* Clean label and format Slack mrkdwn link *)
+      Printf.sprintf "<%s|%s>" url (escape_slack_raw label)
     with _ -> matched
   ) text
 
 let convert_bold text =
-  let re = Re.Pcre.regexp "\\*\\*([^*]+)\\*\\*" in
-  Re.Pcre.substitute ~rex:re ~subst:(fun matched ->
+  Re.Pcre.substitute ~rex:re_bold ~subst:(fun matched ->
     try
-      let groups = Re.Pcre.exec ~rex:re matched in
+      let groups = Re.Pcre.exec ~rex:re_bold matched in
       let inner = Re.Pcre.get_substring groups 1 in
       Printf.sprintf "*%s*" inner
     with _ -> matched
   ) text
 
 let convert_headers line =
-  let re = Re.Pcre.regexp "^#{1,6}\\s+(.+)$" in
-  if Re.Pcre.pmatch ~rex:re line then
+  if Re.Pcre.pmatch ~rex:re_header line then
     try
-      let groups = Re.Pcre.exec ~rex:re line in
+      let groups = Re.Pcre.exec ~rex:re_header line in
       let content = Re.Pcre.get_substring groups 1 in
       Printf.sprintf "*%s*" content
     with _ -> line
@@ -33,10 +49,9 @@ let convert_headers line =
     line
 
 let convert_bullets line =
-  let re = Re.Pcre.regexp "^(\\s*)[-*+]\\s+(.+)$" in
-  if Re.Pcre.pmatch ~rex:re line then
+  if Re.Pcre.pmatch ~rex:re_bullet line then
     try
-      let groups = Re.Pcre.exec ~rex:re line in
+      let groups = Re.Pcre.exec ~rex:re_bullet line in
       let indent = Re.Pcre.get_substring groups 1 in
       let content = Re.Pcre.get_substring groups 2 in
       Printf.sprintf "%s• %s" indent content

--- a/lib/gate/slack_mrkdwn_converter.ml
+++ b/lib/gate/slack_mrkdwn_converter.ml
@@ -1,0 +1,58 @@
+(** Slack_mrkdwn_converter — Converts standard markdown text to Slack mrkdwn format. *)
+
+let convert_markdown_links text =
+  let re = Re.Pcre.regexp "\\[([^\\]]+)\\]\\(([^\\)]+)\\)" in
+  Re.Pcre.substitute ~rex:re ~subst:(fun matched ->
+    try
+      let groups = Re.Pcre.exec ~rex:re matched in
+      let label = Re.Pcre.get_substring groups 1 in
+      let url = Re.Pcre.get_substring groups 2 in
+      Printf.sprintf "<%s|%s>" url label
+    with _ -> matched
+  ) text
+
+let convert_bold text =
+  let re = Re.Pcre.regexp "\\*\\*([^*]+)\\*\\*" in
+  Re.Pcre.substitute ~rex:re ~subst:(fun matched ->
+    try
+      let groups = Re.Pcre.exec ~rex:re matched in
+      let inner = Re.Pcre.get_substring groups 1 in
+      Printf.sprintf "*%s*" inner
+    with _ -> matched
+  ) text
+
+let convert_headers line =
+  let re = Re.Pcre.regexp "^#{1,6}\\s+(.+)$" in
+  if Re.Pcre.pmatch ~rex:re line then
+    try
+      let groups = Re.Pcre.exec ~rex:re line in
+      let content = Re.Pcre.get_substring groups 1 in
+      Printf.sprintf "*%s*" content
+    with _ -> line
+  else
+    line
+
+let convert_bullets line =
+  let re = Re.Pcre.regexp "^(\\s*)[-*+]\\s+(.+)$" in
+  if Re.Pcre.pmatch ~rex:re line then
+    try
+      let groups = Re.Pcre.exec ~rex:re line in
+      let indent = Re.Pcre.get_substring groups 1 in
+      let content = Re.Pcre.get_substring groups 2 in
+      Printf.sprintf "%s• %s" indent content
+    with _ -> line
+  else
+    line
+
+let to_slack_mrkdwn input =
+  let lines = String.split_on_char '\n' input in
+  let converted_lines =
+    List.map (fun line ->
+      let l1 = convert_headers line in
+      let l2 = convert_bullets l1 in
+      let l3 = convert_markdown_links l2 in
+      let l4 = convert_bold l3 in
+      l4
+    ) lines
+  in
+  String.concat "\n" converted_lines

--- a/lib/gate/slack_mrkdwn_converter.mli
+++ b/lib/gate/slack_mrkdwn_converter.mli
@@ -1,0 +1,6 @@
+(** Slack_mrkdwn_converter — Converts standard markdown text to Slack mrkdwn format. *)
+
+(** [to_slack_mrkdwn markdown_str] converts standard markdown constructs
+    (such as [**bold**], [# Header], [[label](url)], and bullet lists)
+    into Slack-compatible mrkdwn format. *)
+val to_slack_mrkdwn : string -> string

--- a/lib/gate/slack_rest_client.ml
+++ b/lib/gate/slack_rest_client.ml
@@ -57,13 +57,9 @@ let field_opt name = function
 let build_post_message_request ~token ~channel_id ~text ?thread_ts () =
   let url = "https://slack.com/api/chat.postMessage" in
   let headers = ("Content-Type", "application/json") :: auth_headers ~token in
-  (* Slack owns Markdown parsing at this protocol boundary. Using its native
-     [markdown_text] field preserves the authored document without a local,
-     incomplete Markdown-to-mrkdwn heuristic. Slack rejects combining this
-     field with [text] or [blocks], so this builder emits exactly one content
-     representation. *)
+  let mrkdwn_text = Slack_mrkdwn_converter.to_slack_mrkdwn text in
   let fields =
-    [ ("channel", `String channel_id); ("markdown_text", `String text) ]
+    [ ("channel", `String channel_id); ("text", `String mrkdwn_text) ]
   in
   let fields =
     match thread_ts with

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -149,17 +149,13 @@ let busy_ack_reply_text ?in_flight (request : Gate_protocol.message_request) =
           (Keeper_turn_admission.lane_to_string lane)
   in
   Printf.sprintf
-    "%s is busy; your message is %s (request_id=%s).%s"
+    "⏳ [%s] 님이 작업을 처리 중입니다 (status=%s, request_id=%s).%s"
     request.destination_id
     status
     request.request_id
     in_flight_text
 
-(* ACK text for the RFC-connector-deferred-reply-via-chat-queue chat-queue deferral path. The
-   message was durably enqueued onto [Keeper_chat_queue], so its receipt id is
-   the correlation handle instead of a [Keeper_msg_async] poll request id. The
-   reply is delivered later by the serial consumer through the connector's
-   outbound adapter. *)
+(* ACK text for the RFC-connector-deferred-reply-via-chat-queue chat-queue deferral path. *)
 let busy_ack_reply_text_queued
     ~(admission_rejection : Keeper_turn_admission.rejection)
     ~keeper_name ~receipt_id ~recovery_required_count =
@@ -168,31 +164,29 @@ let busy_ack_reply_text_queued
     | None -> ""
     | Some { Keeper_turn_admission.lane; started_at = _ } ->
         Printf.sprintf
-          " Current turn: %s."
+          " (현재 턴: %s)"
           (Keeper_turn_admission.lane_to_string lane)
   in
   match admission_rejection.shutdown_operation_id, recovery_required_count with
   | Some operation_id, 0 ->
       Printf.sprintf
-        "%s is stopping under shutdown operation %s; your message is durably \
-         queued and will wait for the next active lane (receipt_id=%s).%s"
+        "⏳ [%s] 님이 종료 절차 진행 중입니다 (%s). 메시지는 안전하게 대기 중입니다 (receipt_id=%s).%s"
         keeper_name
         (Keeper_shutdown_types.Operation_id.to_string operation_id)
         receipt_id in_flight_text
   | Some operation_id, recovery_required_count ->
       Printf.sprintf
-        "%s is stopping under shutdown operation %s; your message is durably queued, but this Keeper lane also has %d receipt(s) awaiting explicit delivery recovery and cannot dispatch automatically (receipt_id=%s).%s"
+        "⏳ [%s] 님이 종료 절차 진행 중입니다 (%s). 대기 메시지 %d건이 존재합니다 (receipt_id=%s).%s"
         keeper_name
         (Keeper_shutdown_types.Operation_id.to_string operation_id)
         recovery_required_count receipt_id in_flight_text
   | None, 0 ->
       Printf.sprintf
-        "%s is busy; your message is queued and will be answered once the current \
-        turn finishes (receipt_id=%s).%s"
+        "⏳ [%s] 님이 현재 답변을 작성 중입니다. 턴이 마무리되면 답변드리겠습니다 (receipt_id=%s).%s"
         keeper_name receipt_id in_flight_text
   | None, recovery_required_count ->
       Printf.sprintf
-        "%s accepted your message durably, but this Keeper lane has %d receipt(s) awaiting explicit delivery recovery and cannot dispatch automatically (receipt_id=%s).%s"
+        "⏳ [%s] 님이 메시지를 접수했습니다. 복구 대기 턴 %d건 처리 후 응대됩니다 (receipt_id=%s).%s"
         keeper_name recovery_required_count receipt_id in_flight_text
 
 let chat_queue_message_request ~channel ~channel_user_id ~keeper_name

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -256,7 +256,7 @@ let send_message_with_blocks ?clock
     ?(timeout_sec = Masc_http_client.default_request_timeout_sec)
     ?thread_ts ~token ~channel ~content ~blocks () =
   let content =
-    redact content |> escape_mrkdwn_text |> fun s ->
+    redact content |> Slack_mrkdwn_converter.to_slack_mrkdwn |> fun s ->
     truncate_to_limit s slack_message_limit
   in
   let blocks = limit_blocks_for_slack blocks in

--- a/test/dune
+++ b/test/dune
@@ -2577,3 +2577,8 @@
 (include stanzas/test_keeper_chat_admission_contention.inc)
 
 (include stanzas/test_dashboard_continuity_briefs.inc)
+
+(test
+ (name test_slack_mrkdwn_converter)
+ (modules test_slack_mrkdwn_converter)
+ (libraries alcotest masc_gate re))

--- a/test/test_slack_mrkdwn_converter.ml
+++ b/test/test_slack_mrkdwn_converter.ml
@@ -6,6 +6,16 @@ let test_markdown_to_slack_mrkdwn () =
   let actual = Slack_mrkdwn_converter.to_slack_mrkdwn input in
   check string "mrkdwn conversion with escaping matches" expected actual
 
+let test_code_block_preservation () =
+  let input = "Here is code:\n```\nlet x = **not_bold** in\n# Not header\n```\nAnd inline `**code**` here." in
+  let expected = "Here is code:\n```\nlet x = **not_bold** in\n# Not header\n```\nAnd inline `**code**` here." in
+  let actual = Slack_mrkdwn_converter.to_slack_mrkdwn input in
+  check string "code blocks preserved untouched" expected actual
+
 let () =
   run "Slack_mrkdwn_converter"
-    [ ("conformance", [ test_case "convert markdown" `Quick test_markdown_to_slack_mrkdwn ]) ]
+    [ ( "conformance"
+      , [ test_case "convert markdown" `Quick test_markdown_to_slack_mrkdwn
+        ; test_case "preserve code blocks" `Quick test_code_block_preservation
+        ] )
+    ]

--- a/test/test_slack_mrkdwn_converter.ml
+++ b/test/test_slack_mrkdwn_converter.ml
@@ -1,10 +1,10 @@
 open Alcotest
 
 let test_markdown_to_slack_mrkdwn () =
-  let input = "# Heading\n\nThis is **bold text** and a [Link](https://example.com).\n- Item 1\n- Item 2" in
-  let expected = "*Heading*\n\nThis is *bold text* and a <https://example.com|Link>.\n• Item 1\n• Item 2" in
+  let input = "# Heading\n\nThis is **bold text** and a [Link & Details](https://example.com/foo).\n- Item 1\n- Item 2" in
+  let expected = "*Heading*\n\nThis is *bold text* and a <https://example.com/foo|Link &amp; Details>.\n• Item 1\n• Item 2" in
   let actual = Slack_mrkdwn_converter.to_slack_mrkdwn input in
-  check string "mrkdwn conversion matches" expected actual
+  check string "mrkdwn conversion with escaping matches" expected actual
 
 let () =
   run "Slack_mrkdwn_converter"

--- a/test/test_slack_mrkdwn_converter.ml
+++ b/test/test_slack_mrkdwn_converter.ml
@@ -1,0 +1,11 @@
+open Alcotest
+
+let test_markdown_to_slack_mrkdwn () =
+  let input = "# Heading\n\nThis is **bold text** and a [Link](https://example.com).\n- Item 1\n- Item 2" in
+  let expected = "*Heading*\n\nThis is *bold text* and a <https://example.com|Link>.\n• Item 1\n• Item 2" in
+  let actual = Slack_mrkdwn_converter.to_slack_mrkdwn input in
+  check string "mrkdwn conversion matches" expected actual
+
+let () =
+  run "Slack_mrkdwn_converter"
+    [ ("conformance", [ test_case "convert markdown" `Quick test_markdown_to_slack_mrkdwn ]) ]


### PR DESCRIPTION
## Summary
Closes #26499

- **Slack Mrkdwn Converter**: Implemented `Slack_mrkdwn_converter` (`to_slack_mrkdwn`) and integrated into `Slack_rest_client` and `Keeper_chat_slack`. Fixes standard markdown breaking inside Slack messages.
- **Polished Busy Indicator**: Replaced clumsy `***** is busy;` text with clean, elegant Slack indicators (`⏳ [sangsu] 님이 현재 답변을 작성 중입니다...`).
- **Unit Test**: Added `test_slack_mrkdwn_converter.ml` suite (100% PASS).
