### PR TITLE
ci: execute the goal store durability suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -881,6 +881,23 @@ jobs:
           chmod +x scripts/ci-run-tests.sh
           scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_verification"
 
+      # Goal store durability: the suite drives a real workspace and asserts
+      # on-disk bytes, not source text — the read path stays lenient while a
+      # write over an undecodable store must be refused and must leave both
+      # goals.json and its .last-good mirror untouched. Compile-only under
+      # @check leaves that refusal ungated.
+      - name: Run goal store durability suite
+        id: goal_store_durability_suite
+        if: ${{ always() && steps.build_step.outcome == 'success' }}
+        env:
+          ME_ROOT: /tmp/me
+          CI_TEST_HEARTBEAT_SEC: 15
+          DUNE_JOBS: 1
+        run: |
+          mkdir -p /tmp/me
+          chmod +x scripts/ci-run-tests.sh
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_goal_store"
+
       - name: Run tool blob retention suite
         id: tool_blob_retention_suite
         if: ${{ always() && steps.build_step.outcome == 'success' }}


### PR DESCRIPTION
## 요약

`test/test_goal_store.ml` 을 CI 실행 대상에 넣어용. 지금은 컴파일만 되고 **한 번도 실행되지 않아용.**

## 근거

```bash
git show origin/main:.github/workflows/ci.yml | rg -o '@test/runtest-[a-zA-Z0-9_-]+' | sort -u | wc -l
# → 22
... | rg goal
# → (0건)
```

runtest 별칭은 있어용 — `test/dune:1049` (names) / `:1208` (modules). 워크플로가 안 부를 뿐이에용.

## 왜 이 suite 인가

실행 subset 이 좁은 건 **의도된 설계**예용. `ci.yml` 이 배제 사유를 적어놨어용 — *source-text, log-wording, TLA text-parity assertions*.

이 suite 는 그중 어느 것도 아니에용. **실제 워크스페이스를 만들고 디스크 바이트를 단정해용.**

```ocaml
let on_disk_before = In_channel.with_open_bin (Goal_store.goals_path config) In_channel.input_all in
(match Goal_store.upsert_goal config ~title:"phase only" ~phase:Goal_phase.Paused () with
 | Ok _ -> fail "upsert_goal wrote over an undecodable store"
 | Error msg -> check bool "refusal names the store path" true (contains_substring msg ...));
check string "undecodable store is left byte-identical on disk" on_disk_before on_disk_after;
check bool "no recovery mirror was written over it" false (Sys.file_exists (goals_recovery_path config))
```

| | |
|---|---|
| 줄 수 / 케이스 | 392 / **14** |
| 소스 텍스트 읽기 | 없어용 |
| 검사 대상 | 반환값 + **디스크 부작용의 부재** |

## 지금 필요한 이유

#26667 의 대표 수리가 *"디코드 실패한 store 를 덮어쓰지 않는다"* 예용. 그 거부를 검증하는 테스트가 위 코드고, **지금 상태로는 실행되지 않아용.** 데이터 손실 방지 수리가 회귀해도 안 잡혀요.

## 검증

- 게이트 배선: 새 스텝은 `build` job 안이고 `continue-on-error` 없음 → `ci-gate` 의 `needs: [… build …]` 로 전파돼용
- YAML 파싱 + 스텝 등록 확인함 (`build` 스텝 30개)
- **suite 자체가 통과하는지는 이 PR 의 CI 가 답해요.** 로컬에서 안 돌렸어용

선례: #26660 (머지됨) 이 같은 형태로 `test_verification` 을 켰고, **켜자마자 숨은 실패가 하나 나왔어용** (정리 코드가 심링크를 추종해 `ENOTEMPTY`). 비용은 9초였어용.

Refs #26667

🤖 Generated with [Claude Code](https://claude.com/claude-code)
