### PR TITLE
chore(keeper): board worker 정지 ignore() 에 정당화 주석

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1225,6 +1225,10 @@ let start_keepalive
           (fun () ->
              run_heartbeat_loop ~proactive_warmup_sec ctx live_meta stop ~wakeup)
           ~finally:(fun () ->
+            (* fire-and-forget: the bool says whether this call was the one that
+               resolved it. Either way the worker is told to stop, so there is
+               nothing for the caller to decide. Mirrors the supervisor's
+               [stop_board_worker]. *)
             ignore (Eio.Promise.try_resolve resolve_board_stop () : bool)))
              ~cleanup:cleanup_tracking
          with


### PR DESCRIPTION
#26869 의 blocking lint 잔여 1건.

```
FAILED 1/39 lints:
 - ignore() justification (new sites)
   lib/keeper/keeper_keepalive.ml:1228
   Accepted shapes: WORKAROUND, HACK, fire-and-forget, RFC-XXXX, TODO, See/see.
```

## main 은 red 가 아니다

`Lint Suite` 는 PR diff 기준(`scripts/ci/check-ignore-without-comment-diff.sh`)이라 main push 에서는 돌지 않는다. 확인:

```
main branch 워크플로 실행 목록에 Lint Suite 없음
Fundamental Check @ 6567991e0 (#26869 머지 커밋)  = success
```

즉 #26869 는 lint 1건이 red 인 상태로 머지됐지만 main 자체는 green 이다. 그래도 정당화 주석은 있어야 맞고, 그 구역을 건드리는 다음 PR 이 같은 lint 에 걸릴 수 있다.

## 변경

주석 한 블록. `try_resolve` 가 돌려주는 bool 은 "이 호출이 promise 를 resolve 한 쪽인가"를 뜻하고, 어느 쪽이든 worker 에게 정지가 전달된 것이므로 호출자가 판단할 것이 없다. supervisor 의 `stop_board_worker` 와 같은 형태다.

## 검증

```
dune build @check                                            exit 0
ocamlformat --check lib/keeper/keeper_keepalive.ml            exit 0
scripts/ci/check-ignore-without-comment-diff.sh               exit 0
```

관련: #26869

🤖 Generated with [Claude Code](https://claude.com/claude-code)
