### PR TITLE
fix(keeper): remove recursive tool output constraints

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -669,12 +669,12 @@ let run_turn
       s.Keeper_run_tools.model_input_projection
     in
     let model_input_projection messages =
-      (* Bounded transmission view first (RFC #26534 PR-C): the cut never
-         sees gate-replay evidence, which [source_model_input_projection]
-         appends afterwards, and the provenance check below compares against
-         the windowed list so its projected-prefix precondition keeps
-         holding. Durable state and checkpoints receive the unwindowed
-         history. *)
+      (* Bounded transmission view first (RFC #26534 PR-C). The source
+         projection appends only a bounded typed Gate replay reference; exact
+         replay bytes remain in the artifact store. The provenance check below
+         compares against the windowed list so its projected-prefix
+         precondition keeps holding. Durable state and checkpoints receive the
+         unwindowed history. *)
       let windowed = Runtime_model_input_tail_window.project messages in
       match source_model_input_projection windowed with
       | Error _ as error ->

--- a/lib/keeper/keeper_artifact_read.ml
+++ b/lib/keeper/keeper_artifact_read.ml
@@ -1,5 +1,5 @@
-let default_max_bytes = 256
-let maximum_max_bytes = 256
+let default_max_bytes = Common.max_tool_output_bytes
+let maximum_max_bytes = Common.max_tool_output_bytes
 let minimum_max_bytes = 1
 
 type request =
@@ -50,7 +50,12 @@ let request_of_json = function
         | Ok () -> Ok { sha256; offset; max_bytes }
         | Error invalid ->
           Error (Tool_output.invalid_sha256_to_string invalid))
-     | _ -> Error "expected sha256, non-negative offset, and max_bytes 1..256")
+     | _ ->
+       Error
+         (Printf.sprintf
+            "expected sha256, non-negative offset, and max_bytes %d..%d"
+            minimum_max_bytes
+            maximum_max_bytes))
   | _ -> Error "expected an object"
 ;;
 
@@ -124,18 +129,6 @@ let page_of_slice (request : request) ~total_bytes requested_bytes =
       }
 ;;
 
-let page (request : request) bytes =
-  let total_bytes = String.length bytes in
-  let available = max 0 (total_bytes - request.offset) in
-  let requested_length = min request.max_bytes available in
-  let requested_bytes =
-    if request.offset > total_bytes
-    then ""
-    else String.sub bytes request.offset requested_length
-  in
-  page_of_slice request ~total_bytes requested_bytes
-;;
-
 let page_to_json page =
   `Assoc
     [ "ok", `Bool true
@@ -151,6 +144,49 @@ let page_to_json page =
            | Base64 -> "base64") )
     ; "content", `String page.content
     ]
+;;
+
+let page_of_slice_within_output_budget request ~total_bytes requested_bytes =
+  let candidate length =
+    page_of_slice
+      request
+      ~total_bytes
+      (String.sub requested_bytes 0 length)
+  in
+  let fits page =
+    page |> page_to_json |> Yojson.Safe.to_string |> String.length
+    <= Common.max_tool_output_bytes
+  in
+  match candidate 0 with
+  | Error _ as error -> error
+  | Ok empty_page when not (fits empty_page) ->
+    Error "artifact page metadata exceeds the model-output budget"
+  | Ok empty_page ->
+    let rec search low high best =
+      if low > high
+      then Ok best
+      else
+        let midpoint = low + ((high - low) / 2) in
+        match candidate midpoint with
+        | Error _ as error -> error
+        | Ok page ->
+          if fits page
+          then search (midpoint + 1) high page
+          else search low (midpoint - 1) best
+    in
+    search 1 (String.length requested_bytes) empty_page
+;;
+
+let page (request : request) bytes =
+  let total_bytes = String.length bytes in
+  let available = max 0 (total_bytes - request.offset) in
+  let requested_length = min request.max_bytes available in
+  let requested_bytes =
+    if request.offset > total_bytes
+    then ""
+    else String.sub bytes request.offset requested_length
+  in
+  page_of_slice_within_output_budget request ~total_bytes requested_bytes
 ;;
 
 let handle ~base_path ~args =
@@ -169,7 +205,7 @@ let handle ~base_path ~args =
        storage_failure (Tool_blob_store.fetch_error_to_string error)
      | Ok None -> invalid_input "artifact does not exist"
      | Ok (Some { content; total_bytes }) ->
-       (match page_of_slice request ~total_bytes content with
+       (match page_of_slice_within_output_budget request ~total_bytes content with
         | Error message -> invalid_input message
         | Ok page -> Keeper_tool_execution.success_data (page_to_json page)))
 ;;

--- a/lib/keeper/keeper_artifact_read.mli
+++ b/lib/keeper/keeper_artifact_read.mli
@@ -6,6 +6,9 @@
     restores the full artifact into model history. *)
 
 val default_max_bytes : int
+(** The canonical MASC tool-output budget. The returned source slice may be
+    smaller when JSON escaping or base64 expansion would exceed that budget. *)
+
 val maximum_max_bytes : int
 val minimum_max_bytes : int
 

--- a/lib/keeper/keeper_gate_replay.ml
+++ b/lib/keeper/keeper_gate_replay.ml
@@ -432,39 +432,25 @@ let replay_evidence_effect_to_string = function
   | Evidence_indeterminate -> "indeterminate"
 ;;
 
-let replay_evidence_json evidence payload =
+let replay_evidence_json evidence =
   let payload_field =
-    match evidence.effect_kind, payload with
-    | Evidence_applied, `Reference _ -> "untrusted_tool_output_ref"
-    | Evidence_applied, `Hydrated _ -> "untrusted_tool_output"
-    | ( Evidence_applied_with_warning
-      | Evidence_failed
-      | Evidence_indeterminate ),
-      `Reference _ ->
+    match evidence.effect_kind with
+    | Evidence_applied -> "untrusted_tool_output_ref"
+    | Evidence_applied_with_warning | Evidence_failed | Evidence_indeterminate ->
       "detail_ref"
-    | ( Evidence_applied_with_warning
-      | Evidence_failed
-      | Evidence_indeterminate ),
-      `Hydrated _ ->
-      "detail"
-  in
-  let payload =
-    match payload with
-    | `Reference reference ->
-      Tool_output.normalized_artifact_ref_to_json reference
-    | `Hydrated payload -> `String payload
   in
   `Assoc
     [ "approval_id", `String evidence.approval_id
     ; "operation", `String evidence.operation
     ; "effect", `String (replay_evidence_effect_to_string evidence.effect_kind)
     ; "replay_journal", `String (replay_journal_to_string evidence.journal)
-    ; payload_field, payload
+    ; ( payload_field
+      , Tool_output.normalized_artifact_ref_to_json evidence.artifact_ref )
     ]
   |> Yojson.Safe.to_string
 ;;
 
-let replay_evidence_fragment evidence payload =
+let replay_evidence_fragment evidence =
   let heading, instruction =
     match evidence.effect_kind with
     | Evidence_applied ->
@@ -482,14 +468,12 @@ let replay_evidence_fragment evidence payload =
   in
   String.concat
     "\n"
-    [ heading; instruction; replay_evidence_json evidence payload ]
+    [ heading; instruction; replay_evidence_json evidence ]
   |> Inference_utils.sanitize_text_utf8
 ;;
 
 let canonical_replay_evidence_fragment evidence =
-  replay_evidence_fragment
-    evidence
-    (`Reference evidence.artifact_ref)
+  replay_evidence_fragment evidence
 ;;
 
 let replay_model_message
@@ -566,23 +550,9 @@ let append_model_evidence_block evidence blocks =
   @ [ Agent_sdk.Types.Text (canonical_replay_evidence_fragment evidence) ]
 ;;
 
-let project_model_input ~base_path evidence messages =
-  let artifact_ref = evidence.artifact_ref in
-  match retrieve_replay_artifact ~base_path artifact_ref with
-  | Error detail ->
-    Log.Keeper.error
-      "Gate replay evidence hydration failed approval=%s sha256=%s: %s"
-      evidence.approval_id
-      artifact_ref.Tool_output.sha256
-      detail;
-    Ok messages
-  | Ok payload ->
-    let hydrated =
-      replay_evidence_fragment
-        evidence
-        (`Hydrated (Inference_utils.sanitize_text_utf8 payload))
-    in
-    Ok (messages @ [ Agent_sdk.Types.user_msg hydrated ])
+let project_model_input ~base_path:_ evidence messages =
+  let referenced = replay_evidence_fragment evidence in
+  Ok (messages @ [ Agent_sdk.Types.user_msg referenced ])
 ;;
 
 let approved_resolution_message ~approval_id ~tool_name ~input ~user_message =

--- a/lib/keeper/keeper_gate_replay.mli
+++ b/lib/keeper/keeper_gate_replay.mli
@@ -96,12 +96,10 @@ val project_model_input :
   model_evidence ->
   Agent_sdk.Types.message list ->
   (Agent_sdk.Types.message list, string) result
-(** Append the full durable payload as an explicit provider-only message.
-    Canonical history remains reference-only and no text search or replacement
-    decides where evidence is attached. A storage miss is logged and leaves the
-    current input unchanged, matching ordinary artifact hydration. OAS measures
-    and dispatches this same projection; no Keeper byte cap or preview
-    substitutes for the current result. *)
+(** Append the canonical typed artifact reference as an explicit provider-only
+    message. Exact replay bytes remain in durable storage and are read through
+    [keeper_artifact_read], so replay evidence cannot bypass provider-input
+    windowing. *)
 
 val approved_resolution_message :
   approval_id:string ->
@@ -121,7 +119,7 @@ val user_message_with_hitl_resolution :
   model_message
 (** Render a durable HITL resolution that was not freshly replayed in this
     setup. Consumed approvals keep the typed content-addressed reference in
-    canonical state and expose its exact bytes through [project_model_input]. *)
+    canonical state. *)
 
 val compose_model_message :
   base_path:string ->

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -117,6 +117,7 @@ type t =
   ; internal_name : string
   ; description : string
   ; input_schema : Yojson.Safe.t
+  ; model_output_projection : Tool_output.model_projection
   ; policy : policy
   ; executor : executor
   ; backend : backend
@@ -570,6 +571,7 @@ let descriptor_with_public_aliases
       ~internal_name
       ~description
       ~input_schema
+      ?(model_output_projection = Tool_output.default_model_projection)
       ~policy
       ~executor
       ~backend
@@ -607,6 +609,7 @@ let descriptor_with_public_aliases
   ; internal_name
   ; description
   ; input_schema
+  ; model_output_projection
   ; policy
   ; executor
   ; backend
@@ -657,6 +660,10 @@ let descriptor
 
 let with_eval_tags eval_tags descriptor =
   { descriptor with eval_tags }
+;;
+
+let with_model_output_projection model_output_projection descriptor =
+  { descriptor with model_output_projection }
 ;;
 
 let public_descriptors =
@@ -1620,6 +1627,7 @@ let internal_descriptors : t list =
       ~input_schema:artifact_read_schema
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_artifact_read
+    |> with_model_output_projection Tool_output.bounded_inline_model_projection
   ; in_process_descriptor_with_schema_source
       ~keeper_model_projection:Internal_name
       ~input_schema_source:memory_search_schema_source

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -137,6 +137,7 @@ type t =
   ; internal_name : string
   ; description : string
   ; input_schema : Yojson.Safe.t
+  ; model_output_projection : Tool_output.model_projection
   ; policy : policy
   ; executor : executor
   ; backend : backend

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -23,7 +23,7 @@ let completion_boundary_of_runtime_handler = function
 
 let terminal_externalization_failure
       state
-      ({ message } : Tool_bridge.externalization_error)
+      ({ message; _ } : Tool_bridge.externalization_error)
   =
   match state with
   | Keeper_tools_oas.Terminal_effect_completed ->

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -268,6 +268,7 @@ let make_tool_bundle
              in
              Tool_bridge.oas_tool_of_masc_with_execution_env
                ~base_path:config.base_path
+               ~model_projection:descriptor.model_output_projection
                ?on_externalization_error
                ~externalization_error_recoverable:descriptor.policy.retryable
                ~name:model_name

--- a/lib/tool_blob_store/tool_output.ml
+++ b/lib/tool_blob_store/tool_output.ml
@@ -112,6 +112,16 @@ type t =
   | Inline of string
   | Stored of artifact_ref
 
+type model_projection =
+  | Store_above of { threshold_bytes : int }
+  | Inline_up_to of { maximum_bytes : int }
+
+let default_model_projection =
+  Store_above { threshold_bytes = Common.max_tool_output_bytes }
+
+let bounded_inline_model_projection =
+  Inline_up_to { maximum_bytes = Common.max_tool_output_bytes }
+
 let marker_prefix = "[masc:blob "
 
 let is_marker s = String.starts_with ~prefix:marker_prefix s

--- a/lib/tool_blob_store/tool_output.mli
+++ b/lib/tool_blob_store/tool_output.mli
@@ -74,6 +74,19 @@ type t =
   | Inline of string
   | Stored of artifact_ref
 
+(** Model-visible projection is owned by the tool descriptor, rather than
+    inferred from the tool name or from a bridge-wide magic threshold. *)
+type model_projection =
+  | Store_above of { threshold_bytes : int }
+  | Inline_up_to of { maximum_bytes : int }
+
+val default_model_projection : model_projection
+(** Store results larger than the canonical MASC tool-output budget. *)
+
+val bounded_inline_model_projection : model_projection
+(** Keep a result inline only while it remains inside that same canonical
+    tool-output budget. This is for explicit artifact-page readers. *)
+
 val marker_prefix : string
 val is_marker : string -> bool
 

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -43,7 +43,7 @@ module Float = Stdlib.Float
     projection capability-aware: runtimes that do not also expose an artifact
     reader cannot accidentally replace exact output with an unreadable marker. *)
 
-let default_externalize_threshold_bytes = 2048
+let default_externalize_threshold_bytes = Common.max_tool_output_bytes
 
 type externalization_error = { message : string }
 
@@ -56,10 +56,11 @@ let resolve_blob_store ?base_path () =
     available; otherwise pass through unchanged. A configured store that
     cannot persist the bytes returns a typed error: putting the oversized
     payload back on the provider wire would defeat this boundary. *)
-let maybe_externalize ?base_path ?(mime = "text/plain") (msg : string)
+let maybe_externalize ?base_path ?(mime = "text/plain")
+      ?(threshold_bytes = default_externalize_threshold_bytes) (msg : string)
   : (string, externalization_error) result
   =
-  if String.length msg <= default_externalize_threshold_bytes then Ok msg
+  if String.length msg <= threshold_bytes then Ok msg
   else
     match resolve_blob_store ?base_path () with
     | None -> Ok msg
@@ -84,8 +85,21 @@ let make_tool_error ?(recoverable = false) ?error_class message
   : Agent_sdk.Types.tool_result =
   Error { Agent_sdk.Types.message; recoverable; error_class }
 
-let project_content ?base_path message =
-  maybe_externalize ?base_path message
+let project_content ?base_path ~model_projection message =
+  match model_projection with
+  | Tool_output.Store_above { threshold_bytes } ->
+    maybe_externalize ?base_path ~threshold_bytes message
+  | Tool_output.Inline_up_to { maximum_bytes } ->
+    if String.length message <= maximum_bytes
+    then Ok message
+    else
+      Error
+        { message =
+            Printf.sprintf
+              "inline tool output exceeds descriptor budget (%d > %d bytes)"
+              (String.length message)
+              maximum_bytes
+        }
 ;;
 
 let externalization_tool_error ~recoverable _error =
@@ -125,11 +139,12 @@ let project_result
       ?base_path
       ?on_externalization_error
       ~externalization_error_recoverable
+      ~model_projection
       message
       on_content
   : Agent_sdk.Types.tool_result
   =
-  match project_content ?base_path message with
+  match project_content ?base_path ~model_projection message with
   | Ok content -> on_content content
   | Error error ->
     Option.iter (fun observe -> observe error) on_externalization_error;
@@ -140,6 +155,7 @@ let project_result
 
 let to_oas_typed_result
       ?base_path
+      ?(model_projection = Tool_output.default_model_projection)
       ?on_externalization_error
       ?(externalization_error_recoverable = true)
       (tr : Tool_result.result)
@@ -151,6 +167,7 @@ let to_oas_typed_result
       ?base_path
       ?on_externalization_error
       ~externalization_error_recoverable
+      ~model_projection
       (Tool_result.message tr)
       (fun content ->
          Ok { Agent_sdk.Types.content; _meta = output.metadata })
@@ -168,6 +185,7 @@ let to_oas_typed_result
       ?base_path
       ?on_externalization_error
       ~externalization_error_recoverable
+      ~model_projection
       (Tool_result.message tr)
       (fun content ->
          Ok { Agent_sdk.Types.content; _meta = Some metadata })
@@ -176,6 +194,7 @@ let to_oas_typed_result
       ?base_path
       ?on_externalization_error
       ~externalization_error_recoverable
+      ~model_projection
       message
       (fun message ->
        make_tool_error
@@ -198,6 +217,7 @@ let to_oas_typed_result
 let oas_tool_of_masc
     ?descriptor
     ?base_path
+    ?model_projection
     ?on_externalization_error
     ?externalization_error_recoverable
     ~name
@@ -208,6 +228,7 @@ let oas_tool_of_masc
   let oas_handler json_args =
     to_oas_typed_result
       ?base_path
+      ?model_projection
       ?on_externalization_error
       ?externalization_error_recoverable
       (handler json_args)
@@ -217,6 +238,7 @@ let oas_tool_of_masc
 let oas_tool_of_masc_with_execution_env
     ?descriptor
     ?base_path
+    ?model_projection
     ?on_externalization_error
     ?externalization_error_recoverable
     ~name
@@ -229,6 +251,7 @@ let oas_tool_of_masc_with_execution_env
   let oas_handler execution_env json_args =
     to_oas_typed_result
       ?base_path
+      ?model_projection
       ?on_externalization_error
       ?externalization_error_recoverable
       (handler execution_env json_args)

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -45,7 +45,14 @@ module Float = Stdlib.Float
 
 let default_externalize_threshold_bytes = Common.max_tool_output_bytes
 
-type externalization_error = { message : string }
+type projection_error_kind =
+  | Artifact_storage_failure
+  | Inline_budget_exceeded
+
+type externalization_error =
+  { kind : projection_error_kind
+  ; message : string
+  }
 
 let resolve_blob_store ?base_path () =
   match base_path with
@@ -77,7 +84,7 @@ let maybe_externalize ?base_path ?(mime = "text/plain")
         | exn ->
           let message = Printexc.to_string exn in
           Log.Misc.error "tool_bridge: blob externalization failed: %s" message;
-          Error { message })
+          Error { kind = Artifact_storage_failure; message })
 
 (** {1 Result Conversion} *)
 
@@ -94,7 +101,8 @@ let project_content ?base_path ~model_projection message =
     then Ok message
     else
       Error
-        { message =
+        { kind = Inline_budget_exceeded
+        ; message =
             Printf.sprintf
               "inline tool output exceeds descriptor budget (%d > %d bytes)"
               (String.length message)
@@ -102,14 +110,21 @@ let project_content ?base_path ~model_projection message =
         }
 ;;
 
-let externalization_tool_error ~recoverable _error =
-  make_tool_error
-    ~recoverable
-    ~error_class:
-      (if recoverable
-       then Agent_sdk.Types.Transient
-       else Agent_sdk.Types.Unknown)
-    "tool output artifact storage failed"
+let externalization_tool_error ~recoverable error =
+  match error.kind with
+  | Artifact_storage_failure ->
+    make_tool_error
+      ~recoverable
+      ~error_class:
+        (if recoverable
+         then Agent_sdk.Types.Transient
+         else Agent_sdk.Types.Unknown)
+      "tool output artifact storage failed"
+  | Inline_budget_exceeded ->
+    make_tool_error
+      ~recoverable:false
+      ~error_class:Agent_sdk.Types.Deterministic
+      "tool output exceeds descriptor budget"
 ;;
 
 let oas_error_class_of_tool_failure_class = function

--- a/lib/tool_bridge.mli
+++ b/lib/tool_bridge.mli
@@ -21,18 +21,19 @@
     Blob bytes and their parent directory are synced before the marker is
     returned, so a later durable checkpoint cannot get ahead of its artifact.
 
-    Disabled unless the caller supplies [base_path]. The storage threshold is
-    a single compile-time producer contract; there is no ambient environment
-    projection policy. *)
+    Disabled unless the caller supplies [base_path]. Each model-visible tool
+    descriptor owns its typed projection policy; the default uses MASC's
+    canonical tool-output budget. *)
 
 val default_externalize_threshold_bytes : int
-(** Compile-time storage threshold. *)
+(** Canonical MASC tool-output budget used by the default projection. *)
 
 type externalization_error = { message : string }
 
 val maybe_externalize :
   ?base_path:string ->
   ?mime:string ->
+  ?threshold_bytes:int ->
   string ->
   (string, externalization_error) result
 (** Externalize when over threshold and a blob store is available;
@@ -43,6 +44,7 @@ val maybe_externalize :
 
 val to_oas_typed_result :
   ?base_path:string ->
+  ?model_projection:Tool_output.model_projection ->
   ?on_externalization_error:(externalization_error -> unit) ->
   ?externalization_error_recoverable:bool ->
   Tool_result.result ->
@@ -68,6 +70,7 @@ val params_of_json_schema : Yojson.Safe.t -> Agent_sdk.Types.tool_param list
 val oas_tool_of_masc :
   ?descriptor:Agent_sdk.Tool.descriptor ->
   ?base_path:string ->
+  ?model_projection:Tool_output.model_projection ->
   ?on_externalization_error:(externalization_error -> unit) ->
   ?externalization_error_recoverable:bool ->
   name:string ->
@@ -89,6 +92,7 @@ val oas_tool_of_masc :
 val oas_tool_of_masc_with_execution_env :
   ?descriptor:Agent_sdk.Tool.descriptor ->
   ?base_path:string ->
+  ?model_projection:Tool_output.model_projection ->
   ?on_externalization_error:(externalization_error -> unit) ->
   ?externalization_error_recoverable:bool ->
   name:string ->

--- a/lib/tool_bridge.mli
+++ b/lib/tool_bridge.mli
@@ -28,7 +28,14 @@
 val default_externalize_threshold_bytes : int
 (** Canonical MASC tool-output budget used by the default projection. *)
 
-type externalization_error = { message : string }
+type projection_error_kind =
+  | Artifact_storage_failure
+  | Inline_budget_exceeded
+
+type externalization_error =
+  { kind : projection_error_kind
+  ; message : string
+  }
 
 val maybe_externalize :
   ?base_path:string ->

--- a/test/test_keeper_gate_replay.ml
+++ b/test/test_keeper_gate_replay.ml
@@ -356,12 +356,21 @@ let test_applied_replay_result_is_model_visible () =
          |> List.hd
          |> Yojson.Safe.from_string
        in
-       Alcotest.check
-         Alcotest.string
-         "exact replay evidence reaches the current provider turn"
-         output
-         Yojson.Safe.Util.(
-           evidence |> member "untrusted_tool_output" |> to_string);
+       (match
+          evidence
+          |> Yojson.Safe.Util.member "untrusted_tool_output_ref"
+          |> Tool_output.normalized_artifact_ref_of_json
+        with
+        | Tool_output.Decoded_normalized_artifact_ref decoded ->
+          Alcotest.check
+            Alcotest.string
+            "replay reference reaches the current provider turn"
+            output_ref.sha256
+            decoded.sha256
+        | Tool_output.Not_normalized_artifact_ref ->
+          Alcotest.fail "provider replay evidence lost its artifact reference"
+        | Tool_output.Invalid_normalized_artifact_ref { detail } ->
+          Alcotest.fail detail);
        Alcotest.check
          Alcotest.bool
          "current model turn cannot request the approved effect again"
@@ -371,7 +380,7 @@ let test_applied_replay_result_is_model_visible () =
             "Do not request the approved operation again"))
 ;;
 
-let test_large_replay_result_reaches_model_exactly () =
+let test_large_replay_result_stays_reference_only () =
   let base_path = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_path)
@@ -462,20 +471,29 @@ let test_large_replay_result_reaches_model_exactly () =
          |> List.find (fun line -> not (String.equal (String.trim line) ""))
          |> Yojson.Safe.from_string
        in
-       Alcotest.check
-         Alcotest.string
-         "provider projection receives the full exact replay payload"
-         raw_output
-         Yojson.Safe.Util.(
-           projected_evidence |> member "untrusted_tool_output" |> to_string);
+       (match
+          projected_evidence
+          |> Yojson.Safe.Util.member "untrusted_tool_output_ref"
+          |> Tool_output.normalized_artifact_ref_of_json
+        with
+        | Tool_output.Decoded_normalized_artifact_ref decoded ->
+          Alcotest.check
+            Alcotest.string
+            "provider projection keeps the exact artifact identity"
+            artifact.sha256
+            decoded.sha256
+        | Tool_output.Not_normalized_artifact_ref ->
+          Alcotest.fail "provider projection lost the replay reference"
+        | Tool_output.Invalid_normalized_artifact_ref { detail } ->
+          Alcotest.fail detail);
        Alcotest.check
          Alcotest.bool
-         "provider projection does not substitute a preview marker"
+         "provider projection does not hydrate the large replay payload"
          false
-         (String_util.contains_substring projected Tool_output.marker_prefix))
+         (String_util.contains_substring projected "LARGE-REPLAY-END"))
 ;;
 
-let test_multimodal_goal_projects_exact_replay_evidence () =
+let test_multimodal_goal_projects_replay_reference () =
   let base_path = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_path)
@@ -540,7 +558,7 @@ let test_multimodal_goal_projects_exact_replay_evidence () =
               Alcotest.bool
               "media block survives replay projection"
               true
-              (String_util.contains_substring evidence_text raw_output)
+              (not (String_util.contains_substring evidence_text raw_output))
           | _ ->
             Alcotest.fail
               "multimodal projection did not preserve canonical media and append replay evidence")
@@ -591,11 +609,11 @@ let test_replay_projection_recovers_when_canonical_reference_is_absent () =
            (Agent_sdk.Types.text_of_content original.content);
          Alcotest.check
            Alcotest.bool
-           "exact replay evidence is appended independently of text layout"
+           "replay reference is appended independently of text layout"
            true
            (String_util.contains_substring
               (Agent_sdk.Types.text_of_content recovered.content)
-              "available exact output")
+              artifact.sha256)
        | Ok _ ->
          Alcotest.fail
            "replay recovery did not append one exact provider message")
@@ -772,13 +790,13 @@ let () =
             `Quick
             test_applied_replay_result_is_model_visible
         ; Alcotest.test_case
-            "large result reaches exact provider projection"
+            "large result stays reference-only"
             `Quick
-            test_large_replay_result_reaches_model_exactly
+            test_large_replay_result_stays_reference_only
         ; Alcotest.test_case
-            "multimodal goal projects exact replay evidence"
+            "multimodal goal projects replay reference"
             `Quick
-            test_multimodal_goal_projects_exact_replay_evidence
+            test_multimodal_goal_projects_replay_reference
         ; Alcotest.test_case
             "canonical reference layout does not control projection"
             `Quick

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -299,7 +299,9 @@ let test_terminal_externalization_failure_contract () =
     Masc.Keeper_tools_oas_bundle.For_testing.terminal_externalization_failure
   in
   let error : Masc.Tool_bridge.externalization_error =
-    { message = "disk unavailable" }
+    { kind = Masc.Tool_bridge.Artifact_storage_failure
+    ; message = "disk unavailable"
+    }
   in
   List.iter
     (fun state ->

--- a/test/test_tool_bridge_externalize.ml
+++ b/test/test_tool_bridge_externalize.ml
@@ -18,7 +18,7 @@ module O = Tool_output
 let externalize_exn ?base_path value =
   match B.maybe_externalize ?base_path value with
   | Ok output -> output
-  | Error { message } -> Alcotest.fail message
+  | Error { message; _ } -> Alcotest.fail message
 
 let tool_ok ?(tool_name = "") message =
   Tool_result.make_ok ~tool_name ~start_time:0.0 ~data:(`String message) ()
@@ -91,11 +91,15 @@ let test_bounded_inline_rejects_oversized_result () =
       (tool_ok ~tool_name:"keeper_artifact_read" payload)
   with
   | Ok _ -> Alcotest.fail "oversized bounded-inline result was accepted"
-  | Error { message; _ } ->
+  | Error { message; recoverable; error_class } ->
     Alcotest.(check string)
       "provider receives bounded projection failure"
-      "tool output artifact storage failed"
-      message
+      "tool output exceeds descriptor budget"
+      message;
+    Alcotest.(check bool) "bounded projection is not retryable" false recoverable;
+    (match error_class with
+     | Some Agent_sdk.Types.Deterministic -> ()
+     | _ -> Alcotest.fail "bounded projection failure is not deterministic")
 
 let test_artifact_reader_owns_inline_projection () =
   let descriptor =
@@ -316,7 +320,7 @@ let test_blob_store_failure_is_typed () =
       in
       (match B.maybe_externalize ~base_path:path payload with
        | Ok _ -> Alcotest.fail "failed store returned provider content"
-       | Error { message } ->
+       | Error { message; _ } ->
          Alcotest.(check bool)
            "storage failure is visible"
            true
@@ -325,7 +329,7 @@ let test_blob_store_failure_is_typed () =
       (match
          B.to_oas_typed_result
            ~base_path:path
-           ~on_externalization_error:(fun { message } ->
+           ~on_externalization_error:(fun { message; _ } ->
              observed := Some message)
            (tool_ok ~tool_name:"test" payload)
        with

--- a/test/test_tool_bridge_externalize.ml
+++ b/test/test_tool_bridge_externalize.ml
@@ -56,7 +56,7 @@ let test_threshold_default_under () =
   let small = "short payload" in
   let result = externalize_exn small in
   Alcotest.(check string) "small unchanged" small result;
-  let large = String.make 8192 'x' in
+  let large = String.make (B.default_externalize_threshold_bytes + 1) 'x' in
   let result_large = externalize_exn large in
   Alcotest.(check string) "large unchanged when no base path" large result_large
 
@@ -70,9 +70,52 @@ let test_to_oas_typed_small_inlined () =
       Alcotest.(check bool) "no marker" false (O.is_marker content)
   | Error _ -> Alcotest.fail "expected Ok"
 
+let test_incident_sized_result_stays_inline () =
+  with_temp_base_path (fun dir ->
+    let payload = String.make 2_500 'w' in
+    match
+      B.to_oas_typed_result
+        ~base_path:dir
+        (tool_ok ~tool_name:"WebSearch" payload)
+    with
+    | Ok { content; _ } ->
+      Alcotest.(check string) "2.5KB result stays inline" payload content;
+      Alcotest.(check bool) "no blob marker" false (O.is_marker content)
+    | Error _ -> Alcotest.fail "expected inline result")
+
+let test_bounded_inline_rejects_oversized_result () =
+  let payload = String.make (B.default_externalize_threshold_bytes + 1) 'x' in
+  match
+    B.to_oas_typed_result
+      ~model_projection:Tool_output.bounded_inline_model_projection
+      (tool_ok ~tool_name:"keeper_artifact_read" payload)
+  with
+  | Ok _ -> Alcotest.fail "oversized bounded-inline result was accepted"
+  | Error { message; _ } ->
+    Alcotest.(check string)
+      "provider receives bounded projection failure"
+      "tool output artifact storage failed"
+      message
+
+let test_artifact_reader_owns_inline_projection () =
+  let descriptor =
+    Masc.Keeper_tool_descriptor.all_descriptors ()
+    |> List.find_opt (fun (descriptor : Masc.Keeper_tool_descriptor.t) ->
+      String.equal descriptor.internal_name "keeper_artifact_read")
+  in
+  match descriptor with
+  | None -> Alcotest.fail "artifact reader descriptor is missing"
+  | Some { model_output_projection = Tool_output.Inline_up_to { maximum_bytes }; _ } ->
+    Alcotest.(check int)
+      "artifact reader uses canonical output budget"
+      B.default_externalize_threshold_bytes
+      maximum_bytes
+  | Some { model_output_projection = Tool_output.Store_above _; _ } ->
+    Alcotest.fail "artifact reader can still create a nested blob"
+
 let test_tool_identity_does_not_bypass_externalization () =
   with_temp_base_path (fun dir ->
-    let payload = String.make 5_000 'b' in
+    let payload = String.make (B.default_externalize_threshold_bytes + 1) 'b' in
     let check_tool tool_name =
       match
         B.to_oas_typed_result
@@ -206,7 +249,9 @@ let test_execution_env_preserves_exact_invocation () =
 
 let test_externalize_with_temp_base_path () =
   with_temp_base_path (fun dir ->
-      let payload = String.make 4096 'z' in
+      let payload =
+        String.make (B.default_externalize_threshold_bytes + 1) 'z'
+      in
       let result = externalize_exn ~base_path:dir payload in
       Alcotest.(check bool) "encoded as marker" true (O.is_marker result);
       match O.decode_from_oas result with
@@ -231,7 +276,7 @@ let test_bounded_read_page_is_not_nested () =
       match
         Masc.Keeper_artifact_read.For_testing.page
           request
-          (String.make 4_096 '\000')
+          (String.make Masc.Keeper_artifact_read.maximum_max_bytes '\000')
       with
       | Ok page -> page
       | Error error -> Alcotest.fail error
@@ -245,10 +290,20 @@ let test_bounded_read_page_is_not_nested () =
       "worst-case bounded page fits inline contract"
       true
       (String.length output <= B.default_externalize_threshold_bytes);
+    Alcotest.(check bool)
+      "page advances beyond the removed 256-byte workaround"
+      true
+      (page.next_offset > 256);
     Alcotest.(check string)
       "bounded page remains provider-visible"
       output
-      (externalize_exn output))
+      (match
+         B.to_oas_typed_result
+           ~model_projection:Tool_output.bounded_inline_model_projection
+           (tool_ok ~tool_name:"keeper_artifact_read" output)
+       with
+       | Ok { content; _ } -> content
+       | Error { message; _ } -> Alcotest.fail message))
 
 let test_blob_store_failure_is_typed () =
   let path = Filename.temp_file "masc_bridge_not_a_directory" "" in
@@ -256,7 +311,9 @@ let test_blob_store_failure_is_typed () =
   Fun.protect
     ~finally:restore
     (fun () ->
-      let payload = String.make 4_096 '\000' in
+      let payload =
+        String.make (B.default_externalize_threshold_bytes + 1) '\000'
+      in
       (match B.maybe_externalize ~base_path:path payload with
        | Ok _ -> Alcotest.fail "failed store returned provider content"
        | Error { message } ->
@@ -316,6 +373,12 @@ let () =
       ( "to_oas_typed_result",
         [
           Alcotest.test_case "small inlined" `Quick test_to_oas_typed_small_inlined;
+          Alcotest.test_case "2.5KB result stays inline" `Quick
+            test_incident_sized_result_stays_inline;
+          Alcotest.test_case "bounded inline rejects oversize" `Quick
+            test_bounded_inline_rejects_oversized_result;
+          Alcotest.test_case "artifact reader owns inline projection" `Quick
+            test_artifact_reader_owns_inline_projection;
           Alcotest.test_case "tool name does not bypass externalization" `Quick
             test_tool_identity_does_not_bypass_externalization;
           Alcotest.test_case "error inlined" `Quick test_to_oas_typed_error_inlined;

--- a/test/test_tool_output_washing_e2e.ml
+++ b/test/test_tool_output_washing_e2e.ml
@@ -24,11 +24,11 @@ module R = Masc.Keeper_artifact_read
 module E = Masc.Keeper_tool_execution
 module T = Agent_sdk.Types
 
-let project_completed_exn ~base_path ~tool_name data =
+let project_completed_exn ?model_projection ~base_path ~tool_name data =
   let result =
     Tool_result.make_ok ~tool_name ~start_time:0.0 ~data ()
   in
-  match Bridge.to_oas_typed_result ~base_path result with
+  match Bridge.to_oas_typed_result ?model_projection ~base_path result with
   | Ok { content; _ } -> content
   | Error { message; _ } -> Alcotest.fail message
 
@@ -70,6 +70,25 @@ let test_artifact_page_makes_progress () =
     | Error error -> Alcotest.fail error
   in
   let emoji = "\240\159\152\128x" in
+  let incident_sized_payload = String.make 2_500 'w' in
+  let default_request =
+    match
+      R.For_testing.request_of_json
+        (`Assoc [ "sha256", `String (String.make 64 'a') ])
+    with
+    | Ok request -> request
+    | Error error -> Alcotest.fail error
+  in
+  let incident_page =
+    match R.For_testing.page default_request incident_sized_payload with
+    | Ok page -> page
+    | Error error -> Alcotest.fail error
+  in
+  Alcotest.(check int)
+    "2.5KB artifact completes in one default page"
+    (String.length incident_sized_payload)
+    incident_page.next_offset;
+  Alcotest.(check bool) "2.5KB default page reaches EOF" true incident_page.eof;
   let utf8_page =
     match R.For_testing.page (request 0 4) emoji with
     | Ok page -> page
@@ -189,8 +208,8 @@ let test_full_flow_externalize_reference_serve () =
         (String.equal payload projected_content);
 
       (* Step 6: The model-visible read tool resolves only the explicit
-         requested page. Its bounded typed JSON remains inline, so the generic
-         bridge cannot turn it into a nested artifact reference. *)
+         requested page. Its descriptor-owned bounded-inline projection cannot
+         turn it into a nested artifact reference. *)
       let read_result =
         R.handle
           ~base_path:dir
@@ -207,6 +226,7 @@ let test_full_flow_externalize_reference_serve () =
          Alcotest.fail "explicit artifact read did not complete");
       let read_output =
         project_completed_exn
+          ~model_projection:Tool_output.bounded_inline_model_projection
           ~base_path:dir
           ~tool_name:"keeper_artifact_read"
           (Option.value
@@ -263,7 +283,10 @@ let test_full_flow_externalize_reference_serve () =
         project_completed_exn
           ~base_path:dir
           ~tool_name:"Execute"
-          (`String (String.make 4_096 'z'))
+          (`String
+            (String.make
+               (Bridge.default_externalize_threshold_bytes + 1)
+               'z'))
       in
       let second_sha =
         match O.decode_from_oas second_marker with


### PR DESCRIPTION
## Summary\n- replace the bridge-wide 2 KB externalization workaround with descriptor-owned typed model-output projection using the canonical 64 KB tool-output budget\n- let keeper_artifact_read return the largest wire-safe page up to that budget, avoiding nested blob references and 256-byte paging\n- keep Gate replay evidence reference-only at the provider boundary so exact replay bytes cannot bypass input windowing\n- classify descriptor inline-budget violations as deterministic/non-retryable while preserving typed retry policy for artifact-storage failures\n\n## Verification\n- MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_tool_bridge_externalize.exe test/test_tool_output_washing_e2e.exe test/test_keeper_gate_replay.exe test/test_keeper_turn_outcome.exe\n- _build/default/test/test_tool_bridge_externalize.exe (15 passed)\n- _build/default/test/test_tool_output_washing_e2e.exe (3 passed)\n- _build/default/test/test_keeper_gate_replay.exe (22 passed)\n- _build/default/test/test_keeper_turn_outcome.exe (25 passed)\n- git diff --check