### PR TITLE
feat(core): read-drop 사유에 Tail_partial_write 추가 (어휘만)

### DIFF
--- a/lib/core/read_drop_reason.ml
+++ b/lib/core/read_drop_reason.ml
@@ -26,6 +26,11 @@ type t =
   | Stat_error
   | Concurrent_removal (* RFC-0134 PR-1. *)
   | Transient_fd_pressure (* RFC-0134 PR-1. *)
+  | Tail_partial_write
+      (* RFC-0134 classification: the last line of an append-only file was
+         still being written when the reader reached it. Not data loss; the
+         reader skips to the previous complete line and the next read sees
+         the row whole. *)
   | Other of string
 
 let to_wire = function
@@ -40,6 +45,7 @@ let to_wire = function
   | Stat_error -> "stat_error"
   | Concurrent_removal -> "concurrent_removal"
   | Transient_fd_pressure -> "transient_fd_pressure"
+  | Tail_partial_write -> "tail_partial_write"
   | Other s -> s
 ;;
 
@@ -55,6 +61,7 @@ let of_wire = function
   | "stat_error" -> Stat_error
   | "concurrent_removal" -> Concurrent_removal
   | "transient_fd_pressure" -> Transient_fd_pressure
+  | "tail_partial_write" -> Tail_partial_write
   | s -> Other s
 ;;
 
@@ -70,7 +77,8 @@ let equal a b =
   | Path_normalization_error, Path_normalization_error
   | Stat_error, Stat_error
   | Concurrent_removal, Concurrent_removal
-  | Transient_fd_pressure, Transient_fd_pressure -> true
+  | Transient_fd_pressure, Transient_fd_pressure
+  | Tail_partial_write, Tail_partial_write -> true
   | Other a, Other b -> String.equal a b
   | List_dir_error, _
   | Entry_load_error, _
@@ -83,6 +91,7 @@ let equal a b =
   | Stat_error, _
   | Concurrent_removal, _
   | Transient_fd_pressure, _
+  | Tail_partial_write, _
   | Other _, _ -> false
 ;;
 

--- a/lib/core/read_drop_reason.mli
+++ b/lib/core/read_drop_reason.mli
@@ -44,6 +44,14 @@ type t =
           RFC-0097 backpressure. PR-3 of RFC-0134 routes this to a
           DEBUG line (or a separate metric in PR-4), not the
           data-integrity counter. *)
+  | Tail_partial_write
+  (** RFC-0134 classification. The last line of an append-only file was
+          still being written when a tail reader reached it, so it parses
+          as truncated JSON. Not data loss: the reader skips to the
+          previous complete line and the next read sees the row whole.
+          Belongs with [Concurrent_removal] and [Transient_fd_pressure]
+          on the not-a-loss side rather than on the data-integrity
+          counter. *)
   | Other of string
   (** Escape hatch for one-off surfaces. PR introducing a new
           [Other] payload must justify why the value cannot be
@@ -70,6 +78,7 @@ type t =
     - [Stat_error] → ["stat_error"]
     - [Concurrent_removal] → ["concurrent_removal"] (RFC-0134 PR-1)
     - [Transient_fd_pressure] → ["transient_fd_pressure"] (RFC-0134 PR-1)
+    - [Tail_partial_write] → ["tail_partial_write"] (RFC-0134)
     - [Other s] → [s] (verbatim) *)
 val to_wire : t -> string
 

--- a/lib/core/safe_ops.ml
+++ b/lib/core/safe_ops.ml
@@ -400,6 +400,13 @@ let persistence_read_drop_reason_entry_load_error = "entry_load_error"
 let persistence_read_drop_reason_invalid_payload = "invalid_payload"
 let persistence_read_drop_reason_json_syntax_error = "json_syntax_error"
 
+(* The last line of an append-only file was still being written when a tail
+   reader reached it. Kept apart from [entry_load_error] because it is not a
+   loss: the reader falls through to the previous complete line and the next
+   read sees the row whole. Same not-a-loss family as RFC-0134's
+   [concurrent_removal] and [transient_fd_pressure]. *)
+let persistence_read_drop_reason_tail_partial_write = "tail_partial_write"
+
 let report_persistence_read_drop ~on_drop ~surface ~reason ~path ~detail =
   Log.Misc.warn "[%s] persistence read drop (%s) path=%s: %s"
     surface reason path detail;

--- a/lib/core/safe_ops.mli
+++ b/lib/core/safe_ops.mli
@@ -108,6 +108,10 @@ val persistence_read_drop_reason_invalid_payload : string
     (e.g. record-of-yojson [Error _], required field missing). *)
 
 val persistence_read_drop_reason_json_syntax_error : string
+
+val persistence_read_drop_reason_tail_partial_write : string
+(** The final line of an append-only file was mid-write when a tail reader
+    parsed it. Not data loss; see [Read_drop_reason.Tail_partial_write]. *)
 (** [Yojson.Json_error] raised while parsing a single line/value.  Use
     this when the load step is logically split from the parse step
     (typical of JSONL surfaces) so the metric distinguishes "file

--- a/test/test_read_drop_reason.ml
+++ b/test/test_read_drop_reason.ml
@@ -27,7 +27,41 @@ let canonical : (string * R.t) list =
   ; (* RFC-0134 PR-1. *)
     "Concurrent_removal", R.Concurrent_removal
   ; "Transient_fd_pressure", R.Transient_fd_pressure
+  ; (* RFC-0134, same not-a-loss family: the final line of an append-only
+       file caught mid-write by a tail reader. *)
+    "Tail_partial_write", R.Tail_partial_write
   ]
+;;
+
+(* [canonical] is hand-maintained, so a new constructor is only covered once
+   it is listed above. This pins the count so adding a variant without
+   listing it fails here rather than silently skipping the round-trip and
+   wire-stability checks. *)
+let test_canonical_covers_every_constructor () =
+  Alcotest.(check int) "canonical entry count" 12 (List.length canonical)
+;;
+
+(* The reason exists to keep an append-race off the data-integrity counter,
+   so the one thing that must never drift is its distinctness from
+   [Entry_load_error]: the live decision-log reader picks between exactly
+   these two by line position. *)
+let test_tail_partial_write_is_its_own_reason () =
+  Alcotest.(check string)
+    "wire string"
+    "tail_partial_write"
+    (R.to_wire R.Tail_partial_write);
+  Alcotest.(check bool)
+    "round-trips"
+    true
+    (R.equal R.Tail_partial_write (R.of_wire (R.to_wire R.Tail_partial_write)));
+  Alcotest.(check bool)
+    "distinct from entry_load_error"
+    false
+    (R.equal R.Tail_partial_write R.Entry_load_error);
+  Alcotest.(check string)
+    "matches the Safe_ops constant byte for byte"
+    Safe.persistence_read_drop_reason_tail_partial_write
+    (R.to_wire R.Tail_partial_write)
 ;;
 
 let test_canonical_round_trip () =
@@ -147,6 +181,14 @@ let () =
             "new variants are disjoint from pre-existing"
             `Quick
             test_rfc_0134_new_variants_disjoint
+        ; Alcotest.test_case
+            "tail_partial_write round-trips and stays off entry_load_error"
+            `Quick
+            test_tail_partial_write_is_its_own_reason
+        ; Alcotest.test_case
+            "canonical list covers every constructor"
+            `Quick
+            test_canonical_covers_every_constructor
         ] )
     ]
 ;;


### PR DESCRIPTION
Refs #26853

## 배경

RFC-0134 (Active) 는 **데이터 손실이 아닌** read drop 을 이미 분리해 놓았다:

```ocaml
| Concurrent_removal      (** Not a data loss; the entry was concurrently
                              retired by another writer. *)
| Transient_fd_pressure   (** Not data loss; retry-eligible. *)
```

**"Not a data loss"** 가 그 분리 기준이다. 이 PR 은 같은 가족에 세 번째를 더한다.

## 문제

append-only 파일의 마지막 줄은 tail 리더가 읽는 순간 **쓰기 중**일 수 있다. 리더는 그 앞 줄로 넘어가 정상 값을 얻고, 다음 읽기에는 그 줄이 완결된 상태로 보인다. **아무것도 잃지 않는다.**

그런데 지금은 그 파싱 실패가 `entry_load_error` 로 보고되어 **진짜 손상과 같은 data-integrity 카운터에 얹힌다.**

라이브 로그 (2026-07-28 ~ 08-04, `keepers/*.decisions.jsonl`):

```
entry_load_error   6건   전부 "Unexpected end of input"
invalid_payload  130건   2026-07-29 sangsu 단일 사건, 성격이 완전히 다름
```

**한 카운터에 두 의미가 섞인다.** 정상 동작을 결함으로 계측하면 진짜 드롭이 묻힌다.

## 이 PR 의 범위

**어휘만이다** — variant, wire 문자열, `Safe_ops` 상수, 테스트. **어떤 생산자도 아직 이 사유를 내지 않는다.**

## 배선을 넣지 않은 이유

줄 위치만으로 분류하는 것 — *"`List.rev` 후 index 0 이 마지막 줄이니 그 파싱 실패는 경합"* — 은 **틀렸다.** 구현해 봤고 `test_keeper_runtime_trust_snapshot` 이 잡았다.

그 테스트의 fixture 는 마지막 줄이 리터럴 `{not-json` 이다. **마지막 줄에서 발생한 진짜 손상**이지 잘린 쓰기가 아니다. 위치만 보면 둘을 구별하지 못하고, 실제 손상을 무해한 것으로 분류하게 된다.

구별하려면 **그 줄이 개행으로 끝났는지** 를 알아야 한다. `Keeper_memory.read_file_tail_lines_result` 는 `String.split_on_char '\n'` 후 빈 줄을 필터링하므로 그 정보가 소실되고, 호출자는 볼 수 없다.

리더가 미완결 마지막 줄을 보고하게 하려면 시그니처가 바뀌고 다른 소비자 (`dashboard_keeper_decision_log_proof` 등) 에 영향이 간다. **별도 변경이 맞다.**

## 테스트

`test_read_drop_reason` 의 `canonical` 목록은 손으로 유지된다. 새 constructor 를 목록에 넣지 않으면 round-trip 과 wire-stability 검사를 **조용히 건너뛴다.**

개수 단언을 추가해서, 다음 variant 를 목록에 안 넣으면 거기서 실패하게 했다.

그리고 `Tail_partial_write` 가 `Entry_load_error` 와 **구별된다는 것**을 명시적으로 단언한다 — 이 사유의 존재 이유가 그 구별이고, 라이브 리더가 줄 위치로 이 둘 중 하나를 고르게 될 것이기 때문이다.

## 검증

- `dune build --root . @check` — exit 0. `equal` 이 catch-all 없이 모든 쌍을 명시하는 스타일이라 컴파일러가 exhaustive match 를 강제했다 (warning 8).
- `test_read_drop_reason` **8/8**
- `test_keeper_runtime_trust_snapshot` **18/18** — 배선을 되돌린 뒤 확인

RFC-0134 (Active, `implementation_prs: []`) 의 하위 작업이다. 별도 RFC 를 열지 않은 이유는 이 타입의 not-a-loss 분리가 그 RFC 의 확립된 패턴이고, 여기에 한 variant 를 더하는 것이기 때문이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)