### PR TITLE
test(metrics): remove retired legacy tool-metric fixtures

### DIFF
--- a/test/test_tool_metrics_persist.ml
+++ b/test/test_tool_metrics_persist.ml
@@ -91,7 +91,7 @@ let test_malformed_lines_skipped () =
     Fs_compat.mkdir_p month_dir;
     let day_file = Filename.concat month_dir
       (Printf.sprintf "%02d.jsonl" tm.Unix.tm_mday) in
-    (* One valid row, one malformed row, and two pre-disposition legacy rows. *)
+    (* One valid row plus two invalid schema shapes. *)
     let valid_line = Yojson.Safe.to_string
       (`Assoc [
         ("tool_name", `String "good");
@@ -100,28 +100,19 @@ let test_malformed_lines_skipped () =
         ("ts", `Float 1000.0);
     ]) in
     let malformed_line = "{\"garbage\": true}" in
-    let legacy_success_line =
+    let forbidden_success_only_line =
       Yojson.Safe.to_string
         (`Assoc
-          [ "tool_name", `String "legacy-success"
+          [ "tool_name", `String "success-only"
           ; "success", `Bool true
           ; "duration_ms", `Float 2.0
-          ; "ts", `Float 1000.0
-          ])
-    in
-    let legacy_failure_line =
-      Yojson.Safe.to_string
-        (`Assoc
-          [ "tool_name", `String "legacy-failure"
-          ; "success", `Bool false
-          ; "duration_ms", `Float 3.0
           ; "ts", `Float 1000.0
           ])
     in
     let content =
       String.concat
         "\n"
-        [ valid_line; malformed_line; legacy_success_line; legacy_failure_line; "" ]
+        [ valid_line; malformed_line; forbidden_success_only_line; "" ]
     in
     Fs_compat.append_file day_file content;
     let n = P.restore ~base_path in
@@ -129,14 +120,10 @@ let test_malformed_lines_skipped () =
     (match M.stats_for "good" with
      | Some s -> Alcotest.(check int) "good count" 1 s.call_count
      | None -> Alcotest.fail "expected good stats");
-    Alcotest.(check bool)
-      "legacy success is intentionally not reconstructed"
-      true
-      (Option.is_none (M.stats_for "legacy-success"));
-    Alcotest.(check bool)
-      "legacy failure is intentionally not reconstructed"
-      true
-      (Option.is_none (M.stats_for "legacy-failure")))
+    Alcotest.(check bool) "malformed row is not reconstructed" true
+      (Option.is_none (M.stats_for "garbage"));
+    Alcotest.(check bool) "success-only row is not reconstructed" true
+      (Option.is_none (M.stats_for "success-only")))
 
 let test_reset_clears_cached_store () =
   with_tmp_dir (fun base_path ->


### PR DESCRIPTION
## 변경

- 폐기된 success-only persisted row 두 건을 하나의 명시적 rejection fixture로 축소했어용.
- 일반 malformed-row 거부와 현재 disposition contract 검증은 유지했어용.
- 폐기된 #26690 stack을 제거하고 main에 독립적으로 재스택했어용.

## 검증

- ocamlformat --check test/test_tool_metrics_persist.ml
- git diff --check
- 실행 검증은 exact-head CI 기준이에용.