### PR TITLE
fix(board): 코드 스팬 안의 @ 를 주소로 읽지 않는다

### DIFF
--- a/lib/board_addressing/board_addressing.ml
+++ b/lib/board_addressing/board_addressing.ml
@@ -26,7 +26,59 @@ let trim_token_edges value =
   if !last < !first then "" else String.sub value !first (!last - !first + 1)
 ;;
 
+(* Markdown code spans and fences are not address text. A comment that
+   mentions `@internals/libs/datadogRum`, `@/lib/constants` or `@@` is
+   discussing code, and tokenizing inside those regions turns every such
+   comment into Malformed_targets and rejects it whole. Live board comments
+   carry exactly those three shapes.
+
+   Blanking rather than deleting keeps the surrounding text separated: a
+   fence between two words must not join them into one token. Content is
+   replaced with spaces so offsets and word boundaries survive.
+
+   An unterminated backtick blanks to end of text. That is the fail-closed
+   direction for this function: an author who opened a code span and did not
+   close it addressed nobody after it. *)
+let blank_code_regions text =
+  let length = String.length text in
+  let buffer = Bytes.of_string text in
+  let blank_range start stop =
+    for index = start to min stop (length - 1) do
+      Bytes.set buffer index ' '
+    done
+  in
+  let run_length_at index =
+    let rec count offset =
+      if index + offset < length && text.[index + offset] = '`' then count (offset + 1)
+      else offset
+    in
+    count 0
+  in
+  let rec scan index =
+    if index >= length then ()
+    else if text.[index] = '`' then (
+      let opener = run_length_at index in
+      let body = index + opener in
+      let rec find_close cursor =
+        if cursor >= length then None
+        else if text.[cursor] = '`' && run_length_at cursor = opener then Some cursor
+        else find_close (cursor + 1)
+      in
+      match find_close body with
+      | Some closer ->
+        blank_range index (closer + opener - 1);
+        scan (closer + opener)
+      | None ->
+        blank_range index (length - 1);
+        ())
+    else scan (index + 1)
+  in
+  scan 0;
+  Bytes.to_string buffer
+;;
+
 let tokens_of_text text =
+  let text = blank_code_regions text in
   text
   |> String.map (function
     | '\t' | '\n' | '\r' -> ' '

--- a/test/board_addressing/test_board_addressing.ml
+++ b/test/board_addressing/test_board_addressing.ml
@@ -77,6 +77,37 @@ let test_parse_broadcast () =
   check_parse "unsupported broadcast hides direct targets" "unsupported:analyst"
     "@@analyst and @alpha"
 
+(* Code spans are not address text. Every one of these strings appeared in a
+   live keeper_board_comment that was rejected whole: @internals/libs/datadogRum
+   is an npm scope, @/lib/constants is a path alias, @@ is an OCaml operator.
+   Board validates candidates fail-closed, which is right for a mistyped
+   address and wrong for an @ that was never an address. *)
+let test_parse_code_spans () =
+  check_parse "npm scope in a code span is not a target" "none"
+    "see `@internals/libs/datadogRum` for the setup";
+  check_parse "path alias in a code span is not a target" "none"
+    "the fix renames `@/lib/constents` to `@/lib/constants`";
+  check_parse "operator in a code span is not a broadcast selector" "none"
+    "use `f @@ x` instead of the parens";
+  check_parse "fenced block is not address text" "none"
+    "before\n```\n@@all\n@alpha\n```\nafter";
+  (* A real address outside the span still parses. *)
+  check_parse "target outside a code span still parses" "targets:alpha"
+    "@alpha please look at `@/lib/constants`";
+  check_parse "broadcast outside a code span still parses" "broadcast"
+    "@@all see `@internals/libs/errors`";
+  (* Blanking must separate, not delete: a span between two tokens keeps them
+     apart instead of splicing them into one. Here the trailing @internals/...
+     sits outside the span, so it is still a candidate and still fails closed
+     -- the point is that it is a separate candidate rather than glued onto
+     alpha. *)
+  check_parse "blanked span separates rather than joins"
+    "targets:alpha,internals/libs/datadogRum"
+    "@alpha`x`@internals/libs/datadogRum";
+  (* An unterminated span addresses nobody after it: fail-closed direction. *)
+  check_parse "unterminated span swallows the rest" "none"
+    "opening `@alpha and never closing"
+
 let () =
   run "board_addressing"
     [ ( "tokenization",
@@ -84,4 +115,5 @@ let () =
           test_case "tokens_of_text" `Quick test_tokens_of_text ] );
       ( "parse",
         [ test_case "targets" `Quick test_parse_targets;
-          test_case "broadcast" `Quick test_parse_broadcast ] ) ]
+          test_case "broadcast" `Quick test_parse_broadcast;
+          test_case "code spans" `Quick test_parse_code_spans ] ) ]


### PR DESCRIPTION
Closes #26849

## 문제

Board 댓글은 `@` 토큰이 유효한 keeper 가 아니면 **통째로 거부**된다. 문서화된 fail-closed 정책이고, 주소를 잘못 쓴 경우에는 옳다.

주소가 아닌 `@` 에는 틀렸다. 파서가 본문 전체를 토큰화하므로 **둘을 구별하지 못한다.**

라이브 `keeper_board_comment` 실패는 전부 후자다:

```
invalid Board target token(s): @internals/libs/datadogRum   ← npm 스코프
invalid Board target token(s): @/lib/constants              ← 경로 alias
unsupported Board broadcast selector(s): @@                 ← OCaml 연산자
```

sangsu 는 2026-08-04 21:50~21:52 에 오타 수정 (`@/lib/constents` → `@/lib/constants`) 을 설명하려다 **3분간 4번 연속 실패**했다.

**즉 코드 이야기를 하는 것이 댓글을 막는다.**

## 왜 이 표면이 중요한가

Board 댓글은 이 워크스페이스에서 **작동하는 협업 표면**이다.

```
185 댓글 / 88 post
댓글 2개 이상          33 post
서로 다른 keeper 2명+  26 post
최장 스레드            9턴 (rondo ↔ sangsu PR 리뷰)
```

그리고 2026-08-03 을 경계로 도구별 실패를 나누면 **여기만 늘었다**:

```
tool                    ~08-02   08-03~
Read                      1706        9
Execute                    685       47
masc_transition            127       26
keeper_task_claim          122       13
keeper_board_comment         4       10    ← 유일한 증가
```

## 변경

`tokens_of_text` 가 분할 전에 마크다운 코드 스팬과 펜스를 공백으로 치환한다.

**삭제가 아니라 공백화**인 이유: 스팬이 양옆 토큰을 붙여 하나로 만들면 안 된다. `@alpha` 뒤에 붙은 스팬은 뒤 토큰을 분리된 후보로 남긴다.

닫히지 않은 백틱은 끝까지 공백화한다. 이 함수에서의 fail-closed 방향이다 — 스팬을 열고 닫지 않은 작성자는 그 뒤로 아무도 주소하지 않았다.

## 정책은 그대로다

후보는 여전히 `Agent_id.of_string` 을 통과해야 하고 여전히 fail-closed 다. **후보 집합만 바뀌며, 애초에 아무도 주소하지 않던 텍스트를 제외하는 방향으로만 바뀐다.**

`Agent_id` 를 느슨하게 하거나 알 수 없는 `@` 를 조용히 무시하는 방향은 택하지 않았다. 그것은 이 저장소가 거부하는 Unknown → Permissive Default 다.

## 검증

- `dune build --root . @check` — exit 0
- `test_board_addressing` **5/5** — 거부된 댓글의 실제 문자열을 그대로 사용하고, 스팬 밖의 진짜 주소와 broadcast 가 여전히 파싱되는지, 공백화가 이웃을 잇지 않고 분리하는지 검사
- **Negative control**: `blank_code_regions` 호출을 제거하면 npm 스코프 케이스가 실패한다
- `test_keeper_lane_mentions` 1 failure, `test_board_dispatch` 3 failures 는 **기존 실패** — 이 변경을 stash 한 상태에서 동일하게 재현된다

## 범위

`Board_addressing.parse` 는 `board_audience`(Board 쓰기) 와 `keeper_lane_mentions`(Keeper 레인) 두 소비자가 공유한다. 이 변경은 양쪽에 적용되며, 양쪽 모두 코드 스팬 안의 `@` 를 주소로 읽지 않게 된다.

RFC-WAIVED: 공유 주소 문법의 토큰화 범위 조정. credential / identity / operator control plane / keeper sandbox / dashboard credential / hooks / workflow 문서 중 어느 것도 건드리지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)