### PR TITLE
fix(keeper): 복구로 시작된 lane 에도 supervised lane 과 같은 sidecar 를 준다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -814,6 +814,15 @@ jobs:
             @test/runtest-test_tool_registry_consistency \
             @test/runtest-test_tool_spec
 
+      - name: Run keeper lane launch-order AST suite
+        # Asserts on lib/keeper sources through Ast_grep, so @check cannot run
+        # it. It sat outside every target list while one of its counts was
+        # already wrong, which is how the two lane-start paths drifted into
+        # forking different sidecar sets.
+        run: |
+          opam exec -- dune build --root . \
+            @test/runtest-test_keeper_keepalive_launch_order_ast
+
       - name: Run paused-work transfer and source-ACK suites
         id: paused_work_transfer_and_operator_suites
         if: ${{ always() && steps.build_step.outcome == 'success' }}

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -465,6 +465,47 @@ let start_keeper_grpc_heartbeat
 ;;
 ;;
 
+(* Ambient Board judgment is a sibling worker on the Keeper lifecycle switch:
+   it drains durable candidates as singleton exact flows, and cancellation
+   joins it with the lane. It belongs to the lane, not to one launch path --
+   forking it from a single place is what keeps that true. A lane started by
+   [start_keepalive] recovery used to get no worker at all, so its Board
+   candidates were recorded and never judged, with no failure anywhere to
+   read.
+
+   RFC-0341 (Accepted): tool, persistence and resource failures are
+   observations and never produce an implicit lifecycle transition. A worker
+   fatal therefore stops the worker and is recorded; the lane continues. *)
+let fork_board_attention_worker
+      ~(sw : Eio.Switch.t)
+      ~(ctx : _ context)
+      ~(keeper_name : string)
+      ~(stop : unit Eio.Promise.t)
+  : unit
+  =
+  Eio.Fiber.fork ~sw (fun () ->
+    match
+      Eio.Fiber.first
+        (fun () ->
+           `Worker
+             (Keeper_board_attention_worker.run
+                ~sw
+                ~clock:ctx.clock
+                ~net:ctx.net
+                ~base_path:ctx.config.base_path
+                ~keeper_name))
+        (fun () ->
+           Eio.Promise.await stop;
+           `Stopped)
+    with
+    | `Stopped | `Worker (Ok ()) -> ()
+    | `Worker (Error fatal) ->
+      Log.Keeper.error
+        "board attention worker stopped keeper=%s: %s (lane continues)"
+        keeper_name
+        (Keeper_board_attention_worker.fatal_error_to_string fatal))
+;;
+
 (* ── Lifecycle bootstrap / publish helpers ── *)
 
 let bootstrap_live_keeper_meta ?lifecycle_token ~(ctx : _ context) (m : keeper_meta)
@@ -1166,14 +1207,25 @@ let start_keepalive
              reg.lane
              ~run:(fun lane_sw ->
         let ctx = { ctx with sw = lane_sw } in
-        (* The sidecar is part of this Keeper lane. It cannot outlive the
-           lane's structured-concurrency scope. *)
+        (* The sidecars are part of this Keeper lane. They cannot outlive the
+           lane's structured-concurrency scope, and a lane reached through
+           recovery carries the same set as a supervised one. *)
         let grpc_close = start_keeper_grpc_heartbeat ~ctx ~m ~stop in
         (match grpc_close with
          | Some _ ->
            Atomic.set reg.grpc_close grpc_close
          | None -> ());
-        run_heartbeat_loop ~proactive_warmup_sec ctx live_meta stop ~wakeup)
+        let board_stop, resolve_board_stop = Eio.Promise.create () in
+        fork_board_attention_worker
+          ~sw:lane_sw
+          ~ctx
+          ~keeper_name:live_meta.name
+          ~stop:board_stop;
+        Eio_guard.protect
+          (fun () ->
+             run_heartbeat_loop ~proactive_warmup_sec ctx live_meta stop ~wakeup)
+          ~finally:(fun () ->
+            ignore (Eio.Promise.try_resolve resolve_board_stop () : bool)))
              ~cleanup:cleanup_tracking
          with
          | Ok () -> Keepalive_started reg

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -70,6 +70,22 @@ val effective_keepalive_meta :
 val wakeup_relevant_keeper_for_board_signal :
   config:Workspace.config -> Board_dispatch.addressed_board_signal -> unit
 
+(** Fork the Board-attention judgment worker as a sibling of the heartbeat
+    loop on the same Keeper lane switch. Both lane-start paths call this, so
+    the lane's sidecar set has one definition: a lane reached through
+    [start_keepalive] recovery judges Board candidates exactly as a supervised
+    one does. Resolve [stop] when the lane's heartbeat ends.
+
+    A worker fatal stops the worker and is recorded; the lane continues
+    (RFC-0341: tool/persistence/resource failures are observations and never
+    produce an implicit lifecycle transition). *)
+val fork_board_attention_worker :
+  sw:Eio.Switch.t ->
+  ctx:'a context ->
+  keeper_name:string ->
+  stop:unit Eio.Promise.t ->
+  unit
+
 (** The heartbeat loop body, extracted for reuse by the supervisor.
     Runs synchronously in the calling fiber until [stop] becomes true. *)
 val run_heartbeat_loop :

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -243,29 +243,15 @@ let launch_supervised_fiber_body
       Eio_guard.protect
         (fun () ->
            try
-             (* Ambient Board judgment is a sibling worker on this exact Keeper
-                lifecycle switch. It drains durable candidates as singleton
-                exact flows: MASC owns the input and durable callbacks, while
-                OAS owns target admission, dispatch, and advancement.
-                Cancellation joins the worker with the Keeper lane. *)
-             Eio.Fiber.fork ~sw:lane_sw (fun () ->
-               match Eio.Fiber.first
-                 (fun () ->
-                    `Worker
-                      (Keeper_board_attention_worker.run
-                         ~sw:lane_sw
-                         ~clock:ctx.clock
-                         ~net:ctx.net
-                         ~base_path
-                         ~keeper_name:meta.name))
-                 (fun () ->
-                    Eio.Promise.await board_worker_stop;
-                    `Stopped)
-               with
-               | `Stopped | `Worker (Ok ()) -> ()
-               | `Worker (Error fatal) ->
-                 failwith
-                   (Keeper_board_attention_worker.fatal_error_to_string fatal));
+             (* MASC owns the worker's input and durable callbacks, while OAS
+                owns target admission, dispatch, and advancement. The fork
+                itself lives in [Keeper_keepalive] so both lane-start paths
+                produce the same lane. *)
+             Keeper_keepalive.fork_board_attention_worker
+               ~sw:lane_sw
+               ~ctx
+               ~keeper_name:meta.name
+               ~stop:board_worker_stop;
              (* Keeper lifetime, idle duration, and progress age are
                 observations only. The supervisor runs the lane directly;
                 configured provider/tool boundaries and explicit operator

--- a/test/dune
+++ b/test/dune
@@ -691,9 +691,16 @@
   (source_tree ../scripts/fixtures))
  (libraries masc_test_deps compaction_exact_output_fixture))
 
+; Reads lib/keeper sources through Ast_grep, so those sources are deps: without
+; them dune keeps a cached pass and the suite never re-runs when the code it
+; asserts on changes.
 (test
  (name test_keeper_keepalive_launch_order_ast)
  (modules test_keeper_keepalive_launch_order_ast)
+ (deps
+  %{workspace_root}/lib/keeper/keeper_keepalive.ml
+  %{workspace_root}/lib/keeper/keeper_supervisor_launch.ml
+  %{workspace_root}/test/fixtures/keeper_keepalive_launch_order_ast_fixture.ml)
  (libraries alcotest ast_grep))
 
 (test

--- a/test/test_keeper_keepalive_launch_order_ast.ml
+++ b/test/test_keeper_keepalive_launch_order_ast.ml
@@ -37,7 +37,40 @@ let test_launch_gate_dominates_launch_side_effects () =
     ; "publish_keeper_started"
     ; "Keeper_lane.fork"
     ; "start_keeper_grpc_heartbeat"
+    ; (* A lane reached through recovery used to carry the gRPC sidecar and no
+         Board-attention worker, so its Board candidates were recorded and
+         never judged. Measured 2026-08-05: 532 pending candidates on four
+         live keepers, the oldest 5 days old, with no failure logged anywhere
+         -- there is no worker to fail. *)
+      "fork_board_attention_worker"
     ]
+;;
+
+(* The lane's sidecar set must have one definition. Two lane-start paths fork
+   the same registry entry's lane ([Keeper_lane.fork] rejects the second with
+   [Already_started]), so whichever path wins decides what the lane contains.
+   Pinning the single fork site is what keeps the two paths from drifting into
+   different lanes again. *)
+let test_board_worker_has_one_fork_site () =
+  check int
+    "keeper_keepalive owns the only Keeper_board_attention_worker.run call"
+    1
+    (Ast_grep.count_calls
+       ~module_path:"lib/keeper/keeper_keepalive.ml"
+       ~callee:"Keeper_board_attention_worker.run");
+  check int
+    "the supervisor does not fork its own worker"
+    0
+    (Ast_grep.count_calls
+       ~module_path:"lib/keeper/keeper_supervisor_launch.ml"
+       ~callee:"Keeper_board_attention_worker.run");
+  check int
+    "the supervisor lane body calls the shared fork"
+    1
+    (Ast_grep.count_calls_in_value_binding
+       ~module_path:"lib/keeper/keeper_supervisor_launch.ml"
+       ~binding_name:"launch_supervised_fiber_body"
+       ~callee:"Keeper_keepalive.fork_board_attention_worker")
 ;;
 
 let cleanup_protect_count ~module_path ~binding_name =
@@ -61,9 +94,14 @@ let test_cleanup_protect_checker_rejects_omitted_helper () =
 let test_supervisor_finally_calls_cleanup_best_effort () =
   let module_path = "lib/keeper/keeper_supervisor_launch.ml" in
   let binding_name = "launch_supervised_fiber_body" in
+  (* Two nested guards: the outer one runs lane cleanup, the inner one stops
+     the Board-attention worker when the heartbeat loop returns. The count was
+     pinned at 1 and has been wrong since the inner guard appeared -- this
+     suite is in no CI target list and declares no [deps] on the sources it
+     reads, so it neither ran nor re-ran. *)
   check int
-    "supervisor has one Eio_guard.protect"
-    1
+    "supervisor has two nested Eio_guard.protect"
+    2
     (Ast_grep.count_calls_in_value_binding
        ~module_path
        ~binding_name
@@ -94,6 +132,10 @@ let () =
             "supervisor finally calls cleanup best effort"
             `Quick
             test_supervisor_finally_calls_cleanup_best_effort
+        ; test_case
+            "board attention worker has one fork site"
+            `Quick
+            test_board_worker_has_one_fork_site
         ] )
     ]
 ;;


### PR DESCRIPTION
Closes #26863 의 근본 원인. 판정 프롬프트나 관측 추가가 아니라 **lane 정의가 두 개였던 것**을 하나로 만든다.

## 무엇이 문제였나

lane 을 fork 하는 지점이 둘이고, 각자 **다른 sidecar 집합**을 띄웠다:

| lane fork 지점 | board attention worker | gRPC sidecar |
|---|:---:|:---:|
| `keeper_supervisor_launch.ml:250` | **O** | X |
| `keeper_keepalive.ml:1167` (`start_keepalive`) | X | **O** |

둘 다 같은 registry entry 의 lane 에 `Keeper_lane.fork` 하고, `start_error` 에 `Already_started` 가 있으므로 **둘 중 하나만 실행된다.** 즉 어느 경로로 lane 을 얻었느냐가 그 lane 이 무엇을 담는지를 결정했다.

`start_keepalive` 는 복구 경로다 — stale entry(`Stopped`/`Failing`/`Crashed`/…)를 회수하고 새 lane 을 띄우며, `keeper_turn.ml:828` 이 message turn 실패 시 호출한다. 그렇게 복구된 keeper 는 **턴은 계속 돌면서 board attention worker 를 영구히 잃었다.** 후보는 기록되고 판정만 안 됐고, **worker 가 없으니 실패도 안 났다.**

## 라이브 실측 (2026-08-05)

```
pending 532건  /  live·unpaused keeper 4명
  code-reviewer  208건  마지막 소비 07-31 15:37  (5일)
  taskmaster     166건  마지막 소비 08-02 11:10  ← 같은 기간 board 게시 26건
  kidsnote        82건  마지막 소비 08-02 15:27
  analyst         76건  마지막 소비 08-02 15:28

board_attention_claim_contention   4일간 0건
Board attention worker failed      3일간 0건
worker 로그에 등장하는 keeper       rondo, sangsu 뿐
```

각 keeper 의 pending 은 그 keeper 의 소비가 멈춘 지점에서 정확히 시작한다.

## 변경

1. fork 를 `Keeper_keepalive.fork_board_attention_worker` 로 옮기고 **두 경로가 그것을 호출**한다. sidecar 정의가 하나가 된다.
2. **worker fatal 이 lane 을 죽이지 않는다.** `RFC-0341` (Accepted):

   > tool, persistence and resource failures are **observations and never produce a latch, pause, recovery band, or implicit lifecycle transition**

   기존 `failwith` 는 이 규칙을 위반했다. worker 는 이미 자기 fatal 을 로그로 남기고(`keeper_board_attention_worker.ml:1656`) lane 경계에서도 기록한 뒤 계속 돈다.

## 게이트가 게이트가 아니었다

이 드리프트를 잡아야 했던 `test_keeper_keepalive_launch_order_ast` 는:

- **어느 CI target list 에도 없었다** (CI 는 `@test/runtest-*` 를 명시 열거)
- **읽는 소스에 `deps` 선언이 없었다** → dune 이 캐시된 pass 를 유지, 소스가 바뀌어도 재실행 안 됨
- 그래서 **이미 틀린 단언을 품고 있었다** — supervisor 의 `Eio_guard.protect` 를 1로 고정했으나 실제는 중첩 2개

세 가지를 다 고쳤다: 카운트 정정, `deps` 선언, CI step 추가. 그리고 fork 지점이 하나임을 고정하는 단언을 추가했다.

`ci.yml` 삽입 위치는 815 행 근처로, 동시 진행 중인 #26830 의 hunk(1036–1072)와 겹치지 않는다.

## 검증

```
dune build @check                                        exit 0
@test/runtest-...launch_order_ast --force                5/5 pass
negative control (복구 경로 fork 만 제거)                  FAIL: Fiber_started Ok branch
                                                               dominates fork_board_attention_worker
baseline 확인 (origin/main 에서 같은 suite 실행)            이미 1건 실패 — 내 회귀가 아님
ocamlformat --check (4 파일)                              exit 0
python yaml.safe_load(ci.yml)                            ok
```

## 확정하지 못한 것

정지한 4명이 각각 어느 경로로 lane 을 얻었는지는 로그에 남지 않아 확인 불가능하다. 이 PR 은 **어느 경로든 온전한 lane 을 만들어** 그 질문 자체를 없앤다. 다만 이미 쌓인 532건이 자동으로 배수되는지는 배포 후 관측이 필요하다 — worker 시작 시 durable drain 이 돌면 배수되어야 한다.

RFC-WAIVED: RFC-0341 이 이 변경의 근거이며 새 설계를 도입하지 않는다 (lane sidecar 를 한 정의로 되돌리고 RFC-0341 위반 `failwith` 를 제거).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
