### PR TITLE
refactor(ids): centralize UUIDv7 and random identifiers

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -106,7 +106,7 @@
   (qcheck-alcotest (and :with-test (>= 0.21)))
   (bisect_ppx (and :with-test (>= 2.8)))
   (mtime (>= 2.0))
-  (uuidm (>= 0.9))
+  (uuidm (>= 0.9.10))
   ; RFC-0004 Phase A0.1 typed SSE event library (lib/sse_event/).
   ; atdgen runs at build-time (codegen for sse_event.atd →
   ; sse_event_{t,j}.{ml,mli}); atdgen-runtime is linked into the

--- a/lib/auth/auth_credential_base.ml
+++ b/lib/auth/auth_credential_base.ml
@@ -8,10 +8,7 @@ open Masc_domain
 
 (** Generate a cryptographically random token (hex string) *)
 let generate_token () =
-  let random_bytes = Crypto_rng.generate 32 in
-  let hex = Buffer.create 64 in
-  String.iter (fun c -> Printf.bprintf hex "%02x" (Char.code c)) random_bytes;
-  Buffer.contents hex
+  Random_id.hex ~bytes:32
 ;;
 
 (** SHA256 hash of a string using Digestif *)

--- a/lib/auth/dune
+++ b/lib/auth/dune
@@ -13,7 +13,7 @@
   masc.masc_types
   masc.config
   masc.config_dir_resolver
-  masc.crypto_rng
+  masc_random_id
   eio
   digestif
   eqaf

--- a/lib/client_identity.ml
+++ b/lib/client_identity.ml
@@ -28,19 +28,7 @@ module Random = Stdlib.Random
     @since 0.5.0
 *)
 
-(* UUID / random generation.  [Random.State.t] is NOT fiber-safe —
-   concurrent [Random.State.int] or [Uuidm.v4_gen] calls against a
-   shared state can produce duplicate values or corrupt internal
-   state.  The previous doc comment claiming "Fiber-safe" was
-   incorrect.  Guard the shared state with an [Eio.Mutex] and route
-   every RNG access through [with_identity_rng]. *)
-
 module StringMap = Set_util.StringMap
-
-let identity_rng = Random.State.make_self_init ()
-let identity_rng_mutex = Eio.Mutex.create ()
-let with_identity_rng f =
-  Eio.Mutex.use_ro identity_rng_mutex (fun () -> f identity_rng)
 
 (** Typed classification of a session_key's display prefix.
 
@@ -158,7 +146,7 @@ type agent_name_origin =
 
 (** Agent identity - extracted from session/request context *)
 type t = {
-  uuid : string;                  (** Permanent unique identifier (UUIDv4 or hash) *)
+  uuid : string;                  (** Permanent UUIDv7 identifier *)
   session_key : string;           (** Unique session identifier *)
   agent_name : string;            (** Display name (e.g., "claude-agent-001") *)
   agent_name_origin : agent_name_origin;
@@ -172,21 +160,16 @@ type t = {
 }
 [@@deriving to_yojson]
 
-(** Generate a unique agent UUID from name + timestamp hash *)
-let generate_uuid ~agent_name =
-  let timestamp = Time_compat.now () in
-  let random_part = with_identity_rng (fun rng -> Random.State.int rng 0xFFFFFF) in
-  let input = Printf.sprintf "%s-%f-%d" agent_name timestamp random_part in
-  (* Simple hash-based UUID: first 8 chars of hex digest *)
-  let hash = Stdlib.Digest.string input |> Stdlib.Digest.to_hex in
-  Printf.sprintf "agent-%s" (String.sub hash 0 12)
+(** Generate a permanent UUID. [agent_name] is intentionally not encoded in
+    the identifier; it remains display metadata. *)
+let generate_uuid ~agent_name:_ =
+  Random_id.uuid_v7 ()
 
 (** {1 Identity Creation} *)
 
 (** Generate a unique session key *)
 let generate_session_key () =
-  let uuid = with_identity_rng (fun rng -> Uuidm.v4_gen rng ()) in
-  Uuidm.to_string uuid
+  Random_id.hex ~bytes:16
 
 (** Create identity from MCP request params *)
 let from_mcp_params params =

--- a/lib/client_identity.mli
+++ b/lib/client_identity.mli
@@ -60,7 +60,12 @@ val string_of_channel : channel -> string
 (** {1 Identity Creation} *)
 
 val generate_uuid : agent_name:string -> string
+(** Generate a canonical UUIDv7. [agent_name] remains display metadata and is
+    not encoded in the identifier. Existing persisted identifiers stay
+    readable because registry records treat this field as opaque text. *)
 val generate_session_key : unit -> string
+(** Generate a 32-character cryptographically random hex key. Its random
+    prefix remains suitable for fallback display-name derivation. *)
 val from_mcp_params : Yojson.Safe.t -> t
 val anonymous : unit -> t
 

--- a/lib/multimodal/dune
+++ b/lib/multimodal/dune
@@ -6,6 +6,6 @@
  ; RFC-0071 Phase 5 ratchet (warning 4)
  (flags
   (:standard -w +4))
- (libraries shared_types unix yojson fs_compat digestif eio)
+ (libraries shared_types unix yojson fs_compat digestif eio masc_random_id)
  (preprocess
   (pps ppx_tla)))

--- a/lib/multimodal/workspace_id.ml
+++ b/lib/multimodal/workspace_id.ml
@@ -9,88 +9,7 @@ type t = string
 
 let max_length = 64
 
-let is_hex c =
-  (c >= '0' && c <= '9')
-  || (c >= 'a' && c <= 'f')
-  || (c >= 'A' && c <= 'F')
-
-(* UUID v7 generator — same construction as Artifact_id; duplicated
-   rather than re-exported to keep module dependencies minimal and
-   to allow future migration (ULID, prefixed form) without touching
-   Shared_types. *)
-
-let initialized = ref false
-
-let init_random () =
-  if not !initialized then begin
-    Random.self_init ();
-    initialized := true
-  end
-
-let hex_byte n = Printf.sprintf "%02x" (n land 0xFF)
-
-let generate () =
-  init_random ();
-  let now_ms = Int64.of_float (Unix.gettimeofday () *. 1000.0) in
-  let ts48 = Int64.logand now_ms 0xFFFFFFFFFFFFL in
-  let byte_at shift =
-    Int64.to_int (Int64.shift_right_logical ts48 shift) land 0xFF
-  in
-  let b0 = byte_at 40 in
-  let b1 = byte_at 32 in
-  let b2 = byte_at 24 in
-  let b3 = byte_at 16 in
-  let b4 = byte_at 8 in
-  let b5 = byte_at 0 in
-  let rand_12 = Random.int 0x1000 in
-  let b6 = 0x70 lor ((rand_12 lsr 8) land 0x0F) in
-  let b7 = rand_12 land 0xFF in
-  let rand_14 = Random.int 0x4000 in
-  let b8 = 0x80 lor ((rand_14 lsr 8) land 0x3F) in
-  let b9 = rand_14 land 0xFF in
-  let r1 = Random.int 0x1000000 in
-  let r2 = Random.int 0x1000000 in
-  let b10 = (r1 lsr 16) land 0xFF in
-  let b11 = (r1 lsr 8) land 0xFF in
-  let b12 = r1 land 0xFF in
-  let b13 = (r2 lsr 16) land 0xFF in
-  let b14 = (r2 lsr 8) land 0xFF in
-  let b15 = r2 land 0xFF in
-  Printf.sprintf "%s%s%s%s-%s%s-%s%s-%s%s-%s%s%s%s%s%s"
-    (hex_byte b0) (hex_byte b1) (hex_byte b2) (hex_byte b3)
-    (hex_byte b4) (hex_byte b5)
-    (hex_byte b6) (hex_byte b7)
-    (hex_byte b8) (hex_byte b9)
-    (hex_byte b10) (hex_byte b11) (hex_byte b12)
-    (hex_byte b13) (hex_byte b14) (hex_byte b15)
-
-let validate_uuid_v7_shape s =
-  if String.length s <> 36 then
-    Error
-      (Printf.sprintf
-         "Workspace_id.of_string: expected 36-char UUID, got %d"
-         (String.length s))
-  else if s.[8] <> '-' || s.[13] <> '-' || s.[18] <> '-' || s.[23] <> '-'
-  then Error "Workspace_id.of_string: missing dashes at expected positions"
-  else if s.[14] <> '7' then
-    Error
-      (Printf.sprintf
-         "Workspace_id.of_string: expected UUID version '7', got %c"
-         s.[14])
-  else
-    let v = Char.lowercase_ascii s.[19] in
-    if v <> '8' && v <> '9' && v <> 'a' && v <> 'b' then
-      Error
-        (Printf.sprintf
-           "Workspace_id.of_string: invalid variant nibble %c" v)
-    else
-      let valid = ref true in
-      for i = 0 to 35 do
-        if i <> 8 && i <> 13 && i <> 18 && i <> 23 && not (is_hex s.[i])
-        then valid := false
-      done;
-      if !valid then Ok ()
-      else Error "Workspace_id.of_string: non-hex character in body"
+let generate = Random_id.uuid_v7
 
 let of_string s =
   if s = "" then Error "Workspace_id.of_string: empty string"
@@ -100,9 +19,8 @@ let of_string s =
          "Workspace_id.of_string: length %d exceeds max %d"
          (String.length s) max_length)
   else
-    match validate_uuid_v7_shape s with
-    | Ok () -> Ok (String.lowercase_ascii s)
-    | Error _ as e -> e
+    Random_id.parse_uuid_v7 s
+    |> Result.map_error (fun error -> "Workspace_id.of_string: " ^ error)
 
 let to_string t = t
 

--- a/lib/multimodal/workspace_id.mli
+++ b/lib/multimodal/workspace_id.mli
@@ -32,8 +32,7 @@
 
     {!compare} and {!equal} delegate to the underlying string. Two
     {!t} values produced by independent {!generate} calls are
-    statistically guaranteed to differ (122-bit randomness in the
-    UUID v7 tail).
+    differ. UUIDv7 has 74 random/counter bits after its timestamp.
 
     @stability Evolving
     @since 0.18.11 *)
@@ -42,8 +41,9 @@ type t = private string
 (** Private string. The only constructors are {!generate} and {!of_string}. *)
 
 val generate : unit -> t
-(** Generate a fresh workspace id (UUID v7). Side-effecting: reads
-    the current wall-clock time and the OCaml [Random] state. *)
+(** Generate a fresh workspace id through the shared Uuidm-backed UUIDv7
+    generator. Calls in one process are monotonic within the same
+    millisecond. *)
 
 val of_string : string -> (t, string) result
 (** Parse and validate a workspace id string.
@@ -51,9 +51,7 @@ val of_string : string -> (t, string) result
     Validation:
     - non-empty (rejects [""]),
     - length ≤ 64 (defensive ceiling, see module preamble),
-    - structurally a UUID v7 — dashes at positions 8/13/18/23,
-      version digit ['7'] at index 14, variant nibble in
-      [\{8,9,a,b\}] at index 19, hex elsewhere.
+    - a complete RFC 9562 UUID with version 7 and the RFC variant.
 
     The output is normalised to lowercase. *)
 

--- a/lib/random_id/dune
+++ b/lib/random_id/dune
@@ -8,4 +8,4 @@
  ; RFC-0071 §3.4 Phase 5 ratchet: warning 4 enabled. Leaf util sublib.
  (flags
   (:standard -w +4))
- (libraries masc.crypto_rng))
+ (libraries masc.crypto_rng threads unix uuidm))

--- a/lib/random_id/random_id.ml
+++ b/lib/random_id/random_id.ml
@@ -21,3 +21,71 @@ let hex ~bytes =
 
 let prefixed ~prefix ~bytes =
   prefix ^ hex ~bytes
+
+(* NDT-OK: UUIDv7 minting is an explicit nondeterministic boundary.  The wall
+   clock supplies the RFC timestamp while the process-seeded PRNG supplies the
+   opaque random/counter tail; consumers never branch on that tail. *)
+type logical_ms_clock = {
+  now_ms : unit -> int64;
+  advance : unit -> unit;
+}
+
+let logical_ms_clock raw_now_ms =
+  let last_ms = ref Int64.min_int in
+  let now_ms () =
+    let observed_ms = raw_now_ms () in
+    let current_ms = Int64.max observed_ms !last_ms in
+    last_ms := current_ms;
+    current_ms
+  in
+  let advance () =
+    if Int64.equal !last_ms Int64.max_int
+    then invalid_arg "UUIDv7 logical millisecond clock exhausted"
+    else last_ms := Int64.succ !last_ms
+  in
+  { now_ms; advance }
+
+let uuid_v7_clock =
+  logical_ms_clock (fun () ->
+    (* NDT-OK: UUIDv7 timestamp source at the identifier-minting boundary. *)
+    Int64.of_float (Unix.gettimeofday () *. 1000.0))
+
+let uuid_v7_generator =
+  Uuidm.v7_monotonic_gen
+    ~now_ms:uuid_v7_clock.now_ms
+    (* NDT-OK: process-seeded entropy for the UUIDv7 opaque tail. *)
+    (Random.State.make_self_init ())
+
+let uuid_v7_mutex = Mutex.create ()
+
+let rec generate_uuid_v7_locked () =
+  match uuid_v7_generator () with
+  | Some uuid -> Uuidm.to_string uuid
+  | None ->
+    (* RFC 9562 permits advancing the logical timestamp after exhausting the
+       12-bit monotonic counter. This also prevents a backwards wall-clock
+       adjustment from blocking ID minting until real time catches up. *)
+    uuid_v7_clock.advance ();
+    generate_uuid_v7_locked ()
+
+let uuid_v7 () =
+  Mutex.protect uuid_v7_mutex generate_uuid_v7_locked
+
+let parse_uuid_v7 value =
+  if String.length value <> 36
+  then Error (Printf.sprintf "expected 36 characters, got %d" (String.length value))
+  else
+    match Uuidm.of_string value with
+    | Some uuid when Uuidm.version uuid = 7 && Uuidm.variant uuid >= 8
+                     && Uuidm.variant uuid <= 11 ->
+      Ok (Uuidm.to_string uuid)
+    | Some uuid when Uuidm.version uuid <> 7 ->
+      Error (Printf.sprintf "expected UUID version 7, got %d" (Uuidm.version uuid))
+    | Some uuid -> Error (Printf.sprintf "invalid UUID variant %d" (Uuidm.variant uuid))
+    | None -> Error "invalid UUID syntax"
+
+module For_testing = struct
+  let logical_ms_clock raw_now_ms =
+    let clock = logical_ms_clock raw_now_ms in
+    clock.now_ms, clock.advance
+end

--- a/lib/random_id/random_id.mli
+++ b/lib/random_id/random_id.mli
@@ -19,3 +19,16 @@ val hex : bytes:int -> string
 val prefixed : prefix:string -> bytes:int -> string
 (** [prefixed ~prefix ~bytes:n] is [prefix ^ hex ~bytes:n].
     Convenience for the common ["kind-" ^ hex] shape. *)
+
+val uuid_v7 : unit -> string
+(** [uuid_v7 ()] returns a canonical lowercase UUIDv7. Calls serialized in
+    one process are monotonic within the same millisecond. This is an opaque
+    correlation identifier, not an authentication secret. *)
+
+val parse_uuid_v7 : string -> (string, string) result
+(** [parse_uuid_v7 value] validates the complete canonical UUID shape,
+    RFC 9562 variant, and version 7, then returns lowercase canonical text. *)
+
+module For_testing : sig
+  val logical_ms_clock : (unit -> int64) -> (unit -> int64) * (unit -> unit)
+end

--- a/lib/session.ml
+++ b/lib/session.ml
@@ -577,22 +577,12 @@ module McpSessionStore = struct
   let process_msg state msg =
     match msg with
     | Generate_id p ->
-        let bytes = Crypto_rng.generate 16 in
-        let buf = Buffer.create 32 in
-        for i = 0 to String.length bytes - 1 do
-          Printf.bprintf buf "%02x" (Char.code (String.get bytes i))
-        done;
-        let id = Printf.sprintf "mcp_%s" (Buffer.contents buf) in
+        let id = Random_id.prefixed ~prefix:"mcp_" ~bytes:16 in
         Eio.Promise.resolve p id;
         state
 
     | Create (agent_name, now, p) ->
-        let bytes = Crypto_rng.generate 16 in
-        let buf = Buffer.create 32 in
-        for i = 0 to String.length bytes - 1 do
-          Printf.bprintf buf "%02x" (Char.code (String.get bytes i))
-        done;
-        let id = Printf.sprintf "mcp_%s" (Buffer.contents buf) in
+        let id = Random_id.prefixed ~prefix:"mcp_" ~bytes:16 in
         let session = {
           id;
           created_at = now;

--- a/lib/shared_types/artifact_id.ml
+++ b/lib/shared_types/artifact_id.ml
@@ -1,77 +1,10 @@
 type t = string
 
-let initialized = ref false
-
-let init_random () =
-  if not !initialized then begin
-    Random.self_init ();
-    initialized := true
-  end
-
-let hex_byte n = Printf.sprintf "%02x" (n land 0xFF)
-
-let generate () =
-  init_random ();
-  let now_ms = Int64.of_float (Unix.gettimeofday () *. 1000.0) in
-  let ts48 = Int64.logand now_ms 0xFFFFFFFFFFFFL in
-  let byte_at shift =
-    Int64.to_int (Int64.shift_right_logical ts48 shift) land 0xFF
-  in
-  let b0 = byte_at 40 in
-  let b1 = byte_at 32 in
-  let b2 = byte_at 24 in
-  let b3 = byte_at 16 in
-  let b4 = byte_at 8 in
-  let b5 = byte_at 0 in
-  let rand_12 = Random.int 0x1000 in
-  let b6 = 0x70 lor ((rand_12 lsr 8) land 0x0F) in
-  let b7 = rand_12 land 0xFF in
-  let rand_14 = Random.int 0x4000 in
-  let b8 = 0x80 lor ((rand_14 lsr 8) land 0x3F) in
-  let b9 = rand_14 land 0xFF in
-  let r1 = Random.int 0x1000000 in
-  let r2 = Random.int 0x1000000 in
-  let b10 = (r1 lsr 16) land 0xFF in
-  let b11 = (r1 lsr 8) land 0xFF in
-  let b12 = r1 land 0xFF in
-  let b13 = (r2 lsr 16) land 0xFF in
-  let b14 = (r2 lsr 8) land 0xFF in
-  let b15 = r2 land 0xFF in
-  Printf.sprintf "%s%s%s%s-%s%s-%s%s-%s%s-%s%s%s%s%s%s"
-    (hex_byte b0) (hex_byte b1) (hex_byte b2) (hex_byte b3)
-    (hex_byte b4) (hex_byte b5)
-    (hex_byte b6) (hex_byte b7)
-    (hex_byte b8) (hex_byte b9)
-    (hex_byte b10) (hex_byte b11) (hex_byte b12)
-    (hex_byte b13) (hex_byte b14) (hex_byte b15)
-
-let is_hex c =
-  (c >= '0' && c <= '9')
-  || (c >= 'a' && c <= 'f')
-  || (c >= 'A' && c <= 'F')
+let generate = Random_id.uuid_v7
 
 let of_string s =
-  if String.length s <> 36 then
-    Error (Printf.sprintf "Artifact_id.of_string: expected 36 chars, got %d"
-             (String.length s))
-  else if s.[8] <> '-' || s.[13] <> '-' || s.[18] <> '-' || s.[23] <> '-' then
-    Error "Artifact_id.of_string: missing dashes at expected positions"
-  else if s.[14] <> '7' then
-    Error (Printf.sprintf "Artifact_id.of_string: expected version '7', got %c"
-             s.[14])
-  else
-    let v = Char.lowercase_ascii s.[19] in
-    if v <> '8' && v <> '9' && v <> 'a' && v <> 'b' then
-      Error (Printf.sprintf "Artifact_id.of_string: invalid variant nibble %c" v)
-    else begin
-      let valid = ref true in
-      for i = 0 to 35 do
-        if i <> 8 && i <> 13 && i <> 18 && i <> 23 && not (is_hex s.[i]) then
-          valid := false
-      done;
-      if !valid then Ok (String.lowercase_ascii s)
-      else Error "Artifact_id.of_string: non-hex character in body"
-    end
+  Random_id.parse_uuid_v7 s
+  |> Result.map_error (fun error -> "Artifact_id.of_string: " ^ error)
 
 let to_string t = t
 

--- a/lib/shared_types/artifact_id.mli
+++ b/lib/shared_types/artifact_id.mli
@@ -17,14 +17,12 @@ type t = private string
 (** Private string. The only constructors are {!generate} and {!of_string}. *)
 
 val generate : unit -> t
-(** Generate a fresh UUID v7. Side-effecting: reads current wall-clock
-    time and the OCaml [Random] state. The first call seeds [Random]
-    via [Random.self_init] if not already seeded by the caller. *)
+(** Generate a fresh UUID v7 through the shared Uuidm-backed generator.
+    Calls in one process are monotonic within the same millisecond. *)
 
 val of_string : string -> (t, string) result
-(** Parse a 36-character UUID string. Validates dashes at positions
-    8/13/18/23, version digit (must be ['7']), and variant nibble
-    (must be one of [{8,9,a,b}]). Returns [Error] for malformed input. *)
+(** Parse a complete UUID string through Uuidm and require RFC 9562 variant
+    and version 7. Returns [Error] for malformed input. *)
 
 val to_string : t -> string
 

--- a/lib/shared_types/dune
+++ b/lib/shared_types/dune
@@ -6,4 +6,4 @@
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags
   (:standard -w +4))
- (libraries unix yojson))
+ (libraries unix yojson masc_random_id))

--- a/lib/subscriptions.ml
+++ b/lib/subscriptions.ml
@@ -67,12 +67,7 @@ module SubscriptionStore = struct
 
   (** Generate subscription ID *)
   let generate_id () : string =
-    let bytes = Crypto_rng.generate 8 in
-    let buf = Buffer.create 16 in
-    for i = 0 to String.length bytes - 1 do
-      Printf.bprintf buf "%02x" (Char.code (String.get bytes i))
-    done;
-    Printf.sprintf "sub_%s" (Buffer.contents buf)
+    Random_id.prefixed ~prefix:"sub_" ~bytes:8
 
   (** Subscribe to resource changes *)
   let subscribe ~(subscriber : string) ~(resource : resource_type) ?(filter : string option) () : subscription =

--- a/lib/voice/voice_session_manager.ml
+++ b/lib/voice/voice_session_manager.ml
@@ -48,13 +48,7 @@ type t = {
 (** {1 Utilities} *)
 
 let generate_session_id () =
-  (* intentional: voice session IDs need randomness for distributed uniqueness *)
-  let high = Random.int 0xFFFF in
-  let mid = Random.int 0xFFFF in
-  let low = Random.int 0xFFFF in
-  Printf.sprintf "vs-%08x-%04x%04x%04x"
-    (Random.int 0x3FFFFFFF)
-    high mid low
+  Random_id.prefixed ~prefix:"vs-" ~bytes:16
 
 let string_of_status = function
   | Active -> "active"
@@ -223,7 +217,6 @@ let session_of_json json =
 (** {1 Creation} *)
 
 let create ~config_path =
-  Random.self_init ();
   let session_dir = Filename.concat config_path "voice_sessions" in
   {
     sessions = Hashtbl.create 16;

--- a/lib/voice/voice_session_manager.mli
+++ b/lib/voice/voice_session_manager.mli
@@ -91,8 +91,8 @@ val session_of_json : Yojson.Safe.t -> session
 (** {1 Lifecycle} *)
 
 val create : config_path:string -> t
-(** Initialises an empty manager. Calls [Random.self_init ()] for
-    {!generate_session_id}. Does not load existing sessions from
+(** Initialises an empty manager. Session identifiers use the shared
+    cryptographic [Random_id] boundary. Does not load existing sessions from
     disk — call {!restore} for that. *)
 
 val start_session :

--- a/lib/workspace/workspace_identity.ml
+++ b/lib/workspace/workspace_identity.ml
@@ -5,8 +5,7 @@
 open Workspace_utils
 
 let generate_session_id () =
-  let t = Unix.gettimeofday () in
-  Printf.sprintf "%04x%04x" (Hashtbl.hash t land 0xFFFF) (Hashtbl.hash (t *. 1000.0) land 0xFFFF)
+  Random_id.hex ~bytes:16
 
 let get_hostname () =
   try Some (Unix.gethostname ()) with Unix.Unix_error _ -> None

--- a/lib/workspace/workspace_identity.mli
+++ b/lib/workspace/workspace_identity.mli
@@ -4,6 +4,8 @@
 open Workspace_utils
 
 val generate_session_id : unit -> string
+(** Generate a 128-bit cryptographically random lowercase hex session ID.
+    Existing shorter persisted session IDs remain readable as opaque text. *)
 val get_hostname : unit -> string option
 val get_tty : unit -> string option
 val resolve_agent_name : Workspace_utils_backend_setup.config -> string -> string

--- a/masc.opam
+++ b/masc.opam
@@ -69,7 +69,7 @@ depends: [
   "qcheck-alcotest" {with-test & >= "0.21"}
   "bisect_ppx" {with-test & >= "2.8"}
   "mtime" {>= "2.0"}
-  "uuidm" {>= "0.9"}
+  "uuidm" {>= "0.9.10"}
   "atdgen" {build & >= "4.2.0"}
   "atdgen-runtime" {>= "4.2.0"}
   "atdts" {build & >= "4.2.0"}

--- a/test/multimodal/test_workspace_id.ml
+++ b/test/multimodal/test_workspace_id.ml
@@ -13,8 +13,7 @@ let test_generate_is_lowercase () =
   assert (s = String.lowercase_ascii s)
 
 let test_generate_two_distinct () =
-  (* 122-bit randomness in the v7 tail; collisions are statistical
-     non-events. *)
+  (* UUIDv7 carries 74 random/counter bits after its timestamp. *)
   let a = W.generate () in
   let b = W.generate () in
   assert (not (W.equal a b))

--- a/test/shared_types/dune
+++ b/test/shared_types/dune
@@ -1,3 +1,3 @@
 (tests
  (names test_shared_types test_resilience_outcome)
- (libraries alcotest shared_types yojson unix))
+ (libraries alcotest shared_types masc_random_id yojson unix))

--- a/test/shared_types/test_shared_types.ml
+++ b/test/shared_types/test_shared_types.ml
@@ -135,6 +135,32 @@ let test_artifact_id_time_ordering () =
   let cmp = A.compare a b in
   check bool "earlier-generated sorts first" true (cmp < 0)
 
+let test_artifact_id_burst_is_monotonic () =
+  let generated = List.init 100 (fun _ -> A.generate ()) in
+  let rec strictly_increasing = function
+    | [] | [ _ ] -> true
+    | first :: (second :: _ as rest) ->
+      A.compare first second < 0 && strictly_increasing rest
+  in
+  check bool "serialized generation is monotonic" true
+    (strictly_increasing generated)
+
+let test_uuid_v7_clock_clamps_wall_clock_rollback () =
+  let observations = ref [ 1_000L; 999L; 1_000L; 1_001L ] in
+  let raw_now_ms () =
+    match !observations with
+    | value :: rest ->
+      observations := rest;
+      value
+    | [] -> fail "clock fixture exhausted"
+  in
+  let now_ms, advance = Random_id.For_testing.logical_ms_clock raw_now_ms in
+  check int64 "first observation" 1_000L (now_ms ());
+  check int64 "rollback clamps to last timestamp" 1_000L (now_ms ());
+  advance ();
+  check int64 "counter exhaustion advances logical time" 1_001L (now_ms ());
+  check int64 "wall time resumes without regression" 1_001L (now_ms ())
+
 (* ──────────────────────────────────────────────────────────── *)
 (* Suite                                                         *)
 (* ──────────────────────────────────────────────────────────── *)
@@ -167,5 +193,8 @@ let () =
       test_case "of_string missing dash" `Quick test_artifact_id_of_string_missing_dash;
       test_case "of_string invalid variant" `Quick test_artifact_id_of_string_invalid_variant;
       test_case "time ordering" `Quick test_artifact_id_time_ordering;
+      test_case "burst is monotonic" `Quick test_artifact_id_burst_is_monotonic;
+      test_case "wall-clock rollback is clamped" `Quick
+        test_uuid_v7_clock_clamps_wall_clock_rollback;
     ];
   ]

--- a/test/test_client_identity.ml
+++ b/test/test_client_identity.ml
@@ -23,6 +23,17 @@ let test_generate_session_key () =
   check bool "keys are different" true (key1 <> key2);
   check bool "key length >= 32" true (String.length key1 >= 32)
 
+let test_generate_uuid_is_uuid_v7 () =
+  let uuid = Client_identity.generate_uuid ~agent_name:"display-only" in
+  check int "canonical length" 36 (String.length uuid);
+  check char "version 7" '7' uuid.[14];
+  match Uuidm.of_string uuid with
+  | Some parsed ->
+    check int "Uuidm version" 7 (Uuidm.version parsed);
+    check bool "RFC variant" true
+      (Uuidm.variant parsed >= 8 && Uuidm.variant parsed <= 11)
+  | None -> fail "expected Uuidm to parse generated UUID"
+
 let test_from_mcp_params () =
   let params = `Assoc [
     ("_agent_name", `String "mcp-agent-001");
@@ -42,6 +53,12 @@ let test_from_mcp_params_minimal () =
   check bool "agent_name starts with agent-" true 
     (String.sub identity.agent_name 0 6 = "agent-");
   check bool "session_key generated" true (String.length identity.session_key > 0)
+
+let test_generated_fallback_agent_names_are_distinct () =
+  let first = Client_identity.from_mcp_params (`Assoc []) in
+  let second = Client_identity.from_mcp_params (`Assoc []) in
+  check bool "fallback names do not share a timestamp prefix" true
+    (first.agent_name <> second.agent_name)
 
 let test_from_mcp_params_empty_session_key () =
   let params = `Assoc [("_session_key", `String "")] in
@@ -283,8 +300,11 @@ let () =
   run "Client_identity" [
     "basics", [
       test_case "generate_session_key" `Quick test_generate_session_key;
+      test_case "generate_uuid is UUIDv7" `Quick test_generate_uuid_is_uuid_v7;
       test_case "from_mcp_params" `Quick test_from_mcp_params;
       test_case "from_mcp_params_minimal" `Quick test_from_mcp_params_minimal;
+      test_case "generated fallback names are distinct" `Quick
+        test_generated_fallback_agent_names_are_distinct;
       test_case "from_mcp_params_empty_session_key" `Quick test_from_mcp_params_empty_session_key;
       test_case "from_mcp_params_blank_session_key" `Quick test_from_mcp_params_blank_session_key;
       test_case "from_mcp_params_short_session_key" `Quick test_from_mcp_params_short_session_key;


### PR DESCRIPTION
## Summary

- replace hand-built Artifact/Workspace UUIDv7 encoding and parsing with Uuidm
- centralize hex/prefixed identifier minting in `Random_id` and migrate session, voice, subscription, MCP, auth, workspace, and client identity call sites
- preserve existing stored opaque IDs while strengthening newly minted ID lengths
- clamp backwards wall-clock observations and advance one logical millisecond on UUIDv7 counter exhaustion, matching Uuidm's documented clock precondition without blocking until wall time catches up
- validate canonical UUIDv7 version and RFC variant through Uuidm

## Verification

- focused build: Shared_types, Workspace_id, Client_identity, Auth
- tests: 22 + 1 + 20 + 57 = 100 passed
- includes burst monotonicity and simulated wall-clock rollback/counter-exhaustion coverage
- `scripts/check-variants.sh`
- `scripts/ci/check-determinism-contract.sh`
- `opam lint`
- `git diff --check`

Closes #26562
Closes #26566