### PR TITLE
fix(dashboard): run current behavior contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -828,6 +828,16 @@ jobs:
       # still compiles every test target; the authoritative runtime, operator,
       # transport, SSE, and contract suites below remain executable gates.
 
+      - name: Run dashboard behavior contracts
+        id: dashboard_behavior_contracts
+        if: ${{ always() && steps.build_step.outcome == 'success' }}
+        env:
+          CI_TEST_HEARTBEAT_SEC: 15
+          DUNE_JOBS: 1
+        run: |
+          chmod +x scripts/ci-run-tests.sh
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-dashboard-http-behavior-contracts"
+
       - name: Run OAS pin behavior suite
         id: oas_pin_behavior_suite
         if: ${{ always() && steps.build_step.outcome == 'success' && needs.changes.outputs.oas_pin == 'true' }}

--- a/lib/dashboard/dashboard_verification.ml
+++ b/lib/dashboard/dashboard_verification.ml
@@ -191,7 +191,7 @@ let requests_json ~base_path ?task_id ?limit () : Yojson.Safe.t =
   let all = load_requests ~base_path () in
   requests_json_of_requests ?task_id ~limit all
 
-let summary_json ~base_path ?recent:_ () : Yojson.Safe.t =
+let summary_json ~base_path () : Yojson.Safe.t =
   let all = load_requests ~base_path () in
   `Assoc
     ([ ("updated_at", `String (Masc_domain.now_iso ()))
@@ -206,7 +206,7 @@ let summary_json ~base_path ?recent:_ () : Yojson.Safe.t =
    the historic proof handler scanned the verification store twice
    per refresh.  This helper performs one scan and folds the two
    projections from the shared list. *)
-let proof_compose ~base_path ?recent:_ ?limit () : Yojson.Safe.t * Yojson.Safe.t =
+let proof_compose ~base_path ?limit () : Yojson.Safe.t * Yojson.Safe.t =
   let limit = clamp_limit limit in
   let all = load_requests ~base_path () in
   let summary =

--- a/lib/dashboard/dashboard_verification.mli
+++ b/lib/dashboard/dashboard_verification.mli
@@ -13,11 +13,10 @@ val requests_json :
   Yojson.Safe.t
 
 (** Summary of immutable submissions: update time and total count only. *)
-val summary_json : base_path:string -> ?recent:int -> unit -> Yojson.Safe.t
+val summary_json : base_path:string -> unit -> Yojson.Safe.t
 
 val proof_compose :
   base_path:string ->
-  ?recent:int ->
   ?limit:int ->
   unit ->
   Yojson.Safe.t * Yojson.Safe.t

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -252,22 +252,20 @@ let dashboard_gate_tool_events_http_json request ~base_path : Yojson.Safe.t =
 ;;
 
 (* /api/v1/dashboard/proof was measured at 28-60s (timeout) under
-   live load.  The compute calls [Dashboard_verification.summary_json]
-   and [Dashboard_verification.requests_json] back-to-back; each
-   walks the on-disk verification request store, so the work runs
-   inline on the Eio main domain and starves other HTTP fibers.
+   live load. The verification projection walks the on-disk request store, so
+   an uncached computation must not run on the Eio main domain.
 
    Same fix pattern as PR #18991 / #18993 / #18994: wrap in
    [Dashboard_cache.get_or_compute] for stale-while-revalidate and
    push the compute through [Domain_pool_ref.submit_io_or_inline]
    so the main domain keeps serving requests during refresh. *)
-let dashboard_proof_compute ~config ~limit ~recent () : Yojson.Safe.t =
+let dashboard_proof_compute ~config ~limit () : Yojson.Safe.t =
   let base_path = config.Workspace.base_path in
   (* Single disk scan via [proof_compose]; the historical
      [summary_json] + [requests_json] sequence walked the verification
      store twice per refresh. *)
   let verification_summary, verification_requests =
-    Dashboard_verification.proof_compose ~base_path ~recent ~limit ()
+    Dashboard_verification.proof_compose ~base_path ~limit ()
   in
   let proof_source ~id ~label ~route =
     `Assoc [ "id", `String id; "label", `String label; "route", `String route ]
@@ -275,7 +273,7 @@ let dashboard_proof_compute ~config ~limit ~recent () : Yojson.Safe.t =
   let proof_sources =
     [
       proof_source ~id:"verification_summary"
-        ~label:"Verification status buckets"
+        ~label:"Verification submission summary"
         ~route:"/api/v1/verification/summary";
       proof_source ~id:"verification_requests"
         ~label:"Verification request evidence"
@@ -291,19 +289,6 @@ let dashboard_proof_compute ~config ~limit ~recent () : Yojson.Safe.t =
         ~route:"/api/v1/dashboard/execution-trust";
     ]
   in
-  let by_status =
-    match verification_summary with
-    | `Assoc fields -> (
-        match List.assoc_opt "by_status" fields with
-        | Some (`Assoc status_fields) -> status_fields
-        | _ -> [])
-    | _ -> []
-  in
-  let status_int key =
-    match List.assoc_opt key by_status with
-    | Some (`Int n) -> n
-    | _ -> 0
-  in
   `Assoc
     [
       "generated_at", `String (Masc_domain.now_iso ());
@@ -317,8 +302,6 @@ let dashboard_proof_compute ~config ~limit ~recent () : Yojson.Safe.t =
                  | Some (`Int n) -> `Int n
                  | _ -> `Int 0)
              | _ -> `Int 0);
-            "verification_pending", `Int (status_int "pending");
-            "verification_rejected", `Int (status_int "rejected");
             "proof_source_count", `Int (List.length proof_sources);
           ] );
       ( "verification",
@@ -333,15 +316,12 @@ let dashboard_proof_compute ~config ~limit ~recent () : Yojson.Safe.t =
 
 let dashboard_proof_http_json ~config request : Yojson.Safe.t =
   let limit = int_query_param request "limit" ~default:25 |> clamp ~min_v:1 ~max_v:100 in
-  let recent =
-    int_query_param request "recent" ~default:5 |> clamp ~min_v:0 ~max_v:20
-  in
   let key =
-    Printf.sprintf "dashboard.proof:%s;%d;%d" config.Workspace.base_path limit recent
+    Printf.sprintf "dashboard.proof:%s;%d" config.Workspace.base_path limit
   in
   Dashboard_cache.get_or_compute key ~ttl:dashboard_projection_cache_ttl_s (fun () ->
     Domain_pool_ref.submit_io_or_inline (fun () ->
-      dashboard_proof_compute ~config ~limit ~recent ()))
+      dashboard_proof_compute ~config ~limit ()))
 ;;
 
 type approval_resolve_http_error =

--- a/lib/server/server_routes_http_routes_verification.ml
+++ b/lib/server/server_routes_http_routes_verification.ml
@@ -4,12 +4,9 @@
     [server_routes_http_routes_runtime.ml] — the verification domain is
     independent of runtime.
 
-    - [GET /api/v1/verification/requests] — operator view of pending /
-      approved / rejected verification requests (see {!Dashboard_verification}).
-    - [GET /api/v1/verification/summary] — one-shot status bucket counts +
-      most recent rejections (verdict_reason carriers). Lets consumers
-      render a compact "X pending / Y approved / Z rejected" card without
-      paging the full request list.
+    - [GET /api/v1/verification/requests] — immutable verification submissions
+      (see {!Dashboard_verification}).
+    - [GET /api/v1/verification/summary] — immutable submission count.
     - [GET /api/v1/verification/specs] — TLA+ spec index with clean / buggy
       cfg coverage (see {!Dashboard_tla_specs}).
     - [GET /api/v1/verification/tlc-results] — latest observed TLC log
@@ -222,13 +219,8 @@ let add_routes router =
        ) request reqd)
   |> Http.Router.get "/api/v1/verification/summary" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let recent =
-           match trimmed_query_param req "recent" with
-           | Some s -> int_of_string_opt s
-           | None -> None
-         in
          let base_path = (Mcp_server.workspace_config state).base_path in
-         let json = Dashboard_verification.summary_json ~base_path ?recent () in
+         let json = Dashboard_verification.summary_json ~base_path () in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/verification/specs" (fun request reqd ->

--- a/lib/server/server_routes_http_routes_verification.mli
+++ b/lib/server/server_routes_http_routes_verification.mli
@@ -1,9 +1,8 @@
 (** Server_routes_http_routes_verification — HTTP routes for the
     TLA+ verification dashboard surface.
 
-    - [GET /api/v1/verification/requests] — pending / approved /
-      rejected verification requests.
-    - [GET /api/v1/verification/summary] — bucket counts.
+    - [GET /api/v1/verification/requests] — immutable verification submissions.
+    - [GET /api/v1/verification/summary] — submission count.
     - [GET /api/v1/verification/specs] — TLA+ spec index.
     - [GET /api/v1/verification/tlc-results] — latest observed TLC
       log projection.

--- a/test/dune
+++ b/test/dune
@@ -1223,6 +1223,13 @@
   bigstringaf)
  (deps ../bin/main_eio.exe))
 
+; Stable dashboard behavior contracts only. The full executable also contains
+; source-shape assertions, so CI must not promote its catch-all runtest alias.
+(rule
+ (alias runtest-dashboard-http-behavior-contracts)
+ (action
+  (run %{exe:test_dashboard_http_core.exe} test "dashboard behavior contracts")))
+
 (test
  (name test_voice_config)
  (modules test_voice_config)

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -2867,31 +2867,38 @@ let test_config_post_materializes_missing_toml () =
   with_test_env @@ fun ~env ~sw ~config ->
   let name = "config-sync-no-toml" in
   prepare_config_sync_keeper config name;
-  Eio.Switch.on_release sw (fun () ->
-    Masc.Keeper_keepalive.stop_keepalive ~base_path:config.base_path name);
-  let raw, json =
-    post_config ~sw ~clock:(Eio.Stdenv.clock env)
-      ~state:(Lib.Mcp_server.For_testing.create_state ~base_path:config.base_path)
-      ~name {|{"proactive_enabled":true}|}
-  in
-  check bool "HTTP 200" true (String.starts_with ~prefix:"HTTP/1.1 200" raw);
-  let open Yojson.Safe.Util in
-  check bool "runtime projection applied proactive config" true
-    (json |> member "proactive" |> member "enabled" |> to_bool);
-  let path =
-    Config_dir_resolver.keepers_dir_for_base_path ~base_path:config.Workspace.base_path
-    |> fun dir -> Filename.concat dir (name ^ ".toml")
-  in
-  check bool "missing declarative TOML was materialized" true (Sys.file_exists path);
-  let parsed =
-    Keeper_toml_loader.parse_toml (In_channel.with_open_bin path In_channel.input_all)
-  in
-  (match parsed with
-   | Error error -> fail error
-   | Ok doc ->
-     check (option bool) "materialized proactive config" (Some true)
-       (Keeper_toml_loader.toml_bool_opt doc "keeper.proactive_enabled"));
-  ignore (Masc.Keeper_keepalive.stop_keepalive_and_await ~base_path:config.base_path name)
+  Fun.protect
+    ~finally:(fun () ->
+      ignore
+        (Masc.Keeper_keepalive.stop_keepalive_and_await
+           ~base_path:config.base_path
+           name))
+    (fun () ->
+      let raw, json =
+        post_config ~sw ~clock:(Eio.Stdenv.clock env)
+          ~state:(Lib.Mcp_server.For_testing.create_state ~base_path:config.base_path)
+          ~name {|{"proactive_enabled":true}|}
+      in
+      check bool "HTTP 200" true (String.starts_with ~prefix:"HTTP/1.1 200" raw);
+      let open Yojson.Safe.Util in
+      check bool "runtime projection applied proactive config" true
+        (json |> member "proactive" |> member "enabled" |> to_bool);
+      let path =
+        Config_dir_resolver.keepers_dir_for_base_path
+          ~base_path:config.Workspace.base_path
+        |> fun dir -> Filename.concat dir (name ^ ".toml")
+      in
+      check bool "missing declarative TOML was materialized" true
+        (Sys.file_exists path);
+      let parsed =
+        Keeper_toml_loader.parse_toml
+          (In_channel.with_open_bin path In_channel.input_all)
+      in
+      match parsed with
+      | Error error -> fail error
+      | Ok doc ->
+        check (option bool) "materialized proactive config" (Some true)
+          (Keeper_toml_loader.toml_bool_opt doc "keeper.proactive_enabled"))
 
 let test_config_post_reports_runtime_sync_failure () =
   with_test_env @@ fun ~env ~sw ~config ->

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1265,7 +1265,7 @@ let test_dashboard_shell_timeout_fallback_reports_timing_context () =
       check int "timing top is empty without an active trace" 0
         (diagnostics |> member "projection_timing_top" |> to_list |> List.length))
 
-let test_dashboard_proof_http_json_surfaces_verification_index () =
+let test_dashboard_proof_http_json_surfaces_submission_index () =
   with_test_env @@ fun ~env:_ ~sw:_ ~config ->
   let module V = Lib.Verification in
   let output =
@@ -1289,13 +1289,15 @@ let test_dashboard_proof_http_json_surfaces_verification_index () =
   let json =
     Server_dashboard_http.dashboard_proof_http_json
       ~config
-      (request "/api/v1/dashboard/proof?limit=5&recent=2")
+      (request "/api/v1/dashboard/proof?limit=5")
   in
   let open Yojson.Safe.Util in
   check int "verification total" 1
     (json |> member "summary" |> member "verification_total" |> to_int);
-  check int "pending total" 1
-    (json |> member "summary" |> member "verification_pending" |> to_int);
+  check bool "request status is not synthesized from immutable submissions" true
+    (json |> member "summary" |> member "verification_pending" = `Null);
+  check bool "rejection status is not synthesized from immutable submissions" true
+    (json |> member "summary" |> member "verification_rejected" = `Null);
   check bool "verification requests exposed" true
     (match json |> member "verification" |> member "requests" |> member "requests" with
      | `List [ _ ] -> true
@@ -1937,7 +1939,7 @@ let test_offline_keeper_composite_exposes_secret_projection () =
       Masc_test_deps.meta_of_json_fixture
         (`Assoc
            [ "name", `String keeper_name
-           ; "agent_name", `String keeper_name
+           ; "agent_name", `String (Masc.Keeper_identity.keeper_agent_name keeper_name)
            ; "trace_id", `String "offline-secret-trace"
            ])
     with
@@ -1983,7 +1985,7 @@ let keeper_state_diagram_meta ?last_runtime_attempt_provider name =
     Masc_test_deps.meta_of_json_fixture
       (`Assoc
          ([ "name", `String name
-          ; "agent_name", `String (name ^ "-agent")
+          ; "agent_name", `String (Masc.Keeper_identity.keeper_agent_name name)
           ; "trace_id", `String ("trace-" ^ name)
           ]
           @ runtime_attempt_fields))
@@ -2861,19 +2863,35 @@ let test_config_post_restarts_from_atomic_toml () =
      | None -> false);
   ignore (Masc.Keeper_keepalive.stop_keepalive_and_await ~base_path:config.base_path name)
 
-let test_config_post_requires_toml () =
+let test_config_post_materializes_missing_toml () =
   with_test_env @@ fun ~env ~sw ~config ->
   let name = "config-sync-no-toml" in
   prepare_config_sync_keeper config name;
+  Eio.Switch.on_release sw (fun () ->
+    Masc.Keeper_keepalive.stop_keepalive ~base_path:config.base_path name);
   let raw, json =
     post_config ~sw ~clock:(Eio.Stdenv.clock env)
       ~state:(Lib.Mcp_server.For_testing.create_state ~base_path:config.base_path)
       ~name {|{"proactive_enabled":true}|}
   in
-  check bool "HTTP 409" true (String.starts_with ~prefix:"HTTP/1.1 409" raw);
+  check bool "HTTP 200" true (String.starts_with ~prefix:"HTTP/1.1 200" raw);
   let open Yojson.Safe.Util in
-  check bool "config not applied" false (json |> member "config_applied" |> to_bool);
-  check bool "runtime not synced" false (json |> member "runtime_sync" |> to_bool)
+  check bool "runtime projection applied proactive config" true
+    (json |> member "proactive" |> member "enabled" |> to_bool);
+  let path =
+    Config_dir_resolver.keepers_dir_for_base_path ~base_path:config.Workspace.base_path
+    |> fun dir -> Filename.concat dir (name ^ ".toml")
+  in
+  check bool "missing declarative TOML was materialized" true (Sys.file_exists path);
+  let parsed =
+    Keeper_toml_loader.parse_toml (In_channel.with_open_bin path In_channel.input_all)
+  in
+  (match parsed with
+   | Error error -> fail error
+   | Ok doc ->
+     check (option bool) "materialized proactive config" (Some true)
+       (Keeper_toml_loader.toml_bool_opt doc "keeper.proactive_enabled"));
+  ignore (Masc.Keeper_keepalive.stop_keepalive_and_await ~base_path:config.base_path name)
 
 let test_config_post_reports_runtime_sync_failure () =
   with_test_env @@ fun ~env ~sw ~config ->
@@ -2962,8 +2980,6 @@ let () =
             test_operator_digest_default_route_exposes_provenance;
           test_case "shell timeout fallback reports timing context" `Quick
             test_dashboard_shell_timeout_fallback_reports_timing_context;
-          test_case "proof payload exposes verification index" `Quick
-            test_dashboard_proof_http_json_surfaces_verification_index;
           test_case "proof route registered in HTTP routers" `Quick
             test_dashboard_proof_route_registered_in_http_routers;
           test_case "Gate mode save reports recovery independently" `Quick
@@ -3016,10 +3032,6 @@ let () =
             test_telemetry_n_default_is_bounded;
           test_case "fleet-composite envelope is cached across polls" `Quick
             test_dashboard_fleet_composite_envelope_is_cached;
-          test_case "offline keeper composite exposes secret projection" `Quick
-            test_offline_keeper_composite_exposes_secret_projection;
-          test_case "state diagram runtime projection redacts live evidence" `Quick
-            test_state_diagram_runtime_projection_redacts_live_runtime_evidence;
           test_case "state diagram runtime projection stays empty without meta" `Quick
             test_state_diagram_runtime_projection_missing_meta_stays_empty;
           test_case "keeper catch-up judge route is classified" `Quick
@@ -3034,6 +3046,16 @@ let () =
             test_event_operator_uses_exact_source_refs_across_unrelated_enqueues;
           test_case "observation metadata does not override terminal contract" `Quick
             test_composite_blocked_uses_terminal_contract_not_observational_metadata;
+        ] );
+      ( "dashboard behavior contracts",
+        [ test_case "proof payload exposes submission index" `Quick
+            test_dashboard_proof_http_json_surfaces_submission_index;
+          test_case "offline keeper composite exposes secret projection" `Quick
+            test_offline_keeper_composite_exposes_secret_projection;
+          test_case "state diagram runtime projection redacts live evidence" `Quick
+            test_state_diagram_runtime_projection_redacts_live_runtime_evidence;
+          test_case "activation config materializes missing TOML" `Quick
+            test_config_post_materializes_missing_toml;
         ] );
       ( "lifecycle event classification (#22071)",
         [ test_case "typed wire lifecycle round-trips" `Quick
@@ -3060,8 +3082,6 @@ let () =
             test_context_shrink_detection;
           test_case "config POST atomically restarts runtime" `Quick
             test_config_post_restarts_from_atomic_toml;
-          test_case "activation config requires TOML" `Quick
-            test_config_post_requires_toml;
           test_case "runtime sync failure preserves commit" `Quick
             test_config_post_reports_runtime_sync_failure;
           test_case "mixed invalid request commits nothing" `Quick


### PR DESCRIPTION
## Summary

- Repair the four stale `test_dashboard_http_core` behavior cases reported by #26616.
- Remove proof status fields that were silently synthesized after verification requests became immutable submissions.
- Add a narrow executable Dune alias and CI step for the four stable dashboard behavior contracts; do not promote the source-shape-heavy catch-all executable.

## Product impact

- User-visible change: proof responses no longer claim zero pending/rejected verification work without an authoritative status source; Keeper config activation correctly materializes a missing TOML file.

## Evidence

- PASS: `ocamlformat --check` on all touched OCaml files.
- PASS: `git diff --check`.
- PASS: `bash scripts/check-doc-truth.sh`.
- PASS: `bash scripts/check-ssot.sh`.
- `actionlint .github/workflows/ci.yml` reports only the same pre-existing SC2129 findings at lines 88 and 188 as `origin/main`.
- PASS: `MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build @test/runtest-dashboard-http-behavior-contracts` (4/4).
- PASS: linked `_build/default/test/test_dashboard_http_core.exe` (66/66). The already-built binary was executed directly because unrelated worktrees held the global Dune/opam locks; no build or dependency state was bypassed.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/2
provenance: operator_proxy
stages:
  - stage: focused_local_contracts
    provenance: operator_proxy
    result: pass_4_of_4
  - stage: dashboard_http_core_full
    provenance: operator_proxy
    result: pass_66_of_66
```

## GOAL LOOP ACT checklist

- [x] Observe — reproduced all four stale contracts from #26616 and captured the local forward-pin compile blocker.
- [x] Orient — traced verification producer to immutable store, dashboard projection, HTTP route, and tests.
- [x] Decide — removed false derived status instead of adding a Gate or compatibility shim.
- [x] Act — changed only the projection, stale fixtures/expectation, and a four-case executable alias.
- [x] Verify — focused local contracts pass 4/4 and the full dashboard executable passes 66/66; latest exact-head CI remains the merge authority.
- [x] Loop — unsafe forward-pin acceptance is tracked in #26588 with this run's reproduction evidence.

## Review evidence

- Self-review: no consumer of the removed `recent`, `verification_pending`, or `verification_rejected` contract exists outside the negative regression assertions.
- Concurrent MASC agent review added failure-safe Keeper cleanup in commit `544f5b67ca`.

## Linked issue

- Closes #26616
- Relates #26113
- Relates #26150
- Relates #26588

## Variant addition checklist

- [ ] **OCaml** — N/A: no variant changed in this repository.
- [ ] **TypeScript** — N/A: no TypeScript union changed.
- [ ] **TLA+ spec** — N/A: no TLA+ domain changed.
- [ ] **Event / JSON schema** — N/A: removed non-authoritative derived response fields, no enum changed.
- [ ] **`make check-variants` passes** — N/A: no variant addition/removal/rename.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/26616-dashboard-http-contracts-20260802` → `main` · 3 commit(s) · synced 2026-08-02T02:15:14Z

| sha | subject | date |
|---|---|---|
| `110a9a952` | fix(dashboard): run current behavior contracts | 2026-08-02 |
| `544f5b67c` | test(dashboard): await keeper cleanup on failures | 2026-08-02 |
| `d7fb17023` | Merge remote-tracking branch 'origin/main' into fix/26616-dashboard-h… | 2026-08-02 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->