### PR TITLE
Surface post-effect failures in workspace start and board projections

### DIFF
--- a/lib/mcp_tool_runtime_board.ml
+++ b/lib/mcp_tool_runtime_board.ml
@@ -77,6 +77,10 @@ let result_after_activity_projection
            operation
            detail)
 
+module For_testing = struct
+  let result_after_activity_projection = result_after_activity_projection
+end
+
 let extract_board_post_id (message : string) =
   match String.index_opt message '{' with
   | None -> None

--- a/lib/mcp_tool_runtime_board.ml
+++ b/lib/mcp_tool_runtime_board.ml
@@ -36,12 +36,46 @@ let emit_activity config ~kind ~actor ?subject ?(tags = []) ~payload () =
     ignore
       (Activity_graph.emit config
          ~actor:(Server_utils.board_actor_entity actor)
-         ?subject ~kind ~payload ~tags ())
+         ?subject ~kind ~payload ~tags ());
+    Ok ()
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
-      Log.Misc.warn "activity emit failed (%s): %s" kind
-        (Stdlib.Printexc.to_string exn)
+      let detail = Stdlib.Printexc.to_string exn in
+      Log.Misc.warn "activity emit failed (%s): %s" kind detail;
+      Error detail
+
+let result_after_activity_projection
+      ~tool_name
+      ~start_time
+      ~(primary_result : Tool_result.result)
+      ~operation
+      emit
+  =
+  if not (Tool_result.is_success primary_result)
+  then primary_result
+  else
+    match emit () with
+    | Ok () -> primary_result
+    | Error detail ->
+      Tool_result.make_err
+        ~tool_name
+        ~class_:Tool_result.Runtime_failure
+        ~start_time
+        ~data:
+          (`Assoc
+            [ ("primary_result", Tool_result.data primary_result)
+            ; ( "effect_disposition"
+              , `String
+                  (Tool_result.failure_effect_disposition_to_string
+                     Tool_result.Proven_post_effect) )
+            ; ("projection", `String operation)
+            ; ("error", `String detail)
+            ])
+        (Printf.sprintf
+           "%s committed, but activity projection failed: %s"
+           operation
+           detail)
 
 let extract_board_post_id (message : string) =
   match String.index_opt message '{' with
@@ -242,7 +276,8 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
   match (name : string) with
   | "masc_board_post" ->
       let result_tr = Board_tool.handle_tool name arguments in
-      if Tool_result.is_success result_tr then begin
+      let result_tr =
+        if Tool_result.is_success result_tr then begin
         let author = Safe_ops.json_string ~default:"anonymous" "author" arguments in
         let content = Safe_ops.json_string ~default:"" "content" arguments in
         let post_id = extract_board_post_id (Tool_result.message result_tr) in
@@ -275,17 +310,26 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
           ("timestamp", `String (Masc_domain.now_iso ()));
         ] in
         Mcp_server.sse_broadcast state notification;
-        emit_activity config ~kind:(Event_kind.Board.to_string Event_kind.Board.Posted) ~actor:author
-          ?subject:
-            (Option.map (Activity_graph.entity ~kind:"post") post_id)
-          ~tags:[ "board"; Event_kind.Board.to_string Event_kind.Board.Posted ]
-          ~payload:
-            (`Assoc
-              [
-                ("content", `String content);
-                ( "post_id", Json_util.string_opt_to_json post_id );
-              ])
-          ();
+        let projected_result =
+          result_after_activity_projection
+            ~tool_name:name
+            ~start_time
+            ~primary_result:result_tr
+            ~operation:(Event_kind.Board.to_string Event_kind.Board.Posted)
+            (fun () ->
+               emit_activity
+                 config
+                 ~kind:(Event_kind.Board.to_string Event_kind.Board.Posted)
+                 ~actor:author
+                 ?subject:(Option.map (Activity_graph.entity ~kind:"post") post_id)
+                 ~tags:[ "board"; Event_kind.Board.to_string Event_kind.Board.Posted ]
+                 ~payload:
+                   (`Assoc
+                     [ ("content", `String content)
+                     ; ("post_id", Json_util.string_opt_to_json post_id)
+                     ])
+                 ())
+        in
         (* Mention processing — mirror masc_broadcast pattern *)
         let mention = Mention.extract content in
         (match mention with
@@ -293,12 +337,16 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
              Notify.notify_mention ~from_agent:author
                ~target_agent:target ~message:content ()
          | None -> ())
-      end;
+        ; projected_result
+        end
+        else result_tr
+      in
       Some result_tr
 
   | "masc_board_comment" ->
       let result_tr = Board_tool.handle_tool name arguments in
-      if Tool_result.is_success result_tr then begin
+      let result_tr =
+        if Tool_result.is_success result_tr then begin
         let author = Safe_ops.json_string ~default:"anonymous" "author" arguments in
         let content = Safe_ops.json_string ~default:"" "content" arguments in
         let post_id = Safe_ops.json_string ~default:"unknown" "post_id" arguments in
@@ -330,16 +378,26 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
           ("timestamp", `String (Masc_domain.now_iso ()));
         ] in
         Mcp_server.sse_broadcast state notification;
-        emit_activity config ~kind:(Event_kind.Board.to_string Event_kind.Board.Commented) ~actor:author
-          ~subject:(Activity_graph.entity ~kind:"post" post_id)
-          ~tags:[ "board"; Event_kind.Board.to_string Event_kind.Board.Commented ]
-          ~payload:
-            (`Assoc
-              [
-                ("post_id", `String post_id);
-                ("content", `String content);
-              ])
-          ();
+        let projected_result =
+          result_after_activity_projection
+            ~tool_name:name
+            ~start_time
+            ~primary_result:result_tr
+            ~operation:(Event_kind.Board.to_string Event_kind.Board.Commented)
+            (fun () ->
+               emit_activity
+                 config
+                 ~kind:(Event_kind.Board.to_string Event_kind.Board.Commented)
+                 ~actor:author
+                 ~subject:(Activity_graph.entity ~kind:"post" post_id)
+                 ~tags:[ "board"; Event_kind.Board.to_string Event_kind.Board.Commented ]
+                 ~payload:(
+                   `Assoc
+                     [ ("post_id", `String post_id)
+                     ; ("content", `String content)
+                     ])
+                 ())
+        in
         (* Mention processing — mirror masc_broadcast pattern *)
         let mention = Mention.extract content in
         (match mention with
@@ -347,13 +405,17 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
              Notify.notify_mention ~from_agent:author
                ~target_agent:target ~message:content ()
          | None -> ())
-      end;
+        ; projected_result
+        end
+        else result_tr
+      in
       Some result_tr
 
   | "masc_board_vote" | "masc_board_comment_vote" ->
       let result_tr = Board_tool.handle_tool name arguments in
       (* Record vote activity as a fitness metric (Issue #1861). *)
-      if Tool_result.is_success result_tr then begin
+      let result_tr =
+        if Tool_result.is_success result_tr then begin
         let voter = Safe_ops.json_string ~default:"anonymous" "voter" arguments in
         let target_id =
           if String.equal name "masc_board_vote" then
@@ -382,22 +444,33 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
         let subject_kind =
           if String.equal name "masc_board_vote" then "post" else "comment"
         in
-        emit_activity config ~kind:(Event_kind.Board.to_string Event_kind.Board.Voted) ~actor:voter
-          ~subject:(Activity_graph.entity ~kind:subject_kind target_id)
-          ~tags:[ "board"; Event_kind.Board.to_string Event_kind.Board.Voted ]
-          ~payload:
-            (`Assoc
-              [
-                ("target_id", `String target_id);
-                ("target_kind", `String subject_kind);
-              ])
-          ()
-      end;
+        result_after_activity_projection
+          ~tool_name:name
+          ~start_time
+          ~primary_result:result_tr
+          ~operation:(Event_kind.Board.to_string Event_kind.Board.Voted)
+          (fun () ->
+             emit_activity
+               config
+               ~kind:(Event_kind.Board.to_string Event_kind.Board.Voted)
+               ~actor:voter
+               ~subject:(Activity_graph.entity ~kind:subject_kind target_id)
+               ~tags:[ "board"; Event_kind.Board.to_string Event_kind.Board.Voted ]
+               ~payload:(
+                 `Assoc
+                   [ ("target_id", `String target_id)
+                   ; ("target_kind", `String subject_kind)
+                   ])
+               ())
+        end
+        else result_tr
+      in
       Some result_tr
 
   | "masc_board_delete" ->
       let result_tr = Board_tool.handle_tool name arguments in
-      if Tool_result.is_success result_tr then begin
+      let result_tr =
+        if Tool_result.is_success result_tr then begin
         let post_id = Safe_ops.json_string ~default:"unknown" "post_id" arguments in
         let notification = `Assoc [
           ("type", `String "masc/board_delete");
@@ -405,12 +478,23 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
           ("timestamp", `String (Masc_domain.now_iso ()));
         ] in
         Mcp_server.sse_broadcast state notification;
-        emit_activity config ~kind:(Event_kind.Board.to_string Event_kind.Board.Deleted) ~actor:agent_name
-          ~subject:(Activity_graph.entity ~kind:"post" post_id)
-          ~tags:[ "board"; Event_kind.Board.to_string Event_kind.Board.Deleted ]
-          ~payload:(`Assoc [ ("post_id", `String post_id) ])
-          ()
-      end;
+        result_after_activity_projection
+          ~tool_name:name
+          ~start_time
+          ~primary_result:result_tr
+          ~operation:(Event_kind.Board.to_string Event_kind.Board.Deleted)
+          (fun () ->
+             emit_activity
+               config
+               ~kind:(Event_kind.Board.to_string Event_kind.Board.Deleted)
+               ~actor:agent_name
+               ~subject:(Activity_graph.entity ~kind:"post" post_id)
+               ~tags:[ "board"; Event_kind.Board.to_string Event_kind.Board.Deleted ]
+               ~payload:(`Assoc [ ("post_id", `String post_id) ])
+               ())
+        end
+        else result_tr
+      in
       Some result_tr
 
   | "masc_board_list" | "masc_board_post_get"

--- a/lib/mcp_tool_runtime_board.mli
+++ b/lib/mcp_tool_runtime_board.mli
@@ -48,6 +48,16 @@ val enforce_caller_identity :
     [_comment_vote]).  Prefer {!ensure_board_post_author} for the
     [masc_board_post]/[author] specialisation. *)
 
+module For_testing : sig
+  val result_after_activity_projection :
+    tool_name:string ->
+    start_time:float ->
+    primary_result:Tool_result.result ->
+    operation:string ->
+    (unit -> (unit, string) result) ->
+    Tool_result.result
+end
+
 (** {1 MCP runtime fallback} *)
 
 val dispatch :

--- a/lib/mcp_tool_runtime_workspace.ml
+++ b/lib/mcp_tool_runtime_workspace.ml
@@ -227,6 +227,7 @@ let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result opt
                  ~data:
                    (`Assoc
                      [ ("task_id", `String task_id)
+                     ; ("primary_result", `String add_result)
                      ; ( "effect_disposition"
                        , `String
                            (Tool_result.failure_effect_disposition_to_string

--- a/lib/mcp_tool_runtime_workspace.ml
+++ b/lib/mcp_tool_runtime_workspace.ml
@@ -242,7 +242,25 @@ let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result opt
             match Planning_eio.set_current_task active_config ~task_id with
             | Error msg ->
               (* [Planning_eio.set_current_task] internal store failure. *)
-              Some (runtime_err_runtime ~tool_name ~start_time msg)
+              Some
+                (Tool_result.make_err
+                   ~tool_name
+                   ~class_:Tool_result.Runtime_failure
+                   ~start_time
+                   ~data:
+                     (`Assoc
+                       [ ("task_id", `String task_id)
+                       ; ("primary_result", `String add_result)
+                       ; ( "effect_disposition"
+                         , `String
+                             (Tool_result.failure_effect_disposition_to_string
+                                Tool_result.Proven_post_effect) )
+                       ; ("error", `String msg)
+                       ])
+                   (Printf.sprintf
+                      "masc_start created and claimed task %s, but setting it current failed: %s"
+                      task_id
+                      msg))
             | Ok () ->
                 Some
                   (runtime_ok ~tool_name ~start_time

--- a/lib/mcp_tool_runtime_workspace.ml
+++ b/lib/mcp_tool_runtime_workspace.ml
@@ -210,16 +210,43 @@ let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result opt
                   "masc_start partial: session bound as %s, but task creation failed: %s"
                   agent_name add_result))
         else begin
-          let _claim_msg = Workspace_task.claim_task active_config ~agent_name ~task_id in
-          match Planning_eio.set_current_task active_config ~task_id with
-          | Error msg ->
-            (* [Planning_eio.set_current_task] internal store failure. *)
-            Some (runtime_err_runtime ~tool_name ~start_time msg)
-          | Ok () ->
-              Some
-                (runtime_ok ~tool_name ~start_time
-                   (Printf.sprintf
-                      "masc_start complete: project scope set, session bound as %s, task %s created+claimed+set as current."
-                      agent_name task_id))
+          match
+            Workspace_task.claim_task_r active_config ~agent_name ~task_id ()
+          with
+          | Error error ->
+            let failure_class =
+              if Masc_domain.is_retryable error
+              then Tool_result.Transient_error
+              else Tool_result.Workflow_rejection
+            in
+            Some
+              (Tool_result.make_err
+                 ~tool_name
+                 ~class_:failure_class
+                 ~start_time
+                 ~data:
+                   (`Assoc
+                     [ ("task_id", `String task_id)
+                     ; ( "effect_disposition"
+                       , `String
+                           (Tool_result.failure_effect_disposition_to_string
+                              Tool_result.Proven_post_effect) )
+                     ; ("error", `String (Masc_domain.to_string error))
+                     ])
+                 (Printf.sprintf
+                    "masc_start created task %s but claim failed: %s"
+                    task_id
+                    (Masc_domain.to_string error)))
+          | Ok _claim_msg ->
+            match Planning_eio.set_current_task active_config ~task_id with
+            | Error msg ->
+              (* [Planning_eio.set_current_task] internal store failure. *)
+              Some (runtime_err_runtime ~tool_name ~start_time msg)
+            | Ok () ->
+                Some
+                  (runtime_ok ~tool_name ~start_time
+                     (Printf.sprintf
+                        "masc_start complete: project scope set, session bound as %s, task %s created+claimed+set as current."
+                        agent_name task_id))
         end
       end

--- a/test/test_mcp_tool_runtime_workspace_path.ml
+++ b/test/test_mcp_tool_runtime_workspace_path.ml
@@ -123,7 +123,11 @@ let test_masc_start_surfaces_claim_failure_after_task_commit () =
         Yojson.Safe.Util.(data |> member "effect_disposition" |> to_string);
       Alcotest.(check string) "task id is returned"
         "task-002"
-        Yojson.Safe.Util.(data |> member "task_id" |> to_string))
+        Yojson.Safe.Util.(data |> member "task_id" |> to_string);
+      Alcotest.(check bool) "committed task result is preserved" true
+        (contains_substring
+           Yojson.Safe.Util.(data |> member "primary_result" |> to_string)
+           "Added task-002"))
 ;;
 
 let test_health_aggregate_sum_rejects_overflow () =

--- a/test/test_mcp_tool_runtime_workspace_path.ml
+++ b/test/test_mcp_tool_runtime_workspace_path.ml
@@ -66,6 +66,66 @@ let test_masc_start_tilde_rejects_empty_initial_home () =
         (contains_substring message "HOME is required to expand '~'"))
 ;;
 
+let test_masc_start_surfaces_claim_failure_after_task_commit () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let base_path = Cases.temp_dir "mcp-start-claim-failure-" in
+  Fun.protect
+    ~finally:(fun () -> Cases.cleanup_dir base_path)
+    (fun () ->
+      let fixture =
+        Cases.make_fixture
+          sw
+          ~proc_mgr:(Eio.Stdenv.process_mgr env)
+          ~fs:(Eio.Stdenv.fs env)
+          ~net:(Eio.Stdenv.net env)
+          ~mono_clock:(Eio.Stdenv.mono_clock env)
+          (Eio.Stdenv.clock env)
+          ~base_path
+          Cases.Fresh
+      in
+      Cases.ensure_bound fixture;
+      let config = Mcp_server.workspace_config fixture.state in
+      ignore
+        (Masc.Workspace.add_task
+           config
+           ~title:"already owned"
+           ~priority:3
+           ~description:"");
+      ignore
+        (Masc.Workspace.claim_task
+           config
+           ~agent_name:fixture.agent_name
+           ~task_id:"task-001");
+      let result =
+        Cases.execute_tool
+          fixture
+          ~name:"masc_start"
+          ~arguments:
+            (`Assoc
+              [ ("path", `String base_path)
+              ; ("task_title", `String "must remain visible")
+              ])
+      in
+      Alcotest.(check bool) "claim failure is not success" false
+        (Tool_result.is_success result);
+      Alcotest.(check (option string)) "claim conflict is workflow rejection"
+        (Some "workflow_rejection")
+        (Tool_result.failure_class result
+         |> Option.map Tool_result.tool_failure_class_to_string);
+      Alcotest.(check bool) "claim failure is explicit" true
+        (contains_substring (Tool_result.message result) "claim failed");
+      let data = Tool_result.data result in
+      Alcotest.(check string) "created task remains a post-effect"
+        "proven_post_effect"
+        Yojson.Safe.Util.(data |> member "effect_disposition" |> to_string);
+      Alcotest.(check string) "task id is returned"
+        "task-002"
+        Yojson.Safe.Util.(data |> member "task_id" |> to_string))
+;;
+
 let test_health_aggregate_sum_rejects_overflow () =
   (match
      Mcp_server.For_testing.publication_recovery_health_count_sum
@@ -507,6 +567,10 @@ let () =
             "rejects tilde expansion when initial HOME is empty"
             `Quick
             test_masc_start_tilde_rejects_empty_initial_home
+        ; Alcotest.test_case
+            "surfaces claim failure after task commit"
+            `Quick
+            test_masc_start_surfaces_claim_failure_after_task_commit
         ; Alcotest.test_case
             "checks aggregate health count overflow"
             `Quick

--- a/test/test_mcp_tool_runtime_workspace_path.ml
+++ b/test/test_mcp_tool_runtime_workspace_path.ml
@@ -125,9 +125,72 @@ let test_masc_start_surfaces_claim_failure_after_task_commit () =
         "task-002"
         Yojson.Safe.Util.(data |> member "task_id" |> to_string);
       Alcotest.(check bool) "committed task result is preserved" true
-        (contains_substring
+      (contains_substring
            Yojson.Safe.Util.(data |> member "primary_result" |> to_string)
            "Added task-002"))
+;;
+
+let test_masc_start_surfaces_current_task_failure_after_claim_commit () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let base_path = Cases.temp_dir "mcp-start-current-task-failure-" in
+  Fun.protect
+    ~finally:(fun () -> Cases.cleanup_dir base_path)
+    (fun () ->
+      let fixture =
+        Cases.make_fixture
+          sw
+          ~proc_mgr:(Eio.Stdenv.process_mgr env)
+          ~fs:(Eio.Stdenv.fs env)
+          ~net:(Eio.Stdenv.net env)
+          ~mono_clock:(Eio.Stdenv.mono_clock env)
+          (Eio.Stdenv.clock env)
+          ~base_path
+          Cases.Fresh
+      in
+      Cases.ensure_bound fixture;
+      let config = Mcp_server.workspace_config fixture.state in
+      let masc_dir = Workspace_utils.masc_dir config in
+      let current_task_path = Filename.concat masc_dir "current_task" in
+      let trash_path = Filename.concat masc_dir "_trash" in
+      Unix.mkdir current_task_path 0o755;
+      Fs_compat.save_file
+        (Filename.concat current_task_path "forensics.txt")
+        "kept";
+      Fs_compat.mkdir_p trash_path;
+      Unix.chmod trash_path 0o555;
+      Fun.protect
+        ~finally:(fun () -> Unix.chmod trash_path 0o755)
+        (fun () ->
+          let result =
+            Cases.execute_tool
+              fixture
+              ~name:"masc_start"
+              ~arguments:
+                (`Assoc
+                  [ ("path", `String base_path)
+                  ; ("task_title", `String "must remain claimed")
+                  ])
+          in
+          Alcotest.(check bool) "current-task failure is not success" false
+            (Tool_result.is_success result);
+          Alcotest.(check (option string)) "store failure is runtime failure"
+            (Some "runtime_failure")
+            (Tool_result.failure_class result
+             |> Option.map Tool_result.tool_failure_class_to_string);
+          let data = Tool_result.data result in
+          Alcotest.(check string) "created and claimed task is a post-effect"
+            "proven_post_effect"
+            Yojson.Safe.Util.(data |> member "effect_disposition" |> to_string);
+          Alcotest.(check string) "task id is returned"
+            "task-001"
+            Yojson.Safe.Util.(data |> member "task_id" |> to_string);
+          Alcotest.(check bool) "committed task result is preserved" true
+            (contains_substring
+               Yojson.Safe.Util.(data |> member "primary_result" |> to_string)
+               "Added task-001")))
 ;;
 
 let test_health_aggregate_sum_rejects_overflow () =
@@ -575,6 +638,10 @@ let () =
             "surfaces claim failure after task commit"
             `Quick
             test_masc_start_surfaces_claim_failure_after_task_commit
+        ; Alcotest.test_case
+            "surfaces current-task failure after claim commit"
+            `Quick
+            test_masc_start_surfaces_current_task_failure_after_claim_commit
         ; Alcotest.test_case
             "checks aggregate health count overflow"
             `Quick

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -696,11 +696,42 @@ let test_post_create_data_is_structured () =
      Alcotest.(check bool) "structured data carries post id" true
        (List.mem_assoc "id" fields)
    | `String _ ->
-     Alcotest.fail
+       Alcotest.fail
        "board_post data is a raw `String (double-encoded JSON); expected structured `Assoc"
    | other ->
      Alcotest.failf "unexpected board_post data shape: %s"
        (Yojson.Safe.to_string other))
+
+let test_activity_projection_failure_preserves_primary_effect () =
+  let primary_result =
+    Tool_result.make_ok
+      ~tool_name:"masc_board_post"
+      ~start_time:0.0
+      ~data:(`Assoc [ ("id", `String "post-1") ])
+      ()
+  in
+  let result =
+    Mcp_tool_runtime_board.For_testing.result_after_activity_projection
+      ~tool_name:"masc_board_post"
+      ~start_time:0.0
+      ~primary_result
+      ~operation:"posted"
+      (fun () -> Error "activity graph unavailable")
+  in
+  Alcotest.(check bool) "projection failure is not success" false
+    (Tool_result.is_success result);
+  Alcotest.(check (option string)) "projection failure is runtime failure"
+    (Some "runtime_failure")
+    (Tool_result.failure_class result
+     |> Option.map Tool_result.tool_failure_class_to_string);
+  let data = Tool_result.data result in
+  Alcotest.(check string) "committed primary effect is explicit"
+    "proven_post_effect"
+    Yojson.Safe.Util.(data |> member "effect_disposition" |> to_string);
+  Alcotest.(check string) "operation is explicit" "posted"
+    Yojson.Safe.Util.(data |> member "projection" |> to_string);
+  Alcotest.(check string) "primary result is preserved" "post-1"
+    Yojson.Safe.Util.(data |> member "primary_result" |> member "id" |> to_string)
 
 let test_post_create_judgment_roundtrip () =
   with_eio @@ fun env ->
@@ -1971,6 +2002,8 @@ let () =
             test_post_create_metadata_payload;
           Alcotest.test_case "create data is structured not double-encoded" `Quick
             test_post_create_data_is_structured;
+          Alcotest.test_case "projection failure preserves primary effect" `Quick
+            test_activity_projection_failure_preserves_primary_effect;
           Alcotest.test_case "create judgment roundtrip" `Quick
             test_post_create_judgment_roundtrip;
           Alcotest.test_case "create judgment list roundtrip (#16300)" `Quick


### PR DESCRIPTION
## What changed

- Make `masc_start` return a typed failure when task creation succeeds but `claim_task` fails.
- Make Board handlers surface Activity Graph projection failures instead of reporting success.
- Include `effect_disposition: proven_post_effect` and the primary result so callers can distinguish committed work from failed downstream projection.

## Why

These paths could previously return apparent success after a required downstream effect failed. That made E2E behavior look healthy while leaving the workspace/task or Board projection partially applied and undiscoverable to the caller.

## Validation

- `ocamlformat --check lib/mcp_tool_runtime_workspace.ml lib/mcp_tool_runtime_board.ml`
- `git diff --check origin/main...HEAD`
- Focused Dune build:
  `MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build lib/mcp_tool_runtime_workspace.ml lib/mcp_tool_runtime_board.ml`

Known follow-ups are intentionally not hidden by this PR: the Board signal hook still logs and suppresses Keeper wake failures, and the existing Board/MCP matrix has registry and fixture mismatches. Full E2E is not claimed green by this change.