### PR TITLE
fix(keeper): centralize lane root ownership

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -792,6 +792,16 @@ let start_keepalive
   (m : keeper_meta)
   : start_keepalive_outcome
   =
+  (* A Keeper lane is server-owned, even when its creation or restart is
+     requested by a tool running inside another Keeper's turn.  In production
+     the root switch is installed once by server bootstrap; the context switch
+     remains the owner for standalone/test runtimes that do not install that
+     global server context. *)
+  let lane_parent_sw =
+    match Eio_context.get_root_switch_opt () with
+    | Some root_sw -> root_sw
+    | None -> ctx.sw
+  in
   let lifecycle_state =
     Keeper_lifecycle_admission.state
       ~paused:m.paused
@@ -1152,7 +1162,7 @@ let start_keepalive
         publish_keeper_started ~live_meta;
         (match
            Keeper_lane.fork
-             ~sw:ctx.sw
+             ~sw:lane_parent_sw
              reg.lane
              ~run:(fun lane_sw ->
         let ctx = { ctx with sw = lane_sw } in

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -794,9 +794,10 @@ let start_keepalive
   =
   (* A Keeper lane is server-owned, even when its creation or restart is
      requested by a tool running inside another Keeper's turn.  In production
-     the root switch is installed once by server bootstrap; the context switch
-     remains the owner for standalone/test runtimes that do not install that
-     global server context. *)
+     the root switch is installed once by server bootstrap.  A standalone/test
+     runtime without that global binding makes [ctx.sw] the explicit owner and
+     must therefore pass a switch that outlives the lane; a turn- or lane-scoped
+     context is not a valid launch owner. *)
   let lane_parent_sw =
     match Eio_context.get_root_switch_opt () with
     | Some root_sw -> root_sw

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -923,29 +923,18 @@ let () =
          Some (Keeper_tool_surface_ops.handle_keeper_delegate ~submitted_by:agent_name ctx args)
        | _ -> eio_context_missing "masc_keeper_delegate")
     | "masc_keeper_up" ->
-      (* The target Keeper lane is server-owned and must outlive the calling
-         Keeper's turn. The forwarded [sw] is turn-scoped on OAS calls. *)
-      (match Eio_context.get_root_switch_opt (), clock with
-       | Some root_sw, Some clock ->
+      (match sw, clock with
+       | Some sw, Some clock ->
          Some
            (Keeper_tool_surface_ops.keeper_up_body
               ~config
               ~agent_name
-              ~sw:root_sw
+              ~sw
               ~clock
               ~publication_recovery_provider
               ?proc_mgr
               ?net
               args)
-       | None, _ ->
-         Some
-           (tool_result_error_data
-              ~tool_name:"masc_keeper_up"
-              (`Assoc
-                 [ ( "error"
-                   , `String
-                       "masc_keeper_up requires the server root switch for its long-lived Keeper lane"
-                   ) ]))
-       | Some _, None -> eio_context_missing "masc_keeper_up")
+       | _ -> eio_context_missing "masc_keeper_up")
     | _ -> None
 ;;

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -1838,7 +1838,7 @@ let test_update_keeper_rejects_lane_swap_while_turn_in_flight () =
            name
           : Masc.Keeper_keepalive.joined_stop_result))
 
-let test_cross_keeper_up_lane_outlives_calling_turn () =
+let test_keeper_up_shared_boundary_outlives_calling_turn () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir "cross-keeper-up-lifetime" in
@@ -1893,22 +1893,27 @@ let test_cross_keeper_up_lane_outlives_calling_turn () =
                 (Eio.Time.with_timeout_exn clock 1.0 (fun () ->
                    Eio.Switch.run @@ fun turn_sw ->
                    Eio_context.with_turn_switch turn_sw @@ fun () ->
-                   !Masc.Keeper_dispatch_ref.dispatch
-                     ~config
-                     ~agent_name:"rondo"
-                     ~publication_recovery_provider:
-                       (Masc_test_deps.publication_recovery_provider
-                          publication_recovery_registry)
-                     ~sw:turn_sw
-                     ~clock
+                   let ctx : _ Masc.Keeper_tool_surface.context =
+                     { config
+                     ; agent_name = "rondo"
+                     ; sw = turn_sw
+                     ; clock
+                     ; proc_mgr = None
+                     ; net = None
+                     ; publication_recovery_provider =
+                         Masc_test_deps.publication_recovery_provider
+                           publication_recovery_registry
+                     }
+                   in
+                   Masc.Keeper_tool_surface.dispatch
+                     ctx
                      ~name:"masc_keeper_up"
                      ~args:
                        (`Assoc
                           [ "name", `String target_name
                           ; "proactive_enabled", `Bool false
                           ; "autoboot_enabled", `Bool false
-                          ])
-                     ()))
+                          ])))
             with
             | Eio.Time.Timeout -> None
           in
@@ -4101,8 +4106,8 @@ let () =
         test_operator_update_supersedes_exact_blocked_shutdown;
       test_case "update rejects lane swap while turn in flight" `Quick
         test_update_keeper_rejects_lane_swap_while_turn_in_flight;
-      test_case "cross-keeper up lane outlives calling turn" `Quick
-        test_cross_keeper_up_lane_outlives_calling_turn;
+      test_case "keeper up shared boundary outlives calling turn" `Quick
+        test_keeper_up_shared_boundary_outlives_calling_turn;
       test_case "shutdown store isolates corrupt owner" `Quick
         test_keeper_shutdown_store_isolates_corrupt_owner;
       test_case "retired stale paused terminal releases exact fence" `Quick


### PR DESCRIPTION
## Summary
- resolve the server-owned parent switch at `start_keepalive`, the shared lane launch boundary
- cover create, update, declarative materialization, and post-message restart paths with the same lifetime invariant
- restore the registered `masc_keeper_up` facade to the ordinary caller-context contract and remove its duplicate root-switch gate/error body

## Regression proof
- `test_heartbeat_integration.exe test direct_keepalive 9 --show-errors`: PASS
  - the test now enters through the ordinary context-based dispatch with a turn-scoped switch, so it fails if root ownership is moved back to one registered facade
- `scripts/dune-local.sh build test/test_heartbeat_integration.exe`: PASS on base `3551dc38ca`
- `ocamlformat --check` (changed files): PASS
- `git diff --check`: PASS

## Ownership contract
- production installs the server root switch once at bootstrap
- standalone/test runtimes without that binding must pass an owner switch that outlives the lane; a turn/lane-scoped context is not a valid launch owner
- no fallback Gate was added at the facade or shared boundary

## Review context
Follow-up to #26558. This closes the P1 N-of-M finding by moving lane lifetime ownership from one tool facade to the shared launch boundary.

Exact head: `98c59d0815` (based on main `3551dc38ca`).