### PR TITLE
fix(stream): handle NDJSON provider errors

### DIFF
--- a/lib/keeper/keeper_agent_run_turn_helpers.ml
+++ b/lib/keeper/keeper_agent_run_turn_helpers.ml
@@ -107,6 +107,7 @@ let sse_event_progress_kind (event : Agent_sdk.Types.sse_event) =
   | Agent_sdk.Types.MessageStop -> Some "sse_message_stop"
   | Agent_sdk.Types.Ping -> None
   | Agent_sdk.Types.SSEError _ -> Some "sse_error"
+  | Agent_sdk.Types.NDJSONError _ -> Some "ndjson_error"
   | Agent_sdk.Types.SSEParseFailed _ -> Some "sse_parse_failed"
   | Agent_sdk.Types.NDJSONParseFailed _ -> Some "ndjson_parse_failed"
   | Agent_sdk.Types.SSEUnknownEventType _ -> Some "sse_unknown_event_type"

--- a/lib/keeper/keeper_chat_events.ml
+++ b/lib/keeper/keeper_chat_events.ml
@@ -11,6 +11,7 @@ type stream_protocol_error_kind =
   | Media_payload_too_large
   | Media_persist_failed
   | Sse_error
+  | Ndjson_error
   | Sse_parse_failed
   | Ndjson_parse_failed
   | Sse_unknown_event_type
@@ -124,6 +125,7 @@ let stream_protocol_error_kind_to_string = function
   | Media_payload_too_large -> "media_payload_too_large"
   | Media_persist_failed -> "media_persist_failed"
   | Sse_error -> "sse_error"
+  | Ndjson_error -> "ndjson_error"
   | Sse_parse_failed -> "sse_parse_failed"
   | Ndjson_parse_failed -> "ndjson_parse_failed"
   | Sse_unknown_event_type -> "sse_unknown_event_type"

--- a/lib/keeper/keeper_chat_events.mli
+++ b/lib/keeper/keeper_chat_events.mli
@@ -21,6 +21,7 @@ type stream_protocol_error_kind =
   | Media_payload_too_large
   | Media_persist_failed
   | Sse_error
+  | Ndjson_error
   | Sse_parse_failed
   | Ndjson_parse_failed
   | Sse_unknown_event_type

--- a/lib/keeper/keeper_chat_oas_stream_bridge.ml
+++ b/lib/keeper/keeper_chat_oas_stream_bridge.ml
@@ -472,6 +472,22 @@ let translate ~redact_text ~base_dir bridge_state
             Event_error
               { message = redact_text ("Provider stream error: " ^ reason) } ]
       }
+  | NDJSONError { message; error_type; raw } ->
+      let reason =
+        match error_type with
+        | None -> message
+        | Some error_type -> error_type ^ ": " ^ message
+      in
+      { bridge_state;
+        chat_events =
+          [ protocol_error ?event_type:error_type
+              ~reason:(redact_text message)
+              ~raw_bytes:(String.length raw)
+              Ndjson_error;
+            Event_error
+              { message =
+                  redact_text ("Provider NDJSON stream error: " ^ reason) } ]
+      }
   | SSEParseFailed { raw; reason } ->
       { bridge_state;
         chat_events =

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -1929,6 +1929,35 @@ let test_keeper_stream_bridge_preserves_ndjson_parse_failure () =
         message
   | _ -> fail "expected NDJSON parse failure to remain a typed visible error"
 
+let test_keeper_stream_bridge_preserves_ndjson_provider_error () =
+  let open Agent_sdk.Types in
+  let message = "request rejected" in
+  let raw = "{\"error\":\"request rejected\"}" in
+  let events =
+    translate_oas_stream_events
+      [ NDJSONError
+          { message; error_type = Some "rate_limit_exceeded"; raw } ]
+  in
+  match events with
+  | [ Keeper_chat_events.Oas_stream_protocol_error
+        { kind
+        ; event_type = Some actual_error_type
+        ; reason = Some actual_reason
+        ; raw_bytes = Some actual_bytes
+        ; _
+        }
+    ; Keeper_chat_events.Event_error { message = actual_message } ] ->
+      check string "NDJSON provider error kind" "ndjson_error"
+        (Keeper_chat_events.stream_protocol_error_kind_to_string kind);
+      check string "NDJSON provider error type" "rate_limit_exceeded"
+        actual_error_type;
+      check string "NDJSON provider error reason" message actual_reason;
+      check int "NDJSON provider error raw bytes" (String.length raw) actual_bytes;
+      check string "NDJSON provider visible error"
+        "Provider NDJSON stream error: rate_limit_exceeded: request rejected"
+        actual_message
+  | _ -> fail "expected NDJSON provider error to remain typed and visible"
+
 let test_keeper_chat_history_persists_attachment_refs_not_raw_media () =
   let base_dir = temp_base_path "gate-keeper-media-history" in
   Fun.protect
@@ -2934,6 +2963,8 @@ let () =
             test_keeper_stream_bridge_surfaces_unknown_and_incomplete_events;
           test_case "stream bridge preserves NDJSON parse failure" `Quick
             test_keeper_stream_bridge_preserves_ndjson_parse_failure;
+          test_case "stream bridge preserves NDJSON provider error" `Quick
+            test_keeper_stream_bridge_preserves_ndjson_provider_error;
           test_case "chat history persists attachment refs not raw media" `Quick
             test_keeper_chat_history_persists_attachment_refs_not_raw_media;
           test_case "user-only chat history persists attachment refs not raw media" `Quick

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -1457,6 +1457,15 @@ let test_sse_event_progress_kind_classifies_known_deltas () =
     (Some "sse_text_delta")
     (kind (ContentBlockDelta { index = 0; delta = TextDelta "visible" }));
   Alcotest.(check (option string))
+    "NDJSON provider error"
+    (Some "ndjson_error")
+    (kind
+       (NDJSONError
+          { message = "request rejected"
+          ; error_type = Some "rate_limit_exceeded"
+          ; raw = "{}"
+          }));
+  Alcotest.(check (option string))
     "thinking delta"
     (Some "sse_thinking_delta")
     (kind (ContentBlockDelta { index = 0; delta = ThinkingDelta "hidden" }));


### PR DESCRIPTION
## Summary

- handle the `NDJSONError` stream event added by Agent SDK
- preserve NDJSON provider errors as a typed `ndjson_error` instead of relabeling them as SSE errors
- expose redacted diagnostics and raw payload byte size without emitting the raw payload

## Root cause

Agent SDK now exposes `NDJSONError` as a distinct stream event. MASC's closed event matches did not handle it, so the warning-as-error build failed in the stream bridge and progress classifier.

## Verification

- `ocamlformat --check` on all touched OCaml files
- focused build: `lib/masc.cmxa`, `test/test_gate_keeper_backend.exe`, `test/test_keeper_turn_driver_accept.exe`
- `test_gate_keeper_backend.exe`: 101/101
- focused `keeper_turn_driver_accept` progress test: pass
- isolated full build: `DUNE_BUILD_DIR="$PWD/_build" dune build --root "$PWD" .`
- `git diff --check`
