### PR TITLE
ci: execute the verification behavior suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -864,6 +864,23 @@ jobs:
           chmod +x scripts/ci-run-tests.sh
           scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_model_inference_metrics"
 
+      # Completion-authority rejection routing and verification-evidence
+      # projection are executable behavior, not implementation shape: the
+      # suite asserts routed identities and stored payloads, never source
+      # text or log wording. It stayed compile-only under @check, so
+      # regression tests added there (#26625, #26657) never ran.
+      - name: Run verification behavior suite
+        id: verification_behavior_suite
+        if: ${{ always() && steps.build_step.outcome == 'success' }}
+        env:
+          ME_ROOT: /tmp/me
+          CI_TEST_HEARTBEAT_SEC: 15
+          DUNE_JOBS: 1
+        run: |
+          mkdir -p /tmp/me
+          chmod +x scripts/ci-run-tests.sh
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_verification"
+
       - name: Run tool blob retention suite
         id: tool_blob_retention_suite
         if: ${{ always() && steps.build_step.outcome == 'success' }}

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -26,18 +26,18 @@ let active_verifications_dir base_path =
 let legacy_verifications_dir base_path =
   Filename.concat base_path "verifications"
 
-let rec rm_rf path =
-  if Sys.file_exists path then
-    if Sys.is_directory path then begin
-      Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
-      Unix.rmdir path
-    end else
-      Sys.remove path
+(** Use a temporary directory for each test.
 
-(** Use a temporary directory for each test *)
+    Cleanup goes through [Masc_test_deps.cleanup_test_workspace], which stats
+    with [Unix.lstat]. The previous local [rm_rf] tested [Sys.file_exists],
+    which resolves symlinks: a dangling link read as absent, was skipped, and
+    left its parent non-empty, so [Unix.rmdir] raised [ENOTEMPTY] out of the
+    [Fun.protect] finally and masked the test result. *)
 let with_temp_dir f =
   let dir = Filename.temp_dir "masc_verify_test" "" in
-  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+  Fun.protect
+    ~finally:(fun () -> Masc_test_deps.cleanup_test_workspace dir)
+    (fun () -> f dir)
 
 let with_eio_temp_dir f =
   Eio_main.run @@ fun env ->


### PR DESCRIPTION
## 요약

`test/test_verification.ml` 을 CI 실행 대상에 넣어용. 지금은 컴파일만 되고 **한 번도 실행되지 않아용.**

## 근거

```bash
git show origin/main:.github/workflows/ci.yml | rg -o '@test/runtest-[a-zA-Z0-9_-]+' | sort -u | wc -l
# → 21
... | rg verification
# → (0건)
```

runtest 별칭은 있어용 (`test/dune:1011`, `:1170`). 워크플로가 안 부를 뿐이에용.

## 왜 이 suite 인가

실행 subset 이 좁은 건 **의도된 설계**예용. `ci.yml` 이 이유를 적어놨어용.

> The former catch-all `dune test` gate mixed executable behavior tests with source-text, log-wording, and TLA text-parity assertions. Those implementation-shape checks made main permanently red after legitimate refactors without identifying a runtime regression.

배제 기준은 **implementation-shape 단정**, 포함 기준은 **authoritative behavior suite** 예용. 그 기준으로 재봤어용.

| | |
|---|---|
| 줄 수 / 케이스 | 1523 / **34** |
| `Alcotest.run` | 1 (실행 가능) |
| 소스 텍스트 읽기 | **0** (`rg 'read_file\|In_channel\|\.ml"'`) |
| 파일시스템 행위 | `Fs_compat` 43, `with_temp` 11 |

배제 사유가 없고 포함 기준에 해당해용. subset 설계를 바꾸자는 게 아니라, **그 설계의 기준을 이 suite 에 적용**하는 거예용.

## 지금 필요한 이유

열린 PR 둘이 이 파일에 회귀 테스트를 넣고 있어용.

| PR | 추가 |
|---|---|
| #26625 | +151 (notes 를 메타데이터만 남기는 계약) |
| #26657 | +79 (rejection 이 레지스트리 바인딩을 쓰는지) |

지금 상태로는 둘 다 green 으로 머지되지만 **그 테스트는 실행되지 않아용.** `@check` 가 컴파일은 보장하니 "깨진 테스트가 들어간다" 는 아니고, **"고친 동작이 회귀해도 안 잡힌다"** 예용.

## 검증

- 게이트 배선: 새 스텝은 `build` job 안이고 `continue-on-error` 없음 → `ci-gate` 의 `needs: [... build ...]` 로 전파돼용
- YAML 파싱 + 스텝 등록 확인함 (`build` 스텝 29개, 새 id 등록됨)
- **suite 자체가 통과하는지는 이 PR 의 CI 가 답해용.** 로컬에서 안 돌렸어용

실행 시간이 늘 수 있어용 (34 케이스, 임시 디렉터리 다수). 측정치를 보고 유지 여부를 판단하면 돼용.

Refs #26659

🤖 Generated with [Claude Code](https://claude.com/claude-code)
