### PR TITLE
fix(docs): 삭제된 파일을 가리키는 문서 참조 2건 제거 (게이트 2개 복구)

### DIFF
--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -167,8 +167,6 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_tool_surface.ml` - tool-surface-policy
 - `lib/keeper/keeper_tool_surface.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_surface_ops.ml` - tool-surface-policy
-- `lib/keeper/keeper_tool_visibility_projection.ml` - tool-surface-policy
-- `lib/keeper/keeper_tool_visibility_projection.mli` - tool-surface-policy
 - `lib/keeper/keeper_tools_oas_bundle.ml` - oas-tool-bridge
 - `lib/keeper/keeper_tools_oas_bundle.mli` - oas-tool-bridge
 - `lib/keeper/keeper_tools_oas_handler_exec.ml` - oas-tool-bridge

--- a/docs/sse-ws-cutover.md
+++ b/docs/sse-ws-cutover.md
@@ -2,7 +2,6 @@
 status: in-progress
 last_verified: 2026-04-26
 code_refs:
-  - dashboard/src/dashboard-ws-cutover.ts
   - dashboard/src/components/transport-beacon.ts
   - dashboard/.env.development
 ---


### PR DESCRIPTION
## 문제

현재 main 에서 게이트 2개가 실패한다. 둘 다 제거 PR 이 포인터를 남긴 탓이다.

| 게이트 | 위치 | 원인 |
|---|---|---|
| `OCaml Structure Ratchet` | `docs/design/keeper-tool-boundary-matrix.md` | `keeper_tool_visibility_projection.{ml,mli}` 를 가리킴 — **#26883** 이 삭제 |
| `doc code_refs` | `docs/sse-ws-cutover.md` frontmatter | `dashboard/src/dashboard-ws-cutover.ts` 를 가리킴 — **#26878** 이 삭제 |

두 문서 모두 **본문에서는 해당 파일을 언급하지 않는다.** 기계가 검사하는 목록만 stale 해졌다.

## 무엇을

매트릭스에서 두 줄 제거, `code_refs` 에서 한 줄 제거. 나란히 있던 나머지 항목(`transport-beacon.ts`, `.env.development`)은 실재하므로 그대로 둔다.

## 건드리지 않은 것

`docs/audit/mutable-state-audit-2026-05-12.md` 와 `RFC-0274` 도 `thompson_sampling.ml`(역시 #26883 이 삭제)을 언급한다. **시점 기록이므로 본문을 고치는 건 계약 수정이 아니라 역사 수정**이다. 계약인 것은 frontmatter `code_refs` 뿐이고 그건 doc-truth 가 강제한다.

## 범위 주의

**이 PR 은 main 파싱 오류를 고치지 않는다.** `lib/board/board_votes.ml:294` 의 stray semicolon(같은 #26883 에서 유입)은 **PR #26890** 이 이미 다루고 있다.

다만 #26890 이 머지되지 못하는 이유가 자기 변경이 아니라 **이 커밋이 해소하는 Structure Ratchet 실패** 다. 즉 이 PR 이 먼저 들어가야 #26890 이 풀린다.

## 검증

- `check-doc-truth.sh` exit 0 — *"every frontmatter code_refs path exists in the repo"*
- `audit-keeper-tool-boundary-matrix.sh` exit 0 — 125개 scoped 파일 커버

RFC-WAIVED: 삭제된 파일을 가리키는 문서 참조 제거. 코드 변경 없음. credential/identity/operator/sandbox/hooks 경계 미접촉.
