### PR TITLE
refactor(runtime): purge dead supports_native_streaming from model_capabilities

### DIFF
--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -105,7 +105,6 @@ type model_capabilities =
   ; supports_multimodal_inputs : bool
   ; supports_response_format_json : bool
   ; supports_structured_output : bool
-  ; supports_native_streaming : bool
   ; supports_system_prompt : bool
   ; supports_caching : bool
   ; supports_prompt_caching : bool
@@ -135,7 +134,6 @@ let model_capabilities_default =
   ; supports_multimodal_inputs = false
   ; supports_response_format_json = false
   ; supports_structured_output = false
-  ; supports_native_streaming = false
   ; supports_system_prompt = false
   ; supports_caching = false
   ; supports_prompt_caching = false

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -88,7 +88,6 @@ type model_capabilities =
   ; supports_multimodal_inputs : bool
   ; supports_response_format_json : bool
   ; supports_structured_output : bool
-  ; supports_native_streaming : bool
   ; supports_system_prompt : bool
   ; supports_caching : bool
   ; supports_prompt_caching : bool

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -497,7 +497,6 @@ let parse_model_capabilities ~(path : string) (tbl : Otoml.t)
       ; supports_multimodal_inputs = b "supports-multimodal-inputs"
       ; supports_response_format_json = b "supports-response-format-json"
       ; supports_structured_output = b "supports-structured-output"
-      ; supports_native_streaming = b "supports-native-streaming"
       ; supports_system_prompt = b "supports-system-prompt"
       ; supports_caching = b "supports-caching"
       ; supports_prompt_caching = b "supports-prompt-caching"

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1597,7 +1597,6 @@ let runtime_declared_model_capabilities_json
       ; "supports_multimodal_inputs", `Bool caps.supports_multimodal_inputs
       ; "supports_response_format_json", `Bool caps.supports_response_format_json
       ; "supports_structured_output", `Bool caps.supports_structured_output
-      ; "supports_native_streaming", `Bool caps.supports_native_streaming
       ; "supports_system_prompt", `Bool caps.supports_system_prompt
       ; "supports_caching", `Bool caps.supports_caching
       ; "supports_prompt_caching", `Bool caps.supports_prompt_caching
@@ -1822,7 +1821,6 @@ let runtime_inventory_entry_json ~default_id (rt : Runtime.t) =
     ; "thinking_control_format", `String (thinking_control_format_wire caps.thinking_control_format)
     ; "supports_response_format_json", `Bool caps.supports_response_format_json
     ; "supports_structured_output", `Bool caps.supports_structured_output
-    ; "supports_native_streaming", `Bool caps.supports_native_streaming
     ; "supports_system_prompt", `Bool caps.supports_system_prompt
     ; "supports_caching", `Bool caps.supports_caching
     ; "supports_prompt_caching", `Bool caps.supports_prompt_caching

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -172,7 +172,6 @@ max_output_tokens = 200000
 supports_tools = true
 supports_reasoning = true
 supports_extended_thinking = true
-supports_native_streaming = true
 |}
 
 let runtime_toml_media_lane_with_global_outside =

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -188,7 +188,6 @@ supports-response-format-json = true
 supports-structured-output = true
 supports-audio-input = true
 supports-video-input = true
-supports-native-streaming = true
 supports-system-prompt = true
 supports-prompt-caching = true
 prompt-cache-alignment = 1024
@@ -300,7 +299,6 @@ id_prefix = "openai_compat/qwen"
 base = "openai_chat"
 max_context_tokens = 128000
 supports_tools = true
-supports_native_streaming = true
 
 [[models]]
 id_prefix = "openai_compat/gpt"
@@ -309,14 +307,12 @@ max_context_tokens = 64000
 supports_tools = true
 supports_response_format_json = true
 supports_structured_output = true
-supports_native_streaming = true
 
 [[models]]
 id_prefix = "openai_compat/small"
 base = "openai_chat"
 max_context_tokens = 32000
 supports_tools = true
-supports_native_streaming = true
 
 [[providers]]
 id = "kimi"
@@ -533,9 +529,9 @@ let test_runtime_inventory_surfaces_declared_model_capabilities () =
       true
       (gpt |> J.member "supports_structured_output" |> J.to_bool);
     Alcotest.(check bool)
-      "top-level native streaming"
+      "top-level streaming"
       true
-      (gpt |> J.member "supports_native_streaming" |> J.to_bool);
+      (gpt |> J.member "streaming" |> J.to_bool);
     Alcotest.(check bool)
       "top-level system prompt"
       true
@@ -1132,7 +1128,6 @@ modality_priority = "visual_first"
 task = "transcription"
 supports_audio_input = true
 supports_video_input = true
-supports_native_streaming = true
 supports_system_prompt = true
 supports_caching = true
 supports_prompt_caching = true
@@ -1152,7 +1147,6 @@ max_output_tokens = 4096
 supports_tools = true
 supports_reasoning = true
 supports_extended_thinking = true
-supports_native_streaming = true
 
 [[models]]
 id_prefix = "reasoning-big-out"
@@ -1163,7 +1157,6 @@ max_output_tokens = 200000
 supports_tools = true
 supports_reasoning = true
 supports_extended_thinking = true
-supports_native_streaming = true
 |}
 ;;
 

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -586,7 +586,6 @@ supports-tool-choice = true
 supports-extended-thinking = true
 supports-reasoning-budget = true
 thinking-control-format = "reasoning-effort"
-supports-native-streaming = true
 supports-response-format-json = true
 supports-structured-output = true
 
@@ -644,7 +643,6 @@ streaming = true
 max-output-tokens = 128000
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-native-streaming = true
 supports-response-format-json = true
 supports-structured-output = false
 

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -367,7 +367,6 @@ supports_tools = true
 supports_tool_choice = true
 supports_response_format_json = false
 supports_structured_output = false
-supports_native_streaming = true
 
 [[targets]]
 id = "deepseek.smoke"


### PR DESCRIPTION
## 배경

#26495 (SSE/streaming) 재설계의 일환으로, `Runtime_schema.model_capabilities` record의 `supports_native_streaming` 필드를 숙청한다.

## dead field 근거

이 필드는 runtime 결정에 **전혀 쓰이지 않는다**:

- `lib/runtime/runtime_adapter.ml:312`에서 최종 capabilities는 base record(`Llm_provider.Capabilities`)의 `supports_native_streaming = spec.streaming`으로 override한다. 즉 TOML `[models.<id>.capabilities]`에 선언된 `supports-native-streaming` 값은 런타임 streaming 동작에 영향을 주지 않는다.
- 실제 streaming 동작은 별개의 TOML `streaming` 필드(`runtime_toml.ml`의 `let streaming = Otoml.find_or ~default:true ["streaming"]`)가 결정한다.
- 유일 소비처는 dashboard 표시. operator에게 "TOML에 뭘 적었는지"를 보여줄 뿐 실제 동작과 무관한 dead projection이었다.

## 변경 내용

**라이브러리 (필드 제거):**
- `lib/runtime/runtime_schema.ml` — type 정의 + `model_capabilities_default`에서 필드 2줄 제거
- `lib/runtime/runtime_schema.mli` — type에서 필드 제거
- `lib/runtime/runtime_toml.ml` — `parse_model_capabilities`에서 `supports-native-streaming` 파싱 제거

**Dashboard (dead projection 제거):**
- `lib/server/server_dashboard_http_runtime_info.ml`
  - `runtime_declared_model_capabilities_json` (model_capabilities接收) — `supports_native_streaming` 표시 제거
  - `runtime_inventory_entry_json` (top-level mirror, model_capabilities 기반) — 동일 제거

**유지 (live 필드):**
- `runtime_adapter.ml:312`의 `supports_native_streaming = spec.streaming` — **다른 record**(`Llm_provider.Capabilities` base record)의 필드. 건드리지 않음.
- `effective_capabilities_json`의 provider caps 표시 — base record 기반이므로 유지.

## 동작 변화 (dashboard)

dashboard runtime inventory entry에서 model_capabilities 수준의 `supports_native_streaming` 필드가 사라진다. 대신 streaming 정보는:
- top-level `streaming` 필드 (`rt.model.streaming`, spec.streaming 기반) — 기존부터 존재
- `effective_capabilities.supports_native_streaming` (provider base record, spec.streaming-derived) — 기존부터 존재

즉, operator에게 **실제 동작을 지배하는 값**이 표시된다. TOML에 잘못 선언된 값이 dashboard에 반영되는 혼란이 제거된다.

## 테스트 수정

- TOML fixture에서 무시되는 dead key(`supports_native_streaming` / `supports-native-streaming`) 제거:
  - `test/test_keeper_turn_driver_failover.ml`
  - `test/test_sse_storm_e2e.ml`
  - `test/test_runtime_provider_auth_headers.ml`
  - `test/test_runtime_per_keeper_routing.ml`
- JSON 검증을 동작 변화에 맞게 수정:
  - `test/test_runtime_per_keeper_routing.ml` — `supports_native_streaming` 검증을 `streaming`(spec.streaming 기반 top-level 필드) 검증으로 교체
- `test/test_runtime_config_validity.ml`은 `Llm_provider.Capabilities` base record caps를 검증하므로 **수정 없음** (유지 대상).

## 범위 참고

drain 회귀 원복은 별개 변경으로 분리한다 (이 PR에 포함하지 않음).

Co-Authored-By: Claude <noreply@anthropic.com>
