### PR TITLE
refactor(keeper): purge the durable board-cursor-ack write path

### DIFF
--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -808,7 +808,6 @@ describe('dashboardHealthChips', () => {
           keeper_reaction_ledger: {
             status: 'ok',
             operator_action_required: false,
-            cursor_ack_count: 4,
             cursor_swept_stimulus_count: 3,
             quarantined_row_count: 1,
             pending_stimulus_count: 0,
@@ -844,7 +843,6 @@ describe('dashboardHealthChips', () => {
           keeper_reaction_ledger: {
             status: 'degraded',
             operator_action_required: true,
-            cursor_ack_count: 4,
             cursor_swept_stimulus_count: 3,
             quarantined_row_count: 1,
             pending_stimulus_count: 2,
@@ -956,7 +954,6 @@ describe('dashboardHealthChips', () => {
             cursor_swept_stimulus_count: 0,
             quarantined_row_count: 0,
             read_error_count: 0,
-            cursor_ack_count: 5,
             operator_action_required: false,
           },
         },

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -326,7 +326,6 @@ function reactionLedgerHealthChip(
   const cursorSwept = ledgerCount(ledger.cursor_swept_stimulus_count)
   const quarantined = ledgerCount(ledger.quarantined_row_count)
   const readErrors = ledgerCount(ledger.read_error_count)
-  const cursorAck = ledgerCount(ledger.cursor_ack_count)
   const status = ledger.status ?? 'unknown'
   const requiresAction = ledger.operator_action_required === true
   if (!requiresAction && pending === 0 && quarantined === 0 && readErrors === 0 && cursorSwept === 0 && status !== 'degraded') {
@@ -352,7 +351,6 @@ function reactionLedgerHealthChip(
       `pending=${pending}`,
       `cursor_swept=${cursorSwept}`,
       `quarantined=${quarantined}`,
-      `cursor_ack=${cursorAck}`,
       `read_errors=${readErrors}`,
     ].join(', '),
     tone,

--- a/dashboard/src/store-normalizers.test.ts
+++ b/dashboard/src/store-normalizers.test.ts
@@ -407,7 +407,6 @@ describe('normalizeDashboardRuntimeResolution fleet safety', () => {
         row_count: 8,
         stimulus_count: 4,
         reaction_count: 4,
-        cursor_ack_count: 2,
         cursor_swept_stimulus_count: 3,
         quarantined_row_count: 1,
         pending_stimulus_count: 0,
@@ -467,7 +466,6 @@ describe('normalizeDashboardRuntimeResolution fleet safety', () => {
       },
       keeper_reaction_ledger: {
         status: 'ok',
-        cursor_ack_count: 2,
         cursor_swept_stimulus_count: 3,
         quarantined_row_count: 1,
         pending_stimulus_count: 0,

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -797,7 +797,6 @@ function normalizeDashboardKeeperReactionLedgerHealth(
   const stimulusCount = asNumber(raw.stimulus_count)
   const reactionCount = asNumber(raw.reaction_count)
   const turnStartedCount = asNumber(raw.turn_started_count)
-  const cursorAckCount = asNumber(raw.cursor_ack_count)
   const quarantinedRowCount = asNumber(raw.quarantined_row_count)
   const cursorSweptStimulusCount = asNumber(raw.cursor_swept_stimulus_count)
   const pendingStimulusCount = asNumber(raw.pending_stimulus_count)
@@ -813,7 +812,6 @@ function normalizeDashboardKeeperReactionLedgerHealth(
     && stimulusCount == null
     && reactionCount == null
     && turnStartedCount == null
-    && cursorAckCount == null
     && quarantinedRowCount == null
     && cursorSweptStimulusCount == null
     && pendingStimulusCount == null
@@ -830,7 +828,6 @@ function normalizeDashboardKeeperReactionLedgerHealth(
     stimulus_count: stimulusCount ?? null,
     reaction_count: reactionCount ?? null,
     turn_started_count: turnStartedCount ?? null,
-    cursor_ack_count: cursorAckCount ?? null,
     quarantined_row_count: quarantinedRowCount ?? null,
     cursor_swept_stimulus_count: cursorSweptStimulusCount ?? null,
     pending_stimulus_count: pendingStimulusCount ?? null,

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -196,7 +196,6 @@ export interface DashboardKeeperReactionLedgerHealth {
   stimulus_count: number | null
   reaction_count: number | null
   turn_started_count: number | null
-  cursor_ack_count: number | null
   quarantined_row_count: number | null
   cursor_swept_stimulus_count: number | null
   pending_stimulus_count: number | null

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -1,8 +1,3 @@
-type cursor =
-  { cursor_ts : float
-  ; post_id : string option
-  }
-
 type stimulus_kind =
   | Board_signal
   | Bootstrap
@@ -22,7 +17,6 @@ type reaction_kind =
   | Turn_started
   | Event_queue_ack
   | Event_queue_cancelled
-  | Cursor_ack
 
 type reaction_decode_error = Unknown_reaction_kind of string
 
@@ -70,7 +64,6 @@ let reaction_kind_to_string = function
   | Turn_started -> "turn_started"
   | Event_queue_ack -> "event_queue_ack"
   | Event_queue_cancelled -> "event_queue_cancelled"
-  | Cursor_ack -> "cursor_ack"
 ;;
 
 (* Closed inverse. Wire drift is a typed decoder failure rather than an open
@@ -79,7 +72,6 @@ let reaction_kind_of_string = function
   | "turn_started" -> Ok Turn_started
   | "event_queue_ack" -> Ok Event_queue_ack
   | "event_queue_cancelled" -> Ok Event_queue_cancelled
-  | "cursor_ack" -> Ok Cursor_ack
   | other -> Error (Unknown_reaction_kind other)
 ;;
 
@@ -454,55 +446,6 @@ module For_testing = struct
   ;;
 end
 
-let cursor_json { cursor_ts; post_id } =
-  `Assoc
-    [ "scope", `String "board"
-    ; "cursor_ts", `Float cursor_ts
-    ; "post_id", option_json (fun value -> `String value) post_id
-    ]
-;;
-
-let record_board_cursor_ack
-      ~base_path
-      ~keeper_name
-      ?stimulus_id
-      ~cursor_ts
-      ~post_id
-      ()
-  =
-  let cursor = { cursor_ts; post_id } in
-  let stimulus_id =
-    match stimulus_id, post_id with
-    | Some value, _ -> value
-    | None, Some post_id -> board_stimulus_id ~post_id
-    | None, None -> digest_id "cursor" (Printf.sprintf "%.6f" cursor_ts)
-  in
-  let recorded_at = Time_compat.now () in
-  let json =
-    `Assoc
-      (base_fields
-         ~record_kind:"cursor_ack"
-         ~event_id:
-           (digest_id
-              "krl"
-              (String.concat
-                 "|"
-                 [ stimulus_id; "cursor_ack"; Printf.sprintf "%.6f" cursor_ts ]))
-         ~keeper_name
-         ~recorded_at
-       @ [ "stimulus_id", `String stimulus_id
-         ; "cursor", cursor_json cursor
-         ; ( "reaction"
-           , `Assoc
-               [ "kind", `String (reaction_kind_to_string Cursor_ack)
-               ; "source", `String "keeper_world_observation.board_cursor"
-               ; "cursor_acked", `Bool true
-               ] )
-         ])
-  in
-  Dated_jsonl.append (store_for_base_path ~base_path ~keeper_name) json
-;;
-
 let assoc_field name = function
   | `Assoc fields -> List.assoc_opt name fields
   | _ -> None
@@ -584,11 +527,7 @@ type row_quarantine_reason =
   | Transition_source_identity_mismatch
   | Event_identity_mismatch
   | Transition_kind_mismatch
-  | Missing_cursor
-  | Missing_cursor_ts
-  | Non_finite_cursor_ts
   | Non_finite_board_updated_at
-  | Invalid_cursor_reaction
 
 let row_quarantine_reason_to_string = function
   | Malformed_json_row -> "malformed_json"
@@ -635,11 +574,7 @@ let row_quarantine_reason_to_string = function
   | Transition_source_identity_mismatch -> "transition_source_identity_mismatch"
   | Event_identity_mismatch -> "event_identity_mismatch"
   | Transition_kind_mismatch -> "transition_kind_mismatch"
-  | Missing_cursor -> "missing_cursor"
-  | Missing_cursor_ts -> "missing_cursor_ts"
-  | Non_finite_cursor_ts -> "non_finite_cursor_ts"
   | Non_finite_board_updated_at -> "non_finite_board_updated_at"
-  | Invalid_cursor_reaction -> "invalid_cursor_reaction"
 ;;
 
 type current_row_metadata =
@@ -658,10 +593,6 @@ type current_row =
       { metadata : current_row_metadata
       ; reaction_kind : reaction_kind
       ; transition_receipt : Keeper_event_queue_state.transition_receipt option
-      }
-  | Current_cursor_ack of
-      { metadata : current_row_metadata
-      ; cursor_token : float * string option
       }
 
 let require_string reason field json =
@@ -690,7 +621,6 @@ let reaction_kind_matches_transition reaction_kind transition =
   | Event_queue_ack, Keeper_event_queue_state.Ack_source_terminal _ -> true
   | Event_queue_cancelled, Keeper_event_queue_state.Cancel_accepted _ -> true
   | Turn_started, _
-  | Cursor_ack, _
   | Event_queue_ack, Keeper_event_queue_state.Cancel_accepted _
   | Event_queue_cancelled,
     ( Keeper_event_queue_state.Transfer_accepted _
@@ -827,55 +757,11 @@ let decode_reaction_row ~event_id metadata reaction =
     Ok
       (Current_reaction
          { metadata; reaction_kind; transition_receipt = Some transition_receipt })
-  | Cursor_ack, "keeper_world_observation.board_cursor" ->
-    Error Reaction_source_mismatch
   | Turn_started, "keeper_event_queue_transition"
   | (Event_queue_ack | Event_queue_cancelled),
-    "keeper_event_queue"
-  | Cursor_ack,
-    ("keeper_event_queue" | "keeper_event_queue_transition") ->
-    Error Reaction_source_mismatch
-  | (Turn_started | Event_queue_ack | Event_queue_cancelled | Cursor_ack),
+    "keeper_event_queue" -> Error Reaction_source_mismatch
+  | (Turn_started | Event_queue_ack | Event_queue_cancelled),
     _ -> Error Unknown_reaction_source
-;;
-
-let decode_cursor_ack_row metadata row =
-  let ( let* ) = Result.bind in
-  let* cursor =
-    match assoc_field "cursor" row with
-    | Some value -> Ok value
-    | None -> Error Missing_cursor
-  in
-  let* cursor_ts =
-    require_finite_float
-      ~missing:Missing_cursor_ts
-      ~non_finite:Non_finite_cursor_ts
-      "cursor_ts"
-      cursor
-  in
-  let post_id = string_field "post_id" cursor in
-  let* reaction =
-    match assoc_field "reaction" row with
-    | Some value -> Ok value
-    | None -> Error Invalid_cursor_reaction
-  in
-  let valid_reaction =
-    match string_field "kind" reaction, string_field "source" reaction with
-    | Some "cursor_ack", Some "keeper_world_observation.board_cursor" -> true
-    | _ -> false
-  in
-  let expected_event_id =
-    digest_id
-      "krl"
-      (String.concat
-         "|"
-         [ metadata.stimulus_id; "cursor_ack"; Printf.sprintf "%.6f" cursor_ts ])
-  in
-  if not valid_reaction
-  then Error Invalid_cursor_reaction
-  else if String.equal metadata.event_id expected_event_id
-  then Ok (Current_cursor_ack { metadata; cursor_token = cursor_ts, post_id })
-  else Error Event_identity_mismatch
 ;;
 
 let decode_current_row ~keeper_name row =
@@ -975,7 +861,6 @@ let decode_current_row ~keeper_name row =
       | None -> Error Missing_reaction
     in
     decode_reaction_row ~event_id metadata reaction
-  | "cursor_ack" -> decode_cursor_ack_row metadata row
   | _ -> Error Unknown_record_kind
 ;;
 
@@ -1063,8 +948,7 @@ let event_queue_reaction_evidence_result ~base_path ~keeper_name ~stimulus_id =
         let metadata =
           match current_row with
           | Current_stimulus { metadata; _ }
-          | Current_reaction { metadata; _ }
-          | Current_cursor_ack { metadata; _ } -> metadata
+          | Current_reaction { metadata; _ } -> metadata
         in
         let recorded_at = Some metadata.recorded_at in
         latest_recorded_at := max_recorded_at !latest_recorded_at recorded_at;
@@ -1084,9 +968,7 @@ let event_queue_reaction_evidence_result ~base_path ~keeper_name ~stimulus_id =
          | Current_reaction { reaction_kind = Event_queue_cancelled; _ } ->
            event_queue_cancelled_seen := true;
            event_queue_cancelled_recorded_at
-             := max_recorded_at !event_queue_cancelled_recorded_at recorded_at
-         | Current_reaction { reaction_kind = Cursor_ack; _ }
-         | Current_cursor_ack _ -> ())
+             := max_recorded_at !event_queue_cancelled_recorded_at recorded_at)
   in
   let note_parsed_row row =
     match string_field "stimulus_id" row with
@@ -1152,10 +1034,7 @@ let event_queue_turn_started_seen_for_source_result
                    = Some expected_stimulus_kind ->
            turn_started_seen := true
          | Some _ | None -> ())
-      | Ok
-          ( Current_stimulus _
-          | Current_reaction _
-          | Current_cursor_ack _ )
+      | Ok (Current_stimulus _ | Current_reaction _)
       | Error _ ->
         ()
     in
@@ -1361,7 +1240,6 @@ let summarize_rows ~keeper_name ~limit rows =
   let turn_started_count = ref 0 in
   let event_queue_ack_count = ref 0 in
   let event_queue_cancelled_count = ref 0 in
-  let cursor_ack_count = ref 0 in
   let quarantined_row_count = ref 0 in
   let quarantine_reason_counts = Hashtbl.create 8 in
   let latest_recorded_at = ref None in
@@ -1393,19 +1271,6 @@ let summarize_rows ~keeper_name ~limit rows =
       incr cursor_swept_stimulus_count
     | Some true | None -> ()
   in
-  let mark_board_cursor_swept cursor_token =
-    Hashtbl.iter
-      (fun stimulus_id stimulus_token ->
-        if compare_board_cursor_token stimulus_token cursor_token <= 0
-        then mark_cursor_swept stimulus_id)
-      board_stimulus_tokens
-  in
-  let note_board_cursor cursor_token =
-    (match !latest_board_cursor with
-     | Some latest when compare_board_cursor_token latest cursor_token >= 0 -> ()
-     | _ -> latest_board_cursor := Some cursor_token);
-    mark_board_cursor_swept cursor_token
-  in
   let remember_board_stimulus metadata stimulus_kind =
     match board_stimulus_token metadata stimulus_kind with
     | Some stimulus_token ->
@@ -1422,17 +1287,14 @@ let summarize_rows ~keeper_name ~limit rows =
     | Turn_started, None -> incr turn_started_count
     | Event_queue_ack, Some _ -> incr event_queue_ack_count
     | Event_queue_cancelled, Some _ -> incr event_queue_cancelled_count
-    | Cursor_ack, None -> incr cursor_ack_count
     | Turn_started, Some _
-    | (Event_queue_ack | Event_queue_cancelled), None
-    | Cursor_ack, Some _ -> ()
+    | (Event_queue_ack | Event_queue_cancelled), None -> ()
   in
   let note_current_row current_row =
     let metadata =
       match current_row with
       | Current_stimulus { metadata; _ }
-      | Current_reaction { metadata; _ }
-      | Current_cursor_ack { metadata; _ } -> metadata
+      | Current_reaction { metadata; _ } -> metadata
     in
     if Event_id_set.mem metadata.event_id !current_event_ids
     then ()
@@ -1450,10 +1312,6 @@ let summarize_rows ~keeper_name ~limit rows =
         incr reaction_count;
         note_reaction_kind reaction_kind transition_receipt;
         mark_reacted metadata.stimulus_id
-      | Current_cursor_ack { cursor_token; _ } ->
-        incr reaction_count;
-        incr cursor_ack_count;
-        note_board_cursor cursor_token
     end
   in
   List.iter
@@ -1492,7 +1350,6 @@ let summarize_rows ~keeper_name ~limit rows =
     ; "turn_started_count", `Int !turn_started_count
     ; "event_queue_ack_count", `Int !event_queue_ack_count
     ; "event_queue_cancelled_count", `Int !event_queue_cancelled_count
-    ; "cursor_ack_count", `Int !cursor_ack_count
     ; "quarantined_row_count", `Int !quarantined_row_count
     ; ( "quarantine_reason_counts"
       , string_count_table_json ~field:"reason" quarantine_reason_counts )
@@ -1523,7 +1380,6 @@ let error_summary ~keeper_name ~limit error =
     ; "turn_started_count", `Int 0
     ; "event_queue_ack_count", `Int 0
     ; "event_queue_cancelled_count", `Int 0
-    ; "cursor_ack_count", `Int 0
     ; "quarantined_row_count", `Int 0
     ; "quarantine_reason_counts", `List []
     ; "cursor_swept_stimulus_count", `Int 0
@@ -1581,7 +1437,6 @@ let unavailable_fleet_summary_json () =
     ; "turn_started_count", `Int 0
     ; "event_queue_ack_count", `Int 0
     ; "event_queue_cancelled_count", `Int 0
-    ; "cursor_ack_count", `Int 0
     ; "quarantined_row_count", `Int 0
     ; "quarantine_reason_counts", `List []
     ; "quarantined_rows_by_keeper", `List []
@@ -1836,7 +1691,6 @@ let fleet_summary_json ~base_path ~keeper_names ~limit_per_keeper =
     ; "event_queue_ack_count", `Int (total_int "event_queue_ack_count")
     ; ( "event_queue_cancelled_count"
       , `Int (total_int "event_queue_cancelled_count") )
-    ; "cursor_ack_count", `Int (total_int "cursor_ack_count")
     ; "quarantined_row_count", `Int quarantined_row_count
     ; "quarantine_reason_counts", quarantine_reason_counts
     ; "quarantined_rows_by_keeper", `List quarantined_rows_by_keeper

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -1,16 +1,15 @@
 (** Durable keeper stimulus -> reaction ledger.
 
     This is the runtime mirror for the KeeperReactionLiveness L1/L5
-    contract: queue-visible stimuli, queue transition reactions, and board
-    cursor acknowledgements are written to a replayable JSONL store under
+    contract: queue-visible stimuli and queue transition reactions are
+    written to a replayable JSONL store under
     [.masc/keepers/<keeper>/reaction-ledger/v5/YYYY-MM/DD.jsonl].  The
     generation namespace is a hard boundary: older stores are neither read nor
-    written by this module. *)
+    written by this module.
 
-type cursor =
-  { cursor_ts : float
-  ; post_id : string option
-  }
+    Legacy [record_kind = "cursor_ack"] rows (written by a since-removed
+    durable board-cursor-ack path) may still exist in historical stores; they
+    are quarantined as [Unknown_record_kind] on read rather than decoded. *)
 
 type stimulus_kind =
   | Board_signal
@@ -33,7 +32,6 @@ type reaction_kind =
   | Turn_started
   | Event_queue_ack
   | Event_queue_cancelled
-  | Cursor_ack
 
 type reaction_decode_error = Unknown_reaction_kind of string
 type row_quarantine_reason
@@ -136,18 +134,6 @@ val event_queue_turn_started_seen_for_source_result :
     reaction exists for the exact durable source identity. Invalid matching
     rows do not become positive evidence; read failures remain explicit so
     callers can conservatively replay. *)
-
-val record_board_cursor_ack :
-  base_path:string ->
-  keeper_name:string ->
-  ?stimulus_id:string ->
-  cursor_ts:float ->
-  post_id:string option ->
-  unit ->
-  unit
-(** Append a durable cursor acknowledgement. Callers should write this before
-    advancing the in-memory board cursor so every cursor advance has a replayable
-    ack row. *)
 
 val summary_for_keeper :
   base_path:string -> keeper_name:string -> limit:int -> Yojson.Safe.t

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -1065,13 +1065,6 @@ let collect_board_events_with_cursor_policy
                (ts, post_id)
                (fst base_cursor, Option.value ~default:"" (snd base_cursor))
              > 0 ->
-        Keeper_reaction_ledger.record_board_cursor_ack
-          ~base_path
-          ~keeper_name:meta.name
-          ~stimulus_id:(Keeper_reaction_ledger.board_stimulus_id ~post_id)
-          ~cursor_ts:ts
-          ~post_id:(Some post_id)
-          ();
         Keeper_registry.set_board_cursor ~base_path meta.name ts (Some post_id)
       | Some base_cursor, Some (ts, post_id) ->
         Log.Keeper.debug

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -252,26 +252,66 @@ let test_current_rows_require_complete_writer_shape () =
     (List.mem "missing_reaction_post_id" reasons)
 ;;
 
-let test_cursor_ack_is_replayable_state_entry () =
+(* The durable board-cursor-ack write path ([record_board_cursor_ack]) was
+   removed: it wrote rows nobody restored a cursor from (producer without a
+   restore-side consumer). Historical stores may still carry
+   [record_kind = "cursor_ack"] rows from before the removal; the classifier's
+   [_ -> Error Unknown_record_kind] fallback must quarantine them per-row
+   rather than fail the whole read. *)
+let test_legacy_cursor_ack_row_is_quarantined_not_fatal () =
   with_temp_base @@ fun base_path ->
-  let keeper_name = "cursor-keeper" in
-  Keeper_reaction_ledger.record_board_cursor_ack
+  let keeper_name = "legacy-cursor-ack-keeper" in
+  let stimulus = board_stimulus ~post_id:"post-99" () in
+  let stimulus_id = Keeper_reaction_ledger.stimulus_id_of_event_queue stimulus in
+  Keeper_reaction_ledger.record_event_queue_stimulus
     ~base_path
     ~keeper_name
-    ~cursor_ts:5678.25
-    ~post_id:(Some "post-99")
-    ();
-  let row =
-    read_recent_rows ~base_path ~keeper_name ~limit:1
-    |> latest_row
-  in
-  check_member_string "cursor ack record kind" "cursor_ack" "record_kind" row;
-  check_member_string "cursor ack stimulus id" "board:post-99" "stimulus_id" row;
-  check (float 0.0001) "cursor timestamp" 5678.25
-    (row |> member "cursor" |> member "cursor_ts" |> to_float);
-  check_member_string "cursor post id" "post-99" "post_id" (row |> member "cursor");
-  check bool "cursor acked" true
-    (row |> member "reaction" |> member "cursor_acked" |> to_bool)
+    stimulus;
+  Dated_jsonl.append
+    (reaction_ledger_store ~base_path ~keeper_name)
+    (`Assoc
+        [ "schema", `String "keeper.reaction_ledger.v5"
+        ; "record_kind", `String "cursor_ack"
+        ; "event_id", `String "krl:legacy-cursor-ack-fixture"
+        ; "keeper_name", `String keeper_name
+        ; "recorded_at_unix", `Float 5678.25
+        ; "stimulus_id", `String stimulus_id
+        ; ( "cursor"
+          , `Assoc
+              [ "scope", `String "board"
+              ; "cursor_ts", `Float 5678.25
+              ; "post_id", `String "post-99"
+              ] )
+        ; ( "reaction"
+          , `Assoc
+              [ "kind", `String "cursor_ack"
+              ; "source", `String "keeper_world_observation.board_cursor"
+              ; "cursor_acked", `Bool true
+              ] )
+        ]);
+  match
+    Keeper_reaction_ledger.event_queue_reaction_evidence_result
+      ~base_path
+      ~keeper_name
+      ~stimulus_id
+  with
+  | Error error ->
+    failf
+      "legacy cursor_ack row must not surface a fatal evidence read error: %s"
+      (Keeper_reaction_ledger.event_queue_reaction_evidence_error_to_string error)
+  | Ok (Keeper_reaction_ledger.Evidence_complete _) ->
+    fail "legacy cursor_ack row must be quarantined, not silently accepted"
+  | Ok
+      (Keeper_reaction_ledger.Evidence_quarantined
+        { evidence; first_reason }) ->
+    check bool "normal stimulus row still matches" true evidence.stimulus_seen;
+    check int "one row matches (the stimulus)" 1 evidence.matched_record_count;
+    check int "legacy cursor_ack row is quarantined" 1
+      evidence.quarantined_record_count;
+    check string
+      "legacy cursor_ack row is an unknown record kind"
+      "unknown_record_kind"
+      (Keeper_reaction_ledger.row_quarantine_reason_to_string first_reason)
 ;;
 
 let test_summary_marks_unreacted_and_reacted_stimuli () =
@@ -310,84 +350,6 @@ let test_summary_marks_unreacted_and_reacted_stimuli () =
     (reacted_summary |> member "pending_stimulus_count" |> to_int);
   check int "turn started count" 1
     (reacted_summary |> member "turn_started_count" |> to_int)
-;;
-
-let test_summary_cursor_ack_sweeps_covered_board_stimuli () =
-  with_temp_base @@ fun base_path ->
-  let keeper_name = "cursor-sweep-keeper" in
-  let first = board_stimulus ~post_id:"post-1" ~updated_at:10.0 () in
-  let second = board_stimulus ~post_id:"post-2" ~updated_at:20.0 () in
-  let third = board_stimulus ~post_id:"post-3" ~updated_at:30.0 () in
-  List.iter
-    (Keeper_reaction_ledger.record_event_queue_stimulus ~base_path ~keeper_name)
-    [ first; second ];
-  Keeper_reaction_ledger.record_board_cursor_ack
-    ~base_path
-    ~keeper_name
-    ~cursor_ts:20.0
-    ~post_id:(Some "post-2")
-    ();
-  let swept_summary =
-    Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:10
-  in
-  check_member_string "cursor-swept summary status" "ok" "status" swept_summary;
-  check int "cursor-swept pending count" 0
-    (swept_summary |> member "pending_stimulus_count" |> to_int);
-  check int "cursor sweep count" 2
-    (swept_summary |> member "cursor_swept_stimulus_count" |> to_int);
-  Keeper_reaction_ledger.record_event_queue_stimulus ~base_path ~keeper_name third;
-  let future_summary =
-    Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:10
-  in
-  check_member_string "future stimulus remains degraded" "degraded" "status" future_summary;
-  check int "future pending count" 1
-    (future_summary |> member "pending_stimulus_count" |> to_int);
-  check string "future pending stimulus id" "board:post-3"
-    (future_summary
-     |> member "pending_stimulus_ids"
-     |> to_list
-     |> List.hd
-     |> to_string)
-;;
-
-let test_summary_cursor_ack_respects_post_id_tiebreaker () =
-  with_temp_base @@ fun base_path ->
-  let keeper_name = "cursor-tiebreaker-keeper" in
-  let first = board_stimulus ~post_id:"post-1" ~updated_at:50.0 () in
-  let second = board_stimulus ~post_id:"post-2" ~updated_at:50.0 () in
-  List.iter
-    (Keeper_reaction_ledger.record_event_queue_stimulus ~base_path ~keeper_name)
-    [ first; second ];
-  Keeper_reaction_ledger.record_board_cursor_ack
-    ~base_path
-    ~keeper_name
-    ~cursor_ts:50.0
-    ~post_id:(Some "post-1")
-    ();
-  let partial_summary =
-    Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:10
-  in
-  check_member_string "partial cursor summary status" "degraded" "status" partial_summary;
-  check int "one post remains pending" 1
-    (partial_summary |> member "pending_stimulus_count" |> to_int);
-  check string "later same-timestamp post remains pending" "board:post-2"
-    (partial_summary
-     |> member "pending_stimulus_ids"
-     |> to_list
-     |> List.hd
-     |> to_string);
-  Keeper_reaction_ledger.record_board_cursor_ack
-    ~base_path
-    ~keeper_name
-    ~cursor_ts:50.0
-    ~post_id:(Some "post-2")
-    ();
-  let complete_summary =
-    Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:10
-  in
-  check_member_string "complete cursor summary status" "ok" "status" complete_summary;
-  check int "same timestamp posts cleared" 0
-    (complete_summary |> member "pending_stimulus_count" |> to_int)
 ;;
 
  let test_fleet_summary_surfaces_durable_event_queue_backlog () =
@@ -829,7 +791,6 @@ let test_reaction_kind_string_roundtrip () =
     [ Keeper_reaction_ledger.Turn_started
     ; Keeper_reaction_ledger.Event_queue_ack
     ; Keeper_reaction_ledger.Event_queue_cancelled
-    ; Keeper_reaction_ledger.Cursor_ack
     ];
   match Keeper_reaction_ledger.reaction_kind_of_string "unknown_custom" with
   | Error (Keeper_reaction_ledger.Unknown_reaction_kind value) ->
@@ -1093,21 +1054,13 @@ let () =
             `Quick
             test_current_rows_require_complete_writer_shape
         ; test_case
-            "cursor ack is replayable state entry"
+            "legacy cursor_ack row is quarantined, not fatal"
             `Quick
-            test_cursor_ack_is_replayable_state_entry
+            test_legacy_cursor_ack_row_is_quarantined_not_fatal
         ; test_case
             "summary marks unreacted and reacted stimuli"
             `Quick
             test_summary_marks_unreacted_and_reacted_stimuli
-        ; test_case
-            "summary cursor ack sweeps covered board stimuli"
-            `Quick
-            test_summary_cursor_ack_sweeps_covered_board_stimuli
-        ; test_case
-            "summary cursor ack respects board post id tiebreaker"
-            `Quick
-            test_summary_cursor_ack_respects_post_id_tiebreaker
         ; test_case
             "fleet summary surfaces durable event queue backlog"
             `Quick

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -3536,60 +3536,6 @@ let test_health_json_uses_crash_log_when_restore_clears_failure_reason () =
               stale_reason
               (row |> member "last_failure_reason" |> to_string))))
 
-let test_health_json_reaction_ledger_cursor_sweep_clears_pending () =
-  with_temp_dir "health-reaction-ledger-cursor-sweep" (fun dir ->
-    with_env "MASC_BASE_PATH" (Some dir) (fun () ->
-      Fun.protect
-        ~finally:(fun () ->
-          Server_auth.server_state := None;
-          Config_dir_resolver.reset ())
-        (fun () ->
-        Config_dir_resolver.reset ();
-        let state = Mcp_server.For_testing.create_state ~base_path:dir in
-        Server_auth.server_state := Some state;
-        let config = (Mcp_server.workspace_config state) in
-        write_keeper_meta_exn config
-          (make_keeper_meta ~name:"cursor-swept" ~trace_id:"trace-cursor" ());
-        let stimulus post_id updated_at : Keeper_event_queue.stimulus =
-          { post_id
-          ; urgency = Immediate
-          ; arrived_at = updated_at +. 10.0
-          ; payload =
-              Keeper_event_queue.Board_signal
-                { kind = Keeper_event_queue.Post_created
-                ; author = ""
-                ; title = ""
-                ; content = ""
-                ; hearth = None
-                ; updated_at = Some updated_at
-                }
-          }
-        in
-        List.iter
-          (Keeper_reaction_ledger.record_event_queue_stimulus
-             ~base_path:dir
-             ~keeper_name:"cursor-swept")
-          [ stimulus "health-post-1" 10.0; stimulus "health-post-2" 20.0 ];
-        Keeper_reaction_ledger.record_board_cursor_ack
-          ~base_path:dir
-          ~keeper_name:"cursor-swept"
-          ~cursor_ts:20.0
-          ~post_id:(Some "health-post-2")
-          ();
-        let request = Httpun.Request.create `GET "/health" in
-        let json = Server_routes_http_runtime.make_health_json request in
-        let open Yojson.Safe.Util in
-        let reaction_ledger = json |> member "keeper_reaction_ledger" in
-        Alcotest.(check string) "health cursor-swept reaction ledger ok"
-          "ok"
-          (reaction_ledger |> member "status" |> to_string);
-        Alcotest.(check int) "health cursor-swept pending stimuli" 0
-          (reaction_ledger |> member "pending_stimulus_count" |> to_int);
-        Alcotest.(check bool)
-          "health cursor-swept reaction ledger clears operator action"
-          false
-          (reaction_ledger |> member "operator_action_required" |> to_bool))))
-
 let test_health_json_reaction_ledger_unavailable_shape () =
   let previous_state = !Server_auth.server_state in
   Fun.protect
@@ -5299,9 +5245,6 @@ let () =
             "health json restores crash-log failure reason"
             `Quick
             test_health_json_uses_crash_log_when_restore_clears_failure_reason;
-          Alcotest.test_case
-            "health json reaction ledger cursor sweep clears pending"
-            `Quick test_health_json_reaction_ledger_cursor_sweep_clears_pending;
           Alcotest.test_case
             "health json reaction ledger unavailable shape"
             `Quick test_health_json_reaction_ledger_unavailable_shape;


### PR DESCRIPTION
## 배경

#26714(durable Board cursor restore)가 운영자 결정으로 close되면서, durable cursor ack 쓰기 경로가 **소비자 없는 생산자**가 됐습니다: in-memory board cursor가 전진할 때마다 durable `cursor_ack` 행이 append되는데, 이를 읽어 복원하는 코드가 0곳입니다. 라이브 keeper reaction ledger에 **1,964행**이 누적된 상태로 지금도 매 전진마다 증가 중이었습니다.

운영자 지시: "과도한 커서는 지우자" — 자기 관측은 강제 기계장치가 아니라 기본 멀티턴 동작으로 해결 (`instructions/masc-workflow.md`의 Autonomy over Enforcement 원칙, me#1248).

## 제거 범위

- `record_board_cursor_ack` API + 유일 호출부 (`keeper_world_observation.ml`) — **in-memory 커서 전진 로직은 유지**
- `Cursor_ack` reaction kind, cursor 행 codec, 검증 매트릭스 arm, 요약 카운터 (`keeper_reaction_ledger.ml/.mli`)
- wire 필드 `cursor_ack_count` + dashboard 소비자 3파일 + 테스트 2파일 (TS/OCaml 양면 스윕)

catch-all `_ ->` 추가 없음, exhaustive match 유지.

## 기존 데이터 계약 (핵심)

라이브 ledger 파일에는 cursor_ack 행이 이미 존재합니다. 절단 후 이 행들은 분류기의 `Unknown_record_kind`로 **행 단위 quarantine**됩니다 — evidence 읽기 전체는 Ok 유지. 신규 테스트 `test_legacy_cursor_ack_row_is_quarantined_not_fatal`이 실제 행 형태(legacy shape 그대로)로 이 계약을 고정합니다.

## 검증

- `test_keeper_reaction_ledger.exe`: **18/18 passed** (신규 quarantine 테스트 포함)
- `test_server_runtime_bootstrap.exe`: 11 failures — **clean main에서 동일 11 failures 재현 확인** (기존 무관 실패, 이 PR 영향 아님. 브랜치 91 vs main 92 테스트 수 차이는 커서 케이스 1개 제거분)
- dashboard vitest: 영향받은 2파일 **61/61 passed** (worktree에 `npm ci` 후 실제 실행)
- `ocamlformat --check` / `git diff --check` clean
- 잔재 스윕: `rg "cursor_ack|Cursor_ack"` → 의도된 2곳만 잔존 (legacy quarantine 테스트, `.mli`의 기존 데이터 계약 주석)

Refs #26714, #26774

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)