### PR TITLE
refactor: remove legacy receipt outcome parser

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -33,10 +33,8 @@ let receipt_duration_ms receipt =
    classify a receipt and falls through to the catch-all
    [(Disp_unknown, Reason_unmapped_runtime_state)].
 
-   This counter alerts operators if a future refactor reintroduces a
-   silent path — a non-zero rate is a regression signal.  Companion
-   to the existing PR #11651 narrative documented at the fall-through
-   case below ([match outcome_kind_of_string ...] catch-all). *)
+   This counter alerts operators if a future refactor leaves a receipt
+   tuple outside the typed classification below. *)
 let () =
   Otel_metric_store.register_counter
     ~name:Keeper_metrics.(to_string ReceiptUnmappedDisposition)

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -18,20 +18,13 @@ type outcome_kind =
   ]
 
 (** Stable serialisation: [`Ok -> "ok"], [`Skipped -> "skipped"],
-    [`Error -> "error"], [`Cancelled -> "cancelled"]. Used at the JSON
-    boundary while the receipt record still stores the legacy string
-    form. *)
+    [`Error -> "error"], [`Cancelled -> "cancelled"]. *)
 val outcome_kind_to_string : outcome_kind -> string
 
 (** TLA+ receipt symbol mapping: [`Ok] serializes as ["ok"] in JSON but
     corresponds to ["receipt_done"] in [KeeperTurnFSM.tla]; [`Error]
     similarly maps to ["receipt_failed"]. *)
 val outcome_kind_to_tla_receipt : outcome_kind -> string
-
-(** Parse the legacy string form. Recognises the four terminal kinds
-    and returns [None] for everything else (including ["unset"]) so
-    callers can decide whether to fail-closed or surface as [`Error]. *)
-val outcome_kind_of_string : string -> outcome_kind option
 
 (** [true] for [`Ok] and [`Skipped] (PhaseGateSkip is a successful
     no-op, not a failure). [false] for [`Error] and [`Cancelled].

--- a/lib/keeper/keeper_execution_receipt_types.ml
+++ b/lib/keeper/keeper_execution_receipt_types.ml
@@ -9,8 +9,7 @@
    [`Skipped] corresponds to TLA+ "receipt_skipped" produced by the
    [PhaseGateSkip] action: the turn reached terminal [Done] without
    dispatching, so it is a successful no-op rather than a failure or
-   cancellation. The receipt record still stores the legacy string for
-   JSON compatibility; consumers must go through these helpers so that
+   cancellation. JSON projection goes through the typed helpers so that
    Skipped/Cancelled/Error are not silently folded into one another. *)
 type outcome_kind = Keeper_execution_receipt_outcome_kind.outcome_kind
 
@@ -18,8 +17,6 @@ let outcome_kind_to_string =
   Keeper_execution_receipt_outcome_kind.outcome_kind_to_string
 let outcome_kind_to_tla_receipt =
   Keeper_execution_receipt_outcome_kind.outcome_kind_to_tla_receipt
-let outcome_kind_of_string =
-  Keeper_execution_receipt_outcome_kind.outcome_kind_of_string
 let outcome_kind_is_terminal_success =
   Keeper_execution_receipt_outcome_kind.outcome_kind_is_terminal_success
 

--- a/lib/keeper/keeper_execution_receipt_types.mli
+++ b/lib/keeper/keeper_execution_receipt_types.mli
@@ -4,9 +4,6 @@ val outcome_kind_to_string :
   Keeper_execution_receipt_outcome_kind.outcome_kind -> string
 val outcome_kind_to_tla_receipt :
   Keeper_execution_receipt_outcome_kind.outcome_kind -> string
-val outcome_kind_of_string :
-  string ->
-  Keeper_execution_receipt_outcome_kind.outcome_kind option
 val outcome_kind_is_terminal_success :
   Keeper_execution_receipt_outcome_kind.outcome_kind -> bool
 type error_kind = Error_kind of string

--- a/lib/keeper_metrics/keeper_execution_receipt_outcome_kind.ml
+++ b/lib/keeper_metrics/keeper_execution_receipt_outcome_kind.ml
@@ -1,4 +1,4 @@
-(** Outcome-kind polymorphic variant + bijection helpers for
+(** Outcome-kind polymorphic variant and projection helpers for
     keeper execution receipts.
 
     Verbatim extract from the head of [Keeper_execution_receipt].
@@ -7,7 +7,7 @@
     polyvariants are structurally typed and constructors auto-share
     across module boundaries without re-declaration.
 
-    Pure variant + total to/from-string + a small terminal-success
+    Pure variant + total string projections + a small terminal-success
     predicate. No parent-local state. *)
 
 type outcome_kind =
@@ -29,14 +29,6 @@ let outcome_kind_to_tla_receipt = function
   | `Skipped -> "receipt_skipped"
   | `Error -> "receipt_failed"
   | `Cancelled -> "receipt_cancelled"
-;;
-
-let outcome_kind_of_string = function
-  | "ok" | "receipt_done" -> Some `Ok
-  | "skipped" | "receipt_skipped" -> Some `Skipped
-  | "error" | "receipt_failed" -> Some `Error
-  | "cancelled" | "receipt_cancelled" -> Some `Cancelled
-  | _ -> None
 ;;
 
 let outcome_kind_is_terminal_success = function

--- a/lib/keeper_metrics/keeper_execution_receipt_outcome_kind.mli
+++ b/lib/keeper_metrics/keeper_execution_receipt_outcome_kind.mli
@@ -1,4 +1,4 @@
-(** Outcome-kind polymorphic variant + bijection helpers for keeper execution
+(** Outcome-kind polymorphic variant and projection helpers for keeper execution
     receipts. *)
 
 type outcome_kind =
@@ -10,5 +10,4 @@ type outcome_kind =
 
 val outcome_kind_to_string : outcome_kind -> string
 val outcome_kind_to_tla_receipt : outcome_kind -> string
-val outcome_kind_of_string : string -> outcome_kind option
 val outcome_kind_is_terminal_success : outcome_kind -> bool


### PR DESCRIPTION
## Summary
- remove the unused receipt outcome string decoder from the keeper_metrics source module
- remove both receipt facade re-exports instead of preserving a facade chain
- delete legacy/compatibility claims from the current typed receipt contract
- keep only typed outcome producers and the two required JSON/TLA projections

## Evidence
- outcome_kind_of_string production callers: 0
- the only call was the Keeper_execution_receipt_types re-export
- current receipt producers construct outcome_kind directly and serialization uses outcome_kind_to_tla_receipt

## Verification
- ocamlformat on all six changed OCaml files
- ocamlc parse checks on all six changed OCaml files
- repository search confirms the parser and legacy receipt-string contract are gone
- git diff --check

## Local build note
Focused scripts/dune-local.sh build was refused because unrelated bare Dune processes currently hold the shared machine-wide build boundary. No process was killed or bypassed; PR CI is the build authority.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`refactor/receipt-outcome-current-contract` → `main` · 1 commit(s) · synced 2026-08-05T02:43:20Z

| sha | subject | date |
|---|---|---|
| `98b358327` | refactor: remove legacy receipt outcome parser | 2026-08-05 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->