### PR TITLE
ci: execute the keeper registry hardening suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -898,6 +898,24 @@ jobs:
           chmod +x scripts/ci-run-tests.sh
           scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_goal_store"
 
+      # Keeper registry hardening: identity resolution and goal-reconciliation
+      # routing are executable behavior — the suite drives a real workspace and
+      # asserts which Keeper a durable stimulus is addressed to, never source
+      # text. It is the only suite covering
+      # [Keeper_goal_reconciliation_wake], so that routing stays ungated under
+      # @check.
+      - name: Run keeper registry hardening suite
+        id: keeper_registry_hardening_suite
+        if: ${{ always() && steps.build_step.outcome == 'success' }}
+        env:
+          ME_ROOT: /tmp/me
+          CI_TEST_HEARTBEAT_SEC: 15
+          DUNE_JOBS: 1
+        run: |
+          mkdir -p /tmp/me
+          chmod +x scripts/ci-run-tests.sh
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_registry_hardening"
+
       - name: Run tool blob retention suite
         id: tool_blob_retention_suite
         if: ${{ always() && steps.build_step.outcome == 'success' }}


### PR DESCRIPTION
## 요약

`test/test_keeper_registry_hardening.ml` (1391줄, **23 케이스**) 을 CI 실행 대상에 넣어용. 지금은 컴파일만 되고 **한 번도 실행되지 않아용.**

#26657 에 먼저 여쭀는데 응답이 없어서 Draft 로 올려요. **그 PR 에 직접 넣으시는 게 낫다면 이건 닫아주세요.**

## 근거

```bash
git show origin/main:.github/workflows/ci.yml | rg -o '@test/runtest-[a-zA-Z0-9_-]+' | sort -u | wc -l
# → 23
```

실행되는 23개 중 **`Keeper_goal_reconciliation_wake` 를 참조하는 suite 가 0** 이에용. 그 모듈을 테스트하는 건 이 suite 하나뿐이고요.

| 경로 | 게이트 |
|---|---|
| rejection 라우팅 | ✅ `test_verification` 이 `wake_rejected_producer → producer_keeper_name → Keeper_identity_binding.resolve` 로 도달 |
| **goal 재조정** | ❌ 도달 경로 없음 |

## 왜 지금인가

#26657 의 `be61c6b144` 가 goal 재조정의 신원 라우팅을 고쳤어용. 그 결함은 **살아있는 데이터가 있어용** — `name=keeper-executor-agent` / `agent_name=keeper-executor-agent-agent` 인 Keeper 가 실제 store 에 있어서, 문자열 휴리스틱이 존재하지 않는 `executor-agent` 를 만들어냈어용 (#26664 에서 측정).

수리는 됐는데 **그 절반이 게이트를 못 받는 상태**예용.

## 배제 기준에 안 걸려용

`ci.yml` 이 배제한 건 *source-text, log-wording, TLA text-parity assertions* 예용. 이 suite 는 실제 워크스페이스를 만들고 **durable stimulus 가 어느 Keeper 로 갔는지**를 단정해용.

## 검증

- 게이트 배선: `build` job 안, `continue-on-error` 없음 → `ci-gate` 의 `needs` 로 전파
- YAML 파싱 + 스텝 등록 확인 (`build` 스텝 31개)
- **suite 통과 여부는 이 PR 의 CI 가 답해요.** 로컬에서 안 돌렸어용

1391줄이라 **켜보면 숨은 실패가 있을 수 있어용.** #26660 때 `test_verification` 이 정확히 그랬고(정리 코드가 심링크 추종 → `ENOTEMPTY`), 그건 나쁜 결과가 아니었어용.

선례: #26660 (9초) · #26670 (8초) 둘 다 머지됐어용.

Refs #26657, #26664

🤖 Generated with [Claude Code](https://claude.com/claude-code)
