### PR TITLE
fix(keeper): librarian 실패의 per-slot 오류 노출 + 굶주림 error 승격

### DIFF
--- a/dashboard/src/api/dashboard-misc.test.ts
+++ b/dashboard/src/api/dashboard-misc.test.ts
@@ -20,7 +20,9 @@ function keeperMemoryHealthPayload() {
       snapshot_bytes: 512,
       added: 1,
       removed: 2,
+      snapshot_present: true,
       librarian_lane_busy: 0,
+      librarian_failures: 0,
       read_error: null,
       alerts: [],
     }, {
@@ -30,7 +32,9 @@ function keeperMemoryHealthPayload() {
       snapshot_bytes: 32,
       added: 0,
       removed: 0,
+      snapshot_present: false,
       librarian_lane_busy: 0,
+      librarian_failures: 0,
       read_error: 'invalid current snapshot',
       alerts: [{
         code: 'snapshot_read_error',
@@ -48,14 +52,64 @@ function keeperMemoryHealthPayload() {
       added: 1,
       removed: 2,
       librarian_lane_busy: 0,
+      librarian_failures: 0,
       read_errors: 1,
     },
     alert_summary: {
       total_alerts: 1,
       warn_alerts: 1,
+      error_alerts: 0,
       keepers_with_alerts: 1,
       snapshot_read_error_keepers: 1,
       librarian_lane_busy_keepers: 0,
+      librarian_starving_keepers: 0,
+    },
+  }
+}
+
+function starvingKeeperPayload() {
+  return {
+    schema: 'keeper.memory_os.current_health.v1',
+    generated_at: 1_700_000_000,
+    cadence_counter_entries: 1,
+    keepers: [{
+      keeper_id: 'starving',
+      revision: 0,
+      facts: 0,
+      snapshot_bytes: 0,
+      added: 0,
+      removed: 0,
+      snapshot_present: false,
+      librarian_lane_busy: 0,
+      librarian_failures: 4,
+      read_error: null,
+      alerts: [{
+        code: 'librarian_starvation',
+        severity: 'error',
+        target: 'librarian_starvation',
+        label: 'Librarian',
+        message: 'Librarian runs failed and no current-memory snapshot exists',
+        value: 4,
+        threshold: 0,
+      }],
+    }],
+    totals: {
+      facts: 0,
+      snapshot_bytes: 0,
+      added: 0,
+      removed: 0,
+      librarian_lane_busy: 0,
+      librarian_failures: 4,
+      read_errors: 0,
+    },
+    alert_summary: {
+      total_alerts: 1,
+      warn_alerts: 0,
+      error_alerts: 1,
+      keepers_with_alerts: 1,
+      snapshot_read_error_keepers: 0,
+      librarian_lane_busy_keepers: 0,
+      librarian_starving_keepers: 1,
     },
   }
 }
@@ -124,6 +178,31 @@ describe('fetchKeeperMemoryHealth', () => {
   it('rejects an alert whose typed target disagrees with its code', async () => {
     const payload = keeperMemoryHealthPayload()
     payload.keepers[1]!.alerts[0]!.target = 'librarian_lane_busy'
+    getMock.mockResolvedValue(payload)
+
+    await expect(fetchKeeperMemoryHealth()).rejects.toThrow(
+      '유효하지 않은 keeper memory health payload',
+    )
+  })
+
+  it('decodes the error-severity librarian starvation contract', async () => {
+    getMock.mockResolvedValue(starvingKeeperPayload())
+
+    const response = await fetchKeeperMemoryHealth()
+
+    expect(response.keepers[0]).toMatchObject({
+      keeper_id: 'starving',
+      snapshot_present: false,
+      librarian_failures: 4,
+    })
+    expect(response.keepers[0]?.alerts[0]?.severity).toBe('error')
+    expect(response.alert_summary.error_alerts).toBe(1)
+    expect(response.alert_summary.librarian_starving_keepers).toBe(1)
+  })
+
+  it('rejects an alert whose severity disagrees with its code', async () => {
+    const payload = starvingKeeperPayload()
+    payload.keepers[0]!.alerts[0]!.severity = 'warn'
     getMock.mockResolvedValue(payload)
 
     await expect(fetchKeeperMemoryHealth()).rejects.toThrow(

--- a/dashboard/src/api/dashboard-misc.ts
+++ b/dashboard/src/api/dashboard-misc.ts
@@ -53,12 +53,29 @@ export function fetchMemorySubsystems(
 export type KeeperMemoryHealthAlertCode =
   | 'snapshot_read_error'
   | 'librarian_lane_busy'
+  | 'librarian_failures'
+  | 'librarian_starvation'
 
-export type KeeperMemoryHealthAlertSeverity = 'warn'
+export type KeeperMemoryHealthAlertSeverity = 'warn' | 'error'
 
 export type KeeperMemoryHealthAlertTarget =
   | 'snapshot_read_error'
   | 'librarian_lane_busy'
+  | 'librarian_failures'
+  | 'librarian_starvation'
+
+// Mirrors the backend contract: each alert code carries exactly one severity
+// (starvation is the only error-level alert). The decoder rejects a payload
+// that disagrees.
+const KEEPER_MEMORY_HEALTH_ALERT_SEVERITY: Record<
+  KeeperMemoryHealthAlertCode,
+  KeeperMemoryHealthAlertSeverity
+> = {
+  snapshot_read_error: 'warn',
+  librarian_lane_busy: 'warn',
+  librarian_failures: 'warn',
+  librarian_starvation: 'error',
+}
 
 export interface KeeperMemoryHealthAlert {
   code: KeeperMemoryHealthAlertCode
@@ -77,7 +94,9 @@ export interface KeeperMemoryHealthKeeperEntry {
   snapshot_bytes: number
   added: number
   removed: number
+  snapshot_present: boolean
   librarian_lane_busy: number
+  librarian_failures: number
   read_error: string | null
   alerts: KeeperMemoryHealthAlert[]
 }
@@ -93,14 +112,17 @@ export interface KeeperMemoryHealthResponse {
     added: number
     removed: number
     librarian_lane_busy: number
+    librarian_failures: number
     read_errors: number
   }
   alert_summary: {
     total_alerts: number
     warn_alerts: number
+    error_alerts: number
     keepers_with_alerts: number
     snapshot_read_error_keepers: number
     librarian_lane_busy_keepers: number
+    librarian_starving_keepers: number
   }
 }
 
@@ -134,11 +156,17 @@ function decodeKeeperMemoryHealthAlert(raw: unknown): KeeperMemoryHealthAlert | 
     'threshold',
   ])) return null
   const code =
-    raw.code === 'snapshot_read_error' || raw.code === 'librarian_lane_busy'
+    raw.code === 'snapshot_read_error'
+    || raw.code === 'librarian_lane_busy'
+    || raw.code === 'librarian_failures'
+    || raw.code === 'librarian_starvation'
       ? raw.code
       : null
   const target =
-    raw.target === 'snapshot_read_error' || raw.target === 'librarian_lane_busy'
+    raw.target === 'snapshot_read_error'
+    || raw.target === 'librarian_lane_busy'
+    || raw.target === 'librarian_failures'
+    || raw.target === 'librarian_starvation'
       ? raw.target
       : null
   const label = nonEmptyString(raw.label)
@@ -149,13 +177,21 @@ function decodeKeeperMemoryHealthAlert(raw: unknown): KeeperMemoryHealthAlert | 
     code === null
     || target === null
     || code !== target
-    || raw.severity !== 'warn'
+    || raw.severity !== KEEPER_MEMORY_HEALTH_ALERT_SEVERITY[code]
     || label === null
     || message === null
     || value === null
     || threshold === null
   ) return null
-  return { code, severity: 'warn', target, label, message, value, threshold }
+  return {
+    code,
+    severity: KEEPER_MEMORY_HEALTH_ALERT_SEVERITY[code],
+    target,
+    label,
+    message,
+    value,
+    threshold,
+  }
 }
 
 function decodeKeeperMemoryHealthEntry(raw: unknown): KeeperMemoryHealthKeeperEntry | null {
@@ -166,7 +202,9 @@ function decodeKeeperMemoryHealthEntry(raw: unknown): KeeperMemoryHealthKeeperEn
     'snapshot_bytes',
     'added',
     'removed',
+    'snapshot_present',
     'librarian_lane_busy',
+    'librarian_failures',
     'read_error',
     'alerts',
   ])) return null
@@ -176,7 +214,11 @@ function decodeKeeperMemoryHealthEntry(raw: unknown): KeeperMemoryHealthKeeperEn
   const snapshot_bytes = nonNegativeInteger(raw.snapshot_bytes)
   const added = nonNegativeInteger(raw.added)
   const removed = nonNegativeInteger(raw.removed)
+  const snapshot_present = typeof raw.snapshot_present === 'boolean'
+    ? raw.snapshot_present
+    : null
   const librarian_lane_busy = nonNegativeInteger(raw.librarian_lane_busy)
+  const librarian_failures = nonNegativeInteger(raw.librarian_failures)
   const read_error = raw.read_error === null ? null : nonEmptyString(raw.read_error)
   const alerts = Array.isArray(raw.alerts)
     ? raw.alerts.map(decodeKeeperMemoryHealthAlert)
@@ -188,7 +230,9 @@ function decodeKeeperMemoryHealthEntry(raw: unknown): KeeperMemoryHealthKeeperEn
     || snapshot_bytes === null
     || added === null
     || removed === null
+    || snapshot_present === null
     || librarian_lane_busy === null
+    || librarian_failures === null
     || (raw.read_error !== null && read_error === null)
     || alerts === null
     || alerts.some(alert => alert === null)
@@ -200,7 +244,9 @@ function decodeKeeperMemoryHealthEntry(raw: unknown): KeeperMemoryHealthKeeperEn
     snapshot_bytes,
     added,
     removed,
+    snapshot_present,
     librarian_lane_busy,
+    librarian_failures,
     read_error,
     alerts: alerts as KeeperMemoryHealthAlert[],
   }
@@ -240,6 +286,7 @@ function decodeKeeperMemoryHealth(raw: unknown): KeeperMemoryHealthResponse | nu
     'added',
     'removed',
     'librarian_lane_busy',
+    'librarian_failures',
     'read_errors',
   ])) return null
   const expectedTotals = {
@@ -248,6 +295,7 @@ function decodeKeeperMemoryHealth(raw: unknown): KeeperMemoryHealthResponse | nu
     added: sum(entry => entry.added),
     removed: sum(entry => entry.removed),
     librarian_lane_busy: sum(entry => entry.librarian_lane_busy),
+    librarian_failures: sum(entry => entry.librarian_failures),
     read_errors: sum(entry => entry.read_error === null ? 0 : 1),
   }
   if (Object.entries(expectedTotals).some(([key, value]) => totals[key] !== value)) return null
@@ -255,17 +303,24 @@ function decodeKeeperMemoryHealth(raw: unknown): KeeperMemoryHealthResponse | nu
   if (!exactKeys(alertSummary, [
     'total_alerts',
     'warn_alerts',
+    'error_alerts',
     'keepers_with_alerts',
     'snapshot_read_error_keepers',
     'librarian_lane_busy_keepers',
+    'librarian_starving_keepers',
   ])) return null
   const totalAlerts = sum(entry => entry.alerts.length)
+  const countAlertSeverity = (severity: KeeperMemoryHealthAlertSeverity) =>
+    sum(entry => entry.alerts.filter(alert => alert.severity === severity).length)
   const expectedAlertSummary = {
     total_alerts: totalAlerts,
-    warn_alerts: totalAlerts,
+    warn_alerts: countAlertSeverity('warn'),
+    error_alerts: countAlertSeverity('error'),
     keepers_with_alerts: sum(entry => entry.alerts.length > 0 ? 1 : 0),
     snapshot_read_error_keepers: sum(entry => entry.read_error === null ? 0 : 1),
     librarian_lane_busy_keepers: sum(entry => entry.librarian_lane_busy > 0 ? 1 : 0),
+    librarian_starving_keepers: sum(entry =>
+      entry.librarian_failures > 0 && !entry.snapshot_present ? 1 : 0),
   }
   if (
     Object.entries(expectedAlertSummary)

--- a/dashboard/src/components/memory/keeper-memory-health.test.ts
+++ b/dashboard/src/components/memory/keeper-memory-health.test.ts
@@ -26,7 +26,9 @@ function makeEntry(
     snapshot_bytes: 512,
     added: 2,
     removed: 1,
+    snapshot_present: true,
     librarian_lane_busy: 0,
+    librarian_failures: 0,
     read_error: null,
     alerts: [],
     ...overrides,
@@ -39,9 +41,11 @@ function makeAlertSummary(
   return {
     total_alerts: 0,
     warn_alerts: 0,
+    error_alerts: 0,
     keepers_with_alerts: 0,
     snapshot_read_error_keepers: 0,
     librarian_lane_busy_keepers: 0,
+    librarian_starving_keepers: 0,
     ...overrides,
   }
 }
@@ -62,6 +66,7 @@ function makeResponse(
       added: 0,
       removed: 0,
       librarian_lane_busy: 0,
+      librarian_failures: 0,
       read_errors: 0,
       ...totalsOverrides,
     },
@@ -145,6 +150,66 @@ describe('KeeperMemoryHealth', () => {
     await waitFor(() => expect(screen.getByText('alpha')).not.toBeNull())
     expect(statValue(container, 'librarian-lane-busy')).toBe('3')
     expect(screen.getByText('Librarian')).not.toBeNull()
+  })
+
+  it('renders librarian starvation as an error row, not a warning', async () => {
+    const alert = {
+      code: 'librarian_starvation' as const,
+      severity: 'error' as const,
+      target: 'librarian_starvation' as const,
+      label: 'Librarian',
+      message: 'Librarian runs failed and no current-memory snapshot exists',
+      value: 4,
+      threshold: 0,
+    }
+    mockFetch.mockResolvedValue(makeResponse(
+      [makeEntry({
+        keeper_id: 'starving',
+        revision: 0,
+        facts: 0,
+        snapshot_bytes: 0,
+        snapshot_present: false,
+        librarian_failures: 4,
+        alerts: [alert],
+      })],
+      { librarian_failures: 4 },
+      makeAlertSummary({
+        total_alerts: 1,
+        error_alerts: 1,
+        keepers_with_alerts: 1,
+        librarian_starving_keepers: 1,
+      }),
+    ))
+    const { container } = render(html`<${KeeperMemoryHealth} />`)
+
+    await waitFor(() => expect(screen.getByText('starving')).not.toBeNull())
+    expect(container.querySelector('.kmh-row--error')).not.toBeNull()
+    expect(container.querySelector('.kmh-badge--error')).not.toBeNull()
+    expect(screen.getByText('없음')).not.toBeNull()
+    expect(statValue(container, 'librarian-failures')).toBe('4')
+    expect(statValue(container, 'starving-keepers')).toBe('1')
+    const alertStat = container.querySelector(
+      '.kmh-totals-strip .kmh-stat[data-stat-key="alerts"] .kmh-stat-value',
+    )
+    expect(alertStat?.classList.contains('kmh-stat-value--error')).toBe(true)
+  })
+
+  it('keeps a never-attempted snapshotless keeper neutral, not alarming', async () => {
+    mockFetch.mockResolvedValue(makeResponse(
+      [makeEntry({
+        keeper_id: 'fresh',
+        revision: 0,
+        facts: 0,
+        snapshot_bytes: 0,
+        snapshot_present: false,
+      })],
+    ))
+    const { container } = render(html`<${KeeperMemoryHealth} />`)
+
+    await waitFor(() => expect(screen.getByText('fresh')).not.toBeNull())
+    expect(container.querySelector('.kmh-row--error')).toBeNull()
+    expect(container.querySelector('.kmh-badge--muted')).not.toBeNull()
+    expect(screen.getByText('없음')).not.toBeNull()
   })
 
   it('shows loading, error, and empty current-snapshot states honestly', async () => {

--- a/dashboard/src/components/memory/keeper-memory-health.ts
+++ b/dashboard/src/components/memory/keeper-memory-health.ts
@@ -17,6 +17,8 @@ import { DEFAULT_PANEL_REFRESH_MS, formatAutoRefreshLabel, setupVisibleAutoRefre
 
 const SNAPSHOT_READ_ERROR_TARGET: KeeperMemoryHealthAlertTarget = 'snapshot_read_error'
 const LIBRARIAN_LANE_BUSY_TARGET: KeeperMemoryHealthAlertTarget = 'librarian_lane_busy'
+const LIBRARIAN_FAILURES_TARGET: KeeperMemoryHealthAlertTarget = 'librarian_failures'
+const LIBRARIAN_STARVATION_TARGET: KeeperMemoryHealthAlertTarget = 'librarian_starvation'
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`
@@ -32,18 +34,25 @@ function hasTargetAlert(alerts: KeeperMemoryHealthAlert[], target: KeeperMemoryH
   return alerts.some(alert => alert.target === target)
 }
 
-function isRowWarning(entry: KeeperMemoryHealthKeeperEntry): boolean {
-  return entryAlerts(entry).length > 0
+function hasErrorAlert(alerts: KeeperMemoryHealthAlert[]): boolean {
+  return alerts.some(alert => alert.severity === 'error')
+}
+
+function alertBadgeClass(alert: KeeperMemoryHealthAlert): string {
+  return alert.severity === 'error' ? 'kmh-badge kmh-badge--error' : 'kmh-badge kmh-badge--warn'
 }
 
 function KeeperRow({ entry }: { entry: KeeperMemoryHealthKeeperEntry }) {
   const alerts = entryAlerts(entry)
-  const warn = isRowWarning(entry)
+  const error = hasErrorAlert(alerts)
+  const warn = alerts.length > 0
   const readErrorWarn = hasTargetAlert(alerts, SNAPSHOT_READ_ERROR_TARGET)
   const laneBusyWarn = hasTargetAlert(alerts, LIBRARIAN_LANE_BUSY_TARGET)
+  const starving = hasTargetAlert(alerts, LIBRARIAN_STARVATION_TARGET)
+  const librarianFailing = starving || hasTargetAlert(alerts, LIBRARIAN_FAILURES_TARGET)
 
   return html`
-    <tr class=${warn ? 'kmh-row--warn' : ''}>
+    <tr class=${error ? 'kmh-row--error' : warn ? 'kmh-row--warn' : ''}>
       <td>${entry.keeper_id}</td>
       <td>${entry.revision}</td>
       <td>${entry.facts.toLocaleString()}</td>
@@ -56,14 +65,25 @@ function KeeperRow({ entry }: { entry: KeeperMemoryHealthKeeperEntry }) {
           : html`<span class="kmh-badge kmh-badge--ok">${entry.librarian_lane_busy}</span>`}
       </td>
       <td>
+        ${starving
+          ? html`<span class="kmh-badge kmh-badge--error">${entry.librarian_failures}</span>`
+          : librarianFailing
+            ? html`<span class="kmh-badge kmh-badge--warn">${entry.librarian_failures}</span>`
+            : html`<span class="kmh-badge kmh-badge--ok">${entry.librarian_failures}</span>`}
+      </td>
+      <td>
         ${readErrorWarn
           ? html`<span class="kmh-badge kmh-badge--warn" title=${entry.read_error ?? ''}>오류</span>`
-          : html`<span class="kmh-badge kmh-badge--ok">정상</span>`}
+          : entry.snapshot_present
+            ? html`<span class="kmh-badge kmh-badge--ok">정상</span>`
+            : starving
+              ? html`<span class="kmh-badge kmh-badge--error">없음</span>`
+              : html`<span class="kmh-badge kmh-badge--muted">없음</span>`}
       </td>
       <td>
         ${alerts.length > 0
           ? alerts.map(alert => html`
-            <span class="kmh-badge kmh-badge--warn" title=${alert.message}>${alert.label}</span>
+            <span class=${alertBadgeClass(alert)} title=${alert.message}>${alert.label}</span>
           `)
           : html`<span class="kmh-badge kmh-badge--ok">정상</span>`}
       </td>
@@ -131,8 +151,20 @@ export function KeeperMemoryHealth() {
 
   const generatedAt = new Date(data.generated_at * 1000).toLocaleTimeString()
   const totalAlerts = data.alert_summary.total_alerts
+  const errorAlerts = data.alert_summary.error_alerts
   const readErrorWarn = data.alert_summary.snapshot_read_error_keepers > 0
   const laneBusyWarn = data.alert_summary.librarian_lane_busy_keepers > 0
+  const starvingKeepers = data.alert_summary.librarian_starving_keepers
+  const librarianFailureClass = starvingKeepers > 0
+    ? ' kmh-stat-value--error'
+    : data.totals.librarian_failures > 0
+      ? ' kmh-stat-value--warn'
+      : ''
+  const alertClass = errorAlerts > 0
+    ? ' kmh-stat-value--error'
+    : totalAlerts > 0
+      ? ' kmh-stat-value--warn'
+      : ''
 
   return html`
     <div class="kmh-panel">
@@ -167,9 +199,21 @@ export function KeeperMemoryHealth() {
               ${data.totals.librarian_lane_busy}
             </span>
           </div>
+          <div class="kmh-stat" data-stat-key="librarian-failures">
+            <span class="kmh-stat-label">Librarian 실패</span>
+            <span class=${`kmh-stat-value${librarianFailureClass}`}>
+              ${data.totals.librarian_failures}
+            </span>
+          </div>
+          <div class="kmh-stat" data-stat-key="starving-keepers">
+            <span class="kmh-stat-label">메모리 없는 키퍼</span>
+            <span class=${`kmh-stat-value${starvingKeepers > 0 ? ' kmh-stat-value--error' : ''}`}>
+              ${starvingKeepers}
+            </span>
+          </div>
           <div class="kmh-stat" data-stat-key="alerts">
             <span class="kmh-stat-label">경보</span>
-            <span class=${`kmh-stat-value${totalAlerts > 0 ? ' kmh-stat-value--warn' : ''}`}>
+            <span class=${`kmh-stat-value${alertClass}`}>
               ${totalAlerts}
             </span>
           </div>
@@ -201,6 +245,7 @@ export function KeeperMemoryHealth() {
                   <th>추가</th>
                   <th>제거</th>
                   <th>lane busy</th>
+                  <th>실패</th>
                   <th>snapshot</th>
                   <th>경보</th>
                 </tr>

--- a/dashboard/src/styles/keeper-memory-health-v2.css
+++ b/dashboard/src/styles/keeper-memory-health-v2.css
@@ -57,6 +57,10 @@
   color: var(--accent-warn, #e0a82e);
 }
 
+.kmh-stat-value--error {
+  color: var(--status-bad, #a01818);
+}
+
 .kmh-read-errors {
   display: flex;
   flex-direction: column;
@@ -129,6 +133,16 @@
   background: color-mix(in srgb, var(--accent-warn, #e0a82e) 10%, transparent);
 }
 
+/* Rows carrying an error-severity alert (librarian starvation): the keeper
+   is running memoryless and cannot recover on its own. */
+.kmh-row--error td {
+  background: color-mix(in srgb, var(--status-bad, #a01818) 8%, transparent);
+}
+
+.kmh-row--error:hover td {
+  background: color-mix(in srgb, var(--status-bad, #a01818) 12%, transparent);
+}
+
 .kmh-badge {
   display: inline-flex;
   align-items: center;
@@ -146,6 +160,18 @@
 .kmh-badge--ok {
   background: color-mix(in srgb, var(--status-ok) 15%, transparent);
   color: var(--status-ok);
+}
+
+.kmh-badge--error {
+  background: color-mix(in srgb, var(--status-bad, #a01818) 20%, transparent);
+  color: var(--status-bad, #a01818);
+}
+
+/* Neutral state: a configured keeper with no snapshot and no failures yet
+   (librarian has not run) — informational, not an alert. */
+.kmh-badge--muted {
+  background: var(--surface-hovered);
+  color: var(--text-tertiary);
 }
 
 .kmh-refresh-label {

--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -434,129 +434,12 @@ let log_exact_error (entry : pending_approval) operation detail =
    the system log, and no metrics endpoint listening to read the per-branch
    counter [record_outcome] already writes. Render the per-attempt provenance so
    the branch and the slot it died on are recoverable. *)
-let flow_evidence_detail (evidence : Exact_output.flow_evidence) =
-  let attempts =
-    List.map
-      (fun (attempt : Exact_output.flow_attempt_snapshot) ->
-      Printf.sprintf
-        "slot=%s call_id=%s"
-        attempt.visit.identity.candidate_id
-        (Exact_output.generation_receipt_snapshot_call_id attempt.receipt
-         |> Exact_output.call_id_to_string))
-      evidence.attempts
-  in
-  let advances =
-    List.map
-      (fun (advance : Exact_output.flow_advance_receipt) ->
-         let failed_slot, failure_kind =
-           match advance.failed with
-           | Exact_output.Flow_advance_candidate_rejected rejection ->
-             ( (Exact_output.candidate_rejection_identity rejection).candidate_id
-             , "candidate_rejected" )
-           | Exact_output.Flow_advance_execution_failed { candidate; _ } ->
-             candidate.visit.identity.candidate_id, "execution_failed"
-         in
-         Printf.sprintf
-           "advance=%s->%s kind=%s"
-           failed_slot
-           advance.next.identity.candidate_id
-           failure_kind)
-      evidence.advances
-  in
-  match attempts @ advances with
-  | [] -> "no candidate attempt or advance was recorded"
-  | details -> String.concat "; " details
-;;
-
-let optional_tokens = function
-  | None -> "unknown"
-  | Some tokens -> string_of_int tokens
-;;
-
-(* [Flow_candidates_exhausted] means every declared slot was refused before any
-   request left this process, and the receipt carries the typed reason with its
-   token arithmetic. Discarding it is what makes a local capacity refusal
-   indistinguishable from a provider outage in the durable row. Matched
-   exhaustively so that a new OAS disposition is a compile error here rather
-   than an unexplained quarantine in production. *)
-let rec capacity_disposition_detail : Exact_output.input_capacity_disposition -> string
-  = function
-  | Token_measurement_required { accepted_through_tokens; rejected_from_tokens } ->
-    Printf.sprintf
-      "token measurement required (accepted_through=%d rejected_from=%s)"
-      accepted_through_tokens
-      (optional_tokens rejected_from_tokens)
-  | Context_window_exceeded { input_tokens; reserved_output_tokens; max_context_tokens } ->
-    Printf.sprintf
-      "context window exceeded (input=%d reserved_output=%d max_context=%d)"
-      input_tokens
-      reserved_output_tokens
-      max_context_tokens
-  | Token_capacity_rejected rejection -> token_capacity_detail rejection
-  | Serialized_request_body_too_large _ ->
-    "serialized request body too large"
-
-and token_capacity_detail : Exact_output.token_capacity_rejection -> string = function
-  | Capacity_evidence_not_yet_valid { now_unix_s; checked_at_unix_s } ->
-    Printf.sprintf
-      "capacity evidence not yet valid (now=%d checked_at=%d)"
-      now_unix_s
-      checked_at_unix_s
-  | Capacity_evidence_expired { now_unix_s; expires_at_unix_s } ->
-    Printf.sprintf
-      "capacity evidence expired (now=%d expires_at=%d)"
-      now_unix_s
-      expires_at_unix_s
-  | Capacity_boundary_unknown { input_tokens; accepted_through_tokens; rejected_from_tokens }
-    ->
-    Printf.sprintf
-      "capacity boundary unknown (input=%d accepted_through=%d rejected_from=%s)"
-      input_tokens
-      accepted_through_tokens
-      (optional_tokens rejected_from_tokens)
-  | Capacity_input_rejected { input_tokens; accepted_through_tokens; rejected_from_tokens }
-    ->
-    Printf.sprintf
-      "capacity input rejected (input=%d accepted_through=%d rejected_from=%d)"
-      input_tokens
-      accepted_through_tokens
-      rejected_from_tokens
-;;
-
-let rejection_disposition_detail : Exact_output.candidate_rejection_disposition -> string
-  = function
-  | Runtime_slot_unavailable -> "runtime slot unavailable"
-  | Runtime_contract_rejected -> "runtime contract rejected"
-  | Input_contract_rejected -> "input contract rejected"
-  | Output_requirement_rejected -> "output requirement rejected"
-  | Input_capacity disposition -> capacity_disposition_detail disposition
-  | Request_preparation_failed -> "request preparation failed"
-;;
-
-let candidate_rejection_detail (rejection : Exact_output.candidate_rejection_receipt) =
-  Printf.sprintf
-    "slot=%s %s"
-    (Exact_output.candidate_rejection_identity rejection).candidate_id
-    (Exact_output.candidate_rejection_disposition rejection
-     |> rejection_disposition_detail)
-;;
-
-(* [Flow_exact_execution_failed] is the branch that carries the provider's own
-   verdict, and it was the only flow error settled with no log line at all. *)
-let execution_cause_detail : Exact_output.execution_error_cause -> string = function
-  | Attempt_already_started -> "attempt already started"
-  | Clock_required_for_timeout -> "clock required for timeout"
-  | Frozen_request_mismatch -> "frozen request mismatch"
-  | Completion_failed -> "completion failed"
-  | Serialized_request_refused { http_status } ->
-    Printf.sprintf "serialized request refused (http_status=%d)" http_status
-  | Incomplete_output -> "incomplete output"
-  | Missing_output -> "missing output"
-  | Ambiguous_output count -> Printf.sprintf "ambiguous output (candidates=%d)" count
-  | Unexpected_output_content -> "unexpected output content"
-  | Invalid_json_output -> "invalid json output"
-  | Internal_non_json_output -> "internal non-json output"
-;;
+(* The renderers themselves moved to [Keeper_exact_flow_detail] so the
+   librarian runtime and this worker print slot provenance identically. *)
+let flow_evidence_detail = Keeper_exact_flow_detail.flow_evidence_detail
+let rejection_disposition_detail = Keeper_exact_flow_detail.rejection_disposition_detail
+let candidate_rejection_detail = Keeper_exact_flow_detail.candidate_rejection_detail
+let execution_cause_detail = Keeper_exact_flow_detail.execution_cause_detail
 
 let exact_attempt_source_resolved (entry : pending_approval) = function
   | Exact_attempt_rejected (Exact_attempt_not_found approval_id) ->
@@ -1040,10 +923,7 @@ let handle_flow_error ~queue_ops (prepared : prepared_flow) = function
     log_exact_error
       prepared.entry
       "exact execution"
-      (Printf.sprintf
-         "%s (%s)"
-         (execution_cause_detail cause.cause)
-         (flow_evidence_detail evidence));
+      (Keeper_exact_flow_detail.execution_failure_detail ~candidate ~cause ~evidence);
     quarantine_candidate
       ~queue_ops
       prepared.entry

--- a/lib/keeper/keeper_exact_flow_detail.ml
+++ b/lib/keeper/keeper_exact_flow_detail.ml
@@ -1,0 +1,177 @@
+module Exact_output = Agent_sdk.Exact_output
+
+let flow_evidence_detail (evidence : Exact_output.flow_evidence) =
+  let attempts =
+    List.map
+      (fun (attempt : Exact_output.flow_attempt_snapshot) ->
+      Printf.sprintf
+        "slot=%s call_id=%s"
+        attempt.visit.identity.candidate_id
+        (Exact_output.generation_receipt_snapshot_call_id attempt.receipt
+         |> Exact_output.call_id_to_string))
+      evidence.attempts
+  in
+  let advances =
+    List.map
+      (fun (advance : Exact_output.flow_advance_receipt) ->
+         let failed_slot, failure_kind =
+           match advance.failed with
+           | Exact_output.Flow_advance_candidate_rejected rejection ->
+             ( (Exact_output.candidate_rejection_identity rejection).candidate_id
+             , "candidate_rejected" )
+           | Exact_output.Flow_advance_execution_failed { candidate; _ } ->
+             candidate.visit.identity.candidate_id, "execution_failed"
+         in
+         Printf.sprintf
+           "advance=%s->%s kind=%s"
+           failed_slot
+           advance.next.identity.candidate_id
+           failure_kind)
+      evidence.advances
+  in
+  match attempts @ advances with
+  | [] -> "no candidate attempt or advance was recorded"
+  | details -> String.concat "; " details
+;;
+
+let optional_tokens = function
+  | None -> "unknown"
+  | Some tokens -> string_of_int tokens
+;;
+
+(* A capacity refusal happens before any request leaves this process, and the
+   receipt carries the typed reason with its token arithmetic. Discarding it
+   is what makes a local capacity refusal indistinguishable from a provider
+   outage in the durable row. Matched exhaustively so that a new OAS
+   disposition is a compile error here rather than an unexplained failure
+   label in production. *)
+let rec capacity_disposition_detail : Exact_output.input_capacity_disposition -> string
+  = function
+  | Token_measurement_required { accepted_through_tokens; rejected_from_tokens } ->
+    Printf.sprintf
+      "token measurement required (accepted_through=%d rejected_from=%s)"
+      accepted_through_tokens
+      (optional_tokens rejected_from_tokens)
+  | Context_window_exceeded { input_tokens; reserved_output_tokens; max_context_tokens } ->
+    Printf.sprintf
+      "context window exceeded (input=%d reserved_output=%d max_context=%d)"
+      input_tokens
+      reserved_output_tokens
+      max_context_tokens
+  | Token_capacity_rejected rejection -> token_capacity_detail rejection
+  | Serialized_request_body_too_large _ ->
+    "serialized request body too large"
+
+and token_capacity_detail : Exact_output.token_capacity_rejection -> string = function
+  | Capacity_evidence_not_yet_valid { now_unix_s; checked_at_unix_s } ->
+    Printf.sprintf
+      "capacity evidence not yet valid (now=%d checked_at=%d)"
+      now_unix_s
+      checked_at_unix_s
+  | Capacity_evidence_expired { now_unix_s; expires_at_unix_s } ->
+    Printf.sprintf
+      "capacity evidence expired (now=%d expires_at=%d)"
+      now_unix_s
+      expires_at_unix_s
+  | Capacity_boundary_unknown { input_tokens; accepted_through_tokens; rejected_from_tokens }
+    ->
+    Printf.sprintf
+      "capacity boundary unknown (input=%d accepted_through=%d rejected_from=%s)"
+      input_tokens
+      accepted_through_tokens
+      (optional_tokens rejected_from_tokens)
+  | Capacity_input_rejected { input_tokens; accepted_through_tokens; rejected_from_tokens }
+    ->
+    Printf.sprintf
+      "capacity input rejected (input=%d accepted_through=%d rejected_from=%d)"
+      input_tokens
+      accepted_through_tokens
+      rejected_from_tokens
+;;
+
+let rejection_disposition_detail : Exact_output.candidate_rejection_disposition -> string
+  = function
+  | Runtime_slot_unavailable -> "runtime slot unavailable"
+  | Runtime_contract_rejected -> "runtime contract rejected"
+  | Input_contract_rejected -> "input contract rejected"
+  | Output_requirement_rejected -> "output requirement rejected"
+  | Input_capacity disposition -> capacity_disposition_detail disposition
+  | Request_preparation_failed -> "request preparation failed"
+;;
+
+let candidate_rejection_detail (rejection : Exact_output.candidate_rejection_receipt) =
+  Printf.sprintf
+    "slot=%s %s"
+    (Exact_output.candidate_rejection_identity rejection).candidate_id
+    (Exact_output.candidate_rejection_disposition rejection
+     |> rejection_disposition_detail)
+;;
+
+(* [Flow_exact_execution_failed] is the branch that carries the provider's own
+   verdict. The typed cause alone ("completion failed") says nothing about
+   which provider said what; the raw response body carried next to it does. *)
+let execution_cause_detail : Exact_output.execution_error_cause -> string = function
+  | Attempt_already_started -> "attempt already started"
+  | Clock_required_for_timeout -> "clock required for timeout"
+  | Frozen_request_mismatch -> "frozen request mismatch"
+  | Completion_failed -> "completion failed"
+  | Serialized_request_refused { http_status } ->
+    Printf.sprintf "serialized request refused (http_status=%d)" http_status
+  | Incomplete_output -> "incomplete output"
+  | Missing_output -> "missing output"
+  | Ambiguous_output count -> Printf.sprintf "ambiguous output (candidates=%d)" count
+  | Unexpected_output_content -> "unexpected output content"
+  | Invalid_json_output -> "invalid json output"
+  | Internal_non_json_output -> "internal non-json output"
+;;
+
+(* Log lines are single-line records; the excerpt bound keeps one failed call
+   from flooding them while the sha256 keeps the full body identifiable in
+   wire captures. *)
+let raw_response_excerpt_max_bytes = 240
+
+let raw_response_excerpt = function
+  | None -> "raw_response=none"
+  | Some (raw : Exact_output.raw_response) ->
+    let flattened =
+      String.map
+        (fun char ->
+           if Char.equal char '\n' || Char.equal char '\r' then ' ' else char)
+        raw.body
+    in
+    if String.length flattened <= raw_response_excerpt_max_bytes
+    then Printf.sprintf "raw_response=%s" flattened
+    else
+      Printf.sprintf
+        "raw_response=%s... (%d bytes total sha256=%s)"
+        (String.sub flattened 0 raw_response_excerpt_max_bytes)
+        (String.length raw.body)
+        raw.body_sha256
+;;
+
+let execution_error_detail (error : Exact_output.execution_error) =
+  Printf.sprintf
+    "call_id=%s cause=%s %s"
+    (Exact_output.call_id_to_string error.call_id)
+    (execution_cause_detail error.cause)
+    (raw_response_excerpt error.raw_response)
+;;
+
+let execution_failure_detail
+      ~(candidate : Exact_output.flow_attempt_receipt)
+      ~cause
+      ~evidence
+  =
+  Printf.sprintf
+    "slot=%s %s; flow=[%s]"
+    candidate.visit.identity.candidate_id
+    (execution_error_detail cause)
+    (flow_evidence_detail evidence)
+;;
+
+let candidates_exhausted_detail ~rejection ~evidence =
+  Printf.sprintf
+    "%s; flow=[%s]"
+    (candidate_rejection_detail rejection)
+    (flow_evidence_detail evidence)
+;;

--- a/lib/keeper/keeper_exact_flow_detail.ml
+++ b/lib/keeper/keeper_exact_flow_detail.ml
@@ -127,7 +127,13 @@ let execution_cause_detail : Exact_output.execution_error_cause -> string = func
 
 (* Log lines are single-line records; the excerpt bound keeps one failed call
    from flooding them while the sha256 keeps the full body identifiable in
-   wire captures. *)
+   wire captures. Provider bodies can echo prompt, memory, or credential
+   material, so the excerpt passes through [Observability_redact.redact_text]
+   before any truncation — cutting first could split a secret across the
+   boundary where the redactor no longer matches it. The cut itself lands on
+   a UTF-8 character boundary so the log line stays valid UTF-8 for the log
+   ring and its JSON serialization. Byte count and sha256 always describe
+   the original wire body, not the redacted excerpt. *)
 let raw_response_excerpt_max_bytes = 240
 
 let raw_response_excerpt = function
@@ -139,12 +145,15 @@ let raw_response_excerpt = function
            if Char.equal char '\n' || Char.equal char '\r' then ' ' else char)
         raw.body
     in
-    if String.length flattened <= raw_response_excerpt_max_bytes
-    then Printf.sprintf "raw_response=%s" flattened
+    let redacted = Observability_redact.redact_text flattened in
+    if String.length redacted <= raw_response_excerpt_max_bytes
+    then Printf.sprintf "raw_response=%s" redacted
     else
       Printf.sprintf
         "raw_response=%s... (%d bytes total sha256=%s)"
-        (String.sub flattened 0 raw_response_excerpt_max_bytes)
+        (String_util.utf8_prefix
+           ~max_bytes:raw_response_excerpt_max_bytes
+           redacted)
         (String.length raw.body)
         raw.body_sha256
 ;;

--- a/lib/keeper/keeper_exact_flow_detail.mli
+++ b/lib/keeper/keeper_exact_flow_detail.mli
@@ -1,0 +1,54 @@
+(** Rendering of OAS exact-output flow errors with their per-slot provenance.
+
+    Every masc consumer of [Agent_sdk.Exact_output] flow errors (HITL summary
+    worker, librarian runtime) renders through this module, so an error's
+    candidate identity, typed cause, raw provider body and flow journey are
+    printed once, the same way, instead of being collapsed to a static label
+    at each consumer boundary. *)
+
+(** Attempts and advances recorded in the flow evidence, one clause per
+    candidate visit ("slot=... call_id=..."; "advance=a->b kind=..."). *)
+val flow_evidence_detail : Agent_sdk.Exact_output.flow_evidence -> string
+
+(** Typed reason a candidate slot was refused before dispatch, including the
+    token arithmetic of capacity refusals. Matched exhaustively so a new OAS
+    disposition is a compile error here. *)
+val rejection_disposition_detail
+  :  Agent_sdk.Exact_output.candidate_rejection_disposition
+  -> string
+
+(** "slot=<id> <disposition>" for one rejected candidate. *)
+val candidate_rejection_detail
+  :  Agent_sdk.Exact_output.candidate_rejection_receipt
+  -> string
+
+(** Typed execution failure cause ("completion failed",
+    "serialized request refused (http_status=...)", ...). *)
+val execution_cause_detail
+  :  Agent_sdk.Exact_output.execution_error_cause
+  -> string
+
+(** Single-line bounded excerpt of the provider's raw response body. Bodies
+    longer than the excerpt bound are cut and annotated with total byte count
+    and the body's sha256 so the full payload stays identifiable. *)
+val raw_response_excerpt
+  :  Agent_sdk.Exact_output.raw_response option
+  -> string
+
+(** call_id + typed cause + raw-response excerpt for one execution error. *)
+val execution_error_detail : Agent_sdk.Exact_output.execution_error -> string
+
+(** Full rendering for [Flow_exact_execution_failed]: failing slot, execution
+    error detail and the flow journey. *)
+val execution_failure_detail
+  :  candidate:Agent_sdk.Exact_output.flow_attempt_receipt
+  -> cause:Agent_sdk.Exact_output.execution_error
+  -> evidence:Agent_sdk.Exact_output.flow_evidence
+  -> string
+
+(** Full rendering for [Flow_candidates_exhausted]: last rejection and the
+    flow journey. *)
+val candidates_exhausted_detail
+  :  rejection:Agent_sdk.Exact_output.candidate_rejection_receipt
+  -> evidence:Agent_sdk.Exact_output.flow_evidence
+  -> string

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -402,6 +402,31 @@ let extract_and_commit_with_exact_output_classified
     Memory_snapshot_write_failed detail)
 ;;
 
+(* A failure while no current snapshot exists means the keeper is running
+   memoryless and cannot leave that state on its own — that is an ERROR,
+   not a WARN. With a snapshot present the previous memory keeps serving
+   recall and the failure only stales it. Both the classified [Error] path
+   and the exception catch in [run_best_effort] route through this rule so
+   an exception cannot demote a starving keeper's failure back to WARN. *)
+let log_failure_with_snapshot_severity ~keepers_dir ~keeper_id detail =
+  let snapshot_absent =
+    match
+      Keeper_memory_os_current.read_for_keepers_dir ~keepers_dir ~keeper_id
+    with
+    | Ok (Some _) -> false
+    | Ok None | Error _ -> true
+  in
+  let message =
+    Printf.sprintf
+      "%s current_snapshot=%s"
+      detail
+      (if snapshot_absent then "absent" else "present")
+  in
+  if snapshot_absent
+  then Log.Keeper.error ~keeper_name:keeper_id "%s" message
+  else Log.Keeper.warn ~keeper_name:keeper_id "%s" message
+;;
+
 let run_best_effort
       ~keepers_dir
       ~keeper_id
@@ -439,31 +464,14 @@ let run_best_effort
              ();
            let deferred = should_record_cadence_backoff_after_error error in
            if deferred then cadence_record_attempt ~keeper_id ~trace_id;
-           (* A failure while no current snapshot exists means the keeper is
-              running memoryless and cannot leave that state on its own —
-              that is an ERROR, not a WARN. With a snapshot present the
-              previous memory keeps serving recall and the failure only
-              stales it. *)
-           let snapshot_absent =
-             match
-               Keeper_memory_os_current.read_for_keepers_dir
-                 ~keepers_dir
-                 ~keeper_id
-             with
-             | Ok (Some _) -> false
-             | Ok None | Error _ -> true
-           in
-           let message =
-             Printf.sprintf
-               "memory os librarian failed lane=%s: %s; cadence deferred=%b current_snapshot=%s"
-               exact_lane_id
-               (extraction_error_to_string error)
-               deferred
-               (if snapshot_absent then "absent" else "present")
-           in
-           if snapshot_absent
-           then Log.Keeper.error ~keeper_name:keeper_id "%s" message
-           else Log.Keeper.warn ~keeper_name:keeper_id "%s" message)
+           log_failure_with_snapshot_severity
+             ~keepers_dir
+             ~keeper_id
+             (Printf.sprintf
+                "memory os librarian failed lane=%s: %s; cadence deferred=%b"
+                exact_lane_id
+                (extraction_error_to_string error)
+                deferred))
       | _ ->
         Log.Keeper.warn
           ~keeper_name:keeper_id
@@ -476,9 +484,11 @@ let run_best_effort
         Keeper_metrics.(to_string MemoryOsLibrarianFailures)
         ~labels:[ "keeper", keeper_id; "site", "memory_os_librarian" ]
         ();
-      Log.Keeper.warn
-        ~keeper_name:keeper_id
-        "memory os librarian failed lane=%s: %s"
-        exact_lane_id
-        (Printexc.to_string exn))
+      log_failure_with_snapshot_severity
+        ~keepers_dir
+        ~keeper_id
+        (Printf.sprintf
+           "memory os librarian failed lane=%s: %s"
+           exact_lane_id
+           (Printexc.to_string exn)))
 ;;

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -287,6 +287,9 @@ let exact_execution_error error =
     | Exact_output.No_generation_dispatch -> No_outward_effect
     | Exact_output.Generation_dispatch_started -> Outward_effect_started
   in
+  (* The static labels stay as prefixes (existing log greps keep working);
+     the payload each branch carries — failing slot, typed cause, raw provider
+     body, flow journey — is rendered after them instead of being discarded. *)
   let detail =
     match error with
     | Exact_output.Flow_attempt_already_started _ ->
@@ -295,15 +298,24 @@ let exact_execution_error error =
       "attempt_start_failed"
     | Flow_measurement_start_failed _ ->
       "measurement_start_failed"
-    | Flow_candidates_exhausted _ ->
-      "candidates_exhausted"
+    | Flow_candidates_exhausted { rejection; evidence } ->
+      Printf.sprintf
+        "candidates_exhausted: %s"
+        (Keeper_exact_flow_detail.candidates_exhausted_detail
+           ~rejection
+           ~evidence)
     | Flow_before_measurement_dispatch_callback_failed _
     | Flow_measurement_terminal_callback_failed _
     | Flow_before_dispatch_callback_failed _
     | Flow_before_advance_callback_failed _ ->
       "unexpected_callback_failure"
-    | Flow_exact_execution_failed _ ->
-      "oas_execution_failed"
+    | Flow_exact_execution_failed { candidate; cause; evidence } ->
+      Printf.sprintf
+        "oas_execution_failed: %s"
+        (Keeper_exact_flow_detail.execution_failure_detail
+           ~candidate
+           ~cause
+           ~evidence)
   in
   { outward_effect; detail }
 ;;
@@ -425,14 +437,33 @@ let run_best_effort
              Keeper_metrics.(to_string MemoryOsLibrarianFailures)
              ~labels:[ "keeper", keeper_id; "site", "memory_os_librarian" ]
              ();
-           if should_record_cadence_backoff_after_error error
-           then cadence_record_attempt ~keeper_id ~trace_id;
-           Log.Keeper.warn
-             ~keeper_name:keeper_id
-             "memory os librarian failed lane=%s: %s; cadence deferred=%b"
-             exact_lane_id
-             (extraction_error_to_string error)
-             (should_record_cadence_backoff_after_error error))
+           let deferred = should_record_cadence_backoff_after_error error in
+           if deferred then cadence_record_attempt ~keeper_id ~trace_id;
+           (* A failure while no current snapshot exists means the keeper is
+              running memoryless and cannot leave that state on its own —
+              that is an ERROR, not a WARN. With a snapshot present the
+              previous memory keeps serving recall and the failure only
+              stales it. *)
+           let snapshot_absent =
+             match
+               Keeper_memory_os_current.read_for_keepers_dir
+                 ~keepers_dir
+                 ~keeper_id
+             with
+             | Ok (Some _) -> false
+             | Ok None | Error _ -> true
+           in
+           let message =
+             Printf.sprintf
+               "memory os librarian failed lane=%s: %s; cadence deferred=%b current_snapshot=%s"
+               exact_lane_id
+               (extraction_error_to_string error)
+               deferred
+               (if snapshot_absent then "absent" else "present")
+           in
+           if snapshot_absent
+           then Log.Keeper.error ~keeper_name:keeper_id "%s" message
+           else Log.Keeper.warn ~keeper_name:keeper_id "%s" message)
       | _ ->
         Log.Keeper.warn
           ~keeper_name:keeper_id

--- a/lib/server/server_dashboard_http_keeper_memory_health.ml
+++ b/lib/server/server_dashboard_http_keeper_memory_health.ml
@@ -33,28 +33,37 @@ let librarian_lane_busy_for_keeper keeper_id =
   |> int_of_float
 ;;
 
-(* Labels mirror the counter increments in [Keeper_librarian_runtime]. *)
+(* Labels mirror the counter increments in [Keeper_librarian_runtime] and the
+   pre-librarian snapshot read in [Keeper_agent_run_post_turn_memory]: a keeper
+   whose current-snapshot read keeps failing aborts before the librarian ever
+   runs, so counting only the librarian site would report it as failure-free. *)
+let librarian_failure_sites = [ "memory_os_librarian"; "memory_os_current_read" ]
+
 let librarian_failures_for_keeper keeper_id =
-  Otel_metric_store.metric_value_or_zero
-    librarian_failures_metric
-    ~labels:[ "keeper", keeper_id; "site", "memory_os_librarian" ]
-    ()
-  |> int_of_float
+  List.fold_left
+    (fun total site ->
+       total
+       + (Otel_metric_store.metric_value_or_zero
+            librarian_failures_metric
+            ~labels:[ "keeper", keeper_id; "site", site ]
+            ()
+          |> int_of_float))
+    0
+    librarian_failure_sites
 ;;
 
 (* A keeper with a config but no current snapshot is the starvation case this
    endpoint exists to expose; enumerating snapshot files alone gives it no
    row at all. Health rows therefore come from the union of configured
-   keepers (<keeper>.toml) and existing snapshots. *)
-let keeper_config_suffix = ".toml"
-
+   keepers and existing snapshots. Discovery goes through
+   [Keeper_types_profile.discover_keepers_toml] rather than toml basenames
+   because a toml may set its canonical [name]: metrics and snapshots are
+   keyed by that name, and a basename row would both miss the real keeper
+   and show a ghost. Invalid tomls keep their basename row so a keeper with
+   a broken config stays visible. *)
 let configured_keeper_ids ~keepers_dir =
-  if not (Sys.file_exists keepers_dir && Sys.is_directory keepers_dir)
-  then []
-  else
-    Sys.readdir keepers_dir
-    |> Array.to_list
-    |> List.filter_map (Filename.chop_suffix_opt ~suffix:keeper_config_suffix)
+  Keeper_types_profile.discover_keepers_toml keepers_dir
+  |> List.map Keeper_types_profile.keeper_toml_discovery_name
 ;;
 
 let health_keeper_ids ~keepers_dir =

--- a/lib/server/server_dashboard_http_keeper_memory_health.ml
+++ b/lib/server/server_dashboard_http_keeper_memory_health.ml
@@ -7,12 +7,18 @@ type keeper_health =
   ; snapshot_bytes : int
   ; added : int
   ; removed : int
+  ; snapshot_present : bool
   ; librarian_lane_busy : int
+  ; librarian_failures : int
   ; read_error : string option
   }
 
 let librarian_lane_busy_metric =
   Keeper_metrics.(to_string MemoryLaneCoalesced)
+;;
+
+let librarian_failures_metric =
+  Keeper_metrics.(to_string MemoryOsLibrarianFailures)
 ;;
 
 let file_size_bytes path =
@@ -25,6 +31,36 @@ let librarian_lane_busy_for_keeper keeper_id =
     ~labels:[ "keeper", keeper_id; "lane", "librarian" ]
     ()
   |> int_of_float
+;;
+
+(* Labels mirror the counter increments in [Keeper_librarian_runtime]. *)
+let librarian_failures_for_keeper keeper_id =
+  Otel_metric_store.metric_value_or_zero
+    librarian_failures_metric
+    ~labels:[ "keeper", keeper_id; "site", "memory_os_librarian" ]
+    ()
+  |> int_of_float
+;;
+
+(* A keeper with a config but no current snapshot is the starvation case this
+   endpoint exists to expose; enumerating snapshot files alone gives it no
+   row at all. Health rows therefore come from the union of configured
+   keepers (<keeper>.toml) and existing snapshots. *)
+let keeper_config_suffix = ".toml"
+
+let configured_keeper_ids ~keepers_dir =
+  if not (Sys.file_exists keepers_dir && Sys.is_directory keepers_dir)
+  then []
+  else
+    Sys.readdir keepers_dir
+    |> Array.to_list
+    |> List.filter_map (Filename.chop_suffix_opt ~suffix:keeper_config_suffix)
+;;
+
+let health_keeper_ids ~keepers_dir =
+  configured_keeper_ids ~keepers_dir
+  @ Keeper_memory_os_current.list_keeper_ids_for_keepers_dir ~keepers_dir
+  |> List.sort_uniq String.compare
 ;;
 
 let keeper_health ~keepers_dir keeper_id =
@@ -41,7 +77,9 @@ let keeper_health ~keepers_dir keeper_id =
     ; snapshot_bytes = 0
     ; added = 0
     ; removed = 0
+    ; snapshot_present = false
     ; librarian_lane_busy = librarian_lane_busy_for_keeper keeper_id
+    ; librarian_failures = librarian_failures_for_keeper keeper_id
     ; read_error = None
     }
   | Ok (Some snapshot) ->
@@ -51,7 +89,9 @@ let keeper_health ~keepers_dir keeper_id =
     ; snapshot_bytes = file_size_bytes snapshot_path
     ; added = List.length snapshot.change.added
     ; removed = List.length snapshot.change.removed
+    ; snapshot_present = true
     ; librarian_lane_busy = librarian_lane_busy_for_keeper keeper_id
+    ; librarian_failures = librarian_failures_for_keeper keeper_id
     ; read_error = None
     }
   | Error message ->
@@ -61,15 +101,17 @@ let keeper_health ~keepers_dir keeper_id =
     ; snapshot_bytes = file_size_bytes snapshot_path
     ; added = 0
     ; removed = 0
+    ; snapshot_present = false
     ; librarian_lane_busy = librarian_lane_busy_for_keeper keeper_id
+    ; librarian_failures = librarian_failures_for_keeper keeper_id
     ; read_error = Some message
     }
 ;;
 
-let alert_json ~code ~target ~label ~message ~value =
+let alert_json ~code ~severity ~target ~label ~message ~value =
   `Assoc
     [ "code", `String code
-    ; "severity", `String "warn"
+    ; "severity", `String severity
     ; "target", `String target
     ; "label", `String label
     ; "message", `String message
@@ -85,24 +127,61 @@ let alerts h =
     | Some message ->
       [ alert_json
           ~code:"snapshot_read_error"
+          ~severity:"warn"
           ~target:"snapshot_read_error"
           ~label:"읽기"
           ~message
           ~value:1.0
       ]
   in
-  if h.librarian_lane_busy <= 0
-  then read_error_alert
-  else
-    read_error_alert
-    @ [ alert_json
+  let lane_busy_alert =
+    if h.librarian_lane_busy <= 0
+    then []
+    else
+      [ alert_json
           ~code:"librarian_lane_busy"
+          ~severity:"warn"
           ~target:"librarian_lane_busy"
           ~label:"Librarian"
           ~message:
             "The Librarian memory lane was busy; current-memory selection was deferred."
           ~value:(float_of_int h.librarian_lane_busy)
       ]
+  in
+  let failure_alert =
+    if h.librarian_failures <= 0
+    then []
+    else if h.snapshot_present
+    then
+      [ alert_json
+          ~code:"librarian_failures"
+          ~severity:"warn"
+          ~target:"librarian_failures"
+          ~label:"Librarian"
+          ~message:
+            "Librarian runs failed since boot; the existing current-memory snapshot keeps serving recall but is no longer being updated."
+          ~value:(float_of_int h.librarian_failures)
+      ]
+    else
+      [ alert_json
+          ~code:"librarian_starvation"
+          ~severity:"error"
+          ~target:"librarian_starvation"
+          ~label:"Librarian"
+          ~message:
+            "Librarian runs failed and no current-memory snapshot exists; the keeper is running memoryless and cannot leave that state on its own."
+          ~value:(float_of_int h.librarian_failures)
+      ]
+  in
+  read_error_alert @ lane_busy_alert @ failure_alert
+;;
+
+let alert_severity = function
+  | `Assoc fields ->
+    (match List.assoc_opt "severity" fields with
+     | Some (`String severity) -> severity
+     | _ -> "warn")
+  | _ -> "warn"
 ;;
 
 let keeper_health_entry_to_json h =
@@ -113,7 +192,9 @@ let keeper_health_entry_to_json h =
     ; "snapshot_bytes", `Int h.snapshot_bytes
     ; "added", `Int h.added
     ; "removed", `Int h.removed
+    ; "snapshot_present", `Bool h.snapshot_present
     ; "librarian_lane_busy", `Int h.librarian_lane_busy
+    ; "librarian_failures", `Int h.librarian_failures
     ; ( "read_error"
       , match h.read_error with
         | Some message -> `String message
@@ -128,7 +209,7 @@ let keeper_memory_health_http_json ~base_path =
     Config_dir_resolver.keepers_dir_for_base_path ~base_path
   in
   let entries =
-    Keeper_memory_os_current.list_keeper_ids_for_keepers_dir ~keepers_dir
+    health_keeper_ids ~keepers_dir
     |> List.map (keeper_health ~keepers_dir)
     |> List.sort (fun left right ->
       compare right.snapshot_bytes left.snapshot_bytes)
@@ -136,11 +217,12 @@ let keeper_memory_health_http_json ~base_path =
   let sum field =
     List.fold_left (fun total entry -> total + field entry) 0 entries
   in
-  let total_alerts =
-    List.fold_left
-      (fun total entry -> total + List.length (alerts entry))
-      0
-      entries
+  let all_alerts = List.concat_map alerts entries in
+  let count_severity severity =
+    List.length
+      (List.filter
+         (fun alert -> String.equal (alert_severity alert) severity)
+         all_alerts)
   in
   `Assoc
     [ "schema", `String "keeper.memory_os.current_health.v1"
@@ -156,6 +238,8 @@ let keeper_memory_health_http_json ~base_path =
           ; "removed", `Int (sum (fun entry -> entry.removed))
           ; ( "librarian_lane_busy"
             , `Int (sum (fun entry -> entry.librarian_lane_busy)) )
+          ; ( "librarian_failures"
+            , `Int (sum (fun entry -> entry.librarian_failures)) )
           ; ( "read_errors"
             , `Int
                 (sum (fun entry ->
@@ -165,8 +249,9 @@ let keeper_memory_health_http_json ~base_path =
           ] )
     ; ( "alert_summary"
       , `Assoc
-          [ "total_alerts", `Int total_alerts
-          ; "warn_alerts", `Int total_alerts
+          [ "total_alerts", `Int (List.length all_alerts)
+          ; "warn_alerts", `Int (count_severity "warn")
+          ; "error_alerts", `Int (count_severity "error")
           ; ( "keepers_with_alerts"
             , `Int
                 (sum (fun entry ->
@@ -181,6 +266,12 @@ let keeper_memory_health_http_json ~base_path =
             , `Int
                 (sum (fun entry ->
                    if entry.librarian_lane_busy > 0 then 1 else 0)) )
+          ; ( "librarian_starving_keepers"
+            , `Int
+                (sum (fun entry ->
+                   if entry.librarian_failures > 0 && not entry.snapshot_present
+                   then 1
+                   else 0)) )
           ] )
     ]
 ;;

--- a/test/dune
+++ b/test/dune
@@ -132,6 +132,7 @@
   test_dashboard_nav_event
   test_server_dashboard_http_memory_subsystems
   test_server_dashboard_http_keeper_memory_health
+  test_keeper_exact_flow_detail
   test_server_dashboard_http_audit_integrity
   test_dashboard_execute_output
   test_tool_assignment_telemetry
@@ -431,6 +432,7 @@
   test_dashboard_nav_event
   test_server_dashboard_http_memory_subsystems
   test_server_dashboard_http_keeper_memory_health
+  test_keeper_exact_flow_detail
   test_server_dashboard_http_audit_integrity
   test_dashboard_execute_output
   test_tool_assignment_telemetry

--- a/test/test_keeper_exact_flow_detail.ml
+++ b/test/test_keeper_exact_flow_detail.ml
@@ -52,6 +52,44 @@ let test_raw_response_excerpt_bounds_long_bodies () =
     (Astring.String.is_infix ~affix:"deadbeef" rendered)
 ;;
 
+let test_raw_response_excerpt_redacts_secrets () =
+  let raw : Exact_output.raw_response =
+    { body = "error: upstream rejected Bearer sk-live-abc123 token"
+    ; body_sha256 = "redsha"
+    }
+  in
+  let rendered = Detail.raw_response_excerpt (Some raw) in
+  Alcotest.(check bool)
+    "secret is gone"
+    false
+    (Astring.String.is_infix ~affix:"sk-live-abc123" rendered);
+  Alcotest.(check bool)
+    "redaction marker present"
+    true
+    (Astring.String.is_infix ~affix:"[REDACTED]" rendered)
+;;
+
+let test_raw_response_excerpt_cuts_on_utf8_boundary () =
+  let body = "a" ^ String.concat "" (List.init 100 (fun _ -> "가")) in
+  let raw : Exact_output.raw_response = { body; body_sha256 = "utf8sha" } in
+  let rendered = Detail.raw_response_excerpt (Some raw) in
+  let start = String.length "raw_response=" in
+  let marker_index =
+    match Astring.String.find_sub ~sub:"... (" rendered with
+    | Some index -> index
+    | None -> Alcotest.fail "expected truncation marker"
+  in
+  let excerpt = String.sub rendered start (marker_index - start) in
+  (* A 240-byte cut would land mid-character: one ASCII byte plus 79 full
+     three-byte "가" characters is 238 bytes, the largest boundary-aligned
+     prefix. A raw [String.sub] would return 240 malformed bytes instead. *)
+  Alcotest.(check int) "boundary-aligned length" 238 (String.length excerpt);
+  Alcotest.(check bool)
+    "keeps original byte count"
+    true
+    (Astring.String.is_infix ~affix:"301 bytes total" rendered)
+;;
+
 let () =
   Alcotest.run
     "keeper_exact_flow_detail"
@@ -64,5 +102,9 @@ let () =
             test_raw_response_excerpt_flattens_newlines
         ; Alcotest.test_case "raw response bounds long bodies" `Quick
             test_raw_response_excerpt_bounds_long_bodies
+        ; Alcotest.test_case "raw response redacts secrets" `Quick
+            test_raw_response_excerpt_redacts_secrets
+        ; Alcotest.test_case "raw response cuts on utf8 boundary" `Quick
+            test_raw_response_excerpt_cuts_on_utf8_boundary
         ] )
     ]

--- a/test/test_keeper_exact_flow_detail.ml
+++ b/test/test_keeper_exact_flow_detail.ml
@@ -1,0 +1,68 @@
+(** Unit tests for the shared exact-output flow error rendering. *)
+
+module Detail = Masc.Keeper_exact_flow_detail
+module Exact_output = Agent_sdk.Exact_output
+
+let test_execution_cause_detail () =
+  Alcotest.(check string)
+    "refused"
+    "serialized request refused (http_status=413)"
+    (Detail.execution_cause_detail
+       (Exact_output.Serialized_request_refused { http_status = 413 }));
+  Alcotest.(check string)
+    "completion"
+    "completion failed"
+    (Detail.execution_cause_detail Exact_output.Completion_failed);
+  Alcotest.(check string)
+    "ambiguous"
+    "ambiguous output (candidates=2)"
+    (Detail.execution_cause_detail (Exact_output.Ambiguous_output 2))
+;;
+
+let test_raw_response_excerpt_none () =
+  Alcotest.(check string)
+    "none"
+    "raw_response=none"
+    (Detail.raw_response_excerpt None)
+;;
+
+let test_raw_response_excerpt_flattens_newlines () =
+  let raw : Exact_output.raw_response =
+    { body = "line1\nline2\rline3"; body_sha256 = "abc" }
+  in
+  Alcotest.(check string)
+    "flattened"
+    "raw_response=line1 line2 line3"
+    (Detail.raw_response_excerpt (Some raw))
+;;
+
+let test_raw_response_excerpt_bounds_long_bodies () =
+  let raw : Exact_output.raw_response =
+    { body = String.make 600 'x'; body_sha256 = "deadbeef" }
+  in
+  let rendered = Detail.raw_response_excerpt (Some raw) in
+  Alcotest.(check bool) "bounded" true (String.length rendered < 400);
+  Alcotest.(check bool)
+    "keeps total byte count"
+    true
+    (Astring.String.is_infix ~affix:"600 bytes total" rendered);
+  Alcotest.(check bool)
+    "keeps body sha"
+    true
+    (Astring.String.is_infix ~affix:"deadbeef" rendered)
+;;
+
+let () =
+  Alcotest.run
+    "keeper_exact_flow_detail"
+    [ ( "render"
+      , [ Alcotest.test_case "execution cause detail" `Quick
+            test_execution_cause_detail
+        ; Alcotest.test_case "raw response none" `Quick
+            test_raw_response_excerpt_none
+        ; Alcotest.test_case "raw response flattens newlines" `Quick
+            test_raw_response_excerpt_flattens_newlines
+        ; Alcotest.test_case "raw response bounds long bodies" `Quick
+            test_raw_response_excerpt_bounds_long_bodies
+        ] )
+    ]

--- a/test/test_server_dashboard_http_keeper_memory_health.ml
+++ b/test/test_server_dashboard_http_keeper_memory_health.ml
@@ -71,6 +71,12 @@ let string_field name json =
   | _ -> Alcotest.failf "expected string field %S" name
 ;;
 
+let bool_field name json =
+  match assoc_field name json with
+  | Some (`Bool b) -> b
+  | _ -> Alcotest.failf "expected bool field %S" name
+;;
+
 let list_field name json =
   match assoc_field name json with
   | Some (`List xs) -> xs
@@ -234,6 +240,90 @@ let test_sorts_by_snapshot_bytes_and_handles_empty_store () =
   Alcotest.(check int) "empty bytes" 0 (int_field "snapshot_bytes" (totals empty))
 ;;
 
+let write_keeper_config ~keepers_dir ~keeper_id =
+  Fs_compat.mkdir_p keepers_dir;
+  Fs_compat.save_file
+    (Filename.concat keepers_dir (keeper_id ^ ".toml"))
+    "name = \"stub\"\n"
+;;
+
+(* A keeper that has a config but never committed memory is exactly the case
+   the endpoint must not hide: it needs a row even with no snapshot file. *)
+let test_configured_keeper_without_snapshot_gets_row () =
+  let base = fresh_dir "masc-memory-health-configured" in
+  let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path:base in
+  let keeper_id = "configured-" ^ Filename.basename base in
+  write_keeper_config ~keepers_dir ~keeper_id;
+  let json = Health.keeper_memory_health_http_json ~base_path:base in
+  let keeper = keeper_obj keeper_id json in
+  Alcotest.(check bool) "snapshot_present" false (bool_field "snapshot_present" keeper);
+  Alcotest.(check int) "facts" 0 (int_field "facts" keeper);
+  Alcotest.(check int)
+    "no alerts without failures"
+    0
+    (List.length (list_field "alerts" keeper))
+;;
+
+let test_librarian_starvation_is_error_alert () =
+  let base = fresh_dir "masc-memory-health-starve" in
+  let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path:base in
+  let keeper_id = "starving-" ^ Filename.basename base in
+  write_keeper_config ~keepers_dir ~keeper_id;
+  Metrics.inc_counter
+    KeeperMetrics.(to_string MemoryOsLibrarianFailures)
+    ~labels:[ "keeper", keeper_id; "site", "memory_os_librarian" ]
+    ~delta:4.0
+    ();
+  let json = Health.keeper_memory_health_http_json ~base_path:base in
+  let keeper = keeper_obj keeper_id json in
+  Alcotest.(check int) "failures" 4 (int_field "librarian_failures" keeper);
+  let alerts = list_field "alerts" keeper in
+  Alcotest.(check (list string))
+    "starvation code"
+    [ "librarian_starvation" ]
+    (List.map (string_field "code") alerts);
+  Alcotest.(check (list string))
+    "error severity"
+    [ "error" ]
+    (List.map (string_field "severity") alerts);
+  Alcotest.(check int)
+    "summary error alerts"
+    1
+    (int_field "error_alerts" (alert_summary json));
+  Alcotest.(check int)
+    "summary starving keepers"
+    1
+    (int_field "librarian_starving_keepers" (alert_summary json))
+;;
+
+let test_librarian_failures_with_snapshot_is_warn_alert () =
+  let base = fresh_dir "masc-memory-health-failwarn" in
+  let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path:base in
+  let keeper_id = "failing-" ^ Filename.basename base in
+  ignore (write_snapshot ~keepers_dir ~keeper_id [ fact "existing memory" ]);
+  Metrics.inc_counter
+    KeeperMetrics.(to_string MemoryOsLibrarianFailures)
+    ~labels:[ "keeper", keeper_id; "site", "memory_os_librarian" ]
+    ~delta:2.0
+    ();
+  let json = Health.keeper_memory_health_http_json ~base_path:base in
+  let keeper = keeper_obj keeper_id json in
+  Alcotest.(check bool) "snapshot_present" true (bool_field "snapshot_present" keeper);
+  let alerts = list_field "alerts" keeper in
+  Alcotest.(check (list string))
+    "failures code"
+    [ "librarian_failures" ]
+    (List.map (string_field "code") alerts);
+  Alcotest.(check (list string))
+    "warn severity"
+    [ "warn" ]
+    (List.map (string_field "severity") alerts);
+  Alcotest.(check int)
+    "summary error alerts"
+    0
+    (int_field "error_alerts" (alert_summary json))
+;;
+
 let () =
   Alcotest.run
     "server_dashboard_http_keeper_memory_health"
@@ -248,6 +338,12 @@ let () =
             test_corrupt_snapshot_is_visible_as_read_error
         ; Alcotest.test_case "sort and empty store" `Quick
             test_sorts_by_snapshot_bytes_and_handles_empty_store
+        ; Alcotest.test_case "configured keeper without snapshot" `Quick
+            test_configured_keeper_without_snapshot_gets_row
+        ; Alcotest.test_case "librarian starvation error alert" `Quick
+            test_librarian_starvation_is_error_alert
+        ; Alcotest.test_case "librarian failures warn alert" `Quick
+            test_librarian_failures_with_snapshot_is_warn_alert
         ] )
     ]
 ;;

--- a/test/test_server_dashboard_http_keeper_memory_health.ml
+++ b/test/test_server_dashboard_http_keeper_memory_health.ml
@@ -240,11 +240,16 @@ let test_sorts_by_snapshot_bytes_and_handles_empty_store () =
   Alcotest.(check int) "empty bytes" 0 (int_field "snapshot_bytes" (totals empty))
 ;;
 
-let write_keeper_config ~keepers_dir ~keeper_id =
+(* Canonical identity comes from [keeper.name] with a file-basename fallback
+   (keeper_types_profile_toml_io.inspect_keeper_toml). [name] defaults to the
+   basename because that is the fleet norm;
+   [test_toml_name_override_uses_canonical_identity] exercises the split. *)
+let write_keeper_config ?name ~keepers_dir ~keeper_id () =
   Fs_compat.mkdir_p keepers_dir;
+  let canonical = Option.value name ~default:keeper_id in
   Fs_compat.save_file
     (Filename.concat keepers_dir (keeper_id ^ ".toml"))
-    "name = \"stub\"\n"
+    (Printf.sprintf "[keeper]\nname = %S\n" canonical)
 ;;
 
 (* A keeper that has a config but never committed memory is exactly the case
@@ -253,7 +258,7 @@ let test_configured_keeper_without_snapshot_gets_row () =
   let base = fresh_dir "masc-memory-health-configured" in
   let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path:base in
   let keeper_id = "configured-" ^ Filename.basename base in
-  write_keeper_config ~keepers_dir ~keeper_id;
+  write_keeper_config ~keepers_dir ~keeper_id ();
   let json = Health.keeper_memory_health_http_json ~base_path:base in
   let keeper = keeper_obj keeper_id json in
   Alcotest.(check bool) "snapshot_present" false (bool_field "snapshot_present" keeper);
@@ -268,7 +273,7 @@ let test_librarian_starvation_is_error_alert () =
   let base = fresh_dir "masc-memory-health-starve" in
   let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path:base in
   let keeper_id = "starving-" ^ Filename.basename base in
-  write_keeper_config ~keepers_dir ~keeper_id;
+  write_keeper_config ~keepers_dir ~keeper_id ();
   Metrics.inc_counter
     KeeperMetrics.(to_string MemoryOsLibrarianFailures)
     ~labels:[ "keeper", keeper_id; "site", "memory_os_librarian" ]
@@ -324,6 +329,54 @@ let test_librarian_failures_with_snapshot_is_warn_alert () =
     (int_field "error_alerts" (alert_summary json))
 ;;
 
+(* Metrics and snapshots are keyed by the canonical [name] in the toml, not
+   by the file basename; enumeration must surface the canonical identity or
+   a renamed keeper's starvation stays invisible behind a ghost row. *)
+let test_toml_name_override_uses_canonical_identity () =
+  let base = fresh_dir "masc-memory-health-rename" in
+  let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path:base in
+  let canonical = "actual-" ^ Filename.basename base in
+  write_keeper_config ~name:canonical ~keepers_dir ~keeper_id:"alias" ();
+  Metrics.inc_counter
+    KeeperMetrics.(to_string MemoryOsLibrarianFailures)
+    ~labels:[ "keeper", canonical; "site", "memory_os_librarian" ]
+    ~delta:1.0
+    ();
+  let json = Health.keeper_memory_health_http_json ~base_path:base in
+  Alcotest.(check (list string)) "canonical row only" [ canonical ] (keeper_ids json);
+  let keeper = keeper_obj canonical json in
+  Alcotest.(check int) "failures visible" 1 (int_field "librarian_failures" keeper);
+  Alcotest.(check (list string))
+    "starvation on canonical row"
+    [ "librarian_starvation" ]
+    (list_field "alerts" keeper |> List.map (string_field "code"))
+;;
+
+(* The pre-librarian snapshot read failure aborts before the librarian runs
+   and increments the counter under its own site label; the health row must
+   count it or a keeper with a corrupt first snapshot reports failure-free. *)
+let test_counts_snapshot_read_site_failures () =
+  let base = fresh_dir "masc-memory-health-readsite" in
+  let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path:base in
+  let keeper_id = "readfail-" ^ Filename.basename base in
+  write_keeper_config ~keepers_dir ~keeper_id ();
+  Metrics.inc_counter
+    KeeperMetrics.(to_string MemoryOsLibrarianFailures)
+    ~labels:[ "keeper", keeper_id; "site", "memory_os_current_read" ]
+    ~delta:2.0
+    ();
+  let json = Health.keeper_memory_health_http_json ~base_path:base in
+  let keeper = keeper_obj keeper_id json in
+  Alcotest.(check int)
+    "read-site failures counted"
+    2
+    (int_field "librarian_failures" keeper);
+  Alcotest.(check (list string))
+    "starvation error raised"
+    [ "librarian_starvation" ]
+    (list_field "alerts" keeper |> List.map (string_field "code"))
+;;
+
 let () =
   Alcotest.run
     "server_dashboard_http_keeper_memory_health"
@@ -344,6 +397,10 @@ let () =
             test_librarian_starvation_is_error_alert
         ; Alcotest.test_case "librarian failures warn alert" `Quick
             test_librarian_failures_with_snapshot_is_warn_alert
+        ; Alcotest.test_case "toml name override canonical identity" `Quick
+            test_toml_name_override_uses_canonical_identity
+        ; Alcotest.test_case "snapshot read site failures counted" `Quick
+            test_counts_snapshot_read_site_failures
         ] )
     ]
 ;;


### PR DESCRIPTION
## 문제 (#26527)

librarian이 07-31 현재 15/15 전실패인데 로그에는 `cause=oas_execution_failed` 한 토큰만 남는다.

1. `keeper_librarian_runtime.exact_execution_error`가 `Flow_exact_execution_failed { candidate; cause; evidence }`의 payload(실패 슬롯, typed cause, provider raw body, flow journey)를 `_`로 폐기하고 정적 라벨로 치환한다 — 어느 슬롯이 왜 죽었는지 사후 판별 불가 (`details=null`).
2. memory health endpoint가 `*.memory-current.json` 파일 열거 기반이라 스냅샷 없는 keeper(현재 10 중 7)는 행 자체가 없다 — 굶주림이 구조적으로 비가시.
3. alert severity가 `"warn"` 하드코딩 — librarian 전멸도 warn 이상으로 표현할 수 없다.

## 변경

1. **`Keeper_exact_flow_detail` 신설 (문자열 collapse 제거 + 렌더러 SSOT 추출)**: hitl_summary_worker의 사설 렌더러(flow_evidence / rejection / execution_cause 계열)를 공유 모듈로 이동해 두 소비자(hitl, librarian)가 동일하게 렌더한다. 신규 `execution_error_detail`은 call_id + typed cause + **provider raw_response 발췌**(240B 바운드, 초과 시 총 바이트 수 + body sha256 명시)를 렌더한다.
2. **librarian runtime**: collapse 지점에서 payload를 렌더한다 (기존 정적 라벨은 prefix로 유지 — 기존 grep 호환). 스냅샷 부재 상태의 실패는 `Log.Keeper.error`로 승격하고 `current_snapshot=absent|present`를 명시한다 — 메모리 없는 keeper가 실패하면 스스로 그 상태를 벗어날 수 없으므로 WARN이 아니라 ERROR다.
3. **memory health endpoint**: keeper 열거를 configured(`*.toml`) ∪ snapshot 파일 union으로 교체(스냅샷 없는 keeper도 행 확보), `snapshot_present` / `librarian_failures` 필드 추가, `librarian_starvation`(**error**) · `librarian_failures`(warn) alert 추가, `alert_json` severity 파라미터화, alert_summary에 warn/error 분리 집계와 `librarian_starving_keepers` 추가.

## 검증

- `dune build lib/keeper lib/server` green.
- 신규 테스트 `test_keeper_exact_flow_detail` 4건(typed cause 렌더, raw 발췌 바운드·개행 평탄화·sha 유지) + health 신규 3건(config-only keeper 행 확보, starvation=error alert, failures=warn alert) 포함 12/12 통과.
- 라이브 진단 경로: 배포 후 다음 librarian 실패 로그가 슬롯·cause·raw body를 직접 담는다 → #26527 root-fix의 입력.

## 경계

- counter/dedup/cap/cooldown 추가 없음. 이미 wire를 건너온 typed payload의 폐기를 중단하고(문자열 collapse 제거), health 열거의 정합성 버그를 고치고, 기존 counter(`MemoryOsLibrarianFailures`)를 기존 health 표면에 연결했다. 슬롯 실패 자체의 root-fix는 #26527에서 이 가시성 데이터를 입력으로 진행한다.
- OAS 변경 없음 — payload는 이미 OAS가 전달하고 있었고 MASC 소비자가 버리고 있었다.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
