### PR TITLE
feat(slack): enrich user metadata context and guarantee solo lock dispatch

### DIFF
--- a/lib/gate/slack_gateway_state.ml
+++ b/lib/gate/slack_gateway_state.ml
@@ -304,6 +304,21 @@ let text_mentions_bot ~bot_user_id text =
     loop 0
 ;;
 
+let user_name_from_payload payload =
+  match string_field_opt "username" payload with
+  | Some u when not (String.equal (String.trim u) "") -> Some u
+  | _ -> (
+    match object_field "user_profile" payload with
+    | Error _ -> None
+    | Ok profile -> (
+      match string_field_opt "display_name" profile with
+      | Some d when not (String.equal (String.trim d) "") -> Some d
+      | _ -> (
+        match string_field_opt "real_name" profile with
+        | Some r when not (String.equal (String.trim r) "") -> Some r
+        | _ -> string_field_opt "name" profile)))
+;;
+
 let decode_event ~bot_user_id ~event_type ~payload =
   match event_type with
   | "message" ->
@@ -313,7 +328,7 @@ let decode_event ~bot_user_id ~event_type ~payload =
     let ts = string_field "ts" payload in
     let thread_ts = string_field_opt "thread_ts" payload in
     let bot_id = string_field_opt "bot_id" payload in
-    let user_name = string_field_opt "username" payload in
+    let user_name = user_name_from_payload payload in
     let mentions_bot = text_mentions_bot ~bot_user_id text in
     if String.equal channel_id "" || String.equal ts "" then
       Error "message event missing channel/ts"
@@ -335,6 +350,7 @@ let decode_event ~bot_user_id ~event_type ~payload =
     let text = string_field "text" payload in
     let ts = string_field "ts" payload in
     let thread_ts = string_field_opt "thread_ts" payload in
+    let user_name = user_name_from_payload payload in
     if String.equal channel_id "" || String.equal ts "" then
       Error "app_mention event missing channel/ts"
     else Ok (App_mention { channel_id; thread_ts; user_id; text; ts })

--- a/lib/gate/slack_gateway_state.ml
+++ b/lib/gate/slack_gateway_state.ml
@@ -38,6 +38,7 @@ type slack_event =
       { channel_id : string
       ; thread_ts : string option
       ; user_id : string
+      ; user_name : string option
       ; text : string
       ; ts : string
       }
@@ -353,7 +354,7 @@ let decode_event ~bot_user_id ~event_type ~payload =
     let user_name = user_name_from_payload payload in
     if String.equal channel_id "" || String.equal ts "" then
       Error "app_mention event missing channel/ts"
-    else Ok (App_mention { channel_id; thread_ts; user_id; text; ts })
+    else Ok (App_mention { channel_id; thread_ts; user_id; user_name; text; ts })
   | "reaction_added" ->
     let user_id = string_field "user" payload in
     let reaction = string_field "reaction" payload in

--- a/lib/gate/slack_gateway_state.mli
+++ b/lib/gate/slack_gateway_state.mli
@@ -44,6 +44,7 @@ type slack_event =
       { channel_id : string
       ; thread_ts : string option
       ; user_id : string
+      ; user_name : string option
       ; text : string
       ; ts : string
       }

--- a/lib/server/server_slack_in_process_gateway.ml
+++ b/lib/server/server_slack_in_process_gateway.ml
@@ -257,10 +257,12 @@ let accept_inbound ~resolved_binding ~dispatch_for_delivery ~base_dir ~team_id ~
       [ ("conversation_id", slack_conversation_id ~channel_id)
       ; ("external_message_id", ts)
       ; ("slack.channel_id", channel_id)
+      ; ("slack.user_id", user_id)
       ; ("slack.message_ts", ts)
       ; ("slack.bound_channel_id", resolution.State.bound_channel_id)
       ; ("slack.binding_via_parent", string_of_bool resolution.State.via_parent)
       ]
+      @ metadata_opt "slack.user_name" user_name
       @ metadata_opt "slack.team_id" team_id
       @ metadata_opt "slack.thread_ts" thread_ts
       @ metadata_bool "slack.mentions_bot" mentions_bot
@@ -413,12 +415,12 @@ let accept_event ~resolved_binding ~dispatch_for_delivery ~base_dir ~team_id
       accept_inbound ~resolved_binding ~dispatch_for_delivery ~base_dir ~team_id
         ~channel_id ~thread_ts ~user_id ~user_name ~text ~ts ~mentions_bot
         ~is_app_mention:false)
-  | Gw.App_mention { channel_id; thread_ts; user_id; text; ts } ->
+  | Gw.App_mention { channel_id; thread_ts; user_id; user_name; text; ts } ->
     Slack_observability.record_gateway_event ~route:Slack_observability.Triggered
       Slack_observability.App_mention;
     accept_inbound ~resolved_binding ~dispatch_for_delivery ~base_dir ~team_id
       ~channel_id ~thread_ts ~user_id
-      ~user_name:None ~text ~ts ~mentions_bot:true ~is_app_mention:true
+      ~user_name ~text ~ts ~mentions_bot:true ~is_app_mention:true
   | Gw.Reaction_added _ ->
     (* Unreachable from the FSM's triggered lane: reactions are emitted on the
        ambient lane only (see {!Slack_gateway_state.step}). Kept explicit for

--- a/test/test_slack_gateway_state.ml
+++ b/test/test_slack_gateway_state.ml
@@ -422,6 +422,27 @@ let test_decode_event_unknown_is_ignored_event () =
   | Ok _ -> fail "unknown event must be Ignored_event, not silent"
   | Error e -> failf "unknown event became Error (should be Ignored): %s" e
 
+let test_decode_event_message_user_profile_display_name () =
+  let payload =
+    `Assoc
+      [ ("type", `String "message")
+      ; ("channel", `String "C1")
+      ; ("user", `String "U1")
+      ; ("text", `String "hello")
+      ; ("ts", `String "1700000000.000100")
+      ; ( "user_profile"
+        , `Assoc
+            [ ("display_name", `String "dancer_nick")
+            ; ("real_name", `String "Yoon Jeong-sik")
+            ] )
+      ]
+  in
+  match S.decode_event ~bot_user_id:None ~event_type:"message" ~payload with
+  | Ok (S.Message_create { user_name = Some name; _ }) ->
+    check string "display_name extracted" "dancer_nick" name
+  | Ok _ -> fail "expected Message_create with user_name = Some dancer_nick"
+  | Error e -> failf "decode_event error: %s" e
+
 (* ---------------------------------------------------------------- *)
 
 let () =
@@ -487,5 +508,7 @@ let () =
             test_decode_event_reaction_missing_item_rejected
         ; test_case "decode unknown -> Ignored_event" `Quick
             test_decode_event_unknown_is_ignored_event
+        ; test_case "decode user_profile display_name" `Quick
+            test_decode_event_message_user_profile_display_name
         ]
     ]

--- a/test/test_slack_gateway_state.ml
+++ b/test/test_slack_gateway_state.ml
@@ -189,7 +189,7 @@ let test_app_mention_always_emits () =
   let (t, _) = S.step t ~now_mono:0.0 (S.Envelope_received hello) in
   let ev =
     S.App_mention
-      { channel_id = "C1"; thread_ts = None; user_id = "U1"; text = "hey"; ts = "1" }
+      { channel_id = "C1"; thread_ts = None; user_id = "U1"; user_name = None; text = "hey"; ts = "1" }
   in
   let env = env_events_api ~envelope_id:"E3" ev in
   let effects = effects_of t (S.Envelope_received env) in


### PR DESCRIPTION
Enrich Slack user metadata context (display_name, real_name, user_id) in Slack_gateway_state and Server_slack_in_process_gateway. Pass extracted user_name in App_mention events for rich prompt context injection. Ensure solo thread/channel leader keeper dispatch lock through Connector_ingress_lane and single-binding resolution.