### PR TITLE
fix(keeper): 미선언 필드 거부에 허용 필드 목록을 담는다 (위임 실패 43건)

### DIFF
--- a/lib/keeper/keeper_invocation_contract.ml
+++ b/lib/keeper/keeper_invocation_contract.ml
@@ -60,9 +60,16 @@ let exact_fields ~field ~allowed fields =
     match List.find_opt (fun key -> not (List.mem key allowed)) keys with
     | None -> Ok ()
     | Some key ->
+      (* [allowed] is the answer the caller is looking for, and dropping it
+         made the rejection unactionable: live logs carry taskmaster trying
+         target.agent, then target.keeper_name, then target.keeper, one per
+         call, against an allowed list of kind and name. Naming the accepted
+         fields turns three round trips into one. *)
       invalid_wire_value
         ~field:(field ^ "." ^ key)
-        ~expected:"no undeclared field"
+        ~expected:
+          (Printf.sprintf "no undeclared field; accepted: %s"
+             (String.concat ", " allowed))
 ;;
 
 let required_field ~field name fields =

--- a/test/dune
+++ b/test/dune
@@ -625,6 +625,11 @@
 ; an explicit executable stanza instead of borrowing the pure synchronous test
 ; group above.
 (test
+ (name test_keeper_invocation_contract_hints)
+ (modules test_keeper_invocation_contract_hints)
+ (libraries alcotest masc_test_deps))
+
+(test
  (name test_keeper_event_queue_state_v2)
  (modules test_keeper_event_queue_state_v2)
  (libraries alcotest masc_test_deps masc.keeper_checkpoint_ref))

--- a/test/test_keeper_invocation_contract_hints.ml
+++ b/test/test_keeper_invocation_contract_hints.ml
@@ -1,0 +1,63 @@
+(** An undeclared-field rejection names the fields that are accepted.
+
+    Live tool-call logs show the cost of the previous message. masc_keeper_delegate
+    failed 43 times out of 171, and the failures are field-name guesses:
+    target.agent, then target.keeper_name, then target.keeper, one per call,
+    against an allowed list of [kind; name]. The rejection said only
+    "no undeclared field", so each attempt was a fresh guess. *)
+
+module C = Masc.Keeper_invocation_contract
+
+let message_of_target_json json =
+  match C.target_of_json json with
+  | Ok _ -> None
+  | Error err -> Some (C.request_error_to_string err)
+
+let contains ~needle haystack =
+  let nl = String.length needle and hl = String.length haystack in
+  let rec go i = i + nl <= hl && (String.sub haystack i nl = needle || go (i + 1)) in
+  nl = 0 || go 0
+
+let test_undeclared_field_names_the_accepted_set () =
+  (* The exact shape taskmaster sent. *)
+  let json = `Assoc [ "agent", `String "analyst" ] in
+  match message_of_target_json json with
+  | None -> Alcotest.fail "expected target.agent to be rejected"
+  | Some msg ->
+    Alcotest.(check bool) "names the offending field" true
+      (contains ~needle:"target.agent" msg);
+    Alcotest.(check bool) "names the accepted fields" true
+      (contains ~needle:"accepted: kind, name" msg)
+
+let test_other_guessed_names_get_the_same_hint () =
+  List.iter
+    (fun field ->
+      let json = `Assoc [ field, `String "analyst" ] in
+      match message_of_target_json json with
+      | None -> Alcotest.failf "expected target.%s to be rejected" field
+      | Some msg ->
+        Alcotest.(check bool)
+          (Printf.sprintf "target.%s hint lists accepted fields" field)
+          true
+          (contains ~needle:"accepted: kind, name" msg))
+    [ "keeper_name"; "keeper" ]
+
+let test_valid_target_still_parses () =
+  let json = `Assoc [ "kind", `String "keeper"; "name", `String "analyst" ] in
+  match C.target_of_json json with
+  | Ok _ -> ()
+  | Error err ->
+    Alcotest.failf "expected a kind/name target to parse, got %s"
+      (C.request_error_to_string err)
+
+let () =
+  Alcotest.run "keeper_invocation_contract_hints"
+    [ ( "undeclared_field_hint"
+      , [ Alcotest.test_case "names the accepted set" `Quick
+            test_undeclared_field_names_the_accepted_set
+        ; Alcotest.test_case "same hint for other guesses" `Quick
+            test_other_guessed_names_get_the_same_hint
+        ; Alcotest.test_case "a valid target still parses" `Quick
+            test_valid_target_still_parses
+        ] )
+    ]


### PR DESCRIPTION
## 문제

`exact_fields` 는 허용 목록을 이미 들고 있으면서 버립니다:

```ocaml
let exact_fields ~field ~allowed fields =
  ...
  | Some key ->
    invalid_wire_value ~field:(field ^ "." ^ key)
                       ~expected:"no undeclared field"    (* allowed 를 버림 *)
```

호출자는 **어느 필드가 틀렸는지는 알고 어느 것이 맞는지는 모릅니다.**

## 라이브 비용

`masc_keeper_delegate` 171건 중 **43건 실패**. 전부 필드명 추측입니다 — 허용 목록은 `["kind"; "name"]` 인데:

```
target.agent must be no undeclared field
target.keeper_name must be no undeclared field
target.keeper must be no undeclared field
target.kind must be required field
```

**한 왕복에 한 번씩 추측**하고, 각 거부가 앞선 것보다 더 알려주는 게 없습니다.

같은 형태를 이 워크스페이스에서 이미 봤습니다: `keeper_task_claim` 실패 135건에서 taskmaster 가 task-145,146,148,150,151,152,153,154 를 차례로 시도하고 전부 거부당했습니다 (#26838). **후보를 순회하는 호출자는 후보들이 원인을 공유한다는 걸 듣지 못한 상태입니다.**

## 변경

```
no undeclared field
  →  no undeclared field; accepted: kind, name
```

한 줄입니다. 정답이 이미 그 함수의 인자에 있었습니다.

## #26821 과의 짝

`#26821` 이 keeper·persona 스키마 11개를 닫아 미선언 필드가 조용히 버려지는 대신 거부되게 했습니다. **닫은 건 맞습니다.** 다만 안내 없는 닫힌 문은 추측의 위치만 옮깁니다 — 조용한 무시에서 조용한 거부로.

## 검증

- `dune build --root . @check` — exit 0
- 신규 `test_keeper_invocation_contract_hints` **3/3**: 로그에 실제로 나온 형태(`target.agent`, `target.keeper_name`, `target.keeper`)에 힌트가 붙는지, 그리고 유효한 `kind`/`name` target 이 여전히 파싱되는지
- **Negative control**: 메시지를 옛 문자열로 되돌리면 힌트 단언 2건이 실패하고 파싱 단언은 통과합니다. 테스트가 이 변경에 종속됨을 확인했습니다.

## 범위

`exact_fields` 는 `keeper_invocation_contract.ml` 안에서 3곳(`target`, 그리고 112·209행)에서 호출됩니다. 이 변경은 세 곳 모두에 적용되며, 각 호출자의 `allowed` 목록이 그대로 메시지에 실립니다.

RFC-WAIVED: 오류 메시지에 이미 보유한 정보를 싣는 변경. credential / identity / operator control plane / keeper sandbox / dashboard credential / hooks / workflow 문서 중 어느 것도 건드리지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)