### PR TITLE
fix(test): migrate the IDE SSE subscriber to the current callback contract

### DIFF
--- a/test/test_server_ide_http.ml
+++ b/test/test_server_ide_http.ml
@@ -541,9 +541,9 @@ let test_post_cursors_broadcasts_ws_invalidation () =
     let token = create_worker_token base_path "alice" in
     let subscriber_id = "test-ide-cursor-ws-invalidation" in
     let received = ref [] in
-    Sse.subscribe_external ~id:subscriber_id (fun frame ->
-      received := frame :: !received;
-      true);
+    Sse.subscribe_external ~id:subscriber_id
+      ~callback:(fun frame -> received := frame :: !received)
+      ();
     Fun.protect
       ~finally:(fun () -> Sse.unsubscribe_external subscriber_id)
       (fun () ->


### PR DESCRIPTION
## 문제

main 이 빌드되지 않는다.

```
File "test/test_server_ide_http.ml", lines 544-546, characters 45-11:
Error: This expression should not be a function, the expected type is unit
```

#26878 이 legacy SSE transport 를 hard-cut 하면서 시그니처가 바뀌었다:

```ocaml
val subscribe_external :
  id:string -> callback:(string -> unit) -> ?is_alive:(unit -> bool) -> unit -> unit
```

이 호출부만 콜백을 위치 인자로 넘기고, 콜백이 `true` 를 반환하며, 종결 `()` 가 없었다. 다른 호출부(`test_keeper_autonomous_turn_source`, `test_keeper_tool_dispatch_runtime`)는 이미 `~callback:` 을 쓴다.

## 범위

이 호출부 하나만. main red 의 나머지 두 건은 이미 담당이 있다:

- `lib/board/board_votes.ml` stray semicolon → **#26890**
- keeper tool boundary matrix stale rows → **#26893**

세 건 모두 오늘 병합된 제거 PR(#26883, #26878)이 소비자를 옮기지 않아 생겼다.

## 검증

`dune build --root . @check` 후 `test_server_ide_http.ml` 오류 0건. 남은 유일한 실패 파일은 `board_votes.ml`(#26890 담당)이다.

RFC-WAIVED: 기존 시그니처로의 테스트 호출부 이관 1건. credential/identity/auth, operator control, keeper sandbox, dashboard credential component, hooks, workflow 문서 어디에도 해당하지 않는다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
