### PR TITLE
test(keeper): pin the chat stream allowlist and the body the dashboard sends to one file

### DIFF
--- a/contracts/keeper-chat-stream-request-fields.json
+++ b/contracts/keeper-chat-stream-request-fields.json
@@ -1,0 +1,12 @@
+[
+  "name",
+  "message",
+  "user_blocks",
+  "turn_instructions",
+  "surface_context",
+  "channel",
+  "channel_user_id",
+  "channel_user_name",
+  "channel_workspace_id",
+  "attachments"
+]

--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -1,4 +1,29 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// parse_keeper_chat_stream_request rejects any body key outside this list with
+// 400. test_keeper_chat_stream_request_contract pins the file to that parser,
+// so reading it here ties the body we send to the parser that accepts it —
+// #26866 removed a key the dashboard kept sending and nothing caught it until
+// production.
+const readServerAcceptedFields = (): readonly string[] => {
+  const path = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    '../../../contracts/keeper-chat-stream-request-fields.json',
+  )
+  const parsed: unknown = JSON.parse(readFileSync(path, 'utf8'))
+  if (
+    !Array.isArray(parsed)
+    || !parsed.every((field): field is string => typeof field === 'string')
+  ) {
+    throw new Error(`${path} must be an array of strings`)
+  }
+  return parsed
+}
+
+const SERVER_ACCEPTED_FIELDS = readServerAcceptedFields()
 
 const { runOperatorAction, currentDashboardActor } = vi.hoisted(() => ({
   runOperatorAction: vi.fn(),
@@ -1222,6 +1247,52 @@ describe('streamKeeperMessage', () => {
         { type: 'text', text: 'describe this' },
       ],
     })
+  })
+
+  it('sends no field the server rejects as undeclared', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('data: {"type":"RUN_FINISHED"}\n\n', {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    // Every option that can add a key, so the assertion covers the widest body
+    // this function produces rather than whichever subset one call happens to
+    // hit.
+    await streamKeeperMessage('sangsu', 'describe this', {
+      onEvent: () => {},
+      channel: 'copilot',
+      channelWorkspaceId: 'session-7',
+      turnInstructions: 'focus on overview',
+      surfaceContext: {
+        label: 'Overview',
+        route: '/overview',
+        scene: 'fleet view',
+        fields: [{ k: 'run', v: '2/5' }],
+      },
+      attachments: [
+        {
+          id: 'att-img',
+          type: 'image',
+          name: 'screen.png',
+          size: 1024,
+          mimeType: 'image/png',
+          data: 'data:image/png;base64,abc123',
+        },
+      ],
+      userBlocks: [{ type: 'text', text: 'describe this' }],
+    })
+
+    // The exact body shape is asserted by the tests above; this one only asks
+    // whether the server would accept the keys, so it stays a check against the
+    // contract file rather than a third copy of the field list.
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const sent = Object.keys(JSON.parse(String(init.body)) as object)
+    expect(
+      sent.filter(field => !SERVER_ACCEPTED_FIELDS.includes(field)),
+    ).toEqual([])
   })
 
   const stubStaleToken = () => {

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -498,6 +498,24 @@ let keeper_stream_success = function
   | Tool_result.Completed () | Tool_result.Deferred () -> true
   | Tool_result.Failed _ -> false
 
+(* The dashboard builds its request body from this same list, so both sides are
+   pinned to contracts/keeper-chat-stream-request-fields.json:
+   test_keeper_chat_stream_request_contract asserts this list equals the file,
+   and dashboard/src/api/keeper.test.ts asserts the body it sends is a subset of
+   it. #26886 was a field the client sent that this list did not accept. *)
+let chat_stream_request_fields =
+  [ "name"
+  ; "message"
+  ; "user_blocks"
+  ; "turn_instructions"
+  ; "surface_context"
+  ; "channel"
+  ; "channel_user_id"
+  ; "channel_user_name"
+  ; "channel_workspace_id"
+  ; "attachments"
+  ]
+
 let parse_keeper_chat_stream_request body_str =
   try
     let ( let* ) = Result.bind in
@@ -505,19 +523,7 @@ let parse_keeper_chat_stream_request body_str =
     let* fields =
       match json with
       | `Assoc fields ->
-        let allowed =
-          [ "name"
-          ; "message"
-          ; "user_blocks"
-          ; "turn_instructions"
-          ; "surface_context"
-          ; "channel"
-          ; "channel_user_id"
-          ; "channel_user_name"
-          ; "channel_workspace_id"
-          ; "attachments"
-          ]
-        in
+        let allowed = chat_stream_request_fields in
         let keys = List.map fst fields in
         if List.length keys <> List.length (List.sort_uniq String.compare keys)
         then Error "request body must contain unique fields"

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -97,6 +97,12 @@ type keeper_chat_stream_request = {
 
 (** {1 Parsing} *)
 
+val chat_stream_request_fields : string list
+(** Every field {!parse_keeper_chat_stream_request} accepts; any other key is
+    rejected. Exposed so the contract test can pin it to
+    [contracts/keeper-chat-stream-request-fields.json], which the dashboard
+    test reads to check the body it sends stays within this set. *)
+
 val parse_keeper_chat_stream_request :
   string -> (keeper_chat_stream_request, string) result
 (** Parses the HTTP body string into a

--- a/test/dune
+++ b/test/dune
@@ -706,6 +706,15 @@
  (modules test_oas_canonical_delegation)
  (libraries alcotest ast_grep masc_test_deps))
 
+; Reads the contract file the dashboard test also reads, so it is a dep:
+; without it dune keeps a cached pass and the suite never re-runs when the
+; contract changes.
+(test
+ (name test_keeper_chat_stream_request_contract)
+ (modules test_keeper_chat_stream_request_contract)
+ (deps %{workspace_root}/contracts/keeper-chat-stream-request-fields.json)
+ (libraries alcotest masc_test_deps))
+
 (test
  (name test_keeper_structured_output_schema)
  (modules test_keeper_structured_output_schema)

--- a/test/test_keeper_chat_stream_request_contract.ml
+++ b/test/test_keeper_chat_stream_request_contract.ml
@@ -1,0 +1,66 @@
+(* Pins the POST /api/v1/keepers/chat/stream field allowlist to
+   contracts/keeper-chat-stream-request-fields.json, which
+   dashboard/src/api/keeper.test.ts reads to check the body it sends stays
+   within the set. Without a shared file the two sides drift silently: #26866
+   dropped direct_reply from the allowlist while the dashboard kept sending it,
+   and every chat POST returned 400 until #26886. *)
+
+open Alcotest
+
+let contract_path = "contracts/keeper-chat-stream-request-fields.json"
+
+let source_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root when Sys.file_exists root -> root
+  | _ -> Sys.getcwd ()
+;;
+
+let contract_fields () =
+  let path = Filename.concat (source_root ()) contract_path in
+  let ic = open_in_bin path in
+  let contents =
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () -> really_input_string ic (in_channel_length ic))
+  in
+  match Yojson.Safe.from_string contents with
+  | `List entries ->
+    List.map
+      (function
+        | `String field -> field
+        | other ->
+          failf
+            "%s: entry is not a string: %s"
+            contract_path
+            (Yojson.Safe.to_string other))
+      entries
+  | other ->
+    failf
+      "%s: not a JSON array: %s"
+      contract_path
+      (Yojson.Safe.to_string other)
+  | exception Yojson.Json_error message ->
+    failf "%s: invalid json: %s" contract_path message
+;;
+
+(* Order-sensitive: the parser echoes the allowlist verbatim in its rejection
+   message, so a reordering changes what an operator reads in the 400 body. *)
+let test_contract_file_matches_parser_allowlist () =
+  check
+    (list string)
+    "contract file lists exactly the parser's accepted fields"
+    Server_routes_http_keeper_stream.chat_stream_request_fields
+    (contract_fields ())
+;;
+
+let () =
+  run
+    "keeper chat stream request contract"
+    [ ( "allowlist"
+      , [ test_case
+            "contract file matches the parser allowlist"
+            `Quick
+            test_contract_file_matches_parser_allowlist
+        ] )
+    ]
+;;


### PR DESCRIPTION
Closes #26887. #26886 후속.

## 문제

`/api/v1/keepers/chat/stream` 의 허용 필드 목록이 OCaml 에만, 요청 body 가 TypeScript 에만 있었다. 두 사본이 서로를 모르므로 #26866 이 allowlist 에서 `direct_reply` 를 빼는 동안 대시보드는 계속 그 필드를 보냈고, 빌드·타입체크·양쪽 테스트 스위트가 전부 green 인 채로 프로덕션에서만 400 이 났다.

## 방식

`contracts/keeper-chat-stream-request-fields.json` 하나에 목록을 두고 양쪽 테스트가 그 파일을 읽는다.

- `test_keeper_chat_stream_request_contract` — 파일이 `chat_stream_request_fields` 와 **정확히** 일치하는지 (순서 포함. 파서가 400 본문에 이 목록을 그대로 출력하므로 순서도 운영자가 읽는 내용이다)
- `dashboard/src/api/keeper.test.ts` — `streamKeeperMessage` 가 만드는 가장 넓은 body 의 키가 전부 그 파일 안에 있는지

어느 한쪽만 움직이면 스위트가 깨진다. 이번 사고 경로(서버가 필드 제거 → 클라이언트가 계속 송신)는 대시보드 테스트가, 반대 경로(파서만 변경)는 OCaml 테스트가 잡는다.

## 생성기를 두지 않은 이유

원래 후보는 dune rule 로 allowlist 를 JSON 으로 내보내는 것이었다. `lib/` 전체가 `include_subdirs unqualified` 로 묶인 단일 `masc` 라이브러리라, 목록을 출력하는 exe 하나가 전체 링크를 한 번 더 붙인다. 레포에 `(mode promote)` / `(action (diff ...))` 관습도 없다. 커밋된 파일 + 양방향 assertion 이 같은 드리프트를 링크 비용 없이 닫는다.

교환 조건: 필드를 추가/제거할 때 JSON 을 손으로 갱신해야 한다 (생성이면 `dune promote`). 실패 메시지가 무엇을 고칠지 지시한다.

## 검증

worktree `.worktrees/keeper-chat-stream-contract-20260805`:

- `dune exec test/test_keeper_chat_stream_request_contract.exe` — 1 test, pass
- 뮤테이션: 계약 파일에서 `attachments` 제거 → 위 테스트 fail (dune `deps` 배선이 캐시된 pass 를 남기지 않는 것도 이때 확인)
- `dune exec test/test_gate_keeper_backend.exe` — 103 tests, pass (기존 파서 테스트 회귀 없음)
- `ocamlformat --check` — 통과
- `dashboard`: `pnpm typecheck`, `pnpm lint` 통과, `vitest run src/api/keeper.test.ts` 60 passed
- 뮤테이션: `keeper.ts` body 에 `direct_reply: true` 재삽입 → 새 테스트가 `expected [ 'direct_reply' ] to deeply equal []` 로 fail

미검증: 실제 서버 대상 end-to-end POST 는 실행하지 않았다.

## 범위 밖

operator `keeper_message` payload 는 같은 게이트를 걸지 않았다. `operator_control.ml` 이 `payload.message` 만 읽고 나머지 키를 거부하지 않으므로 400 이 나는 계약이 아니다.

RFC-WAIVED: credential / identity / operator control plane / sandbox / hooks / workflow 문서 중 어느 것도 건드리지 않는다. 변경은 기존 allowlist 를 모듈 상수로 올리고 그것을 검증하는 테스트 2개를 추가한 것이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UksSyfEqMKrqAt3b5X31Sv
