### PR TITLE
fix(build): bump agent_sdk pin to v0.231.12 — unbreak main (NDJSONError)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MASC
 
 [![OCaml](https://img.shields.io/badge/OCaml-%3E%3D%205.4-orange.svg)](https://ocaml.org/)
-[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.231.11-blue.svg)](https://github.com/jeong-sik/oas)
+[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.231.12-blue.svg)](https://github.com/jeong-sik/oas)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 [한국어 버전](README.ko.md)

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -34,7 +34,7 @@ Keeper는 OAS(OCaml Agent SDK) 위에 구축된다. OAS가 제공하는 핵심 �
 | `Event_bus.t` | 에이전트 간 이벤트 발행/구독 | `oas_events.ml`을 통해 broadcast, heartbeat, board 이벤트 전달 |
 
 <!-- BEGIN GENERATED: oas-pin-manual -->
-OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.11`, runtime pin: `main@6ab2e84e1d3a7728e0cac0e727f2d4872cd3f99e`, declared base version: `v0.231.11`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
+OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.12`, runtime pin: `main@966cd3f61cd5e9e21c8390513dfa27894aeb6230`, declared base version: `v0.231.12`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
 <!-- END GENERATED: oas-pin-manual -->
 
 #### 1.1.1 OAS 환경 변수 경계

--- a/dune-project
+++ b/dune-project
@@ -60,7 +60,7 @@
   ;; ordered multimodal delivery contracts;
   ;; its SHA and rationale live in scripts/oas-agent-sdk-pin.sh (SSOT).
   ;; See check-oas-pin.sh.
-  (agent_sdk (>= 0.231.11))
+  (agent_sdk (>= 0.231.12))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc.opam
+++ b/masc.opam
@@ -31,7 +31,7 @@ depends: [
   "cohttp-eio" {>= "6.0"}
   "piaf" {= "0.2.0"}
   "eio-ssl" {>= "0.3.0"}
-  "agent_sdk" {>= "0.231.11"}
+  "agent_sdk" {>= "0.231.12"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -11,7 +11,7 @@ homepage: "https://github.com/jeong-sik/masc"
 doc: "https://github.com/jeong-sik/masc"
 bug-reports: "https://github.com/jeong-sik/masc/issues"
 depends: [
-  "agent_sdk" {= "0.231.11"}
+  "agent_sdk" {= "0.231.12"}
   "alcotest" {= "1.9.1" & with-test}
   "ambient-context" {= "0.2"}
   "ambient-context-eio" {= "0.2"}
@@ -218,8 +218,8 @@ build: [
 dev-repo: "git+https://github.com/jeong-sik/masc.git"
 pin-depends: [
   [
-  "agent_sdk.0.231.11"
-  "git+https://github.com/jeong-sik/oas.git#6ab2e84e1d3a7728e0cac0e727f2d4872cd3f99e"
+  "agent_sdk.0.231.12"
+  "git+https://github.com/jeong-sik/oas.git#966cd3f61cd5e9e21c8390513dfa27894aeb6230"
 ]
   [
     "bisect_ppx.2.8.3"

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.11"
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.12"
 # v0.231.0 is a hard-cut wave: checkpoint schema is v9 only (v1-v8
 # rejected; #2867), provider_config.output_schema is removed in favor of
 # response_format = JsonSchema as the single structured-output request state
@@ -66,12 +66,22 @@ readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.11"
 # non-conventional (oas#2922 tracks enforcing titles); the tag contains both.
 # Previous pin: main@92e3eea36 (post-v0.231.10); before that v0.231.10
 # (1fa612519).
-readonly OAS_AGENT_SDK_DECLARED_VERSION="0.231.11"
+# v0.231.12 is required, not optional: #26636 consumes
+# [Agent_sdk.Types.NDJSONError], added upstream by #2916, which v0.231.11 does
+# not define. main at 577af4ceb8 fails to compile with "Unbound constructor
+# Agent_sdk.Types.NDJSONError" until this pin advances.
+# The tag also carries #2919 (streaming connections are quarantined after
+# transport EOF) and #2926 (malformed SSE discriminators are classified as
+# wire errors rather than parse failures). MASC does not call the one breaking
+# signature in the range — [Streaming.parse_ollama_ndjson_chunk] moved from
+# [ollama_chunk option] to a typed result — so the change is additive here.
+# Previous pin: v0.231.11 (6ab2e84e1).
+readonly OAS_AGENT_SDK_DECLARED_VERSION="0.231.12"
 # TRACK_REF consumed by check-oas-pin.sh / oas-drift-check.sh /
 # sync-oas-pin-docs.sh; removed by #25579 and restored here (#25584). Use main
 # for merge-ready pins. A blocked Draft cross-repo PR may temporarily declare
 # the exact refs/pull/<number>/head review ref; CI rejects that ref once the PR
 # is no longer both Draft and blocked-on-oas.
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="6ab2e84e1d3a7728e0cac0e727f2d4872cd3f99e"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.231.11"
+readonly OAS_AGENT_SDK_SHA="966cd3f61cd5e9e21c8390513dfa27894aeb6230"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.231.12"


### PR DESCRIPTION
## 🔴 P0 — main 이 컴파일 안 돼용. 핀을 올려서 고쳐용

`main = 577af4ceb8` 의 `Build and Test` 가 실패해용:
```
Error: Unbound constructor Agent_sdk.Types.NDJSONError
Error: This variant pattern is expected to have type sse_event
```

`#26636` (`7914f2c6ad`) 이 `Agent_sdk.Types.NDJSONError` 를 **4파일**에서 쓰는데, 핀된 SHA 에는 그 생성자가 없어용.

```
핀:  6ab2e84e1  = oas v0.231.11 (#2920)   → NDJSONError 등장 0회
추가: b66e2e5df  = oas #2916              → 핀 이후 커밋
```

즉 **핀보다 앞선 SDK 를 전제로 쓰인 코드가 머지됐어용.** 로컬 opam switch 에 앞선 SDK 가 깔려 있으면 통과하고 CI 의 정확 핀에서 깨져용 — `#26631` 본문도 같은 증상을 적어놨어용.

## 핀 격차는 정확히 4커밋이에용

```
966cd3f61  chore(main): release 0.231.12 (#2924)                       ← 새 핀 (tag v0.231.12)
830a51264  fix(streaming): classify malformed SSE discriminators (#2926)
8f0eaead5  Quarantine streaming connections after transport EOF (#2919)
b66e2e5df  fix: preserve Ollama NDJSON outcome kinds (#2916)            ← NDJSONError 도입
6ab2e84e1  chore(main): release 0.231.11 (#2920)                        ← 기존 핀
```

릴리즈 태그 경계라 중간 head 를 고르지 않았어용.

## 반경을 측정했어용 — masc 기준 **추가적**이에용

| 변경 | masc 영향 |
|---|---|
| `types.mli` | `sse_event` 에 `NDJSONError` **추가만** |
| `streaming.mli` | `parse_ollama_ndjson_chunk` 가 `ollama_chunk option` → typed result (**파괴적**) |
| `http_client.mli` | 주석만 |

**그 파괴적 시그니처를 masc 는 안 써용.** 저장소 전체에서 유일한 등장은 테스트의 문자열 리터럴이에용:
```
test/test_gate_keeper_backend.ml:1915   "ollama_ndjson_chunk_parse_failure"
```

그리고 새 variant 로 인한 비전수 match 위험도 확인했어용 — `sse_event` 를 match 하는 모듈은 둘뿐이고 **둘 다 `#26636` 이 넣은 `NDJSONError` arm 을 이미 갖고 있어용**:
```
lib/keeper/keeper_agent_run_turn_helpers.ml
lib/keeper/keeper_chat_oas_stream_bridge.ml
```

## 대안과 비교

`#26636` revert 도 main 을 살려요. 그런데 그건 **전제를 되돌리는** 거고, `NDJSONError` 처리 자체는 옳은 방향이에용 (provider 에러 봉투를 `SSEError` 로 재라벨하지 않는 것). 핀을 맞추는 쪽이 근본이에용.

## 검증

로컬 빌드는 안 돌렸어용 — 공유 opam switch 에 이미 forward 핀이 깔려 있어서 **로컬 green 이 증거가 안 되용** (이 사고의 원인이 정확히 그거예용). **CI 가 판정 주체예용.**

머지 후에는 `bash scripts/opam-pin-external-deps.sh` 로 로컬 switch 를 맞춰야 해용.

## 관련

- #26639 (이 P0 이슈)
- #26621 — forward drift 를 fail-loud 로 만드는 PR. 이번 건이 그 전제의 실증 사례예용
- #26306 — `enforce_admins=false`. `#26636` 도 `CI Gate` 완료 전 머지됐어용 (오늘 세 번째)

RFC-WAIVED: 외부 의존성 핀 값 갱신이라 대상 subsystem(credential/identity/operator/sandbox/hooks/workflow)을 건드리지 않아용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
