### PR TITLE
refactor: hard-cut legacy feature flag state

### DIFF
--- a/dashboard/src/components/feature-health.test.ts
+++ b/dashboard/src/components/feature-health.test.ts
@@ -7,9 +7,7 @@ describe('featureStatusLabel', () => {
     ['healthy', '정상'],
     ['warning', '실험적'],
     ['inactive', '비활성'],
-    ['deprecated', '폐기 예정'],
   ] as const)('featureStatusLabel(%s) → %s', (status, expected) => {
     expect(featureStatusLabel(status)).toBe(expected)
   })
 })
-

--- a/dashboard/src/components/feature-health.ts
+++ b/dashboard/src/components/feature-health.ts
@@ -15,7 +15,7 @@ import { SectionCap } from './common/section-cap'
 import { StatusChip, type StatusChipTone } from './common/status-chip'
 import { KpiStripView, type KpiStripViewData } from './kpi-strip-view'
 
-type FeatureStatus = 'healthy' | 'warning' | 'inactive' | 'deprecated'
+type FeatureStatus = 'healthy' | 'warning' | 'inactive'
 type StatusFilter = FeatureStatus | 'all'
 
 interface FeatureHealthItem {
@@ -26,7 +26,6 @@ interface FeatureHealthItem {
   is_enabled: boolean
   source: string
   status: FeatureStatus
-  since: string
 }
 
 interface FeatureHealthOverview {
@@ -34,7 +33,6 @@ interface FeatureHealthOverview {
   healthy_count: number
   warning_count: number
   inactive_count: number
-  deprecated_count: number
   enabled_count: number
   overridden_count: number
 }
@@ -63,7 +61,6 @@ const STATUS_FILTER_OPTIONS: { value: StatusFilter; label: string }[] = [
   { value: 'healthy', label: '정상' },
   { value: 'warning', label: '실험적' },
   { value: 'inactive', label: '비활성' },
-  { value: 'deprecated', label: '폐기 예정' },
 ]
 
 // Pure filter helpers — exported for isolated testing.
@@ -109,8 +106,8 @@ export async function refreshFeatureHealth(): Promise<void> {
  * Feature-health-domain status → 한국어 라벨.
  *
  * Distinct from `statusLabel` in `lib/status-label.ts` (which handles every
- * runtime/agent status enum). FeatureStatus is a closed 4-enum
- * (`'healthy' | 'warning' | 'inactive' | 'deprecated'`) with feature-flag
+ * runtime/agent status enum). FeatureStatus is a closed enum
+ * (`'healthy' | 'warning' | 'inactive'`) with feature-flag
  * semantics — 'warning' here means "실험적 (experimental)", not "경고"
  * which is what lib/status-label maps it to.
  *
@@ -126,9 +123,6 @@ export function featureStatusLabel(status: FeatureStatus): string {
       return '실험적'
     case 'inactive':
       return '비활성'
-    case 'deprecated':
-    default:
-      return '폐기 예정'
   }
 }
 
@@ -142,9 +136,6 @@ function statusChipTone(status: FeatureStatus): FeatureHealthTone {
       return 'warn'
     case 'inactive':
       return 'neutral'
-    case 'deprecated':
-    default:
-      return 'bad'
   }
 }
 
@@ -167,7 +158,6 @@ function FeatureItem({ item }: { item: FeatureHealthItem }) {
           <div class="mt-1.5 text-sm text-[var(--color-fg-secondary)]">${item.description}</div>
           <div class="mt-1 flex items-center gap-3 text-xs text-[var(--color-fg-muted)]">
             <span>source: ${item.source}</span>
-            <span>since: v${item.since}</span>
           </div>
         </div>
       </div>
@@ -245,7 +235,6 @@ export function FeatureHealth() {
                         { variant: 'stacked', label: '정상', value: overview.healthy_count, kind: 'ok' },
                         { variant: 'stacked', label: '실험적', value: overview.warning_count, kind: 'warn' },
                         { variant: 'stacked', label: '비활성', value: overview.inactive_count },
-                        { variant: 'stacked', label: '폐기 예정', value: overview.deprecated_count, kind: 'err' },
                       ] satisfies KpiStripViewData['cells']}
                     />
                   </div>

--- a/docs/ADR-003-FEATURE-FLAG-REGISTRY-MANAGEMENT.md
+++ b/docs/ADR-003-FEATURE-FLAG-REGISTRY-MANAGEMENT.md
@@ -1,216 +1,27 @@
----
-status: reference
-last_verified: 2026-04-17
-code_refs:
-  - lib/config/feature_flag_registry.ml
----
-
-# ADR-003: Feature Flag Registry Management - 중복과 불일치 방지 전략
-
-**Status**: Accepted
-**Date**: 2026-03-30
-**Reviewers**: Agent-Code, Human
-
----
-
-## Context
-
-MASC는 176개 이상의 환경변수 설정을 사용하며, boolean feature flag는 `lib/config/feature_flag_registry.ml`에 중앙 집중식으로 관리된다. 최근 PR #3793에서 `MASC_KEEPER_WORK_AS_HEARTBEAT` 플래그가 registry에 3번 중복 등록되는 문제가 발견되었다 (lines 95, 130, 140).
-
-### 문제의 근본 원인
-
-1. **Concurrent Feature Branches**: 여러 개발자가 독립적으로 같은 기능에 대한 플래그를 추가
-2. **Git Merge의 한계**: Git은 구조적 중복(같은 값의 다른 위치 삽입)을 감지하지 못함
-3. **리스트 기반 Registry**: Registry가 순서 있는 리스트로 구현되어 hash-key 기반 중복 검사 불가
-4. **불완전한 CI 검증**: 기존 `check-feature-flag-consistency.sh`는 서로 다른 default를 가진 중복만 감지
-
-### 발견된 추가 패턴
-
-registry.ml 분석 결과:
-- 176개 env 변수 getter가 config 모듈에 분산
-- Feature flag lifecycle tracking (Active, Deprecated, Experimental)
-- 일부 config getter는 registry에 미등록 (coverage gap)
-- 설정값 변경 시 registry 동기화 누락 가능성
-
----
+# ADR-003: Feature Flag Registry Management
 
 ## Decision
 
-### 1. Feature Flag Registry는 단일 진실 공급원(SSOT)이다
+`lib/config/feature_flag_registry.ml` is the single source of truth for supported
+boolean feature flags.
 
-**원칙**:
-- 모든 `MASC_*` boolean flag는 `Feature_flag_registry.all_flags`에 등록해야 함
-- `env_name` 필드는 전역 고유해야 함 (duplicate 금지)
-- Registry 외부에서 임의로 `get_bool` 호출 금지
+- Every supported `MASC_*` boolean flag has exactly one registry entry.
+- The registry default and the config reader default must agree.
+- A flag is `Experimental` while its behavior is still being evaluated and
+  `Active` once it is a supported operator control.
+- A flag without a runtime behavior branch is deleted from the reader, registry,
+  metrics, dashboard, tests, and operator documentation in the same change.
+- Removed flags do not retain compatibility readers or lifecycle tombstones.
 
-**검증**:
-- CI가 `check-feature-flag-consistency.sh` 실행
-- duplicate env_name 감지 로직 추가 필요
-- registry와 실제 usage 간 coverage check 필수
+## Verification
 
-### 2. Config 변경은 Registry Update를 동반한다
+Before adding or changing a flag:
 
-**Workflow**:
-```ocaml
-(* 1단계: Feature_flag_registry에 등록 *)
-{
-  env_name = "MASC_NEW_FEATURE_ENABLED";
-  default_value = false;
-  lifecycle = Experimental;
-  category = Runtime;
-  since = "2.163.0";
-  description = "Enable new experimental feature X";
-}
-
-(* 2단계: env_config_*.ml에서 getter 정의 *)
-let get_new_feature_enabled () =
-  Env_config_core.get_bool "MASC_NEW_FEATURE_ENABLED" false
+```bash
+rg 'env_name = "MASC_YOUR_FLAG"' lib/config/feature_flag_registry.ml
+rg 'get_bool.*MASC_YOUR_FLAG' lib/config
+scripts/check-feature-flag-consistency.sh
 ```
 
-**반드시 동시에**:
-- Registry entry 추가
-- Config module getter 추가
-- 두 곳의 default 값 일치 확인
-- Lifecycle 상태 명시
-
-### 3. Concurrent Merge는 Semantic Validation이 필요하다
-
-**현재 한계**:
-- Git merge는 textual conflict만 감지
-- 같은 env_name을 다른 위치에 추가하면 merge conflict 없이 통과
-- 런타임에야 중복 발견 (또는 CI lint가 잡아야 함)
-
-**개선 전략**:
-- **Pre-commit hook**: registry 파일 변경 시 자동으로 duplicate check
-- **CI lint 강화**: env_name uniqueness 검증
-- **Registry 구조 개선 검토**: record type으로 컴파일 타임 uniqueness 강제 (Future)
-
-### 4. Lifecycle Tracking은 Deprecation Workflow를 강제한다
-
-**Flag Lifecycle States**:
-| State | 의미 | 행동 규칙 |
-|-------|------|----------|
-| Experimental | 실험 중, 기본 off | 언제든 제거 가능 |
-| Active | 프로덕션 사용 중 | breaking change 주의 |
-| Deprecated | 단계적 폐기 예정 | 버전 N에서 deprecated, N+2에서 제거 |
-
-**규칙**:
-- Experimental → Active 전환 시 충분한 테스트 필요
-- Active flag를 바로 제거 금지 (먼저 Deprecated로 전환)
-- Deprecated flag는 최소 2 minor version 유지 후 제거
-
----
-
-## Consequences
-
-### 긍정적
-
-1. **중복 방지**: env_name uniqueness가 명확한 규칙이 됨
-2. **추적 가능성**: registry가 모든 flag의 lifecycle 이력 보존
-3. **CI 검증**: 자동화된 consistency check로 인적 오류 감소
-4. **문서화**: registry entry가 flag의 목적과 default를 명시
-
-### 부정적
-
-1. **추가 작업**: flag 추가 시 registry 등록 step 필수
-2. **Merge conflict 증가**: registry 파일이 hot spot이 되어 merge conflict 빈발 가능
-3. **Migration 비용**: 기존 미등록 flag들을 retroactive하게 등록해야 함
-4. **구조적 한계**: 리스트 기반 registry는 여전히 runtime check에 의존
-
-### 미해결 과제
-
-1. **Registry 구조 개선**: 리스트 → hash map 또는 type-level uniqueness로 전환?
-2. **Coverage 완전성**: 모든 env 변수를 registry에 등록할 것인가? (176개)
-3. **동적 flag 추가**: runtime에 flag 추가가 필요한 경우는?
-4. **Multi-module Config**: config가 여러 모듈에 분산된 현 구조를 유지할 것인가?
-
----
-
-## Implementation Checklist
-
-### 즉시 적용 (Done)
-- [x] PR #3793: 중복된 WORK_AS_HEARTBEAT 제거
-
-### 단기 (v2.163.0 목표)
-- [ ] CI lint 강화: env_name duplicate check 추가
-- [ ] Pre-commit hook 추가: registry 변경 시 자동 validation
-- [ ] Coverage report: registry 미등록 flag 목록 자동 생성
-
-### 중기 (v2.164.0 목표)
-- [ ] Registry migration: 기존 미등록 flag들 일괄 등록
-- [ ] Lifecycle policy 문서화: Experimental → Active → Deprecated 전환 기준 명시
-- [ ] Test coverage: registry entry와 실제 usage 일치 검증 테스트
-
-### 장기 (Future)
-- [ ] Registry 구조 개선: type-level uniqueness 또는 GADT 사용 검토
-- [ ] Config unification: 분산된 env_config_* 모듈 통합 방안 검토
-
----
-
-## Best Practices
-
-### ✅ DO
-
-```ocaml
-(* 1. Registry에 먼저 등록 *)
-let flag = {
-  env_name = "MASC_KEEPER_ADAPTIVE_SCHEDULING";
-  default_value = false;
-  lifecycle = Experimental;
-  category = Keeper;
-  since = "2.163.0";
-  description = "Enable adaptive keeper scheduling based on load";
-}
-
-(* 2. Config module에서 참조 *)
-let get_adaptive_scheduling () =
-  Env_config_core.get_bool "MASC_KEEPER_ADAPTIVE_SCHEDULING" false
-  (* ⚠️ default must match registry entry! *)
-```
-
-### ❌ DON'T
-
-```ocaml
-(* ❌ Registry 없이 직접 get_bool 사용 *)
-let get_my_feature () =
-  Env_config_core.get_bool "MASC_MY_FEATURE" true  (* 어디에도 문서화 안 됨 *)
-
-(* ❌ Registry와 다른 default 사용 *)
-(* Registry: default = false, Config: default = true ← inconsistent! *)
-
-(* ❌ Concurrent merge 후 duplicate 방치 *)
-(* same env_name을 여러 곳에 등록 ← CI가 잡아야 함 *)
-```
-
-### 병합 전 Checklist
-
-PR author:
-- [ ] registry 변경이 있는가?
-- [ ] env_name이 기존 registry와 중복되지 않는가?
-- [ ] config module의 default가 registry entry와 일치하는가?
-- [ ] lifecycle 상태가 올바른가? (Experimental for new flags)
-- [ ] since version이 정확한가?
-
-Reviewer:
-- [ ] registry entry가 명확하고 이해 가능한가?
-- [ ] category가 올바른가?
-- [ ] 같은 feature에 대한 기존 flag가 있는가? (rename인가 new인가)
-- [ ] CI lint가 통과했는가?
-
----
-
-## References
-
-- PR #3793: fix(config): remove duplicate WORK_AS_HEARTBEAT entries
-- `lib/config/feature_flag_registry.ml` - Registry SSOT
-- `lib/config/env_config_core.ml` - Base config getters
-- `scripts/check-feature-flag-consistency.sh` - CI consistency check
-- `docs/COMMON-PITFALLS.md` Section 8: Feature Flag Lifecycle Management
-
----
-
-## Changelog
-
-| Date | Change | Author |
-|------|--------|--------|
-| 2026-03-30 | Initial ADR, duplicate WORK_AS_HEARTBEAT 분석 반영 | Agent-Code |
+The registry tests enforce unique environment names, known categories, current
+lifecycle serialization, lookup behavior, and category partitioning.

--- a/docs/COMMON-PITFALLS.md
+++ b/docs/COMMON-PITFALLS.md
@@ -172,11 +172,10 @@ Keeper system prompts are cached in checkpoints. After changing prompts:
 
 ## 8. Feature Flag Registry Duplicates (ADR-003)
 
-Feature flags는 `lib/config/feature_flag_registry.ml`에 중앙 등록되어야 한다. 최근 발견된 문제:
+Feature flags는 `lib/config/feature_flag_registry.ml`에 중앙 등록되어야 한다.
 
 **Common Pattern: Concurrent Merge로 인한 중복 등록**
 ```bash
-# PR #3793: MASC_KEEPER_WORK_AS_HEARTBEAT가 3번 등록됨 (lines 95, 130, 140)
 # 두 feature branch가 독립적으로 같은 플래그를 추가 → merge conflict 없이 통과
 ```
 
@@ -203,7 +202,6 @@ rg "get_bool.*MASC_YOUR_FLAG" lib/config/
 - [ ] env_name이 unique한가?
 - [ ] config module의 default가 registry와 일치하는가?
 - [ ] lifecycle 상태가 올바른가?
-- [ ] since version이 정확한가?
 
 상세: `docs/ADR-003-FEATURE-FLAG-REGISTRY-MANAGEMENT.md`
 

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -90,13 +90,12 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_WIRE_CAPTURE_RETENTION_DAYS` | typed:int | Policies | operator | 94 | Maximum age for [<masc_root>/wire-capture] day files retained by the diagnostic MASC->OAS wire-capture harness. Defau... |
 | `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 419 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
 
-## Env_config_keeper_supervisor (3 knobs; typed classification 2/2)
+## Env_config_keeper_supervisor (2 knobs; typed classification 2/2)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_KEEPER_DEAD_TTL_SEC` | typed:float | Timeouts | operator | 21 | Dead tombstone TTL: seconds before Dead entries are cleaned up. @category Timeouts @ops_class operator |
-| `MASC_KEEPER_DOMAIN_POOL_ENABLED` | feature_flag | n/a | n/a | 12 | Historical keeper Domain_pool pilot flag. The supervisor still reads this for observability, but keepalive fibers rem... |
-| `MASC_KEEPER_SUPERVISOR_SWEEP_SEC` | typed:float | Timeouts | operator | 17 | Interval between supervisor sweep runs (seconds). @category Timeouts @ops_class operator |
+| `MASC_KEEPER_DEAD_TTL_SEC` | typed:float | Timeouts | operator | 11 | Dead tombstone TTL: seconds before Dead entries are cleaned up. @category Timeouts @ops_class operator |
+| `MASC_KEEPER_SUPERVISOR_SWEEP_SEC` | typed:float | Timeouts | operator | 7 | Interval between supervisor sweep runs (seconds). @category Timeouts @ops_class operator |
 
 ## Env_config_runtime (70 knobs; typed classification 4/55)
 

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -35,7 +35,6 @@ end
 (** {1 Keeper supervisor} *)
 
 module KeeperSupervisor : sig
-  val domain_pool_enabled : bool
   val sweep_interval_sec : float
   val dead_ttl_sec : float
 end

--- a/lib/config/env_config_keeper_supervisor.ml
+++ b/lib/config/env_config_keeper_supervisor.ml
@@ -2,16 +2,6 @@
 
 open Env_config_core
 
-(** Historical keeper Domain_pool pilot flag.
-
-    The supervisor still reads this for observability, but keepalive
-    fibers remain on the owning Eio domain. The keepalive body touches
-    Eio switches, clocks, turn timeouts, and provider streams; routing
-    the whole body through [Domain_pool.submit_io] is not domain-safe. *)
-let domain_pool_enabled =
-  Feature_flag_registry.get_bool "MASC_KEEPER_DOMAIN_POOL_ENABLED"
-;;
-
 (** Interval between supervisor sweep runs (seconds).
     @category Timeouts @ops_class operator *)
 let sweep_interval_sec = get_float ~default:30.0 "MASC_KEEPER_SUPERVISOR_SWEEP_SEC"

--- a/lib/config/env_config_keeper_supervisor.mli
+++ b/lib/config/env_config_keeper_supervisor.mli
@@ -1,5 +1,4 @@
 (** Keeper supervisor runtime configuration. *)
 
-val domain_pool_enabled : bool
 val sweep_interval_sec : float
 val dead_ttl_sec : float

--- a/lib/config/env_config_sandbox.ml
+++ b/lib/config/env_config_sandbox.ml
@@ -76,7 +76,7 @@ module Runtime = struct
       "MASC_KEEPER_SANDBOX_DOCKER_IMAGE"
 
   let docker_playground_enabled () =
-    get_bool ~default:false "MASC_KEEPER_DOCKER_PLAYGROUND"
+    Feature_flag_registry.get_bool "MASC_KEEPER_DOCKER_PLAYGROUND"
 
   (** @category Sandbox
       @ops_class operator *)

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -6,10 +6,9 @@
 
     1. Runtime enumeration: operators can query all flags and their values
     2. Consistency verification: CI lint compares registry defaults against actual get_bool calls
-    3. Lifecycle tracking for supported public flags
+    3. Current lifecycle classification for supported public flags
     4. Documentation: machine-readable flag catalog
 
-    @since 2.162.0
     @see <docs/design/inventory-gap-analysis-rfc.md> H5 Feature Flags *)
 
 open Env_config_core
@@ -19,7 +18,6 @@ open Env_config_core
     registry entry, and operator documentation in one change. *)
 type lifecycle =
   | Active
-  | Deprecated of string  (** reason for deprecation *)
   | Experimental          (** not yet stable, may change without notice *)
 
 type flag = {
@@ -28,7 +26,6 @@ type flag = {
   default : bool;            (** Canonical default value *)
   category : string;         (** Grouping: transport, keeper, dashboard, tool, inference, runtime *)
   lifecycle : lifecycle;     (** Current state in the lifecycle *)
-  since : string;            (** Version when flag was introduced *)
 }
 
 (** The canonical registry. Alphabetically ordered within each category.
@@ -40,27 +37,27 @@ let all_flags : flag list = [
   { env_name = "MASC_GRPC_ENABLED";
     description = "gRPC transport server";
     default = true; category = "transport";
-    lifecycle = Active; since = "2.0.0" };
+    lifecycle = Active };
 
   { env_name = "MASC_WS_ENABLED";
     description = "WebSocket transport server";
     default = true; category = "transport";
-    lifecycle = Active; since = "2.0.0" };
+    lifecycle = Active };
 
   { env_name = "MASC_WEBRTC_ENABLED";
     description = "WebRTC DataChannel transport (opt-out via =0)";
     default = true; category = "transport";
-    lifecycle = Active; since = "2.120.0" };
+    lifecycle = Active };
 
   { env_name = "MASC_HTTP_AUTH_STRICT";
     description = "Require auth for all HTTP endpoints (not just /mcp)";
     default = false; category = "transport";
-    lifecycle = Active; since = "2.140.0" };
+    lifecycle = Active };
 
   { env_name = Env_config_core.telemetry_enabled_env_key;
     description = "Telemetry/span collection";
     default = true; category = "transport";
-    lifecycle = Active; since = "2.50.0" };
+    lifecycle = Active };
 
   (* ── Tool Surface ─────────────────────────────────────────── *)
   (* RFC-0084 host-config-cleanup-J — MASC_DISPATCH_V2 entry removed.
@@ -69,18 +66,13 @@ let all_flags : flag list = [
   { env_name = Env_config_core.parse_warn_env_key;
     description = "Escalate malformed env parses to Config_error";
     default = false; category = "tool";
-    lifecycle = Active; since = "2.60.0" };
+    lifecycle = Active };
 
   (* ── Keeper ───────────────────────────────────────────────── *)
-  { env_name = "MASC_KEEPER_DOMAIN_POOL_ENABLED";
-    description = "Historical keeper DomainPool pilot flag. Supervisor keepalive fibers now stay on the owning Eio domain because they use switches, clocks, and provider streams.";
-    default = false; category = "keeper";
-    lifecycle = Experimental; since = "2.170.0" };
-
   { env_name = "MASC_KEEPER_BOOTSTRAP_ENABLED";
     description = "Startup keeper auto-bootstrap scan";
     default = true; category = "keeper";
-    lifecycle = Active; since = "2.130.0" };
+    lifecycle = Active };
 
   (* RFC-0297 P0-1: global lifecycle kill-switches. Before these existed,
      [reactive]/[proactive]/[autonomous] enabled in runtime.toml were
@@ -90,59 +82,59 @@ let all_flags : flag list = [
   { env_name = "MASC_KEEPER_REACTIVE_ENABLED";
     description = "Global kill-switch for keeper reactive turns (mention/board/scope/event-queue triggers)";
     default = true; category = "keeper";
-    lifecycle = Active; since = "2.253.0" };
+    lifecycle = Active };
 
   { env_name = "MASC_KEEPER_PROACTIVE_ENABLED";
     description = "Global kill-switch for keeper proactive (scheduled) turns";
     default = true; category = "keeper";
-    lifecycle = Active; since = "2.253.0" };
+    lifecycle = Active };
 
   { env_name = "MASC_KEEPER_AUTONOMOUS_ENABLED";
     description = "Global kill-switch for keeper autonomous keepalive/PR fan-out";
     default = true; category = "keeper";
-    lifecycle = Active; since = "2.253.0" };
+    lifecycle = Active };
 
   { env_name = "MASC_KEEPER_WORK_AS_HEARTBEAT";
     description = "Count successful workspace heartbeat after a turn as presence proof";
     default = true; category = "keeper";
-    lifecycle = Active; since = "2.162.0" };
+    lifecycle = Active };
 
   { env_name = "MASC_KEEPER_WIRE_CAPTURE";
     description = "Default-off diagnostic MASC-to-OAS request/response wire capture";
     default = false; category = "keeper";
-    lifecycle = Experimental; since = "2.254.0" };
+    lifecycle = Experimental };
 
   { env_name = "MASC_KEEPER_DEBUG";
     description = "Keeper debug logging";
     default = false; category = "keeper";
-    lifecycle = Active; since = "2.50.0" };
+    lifecycle = Active };
 
   { env_name = "MASC_KEEPER_DOCKER_PLAYGROUND";
     description = "Route Execute commands through Docker container";
     default = false; category = "keeper";
-    lifecycle = Active; since = "2.233.0" };
+    lifecycle = Active };
 
   (* ── Dashboard ────────────────────────────────────────────── *)
   { env_name = "MASC_DASHBOARD_FIXTURES_ENABLED";
     description = "Load dashboard fixture data for testing";
     default = false; category = "dashboard";
-    lifecycle = Active; since = "2.140.0" };
+    lifecycle = Active };
 
   { env_name = "MASC_OPERATOR_CACHE_BACKGROUND_REVALIDATE";
     description = "Serve stale operator snapshots while recomputing in the background";
     default = true; category = "dashboard";
-    lifecycle = Active; since = "2.150.0" };
+    lifecycle = Active };
 
   (* ── Runtime ──────────────────────────────────────────────── *)
   { env_name = Env_config_core.orchestrator_enabled_env_key;
     description = "Enable the orchestrator task-availability check loop";
     default = false; category = "runtime";
-    lifecycle = Active; since = "2.0.0" };
+    lifecycle = Active };
 
   { env_name = "MASC_LOCAL_RUNTIME_DEBUG";
     description = "Local LLM runtime debug output";
     default = false; category = "runtime";
-    lifecycle = Active; since = "2.200.0" };
+    lifecycle = Active };
 
   (* ── Contract verification ───────────────────────────────── *)
 ]
@@ -165,12 +157,12 @@ let get_bool env_name =
   match find_opt env_name with
   | Some flag -> runtime_value flag
   | None ->
-      Log.Misc.warn "feature flag %s not found in registry" env_name;
-      Env_config_core.get_bool ~default:false env_name
+      raise
+        (Config_error
+           (Printf.sprintf "feature flag %s is not registered" env_name))
 
 let lifecycle_to_string = function
   | Active -> "active"
-  | Deprecated reason -> "deprecated: " ^ reason
   | Experimental -> "experimental"
 
 (** Serialize a single flag to JSON with its runtime value. *)
@@ -183,7 +175,6 @@ let flag_to_json flag =
     ("source", `String (runtime_source flag));
     ("category", `String flag.category);
     ("lifecycle", `String (lifecycle_to_string flag.lifecycle));
-    ("since", `String flag.since);
   ]
 
 (** Serialize all flags grouped by category. *)
@@ -200,7 +191,3 @@ let to_json () =
 (** Flags where runtime value differs from canonical default. *)
 let overridden_flags () =
   List.filter (fun f -> runtime_value f <> f.default) all_flags
-
-(** Flags in deprecated lifecycle state. *)
-let deprecated_flags () =
-  List.filter (fun f -> match f.lifecycle with Deprecated _ -> true | Active | Experimental -> false) all_flags

--- a/lib/config/feature_flag_registry.mli
+++ b/lib/config/feature_flag_registry.mli
@@ -7,10 +7,9 @@
 
     + Runtime enumeration for operators
     + Consistency verification (CI lint: [check-feature-flag-consistency.sh])
-    + Lifecycle tracking: Active → Deprecated → (removed from registry)
+    + Current lifecycle classification: Active or Experimental
     + Machine-readable flag catalog
 
-    @since 2.162.0
     @see <docs/design/inventory-gap-analysis-rfc.md> H5 Feature Flags *)
 
 (** {1 Types} *)
@@ -18,7 +17,6 @@
 (** Flag lifecycle state machine. *)
 type lifecycle =
   | Active
-  | Deprecated of string  (** reason for deprecation *)
   | Experimental          (** not yet stable, may change without notice *)
 
 type flag = {
@@ -27,7 +25,6 @@ type flag = {
   default : bool;
   category : string;      (** Grouping: transport/tool/keeper/dashboard/inference/runtime *)
   lifecycle : lifecycle;
-  since : string;
 }
 
 (** {1 Registry} *)
@@ -49,9 +46,9 @@ val runtime_value : flag -> bool
     ["default"]. *)
 val runtime_source : flag -> string
 
-(** [get_bool env_name] = registry-aware lookup. Falls back to
-    [Env_config_core.get_bool ~default:false] and logs a warning if
-    [env_name] is not registered. *)
+(** [get_bool env_name] reads the registered flag using its canonical
+    default. Raises {!Env_config_core.Config_error} when [env_name] is not
+    registered. *)
 val get_bool : string -> bool
 
 (** {1 Serialisation} *)
@@ -59,7 +56,7 @@ val get_bool : string -> bool
 val lifecycle_to_string : lifecycle -> string
 
 (** JSON shape: [{env_name, description, canonical_default, runtime_value,
-    source, category, lifecycle, since}]. *)
+    source, category, lifecycle}]. *)
 val flag_to_json : flag -> Yojson.Safe.t
 
 (** All flags grouped by category:
@@ -70,6 +67,3 @@ val to_json : unit -> Yojson.Safe.t
 
 (** Flags whose runtime value differs from the canonical default. *)
 val overridden_flags : unit -> flag list
-
-(** Flags currently in [Deprecated _] lifecycle state. *)
-val deprecated_flags : unit -> flag list

--- a/lib/dashboard/dashboard_feature_health.ml
+++ b/lib/dashboard/dashboard_feature_health.ml
@@ -7,7 +7,6 @@ type feature_status =
   | Healthy
   | Warning
   | Inactive
-  | Deprecated
 
 type feature_health_item = {
   env_name : string;
@@ -17,19 +16,16 @@ type feature_health_item = {
   is_enabled : bool;
   source : string;  (* "env" or "default" *)
   status : feature_status;
-  since : string;
 }
 
 let status_to_string = function
   | Healthy -> "healthy"
   | Warning -> "warning"
   | Inactive -> "inactive"
-  | Deprecated -> "deprecated"
 
 let lifecycle_to_status = function
   | Feature_flag_registry.Active -> Healthy
   | Feature_flag_registry.Experimental -> Warning
-  | Feature_flag_registry.Deprecated _ -> Deprecated
 
 let feature_to_health_item (flag : Feature_flag_registry.flag) : feature_health_item =
   let is_enabled = Feature_flag_registry.runtime_value flag in
@@ -37,7 +33,6 @@ let feature_to_health_item (flag : Feature_flag_registry.flag) : feature_health_
   let lifecycle_str = Feature_flag_registry.lifecycle_to_string flag.lifecycle in
   let status =
     match flag.lifecycle with
-    | Feature_flag_registry.Deprecated _ -> Deprecated
     | Feature_flag_registry.Experimental -> Warning
     | Feature_flag_registry.Active ->
         if is_enabled then Healthy else Inactive
@@ -50,7 +45,6 @@ let feature_to_health_item (flag : Feature_flag_registry.flag) : feature_health_
     is_enabled;
     source;
     status;
-    since = flag.since;
   }
 
 let get_all_features () : feature_health_item list =
@@ -78,7 +72,6 @@ let feature_health_item_to_json (item : feature_health_item) : Yojson.Safe.t =
     ("is_enabled", `Bool item.is_enabled);
     ("source", `String item.source);
     ("status", `String (status_to_string item.status));
-    ("since", `String item.since);
   ]
 
 let overview_json (features : feature_health_item list) : Yojson.Safe.t =
@@ -86,7 +79,6 @@ let overview_json (features : feature_health_item list) : Yojson.Safe.t =
   let healthy_count = count_by_status features Healthy in
   let warning_count = count_by_status features Warning in
   let inactive_count = count_by_status features Inactive in
-  let deprecated_count = count_by_status features Deprecated in
   let enabled_count = List.filter (fun f -> f.is_enabled) features |> List.length in
   let overridden_count = List.filter (fun f -> f.source = "env") features |> List.length in
   `Assoc [
@@ -94,7 +86,6 @@ let overview_json (features : feature_health_item list) : Yojson.Safe.t =
     ("healthy_count", `Int healthy_count);
     ("warning_count", `Int warning_count);
     ("inactive_count", `Int inactive_count);
-    ("deprecated_count", `Int deprecated_count);
     ("enabled_count", `Int enabled_count);
     ("overridden_count", `Int overridden_count);
   ]

--- a/lib/dashboard/dashboard_feature_health.mli
+++ b/lib/dashboard/dashboard_feature_health.mli
@@ -3,8 +3,7 @@
 
     Aggregates status, enablement source, and lifecycle buckets for
     every flag in {!Feature_flag_registry.all_flags} to provide a
-    runtime view of which features are active, experimental, or
-    deprecated. *)
+    runtime view of which features are active or experimental. *)
 
 (** {1 Types} *)
 
@@ -12,7 +11,6 @@ type feature_status =
   | Healthy
   | Warning
   | Inactive
-  | Deprecated
 
 type feature_health_item = {
   env_name : string;
@@ -22,7 +20,6 @@ type feature_health_item = {
   is_enabled : bool;
   source : string;  (** ["env"] when overridden, else ["default"]. *)
   status : feature_status;
-  since : string;
 }
 
 (** {1 Enumeration} *)

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -59,7 +59,6 @@ let get_global_switch = Keeper_process_switch.get
 let set_restart_launch_noop_for_test = Keeper_supervisor_restart_noop.set
 let restart_launch_noop_enabled_for_test = Keeper_supervisor_restart_noop.enabled
 let with_restart_launch_noop_for_test = Keeper_supervisor_restart_noop.with_noop
-let domain_pool_ignored_warning_emitted = Atomic.make false
 
 let launch_supervised_fiber_body
       ~proactive_warmup_sec
@@ -82,39 +81,7 @@ let launch_supervised_fiber_body
       }
     in
     Keeper_registry_event_queue.enqueue ~base_path meta.name bootstrap_signal;
-    (* RFC-0059 PR-7-pilot originally routed the whole keepalive body through
-       a Domain_pool worker.  Live recovery proved that unsafe: the body is
-       an Eio fiber loop that uses the server switch, clock, turn timeouts, and
-       provider streaming.  Moving it to an Executor_pool domain can touch an
-       Eio switch from the wrong domain and tear down keepers at boot.  Keep
-       the flag observable, but run the supervisor fiber on the owning Eio
-       domain.  Only pure/blocking sub-work should use [Domain_pool]. *)
-    let domain_pool_flag = Env_config.KeeperSupervisor.domain_pool_enabled in
-    let bump_fork_outcome outcome =
-      (* Label order mirrors the other [keeper_supervisor.ml] inc_counter
-         call sites ([keeper] first, then the discriminator).  Otel_metric_store
-         label-set keys are order-sensitive, so a single per-metric
-         convention prevents accidental time-series splitting when new
-         call sites add the same labels in a different order. *)
-      Otel_metric_store.inc_counter
-        Keeper_metrics.(to_string DomainPoolFork)
-        ~labels:[ "keeper", meta.name; "outcome", outcome ]
-        ()
-    in
     let fork_body body =
-      bump_fork_outcome
-        (if domain_pool_flag then "inline_eio_context" else "inline_disabled");
-      if
-        domain_pool_flag
-        && Atomic.compare_and_set
-             domain_pool_ignored_warning_emitted
-             false
-             true
-      then
-        Log.Keeper.warn
-          "keeper supervise domain pool ignored: keepalive body requires the owning \
-           Eio domain (first_keeper=%s)"
-          meta.name;
       match
         Keeper_lane.fork
           ~sw:ctx.sw

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -34,7 +34,6 @@ type t =
   | TurnQueueDepth
   | SupervisorSweepStarts
   | SupervisorLastSweepUnixtime
-  | DomainPoolFork
   | TurnHolderBookkeepingFailures
   | Compactions
   | CompactionRatioChange
@@ -238,7 +237,6 @@ let to_string = function
   | TurnQueueDepth -> "masc_keeper_turn_queue_depth"
   | SupervisorSweepStarts -> "masc_keeper_supervisor_sweep_starts_total"
   | SupervisorLastSweepUnixtime -> "masc_keeper_supervisor_last_sweep_unixtime"
-  | DomainPoolFork -> "masc_keeper_domain_pool_fork_total"
   | TurnHolderBookkeepingFailures -> "masc_keeper_turn_holders_bookkeeping_failures_total"
   | Compactions -> "masc_keeper_compactions_total"
   | CompactionRatioChange -> "masc_keeper_compaction_ratio_change"

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -25,7 +25,6 @@ type t =
   | TurnQueueDepth
   | SupervisorSweepStarts
   | SupervisorLastSweepUnixtime
-  | DomainPoolFork
   | TurnHolderBookkeepingFailures
   | Compactions
   | CompactionRatioChange

--- a/scripts/check-feature-flag-consistency.sh
+++ b/scripts/check-feature-flag-consistency.sh
@@ -1,116 +1,70 @@
 #!/usr/bin/env bash
-# check-feature-flag-consistency.sh — CI lint for MASC feature flags.
-#
-# Detects:
-#   1. Duplicate get_bool calls for the same MASC_* env var with different defaults
-#   2. Boolean flags in env_config modules not registered in Feature_flag_registry
-#
-# Exit codes:
-#   0 = clean
-#   1 = inconsistency found
-#
-# @since v2.162.0
-# @see docs/design/inventory-gap-analysis-rfc.md H5
+# check-feature-flag-consistency.sh — registry/consumer consistency lint.
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-CONFIG_DIR="$REPO_ROOT/lib/config"
-REGISTRY="$CONFIG_DIR/feature_flag_registry.ml"
+LIB_DIR="$REPO_ROOT/lib"
+REGISTRY="$LIB_DIR/config/feature_flag_registry.ml"
 ERRORS=0
 
 echo "=== Feature Flag Consistency Check ==="
 
-# ── Step 1: Find all get_bool calls with MASC_* env vars ──────────────
-# Extract: default_value env_var_name file:line
-CALLS=\"\"
-
-# ── Step 2: Check for duplicate env vars with different defaults ──────
-echo ""
-echo "--- Checking for default value conflicts ---"
-# Get unique env var names
-ENV_VARS=$(echo "$CALLS" | awk '{print $2}' | sort -u)
-
-for var in $ENV_VARS; do
-  DEFAULTS=$(echo "$CALLS" | grep " $var$" | awk '{print $1}' | sort -u)
-  NUM_DEFAULTS=$(echo "$DEFAULTS" | wc -l | tr -d ' ')
-  if [ "$NUM_DEFAULTS" -gt 1 ]; then
-    echo "CONFLICT: $var has multiple defaults: $(echo "$DEFAULTS" | tr '\n' ' ')"
-    # Show where
-    grep -rn "get_bool.*\"$var\"" "$CONFIG_DIR" | grep -v feature_flag_registry.ml
-    ERRORS=$((ERRORS + 1))
-  fi
-done
-
-if [ "$ERRORS" -eq 0 ]; then
-  echo "OK: No default value conflicts found."
-fi
-
-# ── Step 3: Check registry coverage ──────────────────────────────────
-echo ""
-echo "--- Checking registry coverage ---"
-
 if [ ! -f "$REGISTRY" ]; then
-  echo "WARNING: Feature_flag_registry not found at $REGISTRY"
-  exit 0
+  echo "ERROR: Feature_flag_registry not found at $REGISTRY"
+  exit 1
 fi
 
-# Extract registered env var names from registry
-REGISTERED=$(grep -o '"MASC_[A-Z_]*"' "$REGISTRY" \
-  | grep -v 'get_bool' \
-  | tr -d '"' \
-  | sort -u)
+REGISTERED=$(sed -n \
+  's/.*env_name = "\(MASC_[A-Z_]*\)".*/\1/p' \
+  "$REGISTRY" | sort -u)
 
-# Extract boolean env vars from config modules (excluding registry itself).
-# grep exits 1 when a pattern has zero matches; that is a valid "none here"
-# result (e.g. env_config_core.ml legitimately has no boolean MASC_* flag once
-# the last one is retired). The trailing `|| true` keeps that empty case from
-# crashing the check under `set -e`/`pipefail`. Real errors are not silenced:
-# missing files surface via grep's stderr and the explicit REGISTRY -f guard.
-CONFIG_BOOLS=$( ( \
-    { grep -rh "Feature_flag_registry.get_bool \"MASC_" "$CONFIG_DIR" || true; } | grep -o "\"MASC_[A-Z_]*\"" | tr -d "\"" ; \
-    { grep -rh "get_bool ~default:\(true\|false\) \"MASC_" "$CONFIG_DIR/env_config_core.ml" || true; } | grep -o "\"MASC_[A-Z_]*\"" | tr -d "\"" \
-  ) | sort -u || true)
+# Registry-backed reads exist in config modules and in runtime gates. Scan the
+# complete library so a live non-config consumer cannot be misreported stale.
+CONSUMED=$(
+  { grep -rh 'Feature_flag_registry.get_bool "MASC_' "$LIB_DIR" || true; } \
+    | grep -o '"MASC_[A-Z_]*"' \
+    | tr -d '"' \
+    | sort -u \
+    || true
+)
 
+echo ""
+echo "--- Checking consumer coverage ---"
 MISSING=0
-for var in $CONFIG_BOOLS; do
+for var in $CONSUMED; do
   if ! echo "$REGISTERED" | grep -q "^${var}$"; then
-    echo "UNREGISTERED: $var (in config modules but not in Feature_flag_registry)"
+    echo "UNREGISTERED: $var"
     MISSING=$((MISSING + 1))
   fi
 done
 
 if [ "$MISSING" -eq 0 ]; then
-  echo "OK: All boolean flags are registered."
+  echo "OK: All literal registry consumers are registered."
 else
-  echo ""
-  echo "WARNING: $MISSING unregistered flag(s). Add them to Feature_flag_registry.all_flags."
   ERRORS=$((ERRORS + MISSING))
 fi
 
-# ── Step 4: Check for registry entries not in config ──────────────────
 echo ""
-echo "--- Checking for stale registry entries ---"
+echo "--- Checking for stale literal registry entries ---"
 STALE=0
 for var in $REGISTERED; do
-  if ! echo "$CONFIG_BOOLS" | grep -q "^${var}$"; then
-    echo "STALE: $var (in registry but not found in config modules)"
+  if ! echo "$CONSUMED" | grep -q "^${var}$"; then
+    echo "STALE: $var"
     STALE=$((STALE + 1))
   fi
 done
 
 if [ "$STALE" -eq 0 ]; then
-  echo "OK: No stale registry entries."
+  echo "OK: Every literal registry entry has a runtime consumer."
 else
-  echo ""
-  echo "WARNING: $STALE stale registry entry(ies)."
+  ERRORS=$((ERRORS + STALE))
 fi
 
-# ── Summary ───────────────────────────────────────────────────────────
 echo ""
-TOTAL_CONFIG=$(echo "$CONFIG_BOOLS" | wc -l | tr -d ' ')
-TOTAL_REGISTERED=$(echo "$REGISTERED" | wc -l | tr -d ' ')
-echo "Summary: $TOTAL_CONFIG config flags, $TOTAL_REGISTERED registered, $ERRORS error(s), $STALE stale"
+TOTAL_CONSUMED=$(echo "$CONSUMED" | sed '/^$/d' | wc -l | tr -d ' ')
+TOTAL_REGISTERED=$(echo "$REGISTERED" | sed '/^$/d' | wc -l | tr -d ' ')
+echo "Summary: $TOTAL_CONSUMED literal consumers, $TOTAL_REGISTERED registry entries, $ERRORS error(s)"
 
 if [ "$ERRORS" -gt 0 ]; then
   echo "FAIL: Feature flag consistency check failed."
@@ -118,4 +72,3 @@ if [ "$ERRORS" -gt 0 ]; then
 fi
 
 echo "PASS: Feature flag consistency check passed."
-exit 0

--- a/test/test_dashboard_feature_health.ml
+++ b/test/test_dashboard_feature_health.ml
@@ -1,9 +1,4 @@
-(** Pure-function unit tests for [Dashboard_feature_health].
-
-    Audit P2 follow-up (2026-04-29 §3.1.2) — listed as
-    "테스트 완전 부재" with the recommendation
-    "basic smoke test".  Closes that gap with property pins
-    instead of a smoke test (richer regression coverage). *)
+(** Pure-function unit tests for [Dashboard_feature_health]. *)
 
 module H = Dashboard_feature_health
 module R = Feature_flag_registry
@@ -33,16 +28,13 @@ let test_status_to_string_warning () =
 let test_status_to_string_inactive () =
   assert (H.status_to_string H.Inactive = "inactive")
 
-let test_status_to_string_deprecated () =
-  assert (H.status_to_string H.Deprecated = "deprecated")
-
 let test_status_to_string_distinct () =
   let labels =
-    [ H.Healthy; H.Warning; H.Inactive; H.Deprecated ]
+    [ H.Healthy; H.Warning; H.Inactive ]
     |> List.map H.status_to_string
   in
   let unique = List.sort_uniq compare labels in
-  assert (List.length unique = 4)
+  assert (List.length unique = 3)
 
 (* ─── (2) lifecycle_to_status mapping ──────────────────────────── *)
 
@@ -51,17 +43,6 @@ let test_lifecycle_active_maps_to_healthy () =
 
 let test_lifecycle_experimental_maps_to_warning () =
   assert (H.lifecycle_to_status R.Experimental = H.Warning)
-
-let test_lifecycle_deprecated_maps_to_deprecated () =
-  assert (
-    H.lifecycle_to_status (R.Deprecated "any reason")
-    = H.Deprecated)
-
-let test_lifecycle_deprecated_empty_reason_still_maps () =
-  (* Edge: an empty deprecation reason still produces Deprecated
-     status (the reason string is irrelevant for the status
-     classification). *)
-  assert (H.lifecycle_to_status (R.Deprecated "") = H.Deprecated)
 
 (* ─── (3) feature_to_health_item: status derivation ──────────── *)
 
@@ -72,7 +53,6 @@ let dummy_flag ~env_name ~lifecycle ~default =
     default;
     category = "runtime";
     lifecycle;
-    since = "0.0.0";
   }
 
 let test_active_enabled_is_healthy () =
@@ -103,25 +83,15 @@ let test_experimental_is_warning_regardless_of_enabled () =
   let item = H.feature_to_health_item f in
   assert (item.status = H.Warning)
 
-let test_deprecated_is_deprecated_regardless_of_enabled () =
-  let env = "MASC_TEST_HEALTH_DEPRECATED_XYZ123" in
-  with_env_unset env @@ fun () ->
-  let f =
-    dummy_flag ~env_name:env
-      ~lifecycle:(R.Deprecated "use MASC_X instead") ~default:true
-  in
-  let item = H.feature_to_health_item f in
-  assert (item.status = H.Deprecated)
-
 let test_lifecycle_field_serialised () =
   let env = "MASC_TEST_HEALTH_LIFECYCLE_FIELD_XYZ123" in
   with_env_unset env @@ fun () ->
   let f =
     dummy_flag ~env_name:env
-      ~lifecycle:(R.Deprecated "old API") ~default:false
+      ~lifecycle:R.Experimental ~default:false
   in
   let item = H.feature_to_health_item f in
-  assert (item.lifecycle = "deprecated: old API")
+  assert (item.lifecycle = "experimental")
 
 (* ─── (4) get_feature_categories: distinct + sorted ─────────── *)
 
@@ -153,28 +123,24 @@ let test_categories_subset_of_documented () =
 (* ─── (5) count_by_status partition ────────────────────────────── *)
 
 let test_count_by_status_partition () =
-  (* The 4 status buckets together must account for every
+  (* The current status buckets together must account for every
      feature.  Pin that
-       count Healthy + count Warning + count Inactive
-       + count Deprecated = total. *)
+       count Healthy + count Warning + count Inactive = total. *)
   let features = H.get_all_features () in
   let total = List.length features in
   let h = H.count_by_status features H.Healthy in
   let w = H.count_by_status features H.Warning in
   let i = H.count_by_status features H.Inactive in
-  let d = H.count_by_status features H.Deprecated in
-  assert (h + w + i + d = total)
+  assert (h + w + i = total)
 
 let test_count_by_status_nonneg () =
   let features = H.get_all_features () in
   let h = H.count_by_status features H.Healthy in
   let w = H.count_by_status features H.Warning in
   let i = H.count_by_status features H.Inactive in
-  let d = H.count_by_status features H.Deprecated in
   assert (h >= 0);
   assert (w >= 0);
-  assert (i >= 0);
-  assert (d >= 0)
+  assert (i >= 0)
 
 (* ─── (6) JSON shape ──────────────────────────────────────────── *)
 
@@ -187,7 +153,7 @@ let test_feature_health_item_json_shape () =
   let j = H.feature_health_item_to_json item in
   let expected_keys =
     [ "env_name"; "description"; "category"; "lifecycle";
-      "is_enabled"; "source"; "status"; "since" ]
+      "is_enabled"; "source"; "status" ]
   in
   List.iter
     (fun k ->
@@ -213,16 +179,12 @@ let () =
   test_status_to_string_healthy ();
   test_status_to_string_warning ();
   test_status_to_string_inactive ();
-  test_status_to_string_deprecated ();
   test_status_to_string_distinct ();
   test_lifecycle_active_maps_to_healthy ();
   test_lifecycle_experimental_maps_to_warning ();
-  test_lifecycle_deprecated_maps_to_deprecated ();
-  test_lifecycle_deprecated_empty_reason_still_maps ();
   test_active_enabled_is_healthy ();
   test_active_disabled_is_inactive ();
   test_experimental_is_warning_regardless_of_enabled ();
-  test_deprecated_is_deprecated_regardless_of_enabled ();
   test_lifecycle_field_serialised ();
   test_categories_are_distinct ();
   test_categories_sorted ();

--- a/test/test_feature_flag_registry.ml
+++ b/test/test_feature_flag_registry.ml
@@ -1,23 +1,18 @@
 (** Pure-function unit tests for [Feature_flag_registry].
 
-    Audit P2 follow-up (2026-04-29 §3.1.2) — the registry was
-    listed as "테스트 완전 부재" with the recommendation
-    "exhaustive variant match test".  This suite pins:
+    This suite pins:
 
-    1. [lifecycle_to_string] covers all 3 variants
-       ([Active], [Deprecated _], [Experimental]) without
-       partial-match silent regression.
+    1. [lifecycle_to_string] covers the current variants
+       ([Active], [Experimental]) without partial-match regression.
     2. Registry invariants: non-empty, env-var name uniqueness,
-       no [Deprecated reason=""], every entry's category is one
-       of the documented six.
+       and every entry's category is one of the documented six.
     3. [find_opt] returns [Some] for registered flags and
        [None] for unknown names.
-    4. [flag_to_json] emits the documented 8-field shape.
+    4. [flag_to_json] emits the documented current field shape.
     5. [to_json] groups all flags into the 6 documented
        categories and the [total_flags] field equals
        [List.length all_flags].
-    6. [deprecated_flags] / [overridden_flags] partition
-       behaviour. *)
+    6. [overridden_flags] returns only actual overrides. *)
 
 module R = Feature_flag_registry
 
@@ -29,18 +24,6 @@ let test_lifecycle_active () =
 let test_lifecycle_experimental () =
   assert (R.lifecycle_to_string R.Experimental = "experimental")
 
-let test_lifecycle_deprecated_with_reason () =
-  let s =
-    R.lifecycle_to_string (R.Deprecated "replaced by MASC_X")
-  in
-  assert (s = "deprecated: replaced by MASC_X")
-
-let test_lifecycle_deprecated_empty_reason () =
-  (* Documents the trailing-space + empty reason behaviour.
-     Not a great UX but pinning current shape. *)
-  let s = R.lifecycle_to_string (R.Deprecated "") in
-  assert (s = "deprecated: ")
-
 (* ─── (2) registry invariants ─────────────────────────────────── *)
 
 let test_registry_nonempty () =
@@ -50,17 +33,6 @@ let test_env_names_unique () =
   let names = List.map (fun f -> f.R.env_name) R.all_flags in
   let unique = List.sort_uniq String.compare names in
   assert (List.length names = List.length unique)
-
-let test_no_blank_deprecation_reason () =
-  let bad =
-    List.filter
-      (fun f ->
-        match f.R.lifecycle with
-        | R.Deprecated "" -> true
-        | _ -> false)
-      R.all_flags
-  in
-  assert (List.length bad = 0)
 
 let test_every_env_name_has_masc_prefix () =
   List.iter
@@ -92,6 +64,11 @@ let test_find_opt_unknown () =
   | None -> ()
   | Some _ -> assert false
 
+let test_get_bool_unknown_rejected () =
+  match R.get_bool "MASC_THIS_FLAG_DOES_NOT_EXIST_XYZ123" with
+  | _ -> assert false
+  | exception Env_config_core.Config_error _ -> ()
+
 let test_find_opt_first_registered () =
   match R.all_flags with
   | [] -> assert false  (* covered by test_registry_nonempty *)
@@ -107,15 +84,14 @@ let test_path_jail_kill_switch_removed () =
 
 (* ─── (4) flag_to_json shape ──────────────────────────────────── *)
 
-let test_flag_to_json_eight_fields () =
+let test_flag_to_json_current_fields () =
   match R.all_flags with
   | [] -> assert false
   | first :: _ ->
       let j = R.flag_to_json first in
       let expected_keys =
         [ "env_name"; "description"; "canonical_default";
-          "runtime_value"; "source"; "category"; "lifecycle";
-          "since" ]
+          "runtime_value"; "source"; "category"; "lifecycle" ]
       in
       List.iter
         (fun k ->
@@ -176,16 +152,7 @@ let test_to_json_categories_partition_all_flags () =
   in
   assert (summed = List.length R.all_flags)
 
-(* ─── (6) deprecated_flags / overridden_flags ─────────────────── *)
-
-let test_deprecated_flags_only_deprecated () =
-  let dep = R.deprecated_flags () in
-  List.iter
-    (fun f ->
-      match f.R.lifecycle with
-      | R.Deprecated _ -> ()
-      | _ -> assert false)
-    dep
+(* ─── (6) overridden_flags ────────────────────────────────────── *)
 
 let test_overridden_flags_subset_of_all () =
   (* Without setting env vars, [overridden_flags] should be a
@@ -202,21 +169,18 @@ let test_overridden_flags_subset_of_all () =
 let () =
   test_lifecycle_active ();
   test_lifecycle_experimental ();
-  test_lifecycle_deprecated_with_reason ();
-  test_lifecycle_deprecated_empty_reason ();
   test_registry_nonempty ();
   test_env_names_unique ();
-  test_no_blank_deprecation_reason ();
   test_every_env_name_has_masc_prefix ();
   test_every_category_in_documented_set ();
   test_find_opt_unknown ();
+  test_get_bool_unknown_rejected ();
   test_find_opt_first_registered ();
   test_path_jail_kill_switch_removed ();
-  test_flag_to_json_eight_fields ();
+  test_flag_to_json_current_fields ();
   test_flag_to_json_canonical_default_is_bool ();
   test_to_json_total_matches_all_flags ();
   test_to_json_six_categories ();
   test_to_json_categories_partition_all_flags ();
-  test_deprecated_flags_only_deprecated ();
   test_overridden_flags_subset_of_all ();
   print_endline "test_feature_flag_registry: all assertions passed"


### PR DESCRIPTION
## Summary

- remove the unreachable Deprecated lifecycle, deprecated query, since history field, dashboard payload/UI branches, and synthetic legacy tests
- delete the no-op MASC_KEEPER_DOMAIN_POOL_ENABLED reader, warning branch, metric, and operator documentation while keeping the sole real Keeper_lane.fork path
- make unregistered registry reads fail with Config_error and route Docker playground through the registry SSOT
- replace the broken consistency check with literal registry-to-runtime consumer validation across the complete lib tree
- reduce the historical registry ADR to the current contract

## Verification

- ocamlformat on all changed OCaml files
- ocamlc parse checks on changed OCaml implementation/test files
- scripts/check-feature-flag-consistency.sh: 15 consumers, 15 registry entries, 0 errors
- shellcheck scripts/check-feature-flag-consistency.sh
- dashboard pnpm typecheck
- dashboard pnpm lint
- targeted feature-health Vitest: 3 passed
- git diff --check

## Local limitation

Focused Dune build was not started because scripts/dune-local.sh detected six unrelated bare Dune processes and correctly refused to bypass the shared lock. CI is the OCaml build authority for this PR.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`refactor/feature-flag-current-contract` → `main` · 1 commit(s) · synced 2026-08-05T03:12:41Z

| sha | subject | date |
|---|---|---|
| `c9603b837` | refactor: hard-cut legacy feature flag state | 2026-08-05 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->