### PR TITLE
chore(oas): promote the pin to the v0.231.11 release tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MASC
 
 [![OCaml](https://img.shields.io/badge/OCaml-%3E%3D%205.4-orange.svg)](https://ocaml.org/)
-[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.231.10-blue.svg)](https://github.com/jeong-sik/oas)
+[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.231.11-blue.svg)](https://github.com/jeong-sik/oas)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 [한국어 버전](README.ko.md)

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -34,7 +34,7 @@ Keeper는 OAS(OCaml Agent SDK) 위에 구축된다. OAS가 제공하는 핵심 �
 | `Event_bus.t` | 에이전트 간 이벤트 발행/구독 | `oas_events.ml`을 통해 broadcast, heartbeat, board 이벤트 전달 |
 
 <!-- BEGIN GENERATED: oas-pin-manual -->
-OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.10`, runtime pin: `main@92e3eea36585b043119d9e79276dbf8a8a9e356f`, declared base version: `v0.231.10`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
+OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.11`, runtime pin: `main@6ab2e84e1d3a7728e0cac0e727f2d4872cd3f99e`, declared base version: `v0.231.11`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
 <!-- END GENERATED: oas-pin-manual -->
 
 #### 1.1.1 OAS 환경 변수 경계

--- a/dune-project
+++ b/dune-project
@@ -60,7 +60,7 @@
   ;; ordered multimodal delivery contracts;
   ;; its SHA and rationale live in scripts/oas-agent-sdk-pin.sh (SSOT).
   ;; See check-oas-pin.sh.
-  (agent_sdk (>= 0.231.10))
+  (agent_sdk (>= 0.231.11))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc.opam
+++ b/masc.opam
@@ -31,7 +31,7 @@ depends: [
   "cohttp-eio" {>= "6.0"}
   "piaf" {= "0.2.0"}
   "eio-ssl" {>= "0.3.0"}
-  "agent_sdk" {>= "0.231.10"}
+  "agent_sdk" {>= "0.231.11"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -11,7 +11,7 @@ homepage: "https://github.com/jeong-sik/masc"
 doc: "https://github.com/jeong-sik/masc"
 bug-reports: "https://github.com/jeong-sik/masc/issues"
 depends: [
-  "agent_sdk" {= "0.231.10"}
+  "agent_sdk" {= "0.231.11"}
   "alcotest" {= "1.9.1" & with-test}
   "ambient-context" {= "0.2"}
   "ambient-context-eio" {= "0.2"}
@@ -218,8 +218,8 @@ build: [
 dev-repo: "git+https://github.com/jeong-sik/masc.git"
 pin-depends: [
   [
-  "agent_sdk.0.231.10"
-  "git+https://github.com/jeong-sik/oas.git#92e3eea36585b043119d9e79276dbf8a8a9e356f"
+  "agent_sdk.0.231.11"
+  "git+https://github.com/jeong-sik/oas.git#6ab2e84e1d3a7728e0cac0e727f2d4872cd3f99e"
 ]
   [
     "bisect_ppx.2.8.3"

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.10"
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.11"
 # v0.231.0 is a hard-cut wave: checkpoint schema is v9 only (v1-v8
 # rejected; #2867), provider_config.output_schema is removed in favor of
 # response_format = JsonSchema as the single structured-output request state
@@ -58,12 +58,17 @@ readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.10"
 # execution contract; durable Memory OS consumption is a separate caller
 # change, with no compatibility decoder or migration path added by this pin.
 # Previous pin: v0.231.6 (ae4cc5536).
-readonly OAS_AGENT_SDK_DECLARED_VERSION="0.231.10"
-# Paired malformed-SSE boundary hardening: OAS preserves accepted-response
-# wire failures and provider-owned error envelopes as typed public facts.
-# Keep this SHA aligned with the OAS change before CI builds MASC.
+# v0.231.11 promotes the prior main-head pin (92e3eea36, the #2910
+# streaming-boundary hard-cut this repo already consumes) to a cut release,
+# and adds #2915: the SSE first-event deadline now holds until data actually
+# arrives instead of being cleared by connection acceptance. Release note gap:
+# the upstream CHANGELOG lists only #2915 because #2910's squash title was
+# non-conventional (oas#2922 tracks enforcing titles); the tag contains both.
+# Previous pin: main@92e3eea36 (post-v0.231.10); before that v0.231.10
+# (1fa612519).
+readonly OAS_AGENT_SDK_DECLARED_VERSION="0.231.11"
 # TRACK_REF consumed by check-oas-pin.sh / oas-drift-check.sh /
 # sync-oas-pin-docs.sh; removed by #25579 and restored here (#25584).
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="92e3eea36585b043119d9e79276dbf8a8a9e356f"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.231.10"
+readonly OAS_AGENT_SDK_SHA="6ab2e84e1d3a7728e0cac0e727f2d4872cd3f99e"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.231.11"

--- a/scripts/oas-api-surface.json
+++ b/scripts/oas-api-surface.json
@@ -1,6 +1,6 @@
 {
-  "pinned_sha": "92e3eea36585b043119d9e79276dbf8a8a9e356f",
-  "pinned_version": "v0.231.10",
+  "pinned_sha": "6ab2e84e1d3a7728e0cac0e727f2d4872cd3f99e",
+  "pinned_version": "v0.231.11",
   "surfaces": {
     "event_bus_payload_variants": [
       "AgentCompleted",


### PR DESCRIPTION
## OAS pin을 v0.231.11 릴리즈 태그로 승격 (+21/−16, 7파일)

upstream이 v0.231.11을 잘랐으므로(oas #2920, 태그 `6ab2e84e1d3a…`), #26550이 실었던 post-v0.231.10 main-head pin(`92e3eea36`)을 정식 릴리즈 태그 기반으로 승격한다.

### 델타

- 이미 소비 중인 #2910(streaming-boundary hard-cut) 위에 **#2915 하나**: SSE first-event deadline이 연결 수락이 아니라 실제 데이터 도착까지 유지된다. public surface 변경 없음 — exhaustive match 영향 0.
- pin SSOT(`scripts/oas-agent-sdk-pin.sh`): SHA→태그 커밋, BASE/DECLARED/MIN → 0.231.11, 서사 주석 추가. 나머지 6파일은 전부 `sync-oas-pin-manifests.sh --surface` 생성물(README 배지·매뉴얼 생성 블록·dune-project·opam floor·locked pin-depends·surface 지문).

### 릴리즈 노트 갭 (기록)

upstream CHANGELOG에는 #2915만 보인다 — #2910의 squash 제목이 non-conventional이라 release-please가 누락했다(제목 강제는 oas#2922로 추적). 태그에는 두 변경 모두 포함된다.

### 검증 (로컬)

- `opam install agent_sdk` → 0.231.10 제거, **0.231.11 설치** (태그의 opam 버전으로 인식)
- `dune build @check` — 새 SDK 기준 타입체크 green (`BUILD_RC=0`)
- `scripts/check-oas-pin.sh` — manifests match + pin reachable from upstream main + API surface fingerprint 일치, 전부 PASS

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
