### PR TITLE
feat(runtime): bound provider-bound history to a quantized tail window (RFC #26534 PR-C)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -669,7 +669,14 @@ let run_turn
       s.Keeper_run_tools.model_input_projection
     in
     let model_input_projection messages =
-      match source_model_input_projection messages with
+      (* Bounded transmission view first (RFC #26534 PR-C): the cut never
+         sees gate-replay evidence, which [source_model_input_projection]
+         appends afterwards, and the provenance check below compares against
+         the windowed list so its projected-prefix precondition keeps
+         holding. Durable state and checkpoints receive the unwindowed
+         history. *)
+      let windowed = Runtime_model_input_tail_window.project messages in
+      match source_model_input_projection windowed with
       | Error _ as error ->
         current_request_input_messages_ref := None;
         error
@@ -680,7 +687,7 @@ let run_turn
         (match
            Keeper_agent_prompt_metrics.provider_content_messages
              ~prompt_context_present
-             ~projection_input:messages
+             ~projection_input:windowed
              ~projected_messages
          with
          | Some provider_content ->

--- a/lib/runtime/runtime_model_input_tail_window.ml
+++ b/lib/runtime/runtime_model_input_tail_window.ml
@@ -1,0 +1,110 @@
+(** Bounded transmission view over provider-bound history — see the
+    interface for the contract (RFC #26534 PR-C, #26544, #26535). *)
+
+let atoms_per_window = 60
+let preamble_marker_key = "masc.model_input_tail_window.v1"
+
+let preamble_text =
+  "[context window] Older turns of this conversation are omitted from this \
+   request. The full history is preserved in the durable checkpoint and \
+   surfaces through the memory system when relevant."
+
+let preamble_message : Agent_sdk.Types.message =
+  { role = Agent_sdk.Types.User
+  ; content = [ Agent_sdk.Types.Text preamble_text ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = [ (preamble_marker_key, `Bool true) ]
+  }
+;;
+
+(* A message is pinned when it must survive every cut: [System] entries
+   (defensive — the runtime carries the system prompt out of band) and any
+   message with extra-system-context provenance. [Invalid]/[Duplicate]
+   provenance still means the per-turn context assembler authored the
+   message, so it is pinned rather than exposed to the cut on a malformed
+   tag. *)
+let is_extra_context (msg : Agent_sdk.Types.message) =
+  match
+    Agent_sdk.Types.Extra_system_context_provenance.classify msg.metadata
+  with
+  | Agent_sdk.Types.Extra_system_context_provenance.Absent -> false
+  | Agent_sdk.Types.Extra_system_context_provenance.Present
+  | Agent_sdk.Types.Extra_system_context_provenance.Invalid
+  | Agent_sdk.Types.Extra_system_context_provenance.Duplicate -> true
+;;
+
+type label =
+  | Pinned
+  | Atom of int
+
+(* Label every message with its atom index, in order. [User] and [Assistant]
+   open a new atom; [Tool] joins the atom of the assistant that issued the
+   call, so both sides of a tool exchange always share one label. A leading
+   orphan [Tool] run (possible only on a history that was already cut
+   upstream of OAS) becomes atom 0 so it is dropped with the first cut
+   rather than transmitted headless. *)
+let annotate (messages : Agent_sdk.Types.message list) :
+  (Agent_sdk.Types.message * label) list * int
+  =
+  let labelled_rev, atom_count =
+    List.fold_left
+      (fun (acc, count) (msg : Agent_sdk.Types.message) ->
+         if is_extra_context msg
+         then ((msg, Pinned) :: acc, count)
+         else (
+           match msg.role with
+           | Agent_sdk.Types.System -> ((msg, Pinned) :: acc, count)
+           | Agent_sdk.Types.User | Agent_sdk.Types.Assistant ->
+             ((msg, Atom count) :: acc, count + 1)
+           | Agent_sdk.Types.Tool ->
+             if count = 0
+             then ((msg, Atom 0) :: acc, 1)
+             else ((msg, Atom (count - 1)) :: acc, count)))
+      ([], 0)
+      messages
+  in
+  (List.rev labelled_rev, atom_count)
+;;
+
+(* Largest multiple of [atoms_per_window] that still leaves at least
+   [atoms_per_window] atoms. Quantizing the drop count keeps the cut point
+   stationary while up to [atoms_per_window] new atoms accumulate, so the
+   transmitted prefix only changes when the window jumps. *)
+let dropped_atoms ~atom_count =
+  if atom_count < 2 * atoms_per_window
+  then 0
+  else (atom_count - atoms_per_window) / atoms_per_window * atoms_per_window
+;;
+
+let project (messages : Agent_sdk.Types.message list) :
+  Agent_sdk.Types.message list
+  =
+  let labelled, atom_count = annotate messages in
+  let drop = dropped_atoms ~atom_count in
+  if drop = 0
+  then messages
+  else (
+    let kept_labelled =
+      List.filter
+        (fun (_msg, label) ->
+           match label with
+           | Pinned -> true
+           | Atom index -> index >= drop)
+        labelled
+    in
+    let first_kept_atom_role =
+      List.find_map
+        (fun ((msg : Agent_sdk.Types.message), label) ->
+           match label with
+           | Atom _ -> Some msg.role
+           | Pinned -> None)
+        kept_labelled
+    in
+    let kept = List.map fst kept_labelled in
+    match first_kept_atom_role with
+    | Some Agent_sdk.Types.User | None -> kept
+    | Some Agent_sdk.Types.Assistant
+    | Some Agent_sdk.Types.Tool
+    | Some Agent_sdk.Types.System -> preamble_message :: kept)
+;;

--- a/lib/runtime/runtime_model_input_tail_window.mli
+++ b/lib/runtime/runtime_model_input_tail_window.mli
@@ -1,0 +1,46 @@
+(** Runtime_model_input_tail_window — bounded transmission view over
+    provider-bound conversation history (RFC #26534 PR-C, #26544).
+
+    [project] keeps only the most recent atoms of the message list that OAS
+    is about to send to a provider. One atom is either an organic [User]
+    message or an [Assistant] message together with the [Tool] messages that
+    answer it, so a cut can never separate a tool result from the tool call
+    that produced it. Durable agent state and checkpoints are untouched: OAS
+    applies a [model_input_projection] to the provider-bound copy only
+    ({!Runtime_agent_context.config.model_input_projection}).
+
+    Cut placement is quantized to whole windows: with
+    [atoms_per_window = K], the drop count is the largest multiple of [K]
+    that still leaves at least [K] atoms. The transmitted prefix therefore
+    stays byte-identical across [K] consecutive atoms of growth before
+    jumping once, which preserves provider prompt-cache reuse between jumps
+    (#26535 measured the alternative: a per-turn sliding cut changes the
+    prefix on every request).
+
+    Messages carrying OAS extra-system-context provenance are never counted
+    and never dropped; that block is re-assembled fresh each turn by the
+    keeper hooks and must survive the cut. When the cut leaves a non-[User]
+    message at the head of the transmitted history, a constant synthetic
+    [User] preamble is prepended so providers that require a [User]-first
+    conversation accept the request; being constant, it does not perturb the
+    quantized prefix. *)
+
+val atoms_per_window : int
+(** Window quantum [K]. Once the conversation exceeds [2*K - 1] atoms the
+    transmitted history holds between [K] and [2*K - 1] atoms; below that
+    threshold {!project} is the identity. Sized from live checkpoint
+    measurement (2026-08-01: sangsu 487 atoms / 706KB, kidsnote 442 atoms /
+    719KB, mean atom ≈ 1.5KB — a [K]..[2K-1] window transmits ≈ 90..180KB
+    of history against a 200K-token primary context). *)
+
+val preamble_marker_key : string
+(** Metadata key tagging the synthetic preamble message, so a captured
+    request distinguishes the marker from organic history. The preamble
+    exists only in the transmitted copy; nothing writes it to durable
+    state. *)
+
+val project :
+  Agent_sdk.Types.message list -> Agent_sdk.Types.message list
+(** Total on every input: never raises, never fails, and returns the input
+    list physically unchanged below the window threshold (including the
+    empty list). *)

--- a/test/dune
+++ b/test/dune
@@ -322,7 +322,8 @@
   test_relation_materializer
   test_keeper_wire_capture
   test_board_rest_routes
-  test_board_context_inference_resolution)
+  test_board_context_inference_resolution
+  test_runtime_model_input_tail_window)
  (modules
   test_keeper_cooldown_cause_23438
   test_keeper_lifecycle_gate
@@ -626,7 +627,8 @@
   test_relation_materializer
   test_keeper_wire_capture
   test_board_rest_routes
-  test_board_context_inference_resolution)
+  test_board_context_inference_resolution
+  test_runtime_model_input_tail_window)
  (libraries
   masc_test_deps masc_schedule multimodal bigstringaf masc.keeper_checkpoint_ref))
 

--- a/test/test_runtime_model_input_tail_window.ml
+++ b/test/test_runtime_model_input_tail_window.ml
@@ -1,0 +1,218 @@
+(** Tests for {!Runtime_model_input_tail_window} (RFC #26534 PR-C, #26544).
+
+    The projection is a pure function of the message list, so every case
+    builds a synthetic history and checks the transmitted view directly:
+    identity below the threshold, quantized cut placement, tool-call atom
+    integrity, extra-context pinning, and the synthetic [User] preamble. *)
+
+module Window = Runtime_model_input_tail_window
+module Types = Agent_sdk.Types
+
+let k = Window.atoms_per_window
+
+let message ?(metadata = []) ~role text : Types.message =
+  { role
+  ; content = [ Types.Text text ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata
+  }
+;;
+
+let user i = message ~role:Types.User (Printf.sprintf "user-%d" i)
+let assistant i = message ~role:Types.Assistant (Printf.sprintf "assistant-%d" i)
+let tool i = message ~role:Types.Tool (Printf.sprintf "tool-%d" i)
+
+let extra_context =
+  message
+    ~metadata:Types.Extra_system_context_provenance.metadata
+    ~role:Types.User
+    "extra-system-context"
+;;
+
+(* [atoms n] builds [n] atoms alternating [user] and [assistant]+2 tools so
+   both atom shapes and tool attachment are exercised. *)
+let atoms n =
+  List.concat
+    (List.init n (fun i ->
+       if i mod 2 = 0
+       then [ user i ]
+       else [ assistant i; tool i; tool (i + 1000) ]))
+;;
+
+let count_atoms messages =
+  List.fold_left
+    (fun count (m : Types.message) ->
+       match m.role with
+       | Types.User | Types.Assistant ->
+         (match Types.Extra_system_context_provenance.classify m.metadata with
+          | Types.Extra_system_context_provenance.Absent -> count + 1
+          | _ -> count)
+       | Types.System | Types.Tool -> count)
+    0
+    messages
+;;
+
+let first_text (messages : Types.message list) =
+  match messages with
+  | { content = Types.Text text :: _; _ } :: _ -> text
+  | _ -> "<none>"
+;;
+
+let is_preamble (m : Types.message) =
+  List.mem_assoc Window.preamble_marker_key m.metadata
+;;
+
+let test_identity_below_threshold () =
+  let history = atoms ((2 * k) - 1) in
+  let projected = Window.project history in
+  Alcotest.(check bool)
+    "physically unchanged below 2K-1 atoms" true
+    (projected == history)
+;;
+
+let test_empty_list_identity () =
+  Alcotest.(check int) "empty stays empty" 0 (List.length (Window.project []))
+;;
+
+let test_cut_at_threshold () =
+  let history = atoms (2 * k) in
+  let projected = Window.project history in
+  Alcotest.(check int) "keeps exactly K atoms at 2K" k (count_atoms projected)
+;;
+
+let test_quantized_cut_point () =
+  (* Between 2K and 3K-1 atoms the drop count stays at K, so the retained
+     head atom is stable while the tail grows — the prompt-cache-stable
+     plateau. At 3K the drop jumps to 2K. *)
+  let head_after n =
+    let projected = Window.project (atoms n) in
+    first_text (List.filter (fun m -> not (is_preamble m)) projected)
+  in
+  let plateau_start = head_after (2 * k) in
+  Alcotest.(check string)
+    "cut point unchanged while the tail grows"
+    plateau_start
+    (head_after ((3 * k) - 1));
+  Alcotest.(check bool)
+    "cut point jumps at 3K"
+    false
+    (String.equal plateau_start (head_after (3 * k)))
+;;
+
+let test_tool_results_stay_with_their_call () =
+  let history = atoms (2 * k) in
+  let projected = Window.project history in
+  let tool_never_opens_atom =
+    let rec scan ~previous_organic = function
+      | [] -> true
+      | (m : Types.message) :: rest ->
+        (match m.role with
+         | Types.Tool ->
+           (match previous_organic with
+            | Some Types.Assistant | Some Types.Tool ->
+              scan ~previous_organic:(Some Types.Tool) rest
+            | Some Types.User | Some Types.System | None -> false)
+         | role -> scan ~previous_organic:(Some role) rest)
+    in
+    scan ~previous_organic:None projected
+  in
+  Alcotest.(check bool)
+    "every tool message follows its assistant atom" true tool_never_opens_atom
+;;
+
+let test_preamble_on_assistant_head () =
+  (* All-assistant atoms: after the cut the head organic message is an
+     assistant turn, which requires the synthetic user preamble. *)
+  let history =
+    List.concat (List.init (2 * k) (fun i -> [ assistant i; tool i ]))
+  in
+  let projected = Window.project history in
+  match projected with
+  | head :: _ ->
+    Alcotest.(check bool) "head is the tagged preamble" true (is_preamble head);
+    Alcotest.(check bool)
+      "preamble is a user message" true
+      (head.role = Types.User)
+  | [] -> Alcotest.fail "projection returned an empty list"
+;;
+
+let test_no_preamble_on_user_head () =
+  (* Even atom count with the user/assistant alternation puts a user atom at
+     every even index, so a drop of K (even) lands on a user head. *)
+  let history = atoms (2 * k) in
+  let projected = Window.project history in
+  Alcotest.(check bool)
+    "no preamble when the retained head is a user message" false
+    (List.exists is_preamble projected)
+;;
+
+let test_extra_context_pinned () =
+  (* 2K organic atoms force a cut; the tagged extra-context message must
+     survive it and must not count toward the window. *)
+  let projected = Window.project (atoms (2 * k) @ [ extra_context ]) in
+  Alcotest.(check bool)
+    "extra context survives the cut" true
+    (List.exists
+       (fun (m : Types.message) ->
+          match Types.Extra_system_context_provenance.classify m.metadata with
+          | Types.Extra_system_context_provenance.Present -> true
+          | _ -> false)
+       projected);
+  (* Below the threshold the tagged message must not tip the atom count
+     over the cut boundary. *)
+  let padded = extra_context :: atoms ((2 * k) - 1) in
+  Alcotest.(check bool)
+    "tagged message does not trigger a cut" true
+    (Window.project padded == padded)
+;;
+
+let test_leading_orphan_tools_drop_with_first_atom () =
+  let history = tool 9000 :: tool 9001 :: atoms (2 * k) in
+  let projected = Window.project history in
+  Alcotest.(check bool)
+    "orphan head tools are not transmitted" false
+    (List.exists
+       (fun (m : Types.message) ->
+          match m.content with
+          | [ Types.Text text ] -> String.equal text "tool-9000"
+          | _ -> false)
+       projected)
+;;
+
+let test_deterministic () =
+  let history = atoms ((2 * k) + 7) in
+  let a = Window.project history in
+  let b = Window.project history in
+  Alcotest.(check int) "same length" (List.length a) (List.length b);
+  Alcotest.(check bool)
+    "same head" true
+    (String.equal (first_text a) (first_text b))
+;;
+
+let () =
+  Alcotest.run
+    "runtime_model_input_tail_window"
+    [ ( "tail_window"
+      , [ Alcotest.test_case "identity below threshold" `Quick
+            test_identity_below_threshold
+        ; Alcotest.test_case "empty list identity" `Quick
+            test_empty_list_identity
+        ; Alcotest.test_case "cut at threshold keeps K atoms" `Quick
+            test_cut_at_threshold
+        ; Alcotest.test_case "cut point is quantized" `Quick
+            test_quantized_cut_point
+        ; Alcotest.test_case "tool results stay with their call" `Quick
+            test_tool_results_stay_with_their_call
+        ; Alcotest.test_case "preamble on assistant head" `Quick
+            test_preamble_on_assistant_head
+        ; Alcotest.test_case "no preamble on user head" `Quick
+            test_no_preamble_on_user_head
+        ; Alcotest.test_case "extra context pinned" `Quick
+            test_extra_context_pinned
+        ; Alcotest.test_case "leading orphan tools drop" `Quick
+            test_leading_orphan_tools_drop_with_first_atom
+        ; Alcotest.test_case "deterministic" `Quick test_deterministic
+        ] )
+    ]
+;;


### PR DESCRIPTION
## RFC #26534 PR-C: 전송 히스토리를 양자화된 꼬리 창으로 유계화

keeper 턴이 더 이상 전체 대화 히스토리를 provider에 전송하지 않는다. 라이브 근거:

- #26544 (오늘): kidsnote 774KB/720msg·code-reviewer 843KB가 primary 창을 포화 → 컴팩션 트리거 → **컴팩션이 필요한 시점에는 어떤 요약 슬롯도 그 입력을 감당 못 함** → `compaction_rejected` 1,990건/일 자기유지 루프, ollama 주간 쿼터 소진까지 파급.
- #26535: 전송 히스토리 비대는 overflow 전에 이미 비용 — 같은 500KB급 프롬프트의 교대 타격이 provider 캐시를 밀어내 hit 20% (실험군 98%).
- sangsu 라이브 관측 (2026-08-01): 705msg/136K를 끄는 keeper가 위키 1건 읽기에 툴콜 18회 루프 후 환각으로 마무리 — 비대는 overflow 전에 인지 저하로 먼저 발현한다.

### 무엇

`Runtime_model_input_tail_window.project : message list -> message list` (total, 순수):

- **원자** = organic `User` 메시지 1개, 또는 `Assistant` 메시지 + 그에 답하는 `Tool` 메시지들. 절단은 원자 경계에서만 일어나므로 tool result가 tool call과 분리될 수 없다.
- **양자화 절단**: `K = atoms_per_window = 60`. drop 수는 "최소 K 원자를 남기는 K의 최대 배수" — 원자 수 120 미만이면 항등(물리적 동일 리스트), 이후 전송 창은 60..119 원자를 순환. 절단점은 K 원자 성장마다 한 번만 점프하므로 **점프 사이 전송 prefix가 byte-identical → prompt cache 재사용 유지** (#26535의 매턴-미끄러짐 캐시 전멸을 회피).
- **Pinning**: `System` 및 extra-system-context provenance가 붙은 메시지는 카운트 제외 + 절단 면제 (recall/facts 블록은 매턴 재조립되는 전송 필수 요소). `Invalid`/`Duplicate` provenance도 보수적으로 pin.
- **합성 preamble**: 절단 후 head가 `User`가 아니면 고정 문자열의 synthetic user 메시지를 prepend (`masc.model_input_tail_window.v1` metadata로 태깅) — user-first를 요구하는 provider 호환. 상수라 양자화된 prefix를 흔들지 않음. 자율 keeper는 실측상 이 케이스가 지배적 (kidsnote: 720msg 중 User 6개).

wiring은 `keeper_agent_run`의 projection 래퍼 안: **tail window → (windowed 기준) turn 입력 관측 → gate-replay evidence append** 순서라 ①절단이 replay evidence를 볼 수 없고(항상 전송됨) ②`provider_content_messages`의 projected-prefix 전제가 그대로 성립해 turn-records `input_components` 관측이 절단 후 실제 전송 조성을 기록한다. 첫 시도는 `keeper_run_tools_hooks` 쪽 합성이었는데, 그 자리는 관측 전제를 깨 매턴 `provenance_unavailable` WARN을 만들어 철회했다.

**Durable 경계**: checkpoint/agent state는 절단을 모른다 — OAS `model_input_projection`은 provider-bound 사본에만 작용 (필드 doc이 명시하는 계약). RFC 3층 분리(전송/보존/지식) 그대로.

**Blast radius**: keeper 대화 런 한정 — wiring 지점(`keeper_agent_run`)은 exact lane(librarian/컴팩션/board)과 코드 경로가 분리돼 있음을 caller 스윕으로 확인. OAS 변경 0줄.

### K=60의 근거 (실측)

2026-08-01 checkpoint 실측: sangsu 487 원자/706KB, kidsnote 442 원자/719KB — 평균 원자 ≈ 1.5KB. 창 60..119 원자 = 히스토리 ≈ 90..180KB ≈ 20..45K tokens (primary 200K의 10~22%). 기존 `context_fit_admission` 측정 게이트는 그대로 최종 방어로 남는다.

### 트레이드오프 (정직)

- keeper는 창 밖 히스토리를 그 턴에서 직접 볼 수 없다. 회복 경로는 설계상 존재: facts recall(pinned)과 durable checkpoint. RFC #26534의 첫 문장이 정확히 이 트레이드를 선언한다.
- 텔레메트리 WARN(신규 파일 telemetry 부재)은 의도: 절단 결과의 관측은 기존 turn-records `input_components`가 담당하며, 이 PR의 wiring이 그 관측을 절단-후 조성으로 정렬한다. 별도 카운터 추가는 telemetry-as-fix 시그니처라 배제.

### 검증 (로컬, 커밋 후)

- 신규 `test_runtime_model_input_tail_window` **10/10**: 임계 미만 항등(물리 동일)·빈 리스트·임계 절단·**양자화 절단점(plateau 유지 + 3K 점프)**·tool 원자 무결성·assistant-head preamble·user-head 무-preamble·extra pinning(생존+비카운트+비트리거)·선두 고아 tool drop·결정론.
- 회귀: `test_keeper_prompt_metrics` 19/19 (projection rewrite 거부 계약 유지), `test_keeper_wire_capture` 17/17.
- `dune build @check` green, 변경 파일 ocamlformat 통과, 메타 게이트 4종(DET/STR/SIL/TEL) PASS.

### 라이브 증명 게이트 (머지≠작동)

배포 후:
1. **kidsnote가 `keeper_clear` 없이 첫 턴에 성공** — 지금 overflow 루프에 갇힌 keeper가 전송 계약 변경만으로 살아나는 것이 이 PR의 완주 판정.
2. turn-records `input_tokens`가 포화 keeper에서 급감 (kidsnote ≈190K → ≈40K 기대).
3. `compaction_rejected` 스팸 중단 (overflow 트리거 자체가 사라짐).
4. 연속 턴 cache hit 회복 (#26535 실험 재현: 절단점 plateau 구간에서 hit 상승).

### 남은 것 (이 PR 밖)

- #26544의 컴팩션 슬롯 용량 모순은 별개 결함으로 남는다 — 이 PR은 overflow 트리거를 제거해 그 경로의 발화 빈도를 낮출 뿐, lane 구성 문제 자체는 RFC 궤도에서 처리.
- 창 밖 히스토리의 의미 압축(librarian 일기)은 사다리의 다음 계단.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
