### PR TITLE
fix(keeper): append 진행 중인 마지막 줄을 손상과 구별해 보고

### DIFF
--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -10,15 +10,23 @@ open Keeper_types
 open Keeper_meta_contract
 open Keeper_types_profile
 
+(* Whether the final returned line was newline-terminated in the file.
+   [Partial_last_line] means an append was in flight when the read happened,
+   which is the difference between a truncated write and real corruption at
+   the tail of an append-only log. *)
+type tail_completion =
+  | Complete
+  | Partial_last_line
+
 (* RFC-0149 §3.1 — typed Result entry point.  Distinguishes "no memory"
    ([Ok []] for missing file or zero-line request) from "IO/parse fault"
    ([Error class]).  The catch-all classifies the exception through the
    closed sum {!Keeper_memory_recall_exn_class.t} so the caller can
    branch on a bounded label instead of a free-form string. *)
-let read_file_tail_lines_result path ~max_bytes ~max_lines :
-    (string list, Keeper_memory_recall_exn_class.t) result =
-  if max_lines <= 0 then Ok []
-  else if not (Fs_compat.file_exists path) then Ok []
+let read_file_tail_lines_with_completion path ~max_bytes ~max_lines :
+    (string list * tail_completion, Keeper_memory_recall_exn_class.t) result =
+  if max_lines <= 0 then Ok ([], Complete)
+  else if not (Fs_compat.file_exists path) then Ok ([], Complete)
   else
     try
       let fd = Unix.openfile path [ Unix.O_RDONLY ] 0 in
@@ -70,14 +78,37 @@ let read_file_tail_lines_result path ~max_bytes ~max_lines :
                then (match lines with _ :: rest -> rest | [] -> [])
                else lines
              in
+             (* The read always ends at end-of-file, so the last byte of
+                [content] tells whether the final line was terminated. A file
+                whose last line is still being appended has no trailing
+                newline yet. The symmetric case at the other end -- a first
+                line cut by the [max_bytes] window -- is already handled above
+                by dropping it when [!pos > 0]. *)
+             let completion =
+               if String.length content > 0
+                  && content.[String.length content - 1] = '\n'
+               then Complete
+               else Partial_last_line
+             in
              let n = List.length lines in
-             if n <= max_lines then lines
-             else
-               let drop = n - max_lines in
-               List.filteri (fun i _ -> i >= drop) lines))
+             let lines =
+               if n <= max_lines then lines
+               else
+                 let drop = n - max_lines in
+                 List.filteri (fun i _ -> i >= drop) lines
+             in
+             (lines, completion)))
     with
     | (Sys_error _ | Unix.Unix_error _ | End_of_file) as exn ->
         Error (Keeper_memory_recall_exn_class.classify exn)
+
+(* The completion flag matters to exactly one caller (the decision-log reader,
+   which must tell an in-flight append from corruption). Everyone else keeps
+   the original shape through this wrapper, so there is one implementation
+   rather than two readers to keep in step. *)
+let read_file_tail_lines_result path ~max_bytes ~max_lines :
+    (string list, Keeper_memory_recall_exn_class.t) result =
+  Result.map fst (read_file_tail_lines_with_completion path ~max_bytes ~max_lines)
 
 let record_memory_recall_read_error ~site path exn_class =
   let exn_label = Keeper_memory_recall_exn_class.to_label exn_class in

--- a/lib/keeper/keeper_memory_recall.mli
+++ b/lib/keeper/keeper_memory_recall.mli
@@ -10,6 +10,22 @@ open Keeper_types_profile
 
 (** {1 File Reading} *)
 
+type tail_completion =
+  | Complete
+  | Partial_last_line
+(** Whether the last returned line was newline-terminated in the file.
+    [Partial_last_line] means an append was in flight during the read: the
+    row is not lost, it is simply not finished yet. This is what separates a
+    truncated write at the tail of an append-only log from real corruption,
+    which [Read_drop_reason.Tail_partial_write] exists to classify. *)
+
+val read_file_tail_lines_with_completion :
+  string -> max_bytes:int -> max_lines:int
+  -> (string list * tail_completion, Keeper_memory_recall_exn_class.t) result
+(** As {!read_file_tail_lines_result}, and additionally reports whether the
+    final line was terminated. The window's leading partial line is already
+    dropped by the reader; this covers the trailing end. *)
+
 val read_file_tail_lines_result :
   string -> max_bytes:int -> max_lines:int
   -> (string list, Keeper_memory_recall_exn_class.t) result

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -425,23 +425,41 @@ let latest_decision_json ~(config : Workspace.config) ~(keeper_name : string) :
   let path = Keeper_types_support.keeper_decision_log_path config keeper_name in
   if not (Fs_compat.file_exists path) then None
   else
-    (match
-       Keeper_memory.read_file_tail_lines_result path
-         ~max_bytes:40000 ~max_lines:20
-     with
-     | Ok lines -> lines
-     | Error exn_class ->
-         Keeper_memory.record_memory_recall_read_error
-           ~site:"keeper_runtime_trust_decisions" path exn_class;
-         [])
+    let lines, completion =
+      match
+        Keeper_memory.read_file_tail_lines_with_completion path
+          ~max_bytes:40000 ~max_lines:20
+      with
+      | Ok (lines, completion) -> (lines, completion)
+      | Error exn_class ->
+          Keeper_memory.record_memory_recall_read_error
+            ~site:"keeper_runtime_trust_decisions" path exn_class;
+          ([], Keeper_memory.Complete)
+    in
+    lines
     |> List.rev
-    |> List.find_map (fun line ->
+    (* [List.rev] puts the newest row first, so index 0 is the file's last
+       line. The decision log is append-only and this read is not synchronised
+       with the writer, so that one line can be mid-write. When the reader
+       reports the tail as unterminated, its parse failure is an in-flight
+       append rather than corruption: [find_map] falls through to the previous
+       complete row and the next read sees it whole. Position alone is not
+       enough — a genuinely malformed last line is newline-terminated and must
+       keep [entry_load_error]. *)
+    |> List.mapi (fun index line -> (index, line))
+    |> List.find_map (fun (index, line) ->
            match Yojson.Safe.from_string line with
            | exception Yojson.Json_error detail ->
-               report_decision_log_read_drop
-                 ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
-                 ~path
-                 ~detail;
+               let reason =
+                 match (index, completion) with
+                 | 0, Keeper_memory.Partial_last_line ->
+                     Safe_ops.persistence_read_drop_reason_tail_partial_write
+                 | 0, Keeper_memory.Complete
+                 | _, Keeper_memory.Partial_last_line
+                 | _, Keeper_memory.Complete ->
+                     Safe_ops.persistence_read_drop_reason_entry_load_error
+               in
+               report_decision_log_read_drop ~reason ~path ~detail;
                None
            | (`Assoc _ as json) -> Some json
            | _ ->

--- a/test/test_keeper_runtime_trust_snapshot.ml
+++ b/test/test_keeper_runtime_trust_snapshot.ml
@@ -163,6 +163,58 @@ let test_snapshot_counts_malformed_decision_rows () =
          (drop_value invalid_payload -. before_invalid_payload))
 ;;
 
+(* Same shape as the test above with one byte of difference: no trailing
+   newline. That is what an append caught in flight looks like on disk, and it
+   is the only thing separating it from the malformed-row case, which ends
+   with "\n" and must keep counting as entry_load_error. Classifying by line
+   position alone cannot tell them apart; an earlier attempt that did was
+   caught by the test above. *)
+let test_snapshot_counts_unterminated_tail_separately () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> remove_tree base_dir)
+    (fun () ->
+       with_env "MASC_BASE_PATH" base_dir
+       @@ fun () ->
+       let config = Masc.Workspace.default_config base_dir in
+       let keeper_name = "runtime-trust-decision-tail" in
+       let meta = make_meta keeper_name in
+       let path = Masc.Keeper_types_support.keeper_decision_log_path config keeper_name in
+       let entry_error = Safe_ops.persistence_read_drop_reason_entry_load_error in
+       let tail_partial = Safe_ops.persistence_read_drop_reason_tail_partial_write in
+       let before_entry_error = drop_value entry_error in
+       let before_tail_partial = drop_value tail_partial in
+       write_file
+         path
+         (String.concat
+            "\n"
+            [ Yojson.Safe.to_string
+                (`Assoc
+                    [ "turn_id", `Int 21
+                    ; "turn_verdict", `String "run"
+                    ; "telemetry", `Assoc [ "selected_model", `String "tail-model" ]
+                    ])
+            ; {|{"turn_id": 22, "turn_verdict": "ru|}
+            ]);
+       let snapshot = K.snapshot_json ~config ~meta in
+       let open Yojson.Safe.Util in
+       Alcotest.(check int)
+         "falls back past the in-flight append"
+         21
+         (snapshot |> member "latest_decision" |> member "turn_id" |> to_int);
+       Alcotest.(check (float 0.001))
+         "unterminated tail counts as tail_partial_write"
+         1.0
+         (drop_value tail_partial -. before_tail_partial);
+       Alcotest.(check (float 0.001))
+         "and stays off the data-integrity reason"
+         0.0
+         (drop_value entry_error -. before_entry_error))
+;;
+
 let test_snapshot_uses_receipt_runtime_model_when_decision_absent () =
   Eio_main.run
   @@ fun env ->
@@ -897,6 +949,10 @@ let () =
             "malformed decision rows increment drop metrics"
             `Quick
             test_snapshot_counts_malformed_decision_rows
+        ; Alcotest.test_case
+            "unterminated tail is not a data-integrity drop"
+            `Quick
+            test_snapshot_counts_unterminated_tail_separately
         ] )
     ; ( "receipt_runtime_model"
       , [ Alcotest.test_case


### PR DESCRIPTION
Closes #26853 · Refs #26855

## 배경

#26855 가 `Tail_partial_write` 를 **생산자 없이** 추가했다. 두 경우를 구별하려면 마지막 줄이 개행으로 끝났는지 알아야 하는데, tail 리더가 `String.split_on_char '\n'` 후 필터링해서 그 정보를 버렸기 때문이다.

이 PR 이 그것을 공급하고, 필요한 한 곳만 배선한다.

## 변경

### 리더

`Keeper_memory_recall.read_file_tail_lines_with_completion` 신규 — 줄 목록과 함께 `Complete | Partial_last_line` 을 반환한다.

읽기는 **항상 파일 끝에서 끝나므로**, 조립된 `content` 의 마지막 바이트가 답을 직접 준다. 반대쪽 끝 — `max_bytes` 창에 잘린 첫 줄 — 은 이미 `!pos > 0` 일 때 버려지고 있었다. **대칭이 완성된다.**

`read_file_tail_lines_result` 는 그대로 남되 플래그를 버리는 래퍼가 된다. 나머지 소비자 4곳은 손대지 않았고, **구현은 하나다**:

```
dashboard_http_helpers.ml:121
dashboard_keeper_decision_log_proof.ml:31
keeper_status_detail.ml:19
keeper_tool_persona_runtime.ml:22
```

### 드롭 사이트

`latest_decision_json` 이 `List.rev` 후 index 0 (파일의 마지막 줄) 의 파싱 실패를, **리더가 tail 을 미완결로 보고했을 때만** `tail_partial_write` 로 분류한다. 그 외는 전부 `entry_load_error` 를 유지한다.

## 위치만으로는 안 된다 — 기존 테스트가 증명했다

`test_snapshot_counts_malformed_decision_rows` 의 fixture 는 마지막 줄이 리터럴 `{not-json` 이고 **개행이 붙어 있다.** 마지막 줄에서 발생한 진짜 손상이지 잘린 쓰기가 아니다.

#26855 작업 중 위치만으로 분류하는 구현을 시도했고 **이 테스트가 잡았다.** 그래서 그 PR 은 어휘만 담고 배선을 뺐다. 이 PR 에서 그 테스트는 **변경 없이 그대로 통과한다.**

## 새 테스트

같은 fixture 에서 **1바이트만 다르다** — 마지막 개행 없음. 디스크상 진행 중인 append 의 모습이고, 손상과 구별되는 유일한 표시다.

```
drop 이 tail_partial_write 로 계상        1.0
entry_load_error 는 움직이지 않음          0.0
```

**Negative control**: `Partial_last_line` arm 을 `entry_load_error` 로 되돌리면 새 케이스만 실패하고 기존 케이스는 green 이다.

## 왜 필요한가

라이브 로그 (`~/.masc/logs/system_log_*.jsonl`):

```
entry_load_error   6건   keepers/*.decisions.jsonl, 전부 "Unexpected end of input"
invalid_payload  130건   2026-07-29 sangsu 단일 사건 — 성격이 완전히 다름
```

한 카운터에 두 의미가 섞여 있었다. `metric_persistence_read_drops` 는 **데이터 유실 신호**로 읽히는데, 6건은 다음 읽기에 완결된 행으로 보이는 정상 경합이다. 정상 동작을 결함으로 계측하면 진짜 드롭이 묻힌다.

RFC-0134 가 `Concurrent_removal` ("Not a data loss") 과 `Transient_fd_pressure` ("Not data loss") 로 이미 세운 분리 기준을 따른다.

## 검증

- `dune build --root . @check` — exit 0
- `test_keeper_runtime_trust_snapshot` **19/19** (기존 18 + 신규 1)
- `test_read_drop_reason` 8/8 · `test_audit_projection` 7/7

RFC-WAIVED: RFC-0134 (Active) 의 not-a-loss 분류를 한 소비자에 배선. credential / identity / operator control plane / keeper sandbox / dashboard credential / hooks / workflow 문서 중 어느 것도 건드리지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)