### PR TITLE
fix(metrics): stop replaying persisted latency at startup

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -628,11 +628,6 @@ let lazy_startup_plan () =
             "keeper_history_migration";
           ];
       };
-      {
-        group_name = "tool_state";
-        execution = Serial;
-        task_names = [ "tool_metrics_restore" ];
-      };
     ]
   in
   let cleanup_groups =
@@ -1066,18 +1061,6 @@ let bootstrap_prompt_state (state : Mcp_server.server_state) =
       |> String.concat ", ")
   end
 
-let restore_tool_metrics_from_disk (state : Mcp_server.server_state) =
-  (try
-     let n = Tool_metrics_persist.restore
-       ~base_path:(Mcp_server.workspace_config state).base_path in
-     if n > 0 then
-       Log.Misc.info "tool metrics: restored %d records from disk" n
-   with
-   | Eio.Cancel.Cancelled _ as e -> raise e
-   | exn ->
-     Log.Misc.warn "tool metrics restore failed: %s (metrics empty until next emission)"
-       (Printexc.to_string exn))
-
 let start_owner_lazy_tasks ~sw state =
   let run_lazy_task (task_name, task_fn) =
     Log.Server.info "lazy_task: starting %s" task_name;
@@ -1095,7 +1078,6 @@ let start_owner_lazy_tasks ~sw state =
   let task_fn = function
     | "restore_sessions" -> fun () -> restore_persisted_sessions state
     | "keeper_history_migration" -> fun () -> startup_migrate_keeper_histories state
-    | "tool_metrics_restore" -> fun () -> restore_tool_metrics_from_disk state
     | "jsonl_prune" -> fun () -> startup_prune_jsonl state
     | task_name ->
       raise

--- a/lib/tool_metrics_persist.ml
+++ b/lib/tool_metrics_persist.ml
@@ -23,7 +23,6 @@ module Float = Stdlib.Float
     Design:
     - Each tool call is serialized as a single JSONL line.
     - Records are buffered in a bounded best-effort queue and flushed every 5 minutes.
-    - On startup, existing day-files are read and replayed into Tool_metrics.
     - All I/O failures are caught and logged (best-effort persistence).
 
     @since 2.108.0 — Issue #3280 *)
@@ -39,46 +38,6 @@ let record_to_json (r : Tool_result.result) : Yojson.Safe.t =
     ; ("duration_ms", `Float (Tool_result.duration_ms r))
     ; ("ts", `Float (Time_compat.now ()))
     ]
-
-type persisted_record = {
-  tool_name : string;
-  disposition : (unit, unit, unit) Tool_result.disposition;
-  duration_ms : float;
-}
-
-type parsed_record =
-  | Current_record of persisted_record
-  | Legacy_success_record
-
-let parse_record (json : Yojson.Safe.t)
-  : (parsed_record, string) Result.t =
-  let tool_name = Safe_ops.json_string_opt "tool_name" json in
-  let disposition = Safe_ops.json_string_opt "disposition" json in
-  let legacy_success = Safe_ops.json_bool_opt "success" json in
-  let duration_ms = Safe_ops.json_float_opt "duration_ms" json in
-  match tool_name, disposition, legacy_success, duration_ms with
-  | Some tool_name, Some disposition, _, Some duration_ms ->
-    Tool_result.unit_disposition_of_string disposition
-    |> Result.map (fun disposition ->
-      Current_record { tool_name; disposition; duration_ms })
-  | Some _, None, Some _, Some _ ->
-    (* The legacy success bit cannot distinguish the current Deferred and
-       Failed dispositions. Keep the execution-disposition SSOT intact while
-       classifying these rows separately from malformed data. *)
-    Ok Legacy_success_record
-  | _ ->
-    let missing =
-      [ ("tool_name", Option.is_none tool_name)
-      ; ("disposition", Option.is_none disposition)
-      ; ("duration_ms", Option.is_none duration_ms)
-      ]
-      |> List.filter_map (fun (field, is_missing) ->
-        if is_missing then Some field else None)
-    in
-    Otel_metric_store.inc_counter Otel_metric_store.metric_error_events ~labels:[("type", Error_event_type.(to_label Parsing))] ();
-    Error
-      (Printf.sprintf "missing required field(s): %s"
-         (String.concat ", " missing))
 
 (* ── Write queue ────────────────────────────────────── *)
 
@@ -168,18 +127,10 @@ let drain_to_store (store : Dated_jsonl.t) : int =
   drain ();
   !count
 
-let flush_now () =
-  match !store_ref with
-  | None ->
-    (* Store not yet initialized — drain and discard to prevent unbounded growth.
-       In practice, restore() initializes store_ref before any enqueue calls. *)
-    let dropped = drain_queue_without_store () in
-    if dropped > 0 then
-      Log.Metrics.warn "tool_metrics_persist: flush_now called before init, dropped %d records"
-        dropped
-  | Some (_, store) ->
-    let flushed = drain_to_store store in
-    Log.Metrics.debug "tool_metrics_persist: flushed %d records" flushed
+let flush_now ~base_path =
+  let store = get_or_create_store ~base_path in
+  let flushed = drain_to_store store in
+  Log.Metrics.debug "tool_metrics_persist: flushed %d records" flushed
 
 let start_flush_fiber ~sw ~clock ~base_path =
   let store = get_or_create_store ~base_path in
@@ -209,65 +160,3 @@ let start_flush_fiber ~sw ~clock ~base_path =
     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       Log.Metrics.error "tool_metrics_persist: shutdown flush failed: %s"
         (Stdlib.Printexc.to_string exn))
-
-(* ── Restore on startup ─────────────────────────────── *)
-
-let restore ~base_path : int =
-  let store = get_or_create_store ~base_path in
-  let count = ref 0 in
-  let legacy = ref 0 in
-  let skipped = ref 0 in
-  let first_skip_reason = ref None in
-  (try
-     Dated_jsonl.iter_all store (fun json ->
-       match parse_record json with
-       | Ok (Current_record r) ->
-         let result : Tool_result.result =
-           match r.disposition with
-           | Tool_result.Completed () ->
-             Tool_result.Completed
-               { Tool_result.tool_name = r.tool_name
-               ; data = `Null
-               ; metadata = None
-               ; duration_ms = r.duration_ms
-               }
-           | Tool_result.Deferred () ->
-             Tool_result.Deferred
-               { Tool_result.tool_name = r.tool_name
-               ; data = `Null
-               ; metadata = None
-               ; duration_ms = r.duration_ms
-               }
-           | Tool_result.Failed () ->
-             Tool_result.Failed
-               { Tool_result.class_ = Tool_result.Runtime_failure
-               ; message = ""
-               ; data = `Null
-               ; tool_name = r.tool_name
-               ; duration_ms = r.duration_ms
-               }
-         in
-         Tool_metrics.record result;
-         Stdlib.incr count
-       | Ok Legacy_success_record -> Stdlib.incr legacy
-       | Error reason ->
-         Stdlib.incr skipped;
-         if Option.is_none !first_skip_reason then
-           first_skip_reason := Some reason);
-     if !legacy > 0 then
-       Log.Metrics.info
-         "tool_metrics_persist: ignored %d legacy success-only record(s); boolean success cannot reconstruct completed/deferred/failed disposition"
-         !legacy;
-     if !skipped > 0 then
-       Log.Metrics.warn
-         "tool_metrics_persist: skipped %d malformed restore record(s)%s"
-         !skipped
-         (match !first_skip_reason with
-          | Some reason -> Printf.sprintf " (first error: %s)" reason
-          | None -> "")
-   with
-   | Eio.Cancel.Cancelled _ as e -> raise e
-   | exn ->
-     Log.Metrics.error "tool_metrics_persist: restore failed: %s"
-       (Stdlib.Printexc.to_string exn));
-  !count

--- a/lib/tool_metrics_persist.mli
+++ b/lib/tool_metrics_persist.mli
@@ -3,7 +3,6 @@
 
     Periodically flushes in-memory tool invocation records to
     [data/tool-metrics/YYYY-MM/DD.jsonl] via {!Dated_jsonl}.
-    On server startup, restores previous records into {!Tool_metrics}.
 
     Flush failures are logged but do not affect server operation.
 
@@ -21,14 +20,9 @@ val start_flush_fiber : sw:Eio.Switch.t -> clock:_ Eio.Time.clock -> base_path:s
     shutdown hook to flush remaining records.
     [base_path] is the workspace root (e.g. [state.workspace_config.base_path]). *)
 
-val restore : base_path:string -> int
-(** [restore ~base_path] reads all existing JSONL day-files under
-    [base_path/data/tool-metrics/] and replays them into {!Tool_metrics}.
-    Returns the number of records restored. *)
-
-val flush_now : unit -> unit
-(** [flush_now ()] immediately drains the write queue to disk.
-    Intended for shutdown hooks and testing. *)
+val flush_now : base_path:string -> unit
+(** [flush_now ~base_path] immediately drains the write queue to the
+    current JSONL store. Intended for shutdown hooks and testing. *)
 
 val reset_for_testing : unit -> unit
 (** Clear cached store state and drop any queued records held in memory.

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -4017,20 +4017,18 @@ let test_lazy_startup_plan_groups_independent_tasks () =
   let groups = Server_runtime_bootstrap.lazy_startup_plan () in
   Alcotest.(check (list string))
     "group order"
-    [ "initialize"; "tool_state"; "cleanup" ]
+    [ "initialize"; "cleanup" ]
     (List.map
        (fun group -> group.Server_runtime_bootstrap.group_name)
        groups);
   match groups with
-  | [ initialize; tool_state; cleanup ] ->
+  | [ initialize; cleanup ] ->
       check_lazy_group initialize ~name:"initialize" ~execution:"parallel"
         ~tasks:
           [
             "restore_sessions";
             "keeper_history_migration";
           ];
-      check_lazy_group tool_state ~name:"tool_state" ~execution:"serial"
-        ~tasks:[ "tool_metrics_restore" ];
       check_lazy_group cleanup ~name:"cleanup" ~execution:"serial"
         ~tasks:[ "jsonl_prune" ];
       Alcotest.(check (list string))
@@ -4038,7 +4036,6 @@ let test_lazy_startup_plan_groups_independent_tasks () =
         [
           "restore_sessions";
           "keeper_history_migration";
-          "tool_metrics_restore";
           "jsonl_prune";
         ]
         (Server_runtime_bootstrap.lazy_startup_task_names ())

--- a/test/test_tool_metrics_persist.ml
+++ b/test/test_tool_metrics_persist.ml
@@ -1,7 +1,6 @@
-(** Tests for Tool_metrics_persist — JSONL disk persistence round-trip *)
+(** Tests for the write-only tool metrics JSONL stream. *)
 
 module P = Masc.Tool_metrics_persist
-module M = Tool_metrics
 module R = Tool_result
 
 let make_result ~name ~success ~duration_ms : R.result =
@@ -16,32 +15,45 @@ let make_result ~name ~success ~duration_ms : R.result =
       ; duration_ms
       }
 
-(** Wrap each test in Eio_main.run for Eio.Mutex support. *)
 let eio_test name fn =
   Alcotest.test_case name `Quick (fun () ->
     Eio_main.run @@ fun env ->
     Fs_compat.set_fs (Eio.Stdenv.fs env);
     fn ())
 
-(** Create a temp directory for test isolation. *)
 let with_tmp_dir f =
-  let dir = Filename.concat (Filename.get_temp_dir_name ())
-    (Printf.sprintf "test-tool-metrics-persist-%d-%d"
-       (Unix.getpid ())
-       (int_of_float (Unix.gettimeofday () *. 1000.0))) in
-  Fs_compat.mkdir_p (Filename.concat dir "data/tool-metrics");
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf
+         "test-tool-metrics-persist-%d-%d"
+         (Unix.getpid ())
+         (int_of_float (Unix.gettimeofday () *. 1000.0)))
+  in
   P.reset_for_testing ();
-  Fun.protect ~finally:(fun () ->
-    P.reset_for_testing ();
-    Fs_compat.remove_tree dir
-  ) (fun () -> f dir)
+  Fun.protect
+    ~finally:(fun () ->
+      P.reset_for_testing ();
+      Fs_compat.remove_tree dir)
+    (fun () -> f dir)
 
-let test_enqueue_flush_restore () =
+let read_records ~base_path =
+  let dir = Filename.concat base_path "data/tool-metrics" in
+  if not (Sys.file_exists dir)
+  then []
+  else (
+    let records = ref [] in
+    let store = Dated_jsonl.create ~base_dir:dir () in
+    Dated_jsonl.iter_all store (fun json -> records := json :: !records);
+    List.rev !records)
+
+let string_field key json =
+  match Safe_ops.json_string_opt key json with
+  | Some value -> value
+  | None -> Alcotest.failf "missing string field %s" key
+
+let test_enqueue_flush_current_records () =
   with_tmp_dir (fun base_path ->
-    M.clear ();
-    (* Initialize the store by triggering restore on the empty dir *)
-    ignore (P.restore ~base_path);
-    (* Enqueue some records *)
     P.enqueue (make_result ~name:"alpha" ~success:true ~duration_ms:10.0);
     P.enqueue (make_result ~name:"alpha" ~success:false ~duration_ms:5.0);
     P.enqueue
@@ -52,92 +64,32 @@ let test_enqueue_flush_restore () =
          ; duration_ms = 3.0
          });
     P.enqueue (make_result ~name:"beta" ~success:true ~duration_ms:20.0);
-    (* flush_now drains the queue to disk *)
-    P.flush_now ();
-    (* Clear in-memory metrics to verify restore works from disk *)
-    M.clear ();
-    Alcotest.(check bool) "cleared" true (Option.is_none (M.stats_for "alpha"));
-    (* Restore from disk *)
-    let n = P.restore ~base_path in
-    Alcotest.(check int) "restored 4 records" 4 n;
-    (* Verify metrics are restored *)
-    (match M.stats_for "alpha" with
-     | Some s ->
-       Alcotest.(check int) "alpha call_count" 3 s.call_count;
-       Alcotest.(check int) "alpha success" 1 s.success_count;
-       Alcotest.(check int) "alpha deferred" 1 s.deferred_count;
-       Alcotest.(check int) "alpha failure" 1 s.failure_count
-     | None -> Alcotest.fail "expected alpha stats");
-    (match M.stats_for "beta" with
-     | Some s ->
-       Alcotest.(check int) "beta call_count" 1 s.call_count;
-       Alcotest.(check int) "beta success" 1 s.success_count
-     | None -> Alcotest.fail "expected beta stats"))
+    P.flush_now ~base_path;
+    let records = read_records ~base_path in
+    Alcotest.(check int) "four records written" 4 (List.length records);
+    Alcotest.(check (list string))
+      "current dispositions only"
+      [ "completed"; "failed"; "deferred"; "completed" ]
+      (List.map (string_field "disposition") records);
+    Alcotest.(check bool)
+      "removed success-bit format is not emitted"
+      true
+      (List.for_all
+         (fun json -> Safe_ops.json_bool_opt "success" json = None)
+         records))
 
-let test_restore_empty_dir () =
+let test_reset_discards_queued_records () =
   with_tmp_dir (fun base_path ->
-    M.clear ();
-    let n = P.restore ~base_path in
-    Alcotest.(check int) "no records" 0 n)
-
-let test_malformed_lines_skipped () =
-  with_tmp_dir (fun base_path ->
-    M.clear ();
-    (* Write a malformed line directly to the JSONL file *)
-    let dir = Filename.concat base_path "data/tool-metrics" in
-    let tm = Unix.gmtime (Unix.gettimeofday ()) in
-    let month_dir = Filename.concat dir
-      (Printf.sprintf "%04d-%02d" (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1)) in
-    Fs_compat.mkdir_p month_dir;
-    let day_file = Filename.concat month_dir
-      (Printf.sprintf "%02d.jsonl" tm.Unix.tm_mday) in
-    (* One valid row plus two invalid schema shapes. *)
-    let valid_line = Yojson.Safe.to_string
-      (`Assoc [
-        ("tool_name", `String "good");
-        ("disposition", `String "completed");
-        ("duration_ms", `Float 7.0);
-        ("ts", `Float 1000.0);
-    ]) in
-    let malformed_line = "{\"garbage\": true}" in
-    let forbidden_success_only_line =
-      Yojson.Safe.to_string
-        (`Assoc
-          [ "tool_name", `String "success-only"
-          ; "success", `Bool true
-          ; "duration_ms", `Float 2.0
-          ; "ts", `Float 1000.0
-          ])
-    in
-    let content =
-      String.concat
-        "\n"
-        [ valid_line; malformed_line; forbidden_success_only_line; "" ]
-    in
-    Fs_compat.append_file day_file content;
-    let n = P.restore ~base_path in
-    Alcotest.(check int) "only current record restored" 1 n;
-    (match M.stats_for "good" with
-     | Some s -> Alcotest.(check int) "good count" 1 s.call_count
-     | None -> Alcotest.fail "expected good stats");
-    Alcotest.(check bool) "malformed row is not reconstructed" true
-      (Option.is_none (M.stats_for "garbage"));
-    Alcotest.(check bool) "success-only row is not reconstructed" true
-      (Option.is_none (M.stats_for "success-only")))
-
-let test_reset_clears_cached_store () =
-  with_tmp_dir (fun base_path ->
-    ignore (P.restore ~base_path);
     P.enqueue (make_result ~name:"alpha" ~success:true ~duration_ms:1.0);
     P.reset_for_testing ();
-    P.flush_now ();
-    let restored = P.restore ~base_path in
-    Alcotest.(check int) "reset drops queued records and cache" 0 restored)
+    P.flush_now ~base_path;
+    Alcotest.(check int)
+      "reset leaves no persisted rows"
+      0
+      (List.length (read_records ~base_path)))
 
 let test_enqueue_drops_when_queue_full () =
   with_tmp_dir (fun base_path ->
-    M.clear ();
-    ignore (P.restore ~base_path);
     for i = 1 to 4101 do
       P.enqueue
         (make_result
@@ -145,15 +97,14 @@ let test_enqueue_drops_when_queue_full () =
            ~success:true
            ~duration_ms:1.0)
     done;
-    P.flush_now ();
-    M.clear ();
-    let restored = P.restore ~base_path in
-    Alcotest.(check int) "bounded queue persists only capacity" 4096 restored)
+    P.flush_now ~base_path;
+    Alcotest.(check int)
+      "bounded queue persists only capacity"
+      4096
+      (List.length (read_records ~base_path)))
 
 let test_enqueue_multidomain_drop_is_bounded () =
   with_tmp_dir (fun base_path ->
-    M.clear ();
-    ignore (P.restore ~base_path);
     let spawn producer =
       Domain.spawn (fun () ->
         for i = 1 to 1500 do
@@ -166,25 +117,23 @@ let test_enqueue_multidomain_drop_is_bounded () =
     in
     let domains = List.init 4 spawn in
     List.iter Domain.join domains;
-    P.flush_now ();
-    M.clear ();
-    let restored = P.restore ~base_path in
-    Alcotest.(check int) "multi-domain producers persist only capacity" 4096 restored)
+    P.flush_now ~base_path;
+    Alcotest.(check int)
+      "multi-domain producers persist only capacity"
+      4096
+      (List.length (read_records ~base_path)))
 
 let () =
-  Alcotest.run "Tool_metrics_persist" [
-    "persistence", [
-      eio_test "enqueue, flush, restore round-trip"
-        test_enqueue_flush_restore;
-      eio_test "restore from empty dir"
-        test_restore_empty_dir;
-      eio_test "malformed lines skipped"
-        test_malformed_lines_skipped;
-      eio_test "reset clears cached store"
-        test_reset_clears_cached_store;
-      eio_test "enqueue drops instead of blocking when queue is full"
-        test_enqueue_drops_when_queue_full;
-      eio_test "enqueue drops safely from multiple domains"
-        test_enqueue_multidomain_drop_is_bounded;
-    ];
-  ]
+  Alcotest.run
+    "Tool_metrics_persist"
+    [ ( "persistence"
+      , [ eio_test "enqueue and flush current rows" test_enqueue_flush_current_records
+        ; eio_test "reset discards queued records" test_reset_discards_queued_records
+        ; eio_test
+            "enqueue drops instead of blocking when queue is full"
+            test_enqueue_drops_when_queue_full
+        ; eio_test
+            "enqueue drops safely from multiple domains"
+            test_enqueue_multidomain_drop_is_bounded
+        ] )
+    ]

--- a/test/test_tool_metrics_persist.ml
+++ b/test/test_tool_metrics_persist.ml
@@ -22,14 +22,7 @@ let eio_test name fn =
     fn ())
 
 let with_tmp_dir f =
-  let dir =
-    Filename.concat
-      (Filename.get_temp_dir_name ())
-      (Printf.sprintf
-         "test-tool-metrics-persist-%d-%d"
-         (Unix.getpid ())
-         (int_of_float (Unix.gettimeofday () *. 1000.0)))
-  in
+  let dir = Filename.temp_dir "test-tool-metrics-persist-" "" in
   P.reset_for_testing ();
   Fun.protect
     ~finally:(fun () ->


### PR DESCRIPTION
## 요약

- #26736의 retired success-only fixture hard-cut 위에서 startup tool-metric replay를 제거했어용.
- 현재 typed JSONL writer는 유지하고, `Telemetry_unified`를 persisted telemetry의 정식 독자로 남겼어용.
- 프로세스 로컬 dashboard latency는 서버 부팅 이후의 live emission만 반영해용.
- `flush_now`는 숨은 store 초기화에 기대지 않고 `base_path`를 명시적으로 받아용.

## 검증

- 5개 변경 OCaml 파일 ocamlformat / parser / diff check
- exact-head Dune 및 전체 동작 검증은 CI

## Stack

- parent: #26736 `1bff32d9647642718667c349d8cd9c7c3f4d2dca`
- child-only: startup replay·restore parser·bootstrap task 제거