### PR TITLE
dashboard: render complete keeper lane inventory

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-lane-strip.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-lane-strip.test.ts
@@ -161,7 +161,7 @@ describe('KeeperLaneStrip', () => {
     expect(text).toContain('≥69')
     // the bare integer would assert a total the server never computed
     expect(text).not.toMatch(/레인\s*69(?!\d)/)
-    expect(el.querySelectorAll('[data-testid="keeper-lane-section"] .border-t').length).toBe(69)
+    expect(el.querySelectorAll('[data-testid="keeper-lane-waiting-row"]').length).toBe(69)
   })
 
   it('attributes the truncation to the capped source and the server limit', () => {

--- a/dashboard/src/components/keeper-workspace/keeper-lane-strip.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-lane-strip.test.ts
@@ -161,8 +161,7 @@ describe('KeeperLaneStrip', () => {
     expect(text).toContain('≥69')
     // the bare integer would assert a total the server never computed
     expect(text).not.toMatch(/레인\s*69(?!\d)/)
-    expect(el.querySelector('[data-testid="keeper-lane-more"]')?.textContent ?? '')
-      .toContain('of at least 69')
+    expect(el.querySelectorAll('[data-testid="keeper-lane-section"] .border-t').length).toBe(69)
   })
 
   it('attributes the truncation to the capped source and the server limit', () => {

--- a/dashboard/src/components/keeper-workspace/keeper-lane-strip.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-lane-strip.ts
@@ -100,7 +100,7 @@ function truncatedSourceLabels(entry: DashboardKeeperWaitingKeeper): string[] {
 
 function LaneWaitingRow({ row }: { row: DashboardKeeperWaitingRow }): VNode {
   return html`
-    <div class="grid gap-0.5 border-t border-[var(--color-border-subtle)] py-1.5 first:border-t-0">
+    <div data-testid="keeper-lane-waiting-row" class="grid gap-0.5 border-t border-[var(--color-border-subtle)] py-1.5 first:border-t-0">
       <div class="flex min-w-0 flex-wrap items-center gap-1.5">
         <${StatusChip} tone=${sourceTone(row.source)} uppercase=${false}>${enumLabel(row.source)}<//>
         <span class="min-w-0 truncate font-mono text-2xs text-[var(--color-fg-primary)]">${row.waiting_on}</span>
@@ -162,7 +162,7 @@ export function KeeperLaneStrip({
               </div>
               ${rows.length > 0
                 ? html`
-                    <div>
+                    <div class="max-h-60 overflow-y-auto">
                       ${rows.map((row, index) => html`
                         <${LaneWaitingRow} key=${`${row.source}:${row.waiting_on}:${index}`} row=${row} />
                       `)}

--- a/dashboard/src/components/keeper-workspace/keeper-lane-strip.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-lane-strip.ts
@@ -39,8 +39,6 @@ import {
 import { formatDateTimeKo } from '../../lib/format-time'
 import { CountBadge } from '../v2/primitives-v2'
 
-const LANE_ROW_LIMIT = 3
-
 // The strip mirrors a heavy server-side aggregation (per-keeper event-queue,
 // turn-admission, external-attention, HITL, schedule scans). It is refreshed
 // by polling — not server push — while the keeper detail is open, so a busy
@@ -137,7 +135,7 @@ export function KeeperLaneStrip({
   autoRefreshMs?: number
 }): VNode {
   const entry = inventoryEntry(inventory, keeper)
-  const rows = (entry?.waiting_on ?? []).slice(0, LANE_ROW_LIMIT)
+  const rows = entry?.waiting_on ?? []
   const waitingCount = entry?.waiting_count ?? 0
   const countTruncated = entry?.waiting_count_truncated === true
   const truncatedSources = entry ? truncatedSourceLabels(entry) : []
@@ -168,11 +166,6 @@ export function KeeperLaneStrip({
                       ${rows.map((row, index) => html`
                         <${LaneWaitingRow} key=${`${row.source}:${row.waiting_on}:${index}`} row=${row} />
                       `)}
-                      ${waitingCount > rows.length
-                        ? html`<div class="pt-1 text-2xs text-[var(--color-fg-muted)]" data-testid="keeper-lane-more">
-                            +${waitingCount - rows.length} more${countTruncated ? ` of at least ${waitingCount}` : ''}
-                          </div>`
-                        : null}
                     </div>
                   `
                 : null}


### PR DESCRIPTION
## Summary

- remove the client-side three-row Keeper lane cap
- render every waiting row sent by the server
- retain server-owned truncation and lower-bound messaging

## Validation

- TypeScript check with the repository dashboard toolchain
- focused Keeper lane Vitest: 11 tests
- Vite production build
