### PR TITLE
fix(build): pin MASC to OAS NDJSON error contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MASC
 
 [![OCaml](https://img.shields.io/badge/OCaml-%3E%3D%205.4-orange.svg)](https://ocaml.org/)
-[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.231.11-blue.svg)](https://github.com/jeong-sik/oas)
+[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.231.12-blue.svg)](https://github.com/jeong-sik/oas)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 [한국어 버전](README.ko.md)

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -34,7 +34,7 @@ Keeper는 OAS(OCaml Agent SDK) 위에 구축된다. OAS가 제공하는 핵심 �
 | `Event_bus.t` | 에이전트 간 이벤트 발행/구독 | `oas_events.ml`을 통해 broadcast, heartbeat, board 이벤트 전달 |
 
 <!-- BEGIN GENERATED: oas-pin-manual -->
-OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.11`, runtime pin: `main@6ab2e84e1d3a7728e0cac0e727f2d4872cd3f99e`, declared base version: `v0.231.11`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
+OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.12`, runtime pin: `main@966cd3f61cd5e9e21c8390513dfa27894aeb6230`, declared base version: `v0.231.12`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
 <!-- END GENERATED: oas-pin-manual -->
 
 #### 1.1.1 OAS 환경 변수 경계

--- a/dune-project
+++ b/dune-project
@@ -60,7 +60,7 @@
   ;; ordered multimodal delivery contracts;
   ;; its SHA and rationale live in scripts/oas-agent-sdk-pin.sh (SSOT).
   ;; See check-oas-pin.sh.
-  (agent_sdk (>= 0.231.11))
+  (agent_sdk (>= 0.231.12))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc.opam
+++ b/masc.opam
@@ -31,7 +31,7 @@ depends: [
   "cohttp-eio" {>= "6.0"}
   "piaf" {= "0.2.0"}
   "eio-ssl" {>= "0.3.0"}
-  "agent_sdk" {>= "0.231.11"}
+  "agent_sdk" {>= "0.231.12"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -11,7 +11,7 @@ homepage: "https://github.com/jeong-sik/masc"
 doc: "https://github.com/jeong-sik/masc"
 bug-reports: "https://github.com/jeong-sik/masc/issues"
 depends: [
-  "agent_sdk" {= "0.231.11"}
+  "agent_sdk" {= "0.231.12"}
   "alcotest" {= "1.9.1" & with-test}
   "ambient-context" {= "0.2"}
   "ambient-context-eio" {= "0.2"}
@@ -218,8 +218,8 @@ build: [
 dev-repo: "git+https://github.com/jeong-sik/masc.git"
 pin-depends: [
   [
-  "agent_sdk.0.231.11"
-  "git+https://github.com/jeong-sik/oas.git#6ab2e84e1d3a7728e0cac0e727f2d4872cd3f99e"
+  "agent_sdk.0.231.12"
+  "git+https://github.com/jeong-sik/oas.git#966cd3f61cd5e9e21c8390513dfa27894aeb6230"
 ]
   [
     "bisect_ppx.2.8.3"

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.11"
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.12"
 # v0.231.0 is a hard-cut wave: checkpoint schema is v9 only (v1-v8
 # rejected; #2867), provider_config.output_schema is removed in favor of
 # response_format = JsonSchema as the single structured-output request state
@@ -66,12 +66,16 @@ readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.11"
 # non-conventional (oas#2922 tracks enforcing titles); the tag contains both.
 # Previous pin: main@92e3eea36 (post-v0.231.10); before that v0.231.10
 # (1fa612519).
-readonly OAS_AGENT_SDK_DECLARED_VERSION="0.231.11"
+# v0.231.12 preserves Ollama provider-error outcomes as the typed
+# [NDJSONError] stream event (#2916). MASC consumes that event at its typed
+# streaming boundary; the pin must move with the public constructor.
+# Previous pin: v0.231.11 (6ab2e84e1).
+readonly OAS_AGENT_SDK_DECLARED_VERSION="0.231.12"
 # TRACK_REF consumed by check-oas-pin.sh / oas-drift-check.sh /
 # sync-oas-pin-docs.sh; removed by #25579 and restored here (#25584). Use main
 # for merge-ready pins. A blocked Draft cross-repo PR may temporarily declare
 # the exact refs/pull/<number>/head review ref; CI rejects that ref once the PR
 # is no longer both Draft and blocked-on-oas.
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="6ab2e84e1d3a7728e0cac0e727f2d4872cd3f99e"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.231.11"
+readonly OAS_AGENT_SDK_SHA="966cd3f61cd5e9e21c8390513dfa27894aeb6230"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.231.12"

--- a/scripts/oas-api-surface.json
+++ b/scripts/oas-api-surface.json
@@ -1,6 +1,6 @@
 {
-  "pinned_sha": "6ab2e84e1d3a7728e0cac0e727f2d4872cd3f99e",
-  "pinned_version": "v0.231.11",
+  "pinned_sha": "966cd3f61cd5e9e21c8390513dfa27894aeb6230",
+  "pinned_version": "v0.231.12",
   "surfaces": {
     "event_bus_payload_variants": [
       "AgentCompleted",


### PR DESCRIPTION
## Summary

- align the MASC `agent_sdk` floor and exact pin with the typed `NDJSONError` contract consumed by #26636
- move the lockfile, generated pin documentation, and OAS surface fingerprint together
- keep NDJSON provider errors typed at the MASC/OAS boundary instead of adding an SSE compatibility shim

## Root cause

`main=577af4ceb8` consumed `Agent_sdk.Types.NDJSONError`, but MASC still pinned OAS `v0.231.11@6ab2e84e...`, whose `sse_event` type has no `NDJSONError` constructor. The exact main CI failure was:

- `lib/keeper/keeper_chat_oas_stream_bridge.ml:475`
- `test/test_keeper_turn_driver_accept.ml:1463`

This is a dependency-contract mismatch, not a rate-limit classification issue and not a verifier/Keeper boundary issue.

## Fix

- OAS floor: `0.231.11` → `0.231.12`
- exact pin: `6ab2e84e...` → `966cd3f61cd5e9e21c8390513dfa27894aeb6230`
- lockfile, docs, and `scripts/oas-api-surface.json` synced from `scripts/oas-agent-sdk-pin.sh`

OAS `v0.231.12` release includes #2916 and the typed `NDJSONError` constructor.

## Verification

- `bash scripts/check-oas-pin.sh --local-only` — pass
- `bash scripts/sync-oas-pin-manifests.sh --check --surface` — pass
- `bash -n scripts/oas-agent-sdk-pin.sh scripts/sync-oas-pin-manifests.sh scripts/oas-drift-check.sh` — pass
- `git diff --check` — pass
- focused Dune compile — pending because another worktree currently holds `/tmp/me-dune-local.lock`; CI is the build authority

Closes #26632 after exact-head CI is green.
