### PR TITLE
fix(harness): make tool-call benchmark cases resolve against the live registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -937,6 +937,26 @@ jobs:
           chmod +x scripts/ci-run-tests.sh
           scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_verification"
 
+      # The tool-call quality benchmark scores keeper runs against selectors
+      # declared in benchmarks/data/tool_call_quality_cases.json. Those
+      # selectors name descriptors in the live keeper registry, so deleting or
+      # re-tagging a descriptor turns a stale case definition into a keeper
+      # quality score instead of an error (#26811). The suite existed in
+      # test/dune but was never listed here, so nothing it asserts has been
+      # running; the registry coherence gate it now carries only counts once
+      # this step does.
+      - name: Run tool-call quality benchmark suite
+        id: tool_call_quality_benchmark_suite
+        if: ${{ always() && steps.build_step.outcome == 'success' }}
+        env:
+          ME_ROOT: /tmp/me
+          CI_TEST_HEARTBEAT_SEC: 15
+          DUNE_JOBS: 1
+        run: |
+          mkdir -p /tmp/me
+          chmod +x scripts/ci-run-tests.sh
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_tool_call_quality_benchmark"
+
       # MCP identity is session-bound behavior: compile-only coverage cannot
       # prove that the complete handshake -> start -> status -> transition
       # path preserves one identity through the durable Task lifecycle. The

--- a/benchmarks/data/tool_call_quality_cases.json
+++ b/benchmarks/data/tool_call_quality_cases.json
@@ -12,7 +12,7 @@
         { "type": "descriptor_id", "value": "agent.execute" }
       ],
       "required_selectors": [
-        { "type": "eval_tag", "value": "capability_introspection" },
+        { "type": "descriptor_id", "value": "agent.search_files" },
         { "type": "descriptor_id", "value": "agent.read_file" }
       ],
       "max_tool_calls": 3,
@@ -22,13 +22,13 @@
       ],
       "arg_checks": [
         {
-          "selector": { "type": "eval_tag", "value": "capability_introspection" },
-          "path": "$.query",
+          "selector": { "type": "descriptor_id", "value": "agent.search_files" },
+          "path": "$.pattern",
           "contains": "prompt_fingerprint"
         },
         {
           "selector": { "type": "descriptor_id", "value": "agent.read_file" },
-          "path": "$.path",
+          "path": "$.file_path",
           "contains": "keeper_tool_call_log"
         }
       ],
@@ -61,7 +61,7 @@
       "keeper_profiles": ["bench-verifier"],
       "forbidden_tools": [],
       "required_selectors": [
-        { "type": "eval_tag", "value": "capability_introspection" },
+        { "type": "descriptor_id", "value": "agent.search_files" },
         { "type": "descriptor_id", "value": "agent.read_file" }
       ],
       "max_tool_calls": 4,
@@ -71,13 +71,13 @@
       ],
       "arg_checks": [
         {
-          "selector": { "type": "eval_tag", "value": "capability_introspection" },
-          "path": "$.query",
+          "selector": { "type": "descriptor_id", "value": "agent.search_files" },
+          "path": "$.pattern",
           "contains": "keeper_agent_run"
         },
         {
           "selector": { "type": "descriptor_id", "value": "agent.read_file" },
-          "path": "$.path",
+          "path": "$.file_path",
           "contains": "keeper_agent_run.ml"
         }
       ],
@@ -94,7 +94,7 @@
       "keeper_profiles": ["bench-executor", "bench-verifier"],
       "forbidden_tools": [],
       "required_selectors": [
-        { "type": "eval_tag", "value": "capability_introspection" },
+        { "type": "descriptor_id", "value": "agent.search_files" },
         { "type": "descriptor_id", "value": "agent.execute" },
         { "type": "descriptor_id", "value": "masc.board.post" }
       ],

--- a/scripts/harness_tool_call_quality.sh
+++ b/scripts/harness_tool_call_quality.sh
@@ -468,11 +468,11 @@ derive_final_result() {
     read_search_prompt_fingerprint)
       printf '%s' "${tool_calls_json}" | jq -c '
         def search_hit:
-          any(.[]; .tool_name == "keeper_tool_search"
-                    and ((.input.query // "") | tostring | contains("prompt_fingerprint")));
+          any(.[]; .tool_name == "tool_search_files"
+                    and ((.input.pattern // "") | tostring | contains("prompt_fingerprint")));
         def read_hit:
           any(.[]; .tool_name == "tool_read_file"
-                    and ((.input.path // "") | tostring | contains("keeper_tool_call_log")));
+                    and ((.input.file_path // "") | tostring | contains("keeper_tool_call_log")));
         {
           status: (if search_hit and read_hit then "completed" else "incomplete" end),
           evidence_found: ((if search_hit then 1 else 0 end) + (if read_hit then 1 else 0 end))
@@ -501,11 +501,11 @@ derive_final_result() {
             .key > $idx
             and .value.tool_name == "tool_read_file"
             and .value.success
-            and ((.value.input.path // "") | tostring | contains("keeper_agent_run.ml"))
+            and ((.value.input.file_path // "") | tostring | contains("keeper_agent_run.ml"))
           );
         def searched:
-          any(.[]; .tool_name == "keeper_tool_search"
-                    and ((.input.query // "") | tostring | contains("keeper_agent_run")));
+          any(.[]; .tool_name == "tool_search_files"
+                    and ((.input.pattern // "") | tostring | contains("keeper_agent_run")));
         (failure_index) as $idx
         | {
             status: (if ($idx != null and searched and recovered_after_failure($idx))
@@ -517,7 +517,7 @@ derive_final_result() {
     multi_step_board_update)
       printf '%s' "${tool_calls_json}" | jq -c '
         def search_hit:
-          any(.[]; .tool_name == "keeper_tool_search");
+          any(.[]; .tool_name == "tool_search_files");
         def bash_hit:
           any(.[]; .tool_name == "tool_execute" and .success);
         def board_hit:

--- a/test/dune
+++ b/test/dune
@@ -277,7 +277,6 @@
   test_tool_output_washing_e2e
   test_keeper_compaction_unit
   test_keeper_context_core_dedup
-  test_tool_call_quality_benchmark
   test_keeper_prompt_metrics
   test_keeper_reaction_ledger
   test_cache_metrics_wiring
@@ -580,7 +579,6 @@
   test_tool_output_washing_e2e
   test_keeper_compaction_unit
   test_keeper_context_core_dedup
-  test_tool_call_quality_benchmark
   test_keeper_prompt_metrics
   test_keeper_reaction_ledger
   test_cache_metrics_wiring
@@ -2566,3 +2564,18 @@
 (include stanzas/test_keeper_chat_admission_contention.inc)
 
 (include stanzas/test_dashboard_continuity_briefs.inc)
+
+; The tool-call quality benchmark reads its case set and evidence fixture from
+; repo-root JSON (benchmarks/data, test/fixtures) rather than from sandbox
+; deps, so under the shared group stanza dune had no reason to re-run it when
+; those files changed — an edit that broke a case definition kept a cached
+; pass. Declaring the two files as deps puts them in the action hash, which is
+; what makes the registry coherence checks in this suite fire on case-set
+; edits (#26811).
+(test
+ (name test_tool_call_quality_benchmark)
+ (modules test_tool_call_quality_benchmark)
+ (deps
+  %{workspace_root}/benchmarks/data/tool_call_quality_cases.json
+  %{workspace_root}/test/fixtures/tool_call_quality_benchmark/evidence_runs.json)
+ (libraries alcotest masc_test_deps))

--- a/test/fixtures/tool_call_quality_benchmark/evidence_runs.json
+++ b/test/fixtures/tool_call_quality_benchmark/evidence_runs.json
@@ -21,15 +21,14 @@
       },
       "tool_calls": [
         {
-          "tool_name": "keeper_tools_list",
+          "tool_name": "tool_search_files",
           "success": true,
           "duration_ms": 24.0,
           "route_evidence": {
-            "descriptor_id": "keeper.tools_list",
-            "eval_tags": ["capability_introspection"]
+            "descriptor_id": "agent.search_files"
           },
           "input": {
-            "query": "prompt_fingerprint keeper_tool_call_log"
+            "pattern": "prompt_fingerprint keeper_tool_call_log"
           }
         },
         {
@@ -41,7 +40,7 @@
             "eval_tags": []
           },
           "input": {
-            "path": "lib/keeper_tool_call_log.ml"
+            "file_path": "lib/keeper_tool_call_log.ml"
           }
         }
       ]
@@ -67,15 +66,14 @@
       },
       "tool_calls": [
         {
-          "tool_name": "keeper_tools_list",
+          "tool_name": "tool_search_files",
           "success": true,
           "duration_ms": 23.0,
           "route_evidence": {
-            "descriptor_id": "keeper.tools_list",
-            "eval_tags": ["capability_introspection"]
+            "descriptor_id": "agent.search_files"
           },
           "input": {
-            "query": "prompt_fingerprint keeper_tool_call_log"
+            "pattern": "prompt_fingerprint keeper_tool_call_log"
           }
         },
         {
@@ -87,7 +85,7 @@
             "eval_tags": []
           },
           "input": {
-            "path": "lib/keeper_tool_call_log.ml"
+            "file_path": "lib/keeper_tool_call_log.ml"
           }
         }
       ]
@@ -113,15 +111,14 @@
       },
       "tool_calls": [
         {
-          "tool_name": "keeper_tools_list",
+          "tool_name": "tool_search_files",
           "success": true,
           "duration_ms": 19.0,
           "route_evidence": {
-            "descriptor_id": "keeper.tools_list",
-            "eval_tags": ["capability_introspection"]
+            "descriptor_id": "agent.search_files"
           },
           "input": {
-            "query": "prompt_fingerprint keeper_tool_call_log"
+            "pattern": "prompt_fingerprint keeper_tool_call_log"
           }
         },
         {
@@ -133,7 +130,7 @@
             "eval_tags": []
           },
           "input": {
-            "cmd": "rg prompt_fingerprint lib"
+            "argv": ["rg", "prompt_fingerprint", "lib"]
           }
         },
         {
@@ -145,7 +142,7 @@
             "eval_tags": []
           },
           "input": {
-            "path": "lib/keeper_tool_call_log.ml"
+            "file_path": "lib/keeper_tool_call_log.ml"
           }
         }
       ]
@@ -200,19 +197,18 @@
             "eval_tags": []
           },
           "input": {
-            "path": "lib/missing_file.ml"
+            "file_path": "lib/missing_file.ml"
           }
         },
         {
-          "tool_name": "keeper_tools_list",
+          "tool_name": "tool_search_files",
           "success": true,
           "duration_ms": 20.0,
           "route_evidence": {
-            "descriptor_id": "keeper.tools_list",
-            "eval_tags": ["capability_introspection"]
+            "descriptor_id": "agent.search_files"
           },
           "input": {
-            "query": "keeper_agent_run prompt_fingerprint"
+            "pattern": "keeper_agent_run prompt_fingerprint"
           }
         },
         {
@@ -224,7 +220,7 @@
             "eval_tags": []
           },
           "input": {
-            "path": "lib/keeper/keeper_agent_run.ml"
+            "file_path": "lib/keeper/keeper_agent_run.ml"
           }
         }
       ]
@@ -258,19 +254,18 @@
             "eval_tags": []
           },
           "input": {
-            "path": "lib/missing_file.ml"
+            "file_path": "lib/missing_file.ml"
           }
         },
         {
-          "tool_name": "keeper_tools_list",
+          "tool_name": "tool_search_files",
           "success": true,
           "duration_ms": 24.0,
           "route_evidence": {
-            "descriptor_id": "keeper.tools_list",
-            "eval_tags": ["capability_introspection"]
+            "descriptor_id": "agent.search_files"
           },
           "input": {
-            "query": "keeper_agent_run prompt_fingerprint"
+            "pattern": "keeper_agent_run prompt_fingerprint"
           }
         },
         {
@@ -282,7 +277,7 @@
             "eval_tags": []
           },
           "input": {
-            "path": "lib/keeper/keeper_agent_run.ml"
+            "file_path": "lib/keeper/keeper_agent_run.ml"
           }
         },
         {
@@ -294,7 +289,7 @@
             "eval_tags": []
           },
           "input": {
-            "path": "lib/keeper/keeper_agent_run.ml"
+            "file_path": "lib/keeper/keeper_agent_run.ml"
           }
         }
       ]

--- a/test/test_tool_call_quality_benchmark.ml
+++ b/test/test_tool_call_quality_benchmark.ml
@@ -506,6 +506,105 @@ let test_route_evidence_quality_treats_empty_evidence_as_missing () =
       ("empty receipt_labels", `Assoc [ ("receipt_labels", `Assoc []) ]);
     ]
 
+(* ── Case set vs live descriptor registry ──────────────────────────────
+   The shipped case set names tools indirectly, through selectors that
+   resolve via descriptor route evidence. [Eval_tool_selector] is
+   deliberately observational: it matches recorded calls and never
+   consults the registry. That leaves a gap no other check covers — a
+   selector naming a descriptor that no longer exists does not error, it
+   simply matches nothing, and scoring reports "the keeper did not do the
+   required thing" instead of "this case is stale".
+
+   #26785 removed keeper_tool_search and moved its capability_introspection
+   eval tag onto keeper_tools_list, whose input schema is empty. Every case
+   requiring that tag with an arg check on $.query became unsatisfiable,
+   and the suite stayed green because the evidence fixture was rewritten to
+   match. These two tests resolve the shipped case set against the live
+   registry so that class of drift fails here instead of surfacing as a
+   keeper quality number. *)
+
+let live_descriptor_calls () =
+  Keeper_tool_descriptor.all_descriptors ()
+  |> List.concat_map (fun (descriptor : Keeper_tool_descriptor.t) ->
+         let route_evidence =
+           Some (Keeper_tool_descriptor.route_evidence_json descriptor)
+         in
+         Keeper_tool_descriptor.registered_names descriptor
+         |> List.map (fun tool_name ->
+                (descriptor, { Eval_tool_selector.tool_name; route_evidence })))
+
+let descriptors_matching selector =
+  live_descriptor_calls ()
+  |> List.filter (fun (_, call) -> Eval_tool_selector.matches selector call)
+  |> List.map fst
+
+let case_selectors (benchmark_case : Tool_call_quality_benchmark.benchmark_case)
+    =
+  benchmark_case.required_selectors
+  @ benchmark_case.forbidden_selectors
+  @ List.map
+      (fun (arg_check : Tool_call_quality_benchmark.arg_check) ->
+        arg_check.selector)
+      benchmark_case.arg_checks
+
+let test_case_selectors_resolve_to_live_descriptors () =
+  let cases, _ = load_fixture () in
+  let unresolved =
+    List.concat_map
+      (fun (benchmark_case : Tool_call_quality_benchmark.benchmark_case) ->
+        case_selectors benchmark_case
+        |> List.filter (fun selector -> descriptors_matching selector = [])
+        |> List.map (fun selector ->
+               benchmark_case.id ^ " -> " ^ Eval_tool_selector.label selector))
+      cases
+  in
+  check (list string) "case selectors naming no live descriptor" [] unresolved
+
+(* Root property of a JSONPath-lite arg-check path: "$.pattern" -> "pattern".
+   Nested paths are checked at their root only; the registry schema is the
+   authority for the top-level argument name, which is what drifted. *)
+let arg_check_root_property path =
+  match String.split_on_char '.' path with
+  | "$" :: property :: _ when property <> "" -> Some property
+  | _ -> None
+
+let schema_property_names schema =
+  match schema with
+  | `Assoc fields -> (
+      match List.assoc_opt "properties" fields with
+      | Some (`Assoc properties) -> List.map fst properties
+      | _ -> [])
+  | _ -> []
+
+let test_arg_check_paths_exist_in_descriptor_schema () =
+  let cases, _ = load_fixture () in
+  let unsatisfiable =
+    List.concat_map
+      (fun (benchmark_case : Tool_call_quality_benchmark.benchmark_case) ->
+        benchmark_case.arg_checks
+        |> List.filter_map
+             (fun (arg_check : Tool_call_quality_benchmark.arg_check) ->
+               match arg_check_root_property arg_check.path with
+               | None -> None
+               | Some property ->
+                   let accepted =
+                     descriptors_matching arg_check.selector
+                     |> List.exists (fun (descriptor : Keeper_tool_descriptor.t)
+                                    ->
+                         List.mem property
+                           (schema_property_names descriptor.input_schema))
+                   in
+                   if accepted then None
+                   else
+                     Some
+                       (benchmark_case.id ^ " -> "
+                       ^ Eval_tool_selector.label arg_check.selector
+                       ^ " has no `" ^ property ^ "` in its input schema")))
+      cases
+  in
+  check (list string) "arg checks naming an absent schema property" []
+    unsatisfiable
+
 let () =
   run "tool_call_quality_benchmark"
     [
@@ -538,5 +637,9 @@ let () =
              `Quick test_route_evidence_quality_treats_empty_evidence_as_missing;
            test_case "unavailable route evidence excludes run from scoring"
              `Quick test_unavailable_route_evidence_excludes_run_from_scoring;
+           test_case "case selectors resolve to live descriptors" `Quick
+             test_case_selectors_resolve_to_live_descriptors;
+           test_case "arg check paths exist in descriptor schema" `Quick
+             test_arg_check_paths_exist_in_descriptor_schema;
          ]);
     ]


### PR DESCRIPTION
## 문제

tool-call quality 벤치마크의 케이스 정의가 **어떤 keeper 도 만족시킬 수 없는 상태**였고, 스위트는 초록이었다.

Closes #26811.

## 무엇이 어긋나 있었나

케이스 정의는 selector 로 도구를 지목하고, `arg_checks` 는 그 도구의 인자를 검사한다. 실측한 불일치 3종:

| 케이스가 요구하는 것 | 라이브 레지스트리 | 결과 |
|---|---|---|
| `eval_tag:capability_introspection` 호출에 `$.query` | 이 태그는 `keeper_tools_list` 에 있고 `input_schema` 는 `empty_object_schema` (**인자 없음**) | 영구 불만족 |
| `descriptor_id:agent.read_file` 호출에 `$.path` | `read_file_schema` 는 `closed_object_schema ~required:["file_path"]` — `path` 없음 | 영구 불만족 |
| 셸 `derive_final_result` 가 `tool_name == "keeper_tool_search"` | 그 도구는 #26785 (`3ac0b0b87e`) 로 삭제됨 | 3케이스 영구 `incomplete` |

`capability_introspection` 태그는 #26785 가 삭제된 `keeper_tool_search` 에서 `keeper_tools_list` 로 옮겼다. 케이스가 원한 것은 도구 목록 조회가 아니라 **파일 내용 검색**이다 (프롬프트: "Search for `prompt_fingerprint`").

## 왜 초록이었나

네 겹이 겹쳤다.

1. **증거 픽스처가 불가능한 호출을 기록한다.** #26785 는 이 벤치마크에서 픽스처 한 파일만 고쳤다 (10 insertions, 10 deletions — 이름 치환뿐). 케이스 정의와 셸은 0줄 변경. 치환 후 픽스처는 인자를 받지 않는 `keeper_tools_list` 에 `{"query": ...}` 를 넘긴다. `input.query` 를 지웠으면 그 자리에서 red 였다.
   - 픽스처 전수: `keeper_tools_list` ← `query` ×5, `tool_read_file` ← `path` ×8, `tool_execute` ← `cmd` ×1. **모든 호출이 실제 스키마와 불일치**했다 (`agent.execute` 는 `argv`).
2. **selector 는 관측적이다.** `Eval_tool_selector` 는 기록된 호출만 매칭하고 레지스트리를 보지 않는다 (모듈 문서가 의도적으로 그렇게 규정). 해소되지 않는 selector 는 에러가 아니라 "아무 호출과도 매칭 안 됨" → scoring 은 **"keeper 가 요구된 일을 하지 않았다"** 로 리포트한다. 정의 결함이 품질 점수로 위장된다.
3. **스위트가 CI 에서 돌지 않았다.** `test/dune` 에는 있었지만 `ci.yml` 의 `@test/runtest-*` 26개 목록에 없었다.
4. **JSON 을 바꿔도 dune 이 재실행하지 않았다.** 케이스/픽스처가 dep 로 선언돼 있지 않아 action hash 에 안 들어간다. 케이스 정의만 고친 편집은 캐시된 pass 를 받는다.

## 변경

**게이트 (근본 수정)** — `test_tool_call_quality_benchmark.ml` 에 2케이스 추가:

- `case selectors resolve to live descriptors` — 케이스 파일의 모든 selector(required/forbidden/arg) 가 라이브 descriptor 로 해소되는지
- `arg check paths exist in descriptor schema` — 모든 `arg_checks` path 의 루트 property 가 해소된 descriptor 의 `input_schema` 에 실재하는지

`Keeper_tool_descriptor.all_descriptors ()` + `route_evidence_json` 으로 라이브 호출을 합성해 `Eval_tool_selector.matches` 에 넣는다 — 모듈을 관측적 용법 그대로 쓰되, 관측 대상이 실제 레지스트리다.

**배선** — `ci.yml` 에 `@test/runtest-test_tool_call_quality_benchmark` 스텝 추가. `test/dune` 에서 이 테스트를 전용 스탠자로 분리하고 케이스/픽스처 두 JSON 을 `(deps ...)` 로 선언.

**드리프트 해소** — 위 게이트가 지적한 것을 실제로 고침:

| 파일 | 변경 |
|---|---|
| `benchmarks/data/tool_call_quality_cases.json` | 검색 selector `eval_tag:capability_introspection` → `descriptor_id:agent.search_files`; `$.query` → `$.pattern`; `$.path` → `$.file_path` |
| `scripts/harness_tool_call_quality.sh` | `keeper_tool_search` → `tool_search_files`; `.input.query` → `.input.pattern`; `.input.path` → `.input.file_path` |
| `test/fixtures/.../evidence_runs.json` | 모든 호출을 실제 스키마 모양으로: `tool_search_files`+`pattern`, `tool_read_file`+`file_path`, `tool_execute`+`argv` |

## 검증

| 항목 | 결과 |
|---|---|
| 수정 전 게이트 | **FAIL** — 4건 지적 (`capability_introspection has no 'query'` ×2, `agent.read_file has no 'path'` ×2) |
| 수정 후 스위트 | `Test Successful, 17 tests run`, exit 0 (기존 15 + 신규 2) |
| 게이트 negative control | 케이스의 `masc.board.post` → `masc.board.post_DELETED` 주입 시 **FAIL**, 메시지에 해당 selector 명시 |
| dep 선언 검증 | 같은 주입을 `--force` 없이 재실행 → **exit 1**. 선언 전에는 exit 0 (캐시된 pass) |
| `dune build --root . @check` | exit 0 (레포 전체 컴파일) |

## 미검증

- `--live` 경로는 실행하지 못했다. #26242 (persona schema 불일치) 가 상류에서 모델 호출 도달을 막고 있다. 이 PR 은 결정론적 층(케이스 정의 ↔ 레지스트리 ↔ 픽스처 ↔ 셸 판정)만 정합화한다. #26242 해소 후 세 케이스가 실제로 통과하는지는 별도 확인이 필요하다.
- `multi_step_board_update` 의 검색 단계는 프롬프트에 검색 대상이 명시돼 있어(`tool_call_quality_benchmark_cli`) `agent.search_files` 로 옮겨도 의미가 보존되지만, 라이브로 확인하지 못했다.

RFC-WAIVED: 벤치마크 하네스의 케이스 정의/픽스처/판정 정합화와 그 CI 배선. credential/identity/auth, operator control, keeper sandbox, dashboard credential component, hooks, workflow 문서 어디에도 해당하지 않는다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
