### PR TITLE
fix(build): consume OAS 0.231.13 stream contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MASC
 
 [![OCaml](https://img.shields.io/badge/OCaml-%3E%3D%205.4-orange.svg)](https://ocaml.org/)
-[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.231.12-blue.svg)](https://github.com/jeong-sik/oas)
+[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.231.13-blue.svg)](https://github.com/jeong-sik/oas)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 [한국어 버전](README.ko.md)

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -34,7 +34,7 @@ Keeper는 OAS(OCaml Agent SDK) 위에 구축된다. OAS가 제공하는 핵심 �
 | `Event_bus.t` | 에이전트 간 이벤트 발행/구독 | `oas_events.ml`을 통해 broadcast, heartbeat, board 이벤트 전달 |
 
 <!-- BEGIN GENERATED: oas-pin-manual -->
-OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.12`, runtime pin: `main@966cd3f61cd5e9e21c8390513dfa27894aeb6230`, declared base version: `v0.231.12`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
+OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.13`, runtime pin: `main@59ccced68c2dc96389a91eee24d0b2c6bd5c53a6`, declared base version: `v0.231.13`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
 <!-- END GENERATED: oas-pin-manual -->
 
 #### 1.1.1 OAS 환경 변수 경계

--- a/dune-project
+++ b/dune-project
@@ -60,7 +60,7 @@
   ;; ordered multimodal delivery contracts;
   ;; its SHA and rationale live in scripts/oas-agent-sdk-pin.sh (SSOT).
   ;; See check-oas-pin.sh.
-  (agent_sdk (>= 0.231.12))
+  (agent_sdk (>= 0.231.13))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/lib/keeper/keeper_agent_run_turn_helpers.ml
+++ b/lib/keeper/keeper_agent_run_turn_helpers.ml
@@ -111,6 +111,8 @@ let sse_event_progress_kind (event : Agent_sdk.Types.sse_event) =
   | Agent_sdk.Types.SSEParseFailed _ -> Some "sse_parse_failed"
   | Agent_sdk.Types.NDJSONParseFailed _ -> Some "ndjson_parse_failed"
   | Agent_sdk.Types.SSEUnknownEventType _ -> Some "sse_unknown_event_type"
+  | Agent_sdk.Types.SSEUnsupportedPart _ -> Some "sse_unsupported_part"
+  | Agent_sdk.Types.SSEUnsupportedResponse _ -> Some "sse_unsupported_response"
   | Agent_sdk.Types.StreamIncomplete _ -> Some "sse_stream_incomplete"
   | Agent_sdk.Types.Connected -> Some "sse_connected"
   | Agent_sdk.Types.Timeout _ -> Some "sse_timeout"

--- a/lib/keeper/keeper_chat_events.ml
+++ b/lib/keeper/keeper_chat_events.ml
@@ -15,6 +15,8 @@ type stream_protocol_error_kind =
   | Sse_parse_failed
   | Ndjson_parse_failed
   | Sse_unknown_event_type
+  | Sse_unsupported_part
+  | Sse_unsupported_response
   | Sse_stream_incomplete
 
 type stream_protocol_error = {
@@ -129,6 +131,8 @@ let stream_protocol_error_kind_to_string = function
   | Sse_parse_failed -> "sse_parse_failed"
   | Ndjson_parse_failed -> "ndjson_parse_failed"
   | Sse_unknown_event_type -> "sse_unknown_event_type"
+  | Sse_unsupported_part -> "sse_unsupported_part"
+  | Sse_unsupported_response -> "sse_unsupported_response"
   | Sse_stream_incomplete -> "sse_stream_incomplete"
 
 let stream_protocol_error_summary error =

--- a/lib/keeper/keeper_chat_events.mli
+++ b/lib/keeper/keeper_chat_events.mli
@@ -25,6 +25,8 @@ type stream_protocol_error_kind =
   | Sse_parse_failed
   | Ndjson_parse_failed
   | Sse_unknown_event_type
+  | Sse_unsupported_part
+  | Sse_unsupported_response
   | Sse_stream_incomplete
 
 type stream_protocol_error = {

--- a/lib/keeper/keeper_chat_oas_stream_bridge.ml
+++ b/lib/keeper/keeper_chat_oas_stream_bridge.ml
@@ -512,6 +512,26 @@ let translate ~redact_text ~base_dir bridge_state
           [ protocol_error ~event_type ~raw_bytes:(String.length raw)
               Sse_unknown_event_type ]
       }
+  | SSEUnsupportedPart { provider_kind; part; raw } ->
+      let provider = Agent_sdk.Llm_provider.Provider_kind.to_string provider_kind in
+      let reason = redact_text (Printf.sprintf "%s.part.%s" provider part) in
+      { bridge_state;
+        chat_events =
+          [ protocol_error ~event_type:part ~reason
+              ~raw_bytes:(String.length raw) Sse_unsupported_part;
+            Event_error
+              { message = "Provider stream capability unsupported: " ^ reason } ]
+      }
+  | SSEUnsupportedResponse { provider_kind; response; raw } ->
+      let provider = Agent_sdk.Llm_provider.Provider_kind.to_string provider_kind in
+      let reason = redact_text (Printf.sprintf "%s.response.%s" provider response) in
+      { bridge_state;
+        chat_events =
+          [ protocol_error ~event_type:response ~reason
+              ~raw_bytes:(String.length raw) Sse_unsupported_response;
+            Event_error
+              { message = "Provider stream capability unsupported: " ^ reason } ]
+      }
   | StreamIncomplete { reason } ->
       { bridge_state;
         chat_events =

--- a/masc.opam
+++ b/masc.opam
@@ -31,7 +31,7 @@ depends: [
   "cohttp-eio" {>= "6.0"}
   "piaf" {= "0.2.0"}
   "eio-ssl" {>= "0.3.0"}
-  "agent_sdk" {>= "0.231.12"}
+  "agent_sdk" {>= "0.231.13"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -11,7 +11,7 @@ homepage: "https://github.com/jeong-sik/masc"
 doc: "https://github.com/jeong-sik/masc"
 bug-reports: "https://github.com/jeong-sik/masc/issues"
 depends: [
-  "agent_sdk" {= "0.231.12"}
+  "agent_sdk" {= "0.231.13"}
   "alcotest" {= "1.9.1" & with-test}
   "ambient-context" {= "0.2"}
   "ambient-context-eio" {= "0.2"}
@@ -218,8 +218,8 @@ build: [
 dev-repo: "git+https://github.com/jeong-sik/masc.git"
 pin-depends: [
   [
-  "agent_sdk.0.231.12"
-  "git+https://github.com/jeong-sik/oas.git#966cd3f61cd5e9e21c8390513dfa27894aeb6230"
+  "agent_sdk.0.231.13"
+  "git+https://github.com/jeong-sik/oas.git#59ccced68c2dc96389a91eee24d0b2c6bd5c53a6"
 ]
   [
     "bisect_ppx.2.8.3"

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.12"
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.13"
 # v0.231.0 is a hard-cut wave: checkpoint schema is v9 only (v1-v8
 # rejected; #2867), provider_config.output_schema is removed in favor of
 # response_format = JsonSchema as the single structured-output request state
@@ -70,12 +70,18 @@ readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.12"
 # [NDJSONError] stream event (#2916). MASC consumes that event at its typed
 # streaming boundary; the pin must move with the public constructor.
 # Previous pin: v0.231.11 (6ab2e84e1).
-readonly OAS_AGENT_SDK_DECLARED_VERSION="0.231.12"
+# v0.231.13 preserves terminal stop semantics (#2927), uses OS entropy for
+# session identifiers (#2928), and makes unsupported Gemini stream parts and
+# response shapes explicit typed events (#2930). MASC consumes those events as
+# capability failures rather than dropping them or relabelling them as parse
+# errors.
+# Previous pin: v0.231.12 (966cd3f61).
+readonly OAS_AGENT_SDK_DECLARED_VERSION="0.231.13"
 # TRACK_REF consumed by check-oas-pin.sh / oas-drift-check.sh /
 # sync-oas-pin-docs.sh; removed by #25579 and restored here (#25584). Use main
 # for merge-ready pins. A blocked Draft cross-repo PR may temporarily declare
 # the exact refs/pull/<number>/head review ref; CI rejects that ref once the PR
 # is no longer both Draft and blocked-on-oas.
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="966cd3f61cd5e9e21c8390513dfa27894aeb6230"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.231.12"
+readonly OAS_AGENT_SDK_SHA="59ccced68c2dc96389a91eee24d0b2c6bd5c53a6"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.231.13"

--- a/scripts/oas-api-surface.json
+++ b/scripts/oas-api-surface.json
@@ -1,6 +1,6 @@
 {
-  "pinned_sha": "966cd3f61cd5e9e21c8390513dfa27894aeb6230",
-  "pinned_version": "v0.231.12",
+  "pinned_sha": "59ccced68c2dc96389a91eee24d0b2c6bd5c53a6",
+  "pinned_version": "v0.231.13",
   "surfaces": {
     "event_bus_payload_variants": [
       "AgentCompleted",

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -1909,6 +1909,52 @@ let test_keeper_stream_bridge_surfaces_unknown_and_incomplete_events () =
         "Provider stream incomplete: max_output_tokens" message
   | _ -> fail "expected visible events for unknown/incomplete provider stream"
 
+let test_keeper_stream_bridge_surfaces_unsupported_provider_shapes () =
+  let open Agent_sdk.Types in
+  let provider_kind = Agent_sdk.Llm_provider.Provider_kind.Gemini in
+  let part_raw = "{\"inlineData\":{}}" in
+  let response_raw = "{\"promptFeedback\":{}}" in
+  let events =
+    translate_oas_stream_events
+      [ SSEUnsupportedPart
+          { provider_kind; part = "inline_data"; raw = part_raw }
+      ; SSEUnsupportedResponse
+          { provider_kind; response = "prompt_feedback"; raw = response_raw }
+      ]
+  in
+  match events with
+  | [ Keeper_chat_events.Oas_stream_protocol_error
+        { kind = part_kind
+        ; event_type = Some "inline_data"
+        ; reason = Some "gemini.part.inline_data"
+        ; raw_bytes = Some part_bytes
+        ; _
+        }
+    ; Keeper_chat_events.Event_error { message = part_message }
+    ; Keeper_chat_events.Oas_stream_protocol_error
+        { kind = response_kind
+        ; event_type = Some "prompt_feedback"
+        ; reason = Some "gemini.response.prompt_feedback"
+        ; raw_bytes = Some response_bytes
+        ; _
+        }
+    ; Keeper_chat_events.Event_error { message = response_message }
+    ] ->
+      check string "unsupported part kind" "sse_unsupported_part"
+        (Keeper_chat_events.stream_protocol_error_kind_to_string part_kind);
+      check string "unsupported response kind" "sse_unsupported_response"
+        (Keeper_chat_events.stream_protocol_error_kind_to_string response_kind);
+      check int "unsupported part raw bytes" (String.length part_raw) part_bytes;
+      check int "unsupported response raw bytes" (String.length response_raw)
+        response_bytes;
+      check string "unsupported part is visible"
+        "Provider stream capability unsupported: gemini.part.inline_data"
+        part_message;
+      check string "unsupported response is visible"
+        "Provider stream capability unsupported: gemini.response.prompt_feedback"
+        response_message
+  | _ -> fail "expected typed visible failures for unsupported provider shapes"
+
 let test_keeper_stream_bridge_preserves_ndjson_parse_failure () =
   let open Agent_sdk.Types in
   let raw = "not-json" in
@@ -2961,6 +3007,8 @@ let () =
             test_stream_protocol_error_summary_includes_diagnostics;
           test_case "stream bridge surfaces unknown and incomplete events" `Quick
             test_keeper_stream_bridge_surfaces_unknown_and_incomplete_events;
+          test_case "stream bridge surfaces unsupported provider shapes" `Quick
+            test_keeper_stream_bridge_surfaces_unsupported_provider_shapes;
           test_case "stream bridge preserves NDJSON parse failure" `Quick
             test_keeper_stream_bridge_preserves_ndjson_parse_failure;
           test_case "stream bridge preserves NDJSON provider error" `Quick


### PR DESCRIPTION
## What changed

- pin `agent_sdk` to the released OAS `v0.231.13` exact SHA and sync every generated consumer
- consume `SSEUnsupportedPart` and `SSEUnsupportedResponse` exhaustively
- preserve the two capability-mismatch shapes as distinct typed Keeper protocol errors and visible turn failures
- add behavior coverage for provider kind, shape discriminator, raw byte count, and visible failure text

## Root cause

The local installed OAS interface had advanced to the `v0.231.13` stream sum while MASC still declared `v0.231.12`. The new constructors therefore made two closed pattern matches non-exhaustive. Separately, current main briefly retained tests for the deleted `Mcp_server_eio.mcp_session_record`; that independent regression is already fixed by merged #26782 and disappeared when this branch was rebased.

## Impact

Unsupported Gemini response shapes are no longer silently ignored or collapsed into parse errors. They remain typed as capability mismatches and fail visibly at the Keeper stream boundary.

## Validation

- `ocamlformat --check` on all touched OCaml files
- `ocamlc -stop-after parsing` on all touched OCaml files
- `git diff --check`
- `scripts/sync-oas-pin-docs.sh --check`
- `AGENT_SDK_LOCAL_REPO=../oas scripts/oas-drift-check.sh`

Focused Dune did not reach compilation locally: a six-hour bare Dune process caused the wrapper's concurrency guard to refuse the first attempt, and the shared switch then reported installed package metadata `0.231.12` while exposing the newer CMI. Required PR CI is the clean exact-pin build authority.
