### PR TITLE
fix(test): unbreak main — two test compile errors

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -1381,7 +1381,7 @@
 (test
  (name test_schedule_domain)
  (modules test_schedule_domain)
- (libraries alcotest yojson masc_schedule))
+ (libraries alcotest yojson ptime masc_schedule))
 
 (test
  (name test_schedule_ical_recur)

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -5223,10 +5223,6 @@ let () =
             `Quick
             test_health_json_degrades_on_active_task_owner_without_keeper_binding;
           Alcotest.test_case
-            "health json excludes awaiting verification from keeper fleet scan"
-            `Quick
-            test_health_json_excludes_awaiting_verification_from_keeper_fleet_scan;
-          Alcotest.test_case
             "health json reports non-keeper active task owner as advisory"
             `Quick
             test_health_json_reports_non_keeper_active_task_owner_as_advisory;


### PR DESCRIPTION
## 🔴 P0 — main 이 red 예용. 컴파일 에러 두 개를 같이 고쳐용

`main = 3722a9d014` 의 `Build and Test` 가 failure 예용. 로그에서 확인한 에러가 **서로 무관한 두 개**예용.

### (A) `test/test_server_runtime_bootstrap.ml:5228`
```
Error: Unbound value test_health_json_excludes_awaiting_verification_from_keeper_fleet_scan
```
`#26604` (`43a3f661f9`) 가 fleet scan 을 `AwaitingVerification -> None`(행을 버림)에서 `Completion_authority_pending`(타입 분기)으로 바꿨어용. 낡은 테스트 **함수는 지웠는데 Alcotest 등록이 남았어용.**

### (B) `test/test_schedule_domain.ml`
```
Error: Unbound module Ptime
```
`#26623` (`51d4766906`) 이 `Ptime.of_rfc3339` 를 테스트에 넣으면서 dune 스탠자에 `ptime` 을 안 넣었어용. `dune-project:9` 가 `(implicit_transitive_deps false)` 라서 `masc_schedule` 경유 `ptime` 은 `-H`(hidden include)로만 도달해용 — 링크는 되는데 **직접 참조가 안 되용.**

---

## 왜 별도 PR 인가용

두 수정이 각각 다른 PR 에 흩어져 있어서 **교착**이었어용:

| | (A) | (B) |
|---|---|---|
| `#26629` | ✅ | ❌ |
| `#26621` | ❌ | ✅ |

각자 상대의 에러로 `Build and Test` 가 떨어져서 **어느 쪽도 혼자 green 이 못 돼용.** required check 가 `CI Gate` 라 그대로면 둘 다 머지 불가예용.

이 PR 은 두 줄기를 합친 **최소 복구**예용 (4줄 삭제 + 1단어 추가). 머지되면:
- `#26629` 는 (A) 가 중복이라 닫으면 되용
- `#26621` 은 (B) 한 줄이 중복이 되고, 핀 정책 변경만 남아 정상 검토하면 되용

## 검증

- (A) 삭제 후 `test_server_runtime_bootstrap.ml` 의 **Alcotest 등록 57개 전부 정의 존재** (정의 94개, 미해결 0)
- (B) `test_schedule_domain.ml` 이 직접 참조하는 외부 모듈은 `Alcotest` / `Ptime` / `Schedule_domain` — `ptime` 만 선언에 없었어용
- 동작 변경 없어용. 테스트 등록 제거 + dune dep 선언뿐이에용

RFC-WAIVED: test 등록 제거와 dune dep 선언만 있는 main 복구 PR 이라 대상 subsystem(credential/identity/operator/sandbox/hooks/workflow) 을 건드리지 않아용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
