### PR TITLE
fix(dashboard): stop sending the direct_reply field the server never read

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -866,7 +866,6 @@ describe('sendKeeperMessageDetailed', () => {
       target_id: 'sangsu',
       payload: {
         message: 'ping',
-        direct_reply: true,
       },
     })
     expect(reply.text).toBe('pong')
@@ -895,7 +894,6 @@ describe('submitQueuedKeeperMessage', () => {
       target_id: 'sangsu',
       payload: {
         message: 'ping',
-        direct_reply: true,
       },
     })
     expect(submitted).toEqual({
@@ -1116,7 +1114,6 @@ describe('streamKeeperMessage', () => {
     expect(JSON.parse(String(init.body))).toEqual({
       name: 'sangsu',
       message: 'ping',
-      direct_reply: true,
     })
     const actorHeader = headers['X-MASC-Agent'] ?? headers['x-masc-agent']
     expect(actorHeader).toBe('dashboard-eager-manta')
@@ -1154,7 +1151,6 @@ describe('streamKeeperMessage', () => {
     expect(JSON.parse(String(init.body))).toEqual({
       name: 'sangsu',
       message: 'ping',
-      direct_reply: true,
       channel: 'copilot',
       channel_workspace_id: 'session-7',
       turn_instructions: 'focus on overview',
@@ -1205,7 +1201,6 @@ describe('streamKeeperMessage', () => {
     expect(JSON.parse(String(init.body))).toMatchObject({
       name: 'sangsu',
       message: 'describe this',
-      direct_reply: true,
       attachments: [
         {
           id: 'att-img',

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -311,7 +311,6 @@ async function callKeeperMessageViaOperator(
 ): Promise<KeeperToolReply> {
   const payload: Record<string, unknown> = {
     message,
-    direct_reply: true,
   }
   const response = await runOperatorAction({
     actor: currentDashboardActor(),
@@ -353,7 +352,6 @@ export async function submitQueuedKeeperMessage(
     target_id: name,
     payload: {
       message,
-      direct_reply: true,
     },
   })
   const operatorResult = isRecord(response.result) ? response.result : null
@@ -537,7 +535,6 @@ export async function streamKeeperMessage(
   const body: Record<string, unknown> = {
     name,
     message,
-    direct_reply: true,
   }
   if (channel && channel.trim() !== '') {
     body.channel = channel.trim()

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -470,7 +470,6 @@ async function requestRuntimeAssistViaOperator(
     target_type: 'keeper',
     target_id: request.keeperName,
     payload: {
-      direct_reply: true,
       message: request.message,
     },
   })


### PR DESCRIPTION
## 증상

대시보드 Keeper 챗이 전부 400으로 실패한다.

```
POST /api/v1/keepers/chat/stream: request body field direct_reply is undeclared;
accepted fields: name, message, user_blocks, turn_instructions, surface_context,
channel, channel_user_id, channel_user_name, channel_workspace_id, attachments
```

## 원인

#26866 (`refactor: type Keeper message boundary`) 이 스트림 파서에 strict allowlist 를 도입했고 `direct_reply` 가 목록에 없다 (`server_routes_http_keeper_stream.ml:508-519`).

`direct_reply` 는 애초에 입력이 아니었다. 구 파서는 allowlist 가 없어 클라이언트 값을 조용히 버렸고, 라우트가 tool args 에 `("direct_reply", \`Bool true)` 를 직접 붙였다. 새 파서도 `~direct_reply:true` 로 하드코딩한다 (같은 파일 608행). 대시보드는 #2932 이래로 서버가 한 번도 읽지 않은 필드를 계속 보내고 있었다.

## 수정

allowlist 에 추가하지 않고 송신 측에서 제거했다. allowlist 에 넣으면 서버가 무시하는 값을 받아들이는 형태가 되고, 값을 서버가 결정하는데 클라이언트가 중복 선언하는 상태가 남는다.

같은 죽은 필드를 보내던 나머지 사이트도 함께 제거했다 (N-of-M 패치 회피).

- `streamKeeperMessage` — 400 의 직접 원인
- `callKeeperMessageViaOperator`, `submitQueuedKeeperMessage` — operator `keeper_message` payload
- `requestRuntimeAssistViaOperator` (fleet-fsm-matrix) — 같은 operator payload

operator 경로는 400 이 나지 않았지만 `operator_control.ml:202-219` 가 `payload.message` 만 읽으므로 이쪽 `direct_reply` 도 동일하게 죽은 필드다.

## 검증

worktree `.worktrees/fix-direct-reply-undeclared-20260805`, `dashboard/` 기준:

- `pnpm run typecheck` — 통과
- `pnpm run lint` — 통과
- `pnpm exec vitest run src/api/keeper.test.ts` — 59 passed
- `pnpm exec vitest run src/components/fleet-fsm-matrix.test.ts` — 46 passed

미검증: 실제 서버 대상 end-to-end POST 는 실행하지 않았다 (성공 시 실제 keeper 턴이 시작되므로). 서버 파서의 allowlist 거동 자체는 `test_gate_keeper_backend.ml:320` 계열 테스트가 이미 덮는다.

## 남는 문제

allowlist(OCaml)와 요청 body(TypeScript)가 서로를 모르는 이중 정의라 이번 같은 드리프트를 컴파일/테스트가 잡지 못한다. 이번 PR 범위 밖이라 별도 이슈로 분리한다.

RFC-WAIVED: credential/identity/operator control plane/sandbox/hooks/workflow 문서 중 어느 것도 건드리지 않는다. 변경은 dashboard 요청 body 에서 서버가 읽지 않는 필드 4곳을 제거한 것뿐이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UksSyfEqMKrqAt3b5X31Sv
