### PR TITLE
test: pin current receipt outcome projections

### DIFF
--- a/test/test_keeper_receipt_authoritative.ml
+++ b/test/test_keeper_receipt_authoritative.ml
@@ -16,6 +16,30 @@
 
 module R = Masc.Keeper_execution_receipt
 
+let test_current_outcome_projections () =
+  [ `Ok, "ok", "receipt_done"
+  ; `Skipped, "skipped", "receipt_skipped"
+  ; `Error, "error", "receipt_failed"
+  ; `Cancelled, "cancelled", "receipt_cancelled"
+  ]
+  |> List.iter (fun (outcome, expected_json, expected_tla) ->
+    let actual_json = R.outcome_kind_to_string outcome in
+    if not (String.equal actual_json expected_json)
+    then
+      failwith
+        (Printf.sprintf
+           "expected JSON receipt outcome %s, got %s"
+           expected_json
+           actual_json);
+    let actual_tla = R.outcome_kind_to_tla_receipt outcome in
+    if not (String.equal actual_tla expected_tla)
+    then
+      failwith
+        (Printf.sprintf
+           "expected TLA receipt outcome %s, got %s"
+           expected_tla
+           actual_tla))
+
 let must_ok ~outcome ~turn_state =
   match R.assert_receipt_authoritative ~outcome ~turn_state with
   | Ok () -> ()
@@ -96,6 +120,7 @@ let test_cancelled_done_passes () =
   must_ok ~outcome:`Cancelled ~turn_state:"done"
 
 let () =
+  test_current_outcome_projections ();
   test_ok_done ();
   test_skipped_done ();
   test_ok_failed_violation ();


### PR DESCRIPTION
## Summary
- add direct coverage for the four typed receipt outcomes
- pin the current JSON and TLA projections that remain after #26870 removed the reverse string decoder
- keep the contract one-way: typed outcome to wire projection only

## Context
#26870 was merged while its Test Coverage Check was red because six covered source files changed without a test-file change. This follow-up contains only the current-contract test that addresses that exact gap; it does not restore any decoder or compatibility path.

## Verification
- ocamlformat
- ocamlc parse check
- git diff --check

## Local build note
The focused Dune wrapper waited on the shared machine-wide lock and was stopped after two minutes without bypassing or killing another session. PR CI is the build authority.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`refactor/receipt-outcome-current-contract` → `main` · 1 commit(s) · synced 2026-08-05T02:45:02Z

| sha | subject | date |
|---|---|---|
| `720182121` | test: pin current receipt outcome projections | 2026-08-05 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->