### PR TITLE
fix(dashboard): 메모리 패널 전체 실패 복구 — turn record wire 필드 4개 디코드

### DIFF
--- a/dashboard/src/api/dashboard-turn-records.test.ts
+++ b/dashboard/src/api/dashboard-turn-records.test.ts
@@ -12,6 +12,13 @@ function entry(overrides: Record<string, unknown> = {}) {
   return {
     record: {
       keeper: 'sangsu',
+      // lib/types/turn_record.ml:148-163 writes these four on every row. The
+      // fixture carried none of them until #26792, so the suite stayed green
+      // against a shape the server had stopped sending.
+      agent_name: 'keeper-sangsu-agent',
+      generation: 1,
+      turn_kind: 'autonomous',
+      raw_trace_run_ref: null,
       trace_id: 'trace-1',
       absolute_turn: 7,
       turn_ref: 'trace-1#7',
@@ -144,6 +151,58 @@ describe('keeper turn record cache token counts', () => {
     getMock.mockResolvedValue(
       payload(entry({ cache_read_input_tokens: 'many', cache_creation_input_tokens: null })),
     )
+
+    await expect(fetchKeeperTurnRecords('sangsu')).rejects.toThrow(
+      '유효하지 않은 keeper turn record payload',
+    )
+  })
+
+  it('projects the record identity fields the writer always emits', async () => {
+    getMock.mockResolvedValue(payload(entry()))
+
+    const response = await fetchKeeperTurnRecords('sangsu')
+
+    expect(response.entries[0]?.record).toMatchObject({
+      agent_name: 'keeper-sangsu-agent',
+      generation: 1,
+      turn_kind: 'autonomous',
+      raw_trace_run_ref: null,
+    })
+  })
+
+  it('projects a populated exact-run reference', async () => {
+    const run_ref = {
+      worker_run_id: 'wr-1',
+      path: '/keepers/sangsu/raw-traces/turn-1.jsonl',
+      start_seq: 1,
+      end_seq: 4,
+      agent_name: 'oas-ollama_cloud.deepseek-v4-flash',
+      session_id: 'trace-1',
+    }
+    getMock.mockResolvedValue(payload(entry({ raw_trace_run_ref: run_ref })))
+
+    const response = await fetchKeeperTurnRecords('sangsu')
+
+    expect(response.entries[0]?.record.raw_trace_run_ref).toEqual(run_ref)
+  })
+
+  it.each([
+    ['agent_name', { agent_name: '' }],
+    ['generation', { generation: -1 }],
+    ['turn_kind', { turn_kind: 'scheduled' }],
+    ['raw_trace_run_ref', { raw_trace_run_ref: { worker_run_id: 'wr-1' } }],
+  ])('rejects a row whose %s violates the writer contract', async (_field, override) => {
+    getMock.mockResolvedValue(payload(entry(override)))
+
+    await expect(fetchKeeperTurnRecords('sangsu')).rejects.toThrow(
+      '유효하지 않은 keeper turn record payload',
+    )
+  })
+
+  it('rejects a row that omits a field the writer always emits', async () => {
+    const row = entry()
+    delete (row.record as Record<string, unknown>).turn_kind
+    getMock.mockResolvedValue(payload(row))
 
     await expect(fetchKeeperTurnRecords('sangsu')).rejects.toThrow(
       '유효하지 않은 keeper turn record payload',

--- a/dashboard/src/api/dashboard-turn-records.ts
+++ b/dashboard/src/api/dashboard-turn-records.ts
@@ -47,9 +47,29 @@ export type TurnRequestWireObservation =
       request_body_bytes: null
     }
 
+// lib/types/turn_record.ml:118-125 — the writer emits exactly these two.
+export type TurnKind = 'autonomous' | 'direct'
+
+// lib/types/turn_record.ml:127-135 — the exact-run reference into the keeper's
+// own raw-trace store. null when the turn recorded no exact run.
+export type TurnRawTraceRunRef = {
+  worker_run_id: string
+  path: string
+  start_seq: number
+  end_seq: number
+  agent_name: string
+  session_id: string
+}
+
 export type TurnRecordEntry = {
   execution_ids: string[]
   keeper: string
+  // lib/types/turn_record.ml:148-163 writes these four unconditionally and its
+  // own reader [require]s them, so the wire always carries them.
+  agent_name: string
+  generation: number
+  turn_kind: TurnKind
+  raw_trace_run_ref: TurnRawTraceRunRef | null
   trace_id: string
   absolute_turn: number
   turn_ref: string
@@ -423,10 +443,46 @@ function decodeTurnInputComponents(raw: unknown): TurnInputComponent[] | null {
     : null
 }
 
+// Mirrors [raw_trace_run_ref_to_json] (lib/types/turn_record.ml:127-135): six
+// fields, no optionals. A reference that names no run is written as null by the
+// producer, so a partial object is a producer defect and stays rejected.
+function decodeTurnRawTraceRunRef(raw: unknown): TurnRawTraceRunRef | null {
+  if (!isRecord(raw) || !hasExactKeys(raw, [
+    'worker_run_id',
+    'path',
+    'start_seq',
+    'end_seq',
+    'agent_name',
+    'session_id',
+  ])) return null
+  const worker_run_id = decodeExactNonEmptyString(raw.worker_run_id)
+  const path = decodeExactNonEmptyString(raw.path)
+  const start_seq = decodeNonNegativeSafeInteger(raw.start_seq)
+  const end_seq = decodeNonNegativeSafeInteger(raw.end_seq)
+  const agent_name = decodeExactNonEmptyString(raw.agent_name)
+  const session_id = decodeExactNonEmptyString(raw.session_id)
+  if (
+    worker_run_id === null
+    || path === null
+    || start_seq === null
+    || end_seq === null
+    || end_seq < start_seq
+    || agent_name === null
+    || session_id === null
+  ) {
+    return null
+  }
+  return { worker_run_id, path, start_seq, end_seq, agent_name, session_id }
+}
+
 function decodeTurnRecordEntry(raw: unknown): TurnRecordEntry | null {
   if (!isRecord(raw) || !hasNoUnknownKeys(raw, [
     'execution_ids',
     'keeper',
+    'agent_name',
+    'generation',
+    'turn_kind',
+    'raw_trace_run_ref',
     'trace_id',
     'absolute_turn',
     'turn_ref',
@@ -454,6 +510,12 @@ function decodeTurnRecordEntry(raw: unknown): TurnRecordEntry | null {
     'ts',
   ])) return null
   const keeper = decodeExactNonEmptyString(raw.keeper)
+  const agent_name = decodeExactNonEmptyString(raw.agent_name)
+  const generation = decodeNonNegativeSafeInteger(raw.generation)
+  const turn_kind =
+    raw.turn_kind === 'autonomous' || raw.turn_kind === 'direct' ? raw.turn_kind : null
+  const raw_trace_run_ref =
+    raw.raw_trace_run_ref === null ? null : decodeTurnRawTraceRunRef(raw.raw_trace_run_ref)
   const trace_id = decodeExactNonEmptyString(raw.trace_id)
   const absolute_turn = asNumber(raw.absolute_turn)
   const turn_ref = decodeExactNonEmptyString(raw.turn_ref)
@@ -502,6 +564,11 @@ function decodeTurnRecordEntry(raw: unknown): TurnRecordEntry | null {
     decodeOptionalField(raw, 'cache_read_input_tokens', decodeNonNegativeSafeInteger)
   if (
     keeper === null
+    || agent_name === null
+    || generation === null
+    || turn_kind === null
+    || !Object.hasOwn(raw, 'raw_trace_run_ref')
+    || (raw_trace_run_ref === null && raw.raw_trace_run_ref !== null)
     || trace_id === null
     || absolute_turn == null
     || !Number.isSafeInteger(absolute_turn)
@@ -543,6 +610,10 @@ function decodeTurnRecordEntry(raw: unknown): TurnRecordEntry | null {
   return {
     execution_ids,
     keeper,
+    agent_name,
+    generation,
+    turn_kind,
+    raw_trace_run_ref,
     trace_id,
     absolute_turn,
     turn_ref,

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -495,6 +495,10 @@ describe('keeper tool telemetry fetchers', () => {
           {
             record: {
               keeper: 'keeper-alpha',
+              agent_name: 'keeper-keeper-alpha-agent',
+              generation: 1,
+              turn_kind: 'autonomous',
+              raw_trace_run_ref: null,
               trace_id: 'trace-grounded',
               absolute_turn: 7,
               turn_ref: 'trace-grounded#7',
@@ -515,6 +519,10 @@ describe('keeper tool telemetry fetchers', () => {
             // decode to undefined, never a fabricated "stop"/placeholder.
             record: {
               keeper: 'keeper-alpha',
+              agent_name: 'keeper-keeper-alpha-agent',
+              generation: 1,
+              turn_kind: 'autonomous',
+              raw_trace_run_ref: null,
               trace_id: 'trace-grounded',
               absolute_turn: 8,
               turn_ref: 'trace-grounded#8',

--- a/dashboard/src/components/keeper-turn-inspector.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector.test.ts
@@ -122,6 +122,10 @@ function turnRecordsWithMemoryOs(): TurnRecordsResponse {
       {
         record: {
           keeper: 'albini',
+          agent_name: 'keeper-albini-agent',
+          generation: 1,
+          turn_kind: 'autonomous',
+          raw_trace_run_ref: null,
           trace_id: 'trace-active',
           absolute_turn: 41,
           turn_ref: 'trace-active#41',
@@ -138,6 +142,10 @@ function turnRecordsWithMemoryOs(): TurnRecordsResponse {
       {
         record: {
           keeper: 'albini',
+          agent_name: 'keeper-albini-agent',
+          generation: 1,
+          turn_kind: 'autonomous',
+          raw_trace_run_ref: null,
           trace_id: 'trace-active',
           absolute_turn: 42,
           turn_ref: 'trace-active#42',

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -62,6 +62,10 @@ vi.mock('../../api/dashboard', async (importOriginal) => {
           record: {
             execution_ids: ['exec-cmp'],
             keeper: 'masc-improver',
+            agent_name: 'keeper-masc-improver-agent',
+            generation: 1,
+            turn_kind: 'autonomous',
+            raw_trace_run_ref: null,
             trace_id: 'trace-cmp',
             absolute_turn: 12,
             turn_ref: 'trace-cmp#12',

--- a/dashboard/src/components/memory-inspector.test.ts
+++ b/dashboard/src/components/memory-inspector.test.ts
@@ -83,6 +83,10 @@ function turnRecordsPayload() {
       record: {
         execution_ids: [],
         keeper: keeper.id,
+        agent_name: `keeper-${keeper.id}-agent`,
+        generation: 1,
+        turn_kind: 'autonomous',
+        raw_trace_run_ref: null,
         trace_id: 'trace-a',
         absolute_turn: 7,
         turn_ref: 'trace-a#7',
@@ -193,6 +197,10 @@ describe('MemoryInspector pure projections', () => {
     record: {
       execution_ids: [],
       keeper: 'keeper',
+      agent_name: 'keeper-keeper-agent',
+      generation: 1,
+      turn_kind: 'autonomous',
+      raw_trace_run_ref: null,
       trace_id: 'trace',
       absolute_turn: turn,
       turn_ref: `trace#${turn}`,


### PR DESCRIPTION
## 문제

Dashboard 메모리 패널이 데이터 대신 에러 한 줄만 렌더한다.

```
⚠ 메모리 불러오기 실패 — 유효하지 않은 keeper turn record payload
```

`memory-inspector.ts:795` 가 `fetchKeeperTurnRecords` 로 메모리 상태를 읽으므로, 이 디코드 실패는 패널 전체를 죽인다 (`memory_os` projection 이 `/api/v1/keepers/:name/turn-records` 응답에 실려 온다).

Closes #26798.

## 원인

라이브 서버가 보내는 record 키와 `decodeTurnRecordEntry` 허용 목록의 차집합 (`comm -23` 으로 계산):

```
agent_name
generation
raw_trace_run_ref
turn_kind
```

- `decodeTurnRecordEntry` 는 `hasNoUnknownKeys` 로 미지 키가 하나라도 있으면 그 행을 거부한다
- `decodeArray` (`dashboard-turn-records.ts:334-341`) 는 행 하나라도 null 이면 배열 전체를 null 로 만든다
- 따라서 4개 필드가 응답 전체를 폐기시킨다

서버측은 `lib/types/turn_record.ml:148-163` 이 이 4개를 무조건 emit 하고 같은 파일의 reader 도 `require` 한다. wire 계약의 SSOT 는 서버이고 dashboard 디코더만 뒤처져 있었다. `raw_trace_run_ref` 는 #26756 이 추가했다.

## 변경

허용 목록만 넓혀 통과시키지 않고 **타입으로 파싱**한다 — exact-shape 계약을 약화시키지 않는다.

| 필드 | 디코드 |
|---|---|
| `agent_name` | 비어있지 않은 문자열, 필수 |
| `generation` | 음수 아닌 안전 정수, 필수 |
| `turn_kind` | `'autonomous' \| 'direct'` — `turn_kind_to_string` 의 variant 쌍 그대로 |
| `raw_trace_run_ref` | 키 필수 / 값 nullable. 객체는 `raw_trace_run_ref_to_json` 을 미러하는 exact-keys 디코더 (`end_seq >= start_seq` 포함), 부분 객체는 거부 |

`TurnKind`, `TurnRawTraceRunRef` 타입을 추가하고 `TurnRecordEntry` 를 확장했다.

## 테스트

픽스처 4곳이 이 4개 필드를 하나도 담고 있지 않았다. 그래서 프로덕션이 깨진 동안 스위트는 green 이었다. 픽스처를 실제 wire 모양으로 교정하고 계약을 고정하는 케이스 7건을 추가했다:

- 4개 필드가 projection 에 실리는지
- 채워진 exact-run 참조가 그대로 실리는지
- 빈 `agent_name` / 음수 `generation` / 미지 `turn_kind`(`'scheduled'`) / 부분 `raw_trace_run_ref` 거부
- writer 가 항상 보내는 필드가 빠진 행 거부

## 검증

| 항목 | 결과 |
|---|---|
| `dashboard-turn-records` + `memory-inspector` + `keeper-turn-inspector` | 71/71 통과 |
| `tsc --noEmit` | exit 0 |
| 라이브 payload 를 `fetchKeeperTurnRecords` 에 주입 (vitest, `get` mock) | 수정 전 = 사용자가 본 문구로 reject / 수정 후 = 통과 |

`tsc` 가 낡은 픽스처 3곳을 추가로 잡아냈고, 그중 memory-inspector 2건은 main 기준선(8/8 통과)과 대조해 이 변경이 원인임을 확인한 뒤 고쳤다.

## 미검증

- dashboard 전체 vitest 스위트는 로컬에서 실행 중이며 이 PR 작성 시점에 완료되지 않았다. CI 결과로 확인한다.
- 서버가 실제로 채운 `raw_trace_run_ref` 는 라이브에서 전량 `null` 이다 (#26786 이 그 원인을 수정 중). 채워진 참조의 디코드는 픽스처로만 검증했고 라이브 값으로는 검증하지 못했다.

## 후속 (이 PR 범위 밖)

dashboard 픽스처는 손으로 작성되고 OCaml 인코더에서 파생되지 않는다. 서버가 필드를 추가/삭제해도 dashboard 테스트는 계속 green 이므로 같은 사고가 재발할 수 있다. wire 계약 교차 검증 게이트는 #26798 에 후속으로 남겼다.

RFC-WAIVED: dashboard 읽기 경로의 디코더 1개와 그 테스트 픽스처 변경. credential/identity/auth, operator control, keeper sandbox, dashboard credential component, hooks, workflow 문서 어디에도 해당하지 않는다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
