### PR TITLE
fix(dashboard): project the materialized evidence snapshot, not raw refs

### DIFF
--- a/dashboard/src/components/verification-requests-panel.test.ts
+++ b/dashboard/src/components/verification-requests-panel.test.ts
@@ -243,6 +243,66 @@ describe('VerificationRequestsPanel', () => {
     })
   })
 
+  // The identity lines the store now projects are not opaque tokens: they carry
+  // path separators, a note prefix, Korean text, and a parenthesised failure
+  // reason. Each must survive rendering intact, and an unreadable artifact must
+  // stay visible instead of being dropped from the list.
+  it('renders projected snapshot identity lines verbatim', async () => {
+    setData([
+      makeRequest({
+        submitted_evidence: [
+          'artifact:repos/demo/services/request-form/src/lib/reportError.ts',
+          'note:executor summary — 비동기 에러 핸들링 통일 완료',
+          'artifact:repos/demo/gone.ml (unreadable: missing)',
+          '(unreadable: invalid_reference)',
+        ],
+      }),
+    ])
+    render(html`<${VerificationRequestsPanel} />`)
+
+    fireEvent.click(screen.getByText('자세히'))
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'artifact:repos/demo/services/request-form/src/lib/reportError.ts',
+        ),
+      ).toBeTruthy()
+      expect(
+        screen.getByText('note:executor summary — 비동기 에러 핸들링 통일 완료'),
+      ).toBeTruthy()
+      expect(
+        screen.getByText('artifact:repos/demo/gone.ml (unreadable: missing)'),
+      ).toBeTruthy()
+      expect(screen.getByText('(unreadable: invalid_reference)')).toBeTruthy()
+    })
+  })
+
+  // Live store extremes: a 1083-char reference and 77 notes over 200 chars.
+  // A path carries no spaces, so without break-words the row overflows sideways
+  // rather than wrapping. Assert the wrap class rides on both evidence lists.
+  it('wraps oversized identity lines instead of overflowing the row', async () => {
+    const longPath = `artifact:repos/demo/${'segment/'.repeat(120)}file.ts`
+    expect(longPath.length).toBeGreaterThan(900)
+    expect(longPath).not.toContain(' ')
+    setData([
+      makeRequest({
+        required_artifacts: [longPath],
+        submitted_evidence: [longPath],
+      }),
+    ])
+    render(html`<${VerificationRequestsPanel} />`)
+
+    fireEvent.click(screen.getByText('자세히'))
+    await waitFor(() => {
+      const lists = document.querySelectorAll('ul.list-disc')
+      expect(lists.length).toBe(2)
+      for (const list of lists) {
+        expect(list.classList.contains('break-words')).toBe(true)
+      }
+      expect(screen.getAllByText(longPath).length).toBe(2)
+    })
+  })
+
   it('renders missing and malformed evidence projection warnings', () => {
     setData([
       makeRequest({

--- a/dashboard/src/components/verification-requests-panel.ts
+++ b/dashboard/src/components/verification-requests-panel.ts
@@ -173,7 +173,7 @@ function VerificationRow({ row }: { row: VerificationRequest }) {
                     ? html`
                         <div>
                           <${DetailLabel}>Required Artifacts</${DetailLabel}>
-                          <ul class="list-disc list-inside flex flex-col gap-1 text-[var(--color-fg-primary)]">
+                          <ul class="list-disc list-inside flex flex-col gap-1 text-[var(--color-fg-primary)] break-words">
                             ${row.required_artifacts.map((artifact) => html`<li><code>${artifact}</code></li>`)}
                           </ul>
                         </div>
@@ -183,7 +183,11 @@ function VerificationRow({ row }: { row: VerificationRequest }) {
                     ? html`
                         <div>
                           <${DetailLabel}>Submitted Evidence</${DetailLabel}>
-                          <ul class="list-disc list-inside flex flex-col gap-1 text-[var(--color-fg-primary)]">
+                          <!-- Identity lines are producer-supplied: the live store holds a
+                               1083-char reference and 77 notes over 200 chars, and a path has
+                               no spaces to break at. Without break-words these overflow the
+                               row horizontally instead of wrapping. -->
+                          <ul class="list-disc list-inside flex flex-col gap-1 text-[var(--color-fg-primary)] break-words">
                             ${row.submitted_evidence.map((evidence) => html`<li><code>${evidence}</code></li>`)}
                           </ul>
                         </div>

--- a/lib/dashboard/dashboard_verification.ml
+++ b/lib/dashboard/dashboard_verification.ml
@@ -103,8 +103,29 @@ let request_to_json (req : V.verification_request) : Yojson.Safe.t =
   let required_artifacts, required_artifacts_error =
     string_list_of_output "required_artifacts" req.output
   in
+  (* [submitted_evidence] is the materialized snapshot the completion authority
+     read, not the producer's raw reference strings: the submit boundary
+     replaces the field with resolved items carrying unreadable markers. The
+     store owns that shape and projects it to identity lines; reading it as a
+     string array rejected every request on the live store. *)
   let submitted_evidence, submitted_evidence_error =
-    string_list_of_output "submitted_evidence" req.output
+    match req.output with
+    | `Assoc fields ->
+      (match List.assoc_opt "submitted_evidence" fields with
+       | None -> [], Some "missing current-schema field \"submitted_evidence\""
+       | Some value ->
+         (match
+            Workspace_verification_store.submitted_evidence_identity_lines value
+          with
+          | Ok lines -> lines, None
+          | Error detail ->
+            ( []
+            , Some
+                (Printf.sprintf
+                   "malformed current-schema field %S: %s"
+                   "submitted_evidence"
+                   detail) )))
+    | _ -> [], Some "verification output must be an object"
   in
   let evidence_projection_error =
     [required_artifacts_error; submitted_evidence_error]

--- a/lib/workspace/workspace_verification_store.ml
+++ b/lib/workspace/workspace_verification_store.ml
@@ -48,6 +48,11 @@ type submitted_evidence_access =
       ; reason : evidence_access_failure
       }
 
+(* Reason code for a reference this module refused to materialize. Unlike the
+   [evidence_read_failure] codes it sits beside on the wire, it has no variant:
+   the rejected reference is never persisted, so there is nothing to carry. *)
+let invalid_reference_code = "invalid_reference"
+
 let evidence_read_failure_code = function
   | Evidence_missing -> "missing"
   | Evidence_not_regular_file -> "not_regular_file"
@@ -98,7 +103,7 @@ let submitted_evidence_item_to_yojson = function
   | Evidence_invalid_reference ->
     `Assoc
       [ "kind", `String "artifact_unreadable"
-      ; "reason", `Assoc [ "code", `String "invalid_reference" ]
+      ; "reason", `Assoc [ "code", `String invalid_reference_code ]
       ]
   | Evidence_artifact_unreadable { reference; reason } ->
     `Assoc
@@ -174,7 +179,7 @@ let submitted_evidence_item_metadata_to_yojson = function
   | Evidence_invalid_reference ->
     `Assoc
       [ "kind", `String "artifact_unreadable"
-      ; "reason", `String "invalid_reference"
+      ; "reason", `String invalid_reference_code
       ]
   | Evidence_artifact_unreadable { reference; reason } ->
     `Assoc
@@ -569,39 +574,27 @@ let snapshot_submitted_evidence_json ~base_path ~worker references =
          |> submitted_evidence_item_to_yojson)
        references)
 
+(* Decode through this module's own snapshot decoder instead of re-reading the
+   JSON fields. Both surfaces read the same persisted bytes, so they have to
+   agree on which snapshots are well-formed: re-deriving the shape here let an
+   artifact item with a [reference] but missing or invalid [content]/[bytes]/
+   [truncated] render as an ordinary identity line while the authority-scoped
+   payload route rejected the very same item. Matching on the typed value makes
+   that divergence unrepresentable, and a new variant becomes a compile error
+   here rather than an [unknown kind] string at runtime. *)
 let submitted_evidence_identity_line (item : Yojson.Safe.t) =
-  match item with
-  | `Assoc fields ->
-    (match List.assoc_opt "kind" fields with
-     | Some (`String "note") ->
-       (match List.assoc_opt "content" fields with
-        | Some (`String content) -> Ok (note_reference_prefix ^ content)
-        | _ -> Error "note item is missing content")
-     | Some (`String "artifact") ->
-       (match List.assoc_opt "reference" fields with
-        | Some (`String reference) -> Ok reference
-        | _ -> Error "artifact item is missing reference")
-     | Some (`String "artifact_unreadable") ->
-       let code =
-         match List.assoc_opt "reason" fields with
-         | Some (`Assoc reason_fields) ->
-           (match List.assoc_opt "code" reason_fields with
-            | Some (`String code) -> Some code
-            | _ -> None)
-         | _ -> None
-       in
-       (match code with
-        | None -> Error "unreadable item is missing a reason code"
-        | Some code ->
-          (match List.assoc_opt "reference" fields with
-           | Some (`String reference) ->
-             Ok (Printf.sprintf "%s (unreadable: %s)" reference code)
-           | None -> Ok (Printf.sprintf "(unreadable: %s)" code)
-           | Some _ -> Error "unreadable item reference must be a string"))
-     | Some (`String kind) ->
-       Error (Printf.sprintf "unknown submitted evidence item kind %S" kind)
-     | _ -> Error "submitted evidence item is missing kind")
-  | _ -> Error "submitted evidence item must be an object"
+  match submitted_evidence_item_of_yojson item with
+  | Error detail -> Error detail
+  | Ok (Evidence_note note) -> Ok (note_reference_prefix ^ note)
+  | Ok (Evidence_artifact { reference; _ }) -> Ok reference
+  | Ok Evidence_invalid_reference ->
+    Ok (Printf.sprintf "(unreadable: %s)" invalid_reference_code)
+  | Ok (Evidence_artifact_unreadable { reference; reason }) ->
+    Ok
+      (Printf.sprintf
+         "%s (unreadable: %s)"
+         reference
+         (evidence_read_failure_code reason))
 ;;
 
 let submitted_evidence_identity_lines (json : Yojson.Safe.t) =

--- a/lib/workspace/workspace_verification_store.ml
+++ b/lib/workspace/workspace_verification_store.ml
@@ -569,6 +569,56 @@ let snapshot_submitted_evidence_json ~base_path ~worker references =
          |> submitted_evidence_item_to_yojson)
        references)
 
+let submitted_evidence_identity_line (item : Yojson.Safe.t) =
+  match item with
+  | `Assoc fields ->
+    (match List.assoc_opt "kind" fields with
+     | Some (`String "note") ->
+       (match List.assoc_opt "content" fields with
+        | Some (`String content) -> Ok (note_reference_prefix ^ content)
+        | _ -> Error "note item is missing content")
+     | Some (`String "artifact") ->
+       (match List.assoc_opt "reference" fields with
+        | Some (`String reference) -> Ok reference
+        | _ -> Error "artifact item is missing reference")
+     | Some (`String "artifact_unreadable") ->
+       let code =
+         match List.assoc_opt "reason" fields with
+         | Some (`Assoc reason_fields) ->
+           (match List.assoc_opt "code" reason_fields with
+            | Some (`String code) -> Some code
+            | _ -> None)
+         | _ -> None
+       in
+       (match code with
+        | None -> Error "unreadable item is missing a reason code"
+        | Some code ->
+          (match List.assoc_opt "reference" fields with
+           | Some (`String reference) ->
+             Ok (Printf.sprintf "%s (unreadable: %s)" reference code)
+           | None -> Ok (Printf.sprintf "(unreadable: %s)" code)
+           | Some _ -> Error "unreadable item reference must be a string"))
+     | Some (`String kind) ->
+       Error (Printf.sprintf "unknown submitted evidence item kind %S" kind)
+     | _ -> Error "submitted evidence item is missing kind")
+  | _ -> Error "submitted evidence item must be an object"
+;;
+
+let submitted_evidence_identity_lines (json : Yojson.Safe.t) =
+  match json with
+  | `List items ->
+    List.fold_left
+      (fun acc item ->
+        match acc, submitted_evidence_identity_line item with
+        | Error _, _ -> acc
+        | Ok lines, Ok line -> Ok (line :: lines)
+        | Ok _, Error detail -> Error detail)
+      (Ok [])
+      items
+    |> Result.map List.rev
+  | _ -> Error "submitted evidence must be an array"
+;;
+
 let inspect_submitted_evidence_for_authority ~base_path ~request_id ~task_id
     ~task_worker ~(authority : Masc_domain.completion_authority) =
   if not (Masc_domain.completion_authority_has_identity authority)

--- a/lib/workspace/workspace_verification_store.mli
+++ b/lib/workspace/workspace_verification_store.mli
@@ -73,6 +73,20 @@ val snapshot_submitted_evidence_json :
     source size, which exceeds the persisted [content] length when [truncated]
     is set by the projection cap. Bare and absolute references are persisted as
     a payload-free typed invalid-reference item. *)
+
+val submitted_evidence_identity_lines :
+  Yojson.Safe.t -> (string list, string) result
+(** Project a persisted [submitted_evidence] snapshot into one identity line
+    per item, for surfaces that name evidence without reading its payload —
+    artifacts project to their reference, notes to their prefixed text, and
+    unreadable items carry the typed reason code so an operator sees the
+    failure rather than a silent gap. Payloads are served separately by the
+    authority-scoped evidence route.
+
+    This module writes the snapshot, so it owns the shape: a caller must not
+    re-derive it. Returns [Error] on any item this module did not write and
+    never partially projects a malformed array. *)
+
 val inspect_submitted_evidence_for_authority :
   base_path:string ->
   request_id:string ->

--- a/test/test_dashboard_verification.ml
+++ b/test/test_dashboard_verification.ml
@@ -413,6 +413,59 @@ let test_requests_json_surfaces_conflict_triage_fields () =
      | `String "Reconcile board / planning / mutation surfaces before ordinary approval." -> ()
      | _ -> Alcotest.fail "next_action mismatch"))
 
+(* Edges the live store does not currently hold but the writer can produce: an
+   empty snapshot, an invalid-reference item that carries no reference at all,
+   and a kind this module never writes. The first two must project; the third
+   must fail the whole array rather than silently drop one item. *)
+let test_requests_json_snapshot_projection_edges () =
+  let row_for ~task_id items =
+    with_temp_base_path (fun base_path ->
+      let output =
+        `Assoc [
+          ("required_artifacts", `List []);
+          ("submitted_evidence", `List items);
+        ]
+      in
+      (match V.create_request ~base_path ~task_id ~output ~criteria:[]
+               ~worker:"keeper-alpha" () with
+       | Ok _ -> ()
+       | Error e -> Alcotest.fail (Printf.sprintf "create_request failed: %s" e));
+      match member "requests" (D.requests_json ~base_path ()) with
+      | `List [row] -> row
+      | _ -> Alcotest.fail "expected one request")
+  in
+  let evidence row =
+    member "submitted_evidence" row |> Yojson.Safe.Util.to_list
+    |> List.map Yojson.Safe.Util.to_string
+  in
+  let error row =
+    match member "evidence_projection_error" row with
+    | `String s -> Some s
+    | _ -> None
+  in
+  let empty = row_for ~task_id:"task-empty-evidence" [] in
+  Alcotest.(check (list string)) "empty snapshot projects empty" [] (evidence empty);
+  Alcotest.(check (option string)) "empty snapshot is not an error" None (error empty);
+  let no_ref =
+    row_for ~task_id:"task-invalid-reference"
+      [ `Assoc [
+          ("kind", `String "artifact_unreadable");
+          ("reason", `Assoc [("code", `String "invalid_reference")]);
+        ] ]
+  in
+  Alcotest.(check (list string)) "reference-less unreadable still names its reason"
+    ["(unreadable: invalid_reference)"] (evidence no_ref);
+  let unknown =
+    row_for ~task_id:"task-unknown-kind"
+      [ `Assoc [("kind", `String "hologram"); ("content", `String "x")] ]
+  in
+  Alcotest.(check (list string)) "unknown kind projects nothing" [] (evidence unknown);
+  Alcotest.(check (option string)) "unknown kind fails the whole array"
+    (Some
+       ("malformed current-schema field \"submitted_evidence\": "
+        ^ "unknown submitted evidence item kind \"hologram\""))
+    (error unknown)
+
 let test_requests_json_surfaces_evidence_projection_error () =
   with_temp_base_path (fun base_path ->
     let output =
@@ -576,6 +629,8 @@ let () =
         test_requests_json_surfaces_evidence_projection_error;
       Alcotest.test_case "projects every snapshot item kind" `Quick
         test_requests_json_projects_every_snapshot_item_kind;
+      Alcotest.test_case "snapshot projection edges" `Quick
+        test_requests_json_snapshot_projection_edges;
       Alcotest.test_case "fd pressure remains observation-only" `Quick
         test_requests_and_summary_remain_available_after_fd_observation;
     ];

--- a/test/test_dashboard_verification.ml
+++ b/test/test_dashboard_verification.ml
@@ -89,12 +89,25 @@ let test_config_input_override_restores_boot_override () =
     Alcotest.(check (option string)) "boot override restored"
       (Some "before") (Config_boot_overrides.get_opt name))
 
+(* The submit boundary replaces [submitted_evidence] with the materialized
+   snapshot, so fixtures must carry snapshot items rather than the producer's
+   raw reference strings. An artifact item projects back to its reference, which
+   keeps every caller's expected list unchanged. *)
+let evidence_snapshot_item reference =
+  `Assoc [
+    ("kind", `String "artifact");
+    ("reference", `String reference);
+    ("content", `String "");
+    ("bytes", `Int 0);
+    ("truncated", `Bool false);
+  ]
+
 let create_pending_request_with_artifacts ~required_artifacts ~base_path ~task_id
     ~worker ~criteria ~evidence =
   let output = `Assoc [
     ("required_artifacts",
      `List (List.map (fun s -> `String s) required_artifacts));
-    ("submitted_evidence", `List (List.map (fun s -> `String s) evidence));
+    ("submitted_evidence", `List (List.map evidence_snapshot_item evidence));
     ("task_title", `String (Printf.sprintf "title for %s" task_id));
   ] in
   match V.create_request ~base_path ~task_id ~output ~criteria ~worker () with
@@ -430,8 +443,60 @@ let test_requests_json_surfaces_evidence_projection_error () =
     Alcotest.(check string) "missing and malformed fields are distinguished"
       ("missing current-schema field \"required_artifacts\"; "
        ^ "malformed current-schema field \"submitted_evidence\": "
-       ^ "expected an array of strings")
+       ^ "submitted evidence item must be an object")
       (member "evidence_projection_error" row |> Yojson.Safe.Util.to_string))
+
+(* The live store holds 47 artifact, 231 note and 6 unreadable items written by
+   the current serializer. Each kind must reach the operator as an identity
+   line; an unreadable item must name its failure instead of vanishing. *)
+let test_requests_json_projects_every_snapshot_item_kind () =
+  with_temp_base_path (fun base_path ->
+    let output =
+      `Assoc [
+        ("required_artifacts", `List []);
+        ("submitted_evidence", `List [
+          `Assoc [
+            ("kind", `String "artifact");
+            ("reference", `String "artifact:repos/demo/main.ml");
+            ("content", `String "let () = ()");
+            ("bytes", `Int 11);
+            ("truncated", `Bool false);
+          ];
+          `Assoc [
+            ("kind", `String "note");
+            ("content", `String "executor summary");
+          ];
+          `Assoc [
+            ("kind", `String "artifact_unreadable");
+            ("reference", `String "artifact:repos/demo/gone.ml");
+            ("reason", `Assoc [("code", `String "missing")]);
+          ];
+        ]);
+      ]
+    in
+    let _req =
+      match V.create_request ~base_path ~task_id:"task-snapshot-kinds"
+              ~output ~criteria:[] ~worker:"keeper-alpha" () with
+      | Ok req -> req
+      | Error e -> Alcotest.fail (Printf.sprintf "create_request failed: %s" e)
+    in
+    let row =
+      match member "requests" (D.requests_json ~base_path ()) with
+      | `List [row] -> row
+      | _ -> Alcotest.fail "expected one snapshot request"
+    in
+    Alcotest.(check (option string)) "snapshot projects without error"
+      None
+      (match member "evidence_projection_error" row with
+       | `String s -> Some s
+       | _ -> None);
+    Alcotest.(check (list string)) "every item kind reaches the operator"
+      [ "artifact:repos/demo/main.ml"
+      ; "note:executor summary"
+      ; "artifact:repos/demo/gone.ml (unreadable: missing)"
+      ]
+      (member "submitted_evidence" row |> Yojson.Safe.Util.to_list
+       |> List.map Yojson.Safe.Util.to_string))
 
 (* ── summary_json ───────────────────────────────────── *)
 
@@ -509,6 +574,8 @@ let () =
         test_requests_json_surfaces_conflict_triage_fields;
       Alcotest.test_case "evidence projection errors" `Quick
         test_requests_json_surfaces_evidence_projection_error;
+      Alcotest.test_case "projects every snapshot item kind" `Quick
+        test_requests_json_projects_every_snapshot_item_kind;
       Alcotest.test_case "fd pressure remains observation-only" `Quick
         test_requests_and_summary_remain_available_after_fd_observation;
     ];

--- a/test/test_dashboard_verification.ml
+++ b/test/test_dashboard_verification.ml
@@ -463,8 +463,26 @@ let test_requests_json_snapshot_projection_edges () =
   Alcotest.(check (option string)) "unknown kind fails the whole array"
     (Some
        ("malformed current-schema field \"submitted_evidence\": "
-        ^ "unknown submitted evidence item kind \"hologram\""))
-    (error unknown)
+        ^ "unknown submitted evidence snapshot kind \"hologram\""))
+    (error unknown);
+  (* The identity surface and the authority-scoped payload route read the same
+     persisted bytes. An artifact item carrying a reference but no payload
+     metadata is rejected by the payload decoder, so naming it here would tell
+     an operator that evidence exists which that route cannot serve. *)
+  let artifact_without_payload =
+    row_for ~task_id:"task-artifact-missing-payload"
+      [ `Assoc [
+          ("kind", `String "artifact");
+          ("reference", `String "artifact:repos/demo/main.ml");
+        ] ]
+  in
+  Alcotest.(check (list string))
+    "artifact missing payload metadata is not named"
+    [] (evidence artifact_without_payload);
+  Alcotest.(check bool)
+    "artifact missing payload metadata fails the array"
+    true
+    (error artifact_without_payload <> None)
 
 let test_requests_json_surfaces_evidence_projection_error () =
   with_temp_base_path (fun base_path ->
@@ -493,10 +511,14 @@ let test_requests_json_surfaces_evidence_projection_error () =
     Alcotest.(check (list string)) "malformed submitted evidence projects empty"
       [] (member "submitted_evidence" row |> Yojson.Safe.Util.to_list
           |> List.map Yojson.Safe.Util.to_string);
+    (* The detail comes from this module's snapshot decoder, which the identity
+       projection now runs, so it names the offending value rather than only
+       its expected shape. *)
     Alcotest.(check string) "missing and malformed fields are distinguished"
       ("missing current-schema field \"required_artifacts\"; "
        ^ "malformed current-schema field \"submitted_evidence\": "
-       ^ "submitted evidence item must be an object")
+       ^ "submitted evidence snapshot item must be an object, got "
+       ^ "\"trace://must-not-be-partially-projected\"")
       (member "evidence_projection_error" row |> Yojson.Safe.Util.to_string))
 
 (* The live store holds 47 artifact, 231 note and 6 unreadable items written by


### PR DESCRIPTION
## 증상

운영자 패널이 모든 검증 요청에 대해 증거 **0건**을 표시한다. 레코드에는 멀쩡히 들어 있다.

```
GET /api/v1/verification/requests
  "submitted_evidence": [],
  "evidence_projection_error":
    "malformed current-schema field \"submitted_evidence\": expected an array of strings"
```

라이브 84 건 전부 이 상태다.

## 원인

`submitted_evidence` 는 두 단계를 거치는데 읽는 쪽이 첫 단계 모양을 본다.

```
submit_request_spec           output.submitted_evidence = 문자열 배열
on_submit_for_verification    같은 필드를 materialized 스냅샷(객체 배열)으로 덮어씀
dashboard_verification        여전히 문자열 배열로 읽음  →  전량 거부
```

쓰는 쪽이 모양을 바꿨고 읽는 쪽이 따라가지 않았다.

## 수정 1 — 투영을 모양의 소유자에게

`Workspace_verification_store.submitted_evidence_identity_lines` 가 항목마다 식별 줄 하나를 낸다. 대시보드는 모양을 재유도하지 않고 이 함수를 호출한다.

| 항목 | 투영 |
|---|---|
| artifact | `artifact:repos/demo/main.ml` |
| note | `note:executor summary` |
| artifact_unreadable | `artifact:repos/demo/gone.ml (unreadable: missing)` |
| reference 없는 invalid | `(unreadable: invalid_reference)` |

읽을 수 없던 아티팩트가 사라지지 않고 이유와 함께 이름을 남긴다. 페이로드는 `CanAdmin` 게이트가 걸린 `/api/v1/verification/evidence` 가 담당하고 이 투영은 식별자만 나른다.

`required_artifacts` 는 문자열 배열 경로를 유지한다 — 생산자가 지금도 그렇게 쓴다.

## 수정 2 — 오버플로 (UI 실측에서 발견)

증거 리스트에 줄바꿈 규칙이 없었다. 라이브 극단값은 다음과 같다.

```
최장 reference    1,083 자   (개행 포함 마크다운 덩어리가 reference 로 제출됨)
최장 note         1,147 자   (200 자 초과 77 건)
한 레코드 최대       13 항목
```

경로에는 끊을 공백이 없어서 이런 줄은 래핑되지 않고 행을 가로로 넘긴다. 두 리스트에 `break-words` 를 건다.

자르지 않는다: 키퍼가 1 KB 덩어리를 아티팩트 참조로 제출한 사실 자체가 운영자가 봐야 할 진단 신호다. 리스트는 접힌 `<details>` 안에 있으므로 비용은 펼칠 때만 든다.

## 수정 3 — 두 독자의 불일치 (MASC Agent 리뷰에서 발견)

첫 구현은 영속 JSON 을 필드 단위로 다시 읽었다. 그래서 `reference` 는 있지만 `content`/`bytes`/`truncated` 가 없거나 잘못된 artifact 항목이 **식별 줄로는 정상 렌더되는데 authority-scoped payload 라우트는 같은 바이트를 거부**했다. 한 스냅샷을 두 독자가 서로 다르게 "정상"이라고 판정했고, 운영자는 payload 라우트가 서빙할 수 없는 증거를 본 셈이다.

`submitted_evidence_item_of_yojson` 의 타입 값에 매치하도록 교체했다. 불일치가 표현 불가능해지고, 새 variant 는 런타임 `unknown kind` 문자열이 아니라 컴파일 에러가 된다 — `.mli` 가 "이 모듈이 모양을 소유한다"고 이미 선언한 바로 그것이다. 24 줄이 8 줄이 됐고, `invalid_reference` 매직 스트링은 상수로 뽑았다.

테스트도 함께 강화됐다: `reference` 만 있고 payload 메타데이터가 없는 artifact 는 이름조차 노출되지 않고 배열 전체를 실패시킨다는 단언이 추가됐다. 이 단언은 교체 전 구현에서 실패한다.

## 라이브 실측 (84 레코드)

현행 직렬화기가 내는 항목은 전부 통과한다: artifact 47, note 231, unreadable 6.

거부되는 것은 더 이상 쓰이지 않는 **두 세대 이전 스키마**다.

- `reason` 이 객체가 아니라 문자열: `"invalid_reference"` 63 건, `"missing"` 44 건
- `submitted_evidence` 항목 자체가 문자열(materialization 이전): 27 건

의도적으로 거부한다. 읽는 쪽이 여러 모양을 관용하는 것이 드리프트가 쌓인 방식이고, 현행 `evidence_read_failure_to_yojson` 는 언제나 `{"code": ...}` 를 쓰므로 문자열 형태는 레거시다. 이 PR 은 현재와 앞으로의 검증을 운영자에게 도달시킨다. 드리프트 자체는 버전 봉투가 필요한 별개 문제다.

## 테스트

**OCaml (12/12)**
- `projects every snapshot item kind` — artifact / note / unreadable 세 종류가 각각 식별 줄로 도달
- `snapshot projection edges` — 빈 스냅샷은 오류 없이 빈 배열, reference 없는 invalid 도 이유를 남김, 미지 kind 는 항목 하나를 조용히 버리지 않고 **배열 전체를 실패**시킴, 그리고 payload 메타데이터 없는 artifact 는 이름조차 노출되지 않음(두 독자 불일치 고정)
- 픽스처를 스냅샷 모양으로 교체(artifact 항목이 참조로 되투영되므로 기존 단언 유효), malformed 기대 메시지 갱신

**Panel (12/12)**
- `renders projected snapshot identity lines verbatim` — 경로 구분자, note 접두사, 한글, 괄호 실패 사유가 그대로 렌더
- `wraps oversized identity lines instead of overflowing the row` — 공백 없는 900+ 자 경로, 두 리스트의 `break-words` 단언
- **이 케이스는 실패 능력을 확인했다**: `break-words` 를 제거하면 정확히 이 케이스만 실패한다 (1 failed / 11 passed)

## 로컬 검증

```
dune build --root . @check                               exit 0
dune exec --root . test/test_dashboard_verification.exe  12 tests, Test Successful
npx vitest run verification-requests-panel.test.ts       12 passed
npx tsc --noEmit                                         exit 0
```

`--root .` 필요: 워크트리에서 그냥 `dune build` 하면 부모 체크아웃을 빌드한다(가짜 green). 대시보드는 fresh worktree 에 `node_modules` 가 없어 `pnpm install --frozen-lockfile` 선행이 필요하다 — 없이 돌리면 가짜 결과가 난다.

## 미검증

- 브라우저 실렌더는 확인하지 못했다(Chrome 확장 미연결). 검증은 jsdom 기반 패널 테스트로 대체했고, 래핑은 클래스 존재로만 단언한다 — 실제 픽셀 레이아웃은 확인하지 않았다
- CI 의 다른 매트릭스 레그는 로컬에서 확인하지 않았다
- 개행을 포함한 note 2 건은 HTML 에서 한 줄로 접힌다. 의도적으로 두었다(식별 줄이지 본문이 아니다)

RFC-WAIVED: 읽는 쪽을 현행 쓰기 모양에 맞추는 수정 + 레이아웃 규칙 1 개. 새 계약·상태를 도입하지 않으며 blast radius 는 대시보드 투영 1 곳, 저장소 신규 함수 1 개, 패널 CSS 클래스다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
