### PR TITLE
feat(runtime): add the 2026-07-31 DeepSeek-V4-Flash Ollama Cloud lane

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -373,6 +373,38 @@ supports-multimodal-inputs = false
 [ollama_cloud.ollama-cloud-deepseek-v4-flash]
 max-request-body-bytes = 524288
 
+# Ollama Cloud's 2026-07-31 DeepSeek-V4-Flash build. It is a DIFFERENT model
+# from the untagged `deepseek-v4-flash` above, not a newer alias of it:
+# /api/show reports parameter_size 304180418494 for `:0731` against
+# 158000000000 for the untagged tag, both FP8 and both reporting
+# deepseek4.context_length 1048576 with capabilities [completion tools thinking].
+#
+# It gets its own entry instead of retagging an existing block because
+# [models.deepseek-v4-flash] is bound to BOTH providers
+# ([ollama_cloud.deepseek-v4-flash] and [deepseek.deepseek-v4-flash]) and the
+# `:0731` suffix is an Ollama tag convention — api.deepseek.com/models serves
+# only `deepseek-v4-flash` and `deepseek-v4-pro`, so an in-place retag would
+# 404 the direct lane.
+[models.ollama-cloud-deepseek-v4-flash-0731]
+api-name = "deepseek-v4-flash:0731"
+max-context = 1048576
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.ollama-cloud-deepseek-v4-flash-0731.capabilities]
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "reasoning-effort"
+supports-image-input = false
+supports-multimodal-inputs = false
+
+# No wizard-default: this adds a selectable lane and deliberately leaves
+# [runtime].default on ollama_cloud.deepseek-v4-flash.
+[ollama_cloud.ollama-cloud-deepseek-v4-flash-0731]
+max-request-body-bytes = 524288
+
 [models.ollama-cloud-deepseek-v4-pro]
 api-name = "deepseek-v4-pro"
 max-context = 524288

--- a/scripts/ollama-caps-baseline.json
+++ b/scripts/ollama-caps-baseline.json
@@ -27,6 +27,14 @@
         "thinking"
       ]
     },
+    "deepseek-v4-flash:0731": {
+      "provider": "ollama_cloud",
+      "capabilities": [
+        "completion",
+        "tools",
+        "thinking"
+      ]
+    },
     "deepseek-v4-pro": {
       "provider": "ollama_cloud",
       "capabilities": [

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -52,6 +52,13 @@ let ollama_cloud_seed_cases =
     ; thinking = true
     ; vision = false
     }
+  ; { runtime_id = "ollama_cloud.ollama-cloud-deepseek-v4-flash-0731"
+    ; api_name = "deepseek-v4-flash:0731"
+    ; context = 1048576
+    ; tools = true
+    ; thinking = true
+    ; vision = false
+    }
   ; { runtime_id = "ollama_cloud.ollama-cloud-deepseek-v4-pro"
     ; api_name = "deepseek-v4-pro"
     ; context = 524288


### PR DESCRIPTION
## 목표

Ollama Cloud 의 2026-07-31 DeepSeek-V4-Flash 빌드를 **선택 가능한 레인으로 추가**한다. `[runtime].default` 는 건드리지 않는다.

## 왜 새 항목인가 — 기존 항목 재태깅이 아니다

`:0731` 은 기존 `deepseek-v4-flash` 의 새 별칭이 아니라 **다른 모델**이다. `/api/show` 실측:

| | `deepseek-v4-flash` | `deepseek-v4-flash:0731` |
|---|---|---|
| `parameter_size` | 158000000000 | **304180418494** |
| `quantization_level` | FP8 | FP8 |
| `deepseek4.context_length` | 1048576 | 1048576 |
| `capabilities` | completion, tools, thinking | completion, tools, thinking |

그리고 in-place 재태깅은 **직통 레인을 404 로 만든다**. `[models.deepseek-v4-flash]` 한 블록이 두 프로바이더에 묶여 있는데(`[ollama_cloud.deepseek-v4-flash]` + `[deepseek.deepseek-v4-flash]`), `:0731` 은 Ollama 태그 규약이다:

```
GET https://ollama.com/v1/models        → deepseek-v4-flash, deepseek-v4-flash:0731, deepseek-v4-pro
GET https://api.deepseek.com/models     → deepseek-v4-flash, deepseek-v4-pro          (:0731 없음)
```

## 변경

| 파일 | 변경 |
|---|---|
| `config/runtime.toml` | `[models.ollama-cloud-deepseek-v4-flash-0731]` + capabilities + `[ollama_cloud.…]` 바인딩 |
| `scripts/ollama-caps-baseline.json` | 실측 capability 항목 1건 |
| `test/test_runtime_config_validity.ml` | seed case 1건 |

`max-context = 1048576` 은 같은 프로바이더의 같은 모델 형제(`[models.ollama-cloud-deepseek-v4-flash]`)와 일치하며 `/api/show` 의 `deepseek4.context_length` 실측값과도 같다. `max-request-body-bytes = 524288` 도 그 형제와 동일 (Keeper working set 은 provider capability 와 별개라는 기존 주석 근거를 따름).

`wizard-default` 를 붙이지 않았고 `[runtime].default` 도 그대로 `ollama_cloud.deepseek-v4-flash` 다. diff 에 `default` 변경 라인이 없다.

## 검증

```
python3 scripts/masc-sync-ollama-caps.py --check --strict
  → OK: 42 Ollama-family model(s) match baseline (0 unverified)   exit=0

dune build @test/runtest-test_runtime_config_validity
  → Test Successful. 56 tests run.                                exit=0

dune build @check
  → Error/Warning 0                                               exit=0
```

capability 값은 손으로 쓰지 않고 RFC-0265 도구로 실측했다. 처음 `--check` 는 `unverified (text-only, absent from baseline); run --refresh` 로 정확히 지적했고, `--refresh` 프로브 결과가 `deepseek-v4-flash:0731 caps=['completion','tools','thinking'] -> image=False audio=False` 였다.

`--refresh` 의 baseline 전체 재작성은 **커밋하지 않았다**. 그 실행이 142 줄을 지우고 3 줄을 넣었는데, 삭제분은 전부 아래 "부수 발견" 의 410 Gone 모델들이다. 모델 하나 추가하는 PR 에 config 숙청을 섞지 않으려고 baseline 을 되돌린 뒤 해당 항목만 넣었다(+8, 재포맷 0 — 삽입 전에 `json.dumps` 라운드트립이 바이트 동일함을 먼저 확인).

## 부수 발견 — 이 PR 에서 고치지 않음

`--refresh` 프로브에서 **19 개 모델이 `HTTP Error 410: Gone`** 이었다. config 가 선언하고 있으나 Ollama Cloud 가 이미 퇴역시킨 항목들이다:

```
deepseek-v3.1:671b · deepseek-v3.2 · devstral-2:123b · devstral-small-2:24b
gemini-3-flash-preview · gemma3:{4b,12b,27b} · glm-4.7 · glm-5 · kimi-k2.5
minimax-m2.1 · minimax-m2.5 · ministral-3:{3b,8b,14b} · qwen3-coder:480b
qwen3-coder-next · rnj-1:8b
```

`--check` 는 baseline 대비 비교라 초록이고, 이 드리프트는 `--refresh` 를 돌려야만 드러난다. 별도 이슈/PR 감이라 여기서는 건드리지 않았다.

## 미확인

`api.deepseek.com` 의 `deepseek-v4-flash` 가 직통 레인에서도 신규 빌드로 교체됐는지는 확인하지 못했다 — `/models` 가 `parameter_size` 를 노출하지 않는다. 이 PR 은 Ollama 레인만 다루므로 영향은 없다.

RFC-WAIVED: 런타임 모델 카탈로그에 선택 가능한 프로바이더 레인 1건 추가. 기본 모델·라우팅·credential/identity/operator-control/sandbox/hooks 무변경이며, capability 값은 기존 RFC-0265 동기화 도구의 실측 결과다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
