### PR TITLE
feat(ci): carry unresolved review threads across merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,6 +427,9 @@ jobs:
       - name: Run deploy preflight safety contract
         run: bash test/test_deploy_preflight.sh
 
+      - name: Run review thread carryover render contract
+        run: bash test/test_pr_review_thread_carryover_render.sh
+
       - name: Check doc truth
         if: needs.changes.outputs.doc_truth == 'true'
         run: |

--- a/.github/workflows/review-thread-carryover.yml
+++ b/.github/workflows/review-thread-carryover.yml
@@ -1,0 +1,38 @@
+name: Review Thread Carryover
+
+# When a PR merges with unresolved review threads, carry them into a
+# review-carryover issue so the findings stay in the fleet's supply loop
+# instead of evaporating with the deleted branch. Observation, not a gate:
+# see instructions/masc-workflow.md "강제 장치보다 자기 관측" (me repo) and
+# scripts/pr-review-thread-carryover.sh for the rationale.
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: review-thread-carryover-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  carryover:
+    name: Carry unresolved review threads
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      # pull_request_target runs with the base ref checked out, so the script
+      # below always comes from the trusted base repo, never from the PR head.
+      - uses: actions/checkout@v7
+
+      - name: Carry unresolved review threads to an issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: bash scripts/pr-review-thread-carryover.sh "$GITHUB_REPOSITORY" "$PR_NUMBER"

--- a/scripts/pr-review-thread-carryover.sh
+++ b/scripts/pr-review-thread-carryover.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# pr-review-thread-carryover.sh — carry unresolved review threads across merge.
+#
+# When a PR merges with unresolved review threads, those threads stop being
+# anyone's context: the branch is deleted, the PR leaves every board, and the
+# finding evaporates unless a human happens to remember it. This script makes
+# the record reach the next actor instead of blocking the merge: it opens one
+# issue per merged PR listing every unresolved thread (path:line, author,
+# excerpt, thread id) and cross-links it from the PR.
+#
+# This is deliberately not a merge gate. Root rationale:
+# instructions/masc-workflow.md "강제 장치보다 자기 관측" — repair the
+# observation path first, leave judgment to the actor. GitHub's native
+# "require conversation resolution" branch protection remains the operator's
+# backstop if observation alone proves insufficient.
+#
+# Usage:
+#   pr-review-thread-carryover.sh <repo|.> <pr>   # carry threads of a merged PR
+#   pr-review-thread-carryover.sh --render-only   # stdin: threads JSON → stdout: issue body
+#
+# --render-only consumes the exact JSON shape fetch_threads emits and renders
+# the issue body for unresolved threads only; it performs no API calls, which
+# is what the test contract exercises.
+#
+# Exit codes: 0 ok (including "nothing to carry") · 1 usage/API error.
+#
+# Requires: gh, jq
+set -euo pipefail
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+LABEL="review-carryover"
+EXCERPT_LIMIT=300
+
+render_body() {
+  # stdin: threads JSON document; arguments: repo, pr (display only).
+  local repo="$1" pr="$2"
+  jq -r --arg repo "$repo" --arg pr "$pr" --argjson limit "$EXCERPT_LIMIT" '
+    [ .data.repository.pullRequest.reviewThreads.nodes[]
+      | select(.isResolved | not) ] as $threads
+    | if ($threads | length) == 0 then empty else
+        "Merged \($repo)#\($pr) left \($threads | length) unresolved review thread(s). Each entry below is an unaddressed finding or an unanswered question; close it with a fix PR, or resolve the thread with grounds via scripts/pr-resolve-thread.sh.\n\n" +
+        ( [ $threads[]
+            | "- **\(.path // "?"):\(.line // "?")** by \(.comments.nodes[0].author.login // "?") — thread `\(.id)`\n  > \(.comments.nodes[0].body | gsub("[\r\n]+"; " ") | .[0:$limit])"
+          ] | join("\n") ) +
+        "\n\ncarryover-marker:pr-\($pr)"
+      end
+  '
+}
+
+if [ "${1:-}" = "--render-only" ]; then
+  render_body "${2:-repo}" "${3:-0}"
+  exit 0
+fi
+
+command -v gh >/dev/null || die "gh not found"
+command -v jq >/dev/null || die "jq not found"
+
+REPO="${1:-}"; PR="${2:-}"
+[ -n "$REPO" ] && [ -n "$PR" ] || die "usage: $0 <repo|.> <pr>  (or --render-only < threads.json)"
+
+if [ "$REPO" = "." ]; then
+  REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)" || die "cannot infer repo from cwd"
+fi
+OWNER="${REPO%%/*}"; NAME="${REPO##*/}"
+[ -n "$OWNER" ] && [ -n "$NAME" ] && [ "$OWNER" != "$NAME" ] || die "repo must be owner/name, got: $REPO"
+
+STATE="$(gh pr view "$PR" --repo "$REPO" --json state -q .state)" || die "cannot read PR state for $REPO#$PR"
+if [ "$STATE" != "MERGED" ]; then
+  # Threads of a closed-unmerged PR die with the code they annotate; carrying
+  # them would resurrect findings about deleted lines.
+  echo "PR $REPO#$PR state is $STATE (not MERGED) — nothing to carry"
+  exit 0
+fi
+
+fetch_threads() {
+  # Same paginated walk as scripts/pr-resolve-thread.sh: gh injects
+  # $endCursor and follows pageInfo until exhausted, then the per-page
+  # documents are slurped back into one document.
+  # shellcheck disable=SC2016
+  gh api graphql --paginate -f query='
+    query($owner:String!, $name:String!, $pr:Int!, $endCursor:String) {
+      repository(owner:$owner, name:$name) {
+        pullRequest(number:$pr) {
+          reviewThreads(first:100, after:$endCursor) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              id isResolved path line
+              comments(first:1) { nodes { author { login } body } }
+            }
+          }
+        }
+      }
+    }' -F owner="$OWNER" -F name="$NAME" -F pr="$PR" \
+    | jq -s '{data:{repository:{pullRequest:{reviewThreads:{nodes:
+        [ .[].data.repository.pullRequest.reviewThreads.nodes[] ]}}}}}'
+}
+
+THREADS_JSON="$(fetch_threads)" || die "review thread query failed for $REPO#$PR"
+UNRESOLVED="$(echo "$THREADS_JSON" | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] | length')"
+
+if [ "$UNRESOLVED" -eq 0 ]; then
+  echo "PR $REPO#$PR merged with 0 unresolved review threads — nothing to carry"
+  exit 0
+fi
+
+BODY="$(echo "$THREADS_JSON" | render_body "$REPO" "$PR")"
+TITLE="[review-carryover] PR #$PR merged with $UNRESOLVED unresolved review thread(s)"
+
+# One carryover issue per PR: a re-fired close event appends instead of
+# duplicating.
+EXISTING="$(gh issue list --repo "$REPO" --search "carryover-marker:pr-$PR in:body" --state all --json number -q '.[0].number // empty')"
+if [ -n "$EXISTING" ]; then
+  gh issue comment "$EXISTING" --repo "$REPO" --body "$BODY" >/dev/null \
+    || die "failed to append carryover to existing issue #$EXISTING"
+  echo "appended carryover for $REPO#$PR to existing issue #$EXISTING"
+  ISSUE_URL="$(gh issue view "$EXISTING" --repo "$REPO" --json url -q .url)"
+else
+  gh label create "$LABEL" --repo "$REPO" \
+    --description "unresolved review threads carried across a merge" \
+    --color D93F0B --force >/dev/null
+  ISSUE_URL="$(gh issue create --repo "$REPO" --title "$TITLE" --label "$LABEL" --body "$BODY")" \
+    || die "failed to create carryover issue for $REPO#$PR"
+  echo "created carryover issue: $ISSUE_URL"
+fi
+
+gh pr comment "$PR" --repo "$REPO" \
+  --body "이 PR은 미해소 리뷰 스레드 $UNRESOLVED 건과 함께 머지되어 $ISSUE_URL 로 이월되었습니다." >/dev/null \
+  || die "failed to cross-link carryover issue on PR #$PR"

--- a/test/test_pr_review_thread_carryover_render.sh
+++ b/test/test_pr_review_thread_carryover_render.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Render contract for scripts/pr-review-thread-carryover.sh --render-only:
+# unresolved threads appear with path:line, author, flattened excerpt, and the
+# dedup marker; resolved threads are excluded; an all-resolved document
+# renders nothing.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/pr-review-thread-carryover.sh"
+
+FIXTURE='{
+  "data": { "repository": { "pullRequest": { "reviewThreads": { "nodes": [
+    { "id": "T_alpha", "isResolved": false, "path": "lib/foo.ml", "line": 12,
+      "comments": { "nodes": [ { "author": { "login": "reviewer-a" },
+        "body": "P1 finding line one\r\nline two" } ] } },
+    { "id": "T_beta", "isResolved": true, "path": "lib/bar.ml", "line": 34,
+      "comments": { "nodes": [ { "author": { "login": "reviewer-b" },
+        "body": "already handled" } ] } },
+    { "id": "T_gamma", "isResolved": false, "path": null, "line": null,
+      "comments": { "nodes": [ { "author": null, "body": "orphan finding" } ] } }
+  ] } } } }
+}'
+
+OUTPUT="$(printf '%s' "$FIXTURE" | bash "$SCRIPT" --render-only jeong-sik/masc 77)"
+
+expect_contains() {
+    local needle="$1"
+    if ! printf '%s' "$OUTPUT" | grep -qF "$needle"; then
+        echo "render output is missing: $needle" >&2
+        printf '%s\n' "$OUTPUT" >&2
+        exit 1
+    fi
+}
+
+expect_contains "2 unresolved review thread(s)"
+expect_contains "lib/foo.ml:12"
+expect_contains "reviewer-a"
+expect_contains "T_alpha"
+expect_contains "P1 finding line one line two"
+expect_contains "?:?"
+expect_contains "orphan finding"
+expect_contains "carryover-marker:pr-77"
+
+if printf '%s' "$OUTPUT" | grep -qF "already handled"; then
+    echo "render output leaked a resolved thread" >&2
+    printf '%s\n' "$OUTPUT" >&2
+    exit 1
+fi
+
+ALL_RESOLVED='{
+  "data": { "repository": { "pullRequest": { "reviewThreads": { "nodes": [
+    { "id": "T_beta", "isResolved": true, "path": "lib/bar.ml", "line": 34,
+      "comments": { "nodes": [ { "author": { "login": "reviewer-b" },
+        "body": "already handled" } ] } }
+  ] } } } }
+}'
+
+EMPTY_OUTPUT="$(printf '%s' "$ALL_RESOLVED" | bash "$SCRIPT" --render-only jeong-sik/masc 77)"
+if [ -n "$EMPTY_OUTPUT" ]; then
+    echo "all-resolved document must render nothing" >&2
+    printf '%s\n' "$EMPTY_OUTPUT" >&2
+    exit 1
+fi
+
+echo "review thread carryover render contract holds"


### PR DESCRIPTION
## 변경

미해소 리뷰 스레드가 머지와 함께 증발하는 구멍을 닫습니다. 오늘 실사례: #26759가 P1 스레드 2건 미해소 상태로 머지 → 브랜치 삭제로 스레드가 모든 보드에서 사라짐 → follow-up #26781은 수동 이어붙이기로만 성립.

- `.github/workflows/review-thread-carryover.yml` — merged closed 이벤트에서 발화. `pull_request_target` + base checkout이라 PR head 코드는 실행되지 않음.
- `scripts/pr-review-thread-carryover.sh` — `pr-resolve-thread.sh`와 동일한 paginated GraphQL walk로 미해소 스레드를 수집해 PR당 1개의 `review-carryover` 이슈 생성 (path:line, author, 300자 발췌, thread id). `carryover-marker:pr-N` 토큰으로 재발화 시 기존 이슈에 코멘트로 append (중복 이슈 없음). PR에 교차 링크 코멘트. closed-unmerged PR은 이월하지 않음 — 삭제된 코드에 대한 지적이므로.
- **머지 게이트가 아님** — 머지 속도에 영향 0. `masc-workflow.md` "강제 장치보다 자기 관측" 원칙의 적용이며, GitHub 네이티브 "require conversation resolution" 브랜치 보호는 operator 백스톱으로 남겨둠 (이 PR은 켜지 않음).

## 검증

- `test/test_pr_review_thread_carryover_render.sh` (CI 연결): 미해소만 렌더·resolved 제외·null path/author `?` 처리·CRLF 평탄화·marker 존재·all-resolved → 무출력 — 로컬 통과.
- 실 데이터 드라이런: #26759의 실제 미해소 스레드 2건에 대해 쿼리+렌더 경로 검증 (이슈 생성 제외) — path:line/author/발췌 정확.
- shellcheck (관례대로 SC2016 disable), `bash -n`, YAML parse 통과.

RFC 검색: `docs/rfc/`에 매칭 선행 RFC 없음 (RFC-0144는 keeper dedup sunset 건으로 무관).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
