### PR TITLE
fix(keeper): 자율턴 비공개 thinking 을 문구 대신 타입 flag 로 나른다

### DIFF
--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -94,6 +94,7 @@ const KeeperChatTraceStepSchema = union([
   object({
     kind: literal('think'),
     text: string(),
+    content_withheld: optional(boolean()),
     ts: optional(string()),
     oas_block_index: optional(number()),
     oasBlockIndex: optional(number()),

--- a/dashboard/src/components/chat/autonomous-turn-group.test.ts
+++ b/dashboard/src/components/chat/autonomous-turn-group.test.ts
@@ -79,7 +79,7 @@ describe('chatHistoryEntriesFromRest — autonomous turn rows', () => {
     blocks: [{
       t: 'trace',
       trace: [
-        { kind: 'think', text: '내부 판단 단계 (내용 비공개)' },
+        { kind: 'think', text: '', content_withheld: true },
         {
           kind: 'tool',
           name: 'keeper_tasks_list',
@@ -98,7 +98,7 @@ describe('chatHistoryEntriesFromRest — autonomous turn rows', () => {
     expect(entryOut?.text).toBe('no work this cycle')
     expect(entryOut?.blocks).toBeUndefined()
     expect(entryOut?.traceSteps).toEqual([
-      { kind: 'think', text: '내부 판단 단계 (내용 비공개)' },
+      { kind: 'think', text: '', contentWithheld: true },
       {
         kind: 'tool',
         name: 'keeper_tasks_list',
@@ -106,6 +106,20 @@ describe('chatHistoryEntriesFromRest — autonomous turn rows', () => {
       },
     ])
     expect(entryOut?.turnRef).toBe('trace-test#41')
+  })
+
+  it('drops a think step whose text is empty without the withheld flag', () => {
+    // Negative control for the branch order in normalizeTraceStep. `asString`
+    // reports '' as absent, so an empty think step is only legitimate when the
+    // flag says the content was withheld. Without the flag it is malformed, and
+    // one malformed step nulls the entire trace array.
+    const [entryOut] = chatHistoryEntriesFromRest('lane-smith', [
+      {
+        ...autonomousRow,
+        blocks: [{ t: 'trace', trace: [{ kind: 'think', text: '' }] }],
+      },
+    ])
+    expect(entryOut?.traceSteps).toBeUndefined()
   })
 
   it('is visible without the internal-message toggle', () => {

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -1700,6 +1700,33 @@ function ChatTraceStep({
   const [open, setOpen] = useState(false)
   const sourceBadge = traceSourceBadge(step)
 
+  if (step.kind === 'think' && step.contentWithheld) {
+    // The server admitted the step without its reasoning (RFC-0358 §2), so
+    // there is nothing to preview, expand, or stream — only the fact and its
+    // timestamp. The wording lives here because the read boundary is a policy
+    // of this surface, not a property of the run.
+    return html`
+      <div
+        class="chat-block-tstep think"
+        data-chat-trace-step="think"
+        data-chat-trace-content-withheld="true"
+        data-chat-turn-order-index=${orderIndex ?? undefined}
+        data-chat-turn-order-kind="trace"
+        data-chat-trace-provenance=${sourceBadge.label}
+        data-chat-trace-ts=${step.ts ?? undefined}
+      >
+        <span class="chat-block-tnode"></span>
+        <div class="min-w-0 flex-1">
+          <div class="chat-block-tstep-row">
+            <span class="chat-block-tstep-kind">Thinking</span>
+            <${TraceSourceBadge} info=${sourceBadge} />
+          </div>
+          <div class="chat-block-tstep-text">내부 판단 단계 (내용 비공개)</div>
+        </div>
+      </div>
+    `
+  }
+
   if (step.kind === 'think') {
     const longThinking = !streaming && step.text.length > THINKING_TRACE_PREVIEW_CHARS
     const previewText = longThinking

--- a/dashboard/src/demo/keeper-autonomous-public-history-fixture.ts
+++ b/dashboard/src/demo/keeper-autonomous-public-history-fixture.ts
@@ -15,7 +15,7 @@ const rawHistory = [
     blocks: [{
       t: 'trace',
       trace: [
-        { kind: 'think', text: '내부 판단 단계 (내용 비공개)' },
+        { kind: 'think', text: '', content_withheld: true },
         {
           kind: 'tool',
           name: 'keeper_tasks_list',

--- a/dashboard/src/keeper-chat-pending.ts
+++ b/dashboard/src/keeper-chat-pending.ts
@@ -92,9 +92,11 @@ function normalizeTraceStep(raw: unknown): ChatTraceStep | null {
   if (kind === 'think') {
     const text = stringValue(raw.text)
     if (text === undefined) return null
-    const step: ChatTraceStep = { kind, text }
+    const contentWithheld = raw.content_withheld === true || raw.contentWithheld === true
+    const step: ChatTraceStep = { kind, text: contentWithheld ? '' : text }
     const ts = stringValue(raw.ts)
     const oasBlockIndex = numberValue(raw.oasBlockIndex)
+    if (contentWithheld) step.contentWithheld = true
     if (ts !== undefined) step.ts = ts
     if (oasBlockIndex !== undefined) step.oasBlockIndex = oasBlockIndex
     return step

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -448,6 +448,20 @@ function normalizeTraceStep(raw: unknown): ChatTraceStep | null {
   if (!isRecord(raw)) return null
   const kind = asString(raw.kind)
   if (kind === 'think') {
+    // The withheld flag is the discriminator, and it has to be read before
+    // `text`: a withheld step carries "" by contract, and `asString` reports an
+    // empty string as absent, which would drop the step — and with it the whole
+    // trace, since `normalizeTraceSteps` nulls the array if any step is null.
+    const contentWithheld = raw.content_withheld === true || raw.contentWithheld === true
+    if (contentWithheld) {
+      return withoutUndefined({
+        kind,
+        text: '',
+        contentWithheld: true,
+        ts: asString(raw.ts),
+        oasBlockIndex: asNumber(raw.oasBlockIndex) ?? asNumber(raw.oas_block_index) ?? undefined,
+      })
+    }
     const text = asString(raw.text)
     return text !== undefined
       ? withoutUndefined({

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -828,7 +828,18 @@ export type ChatMermaidBlock = { t: 'mermaid'; source: string; caption?: string 
 // `ts` (ISO-8601) records when the trace event arrived. Live streams preserve
 // think/tool order structurally in this array; persisted legacy rows may omit
 // timestamps and still render in stored order.
-export type ChatTraceThinkStep = { kind: 'think'; text: string; ts?: string; oasBlockIndex?: number }
+// `contentWithheld` marks a step the server admitted without carrying its
+// reasoning (RFC-0358 §2 public autonomous projection). `text` is '' in that
+// case and the label shown for it is this client's to choose. Distinct from
+// ChatThinkingBlock's `redacted`, which means the provider itself sent only a
+// signature.
+export type ChatTraceThinkStep = {
+  kind: 'think'
+  text: string
+  contentWithheld?: boolean
+  ts?: string
+  oasBlockIndex?: number
+}
 export type ChatTraceReasonStep = { kind: 'reason'; text: string; detail?: string; ts?: string }
 export type ChatTraceProgressStep = { kind: 'progress'; text: string; ts?: string; oasBlockIndex?: number }
 export type ChatTraceToolStep = {

--- a/docs/rfc/RFC-0358-autonomous-turn-kind-on-turn-record.md
+++ b/docs/rfc/RFC-0358-autonomous-turn-kind-on-turn-record.md
@@ -34,6 +34,13 @@ run ref의 session identity가 record의 trace identity와 다르면 현재 reco
 단일 exact run을 `Raw_trace_query.read_run`으로 읽고 허용된 activity field만
 투영한다. 한 파일의 여러 provider run을 합치지 않는다.
 
+Thinking 단계의 존재는 `Trace_think`의 `content_withheld = true`로 나른다.
+문구가 아니라 flag가 그 사실을 나르므로, 표시 문구는 읽는 쪽이 정하고 서버는
+언어를 소유하지 않는다. Encoder와 decoder 양쪽이 `content_withheld = true ==>
+text = ""`를 강제해 caller 실수로도 reasoning text가 이 경계를 넘지 못한다.
+`thinking_block`의 `redacted`(provider가 signature만 보낸 경우)와는 원인이
+다르므로 같은 field로 합치지 않는다.
+
 Public `/chat/history`에는 final text, timestamp, `turn_ref`와 exact run의
 content-free activity trace만 투영한다. Activity trace는 thinking 단계의 존재와
 timestamp, tool name/status/duration만 포함한다. Raw thinking, assistant blocks,

--- a/lib/keeper/keeper_autonomous_turn_source.ml
+++ b/lib/keeper/keeper_autonomous_turn_source.ml
@@ -62,9 +62,13 @@ let check_raw_trace_identity
 
 let trace_step_of_trajectory = function
   | Agent_sdk.Trajectory.Think { ts; _ } ->
+    (* RFC-0358 §2 admits the step and its timestamp, not the reasoning. The
+       flag carries that fact; the label a reader shows for it belongs to the
+       reader, not to this projection. *)
     Some
       (Keeper_chat_blocks.Trace_think
-         { text = "내부 판단 단계 (내용 비공개)"
+         { text = ""
+         ; content_withheld = true
          ; ts = Some (Masc_domain.iso8601_of_unix_seconds ts)
          ; oas_block_index = None
          })

--- a/lib/keeper/keeper_chat_blocks.ml
+++ b/lib/keeper/keeper_chat_blocks.ml
@@ -124,6 +124,7 @@ type trace_tool_status =
 type trace_step =
   | Trace_think of {
       text : string;
+      content_withheld : bool;
       ts : string option;
       oas_block_index : int option;
     }
@@ -322,9 +323,15 @@ let trace_status_to_yojson = function
 ;;
 
 let trace_step_to_yojson = function
-  | Trace_think { text; ts; oas_block_index } ->
+  | Trace_think { text; content_withheld; ts; oas_block_index } ->
+    (* Mirrors the [Thinking { redacted }] wire rule: the flag is only emitted
+       when true, and [text] is forced to "" at the boundary regardless of the
+       in-memory record, so a caller-side bug cannot ship reasoning text behind
+       a flag that claims the content was not carried. *)
+    let wire_text = if content_withheld then "" else text in
     `Assoc
-      ([ ("kind", `String "think"); ("text", `String text) ]
+      ([ ("kind", `String "think"); ("text", `String wire_text) ]
+       @ (if content_withheld then [ ("content_withheld", `Bool true) ] else [])
        @ opt_string_field "ts" ts
        @ opt_int_field "oas_block_index" oas_block_index)
   | Trace_reason { text; detail; ts } ->
@@ -644,12 +651,23 @@ let block_of_yojson json : chat_block option =
           | Some (`Int i) -> Some i
           | _ -> None
         in
+        let get_step_bool key =
+          match List.assoc_opt key step_fields with
+          | Some (`Bool b) -> b
+          | _ -> false
+        in
         (match get_step_string "kind" with
           | Some "think" ->
+            (* "text" stays required so a payload that merely omits it is
+               rejected rather than silently read as a withheld step. The
+               in-memory record cannot hold text alongside the flag: a payload
+               carrying both loses the text here, matching the encoder. *)
             Option.bind (get_step_string "text") (fun text ->
+              let content_withheld = get_step_bool "content_withheld" in
               Some
                 (Trace_think
-                   { text
+                   { text = (if content_withheld then "" else text)
+                   ; content_withheld
                    ; ts = get_step_string "ts"
                    ; oas_block_index =
                        (match get_step_int "oas_block_index" with

--- a/lib/keeper/keeper_chat_blocks.mli
+++ b/lib/keeper/keeper_chat_blocks.mli
@@ -131,9 +131,22 @@ type trace_tool_status =
 type trace_step =
   | Trace_think of {
       text : string;
+      content_withheld : bool;
       ts : string option;
       oas_block_index : int option;
     }
+      (** [content_withheld = true] states that the step happened and its
+          content is not carried on this surface — the public autonomous
+          projection of RFC-0358 §2, which admits the step's existence and
+          timestamp but no reasoning text. [trace_step_to_yojson] and the
+          decoder both force [text = ""] in that case, so a caller building
+          [Trace_think { text = <real reasoning>; content_withheld = true }]
+          cannot transmit the text behind a flag that says it was dropped.
+
+          Distinct from {!thinking_block}'s [redacted], which means the
+          provider sent a signature-only [RedactedThinking] block. Both hide
+          content; only this one is a read-boundary policy, so consumers that
+          explain why must not conflate them. *)
   | Trace_reason of {
       text : string;
       detail : string option;

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -274,9 +274,10 @@ let redact_table_cell redaction = function
     Keeper_chat_blocks.Cell_value { v = redact_string redaction v; num; muted }
 
 let redact_trace_step redaction = function
-  | Keeper_chat_blocks.Trace_think { text; ts; oas_block_index } ->
+  | Keeper_chat_blocks.Trace_think { text; content_withheld; ts; oas_block_index } ->
     Keeper_chat_blocks.Trace_think
-      { text = redact_string redaction text
+      { text = (if content_withheld then "" else redact_string redaction text)
+      ; content_withheld
       ; ts = redact_string_opt redaction ts
       ; oas_block_index
       }

--- a/lib/server/server_dashboard_http_keeper_api_trace.ml
+++ b/lib/server/server_dashboard_http_keeper_api_trace.ml
@@ -156,6 +156,7 @@ let trajectory_line_to_chat_trace_step = function
     Some
       (Keeper_chat_blocks.Trace_think
          { text = entry.content
+         ; content_withheld = false
          ; ts = Some entry.ts_iso
          ; oas_block_index = None
          })

--- a/scripts/harness_dashboard_keeper_autonomous_public_history_dom_smoke.sh
+++ b/scripts/harness_dashboard_keeper_autonomous_public_history_dom_smoke.sh
@@ -71,6 +71,11 @@ with sync_playwright() as playwright:
         page.get_by_text("Observed one healthy follow-up.", exact=True).last.wait_for()
         page.get_by_text("내부 판단 단계 (내용 비공개)", exact=True).wait_for()
         activity = page.locator('[data-chat-work-trace]')
+        # The label is the dashboard's; what crossed the wire is the flag. Assert
+        # the flag reached the DOM so a server that went back to shipping prose
+        # in `text` fails here instead of passing on the rendered string alone.
+        think = activity.locator('[data-chat-trace-step="think"]')
+        assert think.get_attribute("data-chat-trace-content-withheld") == "true"
         tool = activity.locator('[data-chat-trace-step="tool"]')
         assert "keeper_tasks_list" in tool.inner_text()
         assert tool.get_attribute("data-chat-trace-link-state") == "structural"

--- a/test/test_keeper_autonomous_turn_source.ml
+++ b/test/test_keeper_autonomous_turn_source.ml
@@ -180,8 +180,9 @@ let test_projects_exact_run_outcome_and_activity () =
      | [ Keeper_chat_blocks.Trace_think thinking
        ; Keeper_chat_blocks.Trace_tool tool
        ] ->
-       Alcotest.(check string) "thinking content is not public"
-         "내부 판단 단계 (내용 비공개)" thinking.text;
+       Alcotest.(check bool) "thinking step declares withheld content" true
+         thinking.content_withheld;
+       Alcotest.(check string) "thinking content is not public" "" thinking.text;
        Alcotest.(check string) "tool name" "Read" tool.name;
        Alcotest.(check (option string)) "tool id is not public" None tool.tool_call_id;
        Alcotest.(check (option string)) "tool duration" (Some "1000ms") tool.dur;

--- a/test/test_keeper_chat_blocks.ml
+++ b/test/test_keeper_chat_blocks.ml
@@ -228,6 +228,7 @@ let test_dashboard_rich_blocks_roundtrip () =
               B.Trace_think
                 {
                   text = "checking";
+                  content_withheld = false;
                   ts = Some "2026-07-01T00:00:00Z";
                   oas_block_index = Some 0;
                 };
@@ -485,6 +486,115 @@ let test_thinking_block_requires_content () =
        (`List [ `Assoc [ ("t", `String "thinking"); ("redacted", `Bool true) ] ])
      = None)
 
+let withheld_think_trace steps = [ B.Trace { trace = steps } ]
+
+let test_withheld_think_step_roundtrip () =
+  (* The public autonomous projection admits the step and its timestamp with no
+     reasoning text (RFC-0358 §2). The flag is what states that, so it has to
+     survive the wire in both directions. *)
+  let original =
+    withheld_think_trace
+      [ B.Trace_think
+          { text = ""
+          ; content_withheld = true
+          ; ts = Some "2026-08-04T00:00:00Z"
+          ; oas_block_index = None
+          }
+      ]
+  in
+  Alcotest.(check (list yojson_testable))
+    "withheld think step json shape"
+    [ `Assoc
+        [ ("t", `String "trace")
+        ; ( "trace"
+          , `List
+              [ `Assoc
+                  [ ("kind", `String "think")
+                  ; ("text", `String "")
+                  ; ("content_withheld", `Bool true)
+                  ; ("ts", `String "2026-08-04T00:00:00Z")
+                  ]
+              ] )
+        ]
+    ]
+    (blocks_to_json_list original);
+  match B.blocks_of_yojson (`List (blocks_to_json_list original)) with
+  | Some [ B.Trace { trace = [ B.Trace_think { text = ""; content_withheld = true; _ } ] } ]
+    -> ()
+  | _ -> Alcotest.fail "withheld think step should roundtrip with content_withheld=true"
+
+let test_withheld_think_step_encoder_scrubs_smuggled_text () =
+  (* Mirrors the [Thinking { redacted }] guarantee: a caller that builds the
+     flag alongside real reasoning must not be able to ship it. *)
+  let original =
+    withheld_think_trace
+      [ B.Trace_think
+          { text = "leaked reasoning"
+          ; content_withheld = true
+          ; ts = None
+          ; oas_block_index = None
+          }
+      ]
+  in
+  Alcotest.(check (list yojson_testable))
+    "withheld think step with smuggled text is scrubbed on encode"
+    [ `Assoc
+        [ ("t", `String "trace")
+        ; ( "trace"
+          , `List
+              [ `Assoc
+                  [ ("kind", `String "think")
+                  ; ("text", `String "")
+                  ; ("content_withheld", `Bool true)
+                  ]
+              ] )
+        ]
+    ]
+    (blocks_to_json_list original)
+
+let test_withheld_think_step_decoder_scrubs_smuggled_text () =
+  match
+    B.blocks_of_yojson
+      (`List
+         [ `Assoc
+             [ ("t", `String "trace")
+             ; ( "trace"
+               , `List
+                   [ `Assoc
+                       [ ("kind", `String "think")
+                       ; ("text", `String "leaked reasoning")
+                       ; ("content_withheld", `Bool true)
+                       ]
+                   ] )
+             ]
+         ])
+  with
+  | Some [ B.Trace { trace = [ B.Trace_think { text = ""; content_withheld = true; _ } ] } ]
+    -> ()
+  | _ ->
+    Alcotest.fail
+      "decoder must scrub think text when content_withheld=true, not preserve it"
+
+let test_withheld_think_step_still_requires_text_field () =
+  (* Omitting "text" stays a decode failure. Otherwise a truncated or malformed
+     payload would be read as a legitimate withheld step. *)
+  Alcotest.(check bool) "think step without text rejected even when withheld"
+    true
+    (B.blocks_of_yojson
+       (`List
+          [ `Assoc
+              [ ("t", `String "trace")
+              ; ( "trace"
+                , `List
+                    [ `Assoc
+                        [ ("kind", `String "think")
+                        ; ("content_withheld", `Bool true)
+                        ]
+                    ] )
+              ]
+          ])
+     = None)
+
 let () =
   Alcotest.run "keeper_chat_blocks"
     [
@@ -557,5 +667,13 @@ let () =
             test_redacted_thinking_block_decoder_scrubs_smuggled_content;
           Alcotest.test_case "thinking block requires content" `Quick
             test_thinking_block_requires_content;
+          Alcotest.test_case "withheld think step roundtrip" `Quick
+            test_withheld_think_step_roundtrip;
+          Alcotest.test_case "withheld think encoder scrubs smuggled text" `Quick
+            test_withheld_think_step_encoder_scrubs_smuggled_text;
+          Alcotest.test_case "withheld think decoder scrubs smuggled text" `Quick
+            test_withheld_think_step_decoder_scrubs_smuggled_text;
+          Alcotest.test_case "withheld think step still requires text field" `Quick
+            test_withheld_think_step_still_requires_text_field;
         ] );
     ]

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -1302,6 +1302,7 @@ let test_append_turn_redacts_all_supplied_block_strings () =
               { trace =
                   [ B.Trace_think
                       { text = "thinking " ^ secret
+                      ; content_withheld = false
                       ; ts = Some ("ts-" ^ secret)
                       ; oas_block_index = None
                       }
@@ -1585,6 +1586,7 @@ let test_to_json_array_appends_trace_block_to_assistant_turn () =
                      B.Trace_think
                        {
                          text = "checking tasks";
+                         content_withheld = false;
                          ts = Some "2026-07-01T00:00:00Z";
                          oas_block_index = None;
                        };
@@ -1685,6 +1687,7 @@ let test_to_json_array_stream_contract_trace_join () =
                { trace =
                    [ B.Trace_think
                        { text = "thinking";
+                         content_withheld = false;
                          ts = Some "2026-07-05T00:00:00Z";
                          oas_block_index = None;
                        };
@@ -1804,6 +1807,7 @@ let test_to_json_array_stream_contract_lifecycle_replay () =
                { trace =
                    [ B.Trace_think
                        { text = "retained trace";
+                         content_withheld = false;
                          ts = Some "2026-07-05T00:00:00Z";
                          oas_block_index = None;
                        };


### PR DESCRIPTION
## What changed

- `Trace_think` 에 `content_withheld : bool` 을 추가하고, encoder/decoder 양쪽에서 `content_withheld = true ==> text = ""` 를 강제한다.
- 자율턴 공개 투영이 한국어 문구 대신 이 flag 를 보낸다. 표시 문구는 대시보드가 소유한다.
- `Trace_think` 의 `redacted`(≠) 구분을 `.mli` 와 RFC-0358 §2 에 명시한다.
- 대시보드 정규화가 flag 를 `text` 보다 먼저 읽는다.

## Root cause

`#26804` 는 raw thinking 을 공개 surface 에서 빼기 위해 `text` 자리에 고정 문구 `"내부 판단 단계 (내용 비공개)"` 를 넣었다. 내용은 실제로 보호되지만 두 가지가 남았다.

**1. 같은 리터럴이 3개 언어 6개 파일에 복제됐다.**

```
lib/keeper/keeper_autonomous_turn_source.ml
test/test_keeper_autonomous_turn_source.ml
dashboard/src/demo/keeper-autonomous-public-history-fixture.ts
dashboard/src/components/chat/autonomous-turn-group.test.ts   (2곳)
scripts/harness_dashboard_keeper_autonomous_public_history_dom_smoke.sh   # exact=True
```

CLAUDE.md 의 "같은 리터럴이 2곳 이상 등장하면 named constant" 기준에 걸리고, DOM smoke 가 `exact=True` 로 잡고 있어 문구 변경 시 실패 지점이 원인에서 멀어진다.

**2. wire 의 `Trace_think.text` 가 두 종류의 값을 날랐다.** 다른 경로(`server_dashboard_http_keeper_api_trace.ml`)에서는 실제 thinking 본문, 이 경로에서는 정책 placeholder. 소비자가 둘을 구별할 수단이 없었다.

## 선례를 따랐다

같은 파일의 `RedactedThinking` 처리가 이미 검증된 형태를 갖고 있다.

| 층 | 기존 (`thinking_block`) | 이 PR (`Trace_think`) |
|---|---|---|
| wire | `redacted : bool`, `redacted = true ==> content = ""` | `content_withheld : bool`, `content_withheld = true ==> text = ""` |
| schema | `redacted: optional(boolean())` | `content_withheld: optional(boolean())` |
| 표시 문구 | 대시보드 소유 (`primitives.ts`) | 대시보드 소유 (`primitives.ts`) |

`redacted` 를 재사용하지 않은 이유: 그쪽은 **provider 가 signature 만 보낸 경우**이고 대시보드가 "provider 서명으로만 제공되어 표시할 수 없습니다" 라고 설명한다. 이쪽은 **읽기 경계 정책**이다. 원인이 다르므로 합치면 틀린 이유를 표시하게 된다. `.mli` 와 RFC 양쪽에 이 구분을 적었다.

## 구현 중 발견한 실제 결함

`text: ""` 를 withheld 표현으로 쓰자 자율턴의 activity trace 가 **통째로 사라졌다**.

- `dashboard/src/lib/json-coerce.ts:asString` 은 `""` 를 trim 후 `undefined` 로 보고한다 (부재 취급).
- `keeper-state.ts:normalizeTraceStep` 이 그 step 을 `null` 로 만든다.
- `normalizeTraceSteps` 는 step 하나라도 `null` 이면 **배열 전체를 `null`** 로 만든다.

결과적으로 think 한 단계 때문에 tool step 까지 함께 사라진다. flag 를 `text` 보다 먼저 읽도록 분기 순서를 바꿔 닫았고, 그 순서가 왜 필요한지 음성 대조 테스트로 고정했다 (`drops a think step whose text is empty without the withheld flag`).

## Validation

로컬 실행 결과다.

```
$ dune build --root . test/test_keeper_chat_blocks.exe test/test_keeper_autonomous_turn_source.exe \
    test/test_keeper_chat_store.exe test/test_server_dashboard_http_keeper_api_trace.exe
EXIT=0

$ ./_build/default/test/test_keeper_chat_blocks.exe                      36 tests run
$ ./_build/default/test/test_keeper_autonomous_turn_source.exe            8 tests run
$ ./_build/default/test/test_server_dashboard_http_keeper_api_trace.exe  13 tests run
$ ./_build/default/test/test_keeper_chat_store.exe                       55 tests run

$ ocamlformat --check <touched .ml/.mli>   EXIT=0
$ pnpm typecheck                            EXIT=0
$ pnpm lint                                 EXIT=0
$ pnpm test          Test Files 633 passed (633) / Tests 8772 passed (8772)
$ bash -n scripts/harness_...dom_smoke.sh   문법 OK (embedded python 도 compile 통과)
```

`dune build` 는 `--root .` 를 명시했다. 생략하면 dune 이 상위로 올라가 부모 checkout 을 root 로 잡아 워크트리 변경이 아닌 부모 바이너리를 빌드한다 (이번에 실제로 겪었다).

Playwright DOM smoke 는 로컬에서 실행하지 않았다. 대신 스크립트에 flag 가 DOM 에 도달했는지 확인하는 단언을 추가했다 — 렌더된 문자열만 보면 서버가 다시 `text` 에 문구를 실어도 통과하기 때문이다.

```python
think = activity.locator('[data-chat-trace-step="think"]')
assert think.get_attribute("data-chat-trace-content-withheld") == "true"
```

## 추가 테스트

`test_keeper_chat_blocks.ml` 에 4건.

- withheld step roundtrip (wire 에 `text: ""` + `content_withheld: true`)
- encoder 가 밀반입된 text 를 지운다
- decoder 가 밀반입된 text 를 지운다
- `text` key 자체가 없으면 flag 가 있어도 decode 실패 — 잘린 payload 가 정당한 withheld step 으로 읽히지 않게

RFC-WAIVED: `lib/keeper/keeper_chat_blocks*`, `dashboard/src/keeper-state.ts` 는 RFC 사전 발견 대상 subsystem (credential/identity/operator/sandbox/hooks) 이 아니다. 대신 이 변경이 건드리는 계약인 RFC-0358 §2 를 같은 PR 에서 갱신했다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
