### PR TITLE
refactor(tui): remove dead raw HTTP decoder

### DIFF
--- a/bin/masc_tui_http.ml
+++ b/bin/masc_tui_http.ml
@@ -89,7 +89,7 @@ let post_raw_json ~(host : string) ~(port : int) ~(path : string) ~(body : strin
   | Error e -> Error e
   | Ok (status_code, body) ->
       if Masc.Tui_decode.is_success_http_status status_code then Ok body
-      else Error (Masc.Tui_decode.http_status_error { status_code; body })
+      else Error (Masc.Tui_decode.http_status_error ~status_code ~body)
 
 (** Fetch /api/v1/dashboard/briefing (Mission / Overview snapshot). *)
 let fetch_dashboard_briefing ~(host : string) ~(port : int) : (Yojson.Safe.t, string) result =

--- a/lib/tui_decode.ml
+++ b/lib/tui_decode.ml
@@ -314,21 +314,6 @@ let parse_log_entry line =
 
 let trim = String.trim
 
-type http_response = {
-  status_code : int;
-  body : string;
-}
-
-let parse_http_status_code (line : string) : (int, string) result =
-  match String.split_on_char ' ' (String.trim line) |> List.filter (( <> ) "") with
-  | version :: code :: _
-    when String.length version >= 5 && String.starts_with ~prefix:"HTTP/" version
-    -> (
-      match int_of_string_opt code with
-      | Some status -> Ok status
-      | None -> Error (Printf.sprintf "invalid HTTP status code: %S" code))
-  | _ -> Error (Printf.sprintf "invalid HTTP status line: %S" line)
-
 let split_headers_body response =
   let marker = "\r\n\r\n" in
   let rec find idx =
@@ -342,44 +327,26 @@ let split_headers_body response =
   | Some idx -> Some (String.sub response idx (String.length response - idx))
   | None -> None
 
-let parse_http_response (response : string) : (http_response, string) result =
-  match String.split_on_char '\n' response with
-  | [] | [ "" ] -> Error "empty HTTP response"
-  | status_line :: _ ->
-      let* status_code = parse_http_status_code status_line in
-      let* body =
-        match split_headers_body response with
-        | Some body -> Ok body
-        | None -> Error "no empty line in HTTP response"
-      in
-      Ok { status_code; body }
-
 let is_success_http_status status_code = status_code >= 200 && status_code < 300
 
-let http_status_error response =
-  let body = String.trim response.body in
+let http_status_error ~status_code ~body =
+  let body = String.trim body in
   let detail =
     if body = "" then "empty response body"
     else if String.length body > 240 then String.sub body 0 240 ^ "..."
     else body
   in
-  Printf.sprintf "HTTP %d: %s" response.status_code detail
+  Printf.sprintf "HTTP %d: %s" status_code detail
 
 let decode_json_response_body ~allow_empty ~status_code ~body :
     (Yojson.Safe.t, string) result =
   if not (is_success_http_status status_code) then
-    Error (http_status_error { status_code; body })
+    Error (http_status_error ~status_code ~body)
   else if String.length (String.trim body) = 0 then
     if allow_empty then Ok (`Assoc []) else Error "empty response body"
   else
     try Ok (Yojson.Safe.from_string body)
     with Yojson.Json_error e -> Error (Printf.sprintf "(JSON parse: %s)" e)
-
-let decode_json_http_response ~allow_empty (raw : string) :
-    (Yojson.Safe.t, string) result =
-  let* response = parse_http_response raw in
-  decode_json_response_body ~allow_empty ~status_code:response.status_code
-    ~body:response.body
 
 let missing_field key =
   Error (Printf.sprintf "missing required field '%s'" key)

--- a/lib/tui_decode.mli
+++ b/lib/tui_decode.mli
@@ -53,22 +53,14 @@ type log_entry = {
   le_compacted : bool option;
 }
 
-type http_response = {
-  status_code : int;
-  body : string;
-}
-
 val decode_agent : Yojson.Safe.t -> (agent, string) result
 val decode_task : Yojson.Safe.t -> (task, string) result
 val decode_keeper : filename:string -> Yojson.Safe.t -> (keeper, string) result
 val parse_log_entry : string -> (log_entry, string) result
-val parse_http_response : string -> (http_response, string) result
 val is_success_http_status : int -> bool
-val http_status_error : http_response -> string
+val http_status_error : status_code:int -> body:string -> string
 val decode_json_response_body :
   allow_empty:bool -> status_code:int -> body:string -> (Yojson.Safe.t, string) result
-val decode_json_http_response :
-  allow_empty:bool -> string -> (Yojson.Safe.t, string) result
 val required_string_field : Yojson.Safe.t -> string -> (string, string) result
 val optional_string_field :
   Yojson.Safe.t -> string -> (string option, string) result

--- a/test/test_tui_decode.ml
+++ b/test/test_tui_decode.ml
@@ -244,25 +244,6 @@ let test_parse_keeper_chat_response_json_error () =
   | Ok _ -> Alcotest.fail "expected parse failure"
   | Error err -> Alcotest.(check string) "error message" "boom" err
 
-let test_decode_json_http_response_rejects_error_status () =
-  let response =
-    "HTTP/1.1 400 Bad Request\r\nContent-Type: application/json\r\n\r\n\
-     {\"error\":\"bad confirm\"}"
-  in
-  match Tui_decode.decode_json_http_response ~allow_empty:true response with
-  | Ok _ -> Alcotest.fail "expected HTTP 400 to fail"
-  | Error err ->
-      Alcotest.(check string)
-        "http error" "HTTP 400: {\"error\":\"bad confirm\"}" err
-
-let test_decode_json_http_response_allows_empty_success_post () =
-  let response = "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n" in
-  match Tui_decode.decode_json_http_response ~allow_empty:true response with
-  | Ok (`Assoc []) -> ()
-  | Ok json ->
-      Alcotest.failf "expected empty object, got %s" (Yojson.Safe.to_string json)
-  | Error err -> Alcotest.fail err
-
 let test_decode_json_response_body_rejects_error_status () =
   match
     Tui_decode.decode_json_response_body ~allow_empty:true ~status_code:400
@@ -272,6 +253,16 @@ let test_decode_json_response_body_rejects_error_status () =
   | Error err ->
       Alcotest.(check string)
         "http error" "HTTP 400: {\"error\":\"bad confirm\"}" err
+
+let test_decode_json_response_body_allows_empty_success () =
+  match
+    Tui_decode.decode_json_response_body ~allow_empty:true ~status_code:204
+      ~body:""
+  with
+  | Ok (`Assoc []) -> ()
+  | Ok json ->
+      Alcotest.failf "expected empty object, got %s" (Yojson.Safe.to_string json)
+  | Error err -> Alcotest.fail err
 
 type parent_node = {
   node_id : string;
@@ -342,14 +333,12 @@ let () =
         Alcotest.test_case "json error" `Quick
           test_parse_keeper_chat_response_json_error;
       ] );
-    ( "http_response",
+    ( "structured_http_response",
       [
-        Alcotest.test_case "rejects error status" `Quick
-          test_decode_json_http_response_rejects_error_status;
-        Alcotest.test_case "allows empty success post" `Quick
-          test_decode_json_http_response_allows_empty_success_post;
         Alcotest.test_case "body rejects error status" `Quick
           test_decode_json_response_body_rejects_error_status;
+        Alcotest.test_case "body allows empty success" `Quick
+          test_decode_json_response_body_allows_empty_success;
       ] );
     ( "bounded_parent_depth",
       [


### PR DESCRIPTION
## Summary
- remove the test-only raw HTTP status-line decoder and its public API
- retain the production-used Keeper chat body boundary helper
- retain structured status/body JSON decoding and its success/failure tests

## Verification
- MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_tui_decode.exe
- ./_build/default/test/test_tui_decode.exe (22/22)
- git diff --check

Closes #26611