### PR TITLE
fix(test): migrate the second IDE SSE subscriber to the callback contract

### DIFF
--- a/test/test_server_ide_http.ml
+++ b/test/test_server_ide_http.ml
@@ -575,9 +575,9 @@ let test_hook_cursors_broadcast_ws_invalidation () =
   with_ide_server (fun ~base_path ~state:_ ~router:_ ->
     let subscriber_id = "test-hook-cursor-ws-invalidation" in
     let received = ref [] in
-    Sse.subscribe_external ~id:subscriber_id (fun frame ->
-      received := frame :: !received;
-      true);
+    Sse.subscribe_external ~id:subscriber_id
+      ~callback:(fun frame -> received := frame :: !received)
+      ();
     Fun.protect
       ~finally:(fun () -> Sse.unsubscribe_external subscriber_id)
       (fun () ->


### PR DESCRIPTION
## 문제

main 이 여전히 빌드되지 않는다. #26896 이 고친 것과 **같은 결함의 두 번째 호출부**가 그 뒤에 새로 들어왔다.

```
File "test/test_server_ide_http.ml", lines 578-580, characters 45-11:
Error: This expression should not be a function, the expected type is unit
```

## 왜 두 번인가

```
5538e6e99c fix(dashboard): preserve ws refresh invariants (#26900)   ← 578행 추가
1e30b25da3 fix(test): migrate the IDE SSE subscriber ... (#26896)    ← 544행 수리
```

#26878 이 legacy SSE transport 를 hard-cut 하면서 시그니처가 바뀌었다:

```ocaml
val subscribe_external :
  id:string -> callback:(string -> unit) -> ?is_alive:(unit -> bool) -> unit -> unit
```

#26896 이 당시 존재하던 유일한 위반(544행)을 고쳤고, 그 뒤 #26900 이 **낡은 관례를 그대로 복사한** 새 호출부를 넣었다. 소비자 미이관이 아니라 옛 형태의 재생산이다.

## 전수

`subscribe_external` 호출 37곳을 전수 확인했다. 위치 인자 + `true` 반환 형태는 이 578행 하나뿐이며, 나머지는 모두 `~callback:` 을 쓴다.

## 검증

```
$ dune build --root . @check
EXIT=0
```

수정 전 같은 명령은 `test/test_server_ide_http.ml` 하나를 오류로 보고했다. 이 커밋으로 main 이 컴파일된다.

RFC-WAIVED: 기존 시그니처로의 테스트 호출부 이관 1건. credential/identity/auth, operator control, keeper sandbox, dashboard credential component, hooks, workflow 문서 어디에도 해당하지 않는다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
