### PR TITLE
fix(keeper): reject runtime agent aliases as keeper names

### DIFF
--- a/lib/keeper/keeper_identity.ml
+++ b/lib/keeper/keeper_identity.ml
@@ -19,43 +19,35 @@ let parse_keeper_agent_name ~prefix ~suffix agent_name =
   else
     None
 
+(* The four accepted spellings of a runtime keeper-agent identity. Enumerated
+   once: they used to be listed separately in [keeper_name_from_agent_name] and
+   [is_keeper_agent_alias], so adding a spelling to one and not the other made
+   a name an alias that no keeper name could be derived from. *)
+let keeper_agent_affixes =
+  [ "keeper-", "-agent"; "keeper_", "_agent"; "keeper-", "_agent"; "keeper_", "-agent" ]
+;;
+
+(* Answering "is this an agent identity?" and "which keeper does it denote?"
+   with one parse is what removes the unrepresentable middle: a caller cannot
+   observe the first without the second, so it never has to invent a name. *)
+let keeper_name_of_agent_alias agent_name =
+  List.find_map
+    (fun (prefix, suffix) -> parse_keeper_agent_name ~prefix ~suffix agent_name)
+    keeper_agent_affixes
+
 let keeper_name_from_agent_name agent_name =
-  match
-    parse_keeper_agent_name ~prefix:"keeper-" ~suffix:"-agent" agent_name
-  with
+  match keeper_name_of_agent_alias agent_name with
   | Some keeper_name -> Some keeper_name
-  | None -> (
-      match
-        parse_keeper_agent_name ~prefix:"keeper_" ~suffix:"_agent" agent_name
-      with
-      | Some keeper_name -> Some keeper_name
-      | None -> (
-          match
-            parse_keeper_agent_name ~prefix:"keeper-" ~suffix:"_agent" agent_name
-          with
-          | Some keeper_name -> Some keeper_name
-          | None -> (
-              match
-                parse_keeper_agent_name ~prefix:"keeper_" ~suffix:"-agent" agent_name
-              with
-              | Some keeper_name -> Some keeper_name
-              | None ->
-                  if Nickname.is_generated_nickname agent_name
-                     && Keeper_config.validate_name agent_name
-                  then
-                    Some agent_name
-                  else
-                    None)))
+  | None ->
+      if Nickname.is_generated_nickname agent_name
+         && Keeper_config.validate_name agent_name
+      then
+        Some agent_name
+      else
+        None
 
 let is_keeper_agent_alias agent_name =
-  Option.is_some
-    (parse_keeper_agent_name ~prefix:"keeper-" ~suffix:"-agent" agent_name)
-  || Option.is_some
-       (parse_keeper_agent_name ~prefix:"keeper_" ~suffix:"_agent" agent_name)
-  || Option.is_some
-       (parse_keeper_agent_name ~prefix:"keeper-" ~suffix:"_agent" agent_name)
-  || Option.is_some
-       (parse_keeper_agent_name ~prefix:"keeper_" ~suffix:"-agent" agent_name)
+  Option.is_some (keeper_name_of_agent_alias agent_name)
 
 let canonical_keeper_name_from_agent_name agent_name =
   let trimmed = String.trim agent_name in

--- a/lib/keeper/keeper_identity.mli
+++ b/lib/keeper/keeper_identity.mli
@@ -7,6 +7,12 @@ val generate_trace_id : ?now:float -> unit -> string
     for deterministic output.  The counter guarantees uniqueness even when
     [now] is pinned to the same value across consecutive calls. *)
 val keeper_name_from_agent_name : string -> string option
+(** [keeper_name_of_agent_alias s] is [Some keeper] when [s] is a runtime
+    keeper-agent identity in any accepted spelling, and [keeper] is the keeper
+    name it denotes. Returns the name together with the classification so a
+    caller never holds "this is an alias" without the name it resolves to. *)
+val keeper_name_of_agent_alias : string -> string option
+
 val is_keeper_agent_alias : string -> bool
 val canonical_keeper_name_from_agent_name : string -> string option
 val is_keeper_principal_agent_name : string -> bool

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -100,17 +100,18 @@ let parse ?(allow_sandbox_fields = false) (ctx : _ context) (args : Yojson.Safe.
   let name = get_string args "name" "" in
   if not (validate_name name) then
     Error (tool_result_error (invalid_name_error name))
-  else if Keeper_identity.is_keeper_agent_alias name then
-    let canonical_name =
-      Keeper_identity.canonical_keeper_name_from_agent_name name
-      |> Option.value ~default:name
-    in
-    Error
-      (tool_result_error
-         (Printf.sprintf
-            "invalid keeper name: %S is a runtime agent identity; use the canonical keeper name %S"
-            name canonical_name))
   else
+    match Keeper_identity.keeper_name_of_agent_alias name with
+    (* One parse decides both facts. Asking "is it an alias?" separately forced
+       a default keeper name for a case that parse cannot produce, and the
+       resulting message named the rejected input as its own replacement. *)
+    | Some canonical_name ->
+        Error
+          (tool_result_error
+             (Printf.sprintf
+                "invalid keeper name: %S is a runtime agent identity; use the canonical keeper name %S"
+                name canonical_name))
+    | None ->
     match Keeper_meta_contract.reject_removed_model_args ~tool_name:"masc_keeper_up" args with
     | Error e -> Error (tool_result_error e)
     | Ok () ->

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -100,6 +100,16 @@ let parse ?(allow_sandbox_fields = false) (ctx : _ context) (args : Yojson.Safe.
   let name = get_string args "name" "" in
   if not (validate_name name) then
     Error (tool_result_error (invalid_name_error name))
+  else if Keeper_identity.is_keeper_agent_alias name then
+    let canonical_name =
+      Keeper_identity.canonical_keeper_name_from_agent_name name
+      |> Option.value ~default:name
+    in
+    Error
+      (tool_result_error
+         (Printf.sprintf
+            "invalid keeper name: %S is a runtime agent identity; use the canonical keeper name %S"
+            name canonical_name))
   else
     match Keeper_meta_contract.reject_removed_model_args ~tool_name:"masc_keeper_up" args with
     | Error e -> Error (tool_result_error e)

--- a/test/test_keeper_turn_up_args.ml
+++ b/test/test_keeper_turn_up_args.ml
@@ -33,6 +33,51 @@ let test_resolve_mention_targets_normalizes_explicit_values () =
 
 let override_json value = `Assoc [ "max_context_override", value ]
 
+let with_test_context f =
+  let base = Filename.temp_file "keeper-turn-up-args-" "" in
+  Sys.remove base;
+  Unix.mkdir base 0o755;
+  Fun.protect
+    ~finally:(fun () -> Unix.rmdir base)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Eio.Switch.run @@ fun sw ->
+      let ctx : _ Keeper_types_profile.context =
+        { config = Workspace.default_config base
+        ; agent_name = "test-agent"
+        ; sw
+        ; clock = Eio.Stdenv.clock env
+        ; proc_mgr = None
+        ; net = None
+        ; publication_recovery_provider =
+            Masc_test_deps.non_runtime_publication_recovery_provider
+        }
+      in
+      f ctx)
+
+let test_parse_rejects_runtime_agent_identity_as_keeper_name () =
+  with_test_context @@ fun ctx ->
+  List.iter
+    (fun agent_name ->
+      match
+        Keeper_turn_up_args.parse ctx
+          (`Assoc [ "name", `String agent_name ])
+      with
+      | Ok _ ->
+        failf "runtime agent identity %S was accepted as a keeper name" agent_name
+      | Error result ->
+        let body = Keeper_types_profile.tool_result_body result in
+        check bool "identifies the wrong identity kind" true
+          (String.starts_with body ~prefix:"invalid keeper name:");
+        check bool "names the canonical keeper" true
+          (String.ends_with body
+             ~suffix:"use the canonical keeper name \"executor\""))
+    [ "keeper-executor-agent"
+    ; "keeper_executor_agent"
+    ; "keeper-executor_agent"
+    ; "keeper_executor-agent"
+    ]
+
 let test_parse_max_context_override () =
   let check_ok label expected value =
     match Keeper_turn_up_args.parse_max_context_override (override_json value) with
@@ -147,6 +192,12 @@ let () =
       , [ test_case "request values are exact or rejected" `Quick test_parse_max_context_override
         ; test_case "runtime JSON rejects TOML-owned field" `Quick
             test_runtime_json_rejects_toml_owned_max_context_override
+        ] )
+    ; ( "keeper_name"
+      , [ test_case
+            "runtime agent identities are rejected"
+            `Quick
+            test_parse_rejects_runtime_agent_identity_as_keeper_name
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- reject runtime agent identities such as keeper-executor-agent at the canonical keeper-up parse boundary
- return the canonical Keeper name in the error
- cover all supported separator variants with a focused test

## Why
Passing an agent principal as masc_keeper_up.name currently creates a second Keeper and wraps the identity again, e.g. keeper-executor-agent becomes keeper-executor-agent-agent. Dashboard/API, tool dispatch, and declarative TOML materialization all share this parse boundary.

## Scope
No legacy compatibility or migration path. Existing persisted data is not rewritten.

## Verification
- opam exec -- ocamlformat --check lib/keeper/keeper_turn_up_args.ml test/test_keeper_turn_up_args.ml
- scripts/dune-local.sh build test/test_keeper_turn_up_args.exe
- _build/default/test/test_keeper_turn_up_args.exe (7/7 pass)