### PR TITLE
perf(keeper): parallelize safe read tools with race-safe hooks

### DIFF
--- a/lib/keeper/keeper_event_bridge.ml
+++ b/lib/keeper/keeper_event_bridge.ml
@@ -183,8 +183,13 @@ let wrap_event
     removing the catch-all. *)
 let invocation_payload_fields invocation =
   let tool_use_id = Agent_sdk.Tool_contract.Invocation.tool_use_id invocation in
+  let schedule = Agent_sdk.Tool_contract.Invocation.schedule invocation in
   [ "turn", `Int (Agent_sdk.Tool_contract.Invocation.turn invocation)
-  ; "planned_index", `Int (Agent_sdk.Tool_contract.Invocation.planned_index invocation)
+  ; "planned_index", `Int schedule.planned_index
+  ; "batch_index", `Int schedule.batch_index
+  ; "batch_size", `Int schedule.batch_size
+  ; ( "execution_mode"
+    , Agent_sdk.Tool_contract.execution_mode_to_yojson schedule.execution_mode )
   ]
   @ (if tool_use_id = "" then [] else [ "tool_use_id", `String tool_use_id ])
 ;;

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -128,6 +128,13 @@ let usage_missing_of_usage = function
   | None -> true
   | Some usage -> not (usage_has_tokens usage)
 
+let original_result_bytes ~oas_result_bytes output_text =
+  match Tool_output.decode_from_oas output_text with
+  | Tool_output.Not_marker -> Ok oas_result_bytes
+  | Tool_output.Decoded reference -> Ok reference.bytes
+  | Tool_output.Invalid_marker { detail } -> Error detail
+;;
+
 let make_hooks
     ~(config : Workspace.config)
     ~(meta_ref : Keeper_meta_contract.keeper_meta ref)
@@ -145,7 +152,6 @@ let make_hooks
     ()
   : Agent_sdk.Hooks.hooks =
   let sse_turn_complete = "keeper_turn_complete" in
-  let tool_start_time = ref 0.0 in
   (* Per-turn tool call counter for SSE enrichment.
      Incremented in post_tool_use, reset in after_turn. *)
   let tool_call_count_ref = ref 0 in
@@ -158,13 +164,6 @@ let make_hooks
   ignore trajectory_acc;
   let hooks =
     { Agent_sdk.Hooks.empty with
-    pre_tool_use = Some (fun event ->
-      match event with
-      | Agent_sdk.Hooks.PreToolUse _ ->
-        tool_start_time := Time_compat.now ();
-        Agent_sdk.Hooks.Continue
-      | _event -> Agent_sdk.Hooks.Continue);
-
     before_turn = Some (fun event ->
       match event with
       | Agent_sdk.Hooks.BeforeTurn _ ->
@@ -411,6 +410,7 @@ let make_hooks
           ; tool_name
           ; input
           ; output
+          ; result_bytes = oas_result_bytes
           ; duration_ms = hook_duration_ms
           ; _
           } ->
@@ -447,14 +447,10 @@ let make_hooks
           "keeper:%s tool_call tool=%s params=[%s] input_shape=[%s] outcome=%s out_len=%d error_preview=%s"
           (!meta_ref).name tool_name input_keys input_shape outcome_s out_len
           error_preview;
-        (* Persistent tool call I/O log for dashboard inspector.
-           tool_start_time is keeper-local (one ref per make_hooks call).
-           Tool calls within Agent.run are sequential, so no race. *)
-        let duration_ms =
-          if hook_duration_ms > 0.0
-          then hook_duration_ms
-          else (Time_compat.now () -. !tool_start_time) *. ms_per_second
-        in
+        (* OAS measures this exact handler occurrence and carries the result
+           on PostToolUse. Keep that typed value as the single timing
+           authority, including a legitimate zero-duration sample. *)
+        let duration_ms = hook_duration_ms in
         let model =
           current_keeper_model !meta_ref
         in
@@ -468,14 +464,17 @@ let make_hooks
         record_keeper_tool_duration_metric
           ~keeper_name:(!meta_ref).name
           summary;
-        (* Consume truncation info set by keeper_tools_oas before returning
-           the (possibly truncated) result to OAS. Falls back to out_len
-           when no truncation info was set (e.g. OAS-internal tool calls). *)
-        let (original_bytes, truncated_to) =
-          Keeper_tool_call_log.consume_truncation_info
-            ~keeper_name:(!meta_ref).name ()
+        let result_bytes =
+          match original_result_bytes ~oas_result_bytes output_text with
+          | Ok bytes -> bytes
+          | Error detail ->
+            Log.Keeper.warn
+              ~keeper_name:(!meta_ref).name
+              "tool=%s invalid externalized output marker: %s"
+              tool_name
+              detail;
+            oas_result_bytes
         in
-        let result_bytes = if original_bytes > 0 then original_bytes else out_len in
         (* Full record read: log_call no longer falls back to ambient
            context (RFC-0225 §3.3), so every field this row should carry
            must be passed explicitly from the run's own cell. *)
@@ -518,7 +517,7 @@ let make_hooks
              ?allowed_paths:tctx.allowed_paths
              ?network_mode:tctx.network_mode
              ?runtime_profile:tctx.runtime_profile
-             ~result_bytes ?truncated_to ()
+             ~result_bytes ()
          with
          | Eio.Cancel.Cancelled _ as e -> raise e
          | exn ->
@@ -687,4 +686,5 @@ module For_testing = struct
   let tool_input_keys_for_log = tool_input_keys_for_log
   let cost_usd_json = cost_usd_json
   let usage_missing_of_usage = usage_missing_of_usage
+  let original_result_bytes = original_result_bytes
 end

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -563,12 +563,22 @@ let make_hooks
                ()
            in
            let now = Time_compat.now () in
+           (* Round must come from the mutex-guarded [next_round] counter,
+              not a [calls_in_current_turn] read of [acc.entries]: with
+              parallel tool execution two fibers could otherwise observe the
+              same count and record duplicate round numbers. *)
+           let traj_turn = acc.Trajectory.turn in
            let entry : Trajectory.tool_call_entry =
              {
                ts = now;
                ts_iso = Masc_domain.iso8601_of_unix_seconds now;
-               turn = acc.Trajectory.turn;
-               round = Trajectory.calls_in_current_turn acc + 1;
+               turn = traj_turn;
+               round =
+                 Trajectory.next_round
+                   ~masc_root:acc.Trajectory.masc_root
+                   ~keeper_name
+                   ~trace_id
+                   ~turn:traj_turn;
                tool_name;
                args_json = Yojson.Safe.to_string safe_input;
                gate_decision = Trajectory.Pass;

--- a/lib/keeper/keeper_hooks_oas.mli
+++ b/lib/keeper/keeper_hooks_oas.mli
@@ -170,9 +170,9 @@ val make_hooks :
   ?trajectory_acc:Trajectory.accumulator ->
   unit -> Agent_sdk.Hooks.hooks
 (** Build the [Agent_sdk.Hooks.hooks] record used by the keeper turn loop:
-    passive pre-tool timing, post-tool accounting, idle detection, and
-    trajectory hooks wired together. Cost remains part of post-turn
-    observation. *)
+    post-tool accounting, idle detection, and trajectory hooks wired
+    together. OAS [PostToolUse] duration/result fields are the timing and
+    size authority. Cost remains part of post-turn observation. *)
 
 val hook_introspection_json : unit -> Yojson.Safe.t
 (** JSON snapshot describing which hooks are active for the dashboard
@@ -185,4 +185,8 @@ module For_testing : sig
   (** Exact projection used by the turn-complete SSE payload. *)
   val usage_missing_of_usage : Agent_sdk.Types.api_usage option -> bool
   (** Hook usage-evidence decision delegated to {!usage_has_tokens}. *)
+  val original_result_bytes :
+    oas_result_bytes:int -> string -> (int, string) result
+  (** Preserve the verified original byte count carried by an externalized
+      {!Tool_output} marker; inline output keeps the OAS hook count. *)
 end

--- a/lib/keeper/keeper_hooks_oas_introspection.ml
+++ b/lib/keeper/keeper_hooks_oas_introspection.ml
@@ -61,11 +61,6 @@ let hook_introspection_json () : Yojson.Safe.t =
       slot
         ~active:true
         ~source:"keeper_hooks_oas"
-        ~features:[ "tool_start_timing" ]
-        "pre_tool_use";
-      slot
-        ~active:true
-        ~source:"keeper_hooks_oas"
         ~features:
           [
             "tool_callback";

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -101,6 +101,7 @@ type runtime_handler =
 type policy =
   { readonly_of_input : readonly_of_input
   ; readonly_hint : bool option
+  ; execution_mode : Agent_sdk.Tool_contract.execution_mode
   ; retryable : bool
   ; cwd_scope : string option
   ; inline_safe : bool
@@ -218,6 +219,11 @@ let runtime_handler_to_string = function
   | Tool_analyze_image -> "tool_analyze_image"
 ;;
 
+let execution_mode_to_string = function
+  | Agent_sdk.Tool_contract.Concurrent -> "concurrent"
+  | Agent_sdk.Tool_contract.Serial -> "serial"
+;;
+
 let keeper_tool_group_of_runtime_handler = function
   | Tool_execute -> Execute_group
   | Tool_search_files -> Search_files_group
@@ -266,8 +272,10 @@ let discovery_example ~label ?cwd ~argv () =
   `Assoc [ "label", `String label; "input", input ]
 ;;
 
-let policy ?readonly ?readonly_of_input ?cwd_scope ?(retryable = false)
-      ?(inline_safe = false) ?(polling_read = false) ()
+let policy ?readonly ?readonly_of_input
+      ?(execution_mode = Agent_sdk.Tool_contract.Serial)
+      ?cwd_scope ?(retryable = false) ?(inline_safe = false)
+      ?(polling_read = false) ()
   =
   let readonly_of_input =
     match readonly_of_input with
@@ -276,6 +284,7 @@ let policy ?readonly ?readonly_of_input ?cwd_scope ?(retryable = false)
   in
   { readonly_of_input
   ; readonly_hint = readonly
+  ; execution_mode
   ; retryable
   ; cwd_scope
   ; inline_safe
@@ -588,6 +597,7 @@ let descriptor_with_public_aliases
     ; "backend", backend_to_string backend
     ; "sandbox", sandbox_to_string sandbox
     ; "runtime_handler", runtime_handler_to_string runtime_handler
+    ; "execution_mode", execution_mode_to_string policy.execution_mode
     ; ( "keeper_tool_group"
       , keeper_tool_group_to_string
           (keeper_tool_group_of_runtime_handler runtime_handler) )
@@ -1186,6 +1196,20 @@ let read_only_in_process_policy ?(inline_safe = false) ?(polling_read = false) (
     ()
 ;;
 
+let concurrent_read_only_in_process_policy
+      ?(inline_safe = false)
+      ?(polling_read = false)
+      ()
+  =
+  policy
+    ~readonly:true
+    ~execution_mode:Agent_sdk.Tool_contract.Concurrent
+    ~retryable:true
+    ~inline_safe
+    ~polling_read
+    ()
+;;
+
 let write_in_process_policy ?(retryable = false) ?(inline_safe = false) ()
   =
   policy
@@ -1570,7 +1594,7 @@ let internal_descriptors : t list =
         "Return the current wall-clock time as ISO 8601 and Unix epoch \
          seconds. No arguments."
       ~input_schema:empty_object_schema
-      ~policy:(read_only_in_process_policy ())
+      ~policy:(concurrent_read_only_in_process_policy ())
       ~handler:Tool_time_now
   ; (in_process_descriptor
        ~keeper_model_projection:Internal_name
@@ -1582,7 +1606,7 @@ let internal_descriptors : t list =
           keeper_surface_read only for current connected-surface lane context. \
           No arguments."
        ~input_schema:empty_object_schema
-       ~policy:(read_only_in_process_policy ())
+       ~policy:(concurrent_read_only_in_process_policy ())
        ~handler:Tool_tools_list
      |> with_eval_tags [ "capability_introspection" ])
   ; (in_process_descriptor
@@ -1593,7 +1617,7 @@ let internal_descriptors : t list =
          "Search keeper tool schemas by free-text query. Returns ranked tool \
           descriptions and input schemas."
        ~input_schema:tool_search_schema
-       ~policy:(read_only_in_process_policy ())
+       ~policy:(concurrent_read_only_in_process_policy ())
        ~handler:Tool_tool_search
      |> with_eval_tags [ "capability_introspection" ])
     (* ── memory / context (RFC-0179 PR-3) ─────────────────────── *)
@@ -1606,7 +1630,7 @@ let internal_descriptors : t list =
          state for this keeper turn. Context-window occupancy is not \
          currently observed."
       ~input_schema:empty_object_schema
-      ~policy:(read_only_in_process_policy ())
+      ~policy:(concurrent_read_only_in_process_policy ())
       ~handler:Tool_context_status
   ; in_process_descriptor
       ~keeper_model_projection:Internal_name
@@ -1618,7 +1642,7 @@ let internal_descriptors : t list =
          Text pages use UTF-8; arbitrary bytes use base64. The full artifact \
          is never restored into model history."
       ~input_schema:artifact_read_schema
-      ~policy:(read_only_in_process_policy ())
+      ~policy:(concurrent_read_only_in_process_policy ())
       ~handler:Tool_artifact_read
   ; in_process_descriptor_with_schema_source
       ~keeper_model_projection:Internal_name
@@ -1628,7 +1652,7 @@ let internal_descriptors : t list =
       ~description:
         "Search keeper memory or history; current facts use explicit substring filtering and snapshot order."
       ~input_schema:memory_search_schema
-      ~policy:(read_only_in_process_policy ())
+      ~policy:(concurrent_read_only_in_process_policy ())
       ~handler:Tool_memory_search
   ; in_process_descriptor_with_schema_source
       ~keeper_model_projection:Internal_name
@@ -1646,7 +1670,7 @@ let internal_descriptors : t list =
       ~name:"keeper_library_search"
       ~description:"Search the keeper library catalog."
       ~input_schema:library_search_schema
-      ~policy:(read_only_in_process_policy ())
+      ~policy:(concurrent_read_only_in_process_policy ())
       ~handler:Tool_library_search
   ; in_process_descriptor
       ~keeper_model_projection:Internal_name
@@ -1654,7 +1678,7 @@ let internal_descriptors : t list =
       ~name:"keeper_library_read"
       ~description:"Read a library entry by id."
       ~input_schema:library_read_schema
-      ~policy:(read_only_in_process_policy ())
+      ~policy:(concurrent_read_only_in_process_policy ())
       ~handler:Tool_library_read
     (* ── connector surfaces (RFC-0223 P3) ─────────────────────── *)
   ; (in_process_descriptor
@@ -1670,7 +1694,7 @@ let internal_descriptors : t list =
           channels outside Connected Surfaces, read only visible lane evidence \
           and state that the wider registry is unavailable."
        ~input_schema:surface_read_schema
-       ~policy:(read_only_in_process_policy ())
+       ~policy:(concurrent_read_only_in_process_policy ())
        ~handler:Tool_surface_read
      |> with_eval_tags [ "surface_context_read" ])
   ; in_process_descriptor
@@ -2143,6 +2167,7 @@ let eval_tags_json d =
 
 let common_policy_json_fields ~readonly_key policy =
   [ readonly_key, Json_util.bool_opt_to_json policy.readonly_hint
+  ; "execution_mode", `String (execution_mode_to_string policy.execution_mode)
   ; "retryable", `Bool policy.retryable
   ; "cwd_scope", Json_util.string_opt_to_json policy.cwd_scope
   ; "inline_safe", `Bool policy.inline_safe

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -121,6 +121,7 @@ type runtime_handler =
 type policy =
   { readonly_of_input : readonly_of_input
   ; readonly_hint : bool option
+  ; execution_mode : Agent_sdk.Tool_contract.execution_mode
   ; retryable : bool
   ; cwd_scope : string option
   ; inline_safe : bool

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -266,7 +266,12 @@ let make_tool_bundle
                      ~input)
                  ()
              in
+             let oas_descriptor =
+               Agent_sdk.Tool.ordinary_descriptor
+                 descriptor.policy.execution_mode
+             in
              Tool_bridge.oas_tool_of_masc_with_execution_env
+               ~descriptor:oas_descriptor
                ~base_path:config.base_path
                ?on_externalization_error
                ~externalization_error_recoverable:descriptor.policy.retryable

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -127,10 +127,6 @@ let execute_with_observers
             ; "error_preview", `String detail
             ]
              @ invocation_fields));
-      Keeper_tool_call_log.set_truncation_info
-        ~keeper_name:meta.name
-        ~original_bytes:(String.length projected_error)
-        ();
       { tool_result = dispatch_result
       ; failure_effect_disposition = Some result.failure_effect_disposition
       ; deferred_kind = None
@@ -190,10 +186,6 @@ let execute_with_observers
              ; "disposition", `String disposition
              ]
              @ invocation_fields));
-      Keeper_tool_call_log.set_truncation_info
-        ~keeper_name:meta.name
-        ~original_bytes:original_len
-        ();
       { tool_result = observed_result
       ; failure_effect_disposition = None
       ; deferred_kind = None
@@ -249,10 +241,6 @@ let execute_with_observers
             ; "disposition", `String disposition
             ]
              @ invocation_fields));
-      Keeper_tool_call_log.set_truncation_info
-        ~keeper_name:meta.name
-        ~original_bytes:(String.length projected_result)
-        ();
       { tool_result = observed_result
       ; failure_effect_disposition = None
       ; deferred_kind = result.deferred_kind
@@ -317,10 +305,6 @@ let execute_with_observers
           ; "error", `String error_text
           ]
            @ invocation_fields));
-    Keeper_tool_call_log.set_truncation_info
-      ~keeper_name:meta.name
-      ~original_bytes:(String.length projected_error)
-      ();
     { tool_result = exception_result
     ; failure_effect_disposition = Some Tool_result.Effect_outcome_unknown
     ; deferred_kind = None

--- a/lib/keeper/keeper_tools_oas_handler_telemetry.ml
+++ b/lib/keeper/keeper_tools_oas_handler_telemetry.ml
@@ -62,9 +62,14 @@ let tool_io_preview_fields ~tool_name ~input ?output () =
 let oas_invocation_fields = function
   | None -> []
   | Some invocation ->
+    let schedule = Agent_sdk.Tool_contract.Invocation.schedule invocation in
     [ "tool_use_id", `String (Agent_sdk.Tool_contract.Invocation.tool_use_id invocation)
     ; "turn", `Int (Agent_sdk.Tool_contract.Invocation.turn invocation)
-    ; "planned_index", `Int (Agent_sdk.Tool_contract.Invocation.planned_index invocation)
+    ; "planned_index", `Int schedule.planned_index
+    ; "batch_index", `Int schedule.batch_index
+    ; "batch_size", `Int schedule.batch_size
+    ; ( "execution_mode"
+      , Agent_sdk.Tool_contract.execution_mode_to_yojson schedule.execution_mode )
     ]
 ;;
 

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -14,26 +14,6 @@
 
 let max_output_len = 4000
 
-(** Pre-truncation info, keyed by keeper name.
-    Set by the tool handler wrapper (keeper_tools_oas), consumed by the
-    OAS on_tool_result hook (keeper_hooks_oas).  Per-keeper isolation
-    prevents cross-keeper corruption when multiple keepers call tools
-    concurrently. Within a single keeper's Agent.run, tool calls are
-    sequential so set→consume ordering is guaranteed. *)
-let pending_truncation : (string, int * int option) Hashtbl.t = Hashtbl.create 8
-
-let set_truncation_info ~keeper_name ~original_bytes ?truncated_to () =
-  Hashtbl.replace pending_truncation keeper_name (original_bytes, truncated_to)
-;;
-
-let consume_truncation_info ~keeper_name () =
-  match Hashtbl.find_opt pending_truncation keeper_name with
-  | Some info ->
-    Hashtbl.remove pending_truncation keeper_name;
-    info
-  | None -> 0, None
-;;
-
 type turn_ctx_cell = Keeper_tool_call_log_context.cell
 
 let create_turn_ctx_cell = Keeper_tool_call_log_context.create_cell
@@ -148,8 +128,7 @@ let reset_for_testing () =
   configured_store_ref := None;
   Atomic.set async_append_active false;
   Atomic.set append_queue_dropped 0;
-  with_append_queue_lock (fun () -> Stdlib.Queue.clear append_queue);
-  Hashtbl.reset pending_truncation
+  with_append_queue_lock (fun () -> Stdlib.Queue.clear append_queue)
 ;;
 
 let store_dir () =

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -367,7 +367,6 @@ let log_call
       ?network_mode
       ?runtime_profile
       ?result_bytes
-      ?truncated_to
       ()
   =
   match !store_ref with
@@ -391,11 +390,6 @@ let log_call
       let result_bytes_field =
         match result_bytes with
         | Some n -> [ "result_bytes", `Int n ]
-        | None -> []
-      in
-      let truncated_to_field =
-        match truncated_to with
-        | Some n -> [ "truncated_to", `Int n ]
         | None -> []
       in
       let lane_field =
@@ -561,8 +555,7 @@ let log_call
            @ goal_ids_field
            @ sandbox_profile_field
            @ network_mode_field
-           @ result_bytes_field
-           @ truncated_to_field)
+           @ result_bytes_field)
       in
       (* Sanitize UTF-8 before persisting.  Tool output may contain invalid
          byte sequences (truncated UTF-8, binary output from subprocess

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -5,27 +5,6 @@
 
     @since 2.249.0 *)
 
-val set_truncation_info :
-  keeper_name:string ->
-  original_bytes:int ->
-  ?truncated_to:int ->
-  unit ->
-  unit
-(** [set_truncation_info ~keeper_name ~original_bytes ?truncated_to ()]
-    records pre-truncation output size for the given keeper. Called by
-    the tool handler wrapper before returning the (possibly truncated)
-    result to OAS. Per-keeper isolation prevents cross-keeper corruption
-    under concurrent tool execution. *)
-
-val consume_truncation_info :
-  keeper_name:string ->
-  unit ->
-  int * int option
-(** [consume_truncation_info ~keeper_name ()] returns
-    [(original_bytes, truncated_to)] for the given keeper and clears
-    the pending state. Returns [(0, None)] when no truncation info
-    was set (e.g. OAS-internal tool call that bypassed the wrapper). *)
-
 type turn_ctx_cell = Keeper_tool_call_log_context.cell
 (** Per-run turn-context carrier (RFC-0225 §3.3). Created once per
     [run_turn] invocation and threaded to every context reader of the

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -138,7 +138,6 @@ val log_call :
   ?network_mode:string ->
   ?runtime_profile:string ->
   ?result_bytes:int ->
-  ?truncated_to:int ->
   unit ->
   unit
 (** [log_call ...] persists a single tool call record with full I/O.
@@ -154,9 +153,7 @@ val log_call :
     is persisted separately as the operator-facing runtime selector. Turn-policy fields ([lane], [tool_choice],
     [thinking_enabled], [thinking_budget]) capture the effective tool
     selection context. [result_bytes] is the original output size before
-    any observation-only log preview truncation. [truncated_to] records the
-    retained preview size when one exists; it never describes mutation of the
-    Tool result delivered to the Keeper. Best-effort (failures logged). *)
+    any observation-only log preview truncation. Best-effort (failures logged). *)
 
 val read_recent :
   ?keeper_name:string ->

--- a/test/test_keeper_execution_join.ml
+++ b/test/test_keeper_execution_join.ml
@@ -64,16 +64,23 @@ let mk_event ?caused_by payload : Agent_sdk.Event_bus.event =
   ; payload
   }
 
-let invocation ?(turn = 0) ?(planned_index = 0) tool_use_id =
+let invocation
+      ?(turn = 0)
+      ?(planned_index = 0)
+      ?(batch_index = 0)
+      ?(batch_size = 1)
+      ?(execution_mode = Agent_sdk.Tool_contract.Serial)
+      tool_use_id
+  =
   Agent_sdk.Tool_contract.Invocation.create
     ~tool_use_id
     ~turn
     ~completion:Agent_sdk.Tool_contract.Continue_after_success
     ~schedule:
       { planned_index
-      ; batch_index = 0
-      ; batch_size = 1
-      ; execution_mode = Agent_sdk.Tool_contract.Serial
+      ; batch_index
+      ; batch_size
+      ; execution_mode
       }
 
 let test_tool_called_carries_tool_use_id () =
@@ -82,7 +89,12 @@ let test_tool_called_carries_tool_use_id () =
     Bridge.native_event_to_json
       (mk_event
          (Agent_sdk.Event_bus.ToolCalled
-            { invocation = invocation "tu-3"
+            { invocation =
+                invocation
+                  ~batch_index:1
+                  ~batch_size:3
+                  ~execution_mode:Agent_sdk.Tool_contract.Concurrent
+                  "tu-3"
             ; agent_name = "oas-r1"
             ; tool_name = "Read"
             ; input = `Null
@@ -95,6 +107,12 @@ let test_tool_called_carries_tool_use_id () =
     (int_of_field (payload_member "turn" json));
   check (option int) "payload planned_index" (Some 0)
     (int_of_field (payload_member "planned_index" json));
+  check (option int) "payload batch_index" (Some 1)
+    (int_of_field (payload_member "batch_index" json));
+  check (option int) "payload batch_size" (Some 3)
+    (int_of_field (payload_member "batch_size" json));
+  check (option string) "payload execution_mode" (Some "concurrent")
+    (string_of_field (payload_member "execution_mode" json));
   check bool "tool_called has no execution_id (mint happens after publish)"
     true
     (payload_member "execution_id" json = None)

--- a/test/test_keeper_hooks_oas_introspection.ml
+++ b/test/test_keeper_hooks_oas_introspection.ml
@@ -8,7 +8,6 @@
 
     - lib/keeper/keeper_hooks_oas.ml ([make_hooks]) — the keeper_hooks_oas slots
     - lib/keeper/keeper_run_tools.ml — before_turn_params
-    - lib/keeper/keeper_hooks_oas.ml — passive pre_tool_use timing
 
     [before_turn_params] is assembled by [Keeper_run_tools_hooks], not
     [make_hooks], so its source/active claim remains a sibling-module contract
@@ -42,13 +41,12 @@ let slot_active slot_name =
   | Some active -> active
   | None -> failwith ("introspection slot missing active bool: " ^ slot_name)
 
-(* The 9 slots the introspection claims are wired. Retired OAS hook slots are
+(* The 8 slots the introspection claims are wired. Retired OAS hook slots are
    absent rather than retained as inactive compatibility surface. *)
 let expected_active =
   [ "before_turn"
   ; "before_turn_params"
   ; "after_turn"
-  ; "pre_tool_use"
   ; "post_tool_use"
   ; "post_tool_use_failure"
   ; "on_stop"
@@ -59,7 +57,7 @@ let expected_active =
 let test_slot_set () =
   let names = List.map fst (slots_of json) |> List.sort compare in
   let expected = List.sort compare expected_active in
-  check (list string) "introspection exposes exactly the 9 current hook slots" expected names
+  check (list string) "introspection exposes exactly the 8 current hook slots" expected names
 
 let test_active_split () =
   List.iter
@@ -68,9 +66,7 @@ let test_active_split () =
 
 let test_sources () =
   (* before_turn_params comes from a sibling module; the remaining active
-     slots, including passive pre_tool_use timing, are keeper_hooks_oas. *)
-  check (option string) "pre_tool_use source" (Some "keeper_hooks_oas")
-    (slot_string "pre_tool_use" "source");
+     slots are keeper_hooks_oas. *)
   check (option string) "before_turn_params source" (Some "keeper_run_tools")
     (slot_string "before_turn_params" "source");
   check (option string) "after_turn source" (Some "keeper_hooks_oas")
@@ -105,7 +101,6 @@ let runtime_slots_of (hooks : Agent_sdk.Hooks.hooks) =
   [
     "before_turn", Option.is_some hooks.before_turn;
     "after_turn", Option.is_some hooks.after_turn;
-    "pre_tool_use", Option.is_some hooks.pre_tool_use;
     "post_tool_use", Option.is_some hooks.post_tool_use;
     "post_tool_use_failure", Option.is_some hooks.post_tool_use_failure;
     "on_stop", Option.is_some hooks.on_stop;
@@ -122,45 +117,13 @@ let test_runtime_active_claims_match_make_hooks () =
       active
       (slot_active slot_name))
 
-let test_pre_tool_use_is_observation_only () =
-  let hooks = make_runtime_hooks () in
-  let event =
-    Agent_sdk.Hooks.PreToolUse
-      { invocation =
-          Agent_sdk.Tool_contract.Invocation.create
-            ~tool_use_id:"toolu_observation_only"
-            ~turn:7
-            ~completion:Agent_sdk.Tool_contract.Continue_after_success
-            ~schedule:
-              { planned_index = 0
-              ; batch_index = 0
-              ; batch_size = 1
-              ; execution_mode = Agent_sdk.Tool_contract.Serial
-              }
-      ; tool_name = "opaque_internal_name"
-      ; input = `Assoc [ "command", `String "opaque external effect" ]
-      ; accumulated_cost_usd = 1234.0
-      }
-  in
-  match Agent_sdk.Hooks.invoke_validated hooks.pre_tool_use event with
-  | Agent_sdk.Hooks.Continue -> ()
-  | AdjustParams _ -> fail "pre_tool_use timing hook adjusted parameters"
-  | ElicitInput _ -> fail "pre_tool_use timing hook elicited input"
-  | ElicitToolApproval _ ->
-    fail "pre_tool_use timing hook elicited tool approval"
-  | Nudge _ -> fail "pre_tool_use timing hook returned Nudge"
-  | HookFailed _ -> fail "pre_tool_use timing hook failed"
-  | Block _ -> fail "pre_tool_use timing hook returned Block"
-
 let () =
   Alcotest.run "Keeper_hooks_oas_introspection"
     [ ( "slot contract"
-      , [ test_case "exactly the 9 current slots" `Quick test_slot_set
+      , [ test_case "exactly the 8 current slots" `Quick test_slot_set
         ; test_case "all current slots active" `Quick test_active_split
         ; test_case "slot sources" `Quick test_sources
         ; test_case "make_hooks active claims match runtime record" `Quick
             test_runtime_active_claims_match_make_hooks
-        ; test_case "pre_tool_use is observation only" `Quick
-            test_pre_tool_use_is_observation_only
         ] )
     ]

--- a/test/test_keeper_hooks_oas_log_shape.ml
+++ b/test/test_keeper_hooks_oas_log_shape.ml
@@ -2,6 +2,34 @@ open Alcotest
 
 module Under_test = Masc.Keeper_hooks_oas.For_testing
 
+let test_result_bytes_uses_typed_externalized_reference () =
+  let reference =
+    match
+      Masc.Tool_output.make_artifact_ref
+        ~sha256:(String.make 64 'a')
+        ~bytes:8192
+        ~preview:"preview"
+        ~mime:"text/plain"
+    with
+    | Ok reference -> reference
+    | Error error ->
+      fail (Masc.Tool_output.make_error_to_string error)
+  in
+  let marker =
+    Masc.Tool_output.encode_for_oas (Masc.Tool_output.Stored reference)
+  in
+  check (result int string)
+    "externalized output reports original bytes"
+    (Ok 8192)
+    (Under_test.original_result_bytes
+       ~oas_result_bytes:(String.length marker)
+       marker);
+  check (result int string)
+    "inline output keeps OAS bytes"
+    (Ok 5)
+    (Under_test.original_result_bytes ~oas_result_bytes:5 "hello")
+;;
+
 let test_empty_tool_args_are_explicit_object_shape () =
   check string "empty object shape" "object:0"
     (Under_test.tool_input_shape_for_log (`Assoc []));
@@ -135,7 +163,13 @@ let test_thinking_summary_mixed_sums () =
 
 let () =
   run "keeper_hooks_oas_log_shape"
-    [ ( "tool-input-log-shape"
+    [ ( "result-bytes"
+      , [ test_case
+            "typed externalized reference preserves original size"
+            `Quick
+            test_result_bytes_uses_typed_externalized_reference
+        ] )
+    ; ( "tool-input-log-shape"
       , [ test_case "empty args are object:0" `Quick
             test_empty_tool_args_are_explicit_object_shape
         ; test_case "field shapes are explicit" `Quick

--- a/test/test_keeper_tool_call_sse_io_preview.ml
+++ b/test/test_keeper_tool_call_sse_io_preview.ml
@@ -112,9 +112,9 @@ let test_oas_invocation_fields_preserve_exact_occurrence () =
       ~completion:Agent_sdk.Tool_contract.Continue_after_success
       ~schedule:
         { planned_index = 3
-        ; batch_index = 0
-        ; batch_size = 1
-        ; execution_mode = Agent_sdk.Tool_contract.Serial
+        ; batch_index = 2
+        ; batch_size = 4
+        ; execution_mode = Agent_sdk.Tool_contract.Concurrent
         }
   in
   let json =
@@ -130,7 +130,19 @@ let test_oas_invocation_fields_preserve_exact_occurrence () =
   Alcotest.(check int)
     "planned index preserved"
     3
-    Yojson.Safe.Util.(member "planned_index" json |> to_int)
+    Yojson.Safe.Util.(member "planned_index" json |> to_int);
+  Alcotest.(check int)
+    "batch index preserved"
+    2
+    Yojson.Safe.Util.(member "batch_index" json |> to_int);
+  Alcotest.(check int)
+    "batch size preserved"
+    4
+    Yojson.Safe.Util.(member "batch_size" json |> to_int);
+  Alcotest.(check string)
+    "execution mode preserved"
+    "concurrent"
+    Yojson.Safe.Util.(member "execution_mode" json |> to_string)
 ;;
 
 let () =

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -1223,6 +1223,42 @@ let test_readonly_policy_projection_is_descriptor_owned () =
     false
     (List.mem "tool_write_file" projected)
 
+let test_concurrent_execution_is_bounded_to_in_process_reads () =
+  let concurrent_names =
+    all_descriptors ()
+    |> List.filter_map (fun descriptor ->
+      match descriptor.Descriptor.policy.execution_mode with
+      | Agent_sdk.Tool_contract.Serial -> None
+      | Agent_sdk.Tool_contract.Concurrent ->
+        Alcotest.(check (option bool))
+          (descriptor.internal_name ^ " concurrent tool is statically read-only")
+          (Some true)
+          descriptor.policy.readonly_hint;
+        Alcotest.(check bool)
+          (descriptor.internal_name ^ " concurrent tool is in-process")
+          true
+          (descriptor.executor = Descriptor.In_process);
+        Alcotest.(check bool)
+          (descriptor.internal_name ^ " concurrent tool has no sandbox runtime")
+          true
+          (descriptor.sandbox = Descriptor.No_sandbox);
+        Some descriptor.internal_name)
+    |> List.sort String.compare
+  in
+  Alcotest.(check (list string))
+    "concurrent admission is an explicit, reviewable allowlist"
+    [ "keeper_artifact_read"
+    ; "keeper_context_status"
+    ; "keeper_library_read"
+    ; "keeper_library_search"
+    ; "keeper_memory_search"
+    ; "keeper_surface_read"
+    ; "keeper_time_now"
+    ; "keeper_tool_search"
+    ; "keeper_tools_list"
+    ]
+    concurrent_names
+
 let test_readonly_policy_is_descriptor_input_aware () =
   let public_input =
     `Assoc [ "pattern", `String "Keeper_tool_descriptor"; "op", `String "rm" ]
@@ -1676,6 +1712,10 @@ let () =
             "descriptor read-only policy evaluates tool input"
             `Quick
             test_readonly_policy_is_descriptor_input_aware
+        ; test_case
+            "concurrent execution stays bounded to in-process reads"
+            `Quick
+            test_concurrent_execution_is_bounded_to_in_process_reads
         ; test_case
             "MCP context policy uses descriptor resolution"
             `Quick

--- a/test/test_tool_bridge_externalize.ml
+++ b/test/test_tool_bridge_externalize.ml
@@ -202,6 +202,22 @@ let test_execution_env_preserves_exact_invocation () =
       2
       (Agent_sdk.Tool_contract.Invocation.planned_index seen)
 
+let test_execution_mode_preserves_explicit_descriptor () =
+  let tool =
+    B.oas_tool_of_masc_with_execution_env
+      ~descriptor:
+        (Agent_sdk.Tool.ordinary_descriptor Agent_sdk.Tool_contract.Concurrent)
+      ~name:"concurrent_probe"
+      ~description:"preserve explicit execution mode"
+      ~input_schema:(`Assoc [ "type", `String "object" ])
+      (fun _execution_env _input ->
+         tool_ok ~tool_name:"concurrent_probe" "ok")
+  in
+  Alcotest.(check bool)
+    "bridge preserves explicit concurrent descriptor"
+    true
+    (Agent_sdk.Tool.execution_mode tool = Agent_sdk.Tool_contract.Concurrent)
+
 (* --- Marker encoding round-trip via the bridge --- *)
 
 let test_externalize_with_temp_base_path () =
@@ -329,6 +345,8 @@ let () =
             test_round_trip_through_oas;
           Alcotest.test_case "execution env preserves exact invocation" `Quick
             test_execution_env_preserves_exact_invocation;
+          Alcotest.test_case "explicit execution mode is preserved" `Quick
+            test_execution_mode_preserves_explicit_descriptor;
         ] );
       ( "externalize",
         [


### PR DESCRIPTION
## 배경

리뷰어 판정으로 닫힌 #26506(perf(keeper): durably enqueue drafts and parallelize safe reads)의 분할 PR 두 번째다.

- 첫 번째 절반(enqueue idempotency + actor 보존): #26515
- 이 PR: tool concurrency + observability 절반

closed 브랜치 `fix/keeper-parallel-tool-batches-20260730`(62be313108 + 리뷰 수정 c788a702ed)에서 tool-concurrency 관련 hunks만 추출해 현재 main(병합된 #26490의 `Operator_only` 변경 포함) 위에 재적용했다.

## 변경 내용

- **Concurrent 분류**: 읽기 전용 in-process keeper 도구 9개(`keeper_time_now`, `keeper_tools_list`, `keeper_tool_search`, `keeper_context_status`, `keeper_artifact_read`, `keeper_memory_search`, `keeper_library_search`, `keeper_library_read`, `keeper_surface_read`)의 policy에 `execution_mode = Concurrent`를 부여해 OAS 배치 실행기가 병렬로 실행할 수 있게 한다. `test_keeper_tool_descriptor_registry_integrity.ml`에 9개 이름을 명시한 allowlist 가드 테스트를 추가해 확장을 리뷰 가능한 상태로 유지한다.
- **훅 상태 race 수정(근본 원인 수정)**: 기존 `pre_tool_use`의 공유 `tool_start_time` ref와 keeper-name 키의 공유 truncation 해시테이블(`Keeper_tool_call_log.set/consume_truncation_info`)은 도구 호출이 병렬화되는 순간 깨진다. OAS가 `PostToolUse` 이벤트에 호출 단위로 실어주는 `duration_ms`와 `result_bytes`를 유일한 timing/size 권위로 사용하도록 바꿔 공유 가변 상태 자체를 제거했다. 원본 바이트 수는 `Tool_output` 마커에서 복원한다.
- **관측성**: descriptor의 `execution_mode`를 OAS tool bundle 생성 시 그대로 전달하고, 이벤트 브리지/텔레메트리 payload에 배치 스케줄 필드(`batch_index`, `batch_size`, `execution_mode`)를 노출한다. 실제 병렬 dispatch(Eio.Fiber 배치 실행)는 pin된 agent_sdk(OAS) 측에 이미 있으며 이 PR은 masc 측 분류/배선만 담당한다.

## 검증

- 로컬 `dune build`/`runtest`는 repo 규칙(자원 제한)에 따라 생략했다. 컴파일 + 테스트 검증은 CI가 수행해야 한다.
- diff에 half (a) 흔적(`receipt_id`, `Durable_enqueue`)이 없음을 grep으로 확인했다.
- `keeper_tool_descriptor.ml`은 #26490과 겹치는 파일이라 3-way 적용했고, `Operator_only` 변경과 `Concurrent` 변경이 모두 살아있음을 확인했다.
