### PR TITLE
refactor(dashboard): use current stateless MCP transport

### DIFF
--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -14,16 +14,13 @@ const {
   setStoredToken,
 } = vi.hoisted(() => ({
   apiRequestErrorFromResponse: vi.fn(async (method: string, path: string, res: Response) =>
-    new Error(`${method} ${path}: ${res.status} ${res.statusText}`.trim())),
+    new Error(`${method} ${path}: ${res.status}`)),
   fetchWithTimeout: vi.fn(),
   reportToolHostFailure: vi.fn().mockResolvedValue({ ok: true }),
   authHeaders: vi.fn().mockReturnValue({}),
   clearStoredToken: vi.fn(),
   currentDashboardActor: vi.fn().mockReturnValue('dashboard'),
   currentStoredTokenRevision: vi.fn().mockReturnValue(0),
-  // Default to a non-empty stored token so ensureDevToken() short-circuits
-  // without consuming a fetchWithTimeout mock. Individual tests that want
-  // to exercise the dev-token bootstrap can override this.
   getStoredToken: vi.fn().mockReturnValue('test-stored-token'),
   getStoredTokenMeta: vi.fn().mockReturnValue({
     source: 'manual',
@@ -48,20 +45,23 @@ vi.mock('./core', () => ({
   setStoredToken,
 }))
 
-vi.mock('./tool-host-failure', () => ({
-  reportToolHostFailure,
-}))
+vi.mock('./tool-host-failure', () => ({ reportToolHostFailure }))
+vi.mock('../components/common/toast', () => ({ showActionToast: vi.fn() }))
 
-vi.mock('../components/common/toast', () => ({
-  showActionToast: vi.fn(),
-}))
+const okToolResponse = () =>
+  new Response('data: {"result":{"content":[{"type":"text","text":"ok"}]}}\n', {
+    status: 200,
+  })
+
+function callsByMethod(method: string) {
+  const calls = fetchWithTimeout.mock.calls as Array<[string, RequestInit, number]>
+  return calls.filter(([, init]) => {
+    if (typeof init.body !== 'string') return false
+    return JSON.parse(init.body).method === method
+  })
+}
 
 beforeEach(() => {
-  // Re-assert default return values because vi.clearAllMocks() in afterEach
-  // wipes any per-test `.mockReturnValueOnce` queue and can clash with
-  // mocks whose `vi.hoisted` defaults have been overwritten by an earlier
-  // test (e.g. authHeaders). The dev-token bootstrap must stay inert unless
-  // a test explicitly exercises it.
   currentDashboardActor.mockReturnValue('dashboard')
   currentStoredTokenRevision.mockReturnValue(0)
   getStoredToken.mockReturnValue('test-stored-token')
@@ -79,698 +79,145 @@ afterEach(async () => {
   resetMcpClientState()
   vi.clearAllMocks()
   vi.resetModules()
-}, 60_000)
-
-function setupMcpSessionMocks(sessionId: string) {
-  fetchWithTimeout
-    .mockResolvedValueOnce(
-      new Response('{}', { status: 200, headers: { 'Mcp-Session-Id': sessionId } }),
-    )
-    .mockResolvedValueOnce(new Response('', { status: 202 }))
-    .mockResolvedValueOnce(
-      new Response('data: {"result":{"content":[{"type":"text","text":"ok"}]}}\n', { status: 200 }),
-    )
-}
-
-function deferred<T>() {
-  let resolve!: (value: T) => void
-  let reject!: (reason?: unknown) => void
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise
-    reject = rejectPromise
-  })
-  return { promise, resolve, reject }
-}
-
-/** Find a fetchWithTimeout call by matching the JSON body's "method" field. */
-function findCallByMethod(method: string) {
-  return callsByMethod(method)[0]
-}
-
-function callsByMethod(method: string) {
-  const calls = fetchWithTimeout.mock.calls as Array<[string, RequestInit, number]>
-  return calls.filter(([, init]) => {
-    const body = init.body
-    if (typeof body !== 'string') return false
-    try { return JSON.parse(body).method === method }
-    catch { return false }
-  })
-}
-
-describe('mcpHeaders auth integration', () => {
-  it('reinitializes instead of reusing a session after the stored token changes', async () => {
-    setupMcpSessionMocks('sess-before-token-clear')
-
-    const { callMcpTool } = await import('./mcp')
-    await callMcpTool('masc_status', {})
-
-    currentStoredTokenRevision.mockReturnValue(1)
-    setupMcpSessionMocks('sess-after-token-clear')
-    await callMcpTool('masc_status', {})
-
-    const initializeCalls = callsByMethod('initialize')
-    const toolCalls = callsByMethod('tools/call')
-    expect(initializeCalls).toHaveLength(2)
-    expect(toolCalls).toHaveLength(2)
-    expect((initializeCalls[1]![1].headers as Record<string, string>)['Mcp-Session-Id'])
-      .toBeUndefined()
-    expect((toolCalls[0]![1].headers as Record<string, string>)['Mcp-Session-Id'])
-      .toBe('sess-before-token-clear')
-    expect((toolCalls[1]![1].headers as Record<string, string>)['Mcp-Session-Id'])
-      .toBe('sess-after-token-clear')
-  }, 60_000)
-
-  it('rejects an initialization response created under an older token revision', async () => {
-    fetchWithTimeout.mockImplementationOnce(async () => {
-      currentStoredTokenRevision.mockReturnValue(1)
-      return new Response('{}', {
-        status: 200,
-        headers: { 'Mcp-Session-Id': 'sess-stale-auth' },
-      })
-    })
-
-    const { callMcpTool } = await import('./mcp')
-    await expect(callMcpTool('masc_status', {}))
-      .rejects.toThrow('MCP authentication changed during request')
-
-    expect(callsByMethod('notifications/initialized')).toHaveLength(0)
-    expect(callsByMethod('tools/call')).toHaveLength(0)
-  }, 60_000)
-
-  it('does not let a delayed old-token tool response replace the current session', async () => {
-    let tokenRevision = 0
-    currentStoredTokenRevision.mockImplementation(() => tokenRevision)
-    setupMcpSessionMocks('sess-token-a')
-
-    const { callMcpTool } = await import('./mcp')
-    await callMcpTool('masc_status', {})
-
-    const delayedOldResponse = deferred<Response>()
-    fetchWithTimeout.mockImplementationOnce(() => delayedOldResponse.promise)
-    const oldCall = callMcpTool('masc_status', {})
-    await vi.waitFor(() => {
-      expect(callsByMethod('tools/call')).toHaveLength(2)
-    })
-
-    tokenRevision = 1
-    setupMcpSessionMocks('sess-token-b')
-    await callMcpTool('masc_status', {})
-
-    delayedOldResponse.resolve(new Response(
-      'data: {"result":{"content":[{"type":"text","text":"stale"}]}}\n',
-      { status: 200, headers: { 'Mcp-Session-Id': 'sess-token-a' } },
-    ))
-    await expect(oldCall).rejects.toThrow('MCP authentication changed during request')
-
-    fetchWithTimeout.mockResolvedValueOnce(
-      new Response('data: {"result":{"content":[{"type":"text","text":"fresh"}]}}\n', { status: 200 }),
-    )
-    await callMcpTool('masc_status', {})
-
-    expect(callsByMethod('initialize')).toHaveLength(2)
-    const latestToolCall = callsByMethod('tools/call').at(-1)
-    expect((latestToolCall?.[1].headers as Record<string, string>)['Mcp-Session-Id'])
-      .toBe('sess-token-b')
-  }, 60_000)
-
-  it('does not replay a delayed unknown-session response after the token changes', async () => {
-    let tokenRevision = 0
-    currentStoredTokenRevision.mockImplementation(() => tokenRevision)
-    setupMcpSessionMocks('sess-token-a')
-
-    const { callMcpTool } = await import('./mcp')
-    await callMcpTool('masc_status', {})
-
-    const finishOldErrorBody = deferred<void>()
-    apiRequestErrorFromResponse.mockImplementationOnce(async (_method, _path, res) => {
-      await finishOldErrorBody.promise
-      return new Error(`POST /mcp: ${res.status} stale transport session`)
-    })
-    fetchWithTimeout.mockResolvedValueOnce(new Response('{}', {
-      status: 404,
-      statusText: 'Not Found',
-      headers: { 'Mcp-Session-Id': 'sess-uninitialized-replacement' },
-    }))
-    const oldCall = callMcpTool('masc_status', {})
-    await vi.waitFor(() => {
-      expect(callsByMethod('tools/call')).toHaveLength(2)
-    })
-
-    tokenRevision = 1
-    setupMcpSessionMocks('sess-token-b')
-    await callMcpTool('masc_status', {})
-
-    finishOldErrorBody.resolve(undefined)
-    await expect(oldCall).rejects.toThrow('MCP authentication changed during request')
-
-    expect(callsByMethod('initialize')).toHaveLength(2)
-    expect(callsByMethod('tools/call')).toHaveLength(3)
-
-    fetchWithTimeout.mockResolvedValueOnce(
-      new Response('data: {"result":{"content":[{"type":"text","text":"still-b"}]}}\n', { status: 200 }),
-    )
-    await callMcpTool('masc_status', {})
-
-    expect(callsByMethod('initialize')).toHaveLength(2)
-    expect(callsByMethod('tools/call')).toHaveLength(4)
-    const latestToolCall = callsByMethod('tools/call').at(-1)
-    expect((latestToolCall?.[1].headers as Record<string, string>)['Mcp-Session-Id'])
-      .toBe('sess-token-b')
-  }, 60_000)
-
-  it('keeps a newer initializer authoritative when an older initializer finishes last', async () => {
-    let tokenRevision = 0
-    currentStoredTokenRevision.mockImplementation(() => tokenRevision)
-    const initializeA = deferred<Response>()
-    const initializeB = deferred<Response>()
-    fetchWithTimeout.mockImplementationOnce(() => initializeA.promise)
-
-    const { callMcpTool } = await import('./mcp')
-    const callA = callMcpTool('masc_status', {})
-    await vi.waitFor(() => {
-      expect(callsByMethod('initialize')).toHaveLength(1)
-    })
-
-    tokenRevision = 1
-    fetchWithTimeout
-      .mockImplementationOnce(() => initializeB.promise)
-      .mockResolvedValueOnce(new Response('', { status: 202 }))
-      .mockResolvedValueOnce(
-        new Response('data: {"result":{"content":[{"type":"text","text":"b"}]}}\n', { status: 200 }),
-      )
-    const callB = callMcpTool('masc_status', {})
-    await vi.waitFor(() => {
-      expect(callsByMethod('initialize')).toHaveLength(2)
-    })
-
-    initializeB.resolve(new Response('{}', {
-      status: 200,
-      headers: { 'Mcp-Session-Id': 'sess-init-b' },
-    }))
-    await expect(callB).resolves.toBe('b')
-
-    initializeA.resolve(new Response('{}', {
-      status: 200,
-      headers: { 'Mcp-Session-Id': 'sess-init-a' },
-    }))
-    await expect(callA).rejects.toThrow('MCP authentication changed during request')
-
-    fetchWithTimeout.mockResolvedValueOnce(
-      new Response('data: {"result":{"content":[{"type":"text","text":"still-b"}]}}\n', { status: 200 }),
-    )
-    await callMcpTool('masc_status', {})
-
-    expect(callsByMethod('initialize')).toHaveLength(2)
-    const latestToolCall = callsByMethod('tools/call').at(-1)
-    expect((latestToolCall?.[1].headers as Record<string, string>)['Mcp-Session-Id'])
-      .toBe('sess-init-b')
-  }, 60_000)
-
-  it('includes Authorization header from authHeaders in MCP initialize request', async () => {
-    authHeaders.mockReturnValue({
-      'Authorization': 'Bearer test-token-123',
-      'X-MASC-Agent': 'dashboard',
-    })
-    setupMcpSessionMocks('sess-auth')
-
-    const { callMcpTool } = await import('./mcp')
-    await callMcpTool('masc_status', {})
-
-    const initCall = findCallByMethod('initialize')
-    expect(initCall).toBeDefined()
-    const initHeaders = initCall![1].headers as Record<string, string>
-    expect(initHeaders['Authorization']).toBe('Bearer test-token-123')
-    expect(initHeaders['X-MASC-Agent']).toBe('dashboard')
-    expect(initHeaders['Content-Type']).toBe('application/json')
-
-    const toolCall = findCallByMethod('tools/call')
-    expect(toolCall).toBeDefined()
-    const toolHeaders = toolCall![1].headers as Record<string, string>
-    expect(toolHeaders['Authorization']).toBe('Bearer test-token-123')
-  }, 60_000)
-
-  it('works without token when authHeaders returns empty', async () => {
-    authHeaders.mockReturnValue({})
-    setupMcpSessionMocks('sess-noauth')
-
-    const { callMcpTool } = await import('./mcp')
-    await callMcpTool('masc_status', {})
-
-    const initCall = findCallByMethod('initialize')
-    expect(initCall).toBeDefined()
-    const noAuthHeaders = initCall![1].headers as Record<string, string>
-    expect(noAuthHeaders['Authorization']).toBeUndefined()
-    expect(noAuthHeaders['Content-Type']).toBe('application/json')
-  }, 60_000)
 })
 
-describe('dev-token bootstrap', () => {
-  it('fetches /api/v1/dashboard/dev-token once when no token is stored and persists the response', async () => {
+describe('MCP 2026-07-28 dashboard client', () => {
+  it('sends one stateless tools/call with current mirrored metadata', async () => {
+    authHeaders.mockReturnValue({ Authorization: 'Bearer current-token' })
+    fetchWithTimeout.mockResolvedValueOnce(okToolResponse())
+
+    const { callMcpTool } = await import('./mcp')
+    await expect(callMcpTool('masc_status', {})).resolves.toBe('ok')
+
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(1)
+    const [path, init] = fetchWithTimeout.mock.calls[0] as [string, RequestInit]
+    expect(path).toBe('/mcp')
+    const headers = init.headers as Record<string, string>
+    expect(headers).toMatchObject({
+      Authorization: 'Bearer current-token',
+      'Mcp-Protocol-Version': '2026-07-28',
+      'Mcp-Method': 'tools/call',
+      'Mcp-Name': 'masc_status',
+    })
+    expect(headers['Mcp-Session-Id']).toBeUndefined()
+    const body = JSON.parse(init.body as string)
+    expect(body.params._meta).toEqual({
+      'io.modelcontextprotocol/protocolVersion': '2026-07-28',
+      'io.modelcontextprotocol/clientCapabilities': {},
+    })
+    expect(callsByMethod('initialize')).toHaveLength(0)
+    expect(callsByMethod('notifications/initialized')).toHaveLength(0)
+  })
+
+  it('preserves the dashboard actor injection contract', async () => {
+    fetchWithTimeout.mockResolvedValueOnce(okToolResponse())
+    const { callMcpTool } = await import('./mcp')
+    await callMcpTool('masc_keeper_create_from_persona', { persona_name: 'sonsukku' })
+
+    const [, init] = callsByMethod('tools/call')[0]!
+    const body = JSON.parse(init.body as string)
+    expect(body.params.arguments).toEqual({
+      persona_name: 'sonsukku',
+      _agent_name: 'dashboard',
+    })
+  })
+
+  it('does not inject an actor for a token without actor metadata', async () => {
+    getStoredToken.mockReturnValue('codex-token')
+    getStoredTokenMeta.mockReturnValue(null)
+    isRemoteAccess.mockReturnValue(true)
+    authHeaders.mockReturnValue({ Authorization: 'Bearer codex-token' })
+    fetchWithTimeout.mockResolvedValueOnce(okToolResponse())
+
+    const { callMcpTool } = await import('./mcp')
+    await callMcpTool('masc_persona_list', {})
+
+    const [, init] = callsByMethod('tools/call')[0]!
+    const body = JSON.parse(init.body as string)
+    expect(body.params.arguments).toEqual({})
+  })
+
+  it('uses current metadata on every tools/list page', async () => {
+    fetchWithTimeout
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        result: { tools: [{ name: 'one', description: '', inputSchema: {} }], nextCursor: 'next' },
+      }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        result: { tools: [{ name: 'two', description: '', inputSchema: {} }] },
+      }), { status: 200 }))
+
+    const { listAllMcpTools } = await import('./mcp')
+    await expect(listAllMcpTools()).resolves.toHaveLength(2)
+
+    const calls = callsByMethod('tools/list')
+    expect(calls).toHaveLength(2)
+    for (const [, init] of calls) {
+      const headers = init.headers as Record<string, string>
+      const body = JSON.parse(init.body as string)
+      expect(headers['Mcp-Protocol-Version']).toBe('2026-07-28')
+      expect(headers['Mcp-Method']).toBe('tools/list')
+      expect(headers['Mcp-Name']).toBeUndefined()
+      expect(body.params._meta['io.modelcontextprotocol/protocolVersion'])
+        .toBe('2026-07-28')
+    }
+  })
+
+  it('does not retry an HTTP failure as a session recovery', async () => {
+    fetchWithTimeout.mockResolvedValueOnce(new Response('missing', {
+      status: 404,
+      headers: { 'Mcp-Session-Id': 'legacy-replacement' },
+    }))
+
+    const { callMcpTool } = await import('./mcp')
+    await expect(callMcpTool('masc_status', {})).rejects.toThrow('POST /mcp: 404')
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports transport failures without legacy session telemetry', async () => {
+    fetchWithTimeout.mockRejectedValueOnce(new Error('POST /mcp: timeout after 30000ms'))
+
+    const { callMcpTool } = await import('./mcp')
+    await expect(callMcpTool('masc_keeper_msg', { message: 'ping' }))
+      .rejects.toThrow('timeout after 30000ms')
+
+    expect(reportToolHostFailure).toHaveBeenCalledWith(expect.objectContaining({
+      client_name: 'masc-dashboard',
+      tool_name: 'masc_keeper_msg',
+      transport: 'mcp_http',
+      phase: 'tools/call',
+      timeout_ms: 30000,
+    }))
+    expect(reportToolHostFailure.mock.calls[0]![0].session_id).toBeUndefined()
+  })
+
+  it('fails closed after a 403 until client state is reset', async () => {
+    fetchWithTimeout.mockResolvedValueOnce(new Response('forbidden', { status: 403 }))
+    const { callMcpTool, resetMcpClientState } = await import('./mcp')
+
+    await expect(callMcpTool('masc_status', {})).rejects.toThrow('MCP 연결이 차단')
+    await expect(callMcpTool('masc_status', {})).rejects.toThrow('MCP 연결이 차단')
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(1)
+
+    resetMcpClientState()
+    fetchWithTimeout.mockResolvedValueOnce(okToolResponse())
+    await expect(callMcpTool('masc_status', {})).resolves.toBe('ok')
+  })
+
+  it('bootstraps a loopback dev token before the single MCP request', async () => {
     getStoredToken.mockReturnValue(null)
     fetchWithTimeout
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({
-          token: 'loopback-dev-token',
-          actor: 'dashboard',
-          scope: 'admin',
-        }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        }),
-      )
-      // MCP initialize + initialized + tools/call
-      .mockResolvedValueOnce(
-        new Response('{}', { status: 200, headers: { 'Mcp-Session-Id': 'sess-dev' } }),
-      )
-      .mockResolvedValueOnce(new Response('', { status: 202 }))
-      .mockResolvedValueOnce(
-        new Response('data: {"result":{"content":[{"type":"text","text":"ok"}]}}\n', { status: 200 }),
-      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        token: 'loopback-dev-token', actor: 'dashboard', scope: 'admin',
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+      .mockResolvedValueOnce(okToolResponse())
 
     const { callMcpTool } = await import('./mcp')
     await callMcpTool('masc_status', {})
 
     expect(setStoredToken).toHaveBeenCalledWith('loopback-dev-token', {
-      source: 'dev',
-      actor: 'dashboard',
-      scope: 'admin',
+      source: 'dev', actor: 'dashboard', scope: 'admin',
     })
-    const calls = fetchWithTimeout.mock.calls as Array<[string, RequestInit]>
-    expect(calls.length).toBeGreaterThanOrEqual(2)
-    expect(calls[0]?.[0]).toBe('/api/v1/dashboard/dev-token')
-    expect(calls[1]?.[0]).toBe('/mcp')
-  }, 60_000)
-
-  it('keeps a manual loopback token when the default dashboard actor is active', async () => {
-    getStoredToken.mockReturnValue('manual-token')
-    getStoredTokenMeta.mockReturnValue({
-      source: 'manual',
-      actor: null,
-      scope: null,
-    })
-    setupMcpSessionMocks('sess-manual-kept')
-
-    const { callMcpTool } = await import('./mcp')
-    await callMcpTool('masc_status', {})
-
-    expect(setStoredToken).not.toHaveBeenCalled()
-    const calls = fetchWithTimeout.mock.calls as Array<[string, RequestInit]>
-    expect(calls[0]?.[0]).toBe('/mcp')
-  }, 60_000)
-
-  it('keeps manual tokens for non-default dashboard actors', async () => {
-    currentDashboardActor.mockReturnValue('dashboard-manual-actor')
-    authHeaders.mockReturnValue({
-      'Authorization': 'Bearer manual-actor-token',
-      'X-MASC-Agent': 'dashboard-manual-actor',
-    })
-    getStoredToken.mockReturnValue('manual-actor-token')
-    getStoredTokenMeta.mockReturnValue({
-      source: 'manual',
-      actor: null,
-      scope: null,
-    })
-    setupMcpSessionMocks('sess-manual-actor')
-
-    const { callMcpTool } = await import('./mcp')
-    await callMcpTool('masc_status', {})
-
-    expect(setStoredToken).not.toHaveBeenCalled()
-    const calls = fetchWithTimeout.mock.calls as Array<[string, RequestInit]>
-    expect(calls[0]?.[0]).toBe('/mcp')
-  }, 60_000)
-
-  it('swallows dev-token fetch failures so strict-auth servers still reach the 401 path', async () => {
-    getStoredToken.mockReturnValue(null)
-    fetchWithTimeout
-      .mockResolvedValueOnce(new Response('not found', { status: 404 }))
-      .mockResolvedValueOnce(
-        new Response('{}', { status: 200, headers: { 'Mcp-Session-Id': 'sess-nok' } }),
-      )
-      .mockResolvedValueOnce(new Response('', { status: 202 }))
-      .mockResolvedValueOnce(
-        new Response('data: {"result":{"content":[{"type":"text","text":"ok"}]}}\n', { status: 200 }),
-      )
-
-    const { callMcpTool } = await import('./mcp')
-    await callMcpTool('masc_status', {})
-
-    expect(setStoredToken).not.toHaveBeenCalled()
-    const initCall = findCallByMethod('initialize')
-    expect(initCall).toBeDefined()
-  }, 60_000)
-
-  it('clears an old managed dev token when the loopback bootstrap endpoint disappears', async () => {
-    getStoredToken.mockReturnValue('stale-dev-token')
-    getStoredTokenMeta.mockReturnValue({ source: 'dev', actor: 'dashboard', scope: 'admin' })
-    fetchWithTimeout
-      .mockResolvedValueOnce(new Response('not found', { status: 404 }))
-      .mockResolvedValueOnce(
-        new Response('{}', { status: 200, headers: { 'Mcp-Session-Id': 'sess-dev-404' } }),
-      )
-      .mockResolvedValueOnce(new Response('', { status: 202 }))
-      .mockResolvedValueOnce(
-        new Response('data: {"result":{"content":[{"type":"text","text":"ok"}]}}\n', { status: 200 }),
-      )
-
-    const { callMcpTool } = await import('./mcp')
-    await callMcpTool('masc_status', {})
-
-    expect(clearStoredToken).toHaveBeenCalledTimes(1)
-    expect(setStoredToken).not.toHaveBeenCalled()
-  }, 60_000)
-})
-
-describe('callMcpTool', () => {
-  it('injects the dashboard actor into MCP tool arguments', async () => {
-    setupMcpSessionMocks('sess-actor')
-
-    const { callMcpTool } = await import('./mcp')
-    await callMcpTool('masc_keeper_create_from_persona', { persona_name: 'sonsukku' })
-
-    const toolCall = findCallByMethod('tools/call')
-    expect(toolCall).toBeDefined()
-    const body = JSON.parse(toolCall![1].body as string)
-    expect(body.params.arguments).toEqual({
-      persona_name: 'sonsukku',
-      _agent_name: 'dashboard',
-    })
-  }, 60_000)
-
-  it('omits implicit dashboard actor for token-bound sessions without actor metadata', async () => {
-    getStoredToken.mockReturnValue('codex-token')
-    getStoredTokenMeta.mockReturnValue(null)
-    isRemoteAccess.mockReturnValue(true)
-    authHeaders.mockImplementation((opts?: { actorName?: string | null }) => ({
-      Authorization: 'Bearer codex-token',
-      ...(opts?.actorName ? { 'X-MASC-Agent': opts.actorName } : {}),
-    }))
-    setupMcpSessionMocks('sess-token-owner')
-
-    const { callMcpTool } = await import('./mcp')
-    await callMcpTool('masc_persona_list', {})
-
-    const toolCall = findCallByMethod('tools/call')
-    expect(toolCall).toBeDefined()
-    const body = JSON.parse(toolCall![1].body as string)
-    expect(body.params.arguments).toEqual({})
-    const headers = toolCall![1].headers as Record<string, string>
-    expect(headers.Authorization).toBe('Bearer codex-token')
-    expect(headers['X-MASC-Agent']).toBeUndefined()
-  }, 60_000)
-
-  it('treats legacy agent_name as payload when the session is token-authenticated', async () => {
-    authHeaders.mockImplementation((opts?: { actorName?: string | null }) => (
-      opts?.actorName ? { 'X-MASC-Agent': opts.actorName } : {}
-    ))
-    setupMcpSessionMocks('sess-explicit')
-
-    const { callMcpTool } = await import('./mcp')
-    await callMcpTool('masc_agent_fitness', { agent_name: 'codex-tool-matrix', days: 7 })
-
-    const toolCall = findCallByMethod('tools/call')
-    expect(toolCall).toBeDefined()
-    const body = JSON.parse(toolCall![1].body as string)
-    expect(body.params.arguments).toEqual({
-      agent_name: 'codex-tool-matrix',
-      days: 7,
-      _agent_name: 'dashboard',
-    })
-    const headers = toolCall![1].headers as Record<string, string>
-    expect(headers['X-MASC-Agent']).toBe('dashboard')
-  }, 60_000)
-
-  it('still honors an explicit _agent_name override', async () => {
-    authHeaders.mockImplementation((opts?: { actorName?: string | null }) => (
-      opts?.actorName ? { 'X-MASC-Agent': opts.actorName } : {}
-    ))
-    setupMcpSessionMocks('sess-explicit-internal')
-
-    const { callMcpTool } = await import('./mcp')
-    await callMcpTool('masc_bind', { _agent_name: 'codex-tool-matrix' })
-
-    const toolCall = findCallByMethod('tools/call')
-    expect(toolCall).toBeDefined()
-    const body = JSON.parse(toolCall![1].body as string)
-    expect(body.params.arguments).toEqual({
-      _agent_name: 'codex-tool-matrix',
-    })
-    const headers = toolCall![1].headers as Record<string, string>
-    expect(headers['X-MASC-Agent']).toBe('codex-tool-matrix')
-  }, 60_000)
-
-  it('reports tool-host failures after the MCP session is established', async () => {
-    fetchWithTimeout
-      .mockResolvedValueOnce(
-        new Response('{}', {
-          status: 200,
-          headers: { 'Mcp-Session-Id': 'sess-1' },
-        }),
-      )
-      .mockResolvedValueOnce(new Response('', { status: 202 }))
-      .mockRejectedValueOnce(new Error('POST /mcp: timeout after 30000ms'))
-
-    const { callMcpTool } = await import('./mcp')
-
-    await expect(
-      callMcpTool('masc_keeper_msg', { name: 'sangsu', message: 'ping' }),
-    ).rejects.toThrow('POST /mcp: timeout after 30000ms')
-
-    expect(reportToolHostFailure).toHaveBeenCalledTimes(1)
-    expect(reportToolHostFailure).toHaveBeenCalledWith(
-      expect.objectContaining({
-        client_name: 'masc-dashboard',
-        tool_name: 'masc_keeper_msg',
-        transport: 'mcp_http',
-        phase: 'tools/call',
-        session_id: 'sess-1',
-        timeout_ms: 30000,
-      }),
-    )
-  })
-
-  it('attributes a delayed failure to the binding that sent the request', async () => {
-    let tokenRevision = 0
-    currentStoredTokenRevision.mockImplementation(() => tokenRevision)
-    const delayedOldFailure = deferred<Response>()
-    fetchWithTimeout
-      .mockResolvedValueOnce(
-        new Response('{}', {
-          status: 200,
-          headers: { 'Mcp-Session-Id': 'sess-telemetry-a' },
-        }),
-      )
-      .mockResolvedValueOnce(new Response('', { status: 202 }))
-      .mockImplementationOnce(() => delayedOldFailure.promise)
-
-    const { callMcpTool } = await import('./mcp')
-    const oldCall = callMcpTool('masc_keeper_msg', { name: 'sangsu', message: 'old' })
-    const oldFailure = expect(oldCall).rejects.toThrow('POST /mcp: timeout after 30000ms')
-    await vi.waitFor(() => {
-      expect(callsByMethod('tools/call')).toHaveLength(1)
-    })
-
-    tokenRevision = 1
-    setupMcpSessionMocks('sess-telemetry-b')
-    await callMcpTool('masc_status', {})
-
-    delayedOldFailure.reject(new Error('POST /mcp: timeout after 30000ms'))
-    await oldFailure
-
-    expect(reportToolHostFailure).toHaveBeenCalledTimes(1)
-    expect(reportToolHostFailure).toHaveBeenCalledWith(
-      expect.objectContaining({
-        tool_name: 'masc_keeper_msg',
-        phase: 'tools/call',
-        session_id: 'sess-telemetry-a',
-      }),
-    )
-  }, 60_000)
-
-  it('does not retry implicit actor mismatches', async () => {
-    fetchWithTimeout
-      .mockResolvedValueOnce(
-        new Response('{}', {
-          status: 200,
-          headers: { 'Mcp-Session-Id': 'sess-mismatch-1' },
-        }),
-      )
-      .mockResolvedValueOnce(new Response('', { status: 202 }))
-      .mockResolvedValueOnce(
-        new Response('data: {"result":{"isError":true,"content":[{"type":"text","text":"🔐 Unauthorized: No credential found for dashboard (bearer token belongs to codex)"}]}}\n', { status: 200 }),
-      )
-
-    const { callMcpTool } = await import('./mcp')
-
-    await expect(callMcpTool('masc_persona_list', {})).rejects.toThrow(
-      'No credential found for dashboard',
-    )
-    const toolCalls = (fetchWithTimeout.mock.calls as Array<[string, RequestInit]>)
-      .filter(([, init]) => typeof init.body === 'string' && JSON.parse(init.body as string).method === 'tools/call')
-    expect(toolCalls).toHaveLength(1)
-  })
-
-  it('does not retry explicit _agent_name mismatches', async () => {
-    authHeaders.mockImplementation((opts?: { actorName?: string | null }) => (
-      opts?.actorName ? { 'X-MASC-Agent': opts.actorName } : {}
-    ))
-    fetchWithTimeout
-      .mockResolvedValueOnce(
-        new Response('{}', {
-          status: 200,
-          headers: { 'Mcp-Session-Id': 'sess-explicit-mismatch' },
-        }),
-      )
-      .mockResolvedValueOnce(new Response('', { status: 202 }))
-      .mockResolvedValueOnce(
-        new Response('data: {"result":{"isError":true,"content":[{"type":"text","text":"🔐 Unauthorized: No credential found for dashboard (bearer token belongs to codex)"}]}}\n', { status: 200 }),
-      )
-
-    const { callMcpTool } = await import('./mcp')
-
-    await expect(callMcpTool('masc_bind', { _agent_name: 'dashboard' })).rejects.toThrow(
-      'No credential found for dashboard',
-    )
-  })
-
-  it('reinitializes and retries once when the server rejects a stale MCP session', async () => {
-    fetchWithTimeout
-      .mockResolvedValueOnce(
-        new Response('{}', {
-          status: 200,
-          headers: { 'Mcp-Session-Id': 'sess-stale' },
-        }),
-      )
-      .mockResolvedValueOnce(new Response('', { status: 202 }))
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            jsonrpc: '2.0',
-            error: {
-              code: -32600,
-              message: 'transport session is no longer available',
-            },
-            id: null,
-          }),
-          {
-            status: 404,
-            statusText: 'Not Found',
-            headers: { 'Mcp-Session-Id': 'sess-uninitialized' },
-          },
-        ),
-      )
-      .mockResolvedValueOnce(
-        new Response('{}', {
-          status: 200,
-          headers: { 'Mcp-Session-Id': 'sess-fresh' },
-        }),
-      )
-      .mockResolvedValueOnce(new Response('', { status: 202 }))
-      .mockResolvedValueOnce(
-        new Response('data: {"result":{"content":[{"type":"text","text":"ok"}]}}\n', { status: 200 }),
-      )
-
-    const { callMcpTool } = await import('./mcp')
-    await expect(callMcpTool('masc_status', {})).resolves.toBe('ok')
-
-    const calls = fetchWithTimeout.mock.calls as Array<[string, RequestInit, number]>
-    const callsByMethod = (method: string) =>
-      calls.filter(([, init]) => {
-        const body = init.body
-        if (typeof body !== 'string') return false
-        try { return JSON.parse(body).method === method }
-        catch { return false }
-      })
-    const initCalls = callsByMethod('initialize')
-    const toolCalls = callsByMethod('tools/call')
-
-    expect(initCalls).toHaveLength(2)
-    expect(toolCalls).toHaveLength(2)
-    expect((toolCalls[0]![1].headers as Record<string, string>)['Mcp-Session-Id'])
-      .toBe('sess-stale')
-    expect((initCalls[1]![1].headers as Record<string, string>)['Mcp-Session-Id'])
-      .toBeUndefined()
-    expect((toolCalls[1]![1].headers as Record<string, string>)['Mcp-Session-Id'])
-      .toBe('sess-fresh')
-  })
-
-  it('blocks subsequent calls after tools/call returns 403', async () => {
-    fetchWithTimeout
-      .mockResolvedValueOnce(
-        new Response('{}', {
-          status: 200,
-          headers: { 'Mcp-Session-Id': 'sess-403' },
-        }),
-      )
-      .mockResolvedValueOnce(new Response('', { status: 202 }))
-      .mockResolvedValueOnce(
-        new Response('Forbidden', { status: 403, statusText: 'Forbidden' }),
-      )
-
-    const { callMcpTool } = await import('./mcp')
-
-    await expect(callMcpTool('masc_status', {})).rejects.toThrow(
-      'MCP 연결이 차단되었습니다',
-    )
-
-    fetchWithTimeout.mockClear()
-    await expect(callMcpTool('masc_status', {})).rejects.toThrow(
-      'MCP 연결이 차단되었습니다',
-    )
-    expect(fetchWithTimeout).not.toHaveBeenCalled()
-  })
-
-  it('throws on non-2xx initialize response without proceeding', async () => {
-    fetchWithTimeout.mockResolvedValueOnce(
-      new Response('Internal Server Error', { status: 500, statusText: 'Internal Server Error' }),
-    )
-
-    const { callMcpTool } = await import('./mcp')
-
-    await expect(callMcpTool('masc_status', {})).rejects.toThrow(
-      'POST /mcp initialize: 500',
-    )
-    expect(fetchWithTimeout).toHaveBeenCalledTimes(1)
-  })
-
-  it('fails closed when the initialized notification returns non-2xx', async () => {
-    fetchWithTimeout
-      .mockResolvedValueOnce(
-        new Response('{}', {
-          status: 200,
-          headers: { 'Mcp-Session-Id': 'sess-notification-failed' },
-        }),
-      )
-      .mockResolvedValueOnce(
-        new Response('Internal Server Error', {
-          status: 500,
-          statusText: 'Internal Server Error',
-        }),
-      )
-
-    const { callMcpTool } = await import('./mcp')
-
-    await expect(callMcpTool('masc_status', {})).rejects.toThrow(
-      'POST /mcp notifications/initialized: 500',
-    )
-    expect(callsByMethod('tools/call')).toHaveLength(0)
-  })
-
-  it('blocks subsequent calls after initialize returns 403', async () => {
-    fetchWithTimeout.mockResolvedValueOnce(
-      new Response('Forbidden', { status: 403, statusText: 'Forbidden' }),
-    )
-
-    const { callMcpTool } = await import('./mcp')
-
-    await expect(callMcpTool('masc_status', {})).rejects.toThrow(
-      'MCP 연결이 차단되었습니다',
-    )
-
-    fetchWithTimeout.mockClear()
-    await expect(callMcpTool('masc_status', {})).rejects.toThrow(
-      'MCP 연결이 차단되었습니다',
-    )
-    expect(fetchWithTimeout).not.toHaveBeenCalled()
+    expect(fetchWithTimeout.mock.calls.map(call => call[0]))
+      .toEqual(['/api/v1/dashboard/dev-token', '/mcp'])
   })
 })

--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -61,6 +61,14 @@ function callsByMethod(method: string) {
   })
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
 beforeEach(() => {
   currentDashboardActor.mockReturnValue('dashboard')
   currentStoredTokenRevision.mockReturnValue(0)
@@ -173,6 +181,21 @@ describe('MCP 2026-07-28 dashboard client', () => {
     expect(fetchWithTimeout).toHaveBeenCalledTimes(1)
   })
 
+  it('rejects a response completed under an older auth revision', async () => {
+    let revision = 0
+    currentStoredTokenRevision.mockImplementation(() => revision)
+    const response = deferred<Response>()
+    fetchWithTimeout.mockImplementationOnce(() => response.promise)
+
+    const { callMcpTool } = await import('./mcp')
+    const request = callMcpTool('masc_status', {})
+    await vi.waitFor(() => expect(fetchWithTimeout).toHaveBeenCalledTimes(1))
+
+    revision = 1
+    response.resolve(okToolResponse())
+    await expect(request).rejects.toThrow('MCP authentication changed during request')
+  })
+
   it('reports transport failures without legacy session telemetry', async () => {
     fetchWithTimeout.mockRejectedValueOnce(new Error('POST /mcp: timeout after 30000ms'))
 
@@ -201,6 +224,19 @@ describe('MCP 2026-07-28 dashboard client', () => {
     resetMcpClientState()
     fetchWithTimeout.mockResolvedValueOnce(okToolResponse())
     await expect(callMcpTool('masc_status', {})).resolves.toBe('ok')
+  })
+
+  it('does not carry a 403 block into a newer auth revision', async () => {
+    let revision = 0
+    currentStoredTokenRevision.mockImplementation(() => revision)
+    fetchWithTimeout.mockResolvedValueOnce(new Response('forbidden', { status: 403 }))
+    const { callMcpTool } = await import('./mcp')
+
+    await expect(callMcpTool('masc_status', {})).rejects.toThrow('MCP 연결이 차단')
+    revision = 1
+    fetchWithTimeout.mockResolvedValueOnce(okToolResponse())
+    await expect(callMcpTool('masc_status', {})).resolves.toBe('ok')
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(2)
   })
 
   it('bootstraps a loopback dev token before the single MCP request', async () => {

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -25,6 +25,7 @@ interface McpRequestBinding {
 
 let blockedAuthRevision: number | null = null
 let observedTokenRevision = currentStoredTokenRevision()
+let blockedToastShown = false
 
 async function bestEffortReportToolHostFailure(payload: {
   toolName: string
@@ -118,6 +119,7 @@ function synchronizeMcpAuthRevision(): void {
   const currentRevision = currentStoredTokenRevision()
   if (observedTokenRevision !== currentRevision) {
     blockedAuthRevision = null
+    blockedToastShown = false
     resetDevTokenBootstrap()
     observedTokenRevision = currentRevision
   }
@@ -187,8 +189,6 @@ async function mcpPost(
   assertBinding(binding)
   return text
 }
-
-let blockedToastShown = false
 
 async function ensureBinding(): Promise<McpRequestBinding> {
   synchronizeMcpAuthRevision()

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -1,4 +1,4 @@
-// MASC Dashboard — MCP-over-HTTP client with session lifecycle
+// MASC Dashboard — MCP 2026-07-28 over Streamable HTTP
 
 import {
   apiRequestErrorFromResponse,
@@ -11,54 +11,26 @@ import {
   getStoredTokenMeta,
 } from './core'
 import { ensureDevToken, resetDevTokenBootstrap } from './dev-token'
-import {
-  MCP_INIT_COOLDOWN_MS,
-  MCP_INITIALIZE_TIMEOUT_MS,
-  MCP_INITIALIZED_NOTIFY_TIMEOUT_MS,
-} from '../config/constants'
 import { reportToolHostFailure } from './tool-host-failure'
 import { showActionToast } from '../components/common/toast'
 import { errorToString } from '../lib/format-string'
 
-// --- MCP Session Management ---
-
+const MCP_PROTOCOL_VERSION = '2026-07-28'
 const MCP_BLOCKED_MESSAGE = 'MCP 연결이 차단되었습니다.'
 const MCP_AUTH_CHANGED_MESSAGE = 'MCP authentication changed during request'
 
-interface McpSessionBinding {
-  readonly sessionId: string | null
+interface McpRequestBinding {
   readonly authRevision: number
 }
 
-type McpSessionState =
-  | { readonly kind: 'ready'; readonly binding: McpSessionBinding }
-  | { readonly kind: 'blocked'; readonly authRevision: number }
-
-interface McpInitAttempt {
-  readonly generation: number
-  readonly promise: Promise<McpSessionBinding>
-  cooldownTimer: ReturnType<typeof setTimeout> | null
-}
-
-interface McpRequestTrace {
-  binding: McpSessionBinding | null
-}
-
-type McpErrorResponseContract =
-  | { readonly kind: 'unknown_session'; readonly replacementSessionId: string }
-  | { readonly kind: 'other' }
-
-let mcpSessionState: McpSessionState | null = null
+let blockedAuthRevision: number | null = null
 let observedTokenRevision = currentStoredTokenRevision()
-let initGeneration = 0
-let initAttempt: McpInitAttempt | null = null
 
 async function bestEffortReportToolHostFailure(payload: {
   toolName: string
   message: string
   phase: string
   requestId?: string
-  sessionId?: string
   timeoutMs?: number
 }) {
   try {
@@ -69,7 +41,6 @@ async function bestEffortReportToolHostFailure(payload: {
       phase: payload.phase,
       message: payload.message,
       request_id: payload.requestId,
-      session_id: payload.sessionId,
       timeout_ms: payload.timeoutMs,
     })
   } catch {
@@ -111,21 +82,21 @@ function implicitToolActor(): string | null {
 }
 
 function mcpHeadersForActor(
-  binding: McpSessionBinding,
+  binding: McpRequestBinding,
+  method: string,
+  name: string | null,
   actorName?: string | null,
-  extra?: Record<string, string>,
 ): Record<string, string> {
   assertAuthRevision(binding.authRevision)
   const headers: Record<string, string> = {
     ...authHeaders({ actorName }),
     'Content-Type': 'application/json',
     Accept: 'application/json, text/event-stream',
-    ...(extra ?? {}),
+    'Mcp-Protocol-Version': MCP_PROTOCOL_VERSION,
+    'Mcp-Method': method,
   }
+  if (name) headers['Mcp-Name'] = name
   assertAuthRevision(binding.authRevision)
-  if (binding.sessionId) {
-    headers['Mcp-Session-Id'] = binding.sessionId
-  }
   return headers
 }
 
@@ -139,223 +110,89 @@ function assertAuthRevision(expectedRevision: number): void {
   }
 }
 
-function assertPublishedBinding(binding: McpSessionBinding): void {
+function assertBinding(binding: McpRequestBinding): void {
   assertAuthRevision(binding.authRevision)
-  if (mcpSessionState?.kind !== 'ready' || mcpSessionState.binding !== binding) {
-    throw authChangedError()
-  }
-}
-
-function invalidateInitAttempt(): void {
-  initGeneration += 1
-  if (initAttempt?.cooldownTimer) {
-    clearTimeout(initAttempt.cooldownTimer)
-  }
-  initAttempt = null
-}
-
-function resetMcpSessionOnly(): void {
-  mcpSessionState = null
-  invalidateInitAttempt()
 }
 
 function synchronizeMcpAuthRevision(): void {
   const currentRevision = currentStoredTokenRevision()
   if (observedTokenRevision !== currentRevision) {
-    resetMcpSessionOnly()
+    blockedAuthRevision = null
     resetDevTokenBootstrap()
     observedTokenRevision = currentRevision
   }
 }
 
-function mcpBodyMethod(body: unknown): string | null {
-  if (typeof body !== 'object' || body === null) return null
-  const method = (body as Record<string, unknown>).method
-  return typeof method === 'string' ? method : null
-}
-
-function canRetryUnknownSession(body: unknown): boolean {
-  const method = mcpBodyMethod(body)
-  return method !== 'initialize'
-    && method !== 'notifications/initialized'
-    && method !== 'ping'
-    && method !== 'server/discover'
-}
-
-function classifyMcpErrorResponse(
-  res: Response,
-  body: unknown,
-): McpErrorResponseContract {
-  const replacementSessionId = res.headers.get('Mcp-Session-Id')
-  if (
-    res.status === 404
-    && replacementSessionId
-    && canRetryUnknownSession(body)
-  ) {
-    return { kind: 'unknown_session', replacementSessionId }
+function currentRequest(body: unknown): {
+  body: Record<string, unknown>
+  method: string
+  name: string | null
+} {
+  if (typeof body !== 'object' || body === null) {
+    throw new Error('MCP request must be an object')
   }
-  return { kind: 'other' }
-}
-
-function invalidatePublishedBinding(binding: McpSessionBinding): void {
-  assertPublishedBinding(binding)
-  resetMcpSessionOnly()
+  const request = body as Record<string, unknown>
+  if (typeof request.method !== 'string') {
+    throw new Error('MCP request method is required')
+  }
+  const rawParams = request.params
+  const params = typeof rawParams === 'object' && rawParams !== null
+    ? rawParams as Record<string, unknown>
+    : {}
+  const rawMeta = params._meta
+  const meta = typeof rawMeta === 'object' && rawMeta !== null
+    ? rawMeta as Record<string, unknown>
+    : {}
+  const nameKey = request.method === 'resources/read' ? 'uri' : 'name'
+  const rawName = params[nameKey]
+  return {
+    body: {
+      ...request,
+      params: {
+        ...params,
+        _meta: {
+          ...meta,
+          'io.modelcontextprotocol/protocolVersion': MCP_PROTOCOL_VERSION,
+          'io.modelcontextprotocol/clientCapabilities': {},
+        },
+      },
+    },
+    method: request.method,
+    name: typeof rawName === 'string' ? rawName : null,
+  }
 }
 
 async function mcpPost(
   body: unknown,
-  binding: McpSessionBinding,
+  binding: McpRequestBinding,
   timeoutMs = DEFAULT_MCP_TIMEOUT_MS,
   actorName?: string | null,
-  retryUnknownSession = true,
-  requestTrace?: McpRequestTrace,
 ): Promise<string> {
-  assertPublishedBinding(binding)
-  if (requestTrace) requestTrace.binding = binding
+  assertBinding(binding)
+  const request = currentRequest(body)
   const res = await fetchWithTimeout('/mcp', {
     method: 'POST',
-    headers: mcpHeadersForActor(binding, actorName),
-    body: JSON.stringify(body),
+    headers: mcpHeadersForActor(binding, request.method, request.name, actorName),
+    body: JSON.stringify(request.body),
   }, timeoutMs)
-  assertPublishedBinding(binding)
+  assertBinding(binding)
   if (!res.ok) {
     if (res.status === 403) {
-      mcpSessionState = {
-        kind: 'blocked',
-        authRevision: binding.authRevision,
-      }
+      blockedAuthRevision = binding.authRevision
       throw new Error(MCP_BLOCKED_MESSAGE)
     }
-    const responseContract = classifyMcpErrorResponse(res, body)
-    const err = await apiRequestErrorFromResponse('POST', '/mcp', res)
-    if (
-      retryUnknownSession
-      && responseContract.kind === 'unknown_session'
-    ) {
-      invalidatePublishedBinding(binding)
-      const freshBinding = await ensureSession()
-      return mcpPost(body, freshBinding, timeoutMs, actorName, false, requestTrace)
-    }
-    throw err
+    throw await apiRequestErrorFromResponse('POST', '/mcp', res)
   }
-  // Capture session ID only after successful responses. A stale-session 404
-  // may include a fresh header, but that header is not initialized yet.
-  const sid = res.headers.get('Mcp-Session-Id')
   const text = await res.text()
-  assertPublishedBinding(binding)
-  if (sid && sid !== binding.sessionId) {
-    mcpSessionState = {
-      kind: 'ready',
-      binding: { sessionId: sid, authRevision: binding.authRevision },
-    }
-  }
+  assertBinding(binding)
   return text
 }
 
 let blockedToastShown = false
 
-function assertCurrentInitAttempt(
-  attempt: McpInitAttempt,
-  authRevision?: number,
-): void {
-  if (initAttempt !== attempt || attempt.generation !== initGeneration) {
-    throw authChangedError()
-  }
-  if (authRevision !== undefined) assertAuthRevision(authRevision)
-}
-
-async function initializeSession(
-  attempt: McpInitAttempt,
-): Promise<McpSessionBinding> {
-  await ensureDevToken()
-  assertCurrentInitAttempt(attempt)
-  const authRevision = currentStoredTokenRevision()
-  observedTokenRevision = authRevision
-  const initializingBinding: McpSessionBinding = {
-    sessionId: null,
-    authRevision,
-  }
-  const res = await fetchWithTimeout('/mcp', {
-    method: 'POST',
-    headers: mcpHeadersForActor(initializingBinding),
-    body: JSON.stringify({
-      jsonrpc: '2.0',
-      method: 'initialize',
-      params: {
-        protocolVersion: '2025-03-26',
-        capabilities: {},
-        clientInfo: { name: 'masc-dashboard', version: '1.0.0' },
-      },
-      id: 0,
-    }),
-  }, MCP_INITIALIZE_TIMEOUT_MS)
-  assertCurrentInitAttempt(attempt, authRevision)
-  if (!res.ok) {
-    if (res.status === 403) {
-      mcpSessionState = { kind: 'blocked', authRevision }
-      initAttempt = null
-      throw new Error(MCP_BLOCKED_MESSAGE)
-    }
-    throw await apiRequestErrorFromResponse('POST', '/mcp initialize', res)
-  }
-  const binding: McpSessionBinding = {
-    sessionId: res.headers.get('Mcp-Session-Id'),
-    authRevision,
-  }
-  if (binding.sessionId) {
-    try {
-      const initializedRes = await fetchWithTimeout('/mcp', {
-        method: 'POST',
-        headers: mcpHeadersForActor(binding),
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          method: 'notifications/initialized',
-        }),
-      }, MCP_INITIALIZED_NOTIFY_TIMEOUT_MS)
-      assertCurrentInitAttempt(attempt, authRevision)
-      if (!initializedRes.ok) {
-        throw await apiRequestErrorFromResponse(
-          'POST',
-          '/mcp notifications/initialized',
-          initializedRes,
-        )
-      }
-    } catch (err) {
-      assertCurrentInitAttempt(attempt, authRevision)
-      console.warn('[mcp] initialized notification failed:', err)
-      throw err
-    }
-  }
-  assertCurrentInitAttempt(attempt, authRevision)
-  mcpSessionState = { kind: 'ready', binding }
-  initAttempt = null
-  return binding
-}
-
-function startSessionInitialization(): Promise<McpSessionBinding> {
-  const generation = initGeneration + 1
-  initGeneration = generation
-  let attempt!: McpInitAttempt
-  const promise = Promise.resolve()
-    .then(() => initializeSession(attempt))
-    .catch((err: unknown) => {
-      if (initAttempt === attempt) {
-        if (attempt.cooldownTimer) clearTimeout(attempt.cooldownTimer)
-        attempt.cooldownTimer = setTimeout(() => {
-          if (initAttempt === attempt) initAttempt = null
-          attempt.cooldownTimer = null
-        }, MCP_INIT_COOLDOWN_MS)
-      }
-      throw err
-    })
-  attempt = { generation, promise, cooldownTimer: null }
-  initAttempt = attempt
-  return promise
-}
-
-async function ensureSession(): Promise<McpSessionBinding> {
+async function ensureBinding(): Promise<McpRequestBinding> {
   synchronizeMcpAuthRevision()
-  if (mcpSessionState?.kind === 'blocked') {
+  if (blockedAuthRevision === currentStoredTokenRevision()) {
     if (!blockedToastShown) {
       blockedToastShown = true
       showActionToast(
@@ -367,16 +204,15 @@ async function ensureSession(): Promise<McpSessionBinding> {
     }
     throw new Error(MCP_BLOCKED_MESSAGE)
   }
-  if (mcpSessionState?.kind === 'ready') {
-    assertAuthRevision(mcpSessionState.binding.authRevision)
-    return mcpSessionState.binding
-  }
-  if (initAttempt) return initAttempt.promise
-  return startSessionInitialization()
+  await ensureDevToken()
+  const authRevision = currentStoredTokenRevision()
+  observedTokenRevision = authRevision
+  return { authRevision }
 }
 
 export function resetMcpClientState(): void {
-  resetMcpSessionOnly()
+  blockedAuthRevision = null
+  blockedToastShown = false
   resetDevTokenBootstrap()
   observedTokenRevision = currentStoredTokenRevision()
 }
@@ -412,11 +248,8 @@ async function callMcpToolInternal(
 ): Promise<string> {
   const requestId = String(Math.floor(Date.now() % 1000000))
   synchronizeMcpAuthRevision()
-  let phase = mcpSessionState?.kind === 'ready' ? 'tools/call' : 'initialize'
-  const requestTrace: McpRequestTrace = { binding: null }
   try {
-    const binding = await ensureSession()
-    phase = 'tools/call'
+    const binding = await ensureBinding()
     const explicitActor = explicitToolActor(args)
     const actor = explicitActor ?? implicitToolActor()
     const toolArgs =
@@ -431,7 +264,7 @@ async function callMcpToolInternal(
         arguments: toolArgs,
       },
       id: Number.parseInt(requestId, 10),
-    }, binding, DEFAULT_MCP_TIMEOUT_MS, actor, true, requestTrace)
+    }, binding, DEFAULT_MCP_TIMEOUT_MS, actor)
     const parsed = parseMcpHttpResponse(text)
     return extractMcpText(parsed)
   } catch (err) {
@@ -440,10 +273,9 @@ async function callMcpToolInternal(
       await bestEffortReportToolHostFailure({
         toolName,
         message,
-        phase,
-        requestId: phase === 'tools/call' ? requestId : undefined,
-        sessionId: requestTrace.binding?.sessionId ?? undefined,
-        timeoutMs: phase === 'initialize' ? MCP_INITIALIZE_TIMEOUT_MS : DEFAULT_MCP_TIMEOUT_MS,
+        phase: 'tools/call',
+        requestId,
+        timeoutMs: DEFAULT_MCP_TIMEOUT_MS,
       })
     }
     throw err
@@ -482,7 +314,7 @@ function parseMcpListResponse(raw: string): McpListResponse {
 }
 
 async function listMcpTools(cursor?: string): Promise<McpToolsListResult> {
-  const binding = await ensureSession()
+  const binding = await ensureBinding()
   const text = await mcpPost({
     jsonrpc: '2.0',
     method: 'tools/list',


### PR DESCRIPTION
## 변경

- Dashboard MCP 클라이언트를 `2026-07-28` stateless 요청으로 전환합니다.
- 매 요청에 `Mcp-Protocol-Version`, `Mcp-Method`, 선택적 `Mcp-Name`과 동일한 `params._meta`를 전송합니다.
- 제거된 initialize/initialized handshake, `Mcp-Session-Id`, stale-session retry 상태기계를 삭제합니다.

## 이유

서버를 current-only로 hard cut하기 전에 내부 소비자가 구형 session transport에 의존하지 않아야 합니다. 이 PR은 소비자 전환만 수행하며 서버 route나 내부 event stack은 변경하지 않습니다.

## 영향

- MCP tool/list 요청은 각 요청이 독립적입니다.
- 인증 revision 및 403 fail-closed 동작은 유지합니다.
- 후속 PR에서 서버의 구버전/GET/DELETE/session surface를 제거할 수 있습니다.

## 검증

- `../../../dashboard/node_modules/.bin/tsc --noEmit --pretty`
- `../../../dashboard/node_modules/.bin/vitest run src/api/mcp.test.ts` (8/8)
- `git diff --check`
