### PR TITLE
fix: decode autonomous turn runtime identities

### DIFF
--- a/docs/rfc/RFC-0358-autonomous-turn-kind-on-turn-record.md
+++ b/docs/rfc/RFC-0358-autonomous-turn-kind-on-turn-record.md
@@ -20,8 +20,11 @@ related: ["0351", "0233"]
 | `raw_trace_run_ref` | exact OAS run ref option | 완료된 provider dispatch result |
 
 `raw_trace_run_ref`는 `worker_run_id`, `path`, `start_seq`, `end_seq`,
-`agent_name`, `session_id`를 보존한다. Decoder는 run ref의 agent/session
-identity가 record의 agent/trace identity와 다르면 현재 record로 인정하지 않는다.
+`agent_name`, `session_id`를 보존한다. Record의 `agent_name`은 Keeper identity이고
+run ref의 `agent_name`은 OAS runtime identity이므로 서로 비교하지 않는다. Decoder는
+run ref의 session identity가 record의 trace identity와 다르면 현재 record로
+인정하지 않는다. Reader는 선택된 raw row의 OAS runtime/session identity가 run ref와
+다르면 해당 turn을 투영하지 않는다.
 필드가 없는 과거 row를 읽는 migration이나 fallback은 없다.
 
 ## 2. 읽기 경계
@@ -59,5 +62,6 @@ projection이며 keeper prompt 입력이 아니다.
 - 한 trace file에 여러 provider run이 있어도 record가 지목한 run만 투영한다.
 - Public autonomous row의 activity trace에는 raw thinking, tool call id,
   arguments, result가 없다.
-- Agent/session identity mismatch와 keeper trace directory 밖 path를 거부한다.
+- Raw row와 run ref의 OAS runtime/session identity mismatch 및 keeper trace
+  directory 밖 path를 거부한다.
 - Autonomous row volume은 200개의 direct conversation slot을 소비하지 않는다.

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -255,17 +255,10 @@ let dispatch_after_provider_transcript_admission ~messages ~dispatch =
   | Ok () -> dispatch ()
 ;;
 
-(* [run_ref.agent_name] is the OAS runtime identity masc mints per dispatch
-   attempt ([Keeper_turn_driver] formats it as "oas-<runtime_id>"), not the
-   keeper agent identity the turn record carries ("keeper-<name>-agent").
-   Those are separate name spaces, so a [String.equal] between them can never
-   hold: #26756 shipped that comparison alongside the reader that consumes the
-   reference, so every autonomous turn was recorded with
-   [raw_trace_run_ref = None] and the dashboard read model dropped all of
-   them. Ownership is established by the session identity checked below plus
-   [Keeper_autonomous_turn_source.check_trace_file], which requires the
-   referenced file to be a regular file inside this keeper's own raw-trace
-   directory. The runtime identity is recorded, not compared. *)
+(* [run_ref.agent_name] is the OAS runtime identity, not the Keeper identity.
+   The writer binds the reference to this turn's session; the autonomous-turn
+   reader validates the recorded OAS identity and session against every raw
+   trace row before projecting the run. *)
 let turn_record_raw_trace_run_ref
       ~expected_session_id
       (run_ref : Agent_sdk.Raw_trace.run_ref)

--- a/lib/keeper/keeper_autonomous_turn_source.ml
+++ b/lib/keeper/keeper_autonomous_turn_source.ml
@@ -39,6 +39,27 @@ let check_trace_file ~dir path =
     | exception Unix.Unix_error _ -> Missing_or_non_regular
 ;;
 
+type raw_trace_identity_mismatch =
+  | Runtime_agent_name_mismatch
+  | Session_id_mismatch
+
+let check_raw_trace_identity
+      (run_ref : Turn_record.raw_trace_run_ref)
+      (records : Agent_sdk.Raw_trace.record list)
+  =
+  let rec loop = function
+    | [] -> Ok ()
+    | (record : Agent_sdk.Raw_trace.record) :: rest ->
+      if not (String.equal record.agent_name run_ref.agent_name)
+      then Error Runtime_agent_name_mismatch
+      else (
+        match record.session_id with
+        | Some session_id when String.equal session_id run_ref.session_id -> loop rest
+        | Some _ | None -> Error Session_id_mismatch)
+  in
+  loop records
+;;
+
 let trace_step_of_trajectory = function
   | Agent_sdk.Trajectory.Think { ts; _ } ->
     Some
@@ -124,25 +145,37 @@ let turn_of_record ~config ~keeper_name (record : Turn_record.t) =
              run_ref.worker_run_id;
            None
          | Ok ((first : Agent_sdk.Raw_trace.record) :: _ as records) ->
-           let final_text =
-             records
-             |> List.rev
-             |> List.find_opt (fun (row : Agent_sdk.Raw_trace.record) ->
-               row.record_type = Agent_sdk.Raw_trace.Run_finished)
-             |> Option.map (fun (row : Agent_sdk.Raw_trace.record) -> row.final_text)
-             |> Option.join
-           in
-           let trace =
-             Agent_sdk.Trajectory.of_raw_trace_records records
-             |> fun trajectory -> trajectory.steps
-             |> List.filter_map trace_step_of_trajectory
-           in
-           Some
-             { turn_id = Ids.Turn_ref.to_string record.turn_ref
-             ; started_at = first.ts
-             ; final_text
-             ; trace
-             })
+           (match check_raw_trace_identity run_ref records with
+            | Error Runtime_agent_name_mismatch ->
+              Log.Keeper.warn ~keeper_name
+                "autonomous turn source: exact run %s has a mismatched OAS runtime identity"
+                run_ref.worker_run_id;
+              None
+            | Error Session_id_mismatch ->
+              Log.Keeper.warn ~keeper_name
+                "autonomous turn source: exact run %s has a mismatched session identity"
+                run_ref.worker_run_id;
+              None
+            | Ok () ->
+              let final_text =
+                records
+                |> List.rev
+                |> List.find_opt (fun (row : Agent_sdk.Raw_trace.record) ->
+                  row.record_type = Agent_sdk.Raw_trace.Run_finished)
+                |> Option.map (fun (row : Agent_sdk.Raw_trace.record) -> row.final_text)
+                |> Option.join
+              in
+              let trace =
+                Agent_sdk.Trajectory.of_raw_trace_records records
+                |> fun trajectory -> trajectory.steps
+                |> List.filter_map trace_step_of_trajectory
+              in
+              Some
+                { turn_id = Ids.Turn_ref.to_string record.turn_ref
+                ; started_at = first.ts
+                ; final_text
+                ; trace
+                }))
 ;;
 
 let load_recent ~config ~keeper_name ?(limit = default_limit) ?since () =

--- a/lib/types/turn_record.ml
+++ b/lib/types/turn_record.ml
@@ -526,11 +526,6 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
         | json ->
           let* run_ref = raw_trace_run_ref_of_json json in
           let* () =
-            if String.equal run_ref.agent_name agent_name
-            then Ok ()
-            else Error "turn_record: raw trace agent_name does not match record identity"
-          in
-          let* () =
             if String.equal run_ref.session_id trace_id
             then Ok ()
             else Error "turn_record: raw trace session_id does not match trace_id"

--- a/lib/types/turn_record.mli
+++ b/lib/types/turn_record.mli
@@ -74,6 +74,8 @@ type raw_trace_run_ref =
   ; start_seq : int
   ; end_seq : int
   ; agent_name : string
+    (* OAS runtime identity for the dispatched run. This is intentionally a
+       different namespace from [t.agent_name], which is the Keeper identity. *)
   ; session_id : string
   }
 

--- a/lib/types/turn_record.mli
+++ b/lib/types/turn_record.mli
@@ -75,8 +75,10 @@ type raw_trace_run_ref =
   ; end_seq : int
   ; agent_name : string
     (* OAS runtime identity for the dispatched run. This is intentionally a
-       different namespace from [t.agent_name], which is the Keeper identity. *)
+       different namespace from [t.agent_name], which is the Keeper identity;
+       the autonomous-turn reader validates it against the selected raw rows. *)
   ; session_id : string
+    (* Matches [t.trace_id] and the selected raw rows. *)
   }
 
 type t =

--- a/test/test_keeper_autonomous_turn_source.ml
+++ b/test/test_keeper_autonomous_turn_source.ml
@@ -219,6 +219,54 @@ let test_missing_or_outside_trace_is_skipped () =
     (List.length (Keeper_autonomous_turn_source.load_recent ~config ~keeper_name ()))
 ;;
 
+let replace_raw_field_at ~index ~field ~value records =
+  List.mapi
+    (fun current record ->
+      if current <> index
+      then record
+      else
+        match record with
+        | `Assoc fields -> `Assoc ((field, value) :: List.remove_assoc field fields)
+        | other -> other)
+    records
+;;
+
+let test_mismatched_raw_trace_runtime_identity_is_skipped () =
+  with_workspace @@ fun config ->
+  let path = trace_path config "runtime-identity-mismatch" in
+  let records =
+    run_lines ~worker_run_id:"run-mismatch" ~start_seq:1 ~base_ts:4500.
+      ~prompt:"ignored" ~final_text:"must not be attributed"
+    |> replace_raw_field_at ~index:3 ~field:"agent_name"
+         ~value:(`String "oas-other-runtime")
+  in
+  write_lines path records;
+  write_turn_record config ~absolute_turn:44 ~generation:9
+    ~turn_kind:Turn_record.Autonomous
+    ~raw_trace_run_ref:
+      (Some (run_ref ~path ~worker_run_id:"run-mismatch" ~start_seq:1));
+  Alcotest.(check int) "raw runtime identity mismatch is rejected" 0
+    (List.length (Keeper_autonomous_turn_source.load_recent ~config ~keeper_name ()))
+;;
+
+let test_mismatched_raw_trace_session_identity_is_skipped () =
+  with_workspace @@ fun config ->
+  let path = trace_path config "session-identity-mismatch" in
+  let records =
+    run_lines ~worker_run_id:"run-mismatch" ~start_seq:1 ~base_ts:4600.
+      ~prompt:"ignored" ~final_text:"must not be attributed"
+    |> replace_raw_field_at ~index:4 ~field:"session_id"
+         ~value:(`String "trace-other-9999")
+  in
+  write_lines path records;
+  write_turn_record config ~absolute_turn:45 ~generation:9
+    ~turn_kind:Turn_record.Autonomous
+    ~raw_trace_run_ref:
+      (Some (run_ref ~path ~worker_run_id:"run-mismatch" ~start_seq:1));
+  Alcotest.(check int) "raw session identity mismatch is rejected" 0
+    (List.length (Keeper_autonomous_turn_source.load_recent ~config ~keeper_name ()))
+;;
+
 let test_since_and_limit_use_current_records () =
   with_workspace @@ fun config ->
   let write index base_ts text =
@@ -240,11 +288,8 @@ let test_since_and_limit_use_current_records () =
     (List.map (fun (turn : Keeper_autonomous_turn_source.turn) -> turn.final_text) turns)
 ;;
 
-(* The reader above can only project turns whose record carries an exact run
-   reference, so the writer-side acceptance rule belongs to the same guard set.
-   [Keeper_turn_driver] mints the OAS runtime identity as "oas-<runtime_id>",
-   which never equals the keeper agent identity; comparing the two rejected
-   every reference and left every autonomous turn unprojectable. *)
+(* The OAS runtime identity is opaque here. The reader validates it against
+   the selected raw rows without comparing it to the Keeper identity. *)
 let sdk_run_ref ~agent_name ~session_id : Agent_sdk.Raw_trace.run_ref =
   { worker_run_id = "wr-exact-run"
   ; path = "/keepers/" ^ keeper_name ^ "/raw-traces/turn-exact.jsonl"
@@ -310,6 +355,10 @@ let () =
             test_direct_marker_spoof_is_excluded
         ; Alcotest.test_case "rejects trace paths outside keeper store" `Quick
             test_missing_or_outside_trace_is_skipped
+        ; Alcotest.test_case "rejects mismatched raw runtime identity" `Quick
+            test_mismatched_raw_trace_runtime_identity_is_skipped
+        ; Alcotest.test_case "rejects mismatched raw session identity" `Quick
+            test_mismatched_raw_trace_session_identity_is_skipped
         ; Alcotest.test_case "since and limit use current records" `Quick
             test_since_and_limit_use_current_records
         ] )

--- a/test/test_keeper_autonomous_turn_source.ml
+++ b/test/test_keeper_autonomous_turn_source.ml
@@ -4,6 +4,7 @@ open Masc
 
 let keeper_name = "keeper-autonomous-source"
 let agent_name = "keeper-autonomous-agent"
+let runtime_agent_name = "oas-test-runtime"
 let trace_id = "trace-test-0000"
 
 let temp_dir () =
@@ -43,7 +44,7 @@ let raw_record ~worker_run_id ~seq ~ts ~record_type fields =
      :: ("worker_run_id", `String worker_run_id)
      :: ("seq", `Int seq)
      :: ("ts", `Float ts)
-     :: ("agent_name", `String agent_name)
+     :: ("agent_name", `String runtime_agent_name)
      :: ("session_id", `String trace_id)
      :: ("record_type", `String (Agent_sdk.Raw_trace.record_type_to_string record_type))
      :: fields)
@@ -106,7 +107,7 @@ let run_ref ~path ~worker_run_id ~start_seq =
   ; path
   ; start_seq
   ; end_seq = start_seq + 4
-  ; agent_name
+  ; agent_name = runtime_agent_name
   ; session_id = trace_id
   }
 ;;

--- a/test/test_turn_record.ml
+++ b/test/test_turn_record.ml
@@ -89,7 +89,7 @@ let sample_record () : Turn_record.t =
         ; path = "/tmp/turn-record-test.jsonl"
         ; start_seq = 8
         ; end_seq = 15
-        ; agent_name = "sangsu-agent"
+        ; agent_name = "oas-test-runtime"
         ; session_id = "trace-1780648779957-00000"
         }
   ; sampling =
@@ -373,7 +373,7 @@ let test_codec_rejects_mismatched_turn_ref () =
     check bool "turn_ref mismatch is explicit" true
       (Astring.String.is_infix ~affix:"does not match" message)
 
-let test_codec_rejects_mismatched_raw_trace_identity () =
+let test_codec_rejects_mismatched_raw_trace_session () =
   let replace_run_ref_field field value =
     match Turn_record.to_json (sample_record ()) with
     | `Assoc fields ->
@@ -388,16 +388,14 @@ let test_codec_rejects_mismatched_raw_trace_identity () =
          :: List.remove_assoc "raw_trace_run_ref" fields)
     | other -> other
   in
-  List.iter
-    (fun (field, value, expected) ->
-      match Turn_record.of_json (replace_run_ref_field field value) with
-      | Ok _ -> failf "decoded mismatched raw trace %s" field
-      | Error message ->
-        check bool "raw trace mismatch is explicit" true
-          (Astring.String.is_infix ~affix:expected message))
-    [ "agent_name", `String "different-agent", "agent_name does not match"
-    ; "session_id", `String "different-trace", "session_id does not match"
-    ]
+  match
+    Turn_record.of_json
+      (replace_run_ref_field "session_id" (`String "different-trace"))
+  with
+  | Ok _ -> fail "decoded mismatched raw trace session_id"
+  | Error message ->
+    check bool "raw trace session mismatch is explicit" true
+      (Astring.String.is_infix ~affix:"session_id does not match" message)
 
 let test_codec_rejects_partial_or_invalid_request_wire_observation () =
   let replace fields =
@@ -713,8 +711,8 @@ let () =
             test_codec_requires_current_observation_fields
         ; test_case "mismatched turn_ref rejected" `Quick
             test_codec_rejects_mismatched_turn_ref
-        ; test_case "mismatched raw trace identity rejected" `Quick
-            test_codec_rejects_mismatched_raw_trace_identity
+        ; test_case "mismatched raw trace session rejected" `Quick
+            test_codec_rejects_mismatched_raw_trace_session
         ; test_case "partial or invalid request wire observation rejected"
             `Quick
             test_codec_rejects_partial_or_invalid_request_wire_observation


### PR DESCRIPTION
## What changed

- remove the invalid equality check between the Keeper identity and the OAS runtime identity stored in `raw_trace_run_ref.agent_name`
- retain the TurnRecord invariant that `raw_trace_run_ref.session_id = trace_id`
- validate every selected raw-trace row's OAS `agent_name` and `session_id` against the exact run reference before projecting it into Dashboard Chat
- fail closed with an explicit Keeper warning when any row identity differs
- cover production-shaped Keeper/OAS identities and single-row runtime/session corruption with end-to-end tests
- align RFC-0358 and source comments with the current identity boundary

## Root cause

PR #26804 added the Dashboard autonomous-turn projection, but `Turn_record.of_json` required `raw_trace_run_ref.agent_name = record.agent_name`. These fields belong to different namespaces: the TurnRecord owns the Keeper identity while the raw trace owns the OAS runtime identity. Production turns therefore wrote valid raw traces and TurnRecords, then the Dashboard reader rejected every row.

Removing that comparison alone was insufficient: pinned OAS `Raw_trace_query.read_run` selects by path, worker run ID, and sequence range, but does not validate the reference's runtime/session metadata against the returned rows. The MASC read boundary now performs that exact validation before publishing final text or activity.

## Impact

Completed autonomous Keeper turns can be decoded and projected into `GET /api/v1/keepers/:name/chat/history`. A stale or corrupted reference cannot attribute another raw run's result to the current TurnRecord when its OAS runtime or session identity differs.

## Validation

- `scripts/dune-local.sh build test/test_keeper_autonomous_turn_source.exe test/test_turn_record.exe`: passed
- `test_keeper_autonomous_turn_source.exe`: 10/10 passed
- `test_turn_record.exe`: 23/23 passed
- `ocamlformat --check` on touched OCaml files: passed
- `git diff --check`: passed
- pinned OAS `59ccced68c`: every emitted row copies the active run's `agent_name` and `session_id`; `read_run` itself filters only path/run/sequence, so MASC owns the row-identity check
