### PR TITLE
fix(keeper): show autonomous turns in chat after commit

### DIFF
--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -1335,7 +1335,8 @@ export async function moveKeeperChatPendingEntryToEnd(
 
 /** React to a server `keeper_chat_appended` push: re-merge the
  *  persisted transcript so messages arriving through other connectors
- *  (Discord, Slack, agent MCP) appear without a page reload.
+ *  (Discord, Slack, agent MCP), plus committed autonomous turns, appear
+ *  without a page reload.
  *
  *  A keeper that is not in `hydratedChatKeepers` reaches the guard below
  *  for one of two reasons: (a) its panel was never opened — mount

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -381,7 +381,9 @@ function handleKeeperLifecycle(event: { type: string; name?: string }): void {
     scheduleRefresh('operator', () => _refreshOperatorFn?.(), SSE_KEEPER_OPERATOR_DEBOUNCE_MS)
   }
 
-  // keeper_turn_complete: re-hydrate active keeper's conversation + trajectory
+  // keeper_turn_complete is an SDK-hook event that can precede the durable
+  // TurnRecord commit, so it refreshes status only. Transcript freshness is
+  // driven by the post-commit keeper_chat_appended invalidation.
   if (normalizeMascEventType(event.type) === 'keeper_turn_complete') {
     const keeperName = event.name ?? ''
     if (!keeperName) return

--- a/lib/keeper/keeper_chat_broadcast.mli
+++ b/lib/keeper/keeper_chat_broadcast.mli
@@ -16,11 +16,10 @@ type audio_clip = {
   expired : bool;
 }
 
-(** Broadcast a [keeper_chat_appended] SSE event after a completed turn
-    is persisted to the keeper's chat JSONL. The dashboard uses it to
-    re-merge the server transcript live, so messages arriving through
-    other connectors (Discord, Slack, agent MCP) appear without a page
-    reload.
+(** Broadcast a [keeper_chat_appended] SSE event after a transcript-visible
+    row is committed to its authoritative store: the chat JSONL for direct
+    messages, or the TurnRecord store for autonomous turns. The dashboard uses
+    it to re-merge the server transcript live without a page reload.
 
     The event has no dashboard slice mapping on purpose: slice-less
     events take the WS raw-forward catch-all to every authenticated

--- a/lib/keeper/keeper_turn_record_writer.ml
+++ b/lib/keeper/keeper_turn_record_writer.ml
@@ -51,7 +51,14 @@ let write
   in
   try
     let store = Keeper_types_support.keeper_turn_record_store config keeper_name in
-    Dated_jsonl.append store (Turn_record.to_json record)
+    Dated_jsonl.append store (Turn_record.to_json record);
+    match turn_kind with
+    | Turn_record.Autonomous ->
+      Keeper_chat_broadcast.chat_appended
+        ~keeper_name
+        ~source:"agent"
+        ()
+    | Turn_record.Direct -> ()
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->

--- a/lib/keeper/keeper_turn_record_writer.mli
+++ b/lib/keeper/keeper_turn_record_writer.mli
@@ -1,5 +1,8 @@
 (** RFC-0233 §2.2 — append one TurnRecord per keeper turn, at the same
-    cadence as the execution receipt.
+    cadence as the execution receipt. A committed autonomous record emits
+    [keeper_chat_appended] so an open dashboard transcript re-reads its
+    authoritative history without waiting for a page reload. Direct turns
+    already emit that invalidation from their chat-store append path.
 
     Append failures never fail the turn: they log a WARN with the
     keeper/trace coordinates (the receipt path already guards turn

--- a/test/test_keeper_autonomous_turn_source.ml
+++ b/test/test_keeper_autonomous_turn_source.ml
@@ -113,46 +113,53 @@ let run_ref ~path ~worker_run_id ~start_seq =
 ;;
 
 let write_turn_record config ~absolute_turn ~generation ~turn_kind ~raw_trace_run_ref =
-  let record : Turn_record.t =
-    { execution_ids = []
-    ; keeper = keeper_name
-    ; agent_name
-    ; generation
-    ; turn_kind
-    ; trace_id
-    ; absolute_turn
-    ; turn_ref = Ids.Turn_ref.make ~trace_id ~absolute_turn
-    ; blocks = []
-    ; input_components = None
-    ; runtime_profile = "test-runtime"
-    ; model = Some "public-model"
-    ; finish_reason = Some "completed"
-    ; context_window = None
-    ; price_input_per_million = None
-    ; price_output_per_million = None
-    ; request_latency_ms = None
-    ; ttfrc_ms = None
-    ; request_wire_observation = None
-    ; raw_trace_run_ref
-    ; sampling =
-        { temperature = None
-        ; top_p = None
-        ; max_tokens = None
-        ; thinking_budget = None
-        ; enable_thinking = None
-        }
-    ; usage =
-        { input_tokens = None
-        ; output_tokens = None
-        ; cache_creation_input_tokens = None
-        ; cache_read_input_tokens = None
-        }
-    ; ts = 1000. +. float_of_int absolute_turn
-    }
-  in
-  Dated_jsonl.append
-    (Keeper_types_support.keeper_turn_record_store config keeper_name)
-    (Turn_record.to_json record)
+  Keeper_turn_record_writer.write
+    ~config
+    ~keeper_name
+    ~agent_name
+    ~generation
+    ~turn_kind
+    ~trace_id
+    ~absolute_turn
+    ~runtime_profile:"test-runtime"
+    ~model:(Some "public-model")
+    ~finish_reason:(Some "completed")
+    ~context_window:None
+    ~price_input_per_million:None
+    ~price_output_per_million:None
+    ~request_latency_ms:None
+    ~ttfrc_ms:None
+    ~request_wire_observation:None
+    ~raw_trace_run_ref
+    ~sampling:
+      { temperature = None
+      ; top_p = None
+      ; max_tokens = None
+      ; thinking_budget = None
+      ; enable_thinking = None
+      }
+    ~usage:
+      { input_tokens = None
+      ; output_tokens = None
+      ; cache_creation_input_tokens = None
+      ; cache_read_input_tokens = None
+      }
+    ~execution_ids:[]
+    ~blocks:[]
+    ~input_components:None
+    ()
+;;
+
+let keeper_chat_appended_for expected_name frame =
+  match Sse.data_payload_of_frame frame with
+  | Error Sse.Missing_data_payload -> false
+  | Ok payload ->
+    (match Yojson.Safe.from_string payload with
+     | `Assoc fields ->
+       List.assoc_opt "type" fields = Some (`String "keeper_chat_appended")
+       && List.assoc_opt "name" fields = Some (`String expected_name)
+     | _ -> false
+     | exception Yojson.Json_error _ -> false)
 ;;
 
 let trace_path config suffix =
@@ -288,6 +295,62 @@ let test_since_and_limit_use_current_records () =
     (List.map (fun (turn : Keeper_autonomous_turn_source.turn) -> turn.final_text) turns)
 ;;
 
+let test_committed_autonomous_turn_invalidates_live_chat () =
+  with_workspace @@ fun config ->
+  let path = trace_path config "live-chat" in
+  let worker_run_id = "run-live-chat" in
+  write_lines path
+    (run_lines ~worker_run_id ~start_seq:1 ~base_ts:6000.
+       ~prompt:Keeper_unified_prompt.autonomous_wake_marker
+       ~final_text:"visible without reload");
+  let visible_turns_at_broadcast = ref None in
+  let subscriber_id =
+    Printf.sprintf "autonomous-chat-live-%d-%d" (Unix.getpid ())
+      (Random.int 1_000_000)
+  in
+  Eio.Switch.run @@ fun sw ->
+  Eio.Switch.on_release sw (fun () -> Sse.unsubscribe_external subscriber_id);
+  Sse.subscribe_external ~id:subscriber_id
+    ~callback:(fun frame ->
+      if keeper_chat_appended_for keeper_name frame
+      then
+        visible_turns_at_broadcast :=
+          Some
+            (Keeper_autonomous_turn_source.load_recent
+               ~config ~keeper_name ()))
+    ();
+  write_turn_record config ~absolute_turn:46 ~generation:9
+    ~turn_kind:Turn_record.Autonomous
+    ~raw_trace_run_ref:
+      (Some (run_ref ~path ~worker_run_id ~start_seq:1));
+  match !visible_turns_at_broadcast with
+  | Some [ turn ] ->
+    Alcotest.(check (option string)) "committed outcome is readable at broadcast"
+      (Some "visible without reload") turn.final_text
+  | Some turns ->
+    Alcotest.failf "expected one committed turn at broadcast, got %d"
+      (List.length turns)
+  | None -> Alcotest.fail "committed autonomous turn emitted no chat invalidation"
+;;
+
+let test_direct_turn_does_not_duplicate_chat_invalidation () =
+  with_workspace @@ fun config ->
+  let invalidations = ref 0 in
+  let subscriber_id =
+    Printf.sprintf "direct-chat-live-%d-%d" (Unix.getpid ())
+      (Random.int 1_000_000)
+  in
+  Eio.Switch.run @@ fun sw ->
+  Eio.Switch.on_release sw (fun () -> Sse.unsubscribe_external subscriber_id);
+  Sse.subscribe_external ~id:subscriber_id
+    ~callback:(fun frame ->
+      if keeper_chat_appended_for keeper_name frame then incr invalidations)
+    ();
+  write_turn_record config ~absolute_turn:47 ~generation:9
+    ~turn_kind:Turn_record.Direct ~raw_trace_run_ref:None;
+  Alcotest.(check int) "direct chat path owns its invalidation" 0 !invalidations
+;;
+
 (* The OAS runtime identity is opaque here. The reader validates it against
    the selected raw rows without comparing it to the Keeper identity. *)
 let sdk_run_ref ~agent_name ~session_id : Agent_sdk.Raw_trace.run_ref =
@@ -361,6 +424,10 @@ let () =
             test_mismatched_raw_trace_session_identity_is_skipped
         ; Alcotest.test_case "since and limit use current records" `Quick
             test_since_and_limit_use_current_records
+        ; Alcotest.test_case "committed autonomous turn invalidates live chat" `Quick
+            test_committed_autonomous_turn_invalidates_live_chat
+        ; Alcotest.test_case "direct turn does not duplicate chat invalidation" `Quick
+            test_direct_turn_does_not_duplicate_chat_invalidation
         ] )
     ; ( "exact_run_reference"
       , [ Alcotest.test_case "records the OAS runtime identity" `Quick


### PR DESCRIPTION
## What changed

- emit the existing `keeper_chat_appended` invalidation immediately after an autonomous `TurnRecord` commits
- keep direct turns on their existing chat-store invalidation path, avoiding duplicate refreshes
- document that `keeper_turn_complete` is pre-commit status telemetry, not transcript freshness
- add a regression test that reads the committed autonomous projection from inside the broadcast callback

## Root cause

`keeper_turn_complete` is emitted by the SDK `after_turn` hook before the durable `TurnRecord` append. The dashboard therefore refreshed keeper status while the autonomous transcript row still did not exist, and no post-commit chat invalidation followed. The row appeared only after a later reload or reconnect.

## Impact

An open Keeper conversation now re-fetches its authoritative history as soon as an autonomous turn becomes durable, so autonomous work appears without a manual page reload. A failed append emits no ghost chat invalidation.

## Validation

- `scripts/dune-local.sh build lib/masc.cmxa`
- `scripts/dune-local.sh exec ./test/test_keeper_autonomous_turn_source.exe` — 12 passed
- `pnpm typecheck`
- focused dashboard Vitest (`keeper-actions.test.ts`, `sse-store.test.ts`) — 140 passed
- `scripts/harness_dashboard_keeper_autonomous_public_history_dom_smoke.sh` — Playwright interaction passed

After rebasing onto current `origin/main`, the dashboard typecheck and 140 focused tests passed again. The OCaml diff had already passed before the rebase; the two upstream commits touch only Keeper prompt files and their tests, while a separate live `dune build --root .` prevented a redundant concurrent local rerun. PR CI remains the exact-head build authority.
