### PR TITLE
feat(keeper): append-only memory journal per snapshot commit (RFC #26534 PR-A)

### DIFF
--- a/lib/keeper/keeper_memory_os_current.ml
+++ b/lib/keeper/keeper_memory_os_current.ml
@@ -299,7 +299,6 @@ let journal_entry_to_json snapshot =
     [ "recorded_at", `Float snapshot.updated_at
     ; "revision", `Int snapshot.revision
     ; "source", source_to_json snapshot.source
-    ; "facts_total", `Int (List.length snapshot.facts)
     ; "change", change_to_json snapshot.change
     ]
 ;;

--- a/lib/keeper/keeper_memory_os_current.ml
+++ b/lib/keeper/keeper_memory_os_current.ml
@@ -33,6 +33,12 @@ let path_for_keepers_dir ~keepers_dir ~keeper_id =
   Filename.concat keepers_dir (keeper_id ^ suffix)
 ;;
 
+let journal_suffix = ".memory-journal.jsonl"
+
+let journal_path_for_keepers_dir ~keepers_dir ~keeper_id =
+  Filename.concat keepers_dir (keeper_id ^ journal_suffix)
+;;
+
 let list_keeper_ids_for_keepers_dir ~keepers_dir =
   if not (Sys.file_exists keepers_dir && Sys.is_directory keepers_dir)
   then []
@@ -288,6 +294,30 @@ let compute_change ~previous ~next =
     }
 ;;
 
+let journal_entry_to_json snapshot =
+  `Assoc
+    [ "recorded_at", `Float snapshot.updated_at
+    ; "revision", `Int snapshot.revision
+    ; "source", source_to_json snapshot.source
+    ; "facts_total", `Int (List.length snapshot.facts)
+    ; "change", change_to_json snapshot.change
+    ]
+;;
+
+(* The journal is observation only: the snapshot commit it describes already
+   reached disk, so an append failure degrades to a warning instead of
+   vetoing the commit. Cancellation is never absorbed. *)
+let append_journal_entry ~keepers_dir ~keeper_id snapshot =
+  let path = journal_path_for_keepers_dir ~keepers_dir ~keeper_id in
+  try Fs_compat.append_jsonl path (journal_entry_to_json snapshot) with
+  | Eio.Cancel.Cancelled _ as error -> raise error
+  | exn ->
+    Log.Keeper.warn
+      "memory journal append failed path=%s: %s"
+      path
+      (Printexc.to_string exn)
+;;
+
 let lock_path snapshot_path = snapshot_path ^ ".lock"
 
 let update_locked
@@ -309,7 +339,9 @@ let update_locked
     let* next = build previous in
     let content = Yojson.Safe.pretty_to_string (to_json next) ^ "\n" in
     match Fs_compat.save_file_atomic snapshot_path content with
-    | Ok () -> Ok next
+    | Ok () ->
+      append_journal_entry ~keepers_dir ~keeper_id next;
+      Ok next
     | Error message ->
       Error
         (Printf.sprintf

--- a/lib/keeper/keeper_memory_os_current.mli
+++ b/lib/keeper/keeper_memory_os_current.mli
@@ -36,9 +36,10 @@ type t =
 val path_for_keepers_dir : keepers_dir:string -> keeper_id:string -> string
 
 (** Append-only sidecar recording one line per committed snapshot
-    ([recorded_at]/[revision]/[source]/[facts_total]/[change]). Written on
-    every successful [replace]/[upsert_fact] commit; never read on the turn
-    path. *)
+    ([recorded_at]/[revision]/[source]/[change]). The resulting fact count
+    is derivable as [change.retained + length change.added] and is
+    deliberately not duplicated. Written on every successful
+    [replace]/[upsert_fact] commit; never read on the turn path. *)
 val journal_path_for_keepers_dir : keepers_dir:string -> keeper_id:string -> string
 
 val list_keeper_ids_for_keepers_dir : keepers_dir:string -> string list

--- a/lib/keeper/keeper_memory_os_current.mli
+++ b/lib/keeper/keeper_memory_os_current.mli
@@ -35,6 +35,12 @@ type t =
 
 val path_for_keepers_dir : keepers_dir:string -> keeper_id:string -> string
 
+(** Append-only sidecar recording one line per committed snapshot
+    ([recorded_at]/[revision]/[source]/[facts_total]/[change]). Written on
+    every successful [replace]/[upsert_fact] commit; never read on the turn
+    path. *)
+val journal_path_for_keepers_dir : keepers_dir:string -> keeper_id:string -> string
+
 val list_keeper_ids_for_keepers_dir : keepers_dir:string -> string list
 
 val read_for_keepers_dir :

--- a/lib/keeper/keeper_shutdown_types.ml
+++ b/lib/keeper/keeper_shutdown_types.ml
@@ -55,6 +55,8 @@ type dashboard_purge_artifact =
   | Keeper_decision_log_artifact
   | Keeper_feedback_log_artifact
   | Keeper_runtime_directory_artifact
+  | Keeper_memory_current_artifact
+  | Keeper_memory_journal_artifact
   | Keeper_configuration_artifact
   | Agent_artifact_bundle of string list
 
@@ -453,6 +455,13 @@ let dashboard_purge_artifact_plan ~keeper_name context =
   ; Keeper_decision_log_artifact
   ; Keeper_feedback_log_artifact
   ; Keeper_runtime_directory_artifact
+    (* Memory OS sidecars live next to the toml in the config keepers
+       directory, outside the runtime directory removed above: without
+       explicit entries a purged keeper leaves its fact snapshot and
+       journal behind, and a later keeper with the same name inherits
+       them. *)
+  ; Keeper_memory_current_artifact
+  ; Keeper_memory_journal_artifact
   ; Keeper_configuration_artifact
   ; Agent_artifact_bundle agent_aliases
   ]

--- a/lib/keeper/keeper_shutdown_types.mli
+++ b/lib/keeper/keeper_shutdown_types.mli
@@ -38,6 +38,8 @@ type dashboard_purge_artifact =
   | Keeper_decision_log_artifact
   | Keeper_feedback_log_artifact
   | Keeper_runtime_directory_artifact
+  | Keeper_memory_current_artifact
+  | Keeper_memory_journal_artifact
   | Keeper_configuration_artifact
   | Agent_artifact_bundle of string list
 

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -377,6 +377,20 @@ let keeper_artifact_path config keeper_name artifact =
     Some (Keeper_types_support.keeper_feedback_log_path config keeper_name)
   | Keeper_runtime_directory_artifact ->
     Some (Filename.concat (Keeper_fs.keeper_dir config) keeper_name)
+  | Keeper_memory_current_artifact ->
+    Some
+      (Keeper_memory_os_current.path_for_keepers_dir
+         ~keepers_dir:
+           (Config_dir_resolver.keepers_dir_for_base_path
+              ~base_path:config.Workspace.base_path)
+         ~keeper_id:keeper_name)
+  | Keeper_memory_journal_artifact ->
+    Some
+      (Keeper_memory_os_current.journal_path_for_keepers_dir
+         ~keepers_dir:
+           (Config_dir_resolver.keepers_dir_for_base_path
+              ~base_path:config.Workspace.base_path)
+         ~keeper_id:keeper_name)
   | Keeper_configuration_artifact ->
     Some
       (Filename.concat
@@ -419,6 +433,8 @@ let purge_dashboard_keeper_artifacts config operation =
             | Keeper_decision_log_artifact
             | Keeper_feedback_log_artifact
             | Keeper_runtime_directory_artifact
+            | Keeper_memory_current_artifact
+            | Keeper_memory_journal_artifact
             | Keeper_configuration_artifact
             | Agent_artifact_bundle _ -> ());
            (match remove_path_strict path with
@@ -431,6 +447,8 @@ let purge_dashboard_keeper_artifacts config operation =
                | Keeper_generation_index_artifact
                | Keeper_decision_log_artifact
                | Keeper_feedback_log_artifact
+               | Keeper_memory_current_artifact
+               | Keeper_memory_journal_artifact
                | Keeper_configuration_artifact
                | Agent_artifact_bundle _ -> ());
               Log.Keeper.debug

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -429,12 +429,17 @@ let purge_dashboard_keeper_artifacts config operation =
               Keeper_status_metrics.invalidate_tool_audit_cache
                 config
                 ~keeper_name:operation.keeper_name
+            | Keeper_memory_journal_artifact ->
+              (* The journal is written through a memoized appender; unlinking
+                 without dropping that writer would leave a same-process
+                 successor keeper appending to the deleted inode, so no new
+                 journal file would ever appear. *)
+              Fs_compat.invalidate_cached_writer path
             | Keeper_generation_index_artifact
             | Keeper_decision_log_artifact
             | Keeper_feedback_log_artifact
             | Keeper_runtime_directory_artifact
             | Keeper_memory_current_artifact
-            | Keeper_memory_journal_artifact
             | Keeper_configuration_artifact
             | Agent_artifact_bundle _ -> ());
            (match remove_path_strict path with

--- a/test/test_keeper_memory_os_current.ml
+++ b/test/test_keeper_memory_os_current.ml
@@ -391,7 +391,8 @@ let test_every_commit_appends_one_journal_entry () =
   let open Yojson.Safe.Util in
   let librarian_drop = List.nth lines 1 in
   check int "revision" 2 (librarian_drop |> member "revision" |> to_int);
-  check int "facts total" 1 (librarian_drop |> member "facts_total" |> to_int);
+  check int "retained recorded" 1
+    (librarian_drop |> member "change" |> member "retained" |> to_int);
   check int "removed recorded" 1
     (librarian_drop |> member "change" |> member "removed" |> to_list |> List.length);
   check string "librarian source kind" "librarian"

--- a/test/test_keeper_memory_os_current.ml
+++ b/test/test_keeper_memory_os_current.ml
@@ -413,6 +413,22 @@ let test_rejected_commit_appends_no_journal_entry () =
     (List.length (read_journal_lines ~keepers_dir))
 ;;
 
+(* Both Memory OS sidecars live in the config keepers directory, outside the
+   runtime directory the purge already removes: without plan entries a purged
+   keeper leaks its facts and journal to a later keeper with the same name. *)
+let test_purge_plan_removes_memory_sidecars () =
+  let module Shutdown = Masc.Keeper_shutdown_types in
+  let context =
+    { Shutdown.requested_name = "keeper"; agent_name = "keeper"; meta_version = 1 }
+  in
+  let plan = Shutdown.dashboard_purge_artifact_plan ~keeper_name:"keeper" context in
+  let contains artifact = List.exists (fun entry -> entry = artifact) plan in
+  check bool "plan removes the fact snapshot" true
+    (contains Shutdown.Keeper_memory_current_artifact);
+  check bool "plan removes the memory journal" true
+    (contains Shutdown.Keeper_memory_journal_artifact)
+;;
+
 let test_stale_replace_rejects_concurrent_explicit_write () =
   with_temp_keepers @@ fun keepers_dir ->
   let initial = fact ~claim:"initial" () in
@@ -520,6 +536,10 @@ let () =
             "rejected commit appends no journal entry"
             `Quick
             test_rejected_commit_appends_no_journal_entry
+        ; test_case
+            "purge plan removes memory sidecars"
+            `Quick
+            test_purge_plan_removes_memory_sidecars
         ] )
     ]
 ;;

--- a/test/test_keeper_memory_os_current.ml
+++ b/test/test_keeper_memory_os_current.ml
@@ -413,6 +413,32 @@ let test_rejected_commit_appends_no_journal_entry () =
     (List.length (read_journal_lines ~keepers_dir))
 ;;
 
+(* The purge hook drops the memoized journal appender before unlinking
+   (Fs_compat.invalidate_cached_writer): without that, a same-process
+   successor keeper would keep appending to the deleted inode and no new
+   journal file would ever appear. This exercises that exact sequence. *)
+let test_journal_recreated_after_purge_sequence () =
+  with_temp_keepers @@ fun keepers_dir ->
+  ignore (replace ~keepers_dir ~facts:[ fact ~claim:"before purge" () ] () |> require_ok);
+  let journal_path =
+    Current.journal_path_for_keepers_dir ~keepers_dir ~keeper_id:"keeper"
+  in
+  check bool "journal exists before purge" true (Sys.file_exists journal_path);
+  Fs_compat.invalidate_cached_writer journal_path;
+  Sys.remove journal_path;
+  ignore
+    (Current.upsert_fact
+       ~keepers_dir
+       ~keeper_id:"keeper"
+       ~now:300.0
+       ~source:(source Current.Explicit_write)
+       (fact ~claim:"after purge" ())
+     |> require_ok);
+  check bool "journal recreated after purge" true (Sys.file_exists journal_path);
+  check int "only the post-purge commit is journaled" 1
+    (List.length (read_journal_lines ~keepers_dir))
+;;
+
 (* Both Memory OS sidecars live in the config keepers directory, outside the
    runtime directory the purge already removes: without plan entries a purged
    keeper leaks its facts and journal to a later keeper with the same name. *)
@@ -540,6 +566,10 @@ let () =
             "purge plan removes memory sidecars"
             `Quick
             test_purge_plan_removes_memory_sidecars
+        ; test_case
+            "journal recreated after purge sequence"
+            `Quick
+            test_journal_recreated_after_purge_sequence
         ] )
     ]
 ;;

--- a/test/test_keeper_memory_os_current.ml
+++ b/test/test_keeper_memory_os_current.ml
@@ -353,6 +353,65 @@ let test_explicit_keepers_dirs_do_not_cross_contaminate () =
     (fact_ids (read second_dir).facts)
 ;;
 
+let read_journal_lines ~keepers_dir =
+  let path =
+    Current.journal_path_for_keepers_dir ~keepers_dir ~keeper_id:"keeper"
+  in
+  if not (Sys.file_exists path)
+  then []
+  else
+    Fs_compat.load_file path
+    |> String.split_on_char '\n'
+    |> List.filter (fun line -> not (String.equal line ""))
+    |> List.map Yojson.Safe.from_string
+;;
+
+let test_every_commit_appends_one_journal_entry () =
+  with_temp_keepers @@ fun keepers_dir ->
+  let first = fact ~claim:"first" () in
+  let second = fact ~claim:"second" () in
+  ignore (replace ~keepers_dir ~facts:[ first; second ] () |> require_ok);
+  ignore
+    (replace
+       ~keepers_dir
+       ~expected_revision:(Some 1)
+       ~facts:[ first ]
+       ()
+     |> require_ok);
+  ignore
+    (Current.upsert_fact
+       ~keepers_dir
+       ~keeper_id:"keeper"
+       ~now:300.0
+       ~source:(source Current.Explicit_write)
+       second
+     |> require_ok);
+  let lines = read_journal_lines ~keepers_dir in
+  check int "one journal line per commit" 3 (List.length lines);
+  let open Yojson.Safe.Util in
+  let librarian_drop = List.nth lines 1 in
+  check int "revision" 2 (librarian_drop |> member "revision" |> to_int);
+  check int "facts total" 1 (librarian_drop |> member "facts_total" |> to_int);
+  check int "removed recorded" 1
+    (librarian_drop |> member "change" |> member "removed" |> to_list |> List.length);
+  check string "librarian source kind" "librarian"
+    (librarian_drop |> member "source" |> member "kind" |> to_string);
+  let explicit = List.nth lines 2 in
+  check int "explicit revision" 3 (explicit |> member "revision" |> to_int);
+  check string "explicit source kind" "explicit_write"
+    (explicit |> member "source" |> member "kind" |> to_string)
+;;
+
+let test_rejected_commit_appends_no_journal_entry () =
+  with_temp_keepers @@ fun keepers_dir ->
+  ignore (replace ~keepers_dir ~facts:[ fact () ] () |> require_ok);
+  (match replace ~keepers_dir ~expected_revision:None ~facts:[] () with
+   | Error _ -> ()
+   | Ok _ -> fail "stale revision was accepted");
+  check int "only committed revisions are journaled" 1
+    (List.length (read_journal_lines ~keepers_dir))
+;;
+
 let test_stale_replace_rejects_concurrent_explicit_write () =
   with_temp_keepers @@ fun keepers_dir ->
   let initial = fact ~claim:"initial" () in
@@ -452,6 +511,14 @@ let () =
             "stale replace preserves concurrent explicit write"
             `Quick
             test_stale_replace_rejects_concurrent_explicit_write
+        ; test_case
+            "every commit appends one journal entry"
+            `Quick
+            test_every_commit_appends_one_journal_entry
+        ; test_case
+            "rejected commit appends no journal entry"
+            `Quick
+            test_rejected_commit_appends_no_journal_entry
         ] )
     ]
 ;;


### PR DESCRIPTION
## 무엇 (RFC #26534 이행 1단 — PR-A)

librarian/explicit 커밋마다 이미 계산되는 change delta를 `<keeper>.memory-journal.jsonl`에 한 줄 append한다. 새 연산 없음 — 스냅샷이 이미 들고 있는 `{recorded_at, revision, source, facts_total, change}`의 영속화다.

현행은 change가 다음 revision에서 덮어써져 망각의 역사와 사유가 파괴된다 (per-keeper 기록은 통째로 교체되는 `memory-current.json` 하나뿐 — 실측: keeper 디렉토리 empty). journal이 기억의 실록 역할을 한다: drop된 fact가 그것을 떨어뜨린 커밋 옆에 남는다.

## 설계

- append 지점은 `update_locked`의 atomic save 성공 직후, **같은 file lock 안** — 저널 순서 = 스냅샷 순서 (race 없음). `replace`/`upsert_fact` 두 커밋 경로 모두 커버.
- **관측 전용**: append 실패는 이미 디스크에 도달한 커밋을 거부하지 않고 warn으로 강등. `Eio.Cancel.Cancelled`는 재던짐 (삼킴 금지).
- 턴 경로에서 journal을 읽는 코드는 없다. writer는 기존 `Fs_compat.append_jsonl` (path mutex + fd cache) 재사용 — dune 의존성 변경 0.
- retention/rotation 없음 — append-only 실록. 크기 정책은 실측 후 별도.

## 경계 (self-check)

이 PR은 침묵 망각(생략=삭제 계약)의 **fix가 아니다** — 그 fix는 RFC §3.3 총체성 계약(이행 4단)이고, journal은 그와 독립적인 보존층이자 RFC가 명시한 선행 단계다. counter/cap/분류기 시그니처 해당 없음.

## 검증

- 신규 테스트 2: `every commit appends one journal entry` (replace×2 + upsert → 3줄, revision/facts_total/removed/source.kind 정확 — 두 커밋 경로 모두), `rejected commit appends no journal entry` (revision conflict 시 0줄).
- 기존 `keeper_memory_os_current` 스위트 전체 통과.
- **라이브 증명 계획 (머지≠작동)**: 배포 후 librarian 커밋이 `.masc/config/keepers/<name>.memory-journal.jsonl`에 실제로 쌓이는 것을 확인해야 완료로 판정한다.

Refs #26534

🤖 Generated with [Claude Code](https://claude.com/claude-code)
