### PR TITLE
fix(dashboard): 자율 턴 투영을 chat-history 경계에서 통과시킨다

### DIFF
--- a/dashboard/src/api/schemas/keeper-chat-history.test.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.test.ts
@@ -378,4 +378,64 @@ describe('safeParseKeeperChatHistoryMessage', () => {
     )
     expect(out).toBeNull()
   })
+
+  // The backend projects autonomous turns onto the history response
+  // (server_dashboard_http_keeper_api.ml :1043-1065). `object()` strips
+  // keys it does not declare, so before `autonomous_turn` was declared the
+  // consumer's `isRecord(message.autonomous_turn)` branch never ran and
+  // every autonomous turn rendered as an ordinary assistant bubble.
+  it('preserves the autonomous_turn projection instead of stripping it', () => {
+    const out = safeParseKeeperChatHistoryMessage(
+      validMessage({
+        id: 'autonomous:turn-42',
+        role: 'assistant',
+        content: 'checked the release branches',
+        autonomous_turn: {
+          turn_id: 'turn-42',
+          agent_name: 'oas-ollama_cloud.example',
+          generation: 3,
+          finished_at: 1_712_000_001.5,
+          model: 'example-model',
+          stop_reason: 'end_turn',
+        },
+      }),
+    )
+    expect(out).not.toBeNull()
+    expect(out?.autonomous_turn).toEqual({
+      turn_id: 'turn-42',
+      agent_name: 'oas-ollama_cloud.example',
+      generation: 3,
+      finished_at: 1_712_000_001.5,
+      model: 'example-model',
+      stop_reason: 'end_turn',
+    })
+  })
+
+  // `final_text = None` is projected as JSON null, which a required
+  // `string()` rejected — dropping exactly the turns that produced no
+  // terminal text.
+  it('accepts an autonomous turn whose content is null', () => {
+    const out = safeParseKeeperChatHistoryMessage(
+      validMessage({
+        role: 'assistant',
+        content: null,
+        autonomous_turn: { turn_id: 'turn-43', agent_name: 'oas-x', generation: 1 },
+      }),
+    )
+    expect(out).not.toBeNull()
+    expect(out?.content).toBeNull()
+  })
+
+  // A backend that adds a field to the projection must not cost the row:
+  // the consumer reads `autonomous_turn` tolerantly, as it does for
+  // `audio` and `delivery_key`.
+  it('keeps a row whose autonomous_turn carries an unrecognised field', () => {
+    const out = safeParseKeeperChatHistoryMessage(
+      validMessage({
+        role: 'assistant',
+        autonomous_turn: { turn_id: 'turn-44', agent_name: 'oas-x', generation: 1, future: 'x' },
+      }),
+    )
+    expect(out).not.toBeNull()
+  })
 })

--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -20,6 +20,7 @@ import {
   array,
   boolean,
   literal,
+  nullable,
   number,
   object,
   optional,
@@ -252,7 +253,14 @@ export const KeeperChatHistoryMessageSchema = object({
   // it is absent.
   id: optional(string()),
   role: string(),
-  content: string(),
+  // Nullable because the autonomous-turn projection emits `null` when the
+  // turn produced no terminal text (server_dashboard_http_keeper_api.ml
+  // :1055-1058 maps `final_text = None` to `` `Null ``). A required
+  // `string()` dropped those rows at this boundary even though every
+  // consumer already guards the field (`typeof message.content !==
+  // 'string'` in keeper-state.ts :1683/:1733, `?? '공개된 응답 없음'`
+  // at :1651).
+  content: nullable(string()),
   ts: number(),
   // Tool-call rows (role === 'tool') persisted by keeper_chat_store.ml
   // carry the executed tool's id/name; `content` holds the accumulated
@@ -310,6 +318,19 @@ export const KeeperChatHistoryMessageSchema = object({
   // legacy endpoints; consumers fall back to explicit "history without stream
   // events" instead of inventing a lifecycle.
   stream_contract: optional(KeeperChatHistoryStreamContractSchema),
+  // Rows the backend projected from a typed autonomous turn — a turn the
+  // keeper ran on its own, which by design writes no chat-store row
+  // (server_dashboard_http_keeper_api.ml :1043-1065 builds
+  // `{turn_id, agent_name, generation}` plus optional
+  // `finished_at`/`model`/`stop_reason`). Its presence, not `role`, marks
+  // the row so the transcript folds consecutive turns into one group.
+  // Accepted as `unknown` for the same reason as `audio` and
+  // `delivery_key`: the consumer extracts it tolerantly (`isRecord` +
+  // `asString(turn_id)` in keeper-state.ts :1647-1649), so a field added
+  // on the backend must not drop the whole row. Without this key valibot's
+  // `object()` stripped it, and the consumer's `autonomous_turn`
+  // branch was unreachable.
+  autonomous_turn: optional(unknown()),
 })
 
 export type KeeperChatHistoryMessage = InferOutput<typeof KeeperChatHistoryMessageSchema>


### PR DESCRIPTION
## 문제

백엔드는 자율 턴을 `GET /api/v1/keepers/:name/chat/history` 응답에 투영한다 (`server_dashboard_http_keeper_api.ml:1043-1065`). 그런데 dashboard의 valibot 경계가 필요한 두 필드를 **선언하지 않아** 투영이 소비자에게 도달하지 못했다.

| 필드 | 백엔드가 보내는 것 | 경계가 하던 일 | 결과 |
|---|---|---|---|
| `autonomous_turn` | `{turn_id, agent_name, generation}` + optional `finished_at`/`model`/`stop_reason` | `object()`가 미선언 키를 strip | 소비자의 `isRecord(message.autonomous_turn)` 분기(`keeper-state.ts:1647`)가 **도달 불가** |
| `content` | `final_text = None`이면 `` `Null `` (`:1055-1058`) | `string()` 필수 | 터미널 텍스트 없는 자율 턴이 **행 전체 드롭** |

`autonomous_turn`의 존재가 (role이 아니라) 자율 턴 행을 표시하므로, strip되면 접힌 그룹 대신 평범한 assistant 버블로 렌더된다.

## 변경

- `autonomous_turn: optional(unknown())` 선언. `audio`/`delivery_key`와 같은 근거 — 소비자가 `isRecord` + `asString(turn_id)`로 방어적으로 추출하므로, 백엔드가 필드를 추가해도 행 전체를 잃지 않아야 한다.
- `content: nullable(string())`. 인코더가 실제로 내보내는 것과 일치시킨다. 소비자는 이미 `typeof message.content !== 'string'`(`:1683`, `:1733`)과 `?? '공개된 응답 없음'`(`:1651`)로 방어 중이었다 — 경계만 계약보다 엄격했다.

## 검증

```
pnpm vitest run src/api/schemas/keeper-chat-history.test.ts   → 30 passed (기존 27 + 신규 3)
pnpm typecheck (tsc --noEmit)                                  → 통과
pnpm lint (eslint src)                                         → 통과
```

추가한 테스트 3건:
- `autonomous_turn` 투영이 strip되지 않고 보존되는지
- `content: null`인 자율 턴이 드롭되지 않는지
- `autonomous_turn`에 미인식 필드가 있어도 행이 살아남는지 (드리프트 내성)

## 범위 / 선행 조건

이 PR만으로는 화면이 바뀌지 않는다. 현재 라이브에서 자율 턴은 `raw_trace_run_ref = null`이라 리더(`Keeper_autonomous_turn_source.load_recent`)가 전량 폐기하고 있고, 그 원인은 `keeper_agent_run.ml:265-267`이 서로 다른 identity space(`oas-<runtime_id>` vs `keeper-<name>-agent`)를 `String.equal`로 비교하는 것이다.

- 선행: **#26786** (해당 비교 제거)
- 이 PR: 그 뒤 경계에서 투영이 통과하도록

실측: 6개 keeper turn-record 최신 50행 전부 `"raw_trace_run_ref": null` (autonomous 293/300).

RFC-WAIVED: dashboard 읽기 경계의 스키마-계약 정렬. credential/identity/operator/sandbox/hooks 어느 subsystem도 건드리지 않는다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
