### PR TITLE
refactor(keeper): delegate TOML semantics to Otoml

### DIFF
--- a/lib/keeper/keeper_types_profile_oas_env.ml
+++ b/lib/keeper/keeper_types_profile_oas_env.ml
@@ -10,7 +10,16 @@ let string_of_toml_value_for_env = function
   | Keeper_toml_loader.Toml_float f -> Some (string_of_float f)
   | Keeper_toml_loader.Toml_bool true -> Some "1"
   | Keeper_toml_loader.Toml_bool false -> Some "0"
-  | Keeper_toml_loader.Toml_string_array _ -> None
+  | ( Keeper_toml_loader.Toml_string_array _
+    | Keeper_toml_loader.Toml_array _
+    | Keeper_toml_loader.Toml_table _
+    | Keeper_toml_loader.Toml_inline_table _
+    | Keeper_toml_loader.Toml_table_array _
+    | Keeper_toml_loader.Toml_offset_datetime _
+    | Keeper_toml_loader.Toml_local_datetime _
+    | Keeper_toml_loader.Toml_local_date _
+    | Keeper_toml_loader.Toml_local_time _ ) ->
+    None
 ;;
 
 let oas_env_key_prefix = "keeper.oas_env."

--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -4,6 +4,78 @@ include Keeper_types_profile_defaults
 include Keeper_types_profile_toml_normalizers
 include Keeper_types_profile_oas_env
 
+let toml_value_kind = function
+  | Keeper_toml_loader.Toml_string _ -> "string"
+  | Keeper_toml_loader.Toml_int _ -> "integer"
+  | Keeper_toml_loader.Toml_float _ -> "float"
+  | Keeper_toml_loader.Toml_bool _ -> "boolean"
+  | Keeper_toml_loader.Toml_string_array _ -> "string array"
+  | Keeper_toml_loader.Toml_array _ -> "array"
+  | Keeper_toml_loader.Toml_table _ -> "table"
+  | Keeper_toml_loader.Toml_inline_table _ -> "inline table"
+  | Keeper_toml_loader.Toml_table_array _ -> "table array"
+  | Keeper_toml_loader.Toml_offset_datetime _ -> "offset datetime"
+  | Keeper_toml_loader.Toml_local_datetime _ -> "local datetime"
+  | Keeper_toml_loader.Toml_local_date _ -> "local date"
+  | Keeper_toml_loader.Toml_local_time _ -> "local time"
+;;
+
+let validate_known_keeper_field_types doc =
+  let string_fields =
+    [ "name"; "persona_name"; "instructions"; "sandbox_profile"
+    ; "sandbox_image"; "network_mode"; "multimodal_policy" ]
+  in
+  let bool_fields =
+    [ "autoboot_enabled"; "proactive_enabled"; "telemetry_feedback_enabled"
+    ; "always_allow" ]
+  in
+  let int_fields =
+    [ "max_context_override"; "telemetry_feedback_window_hours" ]
+  in
+  let string_array_fields =
+    [ "mention_targets"; "allowed_paths"; "active_goal_ids" ]
+  in
+  let expected key =
+    let bare_key = String.sub key 7 (String.length key - 7) in
+    if List.mem bare_key string_fields
+    then Some ("string", function Keeper_toml_loader.Toml_string _ -> true | _ -> false)
+    else if List.mem bare_key bool_fields
+    then Some ("boolean", function Keeper_toml_loader.Toml_bool _ -> true | _ -> false)
+    else if List.mem bare_key int_fields
+    then Some ("integer", function Keeper_toml_loader.Toml_int _ -> true | _ -> false)
+    else if List.mem bare_key string_array_fields
+    then
+      Some
+        ( "string array"
+        , function Keeper_toml_loader.Toml_string_array _ -> true | _ -> false )
+    else None
+  in
+  doc
+  |> List.find_map (fun (key, value) ->
+       if String.starts_with key ~prefix:"keeper."
+          && not (String.starts_with key ~prefix:oas_env_key_prefix)
+       then
+         match expected key with
+         | Some (expected_kind, accepts) when not (accepts value) ->
+           Some
+             (Printf.sprintf
+                "%s must be a TOML %s, got %s"
+                key
+                expected_kind
+                (toml_value_kind value))
+         | Some _ | None -> None
+       else if String.starts_with key ~prefix:oas_env_key_prefix
+               && Option.is_none (string_of_toml_value_for_env value)
+       then
+         Some
+           (Printf.sprintf
+              "%s must be a scalar TOML value, got %s"
+              key
+              (toml_value_kind value))
+       else None)
+  |> function None -> Ok () | Some error -> Error error
+;;
+
 let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
     : (keeper_profile_defaults, string) result =
   let k key = "keeper." ^ key in
@@ -31,6 +103,10 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
             (Printf.sprintf
                "removed keeper TOML keys: %s"
                (String.concat ", " fields))
+  in
+  let result =
+    Result.bind result (fun () ->
+        validate_known_keeper_field_types doc)
   in
   let result =
     Result.bind result (fun () ->
@@ -91,11 +167,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
      BREAKING: a keeper TOML still carrying [runtime_id] fails to load; migrate
      its value to runtime.toml [[runtime.assignments]]. *)
   let runtime_assignment_result =
-    let present key =
-      match str key with
-      | None -> false
-      | Some raw -> String.trim raw <> ""
-    in
+    let present key = has key in
     match present "model", present "runtime_id" with
     | true, _ | _, true ->
       Error

--- a/lib/keeper_runtime/keeper_runtime_config.ml
+++ b/lib/keeper_runtime/keeper_runtime_config.ml
@@ -91,7 +91,16 @@ let value_to_string = function
     (* Match TOML representation (no trailing zeros). *)
     Some (Printf.sprintf "%g" f)
   | Keeper_toml_loader.Toml_bool b -> Some (if b then "true" else "false")
-  | Keeper_toml_loader.Toml_string_array _ -> None
+  | ( Keeper_toml_loader.Toml_string_array _
+    | Keeper_toml_loader.Toml_array _
+    | Keeper_toml_loader.Toml_table _
+    | Keeper_toml_loader.Toml_inline_table _
+    | Keeper_toml_loader.Toml_table_array _
+    | Keeper_toml_loader.Toml_offset_datetime _
+    | Keeper_toml_loader.Toml_local_datetime _
+    | Keeper_toml_loader.Toml_local_date _
+    | Keeper_toml_loader.Toml_local_time _ ) ->
+    None
 
 (** Resolve a single TOML key to its boot-override value. Returns
     [Some (env_name, value)] when the key is present in the doc and the
@@ -163,7 +172,15 @@ let validate_stream_idle_timeout doc =
   | Some
       (Keeper_toml_loader.Toml_string _
       | Keeper_toml_loader.Toml_bool _
-      | Keeper_toml_loader.Toml_string_array _) ->
+      | Keeper_toml_loader.Toml_string_array _
+      | Keeper_toml_loader.Toml_array _
+      | Keeper_toml_loader.Toml_table _
+      | Keeper_toml_loader.Toml_inline_table _
+      | Keeper_toml_loader.Toml_table_array _
+      | Keeper_toml_loader.Toml_offset_datetime _
+      | Keeper_toml_loader.Toml_local_datetime _
+      | Keeper_toml_loader.Toml_local_date _
+      | Keeper_toml_loader.Toml_local_time _) ->
     Error (Printf.sprintf "%s: expected a numeric TOML value" key)
 
 let load_and_apply ~base_path =

--- a/lib/keeper_toml/dune
+++ b/lib/keeper_toml/dune
@@ -5,4 +5,4 @@
  (public_name masc.keeper_toml)
  (wrapped false)
  (modules keeper_toml_loader keeper_toml_parser)
- (libraries eio fs_compat masc.masc_core))
+ (libraries eio fs_compat masc.masc_core otoml))

--- a/lib/keeper_toml/keeper_toml_loader.ml
+++ b/lib/keeper_toml/keeper_toml_loader.ml
@@ -51,77 +51,170 @@ let toml_string_list (doc : toml_doc) (key : string) : string list =
 (* TOML writer — line-level field update                            *)
 (* ================================================================ *)
 
-let line_assigns_key ~(key : string) (trimmed : string) =
-  match parse_toml trimmed with
-  | Ok [ parsed_key, _ ] -> String.equal key parsed_key
-  | Ok _ | Error _ -> false
+let assignment_equals_index line =
+  let rec loop index quote escaped =
+    if index >= String.length line
+    then None
+    else
+      let character = String.get line index in
+      match quote, escaped, character with
+      | Some '"', true, _ -> loop (index + 1) quote false
+      | Some '"', false, '\\' -> loop (index + 1) quote true
+      | Some '"', false, '"' -> loop (index + 1) None false
+      | Some '\'', _, '\'' -> loop (index + 1) None false
+      | Some _, _, _ -> loop (index + 1) quote false
+      | None, _, '"' -> loop (index + 1) (Some '"') false
+      | None, _, '\'' -> loop (index + 1) (Some '\'') false
+      | None, _, '=' -> Some index
+      | None, _, _ -> loop (index + 1) None false
+  in
+  loop 0 None false
+;;
+
+let assignment_key_of_line trimmed =
+  match assignment_equals_index trimmed with
+  | None -> None
+  | Some equals_at ->
+    let raw_key = String.sub trimmed 0 equals_at |> String.trim in
+    if String.equal raw_key ""
+    then None
+    else
+      match parse_toml (raw_key ^ " = true") with
+      | Ok [ parsed_key, _ ] -> Some parsed_key
+      | Ok _ | Error _ -> None
+;;
+
+let assignment_end lines start =
+  let rec loop index candidate =
+    if index >= Array.length lines
+    then None
+    else
+      let candidate =
+        if index = start
+        then lines.(index)
+        else candidate ^ "\n" ^ lines.(index)
+      in
+      match parse_toml candidate with
+      | Ok [ _, _ ] -> Some index
+      | Ok _ | Error _ -> loop (index + 1) candidate
+  in
+  loop start ""
+;;
+
+let is_table_header trimmed =
+  String.length trimmed > 0 && Char.equal trimmed.[0] '['
+;;
+
+let rewrite_field_in_content
+      ~(table : string)
+      ~(key : string)
+      ~(replacement : string option)
+      (content : string)
+  : (string, string) result
+  =
+  let lines =
+    content
+    |> String.split_on_char '\n'
+    |> List.map String_util.strip_trailing_cr
+    |> Array.of_list
+  in
+  let table_header = Printf.sprintf "[%s]" table in
+  let output = ref [] in
+  let add_line line = output := line :: !output in
+  let add_range first last =
+    let rec loop index =
+      if index <= last
+      then (
+        add_line lines.(index);
+        loop (index + 1))
+    in
+    loop first
+  in
+  let replacement_line () =
+    match replacement with
+    | Some rendered -> Some (Printf.sprintf "%s = %s" key rendered)
+    | None -> None
+  in
+  let rec loop index in_target_table found =
+    if index >= Array.length lines
+    then
+      let found =
+        if in_target_table && not found
+        then (
+          match replacement_line () with
+          | Some line -> add_line line; true
+          | None -> found)
+        else found
+      in
+      if (match replacement with Some _ -> not found | None -> false)
+      then Error (Printf.sprintf "table [%s] not found in TOML" table)
+      else Ok (String.concat "\n" (List.rev !output))
+    else
+      let line = lines.(index) in
+      let trimmed = String.trim line in
+      if String.equal trimmed table_header
+      then (
+        add_line line;
+        loop (index + 1) true found)
+      else if in_target_table && is_table_header trimmed
+      then (
+        let found =
+          if not found
+          then (
+            match replacement_line () with
+            | Some replacement_line -> add_line replacement_line; true
+            | None -> found)
+          else found
+        in
+        add_line line;
+        loop (index + 1) false found)
+      else if in_target_table
+      then (
+        match assignment_key_of_line trimmed with
+        | None ->
+          add_line line;
+          loop (index + 1) true found
+        | Some parsed_key ->
+          (match assignment_end lines index with
+           | None ->
+             Error
+               (Printf.sprintf
+                  "unterminated TOML assignment while editing [%s].%s"
+                  table
+                  parsed_key)
+           | Some last_index ->
+             if (not found) && String.equal key parsed_key
+             then (
+               (match replacement_line () with
+                | Some replacement_line -> add_line replacement_line
+                | None -> ());
+               loop (last_index + 1) true true)
+             else (
+               add_range index last_index;
+               loop (last_index + 1) true found)))
+      else (
+        add_line line;
+        loop (index + 1) false found)
+  in
+  loop 0 false false
 ;;
 
 (** Update or insert a key under a [table] in a TOML file.
     Preserves comments, formatting, and other fields.
     Returns [Ok new_content] or [Error reason]. *)
-let update_rendered_field_in_content
-      ~(table : string)
-      ~(key : string)
-      ~(rendered_value : string)
-      (content : string)
-  : (string, string) result
-  =
-  let lines = String.split_on_char '\n' content in
-  let table_header = Printf.sprintf "[%s]" table in
-  let in_target_table = ref false in
-  let found = ref false in
-  let result_lines = ref [] in
-  let insert_before_next_table = ref false in
-  List.iter
-    (fun raw_line ->
-       let line = String_util.strip_trailing_cr raw_line in
-       let trimmed = String.trim line in
-       if !insert_before_next_table && String.length trimmed > 0 && trimmed.[0] = '['
-       then (
-         (* New table started — insert the field before it *)
-         result_lines := Printf.sprintf "%s = %s" key rendered_value :: !result_lines;
-         found := true;
-         insert_before_next_table := false);
-       if String.trim trimmed = table_header
-       then (
-         in_target_table := true;
-         insert_before_next_table := true;
-         result_lines := line :: !result_lines)
-       else if !in_target_table && String.length trimmed > 0 && trimmed.[0] = '['
-       then (
-         in_target_table := false;
-         if !insert_before_next_table && not !found
-         then (
-           result_lines := Printf.sprintf "%s = %s" key rendered_value :: !result_lines;
-           found := true;
-           insert_before_next_table := false);
-         result_lines := line :: !result_lines)
-       else if
-         !in_target_table
-         && (not !found)
-         && line_assigns_key ~key trimmed
-       then (
-         result_lines := Printf.sprintf "%s = %s" key rendered_value :: !result_lines;
-         found := true;
-         insert_before_next_table := false)
-       else result_lines := line :: !result_lines)
-    lines;
-  (* If we were in the target table at EOF and didn't find the key, append *)
-  if (not !found) && !insert_before_next_table
-  then (
-    result_lines := Printf.sprintf "%s = %s" key rendered_value :: !result_lines;
-    found := true);
-  if not !found
-  then Error (Printf.sprintf "table [%s] not found in TOML" table)
-  else Ok (String.concat "\n" (List.rev !result_lines))
+let update_rendered_field_in_content ~table ~key ~rendered_value content =
+  rewrite_field_in_content
+    ~table
+    ~key
+    ~replacement:(Some rendered_value)
+    content
 ;;
 
 let update_field_in_content ~table ~key ~value content =
   update_rendered_field_in_content
     ~table
     ~key
-    ~rendered_value:(Printf.sprintf "\"%s\"" value)
+    ~rendered_value:(Otoml.Printer.to_string (Otoml.TomlString value) |> String.trim)
     content
 ;;
 
@@ -184,20 +277,6 @@ type toml_edit =
   | Set of toml_value
   | Remove
 
-let toml_escape_string value =
-  let buffer = Buffer.create (String.length value + 8) in
-  String.iter
-    (function
-      | '\\' -> Buffer.add_string buffer "\\\\"
-      | '"' -> Buffer.add_string buffer "\\\""
-      | '\n' -> Buffer.add_string buffer "\\n"
-      | '\r' -> Buffer.add_string buffer "\\r"
-      | '\t' -> Buffer.add_string buffer "\\t"
-      | c -> Buffer.add_char buffer c)
-    value;
-  Buffer.contents buffer
-;;
-
 let rec otoml_value_of_toml_value = function
   | Toml_string value -> Ok (Otoml.TomlString value)
   | Toml_int value -> Ok (Otoml.TomlInteger value)
@@ -232,56 +311,14 @@ let rec otoml_value_of_toml_value = function
 let render_toml_value = function
   | Toml_table _ | Toml_table_array _ ->
     Error "standard tables and table arrays cannot be rendered as key assignments"
-  | Toml_string value ->
-    Ok (Printf.sprintf "\"%s\"" (toml_escape_string value))
-  | Toml_int value -> Ok (string_of_int value)
-  | Toml_float value -> Ok (string_of_float value)
-  | Toml_bool value -> Ok (string_of_bool value)
-  | Toml_string_array values ->
-    values
-    |> List.map (fun value ->
-         Printf.sprintf "\"%s\"" (toml_escape_string value))
-    |> String.concat ", "
-    |> Printf.sprintf "[%s]"
-    |> Result.ok
-  | ( Toml_array _
-    | Toml_inline_table _
-    | Toml_offset_datetime _
-    | Toml_local_datetime _
-    | Toml_local_date _
-    | Toml_local_time _ ) as value ->
+  | value ->
     Result.map
       (fun value -> Otoml.Printer.to_string value |> String.trim)
       (otoml_value_of_toml_value value)
 ;;
 
 let remove_field_in_content ~(table : string) ~(key : string) content =
-  let table_header = Printf.sprintf "[%s]" table in
-  let _, lines =
-    content
-    |> String.split_on_char '\n'
-    |> List.fold_left
-         (fun (in_target_table, acc) raw_line ->
-           let line = String_util.strip_trailing_cr raw_line in
-           let trimmed = String.trim line in
-           let starts_table =
-             String.length trimmed > 0 && Char.equal trimmed.[0] '['
-           in
-           let in_target_table =
-             if String.equal trimmed table_header then true
-             else if starts_table then false
-             else in_target_table
-           in
-           let is_target_field =
-             in_target_table
-             && line_assigns_key ~key trimmed
-           in
-           if is_target_field
-           then in_target_table, acc
-           else in_target_table, line :: acc)
-         (false, [])
-  in
-  String.concat "\n" (List.rev lines)
+  rewrite_field_in_content ~table ~key ~replacement:None content
 ;;
 
 let edit_keeper_toml_fields ~(path : string) fields =
@@ -301,7 +338,7 @@ let edit_keeper_toml_fields ~(path : string) fields =
                   ~rendered_value
                   current)
             | Remove ->
-              Ok (remove_field_in_content ~table:"keeper" ~key current)))
+              remove_field_in_content ~table:"keeper" ~key current))
         (Ok content)
         fields
     in

--- a/lib/keeper_toml/keeper_toml_loader.ml
+++ b/lib/keeper_toml/keeper_toml_loader.ml
@@ -1,15 +1,9 @@
-(** Keeper_toml_loader -- load keeper configuration from TOML files.
+(** Keeper_toml_loader -- typed keeper projection and comment-preserving edits
+    over the Otoml semantic parser in [Keeper_toml_parser]. *)
 
-    Minimal TOML parser: tables, strings (basic + multiline),
-    integers, floats, booleans, and string arrays (single-line and
-    multi-line).
-    Enough to express all keeper_profile_defaults fields. *)
-
-(* tla-lint: file-scope: parser local state — TOML lexer accumulators
-   (line buffer, multiline-string buffer, current_table, key/value list)
-   are confined to a single parse_lines call and never observed as
-   keeper FSM state. Every [:=] / [<-] in this file mutates parser-
-   internal scaffolding, not state-machine state. *)
+(* tla-lint: file-scope: line-editor state is confined to one update call and
+   never observed as keeper FSM state. Every [:=] in this file mutates only
+   comment-preserving edit accumulators. *)
 
 
 (** Parser types and logic extracted to [Keeper_toml_parser].
@@ -58,12 +52,9 @@ let toml_string_list (doc : toml_doc) (key : string) : string list =
 (* ================================================================ *)
 
 let line_assigns_key ~(key : string) (trimmed : string) =
-  match String.index_opt trimmed '=' with
-  | None -> false
-  | Some equals_at ->
-    String.equal
-      key
-      (String.sub trimmed 0 equals_at |> String.trim)
+  match parse_toml trimmed with
+  | Ok [ parsed_key, _ ] -> String.equal key parsed_key
+  | Ok _ | Error _ -> false
 ;;
 
 (** Update or insert a key under a [table] in a TOML file.
@@ -207,17 +198,61 @@ let toml_escape_string value =
   Buffer.contents buffer
 ;;
 
+let rec otoml_value_of_toml_value = function
+  | Toml_string value -> Ok (Otoml.TomlString value)
+  | Toml_int value -> Ok (Otoml.TomlInteger value)
+  | Toml_float value -> Ok (Otoml.TomlFloat value)
+  | Toml_bool value -> Ok (Otoml.TomlBoolean value)
+  | Toml_string_array values ->
+    Ok (Otoml.TomlArray (List.map (fun value -> Otoml.TomlString value) values))
+  | Toml_array values ->
+    List.fold_right
+      (fun value result ->
+        Result.bind (otoml_value_of_toml_value value) (fun value ->
+          Result.map (fun values -> value :: values) result))
+      values
+      (Ok [])
+    |> Result.map (fun values -> Otoml.TomlArray values)
+  | Toml_inline_table fields ->
+    List.fold_right
+      (fun (key, value) result ->
+        Result.bind (otoml_value_of_toml_value value) (fun value ->
+          Result.map (fun fields -> (key, value) :: fields) result))
+      fields
+      (Ok [])
+    |> Result.map (fun fields -> Otoml.TomlInlineTable fields)
+  | Toml_offset_datetime value -> Ok (Otoml.TomlOffsetDateTime value)
+  | Toml_local_datetime value -> Ok (Otoml.TomlLocalDateTime value)
+  | Toml_local_date value -> Ok (Otoml.TomlLocalDate value)
+  | Toml_local_time value -> Ok (Otoml.TomlLocalTime value)
+  | Toml_table _ | Toml_table_array _ ->
+    Error "standard tables and table arrays cannot be nested in assignment values"
+;;
+
 let render_toml_value = function
-  | Toml_string value -> Printf.sprintf "\"%s\"" (toml_escape_string value)
-  | Toml_int value -> string_of_int value
-  | Toml_float value -> string_of_float value
-  | Toml_bool value -> string_of_bool value
+  | Toml_table _ | Toml_table_array _ ->
+    Error "standard tables and table arrays cannot be rendered as key assignments"
+  | Toml_string value ->
+    Ok (Printf.sprintf "\"%s\"" (toml_escape_string value))
+  | Toml_int value -> Ok (string_of_int value)
+  | Toml_float value -> Ok (string_of_float value)
+  | Toml_bool value -> Ok (string_of_bool value)
   | Toml_string_array values ->
     values
     |> List.map (fun value ->
          Printf.sprintf "\"%s\"" (toml_escape_string value))
     |> String.concat ", "
     |> Printf.sprintf "[%s]"
+    |> Result.ok
+  | ( Toml_array _
+    | Toml_inline_table _
+    | Toml_offset_datetime _
+    | Toml_local_datetime _
+    | Toml_local_date _
+    | Toml_local_time _ ) as value ->
+    Result.map
+      (fun value -> Otoml.Printer.to_string value |> String.trim)
+      (otoml_value_of_toml_value value)
 ;;
 
 let remove_field_in_content ~(table : string) ~(key : string) content =
@@ -259,11 +294,12 @@ let edit_keeper_toml_fields ~(path : string) fields =
           Result.bind result (fun current ->
             match edit with
             | Set value ->
-              update_rendered_field_in_content
-                ~table:"keeper"
-                ~key
-                ~rendered_value:(render_toml_value value)
-                current
+              Result.bind (render_toml_value value) (fun rendered_value ->
+                update_rendered_field_in_content
+                  ~table:"keeper"
+                  ~key
+                  ~rendered_value
+                  current)
             | Remove ->
               Ok (remove_field_in_content ~table:"keeper" ~key current)))
         (Ok content)
@@ -276,17 +312,26 @@ let create_keeper_toml_file ~(path : string) fields =
   if Fs_compat.file_exists path
   then Error (Printf.sprintf "refusing to overwrite existing keeper TOML: %s" path)
   else
-    let content =
-      [ "# Generated by masc_keeper_up."; "[keeper]" ]
-      @ List.map
-          (fun (key, value) ->
-            Printf.sprintf "%s = %s" key (render_toml_value value))
-          fields
-      |> String.concat "\n"
-      |> fun rendered -> rendered ^ "\n"
+    let rendered_fields =
+      List.fold_right
+        (fun (key, value) result ->
+          Result.bind (render_toml_value value) (fun rendered_value ->
+            Result.map
+              (fun rendered ->
+                Printf.sprintf "%s = %s" key rendered_value :: rendered)
+              result))
+        fields
+        (Ok [])
     in
-    Fs_compat.mkdir_p (Filename.dirname path);
-    Fs_compat.save_file_atomic path content
+    Result.bind rendered_fields (fun rendered_fields ->
+      let content =
+        [ "# Generated by masc_keeper_up."; "[keeper]" ]
+        @ rendered_fields
+        |> String.concat "\n"
+        |> fun rendered -> rendered ^ "\n"
+      in
+      Fs_compat.mkdir_p (Filename.dirname path);
+      Fs_compat.save_file_atomic path content)
 ;;
 
 (* Higher-level functions (profile_defaults_of_toml, load_keeper_toml,

--- a/lib/keeper_toml/keeper_toml_loader.mli
+++ b/lib/keeper_toml/keeper_toml_loader.mli
@@ -1,8 +1,8 @@
-(** Keeper_toml_loader -- minimal TOML parser for keeper configuration.
+(** Keeper_toml_loader -- Otoml-backed parser for keeper configuration.
 
     Reads TOML files and produces a flat key-value document.
-    Supports tables, strings (with escapes), integers, floats, booleans,
-    and string arrays. No external dependency required.
+    TOML 1.0 syntax is owned by Otoml; keeper-specific typed accessors and the
+    comment-preserving line editor remain here.
 
     The conversion from TOML to keeper_profile_defaults is done in
     {!Keeper_types_profile} to avoid circular dependencies. *)
@@ -14,12 +14,20 @@ type toml_value =
   | Toml_float of float
   | Toml_bool of bool
   | Toml_string_array of string list
+  | Toml_array of toml_value list
+  | Toml_table of (string * toml_value) list
+  | Toml_inline_table of (string * toml_value) list
+  | Toml_table_array of toml_value list
+  | Toml_offset_datetime of string
+  | Toml_local_datetime of string
+  | Toml_local_date of string
+  | Toml_local_time of string
 
 (** A parsed TOML document: mapping from dotted key (e.g. ["keeper.instructions"])
     to value. Tables are flattened with dot separators. *)
 type toml_doc = (string * toml_value) list
 
-(** Parse a TOML string into a flat key-value list.
+(** Parse a TOML 1.0 string with Otoml into a flat canonical key-value list.
     Returns [Error msg] on syntax errors. *)
 val parse_toml : string -> (toml_doc, string) result
 

--- a/lib/keeper_toml/keeper_toml_parser.ml
+++ b/lib/keeper_toml/keeper_toml_parser.ml
@@ -1,14 +1,9 @@
-(** Keeper_toml_parser — TOML parser extracted from [Keeper_toml_loader].
+(** Keeper TOML semantic parsing backed by Otoml.
 
-    Types and parsing logic for TOML configuration. Accessors and
-    mutation operations remain in [Keeper_toml_loader].
-    @since Keeper 500-line decomposition *)
-
-(* tla-lint: file-scope: parser local state — TOML lexer accumulators
-   (line buffer, multiline-string buffer, current_table, key/value list)
-   are confined to a single parse_lines call and never observed as
-   keeper FSM state. Every [:=] / [<-] in this file mutates parser-
-   internal scaffolding, not state-machine state. *)
+    Keeper consumers use a flat, canonical key-path projection. Semantic TOML
+    parsing, escaping, quoted/dotted key handling, and value validation remain
+    owned by Otoml; comment-preserving mutation remains in
+    [Keeper_toml_loader]. *)
 
 type toml_value =
   | Toml_string of string
@@ -16,449 +11,92 @@ type toml_value =
   | Toml_float of float
   | Toml_bool of bool
   | Toml_string_array of string list
+  | Toml_array of toml_value list
+  | Toml_table of (string * toml_value) list
+  | Toml_inline_table of (string * toml_value) list
+  | Toml_table_array of toml_value list
+  | Toml_offset_datetime of string
+  | Toml_local_datetime of string
+  | Toml_local_date of string
+  | Toml_local_time of string
 
 type toml_doc = (string * toml_value) list
 
-(* ================================================================ *)
-(* TOML parser                                                       *)
-(* ================================================================ *)
-
-let is_ws c = c = ' ' || c = '\t'
-
-let trim_leading_ws s =
-  let len = String.length s in
-  let rec scan i = if i >= len then len else if is_ws s.[i] then scan (i + 1) else i in
-  let start = scan 0 in
-  String.sub s start (len - start)
+let rec toml_value_of_otoml = function
+  | Otoml.TomlString value -> Toml_string value
+  | Otoml.TomlInteger value -> Toml_int value
+  | Otoml.TomlFloat value -> Toml_float value
+  | Otoml.TomlBoolean value -> Toml_bool value
+  | Otoml.TomlOffsetDateTime value -> Toml_offset_datetime value
+  | Otoml.TomlLocalDateTime value -> Toml_local_datetime value
+  | Otoml.TomlLocalDate value -> Toml_local_date value
+  | Otoml.TomlLocalTime value -> Toml_local_time value
+  | Otoml.TomlArray values ->
+    let values = List.map toml_value_of_otoml values in
+    (match
+       List.fold_right
+         (fun value strings ->
+           match value, strings with
+           | Toml_string string, Some strings -> Some (string :: strings)
+           | _, _ -> None)
+         values
+         (Some [])
+     with
+     | Some strings -> Toml_string_array strings
+     | None -> Toml_array values)
+  | Otoml.TomlTable fields ->
+    Toml_table
+      (List.map
+         (fun (key, value) -> key, toml_value_of_otoml value)
+         fields)
+  | Otoml.TomlInlineTable fields ->
+    Toml_inline_table
+      (List.map
+         (fun (key, value) -> key, toml_value_of_otoml value)
+         fields)
+  | Otoml.TomlTableArray values ->
+    Toml_table_array (List.map toml_value_of_otoml values)
 ;;
 
-let trim_initial_multiline_newline s =
-  let len = String.length s in
-  if len >= 2 && s.[0] = '\r' && s.[1] = '\n'
-  then String.sub s 2 (len - 2)
-  else if len >= 1 && s.[0] = '\n'
-  then String.sub s 1 (len - 1)
-  else s
+let valid_bare_key key =
+  String.length key > 0
+  && String.for_all
+       (function
+         | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' -> true
+         | _ -> false)
+       key
 ;;
 
-let multiline_suffix_is_valid suffix =
-  let len = String.length suffix in
-  let rec skip_ws i =
-    if i >= len then len else if is_ws suffix.[i] then skip_ws (i + 1) else i
-  in
-  let i = skip_ws 0 in
-  i >= len || suffix.[i] = '#'
+let canonical_key key =
+  if valid_bare_key key then key else Otoml.string_of_path [ key ]
 ;;
 
-(* TOML allows up to two `"` chars immediately after the closing `"""` to be
-   part of the string content.  Extract those and return (trailing, rest). *)
-let extract_trailing_quotes suffix =
-  let n = String.length suffix in
-  let count =
-    if n > 0 && suffix.[0] = '"' then if n > 1 && suffix.[1] = '"' then 2 else 1 else 0
-  in
-  String.make count '"', String.sub suffix count (n - count)
+let string_of_path path =
+  String.concat "." (List.map canonical_key path)
 ;;
 
-let has_closing_bracket s =
-  let len = String.length s in
-  let rec scan i in_str =
-    if i >= len
-    then false
-    else if in_str
-    then
-      if s.[i] = '"'
-      then scan (i + 1) false
-      else if s.[i] = '\\' && i + 1 < len
-      then scan (i + 2) true
-      else scan (i + 1) true
-    else if s.[i] = '"'
-    then scan (i + 1) true
-    else if s.[i] = ']'
-    then true
-    else scan (i + 1) false
-  in
-  scan 0 false
+let rec flatten_table path fields =
+  List.concat_map
+    (fun (key, value) ->
+      let path = path @ [ key ] in
+      match value with
+      | Otoml.TomlTable nested -> flatten_table path nested
+      | value -> [ string_of_path path, toml_value_of_otoml value ])
+    fields
 ;;
 
-let strip_comment (line : string) : string =
-  (* Find # that is not inside a quoted string. *)
-  let len = String.length line in
-  let rec scan i in_str =
-    if i >= len
-    then line
-    else (
-      let c = line.[i] in
-      if in_str
-      then
-        if c = '"'
-        then scan (i + 1) false
-        else if c = '\\' && i + 1 < len
-        then scan (i + 2) true
-        else scan (i + 1) true
-      else if c = '"'
-      then scan (i + 1) true
-      else if c = '#'
-      then String.sub line 0 i |> String.trim
-      else scan (i + 1) false)
+let parse_toml content =
+  (* TOML defines CRLF and LF as equivalent newlines. Otoml 1.0.5 preserves
+     CRLF bytes inside multiline strings, so normalize only CRLF boundaries
+     before semantic parsing. *)
+  let content =
+    content
+    |> String.split_on_char '\n'
+    |> List.map String_util.strip_trailing_cr
+    |> String.concat "\n"
   in
-  scan 0 false
-;;
-
-let parse_basic_string (s : string) : (string, string) result =
-  (* Expects input WITHOUT surrounding quotes. Handles escape sequences. *)
-  let len = String.length s in
-  let buf = Buffer.create len in
-  let rec loop i =
-    if i >= len
-    then Ok (Buffer.contents buf)
-    else if s.[i] = '\\'
-    then
-      if i + 1 >= len
-      then Error "unterminated escape sequence"
-      else (
-        match s.[i + 1] with
-        | 'n' ->
-          Buffer.add_char buf '\n';
-          loop (i + 2)
-        | 't' ->
-          Buffer.add_char buf '\t';
-          loop (i + 2)
-        | 'r' ->
-          Buffer.add_char buf '\r';
-          loop (i + 2)
-        | '\\' ->
-          Buffer.add_char buf '\\';
-          loop (i + 2)
-        | '"' ->
-          Buffer.add_char buf '"';
-          loop (i + 2)
-        | '\n' | '\r' ->
-          (* TOML multiline line-ending backslash: trim the backslash, the
-             newline, and any subsequent whitespace/newlines. *)
-          let rec skip_ws j =
-            if j >= len
-            then j
-            else if s.[j] = ' ' || s.[j] = '\t' || s.[j] = '\n' || s.[j] = '\r'
-            then skip_ws (j + 1)
-            else j
-          in
-          loop (skip_ws (i + 2))
-        | c -> Error (Printf.sprintf "unknown escape \\%c" c))
-    else (
-      Buffer.add_char buf s.[i];
-      loop (i + 1))
-  in
-  loop 0
-;;
-
-let extract_quoted_string (raw : string) : (string, string) result =
-  let len = String.length raw in
-  if len < 2 || raw.[0] <> '"'
-  then Error "expected quoted string"
-  else (
-    (* Find closing quote, handling escapes *)
-    let rec find_end i =
-      if i >= len
-      then Error "unterminated string"
-      else if raw.[i] = '\\'
-      then find_end (i + 2)
-      else if raw.[i] = '"'
-      then Ok i
-      else find_end (i + 1)
-    in
-    match find_end 1 with
-    | Error e -> Error e
-    | Ok end_pos -> parse_basic_string (String.sub raw 1 (end_pos - 1)))
-;;
-
-let parse_value (raw : string) : (toml_value, string) result =
-  let s = String.trim raw in
-  if s = ""
-  then Error "empty value"
-  else if s = "true"
-  then Ok (Toml_bool true)
-  else if s = "false"
-  then Ok (Toml_bool false)
-  else if s.[0] = '"'
-  then Result.map (fun v -> Toml_string v) (extract_quoted_string s)
-  else if s.[0] = '['
-  then (
-    (* Parse string array: ["a", "b", "c"] *)
-    let len = String.length s in
-    if len < 2 || s.[len - 1] <> ']'
-    then Error "unterminated array"
-    else (
-      let inner = String.sub s 1 (len - 2) |> String.trim in
-      if inner = ""
-      then Ok (Toml_string_array [])
-      else (
-        (* Split on commas outside quotes *)
-        let items = ref [] in
-        let buf = Buffer.create 64 in
-        let ok = ref true in
-        let ilen = String.length inner in
-        let rec split i in_str =
-          if i >= ilen
-          then ()
-          else (
-            let c = inner.[i] in
-            if in_str
-            then (
-              Buffer.add_char buf c;
-              if c = '\\' && i + 1 < ilen
-              then (
-                (* Escaped char: add next char and skip it *)
-                Buffer.add_char buf inner.[i + 1];
-                split (i + 2) true)
-              else if c = '"'
-              then split (i + 1) false
-              else split (i + 1) true)
-            else if c = ','
-            then (
-              items := Buffer.contents buf :: !items;
-              Buffer.clear buf;
-              split (i + 1) false)
-            else if c = '"'
-            then (
-              Buffer.add_char buf c;
-              split (i + 1) true)
-            else if is_ws c
-            then split (i + 1) false
-            else (
-              ok := false;
-              split (i + 1) false))
-        in
-        split 0 false;
-        if Buffer.length buf > 0 then items := Buffer.contents buf :: !items;
-        if not !ok
-        then Error "array elements must be quoted strings"
-        else (
-          let parsed =
-            List.rev !items
-            |> List.map (fun item -> extract_quoted_string (String.trim item))
-          in
-          let errors = List.filter Result.is_error parsed in
-          if errors <> []
-          then Error "failed to parse array element"
-          else
-            Ok
-              (Toml_string_array
-                 (List.filter_map
-                    (fun r ->
-                       match r with
-                       | Ok v -> Some v
-                       | Error _ -> None)
-                    parsed))))))
-  else (
-    (* Try int, then float *)
-    match int_of_string_opt s with
-    | Some i -> Ok (Toml_int i)
-    | None ->
-      (match float_of_string_opt s with
-       | Some f -> Ok (Toml_float f)
-       | None -> Error (Printf.sprintf "cannot parse value: %s" s)))
-;;
-
-let starts_with_triple_quote s =
-  let len = String.length s in
-  len >= 3 && s.[0] = '"' && s.[1] = '"' && s.[2] = '"'
-;;
-
-let find_closing_triple_quote s start =
-  let len = String.length s in
-  (* Scan forward, tracking the number of consecutive backslashes immediately
-     preceding the current index (parity determines whether a quote is escaped).
-     This keeps the overall search O(n) rather than O(n^2). *)
-  let rec scan i backslashes =
-    if i + 2 >= len
-    then None
-    else (
-      let escaped = backslashes mod 2 = 1 in
-      if s.[i] = '"' && s.[i + 1] = '"' && s.[i + 2] = '"' && not escaped
-      then Some i
-      else (
-        let next_backslashes = if s.[i] = '\\' then backslashes + 1 else 0 in
-        scan (i + 1) next_backslashes))
-  in
-  scan start 0
-;;
-
-type multiline_string_state =
-  { key : string
-  ; buf : Buffer.t
-  ; start_line : int
-  }
-
-type multiline_array_state =
-  { key : string
-  ; buf : Buffer.t
-  ; start_line : int
-  }
-
-type parse_state =
-  { mutable current_table : string
-  ; mutable acc : toml_doc
-  ; mutable error : string option
-  ; mutable line_num : int
-  ; mutable multiline_string : multiline_string_state option
-  ; mutable multiline_array : multiline_array_state option
-  }
-
-let create_parse_state () =
-  { current_table = ""
-  ; acc = []
-  ; error = None
-  ; line_num = 0
-  ; multiline_string = None
-  ; multiline_array = None
-  }
-;;
-
-let add_entry state key value = state.acc <- (key, value) :: state.acc
-let set_error state message = state.error <- Some message
-
-let parse_toml (content : string) : (toml_doc, string) result =
-  let lines = String.split_on_char '\n' content in
-  let state = create_parse_state () in
-  let full_key key =
-    if state.current_table = "" then key else state.current_table ^ "." ^ key
-  in
-  let line_error message =
-    set_error state (Printf.sprintf "line %d: %s" state.line_num message)
-  in
-  let handle_multiline_string (ml : multiline_string_state) raw_line =
-    match find_closing_triple_quote raw_line 0 with
-    | Some close_pos ->
-      let prefix = String.sub raw_line 0 close_pos in
-      let suffix =
-        String.sub raw_line (close_pos + 3) (String.length raw_line - close_pos - 3)
-      in
-      let trailing_quotes, suffix_remainder = extract_trailing_quotes suffix in
-      if not (multiline_suffix_is_valid suffix_remainder)
-      then line_error "unexpected content after closing multiline string"
-      else (
-        if Buffer.length ml.buf > 0 then Buffer.add_char ml.buf '\n';
-        Buffer.add_string ml.buf prefix;
-        Buffer.add_string ml.buf trailing_quotes;
-        let raw_str = Buffer.contents ml.buf in
-        (match parse_basic_string raw_str with
-         | Ok v -> add_entry state ml.key (Toml_string v)
-         | Error e ->
-           set_error
-             state
-             (Printf.sprintf "line %d: multiline string: %s" ml.start_line e));
-        state.multiline_string <- None)
-    | None ->
-      if Buffer.length ml.buf > 0 then Buffer.add_char ml.buf '\n';
-      Buffer.add_string ml.buf raw_line
-  in
-  let handle_multiline_array (arr : multiline_array_state) raw_line =
-    let line = strip_comment raw_line in
-    let trimmed = String.trim line in
-    if trimmed <> ""
-    then (
-      if Buffer.length arr.buf > 0 then Buffer.add_char arr.buf ' ';
-      Buffer.add_string arr.buf trimmed);
-    if has_closing_bracket trimmed
-    then (
-      let assembled = Buffer.contents arr.buf in
-      (match parse_value assembled with
-       | Ok v -> add_entry state arr.key v
-       | Error e -> set_error state (Printf.sprintf "line %d: %s" arr.start_line e));
-      state.multiline_array <- None)
-  in
-  let start_multiline_string key after_open =
-    let buf = Buffer.create 256 in
-    let stripped = trim_initial_multiline_newline after_open in
-    if stripped <> "" then Buffer.add_string buf stripped;
-    state.multiline_string <- Some { key; buf; start_line = state.line_num }
-  in
-  let start_multiline_array key trimmed =
-    let buf = Buffer.create 256 in
-    Buffer.add_string buf trimmed;
-    state.multiline_array <- Some { key; buf; start_line = state.line_num }
-  in
-  let parse_single_line_multiline_string key after_open close_pos =
-    let inner = String.sub after_open 0 close_pos in
-    let suffix =
-      String.sub after_open (close_pos + 3) (String.length after_open - close_pos - 3)
-    in
-    let trailing_quotes, suffix_remainder = extract_trailing_quotes suffix in
-    if not (multiline_suffix_is_valid suffix_remainder)
-    then line_error "unexpected content after closing multiline string"
-    else (
-      match parse_basic_string (inner ^ trailing_quotes) with
-      | Ok v -> add_entry state key (Toml_string v)
-      | Error e -> line_error e)
-  in
-  let handle_value key value_raw =
-    let trimmed = trim_leading_ws value_raw in
-    if starts_with_triple_quote trimmed
-    then (
-      let after_open = String.sub trimmed 3 (String.length trimmed - 3) in
-      match find_closing_triple_quote after_open 0 with
-      | Some close_pos -> parse_single_line_multiline_string key after_open close_pos
-      | None -> start_multiline_string key after_open)
-    else if
-      String.length trimmed > 0 && trimmed.[0] = '[' && not (has_closing_bracket trimmed)
-    then start_multiline_array key trimmed
-    else (
-      match parse_value value_raw with
-      | Ok v -> add_entry state key v
-      | Error e -> line_error e)
-  in
-  let handle_table trimmed_line =
-    let len = String.length trimmed_line in
-    if trimmed_line.[len - 1] <> ']'
-    then line_error "unterminated table header"
-    else (
-      let table_name = String.sub trimmed_line 1 (len - 2) |> String.trim in
-      if table_name = ""
-      then line_error "empty table name"
-      else state.current_table <- table_name)
-  in
-  let handle_key_value line =
-    match String.index_opt line '=' with
-    | None -> line_error "expected key = value"
-    | Some eq_pos ->
-      let key = String.sub line 0 eq_pos |> String.trim in
-      let value_raw = String.sub line (eq_pos + 1) (String.length line - eq_pos - 1) in
-      if key = "" then line_error "empty key" else handle_value (full_key key) value_raw
-  in
-  let handle_normal_line raw_line =
-    let line = strip_comment raw_line in
-    let trimmed_line = String.trim line in
-    if trimmed_line = ""
-    then ()
-    else if trimmed_line.[0] = '['
-    then handle_table trimmed_line
-    else handle_key_value line
-  in
-  List.iter
-    (fun raw_line ->
-       state.line_num <- state.line_num + 1;
-       let raw_line = String_util.strip_trailing_cr raw_line in
-       if Option.is_none state.error
-       then (
-         match state.multiline_string, state.multiline_array with
-         | Some ml, _ -> handle_multiline_string ml raw_line
-         | None, Some arr -> handle_multiline_array arr raw_line
-         | None, None -> handle_normal_line raw_line))
-    lines;
-  (match state.multiline_string with
-   | Some ml when Option.is_none state.error ->
-     set_error
-       state
-       (Printf.sprintf "line %d: unterminated multiline string" ml.start_line)
-   | _ -> ());
-  (match state.multiline_array with
-   | Some arr when Option.is_none state.error ->
-     set_error
-       state
-       (Printf.sprintf "line %d: unterminated multiline array" arr.start_line)
-   | _ -> ());
-  match state.error with
-  | Some e -> Error e
-  | None -> Ok (List.rev state.acc)
+  match Otoml.Parser.from_string_result content with
+  | Error message -> Error message
+  | Ok (Otoml.TomlTable fields) -> Ok (flatten_table [] fields)
+  | Ok _ -> Error "otoml returned a non-table document root"
 ;;

--- a/lib/keeper_toml/keeper_toml_parser.mli
+++ b/lib/keeper_toml/keeper_toml_parser.mli
@@ -1,4 +1,4 @@
-(** Minimal TOML parser for keeper configuration files. *)
+(** Otoml-backed semantic parser for keeper configuration. *)
 
 type toml_value =
   | Toml_string of string
@@ -6,7 +6,18 @@ type toml_value =
   | Toml_float of float
   | Toml_bool of bool
   | Toml_string_array of string list
+  | Toml_array of toml_value list
+  | Toml_table of (string * toml_value) list
+  | Toml_inline_table of (string * toml_value) list
+  | Toml_table_array of toml_value list
+  | Toml_offset_datetime of string
+  | Toml_local_datetime of string
+  | Toml_local_date of string
+  | Toml_local_time of string
 
 type toml_doc = (string * toml_value) list
 
 val parse_toml : string -> (toml_doc, string) result
+(** Parse a TOML 1.0 document with Otoml and flatten standard tables into
+    canonical key paths. Quoted key segments remain quoted, so a literal key
+    containing a dot cannot collide with a dotted path. *)

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -813,7 +813,16 @@ let handle_get_config _state request reqd =
                  Some (k, `String (Printf.sprintf "%g" f))
                | Keeper_toml_loader.Toml_bool b ->
                  Some (k, `String (if b then "true" else "false"))
-               | Keeper_toml_loader.Toml_string_array _ -> None)
+               | ( Keeper_toml_loader.Toml_string_array _
+                 | Keeper_toml_loader.Toml_array _
+                 | Keeper_toml_loader.Toml_table _
+                 | Keeper_toml_loader.Toml_inline_table _
+                 | Keeper_toml_loader.Toml_table_array _
+                 | Keeper_toml_loader.Toml_offset_datetime _
+                 | Keeper_toml_loader.Toml_local_datetime _
+                 | Keeper_toml_loader.Toml_local_date _
+                 | Keeper_toml_loader.Toml_local_time _ ) ->
+                 None)
             doc
         in
         respond_json

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -113,6 +113,34 @@ let test_parse_string_escapes () =
      | _ -> fail "expected Toml_string")
   | Error e -> fail e
 
+let test_parse_literal_string () =
+  match TL.parse_toml "key = 'keeper\\path'" with
+  | Ok doc ->
+    (match List.assoc_opt "key" doc with
+     | Some (TL.Toml_string s) -> check string "literal string" "keeper\\path" s
+     | _ -> fail "expected Toml_string")
+  | Error e -> fail e
+
+let test_parse_unicode_and_control_escapes () =
+  match TL.parse_toml {|key = "\u0041\b\f"|} with
+  | Ok doc ->
+    (match List.assoc_opt "key" doc with
+     | Some (TL.Toml_string s) -> check string "unicode/control escapes" "A\b\012" s
+     | _ -> fail "expected Toml_string")
+  | Error e -> fail e
+
+let test_parse_quoted_and_dotted_keys_do_not_collide () =
+  let input = "\"a.b\" = \"literal\"\na.b = \"nested\"" in
+  match TL.parse_toml input with
+  | Ok doc ->
+    (match List.assoc_opt {|"a.b"|} doc with
+     | Some (TL.Toml_string s) -> check string "literal dotted key" "literal" s
+     | _ -> fail "expected quoted literal dotted key");
+    (match List.assoc_opt "a.b" doc with
+     | Some (TL.Toml_string s) -> check string "nested dotted key" "nested" s
+     | _ -> fail "expected nested dotted key")
+  | Error e -> fail e
+
 let test_parse_int_value () =
   let input = "count = 42" in
   match TL.parse_toml input with
@@ -186,6 +214,58 @@ let test_parse_empty_array () =
      | Some (TL.Toml_string_array xs) ->
        check int "empty array" 0 (List.length xs)
      | _ -> fail "expected empty Toml_string_array")
+  | Error e -> fail e
+
+let test_parse_general_array () =
+  match TL.parse_toml {|items = [1, "two", true]|} with
+  | Ok doc ->
+    (match List.assoc_opt "items" doc with
+     | Some
+         (TL.Toml_array
+           [ TL.Toml_int 1; TL.Toml_string "two"; TL.Toml_bool true ]) -> ()
+     | _ -> fail "expected mixed Toml_array")
+  | Error e -> fail e
+
+let test_parse_inline_table () =
+  match TL.parse_toml {|point = { x = 1, label = "origin" }|} with
+  | Ok doc ->
+    (match List.assoc_opt "point" doc with
+     | Some (TL.Toml_inline_table fields) ->
+       check (option int) "x" (Some 1)
+         (match List.assoc_opt "x" fields with
+          | Some (TL.Toml_int value) -> Some value
+          | _ -> None);
+       check (option string) "label" (Some "origin")
+         (match List.assoc_opt "label" fields with
+          | Some (TL.Toml_string value) -> Some value
+          | _ -> None)
+     | _ -> fail "expected Toml_inline_table")
+  | Error e -> fail e
+
+let test_parse_datetime_values () =
+  let input = "offset = 1979-05-27T07:32:00Z\ndate = 1979-05-27" in
+  match TL.parse_toml input with
+  | Ok doc ->
+    (match List.assoc_opt "offset" doc with
+     | Some (TL.Toml_offset_datetime value) ->
+       check string "offset datetime" "1979-05-27T07:32:00Z" value
+     | _ -> fail "expected Toml_offset_datetime");
+    (match List.assoc_opt "date" doc with
+     | Some (TL.Toml_local_date value) -> check string "local date" "1979-05-27" value
+     | _ -> fail "expected Toml_local_date")
+  | Error e -> fail e
+
+let test_parse_table_array () =
+  let input = "[[products]]\nname = \"hammer\"\n[[products]]\nname = \"nail\"" in
+  match TL.parse_toml input with
+  | Ok doc ->
+    (match List.assoc_opt "products" doc with
+     | Some (TL.Toml_table_array [ TL.Toml_table first; TL.Toml_table second ]) ->
+       check bool "first table" true
+         (List.mem ("name", TL.Toml_string "hammer") first);
+       check bool "second table" true
+         (List.mem ("name", TL.Toml_string "nail") second)
+     | _ -> fail "expected Toml_table_array")
   | Error e -> fail e
 
 let test_parse_table () =
@@ -526,6 +606,24 @@ max_context_override = 128001
         d.active_goal_ids;
       check (option int) "max_context_override" (Some 128_001)
         d.max_context_override
+
+let test_profile_rejects_wrong_known_field_shape () =
+  let input =
+    {|
+[keeper]
+autoboot_enabled = [true, false]
+|}
+  in
+  match TL.parse_toml input with
+  | Error error -> fail error
+  | Ok doc ->
+    (match KTP.profile_defaults_of_toml doc with
+     | Ok _ -> fail "known scalar field must not silently use its default"
+     | Error message ->
+       check bool "names field" true
+         (contains_substring message "keeper.autoboot_enabled");
+       check bool "names expected type" true
+         (contains_substring message "boolean"))
 
 let test_profile_rejects_invalid_max_context_override () =
   let input =
@@ -901,7 +999,7 @@ let test_typed_keeper_toml_edits_preserve_unrelated_fields () =
 # operator comment
 [keeper]
 instructions = "keep me"
-proactive_enabled	= true
+"proactive_enabled"	= true
 max_context_override	= 200000
 
 [keeper.oas_env]
@@ -939,6 +1037,24 @@ OAS_OPENAI_BASE_URL = "http://127.0.0.1:1"
     check (option string) "unrelated table survives"
       (Some "http://127.0.0.1:1")
       (TL.toml_string_opt doc "keeper.oas_env.OAS_OPENAI_BASE_URL")
+
+let test_keeper_toml_writer_rejects_table_assignment_shapes () =
+  with_temp_dir "keeper-toml-invalid-writer-shape" @@ fun dir ->
+  let shapes =
+    [ "table", TL.Toml_table [ "nested", TL.Toml_string "value" ]
+    ; "table array", TL.Toml_table_array []
+    ]
+  in
+  List.iter
+    (fun (label, value) ->
+      let path = Filename.concat dir (String.map (function ' ' -> '-' | c -> c) label ^ ".toml") in
+      match TL.create_keeper_toml_file ~path [ "invalid", value ] with
+      | Ok () -> failf "%s must not be rendered as a key assignment" label
+      | Error message ->
+        check bool (label ^ " error is explicit") true
+          (contains_substring message "cannot be rendered");
+        check bool (label ^ " file is not created") false (Sys.file_exists path))
+    shapes
 
 let with_profile_base f =
   with_env_restore [ "MASC_CONFIG_DIR"; "MASC_PERSONAS_DIR" ] @@ fun () ->
@@ -1929,6 +2045,11 @@ let () =
           test_case "comments and blanks" `Quick test_parse_comments_and_blanks;
           test_case "string value" `Quick test_parse_string_value;
           test_case "string escapes" `Quick test_parse_string_escapes;
+          test_case "literal string" `Quick test_parse_literal_string;
+          test_case "unicode and control escapes" `Quick
+            test_parse_unicode_and_control_escapes;
+          test_case "quoted and dotted keys do not collide" `Quick
+            test_parse_quoted_and_dotted_keys_do_not_collide;
           test_case "int value" `Quick test_parse_int_value;
           test_case "negative int" `Quick test_parse_negative_int;
           test_case "float value" `Quick test_parse_float_value;
@@ -1937,6 +2058,10 @@ let () =
           test_case "string array escaped quotes" `Quick
             test_parse_string_array_escaped_quotes;
           test_case "empty array" `Quick test_parse_empty_array;
+          test_case "general array" `Quick test_parse_general_array;
+          test_case "inline table" `Quick test_parse_inline_table;
+          test_case "datetime values" `Quick test_parse_datetime_values;
+          test_case "table array" `Quick test_parse_table_array;
           test_case "table" `Quick test_parse_table;
           test_case "inline comment" `Quick test_parse_inline_comment;
           test_case "multiline basic string" `Quick test_parse_multiline_basic_string;
@@ -1984,6 +2109,8 @@ let () =
           test_case "rejects legacy keeper.goal" `Quick
             test_profile_rejects_legacy_goal;
           test_case "full" `Quick test_profile_full;
+          test_case "rejects wrong known-field shape" `Quick
+            test_profile_rejects_wrong_known_field_shape;
           test_case "rejects invalid max_context_override" `Quick
             test_profile_rejects_invalid_max_context_override;
           test_case "parses multimodal_policy" `Quick
@@ -2011,6 +2138,8 @@ let () =
         [
           test_case "typed edits preserve unrelated fields" `Quick
             test_typed_keeper_toml_edits_preserve_unrelated_fields;
+          test_case "rejects table assignment shapes" `Quick
+            test_keeper_toml_writer_rejects_table_assignment_shapes;
         ] );
       ( "unknown_keys",
         [

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1056,6 +1056,86 @@ let test_keeper_toml_writer_rejects_table_assignment_shapes () =
         check bool (label ^ " file is not created") false (Sys.file_exists path))
     shapes
 
+let test_keeper_toml_writer_round_trips_control_escapes () =
+  with_temp_dir "keeper-toml-control-escapes" @@ fun dir ->
+  let path = Filename.concat dir "control.toml" in
+  write_file path "[keeper]\ninstructions = \"old\"\n";
+  let value =
+    "before"
+    ^ String.make 1 (Char.chr 8)
+    ^ String.make 1 (Char.chr 12)
+    ^ "after"
+  in
+  (match
+     TL.edit_keeper_toml_fields
+       ~path
+       [ "instructions", TL.Set (TL.Toml_string value) ]
+   with
+   | Error error -> fail error
+   | Ok () -> ());
+  match Safe_ops.read_file_safe path with
+  | Error error -> fail error
+  | Ok content ->
+    (match TL.parse_toml content with
+     | Error error -> fail ("writer emitted invalid TOML: " ^ error)
+     | Ok doc ->
+       check (option string) "control escapes survive writer round-trip"
+         (Some value)
+         (TL.toml_string_opt doc "keeper.instructions"))
+
+let test_keeper_toml_writer_edits_multiline_assignments () =
+  with_temp_dir "keeper-toml-multiline-edits" @@ fun dir ->
+  let fixture () =
+    "[keeper]\n"
+    ^ "instructions = \"\"\"\n"
+    ^ "line one\n"
+    ^ "line two\n"
+    ^ "\"\"\"\n"
+    ^ "allowed_paths = [\n"
+    ^ "  \"/tmp/old-a\",\n"
+    ^ "  \"/tmp/old-b\",\n"
+    ^ "]\n"
+  in
+  let update_path = Filename.concat dir "update.toml" in
+  write_file update_path (fixture ());
+  (match
+     TL.edit_keeper_toml_fields
+       ~path:update_path
+       [ "instructions", TL.Set (TL.Toml_string "updated\ninstructions")
+       ; "allowed_paths", TL.Set (TL.Toml_string_array [ "/tmp/new-a" ])
+       ]
+   with
+   | Error error -> fail error
+   | Ok () -> ());
+  (match Safe_ops.read_file_safe update_path with
+   | Error error -> fail error
+   | Ok content ->
+     match TL.parse_toml content with
+     | Error error -> fail ("multiline update emitted invalid TOML: " ^ error)
+     | Ok doc ->
+       check (option string) "multiline string replaced"
+         (Some "updated\ninstructions")
+         (TL.toml_string_opt doc "keeper.instructions");
+       check (list string) "multiline array replaced" [ "/tmp/new-a" ]
+         (TL.toml_string_list doc "keeper.allowed_paths"));
+  let remove_path = Filename.concat dir "remove.toml" in
+  write_file remove_path (fixture ());
+  (match
+     TL.edit_keeper_toml_fields
+       ~path:remove_path
+       [ "instructions", TL.Remove ]
+   with
+   | Error error -> fail error
+   | Ok () -> ());
+  match Safe_ops.read_file_safe remove_path with
+  | Error error -> fail error
+  | Ok content ->
+    (match TL.parse_toml content with
+     | Error error -> fail ("multiline removal emitted invalid TOML: " ^ error)
+     | Ok doc ->
+       check (option string) "multiline string removed" None
+         (TL.toml_string_opt doc "keeper.instructions"))
+
 let with_profile_base f =
   with_env_restore [ "MASC_CONFIG_DIR"; "MASC_PERSONAS_DIR" ] @@ fun () ->
   Unix.putenv "MASC_CONFIG_DIR" "";
@@ -2140,6 +2220,10 @@ let () =
             test_typed_keeper_toml_edits_preserve_unrelated_fields;
           test_case "rejects table assignment shapes" `Quick
             test_keeper_toml_writer_rejects_table_assignment_shapes;
+          test_case "round-trips control escapes" `Quick
+            test_keeper_toml_writer_round_trips_control_escapes;
+          test_case "edits multiline assignments" `Quick
+            test_keeper_toml_writer_edits_multiline_assignments;
         ] );
       ( "unknown_keys",
         [


### PR DESCRIPTION
## Summary

- replace the hand-written Keeper TOML semantic parser with Otoml
- preserve the existing flattened canonical key projection and comment-preserving writer boundary
- represent arrays, inline tables, table arrays, and TOML date/time values explicitly; typed consumers reject unsupported shapes
- cover quoted/dotted keys, literal and multiline strings, Unicode/control escapes, mixed arrays, datetimes, table arrays, and CRLF normalization

## Verification

- `scripts/dune-local.sh build test/test_keeper_toml.exe test/test_keeper_toml_parser.exe test/test_keeper_toml_loader.exe test/test_keeper_runtime_config_leaf.exe`
- `test_keeper_toml.exe`: 104/104
- parser/loader/runtime leaf suites: 6/6
- `scripts/check-variants.sh`
- `scripts/ci/check-determinism-contract.sh`
- `git diff --check`

Closes #26563