### PR TITLE
fix(docs): normalize slug RFC headings

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -351,14 +351,14 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | RFC-connector-ambient-attention-wake | Connector ambient attention wake: drive an idle keeper turn from external-att... | Draft | - |
 | RFC-connector-deferred-reply-via-chat-queue | Durable Keeper chat receipts and connector delivery settlement | Active | - |
 | RFC-eliminate-substring-destructive-classifier | Withdrawn command-policy classification experiment | Withdrawn | - |
-| RFC-keeper-conversation-hitl-flow | # RFC: Keeper conversation and non-blocking HITL | Draft | - |
-| RFC-keeper-media-degrade-floor | # RFC: Withdraw silent media degradation | Draft | - |
+| RFC-keeper-conversation-hitl-flow | Keeper conversation and non-blocking HITL | Draft | - |
+| RFC-keeper-media-degrade-floor | Withdraw silent media degradation | Draft | - |
 | RFC-keeper-memory-bank-write-reduction | Keeper memory-bank near-dup accumulation — write reduction, not write-boundar... | Superseded | - |
 | RFC-keeper-memory-consolidation | Keeper durable memory consolidation — deprecate memory_bank into Memory OS | Implemented | - |
 | RFC-keeper-memory-panel-real-data | Keeper memory panel: real-data backing (no fabrication, no score resurrection) | Superseded | - |
 | RFC-keeper-runtime-context-observation-phase0 | Keeper runtime context observation Phase 0 | Draft | - |
 | RFC-keeper-vision-delegation-tool | Vision-as-a-tool delegation (decouple multimodal input from conversation runt... | Draft | - |
-| RFC-memory-os-bounded-context-and-librarian-curator | # RFC: Memory OS 2.0 — bounded working set 전송 계약과 librarian curator 계약 | Draft | - |
+| RFC-memory-os-bounded-context-and-librarian-curator | Memory OS 2.0 — bounded working set 전송 계약과 librarian curator 계약 | Draft | - |
 | RFC-runtime-note-field-and-dashboard-surfacing | Per-runtime note field & dashboard surfacing | Draft | - |
 | RFC-typed-egress-resource-capability | Withdraw product-specific egress effect classification | Withdrawn | - |
 

--- a/scripts/rfc-generate-index.py
+++ b/scripts/rfc-generate-index.py
@@ -204,7 +204,7 @@ def document_for(filepath: Path, frontmatter: dict[str, str]) -> RfcDocument:
             if line.startswith("# "):
                 first_line = line
                 break
-        title = re.sub(r"^# RFC[- ]*\d+[.: —–-]*\s*", "", first_line)
+        title = re.sub(r"^# RFC(?::\s*|[- ]*\d+[.: —–-]*\s*)", "", first_line)
         if not title:
             title = "(untitled)"
 


### PR DESCRIPTION
## Summary

- 번호 없는 RFC의 정확한 `# RFC:` heading 문법을 title에서 제거해용.
- 생성된 index의 세 slug RFC 제목에서 `# RFC:` 잔여를 없애용.
- #26693 머지 직후 남은 P3만 main 기준 단일 커밋으로 분리했어용.

## Verification

- generator `--update` / `--check`
- pyright
- ruff check / format
- `git diff --check`

Related: #26693