### PR TITLE
chore(deps): pin agent_sdk to oas v0.231.12 — repair main red (NDJSONError)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MASC
 
 [![OCaml](https://img.shields.io/badge/OCaml-%3E%3D%205.4-orange.svg)](https://ocaml.org/)
-[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.231.11-blue.svg)](https://github.com/jeong-sik/oas)
+[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.231.12-blue.svg)](https://github.com/jeong-sik/oas)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 [한국어 버전](README.ko.md)

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -34,7 +34,7 @@ Keeper는 OAS(OCaml Agent SDK) 위에 구축된다. OAS가 제공하는 핵심 �
 | `Event_bus.t` | 에이전트 간 이벤트 발행/구독 | `oas_events.ml`을 통해 broadcast, heartbeat, board 이벤트 전달 |
 
 <!-- BEGIN GENERATED: oas-pin-manual -->
-OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.11`, runtime pin: `main@6ab2e84e1d3a7728e0cac0e727f2d4872cd3f99e`, declared base version: `v0.231.11`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
+OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.12`, runtime pin: `main@966cd3f61cd5e9e21c8390513dfa27894aeb6230`, declared base version: `v0.231.12`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
 <!-- END GENERATED: oas-pin-manual -->
 
 #### 1.1.1 OAS 환경 변수 경계

--- a/dune-project
+++ b/dune-project
@@ -60,7 +60,7 @@
   ;; ordered multimodal delivery contracts;
   ;; its SHA and rationale live in scripts/oas-agent-sdk-pin.sh (SSOT).
   ;; See check-oas-pin.sh.
-  (agent_sdk (>= 0.231.11))
+  (agent_sdk (>= 0.231.12))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc.opam
+++ b/masc.opam
@@ -31,7 +31,7 @@ depends: [
   "cohttp-eio" {>= "6.0"}
   "piaf" {= "0.2.0"}
   "eio-ssl" {>= "0.3.0"}
-  "agent_sdk" {>= "0.231.11"}
+  "agent_sdk" {>= "0.231.12"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -11,7 +11,7 @@ homepage: "https://github.com/jeong-sik/masc"
 doc: "https://github.com/jeong-sik/masc"
 bug-reports: "https://github.com/jeong-sik/masc/issues"
 depends: [
-  "agent_sdk" {= "0.231.11"}
+  "agent_sdk" {= "0.231.12"}
   "alcotest" {= "1.9.1" & with-test}
   "ambient-context" {= "0.2"}
   "ambient-context-eio" {= "0.2"}
@@ -218,8 +218,8 @@ build: [
 dev-repo: "git+https://github.com/jeong-sik/masc.git"
 pin-depends: [
   [
-  "agent_sdk.0.231.11"
-  "git+https://github.com/jeong-sik/oas.git#6ab2e84e1d3a7728e0cac0e727f2d4872cd3f99e"
+  "agent_sdk.0.231.12"
+  "git+https://github.com/jeong-sik/oas.git#966cd3f61cd5e9e21c8390513dfa27894aeb6230"
 ]
   [
     "bisect_ppx.2.8.3"

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.11"
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.12"
 # v0.231.0 is a hard-cut wave: checkpoint schema is v9 only (v1-v8
 # rejected; #2867), provider_config.output_schema is removed in favor of
 # response_format = JsonSchema as the single structured-output request state
@@ -66,12 +66,21 @@ readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.11"
 # non-conventional (oas#2922 tracks enforcing titles); the tag contains both.
 # Previous pin: main@92e3eea36 (post-v0.231.10); before that v0.231.10
 # (1fa612519).
-readonly OAS_AGENT_SDK_DECLARED_VERSION="0.231.11"
+# v0.231.12 carries three streaming-boundary changes: #2916 preserves Ollama
+# NDJSON outcome kinds as a typed 3-way result (breaking:
+# parse_ollama_ndjson_chunk returns ollama_ndjson_parse_result), #2919
+# quarantines streaming connections after transport EOF, and #2926 classifies
+# malformed SSE discriminators (introduces the NDJSONError family). MASC main
+# already consumes NDJSONError (#26636) — this bump restores pin-consumer
+# atomicity and repairs the main CI red at 7914f2c6ad (Unbound constructor
+# Agent_sdk.Types.NDJSONError under the 0.231.11 pin).
+# Previous pin: v0.231.11 (6ab2e84e1).
+readonly OAS_AGENT_SDK_DECLARED_VERSION="0.231.12"
 # TRACK_REF consumed by check-oas-pin.sh / oas-drift-check.sh /
 # sync-oas-pin-docs.sh; removed by #25579 and restored here (#25584). Use main
 # for merge-ready pins. A blocked Draft cross-repo PR may temporarily declare
 # the exact refs/pull/<number>/head review ref; CI rejects that ref once the PR
 # is no longer both Draft and blocked-on-oas.
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="6ab2e84e1d3a7728e0cac0e727f2d4872cd3f99e"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.231.11"
+readonly OAS_AGENT_SDK_SHA="966cd3f61cd5e9e21c8390513dfa27894aeb6230"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.231.12"

--- a/scripts/oas-api-surface.json
+++ b/scripts/oas-api-surface.json
@@ -1,6 +1,6 @@
 {
-  "pinned_sha": "6ab2e84e1d3a7728e0cac0e727f2d4872cd3f99e",
-  "pinned_version": "v0.231.11",
+  "pinned_sha": "966cd3f61cd5e9e21c8390513dfa27894aeb6230",
+  "pinned_version": "v0.231.12",
   "surfaces": {
     "event_bus_payload_variants": [
       "AgentCompleted",


### PR DESCRIPTION
## 요약 — main red 수리

main CI가 `7914f2c6ad`(#26636)에서 **failure**입니다: `Unbound constructor Agent_sdk.Types.NDJSONError`. 소비 코드는 main에 있는데 pin이 v0.231.11이라서입니다 — `NDJSONError`는 **v0.231.12에만 존재**합니다 (`git grep`: v0.231.11 0건 / v0.231.12 3파일). pin-소비 원자성 복원이 이 PR입니다.

## 델타 (v0.231.11 → v0.231.12, tag `966cd3f61c`)

- #2916 Ollama NDJSON 3-way typed result (breaking: `parse_ollama_ndjson_chunk`)
- #2919 transport EOF 후 스트리밍 연결 격리
- #2926 malformed SSE discriminator 분류 (**NDJSONError family 도입** — #26636이 소비)

## 검증 (가짜 green 방지 절차)

- 태그 SHA는 `git ls-remote` 실출력 (`966cd3f61cd5e9e21c8390513dfa27894aeb6230`)
- `opam-pin-external-deps.sh --install`로 **0.231.12 실재설치** 후 이 트리에서 `dune build @check` **전체 통과** — NDJSONError 해소 + 다른 exhaustive match 파괴 없음 확인
- manifest 7종은 `sync-oas-pin-manifests.sh --surface` 재생성 (opam/locked/docs/README/api-surface)

선점 선언: https://github.com/jeong-sik/masc/pull/26621#issuecomment-5154604243 · 관련: #26621 (exact-pin 게이트 — 이 사고 클래스의 구조적 방지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)