### PR TITLE
fix(keeper): enforce exact Librarian config state

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -16,7 +16,7 @@ the categorization roadmap. Newly-added typed getters in
 
 **Total**: 207 unique knobs across 8 modules.
 
-**Typed getter classification**: 33/121 tagged (`operator`: 33, `algorithm`: 0, `unclassified`: 88).
+**Typed getter classification**: 32/120 tagged (`operator`: 32, `algorithm`: 0, `unclassified`: 88).
 
 ## Env_config_core (23 knobs; typed classification 2/5)
 
@@ -46,50 +46,50 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_TEST_ALLOW_HOME_BASE_PATH` | string_literal | n/a | n/a | 416 | #9903: production base-path safeguard for test executables. Without this, a test whose [MASC_BASE_PATH] override fail... |
 | `MASC_URL` | string_literal | n/a | n/a | 289 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 
-## Env_config_keeper (40 knobs; typed classification 21/34)
+## Env_config_keeper (40 knobs; typed classification 20/33)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 564 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 510 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
+| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 568 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 514 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | feature_flag | n/a | n/a | 20 | Enable startup keeper bootstrap scan |
 | `MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC` | typed:float | unclassified | unclassified | 41 | Polling interval (seconds) for the lazy-startup wait loop in [server_bootstrap_loops.ml]. The autoboot fiber wakes up... |
 | `MASC_KEEPER_BOOTSTRAP_LISTENER_RETRY_INTERVAL_SEC` | typed:float | unclassified | unclassified | 53 | Polling interval (seconds) for the keeper-lifecycle listener retry loop in [server_bootstrap_loops.ml]. After a liste... |
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | unclassified | unclassified | 28 | Max keeper meta files to scan during bootstrap |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 65 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | unclassified | unclassified | 24 | Keeper considered stale when last turn exceeds this threshold (seconds) |
-| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 530 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT` | typed:int | Runtime | operator | 250 | Default item limit for [GET /keepers/:name/compaction-snapshots]. Default: 25. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER` | typed:int | Runtime | operator | 276 | Multiplier from requested item limit to manifest files scanned. Default: 4. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES` | typed:int | Runtime | operator | 266 | Minimum manifest files scanned before applying [limit * multiplier]. Default: 8. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES` | typed:int | Runtime | operator | 286 | Tail line count read from each selected manifest file. Default: 200. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MAX_LIMIT` | typed:int | Runtime | operator | 256 | Maximum accepted item limit for the compaction snapshot endpoint. Default: 100. @category Runtime @ops_class operator |
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 534 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT` | typed:int | Runtime | operator | 254 | Default item limit for [GET /keepers/:name/compaction-snapshots]. Default: 25. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER` | typed:int | Runtime | operator | 280 | Multiplier from requested item limit to manifest files scanned. Default: 4. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES` | typed:int | Runtime | operator | 270 | Minimum manifest files scanned before applying [limit * multiplier]. Default: 8. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES` | typed:int | Runtime | operator | 290 | Tail line count read from each selected manifest file. Default: 200. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MAX_LIMIT` | typed:int | Runtime | operator | 260 | Maximum accepted item limit for the compaction snapshot endpoint. Default: 100. @category Runtime @ops_class operator |
 | `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 143 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
 | `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 151 | Enable keeper debug logging. Default: false. |
-| `MASC_KEEPER_DURABLE_QUEUE_STALE_SEC` | typed:float | Telemetry | operator | 435 | Durable event-queue backlog age threshold for fleet health degradation. The durable queue remains fully reported rega... |
-| `MASC_KEEPER_GENERATED_MEDIA_DIR_MAX_BYTES` | typed:int | Policies | operator | 373 | Maximum total bytes retained in [<masc_dir>/media] after opportunistic cleanup. Default is 500 MiB. Range: [1, 5 GiB]... |
-| `MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES` | typed:int | Policies | operator | 362 | Maximum raw generated-media bytes accepted by the durable store and serve route. Default is 10 MiB. Range: [1, 50 MiB... |
-| `MASC_KEEPER_GENERATED_MEDIA_RETENTION_SEC` | typed:float | Policies | operator | 384 | Maximum generated-media file age retained by opportunistic cleanup. Default is 24 hours. Range: [1 second, 30 days]. ... |
-| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 543 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
-| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | Thresholds | operator | 396 | Shared keepalive interval, read early so WorkAsHeartbeat can reference it. Any positive interval is valid; the schedu... |
-| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 417 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | typed:bool | Policies | operator | 209 | Memory OS librarian post-turn extraction kill switch. Default: true; invalid values fail closed to false so malformed... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 221 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 233 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 197 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
+| `MASC_KEEPER_DURABLE_QUEUE_STALE_SEC` | typed:float | Telemetry | operator | 439 | Durable event-queue backlog age threshold for fleet health degradation. The durable queue remains fully reported rega... |
+| `MASC_KEEPER_GENERATED_MEDIA_DIR_MAX_BYTES` | typed:int | Policies | operator | 377 | Maximum total bytes retained in [<masc_dir>/media] after opportunistic cleanup. Default is 500 MiB. Range: [1, 5 GiB]... |
+| `MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES` | typed:int | Policies | operator | 366 | Maximum raw generated-media bytes accepted by the durable store and serve route. Default is 10 MiB. Range: [1, 50 MiB... |
+| `MASC_KEEPER_GENERATED_MEDIA_RETENTION_SEC` | typed:float | Policies | operator | 388 | Maximum generated-media file age retained by opportunistic cleanup. Default is 24 hours. Range: [1 second, 30 days]. ... |
+| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 547 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
+| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | Thresholds | operator | 400 | Shared keepalive interval, read early so WorkAsHeartbeat can reference it. Any positive interval is valid; the schedu... |
+| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 421 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | string_literal | n/a | n/a | 183 |  |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 225 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 237 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 213 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
 | `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | unclassified | unclassified | 73 | Maximum metrics file size in bytes before rotation (default: 10MB) |
 | `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | unclassified | unclassified | 76 | Number of rotated files to keep (default: 1, i.e. .1 only) |
-| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | Thresholds | operator | 459 | Interruptible sleep chunk size in seconds: the upper bound on how long a keeper's heartbeat sleep takes to notice a w... |
+| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | Thresholds | operator | 463 | Interruptible sleep chunk size in seconds: the upper bound on how long a keeper's heartbeat sleep takes to notice a w... |
 | `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 154 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
-| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 553 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
-| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | string_literal | n/a | n/a | 470 |  |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 323 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 333 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
-| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 313 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
+| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 557 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
+| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | string_literal | n/a | n/a | 474 |  |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 327 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 337 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
+| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 317 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
 | `MASC_KEEPER_WIRE_CAPTURE` | feature_flag | Policies | operator | 88 | Master switch for diagnostic MASC->OAS wire capture. Default off. @category Policies @ops_class operator |
 | `MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES` | typed:int | Policies | operator | 114 | Maximum bytes for the active [<masc_root>/wire-capture/YYYY-MM/DD.jsonl] file and maximum total bytes retained below ... |
 | `MASC_KEEPER_WIRE_CAPTURE_RETENTION_DAYS` | typed:int | Policies | operator | 103 | Maximum age for [<masc_root>/wire-capture] day files retained by the diagnostic MASC->OAS wire-capture harness. Defau... |
-| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 411 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
+| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 415 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
 
 ## Env_config_keeper_supervisor (3 knobs; typed classification 2/2)
 

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -162,6 +162,11 @@ end
     then the boot override store, then the hardcoded defaults below. *)
 
 module KeeperMemoryOs = struct
+  type librarian_config_state =
+    | Enabled
+    | Disabled
+    | Invalid
+
   let get_int_logged = Env_config_memory.get_int_logged
   let get_float_positive_logged = Env_config_memory.get_float_positive_logged
 
@@ -186,6 +191,17 @@ module KeeperMemoryOs = struct
       ~default
   ;;
 
+  let librarian_config_state () =
+    match Env_config_memory.env_opt librarian_env_key with
+    | None ->
+      if librarian_enabled_default then Enabled else Disabled
+    | Some raw ->
+      (match Env_config_memory.parse_bool_token raw with
+       | Some true -> Enabled
+       | Some false -> Disabled
+       | None -> Invalid)
+  ;;
+
   (** Memory OS recall prompt injection kill switch. Default: true; invalid
       values fail closed to false so malformed operator input cannot leave the
       kill switch accidentally enabled.
@@ -204,10 +220,14 @@ module KeeperMemoryOs = struct
       @category Policies
       @ops_class operator *)
   let librarian_enabled () =
-    get_bool_logged
-      ~invalid:Env_config_memory.Fail_closed
-      librarian_env_key
-      ~default:librarian_enabled_default
+    match librarian_config_state () with
+    | Enabled -> true
+    | Disabled -> false
+    | Invalid ->
+      get_bool_logged
+        ~invalid:Env_config_memory.Fail_closed
+        librarian_env_key
+        ~default:librarian_enabled_default
   ;;
 
   (** Turns between librarian extraction attempts per keeper. Default: 3,

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -214,22 +214,6 @@ module KeeperMemoryOs = struct
       ~default:recall_enabled_default
   ;;
 
-  (** Memory OS librarian post-turn extraction kill switch. Default: true;
-      invalid values fail closed to false so malformed operator input cannot
-      leave the kill switch accidentally enabled.
-      @category Policies
-      @ops_class operator *)
-  let librarian_enabled () =
-    match librarian_config_state () with
-    | Enabled -> true
-    | Disabled -> false
-    | Invalid ->
-      get_bool_logged
-        ~invalid:Env_config_memory.Fail_closed
-        librarian_env_key
-        ~default:librarian_enabled_default
-  ;;
-
   (** Turns between librarian extraction attempts per keeper. Default: 3,
       floored to 1.
       @category Runtime

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -58,6 +58,11 @@ end
 (** {1 Keeper Memory OS} *)
 
 module KeeperMemoryOs : sig
+  type librarian_config_state =
+    | Enabled
+    | Disabled
+    | Invalid
+
   (** Env-var names (SSOT). The config-introspection registry and tests must
       reference these constants rather than re-spelling the literals, so a
       knob rename breaks compilation instead of silently drifting. *)
@@ -71,6 +76,11 @@ module KeeperMemoryOs : sig
   val librarian_enabled_default : bool
   val librarian_cadence_turns_default : int
   val librarian_max_messages_default : int
+
+  val librarian_config_state : unit -> librarian_config_state
+  (** Typed projection of the effective librarian toggle. Blank or absent
+      input uses {!librarian_enabled_default}; malformed non-blank input is
+      [Invalid] rather than being collapsed into [Disabled]. *)
 
   val recall_enabled : unit -> bool
   val librarian_enabled : unit -> bool

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -83,7 +83,6 @@ module KeeperMemoryOs : sig
       [Invalid] rather than being collapsed into [Disabled]. *)
 
   val recall_enabled : unit -> bool
-  val librarian_enabled : unit -> bool
   val librarian_cadence_turns : unit -> int
   val librarian_max_messages : unit -> int
 end

--- a/lib/dashboard/dashboard.ml
+++ b/lib/dashboard/dashboard.ml
@@ -112,11 +112,19 @@ let format_section (s : section) : string =
 let parse_iso_timestamp = Dashboard_labels.parse_iso_timestamp
 let format_elapsed = Dashboard_labels.format_elapsed
 
-let format_librarian_status ~enabled ~failures_total =
+let format_librarian_status ~config_state ~failures_since_start =
+  let config_label =
+    match
+      (config_state : Env_config.KeeperMemoryOs.librarian_config_state)
+    with
+    | Enabled -> "ON"
+    | Disabled -> "OFF"
+    | Invalid -> "INVALID"
+  in
   Printf.sprintf
-    "%s | LIBRARIAN-FAILURES-TOTAL: %d"
-    (if enabled then "ON" else "OFF")
-    failures_total
+    "%s | LIBRARIAN-FAILURES-SINCE-START: %d"
+    config_label
+    failures_since_start
 ;;
 
 let truncate_path (path : string) : string =
@@ -491,7 +499,7 @@ let generate_compact ?(scope = All) (config : Workspace_utils.config) : string =
         + (Otel_metric_store.metric_total Keeper_metrics.(to_string OasExecutionErrors) |> int_of_float)
         (* MemoryOsLibrarianFailures is intentionally excluded: librarian
            failures are not tool errors and are surfaced separately in the
-           LIBRARIAN header segment (LIBRARIAN-FAILURES-TOTAL). *)
+           LIBRARIAN header segment (LIBRARIAN-FAILURES-SINCE-START). *)
         + (Otel_metric_store.metric_total Keeper_metrics.(to_string MemoryActivityEmitFailures) |> int_of_float)
         + (Otel_metric_store.metric_total Keeper_metrics.(to_string SupervisorSweepFailures) |> int_of_float)
         + (Otel_metric_store.metric_total Keeper_metrics.(to_string TomlReconcileSweepFailures) |> int_of_float)
@@ -534,14 +542,16 @@ let generate_compact ?(scope = All) (config : Workspace_utils.config) : string =
         then Printf.sprintf " | TOOL-ERR: %d" tool_failures
         else ""
       in
-      let librarian_enabled = Env_config.KeeperMemoryOs.librarian_enabled () in
-      let librarian_failures =
+      let librarian_config_state =
+        Env_config.KeeperMemoryOs.librarian_config_state ()
+      in
+      let librarian_failures_since_start =
         Otel_metric_store.metric_total Keeper_metrics.(to_string MemoryOsLibrarianFailures) |> int_of_float
       in
       let librarian_status =
         format_librarian_status
-          ~enabled:librarian_enabled
-          ~failures_total:librarian_failures
+          ~config_state:librarian_config_state
+          ~failures_since_start:librarian_failures_since_start
       in
       Printf.sprintf
         "KEEPERS: %d running / %d dead / %d other | LIBRARIAN: %s | GUARD: %d | \

--- a/lib/dashboard/dashboard.mli
+++ b/lib/dashboard/dashboard.mli
@@ -45,7 +45,6 @@ val scope_of_string_opt : string -> scope option
 val format_section : section -> string
 val parse_iso_timestamp : string -> float option
 val format_elapsed : float -> string -> string -> string
-val format_librarian_status : enabled:bool -> failures_total:int -> string
 val truncate_path : string -> string
 val truncate_message : string -> string
 

--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -79,7 +79,7 @@ let run
            Config_dir_resolver.keepers_dir_for_base_path
              ~base_path:config.Workspace.base_path
          in
-         let librarian_series () =
+         let run_admitted_librarian () =
            match
              Keeper_memory_os_current.read_for_keepers_dir
                ~keepers_dir
@@ -118,6 +118,14 @@ let run
                ~keeper_id:meta.name
                ~expected_revision
                librarian_input
+         in
+         let librarian_series () =
+           (* Submission is asynchronous. Re-check the same live SSOT at the
+              execution boundary so an ON -> OFF/INVALID change while queued
+              remains a real kill switch before snapshot I/O or provider work. *)
+           match Env_config.KeeperMemoryOs.librarian_config_state () with
+           | Disabled | Invalid -> ()
+           | Enabled -> run_admitted_librarian ()
          in
          let (_ : Keeper_memory_lane.outcome) =
            Keeper_memory_lane.submit

--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -66,51 +66,75 @@ let run
          "delegation_requests failed: %s"
          (Printexc.to_string exn))
   in
-  (* Memory OS librarian extraction: opt-in, provider-backed, best-effort. Its
-     own lane unit, separate from [det_write_series] above. *)
-  let keepers_dir =
-    Config_dir_resolver.keepers_dir_for_base_path
-      ~base_path:config.Workspace.base_path
-  in
-  let librarian_series () =
-    match
-      Keeper_memory_os_current.read_for_keepers_dir
-        ~keepers_dir
-        ~keeper_id:meta.name
-    with
-    | Error detail ->
-      Otel_metric_store.inc_counter
-        Keeper_metrics.(to_string MemoryOsLibrarianFailures)
-        ~labels:[ "keeper", meta.name; "site", "memory_os_current_read" ]
-        ();
-      Log.Keeper.warn
-        ~keeper_name:meta.name
-        "memory os librarian skipped: current snapshot unavailable: %s"
-        detail
-    | Ok current ->
-      let current_selection, expected_revision =
-        match current with
-        | None -> None, None
-        | Some snapshot ->
-          ( Some
-              { Keeper_librarian.facts = snapshot.facts }
-          , Some snapshot.revision )
-      in
-      let trace_id =
-        Keeper_id.Trace_id.to_string meta.runtime.trace_id
-      in
-      let librarian_input : Keeper_librarian.input =
-        { turn_ref = Ids.Turn_ref.make ~trace_id ~absolute_turn:turn
-        ; generation
-        ; current = current_selection
-        ; messages = librarian_messages
-        }
-      in
-      Keeper_librarian_runtime.run_best_effort
-        ~keepers_dir
-        ~keeper_id:meta.name
-        ~expected_revision
-        librarian_input
+  (* The librarian toggle is owned at this admission boundary. Disabled or
+     invalid configuration must not submit a lane unit, read the current
+     snapshot, advance cadence, or emit Librarian runtime failures. *)
+  let submit_librarian_if_enabled () =
+    match Env_config.KeeperMemoryOs.librarian_config_state () with
+    | Disabled | Invalid -> ()
+    | Enabled ->
+      (match turn_effect_record with
+       | Keeper_run_prompt.Meaningful_turn ->
+         let keepers_dir =
+           Config_dir_resolver.keepers_dir_for_base_path
+             ~base_path:config.Workspace.base_path
+         in
+         let librarian_series () =
+           match
+             Keeper_memory_os_current.read_for_keepers_dir
+               ~keepers_dir
+               ~keeper_id:meta.name
+           with
+           | Error detail ->
+             Otel_metric_store.inc_counter
+               Keeper_metrics.(to_string MemoryOsLibrarianFailures)
+               ~labels:[ "keeper", meta.name; "site", "memory_os_current_read" ]
+               ();
+             Log.Keeper.warn
+               ~keeper_name:meta.name
+               "memory os librarian skipped: current snapshot unavailable: %s"
+               detail
+           | Ok current ->
+             let current_selection, expected_revision =
+               match current with
+               | None -> None, None
+               | Some snapshot ->
+                 ( Some
+                     { Keeper_librarian.facts = snapshot.facts }
+                 , Some snapshot.revision )
+             in
+             let trace_id =
+               Keeper_id.Trace_id.to_string meta.runtime.trace_id
+             in
+             let librarian_input : Keeper_librarian.input =
+               { turn_ref = Ids.Turn_ref.make ~trace_id ~absolute_turn:turn
+               ; generation
+               ; current = current_selection
+               ; messages = librarian_messages
+               }
+             in
+             Keeper_librarian_runtime.run_best_effort
+               ~keepers_dir
+               ~keeper_id:meta.name
+               ~expected_revision
+               librarian_input
+         in
+         let (_ : Keeper_memory_lane.outcome) =
+           Keeper_memory_lane.submit
+             ~base_path:config.Workspace.base_path
+             ~keeper_name:meta.name
+             ~lane:Keeper_memory_lane.Librarian
+             librarian_series
+         in
+         ()
+       | Keeper_run_prompt.Inert_autonomous_turn ->
+         (* Not submitted at all, so the cadence counter does not advance
+            either: an idle stretch leaves the extraction budget untouched
+            instead of spending it on prose about the idleness. *)
+         Otel_metric_store.inc_counter
+           Keeper_metrics.(to_string MemoryOsInertTurnExtractionSkipped)
+           ~labels:[ "keeper", meta.name ]
+           ())
   in
   (* RFC-0257: detach onto the per-keeper memory lane. When the executor
      switch is not initialized (tests, early startup) the lane runs units
@@ -122,24 +146,7 @@ let run
       ~lane:Keeper_memory_lane.Deterministic
       det_write_series
   in
-  (match turn_effect_record with
-   | Keeper_run_prompt.Meaningful_turn ->
-     let (_ : Keeper_memory_lane.outcome) =
-       Keeper_memory_lane.submit
-         ~base_path:config.Workspace.base_path
-         ~keeper_name:meta.name
-         ~lane:Keeper_memory_lane.Librarian
-         librarian_series
-     in
-     ()
-   | Keeper_run_prompt.Inert_autonomous_turn ->
-     (* Not submitted at all, so the cadence counter does not advance either:
-        an idle stretch leaves the extraction budget untouched instead of
-        spending it on prose about the idleness. *)
-     Otel_metric_store.inc_counter
-       Keeper_metrics.(to_string MemoryOsInertTurnExtractionSkipped)
-       ~labels:[ "keeper", meta.name ]
-       ());
+  submit_librarian_if_enabled ();
   (* Post-turn timing evidence is logged to decisions.jsonl. The keyword
      recall eval that used to ride along here was removed: it was called
      with an empty user message, so it short-circuited to a constant

--- a/lib/keeper/keeper_agent_run_post_turn_memory.mli
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.mli
@@ -35,9 +35,11 @@ val run :
     delegation request artifacts on this post-turn memory lane rather than on
     the decision-record append path.
 
-    The post-turn entrypoint owns Librarian admission. Disabled or invalid
-    configuration does not submit a Librarian unit or read its snapshot.
-    When enabled, [turn_effect_record] admits only [Meaningful_turn]; on
+    The post-turn entrypoint owns Librarian admission and its execution fence.
+    Disabled or invalid configuration does not submit a Librarian unit or read
+    its snapshot. An admitted asynchronous unit re-checks the live setting
+    before snapshot I/O so disabling it while queued remains effective. When
+    enabled, [turn_effect_record] admits only [Meaningful_turn]; on
     [Inert_autonomous_turn] the librarian unit is never submitted, so its
     cadence counter does not advance and an idle stretch spends no extraction
     budget.

--- a/lib/keeper/keeper_agent_run_post_turn_memory.mli
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.mli
@@ -35,7 +35,9 @@ val run :
     delegation request artifacts on this post-turn memory lane rather than on
     the decision-record append path.
 
-    [turn_effect_record] gates only the current-memory Librarian sub-stage. On
+    The post-turn entrypoint owns Librarian admission. Disabled or invalid
+    configuration does not submit a Librarian unit or read its snapshot.
+    When enabled, [turn_effect_record] admits only [Meaningful_turn]; on
     [Inert_autonomous_turn] the librarian unit is never submitted, so its
     cadence counter does not advance and an idle stretch spends no extraction
     budget.

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -8,10 +8,6 @@ let input_trace_id (inp : Keeper_librarian.input) =
   Ids.Turn_ref.trace_id inp.turn_ref
 ;;
 
-let enabled () =
-  Env_config.KeeperMemoryOs.librarian_enabled ()
-;;
-
 let cadence_turns () =
   Env_config.KeeperMemoryOs.librarian_cadence_turns ()
 ;;
@@ -401,7 +397,7 @@ let run_best_effort
       (inp : Keeper_librarian.input)
   =
   let trace_id = input_trace_id inp in
-  if enabled () && cadence_due ~keeper_id ~trace_id
+  if cadence_due ~keeper_id ~trace_id
   then (
     try
       match Eio_context.get_net_opt (), Eio_context.get_clock_opt () with

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -65,5 +65,5 @@ val run_best_effort
   -> expected_revision:int option
   -> Keeper_librarian.input
   -> unit
-(** Execute an already-admitted Librarian unit. The post-turn entrypoint owns
-    the configuration gate before lane submission and snapshot I/O. *)
+(** Execute a Librarian unit already admitted and fenced by the post-turn
+    entrypoint. This runtime owns cadence, not the live configuration gate. *)

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -4,7 +4,6 @@
     validation, one atomic current-snapshot replacement is the only MASC-side
     effect. There is no secondary journal or episode/facts fan-out. *)
 
-val enabled : unit -> bool
 val cadence_turns : unit -> int
 
 val cadence_step : cadence:int -> counter:int -> int * bool

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -65,3 +65,5 @@ val run_best_effort
   -> expected_revision:int option
   -> Keeper_librarian.input
   -> unit
+(** Execute an already-admitted Librarian unit. The post-turn entrypoint owns
+    the configuration gate before lane submission and snapshot I/O. *)

--- a/test/dune
+++ b/test/dune
@@ -126,6 +126,7 @@
   test_sidecar_lifecycle_routes
   test_channel_gate_imessage_state
   test_dashboard
+  test_dashboard_librarian_metric
   test_dashboard_perf
   test_dashboard_tool_host_events
   test_dashboard_nav_event
@@ -424,6 +425,7 @@
   test_sidecar_lifecycle_routes
   test_channel_gate_imessage_state
   test_dashboard
+  test_dashboard_librarian_metric
   test_dashboard_perf
   test_dashboard_tool_host_events
   test_dashboard_nav_event

--- a/test/test_dashboard.ml
+++ b/test/test_dashboard.ml
@@ -238,23 +238,9 @@ let test_generate_compact_shows_exact_librarian_facts () =
         (contains invalid_output "LIBRARIAN: INVALID");
       Unix.putenv key "true";
       let enabled_output = Dashboard.generate_compact config in
-      let failure_metric =
-        Keeper_metrics.(to_string MemoryOsLibrarianFailures)
-      in
-      let failures_since_start =
-        Otel_metric_store.metric_total failure_metric |> int_of_float
-      in
       Alcotest.(check bool)
         "enabled config renders ON" true
-        (contains enabled_output "LIBRARIAN: ON");
-      Alcotest.(check bool)
-        "exact process-lifetime failure total has a numeric boundary"
-        true
-        (contains
-           enabled_output
-           (Printf.sprintf
-              "LIBRARIAN-FAILURES-SINCE-START: %d | GUARD:"
-              failures_since_start)))
+        (contains enabled_output "LIBRARIAN: ON"))
 
 let test_keepers_section_dead_phase () =
   Eio_main.run @@ fun env ->

--- a/test/test_dashboard.ml
+++ b/test/test_dashboard.ml
@@ -203,20 +203,6 @@ let test_generate_compact_contains_keepers () =
   Alcotest.(check bool) "contains KEEPERS line" true (contains output "KEEPERS:");
   cleanup_dir dir
 
-let compact_keeper_line output =
-  output
-  |> String.split_on_char '\n'
-  |> List.find (fun line -> String.starts_with ~prefix:"KEEPERS:" line)
-;;
-
-let tool_error_projection line =
-  let pattern = Str.regexp "TOOL-ERR: [0-9]+" in
-  try
-    ignore (Str.search_forward pattern line 0);
-    Some (Str.matched_string line)
-  with Not_found -> None
-;;
-
 let test_generate_compact_shows_exact_librarian_facts () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -251,36 +237,24 @@ let test_generate_compact_shows_exact_librarian_facts () =
         "invalid config is not collapsed into OFF" true
         (contains invalid_output "LIBRARIAN: INVALID");
       Unix.putenv key "true";
-      let enabled_before = Dashboard.generate_compact config in
-      let tool_error_before =
-        enabled_before |> compact_keeper_line |> tool_error_projection
-      in
+      let enabled_output = Dashboard.generate_compact config in
       let failure_metric =
         Keeper_metrics.(to_string MemoryOsLibrarianFailures)
       in
-      let failures_before =
+      let failures_since_start =
         Otel_metric_store.metric_total failure_metric |> int_of_float
       in
-      Otel_metric_store.inc_counter
-        failure_metric
-        ~labels:[ "keeper", "dashboard-test"; "site", "test" ]
-        ();
-      let enabled_after = Dashboard.generate_compact config in
       Alcotest.(check bool)
         "enabled config renders ON" true
-        (contains enabled_after "LIBRARIAN: ON");
+        (contains enabled_output "LIBRARIAN: ON");
       Alcotest.(check bool)
-        "exact process-lifetime failure total is rendered"
+        "exact process-lifetime failure total has a numeric boundary"
         true
         (contains
-           enabled_after
+           enabled_output
            (Printf.sprintf
-              "LIBRARIAN-FAILURES-SINCE-START: %d"
-              (failures_before + 1)));
-      Alcotest.(check (option string))
-        "librarian failure does not change TOOL-ERR"
-        tool_error_before
-        (enabled_after |> compact_keeper_line |> tool_error_projection))
+              "LIBRARIAN-FAILURES-SINCE-START: %d | GUARD:"
+              failures_since_start)))
 
 let test_keepers_section_dead_phase () =
   Eio_main.run @@ fun env ->
@@ -356,8 +330,6 @@ let keepers_tests = [
   "generate compact contains keepers", `Quick, test_generate_compact_contains_keepers;
   "keepers section dead phase", `Quick, test_keepers_section_dead_phase;
   "keepers section with error truncated", `Quick, test_keepers_section_with_error_truncated;
-  (* This test increments a process-global monotonic metric. Keep it last so
-     no later dashboard assertion observes the deliberate +1. *)
   ( "generate compact shows exact librarian facts"
   , `Quick
   , test_generate_compact_shows_exact_librarian_facts );

--- a/test/test_dashboard.ml
+++ b/test/test_dashboard.ml
@@ -255,14 +255,28 @@ let test_generate_compact_shows_exact_librarian_facts () =
       let tool_error_before =
         enabled_before |> compact_keeper_line |> tool_error_projection
       in
-      Otel_metric_store.inc_counter
+      let failure_metric =
         Keeper_metrics.(to_string MemoryOsLibrarianFailures)
+      in
+      let failures_before =
+        Otel_metric_store.metric_total failure_metric |> int_of_float
+      in
+      Otel_metric_store.inc_counter
+        failure_metric
         ~labels:[ "keeper", "dashboard-test"; "site", "test" ]
         ();
       let enabled_after = Dashboard.generate_compact config in
       Alcotest.(check bool)
         "enabled config renders ON" true
         (contains enabled_after "LIBRARIAN: ON");
+      Alcotest.(check bool)
+        "exact process-lifetime failure total is rendered"
+        true
+        (contains
+           enabled_after
+           (Printf.sprintf
+              "LIBRARIAN-FAILURES-SINCE-START: %d"
+              (failures_before + 1)));
       Alcotest.(check (option string))
         "librarian failure does not change TOOL-ERR"
         tool_error_before
@@ -340,11 +354,13 @@ let keepers_tests = [
   "keepers section with entry", `Quick, test_keepers_section_with_entry;
   "generate full contains keepers", `Quick, test_generate_full_contains_keepers;
   "generate compact contains keepers", `Quick, test_generate_compact_contains_keepers;
+  "keepers section dead phase", `Quick, test_keepers_section_dead_phase;
+  "keepers section with error truncated", `Quick, test_keepers_section_with_error_truncated;
+  (* This test increments a process-global monotonic metric. Keep it last so
+     no later dashboard assertion observes the deliberate +1. *)
   ( "generate compact shows exact librarian facts"
   , `Quick
   , test_generate_compact_shows_exact_librarian_facts );
-  "keepers section dead phase", `Quick, test_keepers_section_dead_phase;
-  "keepers section with error truncated", `Quick, test_keepers_section_with_error_truncated;
 ]
 
 let () =

--- a/test/test_dashboard.ml
+++ b/test/test_dashboard.ml
@@ -68,20 +68,6 @@ let test_format_section_empty () =
   let output = Dashboard.format_section section in
   Alcotest.(check bool) "has empty message" true (contains output "(nothing here)")
 
-let test_format_librarian_status_keeps_facts_separate () =
-  Alcotest.(check string)
-    "disabled"
-    "OFF | LIBRARIAN-FAILURES-TOTAL: 0"
-    (Dashboard.format_librarian_status ~enabled:false ~failures_total:0);
-  Alcotest.(check string)
-    "enabled without failures"
-    "ON | LIBRARIAN-FAILURES-TOTAL: 0"
-    (Dashboard.format_librarian_status ~enabled:true ~failures_total:0);
-  Alcotest.(check string)
-    "cumulative failures do not become current health"
-    "ON | LIBRARIAN-FAILURES-TOTAL: 3"
-    (Dashboard.format_librarian_status ~enabled:true ~failures_total:3)
-
 (* ===== parse_iso_timestamp Tests ===== *)
 
 let test_parse_timestamp_valid () =
@@ -217,7 +203,21 @@ let test_generate_compact_contains_keepers () =
   Alcotest.(check bool) "contains KEEPERS line" true (contains output "KEEPERS:");
   cleanup_dir dir
 
-let test_generate_compact_shows_librarian_off_when_disabled () =
+let compact_keeper_line output =
+  output
+  |> String.split_on_char '\n'
+  |> List.find (fun line -> String.starts_with ~prefix:"KEEPERS:" line)
+;;
+
+let tool_error_projection line =
+  let pattern = Str.regexp "TOOL-ERR: [0-9]+" in
+  try
+    ignore (Str.search_forward pattern line 0);
+    Some (Str.matched_string line)
+  with Not_found -> None
+;;
+
+let test_generate_compact_shows_exact_librarian_facts () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = test_dir () in
@@ -233,12 +233,40 @@ let test_generate_compact_shows_librarian_off_when_disabled () =
       cleanup_dir dir)
     (fun () ->
       Unix.putenv key "false";
-      let output = Dashboard.generate_compact config in
+      let disabled_output = Dashboard.generate_compact config in
       Alcotest.(check bool)
-        "contains LIBRARIAN marker" true (contains output "LIBRARIAN:");
+        "contains LIBRARIAN marker" true (contains disabled_output "LIBRARIAN:");
       Alcotest.(check bool)
         "disabled librarian renders OFF" true
-        (contains output "LIBRARIAN: OFF"))
+        (contains disabled_output "LIBRARIAN: OFF");
+      Alcotest.(check bool)
+        "failure counter names process lifetime" true
+        (contains disabled_output "LIBRARIAN-FAILURES-SINCE-START:");
+      Alcotest.(check bool)
+        "retired total label is absent" false
+        (contains disabled_output "LIBRARIAN-FAILURES-TOTAL:");
+      Unix.putenv key "invalid";
+      let invalid_output = Dashboard.generate_compact config in
+      Alcotest.(check bool)
+        "invalid config is not collapsed into OFF" true
+        (contains invalid_output "LIBRARIAN: INVALID");
+      Unix.putenv key "true";
+      let enabled_before = Dashboard.generate_compact config in
+      let tool_error_before =
+        enabled_before |> compact_keeper_line |> tool_error_projection
+      in
+      Otel_metric_store.inc_counter
+        Keeper_metrics.(to_string MemoryOsLibrarianFailures)
+        ~labels:[ "keeper", "dashboard-test"; "site", "test" ]
+        ();
+      let enabled_after = Dashboard.generate_compact config in
+      Alcotest.(check bool)
+        "enabled config renders ON" true
+        (contains enabled_after "LIBRARIAN: ON");
+      Alcotest.(check (option string))
+        "librarian failure does not change TOOL-ERR"
+        tool_error_before
+        (enabled_after |> compact_keeper_line |> tool_error_projection))
 
 let test_keepers_section_dead_phase () =
   Eio_main.run @@ fun env ->
@@ -289,9 +317,6 @@ let test_keepers_section_with_error_truncated () =
 let format_tests = [
   "format_section with content", `Quick, test_format_section;
   "format_section empty", `Quick, test_format_section_empty;
-  ( "format librarian status keeps facts separate"
-  , `Quick
-  , test_format_librarian_status_keeps_facts_separate );
 ]
 
 let timestamp_tests = [
@@ -315,9 +340,9 @@ let keepers_tests = [
   "keepers section with entry", `Quick, test_keepers_section_with_entry;
   "generate full contains keepers", `Quick, test_generate_full_contains_keepers;
   "generate compact contains keepers", `Quick, test_generate_compact_contains_keepers;
-  ( "generate compact shows librarian off when disabled"
+  ( "generate compact shows exact librarian facts"
   , `Quick
-  , test_generate_compact_shows_librarian_off_when_disabled );
+  , test_generate_compact_shows_exact_librarian_facts );
   "keepers section dead phase", `Quick, test_keepers_section_dead_phase;
   "keepers section with error truncated", `Quick, test_keepers_section_with_error_truncated;
 ]

--- a/test/test_dashboard_librarian_metric.ml
+++ b/test/test_dashboard_librarian_metric.ml
@@ -1,0 +1,69 @@
+(** Dedicated-process regression for the compact Librarian failure counter.
+
+    This executable owns its metric store lifetime, so it can exercise a
+    non-zero process-global counter without contaminating another test. *)
+
+let contains text fragment =
+  try
+    ignore (Str.search_forward (Str.regexp_string fragment) text 0);
+    true
+  with Not_found -> false
+;;
+
+let temp_dir () =
+  let path = Filename.temp_file "dashboard-librarian-metric-" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  path
+;;
+
+let rec remove_tree path =
+  if Sys.file_exists path
+  then if Sys.is_directory path
+    then (
+      Sys.readdir path
+      |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path)
+    else Sys.remove path
+;;
+
+let test_nonzero_failure_total_is_rendered_exactly () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let root = temp_dir () in
+  let config = Masc.Workspace.default_config root in
+  Fun.protect
+    ~finally:(fun () -> remove_tree root)
+    (fun () ->
+      ignore (Masc.Workspace.init config ~agent_name:None);
+      let metric =
+        Keeper_metrics.(to_string MemoryOsLibrarianFailures)
+      in
+      let before = Masc.Otel_metric_store.metric_total metric |> int_of_float in
+      Masc.Otel_metric_store.inc_counter
+        metric
+        ~labels:[ "keeper", "dedicated-dashboard-test"; "site", "test" ]
+        ();
+      let expected = before + 1 in
+      let output = Dashboard.generate_compact config in
+      Alcotest.(check bool)
+        "non-zero counter has an exact numeric boundary"
+        true
+        (contains
+           output
+           (Printf.sprintf
+              "LIBRARIAN-FAILURES-SINCE-START: %d | GUARD:"
+              expected)))
+;;
+
+let () =
+  Alcotest.run
+    "dashboard_librarian_metric"
+    [ ( "compact"
+      , [ Alcotest.test_case
+            "non-zero failure total is exact"
+            `Quick
+            test_nonzero_failure_total_is_rendered_exactly
+        ] )
+    ]
+;;

--- a/test/test_keeper_memory_lane.ml
+++ b/test/test_keeper_memory_lane.ml
@@ -430,7 +430,7 @@ let test_post_turn_librarian_live_config_boundaries () =
         run_post_turn ~config ~meta ~turn;
         match
           Lane.For_testing.pending
-            ~base_path:config.Workspace.base_path
+            ~base_path:config.base_path
             ~keeper_name
             ~lane:Lane.Librarian
         with
@@ -451,7 +451,7 @@ let test_post_turn_librarian_live_config_boundaries () =
         let meta = make_meta keeper_name in
         let keepers_dir =
           Config_dir_resolver.keepers_dir_for_base_path
-            ~base_path:config.Workspace.base_path
+            ~base_path:config.base_path
         in
         if poison_snapshot
         then
@@ -463,7 +463,7 @@ let test_post_turn_librarian_live_config_boundaries () =
         let release, set_release = Eio.Promise.create () in
         let blocker =
           Lane.submit
-            ~base_path:config.Workspace.base_path
+            ~base_path:config.base_path
             ~keeper_name
             ~lane:Lane.Librarian
             (fun () ->
@@ -480,7 +480,7 @@ let test_post_turn_librarian_live_config_boundaries () =
           "one running plus one queued Librarian unit"
           (Some 2)
           (Lane.For_testing.pending
-             ~base_path:config.Workspace.base_path
+             ~base_path:config.base_path
              ~keeper_name
              ~lane:Lane.Librarian);
         Unix.putenv env_key terminal_value;

--- a/test/test_keeper_memory_lane.ml
+++ b/test/test_keeper_memory_lane.ml
@@ -5,11 +5,59 @@
     leak-safe on a raising unit. *)
 
 module Lane = Masc.Keeper_memory_lane
+module Librarian_runtime = Masc.Keeper_librarian_runtime
+module Memory_current = Masc.Keeper_memory_os_current
+module Post_turn_memory = Masc.Keeper_agent_run_post_turn_memory
 
 exception Test_boom
 exception Cancel_lane_test
 
 let base_path = Filename.concat (Filename.get_temp_dir_name ()) "test-memory-lane"
+
+let temp_dir prefix =
+  let path = Filename.temp_file prefix "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  path
+;;
+
+let rec remove_tree path =
+  if Sys.file_exists path
+  then if Sys.is_directory path
+    then (
+      Sys.readdir path
+      |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path)
+    else Sys.remove path
+;;
+
+let make_meta name : Masc.Keeper_meta_contract.keeper_meta =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+         [ "name", `String name
+         ; "agent_name", `String name
+         ; "trace_id", `String ("trace-" ^ name)
+         ])
+  with
+  | Ok meta -> meta
+  | Error detail -> Alcotest.failf "keeper meta fixture failed: %s" detail
+;;
+
+let run_post_turn ~config ~meta ~turn =
+  Post_turn_memory.run
+    ~config
+    ~meta
+    ~generation:turn
+    ~turn
+    ~oas_turn_count:1
+    ~actual_tools:[]
+    ~librarian_messages:[]
+    ~turn_effect_record:Masc.Keeper_run_prompt.Meaningful_turn
+    ~post_turn_t0:(Time_compat.now ())
+    ~inference_telemetry:None
+    ()
+;;
 
 (* No executor switch set -> submit runs inline so no work is lost. *)
 let test_inline_when_uninitialized () =
@@ -343,6 +391,137 @@ let test_finished_switch_drops_without_leak () =
   | None -> Alcotest.fail "keeper entry missing after finished switch submit"
 ;;
 
+(* The Librarian setting is live while lane work is asynchronous. The
+   post-turn entrypoint must reject OFF/INVALID before submission, then fence
+   an already queued ON unit again before snapshot I/O when the setting changes
+   while it waits behind an in-flight unit. *)
+let test_post_turn_librarian_live_config_boundaries () =
+  Lane.For_testing.reset ();
+  let root = temp_dir "test-post-turn-librarian-gate-" in
+  let env_key = Env_config.KeeperMemoryOs.librarian_env_key in
+  let previous_env = Sys.getenv_opt env_key in
+  Fun.protect
+    ~finally:(fun () ->
+      (match previous_env with
+       | Some value -> Unix.putenv env_key value
+       | None -> Unix.putenv env_key "");
+      Config_dir_resolver.reset ();
+      Lane.For_testing.reset ();
+      remove_tree root)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      Eio.Switch.run @@ fun sw ->
+      Masc_test_deps.init_eio_clock ~sw env;
+      Lane.init ~sw;
+      let config = Masc.Workspace.default_config root in
+      ignore (Masc.Workspace.init config ~agent_name:None);
+      Config_dir_resolver.reset ();
+      let failure_metric =
+        Keeper_metrics.(to_string MemoryOsLibrarianFailures)
+      in
+      let failures_before =
+        Masc.Otel_metric_store.metric_total failure_metric |> int_of_float
+      in
+      let cadence_entries_before =
+        Librarian_runtime.cadence_counter_entries ()
+      in
+      let expect_no_admission ~value ~keeper_name ~turn =
+        Unix.putenv env_key value;
+        let meta = make_meta keeper_name in
+        run_post_turn ~config ~meta ~turn;
+        match
+          Lane.For_testing.pending
+            ~base_path:config.Workspace.base_path
+            ~keeper_name
+            ~lane:Lane.Librarian
+        with
+        | None -> ()
+        | Some pending ->
+          Alcotest.failf
+            "config=%s created Librarian lane pending=%d"
+            value
+            pending
+      in
+      expect_no_admission ~value:"false" ~keeper_name:"gateoff" ~turn:1;
+      expect_no_admission ~value:"invalid" ~keeper_name:"gateinvalid" ~turn:2;
+      let rec await_librarian_idle ~keeper_name remaining =
+        match
+          Lane.For_testing.pending
+            ~base_path:config.Workspace.base_path
+            ~keeper_name
+            ~lane:Lane.Librarian
+        with
+        | Some 0 -> ()
+        | _ when remaining > 0 ->
+          Eio.Fiber.yield ();
+          await_librarian_idle ~keeper_name (remaining - 1)
+        | Some pending ->
+          Alcotest.failf
+            "queued Librarian unit did not drain, pending=%d"
+            pending
+        | None -> Alcotest.fail "queued Librarian lane disappeared"
+      in
+      let expect_queued_fence ~poison_snapshot ~terminal_value ~keeper_name ~turn =
+        let meta = make_meta keeper_name in
+        let keepers_dir =
+          Config_dir_resolver.keepers_dir_for_base_path
+            ~base_path:config.Workspace.base_path
+        in
+        if poison_snapshot
+        then
+          Unix.mkdir
+            (Memory_current.path_for_keepers_dir ~keepers_dir ~keeper_id:keeper_name)
+            0o755;
+        Unix.putenv env_key "true";
+        let started, set_started = Eio.Promise.create () in
+        let release, set_release = Eio.Promise.create () in
+        let blocker =
+          Lane.submit
+            ~base_path:config.Workspace.base_path
+            ~keeper_name
+            ~lane:Lane.Librarian
+            (fun () ->
+               Eio.Promise.resolve set_started ();
+               Eio.Promise.await release)
+        in
+        (match blocker with
+         | Lane.Submitted -> ()
+         | Lane.Coalesced | Lane.Ran_inline | Lane.Dropped ->
+           Alcotest.fail "Librarian blocker was not submitted");
+        Eio.Promise.await started;
+        run_post_turn ~config ~meta ~turn;
+        Alcotest.(check (option int))
+          "one running plus one queued Librarian unit"
+          (Some 2)
+          (Lane.For_testing.pending
+             ~base_path:config.Workspace.base_path
+             ~keeper_name
+             ~lane:Lane.Librarian);
+        Unix.putenv env_key terminal_value;
+        Eio.Promise.resolve set_release ();
+        await_librarian_idle ~keeper_name 100
+      in
+      expect_queued_fence
+        ~poison_snapshot:true
+        ~terminal_value:"false"
+        ~keeper_name:"queuedoff"
+        ~turn:3;
+      expect_queued_fence
+        ~poison_snapshot:false
+        ~terminal_value:"invalid"
+        ~keeper_name:"queuedinvalid"
+        ~turn:4;
+      Alcotest.(check int)
+        "fenced work did not read invalid snapshots or emit failures"
+        failures_before
+        (Masc.Otel_metric_store.metric_total failure_metric |> int_of_float);
+      Alcotest.(check int)
+        "fenced work did not advance Librarian cadence"
+        cadence_entries_before
+        (Librarian_runtime.cadence_counter_entries ()))
+;;
+
 let () =
   Alcotest.run
     "keeper_memory_lane"
@@ -381,6 +560,10 @@ let () =
             "finished switch drops without leak"
             `Quick
             test_finished_switch_drops_without_leak
+        ; Alcotest.test_case
+            "post-turn Librarian live config boundaries"
+            `Quick
+            test_post_turn_librarian_live_config_boundaries
         ] )
     ]
 ;;

--- a/test/test_keeper_memory_lane.ml
+++ b/test/test_keeper_memory_lane.ml
@@ -411,9 +411,7 @@ let test_post_turn_librarian_live_config_boundaries () =
     (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
-      Eio.Switch.run @@ fun sw ->
-      Masc_test_deps.init_eio_clock ~sw env;
-      Lane.init ~sw;
+      Masc_test_deps.init_eio_clock env;
       let config = Masc.Workspace.default_config root in
       ignore (Masc.Workspace.init config ~agent_name:None);
       Config_dir_resolver.reset ();
@@ -445,24 +443,11 @@ let test_post_turn_librarian_live_config_boundaries () =
       in
       expect_no_admission ~value:"false" ~keeper_name:"gateoff" ~turn:1;
       expect_no_admission ~value:"invalid" ~keeper_name:"gateinvalid" ~turn:2;
-      let rec await_librarian_idle ~keeper_name remaining =
-        match
-          Lane.For_testing.pending
-            ~base_path:config.Workspace.base_path
-            ~keeper_name
-            ~lane:Lane.Librarian
-        with
-        | Some 0 -> ()
-        | _ when remaining > 0 ->
-          Eio.Fiber.yield ();
-          await_librarian_idle ~keeper_name (remaining - 1)
-        | Some pending ->
-          Alcotest.failf
-            "queued Librarian unit did not drain, pending=%d"
-            pending
-        | None -> Alcotest.fail "queued Librarian lane disappeared"
-      in
       let expect_queued_fence ~poison_snapshot ~terminal_value ~keeper_name ~turn =
+        Lane.For_testing.reset ();
+        Eio.Switch.run @@ fun sw ->
+        Masc_test_deps.init_eio_clock ~sw env;
+        Lane.init ~sw;
         let meta = make_meta keeper_name in
         let keepers_dir =
           Config_dir_resolver.keepers_dir_for_base_path
@@ -499,8 +484,7 @@ let test_post_turn_librarian_live_config_boundaries () =
              ~keeper_name
              ~lane:Lane.Librarian);
         Unix.putenv env_key terminal_value;
-        Eio.Promise.resolve set_release ();
-        await_librarian_idle ~keeper_name 100
+        Eio.Promise.resolve set_release ()
       in
       expect_queued_fence
         ~poison_snapshot:true


### PR DESCRIPTION
## 배경

#26514가 `a8d30272e8`에서 남은 P2를 해소하지 않은 채 머지됐어용. compact 표면과 실제 post-turn 진입점의 Librarian 계약을 함께 바로잡아용.

## 변경

- `KeeperMemoryOs`가 `Enabled | Disabled | Invalid` typed 설정 상태를 소유해용.
- post-turn 진입점이 설정 Gate를 소유해 OFF/INVALID에는 lane 제출, snapshot I/O, cadence, failure metric이 없도록 했어용.
- 비동기 대기 중 live 설정이 ON→OFF/INVALID로 바뀌어도 실행 직전 fence가 snapshot/provider 작업을 막아용.
- runtime 내부 중복 bool Gate를 제거하고 cadence만 판단하게 했어용.
- 표기를 `LIBRARIAN-FAILURES-SINCE-START`로 고쳐 process-lifetime counter임을 명시해용.
- dashboard private formatter를 public `.mli`에서 제거했어용.
- 실제 `generate_compact`에서 ON/OFF/INVALID와 퇴역 이름 부재를 검증해용.
- 전용 테스트 프로세스에서 non-zero failure counter와 숫자 경계를 포함한 exact projection을 검증해용.
- 실제 post-turn entrypoint/lane에서 OFF/INVALID 무제출과 queued ON→OFF/INVALID의 snapshot I/O·cadence·failure 무변경을 검증하고, switch child completion으로 대기해용.

## 검증

- `ocamlformat --check` 통과
- `git diff --check` 통과
- 로컬 Dune은 실행하지 않았고 build/test 권위는 CI예용.

대상 커밋: `49d9211799`
연계: #26514
