### PR TITLE
refactor(lib): 근사 중복 44건 공통화 (106 클러스터 전수 판정)

### DIFF
--- a/lib/auth/auth_nickname.ml
+++ b/lib/auth/auth_nickname.ml
@@ -8,21 +8,10 @@
 let nickname_adjectives = Nickname_words.adjectives
 let nickname_animals = Nickname_words.animals
 
-let array_contains arr value =
-  let rec loop idx =
-    idx < Array.length arr && (String.equal arr.(idx) value || loop (idx + 1))
-  in
-  loop 0
-;;
-
-let is_hex4 value =
-  String.length value = 4
-  && String.for_all
-       (function
-         | '0' .. '9' | 'a' .. 'f' -> true
-         | _ -> false)
-       value
-;;
+(* Word-list membership and the hex4 suffix shape come from the same
+   [Nickname_words] SSOT as the vocabulary above. *)
+let array_contains = Nickname_words.array_contains
+let is_hex4 = Nickname_words.is_hex4
 
 let extract_generated_nickname_prefix name =
   let parts = String.split_on_char '-' name in

--- a/lib/board/board_votes.ml
+++ b/lib/board/board_votes.ml
@@ -589,13 +589,7 @@ let set_pinned store ~post_id ~pinned : (unit, board_error) Result.t =
                   | _ -> ()));
                Error e)
 
-let posts_jsonl_snapshot store =
-  let buf = Buffer.create 4096 in
-  Hashtbl.iter (fun _ (pst : post) ->
-    Buffer.add_string buf (Yojson.Safe.to_string (post_to_yojson pst));
-    Buffer.add_char buf '\n'
-  ) store.posts;
-  Buffer.contents buf
+let posts_jsonl_snapshot store = Board_core_persist.posts_jsonl_unlocked store
 
 let comments_jsonl_snapshot store =
   let buf = Buffer.create 4096 in

--- a/lib/board/board_votes.ml
+++ b/lib/board/board_votes.ml
@@ -605,14 +605,7 @@ let comments_jsonl_snapshot store =
   ) store.comments;
   Buffer.contents buf
 
-let reactions_jsonl_snapshot store =
-  let buf = Buffer.create 4096 in
-  Hashtbl.iter
-    (fun _ (reaction : reaction) ->
-       Buffer.add_string buf (Yojson.Safe.to_string (reaction_to_yojson reaction));
-       Buffer.add_char buf '\n')
-    store.reactions;
-  Buffer.contents buf
+let reactions_jsonl_snapshot store = Board_core_persist.reactions_jsonl_unlocked store
 
 let save_jsonl_snapshot ~where ~path content =
   try

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -2,16 +2,7 @@
 
 module StringSet = Set_util.StringSet
 
-let dedupe_schemas (schemas : Masc_domain.tool_schema list) =
-  let unique, _ =
-    List.fold_left
-      (fun (acc, seen) (schema : Masc_domain.tool_schema) ->
-        if StringSet.mem schema.name seen then (acc, seen)
-        else (schema :: acc, StringSet.add schema.name seen))
-      ([], StringSet.empty)
-      schemas
-  in
-  List.rev unique
+let dedupe_schemas = Masc_domain.dedupe_tool_schemas
 
 
 (* Project every descriptor-owned masc_* backend schema into the substrate so

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -1,7 +1,8 @@
 (** Tool schema registry and visibility helpers. *)
 
 val dedupe_schemas : Masc_domain.tool_schema list -> Masc_domain.tool_schema list
-(** Remove duplicate tool schemas by name, keeping the first occurrence. *)
+(** Remove duplicate tool schemas by name, keeping the first occurrence.
+    Alias of {!Masc_domain.dedupe_tool_schemas}. *)
 
 val raw_all_tool_schemas : Masc_domain.tool_schema list
 (** All tool schemas before capability filtering. *)

--- a/lib/config/masc_network_defaults.ml
+++ b/lib/config/masc_network_defaults.ml
@@ -104,6 +104,18 @@ let masc_http_default_port_s =
 (** Default host for the MASC HTTP server. *)
 let masc_http_default_host = "127.0.0.1"
 
+(** [ipaddr_is_loopback ip] classifies a parsed address as loopback:
+    the whole IPv4 [127.0.0.0/8] block (first octet 127), and the single
+    IPv6 address [::1].  Note this is broader on IPv4 than
+    {!is_loopback_host} below, which compares against [Ipaddr.V4.localhost]
+    and so accepts only [127.0.0.1].  The two are not interchangeable. *)
+let ipaddr_is_loopback = function
+  | Ipaddr.V4 addr ->
+      let octets = Ipaddr.V4.to_octets addr in
+      String.length octets = 4 && Char.code octets.[0] = 127
+  | Ipaddr.V6 addr ->
+      Ipaddr.V6.compare addr Ipaddr.V6.localhost = 0
+
 (** [is_loopback_host host] returns [true] when [host] resolves to any
     IPv4/IPv6 loopback address (via {!Ipaddr}).  Treats the literal
     "localhost" (after trim + lowercase) as loopback.  Malformed

--- a/lib/config/masc_network_defaults.mli
+++ b/lib/config/masc_network_defaults.mli
@@ -75,6 +75,12 @@ val masc_http_default_host : string
 
 (** {1 Loopback detection} *)
 
+(** Classifies a parsed address: the whole IPv4 [127.0.0.0/8] block (first
+    octet 127), and the single IPv6 address [::1]. Broader on IPv4 than
+    {!is_loopback_host}, which compares against [Ipaddr.V4.localhost] and so
+    accepts only [127.0.0.1]. The two are not interchangeable. *)
+val ipaddr_is_loopback : (Ipaddr.V4.t, Ipaddr.V6.t) Ipaddr.v4v6 -> bool
+
 (** Treats ["localhost"] (case-insensitive, trimmed) and any IPv4/IPv6
     loopback literal as loopback. Unlike a prefix match, malformed
     addresses return [false] (so ["127.invalid"] is rejected). *)
@@ -82,6 +88,12 @@ val is_loopback_host : string -> bool
 
 (** Convenience for [Uri.host]-style inputs. [None] → [false]. *)
 val is_loopback_host_opt : string option -> bool
+
+val trim_trailing_slashes : string -> string
+(** Return the argument without its trailing ['/'] characters. Scans backwards
+    once and performs at most one [String.sub]; a string with no trailing slash
+    is returned unchanged. An all-slash string becomes [""], and [""] stays
+    [""]. Leading and interior slashes are untouched. *)
 
 val normalize_loopback_base_url : string -> string
 (** Strip trailing slashes from [base_url] and canonicalize loopback

--- a/lib/config/nickname_words.ml
+++ b/lib/config/nickname_words.ml
@@ -72,3 +72,21 @@ let animals =
    ; "tapir"
    ; "zebra"
   |]
+
+(* The generator and the classifier both walk these arrays and both inspect the
+   hex suffix emitted by [Nickname.generate_unique], so the two predicates live
+   next to the vocabulary they read. *)
+
+let array_contains arr value =
+  let rec loop idx =
+    idx < Array.length arr && (String.equal arr.(idx) value || loop (idx + 1))
+  in
+  loop 0
+
+let is_hex4 value =
+  String.length value = 4
+  && String.for_all
+       (function
+         | '0' .. '9' | 'a' .. 'f' -> true
+         | _ -> false)
+       value

--- a/lib/config/nickname_words.mli
+++ b/lib/config/nickname_words.mli
@@ -5,3 +5,13 @@
 
 val adjectives : string array
 val animals : string array
+
+val array_contains : string array -> string -> bool
+(** [array_contains arr value] scans [arr] left to right and returns [true] at
+    the first element that is [String.equal] to [value], [false] when no
+    element matches. *)
+
+val is_hex4 : string -> bool
+(** [is_hex4 value] returns [true] when [value] has length 4 and every
+    character is ['0'..'9'] or ['a'..'f']. That is the shape of the suffix
+    [Nickname.generate_unique] appends. Uppercase hex returns [false]. *)

--- a/lib/core/common.ml
+++ b/lib/core/common.ml
@@ -110,3 +110,20 @@ let truncate_response ?(max_bytes=max_tool_output_bytes) ~total_count response =
     let truncated = String.sub response 0 max_bytes in
     Printf.sprintf "%s\n\n... [truncated: %d/%d bytes shown, total_count=%d]"
       truncated max_bytes len total_count
+
+(* Resolves [.] and [..] textually. No filesystem access, so a symlinked
+   component is not followed. *)
+let lexical_normalize_abs abs =
+  let parts = String.split_on_char '/' abs in
+  let stack = ref [] in
+  List.iter
+    (function
+      | "" | "." -> ()
+      | ".." ->
+        (match !stack with
+         | _ :: rest -> stack := rest
+         | [] -> ())
+      | part -> stack := part :: !stack)
+    parts;
+  "/" ^ String.concat "/" (List.rev !stack)
+;;

--- a/lib/core/common.mli
+++ b/lib/core/common.mli
@@ -91,3 +91,8 @@ val truncate_response :
     {!max_tool_output_bytes}). Otherwise returns the first [max_bytes]
     characters followed by a machine-readable truncation suffix that
     records the original length and [total_count]. *)
+
+val lexical_normalize_abs : string -> string
+(** [lexical_normalize_abs abs] collapses [.], [..] and repeated separators in
+    [abs] textually. It does not touch the filesystem, so symlinked components
+    are left unresolved. *)

--- a/lib/core/json_util.ml
+++ b/lib/core/json_util.ml
@@ -347,3 +347,15 @@ let normalize_string_list items =
   |> List.map String.trim
   |> List.filter (fun item -> not (String.equal item ""))
   |> dedupe_keep_order
+
+let string_assoc_of_json = function
+  | `Assoc fields ->
+    Ok
+      (List.filter_map
+         (fun (key, value) ->
+           match value with
+           | `String s -> Some (key, s)
+           | _ -> None)
+         fields)
+  | _ -> Error "expected string object"
+;;

--- a/lib/core/json_util.mli
+++ b/lib/core/json_util.mli
@@ -166,3 +166,8 @@ val normalize_string_list : string list -> string list
 (** [normalize_string_list items] trims each item, drops the ones that
     are empty after trimming, and removes duplicates while preserving
     the order of first occurrence. *)
+
+val string_assoc_of_json : Yojson.Safe.t -> ((string * string) list, string) result
+(** [string_assoc_of_json json] keeps the members of a JSON object whose value
+    is a string and drops the others. Returns [Error] when [json] is not an
+    object. *)

--- a/lib/core/string_util.ml
+++ b/lib/core/string_util.ml
@@ -300,10 +300,27 @@ let strip_trailing_cr s =
   let len = String.length s in
   if len > 0 && s.[len - 1] = '\r' then String.sub s 0 (len - 1) else s
 
+let strip_one_final_newline value =
+  let len = String.length value in
+  if len >= 2 && Char.equal value.[len - 2] '\r' && Char.equal value.[len - 1] '\n'
+  then String.sub value 0 (len - 2)
+  else if len >= 1 && (Char.equal value.[len - 1] '\n' || Char.equal value.[len - 1] '\r')
+  then String.sub value 0 (len - 1)
+  else value
+
 let first_line text =
   match String.index_opt text '\n' with
   | Some i -> String.sub text 0 i
   | None -> text
+
+let flatten_inline_whitespace value =
+  value
+  |> String.to_seq
+  |> Seq.map (function
+       | '\n' | '\r' | '\t' -> ' '
+       | ch -> ch)
+  |> String.of_seq
+  |> String.trim
 
 (* XML 1.0 entity escape.  Order matters: [&] first so that the
    ampersands introduced by the other replacements are not

--- a/lib/core/string_util.mli
+++ b/lib/core/string_util.mli
@@ -131,9 +131,23 @@ val compact_text : ?max_len:int -> string -> string
 val strip_trailing_cr : string -> string
 (** [strip_trailing_cr s] removes a trailing ['\\r'] character if present. *)
 
+val strip_one_final_newline : string -> string
+(** [strip_one_final_newline value] removes at most one line terminator from
+    the end of [value]: a trailing ["\\r\\n"] pair, otherwise a single trailing
+    ['\\n'] or ['\\r']. Earlier terminators are left in place, so
+    ["a\\n\\n"] becomes ["a\\n"]. *)
+
 val first_line : string -> string
 (** [first_line text] returns the bytes of [text] before the first ['\\n'].
     Returns [text] unchanged when it contains no ['\\n']. Does not trim. *)
+
+val flatten_inline_whitespace : string -> string
+(** [flatten_inline_whitespace value] replaces every ['\\n'], ['\\r'] and
+    ['\\t'] in [value] with a space, then trims leading and trailing
+    whitespace. Runs of interior whitespace are not collapsed, so the result
+    can still contain consecutive spaces. Returns [""] for input that is empty
+    or entirely whitespace. *)
+
 val escape_xml : string -> string
 (** Escape the five XML 1.0 predefined entities: ampersand,
     less-than, greater-than, double-quote, and apostrophe.

--- a/lib/dashboard/dashboard_briefing_sections.ml
+++ b/lib/dashboard/dashboard_briefing_sections.ml
@@ -281,11 +281,7 @@ let start_async_refresh ~actor_name ~config ~sw ~(clock : [> float Eio.Time.cloc
 
 (* ── Public entry point ─────────────────────────────────────────── *)
 
-let actor_name = function
-  | Some value ->
-      let trimmed = String.trim value in
-      if trimmed <> "" then trimmed else "dashboard"
-  | None -> "dashboard"
+let actor_name = Dashboard_projection_cache.normalize_actor_name
 
 let json ?actor ?(force = false) ~config ~sw ~(clock : [> float Eio.Time.clock_ty ] Eio.Resource.t) ~proc_mgr () =
   let now_ts = Unix.gettimeofday () in

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -498,15 +498,7 @@ let model_map_of_keeper_rows keepers =
     keepers
 ;;
 
-let task_updated_at (task : Masc_domain.task) =
-  match task.task_status with
-  | Masc_domain.Done { completed_at; _ } -> completed_at
-  | Masc_domain.Cancelled { cancelled_at; _ } -> cancelled_at
-  | Masc_domain.InProgress { started_at; _ } -> started_at
-  | Masc_domain.AwaitingVerification { submitted_at; _ } -> submitted_at
-  | Masc_domain.Claimed { claimed_at; _ } -> claimed_at
-  | Masc_domain.Todo -> task.created_at
-;;
+let task_updated_at = Dashboard_goals_types_accessor.task_updated_at
 
 let task_completed_at (task : Masc_domain.task) =
   match task.task_status with

--- a/lib/dashboard/dashboard_execution_builders.ml
+++ b/lib/dashboard/dashboard_execution_builders.ml
@@ -400,14 +400,7 @@ let task_operation_severity (task : Masc_domain.task) =
   | Masc_domain.Todo | Masc_domain.Claimed _ | Masc_domain.InProgress _ -> Tone_ok
   | Masc_domain.Done _ | Masc_domain.Cancelled _ -> Tone_ok
 
-let task_operation_updated_at (task : Masc_domain.task) =
-  match task.task_status with
-  | Masc_domain.Done { completed_at; _ } -> completed_at
-  | Masc_domain.Cancelled { cancelled_at; _ } -> cancelled_at
-  | Masc_domain.InProgress { started_at; _ } -> started_at
-  | Masc_domain.AwaitingVerification { submitted_at; _ } -> submitted_at
-  | Masc_domain.Claimed { claimed_at; _ } -> claimed_at
-  | Masc_domain.Todo -> task.created_at
+let task_operation_updated_at = Dashboard_goals_types_accessor.task_updated_at
 
 let task_operation_id (task : Masc_domain.task) =
   match Option.bind task.contract (fun contract -> contract.links.operation_id) with

--- a/lib/dashboard/dashboard_http_keeper_types.ml
+++ b/lib/dashboard/dashboard_http_keeper_types.ml
@@ -71,45 +71,19 @@ let latest_receipt_ts_of_keeper_rows rows =
          | _ -> acc)
        None
 
-let freshness_fields ~now latest_ts =
-  match latest_ts with
-  | Some ts ->
-    [
-      ("latest_ts_unix", `Float ts);
-      ("latest_ts_iso", `String (Masc_domain.iso8601_of_unix_seconds ts));
-      ("latest_age_s", `Float (max 0.0 (now -. ts)));
-    ]
-  | None ->
-    [
-      ("latest_ts_unix", `Null);
-      ("latest_ts_iso", `Null);
-      ("latest_age_s", `Null);
-    ]
+let freshness_fields = Dashboard_tool_source_freshness.freshness_fields
 
+(* The only execution-trust-specific input is the SLO constant above; the
+   health ladder itself is shared with the dashboard source-freshness card. *)
 let source_health_fields ~now ~exists ~entry_count ~latest_ts ?coverage_gap () =
-  let health, stale_reason =
-    match coverage_gap with
-    | Some gap ->
-      ( "coverage_gap",
-        Safe_ops.json_string ~default:"coverage_gap" "stale_reason" gap )
-    | None ->
-      if not exists then ("missing", "store_missing")
-      else if entry_count = 0 then ("empty", "no_entries")
-      else
-        match latest_ts with
-        | None -> ("empty", "no_entries")
-        | Some ts ->
-          let latest_age_s = max 0.0 (now -. ts) in
-          if latest_age_s > execution_trust_freshness_slo_s then
-            ("stale", "freshness_slo_exceeded")
-          else
-            ("ok", "")
-  in
-  [
-    ("health", `String health);
-    ( "stale_reason",
-      if stale_reason = "" then `Null else `String stale_reason );
-  ]
+  Dashboard_tool_source_freshness.health_fields
+    ~now
+    ~exists
+    ~entry_count
+    ~latest_ts
+    ~freshness_slo_s:execution_trust_freshness_slo_s
+    ?coverage_gap
+    ()
 
 let nonempty_string_opt value =
   let trimmed = String.trim value in

--- a/lib/dashboard_tool_source_freshness.ml
+++ b/lib/dashboard_tool_source_freshness.ml
@@ -17,27 +17,24 @@ module Float = Stdlib.Float
 
 (** Dashboard_tool_source_freshness -- source freshness metadata helpers. *)
 
-let numeric_ts_field fields name =
-  match List.assoc_opt name fields with
-  | Some (`Float ts) -> Some ts
-  | Some (`Int ts) -> Some (Float.of_int ts)
-  | _ -> None
-
-let latest_ts_of_record = function
-  | `Assoc fields -> (
-      match numeric_ts_field fields "ts_unix" with
+(* Numeric field reads go through Json_util.assoc_float_opt (same `Float /
+   `Int -> float coercion, same None fallback for non-objects and missing
+   keys). The ts_iso branch stays on assoc_member_opt rather than
+   Json_util.assoc_string_opt because the latter additionally drops
+   whitespace-only strings, which this lookup never did. *)
+let latest_ts_of_record json =
+  match Json_util.assoc_float_opt "ts_unix" json with
+  | Some ts -> Some ts
+  | None -> (
+      match Json_util.assoc_float_opt "ts" json with
       | Some ts -> Some ts
       | None -> (
-          match numeric_ts_field fields "ts" with
+          match Json_util.assoc_float_opt "timestamp" json with
           | Some ts -> Some ts
           | None -> (
-              match numeric_ts_field fields "timestamp" with
-              | Some ts -> Some ts
-              | None -> (
-                  match List.assoc_opt "ts_iso" fields with
-                  | Some (`String iso) -> Masc_domain.parse_iso8601_opt iso
-                  | _ -> None))))
-  | _ -> None
+              match Json_util.assoc_member_opt "ts_iso" json with
+              | Some (`String iso) -> Masc_domain.parse_iso8601_opt iso
+              | _ -> None)))
 
 let count_source_entries dir =
   if not (Sys.file_exists dir) then 0

--- a/lib/dashboard_tool_source_freshness.mli
+++ b/lib/dashboard_tool_source_freshness.mli
@@ -9,9 +9,9 @@
     entry count, last-seen timestamp, and any active coverage
     gaps surfaced through {!Telemetry_coverage_gap}.
 
-    Internal helper [numeric_ts_field] (which extracts a unix
-    timestamp from [`Float] / [`Int] JSON shapes) is hidden —
-    callers consume the higher-level
+    Numeric timestamp extraction from [`Float] / [`Int] JSON
+    shapes is delegated to [Json_util.assoc_float_opt]; callers
+    consume the higher-level
     {!latest_ts_of_record} / {!freshness_fields} /
     {!health_fields} composition layer instead. *)
 

--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -1177,6 +1177,20 @@ let count_entries = count_entries_incremental
 let reset_count_cache_for_testing () =
   Stdlib.Mutex.protect file_count_cache_mu (fun () -> Hashtbl.reset file_count_cache)
 ;;
+
+(* Day key for the [YYYY-MM/DD.jsonl] layout. Must stay UTC: the write path
+   ([Jsonl_writer.dated_path]) picks the day file with [Unix.gmtime], so a
+   local-time key here would look in the wrong file for the hours where the
+   two calendars disagree. Pinned by
+   [test_keeper_approval_resolved_history.ml]. *)
+let utc_day_string ts =
+  let tm = Unix.gmtime ts in
+  Printf.sprintf
+    "%04d-%02d-%02d"
+    (tm.Unix.tm_year + 1900)
+    (tm.Unix.tm_mon + 1)
+    tm.Unix.tm_mday
+
 let read_range t ~since ~until =
   let collected = ref [] in
   iter_range t ~since ~until (fun json -> collected := json :: !collected);

--- a/lib/dated_jsonl/dated_jsonl.mli
+++ b/lib/dated_jsonl/dated_jsonl.mli
@@ -124,6 +124,13 @@ val read_recent_lines : ?offset:int -> t -> int -> string list
 (** Like {!read_recent} but returns raw JSONL strings (no parse).
     Useful for tail-readers that do their own parsing. *)
 
+val utc_day_string : float -> string
+(** [utc_day_string ts] renders the unix timestamp [ts] as ["YYYY-MM-DD"] in
+    UTC, the day key consumed by [~since]/[~until] below. Uses
+    {!Unix.gmtime}, not localtime: the write path ([Jsonl_writer.dated_path])
+    picks the day file with [Unix.gmtime], so a local-time key would address
+    a different file during the hours where the two calendars disagree. *)
+
 val read_range : t -> since:string -> until:string -> Yojson.Safe.t list
 (** [read_range t ~since ~until] returns entries whose day-file falls
     within [[since, until]] (inclusive, format ["YYYY-MM-DD"]).

--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -140,20 +140,7 @@ let set_store_for_testing = set_store
 (* Local by design: this guard needs absolute lexical cleanup that composes with
    existing-prefix realpath for paths that may not exist yet. Env/basepath
    normalizers deliberately carry broader policy such as HOME expansion. *)
-let lexical_normalize_abs abs =
-  let parts = String.split_on_char '/' abs in
-  let stack = ref [] in
-  List.iter
-    (function
-      | "" | "." -> ()
-      | ".." ->
-        (match !stack with
-         | _ :: rest -> stack := rest
-         | [] -> ())
-      | part -> stack := part :: !stack)
-    parts;
-  "/" ^ String.concat "/" (List.rev !stack)
-;;
+let lexical_normalize_abs = Common.lexical_normalize_abs
 
 let lexical_abs ?cwd raw =
   let abs =

--- a/lib/exec/path_scope.ml
+++ b/lib/exec/path_scope.ml
@@ -59,19 +59,7 @@ let normalize_cwd cwd =
 let starts_with_dir ~prefix abs =
   abs = prefix || String.starts_with ~prefix:(prefix ^ "/") abs
 
-let lexical_normalize_abs abs =
-  let parts = String.split_on_char '/' abs in
-  let stack = ref [] in
-  List.iter
-    (function
-      | "" | "." -> ()
-      | ".." ->
-          (match !stack with
-           | _ :: rest -> stack := rest
-           | [] -> ())
-      | part -> stack := part :: !stack)
-    parts;
-  "/" ^ String.concat "/" (List.rev !stack)
+let lexical_normalize_abs = Common.lexical_normalize_abs
 
 let lexical_abs ~cwd raw =
   let abs =

--- a/lib/fusion/fusion_delivery_obligation.ml
+++ b/lib/fusion/fusion_delivery_obligation.ml
@@ -131,13 +131,8 @@ let validate_record record =
 ;;
 
 let canonical_base_path base_path =
-  let normalized = Workspace_utils_backend_setup.normalize_base_path base_path in
-  if String.equal normalized ""
-  then Error (Invalid_base_path "base_path is empty")
-  else
-    try Ok (Fs_compat.realpath normalized) with
-    | Eio.Cancel.Cancelled _ as exn -> raise exn
-    | exn -> Error (Invalid_base_path (Printexc.to_string exn))
+  Workspace_utils_backend_setup.canonical_base_path base_path
+  |> Result.map_error (fun detail -> Invalid_base_path detail)
 ;;
 
 let obligation_root ~base_path =

--- a/lib/fusion/fusion_metrics.ml
+++ b/lib/fusion/fusion_metrics.ml
@@ -12,12 +12,10 @@ let metric_fusion_invocations_total =
 let metric_fusion_judge_executions_total =
   Otel_metric_store_core.declare_counter "masc_fusion_judge_executions_total"
 
-let topology_label = function
-  | Simple -> "simple"
-  | Refine -> "refine"
-  | Conditional -> "conditional"
-  | Judge_of_judges -> "judge_of_judges"
-  | Staged_judge_of_judges -> "staged_judge_of_judges"
+(* OTel label vocabulary is the wire vocabulary declared by the topology's
+   own module, so the label cannot drift from the parse/serialize pair
+   ([fusion_topology_of_string] / [all_fusion_topology_strings]). *)
+let topology_label = Fusion_types.fusion_topology_to_string
 
 let judge_role_of_outcome = function
   | Synthesized node -> node.role

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -231,14 +231,7 @@ let chat_queue_message_request ~channel ~channel_user_id ~keeper_name
 
 (* ── Dispatch ────────────────────────────────────────────────── *)
 
-let normalized_context_value value =
-  value
-  |> String.to_seq
-  |> Seq.map (function
-       | '\n' | '\r' | '\t' -> ' '
-       | ch -> ch)
-  |> String.of_seq
-  |> String.trim
+let normalized_context_value = String_util.flatten_inline_whitespace
 
 let normalized_or_unknown value =
   match normalized_context_value value with

--- a/lib/http_server_h2.ml
+++ b/lib/http_server_h2.ml
@@ -258,20 +258,8 @@ module Compat = struct
   end
 end
 
-let disable_nagle flow =
-  (* TCP_NODELAY on accepted connections: small SSE frames (keeper token
-     deltas, dashboard broadcasts) are not held for Nagle coalescing (~up to
-     40ms/frame under Nagle + delayed ACK). Set per-connection after accept,
-     not on the listen socket, because TCP_NODELAY inheritance from a
-     listening socket is Linux-only and is NOT inherited on macOS. Graceful
-     degradation: if [setsockopt] fails on an unusual socket the connection
-     still works (just with Nagle enabled). *)
-  try
-    Eio_unix.Fd.use_exn "TCP_NODELAY" (Eio_unix.Net.fd flow) (fun ufd ->
-      Unix.setsockopt ufd Unix.TCP_NODELAY true)
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | _ -> ()
+(* Shared with the HTTP/1.1 listener; see lib/socket_options.mli. *)
+let disable_nagle = Socket_options.disable_nagle
 
 (** Run HTTP/2 server with Eio *)
 let run ~sw ~net ~clock config request_handler =

--- a/lib/inference_utils.ml
+++ b/lib/inference_utils.ml
@@ -37,6 +37,25 @@ let zero_usage = Agent_sdk.Types.zero_api_usage
 let usage_of_response (resp : Agent_sdk_response.api_response) : Agent_sdk.Types.api_usage =
   match resp.usage with Some u -> u | None -> zero_usage
 
+(** Field-wise sum of two usage records. [cost_usd] is summed when both sides
+    carry one, passed through when only one does, [None] otherwise. Forms the
+    monoid pair with [zero_usage]; OAS exposes [zero_api_usage] but no
+    corresponding merge, so the arithmetic lives here. *)
+let merge_usage
+    (a : Agent_sdk.Types.api_usage)
+    (b : Agent_sdk.Types.api_usage) : Agent_sdk.Types.api_usage =
+  { Agent_sdk.Types.input_tokens = a.input_tokens + b.input_tokens;
+    output_tokens = a.output_tokens + b.output_tokens;
+    cache_creation_input_tokens =
+      a.cache_creation_input_tokens + b.cache_creation_input_tokens;
+    cache_read_input_tokens =
+      a.cache_read_input_tokens + b.cache_read_input_tokens;
+    cost_usd =
+      (match a.cost_usd, b.cost_usd with
+       | Some x, Some y -> Some (x +. y)
+       | Some x, None | None, Some x -> Some x
+       | None, None -> None) }
+
 (** Convert elapsed seconds to integer milliseconds for telemetry. *)
 let elapsed_duration_ms elapsed_s =
   let elapsed_ms = elapsed_s *. 1000.0 in

--- a/lib/inference_utils.mli
+++ b/lib/inference_utils.mli
@@ -17,6 +17,16 @@ val zero_usage : Agent_sdk.Types.api_usage
 (** Extract usage from an api_response, defaulting to {!zero_usage}. *)
 val usage_of_response : Agent_sdk_response.api_response -> Agent_sdk.Types.api_usage
 
+(** [merge_usage a b] sums the four token counters field-wise
+    ([input_tokens], [output_tokens], [cache_creation_input_tokens],
+    [cache_read_input_tokens]) and combines [cost_usd]: the sum when both
+    sides carry one, the present side when only one does, [None] when
+    neither does.  Forms the monoid pair with {!zero_usage}. *)
+val merge_usage :
+  Agent_sdk.Types.api_usage ->
+  Agent_sdk.Types.api_usage ->
+  Agent_sdk.Types.api_usage
+
 (** Convert elapsed seconds to integer milliseconds for telemetry. Positive
     sub-1ms intervals are rounded up to 1; non-positive or non-finite
     intervals return 0. *)

--- a/lib/keeper/keeper_accountability_types_codec.ml
+++ b/lib/keeper/keeper_accountability_types_codec.ml
@@ -109,11 +109,7 @@ let record_emit_skip ~kind ~reason =
     ()
 ;;
 
-let keeper_name_of_agent agent_name =
-  match Keeper_identity.canonical_keeper_name_from_agent_name agent_name with
-  | Some keeper_name -> keeper_name
-  | None -> String.trim agent_name
-;;
+let keeper_name_of_agent = Keeper_identity.keeper_name_of_agent
 
 let normalize_keeper_name keeper_name =
   match Keeper_identity.canonical_keeper_name keeper_name with
@@ -205,14 +201,7 @@ let resolution_event_to_json (event : resolution_event) =
      @ option_string_field "reason" event.reason)
 ;;
 
-let event_date_string ts =
-  let tm = Unix.gmtime ts in
-  Printf.sprintf
-    "%04d-%02d-%02d"
-    (tm.Unix.tm_year + 1900)
-    (tm.Unix.tm_mon + 1)
-    tm.Unix.tm_mday
-;;
+let event_date_string = Dated_jsonl.utc_day_string
 
 let claim_event_of_json json =
   match json_string_opt "event_type" json with

--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -219,15 +219,7 @@ let agent_error_terminal_reason_code = function
     Printf.sprintf "agent_error_input_required:request_id=%s" request_id
 ;;
 
-let network_error_kind_to_wire = function
-  | Llm_provider.Http_client.Connection_refused -> "connection_refused"
-  | Llm_provider.Http_client.Dns_failure -> "dns_failure"
-  | Llm_provider.Http_client.Tls_error -> "tls_error"
-  | Llm_provider.Http_client.Timeout -> "timeout"
-  | Llm_provider.Http_client.Local_resource_exhaustion -> "local_resource_exhaustion"
-  | Llm_provider.Http_client.End_of_file -> "end_of_file"
-  | Llm_provider.Http_client.Unknown -> "unknown"
-;;
+let network_error_kind_to_wire = Keeper_internal_error.network_error_kind_to_string
 
 let provider_timeout_suffix = function
   | None -> ""

--- a/lib/keeper/keeper_alerting.ml
+++ b/lib/keeper/keeper_alerting.ml
@@ -14,19 +14,8 @@ open Keeper_meta_contract
 open Keeper_types_profile
 open Keeper_memory
 
-let merge_usage
-    (a : Agent_sdk.Types.api_usage)
-    (b : Agent_sdk.Types.api_usage) : Agent_sdk.Types.api_usage =
-  { Agent_sdk.Types.input_tokens = a.input_tokens + b.input_tokens;
-    output_tokens = a.output_tokens + b.output_tokens;
-    cache_creation_input_tokens =
-      a.cache_creation_input_tokens + b.cache_creation_input_tokens;
-    cache_read_input_tokens =
-      a.cache_read_input_tokens + b.cache_read_input_tokens;
-    cost_usd =
-      (match a.cost_usd, b.cost_usd with
-       | Some x, Some y -> Some (x +. y)
-       | Some x, None | None, Some x -> Some x
-       | None, None -> None) }
+(* Alias kept so existing callers of [Keeper_alerting.merge_usage] are
+   unchanged; the arithmetic lives in {!Inference_utils}. *)
+let merge_usage = Inference_utils.merge_usage
 
 include Keeper_alerting_path

--- a/lib/keeper/keeper_alerting.mli
+++ b/lib/keeper/keeper_alerting.mli
@@ -15,7 +15,8 @@ open Keeper_memory
 
 (** {1 Usage Merging} *)
 
-(** Merge two API usage records by summing all fields. *)
+(** Merge two API usage records by summing all fields.
+    Alias of {!Inference_utils.merge_usage}. *)
 val merge_usage :
   Agent_sdk.Types.api_usage ->
   Agent_sdk.Types.api_usage ->

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -1887,19 +1887,10 @@ let resolved_approval_json_of_audit_event json =
     ]
 ;;
 
-(* Day key for the [YYYY-MM/DD.jsonl] layout. Must stay UTC: the write path
-   ([Jsonl_writer.dated_path]) picks the day file with [Unix.gmtime], so a
-   local-time key here would look in the wrong file for the hours where the
-   two calendars disagree. Pinned by
+(* Day key for the [YYYY-MM/DD.jsonl] layout. UTC rationale lives with the
+   owner, [Dated_jsonl.utc_day_string]. Pinned by
    [test_keeper_approval_resolved_history.ml]. *)
-let audit_day_string_of_ts ts =
-  let tm = Unix.gmtime ts in
-  Printf.sprintf
-    "%04d-%02d-%02d"
-    (tm.Unix.tm_year + 1900)
-    (tm.Unix.tm_mon + 1)
-    tm.Unix.tm_mday
-;;
+let audit_day_string_of_ts = Dated_jsonl.utc_day_string
 
 let clamp_int value ~low ~high = max low (min high value)
 

--- a/lib/keeper/keeper_chat_direct_delivery.ml
+++ b/lib/keeper/keeper_chat_direct_delivery.ml
@@ -455,13 +455,8 @@ let validate_now now =
 ;;
 
 let canonical_base_path base_path =
-  let normalized = Workspace_utils_backend_setup.normalize_base_path base_path in
-  if String.equal normalized ""
-  then Error (Invalid_base_path "base_path is empty")
-  else
-    try Ok (Fs_compat.realpath normalized) with
-    | Eio.Cancel.Cancelled _ as exn -> raise exn
-    | exn -> Error (Invalid_base_path (Printexc.to_string exn))
+  Workspace_utils_backend_setup.canonical_base_path base_path
+  |> Result.map_error (fun detail -> Invalid_base_path detail)
 ;;
 
 let keeper_name_id keeper_name =

--- a/lib/keeper/keeper_chat_recovery_command.ml
+++ b/lib/keeper/keeper_chat_recovery_command.ml
@@ -112,16 +112,7 @@ let input_error_to_json error =
      @ details)
 ;;
 
-let dedupe_keep_order values =
-  let rec loop seen acc = function
-    | [] -> List.rev acc
-    | value :: rest ->
-      if List.mem value seen
-      then loop seen acc rest
-      else loop (value :: seen) (value :: acc) rest
-  in
-  loop [] [] values
-;;
+let dedupe_keep_order = Json_util.dedupe_keep_order
 
 let duplicate_fields fields =
   let rec loop seen duplicates = function

--- a/lib/keeper/keeper_external_attention.ml
+++ b/lib/keeper/keeper_external_attention.ml
@@ -137,13 +137,9 @@ let required_string key = function
       | _ -> Error (Printf.sprintf "missing string field %s" key))
   | _ -> Error "expected object"
 
-let optional_string key = function
-  | `Assoc fields -> (
-      match List.assoc_opt key fields with
-      | Some (`String value) when String.trim value <> "" -> Some value
-      | Some (`String _) | Some `Null | None -> None
-      | Some _ -> None)
-  | _ -> None
+(* Json_util.get_string_nonempty is the SSOT for the trim+empty filter;
+   it takes the json first, so the argument order is flipped here. *)
+let optional_string key json = Json_util.get_string_nonempty json key
 
 let required_float key = function
   | `Assoc fields -> (

--- a/lib/keeper/keeper_external_attention.ml
+++ b/lib/keeper/keeper_external_attention.ml
@@ -128,16 +128,7 @@ let opt_string_field key = function
 let string_assoc_json fields =
   `Assoc (List.map (fun (key, value) -> (key, `String value)) fields)
 
-let string_assoc_of_json = function
-  | `Assoc fields ->
-      Ok
-        (List.filter_map
-           (fun (key, value) ->
-             match value with
-             | `String s -> Some (key, s)
-             | _ -> None)
-           fields)
-  | _ -> Error "expected string object"
+let string_assoc_of_json = Json_util.string_assoc_of_json
 
 let required_string key = function
   | `Assoc fields -> (

--- a/lib/keeper/keeper_identity.ml
+++ b/lib/keeper/keeper_identity.ml
@@ -67,6 +67,11 @@ let canonical_keeper_name_from_agent_name agent_name =
       else
         None
 
+let keeper_name_of_agent agent_name =
+  match canonical_keeper_name_from_agent_name agent_name with
+  | Some keeper_name -> keeper_name
+  | None -> String.trim agent_name
+
 let is_keeper_principal_agent_name agent_name =
   let trimmed = String.trim agent_name in
   is_keeper_agent_alias trimmed

--- a/lib/keeper/keeper_identity.mli
+++ b/lib/keeper/keeper_identity.mli
@@ -15,6 +15,18 @@ val keeper_name_of_agent_alias : string -> string option
 
 val is_keeper_agent_alias : string -> bool
 val canonical_keeper_name_from_agent_name : string -> string option
+
+val keeper_name_of_agent : string -> string
+(** [keeper_name_of_agent s] is the canonical keeper name
+    {!canonical_keeper_name_from_agent_name} resolves [s] to, and [String.trim
+    s] when it resolves to none. Total, so metrics that group by identity can
+    fold keeper and non-keeper principals through one function. Known residual:
+    the canonicalizer collapses 3+-part hyphenated non-keeper ids
+    (["codex-mcp-client"] -> ["client"]) onto their last segment, so such
+    principals can share a canonical form. Resolving that needs registry-aware
+    typed identity (RFC-0038 Phase 2); single-token keeper names are
+    unaffected. *)
+
 val is_keeper_principal_agent_name : string -> bool
 (** [is_keeper_principal_agent_name name] returns true for task-owner
     principals that should be treated as keeper-owned work: canonical

--- a/lib/keeper/keeper_paused_work_source_terminal_transaction.ml
+++ b/lib/keeper/keeper_paused_work_source_terminal_transaction.ml
@@ -145,23 +145,14 @@ let validate_paused_owner request (meta : Keeper_meta_contract.keeper_meta) =
 ;;
 
 let validate_source_queue config ~keeper_name request =
-  let* state =
-    Keeper_event_queue_persistence.load_state_result
-      ~base_path:config.Workspace.base_path
-      ~keeper_name
-    |> Result.map_error (fun detail -> Source_queue_validation_failed detail)
-  in
-  if Keeper_event_queue_state.transition_outbox state <> []
-  then Error (Source_queue_validation_failed "source lane has a pending transition outbox")
-  else
-    Keeper_event_queue_state.validate_pending_selection
-      ~selection:
-        { source = request.source
-        ; admitted_revision = request.source_incarnation
-        }
-      state
-    |> Result.map_error (fun detail ->
-      Source_queue_validation_failed detail)
+  Keeper_event_queue_persistence.validate_source_selection
+    ~base_path:config.Workspace.base_path
+    ~keeper_name
+    ~selection:
+      { source = request.source
+      ; admitted_revision = request.source_incarnation
+      }
+  |> Result.map_error (fun detail -> Source_queue_validation_failed detail)
 ;;
 
 let operation_of_receipt receipt =

--- a/lib/keeper/keeper_paused_work_transfer_transaction.ml
+++ b/lib/keeper/keeper_paused_work_transfer_transaction.ml
@@ -213,23 +213,14 @@ let validate_target_owner request (meta : Keeper_meta_contract.keeper_meta) =
 ;;
 
 let validate_source_queue config ~from_keeper request =
-  let* state =
-    Keeper_event_queue_persistence.load_state_result
-      ~base_path:config.Workspace.base_path
-      ~keeper_name:from_keeper
-    |> Result.map_error (fun detail -> Source_queue_validation_failed detail)
-  in
-  if Keeper_event_queue_state.transition_outbox state <> []
-  then Error (Source_queue_validation_failed "source lane has a pending transition outbox")
-  else
-    Keeper_event_queue_state.validate_pending_selection
-      ~selection:
-        { source = request.source
-        ; admitted_revision = request.source_incarnation
-        }
-      state
-    |> Result.map_error (fun detail ->
-      Source_queue_validation_failed detail)
+  Keeper_event_queue_persistence.validate_source_selection
+    ~base_path:config.Workspace.base_path
+    ~keeper_name:from_keeper
+    ~selection:
+      { source = request.source
+      ; admitted_revision = request.source_incarnation
+      }
+  |> Result.map_error (fun detail -> Source_queue_validation_failed detail)
 ;;
 
 let transfer_of_receipt receipt =

--- a/lib/keeper/keeper_sandbox_runtime_setup.ml
+++ b/lib/keeper/keeper_sandbox_runtime_setup.ml
@@ -335,16 +335,7 @@ let workspace_state_path_available kind path =
   | Sys_error _ -> false
 ;;
 
-let unique_preserving_order values =
-  let rec loop seen acc = function
-    | [] -> List.rev acc
-    | value :: rest ->
-      if List.mem value seen
-      then loop seen acc rest
-      else loop (value :: seen) (value :: acc) rest
-  in
-  loop [] [] values
-;;
+let unique_preserving_order = Json_util.dedupe_keep_order
 
 let docker_workspace_state_mount_specs ~base_path ~container_root =
   let host_masc_root = Common.masc_dir_from_base_path ~base_path in

--- a/lib/keeper/keeper_secret_projection.ml
+++ b/lib/keeper/keeper_secret_projection.ml
@@ -149,14 +149,7 @@ let read_file path =
   really_input_string ic (in_channel_length ic)
 ;;
 
-let strip_one_final_newline value =
-  let len = String.length value in
-  if len >= 2 && Char.equal value.[len - 2] '\r' && Char.equal value.[len - 1] '\n'
-  then String.sub value 0 (len - 2)
-  else if len >= 1 && (Char.equal value.[len - 1] '\n' || Char.equal value.[len - 1] '\r')
-  then String.sub value 0 (len - 1)
-  else value
-;;
+let strip_one_final_newline = String_util.strip_one_final_newline
 
 let contains_char value c =
   String.contains value c

--- a/lib/keeper/keeper_secret_redaction.ml
+++ b/lib/keeper/keeper_secret_redaction.ml
@@ -24,13 +24,7 @@ let read_regular_file path st =
     with
     | Sys_error _ | End_of_file -> None
 
-let strip_one_final_newline value =
-  let len = String.length value in
-  if len >= 2 && Char.equal value.[len - 2] '\r' && Char.equal value.[len - 1] '\n'
-  then String.sub value 0 (len - 2)
-  else if len >= 1 && (Char.equal value.[len - 1] '\n' || Char.equal value.[len - 1] '\r')
-  then String.sub value 0 (len - 1)
-  else value
+let strip_one_final_newline = String_util.strip_one_final_newline
 
 let add_value value acc =
   let trimmed = String.trim value in

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -141,12 +141,7 @@ let direct_owner_conversation_context
 
 (* Flatten newlines/tabs to spaces and trim, so a co-view value never breaks
    the line-oriented instruction block. *)
-let normalized_surface_context_value value =
-  value
-  |> String.to_seq
-  |> Seq.map (function '\n' | '\r' | '\t' -> ' ' | ch -> ch)
-  |> String.of_seq
-  |> String.trim
+let normalized_surface_context_value = String_util.flatten_inline_whitespace
 
 let surface_context_field_value = function
   | `String s -> normalized_surface_context_value s

--- a/lib/keeper/keeper_turn_runtime_budget_routing.ml
+++ b/lib/keeper/keeper_turn_runtime_budget_routing.ml
@@ -19,13 +19,4 @@ let next_fail_open_runtime_for_turn
     ~attempted_runtimes
     err
 
-let sdk_error_kind = function
-  | Agent_sdk.Error.Api _ -> "api"
-  | Agent_sdk.Error.Provider _ -> "provider"
-  | Agent_sdk.Error.Agent _ -> "agent"
-  | Agent_sdk.Error.Mcp _ -> "mcp"
-  | Agent_sdk.Error.Config _ -> "config"
-  | Agent_sdk.Error.Serialization _ -> "serialization"
-  | Agent_sdk.Error.Io _ -> "io"
-  | Agent_sdk.Error.Orchestration _ -> "orchestration"
-  | Agent_sdk.Error.Internal _ -> "internal"
+let sdk_error_kind = Keeper_agent_error.sdk_error_kind

--- a/lib/keeper/surface_ref.ml
+++ b/lib/keeper/surface_ref.ml
@@ -49,13 +49,9 @@ let required_string key = function
       | _ -> Error (Printf.sprintf "missing string field %s" key))
   | _ -> Error "expected object"
 
-let optional_string key = function
-  | `Assoc fields -> (
-      match List.assoc_opt key fields with
-      | Some (`String value) when String.trim value <> "" -> Some value
-      | Some (`String _) | Some `Null | None -> None
-      | Some _ -> None)
-  | _ -> None
+(* Json_util.get_string_nonempty is the SSOT for the trim+empty filter;
+   it takes the json first, so the argument order is flipped here. *)
+let optional_string key json = Json_util.get_string_nonempty json key
 
 let optional_object key = function
   | `Assoc fields -> (

--- a/lib/keeper/surface_ref.ml
+++ b/lib/keeper/surface_ref.ml
@@ -40,16 +40,7 @@ let opt_string_field key = function
 let string_assoc_json fields =
   `Assoc (List.map (fun (key, value) -> (key, `String value)) fields)
 
-let string_assoc_of_json = function
-  | `Assoc fields ->
-      Ok
-        (List.filter_map
-           (fun (key, value) ->
-             match value with
-             | `String s -> Some (key, s)
-             | _ -> None)
-           fields)
-  | _ -> Error "expected string object"
+let string_assoc_of_json = Json_util.string_assoc_of_json
 
 let required_string key = function
   | `Assoc fields -> (

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -1020,6 +1020,15 @@ let validate_pending_selection_result ~base_path ~keeper_name ~selection =
   | Ok state -> State.validate_pending_selection ~selection state
 ;;
 
+let validate_source_selection ~base_path ~keeper_name ~selection =
+  match load_state_result ~base_path ~keeper_name with
+  | Error _ as error -> error
+  | Ok state ->
+    if State.transition_outbox state <> []
+    then Error "source lane has a pending transition outbox"
+    else State.validate_pending_selection ~selection state
+;;
+
 let ack_pending_result
       ?(after_commit = fun _ -> ())
       ~base_path

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -122,6 +122,17 @@ val validate_pending_selection_result :
   selection:Keeper_event_queue_state.pending_selection ->
   (unit, string) result
 
+val validate_source_selection :
+  base_path:string ->
+  keeper_name:string ->
+  selection:Keeper_event_queue_state.pending_selection ->
+  (unit, string) result
+(** {!validate_pending_selection_result} preceded by an empty-transition-outbox
+    precondition: a lane holding an unretired transition returns [Error "source
+    lane has a pending transition outbox"] before the selection is examined.
+    Used by the paused-work disposition transactions, which must not build a
+    receipt over a lane whose prior transition is still unprojected. *)
+
 val ack_pending_result :
   ?after_commit:(Keeper_event_queue.t -> unit) ->
   base_path:string ->

--- a/lib/keeper_runtime/keeper_internal_error.mli
+++ b/lib/keeper_runtime/keeper_internal_error.mli
@@ -8,6 +8,10 @@ val incomplete_tool_transcript_kind : string
 (** Canonical wire kind for structural transcript corruption rejected before
     provider dispatch. *)
 
+val network_error_kind_to_string : Llm_provider.Http_client.network_error_kind -> string
+(** [network_error_kind_to_string kind] is the wire spelling of a transport
+    failure kind. *)
+
 type provider_rejection = {
   provider_label : string;
   reason : string;

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -655,14 +655,7 @@ let read_recent ?keeper_name ?(n = 100) () : Yojson.Safe.t list =
     ring_keep_last ~n ~keep raw)
 ;;
 
-let iso_date_of_unix ts =
-  let tm = Unix.gmtime ts in
-  Printf.sprintf
-    "%04d-%02d-%02d"
-    (tm.Unix.tm_year + 1900)
-    (tm.Unix.tm_mon + 1)
-    tm.Unix.tm_mday
-;;
+let iso_date_of_unix = Dated_jsonl.utc_day_string
 
 let ts_of_entry (json : Yojson.Safe.t) : float option =
   match json with

--- a/lib/keeper_tool_surfaces.ml
+++ b/lib/keeper_tool_surfaces.ml
@@ -25,19 +25,7 @@ module Random = Stdlib.Random
 
 open Masc_domain
 
-module SS = Set_util.StringSet
-
-
-let dedupe_schemas (schemas : Masc_domain.tool_schema list) =
-  let unique, _ =
-    List.fold_left
-      (fun (acc, seen) (schema : Masc_domain.tool_schema) ->
-        if SS.mem schema.name seen then (acc, seen)
-        else (schema :: acc, SS.add schema.name seen))
-      ([], SS.empty)
-      schemas
-  in
-  List.rev unique
+let dedupe_schemas = Masc_domain.dedupe_tool_schemas
 
 (* Hashtbl materialisation helper for membership-only checks.  Used
    below where we'd otherwise scan a name list per element of a

--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -682,18 +682,9 @@ let make_usage ?(input_tokens = 0) ?(output_tokens = 0) () : Agent_sdk.Types.api
     cache_read_input_tokens = 0;
     cost_usd = None }
 
-let merge_usage (a : Agent_sdk.Types.api_usage) (b : Agent_sdk.Types.api_usage) : Agent_sdk.Types.api_usage =
-  { Agent_sdk.Types.input_tokens = a.input_tokens + b.input_tokens;
-    output_tokens = a.output_tokens + b.output_tokens;
-    cache_creation_input_tokens =
-      a.cache_creation_input_tokens + b.cache_creation_input_tokens;
-    cache_read_input_tokens =
-      a.cache_read_input_tokens + b.cache_read_input_tokens;
-    cost_usd =
-      (match a.cost_usd, b.cost_usd with
-       | Some x, Some y -> Some (x +. y)
-       | Some x, None | None, Some x -> Some x
-       | None, None -> None) }
+(* Alias kept so existing callers of [Worker_container_types.merge_usage]
+   are unchanged; the arithmetic lives in {!Inference_utils}. *)
+let merge_usage = Inference_utils.merge_usage
 
 let local_worker_heartbeat_interval_sec () = Env_config.Worker.local_worker_heartbeat_sec
 

--- a/lib/local/worker_container_types.mli
+++ b/lib/local/worker_container_types.mli
@@ -127,7 +127,7 @@ val merge_usage :
     [output_tokens], [cache_creation_input_tokens],
     [cache_read_input_tokens], and [cost_usd] (sum if both
     sides have it; pass through the side that does; [None]
-    if neither). *)
+    if neither).  Alias of {!Inference_utils.merge_usage}. *)
 
 (** {1 MCP / MASC transport URL} *)
 

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -39,18 +39,9 @@ let managed_agent_passthrough_tool_set : (string, unit) Hashtbl.t =
     managed_agent_passthrough_tool_names;
   tbl
 
-module StringSet = Set_util.StringSet
 module StringMap = Set_util.StringMap
 
-let dedupe_tool_schemas_by_name (schemas : Masc_domain.tool_schema list) =
-  let _, result =
-    List.fold_left
-      (fun (seen, acc) (schema : Masc_domain.tool_schema) ->
-        if StringSet.mem schema.name seen then (seen, acc)
-        else (StringSet.add schema.name seen, schema :: acc))
-      (StringSet.empty, []) schemas
-  in
-  List.rev result
+let dedupe_tool_schemas_by_name = Config.dedupe_schemas
 
 let default_instructions () =
   "MASC (Multi-Agent Streaming Workspace) enables AI agent collaboration. \

--- a/lib/mcp_server_eio_tool_profile.mli
+++ b/lib/mcp_server_eio_tool_profile.mli
@@ -15,7 +15,8 @@
     fields are part of the contract.  Cursor values themselves are
     opaque base64 strings produced by {!page_items_with_cursor}.
 
-    Internal: [StringSet] / [StringMap], [dedupe_tool_schemas_by_name],
+    Internal: [StringMap], [dedupe_tool_schemas_by_name] (an alias
+    of {!Config.dedupe_schemas}),
     [managed_agent_passthrough_tool_names] (consumed by
     {!tool_schemas_for_profile} only), [label_words_from_identifier]
     + the [custom_tool_titles] / [custom_title_table] data tables

--- a/lib/operator/operator_pending_confirm.ml
+++ b/lib/operator/operator_pending_confirm.ml
@@ -269,11 +269,7 @@ let remove_pending_confirms_by_target config ~target_type ~target_id =
   | Some target_type ->
     remove_pending_confirms_by_typed_target config { target_type; target_id }
 
-let normalize_pending_confirm_actor_filter = function
-  | Some raw ->
-      let trimmed = String.trim raw in
-      if trimmed = "" then None else Some trimmed
-  | None -> None
+let normalize_pending_confirm_actor_filter = Env_config_core.trim_opt
 
 let pending_confirm_scope_of_entries ?actor entries =
   let actor_filter =

--- a/lib/reputation.ml
+++ b/lib/reputation.ml
@@ -100,19 +100,13 @@ let load_jsonl_safe (path : string) : Yojson.Safe.t list =
 
 (** Canonical keeper name used for identity comparison.  Shared with
     {!accountability_metrics} so both metrics fold an identity the same way:
-    via [Keeper_identity.canonical_keeper_name_from_agent_name], which unwraps
-    the full actor id and resolves a generated-nickname alias to its agent
-    type, falling back to the trimmed input for non-keeper principals.
-
-    Known residual: this canonicalizer collapses 3+-part hyphenated non-keeper
-    ids (e.g. "codex-mcp-client" -> "client") onto their last segment, so such
-    principals can share a canonical form.  Resolving that needs registry-aware
-    typed identity (RFC-0038 Phase 2); it does not affect single-token keeper
-    names, which are the subject of the undercount fixed below. *)
-let keeper_name_of_agent agent_name =
-  match Keeper_identity.canonical_keeper_name_from_agent_name agent_name with
-  | Some keeper_name -> keeper_name
-  | None -> String.trim agent_name
+    both call [Keeper_identity.keeper_name_of_agent], which unwraps the full
+    actor id and resolves a generated-nickname alias to its agent type, falling
+    back to the trimmed input for non-keeper principals.  Its residual on
+    3+-part hyphenated non-keeper ids is documented on the owner; it does not
+    affect single-token keeper names, which are the subject of the undercount
+    fixed below. *)
+let keeper_name_of_agent = Keeper_identity.keeper_name_of_agent
 
 (** Count tasks claimed and completed by an agent from the task backlog.
     Reads the canonical Workspace backlog so reputation follows the same storage

--- a/lib/reputation_ledger_v2.ml
+++ b/lib/reputation_ledger_v2.ml
@@ -63,12 +63,7 @@ let get_store (config : Workspace.config) : Dated_jsonl.t =
         Hashtbl.replace store_cache base_path store;
         store)
 
-let event_date_string ts =
-  let tm = Unix.gmtime ts in
-  Printf.sprintf "%04d-%02d-%02d"
-    (tm.Unix.tm_year + 1900)
-    (tm.Unix.tm_mon + 1)
-    tm.Unix.tm_mday
+let event_date_string = Dated_jsonl.utc_day_string
 
 let opt_string_field key = function
   | Some s ->

--- a/lib/resilience/degradation.ml
+++ b/lib/resilience/degradation.ml
@@ -81,14 +81,7 @@ let authorize_transition ~from ~to_ =
 
 (* ── Strategy adjustment ──────────────────────────────────────── *)
 
-let error_mode_kind_label (mode : Recovery.error_mode) : string =
-  match mode with
-  | Recovery.TransientError _ -> "Transient"
-  | Recovery.PermanentError _ -> "Permanent"
-  | Recovery.ResourceExhausted _ -> "ResourceExhausted"
-  | Recovery.AmbiguityError _ -> "Ambiguity"
-  | Recovery.ConsensusError _ -> "Consensus"
-  | Recovery.DegradationRequired _ -> "DegradationRequired"
+let error_mode_kind_label = Recovery.error_mode_kind
 
 let apply_level_to_strategy : type a.
     a level ->

--- a/lib/resilience/keeper_bridge.ml
+++ b/lib/resilience/keeper_bridge.ml
@@ -60,14 +60,7 @@ let strategy_class_of_strategy : type a. a Recovery.strategy -> string =
   | Recovery.Handoff _ -> "Handoff"
   | Recovery.Abort _ -> "Abort"
 
-let error_mode_kind (mode : Recovery.error_mode) : string =
-  match mode with
-  | Recovery.TransientError _ -> "Transient"
-  | Recovery.PermanentError _ -> "Permanent"
-  | Recovery.ResourceExhausted _ -> "ResourceExhausted"
-  | Recovery.AmbiguityError _ -> "Ambiguity"
-  | Recovery.ConsensusError _ -> "Consensus"
-  | Recovery.DegradationRequired _ -> "DegradationRequired"
+let error_mode_kind = Recovery.error_mode_kind
 
 let execution_outcome_to_json
     (outcome : Recovery.execution_outcome) : Yojson.Safe.t =

--- a/lib/resilience/recovery.ml
+++ b/lib/resilience/recovery.ml
@@ -197,6 +197,20 @@ let all_error_mode_tla_symbols =
     "Degradation";
   ]
 
+(* Not a TLA+ symbol. Distinct from [error_mode_to_tla_symbol] above in the
+   DegradationRequired case ("DegradationRequired" here vs "Degradation"
+   there): that one is pinned to specs/resilience/ResilienceDegradation.tla
+   [ErrorModes] and must not follow this one. Consumed by operator message
+   text (degradation.ml) and by the "kind" field of the keeper audit envelope
+   (keeper_bridge.ml), so changing a string here changes a wire value. *)
+let error_mode_kind = function
+  | TransientError _ -> "Transient"
+  | PermanentError _ -> "Permanent"
+  | ResourceExhausted _ -> "ResourceExhausted"
+  | AmbiguityError _ -> "Ambiguity"
+  | ConsensusError _ -> "Consensus"
+  | DegradationRequired _ -> "DegradationRequired"
+
 let strategy_to_tla_symbol : type a. a strategy -> string = function
   | Retry _ -> "Retry"
   | Fallback _ -> "Fallback"

--- a/lib/resilience/recovery.mli
+++ b/lib/resilience/recovery.mli
@@ -129,6 +129,15 @@ val error_mode_to_tla_symbol : error_mode -> string
     {!error_mode} constructors. *)
 val all_error_mode_tla_symbols : string list
 
+(** Constructor label for {!error_mode}, used in operator message text and as
+    the [kind] field of the keeper audit envelope — so a change here changes a
+    wire value. Not a TLA+ symbol: it differs from
+    {!error_mode_to_tla_symbol} on [DegradationRequired]
+    (["DegradationRequired"] here, ["Degradation"] there, where the spelling is
+    pinned to [specs/resilience/ResilienceDegradation.tla]). The two must not
+    be collapsed. *)
+val error_mode_kind : error_mode -> string
+
 (** TLA+ symbol for {!strategy}, matching
     [specs/resilience/ResilienceDegradation.tla] [Strategies]. *)
 val strategy_to_tla_symbol : 'a strategy -> string

--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -29,66 +29,10 @@ let is_auth_header_key key =
   | _ -> false
 ;;
 
-let trim_trailing_slash path =
-  if String.length path > 1 && String.ends_with ~suffix:"/" path
-  then String.sub path 0 (String.length path - 1)
-  else path
-;;
-
-let is_digit c = c >= '0' && c <= '9'
-
-let is_version_segment s =
-  let len = String.length s in
-  len >= 2
-  && s.[0] = 'v'
-  &&
-  let rec all_digits i = i >= len || (is_digit s.[i] && all_digits (i + 1)) in
-  all_digits 1
-;;
-
-let last_path_segment path =
-  match String.rindex_opt path '/' with
-  | Some idx -> String.sub path (idx + 1) (String.length path - idx - 1)
-  | None -> path
-;;
-
-let strip_leading_version request_path =
-  let len = String.length request_path in
-  if len >= 4 && request_path.[0] = '/' && request_path.[1] = 'v' && is_digit request_path.[2]
-  then (
-    let rec find_slash i =
-      if i >= len then len
-      else if request_path.[i] = '/' then i
-      else find_slash (i + 1)
-    in
-    let slash_pos = find_slash 2 in
-    String.sub request_path slash_pos (len - slash_pos))
-  else request_path
-;;
-
-let normalize_openai_compat_request_path ~base_url ~request_path =
-  let request_path =
-    match String.trim request_path with
-    | "" -> Masc_network_defaults.openai_chat_completions_path
-    | path -> path
-  in
-  let base_path = Uri.path (Uri.of_string base_url) |> trim_trailing_slash in
-  if base_path = "" || base_path = "/"
-  then request_path
-  else (
-    let duplicated_prefix = base_path ^ "/" in
-    if String.starts_with ~prefix:duplicated_prefix request_path
-    then (
-      let suffix_start = String.length base_path + 1 in
-      "/"
-      ^ String.sub request_path suffix_start (String.length request_path - suffix_start))
-    else if is_version_segment (last_path_segment base_path)
-            && String.length request_path >= 4
-            && request_path.[0] = '/'
-            && request_path.[1] = 'v'
-            && is_digit request_path.[2]
-    then strip_leading_version request_path
-    else request_path)
+(* Request-path normalization (and its trim/version-segment helpers) is owned
+   by {!Runtime_provider_binding}; this alias keeps the local call site. *)
+let normalize_openai_compat_request_path =
+  Provider_binding.normalize_openai_compat_request_path
 ;;
 
 (* --- Provider resolution --- *)

--- a/lib/runtime_model/provider_runtime_projection.ml
+++ b/lib/runtime_model/provider_runtime_projection.ml
@@ -52,6 +52,11 @@ let binding_base_url_is_loopback binding =
   | Some base_url -> Uri.of_string base_url |> Uri.host |> Masc_network_defaults.is_loopback_host_opt
 ;;
 
+(* Kept local rather than shared with [Runtime_provider_binding]: that module
+   reaches this one through Provider_kind_resolver -> Runtime_model_resolve, so
+   calling into it here closes a module cycle. The match is total over an
+   OAS-owned closed variant, so a new [auth] constructor breaks both copies at
+   compile time. *)
 let binding_auth_is_no_auth (binding : Runtime_binding.t) =
   match binding.Runtime_binding.auth with
   | Runtime_binding.No_auth -> true

--- a/lib/runtime_model/provider_runtime_projection.mli
+++ b/lib/runtime_model/provider_runtime_projection.mli
@@ -31,3 +31,7 @@ val default_model_candidate_for_runtime_prefix :
   ?getenv:(string -> string option) -> string -> default_model_candidate option
 
 val default_execution_model_strings : string -> string list
+
+val split_csv_nonempty : string -> string list
+(** Split on [','], trim each item, and drop the items that are empty after
+    trimming. Used for comma-separated environment variable values. *)

--- a/lib/runtime_model/runtime_model_resolve.ml
+++ b/lib/runtime_model/runtime_model_resolve.ml
@@ -80,12 +80,7 @@ let env_fragment value =
     | _ -> '_')
 ;;
 
-let csv_items raw =
-  raw
-  |> String.split_on_char ','
-  |> List.map String.trim
-  |> List.filter (fun value -> not (String.equal value ""))
-;;
+let csv_items = Provider_runtime_projection.split_csv_nonempty
 
 let default_auto_models_for_profile (profile : Provider_runtime_projection.provider_profile)
   =

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -8,12 +8,7 @@ let trim_opt = Env_config_core.trim_opt
 let configured_bind_host () =
   Env_config_core.masc_host ()
 
-let ipaddr_is_loopback = function
-  | Ipaddr.V4 addr ->
-      let octets = Ipaddr.V4.to_octets addr in
-      String.length octets = 4 && Char.code octets.[0] = 127
-  | Ipaddr.V6 addr ->
-      Ipaddr.V6.compare addr Ipaddr.V6.localhost = 0
+let ipaddr_is_loopback = Masc_network_defaults.ipaddr_is_loopback
 
 let ipaddr_is_unspecified = function
   | Ipaddr.V4 addr -> Ipaddr.V4.compare addr Ipaddr.V4.any = 0

--- a/lib/server/server_bootstrap_http.ml
+++ b/lib/server/server_bootstrap_http.ml
@@ -118,20 +118,8 @@ let register_listener_lifecycle ~sw ~mode =
   mark_stopped
 ;;
 
-let disable_nagle flow =
-  (* TCP_NODELAY on accepted connections: small SSE frames (keeper token
-     deltas, dashboard broadcasts) are not held for Nagle coalescing (~up to
-     40ms/frame under Nagle + delayed ACK). Set per-connection after accept,
-     not on the listen socket, because TCP_NODELAY inheritance from a
-     listening socket is Linux-only and is NOT inherited on macOS. Graceful
-     degradation: if [setsockopt] fails on an unusual socket the connection
-     still works (just with Nagle enabled). *)
-  try
-    Eio_unix.Fd.use_exn "TCP_NODELAY" (Eio_unix.Net.fd flow) (fun ufd ->
-      Unix.setsockopt ufd Unix.TCP_NODELAY true)
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | _ -> ()
+(* Shared with the HTTP/2 listener; see lib/socket_options.mli. *)
+let disable_nagle = Socket_options.disable_nagle
 
 let serve ~sw ~clock ~socket ~addr_label ~request_handler =
   let mode = "h1" in

--- a/lib/server/server_dashboard_http_core_entities.ml
+++ b/lib/server/server_dashboard_http_core_entities.ml
@@ -17,14 +17,7 @@ let dashboard_shell_status_json (config : Workspace.config) : Yojson.Safe.t =
     ]
 ;;
 
-let dashboard_task_assignee (task : Masc_domain.task) =
-  match task.task_status with
-  | Claimed { assignee; _ }
-  | InProgress { assignee; _ }
-  | AwaitingVerification { assignee; _ }
-  | Done { assignee; _ } -> Some assignee
-  | Todo | Cancelled _ -> None
-;;
+let dashboard_task_assignee = Dashboard_execution_builders.task_assignee
 
 let dashboard_task_json config (task : Masc_domain.task) =
   let base_fields =

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -411,14 +411,7 @@ let dashboard_config_patch_allowed_fields =
   @ dashboard_config_bool_fields
   @ dashboard_config_string_list_fields
 
-let dedupe_keep_order_strings values =
-  let rec loop seen acc = function
-    | [] -> List.rev acc
-    | value :: rest ->
-        if List.mem value seen then loop seen acc rest
-        else loop (value :: seen) (value :: acc) rest
-  in
-  loop [] [] values
+let dedupe_keep_order_strings = Json_util.dedupe_keep_order
 
 let duplicate_assoc_keys fields =
   let rec loop seen dup = function
@@ -429,20 +422,10 @@ let duplicate_assoc_keys fields =
   in
   loop [] [] fields
 
-let keeper_chat_recovery_error_status = function
-  | Keeper_chat_queue.Invalid_input _ -> `Bad_request
-  | Keeper_chat_queue.Receipt_already_terminal _
-  | Keeper_chat_queue.Receipt_not_recovery_required _
-  | Keeper_chat_queue.Receipt_not_pending _
-  | Keeper_chat_queue.Pending_revision_mismatch _
-  | Keeper_chat_queue.Recovery_revision_mismatch _
-  | Keeper_chat_queue.Recovery_lease_mismatch _ ->
-      `Conflict
-  | Keeper_chat_queue.Persistence_not_configured
-  | Keeper_chat_queue.Snapshot_unavailable _
-  | Keeper_chat_queue.Revision_exhausted
-  | Keeper_chat_queue.Persist_failed _ ->
-      `Service_unavailable
+(* Same Keeper_chat_queue.error -> status mapping the pending-mutation
+   boundary uses; shared from there so the two HTTP surfaces cannot drift. *)
+let keeper_chat_recovery_error_status =
+  Server_dashboard_http_keeper_chat_pending.mutation_error_status
 
 let handle_keeper_chat_recovery_post state agent_name req reqd ~keeper_name
     ~raw_receipt_id body_str =

--- a/lib/server/server_dashboard_http_keeper_chat_pending.mli
+++ b/lib/server/server_dashboard_http_keeper_chat_pending.mli
@@ -17,6 +17,14 @@ type pending_mutation =
 val pending_mutation_route : string -> (string * string * pending_mutation) option
 (** Parse one exact pending receipt mutation route. *)
 
+val mutation_error_status : Keeper_chat_queue.mutation_error -> Httpun.Status.t
+(** Map a {!Keeper_chat_queue.mutation_error} to the HTTP status the chat-queue
+    mutation boundaries answer with. [Invalid_input] maps to
+    [`Bad_request]; the six receipt-state and revision/lease mismatch
+    errors map to [`Conflict]; [Persistence_not_configured],
+    [Snapshot_unavailable], [Revision_exhausted] and [Persist_failed]
+    map to [`Service_unavailable]. *)
+
 val handle_get :
   Mcp_server.server_state ->
   Httpun.Request.t ->

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -12,23 +12,9 @@ let h2_request_authority_bad_request ~error_code ~message h2_reqd =
     ~status:`Bad_request
 ;;
 
-let make_error_handler () =
-  (* HTTP/2 error handler *)
-  let h2_error_handler _client_addr ?request:_ error respond =
-    let message = match error with
-      | `Exn exn -> Printexc.to_string exn
-      | `Bad_request -> "Bad request"
-      | `Internal_server_error -> "Internal server error"
-    in
-    Log.Http.error "Error: %s" message;
-    let headers = H2.Headers.of_list [("content-type", "text/plain")] in
-    let body = respond headers in
-    H2.Body.Writer.write_string body message;
-    H2.Body.Writer.close body
-  in
-
-
-  h2_error_handler
+(* HTTP/2 error handler: same body as the one the h2 listener installs,
+   so both paths log and respond identically. *)
+let make_error_handler () = Http_server_h2.error_handler
 
 let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
   let mcp_eio_profile_of_transport_profile = function

--- a/lib/server/server_h2_gateway.mli
+++ b/lib/server/server_h2_gateway.mli
@@ -5,11 +5,18 @@
 
 val make_error_handler :
   unit ->
-  'a ->
+  Eio.Net.Sockaddr.stream ->
   ?request:H2.Request.t ->
   H2.Server_connection.error ->
   (H2.Headers.t -> H2.Body.Writer.t) ->
   unit
+(** [make_error_handler ()] is {!Http_server_h2.error_handler}: it maps
+    the H2 connection error to a message, logs it via [Log.Http.error],
+    and writes that message as a [text/plain] body.
+
+    The client address argument is monomorphic in
+    [Eio.Net.Sockaddr.stream], matching the
+    [make_h2_error_handler] parameter of [Server_runtime_bootstrap.run]. *)
 
 val make_request_handler :
   trust_policy:Server_request_authority.trust_policy ->

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -37,28 +37,7 @@ let respond_ide_error ~status ~request err reqd =
     reqd
 ;;
 
-let resolve_workspace_base ~state ~uri =
-  let project_base = base_path_of_state state in
-  let config = (Mcp_server.workspace_config state) in
-  let lookup_repository repo_id =
-    match Repo_store.find ~base_path:project_base repo_id with
-    | Ok repo -> Some (Repo_store.local_path ~base_path:project_base repo)
-    | Error _ -> None
-  in
-  let lookup_playground name =
-    match Keeper_meta_store.read_meta config name with
-    | Ok (Some m) -> Some (Keeper_sandbox.host_root_abs_of_meta ~config m)
-    | _ -> None
-  in
-  let exists_dir p = Sys.file_exists p && Sys.is_directory p in
-  Server_routes_http_routes_workspace.classify_workspace_query
-    ~project_base
-    ~lookup_repository
-    ~lookup_playground
-    ~exists_dir
-    ~repo_param:(Uri.get_query_param uri "repo_id")
-    ~keeper_param:(Uri.get_query_param uri "keeper")
-;;
+let resolve_workspace_base = Server_routes_http_routes_workspace.resolve_workspace_base
 
 let nonempty_query_param uri key =
   match Uri.get_query_param uri key with

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -28,13 +28,7 @@ let dashboard_actor_cache_segment state req =
 ;;
 
 let dashboard_error_json ?ok message =
-  let fields = [ ("error", `String message) ] in
-  let fields =
-    match ok with
-    | None -> fields
-    | Some value -> ("ok", `Bool value) :: fields
-  in
-  `Assoc fields
+  Server_dashboard_http_keeper_api_types.error_json ?ok message
 
 let respond_dashboard_error ?(status = `Bad_request) ?request ?ok reqd message =
   Http.Response.json_value ?request ~status

--- a/lib/server/server_routes_http_routes_workspace.mli
+++ b/lib/server/server_routes_http_routes_workspace.mli
@@ -32,6 +32,23 @@ val classify_workspace_query :
            | `PlaygroundMissing of string
            | `KeeperUnknown of string ]
 
+(** Route-boundary wiring around {!classify_workspace_query}: reads the
+    [repo_id] and [keeper] query params from [uri], looks repositories up
+    through {!Repo_store} and keeper playgrounds through
+    {!Keeper_meta_store}/{!Keeper_sandbox}, and checks the candidate
+    directory with [Sys.file_exists]/[Sys.is_directory]. Returns the base
+    directory and its source tag. *)
+val resolve_workspace_base :
+  state:Mcp_server.server_state ->
+  uri:Uri.t ->
+  string * [ `Project
+           | `Repository of string
+           | `RepositoryMissing of string
+           | `RepositoryUnknown of string
+           | `Playground of string
+           | `PlaygroundMissing of string
+           | `KeeperUnknown of string ]
+
 (** Encode the workspace source tag as the [X-Workspace-Source] header
     so the frontend can render hints (e.g. "Playground 없음 — 프로젝트로
     fallback") without parsing the JSON body. Exposed for unit

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -24,33 +24,7 @@ let cors_preflight_headers origin =
 let json_rpc_error (code : Mcp_error_code.t) message =
   Mcp_error_code.jsonrpc_error_body code ~message
 
-let is_http_error_response = function
-  | `Assoc fields ->
-      let id_is_null =
-        match List.assoc_opt "id" fields with
-        | Some `Null -> true
-        | _ -> false
-      in
-      let code =
-        match List.assoc_opt "error" fields with
-        | Some (`Assoc err_fields) ->
-            (match List.assoc_opt "code" err_fields with
-             | Some (`Int c) -> Some c
-             | _ -> None)
-        | _ -> None
-      in
-      let is_parse_or_invalid = function
-        | Mcp_error_code.Parse_error | Invalid_request -> true
-        | _ -> false
-      in
-      id_is_null
-      && (match code with
-          | Some c ->
-              (match Mcp_error_code.of_wire_code c with
-               | Some ec -> is_parse_or_invalid ec
-               | None -> false)
-          | None -> false)
-  | _ -> false
+let is_http_error_response = Server_mcp_transport_http_headers.is_http_error_response
 
 (** Server start time for uptime calculation *)
 (* server_start_time moved to [Server_routes_http_runtime_health_helpers]

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -44,13 +44,10 @@ val json_rpc_error : Mcp_error_code.t -> string -> string
     escape. *)
 
 val is_http_error_response : Yojson.Safe.t -> bool
-(** [is_http_error_response json] returns [true] when [json] is
-    a JSON-RPC 2.0 response with [id = null] AND [error.code]
-    is {!Mcp_error_code.Parse_error} or {!Mcp_error_code.Invalid_request}.
-    Mirrors the predicate in
-    {!Server_mcp_transport_http_headers}; duplicated here
-    because the route layer needs it before the transport
-    headers module is reachable. *)
+(** Re-export of
+    {!Server_mcp_transport_http_headers.is_http_error_response}: [true] when
+    [json] is a JSON-RPC 2.0 response with [id = null] AND [error.code] is
+    {!Mcp_error_code.Parse_error} or {!Mcp_error_code.Invalid_request}. *)
 
 (** {1 Server uptime} *)
 

--- a/lib/socket_options.ml
+++ b/lib/socket_options.ml
@@ -1,0 +1,20 @@
+(** Socket options applied to accepted connections.
+
+    Shared by the HTTP/1.1 listener ([lib/server/server_bootstrap_http.ml])
+    and the HTTP/2 listener ([lib/http_server_h2.ml]), which previously
+    carried byte-identical copies of {!disable_nagle}. *)
+
+let disable_nagle (flow : [> `Platform of [> `Unix ] | `Socket ] Eio.Resource.t) =
+  (* TCP_NODELAY on accepted connections: small SSE frames (keeper token
+     deltas, dashboard broadcasts) are not held for Nagle coalescing (~up to
+     40ms/frame under Nagle + delayed ACK). Set per-connection after accept,
+     not on the listen socket, because TCP_NODELAY inheritance from a
+     listening socket is Linux-only and is NOT inherited on macOS. Graceful
+     degradation: if [setsockopt] fails on an unusual socket the connection
+     still works (just with Nagle enabled). *)
+  try
+    Eio_unix.Fd.use_exn "TCP_NODELAY" (Eio_unix.Net.fd flow) (fun ufd ->
+      Unix.setsockopt ufd Unix.TCP_NODELAY true)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | _ -> ()

--- a/lib/socket_options.mli
+++ b/lib/socket_options.mli
@@ -1,0 +1,17 @@
+(** Socket options applied to accepted connections.
+
+    Shared by the HTTP/1.1 listener ([lib/server/server_bootstrap_http.ml])
+    and the HTTP/2 listener ([lib/http_server_h2.ml]). *)
+
+val disable_nagle : [> `Platform of [> `Unix ] | `Socket ] Eio.Resource.t -> unit
+(** [disable_nagle flow] sets [TCP_NODELAY] on the underlying file
+    descriptor of [flow] so small writes are sent without waiting for
+    Nagle coalescing.
+
+    Applied per accepted connection rather than on the listening socket,
+    because [TCP_NODELAY] inheritance from a listening socket is
+    Linux-only and is not inherited on macOS.
+
+    Re-raises {!Eio.Cancel.Cancelled}. Any other exception from
+    [setsockopt] is swallowed, leaving the connection with Nagle
+    enabled. *)

--- a/lib/tool_misc_web_fetch.ml
+++ b/lib/tool_misc_web_fetch.ml
@@ -92,15 +92,9 @@ let extract_description html =
   | Some _ as description -> description
   | None -> meta_content nodes "name" "description"
 
-(** URL validation *)
-let valid_url url =
-  let trimmed = String.trim url in
-  if String.equal trimmed "" then false
-  else
-    let uri = Uri.of_string trimmed in
-    match Uri.scheme uri |> Option.map String.lowercase_ascii with
-    | Some "http" | Some "https" -> true
-    | _ -> false
+(** URL validation — shared with the search tool, which already owns the
+    scheme test; see {!Tool_misc_web_search.valid_search_result_url}. *)
+let valid_url = Tool_misc_web_search.valid_search_result_url
 
 let ends_with ~suffix value =
   let value_length = String.length value in

--- a/lib/tool_misc_web_search.mli
+++ b/lib/tool_misc_web_search.mli
@@ -14,7 +14,6 @@
     the pre-compiled whitespace normalizer,
     text cleaning helpers (\[normalize_spaces],
     \[clean_search_text], \[trim_nonempty]),
-    \[valid_search_result_url],
     \[parse_json_search_results] (the generic JSON parser
     behind the per-provider parsers), \[provider_to_string] /
     \[provider_of_string] / \[parse_provider_csv] /
@@ -117,6 +116,16 @@ val clean_search_text : string -> string
     HTML snippet — not limited to search result cleaning.  Exposed so
     [Tool_misc_web_fetch] can share the same pipeline without
     duplicating regexes and entity tables. *)
+
+(** {1 URL validation} *)
+
+val valid_search_result_url : string -> bool
+(** [valid_search_result_url url] trims [url], returns [false] on the
+    empty string, and otherwise parses it with [Uri.of_string] and
+    returns [true] when the scheme, lowercased, is [http] or [https].
+    Any other scheme, and a URL with no scheme, returns [false].
+    Exposed so [Tool_misc_web_fetch] applies the same test rather than
+    carrying a second copy. *)
 
 (** {1 Tool dispatch + simulation} *)
 

--- a/lib/tool_schemas/tools.ml
+++ b/lib/tool_schemas/tools.ml
@@ -6,17 +6,7 @@
 
 open Masc_domain
 
-module StringSet = Set_util.StringSet
-
-let dedupe_schemas_by_name (schemas : tool_schema list) =
-  let unique, _ =
-    List.fold_left
-      (fun (acc, seen) (schema : tool_schema) ->
-        if StringSet.mem schema.name seen then (acc, seen)
-        else (schema :: acc, StringSet.add schema.name seen))
-      ([], StringSet.empty) schemas
-  in
-  List.rev unique
+let dedupe_schemas_by_name = Masc_domain.dedupe_tool_schemas
 
 (** Tool schemas from modules that do NOT depend on Config
     (avoids Tools -> Config -> Tools cycle) *)

--- a/lib/tool_usage_log.ml
+++ b/lib/tool_usage_log.ml
@@ -55,27 +55,9 @@ let retention_days () =
      | _ -> None)
   | None -> None
 
-let numeric_ts_field fields name =
-  match List.assoc_opt name fields with
-  | Some (`Float ts) -> Some ts
-  | Some (`Int ts) -> Some (Float.of_int ts)
-  | _ -> None
-
-let ts_of_record = function
-  | `Assoc fields -> (
-      match numeric_ts_field fields "ts_unix" with
-      | Some ts -> Some ts
-      | None -> (
-          match numeric_ts_field fields "ts" with
-          | Some ts -> Some ts
-          | None -> (
-              match numeric_ts_field fields "timestamp" with
-              | Some ts -> Some ts
-              | None -> (
-                  match List.assoc_opt "ts_iso" fields with
-                  | Some (`String iso) -> Masc_domain.parse_iso8601_opt iso
-                  | _ -> None))))
-  | _ -> None
+(* Same ts_unix / ts / timestamp / ts_iso lookup order as the dashboard
+   freshness card; shared with it rather than re-derived here. *)
+let ts_of_record = Dashboard_tool_source_freshness.latest_ts_of_record
 
 let latest_ts_of_entries entries =
   List.fold_left
@@ -85,45 +67,19 @@ let latest_ts_of_entries entries =
       | _ -> acc)
     None entries
 
-let freshness_fields ~now latest_ts =
-  match latest_ts with
-  | Some ts ->
-    [
-      ("latest_ts_unix", `Float ts);
-      ("latest_ts_iso", `String (Masc_domain.iso8601_of_unix_seconds ts));
-      ("latest_age_s", `Float (Stdlib.Float.max 0.0 (now -. ts)));
-    ]
-  | None ->
-    [
-      ("latest_ts_unix", `Null);
-      ("latest_ts_iso", `Null);
-      ("latest_age_s", `Null);
-    ]
+let freshness_fields = Dashboard_tool_source_freshness.freshness_fields
 
+(* The only tool_usage-specific input is the SLO constant above; the health
+   ladder itself is shared with the dashboard source-freshness card. *)
 let source_health_fields ~now ~exists ~entry_count ~latest_ts ?coverage_gap () =
-  let health, stale_reason =
-    match coverage_gap with
-    | Some gap ->
-      ( "coverage_gap",
-        Safe_ops.json_string ~default:"coverage_gap" "stale_reason" gap )
-    | None ->
-      if not exists then ("missing", "store_missing")
-      else if entry_count = 0 then ("empty", "no_entries")
-      else
-        match latest_ts with
-        | None -> ("empty", "no_entries")
-        | Some ts ->
-          let latest_age_s = Stdlib.Float.max 0.0 (now -. ts) in
-          if Stdlib.Float.compare latest_age_s freshness_slo_s > 0 then
-            ("stale", "freshness_slo_exceeded")
-          else
-            ("ok", "")
-  in
-  [
-    ("health", `String health);
-    ( "stale_reason",
-      if String.equal stale_reason "" then `Null else `String stale_reason );
-  ]
+  Dashboard_tool_source_freshness.health_fields
+    ~now
+    ~exists
+    ~entry_count
+    ~latest_ts
+    ~freshness_slo_s
+    ?coverage_gap
+    ()
 
 let coverage_gaps masc_root =
   Telemetry_coverage_gap.read_recent ~masc_root ~n:50

--- a/lib/tool_workspace.ml
+++ b/lib/tool_workspace.ml
@@ -551,14 +551,6 @@ let inspect_state ctx =
   { task_claimed; current_task_set }
 ;;
 
-let state_to_json st =
-  `Assoc
-    [ "task_claimed", `Bool st.task_claimed
-    ; "current_task_set", `Bool st.current_task_set
-    ; "session_active", `Bool false
-    ]
-;;
-
 (* ── State check (assertion-based verification) ────────────────── *)
 
 (** Issue #8636: SSOT for [masc_check] assertion vocabulary. Schema

--- a/lib/transport_read_model.ml
+++ b/lib/transport_read_model.ml
@@ -4,19 +4,10 @@ type http_context =
   ; include_configured : bool
   }
 
-let trim_trailing_slashes value =
-  (* Single-pass scan + at-most-one [String.sub], instead of recursing
-     once per trailing '/'.  base_url normalization runs on every
-     binding/handshake so even the small-N case adds up. *)
-  let len = String.length value in
-  let rec last_non_slash i =
-    if i < 0 || value.[i] <> '/' then i else last_non_slash (i - 1)
-  in
-  let last = last_non_slash (len - 1) in
-  if last = len - 1 then value else String.sub value 0 (last + 1)
-;;
-
-;;
+(* base_url normalization runs on every binding/handshake, so this shares the
+   owner's single-pass scan rather than keeping a second copy that could
+   drift. *)
+let trim_trailing_slashes = Masc_network_defaults.trim_trailing_slashes
 
 let websocket_scheme_for_http_scheme = function
   | Some scheme ->
@@ -43,12 +34,7 @@ let ipaddr_is_unspecified = function
   | Ipaddr.V6 addr -> Ipaddr.V6.compare addr Ipaddr.V6.unspecified = 0
 ;;
 
-let ipaddr_is_loopback = function
-  | Ipaddr.V4 addr ->
-    let octets = Ipaddr.V4.to_octets addr in
-    String.length octets = 4 && Char.code octets.[0] = 127
-  | Ipaddr.V6 addr -> Ipaddr.V6.compare addr Ipaddr.V6.localhost = 0
-;;
+let ipaddr_is_loopback = Masc_network_defaults.ipaddr_is_loopback
 
 let is_unspecified_host host =
   match Ipaddr.of_string (String.trim host) with

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -942,6 +942,19 @@ type tool_schema = {
   input_schema: Yojson.Safe.t;
 }
 
+(** Drop schemas whose [name] already appeared earlier in the list; the first
+    occurrence of each name is kept and the surviving order is preserved. *)
+let dedupe_tool_schemas (schemas : tool_schema list) =
+  let unique, _ =
+    List.fold_left
+      (fun (acc, seen) (schema : tool_schema) ->
+        if Set_util.StringSet.mem schema.name seen then (acc, seen)
+        else (schema :: acc, Set_util.StringSet.add schema.name seen))
+      ([], Set_util.StringSet.empty)
+      schemas
+  in
+  List.rev unique
+
 (** Structured result for claim_next scheduling (avoids brittle string parsing).
     Defined here so that both Workspace_task_schedule (producer) and consumers
     (tool_task, orchestrator) can reference the type without

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -322,6 +322,11 @@ type tool_schema =
   ; input_schema : Yojson.Safe.t
   }
 
+val dedupe_tool_schemas : tool_schema list -> tool_schema list
+(** [dedupe_tool_schemas schemas] drops entries whose [name] already appeared
+    earlier in [schemas]. The first occurrence of each name is kept and the
+    surviving order is preserved. *)
+
 type claim_next_result =
   | Claim_next_claimed of
       { task_id : string

--- a/lib/voice_config/voice_config.ml
+++ b/lib/voice_config/voice_config.ml
@@ -469,14 +469,7 @@ let local_playback_enabled_for_agent config agent_id =
   | [] -> true
   | agents -> List.mem agent_id agents
 
-let unique_strings values =
-  let rec loop seen acc = function
-    | [] -> List.rev acc
-    | value :: rest ->
-        if List.mem value seen then loop seen acc rest
-        else loop (value :: seen) (value :: acc) rest
-  in
-  loop [] [] values
+let unique_strings = Json_util.dedupe_keep_order
 
 let available_voices config =
   config.tts.default_voice

--- a/lib/workspace/nickname.ml
+++ b/lib/workspace/nickname.ml
@@ -14,20 +14,10 @@ let nickname_rng_mutex = Eio.Mutex.create ()
 let with_nickname_rng f =
   Eio.Mutex.use_ro nickname_rng_mutex (fun () -> f nickname_rng)
 
-let array_contains arr value =
-  let rec loop idx =
-    idx < Array.length arr
-    && (String.equal arr.(idx) value || loop (idx + 1))
-  in
-  loop 0
-
-let is_hex4 value =
-  String.length value = 4
-  && String.for_all
-       (function
-         | '0' .. '9' | 'a' .. 'f' -> true
-         | _ -> false)
-       value
+(* Word-list membership and the hex4 suffix shape come from the same
+   [Nickname_words] SSOT as the vocabulary above. *)
+let array_contains = Nickname_words.array_contains
+let is_hex4 = Nickname_words.is_hex4
 
 (** Generate a short random suffix (4 hex chars) for uniqueness *)
 let random_suffix () =

--- a/lib/workspace/workspace_utils_backend_setup.ml
+++ b/lib/workspace/workspace_utils_backend_setup.ml
@@ -97,6 +97,18 @@ let normalize_base_path path =
     Filename.concat (Config_dir_resolver.current_working_dir ()) trimmed
   else trimmed
 
+(* Normalize then resolve, keeping the failure detail as a plain string so each
+   caller can wrap it in its own error variant. Cancellation is re-raised rather
+   than turned into an Error so a cancelled fiber is not reported as a bad
+   path. *)
+let canonical_base_path base_path =
+  let normalized = normalize_base_path base_path in
+  if String.equal normalized "" then Error "base_path is empty"
+  else
+    try Ok (Fs_compat.realpath normalized) with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error (Printexc.to_string exn)
+
 let running_under_test_executable () =
   let executable =
     Sys.executable_name |> Filename.basename |> String.lowercase_ascii

--- a/lib/workspace/workspace_utils_backend_setup.mli
+++ b/lib/workspace/workspace_utils_backend_setup.mli
@@ -22,6 +22,14 @@ val read_git_file : string -> string option
 val parse_gitdir_to_main_root : string -> string option
 val find_git_root : string -> string option
 val normalize_base_path : string -> string
+
+val canonical_base_path : string -> (string, string) result
+(** [canonical_base_path path] applies [normalize_base_path] and then resolves
+    the result with [Fs_compat.realpath]. Returns [Error "base_path is empty"]
+    when normalization yields [""], and [Error] with the printed exception when
+    resolution raises. [Eio.Cancel.Cancelled] is re-raised instead of being
+    returned as an error. *)
+
 val running_under_test_executable : unit -> bool
 val test_base_path_override_env : string
 val test_base_path_override_enabled : unit -> bool


### PR DESCRIPTION
Stacked on #26813.

## 범위

Tier 2 는 **바이트 동일이 아니라 토큰 유사도 0.95 이상**인 함수 클러스터다. 문자열 리터럴을 보존한 채 측정했다.

두 번에 나눠 전수 처리했다. 미판정 클러스터는 남아 있지 않다.

| 배치 | 판정 | fold | keep |
|---|---|---|---|
| 1차 (12 클러스터) | 12 | 4 | 8 |
| 2차 (94 클러스터, rebase 후 재산출) | 94 | 40 | 54 |
| 합계 | 106 | **44** | **62** |

## 적용

44 건을 기존 소유 모듈로 모았다. 사이트는 로컬 이름을 한 줄 별칭으로 유지해 호출부와 export 표면을 바꾸지 않는다.

홈 분포: `runtime_provider_binding` 4, `core/json_util` 3, `core/string_util` 2, `config/nickname_words` 2, `config/masc_network_defaults` 2, `dashboard_tool_source_freshness` 2, 나머지는 상대 모듈이 이미 참조하던 쪽. 신규 모듈은 `lib/socket_options` 1 개다 (`disable_nagle` 의 홈).

## 유지 62 건 — 판정 사유

유사도만으로는 못 가른다는 것이 이 작업의 결론이다. 반복된 사유:

- **같은 철자, 다른 closed variant.** 두 모듈이 각자 `type error` 를 선언하고 둘 다 `Invalid_field` 를 갖지만, keeper 쪽은 `Unsupported_fields of { context; fields }`, operator 쪽은 `Unsupported_fields of string list` 이다. 접으면 두 서브시스템의 오류 어휘를 통합하게 된다.
- **모듈 레벨 상태가 다름.** `tool_misc_web_fetch` 와 `tool_misc_web_search` 는 캐시 만료 본문이 같지만 각자 `cache_entries` 테이블과 mutex 를 소유한다. 접으면 fetch 캐시와 search 캐시가 한 키스페이스가 된다.
- **leaf 라이브러리가 `masc_core` 에 닿지 못함.** `json_field`, `multimodal`, `shared_audit`, `ide` 가 각자 Yojson variant 이름을 만든다. 그중 둘은 이미 코드 주석에 이유를 적어두고 있었다. 게다가 서로 다르다 — `` `Intlit `` 은 셋에서 `"intlit"`, 둘에서 `"int"` 이고, `json_field` 는 `"assoc"`/`"list"`, 나머지는 `"object"`/`"array"` 다. 이 문자열은 파싱 오류 메시지로 사용자에게 나간다.
- **`=` 대 `==`.** `board_core.ml` 은 `reaction` 레코드의 구조 비교, `runtime_exact_output_registry.ml` 은 registry 스냅샷의 물리 동일성 비교다. 후자는 compare-and-publish 의 base-unchanged 펜스라 `=` 로 접으면 재발행된 동일 값 registry 를 stale base 로 통과시킨다.
- **중복이 아니라 단일 소스 별칭.** `standard_cache_ttl_s` 는 7 개 파일이 같은 상수를 재노출하는 형태고 정의는 이미 한 곳뿐이다.

## 컴파일러가 잡은 오적용 2 건

적용된 44 건 중 2 건이 틀렸고 빌드가 잡았다. 둘 다 이 PR 안에서 수정했다.

1. **모듈 사이클.** `provider_runtime_projection` 이 `Runtime_provider_binding` 을 호출하도록 접었는데, 후자는 `Provider_kind_resolver` → `Runtime_model_resolve` 를 거쳐 전자에 닿는다. 되돌리고, 사본이 남는 이유를 주석으로 기록했다. 이 클러스터는 1 차 배치에서 이미 keep 으로 판정됐던 것이다.
2. **타입 이름 오타.** `server_dashboard_http_keeper_chat_pending.mli` 에 추가된 export 가 `Keeper_chat_queue.error` 를 참조했다. 실제 이름은 `mutation_error` 다.

## 로컬 검증

- `dune build --root .` → exit 0
- `dune runtest --root .` → exit 1, 실패 타깃 35 개
- 이 35 개는 본 변경 **직전 상태에서 실패하던 36 개의 부분집합**이다. 새로 실패한 타깃은 0 개이고, `test_keeper_composite_live_turn_surface` 는 오히려 통과로 바뀌었다
- `docs/runtime-tunables.md` 재생성 → 변화 없음 (`env_config_*.ml` 미변경)

## 미적용

클러스터 `c14` (`validate_source_queue`) 는 fold 판정이지만 적용하지 않았다. 두 사이트의 `request` 레코드와 `Source_queue_validation_failed` 생성자가 모듈 로컬이라, 공통 헬퍼가 `(unit, string) result` 를 반환하고 각 호출부가 자기 생성자로 감싸는 형태로 바꿔야 한다.

RFC-WAIVED: credential / identity / operator control / keeper sandbox / dashboard credential / hooks / workflow 문서를 건드리지 않는다.
