### PR TITLE
refactor(web): parse HTML and RSS with Markup

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -106,6 +106,7 @@
   (qcheck-alcotest (and :with-test (>= 0.21)))
   (bisect_ppx (and :with-test (>= 2.8)))
   (mtime (>= 2.0))
+  (markup (>= 1.0.3))
   (uuidm (>= 0.9.10))
   ; RFC-0004 Phase A0.1 typed SSE event library (lib/sse_event/).
   ; atdgen runs at build-time (codegen for sse_event.atd →

--- a/lib/dune
+++ b/lib/dune
@@ -23,6 +23,7 @@
   re.str
   str
   re.pcre
+  masc.markup_document
   mirage-crypto
   mirage-crypto-ec
   mirage-crypto-rng

--- a/lib/markup_document/dune
+++ b/lib/markup_document/dune
@@ -1,0 +1,8 @@
+(include_subdirs no)
+
+(library
+ (name masc_markup_document)
+ (public_name masc.markup_document)
+ (wrapped false)
+ (modules markup_document)
+ (libraries markup))

--- a/lib/markup_document/markup_document.ml
+++ b/lib/markup_document/markup_document.ml
@@ -1,0 +1,79 @@
+type t =
+  | Text of string
+  | Element of {
+      namespace : string;
+      name : string;
+      attributes : (string * string) list;
+      children : t list;
+    }
+
+let node_of_text parts = Text (String.concat "" parts)
+
+let node_of_element (namespace, name) attributes children =
+  let attributes =
+    List.map (fun ((_, name), value) -> name, value) attributes
+  in
+  Element { namespace; name; attributes; children }
+
+let trees signals =
+  Markup.trees ~text:node_of_text ~element:node_of_element signals
+  |> Markup.to_list
+
+let parse_html source =
+  source |> Markup.string |> Markup.parse_html |> Markup.signals |> trees
+
+let parse_xml source =
+  source
+  |> Markup.string
+  |> Markup.parse_xml ~context:`Document ~entity:Markup.xhtml_entity
+  |> Markup.signals
+  |> trees
+
+let rec text_content = function
+  | Text value -> value
+  | Element { children; _ } ->
+    children |> List.map text_content |> String.concat ""
+
+let attribute key = function
+  | Text _ -> None
+  | Element { attributes; _ } -> List.assoc_opt key attributes
+
+let rec elements_named name nodes =
+  List.concat_map
+    (function
+      | Text _ -> []
+      | (Element element as node) ->
+        let nested = elements_named name element.children in
+        if String.equal element.name name then node :: nested else nested)
+    nodes
+
+let rec first_element_named name = function
+  | [] -> None
+  | Text _ :: rest -> first_element_named name rest
+  | (Element element as node) :: rest ->
+    if String.equal element.name name
+    then Some node
+    else (
+      match first_element_named name element.children with
+      | Some _ as found -> found
+      | None -> first_element_named name rest)
+
+let html_space_tokens value =
+  let is_html_space = function
+    | ' ' | '\t' | '\n' | '\012' | '\r' -> true
+    | _ -> false
+  in
+  let buffer = Buffer.create 16 in
+  let tokens = ref [] in
+  let flush () =
+    if Buffer.length buffer > 0
+    then (
+      tokens := Buffer.contents buffer :: !tokens;
+      Buffer.clear buffer)
+  in
+  String.iter
+    (fun character ->
+       if is_html_space character then flush () else Buffer.add_char buffer character)
+    value;
+  flush ();
+  List.rev !tokens

--- a/lib/markup_document/markup_document.mli
+++ b/lib/markup_document/markup_document.mli
@@ -1,0 +1,23 @@
+(** Standards-parsed HTML/XML document tree shared by web surfaces. *)
+
+type t =
+  | Text of string
+  | Element of {
+      namespace : string;
+      name : string;
+      attributes : (string * string) list;
+      children : t list;
+    }
+
+val parse_html : string -> t list
+(** Parse an HTML5 document or fragment with Markup.ml error recovery. *)
+
+val parse_xml : string -> t list
+(** Parse an XML document with Markup.ml entity, namespace, and CDATA handling. *)
+
+val text_content : t -> string
+val attribute : string -> t -> string option
+val elements_named : string -> t list -> t list
+val first_element_named : string -> t list -> t option
+val html_space_tokens : string -> string list
+(** Split an HTML token-list attribute on the five ASCII whitespace bytes. *)

--- a/lib/server/dune
+++ b/lib/server/dune
@@ -13,6 +13,7 @@
  (flags :standard -open Masc)
  (libraries
   masc
+  masc.markup_document
   masc.dashboard
   masc.fd_accountant
   masc.event_bus_slots

--- a/lib/server/server_dashboard_http_link_preview.ml
+++ b/lib/server/server_dashboard_http_link_preview.ml
@@ -54,30 +54,6 @@ let with_cache_state preview cache_state =
   | `Assoc fields -> `Assoc (assoc_upsert fields "cache_state" (`String cache_state))
   | _ -> preview
 
-(* Static replacement table — both the entity needles and the
-   compiled regexes are fixed.  Old form rebuilt 7 [Re.t] DFAs per
-   [decode_html_entities] call; on a meta-rich page [normalize_text]
-   fires per [meta_content]/[link_href] hit, so a typical preview
-   parse paid dozens of unnecessary compilations. *)
-let html_entity_replacements =
-  [
-    ("&amp;", "&");
-    ("&quot;", "\"");
-    ("&#39;", "'");
-    ("&apos;", "'");
-    ("&lt;", "<");
-    ("&gt;", ">");
-    ("&nbsp;", " ");
-  ]
-  |> List.map (fun (needle, replacement) ->
-       (Re.compile (Re.str needle), replacement))
-
-let decode_html_entities value =
-  List.fold_left
-    (fun acc (re, replacement) ->
-      Re.replace_string re ~all:true ~by:replacement acc)
-    value html_entity_replacements
-
 (* Static whitespace-collapse PCRE, hoisted out of the per-call hot
    path that runs once per normalised meta value. *)
 let whitespace_collapse_re =
@@ -89,7 +65,7 @@ let collapse_whitespace value =
   |> String.trim
 
 let normalize_text value =
-  value |> decode_html_entities |> collapse_whitespace |> String_util.trim_to_option
+  value |> collapse_whitespace |> String_util.trim_to_option
 
 let is_http_scheme = function
   | Some "http" | Some "https" -> true
@@ -184,84 +160,36 @@ let infer_image_url url =
   let lower = String.lowercase_ascii url in
   List.exists (fun ext -> Filename.check_suffix lower ext) image_extensions
 
-(* Static [<head>...</head>] extractor — every link-preview parse hit
-   the per-call [Re.compile] before this hoist. *)
-let head_fragment_re =
-  Re.Pcre.re ~flags:[ `CASELESS; `DOTALL ] "<head[^>]*>(.*?)</head>"
-  |> Re.compile
+let meta_content nodes attr key =
+  Markup_document.elements_named "meta" nodes
+  |> List.find_map (fun node ->
+         match
+           Markup_document.attribute attr node,
+           Markup_document.attribute "content" node
+         with
+         | Some actual, Some content when String.equal (lower_trim actual) key ->
+           normalize_text content
+         | _ -> None)
 
-let first_head_fragment body =
-  match Re.exec_opt head_fragment_re body with
-  | Some groups -> Re.Group.get groups 1
-  | None -> String.sub body 0 (min (String.length body) max_html_chars)
+let link_href nodes rel_value =
+  Markup_document.elements_named "link" nodes
+  |> List.find_map (fun node ->
+         match
+           Markup_document.attribute "rel" node,
+           Markup_document.attribute "href" node
+         with
+         | Some rel, Some href
+           when rel |> Markup_document.html_space_tokens
+                |> List.exists (fun value -> String.equal (lower_trim value) rel_value) ->
+           normalize_text href
+         | _ -> None)
 
-(* Pattern cache for [first_match].  Patterns are constructed dynamically
-   per call site (via [Printf.sprintf] inside [meta_content]/[link_href])
-   but the [attr]/[key]/[rel_value] inputs are drawn from a fixed
-   OG/Twitter/HTML vocabulary, so the unique-pattern set across a process
-   lifetime is ≤30.  Caching collapses repeat link-preview calls to a
-   single PCRE compile per distinct pattern.
-
-   [Stdlib.Mutex] (not [Eio.Mutex]) is correct here: the dashboard HTTP
-   handler may run across multiple Eio domains, and we never block
-   inside the critical section.  The compile itself happens outside the
-   lock — [Re.compile] is pure, so a racing duplicate compile is
-   harmless: both fibers produce structurally identical [Re.re] values
-   and last-writer-wins gives the same observable result. *)
-let pattern_cache : (string, Re.re) Hashtbl.t = Hashtbl.create 32
-let pattern_cache_mu = Mutex.create ()
-
-let get_or_compile_pattern pattern =
-  Mutex.lock pattern_cache_mu;
-  let cached = Hashtbl.find_opt pattern_cache pattern in
-  Mutex.unlock pattern_cache_mu;
-  match cached with
-  | Some re -> re
-  | None ->
-    let re = Re.Pcre.re ~flags:[ `CASELESS; `DOTALL ] pattern |> Re.compile in
-    Mutex.lock pattern_cache_mu;
-    Hashtbl.replace pattern_cache pattern re;
-    Mutex.unlock pattern_cache_mu;
-    re
-
-let first_match body pattern =
-  let re = get_or_compile_pattern pattern in
-  match Re.exec_opt re body with
-  | Some groups -> normalize_text (Re.Group.get groups 1)
-  | None -> None
-
-let meta_content head attr key =
-  let quoted value =
-    Printf.sprintf
-      "<meta[^>]+%s\\s*=\\s*['\"]%s['\"][^>]+content\\s*=\\s*['\"]([^'\"]+)['\"][^>]*>"
-      attr value
+let title_tag nodes =
+  let title =
+    Markup_document.first_element_named "title" nodes
+    |> Option.map Markup_document.text_content
   in
-  let reversed value =
-    Printf.sprintf
-      "<meta[^>]+content\\s*=\\s*['\"]([^'\"]+)['\"][^>]+%s\\s*=\\s*['\"]%s['\"][^>]*>"
-      attr value
-  in
-  match first_match head (quoted key) with
-  | Some _ as value -> value
-  | None -> first_match head (reversed key)
-
-let link_href head rel_value =
-  let pattern =
-    Printf.sprintf
-      "<link[^>]+rel\\s*=\\s*['\"][^'\"]*%s[^'\"]*['\"][^>]+href\\s*=\\s*['\"]([^'\"]+)['\"][^>]*>"
-      rel_value
-  in
-  let reversed =
-    Printf.sprintf
-      "<link[^>]+href\\s*=\\s*['\"]([^'\"]+)['\"][^>]+rel\\s*=\\s*['\"][^'\"]*%s[^'\"]*['\"][^>]*>"
-      rel_value
-  in
-  match first_match head pattern with
-  | Some _ as value -> value
-  | None -> first_match head reversed
-
-let title_tag head =
-  first_match head "<title[^>]*>(.*?)</title>"
+  Option.bind title normalize_text
 
 let resolve_relative_url ~base_url value =
   let base_uri = Uri.of_string base_url in
@@ -274,7 +202,10 @@ let default_favicon_url url =
   |> Uri.to_string
 
 let extract_html_preview_fields ~url body =
-  let head = first_head_fragment body in
+  let head =
+    String.sub body 0 (min (String.length body) max_html_chars)
+    |> Markup_document.parse_html
+  in
   let title =
     match meta_content head "property" "og:title" with
     | Some _ as value -> value

--- a/lib/tool_misc_web_fetch.ml
+++ b/lib/tool_misc_web_fetch.ml
@@ -64,61 +64,33 @@ let extract_mode_of_string raw =
 
 let default_extract_mode = Markdown
 
-(** Extract <title> from HTML *)
-let title_tag_re =
-  Re.Pcre.re ~flags:[ `CASELESS; `DOTALL ] "<title[^>]*>(.*?)</title>"
-  |> Re.compile
-
 let extract_title html =
-  match Re.exec_opt title_tag_re html with
-  | Some groups ->
-      let raw = Re.Group.get groups 1 in
-      let cleaned = Tool_misc_web_search.clean_search_text raw in
-      if String.equal cleaned "" then None else Some cleaned
-  | None -> None
+  let title =
+    Markup_document.parse_html html
+    |> Markup_document.first_element_named "title"
+    |> Option.map Markup_document.text_content
+  in
+  Option.bind title String_util.trim_nonempty
 
-(** Extract <meta name="description"> or og:description from HTML *)
-let meta_description_re =
-  Re.Pcre.re
-    ~flags:[ `CASELESS; `DOTALL ]
-    "<meta[^>]+name\\s*=\\s*['\"]description['\"][^>]+content\\s*=\\s*['\"]([^'\"]+)['\"][^>]*>"
-  |> Re.compile
-
-let meta_description_reversed_re =
-  Re.Pcre.re
-    ~flags:[ `CASELESS; `DOTALL ]
-    "<meta[^>]+content\\s*=\\s*['\"]([^'\"]+)['\"][^>]+name\\s*=\\s*['\"]description['\"][^>]*>"
-  |> Re.compile
-
-let og_description_re =
-  Re.Pcre.re
-    ~flags:[ `CASELESS; `DOTALL ]
-    "<meta[^>]+property\\s*=\\s*['\"]og:description['\"][^>]+content\\s*=\\s*['\"]([^'\"]+)['\"][^>]*>"
-  |> Re.compile
-
-let og_description_reversed_re =
-  Re.Pcre.re
-    ~flags:[ `CASELESS; `DOTALL ]
-    "<meta[^>]+content\\s*=\\s*['\"]([^'\"]+)['\"][^>]+property\\s*=\\s*['\"]og:description['\"][^>]*>"
-  |> Re.compile
-
-let first_match html pattern =
-  match Re.exec_opt pattern html with
-  | Some groups ->
-      let cleaned = Tool_misc_web_search.clean_search_text (Re.Group.get groups 1) in
-      if String.equal cleaned "" then None else Some cleaned
-  | None -> None
+let meta_content nodes attribute value =
+  Markup_document.elements_named "meta" nodes
+  |> List.find_map (fun node ->
+         match
+           Markup_document.attribute attribute node,
+           Markup_document.attribute "content" node
+         with
+         | Some actual, Some content
+           when String.equal
+                  (String.lowercase_ascii (String.trim actual))
+                  value ->
+           String_util.trim_nonempty content
+         | _ -> None)
 
 let extract_description html =
-  match first_match html og_description_re with
-  | Some _ as value -> value
-  | None -> (
-      match first_match html og_description_reversed_re with
-      | Some _ as value -> value
-      | None -> (
-          match first_match html meta_description_re with
-          | Some _ as value -> value
-          | None -> first_match html meta_description_reversed_re))
+  let nodes = Markup_document.parse_html html in
+  match meta_content nodes "property" "og:description" with
+  | Some _ as description -> description
+  | None -> meta_content nodes "name" "description"
 
 (** URL validation *)
 let valid_url url =
@@ -138,141 +110,52 @@ let ends_with ~suffix value =
        (String.sub value (value_length - suffix_length) suffix_length)
        suffix
 
-let html_block_re tag =
-  Re.Pcre.re
-    ~flags:[ `CASELESS; `DOTALL ]
-    (Printf.sprintf "<%s\\b[^>]*>[\\s\\S]*?</%s>" tag tag)
-  |> Re.compile
-
-let remove_html_noise_res =
-  List.map html_block_re
-    [ "script"; "style"; "noscript"; "svg"; "canvas"; "template"; "iframe" ]
-
-let remove_boilerplate_res =
-  List.map html_block_re [ "nav"; "footer"; "aside"; "form" ]
-
-let html_comment_re =
-  Re.Pcre.re ~flags:[ `DOTALL ] "<!--[\\s\\S]*?-->" |> Re.compile
-
-let article_re =
-  Re.Pcre.re ~flags:[ `CASELESS; `DOTALL ] "<article\\b[^>]*>([\\s\\S]*?)</article>"
-  |> Re.compile
-
-let main_re =
-  Re.Pcre.re ~flags:[ `CASELESS; `DOTALL ] "<main\\b[^>]*>([\\s\\S]*?)</main>"
-  |> Re.compile
-
-let body_re =
-  Re.Pcre.re ~flags:[ `CASELESS; `DOTALL ] "<body\\b[^>]*>([\\s\\S]*?)</body>"
-  |> Re.compile
-
-let heading_re =
-  Re.Pcre.re ~flags:[ `CASELESS; `DOTALL ] "<h([1-6])\\b[^>]*>([\\s\\S]*?)</h[1-6]>"
-  |> Re.compile
-
-let link_re =
-  Re.Pcre.re
-    ~flags:[ `CASELESS; `DOTALL ]
-    "<a\\b[^>]*href\\s*=\\s*['\"]([^'\"]+)['\"][^>]*>([\\s\\S]*?)</a>"
-  |> Re.compile
-
-let paragraph_open_re = Re.Pcre.re ~flags:[ `CASELESS ] "<p\\b[^>]*>" |> Re.compile
-let paragraph_close_re = Re.Pcre.re ~flags:[ `CASELESS ] "</p>" |> Re.compile
-let br_re = Re.Pcre.re ~flags:[ `CASELESS ] "<br\\s*/?>" |> Re.compile
-let li_open_re = Re.Pcre.re ~flags:[ `CASELESS ] "<li\\b[^>]*>" |> Re.compile
-let li_close_re = Re.Pcre.re ~flags:[ `CASELESS ] "</li>" |> Re.compile
-let block_open_re =
-  Re.Pcre.re ~flags:[ `CASELESS ] "<(div|section|tr|table|ul|ol)\\b[^>]*>"
-  |> Re.compile
-let block_close_re =
-  Re.Pcre.re ~flags:[ `CASELESS ] "</(div|section|tr|table|ul|ol)>"
-  |> Re.compile
-let residual_tag_re = Re.Pcre.re "<[^>]+>" |> Re.compile
 let horizontal_space_re = Re.Pcre.re "[ \t\r]+" |> Re.compile
 let blank_lines_re = Re.Pcre.re "\n{3,}" |> Re.compile
 
-let html_entity_replacements =
-  [
-    ("&amp;", "&");
-    ("&lt;", "<");
-    ("&gt;", ">");
-    ("&quot;", "\"");
-    ("&#39;", "'");
-    ("&#039;", "'");
-    ("&apos;", "'");
-    ("&nbsp;", " ");
-  ]
-  |> List.map (fun (entity, replacement) ->
-         (Re.str entity |> Re.compile, replacement))
-
-let decode_html_entities text =
+let longest_nonempty nodes =
   List.fold_left
-    (fun acc (entity_re, replacement) ->
-      Re.replace_string entity_re ~by:replacement acc)
-    text
-    html_entity_replacements
-
-let strip_noise html =
-  remove_html_noise_res
-  |> List.fold_left
-       (fun acc re -> Re.replace_string re ~by:"" acc)
-       (Re.replace_string html_comment_re ~by:"" html)
-
-let longest_nonempty blocks =
-  List.fold_left
-    (fun best block ->
-      let candidate = String.trim block in
+    (fun best node ->
+      let candidate = Markup_document.text_content node |> String.trim in
       if String.equal candidate "" then best
       else
         match best with
-        | None -> Some candidate
-        | Some current ->
-            if String.length candidate > String.length current then Some candidate
-            else best)
+        | None -> Some (node, String.length candidate)
+        | Some (_, current_length) ->
+          if String.length candidate > current_length
+          then Some (node, String.length candidate)
+          else best)
     None
-    blocks
+    nodes
 
-let first_group pattern html =
-  Re.all pattern html |> List.map (fun groups -> Re.Group.get groups 1)
+let ignored_elements =
+  [ "script"; "style"; "noscript"; "svg"; "canvas"; "template"; "iframe"
+  ; "nav"; "footer"; "aside"; "form"
+  ]
 
-let select_readable_html html =
-  let html = strip_noise html in
+let rec prune_node = function
+  | Markup_document.Text _ as node -> Some node
+  | Markup_document.Element element ->
+    if List.mem element.name ignored_elements then None
+    else
+      Some
+        (Markup_document.Element
+           { element with children = List.filter_map prune_node element.children })
+
+let select_readable_nodes html =
+  let document = Markup_document.parse_html html in
   let selected, source =
-    match longest_nonempty (first_group article_re html) with
-    | Some article -> (article, Article)
-    | None -> (
-        match longest_nonempty (first_group main_re html) with
-        | Some main -> (main, Main)
-        | None -> (
-            match first_group body_re html with
-            | body :: _ -> (body, Body)
-            | [] -> (html, Document)))
+    match longest_nonempty (Markup_document.elements_named "article" document) with
+    | Some (article, _) -> [ article ], Article
+    | None ->
+      (match longest_nonempty (Markup_document.elements_named "main" document) with
+       | Some (main, _) -> [ main ], Main
+       | None ->
+         (match Markup_document.first_element_named "body" document with
+          | Some body -> [ body ], Body
+          | None -> document, Document))
   in
-  ( List.fold_left
-      (fun acc re -> Re.replace_string re ~by:"" acc)
-      selected
-      remove_boilerplate_res
-  , source )
-
-let clean_inline html =
-  Tool_misc_web_search.clean_search_text html
-
-let render_links html =
-  Re.replace link_re html ~f:(fun groups ->
-      let href = Re.Group.get groups 1 |> String.trim in
-      let label = Re.Group.get groups 2 |> clean_inline in
-      if String.equal label "" then ""
-      else if valid_url href then Printf.sprintf "[%s](%s)" label href
-      else label)
-
-let render_headings html =
-  Re.replace heading_re html ~f:(fun groups ->
-      let level =
-        Re.Group.get groups 1 |> Stdlib.int_of_string_opt |> Option.value ~default:2
-      in
-      let marker = String.make (max 1 (min 6 level)) '#' in
-      let label = Re.Group.get groups 2 |> clean_inline in
-      if String.equal label "" then "\n" else "\n" ^ marker ^ " " ^ label ^ "\n")
+  List.filter_map prune_node selected, source
 
 let normalize_markdown text =
   let lines =
@@ -296,27 +179,43 @@ let normalize_markdown text =
     lines;
   Buffer.contents buf |> Re.replace_string blank_lines_re ~by:"\n\n" |> String.trim
 
-let render_markdown html =
-  html
-  |> render_links
-  |> render_headings
-  |> Re.replace_string br_re ~by:"\n"
-  |> Re.replace_string paragraph_open_re ~by:"\n"
-  |> Re.replace_string paragraph_close_re ~by:"\n"
-  |> Re.replace_string li_open_re ~by:"\n- "
-  |> Re.replace_string li_close_re ~by:"\n"
-  |> Re.replace_string block_open_re ~by:"\n"
-  |> Re.replace_string block_close_re ~by:"\n"
-  |> Re.replace_string residual_tag_re ~by:""
-  |> decode_html_entities
-  |> normalize_markdown
+let rec render_markdown_node = function
+  | Markup_document.Text value -> value
+  | Markup_document.Element element ->
+    let content =
+      element.children |> List.map render_markdown_node |> String.concat ""
+    in
+    (match element.name with
+     | "a" ->
+       let label = Tool_misc_web_search.clean_search_text content in
+       (match List.assoc_opt "href" element.attributes with
+        | Some href when valid_url href && not (String.equal label "") ->
+          Printf.sprintf "[%s](%s)" label href
+        | _ -> label)
+     | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" ->
+       let level = Char.code element.name.[1] - Char.code '0' in
+       let label = Tool_misc_web_search.clean_search_text content in
+       if String.equal label "" then "\n"
+       else "\n" ^ String.make level '#' ^ " " ^ label ^ "\n"
+     | "br" -> "\n"
+     | "li" -> "\n- " ^ content ^ "\n"
+     | "p" | "div" | "section" | "tr" | "table" | "ul" | "ol" ->
+       "\n" ^ content ^ "\n"
+     | _ -> content)
+
+let render_markdown nodes =
+  nodes |> List.map render_markdown_node |> String.concat "" |> normalize_markdown
 
 let render_extracted_text ~extract_mode html =
-  let readable, source = select_readable_html html in
+  let readable, source = select_readable_nodes html in
   let text =
     match extract_mode with
     | Markdown -> render_markdown readable
-    | Text -> Tool_misc_web_search.clean_search_text readable
+    | Text ->
+      readable
+      |> List.map Markup_document.text_content
+      |> String.concat ""
+      |> Tool_misc_web_search.clean_search_text
   in
   text, source
 

--- a/lib/tool_misc_web_search.ml
+++ b/lib/tool_misc_web_search.ml
@@ -47,99 +47,14 @@ type simulated_provider_outcome =
   ]
 
 let whitespace_re = Re.Pcre.re "[ \t\r\n]+" |> Re.compile
-let html_tag_re = Re.Pcre.re "<[^>]+>" |> Re.compile
-let cdata_start_re = Re.str "<![CDATA[" |> Re.compile
-let cdata_end_re = Re.str "]]>" |> Re.compile
-let rss_re = Re.Pcre.re "<rss\\b" |> Re.compile
-let channel_re = Re.Pcre.re "<channel\\b" |> Re.compile
-let item_re = Re.Pcre.re "<item\\b[^>]*>([\\s\\S]*?)</item>" |> Re.compile
-let title_re = Re.Pcre.re "<title>([\\s\\S]*?)</title>" |> Re.compile
-let link_re = Re.Pcre.re "<link>([\\s\\S]*?)</link>" |> Re.compile
-let description_re = Re.Pcre.re "<description>([\\s\\S]*?)</description>" |> Re.compile
-
-let ddg_result_re = Re.Pcre.re
-  {|<a rel="nofollow" class="result__a" href="[^"]*uddg=([^&"]+)[^"]*">([^<]*(?:<b>[^<]*</b>[^<]*)*)</a>|}
-  |> Re.compile
-
-let ddg_snippet_re = Re.Pcre.re
-  {|<a class="result__snippet"[^>]*>([^<]*(?:<b>[^<]*</b>[^<]*)*)</a>|}
-  |> Re.compile
-
-let html_entity_replacements =
-  [
-    ("&amp;", "&");
-    ("&lt;", "<");
-    ("&gt;", ">");
-    ("&quot;", "\"");
-    ("&#39;", "'");
-    ("&#039;", "'");
-    ("&nbsp;", " ");
-  ]
-  |> List.map (fun (entity, replacement) ->
-         (Re.str entity |> Re.compile, replacement))
-
 let normalize_spaces text =
   text |> Re.replace_string whitespace_re ~by:" " |> String.trim
 
-let strip_html_tags text =
-  Re.replace_string html_tag_re ~by:"" text
-
-let strip_cdata text =
-  text
-  |> Re.replace_string cdata_start_re ~by:""
-  |> Re.replace_string cdata_end_re ~by:""
-
-let decode_html_entities text =
-  let basic =
-    html_entity_replacements
-    |> List.fold_left
-         (fun acc (entity_re, replacement) ->
-           Re.replace_string entity_re ~by:replacement acc)
-         text
-  in
-  let len = String.length basic in
-  let buf = Buffer.create len in
-  let decode_numeric entity =
-    let body = String.sub entity 2 (String.length entity - 3) in
-    let maybe_n =
-      if String.length body > 1
-         && (Char.equal body.[0] 'x' || Char.equal body.[0] 'X')
-      then Stdlib.int_of_string_opt ("0" ^ body)
-      else Stdlib.int_of_string_opt body
-    in
-    match maybe_n with
-    | Some n -> Stdlib.Uchar.of_int n |> Stdlib.Buffer.add_utf_8_uchar buf; Some ""
-    | None -> None
-  in
-  let rec loop index =
-    if index >= len then
-      Buffer.contents buf
-    else if not (Char.equal basic.[index] '&') then (
-      Buffer.add_char buf basic.[index];
-      loop (index + 1))
-    else
-      match String.index_from_opt basic index ';' with
-      | None ->
-          Buffer.add_char buf basic.[index];
-          loop (index + 1)
-      | Some semi ->
-          let entity = String.sub basic index (semi - index + 1) in
-          if String.length entity >= 4
-             && String.starts_with ~prefix:"&#" entity
-          then (
-            match decode_numeric entity with
-            | Some _ -> loop (semi + 1)
-            | None ->
-                Buffer.add_string buf entity;
-                loop (semi + 1))
-          else (
-            Buffer.add_string buf entity;
-            loop (semi + 1))
-  in
-  loop 0
-
 let clean_search_text text =
-  text |> strip_cdata |> strip_html_tags |> decode_html_entities |> normalize_spaces
+  Markup_document.parse_html text
+  |> List.map Markup_document.text_content
+  |> String.concat ""
+  |> normalize_spaces
 
 
 let valid_search_result_url url =
@@ -152,19 +67,24 @@ let valid_search_result_url url =
     | Some "http" | Some "https" -> true
     | _ -> false
 
-let search_field field_re block =
-  match Re.exec_opt field_re block with
-  | None -> None
-  | Some groups -> Some (Re.Group.get groups 1 |> clean_search_text)
+let child_text name = function
+  | Markup_document.Text _ -> None
+  | Markup_document.Element { children; _ } ->
+    Markup_document.first_element_named name children
+    |> Option.map (fun node ->
+           Markup_document.text_content node |> normalize_spaces)
 
 let parse_bing_rss_items payload =
-  Re.all item_re payload
-  |> List.filter_map (fun groups ->
-         let block = Re.Group.get groups 1 in
+  Markup_document.parse_xml payload
+  |> Markup_document.elements_named "item"
+  |> List.filter_map (fun item ->
+         let description =
+           child_text "description" item |> Option.map clean_search_text
+         in
          match
-           search_field title_re block,
-           search_field link_re block,
-           search_field description_re block
+           child_text "title" item,
+           child_text "link" item,
+           description
          with
          | Some title, Some url, Some snippet
            when not (String.equal title "") && valid_search_result_url url ->
@@ -175,21 +95,36 @@ let parse_bing_rss_items payload =
          | _ -> None)
 
 let parse_ddg_html payload =
-  let results = Re.all ddg_result_re payload in
-  let snippets = Re.all ddg_snippet_re payload in
-  List.mapi (fun i groups ->
-    let url_encoded = Re.Group.get groups 1 in
-    let title_raw = Re.Group.get groups 2 in
-    let url = Uri.pct_decode url_encoded in
-    let title = clean_search_text title_raw in
-    let snippet =
-      match List.nth_opt snippets i with
-      | Some sg -> clean_search_text (Re.Group.get sg 1)
-      | None -> ""
-    in
-    (title, url, snippet)
-  ) results
-  |> List.filter (fun (title, url, _snippet) -> not (String.equal title "") && valid_search_result_url url)
+  let nodes = Markup_document.parse_html payload in
+  let anchors = Markup_document.elements_named "a" nodes in
+  let has_class class_name node =
+    Markup_document.attribute "class" node
+    |> Option.exists (fun classes ->
+           classes |> Markup_document.html_space_tokens
+           |> List.exists (String.equal class_name))
+  in
+  let results = List.filter (has_class "result__a") anchors in
+  let snippets = List.filter (has_class "result__snippet") anchors in
+  List.mapi
+    (fun index node ->
+      let url =
+        Option.bind
+          (Markup_document.attribute "href" node)
+          (fun href ->
+             Uri.of_string href |> fun uri -> Uri.get_query_param uri "uddg")
+      in
+      let title = Markup_document.text_content node |> normalize_spaces in
+      let snippet =
+        match List.nth_opt snippets index with
+        | Some snippet ->
+          Markup_document.text_content snippet |> normalize_spaces
+        | None -> ""
+      in
+      Option.map (fun url -> title, url, snippet) url)
+    results
+  |> List.filter_map Fun.id
+  |> List.filter (fun (title, url, _snippet) ->
+         not (String.equal title "") && valid_search_result_url url)
 
 let parse_json_search_results ~results_path ~title_field ~snippet_field payload =
   let str_of item key =
@@ -242,9 +177,9 @@ let parse_bing_search_json payload =
     ~title_field:"name" ~snippet_field:"snippet" payload
 
 let looks_like_rss_payload payload =
-  let normalized = String.lowercase_ascii payload in
-  String.contains normalized '<'
-  && (Re.execp rss_re normalized || Re.execp channel_re normalized)
+  let nodes = Markup_document.parse_xml payload in
+  Option.is_some (Markup_document.first_element_named "rss" nodes)
+  || Option.is_some (Markup_document.first_element_named "channel" nodes)
 
 let provider_to_string = function
   | Searxng -> "searxng"

--- a/lib/tool_misc_web_search.mli
+++ b/lib/tool_misc_web_search.mli
@@ -11,14 +11,10 @@
     \[provider_response] / \[cache_entry] (cache + provider data
     types kept internal so callers cannot construct half-formed
     state),
-    9 pre-compiled regex constants (\[whitespace_re], \[html_tag_re],
-    \[cdata_*_re], \[rss_re], \[channel_re], \[item_re],
-    \[title_re], \[link_re], \[description_re], \[ddg_result_re],
-    \[ddg_snippet_re]), \[html_entity_replacements] data table,
+    the pre-compiled whitespace normalizer,
     JSON envelope helpers (\[json_error], \[json_ok]), text
-    cleaning helpers (\[normalize_spaces], \[strip_html_tags],
-    \[strip_cdata], \[decode_html_entities],
-    \[clean_search_text], \[trim_nonempty]),
+    cleaning helpers (\[normalize_spaces], \[clean_search_text],
+    \[trim_nonempty]),
     \[valid_search_result_url], \[search_field],
     \[parse_json_search_results] (the generic JSON parser
     behind the per-provider parsers), \[provider_to_string] /
@@ -81,15 +77,14 @@ val redact_transport_error_detail : string -> string
     without an HTTP roundtrip. *)
 
 val looks_like_rss_payload : string -> bool
-(** [looks_like_rss_payload payload] is [true] iff [payload]
-    contains a [<] character AND matches either an [<rss]
-    or [<channel] tag (case-insensitive).  Used by the Bing
+(** [looks_like_rss_payload payload] parses XML and is [true] iff the document
+    contains an [rss] or [channel] element.  Used by the Bing
     fetcher to dispatch between {!parse_bing_rss_items} and
     {!parse_bing_search_json}. *)
 
 val parse_bing_rss_items : string -> (string * string * string) list
 (** Parse Bing RSS feed items.  Reads [<item>], [<title>],
-    [<link>], [<description>] tags via pre-compiled regex. *)
+    [<link>], and [<description>] elements through the shared XML parser. *)
 
 val parse_ddg_html : string -> (string * string * string) list
 (** Parse DuckDuckGo HTML lite results.  Decodes URL-encoded

--- a/masc.opam
+++ b/masc.opam
@@ -69,6 +69,7 @@ depends: [
   "qcheck-alcotest" {with-test & >= "0.21"}
   "bisect_ppx" {with-test & >= "2.8"}
   "mtime" {>= "2.0"}
+  "markup" {>= "1.0.3"}
   "uuidm" {>= "0.9.10"}
   "atdgen" {build & >= "4.2.0"}
   "atdgen-runtime" {>= "4.2.0"}

--- a/test/test_dashboard_link_preview.ml
+++ b/test/test_dashboard_link_preview.ml
@@ -8,12 +8,12 @@ let test_extract_html_preview_fields () =
       <html>
         <head>
           <title>Fallback Title</title>
-          <meta property="og:title" content="OG Title">
+          <meta data-note="1 > 0" content="OG &copy; Title" property="og:title">
           <meta property="og:description" content="OG description here">
           <meta property="og:site_name" content="Example Site">
           <meta property="og:image" content="/cover.png">
           <link rel="canonical" href="/entry">
-          <link rel="icon" href="/favicon.ico">
+          <link rel="shortcut&#x9;icon" href="/favicon.ico">
         </head>
       </html>
     |}
@@ -22,7 +22,7 @@ let test_extract_html_preview_fields () =
     Server_dashboard_http_link_preview.extract_html_preview_fields
       ~url:"https://example.com/blog/post" html
   in
-  check (option string) "title" (Some "OG Title") extracted.title;
+  check (option string) "title" (Some "OG © Title") extracted.title;
   check (option string) "description" (Some "OG description here")
     extracted.description;
   check (option string) "site_name" (Some "Example Site") extracted.site_name;

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -252,20 +252,29 @@ let () = test "parse_bing_rss_items" (fun () ->
       <link>https://example.com/hello?a=1&amp;b=2</link>
       <description><![CDATA[Snippet with <b>markup</b> &amp; detail]]></description>
     </item>
+    <search:item xmlns:search="urn:search">
+      <search:title>Namespaced Result</search:title>
+      <search:link>https://example.com/namespaced</search:link>
+      <search:description>Namespace-safe item</search:description>
+    </search:item>
   </channel>
 </rss>|}
   in
   let items = Tool_misc.parse_bing_rss_items payload in
-  assert (List.length items = 2);
+  assert (List.length items = 3);
   match items with
-  | (title1, url1, snippet1) :: (title2, url2, snippet2) :: _ ->
+  | (title1, url1, snippet1) :: (title2, url2, snippet2)
+    :: (title3, url3, snippet3) :: _ ->
       assert (title1 = "OpenAI & ChatGPT");
       assert (url1 = "https://openai.com/");
       assert (snippet1 = "OpenAI's latest updates.");
       assert (title2 = "Example Result");
       assert (url2 = "https://example.com/hello?a=1&b=2");
-      assert (snippet2 = "Snippet with markup & detail")
-  | _ -> failwith "expected two parsed items"
+      assert (snippet2 = "Snippet with markup & detail");
+      assert (title3 = "Namespaced Result");
+      assert (url3 = "https://example.com/namespaced");
+      assert (snippet3 = "Namespace-safe item")
+  | _ -> failwith "expected three parsed items"
 )
 
 let () = test "looks_like_rss_payload" (fun () ->
@@ -293,8 +302,8 @@ let () = test "parse_bing_rss_items_drops_non_http_links" (fun () ->
 let () = test "parse_ddg_html" (fun () ->
   let payload =
     {|<html><body>
-      <a rel="nofollow" class="result__a" href="/l/?uddg=https%3A%2F%2Fexample.com%2Falpha">Alpha <b>Result</b></a>
-      <a class="result__snippet">Alpha <b>snippet</b></a>
+      <a rel="nofollow" class="result__a&#x9;extra" href="/l/?uddg=https%3A%2F%2Fexample.com%2Falpha">Alpha <b>Result</b></a>
+      <a class="extra&#xC;result__snippet">Alpha <b>snippet</b></a>
       <a rel="nofollow" class="result__a" href="/l/?uddg=https%3A%2F%2Fexample.com%2Fbeta">Beta</a>
       <a class="result__snippet">Beta summary</a>
     </body></html>|}
@@ -438,6 +447,7 @@ let () = test "dispatch_web_search_include_content_enriches_results" (fun () ->
     <article>
       <h1>Result Page</h1>
       <p>Readable <b>page</b> content &amp; proof.</p>
+      <a title="1 > 0" href="https://example.com/standards">Standards &copy;</a>
     </article>
   </body>
 </html>|}
@@ -483,6 +493,9 @@ let () = test "dispatch_web_search_include_content_enriches_results" (fun () ->
               assert (str_contains content_text "Snippet: Snippet");
               assert (str_contains content_text "Content status: ok (http=200");
               assert (str_contains content_text "Readable page content & proof.");
+              assert
+                (str_contains content_text
+                   "[Standards ©](https://example.com/standards)");
               assert (hit |> member "page_content_status" |> to_string = "ok");
               assert (hit |> member "page_content_http_status" |> to_int = 200);
               assert (hit |> member "page_content_truncated" |> to_bool = false);


### PR DESCRIPTION
## Summary

- replace regex-based HTML/RSS structure parsing with a small Markup-backed DOM adapter
- parse Bing RSS/XML namespace-safely and preserve the existing description-cleaning result contract
- parse DuckDuckGo result anchors/classes structurally and decode redirect targets with Uri
- extract fetched-page title/readable content/links and dashboard OG/meta/link preview fields independent of attribute order or `>` inside quoted attributes
- remove duplicated entity/tag/CDATA parser chains from the three production boundaries

## Verification

- `test_tool_misc_coverage.exe`: 36/36
- `test_dashboard_link_preview.exe`: 3/3
- fixtures cover XML namespaces, CDATA containing HTML, numeric/named entities, quoted `>` attributes, reversed meta attributes, and link rendering
- `opam lint masc.opam`
- `scripts/check-variants.sh`
- `scripts/ci/check-determinism-contract.sh`
- `git diff --check`

Closes #26564