### PR TITLE
fix(keeper): context projection follow-ups — strict tail, lossless persistent rows, trace guard

### DIFF
--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -165,6 +165,7 @@ describe('normalizeKeepers context measurement', () => {
       'turn_record_undecodable',
       'turn_record_read_failed',
       'turn_record_without_usage',
+      'turn_record_trace_mismatch',
     ]) {
       const [keeper] = normalizeKeepers([
         {

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -1122,6 +1122,7 @@ export const KEEPER_CONTEXT_NOT_OBSERVED_REASONS = [
   'turn_record_undecodable',
   'turn_record_read_failed',
   'turn_record_without_usage',
+  'turn_record_trace_mismatch',
 ] as const
 
 export type KeeperContextNotObservedReason =

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -623,6 +623,7 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
             Keeper_context_observation_projection.context_fields
               ~config
               ~keeper_name:m.name
+              ~current_trace_id:(Keeper_id.Trace_id.to_string m.runtime.trace_id)
           in
 	          let summary =
               let trust_json =

--- a/lib/keeper/keeper_context_observation_projection.ml
+++ b/lib/keeper/keeper_context_observation_projection.ml
@@ -20,6 +20,7 @@ let reason_measurement_missing = "context_measurement_missing"
 let reason_undecodable = "turn_record_undecodable"
 let reason_read_failed = "turn_record_read_failed"
 let reason_without_usage = "turn_record_without_usage"
+let reason_trace_mismatch = "turn_record_trace_mismatch"
 
 let not_observed_json ~reason =
   `Assoc [ "kind", `String "not_observed"; "reason", `String reason ]
@@ -58,16 +59,35 @@ type latest_turn_observation =
   | Turn_record_read_failed
   | Observed of Turn_record.t
 
+(* The strict tail read keeps failure classes apart: [read_recent] would
+   silently skip a malformed newest line and serve the previous row as "the
+   measurement", and it flattens listing failures into an empty result. *)
 let latest_turn_observation ~config ~keeper_name =
   match
     let store = Keeper_types_support.keeper_turn_record_store config keeper_name in
-    Dated_jsonl.read_recent store 1
+    Dated_jsonl.read_recent_result store 1
   with
-  | [] -> No_turn_record
-  | json :: _ ->
+  | Ok [] -> No_turn_record
+  | Ok (Dated_jsonl.Parsed json :: _) ->
     (match Turn_record.of_json json with
      | Ok record -> Observed record
      | Error _ -> Undecodable_turn_record)
+  | Ok (Dated_jsonl.Malformed_json { path; line_number; detail } :: _) ->
+    Log.Keeper.warn
+      "context observation newest turn-record row is malformed keeper=%s path=%s line=%s: %s"
+      keeper_name
+      path
+      (match line_number with
+       | Some line -> string_of_int line
+       | None -> "?")
+      detail;
+    Undecodable_turn_record
+  | Error read_error ->
+    Log.Keeper.warn
+      "context observation turn-record read failed keeper=%s: %s"
+      keeper_name
+      (Dated_jsonl.read_error_to_string read_error);
+    Turn_record_read_failed
   | exception (Eio.Cancel.Cancelled _ as error) -> raise error
   | exception exn ->
     Log.Keeper.warn
@@ -117,7 +137,7 @@ let observed_context_fields (record : Turn_record.t) =
   ]
 ;;
 
-let context_fields ~config ~keeper_name =
+let context_fields ~config ~keeper_name ~current_trace_id =
   match latest_turn_observation ~config ~keeper_name with
   | No_turn_record ->
     context_fields_unavailable (not_observed_json ~reason:reason_measurement_missing)
@@ -126,9 +146,16 @@ let context_fields ~config ~keeper_name =
   | Turn_record_read_failed ->
     context_fields_unavailable (not_observed_json ~reason:reason_read_failed)
   | Observed record ->
-    (match record.usage.input_tokens with
-     | None -> context_fields_unavailable (not_observed_json ~reason:reason_without_usage)
-     | Some _ -> observed_context_fields record)
+    (* A reseeded identity starts a new trace while the per-name store keeps
+       the previous trace's rows: projecting those would show the prior
+       generation's occupancy on a keeper whose context is empty. *)
+    if not (String.equal record.trace_id current_trace_id)
+    then context_fields_unavailable (not_observed_json ~reason:reason_trace_mismatch)
+    else (
+      match record.usage.input_tokens with
+      | None ->
+        context_fields_unavailable (not_observed_json ~reason:reason_without_usage)
+      | Some _ -> observed_context_fields record)
 ;;
 
 let last_turn_usage_json_of_meta

--- a/lib/keeper/keeper_context_observation_projection.mli
+++ b/lib/keeper/keeper_context_observation_projection.mli
@@ -13,6 +13,7 @@ val missing_context_fields :
 val context_fields :
   config:Workspace.config ->
   keeper_name:string ->
+  current_trace_id:string ->
   (string * Yojson.Safe.t) list
 (** Context occupancy projected from the keeper's newest TurnRecord
     (RFC-0233), the measurement SSOT: [context_tokens] is the
@@ -21,14 +22,19 @@ val context_fields :
     the nested ["context"] object carries provenance ([turn_ref],
     [observed_at], [request_body_bytes]).
 
-    Display-only: the projection must never feed context pressure or
-    compaction decisions. It reads only the dated-JSONL tail (one line),
-    never checkpoints. Absence stays typed via
-    [context_metrics_unavailable] with a closed reason set:
+    Observation-only: no runtime consumer may derive context-pressure or
+    compaction decisions from these fields; dashboard triage surfaces
+    (bands, ordering, health counts) render them. It reads only the
+    dated-JSONL tail (one strict line), never checkpoints. Absence stays
+    typed via [context_metrics_unavailable] with a closed reason set:
     [context_measurement_missing] (no record),
-    [turn_record_undecodable] (newest line rejected by the strict codec),
-    [turn_record_read_failed] (store IO failed, warn-logged),
-    [turn_record_without_usage] (turn completed without provider usage). *)
+    [turn_record_undecodable] (newest line is not valid JSON or rejects
+    the strict codec, warn-logged),
+    [turn_record_read_failed] (store IO or listing failed, warn-logged),
+    [turn_record_without_usage] (turn completed without provider usage),
+    [turn_record_trace_mismatch] (newest row belongs to a previous trace
+    identity — a reseeded keeper stays typed-absent until its first
+    completed turn). *)
 
 val last_turn_usage_json_of_meta :
   Keeper_meta_contract.keeper_meta -> Yojson.Safe.t

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -141,6 +141,7 @@ let handle_keeper_list ctx args : tool_result =
             @ Keeper_context_observation_projection.context_fields
                 ~config:ctx.config
                 ~keeper_name:m.name
+                ~current_trace_id:(Keeper_id.Trace_id.to_string m.runtime.trace_id)
             @ [
               ( "last_turn_usage"
               , Keeper_context_observation_projection.last_turn_usage_json

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -363,6 +363,8 @@ let keepers_json
                       Keeper_context_observation_projection.context_fields
                         ~config
                         ~keeper_name:meta.name
+                        ~current_trace_id:
+                          (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
                     in
                     let runtime_trust =
                       let t_trust = Time_compat.now () in

--- a/lib/operator/operator_control_snapshot_persistent_agents.ml
+++ b/lib/operator/operator_control_snapshot_persistent_agents.ml
@@ -59,11 +59,19 @@ let persistent_agents_json ?keeper_names ?keeper_rows config =
                  ; "updated_at", field_or_null "updated_at"
                  ; "created_at", field_or_null "created_at"
                  ]
-                 (* Rows here re-project a persisted snapshot verbatim
-                    (field_or_null over stored JSON); reading live
-                    turn-record stores would mix a live measurement into a
-                    persisted view, so context stays typed-absent. *)
-                 @ Keeper_context_observation_projection.missing_context_fields ()
+                 (* Lossless filter (module contract): keeper_rows is the
+                    freshly computed keepers projection, so the measured
+                    context fields forward verbatim like every other field —
+                    synthesizing typed absence here would contradict the
+                    canonical row and trip false diagnostics. *)
+                 @ [ "context_ratio", field_or_null "context_ratio"
+                   ; "context_tokens", field_or_null "context_tokens"
+                   ; "context_max", field_or_null "context_max"
+                   ; "context_source", field_or_null "context_source"
+                   ; ( "context_metrics_unavailable"
+                     , field_or_null "context_metrics_unavailable" )
+                   ; "context", field_or_null "context"
+                   ]
                  @ [ "last_turn_usage", field_or_null "last_turn_usage" ]))
          | _ -> None)
       | _ -> None)
@@ -128,6 +136,8 @@ let persistent_agents_json ?keeper_names ?keeper_rows config =
                     @ Keeper_context_observation_projection.context_fields
                         ~config
                         ~keeper_name:meta.name
+                        ~current_trace_id:
+                          (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
                     @ [ ( "last_turn_usage"
                         , Keeper_context_observation_projection
                           .last_turn_usage_json

--- a/test/test_keeper_context_observation_projection.ml
+++ b/test/test_keeper_context_observation_projection.ml
@@ -19,6 +19,8 @@ let digest_of_label label =
   Digestif.SHA256.digest_string label |> Digestif.SHA256.to_hex
 ;;
 
+let sample_trace = "trace-1780648779957-00000"
+
 let sample_record
       ?(absolute_turn = 4071)
       ?(input_tokens = Some 18_000)
@@ -28,10 +30,9 @@ let sample_record
   =
   { execution_ids = []
   ; keeper = "rondo"
-  ; trace_id = "trace-1780648779957-00000"
+  ; trace_id = sample_trace
   ; absolute_turn
-  ; turn_ref =
-      Ids.Turn_ref.make ~trace_id:"trace-1780648779957-00000" ~absolute_turn
+  ; turn_ref = Ids.Turn_ref.make ~trace_id:sample_trace ~absolute_turn
   ; blocks =
       [ { Turn_record.block = Prompt_block_id.Persona
         ; bytes = 4
@@ -109,7 +110,7 @@ let check_not_observed fields ~reason =
 
 let test_missing_store_is_typed_absence () =
   with_temp_workspace (fun config ->
-    let fields = Projection.context_fields ~config ~keeper_name:"nobody" in
+    let fields = Projection.context_fields ~config ~keeper_name:"nobody" ~current_trace_id:sample_trace in
     check_not_observed fields ~reason:"context_measurement_missing")
 ;;
 
@@ -117,7 +118,7 @@ let test_measured_record_projects () =
   with_temp_workspace (fun config ->
     let record = sample_record () in
     append_record config record;
-    let fields = Projection.context_fields ~config ~keeper_name:"rondo" in
+    let fields = Projection.context_fields ~config ~keeper_name:"rondo" ~current_trace_id:sample_trace in
     (match field fields "context_tokens" with
      | `Int tokens -> check int "tokens" 18_000 tokens
      | _ -> fail "context_tokens is not an int");
@@ -154,7 +155,7 @@ let test_newest_record_wins () =
   with_temp_workspace (fun config ->
     append_record config (sample_record ~absolute_turn:1 ~input_tokens:(Some 100) ());
     append_record config (sample_record ~absolute_turn:2 ~input_tokens:(Some 200) ());
-    let fields = Projection.context_fields ~config ~keeper_name:"rondo" in
+    let fields = Projection.context_fields ~config ~keeper_name:"rondo" ~current_trace_id:sample_trace in
     match field fields "context_tokens" with
     | `Int tokens -> check int "newest tokens" 200 tokens
     | _ -> fail "context_tokens is not an int")
@@ -163,21 +164,62 @@ let test_newest_record_wins () =
 let test_record_without_usage_is_typed () =
   with_temp_workspace (fun config ->
     append_record config (sample_record ~input_tokens:None ());
-    let fields = Projection.context_fields ~config ~keeper_name:"rondo" in
+    let fields = Projection.context_fields ~config ~keeper_name:"rondo" ~current_trace_id:sample_trace in
     check_not_observed fields ~reason:"turn_record_without_usage")
 ;;
 
 let test_undecodable_newest_line_is_typed () =
   with_temp_workspace (fun config ->
     append_raw config ~keeper_name:"rondo" (`Assoc [ "schema", `String "future" ]);
-    let fields = Projection.context_fields ~config ~keeper_name:"rondo" in
+    let fields = Projection.context_fields ~config ~keeper_name:"rondo" ~current_trace_id:sample_trace in
     check_not_observed fields ~reason:"turn_record_undecodable")
+;;
+
+(* Raw non-JSON tail: the permissive reader would silently skip it and serve
+   the previous row as "the measurement"; the strict reader keeps it visible
+   as a typed decode failure. *)
+let test_malformed_raw_tail_is_undecodable_not_previous_row () =
+  with_temp_workspace (fun config ->
+    append_record config (sample_record ());
+    let store = Masc.Keeper_types_support.keeper_turn_record_store config "rondo" in
+    let base_dir = Dated_jsonl.base_dir store in
+    let day_files =
+      Sys.readdir base_dir
+      |> Array.to_list
+      |> List.concat_map (fun month ->
+        let month_path = Filename.concat base_dir month in
+        Sys.readdir month_path
+        |> Array.to_list
+        |> List.map (Filename.concat month_path))
+    in
+    (match day_files with
+     | [ day_file ] ->
+       let channel =
+         open_out_gen [ Open_append; Open_wronly ] 0o600 day_file
+       in
+       output_string channel "not a json line\n";
+       close_out channel
+     | files -> failf "expected exactly one day file, found %d" (List.length files));
+    let fields = Projection.context_fields ~config ~keeper_name:"rondo" ~current_trace_id:sample_trace in
+    check_not_observed fields ~reason:"turn_record_undecodable")
+;;
+
+let test_previous_trace_row_is_typed_absent () =
+  with_temp_workspace (fun config ->
+    append_record config (sample_record ());
+    let fields =
+      Projection.context_fields
+        ~config
+        ~keeper_name:"rondo"
+        ~current_trace_id:"trace-1780648779957-99999"
+    in
+    check_not_observed fields ~reason:"turn_record_trace_mismatch")
 ;;
 
 let test_missing_window_keeps_tokens_without_ratio () =
   with_temp_workspace (fun config ->
     append_record config (sample_record ~context_window:None ());
-    let fields = Projection.context_fields ~config ~keeper_name:"rondo" in
+    let fields = Projection.context_fields ~config ~keeper_name:"rondo" ~current_trace_id:sample_trace in
     (match field fields "context_tokens" with
      | `Int tokens -> check int "tokens survive" 18_000 tokens
      | _ -> fail "context_tokens is not an int");
@@ -199,6 +241,10 @@ let () =
             test_record_without_usage_is_typed
         ; test_case "undecodable newest line is typed" `Quick
             test_undecodable_newest_line_is_typed
+        ; test_case "malformed raw tail is undecodable, not previous row" `Quick
+            test_malformed_raw_tail_is_undecodable_not_previous_row
+        ; test_case "previous trace row is typed absent" `Quick
+            test_previous_trace_row_is_typed_absent
         ; test_case "missing window keeps tokens without ratio" `Quick
             test_missing_window_keeps_tokens_without_ratio
         ] )


### PR DESCRIPTION
## 목표

#26538(TurnRecord → fleet context projection) 병합 직후 Codex 사후 리뷰 P2 4건 중 코드 결함 3건을 수리한다. RFC 참조: `docs/rfc/RFC-0233-turn-observability-execution-identity.md` (측정 계약 — 본 PR은 그 투영의 실패 분류·정합만 고친다).

## 수리 3건

### 1. strict tail read — malformed 줄이 "이전 줄"로 둔갑하지 않게 (P2 인정)

`Dated_jsonl.read_recent`는 malformed 줄을 `Yojson.Json_error → ()`로 조용히 건너뛰고 **그 이전 줄을 반환**한다 — 최신 줄이 깨지면 한 턴 전 측정이 "현재"로 표시되고, 디렉토리 listing 실패도 빈 결과로 눌린다. 정의해둔 `turn_record_undecodable`/`turn_record_read_failed`가 부분 사문이었다.

→ `Dated_jsonl.read_recent_result`(typed `Parsed`/`Malformed_json` + `read_error`)로 교체. malformed tail = `turn_record_undecodable`(warn 로그 + path/line), IO·listing 실패 = `turn_record_read_failed`(`read_error_to_string`). 테스트 `malformed raw tail is undecodable, not previous row`가 폴백 부재를 고정.

### 2. persistent-agent rows의 lossless filter 계약 복원 (P2 인정 — #26538의 내 실수)

`persistent_agents_json`의 keeper_rows 경로는 모듈 doc이 "lossless filter — no field synthesis"로 선언하는데, #26538에서 내가 context 필드만 `missing_context_fields()`로 합성해 canonical `keepers` row(측정됨)와 `persistent_agents` row(부재)가 동시에 모순 — 잘못된 주석("persisted snapshot 재투영")까지 달았다.

→ context 6필드를 다른 필드처럼 `field_or_null`로 그대로 통과. 합성 제거.

### 3. trace 경계 — reseed된 keeper가 이전 세대 점유율을 입지 않게 (P2 인정)

per-name store는 이전 trace의 row를 보존하므로, identity reseed 직후 새 keeper가 **이전 trace의 토큰 점유율**을 표시했다.

→ `context_fields`에 `~current_trace_id` 필수 인자 추가(호출부 4곳 모두 meta의 trace를 전달). 최신 row의 `trace_id` 불일치 시 typed 부재 `turn_record_trace_mismatch` — 첫 완료 턴까지 부재가 정답. closed reason set은 5개가 되었고 TS 미러 리스트도 갱신.

### 4. display-only 계약 문구 정밀화 (P2 절반 인정 — 코드 변경은 문서만)

지적: `context_ratio` 소생이 대시보드의 `PRESSURE_WARN_RATIO(0.5)` 밴드·정렬·헬스 카운트를 다시 작동시킨다 — "must never feed context pressure decisions" 문구와 충돌. 판정: 해당 소비자는 전부 **대시보드 표시/트리아지**(색·정렬·요약 카운트)이고 런타임 압력·컴팩션 판단으로의 경로는 없다. ratio가 null인 동안 죽어 있던 기존 표시 정책이 실측으로 소생하는 것은 측정의 목적 그 자체다. 다만 mli 문구가 과대 약속이었으므로 "no **runtime** consumer may derive context-pressure or compaction decisions; dashboard triage surfaces render them"으로 정밀화. (0.5 임계값 자체의 적정성은 별도 손잡이 — 이 PR 범위 밖.)

## 검증

- OCaml: projection 테스트 8/8 (신규 2: malformed tail·trace mismatch), `dune build` 전체 + operator snapshot 테스트 green, changed 파일 ocamlformat 7/7 clean.
- dashboard: `tsc --noEmit` clean, normalizer 테스트 86/86 (reason 5종 pass-through 포함).

## 라이브 증명 게이트

배포 후: reseed 직전·직후 keeper의 `context_metrics_unavailable.reason == "turn_record_trace_mismatch"` 관측, 정상 keeper는 기존과 동일한 측정 투영 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
