### PR TITLE
docs(rfc): make generated index deterministic

### DIFF
--- a/.github/workflows/rfc-enforcer.yml
+++ b/.github/workflows/rfc-enforcer.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - 'docs/rfc/**'
       - 'docs/design/**'
+      - 'scripts/rfc-generate-index.py'
+      - '.github/workflows/rfc-enforcer.yml'
   workflow_dispatch:
 
 concurrency:
@@ -21,6 +23,9 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: '3.11'
+
+      - name: Check generated RFC index
+        run: python scripts/rfc-generate-index.py --check
 
       - name: Check changed RFC §1 completeness
         run: |

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -47,12 +47,12 @@ implementation_prs: []             # [14181, 14550] 형식 (정수). RFC body �
 commit 이 있는 RFC 만 Implemented 로 표기한다 — RFC body 머지는 spec
 implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 
-| # | Title | Status | Sub-docs |
+| RFC | Title | Status | Sub-docs |
 |---|---|---|---|
 | 0000 | MASC × OAS Consolidated Master Design (SSOT) | Draft | - |
 | 0001 | Withdraw heuristic uncertainty governance | Withdrawn | - |
 | 0002 | Keeper 11-State Machine + Det/NonDet Boundary Formalization | reference | - |
-| 0003 | Withdraw composite lifecycle projection hierarchy | Withdrawn | RFC-0003-phase-2-turn-observation-lifecycle.md |
+| 0003 | Withdraw composite lifecycle projection hierarchy | Withdrawn | Phase 2: Turn-Scoped Observation Lifecycle (`RFC-0003-phase-2-turn-observation-lifecycle.md`, reference) |
 | 0004 | OCaml ↔ TypeScript shared contract — SSE + gRPC-web | Active | - |
 | 0005 | Withdraw the typed command-policy substrate | Withdrawn | - |
 | 0006 | Keeper Surface And Sandbox | Draft | - |
@@ -71,7 +71,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0035 | Cognitive IDE Master Plan Integration | Draft | - |
 | 0036 | Multi-Keeper Docker Orchestration & Lifecycle Cleanup (`RFC-0036-multi-keeper-docker-orchestration.md`)<br>oas Cognitive Mapping (companion to RFC-0035) (`RFC-0036-oas-cognitive-mapping.md`) | Draft<br>Draft | - |
 | 0037 | Board Multimedia & Vision — Eio/File-Based Adaptation (`RFC-0037-board-multimedia-vision-adapted.md`)<br>Local-first Keeper Enablement: Harness/User Boundary (`RFC-0037-local-first-keeper-enablement-boundary.md`) | Draft<br>Draft | - |
-| 0038 | Opaque Identifier Types for Provider, Runtime, Model (`RFC-0038-opaque-identifier-types.md`)<br>Withdraw MASC capability-routing plan (`RFC-0038-runtime-routing-intent-preservation.md`) | Draft<br>Withdrawn | RFC-0038-phase-2-keeper-identity-canonical.md |
+| 0038 | Opaque Identifier Types for Provider, Runtime, Model (`RFC-0038-opaque-identifier-types.md`)<br>Withdraw MASC capability-routing plan (`RFC-0038-runtime-routing-intent-preservation.md`) | Draft<br>Withdrawn | Withdraw identity-alias migration (`RFC-0038-phase-2-keeper-identity-canonical.md`, Withdrawn) |
 | 0041 | Withdraw runtime group/item hierarchy | Withdrawn | - |
 | 0042 | Withdraw Keeper terminal-reason hierarchy | Withdrawn | - |
 | 0043 | Distribute legacy metrics backend metric ownership to domain modules | Active | - |
@@ -87,7 +87,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0054 | Withdraw code generation for command-policy GADTs | Withdrawn | - |
 | 0056 | Incremental Sub-Library Extraction from Flat masc Library | Active | - |
 | 0057 | Tool Descriptor Codegen — `[@@deriving tool]` via Build-Time Generation | Draft | - |
-| 0058 | Withdraw terminal capability hierarchy | Withdrawn | RFC-0058-phase-5-erase-provider-variant.md |
+| 0058 | Withdraw terminal capability hierarchy | Withdrawn | Withdraw provider-variant migration plan (`RFC-0058-phase-5-erase-provider-variant.md`, Withdrawn) |
 | 0062 | Typed `Tool_result.t` + Typed `Sdk_*` Blocker Class (Reverse-Engineered Initi... | Draft | - |
 | 0063 | Telemetry Feedback Loop & Cooperative Scheduling Safety | Draft | - |
 | 0064 | Capacity Probe Adapter (`RFC-0064-capacity-probe-adapter.md`)<br>Descriptor-Owned Tool Surface (`RFC-0064-two-surface-tool-alias.md`) | Active<br>Superseded | - |
@@ -129,7 +129,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0104 | Withdraw Task-to-repository authorization | Withdrawn | - |
 | 0105 | OpenAI-compat boundary: Agent_sdk.Error.t → HTTP status + typed envelope | Implemented | - |
 | 0106 | Cancel-safe try-with discipline (Eio.Cancel.Cancelled propagation) | Active | - |
-| 0107 | Phase C.0 — `Eio_context.get_switch_opt` global access audit (`RFC-0107-eio-context-switch-audit.md`)<br>Outbound HTTP stack consolidation — pooled keep-alive, scoped Switch, Docker ... (`RFC-0107-outbound-http-stack-consolidation.md`) | Evidence<br>Active | RFC-0107-phase-d-pool-design.md |
+| 0107 | Outbound HTTP stack consolidation — pooled keep-alive, scoped Switch, Docker ... | Active | Phase C.0 — `Eio_context.get_switch_opt` global access audit (`RFC-0107-eio-context-switch-audit.md`, Evidence)<br>Phase D — Connection pool design (interface-first) (`RFC-0107-phase-d-pool-design.md`, Active) |
 | 0108 | Atomic JSONL Append (in-process) (`RFC-0108-atomic-jsonl-append.md`)<br>PR / Worktree Operation Safety Gates (`RFC-0108-pr-worktree-operation-safety-gates.md`) | Active<br>Implemented | - |
 | 0109 | CDAL x Goal Integration Contract | Withdrawn | - |
 | 0110 | Tool-pair atomicity at write boundary — sunset compaction repair fabrication | Superseded | - |
@@ -156,7 +156,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0133 | Keeper Phase Casing SSOT Consolidation | Implemented | - |
 | 0134 | Persistence read-drop root fix (recovery story for RFC-0044) | Active | - |
 | 0135 | Supersede dashboard-derived Keeper disposition | Superseded | - |
-| 0136 | Keeper Unified Turn — Stage Decomposition of run_keeper_cycle | Implemented | RFC-0136-phase-4-retry-loop.md |
+| 0136 | Keeper Unified Turn — Stage Decomposition of run_keeper_cycle | Implemented | Keeper Unified Turn — Phase 4: Retry Loop Body Decomposition (`RFC-0136-phase-4-retry-loop.md`, Active) |
 | 0137 | Host FD pressure observation — retired Keeper-pause proposal | Retired | - |
 | 0138 | Dashboard Snapshot Lock-Free Immutable Architecture | Implemented | - |
 | 0139 | Withdraw parallel agent and judge status hierarchies | Withdrawn | - |
@@ -249,7 +249,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0243 | Memory OS confidence mutability via write-side fact upsert | Draft | - |
 | 0244 | Memory OS recall: turn-seeded deterministic lexical retrieval, with provenanc... | Superseded | - |
 | 0245 | Exempt goalless tasks from the per-goal WIP claim cap | Withdrawn | - |
-| 0247 | Memory OS as a brain: typed associative graph, spreading-activation recall, s... (`RFC-0247-memory-os-associative-graph-forgetting-brain.md`)<br>Memory OS purge + LLM-judgment rebuild — implementation plan (phase of RFC-0247) (`RFC-0247-purge-implementation-plan.md`) | Draft<br>Draft | - |
+| 0247 | Memory OS as a brain: typed associative graph, spreading-activation recall, s... | Draft | Memory OS purge + LLM-judgment rebuild — implementation plan (phase of RFC-0247) (`RFC-0247-purge-implementation-plan.md`, Draft) |
 | 0248 | Board context without local authority classification | Draft | - |
 | 0249 | Remove the dead `stale_factor` field (execute RFC-0239/0243/0244/0247) | Draft | - |
 | 0251 | Memory OS: record well, do not value — remove the scoring layer | Draft | - |
@@ -344,6 +344,23 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0353 | 실패 분류가 모듈 경계에서 소실되는 결함 (결정 요청) | Draft | - |
 | 0356 | Approval owns the effect (replay the approved payload, do not require byte-id... | Draft | - |
 | 0357 | Scheduled-autonomous 턴은 heartbeat가 아니라 typed stimulus의 변화로 admit한다 | Draft | - |
+| RFC-0034d-stale-agent-sync | d — release_stale_claims agent-side sync | Draft | - |
+| RFC-async-log-sink-durable-append-offload | Offload the structured-log durable append off the emitting fiber | Draft | - |
+| RFC-checkpoint-pinned-root-containment | Immutable boot-pinned root capability for checkpoint containment | Draft | - |
+| RFC-compaction-deterministic-floor | Compaction must never deadlock: a deterministic structural floor, typed outco... | Draft | - |
+| RFC-connector-ambient-attention-wake | Connector ambient attention wake: drive an idle keeper turn from external-att... | Draft | - |
+| RFC-connector-deferred-reply-via-chat-queue | Durable Keeper chat receipts and connector delivery settlement | Active | - |
+| RFC-eliminate-substring-destructive-classifier | Withdrawn command-policy classification experiment | Withdrawn | - |
+| RFC-keeper-conversation-hitl-flow | # RFC: Keeper conversation and non-blocking HITL | Draft | - |
+| RFC-keeper-media-degrade-floor | # RFC: Withdraw silent media degradation | Draft | - |
+| RFC-keeper-memory-bank-write-reduction | Keeper memory-bank near-dup accumulation — write reduction, not write-boundar... | Superseded | - |
+| RFC-keeper-memory-consolidation | Keeper durable memory consolidation — deprecate memory_bank into Memory OS | Implemented | - |
+| RFC-keeper-memory-panel-real-data | Keeper memory panel: real-data backing (no fabrication, no score resurrection) | Superseded | - |
+| RFC-keeper-runtime-context-observation-phase0 | Keeper runtime context observation Phase 0 | Draft | - |
+| RFC-keeper-vision-delegation-tool | Vision-as-a-tool delegation (decouple multimodal input from conversation runt... | Draft | - |
+| RFC-memory-os-bounded-context-and-librarian-curator | # RFC: Memory OS 2.0 — bounded working set 전송 계약과 librarian curator 계약 | Draft | - |
+| RFC-runtime-note-field-and-dashboard-surfacing | Per-runtime note field & dashboard surfacing | Draft | - |
+| RFC-typed-egress-resource-capability | Withdraw product-specific egress effect classification | Withdrawn | - |
 
 ### 신규 RFC
 

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -137,6 +137,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0112 | Typed JSON parse boundary — eliminate silent-drop fallback across read sites | Implemented | - |
 | 0113 | Withdraw KeeperReactionLiveness runtime hierarchy | Withdrawn | - |
 | 0114 | Withdraw compact-retry and lifecycle guard model | Withdrawn | - |
+| 0115 | KTC turn_phase spec ← runtime parity — backfill spec for Turn_routing / Turn_... | Implemented | - |
 | 0116 | Withdraw fallback-count cap | Withdrawn | - |
 | 0117 | Withdraw runtime health cooldown hierarchy | Withdrawn | - |
 | 0118 | Withdraw terminal runtime projection contract | Withdrawn | - |
@@ -152,6 +153,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0129 | Runtime attempt idle-cap: kill the reserve_fraction band-aid | Implemented | - |
 | 0131 | Withdraw policy-bearing shell command facade | Withdrawn | - |
 | 0132 | Redaction SSOT — `runtime` boundary-label private type | Implemented | - |
+| 0133 | Keeper Phase Casing SSOT Consolidation | Implemented | - |
 | 0134 | Persistence read-drop root fix (recovery story for RFC-0044) | Active | - |
 | 0135 | Supersede dashboard-derived Keeper disposition | Superseded | - |
 | 0136 | Keeper Unified Turn — Stage Decomposition of run_keeper_cycle | Implemented | RFC-0136-phase-4-retry-loop.md |

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -42,312 +42,315 @@ implementation_prs: []             # [14181, 14550] 형식 (정수). RFC body �
 
 ## RFC 목록
 
-데이터 수집 시점: 2026-08-02. `Last activity` 는 해당 RFC 디렉토리 파일의 마지막 git commit. Status 컬럼은 명시적 closeout commit 이 있는 RFC 만 Implemented 로 표기한다 — RFC body 머지는 spec implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
+이 표는 RFC 파일의 frontmatter와 제목에서 결정적으로 생성한다. 병합 방식에 따라
+바뀌는 commit SHA나 날짜는 저장하지 않는다. Status 컬럼은 명시적 closeout
+commit 이 있는 RFC 만 Implemented 로 표기한다 — RFC body 머지는 spec
+implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 
-| # | Title | Status | Last activity | Sub-docs |
-|---|---|---|---|---|
-| 0000 | MASC × OAS Consolidated Master Design (SSOT) | Draft | e967de6553 2026-08-02 | - |
-| 0001 | Withdraw heuristic uncertainty governance | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0002 | Keeper 11-State Machine + Det/NonDet Boundary Formalization | reference | 7b62a87d44 2026-07-13 | - |
-| 0003 | Withdraw composite lifecycle projection hierarchy | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0004 | OCaml ↔ TypeScript shared contract — SSE + gRPC-web | Active | 0ee897eca1 2026-06-03 | - |
-| 0005 | Withdraw the typed command-policy substrate | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0006 | Keeper Surface And Sandbox | Draft | 6ce9619607 2026-05-27 | - |
-| 0008 | Keeper Credential Provider | Draft | 478c943e39 2026-06-02 | - |
-| 0009 | Runtime Trust Phase 2: Operator Recommendations + Opt-in Persist | Draft | 70ac2a7930 2026-06-03 | - |
-| 0010 | ocamlformat config reconciliation | Implemented | a7b9f1f8d0 2026-05-31 | - |
-| 0012 | Mid-Turn Progress Probe | Draft | 00a9aa0dd1 2026-06-06 | - |
-| 0019 | Keeper Credential Unification | Draft | 478c943e39 2026-06-02 | - |
-| 0022 | Withdraw MASC attempt budgets and provider demotion | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0024 | Ollama Runtime Integration + KV Cache Optimization | Draft | 0ee897eca1 2026-06-03 | - |
-| 0025 | Tiered Small-Model Runtime (4B → 9B → 70B+) | Draft | 70ac2a7930 2026-06-03 | - |
-| 0027 | Retired tension and meta-cognition draft | Superseded | 434a7f5a76 2026-07-10 | - |
-| 0029 | Dashboard Fiber-Batched Aggregation | Active | a7b9f1f8d0 2026-05-31 | - |
-| 0032 | Environment Knob Unification | Draft | 609e220e00 2026-08-02 | - |
-| 0034 | d — release_stale_claims agent-side sync | Draft | 00a9aa0dd1 2026-06-06 | - |
-| 0035 | Cognitive IDE Master Plan Integration | Draft | 0ee897eca1 2026-06-03 | - |
-| 0036 | oas Cognitive Mapping (companion to RFC-0035) | Draft | 0ee897eca1 2026-06-03 | - |
-| 0037 | Local-first Keeper Enablement: Harness/User Boundary | Draft | 0ee897eca1 2026-06-03 | - |
-| 0038 | Withdraw MASC capability-routing plan | Withdrawn | 7b62a87d44 2026-07-13 | RFC-0038-phase-2-keeper-identity-canonical.md |
-| 0041 | Withdraw runtime group/item hierarchy | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0042 | Withdraw Keeper terminal-reason hierarchy | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0043 | Distribute legacy metrics backend metric ownership to domain modules | Active | d498dd810a 2026-06-06 | - |
-| 0044 | Typed persistence read-drop reason + Result-based reads | Active | 00a9aa0dd1 2026-06-06 | - |
-| 0045 | SDK turn boundary alignment with MASC keeper FSM | Draft | 00a9aa0dd1 2026-06-06 | - |
-| 0046 | Keeper Detail FSM Hub as SSOT | Active | a7b9f1f8d0 2026-05-31 | - |
-| 0047 | `oas_*` adapter family decomposition (consumer-only OAS boundary) | Draft | 00a9aa0dd1 2026-06-06 | - |
-| 0049 | Dashboard Surface Telemetry Foundation | Draft | d498dd810a 2026-06-06 | - |
-| 0050 | Dashboard Component Ownership Decomposition | Active | 00a9aa0dd1 2026-06-06 | - |
-| 0051 | run_named closure decomposition | Active | 9d7d80804a 2026-06-06 | - |
-| 0052 | Boot-time Required Invariants (typed) | Implemented | 00a9aa0dd1 2026-06-06 | - |
-| 0053 | Tool Dispatch Session-Local Handles | Implemented | 0ee897eca1 2026-06-03 | - |
-| 0054 | Withdraw code generation for command-policy GADTs | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0056 | Incremental Sub-Library Extraction from Flat masc Library | Active | 00a9aa0dd1 2026-06-06 | - |
-| 0057 | Tool Descriptor Codegen — `[@@deriving tool]` via Build-Time Generation | Draft | 7b62a87d44 2026-07-13 | - |
-| 0058 | Withdraw terminal capability hierarchy | Withdrawn | 7b62a87d44 2026-07-13 | RFC-0058-phase-5-erase-provider-variant.md |
-| 0062 | Typed `Tool_result.t` + Typed `Sdk_*` Blocker Class (Reverse-Engineered Initi... | Draft | 00a9aa0dd1 2026-06-06 | - |
-| 0063 | Telemetry Feedback Loop & Cooperative Scheduling Safety | Draft | 00a9aa0dd1 2026-06-06 | - |
-| 0064 | Descriptor-Owned Tool Surface | Superseded | 6ce9619607 2026-05-27 | - |
-| 0065 | Withdraw policy-bearing tool-selection model | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0067 | Goal-Scope Observation→Claim Atomicity | Draft | 00a9aa0dd1 2026-06-06 | - |
-| 0068 | Withdraw operator disposition hierarchy | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0069 | Awareness Channel Split | Active | 361bf75eb5 2026-07-17 | - |
-| 0070 | Keeper Sandbox Runtime — Pure/Edge Separation | Active | 7b62a87d44 2026-07-13 | - |
-| 0071 | Exhaustive Match Sweep Codemod — Eliminate N-of-M `_ -> false/None` Anti-Pattern | Implemented | a7b9f1f8d0 2026-05-31 | - |
-| 0072 | Type-encoded keeper sub-FSM transitions (runtime + turn_phase) | Implemented | a7b9f1f8d0 2026-05-31 | - |
-| 0073 | Withdraw pre-turn tool readiness filtering | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0074 | Sandbox Credential Auto-provision | Retired | 478c943e39 2026-06-02 | - |
-| 0075 | Keeper Tools Smoke — Exhaustive Dispatch Coverage Regression Gate | Implemented | 0ee897eca1 2026-06-03 | - |
-| 0076 | Tool Readiness Notification Channel | Retired | 478c943e39 2026-06-02 | - |
-| 0077 | Write-side silent failure — typed propagation | Implemented | 00a9aa0dd1 2026-06-06 | - |
-| 0079 | Log row typed encoder + silent-drop removal | Implemented | a7296801a7 2026-06-01 | - |
-| 0080 | Registered descriptors are the tool-surface SSOT | Implemented | 7b62a87d44 2026-07-13 | - |
-| 0081 | OAS Telemetry Envelope Context & Keeper/Goal Pivot Timeline | Implemented | 1f2a526520 2026-06-09 | - |
-| 0082 | Withdraw automatic blocker escalation and recovery | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0083 | Dashboard system-actor convention typed unification | Implemented | dac9946522 2026-05-23 | - |
-| 0084 | Tool dispatch handler and observation unification | Implemented | 7b62a87d44 2026-07-13 | - |
-| 0086 | Keeper namespace bulk promotion to sub-library | Implemented | 1fe1daf0e5 2026-07-16 | - |
-| 0087 | Tool Dispatch Path Unification + Legacy Purge | Implemented | 00a9aa0dd1 2026-06-06 | - |
-| 0088 | Counter-as-Fix → Result Propagation (umbrella scoping) | Active | 00a9aa0dd1 2026-06-06 | - |
-| 0089 | String Classifier to Typed Variant — direct replacement, no lint | Implemented | 7b62a87d44 2026-07-13 | - |
-| 0090 | Write-side success-model attribution — finish N-of-M migration | Implemented | d498dd810a 2026-06-06 | - |
-| 0091 | Execute tool: cmd string → typed Argv schema (lexer/validator 박멸) | Implemented | 23dcea3303 2026-06-04 | - |
-| 0093 | Board persistence identity and atomic snapshot | Implemented | 7b62a87d44 2026-07-13 | - |
-| 0094 | Compact cooldown semantics split decision record | Superseded | 434a7f5a76 2026-07-10 | - |
-| 0095 | Provider-D-compat provider streaming wire-up | Implemented | d498dd810a 2026-06-06 | - |
-| 0096 | Keeper Turn Contract — multi-turn reasoning + runtime SPOF root-fix | Withdrawn | 6c5095e528 2026-06-03 | - |
-| 0097 | Keeper sandbox container reuse (long-running sandbox per keeper) | Active | 7b62a87d44 2026-07-13 | - |
-| 0098 | Typed JSON-RPC error envelope & production-code silent-failure lint | Implemented | 434a7f5a76 2026-07-10 | - |
-| 0099 | Session lifecycle — typed events, explicit eviction, resume backpressure | Active | 63c38bf628 2026-07-17 | - |
-| 0100 | Streamable HTTP as default transport (MCP 2025-03-26) | Active | 0ee897eca1 2026-06-03 | - |
-| 0101 | FD accountant — observation across process resource classes | Active | 7b62a87d44 2026-07-13 | - |
-| 0102 | Pre-turn runtime availability gate — reuse, not new surface | Superseded | df319a9896 2026-07-11 | - |
-| 0103 | Log retention opt-in + JSONL volume root reduction | Draft | a7b9f1f8d0 2026-05-31 | - |
-| 0104 | Withdraw Task-to-repository authorization | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0105 | OpenAI-compat boundary: Agent_sdk.Error.t → HTTP status + typed envelope | Implemented | 0ee897eca1 2026-06-03 | - |
-| 0106 | Cancel-safe try-with discipline (Eio.Cancel.Cancelled propagation) | Active | 0ee897eca1 2026-06-03 | - |
-| 0107 | Outbound HTTP stack consolidation — pooled keep-alive, scoped Switch, Docker ... | Active | 7b62a87d44 2026-07-13 | - |
-| 0108 | PR / Worktree Operation Safety Gates | Implemented | 0ee897eca1 2026-06-03 | - |
-| 0109 | CDAL x Goal Integration Contract | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0110 | Tool-pair atomicity at write boundary — sunset compaction repair fabrication | Superseded | 885f6e03cc 2026-07-28 | - |
-| 0111 | Goal mint atomicity — auto-goal uniqueness invariant at write boundary | Implemented | 434a7f5a76 2026-07-10 | - |
-| 0112 | Typed JSON parse boundary — eliminate silent-drop fallback across read sites | Implemented | a7b9f1f8d0 2026-05-31 | - |
-| 0113 | Withdraw KeeperReactionLiveness runtime hierarchy | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0114 | Withdraw compact-retry and lifecycle guard model | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0116 | Withdraw fallback-count cap | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0117 | Withdraw runtime health cooldown hierarchy | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0118 | Withdraw terminal runtime projection contract | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0119 | Withdraw lifecycle projection mapping hierarchy | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0120 | Cross-spec set-name divergence — 3-class classification framework (STALE / DE... | Implemented | 7b62a87d44 2026-07-13 | - |
-| 0121 | Config-dir resolution — single active root, no implicit fallback | Active | a7296801a7 2026-06-01 | - |
-| 0122 | Keeper disk pressure — process-local fleet failure mode beyond FD | Implemented | 7abc844904 2026-06-01 | - |
-| 0123 | Briefing last_event fabrication — option-typed write boundary | Implemented | 00a9aa0dd1 2026-06-06 | - |
-| 0124 | Withdraw fleet resource admission denial | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0125 | Withdraw Keeper watchdog and force-release discipline | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0126 | Silent fallback discipline (typed split for option/result wildcard arms) | Implemented | a48d59f034 2026-07-24 | - |
-| 0127 | Runtime Fast-Fail (Provider Health Phase 3) + Fiber Termination Provenance | Active | 00a9aa0dd1 2026-06-06 | - |
-| 0129 | Runtime attempt idle-cap: kill the reserve_fraction band-aid | Implemented | a41c953ae8 2026-06-06 | - |
-| 0131 | Withdraw policy-bearing shell command facade | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0132 | Redaction SSOT — `runtime` boundary-label private type | Implemented | 5cbe0f454e 2026-07-06 | - |
-| 0134 | Persistence read-drop root fix (recovery story for RFC-0044) | Active | 7b62a87d44 2026-07-13 | - |
-| 0135 | Supersede dashboard-derived Keeper disposition | Superseded | 7b62a87d44 2026-07-13 | - |
-| 0136 | Keeper Unified Turn — Stage Decomposition of run_keeper_cycle | Implemented | 0418bdc838 2026-06-15 | - |
-| 0137 | Host FD pressure observation — retired Keeper-pause proposal | Retired | 7b62a87d44 2026-07-13 | - |
-| 0138 | Dashboard Snapshot Lock-Free Immutable Architecture | Implemented | fdbf1c08d6 2026-07-19 | - |
-| 0139 | Withdraw parallel agent and judge status hierarchies | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0140 | Dashboard wire codec for source observations | Implemented | 7b62a87d44 2026-07-13 | - |
-| 0141 | TOML Field Resolution Typed Variant for repo_manager | Implemented | 478c943e39 2026-06-02 | - |
-| 0142 | runtime_error_classify Decomposition + Typed JSON-Extraction Variant | Active | 0ee897eca1 2026-06-03 | - |
-| 0143 | keeper_runtime_profile Typed Catalog Query Result | Active | d943a4f3b8 2026-06-05 | - |
-| 0144 | Withdraw recording-error dedup and metric sunset gates | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0145 | Permissive-Silent-Fallback Elimination | Active | 00a9aa0dd1 2026-06-06 | - |
-| 0147 | Withdraw decomposition around deleted Keeper policy stages | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0148 | Typed `tool_error` Variant for LLM-Facing Tool Failure Surface | Implemented | 799c1a7331 2026-06-05 | - |
-| 0149 | Audit-Driven Telemetry-as-Fix Sunset | Implemented | 00a9aa0dd1 2026-06-06 | - |
-| 0150 | Keeper Attention Signal — backend 단일 typed wire envelope | Implemented | 434a7f5a76 2026-07-10 | - |
-| 0151 | 4-metric monotone-decrease ratchet for code-smell metrics | Withdrawn | 9d7d80804a 2026-06-06 | - |
-| 0153 | Withdraw runtime tier admission | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0154 | System_error_class typed SSOT — close substring-classifier loop across backen... | Implemented | 0ee897eca1 2026-06-03 | - |
-| 0155 | Withdraw centralized operational policy log taxonomy | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0156 | Withdraw MASC turn-budget timeout policy | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0157 | Withdraw MASC pre-dispatch provider capability filtering | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0158 | Withdraw MASC retry-admission denial | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0159 | Reason_internal_error typed split — close string-classifier catch-all | Draft | 00a9aa0dd1 2026-06-06 | - |
-| 0160 | Withdrawn Shell IR decision-substrate plan | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0161 | Tool Error Hint Symmetry Enforcement | Draft | da3eb7d5c3 2026-05-26 | - |
-| 0162 | JSONL Write-Path FD Pressure Root-Fix | Draft | 0ee897eca1 2026-06-03 | - |
-| 0163 | Tier-group capability profile route canonicalization — typed dedup and bypass... | Withdrawn | 00a9aa0dd1 2026-06-06 | - |
-| 0164 | Withdraw voice exceptions to provider capability filtering | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0167 | Withdrawn product-specific runtime authorization cleanup | Draft | 7b62a87d44 2026-07-13 | - |
-| 0168 | Dashboard upstream-LLM-provider color palette purge | Draft | 685aa5fbb7 2026-06-12 | - |
-| 0169 | Dashboard common/* MCP-client attribution header purge | Draft | 0ee897eca1 2026-06-03 | - |
-| 0170 | Dashboard provider-b palette closure (RFC-0168 N-of-M follow-up) | Draft | 05c74824a2 2026-06-12 | - |
-| 0171 | Design-canvas + ui_kits mock data vendor purge | Draft | 05c74824a2 2026-06-12 | - |
-| 0172 | Big-bang vendor purge across docs, audits, RFCs, design-system, tests | Draft | 6a489efe99 2026-06-16 | - |
-| 0173 | OCaml lib/bin/test vendor purge (identifier + string literal) | Draft | 05c74824a2 2026-06-12 | - |
-| 0174 | Dashboard substring classifier to typed — TypeScript | Draft | e7924e8cdf 2026-05-24 | - |
-| 0175 | Godfile decomposition Wave D — keeper core 5-file split | Draft | 71c70f2806 2026-07-18 | - |
-| 0176 | OAS vendor-purge migration — consume agent_sdk 0.198.0 | Implemented | 0ee897eca1 2026-06-03 | - |
-| 0177 | Phonebook internal vendor-coupled enum purge | Draft | 05c74824a2 2026-06-12 | - |
-| 0178 | Types Sub-library Extraction with `_intf.ml` mli-only Surface (typed-SSOT) | Draft | 0ee897eca1 2026-06-03 | - |
-| 0179 | ToolDescriptor Ecosystem Coverage Extension to Workspace Tools | Draft | d45f4b8b02 2026-06-03 | - |
-| 0180 | 24h Runtime ERROR 7-Pattern Sweep Roadmap | Draft | 0ee897eca1 2026-06-03 | - |
-| 0181 | Withdraw MASC capability-intent routing | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0182 | masc_* Workspace Tool Descriptor Projection + Tool_spec SSOT Consolidation | Draft | 7b62a87d44 2026-07-13 | - |
-| 0184 | Runtime phonebook typed roundtrip for protocol/flavor/provider identifiers | Draft (Deferred) | 05c74824a2 2026-06-12 | - |
-| 0189 | Typed Tool_result.result variant — eliminating boolean blindness in tool disp... | Draft | 799c1a7331 2026-06-05 | - |
-| 0190 | Descriptor as Visibility/Metadata SSOT — Surface Projection from descriptor.p... | Draft | e6b16cb275 2026-06-05 | - |
-| 0191 | Withdraw descriptor authorization policy | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0192 | Runtime deadline propagation — retired admission-wait proposal | Retired | 7b62a87d44 2026-07-13 | - |
-| 0194 | Withdraw tool semantics as an authorization SSOT | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0197 | Runtime Attempt Watchdog — Per-Candidate Wrap + Shared Deadline | Draft | 44966887a6 2026-07-18 | - |
-| 0198 | Execute Typed Redirection (Shell IR Syntax Leakage Closure) | Draft | 214eec8f6c 2026-07-14 | - |
-| 0199 | Withdraw deterministic task-completion auto approval | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0200 | Time constants 를 leaf library 로 분리 | Draft | 0ee897eca1 2026-06-03 | - |
-| 0201 | Activity Events Wait-Free Snapshot | Draft | fdbf1c08d6 2026-07-19 | - |
-| 0203 | In-process Discord connector | Implemented (Phase 3 cutover landed 2026-05-29) | 8a8a90a2f0 2026-07-18 | - |
-| 0204 | Dashboard Read Serving Isolation from Fleet Compute | Draft | 7b62a87d44 2026-07-13 | - |
-| 0205 | Keeper Module Consolidation — Eliminate Facade Anti-Pattern | Draft | ec50013248 2026-07-19 | - |
-| 0206 | Runtime 개념 — runtime→Runtime 재탄생 | Draft | c7757f9721 2026-07-07 | - |
-| 0207 | Per-keeper LLM runtime routing | Draft | 70ac2a7930 2026-06-03 | - |
-| 0208 | Withdrawn compositional Shell IR policy algebra | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0210 | Keeper Playground Repo Currency (fetch + fast-forward, work-preserving) | Draft | 679471d525 2026-06-04 | - |
-| 0211 | Persona ⊥ {model, runtime}, opaque runtime id, runtime.toml keeper-assignment... | Draft | bf66513f1b 2026-06-02 | - |
-| 0212 | Withdraw Keeper exposure policy axis | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0213 | Keeper sandbox/playground isolation model (fix sandbox_repo_not_ready + macOS... | Draft | 7b62a87d44 2026-07-13 | - |
-| 0214 | OTel GenAI Semantic Convention Migration | Draft | b8c26aa41a 2026-06-06 | - |
-| 0215 | Keeper sub-library extraction campaign — sequence and per-PR gates | Draft | 0ed4982f58 2026-07-15 | - |
-| 0216 | Per-Keeper Decline Memory (orphan-task churn root fix) | Draft | f765863658 2026-06-23 | - |
-| 0217 | Telemetry Backend Otel 단일화 (Retired Backend Purge) | Draft | d498dd810a 2026-06-06 | - |
-| 0218 | Keeper tool-surface coherence + web-tooling roadmap — phases and per-phase gates | Draft | ec5d329844 2026-06-06 | - |
-| 0219 | Remove Sandbox Repo Patrol Gates | Draft | 7e800d1231 2026-06-06 | - |
-| 0220 | Withdraw cross-Keeper verification scheduling | Withdrawn | e967de6553 2026-08-02 | - |
-| 0221 | Atomic verification submission — task_status as the sole outcome authority | Implemented (steps 1-3 merged #20613/#20617; steps 4-5 measured then dropped, §3.3/§3.4) | e967de6553 2026-08-02 | - |
-| 0222 | Withdraw harness-owned Task completion | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0223 | Typed connector surfaces: presence in world prompt, pull-based lane context, ... | Draft | c8eb1078d2 2026-06-10 | - |
-| 0224 | Withdraw the mandatory structured completion checklist | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0225 | Per-keeper turn single-flight admission | Draft | 534e9549ed 2026-06-10 | - |
-| 0226 | Ambient lane recording: record-vs-trigger decouple for connector surfaces | Draft | 759814d603 2026-06-11 | - |
-| 0228 | Paged lane pull + fact-retention harness: digest without a summarizer | Draft | 18706b0500 2026-06-11 | - |
-| 0229 | Keeper person notes: deliberate per-speaker memory beyond the log window | Draft | 7b62a87d44 2026-07-13 | - |
-| 0230 | Keeper mention/scope reactivity: cursor-free salience to complement pull-base... | Draft | c8790d6aaf 2026-06-11 | - |
-| 0232 | Typed lane event model: parse at the write boundary, never re-derive by strin... | Draft | fed380a1dc 2026-07-30 | - |
-| 0233 | Typed turn observability: TurnRecord prompt-block provenance + canonical tool... | Draft | 434a7f5a76 2026-07-10 | - |
-| 0234 | Withdraw schedule-specific approval hierarchy | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0235 | Voice output transport: browser-addressed audio delivery with device-routed p... | Draft | 29e585aec9 2026-06-14 | - |
-| 0236 | Voice input transport: browser-captured speech-to-text for the dashboard comp... | Draft | 12435886d0 2026-06-14 | - |
-| 0237 | Eliminate the write_meta ~force escape hatch (route snapshot writes through C... | Draft | 434a7f5a76 2026-07-10 | - |
-| 0239 | Supersede no-progress pause and semantic debounce guards | Superseded | 7b62a87d44 2026-07-13 | - |
-| 0240 | Tool-pair invariant enforced at write-time (eliminate repair-on-read) | Draft | 885f6e03cc 2026-07-28 | - |
-| 0241 | external-attention store lifecycle: read-side bound, retention, and typed tai... | Retired | 8fdcab22ee 2026-07-29 | - |
-| 0242 | Retired continuity prose-filter draft | Superseded | 434a7f5a76 2026-07-10 | - |
-| 0243 | Memory OS confidence mutability via write-side fact upsert | Draft | d1a7fa9756 2026-07-24 | - |
-| 0244 | Memory OS recall: turn-seeded deterministic lexical retrieval, with provenanc... | Superseded | a8683ea2cc 2026-07-30 | - |
-| 0245 | Exempt goalless tasks from the per-goal WIP claim cap | Withdrawn | 59c024c890 2026-07-04 | - |
-| 0247 | Memory OS purge + LLM-judgment rebuild — implementation plan (phase of RFC-0247) | Draft | 1910149d9e 2026-07-30 | - |
-| 0248 | Board context without local authority classification | Draft | 7b62a87d44 2026-07-13 | - |
-| 0249 | Remove the dead `stale_factor` field (execute RFC-0239/0243/0244/0247) | Draft | 6ac33d752e 2026-06-16 | - |
-| 0251 | Memory OS: record well, do not value — remove the scoring layer | Draft | 36bebccdfe 2026-06-17 | - |
-| 0252 | Fusion: 패널+심판(panel+judge) 심의 루프 (MASC 내장) | Draft | 1d15b76607 2026-07-27 | - |
-| 0253 | Dashboard keeper-v2 surfaces: canonical spacing/radius token scale + off-scal... | Draft | ae523ba6d1 2026-06-17 | - |
-| 0254 | Shell IR Approval Gate — Autonomous Production Policy | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0255 | Withdraw inferred argv path policy | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0256 | Migrate hand-rolled Mutex lock/protect/unlock to Mutex.protect | Draft | 727a060579 2026-07-16 | - |
-| 0257 | Per-Keeper memory execution lane | Draft | e530c44aa6 2026-07-26 | - |
-| 0259 | Memory OS — Volatile Claim Grounding, Retraction & Decay | Draft | a8683ea2cc 2026-07-30 | - |
-| 0260 | Withdraw MASC provider-health gate | Draft | 7b62a87d44 2026-07-13 | - |
-| 0261 | gRPC LSP failed-initialize FD/process teardown | Draft | f126d7751e 2026-06-19 | - |
-| 0262 | Withdraw hierarchical Task-completion authority | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0263 | Withdraw actor-priority turn preemption | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0264 | Memory OS recall outcome-anchored eval harness | Draft | a616cd9947 2026-06-19 | - |
-| 0265 | Withdraw MASC modality capability rerouting | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0266 | Fusion async-completion wake + in-progress 가시성 | Draft | 217be11d24 2026-06-20 | - |
-| 0267 | Make task↔goal links visible and explicitly assignable | Draft | 6c9029bcbf 2026-06-25 | - |
-| 0269 | Process Critic Loop for Keeper Work Traces | Draft | fae5c47f35 2026-06-20 | - |
-| 0270 | CI Gate merge guard: block merges on a non-success CI Gate and trip on red main | Draft | 61cb9cfe8f 2026-06-20 | - |
-| 0271 | Withdraw progress-based turn rejection and pause | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0272 | Memory OS — Episode Log Retention (bounded append for events.jsonl / episodes) | Draft | f09d3015ed 2026-06-21 | - |
-| 0273 | Withdraw policy-bearing Keeper configuration tiers | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0274 | Workspace base_path SSOT — retire env runtime read, thread Workspace.config | Draft | a23d1181e4 2026-07-30 | - |
-| 0275 | Retired cognitive-triple removal record | Implemented | 434a7f5a76 2026-07-10 | - |
-| 0276 | Remove Keeper social-model self-report protocol | Implemented | 434a7f5a76 2026-07-10 | - |
-| 0277 | Fusion: 이종 패널 그룹(heterogeneous panel groups) + 발동 예산 제거 | Draft | 27c5da70fc 2026-07-16 | - |
-| 0278 | Fusion: 같은 model을 다른 prompt로 (same-model panels via panel labels) | Draft | 9052e25e02 2026-06-22 | - |
-| 0279 | Withdraw completion-contract result taxonomy | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0280 | Fusion: validated preset type (Parse, don't validate) | Draft | 60cca2c35e 2026-06-22 | - |
-| 0281 | WebSocket transport SSOT — separate upgrade-attachment from session-protocol,... | Draft | 7eaba002d2 2026-06-22 | - |
-| 0282 | Reduce Keeper persona to ordinary instructions | Implemented | 434a7f5a76 2026-07-10 | - |
-| 0283 | Fusion: judge-of-judges 위상 (flat/staged reducer) | Draft | ba354b7bb0 2026-07-17 | - |
-| 0284 | Supersede command-semantics guidance guards | Superseded | 7b62a87d44 2026-07-13 | - |
-| 0285 | Memory OS — Self-Observation Claim Volatility (closing RFC-0259's internal-st... | Draft | 8701b4a9e4 2026-07-30 | - |
-| 0286 | Superseded exec and Keeper boundary diagnosis | Superseded | 7b62a87d44 2026-07-13 | - |
-| 0287 | ws-direct — a single masc-owned WebSocket stack for server and client | Draft | 78f1c2fcf4 2026-06-23 | - |
-| 0288 | Remove per-Keeper goal-horizon fields | Implemented | 434a7f5a76 2026-07-10 | - |
-| 0289 | Extract progress-classification into its own library for a single substantive... | Draft | 88996d4d8b 2026-06-24 | - |
-| 0290 | Generic keeper background-work tool (spawn → wake-on-completion) | Draft | ba354b7bb0 2026-07-17 | - |
-| 0291 | Closed SSE event-type sum + typed broadcast — RFC-0004 Phase A0 Wave 2 increment | Draft | 9144909e70 2026-07-21 | - |
-| 0292 | Complete lib/auth de-duplication — remove drifted Masc.Auth* test copies | Draft | b568e023bf 2026-07-16 | - |
-| 0293 | Withdraw policy-bearing execution endpoints | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0294 | Remove workspace Goal horizon | Implemented | 434a7f5a76 2026-07-10 | - |
-| 0295 | Withdraw derived fleet runtime bands | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0296 | CI skip-gate main-push safety-net: always run Build and Test on non-PR events | Draft | bd0df6dad0 2026-06-28 | - |
-| 0298 | fusion judge pool — judge 모델을 preset에서 분리 | Draft | 5bdaa1b714 2026-06-29 | - |
-| 0299 | RFC-0299 — Typed-Boundary Sweep (string-classifier → closed-sum, dead SSOT re... | Draft | 7b62a87d44 2026-07-13 | - |
-| 0300 | RFC-0300 — Dashboard design-token scope consolidation (radius / shadow / type... | Draft | 345224b01e 2026-06-30 | - |
-| 0301 | Keeper 생성 미디어(이미지/오디오) 대시보드 노출 | Draft | fa7bd52db2 2026-07-02 | - |
-| 0302 | Keeper 메모리 파일 I/O off-main-domain 오프로드 (HOL fix) | Draft | a8683ea2cc 2026-07-30 | - |
-| 0303 | Keeper wake without progress heuristics | Draft | 3722a9d014 2026-08-02 | - |
-| 0304 | Withdraw Critical-class HITL escalation | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0305 | Withdraw global fail-closed governance policy | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0306 | Typed, comment-preserving fusion settings editor | Draft | ba354b7bb0 2026-07-17 | - |
-| 0307 | Mid-turn advisor consult for keepers — evaluation and deferral | Draft | 3e2f4b9968 2026-07-29 | - |
-| 0308 | Withdraw verifier-required Task routing | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0309 | Withdrawn product-specific capability hierarchy | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0311 | Withdraw deterministic evidence floors | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0312 | Keeper repo mappings are advisory default scope, not access caps | Accepted | c96f29136a 2026-07-07 | - |
-| 0315 | Typed wake-turn context and self-directed work lane | Active | 434a7f5a76 2026-07-10 | - |
-| 0316 | Merge gating convergence: enforce_admins=true + live Branch Protection Watchdog | Draft | 43b7c1110a 2026-07-07 | - |
-| 0317 | In-process Slack connector (Socket Mode) | In progress (PR-1/PR-2 landed; PR-3 implemented; PR-4 sidecar removal pending) | c8b5216a15 2026-07-18 | - |
-| 0318 | Replace risk-tier auto approval with request-local Auto Judge | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0319 | Replace hierarchical approval modes with Keeper Gate choices | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0320 | Keeper connector-aware continuation: carry the originating channel through wa... | Draft | 7b62a87d44 2026-07-13 | - |
-| 0321 | Withdraw unconditional static tool-block proposal | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0322 | Withdraw repository-catalog read authorization | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0323 | Withdraw mandatory cross-verifier completion | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0324 | keeper repo 경로를 filesystem 진실로 (catalog 거짓 주입 제거) | Draft | 7b62a87d44 2026-07-13 | - |
-| 0328 | Retire the combined governance and perseveration incident plan | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0329 | Keeper Execute Governance Payload Mapping | Rejected | 7b62a87d44 2026-07-13 | - |
-| 0331 | Withdraw authorization by tool effect class | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0332 | Rejected heuristic memory write dedup draft | Rejected | 434a7f5a76 2026-07-10 | - |
-| 0333 | Deterministic cost↔success frontier join for the eval harness | Draft | ae027bed8f 2026-07-09 | - |
-| 0334 | Board signals as durable Keeper input | Draft | 7b62a87d44 2026-07-13 | - |
-| 0335 | TOML as the Single Settings Source | Draft | e5e4c44f2b 2026-07-09 | - |
-| 0337 | Withdraw deterministic evidence-gate semantics | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| 0338 | Lane-per-keeper durable persistence isolation | Draft | 8033528ee3 2026-07-11 | - |
-| 0340 | Dashboard dev-token privilege reduction — demote from Admin, close the rebind... | Draft | 97387d9e7d 2026-07-11 | - |
-| 0341 | Keeper lifecycle projection SSOT | Draft | 7b62a87d44 2026-07-13 | - |
-| 0342 | Capability catalog overlay, deployment capability declarations, and boot posture | Draft | 25a1c593b5 2026-07-16 | - |
-| 0343 | Repo location SSOT (collapse dual-authority, attribute by git-remote) | Draft | f463ec7b82 2026-07-15 | - |
-| 0345 | Streaming idle-timeout fail-safe floor (#25128) | Draft | 5805c199d6 2026-07-20 | - |
-| 0346 | Gateway redelivery dedup: transcript single-authority, attention as wake-hint | Draft | f1d21b989d 2026-07-21 | - |
-| 0347 | Typed EffectIntent + capability floor at the Keeper Gate | Draft | 92c23f85a5 2026-07-21 | - |
-| 0348 | Bounded lane acquisition for durable keeper_msg writes (#25398) | Draft | dce1ab3b71 2026-07-21 | - |
-| 0349 | Restore a reachable compaction admission path | Draft | 3e2f4b9968 2026-07-29 | - |
-| 0350 | Unbounded request-fiber admission (durable queue + lifecycle-sibling worker +... | Draft | 8c6f0e9742 2026-07-24 | - |
-| 0351 | Memory-first context management and compaction sunset | Draft | 8c4dae264e 2026-07-30 | - |
-| 0352 | Legacy Goal: RFC-0000 §3.2 ↔ §3.15 자기모순 해소 (결정 요청) | Draft | 6952c01917 2026-07-21 | - |
-| 0353 | 실패 분류가 모듈 경계에서 소실되는 결함 (결정 요청) | Draft | e7885e013a 2026-07-30 | - |
-| 0356 | Approval owns the effect (replay the approved payload, do not require byte-id... | Draft | 4883853ace 2026-07-27 | - |
-| 0357 | Scheduled-autonomous 턴은 heartbeat가 아니라 typed stimulus의 변화로 admit한다 | Draft | 58e9ab2d9f 2026-08-02 | - |
-| asyn | Offload the structured-log durable append off the emitting fiber | Draft | 3ec8a423be 2026-07-21 | - |
-| chec | Immutable boot-pinned root capability for checkpoint containment | Draft | 810be9566e 2026-07-18 | - |
-| comp | Compaction must never deadlock: a deterministic structural floor, typed outco... | Draft | e7885e013a 2026-07-30 | - |
-| conn | Durable Keeper chat receipts and connector delivery settlement | Active | 9d59e83655 2026-07-14 | - |
-| elim | Withdrawn command-policy classification experiment | Withdrawn | 7b62a87d44 2026-07-13 | - |
-| keep | Vision-as-a-tool delegation (decouple multimodal input from conversation runt... | Draft | a48d59f034 2026-07-24 | - |
-| memo | # RFC: Memory OS 2.0 — bounded working set 전송 계약과 librarian curator 계약 | Draft | e85c340a5b 2026-08-01 | - |
-| runt | Per-runtime note field & dashboard surfacing | Draft | f3e073c3c9 2026-06-25 | - |
-| type | Withdraw product-specific egress effect classification | Withdrawn | 7b62a87d44 2026-07-13 | - |
+| # | Title | Status | Sub-docs |
+|---|---|---|---|
+| 0000 | MASC × OAS Consolidated Master Design (SSOT) | Draft | - |
+| 0001 | Withdraw heuristic uncertainty governance | Withdrawn | - |
+| 0002 | Keeper 11-State Machine + Det/NonDet Boundary Formalization | reference | - |
+| 0003 | Withdraw composite lifecycle projection hierarchy | Withdrawn | - |
+| 0004 | OCaml ↔ TypeScript shared contract — SSE + gRPC-web | Active | - |
+| 0005 | Withdraw the typed command-policy substrate | Withdrawn | - |
+| 0006 | Keeper Surface And Sandbox | Draft | - |
+| 0008 | Keeper Credential Provider | Draft | - |
+| 0009 | Runtime Trust Phase 2: Operator Recommendations + Opt-in Persist | Draft | - |
+| 0010 | ocamlformat config reconciliation | Implemented | - |
+| 0012 | Mid-Turn Progress Probe | Draft | - |
+| 0019 | Keeper Credential Unification | Draft | - |
+| 0022 | Withdraw MASC attempt budgets and provider demotion | Withdrawn | - |
+| 0024 | Ollama Runtime Integration + KV Cache Optimization | Draft | - |
+| 0025 | Tiered Small-Model Runtime (4B → 9B → 70B+) | Draft | - |
+| 0027 | Retired tension and meta-cognition draft | Superseded | - |
+| 0029 | Dashboard Fiber-Batched Aggregation | Active | - |
+| 0032 | Environment Knob Unification | Draft | - |
+| 0034 | d — release_stale_claims agent-side sync | Draft | - |
+| 0035 | Cognitive IDE Master Plan Integration | Draft | - |
+| 0036 | oas Cognitive Mapping (companion to RFC-0035) | Draft | - |
+| 0037 | Local-first Keeper Enablement: Harness/User Boundary | Draft | - |
+| 0038 | Withdraw MASC capability-routing plan | Withdrawn | RFC-0038-phase-2-keeper-identity-canonical.md |
+| 0041 | Withdraw runtime group/item hierarchy | Withdrawn | - |
+| 0042 | Withdraw Keeper terminal-reason hierarchy | Withdrawn | - |
+| 0043 | Distribute legacy metrics backend metric ownership to domain modules | Active | - |
+| 0044 | Typed persistence read-drop reason + Result-based reads | Active | - |
+| 0045 | SDK turn boundary alignment with MASC keeper FSM | Draft | - |
+| 0046 | Keeper Detail FSM Hub as SSOT | Active | - |
+| 0047 | `oas_*` adapter family decomposition (consumer-only OAS boundary) | Draft | - |
+| 0049 | Dashboard Surface Telemetry Foundation | Draft | - |
+| 0050 | Dashboard Component Ownership Decomposition | Active | - |
+| 0051 | run_named closure decomposition | Active | - |
+| 0052 | Boot-time Required Invariants (typed) | Implemented | - |
+| 0053 | Tool Dispatch Session-Local Handles | Implemented | - |
+| 0054 | Withdraw code generation for command-policy GADTs | Withdrawn | - |
+| 0056 | Incremental Sub-Library Extraction from Flat masc Library | Active | - |
+| 0057 | Tool Descriptor Codegen — `[@@deriving tool]` via Build-Time Generation | Draft | - |
+| 0058 | Withdraw terminal capability hierarchy | Withdrawn | RFC-0058-phase-5-erase-provider-variant.md |
+| 0062 | Typed `Tool_result.t` + Typed `Sdk_*` Blocker Class (Reverse-Engineered Initi... | Draft | - |
+| 0063 | Telemetry Feedback Loop & Cooperative Scheduling Safety | Draft | - |
+| 0064 | Descriptor-Owned Tool Surface | Superseded | - |
+| 0065 | Withdraw policy-bearing tool-selection model | Withdrawn | - |
+| 0067 | Goal-Scope Observation→Claim Atomicity | Draft | - |
+| 0068 | Withdraw operator disposition hierarchy | Withdrawn | - |
+| 0069 | Awareness Channel Split | Active | - |
+| 0070 | Keeper Sandbox Runtime — Pure/Edge Separation | Active | - |
+| 0071 | Exhaustive Match Sweep Codemod — Eliminate N-of-M `_ -> false/None` Anti-Pattern | Implemented | - |
+| 0072 | Type-encoded keeper sub-FSM transitions (runtime + turn_phase) | Implemented | - |
+| 0073 | Withdraw pre-turn tool readiness filtering | Withdrawn | - |
+| 0074 | Sandbox Credential Auto-provision | Retired | - |
+| 0075 | Keeper Tools Smoke — Exhaustive Dispatch Coverage Regression Gate | Implemented | - |
+| 0076 | Tool Readiness Notification Channel | Retired | - |
+| 0077 | Write-side silent failure — typed propagation | Implemented | - |
+| 0079 | Log row typed encoder + silent-drop removal | Implemented | - |
+| 0080 | Registered descriptors are the tool-surface SSOT | Implemented | - |
+| 0081 | OAS Telemetry Envelope Context & Keeper/Goal Pivot Timeline | Implemented | - |
+| 0082 | Withdraw automatic blocker escalation and recovery | Withdrawn | - |
+| 0083 | Dashboard system-actor convention typed unification | Implemented | - |
+| 0084 | Tool dispatch handler and observation unification | Implemented | - |
+| 0086 | Keeper namespace bulk promotion to sub-library | Implemented | - |
+| 0087 | Tool Dispatch Path Unification + Legacy Purge | Implemented | - |
+| 0088 | Counter-as-Fix → Result Propagation (umbrella scoping) | Active | - |
+| 0089 | String Classifier to Typed Variant — direct replacement, no lint | Implemented | - |
+| 0090 | Write-side success-model attribution — finish N-of-M migration | Implemented | - |
+| 0091 | Execute tool: cmd string → typed Argv schema (lexer/validator 박멸) | Implemented | - |
+| 0093 | Board persistence identity and atomic snapshot | Implemented | - |
+| 0094 | Compact cooldown semantics split decision record | Superseded | - |
+| 0095 | Provider-D-compat provider streaming wire-up | Implemented | - |
+| 0096 | Keeper Turn Contract — multi-turn reasoning + runtime SPOF root-fix | Withdrawn | - |
+| 0097 | Keeper sandbox container reuse (long-running sandbox per keeper) | Active | - |
+| 0098 | Typed JSON-RPC error envelope & production-code silent-failure lint | Implemented | - |
+| 0099 | Session lifecycle — typed events, explicit eviction, resume backpressure | Active | - |
+| 0100 | Streamable HTTP as default transport (MCP 2025-03-26) | Active | - |
+| 0101 | FD accountant — observation across process resource classes | Active | - |
+| 0102 | Pre-turn runtime availability gate — reuse, not new surface | Superseded | - |
+| 0103 | Log retention opt-in + JSONL volume root reduction | Draft | - |
+| 0104 | Withdraw Task-to-repository authorization | Withdrawn | - |
+| 0105 | OpenAI-compat boundary: Agent_sdk.Error.t → HTTP status + typed envelope | Implemented | - |
+| 0106 | Cancel-safe try-with discipline (Eio.Cancel.Cancelled propagation) | Active | - |
+| 0107 | Outbound HTTP stack consolidation — pooled keep-alive, scoped Switch, Docker ... | Active | - |
+| 0108 | PR / Worktree Operation Safety Gates | Implemented | - |
+| 0109 | CDAL x Goal Integration Contract | Withdrawn | - |
+| 0110 | Tool-pair atomicity at write boundary — sunset compaction repair fabrication | Superseded | - |
+| 0111 | Goal mint atomicity — auto-goal uniqueness invariant at write boundary | Implemented | - |
+| 0112 | Typed JSON parse boundary — eliminate silent-drop fallback across read sites | Implemented | - |
+| 0113 | Withdraw KeeperReactionLiveness runtime hierarchy | Withdrawn | - |
+| 0114 | Withdraw compact-retry and lifecycle guard model | Withdrawn | - |
+| 0116 | Withdraw fallback-count cap | Withdrawn | - |
+| 0117 | Withdraw runtime health cooldown hierarchy | Withdrawn | - |
+| 0118 | Withdraw terminal runtime projection contract | Withdrawn | - |
+| 0119 | Withdraw lifecycle projection mapping hierarchy | Withdrawn | - |
+| 0120 | Cross-spec set-name divergence — 3-class classification framework (STALE / DE... | Implemented | - |
+| 0121 | Config-dir resolution — single active root, no implicit fallback | Active | - |
+| 0122 | Keeper disk pressure — process-local fleet failure mode beyond FD | Implemented | - |
+| 0123 | Briefing last_event fabrication — option-typed write boundary | Implemented | - |
+| 0124 | Withdraw fleet resource admission denial | Withdrawn | - |
+| 0125 | Withdraw Keeper watchdog and force-release discipline | Withdrawn | - |
+| 0126 | Silent fallback discipline (typed split for option/result wildcard arms) | Implemented | - |
+| 0127 | Runtime Fast-Fail (Provider Health Phase 3) + Fiber Termination Provenance | Active | - |
+| 0129 | Runtime attempt idle-cap: kill the reserve_fraction band-aid | Implemented | - |
+| 0131 | Withdraw policy-bearing shell command facade | Withdrawn | - |
+| 0132 | Redaction SSOT — `runtime` boundary-label private type | Implemented | - |
+| 0134 | Persistence read-drop root fix (recovery story for RFC-0044) | Active | - |
+| 0135 | Supersede dashboard-derived Keeper disposition | Superseded | - |
+| 0136 | Keeper Unified Turn — Stage Decomposition of run_keeper_cycle | Implemented | - |
+| 0137 | Host FD pressure observation — retired Keeper-pause proposal | Retired | - |
+| 0138 | Dashboard Snapshot Lock-Free Immutable Architecture | Implemented | - |
+| 0139 | Withdraw parallel agent and judge status hierarchies | Withdrawn | - |
+| 0140 | Dashboard wire codec for source observations | Implemented | - |
+| 0141 | TOML Field Resolution Typed Variant for repo_manager | Implemented | - |
+| 0142 | runtime_error_classify Decomposition + Typed JSON-Extraction Variant | Active | - |
+| 0143 | keeper_runtime_profile Typed Catalog Query Result | Active | - |
+| 0144 | Withdraw recording-error dedup and metric sunset gates | Withdrawn | - |
+| 0145 | Permissive-Silent-Fallback Elimination | Active | - |
+| 0147 | Withdraw decomposition around deleted Keeper policy stages | Withdrawn | - |
+| 0148 | Typed `tool_error` Variant for LLM-Facing Tool Failure Surface | Implemented | - |
+| 0149 | Audit-Driven Telemetry-as-Fix Sunset | Implemented | - |
+| 0150 | Keeper Attention Signal — backend 단일 typed wire envelope | Implemented | - |
+| 0151 | 4-metric monotone-decrease ratchet for code-smell metrics | Withdrawn | - |
+| 0153 | Withdraw runtime tier admission | Withdrawn | - |
+| 0154 | System_error_class typed SSOT — close substring-classifier loop across backen... | Implemented | - |
+| 0155 | Withdraw centralized operational policy log taxonomy | Withdrawn | - |
+| 0156 | Withdraw MASC turn-budget timeout policy | Withdrawn | - |
+| 0157 | Withdraw MASC pre-dispatch provider capability filtering | Withdrawn | - |
+| 0158 | Withdraw MASC retry-admission denial | Withdrawn | - |
+| 0159 | Reason_internal_error typed split — close string-classifier catch-all | Draft | - |
+| 0160 | Withdrawn Shell IR decision-substrate plan | Withdrawn | - |
+| 0161 | Tool Error Hint Symmetry Enforcement | Draft | - |
+| 0162 | JSONL Write-Path FD Pressure Root-Fix | Draft | - |
+| 0163 | Tier-group capability profile route canonicalization — typed dedup and bypass... | Withdrawn | - |
+| 0164 | Withdraw voice exceptions to provider capability filtering | Withdrawn | - |
+| 0167 | Withdrawn product-specific runtime authorization cleanup | Draft | - |
+| 0168 | Dashboard upstream-LLM-provider color palette purge | Draft | - |
+| 0169 | Dashboard common/* MCP-client attribution header purge | Draft | - |
+| 0170 | Dashboard provider-b palette closure (RFC-0168 N-of-M follow-up) | Draft | - |
+| 0171 | Design-canvas + ui_kits mock data vendor purge | Draft | - |
+| 0172 | Big-bang vendor purge across docs, audits, RFCs, design-system, tests | Draft | - |
+| 0173 | OCaml lib/bin/test vendor purge (identifier + string literal) | Draft | - |
+| 0174 | Dashboard substring classifier to typed — TypeScript | Draft | - |
+| 0175 | Godfile decomposition Wave D — keeper core 5-file split | Draft | - |
+| 0176 | OAS vendor-purge migration — consume agent_sdk 0.198.0 | Implemented | - |
+| 0177 | Phonebook internal vendor-coupled enum purge | Draft | - |
+| 0178 | Types Sub-library Extraction with `_intf.ml` mli-only Surface (typed-SSOT) | Draft | - |
+| 0179 | ToolDescriptor Ecosystem Coverage Extension to Workspace Tools | Draft | - |
+| 0180 | 24h Runtime ERROR 7-Pattern Sweep Roadmap | Draft | - |
+| 0181 | Withdraw MASC capability-intent routing | Withdrawn | - |
+| 0182 | masc_* Workspace Tool Descriptor Projection + Tool_spec SSOT Consolidation | Draft | - |
+| 0184 | Runtime phonebook typed roundtrip for protocol/flavor/provider identifiers | Draft (Deferred) | - |
+| 0189 | Typed Tool_result.result variant — eliminating boolean blindness in tool disp... | Draft | - |
+| 0190 | Descriptor as Visibility/Metadata SSOT — Surface Projection from descriptor.p... | Draft | - |
+| 0191 | Withdraw descriptor authorization policy | Withdrawn | - |
+| 0192 | Runtime deadline propagation — retired admission-wait proposal | Retired | - |
+| 0194 | Withdraw tool semantics as an authorization SSOT | Withdrawn | - |
+| 0197 | Runtime Attempt Watchdog — Per-Candidate Wrap + Shared Deadline | Draft | - |
+| 0198 | Execute Typed Redirection (Shell IR Syntax Leakage Closure) | Draft | - |
+| 0199 | Withdraw deterministic task-completion auto approval | Withdrawn | - |
+| 0200 | Time constants 를 leaf library 로 분리 | Draft | - |
+| 0201 | Activity Events Wait-Free Snapshot | Draft | - |
+| 0203 | In-process Discord connector | Implemented (Phase 3 cutover landed 2026-05-29) | - |
+| 0204 | Dashboard Read Serving Isolation from Fleet Compute | Draft | - |
+| 0205 | Keeper Module Consolidation — Eliminate Facade Anti-Pattern | Draft | - |
+| 0206 | Runtime 개념 — runtime→Runtime 재탄생 | Draft | - |
+| 0207 | Per-keeper LLM runtime routing | Draft | - |
+| 0208 | Withdrawn compositional Shell IR policy algebra | Withdrawn | - |
+| 0210 | Keeper Playground Repo Currency (fetch + fast-forward, work-preserving) | Draft | - |
+| 0211 | Persona ⊥ {model, runtime}, opaque runtime id, runtime.toml keeper-assignment... | Draft | - |
+| 0212 | Withdraw Keeper exposure policy axis | Withdrawn | - |
+| 0213 | Keeper sandbox/playground isolation model (fix sandbox_repo_not_ready + macOS... | Draft | - |
+| 0214 | OTel GenAI Semantic Convention Migration | Draft | - |
+| 0215 | Keeper sub-library extraction campaign — sequence and per-PR gates | Draft | - |
+| 0216 | Per-Keeper Decline Memory (orphan-task churn root fix) | Draft | - |
+| 0217 | Telemetry Backend Otel 단일화 (Retired Backend Purge) | Draft | - |
+| 0218 | Keeper tool-surface coherence + web-tooling roadmap — phases and per-phase gates | Draft | - |
+| 0219 | Remove Sandbox Repo Patrol Gates | Draft | - |
+| 0220 | Withdraw cross-Keeper verification scheduling | Withdrawn | - |
+| 0221 | Atomic verification submission — task_status as the sole outcome authority | Implemented (steps 1-3 merged #20613/#20617; steps 4-5 measured then dropped, §3.3/§3.4) | - |
+| 0222 | Withdraw harness-owned Task completion | Withdrawn | - |
+| 0223 | Typed connector surfaces: presence in world prompt, pull-based lane context, ... | Draft | - |
+| 0224 | Withdraw the mandatory structured completion checklist | Withdrawn | - |
+| 0225 | Per-keeper turn single-flight admission | Draft | - |
+| 0226 | Ambient lane recording: record-vs-trigger decouple for connector surfaces | Draft | - |
+| 0228 | Paged lane pull + fact-retention harness: digest without a summarizer | Draft | - |
+| 0229 | Keeper person notes: deliberate per-speaker memory beyond the log window | Draft | - |
+| 0230 | Keeper mention/scope reactivity: cursor-free salience to complement pull-base... | Draft | - |
+| 0232 | Typed lane event model: parse at the write boundary, never re-derive by strin... | Draft | - |
+| 0233 | Typed turn observability: TurnRecord prompt-block provenance + canonical tool... | Draft | - |
+| 0234 | Withdraw schedule-specific approval hierarchy | Withdrawn | - |
+| 0235 | Voice output transport: browser-addressed audio delivery with device-routed p... | Draft | - |
+| 0236 | Voice input transport: browser-captured speech-to-text for the dashboard comp... | Draft | - |
+| 0237 | Eliminate the write_meta ~force escape hatch (route snapshot writes through C... | Draft | - |
+| 0239 | Supersede no-progress pause and semantic debounce guards | Superseded | - |
+| 0240 | Tool-pair invariant enforced at write-time (eliminate repair-on-read) | Draft | - |
+| 0241 | external-attention store lifecycle: read-side bound, retention, and typed tai... | Retired | - |
+| 0242 | Retired continuity prose-filter draft | Superseded | - |
+| 0243 | Memory OS confidence mutability via write-side fact upsert | Draft | - |
+| 0244 | Memory OS recall: turn-seeded deterministic lexical retrieval, with provenanc... | Superseded | - |
+| 0245 | Exempt goalless tasks from the per-goal WIP claim cap | Withdrawn | - |
+| 0247 | Memory OS purge + LLM-judgment rebuild — implementation plan (phase of RFC-0247) | Draft | - |
+| 0248 | Board context without local authority classification | Draft | - |
+| 0249 | Remove the dead `stale_factor` field (execute RFC-0239/0243/0244/0247) | Draft | - |
+| 0251 | Memory OS: record well, do not value — remove the scoring layer | Draft | - |
+| 0252 | Fusion: 패널+심판(panel+judge) 심의 루프 (MASC 내장) | Draft | - |
+| 0253 | Dashboard keeper-v2 surfaces: canonical spacing/radius token scale + off-scal... | Draft | - |
+| 0254 | Shell IR Approval Gate — Autonomous Production Policy | Withdrawn | - |
+| 0255 | Withdraw inferred argv path policy | Withdrawn | - |
+| 0256 | Migrate hand-rolled Mutex lock/protect/unlock to Mutex.protect | Draft | - |
+| 0257 | Per-Keeper memory execution lane | Draft | - |
+| 0259 | Memory OS — Volatile Claim Grounding, Retraction & Decay | Draft | - |
+| 0260 | Withdraw MASC provider-health gate | Draft | - |
+| 0261 | gRPC LSP failed-initialize FD/process teardown | Draft | - |
+| 0262 | Withdraw hierarchical Task-completion authority | Withdrawn | - |
+| 0263 | Withdraw actor-priority turn preemption | Withdrawn | - |
+| 0264 | Memory OS recall outcome-anchored eval harness | Draft | - |
+| 0265 | Withdraw MASC modality capability rerouting | Withdrawn | - |
+| 0266 | Fusion async-completion wake + in-progress 가시성 | Draft | - |
+| 0267 | Make task↔goal links visible and explicitly assignable | Draft | - |
+| 0269 | Process Critic Loop for Keeper Work Traces | Draft | - |
+| 0270 | CI Gate merge guard: block merges on a non-success CI Gate and trip on red main | Draft | - |
+| 0271 | Withdraw progress-based turn rejection and pause | Withdrawn | - |
+| 0272 | Memory OS — Episode Log Retention (bounded append for events.jsonl / episodes) | Draft | - |
+| 0273 | Withdraw policy-bearing Keeper configuration tiers | Withdrawn | - |
+| 0274 | Workspace base_path SSOT — retire env runtime read, thread Workspace.config | Draft | - |
+| 0275 | Retired cognitive-triple removal record | Implemented | - |
+| 0276 | Remove Keeper social-model self-report protocol | Implemented | - |
+| 0277 | Fusion: 이종 패널 그룹(heterogeneous panel groups) + 발동 예산 제거 | Draft | - |
+| 0278 | Fusion: 같은 model을 다른 prompt로 (same-model panels via panel labels) | Draft | - |
+| 0279 | Withdraw completion-contract result taxonomy | Withdrawn | - |
+| 0280 | Fusion: validated preset type (Parse, don't validate) | Draft | - |
+| 0281 | WebSocket transport SSOT — separate upgrade-attachment from session-protocol,... | Draft | - |
+| 0282 | Reduce Keeper persona to ordinary instructions | Implemented | - |
+| 0283 | Fusion: judge-of-judges 위상 (flat/staged reducer) | Draft | - |
+| 0284 | Supersede command-semantics guidance guards | Superseded | - |
+| 0285 | Memory OS — Self-Observation Claim Volatility (closing RFC-0259's internal-st... | Draft | - |
+| 0286 | Superseded exec and Keeper boundary diagnosis | Superseded | - |
+| 0287 | ws-direct — a single masc-owned WebSocket stack for server and client | Draft | - |
+| 0288 | Remove per-Keeper goal-horizon fields | Implemented | - |
+| 0289 | Extract progress-classification into its own library for a single substantive... | Draft | - |
+| 0290 | Generic keeper background-work tool (spawn → wake-on-completion) | Draft | - |
+| 0291 | Closed SSE event-type sum + typed broadcast — RFC-0004 Phase A0 Wave 2 increment | Draft | - |
+| 0292 | Complete lib/auth de-duplication — remove drifted Masc.Auth* test copies | Draft | - |
+| 0293 | Withdraw policy-bearing execution endpoints | Withdrawn | - |
+| 0294 | Remove workspace Goal horizon | Implemented | - |
+| 0295 | Withdraw derived fleet runtime bands | Withdrawn | - |
+| 0296 | CI skip-gate main-push safety-net: always run Build and Test on non-PR events | Draft | - |
+| 0298 | fusion judge pool — judge 모델을 preset에서 분리 | Draft | - |
+| 0299 | RFC-0299 — Typed-Boundary Sweep (string-classifier → closed-sum, dead SSOT re... | Draft | - |
+| 0300 | RFC-0300 — Dashboard design-token scope consolidation (radius / shadow / type... | Draft | - |
+| 0301 | Keeper 생성 미디어(이미지/오디오) 대시보드 노출 | Draft | - |
+| 0302 | Keeper 메모리 파일 I/O off-main-domain 오프로드 (HOL fix) | Draft | - |
+| 0303 | Keeper wake without progress heuristics | Draft | - |
+| 0304 | Withdraw Critical-class HITL escalation | Withdrawn | - |
+| 0305 | Withdraw global fail-closed governance policy | Withdrawn | - |
+| 0306 | Typed, comment-preserving fusion settings editor | Draft | - |
+| 0307 | Mid-turn advisor consult for keepers — evaluation and deferral | Draft | - |
+| 0308 | Withdraw verifier-required Task routing | Withdrawn | - |
+| 0309 | Withdrawn product-specific capability hierarchy | Withdrawn | - |
+| 0311 | Withdraw deterministic evidence floors | Withdrawn | - |
+| 0312 | Keeper repo mappings are advisory default scope, not access caps | Accepted | - |
+| 0315 | Typed wake-turn context and self-directed work lane | Active | - |
+| 0316 | Merge gating convergence: enforce_admins=true + live Branch Protection Watchdog | Draft | - |
+| 0317 | In-process Slack connector (Socket Mode) | In progress (PR-1/PR-2 landed; PR-3 implemented; PR-4 sidecar removal pending) | - |
+| 0318 | Replace risk-tier auto approval with request-local Auto Judge | Withdrawn | - |
+| 0319 | Replace hierarchical approval modes with Keeper Gate choices | Withdrawn | - |
+| 0320 | Keeper connector-aware continuation: carry the originating channel through wa... | Draft | - |
+| 0321 | Withdraw unconditional static tool-block proposal | Withdrawn | - |
+| 0322 | Withdraw repository-catalog read authorization | Withdrawn | - |
+| 0323 | Withdraw mandatory cross-verifier completion | Withdrawn | - |
+| 0324 | keeper repo 경로를 filesystem 진실로 (catalog 거짓 주입 제거) | Draft | - |
+| 0328 | Retire the combined governance and perseveration incident plan | Withdrawn | - |
+| 0329 | Keeper Execute Governance Payload Mapping | Rejected | - |
+| 0331 | Withdraw authorization by tool effect class | Withdrawn | - |
+| 0332 | Rejected heuristic memory write dedup draft | Rejected | - |
+| 0333 | Deterministic cost↔success frontier join for the eval harness | Draft | - |
+| 0334 | Board signals as durable Keeper input | Draft | - |
+| 0335 | TOML as the Single Settings Source | Draft | - |
+| 0337 | Withdraw deterministic evidence-gate semantics | Withdrawn | - |
+| 0338 | Lane-per-keeper durable persistence isolation | Draft | - |
+| 0340 | Dashboard dev-token privilege reduction — demote from Admin, close the rebind... | Draft | - |
+| 0341 | Keeper lifecycle projection SSOT | Draft | - |
+| 0342 | Capability catalog overlay, deployment capability declarations, and boot posture | Draft | - |
+| 0343 | Repo location SSOT (collapse dual-authority, attribute by git-remote) | Draft | - |
+| 0345 | Streaming idle-timeout fail-safe floor (#25128) | Draft | - |
+| 0346 | Gateway redelivery dedup: transcript single-authority, attention as wake-hint | Draft | - |
+| 0347 | Typed EffectIntent + capability floor at the Keeper Gate | Draft | - |
+| 0348 | Bounded lane acquisition for durable keeper_msg writes (#25398) | Draft | - |
+| 0349 | Restore a reachable compaction admission path | Draft | - |
+| 0350 | Unbounded request-fiber admission (durable queue + lifecycle-sibling worker +... | Draft | - |
+| 0351 | Memory-first context management and compaction sunset | Draft | - |
+| 0352 | Legacy Goal: RFC-0000 §3.2 ↔ §3.15 자기모순 해소 (결정 요청) | Draft | - |
+| 0353 | 실패 분류가 모듈 경계에서 소실되는 결함 (결정 요청) | Draft | - |
+| 0356 | Approval owns the effect (replay the approved payload, do not require byte-id... | Draft | - |
+| 0357 | Scheduled-autonomous 턴은 heartbeat가 아니라 typed stimulus의 변화로 admit한다 | Draft | - |
+| asyn | Offload the structured-log durable append off the emitting fiber | Draft | - |
+| chec | Immutable boot-pinned root capability for checkpoint containment | Draft | - |
+| comp | Compaction must never deadlock: a deterministic structural floor, typed outco... | Draft | - |
+| conn | Durable Keeper chat receipts and connector delivery settlement | Active | - |
+| elim | Withdrawn command-policy classification experiment | Withdrawn | - |
+| keep | Vision-as-a-tool delegation (decouple multimodal input from conversation runt... | Draft | - |
+| memo | # RFC: Memory OS 2.0 — bounded working set 전송 계약과 librarian curator 계약 | Draft | - |
+| runt | Per-runtime note field & dashboard surfacing | Draft | - |
+| type | Withdraw product-specific egress effect classification | Withdrawn | - |
 
 ### 신규 RFC
 
@@ -357,108 +360,11 @@ implementation_prs: []             # [14181, 14550] 형식 (정수). RFC body �
 
 - 단일 RFC: `cat docs/rfc/RFC-NNNN-*.md`
 - 키워드 검색: `rg <keyword> docs/rfc/`
-- 본 README 의 표 + Last activity 컬럼으로 최근 활동 추적
+- 본 README 의 표로 RFC 발견 및 상태 확인. 최근 활동은 해당 RFC 파일의 `git log`로 확인
 - PR 작성 시 RFC 발견 체크: `bash ~/me/scripts/pr-rfc-check.sh --pr-body /tmp/pr-body.md`
 
 ## 비범위 (향후 별도 RFC)
 
 - Frontmatter 자동 lint (CI hook)
 - 기존 RFC retroactive frontmatter 통일
-- 자동 인덱스 생성 (`scripts/rfc-index.sh` 또는 GitHub Action) — 이 표 자동 갱신을 포함
 - Status sweep 전면 audit (Draft → Withdrawn 후보 식별)
-| 0102 | Pre-turn runtime availability gate — historical | Superseded | (this PR) 2026-07-11 | The pre-turn health gate is no longer a live contract. Actual provider/model outcomes belong to OAS and do not pause or deny a Keeper lane. |
-| 0103 | Log retention opt-in + volume-root anchoring | Draft | 9f7b4ce520 2026-05-17 | retroactive index entry — body merged via #15850 (5-PR sprint). Default-disabled retention with explicit opt-in env knob + log volume-root anchored archiver. |
-| 0104 | Keeper task → repository binding — historical | Withdrawn | (this PR) 2026-07-13 | Repository catalog membership no longer grants or denies access; execution uses BasePath/path jail and sandbox containment. |
-| 0105 | Provider-D-compat boundary: `Agent_sdk.Error.t` → HTTP status + typed envelope | Implemented | (this PR) 2026-05-17 | RFC-0098 closeout follow-up audit. RFC-0098 (Implemented #15828) cleared `server_mcp_transport_http` (0 literal codes, 9 typed `Mcp_error_code` sites). This RFC closes the sole remaining lossful boundary in `lib/server/`: `server_openai_compat.ml:125` `Agent_sdk.Error.to_string` typed→string compression, amplified by `route_runtime (_, string) result` signature and `handle_chat_completions` blanket 500 / `"server_error"` flattening. `Openai_compat_error_map.t` total mapping + widened Error tag + envelope `code` field population landed in #15899 (21/21 Alcotest PASS, exhaustive over 9 sdk_error top-level variants, no catch-all). `route_keeper` deeper site at `keeper_turn.ml:521-531` deferred to a separate RFC (larger scope). Related RFC-0098, RFC-0095. |
-| 0106 | Cancel-safe try-with discipline (Eio.Cancel.Cancelled propagation) | Active | (this PR) 2026-05-21 | Existing `scripts/lint-cancel-guard.sh` only matches single-arm `try X with exn -> Y`. **P0 (helper module) + P1 partial 머지**: 8 PR (#15894, 15904, 15917, 15919, 15920, 15925 initial P0+P1 batch + #16949 masc_http_client/pool + #16951 fd_accountant). `lib/cancel_safe/cancel_safe.{ml,mli}` SSOT 존재. **P2 (callbacks) / P3 (ppxlib AST lint) / P4 (regex lint deprecation) 미시작** — P3 가 RFC-0126 Phase 2b prereq. Status promoted Draft → Active. Related RFC-0072, RFC-0097, RFC-0101, RFC-0126. |
-| 0107 | Outbound HTTP stack consolidation — pooled keep-alive, scoped Switch, Docker socket transport | Draft | (this PR) 2026-05-17 | 2026-05-16 ENFILE storm 의 진짜 근본 원인 4개를 다룬다. RFC-0101 (Fd_accountant) 는 같은 사고의 transitional defense — 1/4 kind 만 wired, 3 kind dead branch. (1) cohttp-eio 6.1.1 socket-not-closed bug → `make_closing_client` 워크어라운드 (Eio issue #244 권고 위반); (2) connection pool 부재 (masc + oas); (3) `run_turn:196` ambient switch (turn-scoped FD boundary 없음); (4) subprocess-heavy Docker (`docker run/exec`, `/var/run/docker.sock` 미사용, RFC-0097 spec-only). 4-layer 설계: L1 Transport (Phase B spike → piaf default / cohttp-eio latest 검토), L2 `(host:port) → Client.t` keyed pool, L3 `run_turn` fresh `Eio.Switch.run`, L4 Docker UDS + RFC-0097 활성화. RFC-0101 은 머지 직후 transitional → Phase D + 30일 production soak gate 후 retire. PR #15881 (Sandbox_exec wrap) close. Prior Art: piaf, Tarides Ocsigen→Eio (2025-03), cohttp #85, Eio #244, Eio.Switch axiom. Related RFC-0097, RFC-0100, RFC-0101. |
-| 0108 | Atomic JSONL Append (in-process) | Draft | (this PR) 2026-05-17 | 2026-05-17 `<base-path>/.masc/` 전수 스캔에서 4 카테고리 JSONL 출력에 **43 파일 / 379 라인 malformed** 발견. 손상은 `}{` concat (system_log, oas-events) + utf-8 multibyte 절단 (trajectories, reaction-ledger) 두 패턴. 코드베이스에 **3 단계 동시성 보호 누적** (Tier-0: 없음 / Tier-1: `Stdlib.Mutex` + `Append_fd_cache` / Tier-2: `Eio.Mutex`) — 모든 tier 에서 손상 발생. 직접 원인 두 가지: (a) `output_string + flush` 가 두 syscall 이라 race window 존재, (b) record + '\n' 의 *직렬화 단계와 write 단계 분리*로 large record (PIPE_BUF 초과 trajectory prompt dump) 가 multiple `write(2)` 로 쪼개져 다른 writer 끼어듦. 새 `lib/jsonl_atomic/` 모듈 + Eio.Mutex per-path registry + single write(2) loop 으로 SSOT 수렴. 4 writer (`log.ml`, `trajectory.ml`, `dated_jsonl.ml`, → runtime_event_bridge / keeper_reaction_ledger 자동 fix) 마이그레이션. Cross-process flock + Stdlib.Mutex 전역 audit 는 명시적 비목표. 5-PR sprint (RFC → 모듈 → log → trajectory → dated_jsonl). Originally allocated as RFC-0107 but renumbered after RFC-0107 (outbound HTTP) merged first to main (#15900). Related RFC-0079, RFC-0088. |
-| 0107 | Outbound HTTP stack consolidation — pooled keep-alive, scoped Switch, Docker socket transport | Active | (this PR) 2026-05-17 | 2026-05-16 ENFILE storm 의 진짜 근본 원인 4개를 다룬다. RFC-0101 (Fd_accountant) 는 같은 사고의 transitional defense — 1/4 kind 만 wired, 3 kind dead branch. (1) cohttp-eio 6.1.1 socket-not-closed bug → `make_closing_client` 워크어라운드 (Eio issue #244 권고 위반); (2) connection pool 부재 (masc + oas); (3) `run_turn:196` ambient switch (turn-scoped FD boundary 없음); (4) subprocess-heavy Docker (`docker run/exec`, `/var/run/docker.sock` 미사용, RFC-0097 spec-only). 4-layer 설계: L1 Transport (Phase B spike → piaf default / cohttp-eio latest 검토), L2 `(host:port) → Client.t` keyed pool, L3 `run_turn` fresh `Eio.Switch.run`, L4 Docker UDS + RFC-0097 활성화. RFC-0101 은 머지 직후 transitional → Phase D + 30일 production soak gate 후 retire. PR #15881 (Sandbox_exec wrap) close. Prior Art: piaf, Tarides Ocsigen→Eio (2025-03), cohttp #85, Eio #244, Eio.Switch axiom. Related RFC-0097, RFC-0100, RFC-0101. |
-| 0108 | Atomic JSONL Append (in-process) | Draft | (this PR) 2026-05-17 | 2026-05-17 `<base-path>/.masc/` 전수 스캔에서 4 카테고리 JSONL 출력에 **43 파일 / 379 라인 malformed** 발견. 손상은 `}{` concat (system_log, oas-events) + utf-8 multibyte 절단 (trajectories, reaction-ledger) 두 패턴. 코드베이스에 **3 단계 동시성 보호 누적** (Tier-0: 없음 / Tier-1: `Stdlib.Mutex` + `Append_fd_cache` / Tier-2: `Eio.Mutex`) — 모든 tier 에서 손상 발생. 직접 원인 두 가지: (a) `output_string + flush` 가 두 syscall 이라 race window 존재, (b) record + '\n' 의 *직렬화 단계와 write 단계 분리*로 large record (PIPE_BUF 초과 trajectory prompt dump) 가 multiple `write(2)` 로 쪼개져 다른 writer 끼어듦. 새 `lib/jsonl_atomic/` 모듈 + Eio.Mutex per-path registry + single write(2) loop 으로 SSOT 수렴. 4 writer (`log.ml`, `trajectory.ml`, `dated_jsonl.ml`, → runtime_event_bridge / keeper_reaction_ledger 자동 fix) 마이그레이션. Cross-process flock + Stdlib.Mutex 전역 audit 는 명시적 비목표. 5-PR sprint (RFC → 모듈 → log → trajectory → dated_jsonl). Originally allocated as RFC-0107 but renumbered after RFC-0107 (outbound HTTP) merged first to main (#15900). Related RFC-0079, RFC-0088. |
-| 0109 | CDAL × GOAL Integration Contract — historical | Withdrawn | (this PR) 2026-07-13 | CDAL output is observation only and cannot transition Goal or Task state. Semantic completion uses the configured LLM. |
-| 0124 | Keeper admission denial boundary — historical | Withdrawn | (this PR) 2026-07-13 | FD, disk, and fleet measurements are observations only; they do not deny unrelated Keeper lanes. |
-| 0125 | Withdraw Keeper watchdog and force-release discipline | Withdrawn | (this PR) 2026-05-21 | Elapsed-time watchdog, restart authority, and semaphore force-release are retired. Process/socket resource scopes remain local typed boundaries. |
-| 0126 | Silent fallback discipline (typed split for option/result wildcard arms) | Active | (this PR) 2026-05-21 | 본 RFC body (#15959) + amendment (#16000) + Phase 1 PR-1 (#16019 runtime attempt provenance) + Phase 1 PR-2 (#16024 provider health probe loop) + Phase 1 cross-listed (#16189 RFC-0127 PR-1, §6.1.b absorbs into Phase 1 canary). Phase 2a (`scripts/lint/no-unknown-permissive-default.sh` grep-based) in place. **Phase 2b (ppxlib AST) / Phase 3 (codemod) / Phase 4 (CI hard-fail) 미시작** — Phase 2b 는 RFC-0106 §3.3 dependency. Phase 1 OAS upstream (C2/C3/V16 labels) 도 별도 OAS RFC 대기. Status promoted Draft → Active. Related RFC-0042, RFC-0088, RFC-0106, RFC-0127. |
-| 0127 | Runtime Fast-Fail (Provider Health Phase 3) + Fiber Termination Provenance | Active | (this PR) 2026-05-18 | 2026-05-17 ~13:00–13:30 UTC incident: RunPod pod `ur1wah58zebjov` 502 storm 30분 동안 10-keeper fleet `fiber_unresolved`, supervisor log 가 *어떤 provider 가 502 인지* 한 줄도 출력 안 함 (`fiber_terminated(fiber_unresolved)` 만). Two gaps: **(A)** `runtime.toml` 의 `[providers.X.healthcheck]` 블록은 parser 에 들어가지만 runtime 동작 0 (probe loop wiring 부재) → **RFC-0126 PR-2 (#16024)** 가 main 에 wiring 완료, RFC-0127 scope 와 implementation overlap. **(B)** `Fiber_terminated { outcome }` 가 `provider_id` / `http_status` 정보를 string-squash 으로 잃어버림 → **PR-1 (#16189 MERGED 2026-05-18)** 가 carrier widen + 5 caller propagation + display surface (event_to_string, JSON, failure_reason_to_string) + 7 carrier-preservation tests. **Remaining**: data-flow from `Provider_error.ServerError { code }` (already captured at `keeper_turn_driver.ml:364`) into the now-typed `Fiber_terminated` carrier so supervisor log shows `fiber_terminated(fiber_unresolved provider=runpod_mtp http=502)`. Originally PR-2/PR-3 spec'd as new module + integration test; PR-2 reduced to data-flow plumbing now that probe loop ships via RFC-0126. Related RFC-0024, RFC-0027, RFC-0058, RFC-0088, RFC-0126. |
-| 0129 | Runtime attempt idle-cap: kill the reserve_fraction band-aid | Implemented | (this PR) 2026-05-21 | 2026-05-18 incident: reserve_fraction band-aid 가 keeper-level workaround. **2-PR plan 완료**: PR-1 #16084 (piaf idle-timeout API + pool layer reference, RFC-0121 commit subject 와 dual-listed), PR-2 #16158 (`delete reserve_fraction band-aid` — fleet fix). §5 acceptance 24h soak 경과 (2026-05-19). Second audit-sweep RFC to land directly at Implemented (RFC-0132 #17187 다음). Related RFC-0107, RFC-0121 (#16084 dual-listing). |
-| 0131 | Shell Command Gate facade — historical | Withdrawn | (this PR) 2026-07-13 | Command/product policy was removed; typed argv/path/sandbox invariants remain and external effects use the generic Gate. |
-| 0132 | Redaction SSOT — `runtime` boundary-label private type | Implemented | (this PR) 2026-05-21 | `lib/runtime/` 와 `lib/keeper/` 에 `"runtime"` 리터럴이 ~23 사이트 산재. **3-phase 완전 closure**: PR-1 #16531 (`Boundary_redaction` SSOT 모듈), PR-2 #16536 (23-site codemod), PR-3 #16537 (`scripts/lint/no-runtime-literal-outside-boundary-redaction.sh` + Fundamental Check workflow). `feedback_runtime_lens_boundary_carve_out` (#15040/#15070/#15089) 회귀 root fix. Workaround Rejection Bar §AI 안티패턴 1 (Scattered Hardcoded Defaults). Status promoted Draft → Implemented. Related RFC-0085, RFC-0088, RFC-0089, RFC-0126, RFC-0131. |
-| 0135 | Dashboard Keeper Operational Surface — historical | Superseded | (this PR) 2026-07-13 | One observation still renders consistently, but the dashboard no longer derives blocked, stuck, risk, or operator-action hierarchies. |
-| 0133 | Keeper Phase Casing SSOT Consolidation | Draft | (this PR) 2026-05-19 | PR-1 (#16312) closed 11 dead `snapshot.phase === '<PascalCase>'` compares but the structural duplication remains: backend emits lowercase + snake_case via `phase_to_string`, dashboard normalizes flat `keeper.phase` to PascalCase via 4 separate normalizers (`toKeeperPhase`, `normalizePhase`, `toPascalPhase`, `keeper-state-diagram` internal map), and `STATE_DISPLAY_NAMES` carries both casings as defensive double-keying. Single PR sweep flips canonical type to lowercase, deletes 4 normalizers + dual map keys, promotes schema to picklist + `{unknown}` carrier (RFC-0042 closed-sum). 사용자 절대 원칙: no transitional shims, legacy 박멸 in same PR. Renumbered from 0131 → 0133 after PR #16323 ledger-snapshot collision. Related RFC-0042, RFC-0046, RFC-0088. |
-| 0108 | Atomic JSONL Append (in-process) | Active | (this PR) 2026-05-17 | 2026-05-17 `<base-path>/.masc/` 전수 스캔에서 4 카테고리 JSONL 출력에 **43 파일 / 379 라인 malformed** 발견. 손상은 `}{` concat (system_log, oas-events) + utf-8 multibyte 절단 (trajectories, reaction-ledger) 두 패턴. **§2.5 진단 evolution** (implementation 진행 중 갱신): 초기 가설 (Stdlib.Mutex multi-domain 무효) 은 부분만 맞았고, 실제 root cause 는 *OCaml `out_channel` buffer 가 도메인-safe 아님* — `Append_fd_cache` 의 cached channel 을 두 도메인이 공유하면 mutex critical section 안에서도 buffer corrupt. 결정적 fix = per-call open_out_gen + close (fresh fd, cache 우회). **Implementation 6 PR MERGED**: #15906 Eio SSOT 모듈, #15922 system_log in-line, #15926 trajectory in-line, #15928 dated_jsonl in-line, **#15936 `Fs_compat.append_jsonl` root-fix** (~30 caller 자동 안전), **#15949 `Fs_compat.append_file` root-fix + `Append_fd_cache` 모듈 완전 제거** (-91 LoC). #15953 cleanup Draft (inline 헬퍼 → library delegate, -109 LoC). 운영 실측: 5 malformed 정적 (3 tick 연속), 새 손상 0. Originally allocated as RFC-0107, renumbered after #15900 collision. Related RFC-0079, RFC-0088. |
-| 0136 | Keeper Unified Turn — Stage Decomposition of `run_keeper_cycle` | Active | (this PR) 2026-05-19 | `lib/keeper/keeper_unified_turn.ml` 1943 LOC (5위 godfile, fundamental_roadmap.md Phase 5 명시 target) 의 단일 함수 `run_keeper_cycle` 을 stage-typed sub-module 로 분해. **PR-1 #16604 MERGED** (Phase Gate, -102), **PR-2 #16624 MERGED** (Runtime Resolution, -51), **PR-3 #16643 MERGED** (Pre-Dispatch, -48) — 누적 1943 → 1742 = **-201 LoC (10.3%)**. Phase 4 sub-doc (`RFC-0136-phase-4-retry-loop.md`) 으로 retry loop body (~1100 LOC) 5 sub-PR 분할 (PR-4-a outer setup, PR-4-b error marker, PR-4-c retry core, PR-4-d retry decision, PR-4-e final dispatch). 예상 최종 `keeper_unified_turn.ml` ~620 LOC (-68%). Workaround Rejection Bar 7-check: 모두 N/A. Related RFC-0051, RFC-0056, RFC-0085. |
-| 0136 | Phase 4 — Retry Loop Body Decomposition | Draft | (this PR) 2026-05-19 | RFC-0136 main spec §4.2 PR-3 (deferred — *Retry loop body 별도 sub-doc 검토*) 의 구체 계획. `rec retry_loop` (L604, ~1100 LOC) 가 *single PR 불가* — 새 file 600 LOC cap 위반 + nested helpers (`mark_terminal_error` 9 callsites, `do_run`, `attempt_result`) 동시 추출 필요. 5 sub-PR 분할: PR-4-a outer setup (-167), PR-4-b mark_terminal_error (-53), PR-4-c retry core (-400), PR-4-d retry decision (-300), PR-4-e final dispatch (-180). Sequencing: PR-4-a/b parallel → PR-4-c (depends a+b) → PR-4-d/e parallel. typed `retry_setup` + `terminal_error_outcome` record 도입. Workaround Rejection Bar §3 (N-of-M migration) 경계선 — *해당 RFC closure 의 일부* 명시 + PR-4-final 마감 commit 필수. Related RFC-0051, RFC-0056. |
-| 0137 | Host FD pressure observation — retired Keeper-pause proposal | Retired | (this PR) 2026-07-13 | Host FD pressure remains observable, but automatic Keeper pause and Docker pre-spawn refusal were withdrawn. Resource evidence cannot stop unrelated Keeper lanes. Related RFC-0097, RFC-0101, RFC-0122. |
-| 0139 | Withdraw parallel agent and judge status hierarchies | Withdrawn | (this PR) 2026-05-21 | Dashboard projections must use Keeper runtime and Gate source facts instead of a parallel status hierarchy. Historical implementation PRs remain in Git. |
-| 0141 | TOML Field Resolution Typed Variant for repo_manager | Implemented | (this PR) 2026-06-02 | `Field_resolution.t` keeps repository TOML defaults explicit while rejecting type mismatches. The deleted repository credential subsystem is no longer part of this RFC. Related RFC-0088, RFC-0126, RFC-0142, RFC-0148, RFC-0154. |
-| 0142 | runtime_error_classify Decomposition + Typed JSON-Extraction Variant | Active | (this PR) 2026-05-21 | 2026-05-20 silent-failure audit Tier B1. `lib/runtime/runtime_error_classify.ml` 873→939 LoC + 33 catch-all godfile. 3-phase 분해. **Phase 1 부분 머지**: #16790 (Json_field 모듈), #16806 (telemetry_unified migration), #16894 (dashboard_http_helpers), #16899 (server_dashboard_http). 그러나 *origin 모듈 (runtime_error_classify.ml) 자체 migration 미완* — 4 Json_field usage / 33+ catch-all 잔존. Phase 2 (`runtime_internal_error` / `runtime_error_from_sdk` / `runtime_codex_preflight` split) 미시작. Phase 3 (reachability sweep) 미시작. Status promoted Draft → Active to signal partial landing. Related RFC-0085, RFC-0088, RFC-0148, RFC-0154. |
-| 0143 | keeper_runtime_profile Typed Catalog Query Result | Active | (this PR) 2026-05-21 | 2026-05-20 silent-failure audit Tier A2. `catalog_query_result = Catalog_ok \| Catalog_unavailable of {reason; message}` 변형 + caller-side decision protocol. **PR-1 (bridge) 머지** (#16860 `catalog_metadata_query` typed bridge + Otoml string-error → typed translation, transitional). **PR-2~5 미머지** — PR-2 keeper_runtime_profile self (6 sites), PR-3 lib/keeper external batch (8 files), PR-4 lib/runtime + dashboard + server batch (5 files), PR-5 API deletion + ratchet regenerate. Status promoted Draft → Active. Related RFC-0088, RFC-0141, RFC-0142, RFC-0148, RFC-0154. |
-| 0144 | Withdraw recording-error dedup and metric sunset gates | Withdrawn | (this PR) 2026-05-21 | Typed source errors remain visible; metric thresholds do not control lifecycle or removal. |
-| 0145 | Permissive-Silent-Fallback Elimination | Draft | (this PR) 2026-05-21 | 2026-05-20 PR audit Cluster A 워크어라운드 7건 root-fix 우산. `lib/parse_outcome/` (stdlib + Eio only, no Yojson dep) 가 `try f s with _ -> None/[]/default` 패턴을 typed `('a, [`Json_parse_error of string \| `Other of exn]) result` 로 교체. Cancellation 은 re-raise (Eio rules). 7 predecessor PR (#15820/15840/15866/15883/15980/15781/15954) 코드 그대로 유지, 사이트별 별도 PR 로 migration; counter 는 §Override exemption 으로 transitional. Demo: `tool_keeper.cache_ttl_seconds` (#15954 site). Sunset = 6/7 사이트 마이그레이션 + counter 제거 + CI grep gate. Body PR #16780, renumber from 0144 (#16779, collision recovery). Related RFC-0088, RFC-0109, RFC-0144. |
-| 0148 | Typed `tool_error` Variant for LLM-Facing Tool Failure Surface | Implemented | (this PR) 2026-05-21 | LLM 이 호출하는 tool 들의 *실패 분류* 가 `Failure msg` (catch-all 문자열) 으로 ~30 사이트 분산. closed sum type `tool_error` 7 variant (`Not_found \| Permission_denied \| Invalid_input \| Resource_exhausted \| Timeout \| Cancelled \| Internal_error`) 로 root-fix — 새 실패 클래스 추가 시 컴파일 강제 exhaustive match. Same-day closure: PR-1 #16948 (module + 7 Alcotest), PR-2 #16958 (6 LLM-facing site codemod + RFC §1.1 hallucination 정정 — audit 인용 8 사이트 → 실측 6 사이트). RFC-0154 (operator-facing System_error_class) 의 LLM-facing 자매. JSON wire `{"kind":"...","detail":"..."}`, `Internal_error.exn` 은 in-process debug 전용 (wire 노출 안 함). Related RFC-0088, RFC-0091, RFC-0105, RFC-0154. |
-| 0151 | 4-metric monotone-decrease ratchet for code-smell metrics | Draft | (this PR, renumbered from 0149 due to race w/ PR #16930) 2026-05-20 | PR #16833 ("DIRTY + CI/RFC surface" CLOSED) 의 3-split 첫 번째 step. 4 metric (`godfile_loc_1000plus`=51, `catch_all_arms`=3843, `contains_substring_defs`=29→28, `ignore_no_comment`=113; baseline 2026-05-20) 을 CI 에서 monotone-decrease ratchet 으로 enforce. 절대 임계치 (`legacy metrics backend module` LoC cap 같은 evasion 유도 패턴, legacy metrics backend extraction feedback 참조) 가 아닌 *방향성* gate. `RATCHET-WAIVED: <metric_id> <RFC-NNNN reason>` escape hatch + Override 3-요건 (split-evasion 차단, deprecated path 명시, hard_cap 금지). 본 PR 은 docs-only; `scripts/code-smell/measure.{ml,sh}` + `ci/code-smell-baseline.json` + GH Actions step 은 별도 narrow follow-up 2 PR. Related RFC-0085, RFC-0088, RFC-0126. |
-| 0155 | Withdraw centralized operational policy log taxonomy | Withdrawn | (this PR) 2026-05-21 | Source modules emit typed domain events; the generic logger owns no policy classification. |
-| 0153 | Runtime Backpressure & Tier Admission — historical | Withdrawn | (this PR) 2026-07-13 | Saturation remains observable but no tier or admission decision controls Keeper execution. |
-| 0154 | System_error_class typed SSOT — close substring-classifier loop across backend + telemetry + dashboard | Implemented | (this PR) 2026-05-21 | 5-PR sprint #17015~#17051 (Tool Monitor dashboard UX) 후속. OS-level 실패 분류가 backend 4 substring matcher (`keeper_fd_pressure.ml:97`, `keeper_disk_pressure.ml:55`, `workspace_utils_ops.ml:410`, `keeper_stale_watchdog.ml:203`) 로 분산 + `Telemetry_coverage_gap.record ~error:string` 의 13 caller 가 `Printexc.to_string exn` 으로 압축 + dashboard `classifyCoverageError` 가 *같은 substring vocab 으로 재분류* 하는 정보 손실 cycle. `lib/core/system_error_class.ml` closed-sum SSOT (`Fd_exhaustion \| Disk_exhaustion \| Permission_denied \| Connection_refused \| Timeout \| Other of string`) + wire `error_class` typed tag + dashboard typed-first cascading lookup. 4-PR phased rollout 24h 안 closure: PR-1 #17064 (모듈), PR-3 #17073 (dashboard lookup), PR-4 #17072 (cutover runbook), PR-2 #17078 (wire + 4 matcher 통폐합). Workaround Rejection Bar 시그니처 #2 (substring 분류기) + #3 (N-of-M, PR #17051 disk_exhaustion 가 2-of-M 누적 시작) root fix. Related RFC-0042, RFC-0088, RFC-0097, RFC-0105, RFC-0122, RFC-0142, RFC-0148, RFC-0149. |
-| 0160 | Withdrawn Shell IR decision-substrate plan | Withdrawn | (this PR) 2026-07-13 | Representation work remains historical context; policy stamping and hierarchy-oriented phases are superseded by the non-hierarchical Keeper Gate. |
-| 0162 | JSONL Write-Path FD Pressure Root-Fix | Draft | (this PR) 2026-05-23 | Dashboard fleet-health 패널 audit (2026-05-23) 가 추적한 7 surface signal 이 `.masc/` JSONL writer 의 단일 write-path fd/disk 압박으로 수렴. RFC-0108 §3.3 의 *cross-domain fd cache 비목표* 가정 (fd 수가 keeper N≤64 수준) 을 production evidence (22,440 calls × ENFILE, 30 day-file × 465 MB, dashboard 30s self-amplification) 로 반증. 4-phase migration: Phase 0a (`Fs_compat.append_jsonl` `mkdir_p` once-per-path memoize — append 당 stat 1→0, RFC-0108 직교), Phase 0b (`Dated_jsonl.count_entries` 10s TTL cache — dashboard scan amplification 3× ↓), Phase 1 (`MASC_TOOL_CALL_LOG_RETENTION_DAYS` opt-in → opt-out default 30d, *mli line 99-103 의 "default is 30 days" 약속 회복*), Phase 2 (per-domain fd cache — RFC-0108 §3.3 invalidate). 별도 RFC 후보로 `blocker_class` typed variant 에 `Fd_pressure_blocked` 추가 (§3.5 observability gap, scope 밖). Workaround Rejection Bar §1 (counter/WARN 추가 아닌 syscall 제거) + §2 (substring 없음) + §3 (N-of-M 회피 — 각 phase 가 root contributor 1 개 닫음) 모두 회피. Related RFC-0089, RFC-0097, RFC-0108, RFC-0137, RFC-0154. |
-
-## Closed RFC Archive
-
-> Archive of RFCs whose frontmatter `status` is `Implemented` or `Superseded`.
-> Generated from `rg "^status: (Implemented|Superseded)" docs/rfc/`.
-> Last updated: 2026-05-23.
-
-### Implemented
-
-- [RFC-0010 — ocamlformat config reconciliation](RFC-0010-ocamlformat-config-reconciliation.md)
-- [RFC-0071 — Exhaustive Match Sweep Codemod — Eliminate N-of-M `_ -> false/None` Anti-Pattern](RFC-0071-exhaustive-match-sweep-codemod.md)
-- [RFC-0072 — Type-encoded keeper sub-FSM transitions (runtime + turn_phase)](RFC-0072-keeper-sub-fsm-transitions-typed.md)
-- [RFC-0073 — Tool Readiness Probe — Typed Precondition + Runtime Gap Disclosure](RFC-0073-tool-readiness-probe.md)
-- [RFC-0077 — Write-side silent failure — typed propagation](RFC-0077-write-side-silent-failure-typed.md)
-- [RFC-0079 — Log row typed encoder + silent-drop removal](RFC-0079-log-row-typed-encoder.md)
-- [RFC-0080 — Tool registry SSOT — collapse 15-fold OR membership into typed Tool_name boundary](RFC-0080-tool-registry-ssot.md)
-- [RFC-0081 — OAS Telemetry Envelope Context & Keeper/Goal Pivot Timeline](RFC-0081-telemetry-envelope-and-pivot-timeline.md)
-- [RFC-0084 — Keeper→Tool Dispatch Unification + 100% Trace/Telemetry](RFC-0084-keeper-tool-dispatch-unification.md)
-- [RFC-0086 — Keeper namespace bulk promotion to sub-library](RFC-0086-keeper-namespace-bulk-promotion.md)
-- [RFC-0087 — Tool Dispatch Path Unification + Legacy Purge](RFC-0087-tool-dispatch-path-unification-and-legacy-purge.md)
-- [RFC-0089 — String Classifier to Typed Variant — direct replacement, no lint](RFC-0089-string-classifier-to-typed-variant.md)
-- [RFC-0090 — Write-side success-model attribution — finish N-of-M migration](RFC-0090-write-side-success-model-attribution.md)
-- [RFC-0091 — Execute tool: cmd string → typed Argv schema (lexer/validator 박멸)](RFC-0091-execute-typed-argv.md)
-- [RFC-0093 — Board persistence — path unification (snapshot vs append)](RFC-0093-board-persistence-path-unification.md)
-- [RFC-0095 — Provider-D-compat provider streaming wire-up](RFC-0095-provider-d-compat-streaming-wire-up.md)
-- [RFC-0096 — Keeper Turn Contract — multi-turn reasoning + runtime SPOF root-fix](RFC-0096-keeper-turn-contract-multi-turn-and-runtime-spof.md)
-- [RFC-0098 — Typed JSON-RPC error envelope & production-code silent-failure lint](RFC-0098-typed-jsonrpc-error-envelope.md)
-- [RFC-0102 — Pre-turn runtime availability gate — reuse, not new surface](RFC-0102-pre-turn-runtime-availability-gate.md)
-- [RFC-0105 — Provider-D-compat boundary: Agent_sdk.Error.t → HTTP status + typed envelope](RFC-0105-provider-d-compat-typed-error-mapping.md)
-- [RFC-0110 — Tool-pair atomicity at write boundary — sunset compaction repair fabrication](RFC-0110-tool-pair-atomicity-write-boundary.md)
-- [RFC-0111 — Goal mint atomicity — auto-goal uniqueness invariant at write boundary](RFC-0111-goal-mint-atomicity-uniqueness-invariant.md)
-- [RFC-0112 — Typed JSON parse boundary — eliminate silent-drop fallback across read sites](RFC-0112-typed-json-parse-boundary.md)
-- [RFC-0113 — Withdraw KeeperReactionLiveness runtime hierarchy](RFC-0113-keeper-reaction-liveness-runtime.md)
-- [RFC-0114 — KSM event precondition enforcement at apply_event boundary](RFC-0114-ksm-precondition-enforcement.md)
-- [RFC-0115 — KTC turn_phase spec ← runtime parity — backfill spec for Turn_routing / Turn_exhausted](RFC-0115-ktc-turn-phase-spec-runtime-parity.md)
-- [RFC-0116 — KCR fallback cap mechanism parity — explicit counter at spec ↔ visited-list at runtime](RFC-0116-kcr-fallback-cap-mechanism-parity.md)
-- [RFC-0117 — KCR item-health representation parity — typed Degraded variant + spec cooldown action + PerKeeperIsolation correction](RFC-0117-kcr-health-state-representation-parity.md)
-- [RFC-0118 — KCT NoTerminalRuntime S1 — typed Result at select_runtime boundary + Zombie mapping correction](RFC-0118-kct-terminal-runtime-contract.md)
-- [RFC-0119 — Observer spec mapping table drift lint — guard-marker validator for OCaml↔TLA+ collapse projections](RFC-0119-observer-spec-mapping-table-drift-lint.md)
-- [RFC-0122 — Keeper disk pressure — process-local fleet failure mode beyond FD](RFC-0122-keeper-disk-pressure.md)
-- [RFC-0123 — Briefing last_event fabrication — option-typed write boundary](RFC-0123-briefing-last-event-fabrication-write-boundary.md)
-- [RFC-0126 — Silent fallback discipline (typed split for option/result wildcard arms)](RFC-0126-silent-fallback-discipline.md)
-- [RFC-0129 — Runtime attempt idle-cap: kill the reserve_fraction band-aid](RFC-0129-http-idle-timeout-and-streaming-progress.md)
-- [RFC-0131 — Shell Command Gate facade — multi-caller IR-first validation](RFC-0131-shell-command-gate-facade.md)
-- [RFC-0132 — Redaction SSOT — `runtime` boundary-label private type](RFC-0132-redaction-ssot.md)
-- [RFC-0133 — Keeper Phase Casing SSOT Consolidation](RFC-0133-keeper-phase-casing-ssot-consolidation.md)
-- [RFC-0135 — Dashboard Keeper Operational Surface — Typed SSOT](RFC-0135-dashboard-keeper-operational-ssot.md)
-- [RFC-0136 — Keeper Unified Turn — Stage Decomposition of run_keeper_cycle](RFC-0136-keeper-unified-turn-decomposition.md)
-- [RFC-0138 — dashboard snapshot lock free architecture](RFC-0138-dashboard-snapshot-lock-free-architecture.md)
-- [RFC-0140 — Dashboard Wire-Format Codec Layer](RFC-0140-dashboard-wire-codec-layer.md)
-- [RFC-0148 — Typed `tool_error` Variant for LLM-Facing Tool Failure Surface](RFC-0148-typed-tool-error-variant.md)
-- [RFC-0149 — audit telemetry as fix sunset](RFC-0149-audit-telemetry-as-fix-sunset.md)
-- [RFC-0151 — 4-metric monotone-decrease ratchet for code-smell metrics](RFC-0151-code-smell-monotone-ratchet.md)
-- [RFC-0153 — Runtime Backpressure & Tier Admission](RFC-0153-runtime-backpressure-and-admission.md)
-- [RFC-0154 — System_error_class typed SSOT — close substring-classifier loop across backend + telemetry + dashboard](RFC-0154-system-error-class-typed-ssot.md)
-- [RFC-0155 — System_log_category Typed SSOT — emit-side closed sum for ops log taxonomy](RFC-0155-system-log-category-typed-ssot.md)
-
-### Superseded
-
-- RFC-0055 — Runtime Fallback Chain Capability-Tier Routing (file missing; superseded_by 0058 per table above)

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -364,7 +364,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 
 ### 신규 RFC
 
-신규 RFC 는 번호를 발급받지 않는다 (번호 allocator 제거됨 — 전역 카운터 TOCTOU 회피). 의미 있는 slug 파일명 `RFC-<slug>.md` 로 작성한다. 본 표의 번호 인덱스는 기존 번호 RFC 만 추적한다.
+신규 RFC 는 번호를 발급받지 않는다 (번호 allocator 제거됨 — 전역 카운터 TOCTOU 회피). 의미 있는 slug 파일명 `RFC-<slug>.md` 로 작성한다. 본 표는 기존 번호 RFC 와 신규 slug RFC 를 함께 추적한다.
 
 ## 검색 / 발견
 

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -52,7 +52,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0000 | MASC × OAS Consolidated Master Design (SSOT) | Draft | - |
 | 0001 | Withdraw heuristic uncertainty governance | Withdrawn | - |
 | 0002 | Keeper 11-State Machine + Det/NonDet Boundary Formalization | reference | - |
-| 0003 | Withdraw composite lifecycle projection hierarchy | Withdrawn | - |
+| 0003 | Withdraw composite lifecycle projection hierarchy | Withdrawn | RFC-0003-phase-2-turn-observation-lifecycle.md |
 | 0004 | OCaml ↔ TypeScript shared contract — SSE + gRPC-web | Active | - |
 | 0005 | Withdraw the typed command-policy substrate | Withdrawn | - |
 | 0006 | Keeper Surface And Sandbox | Draft | - |
@@ -64,14 +64,14 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0022 | Withdraw MASC attempt budgets and provider demotion | Withdrawn | - |
 | 0024 | Ollama Runtime Integration + KV Cache Optimization | Draft | - |
 | 0025 | Tiered Small-Model Runtime (4B → 9B → 70B+) | Draft | - |
-| 0027 | Retired tension and meta-cognition draft | Superseded | - |
+| 0027 | Withdraw MASC capability profiles (`RFC-0027-capability-typed-runtime.md`)<br>Retired tension and meta-cognition draft (`RFC-0027-tension-type-safety.md`) | Draft<br>Superseded | - |
 | 0029 | Dashboard Fiber-Batched Aggregation | Active | - |
 | 0032 | Environment Knob Unification | Draft | - |
-| 0034 | d — release_stale_claims agent-side sync | Draft | - |
+| 0034 | v2: Withdraw per-Goal Task caps (`RFC-0034-cap-all-callers.md`)<br>Task Oscillation Mitigation (Cooldown + Severe-Level Human Escalation) (`RFC-0034-task-oscillation-mitigation.md`) | Draft<br>Draft | - |
 | 0035 | Cognitive IDE Master Plan Integration | Draft | - |
-| 0036 | oas Cognitive Mapping (companion to RFC-0035) | Draft | - |
-| 0037 | Local-first Keeper Enablement: Harness/User Boundary | Draft | - |
-| 0038 | Withdraw MASC capability-routing plan | Withdrawn | RFC-0038-phase-2-keeper-identity-canonical.md |
+| 0036 | Multi-Keeper Docker Orchestration & Lifecycle Cleanup (`RFC-0036-multi-keeper-docker-orchestration.md`)<br>oas Cognitive Mapping (companion to RFC-0035) (`RFC-0036-oas-cognitive-mapping.md`) | Draft<br>Draft | - |
+| 0037 | Board Multimedia & Vision — Eio/File-Based Adaptation (`RFC-0037-board-multimedia-vision-adapted.md`)<br>Local-first Keeper Enablement: Harness/User Boundary (`RFC-0037-local-first-keeper-enablement-boundary.md`) | Draft<br>Draft | - |
+| 0038 | Opaque Identifier Types for Provider, Runtime, Model (`RFC-0038-opaque-identifier-types.md`)<br>Withdraw MASC capability-routing plan (`RFC-0038-runtime-routing-intent-preservation.md`) | Draft<br>Withdrawn | RFC-0038-phase-2-keeper-identity-canonical.md |
 | 0041 | Withdraw runtime group/item hierarchy | Withdrawn | - |
 | 0042 | Withdraw Keeper terminal-reason hierarchy | Withdrawn | - |
 | 0043 | Distribute legacy metrics backend metric ownership to domain modules | Active | - |
@@ -90,7 +90,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0058 | Withdraw terminal capability hierarchy | Withdrawn | RFC-0058-phase-5-erase-provider-variant.md |
 | 0062 | Typed `Tool_result.t` + Typed `Sdk_*` Blocker Class (Reverse-Engineered Initi... | Draft | - |
 | 0063 | Telemetry Feedback Loop & Cooperative Scheduling Safety | Draft | - |
-| 0064 | Descriptor-Owned Tool Surface | Superseded | - |
+| 0064 | Capacity Probe Adapter (`RFC-0064-capacity-probe-adapter.md`)<br>Descriptor-Owned Tool Surface (`RFC-0064-two-surface-tool-alias.md`) | Active<br>Superseded | - |
 | 0065 | Withdraw policy-bearing tool-selection model | Withdrawn | - |
 | 0067 | Goal-Scope Observation→Claim Atomicity | Draft | - |
 | 0068 | Withdraw operator disposition hierarchy | Withdrawn | - |
@@ -129,8 +129,8 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0104 | Withdraw Task-to-repository authorization | Withdrawn | - |
 | 0105 | OpenAI-compat boundary: Agent_sdk.Error.t → HTTP status + typed envelope | Implemented | - |
 | 0106 | Cancel-safe try-with discipline (Eio.Cancel.Cancelled propagation) | Active | - |
-| 0107 | Outbound HTTP stack consolidation — pooled keep-alive, scoped Switch, Docker ... | Active | - |
-| 0108 | PR / Worktree Operation Safety Gates | Implemented | - |
+| 0107 | Phase C.0 — `Eio_context.get_switch_opt` global access audit (`RFC-0107-eio-context-switch-audit.md`)<br>Outbound HTTP stack consolidation — pooled keep-alive, scoped Switch, Docker ... (`RFC-0107-outbound-http-stack-consolidation.md`) | Evidence<br>Active | RFC-0107-phase-d-pool-design.md |
+| 0108 | Atomic JSONL Append (in-process) (`RFC-0108-atomic-jsonl-append.md`)<br>PR / Worktree Operation Safety Gates (`RFC-0108-pr-worktree-operation-safety-gates.md`) | Active<br>Implemented | - |
 | 0109 | CDAL x Goal Integration Contract | Withdrawn | - |
 | 0110 | Tool-pair atomicity at write boundary — sunset compaction repair fabrication | Superseded | - |
 | 0111 | Goal mint atomicity — auto-goal uniqueness invariant at write boundary | Implemented | - |
@@ -154,7 +154,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0132 | Redaction SSOT — `runtime` boundary-label private type | Implemented | - |
 | 0134 | Persistence read-drop root fix (recovery story for RFC-0044) | Active | - |
 | 0135 | Supersede dashboard-derived Keeper disposition | Superseded | - |
-| 0136 | Keeper Unified Turn — Stage Decomposition of run_keeper_cycle | Implemented | - |
+| 0136 | Keeper Unified Turn — Stage Decomposition of run_keeper_cycle | Implemented | RFC-0136-phase-4-retry-loop.md |
 | 0137 | Host FD pressure observation — retired Keeper-pause proposal | Retired | - |
 | 0138 | Dashboard Snapshot Lock-Free Immutable Architecture | Implemented | - |
 | 0139 | Withdraw parallel agent and judge status hierarchies | Withdrawn | - |
@@ -237,17 +237,17 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0232 | Typed lane event model: parse at the write boundary, never re-derive by strin... | Draft | - |
 | 0233 | Typed turn observability: TurnRecord prompt-block provenance + canonical tool... | Draft | - |
 | 0234 | Withdraw schedule-specific approval hierarchy | Withdrawn | - |
-| 0235 | Voice output transport: browser-addressed audio delivery with device-routed p... | Draft | - |
+| 0235 | Stale-base revert guard: block PRs that silently revert recently-merged work (`RFC-0235-stale-base-revert-guard.md`)<br>Voice output transport: browser-addressed audio delivery with device-routed p... (`RFC-0235-voice-output-browser-transport-device-routing.md`) | Draft<br>Draft | - |
 | 0236 | Voice input transport: browser-captured speech-to-text for the dashboard comp... | Draft | - |
 | 0237 | Eliminate the write_meta ~force escape hatch (route snapshot writes through C... | Draft | - |
-| 0239 | Supersede no-progress pause and semantic debounce guards | Superseded | - |
+| 0239 | Concurrency ownership model (per-site mutex/atomic → protection by construction) (`RFC-0239-concurrency-ownership-model.md`)<br>Supersede no-progress pause and semantic debounce guards (`RFC-0239-semantic-identity-guards-for-keeper-memory-and-anti-thrash.md`) | Draft<br>Superseded | - |
 | 0240 | Tool-pair invariant enforced at write-time (eliminate repair-on-read) | Draft | - |
 | 0241 | external-attention store lifecycle: read-side bound, retention, and typed tai... | Retired | - |
 | 0242 | Retired continuity prose-filter draft | Superseded | - |
 | 0243 | Memory OS confidence mutability via write-side fact upsert | Draft | - |
 | 0244 | Memory OS recall: turn-seeded deterministic lexical retrieval, with provenanc... | Superseded | - |
 | 0245 | Exempt goalless tasks from the per-goal WIP claim cap | Withdrawn | - |
-| 0247 | Memory OS purge + LLM-judgment rebuild — implementation plan (phase of RFC-0247) | Draft | - |
+| 0247 | Memory OS as a brain: typed associative graph, spreading-activation recall, s... (`RFC-0247-memory-os-associative-graph-forgetting-brain.md`)<br>Memory OS purge + LLM-judgment rebuild — implementation plan (phase of RFC-0247) (`RFC-0247-purge-implementation-plan.md`) | Draft<br>Draft | - |
 | 0248 | Board context without local authority classification | Draft | - |
 | 0249 | Remove the dead `stale_factor` field (execute RFC-0239/0243/0244/0247) | Draft | - |
 | 0251 | Memory OS: record well, do not value — remove the scoring layer | Draft | - |
@@ -281,7 +281,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0281 | WebSocket transport SSOT — separate upgrade-attachment from session-protocol,... | Draft | - |
 | 0282 | Reduce Keeper persona to ordinary instructions | Implemented | - |
 | 0283 | Fusion: judge-of-judges 위상 (flat/staged reducer) | Draft | - |
-| 0284 | Supersede command-semantics guidance guards | Superseded | - |
+| 0284 | Fusion 심판 실행 관측 record (judge observation record) (`RFC-0284-fusion-judge-observation-record.md`)<br>Goal-loop status SSE liveness — server-side change detection extends the goal... (`RFC-0284-goal-loop-sse-liveness.md`)<br>Supersede command-semantics guidance guards (`RFC-0284-keeper-guidance-visibility-drift-guard.md`) | Draft<br>Superseded — RFC-0352 Path B (2026-07-21). The goal-loop OODA<br>Superseded | - |
 | 0285 | Memory OS — Self-Observation Claim Volatility (closing RFC-0259's internal-st... | Draft | - |
 | 0286 | Superseded exec and Keeper boundary diagnosis | Superseded | - |
 | 0287 | ws-direct — a single masc-owned WebSocket stack for server and client | Draft | - |
@@ -342,15 +342,6 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0353 | 실패 분류가 모듈 경계에서 소실되는 결함 (결정 요청) | Draft | - |
 | 0356 | Approval owns the effect (replay the approved payload, do not require byte-id... | Draft | - |
 | 0357 | Scheduled-autonomous 턴은 heartbeat가 아니라 typed stimulus의 변화로 admit한다 | Draft | - |
-| asyn | Offload the structured-log durable append off the emitting fiber | Draft | - |
-| chec | Immutable boot-pinned root capability for checkpoint containment | Draft | - |
-| comp | Compaction must never deadlock: a deterministic structural floor, typed outco... | Draft | - |
-| conn | Durable Keeper chat receipts and connector delivery settlement | Active | - |
-| elim | Withdrawn command-policy classification experiment | Withdrawn | - |
-| keep | Vision-as-a-tool delegation (decouple multimodal input from conversation runt... | Draft | - |
-| memo | # RFC: Memory OS 2.0 — bounded working set 전송 계약과 librarian curator 계약 | Draft | - |
-| runt | Per-runtime note field & dashboard surfacing | Draft | - |
-| type | Withdraw product-specific egress effect classification | Withdrawn | - |
 
 ### 신규 RFC
 

--- a/docs/rfc/RFC-0133-keeper-phase-casing-ssot-consolidation.md
+++ b/docs/rfc/RFC-0133-keeper-phase-casing-ssot-consolidation.md
@@ -1,5 +1,5 @@
 ---
-rfc: "0132"
+rfc: "0133"
 title: "Keeper Phase Casing SSOT Consolidation"
 status: Implemented
 created: 2026-05-19

--- a/scripts/rfc-generate-index.py
+++ b/scripts/rfc-generate-index.py
@@ -19,22 +19,16 @@ RFC_DIR = Path("docs/rfc")
 README = RFC_DIR / "README.md"
 TABLE_HEADER = "| RFC | Title | Status | Sub-docs |"
 TABLE_SEP = "|---|---|---|---|"
-RFC_NUMBERED_FILE_RE = re.compile(
-    r"^RFC-(?P<number>\d{4})-(?P<slug>.+)\.md$"
-)
+RFC_NUMBERED_FILE_RE = re.compile(r"^RFC-(?P<number>\d{4})-(?P<slug>.+)\.md$")
 RFC_PHASE_FILE_RE = re.compile(
     r"^RFC-(?P<number>\d{4})-phase-(?P<phase>[A-Za-z0-9]+)-"
     r"(?P<slug>.+)\.md$"
 )
-RFC_SLUG_FILE_RE = re.compile(
-    r"^RFC-(?P<slug>[a-z0-9]+(?:-[a-z0-9]+)*)\.md$"
-)
+RFC_SLUG_FILE_RE = re.compile(r"^RFC-(?P<slug>[a-z0-9]+(?:-[a-z0-9]+)*)\.md$")
 RFC_REFERENCE_RE = re.compile(
     r"^(?:RFC-)?(?P<number>\d{4})(?:-phase-(?P<phase>[A-Za-z0-9]+))?$"
 )
-RFC_REFERENCE_SLUG_RE = re.compile(
-    r"^(?:RFC-)?(?P<slug>[a-z0-9]+(?:-[a-z0-9]+)*)$"
-)
+RFC_REFERENCE_SLUG_RE = re.compile(r"^(?:RFC-)?(?P<slug>[a-z0-9]+(?:-[a-z0-9]+)*)$")
 
 
 @dataclass(frozen=True)
@@ -135,11 +129,9 @@ def parse_file_identity(name: str) -> FileIdentity:
             phase=None,
         )
 
-    # Existing RFC files predate the current filename contract. Keep their
-    # exact filename visible instead of dropping or reinterpreting it.
-    stem = name.removeprefix("RFC-").removesuffix(".md")
-    return FileIdentity(
-        key=f"legacy:{stem}", display_key=stem, number=None, slug=None, phase=None
+    raise ValueError(
+        f"{name}: filename must use RFC-NNNN-<slug>.md, "
+        "RFC-NNNN-phase-<phase>-<slug>.md, or RFC-<slug>.md"
     )
 
 
@@ -185,7 +177,9 @@ def relation_parent(
         parents.add(identity.number)
 
     if len(parents) > 1:
-        issues.append(f"{filename}: conflicting sub-document parents: {sorted(parents)}")
+        issues.append(
+            f"{filename}: conflicting sub-document parents: {sorted(parents)}"
+        )
     parent = next(iter(parents), None)
     if parent is not None and identity.number != parent:
         issues.append(
@@ -228,7 +222,11 @@ def collect_entries() -> tuple[dict[str, RfcEntry], list[str]]:
     for fpath in sorted(RFC_DIR.glob("RFC-*.md")):
         name = fpath.name
         fm = extract_frontmatter(fpath)
-        identity = parse_file_identity(name)
+        try:
+            identity = parse_file_identity(name)
+        except ValueError as error:
+            issues.append(str(error))
+            continue
         parent, relation_issues = relation_parent(identity, fm, name)
         issues.extend(relation_issues)
         entry_key = f"number:{parent}" if parent is not None else identity.key

--- a/scripts/rfc-generate-index.py
+++ b/scripts/rfc-generate-index.py
@@ -17,10 +17,24 @@ from pathlib import Path
 
 RFC_DIR = Path("docs/rfc")
 README = RFC_DIR / "README.md"
-TABLE_HEADER = "| # | Title | Status | Sub-docs |"
+TABLE_HEADER = "| RFC | Title | Status | Sub-docs |"
 TABLE_SEP = "|---|---|---|---|"
-RFC_FILE_RE = re.compile(r"^RFC-(\d{4})-.+\.md$")
-RFC_PHASE_FILE_RE = re.compile(r"^RFC-(\d{4})-phase-.+\.md$")
+RFC_NUMBERED_FILE_RE = re.compile(
+    r"^RFC-(?P<number>\d{4})-(?P<slug>.+)\.md$"
+)
+RFC_PHASE_FILE_RE = re.compile(
+    r"^RFC-(?P<number>\d{4})-phase-(?P<phase>[A-Za-z0-9]+)-"
+    r"(?P<slug>.+)\.md$"
+)
+RFC_SLUG_FILE_RE = re.compile(
+    r"^RFC-(?P<slug>[a-z0-9]+(?:-[a-z0-9]+)*)\.md$"
+)
+RFC_REFERENCE_RE = re.compile(
+    r"^(?:RFC-)?(?P<number>\d{4})(?:-phase-(?P<phase>[A-Za-z0-9]+))?$"
+)
+RFC_REFERENCE_SLUG_RE = re.compile(
+    r"^(?:RFC-)?(?P<slug>[a-z0-9]+(?:-[a-z0-9]+)*)$"
+)
 
 
 @dataclass(frozen=True)
@@ -32,9 +46,27 @@ class RfcDocument:
 
 @dataclass
 class RfcEntry:
-    number: str
+    key: str
+    display_key: str
+    is_numeric: bool
     documents: list[RfcDocument] = field(default_factory=list)
-    sub_docs: list[str] = field(default_factory=list)
+    sub_docs: list[RfcDocument] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class RfcReference:
+    number: str | None
+    slug: str | None
+    phase: str | None
+
+
+@dataclass(frozen=True)
+class FileIdentity:
+    key: str
+    display_key: str
+    number: str | None
+    slug: str | None
+    phase: str | None
 
 
 def extract_frontmatter(filepath: Path) -> dict[str, str]:
@@ -54,53 +86,186 @@ def extract_frontmatter(filepath: Path) -> dict[str, str]:
     return result
 
 
-def collect_entries() -> dict[str, RfcEntry]:
+def parse_reference(raw: str) -> RfcReference | None:
+    value = raw.strip().strip('"').strip("'")
+    numeric = RFC_REFERENCE_RE.fullmatch(value)
+    if numeric is not None:
+        return RfcReference(
+            number=numeric.group("number"),
+            slug=None,
+            phase=numeric.group("phase"),
+        )
+    slug = RFC_REFERENCE_SLUG_RE.fullmatch(value)
+    if slug is not None:
+        return RfcReference(number=None, slug=slug.group("slug"), phase=None)
+    return None
+
+
+def parse_file_identity(name: str) -> FileIdentity:
+    phase = RFC_PHASE_FILE_RE.fullmatch(name)
+    if phase is not None:
+        number = phase.group("number")
+        return FileIdentity(
+            key=f"number:{number}",
+            display_key=number,
+            number=number,
+            slug=None,
+            phase=phase.group("phase"),
+        )
+
+    numbered = RFC_NUMBERED_FILE_RE.fullmatch(name)
+    if numbered is not None:
+        number = numbered.group("number")
+        return FileIdentity(
+            key=f"number:{number}",
+            display_key=number,
+            number=number,
+            slug=None,
+            phase=None,
+        )
+
+    slug = RFC_SLUG_FILE_RE.fullmatch(name)
+    if slug is not None:
+        value = slug.group("slug")
+        return FileIdentity(
+            key=f"slug:{value}",
+            display_key=f"RFC-{value}",
+            number=None,
+            slug=value,
+            phase=None,
+        )
+
+    # Existing RFC files predate the current filename contract. Keep their
+    # exact filename visible instead of dropping or reinterpreting it.
+    stem = name.removeprefix("RFC-").removesuffix(".md")
+    return FileIdentity(
+        key=f"legacy:{stem}", display_key=stem, number=None, slug=None, phase=None
+    )
+
+
+def relation_parent(
+    identity: FileIdentity, frontmatter: dict[str, str], filename: str
+) -> tuple[str | None, list[str]]:
+    issues: list[str] = []
+    parents: set[str] = set()
+
+    raw_rfc = frontmatter.get("rfc")
+    if raw_rfc is not None:
+        reference = parse_reference(raw_rfc)
+        if reference is None:
+            issues.append(f"{filename}: invalid frontmatter rfc: {raw_rfc!r}")
+        elif identity.number is not None:
+            if reference.number != identity.number:
+                issues.append(
+                    f"{filename}: frontmatter rfc {raw_rfc!r} does not match "
+                    f"filename RFC-{identity.number}"
+                )
+        elif identity.slug is None or reference.slug != identity.slug:
+            issues.append(
+                f"{filename}: frontmatter rfc {raw_rfc!r} does not match "
+                f"filename {identity.display_key}"
+            )
+        if reference is not None:
+            if reference.number is not None and reference.phase is not None:
+                parents.add(reference.number)
+
+    for field_name in ("extends", "supplement_of"):
+        raw_parent = frontmatter.get(field_name)
+        if raw_parent is None:
+            continue
+        reference = parse_reference(raw_parent)
+        if reference is None or reference.number is None:
+            issues.append(
+                f"{filename}: {field_name} must name a numbered RFC: {raw_parent!r}"
+            )
+        else:
+            parents.add(reference.number)
+
+    if identity.number is not None and identity.phase is not None:
+        parents.add(identity.number)
+
+    if len(parents) > 1:
+        issues.append(f"{filename}: conflicting sub-document parents: {sorted(parents)}")
+    parent = next(iter(parents), None)
+    if parent is not None and identity.number != parent:
+        issues.append(
+            f"{filename}: sub-document parent RFC-{parent} does not match "
+            f"filename identity {identity.display_key}"
+        )
+    return parent, issues
+
+
+def document_for(filepath: Path, frontmatter: dict[str, str]) -> RfcDocument:
+    title = frontmatter.get("title", "")
+    if not title:
+        first_line = ""
+        lines = filepath.read_text(encoding="utf-8").splitlines()
+        in_frontmatter = bool(lines and lines[0].strip() == "---")
+        for index, line in enumerate(lines):
+            if index > 0 and line.strip() == "---" and in_frontmatter:
+                in_frontmatter = False
+                continue
+            if in_frontmatter:
+                continue
+            if line.startswith("# "):
+                first_line = line
+                break
+        title = re.sub(r"^# RFC[- ]*\d+[.: —–-]*\s*", "", first_line)
+        if not title:
+            title = "(untitled)"
+
+    return RfcDocument(
+        filename=filepath.name,
+        title=title,
+        status=frontmatter.get("status", "Draft"),
+    )
+
+
+def collect_entries() -> tuple[dict[str, RfcEntry], list[str]]:
     entries: dict[str, RfcEntry] = {}
+    issues: list[str] = []
 
     for fpath in sorted(RFC_DIR.glob("RFC-*.md")):
         name = fpath.name
-        match = RFC_FILE_RE.fullmatch(name)
-        if match is None:
-            print(
-                f"WARN: skipped noncanonical RFC filename: {name}",
-                file=sys.stderr,
-            )
-            continue
-        num = match.group(1)
-        entry = entries.setdefault(num, RfcEntry(number=num))
-
-        if RFC_PHASE_FILE_RE.fullmatch(name) is not None:
-            entry.sub_docs.append(name)
-            continue
-
         fm = extract_frontmatter(fpath)
-        title = fm.get("title", "")
-        if not title:
-            first_line = ""
-            for line in fpath.read_text(encoding="utf-8").splitlines():
-                if line.startswith("# "):
-                    first_line = line
-                    break
-            title = re.sub(r"^# RFC[- ]*\d+[.: —–-]*\s*", "", first_line)
-            if not title:
-                title = "(untitled)"
-
-        entry.documents.append(
-            RfcDocument(
-                filename=name,
-                title=title,
-                status=fm.get("status", "Draft"),
-            )
+        identity = parse_file_identity(name)
+        parent, relation_issues = relation_parent(identity, fm, name)
+        issues.extend(relation_issues)
+        entry_key = f"number:{parent}" if parent is not None else identity.key
+        entry = entries.setdefault(
+            entry_key,
+            RfcEntry(
+                key=entry_key,
+                display_key=identity.display_key if parent is None else parent,
+                is_numeric=identity.number is not None or parent is not None,
+            ),
         )
+        document = document_for(fpath, fm)
 
-    return entries
+        if parent is not None:
+            entry.sub_docs.append(document)
+            continue
+
+        entry.documents.append(document)
+
+    for entry in entries.values():
+        entry.documents.sort(key=lambda document: document.filename)
+        entry.sub_docs.sort(key=lambda document: document.filename)
+
+    return entries, issues
 
 
 def generate_table(entries: dict[str, RfcEntry]) -> str:
     lines = [TABLE_HEADER, TABLE_SEP]
-    for num in sorted(entries):
-        e = entries[num]
+    ordered_entries = sorted(
+        entries.values(), key=lambda entry: (not entry.is_numeric, entry.key)
+    )
+    for e in ordered_entries:
         if not e.documents:
+            title = "(missing main document)"
+            status = "Invalid"
+            subs = ", ".join(document.filename for document in e.sub_docs) or "-"
+            lines.append(f"| {e.display_key} | {title} | {status} | {subs} |")
             continue
 
         duplicate_number = len(e.documents) > 1
@@ -115,8 +280,16 @@ def generate_table(entries: dict[str, RfcEntry]) -> str:
 
         title = "<br>".join(rendered_titles)
         status = "<br>".join(document.status for document in e.documents)
-        subs = ", ".join(e.sub_docs) if e.sub_docs else "-"
-        lines.append(f"| {num} | {title} | {status} | {subs} |")
+        rendered_sub_docs: list[str] = []
+        for document in e.sub_docs:
+            sub_title = document.title
+            if len(sub_title) > 80:
+                sub_title = sub_title[:77] + "..."
+            rendered_sub_docs.append(
+                f"{sub_title} (`{document.filename}`, {document.status})"
+            )
+        subs = "<br>".join(rendered_sub_docs) if rendered_sub_docs else "-"
+        lines.append(f"| {e.display_key} | {title} | {status} | {subs} |")
     return "\n".join(lines)
 
 
@@ -169,7 +342,11 @@ def main() -> int:
             check=True,
         ).stdout.strip()
     )
-    entries = collect_entries()
+    entries, issues = collect_entries()
+    if issues:
+        for issue in issues:
+            print(f"ERROR: {issue}", file=sys.stderr)
+        return 1
     table = generate_table(entries)
 
     if "--check" in sys.argv:

--- a/scripts/rfc-generate-index.py
+++ b/scripts/rfc-generate-index.py
@@ -6,6 +6,7 @@ Usage:
   scripts/rfc-generate-index.py --check       # exit 1 if stale
   scripts/rfc-generate-index.py --update      # overwrite README table
 """
+
 from __future__ import annotations
 
 import re
@@ -16,8 +17,8 @@ from pathlib import Path
 
 RFC_DIR = Path("docs/rfc")
 README = RFC_DIR / "README.md"
-TABLE_HEADER = "| # | Title | Status | Last activity | Sub-docs |"
-TABLE_SEP = "|---|---|---|---|---|"
+TABLE_HEADER = "| # | Title | Status | Sub-docs |"
+TABLE_SEP = "|---|---|---|---|"
 
 
 @dataclass
@@ -25,7 +26,6 @@ class RfcEntry:
     number: str
     title: str = "(untitled)"
     status: str = "Draft"
-    last_activity: str = "-"
     sub_docs: list[str] = field(default_factory=list)
 
 
@@ -44,17 +44,6 @@ def extract_frontmatter(filepath: Path) -> dict[str, str]:
             key, _, value = stripped.partition(":")
             result[key.strip()] = value.strip().strip('"')
     return result
-
-
-def last_git_activity(filepath: Path) -> str:
-    try:
-        result = subprocess.run(
-            ["git", "log", "-1", "--format=%h %cs", "--", str(filepath)],
-            capture_output=True, text=True, check=False,
-        )
-        return result.stdout.strip() or "(untracked)"
-    except Exception:
-        return "-"
 
 
 def collect_entries() -> dict[str, RfcEntry]:
@@ -85,7 +74,6 @@ def collect_entries() -> dict[str, RfcEntry]:
             number=num,
             title=title,
             status=fm.get("status", "Draft"),
-            last_activity=last_git_activity(fpath),
             sub_docs=sub_docs.get(num, []),
         )
 
@@ -100,7 +88,7 @@ def generate_table(entries: dict[str, RfcEntry]) -> str:
         if len(title) > 80:
             title = title[:77] + "..."
         subs = ", ".join(e.sub_docs) if e.sub_docs else "-"
-        lines.append(f"| {num} | {title} | {e.status} | {e.last_activity} | {subs} |")
+        lines.append(f"| {num} | {title} | {e.status} | {subs} |")
     return "\n".join(lines)
 
 
@@ -117,10 +105,12 @@ def check_mode(table: str) -> int:
     if existing == table:
         print("OK: RFC index table is up to date")
         return 0
-    print("MISMATCH: RFC index table is stale. Run: scripts/rfc-generate-index.py --update")
+    print(
+        "MISMATCH: RFC index table is stale. Run: scripts/rfc-generate-index.py --update"
+    )
     for i, (a, b) in enumerate(zip(existing.splitlines(), table.splitlines())):
         if a != b:
-            print(f"  line {i+1}: {a!r} != {b!r}")
+            print(f"  line {i + 1}: {a!r} != {b!r}")
     return 1
 
 
@@ -142,9 +132,15 @@ def update_mode(table: str) -> int:
 
 def main() -> int:
     import os
-    os.chdir(subprocess.run(["git", "rev-parse", "--show-toplevel"],
-                            capture_output=True, text=True, check=True
-                            ).stdout.strip())
+
+    os.chdir(
+        subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    )
     entries = collect_entries()
     table = generate_table(entries)
 

--- a/scripts/rfc-generate-index.py
+++ b/scripts/rfc-generate-index.py
@@ -20,6 +20,7 @@ README = RFC_DIR / "README.md"
 TABLE_HEADER = "| # | Title | Status | Sub-docs |"
 TABLE_SEP = "|---|---|---|---|"
 RFC_FILE_RE = re.compile(r"^RFC-(\d{4})-.+\.md$")
+RFC_PHASE_FILE_RE = re.compile(r"^RFC-(\d{4})-phase-.+\.md$")
 
 
 @dataclass(frozen=True)
@@ -60,11 +61,15 @@ def collect_entries() -> dict[str, RfcEntry]:
         name = fpath.name
         match = RFC_FILE_RE.fullmatch(name)
         if match is None:
+            print(
+                f"WARN: skipped noncanonical RFC filename: {name}",
+                file=sys.stderr,
+            )
             continue
         num = match.group(1)
         entry = entries.setdefault(num, RfcEntry(number=num))
 
-        if "-phase-" in name:
+        if RFC_PHASE_FILE_RE.fullmatch(name) is not None:
             entry.sub_docs.append(name)
             continue
 

--- a/scripts/rfc-generate-index.py
+++ b/scripts/rfc-generate-index.py
@@ -19,13 +19,20 @@ RFC_DIR = Path("docs/rfc")
 README = RFC_DIR / "README.md"
 TABLE_HEADER = "| # | Title | Status | Sub-docs |"
 TABLE_SEP = "|---|---|---|---|"
+RFC_FILE_RE = re.compile(r"^RFC-(\d{4})-.+\.md$")
+
+
+@dataclass(frozen=True)
+class RfcDocument:
+    filename: str
+    title: str
+    status: str
 
 
 @dataclass
 class RfcEntry:
     number: str
-    title: str = "(untitled)"
-    status: str = "Draft"
+    documents: list[RfcDocument] = field(default_factory=list)
     sub_docs: list[str] = field(default_factory=list)
 
 
@@ -48,14 +55,17 @@ def extract_frontmatter(filepath: Path) -> dict[str, str]:
 
 def collect_entries() -> dict[str, RfcEntry]:
     entries: dict[str, RfcEntry] = {}
-    sub_docs: dict[str, list[str]] = {}
 
     for fpath in sorted(RFC_DIR.glob("RFC-*.md")):
         name = fpath.name
-        num = name[4:8]
+        match = RFC_FILE_RE.fullmatch(name)
+        if match is None:
+            continue
+        num = match.group(1)
+        entry = entries.setdefault(num, RfcEntry(number=num))
 
         if "-phase-" in name:
-            sub_docs.setdefault(num, []).append(name)
+            entry.sub_docs.append(name)
             continue
 
         fm = extract_frontmatter(fpath)
@@ -70,11 +80,12 @@ def collect_entries() -> dict[str, RfcEntry]:
             if not title:
                 title = "(untitled)"
 
-        entries[num] = RfcEntry(
-            number=num,
-            title=title,
-            status=fm.get("status", "Draft"),
-            sub_docs=sub_docs.get(num, []),
+        entry.documents.append(
+            RfcDocument(
+                filename=name,
+                title=title,
+                status=fm.get("status", "Draft"),
+            )
         )
 
     return entries
@@ -84,11 +95,23 @@ def generate_table(entries: dict[str, RfcEntry]) -> str:
     lines = [TABLE_HEADER, TABLE_SEP]
     for num in sorted(entries):
         e = entries[num]
-        title = e.title
-        if len(title) > 80:
-            title = title[:77] + "..."
+        if not e.documents:
+            continue
+
+        duplicate_number = len(e.documents) > 1
+        rendered_titles: list[str] = []
+        for document in e.documents:
+            title = document.title
+            if len(title) > 80:
+                title = title[:77] + "..."
+            if duplicate_number:
+                title = f"{title} (`{document.filename}`)"
+            rendered_titles.append(title)
+
+        title = "<br>".join(rendered_titles)
+        status = "<br>".join(document.status for document in e.documents)
         subs = ", ".join(e.sub_docs) if e.sub_docs else "-"
-        lines.append(f"| {num} | {title} | {e.status} | {subs} |")
+        lines.append(f"| {num} | {title} | {status} | {subs} |")
     return "\n".join(lines)
 
 


### PR DESCRIPTION
## Summary

Fix the cause of RFC index drift before adding the CI check.

- remove merge-topology-dependent commit SHA/date from the generated table
- delete the orphaned hand-maintained rows and stale 2026-05-23 Closed RFC Archive
- run `rfc-generate-index.py --check` in the RFC enforcer workflow
- trigger the workflow when the generator or workflow itself changes

A PR-only check over the previous `Last activity` column was insufficient: it could pass for a branch commit and become stale immediately when GitHub created the merge commit. The generated table now depends only on RFC file contents.

## Verification

- `python3 scripts/rfc-generate-index.py --check`
- intentional row mismatch: check exits 1 with the exact changed row
- `pyright --outputjson scripts/rfc-generate-index.py`
- `ruff check scripts/rfc-generate-index.py`
- `ruff format --check scripts/rfc-generate-index.py`
- `python3 scripts/ci/check-yaml-syntax.py`
- `git diff --check`

Closes #26676