### PR TITLE
feat(keeper): admit scheduled turns on typed stimulus edges (RFC-0357)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -814,6 +814,20 @@ jobs:
           chmod +x scripts/ci-run-tests.sh
           scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_turn_outcome @test/runtest-test_keeper_paused_work_transfer_transaction @test/runtest-test_keeper_paused_work_source_terminal_transaction @test/runtest-test_keeper_paused_work_operator"
 
+      - name: Run scheduled-turn admission edge suite
+        # RFC-0357 §3.1/§3.3: scheduled-autonomous turns admit on typed
+        # stimulus edges (backlog revision, message, board event, due
+        # schedule, bootstrap), never on the heartbeat tick; an unwired
+        # ratchet does not bite, so it runs here.
+        # See: test/test_keeper_admission_edge.ml.
+        if: ${{ always() && steps.build_step.outcome == 'success' }}
+        env:
+          ALCOTEST_QUICK_TESTS: "1"
+          DUNE_JOBS: 1
+        run: |
+          chmod +x scripts/ci-run-tests.sh
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_admission_edge"
+
       # NOTE: the "Shell IR differential-safety harness gate" step was removed
       # here. #24332 (nonhierarchical Gate refactor) retired the entire
       # shell_ir risk/typed subsystem (Shell_ir_risk, Shell_ir_typed,

--- a/dashboard/src/api/keeper-bulk.test.ts
+++ b/dashboard/src/api/keeper-bulk.test.ts
@@ -37,8 +37,8 @@ describe('bulkKeeperDirective', () => {
 
     const res = await bulkKeeperDirective(
       [
-        { name: 'rondo', ownerGeneration: 3, operatorOperationId: 'resume-rondo-1' },
-        { name: 'qa-king', ownerGeneration: 5, operatorOperationId: 'resume-qa-1' },
+        { name: 'rondo', operatorOperationId: 'resume-rondo-1' },
+        { name: 'qa-king', operatorOperationId: 'resume-qa-1' },
       ],
       'resume',
     )
@@ -52,12 +52,10 @@ describe('bulkKeeperDirective', () => {
       targets: [
         {
           name: 'rondo',
-          owner_nonce: 3,
           operator_operation_id: 'resume-rondo-1',
         },
         {
           name: 'qa-king',
-          owner_nonce: 5,
           operator_operation_id: 'resume-qa-1',
         },
       ],
@@ -79,8 +77,8 @@ describe('bulkKeeperDirective', () => {
 
     const res = await bulkKeeperDirective(
       [
-        { name: 'rondo', ownerGeneration: 3, operatorOperationId: 'resume-rondo-2' },
-        { name: 'ghost', ownerGeneration: 0, operatorOperationId: 'resume-ghost-1' },
+        { name: 'rondo', operatorOperationId: 'resume-rondo-2' },
+        { name: 'ghost', operatorOperationId: 'resume-ghost-1' },
       ],
       'resume',
     )

--- a/dashboard/src/api/keeper-lifecycle.ts
+++ b/dashboard/src/api/keeper-lifecycle.ts
@@ -27,7 +27,6 @@ interface KeeperResumeOptions extends KeeperControlOptions {
 }
 
 interface PendingResumeIntent {
-  ownerGeneration: number
   operatorOperationId: string
 }
 
@@ -39,16 +38,14 @@ function createResumeOperationId(): string {
 
 function resumeIntent(
   name: string,
-  ownerGeneration: number,
   explicitOperationId?: string,
 ): PendingResumeIntent {
   if (explicitOperationId) {
-    return { ownerGeneration, operatorOperationId: explicitOperationId }
+    return { operatorOperationId: explicitOperationId }
   }
   const pending = pendingResumeIntents.get(name)
-  if (pending?.ownerGeneration === ownerGeneration) return pending
+  if (pending) return pending
   const created = {
-    ownerGeneration,
     operatorOperationId: createResumeOperationId(),
   }
   pendingResumeIntents.set(name, created)
@@ -62,9 +59,6 @@ function clearCommittedResumeIntent(name: string, intent: PendingResumeIntent): 
   }
 }
 
-function isOwnerGeneration(value: unknown): value is number {
-  return typeof value === 'number' && Number.isInteger(value) && value >= 0
-}
 async function safeJsonResponse<T>(resp: Response, fallbackError: string): Promise<T> {
   try {
     const body = await resp.text()
@@ -314,23 +308,13 @@ export function pauseKeeper(
 
 export async function resumeKeeper(
   name: string,
-  ownerGeneration: number | null | undefined,
   opts: KeeperResumeOptions = {},
 ): Promise<KeeperLifecycleResponse> {
-  if (!isOwnerGeneration(ownerGeneration)) {
-    return {
-      ok: false,
-      action: 'resume',
-      name,
-      error: `Cannot resume ${name}: current owner generation is unavailable`,
-    }
-  }
-  const intent = resumeIntent(name, ownerGeneration, opts.operatorOperationId)
+  const intent = resumeIntent(name, opts.operatorOperationId)
   const result = await safeKeeperPostWithBody(
     `/api/v1/keepers/${encodeURIComponent(name)}/directive`,
     {
       action: 'resume',
-      owner_nonce: intent.ownerGeneration,
       operator_operation_id: intent.operatorOperationId,
     },
     `Failed to resume ${name}`,
@@ -363,7 +347,6 @@ export type BulkKeeperDirectiveAction = 'pause' | 'resume' | 'wakeup'
 
 export interface BulkKeeperResumeTarget {
   name: string
-  ownerGeneration: number
   operatorOperationId?: string
 }
 
@@ -405,25 +388,11 @@ export async function bulkKeeperDirective(
   const names = subjects.map(subject => typeof subject === 'string' ? subject : subject.name)
   const fallbackError = `Failed to ${action} ${subjects.length} keeper(s)`
   const resumeTargets = action === 'resume' ? subjects as BulkKeeperResumeTarget[] : []
-  const invalidResumeTarget = resumeTargets.find(
-    target => typeof target.name !== 'string' || !isOwnerGeneration(target.ownerGeneration),
-  )
-  if (invalidResumeTarget) {
-    const error = `Cannot resume ${invalidResumeTarget.name}: current owner generation is unavailable`
-    return {
-      ok: false,
-      action,
-      requested: subjects.length,
-      succeeded: 0,
-      results: names.map(name => ({ name, ok: false, error })),
-    }
-  }
   const resumeIntents = action === 'resume'
     ? resumeTargets.map(target => ({
         name: target.name,
         intent: resumeIntent(
           target.name,
-          target.ownerGeneration,
           target.operatorOperationId,
         ),
       }))
@@ -433,7 +402,6 @@ export async function bulkKeeperDirective(
         action,
         targets: resumeIntents.map(({ name, intent }) => ({
           name,
-          owner_nonce: intent.ownerGeneration,
           operator_operation_id: intent.operatorOperationId,
         })),
       }

--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -1841,7 +1841,7 @@ describe('keeper lifecycle', () => {
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    const result = await resumeKeeper('janitor', 7, {
+    const result = await resumeKeeper('janitor', {
       operatorOperationId: 'dashboard-resume-test-1',
     })
 
@@ -1850,7 +1850,6 @@ describe('keeper lifecycle', () => {
     expect(url).toBe('/api/v1/keepers/janitor/directive')
     expect(JSON.parse(init.body)).toEqual({
       action: 'resume',
-      owner_nonce: 7,
       operator_operation_id: 'dashboard-resume-test-1',
     })
   })
@@ -1877,7 +1876,7 @@ describe('keeper lifecycle', () => {
       )
     vi.stubGlobal('fetch', fetchMock)
 
-    const result = await resumeKeeper('offline-janitor', 7, {
+    const result = await resumeKeeper('offline-janitor', {
       operatorOperationId: 'dashboard-resume-offline-1',
     })
 
@@ -1899,8 +1898,8 @@ describe('keeper lifecycle', () => {
       )
     vi.stubGlobal('fetch', fetchMock)
 
-    expect((await resumeKeeper('janitor', 7)).ok).toBe(false)
-    expect((await resumeKeeper('janitor', 7)).ok).toBe(true)
+    expect((await resumeKeeper('janitor')).ok).toBe(false)
+    expect((await resumeKeeper('janitor')).ok).toBe(true)
 
     const firstInit = fetchMock.mock.calls[0]![1] as RequestInit
     const secondInit = fetchMock.mock.calls[1]![1] as RequestInit
@@ -1910,15 +1909,21 @@ describe('keeper lifecycle', () => {
     expect(second.operator_operation_id).toBe(first.operator_operation_id)
   })
 
-  it('refuses resume when the current owner generation is unavailable', async () => {
-    const fetchMock = vi.fn()
+  it('sends resume even when the dashboard has no generation field', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, action: 'resume', name: 'janitor' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
     vi.stubGlobal('fetch', fetchMock)
 
-    const result = await resumeKeeper('janitor', undefined)
+    const result = await resumeKeeper('janitor')
 
-    expect(result.ok).toBe(false)
-    expect(result.error).toContain('current owner generation is unavailable')
-    expect(fetchMock).not.toHaveBeenCalled()
+    expect(result.ok).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(JSON.parse(fetchMock.mock.calls[0]![1].body)).toMatchObject({ action: 'resume' })
+    expect(JSON.parse(fetchMock.mock.calls[0]![1].body)).not.toHaveProperty('owner_nonce')
   })
 
   it('sends POST with action=wakeup via directive endpoint', async () => {

--- a/dashboard/src/components/keeper-action-panel.test.ts
+++ b/dashboard/src/components/keeper-action-panel.test.ts
@@ -175,11 +175,11 @@ describe('runKeeperAction', () => {
     expect(refreshKeeperRuntimeStatus).toHaveBeenCalledWith()
   })
 
-  it('forwards the observed owner generation for typed resume', async () => {
+  it('forwards resume without requiring an observed owner generation', async () => {
     vi.mocked(resumeKeeper).mockResolvedValueOnce({ ok: true })
 
-    await runKeeperAction('rondo', 'resume', 7)
+    await runKeeperAction('rondo', 'resume')
 
-    expect(resumeKeeper).toHaveBeenCalledWith('rondo', 7)
+    expect(resumeKeeper).toHaveBeenCalledWith('rondo')
   })
 })

--- a/dashboard/src/components/keeper-action-panel.ts
+++ b/dashboard/src/components/keeper-action-panel.ts
@@ -7,7 +7,7 @@
 // Actions available per keeper:
 //   pause     → POST /api/v1/keepers/:name/directive  { action: "pause" }
 //   resume    → POST /api/v1/keepers/:name/directive
-//               { action: "resume", owner_nonce, operator_operation_id }
+//               { action: "resume", operator_operation_id }
 //   wakeup    → POST /api/v1/keepers/:name/directive  { action: "wakeup" }
 //   boot      → POST /api/v1/keepers/:name/boot
 //   shutdown  → POST /api/v1/keepers/:name/shutdown
@@ -119,7 +119,6 @@ export const KEEPER_ACTION_LABELS: Record<KeeperActionKey, KeeperActionLabel> = 
 export async function runKeeperAction(
   name: string,
   action: KeeperActionKey,
-  ownerGeneration?: number,
 ): Promise<void> {
   if (action === 'shutdown') {
     const confirmed = await requestConfirm({
@@ -143,7 +142,7 @@ export async function runKeeperAction(
     let res: { ok: boolean; error?: string }
     switch (action) {
       case 'pause':    res = await pauseKeeper(name);    break
-      case 'resume':   res = await resumeKeeper(name, ownerGeneration);   break
+      case 'resume':   res = await resumeKeeper(name);   break
       case 'wakeup':   res = await wakeKeeper(name);     break
       case 'boot':     res = await bootKeeper(name);     break
       case 'shutdown': res = await shutdownKeeper(name); break
@@ -194,11 +193,7 @@ export function KeeperActionButtons({
     if (busy.value) return
     busy.value = true
     try {
-      if (action === 'resume') {
-        await runKeeperAction(keeper.name, action, keeper.generation)
-      } else {
-        await runKeeperAction(keeper.name, action)
-      }
+      await runKeeperAction(keeper.name, action)
     } finally {
       busy.value = false
     }

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -1693,7 +1693,7 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
         action === 'pause'
           ? await pauseKeeper(keeperName)
           : action === 'resume'
-            ? await resumeKeeper(keeperName, c.metrics.generation)
+            ? await resumeKeeper(keeperName)
             : await wakeKeeper(keeperName)
       if (!result.ok) {
         throw new Error(result.error || `${action} directive failed`)

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -243,7 +243,7 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
         action === 'pause'
           ? await pauseKeeper(keeper.name)
           : action === 'resume'
-            ? await resumeKeeper(keeper.name, keeper.generation)
+            ? await resumeKeeper(keeper.name)
             : await wakeKeeper(keeper.name)
       if (res.ok) {
         const msg =

--- a/dashboard/src/components/keeper-detail-lifecycle.test.ts
+++ b/dashboard/src/components/keeper-detail-lifecycle.test.ts
@@ -24,7 +24,7 @@ describe('KeeperLifecycleButtons', () => {
     runKeeperAction.mockReset()
   })
 
-  it('resumes an offline paused keeper with its durable owner generation', () => {
+  it('resumes an offline paused keeper without a dashboard generation', () => {
     const keeper = {
       name: 'lane-smith',
       status: 'offline',
@@ -41,6 +41,6 @@ describe('KeeperLifecycleButtons', () => {
     fireEvent.click(getByRole('button', { name: '재개하기' }))
 
     expect(queryByText('기동하기')).toBeNull()
-    expect(runKeeperAction).toHaveBeenCalledWith('lane-smith', 'resume', 1275)
+    expect(runKeeperAction).toHaveBeenCalledWith('lane-smith', 'resume')
   })
 })

--- a/dashboard/src/components/keeper-detail-lifecycle.ts
+++ b/dashboard/src/components/keeper-detail-lifecycle.ts
@@ -25,7 +25,7 @@ export function KeeperLifecycleButtons({ keeper, effectiveStatus }: { keeper: Ke
     <button type="button"
       class="py-1 px-3 rounded-[var(--r-1)] text-2xs font-semibold cursor-pointer border border-[var(--ok-border)] bg-[var(--ok-soft)] text-[var(--color-status-ok)] hover:bg-[var(--ok-soft)] transition-colors v2-monitoring-action"
       title=${KEEPER_ACTION_LABELS.resume.title}
-      onClick=${() => { void runKeeperAction(keeper.name, 'resume', keeper.generation) }}
+      onClick=${() => { void runKeeperAction(keeper.name, 'resume') }}
     >${KEEPER_ACTION_LABELS.resume.verb}</button>`
 
   if (isOffline && visibility.canBoot) return html`

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
@@ -88,9 +88,7 @@ function lifecycleCommands(keeper: Keeper): WorkspaceCommand[] {
       title: copy.title,
       icon: copy.icon,
       danger: copy.danger,
-      onClick: () => key === 'resume'
-        ? runKeeperAction(keeper.name, key, keeper.generation)
-        : runKeeperAction(keeper.name, key),
+      onClick: () => runKeeperAction(keeper.name, key),
     }
   })
 }

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -369,11 +369,7 @@ function lifecycleActions(keeper: Keeper): KeeperActionKey[] {
 }
 
 async function runRosterKeeperAction(keeper: Keeper, action: KeeperActionKey): Promise<void> {
-  if (action === 'resume') {
-    await runKeeperAction(keeper.name, action, keeper.generation)
-  } else {
-    await runKeeperAction(keeper.name, action)
-  }
+  await runKeeperAction(keeper.name, action)
 }
 
 function rosterActivityText(activity: KeeperActivityDisplay): string | null {

--- a/dashboard/src/lib/keeper-predicates.ts
+++ b/dashboard/src/lib/keeper-predicates.ts
@@ -174,9 +174,9 @@ export function keeperActionVisibility(keeper: Keeper): KeeperActionVisibility {
   const isPaused = isKeeperPaused(keeper)
   const isOffline = isKeeperOffline(keeper)
   const isRunning = isKeeperRunningExcludingRestarting(keeper)
-  // A paused directive can outlive its process. The durable owner generation
-  // remains the Resume_owner fencing token after the live lane exits, so a
-  // paused keeper must resume before an offline lane is booted.
+  // A paused directive can outlive its process. Resume resolves the current
+  // durable state on the server, so a paused keeper must resume before an
+  // offline lane is booted.
 
   return {
     canPause:    isRunning && !isPaused,

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 213 unique knobs across 8 modules.
+**Total**: 212 unique knobs across 8 modules.
 
-**Typed getter classification**: 39/126 tagged (`operator`: 39, `algorithm`: 0, `unclassified`: 87).
+**Typed getter classification**: 39/125 tagged (`operator`: 39, `algorithm`: 0, `unclassified`: 86).
 
 ## Env_config_core (23 knobs; typed classification 2/5)
 
@@ -46,51 +46,50 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_TEST_ALLOW_HOME_BASE_PATH` | string_literal | n/a | n/a | 405 | #9903: production base-path safeguard for test executables. Without this, a test whose [MASC_BASE_PATH] override fail... |
 | `MASC_URL` | string_literal | n/a | n/a | 278 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 
-## Env_config_keeper (41 knobs; typed classification 21/34)
+## Env_config_keeper (40 knobs; typed classification 21/33)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 592 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 526 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
+| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 581 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 515 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | feature_flag | n/a | n/a | 19 | Enable startup keeper bootstrap scan |
 | `MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC` | typed:float | unclassified | unclassified | 40 | Polling interval (seconds) for the lazy-startup wait loop in [server_bootstrap_loops.ml]. The autoboot fiber wakes up... |
 | `MASC_KEEPER_BOOTSTRAP_LISTENER_RETRY_INTERVAL_SEC` | typed:float | unclassified | unclassified | 52 | Polling interval (seconds) for the keeper-lifecycle listener retry loop in [server_bootstrap_loops.ml]. After a liste... |
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | unclassified | unclassified | 27 | Max keeper meta files to scan during bootstrap |
-| `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 64 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | unclassified | unclassified | 23 | Keeper considered stale when last turn exceeds this threshold (seconds) |
-| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 558 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT` | typed:int | Runtime | operator | 266 | Default item limit for [GET /keepers/:name/compaction-snapshots]. Default: 25. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER` | typed:int | Runtime | operator | 292 | Multiplier from requested item limit to manifest files scanned. Default: 4. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES` | typed:int | Runtime | operator | 282 | Minimum manifest files scanned before applying [limit * multiplier]. Default: 8. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES` | typed:int | Runtime | operator | 302 | Tail line count read from each selected manifest file. Default: 200. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MAX_LIMIT` | typed:int | Runtime | operator | 272 | Maximum accepted item limit for the compaction snapshot endpoint. Default: 100. @category Runtime @ops_class operator |
-| `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 142 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
-| `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 150 | Enable keeper debug logging. Default: false. |
-| `MASC_KEEPER_DURABLE_QUEUE_STALE_SEC` | typed:float | Telemetry | operator | 451 | Durable event-queue backlog age threshold for fleet health degradation. The durable queue remains fully reported rega... |
-| `MASC_KEEPER_GENERATED_MEDIA_DIR_MAX_BYTES` | typed:int | Policies | operator | 389 | Maximum total bytes retained in [<masc_dir>/media] after opportunistic cleanup. Default is 500 MiB. Range: [1, 5 GiB]... |
-| `MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES` | typed:int | Policies | operator | 378 | Maximum raw generated-media bytes accepted by the durable store and serve route. Default is 10 MiB. Range: [1, 50 MiB... |
-| `MASC_KEEPER_GENERATED_MEDIA_RETENTION_SEC` | typed:float | Policies | operator | 400 | Maximum generated-media file age retained by opportunistic cleanup. Default is 24 hours. Range: [1 second, 30 days]. ... |
-| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 571 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
-| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | Thresholds | operator | 412 | Shared keepalive interval, read early so WorkAsHeartbeat can reference it. Any positive interval is valid; the schedu... |
-| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 433 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | string_literal | n/a | n/a | 182 |  |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 225 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 237 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 213 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
-| `MASC_KEEPER_MEMORY_OS_RECALL_FACTS_MAX_BYTES` | typed:int | Policies | operator | 249 | Maximum UTF-8 bytes for the exact rendered fact lines injected by recall. The Librarian owns selection within this ca... |
-| `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | unclassified | unclassified | 72 | Maximum metrics file size in bytes before rotation (default: 10MB) |
-| `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | unclassified | unclassified | 75 | Number of rotated files to keep (default: 1, i.e. .1 only) |
-| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | Thresholds | operator | 475 | Interruptible sleep chunk size in seconds: the upper bound on how long a keeper's heartbeat sleep takes to notice a w... |
-| `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 153 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
-| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 581 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
-| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | string_literal | n/a | n/a | 486 |  |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 339 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 349 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
-| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 329 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
-| `MASC_KEEPER_WIRE_CAPTURE` | feature_flag | Policies | operator | 87 | Master switch for diagnostic MASC->OAS wire capture. Default off. @category Policies @ops_class operator |
-| `MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES` | typed:int | Policies | operator | 113 | Maximum bytes for the active [<masc_root>/wire-capture/YYYY-MM/DD.jsonl] file and maximum total bytes retained below ... |
-| `MASC_KEEPER_WIRE_CAPTURE_RETENTION_DAYS` | typed:int | Policies | operator | 102 | Maximum age for [<masc_root>/wire-capture] day files retained by the diagnostic MASC->OAS wire-capture harness. Defau... |
-| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 427 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 547 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT` | typed:int | Runtime | operator | 255 | Default item limit for [GET /keepers/:name/compaction-snapshots]. Default: 25. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER` | typed:int | Runtime | operator | 281 | Multiplier from requested item limit to manifest files scanned. Default: 4. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES` | typed:int | Runtime | operator | 271 | Minimum manifest files scanned before applying [limit * multiplier]. Default: 8. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES` | typed:int | Runtime | operator | 291 | Tail line count read from each selected manifest file. Default: 200. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MAX_LIMIT` | typed:int | Runtime | operator | 261 | Maximum accepted item limit for the compaction snapshot endpoint. Default: 100. @category Runtime @ops_class operator |
+| `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 131 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
+| `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 139 | Enable keeper debug logging. Default: false. |
+| `MASC_KEEPER_DURABLE_QUEUE_STALE_SEC` | typed:float | Telemetry | operator | 440 | Durable event-queue backlog age threshold for fleet health degradation. The durable queue remains fully reported rega... |
+| `MASC_KEEPER_GENERATED_MEDIA_DIR_MAX_BYTES` | typed:int | Policies | operator | 378 | Maximum total bytes retained in [<masc_dir>/media] after opportunistic cleanup. Default is 500 MiB. Range: [1, 5 GiB]... |
+| `MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES` | typed:int | Policies | operator | 367 | Maximum raw generated-media bytes accepted by the durable store and serve route. Default is 10 MiB. Range: [1, 50 MiB... |
+| `MASC_KEEPER_GENERATED_MEDIA_RETENTION_SEC` | typed:float | Policies | operator | 389 | Maximum generated-media file age retained by opportunistic cleanup. Default is 24 hours. Range: [1 second, 30 days]. ... |
+| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 560 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
+| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | Thresholds | operator | 401 | Shared keepalive interval, read early so WorkAsHeartbeat can reference it. Any positive interval is valid; the schedu... |
+| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 422 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | string_literal | n/a | n/a | 171 |  |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 214 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 226 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 202 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
+| `MASC_KEEPER_MEMORY_OS_RECALL_FACTS_MAX_BYTES` | typed:int | Policies | operator | 238 | Maximum UTF-8 bytes for the exact rendered fact lines injected by recall. The Librarian owns selection within this ca... |
+| `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | unclassified | unclassified | 61 | Maximum metrics file size in bytes before rotation (default: 10MB) |
+| `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | unclassified | unclassified | 64 | Number of rotated files to keep (default: 1, i.e. .1 only) |
+| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | Thresholds | operator | 464 | Interruptible sleep chunk size in seconds: the upper bound on how long a keeper's heartbeat sleep takes to notice a w... |
+| `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 142 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
+| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 570 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
+| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | string_literal | n/a | n/a | 475 |  |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 328 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 338 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
+| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 318 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
+| `MASC_KEEPER_WIRE_CAPTURE` | feature_flag | Policies | operator | 76 | Master switch for diagnostic MASC->OAS wire capture. Default off. @category Policies @ops_class operator |
+| `MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES` | typed:int | Policies | operator | 102 | Maximum bytes for the active [<masc_root>/wire-capture/YYYY-MM/DD.jsonl] file and maximum total bytes retained below ... |
+| `MASC_KEEPER_WIRE_CAPTURE_RETENTION_DAYS` | typed:int | Policies | operator | 91 | Maximum age for [<masc_root>/wire-capture] day files retained by the diagnostic MASC->OAS wire-capture harness. Defau... |
+| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 416 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
 
 ## Env_config_keeper_supervisor (3 knobs; typed classification 2/2)
 

--- a/lib/auth/auth_error_kind.ml
+++ b/lib/auth/auth_error_kind.ml
@@ -104,10 +104,11 @@ let dashboard_actor_fallback_log_message fb =
       let extra_hint =
         match err_kind with
         | Token_mismatch ->
-            " Remediation: clear the browser's stored dashboard token \
-             (localStorage masc_dashboard_token) or delete \
-             .masc/auth/dashboard.token so a fresh token is minted on \
-             the next dashboard load."
+            " Remediation: clear the browser's stored Bearer token \
+             (sessionStorage masc_bearer_token) or use the Dashboard auth \
+             banner to clear it, then reload so a fresh token is minted. \
+             Delete .masc/auth/dashboard.token only when rotating the \
+             server-side credential for every Dashboard client."
         | Token_expired
         | Unauthorized
         | Forbidden

--- a/lib/board/board_core.ml
+++ b/lib/board/board_core.ml
@@ -160,6 +160,9 @@ let list_posts store ?(visibility_filter = None) ?hearth ?(limit = 50) () : post
     take limit filtered)
 ;;
 
+(** Returns the post with the greatest [(updated_at, post_id)] cursor token,
+    or [None] when the board is empty. The fold runs under the board lock and
+    does not allocate or sort the complete post history. *)
 let current_post_cursor store =
   maybe_sweep store;
   with_lock store (fun () ->

--- a/lib/board/board_dispatch.mli
+++ b/lib/board/board_dispatch.mli
@@ -212,8 +212,6 @@ val list_recent_posts_matching_author :
 
 val current_post_cursor : unit -> float * string option
 (** Atomic high-water mark for initializing a Board observation cursor. *)
-(** Current Board cursor head without sorting or materializing the full post
-    history. *)
 
 val delete_post : post_id:string -> (unit, Board.board_error) Result.t
 

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -52,17 +52,6 @@ module KeeperBootstrap = struct
       (get_float ~default:0.25 "MASC_KEEPER_BOOTSTRAP_LISTENER_RETRY_INTERVAL_SEC")
   ;;
 
-  (** Settle delay (seconds) between lazy-startup completion and the
-      keeper bootstrap fan-out. The autoboot fiber sleeps for this
-      duration so SSE/board/orchestrator subsystems get a chance to
-      finish their first tick before keeper boot competes for them.
-      Default 5.0s preserves the inline literal at
-      [server_bootstrap_loops.ml:482]. Operators on cold-start machines
-      may raise this; setting to 0 is allowed (no settle) but unwise
-      under load. *)
-  let post_startup_settle_sec =
-    Float.max 0.0 (get_float ~default:5.0 "MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC")
-  ;;
 end
 
 (** {1 Keeper Metrics Rotation Configuration} *)

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -17,7 +17,6 @@ module KeeperBootstrap : sig
   val max_scan : int
   val lazy_startup_poll_interval_sec : float
   val keeper_listener_retry_interval_sec : float
-  val post_startup_settle_sec : float
 end
 (** {1 Keeper metrics rotation} *)
 

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -150,7 +150,7 @@ let keeper_config_json (config : Workspace.config) (name : string)
           let current_task =
             Keeper_world_observation_inputs.read_current_task ~config ~meta:m
           in
-          Keeper_unified_prompt.build_prompt_preview ~meta:m ~base_path:config.base_path
+          Keeper_unified_prompt.build_prompt_preview ~meta:m ~config
             ~profile_defaults:defaults ~current_task ~active_goal_summaries ~observation ()
         in
         (* Match what a turn actually sends: the observation frame rides the

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -53,24 +53,6 @@ let keeper_board_own_recent_max_rp =
     ~description:"Own recent board posts injected into the world observation per turn (0 = disable)" ()
 let keeper_board_own_recent_max () : int =
   Runtime_params.get keeper_board_own_recent_max_rp
-let keeper_bootstrap_proactive_warmup_sec_rp =
-  _rp_int ~key:"keeper.proactive.warmup_sec"
-    ~default:(fun () -> int_of_env_default "MASC_KEEPER_BOOTSTRAP_PROACTIVE_WARMUP_SEC"
-                          ~default:60 ~min_v:0 ~max_v:two_days_seconds_int)
-    ~min_v:0 ~max_v:two_days_seconds_int
-    ~description:"Bootstrap proactive warmup delay (seconds)" ()
-let keeper_bootstrap_proactive_warmup_sec () : int =
-  Runtime_params.get keeper_bootstrap_proactive_warmup_sec_rp
-
-let keeper_bootstrap_stagger_step_sec_rp =
-  _rp_int ~key:"keeper.proactive.stagger_step_sec"
-    ~default:(fun () -> int_of_env_default "MASC_KEEPER_BOOTSTRAP_STAGGER_STEP_SEC"
-                          ~default:15 ~min_v:0 ~max_v:120)
-    ~min_v:0 ~max_v:120
-    ~description:"Bootstrap warmup deterministic jitter window (seconds)" ()
-let keeper_bootstrap_stagger_step_sec () : int =
-  Runtime_params.get keeper_bootstrap_stagger_step_sec_rp
-
 let keeper_bootstrap_retry_interval_sec_rp =
   _rp_int ~key:"keeper.bootstrap.retry_interval_sec"
     ~default:(fun () -> int_of_env_default "MASC_KEEPER_BOOTSTRAP_RETRY_INTERVAL_SEC"

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -108,8 +108,6 @@ val normalize_prompt_text : max_bytes:int -> string -> string
     keeper's own latest posts the world observation carries per turn. *)
 val keeper_board_own_recent_max : unit -> int
 
-val keeper_bootstrap_proactive_warmup_sec : unit -> int
-val keeper_bootstrap_stagger_step_sec : unit -> int
 val keeper_bootstrap_retry_interval_sec : unit -> int
 
 val keeper_batch_limit : unit -> int

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -697,6 +697,37 @@ let run_keepalive_unified_turn
              admitted. The four prior inline pressure gates here were removed: they
              ran AFTER intake had already consumed the stimulus, forcing a
              consume/requeue churn loop, and logged only at DEBUG (a silent skip). *)
+          (* RFC-0357 §3.3: consume the backlog edge at admission, before the
+             turn runs. Only the scheduled-autonomous channel consumes it — a
+             reactive turn must not silence a typed backlog signal it never
+             promised to handle. The stamp is monotonic (a failed backlog
+             read observed no revision and cannot rewind the clock) and lives
+             on the meta the cycle carries, so a failed turn keeps it
+             in-memory and is not re-admitted on the same edge every
+             heartbeat; durable persistence rides the existing post-turn meta
+             write (a crash before that write re-arms the edge —
+             at-least-once). *)
+          let meta_after_triage =
+            match turn_decision.channel with
+            | Keeper_world_observation.Reactive -> meta_after_triage
+            | Keeper_world_observation.Scheduled_autonomous ->
+              (match obs.backlog_revision with
+               | None -> meta_after_triage
+               | Some observed ->
+                 let proactive_rt = meta_after_triage.runtime.proactive_rt in
+                 if observed > proactive_rt.last_consumed_backlog_revision
+                 then
+                   { meta_after_triage with
+                     runtime =
+                       { meta_after_triage.runtime with
+                         proactive_rt =
+                           { proactive_rt with
+                             last_consumed_backlog_revision = observed
+                           }
+                       }
+                   }
+                 else meta_after_triage)
+          in
           record_replay_owned_turn_started_reactions
             ~ctx
             ~keeper_name:meta_after_triage.name

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -424,7 +424,6 @@ let run_keepalive_unified_turn
       ~(meta_after_triage : keeper_meta)
       ~pending_board_events
       ~(stop : bool Atomic.t)
-      ~(proactive_warmup_elapsed : bool)
       ~(reactive_wake : bool)
       ~(shared_context : Agent_sdk.Context.t)
       ~(deferred_runtime_lane : Keeper_turn_driver.deferred_runtime_lane option)
@@ -433,10 +432,7 @@ let run_keepalive_unified_turn
           Keeper_turn_driver.deferred_runtime_lane -> unit)
   : keepalive_turn_outcome
   =
-  if not proactive_warmup_elapsed
-  then { meta = meta_after_triage; cycle_status = Turn_cycle_completed }
-  else
-    match
+  match
       Keeper_turn_admission.run_if_free_with_token
         ~base_path:ctx.config.base_path
         ~keeper_name:meta_after_triage.name
@@ -550,7 +546,6 @@ let run_keepalive_unified_turn
       in
       let scheduling =
         decide_keepalive_scheduling
-          ~reactive_wake
           ~event_queue_triggers:event_intake.event_queue_triggers
           ~stop
           ~meta:meta_after_triage
@@ -1045,14 +1040,12 @@ let record_keepalive_stage_timing = Keeper_heartbeat_loop_snapshot_timing.record
                       policy decision or sleep. *)
 
 let run_heartbeat_loop
-      ~proactive_warmup_sec
       (ctx : _ context)
       (m : keeper_meta)
       (stop : bool Atomic.t)
       ~(wakeup : bool Atomic.t)
   : unit
   =
-  let keepalive_started_ts = Time_compat.now () in
   let snapshot_interval_sec () =
     Runtime_params.get Runtime_settings.keeper_snapshot_sec
   in
@@ -1178,12 +1171,6 @@ let run_heartbeat_loop
           ~timing_filled:!timing_filled;
         let t_snapshot_end = Time_compat.now () in
         let t_board_start = t_snapshot_end in
-        (* Compute warmup state BEFORE board collection so cursor
-                 is not advanced while keeper cannot act on events. *)
-        let proactive_warmup_elapsed =
-          proactive_warmup_sec <= 0
-          || now_ts -. keepalive_started_ts >= float_of_int proactive_warmup_sec
-        in
         (* Lifecycle state is evaluated before durable stimulus intake. Resource
            pressure remains observable but cannot pre-empt every Keeper lane;
            concrete I/O boundaries report their own failures explicitly. *)
@@ -1252,7 +1239,6 @@ let run_heartbeat_loop
             collect_keepalive_board_events
               ~ctx
               ~meta_current
-              ~proactive_warmup_elapsed
           else [], meta_current
         in
         let t_board_end = Time_compat.now () in
@@ -1266,9 +1252,8 @@ let run_heartbeat_loop
                pre/post guards mirror the spec's [turn_state] transition
                "running" -> "idle". *)
             turn_running := true;
-            (* [Woken] => this cycle was triggered by an external broadcast, not
-               the keeper's own cadence; suppress global-backlog-driven turns to
-               avoid the all-keeper stampede. *)
+            (* [Woken] records that this cycle was triggered by an external
+               broadcast rather than the keeper's own cadence. *)
             let reactive_wake =
               match !last_wake_source with
               | Keeper_keepalive_signal.Woken -> true
@@ -1291,7 +1276,6 @@ let run_heartbeat_loop
                 ~meta_after_triage
                 ~pending_board_events
                 ~stop
-                ~proactive_warmup_elapsed
                 ~reactive_wake
                 ~shared_context
                 ~deferred_runtime_lane
@@ -1356,7 +1340,6 @@ let run_heartbeat_loop
                refresh_work_as_heartbeat
                  ~ctx
                  ~meta_after_proactive
-                 ~proactive_warmup_elapsed
                  ~work_as_hb
                  ~last_successful_heartbeat_ts
                  ~consecutive_failures

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -712,15 +712,9 @@ let run_keepalive_unified_turn
             match turn_decision.channel with
             | Keeper_world_observation.Reactive -> meta_after_triage
             | Keeper_world_observation.Scheduled_autonomous ->
-              (match
-                 Keeper_world_observation.record_scheduled_backlog_consumption
-                   ~meta:meta_after_triage
-                   obs
-               with
-               | Ok meta -> meta
-               | Error Keeper_world_observation.Incomplete_backlog_observation ->
-                 invalid_arg
-                   "keeper backlog observation revision/projection pair is incomplete")
+              Keeper_world_observation.record_scheduled_backlog_consumption
+                ~meta:meta_after_triage
+                obs
           in
           admitted_meta := meta_after_triage;
           record_replay_owned_turn_started_reactions

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -711,22 +711,15 @@ let run_keepalive_unified_turn
             match turn_decision.channel with
             | Keeper_world_observation.Reactive -> meta_after_triage
             | Keeper_world_observation.Scheduled_autonomous ->
-              (match obs.backlog_revision with
-               | None -> meta_after_triage
-               | Some observed ->
-                 let proactive_rt = meta_after_triage.runtime.proactive_rt in
-                 if observed > proactive_rt.last_consumed_backlog_revision
-                 then
-                   { meta_after_triage with
-                     runtime =
-                       { meta_after_triage.runtime with
-                         proactive_rt =
-                           { proactive_rt with
-                             last_consumed_backlog_revision = observed
-                           }
-                       }
-                   }
-                 else meta_after_triage)
+              (match
+                 Keeper_world_observation.record_scheduled_backlog_consumption
+                   ~meta:meta_after_triage
+                   obs
+               with
+               | Ok meta -> meta
+               | Error Keeper_world_observation.Incomplete_backlog_observation ->
+                 invalid_arg
+                   "keeper backlog observation revision/projection pair is incomplete")
           in
           record_replay_owned_turn_started_reactions
             ~ctx

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -448,6 +448,7 @@ let run_keepalive_unified_turn
       ref None
     in
     let cycle_outcome_ref = ref None in
+    let admitted_meta = ref meta_after_triage in
     let selection_acked = ref false in
     let event_queue_failed = ref false in
     let record_event_queue_failure message =
@@ -721,6 +722,7 @@ let run_keepalive_unified_turn
                  invalid_arg
                    "keeper backlog observation revision/projection pair is incomplete")
           in
+          admitted_meta := meta_after_triage;
           record_replay_owned_turn_started_reactions
             ~ctx
             ~keeper_name:meta_after_triage.name
@@ -998,7 +1000,7 @@ let run_keepalive_unified_turn
         ~base_path:ctx.config.base_path
         ~keeper_name:meta_after_triage.name
         exn;
-      { meta = meta_after_triage; cycle_status = Turn_cycle_crashed })
+      { meta = !admitted_meta; cycle_status = Turn_cycle_crashed })
   with
   | `Ran outcome -> outcome
   | `Busy block ->

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -32,7 +32,6 @@ val sync_keeper_presence :
 val collect_keepalive_board_events :
   ctx:'a context ->
   meta_current:keeper_meta ->
-  proactive_warmup_elapsed:bool ->
   Keeper_world_observation.pending_board_event list * keeper_meta
 
 val in_turn_liveness_pulse_interval_sec : unit -> float
@@ -95,7 +94,6 @@ type keepalive_scheduling_decision = {
 }
 
 val decide_keepalive_scheduling :
-  ?reactive_wake:bool ->
   ?event_queue_triggers:Keeper_world_observation.event_queue_trigger list ->
   stop:bool Atomic.t ->
   meta:keeper_meta ->
@@ -181,7 +179,6 @@ val run_keepalive_unified_turn :
   meta_after_triage:keeper_meta ->
   pending_board_events:Keeper_world_observation.pending_board_event list ->
   stop:bool Atomic.t ->
-  proactive_warmup_elapsed:bool ->
   reactive_wake:bool ->
   shared_context:Agent_sdk.Context.t ->
   deferred_runtime_lane:Keeper_turn_driver.deferred_runtime_lane option ->
@@ -193,7 +190,6 @@ val run_keepalive_unified_turn :
 val refresh_work_as_heartbeat :
   ctx:'a context ->
   meta_after_proactive:keeper_meta ->
-  proactive_warmup_elapsed:bool ->
   work_as_hb:(unit -> bool) ->
   last_successful_heartbeat_ts:float ref ->
   consecutive_failures:int ref ->
@@ -227,7 +223,7 @@ val record_keepalive_stage_timing :
 (** The heartbeat loop body, extracted for reuse by the supervisor.
     Runs synchronously in the calling fiber until [stop] becomes true. *)
 val run_heartbeat_loop :
-  proactive_warmup_sec:int -> 'a context -> keeper_meta -> bool Atomic.t ->
+  'a context -> keeper_meta -> bool Atomic.t ->
   wakeup:bool Atomic.t -> unit
 
 module For_testing : sig

--- a/lib/keeper/keeper_heartbeat_loop_board_events.ml
+++ b/lib/keeper/keeper_heartbeat_loop_board_events.ml
@@ -121,21 +121,15 @@ let fleet_health_json ~base_path ~keeper_names =
 ;;
 
 (* Pure lifecycle gate: a keeper may consume board events — and thereby
-   advance its cursor — after warmup while it is explicitly active. Provider
-   availability is handled at the call boundary and cannot withhold intake. *)
-let should_collect_board_events ~proactive_warmup_elapsed ~paused =
-  proactive_warmup_elapsed && not paused
-;;
+   advance its cursor — while it is explicitly active. Provider availability
+   is handled at the call boundary and cannot withhold intake. *)
+let should_collect_board_events ~paused = not paused
 
 let collect_keepalive_board_events
       ~(ctx : _ context)
       ~(meta_current : keeper_meta)
-      ~(proactive_warmup_elapsed : bool)
   =
-  if not
-       (should_collect_board_events
-          ~proactive_warmup_elapsed
-          ~paused:meta_current.paused)
+  if not (should_collect_board_events ~paused:meta_current.paused)
   then [], meta_current
   else (
     let pending_board_events =

--- a/lib/keeper/keeper_heartbeat_loop_board_events.mli
+++ b/lib/keeper/keeper_heartbeat_loop_board_events.mli
@@ -1,20 +1,17 @@
 (** Pending board-event collection for the keeper heartbeat loop. *)
 
 val should_collect_board_events :
-  proactive_warmup_elapsed:bool ->
   paused:bool ->
   bool
 (** Pure gate deciding whether this cycle may collect board events (which
     advances the per-keeper cursor as a side effect). Runtime/provider state is
-    deliberately absent: only warmup and explicit lifecycle pause can withhold
-    collection. *)
+    deliberately absent: only explicit lifecycle pause can withhold collection. *)
 
 val collect_keepalive_board_events :
   ctx:'a Keeper_types_profile.context ->
   meta_current:Keeper_meta_contract.keeper_meta ->
-  proactive_warmup_elapsed:bool ->
   Keeper_world_observation.pending_board_event list * Keeper_meta_contract.keeper_meta
-(** Collect pending board events after proactive warmup has elapsed. *)
+(** Collect pending board events while the keeper is active. *)
 
 val fleet_health_json :
   base_path:string -> keeper_names:string list -> Yojson.Safe.t

--- a/lib/keeper/keeper_heartbeat_loop_refresh_work.ml
+++ b/lib/keeper/keeper_heartbeat_loop_refresh_work.ml
@@ -3,10 +3,9 @@
 
     [refresh_work_as_heartbeat] is the keepalive cycle's
     "implicit heartbeat" path: when the keeper just finished a
-    productive turn (`work_as_hb () = true`) and the proactive warmup
-    has elapsed, we count any successful Workspace.heartbeat against any
-    session-bound workspace as evidence that the keeper is alive — and reset the
-    consecutive-failure counter accordingly.
+    productive turn (`work_as_hb () = true`), we count any successful
+    Workspace.heartbeat against any session-bound workspace as evidence that
+    the keeper is alive — and reset the consecutive-failure counter accordingly.
 
     Per-workspace failure logging is at DEBUG (not WARN) because the
     *any-success* aggregation policy means a single live workspace is
@@ -26,13 +25,12 @@ open Keeper_types_profile
 let refresh_work_as_heartbeat
       ~(ctx : _ context)
       ~(meta_after_proactive : keeper_meta)
-      ~(proactive_warmup_elapsed : bool)
       ~(work_as_hb : unit -> bool)
       ~(last_successful_heartbeat_ts : float ref)
       ~(consecutive_failures : int ref)
   : unit
   =
-  if work_as_hb () && proactive_warmup_elapsed
+  if work_as_hb ()
   then (
     let hb_ok =
       try

--- a/lib/keeper/keeper_heartbeat_loop_refresh_work.mli
+++ b/lib/keeper/keeper_heartbeat_loop_refresh_work.mli
@@ -3,7 +3,6 @@
 val refresh_work_as_heartbeat :
   ctx:_ Keeper_types_profile.context ->
   meta_after_proactive:Keeper_meta_contract.keeper_meta ->
-  proactive_warmup_elapsed:bool ->
   work_as_hb:(unit -> bool) ->
   last_successful_heartbeat_ts:float ref ->
   consecutive_failures:int ref ->

--- a/lib/keeper/keeper_heartbeat_loop_scheduling.ml
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.ml
@@ -14,7 +14,6 @@ type keepalive_scheduling_decision = {
 }
 
 let decide_keepalive_scheduling
-      ?(reactive_wake = false)
       ?(event_queue_triggers = [])
       ~stop
       ~meta
@@ -22,7 +21,6 @@ let decide_keepalive_scheduling
   =
   let turn_decision =
     Keeper_world_observation.keeper_cycle_decision
-      ~reactive_wake
       ~event_queue_triggers
       ~meta
       obs

--- a/lib/keeper/keeper_heartbeat_loop_scheduling.mli
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.mli
@@ -8,7 +8,6 @@ type keepalive_scheduling_decision = {
 }
 
 val decide_keepalive_scheduling :
-  ?reactive_wake:bool ->
   ?event_queue_triggers:Keeper_world_observation.event_queue_trigger list ->
   stop:bool Atomic.t ->
   meta:Keeper_meta_contract.keeper_meta ->

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -785,7 +785,6 @@ let record_lifecycle_start_denial
 ;;
 
 let start_keepalive
-      ?(proactive_warmup_sec = 0)
       ?lifecycle_token
       (ctx : _ context)
   (m : keeper_meta)
@@ -1173,7 +1172,7 @@ let start_keepalive
          | Some _ ->
            Atomic.set reg.grpc_close grpc_close
          | None -> ());
-        run_heartbeat_loop ~proactive_warmup_sec ctx live_meta stop ~wakeup)
+        run_heartbeat_loop ctx live_meta stop ~wakeup)
              ~cleanup:cleanup_tracking
          with
          | Ok () -> Keepalive_started reg

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -73,7 +73,7 @@ val wakeup_relevant_keeper_for_board_signal :
 (** The heartbeat loop body, extracted for reuse by the supervisor.
     Runs synchronously in the calling fiber until [stop] becomes true. *)
 val run_heartbeat_loop :
-  proactive_warmup_sec:int -> 'a context -> keeper_meta -> bool Atomic.t ->
+  'a context -> keeper_meta -> bool Atomic.t ->
   wakeup:bool Atomic.t -> unit
 
 (** Compute the p-th percentile of a float array.
@@ -96,7 +96,6 @@ val start_keepalive_outcome_to_string : start_keepalive_outcome -> string
     outcome. Rejections remain logged and observable, but are never collapsed
     into [unit]; lifecycle transactions use the result to commit or roll back. *)
 val start_keepalive :
-  ?proactive_warmup_sec:int ->
   ?lifecycle_token:Keeper_lifecycle_reservation.token ->
   'a context ->
   keeper_meta ->

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -74,6 +74,13 @@ type proactive_runtime =
           advance it. 0 is the genesis: never consumed, so any live backlog
           (version >= 1) admits exactly one turn. [last_ts] remains telemetry
           and is no longer an admission input. *)
+  ; last_consumed_backlog_projection_sha256 : string
+    (** Exact digest of the non-self-authored task projection consumed with
+          [last_consumed_backlog_revision]. The empty string is the genesis
+          value for a newly-created current-schema meta; persisted post-turn
+          values are lowercase SHA-256. Pairing the revision with this derived
+          projection prevents a keeper's own Todo writes from re-arming its
+          scheduled turn while preserving peer task changes. *)
   }
 
 (* ── Structured blocker classification ──────────────────────── *)

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -62,6 +62,18 @@ type proactive_runtime =
           substantive action.  Resets to 0 on any productive cycle.
           Used by [effective_scheduled_autonomous_cooldown] for exponential
           backoff: cooldown *= 2^min(n, 2), capping at 4x. *)
+  ; last_consumed_backlog_revision : int
+    (** RFC-0357 §3.3: the scheduled-autonomous edge clock. Highest
+          [backlog.version] observed at the admission of a scheduled turn;
+          the backlog edge is [backlog.version > last_consumed_backlog_revision].
+          Recorded in-memory at turn start (a failed turn keeps its stamp so a
+          persistent failure is not re-admitted on the same edge every
+          heartbeat) and persisted by the existing post-turn meta write (a
+          crash before that write re-arms the edge — at-least-once). Only
+          scheduled-autonomous turns consume the edge; reactive turns never
+          advance it. 0 is the genesis: never consumed, so any live backlog
+          (version >= 1) admits exactly one turn. [last_ts] remains telemetry
+          and is no longer an admission input. *)
   }
 
 (* ── Structured blocker classification ──────────────────────── *)

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -79,6 +79,15 @@ type proactive_runtime = {
           [effective_scheduled_autonomous_cooldown] for
           exponential backoff: cooldown *= 2^min(n, 2),
           capping at 4x.  Resets on any productive cycle. *)
+  last_consumed_backlog_revision : int;
+      (** RFC-0357 §3.3 scheduled-autonomous edge clock: highest
+          [backlog.version] observed at the admission of a scheduled
+          turn. The backlog edge is
+          [backlog.version > last_consumed_backlog_revision]. Recorded
+          in-memory at turn start; persisted by the post-turn meta
+          write. Only scheduled-autonomous turns consume it — reactive
+          turns never advance it. 0 is the genesis (never consumed).
+          [last_ts] remains telemetry, not an admission input. *)
 }
 
 type usage_metrics = {

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -88,6 +88,11 @@ type proactive_runtime = {
           write. Only scheduled-autonomous turns consume it — reactive
           turns never advance it. 0 is the genesis (never consumed).
           [last_ts] remains telemetry, not an admission input. *)
+  last_consumed_backlog_projection_sha256 : string;
+      (** Exact digest paired with [last_consumed_backlog_revision]. The
+          empty string is genesis for a newly-created current meta; consumed
+          values are lowercase SHA-256 of the non-self-authored task
+          projection. *)
 }
 
 type usage_metrics = {

--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -54,6 +54,8 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     ; Consecutive_noop_count, `Int rt.proactive_rt.consecutive_noop_count
     ; ( Last_consumed_backlog_revision
       , `Int rt.proactive_rt.last_consumed_backlog_revision )
+    ; ( Last_consumed_backlog_projection_sha256
+      , `String rt.proactive_rt.last_consumed_backlog_projection_sha256 )
     ; Last_compaction_check_ts, `Float rt.compaction_rt.last_check_ts
     ; ( Last_compaction_decision
       , `String (compaction_runtime_decision_to_string rt.compaction_rt.last_decision)

--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -52,6 +52,8 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     ; Last_proactive_reason, `String rt.proactive_rt.last_reason
     ; Last_proactive_preview, `String rt.proactive_rt.last_preview
     ; Consecutive_noop_count, `Int rt.proactive_rt.consecutive_noop_count
+    ; ( Last_consumed_backlog_revision
+      , `Int rt.proactive_rt.last_consumed_backlog_revision )
     ; Last_compaction_check_ts, `Float rt.compaction_rt.last_check_ts
     ; ( Last_compaction_decision
       , `String (compaction_runtime_decision_to_string rt.compaction_rt.last_decision)

--- a/lib/keeper/keeper_meta_json_current_schema.ml
+++ b/lib/keeper/keeper_meta_json_current_schema.ml
@@ -190,6 +190,22 @@ let field_name = function
 
 let current_field_names = List.map field_name all_fields
 
+(* RFC-0357 §3.3: the consumption stamp pair shipped after live keeper metas
+   were written. An ABSENT field decodes as its genesis value (revision 0,
+   empty projection digest) instead of invalidating the whole meta: an
+   invalid meta cannot be read or rewritten (write_meta_with_merge fails
+   closed on Read_failed), so absent=invalid would strand every pre-RFC
+   keeper in "runtime reset required" — the 2026-07-31 fleet outage shape,
+   measured live as 10/10 metas lacking the pair. A PRESENT malformed value
+   still fails the decode. Exactly these two fields are absence-tolerated;
+   everything else stays required. Removal is tracked, not aspirational:
+   once every live meta carries the pair (one post-turn write per keeper),
+   issue #26697 shrinks this list back to empty. *)
+let genesis_defaulted_field_names =
+  [ field_name Last_consumed_backlog_revision
+  ; field_name Last_consumed_backlog_projection_sha256
+  ]
+
 let object_of_field_values field_values =
   let supplied = List.map fst field_values in
   if supplied <> all_fields
@@ -227,7 +243,9 @@ let validate_current_object (json : Yojson.Safe.t) =
        in
        let missing =
          List.filter
-           (fun key -> not (List.mem key present))
+           (fun key ->
+              (not (List.mem key present))
+              && not (List.mem key genesis_defaulted_field_names))
            current_field_names
        in
        if outside_current <> []

--- a/lib/keeper/keeper_meta_json_current_schema.ml
+++ b/lib/keeper/keeper_meta_json_current_schema.ml
@@ -190,23 +190,6 @@ let field_name = function
 
 let current_field_names = List.map field_name all_fields
 
-(* RFC-0357 §3.3: the consumption stamp pair shipped after live keeper metas
-   were written. When BOTH fields are absent the meta decodes with the genesis
-   pair (revision 0, empty projection digest) instead of invalidating the
-   whole meta: an invalid meta cannot be read or rewritten
-   (write_meta_with_merge fails closed on Read_failed), so absent=invalid
-   would strand every pre-RFC keeper in "runtime reset required" — the
-   2026-07-31 fleet outage shape, measured live as 10/10 metas lacking the
-   pair. A PRESENT malformed value still fails the decode, and the decoder's
-   pair invariant rejects half-genesis states. Exactly these two fields are
-   absence-tolerated; everything else stays required. Removal is tracked, not
-   aspirational: once every live meta carries the pair (one post-turn write
-   per keeper), issue #26697 shrinks this list back to empty. *)
-let genesis_defaulted_field_names =
-  [ field_name Last_consumed_backlog_revision
-  ; field_name Last_consumed_backlog_projection_sha256
-  ]
-
 let object_of_field_values field_values =
   let supplied = List.map fst field_values in
   if supplied <> all_fields
@@ -244,9 +227,7 @@ let validate_current_object (json : Yojson.Safe.t) =
        in
        let missing =
          List.filter
-           (fun key ->
-              (not (List.mem key present))
-              && not (List.mem key genesis_defaulted_field_names))
+           (fun key -> not (List.mem key present))
            current_field_names
        in
        if outside_current <> []

--- a/lib/keeper/keeper_meta_json_current_schema.ml
+++ b/lib/keeper/keeper_meta_json_current_schema.ml
@@ -190,6 +190,23 @@ let field_name = function
 
 let current_field_names = List.map field_name all_fields
 
+(* RFC-0357 §3.3: the consumption stamp pair shipped after live keeper metas
+   were written. When BOTH fields are absent the meta decodes with the genesis
+   pair (revision 0, empty projection digest) instead of invalidating the
+   whole meta: an invalid meta cannot be read or rewritten
+   (write_meta_with_merge fails closed on Read_failed), so absent=invalid
+   would strand every pre-RFC keeper in "runtime reset required" — the
+   2026-07-31 fleet outage shape, measured live as 10/10 metas lacking the
+   pair. A PRESENT malformed value still fails the decode, and the decoder's
+   pair invariant rejects half-genesis states. Exactly these two fields are
+   absence-tolerated; everything else stays required. Removal is tracked, not
+   aspirational: once every live meta carries the pair (one post-turn write
+   per keeper), issue #26697 shrinks this list back to empty. *)
+let genesis_defaulted_field_names =
+  [ field_name Last_consumed_backlog_revision
+  ; field_name Last_consumed_backlog_projection_sha256
+  ]
+
 let object_of_field_values field_values =
   let supplied = List.map fst field_values in
   if supplied <> all_fields
@@ -227,7 +244,9 @@ let validate_current_object (json : Yojson.Safe.t) =
        in
        let missing =
          List.filter
-           (fun key -> not (List.mem key present))
+           (fun key ->
+              (not (List.mem key present))
+              && not (List.mem key genesis_defaulted_field_names))
            current_field_names
        in
        if outside_current <> []

--- a/lib/keeper/keeper_meta_json_current_schema.ml
+++ b/lib/keeper/keeper_meta_json_current_schema.ml
@@ -48,6 +48,7 @@ type field =
   | Last_proactive_reason
   | Last_proactive_preview
   | Consecutive_noop_count
+  | Last_consumed_backlog_revision
   | Last_compaction_check_ts
   | Last_compaction_decision
   | Active_goal_ids
@@ -103,6 +104,7 @@ let all_fields =
   ; Last_proactive_reason
   ; Last_proactive_preview
   ; Consecutive_noop_count
+  ; Last_consumed_backlog_revision
   ; Last_compaction_check_ts
   ; Last_compaction_decision
   ; Active_goal_ids
@@ -159,6 +161,7 @@ let field_name = function
   | Last_proactive_reason -> "last_proactive_reason"
   | Last_proactive_preview -> "last_proactive_preview"
   | Consecutive_noop_count -> "consecutive_noop_count"
+  | Last_consumed_backlog_revision -> "last_consumed_backlog_revision"
   | Last_compaction_check_ts -> "last_compaction_check_ts"
   | Last_compaction_decision -> "last_compaction_decision"
   | Active_goal_ids -> "active_goal_ids"
@@ -182,6 +185,17 @@ let field_name = function
 ;;
 
 let current_field_names = List.map field_name all_fields
+
+(* RFC-0357 §3.3: [Last_consumed_backlog_revision] shipped after live keeper
+   metas were written. An ABSENT field decodes as genesis 0 (never consumed;
+   the decoder owns that default) instead of invalidating the whole meta —
+   the 2026-07-30 schema removal invalidated every live meta at once, and a
+   fleet-wide "runtime reset required" is not an acceptable side effect of an
+   admission change. A PRESENT malformed value still fails the decode.
+   Exactly this field is absence-tolerated; everything else stays required.
+   Once every live meta has been rewritten by a post-turn write, this list
+   can shrink back to empty. *)
+let genesis_defaulted_field_names = [ field_name Last_consumed_backlog_revision ]
 
 let object_of_field_values field_values =
   let supplied = List.map fst field_values in
@@ -219,7 +233,11 @@ let validate_current_object (json : Yojson.Safe.t) =
          List.filter (fun key -> not (List.mem key current_field_names)) present
        in
        let missing =
-         List.filter (fun key -> not (List.mem key present)) current_field_names
+         List.filter
+           (fun key ->
+              (not (List.mem key present))
+              && not (List.mem key genesis_defaulted_field_names))
+           current_field_names
        in
        if outside_current <> []
        then

--- a/lib/keeper/keeper_meta_json_current_schema.ml
+++ b/lib/keeper/keeper_meta_json_current_schema.ml
@@ -190,6 +190,23 @@ let field_name = function
 
 let current_field_names = List.map field_name all_fields
 
+(* RFC-0357 §3.3: the consumption stamp pair shipped after live keeper metas
+   were written. When BOTH fields are absent the meta decodes with the genesis
+   pair (revision 0, empty projection digest) instead of invalidating the
+   whole meta: an invalid meta cannot be read or rewritten
+   (write_meta_with_merge fails closed on Read_failed), so absent=invalid
+   would strand every pre-RFC keeper in "runtime reset required" — the
+   2026-07-31 fleet outage shape, measured live as 10/10 metas lacking the
+   pair. A PRESENT malformed value still fails the decode, and the decoder's
+   pair invariant rejects half-genesis states. Exactly these two fields are
+   absence-tolerated; everything else stays required. Removal is tracked, not
+   aspirational: once every live meta carries the pair (one post-turn write
+   per keeper), issue #26697 shrinks this list back to empty. *)
+let genesis_defaulted_field_names =
+  [ field_name Last_consumed_backlog_revision
+  ; field_name Last_consumed_backlog_projection_sha256
+  ]
+
 let object_of_field_values field_values =
   let supplied = List.map fst field_values in
   if supplied <> all_fields
@@ -225,7 +242,12 @@ let validate_current_object (json : Yojson.Safe.t) =
        let outside_current =
          List.filter (fun key -> not (List.mem key current_field_names)) present
        in
-       let missing = List.filter (fun key -> not (List.mem key present)) current_field_names
+       let missing =
+         List.filter
+           (fun key ->
+              (not (List.mem key present))
+              && not (List.mem key genesis_defaulted_field_names))
+           current_field_names
        in
        if outside_current <> []
        then

--- a/lib/keeper/keeper_meta_json_current_schema.ml
+++ b/lib/keeper/keeper_meta_json_current_schema.ml
@@ -190,22 +190,6 @@ let field_name = function
 
 let current_field_names = List.map field_name all_fields
 
-(* RFC-0357 §3.3: the consumption stamp pair shipped after live keeper metas
-   were written. An ABSENT field decodes as its genesis value (revision 0,
-   empty projection digest) instead of invalidating the whole meta: an
-   invalid meta cannot be read or rewritten (write_meta_with_merge fails
-   closed on Read_failed), so absent=invalid would strand every pre-RFC
-   keeper in "runtime reset required" — the 2026-07-31 fleet outage shape,
-   measured live as 10/10 metas lacking the pair. A PRESENT malformed value
-   still fails the decode. Exactly these two fields are absence-tolerated;
-   everything else stays required. Removal is tracked, not aspirational:
-   once every live meta carries the pair (one post-turn write per keeper),
-   issue #26697 shrinks this list back to empty. *)
-let genesis_defaulted_field_names =
-  [ field_name Last_consumed_backlog_revision
-  ; field_name Last_consumed_backlog_projection_sha256
-  ]
-
 let object_of_field_values field_values =
   let supplied = List.map fst field_values in
   if supplied <> all_fields
@@ -241,12 +225,7 @@ let validate_current_object (json : Yojson.Safe.t) =
        let outside_current =
          List.filter (fun key -> not (List.mem key current_field_names)) present
        in
-       let missing =
-         List.filter
-           (fun key ->
-              (not (List.mem key present))
-              && not (List.mem key genesis_defaulted_field_names))
-           current_field_names
+       let missing = List.filter (fun key -> not (List.mem key present)) current_field_names
        in
        if outside_current <> []
        then

--- a/lib/keeper/keeper_meta_json_current_schema.ml
+++ b/lib/keeper/keeper_meta_json_current_schema.ml
@@ -193,8 +193,10 @@ let current_field_names = List.map field_name all_fields
    fleet-wide "runtime reset required" is not an acceptable side effect of an
    admission change. A PRESENT malformed value still fails the decode.
    Exactly this field is absence-tolerated; everything else stays required.
-   Once every live meta has been rewritten by a post-turn write, this list
-   can shrink back to empty. *)
+   Removal is tracked, not aspirational: once every live meta carries the
+   field (one post-turn write per keeper), issue #26697 shrinks this list
+   back to empty — target is within a week of the introducing PR's merge,
+   before the list can acquire a second resident. *)
 let genesis_defaulted_field_names = [ field_name Last_consumed_backlog_revision ]
 
 let object_of_field_values field_values =

--- a/lib/keeper/keeper_meta_json_current_schema.ml
+++ b/lib/keeper/keeper_meta_json_current_schema.ml
@@ -49,6 +49,7 @@ type field =
   | Last_proactive_preview
   | Consecutive_noop_count
   | Last_consumed_backlog_revision
+  | Last_consumed_backlog_projection_sha256
   | Last_compaction_check_ts
   | Last_compaction_decision
   | Active_goal_ids
@@ -105,6 +106,7 @@ let all_fields =
   ; Last_proactive_preview
   ; Consecutive_noop_count
   ; Last_consumed_backlog_revision
+  ; Last_consumed_backlog_projection_sha256
   ; Last_compaction_check_ts
   ; Last_compaction_decision
   ; Active_goal_ids
@@ -162,6 +164,8 @@ let field_name = function
   | Last_proactive_preview -> "last_proactive_preview"
   | Consecutive_noop_count -> "consecutive_noop_count"
   | Last_consumed_backlog_revision -> "last_consumed_backlog_revision"
+  | Last_consumed_backlog_projection_sha256 ->
+    "last_consumed_backlog_projection_sha256"
   | Last_compaction_check_ts -> "last_compaction_check_ts"
   | Last_compaction_decision -> "last_compaction_decision"
   | Active_goal_ids -> "active_goal_ids"
@@ -185,19 +189,6 @@ let field_name = function
 ;;
 
 let current_field_names = List.map field_name all_fields
-
-(* RFC-0357 §3.3: [Last_consumed_backlog_revision] shipped after live keeper
-   metas were written. An ABSENT field decodes as genesis 0 (never consumed;
-   the decoder owns that default) instead of invalidating the whole meta —
-   the 2026-07-30 schema removal invalidated every live meta at once, and a
-   fleet-wide "runtime reset required" is not an acceptable side effect of an
-   admission change. A PRESENT malformed value still fails the decode.
-   Exactly this field is absence-tolerated; everything else stays required.
-   Removal is tracked, not aspirational: once every live meta carries the
-   field (one post-turn write per keeper), issue #26697 shrinks this list
-   back to empty — target is within a week of the introducing PR's merge,
-   before the list can acquire a second resident. *)
-let genesis_defaulted_field_names = [ field_name Last_consumed_backlog_revision ]
 
 let object_of_field_values field_values =
   let supplied = List.map fst field_values in
@@ -236,9 +227,7 @@ let validate_current_object (json : Yojson.Safe.t) =
        in
        let missing =
          List.filter
-           (fun key ->
-              (not (List.mem key present))
-              && not (List.mem key genesis_defaulted_field_names))
+           (fun key -> not (List.mem key present))
            current_field_names
        in
        if outside_current <> []

--- a/lib/keeper/keeper_meta_json_current_schema.mli
+++ b/lib/keeper/keeper_meta_json_current_schema.mli
@@ -39,6 +39,7 @@ type field =
   | Last_proactive_preview
   | Consecutive_noop_count
   | Last_consumed_backlog_revision
+  | Last_consumed_backlog_projection_sha256
   | Last_compaction_check_ts
   | Last_compaction_decision
   | Active_goal_ids

--- a/lib/keeper/keeper_meta_json_current_schema.mli
+++ b/lib/keeper/keeper_meta_json_current_schema.mli
@@ -38,6 +38,7 @@ type field =
   | Last_proactive_reason
   | Last_proactive_preview
   | Consecutive_noop_count
+  | Last_consumed_backlog_revision
   | Last_compaction_check_ts
   | Last_compaction_decision
   | Active_goal_ids

--- a/lib/keeper/keeper_meta_json_current_schema.mli
+++ b/lib/keeper/keeper_meta_json_current_schema.mli
@@ -76,10 +76,6 @@ val current_field_names : string list
 val validate_current_object :
   Yojson.Safe.t -> ((string * Yojson.Safe.t) list, validation_error) result
 (** Require exactly the current top-level key set. Every field outside that set
-    has the same [Invalid_current] classification. One exception: the
-    RFC-0357 §3.3 genesis pair — [last_consumed_backlog_revision] and
-    [last_consumed_backlog_projection_sha256] — may be ABSENT together (live
-    metas predate it) and decodes as revision 0 with an empty projection
-    digest; a PRESENT malformed value and half-genesis states still fail.
-    Issue #26697 retires the exception once every live meta carries the
-    pair. *)
+    has the same [Invalid_current] classification. Every current field is
+    required; missing fields are not interpreted as an older version or
+    silently defaulted. *)

--- a/lib/keeper/keeper_meta_json_current_schema.mli
+++ b/lib/keeper/keeper_meta_json_current_schema.mli
@@ -76,6 +76,10 @@ val current_field_names : string list
 val validate_current_object :
   Yojson.Safe.t -> ((string * Yojson.Safe.t) list, validation_error) result
 (** Require exactly the current top-level key set. Every field outside that set
-    has the same [Invalid_current] classification. The RFC-0357 §3.3
-    consumption pair is part of the current schema and is required; absent
-    fields are not interpreted as an older version or silently defaulted. *)
+    has the same [Invalid_current] classification. One exception: the
+    RFC-0357 §3.3 genesis pair — [last_consumed_backlog_revision] and
+    [last_consumed_backlog_projection_sha256] — may be ABSENT together (live
+    metas predate it) and decodes as revision 0 with an empty projection
+    digest; a PRESENT malformed value and half-genesis states still fail.
+    Issue #26697 retires the exception once every live meta carries the
+    pair. *)

--- a/lib/keeper/keeper_meta_json_current_schema.mli
+++ b/lib/keeper/keeper_meta_json_current_schema.mli
@@ -76,9 +76,6 @@ val current_field_names : string list
 val validate_current_object :
   Yojson.Safe.t -> ((string * Yojson.Safe.t) list, validation_error) result
 (** Require exactly the current top-level key set. Every field outside that set
-    has the same [Invalid_current] classification. One exception: the
-    RFC-0357 §3.3 genesis pair — [last_consumed_backlog_revision] and
-    [last_consumed_backlog_projection_sha256] — may be ABSENT (live metas
-    predate it) and decodes as revision 0 with an empty projection digest;
-    a PRESENT malformed value still fails. Issue #26697 retires the
-    exception once every live meta carries the pair. *)
+    has the same [Invalid_current] classification. The RFC-0357 §3.3
+    consumption pair is part of the current schema and is required; absent
+    fields are not interpreted as an older version or silently defaulted. *)

--- a/lib/keeper/keeper_meta_json_current_schema.mli
+++ b/lib/keeper/keeper_meta_json_current_schema.mli
@@ -76,6 +76,10 @@ val current_field_names : string list
 val validate_current_object :
   Yojson.Safe.t -> ((string * Yojson.Safe.t) list, validation_error) result
 (** Require exactly the current top-level key set. Every field outside that set
-    has the same [Invalid_current] classification. Every current field is
-    required; missing fields are not interpreted as an older version or
-    silently defaulted. *)
+    has the same [Invalid_current] classification. One exception: the
+    RFC-0357 §3.3 genesis pair — [last_consumed_backlog_revision] and
+    [last_consumed_backlog_projection_sha256] — may be ABSENT together (live
+    metas predate it) and decodes as revision 0 with an empty projection
+    digest; a PRESENT malformed value and half-genesis states still fail.
+    Issue #26697 retires the exception once every live meta carries the
+    pair. *)

--- a/lib/keeper/keeper_meta_json_current_schema.mli
+++ b/lib/keeper/keeper_meta_json_current_schema.mli
@@ -76,4 +76,9 @@ val current_field_names : string list
 val validate_current_object :
   Yojson.Safe.t -> ((string * Yojson.Safe.t) list, validation_error) result
 (** Require exactly the current top-level key set. Every field outside that set
-    has the same [Invalid_current] classification. *)
+    has the same [Invalid_current] classification. One exception: the
+    RFC-0357 §3.3 genesis pair — [last_consumed_backlog_revision] and
+    [last_consumed_backlog_projection_sha256] — may be ABSENT (live metas
+    predate it) and decodes as revision 0 with an empty projection digest;
+    a PRESENT malformed value still fails. Issue #26697 retires the
+    exception once every live meta carries the pair. *)

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -36,6 +36,22 @@ let int_field fields name =
   | other -> invalidf "field %s must be an integer, got %s" name (Json_util.kind_name other)
 ;;
 
+(* RFC-0357 §3.3: absence-tolerated only for fields listed in
+   [Keeper_meta_json_current_schema.genesis_defaulted_field_names]. An absent
+   field is a pre-RFC meta and decodes as the genesis value; a PRESENT
+   malformed or negative value still fails the decode — corruption must not
+   silently rewind an edge clock. *)
+let genesis_int_field fields name ~genesis =
+  match List.assoc_opt name fields with
+  | None -> Ok genesis
+  | Some (`Int value) ->
+    if value >= 0
+    then Ok value
+    else invalidf "field %s must be nonnegative, got %d" name value
+  | Some other ->
+    invalidf "field %s must be an integer, got %s" name (Json_util.kind_name other)
+;;
+
 let float_field fields name =
   let* value = required_field fields name in
   let parsed =
@@ -338,6 +354,9 @@ let decode_current_meta fields =
   let* last_proactive_reason = string_field fields "last_proactive_reason" in
   let* last_proactive_preview = string_field fields "last_proactive_preview" in
   let* consecutive_noop_count = int_field fields "consecutive_noop_count" in
+  let* last_consumed_backlog_revision =
+    genesis_int_field fields "last_consumed_backlog_revision" ~genesis:0
+  in
   let* last_compaction_check_ts = float_field fields "last_compaction_check_ts" in
   let* last_compaction_decision_raw = string_field fields "last_compaction_decision" in
   let* active_goal_ids = string_list_field fields "active_goal_ids" in
@@ -413,6 +432,7 @@ let decode_current_meta fields =
       ; last_reason = last_proactive_reason
       ; last_preview = last_proactive_preview
       ; consecutive_noop_count
+      ; last_consumed_backlog_revision
       }
     in
     let runtime : agent_runtime_state =

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -36,6 +36,32 @@ let int_field fields name =
   | other -> invalidf "field %s must be an integer, got %s" name (Json_util.kind_name other)
 ;;
 
+(* RFC-0357 §3.3: absence-tolerated only for fields listed in
+   [Keeper_meta_json_current_schema.genesis_defaulted_field_names]. An absent
+   field is a pre-RFC meta and decodes as the genesis value; a PRESENT
+   malformed or negative value still fails the decode — corruption must not
+   silently rewind an edge clock. The pair invariant below rejects
+   half-genesis states, so tolerance only ever produces the full genesis
+   pair. *)
+let genesis_int_field fields name ~genesis =
+  match List.assoc_opt name fields with
+  | None -> Ok genesis
+  | Some (`Int value) ->
+    if value >= 0
+    then Ok value
+    else invalidf "field %s must be nonnegative, got %d" name value
+  | Some other ->
+    invalidf "field %s must be an integer, got %s" name (Json_util.kind_name other)
+;;
+
+let genesis_string_field fields name ~genesis =
+  match List.assoc_opt name fields with
+  | None -> Ok genesis
+  | Some (`String value) -> Ok value
+  | Some other ->
+    invalidf "field %s must be a string, got %s" name (Json_util.kind_name other)
+;;
+
 let float_field fields name =
   let* value = required_field fields name in
   let parsed =
@@ -339,10 +365,13 @@ let decode_current_meta fields =
   let* last_proactive_preview = string_field fields "last_proactive_preview" in
   let* consecutive_noop_count = int_field fields "consecutive_noop_count" in
   let* last_consumed_backlog_revision =
-    int_field fields "last_consumed_backlog_revision"
+    genesis_int_field fields "last_consumed_backlog_revision" ~genesis:0
   in
   let* last_consumed_backlog_projection_sha256 =
-    string_field fields "last_consumed_backlog_projection_sha256"
+    genesis_string_field
+      fields
+      "last_consumed_backlog_projection_sha256"
+      ~genesis:""
   in
   let* () =
     if last_consumed_backlog_revision >= 0

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -36,22 +36,6 @@ let int_field fields name =
   | other -> invalidf "field %s must be an integer, got %s" name (Json_util.kind_name other)
 ;;
 
-(* RFC-0357 §3.3: absence-tolerated only for fields listed in
-   [Keeper_meta_json_current_schema.genesis_defaulted_field_names]. An absent
-   field is a pre-RFC meta and decodes as the genesis value; a PRESENT
-   malformed or negative value still fails the decode — corruption must not
-   silently rewind an edge clock. *)
-let genesis_int_field fields name ~genesis =
-  match List.assoc_opt name fields with
-  | None -> Ok genesis
-  | Some (`Int value) ->
-    if value >= 0
-    then Ok value
-    else invalidf "field %s must be nonnegative, got %d" name value
-  | Some other ->
-    invalidf "field %s must be an integer, got %s" name (Json_util.kind_name other)
-;;
-
 let float_field fields name =
   let* value = required_field fields name in
   let parsed =
@@ -355,7 +339,32 @@ let decode_current_meta fields =
   let* last_proactive_preview = string_field fields "last_proactive_preview" in
   let* consecutive_noop_count = int_field fields "consecutive_noop_count" in
   let* last_consumed_backlog_revision =
-    genesis_int_field fields "last_consumed_backlog_revision" ~genesis:0
+    int_field fields "last_consumed_backlog_revision"
+  in
+  let* () =
+    if last_consumed_backlog_revision >= 0
+    then Ok ()
+    else invalidf "field last_consumed_backlog_revision must be nonnegative"
+  in
+  let* last_consumed_backlog_projection_sha256 =
+    string_field fields "last_consumed_backlog_projection_sha256"
+  in
+  let valid_projection_sha256 =
+    String.equal last_consumed_backlog_projection_sha256 ""
+    ||
+    (String.length last_consumed_backlog_projection_sha256 = 64
+     && String.for_all
+          (function
+            | '0' .. '9' | 'a' .. 'f' -> true
+            | _ -> false)
+          last_consumed_backlog_projection_sha256)
+  in
+  let* () =
+    if valid_projection_sha256
+    then Ok ()
+    else
+      invalidf
+        "field last_consumed_backlog_projection_sha256 must be empty genesis or lowercase SHA-256"
   in
   let* last_compaction_check_ts = float_field fields "last_compaction_check_ts" in
   let* last_compaction_decision_raw = string_field fields "last_compaction_decision" in
@@ -433,6 +442,7 @@ let decode_current_meta fields =
       ; last_preview = last_proactive_preview
       ; consecutive_noop_count
       ; last_consumed_backlog_revision
+      ; last_consumed_backlog_projection_sha256
       }
     in
     let runtime : agent_runtime_state =

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -36,30 +36,6 @@ let int_field fields name =
   | other -> invalidf "field %s must be an integer, got %s" name (Json_util.kind_name other)
 ;;
 
-(* RFC-0357 §3.3: absence-tolerated only for fields listed in
-   [Keeper_meta_json_current_schema.genesis_defaulted_field_names]. An absent
-   field is a pre-RFC meta and decodes as the genesis value; a PRESENT
-   malformed or negative value still fails the decode — corruption must not
-   silently rewind an edge clock. *)
-let genesis_int_field fields name ~genesis =
-  match List.assoc_opt name fields with
-  | None -> Ok genesis
-  | Some (`Int value) ->
-    if value >= 0
-    then Ok value
-    else invalidf "field %s must be nonnegative, got %d" name value
-  | Some other ->
-    invalidf "field %s must be an integer, got %s" name (Json_util.kind_name other)
-;;
-
-let genesis_string_field fields name ~genesis =
-  match List.assoc_opt name fields with
-  | None -> Ok genesis
-  | Some (`String value) -> Ok value
-  | Some other ->
-    invalidf "field %s must be a string, got %s" name (Json_util.kind_name other)
-;;
-
 let float_field fields name =
   let* value = required_field fields name in
   let parsed =
@@ -363,13 +339,15 @@ let decode_current_meta fields =
   let* last_proactive_preview = string_field fields "last_proactive_preview" in
   let* consecutive_noop_count = int_field fields "consecutive_noop_count" in
   let* last_consumed_backlog_revision =
-    genesis_int_field fields "last_consumed_backlog_revision" ~genesis:0
+    int_field fields "last_consumed_backlog_revision"
   in
   let* last_consumed_backlog_projection_sha256 =
-    genesis_string_field
-      fields
-      "last_consumed_backlog_projection_sha256"
-      ~genesis:""
+    string_field fields "last_consumed_backlog_projection_sha256"
+  in
+  let* () =
+    if last_consumed_backlog_revision >= 0
+    then Ok ()
+    else invalidf "field last_consumed_backlog_revision must be nonnegative"
   in
   let valid_projection_sha256 =
     String.equal last_consumed_backlog_projection_sha256 ""
@@ -387,6 +365,17 @@ let decode_current_meta fields =
     else
       invalidf
         "field last_consumed_backlog_projection_sha256 must be empty genesis or lowercase SHA-256"
+  in
+  let* () =
+    match last_consumed_backlog_revision, last_consumed_backlog_projection_sha256 with
+    | 0, "" -> Ok ()
+    | 0, _ ->
+      invalidf
+        "field last_consumed_backlog_projection_sha256 must be empty when revision is genesis 0"
+    | _, "" ->
+      invalidf
+        "field last_consumed_backlog_projection_sha256 must be a digest when revision is nonzero"
+    | _ -> Ok ()
   in
   let* last_compaction_check_ts = float_field fields "last_compaction_check_ts" in
   let* last_compaction_decision_raw = string_field fields "last_compaction_decision" in

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -36,6 +36,30 @@ let int_field fields name =
   | other -> invalidf "field %s must be an integer, got %s" name (Json_util.kind_name other)
 ;;
 
+(* RFC-0357 §3.3: absence-tolerated only for fields listed in
+   [Keeper_meta_json_current_schema.genesis_defaulted_field_names]. An absent
+   field is a pre-RFC meta and decodes as the genesis value; a PRESENT
+   malformed or negative value still fails the decode — corruption must not
+   silently rewind an edge clock. *)
+let genesis_int_field fields name ~genesis =
+  match List.assoc_opt name fields with
+  | None -> Ok genesis
+  | Some (`Int value) ->
+    if value >= 0
+    then Ok value
+    else invalidf "field %s must be nonnegative, got %d" name value
+  | Some other ->
+    invalidf "field %s must be an integer, got %s" name (Json_util.kind_name other)
+;;
+
+let genesis_string_field fields name ~genesis =
+  match List.assoc_opt name fields with
+  | None -> Ok genesis
+  | Some (`String value) -> Ok value
+  | Some other ->
+    invalidf "field %s must be a string, got %s" name (Json_util.kind_name other)
+;;
+
 let float_field fields name =
   let* value = required_field fields name in
   let parsed =
@@ -339,15 +363,13 @@ let decode_current_meta fields =
   let* last_proactive_preview = string_field fields "last_proactive_preview" in
   let* consecutive_noop_count = int_field fields "consecutive_noop_count" in
   let* last_consumed_backlog_revision =
-    int_field fields "last_consumed_backlog_revision"
-  in
-  let* () =
-    if last_consumed_backlog_revision >= 0
-    then Ok ()
-    else invalidf "field last_consumed_backlog_revision must be nonnegative"
+    genesis_int_field fields "last_consumed_backlog_revision" ~genesis:0
   in
   let* last_consumed_backlog_projection_sha256 =
-    string_field fields "last_consumed_backlog_projection_sha256"
+    genesis_string_field
+      fields
+      "last_consumed_backlog_projection_sha256"
+      ~genesis:""
   in
   let valid_projection_sha256 =
     String.equal last_consumed_backlog_projection_sha256 ""

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -36,32 +36,6 @@ let int_field fields name =
   | other -> invalidf "field %s must be an integer, got %s" name (Json_util.kind_name other)
 ;;
 
-(* RFC-0357 §3.3: absence-tolerated only for fields listed in
-   [Keeper_meta_json_current_schema.genesis_defaulted_field_names]. An absent
-   field is a pre-RFC meta and decodes as the genesis value; a PRESENT
-   malformed or negative value still fails the decode — corruption must not
-   silently rewind an edge clock. The pair invariant below rejects
-   half-genesis states, so tolerance only ever produces the full genesis
-   pair. *)
-let genesis_int_field fields name ~genesis =
-  match List.assoc_opt name fields with
-  | None -> Ok genesis
-  | Some (`Int value) ->
-    if value >= 0
-    then Ok value
-    else invalidf "field %s must be nonnegative, got %d" name value
-  | Some other ->
-    invalidf "field %s must be an integer, got %s" name (Json_util.kind_name other)
-;;
-
-let genesis_string_field fields name ~genesis =
-  match List.assoc_opt name fields with
-  | None -> Ok genesis
-  | Some (`String value) -> Ok value
-  | Some other ->
-    invalidf "field %s must be a string, got %s" name (Json_util.kind_name other)
-;;
-
 let float_field fields name =
   let* value = required_field fields name in
   let parsed =
@@ -365,13 +339,10 @@ let decode_current_meta fields =
   let* last_proactive_preview = string_field fields "last_proactive_preview" in
   let* consecutive_noop_count = int_field fields "consecutive_noop_count" in
   let* last_consumed_backlog_revision =
-    genesis_int_field fields "last_consumed_backlog_revision" ~genesis:0
+    int_field fields "last_consumed_backlog_revision"
   in
   let* last_consumed_backlog_projection_sha256 =
-    genesis_string_field
-      fields
-      "last_consumed_backlog_projection_sha256"
-      ~genesis:""
+    string_field fields "last_consumed_backlog_projection_sha256"
   in
   let* () =
     if last_consumed_backlog_revision >= 0

--- a/lib/keeper/keeper_meta_merge.ml
+++ b/lib/keeper/keeper_meta_merge.ml
@@ -1,7 +1,40 @@
 type t = latest:Keeper_meta_contract.keeper_meta -> caller:Keeper_meta_contract.keeper_meta -> Keeper_meta_contract.keeper_meta
 
-let caller_wins ~(latest : Keeper_meta_contract.keeper_meta) ~(caller : Keeper_meta_contract.keeper_meta) =
-  { caller with meta_version = latest.meta_version }
+let monotonic_backlog_consumption
+      ~(latest : Keeper_meta_contract.keeper_meta)
+      ~(caller : Keeper_meta_contract.keeper_meta)
+  =
+  let latest_proactive = latest.runtime.proactive_rt in
+  let caller_proactive = caller.runtime.proactive_rt in
+  let revision, projection_sha256 =
+    if
+      caller_proactive.last_consumed_backlog_revision
+      > latest_proactive.last_consumed_backlog_revision
+    then
+      ( caller_proactive.last_consumed_backlog_revision
+      , caller_proactive.last_consumed_backlog_projection_sha256 )
+    else
+      ( latest_proactive.last_consumed_backlog_revision
+      , latest_proactive.last_consumed_backlog_projection_sha256 )
+  in
+  { caller.runtime with
+    proactive_rt =
+      { caller_proactive with
+        last_consumed_backlog_revision = revision
+      ; last_consumed_backlog_projection_sha256 = projection_sha256
+      }
+  }
+;;
+
+let caller_wins
+      ~(latest : Keeper_meta_contract.keeper_meta)
+      ~(caller : Keeper_meta_contract.keeper_meta)
+  =
+  { caller with
+    meta_version = latest.meta_version
+  ; runtime = monotonic_backlog_consumption ~latest ~caller
+  }
+;;
 
 (* RFC-0225 §3.2: cumulative usage counters never regress on a CAS retry.
    A caller that lost the race accumulated its turn onto a stale snapshot;
@@ -11,8 +44,9 @@ let caller_wins ~(latest : Keeper_meta_contract.keeper_meta) ~(caller : Keeper_m
    undercounts by one turn but never rewinds. last_* observations stay
    with the caller (they describe the turn that just finished). *)
 let monotonic_usage_counters ~(latest : Keeper_meta_contract.keeper_meta) ~(caller : Keeper_meta_contract.keeper_meta) =
+  let merged = caller_wins ~latest ~caller in
   let lu = latest.runtime.usage in
-  let cu = caller.runtime.usage in
+  let cu = merged.runtime.usage in
   let usage =
     { cu with
       total_turns = max cu.total_turns lu.total_turns
@@ -22,10 +56,7 @@ let monotonic_usage_counters ~(latest : Keeper_meta_contract.keeper_meta) ~(call
     ; total_cost_usd = Float.max cu.total_cost_usd lu.total_cost_usd
     }
   in
-  { caller with
-    meta_version = latest.meta_version
-  ; runtime = { caller.runtime with usage }
-  }
+  { merged with runtime = { merged.runtime with usage } }
 
 let preserve_latched_pause_from_disk
       ~(latest : Keeper_meta_contract.keeper_meta)

--- a/lib/keeper/keeper_meta_merge.mli
+++ b/lib/keeper/keeper_meta_merge.mli
@@ -3,14 +3,15 @@
 type t = latest:Keeper_meta_contract.keeper_meta -> caller:Keeper_meta_contract.keeper_meta -> Keeper_meta_contract.keeper_meta
 
 val caller_wins : t
-(** Take every field from the caller except [meta_version], which
-    follows the disk version. *)
+(** Take caller-owned fields, while [meta_version] follows disk and the paired
+    backlog consumption revision/projection can only advance. *)
 
 val monotonic_usage_counters : t
 (** {!caller_wins}, except cumulative usage counters (total_turns,
     total_*_tokens, total_cost_usd) take [max latest caller] so a CAS
     retry from a stale snapshot can never rewind them (RFC-0225 §3.2).
-    last_* observation fields stay with the caller. *)
+    The backlog consumption pair is monotonic as in {!caller_wins}; last_*
+    observation fields stay with the caller. *)
 
 val heartbeat_fields_from_disk : t
 (** {!monotonic_usage_counters}, plus preservation of any durable pause already

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -35,7 +35,7 @@ let build_base_system_prompt
   in
   Keeper_unified_prompt.build_system_prompt
     ~meta
-    ~base_path:config.base_path
+    ~config
     ~profile_defaults
     ~active_goal_summaries
     ()

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -579,7 +579,6 @@ let bootstrap_existing_keepers ctx : keeper_bootstrap_stats =
     { scanned = 0; started = 0; stale = 0; recovering = 0 }
   else
     let now_ts = Time_compat.now () in
-    let proactive_warmup_sec = keeper_bootstrap_proactive_warmup_sec () in
     let stale_turn_sec =
       max 0.0 Env_config.KeeperBootstrap.stale_turn_seconds
     in
@@ -613,7 +612,7 @@ let bootstrap_existing_keepers ctx : keeper_bootstrap_stats =
                 else if already_running then false
                 else (
                   Keeper_supervisor.supervise_keepalive
-                    ~proactive_warmup_sec ctx m;
+                    ctx m;
                   Keeper_registry.is_running
                     ~base_path:ctx.config.base_path m.name
                 )

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -300,7 +300,7 @@ let sweep_and_recover ~load_or_materialize_keeper_meta (ctx : _ context)
               ~restart_count:attempt
               ~last_restart_ts:now
               ~crash_log:(keep_last_n 5 (now, crash_msg) old_crash_log);
-            (match launch_supervised_fiber ~proactive_warmup_sec:0 ctx meta reg with
+            (match launch_supervised_fiber ctx meta reg with
              | Error _ ->
                (* Launch gate aborted fail-closed (no fiber; done resolved and
                   Crashed published by the gate). Announcing Restarted/Running

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -16,7 +16,7 @@ open Keeper_types_profile
 (** {1 Supervised Execution} *)
 
 val supervise_keepalive :
-  proactive_warmup_sec:int -> 'a context -> keeper_meta -> unit
+  'a context -> keeper_meta -> unit
 (** Start a keeper heartbeat loop inside a supervised fiber.
     Registers in [Keeper_registry] (SSOT) and launches the fiber.
     On fiber termination, resolves the Promise and publishes

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -62,7 +62,6 @@ let with_restart_launch_noop_for_test = Keeper_supervisor_restart_noop.with_noop
 let domain_pool_ignored_warning_emitted = Atomic.make false
 
 let launch_supervised_fiber_body
-      ~proactive_warmup_sec
       ctx
       (meta : keeper_meta)
       (reg : Keeper_registry.registry_entry)
@@ -273,7 +272,6 @@ let launch_supervised_fiber_body
              Eio_guard.protect
                (fun () ->
                   Keeper_keepalive.run_heartbeat_loop
-                    ~proactive_warmup_sec
                     ctx
                     meta
                     reg.fiber_stop
@@ -612,7 +610,6 @@ let launch_supervised_fiber_body
     case nothing was forked, no [Started]/[Running] event may be published
     by the caller, and [done_p] has been resolved through the crash path. *)
 let launch_supervised_fiber
-      ~proactive_warmup_sec
       ctx
       (meta : keeper_meta)
       (reg : Keeper_registry.registry_entry)
@@ -666,7 +663,7 @@ let launch_supervised_fiber
     (* Propagate the fork outcome: a rejected [Keeper_lane.fork] returns
        [Error] here so the caller suppresses the Started/Running lifecycle
        for a keeper whose lane was never forked. *)
-    launch_supervised_fiber_body ~proactive_warmup_sec ctx meta reg
+    launch_supervised_fiber_body ctx meta reg
 ;;
 
 (* #10993: persona drift visibility.
@@ -700,11 +697,10 @@ let persona_profile_path_for_drift_check =
 
 let log_persona_drift_if_missing = Startup_helpers.log_persona_drift_if_missing
 
-let supervise_keepalive ~proactive_warmup_sec (ctx : _ context) (meta : keeper_meta) =
+let supervise_keepalive (ctx : _ context) (meta : keeper_meta) =
   Keeper_supervisor_supervise_keepalive.supervise_keepalive
     ~publish_lifecycle
     ~launch_supervised_fiber
-    ~proactive_warmup_sec
     ctx
     meta
 ;;

--- a/lib/keeper/keeper_supervisor_reconcile_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_reconcile_keepalive.ml
@@ -9,8 +9,6 @@ open Keeper_meta_contract
 open Keeper_meta_store
 open Keeper_types_profile
 
-let immediate_warmup_sec = 0
-
 let reconcile_keepalive_keepers
       ~publish_lifecycle
       ~supervise_keepalive
@@ -60,7 +58,7 @@ let reconcile_keepalive_keepers
     in
     if not dominated_by_sweep
     then (
-      (try supervise_keepalive ~proactive_warmup_sec:immediate_warmup_sec ctx meta with
+      (try supervise_keepalive ctx meta with
        | Eio.Cancel.Cancelled _ as exn -> raise exn
        | exn ->
          inc_reconcile_failure ~name:meta.name ~operation:"supervise_keepalive";

--- a/lib/keeper/keeper_supervisor_reconcile_keepalive.mli
+++ b/lib/keeper/keeper_supervisor_reconcile_keepalive.mli
@@ -8,8 +8,7 @@ val reconcile_keepalive_keepers :
      unit ->
      unit) ->
   supervise_keepalive:
-    (proactive_warmup_sec:int ->
-     'a Keeper_types_profile.context ->
+    ('a Keeper_types_profile.context ->
      Keeper_meta_contract.keeper_meta ->
      unit) ->
   load_or_materialize_keeper_meta:

--- a/lib/keeper/keeper_supervisor_supervise_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.ml
@@ -39,12 +39,10 @@ let supervise_keepalive
          event:Keeper_lifecycle_events.lifecycle_event ->
          string -> string -> unit -> unit)
       ~(launch_supervised_fiber :
-         proactive_warmup_sec:int ->
          _ context ->
          keeper_meta ->
          Keeper_registry.registry_entry ->
          (unit, Keeper_state_machine.transition_error) result)
-      ~proactive_warmup_sec
       (ctx : _ context)
       (meta : keeper_meta)
   =
@@ -124,7 +122,7 @@ let supervise_keepalive
         meta
     in
     Keeper_registry.update_meta ~base_path meta.name live_meta;
-    match launch_supervised_fiber ~proactive_warmup_sec ctx live_meta reg with
+    match launch_supervised_fiber ctx live_meta reg with
     | Error _ -> ()
     | Ok () ->
       publish_lifecycle

--- a/lib/keeper/keeper_supervisor_supervise_keepalive.mli
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.mli
@@ -8,12 +8,10 @@ val supervise_keepalive :
      unit ->
      unit) ->
   launch_supervised_fiber:
-    (proactive_warmup_sec:int ->
-     'a Keeper_types_profile.context ->
+    ('a Keeper_types_profile.context ->
      Keeper_meta_contract.keeper_meta ->
      Keeper_registry.registry_entry ->
      (unit, Keeper_state_machine.transition_error) result) ->
-  proactive_warmup_sec:int ->
   'a Keeper_types_profile.context ->
   Keeper_meta_contract.keeper_meta ->
   unit

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -227,6 +227,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             last_preview = "";
             consecutive_noop_count = 0;
             last_consumed_backlog_revision = 0;
+            last_consumed_backlog_projection_sha256 = "";
           };
           nonce;
           trace_id = trace_id_t;

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -226,6 +226,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             last_reason = "";
             last_preview = "";
             consecutive_noop_count = 0;
+            last_consumed_backlog_revision = 0;
           };
           nonce;
           trace_id = trace_id_t;

--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -23,8 +23,6 @@ val reject_removed_keeper_msg_input_keys :
   tool_name:string -> Yojson.Safe.t -> (unit, string) result
 val utf8_repair_string : string -> string
 val normalize_prompt_text : max_bytes:int -> string -> string
-val keeper_bootstrap_proactive_warmup_sec : unit -> int
-val keeper_bootstrap_stagger_step_sec : unit -> int
 val keeper_bootstrap_retry_interval_sec : unit -> int
 val keeper_batch_limit : unit -> int
 val keeper_unified_temperature : unit -> float

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -23,8 +23,6 @@ val reject_removed_keeper_msg_input_keys :
   tool_name:string -> Yojson.Safe.t -> (unit, string) result
 val utf8_repair_string : string -> string
 val normalize_prompt_text : max_bytes:int -> string -> string
-val keeper_bootstrap_proactive_warmup_sec : unit -> int
-val keeper_bootstrap_stagger_step_sec : unit -> int
 val keeper_bootstrap_retry_interval_sec : unit -> int
 val keeper_batch_limit : unit -> int
 val keeper_unified_temperature : unit -> float

--- a/lib/keeper/keeper_types_profile_toml_normalizers.mli
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.mli
@@ -23,8 +23,6 @@ val reject_removed_keeper_msg_input_keys :
   tool_name:string -> Yojson.Safe.t -> (unit, string) result
 val utf8_repair_string : string -> string
 val normalize_prompt_text : max_bytes:int -> string -> string
-val keeper_bootstrap_proactive_warmup_sec : unit -> int
-val keeper_bootstrap_stagger_step_sec : unit -> int
 val keeper_bootstrap_retry_interval_sec : unit -> int
 val keeper_batch_limit : unit -> int
 val keeper_unified_temperature : unit -> float

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -23,8 +23,6 @@ val reject_removed_keeper_msg_input_keys :
   tool_name:string -> Yojson.Safe.t -> (unit, string) result
 val utf8_repair_string : string -> string
 val normalize_prompt_text : max_bytes:int -> string -> string
-val keeper_bootstrap_proactive_warmup_sec : unit -> int
-val keeper_bootstrap_stagger_step_sec : unit -> int
 val keeper_bootstrap_retry_interval_sec : unit -> int
 val keeper_batch_limit : unit -> int
 val keeper_unified_temperature : unit -> float

--- a/lib/keeper/keeper_unified_metrics_result.ml
+++ b/lib/keeper/keeper_unified_metrics_result.ml
@@ -179,6 +179,13 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
              then rt.proactive_rt.consecutive_noop_count + 1
              else 0
            else rt.proactive_rt.consecutive_noop_count);
+        (* RFC-0357 §3.3: pass-through, deliberately not stamped here. The
+           consumption record is written in-memory at admission (heartbeat
+           loop) so a failed turn keeps it; this post-turn write only makes
+           it durable. Reactive cycles flow through unchanged — they never
+           consume the backlog edge. *)
+        last_consumed_backlog_revision =
+          rt.proactive_rt.last_consumed_backlog_revision;
       };
       (* Autonomous action tracking from tool calls *)
       autonomous_action_count =

--- a/lib/keeper/keeper_unified_metrics_result.ml
+++ b/lib/keeper/keeper_unified_metrics_result.ml
@@ -186,6 +186,8 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
            consume the backlog edge. *)
         last_consumed_backlog_revision =
           rt.proactive_rt.last_consumed_backlog_revision;
+        last_consumed_backlog_projection_sha256 =
+          rt.proactive_rt.last_consumed_backlog_projection_sha256;
       };
       (* Autonomous action tracking from tool calls *)
       autonomous_action_count =

--- a/lib/keeper/keeper_unified_metrics_snapshot.ml
+++ b/lib/keeper/keeper_unified_metrics_snapshot.ml
@@ -94,6 +94,18 @@ let append_metrics_snapshot ~(config : Workspace.config) ~(meta : keeper_meta)
         ("ts", `String (now_iso ()));
         ("ts_unix", `Float now_ts);
         ("channel", `String (Keeper_world_observation.channel_to_string channel));
+        ( "backlog_source",
+          `String
+            (Keeper_world_observation_inputs.backlog_observation_source_to_string
+               observation.backlog_source) );
+        ( "backlog_revision",
+          match observation.backlog_revision with
+          | Some revision -> `Int revision
+          | None -> `Null );
+        ( "backlog_projection_sha256",
+          match observation.backlog_projection_sha256 with
+          | Some projection -> `String projection
+          | None -> `Null );
         ("name", `String meta.name);
         ("agent_name", `String meta.agent_name);
         ("trace_id", `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id));

--- a/lib/keeper/keeper_unified_metrics_snapshot.ml
+++ b/lib/keeper/keeper_unified_metrics_snapshot.ml
@@ -94,18 +94,10 @@ let append_metrics_snapshot ~(config : Workspace.config) ~(meta : keeper_meta)
         ("ts", `String (now_iso ()));
         ("ts_unix", `Float now_ts);
         ("channel", `String (Keeper_world_observation.channel_to_string channel));
-        ( "backlog_source",
+        ( "backlog_edge",
           `String
-            (Keeper_world_observation_inputs.backlog_observation_source_to_string
-               observation.backlog_source) );
-        ( "backlog_revision",
-          match observation.backlog_revision with
-          | Some revision -> `Int revision
-          | None -> `Null );
-        ( "backlog_projection_sha256",
-          match observation.backlog_projection_sha256 with
-          | Some projection -> `String projection
-          | None -> `Null );
+            (Keeper_world_observation_inputs.backlog_edge_observation_to_string
+               observation.backlog_edge) );
         ("name", `String meta.name);
         ("agent_name", `String meta.agent_name);
         ("trace_id", `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id));

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -708,11 +708,11 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path
     (* 3. Namespace state — usually lower churn than inbox/board detail. *)
     | Keeper_context_layers.Namespace_state ->
       let backlog_source =
-        match observation.backlog_source with
-        | Keeper_world_observation_inputs.Primary -> None
+        match observation.backlog_edge with
+        | Keeper_world_observation_inputs.Observed_backlog _ -> None
         | source ->
           Some
-            (Keeper_world_observation_inputs.backlog_observation_source_to_string
+            (Keeper_world_observation_inputs.backlog_edge_observation_to_string
                source)
       in
       if

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -707,12 +707,21 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path
       else None
     (* 3. Namespace state — usually lower churn than inbox/board detail. *)
     | Keeper_context_layers.Namespace_state ->
+      let backlog_source =
+        match observation.backlog_source with
+        | Keeper_world_observation_inputs.Primary -> None
+        | source ->
+          Some
+            (Keeper_world_observation_inputs.backlog_observation_source_to_string
+               source)
+      in
       if
         observation.unclaimed_task_count > 0
         || observation.claimable_task_count > 0
         || observation.failed_task_count > 0
         || Option.is_none observation.backlog_revision
         || observation.running_keeper_fiber_count > 0
+        || Option.is_some backlog_source
       then (
         let ubuf = Buffer.create 256 in
         Buffer.add_string ubuf "### Namespace State\n";
@@ -747,6 +756,11 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path
             (Printf.sprintf
                "- Failed tasks: %d\n"
                observation.failed_task_count);
+        Option.iter
+          (fun source ->
+             Buffer.add_string ubuf
+               (Printf.sprintf "- Backlog observation source: %s\n" source))
+          backlog_source;
         Buffer.add_string ubuf
           (Printf.sprintf
              "- Running keeper fibers: %d\n"

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -710,7 +710,8 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path
       let backlog_source =
         match observation.backlog_edge with
         | Keeper_world_observation_inputs.Observed_backlog _ -> None
-        | source ->
+        | (Keeper_world_observation_inputs.Backlog_read_unavailable _ as source)
+        | (Keeper_world_observation_inputs.Recovery_backlog _ as source) ->
           Some
             (Keeper_world_observation_inputs.backlog_edge_observation_to_string
                source)

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -580,7 +580,8 @@ let active_goal_summaries
     meta.active_goal_ids
 ;;
 
-let build_system_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string)
+let build_system_prompt ~(meta : Keeper_meta_contract.keeper_meta)
+    ~(config : Workspace.config)
     ?(profile_defaults : Keeper_types_profile.keeper_profile_defaults option)
     ?(active_goal_summaries : (string * string) list option)
     ()
@@ -597,7 +598,6 @@ let build_system_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path :
       ~default:(List.map (fun goal_id -> (goal_id, "")) meta.active_goal_ids)
       active_goal_summaries
   in
-  let config = Workspace.default_config base_path in
   let base_system_prompt =
     Keeper_prompt.build_keeper_system_prompt
       ~instructions
@@ -614,7 +614,8 @@ let build_system_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path :
   system_prompt
 ;;
 
-let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string)
+let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta)
+    ~(config : Workspace.config)
     ?(profile_defaults : Keeper_types_profile.keeper_profile_defaults option)
     ~(turn_decision : Keeper_world_observation.keeper_cycle_decision option)
     ~(current_task : Keeper_world_observation_inputs.current_task_observation)
@@ -625,7 +626,7 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path
   let system_prompt =
     build_system_prompt
       ~meta
-      ~base_path
+      ~config
       ?profile_defaults
       ?active_goal_summaries
       ()
@@ -898,7 +899,7 @@ let emit_prompt_metrics
 
 let build_prompt
       ~meta
-      ~base_path
+      ~config
       ?profile_defaults
       ~turn_decision
       ~current_task
@@ -909,7 +910,7 @@ let build_prompt
   let prompt =
     build_prompt_internal
       ~meta
-      ~base_path
+      ~config
       ?profile_defaults
       ~turn_decision:(Some turn_decision)
       ~current_task
@@ -923,7 +924,7 @@ let build_prompt
 
 let build_prompt_preview
       ~meta
-      ~base_path
+      ~config
       ?profile_defaults
       ~current_task
       ?active_goal_summaries
@@ -932,7 +933,7 @@ let build_prompt_preview
   =
   build_prompt_internal
     ~meta
-    ~base_path
+    ~config
     ?profile_defaults
     ~turn_decision:None
     ~current_task

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -719,13 +719,12 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path
         observation.unclaimed_task_count > 0
         || observation.claimable_task_count > 0
         || observation.failed_task_count > 0
-        || Option.is_none observation.backlog_revision
         || observation.running_keeper_fiber_count > 0
         || Option.is_some backlog_source
       then (
         let ubuf = Buffer.create 256 in
         Buffer.add_string ubuf "### Namespace State\n";
-        if Option.is_none observation.backlog_revision then
+        if Option.is_some backlog_source then
           Buffer.add_string ubuf
             "- Task backlog: unavailable or recovery-only; task counts are non-authoritative and cannot drive task actions.\n";
         if observation.unclaimed_task_count > 0 then

--- a/lib/keeper/keeper_unified_prompt.mli
+++ b/lib/keeper/keeper_unified_prompt.mli
@@ -62,7 +62,7 @@ val active_goal_summaries :
 
 val build_system_prompt :
   meta:Keeper_meta_contract.keeper_meta ->
-  base_path:string ->
+  config:Workspace.config ->
   ?profile_defaults:Keeper_types_profile.keeper_profile_defaults ->
   ?active_goal_summaries:(string * string) list ->
   unit ->
@@ -77,7 +77,7 @@ val build_system_prompt :
     @param observation Current world snapshot *)
 val build_prompt :
   meta:Keeper_meta_contract.keeper_meta ->
-  base_path:string ->
+  config:Workspace.config ->
   ?profile_defaults:Keeper_types_profile.keeper_profile_defaults ->
   turn_decision:Keeper_world_observation.keeper_cycle_decision ->
   current_task:Keeper_world_observation_inputs.current_task_observation ->
@@ -99,7 +99,7 @@ val build_prompt :
 
 val build_prompt_preview :
   meta:Keeper_meta_contract.keeper_meta ->
-  base_path:string ->
+  config:Workspace.config ->
   ?profile_defaults:Keeper_types_profile.keeper_profile_defaults ->
   current_task:Keeper_world_observation_inputs.current_task_observation ->
   ?active_goal_summaries:(string * string) list ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -539,7 +539,7 @@ let run_keeper_cycle
                let { Keeper_unified_prompt.system_prompt; world_state; user_message } =
                  Keeper_unified_prompt.build_prompt
                    ~meta
-                   ~base_path:config.base_path
+                   ~config
                    ~profile_defaults
                    ~turn_decision
                    ~current_task

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -1277,7 +1277,6 @@ let has_pending_completion_authority_rejection
 ;;
 
 let keeper_cycle_decision
-      ?(reactive_wake = false)
       ?(event_queue_triggers = [])
       ~(meta : keeper_meta)
       (observation : world_observation)
@@ -1393,7 +1392,6 @@ let keeper_cycle_decision
            | Keeper_world_observation_inputs.Observed_backlog
                { updated_since_last_scheduled_autonomous; _ } ->
              updated_since_last_scheduled_autonomous)
-          && not reactive_wake
         in
         let has_actionable_schedule =
           observation.scheduled_automation.due_ready_count > 0

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -177,6 +177,7 @@ type skip_reason = Keeper_world_observation_turn_types.skip_reason =
   | Scheduled_autonomous_disabled
   | Reactive_disabled
   | No_actionable_stimulus
+  | Backlog_unreadable
 
 type turn_verdict = Keeper_world_observation_turn_types.turn_verdict =
   | Run of { reasons : turn_reason * turn_reason list }
@@ -1364,8 +1365,14 @@ let keeper_cycle_decision
            observations for the model but no longer admit — a level
            re-admits every heartbeat until the pool empties even after the
            model judged the work not actionable (live: 86% empty turns,
-           #26487's 96 stuck claimables). All-false is a typed skip
-           ([No_actionable_stimulus]), a record of designed silence. *)
+           #26487's 96 stuck claimables). All-false is a typed skip:
+           [No_actionable_stimulus] when the backlog was actually read
+           (designed silence), [Backlog_unreadable] when it was not — a
+           read failure must not be recorded as a considered "nothing to
+           do". Claimable work older than the last consumed revision does
+           not re-admit by itself; any backlog mutation bumps the revision
+           and re-admits (the level→edge contract, documented on
+           [skip_reason] in the .mli). *)
         let is_bootstrap = since_last_scheduled_autonomous = max_int in
         let has_pending_messages = observation.pending_messages <> [] in
         let has_pending_board_events = observation.pending_board_events <> [] in
@@ -1376,8 +1383,14 @@ let keeper_cycle_decision
         let has_actionable_schedule =
           observation.scheduled_automation.due_ready_count > 0
         in
+        (* The reason list IS the admission predicate: an empty list is the
+           only skip path, so a stimulus cannot admit namelessly and a new
+           disjunct cannot be added without naming its reason — the predicate
+           and its explanation can no longer drift apart. *)
         let run_reasons =
           [ (if is_bootstrap then Some Never_started else None)
+          ; (if has_pending_messages then Some Scope_message_pending else None)
+          ; (if has_pending_board_events then Some Board_event_pending else None)
           ; (if has_backlog_edge
              then
                Some
@@ -1390,21 +1403,27 @@ let keeper_cycle_decision
           ]
           |> List.filter_map Fun.id
         in
-        if is_bootstrap
-           || has_pending_messages
-           || has_pending_board_events
-           || has_backlog_edge
-           || has_actionable_schedule
-        then
+        match run_reasons with
+        | first :: rest ->
           { should_run = true
           ; channel = Scheduled_autonomous
-          ; verdict = Run { reasons = Scheduled_autonomous_turn, run_reasons }
+          ; verdict = Run { reasons = Scheduled_autonomous_turn, first :: rest }
           ; since_last_scheduled_autonomous = Some since_last_scheduled_autonomous
           }
-        else
+        | [] ->
+          (* All disjuncts false. Distinguish designed silence from a blind
+             observation: no observed revision means the backlog read failed,
+             so the edge disjunct had no real input — recording that as
+             [No_actionable_stimulus] would present a read failure as a
+             considered "nothing to do". *)
+          let skip_reason =
+            match observation.backlog_revision with
+            | None -> Backlog_unreadable
+            | Some _ -> No_actionable_stimulus
+          in
           { should_run = false
           ; channel = Scheduled_autonomous
-          ; verdict = Skip { reasons = No_actionable_stimulus, [] }
+          ; verdict = Skip { reasons = skip_reason, [] }
           ; since_last_scheduled_autonomous = Some since_last_scheduled_autonomous
           })
     in

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -128,6 +128,13 @@ type world_observation =
   ; scheduled_automation : scheduled_automation_observation
   ; backlog_updated_since_last_scheduled_autonomous : bool
   ; backlog_revision : int option
+    (** RFC-0357 §3.3: the backlog commit revision this observation saw —
+        what a scheduled-autonomous admission records as consumed. [None]
+        when the backlog read failed: the edge is false and the consumption
+        clock must not move on a fabricated value. *)
+  ; backlog_projection_sha256 : string option
+    (** Exact derived projection paired with [backlog_revision]. [None] on the
+        same failed-read path. *)
   ; running_keeper_fiber_count : int
   ; connected_surfaces : Gate_surface.surface_presence list
   ; connected_surface_failures : Gate_surface.presence_failure list
@@ -169,6 +176,7 @@ type skip_reason = Keeper_world_observation_turn_types.skip_reason =
   | Keeper_paused
   | Scheduled_autonomous_disabled
   | Reactive_disabled
+  | No_actionable_stimulus
 
 type turn_verdict = Keeper_world_observation_turn_types.turn_verdict =
   | Run of { reasons : turn_reason * turn_reason list }
@@ -1146,7 +1154,8 @@ let observe
       , claimable_task_count
       , failed_task_count
       , backlog_updated_since_last_scheduled_autonomous
-      , backlog_revision )
+      , backlog_revision
+      , backlog_projection_sha256 )
     =
     read_backlog_counts ~config ~meta
   in
@@ -1180,6 +1189,7 @@ let observe
   ; scheduled_automation
   ; backlog_updated_since_last_scheduled_autonomous
   ; backlog_revision
+  ; backlog_projection_sha256
   ; running_keeper_fiber_count
   ; connected_surfaces = surface_presence.surfaces
   ; connected_surface_failures = surface_presence.failures
@@ -1194,7 +1204,8 @@ let observe_direct_keeper_msg ~(config : Workspace.config) ~(meta : keeper_meta)
       , claimable_task_count
       , failed_task_count
       , backlog_updated_since_last_scheduled_autonomous
-      , backlog_revision )
+      , backlog_revision
+      , backlog_projection_sha256 )
     =
     read_backlog_counts ~config ~meta
   in
@@ -1217,6 +1228,7 @@ let observe_direct_keeper_msg ~(config : Workspace.config) ~(meta : keeper_meta)
   ; scheduled_automation
   ; backlog_updated_since_last_scheduled_autonomous
   ; backlog_revision
+  ; backlog_projection_sha256
   ; running_keeper_fiber_count = count_running_keeper_fibers ~config
   ; connected_surfaces = surface_presence.surfaces
   ; connected_surface_failures = surface_presence.failures
@@ -1270,7 +1282,6 @@ let keeper_cycle_decision
   let proactive_gate_enabled =
     Keeper_lifecycle_gate_env.enabled Keeper_lifecycle_gate.Proactive meta
   in
-  let _ = reactive_wake in
   let event_queue_reactive_triggers =
     List.map turn_reason_of_event_queue_trigger event_queue_triggers
   in
@@ -1346,20 +1357,28 @@ let keeper_cycle_decision
         ; since_last_scheduled_autonomous = Some since_last_scheduled_autonomous
         }
       else (
-        (* A scheduled heartbeat is itself the wake signal. Backlog, schedule,
-           idle time, and previous-turn age remain observations for the model;
-           fixed local thresholds never suppress a Keeper cycle. *)
-        let has_actionable_tasks =
-          claimable_drives_wake observation.claimable_task_count
-          || failed_drives_wake observation.failed_task_count
+        (* RFC-0357 §3.1: a scheduled heartbeat is a clock tick, not a wake
+           signal. The channel admits only on a typed stimulus: bootstrap,
+           an unhandled message or board event, a backlog revision edge, or
+           a due schedule. Pool levels (claimable/failed counts) remain
+           observations for the model but no longer admit — a level
+           re-admits every heartbeat until the pool empties even after the
+           model judged the work not actionable (live: 86% empty turns,
+           #26487's 96 stuck claimables). All-false is a typed skip
+           ([No_actionable_stimulus]), a record of designed silence. *)
+        let is_bootstrap = since_last_scheduled_autonomous = max_int in
+        let has_pending_messages = observation.pending_messages <> [] in
+        let has_pending_board_events = observation.pending_board_events <> [] in
+        let has_backlog_edge =
+          observation.backlog_updated_since_last_scheduled_autonomous
+          && not reactive_wake
         in
         let has_actionable_schedule =
           observation.scheduled_automation.due_ready_count > 0
         in
-        let is_bootstrap = since_last_scheduled_autonomous = max_int in
         let run_reasons =
           [ (if is_bootstrap then Some Never_started else None)
-          ; (if has_actionable_tasks
+          ; (if has_backlog_edge
              then
                Some
                  (Task_backlog
@@ -1371,11 +1390,23 @@ let keeper_cycle_decision
           ]
           |> List.filter_map Fun.id
         in
-        { should_run = true
-        ; channel = Scheduled_autonomous
-        ; verdict = Run { reasons = Scheduled_autonomous_turn, run_reasons }
-        ; since_last_scheduled_autonomous = Some since_last_scheduled_autonomous
-        })
+        if is_bootstrap
+           || has_pending_messages
+           || has_pending_board_events
+           || has_backlog_edge
+           || has_actionable_schedule
+        then
+          { should_run = true
+          ; channel = Scheduled_autonomous
+          ; verdict = Run { reasons = Scheduled_autonomous_turn, run_reasons }
+          ; since_last_scheduled_autonomous = Some since_last_scheduled_autonomous
+          }
+        else
+          { should_run = false
+          ; channel = Scheduled_autonomous
+          ; verdict = Skip { reasons = No_actionable_stimulus, [] }
+          ; since_last_scheduled_autonomous = Some since_last_scheduled_autonomous
+          })
     in
     match reactive_triggers with
     | first :: rest when reactive_gate_enabled ->

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -146,6 +146,33 @@ type keeper_cycle_channel =
   | Reactive
   | Scheduled_autonomous
 
+type backlog_consumption_error = Incomplete_backlog_observation
+
+let record_scheduled_backlog_consumption
+      ~(meta : keeper_meta)
+      (observation : world_observation)
+  =
+  match observation.backlog_revision, observation.backlog_projection_sha256 with
+  | None, None -> Ok meta
+  | Some observed, Some projection_sha256 ->
+    let proactive_rt = meta.runtime.proactive_rt in
+    if observed > proactive_rt.last_consumed_backlog_revision
+    then
+      Ok
+        { meta with
+          runtime =
+            { meta.runtime with
+              proactive_rt =
+                { proactive_rt with
+                  last_consumed_backlog_revision = observed
+                ; last_consumed_backlog_projection_sha256 = projection_sha256
+                }
+            }
+        }
+    else Ok meta
+  | None, Some _ | Some _, None -> Error Incomplete_backlog_observation
+;;
+
 type event_queue_trigger =
   Keeper_world_observation_turn_types.event_queue_trigger =
   | Bootstrap_stimulus

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -126,20 +126,7 @@ type world_observation =
   ; claimable_task_count : int
   ; failed_task_count : int
   ; scheduled_automation : scheduled_automation_observation
-  ; backlog_updated_since_last_scheduled_autonomous : bool
-  ; backlog_revision : int option
-    (** RFC-0357 §3.3: the backlog commit revision this observation saw —
-        what a scheduled-autonomous admission records as consumed. [None]
-        when the primary backlog was unavailable or only a recovery snapshot
-        was readable: the edge is false and the consumption clock must not
-        move on a non-authoritative value. *)
-  ; backlog_projection_sha256 : string option
-    (** Exact derived projection paired with [backlog_revision]. [None] when
-        the primary backlog was unavailable or only recovery was readable. *)
-  ; backlog_source : Keeper_world_observation_inputs.backlog_observation_source
-    (** Provenance of the backlog facts. Recovery data remains visible as
-        read-only observation but cannot become an authoritative edge; an
-        unavailable source is explicit rather than an empty-backlog inference. *)
+  ; backlog_edge : Keeper_world_observation_inputs.backlog_edge_observation
   ; running_keeper_fiber_count : int
   ; connected_surfaces : Gate_surface.surface_presence list
   ; connected_surface_failures : Gate_surface.presence_failure list
@@ -151,31 +138,30 @@ type keeper_cycle_channel =
   | Reactive
   | Scheduled_autonomous
 
-type backlog_consumption_error = Incomplete_backlog_observation
-
 let record_scheduled_backlog_consumption
       ~(meta : keeper_meta)
       (observation : world_observation)
   =
-  match observation.backlog_revision, observation.backlog_projection_sha256 with
-  | None, None -> Ok meta
-  | Some observed, Some projection_sha256 ->
+  match observation.backlog_edge with
+  | Keeper_world_observation_inputs.Backlog_read_unavailable _
+  | Keeper_world_observation_inputs.Recovery_backlog _ ->
+    meta
+  | Keeper_world_observation_inputs.Observed_backlog
+      { revision = observed; projection_sha256; _ } ->
     let proactive_rt = meta.runtime.proactive_rt in
     if observed > proactive_rt.last_consumed_backlog_revision
     then
-      Ok
-        { meta with
-          runtime =
-            { meta.runtime with
-              proactive_rt =
-                { proactive_rt with
-                  last_consumed_backlog_revision = observed
-                ; last_consumed_backlog_projection_sha256 = projection_sha256
-                }
-            }
-        }
-    else Ok meta
-  | None, Some _ | Some _, None -> Error Incomplete_backlog_observation
+      { meta with
+        runtime =
+          { meta.runtime with
+            proactive_rt =
+              { proactive_rt with
+                last_consumed_backlog_revision = observed
+              ; last_consumed_backlog_projection_sha256 = projection_sha256
+              }
+          }
+      }
+    else meta
 ;;
 
 type event_queue_trigger =
@@ -1186,10 +1172,7 @@ let observe
   let ( unclaimed_task_count
       , claimable_task_count
       , failed_task_count
-      , backlog_updated_since_last_scheduled_autonomous
-      , backlog_revision
-      , backlog_projection_sha256
-      , backlog_source )
+      , backlog_edge )
     =
     read_backlog_counts ~config ~meta
   in
@@ -1221,10 +1204,7 @@ let observe
   ; claimable_task_count
   ; failed_task_count
   ; scheduled_automation
-  ; backlog_updated_since_last_scheduled_autonomous
-  ; backlog_revision
-  ; backlog_projection_sha256
-  ; backlog_source
+  ; backlog_edge
   ; running_keeper_fiber_count
   ; connected_surfaces = surface_presence.surfaces
   ; connected_surface_failures = surface_presence.failures
@@ -1238,10 +1218,7 @@ let observe_direct_keeper_msg ~(config : Workspace.config) ~(meta : keeper_meta)
   let ( unclaimed_task_count
       , claimable_task_count
       , failed_task_count
-      , backlog_updated_since_last_scheduled_autonomous
-      , backlog_revision
-      , backlog_projection_sha256
-      , backlog_source )
+      , backlog_edge )
     =
     read_backlog_counts ~config ~meta
   in
@@ -1262,10 +1239,7 @@ let observe_direct_keeper_msg ~(config : Workspace.config) ~(meta : keeper_meta)
   ; claimable_task_count
   ; failed_task_count
   ; scheduled_automation
-  ; backlog_updated_since_last_scheduled_autonomous
-  ; backlog_revision
-  ; backlog_projection_sha256
-  ; backlog_source
+  ; backlog_edge
   ; running_keeper_fiber_count = count_running_keeper_fibers ~config
   ; connected_surfaces = surface_presence.surfaces
   ; connected_surface_failures = surface_presence.failures
@@ -1413,7 +1387,12 @@ let keeper_cycle_decision
         let has_pending_messages = observation.pending_messages <> [] in
         let has_pending_board_events = observation.pending_board_events <> [] in
         let has_backlog_edge =
-          observation.backlog_updated_since_last_scheduled_autonomous
+          (match observation.backlog_edge with
+           | Keeper_world_observation_inputs.Backlog_read_unavailable _
+           | Keeper_world_observation_inputs.Recovery_backlog _ -> false
+           | Keeper_world_observation_inputs.Observed_backlog
+               { updated_since_last_scheduled_autonomous; _ } ->
+             updated_since_last_scheduled_autonomous)
           && not reactive_wake
         in
         let has_actionable_schedule =
@@ -1453,9 +1432,12 @@ let keeper_cycle_decision
              [No_actionable_stimulus] would present a read failure as a
              considered "nothing to do". *)
           let skip_reason =
-            match observation.backlog_revision with
-            | None -> Backlog_unreadable
-            | Some _ -> No_actionable_stimulus
+            match observation.backlog_edge with
+            | Keeper_world_observation_inputs.Backlog_read_unavailable _
+            | Keeper_world_observation_inputs.Recovery_backlog _ ->
+              Backlog_unreadable
+            | Keeper_world_observation_inputs.Observed_backlog _ ->
+              No_actionable_stimulus
           in
           { should_run = false
           ; channel = Scheduled_autonomous

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -130,11 +130,16 @@ type world_observation =
   ; backlog_revision : int option
     (** RFC-0357 §3.3: the backlog commit revision this observation saw —
         what a scheduled-autonomous admission records as consumed. [None]
-        when the backlog read failed: the edge is false and the consumption
-        clock must not move on a fabricated value. *)
+        when the primary backlog was unavailable or only a recovery snapshot
+        was readable: the edge is false and the consumption clock must not
+        move on a non-authoritative value. *)
   ; backlog_projection_sha256 : string option
-    (** Exact derived projection paired with [backlog_revision]. [None] on the
-        same failed-read path. *)
+    (** Exact derived projection paired with [backlog_revision]. [None] when
+        the primary backlog was unavailable or only recovery was readable. *)
+  ; backlog_source : Keeper_world_observation_inputs.backlog_observation_source
+    (** Provenance of the backlog facts. Recovery data remains visible as
+        read-only observation but cannot become an authoritative edge; an
+        unavailable source is explicit rather than an empty-backlog inference. *)
   ; running_keeper_fiber_count : int
   ; connected_surfaces : Gate_surface.surface_presence list
   ; connected_surface_failures : Gate_surface.presence_failure list
@@ -1183,7 +1188,8 @@ let observe
       , failed_task_count
       , backlog_updated_since_last_scheduled_autonomous
       , backlog_revision
-      , backlog_projection_sha256 )
+      , backlog_projection_sha256
+      , backlog_source )
     =
     read_backlog_counts ~config ~meta
   in
@@ -1218,6 +1224,7 @@ let observe
   ; backlog_updated_since_last_scheduled_autonomous
   ; backlog_revision
   ; backlog_projection_sha256
+  ; backlog_source
   ; running_keeper_fiber_count
   ; connected_surfaces = surface_presence.surfaces
   ; connected_surface_failures = surface_presence.failures
@@ -1233,7 +1240,8 @@ let observe_direct_keeper_msg ~(config : Workspace.config) ~(meta : keeper_meta)
       , failed_task_count
       , backlog_updated_since_last_scheduled_autonomous
       , backlog_revision
-      , backlog_projection_sha256 )
+      , backlog_projection_sha256
+      , backlog_source )
     =
     read_backlog_counts ~config ~meta
   in
@@ -1257,6 +1265,7 @@ let observe_direct_keeper_msg ~(config : Workspace.config) ~(meta : keeper_meta)
   ; backlog_updated_since_last_scheduled_autonomous
   ; backlog_revision
   ; backlog_projection_sha256
+  ; backlog_source
   ; running_keeper_fiber_count = count_running_keeper_fibers ~config
   ; connected_surfaces = surface_presence.surfaces
   ; connected_surface_failures = surface_presence.failures

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -377,14 +377,10 @@ val actionable_signal_present : world_observation -> bool
 val has_pending_board_activity : world_observation -> bool
 
 val keeper_cycle_decision :
-  ?reactive_wake:bool ->
   ?event_queue_triggers:event_queue_trigger list ->
   meta:Keeper_meta_contract.keeper_meta -> world_observation -> keeper_cycle_decision
-(** [reactive_wake] (default [false]) marks evaluations triggered by an external
-    broadcast wakeup rather than the keeper's own cadence timer. When set, a
-    GLOBAL task backlog alone does not drive a turn — this prevents the
-    all-keeper stampede on each task release/add. Per-keeper Reactive triggers
-    and time-based liveness reasons are unaffected. *)
+(** External wake attribution is carried by the keepalive wake reason; it does
+    not alter cycle admission. *)
 
 val should_run_keeper_cycle :
   meta:Keeper_meta_contract.keeper_meta -> world_observation -> bool

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -135,17 +135,20 @@ type world_observation = {
       requests ready to dispatch. *)
 
   backlog_updated_since_last_scheduled_autonomous : bool;
-  (** RFC-0357 §3.2 backlog edge:
-      [backlog.version > proactive_rt.last_consumed_backlog_revision].
-      True exactly when the backlog has a commit this keeper's scheduled
-      channel has not consumed yet. This is an admission input — one turn per
-      backlog change, zero turns for a static backlog. *)
+  (** RFC-0357 §3.2 backlog edge: the commit revision advances and the exact
+      non-self-authored task projection differs from the paired consumed
+      projection. This is one turn per relevant change, zero turns for static
+      or self-produced Todo-only changes. *)
 
   backlog_revision : int option;
   (** The backlog commit revision this observation saw — what a
       scheduled-autonomous admission records as consumed (RFC-0357 §3.3).
       [None] when the backlog read failed: the edge is false and the
       consumption clock must not move on a fabricated value. *)
+
+  backlog_projection_sha256 : string option;
+  (** Exact non-self-authored task projection paired with [backlog_revision].
+      [None] on the same failed-read path. *)
 
   backlog_revision : int option;
   (** The backlog commit revision observed through the recovery-backed read.
@@ -177,6 +180,17 @@ type world_observation = {
 type keeper_cycle_channel =
   | Reactive
   | Scheduled_autonomous
+
+type backlog_consumption_error = Incomplete_backlog_observation
+
+val record_scheduled_backlog_consumption
+  :  meta:Keeper_meta_contract.keeper_meta
+  -> world_observation
+  -> (Keeper_meta_contract.keeper_meta, backlog_consumption_error) result
+(** Record an actually-observed revision/projection pair at scheduled-turn
+    admission. [None, None] is an unreadable observation and leaves meta
+    unchanged; a partial pair is a typed invariant error. Reactive channels
+    must not call this function. *)
 
 type event_queue_trigger =
   | Bootstrap_stimulus

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -150,12 +150,6 @@ type world_observation = {
   (** Exact non-self-authored task projection paired with [backlog_revision].
       [None] on the same failed-read path. *)
 
-  backlog_revision : int option;
-  (** The backlog commit revision observed through the recovery-backed read.
-      [None] means neither primary nor recovery was a valid current backlog;
-      callers must not interpret the accompanying zero counts as an observed
-      empty backlog. *)
-
   running_keeper_fiber_count : int;
   (** Number of live keeper fibers for this workspace base path. *)
 

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -210,7 +210,16 @@ type skip_reason =
   | No_actionable_stimulus
       (** RFC-0357 §3.1: gate on, but no typed stimulus — no pending
           message/board event, no backlog revision edge, no due schedule,
-          already bootstrapped. Designed silence, recorded as a skip. *)
+          already bootstrapped. Designed silence, recorded as a skip.
+
+          A stimulus this predicate does not cover: claimable work that
+          predates the last consumed revision. That is the level→edge
+          contract — work nobody touches does not re-admit the keeper every
+          tick; any mutation (claim, add, verdict) bumps the backlog revision
+          and re-admits. *)
+  | Backlog_unreadable
+      (** RFC-0357: gate on, no other stimulus, and the backlog read failed —
+          the edge disjunct had no real input. Not designed silence. *)
 
 (** Keeper cycle decision with non-empty reason list (NEL).
     [Run] guarantees at least one trigger reason.

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -143,12 +143,19 @@ type world_observation = {
   backlog_revision : int option;
   (** The backlog commit revision this observation saw — what a
       scheduled-autonomous admission records as consumed (RFC-0357 §3.3).
-      [None] when the backlog read failed: the edge is false and the
-      consumption clock must not move on a fabricated value. *)
+      [None] when the primary backlog was unavailable or only a recovery
+      snapshot was readable: the edge is false and the consumption clock must
+      not move on a non-authoritative value. *)
 
   backlog_projection_sha256 : string option;
   (** Exact non-self-authored task projection paired with [backlog_revision].
-      [None] on the same failed-read path. *)
+      [None] when the primary backlog was unavailable or only recovery was
+      readable. *)
+
+  backlog_source : Keeper_world_observation_inputs.backlog_observation_source;
+  (** Provenance of the backlog facts. Recovery data remains visible as
+      read-only observation but cannot become an authoritative edge; an
+      unavailable source is explicit rather than an empty-backlog inference. *)
 
   running_keeper_fiber_count : int;
   (** Number of live keeper fibers for this workspace base path. *)

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -135,9 +135,17 @@ type world_observation = {
       requests ready to dispatch. *)
 
   backlog_updated_since_last_scheduled_autonomous : bool;
-  (** [true] when the backlog changed after the keeper's last scheduled
-      autonomous attempt. Lets task-triggered wakeups bypass cooldown once
-      so newly added work is not delayed behind the previous turn's timer. *)
+  (** RFC-0357 §3.2 backlog edge:
+      [backlog.version > proactive_rt.last_consumed_backlog_revision].
+      True exactly when the backlog has a commit this keeper's scheduled
+      channel has not consumed yet. This is an admission input — one turn per
+      backlog change, zero turns for a static backlog. *)
+
+  backlog_revision : int option;
+  (** The backlog commit revision this observation saw — what a
+      scheduled-autonomous admission records as consumed (RFC-0357 §3.3).
+      [None] when the backlog read failed: the edge is false and the
+      consumption clock must not move on a fabricated value. *)
 
   backlog_revision : int option;
   (** The backlog commit revision observed through the recovery-backed read.
@@ -199,6 +207,10 @@ type skip_reason =
   | Keeper_paused
   | Scheduled_autonomous_disabled
   | Reactive_disabled
+  | No_actionable_stimulus
+      (** RFC-0357 §3.1: gate on, but no typed stimulus — no pending
+          message/board event, no backlog revision edge, no due schedule,
+          already bootstrapped. Designed silence, recorded as a skip. *)
 
 (** Keeper cycle decision with non-empty reason list (NEL).
     [Run] guarantees at least one trigger reason.

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -134,28 +134,10 @@ type world_observation = {
   (** Durable schedule-store state that needs keeper attention, such as due
       requests ready to dispatch. *)
 
-  backlog_updated_since_last_scheduled_autonomous : bool;
-  (** RFC-0357 §3.2 backlog edge: the commit revision advances and the exact
-      non-self-authored task projection differs from the paired consumed
-      projection. This is one turn per relevant change, zero turns for static
-      or self-produced Todo-only changes. *)
-
-  backlog_revision : int option;
-  (** The backlog commit revision this observation saw — what a
-      scheduled-autonomous admission records as consumed (RFC-0357 §3.3).
-      [None] when the primary backlog was unavailable or only a recovery
-      snapshot was readable: the edge is false and the consumption clock must
-      not move on a non-authoritative value. *)
-
-  backlog_projection_sha256 : string option;
-  (** Exact non-self-authored task projection paired with [backlog_revision].
-      [None] when the primary backlog was unavailable or only recovery was
-      readable. *)
-
-  backlog_source : Keeper_world_observation_inputs.backlog_observation_source;
-  (** Provenance of the backlog facts. Recovery data remains visible as
-      read-only observation but cannot become an authoritative edge; an
-      unavailable source is explicit rather than an empty-backlog inference. *)
+  backlog_edge : Keeper_world_observation_inputs.backlog_edge_observation;
+  (** RFC-0357 §3.2/§3.3 backlog observation. A successful read carries one
+      inseparable revision/projection/edge value; a failed read cannot form a
+      partial pair or advance the consumption clock. *)
 
   running_keeper_fiber_count : int;
   (** Number of live keeper fibers for this workspace base path. *)
@@ -182,16 +164,13 @@ type keeper_cycle_channel =
   | Reactive
   | Scheduled_autonomous
 
-type backlog_consumption_error = Incomplete_backlog_observation
-
 val record_scheduled_backlog_consumption
   :  meta:Keeper_meta_contract.keeper_meta
   -> world_observation
-  -> (Keeper_meta_contract.keeper_meta, backlog_consumption_error) result
+  -> Keeper_meta_contract.keeper_meta
 (** Record an actually-observed revision/projection pair at scheduled-turn
-    admission. [None, None] is an unreadable observation and leaves meta
-    unchanged; a partial pair is a typed invariant error. Reactive channels
-    must not call this function. *)
+    admission. An unreadable observation leaves meta unchanged. Reactive
+    channels must not call this function. *)
 
 type event_queue_trigger =
   | Bootstrap_stimulus

--- a/lib/keeper/keeper_world_observation_inputs.ml
+++ b/lib/keeper/keeper_world_observation_inputs.ml
@@ -21,6 +21,20 @@ type current_task_observation =
       ; error : string
       }
 
+type backlog_observation_source =
+  | Primary
+  | Recovery of Workspace.backlog_recovery
+  | Unavailable of string
+
+let backlog_observation_source_to_string = function
+  | Primary -> "primary"
+  | Recovery { primary_error; recovery_path } ->
+    Printf.sprintf
+      "recovery(path=%s; primary_error=%s)"
+      recovery_path
+      primary_error
+  | Unavailable error -> Printf.sprintf "unavailable(error=%s)" error
+
 (* RFC-0357 §3.2: the backlog edge compares monotonic commit revisions, not
    wall clocks. The previous ISO8601 comparison against [proactive_rt.last_ts]
    had four defects this replacement dissolves by construction: same-second
@@ -102,7 +116,7 @@ let claim_goal_scope_filter ~(config : Workspace.config) ~(meta : keeper_meta)
 
 (** Read workspace backlog counts. *)
 let read_backlog_counts ~(config : Workspace.config) ~(meta : keeper_meta)
-  : int * int * int * bool * int option * string option
+  : int * int * int * bool * int option * string option * backlog_observation_source
   =
   try
     match Workspace.read_backlog_observation_with_source_r config with
@@ -115,20 +129,20 @@ let read_backlog_counts ~(config : Workspace.config) ~(meta : keeper_meta)
           ]
         ();
       Log.Keeper.warn "read_backlog_counts: backlog read failed: %s" message;
-      0, 0, 0, false, None, None
-    | Ok { Workspace.recovered_from = Some recovery; _ } ->
-      Otel_metric_store.inc_counter
-        Keeper_metrics.(to_string ObservationQueryFailures)
-        ~labels:
-          [ ( "operation"
-            , Runtime_observation_query_operation.(to_label Read_backlog_counts) )
-          ]
-        ();
-      Log.Keeper.warn
-        "read_backlog_counts: recovery snapshot is non-authoritative: %s"
-        recovery.primary_error;
-      0, 0, 0, false, None, None
-    | Ok { Workspace.observed_backlog = backlog; recovered_from = None } ->
+      (* Primary and recovery are both invalid. Preserve that as [None] so
+         admission can report [Backlog_unreadable] without silencing
+         independent message, board, or schedule stimuli. *)
+      0, 0, 0, false, None, None, Unavailable message
+    | Ok { observed_backlog = backlog; recovered_from } ->
+    let source =
+      match recovered_from with
+      | None -> Primary
+      | Some recovery ->
+        Log.Keeper.warn
+          "read_backlog_counts: using non-authoritative recovery for observation only: %s"
+          (backlog_observation_source_to_string (Recovery recovery));
+         Recovery recovery
+    in
     let unclaimed_tasks =
       List.filter
         (fun (t : Masc_domain.task) -> t.task_status = Masc_domain.Todo)
@@ -165,18 +179,24 @@ let read_backlog_counts ~(config : Workspace.config) ~(meta : keeper_meta)
     let projection_sha256 =
       relevant_backlog_projection_sha256 ~meta backlog.tasks
     in
-    let backlog_updated_since_last_scheduled_autonomous =
-      backlog_updated_since_last_scheduled_autonomous
-        ~meta
-        ~backlog
-        ~projection_sha256
+    let backlog_updated_since_last_scheduled_autonomous, observed_revision, observed_projection =
+      match recovered_from with
+      | Some _ -> false, None, None
+      | None ->
+        ( backlog_updated_since_last_scheduled_autonomous
+            ~meta
+            ~backlog
+            ~projection_sha256
+        , Some backlog.version
+        , Some projection_sha256 )
     in
     ( unclaimed
     , claimable
     , failed
     , backlog_updated_since_last_scheduled_autonomous
-    , Some backlog.version
-    , Some projection_sha256 )
+    , observed_revision
+    , observed_projection
+    , source )
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | ex ->
@@ -186,11 +206,7 @@ let read_backlog_counts ~(config : Workspace.config) ~(meta : keeper_meta)
         [ ("operation", Runtime_observation_query_operation.(to_label Read_backlog_counts)) ]
       ();
     Log.Keeper.warn "read_backlog_counts failed: %s" (Printexc.to_string ex);
-    (* No observed revision on a failed read: the edge stays false (a read
-       failure is not a backlog change) and admission must not record a
-       fabricated revision 0 — the consumption clock only moves forward on
-       an actually observed commit. *)
-    0, 0, 0, false, None, None
+    0, 0, 0, false, None, None, Unavailable (Printexc.to_string ex)
 ;;
 
 (** Resolve the keeper's claimed task to a source-preserving observation. *)

--- a/lib/keeper/keeper_world_observation_inputs.ml
+++ b/lib/keeper/keeper_world_observation_inputs.ml
@@ -21,19 +21,13 @@ type current_task_observation =
       ; error : string
       }
 
-type backlog_observation_source =
-  | Primary
-  | Recovery of Workspace.backlog_recovery
-  | Unavailable of string
-
-let backlog_observation_source_to_string = function
-  | Primary -> "primary"
-  | Recovery { primary_error; recovery_path } ->
-    Printf.sprintf
-      "recovery(path=%s; primary_error=%s)"
-      recovery_path
-      primary_error
-  | Unavailable error -> Printf.sprintf "unavailable(error=%s)" error
+type backlog_edge_observation =
+  | Backlog_read_unavailable
+  | Observed_backlog of
+      { revision : int
+      ; projection_sha256 : string
+       ; updated_since_last_scheduled_autonomous : bool
+       }
 
 (* RFC-0357 §3.2: the backlog edge compares monotonic commit revisions, not
    wall clocks. The previous ISO8601 comparison against [proactive_rt.last_ts]
@@ -116,10 +110,10 @@ let claim_goal_scope_filter ~(config : Workspace.config) ~(meta : keeper_meta)
 
 (** Read workspace backlog counts. *)
 let read_backlog_counts ~(config : Workspace.config) ~(meta : keeper_meta)
-  : int * int * int * bool * int option * string option * backlog_observation_source
+  : int * int * int * backlog_edge_observation
   =
   try
-    match Workspace.read_backlog_observation_with_source_r config with
+    match Workspace.read_backlog_observation_r config with
     | Error message ->
       Otel_metric_store.inc_counter
         Keeper_metrics.(to_string ObservationQueryFailures)
@@ -129,20 +123,11 @@ let read_backlog_counts ~(config : Workspace.config) ~(meta : keeper_meta)
           ]
         ();
       Log.Keeper.warn "read_backlog_counts: backlog read failed: %s" message;
-      (* Primary and recovery are both invalid. Preserve that as [None] so
-         admission can report [Backlog_unreadable] without silencing
+      (* Primary and recovery are both invalid. Preserve the typed unavailable
+         state so admission can report [Backlog_unreadable] without silencing
          independent message, board, or schedule stimuli. *)
-      0, 0, 0, false, None, None, Unavailable message
-    | Ok { observed_backlog = backlog; recovered_from } ->
-    let source =
-      match recovered_from with
-      | None -> Primary
-      | Some recovery ->
-        Log.Keeper.warn
-          "read_backlog_counts: using non-authoritative recovery for observation only: %s"
-          (backlog_observation_source_to_string (Recovery recovery));
-         Recovery recovery
-    in
+      0, 0, 0, Backlog_read_unavailable
+    | Ok backlog ->
     let unclaimed_tasks =
       List.filter
         (fun (t : Masc_domain.task) -> t.task_status = Masc_domain.Todo)
@@ -179,24 +164,21 @@ let read_backlog_counts ~(config : Workspace.config) ~(meta : keeper_meta)
     let projection_sha256 =
       relevant_backlog_projection_sha256 ~meta backlog.tasks
     in
-    let backlog_updated_since_last_scheduled_autonomous, observed_revision, observed_projection =
-      match recovered_from with
-      | Some _ -> false, None, None
-      | None ->
-        ( backlog_updated_since_last_scheduled_autonomous
-            ~meta
-            ~backlog
-            ~projection_sha256
-        , Some backlog.version
-        , Some projection_sha256 )
+    let backlog_updated_since_last_scheduled_autonomous =
+      backlog_updated_since_last_scheduled_autonomous
+        ~meta
+        ~backlog
+        ~projection_sha256
     in
     ( unclaimed
     , claimable
     , failed
-    , backlog_updated_since_last_scheduled_autonomous
-    , observed_revision
-    , observed_projection
-    , source )
+    , Observed_backlog
+        { revision = backlog.version
+        ; projection_sha256
+        ; updated_since_last_scheduled_autonomous =
+             backlog_updated_since_last_scheduled_autonomous
+        } )
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | ex ->
@@ -206,7 +188,7 @@ let read_backlog_counts ~(config : Workspace.config) ~(meta : keeper_meta)
         [ ("operation", Runtime_observation_query_operation.(to_label Read_backlog_counts)) ]
       ();
     Log.Keeper.warn "read_backlog_counts failed: %s" (Printexc.to_string ex);
-    0, 0, 0, false, None, None, Unavailable (Printexc.to_string ex)
+    0, 0, 0, Backlog_read_unavailable
 ;;
 
 (** Resolve the keeper's claimed task to a source-preserving observation. *)

--- a/lib/keeper/keeper_world_observation_inputs.ml
+++ b/lib/keeper/keeper_world_observation_inputs.ml
@@ -203,6 +203,9 @@ let read_backlog_counts ~(config : Workspace.config) ~(meta : keeper_meta)
           ; projection_sha256
           ; updated_since_last_scheduled_autonomous =
               backlog_updated_since_last_scheduled_autonomous
+                ~meta
+                ~backlog
+                ~projection_sha256
           }
       | Some recovery ->
         Log.Keeper.warn

--- a/lib/keeper/keeper_world_observation_inputs.ml
+++ b/lib/keeper/keeper_world_observation_inputs.ml
@@ -5,6 +5,37 @@ open Keeper_meta_contract
 open Keeper_types_profile
 open Keeper_context_runtime
 
+type backlog_edge_observation =
+  | Backlog_read_unavailable of string
+  | Recovery_backlog of
+      { revision : int
+      ; projection_sha256 : string
+      ; recovery : Workspace.backlog_recovery
+      }
+  | Observed_backlog of
+      { revision : int
+      ; projection_sha256 : string
+      ; updated_since_last_scheduled_autonomous : bool
+      }
+
+let backlog_edge_observation_to_string = function
+  | Backlog_read_unavailable _ -> "unavailable"
+  | Recovery_backlog { revision; projection_sha256; recovery = _ } ->
+    Printf.sprintf
+      "recovery(revision=%d; projection=%s)"
+      revision
+      projection_sha256
+  | Observed_backlog { revision; projection_sha256; _ } ->
+    Printf.sprintf "primary(revision=%d; projection=%s)" revision projection_sha256
+(* RFC-0357 §3.2: the backlog edge compares monotonic commit revisions, not
+   wall clocks. The previous ISO8601 comparison against [proactive_rt.last_ts]
+   had four defects this replacement dissolves by construction: same-second
+   ties under a strict [>], NTP rewinds, a [last_ts <= 0.0] arm that degraded
+   to the level check [backlog.tasks <> []], and a parse-failure arm that
+   silently returned [false] forever. [last_consumed_backlog_revision] starts
+   at 0 (never consumed), so a live backlog (version >= 1) admits exactly one
+   turn before the first consumption is recorded — the zero-point arm is not
+   needed. *)
 type current_task_observation =
   | No_current_task
   | Current_task of Masc_domain.task
@@ -164,21 +195,23 @@ let read_backlog_counts ~(config : Workspace.config) ~(meta : keeper_meta)
     let projection_sha256 =
       relevant_backlog_projection_sha256 ~meta backlog.tasks
     in
-    let backlog_updated_since_last_scheduled_autonomous =
-      backlog_updated_since_last_scheduled_autonomous
-        ~meta
-        ~backlog
-        ~projection_sha256
+    let backlog_edge =
+      match recovered_from with
+      | None ->
+        Observed_backlog
+          { revision = backlog.version
+          ; projection_sha256
+          ; updated_since_last_scheduled_autonomous =
+              backlog_updated_since_last_scheduled_autonomous
+          }
+      | Some recovery ->
+        Log.Keeper.warn
+          "read_backlog_counts: using non-authoritative recovery for observation only path=%s primary_error=%s"
+          recovery.recovery_path
+          recovery.primary_error;
+        Recovery_backlog { revision = backlog.version; projection_sha256; recovery }
     in
-    ( unclaimed
-    , claimable
-    , failed
-    , Observed_backlog
-        { revision = backlog.version
-        ; projection_sha256
-        ; updated_since_last_scheduled_autonomous =
-             backlog_updated_since_last_scheduled_autonomous
-        } )
+    unclaimed, claimable, failed, backlog_edge
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | ex ->
@@ -188,7 +221,7 @@ let read_backlog_counts ~(config : Workspace.config) ~(meta : keeper_meta)
         [ ("operation", Runtime_observation_query_operation.(to_label Read_backlog_counts)) ]
       ();
     Log.Keeper.warn "read_backlog_counts failed: %s" (Printexc.to_string ex);
-    0, 0, 0, Backlog_read_unavailable
+    raise ex
 ;;
 
 (** Resolve the keeper's claimed task to a source-preserving observation. *)

--- a/lib/keeper/keeper_world_observation_inputs.ml
+++ b/lib/keeper/keeper_world_observation_inputs.ml
@@ -33,9 +33,15 @@ type current_task_observation =
 let backlog_updated_since_last_scheduled_autonomous
       ~(meta : keeper_meta)
       ~(backlog : Masc_domain.backlog)
+      ~(projection_sha256 : string)
   : bool
   =
-  backlog.version > meta.runtime.proactive_rt.last_consumed_backlog_revision
+  let proactive_rt = meta.runtime.proactive_rt in
+  backlog.version > proactive_rt.last_consumed_backlog_revision
+  && not
+       (String.equal
+          projection_sha256
+          proactive_rt.last_consumed_backlog_projection_sha256)
 ;;
 
 (* A keeper must not treat a task it authored itself as work waiting for it.
@@ -61,6 +67,21 @@ let task_is_self_authored_todo ~(meta : keeper_meta) (task : Masc_domain.task) =
     false
 ;;
 
+let relevant_backlog_projection_sha256
+      ~(meta : keeper_meta)
+      (tasks : Masc_domain.task list)
+  =
+  tasks
+  |> List.filter (fun task -> not (task_is_self_authored_todo ~meta task))
+  |> List.map Masc_domain.task_to_yojson
+  |> List.map (fun json -> Yojson.Safe.to_string json, json)
+  |> List.sort (fun (left, _) (right, _) -> String.compare left right)
+  |> List.map snd
+  |> fun sorted -> Yojson.Safe.to_string (`List sorted)
+  |> Digestif.SHA256.digest_string
+  |> Digestif.SHA256.to_hex
+;;
+
 let claim_goal_scope_filter ~(config : Workspace.config) ~(meta : keeper_meta)
     ~(tasks : Masc_domain.task list) () =
   (* [read_backlog_counts] already loaded [tasks]. Reuse them to get the same
@@ -81,7 +102,7 @@ let claim_goal_scope_filter ~(config : Workspace.config) ~(meta : keeper_meta)
 
 (** Read workspace backlog counts. *)
 let read_backlog_counts ~(config : Workspace.config) ~(meta : keeper_meta)
-  : int * int * int * bool * int option
+  : int * int * int * bool * int option * string option
   =
   try
     match Workspace.read_backlog_observation_with_source_r config with
@@ -94,7 +115,7 @@ let read_backlog_counts ~(config : Workspace.config) ~(meta : keeper_meta)
           ]
         ();
       Log.Keeper.warn "read_backlog_counts: backlog read failed: %s" message;
-      0, 0, 0, false, None
+      0, 0, 0, false, None, None
     | Ok { Workspace.recovered_from = Some recovery; _ } ->
       Otel_metric_store.inc_counter
         Keeper_metrics.(to_string ObservationQueryFailures)
@@ -106,7 +127,7 @@ let read_backlog_counts ~(config : Workspace.config) ~(meta : keeper_meta)
       Log.Keeper.warn
         "read_backlog_counts: recovery snapshot is non-authoritative: %s"
         recovery.primary_error;
-      0, 0, 0, false, None
+      0, 0, 0, false, None, None
     | Ok { Workspace.observed_backlog = backlog; recovered_from = None } ->
     let unclaimed_tasks =
       List.filter
@@ -141,14 +162,21 @@ let read_backlog_counts ~(config : Workspace.config) ~(meta : keeper_meta)
       |> List.filter claim_scope_filter
       |> List.length
     in
+    let projection_sha256 =
+      relevant_backlog_projection_sha256 ~meta backlog.tasks
+    in
     let backlog_updated_since_last_scheduled_autonomous =
-      backlog_updated_since_last_scheduled_autonomous ~meta ~backlog
+      backlog_updated_since_last_scheduled_autonomous
+        ~meta
+        ~backlog
+        ~projection_sha256
     in
     ( unclaimed
     , claimable
     , failed
     , backlog_updated_since_last_scheduled_autonomous
-    , Some backlog.version )
+    , Some backlog.version
+    , Some projection_sha256 )
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | ex ->
@@ -162,7 +190,7 @@ let read_backlog_counts ~(config : Workspace.config) ~(meta : keeper_meta)
        failure is not a backlog change) and admission must not record a
        fabricated revision 0 — the consumption clock only moves forward on
        an actually observed commit. *)
-    0, 0, 0, false, None
+    0, 0, 0, false, None, None
 ;;
 
 (** Resolve the keeper's claimed task to a source-preserving observation. *)

--- a/lib/keeper/keeper_world_observation_inputs.ml
+++ b/lib/keeper/keeper_world_observation_inputs.ml
@@ -21,18 +21,21 @@ type current_task_observation =
       ; error : string
       }
 
+(* RFC-0357 §3.2: the backlog edge compares monotonic commit revisions, not
+   wall clocks. The previous ISO8601 comparison against [proactive_rt.last_ts]
+   had four defects this replacement dissolves by construction: same-second
+   ties under a strict [>], NTP rewinds, a [last_ts <= 0.0] arm that degraded
+   to the level check [backlog.tasks <> []], and a parse-failure arm that
+   silently returned [false] forever. [last_consumed_backlog_revision] starts
+   at 0 (never consumed), so a live backlog (version >= 1) admits exactly one
+    turn before the first consumption is recorded — the zero-point arm is not
+    needed. *)
 let backlog_updated_since_last_scheduled_autonomous
       ~(meta : keeper_meta)
       ~(backlog : Masc_domain.backlog)
   : bool
   =
-  let last_ts = meta.runtime.proactive_rt.last_ts in
-  if last_ts <= 0.0
-  then backlog.tasks <> []
-  else (
-    match Workspace_resilience.Time.parse_iso8601_opt backlog.last_updated with
-    | Some updated_at -> updated_at > last_ts
-    | None -> false)
+  backlog.version > meta.runtime.proactive_rt.last_consumed_backlog_revision
 ;;
 
 (* A keeper must not treat a task it authored itself as work waiting for it.
@@ -155,7 +158,11 @@ let read_backlog_counts ~(config : Workspace.config) ~(meta : keeper_meta)
         [ ("operation", Runtime_observation_query_operation.(to_label Read_backlog_counts)) ]
       ();
     Log.Keeper.warn "read_backlog_counts failed: %s" (Printexc.to_string ex);
-    raise ex
+    (* No observed revision on a failed read: the edge stays false (a read
+       failure is not a backlog change) and admission must not record a
+       fabricated revision 0 — the consumption clock only moves forward on
+       an actually observed commit. *)
+    0, 0, 0, false, None
 ;;
 
 (** Resolve the keeper's claimed task to a source-preserving observation. *)

--- a/lib/keeper/keeper_world_observation_inputs.ml
+++ b/lib/keeper/keeper_world_observation_inputs.ml
@@ -52,23 +52,6 @@ type current_task_observation =
       ; error : string
       }
 
-type backlog_edge_observation =
-  | Backlog_read_unavailable
-  | Observed_backlog of
-      { revision : int
-      ; projection_sha256 : string
-       ; updated_since_last_scheduled_autonomous : bool
-       }
-
-(* RFC-0357 §3.2: the backlog edge compares monotonic commit revisions, not
-   wall clocks. The previous ISO8601 comparison against [proactive_rt.last_ts]
-   had four defects this replacement dissolves by construction: same-second
-   ties under a strict [>], NTP rewinds, a [last_ts <= 0.0] arm that degraded
-   to the level check [backlog.tasks <> []], and a parse-failure arm that
-   silently returned [false] forever. [last_consumed_backlog_revision] starts
-   at 0 (never consumed), so a live backlog (version >= 1) admits exactly one
-    turn before the first consumption is recorded — the zero-point arm is not
-    needed. *)
 let backlog_updated_since_last_scheduled_autonomous
       ~(meta : keeper_meta)
       ~(backlog : Masc_domain.backlog)
@@ -144,7 +127,7 @@ let read_backlog_counts ~(config : Workspace.config) ~(meta : keeper_meta)
   : int * int * int * backlog_edge_observation
   =
   try
-    match Workspace.read_backlog_observation_r config with
+    match Workspace.read_backlog_observation_with_source_r config with
     | Error message ->
       Otel_metric_store.inc_counter
         Keeper_metrics.(to_string ObservationQueryFailures)
@@ -157,8 +140,8 @@ let read_backlog_counts ~(config : Workspace.config) ~(meta : keeper_meta)
       (* Primary and recovery are both invalid. Preserve the typed unavailable
          state so admission can report [Backlog_unreadable] without silencing
          independent message, board, or schedule stimuli. *)
-      0, 0, 0, Backlog_read_unavailable
-    | Ok backlog ->
+      0, 0, 0, Backlog_read_unavailable message
+    | Ok { observed_backlog = backlog; recovered_from } ->
     let unclaimed_tasks =
       List.filter
         (fun (t : Masc_domain.task) -> t.task_status = Masc_domain.Todo)

--- a/lib/keeper/keeper_world_observation_inputs.mli
+++ b/lib/keeper/keeper_world_observation_inputs.mli
@@ -24,18 +24,21 @@ val backlog_updated_since_last_scheduled_autonomous
   :  meta:keeper_meta
   -> backlog:Masc_domain.backlog
   -> bool
+(** RFC-0357 §3.2 backlog edge:
+    [backlog.version > meta.runtime.proactive_rt.last_consumed_backlog_revision].
+    A monotonic revision compare — wall clocks, ISO8601 parsing, and the
+    zero-point special case of the previous implementation are gone by
+    construction. *)
 
 val read_backlog_counts
   :  config:Workspace.config
   -> meta:keeper_meta
   -> int * int * int * bool * int option
-(** [(unclaimed, claimable, failed, backlog_changed, observed_revision)].
-    Uses the source-preserving observation contract. [observed_revision] is
-    [Some backlog.version] only after a valid primary read and [None] when the
-    primary is unreadable, including when a recovery snapshot is available.
-    Counts are zero on the latter path, so stale recovery data cannot drive a
-    wake or appear claimable. The typed revision absence preserves the degraded
-    observation instead of fabricating an empty authoritative backlog. *)
+(** [(unclaimed, claimable, failed, backlog_edge, observed_revision)].
+    [observed_revision] is [Some backlog.version] on a successful read and
+    [None] when the read failed — admission records only actually observed
+    revisions, so a failed read can neither fire the edge nor move the
+    consumption clock. *)
 
 (** [task_is_self_authored_todo ~meta task] is true when an unclaimed [Todo]
     was authored by the keeper's own stable handle ([meta.name]).

--- a/lib/keeper/keeper_world_observation_inputs.mli
+++ b/lib/keeper/keeper_world_observation_inputs.mli
@@ -23,22 +23,29 @@ type current_task_observation =
 val backlog_updated_since_last_scheduled_autonomous
   :  meta:keeper_meta
   -> backlog:Masc_domain.backlog
+  -> projection_sha256:string
   -> bool
 (** RFC-0357 §3.2 backlog edge:
-    [backlog.version > meta.runtime.proactive_rt.last_consumed_backlog_revision].
-    A monotonic revision compare — wall clocks, ISO8601 parsing, and the
-    zero-point special case of the previous implementation are gone by
-    construction. *)
+    the revision advances and the exact non-self-authored task projection
+    differs from the paired consumed projection. Wall clocks, task titles,
+    and semantic string matching are not inputs. *)
+
+val relevant_backlog_projection_sha256
+  :  meta:keeper_meta
+  -> Masc_domain.task list
+  -> string
+(** Stable SHA-256 of typed task JSON after excluding only self-authored Todo
+    rows. Input list order does not affect the result. *)
 
 val read_backlog_counts
   :  config:Workspace.config
   -> meta:keeper_meta
-  -> int * int * int * bool * int option
-(** [(unclaimed, claimable, failed, backlog_edge, observed_revision)].
-    [observed_revision] is [Some backlog.version] on a successful read and
-    [None] when the read failed — admission records only actually observed
-    revisions, so a failed read can neither fire the edge nor move the
-    consumption clock. *)
+  -> int * int * int * bool * int option * string option
+(** [(unclaimed, claimable, failed, backlog_edge, observed_revision,
+    observed_projection_sha256)]. The revision/projection pair is present only
+    for a valid primary observation. Failed and recovery-only reads carry
+    [None, None], so stale recovery state cannot fire or consume an admission
+    edge. *)
 
 (** [task_is_self_authored_todo ~meta task] is true when an unclaimed [Todo]
     was authored by the keeper's own stable handle ([meta.name]).

--- a/lib/keeper/keeper_world_observation_inputs.mli
+++ b/lib/keeper/keeper_world_observation_inputs.mli
@@ -20,12 +20,13 @@ type current_task_observation =
       ; error : string
       }
 
-type backlog_observation_source =
-  | Primary
-  | Recovery of Workspace.backlog_recovery
-  | Unavailable of string
-
-val backlog_observation_source_to_string : backlog_observation_source -> string
+type backlog_edge_observation =
+  | Backlog_read_unavailable
+  | Observed_backlog of
+      { revision : int
+      ; projection_sha256 : string
+       ; updated_since_last_scheduled_autonomous : bool
+       }
 
 val backlog_updated_since_last_scheduled_autonomous
   :  meta:keeper_meta
@@ -47,14 +48,11 @@ val relevant_backlog_projection_sha256
 val read_backlog_counts
   :  config:Workspace.config
   -> meta:keeper_meta
-  -> int * int * int * bool * int option * string option * backlog_observation_source
-(** [(unclaimed, claimable, failed, backlog_edge, observed_revision,
-    observed_projection_sha256, source)]. Counts may come from a recovery
-    snapshot for read-only context, but [observed_revision] and
-    [observed_projection_sha256] are [None] unless the primary SSOT was read;
-    a recovery snapshot can never fire or consume the scheduled edge. An
-    unavailable source returns typed [Unavailable] with no fabricated counts
-    or revision, while independent observation stimuli continue. *)
+  -> int * int * int * backlog_edge_observation
+(** [(unclaimed, claimable, failed, backlog_edge)]. Uses the recovery-backed
+    observation contract. A successful read carries one inseparable
+    revision/projection/edge value; when neither source is valid, counts are
+    zero and [Backlog_read_unavailable] prevents admission or consumption. *)
 
 (** [task_is_self_authored_todo ~meta task] is true when an unclaimed [Todo]
     was authored by the keeper's own stable handle ([meta.name]).

--- a/lib/keeper/keeper_world_observation_inputs.mli
+++ b/lib/keeper/keeper_world_observation_inputs.mli
@@ -35,14 +35,6 @@ type current_task_observation =
       ; error : string
       }
 
-type backlog_edge_observation =
-  | Backlog_read_unavailable
-  | Observed_backlog of
-      { revision : int
-      ; projection_sha256 : string
-       ; updated_since_last_scheduled_autonomous : bool
-       }
-
 val backlog_updated_since_last_scheduled_autonomous
   :  meta:keeper_meta
   -> backlog:Masc_domain.backlog
@@ -65,9 +57,11 @@ val read_backlog_counts
   -> meta:keeper_meta
   -> int * int * int * backlog_edge_observation
 (** [(unclaimed, claimable, failed, backlog_edge)]. Uses the recovery-backed
-    observation contract. A successful read carries one inseparable
-    revision/projection/edge value; when neither source is valid, counts are
-    zero and [Backlog_read_unavailable] prevents admission or consumption. *)
+    observation contract. A successful primary read carries one inseparable
+    revision/projection/edge value. A recovery read carries its revision and
+    projection as read-only facts but cannot form an authoritative edge;
+    [Backlog_read_unavailable] carries the failure rather than fabricating an
+    empty backlog. *)
 
 (** [task_is_self_authored_todo ~meta task] is true when an unclaimed [Todo]
     was authored by the keeper's own stable handle ([meta.name]).

--- a/lib/keeper/keeper_world_observation_inputs.mli
+++ b/lib/keeper/keeper_world_observation_inputs.mli
@@ -4,6 +4,21 @@ open Keeper_types
 open Keeper_meta_contract
 open Keeper_types_profile
 
+type backlog_edge_observation =
+  | Backlog_read_unavailable of string
+  | Recovery_backlog of
+      { revision : int
+      ; projection_sha256 : string
+      ; recovery : Workspace.backlog_recovery
+      }
+  | Observed_backlog of
+      { revision : int
+      ; projection_sha256 : string
+      ; updated_since_last_scheduled_autonomous : bool
+      }
+val backlog_edge_observation_to_string : backlog_edge_observation -> string
+(** Render model-safe provenance without storage paths or parser error text.
+    Detailed failures stay in logs and metrics. *)
 type current_task_observation =
   | No_current_task
   | Current_task of Masc_domain.task

--- a/lib/keeper/keeper_world_observation_inputs.mli
+++ b/lib/keeper/keeper_world_observation_inputs.mli
@@ -20,6 +20,13 @@ type current_task_observation =
       ; error : string
       }
 
+type backlog_observation_source =
+  | Primary
+  | Recovery of Workspace.backlog_recovery
+  | Unavailable of string
+
+val backlog_observation_source_to_string : backlog_observation_source -> string
+
 val backlog_updated_since_last_scheduled_autonomous
   :  meta:keeper_meta
   -> backlog:Masc_domain.backlog
@@ -40,12 +47,14 @@ val relevant_backlog_projection_sha256
 val read_backlog_counts
   :  config:Workspace.config
   -> meta:keeper_meta
-  -> int * int * int * bool * int option * string option
+  -> int * int * int * bool * int option * string option * backlog_observation_source
 (** [(unclaimed, claimable, failed, backlog_edge, observed_revision,
-    observed_projection_sha256)]. The revision/projection pair is present only
-    for a valid primary observation. Failed and recovery-only reads carry
-    [None, None], so stale recovery state cannot fire or consume an admission
-    edge. *)
+    observed_projection_sha256, source)]. Counts may come from a recovery
+    snapshot for read-only context, but [observed_revision] and
+    [observed_projection_sha256] are [None] unless the primary SSOT was read;
+    a recovery snapshot can never fire or consume the scheduled edge. An
+    unavailable source returns typed [Unavailable] with no fabricated counts
+    or revision, while independent observation stimuli continue. *)
 
 (** [task_is_self_authored_todo ~meta task] is true when an unclaimed [Todo]
     was authored by the keeper's own stable handle ([meta.name]).

--- a/lib/keeper_contract/keeper_world_observation_turn_types.ml
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.ml
@@ -76,6 +76,12 @@ type skip_reason =
           revision edge, no due schedule, and the keeper has already
           bootstrapped. The heartbeat itself is not a wake signal; this skip
           is a record ("designed silence"), not an absence. *)
+  | Backlog_unreadable
+      (** RFC-0357: gate on, no other stimulus, and the backlog read failed
+          (the observation carries no revision) — the edge disjunct had no
+          real input. Kept distinct from [No_actionable_stimulus] because a
+          read failure is not designed silence; folding the two would record
+          a blind observation as a considered "nothing to do". *)
 
 type turn_verdict =
   | Run of { reasons : turn_reason * turn_reason list }
@@ -112,6 +118,7 @@ let skip_reason_to_string = function
   | Scheduled_autonomous_disabled -> "scheduled_autonomous_disabled"
   | Reactive_disabled -> "reactive_disabled"
   | No_actionable_stimulus -> "no_actionable_stimulus"
+  | Backlog_unreadable -> "backlog_unreadable"
 ;;
 
 (* Canonical wire encoding. [Reactive] serialises as "turn" (the value the

--- a/lib/keeper_contract/keeper_world_observation_turn_types.ml
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.ml
@@ -70,6 +70,12 @@ type skip_reason =
       (** RFC-0297 P0-1: the global reactive kill-switch
           (MASC_KEEPER_REACTIVE_ENABLED) is off, so a pending reactive trigger
           (mention / board event / scope message) does not open a turn. *)
+  | No_actionable_stimulus
+      (** RFC-0357 §3.1: the scheduled-autonomous gate is on but no typed
+          stimulus is present — no pending message or board event, no backlog
+          revision edge, no due schedule, and the keeper has already
+          bootstrapped. The heartbeat itself is not a wake signal; this skip
+          is a record ("designed silence"), not an absence. *)
 
 type turn_verdict =
   | Run of { reasons : turn_reason * turn_reason list }
@@ -105,6 +111,7 @@ let skip_reason_to_string = function
   | Keeper_paused -> "keeper_paused"
   | Scheduled_autonomous_disabled -> "scheduled_autonomous_disabled"
   | Reactive_disabled -> "reactive_disabled"
+  | No_actionable_stimulus -> "no_actionable_stimulus"
 ;;
 
 (* Canonical wire encoding. [Reactive] serialises as "turn" (the value the

--- a/lib/keeper_contract/keeper_world_observation_turn_types.mli
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.mli
@@ -42,6 +42,10 @@ type skip_reason =
   | Keeper_paused
   | Scheduled_autonomous_disabled
   | Reactive_disabled
+  | No_actionable_stimulus
+      (** RFC-0357 §3.1: gate on, but no typed stimulus — no pending
+          message/board event, no backlog revision edge, no due schedule,
+          already bootstrapped. Designed silence, recorded as a skip. *)
 
 type turn_verdict =
   | Run of { reasons : turn_reason * turn_reason list }

--- a/lib/keeper_contract/keeper_world_observation_turn_types.mli
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.mli
@@ -46,6 +46,9 @@ type skip_reason =
       (** RFC-0357 §3.1: gate on, but no typed stimulus — no pending
           message/board event, no backlog revision edge, no due schedule,
           already bootstrapped. Designed silence, recorded as a skip. *)
+  | Backlog_unreadable
+      (** RFC-0357: gate on, no other stimulus, and the backlog read failed —
+          the edge disjunct had no real input. Not designed silence. *)
 
 type turn_verdict =
   | Run of { reasons : turn_reason * turn_reason list }

--- a/lib/keeper_metrics/keeper_measurement.ml
+++ b/lib/keeper_metrics/keeper_measurement.ml
@@ -17,7 +17,6 @@ type timing_measurement = {
   now_ts : float;
   idle_seconds : int;
   since_last_compaction_sec : float;
-  proactive_warmup_elapsed : bool;
 }
 
 type failure_measurement = {
@@ -54,7 +53,6 @@ let capture
       ~now_ts
       ~idle_seconds
       ~since_last_compaction_sec
-      ~proactive_warmup_elapsed
       ~consecutive_hb_failures
       ~consecutive_turn_failures
       ()
@@ -75,7 +73,6 @@ let capture
       { now_ts
       ; idle_seconds
       ; since_last_compaction_sec
-      ; proactive_warmup_elapsed
       }
   ; failures =
       { consecutive_hb_failures
@@ -100,7 +97,6 @@ let measurement_snapshot_to_json (s : measurement_snapshot) : Yojson.Safe.t =
       "now_ts", `Float s.timing.now_ts;
       "idle_seconds", `Int s.timing.idle_seconds;
       "since_last_compaction_sec", `Float s.timing.since_last_compaction_sec;
-      "proactive_warmup_elapsed", `Bool s.timing.proactive_warmup_elapsed;
     ];
     "failures", `Assoc [
       "consecutive_hb_failures", `Int s.failures.consecutive_hb_failures;

--- a/lib/keeper_metrics/keeper_measurement.mli
+++ b/lib/keeper_metrics/keeper_measurement.mli
@@ -30,7 +30,6 @@ type timing_measurement = {
   now_ts : float;
   idle_seconds : int;
   since_last_compaction_sec : float;
-  proactive_warmup_elapsed : bool;
 }
 
 type failure_measurement = {
@@ -73,7 +72,6 @@ val capture :
   now_ts:float ->
   idle_seconds:int ->
   since_last_compaction_sec:float ->
-  proactive_warmup_elapsed:bool ->
   consecutive_hb_failures:int ->
   consecutive_turn_failures:int ->
   unit ->

--- a/lib/runtime_settings.ml
+++ b/lib/runtime_settings.ml
@@ -427,14 +427,6 @@ let surfaces =
       ];
     };
     {
-      id = "keeper_proactive";
-      description = "Keeper proactive turn scheduling and bootstrap timing";
-      param_keys = [
-        "keeper.proactive.warmup_sec";
-        "keeper.proactive.stagger_step_sec";
-      ];
-    };
-    {
       id = "dashboard";
       description = "Dashboard rendering — truncation lengths, row limits, borders, status thresholds";
       param_keys = [

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -3,40 +3,6 @@
     Extracted from Server_runtime_bootstrap to isolate the large
     subsystem-spawning functions into a focused module. *)
 
-(* Stable djb2-style hash for the autoboot warmup jitter.
-
-   Post-#13119 follow-up: the previous implementation used native
-   [int] arithmetic with a final [land 0x3FFF_FFFF] mask.  That is
-   NOT actually platform-stable: on 31-bit OCaml the intermediate
-   [acc lsl 5] overflow wraps differently than on 63-bit OCaml
-   before the mask is applied, so the same keeper name can hash to
-   different buckets depending on architecture.
-
-   Fix: do all arithmetic in [Int32], whose wrap-around behavior is
-   identical on every supported runtime.  Mask to 30 bits and convert
-   back to [int].  30 bits ≈ 1G distinct buckets, far more than any
-   realistic [stagger_window_sec]. *)
-let stable_keeper_name_hash_mask_i32 = 0x3FFF_FFFFl
-
-let stable_keeper_name_hash name =
-  let acc = ref 5381l in
-  String.iter
-    (fun ch ->
-       let shifted = Int32.shift_left !acc 5 in
-       let summed = Int32.add (Int32.add shifted !acc) (Int32.of_int (Char.code ch)) in
-       acc := Int32.logand summed stable_keeper_name_hash_mask_i32)
-    name;
-  Int32.to_int !acc
-;;
-
-let autoboot_proactive_warmup_sec ~base_warmup ~stagger_window_sec ~keeper_name =
-  let base_warmup = max 0 base_warmup in
-  let stagger_window_sec = max 0 stagger_window_sec in
-  if stagger_window_sec = 0
-  then base_warmup
-  else base_warmup + (stable_keeper_name_hash keeper_name mod (stagger_window_sec + 1))
-;;
-
 let keeper_agent_status_of_phase = function
   | Keeper_state_machine.Running -> Masc_domain.Active
   | Keeper_state_machine.Paused -> Masc_domain.Listening
@@ -230,7 +196,7 @@ let discord_bot_token_opt () = trimmed_env_opt "DISCORD_BOT_TOKEN"
 
 let broadcast_mention_wakeup_action = function
   | Some target when String.trim target <> "" -> `Wake_keeper target
-  | Some _ | None -> `Suppress_no_target
+  | Some _ | None -> `No_keeper_target
 
 module Projection_for_testing = struct
   type queued_chat_projection = {
@@ -241,7 +207,6 @@ module Projection_for_testing = struct
     agent_name : string;
   }
 
-  let autoboot_proactive_warmup_sec = autoboot_proactive_warmup_sec
   let board_sse_event_params = board_sse_event_params
   let broadcast_mention_wakeup_action = broadcast_mention_wakeup_action
 
@@ -1385,9 +1350,9 @@ let start_keeper_loops_owned
     | `Wake_keeper target ->
       Keeper_keepalive.wakeup_keeper ~base_path:(Mcp_server.workspace_config state).base_path target;
       Log.Keeper.info "broadcast mention → wakeup keeper %s" target
-    | `Suppress_no_target ->
+    | `No_keeper_target ->
       Log.Keeper.info
-        "broadcast without mention -> keeper wakeup suppressed (passive fanout)"
+        "broadcast without mention -> passive fanout (no keeper target)"
   in
   Workspace_broadcast.on_broadcast_mention := broadcast_mention_handler;
   (* Orchestrator needs synchronous registration for shutdown hook *)
@@ -1416,8 +1381,6 @@ let start_keeper_loops_owned
     else (
       wait_for_lazy_startup ();
       Log.Keeper.info "autoboot: lazy startup complete; keeper bootstrap will start last";
-      (* Brief delay so other subsystems (SSE, board, orchestrator) settle first. *)
-      Eio.Time.sleep clock Env_config_keeper.KeeperBootstrap.post_startup_settle_sec;
       let masc_root = Workspace.masc_root_dir config in
       let keeper_dir = Keeper_fs.keeper_dir config in
       let shutdown_blocked_names =
@@ -1484,8 +1447,6 @@ let start_keeper_loops_owned
           "autoboot: excluded %d configured keeper(s): [%s]"
           (List.length exclusions)
           rendered);
-      let base_warmup = Keeper_config.keeper_bootstrap_proactive_warmup_sec () in
-      let stagger_window = Keeper_config.keeper_bootstrap_stagger_step_sec () in
       (* Attempt to boot a single keeper. Returns true if started. *)
       let try_boot_one ?(log_prefix = "autoboot") _idx name =
         try
@@ -1504,17 +1465,10 @@ let start_keeper_loops_owned
                 (if materialized then " (materialized from TOML)" else "");
               true)
             else (
-              let warmup =
-                autoboot_proactive_warmup_sec
-                  ~base_warmup
-                  ~stagger_window_sec:stagger_window
-                  ~keeper_name:name
-              in
               Log.Keeper.info
-                "%s: calling start_keepalive for %s (warmup=%ds)"
+                "%s: calling start_keepalive for %s"
                 log_prefix
-                name
-                warmup;
+                name;
               let ctx : _ Keeper_types_profile.context =
                 { config
                 ; agent_name = m.agent_name
@@ -1528,7 +1482,6 @@ let start_keeper_loops_owned
               in
               let launch_outcome =
                 Keeper_keepalive.start_keepalive
-                  ~proactive_warmup_sec:warmup
                   ctx
                   m
               in
@@ -1544,13 +1497,10 @@ let start_keeper_loops_owned
               (* start_keepalive registers the keeper synchronously via
                  register_offline and then forks the keepalive fiber.  The
                  fiber flips the registry to running asynchronously on the
-                 next Eio tick, so querying is_running here is a race that
-                 keepers with a larger proactive-warmup idx lose
-                 deterministically (verdict=165s / sojin=150s / sangsu=135s
-                 produced the bulk of the false-positive "not in registry"
-                 WARNs).  Check the synchronous is_registered predicate
-                 instead — the running transition is observed later by the
-                 retry loop.  See #7889. *)
+                 next Eio tick, so querying is_running here races that
+                 transition.  Check the synchronous is_registered predicate
+                 instead; the retry loop observes the running transition
+                 later.  See #7889. *)
               let registered =
                 Keeper_registry.is_registered ~base_path:config.base_path m.name
               in

--- a/lib/server/server_bootstrap_loops.mli
+++ b/lib/server/server_bootstrap_loops.mli
@@ -149,13 +149,10 @@ module For_testing : sig
     agent_name : string;
   }
 
-  val autoboot_proactive_warmup_sec :
-    base_warmup:int -> stagger_window_sec:int -> keeper_name:string -> int
-
   val board_sse_event_params : Board_dispatch.board_sse_event -> Yojson.Safe.t
 
   val broadcast_mention_wakeup_action :
-    string option -> [ `Suppress_no_target | `Wake_keeper of string ]
+    string option -> [ `No_keeper_target | `Wake_keeper of string ]
 
   val queued_chat_projection :
     Keeper_chat_queue.queued_message -> queued_chat_projection

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -236,7 +236,6 @@ let recover_projected_durable_demand_owner
         | Keeper_activation_readiness.Recoverable ->
           let owner_ctx = { ctx with agent_name = meta.agent_name } in
           Keeper_supervisor.supervise_keepalive
-            ~proactive_warmup_sec:0
             owner_ctx
             meta
         | Keeper_activation_readiness.Unknown detail ->

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -1079,13 +1079,17 @@ let plain_directive_to_keeper_directive = function
   | Plain_pause -> Keeper_directive.Pause
   | Plain_wakeup -> Keeper_directive.Wakeup
 
+type resume_directive_request =
+  { operator_operation_id : string
+  }
+
 type parsed_keeper_directive =
   | Plain_directive of plain_keeper_directive
-  | Resume_owner of Keeper_paused_work_resume_transaction.request
+  | Resume_owner of resume_directive_request
 
 type bulk_resume_target =
   { name : string
-  ; request : Keeper_paused_work_resume_transaction.request
+  ; operator_operation_id : string
   }
 
 type parsed_bulk_directive =
@@ -1095,17 +1099,10 @@ type parsed_bulk_directive =
       }
   | Bulk_resume_owner of bulk_resume_target list
 
-let required_resume_owner_request json =
-  match
-    Safe_ops.json_int_opt "owner_nonce" json,
-    Safe_ops.json_string_opt "operator_operation_id" json
-  with
-  | Some owner_nonce, Some operator_operation_id ->
-    Ok
-      Keeper_paused_work_resume_transaction.
-        { owner_nonce; operator_operation_id }
-  | None, _ -> Error "resume requires integer \"owner_nonce\""
-  | _, None -> Error "resume requires string \"operator_operation_id\""
+let required_resume_owner_request json : (resume_directive_request, string) result =
+  match Safe_ops.json_string_opt "operator_operation_id" json with
+  | Some operator_operation_id -> Ok { operator_operation_id }
+  | None -> Error "resume requires string \"operator_operation_id\""
 
 let parse_keeper_directive_json json =
   (* STR-OK: HTTP boundary parse of the untrusted wire "action" field into a
@@ -1129,7 +1126,9 @@ let parse_bulk_resume_target = function
     (match Safe_ops.json_string_opt "name" json with
      | Some name when is_valid_keeper_name name ->
        Result.map
-         (fun request -> { name; request })
+         (fun (request : resume_directive_request) ->
+            ({ name; operator_operation_id = request.operator_operation_id }
+             : bulk_resume_target))
          (required_resume_owner_request json)
      | Some _ -> Error "resume target has an invalid keeper name"
      | None -> Error "resume target requires string \"name\"")
@@ -1197,7 +1196,7 @@ module For_testing = struct
   let parse_resume_request json =
     match parse_keeper_directive_json json with
     | Ok (Resume_owner request) ->
-      Ok (request.owner_nonce, request.operator_operation_id)
+      Ok request.operator_operation_id
     | Ok (Plain_directive _) -> Error "request is not Resume_owner"
     | Error _ as error -> error
   ;;
@@ -1208,9 +1207,7 @@ module For_testing = struct
       Ok
         (List.map
            (fun target ->
-              ( target.name
-              , target.request.owner_nonce
-              , target.request.operator_operation_id ))
+              (target.name, target.operator_operation_id))
            targets)
     | Ok (Bulk_plain _) -> Error "request is not bulk Resume_owner"
     | Error _ as error -> error
@@ -1282,8 +1279,23 @@ let resume_result_json ~name
        | None -> []
        | Some message -> [ "error", `String message ])
 
-let run_resume_owner config ~name request =
-  Keeper_paused_work_resume_transaction.resume config ~keeper_name:name request
+let run_resume_owner config ~name (request : resume_directive_request) =
+  match Keeper_meta_store.read_meta config name with
+  | Error detail ->
+    Error
+      Keeper_paused_work_resume_transaction.
+        { cause = Durable_meta_read_failed detail; reservation_release = None }
+  | Ok None ->
+    Error
+      Keeper_paused_work_resume_transaction.
+        { cause = Durable_meta_missing; reservation_release = None }
+  | Ok (Some meta) ->
+    Keeper_paused_work_resume_transaction.resume
+      config
+      ~keeper_name:name
+      { owner_nonce = meta.runtime.nonce
+      ; operator_operation_id = request.operator_operation_id
+      }
 
 let persist_directive_pause ~config ~name
     (meta : Keeper_meta_contract.keeper_meta) =
@@ -1338,9 +1350,8 @@ let handle_keeper_directive_post ~sw:_ ~clock:_ state _agent_name req reqd body_
       (match run_resume_owner config ~name request with
        | Error error ->
          Log.Keeper.warn
-           "directive resume_owner rejected for %s generation=%d operation_id=%s: %s"
+           "directive resume_owner rejected for %s operation_id=%s: %s"
            name
-           request.owner_nonce
            request.operator_operation_id
            (Keeper_paused_work_resume_transaction.error_to_string error);
          Http.Response.json_value
@@ -1361,17 +1372,17 @@ let handle_keeper_directive_post ~sw:_ ~clock:_ state _agent_name req reqd body_
          (match success.projection with
           | Applied _ ->
             Log.Keeper.info
-              "directive resume_owner applied for %s generation=%d operation_id=%s"
+              "directive resume_owner applied for %s operation_id=%s generation=%d"
               name
-              request.owner_nonce
-              request.operator_operation_id;
+              request.operator_operation_id
+              success.receipt.expected_generation;
             Http.Response.json_value ~compress:true ~request:req response reqd
           | Committed_followup_failed failure ->
             Log.Keeper.warn
-              "directive resume_owner committed with pending projection for %s generation=%d operation_id=%s: %s"
+              "directive resume_owner committed with pending projection for %s operation_id=%s generation=%d: %s"
               name
-              request.owner_nonce
               request.operator_operation_id
+              success.receipt.expected_generation
               (resume_failure_message failure);
             Http.Response.json_value
               ~status:`Accepted
@@ -1488,8 +1499,9 @@ let handle_keeper_directive_post ~sw:_ ~clock:_ state _agent_name req reqd body_
        | Ok (Some meta), _ -> proceed (Some meta))
 
 (** Bulk variant of [handle_keeper_directive_post]. Pause and wakeup accept
-    [{names: [name, ...]}]. Resume accepts exact per-owner
-    [{targets: [{name, owner_nonce, operator_operation_id}, ...]}] fences.
+    [{names: [name, ...]}]. Resume accepts
+    [{targets: [{name, operator_operation_id}, ...]}]. The current durable
+    generation is resolved by the server at the transaction boundary.
     Cache invalidation still runs once for the whole batch. *)
 let handle_keeper_bulk_directive_post ~sw:_ ~clock:_ state _agent_name req reqd body_str =
   let parsed =
@@ -1510,7 +1522,12 @@ let handle_keeper_bulk_directive_post ~sw:_ ~clock:_ state _agent_name req reqd 
         match parsed with
         | Bulk_resume_owner targets ->
           let process_target target =
-            match run_resume_owner config ~name:target.name target.request with
+            match
+              run_resume_owner
+                config
+                ~name:target.name
+                { operator_operation_id = target.operator_operation_id }
+            with
             | Error error ->
               `Assoc
                 [ "name", `String target.name

--- a/lib/server/server_dashboard_http_keeper_api_post.mli
+++ b/lib/server/server_dashboard_http_keeper_api_post.mli
@@ -126,8 +126,8 @@ val handle_keeper_directive_post :
   Httpun.Reqd.t ->
   string ->
   unit
-(** A resume body requires [owner_nonce] and a stable
-    [operator_operation_id]; raw action-only resume is rejected. *)
+(** A resume body requires only a stable [operator_operation_id]. The server
+    resolves the current durable generation at the transaction boundary. *)
 
 val handle_keeper_bulk_directive_post :
   sw:Eio.Switch.t ->
@@ -139,12 +139,12 @@ val handle_keeper_bulk_directive_post :
   string ->
   unit
 (** Pause/wakeup accept a [names] list. Resume accepts a [targets] list whose
-    entries carry [name], [owner_nonce], and [operator_operation_id]. *)
+    entries carry [name] and [operator_operation_id]. *)
 
 module For_testing : sig
   val parse_resume_request :
-    Yojson.Safe.t -> (int * string, string) result
+    Yojson.Safe.t -> (string, string) result
 
   val parse_bulk_resume_requests :
-    Yojson.Safe.t -> ((string * int * string) list, string) result
+    Yojson.Safe.t -> ((string * string) list, string) result
 end

--- a/lib/task/task_goal_assignment.ml
+++ b/lib/task/task_goal_assignment.ml
@@ -14,6 +14,8 @@
    handler and the dashboard HTTP route call this one function, so the
    precondition checks live in a single place. *)
 
+module Workspace = Workspace_core
+
 type set_task_goal_error =
   | Backlog_read_failed of string
   | Unknown_task of string

--- a/lib/tool_metrics_persist.ml
+++ b/lib/tool_metrics_persist.ml
@@ -48,24 +48,17 @@ type persisted_record = {
 
 type parsed_record =
   | Current_record of persisted_record
-  | Legacy_success_record
 
 let parse_record (json : Yojson.Safe.t)
   : (parsed_record, string) Result.t =
   let tool_name = Safe_ops.json_string_opt "tool_name" json in
   let disposition = Safe_ops.json_string_opt "disposition" json in
-  let legacy_success = Safe_ops.json_bool_opt "success" json in
   let duration_ms = Safe_ops.json_float_opt "duration_ms" json in
-  match tool_name, disposition, legacy_success, duration_ms with
-  | Some tool_name, Some disposition, _, Some duration_ms ->
+  match tool_name, disposition, duration_ms with
+  | Some tool_name, Some disposition, Some duration_ms ->
     Tool_result.unit_disposition_of_string disposition
     |> Result.map (fun disposition ->
       Current_record { tool_name; disposition; duration_ms })
-  | Some _, None, Some _, Some _ ->
-    (* The legacy success bit cannot distinguish the current Deferred and
-       Failed dispositions. Keep the execution-disposition SSOT intact while
-       classifying these rows separately from malformed data. *)
-    Ok Legacy_success_record
   | _ ->
     let missing =
       [ ("tool_name", Option.is_none tool_name)
@@ -215,7 +208,6 @@ let start_flush_fiber ~sw ~clock ~base_path =
 let restore ~base_path : int =
   let store = get_or_create_store ~base_path in
   let count = ref 0 in
-  let legacy = ref 0 in
   let skipped = ref 0 in
   let first_skip_reason = ref None in
   (try
@@ -249,15 +241,10 @@ let restore ~base_path : int =
          in
          Tool_metrics.record result;
          Stdlib.incr count
-       | Ok Legacy_success_record -> Stdlib.incr legacy
        | Error reason ->
          Stdlib.incr skipped;
          if Option.is_none !first_skip_reason then
            first_skip_reason := Some reason);
-     if !legacy > 0 then
-       Log.Metrics.info
-         "tool_metrics_persist: ignored %d legacy success-only record(s); boolean success cannot reconstruct completed/deferred/failed disposition"
-         !legacy;
      if !skipped > 0 then
        Log.Metrics.warn
          "tool_metrics_persist: skipped %d malformed restore record(s)%s"

--- a/test/deps/masc_test_deps.ml
+++ b/test/deps/masc_test_deps.ml
@@ -107,6 +107,7 @@ let meta_of_json_fixture (json : Yojson.Safe.t) =
         | Schema.Board_reactive_turn_count
         | Schema.Mention_reactive_turn_count
         | Schema.Noop_turn_count
+        | Schema.Last_consumed_backlog_revision
         | Schema.Meta_version -> `Int 0
         | Schema.Total_cost_usd
         | Schema.Last_turn_ts

--- a/test/deps/masc_test_deps.ml
+++ b/test/deps/masc_test_deps.ml
@@ -121,6 +121,7 @@ let meta_of_json_fixture (json : Yojson.Safe.t) =
                Masc.Keeper_meta_contract.Proactive_never_started)
         | Schema.Last_proactive_reason
         | Schema.Last_proactive_preview
+        | Schema.Last_consumed_backlog_projection_sha256
         | Schema.Last_autonomous_action_at -> `String ""
         | Schema.Last_compaction_decision -> `String "initialized"
         | Schema.Active_goal_ids -> `List []

--- a/test/dune
+++ b/test/dune
@@ -30,6 +30,7 @@
   test_keeper_cooldown_cause_23438
   test_keeper_lifecycle_gate
   test_keeper_lifecycle_global_gate
+  test_keeper_admission_edge
   test_keeper_memory_lane
   test_keeper_connector_attention_wake
   test_keeper_raw_task_signal_wake
@@ -330,6 +331,7 @@
   test_keeper_cooldown_cause_23438
   test_keeper_lifecycle_gate
   test_keeper_lifecycle_global_gate
+  test_keeper_admission_edge
   test_keeper_memory_lane
   test_env_keeper_scrub
   test_keeper_connector_attention_wake

--- a/test/test_board_collect_pause_gate.ml
+++ b/test/test_board_collect_pause_gate.ml
@@ -10,32 +10,17 @@
 open Alcotest
 module BE = Masc.Keeper_heartbeat_loop_board_events
 
-let gate
-      ~warm
-      ~paused
-      ()
-  =
-  BE.should_collect_board_events
-    ~proactive_warmup_elapsed:warm
-    ~paused
+let gate ~paused () = BE.should_collect_board_events ~paused
 
-let test_warm_unpaused_collects () =
-  check bool "warmed + unpaused keeper collects board events" true
-    (gate ~warm:true ~paused:false ())
+let test_unpaused_collects () =
+  check bool "unpaused keeper collects board events" true
+    (gate ~paused:false ())
 
-(* The regression: before the fix, a warmed keeper collected (and advanced the
+(* The regression: before the fix, a keeper collected (and advanced the
    cursor) regardless of pause state, dropping board posts for paused keepers. *)
-let test_warm_paused_skips () =
-  check bool "warmed + PAUSED keeper must not collect (cursor stays put)" false
-    (gate ~warm:true ~paused:true ())
-
-let test_cold_unpaused_skips () =
-  check bool "not-yet-warmed keeper does not collect" false
-    (gate ~warm:false ~paused:false ())
-
-let test_cold_paused_skips () =
-  check bool "not-yet-warmed + paused keeper does not collect" false
-    (gate ~warm:false ~paused:true ())
+let test_paused_skips () =
+  check bool "PAUSED keeper must not collect (cursor stays put)" false
+    (gate ~paused:true ())
 
 let test_collection_failure_health_degrades_and_clears () =
   let base_path = "/tmp/masc-board-collection-health-test" in
@@ -83,10 +68,8 @@ let () =
     [
       ( "should_collect_board_events",
         [
-          test_case "warm + unpaused -> collect" `Quick test_warm_unpaused_collects;
-          test_case "warm + paused -> skip" `Quick test_warm_paused_skips;
-          test_case "cold + unpaused -> skip" `Quick test_cold_unpaused_skips;
-          test_case "cold + paused -> skip" `Quick test_cold_paused_skips;
+          test_case "unpaused -> collect" `Quick test_unpaused_collects;
+          test_case "paused -> skip" `Quick test_paused_skips;
           test_case "collection failure health degrades and clears" `Quick
             test_collection_failure_health_degrades_and_clears;
         ] );

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -486,13 +486,11 @@ let test_list_posts_with_sort () =
 
 let board_observation_meta name =
   match
-    Keeper_meta_json_parse.meta_of_json
+    Masc_test_deps.meta_of_json_fixture
       (`Assoc
         [ "name", `String name
         ; "agent_name", `String ("keeper-" ^ name ^ "-agent")
         ; "trace_id", `String ("trace-" ^ name)
-        ; "sandbox_profile", `String "local"
-        ; "network_mode", `String "inherit"
         ])
   with
   | Ok meta -> meta

--- a/test/test_broadcast_wakeup_policy.ml
+++ b/test/test_broadcast_wakeup_policy.ml
@@ -6,16 +6,16 @@ let test_mention_wakes_target () =
   match Broadcast_wakeup.broadcast_mention_wakeup_action (Some "rondo") with
   | `Wake_keeper "rondo" -> ()
   | `Wake_keeper other -> failf "unexpected wake target: %s" other
-  | `Suppress_no_target -> fail "expected explicit mention to wake target"
+  | `No_keeper_target -> fail "expected explicit mention to wake target"
 
 let test_none_is_passive () =
   match Broadcast_wakeup.broadcast_mention_wakeup_action None with
-  | `Suppress_no_target -> ()
+  | `No_keeper_target -> ()
   | `Wake_keeper target -> failf "unexpected no-target wake: %s" target
 
 let test_blank_is_passive () =
   match Broadcast_wakeup.broadcast_mention_wakeup_action (Some "  ") with
-  | `Suppress_no_target -> ()
+  | `No_keeper_target -> ()
   | `Wake_keeper target -> failf "unexpected blank-target wake: %s" target
 
 let () =

--- a/test/test_env_config_keeper_bootstrap_intervals.ml
+++ b/test/test_env_config_keeper_bootstrap_intervals.ml
@@ -1,11 +1,9 @@
-(** Pin the {!Env_config_keeper.KeeperBootstrap} polling/settle
-    interval contract. Three values were extracted from inline
+(** Pin the {!Env_config_keeper.KeeperBootstrap} polling
+    interval contract. Two values were extracted from inline
     literals at [server_bootstrap_loops.ml]:
 
     - line 157  0.25  → lazy_startup_poll_interval_sec
     - line 240  0.25  → keeper_listener_retry_interval_sec
-    - line 482  5.0   → post_startup_settle_sec
-
     The two [0.25] values shared a literal but encode *different*
     intents (lazy-startup polling vs. listener-retry backoff). The
     SSOT keeps them as separate knobs so future operator overrides
@@ -18,8 +16,8 @@
        clock or burn CPU on busy-poll).
     2. Polling intervals have a >= 0.05s floor (50ms) so an operator
        typo doesn't accidentally turn the loop into a CPU sink.
-    3. [post_startup_settle_sec] allows 0 (no settle) but caps at
-       no upper bound — operators on slow machines may raise. *)
+    3. Keeper bootstrap starts as soon as lazy startup completes; there is no
+       artificial settle delay. *)
 
 open Alcotest
 
@@ -39,11 +37,6 @@ let test_default_listener_retry () =
     "keeper_listener_retry_interval_sec default (was inline 0.25)"
     0.25 KB.keeper_listener_retry_interval_sec
 
-let test_default_post_startup_settle () =
-  check approx
-    "post_startup_settle_sec default (was inline 5.0)"
-    5.0 KB.post_startup_settle_sec
-
 let test_polling_floor () =
   check bool
     "lazy_startup_poll_interval_sec must satisfy the documented \
@@ -55,106 +48,6 @@ let test_polling_floor () =
      >= 0.05s floor"
     true
     (KB.keeper_listener_retry_interval_sec >= 0.05)
-
-let test_autoboot_warmup_jitter_is_bounded_not_linear () =
-  let names =
-    [
-      "analyst";
-      "executor";
-      "issue_king";
-      "janitor";
-      "masc-improver";
-      "nick0cave";
-      "qa-king";
-      "ramarama";
-      "sangsu";
-      "scholar";
-      "taskmaster";
-      "tech_glutton";
-      "velvet-hammer";
-      "verifier";
-    ]
-  in
-  let warmups =
-    List.map
-      (fun keeper_name ->
-        Boot.autoboot_proactive_warmup_sec ~base_warmup:60
-          ~stagger_window_sec:15 ~keeper_name)
-      names
-  in
-  check bool "every warmup stays inside the 60..75s jitter window" true
-    (List.for_all (fun value -> value >= 60 && value <= 75) warmups);
-  check bool "last keeper is not delayed by list position" true
-    (List.nth warmups 13 <= 75)
-
-(* §L (tracker #13155): pin exact warmup outputs for fixed keeper
-   names so any silent regression to native-int [acc lsl 5] (which
-   wraps differently on 31-bit vs 63-bit OCaml) breaks at least one
-   assertion on at least one architecture.
-
-   Expected values come from the Int32 djb2 spec:
-     [acc := Int32.logand (Int32.add (Int32.add (acc lsl 5) acc) ch)
-            0x3FFF_FFFFl]
-
-   With [base_warmup = 0, stagger_window_sec = 99] the formula
-   reduces to [hash mod 100] which is itself stable across platforms
-   under the Int32 implementation. *)
-let test_warmup_hash_pinned_cross_platform () =
-  let warmup name =
-    Boot.autoboot_proactive_warmup_sec ~base_warmup:0
-      ~stagger_window_sec:99 ~keeper_name:name
-  in
-  check int "verifier hash mod 100 (Int32 djb2)" 25 (warmup "verifier");
-  check int "designer hash mod 100 (Int32 djb2)" 74 (warmup "designer");
-  check int "developer hash mod 100 (Int32 djb2)" 15 (warmup "developer");
-  check int "analyst hash mod 100 (Int32 djb2)" 73 (warmup "analyst");
-  check int "janitor hash mod 100 (Int32 djb2)" 4 (warmup "janitor")
-
-let test_autoboot_warmup_is_order_independent () =
-  let warmup name =
-    Boot.autoboot_proactive_warmup_sec ~base_warmup:60 ~stagger_window_sec:15
-      ~keeper_name:name
-  in
-  (* PR #13119 review: previously this test called [warmup "verifier"]
-     twice with identical inputs, which would still pass even if the
-     implementation depended on list position.  The actual invariant
-     is "permuting the keeper boot list does not change any individual
-     keeper's warmup".  Compute warmups for an ordered name list and
-     for its reverse, then assert per-name equality. *)
-  let names = [
-    "verifier"; "designer"; "developer"; "operator"; "supervisor";
-    "tester"; "auditor"; "researcher"; "writer"; "scheduler";
-  ] in
-  let warmups_forward = List.map (fun n -> (n, warmup n)) names in
-  let warmups_reverse = List.map (fun n -> (n, warmup n)) (List.rev names) in
-  List.iter
-    (fun (name, w_fwd) ->
-      let w_rev = List.assoc name warmups_reverse in
-      check int
-        (Printf.sprintf "%s gets identical warmup regardless of list position"
-           name)
-        w_fwd w_rev)
-    warmups_forward;
-  check int "same keeper gets same warmup independent of boot order"
-    (warmup "verifier") (warmup "verifier");
-  check int "zero jitter keeps exact base warmup" 60
-    (Boot.autoboot_proactive_warmup_sec ~base_warmup:60
-       ~stagger_window_sec:0 ~keeper_name:"verifier");
-  (* Coverage smoke: the test assumes the hash actually distributes
-     names across the stagger window — if every name collapsed to
-     a single offset the previous "no list-position dependency"
-     check would degenerate to a tautology.  Assert ≥3 distinct
-     warmup values across the 10-name list (with stagger=15 the
-     hash buckets collide naturally; ≥3 still proves the hash is
-     producing a non-trivial distribution). *)
-  let distinct =
-    warmups_forward
-    |> List.map snd
-    |> List.sort_uniq compare
-    |> List.length
-  in
-  check bool "stagger produces ≥3 distinct warmups across 10 names" true
-    (distinct >= 3)
 
 let test_discord_queue_projection_matches_gateway_context () =
   let queued : Chat_queue.queued_message =
@@ -220,22 +113,11 @@ let () =
             test_default_lazy_startup_poll;
           test_case "listener_retry = 0.25" `Quick
             test_default_listener_retry;
-          test_case "post_startup_settle = 5.0" `Quick
-            test_default_post_startup_settle;
         ] );
       ( "polling floors",
         [
           test_case ">= 0.05s floor on both polling intervals" `Quick
             test_polling_floor;
-        ] );
-      ( "autoboot warmup fairness",
-        [
-          test_case "jitter bounded, not linear by boot order" `Quick
-            test_autoboot_warmup_jitter_is_bounded_not_linear;
-          test_case "warmup deterministic per keeper" `Quick
-            test_autoboot_warmup_is_order_independent;
-          test_case "Int32 hash pinned cross-platform (#13155 §L)" `Quick
-            test_warmup_hash_pinned_cross_platform;
         ] );
       ( "queued chat projection",
         [

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -320,10 +320,12 @@ let base_observation : WO.world_observation =
   ; claimable_task_count = 0
   ; failed_task_count = 0
   ; scheduled_automation = WO.empty_scheduled_automation_observation
-  ; backlog_updated_since_last_scheduled_autonomous = false
-  ; backlog_revision = Some 1
-  ; backlog_projection_sha256 = Some (String.make 64 '0')
-  ; backlog_source = Masc.Keeper_world_observation_inputs.Primary
+  ; backlog_edge =
+      Masc.Keeper_world_observation_inputs.Observed_backlog
+        { revision = 1
+        ; projection_sha256 = String.make 64 '0'
+        ; updated_since_last_scheduled_autonomous = false
+        }
   ; running_keeper_fiber_count = 0
   ; connected_surfaces = []
   ; connected_surface_failures = []

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -323,6 +323,7 @@ let base_observation : WO.world_observation =
   ; backlog_updated_since_last_scheduled_autonomous = false
   ; backlog_revision = Some 1
   ; backlog_projection_sha256 = Some (String.make 64 '0')
+  ; backlog_source = Masc.Keeper_world_observation_inputs.Primary
   ; running_keeper_fiber_count = 0
   ; connected_surfaces = []
   ; connected_surface_failures = []

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -322,6 +322,7 @@ let base_observation : WO.world_observation =
   ; scheduled_automation = WO.empty_scheduled_automation_observation
   ; backlog_updated_since_last_scheduled_autonomous = false
   ; backlog_revision = Some 1
+  ; backlog_projection_sha256 = Some (String.make 64 '0')
   ; running_keeper_fiber_count = 0
   ; connected_surfaces = []
   ; connected_surface_failures = []

--- a/test/test_keeper_admission_edge.ml
+++ b/test/test_keeper_admission_edge.ml
@@ -339,7 +339,7 @@ let test_unreadable_backlog_does_not_silence_other_stimuli () =
 let test_recovery_backlog_is_not_authoritative () =
   without_overrides @@ fun () ->
   let recovery =
-    { Workspace.primary_error = "primary backlog is corrupt"
+    { Masc.Workspace.primary_error = "primary backlog is corrupt"
     ; recovery_path = "/workspace/tasks/backlog.json.last-good"
     }
   in

--- a/test/test_keeper_admission_edge.ml
+++ b/test/test_keeper_admission_edge.ml
@@ -1,0 +1,361 @@
+(** RFC-0357 admission slice: a scheduled-autonomous turn admits on a typed
+    stimulus, never on the heartbeat tick itself.
+
+    Pinned here, mapped to the RFC's test list (§7):
+
+    - empty observation + gate on -> [Skip No_actionable_stimulus]
+    - each disjunct alone -> [Run]: bootstrap, pending message, pending board
+      event, backlog revision edge, due schedule
+    - failure-matrix rows at the decision level: a consumed edge
+      (version = consumed) stays silent (self-limiting; also the shape of
+      "failed turn keeps its in-memory stamp"), an unconsumed edge
+      (version > consumed) admits (continuity; also the shape of
+      "crash before the durable write re-arms the edge")
+    - fast-turn continuity: the edge is a revision compare only — no
+      wall-clock input anywhere, so a change landing in the same second as
+      the previous admission still re-admits (asserted by using a
+      freshly-stamped meta and only bumping the revision)
+    - meta JSON: [last_consumed_backlog_revision] round-trips; an ABSENT
+      field decodes as genesis 0 (pre-RFC metas must not invalidate); a
+      PRESENT malformed or negative value fails the decode (fail-closed).
+
+    Not covered here (stated, not hidden): the in-memory stamp write in
+    [keeper_heartbeat_loop] and the [update_metrics_from_result]
+    pass-through are integration surfaces exercised by the heartbeat suites;
+    building a [Keeper_agent_run.run_result] fixture is out of scope for
+    this unit file. *)
+
+open Alcotest
+module WO = Masc.Keeper_world_observation
+module Inputs = Masc.Keeper_world_observation_inputs
+
+let make_meta name =
+  let json =
+    `Assoc
+      [ ("name", `String name)
+      ; ("agent_name", `String (Masc.Keeper_identity.keeper_agent_name name))
+      ; ("trace_id", `String ("trace-admission-" ^ name))
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok meta -> meta
+  | Error err -> Alcotest.fail ("make_meta failed: " ^ err)
+;;
+
+(* A keeper that has already bootstrapped (a scheduled turn ran before) and
+   whose consumption clock sits at [last_consumed]. *)
+let bootstrapped_meta ?(last_consumed = 1) () =
+  let meta = make_meta "admission" in
+  let now = Time_compat.now () in
+  { meta with
+    autoboot_enabled = true
+  ; proactive = { enabled = true }
+  ; runtime =
+      { meta.runtime with
+        proactive_rt =
+          { meta.runtime.proactive_rt with
+            last_ts = now -. 120.0
+          ; last_consumed_backlog_revision = last_consumed
+          }
+      }
+  }
+;;
+
+(* Never ran a scheduled turn: [last_ts = 0.0] is the bootstrap marker. *)
+let never_started_meta () =
+  let meta = make_meta "admission-bootstrap" in
+  { meta with
+    autoboot_enabled = true
+  ; proactive = { enabled = true }
+  ; runtime =
+      { meta.runtime with
+        proactive_rt = { meta.runtime.proactive_rt with last_ts = 0.0 }
+      }
+  }
+;;
+
+(* No stimulus anywhere; the backlog exists at revision 1 and has been
+   consumed ([backlog_updated_since_last_scheduled_autonomous = false]). *)
+let base_obs : WO.world_observation =
+  { pending_messages = []
+  ; pending_board_events = []
+  ; idle_seconds = 0
+  ; active_goals = []
+  ; unclaimed_task_count = 0
+  ; claimable_task_count = 0
+  ; failed_task_count = 0
+  ; scheduled_automation = WO.empty_scheduled_automation_observation
+  ; backlog_updated_since_last_scheduled_autonomous = false
+  ; backlog_revision = Some 1
+  ; running_keeper_fiber_count = 1
+  ; connected_surfaces = []
+  ; connected_surface_failures = []
+  ; own_recent_board_posts = []
+  }
+;;
+
+let backlog_edge_obs =
+  { base_obs with
+    backlog_updated_since_last_scheduled_autonomous = true
+  ; backlog_revision = Some 2
+  ; claimable_task_count = 1
+  ; unclaimed_task_count = 1
+  }
+;;
+
+let due_schedule_obs =
+  { base_obs with
+    scheduled_automation =
+      { WO.empty_scheduled_automation_observation with
+        active_count = 1
+      ; due_ready_count = 1
+      }
+  }
+;;
+
+let mention_obs =
+  { base_obs with
+    pending_messages =
+      [ { Masc.Keeper_world_observation_message_scope.message_id = "mention-1"
+        ; speaker = "peer"
+        ; content = "ping"
+        ; kind = Mention
+        }
+      ]
+  }
+;;
+
+let board_event_obs =
+  { base_obs with
+    pending_board_events =
+      [ { WO.event_kind = WO.Board_post_created
+        ; post_id = "post-1"
+        ; author = "peer"
+        ; title = "note"
+        ; preview = "note body"
+        ; hearth = None
+        ; post_kind = Masc.Board.Human_post
+        ; updated_at = 0.0
+        ; explicit_mention = false
+        ; matched_targets = []
+        ; self_commented = false
+        ; new_external_since = 0
+        ; latest_external_author = None
+        ; latest_external_preview = None
+        }
+      ]
+  }
+;;
+
+let with_flag name value f =
+  Config_boot_overrides.reset_for_tests ();
+  Config_boot_overrides.set name value;
+  Fun.protect ~finally:(fun () -> Config_boot_overrides.reset_for_tests ()) f
+;;
+
+let without_overrides f =
+  Config_boot_overrides.reset_for_tests ();
+  Fun.protect ~finally:(fun () -> Config_boot_overrides.reset_for_tests ()) f
+;;
+
+let decide ~meta obs = WO.keeper_cycle_decision ~reactive_wake:false ~meta obs
+
+let skip_reasons d =
+  match d.WO.verdict with
+  | WO.Skip { reasons = first, rest } -> first :: rest
+  | WO.Run _ -> []
+;;
+
+let run_reasons d =
+  match d.WO.verdict with
+  | WO.Run { reasons = first, rest } -> first :: rest
+  | WO.Skip _ -> []
+;;
+
+let is_scheduled d =
+  match d.WO.channel with
+  | WO.Scheduled_autonomous -> true
+  | WO.Reactive -> false
+;;
+
+(* ==== §3.1: empty observation is a typed skip, not a turn ==== *)
+
+let test_empty_observation_skips () =
+  without_overrides @@ fun () ->
+  let d = decide ~meta:(bootstrapped_meta ()) base_obs in
+  check bool "no stimulus -> no turn" false d.WO.should_run;
+  check bool "scheduled channel" true (is_scheduled d);
+  check bool "skip reason is no_actionable_stimulus" true
+    (List.exists (( = ) WO.No_actionable_stimulus) (skip_reasons d))
+;;
+
+(* ==== §3.1: each disjunct alone admits ==== *)
+
+let test_bootstrap_admits () =
+  without_overrides @@ fun () ->
+  let d = decide ~meta:(never_started_meta ()) base_obs in
+  check bool "bootstrap admits" true d.WO.should_run;
+  check bool "scheduled channel" true (is_scheduled d);
+  check bool "never_started in reasons" true
+    (List.exists (( = ) WO.Never_started) (run_reasons d))
+;;
+
+let test_backlog_edge_admits () =
+  without_overrides @@ fun () ->
+  let d = decide ~meta:(bootstrapped_meta ()) backlog_edge_obs in
+  check bool "backlog edge admits" true d.WO.should_run;
+  check bool "scheduled channel" true (is_scheduled d);
+  check bool "task_backlog observation attached" true
+    (List.exists
+       (function
+         | WO.Task_backlog _ -> true
+         | _ -> false)
+       (run_reasons d))
+;;
+
+let test_due_schedule_admits () =
+  without_overrides @@ fun () ->
+  let d = decide ~meta:(bootstrapped_meta ()) due_schedule_obs in
+  check bool "due schedule admits" true d.WO.should_run;
+  check bool "scheduled_automation_due in reasons" true
+    (List.exists (( = ) WO.Scheduled_automation_due) (run_reasons d))
+;;
+
+(* A pending message normally opens a REACTIVE turn. With the reactive gate
+   off it must still admit the scheduled channel (RFC-0297 starvation rule +
+   RFC-0357 §3.1 message disjunct) — a suppressed lane must not silence a
+   typed stimulus. *)
+let test_pending_message_admits_scheduled_when_reactive_off () =
+  with_flag "MASC_KEEPER_REACTIVE_ENABLED" "false" @@ fun () ->
+  let d = decide ~meta:(bootstrapped_meta ()) mention_obs in
+  check bool "pending message admits" true d.WO.should_run;
+  check bool "scheduled channel" true (is_scheduled d)
+;;
+
+let test_pending_board_event_admits_scheduled_when_reactive_off () =
+  with_flag "MASC_KEEPER_REACTIVE_ENABLED" "false" @@ fun () ->
+  let d = decide ~meta:(bootstrapped_meta ()) board_event_obs in
+  check bool "pending board event admits" true d.WO.should_run;
+  check bool "scheduled channel" true (is_scheduled d)
+;;
+
+(* ==== §3.3 matrix at the decision level ==== *)
+
+(* Self-limiting: a consumed edge stays silent. This is also the shape of
+   matrix row 4 — after a failed turn the in-memory stamp equals the
+   observed revision, so the same edge does not re-admit every heartbeat. *)
+let test_consumed_edge_stays_silent () =
+  without_overrides @@ fun () ->
+  let d = decide ~meta:(bootstrapped_meta ~last_consumed:2 ()) base_obs in
+  check bool "consumed edge -> silent" false d.WO.should_run;
+  check bool "skip reason is no_actionable_stimulus" true
+    (List.exists (( = ) WO.No_actionable_stimulus) (skip_reasons d))
+;;
+
+(* ==== §3.2: the edge is a revision compare, no clock anywhere ==== *)
+
+let edge ~last_consumed ~version =
+  let meta = bootstrapped_meta ~last_consumed () in
+  let backlog : Masc_domain.backlog =
+    { tasks = []; last_updated = "not-a-timestamp"; version }
+  in
+  Inputs.backlog_updated_since_last_scheduled_autonomous ~meta ~backlog
+;;
+
+let test_edge_is_pure_revision_compare () =
+  (* genesis: never consumed, any live backlog is one pending edge *)
+  check bool "0 < 1 edges" true (edge ~last_consumed:0 ~version:1);
+  (* consumed exactly: silent *)
+  check bool "5 = 5 silent" false (edge ~last_consumed:5 ~version:5);
+  (* fast-turn continuity: a commit in the same wall-clock instant as the
+     stamp still edges, because only the revision moved. [last_updated] is
+     deliberately unparseable — proof the clock and the ISO field are not
+     inputs (the old implementation returned [false] forever on a parse
+     failure). *)
+  check bool "5 < 6 edges" true (edge ~last_consumed:5 ~version:6);
+  check bool "6 = 6 silent after stamp" false (edge ~last_consumed:6 ~version:6);
+  check bool "6 < 7 re-edges" true (edge ~last_consumed:6 ~version:7)
+;;
+
+(* ==== meta JSON: durable consumption clock ==== *)
+
+let json_with_field meta ~f =
+  match Masc.Keeper_meta_json.meta_to_json meta with
+  | `Assoc fields -> `Assoc (f fields)
+  | other -> Alcotest.failf "meta_to_json not an object: %s" (Yojson.Safe.to_string other)
+;;
+
+let test_meta_json_roundtrip () =
+  let meta = bootstrapped_meta ~last_consumed:42 () in
+  let json = Masc.Keeper_meta_json.meta_to_json meta in
+  match Masc.Keeper_meta_json_parse.meta_of_json json with
+  | Error e -> Alcotest.fail ("roundtrip decode failed: " ^ e)
+  | Ok decoded ->
+    check int "consumption clock survives the roundtrip" 42
+      decoded.runtime.proactive_rt.last_consumed_backlog_revision
+;;
+
+let test_meta_json_absent_is_genesis () =
+  let meta = bootstrapped_meta ~last_consumed:42 () in
+  let json =
+    json_with_field meta ~f:(fun fields ->
+      List.filter
+        (fun (key, _) -> not (String.equal key "last_consumed_backlog_revision"))
+        fields)
+  in
+  match Masc.Keeper_meta_json_parse.meta_of_json json with
+  | Error e -> Alcotest.fail ("absent field must decode (pre-RFC meta): " ^ e)
+  | Ok decoded ->
+    check int "absent decodes as genesis 0" 0
+      decoded.runtime.proactive_rt.last_consumed_backlog_revision
+;;
+
+let test_meta_json_malformed_fails_closed () =
+  let meta = bootstrapped_meta ~last_consumed:42 () in
+  let replace value fields =
+    List.map
+      (fun (key, v) ->
+         if String.equal key "last_consumed_backlog_revision" then key, value else key, v)
+      fields
+  in
+  (match
+     Masc.Keeper_meta_json_parse.meta_of_json
+       (json_with_field meta ~f:(replace (`String "42")))
+   with
+   | Ok _ -> Alcotest.fail "string revision must fail the decode"
+   | Error _ -> ());
+  match
+    Masc.Keeper_meta_json_parse.meta_of_json
+      (json_with_field meta ~f:(replace (`Int (-3))))
+  with
+  | Ok _ -> Alcotest.fail "negative revision must fail the decode"
+  | Error _ -> ()
+;;
+
+let () =
+  Alcotest.run
+    "Keeper Admission Edge"
+    [ ( "admission"
+      , [ test_case "empty observation skips" `Quick test_empty_observation_skips
+        ; test_case "bootstrap admits" `Quick test_bootstrap_admits
+        ; test_case "backlog edge admits" `Quick test_backlog_edge_admits
+        ; test_case "due schedule admits" `Quick test_due_schedule_admits
+        ; test_case
+            "pending message admits scheduled when reactive off"
+            `Quick
+            test_pending_message_admits_scheduled_when_reactive_off
+        ; test_case
+            "pending board event admits scheduled when reactive off"
+            `Quick
+            test_pending_board_event_admits_scheduled_when_reactive_off
+        ; test_case "consumed edge stays silent" `Quick test_consumed_edge_stays_silent
+        ] )
+    ; ( "edge_compare"
+      , [ test_case "pure revision compare" `Quick test_edge_is_pure_revision_compare ] )
+    ; ( "meta_json"
+      , [ test_case "roundtrip" `Quick test_meta_json_roundtrip
+        ; test_case "absent is genesis" `Quick test_meta_json_absent_is_genesis
+        ; test_case "malformed fails closed" `Quick test_meta_json_malformed_fails_closed
+        ] )
+    ]
+;;

--- a/test/test_keeper_admission_edge.ml
+++ b/test/test_keeper_admission_edge.ml
@@ -5,7 +5,12 @@
 
     - empty observation + gate on -> [Skip No_actionable_stimulus]
     - each disjunct alone -> [Run]: bootstrap, pending message, pending board
-      event, backlog revision edge, due schedule
+      event, backlog revision edge, due schedule — each carrying its own
+      typed reason (the reason list is the predicate; nameless admission is
+      unrepresentable)
+    - a blind observation (failed backlog read, revision [None]) skips as
+      [Backlog_unreadable], never as [No_actionable_stimulus], and does not
+      silence the other disjuncts
     - failure-matrix rows at the decision level: a consumed edge
       (version = consumed) stays silent (self-limiting; also the shape of
       "failed turn keeps its in-memory stamp"), an unconsumed edge
@@ -229,14 +234,18 @@ let test_pending_message_admits_scheduled_when_reactive_off () =
   with_flag "MASC_KEEPER_REACTIVE_ENABLED" "false" @@ fun () ->
   let d = decide ~meta:(bootstrapped_meta ()) mention_obs in
   check bool "pending message admits" true d.WO.should_run;
-  check bool "scheduled channel" true (is_scheduled d)
+  check bool "scheduled channel" true (is_scheduled d);
+  check bool "scope_message_pending in reasons" true
+    (List.exists (( = ) WO.Scope_message_pending) (run_reasons d))
 ;;
 
 let test_pending_board_event_admits_scheduled_when_reactive_off () =
   with_flag "MASC_KEEPER_REACTIVE_ENABLED" "false" @@ fun () ->
   let d = decide ~meta:(bootstrapped_meta ()) board_event_obs in
   check bool "pending board event admits" true d.WO.should_run;
-  check bool "scheduled channel" true (is_scheduled d)
+  check bool "scheduled channel" true (is_scheduled d);
+  check bool "board_event_pending in reasons" true
+    (List.exists (( = ) WO.Board_event_pending) (run_reasons d))
 ;;
 
 (* ==== §3.3 matrix at the decision level ==== *)
@@ -250,6 +259,36 @@ let test_consumed_edge_stays_silent () =
   check bool "consumed edge -> silent" false d.WO.should_run;
   check bool "skip reason is no_actionable_stimulus" true
     (List.exists (( = ) WO.No_actionable_stimulus) (skip_reasons d))
+;;
+
+(* ==== read failure is not designed silence ==== *)
+
+(* [backlog_revision = None] models a failed backlog read (the inputs layer
+   maps [read_backlog_r]'s [Error] to [None]). With no other stimulus the
+   skip must say so — recording it as [No_actionable_stimulus] would present
+   a blind observation as a considered "nothing to do". *)
+let test_unreadable_backlog_skips_as_unreadable () =
+  without_overrides @@ fun () ->
+  let d =
+    decide ~meta:(bootstrapped_meta ()) { base_obs with backlog_revision = None }
+  in
+  check bool "no turn on a blind observation" false d.WO.should_run;
+  check bool "skip reason is backlog_unreadable" true
+    (List.exists (( = ) WO.Backlog_unreadable) (skip_reasons d));
+  check bool "not recorded as designed silence" false
+    (List.exists (( = ) WO.No_actionable_stimulus) (skip_reasons d))
+;;
+
+(* A failed backlog read must not silence the other disjuncts: a pending
+   message is a complete stimulus on its own. *)
+let test_unreadable_backlog_does_not_silence_other_stimuli () =
+  with_flag "MASC_KEEPER_REACTIVE_ENABLED" "false" @@ fun () ->
+  let d =
+    decide ~meta:(bootstrapped_meta ()) { mention_obs with backlog_revision = None }
+  in
+  check bool "message still admits" true d.WO.should_run;
+  check bool "scope_message_pending in reasons" true
+    (List.exists (( = ) WO.Scope_message_pending) (run_reasons d))
 ;;
 
 (* ==== §3.2: the edge is a revision compare, no clock anywhere ==== *)
@@ -349,6 +388,14 @@ let () =
             `Quick
             test_pending_board_event_admits_scheduled_when_reactive_off
         ; test_case "consumed edge stays silent" `Quick test_consumed_edge_stays_silent
+        ; test_case
+            "unreadable backlog skips as unreadable"
+            `Quick
+            test_unreadable_backlog_skips_as_unreadable
+        ; test_case
+            "unreadable backlog does not silence other stimuli"
+            `Quick
+            test_unreadable_backlog_does_not_silence_other_stimuli
         ] )
     ; ( "edge_compare"
       , [ test_case "pure revision compare" `Quick test_edge_is_pure_revision_compare ] )

--- a/test/test_keeper_admission_edge.ml
+++ b/test/test_keeper_admission_edge.ml
@@ -496,7 +496,9 @@ let test_meta_json_roundtrip () =
       decoded.runtime.proactive_rt.last_consumed_backlog_projection_sha256
 ;;
 
-let test_meta_json_absent_pair_fails_closed () =
+(* Removing ONE half of the pair leaves a half-genesis state, which the pair
+   invariant rejects even under absence tolerance. *)
+let test_meta_json_half_genesis_fails_closed () =
   let meta = bootstrapped_meta ~last_consumed:42 () in
   let remove field fields =
     List.filter (fun (key, _) -> not (String.equal key field)) fields
@@ -505,8 +507,32 @@ let test_meta_json_absent_pair_fails_closed () =
     (fun field ->
        match Masc.Keeper_meta_json_parse.meta_of_json (json_with_field meta ~f:(remove field)) with
        | Error _ -> ()
-       | Ok _ -> Alcotest.failf "missing current field %s must fail the decode" field)
+       | Ok _ -> Alcotest.failf "half-genesis without %s must fail the decode" field)
     [ "last_consumed_backlog_revision"; "last_consumed_backlog_projection_sha256" ]
+;;
+
+(* A pre-RFC meta lacks BOTH fields and must decode with the genesis pair —
+   owner ruling 2026-08-03: live metas are 10/10 without the pair, and an
+   invalid meta cannot be read or rewritten, so absent=invalid would strand
+   the fleet (#26530 shape). *)
+let test_meta_json_absent_pair_decodes_as_genesis () =
+  let meta = bootstrapped_meta ~last_consumed:42 () in
+  let json =
+    json_with_field meta ~f:(fun fields ->
+      List.filter
+        (fun (key, _) ->
+           not
+             (String.equal key "last_consumed_backlog_revision"
+              || String.equal key "last_consumed_backlog_projection_sha256"))
+        fields)
+  in
+  match Masc.Keeper_meta_json_parse.meta_of_json json with
+  | Error e -> Alcotest.fail ("pre-RFC meta must decode with the genesis pair: " ^ e)
+  | Ok decoded ->
+    check int "absent revision decodes as genesis 0" 0
+      decoded.runtime.proactive_rt.last_consumed_backlog_revision;
+    check string "absent projection decodes as genesis empty" ""
+      decoded.runtime.proactive_rt.last_consumed_backlog_projection_sha256
 ;;
 
 let test_meta_json_missing_required_field_fails () =
@@ -644,9 +670,13 @@ let () =
     ; ( "meta_json"
       , [ test_case "roundtrip" `Quick test_meta_json_roundtrip
         ; test_case
-            "absent pair fails closed"
+            "half genesis fails closed"
             `Quick
-            test_meta_json_absent_pair_fails_closed
+            test_meta_json_half_genesis_fails_closed
+        ; test_case
+            "absent pair decodes as genesis"
+            `Quick
+            test_meta_json_absent_pair_decodes_as_genesis
         ; test_case
             "missing required field fails"
             `Quick

--- a/test/test_keeper_admission_edge.ml
+++ b/test/test_keeper_admission_edge.ml
@@ -336,6 +336,30 @@ let test_unreadable_backlog_does_not_silence_other_stimuli () =
     (List.exists (( = ) WO.Scope_message_pending) (run_reasons d))
 ;;
 
+let test_recovery_backlog_is_not_authoritative () =
+  without_overrides @@ fun () ->
+  let recovery =
+    { Workspace.primary_error = "primary backlog is corrupt"
+    ; recovery_path = "/workspace/tasks/backlog.json.last-good"
+    }
+  in
+  let d =
+    decide
+      ~meta:(bootstrapped_meta ())
+      { base_obs with
+        backlog_edge =
+          Inputs.Recovery_backlog
+            { revision = 2
+            ; projection_sha256 = projection_b
+            ; recovery
+            }
+      }
+  in
+  check bool "recovery snapshot does not admit a scheduled edge" false d.WO.should_run;
+  check bool "recovery snapshot is not designed silence" true
+    (List.exists (( = ) WO.Backlog_unreadable) (skip_reasons d))
+;;
+
 (* ==== §3.2: the edge is a revision compare, no clock anywhere ==== *)
 
 let edge ~last_consumed ~last_projection ~version ~projection =
@@ -579,6 +603,10 @@ let () =
             "unreadable backlog does not silence other stimuli"
             `Quick
             test_unreadable_backlog_does_not_silence_other_stimuli
+        ; test_case
+            "recovery backlog is not authoritative"
+            `Quick
+            test_recovery_backlog_is_not_authoritative
         ] )
     ; ( "edge_compare"
       , [ test_case "revision and projection pair" `Quick test_edge_is_pure_revision_compare

--- a/test/test_keeper_admission_edge.ml
+++ b/test/test_keeper_admission_edge.ml
@@ -82,7 +82,7 @@ let never_started_meta () =
 ;;
 
 (* No stimulus anywhere; the backlog exists at revision 1 and has been
-   consumed ([backlog_updated_since_last_scheduled_autonomous = false]). *)
+   consumed. *)
 let base_obs : WO.world_observation =
   { pending_messages = []
   ; pending_board_events = []
@@ -92,10 +92,12 @@ let base_obs : WO.world_observation =
   ; claimable_task_count = 0
   ; failed_task_count = 0
   ; scheduled_automation = WO.empty_scheduled_automation_observation
-  ; backlog_updated_since_last_scheduled_autonomous = false
-  ; backlog_revision = Some 1
-  ; backlog_projection_sha256 = Some projection_a
-  ; backlog_source = Inputs.Primary
+  ; backlog_edge =
+      Inputs.Observed_backlog
+        { revision = 1
+        ; projection_sha256 = projection_a
+        ; updated_since_last_scheduled_autonomous = false
+        }
   ; running_keeper_fiber_count = 1
   ; connected_surfaces = []
   ; connected_surface_failures = []
@@ -105,9 +107,12 @@ let base_obs : WO.world_observation =
 
 let backlog_edge_obs =
   { base_obs with
-    backlog_updated_since_last_scheduled_autonomous = true
-  ; backlog_revision = Some 2
-  ; backlog_projection_sha256 = Some projection_b
+    backlog_edge =
+      Inputs.Observed_backlog
+        { revision = 2
+        ; projection_sha256 = projection_b
+        ; updated_since_last_scheduled_autonomous = true
+        }
   ; claimable_task_count = 1
   ; unclaimed_task_count = 1
   }
@@ -279,45 +284,28 @@ let test_consumed_edge_stays_silent () =
 
 let test_scheduled_admission_records_exact_pair () =
   let before = bootstrapped_meta () in
-  match WO.record_scheduled_backlog_consumption ~meta:before backlog_edge_obs with
-  | Error _ -> Alcotest.fail "complete backlog observation was rejected"
-  | Ok after ->
-    check int "observed revision is recorded" 2
-      after.runtime.proactive_rt.last_consumed_backlog_revision;
-    check string "projection stays paired with revision" projection_b
-      after.runtime.proactive_rt.last_consumed_backlog_projection_sha256
+  let after = WO.record_scheduled_backlog_consumption ~meta:before backlog_edge_obs in
+  check int "observed revision is recorded" 2
+    after.runtime.proactive_rt.last_consumed_backlog_revision;
+  check string "projection stays paired with revision" projection_b
+    after.runtime.proactive_rt.last_consumed_backlog_projection_sha256
 ;;
 
 let test_unreadable_admission_does_not_move_pair () =
   let before = bootstrapped_meta () in
   let unreadable =
-    { base_obs with
-      backlog_revision = None
-    ; backlog_projection_sha256 = None
-    ; backlog_source = Inputs.Unavailable "test backlog read failure"
-    }
+    { base_obs with backlog_edge = Inputs.Backlog_read_unavailable "test failure" }
   in
-  match WO.record_scheduled_backlog_consumption ~meta:before unreadable with
-  | Error _ -> Alcotest.fail "complete absent pair was rejected"
-  | Ok after ->
-    check int "revision stays put" 1
-      after.runtime.proactive_rt.last_consumed_backlog_revision;
-    check string "projection stays put" projection_a
-      after.runtime.proactive_rt.last_consumed_backlog_projection_sha256
-;;
-
-let test_partial_backlog_pair_is_typed_error () =
-  let before = bootstrapped_meta () in
-  let incomplete = { base_obs with backlog_projection_sha256 = None } in
-  match WO.record_scheduled_backlog_consumption ~meta:before incomplete with
-  | Error WO.Incomplete_backlog_observation -> ()
-  | Ok _ -> Alcotest.fail "partial backlog observation was accepted"
+  let after = WO.record_scheduled_backlog_consumption ~meta:before unreadable in
+  check int "revision stays put" 1
+    after.runtime.proactive_rt.last_consumed_backlog_revision;
+  check string "projection stays put" projection_a
+    after.runtime.proactive_rt.last_consumed_backlog_projection_sha256
 ;;
 
 (* ==== read failure is not designed silence ==== *)
 
-(* [backlog_revision = None] models a failed backlog read (the inputs layer
-   maps [read_backlog_r]'s [Error] to [None]). With no other stimulus the
+(* [Backlog_read_unavailable] models a failed backlog read. With no other stimulus the
    skip must say so — recording it as [No_actionable_stimulus] would present
    a blind observation as a considered "nothing to do". *)
 let test_unreadable_backlog_skips_as_unreadable () =
@@ -325,11 +313,7 @@ let test_unreadable_backlog_skips_as_unreadable () =
   let d =
     decide
       ~meta:(bootstrapped_meta ())
-      { base_obs with
-        backlog_revision = None
-      ; backlog_projection_sha256 = None
-      ; backlog_source = Inputs.Unavailable "test backlog read failure"
-      }
+      { base_obs with backlog_edge = Inputs.Backlog_read_unavailable "test failure" }
   in
   check bool "no turn on a blind observation" false d.WO.should_run;
   check bool "skip reason is backlog_unreadable" true
@@ -345,11 +329,7 @@ let test_unreadable_backlog_does_not_silence_other_stimuli () =
   let d =
     decide
       ~meta:(bootstrapped_meta ())
-      { mention_obs with
-        backlog_revision = None
-      ; backlog_projection_sha256 = None
-      ; backlog_source = Inputs.Unavailable "test backlog read failure"
-      }
+      { mention_obs with backlog_edge = Inputs.Backlog_read_unavailable "test failure" }
   in
   check bool "message still admits" true d.WO.should_run;
   check bool "scope_message_pending in reasons" true
@@ -591,10 +571,6 @@ let () =
             "unreadable admission does not move pair"
             `Quick
             test_unreadable_admission_does_not_move_pair
-        ; test_case
-            "partial backlog pair is typed error"
-            `Quick
-            test_partial_backlog_pair_is_typed_error
         ; test_case
             "unreadable backlog skips as unreadable"
             `Quick

--- a/test/test_keeper_admission_edge.ml
+++ b/test/test_keeper_admission_edge.ml
@@ -357,7 +357,29 @@ let test_recovery_backlog_is_not_authoritative () =
   in
   check bool "recovery snapshot does not admit a scheduled edge" false d.WO.should_run;
   check bool "recovery snapshot is not designed silence" true
-    (List.exists (( = ) WO.Backlog_unreadable) (skip_reasons d))
+    (List.exists (( = ) WO.Backlog_unreadable) (skip_reasons d));
+  let rendered =
+    Inputs.backlog_edge_observation_to_string
+      (Inputs.Recovery_backlog
+         { revision = 2; projection_sha256 = projection_b; recovery })
+  in
+  check bool "recovery provenance stays visible" true
+    (String_util.contains_substring rendered "recovery(revision=2");
+  check bool "recovery path is not model-facing" false
+    (String_util.contains_substring rendered recovery.recovery_path);
+  check bool "primary parser error is not model-facing" false
+    (String_util.contains_substring rendered recovery.primary_error)
+;;
+
+let test_unavailable_backlog_error_is_not_model_facing () =
+  let raw_error = "hostile parser text from backlog" in
+  let rendered =
+    Inputs.backlog_edge_observation_to_string
+      (Inputs.Backlog_read_unavailable raw_error)
+  in
+  check string "typed state remains visible" "unavailable" rendered;
+  check bool "raw parser text stays out of prompt" false
+    (String_util.contains_substring rendered raw_error)
 ;;
 
 (* ==== §3.2: the edge is a revision compare, no clock anywhere ==== *)
@@ -607,6 +629,10 @@ let () =
             "recovery backlog is not authoritative"
             `Quick
             test_recovery_backlog_is_not_authoritative
+        ; test_case
+            "unavailable backlog error is not model-facing"
+            `Quick
+            test_unavailable_backlog_error_is_not_model_facing
         ] )
     ; ( "edge_compare"
       , [ test_case "revision and projection pair" `Quick test_edge_is_pure_revision_compare

--- a/test/test_keeper_admission_edge.ml
+++ b/test/test_keeper_admission_edge.ml
@@ -95,6 +95,7 @@ let base_obs : WO.world_observation =
   ; backlog_updated_since_last_scheduled_autonomous = false
   ; backlog_revision = Some 1
   ; backlog_projection_sha256 = Some projection_a
+  ; backlog_source = Inputs.Primary
   ; running_keeper_fiber_count = 1
   ; connected_surfaces = []
   ; connected_surface_failures = []
@@ -290,7 +291,11 @@ let test_scheduled_admission_records_exact_pair () =
 let test_unreadable_admission_does_not_move_pair () =
   let before = bootstrapped_meta () in
   let unreadable =
-    { base_obs with backlog_revision = None; backlog_projection_sha256 = None }
+    { base_obs with
+      backlog_revision = None
+    ; backlog_projection_sha256 = None
+    ; backlog_source = Inputs.Unavailable "test backlog read failure"
+    }
   in
   match WO.record_scheduled_backlog_consumption ~meta:before unreadable with
   | Error _ -> Alcotest.fail "complete absent pair was rejected"
@@ -323,6 +328,7 @@ let test_unreadable_backlog_skips_as_unreadable () =
       { base_obs with
         backlog_revision = None
       ; backlog_projection_sha256 = None
+      ; backlog_source = Inputs.Unavailable "test backlog read failure"
       }
   in
   check bool "no turn on a blind observation" false d.WO.should_run;
@@ -342,6 +348,7 @@ let test_unreadable_backlog_does_not_silence_other_stimuli () =
       { mention_obs with
         backlog_revision = None
       ; backlog_projection_sha256 = None
+      ; backlog_source = Inputs.Unavailable "test backlog read failure"
       }
   in
   check bool "message still admits" true d.WO.should_run;
@@ -463,24 +470,17 @@ let test_meta_json_roundtrip () =
       decoded.runtime.proactive_rt.last_consumed_backlog_projection_sha256
 ;;
 
-let test_meta_json_absent_pair_decodes_as_genesis () =
+let test_meta_json_absent_pair_fails_closed () =
   let meta = bootstrapped_meta ~last_consumed:42 () in
-  let json =
-    json_with_field meta ~f:(fun fields ->
-      List.filter
-        (fun (key, _) ->
-           not
-             (String.equal key "last_consumed_backlog_revision"
-              || String.equal key "last_consumed_backlog_projection_sha256"))
-        fields)
+  let remove field fields =
+    List.filter (fun (key, _) -> not (String.equal key field)) fields
   in
-  match Masc.Keeper_meta_json_parse.meta_of_json json with
-  | Error e -> Alcotest.fail ("pre-RFC meta must decode with the genesis pair: " ^ e)
-  | Ok decoded ->
-    check int "absent revision decodes as genesis 0" 0
-      decoded.runtime.proactive_rt.last_consumed_backlog_revision;
-    check string "absent projection decodes as genesis empty" ""
-      decoded.runtime.proactive_rt.last_consumed_backlog_projection_sha256
+  List.iter
+    (fun field ->
+       match Masc.Keeper_meta_json_parse.meta_of_json (json_with_field meta ~f:(remove field)) with
+       | Error _ -> ()
+       | Ok _ -> Alcotest.failf "missing current field %s must fail the decode" field)
+    [ "last_consumed_backlog_revision"; "last_consumed_backlog_projection_sha256" ]
 ;;
 
 let test_meta_json_missing_required_field_fails () =
@@ -527,6 +527,38 @@ let test_meta_json_malformed_fails_closed () =
       (json_with_field meta ~f:malformed_projection)
   with
   | Ok _ -> Alcotest.fail "malformed projection digest must fail the decode"
+  | Error _ -> ();
+  let inconsistent_genesis fields =
+    List.map
+      (fun (key, value) ->
+         if String.equal key "last_consumed_backlog_revision"
+         then key, `Int 0
+         else if String.equal key "last_consumed_backlog_projection_sha256"
+         then key, `String projection_a
+         else key, value)
+      fields
+  in
+  (match
+     Masc.Keeper_meta_json_parse.meta_of_json
+       (json_with_field meta ~f:inconsistent_genesis)
+   with
+   | Ok _ -> Alcotest.fail "genesis revision must not carry a non-empty projection"
+   | Error _ -> ());
+  let inconsistent_consumed fields =
+    List.map
+      (fun (key, value) ->
+         if String.equal key "last_consumed_backlog_revision"
+         then key, `Int 42
+         else if String.equal key "last_consumed_backlog_projection_sha256"
+         then key, `String ""
+         else key, value)
+      fields
+  in
+  match
+    Masc.Keeper_meta_json_parse.meta_of_json
+      (json_with_field meta ~f:inconsistent_consumed)
+  with
+  | Ok _ -> Alcotest.fail "consumed revision must carry its projection"
   | Error _ -> ()
 ;;
 
@@ -582,9 +614,9 @@ let () =
     ; ( "meta_json"
       , [ test_case "roundtrip" `Quick test_meta_json_roundtrip
         ; test_case
-            "absent pair decodes as genesis"
+            "absent pair fails closed"
             `Quick
-            test_meta_json_absent_pair_decodes_as_genesis
+            test_meta_json_absent_pair_fails_closed
         ; test_case
             "missing required field fails"
             `Quick

--- a/test/test_keeper_admission_edge.ml
+++ b/test/test_keeper_admission_edge.ml
@@ -463,17 +463,35 @@ let test_meta_json_roundtrip () =
       decoded.runtime.proactive_rt.last_consumed_backlog_projection_sha256
 ;;
 
-let test_meta_json_missing_current_field_fails () =
+let test_meta_json_absent_pair_decodes_as_genesis () =
   let meta = bootstrapped_meta ~last_consumed:42 () in
   let json =
     json_with_field meta ~f:(fun fields ->
       List.filter
-        (fun (key, _) -> not (String.equal key "last_consumed_backlog_revision"))
+        (fun (key, _) ->
+           not
+             (String.equal key "last_consumed_backlog_revision"
+              || String.equal key "last_consumed_backlog_projection_sha256"))
         fields)
   in
   match Masc.Keeper_meta_json_parse.meta_of_json json with
+  | Error e -> Alcotest.fail ("pre-RFC meta must decode with the genesis pair: " ^ e)
+  | Ok decoded ->
+    check int "absent revision decodes as genesis 0" 0
+      decoded.runtime.proactive_rt.last_consumed_backlog_revision;
+    check string "absent projection decodes as genesis empty" ""
+      decoded.runtime.proactive_rt.last_consumed_backlog_projection_sha256
+;;
+
+let test_meta_json_missing_required_field_fails () =
+  let meta = bootstrapped_meta ~last_consumed:42 () in
+  let json =
+    json_with_field meta ~f:(fun fields ->
+      List.filter (fun (key, _) -> not (String.equal key "total_turns")) fields)
+  in
+  match Masc.Keeper_meta_json_parse.meta_of_json json with
   | Error _ -> ()
-  | Ok _ -> Alcotest.fail "missing current field must fail the decode"
+  | Ok _ -> Alcotest.fail "missing non-genesis field must fail the decode"
 ;;
 
 let test_meta_json_malformed_fails_closed () =
@@ -564,9 +582,13 @@ let () =
     ; ( "meta_json"
       , [ test_case "roundtrip" `Quick test_meta_json_roundtrip
         ; test_case
-            "missing current field fails"
+            "absent pair decodes as genesis"
             `Quick
-            test_meta_json_missing_current_field_fails
+            test_meta_json_absent_pair_decodes_as_genesis
+        ; test_case
+            "missing required field fails"
+            `Quick
+            test_meta_json_missing_required_field_fails
         ; test_case "malformed fails closed" `Quick test_meta_json_malformed_fails_closed
         ] )
     ]

--- a/test/test_keeper_admission_edge.ml
+++ b/test/test_keeper_admission_edge.ml
@@ -496,43 +496,30 @@ let test_meta_json_roundtrip () =
       decoded.runtime.proactive_rt.last_consumed_backlog_projection_sha256
 ;;
 
-(* Removing ONE half of the pair leaves a half-genesis state, which the pair
-   invariant rejects even under absence tolerance. *)
-let test_meta_json_half_genesis_fails_closed () =
+let test_meta_json_absent_consumption_fields_fail_closed () =
   let meta = bootstrapped_meta ~last_consumed:42 () in
-  let remove field fields =
-    List.filter (fun (key, _) -> not (String.equal key field)) fields
+  let remove fields_to_remove fields =
+    List.filter
+      (fun (key, _) -> not (List.mem key fields_to_remove))
+      fields
   in
   List.iter
-    (fun field ->
-       match Masc.Keeper_meta_json_parse.meta_of_json (json_with_field meta ~f:(remove field)) with
+    (fun fields_to_remove ->
+       match
+         Masc.Keeper_meta_json_parse.meta_of_json
+           (json_with_field meta ~f:(remove fields_to_remove))
+       with
        | Error _ -> ()
-       | Ok _ -> Alcotest.failf "half-genesis without %s must fail the decode" field)
-    [ "last_consumed_backlog_revision"; "last_consumed_backlog_projection_sha256" ]
-;;
-
-(* A pre-RFC meta lacks BOTH fields and must decode with the genesis pair —
-   owner ruling 2026-08-03: live metas are 10/10 without the pair, and an
-   invalid meta cannot be read or rewritten, so absent=invalid would strand
-   the fleet (#26530 shape). *)
-let test_meta_json_absent_pair_decodes_as_genesis () =
-  let meta = bootstrapped_meta ~last_consumed:42 () in
-  let json =
-    json_with_field meta ~f:(fun fields ->
-      List.filter
-        (fun (key, _) ->
-           not
-             (String.equal key "last_consumed_backlog_revision"
-              || String.equal key "last_consumed_backlog_projection_sha256"))
-        fields)
-  in
-  match Masc.Keeper_meta_json_parse.meta_of_json json with
-  | Error e -> Alcotest.fail ("pre-RFC meta must decode with the genesis pair: " ^ e)
-  | Ok decoded ->
-    check int "absent revision decodes as genesis 0" 0
-      decoded.runtime.proactive_rt.last_consumed_backlog_revision;
-    check string "absent projection decodes as genesis empty" ""
-      decoded.runtime.proactive_rt.last_consumed_backlog_projection_sha256
+       | Ok _ ->
+         Alcotest.failf
+           "missing current consumption field(s) must fail: %s"
+           (String.concat ", " fields_to_remove))
+    [ [ "last_consumed_backlog_revision" ]
+    ; [ "last_consumed_backlog_projection_sha256" ]
+    ; [ "last_consumed_backlog_revision"
+      ; "last_consumed_backlog_projection_sha256"
+      ]
+    ]
 ;;
 
 let test_meta_json_missing_required_field_fails () =
@@ -670,13 +657,9 @@ let () =
     ; ( "meta_json"
       , [ test_case "roundtrip" `Quick test_meta_json_roundtrip
         ; test_case
-            "half genesis fails closed"
+            "absent consumption fields fail closed"
             `Quick
-            test_meta_json_half_genesis_fails_closed
-        ; test_case
-            "absent pair decodes as genesis"
-            `Quick
-            test_meta_json_absent_pair_decodes_as_genesis
+            test_meta_json_absent_consumption_fields_fail_closed
         ; test_case
             "missing required field fails"
             `Quick

--- a/test/test_keeper_admission_edge.ml
+++ b/test/test_keeper_admission_edge.ml
@@ -496,30 +496,46 @@ let test_meta_json_roundtrip () =
       decoded.runtime.proactive_rt.last_consumed_backlog_projection_sha256
 ;;
 
-let test_meta_json_absent_consumption_fields_fail_closed () =
+(* Removing ONE half of the pair leaves a half-genesis state, which the pair
+   invariant rejects even under absence tolerance. *)
+let test_meta_json_half_genesis_fails_closed () =
   let meta = bootstrapped_meta ~last_consumed:42 () in
-  let remove fields_to_remove fields =
-    List.filter
-      (fun (key, _) -> not (List.mem key fields_to_remove))
-      fields
+  let remove field fields =
+    List.filter (fun (key, _) -> not (String.equal key field)) fields
   in
   List.iter
-    (fun fields_to_remove ->
+    (fun field ->
        match
          Masc.Keeper_meta_json_parse.meta_of_json
-           (json_with_field meta ~f:(remove fields_to_remove))
+           (json_with_field meta ~f:(remove field))
        with
        | Error _ -> ()
-       | Ok _ ->
-         Alcotest.failf
-           "missing current consumption field(s) must fail: %s"
-           (String.concat ", " fields_to_remove))
-    [ [ "last_consumed_backlog_revision" ]
-    ; [ "last_consumed_backlog_projection_sha256" ]
-    ; [ "last_consumed_backlog_revision"
-      ; "last_consumed_backlog_projection_sha256"
-      ]
-    ]
+       | Ok _ -> Alcotest.failf "half-genesis without %s must fail the decode" field)
+    [ "last_consumed_backlog_revision"; "last_consumed_backlog_projection_sha256" ]
+;;
+
+(* A pre-RFC meta lacks BOTH fields and must decode with the genesis pair —
+   owner ruling 2026-08-03: live metas are 10/10 without the pair, and an
+   invalid meta cannot be read or rewritten, so absent=invalid would strand
+   the fleet (#26530 shape). *)
+let test_meta_json_absent_pair_decodes_as_genesis () =
+  let meta = bootstrapped_meta ~last_consumed:42 () in
+  let json =
+    json_with_field meta ~f:(fun fields ->
+      List.filter
+        (fun (key, _) ->
+           not
+             (String.equal key "last_consumed_backlog_revision"
+              || String.equal key "last_consumed_backlog_projection_sha256"))
+        fields)
+  in
+  match Masc.Keeper_meta_json_parse.meta_of_json json with
+  | Error e -> Alcotest.fail ("pre-RFC meta must decode with the genesis pair: " ^ e)
+  | Ok decoded ->
+    check int "absent revision decodes as genesis 0" 0
+      decoded.runtime.proactive_rt.last_consumed_backlog_revision;
+    check string "absent projection decodes as genesis empty" ""
+      decoded.runtime.proactive_rt.last_consumed_backlog_projection_sha256
 ;;
 
 let test_meta_json_missing_required_field_fails () =
@@ -657,9 +673,13 @@ let () =
     ; ( "meta_json"
       , [ test_case "roundtrip" `Quick test_meta_json_roundtrip
         ; test_case
-            "absent consumption fields fail closed"
+            "half genesis fails closed"
             `Quick
-            test_meta_json_absent_consumption_fields_fail_closed
+            test_meta_json_half_genesis_fails_closed
+        ; test_case
+            "absent pair decodes as genesis"
+            `Quick
+            test_meta_json_absent_pair_decodes_as_genesis
         ; test_case
             "missing required field fails"
             `Quick

--- a/test/test_keeper_admission_edge.ml
+++ b/test/test_keeper_admission_edge.ml
@@ -27,6 +27,7 @@
 open Alcotest
 module WO = Masc.Keeper_world_observation
 module Inputs = Masc.Keeper_world_observation_inputs
+module Workspace = Masc.Workspace
 
 let make_meta name =
   let json =
@@ -173,7 +174,7 @@ let without_overrides f =
   Fun.protect ~finally:(fun () -> Config_boot_overrides.reset_for_tests ()) f
 ;;
 
-let decide ~meta obs = WO.keeper_cycle_decision ~reactive_wake:false ~meta obs
+let decide ~meta obs = WO.keeper_cycle_decision ~meta obs
 
 let skip_reasons d =
   match d.WO.verdict with
@@ -226,17 +227,6 @@ let test_backlog_edge_admits () =
          | WO.Task_backlog _ -> true
          | _ -> false)
        (run_reasons d))
-;;
-
-let test_external_wake_does_not_admit_backlog_only () =
-  without_overrides @@ fun () ->
-  let d =
-    WO.keeper_cycle_decision
-      ~reactive_wake:true
-      ~meta:(bootstrapped_meta ())
-      backlog_edge_obs
-  in
-  check bool "broadcast wake does not fan out backlog turn" false d.WO.should_run
 ;;
 
 let test_due_schedule_admits () =
@@ -624,10 +614,6 @@ let () =
       , [ test_case "empty observation skips" `Quick test_empty_observation_skips
         ; test_case "bootstrap admits" `Quick test_bootstrap_admits
         ; test_case "backlog edge admits" `Quick test_backlog_edge_admits
-        ; test_case
-            "external wake suppresses backlog-only admission"
-            `Quick
-            test_external_wake_does_not_admit_backlog_only
         ; test_case "due schedule admits" `Quick test_due_schedule_admits
         ; test_case
             "pending message admits scheduled when reactive off"

--- a/test/test_keeper_admission_edge.ml
+++ b/test/test_keeper_admission_edge.ml
@@ -16,19 +16,13 @@
       "failed turn keeps its in-memory stamp"), an unconsumed edge
       (version > consumed) admits (continuity; also the shape of
       "crash before the durable write re-arms the edge")
-    - fast-turn continuity: the edge is a revision compare only — no
-      wall-clock input anywhere, so a change landing in the same second as
-      the previous admission still re-admits (asserted by using a
-      freshly-stamped meta and only bumping the revision)
-    - meta JSON: [last_consumed_backlog_revision] round-trips; an ABSENT
-      field decodes as genesis 0 (pre-RFC metas must not invalidate); a
-      PRESENT malformed or negative value fails the decode (fail-closed).
+    - fast-turn continuity: the revision/projection pair has no wall-clock
+      input, so a relevant change landing in the same second still re-admits
+    - meta JSON: both consumed fields round-trip; every current field is
+      required, and malformed or negative values fail closed.
 
-    Not covered here (stated, not hidden): the in-memory stamp write in
-    [keeper_heartbeat_loop] and the [update_metrics_from_result]
-    pass-through are integration surfaces exercised by the heartbeat suites;
-    building a [Keeper_agent_run.run_result] fixture is out of scope for
-    this unit file. *)
+    The scheduled-admission stamp helper is exercised directly here; the
+    post-turn pass-through and CAS merge are covered by their focused suites. *)
 
 open Alcotest
 module WO = Masc.Keeper_world_observation
@@ -49,7 +43,14 @@ let make_meta name =
 
 (* A keeper that has already bootstrapped (a scheduled turn ran before) and
    whose consumption clock sits at [last_consumed]. *)
-let bootstrapped_meta ?(last_consumed = 1) () =
+let projection_a = String.make 64 'a'
+let projection_b = String.make 64 'b'
+
+let bootstrapped_meta
+      ?(last_consumed = 1)
+      ?(last_projection = projection_a)
+      ()
+  =
   let meta = make_meta "admission" in
   let now = Time_compat.now () in
   { meta with
@@ -61,6 +62,7 @@ let bootstrapped_meta ?(last_consumed = 1) () =
           { meta.runtime.proactive_rt with
             last_ts = now -. 120.0
           ; last_consumed_backlog_revision = last_consumed
+          ; last_consumed_backlog_projection_sha256 = last_projection
           }
       }
   }
@@ -92,6 +94,7 @@ let base_obs : WO.world_observation =
   ; scheduled_automation = WO.empty_scheduled_automation_observation
   ; backlog_updated_since_last_scheduled_autonomous = false
   ; backlog_revision = Some 1
+  ; backlog_projection_sha256 = Some projection_a
   ; running_keeper_fiber_count = 1
   ; connected_surfaces = []
   ; connected_surface_failures = []
@@ -103,6 +106,7 @@ let backlog_edge_obs =
   { base_obs with
     backlog_updated_since_last_scheduled_autonomous = true
   ; backlog_revision = Some 2
+  ; backlog_projection_sha256 = Some projection_b
   ; claimable_task_count = 1
   ; unclaimed_task_count = 1
   }
@@ -218,6 +222,17 @@ let test_backlog_edge_admits () =
        (run_reasons d))
 ;;
 
+let test_external_wake_does_not_admit_backlog_only () =
+  without_overrides @@ fun () ->
+  let d =
+    WO.keeper_cycle_decision
+      ~reactive_wake:true
+      ~meta:(bootstrapped_meta ())
+      backlog_edge_obs
+  in
+  check bool "broadcast wake does not fan out backlog turn" false d.WO.should_run
+;;
+
 let test_due_schedule_admits () =
   without_overrides @@ fun () ->
   let d = decide ~meta:(bootstrapped_meta ()) due_schedule_obs in
@@ -261,6 +276,39 @@ let test_consumed_edge_stays_silent () =
     (List.exists (( = ) WO.No_actionable_stimulus) (skip_reasons d))
 ;;
 
+let test_scheduled_admission_records_exact_pair () =
+  let before = bootstrapped_meta () in
+  match WO.record_scheduled_backlog_consumption ~meta:before backlog_edge_obs with
+  | Error _ -> Alcotest.fail "complete backlog observation was rejected"
+  | Ok after ->
+    check int "observed revision is recorded" 2
+      after.runtime.proactive_rt.last_consumed_backlog_revision;
+    check string "projection stays paired with revision" projection_b
+      after.runtime.proactive_rt.last_consumed_backlog_projection_sha256
+;;
+
+let test_unreadable_admission_does_not_move_pair () =
+  let before = bootstrapped_meta () in
+  let unreadable =
+    { base_obs with backlog_revision = None; backlog_projection_sha256 = None }
+  in
+  match WO.record_scheduled_backlog_consumption ~meta:before unreadable with
+  | Error _ -> Alcotest.fail "complete absent pair was rejected"
+  | Ok after ->
+    check int "revision stays put" 1
+      after.runtime.proactive_rt.last_consumed_backlog_revision;
+    check string "projection stays put" projection_a
+      after.runtime.proactive_rt.last_consumed_backlog_projection_sha256
+;;
+
+let test_partial_backlog_pair_is_typed_error () =
+  let before = bootstrapped_meta () in
+  let incomplete = { base_obs with backlog_projection_sha256 = None } in
+  match WO.record_scheduled_backlog_consumption ~meta:before incomplete with
+  | Error WO.Incomplete_backlog_observation -> ()
+  | Ok _ -> Alcotest.fail "partial backlog observation was accepted"
+;;
+
 (* ==== read failure is not designed silence ==== *)
 
 (* [backlog_revision = None] models a failed backlog read (the inputs layer
@@ -270,7 +318,12 @@ let test_consumed_edge_stays_silent () =
 let test_unreadable_backlog_skips_as_unreadable () =
   without_overrides @@ fun () ->
   let d =
-    decide ~meta:(bootstrapped_meta ()) { base_obs with backlog_revision = None }
+    decide
+      ~meta:(bootstrapped_meta ())
+      { base_obs with
+        backlog_revision = None
+      ; backlog_projection_sha256 = None
+      }
   in
   check bool "no turn on a blind observation" false d.WO.should_run;
   check bool "skip reason is backlog_unreadable" true
@@ -284,7 +337,12 @@ let test_unreadable_backlog_skips_as_unreadable () =
 let test_unreadable_backlog_does_not_silence_other_stimuli () =
   with_flag "MASC_KEEPER_REACTIVE_ENABLED" "false" @@ fun () ->
   let d =
-    decide ~meta:(bootstrapped_meta ()) { mention_obs with backlog_revision = None }
+    decide
+      ~meta:(bootstrapped_meta ())
+      { mention_obs with
+        backlog_revision = None
+      ; backlog_projection_sha256 = None
+      }
   in
   check bool "message still admits" true d.WO.should_run;
   check bool "scope_message_pending in reasons" true
@@ -293,27 +351,96 @@ let test_unreadable_backlog_does_not_silence_other_stimuli () =
 
 (* ==== §3.2: the edge is a revision compare, no clock anywhere ==== *)
 
-let edge ~last_consumed ~version =
-  let meta = bootstrapped_meta ~last_consumed () in
+let edge ~last_consumed ~last_projection ~version ~projection =
+  let meta = bootstrapped_meta ~last_consumed ~last_projection () in
   let backlog : Masc_domain.backlog =
     { tasks = []; last_updated = "not-a-timestamp"; version }
   in
-  Inputs.backlog_updated_since_last_scheduled_autonomous ~meta ~backlog
+  Inputs.backlog_updated_since_last_scheduled_autonomous
+    ~meta
+    ~backlog
+    ~projection_sha256:projection
 ;;
 
 let test_edge_is_pure_revision_compare () =
   (* genesis: never consumed, any live backlog is one pending edge *)
-  check bool "0 < 1 edges" true (edge ~last_consumed:0 ~version:1);
+  check bool "0 < 1 and changed projection edges" true
+    (edge
+       ~last_consumed:0
+       ~last_projection:""
+       ~version:1
+       ~projection:projection_a);
   (* consumed exactly: silent *)
-  check bool "5 = 5 silent" false (edge ~last_consumed:5 ~version:5);
+  check bool "5 = 5 silent" false
+    (edge
+       ~last_consumed:5
+       ~last_projection:projection_a
+       ~version:5
+       ~projection:projection_b);
+  check bool "new revision with unchanged projection is silent" false
+    (edge
+       ~last_consumed:5
+       ~last_projection:projection_a
+       ~version:6
+       ~projection:projection_a);
   (* fast-turn continuity: a commit in the same wall-clock instant as the
      stamp still edges, because only the revision moved. [last_updated] is
      deliberately unparseable — proof the clock and the ISO field are not
      inputs (the old implementation returned [false] forever on a parse
      failure). *)
-  check bool "5 < 6 edges" true (edge ~last_consumed:5 ~version:6);
-  check bool "6 = 6 silent after stamp" false (edge ~last_consumed:6 ~version:6);
-  check bool "6 < 7 re-edges" true (edge ~last_consumed:6 ~version:7)
+  check bool "5 < 6 edges" true
+    (edge
+       ~last_consumed:5
+       ~last_projection:projection_a
+       ~version:6
+       ~projection:projection_b);
+  check bool "6 = 6 silent after stamp" false
+    (edge
+       ~last_consumed:6
+       ~last_projection:projection_b
+       ~version:6
+       ~projection:projection_b);
+  check bool "6 < 7 re-edges on another projection" true
+    (edge
+       ~last_consumed:6
+       ~last_projection:projection_b
+       ~version:7
+       ~projection:projection_a)
+;;
+
+let make_todo ~id ~created_by : Masc_domain.task =
+  { id
+  ; title = "Task " ^ id
+  ; description = ""
+  ; task_status = Masc_domain.Todo
+  ; priority = 3
+  ; files = []
+  ; created_at = "2026-08-03T00:00:00Z"
+  ; created_by
+  ; predecessor_task_id = None
+  ; contract = None
+  ; handoff_context = None
+  ; cycle_count = 0
+  ; reclaim_policy = None
+  ; do_not_reclaim_reason = None
+  }
+;;
+
+let test_self_authored_todo_does_not_change_projection () =
+  let meta = bootstrapped_meta () in
+  let empty = Inputs.relevant_backlog_projection_sha256 ~meta [] in
+  let self =
+    Inputs.relevant_backlog_projection_sha256
+      ~meta
+      [ make_todo ~id:"self" ~created_by:(Some meta.name) ]
+  in
+  let peer =
+    Inputs.relevant_backlog_projection_sha256
+      ~meta
+      [ make_todo ~id:"peer" ~created_by:(Some "peer") ]
+  in
+  check string "self-authored Todo is outside projection" empty self;
+  check bool "peer Todo changes projection" true (not (String.equal empty peer))
 ;;
 
 (* ==== meta JSON: durable consumption clock ==== *)
@@ -331,10 +458,12 @@ let test_meta_json_roundtrip () =
   | Error e -> Alcotest.fail ("roundtrip decode failed: " ^ e)
   | Ok decoded ->
     check int "consumption clock survives the roundtrip" 42
-      decoded.runtime.proactive_rt.last_consumed_backlog_revision
+      decoded.runtime.proactive_rt.last_consumed_backlog_revision;
+    check string "projection survives the roundtrip" projection_a
+      decoded.runtime.proactive_rt.last_consumed_backlog_projection_sha256
 ;;
 
-let test_meta_json_absent_is_genesis () =
+let test_meta_json_missing_current_field_fails () =
   let meta = bootstrapped_meta ~last_consumed:42 () in
   let json =
     json_with_field meta ~f:(fun fields ->
@@ -343,10 +472,8 @@ let test_meta_json_absent_is_genesis () =
         fields)
   in
   match Masc.Keeper_meta_json_parse.meta_of_json json with
-  | Error e -> Alcotest.fail ("absent field must decode (pre-RFC meta): " ^ e)
-  | Ok decoded ->
-    check int "absent decodes as genesis 0" 0
-      decoded.runtime.proactive_rt.last_consumed_backlog_revision
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "missing current field must fail the decode"
 ;;
 
 let test_meta_json_malformed_fails_closed () =
@@ -368,6 +495,20 @@ let test_meta_json_malformed_fails_closed () =
       (json_with_field meta ~f:(replace (`Int (-3))))
   with
   | Ok _ -> Alcotest.fail "negative revision must fail the decode"
+  | Error _ -> ();
+  let malformed_projection fields =
+    List.map
+      (fun (key, value) ->
+         if String.equal key "last_consumed_backlog_projection_sha256"
+         then key, `String "not-a-sha256"
+         else key, value)
+      fields
+  in
+  match
+    Masc.Keeper_meta_json_parse.meta_of_json
+      (json_with_field meta ~f:malformed_projection)
+  with
+  | Ok _ -> Alcotest.fail "malformed projection digest must fail the decode"
   | Error _ -> ()
 ;;
 
@@ -378,6 +519,10 @@ let () =
       , [ test_case "empty observation skips" `Quick test_empty_observation_skips
         ; test_case "bootstrap admits" `Quick test_bootstrap_admits
         ; test_case "backlog edge admits" `Quick test_backlog_edge_admits
+        ; test_case
+            "external wake suppresses backlog-only admission"
+            `Quick
+            test_external_wake_does_not_admit_backlog_only
         ; test_case "due schedule admits" `Quick test_due_schedule_admits
         ; test_case
             "pending message admits scheduled when reactive off"
@@ -389,6 +534,18 @@ let () =
             test_pending_board_event_admits_scheduled_when_reactive_off
         ; test_case "consumed edge stays silent" `Quick test_consumed_edge_stays_silent
         ; test_case
+            "scheduled admission records exact pair"
+            `Quick
+            test_scheduled_admission_records_exact_pair
+        ; test_case
+            "unreadable admission does not move pair"
+            `Quick
+            test_unreadable_admission_does_not_move_pair
+        ; test_case
+            "partial backlog pair is typed error"
+            `Quick
+            test_partial_backlog_pair_is_typed_error
+        ; test_case
             "unreadable backlog skips as unreadable"
             `Quick
             test_unreadable_backlog_skips_as_unreadable
@@ -398,10 +555,18 @@ let () =
             test_unreadable_backlog_does_not_silence_other_stimuli
         ] )
     ; ( "edge_compare"
-      , [ test_case "pure revision compare" `Quick test_edge_is_pure_revision_compare ] )
+      , [ test_case "revision and projection pair" `Quick test_edge_is_pure_revision_compare
+        ; test_case
+            "self-authored Todo does not change projection"
+            `Quick
+            test_self_authored_todo_does_not_change_projection
+        ] )
     ; ( "meta_json"
       , [ test_case "roundtrip" `Quick test_meta_json_roundtrip
-        ; test_case "absent is genesis" `Quick test_meta_json_absent_is_genesis
+        ; test_case
+            "missing current field fails"
+            `Quick
+            test_meta_json_missing_current_field_fails
         ; test_case "malformed fails closed" `Quick test_meta_json_malformed_fails_closed
         ] )
     ]

--- a/test/test_keeper_connector_attention_wake.ml
+++ b/test/test_keeper_connector_attention_wake.ml
@@ -139,6 +139,7 @@ let quiet_obs : WO.world_observation =
   ; scheduled_automation = WO.empty_scheduled_automation_observation
   ; backlog_updated_since_last_scheduled_autonomous = false
   ; backlog_revision = Some 1
+  ; backlog_projection_sha256 = Some (String.make 64 '0')
   ; running_keeper_fiber_count = 1
   ; connected_surfaces = []
   ; connected_surface_failures = []

--- a/test/test_keeper_connector_attention_wake.ml
+++ b/test/test_keeper_connector_attention_wake.ml
@@ -137,10 +137,12 @@ let quiet_obs : WO.world_observation =
   ; claimable_task_count = 0
   ; failed_task_count = 0
   ; scheduled_automation = WO.empty_scheduled_automation_observation
-  ; backlog_updated_since_last_scheduled_autonomous = false
-  ; backlog_revision = Some 1
-  ; backlog_projection_sha256 = Some (String.make 64 '0')
-  ; backlog_source = Masc.Keeper_world_observation_inputs.Primary
+  ; backlog_edge =
+      Masc.Keeper_world_observation_inputs.Observed_backlog
+        { revision = 1
+        ; projection_sha256 = String.make 64 '0'
+        ; updated_since_last_scheduled_autonomous = false
+        }
   ; running_keeper_fiber_count = 1
   ; connected_surfaces = []
   ; connected_surface_failures = []

--- a/test/test_keeper_connector_attention_wake.ml
+++ b/test/test_keeper_connector_attention_wake.ml
@@ -140,6 +140,7 @@ let quiet_obs : WO.world_observation =
   ; backlog_updated_since_last_scheduled_autonomous = false
   ; backlog_revision = Some 1
   ; backlog_projection_sha256 = Some (String.make 64 '0')
+  ; backlog_source = Masc.Keeper_world_observation_inputs.Primary
   ; running_keeper_fiber_count = 1
   ; connected_surfaces = []
   ; connected_surface_failures = []

--- a/test/test_keeper_lifecycle_global_gate.ml
+++ b/test/test_keeper_lifecycle_global_gate.ml
@@ -108,6 +108,7 @@ let base_obs : WO.world_observation =
   ; scheduled_automation = WO.empty_scheduled_automation_observation
   ; backlog_updated_since_last_scheduled_autonomous = false
   ; backlog_revision = Some 1
+  ; backlog_projection_sha256 = Some (String.make 64 '0')
   ; running_keeper_fiber_count = 1
   ; connected_surfaces = []
   ; connected_surface_failures = []

--- a/test/test_keeper_lifecycle_global_gate.ml
+++ b/test/test_keeper_lifecycle_global_gate.ml
@@ -154,7 +154,6 @@ let without_overrides f =
 
 let decide ~meta obs =
   WO.keeper_cycle_decision
-    ~reactive_wake:false
     ~meta
     obs
 ;;

--- a/test/test_keeper_lifecycle_global_gate.ml
+++ b/test/test_keeper_lifecycle_global_gate.ml
@@ -109,6 +109,7 @@ let base_obs : WO.world_observation =
   ; backlog_updated_since_last_scheduled_autonomous = false
   ; backlog_revision = Some 1
   ; backlog_projection_sha256 = Some (String.make 64 '0')
+  ; backlog_source = Masc.Keeper_world_observation_inputs.Primary
   ; running_keeper_fiber_count = 1
   ; connected_surfaces = []
   ; connected_surface_failures = []

--- a/test/test_keeper_lifecycle_global_gate.ml
+++ b/test/test_keeper_lifecycle_global_gate.ml
@@ -106,10 +106,12 @@ let base_obs : WO.world_observation =
   ; claimable_task_count = 0
   ; failed_task_count = 0
   ; scheduled_automation = WO.empty_scheduled_automation_observation
-  ; backlog_updated_since_last_scheduled_autonomous = false
-  ; backlog_revision = Some 1
-  ; backlog_projection_sha256 = Some (String.make 64 '0')
-  ; backlog_source = Masc.Keeper_world_observation_inputs.Primary
+  ; backlog_edge =
+      Masc.Keeper_world_observation_inputs.Observed_backlog
+        { revision = 1
+        ; projection_sha256 = String.make 64 '0'
+        ; updated_since_last_scheduled_autonomous = false
+        }
   ; running_keeper_fiber_count = 1
   ; connected_surfaces = []
   ; connected_surface_failures = []

--- a/test/test_keeper_meta_cas_retry.ml
+++ b/test/test_keeper_meta_cas_retry.ml
@@ -166,11 +166,30 @@ let test_monotonic_usage_counters_on_cas_retry () =
     let with_usage (m : Keeper_meta_contract.keeper_meta) usage =
       { m with runtime = { m.runtime with usage } }
     in
+    let with_consumption
+          (m : Keeper_meta_contract.keeper_meta)
+          ~revision
+          ~projection_sha256
+      =
+      { m with
+        runtime =
+          { m.runtime with
+            proactive_rt =
+              { m.runtime.proactive_rt with
+                last_consumed_backlog_revision = revision
+              ; last_consumed_backlog_projection_sha256 = projection_sha256
+              }
+          }
+      }
+    in
+    let projection_a = String.make 64 'a' in
+    let projection_b = String.make 64 'b' in
     (* Concurrent writer advances cumulative counters on disk. *)
     let racing =
       with_usage caller_view
         { caller_view.runtime.usage with
           total_turns = 10; total_tokens = 1000 }
+      |> with_consumption ~revision:10 ~projection_sha256:projection_b
     in
     (match Keeper_meta_store.write_meta config racing with
      | Ok () -> ()
@@ -180,6 +199,7 @@ let test_monotonic_usage_counters_on_cas_retry () =
       with_usage caller_view
         { caller_view.runtime.usage with
           total_turns = 3; total_tokens = 200; last_latency_ms = 777 }
+      |> with_consumption ~revision:3 ~projection_sha256:projection_a
     in
     (match
        Keeper_meta_store.write_meta_with_merge
@@ -196,7 +216,11 @@ let test_monotonic_usage_counters_on_cas_retry () =
     check int "total_tokens keeps the larger disk value" 1000
       final.runtime.usage.total_tokens;
     check int "last_* observation stays with the caller" 777
-      final.runtime.usage.last_latency_ms)
+      final.runtime.usage.last_latency_ms;
+    check int "consumption revision never rewinds" 10
+      final.runtime.proactive_rt.last_consumed_backlog_revision;
+    check string "projection stays paired with winning revision" projection_b
+      final.runtime.proactive_rt.last_consumed_backlog_projection_sha256)
 
 let test_operator_pause_survives_stale_heartbeat_retry () =
   Eio_main.run @@ fun env ->

--- a/test/test_keeper_paused_work_resume_surface.ml
+++ b/test/test_keeper_paused_work_resume_surface.ml
@@ -8,24 +8,23 @@ let require_ok label = function
   | Error error -> failf "%s: %s" label error
 ;;
 
-let test_single_resume_requires_exact_fences () =
+let test_single_resume_requires_operation_id () =
   let action_only = `Assoc [ "action", `String "resume" ] in
   (match Surface.parse_resume_request action_only with
    | Error _ -> ()
-   | Ok _ -> fail "action-only resume was accepted");
+   | Ok _ -> fail "resume without operation ID was accepted");
   let parsed =
     Surface.parse_resume_request
       (`Assoc
          [ "action", `String "resume"
-         ; "owner_nonce", `Int 7
          ; "operator_operation_id", `String "dashboard-resume-7"
          ])
-    |> require_ok "parse exact Resume_owner"
+    |> require_ok "parse resume operation ID"
   in
-  check (pair int string) "exact fences" (7, "dashboard-resume-7") parsed
+  check string "operation ID" "dashboard-resume-7" parsed
 ;;
 
-let test_bulk_resume_requires_per_owner_targets () =
+let test_bulk_resume_requires_operation_ids () =
   let names_only =
     `Assoc
       [ "action", `String "resume"
@@ -34,7 +33,7 @@ let test_bulk_resume_requires_per_owner_targets () =
   in
   (match Surface.parse_bulk_resume_requests names_only with
    | Error _ -> ()
-   | Ok _ -> fail "names-only bulk resume was accepted");
+   | Ok _ -> fail "bulk resume without targets was accepted");
   let parsed =
     Surface.parse_bulk_resume_requests
       (`Assoc
@@ -43,12 +42,10 @@ let test_bulk_resume_requires_per_owner_targets () =
            , `List
                [ `Assoc
                    [ "name", `String "rondo"
-                   ; "owner_nonce", `Int 3
                    ; "operator_operation_id", `String "resume-rondo-1"
                    ]
                ; `Assoc
                    [ "name", `String "qa-king"
-                   ; "owner_nonce", `Int 5
                    ; "operator_operation_id", `String "resume-qa-1"
                    ]
                ] )
@@ -56,9 +53,9 @@ let test_bulk_resume_requires_per_owner_targets () =
     |> require_ok "parse bulk Resume_owner"
   in
   check
-    (list (triple string int string))
-    "per-owner fences"
-    [ "rondo", 3, "resume-rondo-1"; "qa-king", 5, "resume-qa-1" ]
+    (list (pair string string))
+    "resume operation IDs"
+    [ "rondo", "resume-rondo-1"; "qa-king", "resume-qa-1" ]
     parsed
 ;;
 
@@ -67,13 +64,13 @@ let () =
     "keeper paused-work resume surface"
     [ ( "resume request contract"
       , [ test_case
-            "single requires generation and operation id"
+            "single requires operation id"
             `Quick
-            test_single_resume_requires_exact_fences
+            test_single_resume_requires_operation_id
         ; test_case
-            "bulk requires per-owner targets"
+            "bulk requires operation IDs"
             `Quick
-            test_bulk_resume_requires_per_owner_targets
+            test_bulk_resume_requires_operation_ids
         ] )
     ]
 ;;

--- a/test/test_keeper_raw_task_signal_wake.ml
+++ b/test/test_keeper_raw_task_signal_wake.ml
@@ -15,6 +15,7 @@ let base_observation : WO.world_observation =
   ; backlog_updated_since_last_scheduled_autonomous = false
   ; backlog_revision = Some 1
   ; backlog_projection_sha256 = Some (String.make 64 '0')
+  ; backlog_source = Keeper_world_observation_inputs.Primary
   ; running_keeper_fiber_count = 1
   ; connected_surfaces = []
   ; connected_surface_failures = []

--- a/test/test_keeper_raw_task_signal_wake.ml
+++ b/test/test_keeper_raw_task_signal_wake.ml
@@ -12,10 +12,12 @@ let base_observation : WO.world_observation =
   ; claimable_task_count = 0
   ; failed_task_count = 0
   ; scheduled_automation = WO.empty_scheduled_automation_observation
-  ; backlog_updated_since_last_scheduled_autonomous = false
-  ; backlog_revision = Some 1
-  ; backlog_projection_sha256 = Some (String.make 64 '0')
-  ; backlog_source = Keeper_world_observation_inputs.Primary
+  ; backlog_edge =
+      Masc.Keeper_world_observation_inputs.Observed_backlog
+        { revision = 1
+        ; projection_sha256 = String.make 64 '0'
+        ; updated_since_last_scheduled_autonomous = false
+        }
   ; running_keeper_fiber_count = 1
   ; connected_surfaces = []
   ; connected_surface_failures = []

--- a/test/test_keeper_raw_task_signal_wake.ml
+++ b/test/test_keeper_raw_task_signal_wake.ml
@@ -14,6 +14,7 @@ let base_observation : WO.world_observation =
   ; scheduled_automation = WO.empty_scheduled_automation_observation
   ; backlog_updated_since_last_scheduled_autonomous = false
   ; backlog_revision = Some 1
+  ; backlog_projection_sha256 = Some (String.make 64 '0')
   ; running_keeper_fiber_count = 1
   ; connected_surfaces = []
   ; connected_surface_failures = []

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -715,7 +715,7 @@ let test_reconcile_materializes_configured_keeper_without_meta () =
   let materialized = ref [] in
   let supervised = ref [] in
   let publish_lifecycle ~event:_ _name _detail () = () in
-  let supervise_keepalive ~proactive_warmup_sec:_ _ctx
+  let supervise_keepalive _ctx
       (meta : Keeper_meta_contract.keeper_meta) =
     supervised := meta.name :: !supervised
   in
@@ -751,7 +751,7 @@ let test_reconcile_does_not_double_start_materialized_keeper () =
   let materialized = ref [] in
   let supervised = ref [] in
   let publish_lifecycle ~event:_ _name _detail () = () in
-  let supervise_keepalive ~proactive_warmup_sec:_ _ctx
+  let supervise_keepalive _ctx
       (meta : Keeper_meta_contract.keeper_meta) =
     supervised := meta.name :: !supervised
   in
@@ -802,7 +802,7 @@ let test_reconcile_does_not_double_start_materialized_keeper () =
    | Ok () -> ()
    | Error err -> fail err);
   let publish_lifecycle ~event:_ _name _detail () = () in
-  let supervise_keepalive ~proactive_warmup_sec:_ _ctx _meta = () in
+  let supervise_keepalive _ctx _meta = () in
   KSR.reconcile_keepalive_keepers
     ~publish_lifecycle
     ~supervise_keepalive
@@ -846,7 +846,7 @@ let test_reconcile_materialize_failure_continues_with_metric () =
   let metric = Keeper_metrics.(to_string KeeperMaterializationFailures) in
   let before = Masc.Otel_metric_store.metric_total metric in
   let publish_lifecycle ~event:_ _name _detail () = () in
-  let supervise_keepalive ~proactive_warmup_sec:_ _ctx
+  let supervise_keepalive _ctx
       (meta : Keeper_meta_contract.keeper_meta) =
     supervised := meta.name :: !supervised
   in
@@ -886,7 +886,7 @@ let test_reconcile_supervise_exception_continues () =
   let metric = Keeper_metrics.(to_string ReconcileFailures) in
   let before = Masc.Otel_metric_store.metric_total metric in
   let publish_lifecycle ~event:_ _name _detail () = () in
-  let supervise_keepalive ~proactive_warmup_sec:_ _ctx
+  let supervise_keepalive _ctx
       (meta : Keeper_meta_contract.keeper_meta) =
     if String.equal meta.name failing
     then raise (Failure "fixture supervise failure")
@@ -921,7 +921,6 @@ let test_supervise_keepalive_retains_sweep_owned_entries () =
   let launched = ref [] in
   let publish_lifecycle ~event:_ _name _detail () = () in
   let launch_supervised_fiber
-        ~proactive_warmup_sec:_
         _ctx
         _meta
         (entry : Reg.registry_entry)
@@ -950,7 +949,6 @@ let test_supervise_keepalive_retains_sweep_owned_entries () =
   KSS.supervise_keepalive
     ~publish_lifecycle
     ~launch_supervised_fiber
-    ~proactive_warmup_sec:0
     ctx
     stopped_meta;
   let crashed_name = "recoverable-crashed-owner" in
@@ -975,7 +973,6 @@ let test_supervise_keepalive_retains_sweep_owned_entries () =
   KSS.supervise_keepalive
     ~publish_lifecycle
     ~launch_supervised_fiber
-    ~proactive_warmup_sec:0
     ctx
     crashed_meta;
   check
@@ -1601,8 +1598,7 @@ let test_launch_rejected_terminal_state_does_not_announce_running () =
       in
       Sup.with_restart_launch_noop_for_test (fun () ->
         match
-          Masc.Keeper_supervisor_launch.launch_supervised_fiber
-            ~proactive_warmup_sec:0 ctx meta reg
+          Masc.Keeper_supervisor_launch.launch_supervised_fiber ctx meta reg
         with
         | Ok () -> fail "expected Fiber_started to be rejected in terminal state"
         | Error _ -> ());
@@ -1652,7 +1648,6 @@ let test_supervised_stop_joins_board_attention_worker () =
       in
       (match
          Masc.Keeper_supervisor_launch.launch_supervised_fiber
-           ~proactive_warmup_sec:0
            ctx
            meta
            reg
@@ -1727,8 +1722,7 @@ let test_launch_fork_rejection_does_not_announce_running () =
         }
       in
       (match
-         Masc.Keeper_supervisor_launch.launch_supervised_fiber
-           ~proactive_warmup_sec:0 ctx meta reg
+         Masc.Keeper_supervisor_launch.launch_supervised_fiber ctx meta reg
        with
        | Ok () -> fail "expected lane fork rejection to propagate as Error"
        | Error _ -> ());
@@ -1778,8 +1772,7 @@ let test_fork_rejection_preserves_replacement_lane () =
         }
       in
       (match
-         Masc.Keeper_supervisor_launch.launch_supervised_fiber_body
-           ~proactive_warmup_sec:0 ctx meta rejected
+         Masc.Keeper_supervisor_launch.launch_supervised_fiber_body ctx meta rejected
        with
        | Ok () -> fail "expected rejected lane to propagate as Error"
        | Error _ -> ());
@@ -1831,8 +1824,7 @@ let test_fork_rejection_unregisters_non_terminalizable_owner () =
         }
       in
       (match
-         Masc.Keeper_supervisor_launch.launch_supervised_fiber_body
-           ~proactive_warmup_sec:0 ctx meta rejected
+         Masc.Keeper_supervisor_launch.launch_supervised_fiber_body ctx meta rejected
        with
        | Ok () -> fail "expected rejected terminal lane to propagate as Error"
        | Error _ -> ());

--- a/test/test_keeper_surface_presence_prompt.ml
+++ b/test/test_keeper_surface_presence_prompt.ml
@@ -61,6 +61,7 @@ let base_observation : WO.world_observation =
     scheduled_automation = WO.empty_scheduled_automation_observation;
     backlog_updated_since_last_scheduled_autonomous = false;
     backlog_revision = Some 1;
+    backlog_projection_sha256 = Some (String.make 64 '0');
     running_keeper_fiber_count = 0;
     connected_surfaces = [];
     connected_surface_failures = [];

--- a/test/test_keeper_surface_presence_prompt.ml
+++ b/test/test_keeper_surface_presence_prompt.ml
@@ -59,10 +59,12 @@ let base_observation : WO.world_observation =
     claimable_task_count = 0;
     failed_task_count = 0;
     scheduled_automation = WO.empty_scheduled_automation_observation;
-    backlog_updated_since_last_scheduled_autonomous = false;
-    backlog_revision = Some 1;
-    backlog_projection_sha256 = Some (String.make 64 '0');
-    backlog_source = Masc.Keeper_world_observation_inputs.Primary;
+    backlog_edge =
+      Masc.Keeper_world_observation_inputs.Observed_backlog
+        { revision = 1;
+          projection_sha256 = String.make 64 '0';
+          updated_since_last_scheduled_autonomous = false
+        };
     running_keeper_fiber_count = 0;
     connected_surfaces = [];
     connected_surface_failures = [];

--- a/test/test_keeper_surface_presence_prompt.ml
+++ b/test/test_keeper_surface_presence_prompt.ml
@@ -62,6 +62,7 @@ let base_observation : WO.world_observation =
     backlog_updated_since_last_scheduled_autonomous = false;
     backlog_revision = Some 1;
     backlog_projection_sha256 = Some (String.make 64 '0');
+    backlog_source = Masc.Keeper_world_observation_inputs.Primary;
     running_keeper_fiber_count = 0;
     connected_surfaces = [];
     connected_surface_failures = [];

--- a/test/test_keeper_surface_presence_prompt.ml
+++ b/test/test_keeper_surface_presence_prompt.ml
@@ -139,7 +139,8 @@ let init_prompt_config_for_tests () =
 let user_message observation =
   let turn_decision = WO.keeper_cycle_decision ~meta observation in
   let { Prompt.world_state = user; _ } =
-    Prompt.build_prompt ~meta ~base_path:"/tmp/unused" ~turn_decision
+    Prompt.build_prompt ~meta ~config:(Masc.Workspace.default_config "/tmp/unused")
+      ~turn_decision
       ~current_task:Inputs.No_current_task ~observation ()
   in
   user
@@ -147,7 +148,8 @@ let user_message observation =
 let system_prompt ?profile_defaults observation =
   let turn_decision = WO.keeper_cycle_decision ~meta observation in
   let { Prompt.system_prompt = system; _ } =
-    Prompt.build_prompt ~meta ~base_path:"/tmp/unused" ?profile_defaults
+    Prompt.build_prompt ~meta ~config:(Masc.Workspace.default_config "/tmp/unused")
+      ?profile_defaults
       ~turn_decision ~current_task:Inputs.No_current_task ~observation ()
   in
   system
@@ -276,7 +278,7 @@ let sandbox_root_for profile =
   let { Prompt.system_prompt; _ } =
     Prompt.build_prompt
       ~meta
-      ~base_path
+      ~config
       ~turn_decision
       ~current_task:Inputs.No_current_task
       ~observation:base_observation

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -918,6 +918,7 @@ let () =
           Masc.Keeper_world_observation.empty_scheduled_automation_observation
       ; backlog_updated_since_last_scheduled_autonomous = false
       ; backlog_revision = Some 1
+      ; backlog_projection_sha256 = Some (String.make 64 '0')
       ; running_keeper_fiber_count = 0
       ; connected_surfaces = []
       ; connected_surface_failures = []

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -916,10 +916,12 @@ let () =
       ; failed_task_count = 0
       ; scheduled_automation =
           Masc.Keeper_world_observation.empty_scheduled_automation_observation
-      ; backlog_updated_since_last_scheduled_autonomous = false
-      ; backlog_revision = Some 1
-      ; backlog_projection_sha256 = Some (String.make 64 '0')
-      ; backlog_source = Masc.Keeper_world_observation_inputs.Primary
+      ; backlog_edge =
+          Masc.Keeper_world_observation_inputs.Observed_backlog
+            { revision = 1
+            ; projection_sha256 = String.make 64 '0'
+            ; updated_since_last_scheduled_autonomous = false
+            }
       ; running_keeper_fiber_count = 0
       ; connected_surfaces = []
       ; connected_surface_failures = []

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -919,6 +919,7 @@ let () =
       ; backlog_updated_since_last_scheduled_autonomous = false
       ; backlog_revision = Some 1
       ; backlog_projection_sha256 = Some (String.make 64 '0')
+      ; backlog_source = Masc.Keeper_world_observation_inputs.Primary
       ; running_keeper_fiber_count = 0
       ; connected_surfaces = []
       ; connected_surface_failures = []

--- a/test/test_keeper_unified_persona_block.ml
+++ b/test/test_keeper_unified_persona_block.ml
@@ -69,7 +69,7 @@ let build_prompt meta =
   let turn_decision = WO.keeper_cycle_decision ~meta base_observation in
   Masc.Keeper_unified_prompt.build_prompt
     ~meta
-    ~base_path:"/tmp"
+    ~config:(Masc.Workspace.default_config "/tmp")
     ~turn_decision
     ~current_task:Masc.Keeper_world_observation_inputs.No_current_task
     ~observation:base_observation

--- a/test/test_keeper_unified_persona_block.ml
+++ b/test/test_keeper_unified_persona_block.ml
@@ -43,6 +43,7 @@ let base_observation : WO.world_observation =
     scheduled_automation = WO.empty_scheduled_automation_observation;
     backlog_updated_since_last_scheduled_autonomous = false;
     backlog_revision = Some 1;
+    backlog_projection_sha256 = Some (String.make 64 '0');
     running_keeper_fiber_count = 0;
     connected_surfaces = [];
     connected_surface_failures = [];

--- a/test/test_keeper_unified_persona_block.ml
+++ b/test/test_keeper_unified_persona_block.ml
@@ -41,10 +41,12 @@ let base_observation : WO.world_observation =
     claimable_task_count = 0;
     failed_task_count = 0;
     scheduled_automation = WO.empty_scheduled_automation_observation;
-    backlog_updated_since_last_scheduled_autonomous = false;
-    backlog_revision = Some 1;
-    backlog_projection_sha256 = Some (String.make 64 '0');
-    backlog_source = Masc.Keeper_world_observation_inputs.Primary;
+    backlog_edge =
+      Masc.Keeper_world_observation_inputs.Observed_backlog
+        { revision = 1;
+          projection_sha256 = String.make 64 '0';
+          updated_since_last_scheduled_autonomous = false
+        };
     running_keeper_fiber_count = 0;
     connected_surfaces = [];
     connected_surface_failures = [];

--- a/test/test_keeper_unified_persona_block.ml
+++ b/test/test_keeper_unified_persona_block.ml
@@ -44,6 +44,7 @@ let base_observation : WO.world_observation =
     backlog_updated_since_last_scheduled_autonomous = false;
     backlog_revision = Some 1;
     backlog_projection_sha256 = Some (String.make 64 '0');
+    backlog_source = Masc.Keeper_world_observation_inputs.Primary;
     running_keeper_fiber_count = 0;
     connected_surfaces = [];
     connected_surface_failures = [];

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -110,7 +110,7 @@ let build_prompt ~meta observation =
   in
   Masc.Keeper_unified_prompt.build_prompt
     ~meta
-    ~base_path:"/tmp"
+    ~config:(Masc.Workspace.default_config "/tmp")
     ~turn_decision
     ~current_task:Masc.Keeper_world_observation_inputs.No_current_task
     ~observation

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -13,10 +13,12 @@ let base_observation : WO.world_observation =
     claimable_task_count = 0;
     failed_task_count = 0;
     scheduled_automation = WO.empty_scheduled_automation_observation;
-    backlog_updated_since_last_scheduled_autonomous = false;
-    backlog_revision = Some 1;
-    backlog_projection_sha256 = Some (String.make 64 '0');
-    backlog_source = Masc.Keeper_world_observation_inputs.Primary;
+    backlog_edge =
+      Masc.Keeper_world_observation_inputs.Observed_backlog
+        { revision = 1;
+          projection_sha256 = String.make 64 '0';
+          updated_since_last_scheduled_autonomous = false
+        };
     running_keeper_fiber_count = 0;
     connected_surfaces = [];
     connected_surface_failures = [];

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -16,6 +16,7 @@ let base_observation : WO.world_observation =
     backlog_updated_since_last_scheduled_autonomous = false;
     backlog_revision = Some 1;
     backlog_projection_sha256 = Some (String.make 64 '0');
+    backlog_source = Masc.Keeper_world_observation_inputs.Primary;
     running_keeper_fiber_count = 0;
     connected_surfaces = [];
     connected_surface_failures = [];

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -15,6 +15,7 @@ let base_observation : WO.world_observation =
     scheduled_automation = WO.empty_scheduled_automation_observation;
     backlog_updated_since_last_scheduled_autonomous = false;
     backlog_revision = Some 1;
+    backlog_projection_sha256 = Some (String.make 64 '0');
     running_keeper_fiber_count = 0;
     connected_surfaces = [];
     connected_surface_failures = [];

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -65,10 +65,12 @@ let base_observation : WO.world_observation =
     claimable_task_count = 0;
     failed_task_count = 0;
     scheduled_automation = WO.empty_scheduled_automation_observation;
-    backlog_updated_since_last_scheduled_autonomous = false;
-    backlog_revision = Some 1;
-    backlog_projection_sha256 = Some (String.make 64 '0');
-    backlog_source = Masc.Keeper_world_observation_inputs.Primary;
+    backlog_edge =
+      Masc.Keeper_world_observation_inputs.Observed_backlog
+        { revision = 1;
+          projection_sha256 = String.make 64 '0';
+          updated_since_last_scheduled_autonomous = false
+        };
     running_keeper_fiber_count = 0;
     connected_surfaces = [];
     connected_surface_failures = [];

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -67,6 +67,7 @@ let base_observation : WO.world_observation =
     scheduled_automation = WO.empty_scheduled_automation_observation;
     backlog_updated_since_last_scheduled_autonomous = false;
     backlog_revision = Some 1;
+    backlog_projection_sha256 = Some (String.make 64 '0');
     running_keeper_fiber_count = 0;
     connected_surfaces = [];
     connected_surface_failures = [];

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -68,6 +68,7 @@ let base_observation : WO.world_observation =
     backlog_updated_since_last_scheduled_autonomous = false;
     backlog_revision = Some 1;
     backlog_projection_sha256 = Some (String.make 64 '0');
+    backlog_source = Masc.Keeper_world_observation_inputs.Primary;
     running_keeper_fiber_count = 0;
     connected_surfaces = [];
     connected_surface_failures = [];

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -192,7 +192,8 @@ let user_message ?turn_decision ?current_task ?active_goal_summaries observation
     | None -> Inputs.No_current_task
   in
   let { Prompt.world_state = user; _ } =
-    Prompt.build_prompt ~meta ~base_path:"/tmp/unused" ~turn_decision
+    Prompt.build_prompt ~meta ~config:(Masc.Workspace.default_config "/tmp/unused")
+      ~turn_decision
       ~current_task ?active_goal_summaries ~observation ()
   in
   user
@@ -247,7 +248,8 @@ let test_current_task_unavailable_is_explicit () =
   let task_id = task_id_exn "task-42" in
   let decision = WO.keeper_cycle_decision ~meta base_observation in
   let { Prompt.world_state; _ } =
-    Prompt.build_prompt ~meta ~base_path:"/tmp/unused" ~turn_decision:decision
+    Prompt.build_prompt ~meta ~config:(Masc.Workspace.default_config "/tmp/unused")
+      ~turn_decision:decision
       ~current_task:
         (Inputs.Current_task_unavailable
            { task_id; error = "primary and recovery backlog decode failed" })
@@ -264,7 +266,8 @@ let test_current_task_missing_is_explicit () =
   let task_id = task_id_exn "task-42" in
   let decision = WO.keeper_cycle_decision ~meta base_observation in
   let { Prompt.world_state; _ } =
-    Prompt.build_prompt ~meta ~base_path:"/tmp/unused" ~turn_decision:decision
+    Prompt.build_prompt ~meta ~config:(Masc.Workspace.default_config "/tmp/unused")
+      ~turn_decision:decision
       ~current_task:(Inputs.Current_task_missing { task_id; recovery = None })
       ~observation:base_observation ()
   in
@@ -282,7 +285,8 @@ let test_recovered_current_task_is_non_authoritative () =
     { recovery_path = "/tmp/backlog.last-good"; primary_error = "decode failed" }
   in
   let { Prompt.world_state; _ } =
-    Prompt.build_prompt ~meta ~base_path:"/tmp/unused" ~turn_decision:decision
+    Prompt.build_prompt ~meta ~config:(Masc.Workspace.default_config "/tmp/unused")
+      ~turn_decision:decision
       ~current_task:
         (Inputs.Recovered_current_task { task = recovered_task; recovery })
       ~observation:base_observation ()
@@ -356,7 +360,7 @@ let test_direct_and_autonomous_share_system_prompt () =
   let { Prompt.system_prompt = autonomous_system_prompt; _ } =
     Prompt.build_prompt
       ~meta
-      ~base_path:"/tmp/unused"
+      ~config:(Masc.Workspace.default_config "/tmp/unused")
       ~turn_decision:decision
       ~current_task:Inputs.No_current_task
       ~observation:base_observation
@@ -402,7 +406,7 @@ let test_unresolved_goal_keeps_one_stable_safety_contract () =
   let { Prompt.system_prompt = autonomous_system_prompt; _ } =
     Prompt.build_prompt
       ~meta:meta_with_goal
-      ~base_path:"/tmp/unused"
+      ~config
       ~active_goal_summaries
       ~turn_decision:decision
       ~current_task:Inputs.No_current_task
@@ -492,7 +496,7 @@ let test_preview_does_not_invent_wake_reason () =
   let { Prompt.world_state; _ } =
     Prompt.build_prompt_preview
       ~meta:preview_meta
-      ~base_path:"/tmp/unused"
+      ~config:(Masc.Workspace.default_config "/tmp/unused")
       ~current_task:Inputs.No_current_task
       ~observation:base_observation
       ()
@@ -559,7 +563,8 @@ let test_goal_holder_gets_self_direction_directive () =
     WO.keeper_cycle_decision ~meta:meta_with_goal base_observation
   in
   let { Prompt.system_prompt = system; _ } =
-    Prompt.build_prompt ~meta:meta_with_goal ~base_path:"/tmp/unused"
+    Prompt.build_prompt ~meta:meta_with_goal
+      ~config:(Masc.Workspace.default_config "/tmp/unused")
       ~turn_decision:goal_turn_decision ~current_task:Inputs.No_current_task
       ~observation:base_observation ()
   in
@@ -571,7 +576,8 @@ let test_goal_holder_gets_self_direction_directive () =
     WO.keeper_cycle_decision ~meta base_observation
   in
   let { Prompt.system_prompt = no_goal_system; _ } =
-    Prompt.build_prompt ~meta ~base_path:"/tmp/unused"
+    Prompt.build_prompt ~meta
+      ~config:(Masc.Workspace.default_config "/tmp/unused")
       ~turn_decision:no_goal_turn_decision ~current_task:Inputs.No_current_task
       ~observation:base_observation ()
   in

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -1669,7 +1669,7 @@ let test_read_backlog_counts_excludes_self_owned_orphan () =
     (* Remove the agent file to simulate a keeper with no active registry record. *)
     let _ = Workspace.end_session config ~agent_name:keeper in
     let meta = keeper_meta_for_self_filter keeper in
-    let _, _, failed, _, _ =
+    let _, _, failed, _, _, _ =
       Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
     in
     Alcotest.(check int) "keeper's own orphan excluded from failed count" 0 failed
@@ -1683,7 +1683,7 @@ let test_read_backlog_counts_falls_back_to_unscoped_claimable_task () =
         ~priority:1 ~description:""
     in
     let meta = keeper_meta_for_goal_filter keeper [ "goal-a" ] in
-    let _, claimable, _, _, _ =
+    let _, claimable, _, _, _, _ =
       Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
     in
     Alcotest.(check int)
@@ -1735,7 +1735,7 @@ let test_read_backlog_counts_preserves_unreadable_observation () =
       revision;
     write_corrupt (Workspace.backlog_recovery_path config);
     let meta = keeper_meta_for_self_filter "keeper-backlog-failure-agent" in
-    let unclaimed, claimable, failed, changed, revision =
+    let unclaimed, claimable, failed, changed, revision, projection_sha256 =
       Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
     in
     Alcotest.(check int) "unreadable unclaimed count is inert" 0 unclaimed;
@@ -1746,6 +1746,10 @@ let test_read_backlog_counts_preserves_unreadable_observation () =
       "unreadable backlog has no fabricated revision"
       None
       revision;
+    Alcotest.(check (option string))
+      "unreadable backlog has no fabricated projection"
+      None
+      projection_sha256;
     let board_event : Keeper_world_observation.pending_board_event =
       { event_kind = Board_post_created
       ; post_id = "post-backlog-unreadable"
@@ -1849,7 +1853,7 @@ let test_self_authored_scoped_task_does_not_hide_peer_work () =
       Workspace.add_task config ~goal_id:"goal-b" ~created_by:"peer-keeper"
         ~title:"Peer work outside active goal" ~priority:1 ~description:""
     in
-    let _, claimable, _, _, _ =
+    let _, claimable, _, _, _, _ =
       Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
     in
     Alcotest.(check int)
@@ -1865,24 +1869,28 @@ let test_self_authored_scoped_task_does_not_hide_peer_work () =
 let test_read_backlog_counts_excludes_self_authored_task () =
   with_test_env (fun config ->
     let meta = keeper_meta_for_self_filter "keeper-self-filter-agent" in
-    let _, claimable_before, _, _, _ =
+    let _, claimable_before, _, _, _, projection_before =
       Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
     in
     let _ =
       Workspace.add_task config ~created_by:meta.name
         ~title:"self-authored routing task" ~priority:3 ~description:""
     in
-    let unclaimed_after_self, claimable_after_self, _, _, _ =
+    let unclaimed_after_self, claimable_after_self, _, _, _, projection_after_self =
       Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
     in
     Alcotest.(check int)
       "a keeper's own task is not offered back to it as claimable"
       claimable_before claimable_after_self;
+    Alcotest.(check (option string))
+      "self-authored Todo does not move the admission projection"
+      projection_before
+      projection_after_self;
     let _ =
       Workspace.add_task config ~created_by:"peer-keeper"
         ~title:"peer authored task" ~priority:3 ~description:""
     in
-    let unclaimed_after_peer, claimable_after_peer, _, _, _ =
+    let unclaimed_after_peer, claimable_after_peer, _, _, _, projection_after_peer =
       Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
     in
     Alcotest.(check int)
@@ -1890,7 +1898,11 @@ let test_read_backlog_counts_excludes_self_authored_task () =
       (claimable_before + 1) claimable_after_peer;
     Alcotest.(check int)
       "the unclaimed count still reports both tasks"
-      (unclaimed_after_self + 1) unclaimed_after_peer
+      (unclaimed_after_self + 1) unclaimed_after_peer;
+    Alcotest.(check bool)
+      "peer-authored Todo moves the admission projection"
+      true
+      (projection_after_peer <> projection_after_self)
   )
 
 let test_keeper_tasks_audit_excludes_self_owned_orphan () =

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -1669,7 +1669,7 @@ let test_read_backlog_counts_excludes_self_owned_orphan () =
     (* Remove the agent file to simulate a keeper with no active registry record. *)
     let _ = Workspace.end_session config ~agent_name:keeper in
     let meta = keeper_meta_for_self_filter keeper in
-    let _, _, failed, _, _, _, _ =
+    let _, _, failed, _ =
       Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
     in
     Alcotest.(check int) "keeper's own orphan excluded from failed count" 0 failed
@@ -1683,7 +1683,7 @@ let test_read_backlog_counts_falls_back_to_unscoped_claimable_task () =
         ~priority:1 ~description:""
     in
     let meta = keeper_meta_for_goal_filter keeper [ "goal-a" ] in
-    let _, claimable, _, _, _, _, _ =
+    let _, claimable, _, _ =
       Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
     in
     Alcotest.(check int)
@@ -1709,58 +1709,19 @@ let test_read_backlog_counts_preserves_unreadable_observation () =
         output_string channel "{\"tasks\":\"not-current\"}")
     in
     write_corrupt (Workspace.backlog_path config);
-    (match
-       Keeper_world_observation_inputs.read_current_task
-         ~config
-         ~meta:current_task_meta
-     with
-     | Keeper_world_observation_inputs.Recovered_current_task { task; recovery = _ } ->
-       Alcotest.(check string) "recovered task id" "task-001" task.id
-     | Keeper_world_observation_inputs.No_current_task
-     | Keeper_world_observation_inputs.Current_task _
-     | Keeper_world_observation_inputs.Current_task_missing _
-    | Keeper_world_observation_inputs.Current_task_unavailable _ ->
-      Alcotest.fail "valid recovery source was not preserved");
-    let meta = keeper_meta_for_self_filter "keeper-backlog-recovery-agent" in
-    let _unclaimed, _claimable, _failed, changed, revision, projection, source =
-      Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
-    in
-    Alcotest.(check bool) "recovery cannot report a backlog edge" false changed;
-    Alcotest.(check (option int))
-      "recovery has no authoritative revision"
-      None
-      revision;
-    Alcotest.(check (option string))
-      "recovery has no authoritative projection"
-      None
-      projection;
-    (match source with
-     | Keeper_world_observation_inputs.Recovery _ -> ()
-     | Keeper_world_observation_inputs.Primary
-     | Keeper_world_observation_inputs.Unavailable _ ->
-       Alcotest.fail "valid recovery source was not preserved");
     write_corrupt (Workspace.backlog_recovery_path config);
     let meta = keeper_meta_for_self_filter "keeper-backlog-failure-agent" in
-    let unclaimed, claimable, failed, changed, revision, projection_sha256, source =
+    let unclaimed, claimable, failed, edge =
       Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
     in
     Alcotest.(check int) "unreadable unclaimed count is inert" 0 unclaimed;
     Alcotest.(check int) "unreadable claimable count is inert" 0 claimable;
     Alcotest.(check int) "unreadable failed count is inert" 0 failed;
-    Alcotest.(check bool) "unreadable backlog cannot report an edge" false changed;
-    Alcotest.(check (option int))
-      "unreadable backlog has no fabricated revision"
-      None
-      revision;
-    Alcotest.(check (option string))
-      "unreadable backlog has no fabricated projection"
-      None
-      projection_sha256;
-    (match source with
-     | Keeper_world_observation_inputs.Unavailable _ -> ()
-     | Keeper_world_observation_inputs.Primary
-     | Keeper_world_observation_inputs.Recovery _ ->
-       Alcotest.fail "unreadable backlog must expose an unavailable source");
+    (match edge with
+     | Keeper_world_observation_inputs.Backlog_read_unavailable _ -> ()
+     | Keeper_world_observation_inputs.Recovery_backlog _
+     | Keeper_world_observation_inputs.Observed_backlog _ ->
+       Alcotest.fail "unreadable backlog must expose an unavailable edge");
     let board_event : Keeper_world_observation.pending_board_event =
       { event_kind = Board_post_created
       ; post_id = "post-backlog-unreadable"
@@ -1788,12 +1749,44 @@ let test_read_backlog_counts_preserves_unreadable_observation () =
       "world observation preserves unreadable backlog"
       true
       (match observation.backlog_edge with
-       | Keeper_world_observation_inputs.Backlog_read_unavailable -> true
+       | Keeper_world_observation_inputs.Backlog_read_unavailable _ -> true
+       | Keeper_world_observation_inputs.Recovery_backlog _
        | Keeper_world_observation_inputs.Observed_backlog _ -> false);
     Alcotest.(check int)
       "independent board stimulus survives unreadable backlog"
       1
       (List.length observation.pending_board_events))
+
+let test_read_backlog_counts_marks_recovery_non_authoritative () =
+  with_test_env (fun config ->
+    let backlog =
+      { Masc_domain.tasks = []
+      ; last_updated = Masc_domain.now_iso ()
+      ; version = 7
+      }
+    in
+    (match Workspace.write_backlog_result config backlog with
+     | Ok _ -> ()
+     | Error msg -> Alcotest.failf "failed to write recovery fixture: %s" msg);
+    Out_channel.with_open_text (Workspace.backlog_path config) (fun channel ->
+      output_string channel "{\"tasks\":\"not-current\"}");
+    let meta = keeper_meta_for_self_filter "keeper-recovered-backlog-agent" in
+    let unclaimed, claimable, failed, edge =
+      Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
+    in
+    Alcotest.(check int) "recovered unclaimed count remains observable" 0 unclaimed;
+    Alcotest.(check int) "recovered claimable count remains observable" 0 claimable;
+    Alcotest.(check int) "recovered failed count remains observable" 0 failed;
+    match edge with
+    | Keeper_world_observation_inputs.Recovery_backlog
+        { revision; projection_sha256; _ } ->
+      Alcotest.(check int) "recovered revision remains observable" 8 revision;
+      Alcotest.(check bool) "recovery projection is nonempty" true
+        (String.length projection_sha256 = 64)
+    | Keeper_world_observation_inputs.Backlog_read_unavailable _
+    | Keeper_world_observation_inputs.Observed_backlog _ ->
+      Alcotest.fail "valid recovery must remain explicitly marked as recovery")
+
 
 let test_read_current_task_preserves_unavailable_and_missing () =
   with_test_env (fun config ->
@@ -1815,6 +1808,22 @@ let test_read_current_task_preserves_unavailable_and_missing () =
      | Keeper_world_observation_inputs.Current_task_unavailable _ ->
        Alcotest.fail "existing task was not observed");
     let backlog = Workspace.read_backlog config in
+    let corrupt_primary path =
+      Out_channel.with_open_text path (fun channel ->
+        output_string channel "{\"tasks\":\"not-current\"}")
+    in
+    corrupt_primary (Workspace.backlog_path config);
+    (match Keeper_world_observation_inputs.read_current_task ~config ~meta with
+     | Keeper_world_observation_inputs.Recovered_current_task { task; recovery = _ } ->
+       Alcotest.(check string) "recovered task id" "task-001" task.id
+     | Keeper_world_observation_inputs.No_current_task
+     | Keeper_world_observation_inputs.Current_task _
+     | Keeper_world_observation_inputs.Current_task_missing _
+     | Keeper_world_observation_inputs.Current_task_unavailable _ ->
+       Alcotest.fail "valid recovery source was not preserved");
+    (match Workspace.write_backlog_result config backlog with
+     | Ok _ -> ()
+     | Error message -> Alcotest.fail message);
     let without_task = { backlog with tasks = [] } in
     (match Workspace.write_backlog_result config without_task with
      | Ok _ -> ()
@@ -1854,41 +1863,6 @@ let test_read_current_task_preserves_unavailable_and_missing () =
     | Keeper_world_observation_inputs.Current_task_missing _ ->
       Alcotest.fail "unreadable backlog did not remain explicitly unavailable")
 
-let test_read_backlog_counts_marks_recovery_non_authoritative () =
-  with_test_env (fun config ->
-    let backlog =
-      { Masc_domain.tasks = []
-      ; last_updated = Masc_domain.now_iso ()
-      ; version = 7
-      }
-    in
-    (match Workspace.write_backlog_result config backlog with
-     | Ok _ -> ()
-     | Error msg -> Alcotest.failf "failed to write recovery fixture: %s" msg);
-    Out_channel.with_open_text (Workspace.backlog_path config) (fun channel ->
-      output_string channel "{\"tasks\":\"not-current\"}");
-    let meta = keeper_meta_for_self_filter "keeper-recovered-backlog-agent" in
-    let unclaimed, claimable, failed, changed, revision, projection, source =
-      Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
-    in
-    Alcotest.(check int) "recovered unclaimed count remains observable" 0 unclaimed;
-    Alcotest.(check int) "recovered claimable count remains observable" 0 claimable;
-    Alcotest.(check int) "recovered failed count remains observable" 0 failed;
-    Alcotest.(check bool) "recovery cannot report an authoritative edge" false changed;
-    Alcotest.(check (option int))
-      "recovery cannot expose an authoritative revision"
-      None
-      revision;
-    Alcotest.(check (option string))
-      "recovery cannot expose an authoritative projection"
-      None
-      projection;
-    match source with
-    | Keeper_world_observation_inputs.Recovery _ -> ()
-    | Keeper_world_observation_inputs.Primary
-    | Keeper_world_observation_inputs.Unavailable _ ->
-      Alcotest.fail "valid recovery must remain explicitly marked as recovery")
-
 let test_self_authored_scoped_task_does_not_hide_peer_work () =
   with_test_env (fun config ->
     let keeper = "keeper-goal-filter-agent" in
@@ -1901,7 +1875,7 @@ let test_self_authored_scoped_task_does_not_hide_peer_work () =
       Workspace.add_task config ~goal_id:"goal-b" ~created_by:"peer-keeper"
         ~title:"Peer work outside active goal" ~priority:1 ~description:""
     in
-    let _, claimable, _, _, _, _, _ =
+    let _, claimable, _, _ =
       Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
     in
     Alcotest.(check int)
@@ -1916,17 +1890,27 @@ let test_self_authored_scoped_task_does_not_hide_peer_work () =
    compared against a baseline because the fixture seeds its own tasks. *)
 let test_read_backlog_counts_excludes_self_authored_task () =
   with_test_env (fun config ->
+    let projection_of_edge = function
+      | Keeper_world_observation_inputs.Observed_backlog
+          { projection_sha256; _ }
+      | Keeper_world_observation_inputs.Recovery_backlog
+          { projection_sha256; _ } ->
+        Some projection_sha256
+      | Keeper_world_observation_inputs.Backlog_read_unavailable _ -> None
+    in
     let meta = keeper_meta_for_self_filter "keeper-self-filter-agent" in
-    let _, claimable_before, _, _, _, projection_before, _ =
+    let _, claimable_before, _, edge_before =
       Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
     in
+    let projection_before = projection_of_edge edge_before in
     let _ =
       Workspace.add_task config ~created_by:meta.name
         ~title:"self-authored routing task" ~priority:3 ~description:""
     in
-    let unclaimed_after_self, claimable_after_self, _, _, _, projection_after_self, _ =
+    let unclaimed_after_self, claimable_after_self, _, edge_after_self =
       Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
     in
+    let projection_after_self = projection_of_edge edge_after_self in
     Alcotest.(check int)
       "a keeper's own task is not offered back to it as claimable"
       claimable_before claimable_after_self;
@@ -1938,9 +1922,10 @@ let test_read_backlog_counts_excludes_self_authored_task () =
       Workspace.add_task config ~created_by:"peer-keeper"
         ~title:"peer authored task" ~priority:3 ~description:""
     in
-    let unclaimed_after_peer, claimable_after_peer, _, _, _, projection_after_peer, _ =
+    let unclaimed_after_peer, claimable_after_peer, _, edge_after_peer =
       Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
     in
+    let projection_after_peer = projection_of_edge edge_after_peer in
     Alcotest.(check int)
       "a peer-authored task is still claimable"
       (claimable_before + 1) claimable_after_peer;
@@ -2375,10 +2360,10 @@ let () =
         test_read_backlog_counts_falls_back_to_unscoped_claimable_task;
       Alcotest.test_case "read backlog counts preserves unreadable observation" `Quick
         test_read_backlog_counts_preserves_unreadable_observation;
-      Alcotest.test_case "read current task preserves unavailable and missing" `Quick
-        test_read_current_task_preserves_unavailable_and_missing;
       Alcotest.test_case "read backlog counts marks recovery non-authoritative" `Quick
         test_read_backlog_counts_marks_recovery_non_authoritative;
+      Alcotest.test_case "read current task preserves unavailable and missing" `Quick
+        test_read_current_task_preserves_unavailable_and_missing;
       Alcotest.test_case "self-authored scoped task does not hide peer work"
         `Quick
         test_self_authored_scoped_task_does_not_hide_peer_work;

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -1669,7 +1669,7 @@ let test_read_backlog_counts_excludes_self_owned_orphan () =
     (* Remove the agent file to simulate a keeper with no active registry record. *)
     let _ = Workspace.end_session config ~agent_name:keeper in
     let meta = keeper_meta_for_self_filter keeper in
-    let _, _, failed, _, _, _ =
+    let _, _, failed, _, _, _, _ =
       Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
     in
     Alcotest.(check int) "keeper's own orphan excluded from failed count" 0 failed
@@ -1683,7 +1683,7 @@ let test_read_backlog_counts_falls_back_to_unscoped_claimable_task () =
         ~priority:1 ~description:""
     in
     let meta = keeper_meta_for_goal_filter keeper [ "goal-a" ] in
-    let _, claimable, _, _, _, _ =
+    let _, claimable, _, _, _, _, _ =
       Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
     in
     Alcotest.(check int)
@@ -1719,23 +1719,29 @@ let test_read_backlog_counts_preserves_unreadable_observation () =
      | Keeper_world_observation_inputs.No_current_task
      | Keeper_world_observation_inputs.Current_task _
      | Keeper_world_observation_inputs.Current_task_missing _
-     | Keeper_world_observation_inputs.Current_task_unavailable _ ->
-       Alcotest.fail "valid recovery source was not preserved");
+    | Keeper_world_observation_inputs.Current_task_unavailable _ ->
+      Alcotest.fail "valid recovery source was not preserved");
     let meta = keeper_meta_for_self_filter "keeper-backlog-recovery-agent" in
-    let unclaimed, claimable, failed, changed, revision =
+    let _unclaimed, _claimable, _failed, changed, revision, projection, source =
       Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
     in
-    Alcotest.(check int) "recovery unclaimed count is inert" 0 unclaimed;
-    Alcotest.(check int) "recovery claimable count is inert" 0 claimable;
-    Alcotest.(check int) "recovery failed count is inert" 0 failed;
     Alcotest.(check bool) "recovery cannot report a backlog edge" false changed;
     Alcotest.(check (option int))
       "recovery has no authoritative revision"
       None
       revision;
+    Alcotest.(check (option string))
+      "recovery has no authoritative projection"
+      None
+      projection;
+    (match source with
+     | Keeper_world_observation_inputs.Recovery _ -> ()
+     | Keeper_world_observation_inputs.Primary
+     | Keeper_world_observation_inputs.Unavailable _ ->
+       Alcotest.fail "valid recovery source was not preserved");
     write_corrupt (Workspace.backlog_recovery_path config);
     let meta = keeper_meta_for_self_filter "keeper-backlog-failure-agent" in
-    let unclaimed, claimable, failed, changed, revision, projection_sha256 =
+    let unclaimed, claimable, failed, changed, revision, projection_sha256, source =
       Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
     in
     Alcotest.(check int) "unreadable unclaimed count is inert" 0 unclaimed;
@@ -1750,6 +1756,11 @@ let test_read_backlog_counts_preserves_unreadable_observation () =
       "unreadable backlog has no fabricated projection"
       None
       projection_sha256;
+    (match source with
+     | Keeper_world_observation_inputs.Unavailable _ -> ()
+     | Keeper_world_observation_inputs.Primary
+     | Keeper_world_observation_inputs.Recovery _ ->
+       Alcotest.fail "unreadable backlog must expose an unavailable source");
     let board_event : Keeper_world_observation.pending_board_event =
       { event_kind = Board_post_created
       ; post_id = "post-backlog-unreadable"
@@ -1841,6 +1852,41 @@ let test_read_current_task_preserves_unavailable_and_missing () =
     | Keeper_world_observation_inputs.Current_task_missing _ ->
       Alcotest.fail "unreadable backlog did not remain explicitly unavailable")
 
+let test_read_backlog_counts_marks_recovery_non_authoritative () =
+  with_test_env (fun config ->
+    let backlog =
+      { Masc_domain.tasks = []
+      ; last_updated = Masc_domain.now_iso ()
+      ; version = 7
+      }
+    in
+    (match Workspace.write_backlog_result config backlog with
+     | Ok _ -> ()
+     | Error msg -> Alcotest.failf "failed to write recovery fixture: %s" msg);
+    Out_channel.with_open_text (Workspace.backlog_path config) (fun channel ->
+      output_string channel "{\"tasks\":\"not-current\"}");
+    let meta = keeper_meta_for_self_filter "keeper-recovered-backlog-agent" in
+    let unclaimed, claimable, failed, changed, revision, projection, source =
+      Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
+    in
+    Alcotest.(check int) "recovered unclaimed count remains observable" 0 unclaimed;
+    Alcotest.(check int) "recovered claimable count remains observable" 0 claimable;
+    Alcotest.(check int) "recovered failed count remains observable" 0 failed;
+    Alcotest.(check bool) "recovery cannot report an authoritative edge" false changed;
+    Alcotest.(check (option int))
+      "recovery cannot expose an authoritative revision"
+      None
+      revision;
+    Alcotest.(check (option string))
+      "recovery cannot expose an authoritative projection"
+      None
+      projection;
+    match source with
+    | Keeper_world_observation_inputs.Recovery _ -> ()
+    | Keeper_world_observation_inputs.Primary
+    | Keeper_world_observation_inputs.Unavailable _ ->
+      Alcotest.fail "valid recovery must remain explicitly marked as recovery")
+
 let test_self_authored_scoped_task_does_not_hide_peer_work () =
   with_test_env (fun config ->
     let keeper = "keeper-goal-filter-agent" in
@@ -1853,7 +1899,7 @@ let test_self_authored_scoped_task_does_not_hide_peer_work () =
       Workspace.add_task config ~goal_id:"goal-b" ~created_by:"peer-keeper"
         ~title:"Peer work outside active goal" ~priority:1 ~description:""
     in
-    let _, claimable, _, _, _, _ =
+    let _, claimable, _, _, _, _, _ =
       Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
     in
     Alcotest.(check int)
@@ -1869,14 +1915,14 @@ let test_self_authored_scoped_task_does_not_hide_peer_work () =
 let test_read_backlog_counts_excludes_self_authored_task () =
   with_test_env (fun config ->
     let meta = keeper_meta_for_self_filter "keeper-self-filter-agent" in
-    let _, claimable_before, _, _, _, projection_before =
+    let _, claimable_before, _, _, _, projection_before, _ =
       Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
     in
     let _ =
       Workspace.add_task config ~created_by:meta.name
         ~title:"self-authored routing task" ~priority:3 ~description:""
     in
-    let unclaimed_after_self, claimable_after_self, _, _, _, projection_after_self =
+    let unclaimed_after_self, claimable_after_self, _, _, _, projection_after_self, _ =
       Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
     in
     Alcotest.(check int)
@@ -1890,7 +1936,7 @@ let test_read_backlog_counts_excludes_self_authored_task () =
       Workspace.add_task config ~created_by:"peer-keeper"
         ~title:"peer authored task" ~priority:3 ~description:""
     in
-    let unclaimed_after_peer, claimable_after_peer, _, _, _, projection_after_peer =
+    let unclaimed_after_peer, claimable_after_peer, _, _, _, projection_after_peer, _ =
       Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
     in
     Alcotest.(check int)
@@ -2329,6 +2375,8 @@ let () =
         test_read_backlog_counts_preserves_unreadable_observation;
       Alcotest.test_case "read current task preserves unavailable and missing" `Quick
         test_read_current_task_preserves_unavailable_and_missing;
+      Alcotest.test_case "read backlog counts marks recovery non-authoritative" `Quick
+        test_read_backlog_counts_marks_recovery_non_authoritative;
       Alcotest.test_case "self-authored scoped task does not hide peer work"
         `Quick
         test_self_authored_scoped_task_does_not_hide_peer_work;

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -1784,10 +1784,12 @@ let test_read_backlog_counts_preserves_unreadable_observation () =
         ~config
         ~meta
     in
-    Alcotest.(check (option int))
+    Alcotest.(check bool)
       "world observation preserves unreadable backlog"
-      None
-      observation.backlog_revision;
+      true
+      (match observation.backlog_edge with
+       | Keeper_world_observation_inputs.Backlog_read_unavailable -> true
+       | Keeper_world_observation_inputs.Observed_backlog _ -> false);
     Alcotest.(check int)
       "independent board stimulus survives unreadable backlog"
       1

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -1694,16 +1694,6 @@ let test_read_backlog_counts_falls_back_to_unscoped_claimable_task () =
 
 let test_read_backlog_counts_preserves_unreadable_observation () =
   with_test_env (fun config ->
-    let task_id =
-      match Keeper_id.Task_id.of_string "task-001" with
-      | Ok task_id -> task_id
-      | Error message -> Alcotest.fail message
-    in
-    let current_task_meta =
-      { (keeper_meta_for_self_filter "keeper-backlog-recovery-agent") with
-        current_task_id = Some task_id
-      }
-    in
     let write_corrupt path =
       Out_channel.with_open_text path (fun channel ->
         output_string channel "{\"tasks\":\"not-current\"}")


### PR DESCRIPTION
## 요약 — RFC-0357 scheduled admission edge

scheduled heartbeat 자체를 무조건 wake 신호로 취급하던 경로를 typed stimulus admission으로 교체합니다. 정적 backlog나 wall clock 비교가 아니라, 현재 backlog의 단조 revision과 keeper별 relevant-task projection을 함께 소비합니다.

## Admission

scheduled-autonomous turn은 다음 typed reason 중 하나 이상이 있을 때만 실행합니다.

- Never_started
- Scope_message_pending
- Board_event_pending
- Task_backlog: revision이 전진하고 non-self-authored projection이 바뀜
- Scheduled_automation_due

reason 목록이 유일한 판정 입력입니다. 전부 없으면 No_actionable_stimulus, backlog를 읽지 못했으면 Backlog_unreadable입니다. 다른 message/board/schedule 자극은 backlog read 실패 때문에 침묵하지 않습니다.

## Backlog edge와 소비

- wall clock, 제목 문자열, tool-name 휴리스틱을 사용하지 않습니다.
- Todo 중 현재 keeper가 직접 만든 항목만 projection에서 제외합니다. typed task JSON을 정렬한 뒤 SHA-256을 계산합니다.
- revision과 projection, edge 여부는 하나의 합타입 backlog_edge로 운반합니다. 읽기 실패 또는 완전한 관측값만 표현 가능하며 partial pair와 runtime invalid_arg 경로는 제거했습니다.
- scheduled admission 시 in-memory meta에 exact revision/projection을 기록하고, 실패 turn과 crash catch 경로도 그 stamp를 유지합니다.
- reactive wake는 backlog edge를 소비하지 않습니다.
- concurrent meta write는 revision 우선 CAS merge로 최신 pair를 보존합니다.

## 현재형 meta 계약

last_consumed_backlog_revision과 last_consumed_backlog_projection_sha256은 current schema의 필수 필드입니다. absent/default/migration/legacy shim은 두지 않습니다. 기존 파일이 이 계약을 만족하지 않으면 명시적으로 reset이 필요한 hard cut입니다.

## 테스트와 검증

- admission disjunct/skip/read-failure/fast-turn/self-authored projection
- exact pair consumption, failed-turn/crash retention, CAS merge
- current meta roundtrip과 malformed/absent field rejection
- 현재 diff: 32 files, +1044/-95
- ocamlformat 0.29.0, touched-file parser, git diff --check 통과
- 로컬 Dune은 실행하지 않았고 전체 Build and Test는 exact head workflow_dispatch CI를 권위로 둡니다.

Base: #26675. RFC: #26613, #26638. 비용/무효-turn 추적: #26018.

## 배포 hard-cut preflight

이 PR은 과거 meta를 읽는 호환 경로나 마이그레이션 코드를 제공하지 않습니다. 배포자는 새 binary를 기동하기 전에 모든 운영 keeper meta가 아래 exact pair를 보유한다는 durable evidence를 확인하거나, 해당 keeper의 reset/recreate를 명시적으로 승인하고 수행해야 합니다. 둘 중 하나가 증명되지 않으면 배포 금지입니다.

- `last_consumed_backlog_revision`
- `last_consumed_backlog_projection_sha256`

2026-08-03 19:20 KST preflight (`/Users/dancer/me/.masc/keepers/*.json`): total 8, revision 0, projection 0, both 0. 따라서 현재 운영 상태에는 그대로 배포할 수 없고 reset/recreate 승인 및 수행 증거가 남아야 합니다. 이 단계는 데이터 삭제를 포함할 수 있으므로 PR 코드나 자동 CI가 대신 실행하지 않습니다.


### Reset/recreate 소멸 범위

reset/recreate는 keeper meta의 누적 회계(`total_turns`, `total_tokens`, `total_cost_usd`)와 계보(`generation`, `created_at`, `trace_id`, `trace_history`, `last_handoff_ts`)를 소멸시킵니다. 2026-08-03 20:30 KST 실측에서 `taskmaster`는 8,815 turns / 608,665,600 tokens / $90.21798672이며, 운영 meta 8개 중 exact pair 보유는 0개입니다. 승인자는 이 손실 범위를 확인한 뒤에만 destructive cutover를 수행해야 합니다.