### PR TITLE
fix(task): align awaiting verification claim contract

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -221,7 +221,7 @@ implementation_prs: []             # [14181, 14550] 형식 (정수). RFC body �
 | 0217 | Telemetry Backend Otel 단일화 (Retired Backend Purge) | Draft | 03d5feaf25 2026-07-08 | - |
 | 0218 | Keeper tool-surface coherence + web-tooling roadmap — phases and per-phase gates | Draft | 03d5feaf25 2026-07-08 | - |
 | 0219 | Remove Sandbox Repo Patrol Gates | Draft | 03d5feaf25 2026-07-08 | - |
-| 0220 | Decouple keeper liveness from verification state + guaranteed satisfier for e... | Draft | 03d5feaf25 2026-07-08 | - |
+| 0220 | Decouple keeper liveness from verification state + guaranteed satisfier for e... | Withdrawn | 03d5feaf25 2026-07-08 | - |
 | 0221 | Atomic verification submission — task_status as the sole outcome authority | Implemented (steps 1-3 merged #20613/#20617; steps 4-5 measured then dropped, §3.3/§3.4) | 03d5feaf25 2026-07-08 | - |
 | 0222 | Withdraw harness-owned Task completion | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | 0223 | Typed connector surfaces: presence in world prompt, pull-based lane context, ... | Draft | 03d5feaf25 2026-07-08 | - |

--- a/docs/rfc/RFC-0220-verification-scheduling-decouple.md
+++ b/docs/rfc/RFC-0220-verification-scheduling-decouple.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0220"
 title: "Decouple keeper liveness from verification state + guaranteed satisfier for every verification obligation"
-status: Draft
+status: Withdrawn
 created: 2026-06-09
-updated: 2026-06-09
+updated: 2026-08-01
 author: vincent
 supersedes: []
 superseded_by: null
@@ -20,6 +20,17 @@ Ground-truth invariants encoded:
 - **I2** — the only legitimate timeout is the OAS provider transport timeout (connect + inter-chunk idle). No heuristic per-turn / wall-clock deadline as control flow.
 
 All file:line anchors in this RFC were verified against the working tree on 2026-06-09 before writing. Anchors are given as `file:line` for reviewer navigation; treat the symbol name as the durable reference.
+
+> **Current implementation boundary (2026-08-01).** This RFC is withdrawn and
+> records historical analysis/proposed design, not the executable task
+> contract. RFC-0323 withdrew mandatory cross-verifier completion: the
+> configured system LLM agent at the OAS/completion-authority boundary (or an
+> authenticated HITL operator) issues the verdict, and no Keeper may claim
+> `AwaitingVerification` or gain verifier authority by winning a claim race.
+> The current typed boundary is `Workspace_task_lifecycle.resolve_claim` →
+> `Held_pending_verdict`, and the current taskboard schema must describe the
+> same fact. In particular, the verifier-by-claiming behavior described below
+> is historical/proposed and must not be used as an implementation instruction.
 
 ---
 

--- a/docs/rfc/RFC-0220-verification-scheduling-decouple.md
+++ b/docs/rfc/RFC-0220-verification-scheduling-decouple.md
@@ -13,7 +13,7 @@ implementation_prs: []
 
 # RFC-0220: Decouple keeper liveness from verification state + guaranteed satisfier for every verification obligation
 
-Status: Draft · Architectural framing + typed-state unification + atomicity fix + deterministic migration
+Status: Withdrawn · Historical analysis; not an implementation contract
 Audit source: `~/me/.tmp/masc-fiber-audit-2026-06-09/DIAGNOSIS.md` (finding S3)
 Ground-truth invariants encoded:
 - **I1** — a keeper must never permanently stop. A blocked/empty claim pool must not idle a keeper.

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 208 unique knobs across 8 modules.
+**Total**: 207 unique knobs across 8 modules.
 
-**Typed getter classification**: 33/121 tagged (`operator`: 33, `algorithm`: 0, `unclassified`: 88).
+**Typed getter classification**: 33/120 tagged (`operator`: 33, `algorithm`: 0, `unclassified`: 87).
 
 ## Env_config_core (23 knobs; typed classification 2/5)
 
@@ -100,80 +100,79 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_DOMAIN_POOL_ENABLED` | feature_flag | n/a | n/a | 12 | Historical keeper Domain_pool pilot flag. The supervisor still reads this for observability, but keepalive fibers rem... |
 | `MASC_KEEPER_SUPERVISOR_SWEEP_SEC` | typed:float | Timeouts | operator | 17 | Interval between supervisor sweep runs (seconds). @category Timeouts @ops_class operator |
 
-## Env_config_runtime (72 knobs; typed classification 5/57)
+## Env_config_runtime (71 knobs; typed classification 5/56)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_AGENT_RATE_BURST` | typed:int | unclassified | unclassified | 330 | Per-agent burst capacity. Default: 50. |
-| `MASC_AGENT_RATE_LIMIT` | typed:float | unclassified | unclassified | 327 | Per-agent requests per second. Default: 20. |
+| `MASC_AGENT_RATE_BURST` | typed:int | unclassified | unclassified | 318 | Per-agent burst capacity. Default: 50. |
+| `MASC_AGENT_RATE_LIMIT` | typed:float | unclassified | unclassified | 315 | Per-agent requests per second. Default: 20. |
 | `MASC_AGENT_TRANSPORT` | string_literal | n/a | n/a | 227 | Agent transport type variant (e.g. "grpc", "http", "ws"). |
-| `MASC_BOARD_FLUSHER_INBOX_CAPACITY` | typed:int | Concurrency | operator | 278 | Capacity of the board flusher inbox (scheduled sweep/flush messages enqueued by the sweeper). Single source of truth ... |
-| `MASC_BOARD_FLUSH_INTERVAL_SEC` | typed:float | unclassified | unclassified | 269 | Flush interval for board persistence (seconds). Default: 30. |
-| `MASC_BRIEFING_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 549 | Dashboard mission briefing cache TTL (seconds). Default: 300 (5 min). |
+| `MASC_BOARD_FLUSHER_INBOX_CAPACITY` | typed:int | Concurrency | operator | 266 | Capacity of the board flusher inbox (scheduled sweep/flush messages enqueued by the sweeper). Single source of truth ... |
+| `MASC_BOARD_FLUSH_INTERVAL_SEC` | typed:float | unclassified | unclassified | 257 | Flush interval for board persistence (seconds). Default: 30. |
+| `MASC_BRIEFING_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 537 | Dashboard mission briefing cache TTL (seconds). Default: 300 (5 min). |
 | `MASC_CACHE_MAX_ENTRIES` | typed:int | unclassified | unclassified | 41 | Maximum total number of cache entries (default 1000) |
 | `MASC_CACHE_MAX_ENTRY_SIZE` | typed:int | unclassified | unclassified | 37 | Maximum size of a single cache entry value in bytes (default 100KB) |
-| `MASC_DASHBOARD_CTX_COMPACTING` | typed:float | unclassified | unclassified | 400 |  |
-| `MASC_DASHBOARD_CTX_HANDOFF_IMMINENT` | typed:float | unclassified | unclassified | 396 | Keeper context-ratio lifecycle thresholds. Higher ratio = closer to context limit = more urgency. |
-| `MASC_DASHBOARD_CTX_PREPARING` | typed:float | unclassified | unclassified | 398 |  |
-| `MASC_DASHBOARD_EXECUTION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 439 | Execution surface compute timeout (light + parameterized). Wraps two [Dashboard_cache.get_or_compute_with_timeout] si... |
-| `MASC_DASHBOARD_EXECUTION_TRUST_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 453 | Execution-trust surface compute timeout. Wraps [Dashboard_cache.get_or_compute_with_timeout] at [server_dashboard_htt... |
-| `MASC_DASHBOARD_KEEPER_ACTION_STALE_SEC` | typed:float | unclassified | unclassified | 391 | Keeper action-age threshold (seconds). Default: 3600 (1 hour). |
-| `MASC_DASHBOARD_MISSION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 463 | Mission card compute timeout. Wraps three [Dashboard_cache.get_or_compute_with_timeout] sites at [server_dashboard_ht... |
-| `MASC_DASHBOARD_RENDER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 496 | Maximum wall-clock for a single dashboard render ([Dashboard_execution.json_render]). Wraps the entire render pipelin... |
-| `MASC_DASHBOARD_SHELL_LIGHT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 483 | Shell render compute timeout (light path). Default 8s. Must remain strictly less than [shell_timeout_sec] so the spli... |
-| `MASC_DASHBOARD_SHELL_PREWARM_OUTER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 428 |  |
-| `MASC_DASHBOARD_SHELL_PREWARM_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 423 | Dashboard shell-cache pre-warm timeouts. The pre-warm fires once on server bootstrap. It is wrapped in two nested tim... |
-| `MASC_DASHBOARD_SHELL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 472 | Shell render compute timeout (full path). Used by [Dashboard_cache.get_or_compute_with_timeout] for the full shell re... |
-| `MASC_DASHBOARD_SIGNAL_LIVE_SEC` | typed:float | unclassified | unclassified | 387 | Duration (seconds) for a signal to count as "live". Default: 300 (5 min). |
-| `MASC_DASHBOARD_SIGNAL_QUIET_SEC` | typed:float | unclassified | unclassified | 383 | Duration (seconds) for borderline "quiet" warning. Default: 600 (10 min). |
-| `MASC_DASHBOARD_SIGNAL_STALE_SEC` | typed:float | unclassified | unclassified | 379 | Duration (seconds) after which a signal is considered stale. Default: 1200 (20 min). |
+| `MASC_DASHBOARD_CTX_COMPACTING` | typed:float | unclassified | unclassified | 388 |  |
+| `MASC_DASHBOARD_CTX_HANDOFF_IMMINENT` | typed:float | unclassified | unclassified | 384 | Keeper context-ratio lifecycle thresholds. Higher ratio = closer to context limit = more urgency. |
+| `MASC_DASHBOARD_CTX_PREPARING` | typed:float | unclassified | unclassified | 386 |  |
+| `MASC_DASHBOARD_EXECUTION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 427 | Execution surface compute timeout (light + parameterized). Wraps two [Dashboard_cache.get_or_compute_with_timeout] si... |
+| `MASC_DASHBOARD_EXECUTION_TRUST_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 441 | Execution-trust surface compute timeout. Wraps [Dashboard_cache.get_or_compute_with_timeout] at [server_dashboard_htt... |
+| `MASC_DASHBOARD_KEEPER_ACTION_STALE_SEC` | typed:float | unclassified | unclassified | 379 | Keeper action-age threshold (seconds). Default: 3600 (1 hour). |
+| `MASC_DASHBOARD_MISSION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 451 | Mission card compute timeout. Wraps three [Dashboard_cache.get_or_compute_with_timeout] sites at [server_dashboard_ht... |
+| `MASC_DASHBOARD_RENDER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 484 | Maximum wall-clock for a single dashboard render ([Dashboard_execution.json_render]). Wraps the entire render pipelin... |
+| `MASC_DASHBOARD_SHELL_LIGHT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 471 | Shell render compute timeout (light path). Default 8s. Must remain strictly less than [shell_timeout_sec] so the spli... |
+| `MASC_DASHBOARD_SHELL_PREWARM_OUTER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 416 |  |
+| `MASC_DASHBOARD_SHELL_PREWARM_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 411 | Dashboard shell-cache pre-warm timeouts. The pre-warm fires once on server bootstrap. It is wrapped in two nested tim... |
+| `MASC_DASHBOARD_SHELL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 460 | Shell render compute timeout (full path). Used by [Dashboard_cache.get_or_compute_with_timeout] for the full shell re... |
+| `MASC_DASHBOARD_SIGNAL_LIVE_SEC` | typed:float | unclassified | unclassified | 375 | Duration (seconds) for a signal to count as "live". Default: 300 (5 min). |
+| `MASC_DASHBOARD_SIGNAL_QUIET_SEC` | typed:float | unclassified | unclassified | 371 | Duration (seconds) for borderline "quiet" warning. Default: 600 (10 min). |
+| `MASC_DASHBOARD_SIGNAL_STALE_SEC` | typed:float | unclassified | unclassified | 367 | Duration (seconds) after which a signal is considered stale. Default: 1200 (20 min). |
 | `MASC_EXECUTOR_DOMAIN_COUNT` | typed:int | Concurrency | operator | 53 | Shared executor worker-domain count override. Env: [MASC_EXECUTOR_DOMAIN_COUNT]. Default: unset, use {!Domain_pool}'s... |
-| `MASC_FULL_HEALTH_CRITICAL_FAILURE_THRESHOLD` | typed:int | unclassified | unclassified | 526 | Number of consecutive [/health?full=1] cache-refresh failures that must accumulate before [masc_full_health_refresh_c... |
-| `MASC_FULL_HEALTH_REFRESH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 514 | Full-health snapshot proactive refresh timeout (seconds). Caps a single [/health?full=1] cache refresh attempt in [Se... |
+| `MASC_FULL_HEALTH_CRITICAL_FAILURE_THRESHOLD` | typed:int | unclassified | unclassified | 514 | Number of consecutive [/health?full=1] cache-refresh failures that must accumulate before [masc_full_health_refresh_c... |
+| `MASC_FULL_HEALTH_REFRESH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 502 | Full-health snapshot proactive refresh timeout (seconds). Caps a single [/health?full=1] cache refresh attempt in [Se... |
 | `MASC_GRPC_ENABLED` | feature_flag | n/a | n/a | 202 | Whether gRPC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
 | `MASC_GRPC_PORT` | string_literal | n/a | n/a | 198 | gRPC server port. Default: 8936. |
 | `MASC_GRPC_TARGET` | string_literal | n/a | n/a | 206 | gRPC client target address. Derived from grpc_port when unset. |
 | `MASC_HTTP_AUTH_STRICT` | feature_flag | n/a | n/a | 232 |  |
-| `MASC_JANITOR_INTERVAL_SEC` | typed:float | unclassified | unclassified | 565 | Bootstrap janitor tick interval (seconds). Drives the SSE/session/ rate-limit/webrtc reaper loop in [server_bootstrap... |
-| `MASC_LABEL_QUIET_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 541 | Dashboard label "quiet" threshold (seconds). Default: 300 (5 min). |
-| `MASC_LABEL_STUCK_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 545 | Dashboard label "stuck" threshold (seconds). Default: 900 (15 min). |
-| `MASC_LANE_PREFERENCE_TTL_S` | typed:float | Timeouts | operator | 368 | Sticky lane-candidate preference TTL (seconds). After a lane candidate succeeds, later turns on the same lane try it ... |
-| `MASC_LIST_PAGE_SIZE` | typed:int | unclassified | unclassified | 291 | Tool list page size, clamped to [10, 1024]. Default: 512. Re-readable within the process; not a guarantee of shell-le... |
-| `MASC_LOCAL_RUNTIME_COOLDOWN_SEC` | string_literal | n/a | n/a | 342 | Local runtime cooldown (seconds). |
-| `MASC_LOCAL_RUNTIME_DEBUG` | feature_flag | n/a | n/a | 338 | Enable local runtime debug logging. Default: false. |
-| `MASC_LOCAL_WORKER_HEARTBEAT_SEC` | typed:int | unclassified | unclassified | 345 | Local worker heartbeat interval (seconds). Default: 60. |
+| `MASC_JANITOR_INTERVAL_SEC` | typed:float | unclassified | unclassified | 553 | Bootstrap janitor tick interval (seconds). Drives the SSE/session/ rate-limit/webrtc reaper loop in [server_bootstrap... |
+| `MASC_LABEL_QUIET_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 529 | Dashboard label "quiet" threshold (seconds). Default: 300 (5 min). |
+| `MASC_LABEL_STUCK_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 533 | Dashboard label "stuck" threshold (seconds). Default: 900 (15 min). |
+| `MASC_LANE_PREFERENCE_TTL_S` | typed:float | Timeouts | operator | 356 | Sticky lane-candidate preference TTL (seconds). After a lane candidate succeeds, later turns on the same lane try it ... |
+| `MASC_LIST_PAGE_SIZE` | typed:int | unclassified | unclassified | 279 | Tool list page size, clamped to [10, 1024]. Default: 512. Re-readable within the process; not a guarantee of shell-le... |
+| `MASC_LOCAL_RUNTIME_COOLDOWN_SEC` | string_literal | n/a | n/a | 330 | Local runtime cooldown (seconds). |
+| `MASC_LOCAL_RUNTIME_DEBUG` | feature_flag | n/a | n/a | 326 | Enable local runtime debug logging. Default: false. |
+| `MASC_LOCAL_WORKER_HEARTBEAT_SEC` | typed:int | unclassified | unclassified | 333 | Local worker heartbeat interval (seconds). Default: 60. |
 | `MASC_MESSAGE_MAX_COUNT` | typed:int | unclassified | unclassified | 144 | Maximum number of message files to retain per workspace (default 200). Oldest messages (by filename sort) are deleted... |
-| `MASC_METRICS_FLUSH_SEC` | typed:float | unclassified | unclassified | 537 | Tool metrics flush interval (seconds). Default: 300 (5 min). |
-| `MASC_OAS_SSE_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 353 | SSE drain interval (seconds). Default: 2.0. |
+| `MASC_METRICS_FLUSH_SEC` | typed:float | unclassified | unclassified | 525 | Tool metrics flush interval (seconds). Default: 300 (5 min). |
+| `MASC_OAS_SSE_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 341 | SSE drain interval (seconds). Default: 2.0. |
 | `MASC_ORCHESTRATOR_AGENT` | typed:string | unclassified | unclassified | 67 | Orchestrator agent name |
 | `MASC_ORCHESTRATOR_INTERVAL` | typed:float | unclassified | unclassified | 63 | Orchestrator check interval (seconds) |
 | `MASC_ORCHESTRATOR_MIN_PRIORITY` | typed:int | unclassified | unclassified | 70 |  |
-| `MASC_PUBLIC_TOOLS_EXTRA` | string_literal | n/a | n/a | 296 | Extra public tools (comma-separated names). |
-| `MASC_RATE_BURST` | typed:int | unclassified | unclassified | 324 | Burst capacity. Default: 150. |
-| `MASC_RATE_LIMIT` | typed:float | unclassified | unclassified | 321 | Requests per second. Default: 100. |
-| `MASC_RATE_LIMIT_BUCKET_TTL_SEC` | typed:int | unclassified | unclassified | 579 | Rate-limit bucket staleness TTL (seconds). Buckets with no traffic for this long are reaped by the janitor loop. Defa... |
-| `MASC_REPO_SYNC_INTERVAL_SEC` | typed:float | unclassified | unclassified | 571 | Repository auto-sync interval (seconds). The repo_sync fiber in [server_bootstrap_loops] wakes at this cadence to fet... |
+| `MASC_PUBLIC_TOOLS_EXTRA` | string_literal | n/a | n/a | 284 | Extra public tools (comma-separated names). |
+| `MASC_RATE_BURST` | typed:int | unclassified | unclassified | 312 | Burst capacity. Default: 150. |
+| `MASC_RATE_LIMIT` | typed:float | unclassified | unclassified | 309 | Requests per second. Default: 100. |
+| `MASC_RATE_LIMIT_BUCKET_TTL_SEC` | typed:int | unclassified | unclassified | 567 | Rate-limit bucket staleness TTL (seconds). Buckets with no traffic for this long are reaped by the janitor loop. Defa... |
+| `MASC_REPO_SYNC_INTERVAL_SEC` | typed:float | unclassified | unclassified | 559 | Repository auto-sync interval (seconds). The repo_sync fiber in [server_bootstrap_loops] wakes at this cadence to fet... |
 | `MASC_SESSION_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 8 | Maximum session age before cleanup (seconds) |
 | `MASC_SESSION_SSE_GRACE_PERIOD_SEC` | typed:float | unclassified | unclassified | 13 | Grace period after SSE disconnect before reaping transport session (seconds). Prevents "Unknown Mcp-Session-Id" error... |
-| `MASC_SIDECAR_CONTROL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 605 | Subprocess timeout (seconds) for sidecar control commands — [stop], [tail], and similar quick housekeeping operatio... |
-| `MASC_SIDECAR_RECONCILE_BACKOFF_SEC` | typed:float | unclassified | unclassified | 593 | Backoff window (seconds) between repeated same-generation [running + unavailable] start dispatches. Default: 30 (matc... |
-| `MASC_SIDECAR_SCHEMA_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 621 | Subprocess timeout (seconds) for sidecar Python schema generation. Wraps [Process_eio.run_argv_with_status] at [serve... |
-| `MASC_SSE_BUFFER_TTL_SEC` | typed:float | unclassified | unclassified | 553 | SSE buffer TTL (seconds). Default: 300 (5 min). |
-| `MASC_STALLED_SESSION_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 557 | Operator digest stalled session threshold (seconds). Default: 300 (5 min). |
+| `MASC_SIDECAR_CONTROL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 593 | Subprocess timeout (seconds) for sidecar control commands — [stop], [tail], and similar quick housekeeping operatio... |
+| `MASC_SIDECAR_RECONCILE_BACKOFF_SEC` | typed:float | unclassified | unclassified | 581 | Backoff window (seconds) between repeated same-generation [running + unavailable] start dispatches. Default: 30 (matc... |
+| `MASC_SIDECAR_SCHEMA_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 609 | Subprocess timeout (seconds) for sidecar Python schema generation. Wraps [Process_eio.run_argv_with_status] at [serve... |
+| `MASC_SSE_BUFFER_TTL_SEC` | typed:float | unclassified | unclassified | 541 | SSE buffer TTL (seconds). Default: 300 (5 min). |
+| `MASC_STALLED_SESSION_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 545 | Operator digest stalled session threshold (seconds). Default: 300 (5 min). |
 | `MASC_STARTUP_WATCHDOG_SEC` | typed:float | unclassified | unclassified | 243 | Startup watchdog timeout, clamped to [30, 600]. Default: 240. Re-readable within the process, but operationally a boo... |
 | `MASC_TEMPO_DEFAULT_INTERVAL_SEC` | typed:float | unclassified | unclassified | 29 | Default polling interval (seconds) |
 | `MASC_TEMPO_MAX_INTERVAL_SEC` | typed:float | unclassified | unclassified | 25 | Maximum polling interval (seconds) - for idle tempo |
 | `MASC_TEMPO_MIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 21 | Minimum polling interval (seconds) - for urgent tempo |
 | `MASC_USE_H2` | string_literal | n/a | n/a | 221 | HTTP mode: typed variant for "auto", "h2_only", "h1_only". |
-| `MASC_VERIFICATION_TIMEOUT_DEADLINE_SEC` | typed:float | unclassified | unclassified | 251 | Maximum time a task may remain AwaitingVerification before surfacing an operator-visible timeout. Default: 24h. |
 | `MASC_WEBRTC_ENABLED` | feature_flag | n/a | n/a | 217 | Whether WebRTC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
-| `MASC_WEB_SEARCH_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 312 |  |
-| `MASC_WEB_SEARCH_FALLBACKS` | string_literal | n/a | n/a | 305 |  |
-| `MASC_WEB_SEARCH_PROVIDER` | string_literal | n/a | n/a | 299 |  |
-| `MASC_WEB_SEARCH_PROVIDER_ORDER` | string_literal | n/a | n/a | 302 |  |
-| `MASC_WEB_SEARCH_TIMEOUT_SEC` | typed:int | unclassified | unclassified | 308 |  |
-| `MASC_WORKSPACE_FILE_MAX_READ_BYTES` | typed:int | Policies | operator | 666 | Maximum bytes served by the IDE workspace file endpoint in one response. The route rejects larger files instead of ma... |
-| `MASC_WORKSPACE_GIT_LOCAL_OP_TIMEOUT_SEC` | typed:float | Timeouts | operator | 656 | Budget (seconds) for local-only git operations under [Masc_exec.Exec_gate.run_argv*] in {!Workspace_git}: [rev-parse]... |
+| `MASC_WEB_SEARCH_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 300 |  |
+| `MASC_WEB_SEARCH_FALLBACKS` | string_literal | n/a | n/a | 293 |  |
+| `MASC_WEB_SEARCH_PROVIDER` | string_literal | n/a | n/a | 287 |  |
+| `MASC_WEB_SEARCH_PROVIDER_ORDER` | string_literal | n/a | n/a | 290 |  |
+| `MASC_WEB_SEARCH_TIMEOUT_SEC` | typed:int | unclassified | unclassified | 296 |  |
+| `MASC_WORKSPACE_FILE_MAX_READ_BYTES` | typed:int | Policies | operator | 654 | Maximum bytes served by the IDE workspace file endpoint in one response. The route rejects larger files instead of ma... |
+| `MASC_WORKSPACE_GIT_LOCAL_OP_TIMEOUT_SEC` | typed:float | Timeouts | operator | 644 | Budget (seconds) for local-only git operations under [Masc_exec.Exec_gate.run_argv*] in {!Workspace_git}: [rev-parse]... |
 | `MASC_WS_ENABLED` | feature_flag | n/a | n/a | 213 | Whether WebSocket transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at... |
 | `MASC_WS_PORT` | string_literal | n/a | n/a | 209 | WebSocket server port. Default: 8937. |
 

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -244,18 +244,6 @@ module Transport = struct
     Float.max 30.0 (Float.min 600.0 v)
 end
 
-module Verification = struct
-  (** Maximum time a task may remain AwaitingVerification before surfacing an
-      operator-visible timeout. Default: 24h. *)
-  let timeout_deadline_seconds () =
-    get_float ~default:(24.0 *. 60.0 *. 60.0) "MASC_VERIFICATION_TIMEOUT_DEADLINE_SEC"
-
-  (* MASC_VERIFICATION_TIMEOUT_CHECK_INTERVAL_SEC was deleted by RFC-0220 §11
-     PR-3 together with the [verification_timeout] server fork it paced and
-     the [Verification_protocol.check_timeouts] no-op it invoked. The knob
-     row was removed from docs/runtime-tunables.md in the same change. *)
-end
-
 (** {1 Board Configuration} *)
 
 module Board = struct

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -115,12 +115,6 @@ module Transport : sig
   val startup_watchdog_sec : unit -> float
 end
 
-(** {1 Verification FSM} *)
-
-module Verification : sig
-  val timeout_deadline_seconds : unit -> float
-end
-
 (** {1 Board persistence} *)
 
 module Board : sig

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -947,9 +947,10 @@ let phase_supports_crash_log_failure_reason = function
 let active_task_owner_fiber_scan_semantics =
   "reports keeper-shaped active task owners without executable keeper fibers; \
    disabled keepers are excluded; matching keeper rows can degrade fleet \
-   status; tasks awaiting a completion-authority verdict are excluded because \
-   their verifier is the system LLM agent rather than a Keeper; credentialed \
-   non-keeper client task owners are reported separately as advisory rows"
+   status; AwaitingVerification obligations are reported separately as \
+   system-LLM completion-authority pending rows and never as Keeper blockers; \
+   credentialed non-keeper client task owners are reported separately as \
+   advisory rows"
 
 let paused_keeper_last_blocker_json paused_keepers_json name =
   match paused_keepers_json with
@@ -1182,6 +1183,13 @@ type active_task_owner_without_executable_fiber = {
   task_status : string;
 }
 
+type completion_authority_pending_task = {
+  producer_agent_name : string;
+  task_id : string;
+  task_status : string;
+  verification_id : string;
+}
+
 type non_keeper_active_task_owner = {
   agent_name : string;
   task_id : string;
@@ -1191,6 +1199,7 @@ type non_keeper_active_task_owner = {
 type active_task_owner_fiber_scan = {
   active_task_owner_without_executable_fibers :
     active_task_owner_without_executable_fiber list;
+  completion_authority_pending_tasks : completion_authority_pending_task list;
   non_keeper_active_task_owners : non_keeper_active_task_owner list;
   active_task_owner_scan_errors : (string * string) list;
 }
@@ -1198,6 +1207,7 @@ type active_task_owner_fiber_scan = {
 let empty_active_task_owner_fiber_scan =
   {
     active_task_owner_without_executable_fibers = [];
+    completion_authority_pending_tasks = [];
     non_keeper_active_task_owners = [];
     active_task_owner_scan_errors = [];
   }
@@ -1214,21 +1224,37 @@ let compare_active_task_owner_without_executable_fiber left right =
     if cmp <> 0 then cmp
     else String.compare left.task_id right.task_id
 
+let compare_completion_authority_pending_task left right =
+  let cmp = String.compare left.producer_agent_name right.producer_agent_name in
+  if cmp <> 0 then cmp
+  else
+    let cmp = String.compare left.task_id right.task_id in
+    if cmp <> 0 then cmp
+    else String.compare left.verification_id right.verification_id
+
 let compare_non_keeper_active_task_owner left right =
   let cmp = String.compare left.agent_name right.agent_name in
   if cmp <> 0 then cmp else String.compare left.task_id right.task_id
 
+type active_task_assignment =
+  | Keeper_task_owner of { assignee : string; task_status : string }
+  | Completion_authority_pending of {
+      producer_agent_name : string;
+      verification_id : string;
+    }
+
 let active_task_assignment (task : Masc_domain.task) =
   match task.task_status with
-  | Masc_domain.AwaitingVerification _ ->
-      (* AwaitingVerification is a durable obligation for the application-owned
-         system LLM completion authority. It is not executable Keeper work and
-         must not degrade Keeper fleet health while waiting for that verdict. *)
-      None
-  | status ->
-      Masc_domain.task_assignee_of_status status
+  | Masc_domain.AwaitingVerification { assignee; verification_id; _ } ->
+      Some (Completion_authority_pending { producer_agent_name = assignee; verification_id })
+  | task_status ->
+      Masc_domain.task_assignee_of_status task_status
       |> Option.map (fun assignee ->
-             (assignee, Workspace_task_schedule.task_status_label status))
+             Keeper_task_owner
+               {
+                 assignee;
+                 task_status = Workspace_task_schedule.task_status_label task_status;
+               })
 
 let active_task_owner_without_executable_fiber_json row =
   let action =
@@ -1244,6 +1270,18 @@ let active_task_owner_without_executable_fiber_json row =
       ("task_status", `String row.task_status);
       ("executable", `Bool false);
       ("action", `String action);
+    ]
+
+let completion_authority_pending_task_json row =
+  `Assoc
+    [
+      ("producer_agent_name", `String row.producer_agent_name);
+      ("task_id", `String row.task_id);
+      ("task_status", `String row.task_status);
+      ("verification_id", `String row.verification_id);
+      ("owner_kind", `String "system_llm_completion_authority");
+      ("fleet_blocking", `Bool false);
+      ("action", `String "await_system_llm_verdict");
     ]
 
 let non_keeper_active_task_owner_json row =
@@ -1322,29 +1360,41 @@ let active_task_owner_fiber_scan config ~executable_names =
   | Error err ->
       {
         active_task_owner_without_executable_fibers = [];
+        completion_authority_pending_tasks = [];
         non_keeper_active_task_owners = [];
         active_task_owner_scan_errors =
           ("backlog", err) :: meta_read_errors;
       }
   | Ok backlog ->
-      let blocking_rows, non_keeper_rows =
+      let pending_rows, blocking_rows, non_keeper_rows =
         backlog.tasks
         |> List.fold_left
-             (fun (blocking_rows, non_keeper_rows) task ->
+             (fun (pending_rows, blocking_rows, non_keeper_rows) task ->
              match active_task_assignment task with
-             | None -> (blocking_rows, non_keeper_rows)
-             | Some (assignee, task_status) ->
+             | None -> (pending_rows, blocking_rows, non_keeper_rows)
+             | Some (Completion_authority_pending { producer_agent_name; verification_id }) ->
+                 ( { producer_agent_name
+                   ; task_id = task.id
+                   ; task_status =
+                       Workspace_task_schedule.task_status_label task.task_status
+                   ; verification_id
+                   }
+                   :: pending_rows
+                 , blocking_rows
+                 , non_keeper_rows )
+             | Some (Keeper_task_owner { assignee; task_status }) ->
                  let keeper_names = keeper_names_for_agent agent_bindings assignee in
                  if
                    List.exists
                      (fun keeper_name -> String_set.mem keeper_name executable_set)
                      keeper_names
-                 then (blocking_rows, non_keeper_rows)
+                 then (pending_rows, blocking_rows, non_keeper_rows)
                  else (
                    match keeper_names with
                    | []
                      when is_credentialed_external_client config assignee ->
-                       ( blocking_rows
+                       ( pending_rows
+                       , blocking_rows
                        , {
                            agent_name = assignee;
                            task_id = task.id;
@@ -1354,9 +1404,10 @@ let active_task_owner_fiber_scan config ~executable_names =
                    | []
                      when List.mem assignee binding_scan.disabled_agent_names
                           || meta_read_errors <> [] ->
-                       (blocking_rows, non_keeper_rows)
+                       (pending_rows, blocking_rows, non_keeper_rows)
                    | [] ->
-                       ( {
+                       ( pending_rows
+                       , {
                            keeper_name = None;
                            agent_name = assignee;
                            task_id = task.id;
@@ -1365,7 +1416,8 @@ let active_task_owner_fiber_scan config ~executable_names =
                          :: blocking_rows
                        , non_keeper_rows )
                    | keeper_names ->
-                       ( keeper_names
+                       ( pending_rows
+                       , keeper_names
                          |> List.fold_left
                               (fun rows keeper_name ->
                                 {
@@ -1377,7 +1429,11 @@ let active_task_owner_fiber_scan config ~executable_names =
                                 :: rows)
                               blocking_rows
                        , non_keeper_rows )))
-             ([], [])
+             ([], [], [])
+      in
+      let pending_rows =
+        pending_rows
+        |> List.sort_uniq compare_completion_authority_pending_task
       in
       let rows =
         blocking_rows
@@ -1388,6 +1444,7 @@ let active_task_owner_fiber_scan config ~executable_names =
       in
       {
         active_task_owner_without_executable_fibers = rows;
+        completion_authority_pending_tasks = pending_rows;
         non_keeper_active_task_owners = non_keeper_rows;
         active_task_owner_scan_errors = meta_read_errors;
       }
@@ -1513,6 +1570,10 @@ let keeper_fleet_safety_health_json
   let active_task_owner_without_executable_fiber =
     active_task_owner_without_executable_fiber_count > 0
   in
+  let completion_authority_pending_task_count =
+    List.length active_task_owner_scan.completion_authority_pending_tasks
+  in
+  let completion_authority_pending = completion_authority_pending_task_count > 0 in
   let phase_details =
     match phase_snapshot with
     | Some snapshot -> snapshot.phase_details
@@ -1662,6 +1723,19 @@ let keeper_fleet_safety_health_json
           (List.map
              active_task_owner_without_executable_fiber_json
              active_task_owner_scan.active_task_owner_without_executable_fibers) )
+    ; "completion_authority_pending", `Bool completion_authority_pending
+    ; ( "completion_authority_pending_task_count"
+      , `Int completion_authority_pending_task_count )
+    ; ( "completion_authority_pending_tasks"
+      , `List
+          (List.map
+             completion_authority_pending_task_json
+             active_task_owner_scan.completion_authority_pending_tasks) )
+    ; ( "completion_authority_pending_semantics"
+      , `String
+          "AwaitingVerification obligations awaiting a verdict from the system \
+           LLM completion-authority lane; producer ownership is retained for \
+           task identity but this row is never a Keeper fleet blocker" )
     ; ( "non_keeper_active_task_owner_count"
       , `Int non_keeper_active_task_owner_count )
     ; ( "non_keeper_active_task_owners"

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -1186,7 +1186,7 @@ type active_task_owner_without_executable_fiber = {
 type completion_authority_pending_task = {
   producer_agent_name : string;
   task_id : string;
-  task_status : string;
+  submitted_at : string;
   verification_id : string;
 }
 
@@ -1240,13 +1240,16 @@ type active_task_assignment =
   | Keeper_task_owner of { assignee : string; task_status : string }
   | Completion_authority_pending of {
       producer_agent_name : string;
+      submitted_at : string;
       verification_id : string;
     }
 
 let active_task_assignment (task : Masc_domain.task) =
   match task.task_status with
-  | Masc_domain.AwaitingVerification { assignee; verification_id; _ } ->
-      Some (Completion_authority_pending { producer_agent_name = assignee; verification_id })
+  | Masc_domain.AwaitingVerification { assignee; submitted_at; verification_id } ->
+      Some
+        (Completion_authority_pending
+           { producer_agent_name = assignee; submitted_at; verification_id })
   | task_status ->
       Masc_domain.task_assignee_of_status task_status
       |> Option.map (fun assignee ->
@@ -1277,7 +1280,7 @@ let completion_authority_pending_task_json row =
     [
       ("producer_agent_name", `String row.producer_agent_name);
       ("task_id", `String row.task_id);
-      ("task_status", `String row.task_status);
+      ("submitted_at", `String row.submitted_at);
       ("verification_id", `String row.verification_id);
       ("owner_kind", `String "system_llm_completion_authority");
       ("fleet_blocking", `Bool false);
@@ -1372,11 +1375,12 @@ let active_task_owner_fiber_scan config ~executable_names =
              (fun (pending_rows, blocking_rows, non_keeper_rows) task ->
              match active_task_assignment task with
              | None -> (pending_rows, blocking_rows, non_keeper_rows)
-             | Some (Completion_authority_pending { producer_agent_name; verification_id }) ->
+             | Some
+                 (Completion_authority_pending
+                    { producer_agent_name; submitted_at; verification_id }) ->
                  ( { producer_agent_name
                    ; task_id = task.id
-                   ; task_status =
-                       Workspace_task_schedule.task_status_label task.task_status
+                   ; submitted_at
                    ; verification_id
                    }
                    :: pending_rows

--- a/lib/tool_surface/tool_shard_types_schemas_taskboard.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_taskboard.ml
@@ -4,9 +4,10 @@ let taskboard_tools : Masc_domain.tool_schema list =
   [ { name = "keeper_tasks_list"
     ; description =
         "List tasks on the MASC backlog. Returns task_id, title, status, assignee, and \
-         priority for each task. For awaiting_verification, follow the rendered \
-         keeper_task_claim action before inspecting evidence; never Read producer \
-         sandbox paths directly."
+         priority for each task. For awaiting_verification, report that the task \
+         is pending a verdict from the system LLM agent at the \
+         completion-authority boundary and is not claimable by any Keeper; never \
+         Read producer sandbox paths directly."
     ; input_schema =
         `Assoc
           [ "type", `String "object"
@@ -15,8 +16,7 @@ let taskboard_tools : Masc_domain.tool_schema list =
                 [ ( "status"
                   , `Assoc
                       [ "type", `String "string"
-                      ; (* Issue #8354: derived from Masc_domain.task_status Variant SSOT.
-             Hand-rolled enum used to drop awaiting_verification. *)
+                      ; (* Derived from the Masc_domain.task_status Variant SSOT. *)
                         ( "enum"
                         , `List
                             (List.map
@@ -89,16 +89,17 @@ let taskboard_tools : Masc_domain.tool_schema list =
   ; { name = "keeper_task_claim"
     ; description =
         "Claim MASC backlog work. With no task_id, claims the next eligible \
-         unclaimed todo or awaiting_verification task that matches your capabilities. \
-         Claiming awaiting_verification atomically binds you in the Task FSM; only \
-         that winner receives the typed submitted_evidence snapshot and may issue the \
-         verdict. Never Read producer sandbox paths directly. With task_id, claims \
-         that exact task when a user, mention, board item, or keeper_tasks_list row \
-         identifies it. If you already own another Claimed/InProgress task, finish \
-         it with keeper_task_done or explicitly release it first; keeper_task_claim \
-         does not auto-release active work. If active_goal_ids are configured, the \
-         no-arg claim prefers goal-linked work and only widens when the scoped pool \
-         has no eligible task."
+         unclaimed todo task that matches your capabilities. \
+         awaiting_verification tasks are pending a verdict from the system LLM agent \
+         at the completion-authority boundary and are not claimable Keeper work. \
+         Never Read producer sandbox paths directly. \
+         With task_id, claims that exact task when a user, mention, board item, or \
+         keeper_tasks_list row identifies it; an awaiting_verification task returns \
+         the typed pending-verdict refusal. If you already own another \
+         Claimed/InProgress task, finish it with keeper_task_done or explicitly \
+         release it first; keeper_task_claim does not auto-release active work. If \
+         active_goal_ids are configured, the no-arg claim prefers goal-linked work \
+         and only widens when the scoped pool has no eligible task."
     ; input_schema =
         `Assoc
           [ "type", `String "object"

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -576,14 +576,14 @@ type task_claim_decision =
 let task_claim_readiness (_task : task) = Claim_ready
 ;;
 
-let task_claim_decision (task : task) =
-  match task.task_status with
+let task_claim_decision_for_status task_status =
+  match task_status with
   | Todo ->
     (* Todo tasks are always claimable regardless of reclaim_policy.
        reclaim_policy only gates Done -> re-claim, not Todo -> first claim.
        task-1869: 6 TaskError fingerprints show coordination-role tasks
        with Block_reclaim policy were blocked from claiming. *)
-    Claim_available (task_claim_readiness task)
+    Claim_available Claim_ready
   | AwaitingVerification { verification_id; _ } ->
     (* A pending obligation belongs to the completion-authority lane. No
        Keeper claim can grant verifier authority or inspect it as agent work. *)
@@ -597,7 +597,13 @@ let task_claim_decision (task : task) =
   | Claimed _
   | InProgress _
   | Cancelled _ ->
-    Claim_unavailable (Claim_block_not_todo task.task_status)
+    Claim_unavailable (Claim_block_not_todo task_status)
+;;
+
+let task_claim_decision (task : task) =
+  match task_claim_decision_for_status task.task_status with
+  | Claim_available Claim_ready -> Claim_available (task_claim_readiness task)
+  | Claim_unavailable block -> Claim_unavailable block
 ;;
 
 let task_claim_decision_is_available task =

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -249,7 +249,7 @@ let all_task_actions =
 let valid_task_action_strings = List.map task_action_to_string all_task_actions
 
 (** Provenance carried by a completion verdict. This type separates verdicts
-    from the agent task-action surface; it does not authenticate the embedded
+    from the Keeper task-action surface; it does not authenticate the embedded
     identity. The producer boundary must construct it only after authenticating
     an operator or accepting a typed system-LLM result. The system LLM agent
     is not a Keeper and has no Keeper lifecycle. *)
@@ -557,7 +557,8 @@ let task_requires_verification (t : task) =
 
 (* RFC-0323 G-10: the typed reclaim claim gate is retired. #23661 removed its
    Todo producer; this change removes the Done producer, so nothing can be
-   blocked-by-reclaim at claim time anymore. [reclaim_policy] survives as
+   blocked-by-reclaim at claim time anymore. Claim blocks now describe the
+   task-status fact that prevents an agent claim. [reclaim_policy] survives as
    release/cancel data plumbing only (its full retirement is a recorded
    follow-up decision, RFC-0323 Radius Map). *)
 
@@ -565,6 +566,7 @@ type task_claim_readiness =
   | Claim_ready
 
 type task_claim_block =
+  | Claim_block_pending_verdict of { verification_id : string }
   | Claim_block_not_todo of task_status
 
 type task_claim_decision =
@@ -583,11 +585,9 @@ let task_claim_decision (task : task) =
        with Block_reclaim policy were blocked from claiming. *)
     Claim_available (task_claim_readiness task)
   | AwaitingVerification { verification_id; _ } ->
-    (* Verification tasks with a valid verification_id can be claimed by
-       other agents for cross-agent verification dispatch. The actual
-       cross-agent check (self-verification block) happens in claim_task_r.
-       Issue #19314. verification_id is a non-empty string — always claimable. *)
-    Claim_available (task_claim_readiness task)
+    (* A pending obligation belongs to the completion-authority lane. No
+       Keeper claim can grant verifier authority or inspect it as agent work. *)
+    Claim_unavailable (Claim_block_pending_verdict { verification_id })
   | Done _
   (* RFC-0323: a verified Done is terminal for every actor, regardless of
      reclaim_policy — re-running completed work creates a NEW task linked via

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -205,6 +205,12 @@ type task_claim_decision =
   | Claim_available of task_claim_readiness
   | Claim_unavailable of task_claim_block
 
+val task_claim_decision_for_status :
+  task_status -> task_claim_decision
+(** Claim admission derived only from the persisted task status. This is the
+    status-level SSOT used by both the full-task projection and lifecycle
+    transitions. *)
+
 val task_claim_decision :
   task -> task_claim_decision
 (** Deterministic claim decision for queue/admission surfaces. An

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -194,9 +194,11 @@ type task_claim_readiness =
   | Claim_ready
 
 (** RFC-0323 G-10: the typed reclaim claim gate is retired (#23661 removed
-    the Todo producer, G-10 the Done producer) — only the status blocks a
-    claim now. [reclaim_policy] survives as release/cancel data plumbing. *)
+    the Todo producer, G-10 the Done producer). Claim blocks describe the
+    task-status fact that prevents an agent claim; [reclaim_policy] survives
+    as release/cancel data plumbing. *)
 type task_claim_block =
+  | Claim_block_pending_verdict of { verification_id : string }
   | Claim_block_not_todo of task_status
 
 type task_claim_decision =
@@ -205,7 +207,9 @@ type task_claim_decision =
 
 val task_claim_decision :
   task -> task_claim_decision
-(** Deterministic claim decision for queue/admission surfaces. *)
+(** Deterministic claim decision for queue/admission surfaces. An
+    [AwaitingVerification] task is unavailable to agents until a completion
+    authority commits its verdict. *)
 
 val task_claim_decision_is_available :
   task -> bool

--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -362,27 +362,6 @@ let notify_reject_verification
        ~notes:""
        ~timestamp:(Time_compat.now ()))
 
-let awaiting_verification_deadline
-      ~(submitted_at : string)
-      ~(deadline : string option)
-  =
-  match deadline with
-  | Some deadline ->
-    (match Masc_domain.parse_iso8601_opt deadline with
-     | Some deadline_ts -> Some ("deadline", deadline, deadline_ts)
-     | None -> None)
-  | None ->
-    (match Masc_domain.parse_iso8601_opt submitted_at with
-     | Some submitted_ts ->
-       let deadline_ts =
-         submitted_ts +. Env_config_runtime.Verification.timeout_deadline_seconds ()
-       in
-       Some
-         ( "submitted_at_fallback"
-         , Masc_domain.iso8601_of_unix_seconds deadline_ts
-         , deadline_ts )
-     | None -> None)
-
 (* RFC-0220 §5: the destructive 24h verification deadline rescue is removed.
    With the verification sub-state folded into [task_status] (RFC-0220 §3.1),
    the illegal Todo+Pending drift is unrepresentable. An

--- a/lib/workspace/workspace_task_lifecycle.ml
+++ b/lib/workspace/workspace_task_lifecycle.ml
@@ -1,7 +1,7 @@
 (** Pure Task lifecycle transition helper. Producers submit completion evidence
-    for verification; the terminal verdict is issued by a
-    [Masc_domain.completion_authority] through {!decide_verdict}, never by an
-    agent action. *)
+    for verification; the terminal verdict is issued by the configured system
+    LLM agent at the [Masc_domain.completion_authority] boundary (or by an
+    authenticated HITL operator), never by a Keeper action. *)
 
 type invalid =
   | Verification_submission_required

--- a/lib/workspace/workspace_task_lifecycle.ml
+++ b/lib/workspace/workspace_task_lifecycle.ml
@@ -38,20 +38,29 @@ type claim_resolution =
   | Held_pending_verdict of { verification_id : string }
 
 let resolve_claim ~same_actor ~agent_name ~now (task : Masc_domain.task) =
-  match task.task_status with
-  | Masc_domain.Todo ->
+  match Masc_domain.task_claim_decision_for_status task.task_status with
+  | Masc_domain.Claim_available Masc_domain.Claim_ready ->
     Worker_claim (Masc_domain.Claimed { assignee = agent_name; claimed_at = now })
-  | Masc_domain.AwaitingVerification { verification_id; _ } ->
+  | Masc_domain.Claim_unavailable
+      (Masc_domain.Claim_block_pending_verdict { verification_id }) ->
     (* No agent claims a pending obligation. The previous behaviour bound the
        claiming agent as its verifier, which is exactly how a Keeper acquired
        approval authority: claim was the authority-granting operation. The
        verdict now comes from a [completion_authority] out of band, so the
        obligation has no assignable satisfier and no keeper is offered it. *)
     Held_pending_verdict { verification_id }
-  | Masc_domain.Claimed { assignee; _ } | Masc_domain.InProgress { assignee; _ } ->
-    if same_actor assignee then Self_owned else Held_by_other assignee
-  | Masc_domain.Done _ -> Held_terminal task.task_status
-  | Masc_domain.Cancelled { cancelled_by; _ } -> Held_by_other cancelled_by
+  | Masc_domain.Claim_unavailable (Masc_domain.Claim_block_not_todo task_status) ->
+    (match task_status with
+     | Masc_domain.Claimed { assignee; _ }
+     | Masc_domain.InProgress { assignee; _ } ->
+       if same_actor assignee then Self_owned else Held_by_other assignee
+     | Masc_domain.Done _ -> Held_terminal task_status
+     | Masc_domain.Cancelled { cancelled_by; _ } -> Held_by_other cancelled_by
+     | Masc_domain.Todo | Masc_domain.AwaitingVerification _ ->
+       (* These constructors are not produced by the status-level decision for
+          this branch. Keep the match exhaustive so a future status addition
+          cannot silently widen claim admission. *)
+       Held_terminal task_status)
 ;;
 
 let decide
@@ -67,20 +76,27 @@ let decide
       ~reason
   =
   match action, task_status with
-  | Masc_domain.Claim, Masc_domain.Todo ->
-    ok
-      ~set_current:task_id
-      (Masc_domain.Claimed { assignee = agent_name; claimed_at = now })
-  | ( Masc_domain.Claim
-    , (Masc_domain.Claimed { assignee; _ } | Masc_domain.InProgress { assignee; _}) ) ->
-    if same_agent assignee then ok task_status else Error Invalid_transition
-  | Masc_domain.Claim, Masc_domain.Done _ -> ok task_status
-  | Masc_domain.Claim, Masc_domain.AwaitingVerification _ ->
-    (* Claiming an obligation used to bind the claimant as its verifier, so the
-       claim race decided who held approval authority. There is no such binding
-       now: the verdict comes from a [completion_authority] out of band. *)
-    Error Verification_pending_verdict
-  | Masc_domain.Claim, Masc_domain.Cancelled _ -> Error Invalid_transition
+  | Masc_domain.Claim, task_status ->
+    (match Masc_domain.task_claim_decision_for_status task_status with
+     | Masc_domain.Claim_available Masc_domain.Claim_ready ->
+       ok
+         ~set_current:task_id
+         (Masc_domain.Claimed { assignee = agent_name; claimed_at = now })
+     | Masc_domain.Claim_unavailable
+         (Masc_domain.Claim_block_pending_verdict _) ->
+       (* The completion authority is the system LLM boundary (or HITL), not
+          a Keeper that wins a claim race. *)
+       Error Verification_pending_verdict
+     | Masc_domain.Claim_unavailable
+         (Masc_domain.Claim_block_not_todo status) ->
+       (match status with
+        | Masc_domain.Claimed { assignee; _ }
+        | Masc_domain.InProgress { assignee; _ } ->
+          if same_agent assignee then ok status else Error Invalid_transition
+        | Masc_domain.Done _ -> ok status
+        | Masc_domain.Cancelled _ -> Error Invalid_transition
+        | Masc_domain.Todo | Masc_domain.AwaitingVerification _ ->
+          Error Invalid_transition))
   | Masc_domain.Start, Masc_domain.Claimed { assignee; _ } ->
     if same_agent assignee
     then

--- a/lib/workspace/workspace_task_lifecycle.mli
+++ b/lib/workspace/workspace_task_lifecycle.mli
@@ -1,7 +1,7 @@
 (** Pure Task lifecycle transition helper. Producers submit completion evidence
-    for verification; the terminal verdict is issued by a
-    [Masc_domain.completion_authority] through {!decide_verdict}, never by an
-    agent action. *)
+    for verification; the terminal verdict is issued by the configured system
+    LLM agent at the [Masc_domain.completion_authority] boundary (or by an
+    authenticated HITL operator), never by a Keeper action. *)
 
 type invalid =
   | Verification_submission_required
@@ -23,9 +23,9 @@ type claim_resolution =
   | Held_by_other of string
   | Held_terminal of Masc_domain.task_status
   | Held_pending_verdict of { verification_id : string }
-      (** Awaiting a completion authority's verdict. No agent may claim it: the
-          removed [Verifier_claim] made claiming the authority-granting
-          operation, so a keeper became the approver by winning a race. *)
+      (** Awaiting the system LLM agent or authenticated HITL completion
+          authority's verdict. No Keeper may claim it or gain verifier
+          authority by winning a race. *)
 
 val resolve_claim
   :  same_actor:(string -> bool)

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -2198,9 +2198,17 @@ let test_health_json_keeps_awaiting_verification_in_system_llm_lane () =
         Alcotest.(check string) "pending row preserves task id"
           "task-awaiting-system-llm-verdict"
           (pending_task |> member "task_id" |> to_string);
-        Alcotest.(check string) "pending row preserves status"
-          "awaiting_verification"
-          (pending_task |> member "task_status" |> to_string);
+        Alcotest.(check string) "pending row preserves submission time"
+          "2026-06-26T00:00:01Z"
+          (pending_task |> member "submitted_at" |> to_string);
+        let pending_task_fields =
+          match pending_task with
+          | `Assoc fields -> fields
+          | _ -> Alcotest.fail "pending task row must be a JSON object"
+        in
+        Alcotest.(check bool) "pending row does not duplicate status"
+          false
+          (List.mem_assoc "task_status" pending_task_fields);
         Alcotest.(check string) "pending row preserves verification id"
           "verification-system-llm-001"
           (pending_task |> member "verification_id" |> to_string);

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -2105,8 +2105,8 @@ let test_health_json_degrades_on_active_task_owner_without_keeper_binding () =
         Alcotest.(check bool) "health asks operator action" true
           (fleet_safety |> member "operator_action_required" |> to_bool)))
 
-let test_health_json_excludes_awaiting_verification_from_keeper_fleet_scan () =
-  with_temp_dir "health-awaiting-verification-not-keeper-work" (fun dir ->
+let test_health_json_keeps_awaiting_verification_in_system_llm_lane () =
+  with_temp_dir "health-awaiting-verification-system-llm" (fun dir ->
     let config_root = make_config_root dir in
     Sys.remove (Filename.concat (Filename.concat config_root "keepers") "example.toml");
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
@@ -2120,40 +2120,101 @@ let test_health_json_excludes_awaiting_verification_from_keeper_fleet_scan () =
         let state = Mcp_server.For_testing.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
         let config = Mcp_server.workspace_config state in
-        let assignee = "keeper-awaiting-verification-agent" in
         let task =
           make_task
-            ~id:"task-awaiting-verification"
-            ~title:"System authority owns the verdict"
+            ~id:"task-awaiting-system-llm-verdict"
+            ~title:"Task awaiting system LLM completion verdict"
             ~status:
               (Types.AwaitingVerification
-                 { assignee
-                 ; submitted_at = "2026-06-26T00:00:01Z"
-                 ; verification_id = "vrf-system-authority"
+                 {
+                   assignee = "producer-agent";
+                   submitted_at = "2026-06-26T00:00:01Z";
+                   verification_id = "verification-system-llm-001";
                  })
             ()
         in
         Workspace.write_backlog config
           { Types.tasks = [ task ]; last_updated = "2026-06-26T00:00:02Z"; version = 2 };
-        let request = Httpun.Request.create `GET "/health" in
-        let json = Server_routes_http_runtime.make_health_json request in
+        let phase_counts :
+            Server_routes_http_runtime_fleet_scan.keeper_phase_counts =
+          { running = 0; failing = 0; recovering = 0 }
+        in
+        let phase_snapshot :
+            Server_routes_http_runtime_fleet_scan.keeper_phase_snapshot =
+          {
+            counts = phase_counts;
+            running_names = [];
+            recovering_names = [];
+            phase_values = [];
+            phase_details = [];
+          }
+        in
+        let execution_snapshot :
+            Server_routes_http_runtime_fleet_scan.keeper_execution_snapshot =
+          { owners = []; executable_names = [] }
+        in
+        let fleet_safety =
+          Server_routes_http_runtime_fleet_scan.keeper_fleet_safety_health_json
+            ~bootable_names:[]
+            ~autoboot_scan:
+              Server_routes_http_runtime_fleet_scan.empty_autoboot_keeper_scan
+            ~phase_snapshot
+            ~execution_snapshot
+            ~phase_counts
+            ~paused_keepers_json:(`Assoc [ ("count", `Int 0) ])
+            ()
+        in
         let open Yojson.Safe.Util in
-        let fleet_safety = json |> member "keeper_fleet_safety" in
-        Alcotest.(check string) "awaiting verification does not degrade fleet" "ok"
+        Alcotest.(check string) "pending verdict does not degrade Keeper fleet"
+          "ok"
           (fleet_safety |> member "status" |> to_string);
-        Alcotest.(check (option string)) "awaiting verification has no fleet blocker" None
+        Alcotest.(check (option string)) "pending verdict is not a Keeper blocker"
+          None
           (fleet_safety |> member "blocker" |> to_string_option);
-        Alcotest.(check bool) "awaiting verification is not keeper work" false
+        Alcotest.(check bool) "pending verdict is absent from Keeper blocker flag"
+          false
           (fleet_safety
            |> member "active_task_owner_without_executable_fiber"
            |> to_bool);
-        Alcotest.(check int) "awaiting verification produces no keeper owner rows" 0
+        Alcotest.(check int) "pending verdict has no Keeper blocker rows" 0
           (fleet_safety
            |> member "active_task_owner_without_executable_fiber_count"
            |> to_int);
-        Alcotest.(check bool) "awaiting verification does not ask fleet action" false
+        Alcotest.(check bool) "system LLM pending flag" true
+          (fleet_safety |> member "completion_authority_pending" |> to_bool);
+        Alcotest.(check int) "one completion authority pending row" 1
+          (fleet_safety
+           |> member "completion_authority_pending_task_count"
+           |> to_int);
+        let pending_tasks =
+          fleet_safety |> member "completion_authority_pending_tasks" |> to_list
+        in
+        Alcotest.(check int) "one exact pending task row" 1
+          (List.length pending_tasks);
+        let pending_task = List.hd pending_tasks in
+        Alcotest.(check string) "pending row preserves producer"
+          "producer-agent"
+          (pending_task |> member "producer_agent_name" |> to_string);
+        Alcotest.(check string) "pending row preserves task id"
+          "task-awaiting-system-llm-verdict"
+          (pending_task |> member "task_id" |> to_string);
+        Alcotest.(check string) "pending row preserves status"
+          "awaiting_verification"
+          (pending_task |> member "task_status" |> to_string);
+        Alcotest.(check string) "pending row preserves verification id"
+          "verification-system-llm-001"
+          (pending_task |> member "verification_id" |> to_string);
+        Alcotest.(check string) "pending row identifies system LLM authority"
+          "system_llm_completion_authority"
+          (pending_task |> member "owner_kind" |> to_string);
+        Alcotest.(check bool) "pending row cannot block Keeper fleet" false
+          (pending_task |> member "fleet_blocking" |> to_bool);
+        Alcotest.(check string) "pending row waits for system LLM verdict"
+          "await_system_llm_verdict"
+          (pending_task |> member "action" |> to_string);
+        Alcotest.(check bool) "pending verdict does not ask Keeper operator action"
+          false
           (fleet_safety |> member "operator_action_required" |> to_bool)))
-
 let test_health_json_reports_non_keeper_active_task_owner_as_advisory () =
   with_temp_dir "health-non-keeper-active-task-owner" (fun dir ->
     let config_root = make_config_root dir in
@@ -5141,6 +5202,10 @@ let () =
             "health json reports dormant task owner as advisory"
             `Quick
             test_health_json_reports_dormant_task_owner_as_advisory;
+          Alcotest.test_case
+            "health json keeps awaiting verification in system LLM lane"
+            `Quick
+            test_health_json_keeps_awaiting_verification_in_system_llm_lane;
           Alcotest.test_case
             "health json ignores stale active task alias when agent executable"
             `Quick

--- a/test/test_tool_shard_coverage.ml
+++ b/test/test_tool_shard_coverage.ml
@@ -165,6 +165,32 @@ let test_board_tools () =
     ]
 ;;
 
+let test_taskboard_verification_claim_contract () =
+  let list_schema =
+    schema_by_name "keeper_tasks_list" Tool_shard_types.taskboard_tools
+  in
+  let claim_schema =
+    schema_by_name "keeper_task_claim" Tool_shard_types.taskboard_tools
+  in
+  let descriptions = list_schema.description ^ "\n" ^ claim_schema.description in
+  Alcotest.(check bool)
+    "awaiting verification is described as pending"
+    true
+    (contains descriptions "pending a verdict from the system LLM agent");
+  Alcotest.(check bool)
+    "awaiting verification is described as not claimable"
+    true
+    (contains descriptions "not claimable");
+  Alcotest.(check bool)
+    "obsolete verifier-by-claiming affordance absent"
+    false
+    (contains descriptions "may issue the verdict");
+  Alcotest.(check bool)
+    "obsolete awaiting claim-pool affordance absent"
+    false
+    (contains descriptions "unclaimed todo or awaiting_verification task")
+;;
+
 let test_keeper_board_post_schema_supports_judgment () =
   let schema = schema_by_name "keeper_board_post" Tool_shard.board_tools in
   match get_json_assoc "properties" schema.input_schema with
@@ -248,6 +274,10 @@ let () =
             `Quick
             test_context_status_description_matches_current_output
         ; Alcotest.test_case "board tools" `Quick test_board_tools
+        ; Alcotest.test_case
+            "taskboard verification claim contract"
+            `Quick
+            test_taskboard_verification_claim_contract
         ; Alcotest.test_case
             "board post judgment"
             `Quick

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -1414,6 +1414,9 @@ let test_task_reclaim_gate_ignores_free_text_without_policy () =
   } in
   match Masc_domain.task_claim_decision t with
   | Masc_domain.Claim_available Masc_domain.Claim_ready -> ()
+  | Masc_domain.Claim_unavailable
+      (Masc_domain.Claim_block_pending_verdict _) ->
+    fail "todo task must not be blocked by a pending verdict"
   | Masc_domain.Claim_unavailable (Masc_domain.Claim_block_not_todo _) ->
     fail "do_not_reclaim_reason should not influence claim readiness"
 
@@ -1436,8 +1439,55 @@ let test_task_reclaim_gate_blocks_only_typed_policy () =
   } in
   match Masc_domain.task_claim_decision t with
   | Masc_domain.Claim_available Masc_domain.Claim_ready -> ()
+  | Masc_domain.Claim_unavailable
+      (Masc_domain.Claim_block_pending_verdict _) ->
+    fail "todo task must not be blocked by a pending verdict"
   | Masc_domain.Claim_unavailable (Masc_domain.Claim_block_not_todo _) ->
     fail "claim-ready task must stay claimable regardless of reclaim policy"
+
+let test_task_claim_awaiting_verification_is_pending_verdict () =
+  let t : Masc_domain.task = {
+    id = "task-006";
+    title = "Pending verdict";
+    description = "";
+    task_status = Masc_domain.AwaitingVerification {
+      assignee = "producer";
+      submitted_at = "2026-07-13T00:00:00Z";
+      verification_id = "vrf-006";
+    };
+    priority = 1;
+    files = [];
+    created_at = "2026-07-13T00:00:00Z";
+    created_by = None;
+    predecessor_task_id = None;
+    contract = None;
+    handoff_context = None;
+    cycle_count = 0;
+    reclaim_policy = None;
+    do_not_reclaim_reason = None;
+  } in
+  (match Masc_domain.task_claim_decision t with
+   | Masc_domain.Claim_unavailable
+       (Masc_domain.Claim_block_pending_verdict { verification_id }) ->
+     check string "verification id" "vrf-006" verification_id
+   | Masc_domain.Claim_available _
+   | Masc_domain.Claim_unavailable (Masc_domain.Claim_block_not_todo _) ->
+     fail "awaiting_verification must be blocked by its pending verdict");
+  check bool
+    "awaiting_verification is not claim-ready"
+    false
+    (Masc_domain.task_claim_decision_is_available t);
+  match Masc_domain.task_claim_next_action t with
+  | Masc_domain.Skip_claim
+      (Masc_domain.Claim_block_pending_verdict { verification_id }) ->
+    check string "next action verification id" "vrf-006" verification_id;
+    check bool
+      "awaiting_verification is not claimable"
+      false
+      (Masc_domain.task_claim_next_action_is_claimable t)
+  | Masc_domain.Claim_now
+  | Masc_domain.Skip_claim (Masc_domain.Claim_block_not_todo _) ->
+    fail "awaiting_verification must not enter the claim action"
 
 
 
@@ -1467,6 +1517,9 @@ let test_task_claim_next_action_todo_policy_block_still_claims () =
   match Masc_domain.task_claim_next_action t with
   | Masc_domain.Claim_now ->
     check bool "claimable" true (Masc_domain.task_claim_next_action_is_claimable t)
+  | Masc_domain.Skip_claim
+      (Masc_domain.Claim_block_pending_verdict _) ->
+    fail "todo task should not be classified as pending verdict"
   | Masc_domain.Skip_claim (Masc_domain.Claim_block_not_todo _) ->
     fail "todo task should not be classified as not-todo"
 
@@ -1726,5 +1779,9 @@ let () =
       test_case "of_yojson error" `Quick test_task_of_yojson_error;
       test_case "claim next action: todo stays claimable under policy block" `Quick
         test_task_claim_next_action_todo_policy_block_still_claims;
+    ];
+    "task_claim", [
+      test_case "awaiting verification waits for verdict" `Quick
+        test_task_claim_awaiting_verification_is_pending_verdict;
     ];
   ]


### PR DESCRIPTION
## Summary

Closes #26598.

- make `AwaitingVerification` unavailable to Keeper claim admission through one typed status-level decision SSOT, `Claim_block_pending_verdict { verification_id }`;
- keep claim admission, explicit claim, and auto-claim aligned: no Keeper or Keeper claim race can acquire verdict authority;
- remove the stale `keeper_tasks_list` / `keeper_task_claim` verifier-by-claiming affordance;
- classify `AwaitingVerification` by its typed status constructor in fleet health, preserving producer, task, raw `submitted_at`, and verification identity in a separate system-LLM completion-authority pending row;
- remove the retired verification deadline helper and configuration knob, correct RFC-0220's withdrawn status, and refresh the generated runtime-tunables SSOT;
- add typed claim, public schema, and runtime fleet regression coverage.

This is MASC-only. It does not change OAS or the MASC -> OAS dependency pin. The deployed `.masc` runtime is not changed by this PR.

Important boundary:

- MASC now prevents Keeper admission and exposes the pending system-LLM lane; it does not claim that an Auto_judge task-verdict producer already exists. Current production verdict production remains the authenticated HITL route; wiring a typed Auto_judge producer is tracked in #26447.
- Typed post-commit authority provenance is implemented in the separate Draft follow-up [#26609](https://github.com/jeong-sik/masc/pull/26609), head `084270c26b`.

## Validation

- `MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_server_runtime_bootstrap.exe` — pass
- `test_server_runtime_bootstrap.exe test bootstrap 36` — pass
- `test_workspace_task_lifecycle.exe` — pass
- `test_tool_shard_coverage.exe` — 11/11 pass
- `test_types_coverage.exe` — new task-claim coverage passes; pre-existing #26218 `NotClaimed` wording failure remains
- `opam exec -- dune exec --root . ./bin/env_knob_catalog.exe -- docs/runtime-tunables.md` — deterministic 207-entry output; generated diff committed in `c23442653d`
- `git diff --check` and `ocamlformat --check` — pass

Draft for CI and adversarial review.
