### PR TITLE
test(keeper): declare the prompt tree the external-prompt test reads

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -1036,7 +1036,6 @@
   test_grpc_client
   test_http_protocol_detect
   test_prompt_registry_defaults
-  test_keeper_prompt_external
   test_eval_calibration
   test_goal_tools
   test_goal_upsert_fsm_bypass_10247
@@ -1185,7 +1184,6 @@
   test_grpc_client
   test_http_protocol_detect
   test_prompt_registry_defaults
-  test_keeper_prompt_external
   test_eval_calibration
   test_goal_tools
   test_goal_upsert_fsm_bypass_10247
@@ -2559,4 +2557,16 @@
  (deps
   (source_tree %{workspace_root}/config/prompts)
   %{workspace_root}/test/fixtures/keeper_system_prompt/assembled_prompt.golden)
+ (libraries alcotest masc_test_deps))
+
+; Stands alone rather than joining the shared group above for one reason: it
+; reads config/prompts/behavior/*.md off the source tree at run time, resolving
+; the repo root through DUNE_SOURCEROOT, so the group's single
+; ../bin/main_eio.exe dep would let an edit under config/prompts replay a cached
+; pass. CI runs this as a hard gate, and a gate that can be served from cache is
+; not a gate. Same reason the golden above declares the tree.
+(test
+ (name test_keeper_prompt_external)
+ (modules test_keeper_prompt_external)
+ (deps (source_tree %{workspace_root}/config/prompts))
  (libraries alcotest masc_test_deps))


### PR DESCRIPTION
#26830 이 머지된 뒤에도 남아 있던 리뷰 지적을 처리합니다. 머지된 PR 브랜치에는 push 하지 않으므로 `main` 대상 새 PR 입니다.

## 문제

`.github/workflows/ci.yml` 의 `prompt_targets` 가 `@test/runtest-test_keeper_prompt_external` 을 하드 게이트로 실행합니다. 그런데 이 테스트는 `DUNE_SOURCEROOT` 로 repo root 를 찾아 `config/prompts/behavior/*.md` 를 **런타임에 읽습니다** (`test_keeper_prompt_external.ml:27,74`). 반면 이 테스트가 속한 공용 그룹의 dep 은 `../bin/main_eio.exe` 하나뿐이었습니다.

dune 은 선언된 dep 으로 결과를 캐싱합니다. behavior 프롬프트를 고쳐도 이 타깃은 무효화되지 않으므로, **CI 가 캐시된 pass 를 그대로 돌려받을 수 있습니다.** 캐시에서 서빙될 수 있는 게이트는 게이트가 아닙니다.

바로 옆 `test_keeper_system_prompt_bytes` 는 같은 이유로 이미 `(source_tree config/prompts)` 를 선언하고 있고, 그 stanza 주석이 그 근거를 그대로 적어놨습니다.

## 변경

- `test_keeper_prompt_external` 을 공용 그룹에서 빼내 자체 stanza 로 분리하고 `(source_tree %{workspace_root}/config/prompts)` 를 선언
- binary dep 은 따라오지 않습니다. 이 테스트는 프로세스를 띄우지 않고 파일을 읽습니다 (`rg 'main_eio|create_process|Sys.command' test/test_keeper_prompt_external.ml` → 0건)
- libraries 를 `alcotest masc_test_deps` 로 축소 — golden 자매 stanza 와 동일

## 검증

같은 타깃을 3회 실행했습니다.

1. 초기 실행 → **6/6 통과**
2. 변경 없이 재실행 → 캐시 no-op
3. `config/prompts/behavior/conversation_routing.md` 의 단언 문자열을 바꾼 뒤 재실행 → **재실행되어 `FAIL expected body text`**

3번이 이 변경이 만들려던 동작입니다. 수정 전이면 3번에서 캐시된 pass 가 나옵니다.

## 하지 않은 것

- 음성 대조군(수정 전 stanza 로 3번이 실제로 캐시 pass 를 내는지)은 돌리지 않았습니다. `main_eio.exe` 전체 빌드가 필요합니다.

## CI 주의

`main` (`b7302aa0b1`) 이 현재 파싱되지 않습니다 — `lib/board/board_votes.ml` 의 stray semicolon 2건 (`c6667443f7` / #26883 이 필드를 지우며 구분자를 남김). 이 PR 의 Build and Test 는 그것 때문에 실패합니다. #26890 이 그 수정입니다. 로컬 검증은 #26890 의 diff 를 임시 적용한 상태에서 수행했고, 커밋에는 포함하지 않았습니다.

RFC-WAIVED: test dune stanza 의 dep 선언만 변경. credential / identity / operator control / sandbox / hooks / workflow 문서 어느 것도 건드리지 않습니다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
