### PR TITLE
fix(test): main 이 컴파일되지 않는 IDE SSE 구독자 1건 계약 정정

### DIFF
--- a/test/test_server_ide_http.ml
+++ b/test/test_server_ide_http.ml
@@ -575,9 +575,9 @@ let test_hook_cursors_broadcast_ws_invalidation () =
   with_ide_server (fun ~base_path ~state:_ ~router:_ ->
     let subscriber_id = "test-hook-cursor-ws-invalidation" in
     let received = ref [] in
-    Sse.subscribe_external ~id:subscriber_id (fun frame ->
-      received := frame :: !received;
-      true);
+    Sse.subscribe_external ~id:subscriber_id
+      ~callback:(fun frame -> received := frame :: !received)
+      ();
     Fun.protect
       ~finally:(fun () -> Sse.unsubscribe_external subscriber_id)
       (fun () ->


### PR DESCRIPTION
## 증상

`origin/main` 이 컴파일되지 않습니다.

```
File "test/test_server_ide_http.ml", lines 578-580, characters 45-11:
578 | .............................................(fun frame ->
579 |       received := frame :: !received;
580 |       true).
Error: This expression should not be a function, the expected type is unit
```

`dune build --root .` 전체에서 나오는 유일한 에러입니다. 나머지 타깃은 전부 통과합니다.

## 원인

```ocaml
(* lib/sse.mli:178 *)
val subscribe_external :
  id:string -> callback:(string -> unit) -> ?is_alive:(unit -> bool) -> unit -> unit
```

`callback` 이 라벨 인자이므로, 위치 인자로 넘긴 함수 리터럴은 맨 끝의 `unit` 자리에 바인딩됩니다. 그래서 "expected type is unit" 이 나옵니다. 반환하던 `true` 는 `~is_alive` 로 분리되기 전의 옛 계약 잔재입니다.

`#26896` 이 같은 파일의 POST-cursor 구독자(544행)를 이 계약으로 옮기면서 hook-cursor 구독자(578행)를 빠뜨렸습니다. 당시 main 은 `#26883` 때문에 이미 red 였고, 이 타깃까지 도달한 실행이 없어서 아무도 잡지 못했습니다.

## 변경

578행을 544행과 바이트 단위로 동일하게 만듭니다.

```ocaml
Sse.subscribe_external ~id:subscriber_id
  ~callback:(fun frame -> received := frame :: !received)
  ();
```

`true` 를 버려도 잃는 동작이 없습니다. 옛 계약의 bool 은 구독 생존 여부였고 지금은 `~is_alive` 가 그 역할을 하며, 이 콜백은 무조건 `true` 를 반환하고 있었습니다 — 즉 기본값 `fun () -> true` 와 같습니다.

## 남은 사이트 확인

`lib/` 와 `test/` 의 `subscribe_external` 호출부를 전수 확인했습니다. 나머지는 전부 `~callback:` 또는 `~is_alive:` 를 씁니다. 옛 계약을 쓰는 마지막 사이트였습니다.

```
lib/server/masc_grpc_service.ml:519       ~id / ~is_alive / ~callback
lib/server/server_mcp_transport_ws.ml:1161 ~id / ~is_alive / ~callback
test/test_sse_external_sub.ml              12 사이트 전부 ~callback:
test/test_ws_transport.ml                   8 사이트 전부 ~callback:
test/test_transport_integration.ml          7 사이트 전부 ~callback:
test/test_keeper_autonomous_turn_source.ml  2 사이트 전부 ~callback:
test/test_mcp_server_eio_call_tool.ml       1 사이트 ~callback:
test/test_keeper_tool_dispatch_runtime.ml   1 사이트 ~callback:
test/test_server_ide_http.ml                2 사이트 (이 PR 로 둘 다 ~callback:)
```

## 검증

- 이 파일이 main 전체 빌드의 유일한 에러였음: `dune build --root . 2>&1 | rg 'File "'` → 1건
- 수정 후 빌드는 요청에 따라 작성자가 직접 확인 예정 (제 쪽에서는 미실행)

`#26896` 이 2개 중 1개만 옮긴 것은 N-of-M 패치지만, 이 PR 은 그 패턴을 반복하는 쪽이 아니라 남은 1개를 채워서 끝내는 쪽입니다. 위 전수 확인이 잔여 0 을 보이는 근거입니다. 호출부 2개를 헬퍼로 묶지 않은 이유는 서로 다른 테스트 함수의 setup 이라, 묶으면 각 테스트가 무엇을 구독하는지 가려지기 때문입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
