### PR TITLE
fix(librarian): 규칙을 역으로 저장하지 않는다

### DIFF
--- a/config/prompts/keeper.librarian.current_selection.md
+++ b/config/prompts/keeper.librarian.current_selection.md
@@ -16,6 +16,7 @@ Retention criteria:
 - Retain an existing ID only when its exact fact is still true, important, non-duplicative, and worth occupying future context.
 - Drop stale, superseded, transient, or derivable existing memories. Dropping is the deletion operation, and each drop states its reason in one sentence (what made this memory stop earning its place).
 - Never recreate a dropped existing fact as a new claim merely to reword it.
+- Record a rule the way its source states it. Do not store the inverse: "when X, do Y" does not license "only when X", and "Y is not yours to do" does not license "stay out of everything nearby". The inverse adds an exclusivity the source never wrote, and once stored it reads as authoritative in every later turn. If the source names when to act, keep it as that; if it names a boundary, keep the boundary at the width it was written.
 - Apply the category criteria below to existing memories too, not only to new claims. A stored memory that would not be written today does not earn retention by already being there. In particular, drop a stored `constraint` that no external rule enforces — one describing what the agent decided to stay out of, wait for, or not take on — with the reason that it was the agent's own scope decision rather than an enforced rule.
 
 New-claim criteria:

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -441,7 +441,24 @@ let test_constraint_category_excludes_self_imposed_scope () =
          "does not earn retention by already being there");
     check bool "stored self-scope constraints are dropped" true
       (String_util.contains_substring user_text
-         "drop a stored `constraint` that no external rule enforces")
+         "drop a stored `constraint` that no external rule enforces");
+    (* Measured 2026-08-05. kidsnote's operator instructions say "@kidsnote로
+       요청받으면 같은 post_id에 구체적인 댓글을 남긴다" -- when to act. The
+       stored memory reads "standing-by policy, only intervening in board posts
+       or tasks when directly mentioned (@kidsnote) or assigned" -- the
+       inverse, with an exclusivity the operator never wrote. The category
+       rules do not catch it because it looks like operator policy, which is
+       the family they preserve. This is about the shape of the statement, not
+       its category. *)
+    check bool "rules are recorded as their source states them" true
+      (String_util.contains_substring user_text
+         "Record a rule the way its source states it");
+    check bool "the inverse is named and refused" true
+      (String_util.contains_substring user_text
+         "does not license \"only when X\"");
+    check bool "boundaries keep their written width" true
+      (String_util.contains_substring user_text
+         "keep the boundary at the width it was written")
 ;;
 
 let test_repo_template_renders_persona () =


### PR DESCRIPTION
Refs #26729

## 빈틈

`constraint` 범주를 외부 강제로 좁히고 자기제한을 이름으로 배제했지만, kidsnote 에서 측정한 형태는 여전히 통과한다.

```
운영자 instructions : "@kidsnote로 요청받으면 같은 post_id에 구체적인 댓글을 남긴다"
                       → 언제 행동할지
저장된 메모리        : "standing-by policy, only intervening in board posts or tasks
                        when directly mentioned (@kidsnote) or assigned"
                       → 그때만
```

**범주 규칙이 이걸 못 잡는다.** operator policy 로 읽히고, 그건 제가 **유지하라고 한 부류** 다. 운영자가 실제로 멘션을 언급했으니 지어낸 것도 아니다.

**뒤집힌 것이다.** "X면 Y하라" 가 "X일 때만" 이 되면서, 원문에 없던 배타성이 붙는다. 논리적으로 역이 성립하지 않는데 저장되고 나면 매 턴 권위 있게 읽힌다.

## 같은 형태가 code-reviewer 에도

```
운영자 : "masc_transition 의 approve 와 reject 는 너의 도구가 아니다"   ← 한 권한을 제한
메모리 : (1) "does not execute masc_transition approve/reject"          ← 정확
         (2) "unclaimed implementation tasks on the board are outside
              the code-reviewer's scope and should be ignored"          ← instructions 에 없음
```

(2) 는 (1) 보다 훨씬 넓다. 그 keeper 는 claim 1회당 `tasks_list` 2,254회로 측정된 최악 비율이다.

## 변경

한 줄이다.

> Record a rule the way its source states it. Do not store the inverse: "when X, do Y" does not license "only when X", and "Y is not yours to do" does not license "stay out of everything nearby". The inverse adds an exclusivity the source never wrote... If the source names when to act, keep it as that; if it names a boundary, keep the boundary at the width it was written.

**범주가 아니라 진술의 형태** 를 다룬다. 앞선 변경들이 "무엇이 constraint 인가" 를 좁혔다면, 이것은 "어떻게 적는가" 다.

## 출처를 먼저 확인했다

이 규칙을 쓰기 전에 `config/keepers/*.toml` 의 `instructions` 전문과 대조했다. 라이브의 자기제한 constraint 5건 중:

- **2건은 운영자 지시의 충실한 요약** — full-cycle-probe 의 probe 범위 (`proactive_enabled = false`, `"do not poll unrelated work"`), code-reviewer 의 approve/reject 경계
- **3건은 instructions 에 없다** — 이 규칙이 겨냥하는 것들

앞서 #26729 에 "5건 전부 librarian 이 만들었다" 고 적었던 것을 같은 이슈에 정정해 두었다.

## 검증

- `dune build --root . @check` — exit 0
- `test_keeper_librarian_retry` **19/19**
- **Negative control**: 이 규칙을 제거하면 신규 단언 3건이 실패한다

RFC-WAIVED: librarian 큐레이션 프롬프트의 진술 규칙 추가. credential / identity / operator control plane / keeper sandbox / dashboard credential / hooks / workflow 문서 중 어느 것도 건드리지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)