### PR TITLE
fix(auth): demote dashboard dev token to worker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -797,17 +797,16 @@ jobs:
         run: |
           opam exec -- dune exec --root . test/test_workspace_coverage.exe -- test revision
 
-      - name: Run OAuth authentication suites
-        # These two suites are introduced by this PR and cover the dual-auth
-        # admission path. @check compiles them but never runs them, so without
-        # this step the 19 cases are dead weight: the Unbound_request_authority
-        # regression that broke /mcp initialize was exactly the class they
-        # assert on.
-        # See: test/test_auth_oauth.ml, test/test_server_oauth_protocol.ml.
+      - name: Run MCP authentication contract suites
+        # @check compiles these suites but never runs them. Exercise both the
+        # dual-auth admission path and the typed HTTP/JSON-RPC auth envelope so
+        # a transport can neither lose the code nor pass with dead assertions.
         run: |
           opam exec -- dune build --root . \
             @test/runtest-test_auth_oauth \
-            @test/runtest-test_server_oauth_protocol
+            @test/runtest-test_server_oauth_protocol \
+            @test/runtest-test_server_auth_dashboard_actor_resolution \
+            @test/runtest-test_error_body_wire_shape
 
       - name: Run paused-work transfer and source-ACK suites
         id: paused_work_transfer_and_operator_suites

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -803,10 +803,13 @@ jobs:
         # a transport can neither lose the code nor pass with dead assertions.
         run: |
           opam exec -- dune build --root . \
+            @test/runtest-test_auth \
             @test/runtest-test_auth_oauth \
             @test/runtest-test_server_oauth_protocol \
             @test/runtest-test_server_auth_dashboard_actor_resolution \
-            @test/runtest-test_error_body_wire_shape
+            @test/runtest-test_error_body_wire_shape \
+            @test/runtest-test_tool_registry_consistency \
+            @test/runtest-test_tool_spec
 
       - name: Run paused-work transfer and source-ACK suites
         id: paused_work_transfer_and_operator_suites

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ Then open `http://127.0.0.1:8935/dashboard`. Options: `--team <preset>` (see
   login — this is the path to actually see the dashboard.
 - **`--docker`** builds a self-contained image and reproducibly boots the server
   + the team; the container binds a network address, so the dashboard shell
-  serves but its live data needs an admin token (the zero-auth loopback dev-token
-  is intentionally not exposed on a non-loopback bind). Use it to verify the
+  serves but its live data needs an explicit bearer token (the loopback
+  dev-token is intentionally not exposed on a non-loopback bind). Use it to verify the
   install/boot; use native to browse the dashboard.
 
 For the `curl | bash` installer, add `--team classic` to seed the same team:

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -43,6 +43,7 @@
     "ninja-keys": "^1.2.2",
     "preact": "^10.29.1",
     "shiki": "^4.0.2",
+    "uuid": "^14.0.0",
     "valibot": "^1.4.2"
   },
   "devDependencies": {

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       shiki:
         specifier: ^4.0.2
         version: 4.0.2
+      uuid:
+        specifier: ^14.0.0
+        version: 14.0.0
       valibot:
         specifier: ^1.4.2
         version: 1.4.2(typescript@6.0.3)

--- a/dashboard/src/api/core.test.ts
+++ b/dashboard/src/api/core.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   ApiRequestError,
+  apiRequestErrorFromResponse,
   authHeaders,
   clearStoredToken,
   confirmOperatorAction,
@@ -39,25 +40,25 @@ describe('stored token metadata', () => {
   it('persists token metadata and prefers the managed dev actor', () => {
     setStoredToken('loopback-dev-token', {
       source: 'dev',
-      actor: 'dashboard-dev!!!',
-      scope: 'admin',
+      actor: 'dashboard',
+      role: 'worker',
     })
 
     expect(getStoredToken()).toBe('loopback-dev-token')
     expect(getStoredTokenMeta()).toEqual({
       source: 'dev',
-      actor: 'dashboard-dev',
-      scope: 'admin',
+      actor: 'dashboard',
+      role: 'worker',
     })
-    expect(currentDashboardActor()).toBe('dashboard-dev')
+    expect(currentDashboardActor()).toBe('dashboard')
     expect(authHeaders()).toMatchObject({
       Authorization: 'Bearer loopback-dev-token',
-      'X-MASC-Agent': 'dashboard-dev',
+      'X-MASC-Agent': 'dashboard',
     })
   })
 
   it('clears both the token and metadata together', () => {
-    setStoredToken('manual-token', { source: 'manual', actor: 'dashboard-user' })
+    setStoredToken('manual-token', { source: 'manual' })
     clearStoredToken()
 
     expect(getStoredToken()).toBeNull()
@@ -69,9 +70,13 @@ describe('stored token metadata', () => {
     const unsubscribe = subscribeStoredTokenChanges(listener)
     const revisionBeforeChanges = currentStoredTokenRevision()
 
-    setStoredToken('manual-token', { source: 'manual', actor: 'dashboard-user' })
-    setStoredToken(' manual-token ', { source: 'manual', actor: 'dashboard-user' })
-    setStoredToken('manual-token', { source: 'manual', actor: 'dashboard-user-2' })
+    setStoredToken('manual-token', { source: 'manual' })
+    setStoredToken(' manual-token ', { source: 'manual' })
+    setStoredToken('manual-token', {
+      source: 'dev',
+      actor: 'dashboard',
+      role: 'worker',
+    })
     clearStoredToken()
     clearStoredToken()
     unsubscribe()
@@ -80,11 +85,11 @@ describe('stored token metadata', () => {
     expect(currentStoredTokenRevision()).toBe(revisionBeforeChanges + 3)
     expect(listener).toHaveBeenNthCalledWith(1, {
       token: 'manual-token',
-      meta: { source: 'manual', actor: 'dashboard-user', scope: null },
+      meta: { source: 'manual' },
     })
     expect(listener).toHaveBeenNthCalledWith(2, {
       token: 'manual-token',
-      meta: { source: 'manual', actor: 'dashboard-user-2', scope: null },
+      meta: { source: 'dev', actor: 'dashboard', role: 'worker' },
     })
     expect(listener).toHaveBeenNthCalledWith(3, {
       token: null,
@@ -97,6 +102,18 @@ describe('stored token metadata', () => {
 
     expect(dashboardBearerToken()).toBeNull()
     expect(authHeaders()).not.toHaveProperty('Authorization')
+  })
+
+  it('omits a guessed actor until a manual token has a server-resolved owner', () => {
+    setStoredToken('manual-token', { source: 'manual' })
+
+    expect(authHeaders()).toEqual({ Authorization: 'Bearer manual-token' })
+
+    setCanonicalDashboardActor('codex')
+    expect(authHeaders()).toEqual({
+      Authorization: 'Bearer manual-token',
+      'X-MASC-Agent': 'codex',
+    })
   })
 })
 
@@ -292,6 +309,35 @@ describe('post', () => {
       target_id: 'keeper-one',
       payload: {},
     })).rejects.toBeInstanceOf(OperatorActionSchemaDriftError)
+  })
+})
+
+describe('typed API errors', () => {
+  it('uses auth_error_code as authority and keeps error prose as detail', async () => {
+    const error = await apiRequestErrorFromResponse(
+      'POST',
+      '/mcp',
+      new Response(JSON.stringify({
+        error: 'stored token belongs to a different actor',
+        auth_error_code: 'actor_mismatch',
+      }), { status: 401 }),
+    )
+
+    expect(error.errorCode).toBe('actor_mismatch')
+    expect(error.authErrorCode).toBe('actor_mismatch')
+    expect(error.detail).toBe('stored token belongs to a different actor')
+  })
+
+  it('does not reinterpret error prose as a typed error code', async () => {
+    const error = await apiRequestErrorFromResponse(
+      'POST',
+      '/mcp',
+      new Response(JSON.stringify({ error: 'invalid_token' }), { status: 401 }),
+    )
+
+    expect(error.errorCode).toBe('invalid_token')
+    expect(error.authErrorCode).toBeUndefined()
+    expect(error.detail).toBe('invalid_token')
   })
 })
 

--- a/dashboard/src/api/core.test.ts
+++ b/dashboard/src/api/core.test.ts
@@ -328,6 +328,26 @@ describe('typed API errors', () => {
     expect(error.detail).toBe('stored token belongs to a different actor')
   })
 
+  it('reads auth_error_code from the JSON-RPC error data contract', async () => {
+    const error = await apiRequestErrorFromResponse(
+      'POST',
+      '/mcp',
+      new Response(JSON.stringify({
+        jsonrpc: '2.0',
+        id: null,
+        error: {
+          code: -32001,
+          message: 'stored token is no longer valid',
+          data: { auth_error_code: 'invalid_token' },
+        },
+      }), { status: 401 }),
+    )
+
+    expect(error.errorCode).toBe('invalid_token')
+    expect(error.authErrorCode).toBe('invalid_token')
+    expect(error.detail).toBe('stored token is no longer valid')
+  })
+
   it('does not reinterpret error prose as a typed error code', async () => {
     const error = await apiRequestErrorFromResponse(
       'POST',

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -426,16 +426,28 @@ async function errorResponseInfoFromResponse(res: Response): Promise<ErrorRespon
   try {
     const parsed = JSON.parse(rawText) as unknown
     if (isRecord(parsed)) {
+      const jsonRpcError = isRecord(parsed.error) ? parsed.error : null
+      const jsonRpcErrorData = jsonRpcError && isRecord(jsonRpcError.data)
+        ? jsonRpcError.data
+        : null
       const errorDetail = typeof parsed.error === 'string' ? parsed.error.trim() : ''
-      const authErrorCode = typeof parsed.auth_error_code === 'string'
+      const topLevelAuthErrorCode = typeof parsed.auth_error_code === 'string'
         ? parsed.auth_error_code.trim()
         : ''
+      const jsonRpcAuthErrorCode = typeof jsonRpcErrorData?.auth_error_code === 'string'
+        ? jsonRpcErrorData.auth_error_code.trim()
+        : ''
+      const authErrorCode = topLevelAuthErrorCode || jsonRpcAuthErrorCode
       const errorCode =
         authErrorCode
         || (typeof parsed.error_code === 'string' ? parsed.error_code.trim() : '')
         || (typeof parsed.status === 'string' ? parsed.status.trim() : '')
         || errorDetail
-      const message = typeof parsed.message === 'string' ? parsed.message.trim() : ''
+      const topLevelMessage = typeof parsed.message === 'string' ? parsed.message.trim() : ''
+      const jsonRpcMessage = typeof jsonRpcError?.message === 'string'
+        ? jsonRpcError.message.trim()
+        : ''
+      const message = topLevelMessage || jsonRpcMessage
       if (message || errorDetail || errorCode) {
         return {
           detail: message || errorDetail || errorCode || undefined,

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -10,6 +10,7 @@ import type {
 import { sanitizeDashboardActorName } from '../lib/dashboard-actor'
 import { isAbortError } from '../lib/async-state'
 import {
+  currentCanonicalDashboardActor,
   currentDashboardActorName,
   setCanonicalDashboardActor,
 } from '../lib/dashboard-session-actor'
@@ -25,17 +26,10 @@ function getQueryParams(): URLSearchParams {
 const TOKEN_STORAGE_KEY = 'masc_bearer_token'
 const TOKEN_META_STORAGE_KEY = 'masc_bearer_token_meta'
 
-type StoredTokenSource = 'dev' | 'manual' | 'url'
-
-const STORED_TOKEN_SOURCES = ['dev', 'manual', 'url'] as const
-
-const DEFAULT_STORED_TOKEN_SOURCE: StoredTokenSource = 'manual'
-
-export interface StoredTokenMeta {
-  source: StoredTokenSource
-  actor?: string | null
-  scope?: string | null
-}
+export type StoredTokenMeta =
+  | { source: 'dev'; actor: 'dashboard'; role: 'worker' }
+  | { source: 'manual' }
+  | { source: 'url' }
 
 export interface StoredTokenChange {
   token: string | null
@@ -74,16 +68,16 @@ export function subscribeStoredTokenChanges(
 function normalizeStoredTokenMeta(value: unknown): StoredTokenMeta | null {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return null
   const record = value as Record<string, unknown>
-  const source = typeof record.source === 'string' ? record.source : null
-  if (source === null || !(STORED_TOKEN_SOURCES as readonly string[]).includes(source)) return null
-  const actor = sanitizeDashboardActorName(
-    typeof record.actor === 'string' ? record.actor : null,
-  )
-  const scope =
-    typeof record.scope === 'string' && record.scope.trim() !== ''
-      ? record.scope.trim()
-      : null
-  return { source: source as StoredTokenSource, actor, scope }
+  if (record.source === 'manual') return { source: 'manual' }
+  if (record.source === 'url') return { source: 'url' }
+  if (
+    record.source === 'dev'
+    && record.actor === 'dashboard'
+    && record.role === 'worker'
+  ) {
+    return { source: 'dev', actor: 'dashboard', role: 'worker' }
+  }
+  return null
 }
 
 function storedTokenMetaEquals(
@@ -91,9 +85,9 @@ function storedTokenMetaEquals(
   right: StoredTokenMeta | null,
 ): boolean {
   if (left === null || right === null) return left === right
-  return left.source === right.source
-    && (left.actor ?? null) === (right.actor ?? null)
-    && (left.scope ?? null) === (right.scope ?? null)
+  if (left.source !== right.source) return false
+  if (left.source !== 'dev' || right.source !== 'dev') return true
+  return left.actor === right.actor && left.role === right.role
 }
 
 function initTokenFromUrl(): void {
@@ -135,7 +129,7 @@ export function getStoredTokenMeta(): StoredTokenMeta | null {
 
 export function setStoredToken(
   token: string,
-  meta: Partial<StoredTokenMeta> & { source?: StoredTokenSource } = {},
+  meta: StoredTokenMeta = { source: 'manual' },
 ): void {
   const normalizedToken = token.trim()
   if (!normalizedToken) {
@@ -144,11 +138,7 @@ export function setStoredToken(
   }
   const previousToken = getStoredToken()
   const previousMeta = getStoredTokenMeta()
-  const nextMeta = normalizeStoredTokenMeta({
-    source: meta.source ?? DEFAULT_STORED_TOKEN_SOURCE,
-    actor: meta.actor ?? null,
-    scope: meta.scope ?? null,
-  })
+  const nextMeta = normalizeStoredTokenMeta(meta)
   sessionStorage.setItem(TOKEN_STORAGE_KEY, normalizedToken)
   if (nextMeta) {
     sessionStorage.setItem(TOKEN_META_STORAGE_KEY, JSON.stringify(nextMeta))
@@ -186,7 +176,7 @@ export function isRemoteAccess(): boolean {
 export function currentDashboardActor(): string {
   const meta = getStoredTokenMeta()
   const managedActor = meta?.source === 'dev'
-    ? sanitizeDashboardActorName(meta.actor)
+    ? meta.actor
     : null
   if (managedActor) return managedActor
   return currentDashboardActorName()
@@ -200,9 +190,13 @@ type HeaderOptions = {
 export function authHeaders(options: HeaderOptions = {}): Record<string, string> {
   const headers: Record<string, string> = {}
   const token = dashboardBearerToken()
+  const tokenMeta = getStoredTokenMeta()
+  const resolvedImplicitActor = token && tokenMeta?.source !== 'dev'
+    ? currentCanonicalDashboardActor()
+    : currentDashboardActor()
   const agent = options.actorName !== undefined
     ? sanitizeDashboardActorName(options.actorName)
-    : currentDashboardActor()
+    : resolvedImplicitActor
   if (token) headers['Authorization'] = `Bearer ${token}`
   if (options.includeActor !== false && agent) {
     headers['X-MASC-Agent'] = agent
@@ -239,6 +233,7 @@ export class ApiRequestError extends Error {
   timeout: boolean
   detail?: string
   errorCode?: string
+  authErrorCode?: string
 
   constructor(opts: {
     method: string
@@ -249,6 +244,7 @@ export class ApiRequestError extends Error {
     timeoutMs?: number
     detail?: string
     errorCode?: string
+    authErrorCode?: string
   }) {
     const method = opts.method.toUpperCase()
     const timeout = opts.timeout === true
@@ -267,6 +263,7 @@ export class ApiRequestError extends Error {
     this.timeout = timeout
     this.detail = detail
     this.errorCode = opts.errorCode?.trim() || undefined
+    this.authErrorCode = opts.authErrorCode?.trim() || undefined
   }
 }
 
@@ -415,6 +412,7 @@ import { isRecord } from '../lib/type-guards'
 interface ErrorResponseInfo {
   detail?: string
   errorCode?: string
+  authErrorCode?: string
 }
 
 async function errorResponseInfoFromResponse(res: Response): Promise<ErrorResponseInfo> {
@@ -428,14 +426,21 @@ async function errorResponseInfoFromResponse(res: Response): Promise<ErrorRespon
   try {
     const parsed = JSON.parse(rawText) as unknown
     if (isRecord(parsed)) {
+      const errorDetail = typeof parsed.error === 'string' ? parsed.error.trim() : ''
+      const authErrorCode = typeof parsed.auth_error_code === 'string'
+        ? parsed.auth_error_code.trim()
+        : ''
       const errorCode =
-        (typeof parsed.error === 'string' ? parsed.error.trim() : '')
+        authErrorCode
+        || (typeof parsed.error_code === 'string' ? parsed.error_code.trim() : '')
         || (typeof parsed.status === 'string' ? parsed.status.trim() : '')
+        || errorDetail
       const message = typeof parsed.message === 'string' ? parsed.message.trim() : ''
-      if (message || errorCode) {
+      if (message || errorDetail || errorCode) {
         return {
-          detail: message || errorCode || undefined,
+          detail: message || errorDetail || errorCode || undefined,
           errorCode: errorCode || undefined,
+          authErrorCode: authErrorCode || undefined,
         }
       }
     }
@@ -458,6 +463,7 @@ export async function apiRequestErrorFromResponse(
     statusText: res.statusText,
     detail: info.detail,
     errorCode: info.errorCode,
+    authErrorCode: info.authErrorCode,
   })
 }
 

--- a/dashboard/src/api/dev-token.test.ts
+++ b/dashboard/src/api/dev-token.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   devTokenBootstrapStatus,
   ensureDevToken,
+  refreshDevTokenAfterAuthError,
   resetDevTokenBootstrap,
   type DevTokenBootstrapStatus,
 } from './dev-token'
@@ -62,7 +63,7 @@ describe('ensureDevToken', () => {
       .mockResolvedValueOnce(jsonResponse({
         token: 'fresh-dev-token',
         actor: 'dashboard',
-        scope: 'admin',
+        role: 'worker',
       }))
 
     await ensureDevToken()
@@ -76,7 +77,7 @@ describe('ensureDevToken', () => {
     expect(setStoredToken).toHaveBeenCalledWith('fresh-dev-token', {
       source: 'dev',
       actor: 'dashboard',
-      scope: 'admin',
+      role: 'worker',
     })
     expect(devTokenBootstrapStatus.value).toBe('ok')
   })
@@ -85,7 +86,7 @@ describe('ensureDevToken', () => {
     fetchWithTimeout.mockResolvedValueOnce(jsonResponse({
       token: 'loopback-dev-token',
       actor: 'dashboard',
-      scope: 'admin',
+      role: 'worker',
     }))
 
     await ensureDevToken()
@@ -105,5 +106,50 @@ describe('ensureDevToken', () => {
     expect(fetchWithTimeout).toHaveBeenCalledTimes(1)
     expect(setStoredToken).not.toHaveBeenCalled()
     expect(devTokenBootstrapStatus.value).toBe('no_endpoint')
+  })
+
+  it('rejects a bootstrap response without the exact worker identity contract', async () => {
+    fetchWithTimeout.mockResolvedValueOnce(jsonResponse({
+      token: 'overprivileged-token',
+      actor: 'dashboard',
+      role: 'admin',
+    }))
+
+    await ensureDevToken()
+
+    expect(setStoredToken).not.toHaveBeenCalled()
+    expect(devTokenBootstrapStatus.value).toBe('invalid_response')
+  })
+
+  it('refreshes a managed loopback token only for a typed refreshable auth code', async () => {
+    let token: string | null = 'stale-token'
+    let meta: { source: 'dev'; actor: 'dashboard'; role: 'worker' } | null = {
+      source: 'dev',
+      actor: 'dashboard',
+      role: 'worker',
+    }
+    getStoredToken.mockImplementation(() => token)
+    getStoredTokenMeta.mockImplementation(() => meta)
+    clearStoredToken.mockImplementation(() => {
+      token = null
+      meta = null
+    })
+    setStoredToken.mockImplementation((nextToken, nextMeta) => {
+      token = nextToken
+      meta = nextMeta
+    })
+    fetchWithTimeout.mockResolvedValueOnce(jsonResponse({
+      token: 'fresh-token',
+      actor: 'dashboard',
+      role: 'worker',
+    }))
+
+    await expect(refreshDevTokenAfterAuthError('invalid_token')).resolves.toBe(true)
+    expect(token).toBe('fresh-token')
+    expect(clearStoredToken).toHaveBeenCalledTimes(1)
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(1)
+
+    await expect(refreshDevTokenAfterAuthError('insufficient_role')).resolves.toBe(false)
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(1)
   })
 })

--- a/dashboard/src/api/dev-token.test.ts
+++ b/dashboard/src/api/dev-token.test.ts
@@ -152,4 +152,42 @@ describe('ensureDevToken', () => {
     await expect(refreshDevTokenAfterAuthError('insufficient_role')).resolves.toBe(false)
     expect(fetchWithTimeout).toHaveBeenCalledTimes(1)
   })
+
+  it('coalesces concurrent stale-token recovery onto one refresh', async () => {
+    let token: string | null = 'stale-token'
+    let meta: { source: 'dev'; actor: 'dashboard'; role: 'worker' } | null = {
+      source: 'dev',
+      actor: 'dashboard',
+      role: 'worker',
+    }
+    let resolveFetch!: (response: Response) => void
+    const pendingFetch = new Promise<Response>((resolve) => {
+      resolveFetch = resolve
+    })
+    getStoredToken.mockImplementation(() => token)
+    getStoredTokenMeta.mockImplementation(() => meta)
+    clearStoredToken.mockImplementation(() => {
+      token = null
+      meta = null
+    })
+    setStoredToken.mockImplementation((nextToken, nextMeta) => {
+      token = nextToken
+      meta = nextMeta
+    })
+    fetchWithTimeout.mockReturnValueOnce(pendingFetch)
+
+    const first = refreshDevTokenAfterAuthError('invalid_token')
+    const second = refreshDevTokenAfterAuthError('token_expired')
+    expect(clearStoredToken).toHaveBeenCalledTimes(1)
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(1)
+
+    resolveFetch(jsonResponse({
+      token: 'fresh-token',
+      actor: 'dashboard',
+      role: 'worker',
+    }))
+
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true])
+    expect(token).toBe('fresh-token')
+  })
 })

--- a/dashboard/src/api/dev-token.ts
+++ b/dashboard/src/api/dev-token.ts
@@ -13,6 +13,7 @@ import {
 const DEV_TOKEN_FETCH_TIMEOUT_MS = 3000
 
 let devTokenBootstrapPromise: Promise<void> | null = null
+let devTokenRefreshPromise: Promise<boolean> | null = null
 
 /**
  * Tracks the outcome of the loopback dev-token bootstrap so the UI can
@@ -134,11 +135,21 @@ export function resetDevTokenBootstrap(): void {
 
 export async function refreshDevTokenAfterAuthError(code: unknown): Promise<boolean> {
   if (!isRefreshableDashboardAuthCode(code)) return false
-  if (isRemoteAccess() || !getStoredToken()) return false
+  if (isRemoteAccess()) return false
   if (getStoredTokenMeta()?.source === 'manual') return false
+  if (devTokenRefreshPromise) return devTokenRefreshPromise
+  if (!getStoredToken()) return false
 
-  clearStoredToken()
-  resetDevTokenBootstrap()
-  await ensureDevToken()
-  return getStoredTokenMeta()?.source === 'dev' && getStoredToken() !== null
+  const refresh = (async () => {
+    clearStoredToken()
+    resetDevTokenBootstrap()
+    await ensureDevToken()
+    return getStoredTokenMeta()?.source === 'dev' && getStoredToken() !== null
+  })()
+  devTokenRefreshPromise = refresh
+  try {
+    return await refresh
+  } finally {
+    if (devTokenRefreshPromise === refresh) devTokenRefreshPromise = null
+  }
 }

--- a/dashboard/src/api/dev-token.ts
+++ b/dashboard/src/api/dev-token.ts
@@ -1,4 +1,5 @@
 import { signal, type ReadonlySignal } from '@preact/signals'
+import type { DashboardAuthErrorCode } from '../types/dashboard-execution'
 import {
   clearStoredToken,
   currentDashboardActor,
@@ -20,6 +21,7 @@ let devTokenBootstrapPromise: Promise<void> | null = null
  *   fetching   — in-flight
  *   ok         — token stored
  *   no_endpoint — /dev-token returned 404 (loopback disabled or strict auth)
+ *   invalid_response — endpoint response violated the exact token contract
  *   network    — fetch threw (server down, CORS, DNS)
  */
 export type DevTokenBootstrapStatus =
@@ -27,6 +29,7 @@ export type DevTokenBootstrapStatus =
   | 'fetching'
   | 'ok'
   | 'no_endpoint'
+  | 'invalid_response'
   | 'network'
 
 export const devTokenBootstrapStatus: ReadonlySignal<DevTokenBootstrapStatus> =
@@ -35,7 +38,20 @@ export const devTokenBootstrapStatus: ReadonlySignal<DevTokenBootstrapStatus> =
 interface DevTokenBootstrapPayload {
   token?: unknown
   actor?: unknown
-  scope?: unknown
+  role?: unknown
+}
+
+const REFRESHABLE_AUTH_CODES: ReadonlySet<DashboardAuthErrorCode> = new Set([
+  'invalid_token',
+  'token_expired',
+  'actor_mismatch',
+])
+
+export function isRefreshableDashboardAuthCode(
+  value: unknown,
+): value is DashboardAuthErrorCode {
+  return typeof value === 'string'
+    && REFRESHABLE_AUTH_CODES.has(value as DashboardAuthErrorCode)
 }
 
 function isRetryableDevTokenStatus(status: number): boolean {
@@ -55,7 +71,7 @@ function shouldRefreshDevToken(): boolean {
   if (isRemoteAccess() || actor !== 'dashboard') return false
   // Loopback dashboard sessions should self-heal if they are still holding
   // a borrowed non-dashboard token (for example an old MCP-client paste/URL token).
-  return meta == null || meta.actor == null || meta.actor !== actor
+  return meta == null || meta.source === 'url'
 }
 
 /** Fetch the loopback-only dev token once per page load and stash it so
@@ -88,26 +104,19 @@ export async function ensureDevToken(): Promise<void> {
       }
       const payload = (await res.json()) as DevTokenBootstrapPayload
       const token = typeof payload.token === 'string' ? payload.token.trim() : ''
-      if (!token) {
-        ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'no_endpoint'
+      if (!token || payload.actor !== 'dashboard' || payload.role !== 'worker') {
+        ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'invalid_response'
         devTokenBootstrapPromise = null
         return
       }
-      const actor = typeof payload.actor === 'string' ? payload.actor.trim() : 'dashboard'
-      const scope =
-        typeof payload.scope === 'string' && payload.scope.trim() !== ''
-          ? payload.scope.trim()
-          : null
       if (
         token !== storedToken
         || storedMeta?.source !== 'dev'
-        || storedMeta.actor !== actor
-        || (storedMeta.scope ?? null) !== scope
       ) {
         setStoredToken(token, {
           source: 'dev',
-          actor,
-          scope,
+          actor: 'dashboard',
+          role: 'worker',
         })
       }
       ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'ok'
@@ -121,4 +130,15 @@ export async function ensureDevToken(): Promise<void> {
 
 export function resetDevTokenBootstrap(): void {
   devTokenBootstrapPromise = null
+}
+
+export async function refreshDevTokenAfterAuthError(code: unknown): Promise<boolean> {
+  if (!isRefreshableDashboardAuthCode(code)) return false
+  if (isRemoteAccess() || !getStoredToken()) return false
+  if (getStoredTokenMeta()?.source === 'manual') return false
+
+  clearStoredToken()
+  resetDevTokenBootstrap()
+  await ensureDevToken()
+  return getStoredTokenMeta()?.source === 'dev' && getStoredToken() !== null
 }

--- a/dashboard/src/api/ide.test.ts
+++ b/dashboard/src/api/ide.test.ts
@@ -228,7 +228,7 @@ describe('ide API', () => {
   })
 
   it('deleteIdeAnnotation sends the bearer token and appends repo_id param without keeper_id', async () => {
-    setStoredToken('delete-test-token', { source: 'manual', actor: 'dashboard-user' })
+    setStoredToken('delete-test-token', { source: 'manual' })
     stubFetch({}, true)
 
     await deleteIdeAnnotation('ann-1', { repoId: 'masc' })

--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -1326,7 +1326,11 @@ describe('streamKeeperMessage', () => {
 
     await expect(
       streamKeeperMessage('sangsu', 'ping', { onEvent: () => {} }),
-    ).rejects.toThrow()
+    ).rejects.toMatchObject({
+      name: 'ApiRequestError',
+      authErrorCode: 'same_origin_blocked',
+      detail: '[AuthError] Forbidden: browser cannot cross-origin HTTP mutation',
+    })
 
     // Only the single chat POST — no dev-token refresh, no retry.
     expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([

--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -1233,7 +1233,7 @@ describe('streamKeeperMessage', () => {
     window.sessionStorage.setItem('masc_bearer_token', 'stale-token')
     window.sessionStorage.setItem(
       'masc_bearer_token_meta',
-      JSON.stringify({ source: 'dev', actor: 'dashboard', scope: 'worker' }),
+      JSON.stringify({ source: 'dev', actor: 'dashboard', role: 'worker' }),
     )
   }
 
@@ -1255,7 +1255,7 @@ describe('streamKeeperMessage', () => {
       }
       if (url === '/api/v1/dashboard/dev-token') {
         return Promise.resolve(new Response(
-          JSON.stringify({ token: 'fresh-token', actor: 'dashboard', scope: 'worker' }),
+          JSON.stringify({ token: 'fresh-token', actor: 'dashboard', role: 'worker' }),
           { status: 200, headers: { 'Content-Type': 'application/json' } },
         ))
       }

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -12,14 +12,9 @@ import type {
   KeeperQueueReceiptFailureKind,
   KeeperUserInputBlock,
 } from '../types'
-import type { DashboardAuthErrorCode } from '../types/dashboard-execution'
 import {
   currentDashboardActor,
   apiRequestErrorFromResponse,
-  clearStoredToken,
-  getStoredToken,
-  getStoredTokenMeta,
-  isRemoteAccess,
   jsonHeaders,
   post,
   runOperatorAction,
@@ -28,7 +23,7 @@ import {
   fetchJsonWithTimeout,
   DEFAULT_GET_TIMEOUT_MS,
 } from './core'
-import { ensureDevToken, resetDevTokenBootstrap } from './dev-token'
+import { refreshDevTokenAfterAuthError } from './dev-token'
 import { isKeeperChatReceiptId, parseKeeperQueueRevision } from '../lib/keeper-chat-receipt'
 import type {
   KeeperCompositeSnapshot,
@@ -513,47 +508,13 @@ function keeperStreamErrorMessage(raw: string, status: number): string {
   return message
 }
 
-/**
- * Auth error codes that mean the stored bearer token is stale or wrong for
- * the requested actor — minting a fresh dev token and retrying can recover.
- * `same_origin_blocked` / `insufficient_role` / `missing_token` are NOT here:
- * a token refresh cannot fix a CORS rejection, a role shortfall, or a request
- * that simply omitted the token.
- */
-const STALE_TOKEN_AUTH_CODES: ReadonlySet<DashboardAuthErrorCode> = new Set([
-  'invalid_token',
-  'token_expired',
-  'actor_mismatch',
-])
-
-/**
- * Decide whether a 401 body signals a stale/wrong bearer token.
- * Primary gate: the typed `auth_error_code` field in the JSON body
- * (server SSOT: `lib/types/masc_error.ml:dashboard_auth_error_code`,
- * emitted by `lib/server/server_auth.ml:auth_error_json`).
- */
-function isStaleTokenAuthError(raw: string): boolean {
+function authErrorCode(raw: string): unknown {
   try {
     const parsed = JSON.parse(raw) as { auth_error_code?: unknown }
-    const code = parsed.auth_error_code
-    if (typeof code === 'string') {
-      return STALE_TOKEN_AUTH_CODES.has(code as DashboardAuthErrorCode)
-    }
+    return parsed.auth_error_code
   } catch {
-    return false
+    return null
   }
-  return false
-}
-
-async function refreshLoopbackDevTokenAfterMismatch(): Promise<boolean> {
-  if (isRemoteAccess() || !getStoredToken()) return false
-  const meta = getStoredTokenMeta()
-  if (meta?.source === 'manual') return false
-
-  clearStoredToken()
-  resetDevTokenBootstrap()
-  await ensureDevToken()
-  return getStoredToken() !== null
 }
 
 export interface StreamKeeperMessageOptions {
@@ -644,8 +605,7 @@ export async function streamKeeperMessage(
     let raw = await res.text()
     if (
       res.status === 401
-      && isStaleTokenAuthError(raw)
-      && await refreshLoopbackDevTokenAfterMismatch()
+      && await refreshDevTokenAfterAuthError(authErrorCode(raw))
     ) {
       res = await postStream()
       if (res.ok) {

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -493,30 +493,6 @@ export interface KeeperStreamOutcome {
   terminal: boolean
 }
 
-function keeperStreamErrorMessage(raw: string, status: number): string {
-  let message = raw || `스트리밍 요청 실패 (${status})`
-  try {
-    const parsed = JSON.parse(raw) as { error?: string | { message?: string }; message?: string }
-    if (typeof parsed.error === 'string') {
-      message = parsed.error
-    } else {
-      message = parsed.error?.message ?? parsed.message ?? message
-    }
-  } catch {
-    // Keep raw text fallback.
-  }
-  return message
-}
-
-function authErrorCode(raw: string): unknown {
-  try {
-    const parsed = JSON.parse(raw) as { auth_error_code?: unknown }
-    return parsed.auth_error_code
-  } catch {
-    return null
-  }
-}
-
 export interface StreamKeeperMessageOptions {
   signal?: AbortSignal
   onEvent: (event: KeeperChatStreamEvent) => void
@@ -589,7 +565,8 @@ export async function streamKeeperMessage(
     body.user_blocks = userBlocks.map(streamUserBlockToWire)
   }
   const requestBody = JSON.stringify(body)
-  const postStream = () => fetch('/api/v1/keepers/chat/stream', {
+  const streamPath = '/api/v1/keepers/chat/stream'
+  const postStream = () => fetch(streamPath, {
     method: 'POST',
     headers: {
       ...jsonHeaders(),
@@ -602,20 +579,18 @@ export async function streamKeeperMessage(
   let res = await postStream()
 
   if (!res.ok) {
-    let raw = await res.text()
+    let requestError = await apiRequestErrorFromResponse('POST', streamPath, res)
     if (
       res.status === 401
-      && await refreshDevTokenAfterAuthError(authErrorCode(raw))
+      && await refreshDevTokenAfterAuthError(requestError.authErrorCode)
     ) {
       res = await postStream()
-      if (res.ok) {
-        raw = ''
-      } else {
-        raw = await res.text()
+      if (!res.ok) {
+        requestError = await apiRequestErrorFromResponse('POST', streamPath, res)
       }
     }
     if (!res.ok) {
-      throw new Error(keeperStreamErrorMessage(raw, res.status))
+      throw requestError
     }
   }
 

--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -48,8 +48,8 @@ vi.mock('./core', () => ({
 vi.mock('./tool-host-failure', () => ({ reportToolHostFailure }))
 vi.mock('../components/common/toast', () => ({ showActionToast: vi.fn() }))
 
-const okToolResponse = () =>
-  new Response('data: {"result":{"content":[{"type":"text","text":"ok"}]}}\n', {
+const okToolResponse = (text = 'ok') =>
+  new Response(`data: ${JSON.stringify({ result: { content: [{ type: 'text', text }] } })}\n`, {
     status: 200,
   })
 
@@ -255,5 +255,23 @@ describe('MCP 2026-07-28 dashboard client', () => {
     })
     expect(fetchWithTimeout.mock.calls.map(call => call[0]))
       .toEqual(['/api/v1/dashboard/dev-token', '/mcp'])
+  })
+
+  it('uses distinct platform UUIDs for consecutive tool request identities', async () => {
+    fetchWithTimeout
+      .mockResolvedValueOnce(okToolResponse('first'))
+      .mockResolvedValueOnce(okToolResponse('second'))
+
+    const { callMcpTool } = await import('./mcp')
+    await expect(callMcpTool('masc_status', {})).resolves.toBe('first')
+    await expect(callMcpTool('masc_status', {})).resolves.toBe('second')
+
+    const requestIds = callsByMethod('tools/call').map(([, init]) => {
+      const body = JSON.parse(init.body as string) as { id: unknown }
+      return body.id
+    })
+    expect(requestIds).toHaveLength(2)
+    expect(requestIds.every(id => typeof id === 'string')).toBe(true)
+    expect(requestIds[0]).not.toBe(requestIds[1])
   })
 })

--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -85,6 +85,7 @@ beforeEach(() => {
 afterEach(async () => {
   const { resetMcpClientState } = await import('./mcp')
   resetMcpClientState()
+  vi.unstubAllGlobals()
   vi.clearAllMocks()
   vi.resetModules()
 })
@@ -273,5 +274,23 @@ describe('MCP 2026-07-28 dashboard client', () => {
     expect(requestIds).toHaveLength(2)
     expect(requestIds.every(id => typeof id === 'string')).toBe(true)
     expect(requestIds[0]).not.toBe(requestIds[1])
+  })
+
+  it('uses Web Crypto random bytes when randomUUID is unavailable', async () => {
+    const getRandomValues = vi.fn((bytes: Uint8Array) => {
+      bytes.forEach((_, index) => { bytes[index] = index })
+      return bytes
+    })
+    vi.stubGlobal('crypto', { getRandomValues })
+    fetchWithTimeout.mockResolvedValueOnce(okToolResponse())
+
+    const { callMcpTool } = await import('./mcp')
+    await expect(callMcpTool('masc_status', {})).resolves.toBe('ok')
+
+    const toolCall = callsByMethod('tools/call')[0]
+    if (!toolCall) throw new Error('tools/call request missing')
+    const body = JSON.parse(toolCall[1].body as string) as { id: unknown }
+    expect(getRandomValues).toHaveBeenCalled()
+    expect(body.id).toBe('00010203-0405-4607-8809-0a0b0c0d0e0f')
   })
 })

--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -243,7 +243,7 @@ describe('MCP 2026-07-28 dashboard client', () => {
     getStoredToken.mockReturnValue(null)
     fetchWithTimeout
       .mockResolvedValueOnce(new Response(JSON.stringify({
-        token: 'loopback-dev-token', actor: 'dashboard', scope: 'admin',
+        token: 'loopback-dev-token', actor: 'dashboard', role: 'worker',
       }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
       .mockResolvedValueOnce(okToolResponse())
 
@@ -251,7 +251,7 @@ describe('MCP 2026-07-28 dashboard client', () => {
     await callMcpTool('masc_status', {})
 
     expect(setStoredToken).toHaveBeenCalledWith('loopback-dev-token', {
-      source: 'dev', actor: 'dashboard', scope: 'admin',
+      source: 'dev', actor: 'dashboard', role: 'worker',
     })
     expect(fetchWithTimeout.mock.calls.map(call => call[0]))
       .toEqual(['/api/v1/dashboard/dev-token', '/mcp'])

--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -83,6 +83,12 @@ function deferred<T>() {
 }
 
 beforeEach(() => {
+  fetchWithTimeout.mockReset()
+  reportToolHostFailure.mockReset().mockResolvedValue({ ok: true })
+  apiRequestErrorFromResponse.mockReset().mockImplementation(
+    async (method: string, path: string, res: Response) =>
+      new Error(`${method} ${path}: ${res.status}`),
+  )
   currentDashboardActor.mockReturnValue('dashboard')
   currentStoredTokenRevision.mockReturnValue(0)
   getStoredToken.mockReturnValue('test-stored-token')
@@ -132,7 +138,16 @@ describe('MCP 2026-07-28 dashboard client', () => {
   })
 
   it('preserves the dashboard actor injection contract', async () => {
-    fetchWithTimeout.mockResolvedValueOnce(okToolResponse())
+    getStoredTokenMeta.mockReturnValue({
+      source: 'dev',
+      actor: 'dashboard',
+      role: 'worker',
+    })
+    fetchWithTimeout
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        token: 'test-stored-token', actor: 'dashboard', role: 'worker',
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+      .mockResolvedValueOnce(okToolResponse())
     const { callMcpTool } = await import('./mcp')
     await callMcpTool('masc_keeper_create_from_persona', { persona_name: 'sonsukku' })
 
@@ -327,6 +342,9 @@ describe('MCP 2026-07-28 dashboard client', () => {
       revision += 1
     })
     fetchWithTimeout
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        token: 'stale-dev-token', actor: 'dashboard', role: 'worker',
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
       .mockResolvedValueOnce(new Response(`data: ${JSON.stringify({
         result: {
           isError: true,
@@ -344,7 +362,12 @@ describe('MCP 2026-07-28 dashboard client', () => {
 
     expect(callsByMethod('tools/call')).toHaveLength(2)
     expect(fetchWithTimeout.mock.calls.map(call => call[0]))
-      .toEqual(['/mcp', '/api/v1/dashboard/dev-token', '/mcp'])
+      .toEqual([
+        '/api/v1/dashboard/dev-token',
+        '/mcp',
+        '/api/v1/dashboard/dev-token',
+        '/mcp',
+      ])
     expect(token).toBe('fresh-dev-token')
     expect(reportToolHostFailure).not.toHaveBeenCalled()
   })
@@ -380,6 +403,9 @@ describe('MCP 2026-07-28 dashboard client', () => {
     })
     fetchWithTimeout
       .mockResolvedValueOnce(new Response(JSON.stringify({
+        token: 'stale-dev-token', actor: 'dashboard', role: 'worker',
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
         jsonrpc: '2.0',
         id: null,
         error: {
@@ -398,7 +424,12 @@ describe('MCP 2026-07-28 dashboard client', () => {
 
     expect(callsByMethod('tools/call')).toHaveLength(2)
     expect(fetchWithTimeout.mock.calls.map(call => call[0]))
-      .toEqual(['/mcp', '/api/v1/dashboard/dev-token', '/mcp'])
+      .toEqual([
+        '/api/v1/dashboard/dev-token',
+        '/mcp',
+        '/api/v1/dashboard/dev-token',
+        '/mcp',
+      ])
     expect(token).toBe('fresh-dev-token')
     expect(reportToolHostFailure).not.toHaveBeenCalled()
   })

--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
+  ApiRequestError,
   apiRequestErrorFromResponse,
   fetchWithTimeout,
   reportToolHostFailure,
@@ -13,6 +14,17 @@ const {
   isRemoteAccess,
   setStoredToken,
 } = vi.hoisted(() => ({
+  ApiRequestError: class ApiRequestError extends Error {
+    status?: number
+    authErrorCode?: string
+
+    constructor(opts: { status?: number; detail?: string; authErrorCode?: string }) {
+      super(opts.detail ?? 'API request failed')
+      this.name = 'ApiRequestError'
+      this.status = opts.status
+      this.authErrorCode = opts.authErrorCode
+    }
+  },
   apiRequestErrorFromResponse: vi.fn(async (method: string, path: string, res: Response) =>
     new Error(`${method} ${path}: ${res.status}`)),
   fetchWithTimeout: vi.fn(),
@@ -32,6 +44,7 @@ const {
 }))
 
 vi.mock('./core', () => ({
+  ApiRequestError,
   apiRequestErrorFromResponse,
   fetchWithTimeout,
   DEFAULT_MCP_TIMEOUT_MS: 30000,
@@ -292,5 +305,101 @@ describe('MCP 2026-07-28 dashboard client', () => {
     const body = JSON.parse(toolCall[1].body as string) as { id: unknown }
     expect(getRandomValues).toHaveBeenCalled()
     expect(body.id).toBe('00010203-0405-4607-8809-0a0b0c0d0e0f')
+  })
+
+  it('refreshes a managed token once on a typed MCP auth result', async () => {
+    let token: string | null = 'stale-dev-token'
+    let meta: { source: 'dev'; actor: 'dashboard'; role: 'worker' } | null = {
+      source: 'dev', actor: 'dashboard', role: 'worker',
+    }
+    let revision = 0
+    getStoredToken.mockImplementation(() => token)
+    getStoredTokenMeta.mockImplementation(() => meta)
+    currentStoredTokenRevision.mockImplementation(() => revision)
+    clearStoredToken.mockImplementationOnce(() => {
+      token = null
+      meta = null
+      revision += 1
+    })
+    setStoredToken.mockImplementationOnce((nextToken, nextMeta) => {
+      token = nextToken
+      meta = nextMeta
+      revision += 1
+    })
+    fetchWithTimeout
+      .mockResolvedValueOnce(new Response(`data: ${JSON.stringify({
+        result: {
+          isError: true,
+          content: [{ type: 'text', text: 'authentication rejected' }],
+          structuredContent: { auth_error_code: 'actor_mismatch' },
+        },
+      })}\n`, { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        token: 'fresh-dev-token', actor: 'dashboard', role: 'worker',
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+      .mockResolvedValueOnce(okToolResponse())
+
+    const { callMcpTool } = await import('./mcp')
+    await expect(callMcpTool('masc_status', {})).resolves.toBe('ok')
+
+    expect(callsByMethod('tools/call')).toHaveLength(2)
+    expect(fetchWithTimeout.mock.calls.map(call => call[0]))
+      .toEqual(['/mcp', '/api/v1/dashboard/dev-token', '/mcp'])
+    expect(token).toBe('fresh-dev-token')
+    expect(reportToolHostFailure).not.toHaveBeenCalled()
+  })
+
+  it('refreshes a managed token once on a typed HTTP 401', async () => {
+    let token: string | null = 'stale-dev-token'
+    let meta: { source: 'dev'; actor: 'dashboard'; role: 'worker' } | null = {
+      source: 'dev', actor: 'dashboard', role: 'worker',
+    }
+    let revision = 0
+    getStoredToken.mockImplementation(() => token)
+    getStoredTokenMeta.mockImplementation(() => meta)
+    currentStoredTokenRevision.mockImplementation(() => revision)
+    clearStoredToken.mockImplementationOnce(() => {
+      token = null
+      meta = null
+      revision += 1
+    })
+    setStoredToken.mockImplementationOnce((nextToken, nextMeta) => {
+      token = nextToken
+      meta = nextMeta
+      revision += 1
+    })
+    apiRequestErrorFromResponse.mockImplementationOnce(async (_method, _path, res) => {
+      const payload = await res.json() as {
+        error?: { message?: string; data?: { auth_error_code?: string } }
+      }
+      return new ApiRequestError({
+        status: res.status,
+        detail: payload.error?.message,
+        authErrorCode: payload.error?.data?.auth_error_code,
+      })
+    })
+    fetchWithTimeout
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        jsonrpc: '2.0',
+        id: null,
+        error: {
+          code: -32001,
+          message: 'authentication rejected',
+          data: { auth_error_code: 'token_expired' },
+        },
+      }), { status: 401, headers: { 'Content-Type': 'application/json' } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        token: 'fresh-dev-token', actor: 'dashboard', role: 'worker',
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+      .mockResolvedValueOnce(okToolResponse())
+
+    const { callMcpTool } = await import('./mcp')
+    await expect(callMcpTool('masc_status', {})).resolves.toBe('ok')
+
+    expect(callsByMethod('tools/call')).toHaveLength(2)
+    expect(fetchWithTimeout.mock.calls.map(call => call[0]))
+      .toEqual(['/mcp', '/api/v1/dashboard/dev-token', '/mcp'])
+    expect(token).toBe('fresh-dev-token')
+    expect(reportToolHostFailure).not.toHaveBeenCalled()
   })
 })

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -1,5 +1,6 @@
 // MASC Dashboard — MCP 2026-07-28 over Streamable HTTP
 
+import { v4 as randomUuid } from 'uuid'
 import {
   apiRequestErrorFromResponse,
   fetchWithTimeout,
@@ -246,7 +247,7 @@ async function callMcpToolInternal(
   toolName: string,
   args: Record<string, unknown>,
 ): Promise<string> {
-  const requestId = crypto.randomUUID()
+  const requestId = randomUuid()
   synchronizeMcpAuthRevision()
   try {
     const binding = await ensureBinding()

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -246,7 +246,7 @@ async function callMcpToolInternal(
   toolName: string,
   args: Record<string, unknown>,
 ): Promise<string> {
-  const requestId = String(Math.floor(Date.now() % 1000000))
+  const requestId = crypto.randomUUID()
   synchronizeMcpAuthRevision()
   try {
     const binding = await ensureBinding()
@@ -263,7 +263,7 @@ async function callMcpToolInternal(
         name: toolName,
         arguments: toolArgs,
       },
-      id: Number.parseInt(requestId, 10),
+      id: requestId,
     }, binding, DEFAULT_MCP_TIMEOUT_MS, actor)
     const parsed = parseMcpHttpResponse(text)
     return extractMcpText(parsed)

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -78,7 +78,7 @@ function implicitToolActor(): string | null {
   if (!actor) return null
   if (!getStoredToken()) return actor
   const meta = getStoredTokenMeta()
-  if (meta?.source === 'dev' || meta?.actor) return actor
+  if (meta?.source === 'dev') return actor
   return null
 }
 

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -2,6 +2,7 @@
 
 import { v4 as randomUuid } from 'uuid'
 import {
+  ApiRequestError,
   apiRequestErrorFromResponse,
   fetchWithTimeout,
   DEFAULT_MCP_TIMEOUT_MS,
@@ -11,7 +12,11 @@ import {
   getStoredToken,
   getStoredTokenMeta,
 } from './core'
-import { ensureDevToken, resetDevTokenBootstrap } from './dev-token'
+import {
+  ensureDevToken,
+  refreshDevTokenAfterAuthError,
+  resetDevTokenBootstrap,
+} from './dev-token'
 import { reportToolHostFailure } from './tool-host-failure'
 import { showActionToast } from '../components/common/toast'
 import { errorToString } from '../lib/format-string'
@@ -224,8 +229,24 @@ interface McpCallResponse {
   result?: {
     content?: Array<{ type?: string; text?: string }>
     isError?: boolean
+    structuredContent?: unknown
   }
   error?: { message?: string }
+}
+
+class McpToolCallError extends Error {
+  readonly authErrorCode: unknown
+
+  constructor(message: string, authErrorCode: unknown) {
+    super(message)
+    this.name = 'McpToolCallError'
+    this.authErrorCode = authErrorCode
+  }
+}
+
+function structuredAuthErrorCode(value: unknown): unknown {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null
+  return (value as Record<string, unknown>).auth_error_code
 }
 
 function parseMcpHttpResponse(raw: string): McpCallResponse {
@@ -238,7 +259,10 @@ function extractMcpText(res: McpCallResponse): string {
   if (res.error?.message) throw new Error(res.error.message)
   if (res.result?.isError) {
     const err = res.result.content?.[0]?.text ?? 'MCP tool call failed'
-    throw new Error(err)
+    throw new McpToolCallError(
+      err,
+      structuredAuthErrorCode(res.result.structuredContent),
+    )
   }
   return res.result?.content?.[0]?.text ?? ''
 }
@@ -246,12 +270,13 @@ function extractMcpText(res: McpCallResponse): string {
 async function callMcpToolInternal(
   toolName: string,
   args: Record<string, unknown>,
+  allowAuthRecovery = true,
 ): Promise<string> {
   const requestId = randomUuid()
   synchronizeMcpAuthRevision()
+  const explicitActor = explicitToolActor(args)
   try {
     const binding = await ensureBinding()
-    const explicitActor = explicitToolActor(args)
     const actor = explicitActor ?? implicitToolActor()
     const toolArgs =
       explicitActor == null && actor
@@ -269,6 +294,19 @@ async function callMcpToolInternal(
     const parsed = parseMcpHttpResponse(text)
     return extractMcpText(parsed)
   } catch (err) {
+    const authErrorCode = err instanceof McpToolCallError
+      ? err.authErrorCode
+      : err instanceof ApiRequestError && err.status === 401
+        ? err.authErrorCode
+        : null
+    if (
+      allowAuthRecovery
+      && explicitActor === null
+      && await refreshDevTokenAfterAuthError(authErrorCode)
+    ) {
+      observedTokenRevision = currentStoredTokenRevision()
+      return callMcpToolInternal(toolName, args, false)
+    }
     const message = errorToString(err)
     if (shouldReportToolHostFailure(message)) {
       await bestEffortReportToolHostFailure({

--- a/dashboard/src/components/auth-status.ts
+++ b/dashboard/src/components/auth-status.ts
@@ -80,7 +80,10 @@ function authBadgeSummary(): {
     }
   }
   // No token and bootstrap failed — show actionable prompt
-  if (!hasToken && (bootstrap === 'no_endpoint' || bootstrap === 'network')) {
+  if (
+    !hasToken
+    && (bootstrap === 'no_endpoint' || bootstrap === 'invalid_response' || bootstrap === 'network')
+  ) {
     return {
       dotColor: 'bg-[var(--color-status-err)] shadow-[0_0_6px_rgb(var(--err-glow)/0.45)]',
       label: 'Login required',

--- a/dashboard/src/components/common/command-palette.test.ts
+++ b/dashboard/src/components/common/command-palette.test.ts
@@ -10,6 +10,12 @@ const runGarbageCollection = vi.fn().mockResolvedValue(undefined)
 const route = signal<any>({ tab: 'code', params: { section: 'ide-shell' }, postId: null })
 const missionAgentBriefs = signal<any[]>([])
 const missionKeeperBriefs = signal<any[]>([])
+const shellAuthSummary = signal<any>({
+  effective_role: 'worker',
+  default_role: 'worker',
+  auth_error_code: null,
+  auth_error_detail: null,
+})
 
 async function loadPalette() {
   vi.resetModules()
@@ -22,6 +28,7 @@ async function loadPalette() {
     missionAgentBriefs,
     missionKeeperBriefs,
   }))
+  vi.doMock('../../store', () => ({ shellAuthSummary }))
   return import('./command-palette')
 }
 
@@ -34,6 +41,12 @@ describe('CommandPalette', () => {
     missionAgentBriefs.value = []
     missionKeeperBriefs.value = []
     route.value = { tab: 'code', params: { section: 'ide-shell' }, postId: null }
+    shellAuthSummary.value = {
+      effective_role: 'worker',
+      default_role: 'worker',
+      auth_error_code: null,
+      auth_error_detail: null,
+    }
   })
 
   afterEach(() => {
@@ -45,6 +58,7 @@ describe('CommandPalette', () => {
     vi.doUnmock('./confirm-dialog')
     vi.doUnmock('../flow-control/flow-control-state')
     vi.doUnmock('../../mission-signals')
+    vi.doUnmock('../../store')
   })
 
   it('loads the web component lazily and wires navigation commands without reserved hotkeys', async () => {
@@ -106,6 +120,12 @@ describe('CommandPalette', () => {
   })
 
   it('runs maintenance actions only after confirmation', async () => {
+    shellAuthSummary.value = {
+      effective_role: 'admin',
+      default_role: 'worker',
+      auth_error_code: null,
+      auth_error_detail: null,
+    }
     const { CommandPalette } = await loadPalette()
 
     render(html`<${CommandPalette} />`, container)
@@ -124,6 +144,19 @@ describe('CommandPalette', () => {
     await palette?.data?.find((item) => item.id === 'action-gc')?.handler()
     expect(runGarbageCollection).toHaveBeenCalledTimes(1)
 
+  })
+
+  it('does not expose admin-only garbage collection to a worker', async () => {
+    const { CommandPalette } = await loadPalette()
+
+    render(html`<${CommandPalette} />`, container)
+    await waitFor(() => {
+      const palette = container.querySelector('ninja-keys') as (HTMLElement & {
+        data?: Array<{ id: string }>
+      }) | null
+      expect(palette?.data?.length).toBeGreaterThan(0)
+      expect(palette?.data?.some((item) => item.id === 'action-gc')).toBe(false)
+    })
   })
 
   it('labels mission entities as command targets, not live runtime counts', async () => {

--- a/dashboard/src/components/common/command-palette.ts
+++ b/dashboard/src/components/common/command-palette.ts
@@ -5,6 +5,8 @@ import { requestConfirm } from './confirm-dialog'
 import { runGarbageCollection } from '../flow-control/flow-control-state'
 import { missionAgentBriefs, missionKeeperBriefs } from '../../mission-signals'
 import { formatCommandTargetSection, formatCommandTargetSummary } from '../../runtime-counts'
+import { shellAuthSummary } from '../../store'
+import { dashboardAuthAccess } from '../../lib/dashboard-auth-access'
 
 interface CommandPaletteAction {
   id: string
@@ -59,6 +61,8 @@ export function CommandPalette({ openOnMount = false }: CommandPaletteProps = {}
   // Sync data whenever the mission snapshot changes
   useEffect(() => {
     if (!ready || !ref.current) return
+
+    const maintenanceAccess = dashboardAuthAccess(shellAuthSummary.value, 'admin')
 
     const baseActions: CommandPaletteAction[] = [
       {
@@ -125,7 +129,10 @@ export function CommandPalette({ openOnMount = false }: CommandPaletteProps = {}
           navigate('code', next)
         }
       },
-      {
+    ]
+
+    if (maintenanceAccess.allowed) {
+      baseActions.push({
         id: 'action-gc',
         title: '유지보수: GC (Garbage Collection) 실행',
         section: 'System Ops',
@@ -134,8 +141,8 @@ export function CommandPalette({ openOnMount = false }: CommandPaletteProps = {}
           const confirmed = await requestConfirm({ title: '유지보수', message: 'GC를 실행합니까?' })
           if (confirmed) void runGarbageCollection()
         }
-      }
-    ]
+      })
+    }
 
     // Add Agents dynamically
     const agents = missionAgentBriefs.value || []
@@ -163,7 +170,7 @@ export function CommandPalette({ openOnMount = false }: CommandPaletteProps = {}
 
     ref.current.data = [...baseActions, ...agentActions, ...keeperActions]
 
-  }, [ready, route.value, missionAgentBriefs.value, missionKeeperBriefs.value])
+  }, [ready, route.value, missionAgentBriefs.value, missionKeeperBriefs.value, shellAuthSummary.value])
 
   useEffect(() => {
     if (!ready || !openOnMount) return

--- a/dashboard/src/components/flow-control/flow-control-panel.test.ts
+++ b/dashboard/src/components/flow-control/flow-control-panel.test.ts
@@ -20,6 +20,7 @@ const {
   maintenanceLoading,
   shellAuthSummary,
   operatorSnapshot,
+  dashboardAuthAccess,
 } = vi.hoisted(() => ({
   fetchPauseStatus: vi.fn().mockResolvedValue(undefined),
   pauseWorkspace: vi.fn().mockResolvedValue(undefined),
@@ -31,6 +32,7 @@ const {
   maintenanceLoading: { value: false },
   shellAuthSummary: { value: null },
   operatorSnapshot: { value: null as MockOperatorSnapshot },
+  dashboardAuthAccess: vi.fn(),
 }))
 
 vi.mock('./flow-control-state', () => ({
@@ -53,12 +55,7 @@ vi.mock('../../operator-store', () => ({
 }))
 
 vi.mock('../../lib/dashboard-auth-access', () => ({
-  dashboardAuthAccess: () => ({
-    allowed: true,
-    required_role: 'worker',
-    effective_role: 'worker',
-    reason: null,
-  }),
+  dashboardAuthAccess,
 }))
 
 import { FlowControlPanel } from './flow-control-panel'
@@ -80,6 +77,12 @@ describe('FlowControlPanel', () => {
     maintenanceLoading.value = false
     shellAuthSummary.value = null
     operatorSnapshot.value = null
+    dashboardAuthAccess.mockImplementation((_summary, requiredRole: 'worker' | 'admin') => ({
+      allowed: requiredRole === 'worker',
+      required_role: requiredRole,
+      effective_role: 'worker',
+      reason: requiredRole === 'worker' ? null : 'admin role is required',
+    }))
   })
 
   afterEach(() => {
@@ -114,6 +117,18 @@ describe('FlowControlPanel', () => {
     expect(status).not.toBeNull()
     expect(status!.textContent).toContain('oas_runtime')
     expect(status!.textContent).toContain('1 active inference')
+  })
+
+  it('keeps worker flow controls enabled but disables admin-only GC', async () => {
+    render(html`<${FlowControlPanel} />`, container)
+    await flushUi()
+
+    const buttons = Array.from(container.querySelectorAll('button'))
+    const pause = buttons.find((button) => button.textContent?.includes('Pause'))
+    const gc = buttons.find((button) => button.textContent?.includes('Run GC'))
+    expect(pause?.disabled).toBe(false)
+    expect(gc?.disabled).toBe(true)
+    expect(dashboardAuthAccess).toHaveBeenCalledWith(null, 'admin')
   })
 
 })

--- a/dashboard/src/components/flow-control/flow-control-panel.ts
+++ b/dashboard/src/components/flow-control/flow-control-panel.ts
@@ -34,6 +34,7 @@ export function FlowControlPanel() {
   const isRunning = state === 'running'
   const isInitializing = state === 'initializing'
   const mutationAccess = dashboardAuthAccess(shellAuthSummary.value, 'worker')
+  const maintenanceAccess = dashboardAuthAccess(shellAuthSummary.value, 'admin')
   const inferenceInflight = operatorSnapshot.value?.inference_inflight ?? null
   return html`
     <div class="v2-command-surface flex flex-col gap-4">
@@ -66,7 +67,7 @@ export function FlowControlPanel() {
       <details>
         <summary class="cursor-pointer text-sm text-[var(--color-fg-secondary)] font-medium select-none py-1">Maintenance</summary>
         <div class="mt-3 flex flex-wrap gap-2">
-          <${ActionButton} variant="ghost" size="md" disabled=${maintenanceLoading.value || !mutationAccess.allowed}
+          <${ActionButton} variant="ghost" size="md" disabled=${maintenanceLoading.value || !maintenanceAccess.allowed}
             onClick=${async () => {
               const confirmed = await requestConfirm({ title: 'Maintenance', message: 'Run GC?' })
               if (confirmed) void runGarbageCollection()

--- a/dashboard/src/components/flow-control/flow-control-state.test.ts
+++ b/dashboard/src/components/flow-control/flow-control-state.test.ts
@@ -6,12 +6,14 @@ const {
   namespaceTruthInitializing,
   serverStatus,
   shellAuthSummary,
+  showToast,
 } = vi.hoisted(() => ({
   callMcpTool: vi.fn(),
   namespaceTruth: { value: null as unknown },
   namespaceTruthInitializing: { value: false },
   serverStatus: { value: null as unknown },
   shellAuthSummary: { value: null as unknown },
+  showToast: vi.fn(),
 }))
 
 vi.mock('../../api/mcp', () => ({
@@ -28,9 +30,12 @@ vi.mock('../../store', () => ({
   shellAuthSummary,
 }))
 
+vi.mock('../common/toast', () => ({ showToast }))
+
 import {
   fetchPauseStatus,
   flowState,
+  runGarbageCollection,
 } from './flow-control-state'
 
 describe('flow-control-state', () => {
@@ -46,6 +51,7 @@ describe('flow-control-state', () => {
       auth_error_detail: null,
     }
     flowState.value = 'unknown'
+    showToast.mockReset()
   })
 
   afterEach(() => {
@@ -132,5 +138,30 @@ describe('flow-control-state', () => {
     callMcpTool.mockResolvedValueOnce(JSON.stringify({ status: 'running', paused: false }))
     await fetchPauseStatus()
     expect(flowState.value).toBe('running')
+  })
+
+  it('rejects garbage collection for a worker before calling MCP', async () => {
+    await runGarbageCollection()
+
+    expect(callMcpTool).not.toHaveBeenCalled()
+    expect(showToast).toHaveBeenCalledWith(
+      'Current role is worker; admin role is required.',
+      'error',
+      6000,
+    )
+  })
+
+  it('runs garbage collection for an admin', async () => {
+    shellAuthSummary.value = {
+      effective_role: 'admin',
+      default_role: 'worker',
+      auth_error_code: null,
+      auth_error_detail: null,
+    }
+    callMcpTool.mockResolvedValueOnce('{"removed":0}')
+
+    await runGarbageCollection()
+
+    expect(callMcpTool).toHaveBeenCalledWith('masc_gc', {})
   })
 })

--- a/dashboard/src/components/flow-control/flow-control-state.ts
+++ b/dashboard/src/components/flow-control/flow-control-state.ts
@@ -92,7 +92,7 @@ export async function resumeWorkspace(): Promise<void> {
 // ── Maintenance ─────────────────────────────────
 
 export async function runGarbageCollection(): Promise<void> {
-  const access = dashboardAuthAccess(shellAuthSummary.value, 'worker')
+  const access = dashboardAuthAccess(shellAuthSummary.value, 'admin')
   if (!access.allowed) {
     showToast(access.reason ?? 'Missing permission to run GC.', 'error', 6000)
     return

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -346,7 +346,7 @@ function disconnectionReasonLabel(): string {
   const hasToken = !!dashboardBearerToken()
   const bootstrap = devTokenBootstrapStatus.value
 
-  if (!hasToken && bootstrap === 'no_endpoint') {
+  if (!hasToken && (bootstrap === 'no_endpoint' || bootstrap === 'invalid_response')) {
     return 'dashboard · auth required'
   }
   if (!hasToken && bootstrap === 'network') {

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -680,7 +680,7 @@ describe('SettingsSurface', () => {
 
   it('renders token presence and source without re-projecting the bearer secret into the DOM', () => {
     const secret = 'masc-secret-that-must-not-enter-dom'
-    setStoredToken(secret, { source: 'manual', scope: 'admin' })
+    setStoredToken(secret, { source: 'manual' })
     shellAuthSummary.value = {
       enabled: true,
       require_token: true,
@@ -697,7 +697,7 @@ describe('SettingsSurface', () => {
     const presence = container.querySelector('[data-testid="settings-account-token-presence"]')
     expect(presence?.textContent).toContain('브라우저에 저장됨')
     expect(presence?.textContent).toContain('source:manual')
-    expect(presence?.textContent).toContain('scope:admin')
+    expect(presence?.textContent).not.toContain('role:')
     expect(container.querySelector('input[aria-label="Dashboard API token"]')).toBeNull()
     expect(container.innerHTML).not.toContain(secret)
   })
@@ -922,7 +922,11 @@ describe('SettingsSurface', () => {
         ? new URL(requestUrl).pathname
         : requestUrl.split('?')[0] ?? requestUrl
       if (path === '/api/v1/dashboard/dev-token') {
-        return new Response(JSON.stringify({ token: 'dev-token', actor: 'dashboard' }), {
+        return new Response(JSON.stringify({
+          token: 'dev-token',
+          actor: 'dashboard',
+          role: 'worker',
+        }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
         })

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -461,7 +461,7 @@ function AccountSettingsSection() {
             ${tokenPresent ? '브라우저에 저장됨' : '저장된 token 없음'}
           </span>
           ${tokenMeta
-            ? html`<span class="set-truth-source mono">source:${tokenMeta.source}${tokenMeta.scope ? ` · scope:${tokenMeta.scope}` : ''}</span>`
+            ? html`<span class="set-truth-source mono">source:${tokenMeta.source}${tokenMeta.source === 'dev' ? ` · role:${tokenMeta.role}` : ''}</span>`
             : null}
         </div>
       <//>

--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -774,7 +774,7 @@ describe('dashboard websocket route subscriptions', () => {
   it('reconnects with a fresh token after hello auth rejection', async () => {
     vi.useFakeTimers()
     installWebSocketMocks()
-    setStoredToken('stale-token', { source: 'dev', actor: 'dashboard' })
+    setStoredToken('stale-token', { source: 'dev', actor: 'dashboard', role: 'worker' })
 
     await connectDashboardWS({ tab: 'overview', params: {} })
     const socket = mockSockets[0]!
@@ -791,7 +791,7 @@ describe('dashboard websocket route subscriptions', () => {
     await flushPromises()
     expect(mockSockets).toHaveLength(1)
 
-    setStoredToken('fresh-token', { source: 'dev', actor: 'dashboard' })
+    setStoredToken('fresh-token', { source: 'dev', actor: 'dashboard', role: 'worker' })
     await flushPromises()
     await flushPromises()
 

--- a/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
+++ b/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
@@ -77,7 +77,8 @@ Useful interpretations:
 - `token_bound_admin_http_ready: no`
   - workspace auth may be enabled, but no usable admin bearer source was found
 - `dashboard_dev_token: available=yes`
-  - the easiest local bootstrap path is `GET /api/v1/dashboard/dev-token`
+  - the browser can bootstrap its loopback-only `dashboard` Worker credential;
+    this credential cannot satisfy admin-only lifecycle routes
 - `codex_mcp.token_status=unset` or `invalid_or_expired`
   - Agent-Code MCP is missing a live bearer token; this is not fixed by `agent-code mcp login`
 - `codex_mcp.config.stages[]`
@@ -300,7 +301,8 @@ BASE_PATH="${MASC_BASE_PATH:-/path/to/base}"
 The command prints the raw bearer once, writes the matching private raw-token
 file under the live auth root, and includes a dashboard URL.
 
-If login JSON says `dashboard_dev_token: available=yes`, the easiest local path is the dev-token bootstrap:
+If login JSON says `dashboard_dev_token: available=yes`, the browser dashboard
+automatically bootstraps a `dashboard` Worker credential from:
 
 ```bash
 TOKEN="$(curl -sS http://127.0.0.1:8935/api/v1/dashboard/dev-token | jq -r '.token')"
@@ -308,6 +310,8 @@ printf 'token=%s\n' "$TOKEN"
 ```
 
 This endpoint is loopback-only and disabled when HTTP strict auth is enabled.
+It is suitable for dashboard reads and Worker-authorized operations, not the
+admin-only keeper lifecycle actions covered by this runbook.
 
 If you do not have that path, the reliable local fallback is to seed the auth store directly.
 
@@ -377,7 +381,8 @@ Pass the token once via query string. The dashboard moves it into `sessionStorag
 http://127.0.0.1:8935/dashboard?agent=agent-code-tool-matrix&token=<raw-token>
 ```
 
-For a dev-token bootstrap, use `agent=dashboard-dev` instead.
+Do not paste the dev-token into this admin URL. The loopback dashboard obtains
+its Worker credential directly and binds it to the exact `dashboard` actor.
 
 You can verify the session with:
 
@@ -460,7 +465,8 @@ mv "$BASE_PATH/.masc/auth/config.json.bak" "$BASE_PATH/.masc/auth/config.json"
 rm -f "$BASE_PATH/.masc/auth/agents/agent-code-tool-matrix.json"
 ```
 
-If you used only `dashboard-dev` dev-token bootstrap, there may be no auth files to roll back.
+The automatic dev-token is a persistent `dashboard` Worker credential and is
+independent of the explicit admin credential created by this runbook.
 
 ## 10. Known Failure Modes
 

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -25,7 +25,7 @@ export OLLAMA_CLOUD_API_KEY=...   # https://ollama.com/settings/keys
 
 - 대시보드: `http://127.0.0.1:8935/dashboard`
 - **네이티브**는 loopback 바인딩이라 대시보드가 데이터까지 나오고 로그인이 필요 없다 — 대시보드를 실제로 보려면 이 경로.
-- **`--docker`**는 self-contained 이미지로 서버+팀을 재현 가능하게 부팅한다. 컨테이너는 네트워크 주소에 바인딩하므로 대시보드 shell은 뜨지만 라이브 데이터는 admin 토큰이 필요하다(zero-auth loopback dev-token은 비-loopback 바인딩에 의도적으로 노출 안 함). 설치/부팅 검증용으로 쓰고, 대시보드 열람은 네이티브로.
+- **`--docker`**는 self-contained 이미지로 서버+팀을 재현 가능하게 부팅한다. 컨테이너는 네트워크 주소에 바인딩하므로 대시보드 shell은 뜨지만 라이브 데이터는 명시적 bearer 토큰이 필요하다(loopback dev-token은 비-loopback 바인딩에 노출되지 않음). 설치/부팅 검증용으로 쓰고, 대시보드 열람은 네이티브로.
 - 팀은 `runtime.toml`의 `[runtime].default = ollama_cloud.deepseek-v4-flash`를 상속하므로 모델 카탈로그를 건드리지 않는다.
 - 옵션: `--team <preset>`(목록은 `presets/`), `--port N`, `--base-path DIR`, `--no-open`, `--no-start`.
 - 팀만 별도로 seed: `scripts/seed-team.sh --preset classic --base-path <경로>`.

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -329,7 +329,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0335 | TOML as the Single Settings Source | Draft | - |
 | 0337 | Withdraw deterministic evidence-gate semantics | Withdrawn | - |
 | 0338 | Lane-per-keeper durable persistence isolation | Draft | - |
-| 0340 | Dashboard dev-token privilege reduction — demote from Admin, close the rebind... | Draft | - |
+| 0340 | Loopback dashboard Worker credential | Active | - |
 | 0341 | Keeper lifecycle projection SSOT | Draft | - |
 | 0342 | Capability catalog overlay, deployment capability declarations, and boot posture | Draft | - |
 | 0343 | Repo location SSOT (collapse dual-authority, attribute by git-remote) | Draft | - |

--- a/docs/rfc/RFC-0340-dashboard-token-only-auth.md
+++ b/docs/rfc/RFC-0340-dashboard-token-only-auth.md
@@ -1,112 +1,90 @@
-# RFC-0340: Dashboard dev-token privilege reduction — demote from Admin, close the rebinding vector
+# RFC-0340: Loopback dashboard Worker credential
 
-- Status: Draft
-- Author: Claude (Fable 5, 70-goal campaign — bug #69)
+- Status: Active
 - Date: 2026-07-10
-- Revised: 2026-07-11 (v3 — threat-boundary, rotation, and fail-closed ordering correction; see §7 revision log)
-- Priority: P1 until request-Host admission and Admin-token rotation land; residual least-privilege work is P2
-- Related: issue #24031 (implementation tracker), `auth-bootstrap-grace-token-proof.md` (2026-07-01, same auth neighborhood — proof-of-possession over self-assertion), RFC-0292 (lib/auth de-dup), RFC-0083 (dashboard system actor typed)
-- Subsystem: credential / identity / auth (RFC-mandatory per CLAUDE.md agent_delegation + workflow-pr §11)
+- Related: issue #24031
+- Subsystem: credential / identity / auth
 
-## 원문 (#69)
+## Contract
 
-> "드더 Auth 기능 살려서 인증 토큰만 접근하게 바꿔야함. 지금 웹에서 명령 아무렇게나 다 내림. 문제임. 보안 문제 시급함"
+`GET /api/v1/dashboard/dev-token` is a loopback bootstrap boundary for the
+browser dashboard. It returns exactly:
 
-## 1. 실측된 문제 (라이브 재현, 2026-07-10)
+```json
+{
+  "token": "<64 lowercase hex characters>",
+  "actor": "dashboard",
+  "role": "worker"
+}
+```
 
-라이브 인스턴스(`localhost:8935`, `enabled:true require_token:true`)에서 전체 사슬을 재현했다:
+The endpoint is unavailable on a non-loopback bind or with strict HTTP auth.
+The admitted request authority must also be an exact loopback host before any
+token or credential I/O occurs. Host suffix and substring matching are not
+part of the contract.
 
-1. **무인증 Admin 토큰 발급**: `GET /api/v1/dashboard/dev-token`이 서버가 loopback에 바인딩되고 strict-auth env override가 꺼져 있을 때(= 기본 로컬 실행) 아무 인증 없이 **Admin 역할** 토큰을 반환한다.
-   - `server_routes_http_dashboard_dev_token.ml:66` `Auth.create_token ~agent_name:"dashboard" ~role:Masc_domain.Admin`.
-   - 라우트 `server_routes_http_routes_dashboard.ml:498` `with_public_read` (무인증). `server_auth.ml:929-937` — non-strict 경로는 handler를 auth·origin 검사 없이 직접 호출.
-   - 실측: `curl http://127.0.0.1:8935/api/v1/dashboard/dev-token` → `200 {"token":"3737dd42..."}`, 그 토큰으로 `POST /operator/action` → `400`(인증 통과, 검증만 실패).
+The credential grants `Worker` permissions. It cannot satisfy `CanAdmin`,
+`CanInit`, or `CanReset`. Dashboard operations that require those permissions
+need an explicit operator credential. Known MCP tools continue to use their
+typed tool permission; the dev-token does not create a path-based exception.
 
-### 근본원인 (정정)
+## Durable rotation
 
-결함은 엔드포인트의 *존재*가 아니라 발급되는 **역할이 `Admin`이라는 것**이다. 대시보드는 read + 특정 mutation만 필요한데 최상위 권한(`CanAdmin`/`CanInit`/`CanReset`)을 무인증으로 나눠준다. v1 초안은 이를 "엔드포인트를 삭제"로 오진했으나, 적대 검증(§7)이 삭제는 근본원인을 빗나가고 빌드를 깨뜨림을 확인했다.
+Only a valid credential whose actor is exactly `dashboard` and whose role is
+exactly `Worker` is reusable. Every other stored candidate enters one serialized
+rotation:
 
-### 심각도 (공격자 경계별 분리)
+1. Persist the new raw token at `.masc/auth/dashboard.token.pending`.
+2. Revoke the current `dashboard` credential.
+3. Persist the new `Worker` credential for the journalled raw token.
+4. Atomically publish the raw token at `.masc/auth/dashboard.token` with private
+   file permissions.
+5. Remove the pending journal.
 
-| 공격자 / 배포 형태 | 등급 | 근거 |
-|---|---|---|
-| **같은 UID의 로컬 프로세스** | Low / Info | 이미 `0o600` 토큰 파일을 읽을 수 있다. 이 행은 로컬 프로세스 위협만 설명한다. |
-| **기본 loopback 서버 + 공격자 웹 origin을 연 브라우저** | **P1** | 브라우저 sandbox 때문에 원격 페이지는 `0o600` 파일을 읽지 못하지만, DNS rebinding 뒤에는 무인증 HTTP로 Admin bearer를 읽을 수 있다. 같은 UID 비교로 이 원격 웹 경계를 낮출 수 없다. |
-| **멀티 유저 / 공유 호스트 / 공유-netns 컨테이너** | **P1** | cross-UID 주체가 파일 권한을 우회해 HTTP로 Admin bearer를 얻는다. |
-| **non-loopback strict-auth 배포** | 닫힘(설정 의존) | `http_auth_strict_enabled()`가 true인 현재 계약에서는 dev-token이 404다. loopback 경로의 방어를 대신하지 않는다. |
+If the process or request is interrupted after step 1, the next call resumes
+with the same raw token. A missing, unreadable, or malformed journal is a typed
+failure; it is never interpreted as permission to mint repeatedly. The rotation
+is protected by one cross-context durable lock.
 
-따라서 **request-Host admission과 기존 Admin credential rotation은 P1**이다. 그 뒤 Worker 권한을 더 줄이는 least-privilege 감사는 P2로 분리한다.
+## Request identity
 
-### 놓쳤던 원격 벡터 (v1 대비 정정 — CORS는 완전 차단이 아님)
+A bearer-bound request must resolve to a credential identity. A present token
+with no resolved actor is rejected as `invalid_token`; it is never assigned the
+string actor `dashboard`. An unauthenticated public-read request remains a
+separate typed case.
 
-dev-token GET은 (a) CORS 헤더를 안 보내고 (b) **request `Host` 헤더를 검증하지 않으며** guard는 서버 *bind* host만 본다(`http_auth_bind_is_loopback`, request Host 아님). 따라서 `127.0.0.1`로 rebinding하는 악성 페이지는 `:8935`에 same-origin이 되어 무인증 GET으로 토큰을 읽어갈 수 있다. v1의 "CORS가 원격 탈취를 막는다"는 안이한 진술이었다. 이건 단일 사용자 laptop에서도 브라우저로 악성 사이트 방문 시 성립하는 실재 벡터다.
+The dashboard stores token provenance as one of:
 
-## 2. 설계 (v3 — fail-closed 순서 고정)
+- `{source: "dev", actor: "dashboard", role: "worker"}`
+- `{source: "manual"}`
+- `{source: "url"}`
 
-### 2.1 W0: request Host admission을 mint/read보다 먼저 수행
+Manual and URL tokens cannot assert an actor or role in browser storage. Until
+the server returns the credential's canonical actor, those requests omit the
+implicit actor header.
 
-dev-token handler는 토큰 파일을 읽거나 credential을 mint하기 전에 request `Host`를 parse한다. host가 없거나 malformed이거나 exact loopback(`localhost`, `127.0.0.1`, `[::1]`)이 아니면 typed rejection으로 404/403을 반환한다. suffix/substring 판정은 금지하고 기존 network host parser의 closed result를 재사용한다. bind host 검사는 방어의 한 층으로 유지하지만 request Host를 대신하지 않는다.
+## Typed self-healing
 
-### 2.2 W1: mint 역할 강등과 route-permission 행렬
+Loopback sessions may replace a managed dev-token and retry once only when the
+server returns `auth_error_code` equal to `invalid_token`, `token_expired`, or
+`actor_mismatch`. REST, Keeper streaming, MCP initialization, and MCP tool
+results use that same typed set.
 
-`server_routes_http_dashboard_dev_token.ml`의 `~role:Masc_domain.Admin`을 `Worker`로 강등한다. 현재 `agent_role = Worker | Admin`이고 Worker는 `CanAdmin`/`CanInit`/`CanReset`를 거부한다(`lib/types/types_auth.ml:26,194-199`).
+Human-readable `error`, `message`, content text, HTTP status alone, and string
+fragments never authorize token replacement. A manual token is never replaced.
+MCP calls carrying an explicit actor are never replayed by this recovery path.
 
-강등 전에 dashboard가 호출하는 mutation을 route의 typed permission 기준으로 전수 투영한다. Worker가 허용해야 할 기능은 기존 permission으로 설명하고, 필요한 capability가 없다면 먼저 permission variant를 추가한다. 단지 UI를 통과시키기 위한 broad `Dashboard_operator` 역할이나 path 문자열 allowlist는 만들지 않는다.
+## Verification
 
-### 2.3 W2: 기존 Admin credential을 role-aware하게 교체
-
-현재 `classify_dashboard_dev_token_candidate`는 token owner가 `"dashboard"`인지 확인할 뿐 role을 확인하지 않아 기존 Admin token을 영구 재사용한다. reusable 조건을 **owner + 기대 role + 유효기간**으로 묶는다.
-
-role mismatch는 기존 credential hash와 raw `dashboard.token`을 일관되게 교체하는 explicit rotation 경계를 지난다. credential write와 raw-token write 사이 crash/I/O 실패는 typed `Rotation_indeterminate`로 남기고 endpoint는 500으로 fail-close한다. 예외를 로그한 뒤 `Ok None`으로 바꿔 새 token을 반복 mint하는 현재 read 경로는 제거한다. 완료 후에는 이전 Admin bearer가 반드시 401이어야 한다.
-
-### 2.4 W3: typed `No_agent` fail-close
-
-`server_auth.ml`의 `Option.value ~default:"dashboard"`(미해결 agent → 문자열 "dashboard")를 제거한다. token-bound 권한 경로는 resolved credential identity를 요구하고, 미해결 상태는 closed variant로 거부한다. public read의 실제 unauthenticated 계약은 이 변경과 섞지 않는다.
-
-### 2.5 부팅 URL은 비차단 후속
-
-`lib/auth/auth_login.ml:81-159`와 dashboard URL-token 소비 경로는 이미 있다. 부팅 시 bearer URL을 출력하는 기능은 이 취약점의 수정 조건이 아니며, 로그/프로세스 목록/referrer 노출 검토 없이 W0-W3에 섞지 않는다.
-
-## 3. 비고찰 대상 (Non-goals)
-
-- strict-auth(non-loopback)는 이미 dev-token을 404 → 변경 없음.
-- CSRF Origin 검사(`ensure_same_origin_browser_request`)는 별개 계층 — 유지.
-- **엔드포인트 삭제는 하지 않는다**(v1에서 철회). 토큰 재사용 경로(`classify_*`/`read_reusable_*`)를 보존한다.
-- bearer query URL 자동 출력은 W0-W3의 non-goal이다.
-
-## 4. 검증
-
-- **admission 우선 증명**: invalid/missing/non-loopback Host 요청에서는 token read/mint hook 호출 횟수 0.
-- **rebinding 방어**: `Host: evil.example`로 dev-token GET → `403/404`; `localhost`, `127.0.0.1`, `[::1]`의 지원 여부는 parser 계약대로 typed test.
-- **강등 증명**: 새 dev-token(Worker)으로 `POST /operator/action`(CanAdmin) → `403 Forbidden`; route-permission 행렬의 허용 mutation만 성공.
-- **rotation 증명**: 기존 Admin dashboard token은 reusable이 아니고 rotation 뒤 401, 새 Worker token만 유효.
-- **rotation fault 증명**: credential/raw-token write 사이 fault injection이 explicit degraded 결과를 남기며 Admin token을 다시 활성화하지 않음.
-- **No_agent fail-close**: 미해결 agent로 권한 요구 라우트 → `401/403`(문자열 "dashboard"로 defaulting 안 됨).
-- **UX 회귀**: 강등 후에도 대시보드 정상 read + 허용 mutation 동작(FE E2E).
-
-## 5. 마이그레이션 / 롤백
-
-- 기존 `.masc/auth/dashboard.token`은 owner뿐 아니라 role을 검사해 rotation한다. 파일 overwrite만으로 완료를 주장하지 않고 credential hash 교체와 old-token rejection을 함께 증명한다.
-- rotation이 indeterminate이면 기존 값을 재사용하거나 추가 mint하지 않고 endpoint를 degraded로 유지한다. 운영자가 typed 상태를 보고 exact retry할 수 있어야 한다.
-- 롤백은 Admin mint 복원이 아니다. 문제가 생기면 dev-token endpoint를 fail-closed로 끄고 명시적 `masc login` token 경로를 사용한다.
-
-## 6. 완료 기준
-
-- [ ] request Host가 token read/mint 전에 exact loopback으로 검증된다.
-- [ ] 무인증 dev-token의 역할이 `Admin`이 아니다(`rg "~role:Masc_domain.Admin" server_routes_http_dashboard_dev_token.ml` = 0).
-- [ ] 무인증 dev-token으로 `CanAdmin` mutation 라우트 100% → `403`.
-- [ ] dashboard route-permission 행렬로 Worker 허용/거부 기능이 전수 검증된다.
-- [ ] 기존 Admin dashboard bearer가 rotation 후 401이고 새 Worker bearer만 유효하다.
-- [ ] token read/rotation I/O 실패가 `Ok None`/재-mint로 붕괴하지 않는다.
-- [ ] 미해결 agent가 문자열 "dashboard"로 defaulting되지 않고 typed fail-close.
-- [ ] 대시보드 정상 read + 허용 mutation이 강등 후에도 동작(회귀 0).
-
-## 7. 개정 로그 (v1 → v3)
-
-v1은 "dev-token 엔드포인트 삭제 + Jupyter ?token= 재구축"을 제안했다. 적대 검증(wf_3d8a1444, 3 렌즈 × opus, 397k tok)이 4개 CONFIRMED blocker로 반박:
-
-1. **초기 심각도 분석 오류** — same-UID 로컬 프로세스와 browser sandbox 안의 원격 웹 origin을 같은 공격자로 취급했다. v3는 DNS rebinding 경계를 P1로 분리한다.
-2. **근본원인 빗나감** — 결함은 엔드포인트 존재가 아니라 `~role:Admin`. 1줄 강등이 삭제 없이 escalation을 닫는다.
-3. **삭제가 빌드를 깸** — dangling re-export 2쌍 + E2E 하네스(`test_sse_storm_e2e.ml`) + `release-evidence.sh` + FE 39 call site + 문서 2개.
-4. **console 모델은 이미 ~80% 구현** — `auth_login.ml`+`core.ts`. 삭제 정당화 근거 못 됨, additive로 재프레임.
-
-추가 정정: CORS는 원격을 **완전 차단하지 않음**(DNS rebinding 잔여 벡터 — §1). v3는 Host admission을 모든 token I/O보다 앞에 두고, role-aware rotation과 typed fail-close까지 하나의 보안 완료 조건으로 고정한다.
+- Invalid request authority performs zero dev-token file I/O.
+- The response has the exact actor and role contract.
+- An existing `Admin` dashboard credential is revoked; its bearer becomes
+  invalid and the replacement bearer resolves to `Worker`.
+- Corrupt journals and injected read/write failures fail closed with stable
+  error codes.
+- The Worker bearer receives `403` from
+  `POST /api/v1/dashboard/gate/mode` (`CanAdmin`) and can use an allowed
+  `CanVote` route.
+- Typed REST and MCP auth failures retry once; prose-only failures do not retry.
+- `rg "~role:Masc_domain.Admin" lib/server/server_routes_http_dashboard_dev_token.ml`
+  returns no matches.

--- a/docs/rfc/RFC-0340-dashboard-token-only-auth.md
+++ b/docs/rfc/RFC-0340-dashboard-token-only-auth.md
@@ -1,3 +1,10 @@
+---
+rfc: "0340"
+title: "Loopback dashboard Worker credential"
+status: Active
+updated: 2026-08-03
+---
+
 # RFC-0340: Loopback dashboard Worker credential
 
 - Status: Active

--- a/lib/auth/auth.ml
+++ b/lib/auth/auth.ml
@@ -196,28 +196,9 @@ let check_permission config ~agent_name ~token ~permission : (unit, masc_error) 
         { reason = Missing_token; message = "Token required" })))
 ;;
 
-(** Tool auth is always strict: unknown internal tools require at least
-    worker-level permission, and unknown external tools are denied. *)
+(** Tool auth is always strict: the catalog owns every callable tool name and
+    its typed permission. Unregistered names are denied regardless of prefix. *)
 let is_tool_auth_strict_enabled () = true
-
-(* #10205 finding 1: SSOT for the internal-tool prefix vocabulary.
-   Unmapped dotted game-view namespaces ([decision.], [experiment.], [client.])
-   were retired from the MCP front door; do not preserve them as implicit
-   strict-auth internals.  Keeper runtime tools are NOT a prefix: a [keeper_*]
-   prefix alone is not enough to cross auth — the catalog must own the tool.
-   That check stays separate. *)
-let internal_tool_prefixes = [ "masc_" ]
-
-let has_internal_tool_prefix tool_name =
-  List.exists
-    (fun pref -> String.starts_with ~prefix:pref tool_name)
-    internal_tool_prefixes
-;;
-
-let is_known_or_internal_tool_name tool_name =
-  has_internal_tool_prefix tool_name
-  || Option.is_some (Tool_catalog.registered_metadata tool_name)
-;;
 
 let unknown_tool_class tool_name =
   if String.trim tool_name = "" then "empty" else "external"
@@ -232,14 +213,19 @@ let record_strict_unknown_tool_denial ~agent_name ~tool_name =
 
 (** Check permission for a tool call *)
 let authorize_tool config ~agent_name ~token ~tool_name : (unit, masc_error) result =
-  if is_known_or_internal_tool_name tool_name
-  then check_permission config ~agent_name ~token ~permission:CanBroadcast
-  else (
+  match Tool_catalog.registered_metadata tool_name with
+  | Some metadata ->
+    check_permission
+      config
+      ~agent_name
+      ~token
+      ~permission:metadata.required_permission
+  | None ->
     let () = record_strict_unknown_tool_denial ~agent_name ~tool_name in
     Error
       (Auth
          (Auth_error.Forbidden
-            { agent = agent_name; action = "use unknown non-masc tool: " ^ tool_name })))
+            { agent = agent_name; action = "use unregistered tool: " ^ tool_name }))
 ;;
 
 (* ============================================ *)
@@ -281,25 +267,25 @@ let resolve_role config ~agent_name ~token : (agent_role, masc_error) result =
 ;;
 
 let authorize_tool_for_role ~agent_name ~role ~tool_name : (unit, masc_error) result =
-  if is_known_or_internal_tool_name tool_name
-  then
-    if has_permission role CanBroadcast
+  match Tool_catalog.registered_metadata tool_name with
+  | Some metadata ->
+    if has_permission role metadata.required_permission
     then Ok ()
     else Error (Auth (Auth_error.Forbidden { agent = agent_name; action = tool_name }))
-  else (
+  | None ->
     let () = record_strict_unknown_tool_denial ~agent_name ~tool_name in
     Error
       (Auth
          (Auth_error.Forbidden
-            { agent = agent_name; action = "use unknown non-masc tool: " ^ tool_name })))
+            { agent = agent_name; action = "use unregistered tool: " ^ tool_name }))
 ;;
 
 (** Role-based tool authorization.
     Resolves the caller role and enforces generic internal-tool access.
     Invalid/expired tokens are rejected (not silently downgraded).
 
-    Known or [masc_*] tools require at least Worker; unknown external tools are
-    forbidden. *)
+    Each registered tool requires its catalog-owned typed permission; every
+    unregistered name is forbidden. *)
 let authorize_tool_v2 config ~agent_name ~token ~tool_name : (unit, masc_error) result =
   match resolve_role config ~agent_name ~token with
   | Error e -> Error e
@@ -367,5 +353,3 @@ let is_auth_enabled config : bool =
   let cfg = load_auth_config config in
   cfg.enabled
 ;;
-
-

--- a/lib/auth/auth.mli
+++ b/lib/auth/auth.mli
@@ -14,6 +14,10 @@ val generate_token : unit -> string
 (** Generate a cryptographically random token: exactly 64 lowercase hex
     characters encoding 32 random bytes. *)
 
+val is_generated_token_shape : string -> bool
+(** [is_generated_token_shape raw] checks the exact lexical shape produced by
+    {!generate_token}. It does not establish token provenance or validity. *)
+
 val sha256_hash : string -> string
 (** Hash a token/secret with SHA-256 and return exactly 64 lowercase hex
     characters. Secret comparisons use Eqaf on this fixed-width form. *)

--- a/lib/auth/auth.mli
+++ b/lib/auth/auth.mli
@@ -302,6 +302,8 @@ val is_tool_auth_strict_enabled : unit -> bool
 val authorize_tool :
   string -> agent_name:string -> token:string option ->
   tool_name:string -> (unit, masc_error) result
+(** Enforce the exact required permission declared by the registered tool
+    catalog. Unregistered names fail closed; prefixes grant no authority. *)
 
 (** {1 Role Resolution} *)
 
@@ -316,6 +318,7 @@ val resolve_role_with_auth_config :
 val authorize_tool_for_role :
   agent_name:string -> role:agent_role -> tool_name:string ->
   (unit, masc_error) result
+(** Pure role check against the same catalog-owned per-tool permission. *)
 
 val authorize_tool_v2 :
   string -> agent_name:string -> token:string option ->

--- a/lib/auth/auth_credential_base.ml
+++ b/lib/auth/auth_credential_base.ml
@@ -6,9 +6,21 @@ open Masc_domain
 (* Crypto utilities                             *)
 (* ============================================ *)
 
-(** Generate a cryptographically random token (hex string) *)
+(** Generated bearer-token shape authority. *)
+let generated_token_bytes = 32
+
+(** Generate a cryptographically random token (hex string). *)
 let generate_token () =
-  Random_id.hex ~bytes:32
+  Random_id.hex ~bytes:generated_token_bytes
+;;
+
+let is_generated_token_shape raw =
+  String.length raw = 2 * generated_token_bytes
+  && String.for_all
+       (function
+         | '0' .. '9' | 'a' .. 'f' -> true
+         | _ -> false)
+       raw
 ;;
 
 (** SHA256 hash of a string using Digestif *)

--- a/lib/auth/auth_error_kind.ml
+++ b/lib/auth/auth_error_kind.ml
@@ -46,7 +46,9 @@ let classify : Masc_domain.t -> t = function
   | Masc_domain.Auth (Masc_domain.Auth_error.InvalidToken _) -> Token_mismatch
   | Masc_domain.Auth (Masc_domain.Auth_error.TokenExpired _) -> Token_expired
   | Masc_domain.Auth (Masc_domain.Auth_error.Unauthorized _) -> Unauthorized
-  | Masc_domain.Auth (Masc_domain.Auth_error.Forbidden _) -> Forbidden
+  | Masc_domain.Auth
+      (Masc_domain.Auth_error.Forbidden _
+      | Masc_domain.Auth_error.SameOriginBlocked) -> Forbidden
   | Masc_domain.Agent (Masc_domain.Agent_error.NotFound _) -> Agent_not_found
   | Masc_domain.System (Masc_domain.System_error.IoError _) -> Io_error
   | Masc_domain.System (Masc_domain.System_error.InvalidJson _) -> Invalid_json

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -110,6 +110,26 @@ let execute_tool_eio
       ~data:(`String msg)
       msg
   in
+  let auth_error_result err =
+    let message = Masc_domain.masc_error_to_string err in
+    let fields =
+      [ ( "effect_disposition"
+        , `String
+            (Tool_result.failure_effect_disposition_to_string
+               Tool_result.Proven_pre_effect) )
+      ]
+      @
+      match Masc_domain.dashboard_auth_error_code err with
+      | Some code -> [ "auth_error_code", `String code ]
+      | None -> []
+    in
+    Tool_result.make_err
+      ~tool_name:name
+      ~class_:Tool_result.Policy_rejection
+      ~start_time:(Time_compat.now ())
+      ~data:(`Assoc fields)
+      message
+  in
   let with_non_public_tool_audit ~agent_name (result : Tool_result.result) =
     if is_non_public_tool
     then (
@@ -169,7 +189,7 @@ let execute_tool_eio
      | Error err ->
        with_non_public_tool_audit
          ~agent_name
-         (runtime_error_result (Masc_domain.masc_error_to_string err))
+         (auth_error_result err)
      | Ok () ->
           (match owner_keeper_identity with
            | Some (keeper_name, keeper_id)

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -988,6 +988,27 @@ let resolve_agent_name_for_auth ~base_path request ~token :
     (string option, Masc_domain.masc_error) result =
   resolve_agent_name_for_auth_raw ~base_path request ~token
 
+type request_authorization_actor =
+  | Resolved_request_actor of string
+  | Anonymous_dashboard_actor
+
+let request_authorization_actor_name = function
+  | Resolved_request_actor agent_name -> agent_name
+  | Anonymous_dashboard_actor -> "dashboard"
+;;
+
+let resolve_request_authorization_actor ~token = function
+  | Some agent_name -> Ok (Resolved_request_actor agent_name)
+  | None ->
+    (match token with
+     | None -> Ok Anonymous_dashboard_actor
+     | Some _ ->
+       Error
+         (Masc_domain.Auth
+            (Masc_domain.Auth_error.InvalidToken
+               "Bearer token did not resolve to a credential identity.")))
+;;
+
 let authorize_permission_request ~base_path ~permission request :
     (unit, Masc_domain.masc_error) result =
   let auth_cfg = Auth.load_auth_config base_path in
@@ -1002,23 +1023,12 @@ let authorize_permission_request ~base_path ~permission request :
   in
   let* () = reject_malformed_request_credential credential in
   let* agent_name_opt = resolve_agent_name_for_auth ~base_path request ~token in
-  (* NDT-OK: pre-existing dashboard fallback for non-token dashboard reads.
-     Token-bound requests without a resolved agent fail closed in the guard below. *)
-  let agent_name = Option.value ~default:"dashboard" agent_name_opt in
-  if
-    auth_cfg.enabled && auth_cfg.require_token && token <> None
-    && agent_name_opt = None
-  then
-    Error
-      (Masc_domain.Auth
-         (Masc_domain.Auth_error.Unauthorized
-            { reason = Missing_token
-            ; message =
-                "Agent name required (X-Gate-Agent / X-MASC-Agent or \
-                 token-bound credential)"
-            }))
-  else
-    Auth.check_permission base_path ~agent_name ~token ~permission
+  let* actor = resolve_request_authorization_actor ~token agent_name_opt in
+  Auth.check_permission
+    base_path
+    ~agent_name:(request_authorization_actor_name actor)
+    ~token
+    ~permission
 
 let authorize_read_request ~base_path request : (unit, Masc_domain.masc_error) result =
   authorize_permission_request ~base_path ~permission:Masc_domain.CanReadState request
@@ -1042,24 +1052,10 @@ let authorize_tool_request_with_actor ~base_path ~tool_name ~request_authority r
                { reason = Generic; message = msg }))
   in
   let* agent_name_opt = resolve_agent_name_for_auth ~base_path request ~token in
-  (* NDT-OK: pre-existing dashboard fallback for non-token dashboard tool requests.
-     Token-bound requests without a resolved agent fail closed in the guard below. *)
-  let agent_name = Option.value ~default:"dashboard" agent_name_opt in
-  if
-    auth_cfg.enabled && auth_cfg.require_token && token <> None
-    && agent_name_opt = None
-  then
-    Error
-      (Masc_domain.Auth
-         (Masc_domain.Auth_error.Unauthorized
-            { reason = Missing_token
-            ; message =
-                "Agent name required (X-Gate-Agent / X-MASC-Agent or \
-                 token-bound credential)"
-            }))
-  else (
-    let* () = Auth.authorize_tool_v2 base_path ~agent_name ~token ~tool_name in
-    Ok agent_name)
+  let* actor = resolve_request_authorization_actor ~token agent_name_opt in
+  let agent_name = request_authorization_actor_name actor in
+  let* () = Auth.authorize_tool_v2 base_path ~agent_name ~token ~tool_name in
+  Ok agent_name
 
 let authorize_tool_request ~base_path ~tool_name ~request_authority request :
     (unit, Masc_domain.masc_error) result =

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -720,8 +720,7 @@ let ensure_same_origin_browser_request ~request_authority request :
          "explicit_trusted_host");
     Error
       (Masc_domain.Auth
-         (Masc_domain.Auth_error.Forbidden
-            { agent = "browser"; action = "cross-origin HTTP mutation" }))
+         Masc_domain.Auth_error.SameOriginBlocked)
   | Multiple_origins | Malformed_origin ->
     Error
       (Masc_domain.Auth
@@ -748,8 +747,7 @@ let ensure_same_origin_if_browser_request ~request_authority request :
          "explicit_trusted_host");
     Error
       (Masc_domain.Auth
-         (Masc_domain.Auth_error.Forbidden
-            { agent = "browser"; action = "cross-origin HTTP mutation" }))
+         Masc_domain.Auth_error.SameOriginBlocked)
   | Multiple_origins | Malformed_origin ->
     Error
       (Masc_domain.Auth
@@ -773,7 +771,9 @@ let http_status_of_auth_error = function
       (Masc_domain.Auth_error.Unauthorized _
       | Masc_domain.Auth_error.InvalidToken _
       | Masc_domain.Auth_error.TokenExpired _) -> `Unauthorized
-  | Masc_domain.Auth (Masc_domain.Auth_error.Forbidden _) -> `Forbidden
+  | Masc_domain.Auth
+      (Masc_domain.Auth_error.Forbidden _
+      | Masc_domain.Auth_error.SameOriginBlocked) -> `Forbidden
   | Masc_domain.Task (Masc_domain.Task_error.NotFound _) -> `Not_found
   | Masc_domain.Agent (Masc_domain.Agent_error.NotFound _) -> `Not_found
   | Masc_domain.Task

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -284,11 +284,11 @@ let verify_mcp_auth_for_authority ~base_path ~request_authority request =
 let verify_mcp_observer_stream_auth_unscoped ~base_path request =
   let auth_config = Auth.load_auth_config base_path in
   let credential = observer_sse_auth_credential_from_request request in
-  let* auth_config = ensure_strict_http_token_auth ~endpoint:"/mcp" auth_config in
-  let* () =
-    reject_malformed_request_credential credential
-    |> Result.map_error Masc_domain.masc_error_to_string
+  let* auth_config =
+    ensure_strict_http_token_auth ~endpoint:"/mcp" auth_config
+    |> Result.map_error mcp_unauthorized
   in
+  let* () = reject_malformed_request_credential credential in
   if not auth_config.Masc_domain.enabled then
     Ok None
   else
@@ -297,23 +297,25 @@ let verify_mcp_observer_stream_auth_unscoped ~base_path request =
         Ok None
     | None ->
         Error
-          "Authentication required. Use 'Authorization: Bearer <token>' header \
-           or 'token' query param for the observer/presence/cursor SSE stream."
+          (mcp_unauthorized
+             ~reason:Masc_domain.Auth_error.Missing_token
+             "Authentication required. Use 'Authorization: Bearer <token>' header \
+              or 'token' query param for the observer/presence/cursor SSE stream.")
     | Some token -> (
         let* agent_name =
           resolve_agent_name_for_auth_raw ~base_path request ~token:(Some token)
-          |> Result.map_error Masc_domain.masc_error_to_string
         in
         match agent_name with
         | None ->
             (* Fail-closed: see verify_mcp_auth above. *)
             Error
-              "Authentication required. Bearer token did not resolve to \
-               any agent."
+              (Masc_domain.Auth
+                 (Masc_domain.Auth_error.InvalidToken
+                    "Authentication required. Bearer token did not resolve to \
+                     any agent."))
         | Some agent_name ->
             Auth.check_permission base_path ~agent_name ~token:(Some token)
               ~permission:Masc_domain.CanReadState
-            |> Result.map_error Masc_domain.masc_error_to_string
             |> Result.map (fun () -> None))
 
 let verify_mcp_observer_stream_auth ~base_path request =
@@ -326,30 +328,36 @@ let verify_operator_mcp_auth_unscoped ~base_path request =
   let credential = request_auth_credential_from_request request in
   if not auth_config.Masc_domain.enabled then
     Error
-      "/mcp/operator requires workspace auth enabled with require_token=true."
+      (mcp_unauthorized
+         "/mcp/operator requires workspace auth enabled with require_token=true.")
   else if not auth_config.require_token then
-    Error "/mcp/operator requires bearer token auth (require_token=true)."
+    Error
+      (mcp_unauthorized
+         "/mcp/operator requires bearer token auth (require_token=true).")
   else
     match credential with
     | Malformed_credential _ ->
-        Error (malformed_request_credential_error () |> Masc_domain.masc_error_to_string)
+        Error (malformed_request_credential_error ())
     | Absent_credential ->
-        Error "Authentication required. Use 'Authorization: Bearer <token>' header."
+        Error
+          (mcp_unauthorized
+             ~reason:Masc_domain.Auth_error.Missing_token
+             "Authentication required. Use 'Authorization: Bearer <token>' header.")
     | Parsed_credential token -> (
         let* agent_name =
           resolve_agent_name_for_auth_raw ~base_path request ~token:(Some token)
-          |> Result.map_error Masc_domain.masc_error_to_string
         in
         match agent_name with
         | None ->
             (* Fail-closed: see verify_mcp_auth above. *)
             Error
-              "Authentication required. Bearer token did not resolve to \
-               any agent."
+              (Masc_domain.Auth
+                 (Masc_domain.Auth_error.InvalidToken
+                    "Authentication required. Bearer token did not resolve to \
+                     any agent."))
         | Some agent_name ->
             Auth.check_permission base_path ~agent_name ~token:(Some token)
               ~permission:Masc_domain.CanAdmin
-            |> Result.map_error Masc_domain.masc_error_to_string
             |> Result.map (fun () -> None))
 
 let verify_operator_mcp_auth ~base_path request =
@@ -859,8 +867,7 @@ let respond_public_read_json_value ?(status = `OK) request reqd value =
    human-readable [error] string. Clients (dashboard keeper stream retry
    gate) dispatch on the typed code instead of substring-matching the
    message. The code is the same SSOT mapping the dashboard shell
-   summary uses ([Masc_domain.dashboard_auth_error_code]). The legacy
-   [error] field is retained for human display and backward compat. *)
+   summary uses ([Masc_domain.dashboard_auth_error_code]). *)
 let auth_error_json err =
   let base = [ ("error", `String (Masc_domain.masc_error_to_string err)) ] in
   let fields =
@@ -1152,11 +1159,11 @@ and with_observer_sse_read_auth handler request reqd =
          (match check_agent_rate_limit request reqd with
           | Ok () -> handler state request reqd
           | Error () -> ())
-       | Error msg ->
+       | Error err ->
          Http_server_eio.Response.json
            ~status:`Unauthorized
            ~extra_headers:(auth_error_headers ~status:`Unauthorized ~cors:[])
-           (Yojson.Safe.to_string (`Assoc [ "error", `String msg ]))
+           (auth_error_json err)
            reqd)
   else
     with_public_read handler request reqd

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -226,15 +226,19 @@ let with_mcp_expected_resource f =
   Auth_oauth.with_expected_resource (Server_oauth_metadata.resource authority) f
 ;;
 
+let mcp_unauthorized ?(reason = Masc_domain.Auth_error.Generic) message =
+  Masc_domain.Auth (Masc_domain.Auth_error.Unauthorized { reason; message })
+;;
+
 (** Verify Bearer token for MCP endpoints *)
 let verify_mcp_auth_unscoped ~base_path request =
   let auth_config = Auth.load_auth_config base_path in
   let credential = request_auth_credential_from_request request in
-  let* auth_config = ensure_strict_http_token_auth ~endpoint:"/mcp" auth_config in
-  let* () =
-    reject_malformed_request_credential credential
-    |> Result.map_error Masc_domain.masc_error_to_string
+  let* auth_config =
+    ensure_strict_http_token_auth ~endpoint:"/mcp" auth_config
+    |> Result.map_error mcp_unauthorized
   in
+  let* () = reject_malformed_request_credential credential in
   if not auth_config.Masc_domain.enabled then
     Ok None  (* Auth disabled - allow all *)
   else
@@ -243,11 +247,12 @@ let verify_mcp_auth_unscoped ~base_path request =
         Ok None  (* Token not required *)
     | None ->
         Error
-          "Authentication required. Use 'Authorization: Bearer <token>' header."
+          (mcp_unauthorized
+             ~reason:Masc_domain.Auth_error.Missing_token
+             "Authentication required. Use 'Authorization: Bearer <token>' header.")
     | Some token -> (
         let* agent_name =
           resolve_agent_name_for_auth_raw ~base_path request ~token:(Some token)
-          |> Result.map_error Masc_domain.masc_error_to_string
         in
         match agent_name with
         | None ->
@@ -258,12 +263,12 @@ let verify_mcp_auth_unscoped ~base_path request =
                [specs/auth/AuthIdentityFSM.tla] invariant
                [NoSilentRewrite] (I2). *)
             Error
-              "Authentication required. Bearer token did not resolve to \
-               any agent."
+              (Masc_domain.Auth
+                 (Masc_domain.Auth_error.InvalidToken
+                    "Bearer token did not resolve to a credential identity."))
         | Some agent_name ->
             Auth.check_permission base_path ~agent_name ~token:(Some token)
               ~permission:Masc_domain.CanReadState
-            |> Result.map_error Masc_domain.masc_error_to_string
             |> Result.map (fun () -> None))
 
 let verify_mcp_auth ~base_path request =

--- a/lib/server/server_auth.mli
+++ b/lib/server/server_auth.mli
@@ -95,14 +95,14 @@ val resolve_agent_name_for_auth_raw :
 (** {1 MCP / observer / operator verification} *)
 
 val verify_mcp_auth :
-  base_path:string -> Httpun.Request.t -> ('a option, string) result
+  base_path:string -> Httpun.Request.t -> ('a option, Masc_domain.masc_error) result
 (** Bearer token check for the [/mcp] endpoint. *)
 
 val verify_mcp_auth_for_authority :
   base_path:string ->
   request_authority:Server_request_authority.authority ->
   Httpun.Request.t ->
-  ('a option, string) result
+  ('a option, Masc_domain.masc_error) result
 (** Bearer token check using an explicitly admitted authority.  Entry points
     that already carry the typed authority should use this instead of
     rebuilding a fiber-local dependency. *)

--- a/lib/server/server_auth.mli
+++ b/lib/server/server_auth.mli
@@ -108,11 +108,11 @@ val verify_mcp_auth_for_authority :
     rebuilding a fiber-local dependency. *)
 
 val verify_mcp_observer_stream_auth :
-  base_path:string -> Httpun.Request.t -> ('a option, string) result
+  base_path:string -> Httpun.Request.t -> ('a option, Masc_domain.masc_error) result
 (** Variant for the observer SSE stream (allows query token). *)
 
 val verify_operator_mcp_auth :
-  base_path:string -> Httpun.Request.t -> ('a option, string) result
+  base_path:string -> Httpun.Request.t -> ('a option, Masc_domain.masc_error) result
 (** Variant for [/mcp/operator] (admin-tier). *)
 
 (** {1 Dashboard actor identification} *)

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -100,12 +100,6 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
         ~status:(status :> H2.Status.t)
         ~extra_headers:(auth_error_headers ~status ~cors)
     in
-    let mcp_auth_failure_of_masc_error err :
-        Server_mcp_transport_http_types.auth_failure =
-      { message = Masc_domain.masc_error_to_string err
-      ; auth_error_code = Masc_domain.dashboard_auth_error_code err
-      }
-    in
     let mcp_auth_error_body failure =
       Server_mcp_transport_http_respond.error_body
         ?data:(Server_mcp_transport_http_protocol.auth_failure_data failure)
@@ -541,10 +535,12 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
             | Server_mcp_transport_http.Full
             | Server_mcp_transport_http.Managed_agent ->
                 verify_mcp_auth ~base_path httpun_request
-                |> Result.map_error mcp_auth_failure_of_masc_error
+                |> Result.map_error
+                     Server_mcp_transport_http_types.auth_failure_of_masc_error
             | Server_mcp_transport_http.Operator_remote ->
                 verify_operator_mcp_auth ~base_path httpun_request
-                |> Result.map_error mcp_auth_failure_of_masc_error
+                |> Result.map_error
+                     Server_mcp_transport_http_types.auth_failure_of_masc_error
           in
           (match validate_mcp_session_profile ~profile session_id with
            | Error msg ->
@@ -698,10 +694,12 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
             | Server_mcp_transport_http.Full
             | Server_mcp_transport_http.Managed_agent ->
                 verify_mcp_auth ~base_path httpun_request
-                |> Result.map_error mcp_auth_failure_of_masc_error
+                |> Result.map_error
+                     Server_mcp_transport_http_types.auth_failure_of_masc_error
             | Server_mcp_transport_http.Operator_remote ->
                 verify_operator_mcp_auth ~base_path httpun_request
-                |> Result.map_error mcp_auth_failure_of_masc_error
+                |> Result.map_error
+                     Server_mcp_transport_http_types.auth_failure_of_masc_error
           in
           (match auth_result with
            | Error failure ->

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -106,10 +106,6 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
       ; auth_error_code = Masc_domain.dashboard_auth_error_code err
       }
     in
-    let mcp_auth_failure_of_message message :
-        Server_mcp_transport_http_types.auth_failure =
-      { message; auth_error_code = None }
-    in
     let mcp_auth_error_body failure =
       Server_mcp_transport_http_respond.error_body
         ?data:(Server_mcp_transport_http_protocol.auth_failure_data failure)
@@ -548,7 +544,7 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
                 |> Result.map_error mcp_auth_failure_of_masc_error
             | Server_mcp_transport_http.Operator_remote ->
                 verify_operator_mcp_auth ~base_path httpun_request
-                |> Result.map_error mcp_auth_failure_of_message
+                |> Result.map_error mcp_auth_failure_of_masc_error
           in
           (match validate_mcp_session_profile ~profile session_id with
            | Error msg ->
@@ -705,7 +701,7 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
                 |> Result.map_error mcp_auth_failure_of_masc_error
             | Server_mcp_transport_http.Operator_remote ->
                 verify_operator_mcp_auth ~base_path httpun_request
-                |> Result.map_error mcp_auth_failure_of_message
+                |> Result.map_error mcp_auth_failure_of_masc_error
           in
           (match auth_result with
            | Error failure ->

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -100,6 +100,23 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
         ~status:(status :> H2.Status.t)
         ~extra_headers:(auth_error_headers ~status ~cors)
     in
+    let mcp_auth_failure_of_masc_error err :
+        Server_mcp_transport_http_types.auth_failure =
+      { message = Masc_domain.masc_error_to_string err
+      ; auth_error_code = Masc_domain.dashboard_auth_error_code err
+      }
+    in
+    let mcp_auth_failure_of_message message :
+        Server_mcp_transport_http_types.auth_failure =
+      { message; auth_error_code = None }
+    in
+    let mcp_auth_error_body failure =
+      Server_mcp_transport_http_respond.error_body
+        ?data:(Server_mcp_transport_http_protocol.auth_failure_data failure)
+        ~code:Mcp_error_code.Auth_error
+        failure.message
+      |> Yojson.Safe.to_string
+    in
     let h2_respond_oauth_error error =
       Log.Misc.warn
         "oauth_http: request rejected error=%s"
@@ -528,8 +545,10 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
             | Server_mcp_transport_http.Full
             | Server_mcp_transport_http.Managed_agent ->
                 verify_mcp_auth ~base_path httpun_request
+                |> Result.map_error mcp_auth_failure_of_masc_error
             | Server_mcp_transport_http.Operator_remote ->
                 verify_operator_mcp_auth ~base_path httpun_request
+                |> Result.map_error mcp_auth_failure_of_message
           in
           (match validate_mcp_session_profile ~profile session_id with
            | Error msg ->
@@ -544,8 +563,8 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
                       ~extra_headers:(cors @ mcp_headers session_id protocol_version)
                 | Ok () ->
                     (match auth_result with
-                     | Error msg ->
-                         let body = json_rpc_error Mcp_error_code.Auth_error msg in
+                     | Error failure ->
+                         let body = mcp_auth_error_body failure in
                          h2_respond_json h2_reqd body ~status:`Unauthorized
                            ~extra_headers:
                              (( "www-authenticate"
@@ -683,12 +702,14 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
             | Server_mcp_transport_http.Full
             | Server_mcp_transport_http.Managed_agent ->
                 verify_mcp_auth ~base_path httpun_request
+                |> Result.map_error mcp_auth_failure_of_masc_error
             | Server_mcp_transport_http.Operator_remote ->
                 verify_operator_mcp_auth ~base_path httpun_request
+                |> Result.map_error mcp_auth_failure_of_message
           in
           (match auth_result with
-           | Error msg ->
-               let body = json_rpc_error Mcp_error_code.Auth_error msg in
+           | Error failure ->
+               let body = mcp_auth_error_body failure in
                h2_respond_json h2_reqd body ~status:`Unauthorized
                  ~extra_headers:
                    (( "www-authenticate"

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -275,9 +275,17 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
     let* () =
       match auth_result with
       | Ok () -> Ok ()
-      | Error msg ->
-          respond_mcp_error ~code:Mcp_error_code.Auth_error ~deps ~request_authority
-            request reqd ~session_id ~protocol_version msg;
+      | Error failure ->
+          respond_mcp_error
+            ?data:(auth_failure_data failure)
+            ~code:Mcp_error_code.Auth_error
+            ~deps
+            ~request_authority
+            request
+            reqd
+            ~session_id
+            ~protocol_version
+            failure.message;
           Error ()
     in
     let otel_transport_context =
@@ -600,9 +608,17 @@ let handle_get_mcp ~deps ?(profile = Full) ?(sse_kind = Sse.Agent_stream)
           safe_respond_with_string reqd response body
       | Ok () ->
       (match auth_result with
-      | Error msg ->
-          respond_mcp_error ~code:Mcp_error_code.Auth_error ~deps ~request_authority
-            request reqd ~session_id ~protocol_version msg
+      | Error failure ->
+          respond_mcp_error
+            ?data:(auth_failure_data failure)
+            ~code:Mcp_error_code.Auth_error
+            ~deps
+            ~request_authority
+            request
+            reqd
+            ~session_id
+            ~protocol_version
+            failure.message
       | Ok () ->
           (match last_event_id with
           | Error error ->
@@ -756,9 +772,17 @@ let handle_get_operator_mcp ~deps request reqd =
   let protocol_version = get_protocol_version_for_session ~session_id request in
   let base_path = deps.get_base_path () in
   match deps.verify_operator_mcp_auth ~base_path request with
-  | Error msg ->
-      respond_mcp_error ~code:Mcp_error_code.Auth_error ~deps ~request_authority
-        request reqd ~session_id ~protocol_version msg
+  | Error failure ->
+      respond_mcp_error
+        ?data:(auth_failure_data failure)
+        ~code:Mcp_error_code.Auth_error
+        ~deps
+        ~request_authority
+        request
+        reqd
+        ~session_id
+        ~protocol_version
+        failure.message
   | Ok () ->
       handle_get_mcp ~deps ~profile:Operator_remote request reqd
 
@@ -776,11 +800,19 @@ let handle_delete_mcp ~deps ?(profile = Full) request reqd =
         deps.verify_operator_mcp_auth ~base_path request
   in
   match auth_result with
-  | Error msg ->
+  | Error failure ->
       let session_id = Mcp_session.get_or_generate (get_session_id_any request) in
       let protocol_version = get_protocol_version_for_session ~session_id request in
-      respond_mcp_error ~code:Mcp_error_code.Auth_error ~deps ~request_authority
-        request reqd ~session_id ~protocol_version msg
+      respond_mcp_error
+        ?data:(auth_failure_data failure)
+        ~code:Mcp_error_code.Auth_error
+        ~deps
+        ~request_authority
+        request
+        reqd
+        ~session_id
+        ~protocol_version
+        failure.message
   | Ok () -> (
       match get_session_id_any request with
       | Some session_id -> (

--- a/lib/server/server_mcp_transport_http.mli
+++ b/lib/server/server_mcp_transport_http.mli
@@ -19,6 +19,11 @@ type runtime = Server_mcp_transport_http_types.runtime = {
   clear_resource_subscriptions_for_session : string -> unit;
 }
 
+type auth_failure = Server_mcp_transport_http_types.auth_failure =
+  { message : string
+  ; auth_error_code : string option
+  }
+
 type deps = {
   get_origin : Httpun.Request.t -> string;
   cors_headers : string -> (string * string) list;
@@ -26,11 +31,12 @@ type deps = {
   is_ready : unit -> bool;
   get_runtime_result : unit -> (runtime, string) result;
   get_base_path : unit -> string;
-  verify_mcp_auth : base_path:string -> Httpun.Request.t -> (unit, string) result;
+  verify_mcp_auth :
+    base_path:string -> Httpun.Request.t -> (unit, auth_failure) result;
   verify_mcp_observer_stream_auth :
-    base_path:string -> Httpun.Request.t -> (unit, string) result;
+    base_path:string -> Httpun.Request.t -> (unit, auth_failure) result;
   verify_operator_mcp_auth :
-    base_path:string -> Httpun.Request.t -> (unit, string) result;
+    base_path:string -> Httpun.Request.t -> (unit, auth_failure) result;
 }
 
 val mcp_protocol_versions : string list

--- a/lib/server/server_mcp_transport_http_agui.ml
+++ b/lib/server/server_mcp_transport_http_agui.ml
@@ -39,9 +39,17 @@ let handle_ag_ui_events ~deps request reqd =
   (* workspace query param ignored — namespace retired *)
   let last_event_id = Server_mcp_transport_http_headers.get_last_event_id request in
   match deps.verify_mcp_observer_stream_auth ~base_path request with
-  | Error msg ->
-      respond_mcp_error ~code:Mcp_error_code.Auth_error ~deps ~request_authority
-        request reqd ~session_id ~protocol_version msg
+  | Error failure ->
+      respond_mcp_error
+        ?data:(auth_failure_data failure)
+        ~code:Mcp_error_code.Auth_error
+        ~deps
+        ~request_authority
+        request
+        reqd
+        ~session_id
+        ~protocol_version
+        failure.message
   | Ok () ->
       (match last_event_id with
       | Error error ->
@@ -181,9 +189,17 @@ let handle_presence_events ~deps request reqd =
   in
   let base_path = deps.get_base_path () in
   match deps.verify_mcp_observer_stream_auth ~base_path request with
-  | Error msg ->
-      respond_mcp_error ~code:Mcp_error_code.Auth_error ~deps ~request_authority
-        request reqd ~session_id:raw_session_id ~protocol_version msg
+  | Error failure ->
+      respond_mcp_error
+        ?data:(auth_failure_data failure)
+        ~code:Mcp_error_code.Auth_error
+        ~deps
+        ~request_authority
+        request
+        reqd
+        ~session_id:raw_session_id
+        ~protocol_version
+        failure.message
   | Ok () ->
       let token = Server_auth.observer_sse_auth_token_from_request request in
       let auth = { Sse.config = base_path; token } in

--- a/lib/server/server_mcp_transport_http_protocol.ml
+++ b/lib/server/server_mcp_transport_http_protocol.ml
@@ -10,6 +10,17 @@ module Http_negotiation = Mcp_transport_protocol.Http_negotiation
    Brings in Mcp_eio alias, Hashtbl tables, mutex, and all session functions. *)
 include Server_mcp_transport_http_session
 
+type auth_failure = Server_mcp_transport_http_types.auth_failure =
+  { message : string
+  ; auth_error_code : string option
+  }
+
+let auth_failure_data failure =
+  Option.map
+    (fun code -> `Assoc [ "auth_error_code", `String code ])
+    failure.auth_error_code
+;;
+
 type deps = Server_mcp_transport_http_types.deps = {
   get_origin : Httpun.Request.t -> string;
   cors_headers : string -> (string * string) list;
@@ -18,11 +29,12 @@ type deps = Server_mcp_transport_http_types.deps = {
   get_runtime_result :
     unit -> (Server_mcp_transport_http_types.runtime, string) result;
   get_base_path : unit -> string;
-  verify_mcp_auth : base_path:string -> Httpun.Request.t -> (unit, string) result;
+  verify_mcp_auth :
+    base_path:string -> Httpun.Request.t -> (unit, auth_failure) result;
   verify_mcp_observer_stream_auth :
-    base_path:string -> Httpun.Request.t -> (unit, string) result;
+    base_path:string -> Httpun.Request.t -> (unit, auth_failure) result;
   verify_operator_mcp_auth :
-    base_path:string -> Httpun.Request.t -> (unit, string) result;
+    base_path:string -> Httpun.Request.t -> (unit, auth_failure) result;
 }
 
 let method_from_body body_str =

--- a/lib/server/server_mcp_transport_http_protocol.mli
+++ b/lib/server/server_mcp_transport_http_protocol.mli
@@ -28,6 +28,14 @@ end
 module Http = Http_server_eio
 module Http_negotiation = Mcp_transport_protocol.Http_negotiation
 
+type auth_failure = Server_mcp_transport_http_types.auth_failure =
+  { message : string
+  ; auth_error_code : string option
+  }
+
+val auth_failure_data : auth_failure -> Yojson.Safe.t option
+(** JSON-RPC error data for a typed authentication failure. *)
+
 (** {1 Capability injection record} *)
 
 type deps = Server_mcp_transport_http_types.deps = {
@@ -39,11 +47,11 @@ type deps = Server_mcp_transport_http_types.deps = {
     unit -> (Server_mcp_transport_http_types.runtime, string) result;
   get_base_path : unit -> string;
   verify_mcp_auth :
-    base_path:string -> Httpun.Request.t -> (unit, string) result;
+    base_path:string -> Httpun.Request.t -> (unit, auth_failure) result;
   verify_mcp_observer_stream_auth :
-    base_path:string -> Httpun.Request.t -> (unit, string) result;
+    base_path:string -> Httpun.Request.t -> (unit, auth_failure) result;
   verify_operator_mcp_auth :
-    base_path:string -> Httpun.Request.t -> (unit, string) result;
+    base_path:string -> Httpun.Request.t -> (unit, auth_failure) result;
 }
 (** Transparent alias of {!Server_mcp_transport_http_types.deps}.
     Re-declared here so runtime consumers see the record fields

--- a/lib/server/server_mcp_transport_http_types.ml
+++ b/lib/server/server_mcp_transport_http_types.ml
@@ -3,6 +3,11 @@ type tool_profile =
   | Managed_agent
   | Operator_remote
 
+type auth_failure =
+  { message : string
+  ; auth_error_code : string option
+  }
+
 type runtime = {
   base_path : string;
   sw : Eio.Switch.t;
@@ -26,9 +31,10 @@ type deps = {
   is_ready : unit -> bool;
   get_runtime_result : unit -> (runtime, string) result;
   get_base_path : unit -> string;
-  verify_mcp_auth : base_path:string -> Httpun.Request.t -> (unit, string) result;
+  verify_mcp_auth :
+    base_path:string -> Httpun.Request.t -> (unit, auth_failure) result;
   verify_mcp_observer_stream_auth :
-    base_path:string -> Httpun.Request.t -> (unit, string) result;
+    base_path:string -> Httpun.Request.t -> (unit, auth_failure) result;
   verify_operator_mcp_auth :
-    base_path:string -> Httpun.Request.t -> (unit, string) result;
+    base_path:string -> Httpun.Request.t -> (unit, auth_failure) result;
 }

--- a/lib/server/server_mcp_transport_http_types.ml
+++ b/lib/server/server_mcp_transport_http_types.ml
@@ -8,6 +8,12 @@ type auth_failure =
   ; auth_error_code : string option
   }
 
+let auth_failure_of_masc_error err =
+  { message = Masc_domain.masc_error_to_string err
+  ; auth_error_code = Masc_domain.dashboard_auth_error_code err
+  }
+;;
+
 type runtime = {
   base_path : string;
   sw : Eio.Switch.t;

--- a/lib/server/server_mcp_transport_http_types.mli
+++ b/lib/server/server_mcp_transport_http_types.mli
@@ -3,6 +3,11 @@ type tool_profile =
   | Managed_agent
   | Operator_remote
 
+type auth_failure =
+  { message : string
+  ; auth_error_code : string option
+  }
+
 type runtime = {
   base_path : string;
   sw : Eio.Switch.t;
@@ -26,9 +31,10 @@ type deps = {
   is_ready : unit -> bool;
   get_runtime_result : unit -> (runtime, string) result;
   get_base_path : unit -> string;
-  verify_mcp_auth : base_path:string -> Httpun.Request.t -> (unit, string) result;
+  verify_mcp_auth :
+    base_path:string -> Httpun.Request.t -> (unit, auth_failure) result;
   verify_mcp_observer_stream_auth :
-    base_path:string -> Httpun.Request.t -> (unit, string) result;
+    base_path:string -> Httpun.Request.t -> (unit, auth_failure) result;
   verify_operator_mcp_auth :
-    base_path:string -> Httpun.Request.t -> (unit, string) result;
+    base_path:string -> Httpun.Request.t -> (unit, auth_failure) result;
 }

--- a/lib/server/server_mcp_transport_http_types.mli
+++ b/lib/server/server_mcp_transport_http_types.mli
@@ -8,6 +8,11 @@ type auth_failure =
   ; auth_error_code : string option
   }
 
+val auth_failure_of_masc_error : Masc_domain.masc_error -> auth_failure
+(** Encodes one typed authentication failure for the MCP transport. This is
+    the shared HTTP/1.1 and HTTP/2 boundary; callers must not rebuild the wire
+    code independently. *)
+
 type runtime = {
   base_path : string;
   sw : Eio.Switch.t;

--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -141,13 +141,6 @@ let classify_mcp_accept = Server_mcp_transport_http.classify_mcp_accept
 
 let force_json_response = Server_mcp_transport_http.force_json_response
 
-let mcp_transport_auth_failure_of_masc_error err :
-    Server_mcp_transport_http.auth_failure =
-  { message = Masc_domain.masc_error_to_string err
-  ; auth_error_code = Masc_domain.dashboard_auth_error_code err
-  }
-;;
-
 let mcp_transport_http_deps () : Server_mcp_transport_http.deps =
   let mcp_eio_profile_of_transport_profile = function
     | Server_mcp_transport_http.Full -> Mcp_server_eio.Full
@@ -203,17 +196,20 @@ let mcp_transport_http_deps () : Server_mcp_transport_http.deps =
       (fun ~base_path request ->
         verify_mcp_auth ~base_path request
         |> Result.map (fun _ -> ())
-        |> Result.map_error mcp_transport_auth_failure_of_masc_error);
+        |> Result.map_error
+             Server_mcp_transport_http_types.auth_failure_of_masc_error);
     verify_mcp_observer_stream_auth =
       (fun ~base_path request ->
         verify_mcp_observer_stream_auth ~base_path request
         |> Result.map (fun _ -> ())
-        |> Result.map_error mcp_transport_auth_failure_of_masc_error);
+        |> Result.map_error
+             Server_mcp_transport_http_types.auth_failure_of_masc_error);
     verify_operator_mcp_auth =
       (fun ~base_path request ->
         verify_operator_mcp_auth ~base_path request
         |> Result.map (fun _ -> ())
-        |> Result.map_error mcp_transport_auth_failure_of_masc_error);
+        |> Result.map_error
+             Server_mcp_transport_http_types.auth_failure_of_masc_error);
   }
 
 let mcp_transport_json_headers session_id protocol_version origin =

--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -148,10 +148,6 @@ let mcp_transport_auth_failure_of_masc_error err :
   }
 ;;
 
-let mcp_transport_auth_failure_of_message message :
-    Server_mcp_transport_http.auth_failure =
-  { message; auth_error_code = None }
-;;
 let mcp_transport_http_deps () : Server_mcp_transport_http.deps =
   let mcp_eio_profile_of_transport_profile = function
     | Server_mcp_transport_http.Full -> Mcp_server_eio.Full
@@ -212,12 +208,12 @@ let mcp_transport_http_deps () : Server_mcp_transport_http.deps =
       (fun ~base_path request ->
         verify_mcp_observer_stream_auth ~base_path request
         |> Result.map (fun _ -> ())
-        |> Result.map_error mcp_transport_auth_failure_of_message);
+        |> Result.map_error mcp_transport_auth_failure_of_masc_error);
     verify_operator_mcp_auth =
       (fun ~base_path request ->
         verify_operator_mcp_auth ~base_path request
         |> Result.map (fun _ -> ())
-        |> Result.map_error mcp_transport_auth_failure_of_message);
+        |> Result.map_error mcp_transport_auth_failure_of_masc_error);
   }
 
 let mcp_transport_json_headers session_id protocol_version origin =

--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -141,6 +141,17 @@ let classify_mcp_accept = Server_mcp_transport_http.classify_mcp_accept
 
 let force_json_response = Server_mcp_transport_http.force_json_response
 
+let mcp_transport_auth_failure_of_masc_error err :
+    Server_mcp_transport_http.auth_failure =
+  { message = Masc_domain.masc_error_to_string err
+  ; auth_error_code = Masc_domain.dashboard_auth_error_code err
+  }
+;;
+
+let mcp_transport_auth_failure_of_message message :
+    Server_mcp_transport_http.auth_failure =
+  { message; auth_error_code = None }
+;;
 let mcp_transport_http_deps () : Server_mcp_transport_http.deps =
   let mcp_eio_profile_of_transport_profile = function
     | Server_mcp_transport_http.Full -> Mcp_server_eio.Full
@@ -194,13 +205,19 @@ let mcp_transport_http_deps () : Server_mcp_transport_http.deps =
         | None -> Server_mcp_transport_http.default_base_path ());
     verify_mcp_auth =
       (fun ~base_path request ->
-        Result.map (fun _ -> ()) (verify_mcp_auth ~base_path request));
+        verify_mcp_auth ~base_path request
+        |> Result.map (fun _ -> ())
+        |> Result.map_error mcp_transport_auth_failure_of_masc_error);
     verify_mcp_observer_stream_auth =
       (fun ~base_path request ->
-        Result.map (fun _ -> ()) (verify_mcp_observer_stream_auth ~base_path request));
+        verify_mcp_observer_stream_auth ~base_path request
+        |> Result.map (fun _ -> ())
+        |> Result.map_error mcp_transport_auth_failure_of_message);
     verify_operator_mcp_auth =
       (fun ~base_path request ->
-        Result.map (fun _ -> ()) (verify_operator_mcp_auth ~base_path request));
+        verify_operator_mcp_auth ~base_path request
+        |> Result.map (fun _ -> ())
+        |> Result.map_error mcp_transport_auth_failure_of_message);
   }
 
 let mcp_transport_json_headers session_id protocol_version origin =

--- a/lib/server/server_routes_http_dashboard_dev_token.ml
+++ b/lib/server/server_routes_http_dashboard_dev_token.ml
@@ -108,31 +108,13 @@ type dashboard_dev_token_candidate =
   | Rotate
 
 let default_dashboard_dev_token_load path = Fs_compat.load_file path
-let dashboard_dev_token_load = Atomic.make default_dashboard_dev_token_load
 
 let default_dashboard_dev_token_write path raw =
   Fs_compat.mkdir_p (Filename.dirname path);
   Fs_compat.save_file_atomic_strict path raw
 ;;
 
-let dashboard_dev_token_write = Atomic.make default_dashboard_dev_token_write
 let dashboard_dev_token_mu = Cross_context_mutex.create ()
-
-let set_dashboard_dev_token_load_for_testing load =
-  Atomic.set dashboard_dev_token_load load
-;;
-
-let reset_dashboard_dev_token_load_for_testing () =
-  Atomic.set dashboard_dev_token_load default_dashboard_dev_token_load
-;;
-
-let set_dashboard_dev_token_write_for_testing write =
-  Atomic.set dashboard_dev_token_write write
-;;
-
-let reset_dashboard_dev_token_write_for_testing () =
-  Atomic.set dashboard_dev_token_write default_dashboard_dev_token_write
-;;
 
 let classify_dashboard_dev_token_candidate ~base_path raw =
   let trimmed = String.trim raw in
@@ -154,7 +136,7 @@ let classify_dashboard_dev_token_candidate ~base_path raw =
     | Error error -> Error (Credential_lookup_failed error)
 ;;
 
-let read_dashboard_dev_token ~base_path =
+let read_dashboard_dev_token ~load ~base_path =
   let path = dashboard_dev_token_path base_path in
   try
     if not (Fs_compat.file_exists path)
@@ -162,7 +144,7 @@ let read_dashboard_dev_token ~base_path =
     else
       classify_dashboard_dev_token_candidate
         ~base_path
-        ((Atomic.get dashboard_dev_token_load) path)
+        (load path)
   with
   | Eio.Cancel.Cancelled _ as error -> raise error
   | error ->
@@ -180,13 +162,13 @@ let is_generated_token raw =
        raw
 ;;
 
-let read_rotation_journal ~base_path =
+let read_rotation_journal ~load ~base_path =
   let path = dashboard_dev_token_pending_path base_path in
   try
     if not (Fs_compat.file_exists path)
     then Ok None
     else (
-      let raw = String.trim ((Atomic.get dashboard_dev_token_load) path) in
+      let raw = String.trim (load path) in
       if is_generated_token raw
       then Ok (Some raw)
       else Error (Rotation_journal_invalid { path }))
@@ -198,9 +180,9 @@ let read_rotation_journal ~base_path =
          { path; detail = Printexc.to_string error })
 ;;
 
-let write_private_atomic path raw =
+let write_private_atomic ~write path raw =
   try
-    match (Atomic.get dashboard_dev_token_write) path raw with
+    match write path raw with
     | Ok () -> Ok ()
     | Error detail -> Error detail
   with
@@ -231,7 +213,7 @@ let revoke_dashboard_credential base_path =
          })
 ;;
 
-let resume_rotation ~base_path raw =
+let resume_rotation ~write ~base_path raw =
   let pending_path = dashboard_dev_token_pending_path base_path in
   let token_path = dashboard_dev_token_path base_path in
   let* () = revoke_dashboard_credential base_path in
@@ -244,7 +226,7 @@ let resume_rotation ~base_path raw =
     |> Result.map_error (fun error -> Credential_rotation_failed error)
   in
   let* () =
-    write_private_atomic token_path raw
+    write_private_atomic ~write token_path raw
     |> Result.map_error (fun detail -> Token_file_write_failed { path = token_path; detail })
   in
   let* () =
@@ -255,31 +237,35 @@ let resume_rotation ~base_path raw =
   Ok (dashboard_dev_token raw)
 ;;
 
-let begin_rotation ~base_path =
+let begin_rotation ~write ~base_path =
   let raw = Auth.generate_token () in
   let pending_path = dashboard_dev_token_pending_path base_path in
   let* () =
-    write_private_atomic pending_path raw
+    write_private_atomic ~write pending_path raw
     |> Result.map_error (fun detail ->
       Rotation_journal_write_failed { path = pending_path; detail })
   in
-  resume_rotation ~base_path raw
+  resume_rotation ~write ~base_path raw
 ;;
 
-let ensure_dashboard_dev_token_unlocked base_path =
-  let* pending = read_rotation_journal ~base_path in
+let ensure_dashboard_dev_token_unlocked ~load ~write base_path =
+  let* pending = read_rotation_journal ~load ~base_path in
   match pending with
-  | Some raw -> resume_rotation ~base_path raw
+  | Some raw -> resume_rotation ~write ~base_path raw
   | None ->
-    let* candidate = read_dashboard_dev_token ~base_path in
+    let* candidate = read_dashboard_dev_token ~load ~base_path in
     (match candidate with
      | Reusable raw -> Ok (dashboard_dev_token raw)
-     | Rotate -> begin_rotation ~base_path)
+     | Rotate -> begin_rotation ~write ~base_path)
 ;;
 
-let ensure_dashboard_dev_token base_path =
+let ensure_dashboard_dev_token
+      ?(load = default_dashboard_dev_token_load)
+      ?(write = default_dashboard_dev_token_write)
+      base_path
+  =
   Cross_context_mutex.with_durable_lock dashboard_dev_token_mu (fun () ->
-    ensure_dashboard_dev_token_unlocked base_path)
+    ensure_dashboard_dev_token_unlocked ~load ~write base_path)
 ;;
 
 let ensure_dashboard_dev_token_for_authority ~request_authority ~base_path =

--- a/lib/server/server_routes_http_dashboard_dev_token.ml
+++ b/lib/server/server_routes_http_dashboard_dev_token.ml
@@ -153,15 +153,6 @@ let read_dashboard_dev_token ~load ~base_path =
          { path; detail = Printexc.to_string error })
 ;;
 
-let is_generated_token raw =
-  String.length raw = 64
-  && String.for_all
-       (function
-         | '0' .. '9' | 'a' .. 'f' -> true
-         | _ -> false)
-       raw
-;;
-
 let read_rotation_journal ~load ~base_path =
   let path = dashboard_dev_token_pending_path base_path in
   try
@@ -169,7 +160,7 @@ let read_rotation_journal ~load ~base_path =
     then Ok None
     else (
       let raw = String.trim (load path) in
-      if is_generated_token raw
+      if Auth.is_generated_token_shape raw
       then Ok (Some raw)
       else Error (Rotation_journal_invalid { path }))
   with

--- a/lib/server/server_routes_http_dashboard_dev_token.ml
+++ b/lib/server/server_routes_http_dashboard_dev_token.ml
@@ -1,14 +1,79 @@
-(** Dashboard dev-token cluster, extracted from
-    [server_routes_http_routes_dashboard.ml]. Wraps the on-disk dev-token
-    file, classifies stored candidates, mints when
-    missing, and exposes the high-level [ensure_dashboard_dev_token]
-    that the dashboard route handlers depend on. *)
+(** Dashboard dev-token issuance and role-aware rotation.
+
+    Rotation is a resumable transaction:
+    journal -> credential revocation -> Worker credential -> public raw token
+    -> journal removal. A failure after the journal write leaves the exact raw
+    token available for an idempotent retry. *)
+
+let ( let* ) = Result.bind
 
 let dashboard_dev_actor_name = "dashboard"
+let dashboard_dev_role = Masc_domain.Worker
+
+type dashboard_dev_token =
+  { raw : string
+  ; actor : string
+  ; role : Masc_domain.agent_role
+  }
 
 type request_error =
   | Non_loopback_request_host of string
-  | Token_operation_failed of string
+  | Token_operation_failed of token_error
+
+and token_error =
+  | Token_file_read_failed of { path : string; detail : string }
+  | Credential_lookup_failed of Masc_domain.masc_error
+  | Rotation_journal_read_failed of { path : string; detail : string }
+  | Rotation_journal_invalid of { path : string }
+  | Rotation_journal_write_failed of { path : string; detail : string }
+  | Credential_revocation_failed of { agent_name : string; detail : string }
+  | Credential_rotation_failed of Masc_domain.masc_error
+  | Token_file_write_failed of { path : string; detail : string }
+  | Rotation_finalize_failed of { path : string; detail : string }
+
+let dashboard_dev_token raw =
+  { raw; actor = dashboard_dev_actor_name; role = dashboard_dev_role }
+;;
+
+let token_error_code = function
+  | Token_file_read_failed _ -> "dashboard_dev_token_read_failed"
+  | Credential_lookup_failed _ -> "dashboard_dev_token_credential_lookup_failed"
+  | Rotation_journal_read_failed _ -> "dashboard_dev_token_rotation_read_failed"
+  | Rotation_journal_invalid _ -> "dashboard_dev_token_rotation_invalid"
+  | Rotation_journal_write_failed _ -> "dashboard_dev_token_rotation_write_failed"
+  | Credential_revocation_failed _ ->
+    "dashboard_dev_token_credential_revocation_failed"
+  | Credential_rotation_failed _ -> "dashboard_dev_token_credential_rotation_failed"
+  | Token_file_write_failed _ -> "dashboard_dev_token_write_failed"
+  | Rotation_finalize_failed _ -> "dashboard_dev_token_rotation_finalize_failed"
+;;
+
+let token_error_to_string = function
+  | Token_file_read_failed { path; detail } ->
+    Printf.sprintf "read dashboard dev-token %s: %s" path detail
+  | Credential_lookup_failed error ->
+    Printf.sprintf
+      "classify dashboard dev-token credential: %s"
+      (Masc_domain.masc_error_to_string error)
+  | Rotation_journal_read_failed { path; detail } ->
+    Printf.sprintf "read dashboard dev-token rotation journal %s: %s" path detail
+  | Rotation_journal_invalid { path } ->
+    Printf.sprintf
+      "dashboard dev-token rotation journal %s is invalid; refusing to mint a replacement"
+      path
+  | Rotation_journal_write_failed { path; detail } ->
+    Printf.sprintf "write dashboard dev-token rotation journal %s: %s" path detail
+  | Credential_revocation_failed { agent_name; detail } ->
+    Printf.sprintf "revoke dashboard credential %S: %s" agent_name detail
+  | Credential_rotation_failed error ->
+    Printf.sprintf
+      "persist dashboard Worker credential: %s"
+      (Masc_domain.masc_error_to_string error)
+  | Token_file_write_failed { path; detail } ->
+    Printf.sprintf "persist dashboard dev-token %s: %s" path detail
+  | Rotation_finalize_failed { path; detail } ->
+    Printf.sprintf "finalize dashboard dev-token rotation %s: %s" path detail
+;;
 
 let request_error_status : request_error -> Httpun.Status.t = function
   | Non_loopback_request_host _ -> `Forbidden
@@ -17,7 +82,7 @@ let request_error_status : request_error -> Httpun.Status.t = function
 
 let request_error_code = function
   | Non_loopback_request_host _ -> "dashboard_dev_token_host_non_loopback"
-  | Token_operation_failed _ -> "dashboard_dev_token_operation_failed"
+  | Token_operation_failed error -> token_error_code error
 ;;
 
 let request_error_to_string = function
@@ -25,13 +90,18 @@ let request_error_to_string = function
     Printf.sprintf
       "dashboard dev-token request Host %S is not an exact loopback host"
       host
-  | Token_operation_failed detail -> detail
+  | Token_operation_failed error -> token_error_to_string error
 ;;
 
 let dashboard_dev_token_path base_path =
   Filename.concat
     (Filename.concat (Common.masc_dir_from_base_path ~base_path) "auth")
     "dashboard.token"
+;;
+
+let dashboard_dev_token_pending_path base_path =
+  dashboard_dev_token_path base_path ^ ".pending"
+;;
 
 type dashboard_dev_token_candidate =
   | Reusable of string
@@ -40,74 +110,177 @@ type dashboard_dev_token_candidate =
 let default_dashboard_dev_token_load path = Fs_compat.load_file path
 let dashboard_dev_token_load = Atomic.make default_dashboard_dev_token_load
 
+let default_dashboard_dev_token_write path raw =
+  Fs_compat.mkdir_p (Filename.dirname path);
+  Fs_compat.save_file_atomic_strict path raw
+;;
+
+let dashboard_dev_token_write = Atomic.make default_dashboard_dev_token_write
+let dashboard_dev_token_mu = Cross_context_mutex.create ()
+
 let set_dashboard_dev_token_load_for_testing load =
   Atomic.set dashboard_dev_token_load load
+;;
 
 let reset_dashboard_dev_token_load_for_testing () =
   Atomic.set dashboard_dev_token_load default_dashboard_dev_token_load
+;;
 
-let classify_dashboard_dev_token_candidate ~base_path raw :
-    (dashboard_dev_token_candidate, string) result =
+let set_dashboard_dev_token_write_for_testing write =
+  Atomic.set dashboard_dev_token_write write
+;;
+
+let reset_dashboard_dev_token_write_for_testing () =
+  Atomic.set dashboard_dev_token_write default_dashboard_dev_token_write
+;;
+
+let classify_dashboard_dev_token_candidate ~base_path raw =
   let trimmed = String.trim raw in
-  if String.equal trimmed "" then
-    Ok Rotate
+  if String.equal trimmed ""
+  then Ok Rotate
   else
-    match Auth.resolve_agent_from_token base_path ~token:trimmed with
-    | Ok owner when String.equal owner dashboard_dev_actor_name ->
-        Ok (Reusable trimmed)
-    | Ok _owner ->
-        Ok Rotate
-    | Error (Masc_domain.Auth (Masc_domain.Auth_error.InvalidToken _ | Masc_domain.Auth_error.TokenExpired _ | Masc_domain.Auth_error.Unauthorized _)) ->
-        Ok Rotate
-    | Error err ->
-        Error (Masc_domain.masc_error_to_string err)
+    match Auth.find_credential_by_token base_path ~token:trimmed with
+    | Ok credential
+      when String.equal credential.agent_name dashboard_dev_actor_name
+           && credential.role = dashboard_dev_role ->
+      Ok (Reusable trimmed)
+    | Ok _ -> Ok Rotate
+    | Error
+        (Masc_domain.Auth
+           (Masc_domain.Auth_error.InvalidToken _
+           | Masc_domain.Auth_error.TokenExpired _
+           | Masc_domain.Auth_error.Unauthorized _)) ->
+      Ok Rotate
+    | Error error -> Error (Credential_lookup_failed error)
+;;
 
-let read_reusable_dashboard_dev_token ~base_path path :
-    (string option, string) result =
-  if not (Fs_compat.file_exists path) then
-    Ok None
-  else
-    try
-      match classify_dashboard_dev_token_candidate ~base_path
-              ((Atomic.get dashboard_dev_token_load) path) with
-      | Ok (Reusable raw) -> Ok (Some raw)
-      | Ok Rotate -> Ok None
-      | Error msg -> Error msg
-    with
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | exn ->
-        Error
-          (Printf.sprintf "read dev-token %s: %s"
-             path (Printexc.to_string exn))
-
-let persist_dashboard_dev_token ~base_path raw : (unit, string) result =
-  let token_path = dashboard_dev_token_path base_path in
+let read_dashboard_dev_token ~base_path =
+  let path = dashboard_dev_token_path base_path in
   try
-    Auth.save_private_text_file token_path raw;
+    if not (Fs_compat.file_exists path)
+    then Ok Rotate
+    else
+      classify_dashboard_dev_token_candidate
+        ~base_path
+        ((Atomic.get dashboard_dev_token_load) path)
+  with
+  | Eio.Cancel.Cancelled _ as error -> raise error
+  | error ->
+    Error
+      (Token_file_read_failed
+         { path; detail = Printexc.to_string error })
+;;
+
+let is_generated_token raw =
+  String.length raw = 64
+  && String.for_all
+       (function
+         | '0' .. '9' | 'a' .. 'f' -> true
+         | _ -> false)
+       raw
+;;
+
+let read_rotation_journal ~base_path =
+  let path = dashboard_dev_token_pending_path base_path in
+  try
+    if not (Fs_compat.file_exists path)
+    then Ok None
+    else (
+      let raw = String.trim ((Atomic.get dashboard_dev_token_load) path) in
+      if is_generated_token raw
+      then Ok (Some raw)
+      else Error (Rotation_journal_invalid { path }))
+  with
+  | Eio.Cancel.Cancelled _ as error -> raise error
+  | error ->
+    Error
+      (Rotation_journal_read_failed
+         { path; detail = Printexc.to_string error })
+;;
+
+let write_private_atomic path raw =
+  try
+    match (Atomic.get dashboard_dev_token_write) path raw with
+    | Ok () -> Ok ()
+    | Error detail -> Error detail
+  with
+  | Eio.Cancel.Cancelled _ as error -> raise error
+  | error -> Error (Printexc.to_string error)
+;;
+
+let remove_rotation_journal path =
+  try
+    Eio_guard.run_in_systhread (fun () -> Sys.remove path);
     Ok ()
   with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn ->
-      Error (Printf.sprintf "persist dev-token: %s" (Printexc.to_string exn))
+  | Eio.Cancel.Cancelled _ as error -> raise error
+  | error -> Error (Printexc.to_string error)
+;;
 
-let mint_dashboard_dev_token base_path : (string, string) result =
-  match
-    Auth.create_token base_path
-      ~agent_name:dashboard_dev_actor_name ~role:Masc_domain.Admin
+let revoke_dashboard_credential base_path =
+  try
+    Auth.delete_credential base_path dashboard_dev_actor_name;
+    Ok ()
   with
-  | Ok (raw, _cred) ->
-      (match persist_dashboard_dev_token ~base_path raw with
-       | Ok () -> Ok raw
-       | Error msg -> Error msg)
-  | Error err ->
-      Error (Masc_domain.masc_error_to_string err)
+  | Eio.Cancel.Cancelled _ as error -> raise error
+  | error ->
+    Error
+      (Credential_revocation_failed
+         { agent_name = dashboard_dev_actor_name
+         ; detail = Printexc.to_string error
+         })
+;;
 
-let ensure_dashboard_dev_token base_path : (string, string) result =
+let resume_rotation ~base_path raw =
+  let pending_path = dashboard_dev_token_pending_path base_path in
   let token_path = dashboard_dev_token_path base_path in
-  match read_reusable_dashboard_dev_token ~base_path token_path with
-  | Error msg -> Error msg
-  | Ok (Some raw) -> Ok raw
-  | Ok None -> mint_dashboard_dev_token base_path
+  let* () = revoke_dashboard_credential base_path in
+  let* _credential =
+    Auth.save_raw_token_credential
+      base_path
+      ~agent_name:dashboard_dev_actor_name
+      ~role:dashboard_dev_role
+      ~raw_token:raw
+    |> Result.map_error (fun error -> Credential_rotation_failed error)
+  in
+  let* () =
+    write_private_atomic token_path raw
+    |> Result.map_error (fun detail -> Token_file_write_failed { path = token_path; detail })
+  in
+  let* () =
+    remove_rotation_journal pending_path
+    |> Result.map_error (fun detail ->
+      Rotation_finalize_failed { path = pending_path; detail })
+  in
+  Ok (dashboard_dev_token raw)
+;;
+
+let begin_rotation ~base_path =
+  let raw = Auth.generate_token () in
+  let pending_path = dashboard_dev_token_pending_path base_path in
+  let* () =
+    write_private_atomic pending_path raw
+    |> Result.map_error (fun detail ->
+      Rotation_journal_write_failed { path = pending_path; detail })
+  in
+  resume_rotation ~base_path raw
+;;
+
+let ensure_dashboard_dev_token_unlocked base_path =
+  let* pending = read_rotation_journal ~base_path in
+  match pending with
+  | Some raw -> resume_rotation ~base_path raw
+  | None ->
+    let* candidate = read_dashboard_dev_token ~base_path in
+    (match candidate with
+     | Reusable raw -> Ok (dashboard_dev_token raw)
+     | Rotate -> begin_rotation ~base_path)
+;;
+
+let ensure_dashboard_dev_token base_path =
+  Cross_context_mutex.with_durable_lock dashboard_dev_token_mu (fun () ->
+    ensure_dashboard_dev_token_unlocked base_path)
+;;
 
 let ensure_dashboard_dev_token_for_authority ~request_authority ~base_path =
   let host = Server_request_authority.host request_authority in
@@ -115,6 +288,6 @@ let ensure_dashboard_dev_token_for_authority ~request_authority ~base_path =
   then Error (Non_loopback_request_host host)
   else
     Result.map_error
-      (fun detail -> Token_operation_failed detail)
+      (fun error -> Token_operation_failed error)
       (ensure_dashboard_dev_token base_path)
 ;;

--- a/lib/server/server_routes_http_dashboard_dev_token.mli
+++ b/lib/server/server_routes_http_dashboard_dev_token.mli
@@ -1,14 +1,39 @@
-(** Dashboard dev-token file and minting helpers for dashboard routes. *)
+(** Dashboard dev-token file and role-aware rotation helpers. *)
 
 type request_error =
   | Non_loopback_request_host of string
-  | Token_operation_failed of string
+  | Token_operation_failed of token_error
+
+and token_error =
+  | Token_file_read_failed of { path : string; detail : string }
+  | Credential_lookup_failed of Masc_domain.masc_error
+  | Rotation_journal_read_failed of { path : string; detail : string }
+  | Rotation_journal_invalid of { path : string }
+  | Rotation_journal_write_failed of { path : string; detail : string }
+  | Credential_revocation_failed of { agent_name : string; detail : string }
+  | Credential_rotation_failed of Masc_domain.masc_error
+  | Token_file_write_failed of { path : string; detail : string }
+  | Rotation_finalize_failed of { path : string; detail : string }
+
+type dashboard_dev_token =
+  { raw : string
+  ; actor : string
+  ; role : Masc_domain.agent_role
+  }
 
 val dashboard_dev_token_path : string -> string
+val dashboard_dev_token_pending_path : string -> string
+val token_error_code : token_error -> string
+val token_error_to_string : token_error -> string
 val request_error_status : request_error -> Httpun.Status.t
 val request_error_code : request_error -> string
 val request_error_to_string : request_error -> string
-val ensure_dashboard_dev_token : string -> (string, string) result
+
+val ensure_dashboard_dev_token :
+  string -> (dashboard_dev_token, token_error) result
+(** Return the reusable Worker token or resume/create one role-aware rotation.
+    Rotation is serialized across Eio and non-Eio callers and is protected
+    against cancellation after the durable transaction starts. *)
 
 val set_dashboard_dev_token_load_for_testing : (string -> string) -> unit
 (** Replace the dev-token file reader for focused failure-path tests. *)
@@ -16,9 +41,14 @@ val set_dashboard_dev_token_load_for_testing : (string -> string) -> unit
 val reset_dashboard_dev_token_load_for_testing : unit -> unit
 (** Restore the production dev-token file reader. *)
 
+val set_dashboard_dev_token_write_for_testing :
+  (string -> string -> (unit, string) result) -> unit
+
+val reset_dashboard_dev_token_write_for_testing : unit -> unit
+
 val ensure_dashboard_dev_token_for_authority :
   request_authority:Server_request_authority.authority ->
   base_path:string ->
-  (string, request_error) result
-(** Enforce the dev-token endpoint's loopback-only policy on an authority
-    already admitted at request entry, before token or credential I/O. *)
+  (dashboard_dev_token, request_error) result
+(** Enforce the endpoint's loopback-only policy on an authority already
+    admitted at request entry, before token or credential I/O. *)

--- a/lib/server/server_routes_http_dashboard_dev_token.mli
+++ b/lib/server/server_routes_http_dashboard_dev_token.mli
@@ -30,21 +30,14 @@ val request_error_code : request_error -> string
 val request_error_to_string : request_error -> string
 
 val ensure_dashboard_dev_token :
+  ?load:(string -> string) ->
+  ?write:(string -> string -> (unit, string) result) ->
   string -> (dashboard_dev_token, token_error) result
 (** Return the reusable Worker token or resume/create one role-aware rotation.
     Rotation is serialized across Eio and non-Eio callers and is protected
-    against cancellation after the durable transaction starts. *)
-
-val set_dashboard_dev_token_load_for_testing : (string -> string) -> unit
-(** Replace the dev-token file reader for focused failure-path tests. *)
-
-val reset_dashboard_dev_token_load_for_testing : unit -> unit
-(** Restore the production dev-token file reader. *)
-
-val set_dashboard_dev_token_write_for_testing :
-  (string -> string -> (unit, string) result) -> unit
-
-val reset_dashboard_dev_token_write_for_testing : unit -> unit
+    against cancellation after the durable transaction starts. Optional I/O
+    functions are scoped to this call so failure-path tests do not mutate
+    process-global credential behavior. *)
 
 val ensure_dashboard_dev_token_for_authority :
   request_authority:Server_request_authority.authority ->

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -669,10 +669,10 @@ let add_routes ~sw ~clock router =
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/workspace" (fun request reqd ->
        with_public_read handle_dashboard_workspace request reqd)
-  (* Dev-only shared bearer for the dashboard UI. Served exclusively when the
+  (* Dev-only Worker bearer for the dashboard UI. Served exclusively when the
      server binds to loopback and strict-auth env overrides are disabled, so
-     that a LAN deployment never hands out a token over the wire. The token is
-     canonicalized to the [dashboard] actor and persisted at
+     that a LAN deployment never hands out a credential over the wire. The
+     token is canonicalized to the [dashboard] actor and persisted at
      [.masc/auth/dashboard.token]. *)
   |> Http.Router.get "/api/v1/dashboard/dev-token" (fun request reqd ->
        if (not (http_auth_bind_is_loopback ()))
@@ -689,9 +689,14 @@ let add_routes ~sw ~clock router =
            in
            begin
              match raw_result with
-             | Ok raw ->
+             | Ok token ->
                Http.Response.json_value ~request:req
-                 (`Assoc [ ("token", `String raw) ]) reqd
+                 (`Assoc
+                    [ "token", `String token.raw
+                    ; "actor", `String token.actor
+                    ; ( "role"
+                      , `String (Masc_domain.agent_role_to_string token.role) )
+                    ]) reqd
              | Error err ->
                let status =
                  Server_routes_http_dashboard_dev_token.request_error_status err

--- a/lib/server/server_routes_http_routes_dashboard.mli
+++ b/lib/server/server_routes_http_routes_dashboard.mli
@@ -10,22 +10,6 @@ val add_routes :
   clock:float Eio.Time.clock_ty Eio.Resource.t ->
   Http_server_eio.Router.t -> Http_server_eio.Router.t
 
-val dashboard_dev_token_path : string -> string
-(** [<base_path>/.masc/auth/dashboard.token] — the canonical
-    dashboard dev-token file written on boot. *)
-
-type dashboard_dev_token =
-  Server_routes_http_dashboard_dev_token.dashboard_dev_token
-type dashboard_dev_token_error =
-  Server_routes_http_dashboard_dev_token.token_error
-
-val ensure_dashboard_dev_token :
-  string -> (dashboard_dev_token, dashboard_dev_token_error) result
-(** Idempotent boot helper: returns the canonical worker-scoped dashboard
-    dev-token identity, generating + persisting one to
-    {!dashboard_dev_token_path} on first call. Persistence and rotation
-    failures remain typed. *)
-
 module For_testing : sig
   type gate_mode_recovery =
     | Recovery_completed of Keeper_gate.operator_recovery_report

--- a/lib/server/server_routes_http_routes_dashboard.mli
+++ b/lib/server/server_routes_http_routes_dashboard.mli
@@ -14,11 +14,17 @@ val dashboard_dev_token_path : string -> string
 (** [<base_path>/.masc/auth/dashboard.token] — the canonical
     dashboard dev-token file written on boot. *)
 
-val ensure_dashboard_dev_token : string -> (string, string) result
-(** Idempotent boot helper: returns the canonical dashboard dev token
-    string, generating + persisting one to {!dashboard_dev_token_path}
-    on first call. [Error msg] when the auth dir is unwritable. Exposed
-    so the dashboard-keeper-routes test can drive the boot path directly. *)
+type dashboard_dev_token =
+  Server_routes_http_dashboard_dev_token.dashboard_dev_token
+type dashboard_dev_token_error =
+  Server_routes_http_dashboard_dev_token.token_error
+
+val ensure_dashboard_dev_token :
+  string -> (dashboard_dev_token, dashboard_dev_token_error) result
+(** Idempotent boot helper: returns the canonical worker-scoped dashboard
+    dev-token identity, generating + persisting one to
+    {!dashboard_dev_token_path} on first call. Persistence and rotation
+    failures remain typed. *)
 
 module For_testing : sig
   type gate_mode_recovery =

--- a/lib/server/server_routes_http_routes_dashboard_setup.ml
+++ b/lib/server/server_routes_http_routes_dashboard_setup.ml
@@ -35,17 +35,6 @@ let oas_telemetry_limit_param req =
 
 let oas_telemetry_provider_param req = trimmed_query_param req "provider"
 
-(* Dashboard dev-token cluster extracted to
-   [Server_routes_http_dashboard_dev_token] (godfile decomp). *)
-
-let dashboard_dev_token_path = Server_routes_http_dashboard_dev_token.dashboard_dev_token_path
-type dashboard_dev_token =
-  Server_routes_http_dashboard_dev_token.dashboard_dev_token
-type dashboard_dev_token_error =
-  Server_routes_http_dashboard_dev_token.token_error
-let ensure_dashboard_dev_token = Server_routes_http_dashboard_dev_token.ensure_dashboard_dev_token
-
-
 (** Broadcast handler: parse JSON body, extract "message" string field, and
     relay via Workspace.broadcast.  Error responses are encoded through Yojson so
     exception messages cannot break JSON framing via embedded quotes. *)

--- a/lib/server/server_routes_http_routes_dashboard_setup.ml
+++ b/lib/server/server_routes_http_routes_dashboard_setup.ml
@@ -39,6 +39,10 @@ let oas_telemetry_provider_param req = trimmed_query_param req "provider"
    [Server_routes_http_dashboard_dev_token] (godfile decomp). *)
 
 let dashboard_dev_token_path = Server_routes_http_dashboard_dev_token.dashboard_dev_token_path
+type dashboard_dev_token =
+  Server_routes_http_dashboard_dev_token.dashboard_dev_token
+type dashboard_dev_token_error =
+  Server_routes_http_dashboard_dev_token.token_error
 let ensure_dashboard_dev_token = Server_routes_http_dashboard_dev_token.ensure_dashboard_dev_token
 
 

--- a/lib/server/server_routes_http_routes_dashboard_setup.mli
+++ b/lib/server/server_routes_http_routes_dashboard_setup.mli
@@ -29,7 +29,12 @@ val oas_telemetry_provider_param : Httpun.Request.t -> string option
 val resolve_telemetry_n : has_time_window:bool -> n_param:string option -> int
 
 val dashboard_dev_token_path : string -> string
-val ensure_dashboard_dev_token : string -> (string, string) result
+type dashboard_dev_token =
+  Server_routes_http_dashboard_dev_token.dashboard_dev_token
+type dashboard_dev_token_error =
+  Server_routes_http_dashboard_dev_token.token_error
+val ensure_dashboard_dev_token :
+  string -> (dashboard_dev_token, dashboard_dev_token_error) result
 
 val handle_broadcast :
   Mcp_server.server_state -> string -> Httpun.Reqd.t -> string -> unit

--- a/lib/server/server_routes_http_routes_dashboard_setup.mli
+++ b/lib/server/server_routes_http_routes_dashboard_setup.mli
@@ -28,14 +28,6 @@ val oas_telemetry_provider_param : Httpun.Request.t -> string option
     n=0 preserved. Exposed for the freeze-guard test. *)
 val resolve_telemetry_n : has_time_window:bool -> n_param:string option -> int
 
-val dashboard_dev_token_path : string -> string
-type dashboard_dev_token =
-  Server_routes_http_dashboard_dev_token.dashboard_dev_token
-type dashboard_dev_token_error =
-  Server_routes_http_dashboard_dev_token.token_error
-val ensure_dashboard_dev_token :
-  string -> (dashboard_dev_token, dashboard_dev_token_error) result
-
 val handle_broadcast :
   Mcp_server.server_state -> string -> Httpun.Reqd.t -> string -> unit
 val handle_dashboard_link_previews :

--- a/lib/server/server_routes_http_routes_frontend.ml
+++ b/lib/server/server_routes_http_routes_frontend.ml
@@ -111,7 +111,7 @@ let websocket_upgrade_authorized ~base_path ~request_authority request =
        let message =
          Printf.sprintf
            "%s Same-origin WebSocket upgrade rejected: %s"
-           token_error
+           (Masc_domain.masc_error_to_string token_error)
            (Masc_domain.masc_error_to_string origin_error)
        in
        Error (websocket_auth_error message))

--- a/lib/sse_jsonrpc_filter.mli
+++ b/lib/sse_jsonrpc_filter.mli
@@ -2,4 +2,7 @@
 
 val jsonrpc_message_for_agent_stream : Yojson.Safe.t -> bool
 
+val event_data_payload : string -> string option
+(** Extract and join the [data:] fields from one SSE event. *)
+
 val event_string_jsonrpc_message_for_agent_stream : string -> bool

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -117,7 +117,7 @@ let execution_policy_of_metadata ~tool_name (metadata : metadata) =
 (* Metadata constructors                                            *)
 (* ================================================================ *)
 
-let default_metadata =
+let default_metadata ~required_permission =
   {
     visibility = Default;
     lifecycle = Active;
@@ -129,7 +129,7 @@ let default_metadata =
     readonly = None;
     mcp_context_required = None;
     idempotent = None;
-    required_permission = Masc_domain.CanBroadcast;
+    required_permission;
   }
 
 (* Runtime-readable so tests and local admin flows can toggle placeholder
@@ -142,7 +142,7 @@ let placeholder_tools_enabled () =
   | _ -> true
 
 let hidden_active ?canonical_name ?replacement ?(allow_direct_call_when_hidden = true)
-    ?(implementation_status = Real) reason =
+    ?(implementation_status = Real) ~required_permission reason =
   {
     visibility = Hidden;
     lifecycle = Active;
@@ -154,7 +154,7 @@ let hidden_active ?canonical_name ?replacement ?(allow_direct_call_when_hidden =
     readonly = None;
     mcp_context_required = None;
     idempotent = None;
-    required_permission = Masc_domain.CanBroadcast;
+    required_permission;
   }
 
 let with_semantic_flags ?readonly ?mcp_context_required ?idempotent meta =
@@ -191,20 +191,19 @@ let readonly_tool =
   with_execution_policy
     ~readonly:true
     ~idempotent:false
-    default_metadata
-  |> with_required_permission Masc_domain.CanReadState
+    (default_metadata ~required_permission:Masc_domain.CanReadState)
 
 let mutating_tool =
   with_execution_policy
     ~readonly:false
     ~idempotent:false
-    default_metadata
+    (default_metadata ~required_permission:Masc_domain.CanBroadcast)
 
 let masc_workspace_tool =
   with_execution_policy
     ~readonly:false
     ~idempotent:false
-    default_metadata
+    (default_metadata ~required_permission:Masc_domain.CanBroadcast)
 
 let read_state_tool = readonly_tool
 let broadcast_tool = masc_workspace_tool
@@ -232,6 +231,7 @@ let explicit_metadata : (string * metadata) list =
   [
     ( "masc_operator_judgment_write",
       hidden_active
+        ~required_permission:Masc_domain.CanAdmin
         "Internal operator-judge write path hidden from the default tool list; use for operator judgment experiments and automation." );
     (* Physically removed: masc_interrupt, masc_approve, masc_reject,
        masc_pending_interrupts, masc_branch (masc-checkpoint CLI removed,
@@ -261,7 +261,9 @@ let explicit_metadata : (string * metadata) list =
     ( "masc_operator_action",
       with_required_permission
         Masc_domain.CanAdmin
-        (hidden_active "Internal operator-action route; hidden from the public tool surface.") );
+        (hidden_active
+           ~required_permission:Masc_domain.CanAdmin
+           "Internal operator-action route; hidden from the public tool surface.") );
     ( "masc_operator_board_attention_quarantine_requeue",
       with_execution_policy
         ~readonly:false
@@ -270,6 +272,7 @@ let explicit_metadata : (string * metadata) list =
            Masc_domain.CanAdmin
            (hidden_active
            ~allow_direct_call_when_hidden:false
+           ~required_permission:Masc_domain.CanAdmin
            "Operator-profile-only exact recovery of one Board-attention quarantine.")) );
     ( "masc_operator_chat_recovery_resolve",
       with_execution_policy
@@ -279,6 +282,7 @@ let explicit_metadata : (string * metadata) list =
            Masc_domain.CanAdmin
            (hidden_active
            ~allow_direct_call_when_hidden:false
+           ~required_permission:Masc_domain.CanAdmin
            "Operator-profile-only exact recovery of one crash-ambiguous Keeper chat receipt.")) );
     ( "masc_operator_task_recovery_resolve",
       with_execution_policy
@@ -288,11 +292,13 @@ let explicit_metadata : (string * metadata) list =
            Masc_domain.CanAdmin
            (hidden_active
            ~allow_direct_call_when_hidden:false
+           ~required_permission:Masc_domain.CanAdmin
            "Operator-profile-only exact owner/version recovery of one Task.")) );
     ( "masc_set_param",
       with_required_permission
         Masc_domain.CanAdmin
         (hidden_active
+           ~required_permission:Masc_domain.CanAdmin
            "Internal HTTP runtime-parameter mutation route; hidden from the public tool surface.") );
     (* Catalog-owned permissions for split/lazily registered tool modules. *)
     ("masc_reset", reset_tool);
@@ -300,6 +306,7 @@ let explicit_metadata : (string * metadata) list =
     ("masc_task_history", read_state_tool);
     ("masc_add_task", add_task_tool);
     ("masc_batch_add_tasks", add_task_tool);
+    ("masc_task_set_goal", complete_task_tool);
     ("masc_update_priority", complete_task_tool);
     ("masc_heartbeat", broadcast_tool);
     ("masc_goal_list", read_state_tool);
@@ -490,12 +497,17 @@ let metadata name =
   match Hashtbl.find_opt metadata_table name with
   | Some meta -> meta
   | None ->
+    (* An unclassified tool is never granted a worker-capable permission. The
+       catalog has no evidence for a narrower policy, so the typed fallback
+       is operator-only and registration/authentication still require an
+       explicit catalog entry. *)
+    let fail_closed = default_metadata ~required_permission:Masc_domain.CanAdmin in
     if is_public_mcp name
-    then default_metadata
+    then fail_closed
     else
       (* External MCP discovery remains an explicit public-surface contract.
          It must not be reused as Keeper authorization or model visibility. *)
-      { default_metadata with
+      { fail_closed with
         visibility = Hidden
       ; allow_direct_call_when_hidden = true
       ; reason = Some "Not on the external MCP discovery surface."

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -55,6 +55,7 @@ type metadata = {
   readonly : bool option;
   mcp_context_required : bool option;
   idempotent : bool option;
+  required_permission : Masc_domain.permission;
 }
 
 type execution_policy_axis =
@@ -128,6 +129,7 @@ let default_metadata =
     readonly = None;
     mcp_context_required = None;
     idempotent = None;
+    required_permission = Masc_domain.CanBroadcast;
   }
 
 (* Runtime-readable so tests and local admin flows can toggle placeholder
@@ -152,6 +154,7 @@ let hidden_active ?canonical_name ?replacement ?(allow_direct_call_when_hidden =
     readonly = None;
     mcp_context_required = None;
     idempotent = None;
+    required_permission = Masc_domain.CanBroadcast;
   }
 
 let with_semantic_flags ?readonly ?mcp_context_required ?idempotent meta =
@@ -180,11 +183,16 @@ let with_execution_policy
     meta
 ;;
 
+let with_required_permission required_permission meta =
+  { meta with required_permission }
+;;
+
 let readonly_tool =
   with_execution_policy
     ~readonly:true
     ~idempotent:false
     default_metadata
+  |> with_required_permission Masc_domain.CanReadState
 
 let mutating_tool =
   with_execution_policy
@@ -200,10 +208,13 @@ let masc_workspace_tool =
 
 let read_state_tool = readonly_tool
 let broadcast_tool = masc_workspace_tool
-let add_task_tool = masc_workspace_tool
-let claim_task_tool = masc_workspace_tool
-let complete_task_tool = masc_workspace_tool
-let reset_tool = mutating_tool
+let add_task_tool = with_required_permission Masc_domain.CanAddTask masc_workspace_tool
+let claim_task_tool = with_required_permission Masc_domain.CanClaimTask masc_workspace_tool
+let complete_task_tool = with_required_permission Masc_domain.CanCompleteTask masc_workspace_tool
+let vote_tool = with_required_permission Masc_domain.CanVote masc_workspace_tool
+let init_tool = with_required_permission Masc_domain.CanInit mutating_tool
+let reset_tool = with_required_permission Masc_domain.CanReset mutating_tool
+let admin_tool = with_required_permission Masc_domain.CanAdmin mutating_tool
 
 let hidden_runtime_tool reason meta =
   {
@@ -248,34 +259,44 @@ let explicit_metadata : (string * metadata) list =
        masc_admin_reset, masc_gc_force, masc_workspace_delete, masc_force_unbind,
        masc_execute) removed — no dispatch path, no schema, no caller. *)
     ( "masc_operator_action",
-      hidden_active "Internal operator-action route; hidden from the public tool surface." );
+      with_required_permission
+        Masc_domain.CanAdmin
+        (hidden_active "Internal operator-action route; hidden from the public tool surface.") );
     ( "masc_operator_board_attention_quarantine_requeue",
       with_execution_policy
         ~readonly:false
         ~idempotent:true
-        (hidden_active
+        (with_required_permission
+           Masc_domain.CanAdmin
+           (hidden_active
            ~allow_direct_call_when_hidden:false
-           "Operator-profile-only exact recovery of one Board-attention quarantine.") );
+           "Operator-profile-only exact recovery of one Board-attention quarantine.")) );
     ( "masc_operator_chat_recovery_resolve",
       with_execution_policy
         ~readonly:false
         ~idempotent:false
-        (hidden_active
+        (with_required_permission
+           Masc_domain.CanAdmin
+           (hidden_active
            ~allow_direct_call_when_hidden:false
-           "Operator-profile-only exact recovery of one crash-ambiguous Keeper chat receipt.") );
+           "Operator-profile-only exact recovery of one crash-ambiguous Keeper chat receipt.")) );
     ( "masc_operator_task_recovery_resolve",
       with_execution_policy
         ~readonly:false
         ~idempotent:false
-        (hidden_active
+        (with_required_permission
+           Masc_domain.CanAdmin
+           (hidden_active
            ~allow_direct_call_when_hidden:false
-           "Operator-profile-only exact owner/version recovery of one Task.") );
+           "Operator-profile-only exact owner/version recovery of one Task.")) );
     ( "masc_set_param",
-      hidden_active
-        "Internal HTTP runtime-parameter mutation route; hidden from the public tool surface." );
+      with_required_permission
+        Masc_domain.CanAdmin
+        (hidden_active
+           "Internal HTTP runtime-parameter mutation route; hidden from the public tool surface.") );
     (* Catalog-owned permissions for split/lazily registered tool modules. *)
     ("masc_reset", reset_tool);
-    ("masc_start", with_semantic_flags ~mcp_context_required:true broadcast_tool);
+    ("masc_start", with_semantic_flags ~mcp_context_required:true init_tool);
     ("masc_task_history", read_state_tool);
     ("masc_add_task", add_task_tool);
     ("masc_batch_add_tasks", add_task_tool);
@@ -299,10 +320,10 @@ let explicit_metadata : (string * metadata) list =
     ("masc_keeper_sandbox_status", read_state_tool);
     ("masc_keeper_waiting_inventory", read_state_tool);
     ("masc_keeper_up", broadcast_tool);
-    ("masc_keeper_down", mutating_tool);
+    ("masc_keeper_down", admin_tool);
     ("masc_keeper_compact", broadcast_tool);
-    ("masc_keeper_clear", mutating_tool);
-    ("masc_keeper_reset", mutating_tool);
+    ("masc_keeper_clear", admin_tool);
+    ("masc_keeper_reset", reset_tool);
     ("masc_plan_get_task", read_state_tool);
     ("masc_plan_clear_task", broadcast_tool);
     ("masc_note_add", broadcast_tool);
@@ -330,22 +351,37 @@ let explicit_metadata : (string * metadata) list =
     ("masc_board_sub_board_list", read_state_tool);
     ("masc_board_sub_board_get", read_state_tool);
     ("masc_board_post", broadcast_tool);
+    ("masc_board_post_update", broadcast_tool);
     ("masc_board_comment", broadcast_tool);
-    ("masc_board_vote", broadcast_tool);
-    ("masc_board_comment_vote", broadcast_tool);
-    ("masc_board_reaction", broadcast_tool);
+    ("masc_board_vote", vote_tool);
+    ("masc_board_comment_vote", vote_tool);
+    ("masc_board_reaction", vote_tool);
     ("masc_board_sub_board_create", broadcast_tool);
     ("masc_board_sub_board_update", broadcast_tool);
     ("masc_board_sub_board_delete", broadcast_tool);
-    ("masc_board_cleanup", mutating_tool);
-    ("masc_board_delete", mutating_tool);
+    ("masc_board_cleanup", admin_tool);
+    ("masc_board_delete", admin_tool);
     ("masc_tool_stats", read_state_tool);
+    ("masc_gc", admin_tool);
     ("masc_pause", broadcast_tool);
     ("masc_resume", broadcast_tool);
+    ("masc_pause_status", read_state_tool);
     ("masc_run_get", broadcast_tool);
     ("masc_run_list", read_state_tool);
     ("masc_run_init", broadcast_tool);
     ("masc_run_plan", broadcast_tool);
+    ("masc_schedule_create", broadcast_tool);
+    ("masc_schedule_list", read_state_tool);
+    ("masc_schedule_get", read_state_tool);
+    ("masc_schedule_cancel", broadcast_tool);
+    ("masc_fusion", broadcast_tool);
+    ("masc_fusion_status", read_state_tool);
+    ("masc_library_list", read_state_tool);
+    ("masc_library_read", read_state_tool);
+    ("masc_library_add", broadcast_tool);
+    ("masc_library_promote", broadcast_tool);
+    ("masc_library_search", read_state_tool);
+    ("masc_session", read_state_tool);
     ( "keeper_tasks_list",
       hidden_runtime_tool
         "Keeper task-list runtime tool; callable but hidden from the public MCP schema surface."
@@ -388,11 +424,29 @@ let explicit_metadata : (string * metadata) list =
 let metadata_table : (string, metadata) Hashtbl.t = Hashtbl.create 256
 let () = List.iter (fun (n, m) -> Hashtbl.replace metadata_table n m) explicit_metadata
 
-let register_metadata name (meta : metadata) =
+let register_metadata_for_testing name (meta : metadata) =
   Hashtbl.replace metadata_table name meta
+
+let register_runtime_metadata name (meta : metadata) =
+  match Hashtbl.find_opt metadata_table name with
+  | None ->
+    Error
+      (Printf.sprintf
+         "tool %s has no catalog-owned required permission"
+         name)
+  | Some authority ->
+    Hashtbl.replace
+      metadata_table
+      name
+      { meta with required_permission = authority.required_permission };
+    Ok ()
 
 let registered_metadata name =
   Hashtbl.find_opt metadata_table name
+
+module For_testing = struct
+  let register_metadata = register_metadata_for_testing
+end
 
 (* ================================================================ *)
 (* Public MCP surface — delegates to Tool_catalog_surfaces (SSOT)   *)
@@ -490,6 +544,8 @@ let metadata_to_fields name =
       ("visibility", `String (visibility_to_string meta.visibility));
       ("lifecycle", `String (lifecycle_to_string meta.lifecycle));
       ("implementationStatus", `String (implementation_status_to_string meta.implementation_status));
+      ( "requiredPermission"
+      , `String (Masc_domain.permission_to_string meta.required_permission) );
     ]
   in
   let with_canonical =

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -223,6 +223,17 @@ let hidden_runtime_tool reason meta =
     reason = Some reason;
   }
 
+let keeper_shard_permission required_permission =
+  hidden_runtime_tool
+    "Keeper shard runtime tool; permission is catalog-owned while execution policy is descriptor-owned."
+    (default_metadata ~required_permission)
+;;
+
+let keeper_shard_read = keeper_shard_permission Masc_domain.CanReadState
+let keeper_shard_write = keeper_shard_permission Masc_domain.CanBroadcast
+let keeper_shard_add_task = keeper_shard_permission Masc_domain.CanAddTask
+let keeper_shard_vote = keeper_shard_permission Masc_domain.CanVote
+
 (* ================================================================ *)
 (* Explicit metadata registry                                       *)
 (* ================================================================ *)
@@ -409,6 +420,47 @@ let explicit_metadata : (string * metadata) list =
       hidden_runtime_tool
         "Keeper tool-list runtime tool; callable but hidden from the public MCP schema surface."
         read_state_tool );
+    (* Keeper shard schemas are registered directly by [Unified_tool_registry],
+       not through [Tool_spec].  Their callable names still need an explicit
+       permission authority here; descriptor policy remains the SSOT for
+       execution axes such as readonly/idempotent. *)
+    ("keeper_time_now", keeper_shard_read);
+    ("keeper_tool_search", keeper_shard_read);
+    ("keeper_context_status", keeper_shard_read);
+    ("keeper_artifact_read", keeper_shard_read);
+    ("keeper_memory_search", keeper_shard_read);
+    ("keeper_memory_write", keeper_shard_write);
+    ("keeper_library_search", keeper_shard_read);
+    ("keeper_library_read", keeper_shard_read);
+    ("keeper_surface_read", keeper_shard_read);
+    ("keeper_surface_post", keeper_shard_write);
+    ("keeper_person_note_set", keeper_shard_write);
+    ("keeper_ide_annotate", keeper_shard_write);
+    ("keeper_voice_speak", keeper_shard_write);
+    ("keeper_voice_listen", keeper_shard_write);
+    ("keeper_voice_agent", keeper_shard_read);
+    ("keeper_voice_sessions", keeper_shard_read);
+    ("keeper_voice_session_start", keeper_shard_write);
+    ("keeper_voice_session_end", keeper_shard_write);
+    ("keeper_tasks_audit", keeper_shard_read);
+    ("keeper_broadcast", keeper_shard_write);
+    ("keeper_task_create", keeper_shard_add_task);
+    ("keeper_board_comment", keeper_shard_write);
+    ("keeper_board_comment_vote", keeper_shard_vote);
+    ("keeper_board_curation_read", keeper_shard_read);
+    ("keeper_board_curation_submit", keeper_shard_write);
+    ("keeper_board_post_get", keeper_shard_read);
+    ("keeper_board_list", keeper_shard_read);
+    ("keeper_board_post", keeper_shard_write);
+    ("keeper_board_stats", keeper_shard_read);
+    ("keeper_board_vote", keeper_shard_vote);
+    ("keeper_board_sub_board_list", keeper_shard_read);
+    ("keeper_board_sub_board_get", keeper_shard_read);
+    ("keeper_board_sub_board_create", keeper_shard_write);
+    ("keeper_board_sub_board_update", keeper_shard_write);
+    ("keeper_board_sub_board_delete", keeper_shard_write);
+    ("tool_edit_file", keeper_shard_write);
+    ("tool_write_file", keeper_shard_write);
     ( "tool_execute",
       hidden_runtime_tool
         "Typed command-execution runtime tool; callable but hidden from the public MCP schema surface."

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -444,6 +444,7 @@ let explicit_metadata : (string * metadata) list =
     ("keeper_voice_session_end", keeper_shard_write);
     ("keeper_tasks_audit", keeper_shard_read);
     ("keeper_broadcast", keeper_shard_write);
+    ("keeper_handoff", keeper_shard_write);
     ("keeper_task_create", keeper_shard_add_task);
     ("keeper_board_comment", keeper_shard_write);
     ("keeper_board_comment_vote", keeper_shard_vote);

--- a/lib/tool/tool_catalog.mli
+++ b/lib/tool/tool_catalog.mli
@@ -27,6 +27,7 @@ type metadata = {
   readonly : bool option;
   mcp_context_required : bool option;
   idempotent : bool option;
+  required_permission : Masc_domain.permission;
 }
 
 type execution_policy_axis =
@@ -92,9 +93,9 @@ val metadata_to_fields : string -> (string * Yojson.Safe.t) list
 val public_contract_fields : string -> (string * Yojson.Safe.t) list
 (** Minimal metadata for public contract responses. *)
 
-val register_metadata : string -> metadata -> unit
-(** Register runtime metadata for a tool. Called by [Tool_spec.register].
-    Overwrites any previous entry for the same name. *)
+val register_runtime_metadata : string -> metadata -> (unit, string) result
+(** Register runtime visibility/execution metadata while preserving the
+    catalog-owned required permission. Unclassified tool names fail closed. *)
 
 val registered_metadata : string -> metadata option
 (** Explicit or [Tool_spec]-registered metadata, without surface-derived
@@ -102,3 +103,7 @@ val registered_metadata : string -> metadata option
 
 val explicit_metadata : (string * metadata) list
 (** Explicitly configured tool metadata entries (for test verification). *)
+
+module For_testing : sig
+  val register_metadata : string -> metadata -> unit
+end

--- a/lib/tool/tool_catalog.mli
+++ b/lib/tool/tool_catalog.mli
@@ -49,12 +49,13 @@ type execution_policy_error =
 
 (** {1 Configuration} *)
 
-val default_metadata : metadata
+val default_metadata : required_permission:Masc_domain.permission -> metadata
 
 val hidden_active :
   ?canonical_name:string -> ?replacement:string ->
   ?allow_direct_call_when_hidden:bool ->
-  ?implementation_status:implementation_status -> string -> metadata
+  ?implementation_status:implementation_status ->
+  required_permission:Masc_domain.permission -> string -> metadata
 
 val placeholder_tools_enabled : unit -> bool
 

--- a/lib/tool/tool_catalog.mli
+++ b/lib/tool/tool_catalog.mli
@@ -107,4 +107,6 @@ val explicit_metadata : (string * metadata) list
 
 module For_testing : sig
   val register_metadata : string -> metadata -> unit
+  (** Install an arbitrary fixture entry, bypassing the production catalog
+      ownership check. Production registration uses [register_runtime_metadata]. *)
 end

--- a/lib/tool_surface/tool_spec.ml
+++ b/lib/tool_surface/tool_spec.ml
@@ -94,24 +94,28 @@ let expects_handler : (string, unit) Hashtbl.t = Hashtbl.create 256
 let register (spec : t) =
   if String.equal spec.name "" then
     invalid_arg "Tool_spec.register: name must not be empty";
-  (* Track for handler coverage verification *)
-  Hashtbl.replace registered_names spec.name ();
-  (* 1. Tag + schema registry *)
+  (* 1. Catalog metadata. Registration preserves the typed declaration;
+     product-name membership must not override visibility. *)
+  (match
+     Tool_catalog.register_runtime_metadata spec.name
+       { Tool_catalog.default_metadata with
+         visibility = spec.visibility;
+         implementation_status = spec.implementation_status;
+         canonical_name = spec.canonical_name;
+         replacement = spec.replacement;
+         reason = spec.reason;
+         allow_direct_call_when_hidden = spec.allow_direct_call_when_hidden;
+         readonly = Some spec.is_read_only;
+         mcp_context_required = Some spec.mcp_context_required;
+         idempotent = Some spec.is_idempotent }
+   with
+   | Ok () -> ()
+   | Error detail -> invalid_arg ("Tool_spec.register: " ^ detail));
+  (* 2. Tag + schema registry. An unclassified tool cannot reach this point. *)
   Tool_dispatch.register_module_tag
     ~schemas:[ to_tool_schema spec ] ~tag:spec.module_tag;
-  (* 2. Catalog metadata. Registration preserves the typed declaration;
-     product-name membership must not override visibility. *)
-  Tool_catalog.register_metadata spec.name
-    { Tool_catalog.visibility = spec.visibility;
-      lifecycle = Tool_catalog.Active;
-      implementation_status = spec.implementation_status;
-      canonical_name = spec.canonical_name;
-      replacement = spec.replacement;
-      reason = spec.reason;
-      allow_direct_call_when_hidden = spec.allow_direct_call_when_hidden;
-      readonly = Some spec.is_read_only;
-      mcp_context_required = Some spec.mcp_context_required;
-      idempotent = Some spec.is_idempotent };
+  (* Track only successfully classified and registered specs. *)
+  Hashtbl.replace registered_names spec.name ();
   (* 3. Handler binding — auto-register Direct/Shared into Tool_dispatch *)
   (match spec.handler_binding with
    | Direct h | Shared h ->

--- a/lib/tool_surface/tool_spec.ml
+++ b/lib/tool_surface/tool_spec.ml
@@ -96,21 +96,28 @@ let register (spec : t) =
     invalid_arg "Tool_spec.register: name must not be empty";
   (* 1. Catalog metadata. Registration preserves the typed declaration;
      product-name membership must not override visibility. *)
-  (match
-     Tool_catalog.register_runtime_metadata spec.name
-       { Tool_catalog.default_metadata with
-         visibility = spec.visibility;
-         implementation_status = spec.implementation_status;
-         canonical_name = spec.canonical_name;
-         replacement = spec.replacement;
-         reason = spec.reason;
-         allow_direct_call_when_hidden = spec.allow_direct_call_when_hidden;
-         readonly = Some spec.is_read_only;
-         mcp_context_required = Some spec.mcp_context_required;
-         idempotent = Some spec.is_idempotent }
-   with
-   | Ok () -> ()
-   | Error detail -> invalid_arg ("Tool_spec.register: " ^ detail));
+  (match Tool_catalog.registered_metadata spec.name with
+   | None ->
+     invalid_arg
+       ("Tool_spec.register: tool " ^ spec.name
+        ^ " has no catalog-owned metadata")
+   | Some authority ->
+     match
+       Tool_catalog.register_runtime_metadata spec.name
+         { authority with
+           visibility = spec.visibility;
+           implementation_status = spec.implementation_status;
+           canonical_name = spec.canonical_name;
+           replacement = spec.replacement;
+           reason = spec.reason;
+           allow_direct_call_when_hidden = spec.allow_direct_call_when_hidden;
+           readonly = Some spec.is_read_only;
+           mcp_context_required = Some spec.mcp_context_required;
+           idempotent = Some spec.is_idempotent }
+     with
+     | Ok () -> ()
+     | Error detail -> invalid_arg ("Tool_spec.register: " ^ detail)
+  );
   (* 2. Tag + schema registry. An unclassified tool cannot reach this point. *)
   Tool_dispatch.register_module_tag
     ~schemas:[ to_tool_schema spec ] ~tag:spec.module_tag;

--- a/lib/tool_surface/tool_spec.mli
+++ b/lib/tool_surface/tool_spec.mli
@@ -76,7 +76,8 @@ val create :
 val register : t -> unit
 (** Register a tool spec into all dispatch subsystems atomically:
     - [Tool_dispatch.register_module_tag] (tag + schema)
-    - [Tool_catalog.register_metadata] (visibility and semantic flags)
+    - [Tool_catalog.register_runtime_metadata] (visibility and semantic flags,
+      preserving the catalog-owned permission)
 
     @raise Invalid_argument if [name] is empty. *)
 

--- a/lib/types/masc_error.ml
+++ b/lib/types/masc_error.ml
@@ -130,6 +130,7 @@ module Auth_error = struct
   type t =
     | Unauthorized of { reason: unauthorized_reason; message: string }
     | Forbidden of { agent: string; action: string }
+    | SameOriginBlocked
     | TokenExpired of string
     | InvalidToken of string
 
@@ -141,6 +142,8 @@ module Auth_error = struct
   let to_string = function
     | Unauthorized { message; _ } -> Printf.sprintf "[AuthError] Unauthorized: %s" message
     | Forbidden { agent; action } -> Printf.sprintf "[AuthError] Forbidden: %s cannot %s" agent action
+    | SameOriginBlocked ->
+        "[AuthError] Forbidden: browser cannot perform a cross-origin HTTP mutation"
     | TokenExpired agent ->
         Printf.sprintf "[AuthError] Token expired for %s." agent
     | InvalidToken reason -> Printf.sprintf "[AuthError] Invalid token: %s" reason
@@ -205,7 +208,7 @@ let to_yojson err =
   `String (to_string err)
 
 let code = function
-  | Auth (Auth_error.Forbidden _) -> 403
+  | Auth (Auth_error.Forbidden _ | Auth_error.SameOriginBlocked) -> 403
   | Auth (Auth_error.Unauthorized _
          | Auth_error.TokenExpired _
          | Auth_error.InvalidToken _) -> 401
@@ -239,18 +242,12 @@ let code = function
 
    The match is exhaustive on the outer [t] so a new auth-relevant
    variant trips Warning 8 here instead of silently falling through.
-   The [Forbidden { agent = "browser"; action = "cross-origin HTTP
-   mutation" }] arm matches the literal action string produced in
-   [Server_auth.ensure_same_origin_browser_request]; that string pair
-   is a pre-existing coupling carried over verbatim from #21040, not a
-   new substring classifier. *)
+   [SameOriginBlocked] is a distinct typed producer outcome; this mapping
+   therefore cannot drift when a human-readable error message changes. *)
 let dashboard_auth_error_code : t -> string option = function
   | Auth (Auth_error.InvalidToken _) -> Some "invalid_token"
   | Auth (Auth_error.TokenExpired _) -> Some "token_expired"
-  | Auth
-      (Auth_error.Forbidden
-         { agent = "browser"; action = "cross-origin HTTP mutation" }) ->
-      Some "same_origin_blocked"
+  | Auth Auth_error.SameOriginBlocked -> Some "same_origin_blocked"
   | Auth (Auth_error.Forbidden _) -> Some "insufficient_role"
   | Auth (Auth_error.Unauthorized { reason; _ }) ->
       Some (Auth_error.unauthorized_reason_to_string reason)
@@ -268,6 +265,7 @@ let is_retryable = function
   | Task _ | Agent _ -> false
   | Auth (Auth_error.TokenExpired _) -> true
   | Auth (Auth_error.Unauthorized _ | Auth_error.Forbidden _
+         | Auth_error.SameOriginBlocked
          | Auth_error.InvalidToken _) -> false
   | System (System_error.IoError _ | System_error.StorageError _
            | System_error.LockContention _) -> true

--- a/lib/types/masc_error.mli
+++ b/lib/types/masc_error.mli
@@ -40,6 +40,7 @@ module Auth_error : sig
   type t =
     | Unauthorized of { reason: unauthorized_reason; message: string }
     | Forbidden of { agent: string; action: string }
+    | SameOriginBlocked
     | TokenExpired of string
     | InvalidToken of string
   val unauthorized_reason_to_string : unauthorized_reason -> string
@@ -88,8 +89,7 @@ val dashboard_auth_error_code : t -> string option
     {ul
     {- ["invalid_token"] for [Auth (InvalidToken _)];}
     {- ["token_expired"] for [Auth (TokenExpired _)];}
-    {- ["same_origin_blocked"] for the browser cross-origin
-       [Auth (Forbidden _)] case;}
+    {- ["same_origin_blocked"] for [Auth SameOriginBlocked];}
     {- ["insufficient_role"] for any other [Auth (Forbidden _)];}
     {- the [unauthorized_reason] code
        (["actor_mismatch"] / ["missing_token"] / ["unknown"]) for

--- a/test/stanzas/test_sse_storm_e2e.inc
+++ b/test/stanzas/test_sse_storm_e2e.inc
@@ -1,7 +1,7 @@
 (test
  (name test_sse_storm_e2e)
  (modules test_sse_storm_e2e)
- (libraries alcotest masc_test_runtime yojson unix)
+ (libraries masc alcotest masc_test_runtime yojson unix)
  (deps ../bin/main_eio.exe)
  (enabled_if (= %{env:MASC_E2E_TESTS=false} "true"))
  (action

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -986,7 +986,7 @@ let test_resolve_role_workspace_secret_grants_admin () =
   | Ok role -> fail (Printf.sprintf "expected Admin, got %s" (Masc_domain.show_agent_role role))
   | Error e -> fail (Masc_domain.masc_error_to_string e)
 
-let test_authorize_unknown_masc_tool_strict_worker_allowed () =
+let test_authorize_unknown_masc_tool_strict_denied () =
   let dir = setup_test_workspace () in
   let _ = Auth.enable_auth dir ~require_token:true ~agent_name:"test-admin" in
   let create_result = Auth.create_token dir ~agent_name:"worker_agent" ~role:Masc_domain.Worker in
@@ -999,8 +999,9 @@ let test_authorize_unknown_masc_tool_strict_worker_allowed () =
   in
   cleanup_test_workspace dir;
   match result with
-  | Ok () -> ()
-  | Error e -> fail (Masc_domain.masc_error_to_string e)
+  | Ok () -> fail "unregistered masc_* tool should be denied"
+  | Error (Masc_domain.Auth (Masc_domain.Auth_error.Forbidden _)) -> ()
+  | Error e -> fail (Printf.sprintf "wrong error: %s" (Masc_domain.masc_error_to_string e))
 
 let test_authorize_unknown_non_masc_tool_strict_denied () =
   let dir = setup_test_workspace () in
@@ -1026,30 +1027,6 @@ let test_authorize_unknown_non_masc_tool_strict_denied () =
         (strict_unknown_tool_denial_count
            ~agent_name:"worker_agent" ~tool_class:"external")
   | Error e -> fail (Printf.sprintf "wrong error: %s" (Masc_domain.masc_error_to_string e))
-
-let test_authorize_unknown_masc_prefix_strict_worker_allowed () =
-  let prefixes_with_unlisted_tool = [ "masc_unlisted_tool" ] in
-  let dir = setup_test_workspace () in
-  let _ = Auth.enable_auth dir ~require_token:true ~agent_name:"test-admin" in
-  let create_result = Auth.create_token dir ~agent_name:"worker_agent" ~role:Masc_domain.Worker in
-  let result =
-    match create_result with
-    | Ok (raw_token, _) ->
-        List.fold_left
-          (fun acc tool_name ->
-             match acc with
-             | Error _ as e -> e
-             | Ok () ->
-                 Auth.authorize_tool dir ~agent_name:"worker_agent"
-                   ~token:(Some raw_token) ~tool_name)
-          (Ok ())
-          prefixes_with_unlisted_tool
-    | Error e -> Error e
-  in
-  cleanup_test_workspace dir;
-  match result with
-  | Ok () -> ()
-  | Error e -> fail (Masc_domain.masc_error_to_string e)
 
 let test_authorize_retired_dotted_tool_prefixes_strict_denied () =
   let retired_unlisted_tools =
@@ -1124,14 +1101,38 @@ let test_authorize_tool_v2_known_keeper_tool_strict_worker_allowed () =
   | Ok () -> ()
   | Error e -> fail (Masc_domain.masc_error_to_string e)
 
-let test_authorize_tool_v2_unknown_internal_worker_allowed () =
+let test_authorize_tool_v2_unknown_internal_denied () =
   let result =
     Auth.authorize_tool_for_role ~agent_name:"worker_agent"
       ~role:Masc_domain.Worker ~tool_name:"masc_unlisted_tool"
   in
   match result with
-  | Ok () -> ()
-  | Error e -> fail (Masc_domain.masc_error_to_string e)
+  | Ok () -> fail "unregistered masc_* tool should be denied"
+  | Error (Masc_domain.Auth (Masc_domain.Auth_error.Forbidden _)) -> ()
+  | Error e -> fail (Printf.sprintf "wrong error: %s" (Masc_domain.masc_error_to_string e))
+
+let test_authorize_tool_v2_enforces_catalog_permission () =
+  List.iter
+    (fun tool_name ->
+       (match
+          Auth.authorize_tool_for_role
+            ~agent_name:"worker_agent"
+            ~role:Masc_domain.Worker
+            ~tool_name
+        with
+        | Error (Masc_domain.Auth (Masc_domain.Auth_error.Forbidden _)) -> ()
+        | Ok () -> fail (tool_name ^ " unexpectedly accepted Worker")
+        | Error e -> fail (Masc_domain.masc_error_to_string e));
+       match
+         Auth.authorize_tool_for_role
+           ~agent_name:"admin_agent"
+           ~role:Masc_domain.Admin
+           ~tool_name
+       with
+       | Ok () -> ()
+       | Error e -> fail (Masc_domain.masc_error_to_string e))
+    [ "masc_start"; "masc_reset"; "masc_keeper_down" ]
+;;
 
 let test_authorize_tool_v2_unknown_keeper_prefix_strict_denied () =
   let result =
@@ -1260,20 +1261,20 @@ let () =
         `Quick test_resolve_role_rejects_agent_name_impersonation_without_token;
       test_case "resolve_role workspace secret grants admin"
         `Quick test_resolve_role_workspace_secret_grants_admin;
-      test_case "strict unknown masc tool allows worker"
-        `Quick test_authorize_unknown_masc_tool_strict_worker_allowed;
+      test_case "strict unknown masc tool denied"
+        `Quick test_authorize_unknown_masc_tool_strict_denied;
       test_case "strict unknown non-masc tool denied"
         `Quick test_authorize_unknown_non_masc_tool_strict_denied;
-      test_case "strict unknown masc prefix allows worker"
-        `Quick test_authorize_unknown_masc_prefix_strict_worker_allowed;
       test_case "strict retired dotted tool prefixes denied"
         `Quick test_authorize_retired_dotted_tool_prefixes_strict_denied;
       test_case "strict known keeper tool allows worker"
         `Quick test_authorize_known_keeper_tool_strict_worker_allowed;
       test_case "strict v2 known keeper tool allows worker"
         `Quick test_authorize_tool_v2_known_keeper_tool_strict_worker_allowed;
-      test_case "strict v2 unknown internal tool allows worker"
-        `Quick test_authorize_tool_v2_unknown_internal_worker_allowed;
+      test_case "strict v2 unknown internal tool denied"
+        `Quick test_authorize_tool_v2_unknown_internal_denied;
+      test_case "strict v2 catalog permission enforced"
+        `Quick test_authorize_tool_v2_enforces_catalog_permission;
       test_case "strict v2 fake keeper prefix denied"
         `Quick test_authorize_tool_v2_unknown_keeper_prefix_strict_denied;
       test_case "tool auth strict env cannot disable fail-closed"

--- a/test/test_auth_error_kind.ml
+++ b/test/test_auth_error_kind.ml
@@ -63,6 +63,14 @@ let test_classify_forbidden () =
         "Forbidden should classify as Forbidden, got %s"
         (Aek.to_string other)
 
+let test_classify_same_origin_blocked () =
+  match Aek.classify (Masc_domain.Auth Masc_domain.Auth_error.SameOriginBlocked) with
+  | Aek.Forbidden -> ()
+  | other ->
+      Alcotest.failf
+        "SameOriginBlocked should classify as Forbidden, got %s"
+        (Aek.to_string other)
+
 let test_classify_agent_not_found () =
   match Aek.classify (Masc_domain.Agent (Masc_domain.Agent_error.NotFound "x")) with
   | Aek.Agent_not_found -> ()
@@ -121,6 +129,7 @@ let suite =
   ; test_case "classify TokenExpired" `Quick test_classify_token_expired
   ; test_case "classify Unauthorized" `Quick test_classify_unauthorized
   ; test_case "classify Forbidden" `Quick test_classify_forbidden
+  ; test_case "classify SameOriginBlocked" `Quick test_classify_same_origin_blocked
   ; test_case "classify AgentNotFound" `Quick test_classify_agent_not_found
   ; test_case "classify IoError" `Quick test_classify_io_error
   ; test_case "classify InvalidJson" `Quick test_classify_invalid_json

--- a/test/test_board_rest_routes.ml
+++ b/test/test_board_rest_routes.ml
@@ -220,13 +220,15 @@ let test_dashboard_dev_token_can_vote_as_credential_owner () =
     match
       Server_routes_http_dashboard_dev_token.ensure_dashboard_dev_token base_path
     with
-    | Error message -> fail message
+    | Error error ->
+      fail
+        (Server_routes_http_dashboard_dev_token.token_error_to_string error)
     | Ok token ->
       match
         Server_auth.authorize_token_bound_permission_request
           ~base_path
           ~permission:Masc_domain.CanVote
-          (reaction_auth_request ~token ())
+          (reaction_auth_request ~token:token.raw ())
       with
       | Ok actor -> check string "dashboard credential owner" "dashboard" actor
       | Error error -> fail (Masc_domain.masc_error_to_string error))

--- a/test/test_dashboard_dev_token_host_gate.ml
+++ b/test/test_dashboard_dev_token_host_gate.ml
@@ -75,19 +75,18 @@ let test_read_failure_does_not_mint_credential () =
       let token_path = Dev_token.dashboard_dev_token_path base_path in
       Fs_compat.mkdir_p (Filename.dirname token_path);
       Fs_compat.save_file token_path "stale";
-      Dev_token.set_dashboard_dev_token_load_for_testing (fun _ ->
-        raise (Sys_error "injected read failure"));
-      Fun.protect
-        ~finally:Dev_token.reset_dashboard_dev_token_load_for_testing
-        (fun () ->
-          match Dev_token.ensure_dashboard_dev_token base_path with
-          | Error _ ->
-              check
-                bool
-                "read failure creates no credential store"
-                false
-                (Sys.file_exists (Common.agents_dir_from_base_path ~base_path))
-          | Ok _ -> fail "unreadable dev-token path must fail closed"))
+      match
+        Dev_token.ensure_dashboard_dev_token
+          ~load:(fun _ -> raise (Sys_error "injected read failure"))
+          base_path
+      with
+      | Error _ ->
+        check
+          bool
+          "read failure creates no credential store"
+          false
+          (Sys.file_exists (Common.agents_dir_from_base_path ~base_path))
+      | Ok _ -> fail "unreadable dev-token path must fail closed")
 ;;
 
 let with_temp_base label f =
@@ -187,20 +186,18 @@ let test_rotation_write_failure_reuses_pending_token () =
   with_temp_base "masc-dev-token-pending-" (fun base_path ->
     let admin_raw = create_persisted_dashboard_token base_path Masc_domain.Admin in
     let token_path = Dev_token.dashboard_dev_token_path base_path in
-    Dev_token.set_dashboard_dev_token_write_for_testing (fun path raw ->
+    let write path raw =
       if String.equal path token_path
       then Error "injected canonical token write failure"
       else (
         Auth.save_private_text_file path raw;
-        Ok ()));
-    Fun.protect
-      ~finally:Dev_token.reset_dashboard_dev_token_write_for_testing
-      (fun () ->
-        match Dev_token.ensure_dashboard_dev_token base_path with
-        | Error (Dev_token.Token_file_write_failed _) -> ()
-        | Error error ->
-          failf "unexpected rotation error: %s" (Dev_token.token_error_to_string error)
-        | Ok _ -> fail "injected canonical write failure succeeded");
+        Ok ())
+    in
+    (match Dev_token.ensure_dashboard_dev_token ~write base_path with
+     | Error (Dev_token.Token_file_write_failed _) -> ()
+     | Error error ->
+       failf "unexpected rotation error: %s" (Dev_token.token_error_to_string error)
+     | Ok _ -> fail "injected canonical write failure succeeded");
     let pending_path = Dev_token.dashboard_dev_token_pending_path base_path in
     check bool "pending token retained" true (Sys.file_exists pending_path);
     let pending_raw = String.trim (Fs_compat.load_file pending_path) in

--- a/test/test_dashboard_dev_token_host_gate.ml
+++ b/test/test_dashboard_dev_token_host_gate.ml
@@ -90,8 +90,7 @@ let test_read_failure_does_not_mint_credential () =
 ;;
 
 let with_temp_base label f =
-  let base_path = Filename.temp_file label ".workspace" in
-  Sys.remove base_path;
+  let base_path = Filename.temp_dir label ".workspace" in
   Fun.protect
     ~finally:(fun () -> Fs_compat.remove_tree base_path)
     (fun () -> f base_path)

--- a/test/test_dashboard_dev_token_host_gate.ml
+++ b/test/test_dashboard_dev_token_host_gate.ml
@@ -1,3 +1,5 @@
+let () = Mirage_crypto_rng_unix.use_default ()
+
 open Alcotest
 
 module Dev_token = Server_routes_http_dashboard_dev_token
@@ -64,7 +66,7 @@ let test_non_loopback_rejection_precedes_token_io () =
       | Ok _ -> fail "non-loopback authority must not reach token I/O")
 ;;
 
-let test_read_failure_does_not_mint_admin_credential () =
+let test_read_failure_does_not_mint_credential () =
   let base_path = Filename.temp_file "masc-dev-token-read-" ".workspace" in
   Sys.remove base_path;
   Fun.protect
@@ -88,6 +90,134 @@ let test_read_failure_does_not_mint_admin_credential () =
           | Ok _ -> fail "unreadable dev-token path must fail closed"))
 ;;
 
+let with_temp_base label f =
+  let base_path = Filename.temp_file label ".workspace" in
+  Sys.remove base_path;
+  Fun.protect
+    ~finally:(fun () -> Fs_compat.remove_tree base_path)
+    (fun () -> f base_path)
+;;
+
+let create_persisted_dashboard_token base_path role =
+  match Auth.create_token base_path ~agent_name:"dashboard" ~role with
+  | Error err -> fail (Masc_domain.masc_error_to_string err)
+  | Ok (raw, _credential) ->
+    Auth.save_private_text_file (Dev_token.dashboard_dev_token_path base_path) raw;
+    raw
+;;
+
+let test_existing_admin_token_rotates_to_worker () =
+  with_temp_base "masc-dev-token-role-" (fun base_path ->
+    let admin_raw = create_persisted_dashboard_token base_path Masc_domain.Admin in
+    match Dev_token.ensure_dashboard_dev_token base_path with
+    | Error error -> fail (Dev_token.token_error_to_string error)
+    | Ok token ->
+      check bool "admin bearer rotated" true (not (String.equal admin_raw token.raw));
+      check string "canonical actor" "dashboard" token.actor;
+      check string "declared role" "worker"
+        (Masc_domain.agent_role_to_string token.role);
+      (match Auth.find_credential_by_token base_path ~token:token.raw with
+       | Error err -> fail (Masc_domain.masc_error_to_string err)
+       | Ok credential ->
+         check string "persisted credential role" "worker"
+           (Masc_domain.agent_role_to_string credential.role));
+      (match
+         Auth.check_permission
+           base_path
+           ~agent_name:"dashboard"
+           ~token:(Some token.raw)
+           ~permission:Masc_domain.CanAdmin
+       with
+       | Error (Masc_domain.Auth (Masc_domain.Auth_error.Forbidden _)) -> ()
+       | Error err ->
+         failf
+           "Worker CanAdmin denial had wrong reason: %s"
+           (Masc_domain.masc_error_to_string err)
+       | Ok () -> fail "dashboard Worker token retained CanAdmin");
+      (match
+         Auth.check_permission
+           base_path
+           ~agent_name:"dashboard"
+           ~token:(Some token.raw)
+           ~permission:Masc_domain.CanVote
+       with
+       | Ok () -> ()
+       | Error err ->
+         failf
+           "dashboard Worker token lost CanVote: %s"
+           (Masc_domain.masc_error_to_string err));
+      check
+        int
+        "canonical token mode"
+        0o600
+        ((Unix.stat (Dev_token.dashboard_dev_token_path base_path)).Unix.st_perm
+         land 0o777);
+      (match Auth.find_credential_by_token base_path ~token:admin_raw with
+       | Error (Masc_domain.Auth (Masc_domain.Auth_error.InvalidToken _)) -> ()
+       | Error err ->
+         failf
+           "old admin token failed with wrong reason: %s"
+           (Masc_domain.masc_error_to_string err)
+       | Ok _ -> fail "old admin token remains valid after rotation"))
+;;
+
+let test_existing_worker_token_is_reused () =
+  with_temp_base "masc-dev-token-reuse-" (fun base_path ->
+    let worker_raw = create_persisted_dashboard_token base_path Masc_domain.Worker in
+    match Dev_token.ensure_dashboard_dev_token base_path with
+    | Error error -> fail (Dev_token.token_error_to_string error)
+    | Ok token -> check string "worker bearer reused" worker_raw token.raw)
+;;
+
+let test_invalid_pending_token_fails_closed () =
+  with_temp_base "masc-dev-token-invalid-pending-" (fun base_path ->
+    let pending_path = Dev_token.dashboard_dev_token_pending_path base_path in
+    Fs_compat.mkdir_p (Filename.dirname pending_path);
+    Auth.save_private_text_file pending_path "not-a-generated-token";
+    match Dev_token.ensure_dashboard_dev_token base_path with
+    | Error (Dev_token.Rotation_journal_invalid { path }) ->
+      check string "typed invalid journal path" pending_path path;
+      check int "no credential minted" 0 (List.length (Auth.list_credentials base_path))
+    | Error error ->
+      failf "unexpected pending-token error: %s" (Dev_token.token_error_to_string error)
+    | Ok _ -> fail "invalid pending token must not mint a replacement")
+;;
+
+let test_rotation_write_failure_reuses_pending_token () =
+  with_temp_base "masc-dev-token-pending-" (fun base_path ->
+    let admin_raw = create_persisted_dashboard_token base_path Masc_domain.Admin in
+    let token_path = Dev_token.dashboard_dev_token_path base_path in
+    Dev_token.set_dashboard_dev_token_write_for_testing (fun path raw ->
+      if String.equal path token_path
+      then Error "injected canonical token write failure"
+      else (
+        Auth.save_private_text_file path raw;
+        Ok ()));
+    Fun.protect
+      ~finally:Dev_token.reset_dashboard_dev_token_write_for_testing
+      (fun () ->
+        match Dev_token.ensure_dashboard_dev_token base_path with
+        | Error (Dev_token.Token_file_write_failed _) -> ()
+        | Error error ->
+          failf "unexpected rotation error: %s" (Dev_token.token_error_to_string error)
+        | Ok _ -> fail "injected canonical write failure succeeded");
+    let pending_path = Dev_token.dashboard_dev_token_pending_path base_path in
+    check bool "pending token retained" true (Sys.file_exists pending_path);
+    let pending_raw = String.trim (Fs_compat.load_file pending_path) in
+    (match Auth.find_credential_by_token base_path ~token:admin_raw with
+     | Error (Masc_domain.Auth (Masc_domain.Auth_error.InvalidToken _)) -> ()
+     | Error err ->
+       failf
+         "old admin token failed with wrong reason: %s"
+         (Masc_domain.masc_error_to_string err)
+     | Ok _ -> fail "old admin token reactivated after partial rotation");
+    match Dev_token.ensure_dashboard_dev_token base_path with
+    | Error error -> fail (Dev_token.token_error_to_string error)
+    | Ok token ->
+      check string "exact pending token published" pending_raw token.raw;
+      check bool "pending token cleared" false (Sys.file_exists pending_path))
+;;
+
 let () =
   run
     "dashboard-dev-token-host-gate"
@@ -98,9 +228,25 @@ let () =
             `Quick
             test_non_loopback_rejection_precedes_token_io
         ; test_case
-            "read failure does not mint admin credential"
+            "read failure does not mint credential"
             `Quick
-            test_read_failure_does_not_mint_admin_credential
+            test_read_failure_does_not_mint_credential
+        ; test_case
+            "existing admin token rotates to worker"
+            `Quick
+            test_existing_admin_token_rotates_to_worker
+        ; test_case
+            "existing worker token is reused"
+            `Quick
+            test_existing_worker_token_is_reused
+        ; test_case
+            "invalid pending token fails closed"
+            `Quick
+            test_invalid_pending_token_fails_closed
+        ; test_case
+            "rotation write failure reuses pending token"
+            `Quick
+            test_rotation_write_failure_reuses_pending_token
         ] )
     ]
 ;;

--- a/test/test_error_body_wire_shape.ml
+++ b/test/test_error_body_wire_shape.ml
@@ -77,9 +77,9 @@ let test_error_body_includes_data_when_supplied () =
 
 let test_auth_failure_code_is_nested_in_jsonrpc_error_data () =
   let failure : Server_mcp_transport_http_protocol.auth_failure =
-    { message = "stored token is no longer valid"
-    ; auth_error_code = Some "invalid_token"
-    }
+    Server_mcp_transport_http_types.auth_failure_of_masc_error
+      (Masc_domain.Auth
+         (Masc_domain.Auth_error.InvalidToken "stored token is no longer valid"))
   in
   let body =
     R.error_body
@@ -94,7 +94,7 @@ let test_auth_failure_code_is_nested_in_jsonrpc_error_data () =
       ; ( "error"
         , `Assoc
             [ "code", `Int (-32001)
-            ; "message", `String "stored token is no longer valid"
+            ; "message", `String failure.message
             ; "data", `Assoc [ "auth_error_code", `String "invalid_token" ]
             ] )
       ]

--- a/test/test_error_body_wire_shape.ml
+++ b/test/test_error_body_wire_shape.ml
@@ -75,6 +75,32 @@ let test_error_body_includes_data_when_supplied () =
   in
   check json_testable "data field included when supplied" expected body
 
+let test_auth_failure_code_is_nested_in_jsonrpc_error_data () =
+  let failure : Server_mcp_transport_http_protocol.auth_failure =
+    { message = "stored token is no longer valid"
+    ; auth_error_code = Some "invalid_token"
+    }
+  in
+  let body =
+    R.error_body
+      ?data:(Server_mcp_transport_http_protocol.auth_failure_data failure)
+      ~code:C.Auth_error
+      failure.message
+  in
+  let expected =
+    `Assoc
+      [ "jsonrpc", `String "2.0"
+      ; "id", `Null
+      ; ( "error"
+        , `Assoc
+            [ "code", `Int (-32001)
+            ; "message", `String "stored token is no longer valid"
+            ; "data", `Assoc [ "auth_error_code", `String "invalid_token" ]
+            ] )
+      ]
+  in
+  check json_testable "typed auth code uses JSON-RPC error.data" expected body
+
 let test_wire_byte_change_documented () =
   (* PR-2 wire-byte change regression guard — outlives the legacy
      factories removed in PR-4. Pre-PR-2 bodies omitted "id";
@@ -111,6 +137,8 @@ let () =
             test_error_body_echoes_request_id;
           test_case "data field when supplied" `Quick
             test_error_body_includes_data_when_supplied;
+          test_case "typed auth code in error.data" `Quick
+            test_auth_failure_code_is_nested_in_jsonrpc_error_data;
           test_case "PR-2 wire-byte change is intentional (regression guard)"
             `Quick test_wire_byte_change_documented;
         ] );

--- a/test/test_masc_error_dashboard_auth_code.ml
+++ b/test/test_masc_error_dashboard_auth_code.ml
@@ -27,9 +27,7 @@ let () =
     (E.dashboard_auth_error_code (E.Auth (E.Auth_error.TokenExpired "agent")));
   check "same_origin_blocked" (Some "same_origin_blocked")
     (E.dashboard_auth_error_code
-       (E.Auth
-          (E.Auth_error.Forbidden
-             { agent = "browser"; action = "cross-origin HTTP mutation" })));
+       (E.Auth E.Auth_error.SameOriginBlocked));
   check "insufficient_role" (Some "insufficient_role")
     (E.dashboard_auth_error_code
        (E.Auth (E.Auth_error.Forbidden { agent = "alice"; action = "delete" })));

--- a/test/test_masc_error_is_retryable.ml
+++ b/test/test_masc_error_is_retryable.ml
@@ -60,6 +60,9 @@ let test_auth_other_non_retryable () =
             (E.Auth_error.Forbidden { agent = "a"; action = "x" }))));
   assert (
     not
+      (E.is_retryable (E.Auth E.Auth_error.SameOriginBlocked)));
+  assert (
+    not
       (E.is_retryable (E.Auth (E.Auth_error.InvalidToken "x"))))
 
 (* ── (3) System: transient I/O retryable, others not ──── *)

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1591,6 +1591,51 @@ let test_execute_tool_generated_agent_name_uses_token_identity () =
 
   cleanup_dir base_path
 
+let test_execute_tool_actor_mismatch_reports_typed_code () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Mcp_eio.set_net (Eio.Stdenv.net env);
+  Mcp_eio.set_clock (Eio.Stdenv.clock env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
+  ignore
+    (Masc.Auth.enable_auth
+       base_path
+       ~require_token:true
+       ~agent_name:"bootstrap-admin");
+  let raw_token =
+    match
+      Masc.Auth.create_token
+        base_path
+        ~agent_name:"codex"
+        ~role:Masc_domain.Worker
+    with
+    | Ok (token, _cred) -> token
+    | Error err -> Alcotest.fail (Masc_domain.masc_error_to_string err)
+  in
+  let result =
+    Mcp_eio.execute_tool_eio
+      ~sw
+      ~clock
+      ~workspace_scope:(Mcp_server.workspace_scope state)
+      ~auth_token:raw_token
+      state
+      ~name:"masc_status"
+      ~arguments:(`Assoc [ "_agent_name", `String "dashboard" ])
+  in
+  Alcotest.(check bool) "actor mismatch rejected" false (Tool_result.is_success result);
+  Alcotest.(check string)
+    "typed actor mismatch"
+    "actor_mismatch"
+    Yojson.Safe.Util.(Tool_result.data result |> member "auth_error_code" |> to_string);
+  Alcotest.(check string)
+    "actor mismatch is pre-effect"
+    "proven_pre_effect"
+    Yojson.Safe.Util.(Tool_result.data result |> member "effect_disposition" |> to_string);
+  cleanup_dir base_path
+
 let test_execute_tool_internal_agent_name_is_caller_identity () =
   let resolve args =
     Masc.Mcp_server_eio_caller_identity.caller_agent_name_from_arguments
@@ -1630,12 +1675,30 @@ let check_task_still_todo config task_id =
         (Masc_domain.task_status_to_string task.task_status)
   | None -> Alcotest.failf "expected task %s to exist" task_id
 
-let check_auth_preflight_result ~tool_name ok msg =
-  Alcotest.(check bool) (tool_name ^ " rejected before handler") false ok;
+let check_auth_preflight_result ~tool_name result =
+  let msg = Tool_result.message result in
+  Alcotest.(check bool)
+    (tool_name ^ " rejected before handler")
+    false
+    (Tool_result.is_success result);
   Alcotest.(check bool) (tool_name ^ " reports auth/credential blocker") true
     (contains_substring msg "Token required"
      || contains_substring msg "Unauthorized"
-     || contains_substring msg "No credential")
+     || contains_substring msg "No credential");
+  Alcotest.(check (option string))
+    (tool_name ^ " policy rejection class")
+    (Some "policy_rejection")
+    (Option.map
+       Tool_result.tool_failure_class_to_string
+       (Tool_result.failure_class result));
+  Alcotest.(check string)
+    (tool_name ^ " typed auth code")
+    "missing_token"
+    Yojson.Safe.Util.(Tool_result.data result |> member "auth_error_code" |> to_string);
+  Alcotest.(check string)
+    (tool_name ^ " proves no effect")
+    "proven_pre_effect"
+    Yojson.Safe.Util.(Tool_result.data result |> member "effect_disposition" |> to_string)
 
 let check_rejected_without_mutation ~tool_name ok msg =
   Alcotest.(check bool) (tool_name ^ " rejected before mutation") false ok;
@@ -1777,8 +1840,7 @@ let test_execute_tool_claim_next_requires_auth_before_mutation () =
       ~name:"keeper_task_claim"
       ~arguments:(`Assoc [ ("agent_name", `String "uncredentialed-agent") ])
   in
-  check_auth_preflight_result ~tool_name:"keeper_task_claim"
-    (Tool_result.is_success result) ((Tool_result.message result));
+  check_auth_preflight_result ~tool_name:"keeper_task_claim" result;
   check_task_still_todo (Mcp_server.workspace_config state) "task-001";
   Alcotest.(check (option string)) "no current task after rejected claim_next" None
     (Masc.Task.Planning_eio.get_current_task (Mcp_server.workspace_config state));
@@ -1813,8 +1875,7 @@ let test_execute_tool_transition_requires_auth_before_mutation () =
             ("action", `String "claim");
           ])
   in
-  check_auth_preflight_result ~tool_name:"masc_transition"
-    (Tool_result.is_success result) ((Tool_result.message result));
+  check_auth_preflight_result ~tool_name:"masc_transition" result;
   check_task_still_todo (Mcp_server.workspace_config state) "task-001";
   Alcotest.(check (option string)) "no current task after rejected transition" None
     (Masc.Task.Planning_eio.get_current_task (Mcp_server.workspace_config state));
@@ -3051,6 +3112,8 @@ let eio_tests = [
     test_execute_tool_domain_agent_name_does_not_reuse_joined_nickname;
   "generated agent_name uses token identity", `Quick,
     test_execute_tool_generated_agent_name_uses_token_identity;
+  "actor mismatch reports typed code", `Quick,
+    test_execute_tool_actor_mismatch_reports_typed_code;
   "internal _agent_name is caller identity", `Quick,
     test_execute_tool_internal_agent_name_is_caller_identity;
   "explicit generated alias claim_next not rewritten by token", `Quick,

--- a/test/test_mcp_server_eio_tool_dispatch.ml
+++ b/test/test_mcp_server_eio_tool_dispatch.ml
@@ -128,7 +128,7 @@ let test_tool_metadata_does_not_gate_heartbeat () =
   let original_metadata = Tool_catalog.metadata tool_name in
   Fun.protect
     ~finally:(fun () ->
-      Tool_catalog.register_metadata tool_name original_metadata;
+      Tool_catalog.For_testing.register_metadata tool_name original_metadata;
       cleanup_dir base_path)
     (fun () ->
       let state = Mcp_eio.For_testing.create_state ~base_path () in
@@ -154,7 +154,7 @@ let test_tool_metadata_does_not_gate_heartbeat () =
           (Masc_domain.agent_to_yojson { agent with last_seen = stale_last_seen })
       in
       let assert_heartbeat implementation_status label =
-        Tool_catalog.register_metadata
+        Tool_catalog.For_testing.register_metadata
           tool_name
           { original_metadata with implementation_status };
         set_stale_last_seen ();

--- a/test/test_server_auth_dashboard_actor_resolution.ml
+++ b/test/test_server_auth_dashboard_actor_resolution.ml
@@ -34,11 +34,9 @@ let request ?token ~actor () =
     "/api/v1/dashboard/briefing"
 
 let resolve ~base_path request =
-  Eio_main.run @@ fun _env ->
   Server_auth.dashboard_actor_resolution_for_request ~base_path request
 
 let project ~base_path request =
-  Eio_main.run @@ fun _env ->
   Server_auth.dashboard_actor_for_request ~base_path request
 
 let loopback_request_authority () =
@@ -299,21 +297,25 @@ let test_admin_token_equality_truth_table () =
   check bool "different-length mismatch" false (equal "admin-secret" "admin-secret-long")
 
 let () =
-  run "server_auth_dashboard_actor_resolution"
-    [ ( "resolution"
-      , [ test_case "anonymous public hint is preserved" `Quick
-            test_anonymous_public_read_preserves_hint
-        ; test_case "rejected credential fails closed" `Quick
-            test_rejected_credential_cannot_supply_actor_hint
-        ; test_case "malformed credential fails closed" `Quick
-            test_malformed_credential_cannot_become_anonymous
-        ; test_case "credential precedence and observer query state" `Quick
-            test_credential_source_precedence_and_observer_query_state
-        ; test_case "MCP auth surfaces preserve typed reasons" `Quick
-            test_mcp_auth_surfaces_preserve_typed_reasons
-        ; test_case "authenticated owner is canonical" `Quick
-            test_authenticated_owner_overrides_request_hint
-        ; test_case "admin token equality truth table" `Quick
-            test_admin_token_equality_truth_table
-        ] )
-    ]
+  Eio_main.run @@ fun _env ->
+  Server_request_authority.with_current
+    (loopback_request_authority ())
+    (fun () ->
+       run "server_auth_dashboard_actor_resolution"
+         [ ( "resolution"
+           , [ test_case "anonymous public hint is preserved" `Quick
+                 test_anonymous_public_read_preserves_hint
+             ; test_case "rejected credential fails closed" `Quick
+                 test_rejected_credential_cannot_supply_actor_hint
+             ; test_case "malformed credential fails closed" `Quick
+                 test_malformed_credential_cannot_become_anonymous
+             ; test_case "credential precedence and observer query state" `Quick
+                 test_credential_source_precedence_and_observer_query_state
+             ; test_case "MCP auth surfaces preserve typed reasons" `Quick
+                 test_mcp_auth_surfaces_preserve_typed_reasons
+             ; test_case "authenticated owner is canonical" `Quick
+                 test_authenticated_owner_overrides_request_hint
+             ; test_case "admin token equality truth table" `Quick
+                 test_admin_token_equality_truth_table
+             ] )
+         ])

--- a/test/test_server_auth_dashboard_actor_resolution.ml
+++ b/test/test_server_auth_dashboard_actor_resolution.ml
@@ -158,7 +158,53 @@ let expect_observer_rejected ~base_path request message =
 let expect_observer_admitted ~base_path request message =
   match Server_auth.verify_mcp_observer_stream_auth ~base_path request with
   | Ok _ -> ()
-  | Error err -> failf "%s: %s" message err
+  | Error err ->
+      failf "%s: %s" message (Masc_domain.masc_error_to_string err)
+
+let test_mcp_auth_surfaces_preserve_typed_reasons () =
+  with_temp_base_path @@ fun base_path ->
+  Masc.Auth.save_auth_config
+    base_path
+    { Masc_domain.default_auth_config with enabled = true; require_token = true };
+  let observer = observer_request () in
+  (match Server_auth.verify_mcp_observer_stream_auth ~base_path observer with
+   | Error
+       (Masc_domain.Auth
+          (Masc_domain.Auth_error.Unauthorized
+             { reason = Masc_domain.Auth_error.Missing_token; _ })) ->
+       ()
+   | Error err ->
+       failf "observer error lost its typed reason: %s"
+         (Masc_domain.masc_error_to_string err)
+   | Ok _ -> fail "observer auth admitted a request without a token");
+  let operator =
+    Httpun.Request.create `GET "/mcp/operator"
+  in
+  (match Server_auth.verify_operator_mcp_auth ~base_path operator with
+   | Error
+       (Masc_domain.Auth
+          (Masc_domain.Auth_error.Unauthorized
+             { reason = Masc_domain.Auth_error.Missing_token; _ })) ->
+       ()
+   | Error err ->
+       failf "operator error lost its typed reason: %s"
+         (Masc_domain.masc_error_to_string err)
+   | Ok _ -> fail "operator auth admitted a request without a token");
+  let deps = Server_routes_http_common.mcp_transport_http_deps () in
+  let expect_transport_code label result =
+    match result with
+    | Error { Server_mcp_transport_http_types.auth_error_code = Some code; _ } ->
+        check string label "missing_token" code
+    | Error { auth_error_code = None; message } ->
+        failf "%s lost auth_error_code: %s" label message
+    | Ok () -> failf "%s admitted a request without a token" label
+  in
+  expect_transport_code
+    "observer transport auth code"
+    (deps.verify_mcp_observer_stream_auth ~base_path observer);
+  expect_transport_code
+    "operator transport auth code"
+    (deps.verify_operator_mcp_auth ~base_path operator)
 
 let test_credential_source_precedence_and_observer_query_state () =
   with_temp_base_path @@ fun base_path ->
@@ -263,6 +309,8 @@ let () =
             test_malformed_credential_cannot_become_anonymous
         ; test_case "credential precedence and observer query state" `Quick
             test_credential_source_precedence_and_observer_query_state
+        ; test_case "MCP auth surfaces preserve typed reasons" `Quick
+            test_mcp_auth_surfaces_preserve_typed_reasons
         ; test_case "authenticated owner is canonical" `Quick
             test_authenticated_owner_overrides_request_hint
         ; test_case "admin token equality truth table" `Quick

--- a/test/test_server_oauth_protocol.ml
+++ b/test/test_server_oauth_protocol.ml
@@ -154,14 +154,18 @@ let test_registration_browser_origin_boundary () =
        ~request_authority:authority
        (registration_request ~origin:"http://127.0.0.1:8935" ())
      |> Result.is_ok);
-  check
-    bool
-    "cross-origin browser registration is rejected before allocation"
-    true
-    (Server_auth.ensure_same_origin_if_browser_request
+  (match
+     Server_auth.ensure_same_origin_if_browser_request
        ~request_authority:authority
        (registration_request ~origin:"https://evil.example" ())
-     |> Result.is_error)
+   with
+   | Error (Masc_domain.Auth Masc_domain.Auth_error.SameOriginBlocked) -> ()
+   | Error error ->
+     failf
+       "cross-origin browser registration returned the wrong typed error: %s"
+       (Masc_domain.masc_error_to_string error)
+   | Ok () ->
+     fail "cross-origin browser registration was admitted before allocation")
 ;;
 
 let test_form_parser_rejects_ambiguity () =

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -25,6 +25,22 @@ let read_file path =
       let len = in_channel_length ic in
       really_input_string ic len)
 
+let write_file path content =
+  let oc = open_out_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+
+let contains_substring ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop index =
+    if index + needle_len > haystack_len then false
+    else if String.sub haystack index needle_len = needle then true
+    else loop (index + 1)
+  in
+  String.equal needle "" || loop 0
+
 let trim_cr s =
   let n = String.length s in
   if n > 0 && s.[n - 1] = '\r' then String.sub s 0 (n - 1) else s
@@ -427,7 +443,7 @@ let with_server f =
   end;
   Fun.protect ~finally:cleanup (fun () ->
     let auth_token = dashboard_dev_token ~port in
-    f ~port ~auth_token)
+    f ~port ~auth_token ~base_path)
 
 let check_status label expected result =
   match result.status with
@@ -519,7 +535,7 @@ let publish_masc_broadcast ~port ~auth_token ~session_id =
            result.body)
 
 let test_mcp_reconnect_stays_accepted () =
-  with_server @@ fun ~port ~auth_token ->
+  with_server @@ fun ~port ~auth_token ~base_path:_ ->
   let sid = initialize_mcp_session ~port ~auth_token in
   let headers =
     [
@@ -661,7 +677,7 @@ let test_ag_ui_frames_are_wire_encoded () =
     first_masc_events
 
 let test_dashboard_dev_token_cannot_call_admin_route () =
-  with_server @@ fun ~port ~auth_token ->
+  with_server @@ fun ~port ~auth_token ~base_path:_ ->
   let result =
     run_curl
       ~headers:
@@ -677,8 +693,38 @@ let test_dashboard_dev_token_cannot_call_admin_route () =
       ()
   in
   check_status "dashboard Worker token denied CanAdmin route" 403 result
+let test_dashboard_dev_token_cannot_reset_workspace () =
+  with_server @@ fun ~port ~auth_token ~base_path ->
+  let session_id = initialize_mcp_session ~port ~auth_token in
+  let sentinel =
+    Filename.concat (Filename.concat base_path ".masc") "reset-denial-sentinel"
+  in
+  write_file sentinel "must-survive";
+  let result =
+    run_curl
+      ~headers:
+        [ ("Accept", "application/json, text/event-stream")
+        ; ("Authorization", "Bearer " ^ auth_token)
+        ; ("Content-Type", "application/json")
+        ; ("Mcp-Session-Id", session_id)
+        ]
+      ~method_:"POST"
+      ~body:
+        {|{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"masc_reset","arguments":{"confirm":true}}}|}
+      ~max_time:2.0
+      ~port
+      ~path:"/mcp"
+      ()
+  in
+  check_status "dashboard Worker reset request completed as MCP rejection" 200 result;
+  check bool
+    "reset denial is typed"
+    true
+    (contains_substring ~needle:"\"auth_error_code\":\"insufficient_role\"" result.body);
+  check bool "workspace sentinel survives denied reset" true (Sys.file_exists sentinel);
+  check string "workspace sentinel content survives" "must-survive" (read_file sentinel)
 let test_ag_ui_rejects_reconnect_then_recovers () =
-  with_server @@ fun ~port ~auth_token ->
+  with_server @@ fun ~port ~auth_token ~base_path:_ ->
   let sid = initialize_mcp_session ~port ~auth_token in
   (* /ag-ui/events uses the observer SSE auth path; mirror /mcp by passing the
      dashboard dev token explicitly. *)
@@ -761,6 +807,10 @@ let () =
             "dev-token cannot call admin route"
             `Slow
             test_dashboard_dev_token_cannot_call_admin_route
+        ; test_case
+            "dev-token cannot reset workspace through MCP"
+            `Slow
+            test_dashboard_dev_token_cannot_reset_workspace
         ] )
     ; ("mcp", [test_case "follow-up reconnect accepted" `Slow test_mcp_reconnect_stays_accepted])
      ; ( "ag_ui"

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -31,16 +31,6 @@ let write_file path content =
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc content)
 
-let contains_substring ~needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  let rec loop index =
-    if index + needle_len > haystack_len then false
-    else if String.sub haystack index needle_len = needle then true
-    else loop (index + 1)
-  in
-  String.equal needle "" || loop 0
-
 let trim_cr s =
   let n = String.length s in
   if n > 0 && s.[n - 1] = '\r' then String.sub s 0 (n - 1) else s
@@ -717,10 +707,21 @@ let test_dashboard_dev_token_cannot_reset_workspace () =
       ()
   in
   check_status "dashboard Worker reset request completed as MCP rejection" 200 result;
-  check bool
+  let response =
+    match Yojson.Safe.from_string result.body with
+    | json -> json
+    | exception Yojson.Json_error message ->
+      failf "reset denial response is invalid JSON: %s" message
+  in
+  check string
     "reset denial is typed"
-    true
-    (contains_substring ~needle:"\"auth_error_code\":\"insufficient_role\"" result.body);
+    "insufficient_role"
+    Yojson.Safe.Util.
+      (response
+       |> member "result"
+       |> member "structuredContent"
+       |> member "auth_error_code"
+       |> to_string);
   check bool "workspace sentinel survives denied reset" true (Sys.file_exists sentinel);
   check string "workspace sentinel content survives" "must-survive" (read_file sentinel)
 let test_ag_ui_rejects_reconnect_then_recovers () =

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -712,7 +712,7 @@ let test_dashboard_dev_token_cannot_reset_workspace () =
     (Some "text/event-stream")
     (header_value result "content-type");
   let response_body =
-    match Sse_jsonrpc_filter.event_data_payload result.body with
+    match Masc.Sse_jsonrpc_filter.event_data_payload result.body with
     | Some body -> body
     | None -> fail "reset denial response has no SSE data payload"
   in

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -609,7 +609,7 @@ let is_masc_event = function
    response from becoming a substring false positive; the numeric [id:] check
    pins the resumability cursor carried by the transformed frame. *)
 let test_ag_ui_frames_are_wire_encoded () =
-  with_server @@ fun ~port ~auth_token ->
+  with_server @@ fun ~port ~auth_token ~base_path:_ ->
   let sid = initialize_mcp_session ~port ~auth_token in
   publish_masc_broadcast ~port ~auth_token ~session_id:sid;
   let headers =
@@ -788,7 +788,7 @@ let check_invalid_request_response label result =
         (Printf.sprintf "%s returned a non-object body: %s" label result.body)
 
 let test_sse_endpoints_reject_malformed_last_event_id () =
-  with_server @@ fun ~port ~auth_token ->
+  with_server @@ fun ~port ~auth_token ~base_path:_ ->
   let sid = initialize_mcp_session ~port ~auth_token in
   let headers cursor =
     [ ("Accept", "text/event-stream")

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -208,11 +208,20 @@ let dashboard_dev_token ~port =
       begin
         match Yojson.Safe.from_string result.body with
         | `Assoc fields ->
-            begin
-              match List.assoc_opt "token" fields with
-              | Some (`String token) when String.trim token <> "" -> token
-              | _ -> fail ("dashboard dev-token response missing token: " ^ result.body)
-            end
+          (match
+             ( List.assoc_opt "token" fields
+             , List.assoc_opt "actor" fields
+             , List.assoc_opt "role" fields )
+           with
+           | ( Some (`String token)
+             , Some (`String "dashboard")
+             , Some (`String "worker") )
+             when String.trim token <> "" ->
+             token
+           | _ ->
+             fail
+               ("dashboard dev-token response violates token/actor/role contract: "
+                ^ result.body))
         | _ -> fail ("dashboard dev-token response is not an object: " ^ result.body)
         | exception Yojson.Json_error msg ->
             fail ("dashboard dev-token response is invalid JSON: " ^ msg)
@@ -651,6 +660,23 @@ let test_ag_ui_frames_are_wire_encoded () =
               event_id))
     first_masc_events
 
+let test_dashboard_dev_token_cannot_call_admin_route () =
+  with_server @@ fun ~port ~auth_token ->
+  let result =
+    run_curl
+      ~headers:
+        [ ("Accept", "application/json")
+        ; ("Authorization", "Bearer " ^ auth_token)
+        ; ("Content-Type", "application/json")
+        ]
+      ~method_:"POST"
+      ~body:"{}"
+      ~max_time:2.0
+      ~port
+      ~path:"/api/v1/dashboard/gate/mode"
+      ()
+  in
+  check_status "dashboard Worker token denied CanAdmin route" 403 result
 let test_ag_ui_rejects_reconnect_then_recovers () =
   with_server @@ fun ~port ~auth_token ->
   let sid = initialize_mcp_session ~port ~auth_token in
@@ -730,12 +756,25 @@ let () =
   Random.self_init ();
   run "sse_storm_e2e"
     [
-      ("mcp", [test_case "follow-up reconnect accepted" `Slow test_mcp_reconnect_stays_accepted]);
-      ("ag_ui",
-       [
-         test_case "reconnect cooldown + recovery" `Slow test_ag_ui_rejects_reconnect_then_recovers;
-         test_case "malformed Last-Event-ID is rejected" `Slow
-           test_sse_endpoints_reject_malformed_last_event_id;
-         test_case "frames are AG-UI wire encoded" `Slow test_ag_ui_frames_are_wire_encoded;
-       ]);
-    ]
+      ( "auth"
+      , [ test_case
+            "dev-token cannot call admin route"
+            `Slow
+            test_dashboard_dev_token_cannot_call_admin_route
+        ] )
+    ; ("mcp", [test_case "follow-up reconnect accepted" `Slow test_mcp_reconnect_stays_accepted])
+     ; ( "ag_ui"
+       , [ test_case
+             "reconnect cooldown + recovery"
+             `Slow
+             test_ag_ui_rejects_reconnect_then_recovers
+         ; test_case
+             "malformed Last-Event-ID is rejected"
+             `Slow
+             test_sse_endpoints_reject_malformed_last_event_id
+         ; test_case
+             "frames are AG-UI wire encoded"
+             `Slow
+             test_ag_ui_frames_are_wire_encoded
+         ] )
+     ]

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -707,11 +707,20 @@ let test_dashboard_dev_token_cannot_reset_workspace () =
       ()
   in
   check_status "dashboard Worker reset request completed as MCP rejection" 200 result;
+  check (option string)
+    "reset denial uses negotiated SSE framing"
+    (Some "text/event-stream")
+    (header_value result "content-type");
+  let response_body =
+    match Sse_jsonrpc_filter.event_data_payload result.body with
+    | Some body -> body
+    | None -> fail "reset denial response has no SSE data payload"
+  in
   let response =
-    match Yojson.Safe.from_string result.body with
+    match Yojson.Safe.from_string response_body with
     | json -> json
     | exception Yojson.Json_error message ->
-      failf "reset denial response is invalid JSON: %s" message
+      failf "reset denial SSE data is invalid JSON: %s" message
   in
   check string
     "reset denial is typed"

--- a/test/test_tool_capability_typed.ml
+++ b/test/test_tool_capability_typed.ml
@@ -48,7 +48,7 @@ let test_has_unknown_tool_returns_false () =
 let test_has_catalog_metadata () =
   let name = "__cap_catalog_tool" in
   Tool_catalog.For_testing.register_metadata name
-    { Tool_catalog.default_metadata with
+    { (Tool_catalog.default_metadata ~required_permission:Masc_domain.CanAdmin) with
       readonly = Some true;
       mcp_context_required = Some true;
       idempotent = Some true;
@@ -66,7 +66,7 @@ let test_read_only_does_not_imply_idempotent () =
   let name = "__cap_read_only_not_idempotent" in
   Tool_catalog.For_testing.register_metadata
     name
-    { Tool_catalog.default_metadata with
+    { (Tool_catalog.default_metadata ~required_permission:Masc_domain.CanAdmin) with
       readonly = Some true
     ; idempotent = None
     };

--- a/test/test_tool_capability_typed.ml
+++ b/test/test_tool_capability_typed.ml
@@ -47,7 +47,7 @@ let test_has_unknown_tool_returns_false () =
 
 let test_has_catalog_metadata () =
   let name = "__cap_catalog_tool" in
-  Tool_catalog.register_metadata name
+  Tool_catalog.For_testing.register_metadata name
     { Tool_catalog.default_metadata with
       readonly = Some true;
       mcp_context_required = Some true;
@@ -64,7 +64,7 @@ let test_has_catalog_metadata () =
 
 let test_read_only_does_not_imply_idempotent () =
   let name = "__cap_read_only_not_idempotent" in
-  Tool_catalog.register_metadata
+  Tool_catalog.For_testing.register_metadata
     name
     { Tool_catalog.default_metadata with
       readonly = Some true

--- a/test/test_tool_registry_consistency.ml
+++ b/test/test_tool_registry_consistency.ml
@@ -150,7 +150,7 @@ let test_default_metadata_has_no_implicit_execution_policy () =
   match
     Tool_catalog.execution_policy_of_metadata
       ~tool_name:"__unregistered_tool"
-      Tool_catalog.default_metadata
+      (Tool_catalog.default_metadata ~required_permission:Masc_domain.CanAdmin)
   with
   | Ok _ -> Alcotest.fail "default metadata must not invent an execution policy"
   | Error (Tool_catalog.Missing_execution_policy { tool_name; missing_axes }) ->

--- a/test/test_tool_registry_consistency.ml
+++ b/test/test_tool_registry_consistency.ml
@@ -180,6 +180,19 @@ let test_keeper_schemas_have_explicit_execution_policy () =
     errors
 ;;
 
+let test_every_registered_schema_has_catalog_permission () =
+  init ();
+  let missing =
+    Tool_dispatch.all_schema_names ()
+    |> List.filter (fun name ->
+      Option.is_none (Tool_catalog.registered_metadata name))
+  in
+  Alcotest.(check (list string))
+    "every registered schema has catalog-owned permission metadata"
+    []
+    missing
+;;
+
 let test_retired_tools_are_absent () =
   init ();
   (* Only fully retired tools — no live dispatch handler and no keeper
@@ -240,6 +253,10 @@ let () =
             "Keeper schemas have explicit execution policy"
             `Quick
             test_keeper_schemas_have_explicit_execution_policy
+        ; test_case
+            "every registered schema has catalog permission"
+            `Quick
+            test_every_registered_schema_has_catalog_permission
         ] )
     ; ( "retired_tools"
       , [ test_case "retired tools are absent" `Quick test_retired_tools_are_absent

--- a/test/test_tool_spec.ml
+++ b/test/test_tool_spec.ml
@@ -10,6 +10,11 @@ module Tool_capability = Tool_capability
 (** Helper: minimal input_schema for test tools. *)
 let empty_schema = `Assoc [ ("type", `String "object") ]
 
+let register_test_metadata name =
+  Tool_catalog.For_testing.register_metadata name
+    (Tool_catalog.default_metadata ~required_permission:Masc_domain.CanAdmin)
+;;
+
 let tool_ok ?(tool_name = "") message =
   Tool_result.make_ok ~tool_name ~start_time:0.0 ~data:(`String message) ()
 ;;
@@ -73,6 +78,7 @@ let () =
                 ~handler_binding:Tag_dispatch
                 ()
             in
+            register_test_metadata "__test_spec_tag_reg";
             Tool_spec.register spec;
             check bool "tag registered" true
               (Option.is_some (Tool_dispatch.lookup_tag "__test_spec_tag_reg"));
@@ -89,6 +95,7 @@ let () =
                 ~handler_binding:Tag_dispatch
                 ()
             in
+            register_test_metadata "__test_spec_schema_reg";
             Tool_spec.register spec;
             check bool "schema registered" true
               (Option.is_some (Tool_dispatch.lookup_schema "__test_spec_schema_reg")));
@@ -103,6 +110,7 @@ let () =
                 ~is_read_only:true
                 ()
             in
+            register_test_metadata "__test_spec_ro";
             Tool_spec.register spec;
             check bool "is_read_only" true
               (Tool_capability.has Tool_capability.Read_only "__test_spec_ro"));
@@ -116,6 +124,7 @@ let () =
                 ~handler_binding:Tag_dispatch
                 ()
             in
+            register_test_metadata "__test_spec_rw";
             Tool_spec.register spec;
             check bool "not read_only" false
               (Tool_capability.has Tool_capability.Read_only "__test_spec_rw"));
@@ -130,6 +139,7 @@ let () =
                 ~mcp_context_required:true
                 ()
             in
+            register_test_metadata "__test_spec_mcp_context";
             Tool_spec.register spec;
             check bool "is_mcp_context_required" true
               (Tool_capability.has Tool_capability.Mcp_context_required "__test_spec_mcp_context");
@@ -148,6 +158,7 @@ let () =
                 ~reason:"test hidden"
                 ()
             in
+            register_test_metadata "__test_spec_catalog";
             Tool_spec.register spec;
             let meta = Tool_catalog.metadata "__test_spec_catalog" in
             check bool "hidden" true (meta.visibility = Tool_catalog.Hidden);
@@ -180,6 +191,8 @@ let () =
                     ())
                 [ "__test_spec_bulk_a"; "__test_spec_bulk_b"; "__test_spec_bulk_c" ]
             in
+            List.iter register_test_metadata
+              [ "__test_spec_bulk_a"; "__test_spec_bulk_b"; "__test_spec_bulk_c" ];
             Tool_spec.register_all specs;
             List.iter
               (fun name ->
@@ -219,6 +232,7 @@ let () =
                 ~handler_binding:Tag_dispatch
                 ()
             in
+            register_test_metadata name;
             Tool_spec.register spec;
             let missing = Tool_spec.verify_handler_coverage () in
             check bool "Tag_dispatch not in missing" false

--- a/test/test_tool_spec.ml
+++ b/test/test_tool_spec.ml
@@ -175,6 +175,25 @@ let () =
                      ~input_schema:empty_schema
                      ~handler_binding:Tag_dispatch
                      ())));
+          test_case "unclassified tool rejected before registry mutation" `Quick (fun () ->
+            let name = "__test_spec_unclassified" in
+            let spec =
+              Tool_spec.create
+                ~name
+                ~description:"unclassified tool"
+                ~module_tag:Tool_dispatch.Mod_misc
+                ~input_schema:empty_schema
+                ~handler_binding:Tag_dispatch
+                ()
+            in
+            check_raises "catalog ownership required"
+              (Invalid_argument
+                 "Tool_spec.register: tool __test_spec_unclassified has no catalog-owned metadata")
+              (fun () -> Tool_spec.register spec);
+            check bool "tag not registered" false
+              (Option.is_some (Tool_dispatch.lookup_tag name));
+            check bool "schema not registered" false
+              (Option.is_some (Tool_dispatch.lookup_schema name)));
         ] );
       ( "register_all",
         [
@@ -232,7 +251,7 @@ let () =
                 ~handler_binding:Tag_dispatch
                 ()
             in
-            register_test_metadata name;
+            register_test_metadata "__test_spec_tag_dispatch";
             Tool_spec.register spec;
             let missing = Tool_spec.verify_handler_coverage () in
             check bool "Tag_dispatch not in missing" false
@@ -248,6 +267,7 @@ let () =
                 ~handler_binding:(Direct (fun ~name:_ ~args:_ -> Some (tool_ok "ok")))
                 ()
             in
+            register_test_metadata name;
             Tool_spec.register spec;
             check bool "handler registered in Tool_dispatch" true
               (Tool_dispatch.is_registered name);


### PR DESCRIPTION
## Summary

- Mint the loopback dashboard credential as `Worker`, never `Admin`.
- Rotate stale or role-mismatched credentials through a resumable durable journal.
- Make REST, Keeper streaming, and MCP recover once from exact typed auth codes.
- Remove browser-side actor and role self-assertion for manual and URL tokens.

## Product impact

- User-visible change: the local dashboard self-heals a stale managed token, while admin-only routes require an explicit operator credential.
- Security impact: a loopback dev-token cannot satisfy `CanAdmin`, `CanInit`, or `CanReset`.
- Failure behavior: corrupt or unreadable token state returns a stable typed error instead of minting repeatedly.

## Evidence

- `pnpm --dir dashboard typecheck`
- `pnpm --dir dashboard exec vitest run src/api/core.test.ts src/api/dev-token.test.ts src/api/mcp.test.ts src/api/keeper.test.ts src/components/settings-surface.test.ts src/dashboard-ws.test.ts` — 222 passed
- `pnpm --dir dashboard lint`
- `pnpm --dir dashboard build`
- `scripts/dune-local.sh build test/test_dashboard_dev_token_host_gate.exe test/test_server_auth_dashboard_actor_resolution.exe test/test_board_rest_routes.exe test/test_mcp_server_eio.exe test/test_sse_storm_e2e.exe bin/main_eio.exe`
- `test_dashboard_dev_token_host_gate.exe` — 7 passed
- `test_server_auth_dashboard_actor_resolution.exe test resolution 1,4-5` — 3 passed
- `test_board_rest_routes.exe` — 9 passed
- `test_mcp_server_eio.exe test eio 49,54-55` — 3 passed
- `test_sse_storm_e2e.exe test auth 0` — real server `CanAdmin` denial passed

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/5
provenance: operator_proxy
stages:
  - dashboard_static_and_unit_tests
  - focused_ocaml_build
  - credential_rotation_tests
  - typed_auth_boundary_tests
  - real_server_canadmin_denial_e2e
```

## GOAL LOOP ACT checklist

- [x] Observe — issue #24031 records the Admin dev-token and rebinding boundary.
- [x] Orient — traced request authority, credential store, REST, Keeper streaming, and MCP consumers.
- [x] Decide — demote the credential and keep admin operations on explicit operator credentials.
- [x] Act — changed the exact issuance, rotation, identity, and recovery boundaries.
- [x] Verify — focused OCaml, TypeScript, production build, and real-server E2E pass.
- [x] Loop — no untracked follow-up in this scope.

## Review evidence

- Adversarial local review checked old-bearer rejection, cancellation-safe resume, manual-token preservation, typed-code-only retry, explicit-actor no-replay, and the real `CanAdmin` route matrix.
- Cross-model review pending on this draft.

## Linked issue

- Closes #24031

## Variant addition checklist

- [x] **OCaml** — typed request and rotation errors are declared in `.mli`; exhaustive matches build.
- [x] **TypeScript** — exact stored-token and bootstrap unions are updated with exhaustive consumers.
- [ ] **TLA+ spec** — N/A; no matching state-machine domain exists.
- [ ] **Event / JSON schema** — N/A; the endpoint and MCP structured-content shapes are covered directly.
- [ ] **`make check-variants` passes** — N/A; focused OCaml/TypeScript exhaustive checks cover the changed variants.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/dashboard-auth-ssot-20260803` → `main` · 1 commit(s) · synced 2026-08-03T13:00:11Z

| sha | subject | date |
|---|---|---|
| `178b8f931` | fix(auth): demote dashboard dev token to worker | 2026-08-03 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->

## Tool authorization boundary

- Removed the legacy `masc_*` prefix authorization path. Unregistered names now fail closed instead of inheriting `CanBroadcast`.
- Registered tools now require the catalog-owned permission (`CanReadState`, `CanInit`, `CanReset`, `CanAdmin`, and others); runtime metadata registration cannot overwrite that permission.
- Compatibility impact: any caller that previously relied on `CanBroadcast` to invoke an admin/reset/init tool must use a credential with the exact catalog permission. The real Worker-token `/mcp` E2E proves `masc_reset(confirm=true)` is rejected as `insufficient_role` and leaves the workspace sentinel unchanged.
- Live-call audit: the derived runtime base `/Users/dancer/me/.masc` currently exposes no `.log` or `.jsonl` corpus to establish whether legacy prefix-only or `CanBroadcast`-for-admin calls occurred. This is recorded as unavailable evidence, not as a claim of zero callers.