### PR TITLE
feat(keeper): retire the overflow FSM vocabulary (#26546 step 2)

### DIFF
--- a/dashboard/src/api/schemas/keeper-composite.ts
+++ b/dashboard/src/api/schemas/keeper-composite.ts
@@ -91,7 +91,6 @@ const KeeperPhaseDiagnosisSchema = object({
     stop_requested: boolean(),
     dead_tombstone_latched: boolean(),
     drain_complete: boolean(),
-    context_overflow: boolean(),
   }),
   determining_condition: nullable(string()),
   rows: array(KeeperPhaseDiagnosisRowSchema),

--- a/dashboard/src/components/keeper-conditions-divergent.test.ts
+++ b/dashboard/src/components/keeper-conditions-divergent.test.ts
@@ -16,7 +16,6 @@ const allHealthy: KeeperConditions = {
   stop_requested: false,
   dead_tombstone_latched: false,
   drain_complete: false,
-  context_overflow: false,
 }
 
 describe("isOperating", () => {
@@ -61,16 +60,6 @@ describe("computeDivergences", () => {
     expect(divs).toHaveLength(1)
     expect(divs[0].field).toBe("context_handoff_needed")
     expect(divs[0].value).toBe(true)
-  })
-
-  it("detects context_overflow when not Overflowed", () => {
-    const divs = computeDivergences({ ...allHealthy, context_overflow: true }, "Running")
-    expect(divs.some(d => d.field === "context_overflow")).toBe(true)
-  })
-
-  it("ignores context_overflow when phase is Overflowed", () => {
-    const divs = computeDivergences({ ...allHealthy, context_overflow: true }, "Overflowed")
-    expect(divs.some(d => d.field === "context_overflow")).toBe(false)
   })
 
   it("detects stop_requested when not Draining", () => {
@@ -132,7 +121,6 @@ describe("computeDivergences", () => {
     const divs = computeDivergences({
       ...allHealthy,
       context_handoff_needed: true,
-      context_overflow: true,
       stop_requested: true,
       turn_healthy: false,
       heartbeat_healthy: false,

--- a/dashboard/src/components/keeper-conditions-divergent.ts
+++ b/dashboard/src/components/keeper-conditions-divergent.ts
@@ -37,11 +37,6 @@ const DIVERGENCE_RULES: Partial<Record<keyof KeeperConditions, DivergenceFn>> = 
       ? '핸드오프 필요 신호가 있지만 아직 HandingOff/Compacting으로 전환 전'
       : null,
 
-  context_overflow: (v, p) =>
-    v && p !== 'Overflowed' && !isTerminated(p)
-      ? '컨텍스트 overflow 감지됨 (phase 미반영)'
-      : null,
-
   stop_requested: (v, p) =>
     v && p !== 'Draining' && !isTerminated(p)
       ? '정지 요청됐으나 Draining 미진입'

--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -622,7 +622,6 @@ describe('RuntimeLensSection', () => {
           stop_requested: false,
           dead_tombstone_latched: false,
           drain_complete: false,
-          context_overflow: false,
         },
         determining_condition: 'running_fiber_alive',
         rows: [],

--- a/dashboard/src/components/keeper-phase-indicator.ts
+++ b/dashboard/src/components/keeper-phase-indicator.ts
@@ -78,7 +78,7 @@ const PIPELINE_STAGE_DETAIL_LABELS: Record<string, string> = {
   launch_pending_no_fiber: '기동 대기',
   phase_running_idle: '대기',
   health_or_turn_failure_probe: '복구 확인',
-  context_overflow_pending_compaction: '압축 대기',
+  context_overflow_retired_phase: '컨텍스트 초과 (retired)',
   context_compaction_in_progress: '압축 진행',
   generation_handoff_in_progress: '승계 진행',
   graceful_shutdown_draining: '종료 정리',

--- a/dashboard/src/lib/keeper-runtime-projection.test.ts
+++ b/dashboard/src/lib/keeper-runtime-projection.test.ts
@@ -54,7 +54,6 @@ function composite(overrides: Partial<KeeperCompositeSnapshot> = {}): KeeperComp
         stop_requested: false,
         dead_tombstone_latched: false,
         drain_complete: false,
-        context_overflow: false,
       },
       determining_condition: 'running_fiber_alive',
       rows: [],

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -1341,7 +1341,6 @@ export interface KeeperConditions {
   stop_requested: boolean
   dead_tombstone_latched: boolean
   drain_complete: boolean
-  context_overflow: boolean
 }
 
 export interface KeeperSupervisorCrashLogEntry {

--- a/docs/keeper-fsm-graph.dot
+++ b/docs/keeper-fsm-graph.dot
@@ -36,9 +36,9 @@ digraph keeper_fsm {
   ];
 
   KSM -> KMC [
-    label = "ksm_to_kmc_compact_trigger\n(Auto_compact_triggered)",
+    label = "ksm_to_kmc_compact_trigger\n(Operator_compact_requested)",
     color = "#1976d2",
-    tooltip = "lib/keeper/keeper_registry.ml:995"
+    tooltip = "lib/keeper/keeper_manual_compaction.ml (manual-only since #26546)"
   ];
 
   KMC -> KSM [

--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -59,15 +59,13 @@ type tla_action =
   | Action_finish_compaction
   | Action_enter_failing
   | Action_clear_failing
-  | Action_enter_overflowed
-  | Action_overflowed_auto_compact
 
 let all_tla_actions =
   [
     Action_start_turn; Action_measurement_broadcast; Action_decide_guard; Action_select_tool_policy;
     Action_start_runtime_selection; Action_select_runtime; Action_runtime_done;
     Action_runtime_exhausted; Action_finish_turn; Action_start_compaction; Action_finish_compaction;
-    Action_enter_failing; Action_clear_failing; Action_enter_overflowed; Action_overflowed_auto_compact;
+    Action_enter_failing; Action_clear_failing;
   ]
 
 type invariant_key =
@@ -269,8 +267,6 @@ let tla_action_to_string = function
   | Action_finish_compaction -> "FinishCompaction"
   | Action_enter_failing -> "EnterFailing"
   | Action_clear_failing -> "ClearFailing"
-  | Action_enter_overflowed -> "EnterOverflowed"
-  | Action_overflowed_auto_compact -> "OverflowedAutoCompact"
 
 let tla_action_of_string = function
   | "StartTurn" -> Some Action_start_turn
@@ -286,8 +282,6 @@ let tla_action_of_string = function
   | "FinishCompaction" -> Some Action_finish_compaction
   | "EnterFailing" -> Some Action_enter_failing
   | "ClearFailing" -> Some Action_clear_failing
-  | "EnterOverflowed" -> Some Action_enter_overflowed
-  | "OverflowedAutoCompact" -> Some Action_overflowed_auto_compact
   | _ -> None
 
 let invariant_key_to_string = function
@@ -716,9 +710,6 @@ let phase_condition_rows (c : Keeper_state_machine.conditions) : phase_condition
     row "compacting_active" "Compacting: compaction active" 10
       c.compaction_active
       Keeper_state_machine.Compacting;
-    row "overflowed_context" "Overflowed: context overflow awaiting compaction" 11
-      c.context_overflow
-      Keeper_state_machine.Overflowed;
     row "failing_unhealthy" "Failing: heartbeat or turn unhealthy" 12
       ((not c.heartbeat_healthy) || not c.turn_healthy)
       Keeper_state_machine.Failing;

--- a/lib/keeper/keeper_composite_observer.mli
+++ b/lib/keeper/keeper_composite_observer.mli
@@ -64,8 +64,6 @@ type tla_action =
   | Action_finish_compaction
   | Action_enter_failing
   | Action_clear_failing
-  | Action_enter_overflowed
-  | Action_overflowed_auto_compact
 
 val all_tla_actions : tla_action list
 

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -303,7 +303,6 @@ let pending_measurement_after_event now entry event =
 let compaction_stage_of_event entry event =
   match event with
   | Keeper_state_machine.Compaction_started
-  | Keeper_state_machine.Auto_compact_triggered
   | Keeper_state_machine.Operator_compact_requested -> Packed Compaction_compacting
   | Keeper_state_machine.Compaction_completed -> Packed Compaction_done
   | Keeper_state_machine.Compaction_failed _ -> Packed Compaction_accumulating

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -212,7 +212,9 @@ let runtime_blocker_surface_of_failure_reason (reason : Keeper_registry.failure_
   | Keeper_registry.Turn_overflow_failure ->
     Some
       { blocker_class = "turn_overflow_failure"
-      ; summary = "Context overflow with compact retry exhausted; the failure was recorded and the Keeper remains active."
+      ; summary =
+          "Context overflow recorded by the retired automatic-recovery path \
+           (#26546); the Keeper remains active."
       }
   | Keeper_registry.Exception detail ->
     Some

--- a/lib/keeper/keeper_status_runtime.ml
+++ b/lib/keeper/keeper_status_runtime.ml
@@ -603,7 +603,9 @@ let pipeline_stage_detail_of_phase (phase : Keeper_state_machine.phase) : string
   | Keeper_state_machine.Offline -> "launch_pending_no_fiber"
   | Keeper_state_machine.Running -> "phase_running_idle"
   | Keeper_state_machine.Failing -> "health_or_turn_failure_probe"
-  | Keeper_state_machine.Overflowed -> "context_overflow_pending_compaction"
+  | Keeper_state_machine.Overflowed ->
+    (* Retired phase (#26546): only historical records can carry it. *)
+    "context_overflow_retired_phase"
   | Keeper_state_machine.Compacting -> "context_compaction_in_progress"
   | Keeper_state_machine.HandingOff -> "generation_handoff_in_progress"
   | Keeper_state_machine.Draining -> "graceful_shutdown_draining"

--- a/lib/keeper/keeper_trace_emit.ml
+++ b/lib/keeper/keeper_trace_emit.ml
@@ -1,7 +1,7 @@
 (** Keeper_trace_emit — TLA+ trace validation용 상태 전이 기록.
 
     MASC_TLA_TRACE=1 일 때만 활성.
-    conditions_to_json 재사용으로 14필드 전체 기록. *)
+    conditions_to_json 재사용으로 condition 필드 전체 기록. *)
 
 module SM = Keeper_state_machine
 module SMJ = Keeper_state_machine_json

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -142,8 +142,8 @@ let lane_should_retry
        serve the same turn. [sdk_error_to_http_error] folds it into a generic
        HTTP 400 which [Runtime_attempt_fsm.should_try_next] treats as terminal,
        so the typed error must be read before that mapping. Overflow on the
-       last candidate still returns the typed error, keeping the reactive
-       compaction trigger ([context_overflow_event_of_error]) intact. *)
+       last candidate still returns the typed error, keeping the typed
+       overflow observation (blocker label, failure route) intact. *)
     true
   else
     match Keeper_turn_driver_try_runtime.sdk_error_to_http_error error with
@@ -165,13 +165,14 @@ let attempt_runtime_candidates
   (* A typed overflow observed on any candidate is a fact about this turn's
      input, not about whichever candidate happened to fail last. When the
      lane ends on a different recoverable error (for example a rate-limited
-     fallback), returning that last error hides the overflow from
-     [context_overflow_event_of_error], the keeper never enters the
-     overflowed phase, and compaction never fires while every cycle repeats
-     the same oversized input (#26530). Remember the first typed overflow
-     and let it represent a naturally exhausted lane. A lane that stops on a
-     non-recoverable error keeps that error: it is the immediate operator
-     signal, and the overflow will be observed again on the next cycle. *)
+     fallback), returning that last error would hide the overflow from the
+     lane classifier: the failure route would misreport a transient error
+     instead of the deterministic capacity bound, and the operator-facing
+     blocker would name the wrong cause (#26530). Remember the first typed
+     overflow and let it represent a naturally exhausted lane. A lane that
+     stops on a non-recoverable error keeps that error: it is the immediate
+     operator signal, and the overflow will be observed again on the next
+     cycle. *)
   let rec loop ~observed_overflow idx = function
     | [] ->
       (match observed_overflow with
@@ -246,9 +247,9 @@ let attempt_runtime_candidates
          else if is_last
          then (
            (* Lane fully exhausted: an overflow seen anywhere in the rotation
-              outranks the last candidate's error so the reactive compaction
-              trigger fires. Cascade telemetry already published each
-              candidate's own error. *)
+              outranks the last candidate's error so the failure route and
+              blocker report the deterministic capacity bound. Cascade
+              telemetry already published each candidate's own error. *)
            match observed_overflow with
            | Some overflow_error -> Error overflow_error
            | None -> Error error)

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -418,27 +418,27 @@ type capacity_non_compaction =
 
 type capacity_transition =
   | Not_capacity
-  | Compact_next_cycle of Compaction_trigger.t
+  | Capacity_refusal_classified of Compaction_trigger.t
   | Capacity_non_compacting of capacity_non_compaction
 
 let capacity_transition_of_error
     (err : Agent_sdk.Error.sdk_error) : capacity_transition =
   match err with
   | Agent_sdk.Error.Api (ContextOverflow { limit; _ }) ->
-    Compact_next_cycle
+    Capacity_refusal_classified
       (Compaction_trigger.Provider_overflow { limit_tokens = limit })
   | Agent_sdk.Error.Api
       (InvalidRequest
          { reason = Request_body_too_large { actual_bytes; limit_bytes }; _ })
     ->
-    Compact_next_cycle
+    Capacity_refusal_classified
       (Compaction_trigger.Request_body_over_capacity
          { actual_bytes; limit_bytes })
   | Agent_sdk.Error.Api
       (InvalidRequest
          { reason = Request_body_refused_by_provider { status }; _ })
     ->
-    Compact_next_cycle
+    Capacity_refusal_classified
       (Compaction_trigger.Request_body_refused_by_provider { status })
   | Agent_sdk.Error.Api
       (InputCapacity
@@ -449,7 +449,7 @@ let capacity_transition_of_error
          ; _
          })
     ->
-    Compact_next_cycle
+    Capacity_refusal_classified
       (Compaction_trigger.Serving_input_capacity
          (Compaction_trigger.Boundary_unknown
             { input_tokens; accepted_through; rejected_from }))
@@ -462,7 +462,7 @@ let capacity_transition_of_error
          ; _
          })
     ->
-    Compact_next_cycle
+    Capacity_refusal_classified
       (Compaction_trigger.Serving_input_capacity
          (Compaction_trigger.Input_rejected
             { input_tokens; accepted_through; rejected_from }))
@@ -514,17 +514,17 @@ let capacity_transition_of_error
 let capacity_refusal_of_error
     (err : Agent_sdk.Error.sdk_error) : capacity_refusal option =
   match capacity_transition_of_error err with
-  | Compact_next_cycle (Compaction_trigger.Provider_overflow { limit_tokens }) ->
+  | Capacity_refusal_classified (Compaction_trigger.Provider_overflow { limit_tokens }) ->
     Some (Provider_context_window { limit_tokens })
-  | Compact_next_cycle
+  | Capacity_refusal_classified
       (Compaction_trigger.Request_body_over_capacity { actual_bytes; limit_bytes })
     ->
     Some (Serialized_request_body { actual_bytes; limit_bytes })
-  | Compact_next_cycle
+  | Capacity_refusal_classified
       (Compaction_trigger.Request_body_refused_by_provider { status }) ->
     Some (Provider_request_body_refusal { status })
-  | Compact_next_cycle (Compaction_trigger.Serving_input_capacity _)
-  | Compact_next_cycle Compaction_trigger.Manual
+  | Capacity_refusal_classified (Compaction_trigger.Serving_input_capacity _)
+  | Capacity_refusal_classified Compaction_trigger.Manual
   | Capacity_non_compacting _
   | Not_capacity ->
     None

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -530,21 +530,6 @@ let capacity_refusal_of_error
     None
 ;;
 
-(* Projection for the two token-axis call sites. Both publish
-   reason="provider_context_overflow" and the [Sdk_context_window_exceeded]
-   blocker class (keeper_unified_turn_execution.ml:485-509), labels that would be
-   wrong for a declared-byte refusal, so this projection admits only the context
-   window. *)
-let context_overflow_event_of_error
-    (err : Agent_sdk.Error.sdk_error) : Keeper_state_machine.event option =
-  match capacity_refusal_of_error err with
-  | Some (Provider_context_window { limit_tokens }) ->
-    Some (Keeper_state_machine.Context_overflow_detected { limit_tokens })
-  | Some (Serialized_request_body _)
-  | Some (Provider_request_body_refusal _)
-  | None ->
-    None
-
 let current_keeper_meta ~(config : Workspace.config) ~(fallback_meta : keeper_meta) =
   match Keeper_registry.get ~base_path:config.base_path fallback_meta.name with
   | Some entry -> entry.meta

--- a/lib/keeper/keeper_turn_runtime_budget.mli
+++ b/lib/keeper/keeper_turn_runtime_budget.mli
@@ -235,14 +235,6 @@ val capacity_transition_of_error :
 (** Total classifier over typed SDK errors. This function does not inspect
     rendered error prose and does not select a provider, model, or failover. *)
 
-val context_overflow_event_of_error :
-  Agent_sdk.Error.sdk_error ->
-  Keeper_state_machine.event option
-(** The context-window axis of {!capacity_transition_of_error} as a lifecycle event.
-    [Some] only for [Provider_context_window]; a byte refusal returns [None]
-    because this projection's call sites label the failure as a context-window
-    exceedance. *)
-
 val current_keeper_meta :
   config:Workspace.config ->
   fallback_meta:keeper_meta ->

--- a/lib/keeper/keeper_turn_runtime_budget.mli
+++ b/lib/keeper/keeper_turn_runtime_budget.mli
@@ -222,10 +222,10 @@ type capacity_non_compaction =
 
 type capacity_transition =
   | Not_capacity
-  | Compact_next_cycle of Compaction_trigger.t
+  | Capacity_refusal_classified of Compaction_trigger.t
   | Capacity_non_compacting of capacity_non_compaction
 (** Provider-neutral transition input for the durable compaction lane.
-    [Compact_next_cycle] preserves the measured token or byte axis.
+    [Capacity_refusal_classified] preserves the measured token or byte axis.
     Future/expired serving evidence and unavailable token measurement remain
     typed non-compacting facts; they are never guessed into a capacity limit. *)
 

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -52,12 +52,6 @@ val turn_tool_event_integrity_error
   :  turn_tool_event_tracker
   -> Agent_sdk.Error.sdk_error option
 
-(** Build an overflow event only from typed [Api (ContextOverflow _)].
-    Non-overflow errors return [None]. *)
-val context_overflow_event_of_error
-  :  Agent_sdk.Error.sdk_error
-  -> Keeper_state_machine.event option
-
 (** Project the initial keeper turn context budget from the routed runtime's
     prevalidated resolution, so lifecycle context math matches the provider
     that will receive the first request. Exposed for regression tests. *)

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -24,13 +24,29 @@ type retry_loop_input =
   }
 
 type declared_lane_failure =
-  | Provider_context_overflow of Keeper_state_machine.event
+  | Provider_context_overflow of { limit_tokens : int option }
   | Declared_runtime_lane_exhausted
 
+(* Only the context-window axis classifies as [Provider_context_overflow]:
+   the blocker below publishes the [Sdk_context_window_exceeded] class,
+   which would be wrong for a declared-byte refusal. *)
 let declared_lane_failure_of_error err =
-  match context_overflow_event_of_error err with
-  | Some event -> Provider_context_overflow event
+  match capacity_refusal_of_error err with
+  | Some (Provider_context_window { limit_tokens }) ->
+    Provider_context_overflow { limit_tokens }
+  | Some (Serialized_request_body _)
+  | Some (Provider_request_body_refusal _)
   | None -> Declared_runtime_lane_exhausted
+
+(* Keeps the exact blocker-detail shape the retired
+   [Keeper_state_machine.Context_overflow_detected] event printed, so
+   operator-facing blocker history stays greppable across #26546. *)
+let context_overflow_blocker_label ~limit_tokens =
+  Printf.sprintf
+    "context_overflow_detected(limit=%s)"
+    (match limit_tokens with
+     | Some n -> string_of_int n
+     | None -> "?")
 
 let run_provider_dispatch_if_authorized ~before_dispatch_authority dispatch =
   match before_dispatch_authority () with
@@ -374,7 +390,7 @@ let run (ctx : ctx)
         Error err, turn_state
       | None ->
         (match declared_lane_failure_of_error err with
-         | Provider_context_overflow overflow_event ->
+         | Provider_context_overflow { limit_tokens } ->
           Keeper_unified_turn_cascade_resolution.publish_cascade_resolution
             ~keeper_name:meta.name
             ~runtime_id:execution.runtime_id
@@ -396,7 +412,7 @@ let run (ctx : ctx)
                 Some
                   (Keeper_meta_contract.blocker_info_of_class
                      ~detail:
-                       (Keeper_state_machine.event_to_string overflow_event
+                       (context_overflow_blocker_label ~limit_tokens
                         ^ ": "
                         ^ overflow_evidence_detail
                         ^ ": "
@@ -461,7 +477,7 @@ let run (ctx : ctx)
 
 module For_testing = struct
   type nonrec declared_lane_failure = declared_lane_failure =
-    | Provider_context_overflow of Keeper_state_machine.event
+    | Provider_context_overflow of { limit_tokens : int option }
     | Declared_runtime_lane_exhausted
 
   let declared_lane_failure_of_error = declared_lane_failure_of_error

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -40,7 +40,6 @@ type t =
   | CompactionRatioChange
   | CompactionSavedTokens
   | CompactionOutcomes
-  | EmergencyCompactRatioThreshold
   | OperatorCompact
   | OperatorClear
   | ToolEmissionRegistrySize
@@ -247,8 +246,6 @@ let to_string = function
   | CompactionRatioChange -> "masc_keeper_compaction_ratio_change"
   | CompactionSavedTokens -> "masc_keeper_compaction_saved_tokens_total"
   | CompactionOutcomes -> "masc_keeper_compaction_outcomes_total"
-  | EmergencyCompactRatioThreshold ->
-    "masc_keeper_emergency_compact_ratio_threshold"
   | OperatorCompact -> "masc_keeper_operator_compact_total"
   | OperatorClear -> "masc_keeper_operator_clear_total"
   | ToolEmissionRegistrySize -> "masc_keeper_tool_emission_registry_size"

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -31,7 +31,6 @@ type t =
   | CompactionRatioChange
   | CompactionSavedTokens
   | CompactionOutcomes
-  | EmergencyCompactRatioThreshold
   | OperatorCompact
   | OperatorClear
   | ToolEmissionRegistrySize

--- a/lib/keeper_registry/keeper_state_machine.ml
+++ b/lib/keeper_registry/keeper_state_machine.ml
@@ -50,9 +50,8 @@ let is_terminal = function
               |   KeeperConditionsGovernPhase.tla:96-100 (Transition action)
        7b     | KeeperReconcileLiveness.tla:98 (Compacting)
               |   KeeperCompactionLifecycle.tla:171-184 (Compacting cycle)
-       7c     | KeeperCompactionLifecycle.tla:154 (Overflowed) — partition
-              |   (KeeperReconcileLiveness omits Overflowed; coverage by
-              |    sibling spec is intentional, see Note C)
+       7c     | (retired #26546 — Overflowed is no longer derived; the
+              |   phase variant survives only to decode historical records)
        8      | KeeperReconcileLiveness.tla:99 (Failing — health degraded)
        9      | KeeperReconcileLiveness.tla:100 (Running)
               |   KeeperCoreTriad.tla:147,316 (turn_healthy=true -> Running)
@@ -73,10 +72,9 @@ let is_terminal = function
        keeper_registry.ml:340 (set), this file:520 (clear in FSM),
        keeper_registry.ml:407 (clear on death) — all three sources
        are anchored in the spec's source-citation block.
-     Note B — Partition (acknowledged). Overflowed phase derivation
-       lives in KeeperCompactionLifecycle.tla; KeeperReconcileLiveness
-       omits it because reconcile liveness is independent of overflow.
-       Multi-spec coverage by design, not drift.
+     Note B — Retired (#26546). Overflowed phase derivation was removed
+       together with the automatic overflow-compaction trigger; no
+       condition maps to Overflowed anymore.
 
    C1 follow-up scope (plan §3, sequenced):
      - Phase 1 (per-priority): convert each branch to `let try_<action>
@@ -130,8 +128,10 @@ let derive_phase (c : conditions) : phase =
   then HandingOff
   else if c.compaction_active
   then Compacting
-  else if c.context_overflow
-  then Overflowed
+  (* [Overflowed] is retired vocabulary (#26546): the automatic
+     overflow-compaction trigger was removed, no condition derives it, and
+     the phase variant remains only so historical durable lifecycle records
+     ("overflowed") still decode. *)
   else if
     (not c.heartbeat_healthy)
     || (not c.turn_healthy)
@@ -163,14 +163,12 @@ let update_conditions (c : conditions) (ev : event) : conditions =
   | Context_measured { context_actions; _ } ->
     { c with context_handoff_needed = context_actions.handoff }
   | Compaction_started -> { c with compaction_active = true }
-  | Compaction_completed ->
-    { c with compaction_active = false; context_overflow = false }
+  | Compaction_completed -> { c with compaction_active = false }
   | Compaction_failed _ ->
-    (* Durable lane settlement owns the retry. Keeping [context_overflow]
-       latched here made the Keeper non-executable, so the exact requeued work
-       could never retry. The failure remains observable through turn health
-       and receipts while this buffer-operation latch is released. *)
-    { c with compaction_active = false; context_overflow = false }
+    (* Durable lane settlement owns the retry. The failure remains
+       observable through turn health and receipts while this
+       buffer-operation latch is released. *)
+    { c with compaction_active = false }
   | Handoff_started -> { c with handoff_active = true }
   | Handoff_completed _ -> { c with handoff_active = false }
   | Handoff_failed _ -> { c with handoff_active = false }
@@ -202,7 +200,6 @@ let update_conditions (c : conditions) (ev : event) : conditions =
     ; restart_requested = false
     ; drain_complete = false
     ; stop_requested = false
-    ; context_overflow = false
     }
   | Fiber_terminated _ -> { c with fiber_alive = false }
   | Supervisor_restart_attempt _ -> { c with restart_requested = true }
@@ -211,17 +208,13 @@ let update_conditions (c : conditions) (ev : event) : conditions =
       fiber_alive = false
     ; credential_archived = true
     }
-  | Context_overflow_detected _ ->
-    { c with context_overflow = true }
-  | Auto_compact_triggered ->
-    (* Legacy explicit input. No entry action produces this event. *)
-    { c with compaction_active = true }
   | Operator_compact_requested ->
     { c with compaction_active = true }
   | Operator_clear_requested _ ->
-    (* Last resort: context fully dropped by [masc_keeper_clear].
-       Conditions reset in-place without passing through [Compacting]. *)
-    { c with context_overflow = false }
+    (* Last resort: context fully dropped by [masc_keeper_clear]. The
+       context payload change is owned by the clear runtime; with the
+       overflow latch retired (#26546) no lifecycle condition changes. *)
+    c
 ;;
 
 (** Compute entry actions for a phase transition.
@@ -265,7 +258,6 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
          | Compaction_started
          | Compaction_completed
          | Compaction_failed _
-         | Context_overflow_detected _
          | Handoff_started
          | Handoff_completed _
          | Handoff_failed _
@@ -276,42 +268,15 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
          | Fiber_terminated _
          | Supervisor_restart_attempt _
          | Credential_archived
-         | Auto_compact_triggered
          | Operator_compact_requested
          | Operator_clear_requested _ -> event_to_string event)
     ]
   | Overflowed ->
-    [ lifecycle
-        "overflowed"
-        (match event with
-         | Context_overflow_detected r ->
-           (match r.limit_tokens with
-            | Some n -> Printf.sprintf "limit=%d" n
-            | None -> "limit=unknown")
-         | Heartbeat_ok
-         | Heartbeat_failed _
-         | Turn_succeeded
-         | Turn_failed _
-         | Context_measured _
-         | Compaction_started
-         | Compaction_completed
-         | Compaction_failed _
-         | Handoff_started
-         | Handoff_completed _
-         | Handoff_failed _
-         | Operator_pause
-         | Operator_resume
-         | Operator_stop _
-         | Stop_requested
-         | Drain_complete
-         | Fiber_started
-         | Fiber_terminated _
-         | Supervisor_restart_attempt _
-         | Credential_archived
-         | Auto_compact_triggered
-         | Operator_compact_requested
-         | Operator_clear_requested _ -> event_to_string event)
-    ]
+    (* Retired phase (#26546): no condition derives [Overflowed] anymore, so
+       this arm is unreachable at runtime. It stays for phase-match
+       exhaustiveness because the variant is preserved to decode historical
+       durable lifecycle records. *)
+    [ lifecycle "overflowed" (event_to_string event) ]
   | Failing -> [ lifecycle "failing" (event_to_string event) ]
   | Paused ->
     let detail =
@@ -336,9 +301,7 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
       | Fiber_terminated _
       | Supervisor_restart_attempt _
       | Credential_archived
-      | Auto_compact_triggered
       | Operator_compact_requested
-      | Context_overflow_detected _
       | Operator_clear_requested _ ->
         (* These events should not normally trigger a Paused transition,
            but if they do, label generically rather than mis-attributing
@@ -392,9 +355,7 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
          | Fiber_started
          | Supervisor_restart_attempt _
          | Credential_archived
-         | Auto_compact_triggered
          | Operator_compact_requested
-         | Context_overflow_detected _
          | Operator_clear_requested _ ->
            (* These events should not normally trigger a Paused→Running
               transition; label generically via [event_to_string]. *)
@@ -440,20 +401,18 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
    This helper enforces structural buffer-operation preconditions at the
    [apply_event] boundary so silent corruption becomes a typed
    [Precondition_violation] result:
-     - Context_overflow_detected, Auto_compact_triggered (overflow
-       lifecycle — the two events that drive Overflowed↔Compacting)
      - Operator_compact_requested (operator-driven buffer op
        exclusivity).  Operator_clear_requested is deliberately *not*
        arm-enforced beyond the terminal guard — see its arm below for
        the operator escape-hatch rationale.
    Other events have no spec preconditions beyond NotTerminal and
-   fall through the catch-all.
+   fall through the catch-all.  The overflow-lifecycle preconditions
+   (Context_overflow_detected, Auto_compact_triggered) were retired with
+   their events (#26546).
 
    Background:
      - iter 9 audit memo: docs/tla-audit/ksm-precondition-enforcement-gap-2026-05-12.md
-     - iter 9 PR #14730 (systematic gap class)
-     - TLA+ §ContextOverflowDetected and §AutoCompactTriggered in
-       KeeperStateMachine.tla *)
+     - iter 9 PR #14730 (systematic gap class) *)
 let check_event_precondition (c : conditions) (ev : event)
   : (unit, transition_error) result
   =
@@ -464,53 +423,6 @@ let check_event_precondition (c : conditions) (ev : event)
      precondition that failed, while the long explanatory text stays
      in source comments above each branch. *)
   match ev with
-  | Context_overflow_detected _ ->
-    if c.compaction_active
-    then
-      Error
-        (Precondition_violation
-           { event = event_to_string ev
-           ; reason =
-               "TLA+ §ContextOverflowDetected requires ~compaction_active; \
-                an overflow signal while compaction is already running means \
-                the in-flight compaction is the runaway — the retry latch \
-                must catch it, not a fresh overflow event that conflates the \
-                two attempts"
-           })
-    else Ok ()
-  | Auto_compact_triggered ->
-    if not c.context_overflow
-    then
-      Error
-        (Precondition_violation
-           { event = event_to_string ev
-           ; reason =
-               "TLA+ §AutoCompactTriggered requires context_overflow=true; \
-                triggering auto-compaction on a non-overflowed keeper flips \
-                compaction_active outside the Overflowed→Compacting transition \
-                and corrupts the overflow lifecycle invariant"
-           })
-    else if c.compaction_active
-    then
-      Error
-        (Precondition_violation
-           { event = event_to_string ev
-           ; reason =
-               "TLA+ §AutoCompactTriggered requires ~compaction_active; \
-                re-triggering while a compaction is already in flight \
-                duplicates the buffer op and tangles the ordering"
-           })
-    else if c.handoff_active
-    then
-      Error
-        (Precondition_violation
-           { event = event_to_string ev
-           ; reason =
-               "TLA+ §AutoCompactTriggered requires ~handoff_active; \
-                starting a compaction during handoff entangles two buffer \
-                ops on the same keeper"
-           })
-    else Ok ()
   | Operator_compact_requested ->
     (* TLA+ §OperatorCompactRequested.  Operator path differs from
        AutoCompactTriggered: it does NOT require [context_overflow], so

--- a/lib/keeper_registry/keeper_state_machine.mli
+++ b/lib/keeper_registry/keeper_state_machine.mli
@@ -28,8 +28,10 @@ type phase =
   | Offline       (** Registered but no heartbeat fiber started *)
   | Running       (** Healthy heartbeat loop executing *)
   | Failing       (** Consecutive failures detected, probing recovery *)
-  | Overflowed    (** Prompt exceeded provider max context; durable lane
-                      compaction is pending. *)
+  | Overflowed    (** Retired (#26546): no condition derives this phase since
+                      the automatic overflow-compaction trigger was removed.
+                      The variant survives so historical durable lifecycle
+                      records ("overflowed") still decode. *)
   | Compacting    (** Context compaction in progress *)
   | HandingOff    (** Generation rollover in progress *)
   | Draining      (** Graceful shutdown: completing current turn *)
@@ -78,11 +80,6 @@ type conditions = {
   (** Supervisor has requested immediate restart of a stopped fiber. *)
   drain_complete : bool;
   (** Current turn finished, no pending work *)
-  context_overflow : bool;
-  (** Provider rejected the most recent prompt for exceeding its max
-      context window. This is a hard failure reported by the provider.
-      Cleared by completed compaction or operator clear; token counts remain
-      observations, not lifecycle gates. *)
   credential_archived : bool;
 }
 
@@ -167,13 +164,6 @@ type event =
       }
   | Supervisor_restart_attempt of { attempt : int }
   | Credential_archived
-  | Context_overflow_detected of {
-      limit_tokens : int option;
-    }
-    (** Provider returned typed [ContextOverflow]. [limit_tokens] is only the
-        provider-declared window limit; actual input tokens remain unknown. *)
-  | Auto_compact_triggered
-    (** Legacy explicit input; no entry action produces this event. *)
   | Operator_compact_requested
     (** Operator invoked [masc_keeper_compact] MCP tool. *)
   | Operator_clear_requested of { preserve_system : bool; reason : string }
@@ -247,7 +237,7 @@ val transition_error_to_string : transition_error -> string
     7.  Paused (operator_paused)
     8.  HandingOff (handoff_active)
     9.  Compacting (compaction_active)
-    10. Overflowed (context_overflow) -- durable compaction pending
+    10. (retired #26546 — Overflowed is no longer derived)
     11. Failing (latest health failure or structural failure observation)
     12. Running (fiber_alive)
     13. Offline (default fallback for inconsistent zero-state)

--- a/lib/keeper_registry/keeper_state_machine_json.ml
+++ b/lib/keeper_registry/keeper_state_machine_json.ml
@@ -27,7 +27,6 @@ let conditions_to_json (c : conditions) =
     ; "dead_tombstone_latched", `Bool c.dead_tombstone_latched
     ; "restart_requested", `Bool c.restart_requested
     ; "drain_complete", `Bool c.drain_complete
-    ; "context_overflow", `Bool c.context_overflow
     ; "credential_archived", `Bool c.credential_archived
     ]
 ;;
@@ -84,16 +83,6 @@ let event_to_json (ev : event) : Yojson.Safe.t =
   | Supervisor_restart_attempt r ->
     obj "supervisor_restart_attempt" [ "attempt", `Int r.attempt ]
   | Credential_archived -> obj "credential_archived" []
-  | Context_overflow_detected r ->
-    let limit_tokens =
-      match r.limit_tokens with
-      | Some n -> `Int n
-      | None -> `Null
-    in
-    obj
-      "context_overflow_detected"
-      [ "limit_tokens", limit_tokens ]
-  | Auto_compact_triggered -> obj "auto_compact_triggered" []
   | Operator_compact_requested -> obj "operator_compact_requested" []
   | Operator_clear_requested r ->
     obj

--- a/lib/keeper_registry/keeper_state_machine_mermaid.ml
+++ b/lib/keeper_registry/keeper_state_machine_mermaid.ml
@@ -35,7 +35,6 @@ let phase_to_mermaid ~(current : phase) : string =
   p "    Offline --> Draining : stop requested\n";
   p "    Offline --> Stopped : stop while not started\n";
   p "    Running --> Failing : hb/turn/reconcile fail\n";
-  p "    Running --> Overflowed : prompt exceeded max context\n";
   p "    Running --> Compacting : compact start\n";
   p "    Running --> HandingOff : handoff start\n";
   p "    Running --> Draining : stop requested\n";
@@ -43,15 +42,13 @@ let phase_to_mermaid ~(current : phase) : string =
   p "    Running --> Stopped : stop requested\n";
   p "    Running --> Crashed : fiber death\n";
   p "    Failing --> Running : clean turn recovery\n";
-  p "    Failing --> Overflowed : prompt exceeded max context\n";
   p "    Failing --> Crashed : fiber death\n";
   p "    Failing --> Draining : stop requested\n";
   p "    Failing --> Paused : operator pause\n";
-  p "    Overflowed --> Running : operator clear\n";
-  p "    Overflowed --> Compacting : auto-compact\n";
-  p "    Overflowed --> Paused : operator pause\n";
-  p "    Overflowed --> Draining : stop requested\n";
-  p "    Overflowed --> Crashed : fiber death\n";
+  (* Overflowed is retired (#26546): no condition derives it, so it renders
+     without inbound edges — kept only for historical records that may still
+     name the phase. *)
+  p "    Overflowed --> Running : operator clear (retired phase)\n";
   p "    Compacting --> Running : compact done\n";
   p "    Compacting --> Running : compact failed (Lane retry queued)\n";
   p "    Compacting --> Failing : hb fail\n";

--- a/lib/keeper_registry/keeper_state_machine_phase.ml
+++ b/lib/keeper_registry/keeper_state_machine_phase.ml
@@ -17,6 +17,8 @@ type phase =
   | Running
   | Failing
   | Overflowed
+    (* Retired (#26546): never derived anymore; kept so historical durable
+       lifecycle records ("overflowed") still decode via [phase_of_string]. *)
   | Compacting
   | HandingOff
   | Draining

--- a/lib/keeper_registry/keeper_state_machine_types.ml
+++ b/lib/keeper_registry/keeper_state_machine_types.ml
@@ -35,7 +35,6 @@ type conditions =
   ; dead_tombstone_latched : bool
   ; restart_requested : bool
   ; drain_complete : bool
-  ; context_overflow : bool
   ; credential_archived : bool
   }
 
@@ -52,7 +51,6 @@ let default_conditions =
   ; dead_tombstone_latched = false
   ; restart_requested = false
   ; drain_complete = false
-  ; context_overflow = false
   ; credential_archived = false
   }
 ;;
@@ -99,9 +97,6 @@ type event =
       }
   | Supervisor_restart_attempt of { attempt : int }
   | Credential_archived
-  | Context_overflow_detected of
-      { limit_tokens : int option }
-  | Auto_compact_triggered
   | Operator_compact_requested
   | Operator_clear_requested of
       { preserve_system : bool
@@ -141,14 +136,6 @@ let event_to_string = function
   | Supervisor_restart_attempt r ->
     Printf.sprintf "supervisor_restart_attempt(%d)" r.attempt
   | Credential_archived -> "credential_archived"
-  | Context_overflow_detected r ->
-    let lim =
-      match r.limit_tokens with
-      | Some n -> string_of_int n
-      | None -> "?"
-    in
-    Printf.sprintf "context_overflow_detected(limit=%s)" lim
-  | Auto_compact_triggered -> "auto_compact_triggered"
   | Operator_compact_requested -> "operator_compact_requested"
   | Operator_clear_requested r ->
     Printf.sprintf

--- a/lib/keeper_registry/keeper_state_machine_types.mli
+++ b/lib/keeper_registry/keeper_state_machine_types.mli
@@ -29,7 +29,6 @@ type conditions = {
   dead_tombstone_latched : bool;
   restart_requested : bool;
   drain_complete : bool;
-  context_overflow : bool;
   credential_archived : bool;
 }
 val default_conditions : conditions
@@ -62,8 +61,6 @@ type event =
     }
   | Supervisor_restart_attempt of { attempt : int; }
   | Credential_archived
-  | Context_overflow_detected of { limit_tokens : int option; }
-  | Auto_compact_triggered
   | Operator_compact_requested
   | Operator_clear_requested of { preserve_system : bool; reason : string; }
 val event_to_string : event -> string

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -850,7 +850,10 @@ let blocked_keeper_action = function
   | Phase Keeper_state_machine.Offline -> Start_or_recover_keeper
   | Phase Keeper_state_machine.Running -> Inspect_capacity_accounting
   | Phase Keeper_state_machine.Failing -> Repair_failing_keeper
-  | Phase Keeper_state_machine.Overflowed -> Recover_context_overflow
+  | Phase Keeper_state_machine.Overflowed ->
+    (* Retired phase (#26546): unreachable for live keepers; kept for
+       exhaustiveness over the preserved variant. *)
+    Recover_context_overflow
   | Phase Keeper_state_machine.Compacting -> Wait_for_compaction
   | Phase Keeper_state_machine.HandingOff -> Wait_for_handoff
   | Phase Keeper_state_machine.Draining -> Wait_for_keeper_drain

--- a/test/test_keeper_overflow_recovery.ml
+++ b/test/test_keeper_overflow_recovery.ml
@@ -1,27 +1,12 @@
-(** Unit tests for the [Overflowed] phase and explicit compaction lifecycle.
+(** Codec tests for [Compaction_trigger].
 
-    Scenarios mirror the five cases in the MASC-1 plan:
-    1. Happy path — Running → Overflowed → Compacting → Running
-    2. Compact failed → executable again for durable Lane retry
-    3. Operator clear — Overflowed → Running without passing Compacting
-    4. Two consecutive overflows in one fiber lifecycle
-    5. Heartbeat failure while Overflowed is preserved through recovery *)
+    The trigger decoder stays a durable reader: dashboards decode historical
+    "pre_compact" records via [of_detail_json]. The Overflowed lifecycle
+    scenarios that used to live here were removed with the
+    [Context_overflow_detected] event (#26546) — no producer derives the
+    [Overflowed] phase anymore. *)
 
 open Alcotest
-
-module SM = Keeper_state_machine
-
-(** Conditions for a healthy Running keeper. *)
-let running_conds : SM.conditions =
-  { SM.default_conditions with
-    fiber_alive = true;
-    heartbeat_healthy = true;
-    turn_healthy = true;
-    dead_tombstone_latched = false;
-  }
-
-let overflow_event ?(limit = Some 200_000) () =
-  SM.Context_overflow_detected { limit_tokens = limit }
 
 let test_provider_overflow_trigger_roundtrip () =
   let trigger = Compaction_trigger.Provider_overflow { limit_tokens = Some 200_000 } in
@@ -204,143 +189,9 @@ let test_malformed_trigger_details_are_typed_errors () =
     [ `Int 0; `Int (-1); `String "200000" ]
 ;;
 
-let apply_ok phase conds ev =
-  match SM.apply_event ~current_phase:phase ~conditions:conds ~event:ev
-          ~now:0.0
-  with
-  | Ok tr -> tr
-  | Error err ->
-    failf
-      "apply_event rejected: %s (phase=%s event=%s)"
-      (SM.transition_error_to_string err)
-      (SM.phase_to_string phase)
-      (SM.event_to_string ev)
-
-let check_phase expected actual msg =
-  check string msg (SM.phase_to_string expected) (SM.phase_to_string actual)
-
-(* ── Scenario 1: happy path ───────────────────────────────── *)
-
-let test_happy_path () =
-  (* Running → overflow detected *)
-  let tr1 = apply_ok SM.Running running_conds (overflow_event ()) in
-  check_phase SM.Overflowed tr1.new_phase "overflow → Overflowed";
-  check bool "context_overflow latched" true
-    tr1.updated_conditions.context_overflow;
-  (* Durable Lane work is not synthesized as an FSM entry effect. *)
-  let has_start_compaction =
-    List.exists (function SM.Start_compaction -> true | _ -> false)
-      tr1.entry_actions
-  in
-  check bool "Overflowed does not synthesize compaction work" false has_start_compaction;
-  (* The Lane executor explicitly starts compaction. *)
-  let tr2 =
-    apply_ok SM.Overflowed tr1.updated_conditions SM.Compaction_started
-  in
-  check_phase SM.Compacting tr2.new_phase "compaction start → Compacting";
-  (* Compaction completes → Running (context_overflow cleared) *)
-  let tr3 =
-    apply_ok SM.Compacting tr2.updated_conditions
-      SM.Compaction_completed
-  in
-  check_phase SM.Running tr3.new_phase "compaction done → Running";
-  check bool "context_overflow cleared" false
-    tr3.updated_conditions.context_overflow
-
-(* ── Scenario 2: compact failure remains recoverable ──────── *)
-
-let test_compact_failure_releases_lane () =
-  (* Running → overflow → Overflowed *)
-  let tr1 = apply_ok SM.Running running_conds (overflow_event ()) in
-  (* The Lane executor explicitly starts compaction. *)
-  let tr2 =
-    apply_ok SM.Overflowed tr1.updated_conditions SM.Compaction_started
-  in
-  (* Compaction fails — the pending source remains available for exact retry. *)
-  let tr3 =
-    apply_ok SM.Compacting tr2.updated_conditions
-      (SM.Compaction_failed { reason = "oas_error" })
-  in
-  check_phase SM.Running tr3.new_phase
-    "compact failed, buffer latch released → Running";
-  check bool "context_overflow latch released" false
-    tr3.updated_conditions.context_overflow;
-  check bool "failure does not synthesize operator pause" false
-    tr3.updated_conditions.operator_paused
-
-(* ── Scenario 3: operator clear bypasses Compacting ───────── *)
-
-let test_operator_clear_returns_to_running () =
-  let tr1 = apply_ok SM.Running running_conds (overflow_event ()) in
-  check_phase SM.Overflowed tr1.new_phase "overflow → Overflowed";
-  let tr2 =
-    apply_ok SM.Overflowed tr1.updated_conditions
-      (SM.Operator_clear_requested
-         { preserve_system = true; reason = "manual test" })
-  in
-  check_phase SM.Running tr2.new_phase
-    "operator clear drops context → Running";
-  check bool "context_overflow cleared" false
-    tr2.updated_conditions.context_overflow;
-  check bool "compaction_active not touched" false
-    tr2.updated_conditions.compaction_active
-
-(* ── Scenario 4: two consecutive overflows in one fiber ───── *)
-
-let test_two_consecutive_overflows () =
-  (* Run one full overflow/compact/running cycle. *)
-  let tr1 = apply_ok SM.Running running_conds (overflow_event ()) in
-  let tr2 =
-    apply_ok SM.Overflowed tr1.updated_conditions SM.Compaction_started
-  in
-  let tr3 =
-    apply_ok SM.Compacting tr2.updated_conditions
-      SM.Compaction_completed
-  in
-  check_phase SM.Running tr3.new_phase "cycle 1 back to Running";
-  (* Second overflow should be handled cleanly after the successful cycle. *)
-  let tr4 = apply_ok SM.Running tr3.updated_conditions (overflow_event ()) in
-  check_phase SM.Overflowed tr4.new_phase "cycle 2 → Overflowed";
-  let tr5 =
-    apply_ok SM.Overflowed tr4.updated_conditions SM.Compaction_started
-  in
-  check_phase SM.Compacting tr5.new_phase "cycle 2 compaction → Compacting"
-
-(* ── Scenario 5: heartbeat failure during Overflowed ──────── *)
-
-let test_heartbeat_failure_preserved_through_overflow () =
-  (* Overflowed with a subsequent heartbeat failure: the heartbeat flag
-     must stick so the keeper surfaces Failing once the overflow is
-     resolved. No event is lost. *)
-  let tr1 = apply_ok SM.Running running_conds (overflow_event ()) in
-  check_phase SM.Overflowed tr1.new_phase "overflow → Overflowed";
-  let tr2 =
-    apply_ok SM.Overflowed tr1.updated_conditions
-      (SM.Heartbeat_failed { consecutive = 1 })
-  in
-  (* Phase stays Overflowed because context_overflow still wins in the
-     priority ladder, but heartbeat_healthy is now false. *)
-  check_phase SM.Overflowed tr2.new_phase
-    "Overflowed outranks heartbeat failure";
-  check bool "heartbeat unhealthy latched" false
-    tr2.updated_conditions.heartbeat_healthy;
-  (* Compaction finishes → overflow cleared. Heartbeat failure now
-     surfaces as Failing.  This confirms no event is swallowed. *)
-  let tr3 =
-    apply_ok SM.Overflowed tr2.updated_conditions SM.Compaction_started
-  in
-  check_phase SM.Compacting tr3.new_phase "compact starts";
-  let tr4 =
-    apply_ok SM.Compacting tr3.updated_conditions
-      SM.Compaction_completed
-  in
-  (* context_overflow cleared, heartbeat_healthy=false remains → Failing *)
-  check_phase SM.Failing tr4.new_phase
-    "post-compact, heartbeat failure surfaces as Failing"
-
 let () =
   run "keeper_overflow_recovery" [
-    "overflow-lifecycle",
+    "compaction-trigger-codec",
     [ test_case "provider overflow trigger codec" `Quick
         test_provider_overflow_trigger_roundtrip;
       test_case "retired trigger kinds rejected" `Quick
@@ -349,14 +200,5 @@ let () =
         test_request_body_over_capacity_rejects_non_refusals;
       test_case "malformed trigger details are typed errors" `Quick
         test_malformed_trigger_details_are_typed_errors;
-      test_case "happy path" `Quick test_happy_path;
-      test_case "compact failure releases Lane" `Quick
-        test_compact_failure_releases_lane;
-      test_case "operator clear returns to Running" `Quick
-        test_operator_clear_returns_to_running;
-      test_case "two consecutive overflows" `Quick
-        test_two_consecutive_overflows;
-      test_case "heartbeat failure preserved through overflow" `Quick
-        test_heartbeat_failure_preserved_through_overflow;
     ]
   ]

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -273,9 +273,6 @@ let test_operator_resume_from_paused_commits_latent_blockers () =
     [ ( "unhealthy turn"
       , { running_conditions with operator_paused = true; turn_healthy = false }
       , SM.Failing )
-    ; ( "context overflow"
-      , { running_conditions with operator_paused = true; context_overflow = true }
-      , SM.Overflowed )
     ; ( "handoff active"
       , { running_conditions with operator_paused = true; handoff_active = true }
       , SM.HandingOff )
@@ -1409,7 +1406,6 @@ let test_invariant_fiber_started_reset_exhaustive () =
     ; dead_tombstone_latched = false
     ; restart_requested = true
     ; drain_complete = true
-    ; context_overflow = true
     ; credential_archived = true
     }
   in
@@ -1650,7 +1646,10 @@ let test_invariant_derive_matches_matrix () =
               | SM.Offline -> SM.default_conditions
               | SM.Running -> running_conditions
               | SM.Failing -> { running_conditions with heartbeat_healthy = false }
-              | SM.Overflowed -> { running_conditions with context_overflow = true }
+              | SM.Overflowed ->
+                (* Retired phase (#26546): no conditions derive it, so the
+                   derive guard below skips this row. *)
+                running_conditions
               | SM.Compacting -> { running_conditions with compaction_active = true }
               | SM.HandingOff -> { running_conditions with handoff_active = true }
               | SM.Draining ->
@@ -1708,7 +1707,6 @@ let test_invariant_priority_chain () =
     ; dead_tombstone_latched = false
     ; restart_requested = true
     ; drain_complete = true
-    ; context_overflow = true
     ; credential_archived = false
     }
   in
@@ -1731,7 +1729,7 @@ let test_invariant_priority_chain () =
   check phase_t "no stop: Paused" SM.Paused (SM.derive_phase no_stop);
   (* Only the explicit operator pause condition can hold Paused. *)
   let no_paused =
-    { no_stop with operator_paused = false; context_overflow = false }
+    { no_stop with operator_paused = false }
   in
   check phase_t "no paused: HandingOff" SM.HandingOff (SM.derive_phase no_paused);
   (* Remove handoff: compaction wins *)
@@ -1772,7 +1770,6 @@ let test_setclear_coverage () =
     ; ("dead_tombstone_latched", fun c -> c.dead_tombstone_latched)
     ; ("restart_requested", fun c -> c.restart_requested)
     ; ("drain_complete", fun c -> c.drain_complete)
-    ; ("context_overflow", fun c -> c.context_overflow)
     ; ("credential_archived", fun c -> c.credential_archived)
     ]
   in
@@ -1790,7 +1787,6 @@ let test_setclear_coverage () =
     ; dead_tombstone_latched = false
     ; restart_requested = false
     ; drain_complete = false
-    ; context_overflow = false
     ; credential_archived = false
     }
   in
@@ -1808,7 +1804,6 @@ let test_setclear_coverage () =
     ; dead_tombstone_latched = true
     ; restart_requested = true
     ; drain_complete = true
-    ; context_overflow = true
     ; credential_archived = true
     }
   in
@@ -1853,10 +1848,6 @@ let test_setclear_coverage () =
     ; "Fiber_terminated", SM.Fiber_terminated { outcome = "test"; provider_id = None; http_status = None }
     ; "Supervisor_restart_attempt", SM.Supervisor_restart_attempt { attempt = 1 }
     ; "Credential_archived", SM.Credential_archived
-    ; ( "Context_overflow_detected"
-      , SM.Context_overflow_detected
-          { limit_tokens = Some 200_000 } )
-    ; "Auto_compact_triggered", SM.Auto_compact_triggered
     ; "Operator_compact_requested", SM.Operator_compact_requested
     ; ( "Operator_clear_requested"
       , SM.Operator_clear_requested { preserve_system = true; reason = "test" } )
@@ -2232,22 +2223,6 @@ let () =
         ] )
     ; ( "precondition_layer"
       , [ test_case
-            "Context_overflow_detected requires ~compaction_active"
-            `Quick
-            KSP.test_pre_overflow_during_compaction
-        ; test_case
-            "Auto_compact_triggered requires context_overflow"
-            `Quick
-            KSP.test_pre_auto_compact_no_overflow
-        ; test_case
-            "Auto_compact_triggered requires ~compaction_active"
-            `Quick
-            KSP.test_pre_auto_compact_active
-        ; test_case
-            "Auto_compact_triggered requires ~handoff_active"
-            `Quick
-            KSP.test_pre_auto_compact_handoff_active
-        ; test_case
             "Operator_compact_requested requires ~compaction_active"
             `Quick
             KSP.test_pre_operator_compact_during_compaction

--- a/test/test_keeper_state_machine_pbt.ml
+++ b/test/test_keeper_state_machine_pbt.ml
@@ -67,19 +67,16 @@ let valid_events_for_phase (phase : SM.phase) (c : SM.conditions) : SM.event lis
         SM.Stop_requested;
         SM.Operator_stop { remove_meta = false };
         SM.Fiber_terminated { outcome = "crash"; provider_id = None; http_status = None };
-        SM.Context_overflow_detected
-          { limit_tokens = Some 200000 };
       ]
     | SM.Failing ->
       [ SM.Heartbeat_ok; SM.Turn_succeeded;
         SM.Fiber_terminated { outcome = "crash"; provider_id = None; http_status = None };
         SM.Stop_requested; SM.Operator_pause;
-        SM.Context_overflow_detected
-          { limit_tokens = Some 200000 };
       ]
     | SM.Overflowed ->
-      [ SM.Auto_compact_triggered;
-        SM.Operator_compact_requested;
+      (* Retired phase (#26546): still a matchable variant for historical
+         decode, so keep exercising events from it. *)
+      [ SM.Operator_compact_requested;
         SM.Operator_clear_requested { preserve_system = true; reason = "pbt" };
         SM.Stop_requested;
         SM.Fiber_terminated { outcome = "crash"; provider_id = None; http_status = None };

--- a/test/test_keeper_state_machine_preconditions.ml
+++ b/test/test_keeper_state_machine_preconditions.ml
@@ -153,12 +153,8 @@ let test_attribution_gate_and_origin_invariant () =
     cases
 ;;
 
-let overflowed_conditions : SM.conditions =
-  { running_conditions with context_overflow = true }
-;;
-
 (* [event_to_string] for payload-carrying events appends the payload
-   (e.g. "context_overflow_detected(limit=...)"), so we use
+   (e.g. "heartbeat_failed(3)"), so we use
    prefix match rather than equality. *)
 let assert_precondition_violation ~event_name err =
   match err with
@@ -171,43 +167,6 @@ let assert_precondition_violation ~event_name err =
   | other ->
     Alcotest.fail
       ("expected Precondition_violation, got " ^ SM.transition_error_to_string other)
-;;
-
-let overflow_event =
-  SM.Context_overflow_detected
-    { limit_tokens = Some 200_000 }
-;;
-
-let test_pre_overflow_during_compaction () =
-  let c = { running_conditions with compaction_active = true } in
-  let err = apply_err ~current_phase:SM.Compacting ~conditions:c ~event:overflow_event in
-  assert_precondition_violation ~event_name:"context_overflow_detected" err
-;;
-
-let test_pre_auto_compact_no_overflow () =
-  let err =
-    apply_err
-      ~current_phase:SM.Running
-      ~conditions:running_conditions
-      ~event:SM.Auto_compact_triggered
-  in
-  assert_precondition_violation ~event_name:"auto_compact_triggered" err
-;;
-
-let test_pre_auto_compact_active () =
-  let c = { overflowed_conditions with compaction_active = true } in
-  let err =
-    apply_err ~current_phase:SM.Compacting ~conditions:c ~event:SM.Auto_compact_triggered
-  in
-  assert_precondition_violation ~event_name:"auto_compact_triggered" err
-;;
-
-let test_pre_auto_compact_handoff_active () =
-  let c = { overflowed_conditions with handoff_active = true } in
-  let err =
-    apply_err ~current_phase:SM.HandingOff ~conditions:c ~event:SM.Auto_compact_triggered
-  in
-  assert_precondition_violation ~event_name:"auto_compact_triggered" err
 ;;
 
 let test_pre_operator_compact_during_compaction () =
@@ -233,7 +192,7 @@ let test_pre_operator_compact_during_handoff () =
 ;;
 
 let test_pre_operator_clear_no_extra_precondition () =
-  let c = { running_conditions with context_overflow = true } in
+  let c = running_conditions in
   let clear_event =
     SM.Operator_clear_requested
       { preserve_system = false; reason = "operator escape-hatch" }

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -1092,8 +1092,9 @@ let test_attempt_loop_overflow_tries_next_candidate () =
     !attempts
 
 (* When every candidate overflows, the last typed ContextOverflow must be
-   preserved so the reactive compaction path
-   ([Keeper_turn_runtime_budget.context_overflow_event_of_error]) still fires. *)
+   preserved so the lane classifier
+   ([Keeper_unified_turn_execution.declared_lane_failure_of_error]) still
+   reports the capacity bound. *)
 let test_attempt_loop_overflow_on_last_candidate_is_terminal () =
   let attempts = ref [] in
   let events = ref [] in
@@ -1121,8 +1122,8 @@ let test_attempt_loop_overflow_on_last_candidate_is_terminal () =
 
 (* #26530: an overflow on an earlier candidate must survive lane exhaustion.
    Live incident 2026-07-31: glm overflowed, the ollama fallback then failed
-   with a rate limit, the lane returned that rate limit, the keeper FSM never
-   entered the overflowed phase, and compaction never fired while every cycle
+   with a rate limit, and the lane returned that rate limit — hiding the
+   deterministic capacity bound from the failure route while every cycle
    replayed the same oversized checkpoint. *)
 let test_attempt_loop_exhaustion_preserves_earlier_overflow () =
   let attempts = ref [] in

--- a/test/test_keeper_unified_context_overflow.ml
+++ b/test/test_keeper_unified_context_overflow.ml
@@ -330,7 +330,7 @@ let () =
             `Quick
             test_unusable_capacity_evidence_is_non_compacting
         ; test_case
-            "event projection admits only the token axis"
+            "lane classifier admits only the token axis"
             `Quick
             test_lane_classifier_admits_only_the_token_axis
         ] )

--- a/test/test_keeper_unified_context_overflow.ml
+++ b/test/test_keeper_unified_context_overflow.ml
@@ -94,11 +94,17 @@ let test_input_capacity_is_not_context_overflow () =
     (EC.is_context_overflow capacity_error);
   check
     bool
-    "typed input capacity emits no overflow event"
+    "typed input capacity does not classify as a lane overflow"
     true
-    (Option.is_none
-       (Masc.Keeper_unified_turn.context_overflow_event_of_error
-          capacity_error))
+    (match
+       Masc.Keeper_unified_turn_execution.For_testing
+       .declared_lane_failure_of_error
+         capacity_error
+     with
+     | Masc.Keeper_unified_turn_execution.For_testing
+       .Declared_runtime_lane_exhausted -> true
+     | Masc.Keeper_unified_turn_execution.For_testing
+       .Provider_context_overflow _ -> false)
 ;;
 
 (* ContextOverflow counts toward the ordinary crash threshold (#26546): the
@@ -262,28 +268,33 @@ let test_unusable_capacity_evidence_is_non_compacting () =
   | _ -> fail "measurement-unavailable became compactable"
 ;;
 
-(* The projection feeding the cascade path publishes
+(* The classifier feeding the cascade path publishes
    reason="provider_context_overflow" and the Sdk_context_window_exceeded blocker
    class, so admitting a byte refusal there would label it as a window exceedance. *)
-let test_event_projection_admits_only_the_token_axis () =
+let test_lane_classifier_admits_only_the_token_axis () =
+  let module E = Masc.Keeper_unified_turn_execution.For_testing in
   (match
-     Budget.context_overflow_event_of_error
+     E.declared_lane_failure_of_error
        (request_body_too_large ~actual_bytes:2_000_000 ~limit_bytes:1_048_576)
    with
-   | None -> ()
-   | Some _ -> fail "a byte refusal was projected as a context-overflow event");
+   | E.Declared_runtime_lane_exhausted -> ()
+   | E.Provider_context_overflow _ ->
+     fail "a byte refusal was classified as a context overflow");
   (match
-     Budget.context_overflow_event_of_error
+     E.declared_lane_failure_of_error
        (request_body_refused_by_provider ~status:413)
    with
-   | None -> ()
-   | Some _ -> fail "a provider byte refusal was projected as a token overflow");
+   | E.Declared_runtime_lane_exhausted -> ()
+   | E.Provider_context_overflow _ ->
+     fail "a provider byte refusal was classified as a token overflow");
   match
-    Budget.context_overflow_event_of_error
+    E.declared_lane_failure_of_error
       (Agent_sdk.Error.Api (ContextOverflow { message = "exceeded"; limit = None }))
   with
-  | Some (Keeper_state_machine.Context_overflow_detected { limit_tokens = None }) -> ()
-  | Some _ | None -> fail "the context overflow event projection regressed"
+  | E.Provider_context_overflow { limit_tokens = None } -> ()
+  | E.Provider_context_overflow { limit_tokens = Some _ }
+  | E.Declared_runtime_lane_exhausted ->
+    fail "the context overflow lane classification regressed"
 ;;
 
 let () =
@@ -321,7 +332,7 @@ let () =
         ; test_case
             "event projection admits only the token axis"
             `Quick
-            test_event_projection_admits_only_the_token_axis
+            test_lane_classifier_admits_only_the_token_axis
         ] )
     ]
 ;;

--- a/test/test_keeper_unified_context_overflow.ml
+++ b/test/test_keeper_unified_context_overflow.ml
@@ -215,7 +215,7 @@ let test_typed_capacity_transition_preserves_axes () =
          })
   in
   (match Budget.capacity_transition_of_error boundary with
-   | Budget.Compact_next_cycle
+   | Budget.Capacity_refusal_classified
        (Compaction_trigger.Serving_input_capacity
           (Compaction_trigger.Boundary_unknown
              { input_tokens = 524_299
@@ -230,7 +230,7 @@ let test_typed_capacity_transition_preserves_axes () =
          ~actual_bytes:2_000_000
          ~limit_bytes:1_048_576)
   with
-  | Budget.Compact_next_cycle
+  | Budget.Capacity_refusal_classified
       (Compaction_trigger.Request_body_over_capacity
          { actual_bytes = 2_000_000; limit_bytes = 1_048_576 }) ->
     ();
@@ -238,7 +238,7 @@ let test_typed_capacity_transition_preserves_axes () =
        Budget.capacity_transition_of_error
          (request_body_refused_by_provider ~status:413)
      with
-     | Budget.Compact_next_cycle
+     | Budget.Capacity_refusal_classified
          (Compaction_trigger.Request_body_refused_by_provider { status = 413 }) ->
        ()
      | _ -> fail "provider refusal did not become a typed capacity trigger")

--- a/test/test_pbt_context_overflow.ml
+++ b/test/test_pbt_context_overflow.ml
@@ -20,7 +20,7 @@ let gen_context_overflow_error =
 
 let prop_overflow_preserves_provider_limit =
   QCheck.Test.make ~count:200
-    ~name:"overflow event preserves the provider-declared optional limit"
+    ~name:"overflow classification preserves the provider-declared optional limit"
     (QCheck.make gen_context_overflow_error)
     (fun err ->
       let expected_limit =
@@ -28,10 +28,15 @@ let prop_overflow_preserves_provider_limit =
         | Agent_sdk.Error.Api (ContextOverflow { limit; _ }) -> limit
         | _ -> assert false
       in
-      match UT.context_overflow_event_of_error err with
-      | Some (Keeper_state_machine.Context_overflow_detected { limit_tokens }) ->
+      match
+        Masc.Keeper_unified_turn_execution.For_testing
+        .declared_lane_failure_of_error err
+      with
+      | Masc.Keeper_unified_turn_execution.For_testing
+        .Provider_context_overflow { limit_tokens } ->
           Option.equal Int.equal expected_limit limit_tokens
-      | _ -> false)
+      | Masc.Keeper_unified_turn_execution.For_testing
+        .Declared_runtime_lane_exhausted -> false)
 
 let user_text text : Agent_sdk.Types.message =
   { role = Agent_sdk.Types.User


### PR DESCRIPTION
## #26546 2단계: overflow FSM 어휘 절제 (+160/−517)

1단계(#26547, 병합됨)가 자동 overflow→컴팩션 recovery 실행부를 제거했다. 이번 단계는 **그 recovery만이 생산하던 state-machine 어휘**를 제거한다. 근거는 1단계와 동일(806연패 + #26545 tail window로 트리거 의미 소멸)이며, 이번 절제 대상은 전부 이미-도달-불가임을 정찰로 확정했다:

- `Context_overflow_detected`는 **FSM에 dispatch되는 곳이 0** — 유일 소비가 blocker 라벨 문자열 생성이었다 (`dispatch_event` 호출 전수 확인).
- `Auto_compact_triggered`는 **생산자 0** (소스 주석 자백: "Legacy explicit input. No entry action produces this event.").
- 따라서 `conditions.context_overflow`를 true로 만드는 경로가 0 → `Overflowed` 파생 분기는 죽은 코드.

### 커밋 구성

| 커밋 | 내용 |
|---|---|
| `414c7c1aa9` | 이벤트 2종 + `context_overflow` condition + `Overflowed` 파생 제거, lane 분류기를 `capacity_refusal_of_error` 직결로 개편(`declared_lane_failure`가 `{ limit_tokens }` 운반), observer TLA 액션 2종(EnterOverflowed/OverflowedAutoCompact, 참조 0) 제거, mermaid/dot 갱신, 테스트 재작성 |
| `168ca25bb0` | `EmergencyCompactRatioThreshold` — emit 0, 대시보드/테스트 참조 0인 dead 메트릭 제거 |
| `8bfd342aa5` | `Compact_next_cycle` → `Capacity_refusal_classified` 개명(예약 동작이 존재한 적 없음 — 분류만 수행), 낡은 reactive-compaction 서술 주석/운영 문구 정리 |

### 보존 (경계 — 1단계의 `Compaction_trigger.t`와 동일 지위)

- **`Overflowed` phase variant + `"overflowed"` 문자열 코덱**: `phase_of_string`이 durable/wire lifecycle 레코드를 디코드하는 3곳(`server_bootstrap_loops`, fleet scan `phase_detail`, `server_schedule_consumers`)에서 사용되고, 과거 806회 전이가 그 레코드에 실재한다. variant 제거는 과거 데이터 디코드를 깨므로 **retired vocabulary**로 보존하고 mli/파생/arm에 명시. TLA phase-set parity(`test_keeper_state_machine_tla_correspondence`)도 이 결정 덕에 무변경.
- **수동 컴팩션 전 경로**: `Operator_compact_requested`/`Compaction_started`/`Compacting` — `masc_keeper_compact`가 사용, `test_keeper_manual_compaction_preemption` 4/4 green.
- **turn_driver 최초-overflow 보존(#26530) 로직**: 동작 유지(마지막 후보의 rate-limit이 deterministic capacity bound를 가리는 것 방지 — failure route/blocker 정확성), 주석만 "compaction 발화" 서사에서 정리.
- **`Turn_overflow_failure` 등 failure-reason 코덱**: 과거 durable meta 읽기용 reader.

### 라벨 연속성

blocker detail은 정확히 기존 형태(`context_overflow_detected(limit=N)`)를 유지 — 이벤트 프린터 제거로 운영 로그 grep이 끊기지 않도록 로컬 포맷터로 이관.

### 검증 (로컬, 커밋 후)

- `dune build @check` green, 변경 OCaml 파일 ocamlformat OK, 메타 게이트 4종(SIL/TEL/DET/STR) PASS.
- 테스트: state_machine 102 · mermaid 5 · **tla_correspondence 5** · pbt 2 · overflow_recovery 4(코덱만) · unified_context_overflow 8 · pbt_context_overflow 2 · failed_selection_disposition 5 · turn_driver_failover 32 · heartbeat_integration 48 · manual_compaction_preemption 4 · clean_only_bug_mirrors 3 · event_priority_monotone_pbt 5 — green.
- pre-existing (이 브랜치 무관, main `a7ab266f86`에서 동일 재현): `test_keeper_tool_dispatch_runtime` 3건, `test_keeper_composite_live_turn_surface` 9건(“agent_name does not match canonical keeper identity” — 로컬 환경 계열, CI green 이력).

### 라이브 증명 게이트 (머지≠작동)

1단계와 묶어 재기동 1회로 배포. 배포 후: ①keeper 정상 순환(파생 phase에 Overflowed 미출현) ②수동 `masc_keeper_compact` 동작 ③대시보드 lifecycle/과거 기록 조회 정상(“overflowed” 레코드 디코드 유지).

### 남은 것 (#26546 ③, 별도 궤도)

`Keeper_compaction_llm_summarizer`/`compaction_exact` lane/컴팩션 텔레메트리 제거는 **수동 compaction까지 걷어내는 단계**라 관측 유예(양자화 점프 반복 + librarian cadence 지속 확인) 후 진행.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
