### PR TITLE
docs(mli): drop private-helper names that no longer exist

### DIFF
--- a/lib/http_server_eio.mli
+++ b/lib/http_server_eio.mli
@@ -3,23 +3,18 @@
 
     Sister module to {!Http_server_h2} (cycle 164, the H2
     wrapper).  Conflict-free with [httpun-ws-eio] (no cohttp 6.x
-    dependency).  Includes built-in routes for [/health],
-    [/ready], plus the streamable MCP endpoint.
+    dependency).
 
-    Internal: helpers stay private — exception
-    \[Shutdown] (graceful-shutdown signaling), the 5 built-in
-    handlers ([health_handler], [ready_handler],
-    [mcp_post_handler], [mcp_get_handler]),
-    \[default_routes] (the route table assembled from those
-    handlers), \[with_streamable_mcp_request_handler],
-    \[make_request_handler] (router → request_handler
-    converter), and \[error_handler] (httpun connection error
-    handler).  The server accept loop lives in the
+    This module carries no routes and no handlers: it exposes
+    {!config}, the {!request_handler} type, and the
+    {!Response} / {!Late_response} / {!Request} / {!Router}
+    building blocks.  Concrete routes, the server accept loop,
+    and connection error handling live in the
     [Server_bootstrap_*] facade modules; the [Eio_main] entry
     point (with signal handlers) lives in the executable
     [bin/main_eio.ml] (and sibling [bin/*_eio.ml] binaries).
-    External callers reach the server through the facade modules
-    instead of these internals.
+
+    Internal: \[safe_respond_with_string] stays private.
 
     @see <https://github.com/anmonteiro/httpun> httpun
     documentation *)

--- a/lib/tool_misc_web_search.mli
+++ b/lib/tool_misc_web_search.mli
@@ -12,10 +12,9 @@
     types kept internal so callers cannot construct half-formed
     state),
     the pre-compiled whitespace normalizer,
-    JSON envelope helpers (\[json_error], \[json_ok]), text
-    cleaning helpers (\[normalize_spaces], \[clean_search_text],
-    \[trim_nonempty]),
-    \[valid_search_result_url], \[search_field],
+    text cleaning helpers (\[normalize_spaces],
+    \[clean_search_text], \[trim_nonempty]),
+    \[valid_search_result_url],
     \[parse_json_search_results] (the generic JSON parser
     behind the per-provider parsers), \[provider_to_string] /
     \[provider_of_string] / \[parse_provider_csv] /


### PR DESCRIPTION
## 요약

`.mli` 헤더가 *"Internal: helpers stay private"* 라며 나열한 심볼 중, **짝 `.ml` 에 존재하지 않는 것**을 지워용. #26634 의 main 쪽 부분이에용.

## 실측 (main `609e220e00`, 짝 `.ml` 등장 횟수)

| `.mli` | 유령 심볼 |
|---|---|
| `lib/http_server_eio.mli` | `Shutdown` 0 · `health_handler` 0 · `ready_handler` 0 · `mcp_post_handler` 0 · `mcp_get_handler` 0 · `default_routes` 0 · `make_request_handler` 0 · `with_streamable_mcp_request_handler` 0 |
| `lib/tool_misc_web_search.mli` | `json_error` 0 · `json_ok` 0 · `search_field` 0 |

`error_handler` 는 1회 등장하지만 모듈 수준 helper 가 아니라 지역 바인딩이라 목록에서 뺐어용.

## `http_server_eio.mli` 는 목록 수정으로 안 끝나용

헤더가 이렇게 주장해용:
> Includes built-in routes for [/health], [/ready], plus the streamable MCP endpoint.

그런데 `http_server_eio.ml` (645줄)의 최상위 정의는 이게 전부예용:
```
type config / let default_config / type request_handler
module Late_response / module Response / module Request / module Router
let safe_respond_with_string
```
**라우트도 핸들러도 없어용.** 같은 문단이 *"The server accept loop lives in the [Server_bootstrap_*] facade modules"* 라고 이동을 인정하면서, **옮겨간 심볼들을 여전히 "이 모듈의 private helper" 로 나열**하고 있었어용.

그래서 헤더를 **모듈이 실제로 무엇인지**로 다시 썼어용 — 라우트 없는 HTTP/1.1 서버 골격(설정 · `request_handler` 타입 · `Response`/`Late_response`/`Request`/`Router`).

## 남긴 심볼은 개별 확인했어용

`tool_misc_web_search.mli` 에서 유지한 것들의 `.ml` 등장 횟수:
```
normalize_spaces 6 · clean_search_text 3 · trim_nonempty 6
valid_search_result_url 6 · parse_json_search_results 6
provider_response 1 · cache_entry 2
```
**문단을 통째로 지우지 않은 이유**예용 — 대부분은 실재해용.

## 검증

동작 변경 0, 주석만이에용. 수정 후 두 파일에서 유령이 남지 않은 걸 확인했어용 (`\[name]` 과 `[name]` 두 표기 모두 검사).

> 참고: 검사기가 `Eio_main`·`Tool_misc_web_fetch` 같은 **타 모듈 참조**와 `contentMaxChars` 같은 **JSON 필드명**도 후보로 잡아용 — 위양성이라 손대지 않았어용. #26634 자동화 시 "같은 모듈 심볼인가" 필터가 필요해용.

RFC-WAIVED: `.mli` 주석만 바꾸는 변경이라 대상 subsystem(credential/identity/operator/sandbox/hooks/workflow)을 건드리지 않아용.

Closes part of #26634

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

# ci:skip-test-coverage

`Test Coverage Check` 가 이렇게 실패했어용:
```
Added 12 lines to covered code paths but no test files changed.
```

이 PR 은 **`.mli` 주석만** 바꿔용 (동작 변경 0, 순 −6줄). 문단을 재작성해서 `+` 줄이 12개 생겼는데, `scripts/check_test_coverage.py:178` 이 **`+` 로 시작하는 모든 diff 줄**을 세고 주석·`.mli` 를 구분하지 않아용:

```python
if line.startswith("+") and not line.startswith("+++"):
```

스크립트 docstring 이 명시한 opt-out 3종 중 2번(*"PR body contains `# ci:skip-test-coverage`"*)을 씁니다. 우회가 아니라 **의도된 경로**예용 — 다만 주석 전용 변경이 이걸 필요로 하는 것 자체는 별도로 보고할게용.

