### PR TITLE
docs(test): SSE E2E 실행 진입점 복구

### DIFF
--- a/docs/VERIFICATION-MATRIX.md
+++ b/docs/VERIFICATION-MATRIX.md
@@ -11,7 +11,7 @@
 - `dune test --root .`
   - 기본 단위/통합 테스트 묶음
   - 실행 진입점은 `make test` 또는 `scripts/ci-run-tests.sh "opam exec -- dune test"`를 기준으로 본다
-- `./_build/default/test/test_sse_storm_e2e.exe`
+- `MASC_E2E_TESTS=true scripts/dune-local.sh build @test/runtest-test_sse_storm_e2e`
   - server executable 기반 SSE reconnect e2e
 - transport harness suite
   - `scripts/harness/transport/run_all.sh`
@@ -27,7 +27,7 @@ dune build --root .
 make test
 make test-transport
 make test-contract
-./_build/default/test/test_sse_storm_e2e.exe
+MASC_E2E_TESTS=true scripts/dune-local.sh build @test/runtest-test_sse_storm_e2e
 ```
 
 의도:
@@ -89,7 +89,7 @@ make test-contract
 
 - `make test`
 - `make test-transport`
-- `test_sse_storm_e2e.exe`
+- `@test/runtest-test_sse_storm_e2e`
 - contract harness 3종
 
 그리고 이번 변경에서 **필수로 올리지 않는 것**은:

--- a/docs/spec/15-testing.md
+++ b/docs/spec/15-testing.md
@@ -58,7 +58,7 @@ CI 필수 게이트. 외부 의존성 없이 재현 가능.
 | 항목 | 실행 방법 | 범위 |
 |------|----------|------|
 | 단위/통합 테스트 묶음 | `dune test --root .` / `make test` | 40+ 테스트 바이너리 |
-| SSE Storm E2E | `./_build/default/test/test_sse_storm_e2e.exe` | SSE reconnect 시나리오 |
+| SSE Storm E2E | `MASC_E2E_TESTS=true scripts/dune-local.sh build @test/runtest-test_sse_storm_e2e` | SSE reconnect 시나리오 |
 | Contract Harness | `make test-contract` | Streamable HTTP and Golden Path contracts |
 
 Contract harness는 서버가 이미 떠 있다고 가정하지 않고 hermetic bootstrap 경로로 실행된다.
@@ -231,9 +231,8 @@ CI 테스트 실행기. 다음 기능을 제공한다:
 make test                    # dune test --root .
 make test-contract           # scripts/harness/contract/run_all.sh
 
-# 수동 검증
-scripts/dune-local.sh build ./test/test_sse_storm_e2e.exe
-./_build/default/test/test_sse_storm_e2e.exe
+# 수동 검증 — Dune action이 exact worktree server executable을 주입한다.
+MASC_E2E_TESTS=true scripts/dune-local.sh build @test/runtest-test_sse_storm_e2e
 ```
 
 ### 6.3 Contract Harness


### PR DESCRIPTION
## 변경

- 문서의 직접 executable 실행을 canonical Dune test alias로 교체했어용.
- Dune action이 현재 worktree의 `main_eio.exe`를 `MASC_MAIN_EIO_EXE`로 주입해용.
- 별도 path fallback이나 상위 checkout 탐색은 추가하지 않았어용.

## 검증

- 문서 전체에서 깨진 직접 실행 명령이 사라졌음을 확인했어용.
- `scripts/check-doc-truth.sh`, `git diff --check` 통과했어용.
- 로컬 Dune은 실행하지 않았고 CI에서 확인해용.

Follow-up to #26705.