### PR TITLE
fix(test): main red 복구 — MCP lifecycle 스모크에 verification hook 설치

### DIFF
--- a/test/test_mcp_session_task_lifecycle.ml
+++ b/test/test_mcp_session_task_lifecycle.ml
@@ -12,6 +12,17 @@ module Mcp_server = Masc.Mcp_server
 
 let () = Mirage_crypto_rng_unix.use_default ()
 
+(* The verification hooks in [Workspace_hooks] default to a fail-closed
+   [Error "... hook is not installed"], so a Task submission reaches durable
+   storage only in a process that installed the real implementations.
+   Production installs them through [Workspace_metric_hooks.install] in
+   [Mcp_server.create_state_eio]'s [on_backend_ready] callback; the harness
+   below builds its config through the non-Eio [For_testing.create_state],
+   which never fires that callback. Installing the same function here is what
+   makes [submit_for_verification] exercise the production persistence
+   boundary instead of the unwired default. *)
+let () = Masc.Workspace_metric_hooks.install ()
+
 let request ~id ~method_ params =
   Yojson.Safe.to_string
     (`Assoc


### PR DESCRIPTION
## 문제

`main` 의 `ci.yml` `Build and Test` 잡이 `#26757` 병합 이후 연속 실패한다 (스텝 24 `Run MCP session Task lifecycle and Keeper prompt config suites`). `Build and Test` 실패는 `CI Gate` 도 red 로 만들고, 이후 열린 모든 PR 이 base 에서 red 를 상속한다 (예: `#26786` — 무관한 `keeper_agent_run` 3파일 변경인데 동일 스텝·동일 문구로 실패).

```
FAIL masc_transition submit_for_verification returned a typed tool error:
[SystemError] IO error: verification request creation failed before status transition
(task=task-001 vrf=vrf-...): verification request persistence hook is not installed
```

Fixes #26792.

## 원인

`#26757` 이 모든 completion 을 verification 경로로 라우팅하면서 `test/test_mcp_session_task_lifecycle.ml` 의 전이를 `done` → `submit_for_verification` 으로 바꿨다. 그런데 그 테스트 프로세스는 verification hook 을 설치하지 않는다.

hook 설치 지점 (#26792 본문이 특정하지 못한 부분):

| 위치 | 내용 |
|---|---|
| `lib/workspace/workspace_hooks.ml:290` | `verification_submit_request_fn` 기본값 = fail-closed `Error "... hook is not installed"` |
| `lib/workspace_metric_hooks.ml:475` | `install ()` 이 `Verification_protocol.create_submit_request` 를 꽂는다 |
| `lib/mcp_server.ml:1097` | production 은 `create_state_eio` 의 `on_backend_ready` 콜백에서 `install ()` 호출 |
| `lib/mcp_server.ml:1031` | `For_testing.create_state` 는 비-Eio `Workspace.default_config` 를 쓰므로 그 콜백이 발화하지 않는다 |

즉 production 경로의 결함이 아니라, 테스트 프로세스가 domain hook 없이 실제 tool dispatch 를 구동한 것이다. hook 기본값이 fail-closed 라 조용히 통과하지 않고 드러났다 — 기본값 설계는 의도대로 동작했다.

## 변경

`test/test_mcp_session_task_lifecycle.ml` 에 production 이 쓰는 동일 함수 `Masc.Workspace_metric_hooks.install ()` 를 모듈 초기화에 추가한다. 스텁이 아니라 production 배선 그대로다.

기존 관습과 동일하다: `test/` 에서 12개 파일이 같은 이유로 `Workspace_metric_hooks.install ()` 를 호출한다 (`test_verification.ml`, `test_tool_task_coverage.ml`, `test_workspace.ml` 등).

## harness 레벨 수정을 택하지 않은 이유

`Mcp_server_eio.For_testing.create_state` 에서 `install ()` 을 호출하면 배선 SSOT 는 하나가 되지만, 그 harness 를 공유하는 dashboard/call_tool 계열 테스트가 함께 실제 `activity_graph` emission, board cleanup, keeper wake hook 을 갖게 된다. main red 수리 범위를 넘는 blast radius 라 이 PR 에서는 하지 않았다.

같은 함정에 빠질 수 있는 나머지 테스트는 실측했다: MCP dispatcher 를 구동하면서 hook 을 설치하지 않는 테스트가 6개 (`test_code_navigation_eio`, `test_mcp_auth_gate`, `test_mcp_server_eio`, `test_mcp_session_task_lifecycle`, `test_mcp_tool_matrix_cases`, `test_tool_contract_truth`). 나머지 5개는 verification 영속 경로를 건드리지 않아 현재 green 이다. harness 통합 여부는 #26792 후속으로 남긴다.

## 검증

- `dune build --root . @test/runtest-test_mcp_session_task_lifecycle` — 통과
- 수정 전 동일 명령 — CI 와 동일 문구로 실패 (로컬 재현)
- CI 는 `.github/workflows/ci.yml:954` 에서 이 alias 를 실행한다

## 미검증

- `Build and Test` 잡의 나머지 스텝은 이미 green 이었으므로 (실패 스텝은 24 단독) 재확인하지 않았다
- 왜 11 커밋이 red 로 머지됐는지 (required check 설정) 는 이 PR 범위 밖 — #21757, #26078

RFC-WAIVED: 테스트 파일 1개에 production hook 배선 1줄 추가. credential/identity/auth, operator control, keeper sandbox, dashboard credential, hooks, workflow 문서 어디에도 해당하지 않는다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
