### PR TITLE
fix(keeper): route wakeups through exact identity bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -898,6 +898,23 @@ jobs:
           chmod +x scripts/ci-run-tests.sh
           scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_goal_store"
 
+      # Keeper registry hardening: identity resolution and goal-reconciliation
+      # routing are executable behavior — the suite drives a real workspace and
+      # asserts which Keeper a durable stimulus is addressed to, never source
+      # text. It is the only suite covering
+      # [Keeper_goal_reconciliation_wake], so that routing stays ungated under
+      # @check.
+      - name: Run keeper registry hardening suite
+        id: keeper_registry_hardening_suite
+        if: ${{ always() && steps.build_step.outcome == 'success' }}
+        env:
+          ME_ROOT: /tmp/me
+          CI_TEST_HEARTBEAT_SEC: 15
+          DUNE_JOBS: 1
+        run: |
+          mkdir -p /tmp/me
+          chmod +x scripts/ci-run-tests.sh
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_registry_hardening"
       - name: Run tool blob retention suite
         id: tool_blob_retention_suite
         if: ${{ always() && steps.build_step.outcome == 'success' }}

--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -22,7 +22,7 @@ code_refs:
 
 ## 1. Purpose
 
-Keeper는 MASC의 자율 에이전트 하네스(harness)다. OAS `Agent.run` 위에서 동작하며, 장기 실행 루프, 컨텍스트 관리, 메모리 계층, 심의(deliberation), 승계(succession), 검증(verification)을 담당한다.
+Keeper는 MASC의 자율 에이전트 하네스(harness)다. OAS `Agent.run` 위에서 동작하며, 장기 실행 루프, 컨텍스트 관리, 메모리 계층, 심의(deliberation), 승계(succession)을 담당한다. Task verification verdict는 Keeper lifecycle 밖의 application-owned system LLM agent 또는 authenticated HITL authority가 typed completion-authority 경계에서 결정한다. Keeper는 evidence를 제출할 수 있지만 verifier가 되지 않는다.
 
 Keeper 하나는 다음을 소유한다:
 - **identity**: `keeper_meta` 레코드 (이름, persona, instructions, typed goal/task links)
@@ -53,8 +53,11 @@ graph LR
     KAR --> KHO[hooks_oas]
   end
   subgraph Decision
-    KD[deliberation] --> KV[verifier]
     KD --> KL[learning]
+  end
+  subgraph Completion Authority
+    CA[system LLM agent] --> CV[typed verdict]
+    HO[authenticated HITL] --> CV
   end
   subgraph Supervision
     KRS[supervisor] --> KKA[keepalive]
@@ -323,6 +326,13 @@ Task completion evidence is assembled by
 `lib/workspace/workspace_task_verification.ml` and persisted through the
 typed verification-request protocol. Evidence strings are observations; local
 substring classifiers do not decide completion.
+
+Task verification is not Keeper work. After a producer Keeper submits the
+typed evidence snapshot, the application-owned system LLM agent receives the
+persisted request and evidence and may emit the typed verdict. An authenticated
+HITL operator is the separate authority path. Neither authority enters Keeper
+registration, claims a Keeper lane, or becomes a Keeper; a rejection wakes only
+the producer Keeper.
 
 Model judgment belongs to the product operation that consumes it. Fusion,
 Keeper failure judgment, board attention, and Task completion review each own

--- a/docs/spec/13-oas-integration.md
+++ b/docs/spec/13-oas-integration.md
@@ -258,7 +258,7 @@ for each selected attempt. OAS provider registry and capability manifests are
 generic execution contracts; they are not the MASC runtime plane.
 
 ```
-runtime_id (e.g. "keeper", "verifier", "context_router")
+runtime_id (e.g. "keeper", a configured completion-authority evaluator route, "context_router")
   -> config/runtime.toml [routes] / profile lookup
   -> MASC runtime labels
   -> MASC/OAS adapter resolves labels against OAS Provider_registry
@@ -392,7 +392,8 @@ MASC typed request
 ```
 
 Fusion, Keeper failure judgment, board attention, Task completion review는 서로 다른
-도메인 계약이다. 공통 문자열 verdict, hidden budget, caller registry로 이들을
+도메인 계약이다. Task completion review의 system LLM completion-authority lane은
+Keeper가 아니며, 공통 문자열 verdict, hidden budget, caller registry로 이들을
 하나의 verifier policy에 합치지 않는다.
 
 ### 9.1 Keeper and Worker Guardrails
@@ -435,7 +436,7 @@ remain MASC-owned under `Masc.Memory.t` and the `Keeper_memory_*` modules.
 | Checkpoint | Partial | shared worker/runtime paths는 OAS Checkpoint를 사용한다. Public `Oas_worker` surface의 extra checkpoint JSON은 neutral `checkpoint_sidecar` 이름을 쓰지만 keeper 경로는 여전히 `lib/keeper/keeper_context_runtime.ml`의 wrapper + serialized context를 유지 |
 | Memory projection | Removed | MASC memory is not projected into OAS; runtime memory storage remains MASC-owned |
 | Runtime config | Complete | runtime_id -> MASC runtime config/profile -> OAS Provider_registry -> Provider_config.t |
-| Verifier | Complete | configured OAS exact-output call; no local tool/effect classifier |
+| System LLM completion authority | Complete | configured OAS exact-output call; no Keeper registration/lifecycle and no local tool/effect classifier |
 | Model resolution | Complete | oas_model_resolve.ml이 Provider_Registry SSOT 사용 |
 | Tool bridge | Complete | MASC tool_schema -> OAS Tool.t 변환 |
 
@@ -500,7 +501,7 @@ Validation steps live in `docs/KEEPER-CONTINUITY-VALIDATION.md`.
 3. **Message 타입은 공유한다**: `Agent_sdk.Types.message`가 MASC와 OAS 모두의 메시지 타입이다. 변환 레이어 없음.
 4. **Runtime name이 model을 추상화한다**: MASC policy code에 구체적 provider/model 이름이 하드코딩되지 않는다. runtime_id -> runtime.toml runtime config -> Provider_registry 체인.
 5. **Event_bus prefix는 `masc:`이다**: MASC 이벤트는 반드시 이 prefix를 사용한다. SSE bridge가 이 prefix로 필터링한다.
-6. **Verifier는 도구 이름으로 건너뛰지 않는다**: read/grep/search/status 같은 이름이나 로컬 effect label은 MODEL 호출을 생략하거나 Pass를 만들 권한이 없다.
+6. **Completion-authority model call은 도구 이름으로 건너뛰지 않는다**: read/grep/search/status 같은 이름이나 로컬 effect label은 MODEL 호출을 생략하거나 Pass를 만들 권한이 없다.
 7. **Checkpoint는 session_id로 네임스페이스된다**: 동일 agent의 다른 세션 checkpoint와 충돌하지 않는다.
 8. **OAS API 확장 제안 전에 adapter를 먼저 시도한다**: MASC-specific 개념을 OAS public contract에 밀어넣지 않는다.
 

--- a/docs/spec/SPEC-INDEX.md
+++ b/docs/spec/SPEC-INDEX.md
@@ -69,7 +69,7 @@ graph TB
 | `10-dashboard.md` | Dashboard | Web UI, API endpoints, SSE real-time updates | Draft |
 | `11-board.md` | Board System | Posts, comments, votes, filesystem/JSONL backend | Draft |
 | `12-memory-systems.md` | Memory Systems | Memory OS fact store, context budget | Draft |
-| `13-oas-integration.md` | OAS Integration | OAS Agent SDK bridge, runtime config, verifier, event bus, boundary rules | Draft |
+| `13-oas-integration.md` | OAS Integration | OAS Agent SDK bridge, runtime config, completion authority/evaluator, event bus, boundary rules | Draft |
 | `14-configuration.md` | Configuration | env, profile, prompt, runtime 설정 | Draft |
 | `15-testing.md` | Testing | 검증 계층, contract suites, fixture/manual 분리 | Draft |
 | `16-root-cause-rubric.md` | Root-Cause Rubric | 7-category taxonomy (SSOT/TEL/BND/SIL/VAR/STR/DET) for issue triage and Keeper benchmark | Reference |

--- a/lib/completion_authority_agent.ml
+++ b/lib/completion_authority_agent.ml
@@ -407,10 +407,18 @@ let process_task_once
                     detail
                 | Completion_authority_wakeup.Unroutable_producer { producer; task_id } ->
                   Log.Misc.error
-                    "completion authority rejection has no canonical Keeper producer task_id=%s producer=%s verification_id=%s"
+                    "completion authority rejection has no registered or persisted Keeper producer binding task_id=%s producer=%s verification_id=%s"
                     task_id
                     producer
                     verification_id
+                | Completion_authority_wakeup.Producer_identity_lookup_failed
+                    { producer; task_id; detail } ->
+                  Log.Misc.error
+                    "completion authority rejection producer identity lookup failed task_id=%s producer=%s verification_id=%s detail=%s"
+                    task_id
+                    producer
+                    verification_id
+                    detail
                 | Completion_authority_wakeup.Durable_queue_failed
                     { keeper_name; detail } ->
                   Log.Misc.error

--- a/lib/completion_authority_wakeup.ml
+++ b/lib/completion_authority_wakeup.ml
@@ -9,20 +9,44 @@ type delivery =
     }
   | Durable_wake_failed of { keeper_name : string; detail : string }
   | Unroutable_producer of { producer : string; task_id : string }
+  | Producer_identity_lookup_failed of {
+      producer : string;
+      task_id : string;
+      detail : string;
+    }
   | Durable_queue_failed of { keeper_name : string; detail : string }
 
 let registered_keeper_name_for_agent ~base_path producer =
-  Keeper_registry.all ~base_path ()
-  |> List.find_map (fun (entry : Keeper_registry.registry_entry) ->
-       if String.equal entry.meta.agent_name producer
-       then Some entry.name
-       else None)
+  let matching_keeper_names =
+    Keeper_registry.all ~base_path ()
+    |> List.filter_map (fun (entry : Keeper_registry.registry_entry) ->
+         if String.equal entry.meta.agent_name producer
+         then Some entry.name
+         else None)
+    |> List.sort String.compare
+  in
+  match matching_keeper_names with
+  | [] -> Ok None
+  | [keeper_name] -> Ok (Some keeper_name)
+  | keeper_names ->
+    Error
+      (Printf.sprintf
+         "multiple registered Keepers share agent_name=%s: %s"
+         producer
+         (String.concat "," keeper_names))
 ;;
 
-let producer_keeper_name ~base_path producer =
-  match registered_keeper_name_for_agent ~base_path producer with
-  | Some keeper_name -> Some keeper_name
-  | None -> Keeper_identity.canonical_keeper_name_from_agent_name producer
+let producer_keeper_name
+      ~(config : Workspace_utils_backend_setup.config)
+      producer
+  =
+  match registered_keeper_name_for_agent ~base_path:config.base_path producer with
+  | Error _ as error -> error
+  | Ok (Some keeper_name) -> Ok (Some keeper_name)
+  | Ok None ->
+    Keeper_meta_store.persisted_keeper_name_for_agent_name
+      config
+      ~agent_name:producer
 ;;
 
 let wake_rejected_producer
@@ -33,10 +57,12 @@ let wake_rejected_producer
       ~reason
       ~authority
   =
-  match producer_keeper_name ~base_path:config.base_path producer with
-  | None ->
+  match producer_keeper_name ~config producer with
+  | Error detail ->
+    Producer_identity_lookup_failed { producer; task_id; detail }
+  | Ok None ->
     Unroutable_producer { producer; task_id }
-  | Some keeper_name ->
+  | Ok (Some keeper_name) ->
     let rejection : Keeper_event_queue.completion_authority_rejection =
       { car_task_id = task_id
       ; car_verification_id = verification_id

--- a/lib/completion_authority_wakeup.ml
+++ b/lib/completion_authority_wakeup.ml
@@ -16,37 +16,20 @@ type delivery =
     }
   | Durable_queue_failed of { keeper_name : string; detail : string }
 
-let registered_keeper_name_for_agent ~base_path producer =
-  let matching_keeper_names =
-    Keeper_registry.all ~base_path ()
-    |> List.filter_map (fun (entry : Keeper_registry.registry_entry) ->
-         if String.equal entry.meta.agent_name producer
-         then Some entry.name
-         else None)
-    |> List.sort String.compare
-  in
-  match matching_keeper_names with
-  | [] -> Ok None
-  | [keeper_name] -> Ok (Some keeper_name)
-  | keeper_names ->
-    Error
-      (Printf.sprintf
-         "multiple registered Keepers share agent_name=%s: %s"
-         producer
-         (String.concat "," keeper_names))
-;;
-
 let producer_keeper_name
       ~(config : Workspace_utils_backend_setup.config)
       producer
   =
-  match registered_keeper_name_for_agent ~base_path:config.base_path producer with
-  | Error _ as error -> error
-  | Ok (Some keeper_name) -> Ok (Some keeper_name)
-  | Ok None ->
-    Keeper_meta_store.persisted_keeper_name_for_agent_name
-      config
-      ~agent_name:producer
+  match Keeper_identity_binding.resolve ~config ~agent_name:producer with
+  | Keeper_identity_binding.Not_found -> Ok None
+  | Keeper_identity_binding.Unique keeper_name -> Ok (Some keeper_name)
+  | Keeper_identity_binding.Ambiguous keeper_names ->
+    Error
+      (Printf.sprintf
+         "multiple registered or persisted Keepers share agent_name=%s: %s"
+         producer
+         (String.concat "," keeper_names))
+  | Keeper_identity_binding.Lookup_failed detail -> Error detail
 ;;
 
 let wake_rejected_producer

--- a/lib/completion_authority_wakeup.ml
+++ b/lib/completion_authority_wakeup.ml
@@ -11,6 +11,20 @@ type delivery =
   | Unroutable_producer of { producer : string; task_id : string }
   | Durable_queue_failed of { keeper_name : string; detail : string }
 
+let registered_keeper_name_for_agent ~base_path producer =
+  Keeper_registry.all ~base_path ()
+  |> List.find_map (fun (entry : Keeper_registry.registry_entry) ->
+       if String.equal entry.meta.agent_name producer
+       then Some entry.name
+       else None)
+;;
+
+let producer_keeper_name ~base_path producer =
+  match registered_keeper_name_for_agent ~base_path producer with
+  | Some keeper_name -> Some keeper_name
+  | None -> Keeper_identity.canonical_keeper_name_from_agent_name producer
+;;
+
 let wake_rejected_producer
       ~(config : Workspace_utils_backend_setup.config)
       ~producer
@@ -19,7 +33,7 @@ let wake_rejected_producer
       ~reason
       ~authority
   =
-  match Keeper_identity.canonical_keeper_name_from_agent_name producer with
+  match producer_keeper_name ~base_path:config.base_path producer with
   | None ->
     Unroutable_producer { producer; task_id }
   | Some keeper_name ->

--- a/lib/completion_authority_wakeup.mli
+++ b/lib/completion_authority_wakeup.mli
@@ -1,6 +1,8 @@
 (** Durable delivery after a completion authority (system LLM or HITL) rejects
     submitted evidence. A live wake is only an acceleration hint; the typed
-    rejection is committed to the producer Keeper's queue first. *)
+    rejection is committed to the producer Keeper's queue first. When a live
+    registry entry exists, its exact [agent_name] binding is authoritative;
+    structural identity parsing is only the deferred/unregistered fallback. *)
 
 type delivery =
   | Signaled of { keeper_name : string }

--- a/lib/completion_authority_wakeup.mli
+++ b/lib/completion_authority_wakeup.mli
@@ -1,8 +1,10 @@
 (** Durable delivery after a completion authority (system LLM or HITL) rejects
     submitted evidence. A live wake is only an acceleration hint; the typed
     rejection is committed to the producer Keeper's queue first. When a live
-    registry entry exists, its exact [agent_name] binding is authoritative;
-    structural identity parsing is only the deferred/unregistered fallback. *)
+    registry entry exists, its exact [agent_name] binding is authoritative. A
+    stopped producer is resolved from the same [agent_name] field in persisted
+    Keeper metadata; an absent or ambiguous binding remains an explicit typed
+    delivery failure. *)
 
 type delivery =
   | Signaled of { keeper_name : string }
@@ -12,6 +14,11 @@ type delivery =
     }
   | Durable_wake_failed of { keeper_name : string; detail : string }
   | Unroutable_producer of { producer : string; task_id : string }
+  | Producer_identity_lookup_failed of {
+      producer : string;
+      task_id : string;
+      detail : string;
+    }
   | Durable_queue_failed of { keeper_name : string; detail : string }
 
 val wake_rejected_producer :

--- a/lib/keeper/keeper_goal_reconciliation_wake.ml
+++ b/lib/keeper/keeper_goal_reconciliation_wake.ml
@@ -13,34 +13,116 @@ type reconciliation_summary = {
   failed_count : int;
 }
 
-let registered_assigned_keepers goal_id =
-  Keeper_registry.all ()
+type keeper_target_resolution =
+  | Assigned_keeper of string
+  | No_assigned_keeper
+  | Ambiguous_assigned_keepers of string list
+  | Assigned_keeper_lookup_failed of string
+
+type durable_assignment_scan = {
+  keeper_names : string list;
+  errors : string list;
+}
+
+let registered_assigned_keepers ~base_path goal_id =
+  Keeper_registry.all ~base_path ()
   |> List.filter_map (fun (entry : Keeper_registry.registry_entry) ->
-       if List.mem goal_id entry.meta.active_goal_ids then Some entry.name else None)
+       if
+         (not entry.meta.paused)
+         && List.mem goal_id entry.meta.active_goal_ids
+       then Some entry.name
+       else None)
+  |> List.sort_uniq String.compare
 ;;
 
 let durable_assigned_keepers config goal_id =
-  Keeper_meta_store.keepalive_keeper_names config
-  |> List.filter_map (fun keeper_name ->
-       match Keeper_meta_store.read_effective_meta config keeper_name with
-       | Ok (Some meta)
-         when not meta.Keeper_meta_contract.paused
-              && List.mem goal_id meta.active_goal_ids ->
-         Some meta.name
-       | Ok (Some _) | Ok None | Error _ -> None)
+  let rec collect keeper_names errors = function
+    | [] ->
+      { keeper_names = List.sort_uniq String.compare keeper_names
+      ; errors = List.rev errors
+      }
+    | keeper_name :: rest ->
+      (match Keeper_meta_store.read_effective_meta_resolved config keeper_name with
+       | Error detail ->
+         collect
+           keeper_names
+           (Printf.sprintf "keeper=%s: %s" keeper_name detail :: errors)
+           rest
+       | Ok None -> collect keeper_names errors rest
+       | Ok (Some (canonical_keeper_name, meta)) ->
+         if
+           (not meta.Keeper_meta_contract.paused)
+           && List.mem goal_id meta.active_goal_ids
+         then collect (canonical_keeper_name :: keeper_names) errors rest
+         else collect keeper_names errors rest)
+  in
+  match Keeper_meta_store.persisted_keeper_names_result config with
+  | Error detail -> { keeper_names = []; errors = [ detail ] }
+  | Ok keeper_names -> collect [] [] keeper_names
 ;;
 
-let sole_assigned_keeper ~config goal_id =
-  registered_assigned_keepers goal_id @ durable_assigned_keepers config goal_id
-  |> List.sort_uniq String.compare
-  |> function
-  | [ keeper_name ] -> Some keeper_name
-  | [] | _ :: _ :: _ -> None
+let assigned_keeper_resolution ~(config : Workspace.config) goal_id =
+  let registered =
+    registered_assigned_keepers ~base_path:config.Workspace.base_path goal_id
+  in
+  let durable = durable_assigned_keepers config goal_id in
+  if durable.errors <> []
+  then
+    Log.Keeper.error
+      "goal reconciliation Keeper assignment scan incomplete goal_id=%s errors=%s"
+      goal_id
+      (String.concat "; " durable.errors);
+  match List.sort_uniq String.compare (registered @ durable.keeper_names) with
+  | [ keeper_name ] -> Assigned_keeper keeper_name
+  | [] when durable.errors <> [] ->
+    Assigned_keeper_lookup_failed (String.concat "; " durable.errors)
+  | [] -> No_assigned_keeper
+  | keeper_names -> Ambiguous_assigned_keepers keeper_names
+;;
+
+let exact_producer_keeper_name ~config ~completing_agent_name =
+  match
+    Keeper_identity_binding.resolve
+      ~config
+      ~agent_name:completing_agent_name
+  with
+  | Keeper_identity_binding.Not_found -> Ok None
+  | Keeper_identity_binding.Unique keeper_name -> Ok (Some keeper_name)
+  | Keeper_identity_binding.Ambiguous keeper_names ->
+    Error
+      (Printf.sprintf
+         "multiple registered or persisted Keepers share agent_name=%s: %s"
+         completing_agent_name
+         (String.concat "," keeper_names))
+  | Keeper_identity_binding.Lookup_failed detail -> Error detail
+;;
 
 let target_keeper_name ~config ~completing_agent_name ~goal_id =
-  match Keeper_identity.canonical_keeper_name_from_agent_name completing_agent_name with
-  | Some keeper_name -> Some keeper_name
-  | None -> sole_assigned_keeper ~config goal_id
+  match assigned_keeper_resolution ~config goal_id with
+  | Assigned_keeper keeper_name -> Some keeper_name
+  | Ambiguous_assigned_keepers keeper_names ->
+    Log.Keeper.error
+      "goal reconciliation has ambiguous active Goal assignment goal_id=%s keepers=%s"
+      goal_id
+      (String.concat "," keeper_names);
+    None
+  | Assigned_keeper_lookup_failed detail ->
+    Log.Keeper.error
+      "goal reconciliation Keeper assignment lookup failed goal_id=%s detail=%s"
+      goal_id
+      detail;
+    None
+  | No_assigned_keeper ->
+    (match exact_producer_keeper_name ~config ~completing_agent_name with
+     | Ok (Some keeper_name) -> Some keeper_name
+     | Ok None -> None
+     | Error detail ->
+       Log.Keeper.error
+         "goal reconciliation producer identity lookup failed goal_id=%s producer=%s detail=%s"
+         goal_id
+         completing_agent_name
+         detail;
+       None)
 
 let wake_keeper ~base_path keeper_name goal_id =
   match

--- a/lib/keeper/keeper_goal_reconciliation_wake.ml
+++ b/lib/keeper/keeper_goal_reconciliation_wake.ml
@@ -27,10 +27,7 @@ type durable_assignment_scan = {
 let registered_assigned_keepers ~base_path goal_id =
   Keeper_registry.all ~base_path ()
   |> List.filter_map (fun (entry : Keeper_registry.registry_entry) ->
-       if
-         (not entry.meta.paused)
-         && List.mem goal_id entry.meta.active_goal_ids
-       then Some entry.name
+       if List.mem goal_id entry.meta.active_goal_ids then Some entry.name
        else None)
   |> List.sort_uniq String.compare
 ;;
@@ -50,9 +47,7 @@ let durable_assigned_keepers config goal_id =
            rest
        | Ok None -> collect keeper_names errors rest
        | Ok (Some (canonical_keeper_name, meta)) ->
-         if
-           (not meta.Keeper_meta_contract.paused)
-           && List.mem goal_id meta.active_goal_ids
+         if List.mem goal_id meta.active_goal_ids
          then collect (canonical_keeper_name :: keeper_names) errors rest
          else collect keeper_names errors rest)
   in

--- a/lib/keeper/keeper_goal_reconciliation_wake.ml
+++ b/lib/keeper/keeper_goal_reconciliation_wake.ml
@@ -62,17 +62,17 @@ let assigned_keeper_resolution ~(config : Workspace.config) goal_id =
   in
   let durable = durable_assigned_keepers config goal_id in
   if durable.errors <> []
-  then
+  then (
     Log.Keeper.error
       "goal reconciliation Keeper assignment scan incomplete goal_id=%s errors=%s"
       goal_id
       (String.concat "; " durable.errors);
-  match List.sort_uniq String.compare (registered @ durable.keeper_names) with
-  | [ keeper_name ] -> Assigned_keeper keeper_name
-  | [] when durable.errors <> [] ->
-    Assigned_keeper_lookup_failed (String.concat "; " durable.errors)
-  | [] -> No_assigned_keeper
-  | keeper_names -> Ambiguous_assigned_keepers keeper_names
+    Assigned_keeper_lookup_failed (String.concat "; " durable.errors))
+  else
+    match List.sort_uniq String.compare (registered @ durable.keeper_names) with
+    | [ keeper_name ] -> Assigned_keeper keeper_name
+    | [] -> No_assigned_keeper
+    | keeper_names -> Ambiguous_assigned_keepers keeper_names
 ;;
 
 let exact_producer_keeper_name ~config ~completing_agent_name =

--- a/lib/keeper/keeper_goal_reconciliation_wake.ml
+++ b/lib/keeper/keeper_goal_reconciliation_wake.ml
@@ -1,6 +1,7 @@
 type enqueue_outcome =
   | Not_ready
   | No_keeper_target of { goal_id : string }
+  | Keeper_target_lookup_failed of { goal_id : string; detail : string }
   | Enqueued of { goal_id : string; keeper_name : string }
   | Already_present of { goal_id : string; keeper_name : string }
   | Enqueue_failed of { goal_id : string; keeper_name : string; detail : string }
@@ -94,30 +95,18 @@ let exact_producer_keeper_name ~config ~completing_agent_name =
 
 let target_keeper_name ~config ~completing_agent_name ~goal_id =
   match assigned_keeper_resolution ~config goal_id with
-  | Assigned_keeper keeper_name -> Some keeper_name
+  | Assigned_keeper keeper_name -> Ok (Some keeper_name)
   | Ambiguous_assigned_keepers keeper_names ->
-    Log.Keeper.error
-      "goal reconciliation has ambiguous active Goal assignment goal_id=%s keepers=%s"
-      goal_id
-      (String.concat "," keeper_names);
-    None
-  | Assigned_keeper_lookup_failed detail ->
-    Log.Keeper.error
-      "goal reconciliation Keeper assignment lookup failed goal_id=%s detail=%s"
-      goal_id
-      detail;
-    None
+    Error
+      (Printf.sprintf
+         "ambiguous active Goal assignment goal_id=%s keepers=%s"
+         goal_id
+         (String.concat "," keeper_names))
+  | Assigned_keeper_lookup_failed detail -> Error detail
   | No_assigned_keeper ->
     (match exact_producer_keeper_name ~config ~completing_agent_name with
-     | Ok (Some keeper_name) -> Some keeper_name
-     | Ok None -> None
-     | Error detail ->
-       Log.Keeper.error
-         "goal reconciliation producer identity lookup failed goal_id=%s producer=%s detail=%s"
-         goal_id
-         completing_agent_name
-         detail;
-       None)
+     | Ok keeper_name -> Ok keeper_name
+     | Error detail -> Error detail)
 
 let wake_keeper ~base_path keeper_name goal_id =
   match
@@ -150,7 +139,16 @@ let enqueue_ready ?(wake_if_present = false) ~config ~completing_agent_name
       ({ Masc_task_handlers.Task_goal_reconciliation.goal_id; triggering_task_id } as ready_fact)
   =
   match target_keeper_name ~config ~completing_agent_name ~goal_id with
-     | None ->
+     | Error detail ->
+       Log.Keeper.error
+         "goal reconciliation Keeper target lookup failed goal_id=%s \
+          triggering_task_id=%s completing_agent=%s detail=%s"
+         goal_id
+         triggering_task_id
+         completing_agent_name
+         detail;
+       Keeper_target_lookup_failed { goal_id; detail }
+     | Ok None ->
        Log.Keeper.warn
          "goal reconciliation ready but no unambiguous Keeper target goal_id=%s \
           triggering_task_id=%s completing_agent=%s"
@@ -158,7 +156,7 @@ let enqueue_ready ?(wake_if_present = false) ~config ~completing_agent_name
          triggering_task_id
          completing_agent_name;
        No_keeper_target { goal_id }
-     | Some keeper_name ->
+     | Ok (Some keeper_name) ->
        let ready : Keeper_event_queue.goal_reconciliation_ready =
          { gr_goal_id = ready_fact.goal_id
          ; gr_triggering_task_id = ready_fact.triggering_task_id
@@ -231,6 +229,8 @@ let reconcile_startup ~config =
          }
        | No_keeper_target _ ->
          { summary with unresolved_count = summary.unresolved_count + 1 }
+       | Keeper_target_lookup_failed _ ->
+         { summary with failed_count = summary.failed_count + 1 }
        | Enqueue_failed _ ->
          { summary with failed_count = summary.failed_count + 1 })
     { ready_count = List.length ready

--- a/lib/keeper/keeper_goal_reconciliation_wake.mli
+++ b/lib/keeper/keeper_goal_reconciliation_wake.mli
@@ -1,6 +1,7 @@
 type enqueue_outcome =
   | Not_ready
   | No_keeper_target of { goal_id : string }
+  | Keeper_target_lookup_failed of { goal_id : string; detail : string }
   | Enqueued of { goal_id : string; keeper_name : string }
   | Already_present of { goal_id : string; keeper_name : string }
   | Enqueue_failed of { goal_id : string; keeper_name : string; detail : string }

--- a/lib/keeper/keeper_goal_reconciliation_wake.mli
+++ b/lib/keeper/keeper_goal_reconciliation_wake.mli
@@ -20,8 +20,10 @@ val enqueue_if_ready :
   enqueue_outcome
 (** Re-read canonical Goal/Task state after a terminal Task commit, durably
     enqueue one typed reconciliation stimulus, then wake its Keeper. The
-    completing Keeper is preferred; an external completion may target the sole
-    durable Keeper whose [active_goal_ids] contains the Goal. The function
+    registered or persisted Keeper assignment whose [active_goal_ids] contains
+    the Goal is authoritative. When no unambiguous assignment exists, an
+    exact live or persisted [agent_name] binding may identify the producer;
+    identity strings are never parsed to invent a Keeper name. The function
     never mutates Goal phase. *)
 
 val reconcile_startup :

--- a/lib/keeper/keeper_identity_binding.ml
+++ b/lib/keeper/keeper_identity_binding.ml
@@ -1,0 +1,30 @@
+(** Authoritative Keeper identity bindings.
+
+    This module deliberately does not parse an agent name or derive a Keeper
+    name from spelling. It joins the live registry and persisted metadata on
+    their typed [agent_name] field and preserves ambiguity as data. *)
+
+type resolution =
+  | Not_found
+  | Unique of string
+  | Ambiguous of string list
+  | Lookup_failed of string
+
+let resolve ~config ~agent_name =
+  let registered_keeper_names =
+    Keeper_registry_lookup.find_all_by_agent_name_in_base_path
+      ~base_path:config.Workspace.base_path
+      agent_name
+    |> List.map (fun (entry : Keeper_registry.registry_entry) -> entry.name)
+    |> List.sort_uniq String.compare
+  in
+  match registered_keeper_names with
+  | _ :: _ :: _ -> Ambiguous registered_keeper_names
+  | [ keeper_name ] -> Unique keeper_name
+  | [] ->
+    (match
+       Keeper_meta_store.persisted_keeper_name_for_agent_name config ~agent_name
+     with
+     | Ok None -> Not_found
+     | Ok (Some keeper_name) -> Unique keeper_name
+     | Error detail -> Lookup_failed detail)

--- a/lib/keeper/keeper_identity_binding.mli
+++ b/lib/keeper/keeper_identity_binding.mli
@@ -1,0 +1,15 @@
+(** Exact Keeper identity binding across live registry and persisted metadata.
+
+    [resolve] compares only the stored [agent_name] field in the live registry
+    or persisted metadata. It never parses or canonicalizes a free-form agent
+    string. Duplicate bindings and storage failures remain explicit so callers
+    cannot silently select a Keeper. *)
+
+type resolution =
+  | Not_found
+  | Unique of string
+  | Ambiguous of string list
+  | Lookup_failed of string
+
+val resolve :
+  config:Workspace.config -> agent_name:string -> resolution

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -89,7 +89,7 @@ let persisted_keeper_name_for_agent_name config ~agent_name =
        | Ok None -> collect_matches matches rest
        | Ok (Some meta) ->
          if String.equal meta.agent_name agent_name
-         then collect_matches (meta.name :: matches) rest
+         then collect_matches (keeper_name :: matches) rest
          else collect_matches matches rest)
   in
   match persisted_keeper_names_result config with

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -80,6 +80,33 @@ let persisted_keeper_names config =
     []
 ;;
 
+let persisted_keeper_name_for_agent_name config ~agent_name =
+  let rec collect_matches matches = function
+    | [] -> Ok (List.rev matches)
+    | keeper_name :: rest ->
+      (match read_meta_file_path (keeper_meta_path config keeper_name) with
+       | Error detail -> Error detail
+       | Ok None -> collect_matches matches rest
+       | Ok (Some meta) ->
+         if String.equal meta.agent_name agent_name
+         then collect_matches (meta.name :: matches) rest
+         else collect_matches matches rest)
+  in
+  match persisted_keeper_names_result config with
+  | Error _ as error -> error
+  | Ok keeper_names ->
+    (match collect_matches [] keeper_names with
+     | Error _ as error -> error
+     | Ok [] -> Ok None
+     | Ok [keeper_name] -> Ok (Some keeper_name)
+     | Ok keeper_names ->
+       Error
+         (Printf.sprintf
+            "multiple persisted Keepers share agent_name=%s: %s"
+            agent_name
+            (String.concat "," keeper_names)))
+;;
+
 let configured_keeper_names config =
   Keeper_types_profile.discover_keepers_toml
     (Config_dir_resolver.keepers_dir_for_base_path

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -34,6 +34,13 @@ val is_keeper_meta_file : string -> bool
 val persisted_keeper_names_result : Workspace.config -> (string list, string) result
 val persisted_keeper_names : Workspace.config -> string list
 
+(** Resolve an agent identity from current persisted Keeper metadata.
+    [Ok None] means no persisted Keeper owns [agent_name]. A metadata read
+    failure or duplicate identity is returned as [Error] and is never
+    collapsed into an absent Keeper. *)
+val persisted_keeper_name_for_agent_name :
+  Workspace.config -> agent_name:string -> (string option, string) result
+
 (** List keeper names declared in TOML config (overlay sources). *)
 val configured_keeper_names : Workspace.config -> string list
 

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -34,7 +34,7 @@ val is_keeper_meta_file : string -> bool
 val persisted_keeper_names_result : Workspace.config -> (string list, string) result
 val persisted_keeper_names : Workspace.config -> string list
 
-(** Resolve an agent identity from current persisted Keeper metadata.
+(** Resolve a Keeper name from its current persisted [agent_name] binding.
     [Ok None] means no persisted Keeper owns [agent_name]. A metadata read
     failure or duplicate identity is returned as [Error] and is never
     collapsed into an absent Keeper. *)

--- a/lib/keeper/keeper_registry_lookup.ml
+++ b/lib/keeper/keeper_registry_lookup.ml
@@ -20,6 +20,12 @@ let find_by_agent_name agent_name =
        String.equal v.meta.agent_name agent_name)
 ;;
 
+let find_all_by_agent_name_in_base_path ~base_path agent_name =
+  Keeper_registry.all ~base_path ()
+  |> List.filter (fun (v : registry_entry) ->
+       String.equal v.meta.agent_name agent_name)
+;;
+
 let find_by_id (uid : Keeper_id.Uid.t) =
   Keeper_registry.all ()
   |> List.find_opt (fun (v : registry_entry) ->

--- a/lib/keeper/keeper_registry_lookup.mli
+++ b/lib/keeper/keeper_registry_lookup.mli
@@ -10,6 +10,12 @@ val find_by_name : string -> registry_entry option
 (** Look up a keeper by agent_name across all base_paths (O(n) scan). *)
 val find_by_agent_name : string -> registry_entry option
 
+(** Look up every Keeper with an exact [agent_name] binding in one base path.
+    The list is intentionally not collapsed: duplicate bindings are an
+    identity ambiguity and callers must not choose one heuristically. *)
+val find_all_by_agent_name_in_base_path :
+  base_path:string -> string -> registry_entry list
+
 (** Look up a keeper by stable UID across all base_paths (O(n) scan). *)
 val find_by_id : Keeper_id.Uid.t -> registry_entry option
 

--- a/lib/server/server_routes_http_routes_verification.ml
+++ b/lib/server/server_routes_http_routes_verification.ml
@@ -183,10 +183,18 @@ let commit_operator_verdict ~config ~operator_id request =
           detail
       | Completion_authority_wakeup.Unroutable_producer { producer; task_id } ->
         Log.Server.error
-          "operator completion rejection has no canonical Keeper producer task_id=%s producer=%s verification_id=%s"
+          "operator completion rejection has no registered or persisted Keeper producer binding task_id=%s producer=%s verification_id=%s"
           task_id
           producer
           verification_id
+      | Completion_authority_wakeup.Producer_identity_lookup_failed
+          { producer; task_id; detail } ->
+        Log.Server.error
+          "operator completion rejection producer identity lookup failed task_id=%s producer=%s verification_id=%s detail=%s"
+          task_id
+          producer
+          verification_id
+          detail
       | Completion_authority_wakeup.Durable_queue_failed { keeper_name; detail } ->
         Log.Server.error
           "operator completion rejection durable queue failed task_id=%s verification_id=%s keeper=%s detail=%s"

--- a/lib/workspace_metric_hooks.ml
+++ b/lib/workspace_metric_hooks.ml
@@ -451,6 +451,12 @@ let install () =
        | Keeper_goal_reconciliation_wake.No_keeper_target { goal_id } ->
          Workspace_hooks.Task_terminal_delivery_degraded
            { kind = "no_keeper_target"; detail = "goal_id=" ^ goal_id }
+       | Keeper_goal_reconciliation_wake.Keeper_target_lookup_failed
+           { goal_id; detail } ->
+         Workspace_hooks.Task_terminal_delivery_degraded
+           { kind = "keeper_target_lookup_failed"
+           ; detail = Printf.sprintf "goal_id=%s: %s" goal_id detail
+           }
        | Keeper_goal_reconciliation_wake.Enqueue_failed
            { goal_id; keeper_name; detail } ->
          Workspace_hooks.Task_terminal_delivery_degraded

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -51,6 +51,13 @@ let make_goal_reconciler_meta () =
   | Error detail -> failwith ("goal reconciler meta failed: " ^ detail)
 ;;
 
+let write_text_file path content =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+;;
+
 let register name =
   let meta = make_meta name in
   KR.For_testing.register ~base_path meta.name meta
@@ -666,7 +673,9 @@ let test_goal_reconciliation_enqueues_once_after_last_terminal_task () =
 ;;
 
 let test_goal_reconciliation_prefers_authoritative_assignment
-      ?(assigned_paused = false) () =
+      ?(assigned_paused = false)
+      ?(corrupt_persisted_assignment = false)
+      () =
   let dir = temp_dir "registry_goal_reconciliation_assignment" in
   Fun.protect
     ~finally:(fun () ->
@@ -742,6 +751,11 @@ let test_goal_reconciliation_prefers_authoritative_assignment
             ~base_path:config.base_path
             assigned_meta.name
             assigned_meta);
+       if corrupt_persisted_assignment
+       then
+         write_text_file
+           (Masc.Keeper_types_profile.keeper_meta_path config "corrupt-assignment")
+           "{ malformed Keeper metadata";
        (match
           Masc.Keeper_goal_reconciliation_wake.enqueue_if_ready
             ~config
@@ -749,14 +763,26 @@ let test_goal_reconciliation_prefers_authoritative_assignment
             ~task_id:"task-002"
         with
         | Masc.Keeper_goal_reconciliation_wake.Enqueued { keeper_name } ->
-          check string
-            "assigned Keeper owns reconciliation wake"
-           assigned_meta.name
-           keeper_name
+          if corrupt_persisted_assignment
+          then fail "incomplete assignment scan was treated as routable"
+          else
+            check string
+              "assigned Keeper owns reconciliation wake"
+              assigned_meta.name
+              keeper_name
+        | Masc.Keeper_goal_reconciliation_wake.No_keeper_target { goal_id } ->
+          if not corrupt_persisted_assignment
+          then fail "authoritative Goal assignment did not produce a durable wake"
+          else check string "incomplete scan leaves Goal visibly unresolved" goal.id goal_id
         | _ -> fail "authoritative Goal assignment did not produce a durable wake");
        check int "producer does not receive an assignment-owned wake" 0
          (registry_snapshot ~base_path:config.base_path producer_meta.name
           |> Keeper_event_queue.length);
+       if corrupt_persisted_assignment
+       then
+         check int "assigned Keeper does not receive a partial-scan wake" 0
+           (registry_snapshot ~base_path:config.base_path assigned_meta.name
+            |> Keeper_event_queue.length);
        let discovery =
          Keeper_event_queue_persistence.discover_keeper_names_with_snapshots
            ~base_path:config.base_path
@@ -767,13 +793,19 @@ let test_goal_reconciliation_prefers_authoritative_assignment
          check
            (list string)
            "only the assigned canonical Keeper receives the wake"
-           [ assigned_meta.name ]
+           (if corrupt_persisted_assignment then [] else [ assigned_meta.name ])
            discovery.keeper_names)
 ;;
 
 let test_goal_reconciliation_keeps_paused_assignment_authoritative () =
   test_goal_reconciliation_prefers_authoritative_assignment
     ~assigned_paused:true
+    ()
+;;
+
+let test_goal_reconciliation_fails_closed_on_assignment_scan_error () =
+  test_goal_reconciliation_prefers_authoritative_assignment
+    ~corrupt_persisted_assignment:true
     ()
 ;;
 
@@ -1391,6 +1423,10 @@ let () =
             "paused Goal assignment remains authoritative"
             `Quick
             test_goal_reconciliation_keeps_paused_assignment_authoritative
+        ; test_case
+            "Goal reconciliation fails closed on assignment scan error"
+            `Quick
+            test_goal_reconciliation_fails_closed_on_assignment_scan_error
         ; test_case
             "restart scan retries missed reconciliation exactly once"
             `Quick

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -665,7 +665,8 @@ let test_goal_reconciliation_enqueues_once_after_last_terminal_task () =
        | None -> fail "Goal disappeared")
 ;;
 
-let test_goal_reconciliation_prefers_authoritative_assignment () =
+let test_goal_reconciliation_prefers_authoritative_assignment
+      ?(assigned_paused = false) () =
   let dir = temp_dir "registry_goal_reconciliation_assignment" in
   Fun.protect
     ~finally:(fun () ->
@@ -678,6 +679,9 @@ let test_goal_reconciliation_prefers_authoritative_assignment () =
        let config = Masc.Workspace.default_config dir in
        let completing_agent_name = "keeper-executor-agent-agent" in
        ignore (Masc.Workspace.init config ~agent_name:(Some completing_agent_name));
+       let producer_meta =
+         { (make_meta "producer") with agent_name = completing_agent_name }
+       in
        let goal, _ =
          match
            Goal_store.upsert_goal
@@ -722,8 +726,16 @@ let test_goal_reconciliation_prefers_authoritative_assignment () =
        in
        finish "task-001";
        finish "task-002";
+       ignore
+         (KR.register_offline
+            ~base_path:config.base_path
+            producer_meta.name
+            producer_meta);
        let assigned_meta =
-         { (make_goal_reconciler_meta ()) with active_goal_ids = [ goal.id ] }
+         { (make_goal_reconciler_meta ()) with
+           active_goal_ids = [ goal.id ]
+         ; paused = assigned_paused
+         }
        in
        ignore
          (KR.register_offline
@@ -739,9 +751,12 @@ let test_goal_reconciliation_prefers_authoritative_assignment () =
         | Masc.Keeper_goal_reconciliation_wake.Enqueued { keeper_name } ->
           check string
             "assigned Keeper owns reconciliation wake"
-            assigned_meta.name
-            keeper_name
+           assigned_meta.name
+           keeper_name
         | _ -> fail "authoritative Goal assignment did not produce a durable wake");
+       check int "producer does not receive an assignment-owned wake" 0
+         (registry_snapshot ~base_path:config.base_path producer_meta.name
+          |> Keeper_event_queue.length);
        let discovery =
          Keeper_event_queue_persistence.discover_keeper_names_with_snapshots
            ~base_path:config.base_path
@@ -754,6 +769,12 @@ let test_goal_reconciliation_prefers_authoritative_assignment () =
            "only the assigned canonical Keeper receives the wake"
            [ assigned_meta.name ]
            discovery.keeper_names)
+;;
+
+let test_goal_reconciliation_keeps_paused_assignment_authoritative () =
+  test_goal_reconciliation_prefers_authoritative_assignment
+    ~assigned_paused:true
+    ()
 ;;
 
 let test_goal_reconciliation_restart_scan_retries_missed_delivery () =
@@ -1366,6 +1387,10 @@ let () =
             "goal reconciliation prefers authoritative assignment"
             `Quick
             test_goal_reconciliation_prefers_authoritative_assignment
+        ; test_case
+            "paused Goal assignment remains authoritative"
+            `Quick
+            test_goal_reconciliation_keeps_paused_assignment_authoritative
         ; test_case
             "restart scan retries missed reconciliation exactly once"
             `Quick

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -27,7 +27,6 @@ let make_meta name =
       (`Assoc
         [
           ("name", `String name);
-          ("agent_name", `String ("agent-" ^ name));
           ("trace_id", `String ("trace-" ^ name));
           ("allowed_paths", `List [ `String "*" ]);
           ("autoboot_enabled", `Bool false);
@@ -666,6 +665,97 @@ let test_goal_reconciliation_enqueues_once_after_last_terminal_task () =
        | None -> fail "Goal disappeared")
 ;;
 
+let test_goal_reconciliation_prefers_authoritative_assignment () =
+  let dir = temp_dir "registry_goal_reconciliation_assignment" in
+  Fun.protect
+    ~finally:(fun () ->
+      KR.For_testing.clear ();
+      cleanup_dir dir)
+    (fun () ->
+       Eio_main.run @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       KR.For_testing.clear ();
+       let config = Masc.Workspace.default_config dir in
+       let completing_agent_name = "keeper-executor-agent-agent" in
+       ignore (Masc.Workspace.init config ~agent_name:(Some completing_agent_name));
+       let goal, _ =
+         match
+           Goal_store.upsert_goal
+             config
+             ~id:"goal-reconciliation-assignment"
+             ~title:"Use the assigned Keeper"
+             ()
+         with
+         | Ok result -> result
+         | Error detail -> fail detail
+       in
+       ignore
+         (Workspace_task.add_task
+            ~goal_id:goal.id
+            config
+            ~title:"first assigned task"
+            ~priority:2
+            ~description:"first linked task");
+       ignore
+         (Workspace_task.add_task
+            ~goal_id:goal.id
+            config
+            ~title:"second assigned task"
+            ~priority:2
+            ~description:"second linked task");
+       let transition task_id action =
+         match
+           Masc.Workspace.transition_task_r
+             config
+             ~agent_name:completing_agent_name
+             ~task_id
+             ~action
+             ()
+         with
+         | Ok _ -> ()
+         | Error error -> fail (Masc_domain.masc_error_to_string error)
+       in
+       let finish task_id =
+         transition task_id Masc_domain.Claim;
+         transition task_id Masc_domain.Start;
+         transition task_id Masc_domain.Cancel
+       in
+       finish "task-001";
+       finish "task-002";
+       let assigned_meta =
+         { (make_goal_reconciler_meta ()) with active_goal_ids = [ goal.id ] }
+       in
+       ignore
+         (KR.register_offline
+            ~base_path:config.base_path
+            assigned_meta.name
+            assigned_meta);
+       (match
+          Masc.Keeper_goal_reconciliation_wake.enqueue_if_ready
+            ~config
+            ~completing_agent_name
+            ~task_id:"task-002"
+        with
+        | Masc.Keeper_goal_reconciliation_wake.Enqueued { keeper_name } ->
+          check string
+            "assigned Keeper owns reconciliation wake"
+            assigned_meta.name
+            keeper_name
+        | _ -> fail "authoritative Goal assignment did not produce a durable wake");
+       let discovery =
+         Keeper_event_queue_persistence.discover_keeper_names_with_snapshots
+           ~base_path:config.base_path
+       in
+       match discovery.read_error with
+       | Some detail -> fail detail
+       | None ->
+         check
+           (list string)
+           "only the assigned canonical Keeper receives the wake"
+           [ assigned_meta.name ]
+           discovery.keeper_names)
+;;
+
 let test_goal_reconciliation_restart_scan_retries_missed_delivery () =
   let dir = temp_dir "registry_goal_reconciliation_restart" in
   let previous_hook = Atomic.get Workspace_hooks.task_terminal_committed_fn in
@@ -681,6 +771,7 @@ let test_goal_reconciliation_restart_scan_retries_missed_delivery () =
        let config = Masc.Workspace.default_config dir in
        let meta = make_goal_reconciler_meta () in
        ignore (Masc.Workspace.init config ~agent_name:(Some meta.agent_name));
+       ignore (KR.register_offline ~base_path:config.base_path meta.name meta);
        Atomic.set Workspace_hooks.task_terminal_committed_fn
          (fun _config ~agent_name:_ ~task_id:_ ->
             Workspace_hooks.Task_terminal_delivered);
@@ -1271,6 +1362,10 @@ let () =
             "goal reconciliation persists once after last terminal task"
             `Quick
             test_goal_reconciliation_enqueues_once_after_last_terminal_task
+        ; test_case
+            "goal reconciliation prefers authoritative assignment"
+            `Quick
+            test_goal_reconciliation_prefers_authoritative_assignment
         ; test_case
             "restart scan retries missed reconciliation exactly once"
             `Quick

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -770,10 +770,11 @@ let test_goal_reconciliation_prefers_authoritative_assignment
               "assigned Keeper owns reconciliation wake"
               assigned_meta.name
               keeper_name
-        | Masc.Keeper_goal_reconciliation_wake.No_keeper_target { goal_id } ->
+        | Masc.Keeper_goal_reconciliation_wake.Keeper_target_lookup_failed
+            { goal_id; detail = _ } ->
           if not corrupt_persisted_assignment
-          then fail "authoritative Goal assignment did not produce a durable wake"
-          else check string "incomplete scan leaves Goal visibly unresolved" goal.id goal_id
+          then fail "authoritative Goal assignment lookup unexpectedly failed"
+          else check string "incomplete scan remains a typed failure" goal.id goal_id
         | _ -> fail "authoritative Goal assignment did not produce a durable wake");
        check int "producer does not receive an assignment-owned wake" 0
          (registry_snapshot ~base_path:config.base_path producer_meta.name
@@ -783,6 +784,13 @@ let test_goal_reconciliation_prefers_authoritative_assignment
          check int "assigned Keeper does not receive a partial-scan wake" 0
            (registry_snapshot ~base_path:config.base_path assigned_meta.name
             |> Keeper_event_queue.length);
+       if corrupt_persisted_assignment
+       then (
+         let summary =
+           Masc.Keeper_goal_reconciliation_wake.reconcile_startup ~config
+         in
+         check int "assignment scan error is classified as failed" 1 summary.failed_count;
+         check int "assignment scan error is not unresolved" 0 summary.unresolved_count);
        let discovery =
          Keeper_event_queue_persistence.discover_keeper_names_with_snapshots
            ~base_path:config.base_path

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -364,17 +364,16 @@ let test_system_llm_rejection_prefers_registered_producer_binding () =
                 "task-registered-producer"
                 rejection.car_task_id
             | _ -> Alcotest.fail "registered producer rejection was not queued");
-         match
-           Keeper_event_queue_persistence.load_result
-             ~base_path
-             ~keeper_name:"executor-agent"
-         with
-         | Error detail -> Alcotest.fail detail
-         | Ok queue ->
-           Alcotest.(check int)
-             "legacy derived queue remains unused"
-             0
-             (Keeper_event_queue.length queue))
+         let discovery =
+           Keeper_event_queue_persistence.discover_keeper_names_with_snapshots ~base_path
+         in
+         (match discovery.read_error with
+          | Some detail -> Alcotest.fail detail
+          | None ->
+            Alcotest.(check (list string))
+              "durable rejection has only the registered Keeper snapshot"
+              [ keeper_name ]
+              discovery.keeper_names))
   )
 
 let test_system_llm_rejection_does_not_derive_unregistered_keeper () =

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -221,6 +221,26 @@ let test_system_llm_rejection_is_durably_delivered_to_producer_keeper () =
     let config = W.default_config base_path in
     let producer = "keeper-verification-rejection-producer-agent" in
     let keeper_name = "verification-rejection-producer" in
+    let meta_json =
+      `Assoc
+        [ "name", `String keeper_name
+        ; "agent_name", `String producer
+        ; "trace_id", `String "trace-persisted-producer"
+        ]
+    in
+    let meta =
+      match Masc_test_deps.meta_of_json_fixture meta_json with
+      | Ok meta -> meta
+      | Error detail -> Alcotest.fail detail
+    in
+    (match
+       Masc.Keeper_meta_store.persist_meta
+         config
+         (Masc.Keeper_types_profile.keeper_meta_path config keeper_name)
+         meta
+     with
+     | Ok () -> ()
+     | Error detail -> Alcotest.fail detail);
     let delivery =
       Masc.Completion_authority_wakeup.wake_rejected_producer
         ~config
@@ -246,6 +266,8 @@ let test_system_llm_rejection_is_durably_delivered_to_producer_keeper () =
        Alcotest.fail "unregistered producer Keeper cannot be signaled"
      | Masc.Completion_authority_wakeup.Durable_wake_failed { detail; _ }
      | Masc.Completion_authority_wakeup.Durable_queue_failed { detail; _ } ->
+       Alcotest.fail detail
+     | Masc.Completion_authority_wakeup.Producer_identity_lookup_failed { detail; _ } ->
        Alcotest.fail detail
      | Masc.Completion_authority_wakeup.Unroutable_producer { producer; _ } ->
        Alcotest.failf "producer was unexpectedly unroutable: %s" producer);
@@ -321,6 +343,8 @@ let test_system_llm_rejection_prefers_registered_producer_binding () =
           | Masc.Completion_authority_wakeup.Durable_wake_failed { detail; _ }
           | Masc.Completion_authority_wakeup.Durable_queue_failed { detail; _ } ->
             Alcotest.fail detail
+          | Masc.Completion_authority_wakeup.Producer_identity_lookup_failed { detail; _ } ->
+            Alcotest.fail detail
           | Masc.Completion_authority_wakeup.Unroutable_producer { producer; _ } ->
             Alcotest.failf "registered producer was unexpectedly unroutable: %s" producer);
          match
@@ -348,6 +372,41 @@ let test_system_llm_rejection_prefers_registered_producer_binding () =
              "legacy derived queue remains unused"
              0
              (Keeper_event_queue.length queue))
+  )
+
+let test_system_llm_rejection_does_not_derive_unregistered_keeper () =
+  with_eio_temp_dir (fun base_path ->
+    let config = W.default_config base_path in
+    let producer = "keeper-executor-agent-agent" in
+    Masc.Keeper_registry.For_testing.clear ();
+    Fun.protect
+      ~finally:Masc.Keeper_registry.For_testing.clear
+      (fun () ->
+         match
+           Masc.Completion_authority_wakeup.wake_rejected_producer
+             ~config
+             ~producer
+             ~task_id:"task-unregistered-producer"
+             ~verification_id:"vrf-unregistered-producer"
+             ~reason:"unregistered producer must remain unroutable"
+             ~authority:
+               (Masc_domain.System_llm_agent
+                  { agent_run_id = "system-agent-unregistered" })
+         with
+         | Masc.Completion_authority_wakeup.Unroutable_producer
+             { producer = actual; task_id } ->
+           Alcotest.(check string) "unroutable producer identity" producer actual;
+           Alcotest.(check string)
+             "unroutable task identity"
+             "task-unregistered-producer"
+             task_id
+         | Masc.Completion_authority_wakeup.Producer_identity_lookup_failed { detail; _ } ->
+           Alcotest.fail detail
+         | Masc.Completion_authority_wakeup.Signaled _
+         | Masc.Completion_authority_wakeup.Durable_deferred _
+         | Masc.Completion_authority_wakeup.Durable_wake_failed _
+         | Masc.Completion_authority_wakeup.Durable_queue_failed _ ->
+           Alcotest.fail "unregistered producer must not derive or enqueue a Keeper name")
   )
 
 let test_system_llm_agent_commits_without_a_keeper_verifier () =
@@ -1537,6 +1596,8 @@ let () =
         test_system_llm_rejection_is_durably_delivered_to_producer_keeper;
       Alcotest.test_case "system LLM rejection uses registry producer binding" `Quick
         test_system_llm_rejection_prefers_registered_producer_binding;
+      Alcotest.test_case "system LLM rejection does not derive unregistered Keeper" `Quick
+        test_system_llm_rejection_does_not_derive_unregistered_keeper;
       Alcotest.test_case "system LLM commits without Keeper verifier" `Quick
         test_system_llm_agent_commits_without_a_keeper_verifier;
       Alcotest.test_case "system LLM uses persisted request contract" `Quick

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -273,6 +273,83 @@ let test_system_llm_rejection_is_durably_delivered_to_producer_keeper () =
        | _ -> Alcotest.fail "system rejection was not durably queued")
   )
 
+let test_system_llm_rejection_prefers_registered_producer_binding () =
+  with_eio_temp_dir (fun base_path ->
+    let config = W.default_config base_path in
+    let keeper_name = "keeper-executor-agent" in
+    let producer = "keeper-executor-agent-agent" in
+    let meta_json =
+      `Assoc
+        [ "name", `String keeper_name
+        ; "agent_name", `String producer
+        ; "trace_id", `String "trace-registered-producer"
+        ]
+    in
+    let meta =
+      match Masc_test_deps.meta_of_json_fixture meta_json with
+      | Ok meta -> meta
+      | Error detail -> Alcotest.fail detail
+    in
+    Masc.Keeper_registry.For_testing.clear ();
+    Fun.protect
+      ~finally:Masc.Keeper_registry.For_testing.clear
+      (fun () ->
+         ignore
+           (Masc.Keeper_registry.For_testing.register
+              ~base_path
+              keeper_name
+              meta);
+         let delivery =
+           Masc.Completion_authority_wakeup.wake_rejected_producer
+             ~config
+             ~producer
+             ~task_id:"task-registered-producer"
+             ~verification_id:"vrf-registered-producer"
+             ~reason:"registered binding must own the rejection queue"
+             ~authority:
+               (Masc_domain.System_llm_agent
+                  { agent_run_id = "system-agent-registered" })
+         in
+         (match delivery with
+          | Masc.Completion_authority_wakeup.Signaled { keeper_name = actual }
+          | Masc.Completion_authority_wakeup.Durable_deferred
+              { keeper_name = actual; _ } ->
+            Alcotest.(check string)
+              "registered agent binding selects the registry keeper"
+              keeper_name
+              actual
+          | Masc.Completion_authority_wakeup.Durable_wake_failed { detail; _ }
+          | Masc.Completion_authority_wakeup.Durable_queue_failed { detail; _ } ->
+            Alcotest.fail detail
+          | Masc.Completion_authority_wakeup.Unroutable_producer { producer; _ } ->
+            Alcotest.failf "registered producer was unexpectedly unroutable: %s" producer);
+         match
+           Keeper_event_queue_persistence.load_result
+             ~base_path
+             ~keeper_name
+         with
+         | Error detail -> Alcotest.fail detail
+         | Ok queue ->
+           (match Keeper_event_queue.to_list queue with
+            | [ { payload = Completion_authority_rejected rejection; _ } ] ->
+              Alcotest.(check string)
+                "registered queue preserves task identity"
+                "task-registered-producer"
+                rejection.car_task_id
+            | _ -> Alcotest.fail "registered producer rejection was not queued");
+         match
+           Keeper_event_queue_persistence.load_result
+             ~base_path
+             ~keeper_name:"executor-agent"
+         with
+         | Error detail -> Alcotest.fail detail
+         | Ok queue ->
+           Alcotest.(check int)
+             "legacy derived queue remains unused"
+             0
+             (Keeper_event_queue.length queue))
+  )
+
 let test_system_llm_agent_commits_without_a_keeper_verifier () =
   with_eio_temp_dir (fun base_path ->
     Masc.Workspace_metric_hooks.install ();
@@ -1458,6 +1535,8 @@ let () =
         test_system_llm_authority_helpers_are_typed;
       Alcotest.test_case "system LLM rejection reaches producer queue" `Quick
         test_system_llm_rejection_is_durably_delivered_to_producer_keeper;
+      Alcotest.test_case "system LLM rejection uses registry producer binding" `Quick
+        test_system_llm_rejection_prefers_registered_producer_binding;
       Alcotest.test_case "system LLM commits without Keeper verifier" `Quick
         test_system_llm_agent_commits_without_a_keeper_verifier;
       Alcotest.test_case "system LLM uses persisted request contract" `Quick

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -220,10 +220,13 @@ let test_system_llm_rejection_is_durably_delivered_to_producer_keeper () =
   with_eio_temp_dir (fun base_path ->
     let config = W.default_config base_path in
     let producer = "keeper-verification-rejection-producer-agent" in
-    let keeper_name = "verification-rejection-producer" in
+    let keeper_name = "persisted-canonical-producer" in
     let meta_json =
       `Assoc
-        [ "name", `String keeper_name
+        (* The filename is the durable queue identity. The metadata carries a
+           valid Keeper name for the same agent identity, but the two names
+           intentionally differ to ensure routing uses the canonical path. *)
+        [ "name", `String "verification-rejection-producer"
         ; "agent_name", `String producer
         ; "trace_id", `String "trace-persisted-producer"
         ]


### PR DESCRIPTION
## Summary

- Keep the verifier as the application-owned `System_llm_agent`: it is not a Keeper and has no Keeper lifecycle.
- Route completion-authority rejection delivery through an exact live-registry or persisted-metadata `agent_name` binding.
- Route Goal reconciliation wakeups by the authoritative `active_goal_ids` assignment first; use the exact producer binding only when no assignment exists.
- Remove structural and string-derived identity routing from both wakeup paths and preserve missing, ambiguous, and storage-failure outcomes explicitly.

## Root cause

The system LLM completion authority owns verification and commits the typed verdict. After a rejection, the producer Keeper must receive a durable typed stimulus. The old wake path derived a Keeper name from the producer string, so a runtime identity such as `keeper-executor-agent-agent` could produce the unrelated queue name `executor-agent`.

Goal reconciliation had the same defect in the opposite order: it derived the completing agent name before consulting the Goal assignment. A completing agent and the Keeper assigned to the Goal are different facts; the assignment is authoritative.

## Correctness boundary

- `System_llm_agent` performs verification; it is never registered as a Keeper or used as a Keeper verifier.
- Live registry identity is authoritative while a producer is registered.
- Persisted Keeper metadata is the durable fallback after unregister or shutdown.
- Goal `active_goal_ids` assignment wins over producer identity, including when the assigned Keeper is paused.
- Exact stored `agent_name` equality is the only identity join. No agent-name parsing or guessed queue name remains in the addressed paths.
- Missing, unreadable, or ambiguous bindings remain explicit and observable; no silent queue selection occurs.
- Verdict commit remains separate from the producer wake. No live queue was rewritten or deleted.

## Validation

- `ocamlformat --check` on touched OCaml files
- `git diff --check`
- focused Dune builds for `test/test_keeper_registry_hardening.exe` and `test/test_verification.exe`
- Keeper registry hardening suite: `25/25` passed
- System LLM completion-authority suite: `7/7` passed
- OAS pin check: `v0.231.12` at `966cd3f61cd5e9e21c8390513dfa27894aeb6230`
- CI is the build authority; this Draft PR remains unmerged until the exact head is green

The PR also covers the root cause described in #26663. The deployed runtime is older than this source head, and no live restart, queue deletion, or runtime-state repair was performed.
