### PR TITLE
ci: make blocked OAS review pins verifiable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,10 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
-    types: [opened, synchronize, reopened]
+    # ready_for_review must re-evaluate Draft-only dependency allowances on the
+    # exact same head; otherwise an ephemeral review ref could retain a green
+    # CI Gate after the PR becomes mergeable.
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch: {}
 
 permissions:
@@ -23,13 +26,15 @@ concurrency:
       github.event_name == 'push' && github.ref_name == 'main' && github.sha
       || github.head_ref || github.ref_name || github.run_id
     }}
-  # Code-changing PR events supersede older CI for the same PR. Pushes to the
-  # same branch also supersede older post-merge CI EXCEPT for main pushes —
-  # main commits are independent state that must each be verified (background:
+  # Code-changing and ready-for-review PR events supersede older CI for the
+  # same PR. Pushes to the same branch also supersede older post-merge CI
+  # EXCEPT for main pushes — main commits are independent state that must each
+  # be verified (background:
   # #14668 / #14670, 30+ main runs cancelled before TLA could complete on
   # 2026-05-11). State-only readiness is enforced by PR Automation against the
-  # existing head CI Gate; it must not create a fresh required CI Gate context.
-  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref_name != 'main') || (github.event_name == 'pull_request' && contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action)) }}
+  # existing head CI Gate. Ready-for-review is the exception: Draft-only
+  # dependency allowances must be revoked and rechecked before merge.
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref_name != 'main') || (github.event_name == 'pull_request' && contains(fromJSON('["opened","synchronize","reopened","ready_for_review"]'), github.event.action)) }}
 
 jobs:
   pr-sync-check:
@@ -427,12 +432,25 @@ jobs:
           scripts/sync-oas-pin-docs.sh --check
           scripts/audit-keeper-tool-boundary-matrix.sh
 
-      - name: Check OAS pin consistency
+      - name: Check OAS pin manifests
         if: needs.changes.outputs.oas_pin == 'true'
         run: |
-          chmod +x scripts/check-oas-pin.sh scripts/oas-drift-check.sh
+          chmod +x scripts/check-oas-pin.sh
+          bash test/test_oas_pin_ref.sh
           scripts/check-oas-pin.sh --local-only
-          scripts/oas-drift-check.sh
+
+      - name: Check OAS API surface source
+        if: needs.changes.outputs.oas_pin == 'true'
+        env:
+          ALLOW_REVIEW_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == true && contains(github.event.pull_request.labels.*.name, 'blocked-on-oas') }}
+        run: |
+          chmod +x scripts/oas-drift-check.sh
+          if [[ "$ALLOW_REVIEW_REF" == "true" ]]; then
+            echo "::notice::Draft PR blocked on OAS: validating the explicit upstream review ref"
+            scripts/oas-drift-check.sh --allow-review-ref
+          else
+            scripts/oas-drift-check.sh
+          fi
 
       - name: Run report self-test
         if: needs.changes.outputs.lib_deps == 'true'

--- a/scripts/check-oas-pin-forward.sh
+++ b/scripts/check-oas-pin-forward.sh
@@ -22,6 +22,10 @@
 # and is rejected, matching the ref-reachability policy of check-oas-pin.sh.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=oas-pin-ref.sh
+source "${SCRIPT_DIR}/oas-pin-ref.sh"
+
 if [[ $# -ne 4 ]]; then
   echo "usage: $0 EXPECTED_SHA INSTALLED_SHA REMOTE TRACK_REF" >&2
   exit 2
@@ -36,6 +40,7 @@ track_ref="$4"
 [[ "${installed_sha}" =~ ^[0-9a-f]{40}$ ]] || exit 1
 [[ "${expected_sha}" != "${installed_sha}" ]] || exit 1
 [[ -n "${remote}" && -n "${track_ref}" ]] || exit 1
+remote_ref="$(oas_pin_remote_ref "${track_ref}")" || exit 1
 
 scratch="$(mktemp -d -t oas-pin-forward.XXXXXX)"
 trap 'rm -rf "${scratch}"' EXIT
@@ -44,7 +49,7 @@ if ! GIT_DIR="${scratch}" git init -q --bare; then
   exit 1
 fi
 if ! GIT_DIR="${scratch}" git fetch -q --no-tags "${remote}" \
-       "+refs/heads/${track_ref}:refs/heads/${track_ref}" 2>/dev/null; then
+       "+${remote_ref}:${remote_ref}" 2>/dev/null; then
   exit 1
 fi
 GIT_DIR="${scratch}" git merge-base --is-ancestor \

--- a/scripts/check-oas-pin.sh
+++ b/scripts/check-oas-pin.sh
@@ -74,7 +74,7 @@ if [[ "${pin_source}" == "${default_pin_source}" ]]; then
     )"
 
     if [[ -z "${latest_track_sha}" ]]; then
-      echo "failed to resolve upstream ${OAS_AGENT_SDK_TRACK_REF} SHA" >&2
+      echo "failed to resolve upstream ${OAS_AGENT_SDK_REMOTE_REF} SHA" >&2
       exit 1
     fi
 
@@ -96,14 +96,14 @@ if [[ "${pin_source}" == "${default_pin_source}" ]]; then
       if ! GIT_DIR="${reachability_scratch}" git merge-base --is-ancestor \
            "${OAS_AGENT_SDK_SHA}" \
            "${OAS_AGENT_SDK_REMOTE_REF}" 2>/dev/null; then
-        echo "OAS pin ${OAS_AGENT_SDK_SHA} is not reachable from ${OAS_AGENT_SDK_TRACK_REF} on ${OAS_AGENT_SDK_URL}" >&2
+        echo "OAS pin ${OAS_AGENT_SDK_SHA} is not reachable from ${OAS_AGENT_SDK_REMOTE_REF} on ${OAS_AGENT_SDK_URL}" >&2
         echo "  Orphan or diverged SHAs are GC candidates on GitHub and will silently break CI once collected." >&2
-        echo "  repair: bump OAS_AGENT_SDK_SHA in scripts/oas-agent-sdk-pin.sh to a commit on ${OAS_AGENT_SDK_TRACK_REF}" >&2
+        echo "  repair: bump OAS_AGENT_SDK_SHA in scripts/oas-agent-sdk-pin.sh to a commit on ${OAS_AGENT_SDK_REMOTE_REF}" >&2
         rm -rf "${reachability_scratch}"
         exit 1
       fi
     else
-      echo "WARN: could not fetch ${OAS_AGENT_SDK_TRACK_REF} from ${OAS_AGENT_SDK_URL}; skipping ref-reachability check" >&2
+      echo "WARN: could not fetch ${OAS_AGENT_SDK_REMOTE_REF} from ${OAS_AGENT_SDK_URL}; skipping ref-reachability check" >&2
     fi
     rm -rf "${reachability_scratch}"
   fi

--- a/scripts/check-oas-pin.sh
+++ b/scripts/check-oas-pin.sh
@@ -103,7 +103,16 @@ if [[ "${pin_source}" == "${default_pin_source}" ]]; then
         exit 1
       fi
     else
-      echo "WARN: could not fetch ${OAS_AGENT_SDK_REMOTE_REF} from ${OAS_AGENT_SDK_URL}; skipping ref-reachability check" >&2
+      # A fetch failure is not evidence that the pin is reachable. This guard
+      # exists precisely because an orphan SHA still resolves locally until
+      # GitHub collects it, so skipping it on the failure path would pass the
+      # case it was written to catch. Offline verification has its own switch.
+      echo "could not fetch ${OAS_AGENT_SDK_REMOTE_REF} from ${OAS_AGENT_SDK_URL}" >&2
+      echo "  ref-reachability is unproven, which is not the same as proven." >&2
+      echo "  repair: restore network access, or run with --local-only to check" >&2
+      echo "  manifests alone." >&2
+      rm -rf "${reachability_scratch}"
+      exit 1
     fi
     rm -rf "${reachability_scratch}"
   fi

--- a/scripts/check-oas-pin.sh
+++ b/scripts/check-oas-pin.sh
@@ -4,14 +4,18 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 LOCAL_ONLY=0
+ALLOW_REVIEW_REF=0
 
 usage() {
   cat <<'EOF'
-Usage: scripts/check-oas-pin.sh [--local-only]
+Usage: scripts/check-oas-pin.sh [--local-only] [--allow-review-ref]
 
 Options:
   --local-only   Skip upstream remote drift lookup and verify only repository
                  manifests plus the current local opam switch.
+  --allow-review-ref
+                 Permit the exact refs/pull/<number>/head configured for a
+                 blocked Draft cross-repo PR during network-backed checks.
   -h, --help     Show this help.
 EOF
 }
@@ -20,6 +24,10 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --local-only)
       LOCAL_ONLY=1
+      shift
+      ;;
+    --allow-review-ref)
+      ALLOW_REVIEW_REF=1
       shift
       ;;
     -h|--help)
@@ -36,8 +44,20 @@ done
 
 # GitHub release metadata can lag for this repo. Keep the dependency floor
 # aligned with the pinned SDK's declared opam version, and ratchet the runtime
-# pin against upstream main so CI catches drift immediately.
+# pin against its declared upstream source ref so CI catches drift immediately.
 source "${SCRIPT_DIR}/oas-agent-sdk-pin.sh"
+# shellcheck source=oas-pin-ref.sh
+source "${SCRIPT_DIR}/oas-pin-ref.sh"
+
+OAS_AGENT_SDK_REMOTE_REF="$(oas_pin_remote_ref "${OAS_AGENT_SDK_TRACK_REF}")" || {
+  echo "invalid OAS_AGENT_SDK_TRACK_REF: ${OAS_AGENT_SDK_TRACK_REF}" >&2
+  exit 1
+}
+if [[ "${LOCAL_ONLY}" -eq 0 ]]; then
+  oas_pin_require_track_policy \
+    "${OAS_AGENT_SDK_REMOTE_REF}" \
+    "${ALLOW_REVIEW_REF}"
+fi
 
 default_pin_source="${OAS_AGENT_SDK_URL}#${OAS_AGENT_SDK_SHA}"
 pin_source="${AGENT_SDK_PIN_URL:-${default_pin_source}}"
@@ -48,18 +68,18 @@ local_oas_checkout="${AGENT_SDK_LOCAL_REPO:-}"
 
 if [[ "${pin_source}" == "${default_pin_source}" ]]; then
   if [[ "${LOCAL_ONLY}" -eq 0 ]]; then
-    latest_main_sha="$(
-      git ls-remote "${OAS_AGENT_SDK_URL}" "refs/heads/${OAS_AGENT_SDK_TRACK_REF}" \
+    latest_track_sha="$(
+      git ls-remote "${OAS_AGENT_SDK_URL}" "${OAS_AGENT_SDK_REMOTE_REF}" \
         | awk '{print $1}'
     )"
 
-    if [[ -z "${latest_main_sha}" ]]; then
+    if [[ -z "${latest_track_sha}" ]]; then
       echo "failed to resolve upstream ${OAS_AGENT_SDK_TRACK_REF} SHA" >&2
       exit 1
     fi
 
-    if [[ "${OAS_AGENT_SDK_SHA}" != "${latest_main_sha}" ]]; then
-      echo "::warning::OAS main drift: pinned ${OAS_AGENT_SDK_SHA}, upstream ${latest_main_sha} — update pin when API-compatible"
+    if [[ "${OAS_AGENT_SDK_SHA}" != "${latest_track_sha}" ]]; then
+      echo "::warning::OAS track-ref drift: pinned ${OAS_AGENT_SDK_SHA}, ${OAS_AGENT_SDK_TRACK_REF} ${latest_track_sha} — update pin when API-compatible"
     fi
 
     # Ref-reachability guard: the pin SHA must be an ancestor of
@@ -71,11 +91,11 @@ if [[ "${pin_source}" == "${default_pin_source}" ]]; then
     if GIT_DIR="${reachability_scratch}" git init -q --bare \
        && GIT_DIR="${reachability_scratch}" git fetch -q --no-tags \
             "${OAS_AGENT_SDK_URL}" \
-            "+refs/heads/${OAS_AGENT_SDK_TRACK_REF}:refs/heads/${OAS_AGENT_SDK_TRACK_REF}" \
+            "+${OAS_AGENT_SDK_REMOTE_REF}:${OAS_AGENT_SDK_REMOTE_REF}" \
             2>/dev/null; then
       if ! GIT_DIR="${reachability_scratch}" git merge-base --is-ancestor \
            "${OAS_AGENT_SDK_SHA}" \
-           "refs/heads/${OAS_AGENT_SDK_TRACK_REF}" 2>/dev/null; then
+           "${OAS_AGENT_SDK_REMOTE_REF}" 2>/dev/null; then
         echo "OAS pin ${OAS_AGENT_SDK_SHA} is not reachable from ${OAS_AGENT_SDK_TRACK_REF} on ${OAS_AGENT_SDK_URL}" >&2
         echo "  Orphan or diverged SHAs are GC candidates on GitHub and will silently break CI once collected." >&2
         echo "  repair: bump OAS_AGENT_SDK_SHA in scripts/oas-agent-sdk-pin.sh to a commit on ${OAS_AGENT_SDK_TRACK_REF}" >&2
@@ -356,7 +376,14 @@ fi
 # contract.  Local-mode callers (dune-local.sh preflight) get the
 # fingerprint check via the artifact verification above.
 if [[ "${LOCAL_ONLY}" -eq 0 && -x "${SCRIPT_DIR}/oas-drift-check.sh" ]]; then
-  if drift_output="$(bash "${SCRIPT_DIR}/oas-drift-check.sh" 2>&1)"; then
+  run_drift_check() {
+    if [[ "${ALLOW_REVIEW_REF}" -eq 1 ]]; then
+      bash "${SCRIPT_DIR}/oas-drift-check.sh" --allow-review-ref
+    else
+      bash "${SCRIPT_DIR}/oas-drift-check.sh"
+    fi
+  }
+  if drift_output="$(run_drift_check 2>&1)"; then
     echo "OAS API surface: ✓ matches fingerprint"
   else
     drift_exit=$?

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -60,7 +60,10 @@ readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.10"
 # Previous pin: v0.231.6 (ae4cc5536).
 readonly OAS_AGENT_SDK_DECLARED_VERSION="0.231.10"
 # TRACK_REF consumed by check-oas-pin.sh / oas-drift-check.sh /
-# sync-oas-pin-docs.sh; removed by #25579 and restored here (#25584).
+# sync-oas-pin-docs.sh; removed by #25579 and restored here (#25584). Use main
+# for merge-ready pins. A blocked Draft cross-repo PR may temporarily declare
+# the exact refs/pull/<number>/head review ref; CI rejects that ref once the PR
+# is no longer both Draft and blocked-on-oas.
 readonly OAS_AGENT_SDK_TRACK_REF="main"
 readonly OAS_AGENT_SDK_SHA="1fa61251936758d37c3a33eac07b8d95c5f26d35"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.231.10"

--- a/scripts/oas-drift-check.sh
+++ b/scripts/oas-drift-check.sh
@@ -111,18 +111,18 @@ resolve_source_dir() {
          "${OAS_AGENT_SDK_URL}" \
          "+${OAS_AGENT_SDK_REMOTE_REF}:${OAS_AGENT_SDK_REMOTE_REF}" \
          2>/dev/null; then
-    echo "git fetch of ${OAS_AGENT_SDK_TRACK_REF} from ${OAS_AGENT_SDK_URL} failed" >&2
+    echo "git fetch of ${OAS_AGENT_SDK_REMOTE_REF} from ${OAS_AGENT_SDK_URL} failed" >&2
     return 1
   fi
   if ! GIT_DIR="${scratch}/bare" git cat-file -e "${OAS_AGENT_SDK_SHA}^{commit}" \
         2>/dev/null; then
-    echo "pinned OAS SHA ${OAS_AGENT_SDK_SHA} is not reachable from ${OAS_AGENT_SDK_TRACK_REF} on ${OAS_AGENT_SDK_URL}" >&2
+    echo "pinned OAS SHA ${OAS_AGENT_SDK_SHA} is not reachable from ${OAS_AGENT_SDK_REMOTE_REF} on ${OAS_AGENT_SDK_URL}" >&2
     return 1
   fi
   if ! GIT_DIR="${scratch}/bare" git merge-base --is-ancestor \
         "${OAS_AGENT_SDK_SHA}" \
         "${OAS_AGENT_SDK_REMOTE_REF}" 2>/dev/null; then
-    echo "pinned OAS SHA ${OAS_AGENT_SDK_SHA} is not reachable from ${OAS_AGENT_SDK_TRACK_REF} on ${OAS_AGENT_SDK_URL}" >&2
+    echo "pinned OAS SHA ${OAS_AGENT_SDK_SHA} is not reachable from ${OAS_AGENT_SDK_REMOTE_REF} on ${OAS_AGENT_SDK_URL}" >&2
     return 1
   fi
   mkdir -p "${scratch}/tree"

--- a/scripts/oas-drift-check.sh
+++ b/scripts/oas-drift-check.sh
@@ -14,6 +14,9 @@
 #   scripts/oas-drift-check.sh               # check; exit 0 match / 2 drift / 1 error
 #   scripts/oas-drift-check.sh --regenerate  # rewrite fingerprint from pinned SHA source
 #   scripts/oas-drift-check.sh --print       # print current surfaces, no diff
+#   scripts/oas-drift-check.sh --allow-review-ref
+#                                              # allow an exact refs/pull/N/head
+#                                              # source for a blocked Draft PR
 #
 # Source resolution (first hit wins):
 #   1. $AGENT_SDK_LOCAL_REPO if a git checkout at the pinned SHA
@@ -28,12 +31,16 @@ FINGERPRINT_FILE="${REPO_ROOT}/scripts/oas-api-surface.json"
 
 # shellcheck source=oas-agent-sdk-pin.sh
 source "${SCRIPT_DIR}/oas-agent-sdk-pin.sh"
+# shellcheck source=oas-pin-ref.sh
+source "${SCRIPT_DIR}/oas-pin-ref.sh"
 
 MODE="check"
+ALLOW_REVIEW_REF=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --regenerate) MODE="regenerate"; shift ;;
     --print)      MODE="print"; shift ;;
+    --allow-review-ref) ALLOW_REVIEW_REF=1; shift ;;
     -h|--help)
       sed -n '1,/^set -euo/p' "$0" | sed 's/^# \{0,1\}//'
       exit 0 ;;
@@ -42,6 +49,14 @@ while [[ $# -gt 0 ]]; do
 done
 
 command -v jq >/dev/null 2>&1 || { echo "jq required" >&2; exit 1; }
+
+OAS_AGENT_SDK_REMOTE_REF="$(oas_pin_remote_ref "${OAS_AGENT_SDK_TRACK_REF}")" || {
+  echo "invalid OAS_AGENT_SDK_TRACK_REF: ${OAS_AGENT_SDK_TRACK_REF}" >&2
+  exit 1
+}
+oas_pin_require_track_policy \
+  "${OAS_AGENT_SDK_REMOTE_REF}" \
+  "${ALLOW_REVIEW_REF}"
 
 # ---------------------------------------------------------------------------
 # Source resolution
@@ -94,7 +109,7 @@ resolve_source_dir() {
   fi
   if ! GIT_DIR="${scratch}/bare" git fetch -q --no-tags \
          "${OAS_AGENT_SDK_URL}" \
-         "+refs/heads/${OAS_AGENT_SDK_TRACK_REF}:refs/heads/${OAS_AGENT_SDK_TRACK_REF}" \
+         "+${OAS_AGENT_SDK_REMOTE_REF}:${OAS_AGENT_SDK_REMOTE_REF}" \
          2>/dev/null; then
     echo "git fetch of ${OAS_AGENT_SDK_TRACK_REF} from ${OAS_AGENT_SDK_URL} failed" >&2
     return 1
@@ -106,7 +121,7 @@ resolve_source_dir() {
   fi
   if ! GIT_DIR="${scratch}/bare" git merge-base --is-ancestor \
         "${OAS_AGENT_SDK_SHA}" \
-        "refs/heads/${OAS_AGENT_SDK_TRACK_REF}" 2>/dev/null; then
+        "${OAS_AGENT_SDK_REMOTE_REF}" 2>/dev/null; then
     echo "pinned OAS SHA ${OAS_AGENT_SDK_SHA} is not reachable from ${OAS_AGENT_SDK_TRACK_REF} on ${OAS_AGENT_SDK_URL}" >&2
     return 1
   fi

--- a/scripts/oas-pin-ref.sh
+++ b/scripts/oas-pin-ref.sh
@@ -10,7 +10,7 @@ oas_pin_remote_ref() {
       [[ "${configured_ref}" != "refs/heads/" ]] || return 1
       printf '%s' "${configured_ref}"
       ;;
-    refs/pull/[1-9]*'/head')
+    refs/pull/[1-9]*/head)
       [[ "${configured_ref}" =~ ^refs/pull/[1-9][0-9]*/head$ ]] || return 1
       printf '%s' "${configured_ref}"
       ;;
@@ -30,7 +30,7 @@ oas_pin_require_track_policy() {
     refs/heads/main)
       return 0
       ;;
-    refs/pull/[1-9]*'/head')
+    refs/pull/[1-9]*/head)
       if [[ "${allow_review_ref}" == "1" ]]; then
         return 0
       fi

--- a/scripts/oas-pin-ref.sh
+++ b/scripts/oas-pin-ref.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Normalize the configured OAS tracking ref without guessing its namespace.
+# Branch names retain the historical shorthand; cross-repo review pins must use
+# GitHub's exact pull-request ref so CI can fetch and prove their ancestry.
+oas_pin_remote_ref() {
+  local configured_ref="$1"
+  case "${configured_ref}" in
+    refs/heads/*)
+      [[ "${configured_ref}" != "refs/heads/" ]] || return 1
+      printf '%s' "${configured_ref}"
+      ;;
+    refs/pull/[1-9]*'/head')
+      [[ "${configured_ref}" =~ ^refs/pull/[1-9][0-9]*/head$ ]] || return 1
+      printf '%s' "${configured_ref}"
+      ;;
+    refs/* | "")
+      return 1
+      ;;
+    *)
+      printf 'refs/heads/%s' "${configured_ref}"
+      ;;
+  esac
+}
+
+oas_pin_require_track_policy() {
+  local remote_ref="$1"
+  local allow_review_ref="${2:-0}"
+  case "${remote_ref}" in
+    refs/heads/main)
+      return 0
+      ;;
+    refs/pull/[1-9]*'/head')
+      if [[ "${allow_review_ref}" == "1" ]]; then
+        return 0
+      fi
+      echo "OAS review ref ${remote_ref} is allowed only for an explicitly blocked Draft PR" >&2
+      echo "  repair: merge the upstream PR and restore OAS_AGENT_SDK_TRACK_REF=main" >&2
+      return 1
+      ;;
+    *)
+      echo "unsupported OAS tracking ref: ${remote_ref}" >&2
+      echo "  allowed: refs/heads/main, or refs/pull/<number>/head for an explicitly blocked Draft PR" >&2
+      return 1
+      ;;
+  esac
+}

--- a/scripts/sync-oas-pin-manifests.sh
+++ b/scripts/sync-oas-pin-manifests.sh
@@ -13,15 +13,19 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 CHECK_ONLY=0
 UPDATE_SURFACE=0
+ALLOW_REVIEW_REF=0
 
 usage() {
   cat <<'EOF'
-Usage: scripts/sync-oas-pin-manifests.sh [--check] [--surface]
+Usage: scripts/sync-oas-pin-manifests.sh [--check] [--surface] [--allow-review-ref]
 
 Options:
   --check     Verify generated OAS pin manifests are up to date.
   --surface   Also check/regenerate scripts/oas-api-surface.json.
               In write mode this runs oas-drift-check.sh --regenerate.
+  --allow-review-ref
+              Permit the exact refs/pull/<number>/head configured for a
+              blocked Draft cross-repo PR.
   -h, --help  Show this help.
 EOF
 }
@@ -34,6 +38,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --surface)
       UPDATE_SURFACE=1
+      shift
+      ;;
+    --allow-review-ref)
+      ALLOW_REVIEW_REF=1
       shift
       ;;
     -h | --help)
@@ -150,9 +158,17 @@ sync_surface() {
   fi
 
   if [[ "${CHECK_ONLY}" -eq 1 ]]; then
-    bash "${SCRIPT_DIR}/oas-drift-check.sh"
+    if [[ "${ALLOW_REVIEW_REF}" -eq 1 ]]; then
+      bash "${SCRIPT_DIR}/oas-drift-check.sh" --allow-review-ref
+    else
+      bash "${SCRIPT_DIR}/oas-drift-check.sh"
+    fi
   else
-    bash "${SCRIPT_DIR}/oas-drift-check.sh" --regenerate
+    if [[ "${ALLOW_REVIEW_REF}" -eq 1 ]]; then
+      bash "${SCRIPT_DIR}/oas-drift-check.sh" --regenerate --allow-review-ref
+    else
+      bash "${SCRIPT_DIR}/oas-drift-check.sh" --regenerate
+    fi
   fi
 }
 

--- a/test/test_oas_pin_ref.sh
+++ b/test/test_oas_pin_ref.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../scripts/oas-pin-ref.sh
+source "${SCRIPT_DIR}/scripts/oas-pin-ref.sh"
+
+expect_value() {
+  local description="$1" expected="$2" configured_ref="$3" actual
+  actual="$(oas_pin_remote_ref "${configured_ref}")"
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "FAIL: ${description}: expected ${expected}, got ${actual}" >&2
+    exit 1
+  fi
+}
+
+expect_reject() {
+  local description="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    echo "FAIL: ${description}: expected rejection" >&2
+    exit 1
+  fi
+}
+
+expect_value "main shorthand" "refs/heads/main" "main"
+expect_value "full main ref" "refs/heads/main" "refs/heads/main"
+expect_value "review ref" "refs/pull/2910/head" "refs/pull/2910/head"
+expect_reject "malformed review ref" oas_pin_remote_ref "refs/pull/0/head"
+expect_reject "unknown namespace" oas_pin_remote_ref "refs/tags/v1"
+
+oas_pin_require_track_policy "refs/heads/main" 0
+oas_pin_require_track_policy "refs/pull/2910/head" 1
+expect_reject \
+  "review ref without explicit Draft allowance" \
+  oas_pin_require_track_policy "refs/pull/2910/head" 0
+expect_reject \
+  "feature branch is not a dependency publication ref" \
+  oas_pin_require_track_policy "refs/heads/feature" 1
+
+echo "[oas-pin-ref test] PASS"


### PR DESCRIPTION
## Summary

- distinguish a blocked Draft dependency wait from a broken published OAS pin
- verify provisional OAS pins through an explicit `refs/pull/<number>/head` ancestry path instead of skipping API-surface proof
- keep merge-ready pins hard-bound to `main`; `ready_for_review` reruns CI so Draft-only allowance cannot retain a stale green gate
- split manifest and API-source checks so the failing truth is visible in the Meta Guards step list

## Product impact

- User-visible change: blocked cross-repo OAS work is shown as a verified dependency wait instead of an indistinguishable broken-pin failure. Merge-ready safety remains fail-closed.

## Policy

| PR state | configured OAS source | result |
|---|---|---|
| Draft + `blocked-on-oas` | exact `refs/pull/<number>/head` | verify ancestry + fingerprint, then pass |
| Ready/non-Draft | review ref | hard fail and require `main` |
| Any state | `main` | existing ancestry + fingerprint checks |
| Any state | arbitrary branch/tag/malformed ref | hard fail |

This does not turn the reachability gate into a warning or skip. It replaces the false-negative `main`-only proof with an explicit review-ref proof while the upstream PR is open.

## Evidence

- `bash -n` on all changed shell scripts
- `shellcheck -e SC1091,SC2034` on all changed shell scripts
- `actionlint -ignore SC2129 .github/workflows/ci.yml` (`SC2129` is pre-existing workflow style noise)
- `bash test/test_oas_pin_ref.sh`
- `bash test/test_check_oas_pin_forward.sh`
- `scripts/check-oas-pin.sh` against current `main` pin and remote OAS: PASS
- live proof: provisional MASC pin `5e0619d661...` remains an ancestor of OAS `refs/pull/2910/head`

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/4
provenance: operator_proxy
stages:
  - name: shell-policy-tests
    provenance: operator_proxy
  - name: workflow-lint
    provenance: operator_proxy
  - name: main-pin-network-proof
    provenance: operator_proxy
  - name: review-ref-ancestry-proof
    provenance: operator_proxy
```

## GOAL LOOP ACT checklist

- [x] Observe — MASC #26550 Meta Guards failed after manifest/fingerprint checks were already aligned because the source resolver fetched only OAS `main`
- [x] Orient — the failure conflated an explicitly blocked Draft dependency wait with an orphaned production pin
- [x] Decide — retain ancestry and fingerprint proof, but make the temporary review source explicit and state-bounded
- [x] Act — added one ref SSOT helper, policy tests, source resolution, and a Ready-transition recheck
- [x] Verify — shell tests, shellcheck, actionlint, current-main proof, and live PR-ref ancestry proof pass
- [x] Loop — MASC #26550 remains the consumer follow-up after this lands

## Review evidence

- Self-review found and closed a readiness bypass: `ready_for_review` now reruns exact-head CI, so a Draft-only green result cannot survive into merge-ready state.
- No cross-model review required by the repository workflow for this shell/CI policy change; exact-head GitHub checks remain pending.

## Linked issue

- Relates #26550

## Variant addition checklist

- [ ] **OCaml** — N/A: no OCaml surface changed
- [ ] **TypeScript** — N/A: no TypeScript surface changed
- [ ] **TLA+ spec** — N/A: no state-machine domain changed
- [ ] **Event / JSON schema** — N/A: no event or JSON schema changed
- [ ] **`make check-variants` passes** — N/A: no variant surface changed

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/oas-review-ref-pin-policy-20260801` → `main` · 1 commit(s) · synced 2026-08-01T09:06:12Z

| sha | subject | date |
|---|---|---|
| `534840da0` | ci: distinguish blocked OAS review pins | 2026-08-01 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->