### PR TITLE
docs(mli): drop a dangling odoc reference left by #26651

### DIFF
--- a/lib/http_server_eio.mli
+++ b/lib/http_server_eio.mli
@@ -41,8 +41,7 @@ val default_config : config
 
 (** {1 Request handler type} *)
 
-(** Standard httpun request handler shape.  Used by
-    {!Router.t} and {!make_request_handler}. *)
+(** Standard httpun request handler shape.  Used by {!Router.t}. *)
 type request_handler = Httpun.Request.t -> Httpun.Reqd.t -> unit
 
 (** {1 Response helpers} *)


### PR DESCRIPTION
## 요약

`#26651` 이 `make_request_handler` 를 private-helper 목록에서 지웠는데, **odoc 상호참조 하나를 남겼어용**:

```ocaml
(** Standard httpun request handler shape.  Used by
    {!Router.t} and {!make_request_handler}. *)
```

## 왜 놓쳤나

그 PR 의 스윕이 `\[name]` 과 `[name]` 만 봤어용. **`{!name}` 은 세 번째 표기**인데 안 봤어용 — 제 실수예용.

## 진짜 dangling 인지 확인

```
lib/http_server_eio.ml   include 문        : 0
lib/http_server_eio.mli  val make_request_handler : 0
```
`include` 로 들어오는 것도 아니고 `val` 선언도 없어서 **해석되지 않는 참조**예용.

## 반경

주석 한 줄. 동작 변경 0.

RFC-WAIVED: `.mli` 주석만 바꿔서 대상 subsystem 을 안 건드려용.

Follow-up to #26651 · 오탐 클래스는 #26650

🤖 Generated with [Claude Code](https://claude.com/claude-code)