### PR TITLE
fix(oauth): close final review gaps

### DIFF
--- a/lib/auth/auth_oauth.ml
+++ b/lib/auth/auth_oauth.ml
@@ -963,6 +963,7 @@ let rotate_refresh_token
         let* scopes =
           match scope with
           | None -> Ok family.scopes
+          | Some raw when String.equal (String.trim raw) "" -> Error Invalid_scope
           | Some raw ->
             let* requested = parse_scopes (Some raw) in
             let granted requested_scope =

--- a/lib/auth/auth_oauth.ml
+++ b/lib/auth/auth_oauth.ml
@@ -345,11 +345,16 @@ let role_of_string = function
 let scopes_of_strings values =
   let rec parse acc = function
     | [] -> Ok acc
-    | "mcp:tools" :: rest -> parse (add_scope_with_implications acc Mcp_tools) rest
-    | "mcp:admin" :: rest -> parse (add_scope_with_implications acc Mcp_admin) rest
+    | "mcp:tools" :: rest -> parse (add_scope_once acc Mcp_tools) rest
+    | "mcp:admin" :: rest -> parse (add_scope_once acc Mcp_admin) rest
     | _ :: _ -> Error (Store_error "invalid OAuth scope")
   in
-  parse [] values
+  let* scopes = parse [] values in
+  if
+    List.exists (equal_scope Mcp_admin) scopes
+    && not (List.exists (equal_scope Mcp_tools) scopes)
+  then Error (Store_error "invalid OAuth scope closure: mcp:admin requires mcp:tools")
+  else Ok scopes
 ;;
 
 let client_to_yojson (client : client) =

--- a/lib/auth/auth_oauth.ml
+++ b/lib/auth/auth_oauth.ml
@@ -87,6 +87,13 @@ let add_scope_once acc scope =
   if List.exists (equal_scope scope) acc then acc else acc @ [ scope ]
 ;;
 
+let add_scope_with_implications acc = function
+  | Mcp_tools -> add_scope_once acc Mcp_tools
+  | Mcp_admin ->
+    let acc = add_scope_once acc Mcp_tools in
+    add_scope_once acc Mcp_admin
+;;
+
 let parse_scopes raw =
   let values =
     match raw with
@@ -101,8 +108,8 @@ let parse_scopes raw =
   let values = if values = [] then [ scope_to_string Mcp_tools ] else values in
   let rec parse acc = function
     | [] -> Ok acc
-    | "mcp:tools" :: rest -> parse (add_scope_once acc Mcp_tools) rest
-    | "mcp:admin" :: rest -> parse (add_scope_once acc Mcp_admin) rest
+    | "mcp:tools" :: rest -> parse (add_scope_with_implications acc Mcp_tools) rest
+    | "mcp:admin" :: rest -> parse (add_scope_with_implications acc Mcp_admin) rest
     | _ :: _ -> Error Invalid_scope
   in
   parse [] values
@@ -337,9 +344,9 @@ let role_of_string = function
 
 let scopes_of_strings values =
   let rec parse acc = function
-    | [] -> Ok (List.rev acc)
-    | "mcp:tools" :: rest -> parse (Mcp_tools :: acc) rest
-    | "mcp:admin" :: rest -> parse (Mcp_admin :: acc) rest
+    | [] -> Ok acc
+    | "mcp:tools" :: rest -> parse (add_scope_with_implications acc Mcp_tools) rest
+    | "mcp:admin" :: rest -> parse (add_scope_with_implications acc Mcp_admin) rest
     | _ :: _ -> Error (Store_error "invalid OAuth scope")
   in
   parse [] values

--- a/lib/auth/auth_oauth.ml
+++ b/lib/auth/auth_oauth.ml
@@ -97,7 +97,7 @@ let add_scope_with_implications acc = function
 let parse_scopes raw =
   let values =
     match raw with
-    | None -> []
+    | None -> [ scope_to_string Mcp_tools ]
     | Some value ->
       value
       |> String.split_on_char ' '
@@ -105,14 +105,15 @@ let parse_scopes raw =
         let item = String.trim item in
         if String.equal item "" then None else Some item)
   in
-  let values = if values = [] then [ scope_to_string Mcp_tools ] else values in
   let rec parse acc = function
     | [] -> Ok acc
     | "mcp:tools" :: rest -> parse (add_scope_with_implications acc Mcp_tools) rest
     | "mcp:admin" :: rest -> parse (add_scope_with_implications acc Mcp_admin) rest
     | _ :: _ -> Error Invalid_scope
   in
-  parse [] values
+  match values with
+  | [] -> Error Invalid_scope
+  | _ -> parse [] values
 ;;
 
 let effective_role ~bootstrap_role scopes =

--- a/lib/auth/auth_oauth.mli
+++ b/lib/auth/auth_oauth.mli
@@ -45,7 +45,8 @@ val parse_scopes : string option -> (scope list, error) result
 (** Parse a space-delimited scope request.  Missing/blank means
     [[Mcp_tools]]. Duplicate scopes are collapsed in declaration order, and
     [Mcp_admin] is canonicalized to include [Mcp_tools] because the Admin RBAC
-    role includes tool permission. *)
+    role includes tool permission. Durable family decoding requires that exact
+    canonical closure and rejects non-canonical stored scope sets. *)
 
 val effective_role :
   bootstrap_role:Masc_domain.agent_role ->

--- a/lib/auth/auth_oauth.mli
+++ b/lib/auth/auth_oauth.mli
@@ -43,7 +43,9 @@ val valid_pkce_value : string -> bool
 
 val parse_scopes : string option -> (scope list, error) result
 (** Parse a space-delimited scope request.  Missing/blank means
-    [[Mcp_tools]]. Duplicate scopes are collapsed in declaration order. *)
+    [[Mcp_tools]]. Duplicate scopes are collapsed in declaration order, and
+    [Mcp_admin] is canonicalized to include [Mcp_tools] because the Admin RBAC
+    role includes tool permission. *)
 
 val effective_role :
   bootstrap_role:Masc_domain.agent_role ->

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -938,7 +938,9 @@ let with_admin_auth handler request reqd =
           Http_server_eio.Response.json ~status:`Forbidden
             {|{"error":"MASC_ADMIN_TOKEN not configured"}|} reqd
       | Some _, None ->
-          Http_server_eio.Response.json ~status:`Unauthorized
+          Http_server_eio.Response.json
+            ~status:`Unauthorized
+            ~extra_headers:(auth_error_headers ~status:`Unauthorized ~cors:[])
             {|{"error":"Admin token required"}|} reqd
       | Some expected, Some given ->
           if admin_token_equal expected given then
@@ -1152,6 +1154,7 @@ and with_observer_sse_read_auth handler request reqd =
        | Error msg ->
          Http_server_eio.Response.json
            ~status:`Unauthorized
+           ~extra_headers:(auth_error_headers ~status:`Unauthorized ~cors:[])
            (Yojson.Safe.to_string (`Assoc [ "error", `String msg ]))
            reqd)
   else

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -865,10 +865,10 @@ let auth_error_json err =
   in
   Yojson.Safe.to_string (`Assoc fields)
 
-let generic_bearer_challenge_headers (status : Httpun.Status.t) =
+let auth_error_headers ~(status : Httpun.Status.t) ~cors =
   match status with
-  | `Unauthorized -> [ "www-authenticate", "Bearer" ]
-  | _ -> []
+  | `Unauthorized -> ("www-authenticate", "Bearer") :: cors
+  | _ -> cors
 
 let respond_auth_error request reqd err =
   let status = http_status_of_auth_error err in
@@ -877,8 +877,7 @@ let respond_auth_error request reqd err =
   let headers =
     Httpun.Headers.of_list
       (("content-length", string_of_int (String.length body))
-       :: generic_bearer_challenge_headers status
-       @ cors_headers origin)
+       :: auth_error_headers ~status ~cors:(cors_headers origin))
   in
   let response = Httpun.Response.create ~headers (status :> Httpun.Status.t) in
   Httpun.Reqd.respond_with_string reqd response body

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -865,6 +865,11 @@ let auth_error_json err =
   in
   Yojson.Safe.to_string (`Assoc fields)
 
+let generic_bearer_challenge_headers (status : Httpun.Status.t) =
+  match status with
+  | `Unauthorized -> [ "www-authenticate", "Bearer" ]
+  | _ -> []
+
 let respond_auth_error request reqd err =
   let status = http_status_of_auth_error err in
   let origin = get_origin request in
@@ -872,7 +877,8 @@ let respond_auth_error request reqd err =
   let headers =
     Httpun.Headers.of_list
       (("content-length", string_of_int (String.length body))
-       :: cors_headers origin)
+       :: generic_bearer_challenge_headers status
+       @ cors_headers origin)
   in
   let response = Httpun.Response.create ~headers (status :> Httpun.Status.t) in
   Httpun.Reqd.respond_with_string reqd response body

--- a/lib/server/server_auth.mli
+++ b/lib/server/server_auth.mli
@@ -297,9 +297,11 @@ val respond_public_read_json_value :
 val auth_error_json : Masc_domain.masc_error -> string
 (** Render an auth error as the standard JSON envelope. *)
 
-val generic_bearer_challenge_headers : Httpun.Status.t -> (string * string) list
-(** Plain Bearer challenge for generic 401 responses; MCP resource metadata is
-    added only by MCP transport responders. *)
+val auth_error_headers :
+  status:Httpun.Status.t -> cors:(string * string) list -> (string * string) list
+(** Shared HTTP/1 and HTTP/2 headers for generic auth errors. Unauthorized
+    responses receive a plain Bearer challenge; MCP resource metadata is added
+    only by MCP transport responders. *)
 
 val respond_auth_error :
   Httpun.Request.t -> Httpun.Reqd.t -> Masc_domain.masc_error -> unit

--- a/lib/server/server_auth.mli
+++ b/lib/server/server_auth.mli
@@ -297,9 +297,14 @@ val respond_public_read_json_value :
 val auth_error_json : Masc_domain.masc_error -> string
 (** Render an auth error as the standard JSON envelope. *)
 
+val generic_bearer_challenge_headers : Httpun.Status.t -> (string * string) list
+(** Plain Bearer challenge for generic 401 responses; MCP resource metadata is
+    added only by MCP transport responders. *)
+
 val respond_auth_error :
   Httpun.Request.t -> Httpun.Reqd.t -> Masc_domain.masc_error -> unit
-(** Compose [http_status_of_auth_error] + [auth_error_json] + CORS. *)
+(** Compose [http_status_of_auth_error] + [auth_error_json] + generic Bearer
+    challenge + CORS. *)
 
 val respond_agent_rate_limited :
   rl_key:string -> Httpun.Request.t -> Httpun.Reqd.t -> unit

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -427,7 +427,7 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
                     h2_reqd
                     (auth_error_json err)
                     ~status:(status :> H2.Status.t)
-                    ~extra_headers:cors
+                    ~extra_headers:(auth_error_headers ~status ~cors)
               | Ok () ->
                   h2_read_body h2_reqd (fun body_str ->
                     match Server_webrtc_transport.handle_offer_request body_str with
@@ -457,7 +457,7 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
                     h2_reqd
                     (auth_error_json err)
                     ~status:(status :> H2.Status.t)
-                    ~extra_headers:cors
+                    ~extra_headers:(auth_error_headers ~status ~cors)
               | Ok () ->
                   h2_read_body h2_reqd (fun body_str ->
                     match Server_webrtc_transport.handle_answer_request body_str with

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -98,7 +98,7 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
         h2_reqd
         (auth_error_json err)
         ~status:(status :> H2.Status.t)
-        ~extra_headers:cors
+        ~extra_headers:(auth_error_headers ~status ~cors)
     in
     let h2_respond_oauth_error error =
       Log.Misc.warn

--- a/lib/server/server_h2_gateway_routes_extra.ml
+++ b/lib/server/server_h2_gateway_routes_extra.ml
@@ -10,11 +10,12 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
     (httpun_meth : [ `GET | `POST | `DELETE | `OPTIONS | `PUT | `HEAD
                     | `CONNECT | `TRACE | `Other of string ]) =
   let h2_respond_auth_error error =
+    let status = Server_auth.http_status_of_auth_error error in
     h2_respond_json
       h2_reqd
       (Server_auth.auth_error_json error)
-      ~status:(Server_auth.http_status_of_auth_error error :> H2.Status.t)
-      ~extra_headers:cors
+      ~status:(status :> H2.Status.t)
+      ~extra_headers:(Server_auth.auth_error_headers ~status ~cors)
   in
   let with_optional_board_reaction_actor f =
     match config with

--- a/test/test_auth_oauth.ml
+++ b/test/test_auth_oauth.ml
@@ -734,6 +734,21 @@ let test_refresh_scope_can_reduce_but_not_expand () =
             in
             check string "admin family can downscope to tools"
               "mcp:tools" worker_from_admin.scope;
+            check
+              bool
+              "an explicitly empty refresh scope is invalid"
+              true
+              (match
+                 Auth_oauth.rotate_refresh_token
+                   ~base_path
+                   ~expected_resource:resource
+                   ~refresh_token:admin_pair.refresh_token
+                   ~client_id:admin_client.client_id
+                   ~scope:(Some "   ")
+                   ~resource:(Some resource)
+               with
+               | Error Auth_oauth.Invalid_scope -> true
+               | Ok _ | Error _ -> false);
             let client, admin_pair =
               issue_pair
                 ~base_path

--- a/test/test_auth_oauth.ml
+++ b/test/test_auth_oauth.ml
@@ -777,6 +777,71 @@ let test_refresh_scope_can_reduce_but_not_expand () =
                | Ok _ | Error _ -> false)))))
 ;;
 
+let test_stored_admin_scope_requires_canonical_tools_closure () =
+  with_env "MASC_OAUTH_ENABLED" "1" (fun () ->
+    with_workspace (fun base_path ->
+      Eio_main.run (fun env ->
+        Fs_compat.set_fs (Eio.Stdenv.fs env);
+        Eio_guard.enable ();
+        Fun.protect
+          ~finally:(fun () ->
+            Eio_guard.disable ();
+            Fs_compat.clear_fs ())
+          (fun () ->
+            let _, bootstrap_credential =
+              Auth.create_token
+                base_path
+                ~agent_name:"noncanonical-scope-codex"
+                ~role:Masc_domain.Admin
+              |> auth_ok
+            in
+            let resource = "http://127.0.0.1:8935/mcp" in
+            let client, pair =
+              issue_pair
+                ~base_path
+                ~bootstrap_credential
+                ~redirect_uri:"http://127.0.0.1:43132/callback/noncanonical"
+                ~resource
+                ~scope:"mcp:admin"
+            in
+            let families_dir =
+              Filename.concat base_path ".masc/auth/oauth/families"
+            in
+            let family_path =
+              Filename.concat families_dir (Sys.readdir families_dir).(0)
+            in
+            let family_json =
+              family_path |> Fs_compat.load_file |> Yojson.Safe.from_string
+            in
+            let noncanonical =
+              match family_json with
+              | `Assoc fields ->
+                `Assoc
+                  (("scopes", `List [ `String "mcp:admin" ])
+                   :: List.remove_assoc "scopes" fields)
+              | _ -> fail "family store record must be an object"
+            in
+            (match
+               Fs_compat.save_file_atomic
+                 family_path
+                 (Yojson.Safe.pretty_to_string noncanonical)
+             with
+             | Ok () -> ()
+             | Error message -> fail message);
+            check
+              bool
+              "non-canonical durable admin scope fails closed"
+              true
+              (Result.is_error
+                 (Auth_oauth.rotate_refresh_token
+                    ~base_path
+                    ~expected_resource:resource
+                    ~refresh_token:pair.refresh_token
+                    ~client_id:client.client_id
+                    ~scope:None
+                    ~resource:(Some resource)))))))
+;;
+
 let test_rotation_keeps_one_current_access_record () =
   with_env "MASC_OAUTH_ENABLED" "1" (fun () ->
     with_workspace (fun base_path ->
@@ -914,6 +979,10 @@ let () =
             "refresh scope can reduce but not expand"
             `Quick
             test_refresh_scope_can_reduce_but_not_expand
+        ; test_case
+            "stored admin scope requires canonical tools closure"
+            `Quick
+            test_stored_admin_scope_requires_canonical_tools_closure
         ; test_case
             "rotation keeps one current access record"
             `Quick

--- a/test/test_auth_oauth.ml
+++ b/test/test_auth_oauth.ml
@@ -712,7 +712,7 @@ let test_refresh_scope_can_reduce_but_not_expand () =
               |> auth_ok
             in
             let resource = "http://127.0.0.1:8935/mcp" in
-            let admin_only_client, admin_only_pair =
+            let admin_client, admin_pair =
               issue_pair
                 ~base_path
                 ~bootstrap_credential
@@ -720,21 +720,20 @@ let test_refresh_scope_can_reduce_but_not_expand () =
                 ~resource
                 ~scope:"mcp:admin"
             in
-            check
-              bool
-              "refresh cannot substitute a scope that was never granted"
-              true
-              (match
-                 Auth_oauth.rotate_refresh_token
-                   ~base_path
-                   ~expected_resource:resource
-                   ~refresh_token:admin_only_pair.refresh_token
-                   ~client_id:admin_only_client.client_id
-                   ~scope:(Some "mcp:tools")
-                   ~resource:(Some resource)
-               with
-               | Error Auth_oauth.Invalid_scope -> true
-               | Ok _ | Error _ -> false);
+            check string "admin response includes its tools implication"
+              "mcp:tools mcp:admin" admin_pair.scope;
+            let worker_from_admin =
+              Auth_oauth.rotate_refresh_token
+                ~base_path
+                ~expected_resource:resource
+                ~refresh_token:admin_pair.refresh_token
+                ~client_id:admin_client.client_id
+                ~scope:(Some "mcp:tools")
+                ~resource:(Some resource)
+              |> oauth_ok
+            in
+            check string "admin family can downscope to tools"
+              "mcp:tools" worker_from_admin.scope;
             let client, admin_pair =
               issue_pair
                 ~base_path

--- a/test/test_auth_oauth.ml
+++ b/test/test_auth_oauth.ml
@@ -382,6 +382,20 @@ let test_consumed_code_is_not_restored_after_store_failure () =
 let test_scope_cannot_escalate_role () =
   check
     bool
+    "omitted authorization scope defaults to tools"
+    true
+    (match Auth_oauth.parse_scopes None with
+     | Ok [ Auth_oauth.Mcp_tools ] -> true
+     | Ok _ | Error _ -> false);
+  check
+    bool
+    "explicitly empty authorization scope is invalid"
+    true
+    (match Auth_oauth.parse_scopes (Some "   ") with
+     | Error Auth_oauth.Invalid_scope -> true
+     | Ok _ | Error _ -> false);
+  check
+    bool
     "worker cannot obtain admin scope"
     true
     (Result.is_error

--- a/test/test_auth_oauth.ml
+++ b/test/test_auth_oauth.ml
@@ -736,18 +736,6 @@ let test_refresh_scope_can_reduce_but_not_expand () =
             in
             check string "admin response includes its tools implication"
               "mcp:tools mcp:admin" admin_pair.scope;
-            let worker_from_admin =
-              Auth_oauth.rotate_refresh_token
-                ~base_path
-                ~expected_resource:resource
-                ~refresh_token:admin_pair.refresh_token
-                ~client_id:admin_client.client_id
-                ~scope:(Some "mcp:tools")
-                ~resource:(Some resource)
-              |> oauth_ok
-            in
-            check string "admin family can downscope to tools"
-              "mcp:tools" worker_from_admin.scope;
             check
               bool
               "an explicitly empty refresh scope is invalid"
@@ -763,6 +751,18 @@ let test_refresh_scope_can_reduce_but_not_expand () =
                with
                | Error Auth_oauth.Invalid_scope -> true
                | Ok _ | Error _ -> false);
+            let worker_from_admin =
+              Auth_oauth.rotate_refresh_token
+                ~base_path
+                ~expected_resource:resource
+                ~refresh_token:admin_pair.refresh_token
+                ~client_id:admin_client.client_id
+                ~scope:(Some "mcp:tools")
+                ~resource:(Some resource)
+              |> oauth_ok
+            in
+            check string "admin family can downscope to tools"
+              "mcp:tools" worker_from_admin.scope;
             let client, admin_pair =
               issue_pair
                 ~base_path

--- a/test/test_server_oauth_protocol.ml
+++ b/test/test_server_oauth_protocol.ml
@@ -83,16 +83,17 @@ let test_codex_discovery_contract () =
 ;;
 
 let test_generic_bearer_challenge () =
+  let cors = [ "vary", "Origin" ] in
   check
     (list (pair string string))
-    "generic 401 advertises plain Bearer"
-    [ "www-authenticate", "Bearer" ]
-    (Server_auth.generic_bearer_challenge_headers `Unauthorized);
+    "generic 401 advertises plain Bearer and preserves CORS"
+    [ "www-authenticate", "Bearer"; "vary", "Origin" ]
+    (Server_auth.auth_error_headers ~status:`Unauthorized ~cors);
   check
     (list (pair string string))
-    "generic 403 has no authentication challenge"
-    []
-    (Server_auth.generic_bearer_challenge_headers `Forbidden)
+    "generic 403 preserves CORS without a challenge"
+    cors
+    (Server_auth.auth_error_headers ~status:`Forbidden ~cors)
 ;;
 
 let test_public_listener_cannot_admit_loopback_oauth_by_host () =

--- a/test/test_server_oauth_protocol.ml
+++ b/test/test_server_oauth_protocol.ml
@@ -82,6 +82,19 @@ let test_codex_discovery_contract () =
        |> List.mem_assoc "resource_documentation"))
 ;;
 
+let test_generic_bearer_challenge () =
+  check
+    (list (pair string string))
+    "generic 401 advertises plain Bearer"
+    [ "www-authenticate", "Bearer" ]
+    (Server_auth.generic_bearer_challenge_headers `Unauthorized);
+  check
+    (list (pair string string))
+    "generic 403 has no authentication challenge"
+    []
+    (Server_auth.generic_bearer_challenge_headers `Forbidden)
+;;
+
 let test_public_listener_cannot_admit_loopback_oauth_by_host () =
   let trust_policy =
     match
@@ -313,6 +326,7 @@ let () =
     "server_oauth_protocol"
     [ ( "protocol"
       , [ test_case "Codex discovery contract" `Quick test_codex_discovery_contract
+        ; test_case "generic Bearer challenge" `Quick test_generic_bearer_challenge
         ; test_case
             "public listener rejects loopback OAuth Host"
             `Quick


### PR DESCRIPTION
## Summary

Closes the two actionable P2 review gaps that arrived as #26688 was merging:

- reject an explicitly empty authorization or refresh `scope` instead of defaulting it to `mcp:tools`;
- preserve a plain `WWW-Authenticate: Bearer` challenge on generic HTTP/1 and HTTP/2 401 responses while keeping MCP `resource_metadata` scoped to MCP transport responders.

The client-eviction race comments on #26688 are obsolete against merged head `8b2828f580`: that implementation no longer evicts any durable client identity at capacity. Capacity recovery remains tracked separately in #26590.

## Verification

- `ocamlformat --check` on all five touched OCaml files
- `git diff --check`
- `MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build @test/runtest-test_auth_oauth @test/runtest-test_server_oauth_protocol`
  - OAuth lifecycle: 12/12 passed
  - OAuth protocol: 11/11 passed

Follow-up to #26688 and #26573.
