### PR TITLE
refactor: type Keeper message boundary

### DIFF
--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -245,9 +245,6 @@ let normalized_or_unknown value =
   | "" -> "unknown"
   | trimmed -> trimmed
 
-let string_assoc_json fields =
-  `Assoc (List.map (fun (key, value) -> (key, `String value)) fields)
-
 (** Sanitize a value for use as a filesystem path component.
     Replaces everything outside [A-Za-z0-9_-] with '_' so that the resulting
     string cannot escape its intended parent directory via '/', '\\', or '..'
@@ -716,26 +713,19 @@ let dispatch_core ?on_text_snapshot ~submitted_by ~sw ~clock ~proc_mgr ~net
     ();
   Keeper_chat_broadcast.chat_appended
     ~keeper_name ~source:lane ();
-  let args =
-    `Assoc [
-      ("name", `String keeper_name);
-      ( "message",
-        `String
-          (contextualize_message ~channel ~channel_user_id ~channel_user_name
-             ~channel_workspace_id ~metadata ~content) );
-      ("direct_reply", `Bool true);
-      ("channel_session_key", `String channel_session_key);
-      (* RFC-0223 P1: raw connector identity, consumed by
-         [Keeper_tool_surface_ops.append_direct_chat_pair_if_reply] so the
-         persisted chat line carries the lane label and speaker instead
-         of the generic "agent" source. Internal-only args, same class
-         as [direct_reply] / [channel_session_key]. *)
-      ("channel", `String channel);
-      ("channel_workspace_id", `String channel_workspace_id);
-      ("channel_user_id", `String channel_user_id);
-      ("channel_user_name", `String channel_user_name);
-      ("channel_metadata", string_assoc_json metadata);
-    ]
+  let direct_message =
+    Keeper_invocation_contract.direct_message
+      ~keeper_name
+      ~prompt:
+        (contextualize_message ~channel ~channel_user_id ~channel_user_name
+           ~channel_workspace_id ~metadata ~content)
+      ~direct_reply:true
+      ~channel_session_key
+      ~channel
+      ~user_blocks:[]
+      ~attachments:[]
+      ()
+    |> Result.map_error Keeper_invocation_contract.request_error_to_string
   in
   let keeper_ctx : _ Keeper_tool_surface.context = {
     config;
@@ -762,26 +752,30 @@ let dispatch_core ?on_text_snapshot ~submitted_by ~sw ~clock ~proc_mgr ~net
                  "channel gate text snapshot callback failed (keeper=%s): %s"
                  keeper_name (Printexc.to_string exn))
   in
-  let defer_to_existing_work
+  let defer_to_existing_work message
       (admission_rejection : Keeper_turn_admission.rejection) =
     `Async_ack
       ( admission_rejection.in_flight
       , Some
           (Keeper_tool_surface.dispatch_keeper_msg ~submitted_by keeper_ctx
-             ~args) )
+             ~message) )
   in
   let dispatch_result =
-    (* The admission boundary, not a route-level peek, owns the FIFO decision.
-       It rechecks the durable queue after acquiring the Keeper turn slot. *)
-    match
-      Keeper_tool_surface.dispatch_keeper_msg_stream_if_free
-        ~on_text_delta keeper_ctx ~args
-    with
-    | `Ran result -> `Streaming result
-    | `Busy admission_rejection ->
-      defer_to_existing_work admission_rejection
+    match direct_message with
+    | Error error -> `Invalid_message error
+    | Ok message ->
+      (* The admission boundary, not a route-level peek, owns the FIFO decision.
+         It rechecks the durable queue after acquiring the Keeper turn slot. *)
+      (match
+         Keeper_tool_surface.dispatch_keeper_msg_stream_if_free
+           ~on_text_delta keeper_ctx ~message
+       with
+       | `Ran result -> `Streaming result
+       | `Busy admission_rejection ->
+         defer_to_existing_work message admission_rejection)
   in
   match dispatch_result with
+  | `Invalid_message error -> Gate_protocol.Keeper_error_result error
   | `Async_ack (in_flight, Some result) when not (Tool_result.is_failed result) ->
       let body = Tool_result.message result in
       let duration_ms =

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -71,7 +71,6 @@ val invalid_name_error : string -> string
 val removed_keeper_input_key_names : string list
 
 (** Field names that are no longer accepted in keeper message input. *)
-val removed_keeper_msg_input_key_names : string list
 
 (** Return which [keys] are present as top-level keys in the JSON object. *)
 val present_json_keys : string list -> Yojson.Safe.t -> string list
@@ -84,8 +83,6 @@ val reject_removed_keeper_input_keys :
   (unit, string) result
 
 (** Reject removed keeper message input keys. *)
-val reject_removed_keeper_msg_input_keys :
-  tool_name:string -> Yojson.Safe.t -> (unit, string) result
 
 (** {1 UTF-8 Safety} *)
 

--- a/lib/keeper/keeper_config_text.ml
+++ b/lib/keeper/keeper_config_text.ml
@@ -97,43 +97,6 @@ let removed_keeper_sandbox_input_key_names =
     "network_mode";
   ]
 
-type removed_keeper_msg_input_owner =
-  | Request_lifecycle
-  | Keeper_definition_field of string
-      (* the input moved to [masc_keeper_up] under this exact field name *)
-  | Keeper_definition_deleted
-      (* the concept itself was removed; no tool accepts a replacement *)
-  | Tool_selection
-
-type removed_keeper_msg_input =
-  { name : string
-  ; owner : removed_keeper_msg_input_owner
-  }
-
-(* Each entry names the input a caller may still send and the truthful way to
-   express the same intent. A [Keeper_definition_field] claim is only made when
-   [masc_keeper_up] declares that exact property (Keeper_schema), so following
-   the remediation cannot produce a second rejection. *)
-let removed_keeper_msg_inputs =
-  [ { name = "timeout_sec"; owner = Request_lifecycle }
-  ; { name = "goal"; owner = Keeper_definition_deleted }
-  ; { name = "short_goal"; owner = Keeper_definition_deleted }
-  ; { name = "mid_goal"; owner = Keeper_definition_deleted }
-  ; { name = "long_goal"; owner = Keeper_definition_deleted }
-  ; { name = "instructions"; owner = Keeper_definition_field "instructions" }
-  ; { name = "require_existing"; owner = Keeper_definition_deleted }
-  ; { name = "new_goal"; owner = Keeper_definition_deleted }
-  ; { name = "new_short_goal"; owner = Keeper_definition_deleted }
-  ; { name = "new_mid_goal"; owner = Keeper_definition_deleted }
-  ; { name = "new_long_goal"; owner = Keeper_definition_deleted }
-  ; { name = "new_instructions"; owner = Keeper_definition_field "instructions" }
-  ; { name = "required_tools"; owner = Tool_selection }
-  ; { name = "required_tool_names"; owner = Tool_selection }
-  ]
-
-let removed_keeper_msg_input_key_names =
-  List.map (fun input -> input.name) removed_keeper_msg_inputs
-
 let present_json_keys (keys : string list) (json : Yojson.Safe.t) : string list =
   match json with
   | `Assoc fields ->
@@ -167,39 +130,6 @@ let reject_removed_keeper_input_keys ?(allow_sandbox_fields = false) ~tool_name
               carry backend details."
              tool_name
              (String.concat ", " sandbox_fields))
-
-let reject_removed_keeper_msg_input_keys ~tool_name (args : Yojson.Safe.t) =
-  let present =
-    match args with
-    | `Assoc fields ->
-      List.filter
-        (fun input -> List.mem_assoc input.name fields)
-        removed_keeper_msg_inputs
-    | _ -> []
-  in
-  let remediation input =
-    match input.owner with
-    | Request_lifecycle ->
-      "request-level whole-turn deadline is retired; use explicit operator \
-       cancellation, provider progress deadlines, or tool-local deadlines"
-    | Keeper_definition_field field ->
-      Printf.sprintf "set %s on masc_keeper_up instead" field
-    | Keeper_definition_deleted ->
-      "this input was removed and has no replacement field on any keeper tool"
-    | Tool_selection ->
-      "Keeper runtime selects tools from its declared capability surface"
-  in
-  let describe input =
-    Printf.sprintf "%s (%s)" input.name (remediation input)
-  in
-  match present with
-  | [] -> Ok ()
-  | inputs ->
-      Error
-        (Printf.sprintf
-           "removed keeper message args for %s: %s."
-           tool_name
-           (String.concat "; " (List.map describe inputs)))
 
 (* ── UTF-8 string processing ────────────────────────────────── *)
 

--- a/lib/keeper/keeper_config_text.mli
+++ b/lib/keeper/keeper_config_text.mli
@@ -29,7 +29,6 @@ val prompt_render_max_bytes : int
 (* ── Removed / rejected keeper input keys ───────────────────── *)
 
 val removed_keeper_input_key_names : string list
-val removed_keeper_msg_input_key_names : string list
 
 val present_json_keys : string list -> Yojson.Safe.t -> string list
 
@@ -38,9 +37,6 @@ val reject_removed_keeper_input_keys :
   tool_name:string ->
   Yojson.Safe.t ->
   (unit, string) result
-
-val reject_removed_keeper_msg_input_keys :
-  tool_name:string -> Yojson.Safe.t -> (unit, string) result
 
 (* ── UTF-8 string processing ────────────────────────────────── *)
 

--- a/lib/keeper/keeper_invocation_contract.ml
+++ b/lib/keeper/keeper_invocation_contract.ml
@@ -8,6 +8,18 @@ type request =
   ; prompt : string
   }
 
+type direct_message =
+  { request : request
+  ; direct_reply : bool
+  ; turn_instructions : string option
+  ; surface_context : Yojson.Safe.t option
+  ; channel_session_key : string option
+  ; channel : string
+  ; user_blocks : Keeper_multimodal_input.user_input_block list
+  ; attachments : Keeper_chat_store.attachment list
+  ; user_oas_blocks : Agent_sdk.Types.content_block list option
+  }
+
 type run_ref =
   { run_id : string
   ; target : target
@@ -35,6 +47,7 @@ type request_error =
   | Invalid_target of string
   | Empty_prompt
   | Invalid_entry_projection
+  | Invalid_multimodal_input of string
   | Invalid_wire_value of
       { field : string
       ; expected : string
@@ -113,6 +126,82 @@ let request ~keeper_name ~prompt =
   else Ok { target = Keeper keeper_name; capability = Invoke_turn; prompt }
 ;;
 
+let nonempty_trimmed_option = function
+  | None -> None
+  | Some value ->
+    let value = String.trim value in
+    if String.equal value "" then None else Some value
+;;
+
+let direct_message
+      ~keeper_name
+      ~prompt
+      ~direct_reply
+      ?turn_instructions
+      ?surface_context
+      ?channel_session_key
+      ~channel
+      ~user_blocks
+      ~attachments
+      ()
+  =
+  let* request = request ~keeper_name ~prompt in
+  let* surface_context =
+    match surface_context with
+    | None -> Ok None
+    | Some (`Assoc _ as context) -> Ok (Some context)
+    | Some _ -> invalid_wire_value ~field:"surface_context" ~expected:"object"
+  in
+  let* user_oas_blocks =
+    Keeper_multimodal_input.to_oas_blocks ~attachments user_blocks
+    |> Result.map
+         (function
+           | [] -> None
+           | blocks -> Some blocks)
+    |> Result.map_error (fun reason -> Invalid_multimodal_input reason)
+  in
+  Ok
+    { request
+    ; direct_reply
+    ; turn_instructions = nonempty_trimmed_option turn_instructions
+    ; surface_context
+    ; channel_session_key = nonempty_trimmed_option channel_session_key
+    ; channel = String.trim channel
+    ; user_blocks
+    ; attachments
+    ; user_oas_blocks
+    }
+;;
+
+let direct_message_with_keeper_name message keeper_name =
+  direct_message
+    ~keeper_name
+    ~prompt:message.request.prompt
+    ~direct_reply:message.direct_reply
+    ?turn_instructions:message.turn_instructions
+    ?surface_context:message.surface_context
+    ?channel_session_key:message.channel_session_key
+    ~channel:message.channel
+    ~user_blocks:message.user_blocks
+    ~attachments:message.attachments
+    ()
+;;
+
+let direct_message_request message = message.request
+let direct_message_target_name message =
+  match message.request.target with
+  | Keeper name -> Keeper_id.Keeper_name.to_string name
+;;
+let direct_message_prompt message = message.request.prompt
+let direct_message_direct_reply message = message.direct_reply
+let direct_message_turn_instructions message = message.turn_instructions
+let direct_message_surface_context message = message.surface_context
+let direct_message_channel_session_key message = message.channel_session_key
+let direct_message_channel message = message.channel
+let direct_message_user_blocks message = message.user_blocks
+let direct_message_attachments message = message.attachments
+let direct_message_user_oas_blocks message = message.user_oas_blocks
+
 let request_of_json json =
   let* fields = object_fields ~field:"delegate" json in
   let* () =
@@ -134,6 +223,7 @@ let request_error_to_string = function
   | Invalid_target reason -> reason
   | Empty_prompt -> "message is required"
   | Invalid_entry_projection -> "Keeper invocation entry projection is not an object"
+  | Invalid_multimodal_input reason -> reason
   | Invalid_wire_value { field; expected } ->
     Printf.sprintf "%s must be %s" field expected
   | Run_ref_mismatch -> "run_ref does not identify the stored Keeper invocation"

--- a/lib/keeper/keeper_invocation_contract.mli
+++ b/lib/keeper/keeper_invocation_contract.mli
@@ -1,14 +1,21 @@
-(** Typed MASC boundary for invoking one Keeper from another tool lane.
+(** Typed MASC boundary for invoking one Keeper.
 
     This module owns no registry and starts no parallel scheduler. It projects
-    the existing durable {!Keeper_msg_async} owner into a typed target,
-    capability, run reference, and result contract. *)
+    the existing durable {!Keeper_msg_async} owner into typed direct-message
+    input, target, capability, run reference, and result contract. *)
 
 type capability = Invoke_turn
 
 type target = Keeper of Keeper_id.Keeper_name.t
 
 type request
+
+type direct_message
+(** Current direct-turn input after an adapter has decoded its wire request.
+    It contains exactly the turn-owned fields: target and prompt,
+    [direct_reply], optional turn/surface context, optional channel session,
+    channel label, semantic user blocks, and attachments. Connector identity
+    and metadata stay at their adapter boundary. *)
 
 type run_ref
 
@@ -33,6 +40,7 @@ type request_error =
   | Invalid_target of string
   | Empty_prompt
   | Invalid_entry_projection
+  | Invalid_multimodal_input of string
   | Invalid_wire_value of
       { field : string
       ; expected : string
@@ -40,6 +48,41 @@ type request_error =
   | Run_ref_mismatch
 
 val request : keeper_name:string -> prompt:string -> (request, request_error) result
+
+val direct_message :
+  keeper_name:string ->
+  prompt:string ->
+  direct_reply:bool ->
+  ?turn_instructions:string ->
+  ?surface_context:Yojson.Safe.t ->
+  ?channel_session_key:string ->
+  channel:string ->
+  user_blocks:Keeper_multimodal_input.user_input_block list ->
+  attachments:Keeper_chat_store.attachment list ->
+  unit ->
+  (direct_message, request_error) result
+
+val direct_message_with_keeper_name :
+  direct_message -> string -> (direct_message, request_error) result
+
+val direct_message_request : direct_message -> request
+val direct_message_target_name : direct_message -> string
+val direct_message_prompt : direct_message -> string
+val direct_message_direct_reply : direct_message -> bool
+val direct_message_turn_instructions : direct_message -> string option
+val direct_message_surface_context : direct_message -> Yojson.Safe.t option
+val direct_message_channel_session_key : direct_message -> string option
+val direct_message_channel : direct_message -> string
+
+val direct_message_user_blocks :
+  direct_message -> Keeper_multimodal_input.user_input_block list
+
+val direct_message_attachments :
+  direct_message -> Keeper_chat_store.attachment list
+
+val direct_message_user_oas_blocks :
+  direct_message -> Agent_sdk.Types.content_block list option
+
 val request_of_json : Yojson.Safe.t -> (request, request_error) result
 val request_error_to_string : request_error -> string
 val target_name : request -> string

--- a/lib/keeper/keeper_multimodal_input.ml
+++ b/lib/keeper/keeper_multimodal_input.ml
@@ -23,42 +23,85 @@ let attachment_to_yojson (att : Keeper_chat_store.attachment) =
 let attachments_to_yojson attachments =
   `List (List.map attachment_to_yojson attachments)
 
-let parse_attachment json =
-  match json with
-  | `Assoc _ ->
-      let id =
-        Json_util.get_string_with_default json ~key:"id" ~default:""
-        |> String.trim
-      in
-      let att_type =
-        Json_util.get_string_with_default json ~key:"type" ~default:""
-        |> String.trim
-      in
-      let name =
-        Json_util.get_string_with_default json ~key:"name" ~default:""
-        |> String.trim
-      in
-      let size =
-        match Json_util.assoc_member_opt "size" json with
-        | Some (`Int n) when n >= 0 -> n
-        | _ -> 0
-      in
-      let mime_type =
-        Json_util.get_string_with_default json ~key:"mime_type" ~default:""
-        |> String.trim
-      in
-      let data =
-        Json_util.get_string_with_default json ~key:"data" ~default:""
-      in
-      if id = "" || data = "" then None
-      else
-        Some { Keeper_chat_store.id; att_type; name; size; mime_type; data }
-  | _ -> None
+let ( let* ) = Result.bind
+
+let exact_object_fields ~field ~allowed = function
+  | `Assoc fields ->
+    let keys = List.map fst fields in
+    if List.length keys <> List.length (List.sort_uniq String.compare keys)
+    then Error (field ^ " must contain unique fields")
+    else
+      (match List.find_opt (fun key -> not (List.mem key allowed)) keys with
+       | Some key ->
+         Error
+           (Printf.sprintf
+              "%s.%s is undeclared; accepted fields: %s"
+              field
+              key
+              (String.concat ", " allowed))
+       | None -> Ok fields)
+  | _ -> Error (field ^ " must be a JSON object")
+;;
+
+let required_string ~field key fields =
+  match List.assoc_opt key fields with
+  | Some (`String value) -> Ok value
+  | Some _ -> Error (Printf.sprintf "%s.%s must be a string" field key)
+  | None -> Error (Printf.sprintf "%s.%s is required" field key)
+;;
+
+let optional_string ~field key fields =
+  match List.assoc_opt key fields with
+  | None -> Ok ""
+  | Some (`String value) -> Ok value
+  | Some _ -> Error (Printf.sprintf "%s.%s must be a string" field key)
+;;
+
+let parse_attachment ~index json =
+  let field = Printf.sprintf "attachments[%d]" index in
+  let* fields =
+    exact_object_fields
+      ~field
+      ~allowed:[ "id"; "type"; "name"; "size"; "mime_type"; "data" ]
+      json
+  in
+  let* id = required_string ~field "id" fields in
+  let* att_type = optional_string ~field "type" fields in
+  let* name = optional_string ~field "name" fields in
+  let* mime_type = optional_string ~field "mime_type" fields in
+  let* data = required_string ~field "data" fields in
+  let* size =
+    match List.assoc_opt "size" fields with
+    | None -> Ok 0
+    | Some (`Int size) when size >= 0 -> Ok size
+    | Some (`Int _) -> Error (field ^ ".size must be non-negative")
+    | Some _ -> Error (field ^ ".size must be an integer")
+  in
+  let id = String.trim id in
+  if String.equal id "" then Error (field ^ ".id must be non-empty")
+  else if String.equal data "" then Error (field ^ ".data must be non-empty")
+  else
+    Ok
+      { Keeper_chat_store.id
+      ; att_type = String.trim att_type
+      ; name = String.trim name
+      ; size
+      ; mime_type = String.trim mime_type
+      ; data
+      }
 
 let parse_attachments json =
   match Json_util.assoc_member_opt "attachments" json with
-  | Some (`List attachments) -> List.filter_map parse_attachment attachments
-  | _ -> []
+  | None | Some `Null -> Ok []
+  | Some (`List attachments) ->
+    let rec loop index acc = function
+      | [] -> Ok (List.rev acc)
+      | attachment :: rest ->
+        let* attachment = parse_attachment ~index attachment in
+        loop (index + 1) (attachment :: acc) rest
+    in
+    loop 0 [] attachments
+  | Some _ -> Error "attachments must be an array"
 
 let user_media_block_to_yojson kind (media : user_media_block) =
   let fields =
@@ -83,69 +126,70 @@ let user_block_to_yojson = function
 let user_blocks_to_yojson blocks =
   `List (List.map user_block_to_yojson blocks)
 
-let parse_user_media_block ~(kind : string) json =
-  let attachment_id =
-    Json_util.get_string_with_default json ~key:"attachment_id" ~default:""
-    |> String.trim
-  in
-  let name =
-    Json_util.get_string_with_default json ~key:"name" ~default:""
-    |> String.trim
-  in
-  let mime_type =
-    Json_util.get_string_with_default json ~key:"mime_type" ~default:""
-    |> String.trim
-  in
+let parse_user_media_block ~(kind : string) fields =
+  let field = "user_blocks " ^ kind ^ " block" in
+  let* attachment_id = required_string ~field "attachment_id" fields in
+  let* name = optional_string ~field "name" fields in
+  let* mime_type = optional_string ~field "mime_type" fields in
   let size =
-    match Json_util.assoc_member_opt "size" json with
-    | None | Some `Null -> Ok None
+    match List.assoc_opt "size" fields with
+    | None -> Ok None
     | Some (`Int size) when size >= 0 -> Ok (Some size)
-    | Some (`Int _) -> Error "user_blocks media size must be non-negative"
-    | Some _ -> Error "user_blocks media size must be an integer"
+    | Some (`Int _) -> Error (field ^ ".size must be non-negative")
+    | Some _ -> Error (field ^ ".size must be an integer")
   in
+  let attachment_id = String.trim attachment_id in
   if attachment_id = "" then
     Error (Printf.sprintf "user_blocks %s block requires attachment_id" kind)
   else
     match size with
     | Error err -> Error err
-    | Ok size -> Ok { attachment_id; name; mime_type; size }
+    | Ok size ->
+      Ok
+        { attachment_id
+        ; name = String.trim name
+        ; mime_type = String.trim mime_type
+        ; size
+        }
 
 let parse_user_input_block json =
-  match json with
-  | `Assoc _ ->
-      let block_type =
-        Json_util.get_string_with_default json ~key:"type" ~default:""
-        |> String.trim
-        |> String.lowercase_ascii
-      in
-      (match block_type with
-       | "text" ->
-           let text =
-             Json_util.get_string_with_default json ~key:"text" ~default:""
-             |> String.trim
-           in
-           if text = "" then
-             Error "user_blocks text block requires non-empty text"
-           else Ok (User_text text)
-       | "image" ->
-           Result.map
-             (fun media -> User_image media)
-             (parse_user_media_block ~kind:"image" json)
-       | "document" ->
-           Result.map
-             (fun media -> User_document media)
-             (parse_user_media_block ~kind:"document" json)
-       | "audio" ->
-           Result.map
-             (fun media -> User_audio media)
-             (parse_user_media_block ~kind:"audio" json)
-       | "" -> Error "user_blocks block requires type"
-       | other ->
-           Error
-             (Printf.sprintf
-                "unsupported user_blocks type %S: expected text, image, document, or audio"
-                other))
-  | _ -> Error "user_blocks entries must be JSON objects"
+  let* base_fields =
+    exact_object_fields
+      ~field:"user_blocks entry"
+      ~allowed:[ "type"; "text"; "attachment_id"; "name"; "mime_type"; "size" ]
+      json
+  in
+  let* block_type = required_string ~field:"user_blocks entry" "type" base_fields in
+  let block_type = String.trim block_type |> String.lowercase_ascii in
+  match block_type with
+  | "text" ->
+    let* fields =
+      exact_object_fields ~field:"user_blocks text block" ~allowed:[ "type"; "text" ] json
+    in
+    let* text = required_string ~field:"user_blocks text block" "text" fields in
+    let text = String.trim text in
+    if text = "" then Error "user_blocks text block requires non-empty text"
+    else Ok (User_text text)
+  | ("image" | "document" | "audio") as kind ->
+    let* fields =
+      exact_object_fields
+        ~field:("user_blocks " ^ kind ^ " block")
+        ~allowed:[ "type"; "attachment_id"; "name"; "mime_type"; "size" ]
+        json
+    in
+    let* media = parse_user_media_block ~kind fields in
+    Ok
+      (match kind with
+       | "image" -> User_image media
+       | "document" -> User_document media
+       | "audio" -> User_audio media
+       | _ -> assert false)
+  | "" -> Error "user_blocks block requires type"
+  | other ->
+    Error
+      (Printf.sprintf
+         "unsupported user_blocks type %S: expected text, image, document, or audio"
+         other)
 
 let parse_user_blocks json =
   match Json_util.assoc_member_opt "user_blocks" json with

--- a/lib/keeper/keeper_multimodal_input.mli
+++ b/lib/keeper/keeper_multimodal_input.mli
@@ -21,16 +21,16 @@ val attachment_to_yojson : Keeper_chat_store.attachment -> Yojson.Safe.t
 
 val attachments_to_yojson : Keeper_chat_store.attachment list -> Yojson.Safe.t
 
-val parse_attachments : Yojson.Safe.t -> Keeper_chat_store.attachment list
-(** Parse optional [attachments] from a request/tool argument object.  Malformed
-    attachment entries are ignored, matching the historical chat stream
-    behavior; referenced-but-missing media is rejected later by {!to_oas_blocks}. *)
+val parse_attachments :
+  Yojson.Safe.t -> (Keeper_chat_store.attachment list, string) result
+(** Parse optional [attachments] from a request object. Duplicate or undeclared
+    fields, wrong types, and missing [id]/[data] are request errors. *)
 
 val user_blocks_to_yojson : user_input_block list -> Yojson.Safe.t
 
 val parse_user_blocks : Yojson.Safe.t -> (user_input_block list, string) result
-(** Parse the optional [user_blocks] request field.  Unknown block types and
-    malformed media refs are request errors, not silently ignored. *)
+(** Parse the optional [user_blocks] request field. Duplicate or undeclared
+    fields, unknown block types, and malformed media refs are request errors. *)
 
 val fallback_message :
   attachments:Keeper_chat_store.attachment list -> user_input_block list -> string

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -358,7 +358,7 @@ let handle_keeper_sandbox_stop ctx args : tool_result =
 
 (** Keeper tools are scoped to the caller's current base_path.
     Do not retarget requests across other base_path registries. *)
-let resolve_ctx ctx ~name:_ _args = ctx
+let resolve_ctx ctx ~name:_ = ctx
 
 (* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
 let keeper_reset_body ~(config : Workspace.config) args : tool_result =
@@ -619,7 +619,7 @@ let handle_keeper_clear ctx args : tool_result =
   keeper_clear_body ~config:ctx.config args
 
 let dispatch ?invocation_ref ctx ~name ~args : tool_result option =
-  let ctx = resolve_ctx ctx ~name args in
+  let ctx = resolve_ctx ctx ~name in
   match name with
   | "masc_persona_list" -> Some (tool_result_with_tool_name ~tool_name:name (Persona.handle_persona_list ctx args))
   | "masc_persona_create" -> Some (tool_result_with_tool_name ~tool_name:name (Keeper_tool_persona_crud.handle_persona_create ctx args))
@@ -668,12 +668,12 @@ let dispatch ?invocation_ref ctx ~name ~args : tool_result option =
   | "masc_keeper_clear" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_clear ctx args))
   | _ -> None
 
-let dispatch_keeper_msg ~submitted_by ?continuation_channel ctx ~args : tool_result =
+let dispatch_keeper_msg ~submitted_by ?continuation_channel ctx ~message : tool_result =
   let name = "masc_keeper_msg" in
-  let ctx = resolve_ctx ctx ~name args in
+  let ctx = resolve_ctx ctx ~name in
   tool_result_with_tool_name
     ~tool_name:name
-    (handle_keeper_msg ?continuation_channel ~submitted_by ctx args)
+    (handle_keeper_msg ?continuation_channel ~submitted_by ctx message)
 ;;
 
 (** Private direct-delivery stream used by connector and dashboard adapters. *)
@@ -684,11 +684,11 @@ let dispatch_keeper_msg_stream
       ?on_admission_rejected
       ?on_admitted
       ctx
-      ~args
+      ~message
   : tool_result option
   =
   let name = "masc_keeper_msg" in
-  let ctx = resolve_ctx ctx ~name args in
+  let ctx = resolve_ctx ctx ~name in
   Some
     (tool_result_with_tool_name
        ~tool_name:name
@@ -699,24 +699,24 @@ let dispatch_keeper_msg_stream
           ?on_admission_rejected
           ?on_admitted
           ctx
-          args))
+          message))
 
 let dispatch_keeper_msg_stream_if_free
       ?on_text_delta
       ?on_event
       ?continuation_channel
       ctx
-      ~args
+      ~message
   =
   let name = "masc_keeper_msg" in
-  let ctx = resolve_ctx ctx ~name args in
+  let ctx = resolve_ctx ctx ~name in
   match
     handle_keeper_msg_stream_if_free
       ?on_text_delta
       ?on_event
       ?continuation_channel
       ctx
-      args
+      message
   with
   | `Busy rejection -> `Busy rejection
   | `Ran result ->

--- a/lib/keeper/keeper_tool_surface.mli
+++ b/lib/keeper/keeper_tool_surface.mli
@@ -30,7 +30,7 @@ val dispatch_keeper_msg
   :  submitted_by:string
   -> ?continuation_channel:Keeper_continuation_channel.t
   -> _ context
-  -> args:Yojson.Safe.t
+  -> message:Keeper_invocation_contract.direct_message
   -> tool_result
 
 module For_testing : sig
@@ -52,7 +52,9 @@ val dispatch_keeper_msg_stream :
   ?continuation_channel:Keeper_continuation_channel.t ->
   ?on_admission_rejected:(Keeper_turn_admission.rejection -> unit) ->
   ?on_admitted:(unit -> (unit, string) result) ->
-  _ context -> args:Yojson.Safe.t -> tool_result option
+  _ context ->
+  message:Keeper_invocation_contract.direct_message ->
+  tool_result option
 
 (** Non-blocking streaming dispatch for direct chat admission. The Keeper turn
     slot performs the authoritative post-lock durable-queue recheck; [`Busy]
@@ -62,5 +64,5 @@ val dispatch_keeper_msg_stream_if_free :
   ?on_event:(Agent_sdk.Types.sse_event -> unit) ->
   ?continuation_channel:Keeper_continuation_channel.t ->
   _ context ->
-  args:Yojson.Safe.t ->
+  message:Keeper_invocation_contract.direct_message ->
   [ `Ran of tool_result option | `Busy of Keeper_turn_admission.rejection ]

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -357,18 +357,6 @@ let with_keeper_name args name =
       `Assoc (("name", `String name) :: List.remove_assoc "name" fields)
   | other -> other
 
-let with_invocation_request args request =
-  match args with
-  | `Assoc fields ->
-    let fields =
-      fields |> List.remove_assoc "name" |> List.remove_assoc "message"
-    in
-    `Assoc
-      (("name", `String (Keeper_invocation_contract.target_name request))
-       :: ("message", `String (Keeper_invocation_contract.prompt request))
-       :: fields)
-  | other -> other
-;;
 (* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
 let prepare_passive_keeper_identity_config ~(config : Workspace.config) ~(agent_name : string) args =
   let requested_name =
@@ -528,8 +516,8 @@ let keeper_name_lookup_candidates raw_name =
     in
     trimmed :: aliases
 
-let resolve_keeper_name_config ~(config : Workspace.config) args =
-  let name = String.trim (get_string args "name" "") in
+let resolve_keeper_name_string_config ~(config : Workspace.config) name =
+  let name = String.trim name in
   let rec loop = function
     | [] -> Error (Printf.sprintf "keeper not found: %s" name)
     | candidate :: rest ->
@@ -540,9 +528,16 @@ let resolve_keeper_name_config ~(config : Workspace.config) args =
   in
   loop (keeper_name_lookup_candidates name)
 
+let resolve_keeper_name_config ~(config : Workspace.config) args =
+  resolve_keeper_name_string_config
+    ~config
+    (get_string args "name" "")
 
-let resolve_keeper_name ctx args =
-  resolve_keeper_name_config ~config:ctx.config args
+
+let resolve_keeper_name ctx message =
+  resolve_keeper_name_string_config
+    ~config:ctx.config
+    (Keeper_invocation_contract.direct_message_target_name message)
 
 let direct_reply_projection json =
   match Keeper_turn_outcome.of_reply_payload (Some json) with
@@ -571,9 +566,18 @@ let direct_reply_visible_text json =
   | Connector_status _ | Connector_no_visible_reply -> None
 ;;
 
-let append_direct_chat_pair_if_reply ~(config : Workspace.config) ~name ~args result =
-  if get_bool args "direct_reply" false && tool_result_success result then (
-    let user_content = get_string args "message" "" |> String.trim in
+let append_direct_chat_pair_if_reply
+      ~(config : Workspace.config)
+      ~name
+      ~message
+      result
+  =
+  if Keeper_invocation_contract.direct_message_direct_reply message
+     && tool_result_success result
+  then (
+    let user_content =
+      Keeper_invocation_contract.direct_message_prompt message |> String.trim
+    in
     (* RFC-0233 §7: the join key the keeper minted into the reply payload,
        threaded onto the persisted row of this agent-initiated / connector
        turn (parse, don't repair — absent/malformed reads as None). *)
@@ -601,7 +605,7 @@ let append_direct_chat_pair_if_reply ~(config : Workspace.config) ~name ~args re
            site owns the assistant reply only. Without [channel] this
            is a genuine agent-initiated message with no upstream
            recorder, so it still owns the full pair. *)
-        let channel = String.trim (get_string args "channel" "") in
+        let channel = Keeper_invocation_contract.direct_message_channel message in
         if channel = "" then begin
           Keeper_chat_store.append_turn
             ~base_dir:config.base_path
@@ -670,27 +674,31 @@ let submit_keeper_invocation
   | Error error -> tool_result_of_handler_error error
 ;;
 
-let handle_keeper_msg ?continuation_channel ~submitted_by ctx args : tool_result =
+let handle_keeper_msg ?continuation_channel ~submitted_by ctx message : tool_result =
   match
-    let* name = message_error (resolve_keeper_name ctx args) in
-    let worker_args = with_keeper_name args name in
-    let* request = message_error (Turn.preflight_keeper_msg ctx worker_args) in
+    let* name = message_error (resolve_keeper_name ctx message) in
+    let* message =
+      Keeper_invocation_contract.direct_message_with_keeper_name message name
+      |> Result.map_error Keeper_invocation_contract.request_error_to_string
+      |> message_error
+    in
+    let* message = message_error (Turn.preflight_keeper_msg ctx message) in
+    let request = Keeper_invocation_contract.direct_message_request message in
     Ok
       (submit_keeper_invocation
          ~submitted_by
          ~submission_to_json:Keeper_invocation_contract.submission_to_json
          ~submission_error_to_json:Keeper_msg_async.submit_error_to_json
-         ~run_turn:(fun ?event_bus request worker_ctx ->
-           let worker_args = with_invocation_request worker_args request in
+         ~run_turn:(fun ?event_bus _request worker_ctx ->
            let result =
              Turn.handle_keeper_msg
                ?event_bus
                ?continuation_channel
                worker_ctx
-               worker_args
+               message
            in
            append_direct_chat_pair_if_reply
-             ~config:ctx.config ~name ~args:worker_args result;
+             ~config:ctx.config ~name ~message result;
            result)
          ctx ~request)
   with
@@ -868,80 +876,84 @@ let handle_keeper_msg_stream
       ?on_admission_rejected
       ?on_admitted
       ctx
-      args
+      message
   : tool_result
   =
   let run name =
-    let resolved_args = with_keeper_name args name in
-    (* Stream turns are synchronous today, but still pin the bus visible at the
-       public surface boundary so later refactors cannot reintroduce a nested
-       fallback lookup in the turn body. *)
-    let event_bus = Event_bus_slots.get_keeper () in
-    let result =
-      Turn.handle_keeper_msg
-        ?on_text_delta
-        ?on_event
-        ?event_bus
-        ?continuation_channel
-        ?on_admission_rejected
-        ?on_admitted
-        ctx
-        resolved_args
-    in
-    complete_keeper_msg_stream_result result
+    match
+      Keeper_invocation_contract.direct_message_with_keeper_name message name
+    with
+    | Error error ->
+      tool_result_error (Keeper_invocation_contract.request_error_to_string error)
+    | Ok message ->
+      (* Stream turns are synchronous today, but still pin the bus visible at the
+         public surface boundary so later refactors cannot reintroduce a nested
+         fallback lookup in the turn body. *)
+      let event_bus = Event_bus_slots.get_keeper () in
+      let result =
+        Turn.handle_keeper_msg
+          ?on_text_delta
+          ?on_event
+          ?event_bus
+          ?continuation_channel
+          ?on_admission_rejected
+          ?on_admitted
+          ctx
+          message
+      in
+      complete_keeper_msg_stream_result result
   in
-  match resolve_keeper_name ctx args with
+  match resolve_keeper_name ctx message with
   | Ok name -> run name
   | Error err ->
-      let raw_name = String.trim (get_string args "name" "") in
-      if not (Keeper_config.validate_name raw_name)
-      then tool_result_error err
-      else
-        (* Preserve typed admission truth after lifecycle teardown removes the
-           metadata row: a shutdown-fenced queued receipt must return to
-           Pending, not become a terminal lookup failure. An open lane still
-           runs the admitted body and surfaces its authoritative metadata
-           error. *)
-        run raw_name
+    let raw_name = Keeper_invocation_contract.direct_message_target_name message in
+    (* Preserve typed admission truth after lifecycle teardown removes the
+       metadata row: a shutdown-fenced queued receipt must return to Pending,
+       not become a terminal lookup failure. An open lane still runs the
+       admitted body and surfaces its authoritative metadata error. *)
+    ignore err;
+    run raw_name
 
 let handle_keeper_msg_stream_if_free
       ?on_text_delta
       ?on_event
       ?continuation_channel
       ctx
-      args
+      message
   =
-  match resolve_keeper_name ctx args with
+  match resolve_keeper_name ctx message with
   | Error err ->
-    let raw_name = String.trim (get_string args "name" "") in
-    if not (Keeper_config.validate_name raw_name)
-    then `Ran (tool_result_error err)
-    else
-      (* A connector message already accepted for a live/raw Keeper identity
-         must remain queueable even if metadata resolution is temporarily
-         unavailable. Run the resolution error itself through the same
-         post-lock admission boundary: a held slot, parked waiter, active
-         receipt, or queue read error returns Busy; only an atomically free
-         lane returns the original metadata error. *)
-      Keeper_turn_admission.run_chat_if_free
-          ~base_path:ctx.config.base_path
-          ~keeper_name:raw_name
-          (fun () -> tool_result_error err)
+    let raw_name = Keeper_invocation_contract.direct_message_target_name message in
+    (* A connector message already accepted for a live/raw Keeper identity
+       must remain queueable even if metadata resolution is temporarily
+       unavailable. Run the resolution error itself through the same
+       post-lock admission boundary: a held slot, parked waiter, active
+       receipt, or queue read error returns Busy; only an atomically free
+       lane returns the original metadata error. *)
+    Keeper_turn_admission.run_chat_if_free
+      ~base_path:ctx.config.base_path
+      ~keeper_name:raw_name
+      (fun () -> tool_result_error err)
   | Ok name ->
-    let resolved_args = with_keeper_name args name in
-    let event_bus = Event_bus_slots.get_keeper () in
-    (match
-       Turn.handle_keeper_msg_if_free
-         ?on_text_delta
-         ?on_event
-         ?event_bus
-         ?continuation_channel
-         ctx
-         resolved_args
-     with
-     | `Busy rejection -> `Busy rejection
-     | `Ran result ->
-       `Ran (complete_keeper_msg_stream_result result))
+    (match Keeper_invocation_contract.direct_message_with_keeper_name message name with
+     | Error error ->
+       `Ran
+         (tool_result_error
+            (Keeper_invocation_contract.request_error_to_string error))
+     | Ok message ->
+       let event_bus = Event_bus_slots.get_keeper () in
+       (match
+          Turn.handle_keeper_msg_if_free
+            ?on_text_delta
+            ?on_event
+            ?event_bus
+            ?continuation_channel
+            ctx
+            message
+        with
+        | `Busy rejection -> `Busy rejection
+        | `Ran result ->
+          `Ran (complete_keeper_msg_stream_result result)))
 (* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
 let resolve_keeper_meta_config ~(config : Workspace.config) args =
   let name = String.trim (get_string args "name" "") in

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -249,17 +249,6 @@ let resolve_turn_runtime_id (meta : keeper_meta) =
   else
     Ok runtime_id
 
-let user_oas_blocks_of_args args =
-  match Keeper_multimodal_input.parse_user_blocks args with
-  | Error err -> Error err
-  | Ok [] -> Ok None
-  | Ok user_blocks ->
-      let attachments = Keeper_multimodal_input.parse_attachments args in
-      match Keeper_multimodal_input.to_oas_blocks ~attachments user_blocks with
-      | Error err -> Error err
-      | Ok [] -> Ok None
-      | Ok blocks -> Ok (Some blocks)
-
 type invocation_surface =
   | Direct_message
   | Keeper_delegate
@@ -272,16 +261,6 @@ let invocation_tool_name = function
 let invocation_turn_type = function
   | Direct_message -> "direct"
   | Keeper_delegate -> "delegate"
-;;
-
-let direct_invocation_request args =
-  let name = get_string args "name" "" in
-  let message = get_string args "message" "" in
-  if not (validate_name name)
-  then Error (invalid_name_error name)
-  else
-    Keeper_invocation_contract.request ~keeper_name:name ~prompt:message
-    |> Result.map_error Keeper_invocation_contract.request_error_to_string
 ;;
 
 let turn_resources_error ~surface failure =
@@ -297,41 +276,23 @@ let turn_resources_error ~surface failure =
        ])
 ;;
 
-let preflight_keeper_invocation ~surface ctx args request =
+let preflight_keeper_invocation ctx request =
   let name = Keeper_invocation_contract.target_name request in
-    let tool_name = invocation_tool_name surface in
-    match Keeper_meta_contract.reject_removed_model_args ~tool_name args with
-    | Error e -> Error e
-    | Ok () ->
-    (match reject_removed_keeper_input_keys ~tool_name args with
-    | Error e -> Error e
-    | Ok () ->
-    (match reject_removed_keeper_msg_input_keys ~tool_name args with
-    | Error e -> Error e
-    | Ok () ->
-    (match user_oas_blocks_of_args args with
-    | Error e -> Error e
-    | Ok _ ->
-    match ensure_keeper_exists ~ctx ~name with
-    | Error e -> Error e
-    | Ok meta ->
-      resolve_turn_runtime_id meta
-      |> Result.map (fun _ -> request))))
+  match ensure_keeper_exists ~ctx ~name with
+  | Error e -> Error e
+  | Ok meta ->
+    resolve_turn_runtime_id meta
+    |> Result.map (fun _ -> request)
+;;
 
-let preflight_keeper_msg ctx args =
-  let name = get_string args "name" "" in
-  let message = get_string args "message" "" in
-  match Keeper_invocation_contract.request ~keeper_name:name ~prompt:message with
-  | Error error -> Error (Keeper_invocation_contract.request_error_to_string error)
-  | Ok request -> preflight_keeper_invocation ~surface:Direct_message ctx args request
+let preflight_keeper_msg ctx message =
+  let request = Keeper_invocation_contract.direct_message_request message in
+  preflight_keeper_invocation ctx request
+  |> Result.map (fun _ -> message)
 ;;
 
 let preflight_keeper_delegate ctx request =
-  preflight_keeper_invocation
-    ~surface:Keeper_delegate
-    ctx
-    (`Assoc [])
-    request
+  preflight_keeper_invocation ctx request
 ;;
 
 (* -- Direct-message turn FSM wrapper ---------------------------------------- *)
@@ -439,8 +400,8 @@ let run_keeper_invocation_turn_admitted_inner
       ?continuation_channel
       ~surface
       ~request
+      ?direct_message
       ctx
-      args
   : tool_result
   =
   with_span
@@ -463,33 +424,26 @@ let run_keeper_invocation_turn_admitted_inner
   in
   let name = Keeper_invocation_contract.target_name request in
   let message = Keeper_invocation_contract.prompt request in
-    let turn_instructions =
-      match get_string_opt args "turn_instructions" with
-      | Some _ as ti -> ti
-      | None -> (
-          match args with
-          | `Assoc fields -> (
-              match List.assoc_opt "surface_context" fields with
-              | Some ctx -> surface_context_to_instructions ctx
-              | None -> None)
-          | _ -> None)
-    in
-    let direct_reply = get_bool args "direct_reply" false in
-    let channel_session_key = get_string_opt args "channel_session_key" in
-    let channel = get_string args "channel" "" in
-    let tool_name = invocation_tool_name surface in
-    (match Keeper_meta_contract.reject_removed_model_args ~tool_name args with
-    | Error e -> tool_result_error ("" ^ e)
-    | Ok () ->
-    (match reject_removed_keeper_input_keys ~tool_name args with
-    | Error e -> tool_result_error ("" ^ e)
-    | Ok () ->
-    (match reject_removed_keeper_msg_input_keys ~tool_name args with
-    | Error e -> tool_result_error ("" ^ e)
-    | Ok () ->
-    (match user_oas_blocks_of_args args with
-    | Error e -> tool_result_error ("" ^ e)
-    | Ok user_blocks ->
+  let turn_instructions, direct_reply, channel_session_key, channel, user_blocks =
+    match direct_message with
+    | None -> None, false, None, "", None
+    | Some direct_message ->
+      let turn_instructions =
+        match
+          Keeper_invocation_contract.direct_message_turn_instructions direct_message
+        with
+        | Some _ as instructions -> instructions
+        | None ->
+          Option.bind
+            (Keeper_invocation_contract.direct_message_surface_context direct_message)
+            surface_context_to_instructions
+      in
+      ( turn_instructions
+      , Keeper_invocation_contract.direct_message_direct_reply direct_message
+      , Keeper_invocation_contract.direct_message_channel_session_key direct_message
+      , Keeper_invocation_contract.direct_message_channel direct_message
+      , Keeper_invocation_contract.direct_message_user_oas_blocks direct_message )
+  in
     match ensure_keeper_exists
       ~ctx ~name
     with
@@ -985,7 +939,7 @@ let run_keeper_invocation_turn_admitted_inner
               in
               tool_result_ok_data reply_json
 
-))))))))
+))))
 
 (* Turn-observation boundary for the chat lane.
 
@@ -1014,8 +968,8 @@ let run_keeper_invocation_turn_admitted
       ?continuation_channel
       ~surface
       ~request
+      ?direct_message
       ctx
-      args
   : tool_result
   =
   let base_path = ctx.config.base_path in
@@ -1038,8 +992,8 @@ let run_keeper_invocation_turn_admitted
       ?continuation_channel
       ~surface
       ~request
+      ?direct_message
       ctx
-      args
   with
   | result ->
     finish ();
@@ -1058,8 +1012,8 @@ let handle_keeper_invocation
       ?on_admitted
       ~surface
       ~request
+      ?direct_message
       ctx
-      args
   : tool_result
   =
   let event_bus =
@@ -1084,8 +1038,8 @@ let handle_keeper_invocation
                ?continuation_channel
                ~surface
                ~request
+               ?direct_message
                ctx
-               args
            | Error detail ->
              tool_result_error
                ("keeper turn admission persistence failed: " ^ detail))
@@ -1097,8 +1051,9 @@ let handle_keeper_invocation
             ?continuation_channel
             ~surface
             ~request
+            ?direct_message
             ctx
-            args)
+            )
     with
     | `Ran result -> result
     | `Rejected
@@ -1142,22 +1097,22 @@ let handle_keeper_msg
       ?on_admission_rejected
       ?on_admitted
       ctx
-      args
+      direct_message
   =
-  match direct_invocation_request args with
-  | Error error -> tool_result_error error
-  | Ok request ->
-    handle_keeper_invocation
-      ?on_text_delta
-      ?on_event
-      ?event_bus
-      ?continuation_channel
-      ?on_admission_rejected
-      ?on_admitted
-      ~surface:Direct_message
-      ~request
-      ctx
-      args
+  let request =
+    Keeper_invocation_contract.direct_message_request direct_message
+  in
+  handle_keeper_invocation
+    ?on_text_delta
+    ?on_event
+    ?event_bus
+    ?continuation_channel
+    ?on_admission_rejected
+    ?on_admitted
+    ~surface:Direct_message
+    ~request
+    ~direct_message
+    ctx
 ;;
 
 let handle_keeper_delegate ?event_bus ctx request =
@@ -1166,7 +1121,6 @@ let handle_keeper_delegate ?event_bus ctx request =
     ~surface:Keeper_delegate
     ~request
     ctx
-    (`Assoc [])
 ;;
 
 let handle_keeper_msg_if_free
@@ -1175,27 +1129,27 @@ let handle_keeper_msg_if_free
       ?event_bus
       ?continuation_channel
       ctx
-      args
+      direct_message
   =
   let event_bus =
     match event_bus with
     | Some _ -> event_bus
     | None -> Event_bus_slots.get_keeper ()
   in
-  match direct_invocation_request args with
-  | Error error -> `Ran (tool_result_error error)
-  | Ok request ->
-    let name = Keeper_invocation_contract.target_name request in
-    Keeper_turn_admission.run_chat_if_free
-      ~base_path:ctx.config.base_path
-      ~keeper_name:name
-      (fun () ->
-        run_keeper_invocation_turn_admitted
-          ?on_text_delta
-          ?on_event
-          ?event_bus
-          ?continuation_channel
-          ~surface:Direct_message
-          ~request
-          ctx
-          args)
+  let request =
+    Keeper_invocation_contract.direct_message_request direct_message
+  in
+  let name = Keeper_invocation_contract.target_name request in
+  Keeper_turn_admission.run_chat_if_free
+    ~base_path:ctx.config.base_path
+    ~keeper_name:name
+    (fun () ->
+      run_keeper_invocation_turn_admitted
+        ?on_text_delta
+        ?on_event
+        ?event_bus
+        ?continuation_channel
+        ~surface:Direct_message
+        ~request
+        ~direct_message
+        ctx)

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -22,8 +22,8 @@ val handle_keeper_up : _ Keeper_types_profile.context -> Yojson.Safe.t -> tool_r
     @since 2.110.0 *)
 val preflight_keeper_msg :
   _ Keeper_types_profile.context ->
-  Yojson.Safe.t ->
-  (Keeper_invocation_contract.request, string) result
+  Keeper_invocation_contract.direct_message ->
+  (Keeper_invocation_contract.direct_message, string) result
 (** Run synchronous validation for [handle_keeper_msg] before an async wrapper
     accepts the turn for later execution. *)
 
@@ -139,7 +139,9 @@ val handle_keeper_msg :
   ?continuation_channel:Keeper_continuation_channel.t ->
   ?on_admission_rejected:(Keeper_turn_admission.rejection -> unit) ->
   ?on_admitted:(unit -> (unit, string) result) ->
-  _ Keeper_types_profile.context -> Yojson.Safe.t -> tool_result
+  _ Keeper_types_profile.context ->
+  Keeper_invocation_contract.direct_message ->
+  tool_result
 (** [event_bus] is captured at the handler boundary and reused by the admitted
     turn body. Callers that omit it keep the process/domain fallback, but
     async wrappers should pass an explicit value captured before submitting the
@@ -163,7 +165,7 @@ val handle_keeper_msg_if_free :
   ?event_bus:Agent_sdk.Event_bus.t ->
   ?continuation_channel:Keeper_continuation_channel.t ->
   _ Keeper_types_profile.context ->
-  Yojson.Safe.t ->
+  Keeper_invocation_contract.direct_message ->
   [ `Ran of tool_result | `Busy of Keeper_turn_admission.rejection ]
 (** Non-blocking chat entrypoint for direct dashboard streaming. It runs the
     same admitted turn body as [handle_keeper_msg] only when the keeper slot is

--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -12,15 +12,12 @@ val float_of_env_default :
 val clamp_int : int -> min_v:int -> max_v:int -> int
 val validate_name : string -> bool
 val removed_keeper_input_key_names : string list
-val removed_keeper_msg_input_key_names : string list
 val present_json_keys : string list -> Yojson.Safe.t -> string list
 val reject_removed_keeper_input_keys :
   ?allow_sandbox_fields:bool ->
   tool_name:string ->
   Yojson.Safe.t ->
   (unit, string) result
-val reject_removed_keeper_msg_input_keys :
-  tool_name:string -> Yojson.Safe.t -> (unit, string) result
 val utf8_repair_string : string -> string
 val normalize_prompt_text : max_bytes:int -> string -> string
 val keeper_bootstrap_proactive_warmup_sec : unit -> int

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -12,15 +12,12 @@ val float_of_env_default :
 val clamp_int : int -> min_v:int -> max_v:int -> int
 val validate_name : string -> bool
 val removed_keeper_input_key_names : string list
-val removed_keeper_msg_input_key_names : string list
 val present_json_keys : string list -> Yojson.Safe.t -> string list
 val reject_removed_keeper_input_keys :
   ?allow_sandbox_fields:bool ->
   tool_name:string ->
   Yojson.Safe.t ->
   (unit, string) result
-val reject_removed_keeper_msg_input_keys :
-  tool_name:string -> Yojson.Safe.t -> (unit, string) result
 val utf8_repair_string : string -> string
 val normalize_prompt_text : max_bytes:int -> string -> string
 val keeper_bootstrap_proactive_warmup_sec : unit -> int

--- a/lib/keeper/keeper_types_profile_toml_normalizers.mli
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.mli
@@ -12,15 +12,12 @@ val float_of_env_default :
 val clamp_int : int -> min_v:int -> max_v:int -> int
 val validate_name : string -> bool
 val removed_keeper_input_key_names : string list
-val removed_keeper_msg_input_key_names : string list
 val present_json_keys : string list -> Yojson.Safe.t -> string list
 val reject_removed_keeper_input_keys :
   ?allow_sandbox_fields:bool ->
   tool_name:string ->
   Yojson.Safe.t ->
   (unit, string) result
-val reject_removed_keeper_msg_input_keys :
-  tool_name:string -> Yojson.Safe.t -> (unit, string) result
 val utf8_repair_string : string -> string
 val normalize_prompt_text : max_bytes:int -> string -> string
 val keeper_bootstrap_proactive_warmup_sec : unit -> int

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -12,15 +12,12 @@ val float_of_env_default :
 val clamp_int : int -> min_v:int -> max_v:int -> int
 val validate_name : string -> bool
 val removed_keeper_input_key_names : string list
-val removed_keeper_msg_input_key_names : string list
 val present_json_keys : string list -> Yojson.Safe.t -> string list
 val reject_removed_keeper_input_keys :
   ?allow_sandbox_fields:bool ->
   tool_name:string ->
   Yojson.Safe.t ->
   (unit, string) result
-val reject_removed_keeper_msg_input_keys :
-  tool_name:string -> Yojson.Safe.t -> (unit, string) result
 val utf8_repair_string : string -> string
 val normalize_prompt_text : max_bytes:int -> string -> string
 val keeper_bootstrap_proactive_warmup_sec : unit -> int

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -207,6 +207,35 @@ let payload_of_queued_message ~keeper_name
     (queued_message : Keeper_chat_queue.queued_message) :
     Server_routes_http_keeper_stream.keeper_chat_stream_request =
   let projection = queued_chat_projection queued_message in
+  let prompt =
+    if projection.payload_channel <> ""
+       && projection.payload_channel_workspace_id <> ""
+       && projection.payload_channel_user_id <> ""
+    then
+      Gate_keeper_backend.contextualize_message
+        ~channel:projection.payload_channel
+        ~channel_user_id:projection.payload_channel_user_id
+        ~channel_user_name:projection.payload_channel_user_name
+        ~channel_workspace_id:projection.payload_channel_workspace_id
+        ~metadata:[]
+        ~content:queued_message.content
+    else queued_message.content
+  in
+  let direct_message =
+    match
+      Keeper_invocation_contract.direct_message
+        ~keeper_name
+        ~prompt
+        ~direct_reply:true
+        ~channel:projection.payload_channel
+        ~user_blocks:queued_message.user_blocks
+        ~attachments:queued_message.attachments
+        ()
+    with
+    | Ok message -> message
+    | Error error ->
+      invalid_arg (Keeper_invocation_contract.request_error_to_string error)
+  in
   { Server_routes_http_keeper_stream.name = keeper_name
   ; message = queued_message.content
   ; turn_instructions = None
@@ -217,6 +246,7 @@ let payload_of_queued_message ~keeper_name
   ; channel_workspace_id = projection.payload_channel_workspace_id
   ; user_blocks = queued_message.user_blocks
   ; attachments = queued_message.attachments
+  ; direct_message
   }
 
 let trimmed_env_opt name =

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -42,6 +42,7 @@ type keeper_chat_stream_request = {
   channel_user_name : string;
   channel_workspace_id : string;
   attachments : Keeper_chat_store.attachment list;
+  direct_message : Keeper_invocation_contract.direct_message;
 }
 
 let keeper_chat_stream_error_json message =
@@ -109,56 +110,24 @@ let chat_speaker_of_request payload =
       speaker_name = None;
       speaker_authority = Keeper_chat_store.Owner }
 
-let turn_instructions_for_request payload =
+let combined_turn_instructions ~turn_instructions ~surface_context =
   let ctx_text =
-    match payload.surface_context with
+    match surface_context with
     | Some ctx -> format_surface_context ctx
     | None -> ""
   in
-  match payload.turn_instructions with
+  match turn_instructions with
   | None -> if ctx_text = "" then None else Some ctx_text
   | Some ti ->
       if ctx_text = "" then Some ti
       else Some (ti ^ "\n\n" ^ ctx_text)
 
-let args_of_request payload : Yojson.Safe.t =
-  let message = message_for_request payload in
-  let base_fields =
-    [ ("name", `String payload.name);
-      ("message", `String message);
-      ("direct_reply", `Bool true) ]
-    @
-    (match turn_instructions_for_request payload with
-     | Some instructions when String.trim instructions <> "" ->
-         [ ("turn_instructions", `String instructions) ]
-     | _ -> [])
-  in
-  let connector_fields =
-    (if has_connector_context payload then
-       [ ("channel", `String payload.channel);
-         ("channel_workspace_id", `String payload.channel_workspace_id) ]
-     else [])
-    @
-    (if payload.channel_user_id <> "" then
-       [ ("channel_user_id", `String payload.channel_user_id) ]
-     else [])
-    @
-    (if payload.channel_user_name <> "" then
-       [ ("channel_user_name", `String payload.channel_user_name) ]
-     else [])
-  in
-  let fields = base_fields @ connector_fields in
-  let fields =
-    if payload.user_blocks = [] then fields
-    else
-      ("user_blocks", Keeper_multimodal_input.user_blocks_to_yojson payload.user_blocks)
-      :: fields
-  in
-  `Assoc
-    (if payload.attachments = [] then fields
-     else
-       ("attachments", Keeper_multimodal_input.attachments_to_yojson payload.attachments)
-       :: fields)
+let turn_instructions_for_request payload =
+  combined_turn_instructions
+    ~turn_instructions:payload.turn_instructions
+    ~surface_context:payload.surface_context
+
+let direct_message_of_request payload = payload.direct_message
 
 let modalities_for_request payload =
   match Keeper_multimodal_input.modalities payload.user_blocks with
@@ -531,99 +500,132 @@ let keeper_stream_success = function
 
 let parse_keeper_chat_stream_request body_str =
   try
+    let ( let* ) = Result.bind in
     let json = Yojson.Safe.from_string body_str in
-    if not (match json with `Assoc _ -> true | _ -> false) then
-      Error "request body must be a JSON object"
+    let* fields =
+      match json with
+      | `Assoc fields ->
+        let allowed =
+          [ "name"
+          ; "message"
+          ; "user_blocks"
+          ; "turn_instructions"
+          ; "surface_context"
+          ; "channel"
+          ; "channel_user_id"
+          ; "channel_user_name"
+          ; "channel_workspace_id"
+          ; "attachments"
+          ]
+        in
+        let keys = List.map fst fields in
+        if List.length keys <> List.length (List.sort_uniq String.compare keys)
+        then Error "request body must contain unique fields"
+        else
+          (match List.find_opt (fun key -> not (List.mem key allowed)) keys with
+           | None -> Ok fields
+           | Some key ->
+             Error
+               (Printf.sprintf
+                  "request body field %s is undeclared; accepted fields: %s"
+                  key
+                  (String.concat ", " allowed)))
+      | _ -> Error "request body must be a JSON object"
+    in
+    let required_string key =
+      match List.assoc_opt key fields with
+      | Some (`String value) -> Ok value
+      | Some _ -> Error (key ^ " must be a string")
+      | None -> Error (key ^ " is required")
+    in
+    let optional_string key =
+      match List.assoc_opt key fields with
+      | None -> Ok ""
+      | Some (`String value) -> Ok value
+      | Some _ -> Error (key ^ " must be a string")
+    in
+    let* name = required_string "name" |> Result.map String.trim in
+    let* raw_message = optional_string "message" |> Result.map String.trim in
+    let* channel = optional_string "channel" |> Result.map String.trim in
+    let* channel_user_id =
+      optional_string "channel_user_id" |> Result.map String.trim
+    in
+    let* channel_user_name =
+      optional_string "channel_user_name" |> Result.map String.trim
+    in
+    let* channel_workspace_id =
+      optional_string "channel_workspace_id" |> Result.map String.trim
+    in
+    let* turn_instructions =
+      match List.assoc_opt "turn_instructions" fields with
+      | None -> Ok None
+      | Some (`String value) ->
+        let value = String.trim value in
+        Ok (if String.equal value "" then None else Some value)
+      | Some _ -> Error "turn_instructions must be a string"
+    in
+    let* surface_context =
+      match List.assoc_opt "surface_context" fields with
+      | None | Some `Null -> Ok None
+      | Some (`Assoc _ as context) -> Ok (Some context)
+      | Some _ -> Error "surface_context must be an object"
+    in
+    let* attachments = Keeper_multimodal_input.parse_attachments json in
+    let* user_blocks = Keeper_multimodal_input.parse_user_blocks json in
+    let message =
+      if String.equal raw_message ""
+      then Keeper_multimodal_input.fallback_message ~attachments user_blocks
+      else raw_message
+    in
+    let has_connector_context =
+      channel <> "" || channel_user_id <> ""
+      || channel_user_name <> "" || channel_workspace_id <> ""
+    in
+    if has_connector_context && (channel = "" || channel_workspace_id = "")
+    then
+      Error
+        "channel and channel_workspace_id are required when connector context is supplied"
     else
-      let name = Json_util.get_string_with_default json ~key:"name" ~default:"" |> String.trim in
-      let raw_message =
-        Json_util.get_string_with_default json ~key:"message" ~default:""
-        |> String.trim
+      let invocation_prompt =
+        if channel <> "" && channel_workspace_id <> "" && channel_user_id <> ""
+        then
+          Gate_keeper_backend.contextualize_message
+            ~channel
+            ~channel_user_id
+            ~channel_user_name
+            ~channel_workspace_id
+            ~metadata:[]
+            ~content:message
+        else message
       in
-      let channel =
-        Json_util.get_string_with_default json ~key:"channel" ~default:""
-        |> String.trim
+      let combined_turn_instructions =
+        combined_turn_instructions ~turn_instructions ~surface_context
       in
-      let channel_user_id =
-        Json_util.get_string_with_default json ~key:"channel_user_id" ~default:""
-        |> String.trim
+      let* direct_message =
+        Keeper_invocation_contract.direct_message
+          ~keeper_name:name
+          ~prompt:invocation_prompt
+          ~direct_reply:true
+          ?turn_instructions:combined_turn_instructions
+          ~channel
+          ~user_blocks
+          ~attachments
+          ()
+        |> Result.map_error Keeper_invocation_contract.request_error_to_string
       in
-      let channel_user_name =
-        Json_util.get_string json "channel_user_name"
-        |> Option.value ~default:""
-        |> String.trim
-      in
-      let channel_workspace_id =
-        Json_util.get_string json "channel_workspace_id"
-        |> Option.value ~default:""
-        |> String.trim
-      in
-      let turn_instructions =
-        match Json_util.get_string json "turn_instructions" with
-        | None -> None
-        | Some s ->
-            let s = String.trim s in
-            if s = "" then None else Some s
-      in
-      let surface_context : Yojson.Safe.t option =
-        match Json_util.assoc_member_opt "surface_context" json with
-        | Some (`Assoc _ as obj) -> Some obj
-        | Some `Null | None -> None
-        | Some _ -> None
-      in
-      let has_connector_context =
-        channel <> "" || channel_user_id <> ""
-        || channel_user_name <> "" || channel_workspace_id <> ""
-      in
-      let attachments = Keeper_multimodal_input.parse_attachments json in
-      let user_blocks_result = Keeper_multimodal_input.parse_user_blocks json in
-      let message_of_blocks user_blocks =
-        match raw_message with
-        | "" ->
-            Keeper_multimodal_input.fallback_message ~attachments user_blocks
-        | message -> message
-      in
-      if name = "" then
-        Error "name is required"
-      else if has_connector_context
-              && (channel = "" || channel_workspace_id = "")
-      then
-        Error
-          "channel and channel_workspace_id are required when connector context is supplied"
-      else
-        match
-          Keeper_meta_contract.reject_removed_model_args ~tool_name:"masc_keeper_msg" json
-        with
-        | Error err -> Error err
-        | Ok () -> (
-          match
-            Keeper_config.reject_removed_keeper_msg_input_keys
-              ~tool_name:"masc_keeper_msg"
-              json
-          with
-          | Error err -> Error err
-          | Ok () -> (
-            match user_blocks_result with
-            | Error err -> Error err
-            | Ok user_blocks ->
-              let message = message_of_blocks user_blocks in
-              if message = "" then
-                Error "message is required"
-              else
-              Ok
-                {
-                  name;
-                  message;
-                  user_blocks;
-                  turn_instructions;
-                  surface_context;
-                  channel;
-                  channel_user_id;
-                  channel_user_name;
-                  channel_workspace_id;
-                  attachments;
-                }
-          ))
+      Ok
+        { name
+        ; message
+        ; user_blocks
+        ; turn_instructions
+        ; surface_context
+        ; channel
+        ; channel_user_id
+        ; channel_user_name
+        ; channel_workspace_id
+        ; attachments
+        ; direct_message
+        }
   with Yojson.Json_error e ->
     Error ("invalid json: " ^ e)
 
@@ -721,7 +723,7 @@ let execute_keeper_stream_tool_streaming
       ?on_admitted
       state
       ~agent_name
-      ~arguments
+      ~message
       ~continuation_channel
       ~on_text_delta
   =
@@ -750,7 +752,7 @@ let execute_keeper_stream_tool_streaming
           ?on_admitted
           keeper_ctx
           ~continuation_channel
-          ~args:arguments
+          ~message
       with
       | Some result ->
           let body = Tool_result.message result in
@@ -832,7 +834,7 @@ let execute_keeper_stream_tool_streaming_if_free
       ?on_event
       state
       ~agent_name
-      ~arguments
+      ~message
       ~continuation_channel
       ~on_text_delta
   =
@@ -859,7 +861,7 @@ let execute_keeper_stream_tool_streaming_if_free
           ?on_event
           ~continuation_channel
           keeper_ctx
-          arguments
+          message
       with
       | `Busy rejection -> `Busy rejection
       | `Ran result ->
@@ -1429,7 +1431,7 @@ let process_single_turn ~user_row_origin ~submission
     ; Keeper_chat_store.Run_error
     ]
   in
-  let args = args_of_request payload in
+  let direct_message = direct_message_of_request payload in
   (* Stream model text deltas live with per-delta redaction. The typed OAS
      bridge owns per-provider-message state so only the final provider
      message controls terminal resend suppression; canonical terminal content
@@ -1982,7 +1984,7 @@ let process_single_turn ~user_row_origin ~submission
               match
                 execute_keeper_stream_tool_streaming_if_free ~sw:request_sw ~clock
                   ?auth_token
-                  state ~agent_name ~arguments:args ~on_event
+                  state ~agent_name ~message:direct_message ~on_event
                   ~continuation_channel
                   ~on_text_delta:(fun _ -> ())
               with
@@ -2007,7 +2009,7 @@ let process_single_turn ~user_row_origin ~submission
                    ~sw:request_sw
                    ~clock
                    ?auth_token
-                   state ~agent_name ~arguments:args ~on_event
+                   state ~agent_name ~message:direct_message ~on_event
                    ~continuation_channel ~on_text_delta:(fun _ -> ())
                    ?on_admitted
                with
@@ -3240,7 +3242,7 @@ module For_testing = struct
   let chat_surface_of_request = chat_surface_of_request
   let chat_speaker_of_request = chat_speaker_of_request
   let turn_instructions_for_request = turn_instructions_for_request
-  let args_of_request = args_of_request
+  let direct_message_of_request = direct_message_of_request
   let defer_dashboard_payload_if_busy_evidence
         ~base_path
         ~clock

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -37,8 +37,7 @@
     (~10 internal lets — [contains_casefold],
     [get_origin] / [cors_headers] adapter helpers,
     [keeper_chat_stream_*] sub-renderers + per-event
-    framing, connector-context and legacy model-argument
-    payload guards). *)
+    framing and connector-context helpers). *)
 
 (** {1 Stream tunables} *)
 
@@ -81,6 +80,7 @@ type keeper_chat_stream_request = {
   channel_user_name : string;
   channel_workspace_id : string;
   attachments : Keeper_chat_store.attachment list;
+  direct_message : Keeper_invocation_contract.direct_message;
 }
 (** Parsed payload of a keeper chat-stream HTTP request.
     [message] is the text fallback used by the existing direct keeper
@@ -89,7 +89,8 @@ type keeper_chat_stream_request = {
     are optional copilot context fields; when
     [turn_instructions] is absent but [surface_context]
     is present, the surface context is formatted and
-    injected as turn instructions.  [channel] and
+    injected as turn instructions. [direct_message] is the validated,
+    turn-owned projection carried after this boundary. [channel] and
     [channel_workspace_id] are required together when any
     connector context is supplied; [channel_user_id] and
     [channel_user_name] are optional. *)
@@ -101,9 +102,8 @@ val parse_keeper_chat_stream_request :
 (** Parses the HTTP body string into a
     {!keeper_chat_stream_request}.  Returns
     [Error reason] on JSON shape mismatches, missing
-    [name] / content, malformed [user_blocks], partial connector context, or a
-    removed Keeper argument (including the retired request-level
-    [timeout_sec]). *)
+    [name] / content, unknown or duplicate fields, wrong field types,
+    malformed [user_blocks] / [attachments], or partial connector context. *)
 
 (** {1 Error envelope} *)
 
@@ -284,7 +284,8 @@ module For_testing : sig
   val chat_surface_of_request : keeper_chat_stream_request -> Surface_ref.t
   val chat_speaker_of_request : keeper_chat_stream_request -> Keeper_chat_store.speaker
   val turn_instructions_for_request : keeper_chat_stream_request -> string option
-  val args_of_request : keeper_chat_stream_request -> Yojson.Safe.t
+  val direct_message_of_request :
+    keeper_chat_stream_request -> Keeper_invocation_contract.direct_message
   val keeper_chat_stream_headers : string -> Httpun.Headers.t
   val defer_dashboard_payload_if_busy :
     base_path:string ->

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -366,31 +366,37 @@ let dispatch_board_context_inference ~state ~sw ~clock ~request ~target_keeper
     }
   in
   let post_id = Board.Post_id.to_string post.id in
-  let args =
-    `Assoc
-      [
-        ("name", `String target_keeper);
-        ("message", `String (board_context_inference_message post));
-        ("direct_reply", `Bool true);
-        ( "surface_context",
-          board_context_inference_surface_context post comments );
-      ]
-  in
-  let result =
-    Keeper_tool_surface.dispatch_keeper_msg
-      ~submitted_by:agent_name
-      keeper_ctx
-      ~args
-  in
-  if Tool_result.is_success result
-  then
-    (match
-       board_context_inference_submission_json ~post_id ~target_source
-         (Tool_result.data result)
-     with
-     | Ok json -> Ok json
-     | Error msg -> Error (`Internal_server_error msg))
-  else Error (`Bad_request (Tool_result.message result))
+  match
+    Keeper_invocation_contract.direct_message
+      ~keeper_name:target_keeper
+      ~prompt:(board_context_inference_message post)
+      ~direct_reply:true
+      ~surface_context:(board_context_inference_surface_context post comments)
+      ~channel:""
+      ~user_blocks:[]
+      ~attachments:[]
+      ()
+  with
+  | Error error ->
+    Error
+      (`Bad_request
+         (Keeper_invocation_contract.request_error_to_string error))
+  | Ok message ->
+    let result =
+      Keeper_tool_surface.dispatch_keeper_msg
+        ~submitted_by:agent_name
+        keeper_ctx
+        ~message
+    in
+    if Tool_result.is_success result
+    then
+      (match
+         board_context_inference_submission_json ~post_id ~target_source
+           (Tool_result.data result)
+       with
+       | Ok json -> Ok json
+       | Error msg -> Error (`Internal_server_error msg))
+    else Error (`Bad_request (Tool_result.message result))
 
 let respond_board_context_inference_error request reqd ~status ~message =
   respond_json_value_with_cors ~status request reqd

--- a/test/test_copilot_dock_channel_wiring.ml
+++ b/test/test_copilot_dock_channel_wiring.ml
@@ -1,7 +1,7 @@
 (* Tests for dashboard Copilot Dock -> keeper chat stream wiring.
 
    Verifies the shared contract from the HTTP parser down to the
-   private direct-message args that the direct-delivery stream
+   typed direct message that the direct-delivery stream
    receives:
    - copilot channel label + operator workspace id parse without requiring
      an external user id;
@@ -25,23 +25,6 @@ let parse_ok body =
   match Stream.For_testing.parse_request body with
   | Ok payload -> payload
   | Error err -> fail ("expected parse to succeed: " ^ err)
-
-let args_assoc args =
-  match args with
-  | `Assoc fields -> fields
-  | _ -> fail "expected args to be a JSON object"
-
-let get_string_field key args =
-  match List.assoc_opt key (args_assoc args) with
-  | Some (`String s) -> s
-  | _ -> ""
-
-let get_bool_field key args =
-  match List.assoc_opt key (args_assoc args) with
-  | Some (`Bool b) -> b
-  | _ -> false
-
-let has_field key args = Option.is_some (List.assoc_opt key (args_assoc args))
 
 let contains needle haystack = Astring.String.is_infix ~affix:needle haystack
 
@@ -88,22 +71,22 @@ let test_copilot_message_is_not_contextualized () =
     (contains "[External channel context]" message);
   check string "message verbatim" "hello" message
 
-let test_copilot_args_carry_turn_instructions () =
+let test_copilot_direct_message_carries_turn_contract () =
   let payload =
     parse_ok
       {|{"name":"luna","message":"hello","channel":"copilot","channel_workspace_id":"session-7","turn_instructions":"focus on overview"}|}
   in
-  let args = Stream.For_testing.args_of_request payload in
-  check string "name" "luna" (get_string_field "name" args);
-  check string "message" "hello" (get_string_field "message" args);
-  check bool "direct_reply" true (get_bool_field "direct_reply" args);
-  check string "turn_instructions" "focus on overview"
-    (get_string_field "turn_instructions" args);
-  check string "channel" "copilot" (get_string_field "channel" args);
-  check string "channel_workspace_id" "session-7"
-    (get_string_field "channel_workspace_id" args);
-  check bool "no channel_user_id" false (has_field "channel_user_id" args);
-  check bool "no channel_user_name" false (has_field "channel_user_name" args)
+  let message = Stream.For_testing.direct_message_of_request payload in
+  check string "name" "luna"
+    (Keeper_invocation_contract.direct_message_target_name message);
+  check string "message" "hello"
+    (Keeper_invocation_contract.direct_message_prompt message);
+  check bool "direct_reply" true
+    (Keeper_invocation_contract.direct_message_direct_reply message);
+  check (option string) "turn_instructions" (Some "focus on overview")
+    (Keeper_invocation_contract.direct_message_turn_instructions message);
+  check string "channel" "copilot"
+    (Keeper_invocation_contract.direct_message_channel message)
 
 let test_surface_context_is_formatted_as_turn_instructions () =
   let payload =
@@ -117,8 +100,10 @@ let test_surface_context_is_formatted_as_turn_instructions () =
   check bool "contains route" true (contains "Route: /overview" text);
   check bool "contains scene" true (contains "Scene: fleet view" text);
   check bool "contains field" true (contains "run: 2/5" text);
-  let args = Stream.For_testing.args_of_request payload in
-  check bool "turn_instructions in args" true (has_field "turn_instructions" args)
+  let message = Stream.For_testing.direct_message_of_request payload in
+  check bool "turn_instructions in direct message" true
+    (Option.is_some
+       (Keeper_invocation_contract.direct_message_turn_instructions message))
 
 let test_turn_instructions_and_surface_context_combine () =
   let payload =
@@ -154,11 +139,12 @@ let test_external_connector_still_contextualized () =
   let message = Stream.For_testing.message_for_request payload in
   check bool "context envelope present" true
     (contains "[External channel context]" message);
-  let args = Stream.For_testing.args_of_request payload in
-  check string "channel_user_id" "user-42"
-    (get_string_field "channel_user_id" args);
-  check string "channel_user_name" "Alice"
-    (get_string_field "channel_user_name" args)
+  let direct_message = Stream.For_testing.direct_message_of_request payload in
+  check bool "direct message is contextualized" true
+    (contains "[External channel context]"
+       (Keeper_invocation_contract.direct_message_prompt direct_message));
+  check string "channel" "discord"
+    (Keeper_invocation_contract.direct_message_channel direct_message)
 
 let test_dashboard_without_channel_is_owner () =
   let payload = parse_ok {|{"name":"luna","message":"hello"}|} in
@@ -169,8 +155,9 @@ let test_dashboard_without_channel_is_owner () =
   let speaker = Stream.For_testing.chat_speaker_of_request payload in
   check string "authority" "owner"
     (Keeper_chat_store.authority_label speaker.speaker_authority);
-  let args = Stream.For_testing.args_of_request payload in
-  check bool "no channel in args" false (has_field "channel" args)
+  let message = Stream.For_testing.direct_message_of_request payload in
+  check string "empty channel" ""
+    (Keeper_invocation_contract.direct_message_channel message)
 
 let () =
   run "copilot_dock_channel_wiring"
@@ -193,8 +180,8 @@ let () =
         [
           test_case "copilot message is not contextualized" `Quick
             test_copilot_message_is_not_contextualized;
-          test_case "turn_instructions forwarded to args" `Quick
-            test_copilot_args_carry_turn_instructions;
+          test_case "turn contract is typed at the HTTP boundary" `Quick
+            test_copilot_direct_message_carries_turn_contract;
           test_case "surface_context formatted as turn instructions" `Quick
             test_surface_context_is_formatted_as_turn_instructions;
           test_case "turn_instructions and surface_context combine" `Quick

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -4,6 +4,49 @@ open Masc
 module K = Keeper_chat_store
 module KT = Keeper_turn
 
+let stream_payload_exn
+      ?(user_blocks = [])
+      ?(attachments = [])
+      ?turn_instructions
+      ?surface_context
+      ?(channel = "")
+      ?(channel_user_id = "")
+      ?(channel_user_name = "")
+      ?(channel_workspace_id = "")
+      ~name
+      ~message
+      ()
+  =
+  let direct_message =
+    match
+      Keeper_invocation_contract.direct_message
+        ~keeper_name:name
+        ~prompt:message
+        ~direct_reply:true
+        ?turn_instructions
+        ?surface_context
+        ~channel
+        ~user_blocks
+        ~attachments
+        ()
+    with
+    | Ok message -> message
+    | Error error ->
+      fail (Keeper_invocation_contract.request_error_to_string error)
+  in
+  { Server_routes_http_keeper_stream.name = name
+  ; message
+  ; user_blocks
+  ; turn_instructions
+  ; surface_context
+  ; channel
+  ; channel_user_id
+  ; channel_user_name
+  ; channel_workspace_id
+  ; attachments
+  ; direct_message
+  }
+
 let rec remove_tree path =
   if Sys.file_exists path then
     if Sys.is_directory path then begin
@@ -274,17 +317,28 @@ let test_parse_keeper_chat_stream_request_accepts_connector_context () =
       check string "workspace id" "workspace-9" payload.channel_workspace_id
   | Error err -> fail ("expected connector context to parse: " ^ err)
 
-let test_parse_keeper_chat_stream_request_rejects_removed_timeout () =
-  let body = {|{"name":"luna","message":"hello","timeout_sec":1200.5}|} in
+let test_parse_keeper_chat_stream_request_rejects_unknown_field () =
+  let body = {|{"name":"luna","message":"hello","unexpected":true}|} in
   match Server_routes_http_keeper_stream.parse_keeper_chat_stream_request body with
-  | Ok _ -> fail "expected the retired request timeout to be rejected"
+  | Ok _ -> fail "expected an undeclared field to be rejected"
   | Error err ->
-    check string
-      "removed field is named explicitly"
-      "removed keeper message args for masc_keeper_msg: timeout_sec \
-       (request-level whole-turn deadline is retired; use explicit operator \
-       cancellation, provider progress deadlines, or tool-local deadlines)."
-      err
+    check bool "unknown field is named" true (string_contains err "unexpected")
+;;
+
+let test_parse_keeper_chat_stream_request_rejects_duplicate_field () =
+  let body = {|{"name":"luna","name":"other","message":"hello"}|} in
+  match Server_routes_http_keeper_stream.parse_keeper_chat_stream_request body with
+  | Ok _ -> fail "expected duplicate fields to be rejected"
+  | Error err ->
+    check string "duplicate field error"
+      "request body must contain unique fields" err
+;;
+
+let test_parse_keeper_chat_stream_request_rejects_wrong_field_type () =
+  let body = {|{"name":"luna","message":"hello","channel":42}|} in
+  match Server_routes_http_keeper_stream.parse_keeper_chat_stream_request body with
+  | Ok _ -> fail "expected wrong field type to be rejected"
+  | Error err -> check string "wrong type error" "channel must be a string" err
 ;;
 
 let test_parse_keeper_chat_stream_request_rejects_partial_connector_context () =
@@ -637,52 +691,38 @@ let test_keeper_stream_args_preserve_user_blocks () =
       size = Some 1024;
     }
   in
-  let payload =
-    { Server_routes_http_keeper_stream.name = "luna";
-      message = "describe this";
-      user_blocks =
-        [
-          Keeper_multimodal_input.User_text "describe this";
-          Keeper_multimodal_input.User_image media;
-        ];
-      turn_instructions = None;
-      surface_context = None;
-      channel = "";
-      channel_user_id = "";
-      channel_user_name = "";
-      channel_workspace_id = "";
-      attachments =
-        [
-          {
-            K.id = "att-img";
-            att_type = "image";
-            name = "screen.png";
-            size = 1024;
-            mime_type = "image/png";
-            data = "abc123";
-          };
-        ];
-    }
+  let user_blocks =
+    [ Keeper_multimodal_input.User_text "describe this"
+    ; Keeper_multimodal_input.User_image media
+    ]
   in
-  match Server_routes_http_keeper_stream.For_testing.args_of_request payload with
-  | `Assoc fields -> (
-      match List.assoc_opt "user_blocks" fields, List.assoc_opt "attachments" fields with
-      | Some (`List [ `Assoc text_fields; `Assoc image_fields ]),
-        Some (`List [ `Assoc attachment_fields ]) ->
-          check (option string) "text block type" (Some "text")
-            (match List.assoc_opt "type" text_fields with
-             | Some (`String value) -> Some value
-             | _ -> None);
-          check (option string) "image block ref" (Some "att-img")
-            (match List.assoc_opt "attachment_id" image_fields with
-             | Some (`String value) -> Some value
-             | _ -> None);
-          check (option string) "attachment payload" (Some "abc123")
-            (match List.assoc_opt "data" attachment_fields with
-             | Some (`String value) -> Some value
-             | _ -> None)
-      | _ -> fail "expected user_blocks and attachment payload in keeper args")
-  | _ -> fail "expected keeper args object"
+  let attachments =
+    [ { K.id = "att-img"
+      ; att_type = "image"
+      ; name = "screen.png"
+      ; size = 1024
+      ; mime_type = "image/png"
+      ; data = "data:image/png;base64,abc123"
+      }
+    ]
+  in
+  let payload =
+    stream_payload_exn ~name:"luna" ~message:"describe this" ~user_blocks
+      ~attachments ()
+  in
+  let direct_message =
+    Server_routes_http_keeper_stream.For_testing.direct_message_of_request payload
+  in
+  check int "user blocks" 2
+    (List.length
+       (Keeper_invocation_contract.direct_message_user_blocks direct_message));
+  check int "attachments" 1
+    (List.length
+       (Keeper_invocation_contract.direct_message_attachments direct_message));
+  check int "OAS blocks validated at boundary" 2
+    (Keeper_invocation_contract.direct_message_user_oas_blocks direct_message
+     |> Option.map List.length
+     |> Option.value ~default:0)
 
 let test_keeper_stream_bridge_preserves_interleaved_thinking_and_tool () =
   let open Agent_sdk.Types in
@@ -2612,16 +2652,8 @@ let test_surface_context_mcp_path_renders_list_fields () =
 
 let test_chat_surface_of_request_labels_copilot_gate () =
   let payload =
-    { Server_routes_http_keeper_stream.name = "luna";
-      message = "hello";
-      turn_instructions = None;
-      surface_context = None;
-      user_blocks = [];
-      channel = "copilot";
-      channel_user_id = "";
-      channel_user_name = "";
-      channel_workspace_id = "session-7";
-      attachments = [] }
+    stream_payload_exn ~name:"luna" ~message:"hello" ~channel:"copilot"
+      ~channel_workspace_id:"session-7" ()
   in
   let surface = Server_routes_http_keeper_stream.For_testing.chat_surface_of_request payload in
   check string "copilot surface label" "copilot" (Surface_ref.lane_label surface);
@@ -2635,16 +2667,8 @@ let test_chat_surface_of_request_labels_copilot_gate () =
 
 let test_chat_speaker_of_request_copilot_is_owner () =
   let payload =
-    { Server_routes_http_keeper_stream.name = "luna";
-      message = "hello";
-      turn_instructions = None;
-      surface_context = None;
-      user_blocks = [];
-      channel = "copilot";
-      channel_user_id = "";
-      channel_user_name = "";
-      channel_workspace_id = "session-7";
-      attachments = [] }
+    stream_payload_exn ~name:"luna" ~message:"hello" ~channel:"copilot"
+      ~channel_workspace_id:"session-7" ()
   in
   let speaker = Server_routes_http_keeper_stream.For_testing.chat_speaker_of_request payload in
   check (option string) "copilot speaker id" None speaker.speaker_id;
@@ -2654,45 +2678,15 @@ let test_chat_speaker_of_request_copilot_is_owner () =
 
 let test_chat_speaker_of_request_connector_is_external () =
   let payload =
-    { Server_routes_http_keeper_stream.name = "luna";
-      message = "hello";
-      turn_instructions = None;
-      surface_context = None;
-      user_blocks = [];
-      channel = "discord";
-      channel_user_id = "user-42";
-      channel_user_name = "Alice";
-      channel_workspace_id = "workspace-9";
-      attachments = [] }
+    stream_payload_exn ~name:"luna" ~message:"hello" ~channel:"discord"
+      ~channel_user_id:"user-42" ~channel_user_name:"Alice"
+      ~channel_workspace_id:"workspace-9" ()
   in
   let speaker = Server_routes_http_keeper_stream.For_testing.chat_speaker_of_request payload in
   check (option string) "connector speaker id" (Some "user-42") speaker.speaker_id;
   check (option string) "connector speaker name" (Some "Alice") speaker.speaker_name;
   check bool "connector speaker authority is external" true
     (speaker.speaker_authority = Keeper_chat_store.External)
-
-let test_parse_keeper_chat_stream_request_rejects_legacy_model_args () =
-  let cases =
-    [
-      ( "models",
-        {|{"name":"luna","message":"hello","models":["glm:legacy"]}|} );
-      ( "allowed_models",
-        {|{"name":"luna","message":"hello","allowed_models":["glm:legacy"]}|} );
-      ( "active_model",
-        {|{"name":"luna","message":"hello","active_model":"glm:legacy"}|} );
-    ]
-  in
-  List.iter
-    (fun (field, body) ->
-      match Server_routes_http_keeper_stream.parse_keeper_chat_stream_request body with
-      | Ok _ -> fail ("expected legacy field to be rejected: " ^ field)
-      | Error err ->
-          check string ("legacy field rejected: " ^ field)
-            (Printf.sprintf
-               "removed keeper model args for masc_keeper_msg: %s. Use runtime_id; concrete provider/model identity is resolved from the default runtime."
-               field)
-            err)
-    cases
 
 (* ── Filesystem-safe sanitizer ──────────────────────────────────────── *)
 
@@ -2929,8 +2923,12 @@ let () =
             test_contextualize_message_includes_channel_metadata;
           test_case "stream request accepts connector context" `Quick
             test_parse_keeper_chat_stream_request_accepts_connector_context;
-          test_case "stream request rejects removed request timeout" `Quick
-            test_parse_keeper_chat_stream_request_rejects_removed_timeout;
+          test_case "stream request rejects unknown fields" `Quick
+            test_parse_keeper_chat_stream_request_rejects_unknown_field;
+          test_case "stream request rejects duplicate fields" `Quick
+            test_parse_keeper_chat_stream_request_rejects_duplicate_field;
+          test_case "stream request rejects wrong field types" `Quick
+            test_parse_keeper_chat_stream_request_rejects_wrong_field_type;
           test_case "stream request rejects partial connector context" `Quick
             test_parse_keeper_chat_stream_request_rejects_partial_connector_context;
           test_case "stream request accepts copilot context" `Quick
@@ -3059,8 +3057,6 @@ let () =
             test_chat_speaker_of_request_copilot_is_owner;
           test_case "connector request speaker is external" `Quick
             test_chat_speaker_of_request_connector_is_external;
-          test_case "stream request rejects legacy model args" `Quick
-            test_parse_keeper_chat_stream_request_rejects_legacy_model_args;
         ] );
       ( "filesystem_safe",
         [

--- a/test/test_keeper_busy_dashboard_deferred.ml
+++ b/test/test_keeper_busy_dashboard_deferred.ml
@@ -388,14 +388,14 @@ let test_stream_surface_preserves_typed_shutdown_rejection () =
     }
   in
   let observed = ref None in
+  let message =
+    (payload ~content:"must remain pending" ()).direct_message
+  in
   let result =
     Keeper_tool_surface_ops.handle_keeper_msg_stream
       ~on_admission_rejected:(fun rejection -> observed := Some rejection)
       ctx
-      (`Assoc
-         [ ("name", `String keeper_name)
-         ; ("message", `String "must remain pending")
-         ])
+      message
   in
   check "shutdown-fenced stream dispatch does not report success"
     (not (Tool_result.is_success result));

--- a/test/test_keeper_busy_dashboard_deferred.ml
+++ b/test/test_keeper_busy_dashboard_deferred.ml
@@ -22,6 +22,21 @@ let thread_id = "busy-dashboard-thread"
 
 let payload ?(name = keeper_name) ?(content = "are you there?") ()
     : Server_routes_http_keeper_stream.keeper_chat_stream_request =
+  let direct_message =
+    match
+      Keeper_invocation_contract.direct_message
+        ~keeper_name:name
+        ~prompt:content
+        ~direct_reply:true
+        ~channel:""
+        ~user_blocks:[]
+        ~attachments:[]
+        ()
+    with
+    | Ok message -> message
+    | Error error ->
+      failwith (Keeper_invocation_contract.request_error_to_string error)
+  in
   { name
   ; message = content
   ; user_blocks = []
@@ -32,6 +47,7 @@ let payload ?(name = keeper_name) ?(content = "are you there?") ()
   ; channel_user_name = ""
   ; channel_workspace_id = ""
   ; attachments = []
+  ; direct_message
   }
 ;;
 

--- a/test/test_keeper_chat_admission_contention.ml
+++ b/test/test_keeper_chat_admission_contention.ml
@@ -291,6 +291,21 @@ let test_queued_server_turn_has_no_second_durable_request () =
            | Ok channel -> channel
            | Error detail -> failwith detail
          in
+         let direct_message =
+           match
+             Keeper_invocation_contract.direct_message
+               ~keeper_name
+               ~prompt:"queued inline boundary"
+               ~direct_reply:true
+               ~channel:""
+               ~user_blocks:[]
+               ~attachments:[]
+               ()
+           with
+           | Ok message -> message
+           | Error error ->
+             failwith (Keeper_invocation_contract.request_error_to_string error)
+         in
          let payload :
              Server_routes_http_keeper_stream.keeper_chat_stream_request =
            { name = keeper_name
@@ -303,6 +318,7 @@ let test_queued_server_turn_has_no_second_durable_request () =
            ; channel_user_name = ""
            ; channel_workspace_id = ""
            ; attachments = []
+           ; direct_message
            }
          in
          let receipt_id =

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1422,9 +1422,7 @@ let test_persona_defaults_reject_unsupported_keeper_fields () =
     {|{
   "name": "Probe",
   "keeper": {
-    "short_goal": "dead horizon",
-    "will": "dead self-model",
-    "model": "dead runtime assignment"
+    "unknown_prompt_field": "not accepted"
   }
 }|};
   match KTP.load_keeper_profile_defaults_result "probe" with
@@ -1433,12 +1431,8 @@ let test_persona_defaults_reject_unsupported_keeper_fields () =
     let detail = KTP.keeper_toml_load_error_to_string error in
     check bool "persona error identifies unsupported contract" true
       (contains_substring detail "unsupported persona keeper fields");
-    check bool "persona error names short_goal" true
-      (contains_substring detail "short_goal");
-    check bool "persona error names will" true
-      (contains_substring detail "will");
-    check bool "persona error names model" true
-      (contains_substring detail "model")
+    check bool "persona error names unknown field" true
+      (contains_substring detail "unknown_prompt_field")
 
 let test_persona_defaults_reject_removed_shards () =
   with_personas_dir @@ fun personas_dir ->

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -644,13 +644,8 @@ let test_validate_args_keeper_board_list_rejects_unknown_field () =
       (Yojson.Safe.to_string forwarded)
   | Error _ -> ()
 
-(* The keeper/persona tool schemas in [Keeper_schema] hand-roll their
-   [`Assoc] input_schema. Eleven of them omitted [additionalProperties],
-   so [Tool_input_validation.unsupported_arg_names] returned [] for them and
-   an undeclared field reached the handler, which then dropped it with no
-   error. Only the fourteen names hand-listed in
-   [Keeper_config_text.removed_keeper_msg_inputs] produced a rejection;
-   a typo did not. *)
+(* Keeper/persona tool schemas are closed: undeclared input cannot reach a
+   handler and disappear silently. *)
 let keeper_schema_input name =
   find_schema_exn name Masc.Keeper_schema.schemas
 
@@ -676,14 +671,6 @@ let assert_rejects_undeclared_field ~tool ~field =
 
 let test_keeper_up_rejects_undeclared_field () =
   assert_rejects_undeclared_field ~tool:"masc_keeper_up" ~field:"shrt_goal"
-
-(* The retired goal inputs were rejected only because they were hand-listed.
-   Closing the schema rejects them through the same path as any other
-   undeclared name, which is what makes the hand-list redundant. *)
-let test_keeper_up_rejects_retired_goal_inputs () =
-  List.iter
-    (fun field -> assert_rejects_undeclared_field ~tool:"masc_keeper_up" ~field)
-    [ "goal"; "short_goal"; "mid_goal"; "long_goal"; "new_goal" ]
 
 let test_keeper_down_rejects_undeclared_field () =
   assert_rejects_undeclared_field ~tool:"masc_keeper_down" ~field:"remove_metaa"
@@ -2258,8 +2245,6 @@ let () =
     ("keeper_schema_closure", [
       Alcotest.test_case "keeper_up rejects an undeclared field" `Quick
         test_keeper_up_rejects_undeclared_field;
-      Alcotest.test_case "keeper_up rejects retired goal inputs" `Quick
-        test_keeper_up_rejects_retired_goal_inputs;
       Alcotest.test_case "keeper_down rejects an undeclared field" `Quick
         test_keeper_down_rejects_undeclared_field;
       Alcotest.test_case "keeper_up accepts live-traffic fields" `Quick


### PR DESCRIPTION
## Summary\n- introduce one typed Keeper direct-message contract at the invocation boundary\n- decode HTTP payloads exactly once and reject unknown, duplicate, or malformed fields\n- remove the named historical keeper_msg input catalog and its facade exports\n- stop forwarding connector identity and metadata into the turn-owned contract\n- carry the typed request through HTTP, queue, Gate, Board, async, and stream paths\n\n## Verification\n- ocamlformat 0.29.0 on all changed OCaml files\n- ocamlc -stop-after parsing on all changed OCaml files\n- git diff --check\n- focused Dune build reached compilation and exposed one type mismatch, which was fixed\n- rerun blocked by an unrelated bare dune build in another worktree; Draft CI is the build authority

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`refactor/keeper-msg-positive-contract` → `main` · 3 commit(s) · synced 2026-08-05T02:24:38Z

| sha | subject | date |
|---|---|---|
| `b5f033845` | refactor: type Keeper message boundary | 2026-08-05 |
| `fba148a84` | test: pass typed Keeper message to stream | 2026-08-05 |
| `6b0ff0fe2` | test: purge retired Keeper field fixtures | 2026-08-05 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->