### PR TITLE
fix(keeper): make dashboard draft admission idempotent

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -26,6 +26,7 @@ import {
   fetchKeeperChatHistory,
   fetchKeeperChatPending,
   fetchKeeperChatReceipt,
+  lookupKeeperChatReceipt,
   fetchKeeperCheckpoints,
   fetchQueuedKeeperMessageResult,
   fetchKeeperRuntimeTrace,
@@ -261,6 +262,29 @@ describe('Keeper chat durable receipt API', () => {
     )
   })
 
+  it('classifies a missing exact receipt separately from lookup unavailability', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(
+        new Response('{}', { status: 404, statusText: 'Not Found' }),
+      )
+      .mockResolvedValueOnce(
+        new Response('{}', { status: 503, statusText: 'Unavailable' }),
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      lookupKeeperChatReceipt(
+        'keeper sangsu',
+        'chatq_00000000-0000-4000-8000-000000000001',
+      ),
+    ).resolves.toEqual({ kind: 'absent' })
+    const unavailable = await lookupKeeperChatReceipt(
+      'keeper sangsu',
+      'chatq_00000000-0000-4000-8000-000000000001',
+    )
+    expect(unavailable.kind).toBe('unavailable')
+  })
+
   it('resolves one exact recovery receipt with string revision and lease evidence', async () => {
     const receiptId = 'chatq_00000000-0000-4000-8000-000000000001'
     const leaseId = 'lease_00000000-0000-4000-8000-000000000002'
@@ -435,7 +459,11 @@ describe('Keeper chat durable receipt API', () => {
         state: { kind: 'pending' },
       },
       content,
-      source: { kind: 'dashboard', thread_id: 'thread-1' },
+      source: {
+        kind: 'dashboard',
+        thread_id: 'thread-1',
+        actor: 'operator-1',
+      },
       user_blocks: [],
       attachments: [],
       submitted_at: 42,
@@ -473,6 +501,32 @@ describe('Keeper chat durable receipt API', () => {
       '/api/v1/keepers/sangsu/chat/pending?limit=100&after=41',
       expect.objectContaining({ headers: expect.any(Object) }),
     )
+  })
+
+  it('rejects dashboard pending provenance without an actor', () => {
+    expect(() => parseKeeperChatPendingSnapshot({
+      schema: 'keeper_chat_queue.pending.v2',
+      ok: true,
+      keeper_name: 'sangsu',
+      revision: '1',
+      current_work: null,
+      total_pending: 1,
+      next_after: null,
+      pending: [{
+        receipt: {
+          schema: 'keeper_chat_queue.receipt.v2',
+          keeper_name: 'sangsu',
+          receipt_id: 'chatq_00000000-0000-4000-8000-000000000001',
+          revision: '1',
+          state: { kind: 'pending' },
+        },
+        content: 'hello',
+        source: { kind: 'dashboard', thread_id: 'thread-1' },
+        user_blocks: [],
+        attachments: [],
+        submitted_at: 42,
+      }],
+    })).toThrow('Keeper pending source actor is missing')
   })
 
   it('rejects chat pagination revision drift without a fixed retry loop', async () => {
@@ -1122,6 +1176,59 @@ describe('streamKeeperMessage', () => {
     expect(actorHeader).toBe('dashboard-eager-manta')
     expect(actorHeader).not.toContain('%')
     expect(events).toEqual(['RUN_FINISHED'])
+  })
+
+  it('requests durable enqueue without waiting for turn completion', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('data: {"type":"RUN_FINISHED"}\n\n', {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await streamKeeperMessage('sangsu', 'queued draft', {
+      enqueueOnly: true,
+      receiptId: 'chatq_00000000-0000-4000-8000-000000000042',
+      onEvent: () => {},
+    })
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(JSON.parse(String(init.body))).toEqual({
+      name: 'sangsu',
+      message: 'queued draft',
+      direct_reply: true,
+      enqueue_only: true,
+      receipt_id: 'chatq_00000000-0000-4000-8000-000000000042',
+    })
+  })
+
+  it('rejects durable enqueue without a receipt before issuing HTTP', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const invalidOptions = {
+      enqueueOnly: true,
+      onEvent: () => {},
+    } as unknown as Parameters<typeof streamKeeperMessage>[2]
+
+    await expect(
+      streamKeeperMessage('sangsu', 'queued draft', invalidOptions),
+    ).rejects.toThrow('enqueueOnly requires receiptId')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a receipt on direct admission before issuing HTTP', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const invalidOptions = {
+      receiptId: 'chatq_00000000-0000-4000-8000-000000000042',
+      onEvent: () => {},
+    } as unknown as Parameters<typeof streamKeeperMessage>[2]
+
+    await expect(
+      streamKeeperMessage('sangsu', 'direct draft', invalidOptions),
+    ).rejects.toThrow('receiptId requires enqueueOnly')
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it('forwards copilot context fields to the stream endpoint', async () => {

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -556,16 +556,34 @@ async function refreshLoopbackDevTokenAfterMismatch(): Promise<boolean> {
   return getStoredToken() !== null
 }
 
-export interface StreamKeeperMessageOptions {
+interface StreamKeeperMessageBaseOptions {
   signal?: AbortSignal
   onEvent: (event: KeeperChatStreamEvent) => void
   attachments?: StreamAttachment[]
   userBlocks?: KeeperUserInputBlock[]
+}
+
+interface StreamKeeperDirectMessageOptions {
   channel?: string
   channelWorkspaceId?: string
   turnInstructions?: string
   surfaceContext?: KeeperStreamSurfaceContext
 }
+
+export type StreamKeeperMessageOptions = StreamKeeperMessageBaseOptions & (
+  | {
+      enqueueOnly: true
+      receiptId: string
+      channel?: never
+      channelWorkspaceId?: never
+      turnInstructions?: never
+      surfaceContext?: never
+    }
+  | (StreamKeeperDirectMessageOptions & {
+      enqueueOnly?: false
+      receiptId?: never
+    })
+)
 
 function streamUserBlockToWire(block: KeeperUserInputBlock): Record<string, unknown> {
   if (block.type === 'text') {
@@ -589,6 +607,8 @@ export async function streamKeeperMessage(
   {
     signal,
     onEvent,
+    enqueueOnly,
+    receiptId,
     attachments,
     userBlocks,
     channel,
@@ -601,6 +621,24 @@ export async function streamKeeperMessage(
     name,
     message,
     direct_reply: true,
+  }
+  if (enqueueOnly) {
+    const normalizedReceiptId = receiptId?.trim() ?? ''
+    if (!normalizedReceiptId) {
+      throw new Error('enqueueOnly requires receiptId')
+    }
+    if (
+      channel !== undefined
+      || channelWorkspaceId !== undefined
+      || turnInstructions !== undefined
+      || surfaceContext !== undefined
+    ) {
+      throw new Error('enqueueOnly does not support connector or turn context')
+    }
+    body.enqueue_only = true
+    body.receipt_id = normalizedReceiptId
+  } else if (receiptId !== undefined) {
+    throw new Error('receiptId requires enqueueOnly')
   }
   if (channel && channel.trim() !== '') {
     body.channel = channel.trim()
@@ -732,6 +770,11 @@ export interface KeeperChatReceipt {
   state: KeeperChatReceiptState
 }
 
+export type KeeperChatReceiptLookup =
+  | { kind: 'present'; receipt: KeeperChatReceipt }
+  | { kind: 'absent' }
+  | { kind: 'unavailable'; error: unknown }
+
 export type KeeperChatRecoveryDecision =
   | { kind: 'requeue_unconfirmed' }
   | {
@@ -760,7 +803,7 @@ export interface KeeperChatPendingAttachment {
 }
 
 export type KeeperChatPendingSource =
-  | { kind: 'dashboard'; threadId: string }
+  | { kind: 'dashboard'; threadId: string; actor: string }
   | { kind: 'discord'; channelId: string; userId: string }
   | {
       kind: 'slack'
@@ -910,19 +953,47 @@ export function parseKeeperChatReceipt(value: unknown): KeeperChatReceipt {
   return { keeperName, receiptId, revision, state }
 }
 
-export async function fetchKeeperChatReceipt(
+async function requestKeeperChatReceipt(
   keeperName: string,
   receiptId: string,
-): Promise<KeeperChatReceipt> {
-  const { response: resp, data } = await fetchJsonWithTimeout(
+): Promise<{ response: Response; data: unknown }> {
+  return fetchJsonWithTimeout(
     `/api/v1/keepers/${encodeURIComponent(keeperName)}/chat/receipts/${encodeURIComponent(receiptId)}`,
     { headers: jsonHeaders() },
     DEFAULT_GET_TIMEOUT_MS,
   )
+}
+
+export async function fetchKeeperChatReceipt(
+  keeperName: string,
+  receiptId: string,
+): Promise<KeeperChatReceipt> {
+  const { response: resp, data } = await requestKeeperChatReceipt(keeperName, receiptId)
   if (!resp.ok) {
     throw new Error(`fetchKeeperChatReceipt: HTTP ${resp.status} ${resp.statusText}`)
   }
   return parseKeeperChatReceipt(data)
+}
+
+export async function lookupKeeperChatReceipt(
+  keeperName: string,
+  receiptId: string,
+): Promise<KeeperChatReceiptLookup> {
+  try {
+    const { response, data } = await requestKeeperChatReceipt(keeperName, receiptId)
+    if (response.status === 404) return { kind: 'absent' }
+    if (!response.ok) {
+      return {
+        kind: 'unavailable',
+        error: new Error(
+          `lookupKeeperChatReceipt: HTTP ${response.status} ${response.statusText}`,
+        ),
+      }
+    }
+    return { kind: 'present', receipt: parseKeeperChatReceipt(data) }
+  } catch (error) {
+    return { kind: 'unavailable', error }
+  }
 }
 
 function parsePendingAttachment(value: unknown): KeeperChatPendingAttachment {
@@ -991,7 +1062,11 @@ function parsePendingSource(value: unknown): KeeperChatPendingSource {
   }
   switch (kind) {
     case 'dashboard':
-      return { kind, threadId: requiredString('thread_id') }
+      return {
+        kind,
+        threadId: requiredString('thread_id'),
+        actor: requiredString('actor'),
+      }
     case 'discord':
       return {
         kind,

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -8,6 +8,7 @@ const {
   shutdownKeeper,
   fetchKeeperChatPending,
   fetchKeeperChatReceipt,
+  lookupKeeperChatReceipt,
   fetchKeeperEventQueuePending,
   cancelKeeperChatPendingReceipt,
   editKeeperChatPendingReceipt,
@@ -15,17 +16,20 @@ const {
   operateKeeperEventQueue,
   resolveKeeperChatRecovery,
   KeeperEventQueueOperationError,
+  isKeeperThreadServerRejectedError,
 } = vi.hoisted(() => ({
   bootKeeper: vi.fn(),
   shutdownKeeper: vi.fn(),
   fetchKeeperChatPending: vi.fn(),
   fetchKeeperChatReceipt: vi.fn(),
+  lookupKeeperChatReceipt: vi.fn(),
   fetchKeeperEventQueuePending: vi.fn(),
   cancelKeeperChatPendingReceipt: vi.fn(),
   editKeeperChatPendingReceipt: vi.fn(),
   moveKeeperChatPendingReceiptToEnd: vi.fn(),
   operateKeeperEventQueue: vi.fn(),
   resolveKeeperChatRecovery: vi.fn(),
+  isKeeperThreadServerRejectedError: vi.fn((_error: unknown) => false),
   KeeperEventQueueOperationError: class KeeperEventQueueOperationError extends Error {
     readonly operation: {
       action: 'cancel' | 'transfer'
@@ -81,6 +85,7 @@ vi.mock('../keeper-actions', () => ({
   recoverKeeperRuntime: vi.fn(),
   resumePendingKeeperChatRequests: vi.fn(async () => undefined),
   sendKeeperThreadMessage: vi.fn(async () => null),
+  isKeeperThreadServerRejectedError,
   interruptKeeperTurn: vi.fn(async () => true),
   isKeeperThreadMessageSendInFlight: vi.fn(() => false),
 }))
@@ -130,6 +135,7 @@ vi.mock('../api/keeper', () => ({
   shutdownKeeper,
   fetchKeeperChatPending,
   fetchKeeperChatReceipt,
+  lookupKeeperChatReceipt,
   fetchKeeperEventQueuePending,
   cancelKeeperChatPendingReceipt,
   editKeeperChatPendingReceipt,
@@ -271,8 +277,11 @@ describe('KeeperConversationPanel', () => {
     vi.mocked(cancelActiveKeeperThreadMessage).mockResolvedValue(true)
     vi.mocked(isKeeperThreadMessageSendInFlight).mockReset()
     vi.mocked(isKeeperThreadMessageSendInFlight).mockReturnValue(false)
+    isKeeperThreadServerRejectedError.mockReset()
+    isKeeperThreadServerRejectedError.mockReturnValue(false)
     fetchKeeperChatPending.mockReset()
     fetchKeeperChatReceipt.mockReset()
+    lookupKeeperChatReceipt.mockReset()
     fetchKeeperEventQueuePending.mockReset()
     cancelKeeperChatPendingReceipt.mockReset()
     editKeeperChatPendingReceipt.mockReset()
@@ -774,8 +783,8 @@ describe('KeeperConversationPanel', () => {
   })
 
   it('keeps queued client action ids attached when draining the queue as independent turns', async () => {
-    enqueueInput('sangsu', 'queued one', undefined, 'queued-click-1')
-    enqueueInput('sangsu', 'queued two', undefined, 'queued-click-2')
+    const first = enqueueInput('sangsu', 'queued one', undefined, 'queued-click-1')
+    const second = enqueueInput('sangsu', 'queued two', undefined, 'queued-click-2')
 
     render(
       html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." />`,
@@ -794,10 +803,14 @@ describe('KeeperConversationPanel', () => {
     expect(vi.mocked(sendKeeperThreadMessage).mock.calls[1]?.[1]).toBe('queued one')
     expect(vi.mocked(sendKeeperThreadMessage).mock.calls[1]?.[2]).toEqual(expect.objectContaining({
       clientActionId: 'queued-click-1',
+      enqueueOnly: true,
+      receiptId: first.receiptId,
     }))
     expect(vi.mocked(sendKeeperThreadMessage).mock.calls[2]?.[1]).toBe('queued two')
     expect(vi.mocked(sendKeeperThreadMessage).mock.calls[2]?.[2]).toEqual(expect.objectContaining({
       clientActionId: 'queued-click-2',
+      enqueueOnly: true,
+      receiptId: second.receiptId,
     }))
   })
 
@@ -827,11 +840,13 @@ describe('KeeperConversationPanel', () => {
     expect(vi.mocked(sendKeeperThreadMessage).mock.calls[2]?.[1]).toBe('queued during drain')
     expect(vi.mocked(sendKeeperThreadMessage).mock.calls[2]?.[2]).toEqual(expect.objectContaining({
       clientActionId: 'queued-click-3',
+      enqueueOnly: true,
     }))
     expect(getQueueLength('sangsu')).toBe(0)
   })
 
-  it('drops an aborted queued send instead of requeueing it', async () => {
+  it('retains an aborted queued send until its durable receipt is acknowledged', async () => {
+    lookupKeeperChatReceipt.mockResolvedValue({ kind: 'absent' })
     vi.mocked(sendKeeperThreadMessage).mockImplementation(async (_keeperName, message) => {
       if (message === 'queued one') throw new DOMException('cancelled', 'AbortError')
     })
@@ -853,7 +868,146 @@ describe('KeeperConversationPanel', () => {
 
     await waitFor(() => expect(sendKeeperThreadMessage).toHaveBeenCalledTimes(2))
     expect(vi.mocked(sendKeeperThreadMessage).mock.calls[1]?.[1]).toBe('queued one')
+    expect(getQueuedMessages('sangsu').map(msg => msg.content)).toEqual([
+      'queued one',
+      'queued two',
+    ])
+    expect(getQueuedMessages('sangsu')[0]?.serverAcceptanceUnknown).toBeUndefined()
+    expect(container.textContent).not.toContain('서버 접수 확인 필요')
+  })
+
+  it('locks an aborted queued send when receipt lookup is unavailable', async () => {
+    lookupKeeperChatReceipt.mockResolvedValue({
+      kind: 'unavailable',
+      error: new Error('receipt lookup timed out'),
+    })
+    vi.mocked(sendKeeperThreadMessage).mockImplementation(async (_keeperName, message) => {
+      if (message === 'queued one') throw new DOMException('cancelled', 'AbortError')
+    })
+    enqueueInput('sangsu', 'queued one', undefined, 'queued-click-1')
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." />`,
+      container,
+    )
+    await Promise.resolve()
+    fireEvent.input(container.querySelector('textarea') as HTMLTextAreaElement, {
+      target: { value: 'trigger drain' },
+    })
+    await Promise.resolve()
+    fireEvent.click(container.querySelector('.send') as HTMLButtonElement)
+
+    await waitFor(() => expect(lookupKeeperChatReceipt).toHaveBeenCalledTimes(1))
+    expect(getQueuedMessages('sangsu')[0]?.serverAcceptanceUnknown).toBe(true)
+    expect(container.textContent).toContain('서버 접수 확인 필요')
+
+    lookupKeeperChatReceipt.mockResolvedValue({ kind: 'absent' })
+    vi.mocked(sendKeeperThreadMessage).mockResolvedValue(undefined)
+    const retry = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.includes('다시 확인'))
+    fireEvent.click(retry as HTMLButtonElement)
+
+    await waitFor(() => expect(sendKeeperThreadMessage).toHaveBeenCalledTimes(3))
+    expect(getQueuedMessages('sangsu')).toEqual([])
+  })
+
+  it('removes an aborted queued send after exact receipt reconciliation', async () => {
+    vi.mocked(sendKeeperThreadMessage).mockImplementation(async (_keeperName, message) => {
+      if (message === 'queued one') throw new DOMException('cancelled', 'AbortError')
+    })
+    const queued = enqueueInput('sangsu', 'queued one', undefined, 'queued-click-1')
+    enqueueInput('sangsu', 'queued two', undefined, 'queued-click-2')
+    lookupKeeperChatReceipt.mockResolvedValue({
+      kind: 'present',
+      receipt: {
+        keeperName: 'sangsu',
+        receiptId: queued.receiptId,
+        revision: '1',
+        state: { kind: 'pending' },
+      },
+    })
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." />`,
+      container,
+    )
+    await Promise.resolve()
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    fireEvent.input(textarea, { target: { value: 'trigger drain' } })
+    await Promise.resolve()
+    fireEvent.click(container.querySelector('.send') as HTMLButtonElement)
+
+    await waitFor(() => expect(lookupKeeperChatReceipt).toHaveBeenCalledWith(
+      'sangsu',
+      queued.receiptId,
+    ))
     expect(getQueuedMessages('sangsu').map(msg => msg.content)).toEqual(['queued two'])
+  })
+
+  it('checks a locked receipt before retrying the enqueue request', async () => {
+    lookupKeeperChatReceipt.mockResolvedValueOnce({
+      kind: 'unavailable',
+      error: new Error('receipt lookup timed out'),
+    })
+    vi.mocked(sendKeeperThreadMessage).mockImplementation(async (_keeperName, message) => {
+      if (message === 'queued one') throw new DOMException('cancelled', 'AbortError')
+    })
+    const queued = enqueueInput('sangsu', 'queued one', undefined, 'queued-click-1')
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." />`,
+      container,
+    )
+    await Promise.resolve()
+    fireEvent.input(container.querySelector('textarea') as HTMLTextAreaElement, {
+      target: { value: 'trigger drain' },
+    })
+    await Promise.resolve()
+    fireEvent.click(container.querySelector('.send') as HTMLButtonElement)
+    await waitFor(() => expect(getQueuedMessages('sangsu')[0]?.serverAcceptanceUnknown).toBe(true))
+
+    lookupKeeperChatReceipt.mockResolvedValueOnce({
+      kind: 'present',
+      receipt: {
+        keeperName: 'sangsu',
+        receiptId: queued.receiptId,
+        revision: '2',
+        state: { kind: 'delivered', completedAt: 1, outcomeRef: null },
+      },
+    })
+    const sendCountBeforeCheck = vi.mocked(sendKeeperThreadMessage).mock.calls.length
+    const retry = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.includes('다시 확인'))
+    fireEvent.click(retry as HTMLButtonElement)
+
+    await waitFor(() => expect(getQueuedMessages('sangsu')).toEqual([]))
+    expect(sendKeeperThreadMessage).toHaveBeenCalledTimes(sendCountBeforeCheck)
+  })
+
+  it('does not mask a definitive receipt collision as successful admission', async () => {
+    const rejection = new Error('receipt payload collision')
+    isKeeperThreadServerRejectedError.mockImplementation(error => error === rejection)
+    vi.mocked(sendKeeperThreadMessage).mockImplementation(async (_keeperName, message) => {
+      if (message === 'queued one') throw rejection
+    })
+    enqueueInput('sangsu', 'queued one', undefined, 'queued-click-1')
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." />`,
+      container,
+    )
+    await Promise.resolve()
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    fireEvent.input(textarea, { target: { value: 'trigger drain' } })
+    await Promise.resolve()
+    fireEvent.click(container.querySelector('.send') as HTMLButtonElement)
+
+    await waitFor(() => expect(sendKeeperThreadMessage).toHaveBeenCalledTimes(2))
+    expect(lookupKeeperChatReceipt).not.toHaveBeenCalled()
+    expect(getQueuedMessages('sangsu').map(message => message.content))
+      .toContain('queued one')
   })
 
   it('forwards the message-level turn inspector action to the transcript', async () => {
@@ -1012,7 +1166,11 @@ describe('KeeperConversationPanel', () => {
           state: { kind: 'pending' },
         },
         content: 'durable queued operator request',
-        source: { kind: 'dashboard', threadId: 'operator-thread-22' },
+        source: {
+          kind: 'dashboard',
+          threadId: 'operator-thread-22',
+          actor: 'operator-22',
+        },
         userBlocks: [],
         attachments: [],
         submittedAt: 42,
@@ -1074,7 +1232,8 @@ describe('KeeperConversationPanel', () => {
       expect(panel?.getAttribute('role')).toBe('dialog')
       expect(panel?.textContent).toContain('durable queued operator request')
       expect(panel?.textContent).toContain(receiptId)
-      expect(panel?.textContent).toContain('dashboard · thread operator-thread-22')
+      expect(panel?.textContent)
+        .toContain('dashboard · actor operator-22 · thread operator-thread-22')
       expect(panel?.textContent).toContain('board-post-9')
       expect(panel?.textContent).toContain('수정')
       expect(panel?.textContent).toContain('맨 뒤로')

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -31,6 +31,7 @@ import {
   recoverKeeperRuntime,
   resumePendingKeeperChatRequests,
   sendKeeperThreadMessage,
+  isKeeperThreadServerRejectedError,
 } from '../keeper-actions'
 import {
   keeperActionErrors,
@@ -92,6 +93,7 @@ import {
   cancelKeeperChatPendingReceipt,
   editKeeperChatPendingReceipt,
   fetchKeeperChatReceipt,
+  lookupKeeperChatReceipt,
   fetchKeeperEventQueuePending,
   fetchKeeperChatPending,
   KeeperEventQueueOperationError,
@@ -488,6 +490,7 @@ function QueueItemCard({ keeperName, msg, onMutate, onSave }: QueueItemCardProps
       data-chat-queue-item=${msg.id}
       data-chat-queue-seq=${msg.sequence}
       data-chat-queue-client-action-id=${msg.clientActionId ?? undefined}
+      data-chat-queue-acceptance=${msg.serverAcceptanceUnknown ? 'unknown' : 'not_submitted'}
     >
       ${editing
         ? html`
@@ -534,8 +537,15 @@ function QueueItemCard({ keeperName, msg, onMutate, onSave }: QueueItemCardProps
                   : null}
               </div>
               <div class="flex items-center gap-1.5 flex-none">
-                <button type="button" class="text-2xs text-[var(--color-fg-secondary)] hover:text-[var(--color-fg-primary)]" onClick=${() => { setEditing(true) }}>수정</button>
-                <button type="button" class="text-2xs text-[var(--color-status-err)] hover:text-[var(--color-status-err)]" onClick=${() => { removeQueuedMessage(keeperName, msg.id); onMutate() }}>삭제</button>
+                ${msg.serverAcceptanceUnknown
+                  ? html`
+                      <span class="text-2xs text-[var(--color-status-warn)]">서버 접수 확인 필요</span>
+                      <button type="button" class="text-2xs underline text-[var(--color-fg-secondary)] hover:text-[var(--color-fg-primary)]" onClick=${onSave}>다시 확인</button>
+                    `
+                  : html`
+                      <button type="button" class="text-2xs text-[var(--color-fg-secondary)] hover:text-[var(--color-fg-primary)]" onClick=${() => { setEditing(true) }}>수정</button>
+                      <button type="button" class="text-2xs text-[var(--color-status-err)] hover:text-[var(--color-status-err)]" onClick=${() => { removeQueuedMessage(keeperName, msg.id); onMutate() }}>삭제</button>
+                    `}
               </div>
             </div>
           `}
@@ -568,7 +578,7 @@ function BusyToolbar({
 function pendingSourceLabel(source: KeeperChatPendingSource): string {
   switch (source.kind) {
     case 'dashboard':
-      return `dashboard · thread ${source.threadId}`
+      return `dashboard · actor ${source.actor} · thread ${source.threadId}`
     case 'discord':
       return `discord · user ${source.userId} · channel ${source.channelId}`
     case 'slack':
@@ -1320,6 +1330,8 @@ export function KeeperConversationPanel({
     [keeperName, queueVersion],
   )
   const queueCount = queuedMessages.length
+  const acceptanceUnknownCount =
+    queuedMessages.filter(message => message.serverAcceptanceUnknown).length
   const visibleThreadWithQueue = useMemo(
     () =>
       queuedMessages.length > 0
@@ -1452,14 +1464,53 @@ export function KeeperConversationPanel({
     await loadFullKeeperHistory(keeperName)
   }
 
-  const drainQueue = async () => {
+  const drainQueue = async (
+    { retryUncertain = false }: { retryUncertain?: boolean } = {},
+  ) => {
     if (isDrainingRef.current) return
     isDrainingRef.current = true
     try {
       for (;;) {
+        const next = getQueuedMessages(keeperName)[0]
+        if (next?.serverAcceptanceUnknown && !retryUncertain) return
         const queued = dequeueInput(keeperName)
         if (!queued) return
+        retryUncertain = false
         bumpQueue()
+
+        if (queued.serverAcceptanceUnknown) {
+          const lookup = await lookupKeeperChatReceipt(keeperName, queued.receiptId)
+          if (
+            lookup.kind === 'present'
+            && lookup.receipt.keeperName === keeperName
+            && lookup.receipt.receiptId === queued.receiptId
+          ) {
+            markInputSent(keeperName)
+            bumpQueue()
+            void reconcileKeeperChatReceipts(keeperName)
+            continue
+          }
+          if (lookup.kind !== 'absent') {
+            if (lookup.kind === 'unavailable') {
+              console.warn(
+                `[keeper] durable receipt lookup failed receipt=${queued.receiptId}`,
+                lookup.error,
+              )
+            } else {
+              console.warn(
+                `[keeper] durable receipt identity mismatch expected=${keeperName}/${queued.receiptId}`,
+                lookup.receipt,
+              )
+            }
+            requeueInputFront(
+              keeperName,
+              queued,
+              { serverAcceptanceUnknown: true },
+            )
+            bumpQueue()
+            return
+          }
+        }
 
         const content = queued.content.trim()
         const attachments = queued.attachments && queued.attachments.length > 0 ? queued.attachments : undefined
@@ -1474,18 +1525,51 @@ export function KeeperConversationPanel({
             attachments,
             blocks: queued.blocks,
             clientActionId: queued.clientActionId,
+            enqueueOnly: true,
+            receiptId: queued.receiptId,
             userBlocks: queued.userBlocks,
           })
           markInputSent(keeperName)
           bumpQueue()
         } catch (err) {
-          if (isAbortError(err)) {
-            markInputSent(keeperName)
+          if (isKeeperThreadServerRejectedError(err)) {
+            requeueInputFront(keeperName, queued)
             bumpQueue()
+            showToast(err.message, 'error')
             return
           }
-          requeueInputFront(keeperName, queued)
+          const lookup = await lookupKeeperChatReceipt(keeperName, queued.receiptId)
+          if (
+            lookup.kind === 'present'
+            && lookup.receipt.keeperName === keeperName
+            && lookup.receipt.receiptId === queued.receiptId
+          ) {
+            markInputSent(keeperName)
+            bumpQueue()
+            void reconcileKeeperChatReceipts(keeperName)
+            return
+          }
+          const acceptanceUnavailable =
+            lookup.kind === 'unavailable'
+            || lookup.kind === 'present'
+          if (lookup.kind === 'unavailable') {
+            console.warn(
+              `[keeper] durable receipt lookup failed receipt=${queued.receiptId}`,
+              lookup.error,
+            )
+          } else if (lookup.kind === 'present') {
+            console.warn(
+              `[keeper] durable receipt identity mismatch expected=${keeperName}/${queued.receiptId}`,
+              lookup.receipt,
+            )
+          }
+          requeueInputFront(
+            keeperName,
+            queued,
+            { serverAcceptanceUnknown: acceptanceUnavailable },
+          )
           bumpQueue()
+          if (isAbortError(err)) return
           const message = err instanceof Error ? err.message : `${keeperName} 메시지 전송 실패`
           showToast(message, 'error')
           return
@@ -1598,8 +1682,15 @@ export function KeeperConversationPanel({
     ? html`
         <div class="mb-3 flex flex-col gap-2" data-chat-queue-list>
           <div class="flex items-center justify-between gap-2 text-2xs text-[var(--color-fg-muted)] v2-monitoring-row" data-chat-queue-row>
-            <span>${queueCount}개 브라우저 초안 · 서버 미접수</span>
-            <button type="button" class="underline hover:text-[var(--color-fg-secondary)]" onClick=${cancelQueue}>모두 취소</button>
+            <span>
+              ${queueCount}개 브라우저 초안
+              · ${acceptanceUnknownCount > 0
+                ? `${acceptanceUnknownCount}개 서버 접수 확인 필요`
+                : '서버 미접수'}
+            </span>
+            ${queueCount > acceptanceUnknownCount
+              ? html`<button type="button" class="underline hover:text-[var(--color-fg-secondary)]" onClick=${cancelQueue}>미접수 초안 취소</button>`
+              : null}
           </div>
           ${queuedMessages.map(msg => html`
             <${QueueItemCard}
@@ -1608,7 +1699,7 @@ export function KeeperConversationPanel({
               msg=${msg}
               onMutate=${bumpQueue}
               onSave=${() => {
-                if (!sending) void drainQueue()
+                if (!sending) void drainQueue({ retryUncertain: true })
               }}
             />
           `)}

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -1068,6 +1068,23 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     return err
   }
 
+  it('removes optimistic transcript rows when durable enqueue acknowledgement is cut', async () => {
+    streamKeeperMessage.mockRejectedValue(abortError())
+
+    const error = await sendKeeperThreadMessage(
+      'echo',
+      'durable draft',
+      {
+        enqueueOnly: true,
+        receiptId: 'chatq_00000000-0000-4000-8000-000000000042',
+      },
+    ).catch(caught => caught)
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error.name).toBe('AbortError')
+    expect(keeperThreads.value.echo ?? []).toEqual([])
+  })
+
   it('does not content-deduplicate repeated same-text sends', async () => {
     streamKeeperMessage
       .mockImplementationOnce(async (
@@ -1838,7 +1855,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       'chatq_00000000-0000-4000-8000-000000000001',
     )
     expect(reply?.delivery).toBe('queued')
-    expect(reply?.text).toContain('메시지는 대기열에 추가했습니다')
+    expect(reply?.text).toContain('메시지를 대기열에 추가했습니다')
     expect(reply?.details).toMatchObject({
       queueReceiptId: 'chatq_00000000-0000-4000-8000-000000000001',
       queueRevision: '4',

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -927,7 +927,7 @@ export async function reconcileKeeperChatReceipts(name: string): Promise<void> {
           role: 'assistant',
           source: 'direct_assistant',
           label: keeperName,
-          text: `${keeperName}가 다른 작업을 처리 중이에요. 메시지는 대기열에 추가했습니다.`,
+          text: `${keeperName} 메시지를 대기열에 추가했습니다.`,
           timestamp,
           delivery: 'queued',
           streamState: null,
@@ -1495,16 +1495,34 @@ function fallbackMessageForUserBlocks(blocks: KeeperUserInputBlock[]): string {
     : `[첨부 ${media.length}개]`
 }
 
+type SendKeeperThreadMessageOptions = {
+  attachments?: KeeperConversationAttachment[]
+  clientActionId?: string
+  clientActionIds?: readonly string[]
+  blocks?: ChatBlock[]
+  userBlocks?: KeeperUserInputBlock[]
+} & (
+  | { enqueueOnly: true; receiptId: string }
+  | { enqueueOnly?: false; receiptId?: never }
+)
+
+export class KeeperThreadServerRejectedError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'KeeperThreadServerRejectedError'
+  }
+}
+
+export function isKeeperThreadServerRejectedError(
+  error: unknown,
+): error is KeeperThreadServerRejectedError {
+  return error instanceof KeeperThreadServerRejectedError
+}
+
 export async function sendKeeperThreadMessage(
   name: string,
   prompt: string,
-  options: {
-    attachments?: KeeperConversationAttachment[]
-    clientActionId?: string
-    clientActionIds?: readonly string[]
-    blocks?: ChatBlock[]
-    userBlocks?: KeeperUserInputBlock[]
-  } = {},
+  options: SendKeeperThreadMessageOptions = {},
 ): Promise<void> {
   const keeperName = name.trim()
   const attachments =
@@ -1580,8 +1598,12 @@ export async function sendKeeperThreadMessage(
   try {
     finalizeAssistantEntry(keeperName, localId, { delivery: 'delivered' })
 
+    const admissionOptions = options.enqueueOnly
+      ? { enqueueOnly: true as const, receiptId: options.receiptId }
+      : {}
     const outcome = await streamKeeperMessage(keeperName, message, {
       signal: controller.signal,
+      ...admissionOptions,
       attachments,
       userBlocks,
       onEvent: event => {
@@ -1641,7 +1663,7 @@ export async function sendKeeperThreadMessage(
         }
         const error = applyKeeperStreamEvent(keeperName, assistantId, event)
         if (error) {
-          throw new Error(error)
+          throw new KeeperThreadServerRejectedError(error)
         }
         if (event.type === 'CUSTOM' && event.name === 'KEEPER_CHAT_QUEUED' && isRecord(event.value)) {
           const queueReceiptId = asString(event.value.receipt_id, '').trim()
@@ -1753,6 +1775,10 @@ export async function sendKeeperThreadMessage(
   } catch (err) {
     flushPendingKeeperStreamDeltas(keeperName, assistantId)
     if (isAbortError(err)) {
+      if (options.enqueueOnly) {
+        removeThreadEntries(keeperName, [localId, assistantId])
+        throw err
+      }
       const durablePendingRequest = requestId
         ? pendingKeeperChatRequestsForKeeper(keeperName)
           .find(candidate => candidate.requestId === requestId) ?? null

--- a/dashboard/src/keeper-chat-store.test.ts
+++ b/dashboard/src/keeper-chat-store.test.ts
@@ -11,6 +11,7 @@ import {
   getQueueLength,
   getQueueTotal,
   updateQueuedMessage,
+  removeQueuedMessage,
   readKeeperDraft,
   writeKeeperDraft,
   clearKeeperDraft,
@@ -105,6 +106,42 @@ describe('keeper-chat-store input queue', () => {
     expect(next!.content).toBe('second')
   })
 
+  it('locks a receipt whose server acceptance is unknown', () => {
+    const first = enqueueInput('keeper-q', 'first')
+    enqueueInput('keeper-q', 'second')
+    const sending = dequeueInput('keeper-q')
+
+    requeueInputFront(
+      'keeper-q',
+      sending!,
+      { serverAcceptanceUnknown: true },
+    )
+
+    expect(() => updateQueuedMessage('keeper-q', first.id, { content: 'edited' }))
+      .toThrow('서버 접수 여부')
+    expect(removeQueuedMessage('keeper-q', first.id)).toBe(false)
+    clearInputQueue('keeper-q')
+    expect(getQueuedMessages('keeper-q').map(message => message.content)).toEqual(['first'])
+  })
+
+  it('unlocks a receipt after an authoritative absent lookup', () => {
+    const queued = enqueueInput('keeper-q', 'first')
+    const sending = dequeueInput('keeper-q')
+    requeueInputFront(
+      'keeper-q',
+      sending!,
+      { serverAcceptanceUnknown: true },
+    )
+
+    const retried = dequeueInput('keeper-q')
+    requeueInputFront('keeper-q', retried!)
+
+    expect(getQueuedMessages('keeper-q')[0]?.serverAcceptanceUnknown).toBeUndefined()
+    expect(updateQueuedMessage('keeper-q', queued.id, { content: 'edited' })?.content)
+      .toBe('edited')
+    expect(removeQueuedMessage('keeper-q', queued.id)).toBe(true)
+  })
+
   it('clearInputQueue removes all items', () => {
     enqueueInput('keeper-q', 'x')
     enqueueInput('keeper-q', 'y')
@@ -175,10 +212,13 @@ describe('keeper-chat-store input queue', () => {
 
   it('clears the client action id when a queued message is edited', () => {
     const msg = enqueueInput('keeper-q', 'original', undefined, 'click-1')
+    const originalReceiptId = msg.receiptId
 
     updateQueuedMessage('keeper-q', msg.id, { content: 'edited' })
 
     expect(hasQueuedInputClientAction('keeper-q', 'click-1')).toBe(false)
+    expect(msg.receiptId).toMatch(/^chatq_[0-9a-f-]{36}$/i)
+    expect(msg.receiptId).not.toBe(originalReceiptId)
     enqueueInput('keeper-q', 'original', undefined, 'click-1')
     expect(getQueueLength('keeper-q')).toBe(2)
   })

--- a/dashboard/src/keeper-chat-store.ts
+++ b/dashboard/src/keeper-chat-store.ts
@@ -12,6 +12,7 @@ import type { ChatBlock, KeeperConversationAttachment, KeeperUserInputBlock } fr
 
 export interface QueuedMessage {
   id: string
+  receiptId: string
   content: string
   timestamp: number
   sequence: number
@@ -20,6 +21,7 @@ export interface QueuedMessage {
   blocks?: ChatBlock[]
   userBlocks?: KeeperUserInputBlock[]
   clientActionId?: string
+  serverAcceptanceUnknown?: true
   editOnOpen?: boolean
 }
 
@@ -30,6 +32,10 @@ export interface InputQueue {
 
 const _queues = new Map<string, InputQueue>()
 let _nextQueueSequence = 0
+
+function nextQueueReceiptId(): string {
+  return `chatq_${crypto.randomUUID()}`
+}
 
 function _ensureQueue(keeperName: string): InputQueue {
   let q = _queues.get(keeperName)
@@ -96,6 +102,7 @@ export function enqueueInput(
   }
   const msg: QueuedMessage = {
     id: `${keeperName}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    receiptId: nextQueueReceiptId(),
     content,
     timestamp: Date.now(),
     sequence: ++_nextQueueSequence,
@@ -177,6 +184,9 @@ export function updateQueuedMessage(
     typeof updates.content === 'string' && updates.content !== item.content
   const attachmentsChanged = 'attachments' in updates
   const changed = contentChanged || attachmentsChanged
+  if (changed && item.serverAcceptanceUnknown) {
+    throw new Error('서버 접수 여부를 확인하기 전에는 메시지를 수정할 수 없습니다.')
+  }
   const nextContent = typeof updates.content === 'string' ? updates.content : item.content
   const nextAttachments = 'attachments' in updates ? updates.attachments : item.attachments
   const nextUserBlocks = changed
@@ -198,6 +208,7 @@ export function updateQueuedMessage(
   else delete item.attachments
   if (changed) delete item.clientActionId
   if (changed) {
+    item.receiptId = nextQueueReceiptId()
     if ('blocks' in updates && updates.blocks && updates.blocks.length > 0) {
       item.blocks = updates.blocks
     } else {
@@ -213,6 +224,9 @@ export function updateQueuedMessage(
 export function removeQueuedMessage(keeperName: string, id: string): boolean {
   const q = _queues.get(keeperName)
   if (!q) return false
+  if (q.items.some(item => item.id === id && item.serverAcceptanceUnknown)) {
+    return false
+  }
   const before = q.items.length
   q.items = q.items.filter(i => i.id !== id)
   return q.items.length < before
@@ -228,11 +242,18 @@ export function dequeueInput(keeperName: string): QueuedMessage | null {
 }
 
 /** Put an unsent/deferred message back at the front of the queue. */
-export function requeueInputFront(keeperName: string, msg: QueuedMessage): void {
+export function requeueInputFront(
+  keeperName: string,
+  msg: QueuedMessage,
+  options: { serverAcceptanceUnknown?: boolean } = {},
+): void {
   const q = _ensureQueue(keeperName)
   q.sending = false
   if (q.items.some(item => item.id === msg.id)) return
-  q.items.unshift({ ...msg, sent: false })
+  const requeued = { ...msg, sent: false }
+  delete requeued.serverAcceptanceUnknown
+  if (options.serverAcceptanceUnknown) requeued.serverAcceptanceUnknown = true
+  q.items.unshift(requeued)
 }
 
 /** Mark the current sending item as done and clear the sending flag. */
@@ -243,7 +264,14 @@ export function markInputSent(keeperName: string): void {
 
 /** Clear all queued items for a keeper. */
 export function clearInputQueue(keeperName: string): void {
-  _queues.delete(keeperName)
+  const q = _queues.get(keeperName)
+  if (!q) return
+  const uncertain = q.items.filter(item => item.serverAcceptanceUnknown)
+  if (uncertain.length === 0) {
+    _queues.delete(keeperName)
+  } else {
+    q.items = uncertain
+  }
 }
 
 /** Number of items waiting (excluding the one currently being sent). */

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -724,7 +724,7 @@ export function applyKeeperStreamEvent(
             ? `${keeperName}의 이전 메시지 상태를 확인해야 해요. 새 메시지는 안전하게 대기 중입니다.`
             : shutdownOperationId
               ? `${keeperName}가 종료 중이에요. 다시 활동을 시작하면 이 메시지를 처리합니다.`
-              : `${keeperName}가 다른 작업을 처리 중이에요. 메시지는 대기열에 추가했습니다.`,
+              : `${keeperName} 메시지를 대기열에 추가했습니다.`,
           delivery: 'queued',
           streamState: null,
           details: {

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -1,7 +1,7 @@
 (** Durable per-Keeper chat receipt queue. *)
 
 type message_source =
-  | Dashboard of { thread_id : string }
+  | Dashboard of { thread_id : string; actor : string }
   | Discord of { channel_id : string; user_id : string }
   | Slack of {
       channel_id : string;
@@ -609,7 +609,7 @@ let registry_mutex = Eio.Mutex.create ()
 let registry : (string, queue_entry) Hashtbl.t = Hashtbl.create 16
 
 let continuation_channel_of_message_source = function
-  | Dashboard { thread_id } ->
+  | Dashboard { thread_id; actor = _ } ->
     (match Keeper_continuation_channel.dashboard ~thread_id with
      | Ok channel -> channel
      | Error message -> invalid_arg message)
@@ -662,8 +662,12 @@ let snapshot_path ~base_path ~keeper_name =
 let load_error kind ?path message = { kind; path; message }
 
 let source_to_yojson = function
-  | Dashboard { thread_id } ->
-    `Assoc [ "kind", `String "dashboard"; "thread_id", `String thread_id ]
+  | Dashboard { thread_id; actor } ->
+    `Assoc
+      [ "kind", `String "dashboard"
+      ; "thread_id", `String thread_id
+      ; "actor", `String actor
+      ]
   | Discord { channel_id; user_id } ->
     `Assoc
       [ "kind", `String "discord"
@@ -729,11 +733,15 @@ let source_of_yojson json =
   match required_string json "kind" with
   | Error _ as error -> error
   | Ok "dashboard" ->
-    (match required_string json "thread_id" with
-     | Ok thread_id when not (String.equal (String.trim thread_id) "") ->
-       Ok (Dashboard { thread_id })
-     | Ok _ -> Error "dashboard chat queue source requires a non-empty thread_id"
-     | Error _ as error -> error)
+    (match required_string json "thread_id", required_string json "actor" with
+     | Ok thread_id, Ok actor
+       when not (String.equal (String.trim thread_id) "")
+            && not (String.equal (String.trim actor) "") ->
+       Ok (Dashboard { thread_id; actor })
+     | Ok _, Ok _ ->
+       Error
+         "dashboard chat queue source requires non-empty thread_id and actor"
+     | Error error, _ | _, Error error -> Error error)
   | Ok "discord" ->
     (match required_string json "channel_id", required_string json "user_id" with
      | Ok channel_id, Ok user_id
@@ -4364,6 +4372,8 @@ module For_testing = struct
   type nonrec commit_failure = commit_failure =
     | Commit_busy
     | Commit_io_error
+
+  let decode_message_source = source_of_yojson
 
   let reset () =
     Atomic.set transaction_failures_for_testing [];

--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -15,7 +15,9 @@
     @since 2.145.0 *)
 
 type message_source =
-  | Dashboard of { thread_id : string }
+  | Dashboard of { thread_id : string; actor : string }
+    (** [actor] is the authorized dashboard caller resolved at the HTTP auth
+        boundary. Both fields are required in the persisted source. *)
   | Discord of { channel_id : string; user_id : string }
   | Slack of {
       channel_id : string;
@@ -477,6 +479,9 @@ module For_testing : sig
     | Commit_io_error
 
   val reset : unit -> unit
+  val decode_message_source :
+    Yojson.Safe.t -> (message_source, string) result
+  (** Exposes the strict durable source decoder for contract tests. *)
   val fail_transaction_at_stages : transaction_stage list -> unit
   val fail_next_commit_with : commit_failure -> unit
   val set_transaction_stage_observer :

--- a/lib/keeper/keeper_chat_receipt_projection.ml
+++ b/lib/keeper/keeper_chat_receipt_projection.ml
@@ -1,8 +1,9 @@
 let message_source_json = function
-  | Keeper_chat_queue.Dashboard { thread_id } ->
+  | Keeper_chat_queue.Dashboard { thread_id; actor } ->
     `Assoc
       [ "kind", `String "dashboard"
       ; "thread_id", `String thread_id
+      ; "actor", `String actor
       ]
   | Keeper_chat_queue.Discord { channel_id; user_id } ->
     `Assoc

--- a/lib/keeper/keeper_multimodal_input.ml
+++ b/lib/keeper/keeper_multimodal_input.ml
@@ -23,42 +23,51 @@ let attachment_to_yojson (att : Keeper_chat_store.attachment) =
 let attachments_to_yojson attachments =
   `List (List.map attachment_to_yojson attachments)
 
+let attachment_string ?(required = false) json key =
+  match Json_util.assoc_member_opt key json with
+  | None | Some `Null ->
+    if required
+    then Error (Printf.sprintf "attachments entry requires %s" key)
+    else Ok ""
+  | Some (`String value) ->
+    let value = if String.equal key "data" then value else String.trim value in
+    if required && String.equal value ""
+    then Error (Printf.sprintf "attachments entry requires non-empty %s" key)
+    else Ok value
+  | Some _ -> Error (Printf.sprintf "attachments entry %s must be a string" key)
+
 let parse_attachment json =
   match json with
   | `Assoc _ ->
-      let id =
-        Json_util.get_string_with_default json ~key:"id" ~default:""
-        |> String.trim
-      in
-      let att_type =
-        Json_util.get_string_with_default json ~key:"type" ~default:""
-        |> String.trim
-      in
-      let name =
-        Json_util.get_string_with_default json ~key:"name" ~default:""
-        |> String.trim
-      in
-      let size =
+    let open Result.Syntax in
+    let* id = attachment_string ~required:true json "id" in
+    let* att_type = attachment_string json "type" in
+    let* name = attachment_string json "name" in
+    let* size =
         match Json_util.assoc_member_opt "size" json with
-        | Some (`Int n) when n >= 0 -> n
-        | _ -> 0
-      in
-      let mime_type =
-        Json_util.get_string_with_default json ~key:"mime_type" ~default:""
-        |> String.trim
-      in
-      let data =
-        Json_util.get_string_with_default json ~key:"data" ~default:""
-      in
-      if id = "" || data = "" then None
-      else
-        Some { Keeper_chat_store.id; att_type; name; size; mime_type; data }
-  | _ -> None
+        | None | Some `Null -> Ok 0
+        | Some (`Int n) when n >= 0 -> Ok n
+        | Some (`Int _) -> Error "attachments entry size must be non-negative"
+        | Some _ -> Error "attachments entry size must be an integer"
+    in
+    let* mime_type = attachment_string json "mime_type" in
+    let* data = attachment_string ~required:true json "data" in
+    Ok { Keeper_chat_store.id; att_type; name; size; mime_type; data }
+  | _ -> Error "attachments entries must be JSON objects"
 
 let parse_attachments json =
   match Json_util.assoc_member_opt "attachments" json with
-  | Some (`List attachments) -> List.filter_map parse_attachment attachments
-  | _ -> []
+  | None | Some `Null -> Ok []
+  | Some (`List attachments) ->
+    let rec loop parsed = function
+      | [] -> Ok (List.rev parsed)
+      | attachment :: rest ->
+        (match parse_attachment attachment with
+         | Ok attachment -> loop (attachment :: parsed) rest
+         | Error _ as error -> error)
+    in
+    loop [] attachments
+  | Some _ -> Error "attachments must be an array"
 
 let user_media_block_to_yojson kind (media : user_media_block) =
   let fields =

--- a/lib/keeper/keeper_multimodal_input.mli
+++ b/lib/keeper/keeper_multimodal_input.mli
@@ -21,10 +21,10 @@ val attachment_to_yojson : Keeper_chat_store.attachment -> Yojson.Safe.t
 
 val attachments_to_yojson : Keeper_chat_store.attachment list -> Yojson.Safe.t
 
-val parse_attachments : Yojson.Safe.t -> Keeper_chat_store.attachment list
-(** Parse optional [attachments] from a request/tool argument object.  Malformed
-    attachment entries are ignored, matching the historical chat stream
-    behavior; referenced-but-missing media is rejected later by {!to_oas_blocks}. *)
+val parse_attachments :
+  Yojson.Safe.t -> (Keeper_chat_store.attachment list, string) result
+(** Strictly parse optional [attachments] from a request/tool argument object.
+    Malformed entries fail the request instead of silently dropping user data. *)
 
 val user_blocks_to_yojson : user_input_block list -> Yojson.Safe.t
 

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -251,11 +251,13 @@ let user_oas_blocks_of_args args =
   | Error err -> Error err
   | Ok [] -> Ok None
   | Ok user_blocks ->
-      let attachments = Keeper_multimodal_input.parse_attachments args in
-      match Keeper_multimodal_input.to_oas_blocks ~attachments user_blocks with
-      | Error err -> Error err
-      | Ok [] -> Ok None
-      | Ok blocks -> Ok (Some blocks)
+    (match Keeper_multimodal_input.parse_attachments args with
+     | Error err -> Error err
+     | Ok attachments ->
+       match Keeper_multimodal_input.to_oas_blocks ~attachments user_blocks with
+       | Error err -> Error err
+       | Ok [] -> Ok None
+       | Ok blocks -> Ok (Some blocks))
 
 type invocation_surface =
   | Direct_message

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -165,13 +165,13 @@ let discord_channel_label = "discord"
 
 let queued_chat_projection (queued_message : Keeper_chat_queue.queued_message) =
   match queued_message.source with
-  | Keeper_chat_queue.Dashboard _ ->
+  | Keeper_chat_queue.Dashboard { thread_id = _; actor } ->
     {
       payload_channel = "";
       payload_channel_user_id = "";
       payload_channel_user_name = "";
       payload_channel_workspace_id = "";
-      agent_name = "dashboard";
+      agent_name = actor;
     }
   | Keeper_chat_queue.Discord { channel_id; user_id } ->
     {
@@ -209,12 +209,15 @@ let payload_of_queued_message ~keeper_name
   let projection = queued_chat_projection queued_message in
   { Server_routes_http_keeper_stream.name = keeper_name
   ; message = queued_message.content
-  ; turn_instructions = None
-  ; surface_context = None
-  ; channel = projection.payload_channel
-  ; channel_user_id = projection.payload_channel_user_id
-  ; channel_user_name = projection.payload_channel_user_name
-  ; channel_workspace_id = projection.payload_channel_workspace_id
+  ; admission =
+      Direct
+        { turn_instructions = None
+        ; surface_context = None
+        ; channel = projection.payload_channel
+        ; channel_user_id = projection.payload_channel_user_id
+        ; channel_user_name = projection.payload_channel_user_name
+        ; channel_workspace_id = projection.payload_channel_workspace_id
+        }
   ; user_blocks = queued_message.user_blocks
   ; attachments = queued_message.attachments
   }

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -31,16 +31,24 @@ type user_input_block = Keeper_multimodal_input.user_input_block =
   | User_document of user_media_block
   | User_audio of user_media_block
 
-type keeper_chat_stream_request = {
-  name : string;
-  message : string;
-  user_blocks : user_input_block list;
+type keeper_chat_direct_context = {
   turn_instructions : string option;
   surface_context : Yojson.Safe.t option;
   channel : string;
   channel_user_id : string;
   channel_user_name : string;
   channel_workspace_id : string;
+}
+
+type keeper_chat_admission =
+  | Direct of keeper_chat_direct_context
+  | Durable_enqueue of Keeper_chat_queue.Receipt_id.t
+
+type keeper_chat_stream_request = {
+  name : string;
+  message : string;
+  admission : keeper_chat_admission;
+  user_blocks : user_input_block list;
   attachments : Keeper_chat_store.attachment list;
 }
 
@@ -65,61 +73,86 @@ let format_surface_context ctx =
      string-returning boundary for [turn_instructions_for_request]. *)
   Option.value ~default:"" (surface_context_to_instructions ctx)
 
-let has_connector_context (payload : keeper_chat_stream_request) =
-  payload.channel <> "" && payload.channel_workspace_id <> ""
+let direct_context = function
+  | { admission = Direct context; _ } -> Some context
+  | { admission = Durable_enqueue _; _ } -> None
 
-let has_external_speaker (payload : keeper_chat_stream_request) =
-  has_connector_context payload && payload.channel_user_id <> ""
+let has_connector_context payload =
+  match direct_context payload with
+  | Some context ->
+    context.channel <> "" && context.channel_workspace_id <> ""
+  | None -> false
+
+let has_external_speaker payload =
+  match direct_context payload with
+  | Some context ->
+    context.channel <> ""
+    && context.channel_workspace_id <> ""
+    && context.channel_user_id <> ""
+  | None -> false
+
+let channel_of_request payload =
+  match direct_context payload with
+  | Some context when has_connector_context payload -> context.channel
+  | Some _ | None -> "dashboard"
 
 let gate_address_of_request payload =
   let field key value =
     let value = String.trim value in
     if value = "" then [] else [ (key, value) ]
   in
-  field "connector" payload.channel
-  @ field "workspace_id" payload.channel_workspace_id
+  match direct_context payload with
+  | None -> []
+  | Some context ->
+    field "connector" context.channel
+    @ field "workspace_id" context.channel_workspace_id
 
 let message_for_request payload =
-  if has_external_speaker payload then
+  match direct_context payload with
+  | Some context when has_external_speaker payload ->
     Gate_keeper_backend.contextualize_message
-      ~channel:payload.channel
-      ~channel_user_id:payload.channel_user_id
-      ~channel_user_name:payload.channel_user_name
-      ~channel_workspace_id:payload.channel_workspace_id
+      ~channel:context.channel
+      ~channel_user_id:context.channel_user_id
+      ~channel_user_name:context.channel_user_name
+      ~channel_workspace_id:context.channel_workspace_id
       ~metadata:[]
       ~content:payload.message
-  else
-    payload.message
+  | Some _ | None -> payload.message
 
 let chat_surface_of_request payload =
-  if has_connector_context payload then
+  match direct_context payload with
+  | Some context when has_connector_context payload ->
     Surface_ref.Gate
-      { label = payload.channel; address = gate_address_of_request payload }
-  else Surface_ref.Dashboard { session_id = None }
+      { label = context.channel; address = gate_address_of_request payload }
+  | Some _ | None -> Surface_ref.Dashboard { session_id = None }
 
 let chat_speaker_of_request payload =
-  if has_external_speaker payload then
-    { Keeper_chat_store.speaker_id = Some payload.channel_user_id;
+  match direct_context payload with
+  | Some context when has_external_speaker payload ->
+    { Keeper_chat_store.speaker_id = Some context.channel_user_id;
       speaker_name =
-        (let name = String.trim payload.channel_user_name in
+        (let name = String.trim context.channel_user_name in
          if name = "" then None else Some name);
       speaker_authority = Keeper_chat_store.External }
-  else
+  | Some _ | None ->
     { Keeper_chat_store.speaker_id = None;
       speaker_name = None;
       speaker_authority = Keeper_chat_store.Owner }
 
 let turn_instructions_for_request payload =
-  let ctx_text =
-    match payload.surface_context with
-    | Some ctx -> format_surface_context ctx
-    | None -> ""
-  in
-  match payload.turn_instructions with
-  | None -> if ctx_text = "" then None else Some ctx_text
-  | Some ti ->
-      if ctx_text = "" then Some ti
-      else Some (ti ^ "\n\n" ^ ctx_text)
+  match direct_context payload with
+  | None -> None
+  | Some context ->
+    let ctx_text =
+      match context.surface_context with
+      | Some ctx -> format_surface_context ctx
+      | None -> ""
+    in
+    (match context.turn_instructions with
+     | None -> if ctx_text = "" then None else Some ctx_text
+     | Some ti ->
+       if ctx_text = "" then Some ti
+       else Some (ti ^ "\n\n" ^ ctx_text))
 
 let args_of_request payload : Yojson.Safe.t =
   let message = message_for_request payload in
@@ -134,18 +167,21 @@ let args_of_request payload : Yojson.Safe.t =
      | _ -> [])
   in
   let connector_fields =
-    (if has_connector_context payload then
-       [ ("channel", `String payload.channel);
-         ("channel_workspace_id", `String payload.channel_workspace_id) ]
-     else [])
-    @
-    (if payload.channel_user_id <> "" then
-       [ ("channel_user_id", `String payload.channel_user_id) ]
-     else [])
-    @
-    (if payload.channel_user_name <> "" then
-       [ ("channel_user_name", `String payload.channel_user_name) ]
-     else [])
+    match direct_context payload with
+    | None -> []
+    | Some context ->
+      (if has_connector_context payload then
+         [ ("channel", `String context.channel);
+           ("channel_workspace_id", `String context.channel_workspace_id) ]
+       else [])
+      @
+      (if context.channel_user_id <> "" then
+         [ ("channel_user_id", `String context.channel_user_id) ]
+       else [])
+      @
+      (if context.channel_user_name <> "" then
+         [ ("channel_user_name", `String context.channel_user_name) ]
+       else [])
   in
   let fields = base_fields @ connector_fields in
   let fields =
@@ -217,7 +253,7 @@ let dashboard_deferred_ack_text ~keeper_name deferred =
         keeper_name
     | None ->
       Printf.sprintf
-        "%s가 다른 작업을 처리 중이에요. 메시지는 대기열에 추가했습니다."
+        "%s 메시지를 대기열에 추가했습니다."
         keeper_name
 
 let dashboard_deferred_chat_to_json ~keeper_name
@@ -261,21 +297,33 @@ let dashboard_deferred_chat_to_json ~keeper_name
 let enqueue_dashboard_payload
       ~clock
       ~thread_id
+      ~actor
       ~user_row_origin
       payload
       ~in_flight
       ~chat_waiting
       ~shutdown_operation_id
   =
-  match
-    Keeper_chat_queue.enqueue ~keeper_name:payload.name
-      { Keeper_chat_queue.content = payload.message
-      ; user_blocks = payload.user_blocks
-      ; attachments = payload.attachments
-      ; timestamp = Eio.Time.now clock
-      ; source = Keeper_chat_queue.Dashboard { thread_id }
-      ; user_row_origin
-      }
+  let message =
+    { Keeper_chat_queue.content = payload.message
+    ; user_blocks = payload.user_blocks
+    ; attachments = payload.attachments
+    ; timestamp = Eio.Time.now clock
+    ; source = Keeper_chat_queue.Dashboard { thread_id; actor }
+    ; user_row_origin
+    }
+  in
+  let enqueue =
+    match payload.admission with
+    | Direct _ ->
+      Keeper_chat_queue.enqueue ~keeper_name:payload.name message
+    | Durable_enqueue receipt_id ->
+      Keeper_chat_queue.enqueue_with_receipt
+        ~keeper_name:payload.name
+        ~receipt_id
+        message
+  in
+  match enqueue
   with
   | Error error -> Error (Keeper_chat_queue.mutation_error_to_string error)
   | Ok receipt ->
@@ -293,6 +341,7 @@ let enqueue_dashboard_payload
 let dashboard_deferred_chat_of_rejection
       ~clock
       ~thread_id
+      ~actor
       ~user_row_origin
       payload
      ({ Keeper_turn_admission.waiting
@@ -305,13 +354,14 @@ let dashboard_deferred_chat_of_rejection
   enqueue_dashboard_payload
     ~clock
     ~thread_id
+    ~actor
     ~user_row_origin
     payload
     ~in_flight
     ~chat_waiting:(waiting > 0)
     ~shutdown_operation_id
 
-let defer_dashboard_payload_if_busy ~base_path ~clock ~thread_id payload =
+let defer_dashboard_payload_if_busy ~base_path ~clock ~thread_id ~actor payload =
   match dashboard_busy_queue_state ~base_path ~keeper_name:payload.name with
   | None -> `Not_busy
   | Some (in_flight, chat_waiting, shutdown_operation_id) ->
@@ -319,6 +369,7 @@ let defer_dashboard_payload_if_busy ~base_path ~clock ~thread_id payload =
          enqueue_dashboard_payload
            ~clock
            ~thread_id
+           ~actor
            ~user_row_origin:Keeper_chat_store.Needs_append
            payload
            ~in_flight
@@ -327,6 +378,26 @@ let defer_dashboard_payload_if_busy ~base_path ~clock ~thread_id payload =
        with
        | Ok queued -> `Queued queued
        | Error message -> `Queue_error message)
+
+let enqueue_dashboard_payload_now ~base_path ~clock ~thread_id ~actor payload =
+  let admission =
+    Keeper_turn_admission.snapshot_for
+      ~base_path
+      ~keeper_name:payload.name
+  in
+  match
+    enqueue_dashboard_payload
+      ~clock
+      ~thread_id
+      ~actor
+      ~user_row_origin:Keeper_chat_store.Needs_append
+      payload
+      ~in_flight:admission.snapshot_in_flight
+      ~chat_waiting:(admission.snapshot_waiting > 0)
+      ~shutdown_operation_id:admission.snapshot_shutdown_operation_id
+  with
+  | Ok queued -> `Queued queued
+  | Error message -> `Queue_error message
 
 let keeper_chat_request_prefixes =
   [
@@ -535,6 +606,20 @@ let parse_keeper_chat_stream_request body_str =
     if not (match json with `Assoc _ -> true | _ -> false) then
       Error "request body must be a JSON object"
     else
+      let malformed_string_field =
+        [ "name"
+        ; "message"
+        ; "channel"
+        ; "channel_user_id"
+        ; "channel_user_name"
+        ; "channel_workspace_id"
+        ; "turn_instructions"
+        ]
+        |> List.find_opt (fun key ->
+          match Json_util.assoc_member_opt key json with
+          | None | Some `Null | Some (`String _) -> false
+          | Some _ -> true)
+      in
       let name = Json_util.get_string_with_default json ~key:"name" ~default:"" |> String.trim in
       let raw_message =
         Json_util.get_string_with_default json ~key:"message" ~default:""
@@ -565,17 +650,40 @@ let parse_keeper_chat_stream_request body_str =
             let s = String.trim s in
             if s = "" then None else Some s
       in
-      let surface_context : Yojson.Safe.t option =
-        match Json_util.assoc_member_opt "surface_context" json with
-        | Some (`Assoc _ as obj) -> Some obj
-        | Some `Null | None -> None
-        | Some _ -> None
+      let enqueue_only_result =
+        match Json_util.assoc_member_opt "enqueue_only" json with
+        | None | Some `Null -> Ok false
+        | Some (`Bool enqueue_only) -> Ok enqueue_only
+        | Some _ -> Error "enqueue_only must be a boolean"
       in
+      let receipt_id_result =
+        match Json_util.assoc_member_opt "receipt_id" json with
+        | None | Some `Null -> Ok None
+        | Some (`String receipt_id) ->
+          Keeper_chat_queue.Receipt_id.of_string (String.trim receipt_id)
+          |> Result.map Option.some
+        | Some _ -> Error "receipt_id must be a string"
+      in
+      let surface_context_result : (Yojson.Safe.t option, string) result =
+        match Json_util.assoc_member_opt "surface_context" json with
+        | Some (`Assoc _ as obj) -> Ok (Some obj)
+        | Some `Null | None -> Ok None
+        | Some _ -> Error "surface_context must be a JSON object"
+      in
+      let surface_context = Result.value ~default:None surface_context_result in
       let has_connector_context =
         channel <> "" || channel_user_id <> ""
         || channel_user_name <> "" || channel_workspace_id <> ""
       in
-      let attachments = Keeper_multimodal_input.parse_attachments json in
+      let has_nonqueue_context =
+        has_connector_context
+        || Option.is_some turn_instructions
+        || Option.is_some surface_context
+      in
+      let attachments_result =
+        Keeper_multimodal_input.parse_attachments json
+      in
+      let attachments = Result.value ~default:[] attachments_result in
       let user_blocks_result = Keeper_multimodal_input.parse_user_blocks json in
       let message_of_blocks user_blocks =
         match raw_message with
@@ -583,16 +691,11 @@ let parse_keeper_chat_stream_request body_str =
             Keeper_multimodal_input.fallback_message ~attachments user_blocks
         | message -> message
       in
-      if name = "" then
-        Error "name is required"
-      else if has_connector_context
-              && (channel = "" || channel_workspace_id = "")
-      then
-        Error
-          "channel and channel_workspace_id are required when connector context is supplied"
-      else
+      let parse_admitted admission =
         match
-          Keeper_meta_contract.reject_removed_model_args ~tool_name:"masc_keeper_msg" json
+          Keeper_meta_contract.reject_removed_model_args
+            ~tool_name:"masc_keeper_msg"
+            json
         with
         | Error err -> Error err
         | Ok () -> (
@@ -610,20 +713,59 @@ let parse_keeper_chat_stream_request body_str =
               if message = "" then
                 Error "message is required"
               else
-              Ok
-                {
-                  name;
-                  message;
-                  user_blocks;
-                  turn_instructions;
-                  surface_context;
-                  channel;
-                  channel_user_id;
-                  channel_user_name;
-                  channel_workspace_id;
-                  attachments;
-                }
+                Ok
+                  {
+                    name;
+                    message;
+                    admission;
+                    user_blocks;
+                    attachments;
+                  }
           ))
+      in
+      if name = "" then
+        Error "name is required"
+      else if Option.is_some malformed_string_field then
+        Error
+          (Printf.sprintf
+             "%s must be a string"
+             (Option.get malformed_string_field))
+      else if has_connector_context
+              && (channel = "" || channel_workspace_id = "")
+      then
+        Error
+          "channel and channel_workspace_id are required when connector context is supplied"
+      else
+        match
+          surface_context_result,
+          attachments_result,
+          enqueue_only_result,
+          receipt_id_result
+        with
+        | Error err, _, _, _
+        | _, Error err, _, _
+        | _, _, Error err, _
+        | _, _, _, Error err ->
+          Error err
+        | Ok _, Ok _, Ok false, Ok (Some _) ->
+          Error "receipt_id requires enqueue_only=true"
+        | Ok _, Ok _, Ok true, Ok None ->
+          Error "enqueue_only=true requires receipt_id"
+        | Ok _, Ok _, Ok true, Ok (Some _) when has_nonqueue_context ->
+          Error
+            "enqueue_only does not support connector, turn-instruction, or surface context"
+        | Ok _, Ok _, Ok false, Ok None ->
+          parse_admitted
+            (Direct
+               { turn_instructions
+               ; surface_context
+               ; channel
+               ; channel_user_id
+               ; channel_user_name
+               ; channel_workspace_id
+               })
+        | Ok _, Ok _, Ok true, Ok (Some receipt_id) ->
+          parse_admitted (Durable_enqueue receipt_id)
   with Yojson.Json_error e ->
     Error ("invalid json: " ^ e)
 
@@ -2002,6 +2144,7 @@ let process_single_turn ~user_row_origin ~submission
                         dashboard_deferred_chat_of_rejection
                           ~clock
                           ~thread_id
+                          ~actor:submitted_by
                           ~user_row_origin
                           payload
                           rejection
@@ -2606,7 +2749,7 @@ let process_single_turn ~user_row_origin ~submission
        Log.Keeper.info
          "keeper_stream: queued request keeper=%s request_id=%s surface=%s"
          payload.name request_id
-         (if has_connector_context payload then payload.channel else "dashboard");
+         (channel_of_request payload);
        Keeper_chat_events.publish events
          (Custom
             { name = "KEEPER_QUEUE_REQUEST"
@@ -2615,9 +2758,7 @@ let process_single_turn ~user_row_origin ~submission
                   { request_id
                   ; destination_type = "keeper"
                   ; destination_id = payload.name
-                  ; channel =
-                      (if has_connector_context payload then payload.channel
-                       else "dashboard")
+                  ; channel = channel_of_request payload
                   ; actor_id = Some agent_name
                   ; status = Gate_protocol.Queued
                   ; modalities = modalities_for_request payload
@@ -3171,12 +3312,13 @@ let handle_keeper_chat_stream ~sw ~clock ~submitted_by state request reqd payloa
            Eio.Switch.on_release stream_sw close_stream;
            let has_external_actor = has_external_speaker payload in
            let agent_name =
-             if has_external_actor then
+             match direct_context payload with
+             | Some context when has_external_actor ->
                Gate_keeper_backend.agent_name_for_channel_actor
-                 ~channel:payload.channel
-                 ~channel_workspace_id:payload.channel_workspace_id
-                 ~channel_user_id:payload.channel_user_id
-             else submitted_by
+                 ~channel:context.channel
+                 ~channel_workspace_id:context.channel_workspace_id
+                 ~channel_user_id:context.channel_user_id
+             | Some _ | None -> submitted_by
            in
            let run_id = Printf.sprintf "keeper-run-%d" (now_id ()) in
            let message_id = Printf.sprintf "keeper-msg-%d" (now_id ()) in
@@ -3209,44 +3351,64 @@ let handle_keeper_chat_stream ~sw ~clock ~submitted_by state request reqd payloa
                 : queued_turn_outcome option);
              wait_for_adapter_finished ()
            in
+           let publish_queued queued =
+             let durable_enqueue =
+               match payload.admission with
+               | Direct _ -> false
+               | Durable_enqueue _ -> true
+             in
+             Log.Keeper.info
+               "keeper_stream: queued dashboard message keeper=%s pending_count=%d inflight_count=%d enqueue_only=%b"
+               payload.name
+               queued.pending_count
+               queued.inflight_count
+               durable_enqueue;
+             Keeper_chat_events.publish events
+               (Run_started { run_id; thread_id });
+             Keeper_chat_events.publish events
+               (Text_message_start
+                  { message_id; role = Keeper_chat_events.Assistant });
+             Keeper_chat_events.publish events
+               (Text_delta
+                  (dashboard_deferred_ack_text
+                     ~keeper_name:payload.name
+                     queued));
+             Keeper_chat_events.publish events
+               (Custom
+                  { name = "KEEPER_CHAT_QUEUED";
+                    value =
+                      dashboard_deferred_chat_to_json
+                        ~keeper_name:payload.name queued
+             });
+             Keeper_chat_events.publish events Text_message_end;
+             Keeper_chat_events.publish events (Run_finished { run_id });
+             wait_for_adapter_finished ()
+           in
            if has_external_speaker payload then run_now ()
            else
              match
                try
-                 defer_dashboard_payload_if_busy
-                   ~base_path
-                   ~clock
-                   ~thread_id
-                   payload
+                 match payload.admission with
+                 | Durable_enqueue _ ->
+                   enqueue_dashboard_payload_now
+                     ~base_path
+                     ~clock
+                     ~thread_id
+                     ~actor:submitted_by
+                     payload
+                 | Direct _ ->
+                   defer_dashboard_payload_if_busy
+                     ~base_path
+                     ~clock
+                     ~thread_id
+                     ~actor:submitted_by
+                     payload
                with
                | Eio.Cancel.Cancelled _ as exn -> raise exn
                | exn -> `Queue_error (Printexc.to_string exn)
              with
              | `Not_busy -> run_now ()
-             | `Queued queued ->
-                 Log.Keeper.info
-                   "keeper_stream: deferred busy dashboard message keeper=%s pending_count=%d inflight_count=%d"
-                   payload.name queued.pending_count queued.inflight_count;
-                 Keeper_chat_events.publish events
-                   (Run_started { run_id; thread_id });
-                 Keeper_chat_events.publish events
-                   (Text_message_start
-                      { message_id; role = Keeper_chat_events.Assistant });
-                 Keeper_chat_events.publish events
-                   (Text_delta
-                      (dashboard_deferred_ack_text
-                         ~keeper_name:payload.name
-                         queued));
-                 Keeper_chat_events.publish events
-                   (Custom
-                      { name = "KEEPER_CHAT_QUEUED";
-                        value =
-                          dashboard_deferred_chat_to_json
-                            ~keeper_name:payload.name queued
-                 });
-                 Keeper_chat_events.publish events Text_message_end;
-                 Keeper_chat_events.publish events (Run_finished { run_id });
-                 wait_for_adapter_finished ()
+             | `Queued queued -> publish_queued queued
              | `Queue_error message ->
                  Log.Keeper.error
                    "keeper_stream: failed to defer busy dashboard message keeper=%s: %s"
@@ -3279,10 +3441,11 @@ module For_testing = struct
         ~base_path
         ~clock
         ~thread_id
+        ~actor
         payload
     =
     match
-      defer_dashboard_payload_if_busy ~base_path ~clock ~thread_id payload
+      defer_dashboard_payload_if_busy ~base_path ~clock ~thread_id ~actor payload
     with
     | `Not_busy -> `Not_busy
     | `Queued queued ->
@@ -3291,11 +3454,18 @@ module For_testing = struct
           , dashboard_deferred_ack_text ~keeper_name:payload.name queued )
     | `Queue_error message -> `Queue_error message
 
-  let defer_dashboard_payload_if_busy ~base_path ~clock ~thread_id payload =
+  let defer_dashboard_payload_if_busy ~base_path ~clock ~thread_id ~actor payload =
     match
-      defer_dashboard_payload_if_busy ~base_path ~clock ~thread_id payload
+      defer_dashboard_payload_if_busy ~base_path ~clock ~thread_id ~actor payload
     with
     | `Not_busy -> `Not_busy
+    | `Queued queued -> `Queued queued.pending_count
+    | `Queue_error message -> `Queue_error message
+
+  let enqueue_dashboard_payload_now ~base_path ~clock ~thread_id ~actor payload =
+    match
+      enqueue_dashboard_payload_now ~base_path ~clock ~thread_id ~actor payload
+    with
     | `Queued queued -> `Queued queued.pending_count
     | `Queue_error message -> `Queue_error message
 

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -70,29 +70,38 @@ type user_input_block = Keeper_multimodal_input.user_input_block =
     MASC request-boundary type, intentionally distinct from dashboard
     rich-render [ChatBlock] values and from OAS provider blocks. *)
 
-type keeper_chat_stream_request = {
-  name : string;
-  message : string;
-  user_blocks : user_input_block list;
+type keeper_chat_direct_context = {
   turn_instructions : string option;
   surface_context : Yojson.Safe.t option;
   channel : string;
   channel_user_id : string;
   channel_user_name : string;
   channel_workspace_id : string;
+}
+
+type keeper_chat_admission =
+  | Direct of keeper_chat_direct_context
+  | Durable_enqueue of Keeper_chat_queue.Receipt_id.t
+(** Dashboard admission mode. [Durable_enqueue] carries its required
+    idempotency identity, so enqueue-only requests without a receipt and
+    direct requests with a receipt are not representable after parsing. *)
+
+type keeper_chat_stream_request = {
+  name : string;
+  message : string;
+  admission : keeper_chat_admission;
+  user_blocks : user_input_block list;
   attachments : Keeper_chat_store.attachment list;
 }
 (** Parsed payload of a keeper chat-stream HTTP request.
     [message] is the text fallback used by the existing direct keeper
-    path; [user_blocks] preserves semantic text/media input for the
-    block-aware runtime path. [turn_instructions] and [surface_context]
-    are optional copilot context fields; when
-    [turn_instructions] is absent but [surface_context]
-    is present, the surface context is formatted and
-    injected as turn instructions.  [channel] and
-    [channel_workspace_id] are required together when any
-    connector context is supplied; [channel_user_id] and
-    [channel_user_name] are optional. *)
+    path; [admission] keeps direct dispatch distinct from durable admission
+    with its required producer-allocated idempotency identity; [user_blocks]
+    preserves semantic text/media input for the block-aware runtime path.
+    [Direct] owns the optional copilot and connector context, so durable
+    enqueue cannot silently discard those fields. Within direct context,
+    [channel] and [channel_workspace_id] are required together when any
+    connector context is supplied. *)
 
 (** {1 Parsing} *)
 
@@ -101,7 +110,7 @@ val parse_keeper_chat_stream_request :
 (** Parses the HTTP body string into a
     {!keeper_chat_stream_request}.  Returns
     [Error reason] on JSON shape mismatches, missing
-    [name] / content, malformed [user_blocks], partial connector context, or a
+    [name] / content, malformed [receipt_id] / [user_blocks], partial connector context, or a
     removed Keeper argument (including the retired request-level
     [timeout_sec]). *)
 
@@ -287,17 +296,26 @@ module For_testing : sig
     base_path:string ->
     clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
     thread_id:string ->
+    actor:string ->
     keeper_chat_stream_request ->
     [ `Not_busy | `Queued of int | `Queue_error of string ]
   val defer_dashboard_payload_if_busy_evidence :
     base_path:string ->
     clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
     thread_id:string ->
+    actor:string ->
     keeper_chat_stream_request ->
     [ `Not_busy
     | `Queued of Yojson.Safe.t * string
     | `Queue_error of string
     ]
+  val enqueue_dashboard_payload_now :
+    base_path:string ->
+    clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+    thread_id:string ->
+    actor:string ->
+    keeper_chat_stream_request ->
+    [ `Queued of int | `Queue_error of string ]
   val canonical_reply_payload_of_body :
     redact_text:(string -> string) ->
     string ->

--- a/test/test_copilot_dock_channel_wiring.ml
+++ b/test/test_copilot_dock_channel_wiring.ml
@@ -26,6 +26,11 @@ let parse_ok body =
   | Ok payload -> payload
   | Error err -> fail ("expected parse to succeed: " ^ err)
 
+let direct_context payload =
+  match payload.Stream.admission with
+  | Direct context -> context
+  | Durable_enqueue _ -> fail "expected direct admission"
+
 let args_assoc args =
   match args with
   | `Assoc fields -> fields
@@ -50,15 +55,38 @@ let test_copilot_parse_accepts_operator_workspace () =
     {|{"name":"luna","message":"hello","channel":"copilot","channel_workspace_id":"session-7","turn_instructions":"focus on overview"}|}
   in
   let payload = parse_ok body in
-  check string "channel" "copilot" payload.channel;
-  check string "workspace id" "session-7" payload.channel_workspace_id;
-  check string "user id optional" "" payload.channel_user_id;
+  let context = direct_context payload in
+  check string "channel" "copilot" context.channel;
+  check string "workspace id" "session-7" context.channel_workspace_id;
+  check string "user id optional" "" context.channel_user_id;
   check (option string) "turn instructions" (Some "focus on overview")
-    payload.turn_instructions;
+    context.turn_instructions;
   check bool "connector context" true
     (Stream.For_testing.has_connector_context payload);
   check bool "external speaker" false
     (Stream.For_testing.has_external_speaker payload)
+
+let test_dashboard_enqueue_only_is_typed () =
+  (match
+     Stream.For_testing.parse_request
+       {|{"name":"luna","message":"hello","enqueue_only":true}|}
+   with
+   | Error error ->
+     check string
+       "enqueue-only requires receipt identity"
+       "enqueue_only=true requires receipt_id"
+       error
+   | Ok _ -> fail "enqueue_only without receipt_id must be rejected");
+  match
+    Stream.For_testing.parse_request
+      {|{"name":"luna","message":"hello","enqueue_only":"true"}|}
+  with
+  | Error error ->
+    check string
+      "invalid enqueue_only is rejected"
+      "enqueue_only must be a boolean"
+      error
+  | Ok _ -> fail "string enqueue_only must not be coerced"
 
 let test_copilot_surface_is_gate_label () =
   let payload =
@@ -179,6 +207,8 @@ let () =
         [
           test_case "copilot context parses without user id" `Quick
             test_copilot_parse_accepts_operator_workspace;
+          test_case "dashboard enqueue-only flag is typed" `Quick
+            test_dashboard_enqueue_only_is_typed;
         ] );
       ( "surface",
         [

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -4,6 +4,25 @@ open Masc
 module K = Keeper_chat_store
 module KT = Keeper_turn
 
+let direct ?turn_instructions ?surface_context ?(channel = "")
+    ?(channel_user_id = "") ?(channel_user_name = "")
+    ?(channel_workspace_id = "") () =
+  Server_routes_http_keeper_stream.Direct
+    { turn_instructions
+    ; surface_context
+    ; channel
+    ; channel_user_id
+    ; channel_user_name
+    ; channel_workspace_id
+    }
+;;
+
+let direct_context payload =
+  match payload.Server_routes_http_keeper_stream.admission with
+  | Direct context -> context
+  | Durable_enqueue _ -> fail "expected direct admission"
+;;
+
 let rec remove_tree path =
   if Sys.file_exists path then
     if Sys.is_directory path then begin
@@ -267,11 +286,122 @@ let test_parse_keeper_chat_stream_request_accepts_connector_context () =
   in
   match Server_routes_http_keeper_stream.parse_keeper_chat_stream_request body with
   | Ok payload ->
-      check string "channel" "discord" payload.channel;
-      check string "user id" "user-42" payload.channel_user_id;
-      check string "user name" "Alice" payload.channel_user_name;
-      check string "workspace id" "workspace-9" payload.channel_workspace_id
+      let context = direct_context payload in
+      check string "channel" "discord" context.channel;
+      check string "user id" "user-42" context.channel_user_id;
+      check string "user name" "Alice" context.channel_user_name;
+      check string "workspace id" "workspace-9" context.channel_workspace_id
   | Error err -> fail ("expected connector context to parse: " ^ err)
+
+let test_parse_keeper_chat_stream_request_accepts_enqueue_receipt () =
+  let body =
+    {|{"name":"luna","message":"hello","enqueue_only":true,"receipt_id":"chatq_00000000-0000-4000-8000-000000000042"}|}
+  in
+  match Server_routes_http_keeper_stream.parse_keeper_chat_stream_request body with
+  | Error err -> fail ("expected enqueue receipt to parse: " ^ err)
+  | Ok payload ->
+    (match payload.admission with
+     | Direct _ -> fail "expected durable enqueue admission"
+     | Durable_enqueue receipt_id ->
+       check string
+         "producer receipt preserved"
+         "chatq_00000000-0000-4000-8000-000000000042"
+         (Keeper_chat_queue.Receipt_id.to_string receipt_id))
+;;
+
+let test_parse_keeper_chat_stream_request_rejects_enqueue_without_receipt () =
+  let body =
+    {|{"name":"luna","message":"hello","enqueue_only":true}|}
+  in
+  match Server_routes_http_keeper_stream.parse_keeper_chat_stream_request body with
+  | Ok _ -> fail "expected enqueue_only without receipt_id to be rejected"
+  | Error err ->
+    check string
+      "durable enqueue requires its idempotency identity"
+      "enqueue_only=true requires receipt_id"
+      err
+;;
+
+let test_parse_keeper_chat_stream_request_rejects_receipt_without_enqueue () =
+  let body =
+    {|{"name":"luna","message":"hello","receipt_id":"chatq_00000000-0000-4000-8000-000000000042"}|}
+  in
+  match Server_routes_http_keeper_stream.parse_keeper_chat_stream_request body with
+  | Ok _ -> fail "expected receipt_id without enqueue_only to be rejected"
+  | Error err ->
+    check string
+      "receipt is scoped to durable enqueue"
+      "receipt_id requires enqueue_only=true"
+      err
+;;
+
+let test_parse_keeper_chat_stream_request_rejects_receipt_for_external_speaker () =
+  let body =
+    {|{"name":"luna","message":"hello","enqueue_only":true,"receipt_id":"chatq_00000000-0000-4000-8000-000000000042","channel":"discord","channel_user_id":"user-42","channel_workspace_id":"workspace-9"}|}
+  in
+  match Server_routes_http_keeper_stream.parse_keeper_chat_stream_request body with
+  | Ok _ -> fail "expected external speaker receipt_id to be rejected"
+  | Error err ->
+    check string
+      "receipt cannot be ignored by the connector direct path"
+      "enqueue_only does not support connector, turn-instruction, or surface context"
+      err
+;;
+
+let test_parse_keeper_chat_stream_request_rejects_copilot_enqueue_context () =
+  let body =
+    {|{"name":"luna","message":"hello","enqueue_only":true,"receipt_id":"chatq_00000000-0000-4000-8000-000000000042","channel":"copilot","channel_workspace_id":"session-7"}|}
+  in
+  match Server_routes_http_keeper_stream.parse_keeper_chat_stream_request body with
+  | Ok _ -> fail "expected copilot context on durable enqueue to be rejected"
+  | Error err ->
+    check string
+      "queue cannot silently discard copilot context"
+      "enqueue_only does not support connector, turn-instruction, or surface context"
+      err
+;;
+
+let test_parse_keeper_chat_stream_request_rejects_malformed_enqueue_context () =
+  let body =
+    {|{"name":"luna","message":"hello","enqueue_only":true,"receipt_id":"chatq_00000000-0000-4000-8000-000000000042","surface_context":42}|}
+  in
+  match Server_routes_http_keeper_stream.parse_keeper_chat_stream_request body with
+  | Ok _ -> fail "expected malformed durable context to be rejected"
+  | Error err ->
+    check string
+      "malformed context cannot be collapsed to absence"
+      "surface_context must be a JSON object"
+      err
+;;
+
+let test_parse_keeper_chat_stream_request_rejects_malformed_attachment () =
+  let body =
+    {|{"name":"luna","message":"hello","enqueue_only":true,"receipt_id":"chatq_00000000-0000-4000-8000-000000000042","attachments":[{"id":"att-1","data":42}]}|}
+  in
+  match Server_routes_http_keeper_stream.parse_keeper_chat_stream_request body with
+  | Ok _ -> fail "expected malformed durable attachment to be rejected"
+  | Error err ->
+    check string
+      "malformed attachment is not silently dropped"
+      "attachments entry data must be a string"
+      err
+;;
+
+let test_dashboard_queue_source_requires_actor () =
+  let source =
+    `Assoc
+      [ "kind", `String "dashboard"
+      ; "thread_id", `String "thread-1"
+      ]
+  in
+  match Keeper_chat_queue.For_testing.decode_message_source source with
+  | Ok _ -> fail "expected dashboard source without actor to be rejected"
+  | Error err ->
+    check bool
+      "missing actor is a hard decode failure"
+      true
+      (String.length err > 0)
+;;
 
 let test_parse_keeper_chat_stream_request_rejects_removed_timeout () =
   let body = {|{"name":"luna","message":"hello","timeout_sec":1200.5}|} in
@@ -303,11 +433,18 @@ let test_parse_keeper_chat_stream_request_accepts_copilot_context () =
   in
   match Server_routes_http_keeper_stream.parse_keeper_chat_stream_request body with
   | Ok payload ->
-      check string "channel" "copilot" payload.channel;
-      check string "workspace id" "session-7" payload.channel_workspace_id;
-      check string "user id optional" "" payload.channel_user_id;
-      check (option string) "turn instructions" (Some "focus on overview") payload.turn_instructions;
-      check bool "surface context absent" true (Option.is_none payload.surface_context)
+      let context = direct_context payload in
+      check string "channel" "copilot" context.channel;
+      check string "workspace id" "session-7" context.channel_workspace_id;
+      check string "user id optional" "" context.channel_user_id;
+      check (option string)
+        "turn instructions"
+        (Some "focus on overview")
+        context.turn_instructions;
+      check bool
+        "surface context absent"
+        true
+        (Option.is_none context.surface_context)
   | Error err -> fail ("expected copilot context to parse: " ^ err)
 
 let test_parse_keeper_chat_stream_request_formats_surface_context () =
@@ -316,9 +453,13 @@ let test_parse_keeper_chat_stream_request_formats_surface_context () =
   in
   match Server_routes_http_keeper_stream.parse_keeper_chat_stream_request body with
   | Ok payload ->
-      check string "channel" "copilot" payload.channel;
-      check (option string) "turn instructions" None payload.turn_instructions;
-      check bool "surface context present" true (Option.is_some payload.surface_context)
+      let context = direct_context payload in
+      check string "channel" "copilot" context.channel;
+      check (option string) "turn instructions" None context.turn_instructions;
+      check bool
+        "surface context present"
+        true
+        (Option.is_some context.surface_context)
   | Error err -> fail ("expected surface context to parse: " ^ err)
 
 let test_parse_keeper_chat_stream_request_accepts_attachment_only_user_blocks () =
@@ -639,17 +780,12 @@ let test_keeper_stream_args_preserve_user_blocks () =
   let payload =
     { Server_routes_http_keeper_stream.name = "luna";
       message = "describe this";
+      admission = direct ();
       user_blocks =
         [
           Keeper_multimodal_input.User_text "describe this";
           Keeper_multimodal_input.User_image media;
         ];
-      turn_instructions = None;
-      surface_context = None;
-      channel = "";
-      channel_user_id = "";
-      channel_user_name = "";
-      channel_workspace_id = "";
       attachments =
         [
           {
@@ -2518,13 +2654,9 @@ let test_chat_surface_of_request_labels_copilot_gate () =
   let payload =
     { Server_routes_http_keeper_stream.name = "luna";
       message = "hello";
-      turn_instructions = None;
-      surface_context = None;
+      admission =
+        direct ~channel:"copilot" ~channel_workspace_id:"session-7" ();
       user_blocks = [];
-      channel = "copilot";
-      channel_user_id = "";
-      channel_user_name = "";
-      channel_workspace_id = "session-7";
       attachments = [] }
   in
   let surface = Server_routes_http_keeper_stream.For_testing.chat_surface_of_request payload in
@@ -2541,13 +2673,9 @@ let test_chat_speaker_of_request_copilot_is_owner () =
   let payload =
     { Server_routes_http_keeper_stream.name = "luna";
       message = "hello";
-      turn_instructions = None;
-      surface_context = None;
+      admission =
+        direct ~channel:"copilot" ~channel_workspace_id:"session-7" ();
       user_blocks = [];
-      channel = "copilot";
-      channel_user_id = "";
-      channel_user_name = "";
-      channel_workspace_id = "session-7";
       attachments = [] }
   in
   let speaker = Server_routes_http_keeper_stream.For_testing.chat_speaker_of_request payload in
@@ -2560,13 +2688,14 @@ let test_chat_speaker_of_request_connector_is_external () =
   let payload =
     { Server_routes_http_keeper_stream.name = "luna";
       message = "hello";
-      turn_instructions = None;
-      surface_context = None;
+      admission =
+        direct
+          ~channel:"discord"
+          ~channel_user_id:"user-42"
+          ~channel_user_name:"Alice"
+          ~channel_workspace_id:"workspace-9"
+          ();
       user_blocks = [];
-      channel = "discord";
-      channel_user_id = "user-42";
-      channel_user_name = "Alice";
-      channel_workspace_id = "workspace-9";
       attachments = [] }
   in
   let speaker = Server_routes_http_keeper_stream.For_testing.chat_speaker_of_request payload in
@@ -2833,6 +2962,22 @@ let () =
             test_contextualize_message_includes_channel_metadata;
           test_case "stream request accepts connector context" `Quick
             test_parse_keeper_chat_stream_request_accepts_connector_context;
+          test_case "stream request accepts enqueue receipt" `Quick
+            test_parse_keeper_chat_stream_request_accepts_enqueue_receipt;
+          test_case "stream request rejects enqueue without receipt" `Quick
+            test_parse_keeper_chat_stream_request_rejects_enqueue_without_receipt;
+          test_case "stream request rejects receipt without enqueue" `Quick
+            test_parse_keeper_chat_stream_request_rejects_receipt_without_enqueue;
+          test_case "stream request rejects external speaker receipt" `Quick
+            test_parse_keeper_chat_stream_request_rejects_receipt_for_external_speaker;
+          test_case "stream request rejects copilot enqueue context" `Quick
+            test_parse_keeper_chat_stream_request_rejects_copilot_enqueue_context;
+          test_case "stream request rejects malformed enqueue context" `Quick
+            test_parse_keeper_chat_stream_request_rejects_malformed_enqueue_context;
+          test_case "stream request rejects malformed attachment" `Quick
+            test_parse_keeper_chat_stream_request_rejects_malformed_attachment;
+          test_case "dashboard queue source requires actor" `Quick
+            test_dashboard_queue_source_requires_actor;
           test_case "stream request rejects removed request timeout" `Quick
             test_parse_keeper_chat_stream_request_rejects_removed_timeout;
           test_case "stream request rejects partial connector context" `Quick

--- a/test/test_keeper_busy_dashboard_deferred.ml
+++ b/test/test_keeper_busy_dashboard_deferred.ml
@@ -24,13 +24,16 @@ let payload ?(name = keeper_name) ?(content = "are you there?") ()
     : Server_routes_http_keeper_stream.keeper_chat_stream_request =
   { name
   ; message = content
+  ; admission =
+      Direct
+        { turn_instructions = None
+        ; surface_context = None
+        ; channel = ""
+        ; channel_user_id = ""
+        ; channel_user_name = ""
+        ; channel_workspace_id = ""
+        }
   ; user_blocks = []
-  ; turn_instructions = None
-  ; surface_context = None
-  ; channel = ""
-  ; channel_user_id = ""
-  ; channel_user_name = ""
-  ; channel_workspace_id = ""
   ; attachments = []
   }
 ;;
@@ -129,7 +132,8 @@ let test_busy_dashboard_enqueues () =
        ~base_path:base
        ~clock
        ~thread_id
-       (payload ())
+       ~actor:"dashboard"
+(payload ())
    with
    | `Queued len -> check "queue length is reported" (len = 1)
    | `Not_busy | `Queue_error _ -> check "busy keeper was deferred" false);
@@ -140,7 +144,10 @@ let test_busy_dashboard_enqueues () =
   check "dashboard queue revision advances" (snapshot.revision = 1L);
   (match snapshot.pending with
    | [ { Keeper_chat_queue.message =
-           { Keeper_chat_queue.content; source = Dashboard { thread_id = queued_thread_id }; _ }
+           { Keeper_chat_queue.content
+           ; source = Dashboard { thread_id = queued_thread_id; actor = _ }
+           ; _
+           }
        ; _
        } ] ->
      check "queued content is the user's message" (String.equal content "are you there?")
@@ -157,12 +164,114 @@ let test_free_dashboard_not_enqueued () =
        ~base_path:base
        ~clock
        ~thread_id
-       (payload ~content:"run now" ())
+       ~actor:"dashboard"
+(payload ~content:"run now" ())
    with
    | `Not_busy -> check "free keeper stays on direct stream path" true
    | `Queued _ | `Queue_error _ -> check "free keeper must not enqueue" false);
   let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
   check "queue remains empty" (snapshot.pending = [] && snapshot.inflight = [])
+;;
+
+let test_enqueue_only_dashboard_is_durable_while_free () =
+  Printf.printf
+    "Test: enqueue-only dashboard dispatch persists without waiting for a turn\n%!";
+  with_env
+  @@ fun ~base ~clock ->
+  let receipt_id = Keeper_chat_queue.Receipt_id.generate () in
+  let queued_payload =
+    { (payload ~content:"queue now" ()) with
+      admission = Durable_enqueue receipt_id
+    }
+  in
+  (match
+     Server_routes_http_keeper_stream.For_testing.enqueue_dashboard_payload_now
+       ~base_path:base
+       ~clock
+       ~thread_id
+       ~actor:"dashboard"
+queued_payload
+   with
+   | `Queued len ->
+     check "free keeper accepts enqueue-only receipt" (len = 1)
+   | `Queue_error _ ->
+     check "enqueue-only persistence succeeds" false);
+  let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
+  check "enqueue-only message remains Pending for the consumer"
+    (List.map
+       (fun (receipt : Keeper_chat_queue.active_receipt) ->
+          receipt.message.content)
+       snapshot.pending
+     = [ "queue now" ])
+;;
+
+let test_enqueue_only_retry_reuses_producer_receipt () =
+  Printf.printf
+    "Test: enqueue-only retry converges on the producer receipt\n%!";
+  with_env
+  @@ fun ~base ~clock ->
+  let receipt_id =
+    Keeper_chat_queue.Receipt_id.of_string
+      "chatq_00000000-0000-4000-8000-000000000042"
+    |> Result.get_ok
+  in
+  let queued_payload =
+    { (payload ~content:"queue once" ()) with
+      admission = Durable_enqueue receipt_id
+    }
+  in
+  let enqueue () =
+    Server_routes_http_keeper_stream.For_testing.enqueue_dashboard_payload_now
+      ~base_path:base
+      ~clock
+      ~thread_id
+      ~actor:"dashboard"
+queued_payload
+  in
+  (match enqueue (), enqueue () with
+   | `Queued first_count, `Queued repeated_count ->
+     check "first enqueue has one pending receipt" (first_count = 1);
+     check "retry does not append a second receipt" (repeated_count = 1)
+   | _ -> check "both enqueue attempts succeed" false);
+  let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
+  check "producer receipt is stored exactly once"
+    (match snapshot.pending with
+     | [ receipt ] ->
+       Keeper_chat_queue.Receipt_id.equal receipt.receipt_id receipt_id
+     | _ -> false)
+;;
+
+let test_enqueue_only_stores_the_authenticated_actor () =
+  Printf.printf
+    "Test: enqueue-only draft stores the authorized dashboard actor\n%!";
+  with_env
+  @@ fun ~base ~clock ->
+  let receipt_id = Keeper_chat_queue.Receipt_id.generate () in
+  let queued_payload =
+    { (payload ~content:"attribute me" ()) with
+      admission = Durable_enqueue receipt_id
+    }
+  in
+  (match
+     Server_routes_http_keeper_stream.For_testing.enqueue_dashboard_payload_now
+       ~base_path:base
+       ~clock
+       ~thread_id
+       ~actor:"operator-7"
+       queued_payload
+   with
+   | `Queued _ -> ()
+   | `Queue_error message ->
+     check ("enqueue succeeds: " ^ message) false);
+  let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
+  check "stored draft keeps the authenticated actor"
+    (match snapshot.pending with
+     | [ receipt ] ->
+       (match receipt.message.source with
+        | Keeper_chat_queue.Dashboard { actor; _ } ->
+          String.equal actor "operator-7"
+        | _ -> false)
+     | _ -> false)
 ;;
 
 let test_existing_backlog_defers_new_dashboard_message () =
@@ -175,7 +284,7 @@ let test_existing_backlog_defers_new_dashboard_message () =
        ; user_blocks = []
        ; attachments = []
        ; timestamp = Eio.Time.now clock
-       ; source = Dashboard { thread_id }
+       ; source = Dashboard { thread_id; actor = "dashboard" }
        ; user_row_origin = Keeper_chat_store.Needs_append
        }
    with
@@ -188,7 +297,8 @@ let test_existing_backlog_defers_new_dashboard_message () =
        ~base_path:base
        ~clock
        ~thread_id
-       (payload ~content:"newer dashboard message" ())
+       ~actor:"dashboard"
+(payload ~content:"newer dashboard message" ())
    with
    | `Queued len -> check "newer message joins existing backlog" (len = 2)
    | `Not_busy | `Queue_error _ ->
@@ -228,7 +338,8 @@ let test_concurrent_busy_dashboard_enqueues_are_per_keeper () =
           ~base_path:base
           ~clock
           ~thread_id:(Printf.sprintf "%s-%d" thread_id i)
-          (payload ~name:keeper_name
+          ~actor:"dashboard"
+(payload ~name:keeper_name
              ~content:(Printf.sprintf "burst message %d" i)
              ())
       in
@@ -286,7 +397,8 @@ let test_busy_dashboard_persist_failure_is_explicit () =
        ~base_path:base
        ~clock
        ~thread_id
-       (payload ~content:"do not acknowledge this as queued" ())
+       ~actor:"dashboard"
+(payload ~content:"do not acknowledge this as queued" ())
    with
    | `Queue_error message ->
      check "dashboard receives the persistence error" (String.length message > 0)
@@ -328,6 +440,7 @@ let test_shutdown_fenced_dashboard_ack_preserves_cause () =
      .defer_dashboard_payload_if_busy_evidence
        ~base_path:base ~clock
        ~thread_id
+       ~actor:"dashboard"
        (payload ~content:"keep this through shutdown" ())
    with
    | `Queued (json, ack) ->
@@ -470,9 +583,28 @@ let test_delegate_resource_error_uses_typed_tool_name () =
           (Tool_result.message result)))
 ;;
 
+let test_dashboard_source_requires_actor () =
+  Printf.printf
+    "Test: dashboard durable source requires actor attribution\n%!";
+  let without_actor =
+    `Assoc
+      [ "kind", `String "dashboard"
+      ; "thread_id", `String thread_id
+      ]
+  in
+  match
+    Keeper_chat_queue.For_testing.decode_message_source without_actor
+  with
+  | Ok _ -> check "missing dashboard actor is rejected" false
+  | Error _ -> check "missing dashboard actor is rejected" true
+;;
+
 let () =
   test_busy_dashboard_enqueues ();
   test_free_dashboard_not_enqueued ();
+  test_enqueue_only_dashboard_is_durable_while_free ();
+  test_enqueue_only_retry_reuses_producer_receipt ();
+  test_enqueue_only_stores_the_authenticated_actor ();
   test_existing_backlog_defers_new_dashboard_message ();
   test_concurrent_busy_dashboard_enqueues_are_per_keeper ();
   test_busy_dashboard_persist_failure_is_explicit ();
@@ -481,6 +613,7 @@ let () =
   test_stream_surface_preserves_typed_shutdown_rejection ();
   test_delegate_surface_uses_serialized_shutdown_fence ();
   test_delegate_resource_error_uses_typed_tool_name ();
+  test_dashboard_source_requires_actor ();
   if !failures > 0
   then (
     Printf.printf "FAILED: %d check(s)\n%!" !failures;

--- a/test/test_keeper_chat_admission_contention.ml
+++ b/test/test_keeper_chat_admission_contention.ml
@@ -295,13 +295,16 @@ let test_queued_server_turn_has_no_second_durable_request () =
              Server_routes_http_keeper_stream.keeper_chat_stream_request =
            { name = keeper_name
            ; message = "queued inline boundary"
+           ; admission =
+               Direct
+                 { turn_instructions = None
+                 ; surface_context = None
+                 ; channel = ""
+                 ; channel_user_id = ""
+                 ; channel_user_name = ""
+                 ; channel_workspace_id = ""
+                 }
            ; user_blocks = []
-           ; turn_instructions = None
-           ; surface_context = None
-           ; channel = ""
-           ; channel_user_id = ""
-           ; channel_user_name = ""
-           ; channel_workspace_id = ""
            ; attachments = []
            }
          in

--- a/test/test_keeper_chat_coalescing.ml
+++ b/test/test_keeper_chat_coalescing.ml
@@ -32,7 +32,9 @@ let with_base prefix body =
     (fun () -> body base_path)
 
 let message
-    ?(source = Keeper_chat_queue.Dashboard { thread_id = "keeper:queue-test" })
+    ?(source =
+      Keeper_chat_queue.Dashboard
+        { thread_id = "keeper:queue-test"; actor = "dashboard" })
     ?(timestamp = 1.0)
     ?(user_blocks = [])
     ?(attachments = [])

--- a/test/test_keeper_turn_admission.ml
+++ b/test/test_keeper_turn_admission.ml
@@ -62,7 +62,9 @@ let queued_message : Keeper_chat_queue.queued_message =
   ; user_blocks = []
   ; attachments = []
   ; timestamp = 1.0
-  ; source = Keeper_chat_queue.Dashboard { thread_id = "keeper:admission" }
+  ; source =
+      Keeper_chat_queue.Dashboard
+        { thread_id = "keeper:admission"; actor = "dashboard" }
   ; user_row_origin = Keeper_chat_store.Needs_append
   }
 ;;
@@ -282,7 +284,9 @@ let test_chat_if_free_rechecks_durable_queue_after_stale_peek () =
     ; user_blocks = []
     ; attachments = []
     ; timestamp = Time_compat.now ()
-    ; source = Keeper_chat_queue.Dashboard { thread_id = "keeper:admission" }
+    ; source =
+        Keeper_chat_queue.Dashboard
+          { thread_id = "keeper:admission"; actor = "dashboard" }
     ; user_row_origin = Keeper_chat_store.Needs_append
     }
   in


### PR DESCRIPTION
## 무엇을 고치나

Dashboard가 바쁜 Keeper에게 보낸 브라우저 초안을 서버 durable queue로 넘길 때, HTTP/SSE ACK가 끊겨도 같은 메시지가 중복 실행되거나 사라지지 않게 합니다.

## 계약

- 브라우저가 draft별 stable receipt id를 만들고 retry에도 재사용
- Direct context와 Durable enqueue를 OCaml/TypeScript 합 타입으로 분리
- 동일 receipt 재전송은 queue SSOT의 enqueue_with_receipt로 수렴
- 404(absent), exact receipt(present), 조회 불가(unavailable)를 구분
- 서버 접수 불명 draft는 자동 재전송하지 않고 exact receipt를 먼저 확인
- definitive receipt collision은 성공으로 숨기지 않음
- Dashboard queue source actor를 필수 durable provenance로 보존; missing actor는 hard-cut decode failure
- malformed context/attachment는 조용히 버리지 않고 request error

#26506에서 실제 overlap이 없던 CPU-only Concurrent 표지와 전역 observer 상태 변경은 전부 제외했습니다. 이 PR은 durable admission만 다룹니다.

## 검증

- Dashboard typecheck 통과
- Vitest 4 files, 226 tests 통과
- focused Dune build 통과
- Gate keeper backend 107 tests 통과
- copilot wiring 9 tests 통과
- chat admission contention / coalescing / turn admission 실행 통과

Full build/test authority는 PR CI입니다.