### PR TITLE
refactor(schedule): remove dead store surface

### DIFF
--- a/lib/schedule/schedule_store.ml
+++ b/lib/schedule/schedule_store.ml
@@ -319,57 +319,11 @@ let make_wake_record ~now (request : schedule_request) =
   }
 ;;
 
-let compare_wake_desc (left : wake_record) (right : wake_record) =
-  match compare right.started_at left.started_at with
-  | 0 ->
-    (match compare right.due_at left.due_at with
-     | 0 -> String.compare right.payload_digest left.payload_digest
-     | cmp -> cmp)
-  | cmp -> cmp
-;;
-
-let wakes_for_schedule state ~schedule_id =
-  state.wakes
-  |> List.filter (fun (wake : wake_record) ->
-    String.equal wake.schedule_id schedule_id)
-  |> List.sort compare_wake_desc
-;;
-
 let last_wake_for_schedule_instance state ~schedule_instance_id ~schedule_id =
-  match
-    wakes_for_schedule state ~schedule_id
-    |> List.filter (fun (wake : wake_record) ->
-      String.equal wake.schedule_instance_id schedule_instance_id)
-  with
-  | [] -> None
-  | wake :: _ -> Some wake
-;;
-
-let wake_matches_occurrence
-      ~schedule_instance_id
-      ~schedule_id
-      ~due_at
-      ~payload_digest
-      (wake : wake_record) =
-  String.equal wake.schedule_instance_id schedule_instance_id
-  && String.equal wake.schedule_id schedule_id
-  && Float.equal wake.due_at due_at
-  && String.equal wake.payload_digest payload_digest
-;;
-
-let wake_for_occurrence
-      state
-      ~schedule_instance_id
-      ~schedule_id
-      ~due_at
-      ~payload_digest
-  =
   List.find_opt
-    (wake_matches_occurrence
-       ~schedule_instance_id
-       ~schedule_id
-       ~due_at
-       ~payload_digest)
+    (fun (wake : wake_record) ->
+       String.equal wake.schedule_instance_id schedule_instance_id
+       && String.equal wake.schedule_id schedule_id)
     state.wakes
 ;;
 
@@ -496,53 +450,57 @@ let update_request config ~schedule_id ~due_at ~expires_at ~payload =
 let refresh_due config ~now =
   Workspace_utils.with_file_lock config (schedules_path config) (fun () ->
     let* state = load_for_mutation config in
-    let changed = ref 0 in
-    let schedules =
-      List.map
-        (fun request ->
+    let schedules, changed =
+      List.fold_right
+        (fun request (schedules, changed) ->
           let updated = Schedule_domain.mark_due ~now request in
-          if updated.Schedule_domain.status <> request.Schedule_domain.status then
-            incr changed;
-          updated)
+          let changed =
+            if updated.Schedule_domain.status <> request.Schedule_domain.status
+            then changed + 1
+            else changed
+          in
+          updated :: schedules, changed)
         state.schedules
+        ([], 0)
     in
-    if !changed = 0 then
+    if changed = 0 then
       Ok (state, 0)
     else (
       let next_state =
         bump_state state ~schedules ~wakes:state.wakes
       in
       let* () = write_state config next_state in
-      Ok (next_state, !changed)))
+      Ok (next_state, changed)))
 ;;
 
 let reschedule_due_recurring config ~now ~schedule_ids =
   Workspace_utils.with_file_lock config (schedules_path config) (fun () ->
     let* state = load_for_mutation config in
-    let ids = Hashtbl.create (List.length schedule_ids) in
-    List.iter (fun schedule_id -> Hashtbl.replace ids schedule_id ()) schedule_ids;
-    let changed = ref 0 in
-    let schedules =
-      List.map
-        (fun (request : schedule_request) ->
-          if not (Hashtbl.mem ids request.schedule_id) then
-            request
+    let schedules, changed =
+      List.fold_right
+        (fun (request : schedule_request) (schedules, changed) ->
+          if
+            not
+              (List.exists
+                 (String.equal request.schedule_id)
+                 schedule_ids)
+          then
+            request :: schedules, changed
           else
             match Schedule_domain.reschedule_after_due_signal ~now request with
-            | None -> request
-            | Some updated ->
-              incr changed;
-              updated)
+            | None -> request :: schedules, changed
+            | Some updated -> updated :: schedules, changed + 1)
         state.schedules
+        ([], 0)
     in
-    if !changed = 0 then
+    if changed = 0 then
       Ok (state, 0)
     else (
       let next_state =
         bump_state state ~schedules ~wakes:state.wakes
       in
       let* () = write_state config next_state in
-      Ok (next_state, !changed)))
+      Ok (next_state, changed)))
 ;;
 
 let start_due_candidate config ~now ~schedule_id =
@@ -684,12 +642,17 @@ let recover_running_on_startup config ~now =
         (match request.status with
          | Running ->
            (match
-              wake_for_occurrence
-                { state with wakes }
-                ~schedule_instance_id:request.schedule_instance_id
-                ~schedule_id:request.schedule_id
-                ~due_at:request.due_at
-                ~payload_digest:(Schedule_domain.payload_digest request.payload)
+              List.find_opt
+                (fun (wake : wake_record) ->
+                   String.equal
+                     wake.schedule_instance_id
+                     request.schedule_instance_id
+                   && String.equal wake.schedule_id request.schedule_id
+                   && Float.equal wake.due_at request.due_at
+                   && String.equal
+                        wake.payload_digest
+                        (Schedule_domain.payload_digest request.payload))
+                wakes
             with
             | Some { status = Wake_running; _ } ->
               let* wakes =

--- a/lib/schedule/schedule_store.mli
+++ b/lib/schedule/schedule_store.mli
@@ -48,17 +48,6 @@ type read_error =
 
 val read_error_to_string : read_error -> string
 
-(** Outcome of loading the durable ledger. [Fresh] is a legitimately absent file
-    (empty store); [Corrupt] is a present-but-unparseable file that must not be
-    silently defaulted or overwritten. *)
-type load_outcome =
-  | Loaded of state
-  | Fresh
-  | Corrupt of
-      { primary_err : string
-      ; recovery_err : string option
-      }
-
 (** Raised by [read_state]/[list_schedules]/[get_schedule] on a corrupt ledger.
     Read paths have no [result] channel, so they fail loud instead of returning
     an empty list. Mutating paths report [Corrupt_ledger] instead. *)
@@ -68,44 +57,25 @@ exception
     ; recovery_err : string option
     }
 
-val schedules_path : Workspace_utils.config -> string
-
-(** Total load that distinguishes a fresh (absent) ledger from a corrupt
-    (present-but-unparseable) one. Performs no writes. *)
-val load : Workspace_utils.config -> load_outcome
-
-(** Read-only snapshot. Returns the empty [default_state] for a [Fresh] store and
+(** Read-only snapshot. Returns an empty state for an absent store and
     raises {!Corrupt_ledger_exn} for a corrupt one. Never writes to disk. *)
 val read_state : Workspace_utils.config -> state
 
-(** Result-returning read-only snapshot. Returns the empty [default_state] for a
-    [Fresh] store and [Error (Corrupt_read_ledger _)] for a corrupt one. Never
+(** Result-returning read-only snapshot. Returns an empty state for an absent
+    store and [Error (Corrupt_read_ledger _)] for a corrupt one. Never
     writes to disk. *)
 val read_state_result : Workspace_utils.config -> (state, read_error) result
 
-val default_state : unit -> state
-val state_to_yojson : state -> Yojson.Safe.t
 val state_of_yojson : Yojson.Safe.t -> (state, string) result
 
 val list_schedules : Workspace_utils.config -> Schedule_domain.schedule_request list
 val get_schedule :
   Workspace_utils.config -> schedule_id:string -> Schedule_domain.schedule_request option
-val wakes_for_schedule :
-  state -> schedule_id:string -> Schedule_domain.wake_record list
 val last_wake_for_schedule_instance :
   state ->
   schedule_instance_id:string ->
   schedule_id:string ->
   Schedule_domain.wake_record option
-
-val wake_for_occurrence :
-  state ->
-  schedule_instance_id:string ->
-  schedule_id:string ->
-  due_at:float ->
-  payload_digest:string ->
-  Schedule_domain.wake_record option
-(** Exact wake occurrence lookup used for dispatch deduplication. *)
 
 val insert_request :
   Workspace_utils.config ->
@@ -205,7 +175,7 @@ val fail_due_candidate :
 
 val due_wake_candidates :
   state -> Schedule_domain.schedule_request list
-(** Returns all due requests. Authorization of dispatched effects belongs to
+(** Returns all due requests. Authorization of downstream effects belongs to
     the payload consumer. *)
 
 val cancel_matching :

--- a/test/test_keeper_waiting_inventory.ml
+++ b/test/test_keeper_waiting_inventory.ml
@@ -759,7 +759,9 @@ let write_pending_confirms_exn config entries =
 let test_corrupt_schedule_ledger_is_read_error () =
   with_workspace
   @@ fun config ->
-  save_text (Schedule_store.schedules_path config) "{not-json";
+  save_text
+    (Filename.concat (Workspace_utils.masc_dir config) "schedules.json")
+    "{not-json";
   let json = Server_keeper_waiting_inventory.dashboard_json config in
   check_metric_float "global read error metric"
     Otel_metric_store.metric_keeper_waiting_count

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -381,6 +381,22 @@ let latest_wake_exn config (request : Schedule_domain.schedule_request) =
   | None -> fail ("missing wake for schedule " ^ request.schedule_id)
 ;;
 
+let find_wake
+      state
+      ~schedule_instance_id
+      ~schedule_id
+      ~due_at
+      ~payload_digest
+  =
+  List.find_opt
+    (fun (wake : Schedule_domain.wake_record) ->
+       String.equal wake.schedule_instance_id schedule_instance_id
+       && String.equal wake.schedule_id schedule_id
+       && Float.equal wake.due_at due_at
+       && String.equal wake.payload_digest payload_digest)
+    state.Schedule_store.wakes
+;;
+
 let single_occurrence_id (result : Schedule_runner.tick_result) =
   match result.emitted with
   | [ signal ] -> Schedule_occurrence_id.to_string signal.occurrence_id
@@ -676,7 +692,7 @@ let test_reused_schedule_id_does_not_match_pruned_terminal_receipt () =
   check bool "recreated occurrence has a new identity" false
     (Schedule_occurrence_id.equal first_signal.occurrence_id second_signal.occurrence_id);
   match
-    Schedule_store.wake_for_occurrence
+    find_wake
       (Schedule_store.read_state config)
       ~schedule_instance_id:second.schedule_instance_id
       ~schedule_id:second.schedule_id
@@ -1208,7 +1224,7 @@ let test_cancelled_occurrence_recovery_does_not_enqueue_again () =
            (Schedule_domain.schedule_status_to_string stored.status)
        | None -> fail "cancelled schedule missing");
       (match
-         Schedule_store.wake_for_occurrence
+         find_wake
            (Schedule_store.read_state config)
            ~schedule_instance_id:request.schedule_instance_id
            ~schedule_id:request.schedule_id

--- a/test/test_schedule_runner.ml
+++ b/test/test_schedule_runner.ml
@@ -479,9 +479,9 @@ let test_tick_retries_same_occurrence_without_blocking_other_schedule () =
    | None -> fail "retry schedule missing after success");
   check Alcotest.(list string) "failed attempt remains beside successful retry"
     [ "succeeded"; "failed" ]
-    (Schedule_store.wakes_for_schedule
-       (Schedule_store.read_state config)
-       ~schedule_id:retry_request.schedule_id
+    ((Schedule_store.read_state config).wakes
+     |> List.filter (fun (wake : wake_record) ->
+       String.equal wake.schedule_id retry_request.schedule_id)
      |> List.map (fun (wake : wake_record) ->
        wake_status_to_string wake.status))
 ;;

--- a/test/test_schedule_store.ml
+++ b/test/test_schedule_store.ml
@@ -2,6 +2,10 @@ open Alcotest
 open Schedule_domain
 open Schedule_store
 
+let schedules_path config =
+  Filename.concat (Workspace_utils.masc_dir config) "schedules.json"
+;;
+
 let json = testable Yojson.Safe.pp Yojson.Safe.equal
 
 let with_workspace f =
@@ -470,15 +474,15 @@ let test_startup_recovery_refuses_corrupt_ledger () =
     (Workspace_core.read_text config (recovery_path config))
 ;;
 
-let test_load_fresh_when_file_absent () =
+let test_read_empty_when_file_absent () =
   with_workspace
   @@ fun config ->
   (* A pristine workspace has no schedules.json yet. *)
-  (match Schedule_store.load config with
-   | Fresh -> ()
-   | Loaded _ -> fail "absent ledger reported as Loaded"
-   | Corrupt _ -> fail "absent ledger reported as Corrupt");
-  let state = read_state config in
+  let state =
+    match read_state_result config with
+    | Ok state -> state
+    | Error error -> fail (read_error_to_string error)
+  in
   check int "fresh store has no schedules" 0 (List.length state.schedules);
   check int "fresh store has no wakes" 0 (List.length state.wakes)
 ;;
@@ -667,18 +671,17 @@ let test_recurring_occurrences_remain_dispatchable () =
     (List.length (due_wake_candidates (read_state config)))
 ;;
 
-let test_load_corrupt_when_both_unparseable () =
+let test_read_error_when_both_unparseable () =
   with_workspace
   @@ fun config ->
   let req = make_request () in
   ignore (insert_ok config req);
   corrupt_both config;
-  match Schedule_store.load config with
-  | Corrupt { primary_err; recovery_err } ->
+  match read_state_result config with
+  | Error (Corrupt_read_ledger { primary_err; recovery_err }) ->
     check bool "primary error is non-empty" true (String.length primary_err > 0);
     check bool "recovery error reported" true (Option.is_some recovery_err)
-  | Fresh -> fail "corrupt-but-present ledger reported as Fresh"
-  | Loaded _ -> fail "corrupt ledger reported as Loaded"
+  | Ok _ -> fail "corrupt ledger returned a readable state"
 ;;
 
 let test_read_state_raises_on_corrupt () =
@@ -721,7 +724,7 @@ let test_insert_surfaces_primary_write_failure () =
      readv, which load classifies as Corrupt_ledger) - it never exercises the
      write-failure path this test names. Inject a write-only failure instead:
      the ledger directory itself is made read-only *after* the (nonexistent-
-     file / Fresh) read succeeds, so save_file_atomic's temp-file creation for
+     file) read succeeds, so save_file_atomic's temp-file creation for
      the write is what fails. *)
   let masc_dir = Workspace_utils.masc_dir config in
   Unix.chmod masc_dir 0o500;
@@ -840,7 +843,17 @@ let test_prune_does_not_bind_orphan_receipt_to_reused_public_id () =
   Workspace_core.write_text
     config
     (schedules_path config)
-    (Yojson.Safe.to_string (state_to_yojson { old_state with schedules = [] }));
+    (Yojson.Safe.to_string
+       (`Assoc
+          [ "version", `Int old_state.version
+          ; "updated_at", `Float old_state.updated_at
+          ; "schedules", `List []
+          ; ( "wakes"
+            , `List
+                (List.map
+                   Schedule_domain.wake_record_to_yojson
+                   old_state.wakes) )
+          ]));
   let new_request = make_request ~schedule_id:old_request.schedule_id () in
   check bool "public ID reuse mints a new instance" false
     (String.equal
@@ -880,10 +893,10 @@ let () =
         ] );
       ( "corruption",
         [
-          test_case "absent ledger loads Fresh" `Quick
-            test_load_fresh_when_file_absent;
-          test_case "both unparseable loads Corrupt" `Quick
-            test_load_corrupt_when_both_unparseable;
+          test_case "absent ledger reads empty" `Quick
+            test_read_empty_when_file_absent;
+          test_case "both unparseable return read error" `Quick
+            test_read_error_when_both_unparseable;
           test_case "startup recovery refuses corrupt ledger" `Quick
             test_startup_recovery_refuses_corrupt_ledger;
           test_case "read_state raises on corrupt ledger" `Quick

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -523,7 +523,10 @@ let test_due_signal_and_dashboard_projection () =
 let test_schedule_store_error_is_explicit () =
   with_config
   @@ fun config ->
-  Workspace_core.write_text config (Schedule_store.schedules_path config) "{not-json";
+  Workspace_core.write_text
+    config
+    (Filename.concat (Workspace_utils.masc_dir config) "schedules.json")
+    "{not-json";
   let result =
     dispatch_exn config Tool_schemas_schedule.List_requests (`Assoc [])
   in


### PR DESCRIPTION
## What changed

- Remove test-only `Schedule_store` exports: `schedules_path`, `load`, `default_state`, `state_to_yojson`, and `wake_for_occurrence`.
- Remove the unused `wakes_for_schedule` function and its one-use sorting helper.
- Inline the single-use exact wake lookup into startup recovery.
- Keep only public functions with at least one production caller.
- Replace mutable transition counters with immutable folds.
- Move storage-path and exact-wake fixture logic into tests instead of widening the production interface.

## Why

After #26791 removed scheduler settlement, `schedule_store.mli` still exposed storage internals and test helpers that no production caller used. Those exports made the store look larger and more reusable than its real contract.

The remaining interface now covers only production reads, schedule mutations, wake delivery transitions, and the current-schema decoder used by the cutover helper.

## Validation

- Every remaining `Schedule_store` `val` has at least one production caller.
- No `discard`, `dispatched`, `settle`, `unsettled`, `settlement`, or `reclaim` term remains in `schedule_store.ml/.mli`.
- `ocamlc -stop-after parsing` passed for all changed OCaml files.
- `ocamlformat --check` passed for all changed OCaml files.
- `git diff --check` passed.

Focused Dune validation was attempted through `scripts/dune-local.sh`, but the wrapper correctly refused while unrelated bare Dune processes were active in other sessions. No lock bypass was used; exact-head CI is required before merge.
