### PR TITLE
fix(ci): dependency-only diff를 coverage source에서 분리

### DIFF
--- a/scripts/check_test_coverage.py
+++ b/scripts/check_test_coverage.py
@@ -13,6 +13,7 @@ Opt-out mechanisms (checked in order):
 3. Commit message contains "# ci:skip-test-coverage" — script-level check
 """
 
+import json
 import os
 from pathlib import Path, PurePosixPath
 import subprocess
@@ -59,6 +60,24 @@ def load_non_code_suffixes(path=NON_CODE_SUFFIXES_PATH):
 
 
 NON_CODE_SUFFIXES = load_non_code_suffixes()
+
+DEPENDENCY_LOCKFILE_NAMES = frozenset(
+    {"bun.lock", "bun.lockb", "package-lock.json", "pnpm-lock.yaml", "yarn.lock"}
+)
+DEPENDENCY_MANIFEST_FIELDS = frozenset(
+    {
+        "bundleDependencies",
+        "bundledDependencies",
+        "dependencies",
+        "devDependencies",
+        "optionalDependencies",
+        "overrides",
+        "peerDependencies",
+        "peerDependenciesMeta",
+        "pnpm",
+        "resolutions",
+    }
+)
 
 
 def base_ref():
@@ -123,12 +142,64 @@ def run_diff_or_fail(args):
         sys.exit(2)
 
 
+def read_json_at_revision(revision, path):
+    """Read one JSON object exactly as committed at revision:path.
+
+    Missing files, invalid JSON, and non-object roots are not dependency-only:
+    the coverage gate must keep treating an unclassified manifest change as
+    product code rather than silently exempting it.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "show", f"{revision}:{path}"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        value = json.loads(result.stdout)
+        return value if isinstance(value, dict) else None
+    except (subprocess.CalledProcessError, json.JSONDecodeError):
+        return None
+
+
+def is_dependency_metadata_only(path):
+    """Return true only for generated lockfiles or dependency-only manifests.
+
+    package.json remains covered when scripts, exports, runtime metadata, or
+    any other non-dependency field changes. This is a structural JSON
+    comparison, not a branch-name, author, or diff-text heuristic.
+    """
+    normalized = PurePosixPath(path.replace("\\", "/"))
+    if normalized.name in DEPENDENCY_LOCKFILE_NAMES:
+        return True
+    if normalized.name != "package.json":
+        return False
+
+    base = read_json_at_revision(f"origin/{base_ref()}", path)
+    head = read_json_at_revision("HEAD", path)
+    if base is None or head is None or base == head:
+        return False
+
+    def without_dependencies(manifest):
+        return {
+            key: value
+            for key, value in manifest.items()
+            if key not in DEPENDENCY_MANIFEST_FIELDS
+        }
+
+    return without_dependencies(base) == without_dependencies(head)
+
+
 def get_changed_covered_files():
     """Get list of covered code files changed in this PR."""
     stdout = run_diff_or_fail(
         ["git", "diff", "--name-only", pr_diff_range(), "--", *COVERED_CODE_PATHS]
     )
-    return [f for f in stdout.strip().split("\n") if f and is_covered_code_file(f)]
+    return [
+        f
+        for f in stdout.strip().split("\n")
+        if f and is_covered_code_file(f) and not is_dependency_metadata_only(f)
+    ]
 
 
 def is_test_file(path):

--- a/scripts/test_check_test_coverage.py
+++ b/scripts/test_check_test_coverage.py
@@ -35,10 +35,14 @@ class CheckTestCoverageTest(unittest.TestCase):
             return_value="lib/a.ml\ndashboard/app.ts\nconfig/runtime.toml\n",
         ) as run_diff:
             with mock.patch.dict(os.environ, {"GITHUB_BASE_REF": "main"}, clear=False):
-                self.assertEqual(
-                    coverage.get_changed_covered_files(),
-                    ["lib/a.ml", "dashboard/app.ts", "config/runtime.toml"],
-                )
+                with mock.patch(
+                    "check_test_coverage.is_dependency_metadata_only",
+                    return_value=False,
+                ):
+                    self.assertEqual(
+                        coverage.get_changed_covered_files(),
+                        ["lib/a.ml", "dashboard/app.ts", "config/runtime.toml"],
+                    )
 
         self.assertEqual(
             run_diff.call_args.args[0],
@@ -93,10 +97,62 @@ class CheckTestCoverageTest(unittest.TestCase):
             ),
         ):
             with mock.patch.dict(os.environ, {"GITHUB_BASE_REF": "main"}, clear=False):
-                self.assertEqual(
-                    coverage.get_changed_covered_files(),
-                    ["lib/app.ml"],
-                )
+                with mock.patch(
+                    "check_test_coverage.is_dependency_metadata_only",
+                    return_value=False,
+                ):
+                    self.assertEqual(
+                        coverage.get_changed_covered_files(),
+                        ["lib/app.ml"],
+                    )
+
+    def test_exact_dependency_lockfiles_are_metadata_not_source(self):
+        for path in (
+            "dashboard/pnpm-lock.yaml",
+            "web/package-lock.json",
+            "ui/yarn.lock",
+        ):
+            self.assertTrue(coverage.is_dependency_metadata_only(path))
+        self.assertFalse(coverage.is_dependency_metadata_only("config/runtime.yaml"))
+        self.assertFalse(
+            coverage.is_dependency_metadata_only("dashboard/package-data.json")
+        )
+
+    def test_package_manifest_dependency_only_change_is_metadata(self):
+        base = {
+            "name": "dashboard",
+            "scripts": {"test": "vitest"},
+            "devDependencies": {"postcss": "8.5.18"},
+        }
+        head = {
+            "name": "dashboard",
+            "scripts": {"test": "vitest"},
+            "devDependencies": {"postcss": "8.5.23"},
+        }
+        with mock.patch(
+            "check_test_coverage.read_json_at_revision", side_effect=[base, head]
+        ):
+            self.assertTrue(
+                coverage.is_dependency_metadata_only("dashboard/package.json")
+            )
+
+    def test_package_manifest_script_change_remains_covered(self):
+        base = {
+            "name": "dashboard",
+            "scripts": {"test": "vitest"},
+            "devDependencies": {"postcss": "8.5.18"},
+        }
+        head = {
+            "name": "dashboard",
+            "scripts": {"test": "vitest --watch"},
+            "devDependencies": {"postcss": "8.5.23"},
+        }
+        with mock.patch(
+            "check_test_coverage.read_json_at_revision", side_effect=[base, head]
+        ):
+            self.assertFalse(
+                coverage.is_dependency_metadata_only("dashboard/package.json")
+            )
 
     def test_test_file_predicate_does_not_match_production_checks(self):
         self.assertFalse(coverage.is_test_file("lib/exec/capability_check_typed.ml"))


### PR DESCRIPTION
## 요약
- 생성 lockfile은 test-required source에서 제외해용.
- package.json은 dependency 필드만 바뀐 경우에만 구조적으로 제외해용.
- scripts, exports 등 다른 필드가 함께 바뀌면 기존 coverage gate를 그대로 적용해용.
- author, branch명, diff 문자열 휴리스틱은 사용하지 않아용.

## 검증
- pyright
- ruff check / format
- coverage checker self-test 13개
- 실제 coverage checker 실행

Closes #26762