### PR TITLE
feat(keeper): lazily expose tool schemas

### DIFF
--- a/config/prompts/keeper.turn_intent.md
+++ b/config/prompts/keeper.turn_intent.md
@@ -13,9 +13,12 @@ the originating conversation, publish durable shared findings to Board, and use
 Task lifecycle changes only for real ownership or verification work. A Task
 claim is coordination, not additional authorization.
 
-The active typed schema is the sole callable catalog. Multiple calls are valid
-when they form one meaningful unit of work. Do not repeat an action already
-proved complete by current state.
+Only schemas active for the current SDK turn are callable. Use
+`keeper_tools_list` to inspect exact registered names or `keeper_tool_search`
+for candidates. Query one exact tool name through `keeper_tool_search` to
+activate it for the next SDK turn, then call it. Multiple calls are valid when
+they form one meaningful unit of work. Do not repeat an action already proved
+complete by current state.
 
 If nothing is actionable after inspection, give a concise no-work report. For
 progress or completion claims, name the subject and provide the exact Task ID,

--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -373,19 +373,20 @@ OAS Agent.run의 hook lifecycle에 keeper 동작을 주입:
 
 ### 8.2 Tool surface projection
 
-`Keeper_tool_descriptor.model_visible_descriptors`가 선언한 모델 이름과 schema는
-매 turn 실제 OAS `Tool.t`로 전부 materialize된다. Keeper, runtime, provider,
-credential 상태는 이 목록을 줄이지 않으며 per-turn ranking, Top-K, allow/deny
-list, affinity, discovery overlay를 적용하지 않는다.
+`Keeper_tool_descriptor.model_visible_descriptors`는 실행 가능한 전체 catalog와
+handler/schema join을 정의한다. OAS Agent의 첫 SDK turn에는
+`keeper_tools_list`와 `keeper_tool_search` schema만 전달한다.
 
-비노출은 동일 capability를 이미 가리키는 exact transport alias와 유효한 canonical
-schema가 없는 descriptor에만 허용된다. transport alias는 자신을 대신해 노출되는
-정확한 model name을 descriptor evidence에 기록한다.
+`keeper_tools_list`는 정확한 등록 이름을 반환한다. `keeper_tool_search`의 free-text
+결과는 advisory 후보일 뿐 surface를 바꾸지 않는다. 후보의 정확한 이름을 다시
+query한 경우에만 그 이름 하나를 Agent-run-local active set에 추가한다. 다음 SDK
+turn의 `Hooks.Selected_tools`가 active set의 schema와 동일한 handler 집합을 Provider와
+실행기에 전달한다. 미등록 이름, 중복 초기 이름, 선택 surface 밖 named tool choice,
+Provider가 만든 비활성 ToolUse는 dispatch 전에 typed failure로 거부된다.
 
-이 경계가 하는 일은 descriptor/registered handler의 존재와 schema join을 exact
-검증하는 것뿐이다. 외부 효과는 tool을 숨겨 예방하지 않고 호출 시 normalized
-Gate가 Always Allowed, LLM Auto Judge, 비차단 HITL 중 하나로 결정한다. 외부
-dependency가 unavailable이면 해당 handler가 명시적 typed failure를 반환한다.
+외부 효과 권한은 surface 활성화가 만들지 않는다. 활성 tool의 실제 호출은 effect
+sink 직전 normalized Gate가 판정하며, unavailable dependency는 handler의 typed
+failure로 반환된다.
 
 ---
 

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -52,3 +52,68 @@ let sync_current_task_id_for_agent_name =
 
 let tool_names =
   List.map Keeper_tool_name.to_string
+
+module StringSet = Set_util.StringSet
+
+type activation_error =
+  | Duplicate_registered_name of string
+  | Duplicate_initial_name of string
+  | Unknown_initial_name of string
+  | Unknown_activation_name of string
+
+type active_tool_surface =
+  { registered_names : string list
+  ; registered_set : StringSet.t
+  ; mutex : Stdlib.Mutex.t
+  ; mutable active_set : StringSet.t
+  }
+
+let add_unique ~duplicate names =
+  let rec add set = function
+    | [] -> Ok set
+    | name :: rest ->
+      if StringSet.mem name set
+      then Error (duplicate name)
+      else add (StringSet.add name set) rest
+  in
+  add StringSet.empty names
+;;
+
+let create_active_tool_surface ~registered_names ~initial_names =
+  match add_unique ~duplicate:(fun name -> Duplicate_registered_name name) registered_names with
+  | Error _ as error -> error
+  | Ok registered_set ->
+    (match add_unique ~duplicate:(fun name -> Duplicate_initial_name name) initial_names with
+     | Error _ as error -> error
+     | Ok active_set ->
+       (match List.find_opt (fun name -> not (StringSet.mem name registered_set)) initial_names with
+        | Some name -> Error (Unknown_initial_name name)
+        | None ->
+          Ok
+            { registered_names
+            ; registered_set
+            ; mutex = Stdlib.Mutex.create ()
+            ; active_set
+            }))
+;;
+
+let activate_exact surface ~names =
+  Stdlib.Mutex.protect surface.mutex (fun () ->
+    match List.find_opt (fun name -> not (StringSet.mem name surface.registered_set)) names with
+    | Some name -> Error (Unknown_activation_name name)
+    | None ->
+      surface.active_set
+      <- List.fold_left
+           (fun active name -> StringSet.add name active)
+           surface.active_set
+           names;
+      Ok ())
+;;
+
+let active_names surface =
+  Stdlib.Mutex.protect surface.mutex (fun () ->
+    List.filter (fun name -> StringSet.mem name surface.active_set) surface.registered_names)
+;;
+
+let is_active surface name =
+  Stdlib.Mutex.protect surface.mutex (fun () -> StringSet.mem name surface.active_set)

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -54,3 +54,28 @@ val sync_current_task_id_for_agent_name :
 
 (** Convenience [List.map Keeper_tool_name.to_string]. *)
 val tool_names : Keeper_tool_name.t list -> string list
+
+type activation_error =
+  | Duplicate_registered_name of string
+  | Duplicate_initial_name of string
+  | Unknown_initial_name of string
+  | Unknown_activation_name of string
+
+type active_tool_surface
+
+(** Create one Agent-run-scoped lazy surface. Both the complete registered
+    catalog and the initial discovery surface are exact names. *)
+val create_active_tool_surface
+  :  registered_names:string list
+  -> initial_names:string list
+  -> (active_tool_surface, activation_error) result
+
+(** Activate exact registered names for subsequent SDK turns. *)
+val activate_exact
+  :  active_tool_surface
+  -> names:string list
+  -> (unit, activation_error) result
+
+(** Active names in canonical registration order. *)
+val active_names : active_tool_surface -> string list
+val is_active : active_tool_surface -> string -> bool

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -63,7 +63,6 @@ type agent_setup = Keeper_run_tools_hooks.agent_setup =
   ; model_input_projection : Agent_sdk.Agent.model_input_projection
   ; gate_replay_evidence : Keeper_gate_replay.model_evidence option
   ; acc : hook_accumulator
-  ; all_tool_names : string list
   ; final_oas_turn_ordinal_ref : int option ref
   ; receipt_turn_count_ref : int option ref
   ; receipt_model_used_ref : string option ref

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -59,7 +59,6 @@ type agent_setup =
   ; model_input_projection : Agent_sdk.Agent.model_input_projection
   ; gate_replay_evidence : Keeper_gate_replay.model_evidence option
   ; acc : hook_accumulator
-  ; all_tool_names : string list
   ; final_oas_turn_ordinal_ref : int option ref
   ; receipt_turn_count_ref : int option ref
   ; receipt_model_used_ref : string option ref

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -19,7 +19,6 @@ type agent_setup =
   ; model_input_projection : Agent_sdk.Agent.model_input_projection
   ; gate_replay_evidence : Keeper_gate_replay.model_evidence option
   ; acc : hook_accumulator
-  ; all_tool_names : string list
   ; final_oas_turn_ordinal_ref : int option ref
   ; receipt_turn_count_ref : int option ref
   ; receipt_model_used_ref : string option ref
@@ -31,7 +30,6 @@ type agent_setup =
 type ctx =
   { acc : hook_accumulator
   ; agent_name : string
-  ; all_tool_names : string list
   ; compute_tool_surface :
       turn:int -> current_tool_choice:Agent_sdk.Types.tool_choice option -> unit ->
       string list * turn_lane
@@ -171,7 +169,6 @@ let assemble_hooks
   let receipt_runtime_observation_ref = ctx.receipt_runtime_observation_ref in
   let receipt_response_text_present_ref = ctx.receipt_response_text_present_ref in
   let tools = ctx.tools in
-  let all_tool_names = ctx.all_tool_names in
   let initial_schema_filter, initial_turn_lane =
     compute_tool_surface
       ~turn:(start_turn_count + 1)
@@ -565,6 +562,7 @@ let assemble_hooks
                   { current_params with
                     extra_system_context = ctx
                   ; tool_choice
+                  ; tool_surface = Agent_sdk.Hooks.Selected_tools schema_filter
                   }
               | _event -> Agent_sdk.Hooks.Continue)
       }
@@ -588,7 +586,6 @@ let assemble_hooks
       ; model_input_projection
       ; gate_replay_evidence
       ; acc
-      ; all_tool_names
       ; final_oas_turn_ordinal_ref
       ; receipt_turn_count_ref
       ; receipt_model_used_ref

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -90,6 +90,55 @@ let gate_causal_initial
     ]
 ;;
 
+let initial_discovery_handler = function
+  | Keeper_tool_descriptor.Tool_tools_list | Tool_tool_search -> true
+  | ( Tool_execute
+    | Tool_search_files
+    | Tool_read_file
+    | Tool_edit_file
+    | Tool_write_file
+    | Tool_time_now
+    | Tool_context_status
+    | Tool_artifact_read
+    | Tool_memory_search
+    | Tool_memory_write
+    | Tool_library_search
+    | Tool_library_read
+    | Tool_surface_read
+    | Tool_surface_post
+    | Tool_person_note_set
+    | Tool_ide_annotate
+    | Tool_voice_dispatch
+    | Tool_task_dispatch
+    | Board_tool_dispatch
+    | Tool_masc_board_dispatch
+    | Tool_masc_task_dispatch
+    | Tool_masc_plan_dispatch
+    | Tool_masc_run_dispatch
+    | Tool_masc_agent_dispatch
+    | Tool_masc_workspace_dispatch
+    | Tool_masc_misc_dispatch
+    | Tool_web_search
+    | Tool_web_fetch
+    | Tool_masc_control_dispatch
+    | Tool_masc_agent_timeline_dispatch
+    | Tool_masc_schedule_dispatch
+    | Tool_masc_keeper_dispatch
+    | Tool_masc_fusion_dispatch
+    | Tool_masc_fusion_status
+    | Tool_masc_library_dispatch
+    | Tool_masc_local_runtime_dispatch
+    | Tool_analyze_image ) ->
+    false
+;;
+
+let initial_model_tool_names descriptors =
+  descriptors
+  |> List.filter (fun (descriptor : Keeper_tool_descriptor.t) ->
+    initial_discovery_handler descriptor.runtime_handler)
+  |> List.concat_map Keeper_tool_descriptor.keeper_model_names
+;;
+
 let prepare_agent_setup
       ~(config : Workspace.config)
       ~(meta : Keeper_meta_contract.keeper_meta)
@@ -296,7 +345,7 @@ let prepare_agent_setup
     - operator_only_count
     - invalid_schema_count
   in
-  let all_tool_names =
+  let registered_model_tool_names =
     List.map (fun (tool : Agent_sdk.Tool.t) -> tool.schema.name) keeper_tools
   in
   let expected_model_names =
@@ -304,24 +353,60 @@ let prepare_agent_setup
     |> List.concat_map Keeper_tool_descriptor.keeper_model_names
     |> List.sort_uniq String.compare
   in
-  let actual_model_names = List.sort_uniq String.compare all_tool_names in
-  let all_model_eligible_tools_visible =
-    expected_model_names = actual_model_names
-    && List.length actual_model_names = List.length all_tool_names
+  let actual_model_names =
+    List.sort_uniq String.compare registered_model_tool_names
   in
-  if not all_model_eligible_tools_visible
-  then
-    Log.Keeper.emit
-      Log.Error
-      ~keeper_name:meta.name
-      ~category:Log.Tool
-      ~details:
-        (`Assoc
-           [ "error_kind", `String "keeper_model_tool_projection_mismatch"
-           ; "expected_names", Json_util.json_string_list expected_model_names
-           ; "actual_names", Json_util.json_string_list all_tool_names
-           ])
-      "Keeper model tool bundle differs from the descriptor projection";
+  let model_projection_is_exact =
+    expected_model_names = actual_model_names
+    && List.length actual_model_names = List.length registered_model_tool_names
+  in
+  let reject_tool_surface detail =
+    (try keeper_tools_cleanup () with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Log.Keeper.error
+         "keeper tool cleanup after surface rejection raised: %s"
+         (Printexc.to_string exn));
+    Error
+      (Agent_sdk.Error.Config
+         (Agent_sdk.Error.InvalidConfig { field = "keeper.tool_surface"; detail }))
+  in
+  let* () =
+    if model_projection_is_exact
+    then Ok ()
+    else
+      reject_tool_surface
+        (Yojson.Safe.to_string
+           (`Assoc
+              [ "error_kind", `String "keeper_model_tool_projection_mismatch"
+              ; "expected_names", Json_util.json_string_list expected_model_names
+              ; "actual_names", Json_util.json_string_list registered_model_tool_names
+              ]))
+  in
+  let initial_discovery_names =
+    initial_model_tool_names model_visible_descriptors
+  in
+  let* active_tool_surface =
+    match
+      Keeper_agent_tool_surface.create_active_tool_surface
+        ~registered_names:registered_model_tool_names
+        ~initial_names:initial_discovery_names
+    with
+    | Ok surface -> Ok surface
+    | Error error ->
+      let detail =
+        match error with
+        | Duplicate_registered_name name ->
+          Printf.sprintf "duplicate registered model tool %S" name
+        | Duplicate_initial_name name ->
+          Printf.sprintf "duplicate initial discovery tool %S" name
+        | Unknown_initial_name name ->
+          Printf.sprintf "initial discovery tool %S is not registered" name
+        | Unknown_activation_name name ->
+          Printf.sprintf "activation tool %S is not registered" name
+      in
+      reject_tool_surface detail
+  in
   let tool_catalog_schemas =
     keeper_tools
     |> List.map (fun (tool : Agent_sdk.Tool.t) ->
@@ -334,46 +419,59 @@ let prepare_agent_setup
   in
   (local_search_fn_ref
    := fun ~query ~max_results ->
-        let ranked =
-          Keeper_tool_registry.rank_tool_schemas
-            ~query
-            ~max_results
-            tool_catalog_schemas
+        let ranked, exact_activation_name =
+          match
+            Keeper_tool_registry.search_tool_schemas
+              ~query
+              ~max_results
+              tool_catalog_schemas
+          with
+          | Exact_name ranked -> [ ranked ], Some ranked.schema.name
+          | Advisory_candidates ranked -> ranked, None
         in
-        let results =
-          List.map
-            (fun (ranked : Keeper_tool_registry.ranked_tool_schema) ->
-               `Assoc
-                 [ "name", `String ranked.schema.name
-                 ; "score", `Float ranked.score
-                 ; "description", `String ranked.schema.description
-                 ; "input_schema", ranked.schema.input_schema
-                 ; "already_visible", `Bool true
-                 ])
-            ranked
+        let activation_result =
+          match exact_activation_name with
+          | None -> Ok ()
+          | Some name ->
+            Keeper_agent_tool_surface.activate_exact
+              active_tool_surface
+              ~names:[ name ]
         in
-        Keeper_tool_execution.success
-          (Yojson.Safe.to_string
+        (match activation_result with
+         | Error _ ->
+           Keeper_tool_execution.failure_data
+             ~class_:Tool_result.Runtime_failure
+             ~message:"exact tool activation rejected an unregistered name"
+             (`Assoc [ "query", `String query ])
+         | Ok () ->
+           let results =
+             List.map
+               (fun (ranked : Keeper_tool_registry.ranked_tool_schema) ->
+                  `Assoc
+                    [ "name", `String ranked.schema.name
+                    ; "score", `Float ranked.score
+                    ; "description", `String ranked.schema.description
+                    ; "input_schema", ranked.schema.input_schema
+                    ; "activated", `Bool (Option.is_some exact_activation_name)
+                    ])
+               ranked
+           in
+           Keeper_tool_execution.success_data
              (`Assoc
-               [ "ok", `Bool true
-               ; "query", `String query
-               ; "results", `List results
-               ; "result_count", `Int (List.length results)
-               ; "registered_descriptor_count", `Int (List.length registered_descriptors)
-               ; "model_visible_descriptor_count", `Int (List.length model_visible_descriptors)
-               ; "transport_alias_count", `Int transport_alias_count
-               ; "operator_only_count", `Int operator_only_count
-               ; "invalid_schema_count", `Int invalid_schema_count
-               ; "unexplained_exclusion_count", `Int unexplained_exclusion_count
-               ; ( "all_model_eligible_tools_visible"
-                 , `Bool all_model_eligible_tools_visible )
-               ])));
+                [ "query", `String query
+                ; "results", `List results
+                ; "result_count", `Int (List.length results)
+                ; "exact_activation", `Bool (Option.is_some exact_activation_name)
+                ; ( "active_tool_names"
+                  , Json_util.json_string_list
+                      (Keeper_agent_tool_surface.active_names active_tool_surface) )
+                ])));
   Log.Keeper.routine
-    "keeper:%s tool visibility: registered=%d visible=%d transport_alias=%d \
+    "keeper:%s lazy tool surface: registered=%d initial=%d transport_alias=%d \
      operator_only=%d invalid_schema=%d unexplained=%d"
     meta.name
-    (List.length registered_descriptors)
-    (List.length all_tool_names)
+    (List.length registered_model_tool_names)
+    (List.length initial_discovery_names)
     transport_alias_count
     operator_only_count
     invalid_schema_count
@@ -411,7 +509,9 @@ let prepare_agent_setup
         ()
     : string list * turn_lane
     =
-    let schema_filter = all_tool_names in
+    let schema_filter =
+      Keeper_agent_tool_surface.active_names active_tool_surface
+    in
     let lane : Keeper_agent_tool_surface.turn_lane =
       if is_retry
       then Lane_retry
@@ -428,7 +528,6 @@ let prepare_agent_setup
   let ctx : Keeper_run_tools_hooks.ctx =
     { acc
     ; agent_name
-    ; all_tool_names
     ; compute_tool_surface
     ; record_tool_assignment
     ; config

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1584,10 +1584,10 @@ let internal_descriptors : t list =
        ~id:"keeper.tools_list"
        ~name:"keeper_tools_list"
        ~description:
-         "List the active keeper tool surface from descriptors and registered schemas. \
-          This is capability introspection, not connector content lookup. Use \
-          keeper_surface_read only for current conversation context. \
-          No arguments."
+         "List registered Keeper tool names and groups for exact activation through \
+          keeper_tool_search. This is capability introspection, not connector \
+          content lookup. Use keeper_surface_read only for current conversation \
+          context. No arguments."
        ~input_schema:empty_object_schema
        ~policy:(read_only_in_process_policy ())
        ~handler:Tool_tools_list
@@ -1597,8 +1597,9 @@ let internal_descriptors : t list =
        ~id:"keeper.tool_search"
        ~name:"keeper_tool_search"
        ~description:
-         "Search keeper tool schemas by free-text query. Returns ranked tool \
-          descriptions and input schemas."
+         "Search registered Keeper tool schemas. Free text returns advisory \
+          candidates; an exact tool name activates only that tool for the next \
+          SDK turn."
        ~input_schema:tool_search_schema
        ~policy:(read_only_in_process_policy ())
        ~handler:Tool_tool_search

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -37,9 +37,9 @@ let injected_masc_tool_names () =
 let keeper_tool_search_schema : Masc_domain.tool_schema =
   { name = Keeper_tool_name.to_string Keeper_tool_name.Tool_search
   ; description =
-      "Search the tool schemas visible in this Keeper turn by free-text query. \
-       Returns only the highest-ranked matching names, descriptions, and input \
-       schemas."
+      "Search registered Keeper tool schemas. A free-text query returns advisory \
+       candidates. Querying one exact returned tool name activates only that tool \
+       for the next SDK turn."
   ; input_schema =
       `Assoc
         [ "type", `String "object"
@@ -48,7 +48,9 @@ let keeper_tool_search_schema : Masc_domain.tool_schema =
               [ ( "query"
                 , `Assoc
                     [ "type", `String "string"
-                    ; "description", `String "Search query for available Keeper tools."
+                    ; ( "description"
+                      , `String
+                          "Free text for candidates, or one exact tool name to activate." )
                     ] )
               ; ( "max_results"
                 , `Assoc
@@ -99,4 +101,18 @@ let rank_tool_schemas ~query ~max_results schemas =
       | 0 -> String.compare left.schema.name right.schema.name
       | ordering -> ordering)
     |> List.filteri (fun index _ -> index < limit)
+;;
+
+type schema_search =
+  | Exact_name of ranked_tool_schema
+  | Advisory_candidates of ranked_tool_schema list
+
+let search_tool_schemas ~query ~max_results schemas =
+  match
+    List.find_opt
+      (fun (schema : Masc_domain.tool_schema) -> String.equal schema.name query)
+      schemas
+  with
+  | Some schema -> Exact_name { schema; score = 1.0 }
+  | None -> Advisory_candidates (rank_tool_schemas ~query ~max_results schemas)
 ;;

--- a/lib/keeper/keeper_tool_registry.mli
+++ b/lib/keeper/keeper_tool_registry.mli
@@ -23,7 +23,7 @@ type ranked_tool_schema =
   ; score : float
   }
 
-(** Rank the supplied, already-authorized tool schemas against [query] using
+(** Rank registered tool schemas against [query] using
     the repository-wide multilingual text-similarity contract. Zero-score
     entries are omitted and no more than [max_results] (clamped to 1–10) are
     returned. *)
@@ -32,3 +32,15 @@ val rank_tool_schemas :
   max_results:int ->
   Masc_domain.tool_schema list ->
   ranked_tool_schema list
+
+type schema_search =
+  | Exact_name of ranked_tool_schema
+  | Advisory_candidates of ranked_tool_schema list
+
+(** Exact name equality is the only activation-capable outcome. Free text
+    produces advisory candidates. *)
+val search_tool_schemas
+  :  query:string
+  -> max_results:int
+  -> Masc_domain.tool_schema list
+  -> schema_search

--- a/lib/keeper/keeper_tool_shared_runtime.ml
+++ b/lib/keeper/keeper_tool_shared_runtime.ml
@@ -399,34 +399,29 @@ let tag_dispatch_fn
       None)
 ;;
 
-let descriptor_active_names active_name_set descriptor =
-  Keeper_tool_descriptor.keeper_model_names descriptor
-  |> List.filter (fun name -> StringSet.mem name active_name_set)
-;;
-
-let descriptor_discovery_json active_name_set descriptor =
+let descriptor_discovery_json descriptor =
   `Assoc
     (Keeper_tool_descriptor.discovery_fields descriptor
-     @ [ ( "active_names"
+     @ [ ( "model_names"
          , Json_util.json_string_list
-             (descriptor_active_names active_name_set descriptor) )
+             (Keeper_tool_descriptor.keeper_model_names descriptor) )
        ])
 ;;
 
 let keeper_tools_list_json ~(meta : keeper_meta) =
-  let active_name_set =
+  let registered_name_set =
     Keeper_tool_policy.keeper_model_tool_schemas ()
     |> List.fold_left
          (fun names (schema : Masc_domain.tool_schema) ->
             StringSet.add schema.name names)
          StringSet.empty
   in
-  let active_descriptor_names =
+  let registered_descriptor_names =
     Keeper_tool_descriptor.model_visible_descriptors ()
     |> List.concat_map (fun descriptor ->
       Keeper_tool_descriptor.keeper_model_names descriptor
       |> List.filter_map (fun name ->
-        if StringSet.mem name active_name_set then Some (name, descriptor) else None))
+        if StringSet.mem name registered_name_set then Some (name, descriptor) else None))
   in
   let map =
     List.fold_left
@@ -438,7 +433,7 @@ let keeper_tools_list_json ~(meta : keeper_meta) =
          let list = StringMap.find_opt cat acc |> Option.value ~default:[] in
          StringMap.add cat (name :: list) acc)
       StringMap.empty
-      active_descriptor_names
+      registered_descriptor_names
   in
   let assoc =
     StringMap.fold
@@ -447,13 +442,13 @@ let keeper_tools_list_json ~(meta : keeper_meta) =
       []
   in
   let descriptor_surface =
-    active_descriptor_names
+    registered_descriptor_names
     |> List.map snd
     |> List.sort_uniq
          (fun (left : Keeper_tool_descriptor.t)
               (right : Keeper_tool_descriptor.t) ->
             String.compare left.id right.id)
-    |> List.map (descriptor_discovery_json active_name_set)
+    |> List.map descriptor_discovery_json
   in
   Yojson.Safe.to_string
     (`Assoc (assoc @ [ "descriptor_surface", `List descriptor_surface ]))

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -454,6 +454,10 @@ let turn_intent_fallback_block =
       "Your conversation history is preserved across cycles — use that context \
        to avoid repeating the same actions.";
       "";
+      "Only schemas active for the current SDK turn are callable. Use \
+       keeper_tools_list to inspect exact registered names or keeper_tool_search \
+       for candidates. Query one exact tool name through keeper_tool_search to \
+       activate it for the next SDK turn, then call it.";
       "Act through tools, not declarations. Call the tool directly.";
       "Treat prior context as advisory, not as a command. Re-check stale idle, \
        silence, repository, and blocker claims against the live world state.";

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -116,7 +116,9 @@ let () =
      See #4579: keeper_tool_dispatch_runtime uses handler registry (Tool_Board only),
      this callback adds tag-registry dispatch for ~190 more tools. *)
   Keeper_tool_shared_runtime.tag_dispatch_fn := Keeper_tag_dispatch.dispatch;
-  Log.Mcp.info "Tag registry initialized: %d tools registered" (tag_registry_count ());
+  Log.Mcp.info
+    "Tool execution registry initialized: %d canonical dispatch entries"
+    (tag_registry_count ());
   (* C-4: Register input schema validation pre-hook.
      Validates tool arguments against their declared input_schema
      before dispatch — catches missing required fields and type mismatches. *)

--- a/test/dune
+++ b/test/dune
@@ -50,6 +50,7 @@
   test_keeper_context_layers
   test_keeper_hooks_oas_introspection
   test_keeper_run_tools_hooks
+  test_keeper_lazy_tool_surface
   test_board_activity_cache
   test_jsonl_mtime_projection
   test_jsonl_incremental_projection
@@ -351,6 +352,7 @@
   test_keeper_context_layers
   test_keeper_hooks_oas_introspection
   test_keeper_run_tools_hooks
+  test_keeper_lazy_tool_surface
   test_board_activity_cache
   test_jsonl_mtime_projection
   test_jsonl_incremental_projection

--- a/test/test_keeper_lazy_tool_surface.ml
+++ b/test/test_keeper_lazy_tool_surface.ml
@@ -1,0 +1,144 @@
+open Masc
+
+let surface () =
+  match
+    Keeper_agent_tool_surface.create_active_tool_surface
+      ~registered_names:[ "list"; "search"; "read"; "write" ]
+      ~initial_names:[ "list"; "search" ]
+  with
+  | Ok surface -> surface
+  | Error _ -> Alcotest.fail "valid lazy surface was rejected"
+;;
+
+let test_initial_surface_is_exact () =
+  Alcotest.(check (list string))
+    "initial names"
+    [ "list"; "search" ]
+    (Keeper_agent_tool_surface.active_names (surface ()))
+;;
+
+let test_actual_catalog_starts_with_discovery_only () =
+  let descriptors = Keeper_tool_descriptor.model_visible_descriptors () in
+  let registered_names =
+    List.concat_map Keeper_tool_descriptor.keeper_model_names descriptors
+  in
+  let initial_names = Keeper_run_tools_setup.initial_model_tool_names descriptors in
+  Alcotest.(check (list string))
+    "initial discovery names"
+    [ "keeper_tools_list"; "keeper_tool_search" ]
+    initial_names;
+  Alcotest.(check bool)
+    "registered catalog remains larger than provider surface"
+    true
+    (List.length registered_names > List.length initial_names)
+;;
+
+let test_activation_preserves_registration_order () =
+  let surface = surface () in
+  (match Keeper_agent_tool_surface.activate_exact surface ~names:[ "write"; "read" ] with
+   | Ok () -> ()
+   | Error _ -> Alcotest.fail "registered activation was rejected");
+  Alcotest.(check (list string))
+    "canonical order"
+    [ "list"; "search"; "read"; "write" ]
+    (Keeper_agent_tool_surface.active_names surface)
+;;
+
+let test_unknown_activation_fails_without_mutation () =
+  let surface = surface () in
+  (match Keeper_agent_tool_surface.activate_exact surface ~names:[ "missing" ] with
+   | Error (Keeper_agent_tool_surface.Unknown_activation_name "missing") -> ()
+   | Error _ -> Alcotest.fail "wrong typed activation error"
+   | Ok () -> Alcotest.fail "unknown activation was accepted");
+  Alcotest.(check (list string))
+    "unchanged"
+    [ "list"; "search" ]
+    (Keeper_agent_tool_surface.active_names surface)
+;;
+
+let test_invalid_initial_surfaces_fail_closed () =
+  (match
+     Keeper_agent_tool_surface.create_active_tool_surface
+       ~registered_names:[ "search"; "search" ]
+       ~initial_names:[ "search" ]
+   with
+   | Error (Keeper_agent_tool_surface.Duplicate_registered_name "search") -> ()
+   | Error _ -> Alcotest.fail "wrong duplicate registration error"
+   | Ok _ -> Alcotest.fail "duplicate registration was accepted");
+  match
+    Keeper_agent_tool_surface.create_active_tool_surface
+      ~registered_names:[ "search" ]
+      ~initial_names:[ "missing" ]
+  with
+  | Error (Keeper_agent_tool_surface.Unknown_initial_name "missing") -> ()
+  | Error _ -> Alcotest.fail "wrong unknown initial error"
+  | Ok _ -> Alcotest.fail "unknown initial name was accepted"
+;;
+
+let schema name description : Masc_domain.tool_schema =
+  { name; description; input_schema = `Assoc [ "type", `String "object" ] }
+;;
+
+let test_only_exact_name_is_activation_capable () =
+  let schemas = [ schema "keeper_read_file" "Read a file" ] in
+  (match
+     Keeper_tool_registry.search_tool_schemas
+       ~query:"read file"
+       ~max_results:5
+       schemas
+   with
+   | Keeper_tool_registry.Advisory_candidates [ ranked ] ->
+     Alcotest.(check string) "candidate" "keeper_read_file" ranked.schema.name
+  | Keeper_tool_registry.Advisory_candidates _ ->
+    Alcotest.fail "expected one advisory candidate"
+  | Keeper_tool_registry.Exact_name _ ->
+    Alcotest.fail "free text became activation authority");
+  (match
+     Keeper_tool_registry.search_tool_schemas
+       ~query:" keeper_read_file "
+       ~max_results:5
+       schemas
+   with
+   | Keeper_tool_registry.Advisory_candidates _ -> ()
+   | Keeper_tool_registry.Exact_name _ ->
+     Alcotest.fail "whitespace-normalized name became activation authority");
+  match
+    Keeper_tool_registry.search_tool_schemas
+      ~query:"keeper_read_file"
+      ~max_results:5
+      schemas
+  with
+  | Keeper_tool_registry.Exact_name ranked ->
+    Alcotest.(check string) "exact" "keeper_read_file" ranked.schema.name
+  | Keeper_tool_registry.Advisory_candidates _ ->
+    Alcotest.fail "exact name did not produce exact activation"
+;;
+
+let () =
+  Alcotest.run
+    "keeper lazy tool surface"
+    [ ( "activation"
+      , [ Alcotest.test_case "initial exact" `Quick test_initial_surface_is_exact
+        ; Alcotest.test_case
+            "actual catalog starts with discovery only"
+            `Quick
+            test_actual_catalog_starts_with_discovery_only
+        ; Alcotest.test_case
+            "canonical activation order"
+            `Quick
+            test_activation_preserves_registration_order
+        ; Alcotest.test_case
+            "unknown activation is atomic"
+            `Quick
+            test_unknown_activation_fails_without_mutation
+        ; Alcotest.test_case
+            "invalid initial surfaces"
+            `Quick
+            test_invalid_initial_surfaces_fail_closed
+        ; Alcotest.test_case
+            "only exact names activate"
+            `Quick
+            test_only_exact_name_is_activation_capable
+        ] )
+    ]
+;;

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -433,17 +433,17 @@ let test_keeper_tools_list_json_uses_typed_groups () =
     (match List.assoc_opt "internal_name" execute_fields with
      | Some (`String internal_name) -> internal_name
      | _ -> fail "discovery_fields missing internal_name");
-  check bool "discovery_fields leaves active_names to shared runtime" true
-    (Option.is_none (List.assoc_opt "active_names" execute_fields));
+  check bool "discovery_fields leaves model_names to shared runtime" true
+    (Option.is_none (List.assoc_opt "model_names" execute_fields));
   let execute = find_descriptor "tool_execute" in
   check string "Execute public alias" "Execute"
     (string_member "public_name" execute);
   check string "Execute executor" "shell_ir"
     (string_member "executor" execute);
   check bool "Execute internal route is not a model name" false
-    (list_member_contains "active_names" "tool_execute" execute);
-  check bool "Execute active public name listed" true
-    (list_member_contains "active_names" "Execute" execute);
+    (list_member_contains "model_names" "tool_execute" execute);
+  check bool "Execute public model name listed" true
+    (list_member_contains "model_names" "Execute" execute);
   check string "Execute model projection" "preferred_public_name"
     (string_member "keeper_model_projection" execute);
   let policy = Yojson.Safe.Util.member "policy" execute in
@@ -500,11 +500,11 @@ let test_keeper_tools_list_json_uses_typed_groups () =
   check bool "Grep policy group omitted" true
     (Yojson.Safe.Util.member "policy_group" grep_policy = `Null);
   check bool "Grep internal route is not a model name" false
-    (list_member_contains "active_names" "tool_search_files" grep);
+    (list_member_contains "model_names" "tool_search_files" grep);
   check bool "Grep preferred model name listed" true
-    (list_member_contains "active_names" "Grep" grep);
+    (list_member_contains "model_names" "Grep" grep);
   check bool "Grep compatibility alias is not a model name" false
-    (list_member_contains "active_names" "Search" grep);
+    (list_member_contains "model_names" "Search" grep);
   let malformed_execute =
     { (descriptor_for_internal "tool_execute") with
       KTD.input_schema =


### PR DESCRIPTION
## Summary\n\n- keep the canonical execution registry complete while exposing only keeper_tools_list and keeper_tool_search on the first SDK turn\n- make free-text search advisory and exact byte-for-byte canonical names the only activation authority\n- project the Agent-run active set through OAS Hooks.Selected_tools on every turn\n- remove misleading all-visible telemetry and descriptor active_names projection\n\n## Dependency\n\nDepends on jeong-sik/oas#2933. Local verification used that PR's build install tree through OCAMLPATH without changing the global opam pin.\n\n## Contract\n\n- registered handlers remain available to the executor registry\n- provider schemas and executable handlers are the same selected Tool_set\n- unknown, duplicate, blank, padded, or fuzzy names never activate a tool\n- activation is Agent-run-local and takes effect on the next SDK turn\n- effect authorization remains at the typed Gate before the sink\n\n## Verification\n\n- focused MASC library build against OAS #2933\n- test_keeper_lazy_tool_surface: 6/6 passed, including the real descriptor catalog starting with exactly two discovery schemas\n- test_keeper_tool_descriptor_registry_integrity: 45/45 passed\n- keeper_tools_list_json subset: 2/2 passed\n- test_keeper_hooks_oas_introspection: 5/5 passed\n- ocamlformat --check on all 14 touched OCaml files\n- git diff --check\n\nThe full test_keeper_run_tools_hooks executable has one existing Docker path mapping failure reproduced unchanged on the main checkout binary. The full test_keeper_tool_dispatch_runtime executable has five unrelated existing failures; the touched keeper_tools_list_json subset passes.