### PR TITLE
fix(server): delegate admin token equality to Eqaf

### DIFF
--- a/docs/rfc/auth-bootstrap-grace-token-proof.md
+++ b/docs/rfc/auth-bootstrap-grace-token-proof.md
@@ -60,7 +60,7 @@ to keep. `verify_workspace_secret` (defined, but with zero callers before
 this change — a second, independent audit finding) compares the caller's
 hashed secret against the caller's already-loaded `auth_config.
 workspace_secret_hash` using `Auth_credential_token.constant_time_string_equal`
-(XOR-accumulated over every byte, no early exit on the first mismatch),
+(delegated to Eqaf's timing-resistant equality),
 falling back to a guarded read of the on-disk hash file only when the
 config predates the cache.
 

--- a/docs/spec/09-server-transport.md
+++ b/docs/spec/09-server-transport.md
@@ -452,7 +452,7 @@ let make_routes ~port ~host:_ ~sw ~clock =
 
 ### 7.5 Admin 인증
 
-`MASC_ADMIN_TOKEN` 환경변수로 admin-only API를 보호한다. 타이밍 사이드채널 공격 방지를 위해 XOR 기반 constant-time 비교를 사용한다.
+`MASC_ADMIN_TOKEN` 환경변수로 admin-only API를 보호한다. 토큰 비교는 검증된 Eqaf의 timing-resistant equality에 위임한다.
 
 ### 7.6 CORS
 
@@ -844,7 +844,7 @@ sequenceDiagram
 
 **INV-SERVER-011**: SIGTERM/SIGINT 수신 시 5초 내 graceful shutdown. 타임아웃 초과 시 `exit 1`. Shutdown notification이 모든 SSE 클라이언트에 broadcast된 후 종료한다.
 
-**INV-SERVER-012**: Admin API는 `MASC_ADMIN_TOKEN`과의 constant-time 비교(`with_admin_auth`)로 보호한다. 타이밍 사이드채널 차단.
+**INV-SERVER-012**: Admin API는 `MASC_ADMIN_TOKEN`과의 비교를 `with_admin_auth`에서 Eqaf의 timing-resistant equality에 위임한다.
 
 ---
 

--- a/lib/server/dune
+++ b/lib/server/dune
@@ -59,6 +59,7 @@
   mirage-crypto-rng.unix
   cstruct
   digestif
+  eqaf
   ocaml-protoc-plugin
   masc_proto
   grpc-direct

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -863,8 +863,9 @@ let check_agent_rate_limit request reqd =
       end
 
 (** Admin-only access - requires MASC_ADMIN_TOKEN.
-    Uses timing-safe comparison (XOR-based constant-time) to prevent
-    timing side-channel attacks that could leak token bytes. *)
+    Delegates timing-resistant comparison to Eqaf. *)
+let admin_token_equal = Eqaf.equal
+
 let with_admin_auth handler request reqd =
   match !server_state with
   | None -> Http_server_eio.Response.json {|{"error":"not initialized"}|} reqd
@@ -879,19 +880,7 @@ let with_admin_auth handler request reqd =
           Http_server_eio.Response.json ~status:`Unauthorized
             {|{"error":"Admin token required"}|} reqd
       | Some expected, Some given ->
-          (* Constant-time comparison: always XOR max(len_a, len_b) bytes.
-             Length difference is folded into the diff accumulator so both
-             length and content mismatches cost the same wall-clock time. *)
-          let len_a = String.length expected in
-          let len_b = String.length given in
-          let max_len = max len_a len_b in
-          let diff = ref (len_a lxor len_b) in
-          for i = 0 to max_len - 1 do
-            let a = if i < len_a then Char.code expected.[i] else 0 in
-            let b = if i < len_b then Char.code given.[i] else 0 in
-            diff := !diff lor (a lxor b)
-          done;
-          if !diff = 0 then
+          if admin_token_equal expected given then
             handler state request reqd
           else
             Http_server_eio.Response.json ~status:`Forbidden
@@ -1180,3 +1169,7 @@ and with_token_permission_auth ~permission handler request reqd =
           | Ok () -> handler state agent_name request reqd
           | Error () -> ())
       | Error err -> respond_auth_error request reqd err)
+
+module For_testing = struct
+  let admin_token_equal = admin_token_equal
+end

--- a/lib/server/server_auth.mli
+++ b/lib/server/server_auth.mli
@@ -423,3 +423,7 @@ val with_token_permission_auth :
   Httpun.Request.t -> Httpun.Reqd.t -> unit
 (** Like [with_permission_auth] but threads the token id into the
     handler so the handler can audit the call. *)
+
+module For_testing : sig
+  val admin_token_equal : string -> string -> bool
+end

--- a/test/test_server_auth_dashboard_actor_resolution.ml
+++ b/test/test_server_auth_dashboard_actor_resolution.ml
@@ -246,6 +246,12 @@ let test_authenticated_owner_overrides_request_hint () =
   check (option string) "authenticated projection" (Some "credential-owner")
     (project ~base_path request)
 
+let test_admin_token_equality_truth_table () =
+  let equal = Server_auth.For_testing.admin_token_equal in
+  check bool "exact match" true (equal "admin-secret" "admin-secret");
+  check bool "same-length mismatch" false (equal "admin-secret" "admin-secrex");
+  check bool "different-length mismatch" false (equal "admin-secret" "admin-secret-long")
+
 let () =
   run "server_auth_dashboard_actor_resolution"
     [ ( "resolution"
@@ -259,5 +265,7 @@ let () =
             test_credential_source_precedence_and_observer_query_state
         ; test_case "authenticated owner is canonical" `Quick
             test_authenticated_owner_overrides_request_hint
+        ; test_case "admin token equality truth table" `Quick
+            test_admin_token_equality_truth_table
         ] )
     ]


### PR DESCRIPTION
## Summary
- remove the second hand-written constant-time string comparison from server admin auth
- delegate the comparison to Eqaf.equal
- declare Eqaf as a direct server library dependency

## Verification
- MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_server_auth_dashboard_actor_resolution.exe
- ./_build/default/test/test_server_auth_dashboard_actor_resolution.exe (5/5)
- git diff --check

Closes #26607