### PR TITLE
fix(schedule): restore the wake-signal wire encoder export (main red)

### DIFF
--- a/lib/schedule/schedule_runner.mli
+++ b/lib/schedule/schedule_runner.mli
@@ -80,6 +80,11 @@ val dispatch_status_to_string : dispatch_status -> string
 
 val signals_dir : Workspace_utils.config -> string
 
+val wake_signal_to_yojson : wake_signal -> Yojson.Safe.t
+(** Durable encoding of an emitted wake signal. {!tick} appends exactly this
+    to the signal store, so it is the wire shape a consumer decodes and the
+    shape a wire-contract test asserts against — not an internal helper. *)
+
 val wake_signal_of_yojson : Yojson.Safe.t -> (wake_signal, string) result
 
 val tick :


### PR DESCRIPTION
## 무엇

`main` 이 red 다. `Schedule_runner.wake_signal_to_yojson` 의 `.mli` export 를 복원한다.

```
Error: Unbound value Schedule_runner.wake_signal_to_yojson
  test/test_schedule_tool_wiring.ml:502
```

CI 의 `Build and Test` 는 `dune build @default @check @install` 로 **모든 테스트를 컴파일**하므로, 이 한 줄이 저장소의 모든 PR 을 막는다.

## 근본 원인

#26796 (`43508b6654 refactor(schedule): remove zombie surfaces`) 가 `lib/schedule/schedule_runner.mli` 에서 `val wake_signal_to_yojson` 을 제거했다. 이 함수는 zombie 가 아니다:

| 위치 | 역할 |
|---|---|
| `schedule_runner.ml:126` | 정의 |
| `schedule_runner.ml:226` | `Dated_jsonl.append (signal_store config) (wake_signal_to_yojson signal)` — **durable 기록의 인코더** |
| `test_schedule_tool_wiring.ml:502` | `check int "signal field count" 8` — **wire shape 계약 테스트** |

즉 emitted wake signal 이 signal store 에 남는 형태가 이 인코더의 출력이고, 테스트는 그 필드 수를 고정한다. 소비자가 디코드하는 wire 자체다.

역함수 `wake_signal_of_yojson` 은 같은 `.mli` 에 남아 있다. 인코더만 빠진 **비대칭**이 의도적 축소가 아니라 누락임을 가리킨다 — 디코더의 대상이 무엇인지 선언하는 짝이 사라졌다.

## 무엇이 바뀌나

`.mli` 에 `val wake_signal_to_yojson : wake_signal -> Yojson.Safe.t` 를 디코더 바로 앞에 복원하고, 왜 내부 헬퍼가 아닌지(durable wire 이며 계약 테스트의 대상) 주석으로 남긴다. `.ml` 은 그대로다.

## 이력

이 파손은 연쇄의 두 번째다. 직전 `2ffa4df129` 에서는 `lib/schedule/schedule_store.ml:420` 이 `Unbound value wake_for_occurrence` 로 깨져 있었고 #26796 이 그것을 해소하면서 본 파손을 만들었다. surface 축소 PR 은 제거 대상의 소비자를 `@check` 로 확인해야 한다 — `@default` 만으로는 실행되지 않는 테스트의 컴파일 실패가 드러나지 않는다.

## 검증

```
dune build @check   → exit 0
```

`@check` 는 CI 의 `Build and Test` 가 컴파일하는 것과 같은 범위다(실행 없이 모든 library/executable/test 컴파일).

RFC-WAIVED: `.mli` export 한 줄 복원. credential/identity/operator-control/sandbox/hooks/workflow 어디에도 해당하지 않으며 설계 변경이 없다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
