### PR TITLE
fix(server): unify JSONL prune SSOT and cover unbounded stores

### DIFF
--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -670,35 +670,15 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
                  0
              in
              let total =
-               prune_dir (Filename.concat masc "audit")
-               + prune_dir (Filename.concat masc "telemetry")
-               + prune_dir (Filename.concat masc "messages")
-               + prune_dir (Filename.concat masc "events")
-               + prune_dir (Filename.concat masc "activity-events")
-               + prune_recall_injections ()
-               + prune_dir (Filename.concat masc "voice_sessions")
-               + prune_dir (Filename.concat masc "tool_calls")
-               (* transition-audit was absent from this list since its
-                  introduction (RFC-0002) — 82 MB across 3 month-dirs by
-                  2026-06-10, scanned by every store-fallback read. *)
-               + prune_dir (Filename.concat masc "transition-audit")
-               (* trajectories: flat <trace_id>.jsonl under
-                  trajectories/<keeper>/ — Dated_jsonl.prune is a no-op
-                  there, so prune by mtime, keeper-scoped. *)
-               + Server_runtime_startup_maintenance.prune_children_dirs
-                   ~prune_dir:
-                     (Server_runtime_startup_maintenance
-                      .prune_flat_jsonl_older_than ~days)
-                   (Filename.concat masc "trajectories")
-               (* Keeper-scoped stores (metrics, crash-events,
-                  execution-receipts) live only under keepers/<name>/ — no
-                  top-level writer exists, so prune keeper-scoped only. The
-                  store list is the SSOT shared with the startup pass; the
-                  inline execution-receipts-only fold this replaced had
-                  already drifted, letting metrics/crash-events accumulate
-                  until restart. *)
-               + Server_runtime_startup_maintenance.prune_keeper_scoped_stores
+               prune_recall_injections ()
+               (* Store list and fold are the SSOT in
+                  Server_runtime_startup_maintenance — the two inline sums
+                  this replaces had already drifted (this pass lacked
+                  resilience_audit; the startup pass lacked
+                  tool_calls/transition-audit). *)
+               + Server_runtime_startup_maintenance.prune_shared_jsonl_stores
                    ~prune_dir
+                   ~days
                    ~masc_root:masc
              in
              if total > 0

--- a/lib/server/server_runtime_startup_maintenance.ml
+++ b/lib/server/server_runtime_startup_maintenance.ml
@@ -23,8 +23,12 @@ let prune_children_dirs ~prune_dir root =
    24h periodic pass. SSOT: both loops fold this exact list via
    [prune_keeper_scoped_stores] — never reintroduce an inline store list in
    either caller (the periodic pass once pruned only execution-receipts,
-   letting metrics/crash-events accumulate until restart). *)
-let keeper_scoped_dated_stores = [ "metrics"; "crash-events"; "execution-receipts" ]
+   letting metrics/crash-events accumulate until restart).
+   turn-records joined 2026-07-31: same [keepers/<name>/<store>/YYYY-MM/DD.jsonl]
+   layout, but absent from every prune list since introduction — ~4 MB/day
+   fleet-wide with no bound. *)
+let keeper_scoped_dated_stores =
+  [ "metrics"; "crash-events"; "execution-receipts"; "turn-records" ]
 
 (* Fold [prune_dir] over every keeper-scoped dated store
    ([keepers/<name>/<store>] for each store in [keeper_scoped_dated_stores]).
@@ -38,6 +42,21 @@ let prune_keeper_scoped_stores ~prune_dir ~masc_root =
         0
         keeper_scoped_dated_stores)
     (Filename.concat masc_root "keepers")
+
+(* A flat-store file is [<name>.jsonl] or a numeric rotation sibling
+   [<name>.jsonl.<n>] (runtime-manifests rotate whole files to [.jsonl.1],
+   which a plain [.jsonl] suffix check would keep forever). Any other
+   extension is never removed. *)
+let is_flat_jsonl_file name =
+  Filename.check_suffix name ".jsonl"
+  ||
+  match String.rindex_opt name '.' with
+  | None -> false
+  | Some dot ->
+    let rot = String.sub name (dot + 1) (String.length name - dot - 1) in
+    rot <> ""
+    && String.for_all (fun c -> c >= '0' && c <= '9') rot
+    && Filename.check_suffix (String.sub name 0 dot) ".jsonl"
 
 (* Trajectory stores are flat [<trace_id>.jsonl] files under
    [trajectories/<keeper>/] — no [YYYY-MM] month dirs — so
@@ -53,7 +72,7 @@ let prune_flat_jsonl_older_than ~days dir =
     in
     Array.fold_left
       (fun acc name ->
-        if Filename.check_suffix name ".jsonl"
+        if is_flat_jsonl_file name
         then
           let path = Filename.concat dir name in
           match (try Some (Unix.stat path) with Unix.Unix_error _ -> None) with
@@ -67,6 +86,66 @@ let prune_flat_jsonl_older_than ~days dir =
         else acc)
       0
       (Sys.readdir dir)
+
+(* Keeper-scoped flat-JSONL stores ([keepers/<name>/<store>] holding
+   [<id>.jsonl] files plus numeric rotation siblings, no month dirs).
+   Pruned by mtime via [prune_flat_jsonl_older_than] in BOTH passes.
+   SSOT like [keeper_scoped_dated_stores]. Both stores had no retention
+   since introduction (raw-traces: one file per turn; runtime-manifests:
+   one rotated JSONL per trace). *)
+let keeper_scoped_flat_stores = [ "raw-traces"; "runtime-manifests" ]
+
+let prune_keeper_scoped_flat_stores ~days ~masc_root =
+  prune_children_dirs
+    ~prune_dir:(fun keeper_dir ->
+      List.fold_left
+        (fun acc store ->
+          acc + prune_flat_jsonl_older_than ~days (Filename.concat keeper_dir store))
+        0
+        keeper_scoped_flat_stores)
+    (Filename.concat masc_root "keepers")
+
+(* Top-level dated-JSONL stores under the masc root pruned by BOTH the
+   startup pass and the 24h periodic pass. SSOT: replaces the two inline
+   sums that had already drifted apart — the startup pass lacked
+   tool_calls/transition-audit while the periodic pass lacked
+   resilience_audit. recall_injections keeps its typed ledger pruner and
+   data/tool-metrics stays startup-only (it lives under base_path, not the
+   masc root); both remain at the callers.
+   oas-events joined 2026-07-31: 434 MB accumulated with no retention. *)
+let top_level_dated_stores =
+  [ "audit"
+  ; "telemetry"
+  ; "messages"
+  ; "events"
+  ; "activity-events"
+  ; "voice_sessions"
+  ; "tool_calls"
+  ; "transition-audit"
+  ; "oas-events"
+  ]
+
+(* Single shared fold over every retention-covered JSONL store. Both the
+   startup pass and the 24h periodic pass call exactly this function, so
+   the covered-store set cannot drift between them again. [prune_dir] is
+   the caller's dated pruner (Dated_jsonl-based in production). *)
+let prune_shared_jsonl_stores ~prune_dir ~days ~masc_root =
+  List.fold_left
+    (fun acc store -> acc + prune_dir (Filename.concat masc_root store))
+    0
+    top_level_dated_stores
+  (* logs/: flat [system_log_YYYY-MM-DD.jsonl] day files (406 MB by
+     2026-07-31, single day up to 180 MB). The active day file keeps a
+     fresh mtime, so only closed day files age out. *)
+  + prune_flat_jsonl_older_than ~days (Filename.concat masc_root "logs")
+  (* trajectories: flat <trace_id>.jsonl under trajectories/<keeper>/ —
+     Dated_jsonl.prune is a no-op there, prune by mtime keeper-scoped. *)
+  + prune_children_dirs
+      ~prune_dir:(prune_flat_jsonl_older_than ~days)
+      (Filename.concat masc_root "trajectories")
+  + prune_children_dirs ~prune_dir (Filename.concat masc_root "resilience_audit")
+  + prune_keeper_scoped_stores ~prune_dir ~masc_root
+  + prune_keeper_scoped_flat_stores ~days ~masc_root
 
 let startup_prune_jsonl (state : Mcp_server.server_state) =
   (try
@@ -96,24 +175,9 @@ let startup_prune_jsonl (state : Mcp_server.server_state) =
        Filename.concat (Mcp_server.workspace_config state).base_path "data/tool-metrics"
      in
      let total =
-       prune_dir (Filename.concat masc "audit")
-       + prune_dir (Filename.concat masc "telemetry")
-       + prune_dir tool_metrics_dir
-       + prune_dir (Filename.concat masc "messages")
-       + prune_dir (Filename.concat masc "events")
-       + prune_dir (Filename.concat masc "activity-events")
+       prune_dir tool_metrics_dir
        + prune_recall_injections ()
-       + prune_dir (Filename.concat masc "voice_sessions")
-       (* trajectories: flat <trace_id>.jsonl under trajectories/<keeper>/ —
-          Dated_jsonl.prune is a no-op there, prune by mtime keeper-scoped. *)
-       + prune_children_dirs
-           ~prune_dir:(prune_flat_jsonl_older_than ~days)
-           (Filename.concat masc "trajectories")
-       (* Top-level masc/"execution-receipts" has no writer (canonical layout
-          is keepers/<name>/<store>), so keeper-scoped stores are pruned via
-          the SSOT fold shared with the 24h periodic pass. *)
-       + prune_keeper_scoped_stores ~prune_dir ~masc_root:masc
-       + prune_children_dirs ~prune_dir (Filename.concat masc "resilience_audit")
+       + prune_shared_jsonl_stores ~prune_dir ~days ~masc_root:masc
      in
      if total > 0 then
          Log.Misc.info "startup prune: pruned %d old JSONL day-files (retention=%dd)"

--- a/lib/server/server_runtime_startup_maintenance.mli
+++ b/lib/server/server_runtime_startup_maintenance.mli
@@ -17,11 +17,32 @@ val prune_keeper_scoped_stores :
     Exposed for unit tests. *)
 
 val prune_flat_jsonl_older_than : days:int -> string -> int
-(** Delete regular [*.jsonl] files directly under the given directory whose
-    mtime is older than [days]; returns the number of files removed.
+(** Delete regular [*.jsonl] files — and their numeric rotation siblings
+    [*.jsonl.<n>] — directly under the given directory whose mtime is older
+    than [days]; returns the number of files removed.
     Used for stores with a flat layout (e.g. [trajectories/<keeper>/])
     where [Dated_jsonl.prune] finds no [YYYY-MM] month dirs and is a no-op.
     Exposed for unit tests. *)
+
+val keeper_scoped_flat_stores : string list
+(** Flat-JSONL stores pruned keeper-scoped ([keepers/<name>/<store>]) by
+    mtime in BOTH passes: [raw-traces] (one file per turn) and
+    [runtime-manifests] (one rotated JSONL per trace). SSOT like
+    [keeper_scoped_dated_stores]. *)
+
+val top_level_dated_stores : string list
+(** Top-level dated-JSONL stores under the masc root pruned by BOTH the
+    startup pass and the 24h periodic pass. SSOT for both loops — never
+    reintroduce an inline store list in either caller. *)
+
+val prune_shared_jsonl_stores :
+  prune_dir:(string -> int) -> days:int -> masc_root:string -> int
+(** Prune every shared retention-covered JSONL store in one fold:
+    [top_level_dated_stores], flat [logs/] day files, keeper-scoped
+    trajectories, [resilience_audit], [keeper_scoped_dated_stores] and
+    [keeper_scoped_flat_stores]. Both the startup pass and the 24h periodic
+    pass call exactly this function so the covered-store set cannot drift.
+    Returns the number of files removed. Exposed for unit tests. *)
 
 val startup_prune_jsonl : Mcp_server.server_state -> unit
 

--- a/test/test_server_runtime_startup_maintenance.ml
+++ b/test/test_server_runtime_startup_maintenance.ml
@@ -79,11 +79,112 @@ let record_visit dir =
 let test_keeper_scoped_store_list_is_ssot () =
   (* Drift guard: the 24h periodic pass used to prune execution-receipts
      only while startup pruned all three. Pin the shared list so neither
-     loop can silently drop a store again. *)
+     loop can silently drop a store again. turn-records joined 2026-07-31. *)
   Alcotest.(check (list string))
-    "keeper-scoped stores = metrics + crash-events + execution-receipts"
-    [ "crash-events"; "execution-receipts"; "metrics" ]
+    "keeper-scoped stores = metrics + crash-events + execution-receipts + turn-records"
+    [ "crash-events"; "execution-receipts"; "metrics"; "turn-records" ]
     (List.sort String.compare SM.keeper_scoped_dated_stores)
+
+let test_top_level_store_list_is_ssot () =
+  (* Drift guard for the top-level list: the startup and periodic passes
+     kept separate inline sums that drifted (startup lacked
+     tool_calls/transition-audit). Pin the shared list. *)
+  Alcotest.(check (list string))
+    "top-level dated stores pinned"
+    [ "activity-events"
+    ; "audit"
+    ; "events"
+    ; "messages"
+    ; "oas-events"
+    ; "telemetry"
+    ; "tool_calls"
+    ; "transition-audit"
+    ; "voice_sessions"
+    ]
+    (List.sort String.compare SM.top_level_dated_stores)
+
+let test_keeper_scoped_flat_store_list_is_ssot () =
+  Alcotest.(check (list string))
+    "keeper-scoped flat stores = raw-traces + runtime-manifests"
+    [ "raw-traces"; "runtime-manifests" ]
+    (List.sort String.compare SM.keeper_scoped_flat_stores)
+
+let test_prune_flat_jsonl_rotation_siblings () =
+  (* runtime-manifests rotate whole files to <trace>.jsonl.1 — a plain
+     .jsonl suffix check would keep rotation siblings forever. Non-numeric
+     trailing extensions must never be removed. *)
+  let root = fresh_dir "masc_prune_flat_rot" in
+  let write path =
+    let oc = open_out path in
+    output_string oc "{}\n";
+    close_out oc
+  in
+  let old_ts = Unix.gettimeofday () -. (40. *. 86400.) in
+  let old_rotated = Filename.concat root "trace-x.jsonl.1" in
+  let old_plain = Filename.concat root "trace-y.jsonl" in
+  let old_non_numeric = Filename.concat root "trace-z.jsonl.bak" in
+  let fresh_rotated = Filename.concat root "trace-w.jsonl.2" in
+  write old_rotated;
+  write old_plain;
+  write old_non_numeric;
+  write fresh_rotated;
+  Unix.utimes old_rotated old_ts old_ts;
+  Unix.utimes old_plain old_ts old_ts;
+  Unix.utimes old_non_numeric old_ts old_ts;
+  let n = SM.prune_flat_jsonl_older_than ~days:30 root in
+  Alcotest.(check int) "old .jsonl and .jsonl.1 pruned" 2 n;
+  Alcotest.(check bool) "old rotation sibling removed" false (Sys.file_exists old_rotated);
+  Alcotest.(check bool) "old plain jsonl removed" false (Sys.file_exists old_plain);
+  Alcotest.(check bool)
+    "non-numeric extension kept" true (Sys.file_exists old_non_numeric);
+  Alcotest.(check bool) "fresh rotation sibling kept" true (Sys.file_exists fresh_rotated)
+
+let test_prune_shared_jsonl_stores_production_geometry () =
+  (* Round-trip on the production masc-root geometry (guard against
+     dual-path derivation no-ops): every covered store gets one stale file
+     and, where meaningful, one fresh sibling. prune_dir is the same
+     Dated_jsonl-based closure both production passes build. *)
+  let masc_root = fresh_dir "masc_shared_prune" in
+  let write path =
+    Fs_compat.mkdir_p (Filename.dirname path);
+    let oc = open_out path in
+    output_string oc "{}\n";
+    close_out oc
+  in
+  let old_ts = Unix.gettimeofday () -. (40. *. 86400.) in
+  let p segs = List.fold_left Filename.concat masc_root segs in
+  (* top-level dated store: stale by filename month, fresh by future month *)
+  let oas_old = p [ "oas-events"; "2020-01"; "01.jsonl" ] in
+  let oas_fresh = p [ "oas-events"; "2999-01"; "01.jsonl" ] in
+  (* logs: flat day files, stale by mtime *)
+  let logs_old = p [ "logs"; "system_log_2020-01-01.jsonl" ] in
+  let logs_fresh = p [ "logs"; "system_log_2999-01-01.jsonl" ] in
+  (* keeper-scoped dated store *)
+  let turn_old = p [ "keepers"; "keeper-a"; "turn-records"; "2020-01"; "01.jsonl" ] in
+  (* keeper-scoped flat stores *)
+  let raw_old = p [ "keepers"; "keeper-a"; "raw-traces"; "turn-old.jsonl" ] in
+  let manifest_old = p [ "keepers"; "keeper-a"; "runtime-manifests"; "trace-x.jsonl.1" ] in
+  let manifest_fresh = p [ "keepers"; "keeper-a"; "runtime-manifests"; "trace-x.jsonl" ] in
+  List.iter
+    write
+    [ oas_old; oas_fresh; logs_old; logs_fresh; turn_old; raw_old; manifest_old; manifest_fresh ];
+  List.iter (fun f -> Unix.utimes f old_ts old_ts) [ logs_old; raw_old; manifest_old ];
+  let prune_dir dir =
+    if Sys.file_exists dir
+    then Dated_jsonl.prune (Dated_jsonl.create ~base_dir:dir ()) ~days:30
+    else 0
+  in
+  let n = SM.prune_shared_jsonl_stores ~prune_dir ~days:30 ~masc_root in
+  Alcotest.(check int) "five stale files pruned" 5 n;
+  Alcotest.(check bool) "stale oas-events day removed" false (Sys.file_exists oas_old);
+  Alcotest.(check bool) "future oas-events day kept" true (Sys.file_exists oas_fresh);
+  Alcotest.(check bool) "stale log day removed" false (Sys.file_exists logs_old);
+  Alcotest.(check bool) "fresh log day kept" true (Sys.file_exists logs_fresh);
+  Alcotest.(check bool) "stale turn-records day removed" false (Sys.file_exists turn_old);
+  Alcotest.(check bool) "stale raw-trace removed" false (Sys.file_exists raw_old);
+  Alcotest.(check bool)
+    "stale manifest rotation removed" false (Sys.file_exists manifest_old);
+  Alcotest.(check bool) "fresh manifest kept" true (Sys.file_exists manifest_fresh)
 
 let test_prune_keeper_scoped_stores_visits_all_stores () =
   (* Regression for the 24h loop drift: both loops call this function, so
@@ -109,7 +210,7 @@ let test_prune_keeper_scoped_stores_visits_all_stores () =
       [ "keeper-a"; "keeper-b" ]
   in
   Alcotest.(check (list string))
-    "all three stores pruned for every keeper"
+    "every dated store pruned for every keeper"
     (List.sort String.compare expected)
     (List.sort String.compare !visited)
 
@@ -137,14 +238,25 @@ let () =
         [
           Alcotest.test_case "populated trajectories dir prunes old files" `Quick
             test_prune_flat_jsonl_removes_old_files;
+          Alcotest.test_case "numeric rotation siblings prune, others kept" `Quick
+            test_prune_flat_jsonl_rotation_siblings;
         ] );
       ( "prune_keeper_scoped_stores",
         [
-          Alcotest.test_case "store list is SSOT (3 stores)" `Quick
+          Alcotest.test_case "store list is SSOT (4 stores)" `Quick
             test_keeper_scoped_store_list_is_ssot;
-          Alcotest.test_case "visits all three stores per keeper" `Quick
+          Alcotest.test_case "visits every dated store per keeper" `Quick
             test_prune_keeper_scoped_stores_visits_all_stores;
           Alcotest.test_case "missing keepers root counts zero" `Quick
             test_prune_keeper_scoped_stores_missing_root;
+        ] );
+      ( "prune_shared_jsonl_stores",
+        [
+          Alcotest.test_case "top-level store list pinned" `Quick
+            test_top_level_store_list_is_ssot;
+          Alcotest.test_case "keeper-scoped flat store list pinned" `Quick
+            test_keeper_scoped_flat_store_list_is_ssot;
+          Alcotest.test_case "production geometry round-trip" `Quick
+            test_prune_shared_jsonl_stores_production_geometry;
         ] );
     ]


### PR DESCRIPTION
## 목적

JSONL retention prune의 store 목록이 startup pass와 24h periodic pass에 **각각 인라인으로 존재해 이미 drift**한 상태였고(startup에는 tool_calls/transition-audit 누락, periodic에는 resilience_audit 누락), 데이터의 대부분을 차지하는 관측 store들이 **retention 없이 무한 성장** 중이었다. 목록을 SSOT로 추출해 양쪽 pass가 같은 fold를 호출하게 하고, 미커버 store를 편입한다.

실측 근거 (2026-07-31, `~/me/reports/masc-memory-context-audit-20260731.md`):

| store | 크기 | 기존 retention |
|---|---:|---|
| oas-events/ | 434 MB | 없음 |
| logs/ | 406 MB (1일 최대 180 MB) | 없음 |
| keepers/*/turn-records | ~4 MB/day fleet | 없음 |
| keepers/*/raw-traces, runtime-manifests | 성장 중 | 없음 |

## 변경

- `Server_runtime_startup_maintenance`에 `top_level_dated_stores` + `prune_shared_jsonl_stores` 추출 — startup/periodic 양쪽이 **정확히 이 함수 하나**를 호출. 인라인 합산 2곳 제거.
- `keeper_scoped_dated_stores`에 `turn-records` 추가 (동일 dated 레이아웃).
- `keeper_scoped_flat_stores` 신설: `raw-traces`(턴당 1파일), `runtime-manifests`(트레이스당 rotated JSONL) — mtime 기준 prune.
- `prune_flat_jsonl_older_than`이 numeric rotation sibling(`*.jsonl.<n>`)도 제거 — 기존 `.jsonl` suffix 검사로는 rotated manifest가 영구 잔존. 비숫자 확장자는 계속 보존.
- `logs/`는 flat day 파일이라 mtime prune — 활성 당일 파일은 mtime이 계속 갱신되므로 닫힌 날짜 파일만 소멸.

## 제외 (의도적, 사유 명시)

- `tool_blobs/`: content-addressed — 참조 계수 없이 age-out하면 살아있는 레코드가 blob을 잃음. 별도 설계 필요.
- `traces/`: per-trace 디렉토리 레이아웃 — 파일 단위가 아닌 디렉토리 retention 설계 필요.
- `costs/`, `audit-approvals/`, `decision_audit/`, `board_attention_*`: 회계/감사 트레일 성격 — 30d 관측 기본값을 적용할지는 소유자 결정 사항.

## 검증

- `dune build --root . test/test_server_runtime_startup_maintenance.exe` 후 직접 실행: **10 tests, all OK** (신규: SSOT 목록 pin 2건, rotation sibling matcher, production geometry round-trip).
- round-trip 테스트는 프로덕션과 동일한 `Dated_jsonl` 기반 `prune_dir` closure로 masc-root 지오메트리(oas-events dated / logs flat / turn-records keeper-dated / raw-traces·runtime-manifests flat+rotation)를 실제 생성·소거 검증 — dual-path derivation no-op 재발 방지.

## Self-review (Best Programmer 기준)

- 목표: retention 미커버 store 편입 + 목록 drift 구조 제거. 달성.
- 변경 파일: `lib/server/server_runtime_startup_maintenance.{ml,mli}`, `lib/server/server_bootstrap_maintenance.ml`, `test/test_server_runtime_startup_maintenance.ml`.
- 로컬 검증: 위 테스트 10/10. periodic caller는 같은 라이브러리라 test exe 빌드에 포함되어 컴파일 확인됨.
- 미검증: 라이브 24h tick에서의 실제 소거량(다음 tick 로그 `periodic JSONL prune: pruned N day-files`로 확인 예정). `MASC_JSONL_RETENTION_DAYS` 기본 30d 외 값은 기존 계약 그대로.

## 리스크

- 소거는 기존과 동일한 두 helper(`Dated_jsonl.prune`, mtime flat prune)만 사용 — 새 삭제 메커니즘 없음.
- 첫 적용 시 oas-events/logs에서 30d 초과분 대량 소거(즉시 ~800 MB 회수 예상)가 한 번 발생 — 이는 의도된 동작.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
