### PR TITLE
fix(goal_store): snapshot .last-good BEFORE primary write so recovery is meaningful

### DIFF
--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -264,14 +264,25 @@ let read_state config =
 let write_state_result config state =
   ensure_dirs config;
   let json = state_to_yojson state in
-  let* () = Workspace_utils.write_json_result config (goals_path config) json in
-  (match Workspace_utils.write_json_result config (goals_recovery_path config) json with
-   | Ok () -> ()
-   | Error msg ->
-     Log.Misc.warn
-       "goal_store: primary goals.json committed; recovery mirror write failed for %s: %s"
-       (goals_recovery_path config)
-       msg);
+  (* Snapshot the current primary to .last-good BEFORE overwriting,
+     so .last-good holds the previous good state, not a copy of the
+     current write.  This makes the recovery path meaningful: if the
+     new primary write fails or produces corrupt data, .last-good
+     still contains the last known-good state. *)
+  let primary = goals_path config in
+  let recovery = goals_recovery_path config in
+  (match Workspace_utils.read_json_result config primary with
+   | Ok prev_json ->
+     (match Workspace_utils.write_json_result config recovery prev_json with
+      | Ok () -> ()
+      | Error msg ->
+        Log.Misc.warn
+          "goal_store: pre-write snapshot to %s failed (non-fatal): %s"
+          recovery msg)
+   | Error _ ->
+     (* No existing primary to snapshot — first write or already gone. *)
+     ());
+  let* () = Workspace_utils.write_json_result config primary json in
   Ok ()
 
 let write_state config state =


### PR DESCRIPTION
## Problem

`write_state_result` wrote `goals.json` then copied the **same new json** to `goals.json.last-good`. Both files held identical content, making `.last-good` useless as a recovery mechanism — a corrupt write corrupted both.

## Fix

Reorder: read current primary → snapshot to `.last-good` → overwrite primary.

If the new write fails or produces corrupt data, `.last-good` still contains the last known-good state.

Ref: task-147 / masc#26668

## Files changed
- `lib/goal/goal_store.ml`: `write_state_result` reorders snapshot-before-overwrite