### PR TITLE
fix(schedule): stop pruning terminal requests that still own unsettled work

### DIFF
--- a/lib/schedule/schedule_store.ml
+++ b/lib/schedule/schedule_store.ml
@@ -886,6 +886,17 @@ let fail_due_candidate config ~now ~schedule_id ~error =
         Ok updated)
 ;;
 
+let has_unsettled_execution executions ~schedule_id =
+  List.exists
+    (fun (execution : execution_record) ->
+       String.equal execution.schedule_id schedule_id
+       &&
+       match execution.status with
+       | Execution_running | Execution_dispatched -> true
+       | Execution_succeeded | Execution_failed -> false)
+    executions
+;;
+
 let prune_completed config =
   Workspace_utils.with_file_lock config (schedules_path config) (fun () ->
     let* state = load_for_mutation config in
@@ -895,7 +906,14 @@ let prune_completed config =
         (fun (request : schedule_request) ->
            match request.status with
            | Scheduled | Due | Running -> true
-           | Succeeded | Failed | Cancelled | Expired -> false)
+           | Succeeded | Failed | Cancelled | Expired ->
+             (* A terminal request can still own work nobody has reported on:
+                accept_running advances a recurring request past an occurrence
+                that stays Execution_dispatched, and the request can then be
+                cancelled from Scheduled. Dropping the pair would delete the only
+                durable record of that work, and the settlement functions need
+                this row -- both of them return Schedule_not_found without it. *)
+             has_unsettled_execution state.executions ~schedule_id:request.schedule_id)
         state.schedules
     in
     let after_count = List.length schedules in

--- a/lib/schedule/schedule_store.mli
+++ b/lib/schedule/schedule_store.mli
@@ -261,9 +261,4 @@ val prune_completed :
     durable record of work a consumer accepted, and both
     [complete_dispatched_occurrence] and [fail_dispatched_occurrence] return
     [Schedule_not_found] without the request row — so pruning the pair would
-    both erase the evidence and make the occurrence unsettleable.
-
-    An occurrence whose consumer evidence is indeterminate is therefore
-    retained without a time bound until #26695 assigns that class a terminal
-    disposition. Without that disposition, retired ledger generations can
-    accumulate retained request/execution pairs. *)
+    both erase the evidence and make the occurrence unsettleable. *)

--- a/lib/schedule/schedule_store.mli
+++ b/lib/schedule/schedule_store.mli
@@ -240,5 +240,15 @@ val due_execution_candidates :
 val prune_completed :
   Workspace_utils.config ->
   (state * int, store_error) result
-(** Deletes all terminal (succeeded, failed, cancelled, expired) schedule
-    requests and their associated execution records. *)
+(** Deletes terminal (succeeded, failed, cancelled, expired) schedule requests
+    and their associated execution records.
+
+    A terminal request is retained while any of its executions is still
+    unsettled ([Execution_running] or [Execution_dispatched]). Terminal here
+    describes the request's intent, not the work: a recurring request advances
+    past an occurrence at [accept_running] and can be cancelled afterwards while
+    that occurrence is still outstanding. The execution row is then the only
+    durable record of work a consumer accepted, and both
+    [complete_dispatched_occurrence] and [fail_dispatched_occurrence] return
+    [Schedule_not_found] without the request row — so pruning the pair would
+    both erase the evidence and make the occurrence unsettleable. *)

--- a/lib/schedule/schedule_store.mli
+++ b/lib/schedule/schedule_store.mli
@@ -251,4 +251,9 @@ val prune_completed :
     durable record of work a consumer accepted, and both
     [complete_dispatched_occurrence] and [fail_dispatched_occurrence] return
     [Schedule_not_found] without the request row — so pruning the pair would
-    both erase the evidence and make the occurrence unsettleable. *)
+    both erase the evidence and make the occurrence unsettleable.
+
+    An occurrence whose consumer evidence is indeterminate is therefore
+    retained without a time bound until #26695 assigns that class a terminal
+    disposition. Without that disposition, retired ledger generations can
+    accumulate retained request/execution pairs. *)

--- a/test/test_schedule_runner.ml
+++ b/test/test_schedule_runner.ml
@@ -767,6 +767,31 @@ let test_reclaim_projects_consumer_completion () =
     (settled.status = Execution_succeeded)
 ;;
 
+let test_reclaim_then_prune_removes_settled_terminal_request () =
+  with_workspace
+  @@ fun config ->
+  let request = accepted_recurring_occurrence config ~schedule_id:"reclaim-prune" in
+  (match cancel config ~schedule_id:request.schedule_id with
+   | Ok _ -> ()
+   | Error error -> fail (service_error_to_string error));
+  let calls = ref [] in
+  let completed_consumer =
+    accepting_consumer
+      ~settlement:(fun _config _execution -> Ok Consumer_completed_occurrence)
+      calls
+  in
+  let outcome = reclaim_ok ~consumer:completed_consumer config ~now:400.0 in
+  check int "terminal request occurrence settled" 1 outcome.settled_elsewhere;
+  let state, pruned =
+    match Schedule_store.prune_completed config with
+    | Ok result -> result
+    | Error error -> fail (Schedule_store.store_error_to_string error)
+  in
+  check int "settled terminal request pruned" 1 pruned;
+  check int "request removed after exact settlement" 0 (List.length state.schedules);
+  check int "execution removed with request" 0 (List.length state.executions)
+;;
+
 let test_reclaim_projects_consumer_cancellation () =
   with_workspace
   @@ fun config ->
@@ -847,6 +872,8 @@ let () =
             test_reclaim_leaves_held_occurrence_alone
         ; test_case "projects consumer completion to schedule execution" `Quick
             test_reclaim_projects_consumer_completion
+        ; test_case "reclaim then prune removes settled terminal request" `Quick
+            test_reclaim_then_prune_removes_settled_terminal_request
         ; test_case "projects consumer cancellation to schedule execution" `Quick
             test_reclaim_projects_consumer_cancellation
         ; test_case "leaves an occurrence when the consumer cannot answer" `Quick

--- a/test/test_schedule_store.ml
+++ b/test/test_schedule_store.ml
@@ -914,6 +914,74 @@ let test_last_good_is_parseable_after_good_write () =
   | Error msg -> fail (".last-good is not parseable: " ^ msg)
 ;;
 
+let store_ok label = function
+  | Ok value -> value
+  | Error err -> fail (label ^ ": " ^ store_error_to_string err)
+;;
+
+(* Reproduces the live shape: a recurring request advances past an occurrence at
+   accept_running, the occurrence stays Execution_dispatched, and the request is
+   then cancelled from Scheduled. The request is terminal; the work is not. *)
+let cancelled_request_with_outstanding_occurrence config ~schedule_id =
+  let request =
+    make_request ~schedule_id ~recurrence:(Interval { interval_sec = 3600 }) ()
+  in
+  let stored = insert_ok config request in
+  ignore (store_ok "refresh_due" (refresh_due config ~now:201.0));
+  ignore
+    (store_ok "start_due_candidate"
+       (start_due_candidate config ~now:202.0 ~schedule_id:stored.schedule_id));
+  let advanced =
+    store_ok "accept_running" (accept_running config ~now:203.0 ~schedule_id:stored.schedule_id ())
+  in
+  check string "recurring request advanced past the occurrence" "scheduled"
+    (schedule_status_to_string advanced.status);
+  let cancelled =
+    store_ok "cancel_request" (cancel_request config ~schedule_id:stored.schedule_id)
+  in
+  check string "request is terminal" "cancelled"
+    (schedule_status_to_string cancelled.status);
+  stored
+;;
+
+let test_prune_keeps_terminal_request_with_unsettled_occurrence () =
+  with_workspace
+  @@ fun config ->
+  let stored =
+    cancelled_request_with_outstanding_occurrence config ~schedule_id:"prune-outstanding"
+  in
+  let state, pruned = store_ok "prune_completed" (prune_completed config) in
+  check int "outstanding occurrence keeps its request" 0 pruned;
+  check int "request row retained" 1 (List.length state.schedules);
+  check int "execution evidence retained" 1 (List.length state.executions);
+  (* The settlement path still resolves, which is the point of retaining it. *)
+  match
+    complete_dispatched_occurrence config ~now:400.0 ~schedule_id:stored.schedule_id
+      ~due_at:stored.due_at
+      ~payload_digest:(Schedule_domain.payload_digest stored.payload) ()
+  with
+  | Ok _ -> ()
+  | Error err -> fail ("settlement after prune failed: " ^ store_error_to_string err)
+;;
+
+let test_prune_deletes_terminal_request_once_settled () =
+  with_workspace
+  @@ fun config ->
+  let stored =
+    cancelled_request_with_outstanding_occurrence config ~schedule_id:"prune-settled"
+  in
+  ignore
+    (store_ok "fail_dispatched_occurrence"
+       (fail_dispatched_occurrence config ~now:300.0 ~schedule_id:stored.schedule_id
+          ~due_at:stored.due_at
+          ~payload_digest:(Schedule_domain.payload_digest stored.payload)
+          ~error:"consumer lost it"));
+  let state, pruned = store_ok "prune_completed" (prune_completed config) in
+  check int "settled terminal request is pruned" 1 pruned;
+  check int "request row removed" 0 (List.length state.schedules);
+  check int "execution rows removed with it" 0 (List.length state.executions)
+;;
+
 let () =
   run "Schedule_store"
     [
@@ -992,6 +1060,10 @@ let () =
             test_fail_due_candidate_records_failed_execution;
           test_case "recurring occurrences remain dispatchable" `Quick
             test_recurring_occurrences_remain_dispatchable;
+          test_case "prune keeps a terminal request with an unsettled occurrence"
+            `Quick test_prune_keeps_terminal_request_with_unsettled_occurrence;
+          test_case "prune deletes a terminal request once settled" `Quick
+            test_prune_deletes_terminal_request_once_settled;
         ] );
     ]
 ;;


### PR DESCRIPTION
Refs #26685, #26695. **#26689 보다 나중에 머지되어야 합니다** (아래 "머지 순서").

## 목표

`prune_completed` 가 terminal schedule 을 지운 뒤 그 schedule 의 execution 을 **상태와 무관하게** 삭제한다. 미정산 `Execution_dispatched` 도 함께 지워진다.

```ocaml
lib/schedule/schedule_store.ml (main)
  | Succeeded | Failed | Cancelled | Expired -> false      (* :898  request 삭제 *)
  ...
  List.filter (fun exec -> List.mem exec.schedule_id remaining_ids) state.executions
                                                            (* :906-910  상태 무검사 *)
```

이건 같은 파일의 `.mli` 와 모순된다 — `accept_running` 의 계약(`:167-169`)은 dispatched occurrence 가 *"correlated work-completion path 가 정산할 때까지"* 유지된다고 선언하는데, prune 이 그 전에 지운다.

**terminal 은 request 의 intent 를 말하지 work 를 말하지 않는다.** recurring request 는 `accept_running` 에서 다음 occurrence 로 advance 하고(`schedule_store.ml:612-616`), 그 뒤 `Scheduled` 상태에서 정상적으로 취소될 수 있다. 그 시점에 이전 occurrence 는 여전히 `dispatched` 다. live 의 미정산 4건이 정확히 이 형태다.

## 왜 지금인가

- **무인 실행이다.** `server_bootstrap_maintenance.ml:697` 이 24h 주기로 호출한다(`:646` gate, `:522` 에서 `last_prune` 을 부팅 시각으로 seed). 지금까지 4건이 살아남은 건 안전장치 때문이 아니라 **서버 재시작이 24h 안에 반복됐기 때문**이다. 하루 이상 연속 가동되면 지워진다.
- **삭제되면 복구 불가다.** execution row 는 consumer 가 수락한 work 의 유일한 durable 기록이고, `complete_dispatched_occurrence` / `fail_dispatched_occurrence` 는 둘 다 request row 없이는 `Schedule_not_found` 를 반환한다(`:670`, `:727`). 즉 삭제 후에는 정산 자체가 불가능해진다.
- **#26689 의 대상을 지운다.** 회수 경로를 넣어놓고 그 대상을 24h 마다 자동 삭제하면 앞 PR 이 무의미해진다. #26695(판정 불가 occurrence 의 처분)도 대상이 사라진 뒤에는 정할 것이 없다.

## 변경

terminal request 라도 **미정산 execution 을 가지고 있으면 보존**한다.

```ocaml
let has_unsettled_execution executions ~schedule_id =
  List.exists
    (fun (execution : execution_record) ->
       String.equal execution.schedule_id schedule_id
       &&
       match execution.status with
       | Execution_running | Execution_dispatched -> true
       | Execution_succeeded | Execution_failed -> false)
    executions
;;
```

`Execution_running` 도 포함한다 — dispatch 진행 중 프로세스가 죽으면 그 상태로 남고, `recover_running_on_startup` 이 처리할 대상이다.

정산이 끝나면 다음 prune 이 정상적으로 지운다. **보존은 조건부이지 영구가 아니다.**

## 변경 파일

| 파일 | 변경 |
|---|---|
| `lib/schedule/schedule_store.ml` | `has_unsettled_execution` + `prune_completed` 필터 조건 |
| `lib/schedule/schedule_store.mli` | 보존 조건과 그 이유를 계약으로 기재 |
| `test/test_schedule_store.ml` | 회귀 2건 |

## 로컬 검증

```
dune build test/test_schedule_store.exe        BUILD_EXIT=0
_build/default/test/test_schedule_store.exe    34/34 PASS   (기존 32 + 신규 2)
dune build @check                              BUILD_EXIT=0, Error/Warning 0
```

**`prune_completed` 에는 테스트가 하나도 없었다.** 신규 2건이 첫 커버리지다:

- `prune keeps a terminal request with an unsettled occurrence` — live 형태를 그대로 재현(recurring → `accept_running` 으로 advance → `Scheduled` 에서 cancel → occurrence 는 `dispatched`). pruned=0, request/execution 보존, **그리고 그 뒤 `complete_dispatched_occurrence` 가 실제로 성공**하는 것까지 확인한다. 보존의 목적이 정산 가능성이므로 그것을 직접 단언한다.
- `prune deletes a terminal request once settled` — 같은 상태에서 occurrence 를 정산한 뒤 prune 하면 pruned=1, request/execution 모두 제거. **보존이 영구화되지 않음**을 고정한다.

## 머지 순서

이 PR 의 테스트는 `test_schedule_store` 스위트에 들어가는데, **그 스위트를 CI 에서 실행하는 스텝은 #26689 가 추가한다** (현재 main 의 `ci.yml` 에는 schedule 스위트가 0개). 따라서:

- #26689 를 먼저 머지하면 이 PR 의 회귀 2건이 CI 에서 실행된다.
- 이 PR 을 먼저 머지하면 회귀 2건은 `@check` 컴파일만 받고 실행되지 않는다.

또한 두 PR 이 `lib/schedule/schedule_store.{ml,mli}` 의 인접 영역을 건드린다(#26689 는 `due_execution_candidates` 뒤, 이 PR 은 `prune_completed` 앞). 나중에 머지되는 쪽에서 rebase 가 필요할 수 있다.

**정리 후보**: #26689 의 `unsettled_dispatched_occurrences` 와 이 PR 의 `has_unsettled_execution` 은 같은 술어의 두 형태다(전자는 `dispatched` 만, 후자는 `running` 포함). 둘 다 머지된 뒤 하나로 합치는 게 맞다. 지금 합치지 않는 이유는 두 PR 을 독립적으로 되돌릴 수 있게 두기 위함이다.

## 범위 밖

미정산 occurrence 가 어느 operator 화면에도 나타나지 않는 문제(5건 중 3건은 `last_execution` 투영에 가려 보이지 않음), `signal_keys.json` 단일 실패점(#26686), operator cancel 이 enqueued wake 를 회수하지 않는 경로 — 전부 #26685 / #26686 에 남아 있다.

RFC-WAIVED: `lib/schedule` 단일 함수의 필터 조건과 그 계약 문서화. credential/identity/operator-control/sandbox/hooks 어디에도 해당하지 않으며, 기존 `.mli` 계약(`:167-169`)을 확장하지 않고 그것과 일치시키는 변경이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
