### PR TITLE
fix(memory): bound recall facts and clarify wire metrics

### DIFF
--- a/config/prompts/keeper.librarian.current_selection.md
+++ b/config/prompts/keeper.librarian.current_selection.md
@@ -1,7 +1,7 @@
 ---
 description: Memory OS librarian current-memory selection prompt
 category: keeper
-template_variables: [current_memory, conversation_history, persona]
+template_variables: [current_memory, conversation_history, persona, max_recall_fact_bytes]
 ---
 
 You own the complete current memory of an AI agent. Read the agent's persona, the exact current-memory snapshot, and a bounded slice of new conversation. Every existing memory ID must appear exactly once in your answer: either in `retained_memory_ids` (it stays) or in `dropped` with a one-sentence reason (it is forgotten). An existing ID that appears in neither list rejects the whole answer.
@@ -9,6 +9,8 @@ You own the complete current memory of an AI agent. Read the agent's persona, th
 You curate on this agent's behalf: the persona section defines who the agent is, and importance is always importance *to that identity* — its role, duties, and ongoing work. A fact worthless to a generic assistant may be essential to this persona, and vice versa.
 
 Keep only the smallest useful set of important knowledge. There is no target item count and no deterministic ranking after your decision. Your returned selection is injected as-is into later Keeper turns, so remove duplication, obsolete state, low-value narration, and details recoverable from authoritative sources.
+
+Capacity contract: the complete rendered fact payload (memory identity, category, claim, separators, and line breaks) must fit within {{max_recall_fact_bytes}} UTF-8 bytes. Choose a smaller useful set when necessary. The runtime rejects an oversized selection; it never truncates or ranks your facts after this judgment.
 
 Retention criteria:
 - Retain an existing ID only when its exact fact is still true, important, non-duplicative, and worth occupying future context.

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -709,6 +709,7 @@ describe('KeeperWorkspaceRail', () => {
     expect(container.textContent).not.toContain('윈도우 사용량')
     expect(container.textContent).toContain('62%')
     expect(container.textContent).toContain('124.0k')
+    expect(container.textContent).toContain('provider 입력 토큰 / 모델 윈도우')
     expect(meter).not.toBeNull()
     expect(meter?.getAttribute('role')).toBe('meter')
     expect(meter?.getAttribute('aria-label')).toBe('컨텍스트 윈도우 사용률')
@@ -838,9 +839,11 @@ describe('KeeperWorkspaceRail', () => {
     const provenance = container.querySelector('[data-testid="ctx-provenance"]')
     expect(provenance).not.toBeNull()
     expect(provenance?.textContent).toContain('T3337')
-    expect(provenance?.textContent).toContain('wire')
+    expect(provenance?.textContent).toContain('요청 본문')
     expect(provenance?.textContent).toContain('393KB')
-    expect(provenance?.textContent).toContain('다음 입력에 함께 실리는 상비 페이로드')
+    expect(provenance?.textContent).toContain('같은 완료 요청')
+    expect(provenance?.textContent).toContain('직렬화 UTF-8 바이트')
+    expect(provenance?.textContent).not.toContain('다음 입력에 함께 실리는 상비 페이로드')
   })
 
   it('renders no provenance line for a non-turn_record source', () => {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -505,14 +505,14 @@ function ContextSection({
           <span class="mono">${tokens ?? '—'}</span>
           <span class="ctx-tok-sep">/</span>
           <span class="mono ctx-tok-full">${maxLabel ?? '—'}</span>
-          <span class="ctx-tok-lbl">사용 / 전체 윈도우</span>
+          <span class="ctx-tok-lbl">provider 입력 토큰 / 모델 윈도우</span>
         </div>
         ${ctxSource === 'turn_record'
           ? html`<div class="ctx-src" data-testid="ctx-provenance" title=${ctxTurnRef ?? undefined}>
               측정: <span class="mono">T${ctxAbsoluteTurn ?? '—'}</span>
               ${ctxObservedAt ? html` · ${formatTimeAgo(ctxObservedAt)}` : null}
-              ${wireLabel ? html` · wire <span class="mono">${wireLabel}</span>` : null}
-              <span class="ctx-src-lbl">다음 입력에 함께 실리는 상비 페이로드</span>
+              ${wireLabel ? html` · 요청 본문 <span class="mono">${wireLabel}</span>` : null}
+              <span class="ctx-src-lbl">같은 완료 요청: 토큰은 모델 측정, 본문은 직렬화 UTF-8 바이트</span>
             </div>`
           : null}
         <div class="cmp-actions">

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 207 unique knobs across 8 modules.
+**Total**: 208 unique knobs across 8 modules.
 
-**Typed getter classification**: 32/120 tagged (`operator`: 32, `algorithm`: 0, `unclassified`: 88).
+**Typed getter classification**: 33/121 tagged (`operator`: 33, `algorithm`: 0, `unclassified`: 88).
 
 ## Env_config_core (23 knobs; typed classification 2/5)
 
@@ -46,50 +46,51 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_TEST_ALLOW_HOME_BASE_PATH` | string_literal | n/a | n/a | 416 | #9903: production base-path safeguard for test executables. Without this, a test whose [MASC_BASE_PATH] override fail... |
 | `MASC_URL` | string_literal | n/a | n/a | 289 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 
-## Env_config_keeper (40 knobs; typed classification 20/33)
+## Env_config_keeper (41 knobs; typed classification 21/34)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 568 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 514 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
+| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 582 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 528 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | feature_flag | n/a | n/a | 20 | Enable startup keeper bootstrap scan |
 | `MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC` | typed:float | unclassified | unclassified | 41 | Polling interval (seconds) for the lazy-startup wait loop in [server_bootstrap_loops.ml]. The autoboot fiber wakes up... |
 | `MASC_KEEPER_BOOTSTRAP_LISTENER_RETRY_INTERVAL_SEC` | typed:float | unclassified | unclassified | 53 | Polling interval (seconds) for the keeper-lifecycle listener retry loop in [server_bootstrap_loops.ml]. After a liste... |
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | unclassified | unclassified | 28 | Max keeper meta files to scan during bootstrap |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 65 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | unclassified | unclassified | 24 | Keeper considered stale when last turn exceeds this threshold (seconds) |
-| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 534 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT` | typed:int | Runtime | operator | 254 | Default item limit for [GET /keepers/:name/compaction-snapshots]. Default: 25. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER` | typed:int | Runtime | operator | 280 | Multiplier from requested item limit to manifest files scanned. Default: 4. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES` | typed:int | Runtime | operator | 270 | Minimum manifest files scanned before applying [limit * multiplier]. Default: 8. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES` | typed:int | Runtime | operator | 290 | Tail line count read from each selected manifest file. Default: 200. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MAX_LIMIT` | typed:int | Runtime | operator | 260 | Maximum accepted item limit for the compaction snapshot endpoint. Default: 100. @category Runtime @ops_class operator |
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 548 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT` | typed:int | Runtime | operator | 268 | Default item limit for [GET /keepers/:name/compaction-snapshots]. Default: 25. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER` | typed:int | Runtime | operator | 294 | Multiplier from requested item limit to manifest files scanned. Default: 4. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES` | typed:int | Runtime | operator | 284 | Minimum manifest files scanned before applying [limit * multiplier]. Default: 8. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES` | typed:int | Runtime | operator | 304 | Tail line count read from each selected manifest file. Default: 200. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MAX_LIMIT` | typed:int | Runtime | operator | 274 | Maximum accepted item limit for the compaction snapshot endpoint. Default: 100. @category Runtime @ops_class operator |
 | `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 143 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
 | `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 151 | Enable keeper debug logging. Default: false. |
-| `MASC_KEEPER_DURABLE_QUEUE_STALE_SEC` | typed:float | Telemetry | operator | 439 | Durable event-queue backlog age threshold for fleet health degradation. The durable queue remains fully reported rega... |
-| `MASC_KEEPER_GENERATED_MEDIA_DIR_MAX_BYTES` | typed:int | Policies | operator | 377 | Maximum total bytes retained in [<masc_dir>/media] after opportunistic cleanup. Default is 500 MiB. Range: [1, 5 GiB]... |
-| `MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES` | typed:int | Policies | operator | 366 | Maximum raw generated-media bytes accepted by the durable store and serve route. Default is 10 MiB. Range: [1, 50 MiB... |
-| `MASC_KEEPER_GENERATED_MEDIA_RETENTION_SEC` | typed:float | Policies | operator | 388 | Maximum generated-media file age retained by opportunistic cleanup. Default is 24 hours. Range: [1 second, 30 days]. ... |
-| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 547 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
-| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | Thresholds | operator | 400 | Shared keepalive interval, read early so WorkAsHeartbeat can reference it. Any positive interval is valid; the schedu... |
-| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 421 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | string_literal | n/a | n/a | 183 |  |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 225 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 237 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 213 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
+| `MASC_KEEPER_DURABLE_QUEUE_STALE_SEC` | typed:float | Telemetry | operator | 453 | Durable event-queue backlog age threshold for fleet health degradation. The durable queue remains fully reported rega... |
+| `MASC_KEEPER_GENERATED_MEDIA_DIR_MAX_BYTES` | typed:int | Policies | operator | 391 | Maximum total bytes retained in [<masc_dir>/media] after opportunistic cleanup. Default is 500 MiB. Range: [1, 5 GiB]... |
+| `MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES` | typed:int | Policies | operator | 380 | Maximum raw generated-media bytes accepted by the durable store and serve route. Default is 10 MiB. Range: [1, 50 MiB... |
+| `MASC_KEEPER_GENERATED_MEDIA_RETENTION_SEC` | typed:float | Policies | operator | 402 | Maximum generated-media file age retained by opportunistic cleanup. Default is 24 hours. Range: [1 second, 30 days]. ... |
+| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 561 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
+| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | Thresholds | operator | 414 | Shared keepalive interval, read early so WorkAsHeartbeat can reference it. Any positive interval is valid; the schedu... |
+| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 435 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | string_literal | n/a | n/a | 184 |  |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 227 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 239 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 215 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
+| `MASC_KEEPER_MEMORY_OS_RECALL_FACTS_MAX_BYTES` | typed:int | Policies | operator | 251 | Maximum UTF-8 bytes for the exact rendered fact lines injected by recall. The Librarian owns selection within this ca... |
 | `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | unclassified | unclassified | 73 | Maximum metrics file size in bytes before rotation (default: 10MB) |
 | `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | unclassified | unclassified | 76 | Number of rotated files to keep (default: 1, i.e. .1 only) |
-| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | Thresholds | operator | 463 | Interruptible sleep chunk size in seconds: the upper bound on how long a keeper's heartbeat sleep takes to notice a w... |
+| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | Thresholds | operator | 477 | Interruptible sleep chunk size in seconds: the upper bound on how long a keeper's heartbeat sleep takes to notice a w... |
 | `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 154 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
-| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 557 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
-| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | string_literal | n/a | n/a | 474 |  |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 327 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 337 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
-| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 317 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
+| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 571 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
+| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | string_literal | n/a | n/a | 488 |  |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 341 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 351 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
+| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 331 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
 | `MASC_KEEPER_WIRE_CAPTURE` | feature_flag | Policies | operator | 88 | Master switch for diagnostic MASC->OAS wire capture. Default off. @category Policies @ops_class operator |
 | `MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES` | typed:int | Policies | operator | 114 | Maximum bytes for the active [<masc_root>/wire-capture/YYYY-MM/DD.jsonl] file and maximum total bytes retained below ... |
 | `MASC_KEEPER_WIRE_CAPTURE_RETENTION_DAYS` | typed:int | Policies | operator | 103 | Maximum age for [<masc_root>/wire-capture] day files retained by the diagnostic MASC->OAS wire-capture harness. Defau... |
-| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 415 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
+| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 429 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
 
 ## Env_config_keeper_supervisor (3 knobs; typed classification 2/2)
 
@@ -225,9 +226,9 @@ the categorization roadmap. Newly-added typed getters in
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALLOW_ANONYMOUS_MUTATIONS` | string_literal | n/a | n/a | 29 |  |
-| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 414 |  |
-| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 418 |  |
-| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 420 |  |
+| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 418 |  |
+| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 422 |  |
+| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 424 |  |
 | `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 150 |  |
 | `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 220 |  |
 | `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 222 |  |
@@ -235,8 +236,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S` | string_literal | n/a | n/a | 160 |  |
 | `MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S` | string_literal | n/a | n/a | 192 |  |
 | `MASC_DECISION_AUDIT_RING_CAPACITY` | string_literal | n/a | n/a | 232 |  |
-| `MASC_DEFAULT_MODEL` | string_literal | n/a | n/a | 380 |  |
-| `MASC_DEFAULT_PROVIDER` | string_literal | n/a | n/a | 382 |  |
+| `MASC_DEFAULT_MODEL` | string_literal | n/a | n/a | 384 |  |
+| `MASC_DEFAULT_PROVIDER` | string_literal | n/a | n/a | 386 |  |
 | `MASC_DISCORD_STATUS_STALE_SEC` | string_literal | n/a | n/a | 224 |  |
 | `MASC_GRPC_STREAM_MAX_BUFFER` | string_literal | n/a | n/a | 81 |  |
 | `MASC_HTTP_HOST` | string_literal | n/a | n/a | 21 |  |
@@ -245,18 +246,18 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_AUTONOMOUS_MAX_TOKENS` | string_literal | n/a | n/a | 136 |  |
 | `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 134 |  |
 | `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 133 |  |
-| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 466 |  |
-| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 492 |  |
-| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 500 |  |
-| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 440 |  |
-| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 442 |  |
-| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 444 |  |
-| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 446 |  |
-| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 452 |  |
+| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 470 |  |
+| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 496 |  |
+| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 504 |  |
+| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 444 |  |
+| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 446 |  |
+| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 448 |  |
+| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 450 |  |
+| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 456 |  |
 | `MASC_TELEMETRY_MAX_BYTES` | string_literal | n/a | n/a | 48 |  |
 | `MASC_TELEMETRY_RETENTION_DAYS` | string_literal | n/a | n/a | 45 |  |
-| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 482 |  |
-| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 484 |  |
+| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 486 |  |
+| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 488 |  |
 | `MASC_TLA_TRACE` | string_literal | n/a | n/a | 127 |  |
 | `MASC_WS_ACK_STALE_THRESHOLD_SEC` | string_literal | n/a | n/a | 91 |  |
 | `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 88 |  |

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -241,7 +241,9 @@ module KeeperMemoryOs = struct
   ;;
 
   (** Maximum UTF-8 bytes for the exact rendered fact lines injected by recall.
-      The Librarian owns selection within this capacity boundary. *)
+      The Librarian owns selection within this capacity boundary.
+      @category Policies
+      @ops_class operator *)
   let recall_facts_max_bytes () =
     max
       1

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -174,6 +174,7 @@ module KeeperMemoryOs = struct
   let librarian_enabled_default = true
   let librarian_cadence_turns_default = 3
   let librarian_max_messages_default = 24
+  let recall_facts_max_bytes_default = 64 * 1024
 
   (* Env-key SSOT: the config-introspection registry
      (env_config_snapshot.ml memory_entries) and the tests reference these
@@ -183,6 +184,7 @@ module KeeperMemoryOs = struct
   let librarian_env_key = "MASC_KEEPER_MEMORY_OS_LIBRARIAN"
   let librarian_cadence_turns_env_key = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS"
   let librarian_max_messages_env_key = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES"
+  let recall_facts_max_bytes_env_key = "MASC_KEEPER_MEMORY_OS_RECALL_FACTS_MAX_BYTES"
 
   let get_bool_logged ?(invalid = Env_config_memory.Default) name ~default =
     Env_config_memory.get_bool_logged
@@ -236,6 +238,16 @@ module KeeperMemoryOs = struct
       (get_int_logged
          librarian_max_messages_env_key
          ~default:librarian_max_messages_default)
+  ;;
+
+  (** Maximum UTF-8 bytes for the exact rendered fact lines injected by recall.
+      The Librarian owns selection within this capacity boundary. *)
+  let recall_facts_max_bytes () =
+    max
+      1
+      (get_int_logged
+         recall_facts_max_bytes_env_key
+         ~default:recall_facts_max_bytes_default)
   ;;
 
 end

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -71,11 +71,13 @@ module KeeperMemoryOs : sig
   val librarian_env_key : string
   val librarian_cadence_turns_env_key : string
   val librarian_max_messages_env_key : string
+  val recall_facts_max_bytes_env_key : string
 
   val recall_enabled_default : bool
   val librarian_enabled_default : bool
   val librarian_cadence_turns_default : int
   val librarian_max_messages_default : int
+  val recall_facts_max_bytes_default : int
 
   val librarian_config_state : unit -> librarian_config_state
   (** Typed projection of the effective librarian toggle. Blank or absent
@@ -85,6 +87,9 @@ module KeeperMemoryOs : sig
   val recall_enabled : unit -> bool
   val librarian_cadence_turns : unit -> int
   val librarian_max_messages : unit -> int
+  val recall_facts_max_bytes : unit -> int
+  (** Maximum UTF-8 bytes for the rendered dynamic fact payload injected by
+      Memory OS recall. Floored to 1. *)
 end
 
 (** {1 Keeper dashboard compaction snapshots} *)

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -365,6 +365,10 @@ let memory_entries =
       ~default:(string_of_int Memory_os_defaults.librarian_max_messages_default)
       Memory_os_defaults.librarian_max_messages_env_key
       "Recent-message window for librarian extraction (floor 1)";
+    entry
+      ~default:(string_of_int Memory_os_defaults.recall_facts_max_bytes_default)
+      Memory_os_defaults.recall_facts_max_bytes_env_key
+      "Maximum UTF-8 bytes for rendered Memory OS recall fact lines (floor 1)";
   ]
 
 let message_gc_entries =

--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -123,6 +123,8 @@ let run
                ; generation
                ; persona
                ; current = current_selection
+               ; max_recall_fact_bytes =
+                   Env_config.KeeperMemoryOs.recall_facts_max_bytes ()
                ; messages = librarian_messages
                }
              in

--- a/lib/keeper/keeper_context_observation_projection.ml
+++ b/lib/keeper/keeper_context_observation_projection.ml
@@ -3,8 +3,8 @@
     Context occupancy is projected from the newest TurnRecord (RFC-0233):
     [input_tokens] is the provider-reported prompt total for the last
     completed turn and [context_window] the window resolved for that same
-    request, so the pair is the measurement SSOT for "what enters with the
-    next input". This module is the single wire projection for that
+    request. The pair describes that completed request; it does not predict the
+    next input. This module is the single wire projection for that
     measurement, for its typed absence, and for the separate,
     provider-reported last-turn usage.
 

--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -18,6 +18,7 @@ type input =
   ; generation : int
   ; persona : string
   ; current : current_selection option
+  ; max_recall_fact_bytes : int
   ; messages : Agent_sdk.Types.message list
   }
 
@@ -133,6 +134,7 @@ let format_persona_for_prompt persona =
 let prompt_variables (inp : input) : (string * string) list =
   [ "persona", format_persona_for_prompt inp.persona
   ; "current_memory", format_current_selection_for_prompt inp.current
+  ; "max_recall_fact_bytes", string_of_int inp.max_recall_fact_bytes
   ; ( "conversation_history"
     , format_messages_for_prompt inp.messages )
   ]
@@ -191,6 +193,10 @@ type parse_error =
   | Duplicate_dropped_memory_id of string
   | Dropped_memory_id_also_retained of string
   | Missing_disposition of string
+  | Recall_fact_budget_exceeded of
+      { actual_bytes : int
+      ; max_bytes : int
+      }
 
 let parse_error_to_string = function
   | Top_level_not_object -> "top_level_not_object"
@@ -212,6 +218,11 @@ let parse_error_to_string = function
   | Dropped_memory_id_also_retained identity ->
     "dropped_memory_id_also_retained: " ^ identity
   | Missing_disposition identity -> "missing_disposition: " ^ identity
+  | Recall_fact_budget_exceeded { actual_bytes; max_bytes } ->
+    Printf.sprintf
+      "recall_fact_budget_exceeded: actual_bytes=%d max_bytes=%d"
+      actual_bytes
+      max_bytes
 ;;
 
 let fact_of_json ~now (json : Yojson.Safe.t) : fact option =
@@ -376,12 +387,22 @@ let selection_of_json_result ?now (inp : input) (json : Yojson.Safe.t) :
                         ~dropped
                     with
                     | Ok facts ->
-                      Ok
-                        { retained_memory_ids
-                        ; new_claims
-                        ; dropped
-                        ; facts
-                        }
+                      (match
+                         Keeper_memory_os_budget.measure
+                           ~max_bytes:inp.max_recall_fact_bytes
+                           facts
+                       with
+                       | Fits _ ->
+                         Ok
+                           { retained_memory_ids
+                           ; new_claims
+                           ; dropped
+                           ; facts
+                           }
+                       | Exceeds { actual_bytes; max_bytes } ->
+                         Error
+                           (Recall_fact_budget_exceeded
+                              { actual_bytes; max_bytes }))
                     | Error _ as error -> error)
                  | Some _, None -> Error Dropped_schema_mismatch
                  | None, _ -> Error Claim_schema_mismatch)))

--- a/lib/keeper/keeper_librarian.mli
+++ b/lib/keeper/keeper_librarian.mli
@@ -2,9 +2,9 @@
 
     The Librarian receives the exact current selection plus a bounded slice of
     new conversation. It returns existing fact identities to retain and new
-    facts to add. Omitting an existing identity removes that memory. No
-    deterministic ranking, recency rule, byte budget, or migration path
-    participates. *)
+    facts to add. Every existing identity must be retained or explicitly
+    dropped. The LLM owns selection within the rendered-fact byte budget; no
+    deterministic ranking, recency rule, or migration path participates. *)
 
 type current_selection =
   { facts : Keeper_memory_os_types.fact list }
@@ -19,6 +19,9 @@ type input =
         importance through this identity; [""] renders as an explicit
         [no persona] marker. *)
   ; current : current_selection option
+  ; max_recall_fact_bytes : int
+    (** Maximum UTF-8 bytes for the exact rendered fact lines. The prompt states
+        this capacity and the parser rejects an oversized selection. *)
   ; messages : Agent_sdk.Types.message list
   }
 
@@ -59,6 +62,10 @@ type parse_error =
   | Duplicate_dropped_memory_id of string
   | Dropped_memory_id_also_retained of string
   | Missing_disposition of string
+  | Recall_fact_budget_exceeded of
+      { actual_bytes : int
+      ; max_bytes : int
+      }
 
 val parse_error_to_string : parse_error -> string
 

--- a/lib/keeper/keeper_memory_os_budget.ml
+++ b/lib/keeper/keeper_memory_os_budget.ml
@@ -21,8 +21,37 @@ let render_facts facts =
   facts |> List.map render_fact |> String.concat "\n"
 ;;
 
+let memory_id_bytes = String.length "sha256:" + (Digestif.SHA256.digest_size * 2)
+
+let saturated_add left right =
+  if left > Int.max_int - right then Int.max_int else left + right
+;;
+
+(* Count the exact rendered shape without hashing identities or allocating the
+   combined payload. [memory_id] is always sha256 plus a fixed-width hex digest. *)
+let rendered_bytes facts =
+  let line_bytes fact =
+    0
+    |> saturated_add (String.length "- [memory_id=")
+    |> saturated_add memory_id_bytes
+    |> saturated_add (String.length " category=")
+    |> saturated_add (String.length (category_to_string fact.category))
+    |> saturated_add (String.length "] ")
+    |> saturated_add (String.length fact.claim)
+  in
+  let bytes, _ =
+    List.fold_left
+      (fun (bytes, first) fact ->
+         let bytes = if first then bytes else saturated_add bytes 1 in
+         saturated_add bytes (line_bytes fact), false)
+      (0, true)
+      facts
+  in
+  bytes
+;;
+
 let measure ~max_bytes facts =
-  let actual_bytes = String.length (render_facts facts) in
+  let actual_bytes = rendered_bytes facts in
   let measurement = { actual_bytes; max_bytes } in
   if actual_bytes <= max_bytes then Fits measurement else Exceeds measurement
 ;;

--- a/lib/keeper/keeper_memory_os_budget.ml
+++ b/lib/keeper/keeper_memory_os_budget.ml
@@ -1,0 +1,28 @@
+open Keeper_memory_os_types
+
+type measurement =
+  { actual_bytes : int
+  ; max_bytes : int
+  }
+
+type fit =
+  | Fits of measurement
+  | Exceeds of measurement
+
+let render_fact fact =
+  Printf.sprintf
+    "- [memory_id=%s category=%s] %s"
+    (memory_id fact)
+    (category_to_string fact.category)
+    fact.claim
+;;
+
+let render_facts facts =
+  facts |> List.map render_fact |> String.concat "\n"
+;;
+
+let measure ~max_bytes facts =
+  let actual_bytes = String.length (render_facts facts) in
+  let measurement = { actual_bytes; max_bytes } in
+  if actual_bytes <= max_bytes then Fits measurement else Exceeds measurement
+;;

--- a/lib/keeper/keeper_memory_os_budget.mli
+++ b/lib/keeper/keeper_memory_os_budget.mli
@@ -14,4 +14,8 @@ type fit =
   | Exceeds of measurement
 
 val render_facts : Keeper_memory_os_types.fact list -> string
+val rendered_bytes : Keeper_memory_os_types.fact list -> int
+(** Exact byte count of {!render_facts}, computed without hashing fact IDs or
+    allocating the combined rendered payload. Saturates at [Int.max_int]. *)
+
 val measure : max_bytes:int -> Keeper_memory_os_types.fact list -> fit

--- a/lib/keeper/keeper_memory_os_budget.mli
+++ b/lib/keeper/keeper_memory_os_budget.mli
@@ -1,0 +1,17 @@
+(** Byte-budget contract for the dynamic Memory OS fact payload.
+
+    The measured bytes are exactly the UTF-8 bytes that recall places in the
+    [facts] template variable: identity, category, claim, separators, and line
+    breaks. Prompt-template boilerplate is deliberately outside this policy. *)
+
+type measurement =
+  { actual_bytes : int
+  ; max_bytes : int
+  }
+
+type fit =
+  | Fits of measurement
+  | Exceeds of measurement
+
+val render_facts : Keeper_memory_os_types.fact list -> string
+val measure : max_bytes:int -> Keeper_memory_os_types.fact list -> fit

--- a/lib/keeper/keeper_memory_os_current.ml
+++ b/lib/keeper/keeper_memory_os_current.ml
@@ -367,6 +367,7 @@ let update_locked
 ;;
 
 let make_snapshot
+      ~max_fact_bytes
       ~previous
       ~now
       ~source
@@ -378,18 +379,27 @@ let make_snapshot
     | None -> [], 1
     | Some snapshot -> snapshot.facts, snapshot.revision + 1
   in
-  let+ change = compute_change ~previous:previous_facts ~next:facts in
-  { revision
-  ; updated_at = now
-  ; source
-  ; facts
-  ; change
-  }
+  match Keeper_memory_os_budget.measure ~max_bytes:max_fact_bytes facts with
+  | Exceeds { actual_bytes; max_bytes } ->
+    Error
+      (Printf.sprintf
+         "Memory OS rendered fact payload exceeds byte budget actual_bytes=%d max_bytes=%d"
+         actual_bytes
+         max_bytes)
+  | Fits _ ->
+    let+ change = compute_change ~previous:previous_facts ~next:facts in
+    { revision
+    ; updated_at = now
+    ; source
+    ; facts
+    ; change
+    }
 ;;
 
 let replace
       ?clock
       ?dropped_statements
+      ?(max_fact_bytes=Env_config.KeeperMemoryOs.recall_facts_max_bytes ())
       ~keepers_dir
       ~keeper_id
       ~expected_revision
@@ -411,6 +421,7 @@ let replace
            (Option.fold ~none:"absent" ~some:string_of_int observed_revision))
     else
       make_snapshot
+        ~max_fact_bytes
         ~previous
         ~now
         ~source
@@ -420,6 +431,7 @@ let replace
 
 let upsert_fact
       ?clock
+      ?(max_fact_bytes=Env_config.KeeperMemoryOs.recall_facts_max_bytes ())
       ~keepers_dir
       ~keeper_id
       ~now
@@ -446,6 +458,7 @@ let upsert_fact
     in
     let facts = if !found then facts else facts @ [ incoming ] in
     make_snapshot
+      ~max_fact_bytes
       ~previous
       ~now
       ~source

--- a/lib/keeper/keeper_memory_os_current.ml
+++ b/lib/keeper/keeper_memory_os_current.ml
@@ -379,6 +379,7 @@ let make_snapshot
     | None -> [], 1
     | Some snapshot -> snapshot.facts, snapshot.revision + 1
   in
+  let max_fact_bytes = max 1 max_fact_bytes in
   match Keeper_memory_os_budget.measure ~max_bytes:max_fact_bytes facts with
   | Exceeds { actual_bytes; max_bytes } ->
     Error

--- a/lib/keeper/keeper_memory_os_current.mli
+++ b/lib/keeper/keeper_memory_os_current.mli
@@ -51,6 +51,7 @@ val read_for_keepers_dir :
 val replace
   :  ?clock:float Eio.Time.clock_ty Eio.Resource.t
   -> ?dropped_statements:Keeper_memory_os_types.dropped_statement list
+  -> ?max_fact_bytes:int
   -> keepers_dir:string
   -> keeper_id:string
   -> expected_revision:int option
@@ -60,10 +61,11 @@ val replace
   -> unit
   -> (t, string) result
 (** Atomically replace the complete current snapshot only when its revision
-    still equals [expected_revision]. Duplicate fact identities reject before
-    writing. Existing state must parse as the exact current schema; malformed,
-    non-current, or concurrently changed state fails closed and is not
-    overwritten.
+    still equals [expected_revision]. Duplicate fact identities and a rendered
+    fact payload above [max_fact_bytes] reject before writing. The default is
+    the Memory OS capacity policy. Existing state must parse as the exact
+    current schema; malformed, non-current, or concurrently changed state fails
+    closed and is not overwritten.
 
     [dropped_statements], when present, is the writer's own account of every
     drop in this commit (the librarian's totality output) and is recorded on
@@ -73,6 +75,7 @@ val replace
 
 val upsert_fact
   :  ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?max_fact_bytes:int
   -> keepers_dir:string
   -> keeper_id:string
   -> now:float
@@ -82,6 +85,7 @@ val upsert_fact
 (** Atomically insert or replace one explicit keeper-authored fact while
     preserving the rest of the current snapshot. A matching identity is
     updated from the explicit incoming fact while preserving its original
-    [first_seen]; no local importance, recency, or echo heuristic participates. *)
+    [first_seen]. The same rendered-fact byte budget as [replace] applies; no
+    local importance, recency, or echo heuristic participates. *)
 
 val to_json : t -> Yojson.Safe.t

--- a/lib/keeper/keeper_memory_os_current.mli
+++ b/lib/keeper/keeper_memory_os_current.mli
@@ -62,8 +62,8 @@ val replace
   -> (t, string) result
 (** Atomically replace the complete current snapshot only when its revision
     still equals [expected_revision]. Duplicate fact identities and a rendered
-    fact payload above [max_fact_bytes] reject before writing. The default is
-    the Memory OS capacity policy. Existing state must parse as the exact
+    fact payload above [max_fact_bytes] reject before writing. The bound is
+    floored to 1 byte; its default is the Memory OS capacity policy. Existing state must parse as the exact
     current schema; malformed, non-current, or concurrently changed state fails
     closed and is not overwritten.
 
@@ -85,7 +85,8 @@ val upsert_fact
 (** Atomically insert or replace one explicit keeper-authored fact while
     preserving the rest of the current snapshot. A matching identity is
     updated from the explicit incoming fact while preserving its original
-    [first_seen]. The same rendered-fact byte budget as [replace] applies; no
+    [first_seen]. The same rendered-fact byte budget and 1-byte floor as
+    [replace] apply; no
     local importance, recency, or echo heuristic participates. *)
 
 val to_json : t -> Yojson.Safe.t

--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -5,10 +5,12 @@ open Keeper_memory_os_types
 type unavailable_reason =
   | Read_error
   | Prompt_render_error
+  | Fact_budget_exceeded
 
 let unavailable_reason_to_label = function
   | Read_error -> "read_error"
   | Prompt_render_error -> "prompt_render_error"
+  | Fact_budget_exceeded -> "fact_budget_exceeded"
 ;;
 
 let record_unavailable reason =
@@ -42,14 +44,6 @@ let render_unavailable_context reason =
       reason
 ;;
 
-let render_fact fact =
-  Printf.sprintf
-    "- [memory_id=%s category=%s] %s"
-    (memory_id fact)
-    (category_to_string fact.category)
-    fact.claim
-;;
-
 type render_result =
   { block : string
   ; injected_fact_keys : string list
@@ -59,8 +53,7 @@ type render_result =
 
 let render_snapshot ~now:_ snapshot =
   let facts = snapshot.Keeper_memory_os_current.facts in
-  let fact_lines = List.map render_fact facts in
-  match fact_lines with
+  match facts with
   | [] ->
     { block = ""
     ; injected_fact_keys = []
@@ -68,12 +61,25 @@ let render_snapshot ~now:_ snapshot =
     ; failure_reason = None
     }
   | _ ->
-    (match
+    let max_bytes = Env_config.KeeperMemoryOs.recall_facts_max_bytes () in
+    (match Keeper_memory_os_budget.measure ~max_bytes facts with
+     | Exceeds { actual_bytes; max_bytes } ->
+       Log.Keeper.warn
+         "memory os recall fact payload exceeds byte budget actual_bytes=%d max_bytes=%d"
+         actual_bytes
+         max_bytes;
+       { block = render_unavailable_context Fact_budget_exceeded
+       ; injected_fact_keys = []
+       ; n_facts_in_store = List.length facts
+       ; failure_reason = Some Fact_budget_exceeded
+       }
+     | Fits _ ->
+       (match
        render_prompt_template
          Keeper_prompt_names.memory_os_recall_context
          [ "revision", string_of_int snapshot.revision
          ; "updated_at", Masc_domain.iso8601_of_unix_seconds snapshot.updated_at
-         ; "facts", String.concat "\n" fact_lines
+         ; "facts", Keeper_memory_os_budget.render_facts facts
          ]
      with
      | Ok block ->
@@ -90,7 +96,7 @@ let render_snapshot ~now:_ snapshot =
        ; injected_fact_keys = []
        ; n_facts_in_store = List.length facts
        ; failure_reason = Some Prompt_render_error
-       })
+       }))
 ;;
 
 let render_context_result ~keepers_dir ~keeper_id ~now =

--- a/lib/keeper/keeper_memory_os_recall.mli
+++ b/lib/keeper/keeper_memory_os_recall.mli
@@ -1,8 +1,9 @@
 (** Render the exact LLM-selected current Memory OS snapshot.
 
     Recall reads the same snapshot as the dashboard and injects every current
-    fact in stored order. It has no count cap, byte budget, recency selection,
-    episode fallback, or deterministic importance policy. *)
+    fact in stored order when the exact rendered fact payload fits the Memory OS
+    byte budget. Oversized persisted state fails closed with explicit unavailable
+    evidence; recall never truncates, ranks, or partially injects facts. *)
 
 val render_context
   :  keepers_dir:string

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -3,6 +3,7 @@ open Alcotest
 module Librarian = Masc.Keeper_librarian
 module Runtime = Masc.Keeper_librarian_runtime
 module Memory = Masc.Keeper_memory_os_types
+module Budget = Masc.Keeper_memory_os_budget
 
 (* Render tests resolve the real repo templates so template <-> code
    variable drift fails here instead of as a live [Prompt_render_failed]
@@ -139,6 +140,21 @@ let test_oversized_selection_is_rejected_without_local_truncation () =
   | Error error ->
     failf "wrong budget error: %s" (Librarian.parse_error_to_string error)
   | Ok _ -> fail "oversized selection was accepted"
+;;
+
+let test_budget_measurement_matches_exact_rendered_utf8_bytes () =
+  let facts =
+    [ fact ~claim:"plain ASCII"
+    ; { (fact ~claim:"한글과 emoji 🧠") with category = Memory.Lesson }
+    ]
+  in
+  let expected = String.length (Budget.render_facts facts) in
+  check int "incremental bytes equal rendered bytes" expected (Budget.rendered_bytes facts);
+  match Budget.measure ~max_bytes:expected facts with
+  | Budget.Fits { actual_bytes; max_bytes } ->
+    check int "measured bytes" expected actual_bytes;
+    check int "boundary is inclusive" expected max_bytes
+  | Budget.Exceeds _ -> fail "exact boundary rejected"
 ;;
 
 let test_unknown_and_duplicate_retained_ids_reject () =
@@ -444,6 +460,10 @@ let () =
             "oversized selection rejects without truncation"
             `Quick
             test_oversized_selection_is_rejected_without_local_truncation
+        ; test_case
+            "incremental budget equals rendered UTF-8 bytes"
+            `Quick
+            test_budget_measurement_matches_exact_rendered_utf8_bytes
         ; test_case "unknown and duplicate retained reject" `Quick
             test_unknown_and_duplicate_retained_ids_reject
         ; test_case "retained/new collision rejects" `Quick

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -50,6 +50,7 @@ let input () : Librarian.input =
   ; current =
       Some
         { Librarian.facts = [ current_a; current_b ] }
+  ; max_recall_fact_bytes = 64 * 1024
   ; messages =
       [ Agent_sdk.Types.make_message
           ~role:Agent_sdk.Types.User
@@ -118,6 +119,26 @@ let test_new_claim_is_materialized_after_retained_facts () =
     check (list string) "retained then new"
       [ "keep A"; "add C" ]
       (List.map (fun (fact : Memory.fact) -> fact.claim) selection.facts)
+;;
+
+let test_oversized_selection_is_rejected_without_local_truncation () =
+  let constrained = { (input ()) with max_recall_fact_bytes = 256 } in
+  let json =
+    selection_json
+      ~retained:[]
+      ~new_claims:[ new_claim ~claim:(String.make 512 'x') () ]
+      ~dropped:[ dropped_json current_a_id; dropped_json current_b_id ]
+      ()
+  in
+  match
+    Librarian.selection_of_json_result ~now:2_000_000. constrained json
+  with
+  | Error (Librarian.Recall_fact_budget_exceeded { actual_bytes; max_bytes }) ->
+    check int "declared budget" 256 max_bytes;
+    check bool "exact rendered payload exceeds budget" true (actual_bytes > max_bytes)
+  | Error error ->
+    failf "wrong budget error: %s" (Librarian.parse_error_to_string error)
+  | Ok _ -> fail "oversized selection was accepted"
 ;;
 
 let test_unknown_and_duplicate_retained_ids_reject () =
@@ -343,6 +364,22 @@ let user_text_of_messages messages =
   |> String.concat "\n"
 ;;
 
+let test_prompt_carries_recall_fact_byte_budget () =
+  let constrained = { (input ()) with max_recall_fact_bytes = 12_345 } in
+  check string "budget variable is exact"
+    "12345"
+    (List.assoc
+       "max_recall_fact_bytes"
+       (Librarian.prompt_variables constrained));
+  match Runtime.messages_for_librarian constrained with
+  | Error detail -> failf "librarian render failed: %s" detail
+  | Ok messages ->
+    check bool "rendered prompt states the capacity" true
+      (String_util.contains_substring
+         (user_text_of_messages messages)
+         "within 12345 UTF-8 bytes")
+;;
+
 let test_repo_template_renders_persona () =
   (match Runtime.messages_for_librarian (input ()) with
    | Error detail -> failf "librarian render failed: %s" detail
@@ -403,6 +440,10 @@ let () =
             test_omission_deletes_and_retention_preserves_exact_fact
         ; test_case "new claim materialized" `Quick
             test_new_claim_is_materialized_after_retained_facts
+        ; test_case
+            "oversized selection rejects without truncation"
+            `Quick
+            test_oversized_selection_is_rejected_without_local_truncation
         ; test_case "unknown and duplicate retained reject" `Quick
             test_unknown_and_duplicate_retained_ids_reject
         ; test_case "retained/new collision rejects" `Quick
@@ -422,6 +463,8 @@ let () =
             test_prompt_contains_exact_current_selection
         ; test_case "prompt carries persona" `Quick
             test_prompt_carries_persona
+        ; test_case "prompt carries recall byte budget" `Quick
+            test_prompt_carries_recall_fact_byte_budget
         ; test_case "repo template renders persona" `Quick
             test_repo_template_renders_persona
         ] )

--- a/test/test_keeper_memory_os_current.ml
+++ b/test/test_keeper_memory_os_current.ml
@@ -284,6 +284,30 @@ let test_recall_preserves_selected_facts_without_local_ranking () =
      | _ -> false)
 ;;
 
+let test_snapshot_write_rejects_rendered_fact_payload_over_budget () =
+  with_temp_keepers @@ fun keepers_dir ->
+  match
+    Current.replace
+      ~max_fact_bytes:128
+      ~keepers_dir
+      ~keeper_id:"keeper"
+      ~expected_revision:None
+      ~now:200.0
+      ~source:(source Current.Explicit_write)
+      ~facts:[ fact ~claim:(String.make 256 'x') () ]
+      ()
+  with
+  | Error message ->
+    check bool "typed boundary detail" true
+      (String_util.contains_substring message "actual_bytes=");
+    check bool "declared budget detail" true
+      (String_util.contains_substring message "max_bytes=128");
+    check bool "no snapshot written" false
+      (Sys.file_exists
+         (Current.path_for_keepers_dir ~keepers_dir ~keeper_id:"keeper"))
+  | Ok _ -> fail "oversized snapshot was committed"
+;;
+
 let test_explicit_upsert_preserves_snapshot_and_records_delta () =
   with_temp_keepers @@ fun keepers_dir ->
   let first = fact ~claim:"first" () in
@@ -557,6 +581,10 @@ let () =
             "recall preserves selected facts and order"
             `Quick
             test_recall_preserves_selected_facts_without_local_ranking
+        ; test_case
+            "snapshot rejects rendered facts over budget"
+            `Quick
+            test_snapshot_write_rejects_rendered_fact_payload_over_budget
         ; test_case
             "explicit upsert preserves snapshot"
             `Quick

--- a/test/test_keeper_memory_os_current.ml
+++ b/test/test_keeper_memory_os_current.ml
@@ -308,6 +308,27 @@ let test_snapshot_write_rejects_rendered_fact_payload_over_budget () =
   | Ok _ -> fail "oversized snapshot was committed"
 ;;
 
+let test_snapshot_write_floors_nonpositive_budget () =
+  with_temp_keepers @@ fun keepers_dir ->
+  match
+    Current.replace
+      ~max_fact_bytes:0
+      ~keepers_dir
+      ~keeper_id:"keeper"
+      ~expected_revision:None
+      ~now:200.0
+      ~source:(source Current.Explicit_write)
+      ~facts:[ fact ~claim:"x" () ]
+      ()
+  with
+  | Error message ->
+    check bool "budget floored to one byte" true
+      (String_util.contains_substring message "max_bytes=1");
+    check bool "invalid zero budget not exposed" false
+      (String_util.contains_substring message "max_bytes=0")
+  | Ok _ -> fail "non-empty snapshot fit within the one-byte floor"
+;;
+
 let test_explicit_upsert_preserves_snapshot_and_records_delta () =
   with_temp_keepers @@ fun keepers_dir ->
   let first = fact ~claim:"first" () in
@@ -585,6 +606,10 @@ let () =
             "snapshot rejects rendered facts over budget"
             `Quick
             test_snapshot_write_rejects_rendered_fact_payload_over_budget
+        ; test_case
+            "snapshot floors nonpositive budget"
+            `Quick
+            test_snapshot_write_floors_nonpositive_budget
         ; test_case
             "explicit upsert preserves snapshot"
             `Quick


### PR DESCRIPTION
## Summary

- bound the exact rendered Memory OS fact payload with a 64 KiB default policy (`MASC_KEEPER_MEMORY_OS_RECALL_FACTS_MAX_BYTES`)
- make Librarian selections over budget fail as typed `Recall_fact_budget_exceeded` results instead of truncating or locally ranking facts
- enforce the same budget at the snapshot write boundary and fail closed on oversized persisted recall state
- clarify the dashboard context card: provider input tokens and serialized request-body bytes are two measurements of the same completed request

## Why

The 2026-07-31 audit measured a small post-cutover snapshot, but that observation was not a lasting capacity invariant. Recall still injected every selected fact, while neither Librarian output nor explicit snapshot writes had a byte boundary.

The dashboard also described exact request wire bytes as a “next input standing payload.” For observed turn T4214, the values were 37,757 provider tokens and 152,302 serialized bytes; they are consistent but use different units and describe the completed request.

## Contract

- The byte policy measures the exact dynamic fact lines: memory ID, category, claim, separators, and newlines.
- The Librarian remains the only semantic selector.
- Oversized output is rejected; no deterministic trimming or ranking is introduced.
- Existing oversized persisted state produces explicit `fact_budget_exceeded` recall evidence rather than partial injection.
- OAS final provider-fit admission remains separate and unchanged.

## Verification

- `scripts/dune-local.sh build test/test_keeper_librarian_retry.exe test/test_keeper_memory_os_current.exe`
- `test_keeper_librarian_retry.exe`: 18/18 passed
- `test_keeper_memory_os_current.exe`: 19/19 passed
- dashboard `keeper-workspace-rail.test.ts`: 41/41 passed
- dashboard `tsc --noEmit --pretty`: passed
- `ocamlformat --check` on touched OCaml files
- `git diff --check`
