### PR TITLE
fix(keeper,dashboard): chat 턴 live-turn 투영 + 거부 사유/이벤트 큐 갱신 배선

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -739,6 +739,12 @@ export interface KeeperEventQueuePendingItem {
   urgency: 'immediate' | 'normal' | 'low'
   arrivedAt: number
   payloadKind: string
+  /** Why a completion_authority_rejected stimulus exists. Only that kind
+      carries it, and it is absent on a backend that predates the field —
+      the projection deliberately does not emit raw payload content for the
+      other kinds. */
+  rejectionReason?: string
+  rejectionTaskId?: string
 }
 
 export interface KeeperEventQueuePendingSnapshot {
@@ -1159,6 +1165,12 @@ export function parseKeeperEventQueuePendingSnapshot(
       urgency: urgency as KeeperEventQueuePendingItem['urgency'],
       arrivedAt,
       payloadKind,
+      ...(typeof raw.rejection_reason === 'string' && raw.rejection_reason.trim()
+        ? { rejectionReason: raw.rejection_reason.trim() }
+        : {}),
+      ...(typeof raw.rejection_task_id === 'string' && raw.rejection_task_id.trim()
+        ? { rejectionTaskId: raw.rejection_task_id.trim() }
+        : {}),
     }
   })
   if (pending.length > totalPending) {

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -282,9 +282,11 @@ function rosterPresenceDisplay(
         ? '반응형'
         : runState.wake_kind === 'proactive_tick'
           ? '자율'
-          : runState.wake_kind != null
-            ? `기원 ${runState.wake_kind}`
-            : '기원 확인 필요'
+          : runState.wake_kind === 'chat_request'
+            ? '대화'
+            : runState.wake_kind != null
+              ? `기원 ${runState.wake_kind}`
+              : '기원 확인 필요'
       return { status: 'busy', detail: `${state.turnPhase} live · ${wakeLabel}` }
     }
     if (runState?.kind === 'waiting') {

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -784,6 +784,14 @@ function KeeperQueueControlPanel({
   }
   useEffect(() => {
     void load()
+    // Without this the queue rows are fetched once and never again, while the
+    // parent's 15s tools poll keeps re-rendering the panel — so formatTimeAgo
+    // ticks '도착 N분 전' upward on rows that may already have been consumed.
+    // Same cadence and visibility gating the receipt strip below already uses;
+    // load(false) keeps a surfaced error visible across polls.
+    return setupVisibleAutoRefresh(() => {
+      void load(false)
+    }, BUSY_REFRESH_MS)
   }, [keeperName])
   const eventRows = eventSnapshot?.pending ?? []
   const activeChatRows = (keeper?.waiting_on ?? [])
@@ -1106,7 +1114,11 @@ function KeeperQueueControlPanel({
           : null}
       </div>
       <div class="grid gap-2 border-t border-[var(--color-border-subtle)] pt-3">
-        <div class="text-xs font-semibold text-[var(--color-fg-secondary)]">자율 이벤트 대기 ${eventSnapshot?.totalPending ?? 0}</div>
+        <!-- eventSnapshot is fetched once per keeperName and after operator actions; it
+             does not poll. Falling back to the 15s-refreshed waiting inventory (the same
+             source 채팅 대기/배송 복구 already use) keeps the count from reading 0 before
+             the one-shot fetch resolves or after it throws. -->
+        <div class="text-xs font-semibold text-[var(--color-fg-secondary)]">자율 이벤트 대기 ${eventSnapshot?.totalPending ?? keeper?.sources?.event_queue_pending ?? 0}</div>
         ${eventRecoveries.map(recovery => {
           const operationId = recovery.operation.operationId
           const key = `event-recovery:${operationId}`
@@ -1140,8 +1152,19 @@ function KeeperQueueControlPanel({
                 wake reason ${item.payloadKind} · urgency ${item.urgency}
                 · 도착 ${formatTimeAgo(item.arrivedAt)} (${new Date(item.arrivedAt * 1000).toLocaleString()})
               </div>
+              ${item.rejectionReason
+                ? html`
+                    <div
+                      class="whitespace-pre-wrap text-2xs text-[var(--color-fg-secondary)]"
+                      data-operator-event-reason
+                    >${item.rejectionTaskId ? `${item.rejectionTaskId}: ` : ''}${item.rejectionReason}</div>
+                  `
+                : null}
               <div class="break-all font-mono text-3xs text-[var(--color-fg-muted)]">
                 source ref ${item.sourceRef}
+              </div>
+              <div class="text-3xs text-[var(--color-fg-muted)]">
+                urgency 변경은 이 항목만이 아니라 대기열 전체를 urgency 순으로 다시 정렬합니다.
               </div>
               <div class="flex flex-wrap gap-1.5">
                 ${(['immediate', 'normal', 'low'] as const).map(urgency => html`

--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -393,6 +393,10 @@ let wake_reason_kind_and_stimuli (wake : Keeper_registry.wake_reason) : string *
   | Keeper_registry.Proactive_tick -> "proactive_tick", []
   | Keeper_registry.Woken stimuli ->
     "woken", List.map Keeper_event_queue.payload_kind_label stimuli
+  (* A chat turn is admitted from the chat queue, not selected from the event
+     queue, so it carries no stimuli. The empty list is the accurate answer,
+     not a placeholder. *)
+  | Keeper_registry.Chat_request -> "chat_request", []
 
 let run_state_to_json (rs : run_state) : Yojson.Safe.t =
   match rs with

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -76,10 +76,12 @@ type turn_attempt_state =
 type wake_reason =
   | Proactive_tick
   | Woken of Keeper_event_queue.stimulus_payload list
+  | Chat_request
 
 let wake_reason_label = function
   | Proactive_tick -> "proactive_tick"
   | Woken _ -> "woken"
+  | Chat_request -> "chat_request"
 ;;
 
 type turn_measurement =

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -336,17 +336,26 @@ type turn_attempt_state = {
 }
 
 (** What entered a turn: its exact consumed event batch, an empty external
-    wake, or the proactive cadence tick. Closed over
-    {!Keeper_event_queue.stimulus_payload} so a new source cannot silently
-    collapse into a generic "running" label on the operator dashboard. *)
+    wake, the proactive cadence tick, or an operator/connector chat message.
+    Closed over {!Keeper_event_queue.stimulus_payload} so a new source cannot
+    silently collapse into a generic "running" label on the operator
+    dashboard. *)
 type wake_reason =
   | Proactive_tick
   | Woken of Keeper_event_queue.stimulus_payload list
+  | Chat_request
+      (** The chat lane ({!Keeper_turn.run_keeper_invocation_turn_admitted})
+          entered the turn. It carries no stimulus payload: a chat turn is
+          admitted from the chat queue, not selected from the event queue, so
+          there is nothing in {!Keeper_event_queue.stimulus_payload} that
+          describes it. Distinct from [Proactive_tick] because a chat turn is
+          requested, not scheduled — collapsing the two would report an
+          operator's message as autonomous activity. *)
 
 val wake_reason_label : wake_reason -> string
-(** Stable low-cardinality label: ["proactive_tick"] or ["woken"]. Use
-    {!Keeper_event_queue.payload_kind_label} on the carried stimuli (for
-    [Woken]) to surface the finer-grained wake cause. *)
+(** Stable low-cardinality label: ["proactive_tick"], ["woken"], or
+    ["chat_request"]. Use {!Keeper_event_queue.payload_kind_label} on the
+    carried stimuli (for [Woken]) to surface the finer-grained wake cause. *)
 
 type turn_measurement = {
   tm_captured_at : float;

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -432,7 +432,7 @@ let run_direct_turn_with_fsm ~(keeper_name : string) ~(turn_id : int) f =
    Precondition: the caller holds the keeper's turn slot. Public direct-message
    and typed-delegate entrypoints construct a valid invocation request before
    reaching this function. *)
-let run_keeper_invocation_turn_admitted
+let run_keeper_invocation_turn_admitted_inner
       ?on_text_delta
       ?on_event
       ?event_bus
@@ -986,6 +986,68 @@ let run_keeper_invocation_turn_admitted
               tool_result_ok_data reply_json
 
 ))))))))
+
+(* Turn-observation boundary for the chat lane.
+
+   [mark_turn_started] is the only installer of [current_turn_observation],
+   and the composite observer's live-turn projection reads [None] without it.
+   Before this wrapper a keeper answering an operator message therefore
+   reported no live turn for its whole duration, and the operator queue panel
+   rendered "live turn 상세 투영은 아직 없습니다" while the turn was running
+   tools. The autonomous lane has carried the same pair since #7122
+   ([Keeper_unified_turn.run_keeper_cycle]); this gives the chat lane that
+   lifecycle instead of adding a second projection beside it.
+
+   Placed on the admitted body, which is the single point all three chat entry
+   paths ([handle_keeper_invocation], [handle_keeper_msg_if_free], and the
+   [on_admitted] arm) funnel through, and which by construction runs while the
+   turn slot is held.
+
+   [mark_turn_finished] is idempotent and runs on both the normal and the
+   exceptional exit. Its own failure must not replace the turn's result or
+   mask an in-flight cancellation, so it is swallowed and logged the way the
+   autonomous lane's turn cleanup does. *)
+let run_keeper_invocation_turn_admitted
+      ?on_text_delta
+      ?on_event
+      ?event_bus
+      ?continuation_channel
+      ~surface
+      ~request
+      ctx
+      args
+  : tool_result
+  =
+  let base_path = ctx.config.base_path in
+  let name = Keeper_invocation_contract.target_name request in
+  Keeper_registry.mark_turn_started
+    ~base_path
+    ~wake:Keeper_registry.Chat_request
+    name;
+  let finish () =
+    try Keeper_registry.mark_turn_finished ~base_path name with
+    | Eio.Cancel.Cancelled _ -> ()
+    | exn ->
+      log_keeper_exn ~label:"mark_turn_finished in chat turn cleanup" exn
+  in
+  match
+    run_keeper_invocation_turn_admitted_inner
+      ?on_text_delta
+      ?on_event
+      ?event_bus
+      ?continuation_channel
+      ~surface
+      ~request
+      ctx
+      args
+  with
+  | result ->
+    finish ();
+    result
+  | exception exn ->
+    finish ();
+    raise exn
+;;
 
 let handle_keeper_invocation
       ?on_text_delta

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -172,6 +172,14 @@ let manual_compaction_preemption_request ~wake ~now pending =
     | Keeper_registry.Woken (_ :: _ as payloads) ->
       not (List.exists is_manual_compaction_payload payloads)
     | Keeper_registry.Proactive_tick | Keeper_registry.Woken [] -> false
+    (* Not reachable: the chat lane admits through
+       [Keeper_turn.run_keeper_invocation_turn_admitted] and never enters
+       [run_keeper_cycle], which is the only producer of the [~wake] threaded
+       here. Enumerated rather than folded into a catch-all so a future chat
+       lane that does reach this point fails the same way an autonomous tick
+       would — by declining to preempt — instead of silently matching a
+       branch written for a different lane. *)
+    | Keeper_registry.Chat_request -> false
   in
   if not source_can_yield
   then None
@@ -234,6 +242,13 @@ let autonomous_yield_request_for_wake ~wake ~base_path ~keeper_name =
            ~base_path
            ~keeper_name)
   | Keeper_registry.Proactive_tick | Keeper_registry.Woken [] ->
+    fun () -> autonomous_yield_request ~base_path ~keeper_name
+  (* Not reachable, same reason as in [manual_compaction_preemption_request]:
+     [~wake] here originates in [run_keeper_cycle], which the chat lane does
+     not call. The autonomous yield request is the conservative answer — it
+     asks whether this lane should step aside, and a chat turn that somehow
+     arrived here should step aside on the same terms. *)
+  | Keeper_registry.Chat_request ->
     fun () -> autonomous_yield_request ~base_path ~keeper_name
 ;;
 

--- a/lib/server/server_dashboard_http_keeper_event_queue_operator.ml
+++ b/lib/server/server_dashboard_http_keeper_event_queue_operator.ml
@@ -71,7 +71,7 @@ let pending_page ~after ~limit pending =
       let stimulus = selection.Keeper_event_queue_state.source in
       let item =
         `Assoc
-          [ "queue_index", `Int index
+          ([ "queue_index", `Int index
           ; "post_id", `String stimulus.Keeper_event_queue.post_id
           ; ( "source_ref"
             , `String
@@ -87,6 +87,30 @@ let pending_page ~after ~limit pending =
             , `String
                 (Keeper_event_queue.payload_kind_label stimulus.payload) )
           ]
+          (* [payload_kind] collapses every payload to a constant string, so a
+             completion_authority_rejected row reached the operator without the
+             rejection's reason — the one field that says why the keeper is
+             blocked. Only that field is added: this projection deliberately
+             omits raw payload content (a board stimulus carries post text),
+             so the whole payload must not be serialized here. Other kinds are
+             enumerated rather than folded into a wildcard so a new payload has
+             to make an explicit decision about operator visibility. *)
+          @ (match stimulus.payload with
+             | Keeper_event_queue.Completion_authority_rejected rejection ->
+               [ "rejection_reason", `String rejection.car_reason
+               ; "rejection_task_id", `String rejection.car_task_id
+               ]
+             | Keeper_event_queue.Board_signal _
+             | Keeper_event_queue.Board_attention _
+             | Keeper_event_queue.Bootstrap
+             | Keeper_event_queue.Fusion_completed _
+             | Keeper_event_queue.Bg_completed _
+             | Keeper_event_queue.Schedule_due _
+             | Keeper_event_queue.Connector_attention _
+             | Keeper_event_queue.Hitl_resolved _
+             | Keeper_event_queue.Manual_compaction_requested
+             | Keeper_event_queue.Goal_assigned _
+             | Keeper_event_queue.Goal_reconciliation_ready _ -> []))
       in
       loop (index + 1) (remaining - 1) (item :: page_rev) rest
   in

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -427,6 +427,88 @@ let with_test_env f =
           Server_request_authority.with_current request_authority (fun () ->
             f ~env ~sw ~config)))
 
+(* The operator queue panel showed a completion_authority_rejected row as its
+   post_id and payload_kind only, so the rejection's own explanation — the one
+   field that says why the keeper stopped making progress — never reached the
+   operator. It is projected explicitly, and only for this kind: the
+   accompanying assertion below pins that a board stimulus still does not leak
+   its post content through the same projection. *)
+let test_event_pending_projection_surfaces_rejection_reason () =
+  let reason =
+    "artifact_unreadable: BottomButton.tsx missing from the sandbox root"
+  in
+  let rejection : Keeper_event_queue.completion_authority_rejection =
+    { car_task_id = "task-159"
+    ; car_verification_id = "vrf-projection-test"
+    ; car_reason = reason
+    ; car_authority =
+        Masc_domain.Human_operator { operator_id = "operator-test" }
+    }
+  in
+  let source : Keeper_event_queue.stimulus =
+    { post_id =
+        Keeper_event_queue.completion_authority_rejection_post_id rejection
+    ; urgency = Immediate
+    ; arrived_at = 42.0
+    ; payload = Keeper_event_queue.Completion_authority_rejected rejection
+    }
+  in
+  let pending_json =
+    match
+      Server_dashboard_http_keeper_event_queue_operator.For_testing.pending_page
+        ~after:0
+        ~limit:100
+        [ Keeper_event_queue_state.{ source; admitted_revision = 7L } ]
+    with
+    | [ json ] -> json
+    | _ -> fail "event pending projection must return one metadata row"
+  in
+  let open Yojson.Safe.Util in
+  check string "rejection reason reaches the operator projection" reason
+    (pending_json |> member "rejection_reason" |> to_string);
+  check string "rejection task id reaches the operator projection" "task-159"
+    (pending_json |> member "rejection_task_id" |> to_string);
+  check string "payload kind is unchanged" "completion_authority_rejected"
+    (pending_json |> member "payload_kind" |> to_string);
+  check bool "verification id stays out of the projection" true
+    (pending_json |> member "car_verification_id" = `Null)
+;;
+
+let test_event_pending_projection_omits_non_rejection_payloads () =
+  let sensitive = "board-body-must-not-ride-the-rejection-change" in
+  let source : Keeper_event_queue.stimulus =
+    { post_id = "board-post-after-rejection-field"
+    ; urgency = Normal
+    ; arrived_at = 42.0
+    ; payload =
+        Board_signal
+          { kind = Post_created
+          ; author = "operator"
+          ; title = "private title"
+          ; content = sensitive
+          ; hearth = None
+          ; updated_at = None
+          }
+    }
+  in
+  let pending_json =
+    match
+      Server_dashboard_http_keeper_event_queue_operator.For_testing.pending_page
+        ~after:0
+        ~limit:100
+        [ Keeper_event_queue_state.{ source; admitted_revision = 7L } ]
+    with
+    | [ json ] -> json
+    | _ -> fail "event pending projection must return one metadata row"
+  in
+  let open Yojson.Safe.Util in
+  check bool "board content still omitted after the rejection field landed"
+    false
+    (contains_substring (Yojson.Safe.to_string pending_json) sensitive);
+  check bool "no rejection field on a non-rejection payload" true
+    (pending_json |> member "rejection_reason" = `Null)
+;;
+
 let test_event_operator_uses_exact_source_refs_across_unrelated_enqueues () =
   with_test_env @@ fun ~env:_ ~sw:_ ~config ->
   let require_ok label = function
@@ -3150,6 +3232,10 @@ let () =
             test_keeper_chat_recovery_route_is_exact;
           test_case "event operator keeps exact source refs across queue changes" `Quick
             test_event_operator_uses_exact_source_refs_across_unrelated_enqueues;
+          test_case "event pending projection surfaces the rejection reason" `Quick
+            test_event_pending_projection_surfaces_rejection_reason;
+          test_case "event pending projection still omits other payload content" `Quick
+            test_event_pending_projection_omits_non_rejection_payloads;
           test_case "observation metadata does not override terminal contract" `Quick
             test_composite_blocked_uses_terminal_contract_not_observational_metadata;
         ] );

--- a/test/test_keeper_composite_live_turn_surface.ml
+++ b/test/test_keeper_composite_live_turn_surface.ml
@@ -28,7 +28,13 @@ let make_meta name =
       (`Assoc
         [
           ("name", `String name);
-          ("agent_name", `String ("agent-" ^ name));
+          (* Derived, not spelled out: [Keeper_meta_json_parse] rejects any
+             agent_name that is not [Keeper_identity.keeper_agent_name name],
+             and the literal this fixture used ("agent-" ^ name) stopped
+             matching that rule — every case in this file failed at
+             [make_meta] before reaching its assertions. *)
+          ( "agent_name"
+          , `String (Masc.Keeper_identity.keeper_agent_name name) );
           ("trace_id", `String ("trace-" ^ name));
           ("allowed_paths", `List [ `String "*" ]);
         ])
@@ -183,6 +189,59 @@ let test_run_state_in_turn_reports_proactive_tick () =
     (J.member "stimulus_kinds" rs |> J.to_list |> List.map J.to_string)
 ;;
 
+(* The chat lane installs the same live-turn observation the autonomous lane
+   does, so an operator message must project a live turn — not the idle
+   [waiting] state the dashboard rendered before the chat lane marked its turn
+   boundary. [chat_request] stays distinct from [proactive_tick] so a
+   requested turn is never reported as autonomous activity. *)
+let test_run_state_in_turn_reports_chat_request () =
+  let base = temp_base () in
+  let name = "chat-keeper" in
+  let json =
+    observed_json ~base ~name
+      ~setup:(fun () ->
+        Keeper_registry.mark_turn_started ~base_path:base
+          ~wake:Keeper_registry.Chat_request name;
+        Keeper_registry.record_turn_tool_inflight ~base_path:base name ~count:2)
+      ()
+  in
+  check bool "is_live true during a chat turn" true
+    (J.member "is_live" json |> J.to_bool);
+  let live = J.member "live_turn" json in
+  (match live with
+   | `Null -> fail "live_turn must be present while a chat turn is active"
+   | _ -> ());
+  check int "live_turn.active_tool_count surfaced for a chat turn" 2
+    (J.member "active_tool_count" live |> J.to_int);
+  let rs = J.member "run_state" json in
+  check string "run_state.kind is in_turn" "in_turn"
+    (J.member "kind" rs |> J.to_string);
+  check string "run_state.wake_kind is chat_request" "chat_request"
+    (J.member "wake_kind" rs |> J.to_string);
+  check (list string)
+    "run_state.stimulus_kinds is empty — a chat turn consumes no stimulus" []
+    (J.member "stimulus_kinds" rs |> J.to_list |> List.map J.to_string)
+;;
+
+let test_chat_turn_clears_live_turn_on_finish () =
+  let base = temp_base () in
+  let name = "chat-keeper-finish" in
+  let json =
+    observed_json ~base ~name
+      ~setup:(fun () ->
+        Keeper_registry.mark_turn_started ~base_path:base
+          ~wake:Keeper_registry.Chat_request name;
+        Keeper_registry.mark_turn_finished ~base_path:base name)
+      ()
+  in
+  check bool "is_live false after the chat turn finishes" false
+    (J.member "is_live" json |> J.to_bool);
+  check bool "live_turn cleared" true
+    (match J.member "live_turn" json with `Null -> true | _ -> false);
+  check string "run_state falls back to waiting" "waiting"
+    (J.member "run_state" json |> J.member "kind" |> J.to_string)
+;;
+
 let test_run_state_waiting_when_running_idle () =
   let base = temp_base () in
   let name = "waiting-keeper" in
@@ -250,6 +309,10 @@ let () =
             test_run_state_in_turn_reports_woken_wake;
           test_case "in_turn reports the proactive tick wake" `Quick
             test_run_state_in_turn_reports_proactive_tick;
+          test_case "in_turn reports a chat-lane turn" `Quick
+            test_run_state_in_turn_reports_chat_request;
+          test_case "chat turn clears the live turn on finish" `Quick
+            test_chat_turn_clears_live_turn_on_finish;
           test_case "waiting for a Running keeper with no live turn" `Quick
             test_run_state_waiting_when_running_idle;
           test_case "suspended for a non-Running phase" `Quick


### PR DESCRIPTION
## 무엇을 고쳤나

대시보드 "운영자 대기열 제어" 패널이 keeper가 실제로 무엇을 하고 있는지 보여주지 못하는 문제 네 가지. 전부 **이미 있는 데이터를 안 잇고 있던 것**이라, 새 개념이나 게이트 없이 배선만 했다.

실측 근거 (keeper `sangsu`, 2026-08-04):

- 19:44:12에 시작한 chat 턴이 11분간 70회 넘는 툴을 실행하는 동안 대시보드에는 `live turn 상세 투영은 아직 없습니다` 만 떴다.
- `completion_authority_rejected:task-159` 행이 이유 없이 표시됐다. 실제 사유(`artifact_unreadable ... missing`)는 디스크에 있었지만 projection이 버렸다.
- urgency `immediate` 이벤트 2건이 13분/8분째 대기 중인데, 화면의 "도착 N분 전"만 올라가고 목록은 한 번 읽은 뒤 갱신되지 않았다.

## 변경

### 1. chat lane에 live-turn observation 설치 (`1e3ad1b`)

`mark_turn_started` 가 `current_turn_observation` 을 `None → Some` 으로 전이시키는 유일한 writer인데, 프로덕션 호출처가 `Keeper_unified_turn.run_keeper_cycle` (자율 lane) 하나뿐이었다. chat 턴은 그 경로를 타지 않아 관찰이 영영 설치되지 않았다.

projection은 서버(`keeper_composite_observer.ml:588-601`)부터 렌더(`keeper-shared.ts:927-950`)까지 이미 완성돼 있었다. 두 번째 표면을 만들지 않고 chat lane을 기존 lifecycle에 넣었다.

- `wake_reason` 에 `Chat_request` 추가. `Proactive_tick | Woken of stimulus_payload list` 로는 chat 턴을 표현할 수 없다 — chat 큐에서 admit되지 event 큐에서 선택되지 않으므로 해당하는 `stimulus_payload` 가 없다. `Proactive_tick` 재사용은 운영자의 메시지를 자율 활동으로 보고하는 거짓말이 된다.
- `run_keeper_invocation_turn_admitted` 를 `mark_turn_started`/`mark_turn_finished` 쌍으로 감쌌다. chat 진입 경로 셋이 전부 여기로 모이고, 구조상 턴 슬롯을 쥔 상태로 실행된다. `mark_turn_finished` 는 idempotent이고 정상/예외 양쪽 종료에서 실행되며, 자신의 실패가 턴 결과를 대체하거나 cancellation을 가리지 않도록 로그 후 삼킨다(자율 lane cleanup과 동일).
- `keeper_unified_turn.ml` 의 `wake` match 두 곳을 wildcard로 넓히지 않고 새 변형을 명시했다. 둘 다 자율 lane 전용이라 chat 턴에는 도달 불가이며, 각각 이유와 보수적 응답을 적었다.

### 2. 거부 사유 projection + 이벤트 큐 갱신 (`945c950`)

- `pending_page` 가 `payload_kind_label` 로 payload 전체를 상수 문자열 하나로 뭉개고 있었다. `car_reason` / `car_task_id` 만 추가한다. 이 projection은 **의도적으로** raw payload를 배제한다(board stimulus는 게시글 본문을 싣는다) — 기존 테스트가 그 계약을 지키고 있어서 payload 통째 노출을 되돌렸다. 나머지 kind는 wildcard 대신 전부 열거해서 새 payload가 노출 여부를 명시적으로 결정하게 했다. 양쪽을 테스트로 고정했다.
- `load()` 가 `[keeperName]` mount effect와 운영자 액션 이후에만 돌았다. interval도 SSE도 새로고침 버튼도 없는데 부모는 15초마다 리렌더되고 `formatTimeAgo` 는 렌더 시점에 `Date.now()` 를 읽는다. 아래 receipt strip이 이미 쓰는 `setupVisibleAutoRefresh` 를 같은 cadence로 재사용했다.
- 헤더 카운터가 `eventSnapshot` null일 때 0을 렌더했다. 옆의 두 카운터가 이미 쓰는 `sources.event_queue_pending` 로 fallback한다.
- roster에서 `chat_request` 를 '대화'로 라벨링(안 하면 '기원 chat_request'로 뜬다).
- urgency 버튼이 해당 항목만이 아니라 **대기열 전체를 재정렬**한다는 사실을 행에 명시했다. `reprioritize_pending` 이 전체 pending에 `sort_by_urgency` 를 돌리고 선택은 head-first다.

## 검증

| 대상 | 결과 |
|---|---|
| `dune build lib/keeper lib/keeper_runtime lib/server` | exit 0 |
| `test_keeper_composite_live_turn_surface` | 11/11 통과 (신규 2건 포함) |
| `test_dashboard_http_core` | 69/69 통과 (신규 2건 포함) |
| `test_keeper_manual_compaction_preemption` | 4/4 통과 |
| `test_keeper_turn_admission` | 통과 |
| `pnpm typecheck` | exit 0 |
| `pnpm lint` | exit 0 |
| `vitest` (keeper-shared / agent-roster / keeper-composite) | 122/122 통과 |

## 함께 고친 것 / 남긴 것

**고침**: `test_keeper_composite_live_turn_surface.ml` 의 11개 케이스가 전부 `make_meta` 에서 죽어 있었다. fixture의 `"agent-" ^ name` 리터럴이 `Keeper_identity.keeper_agent_name` 의 canonical 규칙(`keeper-<name>-agent`)과 더 이상 맞지 않았다. 리터럴 대신 함수에서 파생하도록 바꿔 기존 9개가 다시 돈다.

**안 고침**: `test_keeper_waiting_inventory` 13/17 실패. 원인은 별개 fixture 문제(`fields outside the current schema: sandbox_profile, network_mode`)이고 이 PR이 건드린 파일이 아니다. pre-existing이라 범위에 넣지 않았다.

## 남은 문제 (이 PR 밖)

keeper 샌드박스 경계가 방향에 따라 다르다. 쓰기는 `Execute` 의 argv로 샌드박스 밖에 나가고(`exec_policy.mli:53-62` — argv는 opaque, 분류하지 않는 것이 문서화된 설계), 검증 읽기는 artifact 참조를 샌드박스 상대경로로만 해석한다. 그래서 keeper가 실제로 한 작업이 `artifact_unreadable: missing` 으로 거부된다. task-159가 그 사례다. 경계 규칙 자체를 바꾸는 일이라 RFC가 먼저다.

RFC-WAIVED: credential/identity/operator-control/sandbox/hooks 어느 subsystem도 건드리지 않는다. 변경은 turn observation lifecycle, 대시보드 projection, 클라이언트 렌더에 한정된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
