### PR TITLE
docs(keeper): 코드에 없는 심볼을 설명하는 .mli 주석 2건 제거

### DIFF
--- a/lib/keeper/keeper_board_attention_worker.mli
+++ b/lib/keeper/keeper_board_attention_worker.mli
@@ -34,10 +34,12 @@ type drain_outcome =
       { contention : contention
       ; reason : retry_reason
       }
-(** [Owner_generation_deferred] terminates only the stale worker generation.
-    It neither marks the durable partition drained nor schedules a retry; the
-    unchanged pending partition remains discoverable when the lifecycle-owned
-    registration starts the next owner generation. *)
+(** [Drained] clears the contention re-arms; [Retry_later] keeps the durable
+    partition undrained and re-arms the contention timer, so the same worker
+    re-inspects it (see [apply_drain_rearm]). A generation that moved under the
+    worker arrives here as [Retry_later { reason = Selected_generation_changed }]
+    and is retried, not abandoned. The ledger stays the work authority in both
+    cases. *)
 
 type rearm_schedule =
   | Rearm_scheduled of { delay_s : float }

--- a/lib/keeper/keeper_unified_turn_terminal_error.mli
+++ b/lib/keeper/keeper_unified_turn_terminal_error.mli
@@ -3,7 +3,7 @@
 
     Two paths based on [Keeper_error_classify.is_runtime_exhausted_error]:
 
-    - [Runtime_exhausted] — sets registry to [Turn_runtime_exhausted],
+    - [Runtime_exhausted] — calls [Keeper_registry.mark_turn_runtime_exhausted],
       increments the [kcl_to_ktc_exhaustion] FSM edge counter, logs a
       structured WARN listing the attempted runtimes, and increments
       the [oas_execution_errors] counter with phase [Runtime_exhausted].


### PR DESCRIPTION
## 왜

`keeper_board_attention_worker.mli` 의 `drain_outcome` 주석이 **존재하지 않는 생성자**를 설명하고, 그 설명이 실제 코드와 **정반대**였다.

```ocaml
type drain_outcome =
  | Drained
  | Retry_later of { contention : contention; reason : retry_reason }
(** [Owner_generation_deferred] terminates only the stale worker generation.
    It neither marks the durable partition drained nor schedules a retry; ... *)
```

- `Owner_generation_deferred` — 저장소 전체에서 이 주석 한 줄이 유일한 등장이다.
- `neither ... schedules a retry` — 실제로는 재시도한다:

```ocaml
(* worker.ml:1665 *)
Ok (Retry_later { contention; reason = Selected_generation_changed })

(* worker.ml:355 *)
| Retry_later { contention; reason = _ } ->
  reset_contention_rearms scheduler ~keep:(Some contention);
  Some (schedule_contention_rearm scheduler contention)
```

## 실제로 사람을 속였다

라이브 board attention 적체(pending 719건, #26863)를 진단하면서 이 주석을 계약으로 읽고 **"stale generation 은 외부 재시작 없이는 영구 정지"** 라는 근본원인 가설을 세웠다. `.ml` 을 확인하고서야 틀린 걸 알았다. 이슈에 정정 코멘트를 달았다.

죽은 주석은 읽는 사람을 멈추게 하는 게 아니라 **틀린 방향으로 자신 있게 보낸다.**

## 두 번째 건

`keeper_unified_turn_terminal_error.mli`:

```diff
-    - [Runtime_exhausted] — sets registry to [Turn_runtime_exhausted],
+    - [Runtime_exhausted] — calls [Keeper_registry.mark_turn_runtime_exhausted],
```

`Turn_runtime_exhausted` 라는 phase 는 없다. 함수 이름을 상태 이름으로 적었다. 동작 설명 자체는 맞아서 위 건보다 해가 작다.

## 스윕 범위 (2 of 12, 나머지 10은 정상)

`lib/**/*.mli` doc comment 의 `[Capitalized]` 참조 **1,174종**을 추출해 `.mli` 밖 어디에도 없는 이름을 찾았다 — 12건.

| 판정 | 이름 |
|---|---|
| **stale (이 PR)** | `Owner_generation_deferred`, `Turn_runtime_exhausted` |
| TLA+ action / spec 이름 | `NoDrainTransition`, `GhostDispatch`, `TurnDequeue`, `Guard_ok`, `Undecided` |
| 외부 구현 참조 | `EndTruncatingAccumulator` (claude-code), `Docker_runtime` |
| 문서/환경 개념 | `Disp_pause_human`, `Mid_turn_no_progress`, `Runtime_strategy` |

**lint 은 추가하지 않았다.** 이 형태의 검사는 12건 중 10건이 오탐(83%)이고, 통과시키려면 allowlist 가 필요하다 — CLAUDE.md 가 거부하는 string classifier 형태다. 판정 근거를 여기 남겨 다음 사람이 스캔을 다시 돌리지 않게 한다.

## 검증

```
dune build @check                                  exit 0
ocamlformat --check (두 .mli)                       exit 0
```

주석만 바뀌므로 동작 변화 없음. 새 주석의 주장은 `worker.ml:355` `apply_drain_rearm` 과 `worker.ml:1665` 로 직접 대조 가능하다.

관련: #26863

🤖 Generated with [Claude Code](https://claude.com/claude-code)
