### PR TITLE
feat(keeper): thread resolved persona into Memory OS librarian (RFC #26534 PR-B)

### DIFF
--- a/config/prompts/keeper.librarian.current_selection.md
+++ b/config/prompts/keeper.librarian.current_selection.md
@@ -1,10 +1,12 @@
 ---
 description: Memory OS librarian current-memory selection prompt
 category: keeper
-template_variables: [current_memory, conversation_history]
+template_variables: [current_memory, conversation_history, persona]
 ---
 
-You own the complete current memory of an AI agent. Read the exact current-memory snapshot and a bounded slice of new conversation. Return the existing memory IDs that still deserve to remain plus genuinely new claims. Any current memory ID you omit is forgotten immediately.
+You own the complete current memory of an AI agent. Read the agent's persona, the exact current-memory snapshot, and a bounded slice of new conversation. Return the existing memory IDs that still deserve to remain plus genuinely new claims. Any current memory ID you omit is forgotten immediately.
+
+You curate on this agent's behalf: the persona section defines who the agent is, and importance is always importance *to that identity* — its role, duties, and ongoing work. A fact worthless to a generic assistant may be essential to this persona, and vice versa.
 
 Keep only the smallest useful set of important knowledge. There is no target item count and no deterministic ranking after your decision. Your returned selection is injected as-is into later Keeper turns, so remove duplication, obsolete state, low-value narration, and details recoverable from authoritative sources.
 
@@ -43,6 +45,9 @@ Output schema:
     }
   ]
 }
+
+Persona of the agent whose memory you curate:
+{{persona}}
 
 Exact current memory:
 {{current_memory}}

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -989,7 +989,8 @@ let run_turn
                                  AfterTurn ordinal")
                          | Some final_oas_turn_ordinal ->
                            Keeper_agent_run_finalize_response.finalize
-                             ~config ~meta ~generation ~manifest_keeper_turn_id
+                             ~config ~meta ~generation ~profile_defaults
+                             ~manifest_keeper_turn_id
                              ~session ~append_manifest ~model
                              ~acc
                              ~actual_keeper_tool_names

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -284,6 +284,7 @@ let finalize
     ~config
     ~meta
     ~generation
+    ~(profile_defaults : Keeper_types_profile.keeper_profile_defaults)
     ~manifest_keeper_turn_id
     ~session
     ~(append_manifest : Keeper_agent_run_turn_helpers.append_manifest_fn)
@@ -464,6 +465,7 @@ let finalize
       ~config
       ~meta
       ~generation
+      ~profile_defaults
       ~turn:manifest_keeper_turn_id
       ~oas_turn_count:result.turns
       ~actual_tools:actual_keeper_tool_names

--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -7,6 +7,7 @@ let run
   ~config
   ~(meta : Keeper_meta_contract.keeper_meta)
   ~generation
+  ~(profile_defaults : Keeper_types_profile.keeper_profile_defaults)
   ~turn
   ~oas_turn_count
   ~actual_tools
@@ -106,9 +107,21 @@ let run
              let trace_id =
                Keeper_id.Trace_id.to_string meta.runtime.trace_id
              in
+             (* Same persona SSOT as the keeper's own system prompt
+                ([Keeper_unified_prompt.build_system_prompt]). Loaded here on
+                the memory lane — off the turn path — so the librarian judges
+                retention through the identity the keeper currently lives
+                with. *)
+             let persona =
+               Keeper_types_profile.load_resolved_persona_extended
+                 ~keeper_name:meta.name
+                 ~profile_defaults
+                 ()
+             in
              let librarian_input : Keeper_librarian.input =
                { turn_ref = Ids.Turn_ref.make ~trace_id ~absolute_turn:turn
                ; generation
+               ; persona
                ; current = current_selection
                ; messages = librarian_messages
                }

--- a/lib/keeper/keeper_agent_run_post_turn_memory.mli
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.mli
@@ -12,6 +12,7 @@ val run :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->
   generation:int ->
+  profile_defaults:Keeper_types_profile.keeper_profile_defaults ->
   turn:int ->
   oas_turn_count:int ->
   actual_tools:string list ->
@@ -30,6 +31,12 @@ val run :
 
     [inference_telemetry] is [result.response.telemetry] from the OAS
     result; it is optional because some providers do not emit telemetry.
+
+    [profile_defaults] feeds the persona-name resolution shared with the
+    keeper's own system prompt
+    ([Keeper_types_profile.load_resolved_persona_extended]); the resolved
+    persona text rides the Librarian input so curation judges importance
+    through the keeper's identity.
 
     [deliberation_execution], when available, is persisted as advisory
     delegation request artifacts on this post-turn memory lane rather than on

--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -16,6 +16,7 @@ type current_selection =
 type input =
   { turn_ref : Ids.Turn_ref.t
   ; generation : int
+  ; persona : string
   ; current : current_selection option
   ; messages : Agent_sdk.Types.message list
   }
@@ -118,8 +119,15 @@ let format_current_selection_for_prompt
     current_selection_json current |> Yojson.Safe.pretty_to_string
 ;;
 
+let format_persona_for_prompt persona =
+  match trim_nonempty persona with
+  | None -> "[no persona]"
+  | Some persona -> persona
+;;
+
 let prompt_variables (inp : input) : (string * string) list =
-  [ "current_memory", format_current_selection_for_prompt inp.current
+  [ "persona", format_persona_for_prompt inp.persona
+  ; "current_memory", format_current_selection_for_prompt inp.current
   ; ( "conversation_history"
     , format_messages_for_prompt inp.messages )
   ]

--- a/lib/keeper/keeper_librarian.mli
+++ b/lib/keeper/keeper_librarian.mli
@@ -12,6 +12,12 @@ type current_selection =
 type input =
   { turn_ref : Ids.Turn_ref.t
   ; generation : int
+  ; persona : string
+    (** The same resolved persona text the keeper's own system prompt
+        carries ([Keeper_types_profile.load_resolved_persona_extended]).
+        The librarian curates on the keeper's behalf, so it judges
+        importance through this identity; [""] renders as an explicit
+        [no persona] marker. *)
   ; current : current_selection option
   ; messages : Agent_sdk.Types.message list
   }

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -650,10 +650,10 @@ let load_resolved_persona_extended ~keeper_name ?profile_defaults () =
     | Some defaults -> resolved_persona_name ~keeper_name defaults
     | None -> keeper_name
   in
-  (* DET-OK: absent persona is a known-valid empty block, not an unknown
-     input — read failures are already operator-visible inside
-     [load_persona_extended], and "" renders as an explicit [no persona]
+  (* Read failures are already operator-visible inside
+     [load_persona_extended]; "" renders as an explicit [no persona]
      marker at the librarian prompt boundary. *)
+  (* DET-OK: absent persona is a known-valid empty block, not unknown input. *)
   Option.value ~default:"" (load_persona_extended persona_name)
 
 let load_persona_summary = Keeper_types_profile_persona.load_persona_summary

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -643,6 +643,17 @@ let persona_description_max_chars =
 ;;
 
 let load_persona_extended = Keeper_types_profile_persona.load_persona_extended
+
+let load_resolved_persona_extended ~keeper_name ?profile_defaults () =
+  let persona_name =
+    match profile_defaults with
+    | Some defaults -> resolved_persona_name ~keeper_name defaults
+    | None -> keeper_name
+  in
+  (* An absent persona is a valid empty block. Read failures are already
+     operator-visible in [load_persona_extended]. *)
+  Option.value ~default:"" (load_persona_extended persona_name)
+
 let load_persona_summary = Keeper_types_profile_persona.load_persona_summary
 
 let load_persona_summary_from_path =

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -650,8 +650,10 @@ let load_resolved_persona_extended ~keeper_name ?profile_defaults () =
     | Some defaults -> resolved_persona_name ~keeper_name defaults
     | None -> keeper_name
   in
-  (* An absent persona is a valid empty block. Read failures are already
-     operator-visible in [load_persona_extended]. *)
+  (* DET-OK: absent persona is a known-valid empty block, not an unknown
+     input — read failures are already operator-visible inside
+     [load_persona_extended], and "" renders as an explicit [no persona]
+     marker at the librarian prompt boundary. *)
   Option.value ~default:"" (load_persona_extended persona_name)
 
 let load_persona_summary = Keeper_types_profile_persona.load_persona_summary

--- a/lib/keeper/keeper_types_profile.mli
+++ b/lib/keeper/keeper_types_profile.mli
@@ -191,6 +191,18 @@ val keeper_default_source_snapshot :
   base_path:string -> string -> keeper_default_source_snapshot
 val persona_description_max_chars : int
 val load_persona_extended : ?max_chars:int -> string -> string option
+
+(** Persona-name resolution ([resolved_persona_name] when defaults are
+    available, else the keeper name) fused with the extended-persona load.
+    Single source of truth for "the persona text this keeper lives with":
+    the unified system prompt and the Memory OS librarian must both read
+    persona through here so their views cannot diverge. Returns [""] when
+    the resolved persona has no extended text. *)
+val load_resolved_persona_extended :
+  keeper_name:string ->
+  ?profile_defaults:keeper_profile_defaults ->
+  unit ->
+  string
 val load_persona_summary : string -> persona_summary option
 val load_persona_summary_from_path : string -> string -> persona_summary option
 val list_persona_summaries : unit -> persona_summary list

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -518,18 +518,10 @@ let build_system_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path :
   =
   let instructions = effective_instructions ~meta ?profile_defaults () in
   let persona_extended =
-    let persona_name =
-      match profile_defaults with
-      | Some defaults ->
-          Keeper_types_profile.resolved_persona_name ~keeper_name:meta.name
-            defaults
-      | None -> meta.name
-    in
-    (* An absent persona is a valid empty block. Read failures are already
-       operator-visible in [load_persona_extended]. *)
-    Option.value
-      ~default:""
-      (Keeper_types_profile.load_persona_extended persona_name)
+    Keeper_types_profile.load_resolved_persona_extended
+      ~keeper_name:meta.name
+      ?profile_defaults
+      ()
   in
   let active_goals =
     Option.value

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -4,6 +4,30 @@ module Librarian = Masc.Keeper_librarian
 module Runtime = Masc.Keeper_librarian_runtime
 module Memory = Masc.Keeper_memory_os_types
 
+(* Render tests resolve the real repo templates so template <-> code
+   variable drift fails here instead of as a live [Prompt_render_failed]
+   (same pattern as test_keeper_unified_persona_block). *)
+let has_prompt_root path =
+  Sys.file_exists
+    (Filename.concat path "config/prompts/keeper.librarian.current_selection.md")
+
+let repo_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root when has_prompt_root root -> root
+  | _ ->
+    let rec ascend path =
+      if has_prompt_root path then path
+      else (
+        let parent = Filename.dirname path in
+        if String.equal parent path then Sys.getcwd () else ascend parent)
+    in
+    ascend (Sys.getcwd ())
+
+let () =
+  let prompts_dir = Filename.concat (repo_root ()) "config/prompts" in
+  Prompt_registry.set_markdown_dir prompts_dir;
+  Masc.Prompt_defaults.init ()
+
 let fact ~claim : Memory.fact =
   { claim
   ; category = Memory.Fact
@@ -22,6 +46,7 @@ let input () : Librarian.input =
         ~trace_id:"trace-selection"
         ~absolute_turn:7
   ; generation = 7
+  ; persona = "You are the retry-test keeper."
   ; current =
       Some
         { Librarian.facts = [ current_a; current_b ] }
@@ -201,6 +226,57 @@ let test_prompt_contains_exact_current_selection () =
     (String_util.contains_substring current_memory "first_seen")
 ;;
 
+let test_prompt_carries_persona () =
+  let variables = Librarian.prompt_variables (input ()) in
+  check string "persona is the resolved text"
+    "You are the retry-test keeper."
+    (List.assoc "persona" variables);
+  let blank = { (input ()) with persona = " \n \t " } in
+  check string "blank persona renders an explicit marker"
+    "[no persona]"
+    (List.assoc "persona" (Librarian.prompt_variables blank))
+;;
+
+let user_text_of_messages messages =
+  messages
+  |> List.filter_map (fun (m : Agent_sdk.Types.message) ->
+    if m.role = Agent_sdk.Types.User
+    then
+      Some
+        (m.content
+         |> List.filter_map (function
+           | Agent_sdk.Types.Text s -> Some s
+           | Agent_sdk.Types.ToolResult _ | Agent_sdk.Types.ToolUse _
+           | Agent_sdk.Types.Thinking _ | Agent_sdk.Types.ReasoningDetails _
+           | Agent_sdk.Types.RedactedThinking _ | Agent_sdk.Types.Image _
+           | Agent_sdk.Types.Document _ | Agent_sdk.Types.Audio _ -> None)
+         |> String.concat "\n")
+    else None)
+  |> String.concat "\n"
+;;
+
+let test_repo_template_renders_persona () =
+  (match Runtime.messages_for_librarian (input ()) with
+   | Error detail -> failf "librarian render failed: %s" detail
+   | Ok messages ->
+     let user_text = user_text_of_messages messages in
+     check bool "persona section header present" true
+       (String_util.contains_substring user_text
+          "Persona of the agent whose memory you curate:");
+     check bool "persona text present" true
+       (String_util.contains_substring user_text
+          "You are the retry-test keeper."));
+  match
+    Runtime.messages_for_librarian { (input ()) with persona = "" }
+  with
+  | Error detail -> failf "blank-persona render failed: %s" detail
+  | Ok messages ->
+    check bool "blank persona renders explicit marker" true
+      (String_util.contains_substring
+         (user_text_of_messages messages)
+         "[no persona]")
+;;
+
 let test_cadence_fresh_then_periodic () =
   check (pair int bool) "fresh due"
     (3, true)
@@ -252,6 +328,10 @@ let () =
             test_removed_contract_fields_reject
         ; test_case "prompt carries exact current selection" `Quick
             test_prompt_contains_exact_current_selection
+        ; test_case "prompt carries persona" `Quick
+            test_prompt_carries_persona
+        ; test_case "repo template renders persona" `Quick
+            test_repo_template_renders_persona
         ] )
     ; ( "cadence"
       , [ test_case "fresh then periodic" `Quick test_cadence_fresh_then_periodic

--- a/test/test_keeper_memory_lane.ml
+++ b/test/test_keeper_memory_lane.ml
@@ -49,6 +49,8 @@ let run_post_turn ~config ~meta ~turn =
     ~config
     ~meta
     ~generation:turn
+    ~profile_defaults:
+      Masc.Keeper_types_profile_defaults.empty_keeper_profile_defaults
     ~turn
     ~oas_turn_count:1
     ~actual_tools:[]


### PR DESCRIPTION
## RFC #26534 PR-B: librarian persona 주입

RFC #26534의 librarian 정의는 한 줄입니다 — "persona와 최근 N턴을 보고 keeper 대신 일기를 써주는 존재". PR-A(#26536, journal)가 라이브 증명을 통과해 이 계단이 열렸습니다. 현재 librarian은 `prompt_variables = {current_memory, conversation_history}` 둘뿐인 **persona-blind** 상태로, keeper가 누구인지 모른 채 무엇을 기억할지 판정하고 있었습니다.

같은 결함의 조상이 이미 레포에 있습니다: `test_keeper_unified_persona_block.ml`(D-11) docstring — "unified lane은 persona 주입 없이 출시됐다; keeper는 말을 걸 때만 인격이 있었다". D-11이 본체 턴을 고쳤고, 이 PR은 librarian에 같은 수리를 합니다.

### 변경

1. **`Keeper_types_profile.load_resolved_persona_extended`** — persona-name 해석(profile `persona_name` else keeper name) + extended 로드 융합. `Keeper_unified_prompt.build_system_prompt`의 인라인 블록을 자구 그대로 추출(동작 불변)해서, keeper 본체 system prompt와 librarian이 **같은 함수로만** persona를 읽습니다. `meta.persona` 필드는 제3의 경로라 쓰지 않았습니다.
2. **`Keeper_librarian.input`에 `persona : string`** — 순수 모듈은 I/O 없이 유지, 로드는 admission 지점(`keeper_agent_run_post_turn_memory`, memory lane 위·턴 경로 밖)에서. threading은 `run_turn`(profile_defaults 스코프) → `finalize` → `post_turn_memory` 라벨 인자 — 컴파일러가 전 지점 강제.
3. **빈 persona는 `"[no persona]"` 마커** — 기존 `"[no messages]"` 관례와 동일.
4. **`current_selection` 템플릿** — `{{persona}}` 섹션 + "importance는 이 identity에 대한 importance다" 프레이밍. frontmatter `template_variables`에 `persona` 추가.

### 템플릿↔코드가 배포에서 찢어질 수 없는 이유

바이너리가 repo `config/`를 임베드하고 기동 시 `.masc/config/prompts/`를 강제 수렴(#20929, diverge=stale로 간주 덮어씀; 운영자 커스텀은 `prompt_overrides.json` 별도 레이어 — 현재 라이브에 override 파일 없음 확인). 코드와 템플릿이 같은 바이너리에서 나오므로 "코드는 변수를 주는데 템플릿은 모르는" 혼합 상태가 구조적으로 불가능합니다. 수동 live 파일 갱신 불필요.

### 검증 (로컬)

- `dune build --root . @check` green (전체)
- `test_keeper_librarian_retry` **13/13** — 신규 2건 포함:
  - `prompt carries persona`: persona 원문 passthrough + 공백→`[no persona]`
  - `repo template renders persona`: **실제 repo 템플릿을 registry로 렌더** — 템플릿↔코드 변수 drift가 런타임 `Prompt_render_failed` 대신 CI에서 죽음 (D-11 테스트의 repo_root 패턴 재사용)
- `test_keeper_memory_lane` 헬퍼 시그니처 갱신

**선재 로컬 실패 2건 (이 diff 무관, base `1ca15be98e`에서 동일 재현)**: `test_keeper_memory_lane` lane.010(meta fixture identity 거부), `test_keeper_unified_persona_block` d11.002("Primary goal" affix 부재). 둘 다 main에서 같은 방식으로 실패 — 로컬 env(`MASC_BASE_PATH` override 무시 로그) 성격으로 보이며 CI 판정을 기준으로 합니다.

### 라이브 증명 게이트 (머지≠작동)

머지 후 재빌드·재기동 시:
1. 기동 sync가 live `keeper.librarian.current_selection.md`를 새 템플릿으로 덮었는지 확인 (`{{persona}}` 존재)
2. librarian commit 로그(`memory os librarian committed`)가 계속 나오는지 — 렌더가 깨졌다면 `Prompt_render_failed`로 즉시 드러남
3. 판단 변화 프로브: persona 관련성이 명확히 갈리는 fact 쌍을 심고 retention 차이 관측

RFC: #26534 (Memory OS 2.0 — bounded context and librarian curator). 사다리: PR-A journal(#26536, 라이브 증명 완료) → **PR-B persona(이 PR)** → 총체성 계약 → 전송 계약(꼬리 K) → 컴팩션 숙청.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
