### PR TITLE
test(keeper): carry on-disk meta version in transfer fixture write_meta

### DIFF
--- a/test/test_keeper_paused_work_transfer_transaction.ml
+++ b/test/test_keeper_paused_work_transfer_transaction.ml
@@ -80,9 +80,18 @@ let write_meta config ~keeper_name ~trace_id ~generation ~paused =
          ])
     |> require_ok "parse Keeper metadata fixture"
   in
+  (* write_meta is a CAS: an existing row must be rewritten at its on-disk
+     version, or the store rejects the write as a version conflict. *)
+  let meta_version =
+    match Keeper_meta_store.read_meta config keeper_name with
+    | Ok (Some existing) -> existing.meta_version
+    | Ok None -> 0
+    | Error detail -> Alcotest.fail detail
+  in
   let meta =
     { meta with
       paused
+    ; meta_version
     ; latched_reason =
         (if paused
          then


### PR DESCRIPTION
## 왜

최신 main(#26489)까지 4개 연속 main CI run이 같은 이유로 실패 중이에요:

```
Transfer_owner 9 generic recovery preserves receipted target identity
FAIL persist Keeper metadata: meta version conflict for active-transfer-target: expected 0, disk has 1
```

## 원인 — 회귀가 아니라 출생 결함

- 테스트 파일/#26477 이후 무변경, `Keeper_meta_store` CAS(#9699~)와 fixture 기본값(`meta_version=0`)도 무변경
- 그런데 #26477의 **Build and Test가 CANCELLED 상태로 머지**돼 이 스위트가 CI에서 한 번도 실행된 적이 없어요
- 헬퍼 `write_meta`가 fresh fixture(버전 0)를 디스크 상의 keeper(버전 1)에 그대로 쓰므로 CAS가 항상 거부 — 태어날 때부터 깨져 있었고, #26488이 컴파일을 고치면서 비로소 노출됐어요

## 변경 (테스트 헬퍼 1곳, 9줄)

`write_meta`를 store 계약에 맞는 RMW로 교정: 기존 row가 있으면 on-disk `meta_version`을 이어받아 재작성. 첫 쓰기(`Ok None`) 동작은 변화 없어요. lib 코드·계약은 건드리지 않아요 — CAS는 의도된 write-boundary 권위라 유지.

## 검증

- `test_keeper_paused_work_transfer_transaction` 10/10 통과 (수정 전 1 fail 재현 확인)
- ocamlformat / `git diff --check` 통과
- 전체 권위는 PR CI

## 별도 제보 (이 PR 범위 밖)

#26477처럼 **Build and Test가 취소됐는데 머지가 통과**한 사례가 반복돼요(#26435도 직전 run이 외부 취소). CI Gate가 cancelled를 사실상 통과로 취급하는 구멍으로 보여요. 별도 이슈로 정리할게요.