### PR TITLE
fix(librarian): 자기제한은 카테고리가 아니라 하는 일로 판정한다

### DIFF
--- a/config/prompts/keeper.librarian.current_selection.md
+++ b/config/prompts/keeper.librarian.current_selection.md
@@ -17,7 +17,7 @@ Retention criteria:
 - Drop stale, superseded, transient, or derivable existing memories. Dropping is the deletion operation, and each drop states its reason in one sentence (what made this memory stop earning its place).
 - Never recreate a dropped existing fact as a new claim merely to reword it.
 - Record a rule the way its source states it. Do not store the inverse: "when X, do Y" does not license "only when X", and "Y is not yours to do" does not license "stay out of everything nearby". The inverse adds an exclusivity the source never wrote, and once stored it reads as authoritative in every later turn. If the source names when to act, keep it as that; if it names a boundary, keep the boundary at the width it was written.
-- Apply the category criteria below to existing memories too, not only to new claims. A stored memory that would not be written today does not earn retention by already being there. In particular, drop a stored `constraint` that no external rule enforces — one describing what the agent decided to stay out of, wait for, or not take on — with the reason that it was the agent's own scope decision rather than an enforced rule.
+- Apply the category criteria below to existing memories too, not only to new claims. A stored memory that would not be written today does not earn retention by already being there. In particular, drop a stored memory that no external rule enforces but that still narrows what the agent takes on — one describing what the agent decided to stay out of, wait for, or not take on — with the reason that it was the agent's own scope decision rather than an enforced rule. Read the claim, not its category: relabelling such a memory `preference` or `fact` does not earn it retention.
 
 New-claim criteria:
 - Add a claim only when it remains true and useful on a later day.
@@ -26,9 +26,18 @@ New-claim criteria:
 - Do not duplicate code, git history, PR state, the task board, or other authoritative sources. Store the non-obvious decision, reason, constraint, stable preference, external fact, validated approach, or reusable lesson instead.
 - If unsure, do not add it.
 
+A claim that narrows what this agent will take on is omitted under EVERY
+category, not only under `constraint`. Scope decisions, standing-by policies,
+"only act when mentioned", "do not claim unassigned work", polling cadence, and
+similar self-limits are this turn's operating judgment and expire with it;
+storing one turns a momentary decision into a permanent boundary no operator
+set. Judge this by what the claim does to future action, not by the category it
+arrives under — the same sentence relabelled `preference`, `lesson`, or `fact`
+is the same self-limit and is omitted the same way.
+
 Category criteria — choose the FIRST that fits:
 - code_change: a concrete, lasting change to code or configuration (a file/function was modified, a setting now has value X), described so it is verifiable later.
-- constraint: a rule enforced from outside this agent — an operator policy, a tool or API contract, a CI or review gate, a repository hook, a platform limit. It is a constraint because something other than the agent applies it, and a later keeper hitting the same wall would hit it too. An agent's own choice about what it will or will not take on is NOT a constraint: scope decisions, standing-by policies, "only act when mentioned", "do not claim unassigned work", polling cadence, and similar self-limits are this turn's operating judgment and expire with it. Storing one turns a momentary decision into a permanent boundary that no operator set. Omit it.
+- constraint: a rule enforced from outside this agent — an operator policy, a tool or API contract, a CI or review gate, a repository hook, a platform limit. It is a constraint because something other than the agent applies it, and a later keeper hitting the same wall would hit it too. An agent's own choice about what it will or will not take on is NOT a constraint.
 - blocker: a specific external obstacle that prevents progress and persists beyond this turn (a dependency is missing, an API is down, a credential is absent). Not the keeper merely having no task to do.
 - goal: a durable objective or target the agent is working toward, beyond the current turn.
 - preference: a stable, stated preference about how work should be done (style, tooling, process) that holds across turns.

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -439,9 +439,28 @@ let test_constraint_category_excludes_self_imposed_scope () =
     check bool "already being stored is not a reason to retain" true
       (String_util.contains_substring user_text
          "does not earn retention by already being there");
-    check bool "stored self-scope constraints are dropped" true
+    (* Scoping the omit rule to the constraint bullet left the category itself
+       as the escape hatch. Observed live 2026-08-05 within one hour: kidsnote's
+       store went from revision 129 carrying [constraint] "standing-by policy,
+       only intervening ... when directly mentioned" to revision 131 carrying
+       [preference] "Skip polling on non-scheduled wakes, acting only when the
+       trigger includes a concrete signal like a mention or task assignment" --
+       the same self-limit, relabelled, and retained because the retention rule
+       also named only [constraint]. Both rules are judged on what the claim
+       does to future action instead. *)
+    check bool "the omit rule spans every category" true
       (String_util.contains_substring user_text
-         "drop a stored `constraint` that no external rule enforces");
+         "omitted under EVERY\ncategory, not only under `constraint`");
+    check bool "relabelling does not launder a self-limit" true
+      (String_util.contains_substring user_text
+         "the same sentence relabelled `preference`, `lesson`, or `fact`");
+    check bool "retention reads the claim, not the category" true
+      (String_util.contains_substring user_text
+         "Read the claim, not its category");
+    check bool "stored self-scope memories are dropped" true
+      (String_util.contains_substring user_text
+         "drop a stored memory that no external rule enforces but that still \
+          narrows what the agent takes on");
     (* Measured 2026-08-05. kidsnote's operator instructions say "@kidsnote로
        요청받으면 같은 post_id에 구체적인 댓글을 남긴다" -- when to act. The
        stored memory reads "standing-by policy, only intervening in board posts


### PR DESCRIPTION
자기제한 memory 를 막는 규칙이 `constraint` 불릿 **안에** 있어서, 카테고리 자체가 우회 경로였다.

## 한 시간 안에 라이브에서 관찰됐다

kidsnote 의 store:

```
rev 129  [constraint]  standing-by policy, only intervening in board posts
                       or tasks when directly mentioned (@kidsnote)
rev 131  [preference]  Skip polling on non-scheduled wakes between hourly turns,
                       acting only when the trigger includes a concrete signal
                       like a mention or task assignment
```

**같은 자기제한이 재작성 + 재분류로 살아남았다.** 쓰기 규칙은 이미 `"only act when mentioned"` 와 `polling cadence` 를 omit 대상으로 이름까지 대고 있었지만 그 문장이 `constraint` 정의 안에만 있었고, 유지(retention) 규칙도 `drop a stored `constraint`` 라서 재분류된 행은 **쓰이고 나서 유지까지 됐다.**

## 변경

두 규칙 모두 카테고리가 아니라 **claim 이 미래 행동에 무엇을 하는지**로 판정하게 옮겼다.

```diff
+A claim that narrows what this agent will take on is omitted under EVERY
+category, not only under `constraint`. ... Judge this by what the claim does to
+future action, not by the category it arrives under — the same sentence
+relabelled `preference`, `lesson`, or `fact` is the same self-limit and is
+omitted the same way.
+
 Category criteria — choose the FIRST that fits:
-- constraint: ... An agent's own choice ... is NOT a constraint: scope decisions,
-  standing-by policies, "only act when mentioned", ... Omit it.
+- constraint: ... An agent's own choice about what it will or will not take on is
+  NOT a constraint.
```

```diff
-In particular, drop a stored `constraint` that no external rule enforces
+In particular, drop a stored memory that no external rule enforces but that
+still narrows what the agent takes on ... Read the claim, not its category:
+relabelling such a memory `preference` or `fact` does not earn it retention.
```

## 왜 코드가 아니라 프롬프트인가

`keeper_memory_os_types.mli` 가 명시한다:

> Categories are model context only and do not grant retention, expiry, or promotion authority.

코드는 카테고리로 자기제한을 구분할 수 없고, claim 텍스트를 매칭하면 그것이 이 저장소가 거부하는 string classifier 다. 판정이 가능한 지점은 선택 프롬프트다.

## 라이브 영향

#26862 에 실측: kidsnote 가 만료된 56건 중 **47건의 작성자**인데, 자기 store 는 멘션을 기다리라고 말하고 있었다 — 그 멘션은 워크스페이스 전체 역사에서 **6번** 왔다.

## 검증

```
test_keeper_librarian_retry           19/19 pass
negative control (프롬프트만 되돌림)     FAIL: the omit rule spans every category
ocamlformat --check                   exit 0
```

기존 단언 `drop a stored `constraint`` 는 제거하려는 결합 그 자체라 새 문구로 교체했다.

관련: #26858 (역 저장 금지), #26862, #26831 (retention 재적용 도입)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
