### PR TITLE
fix(keeper): quarantine orphan durable queue owners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -954,7 +954,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          quarantine_targets="@test/runtest-test_keeper_event_queue_orphan_quarantine @test/runtest-test_server_runtime_bootstrap"
+          quarantine_targets="@test/runtest-test_keeper_event_queue_orphan_quarantine"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${quarantine_targets}"
 
       - name: Run tool blob retention suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -940,6 +940,23 @@ jobs:
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
           scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_registry_hardening"
+
+      # Durable owner quarantine moves a full runtime directory and rechecks
+      # exact owner authority under the owner lock. Compile-only coverage does
+      # not prove either filesystem effects or the repeated-name convergence.
+      - name: Run durable owner quarantine suites
+        id: durable_owner_quarantine_suites
+        if: ${{ always() && steps.build_step.outcome == 'success' }}
+        env:
+          ME_ROOT: /tmp/me
+          CI_TEST_HEARTBEAT_SEC: 15
+          DUNE_JOBS: 1
+        run: |
+          mkdir -p /tmp/me
+          chmod +x scripts/ci-run-tests.sh
+          quarantine_targets="@test/runtest-test_keeper_event_queue_orphan_quarantine @test/runtest-test_server_runtime_bootstrap"
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . ${quarantine_targets}"
+
       - name: Run tool blob retention suite
         id: tool_blob_retention_suite
         if: ${{ always() && steps.build_step.outcome == 'success' }}

--- a/lib/config_dir_resolver/config_dir_resolver.ml
+++ b/lib/config_dir_resolver/config_dir_resolver.ml
@@ -461,10 +461,11 @@ let keeper_toml_path_opt name =
   let path = Filename.concat (keepers_dir ()) (name ^ ".toml") in
   if existing_file path then Some path else None
 
+let keeper_toml_path_for_base_path ~base_path name =
+  Filename.concat (keepers_dir_for_base_path ~base_path) (name ^ ".toml")
+
 let keeper_toml_path_opt_for_base_path ~base_path name =
-  let path =
-    Filename.concat (keepers_dir_for_base_path ~base_path) (name ^ ".toml")
-  in
+  let path = keeper_toml_path_for_base_path ~base_path name in
   if existing_file path then Some path else None
 
 let warnings () =

--- a/lib/config_dir_resolver/config_dir_resolver.mli
+++ b/lib/config_dir_resolver/config_dir_resolver.mli
@@ -102,6 +102,11 @@ val keepers_dir_for_base_path : base_path:string -> string
 (** [keepers_dir_for_base_path ~base_path] returns the keepers directory for an
     explicit workspace base path. *)
 
+val keeper_toml_path_for_base_path :
+  base_path:string -> string -> string
+(** Exact base-path-scoped Keeper TOML path. This does not collapse missing,
+    invalid, or inaccessible paths into [None]. *)
+
 val keeper_runtime_store_of_dirname : string -> Common.keeper_runtime_store option
 (** Base-path-independent resolver for canonical child-store names under
     [Common.keepers_runtime_dirname]. *)

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -1612,6 +1612,8 @@ let fsync_parent_directory dir =
     (fun () -> Unix.fsync fd)
 ;;
 
+let fsync_directory = fsync_parent_directory
+
 let rec lock_whole_file fd =
   match Unix.lockf fd Unix.F_LOCK 0 with
   | () -> ()

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -126,6 +126,11 @@ val execution_context : unit -> execution_context
 (** Actual execution context of the current caller. Process-global filesystem
     installation does not imply that a raw Domain has an Eio effect handler. *)
 
+(** Open, fsync, and close one directory. This is a blocking Unix primitive;
+    callers in an Eio fiber must invoke it from an existing system-thread I/O
+    boundary. Filesystems that reject directory fsync raise explicitly. *)
+val fsync_directory : string -> unit
+
 type exact_path_kind =
   | Exact_missing
   | Exact_kind of Unix.file_kind

--- a/lib/keeper/keeper_turn_up_config_persistence.ml
+++ b/lib/keeper/keeper_turn_up_config_persistence.ml
@@ -88,19 +88,23 @@ let persist ~(config : Workspace.config)
   in
   let path = Filename.concat keepers_dir (meta.name ^ ".toml") in
   let result =
-    if Fs_compat.file_exists path
-    then
-      let edits = explicit_edits parsed in
-      if edits = []
-      then Ok { path; created = false }
-      else
-        Keeper_toml_loader.edit_keeper_toml_fields ~path edits
-        |> Result.map (fun () -> { path; created = false })
-    else
-      Keeper_toml_loader.create_keeper_toml_file
-        ~path
-        (full_fields parsed meta)
-      |> Result.map (fun () -> { path; created = true })
+    Keeper_lifecycle_reservation.with_key_lock
+      ~base_path:config.base_path
+      ~keeper_name:meta.name
+      (fun () ->
+         if Fs_compat.file_exists path
+         then
+           let edits = explicit_edits parsed in
+           if edits = []
+           then Ok { path; created = false }
+           else
+             Keeper_toml_loader.edit_keeper_toml_fields ~path edits
+             |> Result.map (fun () -> { path; created = false })
+         else
+           Keeper_toml_loader.create_keeper_toml_file
+             ~path
+             (full_fields parsed meta)
+           |> Result.map (fun () -> { path; created = true }))
   in
   Result.map
     (fun outcome ->

--- a/lib/keeper_runtime/dune
+++ b/lib/keeper_runtime/dune
@@ -44,6 +44,7 @@
   masc_config
   masc_log
   masc_process
+  masc_random_id
   digestif
   str
   time_compat

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -473,6 +473,7 @@ type orphan_quarantine_result =
       ; detail : string
       }
   | Orphan_snapshot_absent
+  | Orphan_pending_delivery_retained
   | Orphan_owner_reappeared
 
 let exact_path_kind_result path =
@@ -516,6 +517,7 @@ let quarantine_orphaned_owner_unlocked owner ~confirm_owner_presence =
   let keeper_name = keeper_name_of_owner owner in
   let owner_dir = keeper_runtime_dir_of_owner owner in
   let snapshot_path = snapshot_path_of_owner owner in
+  let transition_wal_path = transition_wal_path_of_owner owner in
   let keepers_dir = Filename.dirname owner_dir in
   let quarantine_root =
     Filename.concat keepers_dir ".orphaned-event-queues"
@@ -530,6 +532,10 @@ let quarantine_orphaned_owner_unlocked owner ~confirm_owner_presence =
   if not snapshot_exists
   then Ok Orphan_snapshot_absent
   else
+    let* state = load_state_unlocked owner in
+    if not (Keeper_event_queue.is_empty (State.pending state))
+    then Ok Orphan_pending_delivery_retained
+    else
     let* () = require_directory owner_dir in
     let* () =
       try
@@ -557,31 +563,122 @@ let quarantine_orphaned_owner_unlocked owner ~confirm_owner_presence =
       match owner_presence with
       | Orphan_owner_present -> Ok Orphan_owner_reappeared
       | Orphan_owner_absent ->
-        let renamed = ref false in
-        let restore_active_owner () =
-          try
-            Fs_compat.rename quarantine_path owner_dir;
-            renamed := false;
-            Fs_compat.fsync_directory quarantine_root;
-            Fs_compat.fsync_directory keepers_dir;
-            Ok ()
-          with
-          | Eio.Cancel.Cancelled _ as exn -> raise exn
-          | exn ->
-            Error
-              (Printf.sprintf
-                 "failed to restore active event queue owner source=%s target=%s: %s"
-                 quarantine_path
-                 owner_dir
-                 (Printexc.to_string exn))
+        let quarantine_created = ref false in
+        let moved_files = ref [] in
+        let remove_empty_quarantine () =
+          if !quarantine_created
+          then (
+            Unix.rmdir quarantine_path;
+            quarantine_created := false)
         in
-        (try
-           Fs_compat.rename owner_dir quarantine_path;
-           renamed := true;
+        let move_if_present source filename =
+          let* exists = path_exists_result source in
+          if not exists
+          then Ok ()
+          else
+            let target = Filename.concat quarantine_path filename in
+            try
+              Fs_compat.rename source target;
+              moved_files := (source, target) :: !moved_files;
+              Ok ()
+            with
+            | Eio.Cancel.Cancelled _ as exn -> raise exn
+            | exn ->
+              Error
+                (Printf.sprintf
+                   "failed to move event queue file source=%s target=%s: %s"
+                   source
+                   target
+                   (Printexc.to_string exn))
+        in
+        let restore_active_files () =
+          let restore_one (source, target) =
+            match path_exists_result source with
+            | Error _ as error -> error
+            | Ok true ->
+              Error
+                (Printf.sprintf
+                   "refusing to overwrite active event queue file during restore: %s"
+                   source)
+            | Ok false ->
+              (try
+                 Fs_compat.rename target source;
+                 Ok ()
+               with
+               | Eio.Cancel.Cancelled _ as exn -> raise exn
+               | exn ->
+                 Error
+                   (Printf.sprintf
+                      "failed to restore active event queue file source=%s target=%s: %s"
+                      target
+                      source
+                      (Printexc.to_string exn)))
+          in
+          let rec restore = function
+            | [] -> Ok ()
+            | move :: rest ->
+              let* () = restore_one move in
+              restore rest
+          in
+          let* () = restore !moved_files in
+          moved_files := [];
+          (try
+             remove_empty_quarantine ();
+             Fs_compat.fsync_directory owner_dir;
+             Fs_compat.fsync_directory quarantine_root;
+             Fs_compat.fsync_directory keepers_dir;
+             Ok ()
+           with
+           | Eio.Cancel.Cancelled _ as exn -> raise exn
+           | exn ->
+             Error
+               (Printf.sprintf
+                  "failed to finalize restored event queue files keeper=%s: %s"
+                  keeper_name
+                  (Printexc.to_string exn)))
+        in
+        let restore_or_append detail =
+          match restore_active_files () with
+          | Ok () -> Error detail
+          | Error restore_detail ->
+            Error (Printf.sprintf "%s; %s" detail restore_detail)
+        in
+        let move_queue_files () =
+          let* () =
+            try
+              Fs_compat.mkdir_p quarantine_path;
+              quarantine_created := true;
+              require_directory quarantine_path
+            with
+            | Eio.Cancel.Cancelled _ as exn -> raise exn
+            | exn ->
+              Error
+                (Printf.sprintf
+                   "failed to create event queue quarantine generation path=%s: %s"
+                   quarantine_path
+                   (Printexc.to_string exn))
+          in
+          let* () = move_if_present snapshot_path snapshot_filename in
+          move_if_present transition_wal_path transition_wal_filename
+        in
+        (match
+           try move_queue_files () with
+           | Eio.Cancel.Cancelled _ as exn ->
+             (match restore_active_files () with
+              | Ok () | Error _ -> raise exn)
+           | exn -> Error (Printexc.to_string exn)
+         with
+         | Error detail ->
+           if !moved_files = []
+           then (
+             (try remove_empty_quarantine () with _ -> ());
+             Error detail)
+           else restore_or_append detail
+         | Ok () ->
            let post_confirmation =
              try confirm_owner_presence () with
              | Eio.Cancel.Cancelled _ as exn ->
-               (match restore_active_owner () with
+               (match restore_active_files () with
                 | Ok () -> raise exn
                 | Error detail ->
                   Log.Keeper.error
@@ -598,40 +695,35 @@ let quarantine_orphaned_owner_unlocked owner ~confirm_owner_presence =
            in
            (match post_confirmation with
             | Ok Orphan_owner_present ->
-              (match restore_active_owner () with
+              (match restore_active_files () with
                | Ok () -> Ok Orphan_owner_reappeared
                | Error detail -> Error detail)
             | Error detail ->
-              (match restore_active_owner () with
-               | Ok () ->
-                 Error
-                   (Printf.sprintf
-                      "event queue owner confirmation failed after quarantine rename keeper=%s: %s"
-                      keeper_name
-                      detail)
-               | Error restore_detail ->
-                 Error (Printf.sprintf "%s; %s" detail restore_detail))
+              restore_or_append
+                (Printf.sprintf
+                   "event queue owner confirmation failed after quarantine move keeper=%s: %s"
+                   keeper_name
+                   detail)
             | Ok Orphan_owner_absent ->
-              Fs_compat.fsync_directory quarantine_root;
-              Fs_compat.fsync_directory keepers_dir;
-              Ok (Orphan_quarantined { quarantine_path }))
-         with
-         | Eio.Cancel.Cancelled _ as exn -> raise exn
-         | exn ->
-           let detail =
-             Printf.sprintf
-               "event queue orphan quarantine failed keeper=%s source=%s target=%s: %s"
-               keeper_name
-               owner_dir
-               quarantine_path
-               (Printexc.to_string exn)
-           in
-           if !renamed
-           then
-             Ok
-               (Orphan_quarantine_visible_sync_unconfirmed
-                  { quarantine_path; detail })
-           else Error detail)
+              (try
+                 Fs_compat.fsync_directory quarantine_path;
+                 Fs_compat.fsync_directory owner_dir;
+                 Fs_compat.fsync_directory quarantine_root;
+                 Fs_compat.fsync_directory keepers_dir;
+                 Ok (Orphan_quarantined { quarantine_path })
+               with
+               | Eio.Cancel.Cancelled _ as exn -> raise exn
+               | exn ->
+                 let detail =
+                   Printf.sprintf
+                     "event queue orphan quarantine visible but sync unconfirmed keeper=%s path=%s: %s"
+                     keeper_name
+                     quarantine_path
+                     (Printexc.to_string exn)
+                 in
+                 Ok
+                   (Orphan_quarantine_visible_sync_unconfirmed
+                      { quarantine_path; detail }))))
 ;;
 
 let quarantine_orphaned_owner_result

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -518,7 +518,11 @@ let quarantine_orphaned_owner_unlocked owner ~confirm_owner_presence =
   let quarantine_root =
     Filename.concat keepers_dir ".orphaned-event-queues"
   in
-  let quarantine_path = Filename.concat quarantine_root keeper_name in
+  let quarantine_path =
+    Filename.concat
+      quarantine_root
+      (Printf.sprintf "%s-%s" keeper_name (Random_id.uuid_v7 ()))
+  in
   let ( let* ) = Result.bind in
   let* snapshot_exists = path_exists_result snapshot_path in
   if not snapshot_exists

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -475,25 +475,10 @@ type orphan_quarantine_result =
   | Orphan_snapshot_absent
   | Orphan_owner_reappeared
 
-let require_directory path =
-  match Unix.lstat path with
-  | { Unix.st_kind = Unix.S_DIR; _ } -> Ok ()
-  | _ -> Error (Printf.sprintf "event queue quarantine path is not a directory: %s" path)
-  | exception Unix.Unix_error (error, operation, argument) ->
-    Error
-      (Printf.sprintf
-         "failed to inspect event queue quarantine directory path=%s operation=%s argument=%s: %s"
-         path
-         operation
-         argument
-         (Unix.error_message error))
-;;
-
-let path_exists_result path =
-  match Unix.lstat path with
-  | _ -> Ok true
-  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> Ok false
-  | exception Unix.Unix_error (error, operation, argument) ->
+let exact_path_kind_result path =
+  try Ok (Fs_compat.exact_path_kind ~follow:false path) with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | Unix.Unix_error (error, operation, argument) ->
     Error
       (Printf.sprintf
          "failed to inspect event queue quarantine path=%s operation=%s argument=%s: %s"
@@ -501,6 +486,30 @@ let path_exists_result path =
          operation
          argument
          (Unix.error_message error))
+  | Sys_error detail ->
+    Error
+      (Printf.sprintf
+         "failed to inspect event queue quarantine path=%s: %s"
+         path
+         detail)
+;;
+
+let require_directory path =
+  match exact_path_kind_result path with
+  | Ok (Fs_compat.Exact_kind Unix.S_DIR) -> Ok ()
+  | Ok
+      ( Fs_compat.Exact_missing
+      | Fs_compat.Exact_kind _
+      | Fs_compat.Exact_unknown ) ->
+    Error (Printf.sprintf "event queue quarantine path is not a directory: %s" path)
+  | Error _ as error -> error
+;;
+
+let path_exists_result path =
+  match exact_path_kind_result path with
+  | Ok Fs_compat.Exact_missing -> Ok false
+  | Ok (Fs_compat.Exact_kind _ | Fs_compat.Exact_unknown) -> Ok true
+  | Error _ as error -> error
 ;;
 
 let quarantine_orphaned_owner_unlocked owner ~confirm_owner_presence =

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -549,12 +549,58 @@ let quarantine_orphaned_owner_unlocked owner ~confirm_owner_presence =
       | Orphan_owner_present -> Ok Orphan_owner_reappeared
       | Orphan_owner_absent ->
         let renamed = ref false in
+        let restore_active_owner () =
+          try
+            Unix.rename quarantine_path owner_dir;
+            renamed := false;
+            Fs_compat.fsync_directory quarantine_root;
+            Fs_compat.fsync_directory keepers_dir;
+            Ok ()
+          with
+          | Eio.Cancel.Cancelled _ as exn -> raise exn
+          | exn ->
+            Error
+              (Printf.sprintf
+                 "failed to restore active event queue owner source=%s target=%s: %s"
+                 quarantine_path
+                 owner_dir
+                 (Printexc.to_string exn))
+        in
         (try
            Unix.rename owner_dir quarantine_path;
            renamed := true;
-           Fs_compat.fsync_directory quarantine_root;
-           Fs_compat.fsync_directory keepers_dir;
-           Ok (Orphan_quarantined { quarantine_path })
+           let post_confirmation =
+             try confirm_owner_presence () with
+             | Eio.Cancel.Cancelled _ as exn ->
+               (match restore_active_owner () with
+                | Ok () -> raise exn
+                | Error detail -> failwith detail)
+             | exn ->
+               Error
+                 (Printf.sprintf
+                    "event queue owner confirmation raised after quarantine rename keeper=%s: %s"
+                    keeper_name
+                    (Printexc.to_string exn))
+           in
+           (match post_confirmation with
+            | Ok Orphan_owner_present ->
+              (match restore_active_owner () with
+               | Ok () -> Ok Orphan_owner_reappeared
+               | Error detail -> Error detail)
+            | Error detail ->
+              (match restore_active_owner () with
+               | Ok () ->
+                 Error
+                   (Printf.sprintf
+                      "event queue owner confirmation failed after quarantine rename keeper=%s: %s"
+                      keeper_name
+                      detail)
+               | Error restore_detail ->
+                 Error (Printf.sprintf "%s; %s" detail restore_detail))
+            | Ok Orphan_owner_absent ->
+              Fs_compat.fsync_directory quarantine_root;
+              Fs_compat.fsync_directory keepers_dir;
+              Ok (Orphan_quarantined { quarantine_path }))
          with
          | Eio.Cancel.Cancelled _ as exn -> raise exn
          | exn ->

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -462,6 +462,143 @@ let load_state_result ~base_path ~keeper_name =
             (Printexc.to_string exn)))
 ;;
 
+type orphan_owner_presence =
+  | Orphan_owner_absent
+  | Orphan_owner_present
+
+type orphan_quarantine_result =
+  | Orphan_quarantined of { quarantine_path : string }
+  | Orphan_quarantine_visible_sync_unconfirmed of
+      { quarantine_path : string
+      ; detail : string
+      }
+  | Orphan_snapshot_absent
+  | Orphan_owner_reappeared
+
+let fsync_directory path =
+  let fd = Unix.openfile path [ Unix.O_RDONLY; Unix.O_CLOEXEC ] 0 in
+  Fun.protect
+    ~finally:(fun () -> Unix.close fd)
+    (fun () -> Unix.fsync fd)
+;;
+
+let require_directory path =
+  match Unix.lstat path with
+  | { Unix.st_kind = Unix.S_DIR; _ } -> Ok ()
+  | _ -> Error (Printf.sprintf "event queue quarantine path is not a directory: %s" path)
+  | exception Unix.Unix_error (error, operation, argument) ->
+    Error
+      (Printf.sprintf
+         "failed to inspect event queue quarantine directory path=%s operation=%s argument=%s: %s"
+         path
+         operation
+         argument
+         (Unix.error_message error))
+;;
+
+let path_exists_result path =
+  match Unix.lstat path with
+  | _ -> Ok true
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> Ok false
+  | exception Unix.Unix_error (error, operation, argument) ->
+    Error
+      (Printf.sprintf
+         "failed to inspect event queue quarantine path=%s operation=%s argument=%s: %s"
+         path
+         operation
+         argument
+         (Unix.error_message error))
+;;
+
+let quarantine_orphaned_owner_unlocked owner ~confirm_owner_presence =
+  let keeper_name = keeper_name_of_owner owner in
+  let owner_dir = keeper_runtime_dir_of_owner owner in
+  let snapshot_path = snapshot_path_of_owner owner in
+  let keepers_dir = Filename.dirname owner_dir in
+  let quarantine_root =
+    Filename.concat keepers_dir ".orphaned-event-queues"
+  in
+  let quarantine_path = Filename.concat quarantine_root keeper_name in
+  let ( let* ) = Result.bind in
+  let* snapshot_exists = path_exists_result snapshot_path in
+  if not snapshot_exists
+  then Ok Orphan_snapshot_absent
+  else
+    let* () = require_directory owner_dir in
+    let* () =
+      try
+        Fs_compat.mkdir_p quarantine_root;
+        require_directory quarantine_root
+      with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | exn ->
+        Error
+          (Printf.sprintf
+             "failed to prepare event queue quarantine root path=%s: %s"
+             quarantine_root
+             (Printexc.to_string exn))
+    in
+    let* quarantine_exists = path_exists_result quarantine_path in
+    if quarantine_exists
+    then
+      Error
+        (Printf.sprintf
+           "event queue quarantine already exists; refusing to overwrite keeper=%s path=%s"
+           keeper_name
+           quarantine_path)
+    else
+      let* owner_presence = confirm_owner_presence () in
+      match owner_presence with
+      | Orphan_owner_present -> Ok Orphan_owner_reappeared
+      | Orphan_owner_absent ->
+        let renamed = ref false in
+        (try
+           Unix.rename owner_dir quarantine_path;
+           renamed := true;
+           fsync_directory quarantine_root;
+           fsync_directory keepers_dir;
+           Ok (Orphan_quarantined { quarantine_path })
+         with
+         | Eio.Cancel.Cancelled _ as exn -> raise exn
+         | exn ->
+           let detail =
+             Printf.sprintf
+               "event queue orphan quarantine failed keeper=%s source=%s target=%s: %s"
+               keeper_name
+               owner_dir
+               quarantine_path
+               (Printexc.to_string exn)
+           in
+           if !renamed
+           then
+             Ok
+               (Orphan_quarantine_visible_sync_unconfirmed
+                  { quarantine_path; detail })
+           else Error detail)
+;;
+
+let quarantine_orphaned_owner_result
+      ~base_path
+      ~keeper_name
+      ~confirm_owner_presence
+  =
+  match resolve_owner ~base_path ~keeper_name with
+  | Error _ as error -> error
+  | Ok owner ->
+    (try
+       Owner_lock.with_durable_lock owner (fun () ->
+         quarantine_orphaned_owner_unlocked owner ~confirm_owner_presence)
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Error
+         (Printf.sprintf
+            "event queue orphan quarantine raised keeper=%s path=%s: %s"
+            (keeper_name_of_owner owner)
+            (snapshot_path_of_owner owner)
+            (Printexc.to_string exn)))
+;;
+
 
 let queue_of_stimuli stimuli =
   List.fold_left Keeper_event_queue.enqueue Keeper_event_queue.empty stimuli

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -551,7 +551,7 @@ let quarantine_orphaned_owner_unlocked owner ~confirm_owner_presence =
         let renamed = ref false in
         let restore_active_owner () =
           try
-            Unix.rename quarantine_path owner_dir;
+            Fs_compat.rename quarantine_path owner_dir;
             renamed := false;
             Fs_compat.fsync_directory quarantine_root;
             Fs_compat.fsync_directory keepers_dir;
@@ -567,14 +567,19 @@ let quarantine_orphaned_owner_unlocked owner ~confirm_owner_presence =
                  (Printexc.to_string exn))
         in
         (try
-           Unix.rename owner_dir quarantine_path;
+           Fs_compat.rename owner_dir quarantine_path;
            renamed := true;
            let post_confirmation =
              try confirm_owner_presence () with
              | Eio.Cancel.Cancelled _ as exn ->
                (match restore_active_owner () with
                 | Ok () -> raise exn
-                | Error detail -> failwith detail)
+                | Error detail ->
+                  Log.Keeper.error
+                    "failed to restore active event queue owner during cancellation keeper=%s detail=%s"
+                    keeper_name
+                    detail;
+                  raise exn)
              | exn ->
                Error
                  (Printf.sprintf

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -475,13 +475,6 @@ type orphan_quarantine_result =
   | Orphan_snapshot_absent
   | Orphan_owner_reappeared
 
-let fsync_directory path =
-  let fd = Unix.openfile path [ Unix.O_RDONLY; Unix.O_CLOEXEC ] 0 in
-  Fun.protect
-    ~finally:(fun () -> Unix.close fd)
-    (fun () -> Unix.fsync fd)
-;;
-
 let require_directory path =
   match Unix.lstat path with
   | { Unix.st_kind = Unix.S_DIR; _ } -> Ok ()
@@ -559,8 +552,8 @@ let quarantine_orphaned_owner_unlocked owner ~confirm_owner_presence =
         (try
            Unix.rename owner_dir quarantine_path;
            renamed := true;
-           fsync_directory quarantine_root;
-           fsync_directory keepers_dir;
+           Fs_compat.fsync_directory quarantine_root;
+           Fs_compat.fsync_directory keepers_dir;
            Ok (Orphan_quarantined { quarantine_path })
          with
          | Eio.Cancel.Cancelled _ as exn -> raise exn

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -174,9 +174,11 @@ val quarantine_orphaned_owner_result :
   confirm_owner_presence:(unit -> (orphan_owner_presence, string) result) ->
   (orphan_quarantine_result, string) result
 (** Move one exact owner runtime directory out of active event-queue discovery
-    after [confirm_owner_presence] rechecks, under the same durable owner lock,
-    that no registry, metadata, or declarative config authority exists. The
-    snapshot, transition WAL, and sibling runtime evidence move together into
+    after [confirm_owner_presence] verifies before and after the rename, under
+    the same durable owner lock, that no registry, metadata, or declarative
+    config authority exists. A concurrently reappearing owner restores the
+    runtime directory before returning [Orphan_owner_reappeared]. The snapshot,
+    transition WAL, and sibling runtime evidence move together into
     [.masc/keepers/.orphaned-event-queues/<keeper>-<operation-uuid>]. A fresh
     UUID permits a later orphan generation with the same Keeper name to
     converge without overwriting earlier evidence. Both source and target

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -177,8 +177,10 @@ val quarantine_orphaned_owner_result :
     after [confirm_owner_presence] rechecks, under the same durable owner lock,
     that no registry, metadata, or declarative config authority exists. The
     snapshot, transition WAL, and sibling runtime evidence move together into
-    [.masc/keepers/.orphaned-event-queues/<keeper>]. Both source and target
-    parents are fsynced. Existing quarantine data is never overwritten. *)
+    [.masc/keepers/.orphaned-event-queues/<keeper>-<operation-uuid>]. A fresh
+    UUID permits a later orphan generation with the same Keeper name to
+    converge without overwriting earlier evidence. Both source and target
+    parents are fsynced. *)
 
 val cancel_pending_accepted_result :
   ?after_commit:(Keeper_event_queue.t -> unit) ->

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -155,6 +155,31 @@ val load_state_result :
     unprojected source-bearing row remains authoritative until the reaction
     projector records and retires it. *)
 
+type orphan_owner_presence =
+  | Orphan_owner_absent
+  | Orphan_owner_present
+
+type orphan_quarantine_result =
+  | Orphan_quarantined of { quarantine_path : string }
+  | Orphan_quarantine_visible_sync_unconfirmed of
+      { quarantine_path : string
+      ; detail : string
+      }
+  | Orphan_snapshot_absent
+  | Orphan_owner_reappeared
+
+val quarantine_orphaned_owner_result :
+  base_path:string ->
+  keeper_name:string ->
+  confirm_owner_presence:(unit -> (orphan_owner_presence, string) result) ->
+  (orphan_quarantine_result, string) result
+(** Move one exact owner runtime directory out of active event-queue discovery
+    after [confirm_owner_presence] rechecks, under the same durable owner lock,
+    that no registry, metadata, or declarative config authority exists. The
+    snapshot, transition WAL, and sibling runtime evidence move together into
+    [.masc/keepers/.orphaned-event-queues/<keeper>]. Both source and target
+    parents are fsynced. Existing quarantine data is never overwritten. *)
+
 val cancel_pending_accepted_result :
   ?after_commit:(Keeper_event_queue.t -> unit) ->
   base_path:string ->

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -166,6 +166,7 @@ type orphan_quarantine_result =
       ; detail : string
       }
   | Orphan_snapshot_absent
+  | Orphan_pending_delivery_retained
   | Orphan_owner_reappeared
 
 val quarantine_orphaned_owner_result :
@@ -173,16 +174,20 @@ val quarantine_orphaned_owner_result :
   keeper_name:string ->
   confirm_owner_presence:(unit -> (orphan_owner_presence, string) result) ->
   (orphan_quarantine_result, string) result
-(** Move one exact owner runtime directory out of active event-queue discovery
+(** Move one exact owner's event-queue snapshot and transition WAL out of
+    active event-queue discovery
     after [confirm_owner_presence] verifies before and after the rename, under
     the same durable owner lock, that no registry, metadata, or declarative
     config authority exists. A concurrently reappearing owner restores the
-    runtime directory before returning [Orphan_owner_reappeared]. The snapshot,
-    transition WAL, and sibling runtime evidence move together into
+    event-queue files before returning [Orphan_owner_reappeared]. Pending
+    delivery is never quarantined: it is the public pre-registration replay
+    contract and returns [Orphan_pending_delivery_retained]. The snapshot and
+    transition WAL move together into
     [.masc/keepers/.orphaned-event-queues/<keeper>-<operation-uuid>]. A fresh
     UUID permits a later orphan generation with the same Keeper name to
-    converge without overwriting earlier evidence. Both source and target
-    parents are fsynced. *)
+    converge without overwriting earlier evidence. Sibling runtime stores stay
+    in the active owner directory under their own locks. Source and target
+    directories are fsynced. *)
 
 val cancel_pending_accepted_result :
   ?after_commit:(Keeper_event_queue.t -> unit) ->

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -147,7 +147,81 @@ let owner_has_durable_demand state =
   || Keeper_event_queue_state.transition_outbox state <> []
 ;;
 
-let load_durable_demand_meta ~base_path ~config ~keeper_name =
+type exact_durable_owner =
+  | Exact_owner of Keeper_meta_contract.keeper_meta
+  | Exact_owner_not_materialized
+  | Exact_owner_absent
+
+let exact_keeper_config_declared_result
+      (config : Workspace.config)
+      keeper_name
+  =
+  let keepers_dir =
+    Config_dir_resolver.keepers_dir_for_base_path
+      ~base_path:config.base_path
+  in
+  let expected_file = keeper_name ^ ".toml" in
+  match Unix.lstat keepers_dir with
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> Ok false
+  | exception Unix.Unix_error (error, operation, argument) ->
+    Error
+      (Printf.sprintf
+         "failed to inspect Keeper config directory path=%s operation=%s argument=%s: %s"
+         keepers_dir
+         operation
+         argument
+         (Unix.error_message error))
+  | { Unix.st_kind = Unix.S_DIR; _ } ->
+    (match Safe_ops.list_dir_safe keepers_dir with
+     | Error detail ->
+       Error
+         (Printf.sprintf
+            "failed to list Keeper config directory path=%s: %s"
+            keepers_dir
+            detail)
+     | Ok files -> Ok (List.exists (String.equal expected_file) files))
+  | _ ->
+    Error
+      (Printf.sprintf
+         "Keeper config path is not a directory: %s"
+         keepers_dir)
+;;
+
+let exact_durable_owner_result config keeper_name =
+  match Keeper_registry.get ~base_path:config.Workspace.base_path keeper_name with
+  | Some entry when String.equal entry.meta.name keeper_name ->
+    Ok (Exact_owner entry.meta)
+  | Some entry ->
+    Error
+      (Printf.sprintf
+         "registry Keeper identity mismatch lookup=%s meta.name=%s"
+         keeper_name
+         entry.meta.name)
+  | None ->
+    (match Keeper_meta_store.read_effective_meta config keeper_name with
+     | Error _ as error -> error
+     | Ok (Some meta) when String.equal meta.name keeper_name ->
+       Ok (Exact_owner meta)
+     | Ok (Some meta) ->
+       Error
+         (Printf.sprintf
+            "persisted Keeper identity mismatch path_owner=%s meta.name=%s"
+            keeper_name
+            meta.name)
+     | Ok None ->
+       (match exact_keeper_config_declared_result config keeper_name with
+        | Error _ as error -> error
+        | Ok true -> Ok Exact_owner_not_materialized
+        | Ok false -> Ok Exact_owner_absent))
+;;
+
+type durable_demand_owner =
+  | No_durable_demand
+  | Durable_owner of Keeper_meta_contract.keeper_meta
+  | Durable_owner_not_materialized
+  | Durable_owner_absent
+
+let load_durable_demand_owner ~base_path ~config ~keeper_name =
   match
     Executor_pool_ref.submit_strict (fun () ->
       match
@@ -156,17 +230,46 @@ let load_durable_demand_meta ~base_path ~config ~keeper_name =
           ~keeper_name
       with
       | Error detail -> Error (`Demand_unknown detail)
-      | Ok state when not (owner_has_durable_demand state) -> Ok None
+      | Ok state when not (owner_has_durable_demand state) ->
+        Ok No_durable_demand
       | Ok _state ->
-        (match Keeper_meta_store.read_effective_meta config keeper_name with
+        (match exact_durable_owner_result config keeper_name with
          | Error detail -> Error (`Owner_unknown detail)
-         | Ok None -> Error (`Owner_unknown "durable_keeper_metadata_missing")
-         | Ok (Some meta) -> Ok (Some meta)))
+         | Ok (Exact_owner meta) -> Ok (Durable_owner meta)
+         | Ok Exact_owner_not_materialized ->
+           Ok Durable_owner_not_materialized
+         | Ok Exact_owner_absent -> Ok Durable_owner_absent))
   with
   | Ok outcome -> outcome
   | Error (Executor_pool_ref.Work_failed failure) ->
     Error (`Demand_execution_failed failure)
   | Error error -> Error (`Executor_unavailable error)
+;;
+
+type orphan_quarantine_attempt_error =
+  | Quarantine_failed of string
+  | Quarantine_executor_unavailable of Executor_pool_ref.strict_submit_error
+  | Quarantine_execution_failed of exn * Printexc.raw_backtrace
+
+let quarantine_absent_durable_owner ~base_path ~config ~keeper_name =
+  match
+    Executor_pool_ref.submit_strict (fun () ->
+      Keeper_event_queue_persistence.quarantine_orphaned_owner_result
+        ~base_path
+        ~keeper_name
+        ~confirm_owner_presence:(fun () ->
+          match exact_durable_owner_result config keeper_name with
+          | Error _ as error -> error
+          | Ok (Exact_owner _ | Exact_owner_not_materialized) ->
+            Ok Keeper_event_queue_persistence.Orphan_owner_present
+          | Ok Exact_owner_absent ->
+            Ok Keeper_event_queue_persistence.Orphan_owner_absent))
+  with
+  | Ok (Ok outcome) -> Ok outcome
+  | Ok (Error detail) -> Error (Quarantine_failed detail)
+  | Error (Executor_pool_ref.Work_failed (exn, backtrace)) ->
+    Error (Quarantine_execution_failed (exn, backtrace))
+  | Error error -> Error (Quarantine_executor_unavailable error)
 ;;
 
 let recover_projected_durable_demand_owner
@@ -189,7 +292,7 @@ let recover_projected_durable_demand_owner
       ( Keeper_event_queue_recovery.No_pending_transition
       | Keeper_event_queue_recovery.Transition_converged ) ->
     (match
-       load_durable_demand_meta
+       load_durable_demand_owner
          ~base_path
          ~config:ctx.config
          ~keeper_name
@@ -215,8 +318,56 @@ let recover_projected_durable_demand_owner
          keeper_name
          (Printexc.to_string exn)
          (Printexc.raw_backtrace_to_string backtrace)
-     | Ok None -> ()
-     | Ok (Some meta) ->
+     | Ok No_durable_demand -> ()
+     | Ok Durable_owner_not_materialized ->
+       Log.Server.info
+         "keeper durable demand recovery retained keeper=%s reason=owner_not_materialized"
+         keeper_name
+     | Ok Durable_owner_absent ->
+       (match
+          quarantine_absent_durable_owner
+            ~base_path
+            ~config:ctx.config
+            ~keeper_name
+        with
+        | Ok (Keeper_event_queue_persistence.Orphan_quarantined { quarantine_path }) ->
+          Log.Server.warn
+            "keeper durable demand recovery quarantined keeper=%s reason=owner_absent path=%s"
+            keeper_name
+            quarantine_path
+        | Ok
+            (Keeper_event_queue_persistence.Orphan_quarantine_visible_sync_unconfirmed
+              { quarantine_path; detail }) ->
+          Log.Server.error
+            "keeper durable demand recovery quarantined keeper=%s reason=owner_absent_sync_unconfirmed path=%s detail=%s"
+            keeper_name
+            quarantine_path
+            detail
+        | Ok Keeper_event_queue_persistence.Orphan_snapshot_absent ->
+          Log.Server.info
+            "keeper durable demand recovery converged keeper=%s reason=orphan_snapshot_absent"
+            keeper_name
+        | Ok Keeper_event_queue_persistence.Orphan_owner_reappeared ->
+          Log.Server.info
+            "keeper durable demand recovery retained keeper=%s reason=owner_reappeared"
+            keeper_name
+        | Error (Quarantine_failed detail) ->
+          Log.Server.error
+            "keeper durable demand recovery retained keeper=%s reason=orphan_quarantine_failed detail=%s"
+            keeper_name
+            detail
+        | Error (Quarantine_executor_unavailable error) ->
+          Log.Server.error
+            "keeper durable demand recovery retained keeper=%s reason=orphan_quarantine_executor_unavailable detail=%s"
+            keeper_name
+            (Executor_pool_ref.strict_submit_error_to_string error)
+        | Error (Quarantine_execution_failed (exn, backtrace)) ->
+          Log.Server.error
+            "keeper durable demand recovery retained keeper=%s reason=orphan_quarantine_execution_failed detail=%s\n%s"
+            keeper_name
+            (Printexc.to_string exn)
+            (Printexc.raw_backtrace_to_string backtrace))
+     | Ok (Durable_owner meta) ->
        let admission =
          Keeper_turn_admission.snapshot_for ~base_path ~keeper_name
        in
@@ -302,6 +453,19 @@ let recover_keeper_durable_demand_owners
 ;;
 
 module Recovery_for_testing = struct
+  type exact_owner_presence =
+    | Owner_present
+    | Owner_not_materialized
+    | Owner_absent
+
+  let exact_owner_presence config keeper_name =
+    exact_durable_owner_result config keeper_name
+    |> Result.map (function
+      | Exact_owner _ -> Owner_present
+      | Exact_owner_not_materialized -> Owner_not_materialized
+      | Exact_owner_absent -> Owner_absent)
+  ;;
+
   let consume_owner_projection_batch = consume_owner_projection_batch
 end
 

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -162,13 +162,6 @@ let exact_keeper_config_declared_result
       keeper_name
   in
   match Fs_compat.exact_path_kind path with
-  | Fs_compat.Exact_missing -> Ok false
-  | Fs_compat.Exact_kind Unix.S_REG -> Ok true
-  | Fs_compat.Exact_kind _ | Fs_compat.Exact_unknown ->
-    Error
-      (Printf.sprintf
-         "Keeper config declaration is not a regular file: %s"
-         path)
   | exception Eio.Cancel.Cancelled _ as exn -> raise exn
   | exception Unix.Unix_error (error, operation, argument) ->
     Error
@@ -184,6 +177,13 @@ let exact_keeper_config_declared_result
          "failed to inspect Keeper config declaration path=%s: %s"
          path
          detail)
+  | Fs_compat.Exact_missing -> Ok false
+  | Fs_compat.Exact_kind Unix.S_REG -> Ok true
+  | Fs_compat.Exact_kind _ | Fs_compat.Exact_unknown ->
+    Error
+      (Printf.sprintf
+         "Keeper config declaration is not a regular file: %s"
+         path)
 ;;
 
 let exact_durable_owner_result config keeper_name =

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -350,6 +350,10 @@ let recover_projected_durable_demand_owner
           Log.Server.info
             "keeper durable demand recovery converged keeper=%s reason=orphan_snapshot_absent"
             keeper_name
+        | Ok Keeper_event_queue_persistence.Orphan_pending_delivery_retained ->
+          Log.Server.info
+            "keeper durable demand recovery retained keeper=%s reason=pending_pre_registration_delivery"
+            keeper_name
         | Ok Keeper_event_queue_persistence.Orphan_owner_reappeared ->
           Log.Server.info
             "keeper durable demand recovery retained keeper=%s reason=owner_reappeared"

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -162,7 +162,7 @@ let exact_keeper_config_declared_result
       keeper_name
   in
   match Fs_compat.exact_path_kind path with
-  | exception Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
   | exception Unix.Unix_error (error, operation, argument) ->
     Error
       (Printf.sprintf

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -254,16 +254,20 @@ type orphan_quarantine_attempt_error =
 let quarantine_absent_durable_owner ~base_path ~config ~keeper_name =
   match
     Executor_pool_ref.submit_strict (fun () ->
-      Keeper_event_queue_persistence.quarantine_orphaned_owner_result
+      Keeper_lifecycle_reservation.with_key_lock
         ~base_path
         ~keeper_name
-        ~confirm_owner_presence:(fun () ->
-          match exact_durable_owner_result config keeper_name with
-          | Error _ as error -> error
-          | Ok (Exact_owner _ | Exact_owner_not_materialized) ->
-            Ok Keeper_event_queue_persistence.Orphan_owner_present
-          | Ok Exact_owner_absent ->
-            Ok Keeper_event_queue_persistence.Orphan_owner_absent))
+        (fun () ->
+           Keeper_event_queue_persistence.quarantine_orphaned_owner_result
+             ~base_path
+             ~keeper_name
+             ~confirm_owner_presence:(fun () ->
+               match exact_durable_owner_result config keeper_name with
+               | Error _ as error -> error
+               | Ok (Exact_owner _ | Exact_owner_not_materialized) ->
+                 Ok Keeper_event_queue_persistence.Orphan_owner_present
+               | Ok Exact_owner_absent ->
+                 Ok Keeper_event_queue_persistence.Orphan_owner_absent)))
   with
   | Ok (Ok outcome) -> Ok outcome
   | Ok (Error detail) -> Error (Quarantine_failed detail)

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -156,35 +156,34 @@ let exact_keeper_config_declared_result
       (config : Workspace.config)
       keeper_name
   =
-  let keepers_dir =
-    Config_dir_resolver.keepers_dir_for_base_path
+  let path =
+    Config_dir_resolver.keeper_toml_path_for_base_path
       ~base_path:config.base_path
+      keeper_name
   in
-  let expected_file = keeper_name ^ ".toml" in
-  match Unix.lstat keepers_dir with
-  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> Ok false
+  match Fs_compat.exact_path_kind path with
+  | Fs_compat.Exact_missing -> Ok false
+  | Fs_compat.Exact_kind Unix.S_REG -> Ok true
+  | Fs_compat.Exact_kind _ | Fs_compat.Exact_unknown ->
+    Error
+      (Printf.sprintf
+         "Keeper config declaration is not a regular file: %s"
+         path)
+  | exception Eio.Cancel.Cancelled _ as exn -> raise exn
   | exception Unix.Unix_error (error, operation, argument) ->
     Error
       (Printf.sprintf
-         "failed to inspect Keeper config directory path=%s operation=%s argument=%s: %s"
-         keepers_dir
+         "failed to inspect Keeper config declaration path=%s operation=%s argument=%s: %s"
+         path
          operation
          argument
          (Unix.error_message error))
-  | { Unix.st_kind = Unix.S_DIR; _ } ->
-    (match Safe_ops.list_dir_safe keepers_dir with
-     | Error detail ->
-       Error
-         (Printf.sprintf
-            "failed to list Keeper config directory path=%s: %s"
-            keepers_dir
-            detail)
-     | Ok files -> Ok (List.exists (String.equal expected_file) files))
-  | _ ->
+  | exception Sys_error detail ->
     Error
       (Printf.sprintf
-         "Keeper config path is not a directory: %s"
-         keepers_dir)
+         "failed to inspect Keeper config declaration path=%s: %s"
+         path
+         detail)
 ;;
 
 let exact_durable_owner_result config keeper_name =

--- a/lib/server/server_bootstrap_maintenance.mli
+++ b/lib/server/server_bootstrap_maintenance.mli
@@ -13,6 +13,14 @@ val start_background_maintenance :
   Mcp_server.server_state -> string * string
 
 module Recovery_for_testing : sig
+  type exact_owner_presence =
+    | Owner_present
+    | Owner_not_materialized
+    | Owner_absent
+
+  val exact_owner_presence :
+    Workspace.config -> string -> (exact_owner_presence, string) result
+
   val consume_owner_projection_batch :
     commit_cursor:(unit -> unit) ->
     keeper_name:('a -> string) ->

--- a/test/dune
+++ b/test/dune
@@ -642,6 +642,11 @@
  (libraries alcotest masc_test_deps masc.keeper_checkpoint_ref))
 
 (test
+ (name test_keeper_event_queue_orphan_quarantine)
+ (modules test_keeper_event_queue_orphan_quarantine)
+ (libraries alcotest masc_test_deps))
+
+(test
  (name test_keeper_checkpoint_purge)
  (modules test_keeper_checkpoint_purge)
  (libraries alcotest masc_test_deps))

--- a/test/test_keeper_event_queue_orphan_quarantine.ml
+++ b/test/test_keeper_event_queue_orphan_quarantine.ml
@@ -1,5 +1,7 @@
 module Persistence = Keeper_event_queue_persistence
 
+open Masc
+
 let with_temp_dir prefix f =
   let base_path = Filename.temp_dir prefix "" in
   Fun.protect

--- a/test/test_keeper_event_queue_orphan_quarantine.ml
+++ b/test/test_keeper_event_queue_orphan_quarantine.ml
@@ -1,0 +1,120 @@
+module Persistence = Keeper_event_queue_persistence
+
+let rec remove_tree path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path
+      |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path)
+    else Unix.unlink path
+;;
+
+let with_temp_dir prefix f =
+  let base_path = Filename.temp_dir prefix "" in
+  Fun.protect ~finally:(fun () -> remove_tree base_path) (fun () -> f base_path)
+;;
+
+let stimulus : Keeper_event_queue.stimulus =
+  { post_id = "orphan-quarantine-test"
+  ; urgency = Keeper_event_queue.Normal
+  ; arrived_at = 1.0
+  ; payload = Keeper_event_queue.Bootstrap
+  }
+;;
+
+let seed ~base_path ~keeper_name =
+  match
+    Persistence.enqueue_stimulus_if_absent_result
+      ~base_path
+      ~keeper_name
+      stimulus
+  with
+  | Ok Persistence.Enqueued -> ()
+  | Ok Persistence.Already_present -> Alcotest.fail "fresh queue already existed"
+  | Error detail -> Alcotest.fail detail
+;;
+
+let snapshot_path ~base_path ~keeper_name =
+  Filename.concat
+    (Filename.concat
+       (Common.keepers_runtime_dir_of_base ~base_path)
+       keeper_name)
+    "event-queue-v14.json"
+;;
+
+let quarantine_path ~base_path ~keeper_name =
+  Filename.concat
+    (Filename.concat
+       (Common.keepers_runtime_dir_of_base ~base_path)
+       ".orphaned-event-queues")
+    keeper_name
+;;
+
+let test_absent_owner_moves_full_runtime_directory () =
+  with_temp_dir "event-queue-orphan-quarantine-" @@ fun base_path ->
+  let keeper_name = "orphan-owner" in
+  seed ~base_path ~keeper_name;
+  let quarantine_path = quarantine_path ~base_path ~keeper_name in
+  (match
+     Persistence.quarantine_orphaned_owner_result
+       ~base_path
+       ~keeper_name
+       ~confirm_owner_presence:(fun () -> Ok Persistence.Orphan_owner_absent)
+   with
+   | Ok (Persistence.Orphan_quarantined result) ->
+     Alcotest.(check string)
+       "typed quarantine path"
+       quarantine_path
+       result.quarantine_path
+   | Ok _ -> Alcotest.fail "orphan queue did not enter quarantine"
+   | Error detail -> Alcotest.fail detail);
+  Alcotest.(check bool)
+    "active snapshot moved"
+    false
+    (Sys.file_exists (snapshot_path ~base_path ~keeper_name));
+  Alcotest.(check bool)
+    "quarantined snapshot preserved"
+    true
+    (Sys.file_exists (Filename.concat quarantine_path "event-queue-v14.json"));
+  Alcotest.(check (list string))
+    "quarantined owner leaves discovery"
+    []
+    (Persistence.discover_keeper_names_with_snapshots ~base_path).keeper_names
+;;
+
+let test_reappeared_owner_fences_quarantine () =
+  with_temp_dir "event-queue-owner-reappeared-" @@ fun base_path ->
+  let keeper_name = "reappeared-owner" in
+  seed ~base_path ~keeper_name;
+  (match
+     Persistence.quarantine_orphaned_owner_result
+       ~base_path
+       ~keeper_name
+       ~confirm_owner_presence:(fun () -> Ok Persistence.Orphan_owner_present)
+   with
+   | Ok Persistence.Orphan_owner_reappeared -> ()
+   | Ok _ -> Alcotest.fail "present owner did not fence quarantine"
+   | Error detail -> Alcotest.fail detail);
+  Alcotest.(check bool)
+    "present owner snapshot remains active"
+    true
+    (Sys.file_exists (snapshot_path ~base_path ~keeper_name))
+;;
+
+let () =
+  Alcotest.run
+    "Keeper_event_queue_orphan_quarantine"
+    [ ( "quarantine"
+      , [ Alcotest.test_case
+            "absent owner moves full runtime directory"
+            `Quick
+            test_absent_owner_moves_full_runtime_directory
+        ; Alcotest.test_case
+            "reappeared owner fences quarantine"
+            `Quick
+            test_reappeared_owner_fences_quarantine
+        ] )
+    ]
+;;

--- a/test/test_keeper_event_queue_orphan_quarantine.ml
+++ b/test/test_keeper_event_queue_orphan_quarantine.ml
@@ -1,19 +1,10 @@
 module Persistence = Keeper_event_queue_persistence
 
-let rec remove_tree path =
-  if Sys.file_exists path
-  then
-    if Sys.is_directory path
-    then (
-      Sys.readdir path
-      |> Array.iter (fun name -> remove_tree (Filename.concat path name));
-      Unix.rmdir path)
-    else Unix.unlink path
-;;
-
 let with_temp_dir prefix f =
   let base_path = Filename.temp_dir prefix "" in
-  Fun.protect ~finally:(fun () -> remove_tree base_path) (fun () -> f base_path)
+  Fun.protect
+    ~finally:(fun () -> Masc_test_deps.cleanup_test_workspace base_path)
+    (fun () -> f base_path)
 ;;
 
 let stimulus : Keeper_event_queue.stimulus =
@@ -44,32 +35,33 @@ let snapshot_path ~base_path ~keeper_name =
     "event-queue-v14.json"
 ;;
 
-let quarantine_path ~base_path ~keeper_name =
+let quarantine_root ~base_path =
   Filename.concat
-    (Filename.concat
-       (Common.keepers_runtime_dir_of_base ~base_path)
-       ".orphaned-event-queues")
-    keeper_name
+    (Common.keepers_runtime_dir_of_base ~base_path)
+    ".orphaned-event-queues"
+;;
+
+let quarantine_absent_owner ~base_path ~keeper_name =
+  match
+    Persistence.quarantine_orphaned_owner_result
+      ~base_path
+      ~keeper_name
+      ~confirm_owner_presence:(fun () -> Ok Persistence.Orphan_owner_absent)
+  with
+  | Ok (Persistence.Orphan_quarantined { quarantine_path }) -> quarantine_path
+  | Ok _ -> Alcotest.fail "orphan queue did not enter quarantine"
+  | Error detail -> Alcotest.fail detail
 ;;
 
 let test_absent_owner_moves_full_runtime_directory () =
   with_temp_dir "event-queue-orphan-quarantine-" @@ fun base_path ->
   let keeper_name = "orphan-owner" in
   seed ~base_path ~keeper_name;
-  let quarantine_path = quarantine_path ~base_path ~keeper_name in
-  (match
-     Persistence.quarantine_orphaned_owner_result
-       ~base_path
-       ~keeper_name
-       ~confirm_owner_presence:(fun () -> Ok Persistence.Orphan_owner_absent)
-   with
-   | Ok (Persistence.Orphan_quarantined result) ->
-     Alcotest.(check string)
-       "typed quarantine path"
-       quarantine_path
-       result.quarantine_path
-   | Ok _ -> Alcotest.fail "orphan queue did not enter quarantine"
-   | Error detail -> Alcotest.fail detail);
+  let quarantine_path = quarantine_absent_owner ~base_path ~keeper_name in
+  Alcotest.(check string)
+    "quarantine remains under the dedicated root"
+    (quarantine_root ~base_path)
+    (Filename.dirname quarantine_path);
   Alcotest.(check bool)
     "active snapshot moved"
     false
@@ -82,6 +74,30 @@ let test_absent_owner_moves_full_runtime_directory () =
     "quarantined owner leaves discovery"
     []
     (Persistence.discover_keeper_names_with_snapshots ~base_path).keeper_names
+;;
+
+let test_reused_owner_name_gets_distinct_quarantine () =
+  with_temp_dir "event-queue-reused-orphan-quarantine-" @@ fun base_path ->
+  let keeper_name = "reused-orphan-owner" in
+  seed ~base_path ~keeper_name;
+  let first_path = quarantine_absent_owner ~base_path ~keeper_name in
+  seed ~base_path ~keeper_name;
+  let second_path = quarantine_absent_owner ~base_path ~keeper_name in
+  Alcotest.(check bool)
+    "reused owner name preserves both quarantine generations"
+    true
+    (not (String.equal first_path second_path));
+  List.iter
+    (fun path ->
+       Alcotest.(check bool)
+         "quarantined snapshot preserved"
+         true
+         (Sys.file_exists (Filename.concat path "event-queue-v14.json")))
+    [ first_path; second_path ];
+  Alcotest.(check bool)
+    "second active snapshot moved"
+    false
+    (Sys.file_exists (snapshot_path ~base_path ~keeper_name))
 ;;
 
 let test_reappeared_owner_fences_quarantine () =
@@ -115,6 +131,10 @@ let () =
             "reappeared owner fences quarantine"
             `Quick
             test_reappeared_owner_fences_quarantine
+        ; Alcotest.test_case
+            "reused owner name gets a distinct quarantine"
+            `Quick
+            test_reused_owner_name_gets_distinct_quarantine
         ] )
     ]
 ;;

--- a/test/test_keeper_event_queue_orphan_quarantine.ml
+++ b/test/test_keeper_event_queue_orphan_quarantine.ml
@@ -66,14 +66,12 @@ let write_keeper_meta_exn config meta =
 ;;
 
 let write_basepath_keeper_toml base_path name =
-  let keepers_dir =
-    Filename.concat
-      (Filename.concat (Filename.concat base_path Common.masc_dirname) "config")
-      "keepers"
+  let path =
+    Config_dir_resolver.keeper_toml_path_for_base_path ~base_path name
   in
-  Fs_compat.mkdir_p keepers_dir;
+  Fs_compat.mkdir_p (Filename.dirname path);
   Fs_compat.save_file
-    (Filename.concat keepers_dir (name ^ ".toml"))
+    path
     {|[keeper]
 instructions = "example"
 proactive_enabled = false
@@ -235,6 +233,25 @@ let test_exact_owner_presence_requires_exact_authority () =
       | _ -> Alcotest.fail "exact registered owner was not authoritative")
 ;;
 
+let test_non_regular_keeper_declaration_fails_closed () =
+  with_temp_dir "durable-queue-invalid-declaration-" @@ fun base_path ->
+  let config = Workspace.default_config base_path in
+  let keeper_name = "directory-declaration" in
+  let path =
+    Config_dir_resolver.keeper_toml_path_for_base_path
+      ~base_path
+      keeper_name
+  in
+  Fs_compat.mkdir_p path;
+  match
+    Server_bootstrap_maintenance.Recovery_for_testing.exact_owner_presence
+      config
+      keeper_name
+  with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "non-regular Keeper declaration was accepted"
+;;
+
 let () =
   Alcotest.run
     "Keeper_event_queue_orphan_quarantine"
@@ -259,6 +276,10 @@ let () =
             "exact owner presence requires exact authority"
             `Quick
             test_exact_owner_presence_requires_exact_authority
+        ; Alcotest.test_case
+            "non-regular Keeper declaration fails closed"
+            `Quick
+            test_non_regular_keeper_declaration_fails_closed
         ] )
     ]
 ;;

--- a/test/test_keeper_event_queue_orphan_quarantine.ml
+++ b/test/test_keeper_event_queue_orphan_quarantine.ml
@@ -157,6 +157,36 @@ let test_reappeared_owner_fences_quarantine () =
     (Sys.file_exists (snapshot_path ~base_path ~keeper_name))
 ;;
 
+let test_owner_reappearing_after_rename_restores_runtime () =
+  with_temp_dir "event-queue-owner-reappeared-after-rename-" @@ fun base_path ->
+  let keeper_name = "reappeared-after-rename" in
+  let confirmation_count = ref 0 in
+  seed ~base_path ~keeper_name;
+  (match
+     Persistence.quarantine_orphaned_owner_result
+       ~base_path
+       ~keeper_name
+       ~confirm_owner_presence:(fun () ->
+         incr confirmation_count;
+         Ok
+           (if !confirmation_count = 1
+            then Persistence.Orphan_owner_absent
+            else Persistence.Orphan_owner_present))
+   with
+   | Ok Persistence.Orphan_owner_reappeared -> ()
+   | Ok _ -> Alcotest.fail "owner appearing after rename was not restored"
+   | Error detail -> Alcotest.fail detail);
+  Alcotest.(check int) "owner authority checked twice" 2 !confirmation_count;
+  Alcotest.(check bool)
+    "reappeared owner snapshot restored"
+    true
+    (Sys.file_exists (snapshot_path ~base_path ~keeper_name));
+  Alcotest.(check (list string))
+    "restored owner leaves no quarantined generation"
+    []
+    (Array.to_list (Sys.readdir (quarantine_root ~base_path)))
+;;
+
 let test_exact_owner_presence_requires_exact_authority () =
   with_temp_dir "durable-queue-owner-presence-" @@ fun base_path ->
   let config = Workspace.default_config base_path in
@@ -215,6 +245,10 @@ let () =
             "reappeared owner fences quarantine"
             `Quick
             test_reappeared_owner_fences_quarantine
+        ; Alcotest.test_case
+            "owner reappearing after rename restores runtime"
+            `Quick
+            test_owner_reappearing_after_rename_restores_runtime
         ; Alcotest.test_case
             "reused owner name gets a distinct quarantine"
             `Quick

--- a/test/test_keeper_event_queue_orphan_quarantine.ml
+++ b/test/test_keeper_event_queue_orphan_quarantine.ml
@@ -29,6 +29,24 @@ let seed ~base_path ~keeper_name =
   | Error detail -> Alcotest.fail detail
 ;;
 
+let seed_empty_snapshot ~base_path ~keeper_name =
+  seed ~base_path ~keeper_name;
+  match
+    Persistence.drop_by_post_id
+      ~base_path
+      ~keeper_name
+      ~post_id:stimulus.post_id
+      ()
+  with
+  | Ok [ removed ]
+    when Keeper_event_queue.stimulus_identity_equal removed stimulus -> ()
+  | Ok removed ->
+    Alcotest.failf
+      "expected to remove one exact pending stimulus, removed=%d"
+      (List.length removed)
+  | Error detail -> Alcotest.fail detail
+;;
+
 let snapshot_path ~base_path ~keeper_name =
   Filename.concat
     (Filename.concat
@@ -91,10 +109,13 @@ let quarantine_absent_owner ~base_path ~keeper_name =
   | Error detail -> Alcotest.fail detail
 ;;
 
-let test_absent_owner_moves_full_runtime_directory () =
+let test_absent_owner_moves_only_event_queue_files () =
   with_temp_dir "event-queue-orphan-quarantine-" @@ fun base_path ->
   let keeper_name = "orphan-owner" in
-  seed ~base_path ~keeper_name;
+  seed_empty_snapshot ~base_path ~keeper_name;
+  let owner_dir = Filename.dirname (snapshot_path ~base_path ~keeper_name) in
+  let chat_store_path = Filename.concat owner_dir "chat-queue.sqlite3" in
+  Fs_compat.save_file chat_store_path "sibling-store-must-remain-active";
   let quarantine_path = quarantine_absent_owner ~base_path ~keeper_name in
   Alcotest.(check string)
     "quarantine remains under the dedicated root"
@@ -108,6 +129,14 @@ let test_absent_owner_moves_full_runtime_directory () =
     "quarantined snapshot preserved"
     true
     (Sys.file_exists (Filename.concat quarantine_path "event-queue-v14.json"));
+  Alcotest.(check bool)
+    "sibling chat store remains active"
+    true
+    (Sys.file_exists chat_store_path);
+  Alcotest.(check string)
+    "sibling chat store bytes remain unchanged"
+    "sibling-store-must-remain-active"
+    (Fs_compat.load_file chat_store_path);
   Alcotest.(check (list string))
     "quarantined owner leaves discovery"
     []
@@ -117,9 +146,9 @@ let test_absent_owner_moves_full_runtime_directory () =
 let test_reused_owner_name_gets_distinct_quarantine () =
   with_temp_dir "event-queue-reused-orphan-quarantine-" @@ fun base_path ->
   let keeper_name = "reused-orphan-owner" in
-  seed ~base_path ~keeper_name;
+  seed_empty_snapshot ~base_path ~keeper_name;
   let first_path = quarantine_absent_owner ~base_path ~keeper_name in
-  seed ~base_path ~keeper_name;
+  seed_empty_snapshot ~base_path ~keeper_name;
   let second_path = quarantine_absent_owner ~base_path ~keeper_name in
   Alcotest.(check bool)
     "reused owner name preserves both quarantine generations"
@@ -141,7 +170,7 @@ let test_reused_owner_name_gets_distinct_quarantine () =
 let test_reappeared_owner_fences_quarantine () =
   with_temp_dir "event-queue-owner-reappeared-" @@ fun base_path ->
   let keeper_name = "reappeared-owner" in
-  seed ~base_path ~keeper_name;
+  seed_empty_snapshot ~base_path ~keeper_name;
   (match
      Persistence.quarantine_orphaned_owner_result
        ~base_path
@@ -161,7 +190,7 @@ let test_owner_reappearing_after_rename_restores_runtime () =
   with_temp_dir "event-queue-owner-reappeared-after-rename-" @@ fun base_path ->
   let keeper_name = "reappeared-after-rename" in
   let confirmation_count = ref 0 in
-  seed ~base_path ~keeper_name;
+  seed_empty_snapshot ~base_path ~keeper_name;
   (match
      Persistence.quarantine_orphaned_owner_result
        ~base_path
@@ -185,6 +214,43 @@ let test_owner_reappearing_after_rename_restores_runtime () =
     "restored owner leaves no quarantined generation"
     []
     (Array.to_list (Sys.readdir (quarantine_root ~base_path)))
+;;
+
+let test_pending_delivery_survives_until_future_registration () =
+  with_temp_dir "event-queue-future-registration-" @@ fun base_path ->
+  let keeper_name = "future-owner" in
+  seed ~base_path ~keeper_name;
+  (match
+     Persistence.quarantine_orphaned_owner_result
+       ~base_path
+       ~keeper_name
+       ~confirm_owner_presence:(fun () -> Ok Persistence.Orphan_owner_absent)
+   with
+   | Ok Persistence.Orphan_pending_delivery_retained -> ()
+   | Ok _ -> Alcotest.fail "pending pre-registration delivery was quarantined"
+   | Error detail -> Alcotest.fail detail);
+  Alcotest.(check bool)
+    "pending snapshot remains in active discovery"
+    true
+    (Sys.file_exists (snapshot_path ~base_path ~keeper_name));
+  let meta =
+    make_keeper_meta
+      ~name:keeper_name
+      ~trace_id:"trace-future-owner"
+      ()
+  in
+  let entry = Keeper_registry.For_testing.register ~base_path keeper_name meta in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.For_testing.unregister ~base_path keeper_name)
+    (fun () ->
+      match Keeper_event_queue.to_list (Atomic.get entry.event_queue) with
+      | [ replayed ]
+        when Keeper_event_queue.stimulus_identity_equal replayed stimulus -> ()
+      | replayed ->
+        Alcotest.failf
+          "future registration replayed the wrong pending set count=%d"
+          (List.length replayed))
 ;;
 
 let test_exact_owner_presence_requires_exact_authority () =
@@ -257,9 +323,9 @@ let () =
     "Keeper_event_queue_orphan_quarantine"
     [ ( "quarantine"
       , [ Alcotest.test_case
-            "absent owner moves full runtime directory"
+            "absent owner moves only event queue files"
             `Quick
-            test_absent_owner_moves_full_runtime_directory
+            test_absent_owner_moves_only_event_queue_files
         ; Alcotest.test_case
             "reappeared owner fences quarantine"
             `Quick
@@ -272,6 +338,10 @@ let () =
             "reused owner name gets a distinct quarantine"
             `Quick
             test_reused_owner_name_gets_distinct_quarantine
+        ; Alcotest.test_case
+            "pending delivery survives future registration"
+            `Quick
+            test_pending_delivery_survives_until_future_registration
         ; Alcotest.test_case
             "exact owner presence requires exact authority"
             `Quick

--- a/test/test_keeper_event_queue_orphan_quarantine.ml
+++ b/test/test_keeper_event_queue_orphan_quarantine.ml
@@ -41,6 +41,44 @@ let quarantine_root ~base_path =
     ".orphaned-event-queues"
 ;;
 
+let make_keeper_meta ?(paused = false) ?(name = "sangsu")
+    ?(trace_id = "trace-sangsu-live")
+    ?(updated_at = "2026-03-29T10:36:57Z") () =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [ ("name", `String name)
+        ; ("agent_name", `String ("keeper-" ^ name ^ "-agent"))
+        ; ("trace_id", `String trace_id)
+        ; ("updated_at", `String updated_at)
+        ])
+  with
+  | Ok meta -> { meta with paused }
+  | Error err -> Alcotest.fail ("meta_of_json failed: " ^ err)
+;;
+
+let write_keeper_meta_exn config meta =
+  match Keeper_meta_store.write_meta config meta with
+  | Ok () -> ()
+  | Error err -> Alcotest.fail ("keeper meta write failed: " ^ err)
+;;
+
+let write_basepath_keeper_toml base_path name =
+  let keepers_dir =
+    Filename.concat
+      (Filename.concat (Filename.concat base_path Common.masc_dirname) "config")
+      "keepers"
+  in
+  Fs_compat.mkdir_p keepers_dir;
+  Fs_compat.save_file
+    (Filename.concat keepers_dir (name ^ ".toml"))
+    {|[keeper]
+instructions = "example"
+proactive_enabled = false
+autoboot_enabled = true
+|}
+;;
+
 let quarantine_absent_owner ~base_path ~keeper_name =
   match
     Persistence.quarantine_orphaned_owner_result
@@ -119,6 +157,52 @@ let test_reappeared_owner_fences_quarantine () =
     (Sys.file_exists (snapshot_path ~base_path ~keeper_name))
 ;;
 
+let test_exact_owner_presence_requires_exact_authority () =
+  with_temp_dir "durable-queue-owner-presence-" @@ fun base_path ->
+  let config = Workspace.default_config base_path in
+  let module Recovery = Server_bootstrap_maintenance.Recovery_for_testing in
+  let presence keeper_name =
+    match Recovery.exact_owner_presence config keeper_name with
+    | Ok presence -> presence
+    | Error detail -> Alcotest.fail detail
+  in
+  (match presence "absent-owner" with
+   | Recovery.Owner_absent -> ()
+   | _ -> Alcotest.fail "owner without exact authority was retained");
+  write_basepath_keeper_toml base_path "declared-owner";
+  (match presence "declared-owner" with
+   | Recovery.Owner_not_materialized -> ()
+   | _ -> Alcotest.fail "exact TOML owner was classified as orphaned");
+  let persisted_meta =
+    make_keeper_meta
+      ~name:"persisted-owner"
+      ~trace_id:"trace-persisted-owner"
+      ()
+  in
+  write_keeper_meta_exn config persisted_meta;
+  (match presence persisted_meta.name with
+   | Recovery.Owner_present -> ()
+   | _ -> Alcotest.fail "exact persisted owner was not authoritative");
+  let registered_meta =
+    make_keeper_meta
+      ~name:"registered-owner"
+      ~trace_id:"trace-registered-owner"
+      ()
+  in
+  ignore
+    (Keeper_registry.For_testing.register
+       ~base_path
+       registered_meta.name
+       registered_meta);
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.For_testing.unregister ~base_path registered_meta.name)
+    (fun () ->
+      match presence registered_meta.name with
+      | Recovery.Owner_present -> ()
+      | _ -> Alcotest.fail "exact registered owner was not authoritative")
+;;
+
 let () =
   Alcotest.run
     "Keeper_event_queue_orphan_quarantine"
@@ -135,6 +219,10 @@ let () =
             "reused owner name gets a distinct quarantine"
             `Quick
             test_reused_owner_name_gets_distinct_quarantine
+        ; Alcotest.test_case
+            "exact owner presence requires exact authority"
+            `Quick
+            test_exact_owner_presence_requires_exact_authority
         ] )
     ]
 ;;

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -5155,6 +5155,52 @@ let test_transition_projection_cursor_commits_before_isolated_owner_recovery () 
     (List.rev !processed)
 ;;
 
+let test_durable_queue_owner_presence_requires_exact_authority () =
+  with_temp_dir "durable-queue-owner-presence-" @@ fun base_path ->
+  let config = Workspace.default_config base_path in
+  let module Recovery = Server_bootstrap_maintenance.Recovery_for_testing in
+  let presence keeper_name =
+    match Recovery.exact_owner_presence config keeper_name with
+    | Ok presence -> presence
+    | Error detail -> Alcotest.fail detail
+  in
+  (match presence "absent-owner" with
+   | Recovery.Owner_absent -> ()
+   | _ -> Alcotest.fail "owner without exact authority was retained");
+  write_basepath_keeper_toml base_path "declared-owner";
+  (match presence "declared-owner" with
+   | Recovery.Owner_not_materialized -> ()
+   | _ -> Alcotest.fail "exact TOML owner was classified as orphaned");
+  let persisted_meta =
+    make_keeper_meta
+      ~name:"persisted-owner"
+      ~trace_id:"trace-persisted-owner"
+      ()
+  in
+  write_keeper_meta_exn config persisted_meta;
+  (match presence persisted_meta.name with
+   | Recovery.Owner_present -> ()
+   | _ -> Alcotest.fail "exact persisted owner was not authoritative");
+  let registered_meta =
+    make_keeper_meta
+      ~name:"registered-owner"
+      ~trace_id:"trace-registered-owner"
+      ()
+  in
+  ignore
+    (Keeper_registry.For_testing.register
+       ~base_path
+       registered_meta.name
+       registered_meta);
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.For_testing.unregister ~base_path registered_meta.name)
+    (fun () ->
+      match presence registered_meta.name with
+      | Recovery.Owner_present -> ()
+      | _ -> Alcotest.fail "exact registered owner was not authoritative")
+;;
+
 let () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -5167,6 +5213,10 @@ let () =
             "transition projection cursor commits before isolated owner recovery"
             `Quick
             test_transition_projection_cursor_commits_before_isolated_owner_recovery;
+          Alcotest.test_case
+            "durable queue owner presence requires exact authority"
+            `Quick
+            test_durable_queue_owner_presence_requires_exact_authority;
           Alcotest.test_case
             "gRPC tool arguments fail closed before dispatch"
             `Quick

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -5155,52 +5155,6 @@ let test_transition_projection_cursor_commits_before_isolated_owner_recovery () 
     (List.rev !processed)
 ;;
 
-let test_durable_queue_owner_presence_requires_exact_authority () =
-  with_temp_dir "durable-queue-owner-presence-" @@ fun base_path ->
-  let config = Workspace.default_config base_path in
-  let module Recovery = Server_bootstrap_maintenance.Recovery_for_testing in
-  let presence keeper_name =
-    match Recovery.exact_owner_presence config keeper_name with
-    | Ok presence -> presence
-    | Error detail -> Alcotest.fail detail
-  in
-  (match presence "absent-owner" with
-   | Recovery.Owner_absent -> ()
-   | _ -> Alcotest.fail "owner without exact authority was retained");
-  write_basepath_keeper_toml base_path "declared-owner";
-  (match presence "declared-owner" with
-   | Recovery.Owner_not_materialized -> ()
-   | _ -> Alcotest.fail "exact TOML owner was classified as orphaned");
-  let persisted_meta =
-    make_keeper_meta
-      ~name:"persisted-owner"
-      ~trace_id:"trace-persisted-owner"
-      ()
-  in
-  write_keeper_meta_exn config persisted_meta;
-  (match presence persisted_meta.name with
-   | Recovery.Owner_present -> ()
-   | _ -> Alcotest.fail "exact persisted owner was not authoritative");
-  let registered_meta =
-    make_keeper_meta
-      ~name:"registered-owner"
-      ~trace_id:"trace-registered-owner"
-      ()
-  in
-  ignore
-    (Keeper_registry.For_testing.register
-       ~base_path
-       registered_meta.name
-       registered_meta);
-  Fun.protect
-    ~finally:(fun () ->
-      Keeper_registry.For_testing.unregister ~base_path registered_meta.name)
-    (fun () ->
-      match presence registered_meta.name with
-      | Recovery.Owner_present -> ()
-      | _ -> Alcotest.fail "exact registered owner was not authoritative")
-;;
-
 let () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -5213,10 +5167,6 @@ let () =
             "transition projection cursor commits before isolated owner recovery"
             `Quick
             test_transition_projection_cursor_commits_before_isolated_owner_recovery;
-          Alcotest.test_case
-            "durable queue owner presence requires exact authority"
-            `Quick
-            test_durable_queue_owner_presence_requires_exact_authority;
           Alcotest.test_case
             "gRPC tool arguments fail closed before dispatch"
             `Quick


### PR DESCRIPTION
## 문제

Durable event queue discovery accepted any syntactically valid owner directory. When the exact Keeper registry entry, persisted metadata, and TOML declaration were all absent, bootstrap recovery retained and retried that owner forever. The live executor-agent orphan repeated this path once per maintenance interval.

## 변경

- classify durable owners only from exact registry, persisted metadata, or exact TOML declaration; no name normalization or executor remapping
- retain declared but not-yet-materialized Keepers
- recheck owner presence under the durable queue owner lock
- atomically move an absent owner runtime directory into .masc/keepers/.orphaned-event-queues/<keeper>
- fsync both directory sides and report post-rename sync uncertainty as a distinct typed outcome
- never overwrite an existing quarantine
- add isolated quarantine tests and exact-authority classifier coverage

## 검증

- scripts/dune-local.sh build lib/server/server_bootstrap_maintenance.ml test/test_server_runtime_bootstrap.exe
- test_keeper_event_queue_orphan_quarantine.exe: 2/2 passed
- test_server_runtime_bootstrap exact owner presence case: 1/1 passed
- ocamlformat --check on every changed OCaml file
- git diff --check

The older monolithic test_keeper_event_queue executable still stops at its unchanged duplicate-source fixture before reaching later cases; the new quarantine contract therefore has a dedicated focused executable instead of borrowing that broken sequence.