### PR TITLE
fix(dashboard): remove misleading Keeper rail diagnostics

### DIFF
--- a/dashboard/src/components/keeper-workspace/compaction-inspector-overlay.ts
+++ b/dashboard/src/components/keeper-workspace/compaction-inspector-overlay.ts
@@ -192,6 +192,14 @@ function CompactionEmptyState({
   const source = loadState.payloadSource ?? 'unknown_source'
   const producer = loadState.payloadProducer ?? 'unknown_producer'
   const schemaDrift = payloadCount > 0 && decodedCount === 0
+  if (loadState.scanTruncated && payloadCount === 0) {
+    return html`
+      <div class="cmp-empty">
+        <strong>컴팩션 이력 유무를 확인하지 못했습니다.</strong><br />
+        manifest 조회가 끝나기 전에 중단되어 현재 결과만으로 이력이 없다고 판단할 수 없습니다.
+      </div>
+    `
+  }
   return html`
     <div class="cmp-empty">
       <strong>${schemaDrift ? '표시 가능한 compaction snapshot이 없습니다.' : '아직 이 keeper에서 durable compaction snapshot이 없습니다.'}</strong><br />

--- a/dashboard/src/components/keeper-workspace/keeper-lane-strip.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-lane-strip.test.ts
@@ -224,8 +224,8 @@ describe('KeeperLaneStrip', () => {
       />
     `)
     const text = el.textContent ?? ''
-    expect(text).toContain('기준')
-    expect(text).toContain('Auto-refresh 15s')
+    expect(text).toContain('최근 서버 샘플')
+    expect(text).toContain('15초마다 재조회 · 숨김 탭에서는 중지')
   })
 
   it('omits the auto-refresh label when the panel is not polling', () => {
@@ -238,7 +238,7 @@ describe('KeeperLaneStrip', () => {
         error=${null}
       />
     `)
-    expect(el.textContent ?? '').not.toContain('Auto-refresh')
+    expect(el.textContent ?? '').not.toContain('재조회')
   })
 
   it('renders an explicit gap when the keeper is absent from the inventory', () => {

--- a/dashboard/src/components/keeper-workspace/keeper-lane-strip.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-lane-strip.ts
@@ -37,7 +37,6 @@ import {
   stateTone,
 } from '../tools/keeper-waiting-inventory-panel'
 import { formatDateTimeKo } from '../../lib/format-time'
-import { formatAutoRefreshLabel } from '../../lib/auto-refresh'
 import { CountBadge } from '../v2/primitives-v2'
 
 const LANE_ROW_LIMIT = 3
@@ -50,6 +49,11 @@ const LANE_ROW_LIMIT = 3
 // waiting on right now" surface; setupVisibleAutoRefresh still pauses when the
 // tab is hidden and refreshes immediately on focus/return.
 const LANE_REFRESH_MS = KEEPER_WAITING_INVENTORY_REFRESH_MS
+
+function formatLaneRefreshLabel(intervalMs: number): string {
+  const seconds = Math.max(1, Math.round(intervalMs / 1000))
+  return `${seconds}초마다 재조회 · 숨김 탭에서는 중지`
+}
 
 function inventoryEntry(
   inventory: DashboardKeeperWaitingInventory | null | undefined,
@@ -183,9 +187,9 @@ export function KeeperLaneStrip({
                   </div>`
                 : null}
               ${inventory?.generated_at
-                ? html`<div class="text-2xs text-[var(--color-fg-muted)]">기준 ${formatDateTimeKo(inventory.generated_at)}${autoRefreshMs ? html` · ${formatAutoRefreshLabel(autoRefreshMs)}` : null}</div>`
+                ? html`<div class="text-2xs text-[var(--color-fg-muted)]">최근 서버 샘플 ${formatDateTimeKo(inventory.generated_at)}${autoRefreshMs ? html` · ${formatLaneRefreshLabel(autoRefreshMs)}` : null}</div>`
                 : autoRefreshMs
-                  ? html`<div class="text-2xs text-[var(--color-fg-muted)]">${formatAutoRefreshLabel(autoRefreshMs)}</div>`
+                  ? html`<div class="text-2xs text-[var(--color-fg-muted)]">${formatLaneRefreshLabel(autoRefreshMs)}</div>`
                   : null}
             </div>
           `

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -2,12 +2,12 @@ import { cleanup, fireEvent, render, waitFor } from '@testing-library/preact'
 import { html } from 'htm/preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { shellAuthSummary, tasks } from '../../store'
-import { navigate } from '../../router'
 import { callMcpTool } from '../../api/mcp'
 import { fetchKeeperCompactionSnapshots, fetchKeeperTurnRecords, fetchRuntimeProviders } from '../../api/dashboard'
 import { requestConfirm } from '../common/confirm-dialog'
 import { showToast } from '../common/toast'
 import { KeeperWorkspaceRail, runtimeRawSpecOpen } from './keeper-workspace-rail'
+import { selectedTask } from '../goals/task-detail-selection'
 import type { Keeper, Task } from '../../types'
 import type { KeeperRuntimeLensConfigDriftAxis } from '../../api/keeper-runtime-trace'
 import { resetRuntimeCatalog } from '../../lib/runtime-catalog-resource'
@@ -167,6 +167,7 @@ function mkTask(partial: Partial<Task>): Task {
 }
 
 beforeEach(() => {
+  selectedTask.value = null
   tasks.value = [
     mkTask({ id: 'T-4412', title: '세그먼트 리텐션 대시보드', status: 'in_progress', assignee: 'masc-improver' }),
     mkTask({ id: 'T-9999', title: '남의 태스크', status: 'todo', assignee: 'someone-else' }),
@@ -176,6 +177,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup()
   tasks.value = []
+  selectedTask.value = null
   shellAuthSummary.value = null
   compactionSnapshots.value = {}
   runtimeRawSpecOpen.value = false
@@ -712,7 +714,7 @@ describe('KeeperWorkspaceRail', () => {
     expect(container.textContent).toContain('provider 입력 토큰 / 모델 윈도우')
     expect(meter).not.toBeNull()
     expect(meter?.getAttribute('role')).toBe('meter')
-    expect(meter?.getAttribute('aria-label')).toBe('컨텍스트 윈도우 사용률')
+    expect(meter?.getAttribute('aria-label')).toBe('마지막 완료 요청의 컨텍스트 윈도우 사용률')
     expect(meter?.getAttribute('aria-valuenow')).toBe('62')
   })
 
@@ -746,10 +748,19 @@ describe('KeeperWorkspaceRail', () => {
     expect(container.textContent).not.toContain('처리량')
   })
 
-  it('opens the planning task detail when an owned task is clicked', () => {
+  it('opens the shared task detail overlay without leaving the keeper route', () => {
     const { getByRole } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} />`)
     fireEvent.click(getByRole('button', { name: /태스크 열기: T-4412/ }))
-    expect(navigate).toHaveBeenCalledWith('workspace', { section: 'planning', task: 'T-4412' })
+    expect(selectedTask.value?.id).toBe('T-4412')
+  })
+
+  it('does not duplicate awaiting-verification tasks in the attention section', () => {
+    tasks.value = [
+      mkTask({ id: 'T-review', title: '검증할 태스크', status: 'awaiting_verification', assignee: 'masc-improver' }),
+    ]
+    const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} />`)
+    expect(container.textContent).not.toContain('검증 대기 1건')
+    expect(container.textContent).toContain('T-review')
   })
 
   it('renders the attention section from live blocked-task signal', () => {
@@ -839,10 +850,10 @@ describe('KeeperWorkspaceRail', () => {
     const provenance = container.querySelector('[data-testid="ctx-provenance"]')
     expect(provenance).not.toBeNull()
     expect(provenance?.textContent).toContain('T3337')
-    expect(provenance?.textContent).toContain('요청 본문')
-    expect(provenance?.textContent).toContain('393KB')
-    expect(provenance?.textContent).toContain('같은 완료 요청')
-    expect(provenance?.textContent).toContain('직렬화 UTF-8 바이트')
+    expect(provenance?.textContent).toContain('마지막 완료 요청')
+    expect(provenance?.textContent).not.toContain('요청 본문')
+    expect(provenance?.textContent).not.toContain('393KB')
+    expect(provenance?.textContent).not.toContain('직렬화 UTF-8 바이트')
     expect(provenance?.textContent).not.toContain('다음 입력에 함께 실리는 상비 페이로드')
   })
 
@@ -1131,8 +1142,8 @@ describe('KeeperWorkspaceRail', () => {
     expect(diagnostics.textContent).toContain('scan budget')
     const coverage = await findByTestId('compaction-coverage-status')
     expect(coverage.textContent).toContain('표시 0/0')
-    expect(container.textContent).toContain('아직 이 keeper에서 durable compaction snapshot이 없습니다.')
-    expect(container.textContent).toContain('api_count=0 · decoded=0')
+    expect(container.textContent).toContain('컴팩션 이력 유무를 확인하지 못했습니다.')
+    expect(container.textContent).not.toContain('아직 이 keeper에서 durable compaction snapshot이 없습니다.')
   })
 
   it('distinguishes empty durable compaction results from decoded schema drift', async () => {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -13,13 +13,11 @@ import type { VNode } from 'preact'
 import { shellAuthSummary, tasks } from '../../store'
 import type { Keeper, Task } from '../../types'
 import type { KeeperRuntimeLensConfigDriftAxis } from '../../api/keeper-runtime-trace'
-import { navigate } from '../../router'
 import {
   keeperBucket,
   phaseTokenFromKeeper,
   keeperRuntimeLabel,
 } from './keeper-workspace-shared'
-import { CountBadge } from '../v2/primitives-v2'
 import { callMcpTool } from '../../api/mcp'
 import { showToast } from '../common/toast'
 import { requestConfirm } from '../common/confirm-dialog'
@@ -45,6 +43,7 @@ import { recordManualCompaction } from './compaction-snapshots'
 import type { MemoryKeeper } from '../memory-inspector'
 import { keepers } from '../../store'
 import { KeeperLaneSection } from './keeper-lane-strip'
+import { openTaskDetail } from '../goals/task-detail-state'
 
 const LazyCompactionInspectorOverlay = lazy(async () => ({
   default: (await import('./compaction-inspector-overlay')).CompactionInspectorOverlay,
@@ -109,8 +108,6 @@ function attentionItems(keeper: Keeper): AttentionItem[] {
   const items: AttentionItem[] = []
   const blocked = keeper.blocked_task_count ?? 0
   if (blocked > 0) items.push({ sev: 'bad', text: `차단된 태스크 ${blocked}건` })
-  const awaiting = ownedTasks(keeper).filter(t => t.status === 'awaiting_verification')
-  if (awaiting.length > 0) items.push({ sev: 'warn', text: `검증 대기 ${awaiting.length}건` })
   const fallback = items.length === 0 ? attentionFallback(keeper) : null
   if (fallback) items.push({ sev: 'warn', text: fallback })
   return items
@@ -121,7 +118,7 @@ function AttentionSection({ keeper }: { keeper: Keeper }): VNode | null {
   if (items.length === 0) return null
   return html`
     <div class="ctx-sec">
-      <h4 style=${{ display: 'flex', alignItems: 'center', gap: '7px' }}>주의 <${CountBadge}>${items.length}</${CountBadge}></h4>
+      <h4>주의</h4>
       <div class="att-list">
         ${items.map((it, i) => html`
           <div class=${`att-item ${it.sev}`} key=${`${it.text}-${i}`}>
@@ -391,20 +388,16 @@ function ContextSection({
   const compactionCount = keeper.compaction_count ?? null
   const hasCompactionHistory = typeof compactionCount === 'number' && compactionCount > 0
   const hasMeterData = pct !== null && (pct > 0 || max !== null)
-  // Provenance of the measurement: which completed turn produced the numbers
-  // (server projects them from the newest TurnRecord — the measurement SSOT).
+  // The server projects these values from the newest completed TurnRecord.
+  // Keep only turn identity and age here; serialized request bytes are
+  // transport diagnostics, not a second context metric.
   const ctxSource = keeper.context_source ?? keeper.context?.source ?? null
   const ctxAbsoluteTurn = keeper.context?.absolute_turn ?? null
   const ctxObservedAt = keeper.context?.observed_at ?? null
-  const ctxWireBytes = keeper.context?.request_body_bytes ?? null
   const ctxTurnRef = keeper.context?.turn_ref ?? null
   const ctxUnavailableReason =
     keeper.context_metrics_unavailable?.kind === 'not_observed'
       ? keeper.context_metrics_unavailable.reason
-      : null
-  const wireLabel =
-    typeof ctxWireBytes === 'number' && Number.isFinite(ctxWireBytes) && ctxWireBytes > 0
-      ? `${Math.round(ctxWireBytes / 1024)}KB`
       : null
   const compactAccess = dashboardAuthAccess(shellAuthSummary.value, 'worker')
   const canCompact = compactAccess.allowed && !compacting
@@ -491,7 +484,7 @@ function ContextSection({
                 <div
                   class="meter"
                   role="meter"
-                  aria-label="컨텍스트 윈도우 사용률"
+                  aria-label="마지막 완료 요청의 컨텍스트 윈도우 사용률"
                   aria-valuenow=${pct ?? 0}
                   aria-valuemin="0"
                   aria-valuemax="100"
@@ -509,10 +502,8 @@ function ContextSection({
         </div>
         ${ctxSource === 'turn_record'
           ? html`<div class="ctx-src" data-testid="ctx-provenance" title=${ctxTurnRef ?? undefined}>
-              측정: <span class="mono">T${ctxAbsoluteTurn ?? '—'}</span>
+              마지막 완료 요청: <span class="mono">T${ctxAbsoluteTurn ?? '—'}</span>
               ${ctxObservedAt ? html` · ${formatTimeAgo(ctxObservedAt)}` : null}
-              ${wireLabel ? html` · 요청 본문 <span class="mono">${wireLabel}</span>` : null}
-              <span class="ctx-src-lbl">같은 완료 요청: 토큰은 모델 측정, 본문은 직렬화 UTF-8 바이트</span>
             </div>`
           : null}
         <div class="cmp-actions">
@@ -537,9 +528,6 @@ function ContextSection({
 
 function OwnedTasksSection({ keeper }: { keeper: Keeper }): VNode {
   const owned = ownedTasks(keeper)
-  const openTask = (task: Task) => {
-    navigate('workspace', { section: 'planning', task: task.id })
-  }
   return html`
     <div class="ctx-sec">
       <h4>소유 태스크</h4>
@@ -550,9 +538,9 @@ function OwnedTasksSection({ keeper }: { keeper: Keeper }): VNode {
                 type="button"
                 class="tasktag"
                 key=${t.id}
-                title=${`작업으로 이동 · ${t.id} · ${t.title}`}
+                title=${`상세 보기 · ${t.id} · ${t.title}`}
                 aria-label=${`태스크 열기: ${t.id} ${t.title}`}
-                onClick=${() => openTask(t)}
+                onClick=${() => openTaskDetail(t)}
               >
                 <div class="tasktag-top">
                   <span class="tid">${t.id}</span>

--- a/dashboard/src/styles/keeper-v2/v2.css
+++ b/dashboard/src/styles/keeper-v2/v2.css
@@ -1316,10 +1316,9 @@
 .ctx-tok-sep { color: var(--text-dim); }
 .ctx-tok-full { color: var(--text-dim) !important; }
 .ctx-tok-lbl { margin-left: auto; font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); }
-/* measurement provenance under the meter: turn ref, age, wire size */
+/* measurement provenance under the meter: completed turn ref and age */
 .ctx-src { display: flex; flex-wrap: wrap; align-items: baseline; gap: 4px; margin-top: 5px; font-size: var(--fs-11); color: var(--text-mid); }
 .ctx-src .mono { font-family: var(--font-mono); color: var(--text-bright); }
-.ctx-src-lbl { flex-basis: 100%; font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); }
 
 /* recent tool — expandable detail */
 .ctx-item.click { cursor: pointer; }


### PR DESCRIPTION
## 요약

- 중복된 `검증 대기 N건` attention 항목 제거; 소유 태스크 목록을 SSOT로 유지
- 소유 태스크 클릭 시 planning 페이지로 이동하지 않고 기존 공용 TaskDetailOverlay 열기
- 컨텍스트 기본 화면에서 request body bytes/provenance 설명 제거
- 측정값을 `마지막 완료 요청`으로 명시
- Lane timestamp를 `최근 서버 샘플 · N초마다 재조회 · 숨김 탭에서는 중지`로 명확화
- truncated compaction scan에서 이력 부재를 단정하지 않도록 수정

## 범위 제외

- compaction exact 실행 실패는 #26544에서 별도 추적
- compaction event-indexed 조회와 runtime catalog effective SSOT 정리는 #26559 후속 범위

## 검증

- `vitest` keeper rail/lane 집중 테스트: 53 passed
- `vitest` keeper workspace mobile test: 19 passed
- `tsc --noEmit`: passed
- `vite build`: passed
- `git diff --check`: passed

Closes #26559
