### PR TITLE
fix(keeper): WAL 완전 상태 복구와 배포 사전 검증

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,6 +424,9 @@ jobs:
             --recent-main 50 \
             --duplicate-policy warn
 
+      - name: Run deploy preflight safety contract
+        run: bash test/test_deploy_preflight.sh
+
       - name: Check doc truth
         if: needs.changes.outputs.doc_truth == 'true'
         run: |

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -309,15 +309,32 @@ let bump_revision state =
 
 let transition_wal_schema = "masc.keeper_event_queue.transition.v5"
 
-let transition_wal_entry_to_line owner entry =
+type transition_wal_row =
+  { pre_state : State.t
+  ; outbox_entry : State.outbox_entry
+  }
+
+let transition_wal_entry_to_line owner ~pre_state outbox_entry =
   `Assoc
     [ "schema", `String transition_wal_schema
     ; "base_path", `String (Owner_lock.base_path owner)
     ; "keeper_name", `String (keeper_name_of_owner owner)
-    ; "outbox_entry", State.outbox_entry_to_yojson entry
+    ; "pre_state", State.to_yojson pre_state
+    ; "outbox_entry", State.outbox_entry_to_yojson outbox_entry
     ]
   |> Yojson.Safe.to_string
   |> fun row -> row ^ "\n"
+;;
+
+let validate_transition_wal_row pre_state outbox_entry =
+  if State.transition_outbox pre_state <> []
+  then Error "transition WAL pre-state already contains an outbox entry"
+  else
+    match State.replay_transition_outbox_entry outbox_entry pre_state with
+    | Ok replayed when State.transition_outbox replayed = [ outbox_entry ] ->
+      Ok { pre_state; outbox_entry }
+    | Ok _ -> Error "transition WAL pre-state does not produce its exact outbox entry"
+    | Error detail -> Error ("transition WAL pre-state is invalid: " ^ detail)
 ;;
 
 let transition_wal_entry_of_json owner = function
@@ -328,6 +345,7 @@ let transition_wal_entry_of_json owner = function
         | [ ("base_path", `String base_path)
           ; ("keeper_name", `String keeper_name)
           ; ("outbox_entry", entry)
+          ; ("pre_state", pre_state)
           ; ("schema", `String row_schema)
           ] ->
           if not (String.equal row_schema schema)
@@ -337,28 +355,15 @@ let transition_wal_entry_of_json owner = function
               (String.equal base_path (Owner_lock.base_path owner)
                && String.equal keeper_name (keeper_name_of_owner owner))
           then Error "transition WAL row owner does not match its Keeper lane"
-          else State.outbox_entry_of_yojson entry
+          else
+            let* pre_state = State.of_yojson pre_state in
+            let* outbox_entry = State.outbox_entry_of_yojson entry in
+            validate_transition_wal_row pre_state outbox_entry
         | _ -> Error "transition WAL row fields are not exact")
      | Some (`String schema) ->
        Error (Printf.sprintf "unsupported transition WAL schema: %s" schema)
      | Some _ | None -> Error "transition WAL schema must be a string")
   | _ -> Error "transition WAL row must be a JSON object"
-;;
-
-let wal_only_seed (entry : State.outbox_entry) =
-  let source_incarnation =
-    match entry.receipt.transition with
-    | State.Cancel_accepted cancellation -> cancellation.source_incarnation
-    | State.Transfer_accepted transfer -> transfer.source_incarnation
-    | State.Ack_source_terminal source_terminal ->
-      source_terminal.source_incarnation
-  in
-  let pending =
-    List.fold_left Keeper_event_queue.enqueue Keeper_event_queue.empty entry.stimuli
-  in
-  State.empty
-  |> State.with_revision source_incarnation
-  |> State.with_pending pending
 ;;
 
 let replay_transition_wal_bytes ~wal_only owner state bytes =
@@ -381,10 +386,17 @@ let replay_transition_wal_bytes ~wal_only owner state bytes =
        | Ok json ->
          (match transition_wal_entry_of_json owner json with
           | Error _ as error -> error
-          | Ok entry ->
-            let state = if wal_only && not saw_row then wal_only_seed entry else state in
+          | Ok { pre_state; outbox_entry = entry } ->
+            let state = if wal_only && not saw_row then pre_state else state in
             let already_projected = row_is_already_projected entry state in
-            (match State.replay_transition_outbox_entry entry state with
+            let pre_state_matches =
+              already_projected
+              || State.transition_outbox state = [ entry ]
+              || State.to_yojson state = State.to_yojson pre_state
+            in
+            if not pre_state_matches
+            then Error "transition WAL pre-state conflicts with its durable snapshot"
+            else (match State.replay_transition_outbox_entry entry state with
              | Error _ as error -> error
              | Ok state ->
                replay
@@ -987,7 +999,7 @@ let commit_transition_unlocked_with
        (match bump_revision state with
      | Error _ as error -> error
      | Ok checkpoint ->
-       let suffix = transition_wal_entry_to_line owner entry in
+       let suffix = transition_wal_entry_to_line owner ~pre_state:current entry in
        let path = transition_wal_path_of_owner owner in
        let continue_after_commit () =
          let pending = State.pending checkpoint in

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -80,7 +80,7 @@ type transfer_projection_result = State.transfer_projection_result =
 
 
 let snapshot_filename = "event-queue-v15.json"
-let transition_wal_filename = "event-queue-transitions-v5.jsonl"
+let transition_wal_filename = "event-queue-transitions-v6.jsonl"
 
 let owner_error_to_string = Owner_lock.resolve_error_to_string
 
@@ -307,7 +307,7 @@ let bump_revision state =
   else Ok (State.with_revision (Int64.succ (State.revision state)) state)
 ;;
 
-let transition_wal_schema = "masc.keeper_event_queue.transition.v5"
+let transition_wal_schema = "masc.keeper_event_queue.transition.v6"
 
 type transition_wal_row =
   { pre_state : State.t
@@ -356,9 +356,9 @@ let transition_wal_entry_of_json owner = function
                && String.equal keeper_name (keeper_name_of_owner owner))
           then Error "transition WAL row owner does not match its Keeper lane"
           else
-            let* pre_state = State.of_yojson pre_state in
-            let* outbox_entry = State.outbox_entry_of_yojson entry in
-            validate_transition_wal_row pre_state outbox_entry
+            Result.bind (State.of_yojson pre_state) (fun pre_state ->
+              Result.bind (State.outbox_entry_of_yojson entry) (fun outbox_entry ->
+                validate_transition_wal_row pre_state outbox_entry))
         | _ -> Error "transition WAL row fields are not exact")
      | Some (`String schema) ->
        Error (Printf.sprintf "unsupported transition WAL schema: %s" schema)

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -5,7 +5,9 @@
     projected transition, an operation-indexed ledger of older projected
     dispositions, at most one unprojected transition, and durable
     accepted-transfer target projections. Only this schema and the
-    [event-queue-transitions-v5.jsonl] WAL are queue authority. *)
+    [event-queue-transitions-v5.jsonl] WAL are queue authority. Every WAL row
+    carries the complete pre-transition state needed for snapshot-independent
+    recovery. *)
 
 type owner_identity
 type owner_identity_error
@@ -161,7 +163,8 @@ val load_state_result :
 val load_existing_state_result :
   base_path:string -> keeper_name:string -> (Keeper_event_queue_state.t, string) result
 (** Read already-created durable queue state. A current snapshot or v5 WAL is
-    durable owner evidence; a WAL-only owner is replayed from the empty state.
+    durable owner evidence; a WAL-only owner is replayed from the row's exact
+    complete pre-transition state.
     Unlike {!load_state_result}, absence of both artifacts is an explicit
     [Error]. Use this when absence would be interpreted as evidence about prior
     durable work. *)
@@ -169,13 +172,14 @@ val load_existing_state_result :
 val validate_state_read_only_result :
   base_path:string -> keeper_name:string -> (Keeper_event_queue_state.t, string) result
 (** Decode a current snapshot when present and replay its v5 WAL without
-    checkpointing or WAL compaction. A missing snapshot starts from the empty
-    state, matching {!load_state_result}. *)
+    checkpointing or WAL compaction. A missing snapshot starts from the WAL
+    row's exact complete pre-transition state, matching {!load_state_result}. *)
 
 val validate_existing_state_read_only_result :
   base_path:string -> keeper_name:string -> (Keeper_event_queue_state.t, string) result
 (** Decode existing durable state and replay its v5 WAL without checkpointing
-    or WAL compaction. A WAL-only owner is replayed from the empty state;
+    or WAL compaction. A WAL-only owner is replayed from the row's exact
+    complete pre-transition state;
     absence of both artifacts is an explicit error, matching
     {!load_existing_state_result}. *)
 

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -5,9 +5,12 @@
     projected transition, an operation-indexed ledger of older projected
     dispositions, at most one unprojected transition, and durable
     accepted-transfer target projections. Only this schema and the
-    [event-queue-transitions-v5.jsonl] WAL are queue authority. Every WAL row
+    [event-queue-transitions-v6.jsonl] WAL are queue authority. Every WAL row
     carries the complete pre-transition state needed for snapshot-independent
-    recovery. *)
+    recovery. The WAL accepts at most one row and is retired after projection,
+    so its retained size is bounded by one complete state. Serializing that
+    state on each transition is the intentional cost of recovery that does not
+    infer missing sibling work from a delta. *)
 
 type owner_identity
 type owner_identity_error
@@ -162,7 +165,7 @@ val load_state_result :
 
 val load_existing_state_result :
   base_path:string -> keeper_name:string -> (Keeper_event_queue_state.t, string) result
-(** Read already-created durable queue state. A current snapshot or v5 WAL is
+(** Read already-created durable queue state. A current snapshot or v6 WAL is
     durable owner evidence; a WAL-only owner is replayed from the row's exact
     complete pre-transition state.
     Unlike {!load_state_result}, absence of both artifacts is an explicit
@@ -171,13 +174,13 @@ val load_existing_state_result :
 
 val validate_state_read_only_result :
   base_path:string -> keeper_name:string -> (Keeper_event_queue_state.t, string) result
-(** Decode a current snapshot when present and replay its v5 WAL without
+(** Decode a current snapshot when present and replay its v6 WAL without
     checkpointing or WAL compaction. A missing snapshot starts from the WAL
     row's exact complete pre-transition state, matching {!load_state_result}. *)
 
 val validate_existing_state_read_only_result :
   base_path:string -> keeper_name:string -> (Keeper_event_queue_state.t, string) result
-(** Decode existing durable state and replay its v5 WAL without checkpointing
+(** Decode existing durable state and replay its v6 WAL without checkpointing
     or WAL compaction. A WAL-only owner is replayed from the row's exact
     complete pre-transition state;
     absence of both artifacts is an explicit error, matching

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -1,6 +1,6 @@
 (** Pure durable state machine for one Keeper event queue owner.
 
-    The current snapshot and source-bearing transition WAL jointly form the
+    The current snapshot and full-pre-state transition WAL jointly form the
     durable authority. This module performs no I/O; persistence supplies the
     atomic file boundary and publishes [pending] into the live registry only
     after a durable commit. *)

--- a/scripts/check-keeper-event-queue-v15-cutover.sh
+++ b/scripts/check-keeper-event-queue-v15-cutover.sh
@@ -139,6 +139,18 @@ run_gate() {
       fi
     done < <(find "$keepers_root" -mindepth 2 -maxdepth 2 -name 'event-queue-transitions-v4.jsonl' -print0)
 
+    while IFS= read -r -d '' queue_path; do
+      legacy_wal_count=$((legacy_wal_count + 1))
+      [[ -f "$queue_path" && ! -L "$queue_path" ]] \
+        || fail "v5 transition WAL is not an exact regular file: $queue_path"
+      [[ ! -s "$queue_path" ]] \
+        || fail "v5 transition WAL still contains committed evidence: $queue_path"
+      current_queue_path="$(dirname "$queue_path")/event-queue-v15.json"
+      if [[ ! -e "$current_queue_path" && ! -L "$current_queue_path" ]]; then
+        cutover_required=1
+      fi
+    done < <(find "$keepers_root" -mindepth 2 -maxdepth 2 -name 'event-queue-transitions-v5.jsonl' -print0)
+
     while IFS= read -r -d '' current_queue_path; do
       [[ -f "$current_queue_path" && ! -L "$current_queue_path" ]] \
         || fail "v15 queue snapshot is not an exact regular file: $current_queue_path"
@@ -147,13 +159,13 @@ run_gate() {
       "$CUTOVER_HELPER" validate-current-queue \
         --base-path "$BASE_PATH" \
         --keeper-name "$keeper_name" \
-        || fail "v15 queue snapshot or v5 transition WAL is invalid: $current_queue_path"
+        || fail "v15 queue snapshot or v6 transition WAL is invalid: $current_queue_path"
       current_owner_count=$((current_owner_count + 1))
     done < <(find "$keepers_root" -mindepth 2 -maxdepth 2 -name 'event-queue-v15.json' -print0)
 
     while IFS= read -r -d '' queue_path; do
       [[ -f "$queue_path" && ! -L "$queue_path" ]] \
-        || fail "v5 transition WAL is not an exact regular file: $queue_path"
+        || fail "v6 transition WAL is not an exact regular file: $queue_path"
       current_queue_path="$(dirname "$queue_path")/event-queue-v15.json"
       if [[ -e "$current_queue_path" || -L "$current_queue_path" ]]; then
         continue
@@ -163,9 +175,9 @@ run_gate() {
       "$CUTOVER_HELPER" validate-current-wal \
         --base-path "$BASE_PATH" \
         --keeper-name "$keeper_name" \
-        || fail "v5 transition WAL is invalid: $queue_path"
+        || fail "v6 transition WAL is invalid: $queue_path"
       current_owner_count=$((current_owner_count + 1))
-    done < <(find "$keepers_root" -mindepth 2 -maxdepth 2 -name 'event-queue-transitions-v5.jsonl' -print0)
+    done < <(find "$keepers_root" -mindepth 2 -maxdepth 2 -name 'event-queue-transitions-v6.jsonl' -print0)
 
     while IFS= read -r -d '' queue_path; do
       current_queue_path="$(dirname "$queue_path")/event-queue-v15.json"
@@ -394,6 +406,13 @@ if [[ "$SELF_TEST" -eq 1 ]]; then
     >"$legacy_wal_root/.masc/keepers/fixture/event-queue-transitions-v4.jsonl"
   expect_failure nonempty_v4_transition_wal "$legacy_wal_root"
 
+  legacy_v5_wal_root="$fixture_root/legacy-v5-wal"
+  write_schedules "$legacy_v5_wal_root" none
+  write_queue "$legacy_v5_wal_root" 0 0 0
+  printf '{"schema":"masc.keeper_event_queue.transition.v5"}\n' \
+    >"$legacy_v5_wal_root/.masc/keepers/fixture/event-queue-transitions-v5.jsonl"
+  expect_failure nonempty_v5_transition_wal "$legacy_v5_wal_root"
+
   current_root="$fixture_root/current"
   write_schedules "$current_root" running
   write_queue "$current_root" 1 1 1
@@ -412,20 +431,20 @@ if [[ "$SELF_TEST" -eq 1 ]]; then
   write_schedules "$malformed_current_wal_root" running
   write_current_queue "$malformed_current_wal_root"
   printf '{not-json\n' \
-    >"$malformed_current_wal_root/.masc/keepers/fixture/event-queue-transitions-v5.jsonl"
+    >"$malformed_current_wal_root/.masc/keepers/fixture/event-queue-transitions-v6.jsonl"
   expect_failure malformed_current_wal "$malformed_current_wal_root"
 
   wal_only_root="$fixture_root/wal-only"
   write_schedules "$wal_only_root" running
   mkdir -p "$wal_only_root/.masc/keepers/fixture"
-  : >"$wal_only_root/.masc/keepers/fixture/event-queue-transitions-v5.jsonl"
+  : >"$wal_only_root/.masc/keepers/fixture/event-queue-transitions-v6.jsonl"
   "$0" --base-path "$wal_only_root" >/dev/null
 
   malformed_wal_only_root="$fixture_root/malformed-wal-only"
   write_schedules "$malformed_wal_only_root" running
   mkdir -p "$malformed_wal_only_root/.masc/keepers/fixture"
   printf '{not-json\n' \
-    >"$malformed_wal_only_root/.masc/keepers/fixture/event-queue-transitions-v5.jsonl"
+    >"$malformed_wal_only_root/.masc/keepers/fixture/event-queue-transitions-v6.jsonl"
   expect_failure malformed_wal_without_snapshot "$malformed_wal_only_root"
 
   malformed_root="$fixture_root/malformed"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -116,6 +116,32 @@ if [ "$PREPARE_UNDER_CUTOVER_LEASE" = true ]; then
     exit 0
 fi
 
+# Load and validate runtime environment before stopping the serving process.
+# BasePath was frozen above and is intentionally not recomputed from env files.
+preserve_env_override MASC_CONFIG_DIR
+preserve_env_override MASC_PERSONAS_DIR
+KEEPER_ENV="$REPO_DIR/config/keeper.env"
+if [ -f "$KEEPER_ENV" ]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "$KEEPER_ENV"
+    set +a
+fi
+if [ -f "$REPO_DIR/.env" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    source "$REPO_DIR/.env"
+    set +a
+fi
+restore_env_override MASC_CONFIG_DIR
+restore_env_override MASC_PERSONAS_DIR
+
+if [ ! -d "$RUNTIME_ROOT" ] || [ -L "$RUNTIME_ROOT" ]; then
+    echo "Error: deployment requires an existing exact runtime directory at $RUNTIME_ROOT" >&2
+    exit 1
+fi
+mkdir -p "$LOG_DIR"
+
 # --- 2. Detect management mode ---
 if launchctl list "$LAUNCHD_LABEL" >/dev/null 2>&1; then
     echo "Error: loaded launchd service cannot receive the atomic BasePath lease handoff" >&2
@@ -146,33 +172,6 @@ fi
 # and installs the release, then execs the new runtime in that same process.
 # There is no unlock/reacquire window in which an older writer can enter.
 echo "==> Starting prod on :$PROD_PORT with atomic cutover lease handoff..." >&2
-
-# Load secrets needed at runtime (GRAPHQL_API_KEY, SSL_CERT_FILE, etc.)
-# Only repo-local env files are loaded; ~/.zshenv is intentionally skipped
-# to avoid environment contamination from user shell configuration.
-preserve_env_override MASC_CONFIG_DIR
-preserve_env_override MASC_PERSONAS_DIR
-KEEPER_ENV="$REPO_DIR/config/keeper.env"
-if [ -f "$KEEPER_ENV" ]; then
-    set -a
-    # shellcheck disable=SC1090
-    source "$KEEPER_ENV"
-    set +a
-fi
-if [ -f "$REPO_DIR/.env" ]; then
-    set -a
-    # shellcheck disable=SC1091
-    source "$REPO_DIR/.env"
-    set +a
-fi
-restore_env_override MASC_CONFIG_DIR
-restore_env_override MASC_PERSONAS_DIR
-
-if [ ! -d "$RUNTIME_ROOT" ] || [ -L "$RUNTIME_ROOT" ]; then
-    echo "Error: deployment requires an existing exact runtime directory at $RUNTIME_ROOT" >&2
-    exit 1
-fi
-mkdir -p "$LOG_DIR"
 
 HANDOFF_DIR="$(mktemp -d "$RUNTIME_ROOT/deploy-handoff.XXXXXX")"
 PREPARED_FILE="$HANDOFF_DIR/prepared"

--- a/test/test_deploy_preflight.sh
+++ b/test/test_deploy_preflight.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FIXTURE_DIR="$(mktemp -d)"
+SLEEP_PID=""
+
+cleanup() {
+    if [ -n "$SLEEP_PID" ]; then
+        kill "$SLEEP_PID" 2>/dev/null || true
+        wait "$SLEEP_PID" 2>/dev/null || true
+    fi
+    rm -rf "$FIXTURE_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p \
+    "$FIXTURE_DIR/repo/scripts" \
+    "$FIXTURE_DIR/repo/config" \
+    "$FIXTURE_DIR/repo/_build/default/bin" \
+    "$FIXTURE_DIR/runtime/.masc/logs"
+cp "$ROOT_DIR/scripts/deploy.sh" "$FIXTURE_DIR/repo/scripts/deploy.sh"
+touch \
+    "$FIXTURE_DIR/repo/_build/default/bin/main_eio.exe" \
+    "$FIXTURE_DIR/repo/_build/default/bin/keeper_event_queue_v15_cutover_helper.exe"
+chmod +x \
+    "$FIXTURE_DIR/repo/scripts/deploy.sh" \
+    "$FIXTURE_DIR/repo/_build/default/bin/main_eio.exe" \
+    "$FIXTURE_DIR/repo/_build/default/bin/keeper_event_queue_v15_cutover_helper.exe"
+printf '%s\n' 'false' > "$FIXTURE_DIR/repo/config/keeper.env"
+
+sleep 30 &
+SLEEP_PID=$!
+printf '%s\n' "$SLEEP_PID" > "$FIXTURE_DIR/runtime/.masc/masc-prod.pid"
+
+if MASC_BASE_PATH="$FIXTURE_DIR/runtime" \
+    bash "$FIXTURE_DIR/repo/scripts/deploy.sh" --skip-build
+then
+    echo "expected invalid keeper.env to reject deployment" >&2
+    exit 1
+fi
+
+if ! kill -0 "$SLEEP_PID" 2>/dev/null; then
+    echo "deployment stopped the serving process before env validation" >&2
+    exit 1
+fi
+
+echo "deploy preflight preserves the serving process on env failure"

--- a/test/test_keeper_paused_work_source_terminal_transaction.ml
+++ b/test/test_keeper_paused_work_source_terminal_transaction.ml
@@ -515,11 +515,11 @@ let test_terminal_ack_replays_after_projection_and_snapshot_reload () =
         (Filename.concat
            (Common.keepers_runtime_dir_of_base ~base_path:config.Workspace.base_path)
            keeper_name)
-        "event-queue-transitions-v5.jsonl"
+        "event-queue-transitions-v6.jsonl"
     in
     let residual_wal_row =
       `Assoc
-        [ "schema", `String "masc.keeper_event_queue.transition.v5"
+        [ "schema", `String "masc.keeper_event_queue.transition.v6"
         ; "base_path", `String config.Workspace.base_path
         ; "keeper_name", `String keeper_name
         ; "pre_state", State.to_yojson pre_state
@@ -635,11 +635,11 @@ let test_projected_wal_recovery_allows_next_source_ack () =
         (Filename.concat
            (Common.keepers_runtime_dir_of_base ~base_path:config.Workspace.base_path)
            keeper_name)
-        "event-queue-transitions-v5.jsonl"
+        "event-queue-transitions-v6.jsonl"
     in
     let residual_wal_row =
       `Assoc
-        [ "schema", `String "masc.keeper_event_queue.transition.v5"
+        [ "schema", `String "masc.keeper_event_queue.transition.v6"
         ; "base_path", `String config.Workspace.base_path
         ; "keeper_name", `String keeper_name
         ; "pre_state", State.to_yojson first_pre_state

--- a/test/test_keeper_paused_work_source_terminal_transaction.ml
+++ b/test/test_keeper_paused_work_source_terminal_transaction.ml
@@ -472,6 +472,12 @@ let test_reinserted_source_rejects_old_terminal_incarnation () =
 
 let test_terminal_ack_replays_after_projection_and_snapshot_reload () =
   with_source_terminal_lane (fun config keeper_name _meta request ->
+    let pre_state =
+      Persistence.load_state_result
+        ~base_path:config.Workspace.base_path
+        ~keeper_name
+      |> require_ok "load source-terminal ACK pre-state"
+    in
     let first =
       Transaction.ack_pending config ~keeper_name request
       |> Result.map_error Transaction.error_to_string
@@ -516,6 +522,7 @@ let test_terminal_ack_replays_after_projection_and_snapshot_reload () =
         [ "schema", `String "masc.keeper_event_queue.transition.v5"
         ; "base_path", `String config.Workspace.base_path
         ; "keeper_name", `String keeper_name
+        ; "pre_state", State.to_yojson pre_state
         ; "outbox_entry", State.outbox_entry_to_yojson outbox_entry
         ]
     in
@@ -594,6 +601,12 @@ let test_projected_wal_recovery_allows_next_source_ack () =
       ~keeper_name
       (fun pending -> Queue.enqueue pending second_source)
     |> require_ok "seed second source-terminal event";
+    let first_pre_state =
+      Persistence.load_state_result
+        ~base_path:config.Workspace.base_path
+        ~keeper_name
+      |> require_ok "load first source-terminal ACK pre-state"
+    in
     let first_request = request in
     let first =
       Transaction.ack_pending config ~keeper_name first_request
@@ -629,6 +642,7 @@ let test_projected_wal_recovery_allows_next_source_ack () =
         [ "schema", `String "masc.keeper_event_queue.transition.v5"
         ; "base_path", `String config.Workspace.base_path
         ; "keeper_name", `String keeper_name
+        ; "pre_state", State.to_yojson first_pre_state
         ; "outbox_entry", State.outbox_entry_to_yojson first_outbox
         ]
     in

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -874,7 +874,7 @@ let test_reclaim_follows_transfer_durable_state () =
       (Filename.concat
          (Common.keepers_runtime_dir_of_base ~base_path)
          target_keeper)
-      "event-queue-transitions-v5.jsonl"
+      "event-queue-transitions-v6.jsonl"
   in
   check string "checkpointed transition WAL compacted" ""
     (read_file transition_wal_path);
@@ -1082,7 +1082,7 @@ let test_reclaim_keeps_occurrence_when_queue_snapshot_is_missing () =
   let wal_path =
     Filename.concat
       (Filename.dirname queue_path)
-      "event-queue-transitions-v5.jsonl"
+      "event-queue-transitions-v6.jsonl"
   in
   Sys.remove queue_path;
   let outcome =
@@ -1175,7 +1175,8 @@ let test_wal_only_owner_is_recovered_and_settled () =
     check int "WAL-only fixture includes source and sibling" 2
       (List.length selections);
     selections
-    |> List.find_opt (fun selection -> selection.source <> sibling)
+    |> List.find_opt (fun (selection : Keeper_event_queue_state.pending_selection) ->
+      selection.source <> sibling)
     |> function
     | Some selection -> selection
     | None -> fail "WAL-only source selection disappeared"
@@ -1217,10 +1218,10 @@ let test_wal_only_owner_is_recovered_and_settled () =
       keeper_name
   in
   let snapshot_path = Filename.concat keeper_dir "event-queue-v15.json" in
-  let wal_path = Filename.concat keeper_dir "event-queue-transitions-v5.jsonl" in
+  let wal_path = Filename.concat keeper_dir "event-queue-transitions-v6.jsonl" in
   let wal_row =
     `Assoc
-      [ "schema", `String "masc.keeper_event_queue.transition.v5"
+      [ "schema", `String "masc.keeper_event_queue.transition.v6"
       ; "base_path", `String base_path
       ; "keeper_name", `String keeper_name
       ; "pre_state", Keeper_event_queue_state.to_yojson state
@@ -1231,7 +1232,7 @@ let test_wal_only_owner_is_recovered_and_settled () =
   in
   let incomplete_wal_row =
     `Assoc
-      [ "schema", `String "masc.keeper_event_queue.transition.v5"
+      [ "schema", `String "masc.keeper_event_queue.transition.v6"
       ; "base_path", `String base_path
       ; "keeper_name", `String keeper_name
       ; "outbox_entry", Keeper_event_queue_state.outbox_entry_to_yojson entry
@@ -2228,7 +2229,7 @@ let test_cancelled_occurrence_recovery_does_not_enqueue_again () =
           (Filename.concat
              (Common.keepers_runtime_dir_of_base ~base_path)
              keeper_name)
-          "event-queue-transitions-v5.jsonl"
+          "event-queue-transitions-v6.jsonl"
       in
       check bool "cancellation WAL survives until projection" true
         (Sys.file_exists transition_wal_path

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -1149,15 +1149,36 @@ let test_wal_only_owner_is_recovered_and_settled () =
   let request = create_keeper_wake_schedule config in
   ignore (tick_ok config ~now:201.0 : Schedule_runner.tick_result);
   let execution = latest_execution_exn config request in
+  let sibling : Keeper_event_queue.stimulus =
+    { post_id = "wal-only-sibling"
+    ; urgency = Keeper_event_queue.Normal
+    ; arrived_at = 201.5
+    ; payload = Keeper_event_queue.Bootstrap
+    }
+  in
+  (match
+     Keeper_event_queue_persistence.enqueue_stimulus_if_absent_result
+       ~base_path
+       ~keeper_name
+       sibling
+   with
+   | Ok Keeper_event_queue_persistence.Enqueued -> ()
+   | Ok Keeper_event_queue_persistence.Already_present ->
+     fail "fresh WAL-only sibling was already present"
+   | Error detail -> fail detail);
   let state =
     Keeper_event_queue_persistence.load_state_result ~base_path ~keeper_name
     |> Result.fold ~ok:Fun.id ~error:(fun message -> fail message)
   in
   let selection =
-    match Keeper_event_queue_state.pending_selections state with
-    | [ selection ] -> selection
-    | selections ->
-      failf "expected one WAL-only fixture selection, got %d" (List.length selections)
+    let selections = Keeper_event_queue_state.pending_selections state in
+    check int "WAL-only fixture includes source and sibling" 2
+      (List.length selections);
+    selections
+    |> List.find_opt (fun selection -> selection.source <> sibling)
+    |> function
+    | Some selection -> selection
+    | None -> fail "WAL-only source selection disappeared"
   in
   let source_terminal : Keeper_event_queue_state.accepted_source_terminal =
     { source = selection.source
@@ -1202,6 +1223,17 @@ let test_wal_only_owner_is_recovered_and_settled () =
       [ "schema", `String "masc.keeper_event_queue.transition.v5"
       ; "base_path", `String base_path
       ; "keeper_name", `String keeper_name
+      ; "pre_state", Keeper_event_queue_state.to_yojson state
+      ; "outbox_entry", Keeper_event_queue_state.outbox_entry_to_yojson entry
+      ]
+    |> Yojson.Safe.to_string
+    |> fun row -> row ^ "\n"
+  in
+  let incomplete_wal_row =
+    `Assoc
+      [ "schema", `String "masc.keeper_event_queue.transition.v5"
+      ; "base_path", `String base_path
+      ; "keeper_name", `String keeper_name
       ; "outbox_entry", Keeper_event_queue_state.outbox_entry_to_yojson entry
       ]
     |> Yojson.Safe.to_string
@@ -1216,6 +1248,14 @@ let test_wal_only_owner_is_recovered_and_settled () =
    with
    | Error _ -> ()
    | Ok _ -> fail "malformed WAL-only owner was accepted");
+  write_file wal_path incomplete_wal_row;
+  (match
+     Keeper_event_queue_persistence.load_existing_state_result
+       ~base_path
+       ~keeper_name
+   with
+   | Error _ -> ()
+   | Ok _ -> fail "WAL-only owner without complete pre-state was accepted");
   write_file wal_path wal_row;
   let validated =
     Keeper_event_queue_persistence.validate_existing_state_read_only_result
@@ -1235,6 +1275,10 @@ let test_wal_only_owner_is_recovered_and_settled () =
   in
   check int "WAL-only loader restores the committed outbox" 1
     (List.length (Keeper_event_queue_state.transition_outbox recovered));
+  check bool "WAL-only loader preserves sibling pending work" true
+    (Keeper_event_queue_state.pending recovered
+     |> Keeper_event_queue.to_list
+     |> List.exists (( = ) sibling));
   let discovery =
     Keeper_event_queue_persistence.discover_keeper_names_with_durable_state
       ~base_path
@@ -1257,6 +1301,10 @@ let test_wal_only_owner_is_recovered_and_settled () =
   in
   check int "WAL-only recovery retires the outbox" 0
     (List.length (Keeper_event_queue_state.transition_outbox projected));
+  check bool "WAL-only projection preserves sibling pending work" true
+    (Keeper_event_queue_state.pending projected
+     |> Keeper_event_queue.to_list
+     |> List.exists (( = ) sibling));
   let outcome =
     Schedule_runner.reclaim_lost_occurrences
       ~consumer:Server_schedule_consumers.consumer


### PR DESCRIPTION
## 변경

- transition WAL row에 완전한 pre-transition state를 기록해 snapshot 소실 시 sibling pending work도 복원해용.
- pre-state가 없거나 outbox와 모순되는 WAL은 fail-closed 해용.
- `keeper.env`/`.env`와 runtime 경로를 기존 prod 종료 전에 검증해용.

## 검증

- WAL-only source + sibling 복원·projection·schedule settlement 회귀 테스트
- 불완전한 WAL row 거부 테스트
- 잘못된 env에서도 기존 PID가 유지되는 실제 셸 테스트 및 CI 연결
- ocamlformat, OCaml parser, bash -n, shellcheck, YAML parse, hardening ratchet, git diff --check 통과
- 로컬 Dune은 실행하지 않았고 CI에서 확인해용.

Follow-up to #26689.