### PR TITLE
docs(config): name the health cap raise removal target

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -496,7 +496,10 @@ module Dashboard = struct
       WORKAROUND: This is a cap raise (§4 anti-pattern signature) accepted
       as bridge until structural RFC lands (per-component health cache so
       make_health_json no longer fans 17 sync calls per refresh).
-      Removal target: per-component health cache RFC (TBD). *)
+      Removal target: issue #26875 — the replacement RFC does not exist yet,
+      so the issue is what carries the obligation. A cap raise whose removal
+      target is unnamed does not expire, and the next one cites it as
+      precedent. *)
   let full_health_refresh_timeout_sec =
     Float.max 1.0
       (get_float ~default:20.0 "MASC_FULL_HEALTH_REFRESH_TIMEOUT_SEC")


### PR DESCRIPTION
## 무엇을

`MASC_FULL_HEALTH_REFRESH_TIMEOUT_SEC` cap raise 의 `Removal target: ... (TBD)` 를 실제 추적 번호(#26875)로 교체한다. 주석 한 줄, 동작 변경 없음.

## 왜

CLAUDE.md "워크어라운드 거부 기준" 의 Override 3-요건 중 두 개가 비어 있었다.

| 요건 | 변경 전 | 변경 후 |
|---|---|---|
| `WORKAROUND: <production-blocking 사유>` | 있음 | 있음 |
| 대체 RFC 참조 | **TBD** | #26875 (RFC 부재를 이슈가 대신 짊어짐) |
| `removal target` | **TBD** | #26875 |

대체 RFC 도 이슈도 실재하지 않았다. 검색 결과:

- `docs/rfc/` health 관련 3 건(RFC-0050 component ownership, RFC-0117 KCR health parity, RFC-0260 provider health gate) — 셋 다 per-component health cache 가 아니다
- open issue 중 `health cache` 제목 0 건

`Removal target` 이 이름 없는 cap raise 는 만료되지 않고, 다음 cap raise 가 이것을 선례로 삼는다. CLAUDE.md 가 "AI 가 그 패턴을 합리적 선례로 학습해 누적시킨다" 고 지목하는 형태다. 이 PR 은 그 만료 조건에 번호를 붙일 뿐이고, cap 자체는 건드리지 않는다.

## 변경하지 않은 것

- 기본값 20s 그대로. bridge 가 목표 tail(<10%, <50/24h)을 달성했는지 측정하지 않았고, 측정 없이 원복하면 그 자체가 근거 없는 변경이다. 측정은 #26875 의 1 번 항목이다.
- `WORKAROUND:` 라벨 유지. 워크어라운드는 여전히 워크어라운드다.

## 검증

```
dune build --root . @check   exit 0
```

주석만 바뀌므로 테스트 변화 없음.

## 미검증

- 20s bridge 의 실제 효과(`masc_full_health_refresh_critical_total`, timeout 카운트)는 측정하지 않았다. #26875 에 남겼다
- 주석이 인용하는 "17 components", "27% tail at 16s (307/24h)" 는 재측정하지 않고 그대로 두었다

RFC-WAIVED: 주석 1 줄. 동작·계약·상태 변화 없음.

WORKAROUND-WAIVED: 이 PR 은 워크어라운드를 추가하지 않는다. 기존 워크어라운드에 만료 조건을 붙인다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
