### PR TITLE
fix(keeper): back off repeated actionless autonomous turns

### DIFF
--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -57,11 +57,11 @@ type proactive_runtime =
   ; last_reason : string
   ; last_preview : string
   ; consecutive_noop_count : int
-    (** Consecutive autonomous cycles where only observation tools
-          (board_list, context_status, other passive reads) were used with no
-          substantive action.  Resets to 0 on any productive cycle.
-          Used by [effective_scheduled_autonomous_cooldown] for exponential
-          backoff: cooldown *= 2^min(n, 2), capping at 4x. *)
+    (** Consecutive autonomous cycles with no substantive tool call or
+          validated evidence. Text-only explanations cannot clear a durable
+          signal, so the scheduler uses this for exponential backoff:
+          cooldown *= 2^min(n, 2), capping at 4x. Resets on a productive
+          cycle. *)
   }
 
 (* ── Structured blocker classification ──────────────────────── *)

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -74,11 +74,11 @@ type proactive_runtime = {
   last_reason : string;
   last_preview : string;
   consecutive_noop_count : int;
-      (** Consecutive autonomous cycles where only observation
-          tools were used with no substantive action.  Used by
-          [effective_scheduled_autonomous_cooldown] for
-          exponential backoff: cooldown *= 2^min(n, 2),
-          capping at 4x.  Resets on any productive cycle. *)
+      (** Consecutive autonomous cycles with no substantive tool call or
+          validated evidence. Text-only explanations cannot clear a durable
+          signal, so the scheduler uses this for exponential backoff:
+          cooldown *= 2^min(n, 2), capping at 4x. Resets on a productive
+          cycle. *)
 }
 
 type usage_metrics = {

--- a/lib/keeper/keeper_unified_metrics_result.ml
+++ b/lib/keeper/keeper_unified_metrics_result.ml
@@ -175,7 +175,11 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
                  (Option.map validated_evidence_preview validated_evidence));
         consecutive_noop_count =
           (if update_proactive_rt && is_scheduled_autonomous_cycle then
-             if is_noop_cycle ~has_text ~tools_used:tool_names
+             (* Text-only autonomous turns cannot clear a durable signal. They
+                are counted as no-progress even when the model explains that
+                it found no actionable work; a later reactive/new-backlog
+                signal bypasses the resulting scheduler backoff. *)
+             if not has_substantive_tools && not has_validated_evidence
              then rt.proactive_rt.consecutive_noop_count + 1
              else 0
            else rt.proactive_rt.consecutive_noop_count);

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -1280,9 +1280,10 @@ let keeper_cycle_decision
               Some since_last_scheduled_autonomous
           }
         else (
-        (* A scheduled heartbeat is itself the wake signal. Backlog, schedule,
-           idle time, and previous-turn age remain observations for the model;
-           fixed local thresholds never suppress a Keeper cycle. *)
+        (* Once the no-progress backoff has elapsed, a scheduled heartbeat is
+           itself the wake signal. Backlog, schedule, idle time, and
+           previous-turn age remain observations for the model; no other local
+           threshold suppresses the cycle. *)
         let has_actionable_tasks =
           claimable_drives_wake observation.claimable_task_count
           || failed_drives_wake observation.failed_task_count

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -135,6 +135,7 @@ type turn_reason = Keeper_world_observation_turn_types.turn_reason =
 type skip_reason = Keeper_world_observation_turn_types.skip_reason =
   | Keeper_paused
   | Scheduled_autonomous_disabled
+  | No_progress_cooldown_pending of { remaining_sec : int }
   | Reactive_disabled
 
 type turn_verdict = Keeper_world_observation_turn_types.turn_verdict =
@@ -1242,6 +1243,43 @@ let keeper_cycle_decision
         ; since_last_scheduled_autonomous = Some since_last_scheduled_autonomous
         }
       else (
+        (* Actionless scheduled cycles are durable no-progress: a text-only
+           answer or observation-only tool pass cannot clear the signal that
+           caused the wake. Back off the next scheduled attempt by 2x, then
+           4x (the persisted [consecutive_noop_count] is capped at two for
+           this admission policy). Fresh backlog writes and all reactive/event
+           stimuli bypass this gate, so it cannot delay new work or operator
+           attention. The base is the actual heartbeat cadence rather than a
+           second hand-written interval. *)
+        let no_progress_cooldown_sec =
+          let backoff_shift =
+            min 2 meta.runtime.proactive_rt.consecutive_noop_count
+          in
+          Keeper_heartbeat_snapshot.keepalive_interval_sec ()
+          * (1 lsl max 0 backoff_shift)
+        in
+        let no_progress_remaining_sec =
+          max 0 (no_progress_cooldown_sec - since_last_scheduled_autonomous)
+        in
+        let no_progress_cooldown_pending =
+          meta.runtime.proactive_rt.consecutive_noop_count > 0
+          && not observation.backlog_updated_since_last_scheduled_autonomous
+          && since_last_scheduled_autonomous < no_progress_cooldown_sec
+        in
+        if no_progress_cooldown_pending then
+          { should_run = false
+          ; channel = Scheduled_autonomous
+          ; verdict =
+              Skip
+                { reasons =
+                    ( No_progress_cooldown_pending
+                        { remaining_sec = no_progress_remaining_sec }
+                    , [] )
+                }
+          ; since_last_scheduled_autonomous =
+              Some since_last_scheduled_autonomous
+          }
+        else (
         (* A scheduled heartbeat is itself the wake signal. Backlog, schedule,
            idle time, and previous-turn age remain observations for the model;
            fixed local thresholds never suppress a Keeper cycle. *)
@@ -1271,7 +1309,7 @@ let keeper_cycle_decision
         ; channel = Scheduled_autonomous
         ; verdict = Run { reasons = Scheduled_autonomous_turn, run_reasons }
         ; since_last_scheduled_autonomous = Some since_last_scheduled_autonomous
-        })
+        }) )
     in
     match reactive_triggers with
     | first :: rest when reactive_gate_enabled ->

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -1244,7 +1244,7 @@ let keeper_cycle_decision
         }
       else (
         (* Actionless scheduled cycles are durable no-progress: a text-only
-           answer or observation-only tool pass cannot clear the signal that
+           answer or no-tool pass cannot clear the signal that
            caused the wake. Back off the next scheduled attempt by 2x, then
            4x (the persisted [consecutive_noop_count] is capped at two for
            this admission policy). Fresh backlog writes and all reactive/event

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -181,6 +181,9 @@ type turn_reason =
 type skip_reason =
   | Keeper_paused
   | Scheduled_autonomous_disabled
+  | No_progress_cooldown_pending of { remaining_sec : int }
+      (** Previous scheduled cycle made no durable progress; fresh backlog and
+          reactive/event stimuli bypass the remaining delay. *)
   | Reactive_disabled
 
 (** Keeper cycle decision with non-empty reason list (NEL).

--- a/lib/keeper_contract/keeper_world_observation_turn_types.ml
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.ml
@@ -61,6 +61,7 @@ type turn_reason =
 type skip_reason =
   | Keeper_paused
   | Scheduled_autonomous_disabled
+  | No_progress_cooldown_pending of { remaining_sec : int }
   | Reactive_disabled
       (** RFC-0297 P0-1: the global reactive kill-switch
           (MASC_KEEPER_REACTIVE_ENABLED) is off, so a pending reactive trigger
@@ -95,6 +96,7 @@ let turn_reason_of_event_queue_trigger = function
 let skip_reason_to_string = function
   | Keeper_paused -> "keeper_paused"
   | Scheduled_autonomous_disabled -> "scheduled_autonomous_disabled"
+  | No_progress_cooldown_pending _ -> "no_progress_cooldown_pending"
   | Reactive_disabled -> "reactive_disabled"
 ;;
 

--- a/lib/keeper_contract/keeper_world_observation_turn_types.mli
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.mli
@@ -37,6 +37,9 @@ type turn_reason =
 type skip_reason =
   | Keeper_paused
   | Scheduled_autonomous_disabled
+  | No_progress_cooldown_pending of { remaining_sec : int }
+      (** Previous scheduled cycle made no durable progress; fresh backlog and
+          reactive/event stimuli bypass the remaining delay. *)
   | Reactive_disabled
 
 type turn_verdict =

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -375,6 +375,57 @@ let test_threaded_stimulus_decision_renders_wake_reason () =
   check bool "bootstrap reason listed" true
     (contains ~needle:"bootstrap" threaded)
 
+let meta_after_actionless_cycle () =
+  let proactive_rt = meta.runtime.proactive_rt in
+  { meta with
+    runtime =
+      { meta.runtime with
+        proactive_rt =
+          { proactive_rt with
+            last_ts = Time_compat.now () -. 1.0
+          ; consecutive_noop_count = 1
+          } }
+  }
+
+let test_actionless_cycle_backoff_is_operator_visible () =
+  let decision =
+    WO.keeper_cycle_decision ~meta:(meta_after_actionless_cycle ()) base_observation
+  in
+  check bool "actionless cycle is rate-limited" false decision.WO.should_run;
+  check bool "backoff keeps scheduled channel" true
+    (WO.is_autonomous decision.WO.channel);
+  match decision.WO.verdict with
+  | WO.Skip { reasons = (WO.No_progress_cooldown_pending { remaining_sec }, []) } ->
+    check bool "remaining delay is positive" true (remaining_sec > 0)
+  | WO.Skip _ -> Alcotest.fail "expected typed no-progress cooldown reason"
+  | WO.Run _ -> Alcotest.fail "expected no-progress cooldown"
+
+let test_fresh_backlog_bypasses_actionless_backoff () =
+  let observation =
+    { base_observation with
+      claimable_task_count = 1
+    ; unclaimed_task_count = 1
+    ; backlog_updated_since_last_scheduled_autonomous = true
+    }
+  in
+  let decision =
+    WO.keeper_cycle_decision ~meta:(meta_after_actionless_cycle ()) observation
+  in
+  check bool "fresh backlog is not delayed" true decision.WO.should_run;
+  check bool "fresh backlog remains autonomous" true
+    (WO.is_autonomous decision.WO.channel)
+
+let test_reactive_stimulus_bypasses_actionless_backoff () =
+  let decision =
+    WO.keeper_cycle_decision
+      ~event_queue_triggers:[ WO.Bootstrap_stimulus ]
+      ~meta:(meta_after_actionless_cycle ())
+      base_observation
+  in
+  check bool "reactive stimulus is not delayed" true decision.WO.should_run;
+  check bool "reactive stimulus keeps reactive channel" true
+    (not (WO.is_autonomous decision.WO.channel))
+
 let test_bootstrap_stimulus_keeps_reactive_post_action () =
   let decision =
     WO.keeper_cycle_decision
@@ -529,6 +580,12 @@ let () =
         [
           test_case "stimulus decision renders wake reason" `Quick
             test_threaded_stimulus_decision_renders_wake_reason;
+          test_case "actionless scheduled cycle has typed visible backoff" `Quick
+            test_actionless_cycle_backoff_is_operator_visible;
+          test_case "fresh backlog bypasses actionless backoff" `Quick
+            test_fresh_backlog_bypasses_actionless_backoff;
+          test_case "reactive stimulus bypasses actionless backoff" `Quick
+            test_reactive_stimulus_bypasses_actionless_backoff;
           test_case "bootstrap keeps reactive post-action" `Quick
             test_bootstrap_stimulus_keeps_reactive_post_action;
           test_case "preview invents no wake reason" `Quick

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -375,7 +375,7 @@ let test_threaded_stimulus_decision_renders_wake_reason () =
   check bool "bootstrap reason listed" true
     (contains ~needle:"bootstrap" threaded)
 
-let meta_after_actionless_cycle () =
+let meta_after_actionless_cycle ?(count = 1) () =
   let proactive_rt = meta.runtime.proactive_rt in
   { meta with
     runtime =
@@ -383,7 +383,7 @@ let meta_after_actionless_cycle () =
         proactive_rt =
           { proactive_rt with
             last_ts = Time_compat.now () -. 1.0
-          ; consecutive_noop_count = 1
+          ; consecutive_noop_count = count
           } }
   }
 
@@ -399,6 +399,20 @@ let test_actionless_cycle_backoff_is_operator_visible () =
     check bool "remaining delay is positive" true (remaining_sec > 0)
   | WO.Skip _ -> Alcotest.fail "expected typed no-progress cooldown reason"
   | WO.Run _ -> Alcotest.fail "expected no-progress cooldown"
+
+let test_actionless_backoff_caps_at_four_x () =
+  let decision =
+    WO.keeper_cycle_decision
+      ~meta:(meta_after_actionless_cycle ~count:9 ())
+      base_observation
+  in
+  match decision.WO.verdict with
+  | WO.Skip { reasons = (WO.No_progress_cooldown_pending { remaining_sec }, []) } ->
+    let base = Masc.Keeper_heartbeat_snapshot.keepalive_interval_sec () in
+    check bool "backoff is capped at 4x cadence" true
+      (remaining_sec >= max 1 (3 * base))
+  | WO.Skip _ -> Alcotest.fail "expected typed no-progress cooldown reason"
+  | WO.Run _ -> Alcotest.fail "expected capped no-progress cooldown"
 
 let test_fresh_backlog_bypasses_actionless_backoff () =
   let observation =
@@ -582,6 +596,8 @@ let () =
             test_threaded_stimulus_decision_renders_wake_reason;
           test_case "actionless scheduled cycle has typed visible backoff" `Quick
             test_actionless_cycle_backoff_is_operator_visible;
+          test_case "actionless backoff caps at four times cadence" `Quick
+            test_actionless_backoff_caps_at_four_x;
           test_case "fresh backlog bypasses actionless backoff" `Quick
             test_fresh_backlog_bypasses_actionless_backoff;
           test_case "reactive stimulus bypasses actionless backoff" `Quick


### PR DESCRIPTION
## Summary

- count text-only autonomous cycles as no-progress when they produced no substantive tool call or validated evidence
- rate-limit the next scheduled autonomous turn at 2x, then 4x the live heartbeat cadence
- bypass the backoff for fresh backlog writes and all reactive/event-queue stimuli
- expose a typed no_progress_cooldown_pending skip reason and add focused scheduler tests

This is a narrow mitigation for #26487 repeated no-action autonomous loops. It does not pretend do_not_reclaim_reason is an execution-capability SSOT; PR #26523 remains blocked by that regression and needs a separate typed capability/repository contract.

## Verification

- MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_wake_turn_context.exe
- _build/default/test/test_keeper_wake_turn_context.exe test threaded turn decision — 7/7 passed
- Full fixture run still has 3 pre-existing prompt-contract failures outside this diff; all new backoff cases pass.