### PR TITLE
test(mcp): sweep session serialization tests orphaned by #26776

### DIFF
--- a/test/test_mcp_server_eio_coverage.ml
+++ b/test/test_mcp_server_eio_coverage.ml
@@ -365,100 +365,6 @@ let test_detect_mode_partial_content () =
   let result = Mcp_server_eio_protocol.detect_mode "Content" in
   check bool "partial is line delimited" true (result = Mcp_server_eio_protocol.LineDelimited)
 
-(* ============================================================
-   mcp_session_to_json Tests
-   ============================================================ *)
-
-let test_mcp_session_to_json_full () =
-  let session : Mcp_server_eio.mcp_session_record = {
-    id = "sess-123";
-    agent_name = Some "claude";
-    created_at = 1706400000.0;
-    last_seen = 1706403600.0;
-  } in
-  let json = Mcp_server_eio.mcp_session_to_json session in
-  let open Yojson.Safe.Util in
-  check string "id" "sess-123" (json |> member "id" |> to_string);
-  check string "agent_name" "claude" (json |> member "agent_name" |> to_string);
-  check (float 0.1) "created_at" 1706400000.0 (json |> member "created_at" |> to_float);
-  check (float 0.1) "last_seen" 1706403600.0 (json |> member "last_seen" |> to_float)
-
-let test_mcp_session_to_json_no_agent () =
-  let session : Mcp_server_eio.mcp_session_record = {
-    id = "sess-456";
-    agent_name = None;
-    created_at = 1706400000.0;
-    last_seen = 1706400000.0;
-  } in
-  let json = Mcp_server_eio.mcp_session_to_json session in
-  let open Yojson.Safe.Util in
-  check string "id" "sess-456" (json |> member "id" |> to_string);
-  check bool "agent_name null" true ((json |> member "agent_name") = `Null)
-
-(* ============================================================
-   mcp_session_of_json Tests
-   ============================================================ *)
-
-let test_mcp_session_of_json_valid () =
-  let json = `Assoc [
-    ("id", `String "sess-789");
-    ("agent_name", `String "codex");
-    ("created_at", `Float 1706400000.0);
-    ("last_seen", `Float 1706407200.0);
-  ] in
-  match Mcp_server_eio.mcp_session_of_json json with
-  | Some s ->
-      check string "id" "sess-789" s.id;
-      check (option string) "agent_name" (Some "codex") s.agent_name;
-      check (float 0.1) "created_at" 1706400000.0 s.created_at;
-      check (float 0.1) "last_seen" 1706407200.0 s.last_seen
-  | None -> fail "expected Some"
-
-let test_mcp_session_of_json_null_agent () =
-  let json = `Assoc [
-    ("id", `String "sess-abc");
-    ("agent_name", `Null);
-    ("created_at", `Float 1706400000.0);
-    ("last_seen", `Float 1706400000.0);
-  ] in
-  match Mcp_server_eio.mcp_session_of_json json with
-  | Some s ->
-      check string "id" "sess-abc" s.id;
-      check (option string) "agent_name" None s.agent_name
-  | None -> fail "expected Some"
-
-let test_mcp_session_of_json_invalid_missing_id () =
-  let json = `Assoc [
-    ("agent_name", `String "test");
-    ("created_at", `Float 1706400000.0);
-    ("last_seen", `Float 1706400000.0);
-  ] in
-  match Mcp_server_eio.mcp_session_of_json json with
-  | None -> ()
-  | Some _ -> fail "expected None"
-
-let test_mcp_session_of_json_not_assoc () =
-  let json = `String "not an object" in
-  match Mcp_server_eio.mcp_session_of_json json with
-  | None -> ()
-  | Some _ -> fail "expected None"
-
-let test_mcp_session_roundtrip () =
-  let session : Mcp_server_eio.mcp_session_record = {
-    id = "roundtrip-test";
-    agent_name = Some "test-agent";
-    created_at = 1706412345.678;
-    last_seen = 1706498765.432;
-  } in
-  let json = Mcp_server_eio.mcp_session_to_json session in
-  match Mcp_server_eio.mcp_session_of_json json with
-  | Some decoded ->
-      check string "id roundtrip" session.id decoded.id;
-      check (option string) "agent roundtrip" session.agent_name decoded.agent_name;
-      check (float 0.001) "created roundtrip" session.created_at decoded.created_at;
-      check (float 0.001) "last_seen roundtrip" session.last_seen decoded.last_seen
-  | None -> fail "roundtrip failed"
-
 let test_tool_schema_component_bytes () =
   check int "UTF-8 bytes plus JSON bytes" 11
     (Mcp_server_eio.tool_schema_component_bytes
@@ -553,16 +459,5 @@ let () =
       test_case "line delimited" `Quick test_detect_mode_line_delimited;
       test_case "empty" `Quick test_detect_mode_empty;
       test_case "partial content" `Quick test_detect_mode_partial_content;
-    ];
-    "mcp_session_to_json", [
-      test_case "full" `Quick test_mcp_session_to_json_full;
-      test_case "no agent" `Quick test_mcp_session_to_json_no_agent;
-    ];
-    "mcp_session_of_json", [
-      test_case "valid" `Quick test_mcp_session_of_json_valid;
-      test_case "null agent" `Quick test_mcp_session_of_json_null_agent;
-      test_case "missing id" `Quick test_mcp_session_of_json_invalid_missing_id;
-      test_case "not assoc" `Quick test_mcp_session_of_json_not_assoc;
-      test_case "roundtrip" `Quick test_mcp_session_roundtrip;
     ];
   ]


### PR DESCRIPTION
## 변경

main `Build and Test` 컴파일 실패 수리입니다 (run 30881525860).

#26776이 `lib/mcp_server_eio`에서 `mcp_session_record`/`mcp_session_to_json`/`mcp_session_of_json`을 제거하며 테스트 10개 파일을 스윕했지만 `test/test_mcp_server_eio_coverage.ml` 하나를 놓쳤습니다. 삭제된 타입을 참조하는 고아 테스트 7개와 러너 그룹 2개(`mcp_session_to_json`, `mcp_session_of_json`)를 제거합니다.

생존 케이스(detect_mode, tool_schema_component_bytes, invocation identity의 `Invalid_mcp_session_id`)는 현존 표면을 테스트하므로 유지합니다.

## 검증

- `dune exec test/test_mcp_server_eio_coverage.exe` 로컬 통과 (본문 하단 코멘트에 결과 기록)
- 삭제 라인만 있는 diff — 소스(lib) 변경 없음

Blocks: #26781 (같은 main 파손이 그 PR의 Build and Test도 막고 있어 이 PR 선행 머지 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
