### PR TITLE
fix schedule timezone input and result evidence

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -196,21 +196,13 @@ let record_replay_owned_turn_started_reactions ~ctx ~keeper_name stimuli =
     stimuli
 ;;
 
-let complete_schedule_due ~ctx ~keeper_name stimuli =
+let complete_schedule_due ~ctx ~keeper_name:_ stimuli =
   let now = Time_compat.now () in
   let rec loop = function
     | [] -> Ok ()
     | (stimulus : Keeper_event_queue.stimulus) :: rest ->
       (match stimulus.payload with
        | Keeper_event_queue.Schedule_due wake ->
-         let detail =
-           `Assoc
-             [ "kind", `String "keeper.turn_terminal"
-             ; "keeper_name", `String keeper_name
-             ; "occurrence_id", `String stimulus.post_id
-             ; "outcome", `String "succeeded"
-             ]
-         in
          (match
             Schedule_store.complete_dispatched_occurrence
               ctx.config
@@ -218,7 +210,6 @@ let complete_schedule_due ~ctx ~keeper_name stimuli =
               ~schedule_id:wake.schedule_id
               ~due_at:wake.due_at
               ~payload_digest:wake.payload_digest
-              ~detail
               ()
           with
           | Ok _ -> loop rest

--- a/lib/schedule/schedule_store.ml
+++ b/lib/schedule/schedule_store.ml
@@ -660,7 +660,6 @@ let complete_dispatched_occurrence
       ~schedule_id
       ~due_at
       ~payload_digest
-      ?detail
       () =
   Workspace_utils.with_file_lock config (schedules_path config) (fun () ->
     let* state = load_for_mutation config in
@@ -704,7 +703,6 @@ let complete_dispatched_occurrence
              { execution with
                status = Execution_succeeded
              ; finished_at = Some now
-             ; detail
              ; error = None
              })
       in

--- a/lib/schedule/schedule_store.mli
+++ b/lib/schedule/schedule_store.mli
@@ -174,12 +174,12 @@ val complete_dispatched_occurrence :
   schedule_id:string ->
   due_at:float ->
   payload_digest:string ->
-  ?detail:Yojson.Safe.t ->
   unit ->
   (Schedule_domain.schedule_request, store_error) result
 (** Marks one exact running/dispatched occurrence succeeded. Idempotent when
     that occurrence is already succeeded. A one-shot request becomes
-    [Succeeded]; an already-advanced recurring request keeps its next due row. *)
+    [Succeeded]; an already-advanced recurring request keeps its next due row.
+    The original dispatch receipt in the execution detail is preserved. *)
 
 val fail_dispatched_occurrence :
   Workspace_utils.config ->

--- a/lib/tool_schedule.ml
+++ b/lib/tool_schedule.ml
@@ -25,13 +25,135 @@ let required_string args key =
 let optional_float args key = Json_util.get_float args key
 let optional_int args key = Json_util.get_int args key
 
+let all_digits value start length =
+  let rec loop index =
+    index = start + length
+    ||
+    match value.[index] with
+    | '0' .. '9' -> loop (index + 1)
+    | _ -> false
+  in
+  length > 0 && start >= 0 && start + length <= String.length value && loop start
+;;
+
+let int_component value start length =
+  if all_digits value start length
+  then Some (int_of_string (String.sub value start length))
+  else None
+;;
+
+let is_leap_year year = year mod 4 = 0 && (year mod 100 <> 0 || year mod 400 = 0)
+
+let days_in_month ~year = function
+  | 1 | 3 | 5 | 7 | 8 | 10 | 12 -> 31
+  | 4 | 6 | 9 | 11 -> 30
+  | 2 -> if is_leap_year year then 29 else 28
+  | _ -> 0
+;;
+
+(* Gregorian civil date to days since 1970-01-01. The arithmetic is independent
+   of the host timezone, unlike [Unix.mktime]. *)
+let days_since_unix_epoch ~year ~month ~day =
+  let adjusted_year = if month <= 2 then year - 1 else year in
+  let era = adjusted_year / 400 in
+  let year_of_era = adjusted_year - (era * 400) in
+  let shifted_month = month + if month > 2 then -3 else 9 in
+  let day_of_year = (((153 * shifted_month) + 2) / 5) + day - 1 in
+  let day_of_era =
+    (year_of_era * 365) + (year_of_era / 4) - (year_of_era / 100) + day_of_year
+  in
+  (era * 146097) + day_of_era - 719468
+;;
+
+let parse_iso8601_zone value =
+  if String.equal value "Z"
+  then Some 0
+  else if String.length value = 6 && (value.[0] = '+' || value.[0] = '-')
+          && value.[3] = ':'
+  then
+    match int_component value 1 2, int_component value 4 2 with
+    | Some hour, Some minute when hour <= 23 && minute <= 59 ->
+      let seconds = ((hour * 60) + minute) * 60 in
+      Some (if value.[0] = '+' then seconds else -seconds)
+    | _ -> None
+  else None
+;;
+
+let parse_iso8601_suffix suffix =
+  if String.length suffix > 0 && suffix.[0] = '.'
+  then
+    let rec fraction_end index =
+      if index >= String.length suffix
+      then index
+      else
+        match suffix.[index] with
+        | '0' .. '9' -> fraction_end (index + 1)
+        | _ -> index
+    in
+    let zone_start = fraction_end 1 in
+    if zone_start = 1 || zone_start = String.length suffix
+    then None
+    else
+      let fraction = float_of_string_opt ("0" ^ String.sub suffix 0 zone_start) in
+      let zone = String.sub suffix zone_start (String.length suffix - zone_start) in
+      (match fraction, parse_iso8601_zone zone with
+       | Some fraction, Some offset -> Some (fraction, offset)
+       | _ -> None)
+  else Option.map (fun offset -> 0.0, offset) (parse_iso8601_zone suffix)
+;;
+
+let parse_due_at_iso8601 value =
+  if String.length value < 20
+     || value.[4] <> '-'
+     || value.[7] <> '-'
+     || value.[10] <> 'T'
+     || value.[13] <> ':'
+     || value.[16] <> ':'
+  then None
+  else
+    match
+      int_component value 0 4,
+      int_component value 5 2,
+      int_component value 8 2,
+      int_component value 11 2,
+      int_component value 14 2,
+      int_component value 17 2,
+      parse_iso8601_suffix (String.sub value 19 (String.length value - 19))
+    with
+    | ( Some year,
+        Some month,
+        Some day,
+        Some hour,
+        Some minute,
+        Some second,
+        Some (fraction, offset_seconds) )
+      when year >= 1
+           && month >= 1
+           && month <= 12
+           && day >= 1
+           && day <= days_in_month ~year month
+           && hour <= 23
+           && minute <= 59
+           && second <= 59 ->
+      let local_seconds =
+        (days_since_unix_epoch ~year ~month ~day * 86400)
+        + (hour * 3600)
+        + (minute * 60)
+        + second
+      in
+      Some ((float_of_int (local_seconds - offset_seconds)) +. fraction)
+    | _ -> None
+;;
+
 let parse_due_at args =
   match optional_float args "due_at_unix", string_opt args "due_at_iso" with
   | Some due_at, _ -> Ok (Some due_at)
   | None, Some iso ->
-    (match Masc_domain.parse_iso8601_opt iso with
+    (match parse_due_at_iso8601 iso with
      | Some due_at -> Ok (Some due_at)
-     | None -> Error "due_at_iso must be a parseable ISO-8601 timestamp")
+     | None ->
+       Error
+         "due_at_iso must be YYYY-MM-DDTHH:MM:SS[.fraction]Z or include an explicit offset such as +09:00")
   | None, None -> Ok None
 ;;
 

--- a/lib/tool_schemas/tool_schemas_schedule.ml
+++ b/lib/tool_schemas/tool_schemas_schedule.ml
@@ -90,7 +90,7 @@ let create_schema =
         "due_at_unix"
     ; string_prop
         ~description:
-          "ISO-8601 timestamp. Provide this, due_at_unix, or a calendar recurrence (daily/cron) that can derive the first due time."
+          "ISO-8601 timestamp with Z or an explicit numeric offset, for example 2026-08-02T09:00:00+09:00. It is normalized to UTC. Provide this, due_at_unix, or a calendar recurrence (daily/cron) that can derive the first due time."
         "due_at_iso"
     ; object_prop
         ~description:

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -540,6 +540,30 @@ let test_keeper_wake_consumer_records_dispatch_without_work_success () =
       (queue_evidence |> member "pending_count" |> to_int);
     check int "queue evidence read errors" 0
       (queue_evidence |> member "read_errors" |> to_list |> List.length)
+  ; (match
+       Schedule_store.complete_dispatched_occurrence
+         config
+         ~now:202.0
+         ~schedule_id:request.schedule_id
+         ~due_at:request.due_at
+         ~payload_digest:(Schedule_domain.payload_digest request.payload)
+         ()
+     with
+     | Ok _ -> ()
+     | Error err -> fail (Schedule_store.store_error_to_string err));
+    let terminal_dashboard =
+      Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
+    in
+    let terminal_row =
+      dashboard_schedule_row_exn terminal_dashboard ~schedule_id:request.schedule_id
+    in
+    check string "terminal execution succeeded" "succeeded"
+      (terminal_row |> member "last_execution" |> member "status" |> to_string);
+    check string "terminal projection retains recognized receipt" "recognized"
+      (terminal_row
+       |> member "dispatch_receipt"
+       |> member "projection_status"
+       |> to_string)
 ;;
 
 let test_recurring_wakes_keep_distinct_occurrence_ids () =

--- a/test/test_schedule_store.ml
+++ b/test/test_schedule_store.ml
@@ -2,6 +2,8 @@ open Alcotest
 open Schedule_domain
 open Schedule_store
 
+let json = testable Yojson.Safe.pp Yojson.Safe.equal
+
 let temp_dir () =
   let path = Filename.temp_file "schedule_store_test" "" in
   Sys.remove path;
@@ -578,10 +580,22 @@ let test_dispatched_one_shot_completes_by_exact_occurrence () =
   with_workspace
   @@ fun config ->
   let request = make_request ~schedule_id:"accepted-complete-1" () in
+  let dispatch_receipt =
+    `Assoc
+      [ "kind", `String "keeper.wake_enqueued"
+      ; "occurrence_id", `String "schedule:accepted-complete-1:200"
+      ]
+  in
   ignore (insert_ok config request);
   ignore (refresh_due config ~now:201.0);
   ignore (start_due_candidate config ~now:202.0 ~schedule_id:request.schedule_id);
-  ignore (accept_running config ~now:203.0 ~schedule_id:request.schedule_id ());
+  ignore
+    (accept_running
+       config
+       ~now:203.0
+       ~schedule_id:request.schedule_id
+       ~detail:dispatch_receipt
+       ());
   let digest = payload_digest request.payload in
   (match
      complete_dispatched_occurrence
@@ -590,7 +604,6 @@ let test_dispatched_one_shot_completes_by_exact_occurrence () =
        ~schedule_id:request.schedule_id
        ~due_at:request.due_at
        ~payload_digest:digest
-       ~detail:(`Assoc [ "kind", `String "keeper.turn_completed" ])
        ()
    with
    | Ok stored -> check_status "one-shot terminal success" Succeeded stored.status
@@ -602,12 +615,15 @@ let test_dispatched_one_shot_completes_by_exact_occurrence () =
        ~due_at:request.due_at
        ~payload_digest:digest
    with
-   | Some execution ->
-     check string "exact execution succeeded" "succeeded"
-       (execution_status_to_string execution.status);
-     check (option (float 0.001)) "exact execution finished" (Some 204.0)
-       execution.finished_at
-   | None -> fail "exact execution missing");
+     | Some execution ->
+       check string "exact execution succeeded" "succeeded"
+         (execution_status_to_string execution.status);
+       check (option (float 0.001)) "exact execution finished" (Some 204.0)
+         execution.finished_at;
+       check (option json) "dispatch receipt remains available after completion"
+         (Some dispatch_receipt)
+         execution.detail
+     | None -> fail "exact execution missing");
   (match
      complete_dispatched_occurrence
        config

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -208,6 +208,51 @@ let test_create_list_get_cancel () =
      |> to_string)
 ;;
 
+let test_create_accepts_explicit_iso8601_offset () =
+  with_config
+  @@ fun config ->
+  let create ~schedule_id ~due_at_iso =
+    dispatch_exn config Tool_schemas_schedule.Create_request
+      (`Assoc
+        [ "schedule_id", `String schedule_id
+        ; "due_at_iso", `String due_at_iso
+        ; "payload_kind", `String Schedule_supported_kinds.keeper_wake
+        ; ( "payload_body"
+          , `Assoc
+              [ "keeper_name", `String "schedule-keeper"
+              ; "message", `String "run at nine in Korea"
+              ] )
+        ])
+  in
+  let result =
+    create
+      ~schedule_id:"sched-kst-offset"
+      ~due_at_iso:"2026-08-02T09:00:00+09:00"
+  in
+  check bool "explicit ISO-8601 offset accepted" true (Tool_result.is_success result);
+  let open Yojson.Safe.Util in
+  check string "offset normalized to UTC" "2026-08-02T00:00:00Z"
+    (Tool_result.data result |> member "due_at_iso" |> to_string);
+  let west =
+    create
+      ~schedule_id:"sched-west-offset"
+      ~due_at_iso:"2099-01-02T00:30:00-03:30"
+  in
+  check bool "negative ISO-8601 offset accepted" true (Tool_result.is_success west);
+  check string "negative offset normalized to UTC" "2099-01-02T04:00:00Z"
+    (Tool_result.data west |> member "due_at_iso" |> to_string);
+  let invalid =
+    create
+      ~schedule_id:"sched-invalid-date"
+      ~due_at_iso:"2099-02-29T09:00:00+09:00"
+  in
+  check bool "invalid civil date rejected" false (Tool_result.is_success invalid);
+  check bool "invalid date error is explicit" true
+    (String_util.contains_substring
+       (Tool_result.message invalid)
+       "due_at_iso must be")
+;;
+
 let test_removed_convenience_input_does_not_synthesize_payload () =
   with_config
   @@ fun config ->
@@ -412,6 +457,8 @@ let () =
     [ ( "wiring"
       , [ test_case "flat tool surface" `Quick test_flat_tool_surface
         ; test_case "create list get cancel" `Quick test_create_list_get_cancel
+        ; test_case "create accepts explicit ISO-8601 offset" `Quick
+            test_create_accepts_explicit_iso8601_offset
         ; test_case "removed convenience input does not synthesize payload" `Quick
             test_removed_convenience_input_does_not_synthesize_payload
         ; test_case "unregistered wake target rejected" `Quick


### PR DESCRIPTION
## What changed

- accept ISO-8601 `due_at_iso` values with `Z` or explicit numeric offsets such as `+09:00`, validate civil dates, and normalize stored/output timestamps to UTC
- preserve the original typed dispatch receipt when a dispatched occurrence reaches terminal success
- document the accepted timestamp contract and add store, tool, and dashboard end-to-end regressions

## Root cause

Schedule creation delegated to a UTC-`Z`-only parser, so valid offset timestamps were rejected. Separately, terminal completion replaced `execution.detail` with a different terminal object even though the dashboard decodes that field as the dispatch receipt, producing `unrecognized_detail` after successful runs.

## Impact

Operators can schedule with explicit local offsets without manual UTC conversion. Completed keeper-wake rows retain recognized enqueue evidence while terminal truth remains in the typed execution status and `finished_at` fields.

## Validation

- focused Dune build for all 9 schedule test executables
- all 196 schedule tests passed
- regression proves `2026-08-02T09:00:00+09:00` normalizes to `2026-08-02T00:00:00Z`
- regression proves a succeeded execution still projects `dispatch_receipt.projection_status=recognized`

Closes #26552
