### PR TITLE
fix(schedule): #26796이 제거한 wake_signal_to_yojson export 복구 (빌드 실패)

### DIFF
--- a/lib/schedule/schedule_runner.mli
+++ b/lib/schedule/schedule_runner.mli
@@ -80,6 +80,11 @@ val dispatch_status_to_string : dispatch_status -> string
 
 val signals_dir : Workspace_utils.config -> string
 
+val wake_signal_to_yojson : wake_signal -> Yojson.Safe.t
+(** The exact persisted shape of a durable wake signal. [tick] writes rows
+    through this function, so it is also the contract a reader has to satisfy;
+    [test_schedule_tool_wiring] pins the field count against it. *)
+
 val wake_signal_of_yojson : Yojson.Safe.t -> (wake_signal, string) result
 
 val tick :


### PR DESCRIPTION
Closes #26802.

## 증상

`main` 에서 `dune build` 가 실패한다.

```
File "test/test_schedule_tool_wiring.ml", line 502, characters 20-57:
Error: Unbound value Schedule_runner.wake_signal_to_yojson
```

## 원인

#26796 이 `lib/schedule/schedule_runner.mli` 에서 `val wake_signal_to_yojson` 을 zombie surface 로 보고 제거했다. 실제로는 zombie 가 아니었다.

- 구현부 `schedule_runner.ml:126` 은 살아 있고, 같은 파일 `:226` 이 durable signal 을 쓸 때 이 함수를 통과한다: `Dated_jsonl.append (signal_store config) (wake_signal_to_yojson signal)`.
- `test/test_schedule_tool_wiring.ml:502` 가 호출자였다. 이 테스트는 영속화되는 signal JSON 의 필드 수를 8 로 고정한다 — 즉 wire shape 계약 테스트다.

## 변경

`val wake_signal_to_yojson : wake_signal -> Yojson.Safe.t` 를 `.mli` 에 복구하고, 이 값이 무엇을 고정하는지 doc comment 로 명시했다. 같은 PR 이 제거한 나머지 3 개(`signal_kind_of_string`, `signal_seen_path`, `read_recent_signals`)는 호출자가 없어 그대로 둔다.

## 로컬 검증

`dune build --root .` → exit 0, Error 0건. 변경 전 동일 worktree 에서는 위 에러로 exit 1.

RFC-WAIVED: credential / identity / operator control / keeper sandbox / dashboard credential / hooks / workflow 문서 어디에도 해당하지 않는다. 깨진 빌드를 되돌리는 `.mli` 1줄 복구다.
