### PR TITLE
feat(keeper): librarian totality — every drop carries a stated reason (RFC #26534)

### DIFF
--- a/config/prompts/keeper.librarian.current_selection.md
+++ b/config/prompts/keeper.librarian.current_selection.md
@@ -4,7 +4,7 @@ category: keeper
 template_variables: [current_memory, conversation_history, persona]
 ---
 
-You own the complete current memory of an AI agent. Read the agent's persona, the exact current-memory snapshot, and a bounded slice of new conversation. Return the existing memory IDs that still deserve to remain plus genuinely new claims. Any current memory ID you omit is forgotten immediately.
+You own the complete current memory of an AI agent. Read the agent's persona, the exact current-memory snapshot, and a bounded slice of new conversation. Every existing memory ID must appear exactly once in your answer: either in `retained_memory_ids` (it stays) or in `dropped` with a one-sentence reason (it is forgotten). An existing ID that appears in neither list rejects the whole answer.
 
 You curate on this agent's behalf: the persona section defines who the agent is, and importance is always importance *to that identity* — its role, duties, and ongoing work. A fact worthless to a generic assistant may be essential to this persona, and vice versa.
 
@@ -12,8 +12,8 @@ Keep only the smallest useful set of important knowledge. There is no target ite
 
 Retention criteria:
 - Retain an existing ID only when its exact fact is still true, important, non-duplicative, and worth occupying future context.
-- Omit stale, superseded, transient, or derivable existing memories. Omission is the deletion operation.
-- Never recreate an omitted existing fact as a new claim merely to reword it.
+- Drop stale, superseded, transient, or derivable existing memories. Dropping is the deletion operation, and each drop states its reason in one sentence (what made this memory stop earning its place).
+- Never recreate a dropped existing fact as a new claim merely to reword it.
 
 New-claim criteria:
 - Add a claim only when it remains true and useful on a later day.
@@ -43,8 +43,16 @@ Output schema:
       "claim": "A single factual sentence.",
       "category": "code_change|fact|preference|blocker|goal|constraint|validated_approach|lesson"
     }
+  ],
+  "dropped": [
+    {
+      "memory_id": "exact-memory-id-from-current-memory",
+      "reason": "One sentence: why this memory no longer earns its place."
+    }
   ]
 }
+
+Every existing memory ID goes to exactly one of retained_memory_ids or dropped. When nothing is dropped, "dropped" is an empty array.
 
 Persona of the agent whose memory you curate:
 {{persona}}

--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -24,16 +24,21 @@ type input =
 type selection =
   { retained_memory_ids : string list
   ; new_claims : fact list
+  ; dropped : dropped_statement list
   ; facts : fact list
   }
 
 let wire_field_retained_memory_ids = "retained_memory_ids"
 let wire_field_new_claims = "new_claims"
+let wire_field_dropped = "dropped"
 let wire_field_claim = Keeper_memory_os_types.wire_field_claim
 let wire_field_category = Keeper_memory_os_types.wire_field_category
+let wire_field_memory_id = Keeper_memory_os_types.wire_field_memory_id
+let wire_field_reason = Keeper_memory_os_types.wire_field_reason
 let wire_claim_fields = Keeper_memory_os_types.wire_librarian_claim_fields
+let wire_dropped_fields = Keeper_memory_os_types.wire_librarian_dropped_fields
 let wire_current_fields =
-  [ wire_field_retained_memory_ids; wire_field_new_claims ]
+  [ wire_field_retained_memory_ids; wire_field_new_claims; wire_field_dropped ]
 
 let trim_nonempty s =
   let s = String.trim s in
@@ -96,7 +101,7 @@ let format_messages_for_prompt messages =
 
 let current_fact_json fact =
   `Assoc
-    [ "memory_id", `String (memory_id fact)
+    [ wire_field_memory_id, `String (memory_id fact)
     ; ( "fact"
       , `Assoc
           [ wire_field_claim, `String fact.claim
@@ -178,9 +183,14 @@ type parse_error =
   | Duplicate_field of string
   | Missing_required_fields
   | Claim_schema_mismatch
+  | Dropped_schema_mismatch
   | Unknown_retained_memory_id of string
   | Duplicate_retained_memory_id of string
   | Duplicate_selected_memory_id of string
+  | Unknown_dropped_memory_id of string
+  | Duplicate_dropped_memory_id of string
+  | Dropped_memory_id_also_retained of string
+  | Missing_disposition of string
 
 let parse_error_to_string = function
   | Top_level_not_object -> "top_level_not_object"
@@ -188,12 +198,20 @@ let parse_error_to_string = function
   | Duplicate_field field -> "duplicate_field: " ^ field
   | Missing_required_fields -> "missing_required_fields"
   | Claim_schema_mismatch -> "claim_schema_mismatch"
+  | Dropped_schema_mismatch -> "dropped_schema_mismatch"
   | Unknown_retained_memory_id identity ->
     "unknown_retained_memory_id: " ^ identity
   | Duplicate_retained_memory_id identity ->
     "duplicate_retained_memory_id: " ^ identity
   | Duplicate_selected_memory_id identity ->
     "duplicate_selected_memory_id: " ^ identity
+  | Unknown_dropped_memory_id identity ->
+    "unknown_dropped_memory_id: " ^ identity
+  | Duplicate_dropped_memory_id identity ->
+    "duplicate_dropped_memory_id: " ^ identity
+  | Dropped_memory_id_also_retained identity ->
+    "dropped_memory_id_also_retained: " ^ identity
+  | Missing_disposition identity -> "missing_disposition: " ^ identity
 ;;
 
 let fact_of_json ~now (json : Yojson.Safe.t) : fact option =
@@ -215,6 +233,23 @@ let claim_field_error = function
   | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> None
 ;;
 
+let dropped_field_error = function
+  | `Assoc fields -> first_object_field_error ~allowed:wire_dropped_fields fields
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> None
+;;
+
+let dropped_statement_of_json (json : Yojson.Safe.t) : dropped_statement option =
+  match json with
+  | `Assoc fields ->
+    (match
+       string_field wire_field_memory_id fields
+       , string_field wire_field_reason fields
+     with
+     | Some memory_id, Some reason -> Some { memory_id; reason }
+     | (Some _, None) | (None, _) -> None)
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> None
+;;
+
 let current_facts_by_id facts =
   List.fold_left
     (fun by_id fact ->
@@ -229,7 +264,7 @@ let current_facts inp =
   | Some current -> current.facts
 ;;
 
-let materialize_facts ~current_facts ~retained_memory_ids ~new_claims =
+let materialize_facts ~current_facts ~retained_memory_ids ~new_claims ~dropped =
   let open Result.Syntax in
   let current_by_id = current_facts_by_id current_facts in
   let rec retain seen retained_rev = function
@@ -248,6 +283,34 @@ let materialize_facts ~current_facts ~retained_memory_ids ~new_claims =
   in
   let* retained, selected_ids =
     retain String_set.empty [] retained_memory_ids
+  in
+  (* Totality: every current identity must be dispositioned exactly once —
+     retained or dropped with a stated reason. Silent omission is no longer
+     the deletion operation; it is a contract violation. *)
+  let rec validate_dropped seen = function
+    | [] -> Ok seen
+    | (statement : dropped_statement) :: rest ->
+      if String_set.mem statement.memory_id seen
+      then Error (Duplicate_dropped_memory_id statement.memory_id)
+      else if String_set.mem statement.memory_id selected_ids
+      then Error (Dropped_memory_id_also_retained statement.memory_id)
+      else if not (String_map.mem statement.memory_id current_by_id)
+      then Error (Unknown_dropped_memory_id statement.memory_id)
+      else validate_dropped (String_set.add statement.memory_id seen) rest
+  in
+  let* dropped_ids = validate_dropped String_set.empty dropped in
+  let* () =
+    match
+      List.find_opt
+        (fun fact ->
+           let identity = memory_id fact in
+           not
+             (String_set.mem identity selected_ids
+              || String_set.mem identity dropped_ids))
+        current_facts
+    with
+    | Some fact -> Error (Missing_disposition (memory_id fact))
+    | None -> Ok ()
   in
   let rec append_new selected_ids new_rev = function
     | [] -> Ok (retained @ List.rev new_rev)
@@ -285,31 +348,43 @@ let selection_of_json_result ?now (inp : input) (json : Yojson.Safe.t) :
        (match
           string_list_field wire_field_retained_memory_ids fields
           , List.assoc_opt wire_field_new_claims fields
+          , List.assoc_opt wire_field_dropped fields
         with
         | ( Some retained_memory_ids
-          , Some (`List claim_items) ) ->
+          , Some (`List claim_items)
+          , Some (`List dropped_items) ) ->
           (match List.find_map claim_field_error claim_items with
            | Some (Unexpected_object_field field) -> Error (Unexpected_field field)
            | Some (Duplicate_object_field field) -> Error (Duplicate_field field)
            | None ->
-             (match
-                traverse (fact_of_json ~now) claim_items
-              with
-              | Some new_claims ->
+             (match List.find_map dropped_field_error dropped_items with
+              | Some (Unexpected_object_field field) ->
+                Error (Unexpected_field field)
+              | Some (Duplicate_object_field field) ->
+                Error (Duplicate_field field)
+              | None ->
                 (match
-                   materialize_facts
-                     ~current_facts:(current_facts inp)
-                     ~retained_memory_ids
-                     ~new_claims
+                   traverse (fact_of_json ~now) claim_items
+                   , traverse dropped_statement_of_json dropped_items
                  with
-                 | Ok facts ->
-                   Ok
-                     { retained_memory_ids
-                     ; new_claims
-                     ; facts
-                     }
-                 | Error _ as error -> error)
-              | None -> Error Claim_schema_mismatch))
+                 | Some new_claims, Some dropped ->
+                   (match
+                      materialize_facts
+                        ~current_facts:(current_facts inp)
+                        ~retained_memory_ids
+                        ~new_claims
+                        ~dropped
+                    with
+                    | Ok facts ->
+                      Ok
+                        { retained_memory_ids
+                        ; new_claims
+                        ; dropped
+                        ; facts
+                        }
+                    | Error _ as error -> error)
+                 | Some _, None -> Error Dropped_schema_mismatch
+                 | None, _ -> Error Claim_schema_mismatch)))
         | _ -> Error Missing_required_fields))
   | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ ->
     Error Top_level_not_object

--- a/lib/keeper/keeper_librarian.mli
+++ b/lib/keeper/keeper_librarian.mli
@@ -25,15 +25,23 @@ type input =
 type selection =
   { retained_memory_ids : string list
   ; new_claims : Keeper_memory_os_types.fact list
+  ; dropped : Keeper_memory_os_types.dropped_statement list
+    (** One statement per dropped current memory. Totality is enforced:
+        every current identity appears in [retained_memory_ids] or here,
+        so [Missing_disposition] replaces silent forgetting. *)
   ; facts : Keeper_memory_os_types.fact list
   }
 
 val wire_field_retained_memory_ids : string
 val wire_field_new_claims : string
+val wire_field_dropped : string
 val wire_field_claim : string
 val wire_field_category : string
+val wire_field_memory_id : string
+val wire_field_reason : string
 val wire_current_fields : string list
 val wire_claim_fields : string list
+val wire_dropped_fields : string list
 
 val prompt_variables : input -> (string * string) list
 
@@ -43,9 +51,14 @@ type parse_error =
   | Duplicate_field of string
   | Missing_required_fields
   | Claim_schema_mismatch
+  | Dropped_schema_mismatch
   | Unknown_retained_memory_id of string
   | Duplicate_retained_memory_id of string
   | Duplicate_selected_memory_id of string
+  | Unknown_dropped_memory_id of string
+  | Duplicate_dropped_memory_id of string
+  | Dropped_memory_id_also_retained of string
+  | Missing_disposition of string
 
 val parse_error_to_string : parse_error -> string
 

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -387,6 +387,7 @@ let extract_and_commit_with_exact_output_classified
   in
   Keeper_memory_os_current.replace
     ?clock
+    ~dropped_statements:selection.dropped
     ~keepers_dir
     ~keeper_id
     ~expected_revision

--- a/lib/keeper/keeper_memory_os_current.ml
+++ b/lib/keeper/keeper_memory_os_current.ml
@@ -294,21 +294,37 @@ let compute_change ~previous ~next =
     }
 ;;
 
-let journal_entry_to_json snapshot =
+(* [dropped_statements = None] means the writer makes no drop-reason
+   statements (explicit keeper writes, upserts); [Some list] is the
+   librarian's own account of every drop in this commit, possibly empty.
+   Statements live only on the journal line: the snapshot codec stays
+   frozen, so existing on-disk snapshots keep parsing unchanged. *)
+let journal_entry_to_json ~dropped_statements snapshot =
   `Assoc
-    [ "recorded_at", `Float snapshot.updated_at
-    ; "revision", `Int snapshot.revision
-    ; "source", source_to_json snapshot.source
-    ; "change", change_to_json snapshot.change
-    ]
+    ([ "recorded_at", `Float snapshot.updated_at
+     ; "revision", `Int snapshot.revision
+     ; "source", source_to_json snapshot.source
+     ; "change", change_to_json snapshot.change
+     ]
+     @
+     match dropped_statements with
+     | None -> []
+     | Some statements ->
+       [ ( "dropped"
+         , `List (List.map dropped_statement_to_json statements) )
+       ])
 ;;
 
 (* The journal is observation only: the snapshot commit it describes already
    reached disk, so an append failure degrades to a warning instead of
    vetoing the commit. Cancellation is never absorbed. *)
-let append_journal_entry ~keepers_dir ~keeper_id snapshot =
+let append_journal_entry ~keepers_dir ~keeper_id ~dropped_statements snapshot =
   let path = journal_path_for_keepers_dir ~keepers_dir ~keeper_id in
-  try Fs_compat.append_jsonl path (journal_entry_to_json snapshot) with
+  try
+    Fs_compat.append_jsonl
+      path
+      (journal_entry_to_json ~dropped_statements snapshot)
+  with
   | Eio.Cancel.Cancelled _ as error -> raise error
   | exn ->
     Log.Keeper.warn
@@ -321,6 +337,7 @@ let lock_path snapshot_path = snapshot_path ^ ".lock"
 
 let update_locked
       ?clock
+      ?dropped_statements
       ~keepers_dir
       ~keeper_id
       build
@@ -339,7 +356,7 @@ let update_locked
     let content = Yojson.Safe.pretty_to_string (to_json next) ^ "\n" in
     match Fs_compat.save_file_atomic snapshot_path content with
     | Ok () ->
-      append_journal_entry ~keepers_dir ~keeper_id next;
+      append_journal_entry ~keepers_dir ~keeper_id ~dropped_statements next;
       Ok next
     | Error message ->
       Error
@@ -372,6 +389,7 @@ let make_snapshot
 
 let replace
       ?clock
+      ?dropped_statements
       ~keepers_dir
       ~keeper_id
       ~expected_revision
@@ -380,7 +398,7 @@ let replace
       ~facts
       ()
   =
-  update_locked ?clock ~keepers_dir ~keeper_id (fun previous ->
+  update_locked ?clock ?dropped_statements ~keepers_dir ~keeper_id (fun previous ->
     let observed_revision =
       Option.map (fun snapshot -> snapshot.revision) previous
     in

--- a/lib/keeper/keeper_memory_os_current.mli
+++ b/lib/keeper/keeper_memory_os_current.mli
@@ -36,7 +36,8 @@ type t =
 val path_for_keepers_dir : keepers_dir:string -> keeper_id:string -> string
 
 (** Append-only sidecar recording one line per committed snapshot
-    ([recorded_at]/[revision]/[source]/[change]). The resulting fact count
+    ([recorded_at]/[revision]/[source]/[change], plus [dropped] when the
+    writer supplied drop-reason statements). The resulting fact count
     is derivable as [change.retained + length change.added] and is
     deliberately not duplicated. Written on every successful
     [replace]/[upsert_fact] commit; never read on the turn path. *)
@@ -49,6 +50,7 @@ val read_for_keepers_dir :
 
 val replace
   :  ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?dropped_statements:Keeper_memory_os_types.dropped_statement list
   -> keepers_dir:string
   -> keeper_id:string
   -> expected_revision:int option
@@ -61,7 +63,13 @@ val replace
     still equals [expected_revision]. Duplicate fact identities reject before
     writing. Existing state must parse as the exact current schema; malformed,
     non-current, or concurrently changed state fails closed and is not
-    overwritten. *)
+    overwritten.
+
+    [dropped_statements], when present, is the writer's own account of every
+    drop in this commit (the librarian's totality output) and is recorded on
+    the journal line only — the snapshot codec never stores it. Omission
+    means the writer makes no drop-reason statements, not that nothing was
+    dropped. *)
 
 val upsert_fact
   :  ?clock:float Eio.Time.clock_ty Eio.Resource.t

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -6,6 +6,8 @@
 let wire_field_claim = "claim"
 let wire_field_category = "category"
 let wire_field_first_seen = "first_seen"
+let wire_field_memory_id = "memory_id"
+let wire_field_reason = "reason"
 
 module Wire_field_set = Set.Make (String)
 
@@ -32,6 +34,22 @@ let fact_wire_fields =
 
 let wire_librarian_claim_fields =
   [ wire_field_claim; wire_field_category ]
+;;
+
+let wire_librarian_dropped_fields =
+  [ wire_field_memory_id; wire_field_reason ]
+;;
+
+type dropped_statement =
+  { memory_id : string
+  ; reason : string
+  }
+
+let dropped_statement_to_json (d : dropped_statement) =
+  `Assoc
+    [ wire_field_memory_id, `String d.memory_id
+    ; wire_field_reason, `String d.reason
+    ]
 ;;
 
 (* The librarian taxonomy as a closed sum. The LLM emits one exact category

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -9,10 +9,26 @@
 val wire_field_claim : string
 val wire_field_category : string
 val wire_field_first_seen : string
+val wire_field_memory_id : string
+val wire_field_reason : string
 
 (** Claim-object fields accepted from the librarian and rendered in retry
     prompts. *)
 val wire_librarian_claim_fields : string list
+
+(** Dropped-statement object fields accepted from the librarian. *)
+val wire_librarian_dropped_fields : string list
+
+(** The librarian's explicit reason for dropping one existing memory.
+    [memory_id] names a fact in the current snapshot; [reason] is one
+    non-empty sentence. Statements ride the journal line of the commit
+    they explain; the snapshot codec never stores them. *)
+type dropped_statement =
+  { memory_id : string
+  ; reason : string
+  }
+
+val dropped_statement_to_json : dropped_statement -> Yojson.Safe.t
 
 (** Librarian taxonomy as a closed sum. Labels outside the current vocabulary
     reject at the producer and persistence boundaries. Categories are model

--- a/lib/keeper/keeper_structured_output_schema.ml
+++ b/lib/keeper/keeper_structured_output_schema.ml
@@ -50,11 +50,21 @@ let librarian_claim_schema =
   object_schema ~required:(List.map fst fields) fields
 ;;
 
+let librarian_dropped_schema =
+  let fields =
+    [ Keeper_librarian.wire_field_memory_id, string_schema
+    ; Keeper_librarian.wire_field_reason, string_schema
+    ]
+  in
+  object_schema ~required:(List.map fst fields) fields
+;;
+
 let librarian_current_output_schema =
   let fields =
     [ Keeper_librarian.wire_field_retained_memory_ids, string_array_schema
     ; ( Keeper_librarian.wire_field_new_claims
       , `Assoc [ "type", `String "array"; "items", librarian_claim_schema ] )
+    ; Keeper_librarian.wire_field_dropped, array_schema librarian_dropped_schema
     ]
   in
   object_schema ~required:(List.map fst fields) fields

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -65,11 +65,26 @@ let new_claim ?(claim = "add C") () =
     ]
 ;;
 
-let selection_json ?(retained = [ current_a_id ]) ?(new_claims = []) () =
+let dropped_json ?(reason = "superseded by newer state") id =
+  `Assoc
+    [ Librarian.wire_field_memory_id, `String id
+    ; Librarian.wire_field_reason, `String reason
+    ]
+;;
+
+(* Defaults keep the totality contract satisfied for the default input:
+   current = [A; B], retained = [A], so B must carry a drop statement. *)
+let selection_json
+      ?(retained = [ current_a_id ])
+      ?(new_claims = [])
+      ?(dropped = [ dropped_json current_b_id ])
+      ()
+  =
   `Assoc
     [ Librarian.wire_field_retained_memory_ids
     , `List (List.map (fun id -> `String id) retained)
     ; Librarian.wire_field_new_claims, `List new_claims
+    ; Librarian.wire_field_dropped, `List dropped
     ]
 ;;
 
@@ -84,7 +99,15 @@ let test_omission_deletes_and_retention_preserves_exact_fact () =
   | Ok selection ->
     check (list string) "retained ids" [ current_a_id ] selection.retained_memory_ids;
     check int "one fact remains" 1 (List.length selection.facts);
-    check string "exact retained claim" current_a.claim (List.hd selection.facts).claim
+    check string "exact retained claim" current_a.claim (List.hd selection.facts).claim;
+    check (list string) "drop statement names B"
+      [ current_b_id ]
+      (List.map
+         (fun (d : Memory.dropped_statement) -> d.memory_id)
+         selection.dropped);
+    check string "drop statement carries the reason"
+      "superseded by newer state"
+      (List.hd selection.dropped).reason
 ;;
 
 let test_new_claim_is_materialized_after_retained_facts () =
@@ -126,11 +149,12 @@ let test_new_claim_cannot_collide_with_retained_identity () =
   | Ok _ -> fail "retained/new identity collision accepted"
 ;;
 
-let test_new_claim_cannot_recreate_omitted_current_identity () =
+let test_new_claim_cannot_recreate_dropped_current_identity () =
   match
     parse
       (selection_json
          ~retained:[]
+         ~dropped:[ dropped_json current_a_id; dropped_json current_b_id ]
          ~new_claims:[ new_claim ~claim:"keep A" () ]
          ())
   with
@@ -138,9 +162,73 @@ let test_new_claim_cannot_recreate_omitted_current_identity () =
     when String.equal identity current_a_id -> ()
   | Error error ->
     failf
-      "wrong omitted-current collision error: %s"
+      "wrong dropped-current collision error: %s"
       (Librarian.parse_error_to_string error)
-  | Ok _ -> fail "omitted current identity was recreated as a new claim"
+  | Ok _ -> fail "dropped current identity was recreated as a new claim"
+;;
+
+let test_totality_rejects_unaccounted_current_id () =
+  (match parse (selection_json ~dropped:[] ()) with
+   | Error (Librarian.Missing_disposition identity)
+     when String.equal identity current_b_id -> ()
+   | Error error ->
+     failf "wrong totality error: %s" (Librarian.parse_error_to_string error)
+   | Ok _ -> fail "unaccounted current id accepted");
+  match
+    parse
+      (`Assoc
+         [ Librarian.wire_field_retained_memory_ids
+         , `List [ `String current_a_id ]
+         ; Librarian.wire_field_new_claims, `List []
+         ])
+  with
+  | Error Librarian.Missing_required_fields -> ()
+  | Error error ->
+    failf
+      "wrong missing-dropped-field error: %s"
+      (Librarian.parse_error_to_string error)
+  | Ok _ -> fail "selection without dropped field accepted"
+;;
+
+let test_dropped_statements_validate () =
+  (match
+     parse (selection_json ~dropped:[ dropped_json "missing" ] ())
+   with
+   | Error (Librarian.Unknown_dropped_memory_id "missing") -> ()
+   | Error error ->
+     failf "wrong unknown-dropped error: %s" (Librarian.parse_error_to_string error)
+   | Ok _ -> fail "unknown dropped id accepted");
+  (match
+     parse
+       (selection_json
+          ~dropped:[ dropped_json current_b_id; dropped_json current_b_id ]
+          ())
+   with
+   | Error (Librarian.Duplicate_dropped_memory_id identity)
+     when String.equal identity current_b_id -> ()
+   | Error error ->
+     failf "wrong duplicate-dropped error: %s" (Librarian.parse_error_to_string error)
+   | Ok _ -> fail "duplicate dropped id accepted");
+  (match
+     parse
+       (selection_json
+          ~dropped:[ dropped_json current_a_id; dropped_json current_b_id ]
+          ())
+   with
+   | Error (Librarian.Dropped_memory_id_also_retained identity)
+     when String.equal identity current_a_id -> ()
+   | Error error ->
+     failf "wrong dropped-retained overlap error: %s"
+       (Librarian.parse_error_to_string error)
+   | Ok _ -> fail "dropped id overlapping retained accepted");
+  match
+    parse
+      (selection_json ~dropped:[ dropped_json ~reason:"  " current_b_id ] ())
+  with
+  | Error Librarian.Dropped_schema_mismatch -> ()
+  | Error error ->
+    failf "wrong blank-reason error: %s" (Librarian.parse_error_to_string error)
+  | Ok _ -> fail "blank drop reason accepted"
 ;;
 
 let test_strict_json_boundary () =
@@ -319,8 +407,12 @@ let () =
             test_unknown_and_duplicate_retained_ids_reject
         ; test_case "retained/new collision rejects" `Quick
             test_new_claim_cannot_collide_with_retained_identity
-        ; test_case "omitted/new recreation rejects" `Quick
-            test_new_claim_cannot_recreate_omitted_current_identity
+        ; test_case "dropped/new recreation rejects" `Quick
+            test_new_claim_cannot_recreate_dropped_current_identity
+        ; test_case "totality rejects unaccounted id" `Quick
+            test_totality_rejects_unaccounted_current_id
+        ; test_case "dropped statements validate" `Quick
+            test_dropped_statements_validate
         ; test_case "strict JSON boundary" `Quick test_strict_json_boundary
         ; test_case "duplicate object fields reject" `Quick
             test_duplicate_object_fields_reject

--- a/test/test_keeper_memory_os_current.ml
+++ b/test/test_keeper_memory_os_current.ml
@@ -34,9 +34,11 @@ let replace
       ~keepers_dir
       ?(expected_revision = None)
       ?(facts = [])
+      ?dropped_statements
       ()
   =
   Current.replace
+    ?dropped_statements
     ~keepers_dir
     ~keeper_id:"keeper"
     ~expected_revision
@@ -376,6 +378,12 @@ let test_every_commit_appends_one_journal_entry () =
        ~keepers_dir
        ~expected_revision:(Some 1)
        ~facts:[ first ]
+       ~dropped_statements:
+         [ { Masc.Keeper_memory_os_types.memory_id =
+               Masc.Keeper_memory_os_types.memory_id second
+           ; reason = "superseded during test"
+           }
+         ]
        ()
      |> require_ok);
   ignore
@@ -397,10 +405,21 @@ let test_every_commit_appends_one_journal_entry () =
     (librarian_drop |> member "change" |> member "removed" |> to_list |> List.length);
   check string "librarian source kind" "librarian"
     (librarian_drop |> member "source" |> member "kind" |> to_string);
+  let dropped = librarian_drop |> member "dropped" |> to_list in
+  check int "one drop statement" 1 (List.length dropped);
+  check string "drop statement names the removed fact"
+    (Masc.Keeper_memory_os_types.memory_id second)
+    (List.hd dropped |> member "memory_id" |> to_string);
+  check string "drop statement carries the reason" "superseded during test"
+    (List.hd dropped |> member "reason" |> to_string);
+  check bool "statement-less commit has no dropped key" true
+    (List.nth lines 0 |> member "dropped" = `Null);
   let explicit = List.nth lines 2 in
   check int "explicit revision" 3 (explicit |> member "revision" |> to_int);
   check string "explicit source kind" "explicit_write"
-    (explicit |> member "source" |> member "kind" |> to_string)
+    (explicit |> member "source" |> member "kind" |> to_string);
+  check bool "explicit commit has no dropped key" true
+    (explicit |> member "dropped" = `Null)
 ;;
 
 let test_rejected_commit_appends_no_journal_entry () =

--- a/test/test_keeper_structured_output_schema.ml
+++ b/test/test_keeper_structured_output_schema.ml
@@ -177,6 +177,27 @@ let test_librarian_claim_schema_is_closed () =
     (allows_additional_properties claim_schema)
 ;;
 
+let test_librarian_dropped_schema_is_closed () =
+  let schema = Keeper_structured_output_schema.librarian_current_output_schema in
+  check
+    (list string)
+    "librarian top-level required fields"
+    (List.sort String.compare Keeper_librarian.wire_current_fields)
+    (required_strings schema);
+  let dropped_schema =
+    schema
+    |> schema_property Keeper_librarian.wire_field_dropped
+    |> schema_items
+  in
+  check
+    (list string)
+    "librarian dropped required fields"
+    (List.sort String.compare Keeper_librarian.wire_dropped_fields)
+    (required_strings dropped_schema);
+  check bool "librarian dropped schema is closed" false
+    (allows_additional_properties dropped_schema)
+;;
+
 (* The reviewer config must reach json_object-only providers. Counterfactual
    first: a native schema request on a Glm-kind config is rejected by the OAS
    contract — that rejection is exactly what left every task nonterminal
@@ -345,6 +366,10 @@ let () =
             "minimal claim fields remain required"
             `Quick
             test_librarian_claim_schema_is_closed
+        ; test_case
+            "dropped statements are required and closed"
+            `Quick
+            test_librarian_dropped_schema_is_closed
         ] )
     ; ( "verdict schemas"
       , [ test_case


### PR DESCRIPTION
## RFC #26534: librarian 총체성 계약 — 모든 망각에 이유를 진술

사다리 3번째 계단입니다 (PR-A journal #26536 → PR-B persona #26540 → **이 PR**). 지금까지 librarian의 삭제 연산은 침묵이었습니다: `retained_memory_ids`에서 빠지면 그걸로 끝, 왜 잊었는지는 어디에도 남지 않았습니다. ORION 서사 실험(0731)에서 관측한 "묘비 4개, 통합 판단은 있었지만 어디에도 기록 안 됨"의 구조적 원인입니다.

RFC의 계약 완성 조항(교체가 아닌 완성: 현행 + `dropped[{id,reason}]` + 총체성 `Missing_disposition`)을 그대로 구현합니다.

### 계약

모든 현재 memory ID는 답변에 **정확히 한 번** 나타나야 합니다: `retained_memory_ids`(유지) 또는 `dropped`(한 문장 이유와 함께 망각). 누락된 ID는 typed 오류 `Missing_disposition`으로 **전체 거부** → `Reject_and_advance`로 모델 재시도. 침묵 망각은 이제 표현 불가능한 상태입니다.

### 변경

1. **`Keeper_memory_os_types.dropped_statement { memory_id; reason }`** — wire 필드(`memory_id`/`reason`)를 기존 claim 필드 옆 SSOT에 배치.
2. **`Keeper_librarian`**: selection에 `dropped` 추가, typed 오류 4종(`Unknown_dropped_memory_id`/`Duplicate_dropped_memory_id`/`Dropped_memory_id_also_retained`/`Missing_disposition`) + `Dropped_schema_mismatch`(빈 이유 포함). dropped된 fact를 new claim으로 재생성하는 건 기존 검증이 구조적으로 차단(현재 ID 충돌 규칙).
3. **출력 스키마**: `dropped` required, closed object array.
4. **journal 라인에만 진술 기록**: `"dropped": [...]`. **스냅샷 codec은 동결** — 기존 keeper들의 `memory-current.json`은 재해석 없이 그대로 파싱됩니다(레거시 호환 코드 0줄, 프로젝트 독트린 준수). `None`(진술을 만들지 않는 writer: explicit_write/upsert — 키 자체 없음) vs `Some []`(librarian이 "아무것도 안 버림"을 진술 — 빈 배열)를 타입으로 구분.
5. **템플릿**: "Any current memory ID you omit is forgotten immediately" / "Omission is the deletion operation" 등 침묵-망각 언어를 disposition 총체성 계약으로 전면 교체 + `dropped` 출력 예시. (코드·템플릿은 embedded config sync로 같은 바이너리에서 원자적 배포 — #26540에서 확인한 구조.)

### 알려진 트레이드오프

출력 계약이 엄격해져 **약한 lane 모델의 거부율이 오를 수 있습니다** (#26537의 librarian 장황 출력 3~5분/2.5-3K tok 위에 이유 문장들이 추가됨). 완충: 거부 시 lane 후보 순회 재시도, `Domain_output_invalid` → cadence backoff(hot-loop 방지), 실패 시 이전 스냅샷이 recall을 계속 서빙. 실제 거부율은 라이브 증명에서 측정합니다 — 그게 이 사다리의 게이트 규칙입니다(머지≠작동).

### 검증 (로컬, 커밋 상태에서 실행)

- `dune build @check` green
- `test_keeper_librarian_retry` **15/15**: 총체성 거부(미계상 ID→`Missing_disposition`, dropped 필드 부재→`Missing_required_fields`), 진술 검증 4종(unknown/dup/retained-겹침/빈 이유), 진술이 selection까지 운반, dropped fact 재생성 거부
- `test_keeper_memory_os_current` **18/18**: journal 라인에 진술 기록, 진술 없는 커밋(첫 replace·explicit upsert)은 `dropped` 키 자체 부재
- `test_keeper_structured_output_schema` **11/11**: top-level required에 `dropped`, 진술 객체 closed
- Meta 게이트 4종(DET/SIL/STR/TEL) 로컬 PASS — DET-OK 창 함정(#26540에서 학습)을 피해 커밋 후 검증

### 라이브 증명 게이트 (머지≠작동)

머지·재기동 후: ①librarian commit 로그 지속(계약 강화 후 거부율 관찰) ②journal 새 라인에 `dropped[].reason` 실물 확인 ③rev N에서 낡은 fact를 심고 다음 cadence에 이유와 함께 떨어지는지 관측.

RFC: #26534. 사다리: journal(#26536, 증명 완료) → persona(#26540, 병합·재기동 대기) → **총체성(이 PR)** → 전송 계약(꼬리 K, ROI=#26535 cache 실험) → 컴팩션 숙청.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
