### PR TITLE
fix(keeper): 소진된 lane에서 관측된 overflow가 대표 에러가 되도록 보존

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -162,11 +162,26 @@ let attempt_runtime_candidates
        ?decision:Yojson.Safe.t ->
        Keeper_runtime_manifest.event_kind ->
        unit) ~run_attempt candidates =
-  let rec loop idx = function
+  (* A typed overflow observed on any candidate is a fact about this turn's
+     input, not about whichever candidate happened to fail last. When the
+     lane ends on a different recoverable error (for example a rate-limited
+     fallback), returning that last error hides the overflow from
+     [context_overflow_event_of_error], the keeper never enters the
+     overflowed phase, and compaction never fires while every cycle repeats
+     the same oversized input (#26530). Remember the first typed overflow
+     and let it represent a naturally exhausted lane. A lane that stops on a
+     non-recoverable error keeps that error: it is the immediate operator
+     signal, and the overflow will be observed again on the next cycle. *)
+  let rec loop ~observed_overflow idx = function
     | [] ->
-      Error
-        (Agent_sdk.Error.Internal
-           (Printf.sprintf "runtime lane %S exhausted all candidates" runtime_id))
+      (match observed_overflow with
+       | Some overflow_error -> Error overflow_error
+       | None ->
+         Error
+           (Agent_sdk.Error.Internal
+              (Printf.sprintf
+                 "runtime lane %S exhausted all candidates"
+                 runtime_id)))
     | candidate :: rest ->
       let is_last = rest = [] in
       let attempt_runtime_id = runtime_id_of candidate in
@@ -216,8 +231,27 @@ let attempt_runtime_candidates
              ~allow_accept_no_progress_retry
              error
          in
+         let observed_overflow =
+           match observed_overflow with
+           | Some _ -> observed_overflow
+           | None ->
+             if
+               Keeper_turn_driver_try_runtime.context_overflow_should_try_next
+                 error
+             then Some error
+             else None
+         in
          if retry_admitted && retryable_with_input_authority
-         then loop (idx + 1) rest
+         then loop ~observed_overflow (idx + 1) rest
+         else if is_last
+         then (
+           (* Lane fully exhausted: an overflow seen anywhere in the rotation
+              outranks the last candidate's error so the reactive compaction
+              trigger fires. Cascade telemetry already published each
+              candidate's own error. *)
+           match observed_overflow with
+           | Some overflow_error -> Error overflow_error
+           | None -> Error error)
          else (
            (match retryable_with_input_authority, rest with
             | true, next :: later ->
@@ -231,7 +265,7 @@ let attempt_runtime_candidates
             | false, _ | true, [] -> ());
            Error error))
   in
-  loop 0 candidates
+  loop ~observed_overflow:None 0 candidates
 
 let runtime_candidate_missing_error id =
   Agent_sdk.Error.Internal

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -1119,6 +1119,81 @@ let test_attempt_loop_overflow_on_last_candidate_is_terminal () =
     [ "small.test_model"; "smaller.test_model" ]
     !attempts
 
+(* #26530: an overflow on an earlier candidate must survive lane exhaustion.
+   Live incident 2026-07-31: glm overflowed, the ollama fallback then failed
+   with a rate limit, the lane returned that rate limit, the keeper FSM never
+   entered the overflowed phase, and compaction never fired while every cycle
+   replayed the same oversized checkpoint. *)
+let test_attempt_loop_exhaustion_preserves_earlier_overflow () =
+  let attempts = ref [] in
+  let result =
+    Driver.For_testing.attempt_runtime_candidates
+      ~runtime_id:"resilient"
+      ~runtime_id_of:(fun runtime_id -> runtime_id)
+      ~emit_runtime_manifest:(fun ?status:_ ?decision:_ _ -> ())
+      ~run_attempt:(fun ~idx:_ ~runtime_id candidate ->
+        attempts := !attempts @ [ runtime_id ];
+        match candidate with
+        | "small.test_model" ->
+          Error (context_overflow_error "prompt exceeds context window"), None
+        | "fallback.test_model" ->
+          ( Error
+              (Agent_sdk.Error.Api
+                 (Agent_sdk.Retry.RateLimited
+                    { retry_after = None; message = "weekly usage limit" }))
+          , None )
+        | other -> Alcotest.failf "unexpected candidate %s" other)
+      [ "small.test_model"; "fallback.test_model" ]
+  in
+  (match result with
+   | Ok _ -> Alcotest.fail "expected exhausted lane"
+   | Error err ->
+     Alcotest.(check bool)
+       "typed overflow outranks the fallback rate limit"
+       true
+       (Masc.Keeper_error_classify.is_context_overflow err));
+  Alcotest.(check (list string))
+    "both candidates attempted"
+    [ "small.test_model"; "fallback.test_model" ]
+    !attempts
+
+(* Overflow precedence applies only to an exhausted lane: a walk stopped
+   mid-lane by a non-retryable error keeps that stopping error, which is the
+   immediate operator signal. *)
+let test_attempt_loop_midwalk_terminal_outranks_observed_overflow () =
+  let attempts = ref [] in
+  let result =
+    Driver.For_testing.attempt_runtime_candidates
+      ~runtime_id:"resilient"
+      ~runtime_id_of:(fun runtime_id -> runtime_id)
+      ~emit_runtime_manifest:(fun ?status:_ ?decision:_ _ -> ())
+      ~run_attempt:(fun ~idx:_ ~runtime_id candidate ->
+        attempts := !attempts @ [ runtime_id ];
+        match candidate with
+        | "small.test_model" ->
+          Error (context_overflow_error "prompt exceeds context window"), None
+        | "broken.test_model" ->
+          Error (Agent_sdk.Error.Internal "hard mid-lane failure"), None
+        | other ->
+          Alcotest.failf "walk must stop before candidate %s" other)
+      [ "small.test_model"; "broken.test_model"; "fallback.test_model" ]
+  in
+  (match result with
+   | Ok _ -> Alcotest.fail "expected mid-lane stop"
+   | Error (Agent_sdk.Error.Internal msg) ->
+     Alcotest.(check string)
+       "stopping error preserved"
+       "hard mid-lane failure"
+       msg
+   | Error e ->
+     Alcotest.failf
+       "expected stopping Internal error, got %s"
+       (Agent_sdk.Error.to_string e));
+  Alcotest.(check (list string))
+    "walk stopped at the terminal candidate"
+    [ "small.test_model"; "broken.test_model" ]
+    !attempts
+
 let test_checkpoint_denial_defers_exact_frozen_suffix_once () =
   let attempts = ref [] in
   let deferred = ref [] in
@@ -1389,6 +1464,14 @@ let () =
             "context overflow on last candidate stays terminal"
             `Quick
             test_attempt_loop_overflow_on_last_candidate_is_terminal;
+          Alcotest.test_case
+            "lane exhaustion preserves earlier overflow"
+            `Quick
+            test_attempt_loop_exhaustion_preserves_earlier_overflow;
+          Alcotest.test_case
+            "mid-lane terminal outranks observed overflow"
+            `Quick
+            test_attempt_loop_midwalk_terminal_outranks_observed_overflow;
           Alcotest.test_case
             "checkpoint denial defers exact frozen suffix once"
             `Quick


### PR DESCRIPTION
## 문제 (#26530)

2026-07-31 fleet 전멸 라이브 인시던트의 코드 절반. chat lane `[glm-coding.glm-5-turbo → ollama_cloud.deepseek-v4-flash]`에서:

1. glm 1순위가 typed `ContextOverflow`(`model_context_window_exceeded`)로 실패 — 컴팩션 트리거가 되어야 할 신호.
2. rotation이 다음 후보로 진행하며 그 에러를 **폐기**하고, 소진된 lane은 마지막 후보(ollama 429)의 에러만 반환.
3. `context_overflow_event_of_error`가 429만 보므로 keeper FSM이 `overflowed` phase에 진입하지 못하고(재시작 후 실측: `overflowed` 전이 0건, 전부 `turn_failed`), 컴팩션이 영구 미발동 — 같은 비대 체크포인트를 매 사이클 반복하는 자기 유지 루프.

`lane_should_retry`의 기존 주석이 이미 자인하고 있었다: "Overflow on the **last** candidate still returns the typed error" — 마지막이 아닌 후보의 overflow는 소진 시 사라진다.

## 변경

`attempt_runtime_candidates`(keeper_turn_driver.ml) 한 함수:

- rotation을 걸으며 **첫 typed `ContextOverflow`를 기억**하고(판별은 기존 `context_overflow_should_try_next` 재사용 — `Api (ContextOverflow _)`만), **lane이 완전히 소진(`is_last` 도달 또는 후보 고갈)되었을 때 마지막 에러 대신 그 overflow를 반환**한다. 하류의 기존 컴팩션 경로(`context_overflow_event_of_error` → `Provider_overflow` 트리거 → `overflowed` phase)가 수정 없이 그대로 발동한다.
- **불변 경로**: 성공(어느 후보든 성공하면 overflow 관측 무의미), 중도 중단(비재시도성 에러는 즉각적 운영 신호이므로 그대로 반환 — overflow는 다음 사이클에 다시 관측된다), deferred lane hint 게시, 마지막 후보 자체가 overflow인 경우(기존 동작 동일).

시그니처 자기 점검: cap/cooldown/dedup/counter 추가 없음 — 이미 typed로 존재하던 신호가 rotation에서 버려지던 것을 보존하는 변경이며, string 분류기가 아니라 기존 typed 판별식 재사용이다.

## 검증

- 신규 회귀 테스트 2건 (`test_keeper_turn_driver_failover`):
  - `lane exhaustion preserves earlier overflow` — 인시던트 시나리오 그대로: [overflow → RateLimited] 소진 lane이 overflow를 반환 (`is_context_overflow` 판정).
  - `mid-lane terminal outranks observed overflow` — overflow 관측 후 중도 비재시도성 에러는 그 에러 유지 + walk가 거기서 멈춤.
- 기존 failover 스위트(29건) 전체 통과 — 특히 `preserves last SDK error`(overflow 무관측 시 기존 동작), `overflow on last candidate stays terminal`(기존 동작), hint/checkpoint 계열 무변경 확인.

## 경계

- 이 PR은 신호 전파만 고친다. lane 구성(glm 단일 living 후보), ollama weekly 쿼터, 슬롯 생체반응 표면(#26531)은 별개.
- 라이브 검증 경로: 배포 후 fallback까지 소진되는 overflow 사이클에서 `overflowed → compacting` 전이가 로그에 나타나야 한다.

Fixes #26530

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
