### PR TITLE
fix(agui): wire the AG-UI encoder on /ag-ui/events + delete two surfaces #26694 misclassified as broken

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1007,7 +1007,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_sse_coverage @test/runtest-test_ag_ui_coverage && opam exec -- dune exec --root . ./test/test_sse_storm_e2e.exe"
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_sse_coverage @test/runtest-test_ag_ui_coverage @test/runtest-test_sse_storm_e2e"
 
       - name: Run transport harness suite
         id: transport_harness_suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -996,7 +996,7 @@ jobs:
           operator_targets="@test/runtest-test_operator_control_snapshot_state @test/runtest-test_operator_control_snapshot @test/runtest-test_operator_control_snapshot_cache @test/runtest-test_model_map_of_keeper_rows"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${operator_targets}"
 
-      - name: Run SSE reconnect e2e
+      - name: Run SSE unit and reconnect suites
         id: sse_reconnect_e2e
         if: ${{ always() && steps.build_step.outcome == 'success' }}
         env:
@@ -1007,7 +1007,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune exec --root . ./test/test_sse_storm_e2e.exe"
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_sse_coverage @test/runtest-test_ag_ui_coverage && opam exec -- dune exec --root . ./test/test_sse_storm_e2e.exe"
 
       - name: Run transport harness suite
         id: transport_harness_suite

--- a/lib/ag_ui/ag_ui.ml
+++ b/lib/ag_ui/ag_ui.ml
@@ -172,87 +172,21 @@ let event_to_json (e : event) : Yojson.Safe.t =
     Text_delta/tool-call events each pay this cost once per token/chunk.
     Mirrors [Sse.format_event_yojson] (sse.ml).  Byte-identical output:
     [Yojson.Safe.to_buffer] emits the same bytes as [Yojson.Safe.to_string]. *)
-let event_to_sse (e : event) : string =
+let event_to_sse ?id (e : event) : string =
   let buf = Buffer.create 128 in
+  Option.iter
+    (fun id ->
+       Buffer.add_string buf "id: ";
+       Buffer.add_string buf (string_of_int id);
+       Buffer.add_char buf '\n')
+    id;
   Buffer.add_string buf "data: ";
   Yojson.Safe.to_buffer buf (event_to_json e);
   Buffer.add_string buf "\n\n";
   Buffer.contents buf
 
-(* ---------- MASC → AG-UI Event Mapping ---------- *)
-
 (** Default thread ID for the single-namespace AG-UI bridge. *)
 let default_thread_id = "default"
-
-(** Map MASC agent_session_bound to AG-UI RUN_STARTED *)
-let of_agent_session_bound ~agent_name : event =
-  make_event ~thread_id:default_thread_id
-    ~run_id:(Some agent_name)
-    ~custom_name:(Some "AGENT_SESSION_BOUND")
-    ~custom_value:(Some (`Assoc [("agent", `String agent_name)]))
-    Run_started
-
-(** Map MASC agent_unbound to AG-UI RUN_FINISHED *)
-let of_agent_unbound ~agent_name : event =
-  make_event ~thread_id:default_thread_id
-    ~run_id:(Some agent_name)
-    ~custom_name:(Some "AGENT_UNBOUND")
-    ~custom_value:(Some (`Assoc [("agent", `String agent_name)]))
-    Run_finished
-
-(** Map MASC broadcast message to AG-UI text message sequence.
-    Returns a list of 3 events: START, CONTENT, END *)
-let of_broadcast ~agent_name ~message ~message_id : event list =
-  let thread_id = default_thread_id in
-  let mid = Some message_id in
-  [
-    make_event ~thread_id ~run_id:(Some agent_name)
-      ~message_id:mid ~role:(Some Assistant)
-      Text_message_start;
-    make_event ~thread_id ~run_id:(Some agent_name)
-      ~message_id:mid ~delta:(Some message)
-      Text_message_content;
-    make_event ~thread_id ~run_id:(Some agent_name)
-      ~message_id:mid
-      Text_message_end;
-  ]
-
-(** Map MASC task claim to AG-UI STEP_STARTED *)
-let of_task_claimed ~agent_name ~task_id : event =
-  make_event ~thread_id:default_thread_id
-    ~run_id:(Some agent_name)
-    ~step_name:(Some task_id)
-    Step_started
-
-(** Map MASC task done to AG-UI STEP_FINISHED *)
-let of_task_done ~agent_name ~task_id : event =
-  make_event ~thread_id:default_thread_id
-    ~run_id:(Some agent_name)
-    ~step_name:(Some task_id)
-    Step_finished
-
-(** Map MASC tool call to AG-UI TOOL_CALL_START *)
-let of_tool_call ~agent_name ~tool_name ~call_id ~args_json : event list =
-  let thread_id = default_thread_id in
-  [
-    make_event ~thread_id ~run_id:(Some agent_name)
-      ~tool_call_id:(Some call_id)
-      ~tool_call_name:(Some tool_name)
-      Tool_call_start;
-    make_event ~thread_id ~run_id:(Some agent_name)
-      ~tool_call_id:(Some call_id)
-      ~delta:(Some args_json)
-      Tool_call_args;
-    make_event ~thread_id ~run_id:(Some agent_name)
-      ~tool_call_id:(Some call_id)
-      Tool_call_end;
-  ]
-
-(** Map MASC workspace state to AG-UI STATE_SNAPSHOT *)
-let of_workspace_state (state : Yojson.Safe.t) : event =
-  make_event ~thread_id:default_thread_id
-    ~snapshot:(Some state)
-    State_snapshot
 
 (** Map any MASC-specific event to AG-UI CUSTOM *)
 let of_custom ~name (value : Yojson.Safe.t) : event =
@@ -260,26 +194,6 @@ let of_custom ~name (value : Yojson.Safe.t) : event =
     ~custom_name:(Some name)
     ~custom_value:(Some value)
     Custom
-
-(** Map MASC task_update JSON to appropriate AG-UI event.
-    Inspects the "status" field to determine the event type. *)
-let of_task_update (task_json : Yojson.Safe.t) : event =
-  let task_id = Safe_ops.json_string ~default:"unknown" "id" task_json in
-  let status = Safe_ops.json_string ~default:"" "status" task_json in
-  let agent = Safe_ops.json_string ~default:"unknown" "agent" task_json in
-  match status with
-  | "claimed" ->
-    of_task_claimed ~agent_name:agent ~task_id
-  | "done" ->
-    of_task_done ~agent_name:agent ~task_id
-  | _ ->
-    of_custom
-      ~name:"TASK_UPDATE"
-      (`Assoc [
-        ("taskId", `String task_id);
-        ("status", `String status);
-        ("agent", `String agent);
-      ])
 
 (** Protocol version *)
 let protocol_version = "0.1.0"

--- a/lib/ag_ui/ag_ui.ml
+++ b/lib/ag_ui/ag_ui.ml
@@ -164,7 +164,7 @@ let event_to_json (e : event) : Yojson.Safe.t =
 
 (** Format as SSE data through the transport's canonical JSON encoder. *)
 let event_to_sse ?id (e : event) : string =
-  Sse.format_event_yojson ?id (event_to_json e)
+  Sse_wire.format_event_yojson ?id (event_to_json e)
 
 (** Default thread ID for the single-namespace AG-UI bridge. *)
 let default_thread_id = "default"

--- a/lib/ag_ui/ag_ui.ml
+++ b/lib/ag_ui/ag_ui.ml
@@ -162,28 +162,9 @@ let event_to_json (e : event) : Yojson.Safe.t =
     @ optional "name" (fun s -> `String s) e.custom_name
     @ optional "value" (fun j -> j) e.custom_value)
 
-(** Format as SSE data line.
-
-    Builds the [data: <json>\n\n] frame directly into a buffer, skipping the
-    intermediate [Yojson.Safe.to_string] allocation and the [Printf.sprintf]
-    frame allocation — one buffer + one final string instead of two
-    short-lived strings per event.  This is on the per-event streaming hot
-    path: every [keeper_stream_send_event] serializes via this function, so
-    Text_delta/tool-call events each pay this cost once per token/chunk.
-    Mirrors [Sse.format_event_yojson] (sse.ml).  Byte-identical output:
-    [Yojson.Safe.to_buffer] emits the same bytes as [Yojson.Safe.to_string]. *)
+(** Format as SSE data through the transport's canonical JSON encoder. *)
 let event_to_sse ?id (e : event) : string =
-  let buf = Buffer.create 128 in
-  Option.iter
-    (fun id ->
-       Buffer.add_string buf "id: ";
-       Buffer.add_string buf (string_of_int id);
-       Buffer.add_char buf '\n')
-    id;
-  Buffer.add_string buf "data: ";
-  Yojson.Safe.to_buffer buf (event_to_json e);
-  Buffer.add_string buf "\n\n";
-  Buffer.contents buf
+  Sse.format_event_yojson ?id (event_to_json e)
 
 (** Default thread ID for the single-namespace AG-UI bridge. *)
 let default_thread_id = "default"

--- a/lib/ag_ui/ag_ui.ml
+++ b/lib/ag_ui/ag_ui.ml
@@ -77,7 +77,7 @@ type event = {
 }
 
 (** Create an event with defaults *)
-let make_event ?(run_id=None) ?(message_id=None) ?(role=None)
+let make_event ?(timestamp = Time_compat.now ()) ?(run_id=None) ?(message_id=None) ?(role=None)
     ?(delta=None) ?(step_name=None) ?(tool_call_id=None)
     ?(tool_call_name=None) ?(snapshot=None)
     ?(message=None) ?(code=None)
@@ -126,7 +126,7 @@ let make_event ?(run_id=None) ?(message_id=None) ?(role=None)
     code;
     custom_name;
     custom_value;
-    timestamp = Time_compat.now ();
+    timestamp;
   }
 
 let run_error ~thread_id ?run_id ~message ?code () =
@@ -189,8 +189,8 @@ let event_to_sse ?id (e : event) : string =
 let default_thread_id = "default"
 
 (** Map any MASC-specific event to AG-UI CUSTOM *)
-let of_custom ~name (value : Yojson.Safe.t) : event =
-  make_event ~thread_id:default_thread_id
+let of_custom ?timestamp ~name (value : Yojson.Safe.t) : event =
+  make_event ?timestamp ~thread_id:default_thread_id
     ~custom_name:(Some name)
     ~custom_value:(Some value)
     Custom

--- a/lib/ag_ui/ag_ui.mli
+++ b/lib/ag_ui/ag_ui.mli
@@ -100,7 +100,7 @@ val run_error :
 val event_to_json : event -> Yojson.Safe.t
 (** Spec-compliant JSON with camelCase field names. *)
 
-val event_to_sse : event -> string
+val event_to_sse : ?id:int -> event -> string
 (** Format an event as a single SSE [data:] line followed by [\n\n]. *)
 
 (** {1 MASC → AG-UI Mapping} *)
@@ -108,41 +108,8 @@ val event_to_sse : event -> string
 val default_thread_id : string
 (** Thread ID used by the single-namespace MASC bridge (["default"]). *)
 
-val of_agent_session_bound : agent_name:string -> event
-(** [agent_session_bound] → [Run_started] with [custom_name="AGENT_SESSION_BOUND"]. *)
-
-val of_agent_unbound : agent_name:string -> event
-(** [agent_unbound] → [Run_finished] with [custom_name="AGENT_UNBOUND"]. *)
-
-val of_broadcast :
-  agent_name:string -> message:string -> message_id:string -> event list
-(** Broadcast → 3 events: [Text_message_start], [Text_message_content]
-    (with [delta=message]), [Text_message_end]. *)
-
-val of_task_claimed : agent_name:string -> task_id:string -> event
-(** Task claim → [Step_started] with [step_name=task_id]. *)
-
-val of_task_done : agent_name:string -> task_id:string -> event
-(** Task done → [Step_finished] with [step_name=task_id]. *)
-
-val of_tool_call :
-  agent_name:string ->
-  tool_name:string ->
-  call_id:string ->
-  args_json:string ->
-  event list
-(** Tool call → 3 events: [Tool_call_start], [Tool_call_args]
-    (with [delta=args_json]), [Tool_call_end]. *)
-
-val of_workspace_state : Yojson.Safe.t -> event
-(** Workspace snapshot → [State_snapshot]. *)
-
 val of_custom : name:string -> Yojson.Safe.t -> event
 (** Wrap any MASC event in [Custom] with the given [name]/[value]. *)
-
-val of_task_update : Yojson.Safe.t -> event
-(** Inspect [status] in the task JSON: ["claimed"] → {!of_task_claimed},
-    ["done"] → {!of_task_done}, else [Custom] with [name="TASK_UPDATE"]. *)
 
 (** {1 Protocol Metadata} *)
 

--- a/lib/ag_ui/ag_ui.mli
+++ b/lib/ag_ui/ag_ui.mli
@@ -62,6 +62,7 @@ type event = private {
 }
 
 val make_event :
+  ?timestamp:float ->
   ?run_id:string option ->
   ?message_id:string option ->
   ?role:role option ->
@@ -77,7 +78,7 @@ val make_event :
   thread_id:string ->
   event_type ->
   event
-(** Construct an [event] with sensible defaults. [timestamp] is set to
+(** Construct an [event] with sensible defaults. [timestamp] defaults to
     [Time_compat.now ()] at call time.
 
     [Run_error] requires a non-empty [message]. [message] and [code] are
@@ -108,7 +109,7 @@ val event_to_sse : ?id:int -> event -> string
 val default_thread_id : string
 (** Thread ID used by the single-namespace MASC bridge (["default"]). *)
 
-val of_custom : name:string -> Yojson.Safe.t -> event
+val of_custom : ?timestamp:float -> name:string -> Yojson.Safe.t -> event
 (** Wrap any MASC event in [Custom] with the given [name]/[value]. *)
 
 (** {1 Protocol Metadata} *)

--- a/lib/ag_ui/dune
+++ b/lib/ag_ui/dune
@@ -8,6 +8,6 @@
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4) + unused-value ratchet (warning 32)
  (flags
   (:standard -w +4 -w +32))
- (libraries time_compat yojson masc_core)
+ (libraries time_compat yojson masc_core masc.sse_wire)
  (preprocess
   (pps ppx_deriving.show ppx_deriving.eq)))

--- a/lib/dune
+++ b/lib/dune
@@ -63,6 +63,7 @@
   masc.tool_types
   masc.crypto_rng
   masc.time_codec
+  masc.sse_wire
   masc_schedule
   ;; Shared leaf helpers extracted out of include_subdirs-unqualified ownership.
   masc.lockfree_atomic

--- a/lib/keeper/keeper_compact_audit.ml
+++ b/lib/keeper/keeper_compact_audit.ml
@@ -81,16 +81,6 @@ let get_store base_path =
   in
   ensure ()
 
-(* ── ID synthesis ──────────────────────────────────────────────── *)
-
-(* compaction_id = ulid-ish: ts_micros-hex ++ keeper ++ counter *)
-let counter = Atomic.make 0
-
-let synth_compaction_id ~ts_unix ~keeper_name =
-  let ts_us = Int64.of_float (ts_unix *. 1_000_000.0) in
-  let n = Atomic.fetch_and_add counter 1 in
-  Printf.sprintf "%Lx-%s-%x" ts_us keeper_name n
-
 (* ── JSON codecs ───────────────────────────────────────────────── *)
 
 let start_to_json (r : start_record) : Yojson.Safe.t =

--- a/lib/keeper/keeper_compact_audit.mli
+++ b/lib/keeper/keeper_compact_audit.mli
@@ -29,7 +29,7 @@ val parse_trigger : string -> trigger
 val trigger_to_string : trigger -> string
 
 type start_record = {
-  compaction_id : string;   (** Synthesized: ulid-like per-start *)
+  compaction_id : string;   (** Caller-supplied; the key a Complete row pairs on *)
   ts_unix : float;
   keeper_name : string;
   trigger : trigger;

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -448,18 +448,6 @@ let decision_child_scope scope key =
   then Compaction_evidence
   else scope
 
-(* Retired-field rejection on the read path was removed in #17512
-   (91e1fd59df, "Remove retired-field rejection from of_json
-   (backward-compatible)"), which deleted the [of_json] call sites and the
-   covering tests in the same commit.  The rewritten definitions it left
-   behind had no caller from that point on and are removed here.
-
-   Do not re-introduce a read-path rejection without an RFC: persisted rows
-   written before the allowlist narrowed would stop decoding.  The public
-   filtering guarantee lives in {!public_to_json} /
-   {!public_projection_of_decision}, which are wired
-   (server_dashboard_http_keeper_api_types.ml). *)
-
 let rec public_projection_of_decision decision =
   let rec project scope path = function
     | `Assoc fields ->

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -385,13 +385,6 @@ let links_to_json links =
    The previous substring-based redaction (§2 anti-pattern) has been removed;
    public filtering now uses explicit allowlists in {!public_projection_of_decision}. *)
 
-let manifest_top_level_allowlist =
-  StringSet.of_list
-    [ "schema_version"; "ts"; "keeper_name"; "agent_name"; "trace_id"
-    ; "generation"; "keeper_turn_id"; "oas_turn_count"; "logical_seq"; "event"
-    ; "runtime_id"; "status"; "decision"; "links"
-    ]
-
 (* [trigger_detail] keys come from the encoder that writes them, not from a
    copy kept here. The flat list below used to name only "kind" and
    "limit_tokens", so a [Request_body_over_capacity] refusal reached the public
@@ -455,61 +448,17 @@ let decision_child_scope scope key =
   then Compaction_evidence
   else scope
 
-let rec reject_unknown_fields ~allowlist path = function
-  | `Assoc fields ->
-      List.find_map
-        (fun (key, value) ->
-          let full_path = if String.equal path "" then key else path ^ "." ^ key in
-          if StringSet.mem key allowlist then
-            reject_unknown_fields ~allowlist full_path value
-          else Some full_path)
-        fields
-  | `List values ->
-      values
-      |> List.mapi (fun idx value -> idx, value)
-      |> List.find_map (fun (idx, value) ->
-        reject_unknown_fields ~allowlist
-          (Printf.sprintf "%s[%d]" path idx)
-          value)
-  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ -> None
+(* Retired-field rejection on the read path was removed in #17512
+   (91e1fd59df, "Remove retired-field rejection from of_json
+   (backward-compatible)"), which deleted the [of_json] call sites and the
+   covering tests in the same commit.  The rewritten definitions it left
+   behind had no caller from that point on and are removed here.
 
-let reject_retired_manifest_fields fields =
-  match
-    reject_unknown_fields
-      ~allowlist:manifest_top_level_allowlist
-      "" (`Assoc fields)
-  with
-  | Some path ->
-      Error
-        (Printf.sprintf
-           "retired runtime manifest field %S is no longer accepted" path)
-  | None -> Ok ()
-
-let reject_retired_decision_fields decision =
-  let rec check scope path = function
-    | `Assoc fields ->
-        let allowlist = decision_allowlist scope in
-        List.find_map
-          (fun (key, value) ->
-            let full_path = if String.equal path "" then key else path ^ "." ^ key in
-            if StringSet.mem key allowlist then
-              check (decision_child_scope scope key) full_path value
-            else Some full_path)
-          fields
-    | `List values ->
-        values
-        |> List.mapi (fun idx value -> idx, value)
-        |> List.find_map (fun (idx, value) ->
-          check scope (Printf.sprintf "%s[%d]" path idx) value)
-    | _ -> None
-  in
-  match check Decision "" decision with
-  | Some path ->
-      Error
-        (Printf.sprintf
-           "retired runtime manifest decision field %S is no longer accepted"
-           path)
-  | None -> Ok ()
+   Do not re-introduce a read-path rejection without an RFC: persisted rows
+   written before the allowlist narrowed would stop decoding.  The public
+   filtering guarantee lives in {!public_to_json} /
+   {!public_projection_of_decision}, which are wired
+   (server_dashboard_http_keeper_api_types.ml). *)
 
 let rec public_projection_of_decision decision =
   let rec project scope path = function

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -606,6 +606,13 @@ let handle_get_mcp ~deps ?(profile = Full) ?(sse_kind = Sse.Agent_stream)
           respond_mcp_error ~code:Mcp_error_code.Auth_error ~deps ~request_authority
             request reqd ~session_id ~protocol_version msg
       | Ok () ->
+          (match last_event_id with
+          | Error error ->
+              respond_mcp_error ~code:Mcp_error_code.Invalid_request ~deps
+                ~request_authority request reqd ~session_id ~protocol_version
+                (Server_mcp_transport_http_headers.last_event_id_error_to_string
+                   error)
+          | Ok last_event_id ->
       let otel_transport_context =
         Otel_dispatch_hook.http_transport_context ~protocol_version:"1.1"
       in
@@ -741,8 +748,8 @@ let handle_get_mcp ~deps ?(profile = Full) ?(sse_kind = Sse.Agent_stream)
                 session_id msg);
           let client_count = Sse.client_count () in
           if client_count > Sse.max_clients / 2 then
-            Log.Server.info "SSE connected: %s (active: %d/%d)"
-              session_id client_count Sse.max_clients))))
+              Log.Server.info "SSE connected: %s (active: %d/%d)"
+              session_id client_count Sse.max_clients)))))
 
 
 let handle_get_operator_mcp ~deps request reqd =

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -671,7 +671,7 @@ let handle_get_mcp ~deps ?(profile = Full) ?(sse_kind = Sse.Agent_stream)
           let replayed =
             match last_event_id with
             | Some last_id ->
-              Sse.get_events_after_for_kind sse_kind last_id
+              Sse.get_events_after_for_session ~session_id ~kind:sse_kind last_id
               |> List.filter (fun delivery ->
                 if send_raw info delivery.Sse.frame
                 then true

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -86,8 +86,6 @@ let sse_ping_interval_s = Server_mcp_transport_http_headers.sse_ping_interval_s
 
 let post_sse_keepalive_interval_s = Float.max 0.1 sse_ping_interval_s
 
-let get_last_event_id = Server_mcp_transport_http_headers.get_last_event_id
-
 let body_jsonrpc_id body_str =
   try
     match Yojson.Safe.from_string body_str with
@@ -577,7 +575,7 @@ let handle_get_mcp ~deps ?(profile = Full) ?(sse_kind = Sse.Agent_stream)
     | Operator_remote ->
         deps.verify_operator_mcp_auth ~base_path request
   in
-  let last_event_id = get_last_event_id request in
+  let last_event_id = Server_mcp_transport_http_headers.get_last_event_id request in
   match validate_mcp_session_profile ~profile session_id with
   | Error msg ->
       let headers =

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -663,15 +663,21 @@ let handle_get_mcp ~deps ?(profile = Full) ?(sse_kind = Sse.Agent_stream)
           register_sse_conn ~session_id ~info;
           if not (send_raw info (sse_prime_event ())) then
             Log.Server.debug "SSE prime send failed for session %s" info.session_id;
-          (match last_event_id with
-          | Some last_id ->
-              let missed = Sse.get_events_after_for_kind sse_kind last_id in
-              List.iter (fun ev ->
-                if not (send_raw info ev) then
-                  Log.Server.debug "SSE replay send failed for session %s"
-                    info.session_id
-              ) missed
-          | None -> ());
+          let replayed =
+            match last_event_id with
+            | Some last_id ->
+              Sse.get_events_after_for_kind sse_kind last_id
+              |> List.filter (fun delivery ->
+                if send_raw info delivery.Sse.frame
+                then true
+                else (
+                  Log.Server.debug
+                    "SSE replay send failed for session %s"
+                    info.session_id;
+                  false))
+            | None -> []
+          in
+          let replay_handoff = Sse.create_replay_handoff replayed in
           (match deps.get_runtime_result () with
           | Ok runtime ->
               let sw = runtime.sw in
@@ -679,10 +685,12 @@ let handle_get_mcp ~deps ?(profile = Full) ?(sse_kind = Sse.Agent_stream)
               run_sse_pumps ~sw ~stop_promise:info.stop_promise
                 ~drain:(fun () ->
                   let rec drain () =
-                    let event = Eio.Stream.take event_stream in
+                    let delivery = Eio.Stream.take event_stream in
                     (try
                       if not (Atomic.get info.closed || (Atomic.get info.stop)) then
-                        if not (send_raw info event) then
+                        if Sse.accept_live_delivery replay_handoff delivery
+                           && not (send_raw info delivery.Sse.frame)
+                        then
                           Log.Server.debug "SSE drain send failed for session %s"
                             info.session_id
                     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->

--- a/lib/server/server_mcp_transport_http.mli
+++ b/lib/server/server_mcp_transport_http.mli
@@ -109,9 +109,6 @@ val should_use_sse_for_body :
   Mcp_transport_protocol.Http_negotiation.accept_mode ->
   bool
 val force_json_response : bool
-val get_last_event_id :
-  Httpun.Request.t ->
-  (int option, Server_mcp_transport_http_headers.last_event_id_error) result
 val mcp_headers : string -> string -> (string * string) list
 val json_headers :
   deps:deps -> string -> string -> string -> (string * string) list

--- a/lib/server/server_mcp_transport_http.mli
+++ b/lib/server/server_mcp_transport_http.mli
@@ -109,7 +109,9 @@ val should_use_sse_for_body :
   Mcp_transport_protocol.Http_negotiation.accept_mode ->
   bool
 val force_json_response : bool
-val get_last_event_id : Httpun.Request.t -> int option
+val get_last_event_id :
+  Httpun.Request.t ->
+  (int option, Server_mcp_transport_http_headers.last_event_id_error) result
 val mcp_headers : string -> string -> (string * string) list
 val json_headers :
   deps:deps -> string -> string -> string -> (string * string) list

--- a/lib/server/server_mcp_transport_http_agui.ml
+++ b/lib/server/server_mcp_transport_http_agui.ml
@@ -6,40 +6,12 @@ open Server_mcp_transport_http_respond
 
 let sse_stream_headers = Server_mcp_transport_http_headers.sse_stream_headers
 
-type ag_ui_encoding_error =
-  | Missing_data_payload
-  | Invalid_json_payload
-
-let ag_ui_encoding_error_to_string = function
-  | Missing_data_payload -> "missing_data_payload"
-  | Invalid_json_payload -> "invalid_json_payload"
-
-let ag_ui_encoding_error (delivery : Sse.delivery) kind =
+let ag_ui_event_of_masc_event (delivery : Sse.delivery) =
   Ag_ui.of_custom
     ~timestamp:delivery.emitted_at
-    ~name:"MASC_EVENT_ENCODING_ERROR"
-    (`Assoc [ "kind", `String (ag_ui_encoding_error_to_string kind) ])
+    ~name:"MASC_EVENT"
+    delivery.payload
   |> Ag_ui.event_to_sse ~id:delivery.event_id
-;;
-
-let ag_ui_event_of_masc_event (delivery : Sse.delivery) =
-  match Sse.data_payload_of_frame delivery.frame with
-  | Error Sse.Missing_data_payload ->
-      Log.Transport.warn "ag_ui_event_of_masc_event: frame has no data payload";
-      ag_ui_encoding_error delivery Missing_data_payload
-  | Ok data_payload ->
-      (match Yojson.Safe.from_string data_payload with
-      | json ->
-        let ag_event =
-          Ag_ui.of_custom
-            ~timestamp:delivery.emitted_at
-            ~name:"MASC_EVENT"
-            json
-        in
-        Ag_ui.event_to_sse ~id:delivery.event_id ag_event
-      | exception Yojson.Json_error msg ->
-          Log.Transport.warn "ag_ui_event_of_masc_event: non-JSON data payload: %s" msg;
-          ag_ui_encoding_error delivery Invalid_json_payload)
 
 let sse_ping_interval_s = 30.0
 

--- a/lib/server/server_mcp_transport_http_agui.ml
+++ b/lib/server/server_mcp_transport_http_agui.ml
@@ -6,38 +6,34 @@ open Server_mcp_transport_http_respond
 
 let sse_stream_headers = Server_mcp_transport_http_headers.sse_stream_headers
 
+type ag_ui_encoding_error =
+  | Missing_data_payload
+  | Invalid_json_payload
+
+let ag_ui_encoding_error_to_string = function
+  | Missing_data_payload -> "missing_data_payload"
+  | Invalid_json_payload -> "invalid_json_payload"
+
 let ag_ui_encoding_error kind =
   Ag_ui.of_custom
     ~name:"MASC_EVENT_ENCODING_ERROR"
-    (`Assoc [ "kind", `String kind ])
+    (`Assoc [ "kind", `String (ag_ui_encoding_error_to_string kind) ])
   |> Ag_ui.event_to_sse
 ;;
 
 let ag_ui_event_of_masc_event event =
-  try
-    let lines = String.split_on_char '\n' event in
-    let data_line =
-      List.find_opt
-        (fun l -> String.length l > 6 && String.starts_with ~prefix:"data: " l)
-        lines
-    in
-    match data_line with
-    | Some dl ->
-        let json_str = String.sub dl 6 (String.length dl - 6) in
-        let json = Yojson.Safe.from_string json_str in
+  match Sse.data_payload_of_frame event with
+  | Error Sse.Missing_data_payload ->
+      Log.Transport.warn "ag_ui_event_of_masc_event: frame has no data payload";
+      ag_ui_encoding_error Missing_data_payload
+  | Ok json_str ->
+      (match Yojson.Safe.from_string json_str with
+      | json ->
         let ag_event = Ag_ui.of_custom ~name:"MASC_EVENT" json in
         Ag_ui.event_to_sse ag_event
-    | None ->
-      Log.Transport.warn "ag_ui_event_of_masc_event: frame has no data payload";
-      ag_ui_encoding_error "missing_data_payload"
-  with
-  | Yojson.Json_error msg ->
-      Log.Transport.warn "ag_ui_event_of_masc_event: non-JSON data payload: %s" msg;
-      ag_ui_encoding_error "invalid_json_payload"
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn ->
-      Log.Transport.warn "ag_ui_event_of_masc_event failed: %s" (Printexc.to_string exn);
-      ag_ui_encoding_error "encoding_failure"
+      | exception Yojson.Json_error msg ->
+          Log.Transport.warn "ag_ui_event_of_masc_event: non-JSON data payload: %s" msg;
+          ag_ui_encoding_error Invalid_json_payload)
 
 module For_testing = struct
   let ag_ui_event_of_masc_event = ag_ui_event_of_masc_event

--- a/lib/server/server_mcp_transport_http_agui.ml
+++ b/lib/server/server_mcp_transport_http_agui.ml
@@ -130,7 +130,8 @@ let handle_ag_ui_events ~deps request reqd =
                   let replayed =
                     match last_event_id with
                     | Some last_id ->
-                      Sse.get_events_after_for_kind Sse.Observer last_id
+                      Sse.get_events_after_for_session ~session_id
+                        ~kind:Sse.Observer last_id
                       |> List.filter (fun delivery ->
                         if send_raw info (ag_ui_event_of_masc_event delivery)
                         then true

--- a/lib/server/server_mcp_transport_http_agui.ml
+++ b/lib/server/server_mcp_transport_http_agui.ml
@@ -22,7 +22,13 @@ let ag_ui_event_of_masc_event event =
         Ag_ui.event_to_sse ag_event
     | None -> event
   with
-  | Yojson.Json_error _ -> event
+  | Yojson.Json_error msg ->
+      (* A frame carrying a [data:] line whose payload is not JSON cannot be
+         wrapped as an AG-UI CUSTOM event.  Passing it through keeps the stream
+         alive, but the client receives a frame outside the AG-UI schema, so the
+         fallback is logged rather than silent. *)
+      Log.Transport.warn "ag_ui_event_of_masc_event: non-JSON data payload, forwarding unconverted: %s" msg;
+      event
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
       Log.Transport.warn "ag_ui_event_of_masc_event failed: %s" (Printexc.to_string exn);
@@ -116,7 +122,7 @@ let handle_ag_ui_events ~deps request reqd =
               | Some last_id ->
                   let missed = Sse.get_events_after_for_kind Sse.Observer last_id in
                   List.iter (fun ev ->
-                    if not (send_raw info ev) then
+                    if not (send_raw info (ag_ui_event_of_masc_event ev)) then
                       Log.Server.debug "ag-ui replay send failed for session %s" info.session_id
                   ) missed
               | None -> ());
@@ -130,7 +136,7 @@ let handle_ag_ui_events ~deps request reqd =
                         let event = Eio.Stream.take event_stream in
                         (try
                           if not (Atomic.get info.closed || (Atomic.get info.stop)) then
-                            if not (send_raw info event) then
+                            if not (send_raw info (ag_ui_event_of_masc_event event)) then
                               Log.Server.debug "ag-ui drain send failed for session %s"
                                 info.session_id
                         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->

--- a/lib/server/server_mcp_transport_http_agui.ml
+++ b/lib/server/server_mcp_transport_http_agui.ml
@@ -8,41 +8,38 @@ let sse_stream_headers = Server_mcp_transport_http_headers.sse_stream_headers
 
 type ag_ui_encoding_error =
   | Missing_data_payload
-  | Invalid_event_id
   | Invalid_json_payload
 
 let ag_ui_encoding_error_to_string = function
   | Missing_data_payload -> "missing_data_payload"
-  | Invalid_event_id -> "invalid_event_id"
   | Invalid_json_payload -> "invalid_json_payload"
 
-let ag_ui_encoding_error ?id kind =
+let ag_ui_encoding_error (delivery : Sse.delivery) kind =
   Ag_ui.of_custom
+    ~timestamp:delivery.emitted_at
     ~name:"MASC_EVENT_ENCODING_ERROR"
     (`Assoc [ "kind", `String (ag_ui_encoding_error_to_string kind) ])
-  |> Ag_ui.event_to_sse ?id
+  |> Ag_ui.event_to_sse ~id:delivery.event_id
 ;;
 
-let ag_ui_event_of_masc_event event =
-  match Sse.parse_frame event with
-  | Error Sse.Frame_missing_data_payload ->
+let ag_ui_event_of_masc_event (delivery : Sse.delivery) =
+  match Sse.data_payload_of_frame delivery.frame with
+  | Error Sse.Missing_data_payload ->
       Log.Transport.warn "ag_ui_event_of_masc_event: frame has no data payload";
-      ag_ui_encoding_error Missing_data_payload
-  | Error Sse.Frame_invalid_event_id ->
-      Log.Transport.warn "ag_ui_event_of_masc_event: frame has invalid event id";
-      ag_ui_encoding_error Invalid_event_id
-  | Ok { event_id; data_payload } ->
+      ag_ui_encoding_error delivery Missing_data_payload
+  | Ok data_payload ->
       (match Yojson.Safe.from_string data_payload with
       | json ->
-        let ag_event = Ag_ui.of_custom ~name:"MASC_EVENT" json in
-        Ag_ui.event_to_sse ?id:event_id ag_event
+        let ag_event =
+          Ag_ui.of_custom
+            ~timestamp:delivery.emitted_at
+            ~name:"MASC_EVENT"
+            json
+        in
+        Ag_ui.event_to_sse ~id:delivery.event_id ag_event
       | exception Yojson.Json_error msg ->
           Log.Transport.warn "ag_ui_event_of_masc_event: non-JSON data payload: %s" msg;
-          ag_ui_encoding_error ?id:event_id Invalid_json_payload)
-
-module For_testing = struct
-  let ag_ui_event_of_masc_event = ag_ui_event_of_masc_event
-end
+          ag_ui_encoding_error delivery Invalid_json_payload)
 
 let sse_ping_interval_s = 30.0
 
@@ -128,14 +125,21 @@ let handle_ag_ui_events ~deps request reqd =
               in
               if not (send_raw info prime) then
                 Log.Server.debug "ag-ui prime send failed for session %s" info.session_id;
-              (match last_event_id with
-              | Some last_id ->
-                  let missed = Sse.get_events_after_for_kind Sse.Observer last_id in
-                  List.iter (fun ev ->
-                    if not (send_raw info (ag_ui_event_of_masc_event ev)) then
-                      Log.Server.debug "ag-ui replay send failed for session %s" info.session_id
-                  ) missed
-              | None -> ());
+              let replayed =
+                match last_event_id with
+                | Some last_id ->
+                  Sse.get_events_after_for_kind Sse.Observer last_id
+                  |> List.filter (fun delivery ->
+                    if send_raw info (ag_ui_event_of_masc_event delivery)
+                    then true
+                    else (
+                      Log.Server.debug
+                        "ag-ui replay send failed for session %s"
+                        info.session_id;
+                      false))
+                | None -> []
+              in
+              let replay_handoff = Sse.create_replay_handoff replayed in
               (match deps.get_runtime_result () with
               | Ok runtime ->
                   let sw = runtime.sw in
@@ -143,10 +147,15 @@ let handle_ag_ui_events ~deps request reqd =
                   run_sse_pumps ~sw ~stop_promise:info.stop_promise
                     ~drain:(fun () ->
                       let rec drain () =
-                        let event = Eio.Stream.take event_stream in
+                        let delivery = Eio.Stream.take event_stream in
                         (try
                           if not (Atomic.get info.closed || (Atomic.get info.stop)) then
-                            if not (send_raw info (ag_ui_event_of_masc_event event)) then
+                            if Sse.accept_live_delivery replay_handoff delivery
+                               && not
+                                    (send_raw
+                                       info
+                                       (ag_ui_event_of_masc_event delivery))
+                            then
                               Log.Server.debug "ag-ui drain send failed for session %s"
                                 info.session_id
                         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
@@ -253,10 +262,10 @@ let handle_presence_events ~deps request reqd =
               run_sse_pumps ~sw ~stop_promise:info.stop_promise
                 ~drain:(fun () ->
                   let rec drain () =
-                    let event = Eio.Stream.take event_stream in
+                    let delivery = Eio.Stream.take event_stream in
                     (try
                        if not (Atomic.get info.closed || (Atomic.get info.stop)) then
-                         if not (send_raw info event) then
+                         if not (send_raw info delivery.Sse.frame) then
                            Log.Server.debug
                              "presence drain send failed for session %s"
                              info.session_id

--- a/lib/server/server_mcp_transport_http_agui.ml
+++ b/lib/server/server_mcp_transport_http_agui.ml
@@ -6,6 +6,13 @@ open Server_mcp_transport_http_respond
 
 let sse_stream_headers = Server_mcp_transport_http_headers.sse_stream_headers
 
+let ag_ui_encoding_error kind =
+  Ag_ui.of_custom
+    ~name:"MASC_EVENT_ENCODING_ERROR"
+    (`Assoc [ "kind", `String kind ])
+  |> Ag_ui.event_to_sse
+;;
+
 let ag_ui_event_of_masc_event event =
   try
     let lines = String.split_on_char '\n' event in
@@ -20,19 +27,21 @@ let ag_ui_event_of_masc_event event =
         let json = Yojson.Safe.from_string json_str in
         let ag_event = Ag_ui.of_custom ~name:"MASC_EVENT" json in
         Ag_ui.event_to_sse ag_event
-    | None -> event
+    | None ->
+      Log.Transport.warn "ag_ui_event_of_masc_event: frame has no data payload";
+      ag_ui_encoding_error "missing_data_payload"
   with
   | Yojson.Json_error msg ->
-      (* A frame carrying a [data:] line whose payload is not JSON cannot be
-         wrapped as an AG-UI CUSTOM event.  Passing it through keeps the stream
-         alive, but the client receives a frame outside the AG-UI schema, so the
-         fallback is logged rather than silent. *)
-      Log.Transport.warn "ag_ui_event_of_masc_event: non-JSON data payload, forwarding unconverted: %s" msg;
-      event
+      Log.Transport.warn "ag_ui_event_of_masc_event: non-JSON data payload: %s" msg;
+      ag_ui_encoding_error "invalid_json_payload"
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
       Log.Transport.warn "ag_ui_event_of_masc_event failed: %s" (Printexc.to_string exn);
-      event
+      ag_ui_encoding_error "encoding_failure"
+
+module For_testing = struct
+  let ag_ui_event_of_masc_event = ag_ui_event_of_masc_event
+end
 
 let sse_ping_interval_s = 30.0
 

--- a/lib/server/server_mcp_transport_http_agui.ml
+++ b/lib/server/server_mcp_transport_http_agui.ml
@@ -65,136 +65,138 @@ let handle_ag_ui_events ~deps request reqd =
   let protocol_version = get_protocol_version_for_session ~session_id request in
   let base_path = deps.get_base_path () in
   (* workspace query param ignored — namespace retired *)
-  let last_event_id =
-    match Httpun.Headers.get (request : Httpun.Request.t).headers "last-event-id" with
-    | Some id -> (int_of_string_opt (id))
-    | None -> None
-  in
+  let last_event_id = Server_mcp_transport_http_headers.get_last_event_id request in
   match deps.verify_mcp_observer_stream_auth ~base_path request with
   | Error msg ->
       respond_mcp_error ~code:Mcp_error_code.Auth_error ~deps ~request_authority
         request reqd ~session_id ~protocol_version msg
   | Ok () ->
-      let token = Server_auth.observer_sse_auth_token_from_request request in
-      let auth = { Sse.config = base_path; token } in
-      (match check_sse_connect_guard session_id with
-      | Error (reason, retry_after_s) ->
-          respond_sse_rate_limited ~deps ~origin ~session_id ~protocol_version
-            ~reason ~retry_after_s reqd
-      | Ok () ->
-          stop_sse_session_preserve_guard session_id;
-          if Option.is_some last_event_id then
-            Transport_metrics.inc_sse_reconnect ();
-          ensure_sse_backing_session_for_known_transport_session
-            ~transport_session_id:session_id ~sse_session_id:session_id;
-          let expected_resource = Server_oauth_metadata.resource request_authority in
-          (match
-             Auth_oauth.with_expected_resource expected_resource (fun () ->
-               Sse.register ~kind:Sse.Observer ~auth session_id
-                 (* DET-OK: unchanged from main; the authority wrapper only re-indented it. *)
-                 ~last_event_id:(Option.value ~default:0 last_event_id)
-                 ~on_disconnect:(fun () -> stop_sse_session session_id))
-           with
-           | Error reg_err ->
-               let msg = Sse.registration_error_to_string reg_err in
-               Log.Server.warn "%s" msg;
-               respond_sse_register_error ~deps ~origin ~protocol_version reqd msg
-           | Ok (client_id, event_stream, evicted) ->
-              let headers =
-                Httpun.Headers.of_list
-                  (sse_stream_headers ~deps session_id protocol_version origin)
-              in
-              let response = Httpun.Response.create ~headers `OK in
-              let writer = Httpun.Reqd.respond_with_streaming reqd response in
-              let mutex = Eio.Mutex.create () in
-              let info_ref : sse_conn_info option ref = ref None in
-              (match evicted with
-              | Some evicted_sid ->
-                  (* RFC-0099 PR-3: cap-exceeded eviction publishes typed
-                     close frame + Evict/Close event pair. *)
-                  stop_sse_session_evict evicted_sid
-                    ~reason:Session_lifecycle_event.Cap_exceeded
-              | None -> ());
-              let info = make_sse_conn ~session_id ~client_id ~writer ~mutex () in
-              info_ref := Some info;
-              register_sse_conn ~session_id ~info;
-              let prime =
-                Ag_ui.(
-                  make_event ~thread_id:default_thread_id ~run_id:(Some session_id) Run_started
-                  |> event_to_sse)
-              in
-              if not (send_raw info prime) then
-                Log.Server.debug "ag-ui prime send failed for session %s" info.session_id;
-              let replayed =
-                match last_event_id with
-                | Some last_id ->
-                  Sse.get_events_after_for_kind Sse.Observer last_id
-                  |> List.filter (fun delivery ->
-                    if send_raw info (ag_ui_event_of_masc_event delivery)
-                    then true
-                    else (
-                      Log.Server.debug
-                        "ag-ui replay send failed for session %s"
-                        info.session_id;
-                      false))
-                | None -> []
-              in
-              let replay_handoff = Sse.create_replay_handoff replayed in
-              (match deps.get_runtime_result () with
-              | Ok runtime ->
-                  let sw = runtime.sw in
-                  let clock = runtime.clock in
-                  run_sse_pumps ~sw ~stop_promise:info.stop_promise
-                    ~drain:(fun () ->
-                      let rec drain () =
-                        let delivery = Eio.Stream.take event_stream in
-                        (try
-                          if not (Atomic.get info.closed || (Atomic.get info.stop)) then
-                            if Sse.accept_live_delivery replay_handoff delivery
-                               && not
-                                    (send_raw
-                                       info
-                                       (ag_ui_event_of_masc_event delivery))
-                            then
-                              Log.Server.debug "ag-ui drain send failed for session %s"
-                                info.session_id
-                        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-                          Log.Server.error "ag-ui drain write error: %s"
-                            (Printexc.to_string exn);
-                          stop_sse_session_preserve_guard info.session_id);
-                        if not (Atomic.get info.stop) then drain ()
-                      in
-                      try drain ()
-                      with Eio.Cancel.Cancelled _ as e -> raise e
-                         | exn ->
-                           Log.Server.error "ag-ui drain loop error: %s"
-                             (Printexc.to_string exn))
-                    ~ping:(fun () ->
-                      let rec loop () =
-                        if not (Atomic.get info.stop) then (
-                          (try Eio.Time.sleep clock sse_ping_interval_s
-                           with Eio.Cancel.Cancelled _ as exn -> raise exn
-                              | exn -> Log.Server.debug "SSE ping sleep interrupted: %s" (Printexc.to_string exn));
-                          (try
-                             if Atomic.get info.closed then
-                               stop_sse_session_preserve_guard info.session_id
-                             else if not (Atomic.get info.stop) then
-                               if not (send_raw info ": ping\n\n") then
-                                 Log.Server.debug "ag-ui ping send failed for session %s"
-                                   info.session_id
-                           with Eio.Cancel.Cancelled _ as exn -> raise exn
-                              | exn ->
-                                  Log.Server.warn "SSE ping send failed for session %s: %s" info.session_id (Printexc.to_string exn);
-                                  stop_sse_session_preserve_guard info.session_id);
-                          loop ())
-                      in
-                      try loop () with Eio.Cancel.Cancelled _ as exn -> raise exn
-                        | exn ->
-                            Log.Server.error "SSE ping loop exited for session %s: %s" info.session_id (Printexc.to_string exn);
-                            stop_sse_session_preserve_guard info.session_id)
-              | Error msg ->
-                  Log.Server.debug "ag-ui SSE runtime unavailable for session %s: %s"
-                    session_id msg)))
+      (match last_event_id with
+      | Error error ->
+          respond_mcp_error ~code:Mcp_error_code.Invalid_request ~deps
+            ~request_authority request reqd ~session_id ~protocol_version
+            (Server_mcp_transport_http_headers.last_event_id_error_to_string error)
+      | Ok last_event_id ->
+          let token = Server_auth.observer_sse_auth_token_from_request request in
+          let auth = { Sse.config = base_path; token } in
+          (match check_sse_connect_guard session_id with
+          | Error (reason, retry_after_s) ->
+              respond_sse_rate_limited ~deps ~origin ~session_id ~protocol_version
+                ~reason ~retry_after_s reqd
+          | Ok () ->
+              stop_sse_session_preserve_guard session_id;
+              if Option.is_some last_event_id then
+                Transport_metrics.inc_sse_reconnect ();
+              ensure_sse_backing_session_for_known_transport_session
+                ~transport_session_id:session_id ~sse_session_id:session_id;
+              let expected_resource = Server_oauth_metadata.resource request_authority in
+              (match
+                 Auth_oauth.with_expected_resource expected_resource (fun () ->
+                   Sse.register ~kind:Sse.Observer ~auth session_id
+                     (* DET-OK: unchanged from main; the authority wrapper only re-indented it. *)
+                     ~last_event_id:(Option.value ~default:0 last_event_id)
+                     ~on_disconnect:(fun () -> stop_sse_session session_id))
+               with
+               | Error reg_err ->
+                   let msg = Sse.registration_error_to_string reg_err in
+                   Log.Server.warn "%s" msg;
+                   respond_sse_register_error ~deps ~origin ~protocol_version reqd msg
+               | Ok (client_id, event_stream, evicted) ->
+                  let headers =
+                    Httpun.Headers.of_list
+                      (sse_stream_headers ~deps session_id protocol_version origin)
+                  in
+                  let response = Httpun.Response.create ~headers `OK in
+                  let writer = Httpun.Reqd.respond_with_streaming reqd response in
+                  let mutex = Eio.Mutex.create () in
+                  let info_ref : sse_conn_info option ref = ref None in
+                  (match evicted with
+                  | Some evicted_sid ->
+                      (* RFC-0099 PR-3: cap-exceeded eviction publishes typed
+                         close frame + Evict/Close event pair. *)
+                      stop_sse_session_evict evicted_sid
+                        ~reason:Session_lifecycle_event.Cap_exceeded
+                  | None -> ());
+                  let info = make_sse_conn ~session_id ~client_id ~writer ~mutex () in
+                  info_ref := Some info;
+                  register_sse_conn ~session_id ~info;
+                  let prime =
+                    Ag_ui.(
+                      make_event ~thread_id:default_thread_id ~run_id:(Some session_id) Run_started
+                      |> event_to_sse)
+                  in
+                  if not (send_raw info prime) then
+                    Log.Server.debug "ag-ui prime send failed for session %s" info.session_id;
+                  let replayed =
+                    match last_event_id with
+                    | Some last_id ->
+                      Sse.get_events_after_for_kind Sse.Observer last_id
+                      |> List.filter (fun delivery ->
+                        if send_raw info (ag_ui_event_of_masc_event delivery)
+                        then true
+                        else (
+                          Log.Server.debug
+                            "ag-ui replay send failed for session %s"
+                            info.session_id;
+                          false))
+                    | None -> []
+                  in
+                  let replay_handoff = Sse.create_replay_handoff replayed in
+                  (match deps.get_runtime_result () with
+                  | Ok runtime ->
+                      let sw = runtime.sw in
+                      let clock = runtime.clock in
+                      run_sse_pumps ~sw ~stop_promise:info.stop_promise
+                        ~drain:(fun () ->
+                          let rec drain () =
+                            let delivery = Eio.Stream.take event_stream in
+                            (try
+                              if not (Atomic.get info.closed || (Atomic.get info.stop)) then
+                                if Sse.accept_live_delivery replay_handoff delivery
+                                   && not
+                                        (send_raw
+                                           info
+                                           (ag_ui_event_of_masc_event delivery))
+                                then
+                                  Log.Server.debug "ag-ui drain send failed for session %s"
+                                    info.session_id
+                            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+                              Log.Server.error "ag-ui drain write error: %s"
+                                (Printexc.to_string exn);
+                              stop_sse_session_preserve_guard info.session_id);
+                            if not (Atomic.get info.stop) then drain ()
+                          in
+                          try drain ()
+                          with Eio.Cancel.Cancelled _ as e -> raise e
+                             | exn ->
+                               Log.Server.error "ag-ui drain loop error: %s"
+                                 (Printexc.to_string exn))
+                        ~ping:(fun () ->
+                          let rec loop () =
+                            if not (Atomic.get info.stop) then (
+                              (try Eio.Time.sleep clock sse_ping_interval_s
+                               with Eio.Cancel.Cancelled _ as exn -> raise exn
+                                  | exn -> Log.Server.debug "SSE ping sleep interrupted: %s" (Printexc.to_string exn));
+                              (try
+                                 if Atomic.get info.closed then
+                                   stop_sse_session_preserve_guard info.session_id
+                                 else if not (Atomic.get info.stop) then
+                                   if not (send_raw info ": ping\n\n") then
+                                     Log.Server.debug "ag-ui ping send failed for session %s"
+                                       info.session_id
+                               with Eio.Cancel.Cancelled _ as exn -> raise exn
+                                  | exn ->
+                                      Log.Server.warn "SSE ping send failed for session %s: %s" info.session_id (Printexc.to_string exn);
+                                      stop_sse_session_preserve_guard info.session_id);
+                              loop ())
+                          in
+                          try loop () with Eio.Cancel.Cancelled _ as exn -> raise exn
+                            | exn ->
+                                Log.Server.error "SSE ping loop exited for session %s: %s" info.session_id (Printexc.to_string exn);
+                                stop_sse_session_preserve_guard info.session_id)
+                  | Error msg ->
+                      Log.Server.debug "ag-ui SSE runtime unavailable for session %s: %s"
+                        session_id msg))))
 
 let handle_presence_events ~deps request reqd =
   let request_authority = Server_request_authority.current_exn () in

--- a/lib/server/server_mcp_transport_http_agui.ml
+++ b/lib/server/server_mcp_transport_http_agui.ml
@@ -8,32 +8,37 @@ let sse_stream_headers = Server_mcp_transport_http_headers.sse_stream_headers
 
 type ag_ui_encoding_error =
   | Missing_data_payload
+  | Invalid_event_id
   | Invalid_json_payload
 
 let ag_ui_encoding_error_to_string = function
   | Missing_data_payload -> "missing_data_payload"
+  | Invalid_event_id -> "invalid_event_id"
   | Invalid_json_payload -> "invalid_json_payload"
 
-let ag_ui_encoding_error kind =
+let ag_ui_encoding_error ?id kind =
   Ag_ui.of_custom
     ~name:"MASC_EVENT_ENCODING_ERROR"
     (`Assoc [ "kind", `String (ag_ui_encoding_error_to_string kind) ])
-  |> Ag_ui.event_to_sse
+  |> Ag_ui.event_to_sse ?id
 ;;
 
 let ag_ui_event_of_masc_event event =
-  match Sse.data_payload_of_frame event with
-  | Error Sse.Missing_data_payload ->
+  match Sse.parse_frame event with
+  | Error Sse.Frame_missing_data_payload ->
       Log.Transport.warn "ag_ui_event_of_masc_event: frame has no data payload";
       ag_ui_encoding_error Missing_data_payload
-  | Ok json_str ->
-      (match Yojson.Safe.from_string json_str with
+  | Error Sse.Frame_invalid_event_id ->
+      Log.Transport.warn "ag_ui_event_of_masc_event: frame has invalid event id";
+      ag_ui_encoding_error Invalid_event_id
+  | Ok { event_id; data_payload } ->
+      (match Yojson.Safe.from_string data_payload with
       | json ->
         let ag_event = Ag_ui.of_custom ~name:"MASC_EVENT" json in
-        Ag_ui.event_to_sse ag_event
+        Ag_ui.event_to_sse ?id:event_id ag_event
       | exception Yojson.Json_error msg ->
           Log.Transport.warn "ag_ui_event_of_masc_event: non-JSON data payload: %s" msg;
-          ag_ui_encoding_error Invalid_json_payload)
+          ag_ui_encoding_error ?id:event_id Invalid_json_payload)
 
 module For_testing = struct
   let ag_ui_event_of_masc_event = ag_ui_event_of_masc_event

--- a/lib/server/server_mcp_transport_http_agui.mli
+++ b/lib/server/server_mcp_transport_http_agui.mli
@@ -39,11 +39,9 @@ val handle_ag_ui_events :
        typed delivery to the AG-UI wire format. Replay/live overlap is removed
        by exact event id.
     9. Spawn two fibers under the runtime switch:
-       - drain: pulls typed deliveries from the per-session stream, converts each frame to the
-         AG-UI wire format, writes to client, self-terminates on send
-         failure.  A missing or malformed [data:] payload is projected to a
-         schema-valid AG-UI [CUSTOM] event named [MASC_EVENT_ENCODING_ERROR]
-         and logged at {!Log.Transport.warn}; raw MASC frames never cross this
+       - drain: pulls typed deliveries from the per-session stream, converts
+         each original JSON payload to the AG-UI wire format, writes to client,
+         and self-terminates on send failure. Raw MASC frames never cross this
          endpoint's wire boundary.
        - ping: sleeps 30s, writes ": ping\\n\\n" comment frame to
          keep middleboxes from idling out the connection.

--- a/lib/server/server_mcp_transport_http_agui.mli
+++ b/lib/server/server_mcp_transport_http_agui.mli
@@ -35,7 +35,7 @@ val handle_ag_ui_events :
     7. Send a synthetic AG-UI [Run_started] prime event so the client
        can observe the connection has settled.
     8. If [last-event-id] was present, replay missed observer events via
-       {!Sse.get_events_after_for_kind}, each converted from its canonical
+       {!Sse.get_events_after_for_session}, each converted from its canonical
        typed delivery to the AG-UI wire format. Replay/live overlap is removed
        by exact event id.
     9. Spawn two fibers under the runtime switch:
@@ -88,5 +88,5 @@ val handle_presence_events :
     The stream registers a {!Sse.Presence} session under a namespaced
     session id so the dashboard can keep its durable [/mcp] observer
     stream open while subscribing to live-only presence traffic.
-    Presence events are not replayed from {!Sse.get_events_after};
+    Presence events are not replayed from {!Sse.get_events_after_for_session};
     reconnecting clients receive only future liveness/awareness frames. *)

--- a/lib/server/server_mcp_transport_http_agui.mli
+++ b/lib/server/server_mcp_transport_http_agui.mli
@@ -40,8 +40,10 @@ val handle_ag_ui_events :
     9. Spawn two fibers under the runtime switch:
        - drain: pulls from per-session stream, converts each frame to the
          AG-UI wire format, writes to client, self-terminates on send
-         failure.  A frame whose [data:] payload does not parse as JSON is
-         forwarded unconverted and logged at {!Log.Transport.warn}.
+         failure.  A missing or malformed [data:] payload is projected to a
+         schema-valid AG-UI [CUSTOM] event named [MASC_EVENT_ENCODING_ERROR]
+         and logged at {!Log.Transport.warn}; raw MASC frames never cross this
+         endpoint's wire boundary.
        - ping: sleeps 30s, writes ": ping\\n\\n" comment frame to
          keep middleboxes from idling out the connection.
 
@@ -73,6 +75,10 @@ val handle_ag_ui_events :
     while this handler uses a local shadow to keep the AG-UI fiber
     independent of header-module evolution.  A future "let's unify"
     refactor must touch the duplicate explicitly. *)
+
+module For_testing : sig
+  val ag_ui_event_of_masc_event : string -> string
+end
 
 val handle_presence_events :
   deps:Server_mcp_transport_http_types.deps ->

--- a/lib/server/server_mcp_transport_http_agui.mli
+++ b/lib/server/server_mcp_transport_http_agui.mli
@@ -35,10 +35,11 @@ val handle_ag_ui_events :
     7. Send a synthetic AG-UI [Run_started] prime event so the client
        can observe the connection has settled.
     8. If [last-event-id] was present, replay missed observer events via
-       {!Sse.get_events_after_for_kind}, each converted to the AG-UI wire
-       format.
+       {!Sse.get_events_after_for_kind}, each converted from its canonical
+       typed delivery to the AG-UI wire format. Replay/live overlap is removed
+       by exact event id.
     9. Spawn two fibers under the runtime switch:
-       - drain: pulls from per-session stream, converts each frame to the
+       - drain: pulls typed deliveries from the per-session stream, converts each frame to the
          AG-UI wire format, writes to client, self-terminates on send
          failure.  A missing or malformed [data:] payload is projected to a
          schema-valid AG-UI [CUSTOM] event named [MASC_EVENT_ENCODING_ERROR]
@@ -75,10 +76,6 @@ val handle_ag_ui_events :
     while this handler uses a local shadow to keep the AG-UI fiber
     independent of header-module evolution.  A future "let's unify"
     refactor must touch the duplicate explicitly. *)
-
-module For_testing : sig
-  val ag_ui_event_of_masc_event : string -> string
-end
 
 val handle_presence_events :
   deps:Server_mcp_transport_http_types.deps ->

--- a/lib/server/server_mcp_transport_http_agui.mli
+++ b/lib/server/server_mcp_transport_http_agui.mli
@@ -35,10 +35,13 @@ val handle_ag_ui_events :
     7. Send a synthetic AG-UI [Run_started] prime event so the client
        can observe the connection has settled.
     8. If [last-event-id] was present, replay missed observer events via
-       {!Sse.get_events_after_for_kind}.
+       {!Sse.get_events_after_for_kind}, each converted to the AG-UI wire
+       format.
     9. Spawn two fibers under the runtime switch:
-       - drain: pulls from per-session stream, writes raw to client,
-         self-terminates on send failure.
+       - drain: pulls from per-session stream, converts each frame to the
+         AG-UI wire format, writes to client, self-terminates on send
+         failure.  A frame whose [data:] payload does not parse as JSON is
+         forwarded unconverted and logged at {!Log.Transport.warn}.
        - ping: sleeps 30s, writes ": ping\\n\\n" comment frame to
          keep middleboxes from idling out the connection.
 

--- a/lib/server/server_mcp_transport_http_headers.ml
+++ b/lib/server/server_mcp_transport_http_headers.ml
@@ -211,11 +211,19 @@ let sse_comment_with_retry ~comment =
 
 let sse_ping_interval_s = 30.0
 
+type last_event_id_error = Malformed_last_event_id
+
+let last_event_id_error_to_string = function
+  | Malformed_last_event_id ->
+      "Last-Event-ID must be an integer when supplied"
+
 let get_last_event_id (request : Httpun.Request.t) =
   match Httpun.Headers.get request.headers "last-event-id" with
   | Some id -> (
-      int_of_string_opt (id))
-  | None -> None
+      match int_of_string_opt id with
+      | Some event_id -> Ok (Some event_id)
+      | None -> Error Malformed_last_event_id)
+  | None -> Ok None
 
 let mcp_headers session_id protocol_version =
   if Mcp_transport_protocol.is_stateless_protocol_version protocol_version then

--- a/lib/server/server_mcp_transport_http_headers.ml
+++ b/lib/server/server_mcp_transport_http_headers.ml
@@ -211,17 +211,22 @@ let sse_comment_with_retry ~comment =
 
 let sse_ping_interval_s = 30.0
 
-type last_event_id_error = Malformed_last_event_id
+type last_event_id_error =
+  | Malformed_last_event_id
+  | Negative_last_event_id
 
 let last_event_id_error_to_string = function
   | Malformed_last_event_id ->
-      "Last-Event-ID must be an integer when supplied"
+      "Last-Event-ID must be a non-negative integer when supplied"
+  | Negative_last_event_id ->
+      "Last-Event-ID cannot be negative"
 
 let get_last_event_id (request : Httpun.Request.t) =
   match Httpun.Headers.get request.headers "last-event-id" with
   | Some id -> (
       match int_of_string_opt id with
-      | Some event_id -> Ok (Some event_id)
+      | Some event_id when event_id >= 0 -> Ok (Some event_id)
+      | Some _ -> Error Negative_last_event_id
       | None -> Error Malformed_last_event_id)
   | None -> Ok None
 

--- a/lib/server/server_mcp_transport_http_headers.ml
+++ b/lib/server/server_mcp_transport_http_headers.ml
@@ -199,8 +199,7 @@ let force_json_response = env_flag "MASC_FORCE_JSON_RESPONSE"
 let sse_retry_ms = 3000
 
 let sse_prime_event () =
-  let id = Sse.next_id () in
-  Printf.sprintf "retry: %d\nid: %d\n\n" sse_retry_ms id
+  Printf.sprintf "retry: %d\n\n" sse_retry_ms
 
 (* RFC-0089: SSE comment line + reconnect [retry:] directive, sourced from the
    [sse_retry_ms] SSOT. Stream priming sites (presence, activity) used to inline

--- a/lib/server/server_mcp_transport_http_headers.mli
+++ b/lib/server/server_mcp_transport_http_headers.mli
@@ -166,7 +166,9 @@ val sse_ping_interval_s : float
     duplicated in {!Server_mcp_transport_http_agui} (the duplicate
     is intentional — see that module's contract). *)
 
-type last_event_id_error = Malformed_last_event_id
+type last_event_id_error =
+  | Malformed_last_event_id
+  | Negative_last_event_id
 (** A malformed [Last-Event-ID] header is a request error, not an
     absent replay cursor. *)
 
@@ -175,6 +177,6 @@ val last_event_id_error_to_string : last_event_id_error -> string
 val get_last_event_id :
   Httpun.Request.t -> (int option, last_event_id_error) result
 (** [get_last_event_id request] parses the [last-event-id] header.
-    [Ok None] means that the header is absent.  A present header that
-    is not an integer is returned as [Error] so callers cannot silently
+    [Ok None] means that the header is absent. A present header that is not a
+    non-negative integer is returned as [Error] so callers cannot silently
     restart replay from the origin. *)

--- a/lib/server/server_mcp_transport_http_headers.mli
+++ b/lib/server/server_mcp_transport_http_headers.mli
@@ -166,8 +166,15 @@ val sse_ping_interval_s : float
     duplicated in {!Server_mcp_transport_http_agui} (the duplicate
     is intentional — see that module's contract). *)
 
-val get_last_event_id : Httpun.Request.t -> int option
-(** [get_last_event_id request] reads the [last-event-id] header
-    and parses it as an integer.  Returns [None] when the header
-    is absent or non-integer.  Used to drive event replay on SSE
-    reconnect. *)
+type last_event_id_error = Malformed_last_event_id
+(** A malformed [Last-Event-ID] header is a request error, not an
+    absent replay cursor. *)
+
+val last_event_id_error_to_string : last_event_id_error -> string
+
+val get_last_event_id :
+  Httpun.Request.t -> (int option, last_event_id_error) result
+(** [get_last_event_id request] parses the [last-event-id] header.
+    [Ok None] means that the header is absent.  A present header that
+    is not an integer is returned as [Error] so callers cannot silently
+    restart replay from the origin. *)

--- a/lib/server/server_mcp_transport_http_headers.mli
+++ b/lib/server/server_mcp_transport_http_headers.mli
@@ -149,9 +149,9 @@ val sse_retry_ms : int
 
 val sse_prime_event : unit -> string
 (** [sse_prime_event ()] returns the SSE prime frame
-    [["retry: <sse_retry_ms>\nid: <next>\n\n"]] with a fresh id
-    from {!Sse.next_id}.  The trailing double-newline is the SSE
-    frame terminator — required by the spec. *)
+    [["retry: <sse_retry_ms>\n\n"]]. It deliberately carries no [id]: a
+    transport-only prime is absent from the replay store and therefore cannot
+    advance the client's durable replay cursor. *)
 
 val sse_comment_with_retry : comment:string -> string
 (** [sse_comment_with_retry ~comment] returns an SSE comment frame

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -645,49 +645,6 @@ type parsed_sse_event = {
 let parse_cache : (string * parsed_sse_event option) Atomic.t =
   Atomic.make ("", None)
 
-(** Extract the JSON body from an SSE-formatted event string.
-
-    [Sse.format_event] emits [data: <body>] today, but the parser should
-    not depend on that line staying in a fixed position.  External
-    subscribers receive the full SSE-formatted string (gRPC stuffs it
-    into payload_json verbatim and lets the gRPC client re-parse), so the
-    WS callback must peel the SSE wrapper before feeding
-    [Yojson.Safe.from_string].
-
-    The earlier implementation skipped this step, so every production
-    parse failed and send_dashboard_delta_for_sse always fell through to
-    raw-SSE-forward — defeating the parse cache, slice-aware fanout
-    (Phase 2 of #10119), and delta-built counter.  Pure-JSON inputs
-    (the unit-test path) still work via the [_ -> Some sse_event]
-    fallback. *)
-let sse_data_prefix = "data:"
-
-let extract_sse_data_payload_line line =
-  if String.starts_with ~prefix:sse_data_prefix line then
-    let line_len = String.length line in
-    let prefix_len = String.length sse_data_prefix in
-    (* Per RFC: a single optional space follows "data:". Fold the skip
-       into the same [String.sub] to avoid an intermediate allocation
-       on the dashboard fanout hot path (~1 alloc per SSE data line). *)
-    let start =
-      if line_len > prefix_len && Char.equal line.[prefix_len] ' '
-      then prefix_len + 1
-      else prefix_len
-    in
-    Some (String.sub line start (line_len - start))
-  else None
-
-let extract_sse_data_line sse_event =
-  match
-    String.split_on_char '\n' sse_event
-    |> List.filter_map extract_sse_data_payload_line
-  with
-  | [] ->
-      (* Not an SSE data event — pass through as-is so unit tests that
-         hand us pure JSON keep working. *)
-      Some sse_event
-  | data_lines -> Some (String.concat "\n" data_lines)
-
 let parse_sse_dashboard_event sse_event =
   let cached_str, cached_val = Atomic.get parse_cache in
   if cached_str == sse_event then begin
@@ -697,9 +654,13 @@ let parse_sse_dashboard_event sse_event =
   else begin
     Transport_metrics.inc_ws_parse_cache_miss ();
     let result =
-      match extract_sse_data_line sse_event with
-      | None -> None
-      | Some json_body ->
+      match Sse.data_payload_of_frame sse_event with
+      | Error Sse.Missing_data_payload ->
+          Log.Server.warn "[mcp-ws] dropping frame without an SSE data field";
+          Transport_metrics.inc_ws_frame_json_parse_failure
+            ~error_kind:Transport_metrics.Other_ws_frame_json_parse_error;
+          None
+      | Ok json_body ->
         match Yojson.Safe.from_string json_body with
         | exception (Yojson.Json_error msg) ->
             (* Iter 28: previously silently dropped — now emit a counter

--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -141,8 +141,6 @@ let classify_mcp_accept = Server_mcp_transport_http.classify_mcp_accept
 
 let force_json_response = Server_mcp_transport_http.force_json_response
 
-let get_last_event_id = Server_mcp_transport_http.get_last_event_id
-
 let mcp_transport_http_deps () : Server_mcp_transport_http.deps =
   let mcp_eio_profile_of_transport_profile = function
     | Server_mcp_transport_http.Full -> Mcp_server_eio.Full

--- a/lib/server/server_routes_http_common.mli
+++ b/lib/server/server_routes_http_common.mli
@@ -144,10 +144,6 @@ val classify_mcp_accept :
   Httpun.Request.t ->
   Mcp_transport_protocol.Http_negotiation.accept_mode
 val force_json_response : bool
-val get_last_event_id :
-  Httpun.Request.t ->
-  (int option, Server_mcp_transport_http_headers.last_event_id_error) result
-
 (** {1 Header builders} *)
 
 val mcp_headers : string -> string -> (string * string) list

--- a/lib/server/server_routes_http_common.mli
+++ b/lib/server/server_routes_http_common.mli
@@ -144,7 +144,9 @@ val classify_mcp_accept :
   Httpun.Request.t ->
   Mcp_transport_protocol.Http_negotiation.accept_mode
 val force_json_response : bool
-val get_last_event_id : Httpun.Request.t -> int option
+val get_last_event_id :
+  Httpun.Request.t ->
+  (int option, Server_mcp_transport_http_headers.last_event_id_error) result
 
 (** {1 Header builders} *)
 

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -288,6 +288,11 @@ let client_id_counter = Atomic.make 0
 (** Global event counter for resumability *)
 let event_counter = Atomic.make 0
 
+(* Event id allocation, replay-buffer commit, and per-client enqueue are one
+   ordered publication boundary. Producers may run on different domains, so
+   the short non-yielding critical section uses a standard-library mutex. *)
+let delivery_fanout_mutex = Stdlib.Mutex.create ()
+
 (** Event buffer for resumability stores canonical deliveries.
 
     [event_buffer] is written by every [broadcast_impl] / [send_to] and
@@ -971,8 +976,10 @@ let reap_dead_external_subscribers () =
 
 (** Internal broadcast implementation shared by [broadcast] and [broadcast_to].
     Pushes the canonical delivery into each matching client's
-    [event_stream].  The registry snapshot is immutable; the per-stream
-    [Eio.Stream.add] calls happen outside any global lock.
+    [event_stream].  Event-id allocation, replay-buffer commit, and live
+    enqueue are serialized so every client observes the same cursor order.
+    Logging, disconnect hooks, snapshots, and external callbacks stay outside
+    that short publication boundary.
 
     [Eio.Stream.add] on a bounded (capacity 64) stream returns
     immediately as long as the stream is not full.  The per-client drain
@@ -987,6 +994,14 @@ let broadcast_impl ?(buffer = true) ?(notify_external = true)
   let jsonrpc_payload =
     Sse_jsonrpc_filter.jsonrpc_message_for_agent_stream json
   in
+  let target_label = match target with
+    | All -> "all"
+    | Observers -> "observers"
+    | Agent_streams -> "agent_streams"
+    | Presence_only -> "presence"
+  in
+  let delivery, failed =
+    Stdlib.Mutex.protect delivery_fanout_mutex (fun () ->
   (* Atomically allocate the event id so two concurrent broadcasts
      cannot observe the same peeked counter value and emit duplicates. *)
   let current_event_id = next_id () in
@@ -1006,22 +1021,15 @@ let broadcast_impl ?(buffer = true) ?(notify_external = true)
      subscribe/unsubscribe), so we iterate it directly with [SMap.iter].
      Skipping the [(k, v) :: acc] fold trims one tuple + cons cell per
      client per broadcast on this hot fan-out path. *)
-  let target_label = match target with
-    | All -> "all"
-    | Observers -> "observers"
-    | Agent_streams -> "agent_streams"
-    | Presence_only -> "presence"
-  in
   let clients_entries = (Atomic.get clients).entries in
   let failed = ref [] in
   SMap.iter (fun session_id client ->
     if client_matches_target target ~jsonrpc_payload client
        && current_event_id > Atomic.get client.last_event_id then begin
       (* Pre-check stream capacity to avoid blocking broadcast.
-         No TOCTOU risk: single-domain Eio cooperative scheduling has no
-         yield point between Stream.length and Stream.add, so no other
-         fiber can modify the stream in between.  try/catch kept as
-         defense-in-depth for unexpected failures.
+         No producer can fill the stream between [length] and [add] because
+         all producers share [delivery_fanout_mutex]; consumers only reduce
+         its length.  try/catch is retained as defense-in-depth.
          See TLA+ SSEBroadcastBlock spec. *)
       (let queue_len = Eio.Stream.length client.event_stream in
        if queue_len >= stream_capacity then begin
@@ -1039,11 +1047,7 @@ let broadcast_impl ?(buffer = true) ?(notify_external = true)
             saw "WS events stop arriving" with no error indication and
             had to manually refresh.  See plan
             [planning/claude-plans/me-workspace-yousleepwhen-masc-radiant-piglet.md]. *)
-         Transport_metrics.inc_broadcast_failure ~target:target_label ();
-         Log.Server.warn
-           "Broadcast skip: session %s stream full (%d/%d) — disconnecting"
-           session_id queue_len stream_capacity;
-         failed := session_id :: !failed
+         failed := (session_id, `Full queue_len) :: !failed
        end else
          try
            Eio.Stream.add client.event_stream delivery;
@@ -1052,15 +1056,25 @@ let broadcast_impl ?(buffer = true) ?(notify_external = true)
          with
          | Eio.Cancel.Cancelled _ as e -> raise e
          | e ->
-             (* Same P1 fix on the unexpected-exception defense path. *)
-             Transport_metrics.inc_broadcast_failure ~target:target_label ();
-             Log.Server.error "Broadcast enqueue failed for session %s: %s"
-               session_id (Printexc.to_string e);
-             failed := session_id :: !failed)
+             failed := (session_id, `Raised e) :: !failed)
     end
   ) clients_entries;
+  delivery, !failed)
+  in
+  List.iter
+    (fun (session_id, failure) ->
+       Transport_metrics.inc_broadcast_failure ~target:target_label ();
+       match failure with
+       | `Full queue_len ->
+         Log.Server.warn
+           "Broadcast skip: session %s stream full (%d/%d) — disconnecting"
+           session_id queue_len stream_capacity
+       | `Raised e ->
+         Log.Server.error "Broadcast enqueue failed for session %s: %s"
+           session_id (Printexc.to_string e))
+    failed;
   (* Remove failed connections *)
-  List.iter (fun sid -> unregister sid) !failed;
+  List.iter (fun (session_id, _) -> unregister session_id) failed;
   (* Record broadcast duration for transport observability *)
   let elapsed = Time_compat.now () -. t0 in
   Transport_metrics.observe_broadcast_duration ~target:target_label elapsed;
@@ -1095,28 +1109,46 @@ let send_to session_id json =
       "Dropping non-JSON-RPC payload sent via Sse.send_to for session %s"
       session_id
   else
-  let current_event_id = next_id () in
-  let delivery =
-    { event_id = current_event_id
-    ; frame = format_event_yojson ~id:current_event_id ~event_type:"message" json
-    ; emitted_at = Time_compat.now ()
-    }
+  let outcome =
+    Stdlib.Mutex.protect delivery_fanout_mutex (fun () ->
+      let current_event_id = next_id () in
+      let delivery =
+        { event_id = current_event_id
+        ; frame = format_event_yojson ~id:current_event_id ~event_type:"message" json
+        ; emitted_at = Time_compat.now ()
+        }
+      in
+      buffer_event delivery;
+      match SMap.find_opt session_id (Atomic.get clients).entries with
+      | None -> `Absent
+      | Some client ->
+          let queue_len = Eio.Stream.length client.event_stream in
+          if queue_len >= stream_capacity then
+            `Full queue_len
+          else
+            try
+              Eio.Stream.add client.event_stream delivery;
+              Atomic.set client.last_event_id current_event_id;
+              mark_seen client;
+              `Enqueued
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | e -> `Raised e)
   in
-  buffer_event delivery;
-  let client_opt = SMap.find_opt session_id (Atomic.get clients).entries in
-  match client_opt with
-  | None -> ()
-  | Some client ->
-      (try
-        Eio.Stream.add client.event_stream delivery;
-        Atomic.set client.last_event_id current_event_id;
-        mark_seen client;
-        sync_transport_snapshot ()
-      with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | e ->
-          Log.Server.error "Enqueue to %s failed: %s"
-            session_id (Printexc.to_string e))
+  match outcome with
+  | `Absent -> ()
+  | `Enqueued -> sync_transport_snapshot ()
+  | `Full queue_len ->
+      Transport_metrics.inc_broadcast_failure ~target:"send_to" ();
+      Log.Server.warn
+        "Targeted enqueue skip: session %s stream full (%d/%d) — disconnecting"
+        session_id queue_len stream_capacity;
+      unregister session_id
+  | `Raised e ->
+      Transport_metrics.inc_broadcast_failure ~target:"send_to" ();
+      Log.Server.error "Enqueue to %s failed: %s — disconnecting"
+        session_id (Printexc.to_string e);
+      unregister session_id
 
 (** Pop the next event from a client's stream.
     Blocks the calling fiber until an event is available.

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -115,10 +115,15 @@ type broadcast_target =
   | Agent_streams (** Only [Agent_stream] sessions *)
   | Presence_only (** Only [Presence] sessions; never replay-buffered *)
 
+type delivery_audience =
+  | Broadcast_audience of broadcast_target
+  | Session_audience of string
+
 type delivery =
   { event_id : int
   ; frame : string
   ; emitted_at : float
+  ; audience : delivery_audience
   }
 
 (** Maximum concurrent SSE clients -- prevents connection storm on restart.
@@ -364,22 +369,38 @@ let buffer_event delivery =
     in
     { next_state = { events_by_id; count }; result = () })
 
-let event_matches_session_kind kind event =
-  match kind with
-  | Observer -> true
-  | Agent_stream ->
-    Sse_jsonrpc_filter.event_string_jsonrpc_message_for_agent_stream event.frame
-  | Presence -> false
+let session_kind_matches_target target ~jsonrpc_payload kind =
+  match target with
+  | All -> (
+      match kind with
+      | Observer -> true
+      | Agent_stream -> jsonrpc_payload
+      | Presence -> false)
+  | Observers -> kind = Observer
+  | Agent_streams -> kind = Agent_stream && jsonrpc_payload
+  | Presence_only -> kind = Presence
+
+let event_matches_session ~session_id ~kind event =
+  match event.audience with
+  | Session_audience target_session_id ->
+    kind = Agent_stream && String.equal target_session_id session_id
+  | Broadcast_audience target ->
+    let jsonrpc_payload =
+      Sse_jsonrpc_filter.event_string_jsonrpc_message_for_agent_stream event.frame
+    in
+    session_kind_matches_target target ~jsonrpc_payload kind
 
 (** Get events after given ID for replay (MCP spec MUST) *)
-let get_events_after last_id =
+let get_events_after_raw last_id =
   let state = Atomic.get event_buffer in
   let _older_or_equal, _at_last_id, newer = IntMap.split last_id state.events_by_id in
   newer |> IntMap.bindings |> List.map snd
 
-let get_events_after_for_kind kind last_id =
-  get_events_after last_id
-  |> List.filter (event_matches_session_kind kind)
+let get_events_after_for_test = get_events_after_raw
+
+let get_events_after_for_session ~session_id ~kind last_id =
+  get_events_after_raw last_id
+  |> List.filter (event_matches_session ~session_id ~kind)
 
 type replay_handoff = IntSet.t ref
 
@@ -430,12 +451,12 @@ let cleanup_expired_events () =
     that both peek the counter, both get the same value, and then
     both pass it as [~id] would emit events with the **same** id,
     breaking MCP SSE resumability (the [last_event_id] filter in
-    [get_events_after] skips by id, so a duplicate would be
+    replay lookup skips by id, so a duplicate would be
     dropped).
 
     When [~id] is omitted the frame is transport-only: it does not advance the
-    durable replay cursor. Only callers that have committed the same delivery
-    to the replay buffer may attach an id. *)
+    replay cursor. Only callers inside the ordered delivery publication
+    boundary may attach an id. *)
 let format_event ?id ?event_type data =
   (* Hot path: every broadcast goes through here once.  The previous
      three [Printf.sprintf] calls each ran the format interpreter and
@@ -756,15 +777,7 @@ let update_last_event_id session_id event_id =
   | None -> ()
 
 let client_matches_target target ~jsonrpc_payload (client : client) =
-  match target with
-  | All -> (
-      match client.kind with
-      | Observer -> true
-      | Agent_stream -> jsonrpc_payload
-      | Presence -> false)
-  | Observers -> client.kind = Observer
-  | Agent_streams -> client.kind = Agent_stream && jsonrpc_payload
-  | Presence_only -> client.kind = Presence
+  session_kind_matches_target target ~jsonrpc_payload client.kind
 
 (** {1 External Subscriber Hook}
 
@@ -1002,6 +1015,7 @@ let broadcast_impl ?(buffer = true) ?(notify_external = true)
     { event_id = current_event_id
     ; frame = format_event_yojson ~id:current_event_id ~event_type json
     ; emitted_at = t0
+    ; audience = Broadcast_audience target
     }
   in
   if buffer then
@@ -1106,11 +1120,13 @@ let send_to session_id json =
         { event_id = current_event_id
         ; frame = format_event_yojson ~id:current_event_id ~event_type:"message" json
         ; emitted_at = Time_compat.now ()
+        ; audience = Session_audience session_id
         }
       in
       buffer_event delivery;
       match SMap.find_opt session_id (Atomic.get clients).entries with
       | None -> `Absent
+      | Some client when client.kind <> Agent_stream -> `Wrong_kind client.kind
       | Some client ->
           let queue_len = Eio.Stream.length client.event_stream in
           if queue_len >= stream_capacity then
@@ -1127,6 +1143,15 @@ let send_to session_id json =
   in
   match outcome with
   | `Absent -> ()
+  | `Wrong_kind kind ->
+      let kind_label = match kind with
+        | Observer -> "observer"
+        | Agent_stream -> "agent_stream"
+        | Presence -> "presence"
+      in
+      Log.Server.error
+        "Targeted JSON-RPC delivery rejected for non-agent session %s (%s)"
+        session_id kind_label
   | `Enqueued -> sync_transport_snapshot ()
   | `Full queue_len ->
       Transport_metrics.inc_broadcast_failure ~target:"send_to" ();

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -433,33 +433,28 @@ let cleanup_expired_events () =
     [get_events_after] skips by id, so a duplicate would be
     dropped).
 
-    When [~id] is omitted (external callers in
-    [server_mcp_transport_http] / [server_mcp_transport_http_agui])
-    this function still allocates a fresh id atomically, preserving
-    their contract. *)
+    When [~id] is omitted the frame is transport-only: it does not advance the
+    durable replay cursor. Only callers that have committed the same delivery
+    to the replay buffer may attach an id. *)
 let format_event ?id ?event_type data =
-  let effective_id =
-    match id with
-    | Some i -> i
-    | None ->
-        (* Atomic fetch_and_add: returns old value, we want new value so +1 *)
-        Atomic.fetch_and_add event_counter 1 + 1
-  in
   (* Hot path: every broadcast goes through here once.  The previous
      three [Printf.sprintf] calls each ran the format interpreter and
      allocated an intermediate string ([id_line], [event_line], the
      concat), so a single broadcast paid for three string allocations
      plus the [%d]/[%s] dispatch overhead before the result string was
      produced.  A single [Buffer] accumulator with primitive
-     [string_of_int] sidesteps the format interpreter entirely and
-     emits exactly the bytes the SSE wire format requires (id-line +
-     optional event-line + one [data:] line per logical data line + blank).
-     Single-line payloads remain byte-for-byte identical to the previous
-     output. *)
+     [string_of_int] sidesteps the format interpreter entirely and emits the
+     SSE wire format (optional id/event lines + one [data:] line per logical
+     data line + blank).
+     Frames with an explicit id remain byte-for-byte identical to the previous
+     canonical output. *)
   let buf = Buffer.create 64 in
-  Buffer.add_string buf "id: ";
-  Buffer.add_string buf (string_of_int effective_id);
-  Buffer.add_char buf '\n';
+  (match id with
+   | None -> ()
+   | Some event_id ->
+       Buffer.add_string buf "id: ";
+       Buffer.add_string buf (string_of_int event_id);
+       Buffer.add_char buf '\n');
   (match event_type with
    | Some e ->
        Buffer.add_string buf "event: ";
@@ -478,15 +473,10 @@ let format_event ?id ?event_type data =
     [to_string] allocation.  Writes JSON bytes directly into the SSE event
     buffer via [Yojson.Safe.to_buffer], cutting one string allocation per
     broadcast (~9/sec → ~9 fewer short-lived strings/sec for GC to collect). *)
-let format_event_yojson ?id ?event_type json =
-  let effective_id =
-    match id with
-    | Some i -> i
-    | None -> Atomic.fetch_and_add event_counter 1 + 1
-  in
+let format_event_yojson ~id ?event_type json =
   let buf = Buffer.create 128 in
   Buffer.add_string buf "id: ";
-  Buffer.add_string buf (string_of_int effective_id);
+  Buffer.add_string buf (string_of_int id);
   Buffer.add_char buf '\n';
   (match event_type with
    | Some e ->

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -495,11 +495,14 @@ let format_event ?id ?event_type data =
     [to_string] allocation.  Writes JSON bytes directly into the SSE event
     buffer via [Yojson.Safe.to_buffer], cutting one string allocation per
     broadcast (~9/sec → ~9 fewer short-lived strings/sec for GC to collect). *)
-let format_event_yojson ~id ?event_type json =
+let format_event_yojson ?id ?event_type json =
   let buf = Buffer.create 128 in
-  Buffer.add_string buf "id: ";
-  Buffer.add_string buf (string_of_int id);
-  Buffer.add_char buf '\n';
+  Option.iter
+    (fun id ->
+       Buffer.add_string buf "id: ";
+       Buffer.add_string buf (string_of_int id);
+       Buffer.add_char buf '\n')
+    id;
   (match event_type with
    | Some e ->
        Buffer.add_string buf "event: ";

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -60,15 +60,6 @@ let registration_error_to_string = function
 
 type data_payload_error = Missing_data_payload
 
-type parsed_frame =
-  { event_id : int option
-  ; data_payload : string
-  }
-
-type frame_parse_error =
-  | Frame_missing_data_payload
-  | Frame_invalid_event_id
-
 let data_payload_line line =
   let line_len = String.length line in
   let line_len =
@@ -97,39 +88,10 @@ let data_payload_of_frame frame =
   | [] -> Error Missing_data_payload
   | payload_lines -> Ok (String.concat "\n" payload_lines)
 
-let event_id_line line =
-  let line =
-    if String.ends_with ~suffix:"\r" line
-    then String.sub line 0 (String.length line - 1)
-    else line
-  in
-  let prefix = "id:" in
-  if String.starts_with ~prefix line
-  then
-    let value =
-      String.sub line (String.length prefix) (String.length line - String.length prefix)
-      |> String.trim
-    in
-    Some value
-  else None
-
-let parse_frame frame =
-  let lines = String.split_on_char '\n' frame in
-  let event_ids = List.filter_map event_id_line lines in
-  match data_payload_of_frame frame with
-  | Error Missing_data_payload -> Error Frame_missing_data_payload
-  | Ok data_payload ->
-    (match event_ids with
-     | [] -> Ok { event_id = None; data_payload }
-     | [ value ] ->
-       (match int_of_string_opt value with
-        | Some id when id >= 0 -> Ok { event_id = Some id; data_payload }
-        | Some _ | None -> Error Frame_invalid_event_id)
-     | _ :: _ :: _ -> Error Frame_invalid_event_id)
-
 (** Classification of an SSE session's traffic role. *)
 module SMap = Set_util.StringMap
 module IntMap = Map.Make (Int)
+module IntSet = Set.Make (Int)
 
 (* Test-only hooks for forcing a CAS retry in white-box unit tests. *)
 let register_commit_test_hook : (unit -> unit) option Atomic.t = Atomic.make None
@@ -152,6 +114,12 @@ type broadcast_target =
   | Observers    (** Only [Observer] sessions *)
   | Agent_streams (** Only [Agent_stream] sessions *)
   | Presence_only (** Only [Presence] sessions; never replay-buffered *)
+
+type delivery =
+  { event_id : int
+  ; frame : string
+  ; emitted_at : float
+  }
 
 (** Maximum concurrent SSE clients -- prevents connection storm on restart.
     Increased from 50 to 200 to handle Claude.ai MCP client reconnections. *)
@@ -185,7 +153,7 @@ let stream_capacity =
 type client = {
   id: int;
   kind: session_kind;
-  event_stream: string Eio.Stream.t;
+  event_stream: delivery Eio.Stream.t;
   last_event_id: int Atomic.t;
   created_at: float;
   last_seen_at: float Atomic.t;
@@ -320,7 +288,7 @@ let client_id_counter = Atomic.make 0
 (** Global event counter for resumability *)
 let event_counter = Atomic.make 0
 
-(** Event buffer for resumability - stores (event_id, event_string, timestamp)
+(** Event buffer for resumability stores canonical deliveries.
 
     [event_buffer] is written by every [broadcast_impl] / [send_to] and
     drained by the periodic [cleanup_expired_events] background fiber.
@@ -342,10 +310,8 @@ let max_buffer_size =
     (Env_config_core.get_int ~default "MASC_SSE_REPLAY_BUFFER_SIZE")
 let buffer_ttl_seconds = Env_config.InternalTimers.sse_buffer_ttl_sec
 
-type buffered_event = int * string * float
-
 type event_buffer_state = {
-  events_by_id : buffered_event IntMap.t;
+  events_by_id : delivery IntMap.t;
   count : int;
 }
 
@@ -357,8 +323,8 @@ let event_buffer : event_buffer_state Atomic.t =
 let event_buffer_state_of_events events =
   let events_by_id =
     List.fold_left
-      (fun acc (((event_id, _, _) as event) : buffered_event) ->
-         IntMap.add event_id event acc)
+      (fun acc (delivery : delivery) ->
+         IntMap.add delivery.event_id delivery acc)
       IntMap.empty events
   in
   { events_by_id; count = IntMap.cardinal events_by_id }
@@ -376,14 +342,14 @@ let rewrite_event_buffer_for_test () =
   Lockfree_atomic.update event_buffer (fun state ->
     { state with count = state.count })
 
-(** Add event to buffer, maintaining max size *)
-let buffer_event event_id event_str =
+(** Add one canonical delivery to the replay buffer, maintaining max size. *)
+let buffer_event delivery =
   Lockfree_atomic.update_with_commit event_buffer (fun state ->
     run_test_hook buffer_commit_test_hook;
-    let timestamp = Time_compat.now () in
-    let event = (event_id, event_str, timestamp) in
-    let replacing = IntMap.mem event_id state.events_by_id in
-    let events_by_id = IntMap.add event_id event state.events_by_id in
+    let replacing = IntMap.mem delivery.event_id state.events_by_id in
+    let events_by_id =
+      IntMap.add delivery.event_id delivery state.events_by_id
+    in
     let count = if replacing then state.count else state.count + 1 in
     let events_by_id, count =
       if count <= max_buffer_size then events_by_id, count
@@ -396,18 +362,37 @@ let buffer_event event_id event_str =
 let event_matches_session_kind kind event =
   match kind with
   | Observer -> true
-  | Agent_stream -> Sse_jsonrpc_filter.event_string_jsonrpc_message_for_agent_stream event
+  | Agent_stream ->
+    Sse_jsonrpc_filter.event_string_jsonrpc_message_for_agent_stream event.frame
   | Presence -> false
 
 (** Get events after given ID for replay (MCP spec MUST) *)
 let get_events_after last_id =
   let state = Atomic.get event_buffer in
   let _older_or_equal, _at_last_id, newer = IntMap.split last_id state.events_by_id in
-  newer |> IntMap.bindings |> List.map (fun (_id, (_event_id, ev, _ts)) -> ev)
+  newer |> IntMap.bindings |> List.map snd
 
 let get_events_after_for_kind kind last_id =
   get_events_after last_id
   |> List.filter (event_matches_session_kind kind)
+
+type replay_handoff = IntSet.t ref
+
+let create_replay_handoff deliveries =
+  ref
+    (List.fold_left
+       (fun ids (delivery : delivery) -> IntSet.add delivery.event_id ids)
+       IntSet.empty
+       deliveries)
+;;
+
+let accept_live_delivery handoff (delivery : delivery) =
+  if IntSet.mem delivery.event_id !handoff
+  then (
+    handoff := IntSet.remove delivery.event_id !handoff;
+    false)
+  else true
+;;
 
 (** Remove events older than [buffer_ttl_seconds] from the front of the buffer.
     Returns count of evicted events. *)
@@ -416,11 +401,11 @@ let cleanup_expired_events () =
   Lockfree_atomic.update_with_commit event_buffer (fun state ->
     let events_by_id, evicted =
       IntMap.fold
-        (fun id (((_event_id, _ev, ts) as item) : buffered_event) (kept, evicted) ->
-          if now -. ts > buffer_ttl_seconds then
+        (fun id (delivery : delivery) (kept, evicted) ->
+          if now -. delivery.emitted_at > buffer_ttl_seconds then
             (kept, evicted + 1)
           else
-            (IntMap.add id item kept, evicted))
+            (IntMap.add id delivery kept, evicted))
         state.events_by_id
         (IntMap.empty, 0)
     in
@@ -981,7 +966,7 @@ let reap_dead_external_subscribers () =
   List.length removed_ids
 
 (** Internal broadcast implementation shared by [broadcast] and [broadcast_to].
-    Pushes the formatted event string into each matching client's
+    Pushes the canonical delivery into each matching client's
     [event_stream].  The registry snapshot is immutable; the per-stream
     [Eio.Stream.add] calls happen outside any global lock.
 
@@ -991,7 +976,7 @@ let reap_dead_external_subscribers () =
     independently, so broadcast is decoupled from per-connection I/O.
 
     After SSE fan-out, external subscribers (gRPC streams, etc.) are
-    also notified with the same formatted event string. *)
+    notified with the delivery's formatted frame. *)
 let broadcast_impl ?(buffer = true) ?(notify_external = true)
     ?(event_type = "message") target json =
   let t0 = Time_compat.now () in
@@ -1004,9 +989,14 @@ let broadcast_impl ?(buffer = true) ?(notify_external = true)
   (* Write JSON directly into the SSE event buffer, avoiding the
      intermediate [Yojson.Safe.to_string] allocation.  The output
      is byte-for-byte identical to the previous two-step approach. *)
-  let event = format_event_yojson ~id:current_event_id ~event_type json in
+  let delivery =
+    { event_id = current_event_id
+    ; frame = format_event_yojson ~id:current_event_id ~event_type json
+    ; emitted_at = t0
+    }
+  in
   if buffer then
-    buffer_event current_event_id event;
+    buffer_event delivery;
   (* The [SMap.t] returned by [Atomic.get] is immutable
      (Lockfree_atomic.update_with_commit replaces it wholesale on
      subscribe/unsubscribe), so we iterate it directly with [SMap.iter].
@@ -1052,7 +1042,7 @@ let broadcast_impl ?(buffer = true) ?(notify_external = true)
          failed := session_id :: !failed
        end else
          try
-           Eio.Stream.add client.event_stream event;
+           Eio.Stream.add client.event_stream delivery;
            Atomic.set client.last_event_id current_event_id;
            mark_seen client
          with
@@ -1074,7 +1064,7 @@ let broadcast_impl ?(buffer = true) ?(notify_external = true)
   (* Notify external subscribers (gRPC streams, etc.) for durable broadcast
      traffic only. Presence is intentionally live-only and bufferless. *)
   if notify_external then
-    notify_external_subscribers event
+    notify_external_subscribers delivery.frame
 
 (** Broadcast event to all connected clients (backward-compatible). *)
 let broadcast json = broadcast_impl All json
@@ -1102,14 +1092,19 @@ let send_to session_id json =
       session_id
   else
   let current_event_id = next_id () in
-  let event = format_event_yojson ~id:current_event_id ~event_type:"message" json in
-  buffer_event current_event_id event;
+  let delivery =
+    { event_id = current_event_id
+    ; frame = format_event_yojson ~id:current_event_id ~event_type:"message" json
+    ; emitted_at = Time_compat.now ()
+    }
+  in
+  buffer_event delivery;
   let client_opt = SMap.find_opt session_id (Atomic.get clients).entries in
   match client_opt with
   | None -> ()
   | Some client ->
       (try
-        Eio.Stream.add client.event_stream event;
+        Eio.Stream.add client.event_stream delivery;
         Atomic.set client.last_event_id current_event_id;
         mark_seen client;
         sync_transport_snapshot ()
@@ -1138,14 +1133,16 @@ let pop session_id =
   let client_opt = SMap.find_opt session_id (Atomic.get clients).entries in
   match client_opt with
   | None -> None
-  | Some client -> Some (Eio.Stream.take client.event_stream)
+  | Some client -> Some (Eio.Stream.take client.event_stream).frame
 
 (** Non-blocking pop. Returns [Some event] if one is queued, [None] otherwise. *)
 let try_pop session_id =
   let client_opt = SMap.find_opt session_id (Atomic.get clients).entries in
   match client_opt with
   | None -> None
-  | Some client -> Eio.Stream.take_nonblocking client.event_stream
+  | Some client ->
+    Eio.Stream.take_nonblocking client.event_stream
+    |> Option.map (fun delivery -> delivery.frame)
 
 (** Get client count.
     Uses [Atomic.get] so it is safe to call from signal handlers. *)

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -459,60 +459,14 @@ let cleanup_expired_events () =
     replay cursor. Only callers inside the ordered delivery publication
     boundary may attach an id. *)
 let format_event ?id ?event_type data =
-  (* Hot path: every broadcast goes through here once.  The previous
-     three [Printf.sprintf] calls each ran the format interpreter and
-     allocated an intermediate string ([id_line], [event_line], the
-     concat), so a single broadcast paid for three string allocations
-     plus the [%d]/[%s] dispatch overhead before the result string was
-     produced.  A single [Buffer] accumulator with primitive
-     [string_of_int] sidesteps the format interpreter entirely and emits the
-     SSE wire format (optional id/event lines + one [data:] line per logical
-     data line + blank).
-     Frames with an explicit id remain byte-for-byte identical to the previous
-     canonical output. *)
-  let buf = Buffer.create 64 in
-  (match id with
-   | None -> ()
-   | Some event_id ->
-       Buffer.add_string buf "id: ";
-       Buffer.add_string buf (string_of_int event_id);
-       Buffer.add_char buf '\n');
-  (match event_type with
-   | Some e ->
-       Buffer.add_string buf "event: ";
-       Buffer.add_string buf e;
-       Buffer.add_char buf '\n'
-   | None -> ());
-  String.split_on_char '\n' data
-  |> List.iter (fun line ->
-       Buffer.add_string buf "data: ";
-       Buffer.add_string buf line;
-       Buffer.add_char buf '\n');
-  Buffer.add_char buf '\n';
-  Buffer.contents buf
+  Sse_wire.format_event ?id ?event_type data
 
 (** Format SSE event from a [Yojson.Safe.t] value without the intermediate
     [to_string] allocation.  Writes JSON bytes directly into the SSE event
     buffer via [Yojson.Safe.to_buffer], cutting one string allocation per
     broadcast (~9/sec → ~9 fewer short-lived strings/sec for GC to collect). *)
 let format_event_yojson ?id ?event_type json =
-  let buf = Buffer.create 128 in
-  Option.iter
-    (fun id ->
-       Buffer.add_string buf "id: ";
-       Buffer.add_string buf (string_of_int id);
-       Buffer.add_char buf '\n')
-    id;
-  (match event_type with
-   | Some e ->
-       Buffer.add_string buf "event: ";
-       Buffer.add_string buf e;
-       Buffer.add_char buf '\n'
-   | None -> ());
-  Buffer.add_string buf "data: ";
-  Yojson.Safe.to_buffer buf json;
-  Buffer.add_string buf "\n\n";
-  Buffer.contents buf
+  Sse_wire.format_event_yojson ?id ?event_type json
 
 (** Get current event ID *)
 let current_id () = Atomic.get event_counter

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -122,6 +122,7 @@ type delivery_audience =
 type delivery =
   { event_id : int
   ; frame : string
+  ; payload : Yojson.Safe.t
   ; emitted_at : float
   ; audience : delivery_audience
   }
@@ -1014,6 +1015,7 @@ let broadcast_impl ?(buffer = true) ?(notify_external = true)
   let delivery =
     { event_id = current_event_id
     ; frame = format_event_yojson ~id:current_event_id ~event_type json
+    ; payload = json
     ; emitted_at = t0
     ; audience = Broadcast_audience target
     }
@@ -1119,6 +1121,7 @@ let send_to session_id json =
       let delivery =
         { event_id = current_event_id
         ; frame = format_event_yojson ~id:current_event_id ~event_type:"message" json
+        ; payload = json
         ; emitted_at = Time_compat.now ()
         ; audience = Session_audience session_id
         }

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -58,6 +58,36 @@ let registration_error_to_string = function
         "SSE registration failed: session belongs to %s but token belongs to %s"
         session_agent token_agent
 
+type data_payload_error = Missing_data_payload
+
+let data_payload_line line =
+  let line_len = String.length line in
+  let line_len =
+    if line_len > 0 && Char.equal line.[line_len - 1] '\r'
+    then line_len - 1
+    else line_len
+  in
+  let prefix = "data:" in
+  let prefix_len = String.length prefix in
+  if line_len >= prefix_len
+     && String.equal (String.sub line 0 prefix_len) prefix
+  then
+    let payload_start =
+      if line_len > prefix_len && Char.equal line.[prefix_len] ' '
+      then prefix_len + 1
+      else prefix_len
+    in
+    Some (String.sub line payload_start (line_len - payload_start))
+  else None
+
+let data_payload_of_frame frame =
+  match
+    String.split_on_char '\n' frame
+    |> List.filter_map data_payload_line
+  with
+  | [] -> Error Missing_data_payload
+  | payload_lines -> Ok (String.concat "\n" payload_lines)
+
 (** Classification of an SSE session's traffic role. *)
 module SMap = Set_util.StringMap
 module IntMap = Map.Make (Int)

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -60,6 +60,15 @@ let registration_error_to_string = function
 
 type data_payload_error = Missing_data_payload
 
+type parsed_frame =
+  { event_id : int option
+  ; data_payload : string
+  }
+
+type frame_parse_error =
+  | Frame_missing_data_payload
+  | Frame_invalid_event_id
+
 let data_payload_line line =
   let line_len = String.length line in
   let line_len =
@@ -87,6 +96,36 @@ let data_payload_of_frame frame =
   with
   | [] -> Error Missing_data_payload
   | payload_lines -> Ok (String.concat "\n" payload_lines)
+
+let event_id_line line =
+  let line =
+    if String.ends_with ~suffix:"\r" line
+    then String.sub line 0 (String.length line - 1)
+    else line
+  in
+  let prefix = "id:" in
+  if String.starts_with ~prefix line
+  then
+    let value =
+      String.sub line (String.length prefix) (String.length line - String.length prefix)
+      |> String.trim
+    in
+    Some value
+  else None
+
+let parse_frame frame =
+  let lines = String.split_on_char '\n' frame in
+  let event_ids = List.filter_map event_id_line lines in
+  match data_payload_of_frame frame with
+  | Error Missing_data_payload -> Error Frame_missing_data_payload
+  | Ok data_payload ->
+    (match event_ids with
+     | [] -> Ok { event_id = None; data_payload }
+     | [ value ] ->
+       (match int_of_string_opt value with
+        | Some id when id >= 0 -> Ok { event_id = Some id; data_payload }
+        | Some _ | None -> Error Frame_invalid_event_id)
+     | _ :: _ :: _ -> Error Frame_invalid_event_id)
 
 (** Classification of an SSE session's traffic role. *)
 module SMap = Set_util.StringMap

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -448,8 +448,9 @@ let format_event ?id ?event_type data =
      produced.  A single [Buffer] accumulator with primitive
      [string_of_int] sidesteps the format interpreter entirely and
      emits exactly the bytes the SSE wire format requires (id-line +
-     optional event-line + data-line + blank).  The output string is
-     byte-for-byte identical to what [Printf.sprintf] produced. *)
+     optional event-line + one [data:] line per logical data line + blank).
+     Single-line payloads remain byte-for-byte identical to the previous
+     output. *)
   let buf = Buffer.create 64 in
   Buffer.add_string buf "id: ";
   Buffer.add_string buf (string_of_int effective_id);
@@ -460,9 +461,12 @@ let format_event ?id ?event_type data =
        Buffer.add_string buf e;
        Buffer.add_char buf '\n'
    | None -> ());
-  Buffer.add_string buf "data: ";
-  Buffer.add_string buf data;
-  Buffer.add_string buf "\n\n";
+  String.split_on_char '\n' data
+  |> List.iter (fun line ->
+       Buffer.add_string buf "data: ";
+       Buffer.add_string buf line;
+       Buffer.add_char buf '\n');
+  Buffer.add_char buf '\n';
   Buffer.contents buf
 
 (** Format SSE event from a [Yojson.Safe.t] value without the intermediate

--- a/lib/sse.mli
+++ b/lib/sse.mli
@@ -21,13 +21,19 @@ type broadcast_target =
   | Agent_streams
   | Presence_only
 
+type delivery_audience =
+  | Broadcast_audience of broadcast_target
+  | Session_audience of string
+
 type delivery =
   { event_id : int
   ; frame : string
   ; emitted_at : float
+  ; audience : delivery_audience
   }
 (** Canonical occurrence shared by the replay store and live queues.
-    Its id, wire frame, and producer timestamp are allocated once. *)
+    Its id, wire frame, producer timestamp, and exact audience are allocated
+    once. *)
 
 type client = {
   id : int;
@@ -143,7 +149,8 @@ val format_event : ?id:int -> ?event_type:string -> string -> string
 (** [format_event] prefixes every logical line of [data] with [data:] so
     embedded newlines cannot escape the SSE field framing. An omitted [id]
     produces a transport-only frame and does not advance the replay cursor;
-    only replay-buffered canonical deliveries may supply an [id]. *)
+    only deliveries inside the ordered publication boundary may supply an
+    [id]. *)
 val current_id : unit -> int
 
 (** {1 Broadcast} *)
@@ -169,11 +176,11 @@ val remove_external_subscribers : string list -> string list * int
 
 val clients : client_registry_state Atomic.t
 val buffer_event : delivery -> unit
-val get_events_after : int -> delivery list
-val get_events_after_for_kind : session_kind -> int -> delivery list
-(** Replay-buffer lookup filtered for the target session kind. Agent_stream
-    replay only returns JSON-RPC messages; observer replay keeps all durable
-    events; presence replay is empty. *)
+val get_events_after_for_session :
+  session_id:string -> kind:session_kind -> int -> delivery list
+(** Replay-buffer lookup for one exact session. Targeted deliveries are visible
+    only to their named agent-stream session; broadcasts use the same target
+    and JSON-RPC filtering rules as live fan-out. *)
 
 type replay_handoff
 
@@ -184,6 +191,7 @@ val accept_live_delivery : replay_handoff -> delivery -> bool
     register/replay/live overlap without assuming event ids commit in order. *)
 
 val cleanup_expired_events : unit -> int
+val get_events_after_for_test : int -> delivery list
 val event_buffer_events_for_test : unit -> delivery list
 val set_event_buffer_for_test : delivery list -> unit
 val rewrite_event_buffer_for_test : unit -> unit

--- a/lib/sse.mli
+++ b/lib/sse.mli
@@ -153,6 +153,15 @@ val format_event : ?id:int -> ?event_type:string -> string -> string
     produces a transport-only frame and does not advance the replay cursor;
     only deliveries inside the ordered publication boundary may supply an
     [id]. *)
+
+val format_event_yojson
+  :  ?id:int
+  -> ?event_type:string
+  -> Yojson.Safe.t
+  -> string
+(** JSON counterpart of [format_event]. It writes the JSON value directly to
+    the canonical SSE buffer without an intermediate string allocation. *)
+
 val current_id : unit -> int
 
 (** {1 Broadcast} *)

--- a/lib/sse.mli
+++ b/lib/sse.mli
@@ -28,12 +28,14 @@ type delivery_audience =
 type delivery =
   { event_id : int
   ; frame : string
+  ; payload : Yojson.Safe.t
   ; emitted_at : float
   ; audience : delivery_audience
   }
 (** Canonical occurrence shared by the replay store and live queues.
-    Its id, wire frame, producer timestamp, and exact audience are allocated
-    once. *)
+    Its id, typed payload, wire frame, producer timestamp, and exact audience
+    are allocated once. Transport adapters consume [payload] rather than
+    reparsing [frame]. *)
 
 type client = {
   id : int;

--- a/lib/sse.mli
+++ b/lib/sse.mli
@@ -141,8 +141,9 @@ val data_payload_of_frame : string -> (string, data_payload_error) result
 
 val format_event : ?id:int -> ?event_type:string -> string -> string
 (** [format_event] prefixes every logical line of [data] with [data:] so
-    embedded newlines cannot escape the SSE field framing. *)
-val next_id : unit -> int
+    embedded newlines cannot escape the SSE field framing. An omitted [id]
+    produces a transport-only frame and does not advance the replay cursor;
+    only replay-buffered canonical deliveries may supply an [id]. *)
 val current_id : unit -> int
 
 (** {1 Broadcast} *)

--- a/lib/sse.mli
+++ b/lib/sse.mli
@@ -140,6 +140,8 @@ val data_payload_of_frame : string -> (string, data_payload_error) result
     field is rejected; bare JSON is not an SSE frame. *)
 
 val format_event : ?id:int -> ?event_type:string -> string -> string
+(** [format_event] prefixes every logical line of [data] with [data:] so
+    embedded newlines cannot escape the SSE field framing. *)
 val next_id : unit -> int
 val current_id : unit -> int
 

--- a/lib/sse.mli
+++ b/lib/sse.mli
@@ -123,6 +123,14 @@ val cleanup_stale : ?max_age_s:float -> unit -> string list
 
 (** {1 Events} *)
 
+type data_payload_error = Missing_data_payload
+
+val data_payload_of_frame : string -> (string, data_payload_error) result
+(** Extracts and joins the payloads of every [data:] field in one SSE frame.
+    The parser accepts the optional single space after the colon and the
+    LF/CRLF line endings emitted on the wire.  A frame without a [data:]
+    field is rejected; bare JSON is not an SSE frame. *)
+
 val format_event : ?id:int -> ?event_type:string -> string -> string
 val next_id : unit -> int
 val current_id : unit -> int

--- a/lib/sse.mli
+++ b/lib/sse.mli
@@ -131,6 +131,18 @@ val data_payload_of_frame : string -> (string, data_payload_error) result
     LF/CRLF line endings emitted on the wire.  A frame without a [data:]
     field is rejected; bare JSON is not an SSE frame. *)
 
+type parsed_frame =
+  { event_id : int option
+  ; data_payload : string
+  }
+
+type frame_parse_error =
+  | Frame_missing_data_payload
+  | Frame_invalid_event_id
+
+val parse_frame : string -> (parsed_frame, frame_parse_error) result
+(** Parse one internal SSE frame without discarding its resumability cursor. *)
+
 val format_event : ?id:int -> ?event_type:string -> string -> string
 val next_id : unit -> int
 val current_id : unit -> int

--- a/lib/sse.mli
+++ b/lib/sse.mli
@@ -21,10 +21,18 @@ type broadcast_target =
   | Agent_streams
   | Presence_only
 
+type delivery =
+  { event_id : int
+  ; frame : string
+  ; emitted_at : float
+  }
+(** Canonical occurrence shared by the replay store and live queues.
+    Its id, wire frame, and producer timestamp are allocated once. *)
+
 type client = {
   id : int;
   kind : session_kind;
-  event_stream : string Eio.Stream.t;
+  event_stream : delivery Eio.Stream.t;
   last_event_id : int Atomic.t;
   created_at : float;
   last_seen_at : float Atomic.t;
@@ -78,7 +86,7 @@ val registration_error_to_string : registration_error -> string
 val register :
   ?kind:session_kind -> ?on_disconnect:(unit -> unit) ->
   auth:registration_auth -> string -> last_event_id:int ->
-  (int * string Eio.Stream.t * string option, registration_error) result
+  (int * delivery Eio.Stream.t * string option, registration_error) result
 (** [register ~auth session_id ~last_event_id] validates the supplied
     bearer token and MCP session pair before admitting the client.
 
@@ -131,18 +139,6 @@ val data_payload_of_frame : string -> (string, data_payload_error) result
     LF/CRLF line endings emitted on the wire.  A frame without a [data:]
     field is rejected; bare JSON is not an SSE frame. *)
 
-type parsed_frame =
-  { event_id : int option
-  ; data_payload : string
-  }
-
-type frame_parse_error =
-  | Frame_missing_data_payload
-  | Frame_invalid_event_id
-
-val parse_frame : string -> (parsed_frame, frame_parse_error) result
-(** Parse one internal SSE frame without discarding its resumability cursor. *)
-
 val format_event : ?id:int -> ?event_type:string -> string -> string
 val next_id : unit -> int
 val current_id : unit -> int
@@ -169,17 +165,24 @@ val remove_external_subscribers : string list -> string list * int
 (** {1 Event Buffer} *)
 
 val clients : client_registry_state Atomic.t
-type buffered_event = int * string * float
-
-val buffer_event : int -> string -> unit
-val get_events_after : int -> string list
-val get_events_after_for_kind : session_kind -> int -> string list
+val buffer_event : delivery -> unit
+val get_events_after : int -> delivery list
+val get_events_after_for_kind : session_kind -> int -> delivery list
 (** Replay-buffer lookup filtered for the target session kind. Agent_stream
     replay only returns JSON-RPC messages; observer replay keeps all durable
     events; presence replay is empty. *)
+
+type replay_handoff
+
+val create_replay_handoff : delivery list -> replay_handoff
+val accept_live_delivery : replay_handoff -> delivery -> bool
+(** [accept_live_delivery handoff delivery] returns [false] exactly once for
+    each delivery already sent from the replay snapshot. This closes the
+    register/replay/live overlap without assuming event ids commit in order. *)
+
 val cleanup_expired_events : unit -> int
-val event_buffer_events_for_test : unit -> buffered_event list
-val set_event_buffer_for_test : buffered_event list -> unit
+val event_buffer_events_for_test : unit -> delivery list
+val set_event_buffer_for_test : delivery list -> unit
 val rewrite_event_buffer_for_test : unit -> unit
 
 (** {1 Snapshots} *)

--- a/lib/sse_wire/dune
+++ b/lib/sse_wire/dune
@@ -1,0 +1,10 @@
+(include_subdirs no)
+
+(library
+ (name masc_sse_wire)
+ (public_name masc.sse_wire)
+ (modules sse_wire)
+ (wrapped false)
+ (flags
+  (:standard -w +4 -w +32))
+ (libraries yojson))

--- a/lib/sse_wire/sse_wire.ml
+++ b/lib/sse_wire/sse_wire.ml
@@ -1,0 +1,29 @@
+let add_header buf name value =
+  Buffer.add_string buf name;
+  Buffer.add_string buf ": ";
+  Buffer.add_string buf value;
+  Buffer.add_char buf '\n'
+;;
+
+let add_optional_headers buf ?id ?event_type () =
+  Option.iter (fun event_id -> add_header buf "id" (string_of_int event_id)) id;
+  Option.iter (add_header buf "event") event_type
+;;
+
+let format_event ?id ?event_type data =
+  let buf = Buffer.create 64 in
+  add_optional_headers buf ?id ?event_type ();
+  String.split_on_char '\n' data
+  |> List.iter (fun line -> add_header buf "data" line);
+  Buffer.add_char buf '\n';
+  Buffer.contents buf
+;;
+
+let format_event_yojson ?id ?event_type json =
+  let buf = Buffer.create 128 in
+  add_optional_headers buf ?id ?event_type ();
+  Buffer.add_string buf "data: ";
+  Yojson.Safe.to_buffer buf json;
+  Buffer.add_string buf "\n\n";
+  Buffer.contents buf
+;;

--- a/lib/sse_wire/sse_wire.mli
+++ b/lib/sse_wire/sse_wire.mli
@@ -1,0 +1,9 @@
+(** Canonical Server-Sent Events wire framing. *)
+
+val format_event : ?id:int -> ?event_type:string -> string -> string
+(** Frame a text payload. Each logical payload line receives its own [data:]
+    field; optional replay identity and event type precede the payload. *)
+
+val format_event_yojson :
+  ?id:int -> ?event_type:string -> Yojson.Safe.t -> string
+(** Frame JSON without allocating an intermediate serialized JSON string. *)

--- a/test/deps/dune
+++ b/test/deps/dune
@@ -6,6 +6,11 @@
 (copy_files ../../lib/server/server_grpc_tool_dispatch.ml)
 
 (library
+ (name masc_test_runtime)
+ (modules masc_test_runtime)
+ (libraries unix))
+
+(library
  (name masc_test_deps)
  (modules masc_test_deps server_grpc_tool_dispatch)
  (foreign_stubs

--- a/test/deps/masc_test_runtime.ml
+++ b/test/deps/masc_test_runtime.ml
@@ -1,0 +1,47 @@
+(** Exact runtime-binary resolution for process-level tests.
+
+    The caller or Dune owns binary selection.  This helper deliberately does
+    not search parent directories: a test running from a worktree must never
+    escape to a sibling or parent checkout's build artifact. *)
+
+let candidate ~env_override ~dune_sourceroot =
+  match env_override with
+  | Some "" -> Error "MASC_MAIN_EIO_EXE is set but empty"
+  | Some path -> Ok path
+  | None ->
+    (match dune_sourceroot with
+     | Some "" -> Error "DUNE_SOURCEROOT is set but empty"
+     | Some root -> Ok (Filename.concat root "_build/default/bin/main_eio.exe")
+     | None ->
+       Error
+         "main_eio executable is unbound; run via Dune or set MASC_MAIN_EIO_EXE")
+
+let validate path =
+  try
+    let stat = Unix.stat path in
+    if stat.st_kind <> Unix.S_REG then
+      Error (Printf.sprintf "main_eio path is not a regular file: %s" path)
+    else begin
+      Unix.access path [ Unix.X_OK ];
+      Ok (Unix.realpath path)
+    end
+  with
+  | Unix.Unix_error (error, operation, _) ->
+    Error
+      (Printf.sprintf "main_eio executable is unusable (%s: %s): %s" operation
+         (Unix.error_message error) path)
+
+let resolve ~env_override ~dune_sourceroot =
+  match candidate ~env_override ~dune_sourceroot with
+  | Error _ as error -> error
+  | Ok path -> validate path
+
+let find_main_eio_exe () =
+  match
+    resolve ~env_override:(Sys.getenv_opt "MASC_MAIN_EIO_EXE")
+      ~dune_sourceroot:(Sys.getenv_opt "DUNE_SOURCEROOT")
+  with
+  | Error detail -> failwith detail
+  | Ok path ->
+    Printf.eprintf "[masc-test-runtime] main_eio=%s\n%!" path;
+    path

--- a/test/deps/masc_test_runtime.ml
+++ b/test/deps/masc_test_runtime.ml
@@ -4,17 +4,11 @@
     not search parent directories: a test running from a worktree must never
     escape to a sibling or parent checkout's build artifact. *)
 
-let candidate ~env_override ~dune_sourceroot =
+let candidate ~env_override =
   match env_override with
   | Some "" -> Error "MASC_MAIN_EIO_EXE is set but empty"
   | Some path -> Ok path
-  | None ->
-    (match dune_sourceroot with
-     | Some "" -> Error "DUNE_SOURCEROOT is set but empty"
-     | Some root -> Ok (Filename.concat root "_build/default/bin/main_eio.exe")
-     | None ->
-       Error
-         "main_eio executable is unbound; run via Dune or set MASC_MAIN_EIO_EXE")
+  | None -> Error "main_eio executable is unbound; run the test via Dune"
 
 let validate path =
   try
@@ -31,15 +25,14 @@ let validate path =
       (Printf.sprintf "main_eio executable is unusable (%s: %s): %s" operation
          (Unix.error_message error) path)
 
-let resolve ~env_override ~dune_sourceroot =
-  match candidate ~env_override ~dune_sourceroot with
+let resolve ~env_override =
+  match candidate ~env_override with
   | Error _ as error -> error
   | Ok path -> validate path
 
 let find_main_eio_exe () =
   match
     resolve ~env_override:(Sys.getenv_opt "MASC_MAIN_EIO_EXE")
-      ~dune_sourceroot:(Sys.getenv_opt "DUNE_SOURCEROOT")
   with
   | Error detail -> failwith detail
   | Ok path ->

--- a/test/dune
+++ b/test/dune
@@ -931,7 +931,6 @@
   test_masc_log
   test_dashboard_namespace_truth
   test_dashboard_snapshot
-  test_server_runtime_bootstrap
   test_server_runtime_startup_maintenance
   test_server_hibernation
   test_server_base_path_diagnostics
@@ -1090,7 +1089,6 @@
   test_masc_log
   test_dashboard_namespace_truth
   test_dashboard_snapshot
-  test_server_runtime_bootstrap
   test_server_runtime_startup_maintenance
   test_server_hibernation
   test_server_base_path_diagnostics
@@ -1230,6 +1228,18 @@
   masc.embedded_config
   bigstringaf)
  (deps ../bin/main_eio.exe))
+
+(test
+ (name test_server_runtime_bootstrap)
+ (modules test_server_runtime_bootstrap)
+ (libraries
+  masc_test_deps
+  masc_test_runtime
+  masc.embedded_config
+  bigstringaf)
+ (deps ../bin/main_eio.exe)
+ (action
+  (setenv MASC_MAIN_EIO_EXE %{dep:../bin/main_eio.exe} (run %{test}))))
 
 ; Stable dashboard behavior contracts only. The full executable also contains
 ; source-shape assertions, so CI must not promote its catch-all runtest alias.

--- a/test/dune
+++ b/test/dune
@@ -897,6 +897,11 @@
  (modules test_time_codec)
  (libraries alcotest masc.time_codec))
 
+(test
+ (name test_masc_test_runtime)
+ (modules test_masc_test_runtime)
+ (libraries alcotest fs_compat masc_test_runtime unix))
+
 ; Group 3: Eio-native tests (single-module, standard deps)
 ; Merged from ~100 individual (test ...) stanzas.
 
@@ -1221,6 +1226,7 @@
   test_board_moderation)
  (libraries
   masc_test_deps
+  masc_test_runtime
   masc.embedded_config
   bigstringaf)
  (deps ../bin/main_eio.exe))

--- a/test/stanzas/test_board_api_e2e.inc
+++ b/test/stanzas/test_board_api_e2e.inc
@@ -1,6 +1,8 @@
 (test
  (name test_board_api_e2e)
  (modules test_board_api_e2e)
- (libraries alcotest unix)
+ (libraries alcotest masc_test_runtime unix)
  (deps ../bin/main_eio.exe)
- (enabled_if (= %{env:MASC_E2E_TESTS=false} "true")))
+ (enabled_if (= %{env:MASC_E2E_TESTS=false} "true"))
+ (action
+  (setenv MASC_MAIN_EIO_EXE %{dep:../bin/main_eio.exe} (run %{test}))))

--- a/test/stanzas/test_mcp_post_sse_e2e.inc
+++ b/test/stanzas/test_mcp_post_sse_e2e.inc
@@ -1,6 +1,8 @@
 (test
  (name test_mcp_post_sse_e2e)
  (modules test_mcp_post_sse_e2e)
- (libraries alcotest yojson unix)
+ (libraries alcotest masc_test_runtime yojson unix)
  (deps ../bin/main_eio.exe)
- (enabled_if (= %{env:MASC_E2E_TESTS=false} "true")))
+ (enabled_if (= %{env:MASC_E2E_TESTS=false} "true"))
+ (action
+  (setenv MASC_MAIN_EIO_EXE %{dep:../bin/main_eio.exe} (run %{test}))))

--- a/test/stanzas/test_openapi_api_e2e.inc
+++ b/test/stanzas/test_openapi_api_e2e.inc
@@ -1,6 +1,8 @@
 (test
  (name test_openapi_api_e2e)
  (modules test_openapi_api_e2e)
- (libraries alcotest yojson unix masc.server)
+ (libraries alcotest masc_test_runtime yojson unix masc.server)
  (deps ../bin/main_eio.exe)
- (enabled_if (= %{env:MASC_E2E_TESTS=false} "true")))
+ (enabled_if (= %{env:MASC_E2E_TESTS=false} "true"))
+ (action
+  (setenv MASC_MAIN_EIO_EXE %{dep:../bin/main_eio.exe} (run %{test}))))

--- a/test/stanzas/test_operator_mcp_e2e.inc
+++ b/test/stanzas/test_operator_mcp_e2e.inc
@@ -1,8 +1,10 @@
 (test
  (name test_operator_mcp_e2e)
  (modules test_operator_mcp_e2e)
- (libraries masc_test_deps)
+ (libraries masc_test_deps masc_test_runtime)
  (deps
   ../bin/main_eio.exe
   (source_tree ../config))
- (enabled_if (= %{env:MASC_E2E_TESTS=false} "true")))
+ (enabled_if (= %{env:MASC_E2E_TESTS=false} "true"))
+ (action
+  (setenv MASC_MAIN_EIO_EXE %{dep:../bin/main_eio.exe} (run %{test}))))

--- a/test/stanzas/test_sse_storm_e2e.inc
+++ b/test/stanzas/test_sse_storm_e2e.inc
@@ -1,6 +1,8 @@
 (test
  (name test_sse_storm_e2e)
  (modules test_sse_storm_e2e)
- (libraries alcotest yojson unix)
+ (libraries alcotest masc_test_runtime yojson unix)
  (deps ../bin/main_eio.exe)
- (enabled_if (= %{env:MASC_E2E_TESTS=false} "true")))
+ (enabled_if (= %{env:MASC_E2E_TESTS=false} "true"))
+ (action
+  (setenv MASC_MAIN_EIO_EXE %{dep:../bin/main_eio.exe} (run %{test}))))

--- a/test/test_ag_ui_coverage.ml
+++ b/test/test_ag_ui_coverage.ml
@@ -218,6 +218,32 @@ let test_protocol_version () =
   assert (String.length protocol_version > 0);
   assert (String.contains protocol_version '.')
 
+let test_http_bridge_wraps_masc_event () =
+  let encoded =
+    Server_mcp_transport_http_agui.For_testing.ag_ui_event_of_masc_event
+      "data: {\"kind\":\"task_updated\"}\n\n"
+  in
+  assert (String_util.contains_substring encoded "MASC_EVENT");
+  assert (not (String.equal encoded "data: {\"kind\":\"task_updated\"}\n\n"))
+
+let test_http_bridge_projects_invalid_json_to_ag_ui_error () =
+  let raw = "data: {not-json}\n\n" in
+  let encoded =
+    Server_mcp_transport_http_agui.For_testing.ag_ui_event_of_masc_event raw
+  in
+  assert (String_util.contains_substring encoded "MASC_EVENT_ENCODING_ERROR");
+  assert (String_util.contains_substring encoded "invalid_json_payload");
+  assert (not (String.equal encoded raw))
+
+let test_http_bridge_projects_missing_data_to_ag_ui_error () =
+  let raw = "event: legacy\n\n" in
+  let encoded =
+    Server_mcp_transport_http_agui.For_testing.ag_ui_event_of_masc_event raw
+  in
+  assert (String_util.contains_substring encoded "MASC_EVENT_ENCODING_ERROR");
+  assert (String_util.contains_substring encoded "missing_data_payload");
+  assert (not (String.equal encoded raw))
+
 (* ---------- Test Runner ---------- *)
 
 let () =
@@ -243,6 +269,11 @@ let () =
     ("of_task_update_done", test_of_task_update_done);
     ("of_task_update_other", test_of_task_update_other);
     ("protocol_version", test_protocol_version);
+    ("http_bridge_wraps_masc_event", test_http_bridge_wraps_masc_event);
+    ( "http_bridge_projects_invalid_json_to_ag_ui_error",
+      test_http_bridge_projects_invalid_json_to_ag_ui_error );
+    ( "http_bridge_projects_missing_data_to_ag_ui_error",
+      test_http_bridge_projects_missing_data_to_ag_ui_error );
   ] in
   let passed = ref 0 in
   let failed = ref 0 in

--- a/test/test_ag_ui_coverage.ml
+++ b/test/test_ag_ui_coverage.ml
@@ -110,8 +110,11 @@ let test_run_error_rejects_custom_envelope () =
 let test_event_to_sse_format () =
   let e = make_event ~thread_id:"workspace-1" Run_started in
   let sse = event_to_sse ~id:17 e in
+  let transport_only_sse = event_to_sse e in
   assert (String.length sse > 0);
   assert (String.starts_with ~prefix:"id: 17\ndata: " sse);
+  assert (String.starts_with ~prefix:"data: " transport_only_sse);
+  assert (not (String.starts_with ~prefix:"id:" transport_only_sse));
   (* SSE ends with double newline *)
   let len = String.length sse in
   assert (String.sub sse (len - 2) 2 = "\n\n")

--- a/test/test_ag_ui_coverage.ml
+++ b/test/test_ag_ui_coverage.ml
@@ -128,34 +128,6 @@ let test_protocol_version () =
   assert (String.length protocol_version > 0);
   assert (String.contains protocol_version '.')
 
-let test_http_bridge_wraps_masc_event () =
-  let raw = "id: 41\ndata: {\"kind\":\"task_updated\"}\n\n" in
-  let encoded =
-    Server_mcp_transport_http_agui.For_testing.ag_ui_event_of_masc_event
-      raw
-  in
-  assert (String.starts_with ~prefix:"id: 41\n" encoded);
-  assert (String_util.contains_substring encoded "MASC_EVENT");
-  assert (not (String.equal encoded raw))
-
-let test_http_bridge_projects_invalid_json_to_ag_ui_error () =
-  let raw = "data: {not-json}\n\n" in
-  let encoded =
-    Server_mcp_transport_http_agui.For_testing.ag_ui_event_of_masc_event raw
-  in
-  assert (String_util.contains_substring encoded "MASC_EVENT_ENCODING_ERROR");
-  assert (String_util.contains_substring encoded "invalid_json_payload");
-  assert (not (String.equal encoded raw))
-
-let test_http_bridge_projects_missing_data_to_ag_ui_error () =
-  let raw = "event: legacy\n\n" in
-  let encoded =
-    Server_mcp_transport_http_agui.For_testing.ag_ui_event_of_masc_event raw
-  in
-  assert (String_util.contains_substring encoded "MASC_EVENT_ENCODING_ERROR");
-  assert (String_util.contains_substring encoded "missing_data_payload");
-  assert (not (String.equal encoded raw))
-
 (* ---------- Test Runner ---------- *)
 
 let () =
@@ -171,11 +143,6 @@ let () =
     ("event_to_sse_format", test_event_to_sse_format);
     ("of_custom", test_of_custom);
     ("protocol_version", test_protocol_version);
-    ("http_bridge_wraps_masc_event", test_http_bridge_wraps_masc_event);
-    ( "http_bridge_projects_invalid_json_to_ag_ui_error",
-      test_http_bridge_projects_invalid_json_to_ag_ui_error );
-    ( "http_bridge_projects_missing_data_to_ag_ui_error",
-      test_http_bridge_projects_missing_data_to_ag_ui_error );
   ] in
   let passed = ref 0 in
   let failed = ref 0 in

--- a/test/test_ag_ui_coverage.ml
+++ b/test/test_ag_ui_coverage.ml
@@ -109,108 +109,18 @@ let test_run_error_rejects_custom_envelope () =
 
 let test_event_to_sse_format () =
   let e = make_event ~thread_id:"workspace-1" Run_started in
-  let sse = event_to_sse e in
+  let sse = event_to_sse ~id:17 e in
   assert (String.length sse > 0);
-  assert (String.sub sse 0 6 = "data: ");
+  assert (String.starts_with ~prefix:"id: 17\ndata: " sse);
   (* SSE ends with double newline *)
   let len = String.length sse in
   assert (String.sub sse (len - 2) 2 = "\n\n")
-
-(* ---------- MASC → AG-UI Mapping Tests ---------- *)
-
-let test_of_agent_session_bound () =
-  let e = of_agent_session_bound ~agent_name:"claude" in
-  assert (e.event_type = Run_started);
-  assert (e.thread_id = "default");
-  assert (e.run_id = Some "claude");
-  assert (e.custom_name = Some "AGENT_SESSION_BOUND")
-
-let test_of_agent_unbound () =
-  let e = of_agent_unbound ~agent_name:"claude" in
-  assert (e.event_type = Run_finished);
-  assert (e.thread_id = "default");
-  assert (e.run_id = Some "claude")
-
-let test_of_broadcast () =
-  let events = of_broadcast
-    ~agent_name:"claude" ~message:"Hello" ~message_id:"msg-001" in
-  assert (List.length events = 3);
-  let e0 = List.nth events 0 in
-  let e1 = List.nth events 1 in
-  let e2 = List.nth events 2 in
-  assert (e0.event_type = Text_message_start);
-  assert (e0.role = Some Assistant);
-  assert (e1.event_type = Text_message_content);
-  assert (e1.delta = Some "Hello");
-  assert (e2.event_type = Text_message_end)
-
-let test_of_task_claimed () =
-  let e = of_task_claimed
-    ~agent_name:"claude" ~task_id:"task-001" in
-  assert (e.event_type = Step_started);
-  assert (e.step_name = Some "task-001")
-
-let test_of_task_done () =
-  let e = of_task_done
-    ~agent_name:"claude" ~task_id:"task-001" in
-  assert (e.event_type = Step_finished);
-  assert (e.step_name = Some "task-001")
-
-let test_of_tool_call () =
-  let events = of_tool_call
-    ~agent_name:"claude" ~tool_name:"search"
-    ~call_id:"call-001" ~args_json:"{\"q\": \"test\"}" in
-  assert (List.length events = 3);
-  let e0 = List.nth events 0 in
-  assert (e0.event_type = Tool_call_start);
-  assert (e0.tool_call_name = Some "search");
-  let e1 = List.nth events 1 in
-  assert (e1.event_type = Tool_call_args);
-  assert (e1.delta = Some "{\"q\": \"test\"}");
-  let e2 = List.nth events 2 in
-  assert (e2.event_type = Tool_call_end)
-
-let test_of_workspace_state () =
-  let state = `Assoc [("agents", `Int 3); ("tasks", `Int 5)] in
-  let e = of_workspace_state state in
-  assert (e.event_type = State_snapshot);
-  assert (e.snapshot = Some state)
 
 let test_of_custom () =
   let value = `Assoc [("key", `String "value")] in
   let e = of_custom ~name:"MY_EVENT" value in
   assert (e.event_type = Custom);
   assert (e.custom_name = Some "MY_EVENT")
-
-(* ---------- Task Update Mapping ---------- *)
-
-let test_of_task_update_claimed () =
-  let json = `Assoc [
-    ("id", `String "task-001");
-    ("status", `String "claimed");
-    ("agent", `String "claude");
-  ] in
-  let e = of_task_update json in
-  assert (e.event_type = Step_started)
-
-let test_of_task_update_done () =
-  let json = `Assoc [
-    ("id", `String "task-001");
-    ("status", `String "done");
-    ("agent", `String "claude");
-  ] in
-  let e = of_task_update json in
-  assert (e.event_type = Step_finished)
-
-let test_of_task_update_other () =
-  let json = `Assoc [
-    ("id", `String "task-001");
-    ("status", `String "in_progress");
-    ("agent", `String "claude");
-  ] in
-  let e = of_task_update json in
-  assert (e.event_type = Custom);
-  assert (e.custom_name = Some "TASK_UPDATE")
 
 (* ---------- Protocol Version ---------- *)
 
@@ -219,12 +129,14 @@ let test_protocol_version () =
   assert (String.contains protocol_version '.')
 
 let test_http_bridge_wraps_masc_event () =
+  let raw = "id: 41\ndata: {\"kind\":\"task_updated\"}\n\n" in
   let encoded =
     Server_mcp_transport_http_agui.For_testing.ag_ui_event_of_masc_event
-      "data: {\"kind\":\"task_updated\"}\n\n"
+      raw
   in
+  assert (String.starts_with ~prefix:"id: 41\n" encoded);
   assert (String_util.contains_substring encoded "MASC_EVENT");
-  assert (not (String.equal encoded "data: {\"kind\":\"task_updated\"}\n\n"))
+  assert (not (String.equal encoded raw))
 
 let test_http_bridge_projects_invalid_json_to_ag_ui_error () =
   let raw = "data: {not-json}\n\n" in
@@ -257,17 +169,7 @@ let () =
     ("run_error_requires_message", test_run_error_requires_message);
     ("run_error_rejects_custom_envelope", test_run_error_rejects_custom_envelope);
     ("event_to_sse_format", test_event_to_sse_format);
-    ("of_agent_session_bound", test_of_agent_session_bound);
-    ("of_agent_unbound", test_of_agent_unbound);
-    ("of_broadcast", test_of_broadcast);
-    ("of_task_claimed", test_of_task_claimed);
-    ("of_task_done", test_of_task_done);
-    ("of_tool_call", test_of_tool_call);
-    ("of_workspace_state", test_of_workspace_state);
     ("of_custom", test_of_custom);
-    ("of_task_update_claimed", test_of_task_update_claimed);
-    ("of_task_update_done", test_of_task_update_done);
-    ("of_task_update_other", test_of_task_update_other);
     ("protocol_version", test_protocol_version);
     ("http_bridge_wraps_masc_event", test_http_bridge_wraps_masc_event);
     ( "http_bridge_projects_invalid_json_to_ag_ui_error",

--- a/test/test_board_api_e2e.ml
+++ b/test/test_board_api_e2e.ml
@@ -159,9 +159,7 @@ let with_server f =
     | None -> Alcotest.skip ()
   in
   let log_file = Filename.temp_file "board-api-e2e-" ".log" in
-  let base_path = Filename.temp_file "board-api-base-" "" in
-  (try Sys.remove base_path with _ -> ());
-  Unix.mkdir base_path 0o755;
+  let base_path = Filename.temp_dir "board-api-base-" "" in
   let log_fd =
     Unix.openfile log_file [Unix.O_CREAT; Unix.O_WRONLY; Unix.O_TRUNC] 0o644
   in

--- a/test/test_board_api_e2e.ml
+++ b/test/test_board_api_e2e.ml
@@ -88,32 +88,6 @@ let contains_substr needle haystack =
   in
   n = 0 || loop 0
 
-let find_main_eio_exe () =
-  let env_override = Sys.getenv_opt "MASC_MAIN_EIO_EXE" in
-  let candidates =
-    match env_override with
-    | Some p -> [p]
-    | None ->
-        let build_roots = [ "."; ".."; "../.."; "../../.."; "../../../.." ] in
-        let build_candidates =
-          List.map
-            (fun root -> Filename.concat root "_build/default/bin/main_eio.exe")
-            build_roots
-        in
-        [
-          "./bin/main_eio.exe";
-          "../bin/main_eio.exe";
-          "../../bin/main_eio.exe";
-          "../../../bin/main_eio.exe";
-          "../../../../bin/main_eio.exe";
-        ] @ build_candidates
-  in
-  match List.find_opt Sys.file_exists candidates with
-  | Some path -> path
-  | None ->
-      fail
-        "main_eio executable not found. Set MASC_MAIN_EIO_EXE or build with `dune build bin/main_eio.exe`."
-
 let find_free_port () =
   let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
   Fun.protect
@@ -178,7 +152,7 @@ let merge_env_overrides overrides =
   Array.of_list (base @ injected)
 
 let with_server f =
-  let exe = find_main_eio_exe () in
+  let exe = Masc_test_runtime.find_main_eio_exe () in
   let port =
     match find_free_port () with
     | Some p -> p

--- a/test/test_masc_test_runtime.ml
+++ b/test/test_masc_test_runtime.ml
@@ -6,9 +6,7 @@ let touch_executable path =
   Unix.chmod path 0o755
 
 let with_temp_dir f =
-  let path = Filename.temp_file "masc-test-runtime-" "" in
-  Sys.remove path;
-  mkdir path;
+  let path = Filename.temp_dir "masc-test-runtime-" "" in
   Fun.protect ~finally:(fun () -> Fs_compat.remove_tree path) (fun () -> f path)
 
 let test_requires_explicit_root () =

--- a/test/test_masc_test_runtime.ml
+++ b/test/test_masc_test_runtime.ml
@@ -10,7 +10,7 @@ let with_temp_dir f =
   Fun.protect ~finally:(fun () -> Fs_compat.remove_tree path) (fun () -> f path)
 
 let test_requires_explicit_root () =
-  match Masc_test_runtime.resolve ~env_override:None ~dune_sourceroot:None with
+  match Masc_test_runtime.resolve ~env_override:None with
   | Error _ -> ()
   | Ok path -> Alcotest.failf "unexpected implicit binary: %s" path
 
@@ -25,13 +25,11 @@ let test_does_not_escape_to_parent_checkout () =
   touch_executable (Filename.concat parent_bin "main_eio.exe");
   let worktree = Filename.concat parent "worktree" in
   mkdir worktree;
-  match
-    Masc_test_runtime.resolve ~env_override:None ~dune_sourceroot:(Some worktree)
-  with
+  match Masc_test_runtime.resolve ~env_override:None with
   | Error _ -> ()
   | Ok path -> Alcotest.failf "escaped current worktree to %s" path
 
-let test_uses_exact_dune_binary () =
+let test_uses_exact_bound_binary () =
   with_temp_dir @@ fun root ->
   let build = Filename.concat root "_build" in
   let default = Filename.concat build "default" in
@@ -41,9 +39,7 @@ let test_uses_exact_dune_binary () =
   mkdir bin;
   let expected = Filename.concat bin "main_eio.exe" in
   touch_executable expected;
-  match
-    Masc_test_runtime.resolve ~env_override:None ~dune_sourceroot:(Some root)
-  with
+  match Masc_test_runtime.resolve ~env_override:(Some expected) with
   | Error detail -> Alcotest.fail detail
   | Ok actual ->
     Alcotest.(check string) "exact current build" (Unix.realpath expected) actual
@@ -59,7 +55,6 @@ let test_invalid_override_does_not_fall_back () =
   touch_executable (Filename.concat bin "main_eio.exe");
   match
     Masc_test_runtime.resolve ~env_override:(Some (Filename.concat root "missing"))
-      ~dune_sourceroot:(Some root)
   with
   | Error _ -> ()
   | Ok path -> Alcotest.failf "invalid override fell back to %s" path
@@ -71,8 +66,8 @@ let () =
             test_requires_explicit_root
         ; Alcotest.test_case "does not escape parent checkout" `Quick
             test_does_not_escape_to_parent_checkout
-        ; Alcotest.test_case "uses exact Dune binary" `Quick
-            test_uses_exact_dune_binary
+        ; Alcotest.test_case "uses exact bound binary" `Quick
+            test_uses_exact_bound_binary
         ; Alcotest.test_case "invalid override does not fall back" `Quick
             test_invalid_override_does_not_fall_back
         ] )

--- a/test/test_masc_test_runtime.ml
+++ b/test/test_masc_test_runtime.ml
@@ -1,0 +1,81 @@
+let mkdir path = Unix.mkdir path 0o755
+
+let touch_executable path =
+  let channel = open_out path in
+  close_out channel;
+  Unix.chmod path 0o755
+
+let with_temp_dir f =
+  let path = Filename.temp_file "masc-test-runtime-" "" in
+  Sys.remove path;
+  mkdir path;
+  Fun.protect ~finally:(fun () -> Fs_compat.remove_tree path) (fun () -> f path)
+
+let test_requires_explicit_root () =
+  match Masc_test_runtime.resolve ~env_override:None ~dune_sourceroot:None with
+  | Error _ -> ()
+  | Ok path -> Alcotest.failf "unexpected implicit binary: %s" path
+
+let test_does_not_escape_to_parent_checkout () =
+  with_temp_dir @@ fun parent ->
+  let parent_build = Filename.concat parent "_build" in
+  let parent_default = Filename.concat parent_build "default" in
+  let parent_bin = Filename.concat parent_default "bin" in
+  mkdir parent_build;
+  mkdir parent_default;
+  mkdir parent_bin;
+  touch_executable (Filename.concat parent_bin "main_eio.exe");
+  let worktree = Filename.concat parent "worktree" in
+  mkdir worktree;
+  match
+    Masc_test_runtime.resolve ~env_override:None ~dune_sourceroot:(Some worktree)
+  with
+  | Error _ -> ()
+  | Ok path -> Alcotest.failf "escaped current worktree to %s" path
+
+let test_uses_exact_dune_binary () =
+  with_temp_dir @@ fun root ->
+  let build = Filename.concat root "_build" in
+  let default = Filename.concat build "default" in
+  let bin = Filename.concat default "bin" in
+  mkdir build;
+  mkdir default;
+  mkdir bin;
+  let expected = Filename.concat bin "main_eio.exe" in
+  touch_executable expected;
+  match
+    Masc_test_runtime.resolve ~env_override:None ~dune_sourceroot:(Some root)
+  with
+  | Error detail -> Alcotest.fail detail
+  | Ok actual ->
+    Alcotest.(check string) "exact current build" (Unix.realpath expected) actual
+
+let test_invalid_override_does_not_fall_back () =
+  with_temp_dir @@ fun root ->
+  let build = Filename.concat root "_build" in
+  let default = Filename.concat build "default" in
+  let bin = Filename.concat default "bin" in
+  mkdir build;
+  mkdir default;
+  mkdir bin;
+  touch_executable (Filename.concat bin "main_eio.exe");
+  match
+    Masc_test_runtime.resolve ~env_override:(Some (Filename.concat root "missing"))
+      ~dune_sourceroot:(Some root)
+  with
+  | Error _ -> ()
+  | Ok path -> Alcotest.failf "invalid override fell back to %s" path
+
+let () =
+  Alcotest.run "masc test runtime"
+    [ ( "binary resolution"
+      , [ Alcotest.test_case "requires explicit root" `Quick
+            test_requires_explicit_root
+        ; Alcotest.test_case "does not escape parent checkout" `Quick
+            test_does_not_escape_to_parent_checkout
+        ; Alcotest.test_case "uses exact Dune binary" `Quick
+            test_uses_exact_dune_binary
+        ; Alcotest.test_case "invalid override does not fall back" `Quick
+            test_invalid_override_does_not_fall_back
+        ] )
+    ]

--- a/test/test_mcp_post_sse_e2e.ml
+++ b/test/test_mcp_post_sse_e2e.ml
@@ -174,33 +174,6 @@ let normalize_mcp_body body =
   | last :: _ -> last
   | [] -> body
 
-let find_main_eio_exe () =
-  let env_override = Sys.getenv_opt "MASC_MAIN_EIO_EXE" in
-  let candidates =
-    match env_override with
-    | Some p -> [ p ]
-    | None ->
-        let build_roots = [ "."; ".."; "../.."; "../../.."; "../../../.." ] in
-        let build_candidates =
-          List.map
-            (fun root -> Filename.concat root "_build/default/bin/main_eio.exe")
-            build_roots
-        in
-        [
-          "./bin/main_eio.exe";
-          "../bin/main_eio.exe";
-          "../../bin/main_eio.exe";
-          "../../../bin/main_eio.exe";
-          "../../../../bin/main_eio.exe";
-        ]
-        @ build_candidates
-  in
-  match List.find_opt Sys.file_exists candidates with
-  | Some path -> path
-  | None ->
-      fail
-        "main_eio executable not found. Set MASC_MAIN_EIO_EXE or build with `dune build bin/main_eio.exe`."
-
 let find_free_port () =
   let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
   Fun.protect
@@ -262,7 +235,7 @@ let merge_env_overrides overrides =
   Array.of_list (base @ injected)
 
 let with_server f =
-  let exe = find_main_eio_exe () in
+  let exe = Masc_test_runtime.find_main_eio_exe () in
   let port =
     match find_free_port () with
     | Some p -> p

--- a/test/test_mcp_post_sse_e2e.ml
+++ b/test/test_mcp_post_sse_e2e.ml
@@ -242,9 +242,7 @@ let with_server f =
     | None -> Alcotest.skip ()
   in
   let log_file = Filename.temp_file "mcp-post-sse-e2e-" ".log" in
-  let base_path = Filename.temp_file "mcp-post-sse-base-" "" in
-  (try Sys.remove base_path with _ -> ());
-  Unix.mkdir base_path 0o755;
+  let base_path = Filename.temp_dir "mcp-post-sse-base-" "" in
   let log_fd =
     Unix.openfile log_file [ Unix.O_CREAT; Unix.O_WRONLY; Unix.O_TRUNC ] 0o644
   in

--- a/test/test_openapi_api_e2e.ml
+++ b/test/test_openapi_api_e2e.ml
@@ -86,33 +86,6 @@ let run_curl ?(headers = []) ~port ~path () =
   (try Sys.remove body_file with _ -> ());
   { status; body; curl_exit; stderr }
 
-let find_main_eio_exe () =
-  let env_override = Sys.getenv_opt "MASC_MAIN_EIO_EXE" in
-  let candidates =
-    match env_override with
-    | Some p -> [ p ]
-    | None ->
-        let build_roots = [ "."; ".."; "../.."; "../../.."; "../../../.." ] in
-        let build_candidates =
-          List.map
-            (fun root -> Filename.concat root "_build/default/bin/main_eio.exe")
-            build_roots
-        in
-        [
-          "./bin/main_eio.exe";
-          "../bin/main_eio.exe";
-          "../../bin/main_eio.exe";
-          "../../../bin/main_eio.exe";
-          "../../../../bin/main_eio.exe";
-        ]
-        @ build_candidates
-  in
-  match List.find_opt Sys.file_exists candidates with
-  | Some path -> path
-  | None ->
-      fail
-        "main_eio executable not found. Set MASC_MAIN_EIO_EXE or build with `dune build bin/main_eio.exe`."
-
 let find_free_port () =
   let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
   Fun.protect
@@ -186,7 +159,7 @@ let merge_env_overrides overrides =
   Array.of_list (base @ injected)
 
 let with_server f =
-  let exe = find_main_eio_exe () in
+  let exe = Masc_test_runtime.find_main_eio_exe () in
   let port =
     match find_free_port () with
     | Some port -> port

--- a/test/test_openapi_api_e2e.ml
+++ b/test/test_openapi_api_e2e.ml
@@ -166,9 +166,7 @@ let with_server f =
     | None -> Alcotest.skip ()
   in
   let log_file = Filename.temp_file "openapi-api-e2e-" ".log" in
-  let base_path = Filename.temp_file "openapi-api-base-" "" in
-  (try Sys.remove base_path with _ -> ());
-  Unix.mkdir base_path 0o755;
+  let base_path = Filename.temp_dir "openapi-api-base-" "" in
   let log_fd =
     Unix.openfile log_file [ Unix.O_CREAT; Unix.O_WRONLY; Unix.O_TRUNC ] 0o644
   in

--- a/test/test_operator_mcp_e2e.ml
+++ b/test/test_operator_mcp_e2e.ml
@@ -334,9 +334,7 @@ let with_server ?(host = "127.0.0.1") ?(enable_auth = true) f =
   let exe = Masc_test_runtime.find_main_eio_exe () in
   let port = match find_free_port () with Some p -> p | None -> Alcotest.skip () in
   let log_file = Filename.temp_file "operator-mcp-e2e-" ".log" in
-  let base_path = Filename.temp_file "operator-mcp-base-" "" in
-  (try Sys.remove base_path with _ -> ());
-  Unix.mkdir base_path 0o755;
+  let base_path = Filename.temp_dir "operator-mcp-base-" "" in
   let project_root = Masc_test_deps.find_project_root () in
   let config_dir = Filename.concat project_root "config" in
   let personas_dir = Filename.concat config_dir "personas" in

--- a/test/test_operator_mcp_e2e.ml
+++ b/test/test_operator_mcp_e2e.ml
@@ -188,33 +188,6 @@ let contains_substr needle haystack =
   in
   n = 0 || loop 0
 
-let find_main_eio_exe () =
-  let env_override = Sys.getenv_opt "MASC_MAIN_EIO_EXE" in
-  let candidates =
-    match env_override with
-    | Some p -> [ p ]
-    | None ->
-        let build_roots = [ "."; ".."; "../.."; "../../.."; "../../../.." ] in
-        let build_candidates =
-          List.map
-            (fun root -> Filename.concat root "_build/default/bin/main_eio.exe")
-            build_roots
-        in
-        build_candidates
-        @ [
-            "./bin/main_eio.exe";
-            "../bin/main_eio.exe";
-            "../../bin/main_eio.exe";
-            "../../../bin/main_eio.exe";
-            "../../../../bin/main_eio.exe";
-          ]
-  in
-  match List.find_opt Sys.file_exists candidates with
-  | Some path -> path
-  | None ->
-      fail
-        "main_eio executable not found. Set MASC_MAIN_EIO_EXE or build with `dune build bin/main_eio.exe`."
-
 let find_free_port () =
   let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
   Fun.protect
@@ -358,7 +331,7 @@ let extract_nickname_from_join_result result =
             (Printf.sprintf "failed to extract nickname from join result:\n%s" result))
 
 let with_server ?(host = "127.0.0.1") ?(enable_auth = true) f =
-  let exe = find_main_eio_exe () in
+  let exe = Masc_test_runtime.find_main_eio_exe () in
   let port = match find_free_port () with Some p -> p | None -> Alcotest.skip () in
   let log_file = Filename.temp_file "operator-mcp-e2e-" ".log" in
   let base_path = Filename.temp_file "operator-mcp-base-" "" in

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -492,35 +492,6 @@ let main_eio_env_overrides overrides =
      :: ("MASC_INTERNAL_MCP_TOKEN", "")
      :: overrides)
 
-let find_main_eio_exe () =
-  let root = project_root () in
-  let shared_root =
-    root |> Filename.dirname |> Filename.dirname |> Filename.dirname
-  in
-  let build_roots = [ root; Filename.dirname root; shared_root ] in
-  let candidates =
-    [
-      Filename.concat root "bin/main_eio.exe";
-      Filename.concat root "_build/default/bin/main_eio.exe";
-      Filename.concat root "_build/default/masc/bin/main_eio.exe";
-    ]
-    @ List.concat_map
-        (fun base ->
-          [
-            Filename.concat base "bin/main_eio.exe";
-            Filename.concat base "_build/default/bin/main_eio.exe";
-            Filename.concat base "_build/default/masc/bin/main_eio.exe";
-          ])
-        build_roots
-    @ [
-      Filename.concat shared_root "_build/default/bin/main_eio.exe";
-      Filename.concat shared_root "_build/default/masc/bin/main_eio.exe";
-    ]
-  in
-  match List.find_opt Sys.file_exists candidates with
-  | Some path -> path
-  | None -> Alcotest.fail "main_eio executable not found"
-
 let curl_health_status ~port =
   let url = Printf.sprintf "http://127.0.0.1:%d/health" port in
   let args =
@@ -4355,7 +4326,7 @@ let test_prompt_markdown_dir_prefers_resolved_config_dir_over_cwd () =
 
 let test_main_eio_serves_health_before_lazy_startup () =
   with_temp_dir "startup-health" (fun dir ->
-      let exe = find_main_eio_exe () in
+      let exe = Masc_test_runtime.find_main_eio_exe () in
       let port = find_free_port () in
       let log_file = Filename.concat dir "server.log" in
       let log_fd =
@@ -4400,7 +4371,7 @@ let test_main_eio_serves_health_before_lazy_startup () =
 
 let test_main_eio_fresh_bootstrap_and_mcp_handshake () =
   with_temp_dir "startup-fresh-boot-e2e" (fun dir ->
-      let exe = find_main_eio_exe () in
+      let exe = Masc_test_runtime.find_main_eio_exe () in
       let port = find_free_port () in
       let log_file = Filename.concat dir "server.log" in
       let log_fd =
@@ -4552,7 +4523,7 @@ let test_main_eio_fresh_bootstrap_and_mcp_handshake () =
 
 let test_main_eio_preserves_cli_agent_mcp_token_file () =
   with_temp_dir "startup-codex-token-preserve" (fun dir ->
-      let exe = find_main_eio_exe () in
+      let exe = Masc_test_runtime.find_main_eio_exe () in
       let port = find_free_port () in
       let log_file = Filename.concat dir "server.log" in
       let log_fd =
@@ -4762,7 +4733,7 @@ let test_sync_bootable_keeper_credentials_rotates_shared_keeper_tokens () =
 
 let test_main_eio_rejects_same_base_path_on_second_server () =
   with_temp_dir "startup-base-path-owner-lock" (fun dir ->
-      let exe = find_main_eio_exe () in
+      let exe = Masc_test_runtime.find_main_eio_exe () in
       let primary_port = find_free_port () in
       let secondary_port = find_free_port_from (primary_port + 1) in
       let primary_log = Filename.concat dir "primary.log" in
@@ -4848,7 +4819,7 @@ let test_main_eio_rejects_same_base_path_on_second_server () =
 
 let test_main_eio_invalid_runtime_stays_degraded_but_serves_dashboard () =
   with_temp_dir "startup-invalid-runtime" (fun dir ->
-      let exe = find_main_eio_exe () in
+      let exe = Masc_test_runtime.find_main_eio_exe () in
       let port = find_free_port () in
       let log_file = Filename.concat dir "server.log" in
       let log_fd =
@@ -4915,7 +4886,7 @@ let test_main_eio_invalid_runtime_stays_degraded_but_serves_dashboard () =
 
 let test_main_eio_partial_catalog_stays_ready_and_surfaces_rejections () =
   with_temp_dir "startup-partial-runtime" (fun dir ->
-      let exe = find_main_eio_exe () in
+      let exe = Masc_test_runtime.find_main_eio_exe () in
       let port = find_free_port () in
       let mock_port = find_free_port_from (port + 1) in
       let mock_pid =
@@ -4987,7 +4958,7 @@ let test_main_eio_partial_catalog_stays_ready_and_surfaces_rejections () =
 
 let test_main_eio_invalid_default_partial_catalog_stays_degraded () =
   with_temp_dir "startup-default-invalid-partial-runtime" (fun dir ->
-      let exe = find_main_eio_exe () in
+      let exe = Masc_test_runtime.find_main_eio_exe () in
       let port = find_free_port () in
       let mock_port = find_free_port_from (port + 1) in
       let mock_pid =

--- a/test/test_sse_coverage.ml
+++ b/test/test_sse_coverage.ml
@@ -4,7 +4,7 @@
     - format_event: SSE event formatting
     - max_buffer_size: buffer limit constant
     - buffer_event, get_events_after: event buffering
-    - current_id, next_id: event ID management
+    - current_id: durable event ID observation
     - register, unregister, exists: client management
     - client_count: statistics
     - client type: record fields
@@ -61,8 +61,12 @@ let run_domains_together count fn =
    ============================================================ *)
 
 let test_format_event_basic () =
+  let before_id = Sse.current_id () in
   let event = Sse.format_event "test data" in
-  check bool "has id" true (String.length event > 0 && String.sub event 0 3 = "id:");
+  check bool "transport-only frame has no id" false
+    (String.starts_with ~prefix:"id:" event);
+  check int "transport-only frame does not consume replay id"
+    before_id (Sse.current_id ());
   check bool "has data" true (String.length event > 0)
 
 let test_format_event_with_id () =
@@ -95,22 +99,12 @@ let test_max_buffer_size_reasonable () =
     (Sse.max_buffer_size >= 50 && Sse.max_buffer_size <= 1000)
 
 (* ============================================================
-   current_id / next_id Tests
+   current_id Tests
    ============================================================ *)
 
 let test_current_id_positive () =
   let id = Sse.current_id () in
   check bool "positive" true (id >= 0)
-
-let test_next_id_increments () =
-  let before = Sse.current_id () in
-  let next = Sse.next_id () in
-  check bool "incremented" true (next > before)
-
-let test_next_id_sequential () =
-  let id1 = Sse.next_id () in
-  let id2 = Sse.next_id () in
-  check bool "sequential" true (id2 > id1)
 
 (* ============================================================
    register / unregister / exists Tests
@@ -587,8 +581,6 @@ let () =
     ];
     "id_management", [
       test_case "current_id positive" `Quick test_current_id_positive;
-      test_case "next_id increments" `Quick test_next_id_increments;
-      test_case "next_id sequential" `Quick test_next_id_sequential;
     ];
     "client_management", [
       test_case "register creates" `Quick test_register_creates_client;

--- a/test/test_sse_coverage.ml
+++ b/test/test_sse_coverage.ml
@@ -401,6 +401,45 @@ let test_cleanup_expired_events_exact_under_domain_contention () =
       check int "buffer emptied once" 0
         (List.length (Sse.event_buffer_events_for_test ())))
 
+let test_concurrent_broadcast_preserves_replay_and_live_cursor_order () =
+  let original_buffer = Sse.event_buffer_events_for_test () in
+  let original_hook = Atomic.get Sse.buffer_commit_test_hook in
+  let session_id = "test_concurrent_cursor_" ^ string_of_int (Random.bits ()) in
+  Fun.protect
+    ~finally:(fun () ->
+      Atomic.set Sse.buffer_commit_test_hook original_hook;
+      Sse.unregister session_id;
+      Sse.set_event_buffer_for_test original_buffer)
+    (fun () ->
+      Sse.set_event_buffer_for_test [];
+      let (_client_id, event_stream, _) =
+        register_exn ~kind:Sse.Observer session_id ~last_event_id:0
+      in
+      let base_id = Sse.current_id () in
+      let delayed_first_commit = Atomic.make false in
+      Atomic.set Sse.buffer_commit_test_hook
+        (Some (fun () ->
+           if Atomic.compare_and_set delayed_first_commit false true then
+             ignore (Unix.select [] [] [] 0.05)));
+      run_domains_together 2 (fun index ->
+        Sse.broadcast_to Sse.Observers
+          (`Assoc [ "concurrent_sequence", `Int index ]));
+      Atomic.set Sse.buffer_commit_test_hook None;
+      let buffered_ids =
+        Sse.get_events_after base_id
+        |> List.map (fun (event : Sse.delivery) -> event.event_id)
+      in
+      let rec drain acc =
+        match Eio.Stream.take_nonblocking event_stream with
+        | None -> List.rev acc
+        | Some (event : Sse.delivery) -> drain (event.event_id :: acc)
+      in
+      let live_ids = drain [] in
+      check int "both concurrent events are replayable" 2
+        (List.length buffered_ids);
+      check (list int) "live delivery follows durable cursor order"
+        buffered_ids live_ids)
+
 (* ============================================================
    client Type Tests
    ============================================================ *)
@@ -591,6 +630,8 @@ let () =
         test_replay_handoff_deduplicates_exact_ids_only;
       test_case "cleanup exact under domain contention" `Quick
         test_cleanup_expired_events_exact_under_domain_contention;
+      test_case "concurrent broadcast preserves replay/live cursor order" `Quick
+        test_concurrent_broadcast_preserves_replay_and_live_cursor_order;
     ];
     "broadcast", [
       test_case "sends to clients" `Quick test_broadcast_sends_to_clients;

--- a/test/test_sse_coverage.ml
+++ b/test/test_sse_coverage.ml
@@ -15,6 +15,10 @@ open Alcotest
 let jsonrpc_notification method_name =
   `Assoc [ ("jsonrpc", `String "2.0"); ("method", `String method_name) ]
 
+let delivery ?(emitted_at = Unix.gettimeofday ()) event_id frame : Masc.Sse.delivery =
+  { event_id; frame; emitted_at }
+;;
+
 module Sse = Masc.Sse
 module Session = Masc.Session
 
@@ -266,35 +270,34 @@ let test_unregister_if_current_replacement_count () =
 
 let test_buffer_event_and_retrieve () =
   let base_id = Sse.current_id () in
-  Sse.buffer_event (base_id + 1000) "test event 1";
+  Sse.buffer_event (delivery (base_id + 1000) "test event 1");
   let events = Sse.get_events_after (base_id + 999) in
   check bool "has event" true (List.length events >= 1)
 
-let test_buffer_event_timestamps_successful_commit_after_retry () =
+let test_buffer_event_preserves_producer_timestamp_after_retry () =
   let original_buffer = Sse.event_buffer_events_for_test () in
   let original_hook = Atomic.get Sse.buffer_commit_test_hook in
   let forced_retry = Atomic.make false in
-  let retry_barrier = ref 0.0 in
+  let emitted_at = Unix.gettimeofday () in
   Fun.protect
     ~finally:(fun () ->
       Atomic.set Sse.buffer_commit_test_hook original_hook;
       Sse.set_event_buffer_for_test original_buffer)
     (fun () ->
-      Sse.set_event_buffer_for_test [ (777_000, "marker", Unix.gettimeofday ()) ];
+      Sse.set_event_buffer_for_test [ delivery 777_000 "marker" ];
       Atomic.set Sse.buffer_commit_test_hook
         (Some (fun () ->
            if Atomic.compare_and_set forced_retry false true then begin
              Sse.rewrite_event_buffer_for_test ();
              ignore (Unix.select [] [] [] 0.02);
-             retry_barrier := Unix.gettimeofday ()
            end));
-      Sse.buffer_event 777_001 "fresh";
+      Sse.buffer_event (delivery ~emitted_at 777_001 "fresh");
       check bool "forced retry triggered" true (Atomic.get forced_retry);
       match Sse.event_buffer_events_for_test () with
-      | (event_id, _event, ts) :: _ ->
-          check int "new event inserted at head" 777_001 event_id;
-          check bool "timestamp captured after retry barrier" true
-            (ts >= !retry_barrier)
+      | (fresh : Sse.delivery) :: _ ->
+          check int "new event inserted at head" 777_001 fresh.event_id;
+          check (float 0.0) "producer timestamp survives CAS retry"
+            emitted_at fresh.emitted_at
       | [] ->
           fail "buffer should contain the fresh event")
 
@@ -304,10 +307,10 @@ let test_get_events_after_filters () =
     ~finally:(fun () -> Sse.set_event_buffer_for_test original_buffer)
     (fun () ->
       Sse.set_event_buffer_for_test [];
-      Sse.buffer_event 802_000 "event A";
-      Sse.buffer_event 802_001 "event B";
+      Sse.buffer_event (delivery 802_000 "event A");
+      Sse.buffer_event (delivery 802_001 "event B");
       check (list string) "filtered exact replay" [ "event B" ]
-        (Sse.get_events_after 802_000))
+        (Sse.get_events_after 802_000 |> List.map (fun event -> event.Sse.frame)))
 
 let test_get_events_after_preserves_oldest_first_order () =
   let original_buffer = Sse.event_buffer_events_for_test () in
@@ -315,14 +318,14 @@ let test_get_events_after_preserves_oldest_first_order () =
     ~finally:(fun () -> Sse.set_event_buffer_for_test original_buffer)
     (fun () ->
       Sse.set_event_buffer_for_test [];
-      Sse.buffer_event 803_000 "event A";
-      Sse.buffer_event 803_001 "event B";
-      Sse.buffer_event 803_002 "event C";
+      Sse.buffer_event (delivery 803_000 "event A");
+      Sse.buffer_event (delivery 803_001 "event B");
+      Sse.buffer_event (delivery 803_002 "event C");
       check (list string) "all replayed oldest-first"
         [ "event A"; "event B"; "event C" ]
-        (Sse.get_events_after 802_999);
+        (Sse.get_events_after 802_999 |> List.map (fun event -> event.Sse.frame));
       check (list string) "tail replayed oldest-first" [ "event B"; "event C" ]
-        (Sse.get_events_after 803_000))
+        (Sse.get_events_after 803_000 |> List.map (fun event -> event.Sse.frame)))
 
 let test_buffer_event_caps_replay_buffer () =
   let original_buffer = Sse.event_buffer_events_for_test () in
@@ -332,7 +335,8 @@ let test_buffer_event_caps_replay_buffer () =
       Sse.set_event_buffer_for_test [];
       let base = Sse.current_id () + Sse.max_buffer_size + 1 in
       for index = 0 to Sse.max_buffer_size + 4 do
-        Sse.buffer_event (base + index) (Printf.sprintf "event-%d" index)
+        Sse.buffer_event
+          (delivery (base + index) (Printf.sprintf "event-%d" index))
       done;
       let buffered = Sse.event_buffer_events_for_test () in
       let expected_newest_first_indexes =
@@ -347,18 +351,32 @@ let test_buffer_event_caps_replay_buffer () =
       check int "buffer capped" Sse.max_buffer_size (List.length buffered);
       check (list int) "retained ids newest-first"
         (List.map (fun index -> base + index) expected_newest_first_indexes)
-        (List.map (fun (event_id, _, _) -> event_id) buffered);
+        (List.map (fun (event : Sse.delivery) -> event.event_id) buffered);
       check (list string) "retained event contents newest-first"
         expected_newest_first_events
-        (List.map (fun (_, event, _) -> event) buffered);
+        (List.map (fun (event : Sse.delivery) -> event.frame) buffered);
       check (list string) "replay retained events oldest-first"
         (List.rev expected_newest_first_events)
-        (Sse.get_events_after (base - 1)))
+        (Sse.get_events_after (base - 1)
+         |> List.map (fun event -> event.Sse.frame)))
 
 let test_get_events_after_empty () =
   let future_id = Sse.current_id () + 100000 in
   let events = Sse.get_events_after future_id in
   check int "empty for future id" 0 (List.length events)
+
+let test_replay_handoff_deduplicates_exact_ids_only () =
+  let replayed = [ delivery 910_010 "ten"; delivery 910_030 "thirty" ] in
+  let handoff = Sse.create_replay_handoff replayed in
+  check bool "replayed high id skipped once" false
+    (Sse.accept_live_delivery handoff (delivery 910_030 "thirty"));
+  check bool "unreplayed middle id is not lost" true
+    (Sse.accept_live_delivery handoff (delivery 910_020 "twenty"));
+  check bool "replayed low id skipped despite interleaving" false
+    (Sse.accept_live_delivery handoff (delivery 910_010 "ten"));
+  check bool "same id is accepted after overlap drains" true
+    (Sse.accept_live_delivery handoff (delivery 910_010 "ten-again"))
+;;
 
 let test_cleanup_expired_events_exact_under_domain_contention () =
   let original_buffer = Sse.event_buffer_events_for_test () in
@@ -366,8 +384,10 @@ let test_cleanup_expired_events_exact_under_domain_contention () =
   let expired_count = 32 in
   let expired_items =
     List.init expired_count (fun index ->
-      (900_000 + index, Printf.sprintf "expired-%d" index,
-       now -. Sse.buffer_ttl_seconds -. 10.0))
+      delivery
+        ~emitted_at:(now -. Sse.buffer_ttl_seconds -. 10.0)
+        (900_000 + index)
+        (Printf.sprintf "expired-%d" index))
   in
   Fun.protect
     ~finally:(fun () -> Sse.set_event_buffer_for_test original_buffer)
@@ -561,12 +581,14 @@ let () =
     "event_buffer", [
       test_case "buffer and retrieve" `Quick test_buffer_event_and_retrieve;
       test_case "buffer retry timestamps on successful commit" `Quick
-        test_buffer_event_timestamps_successful_commit_after_retry;
+        test_buffer_event_preserves_producer_timestamp_after_retry;
       test_case "filters" `Quick test_get_events_after_filters;
       test_case "preserves oldest-first order" `Quick
         test_get_events_after_preserves_oldest_first_order;
       test_case "caps replay buffer" `Quick test_buffer_event_caps_replay_buffer;
       test_case "empty for future" `Quick test_get_events_after_empty;
+      test_case "replay handoff deduplicates exact ids" `Quick
+        test_replay_handoff_deduplicates_exact_ids_only;
       test_case "cleanup exact under domain contention" `Quick
         test_cleanup_expired_events_exact_under_domain_contention;
     ];

--- a/test/test_sse_coverage.ml
+++ b/test/test_sse_coverage.ml
@@ -15,10 +15,12 @@ open Alcotest
 let jsonrpc_notification method_name =
   `Assoc [ ("jsonrpc", `String "2.0"); ("method", `String method_name) ]
 
-let delivery ?(emitted_at = Unix.gettimeofday ())
-    ?(audience = Masc.Sse.Broadcast_audience Masc.Sse.All)
-    event_id frame : Masc.Sse.delivery =
-  { event_id; frame; emitted_at; audience }
+let delivery ?(emitted_at = Unix.gettimeofday ()) event_id frame : Masc.Sse.delivery =
+  { event_id
+  ; frame
+  ; emitted_at
+  ; audience = Masc.Sse.Broadcast_audience Masc.Sse.All
+  }
 ;;
 
 module Sse = Masc.Sse
@@ -364,34 +366,6 @@ let test_get_events_after_empty () =
   let events = Sse.get_events_after_for_test future_id in
   check int "empty for future id" 0 (List.length events)
 
-let test_targeted_replay_is_session_scoped () =
-  let original_buffer = Sse.event_buffer_events_for_test () in
-  Fun.protect
-    ~finally:(fun () -> Sse.set_event_buffer_for_test original_buffer)
-    (fun () ->
-      let event_id = 804_000 in
-      let frame =
-        Sse.format_event ~id:event_id
-          (Yojson.Safe.to_string
-             (jsonrpc_notification "notifications/resources/updated"))
-      in
-      Sse.set_event_buffer_for_test
-        [ delivery
-            ~audience:(Sse.Session_audience "session-a")
-            event_id frame ];
-      check int "target session replays targeted event" 1
-        (List.length
-           (Sse.get_events_after_for_session ~session_id:"session-a"
-              ~kind:Sse.Agent_stream (event_id - 1)));
-      check int "other session cannot replay targeted event" 0
-        (List.length
-           (Sse.get_events_after_for_session ~session_id:"session-b"
-              ~kind:Sse.Agent_stream (event_id - 1)));
-      check int "observer cannot replay targeted JSON-RPC event" 0
-        (List.length
-           (Sse.get_events_after_for_session ~session_id:"session-a"
-              ~kind:Sse.Observer (event_id - 1))))
-
 let test_replay_handoff_deduplicates_exact_ids_only () =
   let replayed = [ delivery 910_010 "ten"; delivery 910_030 "thirty" ] in
   let handoff = Sse.create_replay_handoff replayed in
@@ -651,8 +625,6 @@ let () =
         test_get_events_after_preserves_oldest_first_order;
       test_case "caps replay buffer" `Quick test_buffer_event_caps_replay_buffer;
       test_case "empty for future" `Quick test_get_events_after_empty;
-      test_case "targeted replay is session scoped" `Quick
-        test_targeted_replay_is_session_scoped;
       test_case "replay handoff deduplicates exact ids" `Quick
         test_replay_handoff_deduplicates_exact_ids_only;
       test_case "cleanup exact under domain contention" `Quick

--- a/test/test_sse_coverage.ml
+++ b/test/test_sse_coverage.ml
@@ -18,6 +18,7 @@ let jsonrpc_notification method_name =
 let delivery ?(emitted_at = Unix.gettimeofday ()) event_id frame : Masc.Sse.delivery =
   { event_id
   ; frame
+  ; payload = `String frame
   ; emitted_at
   ; audience = Masc.Sse.Broadcast_audience Masc.Sse.All
   }
@@ -441,6 +442,20 @@ let test_concurrent_broadcast_preserves_replay_and_live_cursor_order () =
       check (list int) "live delivery follows durable cursor order"
         buffered_ids live_ids)
 
+let test_broadcast_preserves_typed_payload () =
+  let session_id = "test_typed_payload_" ^ string_of_int (Random.bits ()) in
+  Fun.protect
+    ~finally:(fun () -> Sse.unregister session_id)
+    (fun () ->
+      let (_client_id, event_stream, _) =
+        register_exn ~kind:Sse.Observer session_id ~last_event_id:0
+      in
+      let expected = `Assoc [ "typed_payload", `String "preserved" ] in
+      Sse.broadcast_to Sse.Observers expected;
+      let actual = (Eio.Stream.take event_stream : Sse.delivery).payload in
+      check bool "delivery retains producer JSON without wire reparse" true
+        (expected = actual))
+
 (* ============================================================
    client Type Tests
    ============================================================ *)
@@ -631,6 +646,8 @@ let () =
         test_cleanup_expired_events_exact_under_domain_contention;
       test_case "concurrent broadcast preserves replay/live cursor order" `Quick
         test_concurrent_broadcast_preserves_replay_and_live_cursor_order;
+      test_case "broadcast preserves typed payload" `Quick
+        test_broadcast_preserves_typed_payload;
     ];
     "broadcast", [
       test_case "sends to clients" `Quick test_broadcast_sends_to_clients;

--- a/test/test_sse_coverage.ml
+++ b/test/test_sse_coverage.ml
@@ -3,7 +3,7 @@
     Tests for SSE (Server-Sent Events) functionality:
     - format_event: SSE event formatting
     - max_buffer_size: buffer limit constant
-    - buffer_event, get_events_after: event buffering
+    - buffer_event, replay lookup: event buffering
     - current_id: durable event ID observation
     - register, unregister, exists: client management
     - client_count: statistics
@@ -15,8 +15,10 @@ open Alcotest
 let jsonrpc_notification method_name =
   `Assoc [ ("jsonrpc", `String "2.0"); ("method", `String method_name) ]
 
-let delivery ?(emitted_at = Unix.gettimeofday ()) event_id frame : Masc.Sse.delivery =
-  { event_id; frame; emitted_at }
+let delivery ?(emitted_at = Unix.gettimeofday ())
+    ?(audience = Masc.Sse.Broadcast_audience Masc.Sse.All)
+    event_id frame : Masc.Sse.delivery =
+  { event_id; frame; emitted_at; audience }
 ;;
 
 module Sse = Masc.Sse
@@ -259,13 +261,13 @@ let test_unregister_if_current_replacement_count () =
         before (Sse.client_count ()))
 
 (* ============================================================
-   buffer_event / get_events_after Tests
+   buffer_event / replay lookup Tests
    ============================================================ *)
 
 let test_buffer_event_and_retrieve () =
   let base_id = Sse.current_id () in
   Sse.buffer_event (delivery (base_id + 1000) "test event 1");
-  let events = Sse.get_events_after (base_id + 999) in
+  let events = Sse.get_events_after_for_test (base_id + 999) in
   check bool "has event" true (List.length events >= 1)
 
 let test_buffer_event_preserves_producer_timestamp_after_retry () =
@@ -304,7 +306,8 @@ let test_get_events_after_filters () =
       Sse.buffer_event (delivery 802_000 "event A");
       Sse.buffer_event (delivery 802_001 "event B");
       check (list string) "filtered exact replay" [ "event B" ]
-        (Sse.get_events_after 802_000 |> List.map (fun event -> event.Sse.frame)))
+        (Sse.get_events_after_for_test 802_000
+         |> List.map (fun event -> event.Sse.frame)))
 
 let test_get_events_after_preserves_oldest_first_order () =
   let original_buffer = Sse.event_buffer_events_for_test () in
@@ -317,9 +320,11 @@ let test_get_events_after_preserves_oldest_first_order () =
       Sse.buffer_event (delivery 803_002 "event C");
       check (list string) "all replayed oldest-first"
         [ "event A"; "event B"; "event C" ]
-        (Sse.get_events_after 802_999 |> List.map (fun event -> event.Sse.frame));
+        (Sse.get_events_after_for_test 802_999
+         |> List.map (fun event -> event.Sse.frame));
       check (list string) "tail replayed oldest-first" [ "event B"; "event C" ]
-        (Sse.get_events_after 803_000 |> List.map (fun event -> event.Sse.frame)))
+        (Sse.get_events_after_for_test 803_000
+         |> List.map (fun event -> event.Sse.frame)))
 
 let test_buffer_event_caps_replay_buffer () =
   let original_buffer = Sse.event_buffer_events_for_test () in
@@ -351,13 +356,41 @@ let test_buffer_event_caps_replay_buffer () =
         (List.map (fun (event : Sse.delivery) -> event.frame) buffered);
       check (list string) "replay retained events oldest-first"
         (List.rev expected_newest_first_events)
-        (Sse.get_events_after (base - 1)
+        (Sse.get_events_after_for_test (base - 1)
          |> List.map (fun event -> event.Sse.frame)))
 
 let test_get_events_after_empty () =
   let future_id = Sse.current_id () + 100000 in
-  let events = Sse.get_events_after future_id in
+  let events = Sse.get_events_after_for_test future_id in
   check int "empty for future id" 0 (List.length events)
+
+let test_targeted_replay_is_session_scoped () =
+  let original_buffer = Sse.event_buffer_events_for_test () in
+  Fun.protect
+    ~finally:(fun () -> Sse.set_event_buffer_for_test original_buffer)
+    (fun () ->
+      let event_id = 804_000 in
+      let frame =
+        Sse.format_event ~id:event_id
+          (Yojson.Safe.to_string
+             (jsonrpc_notification "notifications/resources/updated"))
+      in
+      Sse.set_event_buffer_for_test
+        [ delivery
+            ~audience:(Sse.Session_audience "session-a")
+            event_id frame ];
+      check int "target session replays targeted event" 1
+        (List.length
+           (Sse.get_events_after_for_session ~session_id:"session-a"
+              ~kind:Sse.Agent_stream (event_id - 1)));
+      check int "other session cannot replay targeted event" 0
+        (List.length
+           (Sse.get_events_after_for_session ~session_id:"session-b"
+              ~kind:Sse.Agent_stream (event_id - 1)));
+      check int "observer cannot replay targeted JSON-RPC event" 0
+        (List.length
+           (Sse.get_events_after_for_session ~session_id:"session-a"
+              ~kind:Sse.Observer (event_id - 1))))
 
 let test_replay_handoff_deduplicates_exact_ids_only () =
   let replayed = [ delivery 910_010 "ten"; delivery 910_030 "thirty" ] in
@@ -420,7 +453,7 @@ let test_concurrent_broadcast_preserves_replay_and_live_cursor_order () =
           (`Assoc [ "concurrent_sequence", `Int index ]));
       Atomic.set Sse.buffer_commit_test_hook None;
       let buffered_ids =
-        Sse.get_events_after base_id
+        Sse.get_events_after_for_test base_id
         |> List.map (fun (event : Sse.delivery) -> event.event_id)
       in
       let rec drain acc =
@@ -618,6 +651,8 @@ let () =
         test_get_events_after_preserves_oldest_first_order;
       test_case "caps replay buffer" `Quick test_buffer_event_caps_replay_buffer;
       test_case "empty for future" `Quick test_get_events_after_empty;
+      test_case "targeted replay is session scoped" `Quick
+        test_targeted_replay_is_session_scoped;
       test_case "replay handoff deduplicates exact ids" `Quick
         test_replay_handoff_deduplicates_exact_ids_only;
       test_case "cleanup exact under domain contention" `Quick

--- a/test/test_sse_retry_ssot.ml
+++ b/test/test_sse_retry_ssot.ml
@@ -16,6 +16,11 @@ let test_frame_derives_from_ssot () =
     (Printf.sprintf ": presence-stream\nretry: %d\n\n" H.sse_retry_ms)
     (H.sse_comment_with_retry ~comment:"presence-stream")
 
+let test_prime_does_not_advance_replay_cursor () =
+  check string "transport-only prime has no durable event id"
+    (Printf.sprintf "retry: %d\n\n" H.sse_retry_ms)
+    (H.sse_prime_event ())
+
 let test_comment_interpolated_retry_constant () =
   let a = H.sse_comment_with_retry ~comment:"activity-stream after=7" in
   let b = H.sse_comment_with_retry ~comment:"presence-stream" in
@@ -33,6 +38,8 @@ let () =
         [
           test_case "frame derives from sse_retry_ms" `Quick
             test_frame_derives_from_ssot;
+          test_case "prime omits replay cursor id" `Quick
+            test_prime_does_not_advance_replay_cursor;
           test_case "comment interpolated, retry constant" `Quick
             test_comment_interpolated_retry_constant;
         ] );

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -543,6 +543,31 @@ let sse_data_jsons body =
       try Some (Yojson.Safe.from_string payload) with Yojson.Json_error _ -> None
     else None)
 
+let sse_id_data_jsons body =
+  let rec collect current_id acc = function
+    | [] -> List.rev acc
+    | line :: rest when String.starts_with ~prefix:"id:" line ->
+      let raw =
+        String.sub line 3 (String.length line - 3) |> String.trim
+      in
+      collect (int_of_string_opt raw) acc rest
+    | line :: rest when String.starts_with ~prefix:"data:" line ->
+      let payload =
+        String.sub line 5 (String.length line - 5) |> String.trim
+      in
+      let acc =
+        match current_id with
+        | None -> acc
+        | Some event_id ->
+          (match Yojson.Safe.from_string payload with
+           | json -> (event_id, json) :: acc
+           | exception Yojson.Json_error _ -> acc)
+      in
+      collect None acc rest
+    | _ :: rest -> collect current_id acc rest
+  in
+  collect None [] (String.split_on_char '\n' body)
+
 let has_numeric_sse_id body =
   String.split_on_char '\n' body
   |> List.exists (fun line ->
@@ -590,7 +615,41 @@ let test_ag_ui_frames_are_wire_encoded () =
          res.body);
   if not (has_numeric_sse_id res.body) then
     fail
-      (Printf.sprintf "/ag-ui/events discarded every SSE cursor: %S" res.body)
+      (Printf.sprintf "/ag-ui/events discarded every SSE cursor: %S" res.body);
+  let first_masc_events =
+    sse_id_data_jsons res.body
+    |> List.filter (fun (_event_id, json) -> is_masc_event json)
+  in
+  let second_sid = initialize_mcp_session ~port ~auth_token in
+  let second_headers =
+    [ ("Accept", "text/event-stream")
+    ; ("Authorization", "Bearer " ^ auth_token)
+    ; ("Mcp-Session-Id", second_sid)
+    ; ("Last-Event-ID", "0")
+    ]
+  in
+  let second =
+    run_curl ~headers:second_headers ~max_time:1.0 ~port ~path:"/ag-ui/events" ()
+  in
+  check_status "second /ag-ui/events replay accepted" 200 second;
+  let second_by_id = sse_id_data_jsons second.body in
+  List.iter
+    (fun (event_id, expected_json) ->
+       match List.assoc_opt event_id second_by_id with
+       | Some actual_json ->
+         if actual_json <> expected_json then
+           fail
+             (Printf.sprintf
+                "AG-UI replay changed payload for SSE id %d\nfirst=%s\nsecond=%s"
+                event_id
+                (Yojson.Safe.to_string expected_json)
+                (Yojson.Safe.to_string actual_json))
+       | None ->
+         fail
+           (Printf.sprintf
+              "second AG-UI replay omitted prior SSE id %d"
+              event_id))
+    first_masc_events
 
 let test_ag_ui_rejects_reconnect_then_recovers () =
   with_server @@ fun ~port ~auth_token ->

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -142,32 +142,6 @@ let header_value result name =
   |> List.find_map (fun (key, value) ->
     if String.equal (String.lowercase_ascii key) name then Some value else None)
 
-let find_main_eio_exe () =
-  let env_override = Sys.getenv_opt "MASC_MAIN_EIO_EXE" in
-  let candidates =
-    match env_override with
-    | Some p -> [p]
-    | None ->
-        let build_roots = [ "."; ".."; "../.."; "../../.."; "../../../.." ] in
-        let build_candidates =
-          List.map
-            (fun root -> Filename.concat root "_build/default/bin/main_eio.exe")
-            build_roots
-        in
-        [
-          "./bin/main_eio.exe";
-          "../bin/main_eio.exe";
-          "../../bin/main_eio.exe";
-          "../../../bin/main_eio.exe";
-          "../../../../bin/main_eio.exe";
-        ] @ build_candidates
-  in
-  match List.find_opt Sys.file_exists candidates with
-  | Some path -> path
-  | None ->
-      fail
-        "main_eio executable not found. Set MASC_MAIN_EIO_EXE or build with `dune build bin/main_eio.exe`."
-
 let find_free_port () =
   let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
   Fun.protect
@@ -396,7 +370,7 @@ let seed_server_config ~base_path =
       (fun () -> output_string oc catalog_overlay_seed)
 
 let with_server f =
-  let exe = find_main_eio_exe () in
+  let exe = Masc_test_runtime.find_main_eio_exe () in
   let port =
     match find_free_port () with
     | Some p -> p

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -478,7 +478,7 @@ let publish_masc_broadcast ~port ~auth_token ~session_id =
     run_curl
       ~headers:
         [ ("Content-Type", "application/json")
-        ; ("Accept", "application/json")
+        ; ("Accept", "application/json, text/event-stream")
         ; ("Authorization", "Bearer " ^ auth_token)
         ; ("Mcp-Session-Id", session_id)
         ]

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -708,17 +708,23 @@ let check_invalid_request_response label result =
 let test_sse_endpoints_reject_malformed_last_event_id () =
   with_server @@ fun ~port ~auth_token ->
   let sid = initialize_mcp_session ~port ~auth_token in
-  let headers =
+  let headers cursor =
     [ ("Accept", "text/event-stream")
     ; ("Authorization", "Bearer " ^ auth_token)
     ; ("Mcp-Session-Id", sid)
-    ; ("Last-Event-ID", "not-an-integer")
+    ; ("Last-Event-ID", cursor)
     ]
   in
   check_invalid_request_response "malformed /mcp cursor rejected"
-    (run_curl ~headers ~max_time:2.0 ~port ~path:"/mcp" ());
+    (run_curl ~headers:(headers "not-an-integer") ~max_time:2.0 ~port ~path:"/mcp" ());
   check_invalid_request_response "malformed /ag-ui/events cursor rejected"
-    (run_curl ~headers ~max_time:2.0 ~port ~path:"/ag-ui/events" ())
+    (run_curl ~headers:(headers "not-an-integer") ~max_time:2.0 ~port
+       ~path:"/ag-ui/events" ());
+  check_invalid_request_response "negative /mcp cursor rejected"
+    (run_curl ~headers:(headers "-1") ~max_time:2.0 ~port ~path:"/mcp" ());
+  check_invalid_request_response "negative /ag-ui/events cursor rejected"
+    (run_curl ~headers:(headers "-1") ~max_time:2.0 ~port
+       ~path:"/ag-ui/events" ())
 
 let () =
   Random.self_init ();

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -459,6 +459,56 @@ let check_status label expected result =
            result.curl_exit
            result.stderr)
 
+let publish_masc_broadcast ~port ~auth_token ~session_id =
+  let body =
+    Yojson.Safe.to_string
+      (`Assoc
+        [ "jsonrpc", `String "2.0"
+        ; "id", `Int 2
+        ; "method", `String "tools/call"
+        ; ( "params"
+          , `Assoc
+              [ "name", `String "masc_broadcast"
+              ; ( "arguments"
+                , `Assoc [ "message", `String "sse-ag-ui-wire-encoding" ] )
+              ] )
+        ])
+  in
+  let result =
+    run_curl
+      ~headers:
+        [ ("Content-Type", "application/json")
+        ; ("Accept", "application/json")
+        ; ("Authorization", "Bearer " ^ auth_token)
+        ; ("Mcp-Session-Id", session_id)
+        ]
+      ~method_:"POST"
+      ~body
+      ~max_time:2.0
+      ~port
+      ~path:"/mcp"
+      ()
+  in
+  check_status "observer source broadcast accepted" 200 result;
+  match Yojson.Safe.from_string result.body with
+  | `Assoc fields when List.mem_assoc "result" fields -> ()
+  | `Assoc fields when List.mem_assoc "error" fields ->
+      fail
+        (Printf.sprintf
+           "observer source broadcast returned an MCP error: %s"
+           result.body)
+  | _ ->
+      fail
+        (Printf.sprintf
+           "observer source broadcast returned an invalid MCP response: %s"
+           result.body)
+  | exception Yojson.Json_error message ->
+      fail
+        (Printf.sprintf
+           "observer source broadcast returned invalid JSON: %s body=%s"
+           message
+           result.body)
+
 let test_mcp_reconnect_stays_accepted () =
   with_server @@ fun ~port ~auth_token ->
   let sid = initialize_mcp_session ~port ~auth_token in
@@ -511,22 +561,17 @@ let is_masc_event = function
     && List.assoc_opt "value" fields <> None
   | _ -> false
 
-(* Guards that /ag-ui/events actually applies the MASC -> AG-UI encoder to the
-   frames it ships, rather than forwarding raw MASC SSE frames.
-
-   Measured with a positive/negative control against a server binary built from
-   this tree (MASC_MAIN_EIO_EXE pinned — the harness otherwise walks up to four
-   directories and can pick the parent checkout's binary):
-     - both encoder call sites wired      -> pass
-     - only the replay call site reverted -> pass
-     - both call sites reverted           -> fail
-   So the frames this test observes arrive on the drain (live) path, and that is
-   the path it pins.  The exact Custom name check prevents the encoding-error
-   envelope from creating a substring false positive.  The numeric [id:] check
-   pins the resumability cursor carried by transformed live/replay frames. *)
+(* Guards that /ag-ui/events applies the MASC -> AG-UI encoder to a deterministic
+   observer replay frame rather than forwarding a raw MASC SSE frame.  The
+   source event is produced through the public MCP dispatch path before the
+   reconnect, so this test does not depend on unrelated startup telemetry or
+   timing.  The exact MASC_EVENT envelope check prevents an encoding-error
+   response from becoming a substring false positive; the numeric [id:] check
+   pins the resumability cursor carried by the transformed frame. *)
 let test_ag_ui_frames_are_wire_encoded () =
   with_server @@ fun ~port ~auth_token ->
   let sid = initialize_mcp_session ~port ~auth_token in
+  publish_masc_broadcast ~port ~auth_token ~session_id:sid;
   let headers =
     [
       ("Accept", "text/event-stream");

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -470,7 +470,10 @@ let publish_masc_broadcast ~port ~auth_token ~session_id =
           , `Assoc
               [ "name", `String "masc_broadcast"
               ; ( "arguments"
-                , `Assoc [ "message", `String "sse-ag-ui-wire-encoding" ] )
+                , `Assoc
+                    [ "agent_name", `String "dashboard"
+                    ; "message", `String "sse-ag-ui-wire-encoding"
+                    ] )
               ] )
         ])
   in
@@ -492,12 +495,36 @@ let publish_masc_broadcast ~port ~auth_token ~session_id =
   in
   check_status "observer source broadcast accepted" 200 result;
   match Yojson.Safe.from_string result.body with
-  | `Assoc fields when List.mem_assoc "result" fields -> ()
-  | `Assoc fields when List.mem_assoc "error" fields ->
-      fail
-        (Printf.sprintf
-           "observer source broadcast returned an MCP error: %s"
-           result.body)
+  | `Assoc fields ->
+      (match List.assoc_opt "result" fields with
+       | Some (`Assoc result_fields) ->
+           (match List.assoc_opt "isError" result_fields with
+            | Some (`Bool false) -> ()
+            | Some (`Bool true) ->
+                fail
+                  (Printf.sprintf
+                     "observer source broadcast returned a tool error: %s"
+                     result.body)
+            | Some _ | None ->
+                fail
+                  (Printf.sprintf
+                     "observer source broadcast result omitted boolean isError: %s"
+                     result.body))
+       | Some _ ->
+           fail
+             (Printf.sprintf
+                "observer source broadcast returned a non-object result: %s"
+                result.body)
+       | None when List.mem_assoc "error" fields ->
+           fail
+             (Printf.sprintf
+                "observer source broadcast returned an MCP error: %s"
+                result.body)
+       | None ->
+           fail
+             (Printf.sprintf
+                "observer source broadcast returned an invalid MCP response: %s"
+                result.body))
   | _ ->
       fail
         (Printf.sprintf

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -481,6 +481,36 @@ let body_contains needle body =
   let rec scan i = i + nl <= bl && (String.sub body i nl = needle || scan (i + 1)) in
   nl > 0 && scan 0
 
+let sse_data_jsons body =
+  String.split_on_char '\n' body
+  |> List.filter_map (fun line ->
+    let prefix = "data:" in
+    if String.starts_with ~prefix line then
+      let payload =
+        String.sub line (String.length prefix) (String.length line - String.length prefix)
+        |> String.trim
+      in
+      try Some (Yojson.Safe.from_string payload) with Yojson.Json_error _ -> None
+    else None)
+
+let has_numeric_sse_id body =
+  String.split_on_char '\n' body
+  |> List.exists (fun line ->
+    let prefix = "id:" in
+    if String.starts_with ~prefix line then
+      let raw =
+        String.sub line (String.length prefix) (String.length line - String.length prefix)
+        |> String.trim
+      in
+      Option.is_some (int_of_string_opt raw)
+    else false)
+
+let is_masc_event = function
+  | `Assoc fields ->
+    List.assoc_opt "name" fields = Some (`String "MASC_EVENT")
+    && List.assoc_opt "value" fields <> None
+  | _ -> false
+
 (* Guards that /ag-ui/events actually applies the MASC -> AG-UI encoder to the
    frames it ships, rather than forwarding raw MASC SSE frames.
 
@@ -491,8 +521,9 @@ let body_contains needle body =
      - only the replay call site reverted -> pass
      - both call sites reverted           -> fail
    So the frames this test observes arrive on the drain (live) path, and that is
-   the path it pins.  [Last-Event-ID] additionally exercises the replay branch,
-   but replay is not what makes the assertion fire. *)
+   the path it pins.  The exact Custom name check prevents the encoding-error
+   envelope from creating a substring false positive.  The numeric [id:] check
+   pins the resumability cursor carried by transformed live/replay frames. *)
 let test_ag_ui_frames_are_wire_encoded () =
   with_server @@ fun ~port ~auth_token ->
   let sid = initialize_mcp_session ~port ~auth_token in
@@ -506,13 +537,15 @@ let test_ag_ui_frames_are_wire_encoded () =
   in
   let res = run_curl ~headers ~max_time:1.0 ~port ~path:"/ag-ui/events" () in
   check_status "/ag-ui/events connect accepted" 200 res;
-  (* [Ag_ui.of_custom ~name:"MASC_EVENT"] is what the encoder wraps every replayed
-     MASC frame in.  A raw frame would not carry that name. *)
-  if not (body_contains "MASC_EVENT" res.body) then
+  let events = sse_data_jsons res.body in
+  if not (List.exists is_masc_event events) then
     fail
       (Printf.sprintf
-         "/ag-ui/events frames are not AG-UI encoded (no MASC_EVENT envelope): %S"
-         res.body)
+         "/ag-ui/events frames are not AG-UI encoded (no exact MASC_EVENT envelope): %S"
+         res.body);
+  if not (has_numeric_sse_id res.body) then
+    fail
+      (Printf.sprintf "/ag-ui/events discarded every SSE cursor: %S" res.body)
 
 let test_ag_ui_rejects_reconnect_then_recovers () =
   with_server @@ fun ~port ~auth_token ->

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -476,6 +476,44 @@ let test_mcp_reconnect_stays_accepted () =
   let second = run_curl ~headers ~max_time:2.0 ~port ~path:"/mcp" () in
   check_status "follow-up /mcp reconnect accepted" 200 second
 
+let body_contains needle body =
+  let nl = String.length needle and bl = String.length body in
+  let rec scan i = i + nl <= bl && (String.sub body i nl = needle || scan (i + 1)) in
+  nl > 0 && scan 0
+
+(* Guards that /ag-ui/events actually applies the MASC -> AG-UI encoder to the
+   frames it ships, rather than forwarding raw MASC SSE frames.
+
+   Measured with a positive/negative control against a server binary built from
+   this tree (MASC_MAIN_EIO_EXE pinned — the harness otherwise walks up to four
+   directories and can pick the parent checkout's binary):
+     - both encoder call sites wired      -> pass
+     - only the replay call site reverted -> pass
+     - both call sites reverted           -> fail
+   So the frames this test observes arrive on the drain (live) path, and that is
+   the path it pins.  [Last-Event-ID] additionally exercises the replay branch,
+   but replay is not what makes the assertion fire. *)
+let test_ag_ui_frames_are_wire_encoded () =
+  with_server @@ fun ~port ~auth_token ->
+  let sid = initialize_mcp_session ~port ~auth_token in
+  let headers =
+    [
+      ("Accept", "text/event-stream");
+      ("Authorization", "Bearer " ^ auth_token);
+      ("Mcp-Session-Id", sid);
+      ("Last-Event-ID", "0");
+    ]
+  in
+  let res = run_curl ~headers ~max_time:1.0 ~port ~path:"/ag-ui/events" () in
+  check_status "/ag-ui/events connect accepted" 200 res;
+  (* [Ag_ui.of_custom ~name:"MASC_EVENT"] is what the encoder wraps every replayed
+     MASC frame in.  A raw frame would not carry that name. *)
+  if not (body_contains "MASC_EVENT" res.body) then
+    fail
+      (Printf.sprintf
+         "/ag-ui/events frames are not AG-UI encoded (no MASC_EVENT envelope): %S"
+         res.body)
+
 let test_ag_ui_rejects_reconnect_then_recovers () =
   with_server @@ fun ~port ~auth_token ->
   let sid = initialize_mcp_session ~port ~auth_token in
@@ -492,6 +530,13 @@ let test_ag_ui_rejects_reconnect_then_recovers () =
   (* Stay well inside the 1s reconnect guard so the next request is truly immediate. *)
   let first = run_curl ~headers ~max_time:0.2 ~port ~path:"/ag-ui/events?workspace=default" () in
   check_status "first /ag-ui/events connect accepted" 200 first;
+  (* Asserting the status alone let the bridge ship unconverted frames unnoticed.
+     This checks the synthetic prime only — it does NOT cover the drain or replay
+     conversion, which [test_ag_ui_frames_are_wire_encoded] below exercises. *)
+  if not (body_contains "RUN_STARTED" first.body) then
+    fail
+      (Printf.sprintf "/ag-ui/events body is not AG-UI framed (no RUN_STARTED): %S"
+         first.body);
 
   let second = run_curl ~headers ~max_time:0.5 ~port ~path:"/ag-ui/events?workspace=default" () in
   check_status "immediate /ag-ui/events reconnect rejected" 429 second;
@@ -505,5 +550,9 @@ let () =
   run "sse_storm_e2e"
     [
       ("mcp", [test_case "follow-up reconnect accepted" `Slow test_mcp_reconnect_stays_accepted]);
-      ("ag_ui", [test_case "reconnect cooldown + recovery" `Slow test_ag_ui_rejects_reconnect_then_recovers]);
+      ("ag_ui",
+       [
+         test_case "reconnect cooldown + recovery" `Slow test_ag_ui_rejects_reconnect_then_recovers;
+         test_case "frames are AG-UI wire encoded" `Slow test_ag_ui_frames_are_wire_encoded;
+       ]);
     ]

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -479,6 +479,7 @@ let publish_masc_broadcast ~port ~auth_token ~session_id =
       ~headers:
         [ ("Content-Type", "application/json")
         ; ("Accept", "application/json, text/event-stream")
+        ; ("X-MASC-Force-JSON", "true")
         ; ("Authorization", "Bearer " ^ auth_token)
         ; ("Mcp-Session-Id", session_id)
         ]

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -682,6 +682,44 @@ let test_ag_ui_rejects_reconnect_then_recovers () =
   let third = run_curl ~headers ~max_time:1.5 ~port ~path:"/ag-ui/events?workspace=default" () in
   check_status "cooldown /ag-ui/events reconnect recovers" 200 third
 
+let check_invalid_request_response label result =
+  check_status label 400 result;
+  match Yojson.Safe.from_string result.body with
+  | `Assoc fields ->
+      (match List.assoc_opt "error" fields with
+       | Some (`Assoc error_fields) ->
+           (match List.assoc_opt "code" error_fields with
+            | Some (`Int (-32600)) -> ()
+            | _ ->
+                fail
+                  (Printf.sprintf
+                     "%s returned wrong error code: %s" label result.body))
+       | _ ->
+           fail
+             (Printf.sprintf "%s returned no JSON-RPC error: %s" label result.body))
+  | exception Yojson.Json_error message ->
+      fail
+        (Printf.sprintf "%s returned invalid JSON: %s body=%s" label message
+           result.body)
+  | _ ->
+      fail
+        (Printf.sprintf "%s returned a non-object body: %s" label result.body)
+
+let test_sse_endpoints_reject_malformed_last_event_id () =
+  with_server @@ fun ~port ~auth_token ->
+  let sid = initialize_mcp_session ~port ~auth_token in
+  let headers =
+    [ ("Accept", "text/event-stream")
+    ; ("Authorization", "Bearer " ^ auth_token)
+    ; ("Mcp-Session-Id", sid)
+    ; ("Last-Event-ID", "not-an-integer")
+    ]
+  in
+  check_invalid_request_response "malformed /mcp cursor rejected"
+    (run_curl ~headers ~max_time:2.0 ~port ~path:"/mcp" ());
+  check_invalid_request_response "malformed /ag-ui/events cursor rejected"
+    (run_curl ~headers ~max_time:2.0 ~port ~path:"/ag-ui/events" ())
+
 let () =
   Random.self_init ();
   run "sse_storm_e2e"
@@ -690,6 +728,8 @@ let () =
       ("ag_ui",
        [
          test_case "reconnect cooldown + recovery" `Slow test_ag_ui_rejects_reconnect_then_recovers;
+         test_case "malformed Last-Event-ID is rejected" `Slow
+           test_sse_endpoints_reject_malformed_last_event_id;
          test_case "frames are AG-UI wire encoded" `Slow test_ag_ui_frames_are_wire_encoded;
        ]);
     ]

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -377,9 +377,7 @@ let with_server f =
     | None -> Alcotest.skip ()
   in
   let log_file = Filename.temp_file "sse-storm-e2e-" ".log" in
-  let base_path = Filename.temp_file "sse-storm-base-" "" in
-  (try Sys.remove base_path with _ -> ());
-  Unix.mkdir base_path 0o755;
+  let base_path = Filename.temp_dir "sse-storm-base-" "" in
   seed_server_config ~base_path;
   let log_fd =
     Unix.openfile log_file [Unix.O_CREAT; Unix.O_WRONLY; Unix.O_TRUNC] 0o644

--- a/test/test_sse_stream.ml
+++ b/test/test_sse_stream.ml
@@ -234,7 +234,7 @@ let test_broadcast_presence_is_live_only ~auth () =
                 (String.split_on_char '\n' event))
        | None -> Alcotest.fail "expected presence event");
       Alcotest.(check int) "presence not replay buffered" 0
-        (List.length (Sse.get_events_after before_id)))
+        (List.length (Sse.get_events_after_for_test before_id)))
 
 let test_non_jsonrpc_broadcast_does_not_reach_agent_streams ~auth () =
   reset ();
@@ -248,11 +248,15 @@ let test_non_jsonrpc_broadcast_does_not_reach_agent_streams ~auth () =
   Alcotest.(check bool) "agent_stream skipped non-JSON-RPC" true
     (got_workspace = None);
   Alcotest.(check int) "observer replay keeps dashboard event" 1
-    (List.length (Sse.get_events_after_for_kind Observer before_id));
+    (List.length
+       (Sse.get_events_after_for_session ~session_id:"s-nonjson-obs"
+          ~kind:Observer before_id));
   Alcotest.(check int)
     "agent_stream replay skips non-JSON-RPC"
     0
-    (List.length (Sse.get_events_after_for_kind Agent_stream before_id));
+    (List.length
+       (Sse.get_events_after_for_session ~session_id:"s-nonjson-workspace"
+          ~kind:Agent_stream before_id));
   Sse.unregister "s-nonjson-obs";
   Sse.unregister "s-nonjson-workspace"
 

--- a/test/test_sse_stream.ml
+++ b/test/test_sse_stream.ml
@@ -14,6 +14,18 @@ let _dummy_push _s = ()
 let jsonrpc_notification method_name =
   `Assoc [ ("jsonrpc", `String "2.0"); ("method", `String method_name) ]
 
+let test_data_payload_of_frame () =
+  Alcotest.(check (result string reject))
+    "optional space and CRLF"
+    (Ok "first\nsecond")
+    (Sse.data_payload_of_frame "id: 7\r\ndata:first\r\ndata: second\r\n\r\n");
+  Alcotest.(check bool)
+    "bare JSON rejected"
+    true
+    (match Sse.data_payload_of_frame "{\"type\":\"event\"}" with
+     | Error Sse.Missing_data_payload -> true
+     | Ok _ -> false)
+
 let register_exn ~auth ?kind session_id ~last_event_id =
   (* Pre-create the MCP session so registration validates an existing
      session rather than auto-bootstrapping one (security/sse-auth-validation). *)
@@ -262,6 +274,11 @@ let () =
     (fun () ->
       Alcotest.run "sse-stream"
         [
+          ( "frame_parser",
+            [
+              Alcotest.test_case "data payload" `Quick
+                test_data_payload_of_frame;
+            ] );
           ( "try_pop",
             [
               Alcotest.test_case "nonexistent session" `Quick test_try_pop_empty;

--- a/test/test_sse_stream.ml
+++ b/test/test_sse_stream.ml
@@ -90,15 +90,34 @@ let test_broadcast_multiple_clients_streams ~auth () =
 
 let test_send_to_popable ~auth () =
   reset ();
-  ignore (register_exn ~auth "s-st-1" ~last_event_id:0);
-  ignore (register_exn ~auth "s-st-2" ~last_event_id:0);
-  Sse.send_to "s-st-1" (jsonrpc_notification "notifications/test");
-  let got1 = Sse.try_pop "s-st-1" in
-  let got2 = Sse.try_pop "s-st-2" in
-  Alcotest.(check bool) "target got event" true (got1 <> None);
-  Alcotest.(check bool) "other did not" true (got2 = None);
-  Sse.unregister "s-st-1";
-  Sse.unregister "s-st-2"
+  let original_buffer = Sse.event_buffer_events_for_test () in
+  Fun.protect
+    ~finally:(fun () ->
+      Sse.unregister "s-st-1";
+      Sse.unregister "s-st-2";
+      Sse.set_event_buffer_for_test original_buffer)
+    (fun () ->
+      Sse.set_event_buffer_for_test [];
+      ignore (register_exn ~auth "s-st-1" ~last_event_id:0);
+      ignore (register_exn ~auth "s-st-2" ~last_event_id:0);
+      let before_id = Sse.current_id () in
+      Sse.send_to "s-st-1" (jsonrpc_notification "notifications/test");
+      let got1 = Sse.try_pop "s-st-1" in
+      let got2 = Sse.try_pop "s-st-2" in
+      Alcotest.(check bool) "target got event" true (got1 <> None);
+      Alcotest.(check bool) "other did not" true (got2 = None);
+      Alcotest.(check int) "target replays targeted event" 1
+        (List.length
+           (Sse.get_events_after_for_session ~session_id:"s-st-1"
+              ~kind:Agent_stream before_id));
+      Alcotest.(check int) "other session cannot replay targeted event" 0
+        (List.length
+           (Sse.get_events_after_for_session ~session_id:"s-st-2"
+              ~kind:Agent_stream before_id));
+      Alcotest.(check int) "observer cannot replay targeted event" 0
+        (List.length
+           (Sse.get_events_after_for_session ~session_id:"s-st-1"
+              ~kind:Observer before_id)))
 
 let test_pop_blocks_then_receives ~auth () =
   reset ();

--- a/test/test_sse_stream.ml
+++ b/test/test_sse_stream.ml
@@ -26,20 +26,6 @@ let test_data_payload_of_frame () =
      | Error Sse.Missing_data_payload -> true
      | Ok _ -> false)
 
-let test_parse_frame_preserves_cursor () =
-  Alcotest.(check bool)
-    "cursor and joined payload"
-    true
-    (match Sse.parse_frame "id: 7\r\ndata:first\r\ndata: second\r\n\r\n" with
-     | Ok { event_id = Some 7; data_payload = "first\nsecond" } -> true
-     | Ok _ | Error _ -> false);
-  Alcotest.(check bool)
-    "invalid cursor rejected"
-    true
-    (match Sse.parse_frame "id: nope\ndata: {}\n\n" with
-     | Error Sse.Frame_invalid_event_id -> true
-     | Ok _ | Error Sse.Frame_missing_data_payload -> false)
-
 let register_exn ~auth ?kind session_id ~last_event_id =
   (* Pre-create the MCP session so registration validates an existing
      session rather than auto-bootstrapping one (security/sse-auth-validation). *)
@@ -241,8 +227,8 @@ let test_broadcast_presence_is_live_only ~auth () =
                 (String.equal "event: presence")
                 (String.split_on_char '\n' event))
        | None -> Alcotest.fail "expected presence event");
-      Alcotest.(check (list string)) "presence not replay buffered" []
-        (Sse.get_events_after before_id))
+      Alcotest.(check int) "presence not replay buffered" 0
+        (List.length (Sse.get_events_after before_id)))
 
 let test_non_jsonrpc_broadcast_does_not_reach_agent_streams ~auth () =
   reset ();
@@ -257,10 +243,10 @@ let test_non_jsonrpc_broadcast_does_not_reach_agent_streams ~auth () =
     (got_workspace = None);
   Alcotest.(check int) "observer replay keeps dashboard event" 1
     (List.length (Sse.get_events_after_for_kind Observer before_id));
-  Alcotest.(check (list string))
+  Alcotest.(check int)
     "agent_stream replay skips non-JSON-RPC"
-    []
-    (Sse.get_events_after_for_kind Agent_stream before_id);
+    0
+    (List.length (Sse.get_events_after_for_kind Agent_stream before_id));
   Sse.unregister "s-nonjson-obs";
   Sse.unregister "s-nonjson-workspace"
 
@@ -292,8 +278,6 @@ let () =
             [
               Alcotest.test_case "data payload" `Quick
                 test_data_payload_of_frame;
-              Alcotest.test_case "preserves cursor" `Quick
-                test_parse_frame_preserves_cursor;
             ] );
           ( "try_pop",
             [

--- a/test/test_sse_stream.ml
+++ b/test/test_sse_stream.ml
@@ -26,6 +26,20 @@ let test_data_payload_of_frame () =
      | Error Sse.Missing_data_payload -> true
      | Ok _ -> false)
 
+let test_parse_frame_preserves_cursor () =
+  Alcotest.(check bool)
+    "cursor and joined payload"
+    true
+    (match Sse.parse_frame "id: 7\r\ndata:first\r\ndata: second\r\n\r\n" with
+     | Ok { event_id = Some 7; data_payload = "first\nsecond" } -> true
+     | Ok _ | Error _ -> false);
+  Alcotest.(check bool)
+    "invalid cursor rejected"
+    true
+    (match Sse.parse_frame "id: nope\ndata: {}\n\n" with
+     | Error Sse.Frame_invalid_event_id -> true
+     | Ok _ | Error Sse.Frame_missing_data_payload -> false)
+
 let register_exn ~auth ?kind session_id ~last_event_id =
   (* Pre-create the MCP session so registration validates an existing
      session rather than auto-bootstrapping one (security/sse-auth-validation). *)
@@ -278,6 +292,8 @@ let () =
             [
               Alcotest.test_case "data payload" `Quick
                 test_data_payload_of_frame;
+              Alcotest.test_case "preserves cursor" `Quick
+                test_parse_frame_preserves_cursor;
             ] );
           ( "try_pop",
             [

--- a/test/test_sse_stream.ml
+++ b/test/test_sse_stream.ml
@@ -26,6 +26,12 @@ let test_data_payload_of_frame () =
      | Error Sse.Missing_data_payload -> true
      | Ok _ -> false)
 
+let test_format_event_preserves_multiline_data () =
+  match Sse.data_payload_of_frame (Sse.format_event ~id:7 "first\nsecond") with
+  | Ok payload -> Alcotest.(check string) "multiline data payload" "first\nsecond" payload
+  | Error Sse.Missing_data_payload ->
+      Alcotest.fail "format_event emitted a frame without a data field"
+
 let register_exn ~auth ?kind session_id ~last_event_id =
   (* Pre-create the MCP session so registration validates an existing
      session rather than auto-bootstrapping one (security/sse-auth-validation). *)
@@ -278,6 +284,8 @@ let () =
             [
               Alcotest.test_case "data payload" `Quick
                 test_data_payload_of_frame;
+              Alcotest.test_case "multiline data framing" `Quick
+                test_format_event_preserves_multiline_data;
             ] );
           ( "try_pop",
             [

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -39,6 +39,8 @@ let contains_substring haystack needle =
   in
   needle_len = 0 || loop 0
 
+let sse_frame json = Printf.sprintf "data: %s\n\n" json
+
 let count_substring haystack needle =
   let haystack_len = String.length haystack in
   let needle_len = String.length needle in
@@ -275,6 +277,7 @@ let test_parse_sse_dashboard_event_known_type () =
         ("type", `String "execution_snapshot");
         ("payload", `Assoc [("keepers", `Int 3)]);
       ])
+    |> sse_frame
   in
   match Ws.parse_sse_dashboard_event event_str with
   | Some parsed ->
@@ -292,6 +295,7 @@ let test_parse_sse_dashboard_event_composite_change_maps_to_composite () =
         ("name", `String "qa-king");
         ("ts_unix", `Float 1_774_000_000.0);
       ])
+    |> sse_frame
   in
   match Ws.parse_sse_dashboard_event event_str with
   | Some parsed ->
@@ -305,6 +309,7 @@ let test_parse_sse_dashboard_event_unknown_type () =
   let event_str =
     Yojson.Safe.to_string
       (`Assoc [("type", `String "not.a.real.event"); ("payload", `Null)])
+    |> sse_frame
   in
   match Ws.parse_sse_dashboard_event event_str with
   | Some parsed ->
@@ -313,7 +318,7 @@ let test_parse_sse_dashboard_event_unknown_type () =
   | None -> Alcotest.fail "expected Some with slice=None, not outright None"
 
 let test_parse_sse_dashboard_event_malformed () =
-  let result = Ws.parse_sse_dashboard_event "not-valid-json{" in
+  let result = Ws.parse_sse_dashboard_event "data: not-valid-json{\n\n" in
   Alcotest.(check bool) "malformed yields None"
     true (Option.is_none result)
 
@@ -321,6 +326,7 @@ let test_parse_sse_dashboard_event_stable_on_repeat () =
   let event_str =
     Yojson.Safe.to_string
       (`Assoc [("type", `String "execution_snapshot"); ("payload", `Int 1)])
+    |> sse_frame
   in
   let extract = function
     | Some (p : Ws.parsed_sse_event) -> Some (p.event_type, p.slice)
@@ -335,10 +341,12 @@ let test_parse_sse_dashboard_event_invalidated_on_new_ref () =
   let e1 =
     Yojson.Safe.to_string
       (`Assoc [("type", `String "execution_snapshot")])
+    |> sse_frame
   in
   let e2 =
     Yojson.Safe.to_string
       (`Assoc [("type", `String "transport_health_snapshot")])
+    |> sse_frame
   in
   let et = function
     | Some (p : Ws.parsed_sse_event) -> Some p.event_type
@@ -408,6 +416,7 @@ let test_parse_cache_counters () =
   let e =
     Yojson.Safe.to_string
       (`Assoc [("type", `String "execution_snapshot")])
+    |> sse_frame
   in
   let (_ : _ option) = Ws.parse_sse_dashboard_event e in (* miss *)
   let (_ : _ option) = Ws.parse_sse_dashboard_event e in (* hit *)
@@ -423,6 +432,7 @@ let test_parse_cache_counters () =
   let e2 =
     Yojson.Safe.to_string
       (`Assoc [("type", `String "execution_snapshot")])
+    |> sse_frame
   in
   let (_ : _ option) = Ws.parse_sse_dashboard_event e2 in (* miss *)
   let misses2 = read_counter misses_name in


### PR DESCRIPTION
Refs #26694
Closes #26582
Closes #26706

## 변경

- `/ag-ui/events`의 live drain과 replay가 raw MASC frame 대신 typed payload를 AG-UI event로 변환해 송신해용.
- replay cursor와 producer timestamp를 같은 `Sse.delivery`에서 보존해 wire 재파싱과 silent fallback을 제거했어용.
- SSE wire framing은 leaf `Sse_wire`가 한 번만 소유하고 `Ag_ui`와 기존 `Sse`가 직접 소비해용.
- 소비자가 없던 manifest retired-field rejector와 compaction ID 합성기를 삭제했어용.
- 6벌로 복제된 E2E `main_eio` 탐색기를 `Masc_test_runtime` 하나로 통합했어용. Dune이 `%{dep:../bin/main_eio.exe}`로 주입한 exact dependency만 허용하고 부모 checkout 탐색과 invalid override fallback은 제거했어용.

## 검증

- 실제 전달 event가 AG-UI `MASC_EVENT` envelope와 numeric SSE cursor를 갖고 replay에서 동일 payload를 유지하는 behavior test를 포함해용.
- 부모 checkout에 가짜 binary가 있어도 선택하지 않고, invalid override도 fallback하지 않는 resolver 회귀 테스트를 추가했어용.
- exact head `76fc254540b765c4d79e5c66215613bcc598c727`의 OCaml format/parser/diff-check를 통과했고, CI run `30853609268`이 성공했어용.
- 로컬 Dune은 실행하지 않았고 Build and Test와 SSE reconnect E2E는 CI를 권위로 둬용.

## 판정

- P0 0 · P1 0 · P2 0이에용.\n- P3 비차단 후속은 temp-dir 전수 정리 #26648, 죽은 fixture·중복 Dune deps #26751, conditional alias 실행 증거 #26150에서 추적해용.
- unresolved review thread 0개예용.
- exact-head CI green, unresolved 0, MERGEABLE이라 코드 기준 병합 가능해용.

