### PR TITLE
feat(dashboard): show Librarian facts in compact status

### DIFF
--- a/lib/dashboard/dashboard.ml
+++ b/lib/dashboard/dashboard.ml
@@ -525,12 +525,22 @@ let generate_compact ?(scope = All) (config : Workspace_utils.config) : string =
         then Printf.sprintf " | TOOL-ERR: %d" tool_failures
         else ""
       in
+      let librarian_enabled = Env_config.KeeperMemoryOs.librarian_enabled () in
+      let librarian_failures =
+        Otel_metric_store.metric_total Keeper_metrics.(to_string MemoryOsLibrarianFailures) |> int_of_float
+      in
+      let librarian_status =
+        if not librarian_enabled then "OFF"
+        else if librarian_failures > 0 then Printf.sprintf "ON (ERR: %d)" librarian_failures
+        else "ON"
+      in
       Printf.sprintf
-        "KEEPERS: %d running / %d dead / %d other | GUARD: %d | \
+        "KEEPERS: %d running / %d dead / %d other | LIBRARIAN: %s | GUARD: %d | \
          META-WRITE-ERR: %d%s"
         k_running
         k_dead
         k_other
+        librarian_status
         guard_violations
         write_meta_failures
         tool_suffix;

--- a/lib/dashboard/dashboard.ml
+++ b/lib/dashboard/dashboard.ml
@@ -489,7 +489,9 @@ let generate_compact ?(scope = All) (config : Workspace_utils.config) : string =
         + (Otel_metric_store.metric_total Keeper_metrics.(to_string WorkspaceHeartbeatFailures) |> int_of_float)
         + (Otel_metric_store.metric_total Keeper_metrics.(to_string TurnMetricsSnapshotFailures) |> int_of_float)
         + (Otel_metric_store.metric_total Keeper_metrics.(to_string OasExecutionErrors) |> int_of_float)
-        + (Otel_metric_store.metric_total Keeper_metrics.(to_string MemoryOsLibrarianFailures) |> int_of_float)
+        (* MemoryOsLibrarianFailures is intentionally excluded: librarian
+           failures are not tool errors and are surfaced separately in the
+           LIBRARIAN header segment (LIBRARIAN-FAILURES-TOTAL). *)
         + (Otel_metric_store.metric_total Keeper_metrics.(to_string MemoryActivityEmitFailures) |> int_of_float)
         + (Otel_metric_store.metric_total Keeper_metrics.(to_string SupervisorSweepFailures) |> int_of_float)
         + (Otel_metric_store.metric_total Keeper_metrics.(to_string TomlReconcileSweepFailures) |> int_of_float)

--- a/lib/dashboard/dashboard.ml
+++ b/lib/dashboard/dashboard.ml
@@ -112,6 +112,13 @@ let format_section (s : section) : string =
 let parse_iso_timestamp = Dashboard_labels.parse_iso_timestamp
 let format_elapsed = Dashboard_labels.format_elapsed
 
+let format_librarian_status ~enabled ~failures_total =
+  Printf.sprintf
+    "%s | LIBRARIAN-FAILURES-TOTAL: %d"
+    (if enabled then "ON" else "OFF")
+    failures_total
+;;
+
 let truncate_path (path : string) : string =
   let limit = max_path_length () in
   if String.length path > limit then
@@ -530,9 +537,9 @@ let generate_compact ?(scope = All) (config : Workspace_utils.config) : string =
         Otel_metric_store.metric_total Keeper_metrics.(to_string MemoryOsLibrarianFailures) |> int_of_float
       in
       let librarian_status =
-        if not librarian_enabled then "OFF"
-        else if librarian_failures > 0 then Printf.sprintf "ON (ERR: %d)" librarian_failures
-        else "ON"
+        format_librarian_status
+          ~enabled:librarian_enabled
+          ~failures_total:librarian_failures
       in
       Printf.sprintf
         "KEEPERS: %d running / %d dead / %d other | LIBRARIAN: %s | GUARD: %d | \

--- a/lib/dashboard/dashboard.mli
+++ b/lib/dashboard/dashboard.mli
@@ -45,6 +45,7 @@ val scope_of_string_opt : string -> scope option
 val format_section : section -> string
 val parse_iso_timestamp : string -> float option
 val format_elapsed : float -> string -> string -> string
+val format_librarian_status : enabled:bool -> failures_total:int -> string
 val truncate_path : string -> string
 val truncate_message : string -> string
 

--- a/test/test_dashboard.ml
+++ b/test/test_dashboard.ml
@@ -68,6 +68,20 @@ let test_format_section_empty () =
   let output = Dashboard.format_section section in
   Alcotest.(check bool) "has empty message" true (contains output "(nothing here)")
 
+let test_format_librarian_status_keeps_facts_separate () =
+  Alcotest.(check string)
+    "disabled"
+    "OFF | LIBRARIAN-FAILURES-TOTAL: 0"
+    (Dashboard.format_librarian_status ~enabled:false ~failures_total:0);
+  Alcotest.(check string)
+    "enabled without failures"
+    "ON | LIBRARIAN-FAILURES-TOTAL: 0"
+    (Dashboard.format_librarian_status ~enabled:true ~failures_total:0);
+  Alcotest.(check string)
+    "cumulative failures do not become current health"
+    "ON | LIBRARIAN-FAILURES-TOTAL: 3"
+    (Dashboard.format_librarian_status ~enabled:true ~failures_total:3)
+
 (* ===== parse_iso_timestamp Tests ===== *)
 
 let test_parse_timestamp_valid () =
@@ -252,6 +266,9 @@ let test_keepers_section_with_error_truncated () =
 let format_tests = [
   "format_section with content", `Quick, test_format_section;
   "format_section empty", `Quick, test_format_section_empty;
+  ( "format librarian status keeps facts separate"
+  , `Quick
+  , test_format_librarian_status_keeps_facts_separate );
 ]
 
 let timestamp_tests = [

--- a/test/test_dashboard.ml
+++ b/test/test_dashboard.ml
@@ -217,6 +217,29 @@ let test_generate_compact_contains_keepers () =
   Alcotest.(check bool) "contains KEEPERS line" true (contains output "KEEPERS:");
   cleanup_dir dir
 
+let test_generate_compact_shows_librarian_off_when_disabled () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = test_dir () in
+  let config = Workspace_utils.default_config dir in
+  setup_workspace config;
+  let key = Env_config.KeeperMemoryOs.librarian_env_key in
+  let prev = Sys.getenv_opt key in
+  Fun.protect
+    ~finally:(fun () ->
+      (match prev with
+       | Some value -> Unix.putenv key value
+       | None -> Unix.putenv key "");
+      cleanup_dir dir)
+    (fun () ->
+      Unix.putenv key "false";
+      let output = Dashboard.generate_compact config in
+      Alcotest.(check bool)
+        "contains LIBRARIAN marker" true (contains output "LIBRARIAN:");
+      Alcotest.(check bool)
+        "disabled librarian renders OFF" true
+        (contains output "LIBRARIAN: OFF"))
+
 let test_keepers_section_dead_phase () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -292,6 +315,9 @@ let keepers_tests = [
   "keepers section with entry", `Quick, test_keepers_section_with_entry;
   "generate full contains keepers", `Quick, test_generate_full_contains_keepers;
   "generate compact contains keepers", `Quick, test_generate_compact_contains_keepers;
+  ( "generate compact shows librarian off when disabled"
+  , `Quick
+  , test_generate_compact_shows_librarian_off_when_disabled );
   "keepers section dead phase", `Quick, test_keepers_section_dead_phase;
   "keepers section with error truncated", `Quick, test_keepers_section_with_error_truncated;
 ]


### PR DESCRIPTION
## 변경

- `masc_dashboard compact=true`에 Librarian 설정 상태를 표시했어용.
- 누적 실패 counter는 현재 health로 추정하지 않고 `LIBRARIAN-FAILURES-TOTAL` 사실값으로 분리했어용.
- OFF / ON+0 / ON+누적 실패를 pure formatter 테스트로 고정했어용.

## 검증

- `ocamlformat --check` 통과했어용.
- `git diff --check` 통과했어용.
- 로컬 Dune은 실행하지 않았고 exact-head CI로 확인해용.