### PR TITLE
fix(schedule): primary 원장 부재 시 .last-good 미러 복구

### DIFF
--- a/lib/schedule/schedule_store.ml
+++ b/lib/schedule/schedule_store.ml
@@ -30,11 +30,20 @@ type read_error =
       ; recovery_err : string option
       }
 
-(* RFC-0234: a parsed-or-absent ledger load. [Fresh] = the file is legitimately
-   absent (empty store, [default_state] is correct). [Corrupt] = the file is
-   present but neither it nor the [.last-good] recovery file parses; callers must
-   NOT collapse this to [default_state] and must NOT overwrite the on-disk file,
-   because the bytes may still hold schedule intent worth manual recovery. *)
+(* RFC-0234: a parsed-or-absent ledger load.
+
+   [Fresh] = neither the primary ledger nor its [.last-good] mirror exists, so
+   [default_state] is correct. [write_state] commits both files together, so an
+   absent primary next to a parseable mirror means the primary was removed
+   out-of-band rather than never written; that case yields [Loaded] from the
+   mirror (and logs a warning) instead of [Fresh], because collapsing it to
+   [default_state] lets the next [write_state] mirror an empty state over the
+   only surviving copy.
+
+   [Corrupt] = at least one of the two files exists and no state can be parsed
+   from either; callers must NOT collapse this to [default_state] and must NOT
+   overwrite the on-disk files, because the bytes may still hold schedule intent
+   worth manual recovery. *)
 type load_outcome =
   | Loaded of state
   | Fresh
@@ -43,11 +52,11 @@ type load_outcome =
       ; recovery_err : string option
       }
 
-(* Raised by the read-only accessor [get_schedule] on a
-   corrupt-but-present ledger. Read paths cannot silently return an empty list
+(* Raised by the read-only accessor [get_schedule] when ledger bytes exist on
+   disk but yield no state. Read paths cannot silently return an empty list
    (that would hide operator data) and they have no [result] channel, so they
    fail loud. The mutating paths use [load] directly and refuse via
-   [Corrupt_ledger] instead of raising, so they never overwrite the file. *)
+   [Corrupt_ledger] instead of raising, so they never overwrite those bytes. *)
 exception
   Corrupt_ledger_exn of
     { primary_err : string
@@ -56,17 +65,20 @@ exception
 
 let ( let* ) = Result.bind
 
+(* [primary_err] states why the primary yielded no state (unparseable, or
+   absent while a mirror file remains). [recovery_err] is [None] when no
+   [.last-good] mirror exists and [Some _] when the mirror exists but yields no
+   state. *)
 let corrupt_message ~primary_err ~recovery_err =
   match recovery_err with
   | None ->
     Printf.sprintf
-      "schedule ledger is present but unparseable (primary: %s); no .last-good \
-       recovery file exists"
+      "schedule ledger could not be loaded (primary: %s); no .last-good recovery \
+       file exists"
       primary_err
   | Some recovery_err ->
     Printf.sprintf
-      "schedule ledger is present but unparseable (primary: %s; .last-good \
-       recovery: %s)"
+      "schedule ledger could not be loaded (primary: %s; .last-good recovery: %s)"
       primary_err recovery_err
 ;;
 
@@ -171,27 +183,68 @@ let state_of_yojson = function
   | json -> Error ("state_of_yojson: " ^ Yojson.Safe.to_string json)
 ;;
 
-(* Parse the [.last-good] recovery file. Returns [Ok state] on a clean parse, or
-   [Error message] describing why recovery is unavailable (absent or unparseable). *)
-let load_recovery config =
+(* Probe result for the [.last-good] recovery mirror. An absent mirror and an
+   unparseable mirror are kept apart because they lead to opposite outcomes when
+   the primary is also absent: no mirror means an uninitialised store ([Fresh]),
+   an unparseable mirror means corruption the operator must see ([Corrupt]). *)
+type recovery_outcome =
+  | Recovery_loaded of state
+  | Recovery_absent
+  | Recovery_unparseable of string
+
+(* Parse the [.last-good] recovery file. [read_json_result] folds file-read
+   failure and JSON failure into one [Error message]; a mirror that exists but
+   yields no state is reported as [Recovery_unparseable] either way. *)
+let load_recovery config : recovery_outcome =
   let recovery = recovery_path config in
-  if Workspace_utils.path_exists config recovery then
+  if Workspace_utils.path_exists config recovery then (
     match Workspace_utils.read_json_result config recovery with
-    | Ok recovery_json -> state_of_yojson recovery_json
-    | Error read_err -> Error read_err
+    | Ok recovery_json ->
+      (match state_of_yojson recovery_json with
+       | Ok state -> Recovery_loaded state
+       | Error parse_err -> Recovery_unparseable parse_err)
+    | Error read_err -> Recovery_unparseable read_err)
   else
-    Error "no .last-good recovery file"
+    Recovery_absent
 ;;
 
-(* Total load that distinguishes a fresh (absent) ledger from a corrupt
-   (present-but-unparseable) one. [read_json_result] folds file-read failure and
-   parse failure into a single [Error message], so an existing-but-broken primary
-   surfaces here rather than being silently swallowed. *)
+let absent_primary_message path =
+  Printf.sprintf "primary ledger file does not exist: %s" path
+;;
+
+(* Total load that distinguishes an uninitialised store from a corrupt one and
+   from a primary removed out-of-band. [read_json_result] folds file-read failure
+   and parse failure into a single [Error message], so an existing-but-broken
+   primary surfaces here rather than being silently swallowed.
+
+   The absent-primary branch consults the [.last-good] mirror for the same reason
+   the present-but-unparseable branch does: [write_state] writes both files, so
+   the mirror is the surviving copy whenever the primary is removed after a
+   successful commit. Reporting [Fresh] there would hand [default_state] to the
+   callers below, and the next [write_state] would overwrite the mirror with it. *)
 let load config : load_outcome =
   ensure_dirs config;
   let path = schedules_path config in
-  if not (Workspace_utils.path_exists config path) then
-    Fresh
+  if not (Workspace_utils.path_exists config path) then (
+    match load_recovery config with
+    | Recovery_loaded state ->
+      (* The next [write_state] rewrites the primary from this state. The warning
+         records that the state came from the mirror, so the repair is visible
+         rather than silent. *)
+      Log.Misc.warn
+        "schedule_store: primary ledger %s does not exist; loaded %d schedules \
+         and %d wakes from recovery mirror %s"
+        path
+        (List.length state.schedules)
+        (List.length state.wakes)
+        (recovery_path config);
+      Loaded state
+    | Recovery_absent -> Fresh
+    | Recovery_unparseable recovery_err ->
+      Corrupt
+        { primary_err = absent_primary_message path
+        ; recovery_err = Some recovery_err
+        })
   else (
     let primary =
       match Workspace_utils.read_json_result config path with
@@ -202,15 +255,18 @@ let load config : load_outcome =
     | Ok state -> Loaded state
     | Error primary_err ->
       (match load_recovery config with
-       | Ok state -> Loaded state
-       | Error recovery_err ->
+       | Recovery_loaded state -> Loaded state
+       | Recovery_absent -> Corrupt { primary_err; recovery_err = None }
+       | Recovery_unparseable recovery_err ->
          Corrupt { primary_err; recovery_err = Some recovery_err }))
 ;;
 
-(* Read-only accessor used by [get_schedule]. [Fresh] yields the
-   empty default (correct for an uninitialised store); [Corrupt] raises rather
-   than returning an empty list, so a corrupt ledger is operator-visible instead
-   of masquerading as "no schedules". Does not write to disk. *)
+(* Read-only accessor used by [get_schedule]. [Fresh] yields the empty default,
+   and [load] narrows [Fresh] to "neither the primary nor the [.last-good] mirror
+   exists"; a primary removed out-of-band arrives here as [Loaded] from the
+   mirror instead of as an empty state. [Corrupt] errors rather than returning an
+   empty list, so a ledger that cannot be parsed is operator-visible instead of
+   masquerading as "no schedules". Does not write to disk. *)
 let read_state_result config =
   match load config with
   | Loaded state -> Ok state
@@ -228,8 +284,11 @@ let read_state config =
 
 (* Resolve the current state for a mutation. [Corrupt] is refused as a typed
    [Corrupt_ledger] error so the mutating function aborts BEFORE calling
-   [write_state]; this is what prevents the corrupt-but-present ledger from being
-   overwritten with an empty default on the next write. *)
+   [write_state]; this is what prevents an unparseable ledger from being
+   overwritten with an empty default on the next write. [Fresh] means [load]
+   found neither the primary nor the [.last-good] mirror, so [default_state] adds
+   no data loss; a primary removed while the mirror survives arrives as [Loaded],
+   and the write that follows restores the primary. *)
 let load_for_mutation config : (state, store_error) result =
   match load config with
   | Loaded state -> Ok state

--- a/lib/schedule/schedule_store.mli
+++ b/lib/schedule/schedule_store.mli
@@ -22,9 +22,11 @@ type store_error =
       { primary_err : string
       ; recovery_err : string option
       }
-      (** RFC-0234: returned by mutating functions when the on-disk ledger is
-          present but neither it nor its [.last-good] recovery file parses. The
-          mutation is refused so the corrupt bytes are NOT overwritten. *)
+      (** RFC-0234: returned by mutating functions when at least one of the
+          ledger and its [.last-good] recovery file exists and no state can be
+          parsed from either. [recovery_err] is [None] when no recovery file
+          exists. The mutation is refused so the surviving bytes are NOT
+          overwritten. *)
 
 type running_recovery_reason =
   | Retryable_dispatch_failure of string
@@ -39,26 +41,31 @@ type read_error =
       { primary_err : string
       ; recovery_err : string option
       }
-      (** Read-only access found a present-but-unparseable ledger. *)
+      (** Read-only access found ledger bytes on disk that yield no state. *)
 
 val read_error_to_string : read_error -> string
 
-(** Raised by [read_state]/[get_schedule] on a corrupt ledger.
-    Read paths have no [result] channel, so they fail loud instead of returning
-    an empty list. Mutating paths report [Corrupt_ledger] instead. *)
+(** Raised by [read_state]/[get_schedule] when ledger bytes exist but yield no
+    state. Read paths have no [result] channel, so they fail loud instead of
+    returning an empty list. Mutating paths report [Corrupt_ledger] instead. *)
 exception
   Corrupt_ledger_exn of
     { primary_err : string
     ; recovery_err : string option
     }
 
-(** Read-only snapshot. Returns an empty state for an absent store and
-    raises {!Corrupt_ledger_exn} for a corrupt one. Never writes to disk. *)
+(** Read-only snapshot. Returns an empty state only when neither the ledger nor
+    its [.last-good] recovery file exists; when the ledger is gone but the
+    recovery file parses, the recovered state is returned and the substitution is
+    logged. Raises {!Corrupt_ledger_exn} when ledger bytes exist but yield no
+    state. Never writes to disk. *)
 val read_state : Workspace_utils.config -> state
 
-(** Result-returning read-only snapshot. Returns an empty state for an absent
-    store and [Error (Corrupt_read_ledger _)] for a corrupt one. Never
-    writes to disk. *)
+(** Result-returning read-only snapshot. Returns an empty state only when neither
+    the ledger nor its [.last-good] recovery file exists, the recovered state
+    when the ledger is gone but the recovery file parses, and
+    [Error (Corrupt_read_ledger _)] when ledger bytes exist but yield no state.
+    Never writes to disk. *)
 val read_state_result : Workspace_utils.config -> (state, read_error) result
 
 val state_of_yojson : Yojson.Safe.t -> (state, string) result

--- a/test/test_schedule_store.ml
+++ b/test/test_schedule_store.ml
@@ -261,6 +261,14 @@ let corrupt_both config =
   Workspace_core.write_text config (recovery_path config) "}also not json"
 ;;
 
+(* Remove the primary ledger while leaving the .last-good mirror alone, the way an
+   out-of-band deletion does (rm, partial rsync, a cleanup script). *)
+let delete_primary config =
+  Workspace_core.delete_path config (schedules_path config);
+  check bool "primary ledger removed" false
+    (Workspace_utils.path_exists config (schedules_path config))
+;;
+
 let test_startup_recovery_returns_only_running_schedule_to_due () =
   with_workspace
   @@ fun config ->
@@ -618,6 +626,14 @@ let test_insert_surfaces_primary_write_failure () =
 let test_insert_keeps_primary_commit_when_recovery_write_fails () =
   with_workspace
   @@ fun config ->
+  (* A directory at the mirror path breaks the mirror *write*. It also breaks the
+     mirror *read*, and load probes the mirror whenever the primary is absent, so
+     the injection needs a parseable primary in place first: load then resolves
+     from the primary and never reaches the probe, leaving write_state's mirror
+     write as the only failing step this test names. *)
+  let committed = make_request ~schedule_id:"recovery-mirror-committed" () in
+  ignore (insert_ok config committed);
+  Workspace_core.delete_path config (schedules_recovery_path config);
   Unix.mkdir (schedules_recovery_path config) 0o755;
   let request =
     make_request ~schedule_id:"recovery-mirror-fail" ()
@@ -628,9 +644,14 @@ let test_insert_keeps_primary_commit_when_recovery_write_fails () =
      fail
        ("recovery mirror failure should not fail committed primary write: "
         ^ store_error_to_string err));
-  match get_schedule config ~schedule_id:request.schedule_id with
-  | Some stored -> check string "primary has schedule" request.schedule_id stored.schedule_id
-  | None -> fail "primary schedule missing after recovery mirror failure"
+  (match get_schedule config ~schedule_id:request.schedule_id with
+   | Some stored -> check string "primary has schedule" request.schedule_id stored.schedule_id
+   | None -> fail "primary schedule missing after recovery mirror failure");
+  match get_schedule config ~schedule_id:committed.schedule_id with
+  | Some stored ->
+    check string "primary keeps the earlier schedule" committed.schedule_id
+      stored.schedule_id
+  | None -> fail "earlier schedule lost after recovery mirror failure"
 ;;
 
 let test_cancel_refused_on_corrupt_ledger () =
@@ -655,6 +676,78 @@ let test_last_good_is_parseable_after_good_write () =
   match Schedule_store.state_of_yojson recovery_json with
   | Ok state -> check int "last-good holds the schedule" 1 (List.length state.schedules)
   | Error msg -> fail (".last-good is not parseable: " ^ msg)
+;;
+
+(* The out-of-band-deletion arm of the same silent-failure-to-data-loss
+   regression: [write_state] commits the primary and the .last-good mirror
+   together, so an absent primary next to a parseable mirror is a deletion, not a
+   fresh store. Reading it as an empty state let the next write mirror that empty
+   state over the surviving copy. *)
+let test_absent_primary_recovers_from_last_good () =
+  with_workspace
+  @@ fun config ->
+  let req = make_request ~schedule_id:"vanished-primary" () in
+  ignore (insert_ok config req);
+  delete_primary config;
+  let recovered = read_state config in
+  check int "schedule recovered from last-good" 1 (List.length recovered.schedules);
+  check string "recovered schedule id" req.schedule_id
+    (List.hd recovered.schedules).schedule_id
+;;
+
+let test_absent_primary_write_restores_primary_without_dropping_schedules () =
+  with_workspace
+  @@ fun config ->
+  let before_deletion = make_request ~schedule_id:"vanished-primary-write" () in
+  ignore (insert_ok config before_deletion);
+  delete_primary config;
+  let after_deletion = make_request ~schedule_id:"added-after-deletion" () in
+  ignore (insert_ok config after_deletion);
+  check bool "primary ledger is restored by the next write" true
+    (Workspace_utils.path_exists config (schedules_path config));
+  check int "recovered and new schedule both persist" 2
+    (List.length (read_state config).schedules);
+  let mirror_json = Workspace_core.read_json config (recovery_path config) in
+  match Schedule_store.state_of_yojson mirror_json with
+  | Ok mirror ->
+    check int "last-good keeps both schedules" 2 (List.length mirror.schedules)
+  | Error msg -> fail (".last-good is not parseable: " ^ msg)
+;;
+
+let test_absent_primary_and_absent_mirror_reads_fresh () =
+  with_workspace
+  @@ fun config ->
+  ignore (insert_ok config (make_request ()));
+  delete_primary config;
+  Workspace_core.delete_path config (recovery_path config);
+  match read_state_result config with
+  | Ok state ->
+    check int "no schedules when both files are gone" 0 (List.length state.schedules);
+    check int "no wakes when both files are gone" 0 (List.length state.wakes)
+  | Error error -> fail (read_error_to_string error)
+;;
+
+let test_absent_primary_with_unparseable_mirror_is_corrupt () =
+  with_workspace
+  @@ fun config ->
+  ignore (insert_ok config (make_request ()));
+  Workspace_core.write_text config (recovery_path config) "}also not json";
+  delete_primary config;
+  let mirror_before = Workspace_core.read_text config (recovery_path config) in
+  (match read_state_result config with
+   | Error (Corrupt_read_ledger { primary_err; recovery_err }) ->
+     check bool "absent primary is described" true (String.length primary_err > 0);
+     check bool "mirror error reported" true (Option.is_some recovery_err)
+   | Ok _ ->
+     fail "absent primary with an unparseable mirror returned a readable state");
+  (match insert_request config (make_request ~schedule_id:"sched-2" ()) with
+   | Ok _ -> fail "insert unexpectedly succeeded against an unparseable mirror"
+   | Error (Corrupt_ledger _) -> ()
+   | Error err -> fail ("expected Corrupt_ledger, got: " ^ store_error_to_string err));
+  check string "unparseable mirror preserved" mirror_before
+    (Workspace_core.read_text config (recovery_path config));
+  check bool "refused mutation did not recreate the primary" false
+    (Workspace_utils.path_exists config (schedules_path config))
 ;;
 
 let cancelled_request_with_wake_receipt config ~schedule_id =
@@ -784,6 +877,15 @@ let () =
             test_cancel_refused_on_corrupt_ledger;
           test_case "last-good is parseable after good write" `Quick
             test_last_good_is_parseable_after_good_write;
+          test_case "absent primary recovers from last-good" `Quick
+            test_absent_primary_recovers_from_last_good;
+          test_case "write after absent primary restores it without dropping schedules"
+            `Quick
+            test_absent_primary_write_restores_primary_without_dropping_schedules;
+          test_case "absent primary and absent mirror read fresh" `Quick
+            test_absent_primary_and_absent_mirror_reads_fresh;
+          test_case "absent primary with unparseable mirror is corrupt" `Quick
+            test_absent_primary_with_unparseable_mirror_is_corrupt;
         ] );
       ( "lifecycle",
         [


### PR DESCRIPTION
## 문제

`schedule_store.load` 는 primary 원장 파일이 없으면 즉시 `Fresh` 를 반환하고 `.last-good` 미러를 **한 번도 읽지 않았습니다**. 미러는 "primary 가 존재하는데 파싱 실패" 경로에서만 도달합니다.

그런데 원장이 사라지는 가장 흔한 방식은 파싱 실패가 아니라 **삭제** 입니다. 그 경우:

1. `load` → `Fresh`
2. 호출자(`read_state_result`, `load_for_mutation`)가 `default_state ()` (빈 상태) 로 접음
3. 다음 `write_state` 가 primary 와 미러를 **함께** 쓰므로, 빈 상태가 유일하게 살아있던 미러를 덮어씀

복구 미러가 자기 자신을 파괴합니다.

## 실측 피해

`~/me/.masc` 라이브 상태에서 `schedules.json` 과 `schedules.json.last-good` 이 **둘 다** 없는 반면, 형제 저장소의 `goals.json.last-good` 과 `tasks/backlog.json.last-good` 은 살아 있습니다.

append-only 인 signals 원장이 소실 시각을 기록하고 있습니다:

```
kidsnote-release-status-1h  due=08-04 18:06:16  emitted=18:06:29  schedule.due_candidate
kidsnote-release-status-1h  due=08-04 19:06:16  emitted=19:06:26  schedule.due_candidate
(20:06 이후 발화 없음)
```

시간당 반복 스케줄이 19:06 이후 조용히 멈췄습니다.

형제 저장소가 살아남은 이유도 확인했습니다: `lib/workspace/workspace_backlog.ml` 은 `path_exists` 단축 없이 `read_json_result` 를 무조건 호출하므로, primary 부재가 recover 경로로 들어갑니다.

## 변경

`load` 가 primary 부재 시 미러를 탐색합니다.

| primary | 미러 | 이전 | 이후 |
|---|---|---|---|
| 없음 | 파싱됨 | `Fresh` → 빈 상태 → 미러 파괴 | `Loaded` + `Log.Misc.warn` (다음 write 가 primary 복원) |
| 없음 | 없음 | `Fresh` | `Fresh` (변화 없음) |
| 없음 | 파싱 실패 | `Fresh` → 빈 상태 | `Corrupt` (operator 에게 노출, 바이트 보존) |

이 판정을 위해 `load_recovery` 의 문자열로 뭉개진 `Error` 를 module-private variant 로 분리했습니다:

```ocaml
type recovery_outcome =
  | Recovery_loaded of state
  | Recovery_absent
  | Recovery_unparseable of string
```

"미러 없음" 과 "미러 못 읽음" 은 primary 도 없을 때 정반대 결과를 내야 하는데 같은 `Error string` 이었습니다.

`Fresh` 의 의미가 좁아졌으므로 `load_outcome`, `Corrupt_ledger_exn`, `read_state_result`, `load_for_mutation` 의 주석을 실제 동작에 맞게 고쳤습니다. 시그니처 변경은 없습니다 (`load` / `load_for_mutation` / `load_outcome` 은 `.mli` 에 없음).

## 검증

- `dune build --root . @check` — exit 0, 출력 없음
- `test/test_schedule_store.exe` — 31/31 통과 (기존 27 + 신규 4)
- **Negative control**: `load` 의 absent-primary 분기만 `Fresh` 로 되돌리면 동작이 바뀌는 신규 테스트 3건이 실패하고, 분기가 그대로인 "absent primary + absent mirror" 1건은 계속 통과합니다. 신규 테스트가 fix 에 종속되어 있음을 확인했습니다.
- 인접 스위트: `test_schedule_domain` 19, `test_schedule_service` 1, `test_schedule_runner` 11, `test_schedule_consumer_dispatch` 27, `test_schedule_tool_wiring` 13, `test_server_dashboard_http_schedule_actions` 2 — 전부 통과.
- `test_keeper_waiting_inventory` 13/17 실패는 base 에서 동일하게 재현되는 기존 실패입니다 (keeper meta schema).

## 알려진 한계

- **미러 쓰기 실패 시 구멍은 남습니다.** `write_state` 는 primary 를 쓰고 미러 쓰기 실패 시 warn 만 하고 `Ok ()` 를 반환합니다. 미러가 지속적으로 실패하는 저장소는 primary 삭제 시 여전히 같은 손실이 발생합니다. 기존 동작이라 이번 범위 밖이지만, 복구 보장이 "미러 쓰기가 성공했었다면" 에 조건부라는 뜻입니다.
- **wire-visible 변경**: primary-corrupt + 미러-부재 케이스에서 `recovery_err` 가 `Some "no .last-good recovery file"` → `None` 으로 바뀝니다 (타입상 정확한 표현). `server_keeper_waiting_inventory.schedule_read_error_detail` 에서 JSON null 로 직렬화됩니다. `dashboard/src` 에서 소비자 0건 확인했습니다.
- **경고는 rate-limit 되지 않습니다.** primary 가 없는 동안 read 경로마다 반복됩니다. 첫 write 에서 자가 복구되며, 조용한 것보다 시끄러운 쪽을 택했습니다.
- **fail-closed 신규 경로**: 초기화된 적 없는 저장소의 미러 경로에 읽을 수 없는 것이 있으면 이제 insert 가 `Corrupt_ledger` 로 거부됩니다. 디스크상으로는 "primary 삭제 + 미러 손상" 과 구별되지 않아 큰 거부를 택했습니다.
- **형제 저장소와 정책이 갈립니다.** `workspace_backlog` 는 미러 복구본을 non-authoritative 로 보고 mutation 에 `Error` 를 반환하는 반면, schedule store 는 자가 복구합니다.
- **기존 테스트 1건의 setup 을 고쳤습니다.** `test_insert_keeps_primary_commit_when_recovery_write_fails` 는 pristine workspace 의 미러 경로에 `Unix.mkdir` 로 실패를 주입했는데, 이제 primary 부재 시 미러를 읽으므로 그 디렉터리가 read 도 깨뜨려 Corrupt 가 됩니다. 성공하는 insert 를 먼저 수행해 primary 를 만든 뒤 미러를 깨도록 바꿨습니다. 단언은 약화되지 않았고 오히려 앞선 스케줄의 생존을 추가로 검사합니다.

## 배포 참고

라이브 서버는 부모 저장소 `_build` 의 바이너리로 동작하므로, 재빌드 + 재시작 전까지 라이브 workspace 에는 효과가 없습니다. 이미 소실된 `~/me/.masc/schedules.json` 은 이 변경으로 복구되지 않습니다 — 재발을 막을 뿐입니다.

RFC-WAIVED: schedule ledger 저장소의 국소 데이터 손실 수정. credential / identity / operator control plane / keeper sandbox / dashboard credential / hooks / workflow 문서 중 어느 것도 건드리지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
