### PR TITLE
fix(server): prune 목록에서 누락된 Dated_jsonl 스토어 3종 커버 (119MB)

### DIFF
--- a/lib/server/server_runtime_startup_maintenance.ml
+++ b/lib/server/server_runtime_startup_maintenance.ml
@@ -112,7 +112,11 @@ let prune_keeper_scoped_flat_stores ~days ~masc_root =
    resilience_audit. recall_injections keeps its typed ledger pruner and
    data/tool-metrics stays startup-only (it lives under base_path, not the
    masc root); both remain at the callers.
-   oas-events joined 2026-07-31: 434 MB accumulated with no retention. *)
+   oas-events joined 2026-07-31: 434 MB accumulated with no retention.
+   costs and audit-approvals joined 2026-08-05: both write the same
+   [YYYY-MM/DD.jsonl] shape through [Dated_jsonl.create]
+   ([cost_ledger.ml:250], [keeper_approval_queue.ml:1732]) yet were on no
+   prune list since introduction — 74 MB and 22 MB measured. *)
 let top_level_dated_stores =
   [ "audit"
   ; "telemetry"
@@ -123,6 +127,8 @@ let top_level_dated_stores =
   ; "tool_calls"
   ; "transition-audit"
   ; "oas-events"
+  ; "costs"
+  ; "audit-approvals"
   ]
 
 (* Single shared fold over every retention-covered JSONL store. Both the
@@ -144,6 +150,12 @@ let prune_shared_jsonl_stores ~prune_dir ~days ~masc_root =
       ~prune_dir:(prune_flat_jsonl_older_than ~days)
       (Filename.concat masc_root "trajectories")
   + prune_children_dirs ~prune_dir (Filename.concat masc_root "resilience_audit")
+  (* decision_audit: [<keeper>/YYYY-MM/DD.jsonl] written via
+     [Keeper_decision_audit.append] ([keeper_decision_audit.ml:185]). Same
+     keeper-scoped dated shape as resilience_audit, so it folds the same way;
+     it lives at the masc root rather than under keepers/, which is why it is
+     not in [keeper_scoped_dated_stores]. 23 MB measured with no retention. *)
+  + prune_children_dirs ~prune_dir (Filename.concat masc_root "decision_audit")
   + prune_keeper_scoped_stores ~prune_dir ~masc_root
   + prune_keeper_scoped_flat_stores ~days ~masc_root
 

--- a/test/test_server_runtime_startup_maintenance.ml
+++ b/test/test_server_runtime_startup_maintenance.ml
@@ -93,6 +93,8 @@ let test_top_level_store_list_is_ssot () =
     "top-level dated stores pinned"
     [ "activity-events"
     ; "audit"
+    ; "audit-approvals"
+    ; "costs"
     ; "events"
     ; "messages"
     ; "oas-events"
@@ -165,9 +167,30 @@ let test_prune_shared_jsonl_stores_production_geometry () =
   let raw_old = p [ "keepers"; "keeper-a"; "raw-traces"; "turn-old.jsonl" ] in
   let manifest_old = p [ "keepers"; "keeper-a"; "runtime-manifests"; "trace-x.jsonl.1" ] in
   let manifest_fresh = p [ "keepers"; "keeper-a"; "runtime-manifests"; "trace-x.jsonl" ] in
+  (* Stores that were on no prune list until 2026-08-05. costs and
+     audit-approvals are top-level dated; decision_audit is keeper-scoped at
+     the masc root, like resilience_audit. *)
+  let costs_old = p [ "costs"; "2020-01"; "01.jsonl" ] in
+  let costs_fresh = p [ "costs"; "2999-01"; "01.jsonl" ] in
+  let approvals_old = p [ "audit-approvals"; "2020-01"; "01.jsonl" ] in
+  let decision_old = p [ "decision_audit"; "keeper-a"; "2020-01"; "01.jsonl" ] in
+  let decision_fresh = p [ "decision_audit"; "keeper-a"; "2999-01"; "01.jsonl" ] in
   List.iter
     write
-    [ oas_old; oas_fresh; logs_old; logs_fresh; turn_old; raw_old; manifest_old; manifest_fresh ];
+    [ oas_old
+    ; oas_fresh
+    ; logs_old
+    ; logs_fresh
+    ; turn_old
+    ; raw_old
+    ; manifest_old
+    ; manifest_fresh
+    ; costs_old
+    ; costs_fresh
+    ; approvals_old
+    ; decision_old
+    ; decision_fresh
+    ];
   List.iter (fun f -> Unix.utimes f old_ts old_ts) [ logs_old; raw_old; manifest_old ];
   let prune_dir dir =
     if Sys.file_exists dir
@@ -175,7 +198,15 @@ let test_prune_shared_jsonl_stores_production_geometry () =
     else 0
   in
   let n = SM.prune_shared_jsonl_stores ~prune_dir ~days:30 ~masc_root in
-  Alcotest.(check int) "five stale files pruned" 5 n;
+  Alcotest.(check int) "eight stale files pruned" 8 n;
+  Alcotest.(check bool) "stale costs day removed" false (Sys.file_exists costs_old);
+  Alcotest.(check bool) "future costs day kept" true (Sys.file_exists costs_fresh);
+  Alcotest.(check bool)
+    "stale audit-approvals day removed" false (Sys.file_exists approvals_old);
+  Alcotest.(check bool)
+    "stale decision_audit day removed" false (Sys.file_exists decision_old);
+  Alcotest.(check bool)
+    "future decision_audit day kept" true (Sys.file_exists decision_fresh);
   Alcotest.(check bool) "stale oas-events day removed" false (Sys.file_exists oas_old);
   Alcotest.(check bool) "future oas-events day kept" true (Sys.file_exists oas_fresh);
   Alcotest.(check bool) "stale log day removed" false (Sys.file_exists logs_old);


### PR DESCRIPTION
Closes #26882

## 문제

`Dated_jsonl` 로 쓰이는 스토어 3개가 어떤 prune 목록에도 없어 무제한 증가했다. 2026-08-05 실측:

| 스토어 | 크기 | 레이아웃 | 분류 |
|---|---|---|---|
| `costs` | 74MB | `YYYY-MM/DD.jsonl` | top-level dated |
| `decision_audit` | 23MB | `<keeper>/YYYY-MM/DD.jsonl` | keeper-scoped |
| `audit-approvals` | 22MB | `YYYY-MM/DD.jsonl` | top-level dated |

셋 다 `Dated_jsonl.create` 를 거친다 — `cost_ledger.ml:250`, `keeper_approval_queue.ml:1732`, `keeper_decision_audit.ml:185`.

## 무엇을

`costs` / `audit-approvals` 는 `top_level_dated_stores` 가 이미 fold 하는 **모양이 정확히 같아서** 그 목록에 넣었다.

`decision_audit` 은 keeper-scoped 이지만 `keepers/` 하위가 아니라 **masc 루트에 있어서** `keeper_scoped_dated_stores` 대신 `resilience_audit` 과 같은 방식으로 fold 한다.

## 같은 결함이 이미 기록돼 있다

이 파일의 `:26` 주석:

> `turn-records` joined 2026-07-31: same layout, but **absent from every prune list since introduction** — ~4 MB/day fleet-wide with no bound.

목록이 수동 유지되고 `Dated_jsonl.create` 호출처와 아무 연결이 없다. **네 번째 누락은 시간 문제다.**

#26882 에 그 점과 함께, 정적 CI 스캔이 답이 아닌 이유도 적었다 — 20곳 넘는 호출처 대부분에서 `base_dir` 이 변수나 함수 결과로 오기 때문에 디렉토리명 패턴 매칭은 오탐을 낸다. `Dated_jsonl.base_dir` 이 존재하므로 **생성 시점 등록**이 실제로 닫는 형태다. 이 PR 범위를 넘어 별도 판단이 필요하다.

## 테스트

새로 만들지 않고 **기존 drift guard 두 개를 갱신**했다.

- **top-level SSOT pin** — `costs`, `audit-approvals` 추가
- **production geometry round-trip** — 새 스토어 3개에 stale/fresh 파일을 심고 기대값을 `5 → 8` 로 올렸다. 미래 날짜(`2999-01`) 파일이 **살아남는지도 단언**하므로, 무차별 삭제가 아니라 선택적 정리임이 증명된다.

## 검증

- `ocamlformat --check` 두 파일 clean
- `check-determinism-contract.sh` exit 0
- 빌드·테스트는 로컬에서 cold rebuild 진행 중 (이 worktree 의 `_build` 를 디스크 정리 때 비웠다). CI 가 게이트이며 결과는 코멘트로 붙인다.

RFC-WAIVED: retention 누락 수정. credential/identity/operator/sandbox/hooks 경계 미접촉. 기존 prune 경로에 스토어 3개를 추가할 뿐 정리 정책 자체는 바꾸지 않는다.
