### PR TITLE
fix(dashboard): show autonomous turn activity in chat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -825,8 +825,8 @@ jobs:
           chmod +x scripts/ci-run-tests.sh
           scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_turn_outcome @test/runtest-test_keeper_paused_work_transfer_transaction @test/runtest-test_keeper_paused_work_source_terminal_transaction @test/runtest-test_keeper_paused_work_operator"
 
-      - name: Run keeper autonomous public-history suite
-        id: keeper_autonomous_public_history_suite
+      - name: Run keeper autonomous chat-activity suite
+        id: keeper_autonomous_chat_activity_suite
         if: ${{ always() && steps.build_step.outcome == 'success' }}
         env:
           CI_TEST_HEARTBEAT_SEC: 15

--- a/dashboard/src/api/schemas/keeper-chat-history.test.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.test.ts
@@ -23,6 +23,26 @@ describe('safeParseKeeperChatHistoryMessage', () => {
     expect(out?.ts).toBeCloseTo(1_712_000_000.25)
   })
 
+  it('keeps autonomous identity and accepts a tool-only turn without prose', () => {
+    const out = safeParseKeeperChatHistoryMessage(
+      validMessage({
+        role: 'assistant',
+        content: null,
+        autonomous_turn: { turn_id: 'trace-a#41' },
+        blocks: [{
+          t: 'trace',
+          trace: [{ kind: 'tool', name: 'keeper_tasks_list', status: 'ok' }],
+        }],
+      }),
+    )
+    expect(out?.content).toBeNull()
+    expect(out?.autonomous_turn).toEqual({ turn_id: 'trace-a#41' })
+    expect(out?.blocks?.[0]).toEqual({
+      t: 'trace',
+      trace: [{ kind: 'tool', name: 'keeper_tasks_list', status: 'ok' }],
+    })
+  })
+
   it('accepts a typed external-effect status block with empty content', () => {
     const out = safeParseKeeperChatHistoryMessage(
       validMessage({
@@ -379,63 +399,4 @@ describe('safeParseKeeperChatHistoryMessage', () => {
     expect(out).toBeNull()
   })
 
-  // The backend projects autonomous turns onto the history response
-  // (server_dashboard_http_keeper_api.ml :1043-1065). `object()` strips
-  // keys it does not declare, so before `autonomous_turn` was declared the
-  // consumer's `isRecord(message.autonomous_turn)` branch never ran and
-  // every autonomous turn rendered as an ordinary assistant bubble.
-  it('preserves the autonomous_turn projection instead of stripping it', () => {
-    const out = safeParseKeeperChatHistoryMessage(
-      validMessage({
-        id: 'autonomous:turn-42',
-        role: 'assistant',
-        content: 'checked the release branches',
-        autonomous_turn: {
-          turn_id: 'turn-42',
-          agent_name: 'oas-ollama_cloud.example',
-          generation: 3,
-          finished_at: 1_712_000_001.5,
-          model: 'example-model',
-          stop_reason: 'end_turn',
-        },
-      }),
-    )
-    expect(out).not.toBeNull()
-    expect(out?.autonomous_turn).toEqual({
-      turn_id: 'turn-42',
-      agent_name: 'oas-ollama_cloud.example',
-      generation: 3,
-      finished_at: 1_712_000_001.5,
-      model: 'example-model',
-      stop_reason: 'end_turn',
-    })
-  })
-
-  // `final_text = None` is projected as JSON null, which a required
-  // `string()` rejected — dropping exactly the turns that produced no
-  // terminal text.
-  it('accepts an autonomous turn whose content is null', () => {
-    const out = safeParseKeeperChatHistoryMessage(
-      validMessage({
-        role: 'assistant',
-        content: null,
-        autonomous_turn: { turn_id: 'turn-43', agent_name: 'oas-x', generation: 1 },
-      }),
-    )
-    expect(out).not.toBeNull()
-    expect(out?.content).toBeNull()
-  })
-
-  // A backend that adds a field to the projection must not cost the row:
-  // the consumer reads `autonomous_turn` tolerantly, as it does for
-  // `audio` and `delivery_key`.
-  it('keeps a row whose autonomous_turn carries an unrecognised field', () => {
-    const out = safeParseKeeperChatHistoryMessage(
-      validMessage({
-        role: 'assistant',
-        autonomous_turn: { turn_id: 'turn-44', agent_name: 'oas-x', generation: 1, future: 'x' },
-      }),
-    )
-    expect(out).not.toBeNull()
-  })
 })

--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -244,6 +244,10 @@ export const KeeperChatHistoryStreamContractSchema = object({
 
 export type KeeperChatHistoryStreamContract = InferOutput<typeof KeeperChatHistoryStreamContractSchema>
 
+const KeeperAutonomousTurnSchema = object({
+  turn_id: string(),
+})
+
 export const KeeperChatHistoryMessageSchema = object({
   // R3: producer-assigned stable message id (keeper_chat_store.ml mints it
   // at append and the read boundary stamps legacy rows, so the backend now
@@ -253,13 +257,8 @@ export const KeeperChatHistoryMessageSchema = object({
   // it is absent.
   id: optional(string()),
   role: string(),
-  // Nullable because the autonomous-turn projection emits `null` when the
-  // turn produced no terminal text (server_dashboard_http_keeper_api.ml
-  // :1055-1058 maps `final_text = None` to `` `Null ``). A required
-  // `string()` dropped those rows at this boundary even though every
-  // consumer already guards the field (`typeof message.content !==
-  // 'string'` in keeper-state.ts :1683/:1733, `?? '공개된 응답 없음'`
-  // at :1651).
+  // Autonomous turns can complete through tools without terminal prose. The
+  // backend keeps that distinct as null while still projecting the work trace.
   content: nullable(string()),
   ts: number(),
   // Tool-call rows (role === 'tool') persisted by keeper_chat_store.ml
@@ -318,19 +317,7 @@ export const KeeperChatHistoryMessageSchema = object({
   // legacy endpoints; consumers fall back to explicit "history without stream
   // events" instead of inventing a lifecycle.
   stream_contract: optional(KeeperChatHistoryStreamContractSchema),
-  // Rows the backend projected from a typed autonomous turn — a turn the
-  // keeper ran on its own, which by design writes no chat-store row
-  // (server_dashboard_http_keeper_api.ml :1043-1065 builds
-  // `{turn_id, agent_name, generation}` plus optional
-  // `finished_at`/`model`/`stop_reason`). Its presence, not `role`, marks
-  // the row so the transcript folds consecutive turns into one group.
-  // Accepted as `unknown` for the same reason as `audio` and
-  // `delivery_key`: the consumer extracts it tolerantly (`isRecord` +
-  // `asString(turn_id)` in keeper-state.ts :1647-1649), so a field added
-  // on the backend must not drop the whole row. Without this key valibot's
-  // `object()` stripped it, and the consumer's `autonomous_turn`
-  // branch was unreachable.
-  autonomous_turn: optional(unknown()),
+  autonomous_turn: optional(KeeperAutonomousTurnSchema),
 })
 
 export type KeeperChatHistoryMessage = InferOutput<typeof KeeperChatHistoryMessageSchema>

--- a/dashboard/src/components/chat/autonomous-turn-group.test.ts
+++ b/dashboard/src/components/chat/autonomous-turn-group.test.ts
@@ -79,14 +79,11 @@ describe('chatHistoryEntriesFromRest — autonomous turn rows', () => {
     blocks: [{
       t: 'trace',
       trace: [
-        { kind: 'think', text: 'checking state' },
+        { kind: 'think', text: '내부 판단 단계 (내용 비공개)' },
         {
           kind: 'tool',
           name: 'keeper_tasks_list',
-          tool_call_id: 'tool-1',
           status: 'ok',
-          args: { status: 'pending' },
-          result: { tasks: [] },
         },
       ],
     }],
@@ -101,14 +98,11 @@ describe('chatHistoryEntriesFromRest — autonomous turn rows', () => {
     expect(entryOut?.text).toBe('no work this cycle')
     expect(entryOut?.blocks).toBeUndefined()
     expect(entryOut?.traceSteps).toEqual([
-      { kind: 'think', text: 'checking state' },
+      { kind: 'think', text: '내부 판단 단계 (내용 비공개)' },
       {
         kind: 'tool',
         name: 'keeper_tasks_list',
-        toolCallId: 'tool-1',
         status: 'ok',
-        args: '{\n  "status": "pending"\n}',
-        result: '{\n  "tasks": []\n}',
       },
     ])
     expect(entryOut?.turnRef).toBe('trace-test#41')
@@ -149,7 +143,9 @@ describe('chatHistoryEntriesFromRest — autonomous turn rows', () => {
     ])
     expect(absent?.text).toBe('텍스트 응답 없음')
     expect(absent?.rawText).toBeNull()
+    expect(absent?.delivery).toBe('no_reply')
     expect(empty?.text).toBe('')
     expect(empty?.rawText).toBe('')
+    expect(empty?.delivery).toBe('history')
   })
 })

--- a/dashboard/src/components/chat/autonomous-turn-group.test.ts
+++ b/dashboard/src/components/chat/autonomous-turn-group.test.ts
@@ -1,10 +1,8 @@
 // Autonomous keeper turns in the chat transcript.
 //
-// These rows have no chat-store row by design (RFC-0351 §5 keeps the wake
-// marker and inert prose out of the durable transcript); the backend projects
-// them from the raw-trace store. A keeper wakes far more often than anyone
-// talks to it, so the transcript must fold a run of them into one collapsed
-// unit instead of listing each between two sentences of conversation.
+// These rows have no chat-store row; the backend projects final text and work
+// trace from the exact recorded autonomous run. A keeper wakes far more often
+// than anyone talks to it, so consecutive turns remain collapsed.
 import { describe, expect, it } from 'vitest'
 import type { KeeperConversationEntry } from '../../types'
 import { buildChatRenderUnits } from './primitives'
@@ -75,24 +73,44 @@ describe('buildChatRenderUnits — autonomous turns', () => {
 
 describe('chatHistoryEntriesFromRest — autonomous turn rows', () => {
   const autonomousRow = {
-    id: 'autonomous:turn-1',
     role: 'assistant',
     content: 'no work this cycle',
     ts: 1785770777,
+    blocks: [{
+      t: 'trace',
+      trace: [
+        { kind: 'think', text: 'checking state' },
+        {
+          kind: 'tool',
+          name: 'keeper_tasks_list',
+          tool_call_id: 'tool-1',
+          status: 'ok',
+          args: { status: 'pending' },
+          result: { tasks: [] },
+        },
+      ],
+    }],
     autonomous_turn: {
       turn_id: 'trace-test#41',
-      agent_name: 'lane-smith-agent',
-      generation: 9,
-      model: 'GLM-5-Turbo',
-      stop_reason: 'end_turn',
     },
   }
 
-  it('projects the public outcome without raw thinking or tool arguments', () => {
+  it('projects the exact outcome and work trace', () => {
     const [entryOut] = chatHistoryEntriesFromRest('lane-smith', [autonomousRow])
     expect(entryOut?.source).toBe('autonomous_turn')
     expect(entryOut?.text).toBe('no work this cycle')
-    expect(entryOut?.traceSteps).toBeUndefined()
+    expect(entryOut?.blocks).toBeUndefined()
+    expect(entryOut?.traceSteps).toEqual([
+      { kind: 'think', text: 'checking state' },
+      {
+        kind: 'tool',
+        name: 'keeper_tasks_list',
+        toolCallId: 'tool-1',
+        status: 'ok',
+        args: '{\n  "status": "pending"\n}',
+        result: '{\n  "tasks": []\n}',
+      },
+    ])
     expect(entryOut?.turnRef).toBe('trace-test#41')
   })
 
@@ -129,7 +147,7 @@ describe('chatHistoryEntriesFromRest — autonomous turn rows', () => {
       { ...autonomousRow, id: 'absent', content: null },
       { ...autonomousRow, id: 'empty', content: '' },
     ])
-    expect(absent?.text).toBe('공개된 응답 없음')
+    expect(absent?.text).toBe('텍스트 응답 없음')
     expect(absent?.rawText).toBeNull()
     expect(empty?.text).toBe('')
     expect(empty?.rawText).toBe('')

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -3313,6 +3313,7 @@ function ToolTraceStep({
   traceStep,
   orderIndex,
   orderKind = 'tool',
+  structuralSummary = false,
 }: {
   entry: KeeperConversationEntry | null
   output: ToolCallEntry | null
@@ -3322,14 +3323,17 @@ function ToolTraceStep({
   traceStep?: ChatTraceToolStep
   orderIndex?: number
   orderKind?: 'tool' | 'tool-entry'
+  structuralSummary?: boolean
 }) {
   const [open, setOpen] = useState(false)
   const name = traceStep?.name || entry?.label || 'tool'
   const callId = toolTraceCallId(entry, traceStep)
   const displayArgs = prettyJsonish(entry?.text || traceStep?.args || '')
   const isEmptyArgs = EMPTY_ARG_TEXTS.has(displayArgs.trim())
-  const unlinkedTraceTool = isUnlinkedTraceTool(entry, traceStep)
-  const sourceBadge = toolTraceSourceBadge(entry, traceStep)
+  const unlinkedTraceTool = !structuralSummary && isUnlinkedTraceTool(entry, traceStep)
+  const sourceBadge = structuralSummary
+    ? { label: 'activity', title: 'source: autonomous activity summary', tone: 'tool' as const }
+    : toolTraceSourceBadge(entry, traceStep)
   let status: ToolTraceDisplayStatus
   if (unlinkedTraceTool) {
     status = 'unlinked'
@@ -3354,7 +3358,7 @@ function ToolTraceStep({
   const hasResult = resultView !== null && resultView.text.trim() !== ''
   // Expandable when there is anything to show: args, a result, or a still-pending
   // call (so the operator can open it and see "출력 대기 중…").
-  const hasBody = unlinkedTraceTool || !isEmptyArgs || hasResult || output === null
+  const hasBody = !structuralSummary && (unlinkedTraceTool || !isEmptyArgs || hasResult || output === null)
 
   return html`
     <div
@@ -3366,7 +3370,7 @@ function ToolTraceStep({
       data-chat-trace-tool-call-id=${callId ?? undefined}
       data-chat-trace-oas-block-index=${traceStep?.oasBlockIndex ?? undefined}
       data-chat-trace-entry-id=${entry?.id ?? undefined}
-      data-chat-trace-link-state=${unlinkedTraceTool ? 'unlinked' : entry ? 'joined' : 'trace-only'}
+      data-chat-trace-link-state=${structuralSummary ? 'structural' : unlinkedTraceTool ? 'unlinked' : entry ? 'joined' : 'trace-only'}
       data-chat-trace-output-state=${status}
       data-chat-trace-output-coverage=${coverageState}
     >
@@ -3558,6 +3562,7 @@ function ToolTraceCard({
   toolOutputHydrationContract?: ToolCallOutputHydrationContract | null
 }) {
   const liveTurn = assistant !== null && !turnComplete
+  const structuralSummary = assistant?.source === 'autonomous_turn'
   const userToggledRef = useRef(false)
   const [open, setOpen] = useState(() => !liveTurn)
   useEffect(() => {
@@ -3609,7 +3614,7 @@ function ToolTraceCard({
     (s) => s.output === null && s.entry !== null && turnComplete && coverageStateForEntry(s.entry) === 'hydration-failed',
   ).length
   const unlinkedN = orderedToolSteps.filter(
-    (s) => s.kind === 'tool' && s.entry === null && !s.step.toolCallId?.trim(),
+    (s) => !structuralSummary && s.kind === 'tool' && s.entry === null && !s.step.toolCallId?.trim(),
   ).length
   const totalMs = orderedToolSteps.reduce(
     (sum, s) => sum + (s.output?.duration_ms ?? (s.kind === 'tool' ? traceStepDurationMs(s.step.dur) : 0)),
@@ -3688,6 +3693,7 @@ function ToolTraceCard({
                           hydrationFailureReason=${toolOutputHydrationContract?.failureReason ?? null}
                           traceStep=${item.step}
                           orderIndex=${index}
+                          structuralSummary=${structuralSummary}
                           orderKind="tool"
                         />`
                       })()

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -3794,9 +3794,8 @@ function autonomousGroupSpanLabel(entries: KeeperConversationEntry[]): string | 
 /** A run of consecutive autonomous turns, collapsed into a single row. Starts
  *  closed: these turns are the keeper working on its own, and the transcript's
  *  subject is the conversation around them. Expanding renders each turn through
- *  TurnWorkBundle — the same component a direct turn uses. Public autonomous
- *  rows contain only their visible outcome; raw thinking and tool arguments
- *  never cross the history endpoint. */
+ *  TurnWorkBundle — the same component a direct turn uses. Each expanded row
+ *  renders the exact run's final text and typed work trace. */
 function AutonomousTurnGroup({
   entries,
   showMetadata,
@@ -3832,18 +3831,27 @@ function AutonomousTurnGroup({
         ${span ? html`<span class="chat-block-trace-meta">${span}</span>` : null}
       </button>
       ${open
-        ? entries.map((entry) => html`<${TurnWorkBundle}
-            key=${entry.id}
-            tools=${[]}
-            assistant=${entry}
-            showMetadata=${showMetadata}
-            variant=${variant}
-            showSourceBadge=${showSourceBadge}
-            toolOutputsCoveredSinceMs=${toolOutputsCoveredSinceMs}
-            toolOutputsCoveredThroughMs=${toolOutputsCoveredThroughMs}
-            toolOutputHydrationContract=${toolOutputHydrationContract}
-            action=${action}
-          />`)
+        ? entries.map((entry) => (entry.traceSteps?.length ?? 0) > 0
+          ? html`<${TurnWorkBundle}
+              key=${entry.id}
+              tools=${[]}
+              assistant=${entry}
+              showMetadata=${showMetadata}
+              variant=${variant}
+              showSourceBadge=${showSourceBadge}
+              toolOutputsCoveredSinceMs=${toolOutputsCoveredSinceMs}
+              toolOutputsCoveredThroughMs=${toolOutputsCoveredThroughMs}
+              toolOutputHydrationContract=${toolOutputHydrationContract}
+              action=${action}
+            />`
+          : html`<${ChatMessageSurface}
+              key=${entry.id}
+              entry=${entry}
+              showMetadata=${showMetadata !== false}
+              variant=${variant}
+              showSourceBadge=${showSourceBadge}
+              action=${action}
+            />`)
         : null}
     </div>
   `

--- a/dashboard/src/demo/keeper-autonomous-public-history-fixture.ts
+++ b/dashboard/src/demo/keeper-autonomous-public-history-fixture.ts
@@ -9,29 +9,34 @@ import { chatHistoryEntriesFromRest } from '../keeper-state'
 
 const rawHistory = [
   {
-    id: 'autonomous:trace-fixture#1',
     role: 'assistant',
-    content: 'Checked the board; no action was required.',
+    content: null,
     ts: 1785770777,
+    blocks: [{
+      t: 'trace',
+      trace: [
+        { kind: 'think', text: 'Checking the current task and pending board events.' },
+        {
+          kind: 'tool',
+          name: 'keeper_tasks_list',
+          tool_call_id: 'fixture-tool-1',
+          status: 'ok',
+          dur: '38ms',
+          args: { status: 'pending' },
+          result: { tasks: [] },
+        },
+      ],
+    }],
     autonomous_turn: {
       turn_id: 'trace-fixture#1',
-      agent_name: 'fixture-agent',
-      generation: 4,
-      blocks: [
-        { kind: 'thinking', content: 'PRIVATE_THINKING_MUST_NOT_RENDER' },
-        { kind: 'tool_use', name: 'Read', input: { token: 'PRIVATE_TOOL_ARG' } },
-      ],
     },
   },
   {
-    id: 'autonomous:trace-fixture#2',
     role: 'assistant',
     content: 'Observed one healthy follow-up.',
     ts: 1785770837,
     autonomous_turn: {
       turn_id: 'trace-fixture#2',
-      agent_name: 'fixture-agent',
-      generation: 4,
     },
   },
 ]
@@ -39,12 +44,12 @@ const rawHistory = [
 const entries = chatHistoryEntriesFromRest('fixture-keeper', rawHistory)
 const fixtureStatus =
   entries.length === 2
-  && entries.every(entry => entry.traceSteps === undefined)
+  && entries[0]?.traceSteps?.length === 2
   && entries.map(entry => entry.turnRef).join('|') === 'trace-fixture#1|trace-fixture#2'
     ? 'ok'
     : 'invalid'
 
-function AutonomousPublicHistoryFixture() {
+function AutonomousTurnActivityFixture() {
   return html`
     <main
       class="min-h-screen px-4 py-8"
@@ -55,10 +60,10 @@ function AutonomousPublicHistoryFixture() {
       <section class="mx-auto max-w-[820px]">
         <header class="mb-5">
           <p class="font-mono text-2xs uppercase tracking-[0.2em]" style="color: var(--text-dim);">
-            Keeper Autonomous Public History Contract
+            Keeper Autonomous Turn Activity
           </p>
           <h1 class="mt-2 text-xl font-semibold" style="color: var(--text-main);">
-            Public outcomes only
+            Exact work shown with each autonomous turn
           </h1>
         </header>
         <div
@@ -80,4 +85,4 @@ function AutonomousPublicHistoryFixture() {
 }
 
 const root = document.getElementById('app')
-if (root) render(html`<${AutonomousPublicHistoryFixture} />`, root)
+if (root) render(html`<${AutonomousTurnActivityFixture} />`, root)

--- a/dashboard/src/demo/keeper-autonomous-public-history-fixture.ts
+++ b/dashboard/src/demo/keeper-autonomous-public-history-fixture.ts
@@ -15,15 +15,12 @@ const rawHistory = [
     blocks: [{
       t: 'trace',
       trace: [
-        { kind: 'think', text: 'Checking the current task and pending board events.' },
+        { kind: 'think', text: '내부 판단 단계 (내용 비공개)' },
         {
           kind: 'tool',
           name: 'keeper_tasks_list',
-          tool_call_id: 'fixture-tool-1',
           status: 'ok',
           dur: '38ms',
-          args: { status: 'pending' },
-          result: { tasks: [] },
         },
       ],
     }],

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -1630,16 +1630,12 @@ interface RestChatHistoryMessage {
   // prefers them over its local parser.
   blocks?: unknown
   stream_contract?: unknown
-  // Present only on rows the backend projected from a typed autonomous turn
-  // (Keeper_autonomous_turn_source): a turn the keeper ran on its own, which
-  // by design has no chat-store row. Its presence, not `role`, marks the row.
+  // Present only on rows projected from a typed autonomous turn. Its presence,
+  // not `role`, marks the row; [blocks] carries that exact run's work trace.
   autonomous_turn?: unknown
 }
 
-/** Convert a current-record autonomous turn into a conversation entry.
- *  Marked `autonomous_turn` so the transcript folds consecutive ones into a
- *  single collapsed group: a keeper wakes far more often than anyone talks to
- *  it, and listing each turn inline would bury the conversation. */
+/** Convert a current-record autonomous turn into a conversation entry. */
 function autonomousTurnEntry(
   keeperName: string,
   message: RestChatHistoryMessage,
@@ -1648,14 +1644,20 @@ function autonomousTurnEntry(
   const turnId = asString(message.autonomous_turn.turn_id)
   if (!turnId) return null
   const timestamp = toIsoTimestamp(message.ts)
-  const publicText = message.content ?? '공개된 응답 없음'
+  const text = message.content ?? '텍스트 응답 없음'
+  const normalizedBlocks = normalizeBlocks(message.blocks, 'assistant')
+  const traceSteps = normalizedBlocks
+    ?.flatMap(block => block.t === 'trace' ? block.trace : [])
+  const blocks = normalizedBlocks?.filter(block => block.t !== 'trace')
   return {
-    id: message.id ?? `autonomous-${turnId}`,
+    id: `autonomous-${turnId}`,
     role: 'assistant',
     source: 'autonomous_turn',
     label: keeperName,
-    text: publicText,
+    text,
     rawText: message.content,
+    blocks: blocks && blocks.length > 0 ? blocks : undefined,
+    traceSteps: traceSteps && traceSteps.length > 0 ? traceSteps : undefined,
     timestamp,
     delivery: 'history',
     streamState: null,
@@ -1663,8 +1665,6 @@ function autonomousTurnEntry(
       reason: 'autonomous turns are projected from typed records and exact retained traces, never streamed',
     }),
     details: null,
-    // The public projection intentionally carries no raw thinking or tool
-    // arguments. The typed record owns the exact turn reference.
     surface: null,
     turnRef: turnId,
   }

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -1659,7 +1659,7 @@ function autonomousTurnEntry(
     blocks: blocks && blocks.length > 0 ? blocks : undefined,
     traceSteps: traceSteps && traceSteps.length > 0 ? traceSteps : undefined,
     timestamp,
-    delivery: 'history',
+    delivery: message.content === null ? 'no_reply' : 'history',
     streamState: null,
     streamContract: keeperStreamContract('rest_history', 'history_without_stream_events', {
       reason: 'autonomous turns are projected from typed records and exact retained traces, never streamed',

--- a/docs/rfc/RFC-0358-autonomous-turn-kind-on-turn-record.md
+++ b/docs/rfc/RFC-0358-autonomous-turn-kind-on-turn-record.md
@@ -28,12 +28,13 @@ identity가 record의 agent/trace identity와 다르면 현재 record로 인정�
 
 `Keeper_autonomous_turn_source`는 최신 current-schema turn record를 index로
 사용하고 `turn_kind = Autonomous`인 row만 선택한다. 본문은 그 row가 가리키는
-단일 exact run을 `Raw_trace_query.summarize_run`으로 읽는다. 한 파일의 여러
-provider run을 합치지 않는다.
+단일 exact run을 `Raw_trace_query.read_run`으로 읽고 허용된 activity field만
+투영한다. 한 파일의 여러 provider run을 합치지 않는다.
 
-Public `/chat/history`에는 final text, timestamp, model, stop reason,
-`turn_ref`, agent identity, generation만 투영한다. Raw thinking, assistant
-blocks, tool arguments, tool results는 이 surface에 존재하지 않는다.
+Public `/chat/history`에는 final text, timestamp, `turn_ref`와 exact run의
+content-free activity trace만 투영한다. Activity trace는 thinking 단계의 존재와
+timestamp, tool name/status/duration만 포함한다. Raw thinking, assistant blocks,
+tool call id, tool arguments, tool results는 이 surface에 존재하지 않는다.
 
 Raw trace path는 해당 keeper의 `raw-traces` directory에 있는 regular JSONL
 file이어야 한다. 다른 경로, 삭제된 file, incompatible record, summary failure는
@@ -56,6 +57,7 @@ projection이며 keeper prompt 입력이 아니다.
 
 - 직접 사용자가 wake marker와 같은 text를 보내도 `Direct` record는 제외한다.
 - 한 trace file에 여러 provider run이 있어도 record가 지목한 run만 투영한다.
-- Public autonomous row에는 thinking/tool block field가 없다.
+- Public autonomous row의 activity trace에는 raw thinking, tool call id,
+  arguments, result가 없다.
 - Agent/session identity mismatch와 keeper trace directory 밖 path를 거부한다.
 - Autonomous row volume은 200개의 direct conversation slot을 소비하지 않는다.

--- a/lib/keeper/keeper_autonomous_turn_source.ml
+++ b/lib/keeper/keeper_autonomous_turn_source.ml
@@ -1,16 +1,12 @@
-(* Public dashboard read model for autonomous keeper turns. Turn identity is
-   producer-owned in Turn_record; raw traces supply only the final public
-   response for that exact recorded OAS run. *)
+(* Dashboard read model for autonomous keeper turns. Turn identity is
+   producer-owned in Turn_record; raw traces supply the final response and
+   typed work trace for that exact recorded OAS run. *)
 
 type turn =
   { turn_id : string
-  ; agent_name : string
-  ; generation : int
   ; started_at : float
-  ; finished_at : float option
-  ; model : string option
-  ; stop_reason : string option
   ; final_text : string option
+  ; trace : Keeper_chat_blocks.trace_step list
   }
 
 let default_limit = 200
@@ -43,6 +39,60 @@ let check_trace_file ~dir path =
     | exception Unix.Unix_error _ -> Missing_or_non_regular
 ;;
 
+let non_blank value =
+  let value = String.trim value in
+  if String.equal value "" then None else Some value
+;;
+
+let json_of_text value =
+  try Yojson.Safe.from_string value with
+  | Yojson.Json_error _ -> `String value
+;;
+
+let trace_step_of_trajectory = function
+  | Agent_sdk.Trajectory.Think { content; ts } ->
+    Option.map
+      (fun text ->
+        Keeper_chat_blocks.Trace_think
+          { text
+          ; ts = Some (Masc_domain.iso8601_of_unix_seconds ts)
+          ; oas_block_index = None
+          })
+      (non_blank content)
+  | Agent_sdk.Trajectory.Act { tool_call; _ } ->
+    let status =
+      match tool_call.finished_at, tool_call.is_error with
+      | None, _ -> Some Keeper_chat_blocks.Trace_tool_pending
+      | Some _, true -> Some Keeper_chat_blocks.Trace_tool_err
+      | Some _, false -> Some Keeper_chat_blocks.Trace_tool_ok
+    in
+    let dur =
+      Option.map
+        (fun finished_at ->
+          let elapsed_ms =
+            max 0
+              (int_of_float
+                 (((finished_at -. tool_call.started_at) *. 1000.) +. 0.5))
+          in
+          Printf.sprintf "%dms" elapsed_ms)
+        tool_call.finished_at
+    in
+    Some
+      (Keeper_chat_blocks.Trace_tool
+         { name = tool_call.tool_name
+         ; tool_call_id = non_blank tool_call.tool_use_id
+         ; status
+         ; dur
+         ; args = Some tool_call.tool_input
+         ; result = Option.map json_of_text tool_call.tool_result
+         ; ts =
+             Some
+               (Masc_domain.iso8601_of_unix_seconds tool_call.started_at)
+         ; oas_block_index = None
+         })
+  | Agent_sdk.Trajectory.Observe _ | Agent_sdk.Trajectory.Respond _ -> None
+;;
+
 let turn_of_record ~config ~keeper_name (record : Turn_record.t) =
   match record.turn_kind, record.raw_trace_run_ref with
   | Turn_record.Direct, _ -> None
@@ -73,31 +123,37 @@ let turn_of_record ~config ~keeper_name (record : Turn_record.t) =
           run_ref.path;
         None
       | Current_regular_file ->
-        (match Agent_sdk.Raw_trace_query.summarize_run (sdk_run_ref run_ref) with
+        (match Agent_sdk.Raw_trace_query.read_run (sdk_run_ref run_ref) with
          | Error err ->
            Log.Keeper.warn ~keeper_name
-             "autonomous turn source: cannot summarize exact run %s: %s"
+             "autonomous turn source: cannot read exact run %s: %s"
              run_ref.worker_run_id
              (Agent_sdk.Error.to_string err);
            None
-         | Ok summary ->
-           (match summary.started_at with
-            | None ->
-              Log.Keeper.warn ~keeper_name
-                "autonomous turn source: exact run %s has no start timestamp"
-                run_ref.worker_run_id;
-              None
-            | Some started_at ->
-              Some
-                { turn_id = Ids.Turn_ref.to_string record.turn_ref
-                ; agent_name = record.agent_name
-                ; generation = record.generation
-                ; started_at
-                ; finished_at = summary.finished_at
-                ; model = record.model
-                ; stop_reason = record.finish_reason
-                ; final_text = summary.final_text
-                }))
+         | Ok [] ->
+           Log.Keeper.warn ~keeper_name
+             "autonomous turn source: exact run %s has no records"
+             run_ref.worker_run_id;
+           None
+         | Ok ((first : Agent_sdk.Raw_trace.record) :: _ as records) ->
+           let final_text =
+             records
+             |> List.rev
+             |> List.find_opt (fun (row : Agent_sdk.Raw_trace.record) ->
+               row.record_type = Agent_sdk.Raw_trace.Run_finished)
+             |> Option.bind (fun row -> row.final_text)
+           in
+           let trace =
+             Agent_sdk.Trajectory.of_raw_trace_records records
+             |> fun trajectory -> trajectory.steps
+             |> List.filter_map trace_step_of_trajectory
+           in
+           Some
+             { turn_id = Ids.Turn_ref.to_string record.turn_ref
+             ; started_at = first.ts
+             ; final_text
+             ; trace
+             })
 ;;
 
 let load_recent ~config ~keeper_name ?(limit = default_limit) ?since () =

--- a/lib/keeper/keeper_autonomous_turn_source.ml
+++ b/lib/keeper/keeper_autonomous_turn_source.ml
@@ -141,7 +141,8 @@ let turn_of_record ~config ~keeper_name (record : Turn_record.t) =
              |> List.rev
              |> List.find_opt (fun (row : Agent_sdk.Raw_trace.record) ->
                row.record_type = Agent_sdk.Raw_trace.Run_finished)
-             |> Option.bind (fun row -> row.final_text)
+             |> Option.map (fun row -> row.final_text)
+             |> Option.join
            in
            let trace =
              Agent_sdk.Trajectory.of_raw_trace_records records

--- a/lib/keeper/keeper_autonomous_turn_source.ml
+++ b/lib/keeper/keeper_autonomous_turn_source.ml
@@ -141,7 +141,7 @@ let turn_of_record ~config ~keeper_name (record : Turn_record.t) =
              |> List.rev
              |> List.find_opt (fun (row : Agent_sdk.Raw_trace.record) ->
                row.record_type = Agent_sdk.Raw_trace.Run_finished)
-             |> Option.map (fun row -> row.final_text)
+             |> Option.map (fun (row : Agent_sdk.Raw_trace.record) -> row.final_text)
              |> Option.join
            in
            let trace =

--- a/lib/keeper/keeper_autonomous_turn_source.ml
+++ b/lib/keeper/keeper_autonomous_turn_source.ml
@@ -1,6 +1,6 @@
 (* Dashboard read model for autonomous keeper turns. Turn identity is
-   producer-owned in Turn_record; raw traces supply the final response and
-   typed work trace for that exact recorded OAS run. *)
+   producer-owned in Turn_record; the exact raw trace supplies the final
+   response and a content-free activity projection for that recorded OAS run. *)
 
 type turn =
   { turn_id : string
@@ -39,26 +39,14 @@ let check_trace_file ~dir path =
     | exception Unix.Unix_error _ -> Missing_or_non_regular
 ;;
 
-let non_blank value =
-  let value = String.trim value in
-  if String.equal value "" then None else Some value
-;;
-
-let json_of_text value =
-  try Yojson.Safe.from_string value with
-  | Yojson.Json_error _ -> `String value
-;;
-
 let trace_step_of_trajectory = function
-  | Agent_sdk.Trajectory.Think { content; ts } ->
-    Option.map
-      (fun text ->
-        Keeper_chat_blocks.Trace_think
-          { text
-          ; ts = Some (Masc_domain.iso8601_of_unix_seconds ts)
-          ; oas_block_index = None
-          })
-      (non_blank content)
+  | Agent_sdk.Trajectory.Think { ts; _ } ->
+    Some
+      (Keeper_chat_blocks.Trace_think
+         { text = "내부 판단 단계 (내용 비공개)"
+         ; ts = Some (Masc_domain.iso8601_of_unix_seconds ts)
+         ; oas_block_index = None
+         })
   | Agent_sdk.Trajectory.Act { tool_call; _ } ->
     let status =
       match tool_call.finished_at, tool_call.is_error with
@@ -80,11 +68,11 @@ let trace_step_of_trajectory = function
     Some
       (Keeper_chat_blocks.Trace_tool
          { name = tool_call.tool_name
-         ; tool_call_id = non_blank tool_call.tool_use_id
+         ; tool_call_id = None
          ; status
          ; dur
-         ; args = Some tool_call.tool_input
-         ; result = Option.map json_of_text tool_call.tool_result
+         ; args = None
+         ; result = None
          ; ts =
              Some
                (Masc_domain.iso8601_of_unix_seconds tool_call.started_at)

--- a/lib/keeper/keeper_autonomous_turn_source.mli
+++ b/lib/keeper/keeper_autonomous_turn_source.mli
@@ -1,27 +1,20 @@
-(** Public dashboard read model for autonomous keeper turns.
+(** Dashboard read model for autonomous keeper turns.
 
     The current {!Turn_record.t} owns the closed turn kind, keeper/agent
     identity, generation, and exact OAS raw-trace run reference. This reader
-    selects only [Autonomous] records and summarizes only that recorded run.
-    It never scans or concatenates provider runs and never projects thinking,
-    tool arguments, tool results, or other raw trace blocks onto the public
-    chat endpoint. *)
+    selects only [Autonomous] records and projects only that recorded run.
+    Final text and typed execution steps come from the same exact raw trace;
+    it never scans or concatenates provider runs. *)
 
 type turn =
   { turn_id : string
-  ; agent_name : string
-  ; generation : int
   ; started_at : float
-  ; finished_at : float option
-  ; model : string option
-  ; stop_reason : string option
   ; final_text : string option
+  ; trace : Keeper_chat_blocks.trace_step list
   }
 
 val default_limit : int
-(** Newest current-schema turn records inspected per request. Raw trace file
-    retention uses the same bound, so the endpoint does not imply reach beyond
-    the files the writer keeps. *)
+(** Newest current-schema turn records inspected per request. *)
 
 val load_recent :
   config:Workspace.config ->

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1035,34 +1035,29 @@ let keeper_chat_history_freshness config name =
   Printf.sprintf "%s|%s|%s" chat_stamp trace_stamp turn_record_stamp
 ;;
 
-(* An autonomous turn is not a chat row and must not become one (see
-   {!Keeper_autonomous_turn_source}): it carries [autonomous_turn] so the
-   dashboard groups it instead of rendering it as conversation. [content]
-   repeats the terminal text so a client that ignores the field shows the
-   turn's outcome rather than an empty bubble. *)
+(* An autonomous turn is not a chat-store row (see
+   {!Keeper_autonomous_turn_source}): this read projection carries a typed
+   [autonomous_turn] identity so the dashboard groups it separately from
+   conversation. Final text and work trace come from the same exact OAS run. *)
 let autonomous_turn_json (turn : Keeper_autonomous_turn_source.turn) =
-  let optional_fields =
-    List.filter_map Fun.id
-      [ Option.map (fun ts -> "finished_at", `Float ts) turn.finished_at
-      ; Option.map (fun model -> "model", `String model) turn.model
-      ; Option.map (fun reason -> "stop_reason", `String reason) turn.stop_reason
-      ]
+  let trace_fields =
+    match turn.trace with
+    | [] -> []
+    | trace ->
+      [ ( "blocks"
+        , Keeper_chat_blocks.blocks_to_yojson
+            [ Keeper_chat_blocks.Trace { trace } ] ) ]
   in
   `Assoc
-    [ "id", `String ("autonomous:" ^ turn.turn_id)
-    ; "role", `String "assistant"
-    ; "ts", `Float turn.started_at
-    ; ( "content"
-      , match turn.final_text with
-        | Some text -> `String text
-        | None -> `Null )
-    ; ( "autonomous_turn"
-      , `Assoc
-          (("turn_id", `String turn.turn_id)
-           :: ("agent_name", `String turn.agent_name)
-           :: ("generation", `Int turn.generation)
-           :: optional_fields) )
-    ]
+    ([ "role", `String "assistant"
+     ; "ts", `Float turn.started_at
+     ; ( "content"
+       , match turn.final_text with
+         | Some text -> `String text
+         | None -> `Null )
+     ; "autonomous_turn", `Assoc [ "turn_id", `String turn.turn_id ]
+     ]
+     @ trace_fields)
 ;;
 
 let keeper_chat_history_json config name =

--- a/scripts/harness_dashboard_keeper_autonomous_public_history_dom_smoke.sh
+++ b/scripts/harness_dashboard_keeper_autonomous_public_history_dom_smoke.sh
@@ -63,19 +63,20 @@ with sync_playwright() as playwright:
         group = page.locator('.chat-block-trace-hd', has_text='자율턴')
         assert group.get_attribute("aria-expanded") == "false"
         before = page.locator("body").inner_text()
-        assert "Checking the current task" not in before
+        assert "내부 판단 단계" not in before
         assert "keeper_tasks_list" not in before
         group.click()
         assert group.get_attribute("aria-expanded") == "true"
         page.get_by_text("텍스트 응답 없음", exact=True).last.wait_for()
         page.get_by_text("Observed one healthy follow-up.", exact=True).last.wait_for()
-        page.get_by_text("Checking the current task and pending board events.", exact=True).wait_for()
+        page.get_by_text("내부 판단 단계 (내용 비공개)", exact=True).wait_for()
         activity = page.locator('[data-chat-work-trace]')
         tool = activity.locator('[data-chat-trace-step="tool"]')
         assert "keeper_tasks_list" in tool.inner_text()
-        tool.locator('.chat-block-tstep-row').click()
-        page.get_by_text('"status": "pending"', exact=False).wait_for()
-        page.get_by_text('"tasks": []', exact=False).wait_for()
+        assert tool.get_attribute("data-chat-trace-link-state") == "structural"
+        assert "조인 불가" not in page.locator("body").inner_text()
+        assert '"status": "pending"' not in page.locator("body").inner_text()
+        assert '"tasks": []' not in page.locator("body").inner_text()
         page.screenshot(path=screenshot, full_page=True)
     finally:
         browser.close()

--- a/scripts/harness_dashboard_keeper_autonomous_public_history_dom_smoke.sh
+++ b/scripts/harness_dashboard_keeper_autonomous_public_history_dom_smoke.sh
@@ -7,7 +7,7 @@ HOST="${HOST:-127.0.0.1}"
 PORT="${PORT:-5188}"
 FIXTURE_URL="http://${HOST}:${PORT}/dashboard/dev-fixtures/keeper-autonomous-public-history-fixture.html"
 SERVER_LOG="${TMPDIR:-/tmp}/masc-autonomous-public-history-vite-${PORT}.log"
-SCREENSHOT="${TMPDIR:-/tmp}/masc-autonomous-public-history-expanded.png"
+SCREENSHOT="${TMPDIR:-/tmp}/masc-autonomous-turn-activity-expanded.png"
 
 server_pid=""
 cleanup() {
@@ -63,19 +63,23 @@ with sync_playwright() as playwright:
         group = page.locator('.chat-block-trace-hd', has_text='자율턴')
         assert group.get_attribute("aria-expanded") == "false"
         before = page.locator("body").inner_text()
-        assert "PRIVATE_THINKING_MUST_NOT_RENDER" not in before
-        assert "PRIVATE_TOOL_ARG" not in before
+        assert "Checking the current task" not in before
+        assert "keeper_tasks_list" not in before
         group.click()
         assert group.get_attribute("aria-expanded") == "true"
-        page.get_by_text("Checked the board; no action was required.", exact=True).last.wait_for()
+        page.get_by_text("텍스트 응답 없음", exact=True).last.wait_for()
         page.get_by_text("Observed one healthy follow-up.", exact=True).last.wait_for()
-        after = page.locator("body").inner_text()
-        assert "PRIVATE_THINKING_MUST_NOT_RENDER" not in after
-        assert "PRIVATE_TOOL_ARG" not in after
+        page.get_by_text("Checking the current task and pending board events.", exact=True).wait_for()
+        activity = page.locator('[data-chat-work-trace]')
+        tool = activity.locator('[data-chat-trace-step="tool"]')
+        assert "keeper_tasks_list" in tool.inner_text()
+        tool.locator('.chat-block-tstep-row').click()
+        page.get_by_text('"status": "pending"', exact=False).wait_for()
+        page.get_by_text('"tasks": []', exact=False).wait_for()
         page.screenshot(path=screenshot, full_page=True)
     finally:
         browser.close()
 PY
 
-printf 'autonomous public history interaction passed\n'
+printf 'autonomous turn activity interaction passed\n'
 printf 'screenshot=%s\n' "${SCREENSHOT}"

--- a/test/test_keeper_autonomous_turn_source.ml
+++ b/test/test_keeper_autonomous_turn_source.ml
@@ -180,16 +180,13 @@ let test_projects_exact_run_outcome_and_activity () =
      | [ Keeper_chat_blocks.Trace_think thinking
        ; Keeper_chat_blocks.Trace_tool tool
        ] ->
-       Alcotest.(check string) "thinking from selected run"
-         "private chain of thought" thinking.text;
+       Alcotest.(check string) "thinking content is not public"
+         "내부 판단 단계 (내용 비공개)" thinking.text;
        Alcotest.(check string) "tool name" "Read" tool.name;
-       Alcotest.(check (option string)) "tool id"
-         (Some "tool-run-selected") tool.tool_call_id;
+       Alcotest.(check (option string)) "tool id is not public" None tool.tool_call_id;
        Alcotest.(check (option string)) "tool duration" (Some "1000ms") tool.dur;
-       Alcotest.(check bool) "tool input" true
-         (tool.args = Some (`Assoc [ "path", `String "secret.ml" ]));
-       Alcotest.(check bool) "tool result" true
-         (tool.result = Some (`Assoc [ "files", `List [ `String "target.ml" ] ]))
+       Alcotest.(check bool) "tool input is not public" true (tool.args = None);
+       Alcotest.(check bool) "tool result is not public" true (tool.result = None)
      | trace ->
        Alcotest.failf "expected think + tool trace, got %d step(s)"
          (List.length trace))

--- a/test/test_keeper_autonomous_turn_source.ml
+++ b/test/test_keeper_autonomous_turn_source.ml
@@ -84,7 +84,6 @@ let run_lines ~worker_run_id ~start_seq ~base_ts ~prompt ~final_text =
       ; "tool_planned_index", `Int 0
       ; "tool_batch_index", `Int 0
       ; "tool_batch_size", `Int 1
-      ; "tool_execution_mode", `String "serial"
       ]
   ; raw_record ~worker_run_id ~seq:(start_seq + 4) ~ts:(base_ts +. 4.)
       ~record_type:Agent_sdk.Raw_trace.Run_finished

--- a/test/test_keeper_autonomous_turn_source.ml
+++ b/test/test_keeper_autonomous_turn_source.ml
@@ -1,4 +1,4 @@
-(** Exact-run and public-redaction guards for Keeper_autonomous_turn_source. *)
+(** Exact-run activity projection guards for Keeper_autonomous_turn_source. *)
 
 open Masc
 
@@ -75,6 +75,18 @@ let run_lines ~worker_run_id ~start_seq ~base_ts ~prompt ~final_text =
       ; "tool_execution_mode", `String "serial"
       ]
   ; raw_record ~worker_run_id ~seq:(start_seq + 3) ~ts:(base_ts +. 3.)
+      ~record_type:Agent_sdk.Raw_trace.Tool_execution_finished
+      [ "tool_name", `String "Read"
+      ; "tool_result", `String {|{"files":["target.ml"]}|}
+      ; "tool_error", `Bool false
+      ; "tool_use_id", `String ("tool-" ^ worker_run_id)
+      ; "tool_turn", `Int 1
+      ; "tool_planned_index", `Int 0
+      ; "tool_batch_index", `Int 0
+      ; "tool_batch_size", `Int 1
+      ; "tool_execution_mode", `String "serial"
+      ]
+  ; raw_record ~worker_run_id ~seq:(start_seq + 4) ~ts:(base_ts +. 4.)
       ~record_type:Agent_sdk.Raw_trace.Run_finished
       [ "final_text", `String final_text; "stop_reason", `String "end_turn" ]
   ]
@@ -94,7 +106,7 @@ let run_ref ~path ~worker_run_id ~start_seq =
   { Turn_record.worker_run_id
   ; path
   ; start_seq
-  ; end_seq = start_seq + 3
+  ; end_seq = start_seq + 4
   ; agent_name
   ; session_id = trace_id
   }
@@ -147,7 +159,7 @@ let trace_path config suffix =
   Filename.concat (ensure_trace_dir config) ("turn-0000000000000-" ^ suffix ^ ".jsonl")
 ;;
 
-let test_projects_only_public_exact_run () =
+let test_projects_exact_run_outcome_and_activity () =
   with_workspace @@ fun config ->
   let path = trace_path config "exact" in
   let first = run_lines ~worker_run_id:"run-first" ~start_seq:1 ~base_ts:1000.
@@ -161,11 +173,26 @@ let test_projects_only_public_exact_run () =
   match Keeper_autonomous_turn_source.load_recent ~config ~keeper_name () with
   | [ turn ] ->
     Alcotest.(check string) "typed turn ref" "trace-test-0000#41" turn.turn_id;
-    Alcotest.(check string) "agent identity" agent_name turn.agent_name;
-    Alcotest.(check int) "generation" 9 turn.generation;
     Alcotest.(check (option string)) "only selected run outcome"
       (Some "selected outcome") turn.final_text;
-    Alcotest.(check (float 0.001)) "selected run timestamp" 2000. turn.started_at
+    Alcotest.(check (float 0.001)) "selected run timestamp" 2000. turn.started_at;
+    (match turn.trace with
+     | [ Keeper_chat_blocks.Trace_think thinking
+       ; Keeper_chat_blocks.Trace_tool tool
+       ] ->
+       Alcotest.(check string) "thinking from selected run"
+         "private chain of thought" thinking.text;
+       Alcotest.(check string) "tool name" "Read" tool.name;
+       Alcotest.(check (option string)) "tool id"
+         (Some "tool-run-selected") tool.tool_call_id;
+       Alcotest.(check (option string)) "tool duration" (Some "1000ms") tool.dur;
+       Alcotest.(check bool) "tool input" true
+         (tool.args = Some (`Assoc [ "path", `String "secret.ml" ]));
+       Alcotest.(check bool) "tool result" true
+         (tool.result = Some (`Assoc [ "files", `List [ `String "target.ml" ] ]))
+     | trace ->
+       Alcotest.failf "expected think + tool trace, got %d step(s)"
+         (List.length trace))
   | turns -> Alcotest.failf "expected one exact turn, got %d" (List.length turns)
 ;;
 
@@ -219,8 +246,8 @@ let test_since_and_limit_use_current_records () =
 let () =
   Alcotest.run "keeper_autonomous_turn_source"
     [ ( "load_recent"
-      , [ Alcotest.test_case "projects only the exact public run" `Quick
-            test_projects_only_public_exact_run
+      , [ Alcotest.test_case "projects exact run outcome and activity" `Quick
+            test_projects_exact_run_outcome_and_activity
         ; Alcotest.test_case "typed direct kind defeats marker spoof" `Quick
             test_direct_marker_spoof_is_excluded
         ; Alcotest.test_case "rejects trace paths outside keeper store" `Quick


### PR DESCRIPTION
## What changed

- project each typed autonomous turn's exact OAS run into Dashboard Chat with final text and a content-free activity timeline
- show reasoning-stage presence plus tool name/status/duration, while keeping raw thinking, tool call IDs, arguments, and results out of public history
- preserve `autonomous_turn.turn_id` and tool-only `content: null` rows at the REST schema boundary
- render the activity in the existing `TurnWorkBundle` instead of a duplicate trace card
- remove unused autonomous history metadata and the duplicate top-level row id

## Root cause

`GET /api/v1/keepers/:name/chat/history` added autonomous rows, but the dashboard schema did not declare `autonomous_turn`, so Valibot stripped the discriminator. Rows without terminal prose were dropped because the schema rejected `content: null`. The backend projection also retained only the final text, so Dashboard Chat could not show what the admitted turn did.

## Public boundary

RFC-0358 now permits only a content-free activity projection from the exact run: reasoning-stage presence/timestamp and tool name/status/duration. Raw thinking, assistant blocks, tool call IDs, arguments, and results remain absent. A tool-only turn uses the existing typed `no_reply` delivery state, so the timeline does not fabricate a Chat step.

## Validation

- `ocamlformat --check` on touched OCaml files: passed
- dashboard typecheck, lint, and production build: passed
- focused schema tests: 38 passed
- keeper-state/chat primitive tests: 221 passed
- Playwright interaction: collapsed autonomous group -> expanded safe activity timeline; passed with screenshot
- latest-head CI run `30917560493`: passed, including `Build and Test` and the dedicated keeper autonomous chat-activity suite

Local focused Dune execution is not claimed green: `scripts/dune-local.sh` correctly refused while unrelated bare Dune processes own the machine-wide lock. CI is the OCaml build authority.
