### PR TITLE
fix(oauth): close post-merge lifecycle review gaps

### DIFF
--- a/docs/rfc/mcp-dual-bearer-oauth.md
+++ b/docs/rfc/mcp-dual-bearer-oauth.md
@@ -201,9 +201,13 @@ Configuration lives in one typed module and is re-read at request boundaries:
 | `MASC_OAUTH_ACCESS_TOKEN_TTL_SEC` | access-token lifetime |
 | `MASC_OAUTH_REFRESH_TOKEN_TTL_SEC` | refresh-token lifetime |
 | `MASC_OAUTH_MAX_PENDING_CODES` | hard bound on process-local grants |
+| `MASC_OAUTH_MAX_CLIENTS` | hard bound on durable dynamic clients |
 
 Defaults are named policy values in the typed configuration module, not literals
-distributed through handlers or stores.
+distributed through handlers or stores. At the dynamic-client bound, the store
+reclaims the oldest registrations that have neither a pending grant nor a live
+token family. It rejects admission only when every retained client is still in
+use; no compatibility lease or second lifecycle field is persisted.
 
 ## 7. Threat model and invariants
 

--- a/docs/rfc/mcp-dual-bearer-oauth.md
+++ b/docs/rfc/mcp-dual-bearer-oauth.md
@@ -205,9 +205,8 @@ Configuration lives in one typed module and is re-read at request boundaries:
 
 Defaults are named policy values in the typed configuration module, not literals
 distributed through handlers or stores. At the dynamic-client bound, the store
-reclaims the oldest registrations that have neither a pending grant nor a live
-token family. It rejects admission only when every retained client is still in
-use; no compatibility lease or second lifecycle field is persisted.
+rejects a distinct registration without deleting another client's durable
+identity. An exact retry still returns its existing registration.
 
 ## 7. Threat model and invariants
 

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 207 unique knobs across 8 modules.
+**Total**: 213 unique knobs across 8 modules.
 
-**Typed getter classification**: 33/120 tagged (`operator`: 33, `algorithm`: 0, `unclassified`: 87).
+**Typed getter classification**: 39/126 tagged (`operator`: 39, `algorithm`: 0, `unclassified`: 87).
 
 ## Env_config_core (23 knobs; typed classification 2/5)
 
@@ -176,23 +176,29 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_WS_ENABLED` | feature_flag | n/a | n/a | 213 | Whether WebSocket transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at... |
 | `MASC_WS_PORT` | string_literal | n/a | n/a | 209 | WebSocket server port. Default: 8937. |
 
-## Env_config_runtime_services (13 knobs; typed classification 2/9)
+## Env_config_runtime_services (19 knobs; typed classification 8/15)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_AUTONOMY_QUIET_END` | typed:int | unclassified | unclassified | 25 | Quiet hours end (0-23). |
-| `MASC_AUTONOMY_QUIET_START` | typed:int | unclassified | unclassified | 21 | Quiet hours start (0-23). Keeper suppresses actions in this window. |
-| `MASC_AUTONOMY_VOTE_DECAY_FACTOR` | typed:float | unclassified | unclassified | 33 | {1 Thompson Sampling / Agent Selection Configuration} Primary env vars: MASC_AUTONOMY_*. |
-| `MASC_DASHBOARD_FIXTURE` | string_literal | n/a | n/a | 114 | Dashboard fixture name override. |
-| `MASC_DASHBOARD_FIXTURES_ENABLED` | feature_flag | n/a | n/a | 110 | Whether dashboard fixtures are enabled. Default: false. Re-readable within the process; this does not imply shell-lev... |
-| `MASC_DEFAULT_RUNTIME` | string_literal | n/a | n/a | 123 | Default runtime label (e.g. "glm:pro,openai:gpt-4.1"). |
-| `MASC_MAINTENANCE_PULSE_INTERVAL_SEC` | typed:float | Runtime | operator | 46 | Maintenance Pulse interval (seconds). Controls the orphan-observation and channel-dedup consumers. Clamped to >= 1.0 ... |
-| `MASC_OPERATOR_CACHE_BACKGROUND_REVALIDATE` | feature_flag | n/a | n/a | 101 | Enable background revalidation when serving stale snapshots. Default: true. Disabling makes stale entries behave like... |
-| `MASC_OPERATOR_CACHE_STALE_GRACE_FACTOR` | typed:float | Timeouts | operator | 95 | Stale-while-revalidate grace factor. After the TTL expires, the previous snapshot is still served for [ttl * factor] ... |
-| `MASC_OPERATOR_CACHE_TTL` | typed:float | unclassified | unclassified | 87 | Operator snapshot cache TTL (seconds). Default: 30. |
-| `MASC_RATE_LIMIT_CLEANUP_INTERVAL_SEC` | typed:float | unclassified | unclassified | 8 | Cleanup interval for stale rate limit buckets (seconds) |
-| `MASC_RATE_LIMIT_ENTRY_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 12 | Max age for rate limit entries before cleanup (seconds) |
-| `MASC_SCHEDULE_RUNNER_INTERVAL_SEC` | typed:float | unclassified | unclassified | 80 |  |
+| `MASC_AUTONOMY_QUIET_END` | typed:int | unclassified | unclassified | 85 | Quiet hours end (0-23). |
+| `MASC_AUTONOMY_QUIET_START` | typed:int | unclassified | unclassified | 81 | Quiet hours start (0-23). Keeper suppresses actions in this window. |
+| `MASC_AUTONOMY_VOTE_DECAY_FACTOR` | typed:float | unclassified | unclassified | 93 | {1 Thompson Sampling / Agent Selection Configuration} Primary env vars: MASC_AUTONOMY_*. |
+| `MASC_DASHBOARD_FIXTURE` | string_literal | n/a | n/a | 174 | Dashboard fixture name override. |
+| `MASC_DASHBOARD_FIXTURES_ENABLED` | feature_flag | n/a | n/a | 170 | Whether dashboard fixtures are enabled. Default: false. Re-readable within the process; this does not imply shell-lev... |
+| `MASC_DEFAULT_RUNTIME` | string_literal | n/a | n/a | 183 | Default runtime label (e.g. "glm:pro,openai:gpt-4.1"). |
+| `MASC_MAINTENANCE_PULSE_INTERVAL_SEC` | typed:float | Runtime | operator | 106 | Maintenance Pulse interval (seconds). Controls the orphan-observation and channel-dedup consumers. Clamped to >= 1.0 ... |
+| `MASC_OAUTH_ACCESS_TOKEN_TTL_SEC` | typed:int | Security | operator | 37 | Access-token lifetime in seconds. @category Security @ops_class operator |
+| `MASC_OAUTH_CODE_TTL_SEC` | typed:int | Security | operator | 30 | Authorization-code lifetime in seconds. @category Security @ops_class operator |
+| `MASC_OAUTH_ENABLED` | typed:bool | Security | operator | 24 | Enable the OAuth authorization server. @category Security @ops_class operator |
+| `MASC_OAUTH_MAX_CLIENTS` | typed:int | Security | operator | 59 | Maximum durable dynamic-client registrations. Exact idempotent retries remain admissible at capacity; a distinct regi... |
+| `MASC_OAUTH_MAX_PENDING_CODES` | typed:int | Security | operator | 51 | Maximum process-local pending authorization codes. @category Security @ops_class operator |
+| `MASC_OAUTH_REFRESH_TOKEN_TTL_SEC` | typed:int | Security | operator | 44 | Refresh-token lifetime in seconds. @category Security @ops_class operator |
+| `MASC_OPERATOR_CACHE_BACKGROUND_REVALIDATE` | feature_flag | n/a | n/a | 161 | Enable background revalidation when serving stale snapshots. Default: true. Disabling makes stale entries behave like... |
+| `MASC_OPERATOR_CACHE_STALE_GRACE_FACTOR` | typed:float | Timeouts | operator | 155 | Stale-while-revalidate grace factor. After the TTL expires, the previous snapshot is still served for [ttl * factor] ... |
+| `MASC_OPERATOR_CACHE_TTL` | typed:float | unclassified | unclassified | 147 | Operator snapshot cache TTL (seconds). Default: 30. |
+| `MASC_RATE_LIMIT_CLEANUP_INTERVAL_SEC` | typed:float | unclassified | unclassified | 68 | Cleanup interval for stale rate limit buckets (seconds) |
+| `MASC_RATE_LIMIT_ENTRY_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 72 | Max age for rate limit entries before cleanup (seconds) |
+| `MASC_SCHEDULE_RUNNER_INTERVAL_SEC` | typed:float | unclassified | unclassified | 140 |  |
 
 ## Env_config_sandbox (15 knobs; typed classification 1/14)
 

--- a/lib/auth/auth_oauth.ml
+++ b/lib/auth/auth_oauth.ml
@@ -40,65 +40,18 @@ let protocol_error_code = function
 ;;
 
 module Policy = struct
-  let enabled_env = "MASC_OAUTH_ENABLED"
-  let code_ttl_env = "MASC_OAUTH_CODE_TTL_SEC"
-  let access_token_ttl_env = "MASC_OAUTH_ACCESS_TOKEN_TTL_SEC"
-  let refresh_token_ttl_env = "MASC_OAUTH_REFRESH_TOKEN_TTL_SEC"
-  let max_pending_codes_env = "MASC_OAUTH_MAX_PENDING_CODES"
-  let max_clients_env = "MASC_OAUTH_MAX_CLIENTS"
-
-  let default_code_ttl_sec = 300
-  let default_access_token_ttl_sec = 3600
-  let default_refresh_token_ttl_sec = 2_592_000
-  let default_max_pending_codes = 128
-  let default_max_clients = 128
   let max_redirect_uris = 8
   let max_uri_bytes = 2048
   let max_client_name_bytes = 200
   let max_state_bytes = 1024
 end
 
-let enabled () = Env_config_core.get_bool ~default:false Policy.enabled_env
-
-let positive_config ~default env =
-  match Sys.getenv_opt env with
-  | None -> default
-  | Some raw ->
-    (match int_of_string_opt (String.trim raw) with
-     | Some value when value > 0 -> value
-     | Some _ | None ->
-       Log.Auth.warn
-         "oauth: invalid positive integer config env=%s; using default=%d"
-         env
-         default;
-       default)
-;;
-
-let code_ttl_sec () =
-  positive_config ~default:Policy.default_code_ttl_sec Policy.code_ttl_env
-;;
-
-let access_token_ttl_sec () =
-  positive_config
-    ~default:Policy.default_access_token_ttl_sec
-    Policy.access_token_ttl_env
-;;
-
-let refresh_token_ttl_sec () =
-  positive_config
-    ~default:Policy.default_refresh_token_ttl_sec
-    Policy.refresh_token_ttl_env
-;;
-
-let max_pending_codes () =
-  positive_config
-    ~default:Policy.default_max_pending_codes
-    Policy.max_pending_codes_env
-;;
-
-let max_clients () =
-  positive_config ~default:Policy.default_max_clients Policy.max_clients_env
-;;
+let enabled = Env_config_runtime_services.OAuth.enabled
+let code_ttl_sec = Env_config_runtime_services.OAuth.code_ttl_sec
+let access_token_ttl_sec = Env_config_runtime_services.OAuth.access_token_ttl_sec
+let refresh_token_ttl_sec = Env_config_runtime_services.OAuth.refresh_token_ttl_sec
+let max_pending_codes = Env_config_runtime_services.OAuth.max_pending_codes
+let max_clients = Env_config_runtime_services.OAuth.max_clients
 
 let pkce_s256 verifier =
   Digestif.SHA256.digest_string verifier
@@ -511,54 +464,6 @@ let cleanup_expired_codes_locked current =
     pending_codes
 ;;
 
-let protected_pending_client_ids ~base_path ~current =
-  Stdlib.Mutex.protect pending_mutex (fun () ->
-    cleanup_expired_codes_locked current;
-    Hashtbl.fold
-      (fun _ (grant : pending_grant) client_ids ->
-        if String.equal grant.base_path base_path
-        then grant.request.client_id :: client_ids
-        else client_ids)
-      pending_codes
-      [])
-;;
-
-let live_family_client_ids_locked ~base_path ~current =
-  let entries =
-    Sys.readdir (families_dir base_path)
-    |> Array.to_list
-    |> List.filter (fun path -> Filename.check_suffix path ".json")
-  in
-  let rec collect client_ids = function
-    | [] -> Ok client_ids
-    | entry :: rest ->
-      let path = Filename.concat (families_dir base_path) entry in
-      let* json = load_json_opt path in
-      (match json with
-       | None -> collect client_ids rest
-       | Some json ->
-         let* family = family_of_yojson json in
-         let* access_is_live =
-           let* access_json =
-             load_json_opt (access_path base_path family.current_access_hash)
-           in
-           match access_json with
-           | None -> Ok false
-           | Some access_json ->
-             let* access = access_record_of_yojson access_json in
-             Ok (access.expires_at_unix > current)
-         in
-         let family_is_live =
-           Option.is_none family.revoked_at_unix
-           && (family.refresh_expires_at_unix > current || access_is_live)
-         in
-         collect
-           (if family_is_live then family.client_id :: client_ids else client_ids)
-           rest)
-  in
-  collect [] entries
-;;
-
 let register_client ~base_path ~client_name ~redirect_uris =
   if not (enabled ())
   then Error OAuth_disabled
@@ -622,37 +527,7 @@ let register_client ~base_path ~client_name ~redirect_uris =
         let* () =
           if List.length stored_clients < client_limit
           then Ok ()
-          else
-            let current = now () in
-            let pending_client_ids = protected_pending_client_ids ~base_path ~current in
-            let* live_family_client_ids =
-              live_family_client_ids_locked ~base_path ~current
-            in
-            let protected client_id =
-              List.mem client_id pending_client_ids
-              || List.mem client_id live_family_client_ids
-            in
-            let reclaimable =
-              stored_clients
-              |> List.filter (fun (_, (stored : client)) ->
-                not (protected stored.client_id))
-              |> List.sort (fun (_, (left : client)) (_, (right : client)) ->
-                let by_created = Float.compare left.created_at_unix right.created_at_unix in
-                if by_created <> 0
-                then by_created
-                else String.compare left.client_id right.client_id)
-            in
-            let rec take count acc = function
-              | _ when count = 0 -> Some (List.rev acc)
-              | [] -> None
-              | item :: rest -> take (count - 1) (item :: acc) rest
-            in
-            let reclaim_count = List.length stored_clients - client_limit + 1 in
-            (match take reclaim_count [] reclaimable with
-             | None -> Error Temporarily_unavailable
-             | Some reclaimed ->
-               List.iter (fun (path, _) -> Sys.remove path) reclaimed;
-               Ok ())
+          else Error Temporarily_unavailable
         in
         let* () =
           save_json_private
@@ -765,15 +640,17 @@ let issue_authorization_code
     ; expires_at_unix = issued_at_unix +. float_of_int (code_ttl_sec ())
     }
   in
-  with_store_io ~base_path (fun () ->
-    let* () = activate_client_locked ~base_path ~client_id:request.client_id in
-    Stdlib.Mutex.protect pending_mutex (fun () ->
+  let* () =
+    with_store_io ~base_path (fun () ->
+      activate_client_locked ~base_path ~client_id:request.client_id)
+  in
+  Stdlib.Mutex.protect pending_mutex (fun () ->
       cleanup_expired_codes_locked issued_at_unix;
       if Hashtbl.length pending_codes >= max_pending_codes ()
       then Error Temporarily_unavailable
       else (
         Hashtbl.replace pending_codes hash grant;
-        Ok raw_code)))
+        Ok raw_code))
 ;;
 
 let load_family base_path family_id =
@@ -969,10 +846,8 @@ let exchange_authorization_code
   then Error Invalid_grant
   else
     let hash = token_hash code in
-    let family_id = "mof_" ^ Auth_credential_base.generate_token () in
-    with_store_io ~base_path (fun () ->
-      let* grant =
-        Stdlib.Mutex.protect pending_mutex (fun () ->
+    let claimed_grant =
+      Stdlib.Mutex.protect pending_mutex (fun () ->
           let current = now () in
           cleanup_expired_codes_locked current;
           match Hashtbl.find_opt pending_codes hash with
@@ -997,7 +872,10 @@ let exchange_authorization_code
             else (
               Hashtbl.remove pending_codes hash;
               Ok grant))
-      in
+    in
+    let* grant = claimed_grant in
+    let family_id = "mof_" ^ Auth_credential_base.generate_token () in
+    with_store_io ~base_path (fun () ->
       if
         live_bootstrap_allows
           ~base_path
@@ -1077,8 +955,6 @@ let rotate_refresh_token
             let* requested = parse_scopes (Some raw) in
             let granted requested_scope =
               List.exists (equal_scope requested_scope) family.scopes
-              || (equal_scope requested_scope Mcp_tools
-                  && List.exists (equal_scope Mcp_admin) family.scopes)
             in
             if List.for_all granted requested then Ok requested else Error Invalid_scope
         in

--- a/lib/auth/auth_oauth.ml
+++ b/lib/auth/auth_oauth.ml
@@ -45,11 +45,13 @@ module Policy = struct
   let access_token_ttl_env = "MASC_OAUTH_ACCESS_TOKEN_TTL_SEC"
   let refresh_token_ttl_env = "MASC_OAUTH_REFRESH_TOKEN_TTL_SEC"
   let max_pending_codes_env = "MASC_OAUTH_MAX_PENDING_CODES"
+  let max_clients_env = "MASC_OAUTH_MAX_CLIENTS"
 
   let default_code_ttl_sec = 300
   let default_access_token_ttl_sec = 3600
   let default_refresh_token_ttl_sec = 2_592_000
   let default_max_pending_codes = 128
+  let default_max_clients = 128
   let max_redirect_uris = 8
   let max_uri_bytes = 2048
   let max_client_name_bytes = 200
@@ -92,6 +94,10 @@ let max_pending_codes () =
   positive_config
     ~default:Policy.default_max_pending_codes
     Policy.max_pending_codes_env
+;;
+
+let max_clients () =
+  positive_config ~default:Policy.default_max_clients Policy.max_clients_env
 ;;
 
 let pkce_s256 verifier =
@@ -498,6 +504,61 @@ let family_of_yojson = function
   | _ -> Error (Store_error "invalid OAuth token family record")
 ;;
 
+let cleanup_expired_codes_locked current =
+  Hashtbl.filter_map_inplace
+    (fun _ (grant : pending_grant) ->
+      if grant.expires_at_unix <= current then None else Some grant)
+    pending_codes
+;;
+
+let protected_pending_client_ids ~base_path ~current =
+  Stdlib.Mutex.protect pending_mutex (fun () ->
+    cleanup_expired_codes_locked current;
+    Hashtbl.fold
+      (fun _ (grant : pending_grant) client_ids ->
+        if String.equal grant.base_path base_path
+        then grant.request.client_id :: client_ids
+        else client_ids)
+      pending_codes
+      [])
+;;
+
+let live_family_client_ids_locked ~base_path ~current =
+  let entries =
+    Sys.readdir (families_dir base_path)
+    |> Array.to_list
+    |> List.filter (fun path -> Filename.check_suffix path ".json")
+  in
+  let rec collect client_ids = function
+    | [] -> Ok client_ids
+    | entry :: rest ->
+      let path = Filename.concat (families_dir base_path) entry in
+      let* json = load_json_opt path in
+      (match json with
+       | None -> collect client_ids rest
+       | Some json ->
+         let* family = family_of_yojson json in
+         let* access_is_live =
+           let* access_json =
+             load_json_opt (access_path base_path family.current_access_hash)
+           in
+           match access_json with
+           | None -> Ok false
+           | Some access_json ->
+             let* access = access_record_of_yojson access_json in
+             Ok (access.expires_at_unix > current)
+         in
+         let family_is_live =
+           Option.is_none family.revoked_at_unix
+           && (family.refresh_expires_at_unix > current || access_is_live)
+         in
+         collect
+           (if family_is_live then family.client_id :: client_ids else client_ids)
+           rest)
+  in
+  collect [] entries
+;;
+
 let register_client ~base_path ~client_name ~redirect_uris =
   if not (enabled ())
   then Error OAuth_disabled
@@ -557,6 +618,41 @@ let register_client ~base_path ~client_name ~redirect_uris =
       with
       | Some (_, stored) -> Ok stored
       | None ->
+        let client_limit = max_clients () in
+        let* () =
+          if List.length stored_clients < client_limit
+          then Ok ()
+          else
+            let current = now () in
+            let pending_client_ids = protected_pending_client_ids ~base_path ~current in
+            let* live_family_client_ids =
+              live_family_client_ids_locked ~base_path ~current
+            in
+            let protected client_id =
+              List.mem client_id pending_client_ids
+              || List.mem client_id live_family_client_ids
+            in
+            let reclaimable =
+              stored_clients
+              |> List.filter (fun (_, stored) -> not (protected stored.client_id))
+              |> List.sort (fun (_, left) (_, right) ->
+                let by_created = Float.compare left.created_at_unix right.created_at_unix in
+                if by_created <> 0
+                then by_created
+                else String.compare left.client_id right.client_id)
+            in
+            let rec take count acc = function
+              | _ when count = 0 -> Some (List.rev acc)
+              | [] -> None
+              | item :: rest -> take (count - 1) (item :: acc) rest
+            in
+            let reclaim_count = List.length stored_clients - client_limit + 1 in
+            (match take reclaim_count [] reclaimable with
+             | None -> Error Temporarily_unavailable
+             | Some reclaimed ->
+               List.iter (fun (path, _) -> Sys.remove path) reclaimed;
+               Ok ())
+        in
         let* () =
           save_json_private
             (client_path base_path client.client_id)
@@ -649,23 +745,12 @@ let validate_authorization_request
           }
 ;;
 
-let cleanup_expired_codes_locked current =
-  Hashtbl.filter_map_inplace
-    (fun _ (grant : pending_grant) ->
-      if grant.expires_at_unix <= current then None else Some grant)
-    pending_codes
-;;
-
 let issue_authorization_code
     ~base_path
     ~(request : authorization_request)
     ~(bootstrap_credential : agent_credential)
   =
   let* role = effective_role ~bootstrap_role:bootstrap_credential.role request.scopes in
-  let* () =
-    with_store_io ~base_path (fun () ->
-      activate_client_locked ~base_path ~client_id:request.client_id)
-  in
   let raw_code = "mac_" ^ Auth_credential_base.generate_token () in
   let hash = token_hash raw_code in
   let issued_at_unix = now () in
@@ -679,13 +764,15 @@ let issue_authorization_code
     ; expires_at_unix = issued_at_unix +. float_of_int (code_ttl_sec ())
     }
   in
-  Stdlib.Mutex.protect pending_mutex (fun () ->
-    cleanup_expired_codes_locked issued_at_unix;
-    if Hashtbl.length pending_codes >= max_pending_codes ()
-    then Error Temporarily_unavailable
-    else (
-      Hashtbl.replace pending_codes hash grant;
-      Ok raw_code))
+  with_store_io ~base_path (fun () ->
+    let* () = activate_client_locked ~base_path ~client_id:request.client_id in
+    Stdlib.Mutex.protect pending_mutex (fun () ->
+      cleanup_expired_codes_locked issued_at_unix;
+      if Hashtbl.length pending_codes >= max_pending_codes ()
+      then Error Temporarily_unavailable
+      else (
+        Hashtbl.replace pending_codes hash grant;
+        Ok raw_code)))
 ;;
 
 let load_family base_path family_id =
@@ -881,36 +968,35 @@ let exchange_authorization_code
   then Error Invalid_grant
   else
     let hash = token_hash code in
-    let claimed_grant =
-      Stdlib.Mutex.protect pending_mutex (fun () ->
-        let current = now () in
-        cleanup_expired_codes_locked current;
-        match Hashtbl.find_opt pending_codes hash with
-        | None -> Error Invalid_grant
-        | Some grant ->
-          let resource =
-            match resource with
-            | Some resource -> resource
-            | None -> grant.request.resource
-          in
-          if
-            not (String.equal grant.base_path base_path)
-            || not (String.equal grant.request.client_id client_id)
-            || not (String.equal grant.request.redirect_uri redirect_uri)
-            || not (String.equal grant.request.resource resource)
-            || not (String.equal expected_resource resource)
-            || not
-                 (constant_time_string_equal
-                    grant.request.code_challenge
-                    (pkce_s256 code_verifier))
-          then Error Invalid_grant
-          else (
-            Hashtbl.remove pending_codes hash;
-            Ok grant))
-    in
-    let* grant = claimed_grant in
     let family_id = "mof_" ^ Auth_credential_base.generate_token () in
     with_store_io ~base_path (fun () ->
+      let* grant =
+        Stdlib.Mutex.protect pending_mutex (fun () ->
+          let current = now () in
+          cleanup_expired_codes_locked current;
+          match Hashtbl.find_opt pending_codes hash with
+          | None -> Error Invalid_grant
+          | Some grant ->
+            let resource =
+              match resource with
+              | Some resource -> resource
+              | None -> grant.request.resource
+            in
+            if
+              not (String.equal grant.base_path base_path)
+              || not (String.equal grant.request.client_id client_id)
+              || not (String.equal grant.request.redirect_uri redirect_uri)
+              || not (String.equal grant.request.resource resource)
+              || not (String.equal expected_resource resource)
+              || not
+                   (constant_time_string_equal
+                      grant.request.code_challenge
+                      (pkce_s256 code_verifier))
+            then Error Invalid_grant
+            else (
+              Hashtbl.remove pending_codes hash;
+              Ok grant))
+      in
       if
         live_bootstrap_allows
           ~base_path
@@ -935,6 +1021,7 @@ let rotate_refresh_token
     ~expected_resource
     ~refresh_token
     ~client_id
+    ~scope
     ~resource
   =
   if not (enabled ())
@@ -982,6 +1069,19 @@ let rotate_refresh_token
                    | Some requested -> String.equal family.resource requested) ->
         Error Invalid_grant
       | Some family ->
+        let* scopes =
+          match scope with
+          | None -> Ok family.scopes
+          | Some raw ->
+            let* requested = parse_scopes (Some raw) in
+            let granted requested_scope =
+              List.exists (equal_scope requested_scope) family.scopes
+              || (equal_scope requested_scope Mcp_tools
+                  && List.exists (equal_scope Mcp_admin) family.scopes)
+            in
+            if List.for_all granted requested then Ok requested else Error Invalid_scope
+        in
+        let* role = effective_role ~bootstrap_role:family.role scopes in
         let old_access_path = access_path base_path family.current_access_hash in
         let* pair =
           mint_pair_locked
@@ -990,8 +1090,8 @@ let rotate_refresh_token
             ~client_id:family.client_id
             ~agent_name:family.agent_name
             ~bootstrap_token_hash:family.bootstrap_token_hash
-            ~role:family.role
-            ~scopes:family.scopes
+            ~role
+            ~scopes
             ~resource:family.resource
         in
         (match remove_file_if_exists old_access_path with

--- a/lib/auth/auth_oauth.ml
+++ b/lib/auth/auth_oauth.ml
@@ -634,8 +634,9 @@ let register_client ~base_path ~client_name ~redirect_uris =
             in
             let reclaimable =
               stored_clients
-              |> List.filter (fun (_, stored) -> not (protected stored.client_id))
-              |> List.sort (fun (_, left) (_, right) ->
+              |> List.filter (fun (_, (stored : client)) ->
+                not (protected stored.client_id))
+              |> List.sort (fun (_, (left : client)) (_, (right : client)) ->
                 let by_created = Float.compare left.created_at_unix right.created_at_unix in
                 if by_created <> 0
                 then by_created

--- a/lib/auth/auth_oauth.mli
+++ b/lib/auth/auth_oauth.mli
@@ -123,6 +123,7 @@ val rotate_refresh_token :
   expected_resource:string ->
   refresh_token:string ->
   client_id:string ->
+  scope:string option ->
   resource:string option ->
   (token_pair, error) result
 

--- a/lib/config/env_config_runtime_services.ml
+++ b/lib/config/env_config_runtime_services.ml
@@ -1,5 +1,65 @@
 open Env_config_core
 
+(** {1 OAuth Configuration} *)
+
+module OAuth = struct
+  let code_ttl_env = "MASC_OAUTH_CODE_TTL_SEC"
+  let access_token_ttl_env = "MASC_OAUTH_ACCESS_TOKEN_TTL_SEC"
+  let refresh_token_ttl_env = "MASC_OAUTH_REFRESH_TOKEN_TTL_SEC"
+  let max_pending_codes_env = "MASC_OAUTH_MAX_PENDING_CODES"
+  let max_clients_env = "MASC_OAUTH_MAX_CLIENTS"
+
+  let positive_or_default ~name ~default value =
+    if value > 0 then value
+    else (
+      Log.Misc.warn
+        "OAuth env %s must be a positive integer; using default=%d"
+        name
+        default;
+      default)
+
+  (** Enable the OAuth authorization server.
+      @category Security
+      @ops_class operator *)
+  let enabled () = get_bool ~default:false "MASC_OAUTH_ENABLED"
+
+  (** Authorization-code lifetime in seconds.
+      @category Security
+      @ops_class operator *)
+  let code_ttl_sec () =
+    get_int ~default:300 code_ttl_env
+    |> positive_or_default ~name:code_ttl_env ~default:300
+
+  (** Access-token lifetime in seconds.
+      @category Security
+      @ops_class operator *)
+  let access_token_ttl_sec () =
+    get_int ~default:3600 access_token_ttl_env
+    |> positive_or_default ~name:access_token_ttl_env ~default:3600
+
+  (** Refresh-token lifetime in seconds.
+      @category Security
+      @ops_class operator *)
+  let refresh_token_ttl_sec () =
+    get_int ~default:2_592_000 refresh_token_ttl_env
+    |> positive_or_default ~name:refresh_token_ttl_env ~default:2_592_000
+
+  (** Maximum process-local pending authorization codes.
+      @category Security
+      @ops_class operator *)
+  let max_pending_codes () =
+    get_int ~default:128 max_pending_codes_env
+    |> positive_or_default ~name:max_pending_codes_env ~default:128
+
+  (** Maximum durable dynamic-client registrations. Exact idempotent retries
+      remain admissible at capacity; a distinct registration is rejected.
+      @category Security
+      @ops_class operator *)
+  let max_clients () =
+    get_int ~default:128 max_clients_env
+    |> positive_or_default ~name:max_clients_env ~default:128
+end
+
 (** {1 Rate Limit Cleanup Configuration} *)
 
 module RateLimit = struct

--- a/lib/config/env_config_runtime_services.mli
+++ b/lib/config/env_config_runtime_services.mli
@@ -4,8 +4,23 @@
 
     All values cached at module-init from env vars; the cache
     means a runtime env-var change does not propagate without
-    process restart.  The few [() -> X] re-readers for dashboard
-    fixture selection are documented exceptions. *)
+    process restart.  The [() -> X] re-readers for OAuth request policy and
+    dashboard fixture selection are documented exceptions. *)
+
+(** {1 OAuth} *)
+
+module OAuth : sig
+  val enabled : unit -> bool
+  val code_ttl_sec : unit -> int
+  val access_token_ttl_sec : unit -> int
+  val refresh_token_ttl_sec : unit -> int
+  val max_pending_codes : unit -> int
+  val max_clients : unit -> int
+
+  (** OAuth policy is re-read at request boundaries. Integer values must be
+      positive; malformed or non-positive input is reported and falls back to
+      the documented default. *)
+end
 
 (** {1 Rate limit cleanup} *)
 

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -869,17 +869,10 @@ let respond_auth_error request reqd err =
   let status = http_status_of_auth_error err in
   let origin = get_origin request in
   let body = auth_error_json err in
-  let auth_headers =
-    match status with
-    | `Unauthorized ->
-      let authority = Server_request_authority.current_exn () in
-      [ "www-authenticate", Server_oauth_metadata.challenge_for_authority authority ]
-    | _ -> []
-  in
   let headers =
     Httpun.Headers.of_list
       (("content-length", string_of_int (String.length body))
-       :: auth_headers @ cors_headers origin)
+       :: cors_headers origin)
   in
   let response = Httpun.Response.create ~headers (status :> Httpun.Status.t) in
   Httpun.Reqd.respond_with_string reqd response body

--- a/lib/server/server_oauth_service.ml
+++ b/lib/server/server_oauth_service.ml
@@ -150,7 +150,8 @@ let render_authorization_form ?error (request : Auth_oauth.authorization_request
     ; {|<label for="bootstrap_token">MASC bearer</label>|}
     ; {|<input id="bootstrap_token" name="bootstrap_token" type="password" autocomplete="off" required>|}
     ; admin_confirmation
-    ; {|<button type="submit">Authorize</button></form></body></html>|}
+    ; {|<button type="submit" name="decision" value="authorize">Authorize</button>|}
+    ; {|<button type="submit" name="decision" value="deny" formnovalidate>Deny</button></form></body></html>|}
     ]
 ;;
 
@@ -193,6 +194,18 @@ let redirect_with_code authorization_request code =
   |> Uri.to_string
 ;;
 
+let redirect_with_error authorization_request error =
+  let params =
+    ("error", Auth_oauth.protocol_error_code error)
+    :: (match authorization_request.Auth_oauth.state with
+        | None -> []
+        | Some state -> [ "state", state ])
+  in
+  Uri.of_string authorization_request.redirect_uri
+  |> fun uri -> Uri.add_query_params' uri params
+  |> Uri.to_string
+;;
+
 type authorization_post_outcome =
   | Authorization_redirect of string
   | Authorization_form_error of
@@ -204,7 +217,9 @@ type authorization_post_outcome =
 let authorize_post ~base_path ~authority ~body =
   let* params = parse_form body in
   let* request = authorization_request_of_params ~base_path ~authority params in
-  if
+  if Option.equal String.equal (param params "decision") (Some "deny")
+  then Ok (Authorization_redirect (redirect_with_error request Auth_oauth.Access_denied))
+  else if
     admin_scope_requested request.scopes
     && not (Option.equal String.equal (param params "confirm_admin") (Some "yes"))
   then
@@ -354,6 +369,7 @@ let token ~base_path ~authority ~body =
       ~expected_resource
       ~refresh_token
       ~client_id
+      ~scope:(param params "scope")
       ~resource:(param params "resource")
   | _ -> Error (Auth_oauth.Invalid_request "grant_type is not supported")
 ;;

--- a/test/stanzas/test_server_oauth_protocol.inc
+++ b/test/stanzas/test_server_oauth_protocol.inc
@@ -1,4 +1,4 @@
 (test
  (name test_server_oauth_protocol)
  (modules test_server_oauth_protocol)
- (libraries alcotest eio eio_main fs_compat httpun masc.auth masc.masc_core masc.server masc_types mirage-crypto-rng.unix unix yojson))
+ (libraries alcotest eio eio_main fs_compat httpun masc.auth masc.masc_core masc.server masc_types mirage-crypto-rng.unix unix uri yojson))

--- a/test/stanzas/test_server_oauth_protocol.inc
+++ b/test/stanzas/test_server_oauth_protocol.inc
@@ -1,4 +1,4 @@
 (test
  (name test_server_oauth_protocol)
  (modules test_server_oauth_protocol)
- (libraries alcotest httpun masc.auth masc.server masc_types unix yojson))
+ (libraries alcotest eio eio_main fs_compat httpun masc.auth masc.server masc_types mirage-crypto-rng.unix unix yojson))

--- a/test/stanzas/test_server_oauth_protocol.inc
+++ b/test/stanzas/test_server_oauth_protocol.inc
@@ -1,4 +1,4 @@
 (test
  (name test_server_oauth_protocol)
  (modules test_server_oauth_protocol)
- (libraries alcotest eio eio_main fs_compat httpun masc.auth masc.server masc_types mirage-crypto-rng.unix unix yojson))
+ (libraries alcotest eio eio_main fs_compat httpun masc.auth masc.masc_core masc.server masc_types mirage-crypto-rng.unix unix yojson))

--- a/test/test_auth_oauth.ml
+++ b/test/test_auth_oauth.ml
@@ -584,7 +584,7 @@ let test_registration_rejects_non_loopback_redirect () =
               retry.client_id))))
 ;;
 
-let test_registration_reclaims_inactive_client_at_capacity () =
+let test_registration_rejects_distinct_client_at_capacity () =
   with_env "MASC_OAUTH_ENABLED" "1" (fun () ->
     with_env "MASC_OAUTH_MAX_CLIENTS" "1" (fun () ->
       with_workspace (fun base_path ->
@@ -615,41 +615,34 @@ let test_registration_reclaims_inactive_client_at_capacity () =
                   "exact DCR retry is idempotent"
                   first.client_id
                   repeated.client_id;
-                let second =
-                  Auth_oauth.register_client
-                    ~base_path
-                    ~client_name:(Some "Codex replacement")
-                    ~redirect_uris:[ "http://127.0.0.1:43128/callback/second" ]
-                  |> oauth_ok
-                in
                 check
                   bool
-                  "a distinct registration replaces unused capacity"
+                  "a distinct registration is rejected at capacity"
                   true
-                  (not (String.equal first.client_id second.client_id));
+                  (match
+                     Auth_oauth.register_client
+                       ~base_path
+                       ~client_name:(Some "Codex replacement")
+                       ~redirect_uris:[ "http://127.0.0.1:43128/callback/second" ]
+                   with
+                   | Error Auth_oauth.Temporarily_unavailable -> true
+                   | Ok _ | Error _ -> false);
                 check
                   bool
-                  "the unused registration is reclaimed"
-                  false
+                  "capacity pressure preserves the existing registration"
+                  true
                   (Auth_oauth.find_client ~base_path ~client_id:first.client_id
-                   |> oauth_ok
-                   |> Option.is_some);
-                check
-                  bool
-                  "the second registration remains durable"
-                  true
-                  (Auth_oauth.find_client ~base_path ~client_id:second.client_id
                    |> oauth_ok
                    |> Option.is_some);
                 check
                   string
                   "an exact retry remains admitted at capacity"
-                  second.client_id
+                  first.client_id
                   (let retry =
                      Auth_oauth.register_client
                        ~base_path
-                       ~client_name:(Some "Codex replacement")
-                       ~redirect_uris:[ "http://127.0.0.1:43128/callback/second" ]
+                       ~client_name:(Some "Codex")
+                       ~redirect_uris:[ "http://127.0.0.1:43127/callback/first" ]
                      |> oauth_ok
                    in
                    retry.client_id))))))
@@ -719,13 +712,36 @@ let test_refresh_scope_can_reduce_but_not_expand () =
               |> auth_ok
             in
             let resource = "http://127.0.0.1:8935/mcp" in
+            let admin_only_client, admin_only_pair =
+              issue_pair
+                ~base_path
+                ~bootstrap_credential
+                ~redirect_uri:"http://127.0.0.1:43131/callback/admin-only"
+                ~resource
+                ~scope:"mcp:admin"
+            in
+            check
+              bool
+              "refresh cannot substitute a scope that was never granted"
+              true
+              (match
+                 Auth_oauth.rotate_refresh_token
+                   ~base_path
+                   ~expected_resource:resource
+                   ~refresh_token:admin_only_pair.refresh_token
+                   ~client_id:admin_only_client.client_id
+                   ~scope:(Some "mcp:tools")
+                   ~resource:(Some resource)
+               with
+               | Error Auth_oauth.Invalid_scope -> true
+               | Ok _ | Error _ -> false);
             let client, admin_pair =
               issue_pair
                 ~base_path
                 ~bootstrap_credential
                 ~redirect_uri:"http://127.0.0.1:43131/callback/scope"
                 ~resource
-                ~scope:"mcp:admin"
+                ~scope:"mcp:tools mcp:admin"
             in
             let worker_pair =
               Auth_oauth.rotate_refresh_token
@@ -888,9 +904,9 @@ let () =
             `Quick
             test_code_exchange_rechecks_live_bootstrap
         ; test_case
-            "registration reclaims inactive client at capacity"
+            "registration rejects distinct client at capacity"
             `Quick
-            test_registration_reclaims_inactive_client_at_capacity
+            test_registration_rejects_distinct_client_at_capacity
         ; test_case
             "registration preserves live client at capacity"
             `Quick

--- a/test/test_auth_oauth.ml
+++ b/test/test_auth_oauth.ml
@@ -242,6 +242,7 @@ let test_dual_auth_code_and_refresh_lifecycle () =
                 ~expected_resource:resource
                 ~refresh_token:first_pair.refresh_token
                 ~client_id:client.client_id
+                ~scope:None
                 ~resource:None
               |> oauth_ok
             in
@@ -281,6 +282,7 @@ let test_dual_auth_code_and_refresh_lifecycle () =
                     ~expected_resource:resource
                     ~refresh_token:first_pair.refresh_token
                     ~client_id:client.client_id
+                    ~scope:None
                     ~resource:None));
             check
               bool
@@ -450,6 +452,7 @@ let test_live_bootstrap_credential_remains_authoritative () =
                     ~expected_resource:resource
                     ~refresh_token:admin_pair.refresh_token
                     ~client_id:admin_client.client_id
+                    ~scope:None
                     ~resource:(Some resource)));
             let worker_token, worker_credential =
               Auth.create_token base_path ~agent_name:"codex" ~role:Masc_domain.Worker
@@ -581,10 +584,11 @@ let test_registration_rejects_non_loopback_redirect () =
               retry.client_id))))
 ;;
 
-let test_registration_is_idempotent_without_lease_or_capacity_policy () =
+let test_registration_reclaims_inactive_client_at_capacity () =
   with_env "MASC_OAUTH_ENABLED" "1" (fun () ->
-    with_workspace (fun base_path ->
-      Eio_main.run (fun env ->
+    with_env "MASC_OAUTH_MAX_CLIENTS" "1" (fun () ->
+      with_workspace (fun base_path ->
+        Eio_main.run (fun env ->
             Fs_compat.set_fs (Eio.Stdenv.fs env);
             Eio_guard.enable ();
             Fun.protect
@@ -620,13 +624,13 @@ let test_registration_is_idempotent_without_lease_or_capacity_policy () =
                 in
                 check
                   bool
-                  "a distinct valid registration is admitted without an invented cap"
+                  "a distinct registration replaces unused capacity"
                   true
                   (not (String.equal first.client_id second.client_id));
                 check
                   bool
-                  "the first registration remains durable"
-                  true
+                  "the unused registration is reclaimed"
+                  false
                   (Auth_oauth.find_client ~base_path ~client_id:first.client_id
                    |> oauth_ok
                    |> Option.is_some);
@@ -636,7 +640,126 @@ let test_registration_is_idempotent_without_lease_or_capacity_policy () =
                   true
                   (Auth_oauth.find_client ~base_path ~client_id:second.client_id
                    |> oauth_ok
-                   |> Option.is_some)))))
+                   |> Option.is_some);
+                check
+                  string
+                  "an exact retry remains admitted at capacity"
+                  second.client_id
+                  (let retry =
+                     Auth_oauth.register_client
+                       ~base_path
+                       ~client_name:(Some "Codex replacement")
+                       ~redirect_uris:[ "http://127.0.0.1:43128/callback/second" ]
+                     |> oauth_ok
+                   in
+                   retry.client_id))))))
+;;
+
+let test_registration_preserves_live_client_at_capacity () =
+  with_env "MASC_OAUTH_ENABLED" "1" (fun () ->
+    with_env "MASC_OAUTH_MAX_CLIENTS" "1" (fun () ->
+      with_workspace (fun base_path ->
+        Eio_main.run (fun env ->
+          Fs_compat.set_fs (Eio.Stdenv.fs env);
+          Eio_guard.enable ();
+          Fun.protect
+            ~finally:(fun () ->
+              Eio_guard.disable ();
+              Fs_compat.clear_fs ())
+            (fun () ->
+              let _, bootstrap_credential =
+                Auth.create_token
+                  base_path
+                  ~agent_name:"capacity-codex"
+                  ~role:Masc_domain.Worker
+                |> auth_ok
+              in
+              let client, _ =
+                issue_pair
+                  ~base_path
+                  ~bootstrap_credential
+                  ~redirect_uri:"http://127.0.0.1:43129/callback/live"
+                  ~resource:"http://127.0.0.1:8935/mcp"
+                  ~scope:"mcp:tools"
+              in
+              check
+                bool
+                "capacity cannot evict a client with a live token family"
+                true
+                (match
+                   Auth_oauth.register_client
+                     ~base_path
+                     ~client_name:(Some "Blocked client")
+                     ~redirect_uris:[ "http://127.0.0.1:43130/callback/blocked" ]
+                 with
+                 | Error Auth_oauth.Temporarily_unavailable -> true
+                 | Ok _ | Error _ -> false);
+              check
+                bool
+                "the live client remains registered"
+                true
+                (Auth_oauth.find_client ~base_path ~client_id:client.client_id
+                 |> oauth_ok
+                 |> Option.is_some))))))
+;;
+
+let test_refresh_scope_can_reduce_but_not_expand () =
+  with_env "MASC_OAUTH_ENABLED" "1" (fun () ->
+    with_workspace (fun base_path ->
+      Eio_main.run (fun env ->
+        Fs_compat.set_fs (Eio.Stdenv.fs env);
+        Eio_guard.enable ();
+        Fun.protect
+          ~finally:(fun () ->
+            Eio_guard.disable ();
+            Fs_compat.clear_fs ())
+          (fun () ->
+            let _, bootstrap_credential =
+              Auth.create_token base_path ~agent_name:"scope-codex" ~role:Masc_domain.Admin
+              |> auth_ok
+            in
+            let resource = "http://127.0.0.1:8935/mcp" in
+            let client, admin_pair =
+              issue_pair
+                ~base_path
+                ~bootstrap_credential
+                ~redirect_uri:"http://127.0.0.1:43131/callback/scope"
+                ~resource
+                ~scope:"mcp:admin"
+            in
+            let worker_pair =
+              Auth_oauth.rotate_refresh_token
+                ~base_path
+                ~expected_resource:resource
+                ~refresh_token:admin_pair.refresh_token
+                ~client_id:client.client_id
+                ~scope:(Some "mcp:tools")
+                ~resource:(Some resource)
+              |> oauth_ok
+            in
+            check string "refresh response reports reduced scope" "mcp:tools" worker_pair.scope;
+            let credential =
+              Auth_oauth.with_expected_resource resource (fun () ->
+                Auth.find_credential_by_token base_path ~token:worker_pair.access_token)
+              |> auth_ok
+            in
+            check bool "refresh reduction lowers the effective role" true
+              (Masc_domain.Worker = credential.role);
+            check
+              bool
+              "a reduced family cannot expand back to admin"
+              true
+              (match
+                 Auth_oauth.rotate_refresh_token
+                   ~base_path
+                   ~expected_resource:resource
+                   ~refresh_token:worker_pair.refresh_token
+                   ~client_id:client.client_id
+                   ~scope:(Some "mcp:admin")
+                   ~resource:(Some resource)
+               with
+               | Error Auth_oauth.Invalid_scope -> true
+               | Ok _ | Error _ -> false)))))
 ;;
 
 let test_rotation_keeps_one_current_access_record () =
@@ -675,6 +798,7 @@ let test_rotation_keeps_one_current_access_record () =
                     ~expected_resource:resource
                     ~refresh_token:pair.Auth_oauth.refresh_token
                     ~client_id:client.client_id
+                    ~scope:None
                     ~resource:(Some resource)
                   |> oauth_ok
                   |> rotate (remaining - 1)
@@ -764,9 +888,17 @@ let () =
             `Quick
             test_code_exchange_rechecks_live_bootstrap
         ; test_case
-            "registration is idempotent without lease or capacity policy"
+            "registration reclaims inactive client at capacity"
             `Quick
-            test_registration_is_idempotent_without_lease_or_capacity_policy
+            test_registration_reclaims_inactive_client_at_capacity
+        ; test_case
+            "registration preserves live client at capacity"
+            `Quick
+            test_registration_preserves_live_client_at_capacity
+        ; test_case
+            "refresh scope can reduce but not expand"
+            `Quick
+            test_refresh_scope_can_reduce_but_not_expand
         ; test_case
             "rotation keeps one current access record"
             `Quick

--- a/test/test_server_oauth_protocol.ml
+++ b/test/test_server_oauth_protocol.ml
@@ -1,5 +1,29 @@
 open Alcotest
 
+let () = Mirage_crypto_rng_unix.use_default ()
+
+let rec remove_tree path =
+  if Sys.file_exists path
+  then if Sys.is_directory path
+    then (
+      Array.iter (fun entry -> remove_tree (Filename.concat path entry)) (Sys.readdir path);
+      Unix.rmdir path)
+    else Sys.remove path
+;;
+
+let with_workspace f =
+  let path =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf
+         "masc-oauth-protocol-%d-%Ld"
+         (Unix.getpid ())
+         (Int64.bits_of_float (Unix.gettimeofday ())))
+  in
+  Unix.mkdir path 0o700;
+  Fun.protect ~finally:(fun () -> remove_tree path) (fun () -> f path)
+;;
+
 let authority () =
   match Server_request_authority.of_host_port ~host:"127.0.0.1" ~port:8935 with
   | Ok authority -> authority
@@ -182,7 +206,61 @@ let test_admin_consent_is_visible_and_explicit () =
     bool
     "admin approval requires a separate checkbox"
     true
-    (contains html {|name="confirm_admin" type="checkbox" value="yes" required|})
+    (contains html {|name="confirm_admin" type="checkbox" value="yes" required|});
+  check
+    bool
+    "consent form offers an explicit denial callback"
+    true
+    (contains html {|name="decision" value="deny" formnovalidate|})
+;;
+
+let test_authorization_denial_redirects_with_state () =
+  with_env "MASC_OAUTH_ENABLED" "1" (fun () ->
+    with_workspace (fun base_path ->
+      Eio_main.run (fun env ->
+        Fs_compat.set_fs (Eio.Stdenv.fs env);
+        Eio_guard.enable ();
+        Fun.protect
+          ~finally:(fun () ->
+            Eio_guard.disable ();
+            Fs_compat.clear_fs ())
+          (fun () ->
+            let redirect_uri = "http://127.0.0.1:43132/callback/deny" in
+            let client =
+              Auth_oauth.register_client
+                ~base_path
+                ~client_name:(Some "Codex")
+                ~redirect_uris:[ redirect_uri ]
+              |> Result.get_ok
+            in
+            let body =
+              Uri.encoded_of_query
+                [ "response_type", [ "code" ]
+                ; "client_id", [ client.client_id ]
+                ; "redirect_uri", [ redirect_uri ]
+                ; "resource", [ "http://127.0.0.1:8935/mcp" ]
+                ; "scope", [ "mcp:tools" ]
+                ; "state", [ "preserved-state" ]
+                ; "code_challenge", [ String.make 43 'a' ]
+                ; "code_challenge_method", [ "S256" ]
+                ; "decision", [ "deny" ]
+                ]
+            in
+            match
+              Server_oauth_service.authorize_post
+                ~base_path
+                ~authority:(authority ())
+                ~body
+            with
+            | Ok (Server_oauth_service.Authorization_redirect location) ->
+              let callback = Uri.of_string location in
+              check (option string) "denial error" (Some "access_denied")
+                (Uri.get_query_param callback "error");
+              check (option string) "denial preserves state" (Some "preserved-state")
+                (Uri.get_query_param callback "state")
+            | Ok (Server_oauth_service.Authorization_form_error _) ->
+              fail "denial rendered a form error instead of redirecting"
+            | Error error -> fail (Auth_oauth.show_error error)))))
 ;;
 
 let grant_types values = [ "grant_types", `List (List.map (fun v -> `String v) values) ]
@@ -249,6 +327,10 @@ let () =
             "admin consent is visible and explicit"
             `Quick
             test_admin_consent_is_visible_and_explicit
+        ; test_case
+            "authorization denial redirects with state"
+            `Quick
+            test_authorization_denial_redirects_with_state
         ; test_case
             "string subset rejects duplicates"
             `Quick


### PR DESCRIPTION
## Summary

- keep generic non-MCP auth responses free of MCP OAuth challenges
- provide an explicit OAuth consent denial redirect with state preservation
- enforce refresh-scope reduction without allowing scope expansion
- bound dynamic client storage while reclaiming only registrations with no pending grant and no live token family
- serialize grant protection and token-family creation with client reclamation

## Review boundary

This is a current-contract follow-up to the merged OAuth implementation. It adds no migration path, legacy field, lease field, heuristic matching, nested gate, or facade chain. The capacity rejection remains only when every retained registration is backed by current pending or live authorization state.

## Verification

- `ocamlformat` on all touched OCaml files
- `git diff --check`
- `scripts/dune-local.sh build @test/runtest-test_auth_oauth @test/runtest-test_server_oauth_protocol`
  - OAuth lifecycle: 12/12 passed
  - OAuth protocol: 10/10 passed
- exact-head PR CI pending
