### PR TITLE
refactor(workspace): drop the self-referential evidence content hash

### DIFF
--- a/lib/workspace/workspace_verification_store.ml
+++ b/lib/workspace/workspace_verification_store.ml
@@ -23,7 +23,6 @@ type submitted_evidence_item =
       ; content : string
       ; bytes : int
       ; truncated : bool
-      ; content_sha256 : string
       }
   | Evidence_invalid_reference
   | Evidence_artifact_unreadable of
@@ -85,21 +84,16 @@ let evidence_read_failure_of_yojson = function
      | _ -> Error "submitted evidence snapshot has an invalid unreadable reason")
   | _ -> Error "submitted evidence snapshot unreadable reason must be an object"
 
-let content_sha256 content =
-  Digestif.SHA256.(digest_string content |> to_hex)
-
 let submitted_evidence_item_to_yojson = function
   | Evidence_note note ->
     `Assoc [ "kind", `String "note"; "content", `String note ]
-  | Evidence_artifact
-      { reference; content; bytes; truncated; content_sha256 } ->
+  | Evidence_artifact { reference; content; bytes; truncated } ->
     `Assoc
       [ "kind", `String "artifact"
       ; "reference", `String reference
       ; "content", `String content
       ; "bytes", `Int bytes
       ; "truncated", `Bool truncated
-      ; "content_sha256", `String content_sha256
       ]
   | Evidence_invalid_reference ->
     `Assoc
@@ -169,18 +163,13 @@ let submitted_evidence_access_to_yojson = function
 
 let submitted_evidence_item_metadata_to_yojson = function
   | Evidence_note note ->
-    `Assoc
-      [ "kind", `String "note"
-      ; "bytes", `Int (String.length note)
-      ; "content_sha256", `String (content_sha256 note)
-      ]
-  | Evidence_artifact { reference; bytes; truncated; content_sha256; _ } ->
+    `Assoc [ "kind", `String "note"; "bytes", `Int (String.length note) ]
+  | Evidence_artifact { reference; bytes; truncated; _ } ->
     `Assoc
       [ "kind", `String "artifact"
       ; "reference", `String reference
       ; "bytes", `Int bytes
       ; "truncated", `Bool truncated
-      ; "content_sha256", `String content_sha256
       ]
   | Evidence_invalid_reference ->
     `Assoc
@@ -239,7 +228,6 @@ let submitted_evidence_item_of_yojson = function
        let open Result.Syntax in
        let* reference = string_field "reference" in
        let* content = string_field "content" in
-       let* expected_content_sha256 = string_field "content_sha256" in
        let* bytes =
          match List.assoc_opt "bytes" fields with
          | Some (`Int value) when value >= 0 -> Ok value
@@ -261,15 +249,7 @@ let submitted_evidence_item_of_yojson = function
          | None -> Error "submitted evidence snapshot is missing truncated"
        in
        let content_bytes = String.length content in
-       if
-         not
-           (String.equal
-              expected_content_sha256
-              (content_sha256 content))
-       then
-         Error
-           "submitted evidence snapshot content_sha256 does not match persisted content"
-       else if truncated && bytes <= content_bytes
+       if truncated && bytes <= content_bytes
        then
          Error
            "truncated submitted evidence snapshot must report more source bytes than persisted content"
@@ -277,15 +257,7 @@ let submitted_evidence_item_of_yojson = function
        then
          Error
            "non-truncated submitted evidence snapshot bytes must equal persisted content length"
-       else
-         Ok
-           (Evidence_artifact
-              { reference
-              ; content
-              ; bytes
-              ; truncated
-              ; content_sha256 = expected_content_sha256
-              })
+       else Ok (Evidence_artifact { reference; content; bytes; truncated })
      | Some (`String "artifact_unreadable") ->
        let open Result.Syntax in
        let field_names =
@@ -573,13 +545,7 @@ let inspect_producer_relative_artifact ~base_path ~worker ~reference relative_pa
     | Error reason ->
       Evidence_artifact_unreadable { reference; reason }
     | Ok (content, bytes, truncated) ->
-      Evidence_artifact
-        { reference
-        ; content
-        ; bytes
-        ; truncated
-        ; content_sha256 = content_sha256 content
-        }
+      Evidence_artifact { reference; content; bytes; truncated }
 
 let snapshot_submitted_evidence_item ~base_path ~worker reference =
   match strip_prefix ~prefix:artifact_reference_prefix reference with

--- a/lib/workspace/workspace_verification_store.mli
+++ b/lib/workspace/workspace_verification_store.mli
@@ -21,7 +21,6 @@ type submitted_evidence_item =
       ; content : string
       ; bytes : int
       ; truncated : bool
-      ; content_sha256 : string
       }
   | Evidence_invalid_reference
   | Evidence_artifact_unreadable of
@@ -70,10 +69,10 @@ val snapshot_submitted_evidence_json :
   Yojson.Safe.t
 (** Materialize submitted evidence once at the producer's submit boundary.
     ["artifact:<relative-path>"] is rooted at the producer's declared sandbox;
-    ["note:<text>"] preserves non-file evidence explicitly.
-    [content_sha256] covers the bounded UTF-8 content persisted in the
-    snapshot, not bytes omitted beyond the projection cap. Bare and absolute
-    references are persisted as a payload-free typed invalid-reference item. *)
+    ["note:<text>"] preserves non-file evidence explicitly. [bytes] reports the
+    source size, which exceeds the persisted [content] length when [truncated]
+    is set by the projection cap. Bare and absolute references are persisted as
+    a payload-free typed invalid-reference item. *)
 val inspect_submitted_evidence_for_authority :
   base_path:string ->
   request_id:string ->

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -1601,6 +1601,72 @@ let test_submitted_evidence_inspection_rejects_cross_playground_path () =
       ()
     | _ -> Alcotest.fail "cross-playground artifact must remain unreadable")
 
+(* Records written before [content_sha256] was dropped still carry it: 58
+   evidence items in the live store are shaped this way. The artifact branch
+   must ignore the extra field rather than reject the record, and it must no
+   longer validate it — the hash below is deliberately wrong, so this decodes
+   only because the check is gone. *)
+let test_submitted_evidence_decodes_legacy_content_sha256 () =
+  with_eio_temp_dir (fun base_path ->
+    let profile_path =
+      Keeper_sandbox_config.keeper_toml_path
+        ~base_path
+        ~agent_name:"keeper-executor-agent"
+    in
+    Fs_compat.mkdir_p (Filename.dirname profile_path);
+    Fs_compat.save_file profile_path "[keeper]\nsandbox_profile = \"docker\"\n";
+    let request_id = "vrf-legacy-content-sha256" in
+    let content = "legacy artifact body" in
+    let legacy_snapshot =
+      `List
+        [ `Assoc
+            [ "kind", `String "artifact"
+            ; "reference", `String "artifact:artifacts/legacy.txt"
+            ; "content", `String content
+            ; "bytes", `Int (String.length content)
+            ; "truncated", `Bool false
+            ; ( "content_sha256"
+              , `String (String.make 64 '0') )
+            ]
+        ; `Assoc [ "kind", `String "note"; "content", `String "executor summary" ]
+        ]
+    in
+    (match
+       V.create_request
+         ~base_path
+         ~request_id
+         ~task_id:"task-001"
+         ~output:(`Assoc [ "submitted_evidence", legacy_snapshot ])
+         ~criteria:[ V.Custom "inspect artifact" ]
+         ~worker:"keeper-executor-agent"
+         ()
+     with
+     | Ok _ -> ()
+     | Error detail -> Alcotest.fail detail);
+    match inspect_evidence ~base_path ~request_id () with
+    | VS.Evidence_available
+        { items =
+            VS.Evidence_artifact
+              { reference; content = decoded; truncated = false; _ }
+            :: VS.Evidence_note "executor summary"
+            :: []
+        ; _
+        } ->
+      Alcotest.(check string)
+        "legacy record keeps its artifact reference"
+        "artifact:artifacts/legacy.txt"
+        reference;
+      Alcotest.(check string)
+        "legacy record keeps its persisted content"
+        content
+        decoded
+    | VS.Evidence_unavailable { reason; _ } ->
+      Alcotest.failf
+        "legacy record was rejected: %s"
+        (VS.evidence_access_failure_to_string ~request_id reason)
+    | VS.Evidence_available _ ->
+      Alcotest.fail "expected the legacy record to decode as artifact + note")
+
 let test_submitted_evidence_inspection_is_bounded_and_utf8_safe () =
   with_eio_temp_dir (fun base_path ->
     let artifact_dir =
@@ -1962,6 +2028,8 @@ let () =
         test_submitted_evidence_inspection_rejects_cross_playground_path;
       Alcotest.test_case "submitted evidence bounded UTF-8" `Quick
         test_submitted_evidence_inspection_is_bounded_and_utf8_safe;
+      Alcotest.test_case "submitted evidence decodes legacy content_sha256" `Quick
+        test_submitted_evidence_decodes_legacy_content_sha256;
       Alcotest.test_case "submitted evidence rejects malformed UTF-8" `Quick
         test_submitted_evidence_rejects_malformed_utf8;
       Alcotest.test_case "submitted evidence rejects symlink and FIFO" `Quick

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -249,7 +249,6 @@ let test_system_llm_review_notes_are_metadata_only () =
               ; content = "secret artifact content must not be duplicated"
               ; bytes = 42
               ; truncated = true
-              ; content_sha256 = "sha256-proof"
               }
           ; VS.Evidence_artifact_unreadable
               { reference = "artifact:missing.txt"; reason = VS.Evidence_missing }
@@ -295,15 +294,9 @@ let test_system_llm_review_notes_are_metadata_only () =
     false
     (contains_substring notes "secret criterion should stay in the audit store");
   Alcotest.(check bool)
-    "artifact hash remains observable"
+    "artifact reference remains observable"
     true
-    (contains_substring notes "sha256-proof");
-  Alcotest.(check bool)
-    "note hash remains observable"
-    true
-    (contains_substring
-       notes
-       (Digestif.SHA256.(digest_string "secret narrative must not be duplicated" |> to_hex)));
+    (contains_substring notes "artifact:proof.txt");
   Alcotest.(check bool)
     "truncation remains observable"
     true
@@ -1365,19 +1358,15 @@ let test_submit_snapshot_resolves_docker_relative_artifact_and_explicit_note () 
     | VS.Evidence_available
         { items =
             VS.Evidence_artifact
-              { reference = "artifact:artifacts/proof.txt"
-              ; content = "docker-relative-proof"
-              ; content_sha256
-              ; _
-              }
+              { reference = "artifact:artifacts/proof.txt"; content; _ }
             :: VS.Evidence_note "executor summary"
             :: []
         ; _
         } ->
       Alcotest.(check string)
-        "snapshot hash covers persisted bounded content"
-        Digestif.SHA256.(digest_string "docker-relative-proof" |> to_hex)
-        content_sha256
+        "snapshot persists the bounded artifact content"
+        "docker-relative-proof"
+        content
     | _ ->
       (match
          inspect_evidence


### PR DESCRIPTION
## 무엇을

검증 증거의 `content_sha256` 을 제거한다. 타입, 영속 스냅샷, authority 메타데이터 투영, 디코더 전부.

이 필드는 두 경로에 나타나고 **성립하지 않는 이유가 서로 다르다.** 나눠서 적는다.

## 경로 1 — 스냅샷 디코더: 자기참조

```ocaml
let* content = string_field "content" in
let* expected_content_sha256 = string_field "content_sha256" in
...
if not (String.equal expected_content_sha256 (content_sha256 content))
then Error "submitted evidence snapshot content_sha256 does not match persisted content"
```

해시와 그 대상이 같은 JSON 객체 안에 있고, 같은 코드 경로가 같은 순간에 함께 쓴다. 대조할 독립 사본이 없다. 실패 가능한 유일한 경우는 JSON 파일 손상이며 그건 파싱이 이미 거부한다.

## 경로 2 — 메타데이터 투영: 자기참조는 아니지만 소비자가 없다

`submitted_evidence_item_metadata_to_yojson` 은 `content` 를 **빼고** 해시만 낸다(리댁션이 의도된 설계). 그래서 이 해시는 다른 파일(`.masc/verifications/vrf-*.json`)에 있는 내용에 대한 커밋먼트다 — 구조적으로는 정당하다.

그런데 값이 없다. 세 가지가 겹친다.

1. **검사하는 코드가 없다.** `submitted_evidence_access_metadata_to_yojson` 호출처는 `completion_authority_agent.ml:128` 한 곳이고 notes 에 쓰기만 한다. 그 해시를 읽어 비교하는 코드가 `lib/`, `test/`, `dashboard/src/` 어디에도 없다. 검사되지 않는 커밋먼트는 보증이 아니다.
2. **LLM 검증자가 쓸 수 없다.** 메타데이터는 검증자 컨텍스트로 가는데 검증자는 `content` 를 못 본다(리댁션). 볼 수 없는 것의 해시는 불투명한 64 자이며 매 검증 프롬프트마다 토큰만 소비한다.
3. **디스크 대조에도 못 쓴다.** `.mli` 가 직접 범위를 밝힌다 — *"covers the bounded UTF-8 content persisted in the snapshot, **not bytes omitted beyond the projection cap**"*. `truncated = true` 면 해시는 잘린 앞부분만 덮으므로 원본 파일 해시와 다르다. 외부 감사가 이 값을 파일과 맞춰 보는 것은 `truncated = false` 일 때만 우연히 성립한다.

라이브: `.masc/verifications` 77 건, 이 검사가 거부를 낸 기록 0 건.

## 유지한 것

정보를 내는 경계 불변식은 그대로 둔다.

- `truncated` 일 때 `bytes > 영속된 content 길이`
- `truncated` 아닐 때 `bytes = content 길이`

이 둘은 **서로 다른 두 값**(선언된 원본 크기 vs 실제 영속된 길이)을 비교하므로 실제로 정보를 낸다. 제거한 해시 검사는 같은 객체 안 이웃 필드를 비교했다.

## 마이그레이션 없음

기존 레코드는 디스크에 잔여 필드를 둔 채 남는다. `artifact` 분기는 필요한 필드만 읽고 나머지를 무시한다(미선언 필드 거부는 `artifact_unreadable` 분기에만 있다). 레거시 호환 코드를 추가하지 않는다.

## 테스트

- `"artifact hash remains observable"` / `"note hash remains observable"` → `artifact:proof.txt` 참조 관측 단언으로 교체. 단언을 지우기만 하면 "메타데이터가 내용을 복제하지 않으면서도 항목별로 무언가는 관측 가능한가" 커버리지가 조용히 줄어든다.
- docker-relative 스냅샷 테스트: 다이제스트 재계산 대신 영속된 content 를 단언
- 리댁션 보증(증거 내용·criteria 가 task notes 로 복제되지 않음)은 변경 없음, 계속 커버됨

## 로컬 검증

```
dune build --root . @check                       exit 0
dune exec --root . test/test_verification.exe    Test Successful, 40 tests run
```

`--root .` 가 필요하다: 워크트리에서 그냥 `dune build` 하면 부모 체크아웃으로 올라가 그쪽 코드를 빌드한다(가짜 green).

## 미검증

- CI 의 다른 매트릭스 레그(OCaml 버전 차이)는 로컬에서 확인하지 않았다
- 검증 프롬프트 토큰 감소량은 측정하지 않았다. 항목당 약 64 자 + 필드명이라는 산술만 있고 실측이 없다

RFC-WAIVED: 소비자 0 인 필드 1 개 제거. 새 계약·경계·상태를 도입하지 않으며 blast radius 는 단일 모듈과 그 테스트에 한정된다.

WORKAROUND-WAIVED: 이 PR 은 워크어라운드를 추가하지 않고 제거한다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
