### PR TITLE
fix(runtime): bound the model input window by measured bytes, not atom count

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1074,7 +1074,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          request_cap_targets="@test/runtest-test_runtime_config_validity @test/runtest-test_keeper_turn_driver_failover @test/runtest-test_keeper_vision_tool @test/runtest-test_runtime_modality_reroute"
+          request_cap_targets="@test/runtest-test_runtime_config_validity @test/runtest-test_keeper_turn_driver_failover @test/runtest-test_keeper_vision_tool @test/runtest-test_runtime_modality_reroute @test/runtest-test_runtime_model_input_tail_window"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${request_cap_targets}"
 
       - name: Run operator control suite

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -693,14 +693,16 @@ let run_turn
       s.Keeper_run_tools.model_input_projection
     in
     let model_input_projection messages =
-      (* Bounded transmission view first (RFC #26534 PR-C). The source
-         projection appends only a bounded typed Gate replay reference; exact
-         replay bytes remain in the artifact store. The provenance check below
-         compares against the windowed list so its projected-prefix
-         precondition keeps holding. Durable state and checkpoints receive the
-         unwindowed history. *)
-      let windowed = Runtime_model_input_tail_window.project messages in
-      match source_model_input_projection windowed with
+      (* [messages] already carries the bounded transmission view: the provider
+         attempt applies it, because its budget is the target's declared
+         request-body cap and that is only resolved per runtime
+         ([Keeper_turn_driver_try_provider.budgeted_model_input_projection]).
+         The source projection appends only a bounded typed Gate replay
+         reference; exact replay bytes remain in the artifact store. The
+         provenance check below compares against the list as received, so its
+         projected-prefix precondition keeps holding. Durable state and
+         checkpoints receive the unwindowed history. *)
+      match source_model_input_projection messages with
       | Error _ as error ->
         current_request_input_messages_ref := None;
         error
@@ -711,7 +713,7 @@ let run_turn
         (match
            Keeper_agent_prompt_metrics.provider_content_messages
              ~prompt_context_present
-             ~projection_input:windowed
+             ~projection_input:messages
              ~projected_messages
          with
          | Some provider_content ->

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -244,6 +244,75 @@ let observe_request_wire_error
     ()
 ;;
 
+(* Share of the declared request capacity held back for the parts of the
+   serialized body MASC does not encode: provider-specific request fields, the
+   JSON envelope, and any provider-side message reshaping. MASC measures
+   messages, tool schemas, and the system prompt with its own encoder, but OAS
+   owns the wire format, so the remainder is bounded rather than computed.
+   A share rather than a constant because the unmeasured remainder scales with
+   the request. Under-reserving does not corrupt state — the provider refusal
+   stays typed and the next assembly re-measures — so this trades transmitted
+   history for refusal margin, not for correctness. *)
+let unmeasured_request_reserve_divisor = 10
+
+(* The canonical MASC message encoder, also used for checkpoint serialization.
+   It is not the provider's encoder; [unmeasured_request_reserve_divisor]
+   carries that difference. *)
+let measure_message_bytes (message : Agent_sdk.Types.message) =
+  String.length
+    (Yojson.Safe.to_string (Keeper_context_core.message_to_json message))
+;;
+
+let declared_request_reserve_bytes ~capacity_bytes ~system_prompt ~tools =
+  let tool_schema_bytes =
+    List.fold_left
+      (fun acc tool ->
+         acc
+         + String.length
+             (Yojson.Safe.to_string (Agent_sdk.Tool.schema_to_json tool)))
+      0
+      tools
+  in
+  let system_prompt_bytes =
+    String.length (Yojson.Safe.to_string (`String system_prompt))
+  in
+  tool_schema_bytes
+  + system_prompt_bytes
+  + (capacity_bytes / unmeasured_request_reserve_divisor)
+;;
+
+(* The bounded transmission view runs here rather than in the caller because
+   its budget is [ctx.max_request_body_bytes], which
+   [Keeper_turn_driver.validate_provider_request_cap] resolves per runtime.
+   A caller that composed the window ahead of runtime selection would have to
+   guess which target's cap applies. The window stays ahead of
+   [ctx.model_input_projection] so that projection's projected-prefix
+   precondition keeps holding against the list it receives. *)
+let budgeted_model_input_projection (ctx : try_provider_ctx)
+  : Agent_sdk.Agent.model_input_projection
+  =
+  let reserved_bytes =
+    declared_request_reserve_bytes
+      ~capacity_bytes:ctx.max_request_body_bytes
+      ~system_prompt:ctx.system_prompt
+      ~tools:ctx.tools
+  in
+  fun messages ->
+    match
+      Runtime_model_input_tail_window.project
+        ~measure_message_bytes
+        ~capacity_bytes:ctx.max_request_body_bytes
+        ~reserved_bytes
+        messages
+    with
+    | Error error ->
+      Error (Runtime_model_input_tail_window.budget_error_to_string error)
+    | Ok windowed ->
+      (match ctx.model_input_projection with
+       | None -> Ok windowed
+       | Some inner -> inner windowed)
+;;
+
 let run_try_provider
       (ctx : try_provider_ctx)
       ?enable_thinking_override
@@ -305,7 +374,7 @@ let run_try_provider
           ; preserve_thinking = ctx.preserve_thinking
           ; event_bus = ctx.event_bus
           ; initial_messages = ctx.initial_messages
-          ; model_input_projection = ctx.model_input_projection
+          ; model_input_projection = Some (budgeted_model_input_projection ctx)
             (* The serialized request body is the quantity the provider admits
                against [max_request_body_bytes]. OAS's provider-specific
                serialization boundary reports every admitted request; a typed

--- a/lib/runtime/runtime_model_input_tail_window.ml
+++ b/lib/runtime/runtime_model_input_tail_window.ml
@@ -1,5 +1,5 @@
 (** Bounded transmission view over provider-bound history — see the
-    interface for the contract (RFC #26534 PR-C, #26544, #26535). *)
+    interface for the contract (RFC-0351 §3 L5, #26534 PR-C, #26535, #26551). *)
 
 let atoms_per_window = 60
 let preamble_marker_key = "masc.model_input_tail_window.v1"
@@ -16,6 +16,34 @@ let preamble_message : Agent_sdk.Types.message =
   ; tool_call_id = None
   ; metadata = [ (preamble_marker_key, `Bool true) ]
   }
+;;
+
+type budget_error =
+  | Reservation_exceeds_capacity of
+      { capacity_bytes : int
+      ; reserved_bytes : int
+      ; undroppable_bytes : int
+      }
+  | Newest_atom_exceeds_available of
+      { available_bytes : int
+      ; newest_atom_bytes : int
+      }
+
+let budget_error_to_string = function
+  | Reservation_exceeds_capacity
+      { capacity_bytes; reserved_bytes; undroppable_bytes } ->
+    Printf.sprintf
+      "model input budget leaves no room for history: capacity_bytes=%d \
+       reserved_bytes=%d undroppable_bytes=%d"
+      capacity_bytes
+      reserved_bytes
+      undroppable_bytes
+  | Newest_atom_exceeds_available { available_bytes; newest_atom_bytes } ->
+    Printf.sprintf
+      "newest conversation atom does not fit the model input budget: \
+       available_bytes=%d newest_atom_bytes=%d"
+      available_bytes
+      newest_atom_bytes
 ;;
 
 (* A message is pinned when it must survive every cut: [System] entries
@@ -67,21 +95,56 @@ let annotate (messages : Agent_sdk.Types.message list) :
   (List.rev labelled_rev, atom_count)
 ;;
 
-(* Largest multiple of [atoms_per_window] that still leaves at least
-   [atoms_per_window] atoms. Quantizing the drop count keeps the cut point
-   stationary while up to [atoms_per_window] new atoms accumulate, so the
-   transmitted prefix only changes when the window jumps. *)
-let dropped_atoms ~atom_count =
-  if atom_count < 2 * atoms_per_window
-  then 0
-  else (atom_count - atoms_per_window) / atoms_per_window * atoms_per_window
+(* [suffix.(i)] is the measured size of atoms [i .. atom_count - 1];
+   [suffix.(atom_count)] is 0. Suffix sums make every candidate cut a single
+   array read, so the quantized scan below stays linear in the atom count. *)
+let atom_suffix_bytes ~measure_message_bytes ~atom_count labelled =
+  let per_atom = Array.make (max atom_count 1) 0 in
+  List.iter
+    (fun (msg, label) ->
+       match label with
+       | Pinned -> ()
+       | Atom index -> per_atom.(index) <- per_atom.(index) + measure_message_bytes msg)
+    labelled;
+  let suffix = Array.make (atom_count + 1) 0 in
+  for index = atom_count - 1 downto 0 do
+    suffix.(index) <- suffix.(index + 1) + per_atom.(index)
+  done;
+  (per_atom, suffix)
 ;;
 
-let project (messages : Agent_sdk.Types.message list) :
-  Agent_sdk.Types.message list
-  =
-  let labelled, atom_count = annotate messages in
-  let drop = dropped_atoms ~atom_count in
+(* Smallest multiple of [atoms_per_window] whose remaining suffix fits
+   [available_bytes]. Quantizing keeps the transmitted prefix byte-identical
+   while the conversation grows inside one window, which is what preserves
+   provider prompt-cache reuse between jumps (#26535 measured the
+   alternative: a per-turn sliding cut changes the prefix on every request).
+   [None] means no quantized cut is small enough and the caller must fall
+   back to an exact cut — correctness outranks cache reuse. *)
+let quantized_drop ~available_bytes ~atom_count suffix =
+  let rec scan drop =
+    if drop >= atom_count
+    then None
+    else if suffix.(drop) <= available_bytes
+    then Some drop
+    else scan (drop + atoms_per_window)
+  in
+  scan 0
+;;
+
+(* Smallest cut of any size whose remaining suffix fits. Returns [atom_count]
+   when even the newest atom alone exceeds [available_bytes]. *)
+let exact_drop ~available_bytes ~atom_count suffix =
+  let rec scan drop =
+    if drop >= atom_count
+    then atom_count
+    else if suffix.(drop) <= available_bytes
+    then drop
+    else scan (drop + 1)
+  in
+  scan 0
+;;
+
+let assemble ~drop ~messages labelled =
   if drop = 0
   then messages
   else (
@@ -107,4 +170,52 @@ let project (messages : Agent_sdk.Types.message list) :
     | Some Agent_sdk.Types.Assistant
     | Some Agent_sdk.Types.Tool
     | Some Agent_sdk.Types.System -> preamble_message :: kept)
+;;
+
+let project
+    ~measure_message_bytes
+    ~capacity_bytes
+    ~reserved_bytes
+    (messages : Agent_sdk.Types.message list)
+  : (Agent_sdk.Types.message list, budget_error) result
+  =
+  let labelled, atom_count = annotate messages in
+  (* Everything the cut cannot remove is charged before any atom is
+     considered. Pinned messages are re-assembled fresh each turn by the
+     keeper hooks, and the preamble is prepended whenever a cut lands on a
+     non-[User] head; charging both up front is what makes an over-capacity
+     request a typed refusal instead of a cut that can never converge. *)
+  let pinned_bytes =
+    List.fold_left
+      (fun acc (msg, label) ->
+         match label with
+         | Pinned -> acc + measure_message_bytes msg
+         | Atom _ -> acc)
+      0
+      labelled
+  in
+  let preamble_bytes = measure_message_bytes preamble_message in
+  let undroppable_bytes = pinned_bytes + preamble_bytes in
+  let available_bytes = capacity_bytes - reserved_bytes - undroppable_bytes in
+  if available_bytes <= 0
+  then
+    Error
+      (Reservation_exceeds_capacity
+         { capacity_bytes; reserved_bytes; undroppable_bytes })
+  else if atom_count = 0
+  then Ok messages
+  else (
+    let per_atom, suffix =
+      atom_suffix_bytes ~measure_message_bytes ~atom_count labelled
+    in
+    match quantized_drop ~available_bytes ~atom_count suffix with
+    | Some drop -> Ok (assemble ~drop ~messages labelled)
+    | None ->
+      let drop = exact_drop ~available_bytes ~atom_count suffix in
+      if drop >= atom_count
+      then
+        Error
+          (Newest_atom_exceeds_available
+             { available_bytes; newest_atom_bytes = per_atom.(atom_count - 1) })
+      else Ok (assemble ~drop ~messages labelled))
 ;;

--- a/lib/runtime/runtime_model_input_tail_window.mli
+++ b/lib/runtime/runtime_model_input_tail_window.mli
@@ -1,5 +1,6 @@
 (** Runtime_model_input_tail_window — bounded transmission view over
-    provider-bound conversation history (RFC #26534 PR-C, #26544).
+    provider-bound conversation history (RFC-0351 §3 L5, #26534 PR-C, #26544,
+    #26551).
 
     [project] keeps only the most recent atoms of the message list that OAS
     is about to send to a provider. One atom is either an organic [User]
@@ -9,29 +10,34 @@
     applies a [model_input_projection] to the provider-bound copy only
     ({!Runtime_agent_context.config.model_input_projection}).
 
-    Cut placement is quantized to whole windows: with
-    [atoms_per_window = K], the drop count is the largest multiple of [K]
-    that still leaves at least [K] atoms. The transmitted prefix therefore
-    stays byte-identical across [K] consecutive atoms of growth before
-    jumping once, which preserves provider prompt-cache reuse between jumps
-    (#26535 measured the alternative: a per-turn sliding cut changes the
-    prefix on every request).
+    The cut is chosen by measured bytes against the target's declared request
+    capacity, not by atom count. An atom count cannot bound a request because
+    atom weight is not uniform: live checkpoints on 2026-08-04 measured 0.3KB
+    to 8.7KB per atom across the fleet, so a window sized for the light end
+    transmits an over-capacity request at the heavy end (#26551).
+
+    Cut placement is quantized to whole windows where the budget allows: the
+    smallest multiple of {!atoms_per_window} whose remaining history fits is
+    used, so the transmitted prefix stays byte-identical while the
+    conversation grows inside one window, which preserves provider
+    prompt-cache reuse between jumps (#26535 measured the alternative: a
+    per-turn sliding cut changes the prefix on every request). When no
+    quantized cut fits, an exact cut is used instead — correctness outranks
+    cache reuse.
 
     Messages carrying OAS extra-system-context provenance are never counted
-    and never dropped; that block is re-assembled fresh each turn by the
-    keeper hooks and must survive the cut. When the cut leaves a non-[User]
-    message at the head of the transmitted history, a constant synthetic
-    [User] preamble is prepended so providers that require a [User]-first
-    conversation accept the request; being constant, it does not perturb the
-    quantized prefix. *)
+    as atoms and never dropped; that block is re-assembled fresh each turn by
+    the keeper hooks and must survive the cut. When the cut leaves a
+    non-[User] message at the head of the transmitted history, a constant
+    synthetic [User] preamble is prepended so providers that require a
+    [User]-first conversation accept the request; being constant, it does not
+    perturb the quantized prefix. Both are charged against the budget before
+    any atom is considered, because no cut can remove them. *)
 
 val atoms_per_window : int
-(** Window quantum [K]. Once the conversation exceeds [2*K - 1] atoms the
-    transmitted history holds between [K] and [2*K - 1] atoms; below that
-    threshold {!project} is the identity. Sized from live checkpoint
-    measurement (2026-08-01: sangsu 487 atoms / 706KB, kidsnote 442 atoms /
-    719KB, mean atom ≈ 1.5KB — a [K]..[2K-1] window transmits ≈ 90..180KB
-    of history against a 200K-token primary context). *)
+(** Window quantum for cut placement. This bounds how often the transmitted
+    prefix changes; it does not bound the request size — {!project} does that
+    from measured bytes. *)
 
 val preamble_marker_key : string
 (** Metadata key tagging the synthetic preamble message, so a captured
@@ -39,8 +45,53 @@ val preamble_marker_key : string
     exists only in the transmitted copy; nothing writes it to durable
     state. *)
 
-val project :
-  Agent_sdk.Types.message list -> Agent_sdk.Types.message list
-(** Total on every input: never raises, never fails, and returns the input
-    list physically unchanged below the window threshold (including the
-    empty list). *)
+type budget_error =
+  | Reservation_exceeds_capacity of
+      { capacity_bytes : int
+      ; reserved_bytes : int
+      ; undroppable_bytes : int
+      }
+      (** The caller's reservation plus the messages no cut can remove
+          already fill the target's capacity, so no history can be
+          transmitted. Dropping atoms cannot resolve this, which is why it is
+          refused rather than cut further. *)
+  | Newest_atom_exceeds_available of
+      { available_bytes : int
+      ; newest_atom_bytes : int
+      }
+      (** A single atom is larger than the whole history budget. Splitting it
+          would separate a tool result from its call, so the request is
+          refused instead. *)
+
+val budget_error_to_string : budget_error -> string
+(** Diagnostic rendering carrying the measured values. Suitable as the
+    [Error] payload of an [Agent_sdk.Agent.model_input_projection], which
+    aborts the turn before request measurement or dispatch. *)
+
+val project
+  :  measure_message_bytes:(Agent_sdk.Types.message -> int)
+  -> capacity_bytes:int
+  -> reserved_bytes:int
+  -> Agent_sdk.Types.message list
+  -> (Agent_sdk.Types.message list, budget_error) result
+(** [project ~measure_message_bytes ~capacity_bytes ~reserved_bytes messages]
+    returns the most recent suffix of [messages] whose measured size fits
+    [capacity_bytes - reserved_bytes], with pinned messages preserved in
+    place.
+
+    [capacity_bytes] is the target's declared request-body cap. MASC does not
+    own provider serialization, so [reserved_bytes] is the caller's account
+    of every request byte that is not conversation history — tool schemas,
+    system prompt, and an allowance for the provider-specific fields MASC
+    cannot measure. Under-reserving does not corrupt state: the provider
+    refusal stays typed, and the next assembly re-measures.
+
+    [measure_message_bytes] is injected rather than fixed here because the
+    canonical message encoder lives above this library. It must be the same
+    encoder for every message of one call; exact agreement with the
+    provider's own serializer is not required, since [reserved_bytes] carries
+    that allowance.
+
+    Never raises. Returns the input list physically unchanged when the whole
+    history fits (including the empty list), so a request that needs no cut
+    is byte-identical to the uncut one. *)

--- a/lib/runtime/runtime_model_input_tail_window.mli
+++ b/lib/runtime/runtime_model_input_tail_window.mli
@@ -25,6 +25,17 @@
     quantized cut fits, an exact cut is used instead — correctness outranks
     cache reuse.
 
+    Two properties of that quantization are worth stating because they are
+    costs, not guarantees. History growth moves the cut in one direction
+    only, but the budget also depends on inputs that shrink: pinned context
+    is re-assembled each turn, so a smaller pinned block can move the cut
+    back and change the prefix once. The cost of that is a cache miss, never
+    a refusal. And because a window is a fixed atom count against a byte
+    budget, a jump can free far more room than it needed — a keeper whose
+    atoms are heavy transmits well under its budget right after a jump and
+    refills toward it, the same sawtooth an atom-count window had, now
+    bounded in the unit the target actually refuses on.
+
     Messages carrying OAS extra-system-context provenance are never counted
     as atoms and never dropped; that block is re-assembled fresh each turn by
     the keeper hooks and must survive the cut. When the cut leaves a

--- a/test/test_runtime_model_input_tail_window.ml
+++ b/test/test_runtime_model_input_tail_window.ml
@@ -366,12 +366,20 @@ let test_never_returns_an_over_budget_projection () =
      refuse. *)
   let history = atoms (5 * k) in
   let reserved_bytes = 1_000 in
+  let projected_count = ref 0 in
   List.iter
     (fun capacity_bytes ->
        match project ~capacity_bytes ~reserved_bytes history with
-       | Ok projected -> fits_budget ~capacity_bytes ~reserved_bytes projected
+       | Ok projected ->
+         incr projected_count;
+         fits_budget ~capacity_bytes ~reserved_bytes projected
        | Error _ -> ())
-    [ 5_000; 20_000; 60_000; 150_000; 400_000; 900_000; 2_000_000 ]
+    [ 5_000; 20_000; 60_000; 150_000; 400_000; 900_000; 2_000_000 ];
+  (* Without this the case passes vacuously: a projection that refused every
+     capacity would assert nothing at all. *)
+  Alcotest.(check bool)
+    "at least one capacity produced a projection to check" true
+    (!projected_count > 0)
 ;;
 
 let has_tag tag messages =

--- a/test/test_runtime_model_input_tail_window.ml
+++ b/test/test_runtime_model_input_tail_window.ml
@@ -1,9 +1,13 @@
-(** Tests for {!Runtime_model_input_tail_window} (RFC #26534 PR-C, #26544).
+(** Tests for {!Runtime_model_input_tail_window} (RFC-0351 §3 L5, #26534 PR-C,
+    #26544, #26551).
 
-    The projection is a pure function of the message list, so every case
-    builds a synthetic history and checks the transmitted view directly:
-    identity below the threshold, quantized cut placement, tool-call atom
-    integrity, extra-context pinning, and the synthetic [User] preamble. *)
+    The projection is a pure function of the message list and the byte budget,
+    so every case builds a synthetic history and checks the transmitted view
+    directly. The load-bearing property is stated once as {!fits_budget} and
+    re-asserted per case: whatever the projection returns must fit the budget
+    it was given. A count-shaped assertion cannot express that, which is the
+    defect these tests cover — a window sized in atoms transmitted an
+    over-capacity request whenever atom weight exceeded the sizing sample. *)
 
 module Window = Runtime_model_input_tail_window
 module Types = Agent_sdk.Types
@@ -19,9 +23,36 @@ let message ?(metadata = []) ~role text : Types.message =
   }
 ;;
 
-let user i = message ~role:Types.User (Printf.sprintf "user-%d" i)
-let assistant i = message ~role:Types.Assistant (Printf.sprintf "assistant-%d" i)
-let tool i = message ~role:Types.Tool (Printf.sprintf "tool-%d" i)
+(* Test-local encoder: the byte count is the transmitted text length, so a
+   budget in the assertions below is readable as a character count. The
+   production caller injects the canonical MASC message encoder instead. *)
+let measure_message_bytes (m : Types.message) =
+  List.fold_left
+    (fun acc (block : Types.content_block) ->
+       match block with
+       | Types.Text text -> acc + String.length text
+       | _ -> acc)
+    0
+    m.content
+;;
+
+let total_bytes messages =
+  List.fold_left (fun acc m -> acc + measure_message_bytes m) 0 messages
+;;
+
+(* [padded tag bytes] is a message whose measured size is [bytes] and whose
+   leading characters identify it, so a cut point stays observable. *)
+let padded ~role ~tag bytes =
+  let filler = String.make (max 0 (bytes - String.length tag)) 'x' in
+  message ~role (tag ^ filler)
+;;
+
+let atom_bytes = 1_000
+let user i = padded ~role:Types.User ~tag:(Printf.sprintf "user-%d|" i) atom_bytes
+let assistant i =
+  padded ~role:Types.Assistant ~tag:(Printf.sprintf "assistant-%d|" i) atom_bytes
+;;
+let tool i = padded ~role:Types.Tool ~tag:(Printf.sprintf "tool-%d|" i) atom_bytes
 
 let extra_context =
   message
@@ -31,7 +62,9 @@ let extra_context =
 ;;
 
 (* [atoms n] builds [n] atoms alternating [user] and [assistant]+2 tools so
-   both atom shapes and tool attachment are exercised. *)
+   both atom shapes and tool attachment are exercised. The assistant atoms
+   weigh three times the user atoms, which is the non-uniformity a count-based
+   window cannot see. *)
 let atoms n =
   List.concat
     (List.init n (fun i ->
@@ -40,14 +73,21 @@ let atoms n =
        else [ assistant i; tool i; tool (i + 1000) ]))
 ;;
 
+let is_preamble (m : Types.message) =
+  List.mem_assoc Window.preamble_marker_key m.metadata
+;;
+
 let count_atoms messages =
   List.fold_left
     (fun count (m : Types.message) ->
        match m.role with
        | Types.User | Types.Assistant ->
-         (match Types.Extra_system_context_provenance.classify m.metadata with
-          | Types.Extra_system_context_provenance.Absent -> count + 1
-          | _ -> count)
+         if is_preamble m
+         then count
+         else (
+           match Types.Extra_system_context_provenance.classify m.metadata with
+           | Types.Extra_system_context_provenance.Absent -> count + 1
+           | _ -> count)
        | Types.System | Types.Tool -> count)
     0
     messages
@@ -59,50 +99,147 @@ let first_text (messages : Types.message list) =
   | _ -> "<none>"
 ;;
 
-let is_preamble (m : Types.message) =
-  List.mem_assoc Window.preamble_marker_key m.metadata
+(* A capacity no synthetic history in this file can reach, for the cases that
+   exercise structure rather than the budget. *)
+let unbounded_capacity = 100_000_000
+
+let project ?(capacity_bytes = unbounded_capacity) ?(reserved_bytes = 0) history =
+  Window.project
+    ~measure_message_bytes
+    ~capacity_bytes
+    ~reserved_bytes
+    history
 ;;
 
-let test_identity_below_threshold () =
-  let history = atoms ((2 * k) - 1) in
-  let projected = Window.project history in
+let ok_exn ~what result =
+  match result with
+  | Ok messages -> messages
+  | Error error ->
+    Alcotest.failf "%s: %s" what (Window.budget_error_to_string error)
+;;
+
+(* The contract, stated once. Everything the projection keeps — pinned
+   messages and the synthetic preamble included — has to fit alongside the
+   caller's reservation. *)
+let fits_budget ~capacity_bytes ~reserved_bytes projected =
   Alcotest.(check bool)
-    "physically unchanged below 2K-1 atoms" true
+    (Printf.sprintf
+       "transmitted %d + reserved %d fits capacity %d"
+       (total_bytes projected)
+       reserved_bytes
+       capacity_bytes)
+    true
+    (total_bytes projected + reserved_bytes <= capacity_bytes)
+;;
+
+let test_identity_when_everything_fits () =
+  let history = atoms ((2 * k) - 1) in
+  let projected = ok_exn ~what:"identity" (project history) in
+  Alcotest.(check bool)
+    "physically unchanged when the whole history fits" true
     (projected == history)
 ;;
 
 let test_empty_list_identity () =
-  Alcotest.(check int) "empty stays empty" 0 (List.length (Window.project []))
+  let projected = ok_exn ~what:"empty" (project []) in
+  Alcotest.(check int) "empty stays empty" 0 (List.length projected)
 ;;
 
-let test_cut_at_threshold () =
-  let history = atoms (2 * k) in
-  let projected = Window.project history in
-  Alcotest.(check int) "keeps exactly K atoms at 2K" k (count_atoms projected)
-;;
-
-let test_quantized_cut_point () =
-  (* Between 2K and 3K-1 atoms the drop count stays at K, so the retained
-     head atom is stable while the tail grows — the prompt-cache-stable
-     plateau. At 3K the drop jumps to 2K. *)
-  let head_after n =
-    let projected = Window.project (atoms n) in
-    first_text (List.filter (fun m -> not (is_preamble m)) projected)
+let test_cut_when_over_capacity () =
+  (* 4K atoms against a capacity that cannot hold them: the projection must
+     cut, and what it returns must fit. *)
+  let history = atoms (4 * k) in
+  let capacity_bytes = 60_000 in
+  let reserved_bytes = 5_000 in
+  let projected =
+    ok_exn ~what:"cut" (project ~capacity_bytes ~reserved_bytes history)
   in
-  let plateau_start = head_after (2 * k) in
+  Alcotest.(check bool)
+    "history was cut" true
+    (count_atoms projected < count_atoms history);
+  fits_budget ~capacity_bytes ~reserved_bytes projected
+;;
+
+let test_heavy_atoms_cut_below_the_count_threshold () =
+  (* The regression this module exists for (#26551). The history holds fewer
+     than [2 * k] atoms, so an atom-count window is the identity — but the
+     atoms are heavy enough that transmitting all of them exceeds capacity.
+     The cut must happen on bytes. *)
+  let atom_count = (2 * k) - 1 in
+  let history = atoms atom_count in
+  let capacity_bytes = total_bytes history / 2 in
+  let reserved_bytes = 0 in
+  let projected =
+    ok_exn ~what:"heavy atoms" (project ~capacity_bytes ~reserved_bytes history)
+  in
+  Alcotest.(check bool)
+    "an atom-count window would not have cut here" true
+    (atom_count < 2 * k);
+  Alcotest.(check bool)
+    "history was cut" true
+    (count_atoms projected < atom_count);
+  fits_budget ~capacity_bytes ~reserved_bytes projected
+;;
+
+let test_cut_is_quantized_when_a_quantized_cut_fits () =
+  (* Cache stability (#26535): when some multiple of [k] fits, the drop count
+     is that multiple, so the transmitted prefix only moves in whole
+     windows. *)
+  let history = atoms (4 * k) in
+  let capacity_bytes = total_bytes history / 2 in
+  let projected =
+    ok_exn ~what:"quantized" (project ~capacity_bytes history)
+  in
+  let dropped = count_atoms history - count_atoms projected in
+  Alcotest.(check bool)
+    (Printf.sprintf "dropped %d is a multiple of %d" dropped k)
+    true
+    (dropped mod k = 0);
+  Alcotest.(check bool) "something was dropped" true (dropped > 0);
+  fits_budget ~capacity_bytes ~reserved_bytes:0 projected
+;;
+
+let test_cut_point_is_stable_while_the_budget_holds () =
+  (* Inside one window the retained head does not move, which is what keeps
+     the provider prompt-cache prefix byte-identical between jumps. The
+     capacity is chosen so a cut is already in force: a plateau that holds
+     only because nothing was cut would not test anything. *)
+  let capacity_bytes = 400_000 in
+  let projected_after n =
+    ok_exn ~what:"plateau" (project ~capacity_bytes (atoms n))
+  in
+  let head_after n =
+    first_text (List.filter (fun m -> not (is_preamble m)) (projected_after n))
+  in
+  Alcotest.(check bool)
+    "a cut is in force at the plateau" true
+    (count_atoms (projected_after (4 * k)) < 4 * k);
   Alcotest.(check string)
     "cut point unchanged while the tail grows"
-    plateau_start
-    (head_after ((3 * k) - 1));
+    (head_after (4 * k))
+    (head_after ((4 * k) + 1))
+;;
+
+let test_exact_cut_when_no_quantized_cut_fits () =
+  (* Fewer than [k] atoms can ever be dropped by quantization here, so the
+     budget can only be met by an exact cut. Correctness outranks cache
+     reuse, and the result must still fit. *)
+  let history = atoms (k - 1) in
+  let capacity_bytes = total_bytes history / 4 in
+  let projected =
+    ok_exn ~what:"exact cut" (project ~capacity_bytes history)
+  in
   Alcotest.(check bool)
-    "cut point jumps at 3K"
-    false
-    (String.equal plateau_start (head_after (3 * k)))
+    "history was cut" true
+    (count_atoms projected < count_atoms history);
+  fits_budget ~capacity_bytes ~reserved_bytes:0 projected
 ;;
 
 let test_tool_results_stay_with_their_call () =
-  let history = atoms (2 * k) in
-  let projected = Window.project history in
+  let history = atoms (4 * k) in
+  let projected =
+    ok_exn ~what:"tool pairing" (project ~capacity_bytes:60_000 history)
+  in
   let tool_never_opens_atom =
     let rec scan ~previous_organic = function
       | [] -> true
@@ -125,9 +262,11 @@ let test_preamble_on_assistant_head () =
   (* All-assistant atoms: after the cut the head organic message is an
      assistant turn, which requires the synthetic user preamble. *)
   let history =
-    List.concat (List.init (2 * k) (fun i -> [ assistant i; tool i ]))
+    List.concat (List.init (4 * k) (fun i -> [ assistant i; tool i ]))
   in
-  let projected = Window.project history in
+  let projected =
+    ok_exn ~what:"preamble" (project ~capacity_bytes:60_000 history)
+  in
   match projected with
   | head :: _ ->
     Alcotest.(check bool) "head is the tagged preamble" true (is_preamble head);
@@ -137,20 +276,19 @@ let test_preamble_on_assistant_head () =
   | [] -> Alcotest.fail "projection returned an empty list"
 ;;
 
-let test_no_preamble_on_user_head () =
-  (* Even atom count with the user/assistant alternation puts a user atom at
-     every even index, so a drop of K (even) lands on a user head. *)
+let test_no_preamble_when_nothing_is_cut () =
   let history = atoms (2 * k) in
-  let projected = Window.project history in
+  let projected = ok_exn ~what:"no cut" (project history) in
   Alcotest.(check bool)
-    "no preamble when the retained head is a user message" false
+    "no preamble when the whole history fits" false
     (List.exists is_preamble projected)
 ;;
 
 let test_extra_context_pinned () =
-  (* 2K organic atoms force a cut; the tagged extra-context message must
-     survive it and must not count toward the window. *)
-  let projected = Window.project (atoms (2 * k) @ [ extra_context ]) in
+  let history = atoms (4 * k) @ [ extra_context ] in
+  let projected =
+    ok_exn ~what:"pinned" (project ~capacity_bytes:60_000 history)
+  in
   Alcotest.(check bool)
     "extra context survives the cut" true
     (List.exists
@@ -159,31 +297,112 @@ let test_extra_context_pinned () =
           | Types.Extra_system_context_provenance.Present -> true
           | _ -> false)
        projected);
-  (* Below the threshold the tagged message must not tip the atom count
-     over the cut boundary. *)
-  let padded = extra_context :: atoms ((2 * k) - 1) in
+  let padded_history = extra_context :: atoms ((2 * k) - 1) in
+  let unchanged = ok_exn ~what:"pinned identity" (project padded_history) in
   Alcotest.(check bool)
-    "tagged message does not trigger a cut" true
-    (Window.project padded == padded)
+    "tagged message does not trigger a cut on its own" true
+    (unchanged == padded_history)
+;;
+
+let test_pinned_bytes_are_charged_before_atoms () =
+  (* Pinned messages cannot be dropped, so they are spent from the budget
+     first. With the pinned block alone over capacity the projection refuses
+     instead of cutting atoms that cannot help. *)
+  let pinned =
+    message
+      ~metadata:Types.Extra_system_context_provenance.metadata
+      ~role:Types.User
+      (String.make 50_000 'p')
+  in
+  match project ~capacity_bytes:10_000 (pinned :: atoms 4) with
+  | Ok _ -> Alcotest.fail "expected a typed refusal, not a projection"
+  | Error (Window.Reservation_exceeds_capacity { undroppable_bytes; _ }) ->
+    Alcotest.(check bool)
+      "refusal reports the undroppable bytes" true
+      (undroppable_bytes >= 50_000)
+  | Error other ->
+    Alcotest.failf
+      "expected Reservation_exceeds_capacity, got %s"
+      (Window.budget_error_to_string other)
+;;
+
+let test_reservation_exceeding_capacity_is_typed () =
+  match project ~capacity_bytes:1_000 ~reserved_bytes:1_000 (atoms 4) with
+  | Ok _ -> Alcotest.fail "expected a typed refusal, not a projection"
+  | Error (Window.Reservation_exceeds_capacity { capacity_bytes; reserved_bytes; _ })
+    ->
+    Alcotest.(check int) "capacity is reported" 1_000 capacity_bytes;
+    Alcotest.(check int) "reservation is reported" 1_000 reserved_bytes
+  | Error other ->
+    Alcotest.failf
+      "expected Reservation_exceeds_capacity, got %s"
+      (Window.budget_error_to_string other)
+;;
+
+let test_single_oversized_atom_is_typed () =
+  (* Splitting an atom would separate a tool result from its call, so an atom
+     larger than the whole history budget is refused rather than truncated. *)
+  let heavy i =
+    padded ~role:Types.User ~tag:(Printf.sprintf "heavy-%d|" i) 500_000
+  in
+  match project ~capacity_bytes:1_000_000 ~reserved_bytes:900_000
+          [ heavy 0; heavy 1 ]
+  with
+  | Ok _ -> Alcotest.fail "expected a typed refusal, not a projection"
+  | Error (Window.Newest_atom_exceeds_available { newest_atom_bytes; _ }) ->
+    Alcotest.(check int)
+      "refusal reports the atom size" 500_000 newest_atom_bytes
+  | Error other ->
+    Alcotest.failf
+      "expected Newest_atom_exceeds_available, got %s"
+      (Window.budget_error_to_string other)
+;;
+
+let test_never_returns_an_over_budget_projection () =
+  (* Termination guard. A projection that returned an over-budget list would
+     be refused by the provider without shrinking the next assembly, because a
+     failed turn adds no history — the request would repeat byte-for-byte.
+     Every accepted capacity across the range must therefore either fit or
+     refuse. *)
+  let history = atoms (5 * k) in
+  let reserved_bytes = 1_000 in
+  List.iter
+    (fun capacity_bytes ->
+       match project ~capacity_bytes ~reserved_bytes history with
+       | Ok projected -> fits_budget ~capacity_bytes ~reserved_bytes projected
+       | Error _ -> ())
+    [ 5_000; 20_000; 60_000; 150_000; 400_000; 900_000; 2_000_000 ]
+;;
+
+let has_tag tag messages =
+  let width = String.length tag in
+  List.exists
+    (fun (m : Types.message) ->
+       match m.content with
+       | [ Types.Text text ] ->
+         String.length text >= width && String.equal (String.sub text 0 width) tag
+       | _ -> false)
+    messages
 ;;
 
 let test_leading_orphan_tools_drop_with_first_atom () =
-  let history = tool 9000 :: tool 9001 :: atoms (2 * k) in
-  let projected = Window.project history in
+  let history = tool 9000 :: tool 9001 :: atoms (4 * k) in
+  Alcotest.(check bool)
+    "the orphan run is present before projection" true
+    (has_tag "tool-9000|" history);
+  let projected =
+    ok_exn ~what:"orphan tools" (project ~capacity_bytes:60_000 history)
+  in
   Alcotest.(check bool)
     "orphan head tools are not transmitted" false
-    (List.exists
-       (fun (m : Types.message) ->
-          match m.content with
-          | [ Types.Text text ] -> String.equal text "tool-9000"
-          | _ -> false)
-       projected)
+    (has_tag "tool-9000|" projected)
 ;;
 
 let test_deterministic () =
   let history = atoms ((2 * k) + 7) in
-  let a = Window.project history in
-  let b = Window.project history in
+  let capacity_bytes = 90_000 in
+  let a = ok_exn ~what:"first" (project ~capacity_bytes history) in
+  let b = ok_exn ~what:"second" (project ~capacity_bytes history) in
   Alcotest.(check int) "same length" (List.length a) (List.length b);
   Alcotest.(check bool)
     "same head" true
@@ -194,22 +413,36 @@ let () =
   Alcotest.run
     "runtime_model_input_tail_window"
     [ ( "tail_window"
-      , [ Alcotest.test_case "identity below threshold" `Quick
-            test_identity_below_threshold
+      , [ Alcotest.test_case "identity when everything fits" `Quick
+            test_identity_when_everything_fits
         ; Alcotest.test_case "empty list identity" `Quick
             test_empty_list_identity
-        ; Alcotest.test_case "cut at threshold keeps K atoms" `Quick
-            test_cut_at_threshold
-        ; Alcotest.test_case "cut point is quantized" `Quick
-            test_quantized_cut_point
+        ; Alcotest.test_case "cut when over capacity" `Quick
+            test_cut_when_over_capacity
+        ; Alcotest.test_case "heavy atoms cut below the count threshold" `Quick
+            test_heavy_atoms_cut_below_the_count_threshold
+        ; Alcotest.test_case "cut is quantized when a quantized cut fits" `Quick
+            test_cut_is_quantized_when_a_quantized_cut_fits
+        ; Alcotest.test_case "cut point is stable while the budget holds" `Quick
+            test_cut_point_is_stable_while_the_budget_holds
+        ; Alcotest.test_case "exact cut when no quantized cut fits" `Quick
+            test_exact_cut_when_no_quantized_cut_fits
         ; Alcotest.test_case "tool results stay with their call" `Quick
             test_tool_results_stay_with_their_call
         ; Alcotest.test_case "preamble on assistant head" `Quick
             test_preamble_on_assistant_head
-        ; Alcotest.test_case "no preamble on user head" `Quick
-            test_no_preamble_on_user_head
+        ; Alcotest.test_case "no preamble when nothing is cut" `Quick
+            test_no_preamble_when_nothing_is_cut
         ; Alcotest.test_case "extra context pinned" `Quick
             test_extra_context_pinned
+        ; Alcotest.test_case "pinned bytes are charged before atoms" `Quick
+            test_pinned_bytes_are_charged_before_atoms
+        ; Alcotest.test_case "reservation exceeding capacity is typed" `Quick
+            test_reservation_exceeding_capacity_is_typed
+        ; Alcotest.test_case "single oversized atom is typed" `Quick
+            test_single_oversized_atom_is_typed
+        ; Alcotest.test_case "never returns an over-budget projection" `Quick
+            test_never_returns_an_over_budget_projection
         ; Alcotest.test_case "leading orphan tools drop" `Quick
             test_leading_orphan_tools_drop_with_first_atom
         ; Alcotest.test_case "deterministic" `Quick test_deterministic


### PR DESCRIPTION
## 무엇

provider-bound history 의 전송량 판정을 atom **개수**에서 측정된 **바이트**로 바꾼다. RFC-0351 §3 L5 / S3 (조립 예산 배선) 의 history 소스 부분이다.

`Runtime_model_input_tail_window` 는 최근 `atoms_per_window` 배수만큼만 자르고 그 결과의 크기를 재지 않았다. atom 무게는 균일하지 않으므로 개수는 요청 크기를 구속하지 못한다.

## 근본 원인

`.mli` 의 사이징 근거는 2026-08-01 측정 2건이다 — sangsu 487 atoms / 706KB, kidsnote 442 atoms / 719KB, mean atom ≈ 1.5KB. 2026-08-04 라이브 체크포인트 11건 재측정에서 mean atom 은 0.3KB ~ 8.7KB 로 분포한다.

무거운 쪽 (keeper rondo, trace-1785189111911-00004) 실측:

| 값 | 측정 |
|---|---|
| checkpoint | 7,912,406 B / 3,321 messages / 2,033 atoms |
| 개수 규칙이 고른 전송 창 | drop 1,920 → 113 atoms → 981,356 B |
| tool schemas + system prompt | 69,181 + 9,358 B |
| 조립 추정 합계 | 1,059,895 B |
| provider 측정 거부 | `request_body_too_large(actual=1051311, limit=1048576)` |

메시지 바이트의 77.2% 가 `tool_result` 이고, 그 중 66.5% 가 `masc_keeper_waiting_inventory` 303 회 (4,059,817 B) 다. 전송 창 안에서는 774,404 B, 창의 78.9% 를 차지한다.

### 자기 잠금

실패한 턴은 history 를 늘리지 않는다. atom 수가 그대로이므로 개수 기반 cut 은 같은 위치에 머물고, 다음 요청은 바이트 단위로 동일하다. 201 개 raw-trace 파일의 run_finished 203 건 중 196 건이 `request_body_too_large` 이고, 17:39–17:44 연속 거부의 actual 은 1,051,310 → 1,051,311 로 고정되어 있다. 런타임 로테이션은 출구가 아니다 (GLM-5-Turbo 184 건, deepseek-v4-flash 12 건, 양쪽 cap 모두 1,048,576).

체크포인트 11 건 중 조립 추정이 cap 을 넘는 것은 rondo 하나뿐이다 (1,060KB vs 나머지 104–436KB).

### 해소 경위 — 기내 복구 경로는 없다

이 wedge 는 프로세스 안에서 풀리지 않았다. 2026-08-04 19:37:59 KST 에 `masc-checkpoint-purge` (오프라인 런북, `docs/CHECKPOINT-PURGE-RUNBOOK.md`) 가 실행되어 checkpoint 가 7.5MB → 2.3MB 로 줄었고 (`backups-checkpoint-purge-trace-1785189111911-00004-20260804T103759Z`), 그 이후 턴이 통과하기 시작했다. `compaction_count` 는 12 로 변하지 않았으므로 컴팩션 경로도 아니다.

즉 관측된 복구는 사람이 오프라인 도구를 돌린 결과다. purge 는 무게를 덜어낼 뿐 판정 규칙을 바꾸지 않으므로, atom 이 다시 무거워지면 같은 지점에서 재발한다.

## 무엇이 바뀌나

- `project` 는 `~measure_message_bytes ~capacity_bytes ~reserved_bytes` 를 받고 `result` 를 반환한다.
- cut 은 남은 history 가 예산에 들어가는 **가장 작은 `atoms_per_window` 배수**다. 양자화는 유지되므로 전송 prefix 는 창 안에서 byte-identical 하게 유지된다 (#26535 이 측정한 prompt-cache 재사용 조건). 어떤 배수도 들어가지 않으면 정확한 cut 으로 내려간다.
- cut 이 제거할 수 없는 바이트 — pinned (extra-system-context) 와 합성 preamble — 는 atom 을 고려하기 전에 예산에서 차감한다. 이것이 "더 버려도 줄지 않는" 무한 루프를 구조적으로 불가능하게 만든다.
- typed 거부 2 종을 추가한다. `Reservation_exceeds_capacity` (고정 비용만으로 cap 초과), `Newest_atom_exceeds_available` (단일 atom 이 예산 초과 — 분할하면 tool_result 가 그 호출과 분리되므로 거부). 둘 다 `model_input_projection` 의 `Error` 로 전달되어 OAS 가 request measurement 이전에 턴을 중단한다.
- window 적용 지점을 `Keeper_agent_run` 에서 `Keeper_turn_driver_try_provider` 로 옮긴다. 예산은 `validate_provider_request_cap` 가 런타임별로 해석하는 `max_request_body_bytes` 이므로, 런타임 선택 이전에 조립하면 어느 target 의 cap 인지 알 수 없다. window 는 기존과 동일하게 caller projection 앞에 남으므로 그 projected-prefix 선행조건은 유지된다.
- provider attempt 의 `model_input_projection` 은 이제 항상 `Some` 이다. 이전에 `None` 이던 경로 (`Keeper_turn_driver_wrappers.run_named_with_masc_tools`) 도 예산을 받는다. 예산에 들어가는 history 는 물리적으로 동일한 리스트로 반환되므로, 짧은 history 의 one-shot 호출은 동작이 바뀌지 않는다.

`atoms_per_window` 는 삭제하지 않고 cut 배치 양자로 남는다. 요청 크기를 구속하지 않으며 전송 prefix 가 얼마나 자주 바뀌는지만 정한다.

## 남는 위험

MASC 는 provider 직렬화를 소유하지 않는다. `reserved_bytes` 는 tool schema + system prompt (측정) + capacity 의 1/10 (미측정 몫: provider-specific request 필드, JSON envelope, provider 측 메시지 재구성) 이다. 이 몫이 부족하면 provider 거부는 여전히 typed 이지만 다음 조립이 같은 결과를 낸다.

이 잔여를 닫는 것은 provider 가 돌려주는 `actual_bytes`/`limit_bytes` 로 같은 턴 안에서 재조립하는 경로다 — 추정이 아니라 측정값을 쓰므로 종료가 보장된다. 별도 PR 로 분리했다. 본 PR 은 그 경로 없이도 관측된 wedge 를 해소한다.

cap 이 tool schema 크기 (실측 69–70KB) 보다 작은 runtime 은 `Reservation_exceeds_capacity` 로 매 턴 거부된다. 그런 runtime 은 본 PR 이전에도 tool schema 조차 전송할 수 없었으므로 이미 동작하지 않았고, 변경은 그 사실을 provider 거부 대신 typed 거부로 드러낸다.

## #26551 정정

이 PR 은 #26551 의 마지막 기대 계약 (*"실제 provider 요청 조립 직전에 runtime별 입력 한도로 최종 fit 을 검증한다"*) 을 구현한다.

다만 #26551 의 증상/재현 절은 원인을 `Keeper_memory_os_recall.render_snapshot` 으로 지목하는데, 실측은 그것을 반증한다. rondo checkpoint 에서 system_prompt 는 9,358 B, `context` 는 309 B, `keeper_memory_write` tool_result 전체가 7,827 B 로 전체의 0.2% 미만이다. **history 단독으로 cap 을 넘는다.** recall byte budget (#25516) 만 고쳐도 이 wedge 는 남는다.

## 검증

- `test/test_runtime_model_input_tail_window.ml` 재작성. 핵심 속성을 `fits_budget` 로 한 번 서술하고 케이스마다 재주장한다 — 반환된 리스트는 받은 예산에 들어가야 한다.
- 추가 케이스: 개수 임계 미만에서 무거운 atom 이 잘리는가 (본 결함의 회귀), 양자화 배수 유지, 예산이 유지되는 동안 cut 지점 고정, 양자화가 불가할 때 정확한 cut, pinned 바이트 선차감, typed 거부 2 종, 그리고 범위 전체에서 over-budget 결과를 반환하지 않는 종료 가드.
- 기존 구조 케이스 유지: tool_result 쌍 보존, extra-context pinning, preamble, 선행 orphan tool, 결정성.

`test_runtime_model_input_tail_window` 는 CI 실행 allowlist 에 없었다 (이 PR 이전에도). `ci.yml` 의 `request_cap_targets` 에 추가했다 — 이 그룹이 request capacity 계열의 기존 자리다. 추가만으로는 증거가 아니므로 alias 해석까지 확인했다.

로컬 실행 (base `43508b6654`):

```
dune build test/test_runtime_model_input_tail_window.exe lib/keeper   → exit 0
dune build @test/runtest-test_runtime_model_input_tail_window         → exit 0, 17 tests run
```

base 는 `2ffa4df129` 가 아니라 `43508b6654` 다. 전자에서는 `lib/schedule/schedule_store.ml:420` 의 `Unbound value wake_for_occurrence` 로 빌드가 실패하며, 이는 본 PR 범위 밖이고 #26796 이 해소했다.

RFC-WAIVED: 변경 영역 (`lib/runtime/`, `lib/keeper/keeper_turn_driver_try_provider.ml`, `lib/keeper/keeper_agent_run.ml`) 은 credential/identity/operator-control/sandbox/hooks/workflow 어디에도 해당하지 않는다. 설계 근거는 기존 RFC-0351 §3 L5 / S3 이며 신규 설계를 도입하지 않는다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
