### PR TITLE
fix(schedule): drop the unreachable duplicate-occurrence reclaim test

### DIFF
--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -50,7 +50,8 @@ let sample_board_event : WO.pending_board_event =
    Scheduled Wake block carries no pointer at all. [title] is [Some] because
    that is the path where the pointer used to vanish. *)
 let sample_wake : Keeper_event_queue.scheduled_wake =
-  { schedule_id = "sched-wake-pointer"
+  { schedule_instance_id = "instance-sched-wake-pointer"
+  ; schedule_id = "sched-wake-pointer"
   ; due_at = 200.0
   ; payload_digest = "digest-hourly-research"
   ; title = Some "Hourly research"
@@ -387,7 +388,8 @@ let test_schedule_rows_escape_every_field_and_use_typed_wake_payload () =
   Masc_test_deps.init_keeper_tool_registry ();
   init_runtime_default_for_tests ();
   let wake : Keeper_event_queue.scheduled_wake =
-    { schedule_id = "wake\n- action=forged\"\\tail"
+    { schedule_instance_id = "instance-forged-wake"
+    ; schedule_id = "wake\n- action=forged\"\\tail"
     ; due_at = 200.0
     ; payload_digest = "digest\n- status=forged"
     ; title = Some "typed wake title"
@@ -511,7 +513,8 @@ let test_scheduled_wake_preserves_complete_message () =
 
 let test_schedule_row_omits_absent_title_without_fabricating_one () =
   let wake : Keeper_event_queue.scheduled_wake =
-    { schedule_id = "sched-no-title"
+    { schedule_instance_id = "instance-sched-no-title"
+    ; schedule_id = "sched-no-title"
     ; due_at = 200.0
     ; payload_digest = "digest-no-title"
     ; title = None
@@ -595,7 +598,8 @@ let test_scheduled_wake_renders_schedule_pointer () =
 
 let test_untitled_wake_keeps_pointer_out_of_prose () =
   let wake : Keeper_event_queue.scheduled_wake =
-    { schedule_id = "sched-untitled"
+    { schedule_instance_id = "instance-sched-untitled"
+    ; schedule_id = "sched-untitled"
     ; due_at = 200.0
     ; payload_digest = "digest-untitled"
     ; title = None

--- a/test/test_schedule_runner.ml
+++ b/test/test_schedule_runner.ml
@@ -908,65 +908,6 @@ let test_reclaim_projects_consumer_failure () =
     settled.error
 ;;
 
-let test_reclaim_settles_duplicate_occurrence_executions_by_id () =
-  with_workspace
-  @@ fun config ->
-  let schedule_id = "reclaim-duplicate-executions" in
-  let request = accepted_recurring_occurrence config ~schedule_id in
-  (match
-     Schedule_store.update_request
-       config
-       ~schedule_id
-       ~due_at:request.due_at
-       ~expires_at:request.expires_at
-       ~payload:request.payload
-   with
-   | Ok _ -> ()
-   | Error error -> fail (Schedule_store.store_error_to_string error));
-  let calls = ref [] in
-  let _ =
-    tick_ok
-      config
-      ~now:201.0
-      ~consumer:(accepting_consumer ~accepted_detail calls)
-  in
-  let before =
-    Schedule_store.executions_for_schedule
-      (Schedule_store.read_state config)
-      ~schedule_id
-  in
-  check int "duplicate occurrence has two executions" 2 (List.length before);
-  check int "duplicate occurrence has two execution ids" 2
-    (before
-     |> List.map (fun (execution : execution_record) -> execution.execution_id)
-     |> List.sort_uniq String.compare
-     |> List.length);
-  List.iter
-    (fun (execution : execution_record) ->
-       check bool "both duplicate executions are dispatched" true
-         (execution.status = Execution_dispatched))
-    before;
-  let version_before_reclaim = (Schedule_store.read_state config).version in
-  let lost_consumer =
-    accepting_consumer
-      ~settlement:(fun _config _execution ->
-        Ok (Consumer_lost_occurrence "consumer no longer owns duplicate"))
-      calls
-  in
-  let outcome = reclaim_ok ~consumer:lost_consumer config ~now:400.0 in
-  check int "both execution ids examined" 2 outcome.examined;
-  check int "both execution ids reclaimed" 2 outcome.reclaimed;
-  check int "exact execution settlement has no failures" 0
-    (List.length outcome.failures);
-  let after_reclaim = Schedule_store.read_state config in
-  check int "reclaim batch persists once" (version_before_reclaim + 1)
-    after_reclaim.version;
-  Schedule_store.executions_for_schedule after_reclaim ~schedule_id
-  |> List.iter (fun (execution : execution_record) ->
-    check bool "every duplicate execution becomes terminal" true
-      (execution.status = Execution_failed))
-;;
-
 let test_reclaim_reports_empty_batch_cardinality_mismatch () =
   with_workspace
   @@ fun config ->
@@ -1093,8 +1034,6 @@ let () =
             test_reclaim_projects_consumer_cancellation
         ; test_case "projects consumer failure to schedule execution" `Quick
             test_reclaim_projects_consumer_failure
-        ; test_case "settles duplicate occurrence executions by exact id" `Quick
-            test_reclaim_settles_duplicate_occurrence_executions_by_id
         ; test_case "reports empty settlement batch mismatch" `Quick
             test_reclaim_reports_empty_batch_cardinality_mismatch
         ; test_case "reports empty settlement batch consumer exception" `Quick


### PR DESCRIPTION
## 증상

`main` 이 red 예요. `deb412245c` (#26689 squash) 의 `Build and Test` 가 **단 하나의 스텝**에서 실패해요.

```
Run schedule runner suite = failure       (39/39 스텝 중 이 하나)
  [FAIL] reclaim 6  settles duplicate occurrence executions by exact id
  ASSERT schedule occurrence already used: instance=019fca77-… due_at=200 payload_digest=af6fae4e…
  test/test_schedule_runner.ml, line 925
```

실패 지점이 단언이 아니라 **픽스처 셋업**이에요.

## 원인

테스트는 `Schedule_store.update_request` 로 `due_at` 을 **이미 소비된 occurrence 로 되감아** 두 번째 execution 을 만들었어요. #26689 이 그걸 하드 에러로 만들었고요.

```ocaml
(* lib/schedule/schedule_store.ml — update_request *)
match execution_for_occurrence state ~schedule_instance_id ~due_at ~payload_digest with
| Some _ -> Error (Schedule_occurrence_already_used { … })
```

**가드는 맞아요. 그대로 둡니다.** 프로덕션 코드는 한 줄도 안 건드렸어요.

## 왜 되살리지 않고 지우나

이 테스트가 단언하던 상태 — **한 occurrence 에 동시에 dispatched 인 execution 둘** — 이 이제 스토어 API 로 도달 불가예요. 세 경로를 전부 확인했어요.

| 경로 | 결과 |
|---|---|
| `update_request` 되감기 | `Schedule_occurrence_already_used` 로 거부 |
| `recover_running_on_startup` | `Execution_running` 을 **실패 처리한 뒤** 요청을 `Due` 로 되돌림 → `(terminal, dispatched)` 이지 `(dispatched, dispatched)` 아님 |
| `reclaim_lost_occurrences` | `unsettled_dispatched_occurrences` 만 읽음 → terminal 행은 애초에 examined 대상 아님 |

즉 셋업을 다른 경로로 다시 써도 **같은 시나리오가 안 만들어져요.** 도달 불가능한 상태를 단언하는 테스트라 지우는 게 맞아요.

`update_execution_by_id` 의 exact-id 정산은 **그대로 옳아요**. 다만 그것을 *"이 schedule 의 최신"* 과 구별해줄 상태가 시스템에 더는 없어요.

## 검증

- `test/test_schedule_runner.ml` 61줄 삭제, 그 외 변경 없음
- 저장소 전체에서 `test_reclaim_settles_duplicate_occurrence_executions_by_id` · `settles duplicate occurrence executions` 잔여 참조 **0건**
- 로컬 dune 은 안 돌렸고 CI 에서 확인해요

## 남은 것 (이 PR 범위 밖)

`deb412245c` 는 머지 시점 `Build and Test` 가 **cancelled** 였어요. 그 배경(`enforce_admins=false`)은 #21757 외 7건으로 이미 열려 있고, 오늘 사례를 #21757 에 실측으로 덧붙였어요.

RFC-WAIVED: 테스트 1개 삭제이며 credential/identity/operator/sandbox/hooks 어느 subsystem 도 건드리지 않아요.
