### PR TITLE
fix(keeper): fence keepalive lane swap on the turn admission slot (#26542)

### DIFF
--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -69,6 +69,91 @@ let resolve_active_goal_ids config p old_ids =
           (Printf.sprintf "unknown active_goal_ids: %s"
              (String.concat ", " missing))
 
+let turn_in_flight_rejection ~keeper_name
+    (info : Keeper_turn_admission.in_flight_info) : tool_result =
+  tool_result_error_data
+    ~class_:Tool_result.Workflow_rejection
+    (`Assoc
+       [ "error", `String "keeper_turn_in_flight"
+       ; "keeper", `String keeper_name
+       ; ( "block"
+         , Keeper_turn_admission.autonomous_block_to_yojson
+             (Keeper_turn_admission.Turn_busy (Some info)) )
+       ; "metadata_committed", `Bool true
+       ; ( "message"
+         , `String
+             "keeper metadata was updated but the keepalive lane was not \
+              restarted: a turn holds this keeper's slot. A keeper's own \
+              turn always holds the slot, so masc_keeper_up cannot restart \
+              its caller from inside that turn. Retry masc_keeper_up when \
+              the keeper is idle to restart the lane." )
+       ])
+;;
+
+(* The lane swap tears down the registry entry a live turn's finalize path
+   still needs: a swap that raced an admitted turn left that turn's slot
+   permanently held after its provider run completed (#26542 — a keeper
+   calling masc_keeper_up on itself mid-turn locked itself out of every
+   subsequent turn until process restart). The swap therefore requires an
+   idle turn slot, enforced with the same admission fence the shutdown
+   path uses:
+
+   - [begin_shutdown] fences new admissions and samples the current holder
+     in one critical section; a published holder rejects the swap (typed,
+     no waiting) — a keeper's own turn always holds the slot, so a
+     mid-turn self keeper_up lands on that rejection by construction.
+   - A holder that acquired the slot but has not yet published bounces at
+     its publish-time fence check without running a turn body, so the
+     fenced swap window stays turn-free.
+   - The fence is rolled back before [start_keepalive]:
+     [commit_registration_if_open] refuses lane registration under any
+     fence.
+   - [Shutdown_already_reserved] with an idle slot proceeds without a
+     fence of our own: that is the durable blocked-shutdown supersession
+     path (metadata commit takes ownership of the foreign fence), and the
+     concurrent-update race it also matches is absorbed by the existing
+     launch-conflict arm. *)
+let swap_keepalive_lane_fenced (ctx : _ context) (updated : keeper_meta)
+  : (joined_stop_result * start_keepalive_outcome, tool_result) result =
+  let base_path = ctx.config.base_path in
+  let keeper_name = updated.name in
+  let rollback ~operation_id =
+    match
+      Keeper_turn_admission.rollback_shutdown
+        ~base_path
+        ~keeper_name
+        ~operation_id
+    with
+    | Keeper_turn_admission.Shutdown_rolled_back
+    | Keeper_turn_admission.Shutdown_not_reserved
+    | Keeper_turn_admission.Shutdown_reserved_by_other _ -> ()
+  in
+  let swap () = stop_keepalive_and_await ~base_path keeper_name in
+  let operation_id = Keeper_shutdown_types.Operation_id.generate () in
+  match
+    Keeper_turn_admission.begin_shutdown ~base_path ~keeper_name ~operation_id
+  with
+  | Keeper_turn_admission.Shutdown_reserved { in_flight = Some info; _ } ->
+    rollback ~operation_id;
+    Error (turn_in_flight_rejection ~keeper_name info)
+  | Keeper_turn_admission.Shutdown_already_reserved
+      { in_flight = Some info; _ } ->
+    Error (turn_in_flight_rejection ~keeper_name info)
+  | Keeper_turn_admission.Shutdown_reserved { in_flight = None; _ } ->
+    let stop_outcome =
+      match swap () with
+      | outcome ->
+        rollback ~operation_id;
+        outcome
+      | exception exn ->
+        rollback ~operation_id;
+        raise exn
+    in
+    Ok (stop_outcome, start_keepalive ctx updated)
+  | Keeper_turn_admission.Shutdown_already_reserved { in_flight = None; _ } ->
+    Ok (swap (), start_keepalive ctx updated)
+;;
+
 let update_keeper ?(preserve_prompt_defaults = false)
     (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool_result
     =
@@ -296,12 +381,9 @@ let update_keeper ?(preserve_prompt_defaults = false)
                   durable, so the keepalive restart below delivers it on the
                   new fiber's first cycle. Removals never wake. *)
                enqueue_goal_assignment_wakes updated;
-               let stop_outcome =
-                 stop_keepalive_and_await
-                   ~base_path:ctx.config.base_path
-                   updated.name
-               in
-               let launch_outcome = start_keepalive ctx updated in
+               (match swap_keepalive_lane_fenced ctx updated with
+                | Error rejection -> rejection
+                | Ok (stop_outcome, launch_outcome) ->
                (match launch_outcome with
                 | Keepalive_started _ ->
                   tool_result_ok_data (Keeper_meta_json.meta_to_json updated)
@@ -326,4 +408,4 @@ let update_keeper ?(preserve_prompt_defaults = false)
                   tool_result_error
                     (Printf.sprintf
                        "keeper metadata was updated but lane restart failed: %s"
-                       (start_keepalive_outcome_to_string rejected))))))))
+                       (start_keepalive_outcome_to_string rejected)))))))))

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -1734,6 +1734,110 @@ let test_operator_update_supersedes_exact_blocked_shutdown () =
            stopped_name
           : Masc.Keeper_keepalive.joined_stop_result))
 
+let test_update_keeper_rejects_lane_swap_while_turn_in_flight () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir "update-turn-in-flight" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_turn_admission.For_testing.reset ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let (_init_message : string) =
+        Masc.Workspace.init config ~agent_name:(Some "tester")
+      in
+      let name = "update-turn-in-flight" in
+      let meta = make_meta name in
+      (match Keeper_meta_store.write_meta config meta with
+       | Ok () -> ()
+       | Error detail -> fail detail);
+      let profile_defaults =
+        { Keeper_profile_defaults.empty_keeper_profile_defaults with
+          sandbox_profile = Some meta.sandbox_profile
+        }
+      in
+      let parsed : Turn_up_args.parsed_args =
+        { name
+        ; runtime_id_opt = None
+        ; allowed_paths_opt = None
+        ; autoboot_enabled_opt = None
+        ; mention_targets_opt = None
+        ; active_goal_ids_opt = None
+        ; max_context_override_opt = None
+        ; max_context_override_present = false
+        ; proactive_enabled_opt = None
+        ; sandbox_profile_opt = None
+        ; network_mode_opt = None
+        ; persona_name_opt = None
+        ; instructions_arg = Some "rejected mid-turn intent"
+        ; profile_defaults
+        ; instructions_opt = profile_defaults.instructions
+        }
+      in
+      let ctx : _ Keeper_types_profile.context =
+        { config
+        ; agent_name = "tester"
+        ; sw
+        ; clock = Eio.Stdenv.clock env
+        ; proc_mgr = None
+        ; net = None
+        ; publication_recovery_provider =
+            Masc_test_deps.non_runtime_publication_recovery_provider
+        }
+      in
+      (* A keeper's own turn holds the slot while its tools run: invoking
+         the update from inside the admitted closure reproduces the
+         mid-turn self masc_keeper_up of #26542 structurally. *)
+      (match
+         Masc.Keeper_turn_admission.run_if_free
+           ~base_path:config.base_path
+           ~keeper_name:name
+           (fun () -> Turn_up_update.update_keeper ctx parsed meta)
+       with
+       | `Busy _ -> fail "turn slot unexpectedly busy before the test turn"
+       | `Ran result ->
+         check bool "mid-turn update is rejected" false
+           (Keeper_types_profile.tool_result_success result);
+         let data = Tool_result.data result in
+         check (option string) "rejection is typed"
+           (Some "keeper_turn_in_flight")
+           (Json_util.get_string data "error");
+         let mid_turn_snapshot =
+           Masc.Keeper_turn_admission.snapshot_for
+             ~base_path:config.base_path
+             ~keeper_name:name
+         in
+         check bool "rejection rolls the fence back inside the turn" true
+           (Option.is_none mid_turn_snapshot.snapshot_shutdown_operation_id));
+      let after =
+        match Keeper_meta_store.read_meta config name with
+        | Ok (Some after) -> after
+        | Ok None -> fail "keeper metadata disappeared"
+        | Error detail -> fail detail
+      in
+      check string "metadata commit preceded the rejection"
+        "rejected mid-turn intent"
+        after.instructions;
+      let idle_snapshot =
+        Masc.Keeper_turn_admission.snapshot_for
+          ~base_path:config.base_path
+          ~keeper_name:name
+      in
+      check bool "no shutdown fence remains after the turn" true
+        (Option.is_none idle_snapshot.snapshot_shutdown_operation_id);
+      check bool "turn slot is idle after the turn" true
+        (Option.is_none idle_snapshot.snapshot_in_flight);
+      let retry = Turn_up_update.update_keeper ctx parsed after in
+      check bool "idle update restarts the lane" true
+        (Keeper_types_profile.tool_result_success retry);
+      ignore
+        (Masc.Keeper_keepalive.stop_keepalive_and_await
+           ~base_path:config.base_path
+           name
+          : Masc.Keeper_keepalive.joined_stop_result))
+
 let test_keeper_shutdown_store_isolates_corrupt_owner () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -3900,6 +4004,8 @@ let () =
         test_keeper_shutdown_store_round_trip_and_identity_guard;
       test_case "operator update supersedes exact blocked shutdown" `Quick
         test_operator_update_supersedes_exact_blocked_shutdown;
+      test_case "update rejects lane swap while turn in flight" `Quick
+        test_update_keeper_rejects_lane_swap_while_turn_in_flight;
       test_case "shutdown store isolates corrupt owner" `Quick
         test_keeper_shutdown_store_isolates_corrupt_owner;
       test_case "retired stale paused terminal releases exact fence" `Quick


### PR DESCRIPTION
## #26542: keepalive lane swap을 turn admission slot 위에 올린다

라이브 P0 (#26542, sangsu 2026-07-31 04:43): keeper가 **자기 admitted chat 턴 안에서 `masc_keeper_up(자기 이름)`을 호출** → `update_keeper`가 turn slot을 안 보고 lane을 stop/start로 swap → 턴의 finalize가 교체된 registry entry 앞에서 조용히 영구 블록 → 고아가 된 turn mutex가 이후 모든 턴을 봉쇄(에러 로그 0건, 강제 해제 API 없음, 서버 재기동 전까지 복구 불가).

### 수리

swap(`stop_keepalive_and_await` → `start_keepalive`)이 **idle turn slot을 요구**한다. 새 gate가 아니라 shutdown 경로가 이미 쓰는 admission fence의 재사용:

| `begin_shutdown` 결과 | 동작 |
|---|---|
| `Shutdown_reserved { in_flight = Some }` | rollback 후 **typed 거부** (`keeper_turn_in_flight`, `Workflow_rejection`) |
| `Shutdown_already_reserved { in_flight = Some }` | typed 거부 (남의 fence는 건드리지 않음) |
| `Shutdown_reserved { in_flight = None }` | fence 하에 stop → rollback → start (`commit_registration_if_open`이 어떤 fence 아래서도 등록을 거부하므로 rollback이 start보다 먼저) |
| `Shutdown_already_reserved { in_flight = None }` | 진행 — durable blocked-shutdown supersession 경로 보존 (기존 테스트 "operator update supersedes exact blocked shutdown"이 이 분기를 요구, 그대로 green) |

왜 이 설계가 자기-호출 케이스를 특수 분기 없이 죽이는가: **keeper 자신의 턴은 언제나 slot을 쥐고 있으므로**, mid-turn self keeper_up은 구조상 `in_flight = Some`에 착지한다. 대기(defer) 선택지는 자기 턴이 끝나길 자기가 기다리는 데드락이라 존재하지 않는다 — `run_serialized` 문서가 이미 같은 계약("do not call this from within an admitted turn of the same keeper")을 명시한다.

미발행(published 전) 홀더 창까지 안전한 이유: fence 체크는 `run_locked`의 **publish 시점**(state_mu 아래)에 있다. lock은 잡았지만 미발행인 waiter는 재개되는 순간 fence에 튕겨 턴 본문이 시작되지 못한다 — fenced swap 창은 턴-프리.

### 계약 변화 (정직한 트레이드오프)

- busy 거부 시 **metadata는 이미 커밋된 상태**다(`metadata_committed: true`를 페이로드에 명시). CAS-merge meta write는 원래 턴-안전(2026-06-10 회귀 방지 주석)이라 fence 대상이 아니고, 이는 기존 "keeper metadata was updated but lane restart failed" 오류 모드와 같은 계약면이다. 거부 페이로드가 "idle일 때 재시도하면 lane 재시작" 계약을 명시한다.
- 외부(대시보드) 재시작이 in-flight 턴과 경합하면 이제 조용한 mutex 고아 대신 typed busy를 받는다.

### 검증 (로컬, 커밋 후 실행)

- `dune build @check` green
- `test_heartbeat_integration` direct_keepalive **27/27** — 신규 "update rejects lane swap while turn in flight": `run_if_free` 클로저 안에서 `update_keeper` 호출(= mid-turn self keeper_up의 구조적 재현) → typed 거부 + fence rollback 확인 + meta 커밋 확인 + 턴 종료 후 slot idle + **idle 재시도는 재시작 성공**. 구 코드에서는 이 시나리오가 성공해버리므로 테스트가 버그를 판별한다.
- 기존 supersession 케이스(7) 보존 green — `Already_reserved{None} → 진행` 분기의 회귀 방지 증거
- `test_keeper_effective_meta_overlay` 25/25
- 메타 게이트 4종(DET/STR/SIL/TEL) PASS

### 라이브 증명 게이트 (머지≠작동)

머지·재기동 후: ①keeper에게 mid-turn self keeper_up을 유도(또는 자연 발생 관측)해 typed `keeper_turn_in_flight` 거부가 돌아오고 ②그 턴이 정상 완주하며 mutex가 해제되는 것 ③idle 재시도 keeper_up이 lane을 재시작하는 것을 확인한다.

### 남은 것

finalize가 entry swap 후 정확히 어느 대기에서 블록됐는지의 규명은 이 PR로 해당 상태가 도달-불가능해져 P0에서 제외. 필요 시 별도 진단 이슈로.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
