### PR TITLE
fix(keeper): deliver continuation checkpoints

### DIFF
--- a/dashboard/src/api/schemas/keeper-chat-history.test.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.test.ts
@@ -36,6 +36,19 @@ describe('safeParseKeeperChatHistoryMessage', () => {
     ])
   })
 
+  it('accepts a typed continuation status block with empty content', () => {
+    const out = safeParseKeeperChatHistoryMessage(
+      validMessage({
+        role: 'assistant',
+        content: '',
+        blocks: [{ t: 'status', kind: 'continuation_checkpoint' }],
+      }),
+    )
+    expect(out?.blocks).toEqual([
+      { t: 'status', kind: 'continuation_checkpoint' },
+    ])
+  })
+
   it('accepts unknown role strings (open enum for backend-ahead deploys)', () => {
     const out = safeParseKeeperChatHistoryMessage(
       validMessage({ role: 'tool-result-v2' }),

--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -205,7 +205,10 @@ export const KeeperChatBlockSchema = union([
   }),
   object({
     t: literal('status'),
-    kind: literal('external_effect_pending'),
+    kind: union([
+      literal('continuation_checkpoint'),
+      literal('external_effect_pending'),
+    ]),
   }),
   object({
     t: literal('trace'),

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -215,6 +215,35 @@ describe('ChatTranscript', () => {
     expect(container.querySelector('.chat-bubble')).toBeNull()
   })
 
+  it('renders a typed continuation checkpoint as durable status, not assistant prose', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'continuation-1',
+            role: 'assistant',
+            source: 'direct_assistant',
+            label: 'sangsu',
+            text: '',
+            rawText: '',
+            blocks: [{ t: 'status', kind: 'continuation_checkpoint' }],
+          }),
+        ]}
+        emptyText="empty"
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const status = container.querySelector(
+      '[data-chat-control-status="continuation_checkpoint"]',
+    )
+    expect(status).not.toBeNull()
+    expect(status?.textContent).toContain('이어가기 예약됨')
+    expect(status?.textContent).toContain('다음 주기에 이어서')
+    expect(container.querySelector('.chat-bubble')).toBeNull()
+  })
+
   it('renders failure rows as a typed card with collapsed diagnostic detail', async () => {
     const text = 'Keeper request failed: Internal error: [masc_oas_error] {"kind":"accept_rejected","scope":"ollama_cloud.deepseek-v4-flash","reason_kind":"no_usable_progress"}'
     render(

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2545,15 +2545,16 @@ const CARD_BLOCK_TYPES: ReadonlySet<ChatBlock['t']> = new Set([
   'status',
 ])
 
-type ChatControlStatus = 'external_effect_pending'
+type ChatControlStatus = 'continuation_checkpoint' | 'external_effect_pending'
 
 function chatControlStatus(entry: KeeperConversationEntry): ChatControlStatus | null {
   const persistedStatus = (entry.blocks ?? []).find(
     (block): block is Extract<ChatBlock, { t: 'status' }> => block.t === 'status',
   )
   if (persistedStatus) return persistedStatus.kind
-  return entry.details?.turnOutcome === 'external_effect_pending'
-    ? 'external_effect_pending'
+  const turnOutcome = entry.details?.turnOutcome
+  return turnOutcome === 'continuation_checkpoint' || turnOutcome === 'external_effect_pending'
+    ? turnOutcome
     : null
 }
 
@@ -2565,9 +2566,48 @@ function ChatControlStatusCard({
   action?: ChatTranscriptAction
 }) {
   const status = chatControlStatus(entry)
-  if (status !== 'external_effect_pending') return null
+  if (!status) return null
   const timestamp = timeLabel(entry.timestamp)
   const supportingBlocks = (entry.blocks ?? []).filter(block => block.t !== 'status')
+
+  if (status === 'continuation_checkpoint') {
+    return html`
+      <article
+        class="w-full rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-subtle)] px-4 py-3.5"
+        role="status"
+        aria-live="polite"
+        data-chat-control-status="continuation_checkpoint"
+        data-chat-entry-id=${entry.id}
+        data-chat-turn-ref=${entry.turnRef ?? undefined}
+      >
+        <div class="flex items-start gap-3">
+          <div
+            class="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-full border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] text-[var(--color-fg-secondary)]"
+            aria-hidden="true"
+          >
+            <${ShieldCheck} size=${18} />
+          </div>
+          <div class="min-w-0 flex-1">
+            <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+              <strong class="text-sm font-semibold text-[var(--color-fg-primary)]">이어가기 예약됨</strong>
+              ${timestamp
+                ? html`<span class="text-2xs tabular-nums text-[var(--color-fg-muted)]">${timestamp}</span>`
+                : null}
+            </div>
+            <p class="mt-1 text-sm leading-paragraph text-[var(--color-fg-secondary)]">
+              작업이 체크포인트에 저장되었습니다.
+            </p>
+            <p class="mt-0.5 text-xs leading-paragraph text-[var(--color-fg-muted)]">
+              Keeper가 다음 주기에 이어서 처리합니다.
+            </p>
+          </div>
+        </div>
+        ${supportingBlocks.length > 0
+          ? html`<div class="mt-3"><${ChatBlocks} blocks=${supportingBlocks} fallbackText="" /></div>`
+          : null}
+      </article>
+    `
+  }
 
   return html`
     <article

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -2232,6 +2232,56 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     expect(keeperActionErrors.value.echo).toContain('표시할 답변')
   })
 
+  it('resumes a continuation checkpoint as delivered without assistant prose', async () => {
+    upsertPendingKeeperChatRequest({
+      requestId: 'kmsg_echo_1',
+      keeperName: 'echo',
+      message: '계속 진행해',
+      submittedAt: Date.UTC(2026, 5, 15, 9, 0, 0),
+    })
+    fetchQueuedKeeperMessageResult.mockResolvedValue({
+      requestId: 'kmsg_echo_1',
+      keeperName: 'echo',
+      status: 'done',
+      ok: true,
+      result: {
+        reply: '',
+        turn_outcome: 'continuation_checkpoint',
+      },
+    })
+    queuedKeeperMessageToReply.mockImplementation(() => ({
+      text: '',
+      details: {
+        traceId: null,
+        turnRef: null,
+        providerMessageId: null,
+        generation: null,
+        modelUsed: null,
+        stopReason: null,
+        latencyMs: null,
+        costUsd: null,
+        usage: null,
+        replyText: null,
+        turnOutcome: 'continuation_checkpoint',
+        rawPayload: {
+          reply: '',
+          turn_outcome: 'continuation_checkpoint',
+        },
+      },
+    }))
+    fetchKeeperChatHistory.mockResolvedValue([])
+
+    await resumePendingKeeperChatRequests('echo')
+
+    expect(pendingKeeperChatRequestsForKeeper('echo')).toEqual([])
+    const thread = keeperThreads.value.echo ?? []
+    expect(thread.map(entry => [entry.role, entry.text, entry.delivery])).toEqual([
+      ['user', '계속 진행해', 'delivered'],
+      ['assistant', '', 'delivered'],
+    ])
+    expect(keeperActionErrors.value.echo).toBeNull()
+  })
+
   it('resumes repeated same-message sends as distinct request ids', async () => {
     const submittedAt = Date.UTC(2026, 5, 15, 9, 0, 0)
     upsertPendingKeeperChatRequest({

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -1825,6 +1825,33 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     expect(keeperActionErrors.value.echo).toBeNull()
   })
 
+  it('keeps a checkpoint with tool calls free of tool-only placeholder text', async () => {
+    streamKeeperMessage.mockImplementation(emitting([
+      { type: 'RUN_STARTED' },
+      { type: 'TOOL_CALL_START', toolCallId: 'tc-1', toolCallName: 'keeper_board_list' },
+      { type: 'TOOL_CALL_END', toolCallId: 'tc-1' },
+      {
+        type: 'CUSTOM',
+        name: 'KEEPER_CONTINUATION_CHECKPOINT',
+        value: {
+          message: 'Continuation checkpoint saved; keeper remains scheduled.',
+        },
+      },
+      { type: 'RUN_FINISHED' },
+    ], true))
+
+    await sendKeeperThreadMessage('echo', '계속 진행해')
+
+    const reply = (keeperThreads.value.echo ?? []).find(entry => entry.role === 'assistant')
+    expect(reply?.delivery).toBe('delivered')
+    expect(reply?.text).toBe('')
+    expect(reply?.blocks).toEqual([
+      { t: 'status', kind: 'continuation_checkpoint' },
+    ])
+    expect(reply?.error).toBeNull()
+    expect(keeperActionErrors.value.echo).toBeNull()
+  })
+
   it('keeps a busy server-accepted message queued after RUN_FINISHED', async () => {
     fetchKeeperChatReceipt.mockResolvedValue({
       keeperName: 'echo',

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -1800,6 +1800,31 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     expect(invalidateDashboardCache).not.toHaveBeenCalled()
   })
 
+  it('keeps an empty continuation checkpoint as a delivered typed status', async () => {
+    streamKeeperMessage.mockImplementation(emitting([
+      { type: 'RUN_STARTED' },
+      {
+        type: 'CUSTOM',
+        name: 'KEEPER_CONTINUATION_CHECKPOINT',
+        value: {
+          message: 'Continuation checkpoint saved; keeper remains scheduled.',
+        },
+      },
+      { type: 'RUN_FINISHED' },
+    ], true))
+
+    await sendKeeperThreadMessage('echo', '계속 진행해')
+
+    const reply = (keeperThreads.value.echo ?? []).find(entry => entry.role === 'assistant')
+    expect(reply?.delivery).toBe('delivered')
+    expect(reply?.text).toBe('')
+    expect(reply?.blocks).toEqual([
+      { t: 'status', kind: 'continuation_checkpoint' },
+    ])
+    expect(reply?.error).toBeNull()
+    expect(keeperActionErrors.value.echo).toBeNull()
+  })
+
   it('keeps a busy server-accepted message queued after RUN_FINISHED', async () => {
     fetchKeeperChatReceipt.mockResolvedValue({
       keeperName: 'echo',

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -1736,7 +1736,7 @@ export async function sendKeeperThreadMessage(
       return
     }
     let emptyTerminalText = ''
-    if (toolCallEnded) {
+    if (toolCallEnded && !hasContinuationStatus) {
       emptyTerminalText = TOOL_ONLY_EMPTY_REPLY_TEXT
     }
 

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -1704,7 +1704,18 @@ export async function sendKeeperThreadMessage(
       finalEntry?.delivery === 'queued'
         ? 'queued' as KeeperConversationDelivery
         : 'delivered' as KeeperConversationDelivery
-    if (!finalText && finalDelivery !== 'queued' && !toolCallEnded) {
+    const hasContinuationStatus = (
+      finalEntry?.details?.turnOutcome === 'continuation_checkpoint'
+      && finalEntry.blocks?.some(block => (
+        block.t === 'status' && block.kind === 'continuation_checkpoint'
+      )) === true
+    )
+    if (
+      !finalText
+      && finalDelivery !== 'queued'
+      && !toolCallEnded
+      && !hasContinuationStatus
+    ) {
       finalizeAssistantEntry(keeperName, assistantId, {
         text: EMPTY_VISIBLE_REPLY_TEXT,
         rawText: finalEntry?.rawText || EMPTY_VISIBLE_REPLY_TEXT,

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -687,7 +687,6 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
       }
 
       const reply = queuedKeeperMessageToReply(result)
-      const isCheckpoint = reply.details?.turnOutcome === 'continuation_checkpoint'
       const isNoVisibleReply = reply.details?.turnOutcome === 'no_visible_reply'
       const suppressReply = keeperTurnOutcomeSuppressesReply(reply.details?.turnOutcome)
       const isCancelled = result.status === 'cancelled'
@@ -707,8 +706,6 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
       let assistantDelivery: KeeperConversationDelivery = 'delivered'
       if (isCancelled) {
         assistantDelivery = 'cancelled'
-      } else if (isCheckpoint) {
-        assistantDelivery = 'queued'
       } else if (isNoVisibleReply) {
         assistantDelivery = 'error'
       } else if (isError) {

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -1317,6 +1317,23 @@ describe('thread history merge & persistence', () => {
     ])
   })
 
+  it('keeps a typed continuation status block when assistant content is empty', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      {
+        role: 'assistant',
+        content: '',
+        ts: 1_780_000_000,
+        blocks: [{ t: 'status', kind: 'continuation_checkpoint' }],
+      },
+    ])
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.text).toBe('')
+    expect(entries[0]?.blocks).toEqual([
+      { t: 'status', kind: 'continuation_checkpoint' },
+    ])
+  })
+
   it('still drops rows that have no content and no attachments', () => {
     const entries = chatHistoryEntriesFromRest('echo', [
       { role: 'user', content: '', ts: 1_780_000_000 },

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -537,8 +537,9 @@ function normalizeBlocks(raw: unknown, role: KeeperConversationRole): ChatBlock[
         return html ? { t: 'h4', html } : null
       }
       if (t === 'status') {
-        return asString(item.kind) === 'external_effect_pending'
-          ? { t: 'status', kind: 'external_effect_pending' }
+        const kind = asString(item.kind)
+        return kind === 'continuation_checkpoint' || kind === 'external_effect_pending'
+          ? { t: 'status', kind }
           : null
       }
       if (t === 'ul') {

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -337,7 +337,7 @@ describe('applyKeeperStreamEvent', () => {
     expect(activeStreamRequestId('sangsu')).toBeNull()
   })
 
-  it('keeps explicit continuation checkpoints queued when a successful terminal follows', () => {
+  it('projects explicit continuation checkpoints as a durable status', () => {
     assistantEntry()
     setActiveStreamRequestId('sangsu', 'kmsg_current')
     applyKeeperStreamEvent('sangsu', 'reply-1', {
@@ -363,9 +363,12 @@ describe('applyKeeperStreamEvent', () => {
 
     const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
     expect(entry?.text).toBe('')
-    expect(entry?.delivery).toBe('queued')
+    expect(entry?.delivery).toBe('delivered')
     expect(entry?.streamState).toBeNull()
     expect(entry?.details?.turnOutcome).toBe('continuation_checkpoint')
+    expect(entry?.blocks).toEqual([
+      { t: 'status', kind: 'continuation_checkpoint' },
+    ])
     expect(activeStreamRequestId('sangsu')).toBeNull()
   })
 

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -754,13 +754,17 @@ export function applyKeeperStreamEvent(
           : ''
         updateThreadEntry(keeperName, assistantEntryId, entry => ({
           ...entry,
+          blocks: [
+            ...(entry.blocks ?? []).filter(block => block.t !== 'status'),
+            { t: 'status', kind: 'continuation_checkpoint' },
+          ],
           details: {
             ...(entry.details ?? {}),
             turnOutcome: 'continuation_checkpoint',
           },
           text: '',
           rawText: rawText || entry.rawText,
-          delivery: 'queued',
+          delivery: 'delivered',
           streamState: null,
           streamContract: keeperClientObservedSseStreamContract('queue_event', 'queue_request_event', {
             eventName: 'KEEPER_CONTINUATION_CHECKPOINT',

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -850,7 +850,10 @@ export type ChatBroadcastBlock = { t: 'broadcast'; scope: string; via?: string; 
 // keeper_chat_blocks.ml); ChatFusionCard lazy-fetches the board post by
 // board_post_id and renders its meta_json (panel answers + judge synthesis).
 export type ChatFusionBlock = { t: 'fusion'; board_post_id: string; run_id?: string }
-export type ChatStatusBlock = { t: 'status'; kind: 'external_effect_pending' }
+export type ChatStatusBlock = {
+  t: 'status'
+  kind: 'continuation_checkpoint' | 'external_effect_pending'
+}
 
 export type ChatBlock =
   | ChatTextBlock

--- a/docs/rfc/RFC-0232-typed-lane-event-model.md
+++ b/docs/rfc/RFC-0232-typed-lane-event-model.md
@@ -232,12 +232,14 @@ no longer disagree about who "me" is.
 ```ocaml
 type turn_outcome =
   | Visible_reply of string                (* persist to lane *)
-  | Continuation_checkpoint                (* internal; not a lane line *)
+  | Continuation_checkpoint                (* persist typed status to lane *)
 ```
 
 The pipeline that *creates* the checkpoint returns
 `Continuation_checkpoint`; the keeper-stream persistence site matches on
-the variant. `is_continuation_checkpoint_reply` and its prefix constant
+the variant and persists a typed continuation status block without
+assistant prose. Connectors project the same typed status to canonical
+status text. `is_continuation_checkpoint_reply` and its prefix constant
 are deleted. New outcome variants (e.g. a future `Deferred`) break the
 persistence site at compile time instead of silently persisting or
 silently vanishing.

--- a/docs/rfc/RFC-0232-typed-lane-event-model.md
+++ b/docs/rfc/RFC-0232-typed-lane-event-model.md
@@ -244,6 +244,11 @@ are deleted. New outcome variants (e.g. a future `Deferred`) break the
 persistence site at compile time instead of silently persisting or
 silently vanishing.
 
+The projected checkpoint status is the terminal reply for the current direct
+request. A later autonomous turn is a separate delivery; routing that later
+result back to the originating connector requires the durable channel
+provenance contract in RFC-0320 and is not inferred from this receipt.
+
 This also closes §1.2 structurally: turn completion returns a value the
 persistence layer must consume — "completed a turn but never appended the
 assistant line" stops being expressible as an accidental omission on the

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -621,7 +621,12 @@ let accept_connector ~delivery ~clock ~config ~channel ~channel_user_id
 
 let persist_connector_assistant_reply ~base_dir ~keeper_name ~surface
     ?conversation_id ?turn_ref ?blocks ~reply () =
-  let content = String.trim reply in
+  let has_status =
+    Option.exists
+      (List.exists (function Keeper_chat_blocks.Status _ -> true | _ -> false))
+      blocks
+  in
+  let content = if has_status then "" else String.trim reply in
   let has_blocks =
     match blocks with
     | Some (_ :: _) -> true

--- a/lib/keeper/keeper_chat_blocks.ml
+++ b/lib/keeper/keeper_chat_blocks.ml
@@ -81,11 +81,15 @@ type fusion_block = {
   run_id : string;
 }
 
-type status_kind = External_effect_pending
+type status_kind =
+  | Continuation_checkpoint
+  | External_effect_pending
 
 type status_block = { kind : status_kind }
 
 let status_kind_connector_text = function
+  | Continuation_checkpoint ->
+    "작업이 체크포인트에 저장되었습니다. 다음 주기에 이어서 처리합니다."
   | External_effect_pending ->
     "승인 대기: 외부 작업을 실행하기 전에 확인이 필요합니다."
 ;;
@@ -97,6 +101,8 @@ type connector_projection =
 
 let connector_projection ~turn_outcome ~reply =
   match turn_outcome, reply with
+  | Keeper_turn_outcome.Continuation_checkpoint, _ ->
+    Connector_status { kind = Continuation_checkpoint }
   | Keeper_turn_outcome.External_effect_pending, _ ->
     Connector_status { kind = External_effect_pending }
   | Keeper_turn_outcome.Visible_reply, Some reply ->
@@ -106,7 +112,6 @@ let connector_projection ~turn_outcome ~reply =
     else Connector_text reply
   | Keeper_turn_outcome.Visible_reply, None ->
     Connector_no_visible_reply
-  | Keeper_turn_outcome.Continuation_checkpoint, _
   | Keeper_turn_outcome.No_visible_reply, _ ->
     Connector_no_visible_reply
 ;;
@@ -294,10 +299,12 @@ let trace_tool_status_to_label = function
 ;;
 
 let status_kind_to_label = function
+  | Continuation_checkpoint -> "continuation_checkpoint"
   | External_effect_pending -> "external_effect_pending"
 ;;
 
 let status_kind_of_label = function
+  | "continuation_checkpoint" -> Some Continuation_checkpoint
   | "external_effect_pending" -> Some External_effect_pending
   | _ -> None
 ;;

--- a/lib/keeper/keeper_chat_blocks.mli
+++ b/lib/keeper/keeper_chat_blocks.mli
@@ -100,7 +100,9 @@ type fusion_block = {
   run_id : string;
 }
 
-type status_kind = External_effect_pending
+type status_kind =
+  | Continuation_checkpoint
+  | External_effect_pending
 
 type status_block = { kind : status_kind }
 

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1910,8 +1910,7 @@ let start_keeper_loops_owned
                    match kind with
                    | Turn_failed -> Keeper_chat_queue.Turn_failed
                    | Turn_cancelled -> Keeper_chat_queue.Cancelled
-                   | No_visible_reply
-                   | Continuation_checkpoint_without_reply ->
+                   | No_visible_reply ->
                        Keeper_chat_queue.No_visible_reply
                    | Missing_turn_ref -> Keeper_chat_queue.Internal_error
                    | Transcript_persist_failed ->

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -1064,6 +1064,16 @@ let direct_reply_terminal_error ?(has_visible_blocks = false) payload_json_opt v
 
 let persisted_reply_blocks ~turn_outcome media_blocks =
   match turn_outcome, media_blocks with
+  | Keeper_turn_outcome.Continuation_checkpoint, Some media_blocks ->
+    Some
+      (Keeper_chat_blocks.Status
+         { kind = Keeper_chat_blocks.Continuation_checkpoint }
+       :: media_blocks)
+  | Keeper_turn_outcome.Continuation_checkpoint, None ->
+    Some
+      [ Keeper_chat_blocks.Status
+          { kind = Keeper_chat_blocks.Continuation_checkpoint }
+      ]
   | Keeper_turn_outcome.External_effect_pending, Some media_blocks ->
     Some
       (Keeper_chat_blocks.Status
@@ -1074,9 +1084,8 @@ let persisted_reply_blocks ~turn_outcome media_blocks =
       [ Keeper_chat_blocks.Status
           { kind = Keeper_chat_blocks.External_effect_pending }
       ]
-  | ( Keeper_turn_outcome.Visible_reply
-    | Keeper_turn_outcome.Continuation_checkpoint
-    | Keeper_turn_outcome.No_visible_reply ), media_blocks ->
+  | (Keeper_turn_outcome.Visible_reply | Keeper_turn_outcome.No_visible_reply),
+    media_blocks ->
     media_blocks
 
 type keeper_stream_terminal_status =
@@ -1166,7 +1175,6 @@ and queued_turn_failure_kind =
   | Turn_failed
   | Turn_cancelled
   | No_visible_reply
-  | Continuation_checkpoint_without_reply
   | Missing_turn_ref
   | Transcript_persist_failed
   | Stream_projection_failed
@@ -1333,8 +1341,6 @@ let queued_turn_failure_kind_to_string = function
   | Turn_failed -> "turn_failed"
   | Turn_cancelled -> "turn_cancelled"
   | No_visible_reply -> "no_visible_reply"
-  | Continuation_checkpoint_without_reply ->
-      "continuation_checkpoint_without_reply"
   | Missing_turn_ref -> "missing_turn_ref"
   | Transcript_persist_failed -> "transcript_persist_failed"
   | Stream_projection_failed -> "stream_projection_failed"
@@ -2260,19 +2266,6 @@ let process_single_turn ~user_row_origin ~submission
                  let turn_outcome = canonical_reply.turn_outcome in
                  let delivery_result =
                    match turn_outcome, String_util.trim_to_option visible_reply with
-                   | Keeper_turn_outcome.Continuation_checkpoint, _ when queued_turn ->
-                       let detail =
-                         "queued turn ended with a continuation checkpoint and no delivered reply"
-                       in
-                       (match persist_failure_reply ?blocks ?turn_ref detail with
-                        | Ok () ->
-                            Ok
-                              (Some
-                                 (Failed
-                                    { kind = Continuation_checkpoint_without_reply
-                                    ; detail
-                                    }))
-                        | Error persist_error -> Error persist_error)
                    | Keeper_turn_outcome.Continuation_checkpoint, _ ->
                        (match
                           continuation_delivery_plan
@@ -2835,17 +2828,22 @@ let process_single_turn ~user_row_origin ~submission
             Keeper_turn_outcome.equal turn_outcome
               Keeper_turn_outcome.Continuation_checkpoint
           then
-            Keeper_chat_events.publish events
-              (Custom
-                 { name = "KEEPER_CONTINUATION_CHECKPOINT";
-                   value =
-                     `Assoc
-                       (("message", `String visible_reply)
-                        :: (match request_id with
-                            | Some request_id ->
-                                [ ("request_id", `String request_id) ]
-                            | None -> []))
-                 });
+            begin
+              Keeper_chat_events.publish events
+                (Status_block
+                   { kind = Keeper_chat_blocks.Continuation_checkpoint });
+              Keeper_chat_events.publish events
+                (Custom
+                   { name = "KEEPER_CONTINUATION_CHECKPOINT";
+                     value =
+                       `Assoc
+                         (("message", `String visible_reply)
+                          :: (match request_id with
+                              | Some request_id ->
+                                  [ ("request_id", `String request_id) ]
+                              | None -> []))
+                   })
+            end;
           publish_terminal ~status:(Request_stream Stream_done) ();
           Keeper_chat_events.publish events Text_message_end;
           Keeper_chat_events.publish events (Run_finished { run_id });

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -1372,19 +1372,6 @@ let empty_reply_delivery_plan ~queued_turn ~has_visible_blocks ~has_tool_calls =
   then `Failure
   else `User_only
 
-let continuation_delivery_plan
-      ~has_direct_checkpoint
-      ~has_visible_blocks
-      ~has_tool_calls
-  =
-  if has_visible_blocks
-  then `Assistant_reply
-  else if has_tool_calls
-  then `Tool_calls_only
-  else if has_direct_checkpoint
-  then `No_assistant_reply
-  else `User_only
-
 type keeper_stream_bridge_state = Keeper_chat_oas_stream_bridge.state
 
 type translated_keeper_stream_event =
@@ -2258,39 +2245,20 @@ let process_single_turn ~user_row_origin ~submission
                        Ok queued_outcome
                    | Error _ as error -> error
                  in
-                 let broadcast_after_tool_only_persist () =
-                   Keeper_chat_broadcast.chat_appended
-                     ~keeper_name:payload.name ~source:chat_source ();
-                   Ok None
-                 in
                  let turn_outcome = canonical_reply.turn_outcome in
                  let delivery_result =
                    match turn_outcome, String_util.trim_to_option visible_reply with
                    | Keeper_turn_outcome.Continuation_checkpoint, _ ->
-                       (match
-                          continuation_delivery_plan
-                            ~has_direct_checkpoint:
-                              (Option.is_some !direct_delivery_checkpoint)
-                            ~has_visible_blocks
-                            ~has_tool_calls:(tool_calls <> [])
-                        with
-                        | `Assistant_reply ->
-                          persist_assistant_reply ~assistant_content:""
-                          |> delivered_after_persist
-                        | `Tool_calls_only ->
-                          Result.bind
-                            (persist_tool_calls_only ())
-                            (fun () -> broadcast_after_tool_only_persist ())
-                        | `No_assistant_reply ->
-                          commit_direct_terminal
-                            ~ok:true
-                            ~body
-                            ~data:payload_json_opt
-                            Keeper_chat_direct_delivery.No_assistant_reply
-                          |> Result.map (fun () -> None)
-                        | `User_only ->
-                          persist_user_message_only ();
-                          Ok None)
+                       (* [persisted_reply_blocks] always returns [Some _] for
+                          [Continuation_checkpoint] (a typed status block), so
+                          [has_visible_blocks] is always true on this arm: a
+                          checkpoint turn always persists a delivered assistant
+                          row with [content = ""] plus the status block —
+                          including turns that also produced tool calls and
+                          turns carrying a direct-delivery checkpoint. There is
+                          no tool-calls-only or user-only continuation path. *)
+                       persist_assistant_reply ~assistant_content:""
+                       |> delivered_after_persist
                    | Keeper_turn_outcome.No_visible_reply, _
                    | Keeper_turn_outcome.Visible_reply, None ->
                        let detail =
@@ -3304,7 +3272,6 @@ module For_testing = struct
     queued_delivery_outcome_of_turn_ref
   let committed_delivery_outcome = committed_delivery_outcome
   let empty_reply_delivery_plan = empty_reply_delivery_plan
-  let continuation_delivery_plan = continuation_delivery_plan
   let format_surface_context = format_surface_context
   let surface_context_to_instructions = surface_context_to_instructions
   let keeper_tool_failure_log_details = keeper_tool_failure_log_details

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -162,7 +162,6 @@ type queued_turn_failure_kind =
   | Turn_failed
   | Turn_cancelled
   | No_visible_reply
-  | Continuation_checkpoint_without_reply
   | Missing_turn_ref
   | Transcript_persist_failed
   | Stream_projection_failed
@@ -227,8 +226,9 @@ val process_single_turn :
     queue-consumer [handle_turn] wiring) changes terminal handling for
     [No_visible_reply], an empty [Visible_reply], and
     [Continuation_checkpoint]. A media-only ordinary reply is delivered even
-    when its text is empty. A queued continuation remains a typed failure but
-    retains any streamed media blocks on that durable failure row. Its [claim]
+    when its text is empty. A continuation persists a typed status block and
+    is delivered to the originating connector without inventing assistant
+    prose. The [claim]
     callback atomically claims the exact observed queue receipt after turn
     admission and before transcript or provider effects.
 

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -228,7 +228,10 @@ val process_single_turn :
     [Continuation_checkpoint]. A media-only ordinary reply is delivered even
     when its text is empty. A continuation persists a typed status block and
     is delivered to the originating connector without inventing assistant
-    prose. The [claim]
+    prose. A continuation always commits a delivered assistant row
+    ([content = ""] plus the typed status block) — including direct turns,
+    which previously could commit [No_assistant_reply] or [Tool_calls_only]
+    instead. The [claim]
     callback atomically claims the exact observed queue receipt after turn
     admission and before transcript or provider effects.
 
@@ -320,11 +323,6 @@ module For_testing : sig
     has_visible_blocks:bool ->
     has_tool_calls:bool ->
     [ `Visible_blocks | `Tool_calls_only | `Failure | `User_only ]
-  val continuation_delivery_plan :
-    has_direct_checkpoint:bool ->
-    has_visible_blocks:bool ->
-    has_tool_calls:bool ->
-    [ `Assistant_reply | `Tool_calls_only | `No_assistant_reply | `User_only ]
   val format_surface_context : Yojson.Safe.t -> string
   val surface_context_to_instructions : Yojson.Safe.t -> string option
   val keeper_tool_failure_log_details :

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -210,7 +210,8 @@ let test_persist_connector_assistant_reply_records_typed_status () =
         Surface_ref.Gate { label = "discord"; address = [] }
       in
       Gate_keeper_backend.persist_connector_assistant_reply ~base_dir
-        ~keeper_name ~surface ~reply:""
+        ~keeper_name ~surface
+        ~reply:"assistant preface that must not survive"
         ~blocks:
           [ Keeper_chat_blocks.Status
               { kind = Keeper_chat_blocks.External_effect_pending }

--- a/test/test_keeper_chat_blocks.ml
+++ b/test/test_keeper_chat_blocks.ml
@@ -401,6 +401,21 @@ let test_status_block_roundtrip () =
   | Some _ -> Alcotest.fail "status block changed shape across round-trip"
   | None -> Alcotest.fail "blocks_of_yojson rejected valid status block"
 
+let test_continuation_status_block_roundtrip () =
+  let original = [ B.Status { kind = B.Continuation_checkpoint } ] in
+  match B.blocks_of_yojson (B.blocks_to_yojson original) with
+  | Some [ B.Status { kind = B.Continuation_checkpoint } ] -> ()
+  | Some _ ->
+    Alcotest.fail "continuation status block changed shape across round-trip"
+  | None ->
+    Alcotest.fail "blocks_of_yojson rejected valid continuation status block"
+
+let test_continuation_status_connector_text () =
+  Alcotest.(check string)
+    "continuation status connector text"
+    "작업이 체크포인트에 저장되었습니다. 다음 주기에 이어서 처리합니다."
+    (B.status_kind_connector_text B.Continuation_checkpoint)
+
 (* RFC-0302: the thinking block wire shape is the contract the dashboard
    schema mirrors (t=thinking, content required, redacted omitted when
    false). Pin it so a drift breaks here. *)
@@ -528,6 +543,10 @@ let () =
             test_fusion_block_tolerates_missing_run_id;
           Alcotest.test_case "status block roundtrip" `Quick
             test_status_block_roundtrip;
+          Alcotest.test_case "continuation status block roundtrip" `Quick
+            test_continuation_status_block_roundtrip;
+          Alcotest.test_case "continuation status connector text" `Quick
+            test_continuation_status_connector_text;
           Alcotest.test_case "thinking block roundtrip" `Quick
             test_thinking_block_roundtrip;
           Alcotest.test_case "redacted thinking block roundtrip" `Quick

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -494,35 +494,55 @@ let test_media_only_queued_reply_uses_delivery_path () =
     fail "media-only queued reply must use the delivered assistant path"
 
 let test_media_continuation_uses_assistant_delivery_path () =
-  List.iter
-    (fun has_direct_checkpoint ->
-       match
-         Stream.For_testing.continuation_delivery_plan
-           ~has_direct_checkpoint
-           ~has_visible_blocks:true
-           ~has_tool_calls:true
-       with
-       | `Assistant_reply -> ()
-       | `Tool_calls_only | `No_assistant_reply | `User_only ->
-         fail
-           "media continuation must persist and broadcast the structured assistant row")
-    [ false; true ]
-
-let test_continuation_status_uses_assistant_delivery_path () =
-  let blocks =
-    Stream.For_testing.persisted_reply_blocks
-      ~turn_outcome:TO.Continuation_checkpoint
-      None
+  (* A continuation with accumulated media still persists one assistant row:
+     the typed status block leads and the media blocks survive. *)
+  let media =
+    Masc.Keeper_chat_blocks.Image { src = "/media/generated.png"; cap = None }
   in
   match
-    Stream.For_testing.continuation_delivery_plan
-      ~has_direct_checkpoint:false
-      ~has_visible_blocks:(Option.is_some blocks)
-      ~has_tool_calls:false
+    Stream.For_testing.persisted_reply_blocks
+      ~turn_outcome:TO.Continuation_checkpoint
+      (Some [ media ])
   with
-  | `Assistant_reply -> ()
-  | `Tool_calls_only | `No_assistant_reply | `User_only ->
-    fail "typed continuation status must use the delivered assistant path"
+  | Some
+      [ Masc.Keeper_chat_blocks.Status
+          { kind = Masc.Keeper_chat_blocks.Continuation_checkpoint }
+      ; Masc.Keeper_chat_blocks.Image { src = "/media/generated.png"; cap = None }
+      ] ->
+    ()
+  | Some _ ->
+    fail "media continuation dropped or reordered the persisted blocks"
+  | None -> fail "media continuation did not persist a status block"
+
+let test_continuation_status_uses_assistant_delivery_path () =
+  (* Real invariant behind the stream call site: for
+     [Continuation_checkpoint], [persisted_reply_blocks] always returns
+     [Some] with the status block leading, so the turn always takes the
+     assistant-reply persist path — never a tool-calls-only or user-only
+     path — regardless of media or direct-delivery checkpoint state. *)
+  List.iter
+    (fun media_blocks ->
+       match
+         Stream.For_testing.persisted_reply_blocks
+           ~turn_outcome:TO.Continuation_checkpoint media_blocks
+       with
+       | Some
+           (Masc.Keeper_chat_blocks.Status
+              { kind = Masc.Keeper_chat_blocks.Continuation_checkpoint }
+            :: _) ->
+         ()
+       | Some _ ->
+         fail "continuation status block must lead the persisted blocks"
+       | None ->
+         fail
+           "continuation without visible blocks would miss the assistant \
+            delivery path")
+    [ None
+    ; Some
+        [ Masc.Keeper_chat_blocks.Image
+            { src = "/media/generated.png"; cap = None }
+        ]
+    ]
 
 let body fields = `Assoc fields
 

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -146,6 +146,20 @@ let test_external_effect_status_becomes_persisted_chat_block () =
   | Some _ -> fail "typed Gate wait persisted the wrong block shape"
   | None -> fail "typed Gate wait did not persist a status block"
 
+let test_continuation_status_becomes_persisted_chat_block () =
+  match
+    Stream.For_testing.persisted_reply_blocks
+      ~turn_outcome:TO.Continuation_checkpoint
+      None
+  with
+  | Some
+      [ Masc.Keeper_chat_blocks.Status
+          { kind = Masc.Keeper_chat_blocks.Continuation_checkpoint }
+      ] ->
+    ()
+  | Some _ -> fail "typed continuation persisted the wrong block shape"
+  | None -> fail "typed continuation did not persist a status block"
+
 let test_terminal_effect_defer_kinds_remain_distinct () =
   let expect_yield label state expected =
     match Masc.Keeper_agent_run.terminal_effect_boundary_decision state with
@@ -494,6 +508,22 @@ let test_media_continuation_uses_assistant_delivery_path () =
            "media continuation must persist and broadcast the structured assistant row")
     [ false; true ]
 
+let test_continuation_status_uses_assistant_delivery_path () =
+  let blocks =
+    Stream.For_testing.persisted_reply_blocks
+      ~turn_outcome:TO.Continuation_checkpoint
+      None
+  in
+  match
+    Stream.For_testing.continuation_delivery_plan
+      ~has_direct_checkpoint:false
+      ~has_visible_blocks:(Option.is_some blocks)
+      ~has_tool_calls:false
+  with
+  | `Assistant_reply -> ()
+  | `Tool_calls_only | `No_assistant_reply | `User_only ->
+    fail "typed continuation status must use the delivered assistant path"
+
 let body fields = `Assoc fields
 
 let test_direct_reply_visible_text () =
@@ -546,8 +576,20 @@ let test_connector_projection_keeps_external_wait_typed () =
       ~reply:(Some "assistant preface that must not survive")
   with
   | Connector_status { kind = External_effect_pending } -> ()
+  | Connector_status { kind = Continuation_checkpoint }
   | Connector_text _ | Connector_no_visible_reply ->
     fail "external-effect wait must remain a typed connector status"
+
+let test_connector_projection_keeps_continuation_typed () =
+  match
+    Masc.Keeper_chat_blocks.connector_projection
+      ~turn_outcome:TO.Continuation_checkpoint
+      ~reply:(Some "assistant preface that must not survive")
+  with
+  | Connector_status { kind = Continuation_checkpoint } -> ()
+  | Connector_status { kind = External_effect_pending }
+  | Connector_text _ | Connector_no_visible_reply ->
+    fail "continuation checkpoint must remain a typed connector status"
 
 let test_direct_reply_projection_keeps_external_wait_typed () =
   match
@@ -558,6 +600,7 @@ let test_direct_reply_projection_keeps_external_wait_typed () =
          ])
   with
   | Connector_status { kind = External_effect_pending } -> ()
+  | Connector_status { kind = Continuation_checkpoint }
   | Connector_text _ | Connector_no_visible_reply ->
     fail "direct reply collapsed external-effect wait into silence"
 
@@ -604,6 +647,10 @@ let () =
             test_media_only_queued_reply_uses_delivery_path;
           test_case "media continuation uses assistant delivery path" `Quick
             test_media_continuation_uses_assistant_delivery_path;
+          test_case "continuation status uses assistant delivery path" `Quick
+            test_continuation_status_uses_assistant_delivery_path;
+          test_case "continuation status persists as a chat block" `Quick
+            test_continuation_status_becomes_persisted_chat_block;
         ] );
       ( "direct_reply",
         [
@@ -611,6 +658,8 @@ let () =
             test_direct_reply_visible_text;
           test_case "connector projection keeps external wait typed" `Quick
             test_connector_projection_keeps_external_wait_typed;
+          test_case "connector projection keeps continuation typed" `Quick
+            test_connector_projection_keeps_continuation_typed;
           test_case "direct reply keeps external wait typed" `Quick
             test_direct_reply_projection_keeps_external_wait_typed;
         ] );


### PR DESCRIPTION
## Summary

- persist `Continuation_checkpoint` as a typed keeper-chat status block
- deliver the same typed status through Slack, Discord, SSE, history hydration, and queue polling
- mark the exact queued receipt delivered after transcript persistence instead of converting the checkpoint into `no_visible_reply`
- keep the repeated-tool-call guard and avoid replaying a turn whose tools may already have committed effects
- align RFC-0232 with the durable status projection

Fixes #26498.

## Verification

- `ocamlformat --check` on changed OCaml files
- `scripts/dune-local.sh build test/test_keeper_turn_outcome.exe test/test_keeper_chat_blocks.exe`
- `test_keeper_turn_outcome.exe` — 25 passed
- `test_keeper_chat_blocks.exe` — 32 passed
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm lint`
- focused dashboard Vitest suite — 378 passed
- `git diff --check`
