### PR TITLE
fix(keeper): keeper/persona 도구 스키마의 미선언 필드 조용한 무시 차단

### DIFF
--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -134,6 +134,7 @@ let keeper_schemas : tool_schema list = [
           ("description", `String "If true, return full persona summaries. If false, return names only.");
         ]);
       ]);
+      ("additionalProperties", `Bool false);
     ];
   };
   {
@@ -209,6 +210,7 @@ let keeper_schemas : tool_schema list = [
           ("description", `String "If false, return only keepers with audit issues while keeping summary counts over all audited keepers.");
         ]);
       ]);
+      ("additionalProperties", `Bool false);
     ];
   };
 
@@ -221,6 +223,10 @@ let keeper_schemas : tool_schema list = [
         ("name", `Assoc [
           ("type", `String "string");
           ("description", `String "Keeper handle (stable). Example: 'keeper-helper'");
+        ]);
+        ("persona_name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional persona handle recorded in the keeper TOML. Falls back to the resolved profile defaults when omitted.");
         ]);
         ("instructions", `Assoc [
           ("type", `String "string");
@@ -265,6 +271,11 @@ let keeper_schemas : tool_schema list = [
         ]);
       ]);
       ("required", `List [`String "name"]);
+      (* [network_mode] is deliberately absent: it is accepted only on the
+         dashboard HTTP path, which calls [Keeper_turn_up_args.parse] with
+         [~allow_sandbox_fields:true] and does not validate against this
+         schema. The MCP contract rejects it. *)
+      ("additionalProperties", `Bool false);
     ];
   };
 
@@ -374,6 +385,7 @@ let keeper_schemas : tool_schema list = [
         ]);
       ]);
       ("required", `List [`String "name"]);
+      ("additionalProperties", `Bool false);
     ];
   };
 
@@ -392,6 +404,7 @@ let keeper_schemas : tool_schema list = [
           ("description", `String "Return keeper summaries (model/context/handoff/compaction) instead of names only.");
         ]);
       ]);
+      ("additionalProperties", `Bool false);
     ];
   };
 
@@ -408,6 +421,7 @@ Clears stale data from previous sessions. Does not affect configuration, goals, 
         ]);
       ]);
       ("required", `List [`String "name"]);
+      ("additionalProperties", `Bool false);
     ];
   };
 
@@ -423,6 +437,7 @@ Clears stale data from previous sessions. Does not affect configuration, goals, 
         ]);
       ]);
       ("required", `List [`String "name"]);
+      ("additionalProperties", `Bool false);
     ];
   };
 
@@ -452,6 +467,7 @@ Requires a reason for the audit trail.";
         ]);
       ]);
       ("required", `List [`String "name"; `String "reason"]);
+      ("additionalProperties", `Bool false);
     ];
   };
 
@@ -483,6 +499,7 @@ keeper spawned from this persona inherits. Required fields: persona_name, displa
         ("proactive_enabled", `Assoc [("type", `String "boolean")]);
       ]);
       ("required", `List [`String "persona_name"; `String "display_name"]);
+      ("additionalProperties", `Bool false);
     ];
   };
 
@@ -510,6 +527,7 @@ persona does not exist.";
         ("proactive_enabled", `Assoc [("type", `String "boolean")]);
       ]);
       ("required", `List [`String "persona_name"]);
+      ("additionalProperties", `Bool false);
     ];
   };
 
@@ -529,6 +547,7 @@ future spawns from the persona.";
         ]);
       ]);
       ("required", `List [`String "persona_name"]);
+      ("additionalProperties", `Bool false);
     ];
   };
 

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -644,6 +644,132 @@ let test_validate_args_keeper_board_list_rejects_unknown_field () =
       (Yojson.Safe.to_string forwarded)
   | Error _ -> ()
 
+(* The keeper/persona tool schemas in [Keeper_schema] hand-roll their
+   [`Assoc] input_schema. Eleven of them omitted [additionalProperties],
+   so [Tool_input_validation.unsupported_arg_names] returned [] for them and
+   an undeclared field reached the handler, which then dropped it with no
+   error. Only the fourteen names hand-listed in
+   [Keeper_config_text.removed_keeper_msg_inputs] produced a rejection;
+   a typo did not. *)
+let keeper_schema_input name =
+  find_schema_exn name Masc.Keeper_schema.schemas
+
+let assert_rejects_undeclared_field ~tool ~field =
+  match
+    Tool_input_validation.validate_args
+      ~schema:(keeper_schema_input tool)
+      ~name:tool
+      ~args:(`Assoc [ "name", `String "k"; field, `String "x" ])
+      ()
+  with
+  | Ok forwarded ->
+    Alcotest.failf
+      "expected %s to reject undeclared field %s, but it passed: %s"
+      tool field
+      (Yojson.Safe.to_string forwarded)
+  | Error result ->
+    let msg = Yojson.Safe.to_string (Tool_result.data result) in
+    Alcotest.(check bool)
+      (Printf.sprintf "%s error names %s" tool field)
+      true
+      (string_contains msg ("unsupported field(s): " ^ field))
+
+let test_keeper_up_rejects_undeclared_field () =
+  assert_rejects_undeclared_field ~tool:"masc_keeper_up" ~field:"shrt_goal"
+
+(* The retired goal inputs were rejected only because they were hand-listed.
+   Closing the schema rejects them through the same path as any other
+   undeclared name, which is what makes the hand-list redundant. *)
+let test_keeper_up_rejects_retired_goal_inputs () =
+  List.iter
+    (fun field -> assert_rejects_undeclared_field ~tool:"masc_keeper_up" ~field)
+    [ "goal"; "short_goal"; "mid_goal"; "long_goal"; "new_goal" ]
+
+let test_keeper_down_rejects_undeclared_field () =
+  assert_rejects_undeclared_field ~tool:"masc_keeper_down" ~field:"remove_metaa"
+
+(* Regression guard for the closure itself: every field observed in live
+   ~/me/.masc tool-call logs must still be accepted. Closing a schema turns
+   a silent drop into a hard rejection, so an under-declared property breaks
+   a working call — the same failure the keeper_board_list [compact] omission
+   produced above. [persona_name] is in this list because
+   [Keeper_turn_up_args.parse] reads it and
+   [Keeper_turn_up_config_persistence] writes it to the keeper TOML, while
+   the schema did not declare it. *)
+let test_keeper_up_accepts_live_traffic_fields () =
+  let args =
+    `Assoc
+      [ "name", `String "sangsu"
+      ; "persona_name", `String "sangsu"
+      ; "instructions", `String "do the thing"
+      ; "active_goal_ids", `List [ `String "g1" ]
+      ; "sandbox_profile", `String "local"
+      ; "allowed_paths", `List [ `String "/tmp" ]
+      ; "mention_targets", `List [ `String "sangsu" ]
+      ; "autoboot_enabled", `Bool true
+      ; "proactive_enabled", `Bool true
+      ; "runtime_id", `String "rt"
+      ; "max_context_override", `Int 0
+      ]
+  in
+  match
+    Tool_input_validation.validate_args
+      ~schema:(keeper_schema_input "masc_keeper_up")
+      ~name:"masc_keeper_up"
+      ~args
+      ()
+  with
+  | Ok _ -> ()
+  | Error result ->
+    Alcotest.failf
+      "expected masc_keeper_up to accept its live-traffic fields, got %s"
+      (Yojson.Safe.to_string (Tool_result.data result))
+
+let test_keeper_clear_accepts_live_traffic_fields () =
+  match
+    Tool_input_validation.validate_args
+      ~schema:(keeper_schema_input "masc_keeper_clear")
+      ~name:"masc_keeper_clear"
+      ~args:
+        (`Assoc
+          [ "name", `String "sangsu"
+          ; "preserve_system_prompt", `Bool true
+          ; "reason", `String "context overflow"
+          ])
+      ()
+  with
+  | Ok _ -> ()
+  | Error result ->
+    Alcotest.failf
+      "expected masc_keeper_clear to accept its live-traffic fields, got %s"
+      (Yojson.Safe.to_string (Tool_result.data result))
+
+(* [network_mode] stays undeclared on purpose: it is accepted only on the
+   dashboard HTTP path, which calls [Keeper_turn_up_args.parse] with
+   [~allow_sandbox_fields:true] and never validates against this schema. *)
+let test_keeper_up_rejects_network_mode () =
+  assert_rejects_undeclared_field ~tool:"masc_keeper_up" ~field:"network_mode"
+
+(* Every schema in the keeper surface forbids undeclared fields. A new tool
+   added without [additionalProperties] reopens the silent-drop path, so the
+   invariant is asserted over the whole list rather than per tool. *)
+let test_every_keeper_schema_forbids_additional_properties () =
+  List.iter
+    (fun (schema : Masc_domain.tool_schema) ->
+      let forbids =
+        match schema.input_schema with
+        | `Assoc fields ->
+          (match List.assoc_opt "additionalProperties" fields with
+           | Some (`Bool false) -> true
+           | _ -> false)
+        | _ -> false
+      in
+      Alcotest.(check bool)
+        (Printf.sprintf "%s forbids additional properties" schema.name)
+        true
+        forbids)
+    Masc.Keeper_schema.schemas
+
 let test_validate_args_keeper_memory_search_rejects_removed_kind () =
   match
     Tool_input_validation.validate_args
@@ -2128,6 +2254,22 @@ let () =
         test_typed_tool_contract_rejection_corpus;
       Alcotest.test_case "keeper schemas pin required fields" `Quick
         test_keeper_tool_schemas_pin_required_fields;
+    ]);
+    ("keeper_schema_closure", [
+      Alcotest.test_case "keeper_up rejects an undeclared field" `Quick
+        test_keeper_up_rejects_undeclared_field;
+      Alcotest.test_case "keeper_up rejects retired goal inputs" `Quick
+        test_keeper_up_rejects_retired_goal_inputs;
+      Alcotest.test_case "keeper_down rejects an undeclared field" `Quick
+        test_keeper_down_rejects_undeclared_field;
+      Alcotest.test_case "keeper_up accepts live-traffic fields" `Quick
+        test_keeper_up_accepts_live_traffic_fields;
+      Alcotest.test_case "keeper_clear accepts live-traffic fields" `Quick
+        test_keeper_clear_accepts_live_traffic_fields;
+      Alcotest.test_case "keeper_up rejects dashboard-only network_mode" `Quick
+        test_keeper_up_rejects_network_mode;
+      Alcotest.test_case "every keeper schema forbids additional properties" `Quick
+        test_every_keeper_schema_forbids_additional_properties;
     ]);
     ("oneof_const_discriminator", [
       Alcotest.test_case "alpha branch matches via const" `Quick


### PR DESCRIPTION
## 문제

`lib/keeper/keeper_schema.ml` 의 15개 스키마 중 **11개가 `additionalProperties` 를 선언하지 않았습니다.**

강제 체인은 실재합니다:

```
tool_input_validation.ml:499  schema_shape_error
  → unsupported_arg_names (210)
    → forbids_additional_properties (204)   ← Some (`Bool false) 일 때만 true
```

키가 없으면 `unsupported_arg_names` 가 `[]` 를 반환하고, 미선언 필드는 핸들러까지 도달한 뒤 **에러 없이 버려집니다**.

지금 그 필드들을 막는 유일한 것은 `Keeper_config_text` 의 손목록입니다. 열거된 이름만 걸리고 오타는 그냥 통과합니다.

## `persona_name` — 닫기 전에 발견한 실제 결함

`masc_keeper_up` 은 `persona_name` 을

- `Keeper_turn_up_args.parse:153` 에서 args 로부터 읽고
- `Keeper_turn_up_config_persistence:47,66` 에서 keeper TOML 에 **씁니다**

그런데 스키마에 선언이 없습니다. 문서화되지 않은 입력이라 클라이언트는 존재를 모릅니다.

**선언 없이 닫았으면 동작하던 호출이 깨졌습니다.** 같은 형태의 회귀 선례가 이 저장소에 있습니다 — `keeper_board_list` 가 `compact` 를 선언하지 않아 정당한 호출을 `unsupported field` 로 거부한 건 (`test_tool_input_validation.ml:597`).

## `network_mode` 는 의도적으로 미선언

`Keeper_turn_up_args.parse ~allow_sandbox_fields:true` 로 호출될 때만 읽히고, 그 호출자는 `server_dashboard_http_keeper_api_post.ml:860` 대시보드 HTTP 경로 하나뿐입니다. 그 경로는 이 스키마로 검증하지 않습니다. MCP 계약에서는 거부가 맞습니다. 코드에 이유를 주석으로 남겼습니다.

## 라이브 트래픽 위험 측정

`~/me/.masc` tool-call 로그 48콜 전수:

| 도구 | 호출 | 미선언 필드 |
|---|---|---|
| `masc_keeper_list` | 23 | 0 |
| `masc_keeper_up` | 11 | 0 |
| `masc_keeper_compact` | 10 | 0 |
| `masc_keeper_clear` | 2 | 0 |
| `masc_keeper_persona_audit` | 2 | 0 |

관측된 호출자 중 깨지는 것은 없습니다.

한계: `masc_persona_create` / `masc_persona_update` / `masc_persona_delete` / `masc_persona_list` / `masc_keeper_down` / `masc_keeper_reset` 은 로그에 호출 0건이라 **무증거**이지 안전 확인이 아닙니다. 대신 핸들러(`keeper_tool_persona_crud.ml`)를 직접 읽어 args 로부터 읽는 필드가 전부 선언돼 있음을 확인했습니다. `tool_access` / `tool_denylist` 는 args 가 아니라 **저장된 profile** 을 검사하므로(`List.mem_assoc key existing`) 무관합니다.

## 검증

- `dune build --root . @check` — exit 0. exit 0 이 컴파일 증거가 아닐 수 있어 positive control 수행: 의도적 타입 오류 → exit 1 + `keeper_schema.ml` 지목, 되돌린 뒤 exit 0.
- `test_tool_input_validation` — 86/86 통과, 신규 `keeper_schema_closure` 그룹 7건 포함.
- **Negative control 2종이 서로 다른 테스트를 뒤집습니다**:
  - `masc_keeper_up` 닫기만 되돌림 → 거부 테스트 4건 실패 (0, 1, 5, 6)
  - `persona_name` 선언만 되돌림 → **수용 테스트 1건 실패** (3)
- 인접 스위트: `test_keeper_turn_up_args` 7/7, `test_tool_registry_consistency` 8/8, `test_keeper_tool_descriptor_registry_integrity` 46/46, `test_tool_schema_oas_boundary` 2/2, `test_keeper_effective_meta_overlay` 23/23, `test_dashboard_namespace_truth` 12/12.
- 기존 실패 3건(`test_tools_coverage` 1, `test_keeper_tool_dispatch_runtime` 4, `test_mcp_server_eio` 2)은 같은 main 기반 무관 워크트리에서 동일하게 재현되어 이 변경과 무관합니다.

## 불변식 테스트

개별 도구 테스트 외에 전체 리스트에 대한 단언을 추가했습니다:

```ocaml
List.iter (fun schema -> (* additionalProperties = `Bool false *)) Masc.Keeper_schema.schemas
```

`additionalProperties` 없이 새 도구를 추가하면 조용한 무시 경로가 다시 열리므로, 도구별이 아니라 목록 전체에 걸었습니다.

## 후속 (이 PR 아님)

`Keeper_config_text.removed_keeper_msg_inputs` 의 죽은 필드명 14개 손목록은 이 변경으로 MCP 경로에서는 중복이 됩니다. 다만 `server_routes_http_keeper_stream.ml:600` 의 HTTP 라우트가 이 목록을 직접 호출하고 그 경로에는 스키마 검증이 없어, 지금 지우면 그 경로의 거부가 조용한 무시로 강등됩니다. HTTP 라우트의 입력 계약과 함께 별도로 다룹니다.

RFC-WAIVED: keeper 도구 스키마의 입력 계약 강화. credential / identity / operator control plane / keeper sandbox / dashboard credential / hooks / workflow 문서 중 어느 것도 건드리지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)