### PR TITLE
refactor(uri): use typed URI and cookie parsers

### DIFF
--- a/lib/auth/auth_login.ml
+++ b/lib/auth/auth_login.ml
@@ -30,17 +30,6 @@ let auth_change_to_string = function
 let normalize_base_path path =
   Env_config_core.normalize_masc_base_path_input path
 
-let url_encode value =
-  let buf = Buffer.create (String.length value) in
-  String.iter
-    (function
-      | ('A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '-' | '_' | '.' | '~') as c
-        ->
-          Buffer.add_char buf c
-      | c -> Printf.bprintf buf "%%%02X" (Char.code c))
-    value;
-  Buffer.contents buf
-
 let single_quote_shell value =
   "'" ^ String.concat "'\\''" (String.split_on_char '\'' value) ^ "'"
 
@@ -89,13 +78,16 @@ let mint ~base_path ~host ~port ~agent_name ~role ~token_env_var
           let raw_token_file =
             persist_raw_token ~base_path ~agent_name bearer_token
           in
-          let agent_param = url_encode agent_name in
-          let token_param = url_encode bearer_token in
           let dashboard_url =
-            Printf.sprintf "http://%s:%d/dashboard?agent=%s&token=%s"
-              host port agent_param token_param
+            Uri.make ~scheme:"http" ~host ~port ~path:"/dashboard"
+              ~query:[ ("agent", [ agent_name ]); ("token", [ bearer_token ]) ]
+              ()
+            |> Uri.to_string
           in
-          let mcp_url = Printf.sprintf "http://%s:%d/mcp" host port in
+          let mcp_url =
+            Uri.make ~scheme:"http" ~host ~port ~path:"/mcp" ()
+            |> Uri.to_string
+          in
           Ok
             {
               base_path;

--- a/lib/auth/dune
+++ b/lib/auth/dune
@@ -22,6 +22,7 @@
   masc.masc_tool_dispatch
   masc.otel_metric_store
   masc.tool_types
-  time_compat)
+  time_compat
+  uri)
  (preprocess
   (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq)))

--- a/lib/server/server_ide_lsp_proxy.ml
+++ b/lib/server/server_ide_lsp_proxy.ml
@@ -466,34 +466,14 @@ let extract_uri params =
   | _ -> None
 ;;
 
-(** Decode percent-encoded URI component (e.g. [%20] -> [ ]). *)
-let pct_decode s =
-  let len = String.length s in
-  let buf = Buffer.create len in
-  let i = ref 0 in
-  while !i < len do
-    let c = String.get s !i in
-    if c = '%' && !i + 2 < len then begin
-      let hex = String.sub s (!i + 1) 2 in
-      (match int_of_string_opt ("0x" ^ String.uppercase_ascii hex) with
-       | Some byte -> Buffer.add_char buf (Char.chr byte); i := !i + 3
-       | None -> Buffer.add_char buf c; incr i)
-    end else begin
-      Buffer.add_char buf c;
-      incr i
-    end
-  done;
-  Buffer.contents buf
-
 let path_of_file_uri uri =
-  let prefix = "file://" in
-  if String.starts_with ~prefix uri
-  then (
-    let raw =
-      String.sub uri (String.length prefix) (String.length uri - String.length prefix)
-    in
-    pct_decode raw)
-  else uri
+  let parsed = Uri.of_string uri in
+  match Uri.scheme parsed with
+  | Some "file" ->
+    (match Uri.host parsed with
+     | None | Some "" | Some "localhost" -> Uri.path parsed |> Uri.pct_decode
+     | Some _ -> uri)
+  | _ -> uri
 ;;
 
 (** [fpath_within ~base path] is [Some rel] when the normalized absolute

--- a/lib/server/server_mcp_transport_http_session.ml
+++ b/lib/server/server_mcp_transport_http_session.ml
@@ -442,15 +442,10 @@ let protocol_version_from_body body_str =
   Mcp_transport_protocol.protocol_version_from_body body_str
 
 let get_session_id_query target =
-  match String.split_on_char '?' target with
-  | [ _; query ] ->
-      query
-      |> String.split_on_char '&'
-      |> List.find_map (fun param ->
-             match String.split_on_char '=' param with
-             | [ "session_id"; v ] | [ "sessionId"; v ] -> Some v
-             | _ -> None)
-  | _ -> None
+  let uri = Uri.of_string target in
+  match Uri.get_query_param uri "session_id" with
+  | Some _ as value -> value
+  | None -> Uri.get_query_param uri "sessionId"
 
 let capitalize_ascii (s : string) =
   if s = "" then
@@ -482,16 +477,13 @@ let get_cookie_value (request : Httpun.Request.t) cookie_name =
   match get_header_any_case request.headers "cookie" with
   | None -> None
   | Some raw ->
-      raw
-      |> String.split_on_char ';'
-      |> List.find_map (fun part ->
-             match String.split_on_char '=' (String.trim part) with
-             | key :: value_parts
-               when String.lowercase_ascii (String.trim key)
-                    = String.lowercase_ascii cookie_name ->
-                 let value = String.concat "=" value_parts |> String.trim in
-                 if value = "" then None else Some value
-             | _ -> None)
+      Cohttp.Header.init_with "cookie" raw
+      |> Cohttp.Cookie.Cookie_hdr.extract
+      |> List.find_map (fun (name, value) ->
+             if String.equal name cookie_name then
+               let value = String.trim value in
+               if String.equal value "" then None else Some value
+             else None)
 
 let get_session_id_any (request : Httpun.Request.t) =
   match get_session_id_query request.target with

--- a/lib/server/server_mcp_transport_http_session.mli
+++ b/lib/server/server_mcp_transport_http_session.mli
@@ -177,7 +177,7 @@ val get_cookie_value :
   Httpun.Request.t -> string -> string option
 (** [get_cookie_value request cookie_name] parses the [Cookie:]
     header and returns the value for [cookie_name]
-    (case-insensitive cookie name match, value trimmed).
+    (RFC case-sensitive cookie name match, value trimmed).
     [None] when absent or blank. *)
 
 val get_session_id_any : Httpun.Request.t -> string option

--- a/test/test_auth_login.ml
+++ b/test/test_auth_login.ml
@@ -137,6 +137,26 @@ let test_login_long_lived_passes_env_var_through () =
          |> Yojson.Safe.Util.member "token_env_var"
          |> Yojson.Safe.Util.to_string)
 
+let test_login_url_uses_uri_components () =
+  with_temp_dir "auth-login-uri" @@ fun base_path ->
+  match
+    Auth_login.mint ~base_path ~host:"::1" ~port:8935
+      ~agent_name:"agent +&" ~role:Masc_domain.Worker
+      ~token_env_var:"MASC_TOKEN" ~token_lifetime:Auth_login.With_expiry ()
+  with
+  | Error err ->
+    failf "login mint failed: %s" (Masc_domain.masc_error_to_string err)
+  | Ok report ->
+    let dashboard = Uri.of_string report.dashboard_url in
+    check (option string) "IPv6 host" (Some "::1") (Uri.host dashboard);
+    check (option int) "port" (Some 8935) (Uri.port dashboard);
+    check string "dashboard path" "/dashboard" (Uri.path dashboard);
+    check (option string) "agent query round-trip" (Some "agent +&")
+      (Uri.get_query_param dashboard "agent");
+    let mcp = Uri.of_string report.mcp_url in
+    check (option string) "MCP IPv6 host" (Some "::1") (Uri.host mcp);
+    check string "MCP path" "/mcp" (Uri.path mcp)
+
 let () =
   run "auth_login"
     [
@@ -146,5 +166,7 @@ let () =
             test_login_with_expiry_uses_caller_env_var;
           test_case "long-lived honors caller env var + no expires_at"
             `Quick test_login_long_lived_passes_env_var_through;
+          test_case "URL uses URI components" `Quick
+            test_login_url_uses_uri_components;
         ] );
     ]

--- a/test/test_mcp_h1_h2_admission_parity.ml
+++ b/test/test_mcp_h1_h2_admission_parity.ml
@@ -284,6 +284,24 @@ let test_shared_protocol_and_delete_matrix () =
   check (option string) "DELETE without session has no admission id" None
     (Transport.get_session_id_any (request ~meth:`DELETE "/mcp"))
 
+let test_session_id_parsing_uses_uri_and_cookie_contracts () =
+  check (option string) "percent-decoded query value" (Some "a&b=c")
+    (Transport.get_session_id_query "/mcp?session_id=a%26b%3Dc");
+  check (option string) "first duplicate query value" (Some "first")
+    (Transport.get_session_id_query
+       "/mcp?session_id=first&session_id=second");
+  check (option string) "legacy camel-case query key" (Some "legacy")
+    (Transport.get_session_id_query "/mcp?sessionId=legacy");
+  let cookie_request =
+    request ~headers:[ ("cookie", "mcp-session-id=exact=value; Other=x") ]
+      "/mcp"
+  in
+  check (option string) "cookie parser preserves equals in value"
+    (Some "exact=value")
+    (Transport.get_cookie_value cookie_request "mcp-session-id");
+  check (option string) "cookie name is case-sensitive" None
+    (Transport.get_cookie_value cookie_request "Mcp-Session-Id")
+
 let test_sse_backing_session_bridge_requires_known_transport_session () =
   let transport_session_id = "h1-h2-parity-sse-transport-session" in
   let sse_session_id = "presence:" ^ transport_session_id in
@@ -570,6 +588,8 @@ let () =
             test_shared_post_admission_matrix;
           test_case "protocol and DELETE predicate matrix" `Quick
             test_shared_protocol_and_delete_matrix;
+          test_case "session URI and cookie parsing contracts" `Quick
+            test_session_id_parsing_uses_uri_and_cookie_contracts;
           test_case "SSE backing session bridge requires known transport session"
             `Quick
             test_sse_backing_session_bridge_requires_known_transport_session;

--- a/test/test_server_ide_lsp_proxy.ml
+++ b/test/test_server_ide_lsp_proxy.ml
@@ -85,7 +85,18 @@ let test_file_uri_resolution_is_workspace_scoped () =
     (option string)
     "encoded traversal is rejected after decode"
     None
-    (Lsp.resolve_relative ~base "file:///workspace/masc/sub%2F..%2F..%2Fetc/passwd")
+    (Lsp.resolve_relative ~base "file:///workspace/masc/sub%2F..%2F..%2Fetc/passwd");
+  check
+    (option string)
+    "localhost file authority is local"
+    (Some "lib/server.ml")
+    (Lsp.resolve_relative ~base
+       "file://localhost/workspace/masc/lib/server.ml");
+  check
+    (option string)
+    "remote file authority is rejected"
+    None
+    (Lsp.resolve_relative ~base "file://remote/workspace/masc/lib/server.ml")
 ;;
 
 let test_file_uri_resolution_rejects_symlink_escape () =


### PR DESCRIPTION
## Summary

- parse MCP session query parameters with Uri, preserving percent decoding, duplicate-key order, and legacy camelCase fallback
- parse Cookie headers with Cohttp and exact case-sensitive cookie names
- construct dashboard/MCP login URLs with Uri so IPv6 hosts and query escaping are correct
- parse LSP file URIs with Uri; allow local/localhost authority and reject remote authority before workspace scope checks
- remove hand-written percent decoder and delimiter parsers

## Verification

- `test_mcp_h1_h2_admission_parity.exe`: 15/15
- `test_auth_login.exe`: 3/3
- `test_server_ide_lsp_proxy.exe`: 15/15
- covers encoded `a&b=c`, duplicate query params, cookie values containing `=`, case sensitivity, IPv6 URLs, encoded traversal, localhost, and remote file authority
- `scripts/check-variants.sh`
- `scripts/ci/check-determinism-contract.sh`
- `git diff --check`

Closes #26567