### PR TITLE
fix(oauth): canonicalize admin scope closure

### DIFF
--- a/lib/auth/auth_oauth.ml
+++ b/lib/auth/auth_oauth.ml
@@ -345,11 +345,16 @@ let role_of_string = function
 let scopes_of_strings values =
   let rec parse acc = function
     | [] -> Ok acc
-    | "mcp:tools" :: rest -> parse (add_scope_with_implications acc Mcp_tools) rest
-    | "mcp:admin" :: rest -> parse (add_scope_with_implications acc Mcp_admin) rest
+    | "mcp:tools" :: rest -> parse (add_scope_once acc Mcp_tools) rest
+    | "mcp:admin" :: rest -> parse (add_scope_once acc Mcp_admin) rest
     | _ :: _ -> Error (Store_error "invalid OAuth scope")
   in
-  parse [] values
+  let* scopes = parse [] values in
+  if
+    List.exists (equal_scope Mcp_admin) scopes
+    && not (List.exists (equal_scope Mcp_tools) scopes)
+  then Error (Store_error "invalid OAuth scope closure: mcp:admin requires mcp:tools")
+  else Ok scopes
 ;;
 
 let client_to_yojson (client : client) =

--- a/lib/auth/auth_oauth.ml
+++ b/lib/auth/auth_oauth.ml
@@ -87,6 +87,13 @@ let add_scope_once acc scope =
   if List.exists (equal_scope scope) acc then acc else acc @ [ scope ]
 ;;
 
+let add_scope_with_implications acc = function
+  | Mcp_tools -> add_scope_once acc Mcp_tools
+  | Mcp_admin ->
+    let acc = add_scope_once acc Mcp_tools in
+    add_scope_once acc Mcp_admin
+;;
+
 let parse_scopes raw =
   let values =
     match raw with
@@ -101,8 +108,8 @@ let parse_scopes raw =
   let values = if values = [] then [ scope_to_string Mcp_tools ] else values in
   let rec parse acc = function
     | [] -> Ok acc
-    | "mcp:tools" :: rest -> parse (add_scope_once acc Mcp_tools) rest
-    | "mcp:admin" :: rest -> parse (add_scope_once acc Mcp_admin) rest
+    | "mcp:tools" :: rest -> parse (add_scope_with_implications acc Mcp_tools) rest
+    | "mcp:admin" :: rest -> parse (add_scope_with_implications acc Mcp_admin) rest
     | _ :: _ -> Error Invalid_scope
   in
   parse [] values
@@ -337,9 +344,9 @@ let role_of_string = function
 
 let scopes_of_strings values =
   let rec parse acc = function
-    | [] -> Ok (List.rev acc)
-    | "mcp:tools" :: rest -> parse (Mcp_tools :: acc) rest
-    | "mcp:admin" :: rest -> parse (Mcp_admin :: acc) rest
+    | [] -> Ok acc
+    | "mcp:tools" :: rest -> parse (add_scope_with_implications acc Mcp_tools) rest
+    | "mcp:admin" :: rest -> parse (add_scope_with_implications acc Mcp_admin) rest
     | _ :: _ -> Error (Store_error "invalid OAuth scope")
   in
   parse [] values

--- a/lib/auth/auth_oauth.mli
+++ b/lib/auth/auth_oauth.mli
@@ -45,7 +45,8 @@ val parse_scopes : string option -> (scope list, error) result
 (** Parse a space-delimited scope request.  Missing/blank means
     [[Mcp_tools]]. Duplicate scopes are collapsed in declaration order, and
     [Mcp_admin] is canonicalized to include [Mcp_tools] because the Admin RBAC
-    role includes tool permission. *)
+    role includes tool permission. Durable family decoding requires that exact
+    canonical closure and rejects non-canonical stored scope sets. *)
 
 val effective_role :
   bootstrap_role:Masc_domain.agent_role ->

--- a/lib/auth/auth_oauth.mli
+++ b/lib/auth/auth_oauth.mli
@@ -43,7 +43,9 @@ val valid_pkce_value : string -> bool
 
 val parse_scopes : string option -> (scope list, error) result
 (** Parse a space-delimited scope request.  Missing/blank means
-    [[Mcp_tools]]. Duplicate scopes are collapsed in declaration order. *)
+    [[Mcp_tools]]. Duplicate scopes are collapsed in declaration order, and
+    [Mcp_admin] is canonicalized to include [Mcp_tools] because the Admin RBAC
+    role includes tool permission. *)
 
 val effective_role :
   bootstrap_role:Masc_domain.agent_role ->

--- a/test/test_auth_oauth.ml
+++ b/test/test_auth_oauth.ml
@@ -777,6 +777,71 @@ let test_refresh_scope_can_reduce_but_not_expand () =
                | Ok _ | Error _ -> false)))))
 ;;
 
+let test_stored_admin_scope_requires_canonical_tools_closure () =
+  with_env "MASC_OAUTH_ENABLED" "1" (fun () ->
+    with_workspace (fun base_path ->
+      Eio_main.run (fun env ->
+        Fs_compat.set_fs (Eio.Stdenv.fs env);
+        Eio_guard.enable ();
+        Fun.protect
+          ~finally:(fun () ->
+            Eio_guard.disable ();
+            Fs_compat.clear_fs ())
+          (fun () ->
+            let _, bootstrap_credential =
+              Auth.create_token
+                base_path
+                ~agent_name:"noncanonical-scope-codex"
+                ~role:Masc_domain.Admin
+              |> auth_ok
+            in
+            let resource = "http://127.0.0.1:8935/mcp" in
+            let client, pair =
+              issue_pair
+                ~base_path
+                ~bootstrap_credential
+                ~redirect_uri:"http://127.0.0.1:43132/callback/noncanonical"
+                ~resource
+                ~scope:"mcp:admin"
+            in
+            let families_dir =
+              Filename.concat base_path ".masc/auth/oauth/families"
+            in
+            let family_path =
+              Filename.concat families_dir (Sys.readdir families_dir).(0)
+            in
+            let family_json =
+              family_path |> Fs_compat.load_file |> Yojson.Safe.from_string
+            in
+            let noncanonical =
+              match family_json with
+              | `Assoc fields ->
+                `Assoc
+                  (("scopes", `List [ `String "mcp:admin" ])
+                   :: List.remove_assoc "scopes" fields)
+              | _ -> fail "family store record must be an object"
+            in
+            (match
+               Fs_compat.save_file_atomic
+                 family_path
+                 (Yojson.Safe.pretty_to_string noncanonical)
+             with
+             | Ok () -> ()
+             | Error message -> fail message);
+            check
+              bool
+              "non-canonical durable admin scope fails closed"
+              true
+              (Result.is_error
+                 (Auth_oauth.rotate_refresh_token
+                    ~base_path
+                    ~expected_resource:resource
+                    ~refresh_token:pair.refresh_token
+                    ~client_id:client.client_id
+                    ~scope:None
+                    ~resource:(Some resource)))))))
+;;
+
 let test_rotation_keeps_one_current_access_record () =
   with_env "MASC_OAUTH_ENABLED" "1" (fun () ->
     with_workspace (fun base_path ->
@@ -914,6 +979,10 @@ let () =
             "refresh scope can reduce but not expand"
             `Quick
             test_refresh_scope_can_reduce_but_not_expand
+        ; test_case
+            "stored admin scope requires canonical tools closure"
+            `Quick
+            test_stored_admin_scope_requires_canonical_tools_closure
         ; test_case
             "rotation keeps one current access record"
             `Quick

--- a/test/test_auth_oauth.ml
+++ b/test/test_auth_oauth.ml
@@ -712,7 +712,7 @@ let test_refresh_scope_can_reduce_but_not_expand () =
               |> auth_ok
             in
             let resource = "http://127.0.0.1:8935/mcp" in
-            let admin_only_client, admin_only_pair =
+            let admin_client, admin_pair =
               issue_pair
                 ~base_path
                 ~bootstrap_credential
@@ -720,21 +720,20 @@ let test_refresh_scope_can_reduce_but_not_expand () =
                 ~resource
                 ~scope:"mcp:admin"
             in
-            check
-              bool
-              "refresh cannot substitute a scope that was never granted"
-              true
-              (match
-                 Auth_oauth.rotate_refresh_token
-                   ~base_path
-                   ~expected_resource:resource
-                   ~refresh_token:admin_only_pair.refresh_token
-                   ~client_id:admin_only_client.client_id
-                   ~scope:(Some "mcp:tools")
-                   ~resource:(Some resource)
-               with
-               | Error Auth_oauth.Invalid_scope -> true
-               | Ok _ | Error _ -> false);
+            check string "admin response includes its tools implication"
+              "mcp:tools mcp:admin" admin_pair.scope;
+            let worker_from_admin =
+              Auth_oauth.rotate_refresh_token
+                ~base_path
+                ~expected_resource:resource
+                ~refresh_token:admin_pair.refresh_token
+                ~client_id:admin_client.client_id
+                ~scope:(Some "mcp:tools")
+                ~resource:(Some resource)
+              |> oauth_ok
+            in
+            check string "admin family can downscope to tools"
+              "mcp:tools" worker_from_admin.scope;
             let client, admin_pair =
               issue_pair
                 ~base_path


### PR DESCRIPTION
## 문제

#26688에서 `mcp:admin`만 받은 token family는 `Admin` credential로 투영되어 tool 권한까지 행사하지만, durable scope에는 `mcp:tools`가 없어 refresh downscope를 `Invalid_scope`로 거절했습니다. 권한과 refresh가 같은 grant를 다르게 해석했습니다.

## 변경

- `mcp:admin`을 발급/저장 decode 시 canonical `mcp:tools mcp:admin` closure로 정규화
- admin family가 `mcp:tools`로 정상 downscope되고 Worker role로 낮아지는 회귀 테스트
- 기존 role RBAC를 권한 SSOT로 유지하며 scope family가 그 함의를 정확히 보존

## 검증

- `ocamlformat --check`
- `ocamlc -stop-after parsing`
- `git diff --check`
- focused Dune은 다른 세션의 bare Dune PID 29776/49084 때문에 repo wrapper가 exit 75로 거절; exact-head CI가 build authority

## 위험

OAuth authorization lifecycle 변경이므로 human security review가 필요합니다. DCR client cap의 authenticated deletion/ownership lifecycle은 이 PR 범위 밖이며 별도 blocker입니다.

Refs #26688