### PR TITLE
fix(keeper): 빈 경우를 아예 말하지 않는다

### DIFF
--- a/config/prompts/keeper.system.md
+++ b/config/prompts/keeper.system.md
@@ -106,15 +106,13 @@ candidate in turn only produces a run of refusals. Handing a Task back is a
 status transition, not a Task-specific tool, and the refusal message names the
 Task you hold but not the way out.
 
-When the board is genuinely empty, that is a fact about supply, not a conclusion
-that there is nothing to do. Your goals, memory, and repositories are still
-there to work from.
+Your goals, memory, and repositories are work surfaces of their own. The Board
+is one of several places work lives, not the register that decides whether work
+exists.
 
-If nothing is actionable after inspecting current state, give a concise no-work
-report as your answer for the turn and stop there. A no-work report is not a
-Board post. The Board carries what another Keeper can act on; an unchanged
-status republished every cycle crowds that view and accumulates in your own
-history without adding a fact. Post when what you found is new.
+The Board carries what another Keeper can act on. Post when what you found is
+new: an unchanged status republished every cycle crowds that view and
+accumulates in your own history without adding a fact.
 
 For a progress or completion claim, name the subject and give the exact Task ID,
 artifact, operation ID, commit, trace, or pull request that proves it.

--- a/test/test_keeper_prompt_metrics.ml
+++ b/test/test_keeper_prompt_metrics.ml
@@ -293,23 +293,24 @@ let test_merged_system_block_keeps_turn_intent_rules () =
     (has_in prompt "Choose the smallest useful action that current evidence supports");
   check bool "task claim is coordination, not authority" true
     (has_in prompt "A Task claim coordinates ownership; it grants no additional authority");
-  check bool "no-work report is a valid outcome" true
-    (has_in prompt "give a concise no-work report");
-  (* The rule said to report and never said where, so the report went to the
-     shared surface. Measured on the live workspace 2026-08-05: every one of
-     the 26 board posts of the preceding 4.7 hours was taskmaster's
-     "[TASKMASTER] Hourly status -- 0 unclaimed", none of them answered, the
-     gap between them shrinking from 85 minutes to 4; the newest comment by
-     then was 9.2 hours old. That keeper's own config already carries the same
-     defect from 2026-07-20, when an unrouted "report" instruction flowed into
-     keeper_task_create and left 272 identical meta-tasks -- naming
-     keeper_broadcast fixed the channel but not the unconditional report, so
-     the flood moved to the Board. [Own_board_posts] is a context layer, so
-     the copies also accumulate in the poster's own history. *)
-  check bool "a no-work report is answered, not posted" true
-    (has_in prompt "A no-work report is not a Board post");
-  check bool "the cost of republishing an unchanged status is stated" true
-    (has_in prompt "an unchanged status republished every cycle crowds that view");
+  (* No empty case is named at all. Naming one -- even to forbid output --
+     creates a branch the keeper must first decide it has reached, and having
+     decided, it reports. Every instance measured on 2026-08-05 has that shape:
+     this prompt's own "give a concise no-work report" produced 26 identical
+     board posts in 4.7 hours; taskmaster's config guard "세상 상태가 지난
+     턴과 같으면 아무것도 하지 않는 것이 정답" did not hold against it; the
+     hourly wake message's "If nothing needs you, say so in one line" runs on
+     six keepers; and 23 of taskmaster's 29 stored memory facts were board
+     snapshots written in place of work. Routing the report (2026-07-20:
+     keeper_task_create -> keeper_broadcast) only moved the flood, because the
+     report itself stayed unconditional -- so the branch is removed rather
+     than rerouted. *)
+  check bool "no empty-case branch is named" false
+    (has_in prompt "no-work report"
+     || has_in prompt "If nothing is actionable"
+     || has_in prompt "there is nothing to do");
+  check bool "the board does not decide whether work exists" true
+    (has_in prompt "not the register that decides whether work exists");
   check bool "posting is tied to newness" true
     (has_in prompt "Post when what you found is new");
   check bool "completion claims name their evidence" true
@@ -340,8 +341,8 @@ let test_system_block_states_product_and_capabilities () =
     (has_in prompt "The Librarian, a system Keeper");
   check bool "communication is stated as load-bearing" true
     (has_in prompt "Communication is the load-bearing part of this system");
-  check bool "empty board is supply, not a verdict" true
-    (has_in prompt "that is a fact about supply, not a conclusion that there is nothing to do")
+  check bool "goals, memory and repositories are work surfaces" true
+    (has_in prompt "Your goals, memory, and repositories are work surfaces of their own")
 
 (* The collaboration surface a keeper is actually given. Board alone exposes
    sixteen keeper-callable tools (post, comment, votes, search, stats, five


### PR DESCRIPTION
#26861 은 보고를 Board 밖으로 옮겼지만 **분기는 남겼다**: `If nothing is actionable ... give a concise no-work report`.

빈 경우를 이름 붙이면 — 보고 위치를 정해도, 출력을 금지해도 — keeper 는 **그 분기에 도달했는지를 먼저 판정**해야 하고, 판정했으면 말한다.

## 라이브 실측 2026-08-05 — 전부 같은 형태다

| 어디 | 문장 | 산출물 |
|---|---|---|
| system prompt | `give a concise no-work report` | board post **26건 / 4.7h**, 간격 85분 → 4분 |
| taskmaster config | `세상 상태가 지난 턴과 같으면 아무것도 하지 않는 것이 정답` | 위 문장을 못 이김 |
| wake message | `If nothing needs you, say so in one line` | 매시간 6 keeper |
| taskmaster memory | — | 29건 중 **23건이 board 스냅샷** (일 대신 기록) |

2026-07-20 에 이미 증명됐다: 보고를 `keeper_task_create` → `keeper_broadcast` 로 **옮기기만** 했더니 meta-task 272건을 남기고 홍수가 Board 로 자리를 옮겼다. 어느 쪽이든 보고가 무조건이었기 때문이다. **그래서 이번엔 옮기지 않고 없앤다.**

## 변경

```diff
-When the board is genuinely empty, that is a fact about supply, not a conclusion
-that there is nothing to do. Your goals, memory, and repositories are still
-there to work from.
-
-If nothing is actionable after inspecting current state, give a concise no-work
-report as your answer for the turn and stop there. A no-work report is not a
-Board post. The Board carries what another Keeper can act on; an unchanged
-status republished every cycle crowds that view and accumulates in your own
-history without adding a fact. Post when what you found is new.
+Your goals, memory, and repositories are work surfaces of their own. The Board
+is one of several places work lives, not the register that decides whether work
+exists.
+
+The Board carries what another Keeper can act on. Post when what you found is
+new: an unchanged status republished every cycle crowds that view and
+accumulates in your own history without adding a fact.
```

인접한 `When the board is genuinely empty` 문장도 같이 뺐다 — 그것도 **비었는지를 먼저 판정**하게 만든다. 같은 내용을 조건 없이 서술한다.

## 테스트는 부재를 단언한다

```ocaml
check bool "no empty-case branch is named" false
  (has_in prompt "no-work report"
   || has_in prompt "If nothing is actionable"
   || has_in prompt "there is nothing to do");
```

#26861 에서 내가 넣은 세 단언(`a no-work report is answered, not posted` 등)은 채널만 좁힌 절반이었고, 이 PR 이 나머지 절반이다.

## 검증

```
test_keeper_prompt_metrics                     22/22 pass
negative control (프롬프트만 되돌림)              FAIL: no empty-case branch is named
ocamlformat --check                            exit 0
```

## 남은 것

wake message `If nothing needs you, say so in one line` 는 `schedules.json` 의 6개 반복 스케줄(`interval_sec: 3600`)이다. 런타임 데이터라 이 PR 범위 밖이고, 프롬프트에서 분기를 없애도 그 문장이 매시간 같은 계약을 다시 건다.

관련: #26861, #26862

🤖 Generated with [Claude Code](https://claude.com/claude-code)
