### PR TITLE
docs(workspace): centralize pending-verdict contract

### DIFF
--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -102,9 +102,8 @@ type task_status =
       ; submitted_at : string
       ; verification_id : string
       }
-      (** No verifier binding: the removed [phase] field made whichever agent won
-          the claim race the approver. [verification_id] joins to the evidence
-          record the authority reads. *)
+      (** No verifier binding. [verification_id] joins to the evidence record
+          the authority reads. *)
   | Done of { assignee : string; completed_at : string; notes : string option }
   | Cancelled of { cancelled_by : string; cancelled_at : string; reason : string option }
 [@@deriving show]

--- a/lib/workspace/workspace_task_claim.ml
+++ b/lib/workspace/workspace_task_claim.ml
@@ -156,9 +156,6 @@ let claim_task_r config ~agent_name ~task_id ()
                       task_id)))
          | `Claimed_by other -> Error (Masc_domain.Task (Masc_domain.Task_error.AlreadyClaimed { task_id; by = other }))
          | `Pending_verdict verification_id ->
-           (* Previously this arm only blocked the *submitting* worker, and any
-              other agent that claimed became the verifier. No agent claims an
-              obligation now: the verdict is issued by a completion authority. *)
            Error
              (Masc_domain.Task
                 (Masc_domain.Task_error.InvalidState

--- a/lib/workspace/workspace_task_lifecycle.ml
+++ b/lib/workspace/workspace_task_lifecycle.ml
@@ -1,12 +1,6 @@
-(** Pure Task lifecycle transition helper. Producers submit completion evidence
-    for verification; the terminal verdict is issued by the configured system
-    LLM agent at the [Masc_domain.completion_authority] boundary (or by an
-    authenticated HITL operator), never by a Keeper action. *)
-
 type invalid =
   | Verification_submission_required
   | Verification_pending_verdict
-      (** An [AwaitingVerification] obligation is not claimable by any agent. *)
   | Verdict_authority_identity_required
   | Verdict_rejection_reason_required
   | Verification_id_mismatch of { expected : string; actual : string }
@@ -43,11 +37,6 @@ let resolve_claim ~same_actor ~agent_name ~now (task : Masc_domain.task) =
     Worker_claim (Masc_domain.Claimed { assignee = agent_name; claimed_at = now })
   | Masc_domain.Claim_unavailable
       (Masc_domain.Claim_block_pending_verdict { verification_id }) ->
-    (* No agent claims a pending obligation. The previous behaviour bound the
-       claiming agent as its verifier, which is exactly how a Keeper acquired
-       approval authority: claim was the authority-granting operation. The
-       verdict now comes from a [completion_authority] out of band, so the
-       obligation has no assignable satisfier and no keeper is offered it. *)
     Held_pending_verdict { verification_id }
   | Masc_domain.Claim_unavailable (Masc_domain.Claim_block_not_todo task_status) ->
     (match task_status with
@@ -84,8 +73,6 @@ let decide
          (Masc_domain.Claimed { assignee = agent_name; claimed_at = now })
      | Masc_domain.Claim_unavailable
          (Masc_domain.Claim_block_pending_verdict _) ->
-       (* The completion authority is the system LLM boundary (or HITL), not
-          a Keeper that wins a claim race. *)
        Error Verification_pending_verdict
      | Masc_domain.Claim_unavailable
          (Masc_domain.Claim_block_not_todo status) ->

--- a/lib/workspace/workspace_task_lifecycle.mli
+++ b/lib/workspace/workspace_task_lifecycle.mli
@@ -6,6 +6,8 @@
 type invalid =
   | Verification_submission_required
   | Verification_pending_verdict
+      (** Agent actions cannot resolve an [AwaitingVerification] obligation;
+          the completion-authority entry point owns its verdict. *)
   | Verdict_authority_identity_required
   | Verdict_rejection_reason_required
   | Verification_id_mismatch of { expected : string; actual : string }

--- a/lib/workspace/workspace_task_lifecycle.mli
+++ b/lib/workspace/workspace_task_lifecycle.mli
@@ -6,7 +6,6 @@
 type invalid =
   | Verification_submission_required
   | Verification_pending_verdict
-      (** An [AwaitingVerification] obligation is not claimable by any agent. *)
   | Verdict_authority_identity_required
   | Verdict_rejection_reason_required
   | Verification_id_mismatch of { expected : string; actual : string }
@@ -23,10 +22,10 @@ type claim_resolution =
   | Held_by_other of string
   | Held_terminal of Masc_domain.task_status
   | Held_pending_verdict of { verification_id : string }
-      (** Awaiting the system LLM agent or authenticated HITL completion
-          authority's verdict. No Keeper may claim it or gain verifier
-          authority by winning a race. *)
 
+(** Project [Masc_domain.task_claim_decision_for_status] into the workspace
+    claim result. An [AwaitingVerification] obligation projects to
+    [Held_pending_verdict], never to [Worker_claim]. *)
 val resolve_claim
   :  same_actor:(string -> bool)
   -> agent_name:string

--- a/lib/workspace/workspace_task_schedule.ml
+++ b/lib/workspace/workspace_task_schedule.ml
@@ -275,12 +275,7 @@ let claim_next_r
             working_tasks
         in
         (* Eligibility and the claim outcome are one decision
-           ([Workspace_task_lifecycle.resolve_claim]). Every
-           [AwaitingVerification] obligation resolves to [Held_pending_verdict]
-           and is excluded here: it awaits a completion authority's verdict,
-           which is not an agent's work. Previously a cross-agent obligation
-           resolved to [Verifier_claim] and stayed eligible, which is exactly how
-           a keeper became its verifier by winning the claim.
+           ([Workspace_task_lifecycle.resolve_claim]).
            [task_claim_next_action_is_claimable] still owns the Todo reclaim
            gate. *)
         let same_actor a = Workspace_task_classify.same_task_actor config a agent_name in
@@ -293,9 +288,6 @@ let claim_next_r
           | Workspace_task_lifecycle.Self_owned
           | Workspace_task_lifecycle.Held_by_other _
           | Workspace_task_lifecycle.Held_terminal _
-          (* An obligation awaiting a completion authority's verdict is not
-             claimable work for any keeper — this arm is what previously put
-             AwaitingVerification tasks into the keeper claim pool. *)
           | Workspace_task_lifecycle.Held_pending_verdict _ -> false
         in
         let unclaimed =


### PR DESCRIPTION
## Summary

Remove only the duplicated implementation commentary around `AwaitingVerification` claim refusal.

- keep the public contract in `workspace_task_lifecycle.mli`
- point that contract directly at `Masc_domain.task_claim_decision_for_status`
- remove copied historical/current prose from the `.ml` branches
- keep RFC tombstone, tool descriptions, and runtime refusal text because they serve distinct human/agent/runtime consumers

No behavior, schema, or emitted error string changes.

## Verification

- `ocamlformat --check` on all three changed OCaml files
- `git diff --check`
- focused Dune wrapper was attempted but refused because an unrelated bare Dune process (`29776`) holds the machine-wide build path; not bypassed

Closes #26677