### PR TITLE
fix(auth): delegate secret equality to Eqaf

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -87,6 +87,7 @@
   (eio_posix (>= 0.16))
   (cstruct (>= 6.0))
   (digestif (>= 1.1))
+  (eqaf (>= 0.10))
   optint
   (ocaml-protoc-plugin (>= 4.0))
   (pbrt (and (>= 3.0) (< 4.0)))

--- a/lib/auth/auth.mli
+++ b/lib/auth/auth.mli
@@ -11,10 +11,12 @@ open Masc_domain
 (** {1 Token Generation} *)
 
 val generate_token : unit -> string
-(** Generate a cryptographically random hex token (64 chars). *)
+(** Generate a cryptographically random token: exactly 64 lowercase hex
+    characters encoding 32 random bytes. *)
 
 val sha256_hash : string -> string
-(** Hash a token/secret with SHA-256 and return lowercase hex. *)
+(** Hash a token/secret with SHA-256 and return exactly 64 lowercase hex
+    characters. Secret comparisons use Eqaf on this fixed-width form. *)
 
 val save_private_text_file : string -> string -> unit
 (** [save_private_text_file path content] writes [content] to [path] with
@@ -218,7 +220,8 @@ val save_raw_token_credential :
   string -> agent_name:string -> role:agent_role -> raw_token:string ->
   (agent_credential, masc_error) result
 (** [save_raw_token_credential config ~agent_name ~role ~raw_token] hashes the
-    raw token and persists the credential. *)
+    raw token and persists the credential. Externally supplied tokens are
+    opaque and byte-preserving, but empty or whitespace-only input is rejected. *)
 
 val save_raw_token_credential_without_expiry :
   string -> agent_name:string -> role:agent_role -> raw_token:string ->

--- a/lib/auth/auth_credential_base.ml
+++ b/lib/auth/auth_credential_base.ml
@@ -17,6 +17,11 @@ let generate_token () =
 (** SHA256 hash of a string using Digestif *)
 let sha256_hash input = Digestif.SHA256.(digest_string input |> to_hex)
 
+(** Timing-resistant equality delegated to Eqaf. Runtime depends on the public
+    input lengths, not secret contents. Auth comparisons below operate on
+    fixed-width SHA-256 hex digests. *)
+let constant_time_string_equal = Eqaf.equal
+
 (* ============================================ *)
 (* Auth directory management                    *)
 (* ============================================ *)
@@ -88,7 +93,7 @@ let save_internal_keeper_token_hash config ~raw_token =
 
 let verify_internal_keeper_token config ~token =
   match load_internal_keeper_token_hash config with
-  | Some stored_hash -> String.equal stored_hash (sha256_hash token)
+  | Some stored_hash -> constant_time_string_equal stored_hash (sha256_hash token)
   | None -> false
 ;;
 

--- a/lib/auth/auth_credential_token.ml
+++ b/lib/auth/auth_credential_token.ml
@@ -94,7 +94,11 @@ let constant_time_string_equal = Auth_credential_base.constant_time_string_equal
 
 let validate_raw_token raw_token =
   if String.trim raw_token = ""
-  then Error (Auth (Auth_error.InvalidToken "Raw token must not be empty"))
+  then
+    Error
+      (Auth
+         (Auth_error.InvalidToken
+            "Raw token must not be blank or whitespace-only"))
   else Ok ()
 ;;
 

--- a/lib/auth/auth_credential_token.ml
+++ b/lib/auth/auth_credential_token.ml
@@ -89,18 +89,13 @@ let collision_log_to_yojson log =
     ]
 ;;
 
-(** Constant-time string equality for raw bearer tokens.  It XOR-accumulates
-    every byte of the shorter input and checks length equality separately so
-    the comparison does not short-circuit on the first differing byte. *)
-let constant_time_string_equal a b =
-  let len_a = String.length a in
-  let len_b = String.length b in
-  let acc = ref 0 in
-  let min_len = min len_a len_b in
-  for i = 0 to min_len - 1 do
-    acc := !acc lor (Char.code a.[i] lxor Char.code b.[i])
-  done;
-  !acc = 0 && len_a = len_b
+(** Auth comparisons use Eqaf's timing-resistant equality. *)
+let constant_time_string_equal = Auth_credential_base.constant_time_string_equal
+
+let validate_raw_token raw_token =
+  if String.trim raw_token = ""
+  then Error (Auth (Auth_error.InvalidToken "Raw token must not be empty"))
+  else Ok ()
 ;;
 
 (** Compare two credentials field-by-field.  The caller supplies the
@@ -280,27 +275,30 @@ let expires_at_for_auth_config auth_cfg =
 let save_raw_token_credential_with_expiry config ~agent_name ~role ~raw_token ~expires_at
   : (agent_credential, masc_error) result
   =
-  let cred =
-    { id = None
-    ; agent_id = None
-    ; agent_name
-    ; token = sha256_hash raw_token
-    ; role
-    ; created_at = now_iso ()
-    ; expires_at
-    }
-  in
-  try
-    save_credential config cred;
-    Ok cred
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn ->
-    let msg =
-      Printf.sprintf "Failed to save agent credential: %s" (Printexc.to_string exn)
+  match validate_raw_token raw_token with
+  | Error _ as error -> error
+  | Ok () ->
+    let cred =
+      { id = None
+      ; agent_id = None
+      ; agent_name
+      ; token = sha256_hash raw_token
+      ; role
+      ; created_at = now_iso ()
+      ; expires_at
+      }
     in
-    Log.Auth.error "%s" msg;
-    Error (System (System_error.IoError msg))
+    (try
+       save_credential config cred;
+       Ok cred
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
+       let msg =
+         Printf.sprintf "Failed to save agent credential: %s" (Printexc.to_string exn)
+       in
+       Log.Auth.error "%s" msg;
+       Error (System (System_error.IoError msg)))
 ;;
 
 let save_raw_token_credential config ~agent_name ~role ~raw_token
@@ -364,29 +362,32 @@ type rotation_outcome =
 let save_rotated_raw_token config (cred : agent_credential) ~raw_token
   : (agent_credential, masc_error) result
   =
-  let auth_cfg = load_auth_config config in
-  let rotated =
-    { cred with
-      token = sha256_hash raw_token
-    ; created_at = now_iso ()
-    ; expires_at = expires_at_for_auth_config auth_cfg
-    }
-  in
-  try
-    persist_raw_token config ~agent_name:rotated.agent_name raw_token;
-    save_credential config rotated;
-    Ok rotated
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn ->
-    let msg =
-      Printf.sprintf
-        "Failed to rotate agent credential for %s: %s"
-        rotated.agent_name
-        (Printexc.to_string exn)
+  match validate_raw_token raw_token with
+  | Error _ as error -> error
+  | Ok () ->
+    let auth_cfg = load_auth_config config in
+    let rotated =
+      { cred with
+        token = sha256_hash raw_token
+      ; created_at = now_iso ()
+      ; expires_at = expires_at_for_auth_config auth_cfg
+      }
     in
-    Log.Auth.error "%s" msg;
-    Error (System (System_error.IoError msg))
+    (try
+       persist_raw_token config ~agent_name:rotated.agent_name raw_token;
+       save_credential config rotated;
+       Ok rotated
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
+       let msg =
+         Printf.sprintf
+           "Failed to rotate agent credential for %s: %s"
+           rotated.agent_name
+           (Printexc.to_string exn)
+       in
+       Log.Auth.error "%s" msg;
+       Error (System (System_error.IoError msg)))
 ;;
 
 let rotate_shared_tokens_matching config ~include_agent : rotation_outcome list =
@@ -508,7 +509,7 @@ let verify_token config ~agent_name ~token : (agent_credential, masc_error) resu
   | None -> verify_token_owner_alias config ~agent_name ~token
   | Some cred ->
     let token_hash = sha256_hash token in
-    if cred.token <> token_hash
+    if not (constant_time_string_equal cred.token token_hash)
     then Error (Auth (Auth_error.InvalidToken "Token mismatch"))
     else (
       (* Check expiry *)

--- a/lib/auth/auth_credential_token.mli
+++ b/lib/auth/auth_credential_token.mli
@@ -36,6 +36,9 @@ type credential_comparison =
 
 val collision_log_to_yojson : collision_log -> Yojson.Safe.t
 val constant_time_string_equal : string -> string -> bool
+(** Timing-resistant equality provided by {!Eqaf.equal}. Execution time
+    depends on the input lengths, not their contents. Auth callers compare
+    fixed-width SHA-256 hex digests. *)
 
 val compare_credentials :
   token_hash_prefix:string -> agent_credential -> agent_credential -> credential_comparison
@@ -60,6 +63,9 @@ val expires_at_for_auth_config : auth_config -> string option
 val save_raw_token_credential_with_expiry :
   string -> agent_name:string -> role:agent_role -> raw_token:string -> expires_at:string option ->
   (agent_credential, masc_error) result
+(** Raw externally supplied tokens are opaque and preserve their exact bytes,
+    but must contain at least one non-whitespace character. They are hashed to
+    a fixed-width SHA-256 hex digest before storage or comparison. *)
 
 val save_raw_token_credential :
   string -> agent_name:string -> role:agent_role -> raw_token:string ->

--- a/lib/auth/dune
+++ b/lib/auth/dune
@@ -16,6 +16,7 @@
   masc.crypto_rng
   eio
   digestif
+  eqaf
   masc.fs_compat
   masc.masc_log
   masc.masc_tool_dispatch

--- a/masc.opam
+++ b/masc.opam
@@ -58,6 +58,7 @@ depends: [
   "eio_posix" {>= "0.16"}
   "cstruct" {>= "6.0"}
   "digestif" {>= "1.1"}
+  "eqaf" {>= "0.10"}
   "optint"
   "ocaml-protoc-plugin" {>= "4.0"}
   "pbrt" {>= "3.0" & < "4.0"}

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -169,6 +169,14 @@ let test_sha256_hash () =
   check bool "different input different hash" true (hash1 <> hash3);
   check int "hash length is 64 chars" 64 (String.length hash1)
 
+let test_eqaf_equality_truth_table () =
+  let equal = Auth_credential_token.constant_time_string_equal in
+  check bool "empty strings" true (equal "" "");
+  check bool "same contents" true (equal "0123456789abcdef" "0123456789abcdef");
+  check bool "different first byte" false (equal "1123456789abcdef" "0123456789abcdef");
+  check bool "different last byte" false (equal "0123456789abcdee" "0123456789abcdef");
+  check bool "different lengths" false (equal "short" "longer")
+
 (* ============================================ *)
 (* Auth config tests                            *)
 (* ============================================ *)
@@ -672,6 +680,20 @@ let test_save_raw_token_credential_uses_provided_token () =
            "provided raw token should verify after save_raw_token_credential: %s"
            (Masc_domain.masc_error_to_string e))
 
+let test_save_raw_token_credential_rejects_blank_token () =
+  let dir = setup_test_workspace () in
+  let result =
+    Auth.save_raw_token_credential dir ~agent_name:"bootstrap-admin"
+      ~role:Masc_domain.Admin ~raw_token:"   "
+  in
+  cleanup_test_workspace dir;
+  match result with
+  | Error (Masc_domain.Auth (Masc_domain.Auth_error.InvalidToken reason)) ->
+    check string "explicit blank token error" "Raw token must not be empty" reason
+  | Error error ->
+    failf "expected InvalidToken, received %s" (Masc_domain.masc_error_to_string error)
+  | Ok _ -> fail "blank raw token must be rejected"
+
 let test_save_raw_token_credential_in_eio_runtime () =
   let dir = setup_test_workspace () in
   let raw_token = "runtime-admin-token" in
@@ -1159,6 +1181,7 @@ let () =
     "token_generation", [
       test_case "generate token" `Quick test_token_generation;
       test_case "sha256 hash" `Quick test_sha256_hash;
+      test_case "Eqaf equality truth table" `Quick test_eqaf_equality_truth_table;
     ];
     "config", [
       test_case "parent Auth is leaf re-export facade" `Quick
@@ -1203,6 +1226,8 @@ let () =
         test_verify_token_rejects_dashboard_dev_legacy_alias;
       test_case "save_raw_token_credential uses provided token" `Quick
         test_save_raw_token_credential_uses_provided_token;
+      test_case "save_raw_token_credential rejects blank token" `Quick
+        test_save_raw_token_credential_rejects_blank_token;
       test_case "save_raw_token_credential works in eio runtime" `Quick
         test_save_raw_token_credential_in_eio_runtime;
       test_case "ensure_keeper_credential uses per-keeper token" `Quick

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -689,7 +689,8 @@ let test_save_raw_token_credential_rejects_blank_token () =
   cleanup_test_workspace dir;
   match result with
   | Error (Masc_domain.Auth (Masc_domain.Auth_error.InvalidToken reason)) ->
-    check string "explicit blank token error" "Raw token must not be empty" reason
+    check string "explicit blank token error"
+      "Raw token must not be blank or whitespace-only" reason
   | Error error ->
     failf "expected InvalidToken, received %s" (Masc_domain.masc_error_to_string error)
   | Ok _ -> fail "blank raw token must be rejected"


### PR DESCRIPTION
## Summary

- replace the hand-written token equality loop with the directly declared Eqaf 0.10 primitive
- route credential, workspace-secret, direct token verification, and internal keeper hash comparisons through the same boundary
- make token contracts explicit: generated tokens are 64 lowercase hex characters; injected tokens are opaque, byte-preserving, and non-blank

## Product impact

- User-visible change: whitespace-only injected admin/client tokens are rejected instead of persisting an unusable credential. Existing non-blank opaque tokens remain accepted unchanged.

## Evidence

- `test_auth`: 57/57 PASS at `7b8c83545c`
- `test_auth_bearer_mismatch_9786`: PASS
- `test_auth_rotate_shared_tokens_10304`: PASS
- `test_server_runtime_bootstrap`: touched internal-auth and credential-sync cases PASS; 10 unrelated existing health/main-process cases fail in the sandboxed full executable
- `test_auth_ambiguous_lookup_9786`: 3 obsolete fixture failures reproduced unchanged on `main` (missing required credential `id`)
- `opam lint masc.opam`: PASS
- `git diff --check` and changed-file `ocamlformat --check`: PASS
- auth source rescan: no remaining raw `String.equal` / `<>` secret-hash comparisons

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/1
provenance: operator_proxy
stages:
  - name: focused_auth_tests
    provenance: operator_proxy
    result: pass_with_documented_main_baseline_failures
```

## GOAL LOOP ACT checklist

- [x] Observe — #26565 records input-length-dependent hand-written comparison
- [x] Orient — mapped to the P1 auth/crypto reinvented-wheel finding
- [x] Decide — use the installed Eqaf primitive already underlying Digestif
- [x] Act — direct dependency plus one comparison boundary and explicit token contracts
- [x] Verify — auth truth table, token lifecycle, mismatch, rotation, bootstrap, lint, source rescan
- [x] Loop — remaining independent audit findings remain tracked in #26562–#26564, #26566–#26567

## Review evidence

- Best Programmer self-review at `7b8c83545c`: all 8 changed files trace to the auth equality or dependency contract; checked external-token compatibility and direct comparison omissions.
- Risk retained for review: blank external tokens now fail at persistence; this is an intentional fail-closed boundary.
- Cross-model review: not run; this remains a Draft PR pending CI and review sweep.

## Linked issue

- Closes #26565
- Relates #26562
- Relates #26563
- Relates #26564
- Relates #26566
- Relates #26567

## Variant addition checklist

- [ ] **OCaml** — N/A: no variant changed
- [ ] **TypeScript** — N/A: no TypeScript union changed
- [ ] **TLA+ spec** — N/A: no TLA+ domain changed
- [ ] **Event / JSON schema** — N/A: no enum changed
- [ ] **`make check-variants` passes** — N/A: no variant or schema enum change

RFC-WAIVED: replacement of a security primitive with an existing audited dependency; no wire or architecture change.

[근거] installed Eqaf 0.10 `eqaf.mli` timing contract and `opam list --installed`; 확인 2026-08-01 19:12 KST; 신뢰도 High
