### PR TITLE
refactor(keeper): status 스텁 제거 + fail-open 기본값 3곳 방향 수정

### DIFF
--- a/dashboard/src/components/keeper-detail.test.ts
+++ b/dashboard/src/components/keeper-detail.test.ts
@@ -333,7 +333,6 @@ describe('KeeperDetailPage', () => {
         last_reply_preview: null,
         last_error: null,
         keepalive_running: true,
-        next_eligible_at_s: null,
       },
       trust: {
         disposition: 'Blocked',

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -197,12 +197,6 @@ function formatTime(timestamp?: string | null): string | null {
   return result === NO_TIME_INFO ? null : result
 }
 
-function formatEligible(seconds?: number | null): string | null {
-  if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds <= 0) return null
-  if (seconds < 60) return `${Math.round(seconds)}s`
-  return `${Math.ceil(seconds / 60)}m`
-}
-
 function cancelKeeperThreadFromUi(keeperName: string): void {
   void cancelActiveKeeperThreadMessage(keeperName)
     .then(cancelled => {
@@ -421,7 +415,6 @@ export function KeeperDiagnosticSummary({
       <div class="text-xs text-[var(--color-fg-primary)] leading-relaxed mt-1 v2-monitoring-row">
         응답: ${diagnostic?.last_reply_status ?? '미조회'}
         ${diagnostic?.last_reply_at ? html` -- ${formatTime(diagnostic.last_reply_at)}` : null}
-        ${diagnostic?.next_eligible_at_s ? html` -- 다음 응답 가능 ${formatEligible(diagnostic.next_eligible_at_s)}` : null}
       </div>
       ${diagnostic?.last_error
         ? html`<${AgentFailure}

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -860,7 +860,6 @@ export function normalizeKeeperDiagnostic(raw: unknown): KeeperDiagnostic | null
     last_reply_at: toIsoTimestamp(raw.last_reply_at) ?? null, // undefined->null: field is string|null
     last_reply_preview: asString(raw.last_reply_preview) ?? null,
     last_error: asString(raw.last_error) ?? null,
-    next_eligible_at_s: asNumber(raw.next_eligible_at_s) ?? null,
     recoverable: typeof raw.recoverable === 'boolean' ? raw.recoverable : undefined,
     summary: asString(raw.summary),
     keepalive_running: typeof raw.keepalive_running === 'boolean' ? raw.keepalive_running : undefined,

--- a/dashboard/src/store-reconcile.test.ts
+++ b/dashboard/src/store-reconcile.test.ts
@@ -169,33 +169,6 @@ describe('reconcileKeepers', () => {
     expect(result[0]).toBe(updated)
   })
 
-  it('keeps row references for nested diagnostic countdown drift within the same display bucket', () => {
-    const keeper = makeKeeper({
-      diagnostic: {
-        summary: 'Keeper is waiting for a scheduled wake.',
-        health_state: 'healthy',
-        quiet_reason: 'min_gap',
-        next_action_path: 'direct_message',
-        last_reply_status: 'never',
-        next_eligible_at_s: 281.1,
-      },
-    })
-    const next = makeKeeper({
-      diagnostic: {
-        summary: 'Keeper is waiting for a scheduled wake.',
-        health_state: 'healthy',
-        quiet_reason: 'min_gap',
-        next_action_path: 'direct_message',
-        last_reply_status: 'never',
-        next_eligible_at_s: 275.5,
-      },
-    })
-
-    const result = reconcileKeepers([keeper], [next])
-
-    expect(result[0]).toBe(keeper)
-  })
-
   it('updates immediately for meaningful keeper state changes', () => {
     const keeper = makeKeeper({ status: 'idle', pipeline_stage: 'idle' })
     const updated = makeKeeper({ status: 'offline', pipeline_stage: 'failing' })

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -202,7 +202,6 @@ const KEEPER_RELATIVE_AGE_FIELDS = new Set<string>([
   'last_turn_ago_s',
   'last_handoff_ago_s',
   'last_proactive_ago_s',
-  'next_eligible_at_s',
 ])
 
 function relativeAgeRenderBucket(value: unknown): unknown {

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -622,7 +622,6 @@ export interface KeeperDiagnostic {
   last_reply_at?: string | null
   last_reply_preview?: string | null
   last_error?: string | null
-  next_eligible_at_s?: number | null
   recoverable?: boolean
   summary?: string
   keepalive_running?: boolean

--- a/lib/keeper/keeper_status_runtime.ml
+++ b/lib/keeper/keeper_status_runtime.ml
@@ -118,12 +118,12 @@ let parse_agent_status (config : Workspace.config) ~(agent_name : string) : Yojs
               |> Option.value ~default:0.0
             in
             (* An unparseable timestamp is absence of evidence, so omit the
-               derived age instead of emitting 0.0. Consumers already read
-               these through [Option.value ~default:max_float] (see
-               [agent_last_seen_ago_s] and [keeper_health_state]), i.e. a
-               missing field means "infinitely stale". Emitting 0.0 read as
-               "seen just now" and made that fail-closed default
-               unreachable, because the field was always present. *)
+               derived age instead of emitting 0.0. Both readers —
+               [agent_last_seen_ago_s] and [keeper_health_state] — already fall
+               back to [max_float] when the field is missing, i.e. treat it as
+               infinitely stale. Emitting 0.0 read as "seen just now" and made
+               that fail-closed fallback unreachable, because the field was
+               always present. *)
             let derived_age key ts =
               if ts <= 0.0 then [] else [ (key, `Float (now_ts -. ts)) ]
             in

--- a/lib/keeper/keeper_status_runtime.ml
+++ b/lib/keeper/keeper_status_runtime.ml
@@ -117,23 +117,29 @@ let parse_agent_status (config : Workspace.config) ~(agent_name : string) : Yojs
               Workspace_resilience.Time.parse_iso8601_opt agent.last_seen
               |> Option.value ~default:0.0
             in
-            let age_s = if session_bound_ts <= 0.0 then 0.0 else now_ts -. session_bound_ts in
-            let last_seen_ago_s =
-              if last_seen_ts <= 0.0 then 0.0 else now_ts -. last_seen_ts
+            (* An unparseable timestamp is absence of evidence, so omit the
+               derived age instead of emitting 0.0. Consumers already read
+               these through [Option.value ~default:max_float] (see
+               [agent_last_seen_ago_s] and [keeper_health_state]), i.e. a
+               missing field means "infinitely stale". Emitting 0.0 read as
+               "seen just now" and made that fail-closed default
+               unreachable, because the field was always present. *)
+            let derived_age key ts =
+              if ts <= 0.0 then [] else [ (key, `Float (now_ts -. ts)) ]
             in
             `Assoc
-              [
-                ("name", `String agent.name);
-                ("agent_type", `String agent.agent_type);
-                ("status", `String (Masc_domain.string_of_agent_status agent.status));
-                ( "capabilities",
-                  `List (List.map (fun s -> `String s) agent.capabilities) );
-                ( "current_task", Json_util.string_opt_to_json agent.current_task );
-                ("session_bound_at", `String agent.session_bound_at);
-                ("last_seen", `String agent.last_seen);
-                ("age_s", `Float age_s);
-                ("last_seen_ago_s", `Float last_seen_ago_s);
-              ]))
+              ([
+                 ("name", `String agent.name);
+                 ("agent_type", `String agent.agent_type);
+                 ("status", `String (Masc_domain.string_of_agent_status agent.status));
+                 ( "capabilities",
+                   `List (List.map (fun s -> `String s) agent.capabilities) );
+                 ( "current_task", Json_util.string_opt_to_json agent.current_task );
+                 ("session_bound_at", `String agent.session_bound_at);
+                 ("last_seen", `String agent.last_seen);
+               ]
+               @ derived_age "age_s" session_bound_ts
+               @ derived_age "last_seen_ago_s" last_seen_ts)))
 
 let json_string_opt key json = Json_util.get_string_nonempty json key
 
@@ -333,7 +339,7 @@ let classify_keeper_quiet_reason ~meta ~keepalive_running ~agent_status ~now_ts 
 
 let keeper_health_state ?(fiber_health = Fiber_unknown)
     ?(keepalive_interval_s = 300.0)
-    ~meta ~keepalive_running ~agent_status ~quiet_reason ~now_ts () : keeper_health =
+    ~meta ~keepalive_running ~agent_status ~quiet_reason () : keeper_health =
   (* Supervisor-level health takes priority *)
   match fiber_health with
   | Fiber_zombie -> KH_zombie
@@ -345,7 +351,6 @@ let keeper_health_state ?(fiber_health = Fiber_unknown)
     json_float_opt "last_seen_ago_s" agent_status |> Option.value ~default:max_float
   in
   let stale_threshold_s = agent_staleness_threshold_s in
-  let _ = now_ts in
   if
     (not keepalive_running)
     &&
@@ -377,8 +382,6 @@ let keeper_next_action_path ~(health_state : keeper_health) ~quiet_reason =
           "probe"
       | Some "disabled" -> "recover"
       | _ -> "direct_message")
-
-let keeper_next_eligible_at_s ~meta:_ ~quiet_reason:_ ~now_ts:_ = `Null
 
 let keeper_diagnostic_summary ~meta ~(health_state : keeper_health) ~quiet_reason =
   match health_state with
@@ -549,7 +552,7 @@ let keeper_diagnostic_json
     classify_keeper_quiet_reason ~meta ~keepalive_running ~agent_status ~now_ts
   in
   let health_state =
-    keeper_health_state ~meta ~keepalive_running ~agent_status ~quiet_reason ~now_ts ()
+    keeper_health_state ~meta ~keepalive_running ~agent_status ~quiet_reason ()
   in
   let next_action_path = keeper_next_action_path ~health_state ~quiet_reason in
   let last_reply_status, last_reply_at, last_reply_preview =
@@ -576,7 +579,6 @@ let keeper_diagnostic_json
       ("last_reply_preview", last_reply_preview);
       ("last_error", last_error);
       ("keepalive_running", `Bool keepalive_running);
-      ("next_eligible_at_s", keeper_next_eligible_at_s ~meta ~quiet_reason ~now_ts);
     ]
 
 (** Derive pipeline stage directly from the Keeper lifecycle phase. *)

--- a/lib/keeper/keeper_status_runtime.mli
+++ b/lib/keeper/keeper_status_runtime.mli
@@ -52,7 +52,6 @@ val keeper_health_state :
   keepalive_running:bool ->
   agent_status:Yojson.Safe.t ->
   quiet_reason:string option ->
-  now_ts:float ->
   unit ->
   keeper_health
 

--- a/lib/keeper/keeper_unified_metrics.mli
+++ b/lib/keeper/keeper_unified_metrics.mli
@@ -162,7 +162,6 @@ val append_metrics_snapshot :
   checkpoint_bytes:int ->
   message_count:int ->
   handoff_json:Yojson.Safe.t option ->
-  ?count_completed_turn:bool ->
   unit ->
   unit
 

--- a/lib/keeper/keeper_unified_metrics_snapshot.ml
+++ b/lib/keeper/keeper_unified_metrics_snapshot.ml
@@ -18,7 +18,6 @@ let append_metrics_snapshot ~(config : Workspace.config) ~(meta : keeper_meta)
     ~(checkpoint_bytes : int)
     ~(message_count : int)
     ~(handoff_json : Yojson.Safe.t option)
-    ?(count_completed_turn = true)
     () : unit =
   let now_ts = Time_compat.now () in
   let _observation = observation in
@@ -81,12 +80,10 @@ let append_metrics_snapshot ~(config : Workspace.config) ~(meta : keeper_meta)
     ~channel:(Keeper_world_observation.channel_to_string channel)
     ~runtime_profile
     ~latency_ms;
-  if count_completed_turn
-  then
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string TurnCompleted)
-      ~labels:[("keeper", meta.name)]
-      ();
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string TurnCompleted)
+    ~labels:[("keeper", meta.name)]
+    ();
   let snapshot =
     `Assoc
       (Keeper_metrics_record.fields Keeper_metrics_record.Turn

--- a/lib/keeper/keeper_unified_metrics_snapshot.mli
+++ b/lib/keeper/keeper_unified_metrics_snapshot.mli
@@ -12,6 +12,5 @@ val append_metrics_snapshot :
   checkpoint_bytes:int ->
   message_count:int ->
   handoff_json:Yojson.Safe.t option ->
-  ?count_completed_turn:bool ->
   unit ->
   unit

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -75,9 +75,6 @@ let terminal_outcome_of_result result =
     Terminal_checkpoint
 ;;
 
-let terminal_outcome_is_completed_turn _ = true
-;;
-
 let terminal_outcome_to_activity_kind = function
   | Terminal_done | Terminal_checkpoint -> "keeper.turn_completed"
   | Terminal_input_required -> "keeper.turn_input_required"
@@ -126,7 +123,6 @@ let append_metrics_snapshot
       ~checkpoint_bytes:lifecycle.checkpoint_bytes
       ~message_count:lifecycle.message_count
       ~handoff_json:lifecycle.handoff_json
-      ~count_completed_turn:(terminal_outcome_is_completed_turn terminal_outcome)
       ()
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -509,7 +505,6 @@ module For_testing = struct
     | Terminal_input_required
 
   let terminal_outcome_of_result = terminal_outcome_of_result
-  let terminal_outcome_is_completed_turn = terminal_outcome_is_completed_turn
 
   let persist_terminal_turn_meta_for_outcome
         ~config

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -9,7 +9,6 @@ module For_testing : sig
     | Terminal_input_required
 
   val terminal_outcome_of_result : Keeper_agent_run.run_result -> terminal_outcome
-  val terminal_outcome_is_completed_turn : terminal_outcome -> bool
 
   val persist_terminal_turn_meta_for_outcome
     :  config:Workspace.config

--- a/lib/operator/operator_control_snapshot_runtime_status.ml
+++ b/lib/operator/operator_control_snapshot_runtime_status.ml
@@ -29,9 +29,10 @@ let runtime_status_from_live_signal (agent_status_json : Yojson.Safe.t) =
 (* [keeper_diagnostic_json] always emits "health_state", so a missing or
    unparseable field means the blob did not come from that producer. Deny the
    override in that case: this gate exists to stop a non-healthy keeper from
-   being displayed as live, and the previous two-step defaulting
-   (~default:"offline" then ~default:KH_offline) landed on KH_offline, which is
-   in the allow set — so an absent or corrupt field granted the override. *)
+   being displayed as live, and the previous code defaulted twice — first to
+   the string "offline", then to [KH_offline] — both landing on a constructor
+   that is in the allow set, so an absent or corrupt field granted the
+   override. *)
 let health_state_allows_runtime_status_override (diagnostic : Yojson.Safe.t) =
   match
     Json_util.get_string diagnostic "health_state"

--- a/lib/operator/operator_control_snapshot_runtime_status.ml
+++ b/lib/operator/operator_control_snapshot_runtime_status.ml
@@ -26,15 +26,22 @@ let runtime_status_from_live_signal (agent_status_json : Yojson.Safe.t) =
   | _ -> None
 ;;
 
+(* [keeper_diagnostic_json] always emits "health_state", so a missing or
+   unparseable field means the blob did not come from that producer. Deny the
+   override in that case: this gate exists to stop a non-healthy keeper from
+   being displayed as live, and the previous two-step defaulting
+   (~default:"offline" then ~default:KH_offline) landed on KH_offline, which is
+   in the allow set — so an absent or corrupt field granted the override. *)
 let health_state_allows_runtime_status_override (diagnostic : Yojson.Safe.t) =
-  let kh =
-    Safe_ops.json_string ~default:"offline" "health_state" diagnostic
-    |> Keeper_status_runtime.keeper_health_of_string_opt
-    |> Option.value ~default:Keeper_types.KH_offline
-  in
-  match kh with
-  | Keeper_types.KH_stale | KH_degraded | KH_zombie | KH_dead -> false
-  | KH_healthy | KH_idle | KH_offline -> true
+  match
+    Json_util.get_string diagnostic "health_state"
+    |> Option.map Keeper_status_runtime.keeper_health_of_string_opt
+  with
+  | None | Some None -> false
+  | Some (Some kh) ->
+    (match kh with
+     | Keeper_types.KH_stale | KH_degraded | KH_zombie | KH_dead -> false
+     | KH_healthy | KH_idle | KH_offline -> true)
 ;;
 
 let align_keeper_runtime_status

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -161,23 +161,25 @@ let agent_of_yojson json =
             in
             Printf.sprintf "%s (last_seen=%s)" original_error last_seen_repr
           in
-          let now_iso () =
-            `String (iso8601_of_unix_seconds (Unix.gettimeofday ()))
-          in
+          (* No liveness evidence at all. [agent_to_yojson] always writes
+             [last_seen], so reaching here means the record did not come from
+             this codec: truncated, hand-edited, or an older schema. Keeping
+             the record is still right (#9751) — it is rebuilt on the next
+             heartbeat — but the filler must not claim liveness. The epoch
+             makes [parse_agent_status] treat the timestamp as absent, so the
+             derived age is omitted and consumers fall back to their
+             [max_float] "infinitely stale" default. A [now ()] filler
+             inverted that: a corrupt record read as "seen just now" and
+             satisfied every downstream liveness check. *)
+          let no_evidence_iso () = `String (iso8601_of_unix_seconds 0.0) in
           let normalized_last_seen =
             match last_seen_raw with
             | Some value ->
                 normalize_agent_last_seen ~session_bound_at:session_bound_at_value value
             | None ->
-                (* Missing last_seen → bootstrap from session_bound_at when
-                   present, otherwise fall back to the current wall-clock
-                   time (#9751).  [last_seen] is a liveness marker, not
-                   identity-critical; a recent-but-approximate timestamp
-                   is strictly better than failing the whole record
-                   deserialisation for an optional field. *)
                 (match session_bound_at_value with
                  | Some _ as v -> v
-                 | None -> Some (now_iso ()))
+                 | None -> Some (no_evidence_iso ()))
           in
           (match normalized_last_seen with
           | Some normalized_last_seen ->
@@ -185,16 +187,15 @@ let agent_of_yojson json =
                 ("last_seen", normalized_last_seen)
                 :: List.remove_assoc "last_seen" fields
               in
-              (* If session_bound_at is also unusable, inject a now() value so
-                 the generated deserialiser's required-field check passes.
-                 The agent record can always be rebuilt from a heartbeat;
-                 losing the whole entry because of a missing timestamp is
-                 strictly worse (#9751). *)
+              (* Same reasoning for session_bound_at: the generated
+                 deserialiser requires the field, so fill it to keep the
+                 record, but with the epoch rather than a value that claims
+                 the session was bound just now. *)
               let normalized_fields =
                 match session_bound_at_value with
                 | Some _ -> fields_without_last_seen
                 | None ->
-                    ("session_bound_at", now_iso ())
+                    ("session_bound_at", no_evidence_iso ())
                     :: List.remove_assoc "session_bound_at" fields_without_last_seen
               in
               (match agent_of_yojson_generated (`Assoc normalized_fields) with

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -796,12 +796,6 @@ let () =
 ;;
 
 let () =
-  check
-    "runtime checkpoint remains a completed Keeper activity turn"
-    (UTS.terminal_outcome_is_completed_turn UTS.Terminal_checkpoint)
-;;
-
-let () =
   with_temp_dir "keeper-checkpoint-turn-persist" @@ fun workspace_dir ->
   let keeper_name = "checkpoint-turn-persist" in
   let config = Masc.Workspace.default_config workspace_dir in


### PR DESCRIPTION
## 무엇을

keeper status 경로에서 **계산한다고 주장하면서 하지 않던 것 4개**를 제거하고, **허용 방향으로 실패하던 기본값 3개**의 방향을 뒤집습니다. 16파일 −105/+59.

## 제거 — 스텁

### `keeper_next_eligible_at_s`

```ocaml
let keeper_next_eligible_at_s ~meta:_ ~quiet_reason:_ ~now_ts:_ = `Null
```

`#24352`가 아니라 **#24332 (`7b62a87d44`)**가 계층적 governance 쿨다운을 은퇴시키며 본문을 걷어냈습니다. 삭제된 본문:
```ocaml
| Some "min_gap" when meta.runtime.proactive_rt.last_ts > 0.0 ->
    cooldown_sec -. (now_ts -. last_ts)
```

대시보드 쪽은 그대로 남아 `keeper-shared.ts`가 `다음 응답 가능 ...`을 truthiness 뒤에서 렌더했는데, 백엔드가 그 조건을 만족시킬 수 없었습니다. `store-reconcile.test.ts`는 이 필드의 버킷팅을 테스트하면서 픽스처에 `quiet_reason: 'min_gap'`을 넣는데, **그 값의 생산자도 저장소에 0건**입니다. 함수·JSON 필드·대시보드 6곳·그 테스트를 제거합니다.

### `terminal_outcome_is_completed_turn _ = true`

같은 커밋이 만든 스텁입니다. `stop_reason`을 `Terminal_done | Terminal_checkpoint | Terminal_input_required`로 매핑하는 함수 **바로 아래**에서 그 분류를 통째로 버립니다. 값은 `?count_completed_turn`으로 흘러가는데 그 기본값도 `true`이고 `false`를 넘기는 호출자가 없습니다 — 항상-참이 두 겹입니다.

`TurnCompleted` 카운터는 지금도 무조건 증가하고 있었고 그대로입니다. 사라지는 건 판정하는 척하던 술어, 그것이 먹이던 플래그, 그리고 `"runtime checkpoint remains a completed Keeper activity turn"`으로 항상-참을 고정하던 테스트입니다.

`TurnCompleted`가 `Terminal_input_required`를 제외해야 하는지는 메트릭 의미 문제라 건드리지 않았습니다.

### `keeper_health_state`의 `now_ts`

`.mli`가 광고하는데 본문 첫 줄이 `let _ = now_ts in`입니다.

## 방향 수정 — fail-open 3곳

### operator override 게이트

```ocaml
Safe_ops.json_string ~default:"offline" "health_state" diagnostic
|> keeper_health_of_string_opt
|> Option.value ~default:Keeper_types.KH_offline
```

기본값 2단이 모두 `KH_offline`에 착지하고 그건 **허용 집합**에 있습니다. 필드가 없거나 깨지면 override가 허용됐고, 그 override는 inactive surface status를 live-signal 기반 값으로 **갈아치웁니다** — 게이트의 목적이 정확히 그걸 막는 것인데 반대로 동작했습니다.

`keeper_diagnostic_json`은 이 필드를 무조건 방출하므로 결측은 "정본 생산자가 아님"을 뜻합니다. 이제 거부합니다.

### `last_seen` 증거 사슬 — 두 층

```
types_core.ml         증거 0인 레코드 → now()           ← 1층
keeper_status_runtime  파싱 실패 → last_seen_ago_s = 0.0  ← 2층
```

소비자 규약은 이미 fail-closed입니다 — `agent_last_seen_ago_s`와 `keeper_health_state`가 `Option.value ~default:max_float`(무한히 오래됨)로 읽습니다. **그런데 생산자가 필드를 항상 채워서 그 기본값이 도달 불가였습니다.**

두 층이 합쳐지면 손상된 agent 레코드가 "방금 봤음"으로 읽히고, `agent_runtime_has_live_signal`을 만족시켜 위의 override로 들어갑니다.

filler를 epoch로 바꾸고 증거가 없으면 파생 age 필드를 생략합니다. **한 층만 고치면 다른 층이 무력화합니다** — epoch를 넣어도 `if last_seen_ts <= 0.0 then 0.0`이 그걸 "방금"으로 되돌리고, 필드 생략만 하면 `now()`가 여전히 진짜 타임스탬프로 보입니다.

레코드를 살리는 판단(#9751)은 유지합니다 — 다음 heartbeat에 재구성됩니다. 바뀐 것은 채우는 **값**뿐입니다.

## 의도적으로 남긴 것

- **`KH_zombie` / `KH_dead`** — 오늘 생산 불가입니다(`keeper_diagnostic_json`이 `~fiber_health`를 안 넘김). 그런데 `keeper_next_action_path`가 `auto_restart` / `manual_restart`로 매핑하고 #24332가 `KH_dead` 진단문을 **갱신**했으므로, 폐기된 개념이 아니라 **인자 하나가 빠진 미완 배선**입니다. 지우면 설계된 회복 경로가 사라집니다. **현재 좀비 keeper가 auto-restart 대상으로 표시되지 않는다**는 결함으로 보고합니다.
- **`keeper_health_or_offline`의 fail-open 2곳**(`:443`, `:524`) — 두 함수 모두 반환 타입에 에러 채널이 없어 시그니처 변경이 필요합니다. 반쯤 고치지 않았습니다.
- **stale 600s vs 120s** — `2.0 *. keepalive_interval_s`와 `agent_staleness_threshold_s`가 boolean 하나로 갈립니다. 5배 차이가 어느 쪽이 맞는지는 keeper 회복 정책이라 임의로 정하지 않습니다.

## 검증

- 로컬 전체 빌드는 돌리지 못했습니다(다른 워크트리 빌드가 30분+ 점유). **CI 빌드가 1차 검증입니다.**
- 잔여 참조 0건: `rg 'next_eligible_at_s|formatEligible|terminal_outcome_is_completed_turn|count_completed_turn' lib bin test dashboard/src`
- `lib/config/env_config_*.ml` 미접촉 — `Env knob catalog drift gate` 재생성 불필요를 확인했습니다.
- 대시보드는 `age_s`/`last_seen_ago_s`를 `asNumber(raw.x) ?? null`로 읽으므로 필드 생략이 안전합니다.

RFC-WAIVED: credential / identity / operator control action handler / keeper sandbox / hooks 어디에도 해당하지 않습니다. `operator_control_snapshot_runtime_status.ml` 변경은 credential/identity 가 아니라 status override 판정이며, 방향을 허용에서 거부로 좁히는 변경입니다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
