### PR TITLE
fix(verification): hard-cut structured evidence failures

### DIFF
--- a/lib/workspace/workspace_verification_store.ml
+++ b/lib/workspace/workspace_verification_store.ml
@@ -11,7 +11,6 @@ type evidence_read_failure =
   | Evidence_missing
   | Evidence_not_regular_file
   | Evidence_outside_worker_playground
-  | Evidence_invalid_reference
   | Evidence_invalid_utf8
   | Evidence_symbolic_link
   | Evidence_changed_during_read
@@ -26,6 +25,7 @@ type submitted_evidence_item =
       ; truncated : bool
       ; content_sha256 : string
       }
+  | Evidence_invalid_reference
   | Evidence_artifact_unreadable of
       { reference : string
       ; reason : evidence_read_failure
@@ -53,7 +53,6 @@ let evidence_read_failure_to_string = function
   | Evidence_missing -> "missing"
   | Evidence_not_regular_file -> "not_regular_file"
   | Evidence_outside_worker_playground -> "outside_worker_playground"
-  | Evidence_invalid_reference -> "invalid_reference"
   | Evidence_invalid_utf8 -> "invalid_utf8"
   | Evidence_symbolic_link -> "symbolic_link"
   | Evidence_changed_during_read -> "changed_during_read"
@@ -63,30 +62,40 @@ let evidence_read_failure_code = function
   | Evidence_missing -> "missing"
   | Evidence_not_regular_file -> "not_regular_file"
   | Evidence_outside_worker_playground -> "outside_worker_playground"
-  | Evidence_invalid_reference -> "invalid_reference"
   | Evidence_invalid_utf8 -> "invalid_utf8"
   | Evidence_symbolic_link -> "symbolic_link"
   | Evidence_changed_during_read -> "changed_during_read"
   | Evidence_read_error _ -> "read_error"
 
-let evidence_read_failure_of_string = function
-  | "missing" -> Ok Evidence_missing
-  | "not_regular_file" -> Ok Evidence_not_regular_file
-  | "outside_worker_playground" -> Ok Evidence_outside_worker_playground
-  | "invalid_reference" -> Ok Evidence_invalid_reference
-  | "invalid_utf8" -> Ok Evidence_invalid_utf8
-  | "symbolic_link" -> Ok Evidence_symbolic_link
-  | "changed_during_read" -> Ok Evidence_changed_during_read
-  | raw when String.starts_with ~prefix:"read_error:" raw ->
-    Ok
-      (Evidence_read_error
-         (String.sub raw 11 (String.length raw - 11)))
-  | raw -> Error (Printf.sprintf "unknown evidence read failure %S" raw)
+let evidence_read_failure_to_yojson reason =
+  match reason with
+  | Evidence_read_error detail ->
+    `Assoc [ "code", `String "read_error"; "detail", `String detail ]
+  | ( Evidence_missing
+    | Evidence_not_regular_file
+    | Evidence_outside_worker_playground
+    | Evidence_invalid_utf8
+    | Evidence_symbolic_link
+    | Evidence_changed_during_read ) ->
+    `Assoc [ "code", `String (evidence_read_failure_code reason) ]
+
+let evidence_read_failure_of_yojson = function
+  | `Assoc fields ->
+    (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
+     | [ "code", `String "missing" ] -> Ok Evidence_missing
+     | [ "code", `String "not_regular_file" ] -> Ok Evidence_not_regular_file
+     | [ "code", `String "outside_worker_playground" ] ->
+       Ok Evidence_outside_worker_playground
+     | [ "code", `String "invalid_utf8" ] -> Ok Evidence_invalid_utf8
+     | [ "code", `String "symbolic_link" ] -> Ok Evidence_symbolic_link
+     | [ "code", `String "changed_during_read" ] -> Ok Evidence_changed_during_read
+     | [ "code", `String "read_error"; "detail", `String detail ] ->
+       Ok (Evidence_read_error detail)
+     | _ -> Error "submitted evidence snapshot has an invalid unreadable reason")
+  | _ -> Error "submitted evidence snapshot unreadable reason must be an object"
 
 let content_sha256 content =
   Digestif.SHA256.(digest_string content |> to_hex)
-
-let redacted_invalid_reference = "<redacted-invalid-reference>"
 
 let submitted_evidence_item_to_yojson = function
   | Evidence_note note ->
@@ -101,25 +110,17 @@ let submitted_evidence_item_to_yojson = function
       ; "truncated", `Bool truncated
       ; "content_sha256", `String content_sha256
       ]
+  | Evidence_invalid_reference ->
+    `Assoc
+      [ "kind", `String "artifact_unreadable"
+      ; "reason", `Assoc [ "code", `String "invalid_reference" ]
+      ]
   | Evidence_artifact_unreadable { reference; reason } ->
-    (match reason with
-     | Evidence_invalid_reference ->
-       `Assoc
-         [ "kind", `String "artifact_unreadable"
-         ; "reason", `String (evidence_read_failure_code reason)
-         ]
-     | ( Evidence_missing
-       | Evidence_not_regular_file
-       | Evidence_outside_worker_playground
-       | Evidence_invalid_utf8
-       | Evidence_symbolic_link
-       | Evidence_changed_during_read
-       | Evidence_read_error _ ) ->
-       `Assoc
-         [ "kind", `String "artifact_unreadable"
-         ; "reference", `String reference
-         ; "reason", `String (evidence_read_failure_to_string reason)
-         ])
+    `Assoc
+      [ "kind", `String "artifact_unreadable"
+      ; "reference", `String reference
+      ; "reason", evidence_read_failure_to_yojson reason
+      ]
 
 let request_header_to_yojson request =
   `Assoc
@@ -190,25 +191,17 @@ let submitted_evidence_item_metadata_to_yojson = function
       ; "truncated", `Bool truncated
       ; "content_sha256", `String content_sha256
       ]
+  | Evidence_invalid_reference ->
+    `Assoc
+      [ "kind", `String "artifact_unreadable"
+      ; "reason", `String "invalid_reference"
+      ]
   | Evidence_artifact_unreadable { reference; reason } ->
-    (match reason with
-     | Evidence_invalid_reference ->
-       `Assoc
-         [ "kind", `String "artifact_unreadable"
-         ; "reason", `String (evidence_read_failure_code reason)
-         ]
-     | ( Evidence_missing
-       | Evidence_not_regular_file
-       | Evidence_outside_worker_playground
-       | Evidence_invalid_utf8
-       | Evidence_symbolic_link
-       | Evidence_changed_during_read
-       | Evidence_read_error _ ) ->
-       `Assoc
-         [ "kind", `String "artifact_unreadable"
-         ; "reference", `String reference
-         ; "reason", `String (evidence_read_failure_code reason)
-         ])
+    `Assoc
+      [ "kind", `String "artifact_unreadable"
+      ; "reference", `String reference
+      ; "reason", `String (evidence_read_failure_code reason)
+      ]
 ;;
 
 let submitted_evidence_access_metadata_to_yojson = function
@@ -304,23 +297,18 @@ let submitted_evidence_item_of_yojson = function
               })
      | Some (`String "artifact_unreadable") ->
        let open Result.Syntax in
-       let* reason_raw = string_field "reason" in
-       let* reason = evidence_read_failure_of_string reason_raw in
-       (match reason, List.assoc_opt "reference" fields with
-        | Evidence_invalid_reference, None ->
-          Ok
-            (Evidence_artifact_unreadable
-               { reference = redacted_invalid_reference; reason })
-        | Evidence_invalid_reference, Some _ ->
-          Error
-            "invalid submitted evidence references must not persist the rejected value"
-        | ( Evidence_missing
-          | Evidence_not_regular_file
-          | Evidence_outside_worker_playground
-          | Evidence_invalid_utf8
-          | Evidence_symbolic_link
-          | Evidence_changed_during_read
-          | Evidence_read_error _ ), _ ->
+       let* reason_json =
+         match List.assoc_opt "reason" fields with
+         | Some reason -> Ok reason
+         | None -> Error "submitted evidence snapshot is missing unreadable reason"
+       in
+       (match reason_json, List.assoc_opt "reference" fields with
+        | `Assoc [ "code", `String "invalid_reference" ], None ->
+          Ok Evidence_invalid_reference
+        | `Assoc [ "code", `String "invalid_reference" ], Some _ ->
+          Error "invalid submitted evidence references must not persist the rejected value"
+        | reason_json, _ ->
+          let* reason = evidence_read_failure_of_yojson reason_json in
           let* reference = string_field "reference" in
           Ok (Evidence_artifact_unreadable { reference; reason }))
      | Some (`String kind) ->
@@ -569,7 +557,7 @@ let valid_producer_relative_path path =
 
 let inspect_producer_relative_artifact ~base_path ~worker ~reference relative_path =
   if not (valid_producer_relative_path relative_path)
-  then Evidence_artifact_unreadable { reference; reason = Evidence_invalid_reference }
+  then Evidence_invalid_reference
   else
     let project_root = project_root_of_base_path base_path in
     let ownership_root =
@@ -603,9 +591,7 @@ let snapshot_submitted_evidence_item ~base_path ~worker reference =
     (match strip_prefix ~prefix:note_reference_prefix reference with
      | Some note when not (String.equal (String.trim note) "") ->
        Evidence_note note
-     | Some _ | None ->
-       Evidence_artifact_unreadable
-         { reference; reason = Evidence_invalid_reference })
+     | Some _ | None -> Evidence_invalid_reference)
 
 let snapshot_submitted_evidence_json ~base_path ~worker references =
   `List

--- a/lib/workspace/workspace_verification_store.ml
+++ b/lib/workspace/workspace_verification_store.ml
@@ -297,20 +297,31 @@ let submitted_evidence_item_of_yojson = function
               })
      | Some (`String "artifact_unreadable") ->
        let open Result.Syntax in
+       let field_names =
+         fields |> List.map fst |> List.sort String.compare
+       in
        let* reason_json =
          match List.assoc_opt "reason" fields with
          | Some reason -> Ok reason
          | None -> Error "submitted evidence snapshot is missing unreadable reason"
        in
-       (match reason_json, List.assoc_opt "reference" fields with
-        | `Assoc [ "code", `String "invalid_reference" ], None ->
+       (match reason_json, List.assoc_opt "reference" fields, field_names with
+        | ( `Assoc [ "code", `String "invalid_reference" ]
+          , None
+          , [ "kind"; "reason" ] ) ->
           Ok Evidence_invalid_reference
-        | `Assoc [ "code", `String "invalid_reference" ], Some _ ->
+        | `Assoc [ "code", `String "invalid_reference" ], Some _, _ ->
           Error "invalid submitted evidence references must not persist the rejected value"
-        | reason_json, _ ->
+        | `Assoc [ "code", `String "invalid_reference" ], None, _ ->
+          Error
+            "invalid submitted evidence references must be payload-free"
+        | reason_json, _, [ "kind"; "reason"; "reference" ] ->
           let* reason = evidence_read_failure_of_yojson reason_json in
           let* reference = string_field "reference" in
-          Ok (Evidence_artifact_unreadable { reference; reason }))
+          Ok (Evidence_artifact_unreadable { reference; reason })
+        | _, _, _ ->
+          Error
+            "submitted evidence unreadable item has unexpected fields")
      | Some (`String kind) ->
        Error (Printf.sprintf "unknown submitted evidence snapshot kind %S" kind)
      | Some value ->

--- a/lib/workspace/workspace_verification_store.ml
+++ b/lib/workspace/workspace_verification_store.ml
@@ -49,15 +49,6 @@ type submitted_evidence_access =
       ; reason : evidence_access_failure
       }
 
-let evidence_read_failure_to_string = function
-  | Evidence_missing -> "missing"
-  | Evidence_not_regular_file -> "not_regular_file"
-  | Evidence_outside_worker_playground -> "outside_worker_playground"
-  | Evidence_invalid_utf8 -> "invalid_utf8"
-  | Evidence_symbolic_link -> "symbolic_link"
-  | Evidence_changed_during_read -> "changed_during_read"
-  | Evidence_read_error detail -> "read_error:" ^ detail
-
 let evidence_read_failure_code = function
   | Evidence_missing -> "missing"
   | Evidence_not_regular_file -> "not_regular_file"

--- a/lib/workspace/workspace_verification_store.mli
+++ b/lib/workspace/workspace_verification_store.mli
@@ -56,7 +56,9 @@ val submitted_evidence_access_to_yojson :
 val submitted_evidence_access_metadata_to_yojson :
   submitted_evidence_access -> Yojson.Safe.t
 
-val evidence_read_failure_to_string : evidence_read_failure -> string
+val evidence_read_failure_code : evidence_read_failure -> string
+(** Stable bounded code for diagnostics and metadata. Error detail is carried
+    only by the structured durable reason object. *)
 val evidence_access_failure_to_string :
   request_id:string -> evidence_access_failure -> string
 val evidence_read_failure_of_owned_read_failure :

--- a/lib/workspace/workspace_verification_store.mli
+++ b/lib/workspace/workspace_verification_store.mli
@@ -9,7 +9,6 @@ type evidence_read_failure =
   | Evidence_missing
   | Evidence_not_regular_file
   | Evidence_outside_worker_playground
-  | Evidence_invalid_reference
   | Evidence_invalid_utf8
   | Evidence_symbolic_link
   | Evidence_changed_during_read
@@ -24,6 +23,7 @@ type submitted_evidence_item =
       ; truncated : bool
       ; content_sha256 : string
       }
+  | Evidence_invalid_reference
   | Evidence_artifact_unreadable of
       { reference : string
       ; reason : evidence_read_failure
@@ -71,7 +71,7 @@ val snapshot_submitted_evidence_json :
     ["note:<text>"] preserves non-file evidence explicitly.
     [content_sha256] covers the bounded UTF-8 content persisted in the
     snapshot, not bytes omitted beyond the projection cap. Bare and absolute
-    references are persisted as typed invalid references. *)
+    references are persisted as a payload-free typed invalid-reference item. *)
 val inspect_submitted_evidence_for_authority :
   base_path:string ->
   request_id:string ->

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -401,6 +401,48 @@ let test_unreadable_evidence_uses_structured_current_contract () =
        |> Yojson.Safe.Util.to_string)
   | _ -> Alcotest.fail "expected one readable failure and one invalid reference"
 
+let test_invalid_reference_snapshot_rejects_hidden_payload () =
+  with_eio_temp_dir (fun base_path ->
+    let request_id = "vrf-invalid-reference-hidden-payload" in
+    let output =
+      `Assoc
+        [ ( "submitted_evidence"
+          , `List
+              [ `Assoc
+                  [ "kind", `String "artifact_unreadable"
+                  ; "reason", `Assoc [ "code", `String "invalid_reference" ]
+                  ; "raw_reference", `String "/private/producer/secret.txt"
+                  ]
+              ] )
+        ]
+    in
+    (match
+       V.create_request
+         ~base_path
+         ~request_id
+         ~task_id:"task-001"
+         ~output
+         ~criteria:[]
+         ~worker:"keeper-executor-agent"
+         ()
+     with
+     | Ok _ -> ()
+     | Error detail -> Alcotest.fail detail);
+    match
+      VS.inspect_submitted_evidence_for_authority
+        ~base_path
+        ~request_id
+        ~task_id:"task-001"
+        ~task_worker:"keeper-executor-agent"
+        ~authority:(Masc_domain.Human_operator { operator_id = "operator-test" })
+    with
+    | VS.Evidence_unavailable { reason = VS.Evidence_snapshot_invalid detail; _ } ->
+      Alcotest.(check bool)
+        "hidden invalid-reference payload is rejected"
+        true
+        (contains_substring detail "payload-free")
+    | _ -> Alcotest.fail "hidden invalid-reference payload was accepted")
+
 let test_system_llm_rejection_is_durably_delivered_to_producer_keeper () =
   with_eio_temp_dir (fun base_path ->
     let config = W.default_config base_path in
@@ -1789,6 +1831,8 @@ let () =
         test_system_llm_review_notes_are_metadata_only;
       Alcotest.test_case "unreadable evidence uses structured current contract" `Quick
         test_unreadable_evidence_uses_structured_current_contract;
+      Alcotest.test_case "invalid reference rejects hidden payload" `Quick
+        test_invalid_reference_snapshot_rejects_hidden_payload;
       Alcotest.test_case "system LLM rejection reaches producer queue" `Quick
         test_system_llm_rejection_is_durably_delivered_to_producer_keeper;
       Alcotest.test_case "system LLM rejection uses registry producer binding" `Quick

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -1311,7 +1311,7 @@ let test_submit_snapshot_resolves_docker_relative_artifact_and_explicit_note () 
            } ->
          Alcotest.failf
            "Docker-relative artifact snapshot unreadable: %s"
-           (VS.evidence_read_failure_to_string reason)
+           (VS.evidence_read_failure_code reason)
        | VS.Evidence_available { items; _ } ->
          Alcotest.failf
            "expected explicit artifact and note snapshot, got %d items"
@@ -1383,7 +1383,7 @@ let test_submit_snapshot_survives_mutation_deletion_and_authority_cwd () =
                } ->
              Alcotest.failf
                "immutable artifact snapshot unreadable: %s"
-               (VS.evidence_read_failure_to_string reason)
+               (VS.evidence_read_failure_code reason)
            | VS.Evidence_available { items; _ } ->
              Alcotest.failf
                "expected one immutable artifact snapshot, got %d items"
@@ -1656,7 +1656,7 @@ let test_changed_during_read_maps_to_typed_unreadable_reason () =
     "changed_during_read"
     (VS.evidence_read_failure_of_owned_read_failure
        (Fs_compat.Filesystem_identity_changed { path = "artifact.txt" })
-     |> VS.evidence_read_failure_to_string)
+     |> VS.evidence_read_failure_code)
 
 let test_submitted_evidence_requires_exact_task_assignment_identity () =
   with_eio_temp_dir (fun base_path ->

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -252,10 +252,7 @@ let test_system_llm_review_notes_are_metadata_only () =
                   VS.Evidence_read_error
                     "Unix.Unix_error(ENOENT, open, /private/producer/secret.txt)"
               }
-          ; VS.Evidence_artifact_unreadable
-              { reference = "/private/producer/invalid-reference.txt"
-              ; reason = VS.Evidence_invalid_reference
-              }
+          ; VS.Evidence_invalid_reference
           ]
       }
   in
@@ -362,6 +359,47 @@ let test_system_llm_review_notes_are_metadata_only () =
       "full audit keeps the unavailable detail"
       true
       (contains_substring unavailable_audit "/private/producer/request.json")
+
+let test_unreadable_evidence_uses_structured_current_contract () =
+  let request : VS.request_header =
+    { id = "vrf-structured-reason"
+    ; task_id = "task-structured-reason"
+    ; worker = "keeper-executor-agent"
+    ; created_at = 1.0
+    }
+  in
+  let json =
+    VS.submitted_evidence_access_to_yojson
+      (VS.Evidence_available
+         { request
+         ; items =
+             [ VS.Evidence_artifact_unreadable
+                 { reference = "artifact:proof.txt"
+                 ; reason = VS.Evidence_read_error "permission denied"
+                 }
+             ; VS.Evidence_invalid_reference
+             ]
+         })
+  in
+  match Yojson.Safe.Util.member "items" json |> Yojson.Safe.Util.to_list with
+  | [ readable; invalid ] ->
+    Alcotest.(check (list (pair string string)))
+      "read error payload is structured"
+      [ "code", "read_error"; "detail", "permission denied" ]
+      (Yojson.Safe.Util.member "reason" readable
+       |> Yojson.Safe.Util.to_assoc
+       |> List.map (fun (key, value) -> key, Yojson.Safe.Util.to_string value));
+    Alcotest.(check bool)
+      "invalid references persist no payload"
+      false
+      (Yojson.Safe.Util.to_assoc invalid |> List.mem_assoc "reference");
+    Alcotest.(check string)
+      "invalid reference remains typed"
+      "invalid_reference"
+      (Yojson.Safe.Util.member "reason" invalid
+       |> Yojson.Safe.Util.member "code"
+       |> Yojson.Safe.Util.to_string)
+  | _ -> Alcotest.fail "expected one readable failure and one invalid reference"
 
 let test_system_llm_rejection_is_durably_delivered_to_producer_keeper () =
   with_eio_temp_dir (fun base_path ->
@@ -1354,8 +1392,7 @@ let test_submit_snapshot_rejects_relative_traversal_and_symlink_escape () =
         with
         | VS.Evidence_available
             { items =
-                VS.Evidence_artifact_unreadable
-                  { reason = VS.Evidence_invalid_reference; _ }
+                VS.Evidence_invalid_reference
                 :: VS.Evidence_artifact_unreadable
                      { reason = VS.Evidence_symbolic_link; _ }
                 :: []
@@ -1414,10 +1451,8 @@ let test_submit_snapshot_rejects_bare_and_absolute_references () =
     with
     | VS.Evidence_available
         { items =
-            VS.Evidence_artifact_unreadable
-              { reason = VS.Evidence_invalid_reference; _ }
-            :: VS.Evidence_artifact_unreadable
-                 { reason = VS.Evidence_invalid_reference; _ }
+            VS.Evidence_invalid_reference
+            :: VS.Evidence_invalid_reference
             :: []
         ; _
         } ->
@@ -1446,8 +1481,7 @@ let test_submitted_evidence_inspection_rejects_cross_playground_path () =
     with
     | VS.Evidence_available
         { items =
-            VS.Evidence_artifact_unreadable
-              { reason = VS.Evidence_invalid_reference; _ }
+            VS.Evidence_invalid_reference
             :: _
         ; _
         } ->
@@ -1753,6 +1787,8 @@ let () =
         test_system_llm_authority_helpers_are_typed;
       Alcotest.test_case "system LLM notes keep metadata only" `Quick
         test_system_llm_review_notes_are_metadata_only;
+      Alcotest.test_case "unreadable evidence uses structured current contract" `Quick
+        test_unreadable_evidence_uses_structured_current_contract;
       Alcotest.test_case "system LLM rejection reaches producer queue" `Quick
         test_system_llm_rejection_is_durably_delivered_to_producer_keeper;
       Alcotest.test_case "system LLM rejection uses registry producer binding" `Quick


### PR DESCRIPTION
## Summary

- invalid submitted references를 payload-free typed evidence item으로 만들었어용.
- 읽기 실패를 `{code, detail?}` 구조화 JSON으로 저장해용.
- redaction placeholder, colon-prefix decoder/encoder를 제거했어용.
- task-note metadata에는 raw invalid reference와 read-error detail을 싣지 않아용.

## Contract boundary

current-only hard cut이에용. 구 `reason: string` decoder, migration, placeholder 복원 경로는 추가하지 않았어용.

2026-08-03 KST 라이브 read-only census:
- verification JSON 69개
- 구 `reason: string` 레코드 40개, item 107개
- 현재 backlog 143개 중 `AwaitingVerification` 0개

따라서 40개는 현재 판정 의무가 아닌 과거 스냅샷이며, 새 decoder에서 의도적으로 읽히지 않아용. 라이브 파일 삭제나 재작성은 하지 않았어용.

## Verification

- touched OCaml: `ocamlformat --check`
- touched implementation/interface/test: `ocamlc -stop-after parsing`
- `git diff --check`
- 로컬 Dune 미실행; exact-head PR CI가 build/test 권위예용.