### PR TITLE
fix(keeper): 할 일 없음 보고는 답변이지 Board 게시가 아니다

### DIFF
--- a/config/prompts/keeper.system.md
+++ b/config/prompts/keeper.system.md
@@ -124,8 +124,13 @@ conclusion that there is nothing to do. Your goals, memory, and repositories are
 still there to work from.
 
 If nothing is actionable after inspecting current state, give a concise no-work
-report. For a progress or completion claim, name the subject and give the exact
-Task ID, artifact, operation ID, commit, trace, or pull request that proves it.
+report as your answer for the turn, and stop there. A no-work report is not a
+Board post. The Board carries what another Keeper can act on; an unchanged
+status republished every cycle crowds that view and accumulates in your own
+history without adding a fact. Post when what you found is new.
+
+For a progress or completion claim, name the subject and give the exact Task ID,
+artifact, operation ID, commit, trace, or pull request that proves it.
 
 Tool calls, typed task and goal transitions, and the runtime checkpoint are the
 authoritative record of your action. Do not invent a second state protocol in

--- a/test/test_keeper_prompt_metrics.ml
+++ b/test/test_keeper_prompt_metrics.ml
@@ -304,6 +304,23 @@ let test_merged_system_block_keeps_turn_intent_rules () =
     (has_in prompt "A Task claim coordinates ownership; it grants no additional authority");
   check bool "no-work report is a valid outcome" true
     (has_in prompt "give a concise no-work report");
+  (* The rule said to report and never said where, so the report went to the
+     shared surface. Measured on the live workspace 2026-08-05: every one of
+     the 26 board posts of the preceding 4.7 hours was taskmaster's
+     "[TASKMASTER] Hourly status -- 0 unclaimed", none of them answered, the
+     gap between them shrinking from 85 minutes to 4; the newest comment by
+     then was 9.2 hours old. That keeper's own config already carries the same
+     defect from 2026-07-20, when an unrouted "report" instruction flowed into
+     keeper_task_create and left 272 identical meta-tasks -- naming
+     keeper_broadcast fixed the channel but not the unconditional report, so
+     the flood moved to the Board. [Own_board_posts] is a context layer, so
+     the copies also accumulate in the poster's own history. *)
+  check bool "a no-work report is answered, not posted" true
+    (has_in prompt "A no-work report is not a Board post");
+  check bool "the cost of republishing an unchanged status is stated" true
+    (has_in prompt "an unchanged status republished every cycle crowds that view");
+  check bool "posting is tied to newness" true
+    (has_in prompt "Post when what you found is new");
   check bool "completion claims name their evidence" true
     (has_in prompt "give the exact Task ID, artifact, operation ID, commit, trace, or pull request");
   check bool "no second state protocol in prose" true


### PR DESCRIPTION
## 무엇이 문제인가

`keeper.system.md` 는 "할 일이 없으면 보고하라"고만 말하고 **어디에** 보고할지는 말하지 않았다. 그래서 보고가 공유 surface 로 흘렀다.

라이브 워크스페이스 실측 (2026-08-05 09:23, `~/me/.masc`):

```
직전 6시간 board post 26건  →  26건 전부 taskmaster
                              "[TASKMASTER] Hourly status — 0 unclaimed"
                              댓글 0건
간격                          04:17 → 05:42 → 06:18 … 08:39 → 08:39 → 09:01
                              85분에서 4분으로 좁혀짐 ("Hourly" 라는 제목과 무관)
가장 최근 board comment        9.2시간 전
tasks/backlog.json mtime       7.4시간 전
```

즉 **게시는 가속되는데 대화는 멈춰 있다.** 최근 board 창은 한 keeper 의 무변화 상태 보고가 전부다.

## 같은 결함의 재발

`taskmaster.toml` 이 2026-07-20 사고를 이미 기록하고 있다:

> `unclaimed면 보고하고 / 재할당` 지시가 도구를 지정하지 않아, 보고·라우팅이 `keeper_task_create` 로 흘러 새 unclaimed task 를 만들었다. 그 task 가 다음 턴에 같은 트리거를 스스로 충족시켜 동일 템플릿 272건이 쌓였다.

당시 수정은 "보고는 `keeper_broadcast` 로 한다" — **채널만 지정하고 보고 자체의 조건은 두지 않았다.** 그래서 홍수가 task 에서 Board 로 자리를 옮겼다. 같은 config 에 `세상 상태가 지난 턴과 같으면 아무것도 하지 않는 것이 정답이다` 라는 문장이 이미 있지만, system prompt 가 행동을 지정하는 쪽이라 그쪽이 이겼다.

`Own_board_posts` 는 context layer 이므로(`lib/keeper/keeper_context_layers.ml:13`) 같은 글이 게시자 자신의 히스토리에도 그대로 쌓인다.

## 변경

`config/prompts/keeper.system.md` — "Choosing the next action" 의 한 문단:

```diff
 If nothing is actionable after inspecting current state, give a concise no-work
-report. For a progress or completion claim, name the subject and give the exact
-Task ID, artifact, operation ID, commit, trace, or pull request that proves it.
+report as your answer for the turn, and stop there. A no-work report is not a
+Board post. The Board carries what another Keeper can act on; an unchanged
+status republished every cycle crowds that view and accumulates in your own
+history without adding a fact. Post when what you found is new.
+
+For a progress or completion claim, name the subject and give the exact Task ID,
+artifact, operation ID, commit, trace, or pull request that proves it.
```

Gate/카운터/cap/dedup 을 추가하지 않았다. 모호한 지시를 채널이 명시된 지시로 바꾼 것이다. `제약은 최소화하고 많이 협업하도록` 이라는 방향과 같다 — Board 에서 노이즈를 빼면 남는 것이 협업 재료다.

## 검증

```
dune build @check                                     exit 0
test_keeper_prompt_metrics.exe                        24/24 pass
negative control (prompt만 origin/main 으로 되돌림)     FAIL: "a no-work report is answered, not posted"
                                                      → 테스트가 embedded default 가 아니라
                                                        디스크의 config/prompts 를 읽는다는 것도 함께 확인
ocamlformat --check test/test_keeper_prompt_metrics.ml exit 0
```

기존 단언 `give a concise no-work report` 는 `collapse_whitespace` 후 부분일치라 그대로 통과한다 (보고 자체는 여전히 유효한 결과다 — 위치만 정해졌다).

## 검증하지 않은 것

- 실제 게시 빈도가 줄어드는지는 배포 후 관측 필요. 확인 지표: taskmaster 의 시간당 board post 수, board comment 최신성.
- 다른 keeper 들의 memory 에 남아 있는 자기제한 constraint 5건(아래)은 런타임 데이터라 이 PR 이 건드리지 않는다.

## 관련

라이브 memory 에 남아 있는 자기제한 constraint (별건, 이슈로 기록 예정):

| keeper | constraint |
|---|---|
| code-reviewer | `Only act on new [verification] tagged posts or direct mentions; unclaimed implementation tasks … should be ignored` |
| kidsnote | `only intervening … when directly mentioned (@kidsnote) or assigned` |
| analyst | `suppress periodic polling and switch to low-frequency keepalive` |
| lane-smith | `[blocker] scheduler loop causing ~30s autonomous wakes with empty backlogs` |
| full-cycle-probe | `does not autonomously claim backlog tasks` (operator 지시 충실 요약) |

#26858 (librarian: 규칙을 역으로 저장하지 않는다) 이 향후 승격을 막고, 이 PR 은 빈 backlog 에서 나오는 반대쪽 반응(무한 보고)을 막는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

`pr-rfc-check.sh --pr-body` PASS (exit 0). 게이트가 실제로 판정하는지 positive control 로 확인함 — `add a cooldown` / `this change is a workaround` / `only fixed 3 of 8 sites` 각각 exit 1.
