### PR TITLE
fix(keeper): restore durable Board cursor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -981,7 +981,8 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_registry_hardening @test/runtest-test_keeper_reaction_ledger @test/runtest-test_board_dispatch @test/runtest-test_keeper_registry_admission_no_suspend"
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_registry_hardening @test/runtest-test_keeper_reaction_ledger @test/runtest-test_keeper_registry_admission_no_suspend"
+          scripts/ci-run-tests.sh "opam exec -- dune exec --root . test/test_board_dispatch.exe -- test board_cursor"
 
       # Keeper unified prompt surface: asserts what a Keeper is actually handed
       # on a turn. The schedule wake row carries two ids with different

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -981,7 +981,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_registry_hardening @test/runtest-test_keeper_reaction_ledger"
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_registry_hardening @test/runtest-test_keeper_reaction_ledger @test/runtest-test_board_dispatch @test/runtest-test_keeper_registry_admission_no_suspend"
 
       # Keeper unified prompt surface: asserts what a Keeper is actually handed
       # on a turn. The schedule wake row carries two ids with different

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -738,11 +738,13 @@ jobs:
           wait "${heartbeat_pid}" 2>/dev/null || true
           exit "${build_status}"
 
-      - name: Run event queue v15 cutover gate self-test
+      - name: Run deployment cutover gate self-tests
         if: ${{ always() && steps.build_step.outcome == 'success' }}
         env:
           MASC_EVENT_QUEUE_V15_CUTOVER_HELPER: ${{ github.workspace }}/_build/default/bin/keeper_event_queue_v15_cutover_helper.exe
-        run: scripts/check-keeper-event-queue-v15-cutover.sh --self-test
+        run: |
+          scripts/check-keeper-event-queue-v15-cutover.sh --self-test
+          scripts/check-deploy-cutover-gates.sh
 
       - name: Check keeper event queue projection boundary
         # This parser uses compiler-libs directly, so keep it beside the sole

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -966,12 +966,9 @@ jobs:
           chmod +x scripts/ci-run-tests.sh
           scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_schedule_runner @test/runtest-test_schedule_store @test/runtest-test_schedule_consumer_dispatch"
 
-      # Keeper registry hardening: identity resolution and goal-reconciliation
-      # routing are executable behavior — the suite drives a real workspace and
-      # asserts which Keeper a durable stimulus is addressed to, never source
-      # text. It is the only suite covering
-      # [Keeper_goal_reconciliation_wake], so that routing stays ungated under
-      # @check.
+      # Keeper registry hardening: identity resolution, goal-reconciliation
+      # routing, and current-generation cursor readiness are executable
+      # behavior. These suites drive real workspaces rather than source text.
       - name: Run keeper registry hardening suite
         id: keeper_registry_hardening_suite
         if: ${{ always() && steps.build_step.outcome == 'success' }}
@@ -982,7 +979,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_registry_hardening"
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_registry_hardening @test/runtest-test_keeper_reaction_ledger"
 
       # Keeper unified prompt surface: asserts what a Keeper is actually handed
       # on a turn. The schedule wake row carries two ids with different

--- a/bin/dune
+++ b/bin/dune
@@ -185,6 +185,16 @@
   unix
   yojson))
 
+;; Read-only deployment gate for the current reaction-ledger Board cursor
+;; generation. The generation is consumed from Keeper_reaction_ledger itself.
+
+(executable
+ (name keeper_board_cursor_cutover_check)
+ (modules keeper_board_cursor_cutover_check)
+ (public_name masc-keeper-board-cursor-cutover-check)
+ (package masc)
+ (libraries masc fs_compat yojson eio eio_main cmdliner))
+
 ;; Per-turn timeline tool: masc-trace <base-path> <keeper> <turn_id>
 ;; Reads execution-receipts JSONL and prints rows matching the turn_id.
 ;; Foundation for the Step 10 turn-tracing CLI; widens to tool_calls

--- a/bin/keeper_board_cursor_cutover_check.ml
+++ b/bin/keeper_board_cursor_cutover_check.ml
@@ -1,0 +1,118 @@
+open Masc
+open Cmdliner
+
+let metadata_issue_json keeper_name detail =
+  `Assoc
+    [ "kind", `String "keeper_metadata_unreadable"
+    ; "keeper_name", `String keeper_name
+    ; "detail", `String detail
+    ]
+;;
+
+let cursor_issue_json = function
+  | Keeper_reaction_ledger.Board_cursor_missing { keeper_name } ->
+    `Assoc
+      [ "kind", `String "board_cursor_missing"
+      ; "keeper_name", `String keeper_name
+      ]
+  | Keeper_reaction_ledger.Board_cursor_unreadable { keeper_name; error } ->
+    `Assoc
+      [ "kind", `String "board_cursor_unreadable"
+      ; "keeper_name", `String keeper_name
+      ; ( "detail"
+        , `String (Keeper_reaction_ledger.board_cursor_restore_error_to_string error) )
+      ]
+;;
+
+let print_result ~status ~base_path ~keeper_count ~ready_count ~issues =
+  Yojson.Safe.pretty_to_channel
+    stdout
+    (`Assoc
+       [ "schema", `String "keeper.board_cursor_cutover.v1"
+       ; "status", `String status
+       ; "base_path", `String base_path
+       ; "storage_generation", `String Keeper_reaction_ledger.storage_generation
+       ; "keeper_count", `Int keeper_count
+       ; "ready_count", `Int ready_count
+       ; "issues", `List issues
+       ]);
+  output_char stdout '\n';
+  flush stdout
+;;
+
+let validate_metadata config keeper_names =
+  List.filter_map
+    (fun keeper_name ->
+       match Keeper_meta_store.read_meta config keeper_name with
+       | Ok (Some _) -> None
+       | Ok None -> Some (metadata_issue_json keeper_name "metadata disappeared during audit")
+       | Error detail -> Some (metadata_issue_json keeper_name detail))
+    keeper_names
+;;
+
+let main base_path =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let workspace_config = Workspace.default_config base_path in
+  match Keeper_meta_store.keeper_names_result workspace_config with
+  | Error detail ->
+    print_result
+      ~status:"fail"
+      ~base_path
+      ~keeper_count:0
+      ~ready_count:0
+      ~issues:
+        [ `Assoc
+            [ "kind", `String "keeper_metadata_discovery_failed"
+            ; "detail", `String detail
+            ]
+        ];
+    exit 2
+  | Ok [] ->
+    print_result
+      ~status:"fail"
+      ~base_path
+      ~keeper_count:0
+      ~ready_count:0
+      ~issues:[ `Assoc [ "kind", `String "no_registered_keepers" ] ];
+    exit 2
+  | Ok keeper_names ->
+    let metadata_issues = validate_metadata workspace_config keeper_names in
+    let report =
+      Keeper_reaction_ledger.board_cursor_cutover_report ~base_path ~keeper_names
+    in
+    let issues = metadata_issues @ List.map cursor_issue_json report.issues in
+    let ready = List.is_empty issues in
+    print_result
+      ~status:(if ready then "pass" else "fail")
+      ~base_path
+      ~keeper_count:report.keeper_count
+      ~ready_count:report.ready_count
+      ~issues;
+    if not ready then exit 2
+;;
+
+let base_path_conv =
+  let parse value =
+    let value = String.trim value in
+    if String.equal value ""
+    then Error (`Msg "base path must be non-empty")
+    else Ok value
+  in
+  Arg.conv (parse, Format.pp_print_string)
+;;
+
+let base_path_arg =
+  Arg.(required & opt (some base_path_conv) None & info [ "base-path" ] ~docv:"PATH")
+;;
+
+let command =
+  Cmd.v
+    (Cmd.info
+       "masc-keeper-board-cursor-cutover-check"
+       ~doc:"Check current-generation Keeper Board cursor readiness")
+    Term.(const main $ base_path_arg)
+;;
+
+let () = exit (Cmd.eval command)

--- a/bin/keeper_board_cursor_cutover_check.ml
+++ b/bin/keeper_board_cursor_cutover_check.ml
@@ -69,14 +69,6 @@ let main base_path =
             ]
         ];
     exit 2
-  | Ok [] ->
-    print_result
-      ~status:"fail"
-      ~base_path
-      ~keeper_count:0
-      ~ready_count:0
-      ~issues:[ `Assoc [ "kind", `String "no_registered_keepers" ] ];
-    exit 2
   | Ok keeper_names ->
     let metadata_issues = validate_metadata workspace_config keeper_names in
     let report =

--- a/bin/keeper_board_cursor_cutover_check.ml
+++ b/bin/keeper_board_cursor_cutover_check.ml
@@ -50,7 +50,18 @@ let validate_metadata config keeper_names =
     keeper_names
 ;;
 
+let bind_explicit_base_path base_path =
+  let resolved_base_path =
+    Workspace_utils_backend_setup.resolve_requested_base_path base_path
+  in
+  Unix.putenv Env_config_core.base_path_input_env_key base_path;
+  Unix.putenv Env_config_core.base_path_env_key resolved_base_path;
+  Workspace_utils_backend_setup.cache_resolved_base_path resolved_base_path;
+  resolved_base_path
+;;
+
 let main base_path =
+  let base_path = bind_explicit_base_path base_path in
   Eio_main.run
   @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);

--- a/docs/runbooks/keeper-board-cursor-cutover.md
+++ b/docs/runbooks/keeper-board-cursor-cutover.md
@@ -1,0 +1,19 @@
+# Keeper Board cursor cutover
+
+After installing the candidate binaries, but before starting or restarting
+MASC against an existing workspace, run the read-only gate:
+
+```sh
+masc-keeper-board-cursor-cutover-check --base-path /path/to/workspace
+```
+
+The command discovers canonical Keeper metadata, validates every metadata row,
+and asks the production reaction-ledger reader for each Keeper's current-
+generation Board cursor. It exits `0` only when every registered Keeper is
+ready. Missing, malformed, or unreadable state exits `2`; the command never
+writes or repairs runtime state.
+
+A workspace with no registered Keeper metadata fails closed as well. A
+genuinely new workspace has no pre-existing cursor state to cut over and does
+not need this gate. Reset or recreate runtime state only through a separately
+approved operator action.

--- a/docs/spec/SPEC-INDEX.md
+++ b/docs/spec/SPEC-INDEX.md
@@ -31,7 +31,7 @@ used as evidence.
 | `.mli` interfaces under `lib/` | 401 |
 | MCP tool modules (`tool_*.ml`) | 109 |
 | Test files (`test/*.ml`) | 449 |
-| Executables | 9 public (`masc`, `masc-stdio`, `masc-cost`, `masc-compaction-audit`, `masc-keeper-feature-proof`, `masc-trace`, `masc-tui`, `masc-worker-run`, `masc-fusion-run`) + 4 internal (`public_tool_manifest`, `env_knob_catalog`, `gen_tool_descriptors`, `keeper_event_queue_v15_cutover_helper`) |
+| Executables | 11 public (`masc`, `masc-stdio`, `masc-cost`, `masc-compaction-audit`, `masc-checkpoint-purge`, `masc-keeper-feature-proof`, `masc-keeper-board-cursor-cutover-check`, `masc-trace`, `masc-tui`, `masc-worker-run`, `masc-fusion-run`) + 4 internal (`public_tool_manifest`, `env_knob_catalog`, `gen_tool_descriptors`, `keeper_event_queue_v15_cutover_helper`) |
 
 숫자는 2026-04-23 repo snapshot 기준. `rg --files lib/ test/ bin/` 및 `wc -l`로 재계산. 최신 truth는 다시 계산해야 한다.
 

--- a/lib/keeper/keeper_board_cursor_genesis.ml
+++ b/lib/keeper/keeper_board_cursor_genesis.ml
@@ -1,0 +1,71 @@
+type error =
+  | Shutdown_fenced of Keeper_shutdown_types.Operation_id.t
+  | Lifecycle_reserved of Keeper_lifecycle_reservation.snapshot
+  | Restore_failed of Keeper_reaction_ledger.board_cursor_restore_error
+  | Persist_failed of string
+
+let error_to_string = function
+  | Shutdown_fenced operation_id ->
+    Printf.sprintf
+      "shutdown operation %s owns keeper admission"
+      (Keeper_shutdown_types.Operation_id.to_string operation_id)
+  | Lifecycle_reserved owner ->
+    Keeper_lifecycle_reservation.snapshot_to_string owner
+  | Restore_failed error ->
+    Keeper_reaction_ledger.board_cursor_restore_error_to_string error
+  | Persist_failed detail -> detail
+;;
+
+let ensure_with ?lifecycle_token ~current_post_cursor ~base_path ~keeper_name () =
+  try
+    Keeper_lifecycle_reservation.with_key_lock ~base_path ~keeper_name (fun () ->
+      match
+        Keeper_lifecycle_reservation.authorize
+          ?token:lifecycle_token
+          ~base_path
+          ~keeper_name
+          ()
+      with
+      | Error owner -> Error (Lifecycle_reserved owner)
+      | Ok () ->
+        (* The lifecycle key lock remains outside and before the admission
+           lock. Board and JSONL operations may suspend, so the admission
+           authority below uses its fiber-cooperative durable-effect slot. *)
+        (match
+           Keeper_turn_admission.run_durable_effect_if_open
+             ~base_path
+             ~keeper_name
+             (fun _intake_token ->
+                match
+                  Keeper_reaction_ledger.latest_board_cursor_result
+                    ~base_path
+                    ~keeper_name
+                with
+                | Error error -> Error (Restore_failed error)
+                | Ok (Some _) -> Ok ()
+                | Ok None ->
+                  let cursor_ts, post_id = current_post_cursor () in
+                  Keeper_reaction_ledger.record_board_cursor_ack
+                    ~base_path
+                    ~keeper_name
+                    ~cursor_ts
+                    ~post_id
+                    ();
+                  Ok ())
+         with
+         | Keeper_turn_admission.Durable_effect_shutdown_reserved operation_id ->
+           Error (Shutdown_fenced operation_id)
+         | Keeper_turn_admission.Durable_effect_committed result -> result))
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Persist_failed (Printexc.to_string exn))
+;;
+
+let ensure ?lifecycle_token ~base_path ~keeper_name () =
+  ensure_with
+    ?lifecycle_token
+    ~current_post_cursor:Board_dispatch.current_post_cursor
+    ~base_path
+    ~keeper_name
+    ()
+;;

--- a/lib/keeper/keeper_board_cursor_genesis.mli
+++ b/lib/keeper/keeper_board_cursor_genesis.mli
@@ -1,0 +1,26 @@
+(** Establish the current-generation durable Board cursor before a Keeper is
+    admitted. This is genesis from the current Board head; it never reads or
+    converts an older reaction-ledger generation. *)
+
+type error =
+  | Shutdown_fenced of Keeper_shutdown_types.Operation_id.t
+  | Lifecycle_reserved of Keeper_lifecycle_reservation.snapshot
+  | Restore_failed of Keeper_reaction_ledger.board_cursor_restore_error
+  | Persist_failed of string
+
+val error_to_string : error -> string
+
+val ensure_with :
+  ?lifecycle_token:Keeper_lifecycle_reservation.token ->
+  current_post_cursor:(unit -> float * string option) ->
+  base_path:string ->
+  keeper_name:string ->
+  unit ->
+  (unit, error) result
+
+val ensure :
+  ?lifecycle_token:Keeper_lifecycle_reservation.token ->
+  base_path:string ->
+  keeper_name:string ->
+  unit ->
+  (unit, error) result

--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -625,7 +625,8 @@ let observe
            }
        | None -> None);
     board_cursor =
-      { bc_ts = entry.board_cursor_ts; bc_post_id = entry.board_cursor_post_id };
+      (let bc_ts, bc_post_id = entry.board_cursor in
+       { bc_ts; bc_post_id });
     board_wakeups = Keeper_registry.StringMap.cardinal entry.board_wakeups;
     fiber_stop_flag = Atomic.get entry.fiber_stop;
     fiber_wakeup_flag = Atomic.get entry.fiber_wakeup;

--- a/lib/keeper/keeper_composite_observer.mli
+++ b/lib/keeper/keeper_composite_observer.mli
@@ -202,8 +202,8 @@ type turn_attempt = {
   ta_first_started_at : float;
 }
 
-(** Board consumption cursor, mirrored from
-    [registry_entry.board_cursor_ts] / [board_cursor_post_id]. Lets
+(** Board consumption cursor, mirrored from the restored
+    [registry_entry.board_cursor]. Lets
     operators see how far a keeper has consumed the shared board. *)
 type board_cursor = {
   bc_ts : float;

--- a/lib/keeper/keeper_event_queue_recovery.ml
+++ b/lib/keeper/keeper_event_queue_recovery.ml
@@ -299,13 +299,13 @@ let project_claimed_owner owner =
        }
        :: _ ->
        (match
-          Keeper_turn_admission.run_durable_intake_if_open
+          Keeper_turn_admission.run_durable_effect_if_open
             ~base_path
             ~keeper_name
             (fun _source_intake_token -> project_open_owner ())
         with
-        | Keeper_turn_admission.Intake_committed result -> result
-        | Keeper_turn_admission.Intake_shutdown_reserved operation_id ->
+        | Keeper_turn_admission.Durable_effect_committed result -> result
+        | Keeper_turn_admission.Durable_effect_shutdown_reserved operation_id ->
           Error (Owner_shutdown_reserved operation_id)))
 ;;
 

--- a/lib/keeper/keeper_event_queue_recovery.mli
+++ b/lib/keeper/keeper_event_queue_recovery.mli
@@ -73,7 +73,7 @@ val project_owner_result :
   base_path:string ->
   keeper_name:string ->
   (projection_outcome, projection_error) result
-(** Acquire the process-local owner claim and the owner's durable-intake fence,
+(** Acquire the process-local owner claim and the owner's durable-effect fence,
     then inspect the durable outbox. A shutdown that linearizes first returns
     [Owner_shutdown_reserved]; an in-flight projection finishes before the
     shutdown join returns, so it cannot recreate artifacts after purge.

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -703,7 +703,6 @@ type start_keepalive_outcome =
   | Keepalive_already_registered of Keeper_registry.registry_entry
   | Keepalive_lifecycle_denied of Keeper_lifecycle_admission.autonomous_denial
   | Keepalive_identity_unrepairable
-  | Keepalive_board_cursor_genesis_failed of Keeper_board_cursor_genesis.error
   | Keepalive_registration_rejected of Keeper_registry.registration_error
   | Keepalive_fiber_start_rejected of Keeper_state_machine.transition_error
   | Keepalive_lane_ownership_lost
@@ -720,8 +719,6 @@ let start_keepalive_outcome_to_string = function
   | Keepalive_lifecycle_denied denial ->
     Keeper_lifecycle_admission.autonomous_denial_to_wire denial
   | Keepalive_identity_unrepairable -> "keeper identity drift could not be repaired"
-  | Keepalive_board_cursor_genesis_failed error ->
-    Keeper_board_cursor_genesis.error_to_string error
   | Keepalive_registration_rejected
       (Keeper_registry.Registration_shutdown_reserved operation_id) ->
     Printf.sprintf
@@ -897,36 +894,20 @@ let start_keepalive
         (Printf.sprintf "start_keepalive: skipped %s (already registered)" m.name);
       Keepalive_already_registered registered
     | None ->
-      (* Establish the durable subscription head before the registry lane can
-         become visible. *)
       (match
-         Keeper_board_cursor_genesis.ensure
-           ?lifecycle_token
-           ~base_path:ctx.config.base_path
-           ~keeper_name:m.name
-           ()
+         match lifecycle_token with
+         | None ->
+           Keeper_registry.register_offline_if_admitted
+             ~base_path:ctx.config.base_path
+             m.name
+             m
+         | Some token ->
+           Keeper_registry.register_offline_if_admitted_for_lifecycle
+             token
+             ~base_path:ctx.config.base_path
+             m.name
+             m
        with
-       | Error error ->
-         Log.Keeper.error
-           "start_keepalive: Board cursor genesis failed keeper=%s: %s"
-           m.name
-           (Keeper_board_cursor_genesis.error_to_string error);
-         Keepalive_board_cursor_genesis_failed error
-       | Ok () ->
-         (match
-            match lifecycle_token with
-            | None ->
-              Keeper_registry.register_offline_if_admitted
-                ~base_path:ctx.config.base_path
-                m.name
-                m
-            | Some token ->
-              Keeper_registry.register_offline_if_admitted_for_lifecycle
-                token
-                ~base_path:ctx.config.base_path
-                m.name
-                m
-          with
        | Error (Keeper_registry.Registration_shutdown_reserved operation_id) ->
          Log.Keeper.warn
            "start_keepalive: skipped %s because shutdown operation %s owns admission"
@@ -1219,7 +1200,7 @@ let start_keepalive
              ~base_path:ctx.config.base_path
              ~keeper_name:live_meta.name
              ~failure_reason:(Keeper_registry.Exception detail);
-          Keepalive_fork_rejected error)))
+          Keepalive_fork_rejected error))
         )
 ;;
 

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -703,6 +703,7 @@ type start_keepalive_outcome =
   | Keepalive_already_registered of Keeper_registry.registry_entry
   | Keepalive_lifecycle_denied of Keeper_lifecycle_admission.autonomous_denial
   | Keepalive_identity_unrepairable
+  | Keepalive_board_cursor_genesis_failed of Keeper_board_cursor_genesis.error
   | Keepalive_registration_rejected of Keeper_registry.registration_error
   | Keepalive_fiber_start_rejected of Keeper_state_machine.transition_error
   | Keepalive_lane_ownership_lost
@@ -719,6 +720,8 @@ let start_keepalive_outcome_to_string = function
   | Keepalive_lifecycle_denied denial ->
     Keeper_lifecycle_admission.autonomous_denial_to_wire denial
   | Keepalive_identity_unrepairable -> "keeper identity drift could not be repaired"
+  | Keepalive_board_cursor_genesis_failed error ->
+    Keeper_board_cursor_genesis.error_to_string error
   | Keepalive_registration_rejected
       (Keeper_registry.Registration_shutdown_reserved operation_id) ->
     Printf.sprintf
@@ -735,6 +738,13 @@ let start_keepalive_outcome_to_string = function
   | Keepalive_registration_rejected
       (Keeper_registry.Registration_event_queue_unavailable { keeper_name; detail }) ->
     Printf.sprintf "event queue unavailable for %s: %s" keeper_name detail
+  | Keepalive_registration_rejected
+      (Keeper_registry.Registration_board_cursor_unavailable
+         { keeper_name; reason }) ->
+    Printf.sprintf
+      "board cursor unavailable for %s: %s"
+      keeper_name
+      (Keeper_registry.board_cursor_registration_error_to_string reason)
   | Keepalive_fiber_start_rejected error ->
     Printf.sprintf
       "Fiber_started rejected: %s"
@@ -887,21 +897,36 @@ let start_keepalive
         (Printf.sprintf "start_keepalive: skipped %s (already registered)" m.name);
       Keepalive_already_registered registered
     | None ->
-      (* Register in Keeper_registry first — single source of truth. *)
+      (* Establish the durable subscription head before the registry lane can
+         become visible. *)
       (match
-         match lifecycle_token with
-         | None ->
-           Keeper_registry.register_offline_if_admitted
-             ~base_path:ctx.config.base_path
-             m.name
-             m
-         | Some token ->
-           Keeper_registry.register_offline_if_admitted_for_lifecycle
-             token
-             ~base_path:ctx.config.base_path
-             m.name
-             m
+         Keeper_board_cursor_genesis.ensure
+           ?lifecycle_token
+           ~base_path:ctx.config.base_path
+           ~keeper_name:m.name
+           ()
        with
+       | Error error ->
+         Log.Keeper.error
+           "start_keepalive: Board cursor genesis failed keeper=%s: %s"
+           m.name
+           (Keeper_board_cursor_genesis.error_to_string error);
+         Keepalive_board_cursor_genesis_failed error
+       | Ok () ->
+         (match
+            match lifecycle_token with
+            | None ->
+              Keeper_registry.register_offline_if_admitted
+                ~base_path:ctx.config.base_path
+                m.name
+                m
+            | Some token ->
+              Keeper_registry.register_offline_if_admitted_for_lifecycle
+                token
+                ~base_path:ctx.config.base_path
+                m.name
+                m
+          with
        | Error (Keeper_registry.Registration_shutdown_reserved operation_id) ->
          Log.Keeper.warn
            "start_keepalive: skipped %s because shutdown operation %s owns admission"
@@ -931,6 +956,16 @@ let start_keepalive
          Keepalive_registration_rejected
            (Keeper_registry.Registration_event_queue_unavailable
               { keeper_name; detail })
+       | Error
+           (Keeper_registry.Registration_board_cursor_unavailable
+              { keeper_name; reason }) ->
+         Log.Keeper.error
+           "start_keepalive: registry board cursor unavailable keeper=%s: %s"
+           keeper_name
+           (Keeper_registry.board_cursor_registration_error_to_string reason);
+         Keepalive_registration_rejected
+           (Keeper_registry.Registration_board_cursor_unavailable
+              { keeper_name; reason })
        | Ok reg ->
       (* Restore persisted tool usage stats from previous session *)
       Keeper_registry_tool_usage_persistence.restore ~base_path:ctx.config.base_path m.name;
@@ -1184,7 +1219,7 @@ let start_keepalive
              ~base_path:ctx.config.base_path
              ~keeper_name:live_meta.name
              ~failure_reason:(Keeper_registry.Exception detail);
-           Keepalive_fork_rejected error))
+          Keepalive_fork_rejected error)))
         )
 ;;
 

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -85,7 +85,6 @@ type start_keepalive_outcome =
   | Keepalive_already_registered of Keeper_registry.registry_entry
   | Keepalive_lifecycle_denied of Keeper_lifecycle_admission.autonomous_denial
   | Keepalive_identity_unrepairable
-  | Keepalive_board_cursor_genesis_failed of Keeper_board_cursor_genesis.error
   | Keepalive_registration_rejected of Keeper_registry.registration_error
   | Keepalive_fiber_start_rejected of Keeper_state_machine.transition_error
   | Keepalive_lane_ownership_lost

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -85,6 +85,7 @@ type start_keepalive_outcome =
   | Keepalive_already_registered of Keeper_registry.registry_entry
   | Keepalive_lifecycle_denied of Keeper_lifecycle_admission.autonomous_denial
   | Keepalive_identity_unrepairable
+  | Keepalive_board_cursor_genesis_failed of Keeper_board_cursor_genesis.error
   | Keepalive_registration_rejected of Keeper_registry.registration_error
   | Keepalive_fiber_start_rejected of Keeper_state_machine.transition_error
   | Keepalive_lane_ownership_lost

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -30,7 +30,7 @@ module Event_id_set = Set.Make (String)
 
 (* The storage namespace and row schema advance together. Readers inspect
    exactly this namespace, keeping exact evidence under one authority. *)
-let storage_generation = "v5"
+let storage_generation = "v6"
 let schema = "keeper.reaction_ledger." ^ storage_generation
 
 let stimulus_kind_to_string = function
@@ -462,32 +462,32 @@ let cursor_json { cursor_ts; post_id } =
     ]
 ;;
 
-let record_board_cursor_ack
-      ~base_path
-      ~keeper_name
-      ?stimulus_id
-      ~cursor_ts
-      ~post_id
-      ()
-  =
+let cursor_ts_identity cursor_ts =
+  Printf.sprintf "%016Lx" (Int64.bits_of_float cursor_ts)
+;;
+
+let cursor_stimulus_id ~cursor_ts = function
+  | Some post_id -> board_stimulus_id ~post_id
+  | None -> digest_id "cursor" (cursor_ts_identity cursor_ts)
+;;
+
+let cursor_event_id ~stimulus_id ~cursor_ts =
+  digest_id
+    "krl"
+    (String.concat
+       "|"
+       [ stimulus_id; "cursor_ack"; cursor_ts_identity cursor_ts ])
+;;
+
+let record_board_cursor_ack ~base_path ~keeper_name ~cursor_ts ~post_id () =
   let cursor = { cursor_ts; post_id } in
-  let stimulus_id =
-    match stimulus_id, post_id with
-    | Some value, _ -> value
-    | None, Some post_id -> board_stimulus_id ~post_id
-    | None, None -> digest_id "cursor" (Printf.sprintf "%.6f" cursor_ts)
-  in
+  let stimulus_id = cursor_stimulus_id ~cursor_ts post_id in
   let recorded_at = Time_compat.now () in
   let json =
     `Assoc
       (base_fields
          ~record_kind:"cursor_ack"
-         ~event_id:
-           (digest_id
-              "krl"
-              (String.concat
-                 "|"
-                 [ stimulus_id; "cursor_ack"; Printf.sprintf "%.6f" cursor_ts ]))
+         ~event_id:(cursor_event_id ~stimulus_id ~cursor_ts)
          ~keeper_name
          ~recorded_at
        @ [ "stimulus_id", `String stimulus_id
@@ -585,7 +585,10 @@ type row_quarantine_reason =
   | Event_identity_mismatch
   | Transition_kind_mismatch
   | Missing_cursor
+  | Invalid_cursor_scope
   | Missing_cursor_ts
+  | Missing_cursor_post_id
+  | Invalid_cursor_post_id
   | Non_finite_cursor_ts
   | Non_finite_board_updated_at
   | Invalid_cursor_reaction
@@ -636,10 +639,38 @@ let row_quarantine_reason_to_string = function
   | Event_identity_mismatch -> "event_identity_mismatch"
   | Transition_kind_mismatch -> "transition_kind_mismatch"
   | Missing_cursor -> "missing_cursor"
+  | Invalid_cursor_scope -> "invalid_cursor_scope"
   | Missing_cursor_ts -> "missing_cursor_ts"
+  | Missing_cursor_post_id -> "missing_cursor_post_id"
+  | Invalid_cursor_post_id -> "invalid_cursor_post_id"
   | Non_finite_cursor_ts -> "non_finite_cursor_ts"
   | Non_finite_board_updated_at -> "non_finite_board_updated_at"
   | Invalid_cursor_reaction -> "invalid_cursor_reaction"
+;;
+
+type board_cursor_restore_error =
+  | Board_cursor_malformed_row of
+      { path : string
+      ; line_number : int option
+      ; detail : string
+      }
+  | Board_cursor_invalid_row of row_quarantine_reason
+  | Board_cursor_read_error of Dated_jsonl.read_error
+
+let board_cursor_restore_error_to_string = function
+  | Board_cursor_malformed_row { path; line_number; detail } ->
+    Printf.sprintf
+      "malformed reaction-ledger row path=%s line=%s: %s"
+      path
+      (match line_number with
+       | Some value -> string_of_int value
+       | None -> "unknown")
+      detail
+  | Board_cursor_invalid_row reason ->
+    Printf.sprintf
+      "invalid reaction-ledger row before board cursor: %s"
+      (row_quarantine_reason_to_string reason)
+  | Board_cursor_read_error error -> Dated_jsonl.read_error_to_string error
 ;;
 
 type current_row_metadata =
@@ -846,6 +877,11 @@ let decode_cursor_ack_row metadata row =
     | Some value -> Ok value
     | None -> Error Missing_cursor
   in
+  let* () =
+    match assoc_field "scope" cursor with
+    | Some (`String "board") -> Ok ()
+    | Some _ | None -> Error Invalid_cursor_scope
+  in
   let* cursor_ts =
     require_finite_float
       ~missing:Missing_cursor_ts
@@ -853,26 +889,37 @@ let decode_cursor_ack_row metadata row =
       "cursor_ts"
       cursor
   in
-  let post_id = string_field "post_id" cursor in
+  let* post_id =
+    match assoc_field "post_id" cursor with
+    | None -> Error Missing_cursor_post_id
+    | Some `Null -> Ok None
+    | Some (`String value) when not (String.equal value "") -> Ok (Some value)
+    | Some _ -> Error Invalid_cursor_post_id
+  in
   let* reaction =
     match assoc_field "reaction" row with
     | Some value -> Ok value
     | None -> Error Invalid_cursor_reaction
   in
   let valid_reaction =
-    match string_field "kind" reaction, string_field "source" reaction with
-    | Some "cursor_ack", Some "keeper_world_observation.board_cursor" -> true
+    match
+      ( string_field "kind" reaction
+      , string_field "source" reaction
+      , assoc_field "cursor_acked" reaction )
+    with
+    | ( Some "cursor_ack"
+      , Some "keeper_world_observation.board_cursor"
+      , Some (`Bool true) ) -> true
     | _ -> false
   in
   let expected_event_id =
-    digest_id
-      "krl"
-      (String.concat
-         "|"
-         [ metadata.stimulus_id; "cursor_ack"; Printf.sprintf "%.6f" cursor_ts ])
+    cursor_event_id ~stimulus_id:metadata.stimulus_id ~cursor_ts
   in
+  let expected_stimulus_id = cursor_stimulus_id ~cursor_ts post_id in
   if not valid_reaction
   then Error Invalid_cursor_reaction
+  else if not (String.equal metadata.stimulus_id expected_stimulus_id)
+  then Error Event_identity_mismatch
   else if String.equal metadata.event_id expected_event_id
   then Ok (Current_cursor_ack { metadata; cursor_token = cursor_ts, post_id })
   else Error Event_identity_mismatch
@@ -977,6 +1024,25 @@ let decode_current_row ~keeper_name row =
     decode_reaction_row ~event_id metadata reaction
   | "cursor_ack" -> decode_cursor_ack_row metadata row
   | _ -> Error Unknown_record_kind
+;;
+
+let latest_board_cursor_result ~base_path ~keeper_name =
+  match
+    Dated_jsonl.find_latest_entry_result
+      (store_for_base_path ~base_path ~keeper_name)
+      (function
+        | Dated_jsonl.Malformed_json { path; line_number; detail } ->
+          Some (Error (Board_cursor_malformed_row { path; line_number; detail }))
+        | Dated_jsonl.Parsed row ->
+          (match decode_current_row ~keeper_name row with
+           | Error reason -> Some (Error (Board_cursor_invalid_row reason))
+           | Ok (Current_cursor_ack { cursor_token = cursor_ts, post_id; _ }) ->
+             Some (Ok (Some { cursor_ts; post_id }))
+           | Ok (Current_stimulus _ | Current_reaction _) -> None))
+  with
+  | Error error -> Error (Board_cursor_read_error error)
+  | Ok None -> Ok None
+  | Ok (Some result) -> result
 ;;
 
 type event_queue_reaction_evidence =

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -1045,6 +1045,38 @@ let latest_board_cursor_result ~base_path ~keeper_name =
   | Ok (Some result) -> result
 ;;
 
+type board_cursor_cutover_issue =
+  | Board_cursor_missing of { keeper_name : string }
+  | Board_cursor_unreadable of
+      { keeper_name : string
+      ; error : board_cursor_restore_error
+      }
+
+type board_cursor_cutover_report =
+  { keeper_count : int
+  ; ready_count : int
+  ; issues : board_cursor_cutover_issue list
+  }
+
+let board_cursor_cutover_report ~base_path ~keeper_names =
+  let keeper_names = List.sort_uniq String.compare keeper_names in
+  let ready_count, issues =
+    List.fold_left
+      (fun (ready_count, issues) keeper_name ->
+         match latest_board_cursor_result ~base_path ~keeper_name with
+         | Ok (Some _) -> ready_count + 1, issues
+         | Ok None -> ready_count, Board_cursor_missing { keeper_name } :: issues
+         | Error error ->
+           ready_count, Board_cursor_unreadable { keeper_name; error } :: issues)
+      (0, [])
+      keeper_names
+  in
+  { keeper_count = List.length keeper_names
+  ; ready_count
+  ; issues = List.rev issues
+  }
+;;
+
 type event_queue_reaction_evidence =
   { keeper_name : string
   ; stimulus_id : string

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -3,7 +3,7 @@
     This is the runtime mirror for the KeeperReactionLiveness L1/L5
     contract: queue-visible stimuli, queue transition reactions, and board
     cursor acknowledgements are written to a replayable JSONL store under
-    [.masc/keepers/<keeper>/reaction-ledger/v5/YYYY-MM/DD.jsonl].  The
+    [.masc/keepers/<keeper>/reaction-ledger/v6/YYYY-MM/DD.jsonl].  The
     generation namespace is a hard boundary: older stores are neither read nor
     written by this module. *)
 
@@ -41,6 +41,17 @@ type row_quarantine_reason
 val stimulus_kind_to_string : stimulus_kind -> string
 val reaction_kind_to_string : reaction_kind -> string
 val row_quarantine_reason_to_string : row_quarantine_reason -> string
+
+type board_cursor_restore_error =
+  | Board_cursor_malformed_row of
+      { path : string
+      ; line_number : int option
+      ; detail : string
+      }
+  | Board_cursor_invalid_row of row_quarantine_reason
+  | Board_cursor_read_error of Dated_jsonl.read_error
+
+val board_cursor_restore_error_to_string : board_cursor_restore_error -> string
 
 val stimulus_kind_of_string : string -> stimulus_kind option
 (** Inverse of {!stimulus_kind_to_string}.  Strings outside the closed sum
@@ -140,7 +151,6 @@ val event_queue_turn_started_seen_for_source_result :
 val record_board_cursor_ack :
   base_path:string ->
   keeper_name:string ->
-  ?stimulus_id:string ->
   cursor_ts:float ->
   post_id:string option ->
   unit ->
@@ -148,6 +158,17 @@ val record_board_cursor_ack :
 (** Append a durable cursor acknowledgement. Callers should write this before
     advancing the in-memory board cursor so every cursor advance has a replayable
     ack row. *)
+
+val latest_board_cursor_result :
+  base_path:string ->
+  keeper_name:string ->
+  (cursor option, board_cursor_restore_error) result
+(** Restore the newest durable board cursor. The scan is newest-first and
+    ignores rows whose closed [record_kind] identifies them as non-cursor
+    state. A malformed row, unknown record kind, or invalid cursor row
+    encountered before the newest cursor is a typed failure, so cursor
+    corruption cannot silently roll the Keeper back to an older cursor.
+    [Ok None] means the current ledger contains no cursor acknowledgement. *)
 
 val summary_for_keeper :
   base_path:string -> keeper_name:string -> limit:int -> Yojson.Safe.t

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -38,6 +38,11 @@ type reaction_kind =
 type reaction_decode_error = Unknown_reaction_kind of string
 type row_quarantine_reason
 
+val storage_generation : string
+(** Current reaction-ledger namespace. Deployment checks consume this value
+    from the same module as readers and writers; no second generation literal
+    is maintained. *)
+
 val stimulus_kind_to_string : stimulus_kind -> string
 val reaction_kind_to_string : reaction_kind -> string
 val row_quarantine_reason_to_string : row_quarantine_reason -> string
@@ -169,6 +174,24 @@ val latest_board_cursor_result :
     encountered before the newest cursor is a typed failure, so cursor
     corruption cannot silently roll the Keeper back to an older cursor.
     [Ok None] means the current ledger contains no cursor acknowledgement. *)
+
+type board_cursor_cutover_issue =
+  | Board_cursor_missing of { keeper_name : string }
+  | Board_cursor_unreadable of
+      { keeper_name : string
+      ; error : board_cursor_restore_error
+      }
+
+type board_cursor_cutover_report =
+  { keeper_count : int
+  ; ready_count : int
+  ; issues : board_cursor_cutover_issue list
+  }
+
+val board_cursor_cutover_report :
+  base_path:string -> keeper_names:string list -> board_cursor_cutover_report
+(** Read-only current-generation cursor readiness for an explicit canonical
+    Keeper set. Names are sorted and deduplicated before inspection. *)
 
 val summary_for_keeper :
   base_path:string -> keeper_name:string -> limit:int -> Yojson.Safe.t

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -535,8 +535,6 @@ let cleanup_tracking ~base_path name =
          { entry with
            board_wakeups = StringMap.empty
          ; tool_usage = StringMap.empty
-         ; board_cursor_ts = 0.0
-         ; board_cursor_post_id = None
          }
      with
      | Ok () -> ()
@@ -553,8 +551,6 @@ let cleanup_tracking_exact (entry : registry_entry) =
     { current with
       board_wakeups = StringMap.empty
     ; tool_usage = StringMap.empty
-    ; board_cursor_ts = 0.0
-    ; board_cursor_post_id = None
     })
 ;;
 
@@ -567,14 +563,14 @@ let clear () =
 
 let get_board_cursor ~base_path name =
   match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
-  | Some entry -> entry.board_cursor_ts, entry.board_cursor_post_id
-  | None -> 0.0, None
+  | Some entry -> Some entry.board_cursor
+  | None -> None
 ;;
 
 let set_board_cursor ~base_path name ts post_id =
   match
     update_entry ~base_path name (fun e ->
-      { e with board_cursor_ts = ts; board_cursor_post_id = post_id })
+      { e with board_cursor = ts, post_id })
   with
   | Ok () -> ()
   | Error err ->
@@ -1215,7 +1211,8 @@ let get_phase ~base_path name =
 
 module For_testing = struct
   let unsafe_put_entry = unsafe_put_entry
-  let register = register
+  let register = register_for_testing
+  let register_offline = register_offline_for_testing
   let unregister = unregister
   let clear = clear
   let reload_meta_from_disk = reload_meta_from_disk

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -20,10 +20,13 @@ include module type of Keeper_registry_types
 
 
 
-(** Register a fresh keeper before its first keepalive fiber launch.
-    The entry starts in [Offline] and must receive [Fiber_started] when the
-    runtime actually launches the fiber. *)
-val register_offline : base_path:string -> string -> keeper_meta -> registry_entry
+type board_cursor_registration_error =
+  | Board_cursor_missing
+  | Board_cursor_restore_failed of
+      Keeper_reaction_ledger.board_cursor_restore_error
+
+val board_cursor_registration_error_to_string :
+  board_cursor_registration_error -> string
 
 type registration_error =
   | Registration_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
@@ -32,6 +35,10 @@ type registration_error =
   | Registration_event_queue_unavailable of
       { keeper_name : string
       ; detail : string
+      }
+  | Registration_board_cursor_unavailable of
+      { keeper_name : string
+      ; reason : board_cursor_registration_error
       }
 
 (** Production registration gate: the final registry CAS is serialized with
@@ -56,6 +63,10 @@ type register_restarting_error =
   | Restart_event_queue_unavailable of
       { keeper_name : string
       ; detail : string
+      }
+  | Restart_board_cursor_unavailable of
+      { keeper_name : string
+      ; reason : board_cursor_registration_error
       }
 
 (** Register a keeper that is about to relaunch after a crash.
@@ -418,6 +429,12 @@ module For_testing : sig
       direct fixtures that want a keeper to begin in [Running]. *)
   val register : base_path:string -> string -> keeper_meta -> registry_entry
 
+  (** Register a test fixture in [Offline]. Both test registration helpers
+      explicitly persist the valid empty-Board cursor before installing the
+      entry; production registration never uses this initializer. *)
+  val register_offline :
+    base_path:string -> string -> keeper_meta -> registry_entry
+
   (** Unregister a keeper (removes from registry). *)
   val unregister : base_path:string -> string -> unit
 
@@ -508,8 +525,10 @@ val cleanup_tracking : base_path:string -> string -> unit
 (** Reset tracking only if [entry]'s lane still owns its registry key. *)
 val cleanup_tracking_exact : registry_entry -> exact_update_result
 
-(** Get board event cursor token. Returns [(0.0, None)] if not found. *)
-val get_board_cursor : base_path:string -> string -> float * string option
+(** Get the restored board event cursor token. [None] means the Keeper is not
+    registered; an empty Board is represented by [Some (0.0, None)]. *)
+val get_board_cursor :
+  base_path:string -> string -> (float * string option) option
 
 (** Update board event cursor token. No-op if not found. *)
 val set_board_cursor :

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -208,7 +208,7 @@ let with_durable_intake
     else Error Durable_intake_token_not_live
   | None ->
     (match
-       Keeper_turn_admission.run_durable_intake_if_open
+       Keeper_turn_admission.run_durable_effect_if_open
          ~base_path
          ~keeper_name
          (fun _intake_token ->
@@ -216,8 +216,8 @@ let with_durable_intake
             | Ok () -> Ok (operation ())
             | Error _ as error -> error)
      with
-     | Keeper_turn_admission.Intake_committed result -> result
-     | Keeper_turn_admission.Intake_shutdown_reserved operation_id ->
+     | Keeper_turn_admission.Durable_effect_committed result -> result
+     | Keeper_turn_admission.Durable_effect_shutdown_reserved operation_id ->
        Error (Durable_intake_shutdown_reserved operation_id))
 ;;
 
@@ -546,14 +546,14 @@ let project_accepted_transfer_durable_result
         "target transfer durable intake token is not live for this Keeper"
   | None ->
     (match
-       Keeper_turn_admission.run_durable_intake_if_open
+       Keeper_turn_admission.run_durable_effect_if_open
          ~base_path
          ~keeper_name:name
          (fun _intake_token -> project ())
      with
-     | Keeper_turn_admission.Intake_shutdown_reserved operation_id ->
+     | Keeper_turn_admission.Durable_effect_shutdown_reserved operation_id ->
        Transfer_projection_shutdown_reserved operation_id
-     | Keeper_turn_admission.Intake_committed result -> interpret result)
+     | Keeper_turn_admission.Durable_effect_committed result -> interpret result)
 ;;
 
 let enqueue_hitl_resolution_durable_result
@@ -714,13 +714,13 @@ let transfer_pending_accepted_result
            "source transfer durable intake token is not live for this Keeper")
   | None ->
     (match
-       Keeper_turn_admission.run_durable_intake_if_open
+       Keeper_turn_admission.run_durable_effect_if_open
          ~base_path
          ~keeper_name:name
          (fun _intake_token -> commit ())
      with
-     | Keeper_turn_admission.Intake_committed result -> result
-     | Keeper_turn_admission.Intake_shutdown_reserved operation_id ->
+     | Keeper_turn_admission.Durable_effect_committed result -> result
+     | Keeper_turn_admission.Durable_effect_shutdown_reserved operation_id ->
        Error (Transfer_pending_shutdown_reserved operation_id))
 ;;
 

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -472,6 +472,26 @@ let update_entry_if_registered_unit ~base_path name f =
   ignore (update_entry_if_registered ~base_path name (fun entry -> f entry, true))
 ;;
 
+type board_cursor_registration_error =
+  | Board_cursor_missing
+  | Board_cursor_restore_failed of
+      Keeper_reaction_ledger.board_cursor_restore_error
+
+let board_cursor_registration_error_to_string = function
+  | Board_cursor_missing -> "durable board cursor acknowledgement is missing"
+  | Board_cursor_restore_failed error ->
+    Keeper_reaction_ledger.board_cursor_restore_error_to_string error
+;;
+
+let load_board_cursor_result ~base_path ~keeper_name =
+  match
+    Keeper_reaction_ledger.latest_board_cursor_result ~base_path ~keeper_name
+  with
+  | Ok (Some cursor) -> Ok (cursor.cursor_ts, cursor.post_id)
+  | Ok None -> Error Board_cursor_missing
+  | Error error -> Error (Board_cursor_restore_failed error)
+;;
+
 type registration_error =
   | Registration_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
   | Registration_lifecycle_reserved of Keeper_lifecycle_reservation.snapshot
@@ -479,6 +499,10 @@ type registration_error =
   | Registration_event_queue_unavailable of
       { keeper_name : string
       ; detail : string
+      }
+  | Registration_board_cursor_unavailable of
+      { keeper_name : string
+      ; reason : board_cursor_registration_error
       }
 
 let register_with_state_result
@@ -515,6 +539,10 @@ let register_with_state_result
   with
   | Error detail -> Error (Registration_event_queue_unavailable { keeper_name = name; detail })
   | Ok initial_event_queue ->
+  (match load_board_cursor_result ~base_path ~keeper_name:name with
+  | Error reason ->
+    Error (Registration_board_cursor_unavailable { keeper_name = name; reason })
+  | Ok board_cursor ->
   let entry =
     { base_path
     ; name
@@ -539,8 +567,7 @@ let register_with_state_result
     ; turn_attempt_state = Atomic.make None
     ; current_turn_switch = Atomic.make None
     ; board_wakeups = StringMap.empty
-    ; board_cursor_ts = 0.0
-    ; board_cursor_post_id = None
+    ; board_cursor
     ; tool_usage = StringMap.empty
     ; transition_seq = 0
     ; waiting_for_inference = Atomic.make false
@@ -606,6 +633,7 @@ let register_with_state_result
       name
       (Atomic.get running_count_atomic);
     Ok entry
+  )
 ;;
 
 let register_with_state ~base_path name meta ~phase ~conditions =
@@ -627,6 +655,12 @@ let register_with_state ~base_path name meta ~phase ~conditions =
          "keeper registration event queue unavailable keeper=%s: %s"
          keeper_name
          detail)
+  | Error (Registration_board_cursor_unavailable { keeper_name; reason }) ->
+    invalid_arg
+      (Printf.sprintf
+         "keeper registration board cursor unavailable keeper=%s: %s"
+         keeper_name
+         (board_cursor_registration_error_to_string reason))
   | Error (Registration_shutdown_reserved _) ->
     invalid_arg "unchecked registry registration observed a shutdown fence"
   | Error (Registration_lifecycle_reserved owner) ->
@@ -636,7 +670,17 @@ let register_with_state ~base_path name meta ~phase ~conditions =
          (Keeper_lifecycle_reservation.snapshot_to_string owner))
 ;;
 
-let register ~base_path name meta =
+let persist_test_board_cursor ~base_path ~keeper_name =
+  Keeper_reaction_ledger.record_board_cursor_ack
+    ~base_path
+    ~keeper_name
+    ~cursor_ts:0.0
+    ~post_id:None
+    ()
+;;
+
+let register_for_testing ~base_path name meta =
+  persist_test_board_cursor ~base_path ~keeper_name:name;
   let conditions =
     { Keeper_state_machine.default_conditions with
       fiber_alive = true
@@ -646,7 +690,8 @@ let register ~base_path name meta =
   register_with_state ~base_path name meta ~phase ~conditions
 ;;
 
-let register_offline ~base_path name meta =
+let register_offline_for_testing ~base_path name meta =
+  persist_test_board_cursor ~base_path ~keeper_name:name;
   let conditions =
     { Keeper_state_machine.default_conditions with
       launch_pending = true
@@ -696,6 +741,10 @@ type register_restarting_error =
       { keeper_name : string
       ; detail : string
       }
+  | Restart_board_cursor_unavailable of
+      { keeper_name : string
+      ; reason : board_cursor_registration_error
+      }
 
 let register_restarting ~base_path name meta
   : (registry_entry, register_restarting_error) result
@@ -728,6 +777,10 @@ let register_restarting ~base_path name meta
   with
   | Error detail -> Error (Restart_event_queue_unavailable { keeper_name = name; detail })
   | Ok initial_event_queue ->
+  (match load_board_cursor_result ~base_path ~keeper_name:name with
+  | Error reason ->
+    Error (Restart_board_cursor_unavailable { keeper_name = name; reason })
+  | Ok board_cursor ->
   let new_entry =
     { base_path
     ; name
@@ -752,8 +805,7 @@ let register_restarting ~base_path name meta
     ; turn_attempt_state = Atomic.make None
     ; current_turn_switch = Atomic.make None
     ; board_wakeups = StringMap.empty
-    ; board_cursor_ts = 0.0
-    ; board_cursor_post_id = None
+    ; board_cursor
     ; tool_usage = StringMap.empty
     ; transition_seq = 0
     ; waiting_for_inference = Atomic.make false
@@ -798,6 +850,7 @@ let register_restarting ~base_path name meta
       base_path
       (Keeper_state_machine.phase_to_string phase);
     Ok registered
+  )
 ;;
 
 type unregister_exact_result =

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -124,8 +124,7 @@ type registry_entry =
   ; turn_attempt_state : turn_attempt_state option Atomic.t
   ; current_turn_switch : Eio.Switch.t option Atomic.t
   ; board_wakeups : float StringMap.t
-  ; board_cursor_ts : float
-  ; board_cursor_post_id : string option
+  ; board_cursor : float * string option
   ; tool_usage : tool_call_entry StringMap.t
   ; transition_seq : int
   ; waiting_for_inference : bool Atomic.t

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -407,8 +407,9 @@ type registry_entry = {
       (** Live turn-scoped switch exposed for operator interrupt.
           [Some sw] while a turn is running; [None] otherwise. *)
   board_wakeups : float StringMap.t;
-  board_cursor_ts : float;
-  board_cursor_post_id : string option;
+  board_cursor : float * string option;
+      (** Restored durable Board cursor. [(0.0, None)] is the valid empty
+          Board head. A registered entry cannot represent a missing cursor. *)
   tool_usage : Keeper_types.tool_call_entry StringMap.t;
   transition_seq : int;
   waiting_for_inference : bool Atomic.t;

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -293,6 +293,17 @@ let sweep_and_recover ~load_or_materialize_keeper_meta (ctx : _ context)
               Keeper_metrics.(to_string RestartOutcomes)
               ~labels:[ "keeper", keeper_name; "outcome", "event_queue_unavailable" ]
               ()
+          | Error
+              (Keeper_registry.Restart_board_cursor_unavailable
+                 { keeper_name; reason }) ->
+            Log.Keeper.error
+              "%s: restart refused because durable board cursor is unavailable: %s"
+              keeper_name
+              (Keeper_registry.board_cursor_registration_error_to_string reason);
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string RestartOutcomes)
+              ~labels:[ "keeper", keeper_name; "outcome", "board_cursor_unavailable" ]
+              ()
           | Ok reg ->
             Keeper_registry.restore_supervisor_state
               ~base_path

--- a/lib/keeper/keeper_supervisor_supervise_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.ml
@@ -139,11 +139,23 @@ let supervise_keepalive
   in
   let register_and_launch () =
     match
-      Keeper_registry.register_offline_if_admitted
+      Keeper_board_cursor_genesis.ensure
         ~base_path
-        meta.name
-        meta
+        ~keeper_name:meta.name
+        ()
     with
+    | Error error ->
+      Log.Keeper.error
+        "supervisor Board cursor genesis failed keeper=%s: %s"
+        meta.name
+        (Keeper_board_cursor_genesis.error_to_string error)
+    | Ok () ->
+    (match
+       Keeper_registry.register_offline_if_admitted
+         ~base_path
+         meta.name
+         meta
+     with
     | Error (Keeper_registry.Registration_shutdown_reserved operation_id) ->
       Log.Keeper.warn
         "supervisor launch skipped %s because shutdown operation %s owns admission"
@@ -164,7 +176,14 @@ let supervise_keepalive
         "supervisor registry event queue unavailable keeper=%s: %s"
         keeper_name
         detail
-    | Ok reg -> launch_registered reg
+    | Error
+        (Keeper_registry.Registration_board_cursor_unavailable
+           { keeper_name; reason }) ->
+      Log.Keeper.error
+        "supervisor registry board cursor unavailable keeper=%s: %s"
+        keeper_name
+        (Keeper_registry.board_cursor_registration_error_to_string reason)
+    | Ok reg -> launch_registered reg)
   in
   match execution_truth with
   | Keeper_activation_readiness.Unknown detail ->

--- a/lib/keeper/keeper_supervisor_supervise_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.ml
@@ -139,23 +139,11 @@ let supervise_keepalive
   in
   let register_and_launch () =
     match
-      Keeper_board_cursor_genesis.ensure
+      Keeper_registry.register_offline_if_admitted
         ~base_path
-        ~keeper_name:meta.name
-        ()
-    with
-    | Error error ->
-      Log.Keeper.error
-        "supervisor Board cursor genesis failed keeper=%s: %s"
         meta.name
-        (Keeper_board_cursor_genesis.error_to_string error)
-    | Ok () ->
-    (match
-       Keeper_registry.register_offline_if_admitted
-         ~base_path
-         meta.name
-         meta
-     with
+        meta
+    with
     | Error (Keeper_registry.Registration_shutdown_reserved operation_id) ->
       Log.Keeper.warn
         "supervisor launch skipped %s because shutdown operation %s owns admission"
@@ -183,7 +171,7 @@ let supervise_keepalive
         "supervisor registry board cursor unavailable keeper=%s: %s"
         keeper_name
         (Keeper_registry.board_cursor_registration_error_to_string reason)
-    | Ok reg -> launch_registered reg)
+    | Ok reg -> launch_registered reg
   in
   match execution_truth with
   | Keeper_activation_readiness.Unknown detail ->

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -53,6 +53,10 @@ type 'a registration_commit_result =
   | Registration_committed of 'a
   | Registration_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
 
+type 'a durable_effect_result =
+  | Durable_effect_committed of 'a
+  | Durable_effect_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
+
 type slot_snapshot =
   { snapshot_keeper_name : string
   ; snapshot_slot_created : bool
@@ -122,9 +126,10 @@ type slot =
        fiber-cooperative, hence Eio.Mutex. Manipulated with raw
        lock/try_lock/unlock — [use_rw] would poison the slot when a turn
        raises, deadlocking the keeper forever. *)
-  ; intake_mu : Eio.Mutex.t
-    (* Serializes durable external intake with shutdown join. Unlike
-       [state_mu], callers may suspend while holding this cooperative mutex. *)
+  ; durable_effect_mu : Eio.Mutex.t
+    (* Serializes suspending durable mutations whose state shutdown cleanup
+       may delete. [begin_shutdown] closes admission under [state_mu], then
+       [await_idle_after_shutdown] joins this cooperative mutex. *)
   ; state_mu : Stdlib.Mutex.t
     (* Guards [info]/[waiting]. Critical sections never yield, so the
        non-cooperative mutex is the right choice here. *)
@@ -207,7 +212,7 @@ let slot_for ~base_path ~keeper_name =
         { base_path
         ; keeper_name
         ; turn_mu = Eio.Mutex.create ()
-        ; intake_mu = Eio.Mutex.create ()
+        ; durable_effect_mu = Eio.Mutex.create ()
         ; state_mu = Stdlib.Mutex.create ()
         ; info = None
         ; waiting = 0
@@ -453,30 +458,26 @@ let commit_registration_if_open ~base_path ~keeper_name commit =
     | None -> Registration_committed (commit ()))
 ;;
 
-type 'a durable_intake_result =
-  | Intake_committed of 'a
-  | Intake_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
-
 type 'a transfer_intake_result =
   | Transfer_intake_committed of 'a
   | Transfer_intake_source_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
   | Transfer_intake_target_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
 
-let run_durable_intake_if_open ~base_path ~keeper_name intake =
+let run_durable_effect_if_open ~base_path ~keeper_name durable_mutation =
   let slot = slot_for ~base_path ~keeper_name in
-  Eio.Mutex.lock slot.intake_mu;
-  let release () = Eio.Mutex.unlock slot.intake_mu in
+  Eio.Mutex.lock slot.durable_effect_mu;
+  let release () = Eio.Mutex.unlock slot.durable_effect_mu in
   match peek_shutdown slot with
   | Some operation_id ->
     release ();
-    Intake_shutdown_reserved operation_id
+    Durable_effect_shutdown_reserved operation_id
   | None ->
     let intake_token = { intake_slot = slot; intake_active = true } in
-    (match intake intake_token with
+    (match durable_mutation intake_token with
      | value ->
        intake_token.intake_active <- false;
        release ();
-       Intake_committed value
+       Durable_effect_committed value
      | exception exn ->
        intake_token.intake_active <- false;
        release ();
@@ -491,7 +492,7 @@ let run_transfer_intake_if_open
   =
   let acquire_source_then_target () =
     match
-      run_durable_intake_if_open
+      run_durable_effect_if_open
         ~base_path
         ~keeper_name:from_keeper
         (fun source_intake_token ->
@@ -503,39 +504,39 @@ let run_transfer_intake_if_open
                   ~target_intake_token:source_intake_token)
            else
              match
-               run_durable_intake_if_open
+               run_durable_effect_if_open
                  ~base_path
                  ~keeper_name:to_keeper
                  (fun target_intake_token ->
                     operation ~source_intake_token ~target_intake_token)
              with
-             | Intake_committed result -> Transfer_intake_committed result
-             | Intake_shutdown_reserved operation_id ->
+             | Durable_effect_committed result -> Transfer_intake_committed result
+             | Durable_effect_shutdown_reserved operation_id ->
                Transfer_intake_target_shutdown_reserved operation_id)
     with
-    | Intake_committed result -> result
-    | Intake_shutdown_reserved operation_id ->
+    | Durable_effect_committed result -> result
+    | Durable_effect_shutdown_reserved operation_id ->
       Transfer_intake_source_shutdown_reserved operation_id
   in
   let acquire_target_then_source () =
     match
-      run_durable_intake_if_open
+      run_durable_effect_if_open
         ~base_path
         ~keeper_name:to_keeper
         (fun target_intake_token ->
            match
-             run_durable_intake_if_open
+             run_durable_effect_if_open
                ~base_path
                ~keeper_name:from_keeper
                (fun source_intake_token ->
                   operation ~source_intake_token ~target_intake_token)
            with
-           | Intake_committed result -> Transfer_intake_committed result
-           | Intake_shutdown_reserved operation_id ->
+           | Durable_effect_committed result -> Transfer_intake_committed result
+           | Durable_effect_shutdown_reserved operation_id ->
              Transfer_intake_source_shutdown_reserved operation_id)
     with
-    | Intake_committed result -> result
-    | Intake_shutdown_reserved operation_id ->
+    | Durable_effect_committed result -> result
+    | Durable_effect_shutdown_reserved operation_id ->
       Transfer_intake_target_shutdown_reserved operation_id
   in
   if String.compare from_keeper to_keeper <= 0
@@ -552,8 +553,8 @@ let await_idle_after_shutdown ~base_path ~keeper_name =
   let slot = slot_for ~base_path ~keeper_name in
   Eio.Mutex.lock slot.turn_mu;
   Eio.Mutex.unlock slot.turn_mu;
-  Eio.Mutex.lock slot.intake_mu;
-  Eio.Mutex.unlock slot.intake_mu
+  Eio.Mutex.lock slot.durable_effect_mu;
+  Eio.Mutex.unlock slot.durable_effect_mu
 ;;
 
 let chat_waiting ~base_path ~keeper_name =

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -123,9 +123,9 @@ type slot =
   ; keeper_name : string
   ; turn_mu : Eio.Mutex.t
     (* Held across the whole admitted turn (possibly minutes): must be
-       fiber-cooperative, hence Eio.Mutex. Manipulated with raw
-       lock/try_lock/unlock — [use_rw] would poison the slot when a turn
-       raises, deadlocking the keeper forever. *)
+       fiber-cooperative, hence Eio.Mutex. Admitted turns use raw
+       lock/try_lock/unlock — [use_rw] would poison the slot when a turn raises,
+       deadlocking the keeper forever. *)
   ; durable_effect_mu : Eio.Mutex.t
     (* Serializes suspending durable mutations whose state shutdown cleanup
        may delete. [begin_shutdown] closes admission under [state_mu], then
@@ -465,23 +465,14 @@ type 'a transfer_intake_result =
 
 let run_durable_effect_if_open ~base_path ~keeper_name durable_mutation =
   let slot = slot_for ~base_path ~keeper_name in
-  Eio.Mutex.lock slot.durable_effect_mu;
-  let release () = Eio.Mutex.unlock slot.durable_effect_mu in
-  match peek_shutdown slot with
-  | Some operation_id ->
-    release ();
-    Durable_effect_shutdown_reserved operation_id
-  | None ->
-    let intake_token = { intake_slot = slot; intake_active = true } in
-    (match durable_mutation intake_token with
-     | value ->
-       intake_token.intake_active <- false;
-       release ();
-       Durable_effect_committed value
-     | exception exn ->
-       intake_token.intake_active <- false;
-       release ();
-       raise exn)
+  Eio.Mutex.use_ro slot.durable_effect_mu (fun () ->
+    match peek_shutdown slot with
+    | Some operation_id -> Durable_effect_shutdown_reserved operation_id
+    | None ->
+      let intake_token = { intake_slot = slot; intake_active = true } in
+      Fun.protect
+        ~finally:(fun () -> intake_token.intake_active <- false)
+        (fun () -> Durable_effect_committed (durable_mutation intake_token)))
 ;;
 
 let run_transfer_intake_if_open
@@ -551,10 +542,8 @@ let intake_token_matches token ~base_path ~keeper_name =
 
 let await_idle_after_shutdown ~base_path ~keeper_name =
   let slot = slot_for ~base_path ~keeper_name in
-  Eio.Mutex.lock slot.turn_mu;
-  Eio.Mutex.unlock slot.turn_mu;
-  Eio.Mutex.lock slot.durable_effect_mu;
-  Eio.Mutex.unlock slot.durable_effect_mu
+  Eio.Mutex.use_ro slot.turn_mu (fun () -> ());
+  Eio.Mutex.use_ro slot.durable_effect_mu (fun () -> ())
 ;;
 
 let chat_waiting ~base_path ~keeper_name =

--- a/lib/keeper/keeper_turn_admission.mli
+++ b/lib/keeper/keeper_turn_admission.mli
@@ -80,9 +80,9 @@ type 'a registration_commit_result =
   | Registration_committed of 'a
   | Registration_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
 
-type 'a durable_intake_result =
-  | Intake_committed of 'a
-  | Intake_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
+type 'a durable_effect_result =
+  | Durable_effect_committed of 'a
+  | Durable_effect_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
 
 type 'a transfer_intake_result =
   | Transfer_intake_committed of 'a
@@ -91,7 +91,7 @@ type 'a transfer_intake_result =
 
 type intake_token
 (** Opaque authority for one currently admitted durable intake. The token is
-    valid only inside the callback passed to [run_durable_intake_if_open]. *)
+    valid only inside the callback passed to [run_durable_effect_if_open]. *)
 
 type slot_snapshot =
   { snapshot_keeper_name : string
@@ -273,15 +273,21 @@ val commit_registration_if_open :
   (unit -> 'a) ->
   'a registration_commit_result
 
-(** Serialize one suspending durable intake effect with shutdown join. The
-    shutdown fence is checked after the intake mutex is acquired: intake that
-    wins commits before [await_idle_after_shutdown] returns, while a shutdown
-    that wins prevents the effect from starting. *)
-val run_durable_intake_if_open :
+(** Serialize a suspending durable Keeper mutation while admission remains
+    open. This boundary is for mutations whose state shutdown cleanup may
+    delete, including registration genesis and external queue intake. The
+    closure runs under one fiber-cooperative mutex and never while [state_mu]
+    is held. A shutdown that linearizes first rejects the closure; a durable
+    mutation that linearizes first finishes before [await_idle_after_shutdown]
+    returns.
+
+    Callers that also own the lifecycle key lock must acquire that lock before
+    this function, preserving lifecycle-key -> admission lock order. *)
+val run_durable_effect_if_open :
   base_path:string ->
   keeper_name:string ->
   (intake_token -> 'a) ->
-  'a durable_intake_result
+  'a durable_effect_result
 
 (** Hold both source and target durable-intake fences in canonical Keeper-name
     order for one transfer effect. Opposing A-to-B and B-to-A operations
@@ -304,10 +310,10 @@ val intake_token_matches :
   bool
 (** [true] only for a live token belonging to the requested Keeper. *)
 
-(** Join the current turn holder and any durable external intake after
+(** Join the current turn holder and any guarded durable mutation after
     admission has been closed. This waits without an invented timeout, then
     immediately releases both slots. Never call from the same admitted turn
-    or intake. *)
+    or guarded durable mutation. *)
 val await_idle_after_shutdown : base_path:string -> keeper_name:string -> unit
 
 val snapshot_for : base_path:string -> keeper_name:string -> slot_snapshot

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -398,7 +398,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
                 | ( Keepalive_already_registered _
                   | Keepalive_lifecycle_denied _
                   | Keepalive_identity_unrepairable
-                  | Keepalive_board_cursor_genesis_failed _
                   | Keepalive_registration_rejected _
                   | Keepalive_fiber_start_rejected _
                   | Keepalive_lane_ownership_lost

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -24,7 +24,7 @@ let write_initial_meta config meta =
 let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
   Log.Keeper.info "create_keeper: starting for name=%s" p.name;
   let task_id = Printf.sprintf "keeper_create_%s" p.name in
-  let tracker = Progress.start_tracking ~task_id ~total_steps:7 () in
+  let tracker = Progress.start_tracking ~task_id ~total_steps:8 () in
   Progress.Tracker.step tracker ~message:"Resolving keeper configuration" ();
   let now_ts = Time_compat.now () in
   let autoboot_enabled =
@@ -335,44 +335,76 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
          tool_result_error
            (Printf.sprintf "declarative keeper config write failed: %s" e)
        | Ok _ ->
-      Progress.Tracker.step tracker ~message:"Writing keeper metadata" ();
-      match write_initial_meta ctx.config meta with
-      | Error e ->
-        Otel_metric_store.inc_counter Keeper_metrics.(to_string WriteMetaFailures)
-          ~labels:[("keeper", p.name); ("phase", "create_keeper")] ();
-        Log.Keeper.error "create_keeper failed: write_meta error for name=%s: %s" p.name e;
-        Progress.stop_tracking task_id;
-        tool_result_error e
-      | Ok () ->
-        Log.Keeper.debug "create_keeper: metadata written for name=%s trace_id=%s"
-          p.name (Keeper_id.Trace_id.to_string meta.runtime.trace_id);
-        Progress.Tracker.step tracker ~message:"Starting keepalive loop" ();
-        Log.Keeper.info "create_keeper: starting keepalive for name=%s" p.name;
-        let launch_outcome = start_keepalive ctx meta in
-        (match launch_outcome with
-         | Keepalive_started _ ->
-        Progress.Tracker.complete tracker ~message:"Keeper created" ();
-        Log.Keeper.info "create_keeper: completed for name=%s trace_id=%s" p.name (Keeper_id.Trace_id.to_string meta.runtime.trace_id);
-        let json = `Assoc [
-          ("name", `String meta.name);
-          ("agent_name", `String meta.agent_name);
-          ("trace_id", `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id));
-          ("generation", `Int meta.runtime.nonce);
-          ("instructions", `String meta.instructions);
-          ("proactive_enabled", `Bool meta.proactive.enabled);
-          ("max_context_override", Json_util.int_opt_to_json meta.max_context_override);
-          ("oas_env", `Assoc (List.map (fun (k, v) -> (k, `String v)) meta.oas_env));
-        ] in
-        tool_result_ok_data json
-         | ( Keepalive_already_registered _
-           | Keepalive_lifecycle_denied _
-           | Keepalive_identity_unrepairable
-           | Keepalive_registration_rejected _
-           | Keepalive_fiber_start_rejected _
-           | Keepalive_lane_ownership_lost
-           | Keepalive_fork_rejected _ ) as rejected ->
-           Progress.stop_tracking task_id;
-           tool_result_error
-             (Printf.sprintf
-                "keeper metadata was created but lane launch failed: %s"
-                (start_keepalive_outcome_to_string rejected)))))
+         Progress.Tracker.step tracker ~message:"Persisting initial Board cursor" ();
+         (match
+            Keeper_board_cursor_genesis.ensure
+              ~base_path:ctx.config.base_path
+              ~keeper_name:p.name
+              ()
+          with
+          | Error error ->
+            let detail = Keeper_board_cursor_genesis.error_to_string error in
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string LifecycleDispatchRejections)
+              ~labels:[ "keeper", p.name; "event", "create_board_cursor_persistence" ]
+              ();
+            Log.Keeper.error
+              "create_keeper failed: initial board cursor persistence error for name=%s: %s"
+              p.name
+              detail;
+            Progress.stop_tracking task_id;
+            tool_result_error
+              (Printf.sprintf
+                 "initial board cursor persistence failed before metadata creation: %s"
+                 detail)
+          | Ok () ->
+            Progress.Tracker.step tracker ~message:"Writing keeper metadata" ();
+            (match write_initial_meta ctx.config meta with
+             | Error e ->
+               Otel_metric_store.inc_counter Keeper_metrics.(to_string WriteMetaFailures)
+                 ~labels:[("keeper", p.name); ("phase", "create_keeper")] ();
+               Log.Keeper.error
+                 "create_keeper failed: write_meta error for name=%s: %s"
+                 p.name
+                 e;
+               Progress.stop_tracking task_id;
+               tool_result_error e
+             | Ok () ->
+               Log.Keeper.debug
+                 "create_keeper: metadata written for name=%s trace_id=%s"
+                 p.name
+                 (Keeper_id.Trace_id.to_string meta.runtime.trace_id);
+               Progress.Tracker.step tracker ~message:"Starting keepalive loop" ();
+               Log.Keeper.info "create_keeper: starting keepalive for name=%s" p.name;
+               let launch_outcome = start_keepalive ctx meta in
+               (match launch_outcome with
+                | Keepalive_started _ ->
+                  Progress.Tracker.complete tracker ~message:"Keeper created" ();
+                  Log.Keeper.info
+                    "create_keeper: completed for name=%s trace_id=%s"
+                    p.name
+                    (Keeper_id.Trace_id.to_string meta.runtime.trace_id);
+                  let json = `Assoc [
+                    ("name", `String meta.name);
+                    ("agent_name", `String meta.agent_name);
+                    ("trace_id", `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id));
+                    ("generation", `Int meta.runtime.nonce);
+                    ("instructions", `String meta.instructions);
+                    ("proactive_enabled", `Bool meta.proactive.enabled);
+                    ("max_context_override", Json_util.int_opt_to_json meta.max_context_override);
+                    ("oas_env", `Assoc (List.map (fun (k, v) -> (k, `String v)) meta.oas_env));
+                  ] in
+                  tool_result_ok_data json
+                | ( Keepalive_already_registered _
+                  | Keepalive_lifecycle_denied _
+                  | Keepalive_identity_unrepairable
+                  | Keepalive_board_cursor_genesis_failed _
+                  | Keepalive_registration_rejected _
+                  | Keepalive_fiber_start_rejected _
+                  | Keepalive_lane_ownership_lost
+                  | Keepalive_fork_rejected _ ) as rejected ->
+                  Progress.stop_tracking task_id;
+                  tool_result_error
+                    (Printf.sprintf
+                       "keeper metadata was created but lane launch failed: %s"
+                       (start_keepalive_outcome_to_string rejected)))))))

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -401,7 +401,6 @@ let update_keeper ?(preserve_prompt_defaults = false)
                           (Keepalive_already_registered entry)))
                 | ( Keepalive_lifecycle_denied _
                   | Keepalive_identity_unrepairable
-                  | Keepalive_board_cursor_genesis_failed _
                   | Keepalive_registration_rejected _
                   | Keepalive_fiber_start_rejected _
                   | Keepalive_lane_ownership_lost

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -401,6 +401,7 @@ let update_keeper ?(preserve_prompt_defaults = false)
                           (Keepalive_already_registered entry)))
                 | ( Keepalive_lifecycle_denied _
                   | Keepalive_identity_unrepairable
+                  | Keepalive_board_cursor_genesis_failed _
                   | Keepalive_registration_rejected _
                   | Keepalive_fiber_start_rejected _
                   | Keepalive_lane_ownership_lost

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -801,7 +801,7 @@ let pending_board_event_of_stimulus
 ;;
 
 (** Collect recent board activity using cursor-based tracking.
-    Cursor state lives in Keeper_registry as [(updated_at, post_id)].
+    Cursor state is restored into Keeper_registry as [(updated_at, post_id)].
     Returns (structured events, new post count, mention count).
 
     Comment-stream dedup: after the initial cursor + author filter,
@@ -816,31 +816,8 @@ let collect_board_events_with_cursor_policy
   : pending_board_event list * int * int
   =
   try
-    let cursor_ts, cursor_post_id =
-      Keeper_registry.get_board_cursor ~base_path meta.name
-    in
     let base_cursor =
-      if cursor_ts > 0.0
-      then Some (cursor_ts, cursor_post_id)
-      else (
-        let initial_cursor = Board_dispatch.current_post_cursor () in
-        if advance_cursor
-        then (
-          let ts, post_id = initial_cursor in
-          Keeper_registry.set_board_cursor ~base_path meta.name ts post_id;
-          (match post_id with
-           | Some post_id ->
-             Log.Keeper.info
-               "board cursor initialized at current head for %s: (%f, %s)"
-               meta.name
-               ts
-               post_id
-           | None ->
-             Log.Keeper.info
-               "board cursor initialized at empty current head for %s: (%f, no post)"
-               meta.name
-               ts));
-        None)
+      Keeper_registry.get_board_cursor ~base_path meta.name
     in
     let posts =
       match base_cursor with
@@ -1068,7 +1045,6 @@ let collect_board_events_with_cursor_policy
         Keeper_reaction_ledger.record_board_cursor_ack
           ~base_path
           ~keeper_name:meta.name
-          ~stimulus_id:(Keeper_reaction_ledger.board_stimulus_id ~post_id)
           ~cursor_ts:ts
           ~post_id:(Some post_id)
           ();

--- a/lib/keeper_schedule_creation_admission.ml
+++ b/lib/keeper_schedule_creation_admission.ml
@@ -1,12 +1,12 @@
 let run config ~keeper_name create =
   match
-    Keeper_turn_admission.run_durable_intake_if_open
+    Keeper_turn_admission.run_durable_effect_if_open
       ~base_path:config.Workspace.base_path
       ~keeper_name
       (fun _intake_token -> create ())
   with
-  | Keeper_turn_admission.Intake_committed result -> result
-  | Keeper_turn_admission.Intake_shutdown_reserved operation_id ->
+  | Keeper_turn_admission.Durable_effect_committed result -> result
+  | Keeper_turn_admission.Durable_effect_shutdown_reserved operation_id ->
     Error
       (Schedule_service.Creation_rejected
          (Printf.sprintf

--- a/lib/server/server_schedule_consumers.ml
+++ b/lib/server/server_schedule_consumers.ml
@@ -1051,13 +1051,13 @@ let dispatch_keeper_wake
            })
   in
   match
-    Keeper_turn_admission.run_durable_intake_if_open
+    Keeper_turn_admission.run_durable_effect_if_open
       ~base_path
       ~keeper_name:intake_owner
       dispatch_while_fenced
   with
-  | Keeper_turn_admission.Intake_committed result -> result
-  | Keeper_turn_admission.Intake_shutdown_reserved operation_id ->
+  | Keeper_turn_admission.Durable_effect_committed result -> result
+  | Keeper_turn_admission.Durable_effect_shutdown_reserved operation_id ->
     retryable_dispatch_failure
       (Printf.sprintf
          "scheduled keeper wake rejected by shutdown fence keeper=%s operation=%s"

--- a/scripts/check-deploy-cutover-gates.sh
+++ b/scripts/check-deploy-cutover-gates.sh
@@ -10,10 +10,18 @@ fail() {
 fixture_root="$(mktemp -d "${TMPDIR:-/tmp}/deploy-cutover-gates.XXXXXX")"
 trap 'rm -rf "$fixture_root"' EXIT
 
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+real_board_cursor_checker="$repo_root/_build/default/bin/keeper_board_cursor_cutover_check.exe"
+
 mkdir -p \
     "$fixture_root/scripts" \
     "$fixture_root/_build/default/bin" \
-    "$fixture_root/base/.masc"
+    "$fixture_root/base/.masc/keepers"
+
+[ -x "$real_board_cursor_checker" ] \
+    || fail "real Board cursor cutover checker is not built: $real_board_cursor_checker"
+"$real_board_cursor_checker" --base-path "$fixture_root/base" >/dev/null \
+    || fail "empty canonical Keeper set was not vacuously ready"
 cp "$(dirname "${BASH_SOURCE[0]}")/deploy.sh" "$fixture_root/scripts/deploy.sh"
 
 cat >"$fixture_root/_build/default/bin/main_eio.exe" <<'EOF'

--- a/scripts/check-deploy-cutover-gates.sh
+++ b/scripts/check-deploy-cutover-gates.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -euo pipefail
+
+fail() {
+    echo "[deploy-cutover-gates] $*" >&2
+    exit 1
+}
+
+fixture_root="$(mktemp -d "${TMPDIR:-/tmp}/deploy-cutover-gates.XXXXXX")"
+trap 'rm -rf "$fixture_root"' EXIT
+
+mkdir -p \
+    "$fixture_root/scripts" \
+    "$fixture_root/_build/default/bin" \
+    "$fixture_root/base/.masc"
+cp "$(dirname "${BASH_SOURCE[0]}")/deploy.sh" "$fixture_root/scripts/deploy.sh"
+
+cat >"$fixture_root/_build/default/bin/main_eio.exe" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+
+cat >"$fixture_root/_build/default/bin/keeper_event_queue_v15_cutover_helper.exe" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+
+cat >"$fixture_root/scripts/check-keeper-event-queue-v15-cutover.sh" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+printf 'event_queue\n' >>"$CUTOVER_TRACE"
+EOF
+
+cat >"$fixture_root/_build/default/bin/keeper_board_cursor_cutover_check.exe" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+printf 'board_cursor\n' >>"$CUTOVER_TRACE"
+if [ "${BOARD_CURSOR_CUTOVER_FAIL:-0}" = "1" ]; then
+    exit 2
+fi
+EOF
+
+chmod +x \
+    "$fixture_root/scripts/deploy.sh" \
+    "$fixture_root/scripts/check-keeper-event-queue-v15-cutover.sh" \
+    "$fixture_root/_build/default/bin/main_eio.exe" \
+    "$fixture_root/_build/default/bin/keeper_event_queue_v15_cutover_helper.exe" \
+    "$fixture_root/_build/default/bin/keeper_board_cursor_cutover_check.exe"
+
+trace_path="$fixture_root/cutover.trace"
+export CUTOVER_TRACE="$trace_path"
+MASC_BASE_PATH="$fixture_root/base" \
+MASC_EVENT_QUEUE_V15_CUTOVER_LEASE_OWNER_PID="$$" \
+    "$fixture_root/scripts/deploy.sh" \
+    --skip-build \
+    --prepare-under-cutover-lease
+
+expected_trace=$'event_queue\nboard_cursor'
+actual_trace="$(cat "$trace_path")"
+[ "$actual_trace" = "$expected_trace" ] \
+    || fail "cutover gates ran out of order: $actual_trace"
+[ -x "$fixture_root/releases/main_eio.exe" ] \
+    || fail "release was not installed after both cutover gates passed"
+
+rm -f "$fixture_root/releases/main_eio.exe" "$trace_path"
+if BOARD_CURSOR_CUTOVER_FAIL=1 \
+    MASC_BASE_PATH="$fixture_root/base" \
+    MASC_EVENT_QUEUE_V15_CUTOVER_LEASE_OWNER_PID="$$" \
+    "$fixture_root/scripts/deploy.sh" \
+    --skip-build \
+    --prepare-under-cutover-lease; then
+    fail "deployment continued after the Board cursor cutover gate failed"
+fi
+[ ! -e "$fixture_root/releases/main_eio.exe" ] \
+    || fail "release was installed after the Board cursor cutover gate failed"
+
+printf '[deploy-cutover-gates] self-test OK\n'

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -77,12 +77,14 @@ if [ "$SKIP_BUILD" = false ]; then
     "$REPO_DIR/scripts/dune-local.sh" build \
         bin/main_eio.exe \
         bin/keeper_event_queue_v15_cutover_helper.exe \
+        bin/keeper_board_cursor_cutover_check.exe \
         2>&1
     echo "    Build complete." >&2
 fi
 
 BUILD_EXE="$REPO_DIR/_build/default/bin/main_eio.exe"
 BUILD_CUTOVER_HELPER="$REPO_DIR/_build/default/bin/keeper_event_queue_v15_cutover_helper.exe"
+BUILD_BOARD_CURSOR_CUTOVER_CHECK="$REPO_DIR/_build/default/bin/keeper_board_cursor_cutover_check.exe"
 if [ ! -x "$BUILD_EXE" ]; then
     echo "Error: Build artifact not found at $BUILD_EXE" >&2
     exit 1
@@ -91,11 +93,17 @@ if [ ! -x "$BUILD_CUTOVER_HELPER" ]; then
     echo "Error: Event-queue cutover helper not found at $BUILD_CUTOVER_HELPER" >&2
     exit 1
 fi
+if [ ! -x "$BUILD_BOARD_CURSOR_CUTOVER_CHECK" ]; then
+    echo "Error: Board-cursor cutover check not found at $BUILD_BOARD_CURSOR_CUTOVER_CHECK" >&2
+    exit 1
+fi
 
 prepare_release_under_cutover_lease() {
     MASC_EVENT_QUEUE_V15_CUTOVER_HELPER="$BUILD_CUTOVER_HELPER" \
         "$SCRIPT_DIR/check-keeper-event-queue-v15-cutover.sh" \
         --base-path "$BASE_PATH"
+
+    "$BUILD_BOARD_CURSOR_CUTOVER_CHECK" --base-path "$BASE_PATH"
 
     mkdir -p "$RELEASE_DIR"
     if [ -f "$RELEASE_EXE" ]; then

--- a/test/stanzas/test_keeper_keepalive_helpers.inc
+++ b/test/stanzas/test_keeper_keepalive_helpers.inc
@@ -1,4 +1,4 @@
 (test
  (name test_keeper_keepalive_helpers)
  (modules test_keeper_keepalive_helpers)
- (libraries masc masc.config masc.keeper_metrics masc.keeper_runtime masc_workspace masc_types masc.keeper_registry alcotest eio eio_main unix))
+ (libraries masc_test_deps masc.config masc.keeper_metrics masc.keeper_runtime masc_workspace masc_types masc.keeper_registry alcotest eio eio_main unix))

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -2430,6 +2430,23 @@ let () =
         (with_eio test_list_posts_negative_limit_returns_empty);
       Alcotest.test_case "sort orders" `Quick (with_eio test_list_posts_with_sort);
       Alcotest.test_case
+        "dashboard projection does not produce attention candidate"
+        `Quick
+        (with_eio test_dashboard_projection_does_not_produce_attention_candidate);
+      Alcotest.test_case "recent bypasses hot cutoff" `Quick
+        (with_eio test_recent_sort_bypasses_hot_cutoff);
+      Alcotest.test_case "filters" `Quick (with_eio test_list_posts_with_filters);
+      Alcotest.test_case "comment author filter" `Quick
+        (with_eio test_list_posts_matches_comment_author);
+      Alcotest.test_case "literal wildcard filter" `Quick
+        (with_eio test_author_filter_treats_wildcards_literally);
+      Alcotest.test_case "author match precedes recent result limit" `Quick
+        (with_eio test_recent_author_match_applies_before_limit);
+      Alcotest.test_case "legacy post without kind is rejected" `Quick
+        (with_eio test_legacy_post_without_kind_is_rejected);
+    ];
+    "board_cursor", [
+      Alcotest.test_case
         "durable cursor starts at creation head"
         `Quick
         (with_eio test_durable_board_cursor_starts_at_creation_head);
@@ -2453,21 +2470,6 @@ let () =
         "initial cursor requires lifecycle owner"
         `Quick
         (with_eio test_initial_cursor_requires_lifecycle_owner);
-      Alcotest.test_case
-        "dashboard projection does not produce attention candidate"
-        `Quick
-        (with_eio test_dashboard_projection_does_not_produce_attention_candidate);
-      Alcotest.test_case "recent bypasses hot cutoff" `Quick
-        (with_eio test_recent_sort_bypasses_hot_cutoff);
-      Alcotest.test_case "filters" `Quick (with_eio test_list_posts_with_filters);
-      Alcotest.test_case "comment author filter" `Quick
-        (with_eio test_list_posts_matches_comment_author);
-      Alcotest.test_case "literal wildcard filter" `Quick
-        (with_eio test_author_filter_treats_wildcards_literally);
-      Alcotest.test_case "author match precedes recent result limit" `Quick
-        (with_eio test_recent_author_match_applies_before_limit);
-      Alcotest.test_case "legacy post without kind is rejected" `Quick
-        (with_eio test_legacy_post_without_kind_is_rejected);
     ];
     "comments", [
       Alcotest.test_case "add and get" `Quick (with_eio test_add_and_get_comments);

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -486,23 +486,20 @@ let test_list_posts_with_sort () =
 
 let board_observation_meta name =
   match
-    Keeper_meta_json_parse.meta_of_json
+    Masc_test_deps.meta_of_json_fixture
       (`Assoc
         [ "name", `String name
         ; "agent_name", `String ("keeper-" ^ name ^ "-agent")
         ; "trace_id", `String ("trace-" ^ name)
-        ; "sandbox_profile", `String "local"
-        ; "network_mode", `String "inherit"
         ])
   with
   | Ok meta -> meta
   | Error message -> Alcotest.failf "board observation meta failed: %s" message
 
-let test_first_board_observation_starts_at_current_head () =
+let test_durable_board_cursor_starts_at_creation_head () =
   let base_path = Sys.getenv "MASC_BASE_PATH" in
   let keeper_name = "cursor-bootstrap" in
   let meta = board_observation_meta keeper_name in
-  ignore (Keeper_registry.For_testing.register ~base_path keeper_name meta);
   Fun.protect
     ~finally:(fun () -> Keeper_registry.For_testing.unregister ~base_path keeper_name)
     (fun () ->
@@ -517,6 +514,23 @@ let test_first_board_observation_starts_at_current_head () =
          | Ok post -> post
          | Error error -> Alcotest.fail (Board.show_board_error error)
        in
+       (match
+          Keeper_board_cursor_genesis.ensure
+            ~base_path
+            ~keeper_name
+            ()
+        with
+        | Ok () -> ()
+        | Error error ->
+          Alcotest.failf
+            "initial Board cursor persistence failed: %s"
+            (Keeper_board_cursor_genesis.error_to_string error));
+       (match Keeper_registry.register_offline_if_admitted ~base_path keeper_name meta with
+        | Ok _ -> ()
+        | Error (Keeper_registry.Registration_board_cursor_unavailable { reason; _ }) ->
+          Alcotest.fail
+            (Keeper_registry.board_cursor_registration_error_to_string reason)
+        | Error _ -> Alcotest.fail "Keeper registration rejected durable Board cursor");
        let events, new_count, mention_count =
          Keeper_world_observation.collect_board_events ~base_path ~meta
        in
@@ -527,7 +541,9 @@ let test_first_board_observation_starts_at_current_head () =
        Alcotest.(check int) "historical post is not counted as new" 0 new_count;
        Alcotest.(check int) "historical mention is not counted" 0 mention_count;
        let cursor_ts, cursor_post_id =
-         Keeper_registry.get_board_cursor ~base_path keeper_name
+         match Keeper_registry.get_board_cursor ~base_path keeper_name with
+         | Some cursor -> cursor
+         | None -> Alcotest.fail "registered Keeper lost its Board cursor"
        in
        Alcotest.(check (float 0.0))
          "cursor starts at exact current Board head"
@@ -562,6 +578,292 @@ let test_first_board_observation_starts_at_current_head () =
            (Board.Post_id.to_string new_post.id)
            event.Keeper_world_observation.post_id
        | _ -> Alcotest.fail "expected exactly one new Board event")
+
+let test_initial_board_cursor_retry_preserves_subscription_head () =
+  let base_path = Sys.getenv "MASC_BASE_PATH" in
+  let keeper_name = "cursor-create-retry" in
+  let create content =
+    match
+      Board_dispatch.create_post
+        ~author:"external-author"
+        ~content
+        ~post_kind:Board.Human_post
+        ()
+    with
+    | Ok post -> post
+    | Error error -> Alcotest.fail (Board.show_board_error error)
+  in
+  let subscription_head = create "subscription head" in
+  let persist () =
+    match
+      Keeper_board_cursor_genesis.ensure
+        ~base_path
+        ~keeper_name
+        ()
+    with
+    | Ok () -> ()
+    | Error error ->
+      Alcotest.failf
+        "initial Board cursor persistence failed: %s"
+        (Keeper_board_cursor_genesis.error_to_string error)
+  in
+  persist ();
+  Unix.sleepf 0.01;
+  ignore (create "post created while metadata write is retried");
+  persist ();
+  match
+    Keeper_reaction_ledger.latest_board_cursor_result ~base_path ~keeper_name
+  with
+  | Ok (Some cursor) ->
+    Alcotest.(check (float 0.0))
+      "retry preserves the original subscription timestamp"
+      subscription_head.updated_at
+      cursor.cursor_ts;
+    Alcotest.(check (option string))
+      "retry preserves the original subscription post"
+      (Some (Board.Post_id.to_string subscription_head.id))
+      cursor.post_id
+  | Ok None -> Alcotest.fail "initial Board cursor disappeared on retry"
+  | Error error ->
+    Alcotest.fail
+      (Keeper_reaction_ledger.board_cursor_restore_error_to_string error)
+
+let test_concurrent_initial_cursor_persistence_samples_once () =
+  let base_path = Sys.getenv "MASC_BASE_PATH" in
+  let keeper_name = "cursor-create-concurrent" in
+  let first_sample_entered, resolve_first_sample_entered = Eio.Promise.create () in
+  let release_first_sample, resolve_release_first_sample = Eio.Promise.create () in
+  let sample_count = Atomic.make 0 in
+  let current_post_cursor () =
+    let sample_index = Atomic.fetch_and_add sample_count 1 in
+    if sample_index = 0
+    then (
+      Eio.Promise.resolve resolve_first_sample_entered ();
+      Eio.Promise.await release_first_sample;
+      10.0, Some "first-head")
+    else 20.0, Some "second-head"
+  in
+  let persist () =
+    Keeper_board_cursor_genesis.ensure_with
+      ~current_post_cursor
+      ~base_path
+      ~keeper_name
+      ()
+  in
+  Eio.Switch.run @@ fun sw ->
+  let first_done, resolve_first_done = Eio.Promise.create () in
+  let second_done, resolve_second_done = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () -> Eio.Promise.resolve resolve_first_done (persist ()));
+  Eio.Promise.await first_sample_entered;
+  Eio.Fiber.fork ~sw (fun () -> Eio.Promise.resolve resolve_second_done (persist ()));
+  Eio.Fiber.yield ();
+  Eio.Promise.resolve resolve_release_first_sample ();
+  let check_result = function
+    | Ok () -> ()
+    | Error error ->
+      Alcotest.failf
+        "initial cursor persistence failed: %s"
+        (Keeper_board_cursor_genesis.error_to_string error)
+  in
+  check_result (Eio.Promise.await first_done);
+  check_result (Eio.Promise.await second_done);
+  Alcotest.(check int) "subscription head sampled exactly once" 1 (Atomic.get sample_count);
+  match Keeper_reaction_ledger.latest_board_cursor_result ~base_path ~keeper_name with
+  | Ok (Some cursor) ->
+    Alcotest.(check (float 0.0)) "first subscription timestamp wins" 10.0 cursor.cursor_ts;
+    Alcotest.(check (option string))
+      "first subscription identity wins"
+      (Some "first-head")
+      cursor.post_id
+  | Ok None -> Alcotest.fail "concurrent initialization lost the durable cursor"
+  | Error error ->
+    Alcotest.fail
+      (Keeper_reaction_ledger.board_cursor_restore_error_to_string error)
+
+let test_initial_cursor_respects_shutdown_fence () =
+  let base_path = Sys.getenv "MASC_BASE_PATH" in
+  let keeper_name = "cursor-shutdown-fence" in
+  let operation_id = Keeper_shutdown_types.Operation_id.generate () in
+  let sampled = Atomic.make false in
+  ignore
+    (Keeper_turn_admission.begin_shutdown
+       ~base_path
+       ~keeper_name
+       ~operation_id
+      : Keeper_turn_admission.begin_shutdown_result);
+  Fun.protect
+    ~finally:(fun () ->
+      ignore
+        (Keeper_turn_admission.rollback_shutdown
+           ~base_path
+           ~keeper_name
+           ~operation_id
+          : Keeper_turn_admission.rollback_shutdown_result))
+    (fun () ->
+       let result =
+         Keeper_board_cursor_genesis.ensure_with
+           ~current_post_cursor:(fun () ->
+             Atomic.set sampled true;
+             42.0, Some "must-not-be-sampled")
+           ~base_path
+           ~keeper_name
+           ()
+       in
+       (match result with
+        | Error (Keeper_board_cursor_genesis.Shutdown_fenced actual) ->
+          Alcotest.(check bool)
+            "shutdown owner is preserved"
+            true
+            (Keeper_shutdown_types.Operation_id.equal actual operation_id)
+        | Error error ->
+          Alcotest.fail
+            ("unexpected cursor genesis error: "
+             ^ Keeper_board_cursor_genesis.error_to_string error)
+        | Ok () -> Alcotest.fail "shutdown-fenced cursor genesis succeeded");
+       Alcotest.(check bool)
+         "shutdown fence prevents Board sampling"
+         false
+         (Atomic.get sampled);
+       match
+         Keeper_reaction_ledger.latest_board_cursor_result
+           ~base_path
+           ~keeper_name
+       with
+       | Ok None -> ()
+       | Ok (Some _) -> Alcotest.fail "shutdown fence allowed a durable cursor write"
+       | Error error ->
+         Alcotest.fail
+           (Keeper_reaction_ledger.board_cursor_restore_error_to_string error))
+
+let test_shutdown_joins_started_initial_cursor () =
+  let base_path = Sys.getenv "MASC_BASE_PATH" in
+  let keeper_name = "cursor-shutdown-contention" in
+  let operation_id = Keeper_shutdown_types.Operation_id.generate () in
+  let sample_entered, resolve_sample_entered = Eio.Promise.create () in
+  let release_sample, resolve_release_sample = Eio.Promise.create () in
+  let idle_joined = Atomic.make false in
+  Fun.protect
+    ~finally:(fun () ->
+      ignore
+        (Keeper_turn_admission.rollback_shutdown
+           ~base_path
+           ~keeper_name
+           ~operation_id
+          : Keeper_turn_admission.rollback_shutdown_result))
+    (fun () ->
+       Eio.Switch.run @@ fun sw ->
+       let genesis_done, resolve_genesis_done = Eio.Promise.create () in
+       let idle_done, resolve_idle_done = Eio.Promise.create () in
+       Eio.Fiber.fork ~sw (fun () ->
+         let result =
+           Keeper_board_cursor_genesis.ensure_with
+             ~current_post_cursor:(fun () ->
+               Eio.Promise.resolve resolve_sample_entered ();
+               Eio.Promise.await release_sample;
+               23.0, Some "contention-head")
+             ~base_path
+             ~keeper_name
+             ()
+         in
+         Eio.Promise.resolve resolve_genesis_done result);
+       Eio.Promise.await sample_entered;
+       (match
+          Keeper_turn_admission.begin_shutdown
+            ~base_path
+            ~keeper_name
+            ~operation_id
+        with
+        | Keeper_turn_admission.Shutdown_reserved _ -> ()
+        | Keeper_turn_admission.Shutdown_already_reserved _ ->
+          Alcotest.fail "unexpected existing shutdown owner");
+       Eio.Fiber.fork ~sw (fun () ->
+         Keeper_turn_admission.await_idle_after_shutdown ~base_path ~keeper_name;
+         Atomic.set idle_joined true;
+         Eio.Promise.resolve resolve_idle_done ());
+       Eio.Fiber.yield ();
+       Eio.Fiber.yield ();
+       Alcotest.(check bool)
+         "shutdown cleanup waits for started cursor genesis"
+         false
+         (Atomic.get idle_joined);
+       Eio.Promise.resolve resolve_release_sample ();
+       (match Eio.Promise.await genesis_done with
+        | Ok () -> ()
+        | Error error ->
+          Alcotest.fail
+            ("started cursor genesis failed: "
+             ^ Keeper_board_cursor_genesis.error_to_string error));
+       Eio.Promise.await idle_done;
+       Alcotest.(check bool)
+         "shutdown cleanup joins cursor genesis"
+         true
+         (Atomic.get idle_joined))
+
+let test_initial_cursor_requires_lifecycle_owner () =
+  let base_path = Sys.getenv "MASC_BASE_PATH" in
+  let keeper_name = "cursor-lifecycle-owner" in
+  let token =
+    match
+      Keeper_lifecycle_reservation.acquire
+        ~base_path
+        ~keeper_name
+        ~expected_generation:0
+        ~purpose:Keeper_lifecycle_reservation.Paused_work_disposition
+    with
+    | Ok token -> token
+    | Error _ -> Alcotest.fail "cursor test could not acquire lifecycle ownership"
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      ignore
+        (Keeper_lifecycle_reservation.release token
+          : Keeper_lifecycle_reservation.release_outcome))
+    (fun () ->
+       let sample () = 17.0, Some "lifecycle-head" in
+       (match
+          Keeper_board_cursor_genesis.ensure_with
+            ~current_post_cursor:sample
+            ~base_path
+            ~keeper_name
+            ()
+        with
+        | Error (Keeper_board_cursor_genesis.Lifecycle_reserved owner) ->
+          Alcotest.(check string)
+            "lifecycle owner is preserved"
+            (Keeper_lifecycle_reservation.owner_id token)
+            owner.owner_id
+        | Error error ->
+          Alcotest.fail
+            ("unexpected cursor genesis error: "
+             ^ Keeper_board_cursor_genesis.error_to_string error)
+        | Ok () -> Alcotest.fail "unowned cursor genesis crossed lifecycle authority");
+       (match
+          Keeper_board_cursor_genesis.ensure_with
+            ~lifecycle_token:token
+            ~current_post_cursor:sample
+            ~base_path
+            ~keeper_name
+            ()
+        with
+        | Ok () -> ()
+        | Error error ->
+          Alcotest.fail
+            ("owned cursor genesis failed: "
+             ^ Keeper_board_cursor_genesis.error_to_string error));
+       match
+         Keeper_reaction_ledger.latest_board_cursor_result
+           ~base_path
+           ~keeper_name
+       with
+       | Ok (Some cursor) ->
+         Alcotest.(check (pair (float 0.0) (option string)))
+           "owned genesis persists the exact cursor"
+           (17.0, Some "lifecycle-head")
+           (cursor.cursor_ts, cursor.post_id)
+       | Ok None -> Alcotest.fail "owned cursor genesis persisted nothing"
+       | Error error ->
+         Alcotest.fail
+           (Keeper_reaction_ledger.board_cursor_restore_error_to_string error))
 
 let test_dashboard_projection_does_not_produce_attention_candidate () =
   let base_path = Sys.getenv "MASC_BASE_PATH" in
@@ -2128,9 +2430,29 @@ let () =
         (with_eio test_list_posts_negative_limit_returns_empty);
       Alcotest.test_case "sort orders" `Quick (with_eio test_list_posts_with_sort);
       Alcotest.test_case
-        "first observation starts at current head"
+        "durable cursor starts at creation head"
         `Quick
-        (with_eio test_first_board_observation_starts_at_current_head);
+        (with_eio test_durable_board_cursor_starts_at_creation_head);
+      Alcotest.test_case
+        "initial cursor retry preserves subscription head"
+        `Quick
+        (with_eio test_initial_board_cursor_retry_preserves_subscription_head);
+      Alcotest.test_case
+        "concurrent initial cursor persistence samples once"
+        `Quick
+        (with_eio test_concurrent_initial_cursor_persistence_samples_once);
+      Alcotest.test_case
+        "initial cursor respects shutdown fence"
+        `Quick
+        (with_eio test_initial_cursor_respects_shutdown_fence);
+      Alcotest.test_case
+        "shutdown joins started initial cursor"
+        `Quick
+        (with_eio test_shutdown_joins_started_initial_cursor);
+      Alcotest.test_case
+        "initial cursor requires lifecycle owner"
+        `Quick
+        (with_eio test_initial_cursor_requires_lifecycle_owner);
       Alcotest.test_case
         "dashboard projection does not produce attention candidate"
         `Quick

--- a/test/test_compaction_exact_output_conformance.ml
+++ b/test/test_compaction_exact_output_conformance.ml
@@ -129,7 +129,7 @@ let ensure_registered_keeper ~base_path keeper_name =
           ])
       |> Result.get_ok
     in
-    ignore (Keeper_registry.register_offline ~base_path keeper_name meta)
+    ignore (Keeper_registry.For_testing.register_offline ~base_path keeper_name meta)
 ;;
 
 let prepare_exn

--- a/test/test_compaction_exact_output_entrypoint_clockless.ml
+++ b/test/test_compaction_exact_output_entrypoint_clockless.ml
@@ -122,7 +122,7 @@ let test_domain_invalid_and_clockless_flow_failure_are_terminal () =
       let meta = make_meta () in
       Masc.Keeper_registry.For_testing.clear ();
       ignore
-        (Masc.Keeper_registry.register_offline
+        (Masc.Keeper_registry.For_testing.register_offline
            ~base_path:exact_flow_base_path
            meta.name
            meta);
@@ -196,7 +196,7 @@ let test_absent_source_authority_is_typed_at_before_dispatch () =
       let meta = make_meta () in
       Masc.Keeper_registry.For_testing.clear ();
       ignore
-        (Masc.Keeper_registry.register_offline
+        (Masc.Keeper_registry.For_testing.register_offline
            ~base_path:exact_flow_base_path
            meta.name
            meta);

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -2836,9 +2836,15 @@ let prepare_config_sync_keeper config name =
       ; proactive = { enabled = false }
       }
   in
-  match Masc.Keeper_meta_store.write_meta config meta with
-  | Ok () -> ()
-  | Error error -> fail ("write meta: " ^ error)
+  (match Masc.Keeper_meta_store.write_meta config meta with
+   | Ok () -> ()
+   | Error error -> fail ("write meta: " ^ error));
+  Masc.Keeper_reaction_ledger.record_board_cursor_ack
+    ~base_path:config.Workspace.base_path
+    ~keeper_name:name
+    ~cursor_ts:0.0
+    ~post_id:None
+    ()
 
 let write_config_sync_toml config name =
   let dir =

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -731,9 +731,22 @@ let test_direct_start_keepalive_resolves_done_on_stop () =
         }
       in
       seed_keeper_sandbox_profile ~base_dir keeper_name;
-      ignore
-        (Masc.Keeper_keepalive.start_keepalive ctx meta
-          : Masc.Keeper_keepalive.start_keepalive_outcome);
+      (match Masc.Keeper_keepalive.start_keepalive ctx meta with
+       | Masc.Keeper_keepalive.Keepalive_started _ -> ()
+       | outcome ->
+         fail
+           ("direct keepalive did not materialize its Board cursor: "
+            ^ Masc.Keeper_keepalive.start_keepalive_outcome_to_string outcome));
+      (match
+         Masc.Keeper_reaction_ledger.latest_board_cursor_result
+           ~base_path:config.base_path
+           ~keeper_name
+       with
+       | Ok (Some _) -> ()
+       | Ok None -> fail "direct keepalive left no current-generation Board cursor"
+       | Error error ->
+         fail
+           (Masc.Keeper_reaction_ledger.board_cursor_restore_error_to_string error));
       Eio.Time.sleep ctx.clock 0.05;
       (match
          Masc.Keeper_keepalive.stop_keepalive_and_await
@@ -2692,15 +2705,15 @@ let test_keeper_dormant_shutdown_join_cancel_rolls_back_fence () =
       Eio.Switch.run @@ fun outer_sw ->
       Eio.Fiber.fork ~sw:outer_sw (fun () ->
         (match
-           Masc.Keeper_turn_admission.run_durable_intake_if_open
+           Masc.Keeper_turn_admission.run_durable_effect_if_open
              ~base_path:config.base_path
              ~keeper_name:name
              (fun _intake_token ->
                 Eio.Promise.resolve intake_started_u ();
                 Eio.Promise.await release_intake)
          with
-         | Masc.Keeper_turn_admission.Intake_committed () -> ()
-         | Masc.Keeper_turn_admission.Intake_shutdown_reserved operation_id ->
+         | Masc.Keeper_turn_admission.Durable_effect_committed () -> ()
+         | Masc.Keeper_turn_admission.Durable_effect_shutdown_reserved operation_id ->
            fail
              ("test intake unexpectedly saw shutdown reservation "
               ^ Shutdown_types.Operation_id.to_string operation_id));

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -731,11 +731,17 @@ let test_direct_start_keepalive_resolves_done_on_stop () =
         }
       in
       seed_keeper_sandbox_profile ~base_dir keeper_name;
+      Masc.Keeper_reaction_ledger.record_board_cursor_ack
+        ~base_path:config.base_path
+        ~keeper_name
+        ~cursor_ts:0.0
+        ~post_id:None
+        ();
       (match Masc.Keeper_keepalive.start_keepalive ctx meta with
        | Masc.Keeper_keepalive.Keepalive_started _ -> ()
        | outcome ->
          fail
-           ("direct keepalive did not materialize its Board cursor: "
+           ("direct keepalive did not restore its Board cursor: "
             ^ Masc.Keeper_keepalive.start_keepalive_outcome_to_string outcome));
       (match
          Masc.Keeper_reaction_ledger.latest_board_cursor_result
@@ -768,6 +774,62 @@ let test_direct_start_keepalive_resolves_done_on_stop () =
          | Some (`Crashed reason) ->
            fail ("expected stopped promise, got crashed: " ^ reason)
          | None -> fail "expected done_p to resolve on stop"))
+
+let test_existing_keeper_without_cursor_fails_closed () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  R.For_testing.clear ();
+  let base_dir = temp_dir "existing-keeper-missing-cursor" in
+  let keeper_name = "existing-missing-cursor" in
+  Fun.protect
+    ~finally:(fun () ->
+      R.For_testing.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      ensure_default_runtime ();
+      let config = Masc.Workspace.default_config base_dir in
+      ignore (Masc.Workspace.init config ~agent_name:(Some "tester"));
+      let meta = make_meta keeper_name in
+      (match Keeper_meta_store.write_meta config meta with
+       | Ok () -> ()
+       | Error detail -> fail detail);
+      seed_keeper_sandbox_profile ~base_dir keeper_name;
+      Eio.Switch.run @@ fun sw ->
+      let ctx : _ Keeper_types_profile.context =
+        { config
+        ; agent_name = "tester"
+        ; sw
+        ; clock = Eio.Stdenv.clock env
+        ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
+        ; net = None
+        ; publication_recovery_provider =
+            Masc_test_deps.publication_recovery_provider
+              (publication_recovery_registry env sw config)
+        }
+      in
+      (match Masc.Keeper_keepalive.start_keepalive ctx meta with
+       | Masc.Keeper_keepalive.Keepalive_registration_rejected
+           (Masc.Keeper_registry.Registration_board_cursor_unavailable
+              { keeper_name = rejected_keeper
+              ; reason = Masc.Keeper_registry.Board_cursor_missing
+              }) ->
+         check string "missing cursor owner" keeper_name rejected_keeper
+       | outcome ->
+         fail
+           ("existing Keeper without a cursor did not fail closed: "
+            ^ Masc.Keeper_keepalive.start_keepalive_outcome_to_string outcome));
+      check bool "missing cursor installs no registry entry" true
+        (Option.is_none (R.get ~base_path:config.base_path keeper_name));
+      match
+        Masc.Keeper_reaction_ledger.latest_board_cursor_result
+          ~base_path:config.base_path
+          ~keeper_name
+      with
+      | Ok None -> ()
+      | Ok (Some _) -> fail "existing Keeper was silently rebased to the current Board head"
+      | Error error ->
+        fail
+          (Masc.Keeper_reaction_ledger.board_cursor_restore_error_to_string error))
 
 let test_keeper_lane_join_waits_for_children_and_cleanup () =
   Eio_main.run @@ fun _env ->
@@ -4247,6 +4309,8 @@ let () =
     "direct_keepalive", [
       test_case "stop resolves done after lane exit" `Quick
         test_direct_start_keepalive_resolves_done_on_stop;
+      test_case "existing Keeper missing cursor fails closed" `Quick
+        test_existing_keeper_without_cursor_fails_closed;
       test_case "lane join waits for children and cleanup" `Quick
         test_keeper_lane_join_waits_for_children_and_cleanup;
       test_case "lane join surfaces cleanup failure" `Quick

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -56,7 +56,7 @@ let ensure_registered_keeper ~base_path keeper_name =
       |> Result.get_ok
     in
     ignore
-      (Masc.Keeper_registry.register_offline
+      (Masc.Keeper_registry.For_testing.register_offline
          ~base_path
          keeper_name
          meta)

--- a/test/test_keeper_board_attention_exact_flow.ml
+++ b/test/test_keeper_board_attention_exact_flow.ml
@@ -82,7 +82,7 @@ let prepare_exact ~net candidate =
            ])
        |> Result.get_ok
      in
-     ignore (Keeper_registry.register_offline ~base_path keeper_name meta));
+     ignore (Keeper_registry.For_testing.register_offline ~base_path keeper_name meta));
   Exact_flow.prepare
     ~base_path
     ~keeper_name
@@ -280,7 +280,7 @@ let test_explicit_lane_failover_and_success_provenance () =
         |> Result.get_ok
       in
       ignore
-        (Keeper_registry.register_offline
+        (Keeper_registry.For_testing.register_offline
            ~base_path
            candidate.keeper_name
            meta);

--- a/test/test_keeper_composite_live_turn_surface.ml
+++ b/test/test_keeper_composite_live_turn_surface.ml
@@ -28,7 +28,6 @@ let make_meta name =
       (`Assoc
         [
           ("name", `String name);
-          ("agent_name", `String ("agent-" ^ name));
           ("trace_id", `String ("trace-" ^ name));
           ("allowed_paths", `List [ `String "*" ]);
         ])
@@ -197,7 +196,7 @@ let test_run_state_waiting_when_running_idle () =
 let test_run_state_suspended_for_non_running_phase () =
   let base = temp_base () in
   let name = "offline-keeper" in
-  ignore (Keeper_registry.register_offline ~base_path:base name (make_meta name));
+  ignore (Keeper_registry.For_testing.register_offline ~base_path:base name (make_meta name));
   let json =
     match Keeper_registry.get ~base_path:base name with
     | Some entry -> Observer.snapshot_to_json (Observer.observe entry)

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -2186,7 +2186,7 @@ let () =
       let keeper_name = "keeper-event-queue-durable-offline-test" in
       let meta = meta_for_keeper keeper_name "trace-durable-offline-test" in
       Masc.Keeper_registry.For_testing.clear ();
-      ignore (Masc.Keeper_registry.register_offline ~base_path keeper_name meta);
+      ignore (Masc.Keeper_registry.For_testing.register_offline ~base_path keeper_name meta);
       (match
          Masc.Keeper_registry_event_queue.enqueue_durable_result
            ~base_path

--- a/test/test_keeper_keepalive_helpers.ml
+++ b/test/test_keeper_keepalive_helpers.ml
@@ -37,11 +37,9 @@ let make_keepalive_meta ~name ~agent_name =
         ("name", `String name);
         ("agent_name", `String agent_name);
         ("trace_id", `String ("trace-" ^ name));
-        ("sandbox_profile", `String "local");
-        ("network_mode", `String "inherit");
       ]
   in
-  match Keeper_meta_json_parse.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Error err -> fail ("meta_of_json failed: " ^ err)
   | Ok meta -> meta
 
@@ -184,16 +182,13 @@ module KBA = Masc.Keeper_board_audience
 module KBAC = Masc.Keeper_board_attention_candidate
 
 let make_board_resume_meta name =
-  let json =
-    `Assoc
-      [ ("name", `String name)
-      ; ("agent_name", `String ("keeper-" ^ name))
-      ; ("trace_id", `String ("trace-" ^ name))
-      ; ("sandbox_profile", `String "local")
-      ; ("network_mode", `String "inherit")
-      ]
-  in
-  match Keeper_meta_json_parse.meta_of_json json with
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [ "name", `String name
+        ; "trace_id", `String ("trace-" ^ name)
+        ])
+  with
   | Error err -> fail ("meta_of_json failed: " ^ err)
   | Ok meta -> meta
 ;;
@@ -610,6 +605,12 @@ let test_restarting_exact_mention_is_durable_with_deferred_wake () =
        (match Keeper_meta_store.write_meta config meta with
         | Ok () -> ()
         | Error detail -> fail ("write_meta failed: " ^ detail));
+       Keeper_reaction_ledger.record_board_cursor_ack
+         ~base_path:config.base_path
+         ~keeper_name:meta.name
+         ~cursor_ts:0.0
+         ~post_id:None
+         ();
        (match
           Keeper_registry.register_restarting
             ~base_path:config.base_path

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -22,7 +22,7 @@ let ensure_registered_keeper
   | Some _ -> ()
   | None ->
     ignore
-      (Masc.Keeper_registry.register_offline
+      (Masc.Keeper_registry.For_testing.register_offline
          ~base_path
          meta.name
          meta)

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -111,14 +111,21 @@ let event_queue_snapshot_path ~base_path ~keeper_name =
     "event-queue-v15.json"
 ;;
 
-let reaction_ledger_dir ~base_path ~keeper_name =
+let reaction_ledger_dir_for_generation ~generation ~base_path ~keeper_name =
   Filename.concat
     (Filename.concat
        (Filename.concat
           (Filename.concat (Common.masc_dir_from_base_path ~base_path) "keepers")
           keeper_name)
        "reaction-ledger")
-    "v5"
+    generation
+;;
+
+let reaction_ledger_dir ~base_path ~keeper_name =
+  reaction_ledger_dir_for_generation
+    ~generation:"v6"
+    ~base_path
+    ~keeper_name
 ;;
 
 let reaction_ledger_store ~base_path ~keeper_name =
@@ -186,7 +193,7 @@ let test_event_queue_stimulus_and_turn_reaction () =
   in
   check int "two rows persisted" 2 (List.length rows);
   let stimulus_row = List.nth rows 0 in
-  check_member_string "stimulus schema" "keeper.reaction_ledger.v5" "schema" stimulus_row;
+  check_member_string "stimulus schema" "keeper.reaction_ledger.v6" "schema" stimulus_row;
   check_member_string "stimulus record kind" "stimulus" "record_kind" stimulus_row;
   check_member_string "board stimulus id" "board:post-42" "stimulus_id" stimulus_row;
   check_member_string
@@ -272,6 +279,311 @@ let test_cursor_ack_is_replayable_state_entry () =
   check_member_string "cursor post id" "post-99" "post_id" (row |> member "cursor");
   check bool "cursor acked" true
     (row |> member "reaction" |> member "cursor_acked" |> to_bool)
+;;
+
+let test_latest_board_cursor_restores_empty_board_head () =
+  with_temp_base @@ fun base_path ->
+  let keeper_name = "empty-board-cursor-keeper" in
+  (match
+     Keeper_reaction_ledger.latest_board_cursor_result ~base_path ~keeper_name
+   with
+   | Ok None -> ()
+   | Ok (Some _) -> fail "empty ledger must not manufacture a board cursor"
+   | Error error ->
+     fail (Keeper_reaction_ledger.board_cursor_restore_error_to_string error));
+  Keeper_reaction_ledger.record_board_cursor_ack
+    ~base_path
+    ~keeper_name
+    ~cursor_ts:0.0
+    ~post_id:None
+    ();
+  match Keeper_reaction_ledger.latest_board_cursor_result ~base_path ~keeper_name with
+  | Ok (Some cursor) ->
+    check (float 0.0) "empty Board cursor timestamp remains valid" 0.0 cursor.cursor_ts;
+    check (option string) "empty Board cursor has no post id" None cursor.post_id
+  | Ok None -> fail "durable empty Board cursor was not restored"
+  | Error error ->
+    fail (Keeper_reaction_ledger.board_cursor_restore_error_to_string error)
+;;
+
+let test_latest_board_cursor_hard_cuts_v5_namespace () =
+  with_temp_base @@ fun base_path ->
+  let keeper_name = "v5-cursor-hard-cut" in
+  let v5_store =
+    Dated_jsonl.create
+      ~base_dir:
+        (reaction_ledger_dir_for_generation
+           ~generation:"v5"
+           ~base_path
+           ~keeper_name)
+      ()
+  in
+  Dated_jsonl.append
+    v5_store
+    (`Assoc [ "schema", `String "keeper.reaction_ledger.v5" ]);
+  match Keeper_reaction_ledger.latest_board_cursor_result ~base_path ~keeper_name with
+  | Ok None -> ()
+  | Ok (Some _) -> fail "v5 cursor must not enter the v6 authority namespace"
+  | Error error ->
+    fail
+      ("v5 cursor affected the v6 reader: "
+       ^ Keeper_reaction_ledger.board_cursor_restore_error_to_string error)
+;;
+
+let rewrite_object_field row ~object_name ~field_name replacement =
+  match row with
+  | `Assoc fields ->
+    let rewritten =
+      match List.assoc_opt object_name fields with
+      | Some (`Assoc object_fields) ->
+        let object_fields = List.remove_assoc field_name object_fields in
+        `Assoc
+          (match replacement with
+           | None -> object_fields
+           | Some value -> (field_name, value) :: object_fields)
+      | _ -> failf "%s fixture must contain an object" object_name
+    in
+    `Assoc ((object_name, rewritten) :: List.remove_assoc object_name fields)
+  | _ -> fail "cursor fixture must be an object"
+;;
+
+let rewrite_cursor_post_id row replacement =
+  rewrite_object_field row ~object_name:"cursor" ~field_name:"post_id" replacement
+;;
+
+let check_invalid_cursor_post_id replacement expected_reason =
+  with_temp_base @@ fun base_path ->
+  let keeper_name = "invalid-cursor-post-id" in
+  Keeper_reaction_ledger.record_board_cursor_ack
+    ~base_path
+    ~keeper_name
+    ~cursor_ts:42.5
+    ~post_id:(Some "post-cursor")
+    ();
+  let row =
+    read_recent_rows ~base_path ~keeper_name ~limit:1
+    |> latest_row
+    |> fun row -> rewrite_cursor_post_id row replacement
+  in
+  Dated_jsonl.append (reaction_ledger_store ~base_path ~keeper_name) row;
+  match Keeper_reaction_ledger.latest_board_cursor_result ~base_path ~keeper_name with
+  | Error (Keeper_reaction_ledger.Board_cursor_invalid_row reason) ->
+    check string "cursor post id fails closed" expected_reason
+      (Keeper_reaction_ledger.row_quarantine_reason_to_string reason)
+  | Error error ->
+    failf
+      "wrong board cursor restore error: %s"
+      (Keeper_reaction_ledger.board_cursor_restore_error_to_string error)
+  | Ok _ -> fail "invalid cursor post id must not restore"
+;;
+
+let test_latest_board_cursor_requires_post_id_field () =
+  check_invalid_cursor_post_id None "missing_cursor_post_id"
+;;
+
+let test_latest_board_cursor_rejects_wrong_post_id_type () =
+  check_invalid_cursor_post_id (Some (`Bool true)) "invalid_cursor_post_id"
+;;
+
+let test_latest_board_cursor_binds_post_id_identity () =
+  check_invalid_cursor_post_id
+    (Some (`String "post-other"))
+    "event_identity_mismatch"
+;;
+
+let test_latest_board_cursor_binds_missing_post_identity () =
+  check_invalid_cursor_post_id (Some `Null) "event_identity_mismatch"
+;;
+
+let check_invalid_cursor_row ~rewrite expected_reason =
+  with_temp_base @@ fun base_path ->
+  let keeper_name = "invalid-cursor-row" in
+  Keeper_reaction_ledger.record_board_cursor_ack
+    ~base_path
+    ~keeper_name
+    ~cursor_ts:42.5
+    ~post_id:(Some "post-cursor")
+    ();
+  let row =
+    read_recent_rows ~base_path ~keeper_name ~limit:1 |> latest_row |> rewrite
+  in
+  Dated_jsonl.append (reaction_ledger_store ~base_path ~keeper_name) row;
+  match Keeper_reaction_ledger.latest_board_cursor_result ~base_path ~keeper_name with
+  | Error (Keeper_reaction_ledger.Board_cursor_invalid_row reason) ->
+    check string "cursor row fails closed" expected_reason
+      (Keeper_reaction_ledger.row_quarantine_reason_to_string reason)
+  | Error error ->
+    failf
+      "wrong board cursor restore error: %s"
+      (Keeper_reaction_ledger.board_cursor_restore_error_to_string error)
+  | Ok _ -> fail "invalid cursor row must not restore"
+;;
+
+let test_latest_board_cursor_binds_exact_timestamp () =
+  let adjacent =
+    Int64.bits_of_float 42.5 |> Int64.succ |> Int64.float_of_bits
+  in
+  check_invalid_cursor_row
+    ~rewrite:(fun row ->
+      rewrite_object_field
+        row
+        ~object_name:"cursor"
+        ~field_name:"cursor_ts"
+        (Some (`Float adjacent)))
+    "event_identity_mismatch"
+;;
+
+let test_latest_board_cursor_requires_board_scope () =
+  check_invalid_cursor_row
+    ~rewrite:(fun row ->
+      rewrite_object_field
+        row
+        ~object_name:"cursor"
+        ~field_name:"scope"
+        (Some (`String "other")))
+    "invalid_cursor_scope"
+;;
+
+let test_latest_board_cursor_requires_positive_ack () =
+  check_invalid_cursor_row
+    ~rewrite:(fun row ->
+      rewrite_object_field
+        row
+        ~object_name:"reaction"
+        ~field_name:"cursor_acked"
+        (Some (`Bool false)))
+    "invalid_cursor_reaction"
+;;
+
+let test_latest_board_cursor_skips_valid_non_cursor_rows () =
+  with_temp_base @@ fun base_path ->
+  let keeper_name = "cursor-with-newer-stimulus" in
+  Keeper_reaction_ledger.record_board_cursor_ack
+    ~base_path
+    ~keeper_name
+    ~cursor_ts:42.5
+    ~post_id:(Some "post-cursor")
+    ();
+  Keeper_reaction_ledger.record_event_queue_stimulus
+    ~base_path
+    ~keeper_name
+    (board_stimulus ~post_id:"post-newer-stimulus" ());
+  match Keeper_reaction_ledger.latest_board_cursor_result ~base_path ~keeper_name with
+  | Ok (Some cursor) ->
+    check (float 0.0) "newest durable cursor restored" 42.5 cursor.cursor_ts;
+    check (option string) "newest durable cursor post id restored"
+      (Some "post-cursor") cursor.post_id
+  | Ok None -> fail "valid non-cursor row hid the durable cursor"
+  | Error error ->
+    fail (Keeper_reaction_ledger.board_cursor_restore_error_to_string error)
+;;
+
+let test_latest_board_cursor_fails_on_invalid_identified_non_cursor_row () =
+  with_temp_base @@ fun base_path ->
+  let keeper_name = "cursor-with-invalid-newer-stimulus" in
+  Keeper_reaction_ledger.record_board_cursor_ack
+    ~base_path
+    ~keeper_name
+    ~cursor_ts:42.5
+    ~post_id:(Some "post-cursor")
+    ();
+  Dated_jsonl.append
+    (reaction_ledger_store ~base_path ~keeper_name)
+    (`Assoc [ "record_kind", `String "stimulus" ]);
+  match Keeper_reaction_ledger.latest_board_cursor_result ~base_path ~keeper_name with
+  | Error (Keeper_reaction_ledger.Board_cursor_invalid_row reason) ->
+    check string "invalid identified row fails closed" "missing_schema"
+      (Keeper_reaction_ledger.row_quarantine_reason_to_string reason)
+  | Error error ->
+    failf
+      "wrong board cursor restore error: %s"
+      (Keeper_reaction_ledger.board_cursor_restore_error_to_string error)
+  | Ok _ -> fail "invalid identified row must not roll back to an older cursor"
+;;
+
+let test_latest_board_cursor_fails_on_invalid_newer_row () =
+  with_temp_base @@ fun base_path ->
+  let keeper_name = "cursor-invalid-newer-row" in
+  Keeper_reaction_ledger.record_board_cursor_ack
+    ~base_path
+    ~keeper_name
+    ~cursor_ts:42.5
+    ~post_id:(Some "post-cursor")
+    ();
+  Dated_jsonl.append
+    (reaction_ledger_store ~base_path ~keeper_name)
+    (`Assoc [ "schema", `String "keeper.reaction_ledger.v6" ]);
+  match Keeper_reaction_ledger.latest_board_cursor_result ~base_path ~keeper_name with
+  | Error (Keeper_reaction_ledger.Board_cursor_invalid_row reason) ->
+    check string "invalid newer row is fail-closed"
+      "missing_event_id"
+      (Keeper_reaction_ledger.row_quarantine_reason_to_string reason)
+  | Error error ->
+    failf
+      "wrong board cursor restore error: %s"
+      (Keeper_reaction_ledger.board_cursor_restore_error_to_string error)
+  | Ok _ -> fail "invalid newer ledger row must not roll back to an older cursor"
+;;
+
+let test_latest_board_cursor_fails_on_unknown_kind_non_cursor_shape () =
+  with_temp_base @@ fun base_path ->
+  let keeper_name = "cursor-unknown-kind-newer-row" in
+  Keeper_reaction_ledger.record_board_cursor_ack
+    ~base_path
+    ~keeper_name
+    ~cursor_ts:42.5
+    ~post_id:(Some "post-cursor")
+    ();
+  Keeper_reaction_ledger.record_event_queue_stimulus
+    ~base_path
+    ~keeper_name
+    (board_stimulus ~post_id:"post-unknown-kind" ());
+  let unknown_kind_row =
+    match read_recent_rows ~base_path ~keeper_name ~limit:1 |> latest_row with
+    | `Assoc fields ->
+      `Assoc
+        (("record_kind", `String "future_record_kind")
+         :: List.remove_assoc "record_kind" fields)
+    | _ -> fail "stimulus fixture must be a JSON object"
+  in
+  Dated_jsonl.append
+    (reaction_ledger_store ~base_path ~keeper_name)
+    unknown_kind_row;
+  match Keeper_reaction_ledger.latest_board_cursor_result ~base_path ~keeper_name with
+  | Error (Keeper_reaction_ledger.Board_cursor_invalid_row reason) ->
+    check
+      string
+      "unknown record kind cannot decode as a skippable non-cursor row"
+      "unknown_record_kind"
+      (Keeper_reaction_ledger.row_quarantine_reason_to_string reason)
+  | Error error ->
+    failf
+      "wrong board cursor restore error: %s"
+      (Keeper_reaction_ledger.board_cursor_restore_error_to_string error)
+  | Ok _ -> fail "unknown record kind must not roll back to an older cursor"
+;;
+
+let test_latest_board_cursor_fails_on_malformed_newer_row () =
+  with_temp_base @@ fun base_path ->
+  let keeper_name = "cursor-malformed-newer-row" in
+  Keeper_reaction_ledger.record_board_cursor_ack
+    ~base_path
+    ~keeper_name
+    ~cursor_ts:42.5
+    ~post_id:(Some "post-cursor")
+    ();
+  let future_month =
+    Filename.concat (reaction_ledger_dir ~base_path ~keeper_name) "9999-12"
+  in
+  mkdir_p future_month;
+  write_file (Filename.concat future_month "31.jsonl") "not-json\n";
+  match Keeper_reaction_ledger.latest_board_cursor_result ~base_path ~keeper_name with
+  | Error (Keeper_reaction_ledger.Board_cursor_malformed_row _) -> ()
+  | Error error ->
+    failf
+      "wrong board cursor restore error: %s"
+      (Keeper_reaction_ledger.board_cursor_restore_error_to_string error)
+  | Ok _ -> fail "malformed newer ledger row must not roll back to an older cursor"
 ;;
 
 let test_summary_marks_unreacted_and_reacted_stimuli () =
@@ -703,7 +1015,7 @@ let test_unknown_reaction_is_quarantined_without_clearing_pending () =
   Dated_jsonl.append
     (reaction_ledger_store ~base_path ~keeper_name)
     (`Assoc
-        [ "schema", `String "keeper.reaction_ledger.v5"
+        [ "schema", `String "keeper.reaction_ledger.v6"
         ; "record_kind", `String "reaction"
         ; "event_id", `String (stimulus_id ^ ":reaction:turn_started")
         ; "keeper_name", `String keeper_name
@@ -1035,7 +1347,7 @@ let test_missing_identity_does_not_claim_an_occurrence_identity () =
   Dated_jsonl.append
     (reaction_ledger_store ~base_path ~keeper_name)
     (`Assoc
-        [ "schema", `String "keeper.reaction_ledger.v5"
+        [ "schema", `String "keeper.reaction_ledger.v6"
         ; "record_kind", `String "stimulus"
         ; "event_id", `String "unattributed-event"
         ; "keeper_name", `String keeper_name
@@ -1096,6 +1408,62 @@ let () =
             "cursor ack is replayable state entry"
             `Quick
             test_cursor_ack_is_replayable_state_entry
+        ; test_case
+            "latest board cursor restores an empty Board head"
+            `Quick
+            test_latest_board_cursor_restores_empty_board_head
+        ; test_case
+            "latest board cursor hard-cuts the v5 namespace"
+            `Quick
+            test_latest_board_cursor_hard_cuts_v5_namespace
+        ; test_case
+            "latest board cursor requires a post id field"
+            `Quick
+            test_latest_board_cursor_requires_post_id_field
+        ; test_case
+            "latest board cursor rejects a wrong post id type"
+            `Quick
+            test_latest_board_cursor_rejects_wrong_post_id_type
+        ; test_case
+            "latest board cursor binds the post id identity"
+            `Quick
+            test_latest_board_cursor_binds_post_id_identity
+        ; test_case
+            "latest board cursor binds the missing post identity"
+            `Quick
+            test_latest_board_cursor_binds_missing_post_identity
+        ; test_case
+            "latest board cursor binds the exact timestamp"
+            `Quick
+            test_latest_board_cursor_binds_exact_timestamp
+        ; test_case
+            "latest board cursor requires Board scope"
+            `Quick
+            test_latest_board_cursor_requires_board_scope
+        ; test_case
+            "latest board cursor requires a positive ack"
+            `Quick
+            test_latest_board_cursor_requires_positive_ack
+        ; test_case
+            "latest board cursor skips valid non-cursor rows"
+            `Quick
+            test_latest_board_cursor_skips_valid_non_cursor_rows
+        ; test_case
+            "latest board cursor fails on an invalid identified non-cursor row"
+            `Quick
+            test_latest_board_cursor_fails_on_invalid_identified_non_cursor_row
+        ; test_case
+            "latest board cursor fails on an invalid newer row"
+            `Quick
+            test_latest_board_cursor_fails_on_invalid_newer_row
+        ; test_case
+            "latest board cursor fails on an unknown-kind non-cursor row"
+            `Quick
+            test_latest_board_cursor_fails_on_unknown_kind_non_cursor_shape
+        ; test_case
+            "latest board cursor fails on a malformed newer row"
+            `Quick
+            test_latest_board_cursor_fails_on_malformed_newer_row
         ; test_case
             "summary marks unreacted and reacted stimuli"
             `Quick

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -330,6 +330,47 @@ let test_latest_board_cursor_hard_cuts_v5_namespace () =
        ^ Keeper_reaction_ledger.board_cursor_restore_error_to_string error)
 ;;
 
+let test_board_cursor_cutover_report_requires_every_keeper () =
+  with_temp_base @@ fun base_path ->
+  Keeper_reaction_ledger.record_board_cursor_ack
+    ~base_path
+    ~keeper_name:"ready"
+    ~cursor_ts:42.5
+    ~post_id:(Some "post-ready")
+    ();
+  let report =
+    Keeper_reaction_ledger.board_cursor_cutover_report
+      ~base_path
+      ~keeper_names:[ "missing"; "ready"; "ready" ]
+  in
+  check int "deduplicated Keeper count" 2 report.keeper_count;
+  check int "ready Keeper count" 1 report.ready_count;
+  match report.issues with
+  | [ Keeper_reaction_ledger.Board_cursor_missing { keeper_name } ] ->
+    check string "missing Keeper is named" "missing" keeper_name
+  | _ -> fail "cutover report must identify the Keeper without a current cursor"
+;;
+
+let test_board_cursor_cutover_report_surfaces_corruption () =
+  with_temp_base @@ fun base_path ->
+  let keeper_name = "corrupt" in
+  Dated_jsonl.append
+    (reaction_ledger_store ~base_path ~keeper_name)
+    (`Assoc [ "schema", `String "keeper.reaction_ledger.v6" ]);
+  let report =
+    Keeper_reaction_ledger.board_cursor_cutover_report
+      ~base_path
+      ~keeper_names:[ keeper_name ]
+  in
+  check int "corrupt Keeper is not ready" 0 report.ready_count;
+  match report.issues with
+  | [ Keeper_reaction_ledger.Board_cursor_unreadable { keeper_name = actual; error } ] ->
+    check string "corrupt Keeper is named" keeper_name actual;
+    check string "typed corruption reason" "invalid reaction-ledger row before board cursor: missing_event_id"
+      (Keeper_reaction_ledger.board_cursor_restore_error_to_string error)
+  | _ -> fail "cutover report must preserve the typed cursor read error"
+;;
+
 let rewrite_object_field row ~object_name ~field_name replacement =
   match row with
   | `Assoc fields ->
@@ -1416,6 +1457,14 @@ let () =
             "latest board cursor hard-cuts the v5 namespace"
             `Quick
             test_latest_board_cursor_hard_cuts_v5_namespace
+        ; test_case
+            "board cursor cutover requires every Keeper"
+            `Quick
+            test_board_cursor_cutover_report_requires_every_keeper
+        ; test_case
+            "board cursor cutover surfaces corruption"
+            `Quick
+            test_board_cursor_cutover_report_surfaces_corruption
         ; test_case
             "latest board cursor requires a post id field"
             `Quick

--- a/test/test_keeper_registry_admission_no_suspend.ml
+++ b/test/test_keeper_registry_admission_no_suspend.ml
@@ -42,7 +42,6 @@ let make_meta name =
     Masc_test_deps.meta_of_json_fixture
       (`Assoc
         [ "name", `String name
-        ; "agent_name", `String ("agent-" ^ name)
         ; "trace_id", `String ("trace-" ^ name)
         ; "allowed_paths", `List [ `String "*" ]
         ; "autoboot_enabled", `Bool false
@@ -60,6 +59,12 @@ let run_interleaving () =
   Eio_main.run (fun _env ->
     KR.For_testing.clear ();
     Admission.For_testing.reset ();
+    Masc.Keeper_reaction_ledger.record_board_cursor_ack
+      ~base_path
+      ~keeper_name
+      ~cursor_ts:0.0
+      ~post_id:None
+      ();
     let key_lock_taken, set_key_lock_taken = Eio.Promise.create () in
     let release_key_lock, do_release_key_lock = Eio.Promise.create () in
     let registration_done, set_registration_done = Eio.Promise.create () in

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -154,8 +154,8 @@ let test_update_entry_exact_preserves_replacement_lane () =
 let test_dispatch_event_exact_preserves_replacement_lane () =
   KR.For_testing.clear ();
   let old_meta = make_meta "alice" in
-  let old_entry = KR.register_offline ~base_path old_meta.name old_meta in
-  let replacement = KR.register_offline ~base_path old_meta.name old_meta in
+  let old_entry = KR.For_testing.register_offline ~base_path old_meta.name old_meta in
+  let replacement = KR.For_testing.register_offline ~base_path old_meta.name old_meta in
   (match KR.dispatch_event_exact old_entry KSM.Fiber_started with
    | Error _ -> ()
    | Ok _ -> fail "stale exact dispatch mutated the replacement lane");
@@ -267,7 +267,7 @@ let test_wakeup_running_reports_typed_outcome () =
    | KR.Deferred_lifecycle _ ->
      fail "running keeper was not signaled");
   let offline_meta = make_meta "offline" in
-  let offline = KR.register_offline ~base_path offline_meta.name offline_meta in
+  let offline = KR.For_testing.register_offline ~base_path offline_meta.name offline_meta in
   Atomic.set offline.fiber_wakeup false;
   (match
      KR.wakeup_running ~intent:KR.Hitl_resolution ~base_path "offline"
@@ -345,7 +345,7 @@ let test_wakeup_running_exact_reports_deferred_outcomes () =
    | KR.Exact_wake_lifecycle_reserved _ ->
      fail "removed exact owner did not report missing");
   let offline_meta = make_meta "exact-offline" in
-  let offline = KR.register_offline ~base_path offline_meta.name offline_meta in
+  let offline = KR.For_testing.register_offline ~base_path offline_meta.name offline_meta in
   (match KR.wakeup_running_exact ~intent:KR.Reactive_signal offline with
    | KR.Exact_wake_not_running phase ->
      check string "exact deferred phase" "offline" (KSM.phase_to_string phase)
@@ -497,6 +497,96 @@ let cleanup_dir path =
   | exception Unix.Unix_error (Unix.ENOENT, _, _) -> ()
 ;;
 
+let record_board_cursor ~base_path ~keeper_name ~cursor_ts ~post_id =
+  Masc.Keeper_reaction_ledger.record_board_cursor_ack
+    ~base_path
+    ~keeper_name
+    ~cursor_ts
+    ~post_id
+    ()
+;;
+
+let test_registration_requires_durable_board_cursor () =
+  let dir = temp_dir "registry_missing_board_cursor" in
+  Fun.protect
+    ~finally:(fun () ->
+      KR.For_testing.clear ();
+      cleanup_dir dir)
+    (fun () ->
+       let meta = make_meta "missing-board-cursor" in
+       match KR.register_offline_if_admitted ~base_path:dir meta.name meta with
+       | Error
+           (KR.Registration_board_cursor_unavailable
+              { keeper_name; reason = KR.Board_cursor_missing }) ->
+         check string "missing cursor keeper is identified" meta.name keeper_name;
+         check bool "failed registration installs no entry" true
+           (Option.is_none (KR.get ~base_path:dir meta.name))
+       | Error error ->
+         failf
+           "wrong registration failure: %s"
+           (match error with
+            | KR.Registration_board_cursor_unavailable { reason; _ } ->
+              KR.board_cursor_registration_error_to_string reason
+            | KR.Registration_shutdown_reserved _ -> "shutdown_reserved"
+            | KR.Registration_lifecycle_reserved _ -> "lifecycle_reserved"
+            | KR.Registration_invalid validation_error ->
+              KR.registry_entry_validation_error_to_string validation_error
+            | KR.Registration_event_queue_unavailable { detail; _ } -> detail)
+       | Ok _ -> fail "registration accepted a Keeper without a durable board cursor")
+;;
+
+let test_registration_and_restart_restore_exact_board_cursor () =
+  let dir = temp_dir "registry_restore_board_cursor" in
+  Fun.protect
+    ~finally:(fun () ->
+      KR.For_testing.clear ();
+      cleanup_dir dir)
+    (fun () ->
+       let meta = make_meta "restored-board-cursor" in
+       record_board_cursor
+         ~base_path:dir
+         ~keeper_name:meta.name
+         ~cursor_ts:123.5
+         ~post_id:(Some "post-123");
+       let registered =
+         match KR.register_offline_if_admitted ~base_path:dir meta.name meta with
+         | Ok entry -> entry
+         | Error error ->
+           failf
+             "registration rejected a durable cursor: %s"
+             (match error with
+              | KR.Registration_board_cursor_unavailable { reason; _ } ->
+                KR.board_cursor_registration_error_to_string reason
+              | KR.Registration_shutdown_reserved _ -> "shutdown_reserved"
+              | KR.Registration_lifecycle_reserved _ -> "lifecycle_reserved"
+              | KR.Registration_invalid validation_error ->
+                KR.registry_entry_validation_error_to_string validation_error
+              | KR.Registration_event_queue_unavailable { detail; _ } -> detail)
+       in
+       check (pair (float 0.0) (option string))
+         "registration restores exact cursor"
+         (123.5, Some "post-123")
+         registered.board_cursor;
+       record_board_cursor
+         ~base_path:dir
+         ~keeper_name:meta.name
+         ~cursor_ts:456.75
+         ~post_id:(Some "post-456");
+       let restarting =
+         match KR.register_restarting ~base_path:dir meta.name meta with
+         | Ok entry -> entry
+         | Error (KR.Restart_board_cursor_unavailable { reason; _ }) ->
+           fail (KR.board_cursor_registration_error_to_string reason)
+         | Error (KR.Restart_event_queue_unavailable { detail; _ }) -> fail detail
+         | Error (KR.Restart_shutdown_reserved _) -> fail "restart shutdown reserved"
+         | Error (KR.Restart_lifecycle_reserved _) -> fail "restart lifecycle reserved"
+       in
+       check (pair (float 0.0) (option string))
+         "restart restores the newest exact cursor"
+         (456.75, Some "post-456")
+         restarting.board_cursor)
+;;
+
 let test_reactive_wakeup_defers_offline_lane_after_queue_commit () =
   let dir = temp_dir "registry_reactive_offline_wakeup" in
   Fun.protect
@@ -508,7 +598,7 @@ let test_reactive_wakeup_defers_offline_lane_after_queue_commit () =
        Fs_compat.set_fs (Eio.Stdenv.fs env);
        KR.For_testing.clear ();
        let meta = make_meta "reactive-offline" in
-       let entry = KR.register_offline ~base_path:dir meta.name meta in
+       let entry = KR.For_testing.register_offline ~base_path:dir meta.name meta in
        let stimulus : Keeper_event_queue.stimulus =
          { post_id = "reactive-offline-stimulus"
          ; urgency = Keeper_event_queue.Normal
@@ -545,7 +635,7 @@ let test_goal_assignment_defers_offline_lane_after_queue_commit () =
        let config = Masc.Workspace.default_config dir in
        let meta = make_meta "goal-offline" in
        let entry =
-         KR.register_offline ~base_path:config.base_path meta.name meta
+         KR.For_testing.register_offline ~base_path:config.base_path meta.name meta
        in
        Atomic.set entry.fiber_wakeup false;
        let added =
@@ -586,7 +676,7 @@ let test_goal_reconciliation_enqueues_once_after_last_terminal_task () =
        let meta = make_goal_reconciler_meta () in
        ignore (Masc.Workspace.init config ~agent_name:(Some meta.agent_name));
        Masc.Workspace_metric_hooks.install ();
-       ignore (KR.register_offline ~base_path:config.base_path meta.name meta);
+       ignore (KR.For_testing.register_offline ~base_path:config.base_path meta.name meta);
        let goal, _ =
          match
            Goal_store.upsert_goal
@@ -736,7 +826,7 @@ let test_goal_reconciliation_prefers_authoritative_assignment
        finish "task-001";
        finish "task-002";
        ignore
-         (KR.register_offline
+         (KR.For_testing.register_offline
             ~base_path:config.base_path
             producer_meta.name
             producer_meta);
@@ -747,7 +837,7 @@ let test_goal_reconciliation_prefers_authoritative_assignment
          }
        in
        ignore
-         (KR.register_offline
+         (KR.For_testing.register_offline
             ~base_path:config.base_path
             assigned_meta.name
             assigned_meta);
@@ -832,7 +922,7 @@ let test_goal_reconciliation_restart_scan_retries_missed_delivery () =
        let config = Masc.Workspace.default_config dir in
        let meta = make_goal_reconciler_meta () in
        ignore (Masc.Workspace.init config ~agent_name:(Some meta.agent_name));
-       ignore (KR.register_offline ~base_path:config.base_path meta.name meta);
+       ignore (KR.For_testing.register_offline ~base_path:config.base_path meta.name meta);
        Atomic.set Workspace_hooks.task_terminal_committed_fn
          (fun _config ~agent_name:_ ~task_id:_ ->
             Workspace_hooks.Task_terminal_delivered);
@@ -1422,6 +1512,16 @@ let () =
             "exact wake serializes lifecycle ownership and replacement"
             `Quick
             test_wakeup_running_exact_respects_lifecycle_owner_and_replacement
+        ] )
+    ; ( "board_cursor_registration"
+      , [ test_case
+            "missing durable cursor fails closed"
+            `Quick
+            test_registration_requires_durable_board_cursor
+        ; test_case
+            "registration and restart restore exact durable cursor"
+            `Quick
+            test_registration_and_restart_restore_exact_board_cursor
         ] )
     ; ( "wakeup_callers"
       , [ test_case

--- a/test/test_keeper_shutdown_reconciliation_settlement.ml
+++ b/test/test_keeper_shutdown_reconciliation_settlement.ml
@@ -281,7 +281,7 @@ let test_vanished_lane_matches_absent_lane () =
     (fun () ->
        let keeper_name = "vanished-lane" in
        let entry =
-         Keeper_registry.register_offline
+         Keeper_registry.For_testing.register_offline
            ~base_path
            keeper_name
            (meta_fixture_exn ~keeper_name)
@@ -319,12 +319,12 @@ let test_replaced_lane_still_fails () =
     (fun () ->
        let keeper_name = "replaced-lane" in
        let meta = meta_fixture_exn ~keeper_name in
-       let original = Keeper_registry.register_offline ~base_path keeper_name meta in
+       let original = Keeper_registry.For_testing.register_offline ~base_path keeper_name meta in
        (* A different lane now owns the keeper. The operation still names the
           lane it owned, so its retained meta must not overwrite the new one. *)
        Keeper_registry.For_testing.unregister ~base_path keeper_name;
        let replacement =
-         Keeper_registry.register_offline ~base_path keeper_name meta
+         Keeper_registry.For_testing.register_offline ~base_path keeper_name meta
        in
        check
          bool

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -758,7 +758,7 @@ let test_reconcile_does_not_double_start_materialized_keeper () =
   let load_or_materialize_keeper_meta _ctx requested =
     materialized := requested :: !materialized;
     let meta = make_meta requested in
-    let _entry = Reg.register_offline ~base_path:config.base_path requested meta in
+    let _entry = Reg.For_testing.register_offline ~base_path:config.base_path requested meta in
     Ok (Some meta)
   in
   KSR.reconcile_keepalive_keepers
@@ -1054,7 +1054,7 @@ let test_fresh_supervision_cohort_keepers_rereads_registry () =
   in
   Reg.For_testing.unregister ~base_path:bp "alpha";
   Reg.For_testing.unregister ~base_path:bp "bravo";
-  let _entry = Reg.register_offline ~base_path:bp "bravo" (make_meta "bravo") in
+  let _entry = Reg.For_testing.register_offline ~base_path:bp "bravo" (make_meta "bravo") in
   let fresh = Sup.fresh_supervision_cohort_keepers ~base_path:bp cohort in
   check (list string) "removed entries omitted"
     [ "bravo" ]
@@ -1637,7 +1637,7 @@ let test_supervised_stop_joins_board_attention_worker () =
       (match Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
        | Error err -> fail err);
-      let reg = Reg.register_offline ~base_path:config.base_path name meta in
+      let reg = Reg.For_testing.register_offline ~base_path:config.base_path name meta in
       let ctx : _ Keeper_types_profile.context =
         { config
         ; agent_name = supervisor_agent_name

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -537,7 +537,7 @@ let test_runtime_mcp_keeper_log_context_uses_keeper_trace_and_current_turn () =
       cleanup_dir base_path)
     (fun () ->
       ignore
-        (Masc.Keeper_registry.register_offline ~base_path keeper_name meta);
+        (Masc.Keeper_registry.For_testing.register_offline ~base_path keeper_name meta);
       Masc.Keeper_registry.mark_turn_started ~base_path
         ~wake:Masc.Keeper_registry.Proactive_tick keeper_name;
       let entry =
@@ -599,7 +599,7 @@ let test_runtime_mcp_keeper_log_context_loads_current_task_contract () =
       cleanup_dir base_path)
     (fun () ->
       ignore
-        (Masc.Keeper_registry.register_offline ~base_path keeper_name meta);
+        (Masc.Keeper_registry.For_testing.register_offline ~base_path keeper_name meta);
       let entry =
         match Masc.Keeper_registry.get ~base_path keeper_name with
         | Some entry -> entry
@@ -636,7 +636,7 @@ let test_record_runtime_mcp_keeper_tool_trace_logs_and_broadcasts () =
       cleanup_dir base_path)
     (fun () ->
       ignore
-        (Masc.Keeper_registry.register_offline ~base_path keeper_name meta);
+        (Masc.Keeper_registry.For_testing.register_offline ~base_path keeper_name meta);
       Masc.Keeper_registry.mark_turn_started ~base_path
         ~wake:Masc.Keeper_registry.Proactive_tick keeper_name;
       let entry =

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -68,7 +68,7 @@ let reaction_ledger_dir ~base_path ~keeper_name =
           (Common.keepers_runtime_dir_of_base ~base_path)
           keeper_name)
        "reaction-ledger")
-    "v5"
+    Keeper_reaction_ledger.storage_generation
 ;;
 
 let write_malformed_reaction_ledger_row ~base_path ~keeper_name =
@@ -2835,7 +2835,10 @@ let test_dashboard_projects_quarantined_and_unreadable_reaction_evidence () =
        ~base_dir:(reaction_ledger_dir ~base_path ~keeper_name)
        ())
     (`Assoc
-        [ "schema", `String "keeper.reaction_ledger.v5"
+        [ ( "schema"
+          , `String
+              ("keeper.reaction_ledger."
+               ^ Keeper_reaction_ledger.storage_generation) )
         ; "record_kind", `String "reaction"
         ; "event_id", `String (stimulus_id ^ ":reaction:turn_started")
         ; "keeper_name", `String keeper_name

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -2450,7 +2450,7 @@ let test_health_json_reuses_canonical_owner_execution_snapshot () =
               ~base_path:config.Workspace.base_path
               meta.name;
             ignore
-              (Keeper_registry.register_offline
+              (Keeper_registry.For_testing.register_offline
                  ~base_path:config.Workspace.base_path
                  meta.name
                  meta);

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -284,7 +284,7 @@ let register_test_keeper ctx ~keeper_name ~agent_name =
   with
   | Ok meta ->
       ignore
-        (Keeper_registry.register_offline ~base_path:ctx.Task.Tool.config.Workspace.base_path
+        (Keeper_registry.For_testing.register_offline ~base_path:ctx.Task.Tool.config.Workspace.base_path
            keeper_name meta)
   | Error e -> failwith ("failed to build keeper meta: " ^ e)
 


### PR DESCRIPTION
## 변경점

- Keeper 등록/재시작 시 v6 reaction ledger의 durable Board cursor를 exact restore해용.
- 새 Keeper 생성만 metadata 쓰기 전에 현재 Board head를 genesis로 영속화해용.
- 기존 Keeper에 v6 cursor가 없거나 깨졌다면 자동 보정하지 않고 typed error로 등록을 거부해용.
- candidate binary의 `masc-keeper-board-cursor-cutover-check`가 canonical metadata owner 전부를 production reader로 읽고, 하나라도 준비되지 않으면 배포 전 실패해용.

## v6가 필요한 이유

커서 timestamp identity가 6자리 문자열에서 exact float bits로 바뀌었고, scope/post_id/cursor_acked/stimulus/event identity 계약도 함께 강화됐어용. v5 namespace를 재사용하면 서로 다른 row 계약이 한 authority에 섞이므로 v6 hard cut을 유지해용. 과거 세대 읽기·migration·startup repair는 추가하지 않았어용.

## 배포 조건

현재 live canonical metadata owner 8개 모두 v6 cursor가 0개라 gate가 실패해야 정상이에용. candidate 설치 후 runtime 시작/재시작 전에 gate가 `pass`해야 하며, reset/recreate는 별도 operator 승인이 필요해용. metadata 없는 `audit-ghost` storage는 Keeper로 오집계하지 않고 #26746에 별도 기록했어용.

## 검증

- exact head `20414b93ac0dc4372e825ec75c8ce646fa3ffbd6`를 #26689 exact head `ea66b02663c340a65d4febd900b9ea15011f21c1` 위로 재스택했어용.
- 앞 두 patch의 `git range-diff`는 `=`이고, gate patch는 수동 argv parser를 repo 표준 Cmdliner로 교체했어용. OCaml format/parser, YAML parse, diff-check를 통과했어용.
- production reader 기반 positive/missing/corrupt cutover 테스트를 CI 실행 대상에 넣었어용.
- 로컬 Dune은 실행하지 않았고 exact-head CI를 기다려용.

[근거] `Keeper_meta_store.keeper_names_result`, `Keeper_reaction_ledger.latest_board_cursor_result`, `/Users/dancer/me/.masc/keepers` read-only 확인 · 2026-08-04 KST · High

