### PR TITLE
fix(keeper): 빈 task backlog를 섹션 생략이 아니라 문장으로 진술

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -672,6 +672,38 @@ let build_system_prompt ~(meta : Keeper_meta_contract.keeper_meta)
   system_prompt
 ;;
 
+(* The backlog read produces three distinct facts, and the Namespace State
+   section must be able to state each one. "Readable and empty" used to be
+   encoded as an omitted section, which a reader of the rendered text cannot
+   tell apart from "not observed": the keeper was handed nothing rather than
+   an empty board. Typed here rather than left as a boolean disjunction so a
+   further backlog outcome forces an arm at the render site. *)
+type backlog_statement =
+  | Backlog_unreadable
+    (* Neither primary nor recovery was a valid current backlog. The
+       accompanying zero counts are not an observation. *)
+  | Backlog_readable_empty
+    (* Authoritative read that returned no unclaimed, claimable, or failed
+       rows. *)
+  | Backlog_readable_with_rows
+    (* Authoritative read with at least one counted row; the per-count lines
+       carry the numbers. *)
+
+let backlog_statement_of_observation
+      (observation : Keeper_world_observation.world_observation)
+  : backlog_statement
+  =
+  match observation.backlog_revision with
+  | None -> Backlog_unreadable
+  | Some _ ->
+    if
+      observation.unclaimed_task_count = 0
+      && observation.claimable_task_count = 0
+      && observation.failed_task_count = 0
+    then Backlog_readable_empty
+    else Backlog_readable_with_rows
+;;
+
 let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta)
     ~(config : Workspace.config)
     ?(profile_defaults : Keeper_types_profile.keeper_profile_defaults option)
@@ -764,20 +796,22 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta)
         Buffer.add_char ubuf '\n';
         Some (Buffer.contents ubuf))
       else None
-    (* 3. Namespace state — usually lower churn than inbox/board detail. *)
+    (* 3. Namespace state — usually lower churn than inbox/board detail.
+       Rendered on every turn: the backlog readability fact and the running
+       fiber count are observed on every turn, and an omitted section states
+       nothing about a backlog that was read and holds no rows. *)
     | Keeper_context_layers.Namespace_state ->
-      if
-        observation.unclaimed_task_count > 0
-        || observation.claimable_task_count > 0
-        || observation.failed_task_count > 0
-        || Option.is_none observation.backlog_revision
-        || observation.running_keeper_fiber_count > 0
-      then (
+      Some (
         let ubuf = Buffer.create 256 in
         Buffer.add_string ubuf "### Namespace State\n";
-        if Option.is_none observation.backlog_revision then
-          Buffer.add_string ubuf
-            "- Task backlog: unavailable or recovery-only; task counts are non-authoritative and cannot drive task actions.\n";
+        (match backlog_statement_of_observation observation with
+         | Backlog_unreadable ->
+           Buffer.add_string ubuf
+             "- Task backlog: unavailable or recovery-only; task counts are non-authoritative and cannot drive task actions.\n"
+         | Backlog_readable_empty ->
+           Buffer.add_string ubuf
+             "- Task backlog: readable; it holds 0 unclaimed tasks, 0 claimable tasks for this keeper, and 0 failed tasks.\n"
+         | Backlog_readable_with_rows -> ());
         if observation.unclaimed_task_count > 0 then
           Buffer.add_string ubuf
             (Printf.sprintf "- Unclaimed tasks: %d\n"
@@ -811,8 +845,7 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta)
              "- Running keeper fibers: %d\n"
              observation.running_keeper_fiber_count);
         Buffer.add_char ubuf '\n';
-        Some (Buffer.contents ubuf))
-      else None
+        Buffer.contents ubuf)
     (* 4. Autonomous trigger — lower churn than reactive inboxes. *)
     | Keeper_context_layers.Autonomous_trigger ->
       if autonomous_trigger <> [] then

--- a/test/test_keeper_surface_presence_prompt.ml
+++ b/test/test_keeper_surface_presence_prompt.ml
@@ -235,6 +235,71 @@ let test_namespace_state_names_running_keeper_fibers () =
   check bool "legacy active agents label absent" false
     (contains ~needle:"- Active agents:" user)
 
+(* An authoritative backlog holding no rows must be a statement, not the
+   absence of a section. While it was encoded as an omission the keeper read
+   nothing at all for that case, so "read the board, it is empty" and "the
+   board was never observed" arrived as the same bytes. *)
+let readable_empty_line =
+  "- Task backlog: readable; it holds 0 unclaimed tasks, 0 claimable tasks \
+   for this keeper, and 0 failed tasks."
+
+let unavailable_line = "- Task backlog: unavailable or recovery-only"
+
+let test_readable_empty_backlog_is_stated () =
+  (* base_observation: backlog_revision = Some 1, every count 0, no fibers. *)
+  let user = user_message base_observation in
+  check bool "namespace state section present" true
+    (contains ~needle:"### Namespace State" user);
+  check bool "readable empty backlog stated" true
+    (contains ~needle:readable_empty_line user);
+  check bool "unavailable wording absent" false
+    (contains ~needle:unavailable_line user);
+  check bool "running fiber count still rendered" true
+    (contains ~needle:"- Running keeper fibers: 0" user)
+
+let test_readable_empty_backlog_stated_with_running_fibers () =
+  let user =
+    user_message { base_observation with running_keeper_fiber_count = 2 }
+  in
+  check bool "readable empty backlog stated alongside fibers" true
+    (contains ~needle:readable_empty_line user);
+  check bool "fiber count rendered" true
+    (contains ~needle:"- Running keeper fibers: 2" user)
+
+let test_unavailable_backlog_keeps_non_authoritative_wording () =
+  let user = user_message { base_observation with backlog_revision = None } in
+  check bool "unavailable wording present" true
+    (contains ~needle:unavailable_line user);
+  check bool "counts declared non-authoritative" true
+    (contains
+       ~needle:"task counts are non-authoritative and cannot drive task actions"
+       user);
+  check bool "readable claim absent when unreadable" false
+    (contains ~needle:readable_empty_line user)
+
+let test_backlog_with_rows_omits_readable_empty_statement () =
+  let user =
+    user_message
+      {
+        base_observation with
+        unclaimed_task_count = 3;
+        claimable_task_count = 1;
+      }
+  in
+  check bool "counted rows rendered" true
+    (contains ~needle:"- Unclaimed tasks: 3" user);
+  check bool "readable empty statement absent" false
+    (contains ~needle:readable_empty_line user);
+  check bool "unavailable wording absent" false
+    (contains ~needle:unavailable_line user)
+
+let test_failed_only_backlog_omits_readable_empty_statement () =
+  let user = user_message { base_observation with failed_task_count = 2 } in
+  check bool "failed count rendered" true
+    (contains ~needle:"- Failed tasks: 2" user);
+  check bool "readable empty statement absent" false
+    (contains ~needle:readable_empty_line user)
+
 let test_profile_defaults_feed_identity_prompt () =
   with_repo_prompt_config @@ fun () ->
   let profile_defaults =
@@ -365,5 +430,18 @@ let () =
             test_profile_defaults_feed_identity_prompt;
           test_case "no-goal prompt blocks repo creation question" `Quick
             test_no_goal_prompt_blocks_repo_creation_question;
+        ] );
+      ( "namespace state backlog statement",
+        [
+          test_case "readable empty backlog is stated" `Quick
+            test_readable_empty_backlog_is_stated;
+          test_case "readable empty backlog stated with running fibers" `Quick
+            test_readable_empty_backlog_stated_with_running_fibers;
+          test_case "unavailable backlog keeps non-authoritative wording" `Quick
+            test_unavailable_backlog_keeps_non_authoritative_wording;
+          test_case "backlog with rows omits readable empty statement" `Quick
+            test_backlog_with_rows_omits_readable_empty_statement;
+          test_case "failed-only backlog omits readable empty statement" `Quick
+            test_failed_only_backlog_omits_readable_empty_statement;
         ] );
     ]


### PR DESCRIPTION
## 문제

`keeper_unified_prompt.ml` 의 `Namespace_state` 레이어는 다섯 항 논리합 뒤에 숨어 있었습니다:

```ocaml
if unclaimed_task_count > 0
   || claimable_task_count > 0
   || failed_task_count > 0
   || Option.is_none backlog_revision
   || running_keeper_fiber_count > 0
then ( ... ) else None
```

백로그를 **읽을 수 있고** (`backlog_revision = Some`) 세 카운트가 전부 0이면 `### Namespace State` 섹션 전체가 생략됩니다.

여기 비대칭이 있습니다:

- "백로그를 읽을 수 없다" → 명시적인 문장이 있고 **말할 수 있음**
- "백로그를 읽었고 비어 있다" → **섹션의 부재로 인코딩**되어 말할 수 없음

렌더된 텍스트만 보는 독자에게 이 부재는 "관측되지 않음" 과 구별되지 않습니다. Keeper 는 빈 판을 보고 있는 것이 아니라 아무것도 안 보고 있습니다.

같은 arm 아래 저자가 이미 원칙을 적용한 줄이 있습니다:

```ocaml
if unclaimed_task_count > 0 && claimable_task_count = 0 then
  Buffer.add_string ubuf "- Claimable tasks for this keeper: 0\n";
```

0을 명시적으로 말하는 법을 알고 있었고, `unclaimed > 0` 일 때만 적용했습니다.

## 변경

boolean 논리합을 module-private variant 로 교체하고, arm 이 항상 `Some` 을 반환합니다:

```ocaml
type backlog_statement =
  | Backlog_unreadable
  | Backlog_readable_empty
  | Backlog_readable_with_rows
```

`Backlog_readable_empty` 일 때 렌더:

```
- Task backlog: readable; it holds 0 unclaimed tasks, 0 claimable tasks for this keeper, and 0 failed tasks.
```

`Backlog_unreadable` 의 문장은 바이트 단위로 이전과 동일합니다. 그 아래 unclaimed / claimable / blocked / failed / fiber 줄은 건드리지 않았습니다.

명령형·권유형 문구는 넣지 않았습니다. 이 변경은 관측을 **표현 가능하게** 만들 뿐이고, 빈 판에서 무엇을 할지에 대한 licence 는 keeper system prompt 의 몫입니다 (별도 PR).

## 항상 렌더해도 안전한지 확인한 것

- `Keeper_context_layers.assemble` 은 per-layer 변화 감지 없는 순수 `filter_map` + concat
- `keeper_agent_prompt_metrics.ml:118` 의 `cacheable_bytes` 는 `system_prompt` 바이트만 세며 `dynamic_context` 는 명시적으로 제외
- `Turn_record.diff_blocks` 는 프레임 전체를 하나의 `Dynamic_context` 블록으로 다루고, 그 블록은 이미 매 턴 기록됨 (`world_state` 는 `## Current World State` 헤더를 항상 실어 비지 않음)
- 턴 간 `world_state` 를 비교하는 코드 없음

## 검증

- `dune build --root . @check` — exit 0, 출력 없음. exit 0 이 컴파일 증거가 아닐 수 있어 positive control 수행: 의도적 타입 오류 추가 → exit 1 + 예상 위치의 타입 에러, 되돌린 뒤 재실행 → exit 0.
- `test_keeper_surface_presence_prompt` — 신규 5건 전부 통과 (readable-empty / readable-empty + running fibers / unavailable / rows-present / failed-only).
- 스위트의 기존 실패 3건(`sandbox paths 2`, `connected surfaces 6`, `connected surfaces 7`)은 **같은 main 기반의 무관한 워크트리에서 동일하게 재현**되어 이 변경과 무관함을 독립 확인했습니다.
- 인접 스위트: `test_keeper_unified_verification_surface` 27/27, `test_keeper_context_layers` 6/6, `test_keeper_prompt_metrics` 19/19, `test_prompt_registry_defaults` 26/26.

## 알려진 한계

- **결함 유형은 전부-0 케이스에서만 닫힙니다.** `backlog_revision = Some`, `unclaimed = 0`, `claimable = 0`, `failed = 2` 이면 `Backlog_readable_with_rows` 로 가서 `- Failed tasks: 2` 만 찍히고, unclaimed / claimable 의 0 은 여전히 줄의 부재로 인코딩됩니다. 신규 테스트 4번이 이 동작을 명시적으로 고정합니다. 자가 생성의 트리거 조건은 전부-0 이므로 이 PR 의 목적은 충족되지만, 원칙 자체는 아직 부분적입니다.
- **타이핑이 producer 까지 가지 않았습니다.** `read_backlog_counts` (`keeper_world_observation_inputs.ml:66`) 는 여전히 `int * int * int * int option` 을 반환하므로 `backlog_revision = None` 과 nonzero 카운트가 동시에 표현 가능합니다. 근본 해결은 producer 가 `Unreadable | Readable of { version; counts }` 를 반환해 revision 없이 카운트가 존재할 수 없게 하는 것입니다. 이번 범위 밖입니다.
- **5개 신규 테스트 중 fix 에 민감한 것은 2개입니다.** lib 변경만 되돌리면 case 0, 1 이 뒤집히고 case 2·3·4 는 변경 유무와 무관하게 통과합니다. 후자는 정당한 회귀 가드이지만 fix 의 증거는 아닙니다.
- **렌더 델타가 리터럴 전부-0 보다 약간 넓습니다.** 카운트가 전부 0이면서 `running_keeper_fiber_count > 0` 인 경우 섹션은 이전에도 렌더됐고 이제 readable-empty 줄이 추가됩니다. readable-empty 부류에서 문장을 균일하게 하려는 의도입니다.
- **`dynamic_context` 가 턴당 약 110 바이트 늘어납니다.** `cacheable_bytes` 에는 포함되지 않지만 RFC-0351 모델 입력 바이트 예산에는 계상됩니다.
- `backlog_statement` 는 `.mli` 항목이 없는 module-private 이라 렌더된 텍스트를 통해서만 검사됩니다.

RFC-WAIVED: keeper 프롬프트 렌더 레이어의 국소 관측성 수정. credential / identity / operator control plane / keeper sandbox / dashboard credential / hooks / workflow 문서 중 어느 것도 건드리지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
