### PR TITLE
fix(docs): #26883 이 삭제한 모듈의 matrix 행 제거 (main red 해소)

### DIFF
--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -167,8 +167,6 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_tool_surface.ml` - tool-surface-policy
 - `lib/keeper/keeper_tool_surface.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_surface_ops.ml` - tool-surface-policy
-- `lib/keeper/keeper_tool_visibility_projection.ml` - tool-surface-policy
-- `lib/keeper/keeper_tool_visibility_projection.mli` - tool-surface-policy
 - `lib/keeper/keeper_tools_oas_bundle.ml` - oas-tool-bridge
 - `lib/keeper/keeper_tools_oas_bundle.mli` - oas-tool-bridge
 - `lib/keeper/keeper_tools_oas_handler_exec.ml` - oas-tool-bridge


### PR DESCRIPTION
## 문제

`main` 이 `OCaml Structure Ratchet` 에서 red 입니다. 제 변경 때문이 아니라 이미 머지된 것 때문입니다.

```
$ scripts/audit-keeper-tool-boundary-matrix.sh
[keeper-tool-boundary-matrix] FAIL - stale matrix paths

Stale matrix paths:
  - lib/keeper/keeper_tool_visibility_projection.ml
  - lib/keeper/keeper_tool_visibility_projection.mli
```

`#26883` (`c6667443f7`, *remove Thompson Sampling and Text_similarity*) 이 두 모듈을 삭제했는데 `docs/design/keeper-tool-boundary-matrix.md` 의 소유 행 2 개가 남았습니다.

이 ratchet 은 **양방향** 검사입니다 — 소유자 없는 keeper 모듈도 잡고, 파일 없는 matrix 행도 잡습니다. 그래서 `lib_deps` 또는 `build` 를 건드리는 **모든 열린 PR** 이 자기 diff 와 무관하게 이 red 를 물려받습니다.

## 변경

행 2 개 삭제. 그것뿐입니다.

```
before: FAIL - stale matrix paths (2)
after:  OK - 125 scoped keeper files covered
```

## 왜 별도 PR 인가

`#26892` (프롬프트 앵커 가드 제거) 작업 중에 발견했지만 그쪽에 섞지 않았습니다. 원인이 다르고, 이건 열린 PR 전부를 막고 있어 먼저 들어가는 편이 낫습니다.

RFC-WAIVED: 삭제된 파일을 가리키는 문서 행 제거입니다. 계약도 동작도 바뀌지 않습니다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
