### PR TITLE
refactor(lib): 동일 구현 55건 공통화 (중복 793줄 중 판정 후 적용)

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -22,27 +22,27 @@ the categorization roadmap. Newly-added typed getters in
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_ADMIN_TOKEN` | string_literal | n/a | n/a | 493 | SSOT for auth env-var names (issue 8352). |
+| `MASC_ADMIN_TOKEN` | string_literal | n/a | n/a | 502 | SSOT for auth env-var names (issue 8352). |
 | `MASC_BASE_PATH` | string_literal | n/a | n/a | 346 | Env var names exposed as SSOT constants so out-of-process callers that read/write the variable by name (docker worker... |
 | `MASC_BASE_PATH_INPUT` | string_literal | n/a | n/a | 347 | Env var names exposed as SSOT constants so out-of-process callers that read/write the variable by name (docker worker... |
-| `MASC_BUILD_GIT_COMMIT` | string_literal | n/a | n/a | 540 | Git commit hash override for build identity. |
+| `MASC_BUILD_GIT_COMMIT` | string_literal | n/a | n/a | 549 | Git commit hash override for build identity. |
 | `MASC_CLUSTER_NAME` | string_literal | n/a | n/a | 264 |  |
-| `MASC_CONFIG_DIR` | string_literal | n/a | n/a | 472 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
-| `MASC_DATA_DIR` | string_literal | n/a | n/a | 484 | SSOT for the MASC_DATA_DIR env-var name (issue 8352). Overrides [<base_path>/data] as the root for runtime data stores. |
-| `MASC_GIT_FETCH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 512 | [git fetch origin] is network-bound and can stall behind a slow Docker bridge or a large remote. Default 120s gives e... |
+| `MASC_CONFIG_DIR` | string_literal | n/a | n/a | 481 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
+| `MASC_DATA_DIR` | string_literal | n/a | n/a | 493 | SSOT for the MASC_DATA_DIR env-var name (issue 8352). Overrides [<base_path>/data] as the root for runtime data stores. |
+| `MASC_GIT_FETCH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 521 | [git fetch origin] is network-bound and can stall behind a slow Docker bridge or a large remote. Default 120s gives e... |
 | `MASC_HOST` | string_literal | n/a | n/a | 235 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
 | `MASC_HOST_FD_PRESSURE_POLLER_DISABLED` | typed:bool | Policies | operator | 330 | Operator policy toggle for disabling host fd pressure polling. @category Policies @ops_class operator |
 | `MASC_HOST_FD_PRESSURE_POLL_INTERVAL_SEC` | typed:float | Timeouts | operator | 336 | Operator timeout/interval knob for host fd pressure polling cadence. @category Timeouts @ops_class operator |
 | `MASC_HOST_FD_PRESSURE_STATE_FILE` | string_literal | n/a | n/a | 319 | {1 Host pressure integration} |
 | `MASC_HTTP_BASE_URL` | string_literal | n/a | n/a | 277 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 | `MASC_HTTP_PORT` | string_literal | n/a | n/a | 236 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
-| `MASC_LOG_LEVEL` | string_literal | n/a | n/a | 517 | SSOT for logging / observability env-var names (issue 8352). |
-| `MASC_LOG_ROUTINE_LEVEL` | string_literal | n/a | n/a | 518 | SSOT for logging / observability env-var names (issue 8352). |
-| `MASC_ORCHESTRATOR_ENABLED` | string_literal | n/a | n/a | 468 | SSOT for the MASC_ORCHESTRATOR_ENABLED env-var name (issue 8352). Referenced by feature_flag_registry catalog, env_co... |
+| `MASC_LOG_LEVEL` | string_literal | n/a | n/a | 526 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_LOG_ROUTINE_LEVEL` | string_literal | n/a | n/a | 527 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_ORCHESTRATOR_ENABLED` | string_literal | n/a | n/a | 477 | SSOT for the MASC_ORCHESTRATOR_ENABLED env-var name (issue 8352). Referenced by feature_flag_registry catalog, env_co... |
 | `MASC_PARSE_WARN` | string_literal | n/a | n/a | 34 |  |
-| `MASC_PERSONAS_DIR` | string_literal | n/a | n/a | 473 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
-| `MASC_PUBSUB_MAX_MESSAGES` | typed:int | unclassified | unclassified | 544 | PubSub max messages per read. Default: 1000. |
-| `MASC_TELEMETRY_ENABLED` | typed:bool | unclassified | unclassified | 529 | Whether telemetry tracking is enabled. Default: true. |
+| `MASC_PERSONAS_DIR` | string_literal | n/a | n/a | 482 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
+| `MASC_PUBSUB_MAX_MESSAGES` | typed:int | unclassified | unclassified | 553 | PubSub max messages per read. Default: 1000. |
+| `MASC_TELEMETRY_ENABLED` | typed:bool | unclassified | unclassified | 538 | Whether telemetry tracking is enabled. Default: true. |
 | `MASC_TEST_ALLOW_HOME_BASE_PATH` | string_literal | n/a | n/a | 405 | #9903: production base-path safeguard for test executables. Without this, a test whose [MASC_BASE_PATH] override fail... |
 | `MASC_URL` | string_literal | n/a | n/a | 278 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 

--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -621,6 +621,18 @@ let log_gate_decision config ~agent_id ~trace_id ~decision ~action_type ~confirm
     ])
     ~outcome:Success ()
 
+(** Render the result of an audit write as a two-field JSON receipt.
+    [Ok ()] becomes [{"recorded": true}]; [Error detail] becomes
+    [{"recorded": false, "error": <detail>}] with the detail passed through
+    {!Observability_redact.redact_text}. *)
+let write_result_to_json = function
+  | Ok () -> `Assoc [("recorded", `Bool true)]
+  | Error detail ->
+    `Assoc [
+      ("recorded", `Bool false);
+      ("error", `String (Observability_redact.redact_text detail));
+    ]
+
 (** {1 Pruning (replaces rotation)} *)
 
 (** Prune audit entries older than [days] days.

--- a/lib/audit_log.mli
+++ b/lib/audit_log.mli
@@ -207,6 +207,12 @@ val log_gate_decision :
   confirmation_state:string ->
   unit -> unit
 
+val write_result_to_json : (unit, string) result -> Yojson.Safe.t
+(** Render the result of an audit write as a two-field JSON receipt.
+    [Ok ()] becomes [{"recorded": true}]; [Error detail] becomes
+    [{"recorded": false, "error": <detail>}] with the detail passed through
+    {!Observability_redact.redact_text}. *)
+
 (** {1 Maintenance} *)
 
 (** {1 Statistics} *)

--- a/lib/cancel_safe/cancel_safe.ml
+++ b/lib/cancel_safe/cancel_safe.ml
@@ -13,3 +13,11 @@ let protect ~on_exn f =
   | exn -> on_exn exn
 
 let observe ~on_exn f = protect ~on_exn f
+
+let is_internal_race_cancel exn =
+  match exn with
+  | Eio.Cancel.Cancelled _ ->
+      let msg = Printexc.to_string exn in
+      String.equal msg "Cancelled: Eio__core__Fiber.Not_first"
+      || String.ends_with ~suffix:"Eio__core__Fiber.Not_first" msg
+  | _ -> false

--- a/lib/cancel_safe/cancel_safe.mli
+++ b/lib/cancel_safe/cancel_safe.mli
@@ -21,3 +21,12 @@ val observe : on_exn:(exn -> unit) -> (unit -> unit) -> unit
 (** [observe ~on_exn f] is [protect ~on_exn f] specialised for callbacks
     whose result is [unit]. Typical use: lifecycle observers that must
     record a failure but continue the surrounding workflow. *)
+
+val is_internal_race_cancel : exn -> bool
+(** [is_internal_race_cancel exn] returns [true] when [exn] is an
+    [Eio.Cancel.Cancelled] whose [Printexc.to_string] rendering is
+    ["Cancelled: Eio__core__Fiber.Not_first"] or ends with
+    ["Eio__core__Fiber.Not_first"]. That payload comes from Eio's own
+    [Fiber.first] race resolution — the losing fiber is cancelled by the
+    runtime, not by the surrounding switch. Any other exception, including
+    every other [Cancelled] payload, returns [false]. *)

--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -443,6 +443,15 @@ let base_path () =
         "MASC_BASE_PATH is not set. Set MASC_BASE_PATH to the project root \
          containing the .masc/ directory.")
 
+(** Resolve a configured path against the project base path. Relative
+    paths are concatenated onto [base_path ()]; absolute paths are
+    returned unchanged. *)
+let resolve_against_base_path raw_path =
+  if Filename.is_relative raw_path then
+    Filename.concat (base_path ()) raw_path
+  else
+    raw_path
+
 let sb_path_opt () =
   match base_path_opt () with
   | Some root ->

--- a/lib/config/env_config_core.mli
+++ b/lib/config/env_config_core.mli
@@ -156,6 +156,13 @@ val running_under_test_executable : unit -> bool
 val test_allow_home_base_path_env : string
 val base_path_prod_guard : string -> string
 val base_path : unit -> string
+
+val resolve_against_base_path : string -> string
+(** [resolve_against_base_path raw] returns [raw] unchanged when it is
+    absolute, and [Filename.concat (base_path ()) raw] when it is
+    relative.  Raises [Config_error] through [base_path] when
+    [MASC_BASE_PATH] is unset. *)
+
 val sb_path_opt : unit -> string option
 val sb_path_result : unit -> (string, string) result
 val sb_path : unit -> string

--- a/lib/core/atomic_util.ml
+++ b/lib/core/atomic_util.ml
@@ -1,0 +1,6 @@
+(* See atomic_util.mli for the contract. *)
+
+let rec update atomic f =
+  let old_val = Atomic.get atomic in
+  let new_val = f old_val in
+  if Atomic.compare_and_set atomic old_val new_val then () else update atomic f

--- a/lib/core/dune
+++ b/lib/core/dune
@@ -12,6 +12,7 @@
  (flags
   (:standard -w +4 -w +32))
  (modules
+  atomic_util
   json_util
   safe_ops
   common

--- a/lib/core/json_util.ml
+++ b/lib/core/json_util.ml
@@ -192,6 +192,13 @@ let string_opt_to_json_trimmed : string option -> Yojson.Safe.t = function
     if trimmed <> "" then `String trimmed else `Null
   | None -> `Null
 
+(** Ratio of two ints as a JSON float, or [`Null] when the denominator
+    is 0 (no NaN reaches the wire). *)
+let int_ratio_json numerator denominator =
+  if denominator = 0
+  then `Null
+  else `Float (float_of_int numerator /. float_of_int denominator)
+
 let float_opt_to_json : float option -> Yojson.Safe.t = function
   | Some f -> `Float f
   | None -> `Null
@@ -235,6 +242,21 @@ let assoc_float_opt name json =
   | Some (`Int value) -> Some (Float.of_int value)
   | _ -> None
 
+(** Scans a JSON array for the first [`Assoc] row whose [field] member is
+    the string [value].  Rows that are not objects, and rows without a
+    string [field], are skipped. *)
+let find_assoc_row_by_string_field ~field ~value = function
+  | `List rows ->
+    List.find_map
+      (function
+        | (`Assoc _ as row) -> (
+          match assoc_member_opt field row with
+          | Some (`String candidate) when String.equal candidate value -> Some row
+          | _ -> None)
+        | _ -> None)
+      rows
+  | _ -> None
+
 let json_string_list_member name json =
   try
     match Yojson.Safe.Util.member name json with
@@ -250,6 +272,63 @@ let json_string_list_member name json =
   | Yojson.Safe.Util.Type_error _ -> []
 
 
+(** {1 Assoc field validation (Result-returning)}
+
+    These operate on an already-destructured [`Assoc] field list rather
+    than on a whole [Yojson.Safe.t] (that is the [require_*] family
+    above).  [surface] names the object in the error message, so a
+    failure reads ["<surface>.<field> is required"]. *)
+
+let reject_unknown_fields ~surface ~allowed fields =
+  let rec duplicate seen = function
+    | [] -> None
+    | (key, _) :: rest ->
+      if List.mem key seen then Some key else duplicate (key :: seen) rest
+  in
+  match duplicate [] fields with
+  | Some field -> Error (Printf.sprintf "%s contains duplicate field %s" surface field)
+  | None ->
+    (match List.find_opt (fun (key, _) -> not (List.mem key allowed)) fields with
+     | None -> Ok ()
+     | Some (field, _) ->
+       Error (Printf.sprintf "%s contains unsupported field %s" surface field))
+
+let require_field_string ~surface field fields =
+  match List.assoc_opt field fields with
+  | Some (`String value) when String.trim value <> "" -> Ok value
+  | Some (`String _) ->
+    Error (Printf.sprintf "%s.%s must be non-blank" surface field)
+  | Some _ -> Error (Printf.sprintf "%s.%s must be a string" surface field)
+  | None -> Error (Printf.sprintf "%s.%s is required" surface field)
+
+let require_field_float ~surface field fields =
+  match List.assoc_opt field fields with
+  | Some (`Float value) -> Ok value
+  | Some (`Int value) -> Ok (Float.of_int value)
+  | Some _ -> Error (Printf.sprintf "%s.%s must be a number" surface field)
+  | None -> Error (Printf.sprintf "%s.%s is required" surface field)
+
+let require_field_positive_int ~surface field fields =
+  match List.assoc_opt field fields with
+  | Some (`Int value) when value > 0 -> Ok value
+  | Some _ -> Error (Printf.sprintf "%s.%s must be a positive integer" surface field)
+  | None -> Error (Printf.sprintf "%s.%s is required" surface field)
+
+let require_field_string_list ~surface field fields =
+  match List.assoc_opt field fields with
+  | Some (`List values) ->
+    let rec parse index acc = function
+      | [] -> Ok (List.rev acc)
+      | `String value :: rest -> parse (index + 1) (value :: acc) rest
+      | _ :: _ ->
+        Error
+          (Printf.sprintf "%s.%s[%d] must be a string" surface field index)
+    in
+    parse 0 [] values
+  | Some _ -> Error (Printf.sprintf "%s.%s must be an array" surface field)
+  | None -> Error (Printf.sprintf "%s.%s is required" surface field)
+
+
 (** List utilities *)
 
 let dedupe_keep_order xs =
@@ -262,3 +341,9 @@ let dedupe_keep_order xs =
           loop (x :: seen) (x :: acc) rest
   in
   loop [] [] xs
+
+let normalize_string_list items =
+  items
+  |> List.map String.trim
+  |> List.filter (fun item -> not (String.equal item ""))
+  |> dedupe_keep_order

--- a/lib/core/json_util.mli
+++ b/lib/core/json_util.mli
@@ -53,6 +53,10 @@ val string_opt_to_json_trimmed : string option -> Yojson.Safe.t
 (** [string_opt_to_json_trimmed] trims whitespace and returns [`Null]
     for empty or whitespace-only strings. *)
 val int_opt_to_json : int option -> Yojson.Safe.t
+val int_ratio_json : int -> int -> Yojson.Safe.t
+(** [int_ratio_json numerator denominator] returns
+    [`Float (numerator /. denominator)] as floats, or [`Null] when
+    [denominator] is 0. *)
 val float_opt_to_json : float option -> Yojson.Safe.t
 val bool_opt_to_json : bool option -> Yojson.Safe.t
 val string_opt_field : string -> string option -> string * Yojson.Safe.t
@@ -90,11 +94,75 @@ val assoc_bool_opt : string -> Yojson.Safe.t -> bool option
 val assoc_float_opt : string -> Yojson.Safe.t -> float option
 (** [assoc_float_opt name json] extracts float field, coerces int to float *)
 
+val find_assoc_row_by_string_field :
+  field:string -> value:string -> Yojson.Safe.t -> Yojson.Safe.t option
+(** [find_assoc_row_by_string_field ~field ~value json] returns the first
+    [`Assoc] row of the JSON array [json] whose [field] member is the
+    string [value].  Returns [None] when [json] is not an array or when
+    no row matches. *)
+
 val json_string_list_member : string -> Yojson.Safe.t -> string list
 (** [json_string_list_member name json] extracts a list of non-empty
     trimmed strings from the JSON array at field [name]. Returns [[]]
     if the field is missing or not an array. *)
+(** {1 Assoc field validation (Result-returning)}
+
+    These take an already-destructured [`Assoc] field list, unlike the
+    [require_*] family above which takes a whole [Yojson.Safe.t].
+    [surface] names the object in the error message, so a failure reads
+    ["<surface>.<field> is required"]. *)
+
+val reject_unknown_fields :
+  surface:string ->
+  allowed:string list ->
+  (string * Yojson.Safe.t) list ->
+  (unit, string) result
+(** [reject_unknown_fields ~surface ~allowed fields] returns [Ok ()] when
+    every key in [fields] appears in [allowed] and no key repeats.
+    Reports the duplicate key first, then the first unsupported key. *)
+
+val require_field_string :
+  surface:string ->
+  string ->
+  (string * Yojson.Safe.t) list ->
+  (string, string) result
+(** [require_field_string ~surface field fields] returns the string at
+    [field].  Errors when the field is missing, is not a string, or is
+    blank after trimming.  The value is returned untrimmed. *)
+
+val require_field_float :
+  surface:string ->
+  string ->
+  (string * Yojson.Safe.t) list ->
+  (float, string) result
+(** [require_field_float ~surface field fields] returns the float at
+    [field], widening [`Int] to float.  Errors when the field is missing
+    or is neither a float nor an int. *)
+
+val require_field_positive_int :
+  surface:string ->
+  string ->
+  (string * Yojson.Safe.t) list ->
+  (int, string) result
+(** [require_field_positive_int ~surface field fields] returns the int at
+    [field] when it is greater than 0.  Errors when the field is missing,
+    is not an int, or is 0 or negative. *)
+
+val require_field_string_list :
+  surface:string ->
+  string ->
+  (string * Yojson.Safe.t) list ->
+  (string list, string) result
+(** [require_field_string_list ~surface field fields] returns the array at
+    [field] as a string list.  Errors when the field is missing, is not an
+    array, or holds a non-string element (the error names its index). *)
+
 (** List utilities *)
 
 val dedupe_keep_order : 'a list -> 'a list
 (** [dedupe_keep_order xs] removes duplicates while preserving order *)
+
+val normalize_string_list : string list -> string list
+(** [normalize_string_list items] trims each item, drops the ones that
+    are empty after trimming, and removes duplicates while preserving
+    the order of first occurrence. *)

--- a/lib/core/list_util.ml
+++ b/lib/core/list_util.ml
@@ -11,6 +11,15 @@
 let count_if pred xs =
   List.fold_left (fun n x -> if pred x then n + 1 else n) 0 xs
 
+(** [take_first n xs] returns the first [n] elements of [xs].
+    Returns [[]] when [n <= 0] and [xs] when [List.length xs <= n]. *)
+let rec take_first n xs =
+  if n <= 0 then []
+  else
+    match xs with
+    | [] -> []
+    | x :: rest -> x :: take_first (n - 1) rest
+
 (** [take_last n xs] returns the last [n] elements of [xs].
     Returns [[]] when [n <= 0] and [xs] when [List.length xs <= n]. *)
 let take_last n xs =

--- a/lib/core/list_util.mli
+++ b/lib/core/list_util.mli
@@ -5,6 +5,10 @@ val count_if : ('a -> bool) -> 'a list -> int
     but does not allocate the intermediate filter list. Single fold,
     O(n) time, O(1) extra space. *)
 
+val take_first : int -> 'a list -> 'a list
+(** [take_first n xs] returns the first [n] elements of [xs].
+    Returns [[]] when [n <= 0] and [xs] when [List.length xs <= n]. *)
+
 val take_last : int -> 'a list -> 'a list
 (** [take_last n xs] returns the last [n] elements of [xs].
     Returns [[]] when [n <= 0] and [xs] when [List.length xs <= n]. *)

--- a/lib/core/safe_ops.ml
+++ b/lib/core/safe_ops.ml
@@ -412,6 +412,18 @@ let report_persistence_read_drop ~on_drop ~surface ~reason ~path ~detail =
     surface reason path detail;
   on_drop ()
 
+(* The counted variant of [report_persistence_read_drop]: the [on_drop]
+   callback existed so callers could supply the counter, and every JSONL
+   surface supplied the same one. *)
+let report_persistence_read_drop_counted ~surface ~reason ~path ~detail =
+  report_persistence_read_drop
+    ~on_drop:(fun () ->
+      Otel_metric_store_core.inc_counter
+        Otel_metric_names.metric_persistence_read_drops
+        ~labels:[ ("surface", surface); ("reason", reason) ]
+        ())
+    ~surface ~reason ~path ~detail
+
 let result_to_option_logged ~on_drop ~surface ~reason ~path = function
   | Ok value -> Some value
   | Error detail ->
@@ -559,6 +571,16 @@ let json_string_opt key json =
   match safe_member key json with
   | `String s -> Some s
   | _ -> None
+
+(* Trimmed variant of json_string_opt: whitespace-only values are dropped
+   rather than surfaced as an empty string, and the returned value is the
+   trimmed one. *)
+let json_string_nonempty_opt key json =
+  match json_string_opt key json with
+  | Some value ->
+      let value = String.trim value in
+      if value = "" then None else Some value
+  | None -> None
 
 (* String-coercing *_opt variants mirror json_int/json_float/json_bool:
    accept stringified numerics/bools from small-LLM callers. Missing key

--- a/lib/core/safe_ops.mli
+++ b/lib/core/safe_ops.mli
@@ -126,6 +126,17 @@ val report_persistence_read_drop :
   unit
 (** Report a persisted read-model drop via WARN log + Otel_metric_store counter. *)
 
+val report_persistence_read_drop_counted :
+  surface:string ->
+  reason:string ->
+  path:string ->
+  detail:string ->
+  unit
+(** [report_persistence_read_drop_counted] calls
+    {!report_persistence_read_drop} with the drop counter every JSONL
+    surface uses: [masc_persistence_read_drops_total] incremented with
+    labels [surface] and [reason]. *)
+
 val result_to_option_logged :
   on_drop:(unit -> unit) ->
   surface:string ->
@@ -182,6 +193,12 @@ val json_float : ?default:float -> string -> Yojson.Safe.t -> float
 val json_bool : ?default:bool -> string -> Yojson.Safe.t -> bool
 val json_string_list : string -> Yojson.Safe.t -> string list
 val json_string_opt : string -> Yojson.Safe.t -> string option
+
+val json_string_nonempty_opt : string -> Yojson.Safe.t -> string option
+(** [json_string_nonempty_opt key json] returns the trimmed string field
+    [key], or [None] when the field is missing, is not a string, or is
+    empty after trimming. *)
+
 val json_int_opt : string -> Yojson.Safe.t -> int option
 val json_float_opt : string -> Yojson.Safe.t -> float option
 val json_bool_opt : string -> Yojson.Safe.t -> bool option

--- a/lib/core/string_util.ml
+++ b/lib/core/string_util.ml
@@ -300,6 +300,11 @@ let strip_trailing_cr s =
   let len = String.length s in
   if len > 0 && s.[len - 1] = '\r' then String.sub s 0 (len - 1) else s
 
+let first_line text =
+  match String.index_opt text '\n' with
+  | Some i -> String.sub text 0 i
+  | None -> text
+
 (* XML 1.0 entity escape.  Order matters: [&] first so that the
    ampersands introduced by the other replacements are not
    double-escaped. *)

--- a/lib/core/string_util.mli
+++ b/lib/core/string_util.mli
@@ -130,6 +130,10 @@ val compact_text : ?max_len:int -> string -> string
 
 val strip_trailing_cr : string -> string
 (** [strip_trailing_cr s] removes a trailing ['\\r'] character if present. *)
+
+val first_line : string -> string
+(** [first_line text] returns the bytes of [text] before the first ['\\n'].
+    Returns [text] unchanged when it contains no ['\\n']. Does not trim. *)
 val escape_xml : string -> string
 (** Escape the five XML 1.0 predefined entities: ampersand,
     less-than, greater-than, double-quote, and apostrophe.

--- a/lib/dashboard/dashboard_briefing.ml
+++ b/lib/dashboard/dashboard_briefing.ml
@@ -26,56 +26,6 @@ let matching_action target_type target_id actions =
       | _ -> false)
     actions
 
-let incident_action_types kind =
-  match kind with
-  | "spawn_failure_present" -> [ "task_inject" ]
-  | "detached_actor_present"
-  | "empty_note_turn_present"
-  | "low_confidence_routing"
-  | "routing_escalation_present" ->
-      [ "broadcast" ]
-  | "planned_worker_without_turn" -> [ "task_inject"; "broadcast" ]
-  | "local64_role_gap" -> [ "task_inject" ]
-  | "stalled_session" -> [ "namespace_pause" ]
-  | "command_issue_pressure"
-  | "command_routing_confidence"
-  | "command_quality_per_token"
-  | "command_verification_gate_failures"
-  | "command_rework_rate"
-  | "command_artifact_scope_drift"
-  | "command_cache_contention"
-  | "command_speculative_posture"
-  | "intent_blocked"
-  | "intent_handoff_ready" ->
-      [ "broadcast" ]
-  | _ -> []
-
-let action_matches_incident incident action =
-  let target_type = string_field "target_type" incident in
-  let target_id = String_util.trim_to_option (string_field "target_id" incident) in
-  let action_target_type = string_field "target_type" action in
-  let action_target_id = String_util.trim_to_option (string_field "target_id" action) in
-  let same_target =
-    String.equal action_target_type target_type
-    &&
-    match target_id, action_target_id with
-    | Some left, Some right -> String.equal left right
-    | None, None -> true
-    | _ -> false
-  in
-  if not same_target then false
-  else
-    let incident_summary = normalized_text_key (string_field "summary" incident) in
-    let action_reason = normalized_text_key (string_field "reason" action) in
-    let reason_matches =
-      incident_summary <> "" && action_reason <> ""
-      && String.equal incident_summary action_reason
-    in
-    if reason_matches then true
-    else
-      let action_type = string_field "action_type" action in
-      List.mem action_type (incident_action_types (string_field "kind" incident))
-
 let matching_action_for_incident incident actions =
   let target_type = string_field "target_type" incident in
   let target_id = String_util.trim_to_option (string_field "target_id" incident) in
@@ -91,7 +41,11 @@ let matching_action_for_incident incident actions =
            | None, None -> true
            | _ -> false)
   in
-  match List.find_opt (action_matches_incident incident) candidates with
+  match
+    List.find_opt
+      (Dashboard_briefing_assembly.action_matches_incident incident)
+      candidates
+  with
   | Some action -> Some action
   | None -> (match candidates with action :: _ -> Some action | [] -> None)
 

--- a/lib/dashboard/dashboard_briefing_assembly.mli
+++ b/lib/dashboard/dashboard_briefing_assembly.mli
@@ -51,3 +51,16 @@ val build_internal_signals :
     operator's incident + recommended-action streams into
     one internal-signal list, sorted by descending
     pressure rank. *)
+
+(** {1 Incident / action pairing} *)
+
+val action_matches_incident : Yojson.Safe.t -> Yojson.Safe.t -> bool
+(** [action_matches_incident incident action] returns [true]
+    when [action] targets the same [target_type] /
+    [target_id] pair as [incident] and either its
+    normalized [reason] equals the incident's normalized
+    [summary] (both non-empty), or its [action_type] is one
+    of the types listed for the incident's [kind].  Returns
+    [false] on a target mismatch.  Shared with
+    {!Dashboard_briefing}, which pairs the same operator
+    digest streams. *)

--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -173,14 +173,6 @@ let is_compute_timeout exn =
   | Compute_timeout _ -> true
   | _ -> false
 
-let is_internal_race_cancel exn =
-  match exn with
-  | Eio.Cancel.Cancelled _ ->
-      let msg = Printexc.to_string exn in
-      String.equal msg "Cancelled: Eio__core__Fiber.Not_first"
-      || String.ends_with ~suffix:"Eio__core__Fiber.Not_first" msg
-  | _ -> false
-
 let should_restore_stale_after_failure exn =
   match exn with
   | Compute_timeout _ -> true
@@ -370,7 +362,7 @@ let get_or_compute_eio ?wait_timeout_sec key ~ttl compute =
         | exception exn ->
           (match exn with
            | Compute_timeout _ -> ()
-           | _ when is_internal_race_cancel exn ->
+           | _ when Cancel_safe.is_internal_race_cancel exn ->
                Log.Dashboard.debug "cache bg-revalidate race-cancel for %s, scheduling early retry" key
            | _ -> Log.Dashboard.warn "cache bg-revalidate failed (%s): %s" key (Printexc.to_string exn));
           atomic_update table (fun map ->
@@ -381,7 +373,7 @@ let get_or_compute_eio ?wait_timeout_sec key ~ttl compute =
               (* After race-cancel, set expires_at = ts so the next lookup
                  immediately triggers recompute instead of returning stale. *)
               let expires_at =
-                if is_internal_race_cancel exn then ts else ts +. backoff_grace
+                if Cancel_safe.is_internal_race_cancel exn then ts else ts +. backoff_grace
               in
               ((), SMap.add key (Ready { value = stale_value; expires_at; stale_until = ts +. backoff_grace }) map)
             | _ -> ((), map)
@@ -474,7 +466,7 @@ let get_or_compute_eio ?wait_timeout_sec key ~ttl compute =
            value
        | Some (Error exn) ->
            let fallback_val = ref None in
-           if not (is_internal_race_cancel exn || is_compute_timeout exn) then
+           if not (Cancel_safe.is_internal_race_cancel exn || is_compute_timeout exn) then
              Log.Dashboard.error "cache revalidation failed: %s" (Printexc.to_string exn);
            atomic_update table (fun map ->
              match SMap.find_opt key map with

--- a/lib/dashboard/dashboard_http_keeper_detail.ml
+++ b/lib/dashboard/dashboard_http_keeper_detail.ml
@@ -29,13 +29,6 @@ let init_acc =
   ; ma_last_handoff = None
   }
 
-let nonempty_string_opt key json =
-  match Safe_ops.json_string_opt key json with
-  | Some value ->
-      let value = String.trim value in
-      if value = "" then None else Some value
-  | None -> None
-
 let string_list_member_opt key json =
   match Json_util.assoc_member_opt key json with
   | Some (`List values) ->
@@ -48,11 +41,6 @@ let string_list_member_opt key json =
       in
       decode [] values
   | _ -> None
-
-let ratio_json numerator denominator =
-  if denominator = 0
-  then `Null
-  else `Float (float_of_int numerator /. float_of_int denominator)
 
 let compute_metrics_window
     ~(parsed_metrics : Yojson.Safe.t list)
@@ -94,7 +82,7 @@ let compute_metrics_window
             in
             (match
                Safe_ops.json_float_opt "ts_unix" json,
-               nonempty_string_opt "trace_id" json,
+               Safe_ops.json_string_nonempty_opt "trace_id" json,
                Safe_ops.json_int_opt "generation" json,
                Safe_ops.json_int_opt "latency_ms" json,
                Safe_ops.json_int_opt "tool_call_count" json,
@@ -125,10 +113,10 @@ let compute_metrics_window
                  in
                  let handoff_obj = member "handoff" json in
                  let handoff_prev_trace_id =
-                   nonempty_string_opt "prev_trace_id" handoff_obj
+                   Safe_ops.json_string_nonempty_opt "prev_trace_id" handoff_obj
                  in
                  let handoff_new_trace_id =
-                   nonempty_string_opt "new_trace_id" handoff_obj
+                   Safe_ops.json_string_nonempty_opt "new_trace_id" handoff_obj
                  in
                  let handoff_new_generation =
                    Safe_ops.json_int_opt "to_generation" handoff_obj
@@ -350,14 +338,14 @@ let compute_metrics_window
       ; "handoff_count", `Int acc.ma_handoff_count
       ; "fallback_count", `Int acc.ma_fallback_count
       ; ( "fallback_rate"
-        , ratio_json
+        , Json_util.int_ratio_json
             acc.ma_fallback_count
             acc.ma_fallback_observed_points )
       ; "fallback_observed_points", `Int acc.ma_fallback_observed_points
       ; ( "intervention_share"
-        , ratio_json acc.ma_proactive_points interaction_points )
+        , Json_util.int_ratio_json acc.ma_proactive_points interaction_points )
       ; ( "intervention_per_turn"
-        , ratio_json acc.ma_proactive_points acc.ma_turn_points )
+        , Json_util.int_ratio_json acc.ma_proactive_points acc.ma_turn_points )
       ; "tool_call_count", `Int acc.ma_tool_call_count
       ; "top_work_kinds", `List top_work_kinds
       ; "top_tools", `List top_tools

--- a/lib/dashboard/dashboard_http_keeper_types.ml
+++ b/lib/dashboard/dashboard_http_keeper_types.ml
@@ -129,12 +129,7 @@ let sort_by_latest_ts jsons =
 let string_member_nonempty key json =
   Option.bind (Safe_ops.json_string_opt key json) nonempty_string_opt
 
-let rec take_list n xs =
-  if n <= 0 then []
-  else
-    match xs with
-    | [] -> []
-    | x :: rest -> x :: take_list (n - 1) rest
+let take_list n xs = List_util.take_first n xs
 
 let percentile_sorted_float (sorted : float array) (p : float) : float =
   let n = Array.length sorted in

--- a/lib/exec/exec_gate.ml
+++ b/lib/exec/exec_gate.ml
@@ -2,6 +2,8 @@
    fields are observability context; they do not authorize or classify the
    command. *)
 
+let raw_source_of_argv argv = String.concat " " (List.map Filename.quote argv)
+
 let run_argv ~actor:_ ~raw_source:_ ~summary:_
     ?timeout_sec ?env argv =
   Process_eio.run_argv ?timeout_sec ?env argv

--- a/lib/exec/exec_gate.mli
+++ b/lib/exec/exec_gate.mli
@@ -1,6 +1,10 @@
 (** Production spawn wrappers around [Process_eio].  Actor, source, and
     summary are observability context only. *)
 
+val raw_source_of_argv : string list -> string
+(** Joins [argv] with a single space after passing each element through
+    [Filename.quote], producing the string passed as [~raw_source]. *)
+
 val run_argv :
   actor:Agent_id.t ->
   raw_source:string ->

--- a/lib/fs_compat/atomic_write.ml
+++ b/lib/fs_compat/atomic_write.ml
@@ -2770,22 +2770,14 @@ let atomic_orphan_cleanup_operation_to_string = function
   | Close_cleanup_descriptor -> "close_cleanup_descriptor"
 ;;
 
-let file_kind_to_string = function
-  | Unix.S_REG -> "regular_file"
-  | Unix.S_DIR -> "directory"
-  | Unix.S_CHR -> "character_device"
-  | Unix.S_BLK -> "block_device"
-  | Unix.S_LNK -> "symbolic_link"
-  | Unix.S_FIFO -> "fifo"
-  | Unix.S_SOCK -> "socket"
-;;
-
 let atomic_orphan_cleanup_cause_to_string = function
   | Unix_failure (error, fn, arg) ->
     Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message error)
   | Sys_failure detail -> detail
   | Unexpected_file_kind kind ->
-    Printf.sprintf "unexpected file kind: %s" (file_kind_to_string kind)
+    Printf.sprintf
+      "unexpected file kind: %s"
+      (Owned_directory_chain.file_kind_to_string kind)
   | Outside_ownership_root { ownership_root } ->
     Printf.sprintf "path is outside ownership root: %s" ownership_root
   | Identity_changed -> "filesystem identity changed during cleanup"

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -698,15 +698,7 @@ let owned_regular_file_read_operation_to_string = function
   | Close_descriptor -> "close_descriptor"
 ;;
 
-let file_kind_to_string = function
-  | Unix.S_REG -> "regular_file"
-  | Unix.S_DIR -> "directory"
-  | Unix.S_CHR -> "character_device"
-  | Unix.S_BLK -> "block_device"
-  | Unix.S_LNK -> "symbolic_link"
-  | Unix.S_FIFO -> "fifo"
-  | Unix.S_SOCK -> "socket"
-;;
+let file_kind_to_string = Owned_directory_chain.file_kind_to_string
 
 let owned_regular_file_read_failure_to_string = function
   | Ownership_boundary_rejected { path; rejection } ->

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -168,6 +168,11 @@ val inspect_owned_directory_chain
   -> (owned_directory_chain_observation, owned_directory_chain_rejection) result
 (** Shared no-follow ownership-boundary inspection. *)
 
+val file_kind_to_string : Unix.file_kind -> string
+(** Render a [Unix.file_kind] as the lowercase snake_case name of the
+    constructor ([S_REG] becomes ["regular_file"], [S_FIFO] becomes
+    ["fifo"]). *)
+
 val owned_directory_chain_rejection_to_string
   :  owned_directory_chain_rejection
   -> string

--- a/lib/fs_compat/owned_directory_chain.mli
+++ b/lib/fs_compat/owned_directory_chain.mli
@@ -19,6 +19,11 @@ type observation =
   | Owned_directory_missing
   | Owned_directory of Unix.stats
 
+val file_kind_to_string : Unix.file_kind -> string
+(** Render a [Unix.file_kind] as the lowercase snake_case name of the
+    constructor ([S_REG] becomes ["regular_file"], [S_FIFO] becomes
+    ["fifo"]). *)
+
 val rejection_to_string : rejection -> string
 
 val paths

--- a/lib/gate/channel_gate_binding_store.ml
+++ b/lib/gate/channel_gate_binding_store.ml
@@ -219,6 +219,12 @@ let bound_channels_result store ~keeper_name =
              else None)
            bindings)
 
+let find_binding_by_channel_id (bindings : binding list) ~channel_id =
+  List.find_map
+    (fun (binding : binding) ->
+      if String.equal binding.channel_id channel_id then Some binding else None)
+    bindings
+
 let binding_json (binding : binding) =
   `Assoc
     [

--- a/lib/gate/channel_gate_binding_store.mli
+++ b/lib/gate/channel_gate_binding_store.mli
@@ -79,6 +79,13 @@ val mutation_error_to_string : mutation_error -> string
 val read_bindings_result : t -> (binding list, binding_store_error) result
 val bound_channels_result :
   t -> keeper_name:string -> (string list, binding_store_error) result
+val find_binding_by_channel_id :
+  binding list -> channel_id:string -> binding option
+(** [find_binding_by_channel_id bindings ~channel_id] returns the first
+    binding whose [channel_id] is equal to [channel_id], or [None] when
+    no binding matches.  Compares the ids as given; callers normalize
+    beforehand. *)
+
 val binding_json : binding -> Yojson.Safe.t
 val audit_event_json : t -> audit_event -> Yojson.Safe.t
 val mutate_bindings :

--- a/lib/gate/channel_gate_connector.ml
+++ b/lib/gate/channel_gate_connector.ml
@@ -27,6 +27,15 @@ module type S = sig
   val connected : unit -> bool
 end
 
+(* Wire vocabulary of the [status] field every connector emits from
+   [status_json]. Kept here, next to [S], so the connectors and the
+   dashboard read the same four values. *)
+let connector_state_label ~available ~connected ~stale =
+  if not available then "offline"
+  else if stale then "stale"
+  else if connected then "connected"
+  else "disconnected"
+
 (* Module-level registry: [register] runs during startup while [find]/[all]
    are also reachable from HTTP handlers and tests. Use Stdlib.Mutex because
    callers do not always have an Eio context, and keep the critical sections

--- a/lib/gate/channel_gate_connector.mli
+++ b/lib/gate/channel_gate_connector.mli
@@ -63,6 +63,16 @@ module type S = sig
       (status file staleness, in-process gateway state). RFC-0223 P2. *)
 end
 
+(** {1 Connector status vocabulary} *)
+
+val connector_state_label :
+  available:bool -> connected:bool -> stale:bool -> string
+(** [connector_state_label ~available ~connected ~stale] returns the
+    value connectors put in the [status] field of {!S.status_json}:
+    ["offline"] when not available, otherwise ["stale"] when the
+    liveness source is stale, otherwise ["connected"] or
+    ["disconnected"]. *)
+
 (** {1 Registry} *)
 
 val register : (module S) -> unit

--- a/lib/gate/channel_gate_discord_names.ml
+++ b/lib/gate/channel_gate_discord_names.ml
@@ -17,16 +17,10 @@ type name_map = {
 
 let default_names_path = ".gate/runtime/discord/names.json"
 
-let resolve_path raw_path =
-  if Filename.is_relative raw_path then
-    Filename.concat (Env_config_core.base_path ()) raw_path
-  else
-    raw_path
-
 let configured_write_path env_name ~default =
   match Sys.getenv_opt env_name |> Env_config_core.trim_opt with
-  | Some raw -> resolve_path raw
-  | None -> resolve_path default
+  | Some raw -> Env_config_core.resolve_against_base_path raw
+  | None -> Env_config_core.resolve_against_base_path default
 
 let names_write_path () =
   configured_write_path "MASC_DISCORD_NAMES_PATH" ~default:default_names_path

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -137,12 +137,6 @@ let bool_member json key =
 let bool_option_member json key =
   Json_util.get_bool json key
 
-let connector_state_label ~available ~connected ~stale =
-  if not available then "offline"
-  else if stale then "stale"
-  else if connected then "connected"
-  else "disconnected"
-
 let bot_token_opt () =
   match Sys.getenv_opt "DISCORD_BOT_TOKEN" with
   | None -> None
@@ -235,7 +229,10 @@ let status_json ?(audit_limit = 10) () =
       ("connected", `Bool connected);
       ("stale", `Bool stale);
       ("stale_after_sec", `Int (stale_after_sec ()));
-      ("status", `String (connector_state_label ~available ~connected ~stale));
+      ( "status",
+        `String
+          (Channel_gate_connector.connector_state_label ~available ~connected
+             ~stale) );
       ("error", `String error);
       ("status_source", `String "in_process_gateway");
       ("gateway_state", `String (gateway_state_label gateway_state));
@@ -284,19 +281,6 @@ let list_assoc_field key = function
   | `Assoc fields -> List.assoc_opt key fields
   | _ -> None
 
-let find_assoc_by_string_field ~field ~value = function
-  | `List rows ->
-      List.find_map
-        (function
-          | (`Assoc _ as row) -> (
-              match list_assoc_field field row with
-              | Some (`String candidate) when String.equal candidate value ->
-                  Some row
-              | _ -> None)
-          | _ -> None)
-        rows
-  | _ -> None
-
 let connector_json ?gate_status_json ?(audit_limit = 10) () =
   let status = status_json ~audit_limit () in
   let observed_channel =
@@ -306,8 +290,8 @@ let connector_json ?gate_status_json ?(audit_limit = 10) () =
         match list_assoc_field "channels" json with
         | Some channels -> (
             match
-              find_assoc_by_string_field ~field:"channel" ~value:channel
-                channels
+              Json_util.find_assoc_row_by_string_field ~field:"channel"
+                ~value:channel channels
             with
             | Some row -> row
             | None -> `Null)
@@ -502,12 +486,6 @@ type keeper_binding_resolution = {
   via_parent : bool;
 }
 
-let binding_for_channel bindings ~channel_id =
-  List.find_map
-    (fun (b : binding) ->
-      if String.equal b.channel_id channel_id then Some b else None)
-    bindings
-
 let resolve_keeper_for_channel_result ~channel_id =
   let normalized = String.trim channel_id in
   if String.equal normalized "" then Ok None
@@ -515,7 +493,9 @@ let resolve_keeper_for_channel_result ~channel_id =
     match read_bindings_lookup_result () with
     | Error _ as error -> error
     | Ok candidates ->
-      (match binding_for_channel candidates ~channel_id:normalized with
+      (match
+         Store.find_binding_by_channel_id candidates ~channel_id:normalized
+       with
        | Some binding ->
          Ok
            (Some
@@ -532,7 +512,7 @@ let resolve_keeper_for_channel_result ~channel_id =
                 if String.equal parent_channel_id normalized
                 then None
                 else
-                  binding_for_channel candidates
+                  Store.find_binding_by_channel_id candidates
                     ~channel_id:parent_channel_id)
          in
          Ok

--- a/lib/gate/channel_gate_discord_state.mli
+++ b/lib/gate/channel_gate_discord_state.mli
@@ -9,10 +9,11 @@
     path resolvers, the shared binding-store wrappers, the
     [string_member] / [int_member] / [bool_member] /
     [bool_option_member] yojson lookups, [stale_of_updated_at],
-    [connector_state_label], [list_assoc_field],
-    [find_assoc_by_string_field], and binding transaction helpers) are
+    [list_assoc_field], and binding transaction helpers) are
     hidden — only the {!Channel_gate_connector.S} surface is
-    public. *)
+    public.  The status label comes from
+    {!Channel_gate_connector.connector_state_label} and the observed
+    channel row from {!Json_util.find_assoc_row_by_string_field}. *)
 
 (** {1 Connector identity} *)
 

--- a/lib/gate/channel_gate_imessage_state.ml
+++ b/lib/gate/channel_gate_imessage_state.ml
@@ -17,12 +17,6 @@ let default_binding_audit_path = ".gate/runtime/imessage/binding_audit.jsonl"
 let stale_after_sec () =
   Env_config_core.get_int ~default:30 "MASC_IMESSAGE_STATUS_STALE_SEC"
 
-let resolve_path raw_path =
-  if Filename.is_relative raw_path then
-    Filename.concat (Env_config_core.base_path ()) raw_path
-  else
-    raw_path
-
 let redact_chat_guid raw =
   let value = String.trim raw in
   if value = "" then ""
@@ -34,8 +28,8 @@ let redact_chat_guid raw =
 
 let configured_write_path env_name ~default =
   match Sys.getenv_opt env_name |> Env_config_core.trim_opt with
-  | Some raw -> resolve_path raw
-  | None -> resolve_path default
+  | Some raw -> Env_config_core.resolve_against_base_path raw
+  | None -> Env_config_core.resolve_against_base_path default
 
 let status_path () =
   configured_write_path "MASC_IMESSAGE_STATUS_PATH" ~default:default_status_path
@@ -82,12 +76,6 @@ let stale_of_updated_at updated_at =
   match Gate_time_util.parse_iso8601_opt updated_at with
   | Some ts -> Unix.gettimeofday () -. ts > float_of_int (stale_after_sec ())
   | None -> true
-
-let connector_state_label ~available ~connected ~stale =
-  if not available then "offline"
-  else if stale then "stale"
-  else if connected then "connected"
-  else "disconnected"
 
 (* RFC-0223 P2: presence surface. Both recomputed per call — no cached
    presence state. *)
@@ -146,7 +134,10 @@ let status_json ?(audit_limit = 10) () =
       ("connected", `Bool connected);
       ("stale", `Bool stale);
       ("stale_after_sec", `Int (stale_after_sec ()));
-      ("status", `String (connector_state_label ~available ~connected ~stale));
+      ( "status",
+        `String
+          (Channel_gate_connector.connector_state_label ~available ~connected
+             ~stale) );
       ("error", `String error);
       ("status_path", `String status_path);
       ("binding_store_path", `String binding_store_path);
@@ -181,19 +172,6 @@ let list_assoc_field key = function
   | `Assoc fields -> List.assoc_opt key fields
   | _ -> None
 
-let find_assoc_by_string_field ~field ~value = function
-  | `List rows ->
-      List.find_map
-        (function
-          | (`Assoc _ as row) -> (
-              match list_assoc_field field row with
-              | Some (`String candidate) when String.equal candidate value ->
-                  Some row
-              | _ -> None)
-          | _ -> None)
-        rows
-  | _ -> None
-
 let connector_json ?gate_status_json ?(audit_limit = 10) () =
   let status = status_json ~audit_limit () in
   let observed_channel =
@@ -203,7 +181,8 @@ let connector_json ?gate_status_json ?(audit_limit = 10) () =
         match list_assoc_field "channels" json with
         | Some channels -> (
             match
-              find_assoc_by_string_field ~field:"channel" ~value:channel channels
+              Json_util.find_assoc_row_by_string_field ~field:"channel"
+                ~value:channel channels
             with
             | Some row -> row
             | None -> `Null)

--- a/lib/gate/channel_gate_slack_state.ml
+++ b/lib/gate/channel_gate_slack_state.ml
@@ -26,15 +26,10 @@ let default_binding_audit_path = ".gate/runtime/slack/binding_audit.jsonl"
 
 (* Slack has no Discord-style guilds; the bot token authorizes per-workspace.
    Path resolvers read an env override, else fall back to the default. *)
-let resolve_path raw_path =
-  if Filename.is_relative raw_path then
-    Filename.concat (Env_config_core.base_path ()) raw_path
-  else raw_path
-
 let slack_path ~env_var ~default () =
   match Env_config_core.raw_value_opt env_var |> Env_config_core.trim_opt with
-  | Some path -> resolve_path path
-  | None -> resolve_path default
+  | Some path -> Env_config_core.resolve_against_base_path path
+  | None -> Env_config_core.resolve_against_base_path default
 
 let status_path () =
   slack_path ~env_var:"MASC_SLACK_STATUS_PATH" ~default:default_status_path ()
@@ -69,12 +64,6 @@ let set_trigger_policy (p : Slack_gateway_state.trigger_policy) =
   trigger_policy_ref := Some p
 
 let get_trigger_policy () = !trigger_policy_ref
-
-let connector_state_label ~available ~connected ~stale =
-  if not available then "offline"
-  else if stale then "stale"
-  else if connected then "connected"
-  else "disconnected"
 
 (* Outbound REST uses the bot token (xoxb-...). The app token (xapp-...) is read
    only by {!Slack_socket_client} for apps.connections.open. Both resolve
@@ -159,7 +148,10 @@ let status_json ?(audit_limit = 10) () =
     ; ("connected", `Bool connected)
     ; ("stale", `Bool stale)
     ; ("stale_after_sec", `Int (stale_after_sec ()))
-    ; ("status", `String (connector_state_label ~available ~connected ~stale))
+    ; ("status",
+       `String
+         (Channel_gate_connector.connector_state_label ~available ~connected
+            ~stale))
     ; ("error", `String error)
     ; ("status_source", `String "in_process_gateway")
     ; ("gateway_state", `String (gateway_state_label gateway_state))
@@ -313,12 +305,6 @@ type keeper_binding_resolution = {
   via_parent : bool;
 }
 
-let binding_for_channel bindings ~channel_id =
-  List.find_map
-    (fun (b : binding) ->
-      if String.equal b.channel_id channel_id then Some b else None)
-    bindings
-
 (* Slack threads share the parent channel id (a thread_ts is a message
    timestamp, not a channel), so resolution is a single exact lookup — no
    thread→parent fallback like Discord. *)
@@ -329,7 +315,9 @@ let resolve_keeper_for_channel_result ~channel_id =
     match read_bindings_result () with
     | Error error -> Error error
     | Ok candidates -> (
-      match binding_for_channel candidates ~channel_id:normalized with
+      match
+        Store.find_binding_by_channel_id candidates ~channel_id:normalized
+      with
       | Some b ->
         Ok
           (Some

--- a/lib/keeper/keeper_agent_error.mli
+++ b/lib/keeper/keeper_agent_error.mli
@@ -32,6 +32,21 @@ val sdk_termination_semantics
 
 val sdk_termination_semantics_to_string : sdk_termination_semantics -> string
 
+(** Snake_case wire label for a provider network error kind
+    ([Connection_refused] -> ["connection_refused"], [Dns_failure] ->
+    ["dns_failure"], [Tls_error] -> ["tls_error"], [Timeout] ->
+    ["timeout"], [Local_resource_exhaustion] ->
+    ["local_resource_exhaustion"], [End_of_file] -> ["end_of_file"],
+    [Unknown] -> ["unknown"]). *)
+val network_error_kind_to_wire : Llm_provider.Http_client.network_error_kind -> string
+
+(** Snake_case wire label for the disposition carried by a closed terminal
+    tool effect: ["proven_pre_effect"], ["proven_post_effect"] or
+    ["effect_outcome_unknown"]. *)
+val terminal_effect_disposition_to_wire
+  :  Agent_sdk.Error.closed_terminal_effect
+  -> string
+
 (** RFC-0042 PR-2.5: typed bridge variants of the wire accessors.
     Wrap the existing parametrised wire string in
     [Keeper_turn_terminal_code.Sdk_error]. PR-3 swaps

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -683,28 +683,13 @@ let persist_snapshot_exact_unlocked
   | Unavailable error -> Error error
 ;;
 
-let reject_unknown_fields ~surface ~allowed fields =
-  let rec duplicate seen = function
-    | [] -> None
-    | (key, _) :: rest ->
-      if List.mem key seen then Some key else duplicate (key :: seen) rest
-  in
-  match duplicate [] fields with
-  | Some field -> Error (Printf.sprintf "%s contains duplicate field %s" surface field)
-  | None ->
-    (match List.find_opt (fun (key, _) -> not (List.mem key allowed)) fields with
-     | None -> Ok ()
-     | Some (field, _) ->
-       Error (Printf.sprintf "%s contains unsupported field %s" surface field))
-;;
-
-let required_string ~surface field fields =
-  match List.assoc_opt field fields with
-  | Some (`String value) when String.trim value <> "" -> Ok value
-  | Some (`String _) -> Error (Printf.sprintf "%s.%s must be non-blank" surface field)
-  | Some _ -> Error (Printf.sprintf "%s.%s must be a string" surface field)
-  | None -> Error (Printf.sprintf "%s.%s is required" surface field)
-;;
+(* Assoc-field validators live in Json_util; these aliases keep the call
+   sites in this module short. *)
+let reject_unknown_fields = Json_util.reject_unknown_fields
+let required_string = Json_util.require_field_string
+let required_float = Json_util.require_field_float
+let required_positive_int = Json_util.require_field_positive_int
+let required_string_list = Json_util.require_field_string_list
 
 let required_member ~surface field fields =
   match List.assoc_opt field fields with
@@ -734,35 +719,6 @@ let optional_float ~surface field fields =
   | Some (`Float value) -> Ok (Some value)
   | Some (`Int value) -> Ok (Some (Float.of_int value))
   | Some _ -> Error (Printf.sprintf "%s.%s must be a number or null" surface field)
-;;
-
-let required_positive_int ~surface field fields =
-  match List.assoc_opt field fields with
-  | Some (`Int value) when value > 0 -> Ok value
-  | Some _ -> Error (Printf.sprintf "%s.%s must be a positive integer" surface field)
-  | None -> Error (Printf.sprintf "%s.%s is required" surface field)
-;;
-
-let required_float ~surface field fields =
-  match List.assoc_opt field fields with
-  | Some (`Float value) -> Ok value
-  | Some (`Int value) -> Ok (Float.of_int value)
-  | Some _ -> Error (Printf.sprintf "%s.%s must be a number" surface field)
-  | None -> Error (Printf.sprintf "%s.%s is required" surface field)
-;;
-
-let required_string_list ~surface field fields =
-  match List.assoc_opt field fields with
-  | Some (`List values) ->
-    let rec parse index acc = function
-      | [] -> Ok (List.rev acc)
-      | `String value :: rest -> parse (index + 1) (value :: acc) rest
-      | _ :: _ ->
-        Error (Printf.sprintf "%s.%s[%d] must be a string" surface field index)
-    in
-    parse 0 [] values
-  | Some _ -> Error (Printf.sprintf "%s.%s must be an array" surface field)
-  | None -> Error (Printf.sprintf "%s.%s is required" surface field)
 ;;
 
 let exact_attempt_identity_matches

--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -196,11 +196,6 @@ let candidate_path ~base_path ~keeper_name =
     (Workspace_utils_backend_setup.sanitize_namespace_segment keeper_name ^ ".jsonl")
 ;;
 
-let option_json f = function
-  | Some value -> f value
-  | None -> `Null
-;;
-
 let queue_reaction_to_yojson (reaction : Board_dispatch.board_reaction_change) =
   `Assoc
     [ ( "target_type"
@@ -225,8 +220,8 @@ let signal_to_yojson (signal : Board_dispatch.board_signal) =
     ; "author", `String signal.author
     ; "title", `String signal.title
     ; "content", `String signal.content
-    ; "hearth", option_json (fun value -> `String value) signal.hearth
-    ; "updated_at", option_json (fun value -> `Float value) signal.updated_at
+    ; "hearth", Json_util.option_to_yojson (fun value -> `String value) signal.hearth
+    ; "updated_at", Json_util.option_to_yojson (fun value -> `Float value) signal.updated_at
     ; ( "reaction"
       , match signal.kind with
         | Board_dispatch.Board_reaction_changed reaction ->
@@ -262,14 +257,14 @@ let keeper_context_to_yojson (meta : Keeper_meta_contract.keeper_meta) =
       (`Assoc
          [ "lane_keeper_name", `String meta.name
          ; "agent_name", `String meta.agent_name
-         ; "keeper_record_id", option_json Ids.Keeper_id.to_yojson meta.id
+         ; "keeper_record_id", Json_util.option_to_yojson Ids.Keeper_id.to_yojson meta.id
          ; ( "keeper_runtime_uid"
-           , option_json Keeper_id.uid_to_yojson meta.keeper_id )
-         ; "persona", option_json (fun value -> `String value) meta.persona
+           , Json_util.option_to_yojson Keeper_id.uid_to_yojson meta.keeper_id )
+         ; "persona", Json_util.option_to_yojson (fun value -> `String value) meta.persona
          ; "instructions", `String meta.instructions
          ; "active_goal_ids", json_string_list meta.active_goal_ids
          ; ( "current_task_id"
-           , option_json
+           , Json_util.option_to_yojson
                (fun task_id -> `String (Keeper_id.Task_id.to_string task_id))
                meta.current_task_id )
          ; "mention_keeper_ids", json_string_list mention_targets
@@ -361,7 +356,7 @@ let resumable_status_to_yojson = function
     `Assoc
       [ "kind", `String "pending"
       ; ( "last_delivery_failure"
-        , option_json
+        , Json_util.option_to_yojson
             delivery_failure_to_yojson
             pending.last_delivery_failure )
       ]
@@ -370,7 +365,7 @@ let resumable_status_to_yojson = function
       [ "kind", `String "judged"
       ; "judgment", judgment_to_yojson judged.judgment
       ; ( "last_delivery_failure"
-        , option_json
+        , Json_util.option_to_yojson
             delivery_failure_to_yojson
             judged.last_delivery_failure )
       ]
@@ -402,7 +397,7 @@ let quarantine_to_yojson quarantine =
       , `String
           (quarantine_failure_category_to_string quarantine.failure_category) )
     ; ( "attempt_provenance"
-      , option_json attempt_provenance_to_yojson quarantine.attempt_provenance )
+      , Json_util.option_to_yojson attempt_provenance_to_yojson quarantine.attempt_provenance )
     ; "quarantined_at", `Float quarantine.quarantined_at
     ; "prior_status", resumable_status_to_yojson quarantine.prior_status
     ]

--- a/lib/keeper/keeper_board_attention_candidate.mli
+++ b/lib/keeper/keeper_board_attention_candidate.mli
@@ -183,6 +183,35 @@ val of_board_signal :
 val candidate_to_json : candidate -> Yojson.Safe.t
 val candidate_of_json : Yojson.Safe.t -> (candidate, string) result
 
+(** {1 Structural decode helpers}
+
+    Shared with {!Keeper_board_attention_partition}, which decodes the
+    same candidate JSON. [context] prefixes the error message. *)
+
+val assoc :
+  context:string ->
+  Yojson.Safe.t ->
+  ((string * Yojson.Safe.t) list, string) result
+(** [assoc ~context json] returns the fields of a [`Assoc], or an error
+    saying [context] must be an object. *)
+
+val exact_fields :
+  context:string ->
+  string list ->
+  (string * Yojson.Safe.t) list ->
+  (unit, string) result
+(** [exact_fields ~context expected fields] returns [Ok ()] when the keys
+    of [fields] are exactly [expected], counting duplicates.  The error
+    lists both the expected and the actual keys. *)
+
+val field :
+  context:string ->
+  string ->
+  (string * Yojson.Safe.t) list ->
+  (Yojson.Safe.t, string) result
+(** [field ~context key fields] returns the value bound to [key], or an
+    error naming the missing field. *)
+
 val load_candidates :
   base_path:string -> keeper_name:string -> (candidate list, string) result
 

--- a/lib/keeper/keeper_board_attention_partition.ml
+++ b/lib/keeper/keeper_board_attention_partition.ml
@@ -248,30 +248,11 @@ let to_yojson partition =
     ]
 ;;
 
-let assoc ~context = function
-  | `Assoc fields -> Ok fields
-  | _ -> Error (context ^ " must be an object")
-;;
-
-let exact_fields ~context expected fields =
-  let actual = List.map fst fields in
-  if List.length actual = List.length expected
-     && List.for_all (fun key -> List.mem key actual) expected
-  then Ok ()
-  else
-    Error
-      (Printf.sprintf
-         "%s fields must be exactly [%s], got [%s]"
-         context
-         (String.concat "," expected)
-         (String.concat "," actual))
-;;
-
-let field ~context key fields =
-  match List.assoc_opt key fields with
-  | Some value -> Ok value
-  | None -> Error (Printf.sprintf "%s missing field %s" context key)
-;;
+(* Structural decode helpers live in Candidate, which decodes the same
+   candidate JSON; these aliases keep the call sites in this module short. *)
+let assoc = Candidate.assoc
+let exact_fields = Candidate.exact_fields
+let field = Candidate.field
 
 let string_json ~context = function
   | `String value when not (String.equal value "") -> Ok value

--- a/lib/keeper/keeper_board_attention_quarantine_command.ml
+++ b/lib/keeper/keeper_board_attention_quarantine_command.ml
@@ -492,14 +492,7 @@ let audit config ~actor command ~outcome =
   | exn -> Error (Printexc.to_string exn)
 ;;
 
-let audit_json = function
-  | Ok () -> `Assoc [ "recorded", `Bool true ]
-  | Error detail ->
-    `Assoc
-      [ "recorded", `Bool false
-      ; "error", `String (Observability_redact.redact_text detail)
-      ]
-;;
+let audit_json = Audit_log.write_result_to_json
 
 let wake_to_string = function
   | Wake.Signaled -> "signaled"

--- a/lib/keeper/keeper_chat_direct_delivery.ml
+++ b/lib/keeper/keeper_chat_direct_delivery.ml
@@ -1119,45 +1119,15 @@ let of_yojson = function
   | _ -> Error (Decode_failed "direct delivery checkpoint must be an object")
 ;;
 
-type operation_lock =
-  { mutex : Eio.Mutex.t
-  ; mutable users : int
-  }
-
-let operation_locks : (string, operation_lock) Hashtbl.t = Hashtbl.create 16
-let operation_locks_mutex = Stdlib.Mutex.create ()
-
-let acquire_operation_lock key =
-  Stdlib.Mutex.protect operation_locks_mutex (fun () ->
-    match Hashtbl.find_opt operation_locks key with
-    | Some lock ->
-      lock.users <- lock.users + 1;
-      lock
-    | None ->
-      let lock = { mutex = Eio.Mutex.create (); users = 1 } in
-      Hashtbl.add operation_locks key lock;
-      lock)
-;;
-
-let release_operation_lock key lock =
-  Stdlib.Mutex.protect operation_locks_mutex (fun () ->
-    lock.users <- lock.users - 1;
-    if lock.users = 0
-    then
-      match Hashtbl.find_opt operation_locks key with
-      | Some current when current == lock -> Hashtbl.remove operation_locks key
-      | Some _ | None -> ())
-;;
-
 let with_operation_lock key f =
-  let lock = acquire_operation_lock key in
-  match Eio.Mutex.use_rw ~protect:true lock.mutex f with
+  let lock = Keeper_fs.acquire_path_lock key in
+  match Eio.Mutex.use_rw ~protect:true (Keeper_fs.path_lock_mutex lock) f with
   | value ->
-    release_operation_lock key lock;
+    Keeper_fs.release_path_lock key lock;
     value
   | exception exn ->
     let backtrace = Printexc.get_raw_backtrace () in
-    release_operation_lock key lock;
+    Keeper_fs.release_path_lock key lock;
     Printexc.raise_with_backtrace exn backtrace
 ;;
 

--- a/lib/keeper/keeper_chat_recovery_command.ml
+++ b/lib/keeper/keeper_chat_recovery_command.ml
@@ -358,14 +358,7 @@ let audit config ~actor command ~outcome =
   | exn -> Error (Printexc.to_string exn)
 ;;
 
-let audit_json = function
-  | Ok () -> `Assoc [ "recorded", `Bool true ]
-  | Error detail ->
-    `Assoc
-      [ "recorded", `Bool false
-      ; "error", `String (Observability_redact.redact_text detail)
-      ]
-;;
+let audit_json = Audit_log.write_result_to_json
 
 let success_json ~audit command
     (report : Keeper_chat_queue.recovery_resolution_report) =

--- a/lib/keeper/keeper_checkpoint_purge.ml
+++ b/lib/keeper/keeper_checkpoint_purge.ml
@@ -44,11 +44,6 @@ type item =
   ; flat_last : int
   }
 
-let messages_of_unit = function
-  | Keeper_compaction_unit.Ordinary_message message -> [ message ]
-  | Keeper_compaction_unit.Closed_tool_cycle messages -> messages
-;;
-
 let is_text_only (message : Agent_sdk.Types.message) =
   (match message.role with
    | Agent_sdk.Types.User | Agent_sdk.Types.Assistant -> true
@@ -183,7 +178,7 @@ let purge_messages ~config messages =
         let flat_index = ref (-1) in
         List.map
           (fun unit_ ->
-             let unit_messages = messages_of_unit unit_ in
+             let unit_messages = Keeper_compaction_unit.messages_of_closed_unit unit_ in
              flat_index := !flat_index + List.length unit_messages;
              { unit_; flat_last = !flat_index })
           closed_prefix
@@ -206,7 +201,10 @@ let purge_messages ~config messages =
       in
       let purge_item item =
         if protected item
-        then { messages = messages_of_unit item.unit_; dedup_key = None }
+        then
+          { messages = Keeper_compaction_unit.messages_of_closed_unit item.unit_
+          ; dedup_key = None
+          }
         else (
           match item.unit_ with
           | Keeper_compaction_unit.Ordinary_message message ->

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -174,11 +174,6 @@ let unit_message_count = function
   | Keeper_compaction_unit.Closed_tool_cycle messages -> List.length messages
 ;;
 
-let messages_of_unit = function
-  | Keeper_compaction_unit.Ordinary_message message -> [ message ]
-  | Keeper_compaction_unit.Closed_tool_cycle messages -> messages
-;;
-
 let selected_message_count units selected =
   let units = Array.of_list units in
   List.fold_left

--- a/lib/keeper/keeper_compaction_unit.ml
+++ b/lib/keeper/keeper_compaction_unit.ml
@@ -71,6 +71,11 @@ type open_cycle =
   ; messages_rev : T.message list
   }
 
+let messages_of_closed_unit = function
+  | Ordinary_message message -> [ message ]
+  | Closed_tool_cycle messages -> messages
+;;
+
 (* Blank classification must not normalize the provider-owned identity used
    by cycle matching and persisted evidence. *)
 let tool_id_is_blank tool_use_id = String.trim tool_use_id = ""

--- a/lib/keeper/keeper_compaction_unit.mli
+++ b/lib/keeper/keeper_compaction_unit.mli
@@ -69,6 +69,11 @@ type provider_transcript_error =
   | Unresolved_tool_results of { tool_use_ids : string list }
 [@@deriving show]
 
+val messages_of_closed_unit : closed_unit -> Agent_sdk.Types.message list
+(** Flatten a unit back to the messages it holds: the single message of
+    [Ordinary_message], or the message list of [Closed_tool_cycle] in its
+    original order. *)
+
 val partition
   :  ?quarantine:bool
   -> Agent_sdk.Types.message list

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -416,13 +416,7 @@ let exact_direct_mention_present ~(targets : string list) (content : string) :
 (* Delegate to Keeper_prompt — single source of truth for keeper prompts. *)
 let build_keeper_system_prompt = Keeper_prompt.build_keeper_system_prompt
 
-let append_trait_clause ~(base : string) ~(clause : string) : string =
-  let b = String.trim base in
-  let c = String.trim clause in
-  if c = "" then b
-  else if b = "" then c
-  else if String_util.contains_substring_ci b c then b
-  else Printf.sprintf "%s; %s" b c
+let append_trait_clause = Keeper_prompt.append_trait_clause
 
 
 include Keeper_text_processing

--- a/lib/keeper/keeper_event_bridge_error_json.ml
+++ b/lib/keeper/keeper_event_bridge_error_json.ml
@@ -35,16 +35,6 @@ let agent_completed_result_fields = function
     ]
 ;;
 
-let network_error_kind_to_wire = function
-  | Llm_provider.Http_client.Connection_refused -> "connection_refused"
-  | Llm_provider.Http_client.Dns_failure -> "dns_failure"
-  | Llm_provider.Http_client.Tls_error -> "tls_error"
-  | Llm_provider.Http_client.Timeout -> "timeout"
-  | Llm_provider.Http_client.Local_resource_exhaustion -> "local_resource_exhaustion"
-  | Llm_provider.Http_client.End_of_file -> "end_of_file"
-  | Llm_provider.Http_client.Unknown -> "unknown"
-;;
-
 let invalid_request_reason_to_wire = function
   | Agent_sdk.Retry.Json_parse_error -> "json_parse_error"
   | Agent_sdk.Retry.Request_body_too_large _ -> "request_body_too_large"
@@ -121,13 +111,6 @@ let input_capacity_reason_to_json = function
       ]
 ;;
 
-let terminal_effect_disposition_to_wire effect_disposition =
-  match Agent_sdk.Error.terminal_effect_disposition effect_disposition with
-  | Agent_sdk.Tool_contract.Proven_pre_effect -> "proven_pre_effect"
-  | Agent_sdk.Tool_contract.Proven_post_effect -> "proven_post_effect"
-  | Agent_sdk.Tool_contract.Effect_outcome_unknown -> "effect_outcome_unknown"
-;;
-
 let agent_failed_error_summary = function
   | Agent_sdk.Error.Agent (Agent_sdk.Error.TerminalToolEffectFailed _) ->
     "terminal_tool_effect_failed"
@@ -200,7 +183,7 @@ let sdk_api_error_fields = function
   | Agent_sdk.Retry.NetworkError { message; kind } ->
     [ "variant", `String "network_error"
     ; "message", `String message
-    ; "network_kind", `String (network_error_kind_to_wire kind)
+    ; "network_kind", `String (Keeper_agent_error.network_error_kind_to_wire kind)
     ]
   | Agent_sdk.Retry.Timeout { message } ->
     [ "variant", `String "timeout"; "message", `String message ]
@@ -223,7 +206,7 @@ let sdk_agent_error_fields = function
     [ "variant", `String "terminal_tool_effect_failed"
     ; "tool_use_id", `String tool_use_id
     ; ( "effect_disposition"
-      , `String (terminal_effect_disposition_to_wire effect_disposition) )
+      , `String (Keeper_agent_error.terminal_effect_disposition_to_wire effect_disposition) )
     ; "detail_digest", `String (sha256_hex detail)
     ]
   | Agent_sdk.Error.TerminalToolDurabilityFailed
@@ -234,7 +217,7 @@ let sdk_agent_error_fields = function
     ; "turn", `Int (Agent_sdk.Tool_contract.Invocation.turn invocation)
     ; "planned_index", `Int (Agent_sdk.Tool_contract.Invocation.planned_index invocation)
     ; ( "effect_disposition"
-      , `String (terminal_effect_disposition_to_wire effect_disposition) )
+      , `String (Keeper_agent_error.terminal_effect_disposition_to_wire effect_disposition) )
     ; "detail_digest", `String (sha256_hex detail)
     ]
   | Agent_sdk.Error.GuardrailViolation { validator; reason } ->
@@ -423,7 +406,7 @@ let sdk_provider_error_fields error =
     [ "variant", `String "network_error"
     ; "message", `String message
     ; "provider", `String provider
-    ; "network_kind", `String (network_error_kind_to_wire kind)
+    ; "network_kind", `String (Keeper_agent_error.network_error_kind_to_wire kind)
     ; ( "timeout_phase"
       , match timeout_phase with
         | Some phase -> `String (Llm_provider.Http_client.timeout_phase_to_label phase)

--- a/lib/keeper/keeper_external_attention.ml
+++ b/lib/keeper/keeper_external_attention.ml
@@ -332,12 +332,7 @@ let event_of_json json =
   | other -> Error (Printf.sprintf "unknown external attention event %S" other)
 
 let report_read_drop ~reason ~path ~detail =
-  Safe_ops.report_persistence_read_drop
-    ~on_drop:(fun () ->
-      Otel_metric_store.inc_counter
-        Otel_metric_store.metric_persistence_read_drops
-        ~labels:[ ("surface", persistence_surface); ("reason", reason) ]
-        ())
+  Safe_ops.report_persistence_read_drop_counted
     ~surface:persistence_surface ~reason ~path ~detail
 
 let parse_line_result ~file_path ~line_no line =

--- a/lib/keeper/keeper_fs.ml
+++ b/lib/keeper/keeper_fs.ml
@@ -749,6 +749,41 @@ end
 ;;
 
 (* ================================================================ *)
+(* Path Locks (refcounted Eio.Mutex registry keyed by path)         *)
+(* ================================================================ *)
+
+type path_lock =
+  { mutex : Eio.Mutex.t
+  ; mutable users : int
+  }
+
+let path_locks : (string, path_lock) Hashtbl.t = Hashtbl.create 16
+let path_locks_mutex = Stdlib.Mutex.create ()
+let path_lock_mutex lock = lock.mutex
+
+let acquire_path_lock key =
+  Stdlib.Mutex.protect path_locks_mutex (fun () ->
+    match Hashtbl.find_opt path_locks key with
+    | Some lock ->
+      lock.users <- lock.users + 1;
+      lock
+    | None ->
+      let lock = { mutex = Eio.Mutex.create (); users = 1 } in
+      Hashtbl.add path_locks key lock;
+      lock)
+;;
+
+let release_path_lock key lock =
+  Stdlib.Mutex.protect path_locks_mutex (fun () ->
+    lock.users <- lock.users - 1;
+    if lock.users = 0
+    then
+      match Hashtbl.find_opt path_locks key with
+      | Some current when current == lock -> Hashtbl.remove path_locks key
+      | Some _ | None -> ())
+;;
+
+(* ================================================================ *)
 (* Standard Keeper Paths                                            *)
 (* ================================================================ *)
 

--- a/lib/keeper/keeper_fs.mli
+++ b/lib/keeper/keeper_fs.mli
@@ -199,6 +199,24 @@ module For_testing : sig
     -> (unit, durable_remove_error) result
 end
 
+(** {1 Path Locks} *)
+
+(** A lock held in the process-wide registry under one path key, carrying an
+    [Eio.Mutex.t] and the number of holders that currently reference it. *)
+type path_lock
+
+(** The [Eio.Mutex.t] carried by [path_lock]. *)
+val path_lock_mutex : path_lock -> Eio.Mutex.t
+
+(** Return the lock registered under [key], creating and registering a fresh
+    one when the key has no entry, and add one to its holder count. *)
+val acquire_path_lock : string -> path_lock
+
+(** Subtract one from the holder count of [lock]. When the count reaches zero
+    and the entry registered under [key] is still physically the same lock,
+    that entry is removed from the registry. *)
+val release_path_lock : string -> path_lock -> unit
+
 (** {1 Standard Keeper Paths} *)
 
 (** [.masc/keepers/] directory. *)

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -315,41 +315,13 @@ let wakeup_keeper ?base_path ?stimulus name =
    here it only picks urgency (explicit targets and broadcasts are [Immediate]). It is not
    carried in the payload — the next prompt re-derives board context from the
    typed [Board_signal] payload, not from a wake-reason string. *)
-let queue_reaction_target_of_board = function
-  | Board.Reaction_post -> Keeper_event_queue.Reaction_post
-  | Board.Reaction_comment -> Keeper_event_queue.Reaction_comment
-;;
-
-let queue_reaction_change_of_board
-      (reaction : Board_dispatch.board_reaction_change)
-  : Keeper_event_queue.board_reaction_change
-  =
-  { target_type = queue_reaction_target_of_board reaction.target_type
-  ; target_id = reaction.target_id
-  ; user_id = reaction.user_id
-  ; emoji = reaction.emoji
-  ; reacted = reaction.reacted
-  }
-;;
-
 let board_signal_stimulus
       ~(reason : Board_wake.wake_reason)
       (signal : Board_dispatch.board_signal)
   =
   let payload : Keeper_event_queue.stimulus_payload =
     Keeper_event_queue.Board_signal
-      { kind =
-          (match signal.kind with
-           | Board_dispatch.Board_post_created -> Keeper_event_queue.Post_created
-           | Board_dispatch.Board_comment_added -> Keeper_event_queue.Comment_added
-           | Board_dispatch.Board_reaction_changed reaction ->
-             Keeper_event_queue.Reaction_changed (queue_reaction_change_of_board reaction))
-      ; author = signal.author
-      ; title = signal.title
-      ; content = signal.content
-      ; hearth = signal.hearth
-      ; updated_at = signal.updated_at
-      }
+      (Board_wake.board_stimulus_of_board_signal signal)
   in
   { Keeper_event_queue.post_id = signal.post_id
   ; urgency =

--- a/lib/keeper/keeper_lifecycle_reservation.ml
+++ b/lib/keeper/keeper_lifecycle_reservation.ml
@@ -57,6 +57,12 @@ let snapshot_to_string snapshot =
     (purpose_to_string snapshot.purpose)
 ;;
 
+let release_outcome_to_string = function
+  | Released -> "released"
+  | Release_missing -> "release_missing"
+  | Release_not_owner owner -> "release_not_owner: " ^ snapshot_to_string owner
+;;
+
 let canonical_key ~base_path ~keeper_name =
   Keeper_registry_types.registry_key ~base_path (String.trim keeper_name)
 ;;

--- a/lib/keeper/keeper_lifecycle_reservation.mli
+++ b/lib/keeper/keeper_lifecycle_reservation.mli
@@ -26,6 +26,11 @@ type release_outcome =
 val purpose_to_string : purpose -> string
 val snapshot_to_string : snapshot -> string
 
+(** Render a release outcome as ["released"], ["release_missing"], or
+    ["release_not_owner: "] followed by {!snapshot_to_string} of the owner
+    that still holds the reservation. *)
+val release_outcome_to_string : release_outcome -> string
+
 val acquire :
   base_path:string ->
   keeper_name:string ->

--- a/lib/keeper/keeper_meta_json_current_schema.mli
+++ b/lib/keeper/keeper_meta_json_current_schema.mli
@@ -71,6 +71,11 @@ val object_of_field_values :
 val current_field_names : string list
 (** Derived from {!all_fields}; never maintained as a separate string list. *)
 
+val find_duplicate : ('a * 'b) list -> 'a option
+(** Return [Some key] for the first key that already occurred earlier in the
+    association list, or [None] when every key is distinct. Callers decide how
+    to report the duplicate. *)
+
 val validate_current_object :
   Yojson.Safe.t -> ((string * Yojson.Safe.t) list, validation_error) result
 (** Require exactly the current top-level key set. Every field outside that set

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -83,15 +83,6 @@ let string_list_field fields name =
   | other -> invalidf "field %s must be an array, got %s" name (Json_util.kind_name other)
 ;;
 
-let find_duplicate fields =
-  let rec loop seen = function
-    | [] -> None
-    | (key, _) :: rest ->
-      if List.mem key seen then Some key else loop (key :: seen) rest
-  in
-  loop [] fields
-;;
-
 let require_exact_fields ~context expected fields =
   match find_duplicate fields with
   | Some key -> invalidf "%s has duplicate field %s" context key

--- a/lib/keeper/keeper_paused_work_source_terminal_transaction.ml
+++ b/lib/keeper/keeper_paused_work_source_terminal_transaction.ml
@@ -95,14 +95,10 @@ let error_to_string error =
   let base = failure_to_string error.cause in
   match error.reservation_release with
   | None -> base
-  | Some Keeper_lifecycle_reservation.Released ->
-    base ^ "; reservation_release=released"
-  | Some Keeper_lifecycle_reservation.Release_missing ->
-    base ^ "; reservation_release=release_missing"
-  | Some (Keeper_lifecycle_reservation.Release_not_owner owner) ->
+  | Some outcome ->
     base
-    ^ "; reservation_release=release_not_owner: "
-    ^ Keeper_lifecycle_reservation.snapshot_to_string owner
+    ^ "; reservation_release="
+    ^ Keeper_lifecycle_reservation.release_outcome_to_string outcome
 ;;
 
 let validate_request request =

--- a/lib/keeper/keeper_paused_work_transfer_transaction.ml
+++ b/lib/keeper/keeper_paused_work_transfer_transaction.ml
@@ -140,13 +140,10 @@ let error_to_string error =
   let base = failure_to_string error.cause in
   match error.reservation_release with
   | None -> base
-  | Some Keeper_lifecycle_reservation.Released -> base ^ "; reservation_release=released"
-  | Some Keeper_lifecycle_reservation.Release_missing ->
-    base ^ "; reservation_release=release_missing"
-  | Some (Keeper_lifecycle_reservation.Release_not_owner owner) ->
+  | Some outcome ->
     base
-    ^ "; reservation_release=release_not_owner: "
-    ^ Keeper_lifecycle_reservation.snapshot_to_string owner
+    ^ "; reservation_release="
+    ^ Keeper_lifecycle_reservation.release_outcome_to_string outcome
 ;;
 
 let validate_request ~from_keeper ~to_keeper request =

--- a/lib/keeper/keeper_person_notes.ml
+++ b/lib/keeper/keeper_person_notes.ml
@@ -15,12 +15,7 @@ let notes_path ~base_dir ~keeper_name =
 let persistence_surface = "keeper_person_notes"
 
 let report_read_drop ~reason ~path ~detail =
-  Safe_ops.report_persistence_read_drop
-    ~on_drop:(fun () ->
-      Otel_metric_store.inc_counter
-        Otel_metric_store.metric_persistence_read_drops
-        ~labels:[ ("surface", persistence_surface); ("reason", reason) ]
-        ())
+  Safe_ops.report_persistence_read_drop_counted
     ~surface:persistence_surface
     ~reason
     ~path

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -72,11 +72,6 @@ let reaction_kind_of_string = function
   | other -> Error (Unknown_reaction_kind other)
 ;;
 
-let option_json f = function
-  | Some value -> f value
-  | None -> `Null
-;;
-
 let digest_id prefix payload = prefix ^ ":" ^ Digest.to_hex (Digest.string payload)
 let board_stimulus_id ~post_id = "board:" ^ post_id
 
@@ -241,7 +236,7 @@ let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
              ; "post_id", `String stimulus.post_id
              ; "urgency", `String (urgency_to_string stimulus.urgency)
              ; "arrived_at_unix", `Float stimulus.arrived_at
-             ; "board_updated_at_unix", option_json (fun value -> `Float value) board_updated_at
+             ; "board_updated_at_unix", Json_util.option_to_yojson (fun value -> `Float value) board_updated_at
              ; "payload_preview", `String (stimulus_payload_preview stimulus.payload)
              ] )
        ])

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -84,16 +84,10 @@ type source_ack_result =
       }
 
 
-let rec queue_contains queue stimulus =
-  match Keeper_event_queue.dequeue queue with
-  | None -> false
-  | Some (head, rest) ->
-    Keeper_event_queue.stimulus_identity_equal head stimulus
-    || queue_contains rest stimulus
-;;
-
 let enqueue_if_missing queue stimulus =
-  if queue_contains queue stimulus then queue else Keeper_event_queue.enqueue queue stimulus
+  if Keeper_event_queue.contains queue stimulus
+  then queue
+  else Keeper_event_queue.enqueue queue stimulus
 ;;
 
 let rec stimulus_with_post_id queue post_id =

--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -80,12 +80,6 @@ let running_managed_container ~network_label containers =
       && c.network_label = Some network_label)
     containers
 
-let image_preflight_start_error (failure : Keeper_sandbox_runtime.classified_error) =
-  Keeper_sandbox_runtime.docker_image_preflight_failure_message
-    ~prefix:"docker_container_start_failed"
-    failure
-;;
-
 let start_managed_container
     ~(config : Workspace.config)
     ~(meta : keeper_meta)
@@ -127,7 +121,8 @@ let start_managed_container
                   ~image
                   ~timeout_sec
               with
-              | Error failure -> Error (image_preflight_start_error failure)
+              | Error failure ->
+                Error (Keeper_sandbox_runtime.image_preflight_start_error failure)
               | Ok () ->
               let _cleanup =
                 Keeper_sandbox_runtime.maybe_cleanup_stale_containers

--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -775,6 +775,12 @@ let docker_image_preflight_failure_message ~prefix failure =
     failure.message
 ;;
 
+let image_preflight_start_error (failure : classified_error) =
+  docker_image_preflight_failure_message
+    ~prefix:"docker_container_start_failed"
+    failure
+;;
+
 let docker_preflight_to_yojson (preflight : docker_preflight) =
   `Assoc
     [ "backend", `String "docker"

--- a/lib/keeper/keeper_sandbox_runtime.mli
+++ b/lib/keeper/keeper_sandbox_runtime.mli
@@ -368,6 +368,12 @@ val ensure_keeper_sandbox_image_present_with_class_optional
 val docker_image_preflight_error_code : classified_error -> string
 val docker_image_preflight_failure_message : prefix:string -> classified_error -> string
 
+(** [docker_image_preflight_failure_message] applied with the
+    ["docker_container_start_failed"] prefix, for callers that abort a
+    container start because the image preflight returned
+    [Error classified_error]. *)
+val image_preflight_start_error : classified_error -> string
+
 (** Returns the [--security-opt seccomp=...] argv fragment when the
     runtime passes; [Error _] when something is missing.
 

--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -101,48 +101,19 @@ let error_to_string = function
     Printf.sprintf "shutdown supersession actor is invalid: %s" detail
 ;;
 
-type operation_lock =
-  { mutex : Eio.Mutex.t
-  ; mutable users : int
-  }
-
-let operation_locks : (string, operation_lock) Hashtbl.t = Hashtbl.create 16
-let operation_locks_mutex = Stdlib.Mutex.create ()
-
 type lock_access =
   | Read
   | Write
 
-let acquire_operation_lock key =
-  Stdlib.Mutex.protect operation_locks_mutex (fun () ->
-    match Hashtbl.find_opt operation_locks key with
-    | Some lock ->
-      lock.users <- lock.users + 1;
-      lock
-    | None ->
-      let lock = { mutex = Eio.Mutex.create (); users = 1 } in
-      Hashtbl.add operation_locks key lock;
-      lock)
-;;
-
-let release_operation_lock key lock =
-  Stdlib.Mutex.protect operation_locks_mutex (fun () ->
-    lock.users <- lock.users - 1;
-    if lock.users = 0
-    then
-      match Hashtbl.find_opt operation_locks key with
-      | Some current when current == lock -> Hashtbl.remove operation_locks key
-      | Some _ | None -> ())
-;;
-
 let with_operation_lock ~access key f =
-  let lock = acquire_operation_lock key in
+  let lock = Keeper_fs.acquire_path_lock key in
   Fun.protect
-    ~finally:(fun () -> release_operation_lock key lock)
+    ~finally:(fun () -> Keeper_fs.release_path_lock key lock)
     (fun () ->
        match access with
-       | Write -> Eio.Mutex.use_rw ~protect:true lock.mutex f
-       | Read -> Eio.Mutex.use_ro lock.mutex f)
+       | Write ->
+         Eio.Mutex.use_rw ~protect:true (Keeper_fs.path_lock_mutex lock) f
+       | Read -> Eio.Mutex.use_ro (Keeper_fs.path_lock_mutex lock) f)
 ;;
 
 let records_dir (config : Workspace.config) =

--- a/lib/keeper/keeper_status_metrics.ml
+++ b/lib/keeper/keeper_status_metrics.ml
@@ -60,11 +60,6 @@ let empty_tool_audit_snapshot =
 let age_seconds_opt ~now_ts timestamp =
   if timestamp <= 0.0 then None else Some (now_ts -. timestamp)
 
-let ratio_json numerator denominator =
-  if denominator = 0
-  then `Null
-  else `Float (float_of_int numerator /. float_of_int denominator)
-
 let metrics_summary_to_json (summary : metrics_summary) : Yojson.Safe.t =
   let interaction_points =
     summary.turn_points + summary.proactive_points
@@ -76,22 +71,15 @@ let metrics_summary_to_json (summary : metrics_summary) : Yojson.Safe.t =
     ; "proactive_points", `Int summary.proactive_points
     ; "window_interactions", `Int interaction_points
     ; ( "intervention_share"
-      , ratio_json summary.proactive_points interaction_points )
+      , Json_util.int_ratio_json summary.proactive_points interaction_points )
     ; ( "intervention_per_turn"
-      , ratio_json summary.proactive_points summary.turn_points )
+      , Json_util.int_ratio_json summary.proactive_points summary.turn_points )
     ; "handoff_count", `Int summary.handoff_count
     ; ( "last_handoff"
       , match summary.last_handoff with
         | Some json -> json
         | None -> `Null )
     ]
-
-let nonempty_string_opt key json =
-  match Safe_ops.json_string_opt key json with
-  | Some value ->
-      let value = String.trim value in
-      if value = "" then None else Some value
-  | None -> None
 
 let summarize_metrics_lines (lines : string list) : metrics_summary =
   List.fold_left
@@ -128,7 +116,7 @@ let summarize_metrics_lines (lines : string list) : metrics_summary =
             in
             (match
                Safe_ops.json_float_opt "ts_unix" json,
-               nonempty_string_opt "trace_id" json,
+               Safe_ops.json_string_nonempty_opt "trace_id" json,
                Safe_ops.json_int_opt "generation" json,
                Safe_ops.json_bool_opt "handoff_performed" json,
                parsed_channel
@@ -161,12 +149,12 @@ let summarize_metrics_lines (lines : string list) : metrics_summary =
                          ; "generation", `Int generation
                          ; ( "prev_trace_id"
                            , Json_util.string_opt_to_json
-                               (nonempty_string_opt
+                               (Safe_ops.json_string_nonempty_opt
                                   "prev_trace_id"
                                   handoff) )
                          ; ( "new_trace_id"
                            , Json_util.string_opt_to_json
-                               (nonempty_string_opt
+                               (Safe_ops.json_string_nonempty_opt
                                   "new_trace_id"
                                   handoff) )
                          ; ( "to_generation"
@@ -279,14 +267,14 @@ let latest_tool_audit_snapshot_from_metrics config keeper_name =
              (match
                 string_list_member_opt "tools_used" json,
                 Safe_ops.json_int_opt "tool_call_count" json,
-                nonempty_string_opt "ts" json
+                Safe_ops.json_string_nonempty_opt "ts" json
               with
               | Some tools, Some tool_call_count, Some timestamp ->
                   Some
                     { latest_tool_names = tools
                     ; latest_tool_call_count = Some tool_call_count
                     ; latest_action_source =
-                        nonempty_string_opt "action_source" json
+                        Safe_ops.json_string_nonempty_opt "action_source" json
                     ; tool_audit_source = Some "keeper_metrics"
                     ; tool_audit_at = Some timestamp
                     }

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -179,12 +179,6 @@ let format_docker_exec_error ~head_program ~st ~out =
   | Unix.WSTOPPED n -> Printf.sprintf "docker_%s_stopped: signal=%d" head_program n
 ;;
 
-let image_preflight_start_error (failure : Keeper_sandbox_runtime.classified_error) =
-  Keeper_sandbox_runtime.docker_image_preflight_failure_message
-    ~prefix:"docker_container_start_failed"
-    failure
-;;
-
 let sandbox_environment () =
   Env_keeper_scrub.filter_environment (Unix.environment ())
 ;;
@@ -371,7 +365,8 @@ let start_container ?timeout_sec (t : t) =
         ?timeout_sec
         ()
     with
-    | Error failure -> Error (image_preflight_start_error failure)
+    | Error failure ->
+      Error (Keeper_sandbox_runtime.image_preflight_start_error failure)
     | Ok () ->
       match
         Keeper_sandbox_runtime.ensure_keeper_sandbox_runtime_optional

--- a/lib/keeper_catchup_digest.ml
+++ b/lib/keeper_catchup_digest.ml
@@ -177,11 +177,6 @@ let json_num_field name json =
   | _ -> None
 ;;
 
-let string_opt_to_json = function
-  | Some s -> `String s
-  | None -> `Null
-;;
-
 (* ── Fail-visible day-partitioned reader ─────────────────────────── *)
 
 (* A parse or IO failure is appended to [errs] (fail-visible), never
@@ -658,11 +653,11 @@ let task_snapshot_to_json (s : task_snapshot) =
   `Assoc
     [ "title", `String s.title
     ; "status", `String s.status
-    ; "assignee", string_opt_to_json s.assignee
-    ; "submitted_at", string_opt_to_json s.submitted_at
-    ; "verification_id", string_opt_to_json s.verification_id
-    ; "handoff_summary", string_opt_to_json s.handoff_summary
-    ; "handoff_next_step", string_opt_to_json s.handoff_next_step
+    ; "assignee", Json_util.string_opt_to_json s.assignee
+    ; "submitted_at", Json_util.string_opt_to_json s.submitted_at
+    ; "verification_id", Json_util.string_opt_to_json s.verification_id
+    ; "handoff_summary", Json_util.string_opt_to_json s.handoff_summary
+    ; "handoff_next_step", Json_util.string_opt_to_json s.handoff_next_step
     ; "handoff_evidence_refs", `List (List.map (fun ref_ -> `String ref_) s.handoff_evidence_refs)
     ]
 ;;

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.ml
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.ml
@@ -344,59 +344,13 @@ let summary_attempt_disposition_to_yojson = function
     `Assoc [ "code", `String "settled" ]
 ;;
 
-let reject_unknown_fields ~surface ~allowed fields =
-  let rec duplicate seen = function
-    | [] -> None
-    | (key, _) :: rest ->
-      if List.mem key seen then Some key else duplicate (key :: seen) rest
-  in
-  match duplicate [] fields with
-  | Some field -> Error (Printf.sprintf "%s contains duplicate field %s" surface field)
-  | None ->
-    (match List.find_opt (fun (key, _) -> not (List.mem key allowed)) fields with
-     | None -> Ok ()
-     | Some (field, _) ->
-       Error (Printf.sprintf "%s contains unsupported field %s" surface field))
-;;
-
-let required_string ~surface field fields =
-  match List.assoc_opt field fields with
-  | Some (`String value) when String.trim value <> "" -> Ok value
-  | Some (`String _) ->
-    Error (Printf.sprintf "%s.%s must be non-blank" surface field)
-  | Some _ -> Error (Printf.sprintf "%s.%s must be a string" surface field)
-  | None -> Error (Printf.sprintf "%s.%s is required" surface field)
-;;
-
-let required_float ~surface field fields =
-  match List.assoc_opt field fields with
-  | Some (`Float value) -> Ok value
-  | Some (`Int value) -> Ok (Float.of_int value)
-  | Some _ -> Error (Printf.sprintf "%s.%s must be a number" surface field)
-  | None -> Error (Printf.sprintf "%s.%s is required" surface field)
-;;
-
-let required_positive_int ~surface field fields =
-  match List.assoc_opt field fields with
-  | Some (`Int value) when value > 0 -> Ok value
-  | Some _ -> Error (Printf.sprintf "%s.%s must be a positive integer" surface field)
-  | None -> Error (Printf.sprintf "%s.%s is required" surface field)
-;;
-
-let required_string_list ~surface field fields =
-  match List.assoc_opt field fields with
-  | Some (`List values) ->
-    let rec parse index acc = function
-      | [] -> Ok (List.rev acc)
-      | `String value :: rest -> parse (index + 1) (value :: acc) rest
-      | _ :: _ ->
-        Error
-          (Printf.sprintf "%s.%s[%d] must be a string" surface field index)
-    in
-    parse 0 [] values
-  | Some _ -> Error (Printf.sprintf "%s.%s must be an array" surface field)
-  | None -> Error (Printf.sprintf "%s.%s is required" surface field)
-;;
+(* Assoc-field validators live in Json_util; these aliases keep the call
+   sites in this module short. *)
+let reject_unknown_fields = Json_util.reject_unknown_fields
+let required_string = Json_util.require_field_string
+let required_float = Json_util.require_field_float
+let required_positive_int = Json_util.require_field_positive_int
+let required_string_list = Json_util.require_field_string_list
 
 let summary_attempt_disposition_of_yojson_with_error json =
   match json with

--- a/lib/keeper_runtime/keeper_disk_pressure.ml
+++ b/lib/keeper_runtime/keeper_disk_pressure.ml
@@ -109,12 +109,6 @@ let parse_df_output ~path lines =
   | _ -> Probe_error "df returned no filesystem row"
 ;;
 
-let process_status_to_string = function
-  | Unix.WEXITED code -> Printf.sprintf "exited(%d)" code
-  | Unix.WSIGNALED signal -> Printf.sprintf "signaled(%d)" signal
-  | Unix.WSTOPPED signal -> Printf.sprintf "stopped(%d)" signal
-;;
-
 let probe_uncached path =
   let path = nearest_existing_path path in
   try
@@ -126,7 +120,7 @@ let probe_uncached path =
     with
     | lines, Unix.WEXITED 0 -> parse_df_output ~path lines
     | _lines, status ->
-      let detail = "df -Pk " ^ process_status_to_string status in
+      let detail = "df -Pk " ^ With_process.status_to_string status in
       Log.Keeper.warn "disk_observation: probe failed path=%s detail=%s" path detail;
       Probe_error detail
   with

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -282,6 +282,12 @@ let remove_by_post_id post_id queue =
   in
   removed, of_list kept
 
+(* Scans both halves of the queue directly instead of rebuilding it through
+   repeated [dequeue], so membership stays allocation-free. *)
+let contains (queue : t) (stimulus : stimulus) : bool =
+  let same head = stimulus_identity_equal head stimulus in
+  List.exists same queue.front || List.exists same queue.back_rev
+
 let uniq_stimuli stimuli =
   List.fold_left
     (fun acc stimulus ->

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -259,6 +259,10 @@ val remove_by_post_id : post_id -> t -> stimulus list * t
 (** Remove all stimuli whose [post_id] matches the argument, returning the
     removed stimuli in FIFO order plus the remaining queue. *)
 
+val contains : t -> stimulus -> bool
+(** [contains q s] is [true] when some stimulus already in [q] compares equal
+    to [s] under {!stimulus_identity_equal}. Queue order is unchanged. *)
+
 val uniq_stimuli : stimulus list -> stimulus list
 (** Remove duplicate stimuli by {!stimulus_identity_equal} while preserving the
     first occurrence order. *)

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -243,20 +243,6 @@ let with_pending pending state =
 
 let with_revision revision state = { state with revision }
 
-let rec queue_contains queue stimulus =
-  match Keeper_event_queue.dequeue queue with
-  | None -> false
-  | Some (head, rest) ->
-    Keeper_event_queue.stimulus_identity_equal head stimulus
-    || queue_contains rest stimulus
-;;
-
-let enqueue_if_missing queue stimulus =
-  if queue_contains queue stimulus
-  then queue
-  else Keeper_event_queue.enqueue queue stimulus
-;;
-
 let transition_outbox_blocked state = state.transition_outbox <> []
 
 let rec first_ready_entry ~ready = function

--- a/lib/keeper_runtime/keeper_fd_pressure.ml
+++ b/lib/keeper_runtime/keeper_fd_pressure.ml
@@ -180,12 +180,6 @@ let parse_system_fd_snapshot lines =
   | _ -> None
 ;;
 
-let process_status_to_string = function
-  | Unix.WEXITED code -> Printf.sprintf "exited(%d)" code
-  | Unix.WSIGNALED signal -> Printf.sprintf "signaled(%d)" signal
-  | Unix.WSTOPPED signal -> Printf.sprintf "stopped(%d)" signal
-;;
-
 let read_first_line path =
   try
     let ic = open_in path in
@@ -235,7 +229,7 @@ let detect_darwin_system_fd_snapshot_now () =
       | _lines, status ->
         Log.Keeper.warn
           "fd_observation: sysctl FD probe exited with %s"
-          (process_status_to_string status);
+          (With_process.status_to_string status);
         None
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -343,20 +343,12 @@ let rec drop_list n = function
   | [] -> []
   | _ :: rest -> drop_list (n - 1) rest
 
-let rec take_list n xs =
-  if n <= 0 then
-    []
-  else
-    match xs with
-    | [] -> []
-    | x :: rest -> x :: take_list (n - 1) rest
-
 let paginate_json_items ?(page_size = 128) ~field_name items cursor =
   match decode_cursor_offset cursor with
   | Error msg -> Error msg
   | Ok offset ->
       let total = List.length items in
-      let page = items |> drop_list offset |> take_list page_size in
+      let page = items |> drop_list offset |> List_util.take_first page_size in
       let next_offset = offset + List.length page in
       let fields =
         [ (field_name, `List page) ]

--- a/lib/notify.ml
+++ b/lib/notify.ml
@@ -15,9 +15,6 @@ type focus_payload = {
   task_id: string option;
 }
 
-let exec_gate_raw_source argv =
-  String.concat " " (List.map Filename.quote argv)
-
 (** {1 Non-blocking Shell Execution} *)
 
 (** Run argv and get single line (Eio-native, no shell) *)
@@ -25,7 +22,7 @@ let run_argv_line argv =
   let output =
     Masc_exec.Exec_gate.run_argv
       ~actor:(Masc_exec.Agent_id.of_string "system/notify")
-      ~raw_source:(exec_gate_raw_source argv)
+      ~raw_source:(Masc_exec.Exec_gate.raw_source_of_argv argv)
       ~summary:"notify argv"
 
       argv
@@ -44,7 +41,7 @@ let run_argv_ignore argv =
      let status, _output =
        Masc_exec.Exec_gate.run_argv_with_status
          ~actor:(Masc_exec.Agent_id.of_string "system/notify")
-         ~raw_source:(exec_gate_raw_source argv)
+         ~raw_source:(Masc_exec.Exec_gate.raw_source_of_argv argv)
          ~summary:"notify argv"
 
          argv

--- a/lib/operator/operator_task_recovery_command.ml
+++ b/lib/operator/operator_task_recovery_command.ml
@@ -195,14 +195,7 @@ let audit config ~actor command ~outcome =
   | exn -> Error (Printexc.to_string exn)
 ;;
 
-let audit_json = function
-  | Ok () -> `Assoc [ "recorded", `Bool true ]
-  | Error detail ->
-    `Assoc
-      [ "recorded", `Bool false
-      ; "error", `String (Observability_redact.redact_text detail)
-      ]
-;;
+let audit_json = Audit_log.write_result_to_json
 
 let success_json ~audit command
     (result : Workspace.operator_task_recovery_result) =

--- a/lib/process/with_process.ml
+++ b/lib/process/with_process.ml
@@ -21,6 +21,11 @@ let set_process_guard guard = Atomic.set process_guard guard
 let reset_process_guard_for_testing () = Atomic.set process_guard default_process_guard
 let with_process_guard f = (Atomic.get process_guard).run f
 
+let status_to_string = function
+  | Unix.WEXITED code -> Printf.sprintf "exited(%d)" code
+  | Unix.WSIGNALED signal -> Printf.sprintf "signaled(%d)" signal
+  | Unix.WSTOPPED signal -> Printf.sprintf "stopped(%d)" signal
+
 let close_best_effort ic =
   try let _ = (Unix.close_process_in ic : Unix.process_status) in ()
   with Unix.Unix_error _ | Sys_error _ | Failure _ -> ()

--- a/lib/process/with_process.mli
+++ b/lib/process/with_process.mli
@@ -11,6 +11,11 @@ val set_process_guard : process_guard -> unit
 val reset_process_guard_for_testing : unit -> unit
 (** Restore the default direct guard. Intended for focused tests. *)
 
+val status_to_string : Unix.process_status -> string
+(** Render the exit status returned by {!with_process_args_in} as
+    ["exited(N)"], ["signaled(N)"] or ["stopped(N)"], where [N] is the exit
+    code or signal number. Intended for log and probe-error text. *)
+
 val with_process_args_in :
   string -> string array -> (in_channel -> 'a) -> 'a * Unix.process_status
 (** [with_process_args_in prog argv f] opens [prog] with exact argv control,

--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -21,14 +21,6 @@ module Provider_binding = Runtime_provider_binding
 
 (* --- Inlined from the deleted [Runtime_config_provider_binding] --- *)
 
-(* Trim, lowercase, and replace [-] with [_] in a provider identifier so
-   label/binding lookups are case- and separator-insensitive. *)
-let normalize_provider_id provider_id =
-  String.trim provider_id
-  |> String.lowercase_ascii
-  |> String.map (fun c -> if c = '-' then '_' else c)
-;;
-
 let normalize_header_key key = String.lowercase_ascii (String.trim key)
 
 let is_auth_header_key key =
@@ -111,7 +103,7 @@ let resolve_provider_prefix (provider_id : string) : string option =
   match runtime_binding_id provider_id with
   | Some _ as found -> found
   | None ->
-    let normalized = normalize_provider_id provider_id in
+    let normalized = Provider_binding.normalize_provider_id provider_id in
     runtime_binding_id normalized
 ;;
 

--- a/lib/schedule/schedule_domain.mli
+++ b/lib/schedule/schedule_domain.mli
@@ -148,3 +148,18 @@ val wake_record_of_yojson :
   Yojson.Safe.t -> (wake_record, string) result
 val schedule_request_to_yojson : schedule_request -> Yojson.Safe.t
 val schedule_request_of_yojson : Yojson.Safe.t -> (schedule_request, string) result
+
+(* JSON field accessors. Exported because the schedule store, runner, and the
+   server-side payload consumers decode the same object shapes and previously
+   each carried a private copy. *)
+
+val assoc_field :
+  string -> (string * Yojson.Safe.t) list -> (Yojson.Safe.t, string) result
+(** [assoc_field name fields] returns the value bound to [name], or
+    [Error ("missing field: " ^ name)] when [name] is absent. *)
+
+val float_field : string -> (string * Yojson.Safe.t) list -> (float, string) result
+(** [float_field name fields] reads [name] as a float. A [`Int] value is
+    widened with [float_of_int]. Returns [Error ("missing field: " ^ name)]
+    when [name] is absent, and [Error (name ^ ": expected float")] for any
+    other JSON value. *)

--- a/lib/schedule/schedule_runner.ml
+++ b/lib/schedule/schedule_runner.ml
@@ -109,20 +109,6 @@ let string_field name fields =
   | None -> Error ("missing field: " ^ name)
 ;;
 
-let float_field name fields =
-  match List.assoc_opt name fields with
-  | Some (`Float value) -> Ok value
-  | Some (`Int value) -> Ok (float_of_int value)
-  | Some _ -> Error ("expected float field: " ^ name)
-  | None -> Error ("missing field: " ^ name)
-;;
-
-let assoc_field name fields =
-  match List.assoc_opt name fields with
-  | Some value -> Ok value
-  | None -> Error ("missing field: " ^ name)
-;;
-
 let wake_signal_to_yojson signal =
   `Assoc
     [ "event_type", `String (signal_kind_to_string signal.kind)
@@ -143,10 +129,10 @@ let wake_signal_of_yojson = function
     let* occurrence_id = string_field "occurrence_id" fields in
     let* schedule_instance_id = string_field "schedule_instance_id" fields in
     let* schedule_id = string_field "schedule_id" fields in
-    let* emitted_at = float_field "emitted_at" fields in
-    let* due_at = float_field "due_at" fields in
+    let* emitted_at = Schedule_domain.float_field "emitted_at" fields in
+    let* due_at = Schedule_domain.float_field "due_at" fields in
     let* payload_digest = string_field "payload_digest" fields in
-    let* payload = assoc_field "payload" fields in
+    let* payload = Schedule_domain.assoc_field "payload" fields in
     let* decoded_payload = Schedule_domain.payload_of_yojson payload in
     let actual_payload_digest = Schedule_domain.payload_digest decoded_payload in
     let* () =

--- a/lib/schedule/schedule_store.ml
+++ b/lib/schedule/schedule_store.ml
@@ -142,14 +142,6 @@ let int_field name fields =
   | None -> Error ("missing field: " ^ name)
 ;;
 
-let float_field name fields =
-  match List.assoc_opt name fields with
-  | Some (`Float value) -> Ok value
-  | Some (`Int value) -> Ok (float_of_int value)
-  | Some _ -> Error ("expected float field: " ^ name)
-  | None -> Error ("missing field: " ^ name)
-;;
-
 let list_field name fields =
   match List.assoc_opt name fields with
   | Some (`List value) -> Ok value
@@ -170,7 +162,7 @@ let collect_results parse rows =
 let state_of_yojson = function
   | `Assoc fields ->
     let* version = int_field "version" fields in
-    let* updated_at = float_field "updated_at" fields in
+    let* updated_at = Schedule_domain.float_field "updated_at" fields in
     let* schedules_json = list_field "schedules" fields in
     let* wakes_json = list_field "wakes" fields in
     let* schedules =

--- a/lib/schedule_payload_projection.ml
+++ b/lib/schedule_payload_projection.ml
@@ -38,11 +38,6 @@ type support_summary =
 
 let ( let* ) = Result.bind
 
-let trim_nonempty value =
-  let trimmed = String.trim value in
-  if String.equal trimmed "" then None else Some trimmed
-;;
-
 let known_kind_to_string = function
   | Keeper_wake -> Schedule_supported_kinds.keeper_wake
 ;;
@@ -82,14 +77,14 @@ let classify_kind = function
 
 let assoc_string key fields =
   match List.assoc_opt key fields with
-  | Some (`String value) -> trim_nonempty value
+  | Some (`String value) -> String_util.trim_nonempty value
   | _ -> None
 ;;
 
 let required_string_field name fields =
   match List.assoc_opt name fields with
   | Some (`String value) ->
-    (match trim_nonempty value with
+    (match String_util.trim_nonempty value with
      | Some value -> Ok value
      | None -> Error (name ^ " must be non-empty"))
   | Some _ -> Error ("expected string field: " ^ name)
@@ -99,7 +94,7 @@ let required_string_field name fields =
 let optional_string_field name fields =
   match List.assoc_opt name fields with
   | None | Some `Null -> Ok None
-  | Some (`String value) -> Ok (trim_nonempty value)
+  | Some (`String value) -> Ok (String_util.trim_nonempty value)
   | Some _ -> Error ("expected string field: " ^ name)
 ;;
 

--- a/lib/server/proactive_refresh.ml
+++ b/lib/server/proactive_refresh.ml
@@ -30,17 +30,9 @@ let default_config ~label ~interval_s =
     warn_first_failure = true;
   }
 
-let is_internal_race_cancel exn =
-  match exn with
-  | Eio.Cancel.Cancelled _ ->
-      let msg = Printexc.to_string exn in
-      String.equal msg "Cancelled: Eio__core__Fiber.Not_first"
-      || String.ends_with ~suffix:"Eio__core__Fiber.Not_first" msg
-  | _ -> false
-
 let should_reraise_cancel exn =
   match exn with
-  | Eio.Cancel.Cancelled _ -> not (is_internal_race_cancel exn)
+  | Eio.Cancel.Cancelled _ -> not (Cancel_safe.is_internal_race_cancel exn)
   | _ -> false
 
 let timeout_failure_message ~label ~phase ~timeout_s ~elapsed_s =

--- a/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
@@ -5,15 +5,6 @@ open Server_dashboard_http_keeper_api_types
 
 module Http = Http_server_eio
 
-let error_json ?ok message =
-  let fields = [ ("error", `String message) ] in
-  let fields =
-    match ok with
-    | None -> fields
-    | Some value -> ("ok", `Bool value) :: fields
-  in
-  `Assoc fields
-
 let respond_error ?(status = `Bad_request) ?request ?ok reqd message =
   Http.Response.json_value ?request ~status (error_json ?ok message) reqd
 

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -17,15 +17,6 @@ let dedupe_thinking_lines = Trace.dedupe_thinking_lines
 let read_internal_history_lines = Trace.read_internal_history_lines
 let merge_keeper_trace_lines = Trace.merge_keeper_trace_lines
 
-let error_json ?ok message =
-  let fields = [ ("error", `String message) ] in
-  let fields =
-    match ok with
-    | None -> fields
-    | Some value -> ("ok", `Bool value) :: fields
-  in
-  `Assoc fields
-
 let respond_error ?(status = `Bad_request) ?request ?ok reqd message =
   Http.Response.json_value ?request ~status (error_json ?ok message) reqd
 

--- a/lib/server/server_dashboard_http_keeper_api_post.mli
+++ b/lib/server/server_dashboard_http_keeper_api_post.mli
@@ -16,7 +16,6 @@ val merge_keeper_trace_lines :
   Trajectory.trajectory_line list ->
   Trajectory.trajectory_line list
 
-val error_json : ?ok:bool -> string -> Yojson.Safe.t
 val respond_error :
   ?status:Httpun.Status.t ->
   ?request:Httpun.Request.t ->

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -436,3 +436,12 @@ let runtime_manifest_public_json row =
   Keeper_runtime_manifest.public_to_json row
 
 let take_last = List_util.take_last
+
+let error_json ?ok message =
+  let fields = [ ("error", `String message) ] in
+  let fields =
+    match ok with
+    | None -> fields
+    | Some value -> ("ok", `Bool value) :: fields
+  in
+  `Assoc fields

--- a/lib/server/server_dashboard_http_keeper_api_types.mli
+++ b/lib/server/server_dashboard_http_keeper_api_types.mli
@@ -201,3 +201,9 @@ val runtime_manifest_public_json :
   Keeper_runtime_manifest.t -> Yojson.Safe.t
 (** Pure: convert a manifest row to its public JSON, with provider/model
     identity redaction applied. *)
+
+(** {1 Error envelope} *)
+
+val error_json : ?ok:bool -> string -> Yojson.Safe.t
+(** [error_json ?ok message] builds [`Assoc] with an ["error"] field holding
+    [message], prefixed by an ["ok"] boolean field when [ok] is supplied. *)

--- a/lib/server/server_dashboard_surface.ml
+++ b/lib/server/server_dashboard_surface.ml
@@ -21,26 +21,21 @@ type t = {
 
 let schema = "masc.dashboard_surface.v1"
 
-let assoc_field key = function
-  | `Assoc fields -> List.assoc_opt key fields
-  | _ -> None
-;;
-
 let string_field key json =
-  match assoc_field key json with
+  match Json_util.assoc_member_opt key json with
   | Some (`String value) -> String_util.trim_to_option value
   | _ -> None
 ;;
 
 let float_field key json =
-  match assoc_field key json with
+  match Json_util.assoc_member_opt key json with
   | Some (`Float value) -> Some value
   | Some (`Int value) -> Some (float_of_int value)
   | _ -> None
 ;;
 
 let projection_diagnostics json =
-  match assoc_field "projection_diagnostics" json with
+  match Json_util.assoc_member_opt "projection_diagnostics" json with
   | Some (`Assoc fields) -> `Assoc fields
   | _ -> `Assoc []
 ;;

--- a/lib/server/server_mcp_transport_http_conn.ml
+++ b/lib/server/server_mcp_transport_http_conn.ml
@@ -48,12 +48,6 @@ let make_sse_conn ~session_id ~client_id ~writer ~mutex () =
 
 module SMap = Set_util.StringMap
 
-let rec atomic_update atomic f =
-  let old_val = Atomic.get atomic in
-  let new_val = f old_val in
-  if Atomic.compare_and_set atomic old_val new_val then ()
-  else atomic_update atomic f
-
 let sse_conn_by_session : sse_conn_info SMap.t Atomic.t = Atomic.make SMap.empty
 
 type sse_connect_guard_state = {
@@ -108,7 +102,7 @@ let guard_expired ~now ~session_id state =
 (** Register an SSE connection under [sse_registry_mutex].
     All call sites must use this instead of direct [Hashtbl.replace]. *)
 let register_sse_conn ~session_id ~info =
-  atomic_update sse_conn_by_session (fun map -> SMap.add session_id info map)
+  Atomic_util.update sse_conn_by_session (fun map -> SMap.add session_id info map)
 
 (* Claim the single close of [info]: returns [true] for exactly one caller even
    under concurrent close paths (a disconnect on one domain racing eviction or
@@ -145,7 +139,7 @@ let close_sse_conn info =
 
 let stop_sse_session_impl ~clear_guard session_id =
   let info_opt = ref None in
-  atomic_update sse_conn_by_session (fun map ->
+  Atomic_util.update sse_conn_by_session (fun map ->
     match SMap.find_opt session_id map with
     | None -> map
     | Some info ->
@@ -153,7 +147,7 @@ let stop_sse_session_impl ~clear_guard session_id =
         SMap.remove session_id map
   );
   if clear_guard then
-    atomic_update sse_connect_guard_by_session (fun map -> SMap.remove session_id map);
+    Atomic_util.update sse_connect_guard_by_session (fun map -> SMap.remove session_id map);
   match !info_opt with
   | None -> ()
   | Some info -> close_sse_conn info
@@ -172,13 +166,13 @@ let stop_sse_session_preserve_guard session_id =
 let stop_sse_session_evict session_id
     ~(reason : Session_lifecycle_event.evict_reason) =
   let info_opt = ref None in
-  atomic_update sse_conn_by_session (fun map ->
+  Atomic_util.update sse_conn_by_session (fun map ->
     match SMap.find_opt session_id map with
     | None -> map
     | Some info ->
         info_opt := Some info;
         SMap.remove session_id map);
-  atomic_update sse_connect_guard_by_session (fun map ->
+  Atomic_util.update sse_connect_guard_by_session (fun map ->
     SMap.remove session_id map);
   (match !info_opt with
    | None -> ()
@@ -229,7 +223,7 @@ let reap_stale_guards () =
     ) (Atomic.get sse_connect_guard_by_session) []
   in
   if stale <> [] then
-    atomic_update sse_connect_guard_by_session (fun map ->
+    Atomic_util.update sse_connect_guard_by_session (fun map ->
       List.fold_left (fun acc sid -> SMap.remove sid acc) map stale
     );
   List.length stale
@@ -298,7 +292,7 @@ let prune_connect_times ~now times =
 let check_sse_connect_guard session_id =
   let now = Time_compat.now () in
   let result = ref (Ok ()) in
-  atomic_update sse_connect_guard_by_session (fun map ->
+  Atomic_util.update sse_connect_guard_by_session (fun map ->
     let state =
       match SMap.find_opt session_id map with
       | Some v ->

--- a/lib/server/server_mcp_transport_http_session.ml
+++ b/lib/server/server_mcp_transport_http_session.ml
@@ -2,12 +2,6 @@ open Result.Syntax
 
 module SMap = Set_util.StringMap
 
-let rec atomic_update atomic f =
-  let old_val = Atomic.get atomic in
-  let new_val = f old_val in
-  if Atomic.compare_and_set atomic old_val new_val then ()
-  else atomic_update atomic f
-
 let mcp_protocol_versions = Mcp_transport_protocol.supported_protocol_versions
 
 let mcp_protocol_version_default = Mcp_transport_protocol.default_protocol_version
@@ -81,18 +75,18 @@ let record_mcp_server_session_duration ?error_type session_id =
 
 let remember_session_activity ?otel_transport_context session_id =
   let now = Unix.gettimeofday () in
-  atomic_update session_started_at (fun map ->
+  Atomic_util.update session_started_at (fun map ->
     if SMap.mem session_id map then map else SMap.add session_id now map);
-  atomic_update session_last_active_sse (fun map -> SMap.add session_id now map);
+  Atomic_util.update session_last_active_sse (fun map -> SMap.add session_id now map);
   match otel_transport_context with
   | None -> ()
   | Some transport ->
-    atomic_update session_transport_context (fun map ->
+    Atomic_util.update session_transport_context (fun map ->
       SMap.add session_id transport map)
 
 let remember_protocol_version ?otel_transport_context session_id version =
   if is_valid_protocol_version version then begin
-    atomic_update protocol_version_by_session (fun map -> SMap.add session_id version map);
+    Atomic_util.update protocol_version_by_session (fun map -> SMap.add session_id version map);
     remember_session_activity ?otel_transport_context session_id
   end
 
@@ -143,18 +137,18 @@ let ensure_sse_backing_session_for_known_transport_session
     ()
 
 let remember_mcp_profile ?otel_transport_context session_id profile =
-  atomic_update mcp_profile_by_session (fun map -> SMap.add session_id profile map);
+  Atomic_util.update mcp_profile_by_session (fun map -> SMap.add session_id profile map);
   if is_known_session session_id then
     remember_session_activity ?otel_transport_context session_id
 
 let forget_mcp_session session_id =
   record_mcp_server_session_duration session_id;
   Client_registry_eio.unregister_mcp_session session_id;
-  atomic_update protocol_version_by_session (fun map -> SMap.remove session_id map);
-  atomic_update mcp_profile_by_session (fun map -> SMap.remove session_id map);
-  atomic_update session_last_active_sse (fun map -> SMap.remove session_id map);
-  atomic_update session_started_at (fun map -> SMap.remove session_id map);
-  atomic_update session_transport_context (fun map -> SMap.remove session_id map)
+  Atomic_util.update protocol_version_by_session (fun map -> SMap.remove session_id map);
+  Atomic_util.update mcp_profile_by_session (fun map -> SMap.remove session_id map);
+  Atomic_util.update session_last_active_sse (fun map -> SMap.remove session_id map);
+  Atomic_util.update session_started_at (fun map -> SMap.remove session_id map);
+  Atomic_util.update session_transport_context (fun map -> SMap.remove session_id map)
 
 (* ===== File persistence ===== *)
 
@@ -330,7 +324,7 @@ let load_sessions_from_file () =
                           | Some value -> value
                           | None -> t
                         in
-                        atomic_update protocol_version_by_session
+                        Atomic_util.update protocol_version_by_session
                           (fun map -> SMap.add sid v map);
                         let profile =
                           match profile_str with
@@ -339,16 +333,16 @@ let load_sessions_from_file () =
                         in
                         (match profile with
                          | Some profile ->
-                             atomic_update mcp_profile_by_session
+                             Atomic_util.update mcp_profile_by_session
                                (fun map -> SMap.add sid profile map)
                          | None -> ());
-                        atomic_update session_last_active_sse
+                        Atomic_util.update session_last_active_sse
                           (fun map -> SMap.add sid t map);
-                        atomic_update session_started_at
+                        Atomic_util.update session_started_at
                           (fun map -> SMap.add sid started_at map);
                         (match transport_context fields with
                          | Some transport ->
-                             atomic_update session_transport_context
+                             Atomic_util.update session_transport_context
                                (fun map -> SMap.add sid transport map)
                          | None -> ())
                       end
@@ -376,7 +370,7 @@ let reap_stale_sessions ~is_active_session =
     SMap.fold (fun sid _ (stale_acc, grace_acc) ->
       if is_active_session sid then begin
         (* Active right now — refresh timestamp, keep session *)
-        atomic_update session_last_active_sse
+        Atomic_util.update session_last_active_sse
           (fun map -> SMap.add sid now map);
         (stale_acc, grace_acc)
       end else begin

--- a/lib/server/server_routes_http_routes_keeper_repos.ml
+++ b/lib/server/server_routes_http_routes_keeper_repos.ml
@@ -6,11 +6,6 @@ module Http = Http_server_eio
 let mappings_path = "/api/v1/keeper-repos"
 let mapping_prefix = "/api/v1/keeper-repos/"
 
-let path_parts rest =
-  rest
-  |> String.split_on_char '/'
-  |> List.filter (fun part -> String.trim part <> "")
-
 let extract_keeper_id path =
   match extract_path_param ~prefix:mapping_prefix path with
   | None | Some "" -> Error "missing keeper id"

--- a/lib/server/server_routes_http_routes_repositories.ml
+++ b/lib/server/server_routes_http_routes_repositories.ml
@@ -17,11 +17,6 @@ let sync_suffix = "/sync"
 let extract_repo_id path =
   extract_path_param ~prefix:repositories_prefix path
 
-let path_parts rest =
-  rest
-  |> String.split_on_char '/'
-  |> List.filter (fun part -> String.trim part <> "")
-
 let extract_repo_id_for_sync path =
   match extract_path_param ~prefix:repositories_prefix path with
   | None -> None

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -361,11 +361,6 @@ let assoc_string_opt name json =
   | Some (`String value) -> Some value
   | _ -> None
 
-let assoc_bool_opt name json =
-  match assoc_member_opt name json with
-  | Some (`Bool value) -> Some value
-  | _ -> None
-
 let assoc_string_list name json =
   match assoc_member_opt name json with
   | Some (`List values) ->
@@ -396,7 +391,7 @@ let full_health_operator_summary ~keeper_fleet_safety
     in
     status := max_health_status !status component_status;
     let action_required =
-      match assoc_bool_opt "operator_action_required" json with
+      match Json_util.assoc_bool_opt "operator_action_required" json with
       | Some value -> value
       | None -> false
     in

--- a/lib/server/server_schedule_consumers.ml
+++ b/lib/server/server_schedule_consumers.ml
@@ -29,14 +29,10 @@ let record_unsupported_payload_dispatch _request rejection =
   | Schedule_payload_projection.Dispatch_invalid_supported_payload _ -> ()
 ;;
 
-let assoc_field name fields =
-  match List.assoc_opt name fields with
-  | Some value -> Ok value
-  | None -> Error ("missing field: " ^ name)
-;;
-
+(* Consumer-local: rejects blank strings, so only the raw field lookup is
+   shared with the schedule domain. *)
 let string_field name fields =
-  let* value = assoc_field name fields in
+  let* value = Schedule_domain.assoc_field name fields in
   match value with
   | `String value when String.trim value <> "" -> Ok value
   | `String _ -> Error (name ^ " must be non-empty")

--- a/lib/server/server_startup_takeover.ml
+++ b/lib/server/server_startup_takeover.ml
@@ -81,16 +81,6 @@ type base_path_acquire_result =
   | Base_path_already_owned of { pid : int option }
   | Base_path_rejected of base_path_lock_rejection
 
-let file_kind_to_string = function
-  | Unix.S_REG -> "regular_file"
-  | Unix.S_DIR -> "directory"
-  | Unix.S_CHR -> "character_device"
-  | Unix.S_BLK -> "block_device"
-  | Unix.S_LNK -> "symbolic_link"
-  | Unix.S_FIFO -> "fifo"
-  | Unix.S_SOCK -> "socket"
-;;
-
 let base_path_lock_rejection_to_string = function
   | Base_path_canonicalization_failed { base_path; reason } ->
     Printf.sprintf "BasePath canonicalization failed path=%s error=%s" base_path reason
@@ -98,7 +88,7 @@ let base_path_lock_rejection_to_string = function
     Printf.sprintf
       "BasePath is not a directory path=%s kind=%s"
       path
-      (file_kind_to_string kind)
+      (Fs_compat.file_kind_to_string kind)
   | Run_directory_canonicalization_failed { run_dir; reason } ->
     Printf.sprintf
       "host run directory canonicalization failed path=%s error=%s"
@@ -108,7 +98,7 @@ let base_path_lock_rejection_to_string = function
     Printf.sprintf
       "host run directory is not a directory path=%s kind=%s"
       path
-      (file_kind_to_string kind)
+      (Fs_compat.file_kind_to_string kind)
   | Run_directory_untrusted_owner { path; effective_uid; observed_uid } ->
     Printf.sprintf
       "host run directory owner is outside the process/system trust boundary path=%s effective_uid=%d observed_uid=%d"
@@ -129,7 +119,7 @@ let base_path_lock_rejection_to_string = function
     Printf.sprintf
       "private BasePath lease path is not a directory path=%s kind=%s"
       path
-      (file_kind_to_string kind)
+      (Fs_compat.file_kind_to_string kind)
   | Lease_directory_wrong_owner { path; expected_uid; observed_uid } ->
     Printf.sprintf
       "private BasePath lease directory owner mismatch path=%s expected_uid=%d observed_uid=%d"
@@ -153,7 +143,7 @@ let base_path_lock_rejection_to_string = function
     Printf.sprintf
       "BasePath lease is not a regular file path=%s kind=%s"
       path
-      (file_kind_to_string kind)
+      (Fs_compat.file_kind_to_string kind)
   | Lease_file_multiply_linked { path; links } ->
     Printf.sprintf
       "BasePath lease has multiple hard links path=%s links=%d"

--- a/lib/server_utils.ml
+++ b/lib/server_utils.ml
@@ -372,6 +372,12 @@ let extract_path_param ~prefix path =
     if String.length param > 0 then Some param else None
   else None
 
+(** Split a path remainder on '/' and drop segments that are blank after trim. *)
+let path_parts rest =
+  rest
+  |> String.split_on_char '/'
+  |> List.filter (fun part -> String.trim part <> "")
+
 (** Standard query param: limit with default 50, clamped 1..200. *)
 let standard_limit request =
   int_query_param request "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200

--- a/lib/server_utils.mli
+++ b/lib/server_utils.mli
@@ -244,6 +244,10 @@ val extract_path_param : prefix:string -> string -> string option
     pre-extraction-helper code had three independent
     String.sub callsites that all crashed on edge inputs. *)
 
+val path_parts : string -> string list
+(** [path_parts rest] splits [rest] on ['/'] and drops the
+    segments that are empty after trimming. *)
+
 (** {1 Standard pagination} *)
 
 val standard_limit : Httpun.Request.t -> int

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -11,16 +11,6 @@ let task_log_info ~task_id fmt =
     (fun message -> Log.Task.info "task_id=%s %s" task_id message)
     fmt
 
-let task_log_warn ~task_id fmt =
-  Stdlib.Format.ksprintf
-    (fun message -> Log.Task.warn "task_id=%s %s" task_id message)
-    fmt
-
-let task_log_error ~task_id fmt =
-  Stdlib.Format.ksprintf
-    (fun message -> Log.Task.error "task_id=%s %s" task_id message)
-    fmt
-
 let workflow_rejection_result
       ~tool_name
       ~start_time

--- a/lib/task/tool_task_handlers.ml
+++ b/lib/task/tool_task_handlers.ml
@@ -558,14 +558,3 @@ let handle_release ~tool_name ~start_time ctx args =
               sync_planning_current_task_with_owned_task ctx)
            result;
          result_to_response ~tool_name ~start_time result)
-
-let transition_known_args =
-  [
-    "task_id";
-    "action";
-    "notes";
-    "reason";
-    "expected_version";
-    "agent_name";
-    "handoff_context";
-  ]

--- a/lib/task/tool_task_handlers.mli
+++ b/lib/task/tool_task_handlers.mli
@@ -19,6 +19,14 @@ val push_event_to_sessions_fn : (Yojson.Safe.t -> unit) Atomic.t
 val set_task_owner_hooks : task_owner_hooks -> unit
 val current_task_owner_hooks : unit -> task_owner_hooks
 
+(** Formats [fmt] and emits it on [Log.Task] at warn level, prefixed with
+    [task_id=<task_id> ]. *)
+val task_log_warn : task_id:string -> ('a, unit, string, unit) format4 -> 'a
+
+(** Formats [fmt] and emits it on [Log.Task] at error level, prefixed with
+    [task_id=<task_id> ]. *)
+val task_log_error : task_id:string -> ('a, unit, string, unit) format4 -> 'a
+
 include module type of Tool_task_payloads
 include module type of Tool_task_args
 include module type of Tool_task_completion_review

--- a/lib/task_completion_claim.ml
+++ b/lib/task_completion_claim.ml
@@ -1,13 +1,10 @@
 (* SSOT for deliverable completion-claim detection. See task_completion_claim.mli
    for the contract and the RFC-0323 escalation note on the string-match limit. *)
 
-let first_line text =
-  match String.index_opt text '\n' with
-  | Some i -> String.sub text 0 i
-  | None -> text
-
 let deliverable_claims_completion ~task_id deliverable =
-  let normalized = deliverable |> String.trim |> String.lowercase_ascii |> first_line in
+  let normalized =
+    deliverable |> String.trim |> String.lowercase_ascii |> String_util.first_line
+  in
   normalized <> ""
   && (String.starts_with
         ~prefix:(String.lowercase_ascii task_id ^ " completed")

--- a/lib/tool_blob_store/tool_blob_store.ml
+++ b/lib/tool_blob_store/tool_blob_store.ml
@@ -373,16 +373,6 @@ let delete_error_to_string { sha256; path; reason } =
   Printf.sprintf "blob delete failed sha256=%s path=%s: %s" sha256 path reason
 ;;
 
-let file_kind_to_string = function
-  | Unix.S_REG -> "regular_file"
-  | Unix.S_DIR -> "directory"
-  | Unix.S_CHR -> "character_device"
-  | Unix.S_BLK -> "block_device"
-  | Unix.S_LNK -> "symbolic_link"
-  | Unix.S_FIFO -> "fifo"
-  | Unix.S_SOCK -> "socket"
-;;
-
 let delete t ~sha256 =
   match validate_sha256 sha256 with
   | Error invalid ->
@@ -419,7 +409,7 @@ let delete t ~sha256 =
               ; reason =
                   Printf.sprintf
                     "refusing to delete non-regular blob kind=%s"
-                    (file_kind_to_string target.st_kind)
+                    (Fs_compat.file_kind_to_string target.st_kind)
               }
           else
             (match

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.ml
@@ -23,12 +23,6 @@ let default_case_set_path ~repo_root =
 let default_evidence_path ~repo_root =
   Filename.concat repo_root "test/fixtures/tool_call_quality_benchmark/evidence_runs.json"
 
-let normalize_string_list items =
-  items
-  |> List.map String.trim
-  |> List.filter (fun item -> not (String.equal item ""))
-  |> Json_util.dedupe_keep_order
-
 let errorf fmt = Printf.ksprintf (fun s -> Error s) fmt
 
 let ( let* ) = Result.bind
@@ -79,7 +73,7 @@ let string_list_field json key =
   let* items = list_field json key in
   Ok (items
       |> List.filter_map (function `String s -> Some s | _ -> None)
-      |> normalize_string_list)
+      |> Json_util.normalize_string_list)
 
 let selector_list_field json key =
   let* items = list_field json key in

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_summary.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_summary.ml
@@ -48,18 +48,12 @@ let percentile95_int_option values =
       | Some v -> Stdlib.Float.of_int v
       | None -> 0.0
 
-let normalize_string_list items =
-  items
-  |> List.map String.trim
-  |> List.filter (fun item -> not (String.equal item ""))
-  |> Json_util.dedupe_keep_order
-
 let model_label (run : evidence_run) = run.provider ^ ":" ^ run.model
 
 let normalize_filter_set values =
   let table = Hashtbl.create 8 in
   values
-  |> normalize_string_list
+  |> Json_util.normalize_string_list
   |> List.iter (fun value -> Hashtbl.replace table value ());
   table
 

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_summary.mli
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_summary.mli
@@ -12,10 +12,10 @@
     {!Tool_call_quality_benchmark} (the facade that wires all
     three together).
 
-    Internal: 19 helpers stay private (\[avg_float\],
+    Internal: 18 helpers stay private (\[avg_float\],
     \[avg_int_option\], \[avg_float_option\],
     \[percentile95_int_option\], \[dedupe_keep_order\],
-    \[normalize_string_list\], \[model_label\],
+    \[model_label\],
     \[normalize_filter_set\], \[keep_run\],
     \[group_scores_by_case\], \[modal_ratio\], \[tool_sequence\],
     \[summary_key_of_run\], \[summary_key_of_score\],

--- a/lib/tool_library.ml
+++ b/lib/tool_library.ml
@@ -173,19 +173,8 @@ let list_documents ?(include_candidates=false) () =
    matching ..." / "No candidate matching ..." not-found cases are
    [Workflow_rejection] because the caller chose the topic. *)
 
-let workflow_err ~tool_name ~start_time msg : Tool_result.result =
-  Tool_result.make_err
-    ~tool_name
-    ~class_:Tool_result.Workflow_rejection
-    ~start_time
-    msg
-
-let runtime_err ~tool_name ~start_time msg : Tool_result.result =
-  Tool_result.make_err
-    ~tool_name
-    ~class_:Tool_result.Runtime_failure
-    ~start_time
-    msg
+let workflow_err = Tool_result.workflow_err
+let runtime_err = Tool_result.runtime_err
 
 let topic_required ~tool_name ~start_time =
   workflow_err ~tool_name ~start_time "topic is required"

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -51,12 +51,7 @@ type context = {
 let text_ok ~tool_name ~start_time body : Tool_result.result =
   Tool_result.ok ~tool_name ~start_time body
 
-let workflow_err ~tool_name ~start_time msg : Tool_result.result =
-  Tool_result.make_err
-    ~tool_name
-    ~class_:Tool_result.Workflow_rejection
-    ~start_time
-    msg
+let workflow_err = Tool_result.workflow_err
 
 let expect_no_args ~tool_name ~start_time args =
   match args with

--- a/lib/tool_misc_web_search.ml
+++ b/lib/tool_misc_web_search.ml
@@ -702,19 +702,8 @@ let with_simulated_search_for_test ~outcomes f =
 let data_ok ~tool_name ~start_time data : Tool_result.result =
   Tool_result.make_ok ~tool_name ~start_time ~data ()
 
-let workflow_err ~tool_name ~start_time msg : Tool_result.result =
-  Tool_result.make_err
-    ~tool_name
-    ~class_:Tool_result.Workflow_rejection
-    ~start_time
-    msg
-
-let runtime_err ~tool_name ~start_time msg : Tool_result.result =
-  Tool_result.make_err
-    ~tool_name
-    ~class_:Tool_result.Runtime_failure
-    ~start_time
-    msg
+let workflow_err = Tool_result.workflow_err
+let runtime_err = Tool_result.runtime_err
 
 let handle ~tool_name ~start_time args : Tool_result.result =
   let query = get_string args "query" "" in

--- a/lib/tool_schedule.ml
+++ b/lib/tool_schedule.ml
@@ -11,15 +11,10 @@ type context =
 
 let ( let* ) = Result.bind
 
-let trim_nonempty value =
-  let trimmed = String.trim value in
-  if String.equal trimmed "" then None else Some trimmed
-;;
-
 let string_opt args key =
   match Json_util.get_string args key with
   | None -> None
-  | Some value -> trim_nonempty value
+  | Some value -> String_util.trim_nonempty value
 ;;
 
 let required_string args key =

--- a/lib/tool_types/tool_result.ml
+++ b/lib/tool_types/tool_result.ml
@@ -298,3 +298,16 @@ let make_err_of_exn ?class_ ~tool_name ~start_time exn : result =
   in
   Failed { class_; message; data = `String message; tool_name; duration_ms }
 ;;
+
+(** {1 Class-specialised constructors}
+
+    {!make_err} with the [class_] fixed, for the two classes that
+    [Tool_*.dispatch] handlers construct directly. *)
+
+let workflow_err ~tool_name ~start_time message_str : result =
+  make_err ~tool_name ~class_:Workflow_rejection ~start_time message_str
+;;
+
+let runtime_err ~tool_name ~start_time message_str : result =
+  make_err ~tool_name ~class_:Runtime_failure ~start_time message_str
+;;

--- a/lib/tool_types/tool_result.mli
+++ b/lib/tool_types/tool_result.mli
@@ -198,3 +198,13 @@ val make_err_of_exn
   -> start_time:float
   -> exn
   -> result
+
+(** {1 Class-specialised constructors} *)
+
+(** {!make_err} with [~class_:Workflow_rejection] and the default [`Null]
+    data payload. *)
+val workflow_err : tool_name:string -> start_time:float -> string -> result
+
+(** {!make_err} with [~class_:Runtime_failure] and the default [`Null]
+    data payload. *)
+val runtime_err : tool_name:string -> start_time:float -> string -> result

--- a/lib/tool_usage_log.ml
+++ b/lib/tool_usage_log.ml
@@ -55,11 +55,6 @@ let retention_days () =
      | _ -> None)
   | None -> None
 
-let max_ts_opt current candidate =
-  match current with
-  | Some existing when existing >= candidate -> current
-  | _ -> Some candidate
-
 let numeric_ts_field fields name =
   match List.assoc_opt name fields with
   | Some (`Float ts) -> Some ts

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -415,13 +415,8 @@ let inc_agent_stale () = Otel_metric_store.inc_counter Otel_metric_store.metric_
 
 (** {1 Transport Health JSON Snapshot} *)
 
-let assoc_field key = function
-  | `Assoc fields -> List.assoc_opt key fields
-  | _ -> None
-;;
-
 let int_field key json =
-  match assoc_field key json with
+  match Json_util.assoc_member_opt key json with
   | Some (`Int value) -> value
   | Some (`Intlit raw) -> Safe_ops.int_of_string_with_default ~default:0 raw
   | _ -> 0

--- a/lib/transport_metrics.mli
+++ b/lib/transport_metrics.mli
@@ -16,7 +16,7 @@
     high-cardinality so kept internal), [grpc_enabled] /
     [grpc_port] / [ws_port] (env-derived), [set_agent_heartbeat_age]
     / [inc_agent_stale] (per-agent labels, internal-only), the
-    JSON helpers (\[assoc_field], [int_field], [int_field_opt],
+    JSON helpers ([int_field], [int_field_opt],
     [int_option_json], [workspace_id_from_config], [cluster_summary_json]),
     [http_listener_mode], [primary_path], [queue_pressure],
     [tcp_port_reachable], [hot_session_json], the

--- a/lib/workspace_status_rendering.ml
+++ b/lib/workspace_status_rendering.ml
@@ -26,11 +26,6 @@ let option_or_dash = function
   | Some value when not (String.equal (String.trim value) "") -> value
   | _ -> "-"
 
-let first_line text =
-  match String.index_opt text '\n' with
-  | Some i -> String.sub text 0 i
-  | None -> text
-
 let take_items limit items =
   let rec loop remaining acc = function
     | _ when remaining <= 0 -> List.rev acc
@@ -123,7 +118,7 @@ let agent_focus_label ~active_assigned_task_ids (agent : Masc_domain.agent) =
   | [] -> (
       match agent.current_task with
       | Some raw_task ->
-          let task = raw_task |> String.trim |> first_line in
+          let task = raw_task |> String.trim |> String_util.first_line in
           if String.equal task "" then
             Masc_domain.agent_status_to_string agent.status
           else


### PR DESCRIPTION
Base 는 `main` 이다. 처음에는 #26806 (빌드 파손 복구) 위에 쌓았으나, 같은 복구를 #26805 가 먼저 머지해서 #26806 은 중복으로 닫았다. 이 브랜치는 현재 `main` (5392537299) 위로 rebase 했고 충돌은 없었다. rebase 후 `dune build --root .` 재실행 → exit 0.

## 무엇을 찾았나

`lib/` 전체에서 최상위 `let` 본문 6줄 이상이 **공백 정규화 후 바이트 단위로 동일**한 그룹을 전수 수집했다. 85 그룹, 중복분 793 줄.

탐지기 주의점 하나를 먼저 밝힌다. 초기 스트리퍼가 문자열 리터럴 내용을 지웠고, 그래서 출력이 다른 함수가 동일로 잡혔다. 문자열 보존 기준으로 재측정한 값이 위 85 그룹이며, 리터럴만 다른 6 그룹 60 줄은 제외했다. 아래 판정 과정에서 이 유형이 `keep` 사유로 여러 번 등장한다.

## 판정

91 개 후보를 각각 **그 함수가 만지는 타입**과 **dune 라이브러리 그래프** 기준으로 판정했다. 55 unify, 36 keep.

`keep` 이 나온 이유는 대체로 셋 중 하나다.

1. **모듈 로컬 error 타입** — 본문이 반환하는 `Error (Decode_failed ...)` 의 생성자 이름만 같고 타입이 다르다. `Fusion_delivery_obligation.error`(11 생성자) 와 `Keeper_chat_direct_delivery.error`(22 생성자) 를 합쳐야 하므로 무관한 실패 도메인을 통합하게 된다.
2. **라이브러리 경계** — `lib/shared_audit/dune` 는 `masc_core` 를 의존하지 않는다. 합치려면 `(libraries ...)` 에 새 항목이 필요하고, 그건 금지다. 이 중복은 `envelope.ml:61` 에 이미 의도적이라고 적혀 있었다. 덧붙여 두 매핑은 동등하지도 않다 — `Json_util` 은 `` `Intlit `` → `"intlit"`, `Envelope` 는 `"int"`.
3. **의도적 우회 경로** — 예: 두 gate 커넥터가 env 를 읽는 계층이 다르다(`Sys.getenv_opt` vs `Env_config_core.raw_value_opt`, 후자는 `Config_boot_overrides` 까지 폴백). 공통화하면 어느 쪽이 이기는지를 바꾸게 되므로 de-duplication 이 아니라 동작 변경이다.

## 어디로 옮겼나

새 파일을 늘리지 않는 것을 우선했다. `lib/` 에는 이미 60 줄 미만 모듈이 327 개 있다.

| 홈 | 건수 |
|---|---|
| `lib/core/json_util.ml` | 12 |
| `lib/core/string_util.ml` | 3 |
| `lib/core/safe_ops.ml` | 2 |
| 나머지 | 상대 모듈이 이미 참조하던 쪽으로 밀어넣음 |

신규 모듈은 1 개다. `lib/core/atomic_util.ml` — `server_mcp_transport_http_conn.ml` 과 `..._session.ml` 이 각자 인라인으로 갖고 있던 CAS 재시도 루프의 공통 홈이다. 같은 이름의 모듈이 #26801 에서 참조 0 으로 삭제됐는데, 개념 자체는 필요했고 아무도 쓰지 않고 있었을 뿐이다.

## 로컬 검증

- `dune build --root .` → exit 0, Error 0 건
- `dune runtest --root .` → exit 1. 실패 테스트 타깃 36 개
- 그 36 개를 **직전 커밋(dedup 미적용)에서 개별 재실행**해 대칭 비교: 36/36 동일한 종료 코드로 실패. 차이 0 건 → 본 변경으로 인한 회귀 없음
- 실패들은 기존 fixture 드리프트(#26496 계열), `.DS_Store` 가 섞인 dated-JSONL 레이아웃, 네트워크 필요 `install.sh` 등

## 미검증

CI 의 required check 는 아직 돌지 않았다. 로컬 실패 36 건이 CI 에서도 동일하게 pre-existing 인지는 CI 결과로 확인해야 한다.

RFC-WAIVED: credential / identity / operator control / keeper sandbox / dashboard credential / hooks / workflow 문서를 건드리지 않는다. 동일 구현을 기존 소유 모듈로 모으는 변경이다.

