### PR TITLE
fix(keeper): hard-cut dead persona fields

### DIFF
--- a/config/personas/code-reviewer/profile.json
+++ b/config/personas/code-reviewer/profile.json
@@ -3,12 +3,6 @@
   "role": "코드 산출물 리뷰어. diff, PR, commit 을 읽고 결함을 findings 로 남기는 keeper.",
   "trait": "산출물만 본다. 요약을 신뢰하지 않고 변경된 코드를 직접 읽는다.",
   "keeper": {
-    "short_goal": "변경된 코드를 읽고 결함을 board comment 와 task 로 남긴다.",
-    "mid_goal": "결함이 리뷰 단계에서 발견되어 main 에 도달하지 않게 한다.",
-    "long_goal": "코드베이스에 누적되는 워크어라운드 패턴을 리뷰 단계에서 차단한다.",
-    "will": "완료 보고문을 읽지 않고 diff 를 읽는다. 보고와 코드가 다르면 코드를 믿는다.",
-    "needs": "변경 대상 diff 또는 PR, 관련 파일 원문, 테스트 실행 결과",
-    "desires": "모든 결함에 file:line 과 재현 조건이 붙은 findings.",
     "instructions": "너는 code-reviewer 다. 코드 산출물을 읽고 결함을 찾는다.\n\n권한 경계 (가장 중요):\n- 너는 task 완료를 판정하지 않는다. masc_transition 의 approve 와 reject 는 너의 도구가 아니다. 호출하지 마라.\n- task 상태를 바꾸는 것은 너의 일이 아니다. 너는 리뷰 결과만 기록한다.\n- 완료 판정은 keeper 가 아닌 경계(HITL 확인 또는 fusion judge)가 내린다. 네가 그 자리를 대신하려 하면 리뷰가 아니라 승인이 된다.\n\n리뷰 절차:\n1. 리뷰 대상을 확정한다. PR 번호, commit SHA, 또는 파일 경로. 대상이 불명확하면 board 에 무엇을 리뷰해야 하는지 묻고 끝낸다.\n2. diff 를 읽는다. Execute 로 git diff 또는 gh pr diff 를 쓴다. 요약문이나 completion notes 로 리뷰를 대체하지 않는다.\n3. 변경된 각 파일의 원문을 Read 로 읽는다. diff 만으로는 삭제된 호출자와 남은 호출자를 구분할 수 없다.\n4. 변경된 함수의 호출처를 Grep 으로 전수 확인한다. 호출처 확인 없이 시그니처 변경을 승인 의견으로 쓰지 않는다.\n5. findings 를 board comment 로 남긴다. 각 finding 에는 file:line, 증상, 재현 조건, 근본 원인 추정을 쓴다.\n6. 후속 작업이 필요한 finding 은 masc_add_task 로 task 를 만든다. 제목에 대상 파일을 넣는다.\n\n무엇을 결함으로 보는가:\n- silent failure: 에러를 로그만 남기고 진행하는 경로, 값이 없을 때 기본값으로 대체하는 경로.\n- unknown 을 permissive default 로 매핑하는 match 의 wildcard 브랜치.\n- 타입으로 표현 가능한 것을 string 비교로 분류하는 코드.\n- 같은 리터럴이 두 곳 이상에 복제된 설정값.\n- catch-all 추가, cap 또는 cooldown 또는 dedup 으로 증상을 억제하는 변경. 이것들은 원인을 고치지 않는다.\n- counter 나 metric 만 추가하고 실패 자체는 그대로 두는 변경. 관측은 수정이 아니다.\n- 테스트 없는 동작 변경.\n- 픽스처 지오메트리에서만 통과하고 프로덕션 경로에서는 발화하지 않는 가드.\n\n증거 규칙:\n- 직접 읽은 것만 쓴다. 심볼이 존재한다고 추측하지 않는다.\n- 부재를 주장할 때는 검색 형태를 두 가지 이상 바꿔 확인한 뒤에 쓴다. 한 번의 검색 결과 0건은 부재의 근거가 아니다.\n- 수치를 쓸 때는 그 수치를 낸 명령을 함께 쓴다.\n\nidle 규칙:\n- 리뷰할 산출물이 없으면 board 에 리뷰 대상 없음을 기록하고 끝낸다. 없는 대상을 찾아 헤매지 않는다.\n- 이미 리뷰한 SHA 를 다시 리뷰하지 않는다. head 가 움직였으면 새 SHA 만 본다.\n\n정체성: 너는 code-reviewer 다. adversary 는 주장과 계획을 반박하는 keeper 이고, 너는 코드 산출물을 읽는 keeper 다. 보드에서 다른 keeper 의 글을 읽어도 그건 네 발화가 아니다.\n",
     "mention_targets": [
       "code-reviewer",

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -164,23 +164,22 @@ let keeper_schemas : tool_schema list = [
           ("items", `Assoc [("type", `String "string")]);
           ("description", `String "Goal IDs this keeper is allowed to claim work for. Empty clears goal scoping.");
         ]);
-        ("sandbox_profile", `Assoc [
-          ("type", `String "string");
-          ("enum", `List [`String "local"; `String "docker"]);
-          ("default", `String "local");
-          ("description", `String "Sandbox isolation profile. New keepers default to local with playground-only writes when omitted; select docker explicitly when required.");
-        ]);
         ("autoboot_enabled", `Assoc [
           ("type", `String "boolean");
           ("description", `String "If false, persist the keeper but skip auto-start on future server boots.");
         ]);
         ("proactive_enabled", `Assoc [("type", `String "boolean")]);
+        ("runtime_id", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional opaque runtime id. Creation writes the keeper assignment to runtime.toml; persona profiles never own runtime selection.");
+        ]);
         ("allowed_paths", `Assoc [
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);
         ]);
       ]);
       ("required", `List [`String "persona_name"]);
+      ("additionalProperties", `Bool false);
     ];
   };
 
@@ -254,6 +253,10 @@ let keeper_schemas : tool_schema list = [
         ("proactive_enabled", `Assoc [
           ("type", `String "boolean");
           ("description", `String "If true, scheduled keeper cycles may produce proactive responses.");
+        ]);
+        ("runtime_id", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional opaque runtime id. Writes the keeper assignment to runtime.toml.");
         ]);
         ("allowed_paths", `Assoc [
           ("type", `String "array");

--- a/lib/keeper/keeper_tool_persona_crud.ml
+++ b/lib/keeper/keeper_tool_persona_crud.ml
@@ -110,8 +110,8 @@ let validate_create_args args =
      - keeper template defaults, nested under ["keeper"]: ["instructions"],
        ["mention_targets"], ["proactive_enabled"] — read by
        [Keeper_types_profile_persona_defaults.load_from_path], which only ever
-       inspects the ["keeper"] member and rejects removed fields
-       (tool_access/tool_denylist) fail-closed.
+       inspects the ["keeper"] member and rejects every field outside its
+       closed contract.
 
    Earlier this tool wrote every field at the top level under different keys
    (["display_name"] instead of ["name"]; the keeper-template fields at the

--- a/lib/keeper/keeper_tool_persona_runtime.ml
+++ b/lib/keeper/keeper_tool_persona_runtime.ml
@@ -40,12 +40,78 @@ let find_jsonl_row_by_action_id rows action_id =
          | Some candidate when candidate = action_id -> Some json
          | _ -> None)
 
+let create_from_persona_arg_names =
+  [ "active_goal_ids"
+  ; "allowed_paths"
+  ; "autoboot_enabled"
+  ; "dry_run"
+  ; "instructions"
+  ; "mention_targets"
+  ; "name"
+  ; "persona_name"
+  ; "proactive_enabled"
+  ; "runtime_id"
+  ]
+
+let validate_create_from_persona_args = function
+  | `Assoc fields ->
+      let unsupported =
+        fields
+        |> List.filter_map (fun (key, _) ->
+          if List.mem key create_from_persona_arg_names then None else Some key)
+        |> List.sort_uniq String.compare
+      in
+      if unsupported <> [] then
+        Error
+          (Printf.sprintf
+             "unsupported masc_keeper_create_from_persona arguments: %s"
+             (String.concat ", " unsupported))
+      else
+        let expected_kind key value =
+          match key, value with
+          | ("active_goal_ids" | "allowed_paths" | "mention_targets"), `List items
+            when List.for_all (function `String _ -> true | _ -> false) items ->
+              None
+          | ("autoboot_enabled" | "dry_run" | "proactive_enabled"), `Bool _ ->
+              None
+          | ("instructions" | "name" | "persona_name" | "runtime_id"), `String _ ->
+              None
+          | ("active_goal_ids" | "allowed_paths" | "mention_targets"), _ ->
+              Some "an array of strings"
+          | ("autoboot_enabled" | "dry_run" | "proactive_enabled"), _ ->
+              Some "a boolean"
+          | ("instructions" | "name" | "persona_name" | "runtime_id"), _ ->
+              Some "a string"
+          | _ -> None
+        in
+        (match
+           List.find_map
+             (fun (key, value) ->
+               Option.map (fun expected -> key, expected, value)
+                 (expected_kind key value))
+             fields
+         with
+         | None -> Ok ()
+         | Some (key, expected, value) ->
+             Error
+               (Printf.sprintf
+                  "%s must be %s (received %s)"
+                  key expected (Json_util.kind_name value)))
+  | value ->
+      Error
+        (Printf.sprintf
+           "masc_keeper_create_from_persona arguments must be an object \
+            (received %s)"
+           (Json_util.kind_name value))
+
 let resolved_keeper_args_to_json
     ~name ~persona_name
     ~instructions
     ~mention_targets
     ~allowed_paths_opt
+    ~active_goal_ids_opt
     ~autoboot_enabled_opt
+    ~runtime_id_opt
     ~proactive_enabled =
   let base =
     [
@@ -66,8 +132,22 @@ let resolved_keeper_args_to_json
     | Some value -> [ ("autoboot_enabled", `Bool value) ]
     | None -> []
   in
+  let active_goal_ids_field =
+    match active_goal_ids_opt with
+    | Some ids -> [("active_goal_ids", Json_util.json_string_list ids)]
+    | None -> []
+  in
+  let runtime_id_field =
+    match runtime_id_opt with
+    | Some runtime_id -> [("runtime_id", `String runtime_id)]
+    | None -> []
+  in
   `Assoc
-    (base @ allowed_paths_field @ autoboot_field)
+    (base
+     @ allowed_paths_field
+     @ active_goal_ids_field
+     @ autoboot_field
+     @ runtime_id_field)
 
 let toml_escape_string value =
   let buf = Buffer.create (String.length value + 8) in
@@ -220,6 +300,9 @@ let resolved_keeper_args_from_persona args :
             ~tool_name:"masc_keeper_create_from_persona" args with
     | Error err -> Error err
     | Ok () ->
+    match validate_create_from_persona_args args with
+    | Error err -> Error err
+    | Ok () ->
     match load_persona_summary persona_name with
     | None ->
         Error
@@ -258,9 +341,30 @@ let resolved_keeper_args_from_persona args :
               |> Option.value ~default:false
             in
             let autoboot_enabled = get_bool_opt args "autoboot_enabled" in
-            (match Keeper_turn_up_args.parse_present_string_list_opt args "allowed_paths" with
-            | Error err -> Error err
-            | Ok allowed_paths_opt ->
+            let runtime_id_result =
+              match Json_util.assoc_member_opt "runtime_id" args with
+              | None -> Ok None
+              | Some (`String value) when String.trim value <> "" ->
+                  Ok (Some (String.trim value))
+              | Some (`String _) -> Error "runtime_id must not be empty"
+              | Some value ->
+                  Error
+                    (Printf.sprintf
+                       "runtime_id must be a string (received %s)"
+                       (Json_util.kind_name value))
+            in
+            (match
+               Keeper_turn_up_args.parse_present_string_list_opt
+                 args "allowed_paths",
+               Keeper_turn_up_args.parse_present_string_list_opt
+                 args "active_goal_ids",
+               runtime_id_result
+             with
+            | Error err, _, _
+            | _, Error err, _
+            | _, _, Error err -> Error err
+            | Ok allowed_paths_opt, Ok active_goal_ids_opt,
+              Ok runtime_id_opt ->
                  let allowed_paths =
                    match allowed_paths_opt with
                    | Some _ as paths -> paths
@@ -273,7 +377,9 @@ let resolved_keeper_args_from_persona args :
                      ~instructions
                      ~mention_targets
                      ~allowed_paths_opt:allowed_paths
+                     ~active_goal_ids_opt
                      ~autoboot_enabled_opt:autoboot_enabled
+                     ~runtime_id_opt
                      ~proactive_enabled
                  in
                  (match json_operator_todo_placeholder_paths resolved with

--- a/lib/keeper/keeper_types_profile_persona_defaults.ml
+++ b/lib/keeper/keeper_types_profile_persona_defaults.ml
@@ -11,6 +11,23 @@ type load_error =
   ; detail : string
   }
 
+let supported_keeper_fields =
+  [ "always_allow"
+  ; "instructions"
+  ; "mention_targets"
+  ; "proactive_enabled"
+  ; "telemetry_feedback_enabled"
+  ; "telemetry_feedback_window_hours"
+  ]
+
+let unsupported_keeper_fields = function
+  | `Assoc fields ->
+      fields
+      |> List.filter_map (fun (key, _) ->
+        if List.mem key supported_keeper_fields then None else Some key)
+      |> List.sort_uniq String.compare
+  | _ -> []
+
 let load_from_path ~name path : (keeper_profile_defaults, load_error) result =
   let error kind detail = Error { path; kind; detail } in
   match Safe_ops.read_file_safe path with
@@ -18,7 +35,7 @@ let load_from_path ~name path : (keeper_profile_defaults, load_error) result =
   | Ok content ->
     (match Safe_ops.parse_json_safe ~context:path content with
      | Error detail -> error Persona_parse_error detail
-     | Ok json ->
+     | Ok (`Assoc _ as json) ->
       if
         Keeper_types_profile_persona.reject_placeholder_persona_profile
           ~label:"load_keeper_profile_defaults" ~path json
@@ -29,34 +46,16 @@ let load_from_path ~name path : (keeper_profile_defaults, load_error) result =
           | Some v -> v
           | None -> `Null
         in
-        let removed_fields =
-          [ "goal"
-          ; "tool_access"
-          ; "tool_denylist"
-          ; "shards"
-          ; "policy_voice_enabled"
-          ]
-          |> List.filter (fun key ->
-            Option.is_some (Json_util.assoc_member_opt key keeper_json))
-        in
-        if removed_fields <> [] then
-          error Persona_parse_error
-            (Printf.sprintf
-               "removed persona keeper fields are no longer supported: %s"
-               (String.concat ", " removed_fields))
-        else (
-        (* Persona profiles do not own a
-           runtime/model selection. Warn so stale manifests are visible. *)
-        (match Safe_ops.json_string_opt "model" keeper_json with
-         | Some raw ->
-             Log.Keeper.warn
-               "persona profile %s has a [model] key (%s); ignored - \
-                keeper->runtime assignment lives in runtime.toml \
-                [[runtime.assignments]]"
-               path raw
-         | None -> ());
         match keeper_json with
         | `Assoc _ ->
+          let unsupported_fields = unsupported_keeper_fields keeper_json in
+          if unsupported_fields <> [] then
+            error Persona_parse_error
+              (Printf.sprintf
+                 "unsupported persona keeper fields: %s. Supported fields: %s"
+                 (String.concat ", " unsupported_fields)
+                 (String.concat ", " supported_keeper_fields))
+          else
             Ok
               {
               id = Some (Ids.Keeper_id.generate ~name ~path);
@@ -81,7 +80,13 @@ let load_from_path ~name path : (keeper_profile_defaults, load_error) result =
               oas_env = [];
               unknown_toml_keys = [];
               }
-        | _ -> Ok { empty_keeper_profile_defaults with manifest_path = Some path })))
+        | `Null ->
+            Ok { empty_keeper_profile_defaults with manifest_path = Some path }
+        | _ ->
+            error Persona_parse_error
+              "persona profile field [keeper] must be a JSON object")
+     | Ok _ ->
+       error Persona_parse_error "persona profile root must be a JSON object")
 
 let load_from_dirs ~persona_dirs ~name : (keeper_profile_defaults, load_error) result =
   match

--- a/scripts/harness_tool_call_quality.sh
+++ b/scripts/harness_tool_call_quality.sh
@@ -264,39 +264,26 @@ EOF
 write_benchmark_persona_profile() {
   local persona_name="$1"
   local keeper_profile="$2"
-  local model_label="$3"
   local persona_dir profile_path
-  local display_name role trait goal short_goal mid_goal long_goal instructions
+  local display_name role trait instructions
 
   case "${keeper_profile}" in
     bench-analyst)
       display_name="Benchmark Analyst"
       role="Repeatable tool-quality analyst"
       trait="Deterministic evidence-first analyst"
-      goal="같은 입력에서 같은 도구 선택과 같은 근거 구조가 반복되도록 tool-quality benchmark 과제를 수행한다."
-      short_goal="지정된 과제를 필요한 최소 도구로 해결하고 동일한 evidence 경로를 재현한다."
-      mid_goal="benchmark 전반에서 불필요한 도구 호출을 줄이고 근거 기반 응답만 남긴다."
-      long_goal="provider:model 간 tool 선택 품질 차이를 낮은 분산으로 비교 가능한 형태로 남긴다."
       instructions="너는 tool-quality benchmark 전용 analyst keeper다. 같은 입력에서 같은 근거와 같은 도구 선택이 반복되도록 행동한다. 허용된 도구가 필요할 때만 호출하고, text-only로 해결 가능하면 도구를 호출하지 않는다. 답은 짧고 구조적으로 유지하고, 최종 판단은 evidence 기반으로만 내린다."
       ;;
     bench-executor)
       display_name="Benchmark Executor"
       role="Repeatable tool-quality executor"
       trait="Deterministic completion-focused executor"
-      goal="같은 입력에서 가능한 한 같은 순서와 같은 최소 도구 집합으로 benchmark 과제를 끝낸다."
-      short_goal="max_tool_calls 안에서 필요한 도구만 사용해 과제를 완료한다."
-      mid_goal="tool sequence와 완료 경로를 반복 가능하게 유지한다."
-      long_goal="completion 중심 keeper 프로필의 tool quality를 낮은 분산으로 비교 가능하게 만든다."
       instructions="너는 tool-quality benchmark 전용 executor keeper다. 같은 입력에서는 가능한 한 같은 순서와 같은 최소 도구 집합으로 과제를 끝낸다. 필요한 도구만 호출하고, max_tool_calls 안에서 끝내는 것을 우선한다. 실패하면 무작정 반복하지 말고 한 번 다른 경로로 회복한 뒤 바로 마무리한다. 최종 출력은 완료 여부와 핵심 evidence만 남긴다."
       ;;
     bench-verifier)
       display_name="Benchmark Verifier"
       role="Repeatable tool-quality verifier"
       trait="Deterministic recovery-focused verifier"
-      goal="같은 입력에서 같은 검증 절차를 반복 가능하게 수행하고, 필요한 경우 한 번만 회복한다."
-      short_goal="검증 과제를 측정 가능한 evidence로 판정하고, 회복이 필요하면 한 번만 전환한다."
-      mid_goal="failure 이후 recovery 경로의 품질을 반복 가능한 방식으로 남긴다."
-      long_goal="verification 중심 keeper 프로필의 tool quality와 recovery 품질을 비교 가능하게 만든다."
       instructions="너는 tool-quality benchmark 전용 verifier keeper다. 같은 입력에서 같은 검증 절차를 반복 가능하게 수행한다. 검증이 필요하면 측정 가능한 evidence를 우선하고, 실패 후 회복이 필요하면 다른 도구나 다른 인자로 한 번만 전환한다. 추측으로 통과시키지 않는다. 출력은 pass/fail와 미충족 조건을 명확히 남긴다."
       ;;
     *)
@@ -312,28 +299,17 @@ write_benchmark_persona_profile() {
     --arg name "${display_name}" \
     --arg role "${role}" \
     --arg trait "${trait}" \
-    --arg goal "${goal}" \
-    --arg short_goal "${short_goal}" \
-    --arg mid_goal "${mid_goal}" \
-    --arg long_goal "${long_goal}" \
     --arg instructions "${instructions}" \
     --arg mention "${keeper_profile}" \
-    --arg model "${model_label}" \
     '{
       name: $name,
       role: $role,
       trait: $trait,
       keeper: {
-        goal: $goal,
-        short_goal: $short_goal,
-        mid_goal: $mid_goal,
-        long_goal: $long_goal,
         instructions: $instructions,
         mention_targets: [$mention],
         proactive_enabled: false,
-        telemetry_feedback_enabled: false,
-        runtime_id: "keeper_unified",
-        models: [$model]
+        telemetry_feedback_enabled: false
       }
     }' > "${profile_path}"
 }
@@ -625,12 +601,11 @@ stop_keeper_best_effort() {
 run_live_case() {
   local provider="$1"
   local model="$2"
-  local model_label="$3"
-  local keeper_profile="$4"
-  local repeat_index="$5"
-  local case_json="$6"
+  local keeper_profile="$3"
+  local repeat_index="$4"
+  local case_json="$5"
 
-  local case_id keeper_name run_slug run_dir persona_name
+  local case_id keeper_name run_slug run_dir persona_name runtime_id
   local message create_args create_json status_before_json status_after_json
   local request_json request_id result_json msg_payload final_output tool_log_json
   local tool_calls_json metrics_json prompt_fingerprint tool_surface_fingerprint
@@ -642,17 +617,20 @@ run_live_case() {
   run_slug="$(slugify "${provider}-${model}-${keeper_profile}-${case_id}-r${repeat_index}")"
   keeper_name="bench-${run_slug}"
   persona_name="${keeper_name}"
+  runtime_id="${provider}.${model}"
   run_dir="${RAW_DIR}/${keeper_name}"
   mkdir -p "${run_dir}"
 
-  write_benchmark_persona_profile "${persona_name}" "${keeper_profile}" "${model_label}"
+  write_benchmark_persona_profile "${persona_name}" "${keeper_profile}"
   message="$(build_case_message "${case_json}")"
 
   create_args="$(jq -cn \
     --arg persona_name "${persona_name}" \
+    --arg runtime_id "${runtime_id}" \
     --argjson allowed_paths "$(jq -cn --arg path "${WORKSPACE_ROOT}" '[ $path ]')" \
     '{
       persona_name: $persona_name,
+      runtime_id: $runtime_id,
       autoboot_enabled: false,
       proactive_enabled: false,
       allowed_paths: $allowed_paths
@@ -940,7 +918,7 @@ run_live_harness() {
       while IFS= read -r keeper_profile; do
         [[ -z "${keeper_profile}" ]] && continue
         for (( repeat_index = 1; repeat_index <= REPEATS; repeat_index++ )); do
-          run_live_case "${provider}" "${model}" "${model_label}" "${keeper_profile}" "${repeat_index}" "${case_json}" \
+          run_live_case "${provider}" "${model}" "${keeper_profile}" "${repeat_index}" "${case_json}" \
             >> "${evidence_jsonl}"
         done
       done < <(keeper_profiles_for_case "${case_json}")

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1217,19 +1217,32 @@ let test_persona_defaults_load_prompt_fields () =
   check (option string) "instructions load" (Some "legacy instructions")
     defaults.instructions
 
-let test_persona_defaults_reject_legacy_goal () =
+let test_persona_defaults_reject_unsupported_keeper_fields () =
   with_personas_dir @@ fun personas_dir ->
   let persona_dir = Filename.concat personas_dir "probe" in
   mkdir_p persona_dir;
   write_file
     (Filename.concat persona_dir "profile.json")
-    {|{"name":"Probe","keeper":{"goal":"removed"}}|};
+    {|{
+  "name": "Probe",
+  "keeper": {
+    "short_goal": "dead horizon",
+    "will": "dead self-model",
+    "model": "dead runtime assignment"
+  }
+}|};
   match KTP.load_keeper_profile_defaults_result "probe" with
-  | Ok _ -> fail "removed persona keeper.goal must fail loading"
+  | Ok _ -> fail "unsupported persona keeper fields must fail loading"
   | Error error ->
     let detail = KTP.keeper_toml_load_error_to_string error in
-    check bool "persona error names goal" true
-      (contains_substring detail "goal")
+    check bool "persona error identifies unsupported contract" true
+      (contains_substring detail "unsupported persona keeper fields");
+    check bool "persona error names short_goal" true
+      (contains_substring detail "short_goal");
+    check bool "persona error names will" true
+      (contains_substring detail "will");
+    check bool "persona error names model" true
+      (contains_substring detail "model")
 
 let test_persona_defaults_reject_removed_shards () =
   with_personas_dir @@ fun personas_dir ->
@@ -1255,6 +1268,28 @@ let test_persona_defaults_reject_removed_shards () =
       "persona error names voice policy"
       true
       (contains_substring detail "policy_voice_enabled")
+
+let test_persona_defaults_reject_non_object_shapes () =
+  with_personas_dir @@ fun personas_dir ->
+  let persona_dir = Filename.concat personas_dir "probe" in
+  mkdir_p persona_dir;
+  let profile_path = Filename.concat persona_dir "profile.json" in
+  write_file profile_path {|{"name":"Probe","keeper":"invalid"}|};
+  (match KTP.load_keeper_profile_defaults_result "probe" with
+   | Ok _ -> fail "non-object persona keeper must fail loading"
+   | Error error ->
+     check bool "nested shape error names keeper" true
+       (contains_substring
+          (KTP.keeper_toml_load_error_to_string error)
+          "keeper"));
+  write_file profile_path {|["invalid root"]|};
+  match KTP.load_keeper_profile_defaults_result "probe" with
+  | Ok _ -> fail "non-object persona root must fail loading"
+  | Error error ->
+    check bool "root shape error names root" true
+      (contains_substring
+         (KTP.keeper_toml_load_error_to_string error)
+         "root")
 
 let test_persona_resolver_rejects_operator_todo_profile () =
   with_personas_dir @@ fun personas_dir ->
@@ -1386,6 +1421,61 @@ let test_persona_resolver_preserves_allowed_paths () =
                items
          | _ -> [])
 
+let test_persona_resolver_preserves_runtime_owned_overrides () =
+  with_personas_dir @@ fun personas_dir ->
+  let persona_dir = Filename.concat personas_dir "probe" in
+  mkdir_p persona_dir;
+  write_file
+    (Filename.concat persona_dir "profile.json")
+    {|{"name":"Probe","keeper":{"instructions":"test persona keeper"}}|};
+  match
+    KEP.resolved_keeper_args_from_persona
+      (`Assoc
+        [ "persona_name", `String "probe"
+        ; "runtime_id", `String "runtime.opaque"
+        ; "active_goal_ids", `List [ `String "goal-1" ]
+        ])
+  with
+  | Error e -> fail ("resolver failed: " ^ e)
+  | Ok (_, resolved) ->
+      check string "runtime_id preserved" "runtime.opaque"
+        (Yojson.Safe.Util.member "runtime_id" resolved
+         |> Yojson.Safe.Util.to_string);
+      check (list string) "active_goal_ids preserved" [ "goal-1" ]
+        (Yojson.Safe.Util.member "active_goal_ids" resolved
+         |> Yojson.Safe.Util.to_list
+         |> List.map Yojson.Safe.Util.to_string)
+
+let test_persona_resolver_rejects_unsupported_or_ill_typed_args () =
+  with_personas_dir @@ fun personas_dir ->
+  let persona_dir = Filename.concat personas_dir "probe" in
+  mkdir_p persona_dir;
+  write_file
+    (Filename.concat persona_dir "profile.json")
+    {|{"name":"Probe","keeper":{"instructions":"test persona keeper"}}|};
+  (match
+     KEP.resolved_keeper_args_from_persona
+       (`Assoc
+         [ "persona_name", `String "probe"
+         ; "unknown_arg", `String "must fail closed"
+         ])
+   with
+   | Ok _ -> fail "unknown persona creation argument must fail"
+   | Error e ->
+       check bool "unknown argument named" true
+         (contains_substring e "unknown_arg"));
+  match
+    KEP.resolved_keeper_args_from_persona
+      (`Assoc
+        [ "persona_name", `String "probe"
+        ; "proactive_enabled", `String "not-a-boolean"
+        ])
+  with
+  | Ok _ -> fail "ill-typed persona creation argument must fail"
+  | Error e ->
+      check bool "ill-typed argument named" true
+        (contains_substring e "proactive_enabled")
+
 let test_persona_resolver_renders_durable_keeper_toml () =
   let resolved =
     `Assoc
@@ -1397,6 +1487,8 @@ let test_persona_resolver_renders_durable_keeper_toml () =
         ("mention_targets", `List [ `String "probe"; `String "@probe" ]);
         ("proactive_enabled", `Bool true);
         ("allowed_paths", `List [ `String "/tmp/probe" ]);
+        ("active_goal_ids", `List [ `String "goal-1" ]);
+        ("runtime_id", `String "runtime.opaque");
       ]
   in
   match KEP.render_keeper_toml_from_resolved_args resolved with
@@ -1419,7 +1511,11 @@ let test_persona_resolver_renders_durable_keeper_toml () =
               check (list string) "mention targets"
                 [ "probe"; "@probe" ] defaults.mention_targets;
               check (option (list string)) "allowed_paths"
-                (Some [ "/tmp/probe" ]) defaults.allowed_paths))
+                (Some [ "/tmp/probe" ]) defaults.allowed_paths;
+              check (option (list string)) "active_goal_ids"
+                (Some [ "goal-1" ]) defaults.active_goal_ids;
+              check bool "runtime_id excluded from keeper TOML" false
+                (contains_substring toml "runtime_id")))
 
 (* ================================================================ *)
 (* Unknown-key detection                                             *)
@@ -1991,10 +2087,12 @@ let () =
             test_bundled_issue_king_uses_local_sandbox;
           test_case "persona defaults load prompt fields" `Quick
             test_persona_defaults_load_prompt_fields;
-          test_case "persona defaults reject legacy goal" `Quick
-            test_persona_defaults_reject_legacy_goal;
+          test_case "persona defaults reject unsupported keeper fields" `Quick
+            test_persona_defaults_reject_unsupported_keeper_fields;
           test_case "persona defaults reject removed shards" `Quick
             test_persona_defaults_reject_removed_shards;
+          test_case "persona defaults reject non-object shapes" `Quick
+            test_persona_defaults_reject_non_object_shapes;
           test_case "persona resolver rejects OPERATOR_TODO profile" `Quick
             test_persona_resolver_rejects_operator_todo_profile;
           test_case "persona resolver rejects placeholder in resolved payload" `Quick
@@ -2003,6 +2101,10 @@ let () =
             test_persona_resolver_preserves_autoboot_enabled_arg;
           test_case "persona resolver preserves allowed_paths" `Quick
             test_persona_resolver_preserves_allowed_paths;
+          test_case "persona resolver preserves runtime-owned overrides" `Quick
+            test_persona_resolver_preserves_runtime_owned_overrides;
+          test_case "persona resolver rejects unsupported or ill-typed args" `Quick
+            test_persona_resolver_rejects_unsupported_or_ill_typed_args;
           test_case "persona resolver renders durable keeper TOML" `Quick
             test_persona_resolver_renders_durable_keeper_toml;
         ] );

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -549,6 +549,10 @@ let test_masc_keeper_create_from_persona_schema () =
       | Some props ->
           Alcotest.(check bool) "has persona_name" true
             (List.mem_assoc "persona_name" props);
+          Alcotest.(check bool) "has runtime_id" true
+            (List.mem_assoc "runtime_id" props);
+          Alcotest.(check bool) "omits removed sandbox_profile" false
+            (List.mem_assoc "sandbox_profile" props);
           Alcotest.(check bool) "omits removed goal" false
             (List.mem_assoc "goal" props);
           Alcotest.(check bool) "omits retired shards" false


### PR DESCRIPTION
## Summary

- reject every persona `keeper` field outside the current closed contract, including retired goal horizons, self-model fields, and persona-owned model/runtime selection
- remove dead horizon/self-model data from the bundled code-reviewer and tool-call-quality benchmark personas
- route live benchmark runtime selection through the typed `runtime_id` creation argument, which writes the keeper assignment to `runtime.toml`
- preserve `active_goal_ids` across the create-from-persona facade and remove the already-rejected `sandbox_profile` facade field

## Contract

- RFC-0211: persona profiles do not own model/runtime selection; `runtime.toml` assignments are the SSOT
- RFC-0282: `will` / `needs` / `desires` are removed
- RFC-0288: short/mid/long goal horizons are removed
- no migration or compatibility reader is added; stale fields fail closed

## Validation

- `scripts/dune-local.sh build test/test_keeper_toml.exe test/test_tools_coverage.exe`
- `_build/default/test/test_keeper_toml.exe` (97 tests)
- `_build/default/test/test_tools_coverage.exe` (50 tests)
- `ocamlformat --check ...`
- `bash -n scripts/harness_tool_call_quality.sh`
- `jq empty config/personas/code-reviewer/profile.json`
- `git diff --check`

## Follow-up

Issue #26498 (Chat repeated-tool continuation ending in `failed/no_visible_reply`) remains a separate typed queue/delivery state change and is intentionally not mixed into this hard-cut PR.
