### PR TITLE
fix(dashboard): preserve WS refresh invariants

### DIFF
--- a/dashboard/src/dashboard-ws-state.ts
+++ b/dashboard/src/dashboard-ws-state.ts
@@ -13,6 +13,7 @@ export const dashboardWsLastDisconnectedAt = signal(0)
 let hasReachedReady = false
 
 export function noteDashboardWsReady(): void {
+  dashboardWsReady.value = true
   if (hasReachedReady) dashboardWsReconnectCount.value++
   hasReachedReady = true
 }
@@ -66,5 +67,6 @@ export function _resetDashboardWsCounterForTests(): void {
   dashboardWsLastPongLatencyMs.value = null
   dashboardWsReconnectCount.value = 0
   dashboardWsLastDisconnectedAt.value = 0
+  dashboardWsReady.value = false
   hasReachedReady = false
 }

--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -1,3 +1,4 @@
+import { effect } from '@preact/signals'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const sseStoreMocks = vi.hoisted(() => ({
@@ -37,6 +38,7 @@ import {
   dashboardWsLastPongLatencyMs,
   dashboardWsLastSeq,
   dashboardWsReady,
+  dashboardWsReconnectCount,
 } from './dashboard-ws-state'
 
 interface JsonRpcRequest {
@@ -584,6 +586,22 @@ describe('dashboard websocket route subscriptions', () => {
     expect(mockSockets).toHaveLength(2)
     expect(mockSockets[1]!.url).toBe('ws://localhost:3000/ws')
     expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    let readyWhenReconnectAdvanced: boolean | null = null
+    const dispose = effect(() => {
+      if (dashboardWsReconnectCount.value > 0) {
+        readyWhenReconnectAdvanced = dashboardWsReady.value
+      }
+    })
+    const secondSocket = mockSockets[1]!
+    secondSocket.open()
+    const secondHello = parseRpc(secondSocket, 0)
+    secondSocket.receive({ jsonrpc: '2.0', id: secondHello.id, result: {} })
+    await flushPromises()
+
+    expect(dashboardWsReconnectCount.value).toBe(1)
+    expect(readyWhenReconnectAdvanced).toBe(true)
+    dispose()
   })
 
   it('clears lastError on a clean close while reconnect remains active', async () => {

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -914,9 +914,8 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
         if (socket !== ws) return
         if (!discovery.fromCache) writeCachedWsUrl(wsUrl)
         resetDiscoveryCacheFailures()
-        noteDashboardWsReady()
         batch(() => {
-          dashboardWsReady.value = true
+          noteDashboardWsReady()
           dashboardWsLastError.value = null
         })
         if (desiredRouteState) {

--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -524,6 +524,20 @@ let turn_number_of_id turn_id =
   if raw = "" then None else int_of_string_opt raw
 ;;
 
+let noop_cursor_changed_sink ~keeper_id:_ = ()
+let cursor_changed_sink = Atomic.make noop_cursor_changed_sink
+let register_cursor_changed_sink sink = Atomic.set cursor_changed_sink sink
+
+let notify_cursor_changed ~keeper_id =
+  try Atomic.get cursor_changed_sink ~keeper_id with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Printf.eprintf
+      "Ide_bridge.cursor_changed_sink error: keeper=%s error=%s\n%!"
+      keeper_id
+      (Printexc.to_string exn)
+;;
+
 let cursor_event_json
     ~keeper_id
     ~file_path
@@ -600,7 +614,9 @@ let ingest_cursor_event_from_hook
         ~turn_id
         ()
     in
-    (try append_cursor ~base_dir:base_path ~partition json
+    (try
+       append_cursor ~base_dir:base_path ~partition json;
+       notify_cursor_changed ~keeper_id
      with exn ->
        Printf.eprintf
          "Ide_bridge.ingest_cursor_event_from_hook error: %s\n%!"
@@ -659,6 +675,7 @@ let ingest_cursor_event
     in
     (try
        append_cursor ~base_dir:base_path ~partition json;
+       notify_cursor_changed ~keeper_id;
        Ok ()
      with exn ->
        Printf.eprintf

--- a/lib/ide/ide_bridge.mli
+++ b/lib/ide/ide_bridge.mli
@@ -34,6 +34,10 @@ val cursor_focus_mode_of_string : string -> string option
 (** Return the canonical cursor focus mode when [mode] is part of the IDE
     cursor contract. *)
 
+val register_cursor_changed_sink : (keeper_id:string -> unit) -> unit
+(** Register the server-push adapter notified after a cursor record is durable.
+    The IDE storage layer does not depend on the server transport. *)
+
 (** Ingest a cursor event from an external source (e.g. editor or LSP).
     Unlike [ingest_cursor_event_from_hook], this does not require a tool hook
     context and uses the provided [source] label as the tool_name field. *)

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -582,6 +582,12 @@ let build_cursor_snapshot state uri ~partition ~keeper_id ~limit ~offset =
 ;;
 
 let add_routes router =
+  Ide_bridge.register_cursor_changed_sink (fun ~keeper_id ->
+    Sse.broadcast
+      (`Assoc
+         [ "type", `String "ide_cursor_changed"
+         ; "keeper_id", `String keeper_id
+         ]));
   Ide_bridge.install_agent_observation_sinks ();
   router
   |> Http.Router.get "/api/v1/ide/observations/snapshot" observation_snapshot_handler
@@ -1152,11 +1158,6 @@ let add_routes router =
                               ()
                           with
                           | Ok () ->
-                            Sse.broadcast
-                              (`Assoc
-                                 [ "type", `String "ide_cursor_changed"
-                                 ; "keeper_id", `String keeper_id
-                                 ]);
                             Http.Response.json_value
                               ~status:`Created
                               ~request

--- a/test/test_ide_bridge.ml
+++ b/test/test_ide_bridge.ml
@@ -234,6 +234,37 @@ let test_cursor_from_hook_uses_real_file_and_line () =
     | _ -> fail "expected one cursor")
 ;;
 
+let test_cursor_from_hook_notifies_after_persist () =
+  with_temp_dir (fun base_dir ->
+    let notified_keeper = ref None in
+    Ide_bridge.register_cursor_changed_sink (fun ~keeper_id ->
+      notified_keeper := Some keeper_id);
+    Fun.protect
+      ~finally:(fun () ->
+        Ide_bridge.register_cursor_changed_sink (fun ~keeper_id:_ -> ()))
+      (fun () ->
+        Ide_bridge.ingest_tool_event_from_hook
+          ~base_path:base_dir
+          ~partition:Ide_paths.Legacy_default
+          ~tool_name:"keeper_ide_annotate"
+          ~keeper_id:"k1"
+          ~turn_id:"turn-7"
+          ~outcome:"ok"
+          ~typed_outcome_str:"progress"
+          ~duration_ms:10.0
+          ~output_text:"annotated"
+          ~input:
+            (`Assoc
+               [ "file_path", `String "lib/test.ml"
+               ; "line_start", `Int 12
+               ; "focus_mode", `String "editing"
+               ]);
+        check (option string) "durable cursor notification keeper" (Some "k1")
+          !notified_keeper;
+        check int "cursor is durable before notification returns" 1
+          (List.length (Ide_bridge.list_cursors ~base_path:base_dir ()))))
+;;
+
 let test_cursor_from_hook_skips_missing_line () =
   with_temp_dir (fun base_dir ->
     let input = `Assoc [ "file_path", `String "lib/test.ml" ] in
@@ -899,6 +930,10 @@ let () =
         ] )
     ; ( "cursor"
       , [ test_case "from hook uses real file and line" `Quick test_cursor_from_hook_uses_real_file_and_line
+        ; test_case
+            "from hook notifies after persist"
+            `Quick
+            test_cursor_from_hook_notifies_after_persist
         ; test_case "from hook skips missing line" `Quick test_cursor_from_hook_skips_missing_line
         ; test_case
             "from hook skips missing focus mode"

--- a/test/test_server_ide_http.ml
+++ b/test/test_server_ide_http.ml
@@ -571,6 +571,45 @@ let test_post_cursors_broadcasts_ws_invalidation () =
         | [] -> fail "POST cursor did not broadcast a websocket invalidation"))
 ;;
 
+let test_hook_cursors_broadcast_ws_invalidation () =
+  with_ide_server (fun ~base_path ~state:_ ~router:_ ->
+    let subscriber_id = "test-hook-cursor-ws-invalidation" in
+    let received = ref [] in
+    Sse.subscribe_external ~id:subscriber_id (fun frame ->
+      received := frame :: !received;
+      true);
+    Fun.protect
+      ~finally:(fun () -> Sse.unsubscribe_external subscriber_id)
+      (fun () ->
+        Ide_bridge.ingest_tool_event_from_hook
+          ~base_path
+          ~partition:Ide_paths.Legacy_default
+          ~tool_name:"keeper_ide_annotate"
+          ~keeper_id:"alice"
+          ~turn_id:"turn-7"
+          ~outcome:"ok"
+          ~typed_outcome_str:"progress"
+          ~duration_ms:10.0
+          ~output_text:"annotated"
+          ~input:
+            (`Assoc
+               [ "file_path", `String "lib/a.ml"
+               ; "line_start", `Int 7
+               ; "focus_mode", `String "editing"
+               ]);
+        match !received with
+        | frame :: _ ->
+          (match Sse.data_payload_of_frame frame with
+           | Error Sse.Missing_data_payload -> fail "hook cursor invalidation frame has no data"
+           | Ok payload ->
+             let json = Yojson.Safe.from_string payload in
+             check string "hook cursor invalidation type" "ide_cursor_changed"
+               (json_string_member "hook cursor invalidation" "type" json);
+             check string "hook cursor invalidation keeper" "alice"
+               (json_string_member "hook cursor invalidation" "keeper_id" json))
+        | [] -> fail "tool-hook cursor did not broadcast a websocket invalidation"))
+;;
+
 let test_post_cursors_honors_canonical_url_scope () =
   with_ide_server (fun ~base_path ~state:_ ~router ->
     let token = create_worker_token base_path "alice" in
@@ -1157,6 +1196,8 @@ let () =
             test_post_cursors_persists_valid_focus_mode
         ; test_case "POST cursor broadcasts WS invalidation" `Quick
             test_post_cursors_broadcasts_ws_invalidation
+        ; test_case "tool-hook cursor broadcasts WS invalidation" `Quick
+            test_hook_cursors_broadcast_ws_invalidation
         ; test_case "POST cursor honors canonical_url scope" `Quick
             test_post_cursors_honors_canonical_url_scope
         ; test_case "POST annotation accepts matching repo scope" `Quick


### PR DESCRIPTION
## Summary
- make WS readiness observable before reconnect recovery reacts to the reconnect counter
- emit ide_cursor_changed only after cursor persistence for both HTTP writes and keeper tool-hook ingestion
- keep the IDE storage layer transport-neutral through a registered server-push sink

## Why
Follow-up to #26878. Post-merge review found that reconnect recovery could be skipped and tool-hook cursor writes lacked the new WS invalidation after the legacy cursor SSE stream was removed.

## Verification
- dashboard lint: pass
- dashboard-ws.test.ts and sse-store.test.ts: 90/90 pass on Node 22
- OCaml parser and ocamlformat checks: pass
- focused Dune build: blocked by unrelated bare Dune processes; exact-head CI is authoritative
