### PR TITLE
fix(keeper): remove prompt config reentry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -906,6 +906,22 @@ jobs:
           chmod +x scripts/ci-run-tests.sh
           scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_verification"
 
+      # MCP identity is session-bound behavior: compile-only coverage cannot
+      # prove that initialize -> start -> status -> transition preserves one
+      # identity through the durable task lifecycle.
+      - name: Run MCP identity full-cycle suite
+        id: mcp_identity_full_cycle_suite
+        if: ${{ always() && steps.build_step.outcome == 'success' }}
+        env:
+          ME_ROOT: /tmp/me
+          CI_TEST_HEARTBEAT_SEC: 15
+          DUNE_JOBS: 1
+        run: |
+          mkdir -p /tmp/me
+          chmod +x scripts/ci-run-tests.sh
+          identity_targets="@test/runtest-test_client_identity @test/runtest-test_mcp_full_cycle"
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . ${identity_targets}"
+
       # Goal store durability: the suite drives a real workspace and asserts
       # on-disk bytes, not source text — the read path stays lenient while a
       # write over an undecodable store must be refused and must leave both

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -907,10 +907,11 @@ jobs:
           scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_verification"
 
       # MCP identity is session-bound behavior: compile-only coverage cannot
-      # prove that initialize -> start -> status -> transition preserves one
-      # identity through the durable task lifecycle.
-      - name: Run MCP identity full-cycle suite
-        id: mcp_identity_full_cycle_suite
+      # prove that the complete handshake -> start -> status -> transition
+      # path preserves one identity through the durable Task lifecycle. The
+      # Keeper prompt target separately proves caller-owned config projection.
+      - name: Run MCP session Task lifecycle and Keeper prompt config suites
+        id: mcp_session_task_lifecycle_suite
         if: ${{ always() && steps.build_step.outcome == 'success' }}
         env:
           ME_ROOT: /tmp/me
@@ -919,7 +920,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          identity_targets="@test/runtest-test_client_identity @test/runtest-test_mcp_full_cycle"
+          identity_targets="@test/runtest-test_client_identity @test/runtest-test_mcp_session_task_lifecycle @test/runtest-test_keeper_sandbox_docker_cwd_response"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${identity_targets}"
 
       # Goal store durability: the suite drives a real workspace and asserts

--- a/docs/rfc/RFC-0357-scheduled-turn-typed-stimulus-admission.md
+++ b/docs/rfc/RFC-0357-scheduled-turn-typed-stimulus-admission.md
@@ -122,7 +122,7 @@ RFC-0303이 기각한 것은 **출력 품질 휴리스틱**이다: `made_progres
 ## 8. 검증
 
 - 단위: 빈 observation + gate on → `Skip No_actionable_stimulus`. 각 disjunct 단독 → `Run`. bootstrap은 generation당 1회. §3.3 매트릭스 4행 각각: 연속(변경→재admit)·자기제한(무변경→skip)·크래시 재기동 재소집(durable 소비 revision 이전 값 유지 확인)·실패 턴 비재소집. reactive 턴이 backlog edge를 소비하지 않음(mention 턴 후 미처리 backlog 변경 → scheduled 채널 admit 유지). **빠른 턴 연속성**: admission과 같은 눈금(동일 시각)에 일어난 변경도 revision 증가만으로 재admit — 시각 동률에 의존하는 테스트 금지.
-- 라이브 (감사 Phase 4 완료 기준 그대로): 신호 없는 10분간 provider call 0, heartbeat row는 계속 기록. direct message는 즉시 reactive 턴. 정적 백로그 keeper(#26487의 full-cycle-probe 형태)는 부트 후 autonomous 턴 1회 이하.
+- 라이브: 신호 없는 10분간 provider call 0, heartbeat row는 계속 기록. direct message는 즉시 reactive 턴. Full-cycle 검증은 Keeper를 기동하지 않는 격리 one-shot MCP E2E로만 수행한다.
 - 비용: 신호 없는 날의 scheduled 채널 provider 비용 ≈ $0 (오늘 $78.77의 대조 실측을 병합 후 기록).
 
 ## 9. 비제안

--- a/docs/rfc/RFC-0357-scheduled-turn-typed-stimulus-admission.md
+++ b/docs/rfc/RFC-0357-scheduled-turn-typed-stimulus-admission.md
@@ -122,7 +122,7 @@ RFC-0303이 기각한 것은 **출력 품질 휴리스틱**이다: `made_progres
 ## 8. 검증
 
 - 단위: 빈 observation + gate on → `Skip No_actionable_stimulus`. 각 disjunct 단독 → `Run`. bootstrap은 generation당 1회. §3.3 매트릭스 4행 각각: 연속(변경→재admit)·자기제한(무변경→skip)·크래시 재기동 재소집(durable 소비 revision 이전 값 유지 확인)·실패 턴 비재소집. reactive 턴이 backlog edge를 소비하지 않음(mention 턴 후 미처리 backlog 변경 → scheduled 채널 admit 유지). **빠른 턴 연속성**: admission과 같은 눈금(동일 시각)에 일어난 변경도 revision 증가만으로 재admit — 시각 동률에 의존하는 테스트 금지.
-- 라이브: 신호 없는 10분간 provider call 0, heartbeat row는 계속 기록. direct message는 즉시 reactive 턴. Full-cycle 검증은 Keeper를 기동하지 않는 격리 one-shot MCP E2E로만 수행한다.
+- 라이브: 신호 없는 10분간 provider call 0, heartbeat row는 계속 기록. direct message는 즉시 reactive 턴. Keeper를 기동하지 않는 격리 MCP session/Task lifecycle smoke는 protocol admission만 검증하며, 제품 Full Lifecycle 증거는 `docs/product/KEEPER-FULL-LIFECYCLE-BEHAVIOR.md` §5의 uninterrupted 15단계 계약을 따른다.
 - 비용: 신호 없는 날의 scheduled 채널 provider 비용 ≈ $0 (오늘 $78.77의 대조 실측을 병합 후 기록).
 
 ## 9. 비제안

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -150,7 +150,7 @@ let keeper_config_json (config : Workspace.config) (name : string)
           let current_task =
             Keeper_world_observation_inputs.read_current_task ~config ~meta:m
           in
-          Keeper_unified_prompt.build_prompt_preview ~meta:m ~base_path:config.base_path
+          Keeper_unified_prompt.build_prompt_preview ~meta:m ~config
             ~profile_defaults:defaults ~current_task ~active_goal_summaries ~observation ()
         in
         (* Match what a turn actually sends: the observation frame rides the

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -35,7 +35,7 @@ let build_base_system_prompt
   in
   Keeper_unified_prompt.build_system_prompt
     ~meta
-    ~base_path:config.base_path
+    ~config
     ~profile_defaults
     ~active_goal_summaries
     ()

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -580,7 +580,8 @@ let active_goal_summaries
     meta.active_goal_ids
 ;;
 
-let build_system_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string)
+let build_system_prompt ~(meta : Keeper_meta_contract.keeper_meta)
+    ~(config : Workspace.config)
     ?(profile_defaults : Keeper_types_profile.keeper_profile_defaults option)
     ?(active_goal_summaries : (string * string) list option)
     ()
@@ -597,7 +598,6 @@ let build_system_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path :
       ~default:(List.map (fun goal_id -> (goal_id, "")) meta.active_goal_ids)
       active_goal_summaries
   in
-  let config = Workspace.default_config base_path in
   let base_system_prompt =
     Keeper_prompt.build_keeper_system_prompt
       ~instructions
@@ -614,7 +614,8 @@ let build_system_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path :
   system_prompt
 ;;
 
-let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string)
+let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta)
+    ~(config : Workspace.config)
     ?(profile_defaults : Keeper_types_profile.keeper_profile_defaults option)
     ~(turn_decision : Keeper_world_observation.keeper_cycle_decision option)
     ~(current_task : Keeper_world_observation_inputs.current_task_observation)
@@ -625,7 +626,7 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path
   let system_prompt =
     build_system_prompt
       ~meta
-      ~base_path
+      ~config
       ?profile_defaults
       ?active_goal_summaries
       ()
@@ -884,7 +885,7 @@ let emit_prompt_metrics
 
 let build_prompt
       ~meta
-      ~base_path
+      ~config
       ?profile_defaults
       ~turn_decision
       ~current_task
@@ -895,7 +896,7 @@ let build_prompt
   let prompt =
     build_prompt_internal
       ~meta
-      ~base_path
+      ~config
       ?profile_defaults
       ~turn_decision:(Some turn_decision)
       ~current_task
@@ -909,7 +910,7 @@ let build_prompt
 
 let build_prompt_preview
       ~meta
-      ~base_path
+      ~config
       ?profile_defaults
       ~current_task
       ?active_goal_summaries
@@ -918,7 +919,7 @@ let build_prompt_preview
   =
   build_prompt_internal
     ~meta
-    ~base_path
+    ~config
     ?profile_defaults
     ~turn_decision:None
     ~current_task

--- a/lib/keeper/keeper_unified_prompt.mli
+++ b/lib/keeper/keeper_unified_prompt.mli
@@ -62,22 +62,26 @@ val active_goal_summaries :
 
 val build_system_prompt :
   meta:Keeper_meta_contract.keeper_meta ->
-  base_path:string ->
+  config:Workspace.config ->
   ?profile_defaults:Keeper_types_profile.keeper_profile_defaults ->
   ?active_goal_summaries:(string * string) list ->
   unit ->
   string
 (** Build the model-facing stable Keeper contract shared by direct and
     autonomous turns. Channel-specific input belongs in dynamic context or the
-    persisted user message, not in a second system-prompt implementation. *)
+    persisted user message, not in a second system-prompt implementation.
+
+    [config] is the caller-owned workspace generation admitted for the turn.
+    Prompt construction never resolves a second default config. *)
 
 (** Build the three-channel unified prompt from keeper state.
 
     @param meta Keeper metadata (identity, soul, goals, instructions)
+    @param config Caller-owned workspace generation for this turn
     @param observation Current world snapshot *)
 val build_prompt :
   meta:Keeper_meta_contract.keeper_meta ->
-  base_path:string ->
+  config:Workspace.config ->
   ?profile_defaults:Keeper_types_profile.keeper_profile_defaults ->
   turn_decision:Keeper_world_observation.keeper_cycle_decision ->
   current_task:Keeper_world_observation_inputs.current_task_observation ->
@@ -99,7 +103,7 @@ val build_prompt :
 
 val build_prompt_preview :
   meta:Keeper_meta_contract.keeper_meta ->
-  base_path:string ->
+  config:Workspace.config ->
   ?profile_defaults:Keeper_types_profile.keeper_profile_defaults ->
   current_task:Keeper_world_observation_inputs.current_task_observation ->
   ?active_goal_summaries:(string * string) list ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -539,7 +539,7 @@ let run_keeper_cycle
                let { Keeper_unified_prompt.system_prompt; world_state; user_message } =
                  Keeper_unified_prompt.build_prompt
                    ~meta
-                   ~base_path:config.base_path
+                   ~config
                    ~profile_defaults
                    ~turn_decision
                    ~current_task

--- a/lib/mcp_tool_runtime_workspace.ml
+++ b/lib/mcp_tool_runtime_workspace.ml
@@ -187,14 +187,25 @@ let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result opt
             active_config ~title:task_title ~priority:3 ~description:""
         with
         | Error error ->
+          let detail = Workspace_task_create.add_task_error_to_string error in
           Some
-            (runtime_err_runtime
+            (Tool_result.make_err
                ~tool_name
+               ~class_:Tool_result.Runtime_failure
                ~start_time
+               ~data:
+                 (`Assoc
+                   [ ("agent_name", `String agent_name)
+                   ; ( "effect_disposition"
+                     , `String
+                         (Tool_result.failure_effect_disposition_to_string
+                            Tool_result.Proven_post_effect) )
+                   ; ("error", `String detail)
+                   ])
                (Printf.sprintf
                   "masc_start failed while creating a task after binding session %s: %s"
                   agent_name
-                  (Workspace_task_create.add_task_error_to_string error)))
+                  detail))
         | Ok created ->
           let task_id = created.task_id in
           let add_result = created.summary in

--- a/lib/mcp_tool_runtime_workspace.ml
+++ b/lib/mcp_tool_runtime_workspace.ml
@@ -182,34 +182,22 @@ let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result opt
                 agent_name
                 masc_add_task_name))
       else begin
-        let add_result =
-          Workspace_task.add_task
+        match
+          Workspace_task_create.add_task_with_result
             active_config ~title:task_title ~priority:3 ~description:""
-        in
-        (* Extract task ID from result like "Added task-001: title" *)
-        let task_id =
-          try
-            let prefix = "Added " in
-            let idx = ref 0 in
-            while !idx < String.length add_result - String.length prefix &&
-                  not (String.equal (Stdlib.String.sub add_result !idx (String.length prefix)) prefix) do
-              Stdlib.incr idx
-            done;
-            let start = !idx + String.length prefix in
-            let end_idx = match String.index_from_opt add_result start ':' with
-              | Some idx -> idx
-              | None -> String.length add_result
-            in
-            String.sub add_result start (end_idx - start)
-          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ""
-        in
-        if String.equal task_id "" then
+        with
+        | Error error ->
           Some
-            (runtime_ok ~tool_name ~start_time
+            (runtime_err_runtime
+               ~tool_name
+               ~start_time
                (Printf.sprintf
-                  "masc_start partial: session bound as %s, but task creation failed: %s"
-                  agent_name add_result))
-        else begin
+                  "masc_start failed while creating a task after binding session %s: %s"
+                  agent_name
+                  (Workspace_task_create.add_task_error_to_string error)))
+        | Ok created ->
+          let task_id = created.task_id in
+          let add_result = created.summary in
           match
             Workspace_task.claim_task_r active_config ~agent_name ~task_id ()
           with
@@ -267,5 +255,4 @@ let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result opt
                      (Printf.sprintf
                         "masc_start complete: project scope set, session bound as %s, task %s created+claimed+set as current."
                         agent_name task_id))
-        end
       end

--- a/lib/mcp_tool_runtime_workspace.mli
+++ b/lib/mcp_tool_runtime_workspace.mli
@@ -43,8 +43,9 @@ val handle_start :
     2. **Bind agent session**: idempotent when already bound.
        Failure surfaces as a startup error.
     3. **Optional task creation**: when [task_title] non-empty,
-       runs [Workspace_task.add_task] + extracts the task id from
-       the [["Added task-NNN: title"]] response prefix.
+       consumes the typed result from
+       {!Workspace_task_create.add_task_with_result}; task creation failure
+       remains an error and never becomes a partial-success message.
 
     {2 Error message wording (pinned)}
 

--- a/lib/workspace/workspace_utils_paths_backend.ml
+++ b/lib/workspace/workspace_utils_paths_backend.ml
@@ -239,6 +239,7 @@ let root_is_initialized config =
 (* Server-level cache for is_initialized — avoids 3 syscalls per request.
    Cache key is (base_path, cluster_name) to handle multi-config scenarios. *)
 type init_cache_entry = {
+  cache_key : string * string;
   cached_result : bool;
   cached_at : float;
 }
@@ -246,12 +247,18 @@ type init_cache_entry = {
 let initialized_cache : init_cache_entry option Atomic.t = Atomic.make None
 let initialized_cache_ttl = 1.0  (* seconds *)
 
+let init_cache_key config =
+  (config.base_path, config.backend_config.Backend_types.cluster_name)
+
 (** Check if current workspace is initialized - backend-agnostic.
     Cached with 1-second TTL to avoid 3 filesystem syscalls per request. *)
 let is_initialized config =
   let now = Time_compat.now () in
+  let cache_key = init_cache_key config in
   match Atomic.get initialized_cache with
-  | Some entry when now -. entry.cached_at < initialized_cache_ttl ->
+  | Some entry
+    when entry.cache_key = cache_key
+         && now -. entry.cached_at < initialized_cache_ttl ->
       entry.cached_result
   | _ ->
       let result =
@@ -268,7 +275,8 @@ let is_initialized config =
             Sys.is_directory (masc_dir config) &&
             Sys.file_exists (state_path config)
       in
-      Atomic.set initialized_cache (Some { cached_result = result; cached_at = now });
+      Atomic.set initialized_cache
+        (Some { cache_key; cached_result = result; cached_at = now });
       result
 
 (** Invalidate the is_initialized cache. Call this when workspace state

--- a/test/dune
+++ b/test/dune
@@ -1005,7 +1005,7 @@
   test_file_lock_eio
   test_error_logging_coverage
   test_client_identity
-  test_mcp_full_cycle
+  test_mcp_session_task_lifecycle
   test_client_registry_eio
   test_minted_name_gate
   test_identity_e2e
@@ -1164,7 +1164,7 @@
   test_file_lock_eio
   test_error_logging_coverage
   test_client_identity
-  test_mcp_full_cycle
+  test_mcp_session_task_lifecycle
   test_client_registry_eio
   test_minted_name_gate
   test_identity_e2e

--- a/test/test_keeper_sandbox_docker_cwd_response.ml
+++ b/test/test_keeper_sandbox_docker_cwd_response.ml
@@ -35,6 +35,18 @@ let cleanup_dir path =
   in
   rm path
 
+let restore_env name = function
+  | Some value -> Unix.putenv name value
+  | None -> Unix.putenv name ""
+
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  Fun.protect
+    ~finally:(fun () -> restore_env name previous)
+    (fun () ->
+      restore_env name value;
+      f ())
+
 let make_docker_meta ~name : Keeper_meta_contract.keeper_meta =
   let json =
     `Assoc
@@ -313,6 +325,47 @@ let test_typed_execute_response_cwd_uses_container_path () =
         not_directory_cwd
         not_directory_location_cwd)
 
+let test_prompt_keeps_caller_owned_workspace_generation () =
+  let admitted_base = temp_dir "keeper_prompt_admitted_" in
+  let divergent_base = temp_dir "keeper_prompt_divergent_" in
+  Fun.protect
+    ~finally:(fun () ->
+      Workspace.reset_default_config_cache ();
+      cleanup_dir admitted_base;
+      cleanup_dir divergent_base)
+    (fun () ->
+      with_env "MASC_TEST_ALLOW_BASE_PATH_OVERRIDE" None @@ fun () ->
+      with_env "MASC_BASE_PATH" None @@ fun () ->
+      with_env "MASC_BASE_PATH_INPUT" None @@ fun () ->
+      Workspace.reset_default_config_cache ();
+      let config = Workspace.default_config admitted_base in
+      let meta =
+        { (make_docker_meta ~name:"caller-config-pin") with
+          sandbox_profile = Keeper_types_profile_sandbox.Local
+        }
+      in
+      let expected_root =
+        Keeper_sandbox.keeper_visible_root_abs_of_meta ~config meta
+      in
+      let divergent_root =
+        Filename.concat divergent_base (Keeper_sandbox.host_root_rel_of_meta ~meta)
+      in
+      with_env "MASC_TEST_ALLOW_BASE_PATH_OVERRIDE" (Some "true") @@ fun () ->
+      with_env "MASC_BASE_PATH" (Some divergent_base) @@ fun () ->
+      with_env "MASC_BASE_PATH_INPUT" (Some divergent_base) @@ fun () ->
+      Workspace.reset_default_config_cache ();
+      let prompt =
+        Keeper_run_context.build_base_system_prompt
+          ~config
+          ~profile_defaults:
+            Keeper_types_profile_defaults.empty_keeper_profile_defaults
+          ~meta
+      in
+      check bool "prompt uses the admitted config sandbox root" true
+        (Astring.String.is_infix ~affix:expected_root prompt);
+      check bool "prompt does not resolve a second workspace generation" false
+        (Astring.String.is_infix ~affix:divergent_root prompt))
+
 let test_retired_path_jail_env_detection () =
   let configured value =
     Retired_env_warnings.For_testing.shell_ir_path_jail_env_configured
@@ -377,6 +430,9 @@ let () =
         ; test_case
             "typed Execute Docker cwd response does not leak host"
             `Quick test_typed_execute_response_cwd_uses_container_path
+        ; test_case
+            "Keeper prompt keeps caller-owned workspace generation"
+            `Quick test_prompt_keeps_caller_owned_workspace_generation
         ] )
     ; ( "source-pin"
       , [

--- a/test/test_keeper_surface_presence_prompt.ml
+++ b/test/test_keeper_surface_presence_prompt.ml
@@ -134,16 +134,18 @@ let init_prompt_config_for_tests () =
 
 let user_message observation =
   let turn_decision = WO.keeper_cycle_decision ~meta observation in
+  let config = Masc.Workspace.default_config "/tmp/unused" in
   let { Prompt.world_state = user; _ } =
-    Prompt.build_prompt ~meta ~base_path:"/tmp/unused" ~turn_decision
+    Prompt.build_prompt ~meta ~config ~turn_decision
       ~current_task:Inputs.No_current_task ~observation ()
   in
   user
 
 let system_prompt ?profile_defaults observation =
   let turn_decision = WO.keeper_cycle_decision ~meta observation in
+  let config = Masc.Workspace.default_config "/tmp/unused" in
   let { Prompt.system_prompt = system; _ } =
-    Prompt.build_prompt ~meta ~base_path:"/tmp/unused" ?profile_defaults
+    Prompt.build_prompt ~meta ~config ?profile_defaults
       ~turn_decision ~current_task:Inputs.No_current_task ~observation ()
   in
   system
@@ -272,7 +274,7 @@ let sandbox_root_for profile =
   let { Prompt.system_prompt; _ } =
     Prompt.build_prompt
       ~meta
-      ~base_path
+      ~config
       ~turn_decision
       ~current_task:Inputs.No_current_task
       ~observation:base_observation

--- a/test/test_keeper_unified_persona_block.ml
+++ b/test/test_keeper_unified_persona_block.ml
@@ -63,9 +63,10 @@ let make_meta name : Masc.Keeper_meta_contract.keeper_meta =
 
 let build_prompt meta =
   let turn_decision = WO.keeper_cycle_decision ~meta base_observation in
+  let config = Masc.Workspace.default_config "/tmp" in
   Masc.Keeper_unified_prompt.build_prompt
     ~meta
-    ~base_path:"/tmp"
+    ~config
     ~turn_decision
     ~current_task:Masc.Keeper_world_observation_inputs.No_current_task
     ~observation:base_observation

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -104,9 +104,10 @@ let build_prompt ~meta observation =
   let turn_decision =
     Masc.Keeper_world_observation.keeper_cycle_decision ~meta observation
   in
+  let config = Masc.Workspace.default_config "/tmp" in
   Masc.Keeper_unified_prompt.build_prompt
     ~meta
-    ~base_path:"/tmp"
+    ~config
     ~turn_decision
     ~current_task:Masc.Keeper_world_observation_inputs.No_current_task
     ~observation

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -86,6 +86,8 @@ let meta : Masc.Keeper_meta_contract.keeper_meta =
         ("trace_id", `String "test-trace-wake-context");
       ])
 
+let prompt_config = lazy (Masc.Workspace.default_config "/tmp/unused")
+
 (* Same throwaway runtime default as test_keeper_surface_presence_prompt:
    the Autonomous Trigger section consults the default runtime (RFC-0206). *)
 let runtime_toml =
@@ -188,7 +190,7 @@ let user_message ?turn_decision ?current_task ?active_goal_summaries observation
     | None -> Inputs.No_current_task
   in
   let { Prompt.world_state = user; _ } =
-    Prompt.build_prompt ~meta ~base_path:"/tmp/unused" ~turn_decision
+    Prompt.build_prompt ~meta ~config:(Lazy.force prompt_config) ~turn_decision
       ~current_task ?active_goal_summaries ~observation ()
   in
   user
@@ -243,7 +245,8 @@ let test_current_task_unavailable_is_explicit () =
   let task_id = task_id_exn "task-42" in
   let decision = WO.keeper_cycle_decision ~meta base_observation in
   let { Prompt.world_state; _ } =
-    Prompt.build_prompt ~meta ~base_path:"/tmp/unused" ~turn_decision:decision
+    Prompt.build_prompt ~meta ~config:(Lazy.force prompt_config)
+      ~turn_decision:decision
       ~current_task:
         (Inputs.Current_task_unavailable
            { task_id; error = "primary and recovery backlog decode failed" })
@@ -260,7 +263,8 @@ let test_current_task_missing_is_explicit () =
   let task_id = task_id_exn "task-42" in
   let decision = WO.keeper_cycle_decision ~meta base_observation in
   let { Prompt.world_state; _ } =
-    Prompt.build_prompt ~meta ~base_path:"/tmp/unused" ~turn_decision:decision
+    Prompt.build_prompt ~meta ~config:(Lazy.force prompt_config)
+      ~turn_decision:decision
       ~current_task:(Inputs.Current_task_missing { task_id; recovery = None })
       ~observation:base_observation ()
   in
@@ -278,7 +282,8 @@ let test_recovered_current_task_is_non_authoritative () =
     { recovery_path = "/tmp/backlog.last-good"; primary_error = "decode failed" }
   in
   let { Prompt.world_state; _ } =
-    Prompt.build_prompt ~meta ~base_path:"/tmp/unused" ~turn_decision:decision
+    Prompt.build_prompt ~meta ~config:(Lazy.force prompt_config)
+      ~turn_decision:decision
       ~current_task:
         (Inputs.Recovered_current_task { task = recovered_task; recovery })
       ~observation:base_observation ()
@@ -352,7 +357,7 @@ let test_direct_and_autonomous_share_system_prompt () =
   let { Prompt.system_prompt = autonomous_system_prompt; _ } =
     Prompt.build_prompt
       ~meta
-      ~base_path:"/tmp/unused"
+      ~config:(Lazy.force prompt_config)
       ~turn_decision:decision
       ~current_task:Inputs.No_current_task
       ~observation:base_observation
@@ -398,7 +403,7 @@ let test_unresolved_goal_keeps_one_stable_safety_contract () =
   let { Prompt.system_prompt = autonomous_system_prompt; _ } =
     Prompt.build_prompt
       ~meta:meta_with_goal
-      ~base_path:"/tmp/unused"
+      ~config:(Lazy.force prompt_config)
       ~active_goal_summaries
       ~turn_decision:decision
       ~current_task:Inputs.No_current_task
@@ -488,7 +493,7 @@ let test_preview_does_not_invent_wake_reason () =
   let { Prompt.world_state; _ } =
     Prompt.build_prompt_preview
       ~meta:preview_meta
-      ~base_path:"/tmp/unused"
+      ~config:(Lazy.force prompt_config)
       ~current_task:Inputs.No_current_task
       ~observation:base_observation
       ()
@@ -555,7 +560,7 @@ let test_goal_holder_gets_self_direction_directive () =
     WO.keeper_cycle_decision ~meta:meta_with_goal base_observation
   in
   let { Prompt.system_prompt = system; _ } =
-    Prompt.build_prompt ~meta:meta_with_goal ~base_path:"/tmp/unused"
+    Prompt.build_prompt ~meta:meta_with_goal ~config:(Lazy.force prompt_config)
       ~turn_decision:goal_turn_decision ~current_task:Inputs.No_current_task
       ~observation:base_observation ()
   in
@@ -567,7 +572,7 @@ let test_goal_holder_gets_self_direction_directive () =
     WO.keeper_cycle_decision ~meta base_observation
   in
   let { Prompt.system_prompt = no_goal_system; _ } =
-    Prompt.build_prompt ~meta ~base_path:"/tmp/unused"
+    Prompt.build_prompt ~meta ~config:(Lazy.force prompt_config)
       ~turn_decision:no_goal_turn_decision ~current_task:Inputs.No_current_task
       ~observation:base_observation ()
   in

--- a/test/test_mcp_full_cycle.ml
+++ b/test/test_mcp_full_cycle.ml
@@ -1,154 +1,165 @@
-(** Integration Test: Full MCP Cycle
+(** One-shot synthetic MCP full-cycle probe.
 
-    Tests the complete flow: Agent → MCP Server → Tool → Response
-    Verifies agent identity preservation throughout the cycle.
-
-    @since 0.5.0
-*)
+    This is deliberately not a Keeper. It exercises protocol admission,
+    session identity, typed tool dispatch, workspace persistence, and task
+    completion once inside an isolated workspace. It never starts a provider
+    call, heartbeat, autonomous loop, or autoboot entry. *)
 
 open Alcotest
-open Masc
 
-(** Test fixtures *)
-module Fixtures = struct
-  let make_identity_params ~agent_name =
-    `Assoc [
-      ("agent_name", `String agent_name);
-      ("_agent_name", `String agent_name);
-      ("_channel", `String "internal");
-    ]
+module Mcp_eio = Masc.Mcp_server_eio
+module Mcp_server = Masc.Mcp_server
 
-  let identity_for ?session_key agent_name =
-    let session_key =
-      match session_key with
-      | Some value -> value
-      | None -> "session-" ^ agent_name
-    in
-    Client_identity.from_mcp_params
-      (`Assoc
-        [
-          ("_agent_name", `String agent_name);
-          ("_session_key", `String session_key);
-        ])
-end
+let () = Mirage_crypto_rng_unix.use_default ()
 
-(** Test: Agent identity extracted from MCP params *)
-let test_identity_extraction () =
-  let params = Fixtures.make_identity_params ~agent_name:"integration-agent" in
-  let args = Yojson.Safe.Util.(params |> member "arguments" |> function `Null -> params | x -> x) in
-  let identity = Client_identity.from_mcp_params args in
-  
-  check string "agent_name extracted" "integration-agent" identity.agent_name;
-  match identity.channel with
-  | Some Client_identity.Internal -> ()
-  | _ -> fail "expected Internal channel"
+let temp_dir () =
+  let path = Filename.temp_file "masc_full_cycle_probe_" "" in
+  Unix.unlink path;
+  Unix.mkdir path 0o755;
+  path
 
-(** Test: Agent identity persists in registry *)
-let test_identity_registry_persistence () =
+let cleanup_dir root =
+  let rec remove path =
+    if Sys.is_directory path then begin
+      Array.iter
+        (fun name -> remove (Filename.concat path name))
+        (Sys.readdir path);
+      Unix.rmdir path
+    end else
+      Unix.unlink path
+  in
+  try remove root with Sys_error _ -> ()
+
+let request ~id ~method_ params =
+  Yojson.Safe.to_string
+    (`Assoc
+      [ ("jsonrpc", `String "2.0")
+      ; ("id", `Int id)
+      ; ("method", `String method_)
+      ; ("params", params)
+      ])
+
+let initialize_request =
+  request ~id:1 ~method_:"initialize"
+    (`Assoc
+      [ ("protocolVersion", `String "2025-11-25")
+      ; ("capabilities", `Assoc [])
+      ; ( "clientInfo"
+        , `Assoc
+            [ ("name", `String "masc-full-cycle-probe")
+            ; ("version", `String "1")
+            ] )
+      ])
+
+let tool_request ~id ~name arguments =
+  request ~id ~method_:"tools/call"
+    (`Assoc
+      [ ("name", `String name)
+      ; ("arguments", arguments)
+      ])
+
+let result_fields_exn label = function
+  | `Assoc response_fields ->
+    (match List.assoc_opt "result" response_fields with
+     | Some (`Assoc result_fields) -> result_fields
+     | Some _ -> failf "%s returned a non-object result" label
+     | None ->
+       failf "%s returned no result: %s" label
+         (Yojson.Safe.to_string (`Assoc response_fields)))
+  | response ->
+    failf "%s returned a non-object response: %s" label
+      (Yojson.Safe.to_string response)
+
+let check_protocol_success label response =
+  ignore (result_fields_exn label response)
+
+let check_tool_success label response =
+  let fields = result_fields_exn label response in
+  match List.assoc_opt "isError" fields with
+  | Some (`Bool false) -> ()
+  | Some (`Bool true) ->
+    failf "%s returned a typed tool error: %s" label
+      (Yojson.Safe.to_string response)
+  | _ -> failf "%s omitted result.isError: %s" label
+           (Yojson.Safe.to_string response)
+
+let task_exn config =
+  match Masc.Workspace.get_tasks_raw config with
+  | [ task ] -> task
+  | tasks -> failf "expected one synthetic task, got %d" (List.length tasks)
+
+let test_one_shot_protocol_to_durable_outcome () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
-  let reg = Client_identity.Registry.create () in
-  
-  (* First call - register agent *)
-  let id1 = Fixtures.identity_for "persistent-agent" in
-  let registered = Client_identity.Registry.register reg id1 in
-  
-  (* Simulate second call - should find existing *)
-  let found = Client_identity.Registry.find_by_name reg "persistent-agent" in
-  match found with
-  | Some id2 ->
-      check string "same session_key" registered.session_key id2.session_key;
-      check bool "same agent" true (Client_identity.same_agent registered id2)
-  | None -> fail "identity not found in registry"
+  Mcp_eio.set_net (Eio.Stdenv.net env);
+  Mcp_eio.set_clock (Eio.Stdenv.clock env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+      let state = Mcp_eio.For_testing.create_state ~base_path () in
+      let session_id = "full-cycle-probe-session" in
+      let call request =
+        Mcp_eio.handle_request ~clock ~sw ~mcp_session_id:session_id state request
+      in
 
-(** Test: Multi-agent scenario - identities don't collide *)
-let test_multi_agent_isolation () =
-  Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  let reg = Client_identity.Registry.create () in
-  
-  let agents = ["agent-a"; "agent-b"; "agent-c"] in
-  let identities = List.map (fun name ->
-    Client_identity.Registry.register reg (Fixtures.identity_for name)
-  ) agents in
-  
-  (* Verify all agents have unique session keys *)
-  let session_keys = List.map (fun id -> id.Client_identity.session_key) identities in
-  let unique_keys = List.sort_uniq String.compare session_keys in
-  check int "all keys unique" 3 (List.length unique_keys);
-  
-  (* Verify each can be found by name *)
-  List.iter (fun name ->
-    match Client_identity.Registry.find_by_name reg name with
-    | Some id -> check string "correct name" name id.agent_name
-    | None -> fail (Printf.sprintf "agent %s not found" name)
-  ) agents
+      call initialize_request |> check_protocol_success "initialize";
 
-(** Test: Capability filtering *)
-let test_capability_filtering () =
-  Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  let reg = Client_identity.Registry.create () in
-  
-  let params_with_caps = `Assoc [
-    ("_agent_name", `String "capable-agent");
-    ("_capabilities", `List [`String "code"; `String "search"; `String "file_ops"]);
-  ] in
-  let id = Client_identity.from_mcp_params params_with_caps in
-  let _ = Client_identity.Registry.register reg id in
-  
-  check bool "has code" true (Client_identity.has_capability id "code");
-  check bool "has search" true (Client_identity.has_capability id "search");
-  check bool "no admin" false (Client_identity.has_capability id "admin")
+      call
+        (tool_request ~id:2 ~name:"masc_start"
+           (`Assoc
+             [ ("path", `String base_path)
+             ; ("task_title", `String "Synthetic full-cycle proof")
+             ; ("_agent_name", `String "full-cycle-probe")
+             ]))
+      |> check_tool_success "masc_start";
 
-(** Test: Concurrent registration safety *)
-let test_concurrent_registration () =
-  Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  let reg = Client_identity.Registry.create () in
-  
-  (* Spawn multiple fibers registering agents *)
-  Eio.Fiber.all (List.init 10 (fun i () ->
-    let name = Printf.sprintf "concurrent-agent-%d" i in
-    let id = Fixtures.identity_for name in
-    let _ = Client_identity.Registry.register reg id in
-    (* Touch a few times *)
-    for _ = 1 to 5 do
-      Client_identity.Registry.touch reg id.session_key ();
-      Eio.Fiber.yield ()
-    done
-  ));
-  
-  check int "all registered" 10 (Client_identity.Registry.count reg)
+      let config = Mcp_server.workspace_config state in
+      let claimed_task = task_exn config in
+      (match claimed_task.Masc_domain.task_status with
+       | Masc_domain.Claimed { assignee; _ } ->
+         check string "task owner" "full-cycle-probe" assignee
+       | status ->
+         failf "masc_start did not claim the task: %s"
+           (Masc_domain.task_status_to_string status));
+      check (option string) "current task persisted"
+        (Some claimed_task.id)
+        (Masc.Task.Planning_eio.get_current_task config);
 
-(** Test: Session key stability across updates *)
-let test_session_key_stability () =
-  Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  let reg = Client_identity.Registry.create () in
-  
-  let id = Fixtures.identity_for "stable-agent" in
-  let original_key = id.session_key in
-  let _ = Client_identity.Registry.register reg id in
-  
-  (* Multiple touches keep the session stable. *)
-  Client_identity.Registry.touch reg original_key ();
-  
-  match Client_identity.Registry.find_by_session reg original_key with
-  | Some updated ->
-      check string "session_key unchanged" original_key updated.session_key
-  | None -> fail "identity lost"
+      call
+        (tool_request ~id:3 ~name:"masc_status"
+           (`Assoc [ ("_agent_name", `String "full-cycle-probe") ]))
+      |> check_tool_success "masc_status";
+
+      call
+        (tool_request ~id:4 ~name:"masc_transition"
+           (`Assoc
+             [ ("agent_name", `String "full-cycle-probe")
+             ; ("task_id", `String claimed_task.id)
+             ; ("action", `String "done")
+             ; ("notes", `String "Synthetic full-cycle proof completed")
+             ; ("_agent_name", `String "full-cycle-probe")
+             ]))
+      |> check_tool_success "masc_transition done";
+
+      let completed_task = task_exn config in
+      (match completed_task.Masc_domain.task_status with
+       | Masc_domain.Done { assignee; notes; _ } ->
+         check string "completion owner" "full-cycle-probe" assignee;
+         check (option string) "durable completion note"
+           (Some "Synthetic full-cycle proof completed") notes
+       | status ->
+         failf "task did not reach done: %s"
+           (Masc_domain.task_status_to_string status));
+      check (option string) "current task cleared" None
+        (Masc.Task.Planning_eio.get_current_task config))
 
 let () =
-  run "MCP Full Cycle" [
-    "identity", [
-      test_case "extraction" `Quick test_identity_extraction;
-      test_case "registry_persistence" `Quick test_identity_registry_persistence;
-      test_case "multi_agent_isolation" `Quick test_multi_agent_isolation;
-      test_case "capability_filtering" `Quick test_capability_filtering;
-    ];
-    "lifecycle", [
-      test_case "concurrent_registration" `Quick test_concurrent_registration;
-      test_case "session_key_stability" `Quick test_session_key_stability;
-    ];
-  ]
+  run "MCP one-shot full-cycle probe"
+    [ ( "protocol to durable outcome"
+      , [ test_case "initialize, start, observe, complete" `Quick
+            test_one_shot_protocol_to_durable_outcome
+        ] )
+    ]

--- a/test/test_mcp_full_cycle.ml
+++ b/test/test_mcp_full_cycle.ml
@@ -12,24 +12,6 @@ module Mcp_server = Masc.Mcp_server
 
 let () = Mirage_crypto_rng_unix.use_default ()
 
-let temp_dir () =
-  let path = Filename.temp_file "masc_full_cycle_probe_" "" in
-  Unix.unlink path;
-  Unix.mkdir path 0o755;
-  path
-
-let cleanup_dir root =
-  let rec remove path =
-    if Sys.is_directory path then begin
-      Array.iter
-        (fun name -> remove (Filename.concat path name))
-        (Sys.readdir path);
-      Unix.rmdir path
-    end else
-      Unix.unlink path
-  in
-  try remove root with Sys_error _ -> ()
-
 let request ~id ~method_ params =
   Yojson.Safe.to_string
     (`Assoc
@@ -83,6 +65,18 @@ let check_tool_success label response =
   | _ -> failf "%s omitted result.isError: %s" label
            (Yojson.Safe.to_string response)
 
+let structured_content_exn label response =
+  let fields = result_fields_exn label response in
+  match List.assoc_opt "structuredContent" fields with
+  | Some structured_content -> structured_content
+  | None ->
+    failf "%s omitted result.structuredContent: %s" label
+      (Yojson.Safe.to_string response)
+
+let status_snapshot_exn response =
+  let open Yojson.Safe.Util in
+  structured_content_exn "masc_status" response |> member "snapshot" |> to_string
+
 let task_exn config =
   match Masc.Workspace.get_tasks_raw config with
   | [ task ] -> task
@@ -95,9 +89,9 @@ let test_one_shot_protocol_to_durable_outcome () =
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
-  let base_path = temp_dir () in
+  let base_path = Filename.temp_dir "masc_full_cycle_probe_" "" in
   Fun.protect
-    ~finally:(fun () -> cleanup_dir base_path)
+    ~finally:(fun () -> Masc_test_deps.cleanup_test_workspace base_path)
     (fun () ->
       let state = Mcp_eio.For_testing.create_state ~base_path () in
       let session_id = "full-cycle-probe-session" in
@@ -128,10 +122,20 @@ let test_one_shot_protocol_to_durable_outcome () =
         (Some claimed_task.id)
         (Masc.Task.Planning_eio.get_current_task config);
 
-      call
-        (tool_request ~id:3 ~name:"masc_status"
-           (`Assoc [ ("_agent_name", `String "full-cycle-probe") ]))
-      |> check_tool_success "masc_status";
+      let status_response =
+        call (tool_request ~id:3 ~name:"masc_status" (`Assoc []))
+      in
+      check_tool_success "masc_status" status_response;
+      let expected_identity_line =
+        Printf.sprintf
+          "🧭 You: agent=full-cycle-probe | bound=yes | owned=%s | current=%s"
+          claimed_task.id
+          claimed_task.id
+      in
+      check bool "status projects session-bound identity and claimed task" true
+        (status_snapshot_exn status_response
+         |> String.split_on_char '\n'
+         |> List.exists (String.equal expected_identity_line));
 
       call
         (tool_request ~id:4 ~name:"masc_transition"
@@ -140,7 +144,6 @@ let test_one_shot_protocol_to_durable_outcome () =
              ; ("task_id", `String claimed_task.id)
              ; ("action", `String "done")
              ; ("notes", `String "Synthetic full-cycle proof completed")
-             ; ("_agent_name", `String "full-cycle-probe")
              ]))
       |> check_tool_success "masc_transition done";
 

--- a/test/test_mcp_session_task_lifecycle.ml
+++ b/test/test_mcp_session_task_lifecycle.ml
@@ -228,16 +228,24 @@ let test_task_creation_failure_remains_typed_error () =
       let backlog_path = Masc.Workspace.backlog_path config in
       Fs_compat.save_file backlog_path "{invalid-primary";
       Fs_compat.save_file (backlog_path ^ ".last-good") "{invalid-recovery";
-      call
-        (tool_request ~id:3 ~name:"masc_start"
-           (`Assoc
-             [ ("path", `String base_path)
-             ; ("task_title", `String "must not become partial success")
-             ; ("_agent_name", `String "session-task-failure")
-             ]))
-      |> check_tool_failure
-           "masc_start task creation"
-           ~failure_class:"runtime_failure")
+      let response =
+        call
+          (tool_request ~id:3 ~name:"masc_start"
+             (`Assoc
+               [ ("path", `String base_path)
+               ; ("task_title", `String "must not become partial success")
+               ; ("_agent_name", `String "session-task-failure")
+               ]))
+      in
+      check_tool_failure
+        "masc_start task creation"
+        ~failure_class:"runtime_failure"
+        response;
+      let structured = structured_content_exn "masc_start task creation" response in
+      check string "session bind is a proven post-effect" "proven_post_effect"
+        Yojson.Safe.Util.(structured |> member "effect_disposition" |> to_string);
+      check string "bound session identity is preserved" "session-task-failure"
+        Yojson.Safe.Util.(structured |> member "agent_name" |> to_string))
 
 let () =
   run "MCP session-bound Task lifecycle smoke"

--- a/test/test_mcp_session_task_lifecycle.ml
+++ b/test/test_mcp_session_task_lifecycle.ml
@@ -1,9 +1,9 @@
-(** One-shot synthetic MCP full-cycle probe.
+(** Isolated MCP session-bound Task lifecycle smoke.
 
-    This is deliberately not a Keeper. It exercises protocol admission,
-    session identity, typed tool dispatch, workspace persistence, and task
-    completion once inside an isolated workspace. It never starts a provider
-    call, heartbeat, autonomous loop, or autoboot entry. *)
+    This exercises protocol admission, session identity, typed tool dispatch,
+    workspace persistence, and Task completion once inside an isolated
+    workspace. It is not evidence for the product-level Keeper Full Lifecycle
+    contract. *)
 
 open Alcotest
 
@@ -28,9 +28,17 @@ let initialize_request =
       ; ("capabilities", `Assoc [])
       ; ( "clientInfo"
         , `Assoc
-            [ ("name", `String "masc-full-cycle-probe")
+            [ ("name", `String "masc-session-task-smoke")
             ; ("version", `String "1")
             ] )
+      ])
+
+let initialized_notification =
+  Yojson.Safe.to_string
+    (`Assoc
+      [ ("jsonrpc", `String "2.0")
+      ; ("method", `String "notifications/initialized")
+      ; ("params", `Assoc [])
       ])
 
 let tool_request ~id ~name arguments =
@@ -65,6 +73,23 @@ let check_tool_success label response =
   | _ -> failf "%s omitted result.isError: %s" label
            (Yojson.Safe.to_string response)
 
+let check_tool_failure label ~failure_class response =
+  let fields = result_fields_exn label response in
+  (match List.assoc_opt "isError" fields with
+   | Some (`Bool true) -> ()
+   | _ ->
+     failf "%s did not return an MCP tool error: %s" label
+       (Yojson.Safe.to_string response));
+  let actual_failure_class =
+    match List.assoc_opt "_meta" fields with
+    | Some (`Assoc meta_fields) ->
+      (match List.assoc_opt "failure_class" meta_fields with
+       | Some (`String value) -> value
+       | _ -> failf "%s omitted _meta.failure_class" label)
+    | _ -> failf "%s omitted result._meta" label
+  in
+  check string (label ^ " failure class") failure_class actual_failure_class
+
 let structured_content_exn label response =
   let fields = result_fields_exn label response in
   match List.assoc_opt "structuredContent" fields with
@@ -82,31 +107,37 @@ let task_exn config =
   | [ task ] -> task
   | tasks -> failf "expected one synthetic task, got %d" (List.length tasks)
 
-let test_one_shot_protocol_to_durable_outcome () =
+let test_session_task_lifecycle () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
-  let base_path = Filename.temp_dir "masc_full_cycle_probe_" "" in
+  let base_path = Filename.temp_dir "masc_session_task_smoke_" "" in
   Fun.protect
     ~finally:(fun () -> Masc_test_deps.cleanup_test_workspace base_path)
     (fun () ->
       let state = Mcp_eio.For_testing.create_state ~base_path () in
-      let session_id = "full-cycle-probe-session" in
+      let session_id = "session-task-smoke" in
       let call request =
         Mcp_eio.handle_request ~clock ~sw ~mcp_session_id:session_id state request
       in
 
       call initialize_request |> check_protocol_success "initialize";
+      (match call initialized_notification with
+       | `Null -> ()
+       | response ->
+         failf
+           "notifications/initialized was not accepted as a notification: %s"
+           (Yojson.Safe.to_string response));
 
       call
         (tool_request ~id:2 ~name:"masc_start"
            (`Assoc
              [ ("path", `String base_path)
-             ; ("task_title", `String "Synthetic full-cycle proof")
-             ; ("_agent_name", `String "full-cycle-probe")
+             ; ("task_title", `String "Synthetic MCP Task lifecycle")
+             ; ("_agent_name", `String "session-task-smoke")
              ]))
       |> check_tool_success "masc_start";
 
@@ -114,7 +145,7 @@ let test_one_shot_protocol_to_durable_outcome () =
       let claimed_task = task_exn config in
       (match claimed_task.Masc_domain.task_status with
        | Masc_domain.Claimed { assignee; _ } ->
-         check string "task owner" "full-cycle-probe" assignee
+         check string "task owner" "session-task-smoke" assignee
        | status ->
          failf "masc_start did not claim the task: %s"
            (Masc_domain.task_status_to_string status));
@@ -128,7 +159,7 @@ let test_one_shot_protocol_to_durable_outcome () =
       check_tool_success "masc_status" status_response;
       let expected_identity_line =
         Printf.sprintf
-          "🧭 You: agent=full-cycle-probe | bound=yes | owned=%s | current=%s"
+          "🧭 You: agent=session-task-smoke | bound=yes | owned=%s | current=%s"
           claimed_task.id
           claimed_task.id
       in
@@ -140,29 +171,80 @@ let test_one_shot_protocol_to_durable_outcome () =
       call
         (tool_request ~id:4 ~name:"masc_transition"
            (`Assoc
-             [ ("agent_name", `String "full-cycle-probe")
+             [ ("agent_name", `String "session-task-smoke")
              ; ("task_id", `String claimed_task.id)
              ; ("action", `String "done")
-             ; ("notes", `String "Synthetic full-cycle proof completed")
+             ; ("notes", `String "Synthetic MCP Task lifecycle completed")
              ]))
       |> check_tool_success "masc_transition done";
 
       let completed_task = task_exn config in
       (match completed_task.Masc_domain.task_status with
        | Masc_domain.Done { assignee; notes; _ } ->
-         check string "completion owner" "full-cycle-probe" assignee;
+         check string "completion owner" "session-task-smoke" assignee;
          check (option string) "durable completion note"
-           (Some "Synthetic full-cycle proof completed") notes
+           (Some "Synthetic MCP Task lifecycle completed") notes
        | status ->
          failf "task did not reach done: %s"
            (Masc_domain.task_status_to_string status));
       check (option string) "current task cleared" None
         (Masc.Task.Planning_eio.get_current_task config))
 
+let test_task_creation_failure_remains_typed_error () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Mcp_eio.set_net (Eio.Stdenv.net env);
+  Mcp_eio.set_clock (Eio.Stdenv.clock env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = Filename.temp_dir "masc_session_task_failure_" "" in
+  Fun.protect
+    ~finally:(fun () -> Masc_test_deps.cleanup_test_workspace base_path)
+    (fun () ->
+      let state = Mcp_eio.For_testing.create_state ~base_path () in
+      let call request =
+        Mcp_eio.handle_request
+          ~clock
+          ~sw
+          ~mcp_session_id:"session-task-failure"
+          state
+          request
+      in
+      call initialize_request |> check_protocol_success "initialize";
+      (match call initialized_notification with
+       | `Null -> ()
+       | response ->
+         failf
+           "notifications/initialized was not accepted as a notification: %s"
+           (Yojson.Safe.to_string response));
+      call
+        (tool_request ~id:2 ~name:"masc_start"
+           (`Assoc
+             [ ("path", `String base_path)
+             ; ("_agent_name", `String "session-task-failure")
+             ]))
+      |> check_tool_success "masc_start bootstrap";
+      let config = Mcp_server.workspace_config state in
+      let backlog_path = Masc.Workspace.backlog_path config in
+      Fs_compat.save_file backlog_path "{invalid-primary";
+      Fs_compat.save_file (backlog_path ^ ".last-good") "{invalid-recovery";
+      call
+        (tool_request ~id:3 ~name:"masc_start"
+           (`Assoc
+             [ ("path", `String base_path)
+             ; ("task_title", `String "must not become partial success")
+             ; ("_agent_name", `String "session-task-failure")
+             ]))
+      |> check_tool_failure
+           "masc_start task creation"
+           ~failure_class:"runtime_failure")
+
 let () =
-  run "MCP one-shot full-cycle probe"
+  run "MCP session-bound Task lifecycle smoke"
     [ ( "protocol to durable outcome"
-      , [ test_case "initialize, start, observe, complete" `Quick
-            test_one_shot_protocol_to_durable_outcome
+      , [ test_case "handshake, start, observe, complete" `Quick
+            test_session_task_lifecycle
+        ; test_case "task creation failure stays an error" `Quick
+            test_task_creation_failure_remains_typed_error
         ] )
     ]


### PR DESCRIPTION
## Summary
- pass the admitted `Workspace.config` through Keeper prompt construction instead of resolving a second default config
- make `masc_start` consume the typed task-creation result; task creation failure cannot become partial success
- narrow the isolated MCP test to a session-bound Task lifecycle smoke with the complete initialize/initialized handshake
- keep product Full Lifecycle truth at `docs/product/KEEPER-FULL-LIFECYCLE-BEHAVIOR.md` §5

## Runtime evidence
- the former live `full-cycle-probe` lane was disabled and stopped through the dashboard CanAdmin API
- historical failure stack: `Workspace_utils_backend_setup.with_default_config_cache_mutex -> Keeper_unified_prompt.build_system_prompt`

## Verification
- `ocamlformat --check`: pass
- `ocamlc -stop-after parsing`: pass
- `git diff --check`: pass
- exact head `e1012b606f50c70710bf3e6958cf94e26c451fba` CI: pending

Known pre-existing prompt fixture failures are tracked separately in #26733.