### PR TITLE
refactor(board): enforce current persisted-row schema

### DIFF
--- a/lib/board/board_metrics_hooks.ml
+++ b/lib/board/board_metrics_hooks.ml
@@ -7,12 +7,6 @@
     value at each call site. The variant -> Otel_metric_store label string mapping
     lives only in the adapter (board_metric_hooks_adapter.ml). *)
 
-(** Persistence surface that recorded a read drop. Single value today; the
-    sum keeps the dimension typed and adding a surface a compile obligation.
-    This is a board-persistence-row surface, unrelated to the deleted
-    Tool-layer [surface] type (#19854). *)
-type board_persist_surface = Board_post_meta_json
-
 (** Outcome of an attempt to start the board dispatch flusher actor. *)
 type flusher_outcome =
   | Switch_finished  (** Switch was already finished when startup ran. *)
@@ -22,15 +16,12 @@ type observer = {
   observe_persist_lock_acquire_sec : float -> unit;
   observe_persist_lock_held_sec : float -> unit;
   inc_dispatch_flusher_start_outcome : outcome:flusher_outcome -> unit;
-  inc_persistence_read_drop :
-    surface:board_persist_surface -> reason:Read_drop_reason.t -> unit;
 }
 
 let noop_observer = {
   observe_persist_lock_acquire_sec = (fun _ -> ());
   observe_persist_lock_held_sec = (fun _ -> ());
   inc_dispatch_flusher_start_outcome = (fun ~outcome:_ -> ());
-  inc_persistence_read_drop = (fun ~surface:_ ~reason:_ -> ());
 }
 
 let observer = Atomic.make noop_observer
@@ -45,6 +36,3 @@ let observe_persist_lock_held_sec seconds =
 
 let inc_dispatch_flusher_start_outcome ~outcome =
   (Atomic.get observer).inc_dispatch_flusher_start_outcome ~outcome
-
-let inc_persistence_read_drop ~surface ~reason =
-  (Atomic.get observer).inc_persistence_read_drop ~surface ~reason

--- a/lib/board/board_metrics_hooks.mli
+++ b/lib/board/board_metrics_hooks.mli
@@ -1,8 +1,5 @@
 (** Board-owned metric hooks with typed label dimensions. *)
 
-type board_persist_surface =
-  | Board_post_meta_json
-
 type flusher_outcome =
   | Switch_finished
   | Cas_exhausted
@@ -11,13 +8,9 @@ type observer =
   { observe_persist_lock_acquire_sec : float -> unit
   ; observe_persist_lock_held_sec : float -> unit
   ; inc_dispatch_flusher_start_outcome : outcome:flusher_outcome -> unit
-  ; inc_persistence_read_drop :
-      surface:board_persist_surface -> reason:Read_drop_reason.t -> unit
   }
 
 val set_observer : observer -> unit
 val observe_persist_lock_acquire_sec : float -> unit
 val observe_persist_lock_held_sec : float -> unit
 val inc_dispatch_flusher_start_outcome : outcome:flusher_outcome -> unit
-val inc_persistence_read_drop :
-  surface:board_persist_surface -> reason:Read_drop_reason.t -> unit

--- a/lib/board/board_votes.mli
+++ b/lib/board/board_votes.mli
@@ -126,15 +126,13 @@ val visibility_of_string : string -> visibility option
     {!Board} facade unchanged. *)
 
 val post_of_yojson : Yojson.Safe.t -> post option
-(** Decodes a single persisted-post JSON row.  Returns
-    [None] when any required field is missing or any id /
-    visibility / post-kind parser rejects the value. Rows without an
-    explicit [post_kind] are rejected rather than classified from prose,
-    author names, or timing metadata. *)
+(** Decodes one row emitted by the current {!post_to_yojson} writer.  Returns
+    [None] unless the field set, JSON types, identifiers, derived values, and
+    optional typed objects match that current wire shape exactly. *)
 
 val comment_of_yojson : Yojson.Safe.t -> comment option
-(** Decodes a single persisted-comment JSON row.  Same
-    fail-soft contract as {!post_of_yojson}. *)
+(** Decodes one row emitted by the current {!comment_to_yojson} writer, with
+    the same exact current-wire contract as {!post_of_yojson}. *)
 
 (** {1 Hearth aggregation} *)
 

--- a/lib/board/board_votes_json.ml
+++ b/lib/board/board_votes_json.ml
@@ -2,117 +2,197 @@
 
 include Board_core
 
-let record_post_meta_json_read_drop () =
-  Board_metrics_hooks.inc_persistence_read_drop
-    ~surface:Board_metrics_hooks.Board_post_meta_json
-    ~reason:Read_drop_reason.Invalid_payload
-;;
-
 let visibility_of_string = Board_core_classify.visibility_of_string
 
-(* RFC-0233 §7: decode the typed post origin. Parse, don't repair — an absent
-   [origin], a non-object value, or a malformed sub-field all degrade to [None]
-   (per-field for the sub-fields), NEVER dropping the row: origin is provenance
-   metadata, not load-bearing identity (contrast the [meta] row-drop below).
-   [Ids.Turn_ref.of_string] is total and returns [None] on a malformed join
-   key. An all-[None] origin decodes to [None] (no empty record carried). *)
+let has_exact_field_set ~allowed fields =
+  let rec loop seen = function
+    | [] -> true
+    | (name, _) :: rest ->
+      if List.mem name seen || not (List.mem name allowed)
+      then false
+      else loop (name :: seen) rest
+  in
+  loop [] fields
+;;
+
+let post_field_names =
+  [ "id"
+  ; "author"
+  ; "title"
+  ; "body"
+  ; "post_kind"
+  ; "content"
+  ; "visibility"
+  ; "created_at"
+  ; "updated_at"
+  ; "expires_at"
+  ; "votes_up"
+  ; "votes_down"
+  ; "score"
+  ; "reply_count"
+  ; "pinned"
+  ; "hearth"
+  ; "thread_id"
+  ; "origin"
+  ; "classification_reason"
+  ; "meta"
+  ]
+;;
+
+let comment_field_names =
+  [ "id"
+  ; "post_id"
+  ; "parent_id"
+  ; "author"
+  ; "content"
+  ; "created_at"
+  ; "expires_at"
+  ; "votes_up"
+  ; "votes_down"
+  ; "score"
+  ]
+;;
+
+let required_string fields key =
+  match List.assoc_opt key fields with
+  | Some (`String value) -> Some value
+  | None | Some _ -> None
+;;
+
+let required_float fields key =
+  match List.assoc_opt key fields with
+  | Some (`Float value) -> Some value
+  | None | Some _ -> None
+;;
+
+let required_int fields key =
+  match List.assoc_opt key fields with
+  | Some (`Int value) -> Some value
+  | None | Some _ -> None
+;;
+
+let required_bool fields key =
+  match List.assoc_opt key fields with
+  | Some (`Bool value) -> Some value
+  | None | Some _ -> None
+;;
+
+let optional_string fields key =
+  match List.assoc_opt key fields with
+  | None -> Ok None
+  | Some (`String value) -> Ok (Some value)
+  | Some _ -> Error ()
+;;
+
+let optional_meta fields =
+  match List.assoc_opt "meta" fields with
+  | None -> Ok None
+  | Some (`Assoc _ as meta) -> Ok (Some meta)
+  | Some _ -> Error ()
+;;
+
+(* RFC-0233 §7: an emitted origin is a current typed value, not a repairable
+   hint. Absent [origin] remains valid; a present malformed object rejects its
+   row at the caller. *)
 let post_origin_of_yojson (json : Yojson.Safe.t) : post_origin option =
   match json with
-  | `Assoc _ ->
+  | `Assoc fields ->
     let turn_ref =
-      match Safe_ops.json_string_opt "turn_ref" json with
-      | Some s -> Ids.Turn_ref.of_string s
-      | None -> None
+      match List.assoc_opt "turn_ref" fields with
+      | None -> Ok None
+      | Some (`String raw) ->
+        (match Ids.Turn_ref.of_string raw with
+         | Some turn_ref -> Ok (Some turn_ref)
+         | None -> Error ())
+      | Some _ -> Error ()
     in
-    let source = Safe_ops.json_string_opt "source" json in
-    let fusion_run_id = Safe_ops.json_string_opt "fusion_run_id" json in
+    let source = optional_string fields "source" in
+    let fusion_run_id = optional_string fields "fusion_run_id" in
     (match turn_ref, source, fusion_run_id with
-     | None, None, None -> None
-     | _ -> Some { turn_ref; source; fusion_run_id })
+     | Ok turn_ref, Ok source, Ok fusion_run_id ->
+       if Option.is_none turn_ref
+          && Option.is_none source
+          && Option.is_none fusion_run_id
+       then None
+       else Some { turn_ref; source; fusion_run_id }
+     | Error (), _, _ | _, Error (), _ | _, _, Error () -> None)
   | _ -> None
 ;;
 
+let optional_origin fields =
+  match List.assoc_opt "origin" fields with
+  | None -> Ok None
+  | Some json ->
+    (match post_origin_of_yojson json with
+     | Some origin -> Ok (Some origin)
+     | None -> Error ())
+;;
+
 let post_of_yojson (json : Yojson.Safe.t) : post option =
-  match
-    ( Safe_ops.json_string_opt "id" json
-    , Safe_ops.json_string_opt "author" json
-    , Safe_ops.json_string_opt "content" json
-    , Safe_ops.json_string_opt "visibility" json
-    , Safe_ops.json_float_opt "created_at" json
-    , Safe_ops.json_float_opt "expires_at" json )
-  with
-  | ( Some id_str
-    , Some author_str
-    , Some content
-    , Some vis_str
-    , Some created_at
-    , Some expires_at ) ->
-    let title_opt = Safe_ops.json_string_opt "title" json in
-    let body_opt = Safe_ops.json_string_opt "body" json in
-    (* Backward compat: default updated_at to created_at if missing *)
-    let updated_at =
-      Safe_ops.json_float_opt "updated_at" json |> Option.value ~default:created_at
-    in
-    let votes_up = Safe_ops.json_int ~default:0 "votes_up" json in
-    let votes_down = Safe_ops.json_int ~default:0 "votes_down" json in
-    let reply_count = Safe_ops.json_int ~default:0 "reply_count" json in
-    let hearth = Safe_ops.json_string_opt "hearth" json in
-    let thread_id = Safe_ops.json_string_opt "thread_id" json in
-    (* Missing on legacy rows persisted before the pin field existed -> default false. *)
-    let pinned = Safe_ops.json_bool ~default:false "pinned" json in
+  match json with
+  | `Assoc fields
+    when has_exact_field_set ~allowed:post_field_names fields ->
+    (match
+       ( required_string fields "id"
+       , required_string fields "author"
+       , required_string fields "title"
+       , required_string fields "body"
+       , required_string fields "content"
+       , required_string fields "post_kind"
+       , required_string fields "visibility"
+       , required_float fields "created_at"
+       , required_float fields "updated_at"
+       , required_float fields "expires_at"
+       , required_int fields "votes_up"
+       , required_int fields "votes_down"
+       , required_int fields "score"
+       , required_int fields "reply_count"
+       , required_bool fields "pinned"
+       , optional_string fields "hearth"
+       , optional_string fields "thread_id"
+       , optional_string fields "classification_reason"
+       , optional_meta fields
+       , optional_origin fields )
+     with
+     | ( Some id_str
+       , Some author_str
+       , Some title
+       , Some body
+       , Some content
+       , Some post_kind_raw
+       , Some vis_str
+       , Some created_at
+       , Some updated_at
+       , Some expires_at
+       , Some votes_up
+       , Some votes_down
+       , Some score
+       , Some reply_count
+       , Some pinned
+       , Ok hearth
+       , Ok thread_id
+       , Ok classification_reason
+       , Ok meta_json
+       , Ok origin ) ->
     let post_kind_opt =
-      match Safe_ops.json_string_opt "post_kind" json with
-      | Some raw -> post_kind_of_string raw
-      | None -> None
+      post_kind_of_string post_kind_raw
     in
     if Option.is_none post_kind_opt
     then
       Log.BoardLog.warn
         "dropping persisted board post %s: missing or invalid post_kind"
         id_str;
-    let meta_json =
-      match Safe_ops.json_member_opt "meta" json with
-      | Some (`Assoc _ as meta) -> Some meta
-      | Some _ | None ->
-        (match Safe_ops.json_string_opt "meta_json" json with
-         | Some raw ->
-           (try Some (Yojson.Safe.from_string raw) with
-            | Yojson.Json_error _ ->
-              record_post_meta_json_read_drop ();
-              None)
-         | None -> None)
-    in
-    let origin =
-      match Safe_ops.json_member_opt "origin" json with
-      | Some o -> post_origin_of_yojson o
-      | None -> None
-    in
-    (match
-       ( Post_id.of_string id_str
-       , Agent_id.of_string author_str
-       , visibility_of_string vis_str
-       , post_kind_opt )
-     with
-     | Ok id, Ok author, Some visibility, Some post_kind ->
-       (match
-          normalize_post_payload
-            ~content
-            ?title:title_opt
-            ?body:body_opt
-            ~post_kind
-            ?meta_json
-            ()
-        with
-        | Error (Board_core_payload.Meta_not_assoc _) ->
-          (* Row-level malformed meta_json: drop the row. The legacy
-             code path silently coerced the same payload to an empty
-             meta object at board_core_payload.ml:73, persisting a
-             "successful" row with the original meta vaporised. We
-             now reject the row outright so callers see the load
-             count drop instead of an invisible data shape change. *)
-          None
-        | Ok (title, body, post_kind, meta_json) ->
-          Some
+    if not (String.equal content body) || score <> votes_up - votes_down
+    then None
+    else
+      (match
+         ( Post_id.of_string id_str
+         , Agent_id.of_string author_str
+         , visibility_of_string vis_str
+         , post_kind_opt )
+       with
+       | Ok id, Ok author, Some visibility, Some post_kind ->
+          let post =
             { id
             ; author
             ; title
@@ -131,54 +211,75 @@ let post_of_yojson (json : Yojson.Safe.t) : post option =
             ; hearth
             ; thread_id
             ; origin
-            })
+            }
+          in
+          if Option.equal
+               String.equal
+               classification_reason
+               (post_classification_reason post)
+          then Some post
+          else None
+       | _ -> None)
      | _ -> None)
-  | _ -> None
+  | `Assoc _ | _ -> None
 ;;
 
 let comment_of_yojson (json : Yojson.Safe.t) : comment option =
-  match
-    ( Safe_ops.json_string_opt "id" json
-    , Safe_ops.json_string_opt "post_id" json
-    , Safe_ops.json_string_opt "author" json
-    , Safe_ops.json_string_opt "content" json
-    , Safe_ops.json_float_opt "created_at" json
-    , Safe_ops.json_float_opt "expires_at" json )
-  with
-  | ( Some id_str
-    , Some post_id_str
-    , Some author_str
-    , Some content
-    , Some created_at
-    , Some expires_at ) ->
-    let parent_id_opt = Safe_ops.json_string_opt "parent_id" json in
-    let votes_up = Safe_ops.json_int ~default:0 "votes_up" json in
-    let votes_down = Safe_ops.json_int ~default:0 "votes_down" json in
+  match json with
+  | `Assoc fields
+    when has_exact_field_set ~allowed:comment_field_names fields ->
+    let parent_id =
+      match List.assoc_opt "parent_id" fields with
+      | Some `Null -> Ok None
+      | Some (`String raw) ->
+        (match Comment_id.of_string raw with
+         | Ok parent_id -> Ok (Some parent_id)
+         | Error _ -> Error ())
+      | None | Some _ -> Error ()
+    in
     (match
-       ( Comment_id.of_string id_str
-       , Post_id.of_string post_id_str
-       , Agent_id.of_string author_str )
+       ( required_string fields "id"
+       , required_string fields "post_id"
+       , required_string fields "author"
+       , required_string fields "content"
+       , required_float fields "created_at"
+       , required_float fields "expires_at"
+       , required_int fields "votes_up"
+       , required_int fields "votes_down"
+       , required_int fields "score"
+       , parent_id )
      with
-     | Ok id, Ok post_id, Ok author ->
-       let parent_id =
-         match parent_id_opt with
-         | Some s ->
-           (match Comment_id.of_string s with
-            | Ok cid -> Some cid
-            | _ -> None)
-         | None -> None
-       in
-       Some
-         { id
-         ; post_id
-         ; parent_id
-         ; author
-         ; content
-         ; created_at
-         ; expires_at
-         ; votes_up
-         ; votes_down
-         }
+     | ( Some id_str
+       , Some post_id_str
+       , Some author_str
+       , Some content
+       , Some created_at
+       , Some expires_at
+       , Some votes_up
+       , Some votes_down
+       , Some score
+       , Ok parent_id ) ->
+       if score <> votes_up - votes_down
+       then None
+       else
+         (match
+          ( Comment_id.of_string id_str
+          , Post_id.of_string post_id_str
+          , Agent_id.of_string author_str )
+        with
+        | Ok id, Ok post_id, Ok author ->
+          Some
+            { id
+            ; post_id
+            ; parent_id
+            ; author
+            ; content
+            ; created_at
+            ; expires_at
+            ; votes_up
+            ; votes_down
+            }
+          | _ -> None)
      | _ -> None)
   | _ -> None
 ;;

--- a/lib/board/board_votes_json.mli
+++ b/lib/board/board_votes_json.mli
@@ -6,7 +6,11 @@ end
 
 val visibility_of_string : string -> visibility option
 val post_of_yojson : Yojson.Safe.t -> post option
+(** Accepts only the exact current {!post_to_yojson} wire shape. *)
+
 val comment_of_yojson : Yojson.Safe.t -> comment option
+(** Accepts only the exact current {!comment_to_yojson} wire shape. *)
+
 val load_persisted_posts : store -> (int, string * exn) result
 (** Load posts from disk into [store].  Returns [Ok loaded_count] on success
     (including when the persistence file is absent: [Ok 0]).  Returns

--- a/lib/board_metric_hooks_adapter.ml
+++ b/lib/board_metric_hooks_adapter.ml
@@ -7,22 +7,11 @@
     working. The mappings are total (no [_ ->] wildcard) so adding a label
     variant is a compile obligation here. *)
 
-(* surface label for masc_persistence_read_drops_total *)
-let board_persist_surface_to_label :
-  Board_metrics_hooks.board_persist_surface -> string = function
-  | Board_post_meta_json -> "board_post_meta_json"
-
 (* outcome label for masc_board_dispatch_flusher_start_outcomes_total *)
 let flusher_outcome_to_label : Board_metrics_hooks.flusher_outcome -> string =
   function
   | Switch_finished -> "switch_finished"
   | Cas_exhausted -> "cas_exhausted"
-
-(* reason label for masc_persistence_read_drops_total; reuses the
-   SSOT wire mapping in Read_drop_reason (byte-identical to the old
-   Safe_ops.persistence_read_drop_reason_* constants). *)
-let read_drop_reason_to_label : Read_drop_reason.t -> string =
-  Read_drop_reason.to_wire
 
 let install () =
   Board_metrics_hooks.set_observer
@@ -42,14 +31,5 @@ let install () =
            Otel_metric_store.inc_counter
              Otel_metric_store.metric_board_dispatch_flusher_start_outcomes
              ~labels:[ ("outcome", flusher_outcome_to_label outcome) ]
-             ());
-      inc_persistence_read_drop =
-        (fun ~surface ~reason ->
-           Otel_metric_store.inc_counter
-             Otel_metric_store.metric_persistence_read_drops
-             ~labels:
-               [ ("surface", board_persist_surface_to_label surface)
-               ; ("reason", read_drop_reason_to_label reason)
-               ]
              ());
     }

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -36,9 +36,9 @@ let block_board_masc_dir_with_file () =
   Fs_compat.save_file masc_dir "not a directory";
   base
 
-let seed_legacy_keeper_post () =
+let seed_post_without_kind () =
   let now = Time_compat.now () in
-  let post_id = Printf.sprintf "legacy-keeper-%06x" (Random.bits ()) in
+  let post_id = Printf.sprintf "missing-kind-%06x" (Random.bits ()) in
   let path = Board.persist_path () in
   let dir = Filename.dirname path in
   Fs_compat.mkdir_p dir;
@@ -47,7 +47,7 @@ let seed_legacy_keeper_post () =
       [
         ("id", `String post_id);
         ("author", `String "dm-keeper");
-        ("title", `String "Legacy keeper");
+        ("title", `String "Missing kind");
         ("body", `String "keeper");
         ("content", `String "keeper");
         ("visibility", `String "internal");
@@ -56,7 +56,9 @@ let seed_legacy_keeper_post () =
         ("expires_at", `Float 0.0);
         ("votes_up", `Int 0);
         ("votes_down", `Int 0);
+        ("score", `Int 0);
         ("reply_count", `Int 0);
+        ("pinned", `Bool false);
         ("meta", `Assoc [ ("source", `String "keeper_board_post") ]);
       ]
   in
@@ -802,12 +804,12 @@ let test_recent_author_match_applies_before_limit () =
       (Board.Post_id.to_string post.id)
   | _ -> Alcotest.fail "expected exactly one matching author post"
 
-let test_legacy_post_without_kind_is_rejected () =
-  let post_id = seed_legacy_keeper_post () in
+let test_post_without_kind_is_rejected () =
+  let post_id = seed_post_without_kind () in
   match Board_dispatch.get_post ~post_id with
   | Error (Board.Post_not_found _) -> ()
   | Error e -> Alcotest.fail (Board.show_board_error e)
-  | Ok _ -> Alcotest.fail "legacy post without post_kind must not be classified"
+  | Ok _ -> Alcotest.fail "post without post_kind must be rejected"
 
 (** {1 Comment Operations} *)
 
@@ -2141,8 +2143,8 @@ let () =
         (with_eio test_author_filter_treats_wildcards_literally);
       Alcotest.test_case "author match precedes recent result limit" `Quick
         (with_eio test_recent_author_match_applies_before_limit);
-      Alcotest.test_case "legacy post without kind is rejected" `Quick
-        (with_eio test_legacy_post_without_kind_is_rejected);
+      Alcotest.test_case "post without kind is rejected" `Quick
+        (with_eio test_post_without_kind_is_rejected);
     ];
     "comments", [
       Alcotest.test_case "add and get" `Quick (with_eio test_add_and_get_comments);

--- a/test/test_board_metrics_labels.ml
+++ b/test/test_board_metrics_labels.ml
@@ -1,57 +1,21 @@
-(* test/test_board_metrics_labels.ml
-
-   Pins the Otel_metric_store label strings emitted for the typed metric-label
-   closed sums on [Board_metrics_hooks.observer]. The refactor replaced
-   bare [string] label params with closed sums; the [variant -> string]
-   mapping lives only in the Otel_metric_store adapter
-   ([Board_metric_hooks_adapter.*_to_label]).
-
-   These strings are wire contracts: dashboards and alerts are keyed on
-   them. The expected values below are the exact strings the pre-typed
-   string hooks passed, so this test fails if any future variant change
-   drifts a Otel_metric_store label. *)
+(** Pins Board metric label strings emitted by the typed hook adapter. *)
 
 module BPH = Masc.Board_metric_hooks_adapter
 module BMH = Masc.Board_metrics_hooks
-module RDR = Read_drop_reason
 
 let check_label name expected actual =
   Alcotest.(check string) name expected actual
 
-(* surface label for masc_persistence_read_drops_total. Old code passed
-   the literal "board_post_meta_json". *)
-let test_board_persist_surface_to_label () =
-  check_label "Board_post_meta_json" "board_post_meta_json"
-    (BPH.board_persist_surface_to_label BMH.Board_post_meta_json)
-
-(* outcome label for masc_board_dispatch_flusher_start_outcomes_total.
-   Old code passed "switch_finished" / "cas_exhausted". *)
 let test_flusher_outcome_to_label () =
   check_label "Switch_finished" "switch_finished"
     (BPH.flusher_outcome_to_label BMH.Switch_finished);
   check_label "Cas_exhausted" "cas_exhausted"
     (BPH.flusher_outcome_to_label BMH.Cas_exhausted)
 
-(* reason label for masc_persistence_read_drops_total. The board only
-   emits Invalid_payload; the adapter reuses Read_drop_reason.to_wire,
-   which is byte-identical to the old
-   Safe_ops.persistence_read_drop_reason_invalid_payload = "invalid_payload". *)
-let test_read_drop_reason_to_label () =
-  check_label "Invalid_payload" "invalid_payload"
-    (BPH.read_drop_reason_to_label RDR.Invalid_payload);
-  (* Match the old Safe_ops constant directly to prove no drift. *)
-  check_label "matches Safe_ops constant"
-    Safe_ops.persistence_read_drop_reason_invalid_payload
-    (BPH.read_drop_reason_to_label RDR.Invalid_payload)
-
 let () =
   Alcotest.run "board_metrics_labels"
     [ ( "to_label byte-identity"
-      , [ Alcotest.test_case "board_persist_surface" `Quick
-            test_board_persist_surface_to_label
-        ; Alcotest.test_case "flusher_outcome" `Quick
+      , [ Alcotest.test_case "flusher_outcome" `Quick
             test_flusher_outcome_to_label
-        ; Alcotest.test_case "read_drop_reason" `Quick
-            test_read_drop_reason_to_label
         ] )
     ]

--- a/test/test_board_persistence_load_contract.ml
+++ b/test/test_board_persistence_load_contract.ml
@@ -14,6 +14,8 @@
 
 open Masc
 
+let () = Mirage_crypto_rng_unix.use_default ()
+
 let fresh_test_base_path () =
   let dir =
     Filename.concat
@@ -50,6 +52,74 @@ let test_load_persisted_comments_missing_file () =
       (Printexc.to_string e)
 ;;
 
+let remove_key json key =
+  match json with
+  | `Assoc fields ->
+    `Assoc (List.filter (fun (name, _) -> not (String.equal name key)) fields)
+  | other -> other
+;;
+
+let prepend_field json field =
+  match json with
+  | `Assoc fields -> `Assoc (field :: fields)
+  | other -> other
+;;
+
+let replace_key json key value =
+  match json with
+  | `Assoc fields ->
+    `Assoc
+      (List.map
+         (fun (name, current) ->
+            if String.equal name key then name, value else name, current)
+         fields)
+  | other -> other
+;;
+
+let test_loader_keeps_only_current_rows () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let _dir = fresh_test_base_path () in
+  let source_store = Board_core.create_store () in
+  let post =
+    match
+      Board_core.create_post
+        source_store
+        ~author:"current-writer"
+        ~content:"current persisted row"
+        ~post_kind:Board.Human_post
+        ()
+    with
+    | Ok post -> post
+    | Error error ->
+      Alcotest.failf "create_post failed: %s" (Board.show_board_error error)
+  in
+  let canonical = Board_core.post_to_yojson post in
+  let path = Board.persist_path () in
+  let append json =
+    Fs_compat.append_file path (Yojson.Safe.to_string json ^ "\n")
+  in
+  append (remove_key canonical "pinned");
+  append (prepend_field canonical ("meta_json", `String "{}"));
+  append (replace_key canonical "votes_up" (`String "0"));
+  let loaded_store = Board_core.create_store () in
+  (match Masc_board_handlers.Board_votes_json.load_persisted_posts loaded_store with
+   | Ok 1 -> ()
+   | Ok count -> Alcotest.failf "expected exactly one current row, loaded %d" count
+   | Error (load_path, error) ->
+     Alcotest.failf
+       "load failed: %s (%s)"
+       load_path
+       (Printexc.to_string error));
+  Alcotest.(check bool)
+    "canonical post is present"
+    true
+    (Result.is_ok
+       (Board_core.get_post
+          loaded_store
+          ~post_id:(Board.Post_id.to_string post.id)))
+;;
+
 let () =
   Random.self_init ();
   Alcotest.run
@@ -63,6 +133,10 @@ let () =
             "comments loader returns Ok 0 when file absent"
             `Quick
             test_load_persisted_comments_missing_file
+        ; Alcotest.test_case
+            "loader keeps only exact current rows"
+            `Quick
+            test_loader_keeps_only_current_rows
         ] )
     ]
 ;;

--- a/test/test_board_post_origin.ml
+++ b/test/test_board_post_origin.ml
@@ -1,19 +1,14 @@
-(** RFC-0233 §7 (PR-B): board post typed [origin] codec + secondary indexes.
+(** Board persisted-row schema, typed origin codec, and secondary indexes.
 
     Pins the board-side half of the turn-identity contract:
     - {!Board_core_json.post_to_yojson} / {!Board_votes_json.post_of_yojson}
       round-trip the typed [origin] (turn_ref / source / fusion_run_id).
-    - decode is parse-don't-repair: a non-object origin or a malformed
-      [turn_ref] degrades to [None] WITHOUT dropping the post (origin is
-      provenance, not load-bearing identity — contrast the [meta] row-drop).
+    - decoding accepts only the exact current writer shape; malformed origins,
+      missing current fields, legacy keys, coercions, duplicates, and unknown
+      fields reject the row.
     - {!Board_core.find_post_by_turn_ref} / {!find_post_by_run_id} are exact
       O(1) index lookups (RFC §7.6 guard #2/#3, no meta_json scan, no window),
-      and the indexes are rebuilt on load.
-
-    The producer side (which keeper turn populates [origin.turn_ref]) is a
-    named follow-up; PR-B wires only fusion's [fusion_run_id], whose effect —
-    a post findable by [find_post_by_run_id] — is exercised here via a
-    fusion-shaped origin. *)
+      and the indexes are rebuilt on load. *)
 
 open Masc
 
@@ -74,6 +69,19 @@ let replace_key json key value =
   | other -> other
 ;;
 
+let remove_key json key =
+  match json with
+  | `Assoc fields ->
+    `Assoc (List.filter (fun (name, _) -> not (String.equal name key)) fields)
+  | other -> other
+;;
+
+let prepend_field json field =
+  match json with
+  | `Assoc fields -> `Assoc (field :: fields)
+  | other -> other
+;;
+
 let test_codec_round_trip () =
   let store = Board_core.create_store () in
   let tr = Ids.Turn_ref.make ~trace_id:"trace-abc" ~absolute_turn:42 in
@@ -107,28 +115,125 @@ let test_codec_absent_origin () =
   Alcotest.(check bool) "absent origin decodes to None" true (Option.is_none decoded.origin)
 ;;
 
-let test_malformed_origin_preserves_post () =
+let test_malformed_origin_rejected () =
   let store = Board_core.create_store () in
   let tr = Ids.Turn_ref.make ~trace_id:"t" ~absolute_turn:1 in
   let post = create store ~origin:(make_origin ~turn_ref:tr ()) ~content:"malformed origin" in
   let json = Board_core.post_to_yojson post in
-  (* origin as a non-object value -> degrade to None, keep the row. *)
-  (match decode (replace_key json "origin" (`Int 5)) with
-   | Some p -> Alcotest.(check bool) "non-object origin -> None" true (Option.is_none p.origin)
-   | None -> Alcotest.fail "row dropped on non-object origin (must be preserved)");
-  (* malformed turn_ref string -> turn_ref None, but a valid sibling field is
-     kept (per-field degrade, not whole-origin drop, not row drop). *)
+  Alcotest.(check bool)
+    "non-object origin rejected"
+    true
+    (Option.is_none (decode (replace_key json "origin" (`Int 5))));
   let bad_origin =
     `Assoc [ "turn_ref", `String "no-separator"; "source", `String "fusion" ]
   in
-  match decode (replace_key json "origin" bad_origin) with
-  | Some p ->
-    (match p.origin with
-     | Some (o : Board.post_origin) ->
-       Alcotest.(check bool) "malformed turn_ref -> None" true (Option.is_none o.turn_ref);
-       Alcotest.(check (option string)) "valid sibling kept" (Some "fusion") o.source
-     | None -> Alcotest.fail "origin fully dropped though source was valid")
-  | None -> Alcotest.fail "row dropped on malformed turn_ref (must be preserved)"
+  Alcotest.(check bool)
+    "malformed turn_ref rejected"
+    true
+    (Option.is_none (decode (replace_key json "origin" bad_origin)));
+  Alcotest.(check bool)
+    "empty origin rejected"
+    true
+    (Option.is_none (decode (replace_key json "origin" (`Assoc []))))
+;;
+
+let test_current_post_schema_is_exact () =
+  let store = Board_core.create_store () in
+  let post = create_no_origin store ~content:"current schema" in
+  let json = Board_core.post_to_yojson post in
+  List.iter
+    (fun field ->
+       Alcotest.(check bool)
+         (field ^ " is required")
+         true
+         (Option.is_none (decode (remove_key json field))))
+    [ "id"
+    ; "author"
+    ; "title"
+    ; "body"
+    ; "post_kind"
+    ; "content"
+    ; "visibility"
+    ; "created_at"
+    ; "updated_at"
+    ; "expires_at"
+    ; "votes_up"
+    ; "votes_down"
+    ; "score"
+    ; "reply_count"
+    ; "pinned"
+    ];
+  let rejected label candidate =
+    Alcotest.(check bool) label true (Option.is_none (decode candidate))
+  in
+  rejected
+    "legacy meta_json rejected"
+    (prepend_field json ("meta_json", `String "{}"));
+  rejected "unknown field rejected" (prepend_field json ("unknown", `Int 1));
+  rejected "duplicate field rejected" (prepend_field json ("id", `String "duplicate"));
+  rejected
+    "string timestamp rejected"
+    (replace_key json "updated_at" (`String "1.0"));
+  rejected "float counter rejected" (replace_key json "votes_up" (`Float 0.0));
+  rejected "string bool rejected" (replace_key json "pinned" (`String "false"));
+  rejected "body/content mismatch rejected" (replace_key json "content" (`String "other"));
+  rejected "score mismatch rejected" (replace_key json "score" (`Int 1));
+  rejected
+    "classification mismatch rejected"
+    (prepend_field json ("classification_reason", `String "fabricated"))
+;;
+
+let test_current_comment_schema_is_exact () =
+  let store = Board_core.create_store () in
+  let post = create_no_origin store ~content:"comment parent" in
+  let comment =
+    match
+      Board_core.add_comment
+        store
+        ~post_id:(Board.Post_id.to_string post.id)
+        ~author:"commenter"
+        ~content:"current comment"
+        ()
+    with
+    | Ok comment -> comment
+    | Error error -> Alcotest.failf "add_comment failed: %s" (Board.show_board_error error)
+  in
+  let json = Board_core.comment_to_yojson comment in
+  let decode_comment = Masc_board_handlers.Board_votes_json.comment_of_yojson in
+  Alcotest.(check bool)
+    "canonical comment round trip"
+    true
+    (Option.is_some (decode_comment json));
+  List.iter
+    (fun field ->
+       Alcotest.(check bool)
+         (field ^ " is required")
+         true
+         (Option.is_none (decode_comment (remove_key json field))))
+    [ "id"
+    ; "post_id"
+    ; "parent_id"
+    ; "author"
+    ; "content"
+    ; "created_at"
+    ; "expires_at"
+    ; "votes_up"
+    ; "votes_down"
+    ; "score"
+    ];
+  Alcotest.(check bool)
+    "malformed parent id rejected"
+    true
+    (Option.is_none
+       (decode_comment (replace_key json "parent_id" (`String ""))));
+  Alcotest.(check bool)
+    "comment score mismatch rejected"
+    true
+    (Option.is_none (decode_comment (replace_key json "score" (`Int 1))));
+  Alcotest.(check bool)
+    "comment unknown field rejected"
+    true
+    (Option.is_none (decode_comment (prepend_field json ("unknown", `Int 1))))
 ;;
 
 (* Producer side (RFC-0233 §7): the keeper-authored origin constructor used by
@@ -235,9 +340,17 @@ let () =
       , [ Alcotest.test_case "origin round trip" `Quick (with_eio test_codec_round_trip)
         ; Alcotest.test_case "absent origin -> None" `Quick (with_eio test_codec_absent_origin)
         ; Alcotest.test_case
-            "malformed origin -> None, post preserved"
+            "malformed origin rejects row"
             `Quick
-            (with_eio test_malformed_origin_preserves_post)
+            (with_eio test_malformed_origin_rejected)
+        ; Alcotest.test_case
+            "current post schema is exact"
+            `Quick
+            (with_eio test_current_post_schema_is_exact)
+        ; Alcotest.test_case
+            "current comment schema is exact"
+            `Quick
+            (with_eio test_current_comment_schema_is_exact)
         ; Alcotest.test_case
             "keeper-authored origin carries turn_ref"
             `Quick


### PR DESCRIPTION
## What changed

- make persisted Board post/comment decoding accept only the exact shape emitted by the current writers
- reject missing/unknown/duplicate fields, JSON type coercions, malformed typed objects, and inconsistent derived values
- remove `meta_json` string reparsing and all missing-field defaults/repairs
- remove the now-dead Board `meta_json` read-drop metric surface and adapter plumbing
- replace legacy-oriented fixtures and docs with current-contract tests

## Why

The readers still carried multiple historical contracts: missing counters and timestamps were synthesized, `meta_json` strings were reparsed, malformed origin values degraded to absence, and body/title data could be reconstructed. That made the persistence boundary accept states that the only current writers never emit.

This change makes the current writer the single wire authority. Invalid rows are skipped instead of repaired into a different in-memory value.

## Impact

- current persisted rows continue to round-trip and load
- rows outside the current post/comment wire schema are rejected
- the obsolete `board_post_meta_json` metric label/API is no longer exposed

Live runtime inspection before the hard cut found 168 Board post rows, all matching the current required shape, with no `meta_json` string rows or missing current fields.

## Validation

- `scripts/dune-local.sh build -j 1 lib/board/masc_board_handlers.cmxa test/test_board_post_origin.exe test/test_board_persistence_load_contract.exe test/test_board_dispatch.exe test/test_keeper_board_attention_candidate.exe test/test_board_ttl.exe test/test_board_metrics_labels.exe`
- `test_board_post_origin.exe` — 10/10 passed
- `test_board_persistence_load_contract.exe` — 3/3 passed
- `test_board_dispatch.exe test posts 26` — passed
- `test_board_ttl.exe` — 15/15 passed
- `test_board_metrics_labels.exe` — passed
- `ocamlformat --check` on all changed OCaml files
- `git diff --check`
- `scripts/ci/check-determinism-contract.sh`

Four broader focused tests are already red on exact base `238ee781aafb553ea8fd5c3e59f68fed89de1cd2` and reproduce unchanged on this head; they are recorded separately because they do not exercise this persisted-row decoder:

- #26808 — exact create dedup
- #26807 — current Keeper meta/error fixture drift

