### PR TITLE
fix(keeper): close P1 gaps in WAL v6 cutover and deploy preflight

### DIFF
--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -82,6 +82,13 @@ type transfer_projection_result = State.transfer_projection_result =
 let snapshot_filename = "event-queue-v15.json"
 let transition_wal_filename = "event-queue-transitions-v6.jsonl"
 
+(* Same rejection set as scripts/check-keeper-event-queue-v15-cutover.sh: a
+   nonempty legacy WAL is committed evidence the current binary cannot replay,
+   so a launcher that skips the cutover gate must still fail closed on it. *)
+let legacy_transition_wal_filenames =
+  [ "event-queue-transitions-v4.jsonl"; "event-queue-transitions-v5.jsonl" ]
+;;
+
 let owner_error_to_string = Owner_lock.resolve_error_to_string
 
 let resolve_owner ~base_path ~keeper_name =
@@ -277,7 +284,46 @@ type primary_snapshot =
   | Primary_missing
   | Primary_current of State.t
 
-let read_primary_unlocked owner =
+let reject_legacy_transition_wal_unlocked owner =
+  let runtime_dir = keeper_runtime_dir_of_owner owner in
+  let first_violation filename =
+    let path = Filename.concat runtime_dir filename in
+    try
+      if not (Sys.file_exists path)
+      then None
+      else (
+        match Safe_ops.read_file_safe path with
+        | Error message ->
+          Some
+            (Printf.sprintf
+               "failed to read legacy transition WAL %s: %s"
+               path
+               message)
+        | Ok "" -> None
+        | Ok _ ->
+          Some
+            (Printf.sprintf
+               "legacy transition WAL still contains committed evidence \
+                keeper=%s path=%s: run \
+                scripts/check-keeper-event-queue-v15-cutover.sh before \
+                starting this binary"
+               (keeper_name_of_owner owner)
+               path))
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn ->
+      Some
+        (Printf.sprintf
+           "failed to inspect legacy transition WAL %s: %s"
+           path
+           (Printexc.to_string exn))
+  in
+  match List.find_map first_violation legacy_transition_wal_filenames with
+  | Some message -> Error message
+  | None -> Ok ()
+;;
+
+let read_primary_current_unlocked owner =
   let path = snapshot_path_of_owner owner in
   match read_json_if_present path with
   | Error _ as error -> error
@@ -299,6 +345,12 @@ let read_primary_unlocked owner =
                ~path
                ~surface:"event queue snapshot"
                message)))
+;;
+
+let read_primary_unlocked owner =
+  match reject_legacy_transition_wal_unlocked owner with
+  | Error message -> Error message
+  | Ok () -> read_primary_current_unlocked owner
 ;;
 
 let bump_revision state =

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -10,7 +10,10 @@
     recovery. The WAL accepts at most one row and is retired after projection,
     so its retained size is bounded by one complete state. Serializing that
     state on each transition is the intentional cost of recovery that does not
-    infer missing sibling work from a delta. *)
+    infer missing sibling work from a delta. Every load path rejects a
+    nonempty legacy transition WAL (v4/v5) as unmigrated committed evidence,
+    matching the cutover gate, so a launcher that skips the gate cannot load a
+    stale snapshot over an unprojected legacy transition. *)
 
 type owner_identity
 type owner_identity_error

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -118,9 +118,17 @@ fi
 
 # Load and validate runtime environment before stopping the serving process.
 # BasePath was frozen above and is intentionally not recomputed from env files.
+# Deployment control variables are frozen before sourcing: an env file entry
+# reusing one of these names aborts the deploy here, while the serving process
+# is still untouched, instead of silently redirecting which PID is stopped,
+# which launchd label is checked, or where the new runtime starts.
+KEEPER_ENV="$REPO_DIR/config/keeper.env"
+readonly SCRIPT_DIR REPO_DIR RELEASE_DIR PROD_PORT HEALTH_URL BASE_PATH \
+    RUNTIME_ROOT PID_FILE LOG_DIR LAUNCHD_LABEL SKIP_BUILD RESTART_TUNNEL \
+    PREPARE_UNDER_CUTOVER_LEASE BUILD_EXE BUILD_CUTOVER_HELPER RELEASE_EXE \
+    BACKUP_EXE KEEPER_ENV
 preserve_env_override MASC_CONFIG_DIR
 preserve_env_override MASC_PERSONAS_DIR
-KEEPER_ENV="$REPO_DIR/config/keeper.env"
 if [ -f "$KEEPER_ENV" ]; then
     set -a
     # shellcheck disable=SC1090

--- a/test/dune
+++ b/test/dune
@@ -314,6 +314,7 @@
   test_keeper_event_queue_owner_lock
   test_cross_context_mutex
   test_keeper_event_queue_persist_poison
+  test_keeper_event_queue_legacy_wal_reject
   test_workspace_routes_keeper
   test_workspace_tree_exclusions
   test_workspace_file_confidentiality
@@ -618,6 +619,7 @@
   test_keeper_event_queue_owner_lock
   test_cross_context_mutex
   test_keeper_event_queue_persist_poison
+  test_keeper_event_queue_legacy_wal_reject
   test_workspace_routes_keeper
   test_workspace_tree_exclusions
   test_workspace_file_confidentiality

--- a/test/test_deploy_preflight.sh
+++ b/test/test_deploy_preflight.sh
@@ -46,3 +46,29 @@ if ! kill -0 "$SLEEP_PID" 2>/dev/null; then
 fi
 
 echo "deploy preflight preserves the serving process on env failure"
+
+# An env file entry reusing a deployment control name must abort the deploy
+# before the stop step instead of redirecting which PID gets killed.
+printf 'PID_FILE=%s\n' "$FIXTURE_DIR/hijack.pid" \
+    > "$FIXTURE_DIR/repo/config/keeper.env"
+
+OVERRIDE_ERR="$FIXTURE_DIR/deploy-override.err"
+if MASC_BASE_PATH="$FIXTURE_DIR/runtime" \
+    bash "$FIXTURE_DIR/repo/scripts/deploy.sh" --skip-build 2>"$OVERRIDE_ERR"
+then
+    echo "expected control-variable override in keeper.env to reject deployment" >&2
+    exit 1
+fi
+
+if ! grep -q "readonly variable" "$OVERRIDE_ERR"; then
+    echo "deployment failed for a reason other than the control-variable freeze" >&2
+    cat "$OVERRIDE_ERR" >&2
+    exit 1
+fi
+
+if ! kill -0 "$SLEEP_PID" 2>/dev/null; then
+    echo "deployment stopped the serving process on control-variable override" >&2
+    exit 1
+fi
+
+echo "deploy preflight rejects control-variable overrides before touching prod"

--- a/test/test_keeper_event_queue_legacy_wal_reject.ml
+++ b/test/test_keeper_event_queue_legacy_wal_reject.ml
@@ -1,0 +1,99 @@
+(** Every load path must reject a nonempty legacy transition WAL (v4/v5): it is
+    committed evidence the v6 binary cannot replay, so loading the current
+    snapshot over it could resurrect already-disposed work. Empty legacy WALs
+    carry no evidence and stay tolerated, matching
+    scripts/check-keeper-event-queue-v15-cutover.sh. *)
+
+module Persistence = Keeper_event_queue_persistence
+
+let rec rm_rf path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path)
+    else Unix.unlink path
+
+let write_file path contents =
+  Out_channel.with_open_bin path (fun oc -> Out_channel.output_string oc contents)
+
+let contains_legacy_rejection message =
+  let needle = "legacy transition WAL" in
+  let needle_len = String.length needle in
+  let message_len = String.length message in
+  let rec go i =
+    i + needle_len <= message_len
+    && (String.equal (String.sub message i needle_len) needle || go (i + 1))
+  in
+  go 0
+
+let expect_legacy_error label = function
+  | Ok _ -> failwith (label ^ ": expected legacy transition WAL rejection")
+  | Error message ->
+    if not (contains_legacy_rejection message)
+    then failwith (label ^ ": failed for another reason: " ^ message)
+
+let expect_ok label = function
+  | Ok _ -> ()
+  | Error message -> failwith (label ^ ": expected Ok, got: " ^ message)
+
+let () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let mono_clock = Eio.Stdenv.mono_clock env in
+  let net = Eio.Stdenv.net env in
+  Eio.Switch.run @@ fun sw ->
+  Eio_context.with_test_env ~net ~clock ~mono_clock ~sw @@ fun () ->
+  let base_path = Filename.temp_file "kq_legacy_wal" "" in
+  Sys.remove base_path;
+  Unix.mkdir base_path 0o755;
+  Fun.protect
+    ~finally:(fun () -> if Sys.file_exists base_path then rm_rf base_path)
+    (fun () ->
+      let keeper_name = "legacy_probe" in
+      Persistence.persist ~base_path ~keeper_name Keeper_event_queue.empty;
+      let runtime_dir =
+        Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name
+      in
+      let snapshot_path = Filename.concat runtime_dir "event-queue-v15.json" in
+      let v4_path = Filename.concat runtime_dir "event-queue-transitions-v4.jsonl" in
+      let v5_path = Filename.concat runtime_dir "event-queue-transitions-v5.jsonl" in
+      assert (Sys.file_exists snapshot_path);
+
+      (* An empty legacy WAL carries no evidence: loads stay Ok. *)
+      write_file v5_path "";
+      expect_ok
+        "empty v5 beside snapshot"
+        (Persistence.load_state_result ~base_path ~keeper_name);
+
+      (* Nonempty legacy WAL beside the current snapshot: every load fails. *)
+      write_file v5_path "{\"schema\":\"masc.keeper_event_queue.transition.v5\"}\n";
+      expect_legacy_error
+        "load_state_result with nonempty v5"
+        (Persistence.load_state_result ~base_path ~keeper_name);
+      expect_legacy_error
+        "validate_state_read_only_result with nonempty v5"
+        (Persistence.validate_state_read_only_result ~base_path ~keeper_name);
+
+      (* The reviewer scenario: crash after appending the legacy transition but
+         before checkpointing leaves the WAL as the only evidence. *)
+      Sys.remove snapshot_path;
+      expect_legacy_error
+        "load_existing_state_result with WAL-only nonempty v5"
+        (Persistence.load_existing_state_result ~base_path ~keeper_name);
+
+      (* v4 sits in the same rejection set. *)
+      Sys.remove v5_path;
+      write_file v4_path "{\"schema\":\"masc.keeper_event_queue.transition.v4\"}\n";
+      expect_legacy_error
+        "load_state_result with nonempty v4"
+        (Persistence.load_state_result ~base_path ~keeper_name);
+
+      (* Removing the legacy evidence restores normal loads. *)
+      Sys.remove v4_path;
+      expect_ok
+        "load after legacy WALs removed"
+        (Persistence.load_state_result ~base_path ~keeper_name));
+
+  print_endline "test_keeper_event_queue_legacy_wal_reject: OK"


### PR DESCRIPTION
## 변경

#26759가 P1 리뷰 스레드 2건이 미해소인 채 머지되어, 그 2건을 닫는 follow-up입니다.

- **deploy control 변수 동결** (`scripts/deploy.sh`): `keeper.env`/`.env` sourcing 전에 `PID_FILE`, `LAUNCHD_LABEL`, `PROD_PORT`, `RUNTIME_ROOT` 등 배포 제어 변수를 `readonly`로 동결. env 파일이 이 이름을 재사용하면 serving 프로세스를 건드리기 전에 deploy가 중단됨 (이전: 다른 PID를 kill하거나 다른 launchd label을 검사하도록 조용히 재지향 가능). 검증은 bash 3.2(macOS system)와 bash 5 모두에서 readonly 위반 → 즉시 exit 1 실측.
- **legacy WAL 런타임 거부** (`lib/keeper_runtime/keeper_event_queue_persistence.ml`): `read_primary_unlocked`에서 nonempty legacy transition WAL(v4/v5)을 fail-closed로 거부. 모든 load 경로(`load_state_result` / `load_existing_state_result` / `validate_*`)가 이 단일 choke point를 지나므로 cutover gate를 우회하는 launcher도 stale snapshot 위로 미투영 legacy transition을 무시하고 로드할 수 없음. empty legacy WAL은 gate와 동일하게 허용. 마이그레이션/디코더 fallback 없음.

## 검증

- `test/test_keeper_event_queue_legacy_wal_reject.ml` (신규): empty v5 허용 / nonempty v5 3개 load 경로 전부 거부 / WAL-only nonempty v5 거부(리뷰어 시나리오) / nonempty v4 거부 / 제거 후 정상 로드 복원 — 로컬 통과.
- `test/test_deploy_preflight.sh`: 기존 시나리오 + `PID_FILE` 오버라이드 시 deploy 거부·serving PID 생존·`readonly variable` stderr 확인 — 로컬 통과.
- `dune build @check`, `test_keeper_event_queue_persist_poison`, `test_keeper_paused_work_source_terminal_transaction`(11 tests), ocamlformat, `bash -n`, shellcheck 통과.
- 참고: 현재 main의 `Build and Test` 실패는 #26776의 `mcp_session_record` 타입 제거가 `test/test_mcp_server_eio_coverage.ml` 소비자를 스윕하지 않은 기존 파손으로, 이 PR과 무관 (별도 수리 PR 예정).

Closes the two unresolved P1 review threads on #26759.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
