### PR TITLE
feat(keeper): project measured context from TurnRecord into fleet observation (context SSOT visibility)

### DIFF
--- a/dashboard/src/components/keeper-turn-inspector.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector.test.ts
@@ -279,6 +279,27 @@ describe('KeeperTurnInspector v2 drawer', () => {
     expect(drawerText).toContain('local')
   })
 
+  it('renders input components sorted by bytes with the wire body size', async () => {
+    fetchKeeperTurnRecordsMock.mockResolvedValue(turnRecordsWithMemoryOs())
+
+    const { container } = render(html`<${KeeperTurnInspector} keeperName="albini" />`)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('T42')
+    })
+
+    const section = container.querySelector('[data-testid="turn-input-components"]')
+    expect(section).toBeTruthy()
+    const text = section?.textContent ?? ''
+    expect(text).toContain('입력 구성')
+    expect(text).toContain('prompt.memory_os_recall')
+    expect(text).toContain('3.3KB')
+    // Sorted by bytes descending: recall (3392B) precedes persona (1200B).
+    expect(text.indexOf('prompt.memory_os_recall')).toBeLessThan(text.indexOf('prompt.persona'))
+    expect(text).toContain('합계 4.5KB')
+    expect(text).toContain('wire 547.4KB')
+  })
+
   it('matches an initial timestamp to the closest retained turn row', () => {
     const response = turnRecordsWithMemoryOs()
     const nearTurn42 = new Date((1_781_587_560 + 12) * 1000).toISOString()

--- a/dashboard/src/components/keeper-turn-inspector.ts
+++ b/dashboard/src/components/keeper-turn-inspector.ts
@@ -23,6 +23,7 @@ import type {
   ToolCallsResponse,
   TurnBlock,
   TurnBlockDiff,
+  TurnInputComponent,
   TurnRecordEntry,
   TurnRecordRow,
   TurnRecordsResponse,
@@ -106,6 +107,33 @@ function BlockRow({ block }: { block: TurnBlock }) {
       <span class="text-[var(--color-fg-disabled)]" title=${block.digest}>
         ${block.digest.slice(0, 12)}
       </span>
+    </div>
+  `
+}
+
+// Bytes label for input components: sub-KB values stay exact so small
+// prompt blocks do not all round to "0.0KB".
+function formatComponentBytes(bytes: number): string {
+  return bytes >= 1024 ? `${(bytes / 1024).toFixed(1)}KB` : `${bytes}B`
+}
+
+function sortedInputComponents(record: TurnRecordEntry): TurnInputComponent[] {
+  return [...(record.input_components ?? [])].sort((a, b) => b.bytes - a.bytes)
+}
+
+function InputComponentRow({
+  component,
+  totalBytes,
+}: {
+  component: TurnInputComponent
+  totalBytes: number
+}) {
+  const share = totalBytes > 0 ? Math.round((component.bytes / totalBytes) * 100) : 0
+  return html`
+    <div class="flex items-center gap-2 text-2xs font-mono v2-monitoring-row">
+      <span class="text-[var(--color-fg-default)]">${component.component}</span>
+      <span class="text-[var(--color-fg-muted)]">${formatComponentBytes(component.bytes)}</span>
+      <span class="text-[var(--color-fg-disabled)]">${share}%</span>
     </div>
   `
 }
@@ -412,6 +440,12 @@ thinking.budget= ${record.thinking_budget ?? '—'}
 # context blocks (조립 순서)
 ${record.blocks.length
     ? record.blocks.map(b => `  - ${b.block}  ${b.bytes}B  ${b.digest.slice(0, 12)}`).join('\n')
+    : '  (none)'}
+
+# input components (요청 조립 뷰, 큰 순)
+${record.input_components && record.input_components.length
+    ? sortedInputComponents(record).map(c => `  - ${c.component}  ${c.bytes}B`).join('\n')
+      + (record.request_body_bytes != null ? `\n  wire body = ${record.request_body_bytes}B` : '')
     : '  (none)'}
 
 # tool executions
@@ -1184,6 +1218,27 @@ function TurnRow({
             ? html`<div class="text-2xs text-[var(--color-fg-disabled)] v2-monitoring-row">기록된 블록 없음</div>`
             : record.blocks.map(block => html`<${BlockRow} block=${block} />`)}
         </div>
+        ${record.input_components && record.input_components.length > 0
+          ? (() => {
+              const components = sortedInputComponents(record)
+              const totalBytes = components.reduce((sum, c) => sum + c.bytes, 0)
+              return html`
+                <div data-testid="turn-input-components">
+                  <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)] mb-1">
+                    입력 구성 (요청 조립 뷰, 큰 순)
+                  </div>
+                  ${components.map(component =>
+                    html`<${InputComponentRow} component=${component} totalBytes=${totalBytes} />`)}
+                  <div class="flex items-center gap-2 text-2xs font-mono v2-monitoring-row">
+                    <span class="text-[var(--color-fg-muted)]">합계 ${formatComponentBytes(totalBytes)}</span>
+                    ${record.request_body_bytes != null
+                      ? html`<span class="text-[var(--color-fg-disabled)]">· wire ${formatComponentBytes(record.request_body_bytes)} (방언 투영 후 실제 요청 본문)</span>`
+                      : null}
+                  </div>
+                </div>
+              `
+            })()
+          : null}
         <div>
           <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)] mb-1">
             이전 턴 대비

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -786,9 +786,9 @@ describe('KeeperWorkspaceRail', () => {
   it('renders context metrics as missing when only a zero default exists', () => {
     const k = mkKeeper({ context_ratio: 0, compaction_count: 0 })
     const { container } = render(html`<${KeeperWorkspaceRail} keeper=${k} />`)
-    // v2 collapses the missing-context state into a single "윈도우 사용률 미수신"
+    // v2 collapses the missing-context state into a single "윈도우 사용률 미측정"
     // empty card (.ctx-empty); no fake usage meter and no usage percentage.
-    expect(container.textContent).toContain('윈도우 사용률 미수신')
+    expect(container.textContent).toContain('윈도우 사용률 미측정')
     expect(container.querySelector('.ctx-empty')).not.toBeNull()
     expect(container.textContent).not.toContain('윈도우 사용량')
     expect(container.querySelector('.meter')).toBeNull()
@@ -800,10 +800,58 @@ describe('KeeperWorkspaceRail', () => {
   it('shows token-only context without a fake window percentage', () => {
     const k = mkKeeper({ context_ratio: 0, context_tokens: 37800 })
     const { container } = render(html`<${KeeperWorkspaceRail} keeper=${k} />`)
-    expect(container.textContent).toContain('윈도우 사용률 미수신')
+    expect(container.textContent).toContain('윈도우 사용률 미측정')
     expect(container.textContent).toContain('37.8k')
     expect(container.textContent).not.toContain('윈도우 사용량')
     expect(container.querySelector('.meter')).toBeNull()
+  })
+
+  it('names the typed absence reason from the projection', () => {
+    const k = mkKeeper({
+      context_ratio: 0,
+      compaction_count: 0,
+      context_metrics_unavailable: { kind: 'not_observed', reason: 'turn_record_without_usage' },
+    })
+    const { container } = render(html`<${KeeperWorkspaceRail} keeper=${k} />`)
+    expect(container.textContent).toContain('턴 레코드 기준 측정 불가')
+    expect(container.textContent).toContain('turn_record_without_usage')
+  })
+
+  it('renders measurement provenance for a turn_record-sourced context', () => {
+    const k = mkKeeper({
+      context_ratio: 0.5,
+      context_tokens: 100887,
+      context_max: 200000,
+      context_source: 'turn_record',
+      context: {
+        source: 'turn_record',
+        context_ratio: 0.5,
+        context_tokens: 100887,
+        context_max: 200000,
+        observed_at: new Date(Date.now() - 120000).toISOString(),
+        turn_ref: 'trace-1785189111911-00004#3337',
+        absolute_turn: 3337,
+        request_body_bytes: 402408,
+      },
+    })
+    const { container } = render(html`<${KeeperWorkspaceRail} keeper=${k} />`)
+    const provenance = container.querySelector('[data-testid="ctx-provenance"]')
+    expect(provenance).not.toBeNull()
+    expect(provenance?.textContent).toContain('T3337')
+    expect(provenance?.textContent).toContain('wire')
+    expect(provenance?.textContent).toContain('393KB')
+    expect(provenance?.textContent).toContain('다음 입력에 함께 실리는 상비 페이로드')
+  })
+
+  it('renders no provenance line for a non-turn_record source', () => {
+    const k = mkKeeper({
+      context_ratio: 0.5,
+      context_tokens: 100887,
+      context_max: 200000,
+      context_source: 'keeper_context_status',
+    })
+    const { container } = render(html`<${KeeperWorkspaceRail} keeper=${k} />`)
+    expect(container.querySelector('[data-testid="ctx-provenance"]')).toBeNull()
   })
 
   it('runs overflow compaction without force through the existing MCP tool', async () => {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -39,6 +39,7 @@ import {
   runtimeCatalogRequestConfig,
 } from '../../lib/runtime-provider-summary'
 import { formatContextTokens } from '../../lib/format-number'
+import { formatTimeAgo } from '../../lib/format-time'
 import { persistentSignal } from '../../lib/persistent-signal'
 import { recordManualCompaction } from './compaction-snapshots'
 import type { MemoryKeeper } from '../memory-inspector'
@@ -390,6 +391,21 @@ function ContextSection({
   const compactionCount = keeper.compaction_count ?? null
   const hasCompactionHistory = typeof compactionCount === 'number' && compactionCount > 0
   const hasMeterData = pct !== null && (pct > 0 || max !== null)
+  // Provenance of the measurement: which completed turn produced the numbers
+  // (server projects them from the newest TurnRecord — the measurement SSOT).
+  const ctxSource = keeper.context_source ?? keeper.context?.source ?? null
+  const ctxAbsoluteTurn = keeper.context?.absolute_turn ?? null
+  const ctxObservedAt = keeper.context?.observed_at ?? null
+  const ctxWireBytes = keeper.context?.request_body_bytes ?? null
+  const ctxTurnRef = keeper.context?.turn_ref ?? null
+  const ctxUnavailableReason =
+    keeper.context_metrics_unavailable?.kind === 'not_observed'
+      ? keeper.context_metrics_unavailable.reason
+      : null
+  const wireLabel =
+    typeof ctxWireBytes === 'number' && Number.isFinite(ctxWireBytes) && ctxWireBytes > 0
+      ? `${Math.round(ctxWireBytes / 1024)}KB`
+      : null
   const compactAccess = dashboardAuthAccess(shellAuthSummary.value, 'worker')
   const canCompact = compactAccess.allowed && !compacting
   const compactReason = compactAccess.reason ?? '컴팩션 실행 권한이 필요합니다.'
@@ -482,13 +498,23 @@ function ContextSection({
                 ><span style=${{ width: `${pct ?? 0}%` }}></span></div>
               </div>
             `
-          : html`<div class="ctx-empty" data-missing="context-window"><strong>윈도우 사용률 미수신</strong><span>런타임이 전체 윈도우 총량을 아직 보내지 않았습니다.</span></div>`}
+          : html`<div class="ctx-empty" data-missing="context-window"><strong>윈도우 사용률 미측정</strong><span>${ctxUnavailableReason
+                ? html`턴 레코드 기준 측정 불가: <span class="mono">${ctxUnavailableReason}</span>`
+                : '측정된 턴 레코드가 아직 없습니다.'}</span></div>`}
         <div class="ctx-tok">
           <span class="mono">${tokens ?? '—'}</span>
           <span class="ctx-tok-sep">/</span>
           <span class="mono ctx-tok-full">${maxLabel ?? '—'}</span>
           <span class="ctx-tok-lbl">사용 / 전체 윈도우</span>
         </div>
+        ${ctxSource === 'turn_record'
+          ? html`<div class="ctx-src" data-testid="ctx-provenance" title=${ctxTurnRef ?? undefined}>
+              측정: <span class="mono">T${ctxAbsoluteTurn ?? '—'}</span>
+              ${ctxObservedAt ? html` · ${formatTimeAgo(ctxObservedAt)}` : null}
+              ${wireLabel ? html` · wire <span class="mono">${wireLabel}</span>` : null}
+              <span class="ctx-src-lbl">다음 입력에 함께 실리는 상비 페이로드</span>
+            </div>`
+          : null}
         <div class="cmp-actions">
           <button
             type="button"

--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -101,6 +101,83 @@ describe('normalizeKeepers phase field', () => {
   })
 })
 
+describe('normalizeKeepers context measurement', () => {
+  it('decodes context numbers declared by the turn_record projection', () => {
+    const [keeper] = normalizeKeepers([
+      {
+        name: 'rondo',
+        status: 'active',
+        context_ratio: 0.504435,
+        context_tokens: 100887,
+        context_max: 200000,
+        context_source: 'turn_record',
+        context_metrics_unavailable: null,
+        context: {
+          source: 'turn_record',
+          context_ratio: 0.504435,
+          context_tokens: 100887,
+          context_max: 200000,
+          observed_at: '2026-07-31T12:37:20Z',
+          turn_ref: 'trace-1785189111911-00004#3337',
+          absolute_turn: 3337,
+          request_body_bytes: 402408,
+        },
+      },
+    ])
+
+    expect(keeper?.context_tokens).toBe(100887)
+    expect(keeper?.context_max).toBe(200000)
+    expect(keeper?.context_ratio).toBeCloseTo(0.504435)
+    expect(keeper?.context_source).toBe('turn_record')
+    expect(keeper?.context?.turn_ref).toBe('trace-1785189111911-00004#3337')
+    expect(keeper?.context?.absolute_turn).toBe(3337)
+    expect(keeper?.context?.request_body_bytes).toBe(402408)
+    expect(keeper?.context?.observed_at).toBe('2026-07-31T12:37:20Z')
+  })
+
+  it('keeps numbers null under a retired or unknown context source', () => {
+    const [keeper] = normalizeKeepers([
+      {
+        name: 'sojin',
+        status: 'active',
+        context_ratio: 0.13,
+        context_tokens: 16312,
+        context_max: 128000,
+        context_source: 'keeper_context_status',
+        context: {
+          source: 'keeper_context_status',
+          context_tokens: 16312,
+          context_max: 128000,
+        },
+      },
+    ])
+
+    expect(keeper?.context_tokens).toBeNull()
+    expect(keeper?.context_max).toBeNull()
+    expect(keeper?.context_ratio).toBeNull()
+    expect(keeper?.context_source).toBeNull()
+    expect(keeper?.context?.context_tokens).toBeNull()
+    expect(keeper?.context?.source).toBeNull()
+  })
+
+  it('passes through the new typed absence reasons', () => {
+    for (const reason of [
+      'turn_record_undecodable',
+      'turn_record_read_failed',
+      'turn_record_without_usage',
+    ]) {
+      const [keeper] = normalizeKeepers([
+        {
+          name: 'rondo',
+          status: 'active',
+          context_metrics_unavailable: { kind: 'not_observed', reason },
+        },
+      ])
+      expect(keeper?.context_metrics_unavailable).toEqual({ kind: 'not_observed', reason })
+    }
+  })
+})
+
 describe('normalizeKeepers lifecycle metrics', () => {
   it('drops retired compaction policy fields', () => {
     const [keeper] = normalizeKeepers([

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -2,6 +2,7 @@ import type {
   CtxCompositionTelemetry,
   Keeper,
   KeeperContextMetricsUnavailable,
+  KeeperContextNotObservedReason,
   KeeperLifecycleState,
   KeeperLastTurnUsage,
   KeeperMetricPoint,
@@ -13,6 +14,7 @@ import type {
   PromptTelemetry,
   ProviderHealth,
 } from './types'
+import { KEEPER_CONTEXT_NOT_OBSERVED_REASONS } from './types'
 import { isRecord, asString, asNumber, asBoolean, asStringArray, toIsoTimestamp } from './components/common/normalize'
 import { isKeeperOffline } from './lib/keeper-predicates'
 import { keeperDisplayStatus } from './lib/keeper-runtime-display'
@@ -44,8 +46,12 @@ export function normalizeKeeperContextMetricsUnavailable(
 
   const kind = asString(raw.kind) ?? null
   const reason = asString(raw.reason) ?? null
-  if (kind === 'not_observed' && reason === 'context_measurement_missing') {
-    return { kind, reason }
+  if (
+    kind === 'not_observed'
+    && reason !== null
+    && (KEEPER_CONTEXT_NOT_OBSERVED_REASONS as readonly string[]).includes(reason)
+  ) {
+    return { kind, reason: reason as KeeperContextNotObservedReason }
   }
 
   return { kind: 'invalid_payload', reported_kind: kind, reported_reason: reason }
@@ -622,18 +628,32 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
       const name = asString(row.name)
       if (!name) return null
 
-      const contextRatio = null
+      // Context fields decode from the wire only when their declared
+      // producer is the TurnRecord projection
+      // (Keeper_context_observation_projection) — the measurement SSOT.
+      // A retired or unknown source drops entirely (numbers and string):
+      // absence is explained by the typed context_metrics_unavailable
+      // channel, never by echoing a retired producer name.
+      const topContextSource = asString(row.context_source) ?? null
+      const topContextMeasured = topContextSource === 'turn_record'
+      const contextRatio = topContextMeasured ? asNumber(row.context_ratio) ?? null : null
       const statusRaw = asString(row.status) ?? asString(agentRaw?.status) ?? 'offline'
       const model = undefined
       const metricsSeries = normalizeMetricsSeries(row.metrics_series)
 
+      const nestedContextSource = contextRaw ? asString(contextRaw.source) ?? null : null
+      const nestedContextMeasured = nestedContextSource === 'turn_record'
       const normalizedContext =
         contextRaw
           ? {
-              source: null,
-              context_ratio: null,
-              context_tokens: null,
-              context_max: null,
+              source: nestedContextMeasured ? nestedContextSource : null,
+              context_ratio: nestedContextMeasured ? asNumber(contextRaw.context_ratio) ?? null : null,
+              context_tokens: nestedContextMeasured ? asNumber(contextRaw.context_tokens) ?? null : null,
+              context_max: nestedContextMeasured ? asNumber(contextRaw.context_max) ?? null : null,
+              observed_at: nestedContextMeasured ? asString(contextRaw.observed_at) ?? null : null,
+              turn_ref: nestedContextMeasured ? asString(contextRaw.turn_ref) ?? null : null,
+              absolute_turn: nestedContextMeasured ? asNumber(contextRaw.absolute_turn) ?? null : null,
+              request_body_bytes: nestedContextMeasured ? asNumber(contextRaw.request_body_bytes) ?? null : null,
               message_count: asNumber(contextRaw.message_count),
               has_checkpoint: typeof contextRaw.has_checkpoint === 'boolean' ? contextRaw.has_checkpoint : undefined,
             }
@@ -768,9 +788,9 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
         last_blocker: asString(row.last_blocker) ?? null,
         runtime_warning_ctx_ratio: asNumber(row.runtime_warning_ctx_ratio) ?? null,
         context_ratio: contextRatio,
-        context_tokens: null,
-        context_max: null,
-        context_source: null,
+        context_tokens: topContextMeasured ? asNumber(row.context_tokens) ?? null : null,
+        context_max: topContextMeasured ? asNumber(row.context_max) ?? null : null,
+        context_source: topContextMeasured ? topContextSource : null,
         context_metrics_unavailable: normalizeKeeperContextMetricsUnavailable(row.context_metrics_unavailable),
         last_turn_usage: normalizeKeeperLastTurnUsage(row.last_turn_usage),
         context: normalizedContext,

--- a/dashboard/src/operator-normalizers.test.ts
+++ b/dashboard/src/operator-normalizers.test.ts
@@ -285,7 +285,52 @@ describe('normalizeOperatorSnapshot', () => {
     expect(result.keepers[0]!.context_ratio).toBeNull()
     expect(result.keepers[0]!.context_tokens).toBeNull()
     expect(result.keepers[0]!.context_max).toBeNull()
+    // The nested retired payload names no top-level source; the string stays
+    // absent and no numbers are revived from it.
     expect(result.keepers[0]!.context_source).toBeNull()
+  })
+
+  it('decodes context numbers declared by the turn_record projection', () => {
+    const result = normalizeOperatorSnapshot({
+      keepers: [
+        {
+          name: 'rondo',
+          context_ratio: 0.504435,
+          context_tokens: 100887,
+          context_max: 200000,
+          context_source: 'turn_record',
+          context_metrics_unavailable: null,
+        },
+      ],
+    })
+
+    expect(result.keepers[0]).toMatchObject({
+      context_ratio: 0.504435,
+      context_tokens: 100887,
+      context_max: 200000,
+      context_source: 'turn_record',
+    })
+  })
+
+  it('drops context fields entirely under a retired source', () => {
+    const result = normalizeOperatorSnapshot({
+      keepers: [
+        {
+          name: 'sojin',
+          context_ratio: 0.1274375,
+          context_tokens: 16312,
+          context_max: 128000,
+          context_source: 'keeper_context_status',
+        },
+      ],
+    })
+
+    expect(result.keepers[0]).toMatchObject({
+      context_ratio: null,
+      context_tokens: null,
+      context_max: null,
+      context_source: null,
+    })
   })
 
   it('preserves unknown context and separately typed last-turn usage', () => {

--- a/dashboard/src/operator-normalizers.ts
+++ b/dashboard/src/operator-normalizers.ts
@@ -227,6 +227,11 @@ function normalizeKeeper(raw: unknown): OperatorKeeperSnapshot | null {
   const name = asString(raw.name)
   if (!name) return null
   const hasModelLabel = Boolean(asString(raw.model) ?? asString(raw.active_model) ?? asString(raw.primary_model))
+  // Context fields are accepted only from the TurnRecord projection (the
+  // measurement SSOT); a retired or unknown source drops entirely — absence
+  // is explained by the typed context_metrics_unavailable channel.
+  const contextSource = asString(raw.context_source) ?? null
+  const contextMeasured = contextSource === 'turn_record'
   return {
     name,
     runtime_class: 'keeper' as const,
@@ -236,10 +241,10 @@ function normalizeKeeper(raw: unknown): OperatorKeeperSnapshot | null {
     registered: asBoolean(raw.registered),
     agent_name: asString(raw.agent_name),
     status: asString(raw.status),
-    context_ratio: null,
-    context_tokens: null,
-    context_max: null,
-    context_source: null,
+    context_ratio: contextMeasured ? asNumber(raw.context_ratio) ?? null : null,
+    context_tokens: contextMeasured ? asNumber(raw.context_tokens) ?? null : null,
+    context_max: contextMeasured ? asNumber(raw.context_max) ?? null : null,
+    context_source: contextMeasured ? contextSource : null,
     context_metrics_unavailable: normalizeKeeperContextMetricsUnavailable(raw.context_metrics_unavailable),
     last_turn_usage: normalizeKeeperLastTurnUsage(raw.last_turn_usage),
     generation: asNumber(raw.generation),

--- a/dashboard/src/styles/keeper-v2/v2.css
+++ b/dashboard/src/styles/keeper-v2/v2.css
@@ -1316,6 +1316,10 @@
 .ctx-tok-sep { color: var(--text-dim); }
 .ctx-tok-full { color: var(--text-dim) !important; }
 .ctx-tok-lbl { margin-left: auto; font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); }
+/* measurement provenance under the meter: turn ref, age, wire size */
+.ctx-src { display: flex; flex-wrap: wrap; align-items: baseline; gap: 4px; margin-top: 5px; font-size: var(--fs-11); color: var(--text-mid); }
+.ctx-src .mono { font-family: var(--font-mono); color: var(--text-bright); }
+.ctx-src-lbl { flex-basis: 100%; font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); }
 
 /* recent tool — expandable detail */
 .ctx-item.click { cursor: pointer; }

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -1115,10 +1115,22 @@ export interface KeeperLastTurnUsage {
   source: 'keeper_runtime_usage'
 }
 
+// Mirrors the closed reason set in
+// lib/keeper/keeper_context_observation_projection.ml — extend both together.
+export const KEEPER_CONTEXT_NOT_OBSERVED_REASONS = [
+  'context_measurement_missing',
+  'turn_record_undecodable',
+  'turn_record_read_failed',
+  'turn_record_without_usage',
+] as const
+
+export type KeeperContextNotObservedReason =
+  (typeof KEEPER_CONTEXT_NOT_OBSERVED_REASONS)[number]
+
 export type KeeperContextMetricsUnavailable =
   | {
       kind: 'not_observed'
-      reason: 'context_measurement_missing'
+      reason: KeeperContextNotObservedReason
     }
   | {
       kind: 'invalid_payload'
@@ -1226,6 +1238,12 @@ export interface Keeper {
     context_ratio?: number | null
     context_tokens?: number | null
     context_max?: number | null
+    // Provenance of a turn_record-sourced measurement (RFC-0233): which
+    // completed turn produced the numbers and its serialized request size.
+    observed_at?: string | null
+    turn_ref?: string | null
+    absolute_turn?: number | null
+    request_body_bytes?: number | null
     message_count?: number
     has_checkpoint?: boolean
   }

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -620,7 +620,9 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
               max_context_resolution
           in
           let context_projection_fields =
-            Keeper_context_observation_projection.missing_context_fields ()
+            Keeper_context_observation_projection.context_fields
+              ~config
+              ~keeper_name:m.name
           in
 	          let summary =
               let trust_json =

--- a/lib/keeper/keeper_context_observation_projection.ml
+++ b/lib/keeper/keeper_context_observation_projection.ml
@@ -1,18 +1,35 @@
 (** Current Keeper context-observation projection.
 
-    Context occupancy has no owner-boundary measurement in the current
-    runtime contract. This module is the single wire projection for that
-    absence and for the separate, provider-reported last-turn usage. *)
+    Context occupancy is projected from the newest TurnRecord (RFC-0233):
+    [input_tokens] is the provider-reported prompt total for the last
+    completed turn and [context_window] the window resolved for that same
+    request, so the pair is the measurement SSOT for "what enters with the
+    next input". This module is the single wire projection for that
+    measurement, for its typed absence, and for the separate,
+    provider-reported last-turn usage.
 
-let missing_measurement_json () =
-  `Assoc
-    [ "kind", `String "not_observed"
-    ; "reason", `String "context_measurement_missing"
-    ]
+    Display-only: nothing here may feed context pressure or compaction
+    decisions. Fleet observation reads only the dated-JSONL tail, never
+    checkpoints. *)
+
+let turn_record_source = "turn_record"
+
+(* Closed reason set. Every non-observed outcome names which stage failed;
+   an unknown string here is a bug, not a new category. *)
+let reason_measurement_missing = "context_measurement_missing"
+let reason_undecodable = "turn_record_undecodable"
+let reason_read_failed = "turn_record_read_failed"
+let reason_without_usage = "turn_record_without_usage"
+
+let not_observed_json ~reason =
+  `Assoc [ "kind", `String "not_observed"; "reason", `String reason ]
 ;;
 
-let missing_context_fields () =
-  let unavailable = missing_measurement_json () in
+let missing_measurement_json () =
+  not_observed_json ~reason:reason_measurement_missing
+;;
+
+let context_fields_unavailable unavailable =
   let context =
     `Assoc
       [ "source", `Null
@@ -29,6 +46,89 @@ let missing_context_fields () =
   ; "context_metrics_unavailable", unavailable
   ; "context", context
   ]
+;;
+
+let missing_context_fields () =
+  context_fields_unavailable (missing_measurement_json ())
+;;
+
+type latest_turn_observation =
+  | No_turn_record
+  | Undecodable_turn_record
+  | Turn_record_read_failed
+  | Observed of Turn_record.t
+
+let latest_turn_observation ~config ~keeper_name =
+  match
+    let store = Keeper_types_support.keeper_turn_record_store config keeper_name in
+    Dated_jsonl.read_recent store 1
+  with
+  | [] -> No_turn_record
+  | json :: _ ->
+    (match Turn_record.of_json json with
+     | Ok record -> Observed record
+     | Error _ -> Undecodable_turn_record)
+  | exception (Eio.Cancel.Cancelled _ as error) -> raise error
+  | exception exn ->
+    Log.Keeper.warn
+      "context observation turn-record read failed keeper=%s: %s"
+      keeper_name
+      (Printexc.to_string exn);
+    Turn_record_read_failed
+;;
+
+let observed_context_fields (record : Turn_record.t) =
+  let opt_int = function
+    | Some v -> `Int v
+    | None -> `Null
+  in
+  let tokens = record.usage.input_tokens in
+  let window = record.context_window in
+  let ratio =
+    match tokens, window with
+    | Some tokens, Some window when window > 0 ->
+      `Float (float_of_int tokens /. float_of_int window)
+    | Some _, (Some _ | None) | None, _ -> `Null
+  in
+  let request_body_bytes =
+    match record.request_wire_observation with
+    | Some { body_bytes; _ } -> `Int body_bytes
+    | None -> `Null
+  in
+  let context =
+    `Assoc
+      [ "source", `String turn_record_source
+      ; "context_ratio", ratio
+      ; "context_tokens", opt_int tokens
+      ; "context_max", opt_int window
+      ; "observed_at", `String (Masc_domain.iso8601_of_unix_seconds record.ts)
+      ; "turn_ref", Ids.Turn_ref.to_yojson record.turn_ref
+      ; "absolute_turn", `Int record.absolute_turn
+      ; "request_body_bytes", request_body_bytes
+      ; "metrics_unavailable", `Null
+      ]
+  in
+  [ "context_ratio", ratio
+  ; "context_tokens", opt_int tokens
+  ; "context_max", opt_int window
+  ; "context_source", `String turn_record_source
+  ; "context_metrics_unavailable", `Null
+  ; "context", context
+  ]
+;;
+
+let context_fields ~config ~keeper_name =
+  match latest_turn_observation ~config ~keeper_name with
+  | No_turn_record ->
+    context_fields_unavailable (not_observed_json ~reason:reason_measurement_missing)
+  | Undecodable_turn_record ->
+    context_fields_unavailable (not_observed_json ~reason:reason_undecodable)
+  | Turn_record_read_failed ->
+    context_fields_unavailable (not_observed_json ~reason:reason_read_failed)
+  | Observed record ->
+    (match record.usage.input_tokens with
+     | None -> context_fields_unavailable (not_observed_json ~reason:reason_without_usage)
+     | Some _ -> observed_context_fields record)
 ;;
 
 let last_turn_usage_json_of_meta

--- a/lib/keeper/keeper_context_observation_projection.mli
+++ b/lib/keeper/keeper_context_observation_projection.mli
@@ -10,6 +10,26 @@ val missing_context_fields :
 (** Null context fields plus {!missing_measurement_json}. Checkpoint inventory
     is a separate endpoint and is not loaded by fleet context observation. *)
 
+val context_fields :
+  config:Workspace.config ->
+  keeper_name:string ->
+  (string * Yojson.Safe.t) list
+(** Context occupancy projected from the keeper's newest TurnRecord
+    (RFC-0233), the measurement SSOT: [context_tokens] is the
+    provider-reported prompt total of the last completed turn,
+    [context_max] the context window resolved for that same request, and
+    the nested ["context"] object carries provenance ([turn_ref],
+    [observed_at], [request_body_bytes]).
+
+    Display-only: the projection must never feed context pressure or
+    compaction decisions. It reads only the dated-JSONL tail (one line),
+    never checkpoints. Absence stays typed via
+    [context_metrics_unavailable] with a closed reason set:
+    [context_measurement_missing] (no record),
+    [turn_record_undecodable] (newest line rejected by the strict codec),
+    [turn_record_read_failed] (store IO failed, warn-logged),
+    [turn_record_without_usage] (turn completed without provider usage). *)
+
 val last_turn_usage_json_of_meta :
   Keeper_meta_contract.keeper_meta -> Yojson.Safe.t
 (** Provider-reported usage from the latest successful usage observation.

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -138,7 +138,9 @@ let handle_keeper_list ctx args : tool_result =
               ("noop_turn_count", `Int m.runtime.noop_turn_count);
               ("autonomous_action_count", `Int m.runtime.autonomous_action_count);
             ]
-            @ Keeper_context_observation_projection.missing_context_fields ()
+            @ Keeper_context_observation_projection.context_fields
+                ~config:ctx.config
+                ~keeper_name:m.name
             @ [
               ( "last_turn_usage"
               , Keeper_context_observation_projection.last_turn_usage_json

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -360,7 +360,9 @@ let keepers_json
                         | None -> `Null
                     in
                     let context_snapshot_fields =
-                      Keeper_context_observation_projection.missing_context_fields ()
+                      Keeper_context_observation_projection.context_fields
+                        ~config
+                        ~keeper_name:meta.name
                     in
                     let runtime_trust =
                       let t_trust = Time_compat.now () in

--- a/lib/operator/operator_control_snapshot_persistent_agents.ml
+++ b/lib/operator/operator_control_snapshot_persistent_agents.ml
@@ -59,6 +59,10 @@ let persistent_agents_json ?keeper_names ?keeper_rows config =
                  ; "updated_at", field_or_null "updated_at"
                  ; "created_at", field_or_null "created_at"
                  ]
+                 (* Rows here re-project a persisted snapshot verbatim
+                    (field_or_null over stored JSON); reading live
+                    turn-record stores would mix a live measurement into a
+                    persisted view, so context stays typed-absent. *)
                  @ Keeper_context_observation_projection.missing_context_fields ()
                  @ [ "last_turn_usage", field_or_null "last_turn_usage" ]))
          | _ -> None)
@@ -121,7 +125,9 @@ let persistent_agents_json ?keeper_names ?keeper_rows config =
                     ; "updated_at", `String meta.updated_at
                     ; "created_at", `String meta.created_at
                     ]
-                    @ Keeper_context_observation_projection.missing_context_fields ()
+                    @ Keeper_context_observation_projection.context_fields
+                        ~config
+                        ~keeper_name:meta.name
                     @ [ ( "last_turn_usage"
                         , Keeper_context_observation_projection
                           .last_turn_usage_json

--- a/test/dune
+++ b/test/dune
@@ -1923,6 +1923,8 @@
 
 (include stanzas/test_turn_record.inc)
 
+(include stanzas/test_keeper_context_observation_projection.inc)
+
 (include stanzas/test_keeper_chat_coalescing.inc)
 
 (include stanzas/test_keeper_turn_admission.inc)

--- a/test/stanzas/test_keeper_context_observation_projection.inc
+++ b/test/stanzas/test_keeper_context_observation_projection.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_context_observation_projection)
+ (modules test_keeper_context_observation_projection)
+ (libraries masc_test_deps))

--- a/test/test_keeper_context_observation_projection.ml
+++ b/test/test_keeper_context_observation_projection.ml
@@ -1,0 +1,206 @@
+(** Context-observation projection sources the newest TurnRecord: the
+    provider-measured numbers reach the wire fields, and every absence is a
+    typed reason instead of a pinned null. *)
+
+open Alcotest
+
+module Projection = Masc.Keeper_context_observation_projection
+
+let with_temp_workspace f =
+  let path = Filename.temp_file "ctx-observation-" ".dir" in
+  Sys.remove path;
+  Unix.mkdir path 0o700;
+  Fun.protect
+    ~finally:(fun () -> Fs_compat.remove_tree path)
+    (fun () -> f (Masc.Workspace.default_config path))
+;;
+
+let digest_of_label label =
+  Digestif.SHA256.digest_string label |> Digestif.SHA256.to_hex
+;;
+
+let sample_record
+      ?(absolute_turn = 4071)
+      ?(input_tokens = Some 18_000)
+      ?(context_window = Some 131_072)
+      ()
+  : Turn_record.t
+  =
+  { execution_ids = []
+  ; keeper = "rondo"
+  ; trace_id = "trace-1780648779957-00000"
+  ; absolute_turn
+  ; turn_ref =
+      Ids.Turn_ref.make ~trace_id:"trace-1780648779957-00000" ~absolute_turn
+  ; blocks =
+      [ { Turn_record.block = Prompt_block_id.Persona
+        ; bytes = 4
+        ; digest = digest_of_label "aaaa"
+        }
+      ]
+  ; input_components = Some [ { component = Turn_record.Tool_schemas; bytes = 8192 } ]
+  ; runtime_profile = "glm-coding.glm-5-turbo"
+  ; model = Some "glm-5-turbo"
+  ; finish_reason = Some "completed"
+  ; context_window
+  ; price_input_per_million = None
+  ; price_output_per_million = None
+  ; request_latency_ms = Some 1234
+  ; ttfrc_ms = None
+  ; request_wire_observation =
+      Some { runtime_profile = "glm-coding.glm-5-turbo"; body_bytes = 560_513 }
+  ; sampling =
+      { temperature = None
+      ; top_p = None
+      ; max_tokens = None
+      ; thinking_budget = None
+      ; enable_thinking = Some true
+      }
+  ; usage =
+      { input_tokens
+      ; output_tokens = Some 412
+      ; cache_creation_input_tokens = None
+      ; cache_read_input_tokens = Some 15_000
+      }
+  ; ts = 1_781_200_000.5
+  }
+;;
+
+let append_record config record =
+  let store =
+    Masc.Keeper_types_support.keeper_turn_record_store config record.Turn_record.keeper
+  in
+  Dated_jsonl.append store (Turn_record.to_json record)
+;;
+
+let append_raw config ~keeper_name json =
+  let store = Masc.Keeper_types_support.keeper_turn_record_store config keeper_name in
+  Dated_jsonl.append store json
+;;
+
+let field fields name =
+  match List.assoc_opt name fields with
+  | Some value -> value
+  | None -> failf "field %s is absent from the projection" name
+;;
+
+let context_object fields =
+  match field fields "context" with
+  | `Assoc context -> context
+  | _ -> fail "context field is not an object"
+;;
+
+let check_not_observed fields ~reason =
+  (match field fields "context_metrics_unavailable" with
+   | `Assoc unavailable ->
+     check string "kind" "not_observed"
+       (match List.assoc_opt "kind" unavailable with
+        | Some (`String kind) -> kind
+        | _ -> "<missing>");
+     check string "reason" reason
+       (match List.assoc_opt "reason" unavailable with
+        | Some (`String value) -> value
+        | _ -> "<missing>")
+   | _ -> fail "context_metrics_unavailable is not an object");
+  check bool "context_tokens is null" true (field fields "context_tokens" = `Null);
+  check bool "context_max is null" true (field fields "context_max" = `Null);
+  check bool "context_source is null" true (field fields "context_source" = `Null)
+;;
+
+let test_missing_store_is_typed_absence () =
+  with_temp_workspace (fun config ->
+    let fields = Projection.context_fields ~config ~keeper_name:"nobody" in
+    check_not_observed fields ~reason:"context_measurement_missing")
+;;
+
+let test_measured_record_projects () =
+  with_temp_workspace (fun config ->
+    let record = sample_record () in
+    append_record config record;
+    let fields = Projection.context_fields ~config ~keeper_name:"rondo" in
+    (match field fields "context_tokens" with
+     | `Int tokens -> check int "tokens" 18_000 tokens
+     | _ -> fail "context_tokens is not an int");
+    (match field fields "context_max" with
+     | `Int window -> check int "window" 131_072 window
+     | _ -> fail "context_max is not an int");
+    (match field fields "context_ratio" with
+     | `Float ratio ->
+       check bool "ratio matches tokens/window" true
+         (Float.abs (ratio -. (18_000.0 /. 131_072.0)) < 1e-9)
+     | _ -> fail "context_ratio is not a float");
+    (match field fields "context_source" with
+     | `String source -> check string "source" "turn_record" source
+     | _ -> fail "context_source is not a string");
+    check bool "unavailable is null" true
+      (field fields "context_metrics_unavailable" = `Null);
+    let context = context_object fields in
+    (match List.assoc_opt "absolute_turn" context with
+     | Some (`Int turn) -> check int "absolute_turn" 4071 turn
+     | _ -> fail "context.absolute_turn missing");
+    (match List.assoc_opt "request_body_bytes" context with
+     | Some (`Int bytes) -> check int "request bytes" 560_513 bytes
+     | _ -> fail "context.request_body_bytes missing");
+    (match List.assoc_opt "turn_ref" context with
+     | Some (`String turn_ref) ->
+       check string "turn_ref" "trace-1780648779957-00000#4071" turn_ref
+     | _ -> fail "context.turn_ref missing");
+    match List.assoc_opt "observed_at" context with
+    | Some (`String _) -> ()
+    | _ -> fail "context.observed_at missing")
+;;
+
+let test_newest_record_wins () =
+  with_temp_workspace (fun config ->
+    append_record config (sample_record ~absolute_turn:1 ~input_tokens:(Some 100) ());
+    append_record config (sample_record ~absolute_turn:2 ~input_tokens:(Some 200) ());
+    let fields = Projection.context_fields ~config ~keeper_name:"rondo" in
+    match field fields "context_tokens" with
+    | `Int tokens -> check int "newest tokens" 200 tokens
+    | _ -> fail "context_tokens is not an int")
+;;
+
+let test_record_without_usage_is_typed () =
+  with_temp_workspace (fun config ->
+    append_record config (sample_record ~input_tokens:None ());
+    let fields = Projection.context_fields ~config ~keeper_name:"rondo" in
+    check_not_observed fields ~reason:"turn_record_without_usage")
+;;
+
+let test_undecodable_newest_line_is_typed () =
+  with_temp_workspace (fun config ->
+    append_raw config ~keeper_name:"rondo" (`Assoc [ "schema", `String "future" ]);
+    let fields = Projection.context_fields ~config ~keeper_name:"rondo" in
+    check_not_observed fields ~reason:"turn_record_undecodable")
+;;
+
+let test_missing_window_keeps_tokens_without_ratio () =
+  with_temp_workspace (fun config ->
+    append_record config (sample_record ~context_window:None ());
+    let fields = Projection.context_fields ~config ~keeper_name:"rondo" in
+    (match field fields "context_tokens" with
+     | `Int tokens -> check int "tokens survive" 18_000 tokens
+     | _ -> fail "context_tokens is not an int");
+    check bool "ratio is null without a window" true
+      (field fields "context_ratio" = `Null);
+    check bool "max is null without a window" true (field fields "context_max" = `Null))
+;;
+
+let () =
+  run
+    "keeper_context_observation_projection"
+    [ ( "projection"
+      , [ test_case "missing store is typed absence" `Quick
+            test_missing_store_is_typed_absence
+        ; test_case "measured record projects tokens/window/provenance" `Quick
+            test_measured_record_projects
+        ; test_case "newest record wins" `Quick test_newest_record_wins
+        ; test_case "record without usage is typed" `Quick
+            test_record_without_usage_is_typed
+        ; test_case "undecodable newest line is typed" `Quick
+            test_undecodable_newest_line_is_typed
+        ; test_case "missing window keeps tokens without ratio" `Quick
+            test_missing_window_keeps_tokens_without_ratio
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 목표

"다음 턴 입력과 함께 들어가는 상비 페이로드가 얼마인가"라는 질문에 UI가 SSOT 수치로 답하게 한다. 측정은 이미 존재한다 — RFC-0233 TurnRecord가 매 턴 provider 측정 usage(`input_tokens`), 해석된 `context_window`, 직렬화된 요청 크기(`request_body_bytes`), 입력 분해(`input_components`)를 기록한다. 이 PR은 그 측정을 화면까지 운반한다.

## 배경: 부재의 3층

RFC 참조: `docs/rfc/RFC-0233-turn-observability-execution-identity.md` (측정 계약). 본 PR은 새 측정을 만들지 않고 RFC-0233 산출물의 wire 투영만 추가한다.

1. **서버가 부재를 선언**: `keeper_context_observation_projection.ml`은 "context occupancy has no owner-boundary measurement" 전제로 `context_tokens: Null`을 하드코딩했다. 이 전제는 RFC-0233 착륙 이전의 것으로, 지금은 낡았다.
2. **클라이언트가 부재를 고정**: `keeper-store-normalize.ts`와 `operator-normalizers.ts`가 서버 값과 무관하게 `context_tokens: null`을 핀했다. 서버를 고쳐도 화면은 계속 비어 있는 구조.
3. **분해는 렌더 0**: `input_components`(thinking/tool_result/tool_use/text/user/tool_schemas 바이트)는 매 턴 기록되고 API로 운반되고 TS 타입까지 있으나 그리는 컴포넌트가 없었다.

결과: workspace rail의 컨텍스트 카드는 상시 "윈도우 사용률 미수신".

## 변경

### 서버 (OCaml)

- `keeper_context_observation_projection.context_fields ~config ~keeper_name` 추가: 최신 TurnRecord 1건(tail 읽기)에서 `context_tokens`/`context_max`/`context_ratio`/`context_source="turn_record"`와 provenance(`turn_ref`, `absolute_turn`, `observed_at`, `request_body_bytes`)를 투영.
- 부재는 closed reason set으로 typed 유지: `context_measurement_missing`(레코드 없음) / `turn_record_undecodable`(strict codec 거부) / `turn_record_read_failed`(IO 실패, warn 로그) / `turn_record_without_usage`(usage 미보고 턴).
- 호출부 교체 4곳: `keeper_status`, `dashboard_http_keeper`, `operator_control_snapshot`, `operator_control_snapshot_persistent_agents`(live meta 열거 경로). persisted-JSON 재투영 경로는 의도적으로 typed-absent 유지(주석 명시).
- 표시 전용 계약 유지: 이 값은 context 압력·컴팩션 판단에 쓰이지 않는다(기존 mli 문구 계승). checkpoint는 읽지 않는다(기존 성능 경계 유지, dated-JSONL tail 1줄만).

### 클라이언트 (dashboard)

- normalizer 2곳의 핀 null 제거, 단 **선언된 producer가 `turn_record`일 때만** 숫자를 디코드. retired/unknown source는 통째로 drop(기존 "does not revive retired payloads" 계약 유지) — 부재 설명은 typed `context_metrics_unavailable` 채널이 담당.
- workspace rail 컨텍스트 카드: 기존 미터가 측정치로 점등 + 출처 라인("측정: T3337 · n분 전 · wire 393KB · 다음 입력에 함께 실리는 상비 페이로드"). 빈 상태는 typed reason을 그대로 표기.
- turn inspector: `입력 구성` 섹션 신설 — input_components를 바이트 내림차순으로 렌더(점유율 % 포함), 합계와 wire body 크기 병기. copy 텍스트에도 포함.

## 비변경 (명시)

- 새 저장 상태 0, 새 측정 0, 새 파일 0. 전부 기존 SSOT 산출물의 읽기 시점 투영.
- 판단 로직 0: ratio는 표시용 나눗셈이며 어떤 결정에도 연결되지 않는다.
- persisted-agents 재투영 경로는 부재 유지(라이브 측정과 persisted 뷰 혼합 방지).

## 검증

- OCaml: `test_keeper_context_observation_projection` 신설 6케이스 (typed absence / 측정 투영 / 최신 우선 / usage 없음 / undecodable / window 없음) — 6/6 통과. `dune build` 전체 green.
- dashboard: `tsc --noEmit` clean, eslint 0 errors, vitest 영향 6파일 222/222 통과 (normalizer 양쪽 decode·drop 계약, rail provenance/absence, inspector 입력 구성 정렬·wire 병기).
- 기존 계약 보존 확인: "does not revive context fields from retired nested payloads" (operator-normalizers.test) 통과 유지.

## 라이브 증명 게이트 (머지 ≠ 작동)

배포 후 확인해야 완료로 판정한다:

1. `/api/v1/dashboard/…` keeper 응답에 `context_source: "turn_record"`와 실측 토큰이 실리는지.
2. workspace rail 컨텍스트 카드가 rondo에서 실제 점등하는지 (기대: ~50% · T33xx · wire ~400KB).
3. turn inspector에 message_thinking / message_tool_result 분해가 보이는지.

## 남은 미검증

- 전체 vitest 스위트·전체 OCaml 테스트 스위트는 CI에서 확인 (로컬은 영향 파일 스코프 실행).
- SSE 실시간 경로로 오는 keeper 스냅샷의 context 필드 유무는 라이브에서 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
