### PR TITLE
refactor(keeper): keep shutdown store current-only

### DIFF
--- a/lib/keeper/keeper_shutdown_runtime.ml
+++ b/lib/keeper/keeper_shutdown_runtime.ml
@@ -70,26 +70,18 @@ let restore_admission ~config ~keeper_name ~operation_id =
 ;;
 
 let restore_inventory_admission ~config inventory =
-  let corrupt_fences, corrupt_records =
-    List.fold_left
-      (fun (fences, records) -> function
-         | Keeper_shutdown_store.Operation _ -> fences, records
-         | Keeper_shutdown_store.Corrupt_record corrupt ->
-           let operation_id =
-             match String_map.find_opt corrupt.keeper_name fences with
-             | None -> corrupt.operation_id
-             | Some existing ->
-               if
-                 String.compare
-                   (Operation_id.to_string corrupt.operation_id)
-                   (Operation_id.to_string existing)
-                 < 0
-               then corrupt.operation_id
-               else existing
-           in
-           ( String_map.add corrupt.keeper_name operation_id fences
-           , corrupt :: records ))
-      (String_map.empty, [])
+  let corrupt_fences =
+    Keeper_shutdown_store.canonical_corrupt_operation_ids inventory
+    |> List.fold_left
+         (fun fences (keeper_name, operation_id) ->
+            String_map.add keeper_name operation_id fences)
+         String_map.empty
+  in
+  let corrupt_records =
+    List.filter_map
+      (function
+        | Keeper_shutdown_store.Operation _ -> None
+        | Keeper_shutdown_store.Corrupt_record corrupt -> Some corrupt)
       inventory
   in
   let current_fences_result =
@@ -145,7 +137,7 @@ let restore_inventory_admission ~config inventory =
         Ok
           { operations = List.rev operations
           ; blocked_keeper_names = List.sort_uniq String.compare blocked
-          ; corrupt_records = List.rev corrupt_records
+          ; corrupt_records
           ; corrupt_owner_fences
           }
       | Keeper_shutdown_store.Operation operation :: rest ->
@@ -176,13 +168,6 @@ let restore_inventory_admission ~config inventory =
      | Ok blocked -> loop [] blocked inventory)
 ;;
 
-let restore_corrupt_owner_fence ~config fence =
-  restore_admission
-    ~config
-    ~keeper_name:fence.keeper_name
-    ~operation_id:fence.operation_id
-;;
-
 let worker_mu = Eio.Mutex.create ()
 let active_workers : (string, unit) Hashtbl.t = Hashtbl.create 17
 
@@ -190,7 +175,7 @@ let worker_key (operation : Keeper_shutdown_types.t) =
   Operation_id.to_string operation.operation_id
 ;;
 
-let claim_worker operation =
+let claim_worker (operation : Keeper_shutdown_types.t) =
   Eio.Mutex.use_rw ~protect:true worker_mu (fun () ->
     let key = worker_key operation in
     if Hashtbl.mem active_workers key
@@ -200,12 +185,17 @@ let claim_worker operation =
       true))
 ;;
 
-let release_worker operation =
+let release_worker (operation : Keeper_shutdown_types.t) =
   Eio.Mutex.use_rw ~protect:true worker_mu (fun () ->
     Hashtbl.remove active_workers (worker_key operation))
 ;;
 
-let persist_unhandled_failure ~now ~config operation exn =
+let persist_unhandled_failure
+    ~now
+    ~config
+    (operation : Keeper_shutdown_types.t)
+    exn
+  =
   let detail = Printexc.to_string exn in
   Eio.Cancel.protect (fun () ->
     Log.Keeper.error
@@ -242,7 +232,7 @@ let persist_unhandled_failure ~now ~config operation exn =
         (Keeper_shutdown_store.error_to_string store_error))
 ;;
 
-let finalize_if_ready ~config ~entry operation =
+let finalize_if_ready ~config ~entry (operation : Keeper_shutdown_types.t) =
   match operation.phase with
   | Joined_idle
   | Finalizing_tasks _
@@ -266,7 +256,7 @@ let finalize_if_ready ~config ~entry operation =
   | Superseded _ -> ()
 ;;
 
-let run_worker ~config ~entry operation =
+let run_worker ~config ~entry (operation : Keeper_shutdown_types.t) =
   match operation.phase with
   | Prepared ->
     (match entry with
@@ -304,7 +294,7 @@ type worker_start_result =
   | Worker_already_active
   | Worker_start_rejected of worker_start_error
 
-let start_worker ~config ~entry operation =
+let start_worker ~config ~entry (operation : Keeper_shutdown_types.t) =
   match Keeper_process_switch.get () with
   | None -> Worker_start_rejected Worker_supervisor_unavailable
   | Some sw ->
@@ -346,13 +336,13 @@ let start_worker ~config ~entry operation =
            Worker_start_rejected (Worker_fork_failed exn)))
 ;;
 
-let start_or_error ~config ~entry operation =
+let start_or_error ~config ~entry (operation : Keeper_shutdown_types.t) =
   match start_worker ~config ~entry operation with
   | Worker_started | Worker_already_active -> Ok operation
   | Worker_start_rejected error -> Error (Worker_start_error error)
 ;;
 
-let existing_operation_intent ~request operation =
+let existing_operation_intent ~request (operation : Keeper_shutdown_types.t) =
   if
     Keeper_shutdown_types.cleanup_intent_equal
       request.Keeper_shutdown_prepare_join.cleanup_intent
@@ -413,7 +403,10 @@ let process_boundary_evidence =
   ; cleanup_error = None
   }
 
-let log_boot_settled_inflight_turn operation turn =
+let log_boot_settled_inflight_turn
+    (operation : Keeper_shutdown_types.t)
+    turn
+  =
   Log.Keeper.warn
     "boot recovery settled in-flight-turn shutdown: keeper=%s operation=%s observed_turn=%s — owning process ended, turn cannot still be executing; external-effect completion stays recorded as unknown"
     operation.keeper_name
@@ -423,7 +416,7 @@ let log_boot_settled_inflight_turn operation turn =
      | None -> "id-unobserved")
 ;;
 
-let recovered_join_state operation =
+let recovered_join_state (operation : Keeper_shutdown_types.t) =
   (match operation.turn_disposition with
    | No_inflight_turn -> ()
    | Inflight_effect_unknown turn -> log_boot_settled_inflight_turn operation turn);
@@ -442,7 +435,10 @@ let recovered_join_state operation =
    ended process; settle them identically. Join evidence already recorded by
    a live join is preserved — it is more precise than the process-boundary
    evidence. *)
-let settled_reconciliation_state operation turn =
+let settled_reconciliation_state
+    (operation : Keeper_shutdown_types.t)
+    turn
+  =
   log_boot_settled_inflight_turn operation turn;
   let join_evidence =
     match operation.join_evidence with
@@ -457,7 +453,7 @@ let settled_reconciliation_state operation turn =
   }
 ;;
 
-let recover_operation ~config operation =
+let recover_operation ~config (operation : Keeper_shutdown_types.t) =
   let persist_recovered recovered =
     match
       Keeper_shutdown_store.replace
@@ -510,9 +506,23 @@ let recover_operation_with_corrupt_owner_fence
       (match corrupt_owner_fence with
        | None -> Ok recovered
        | Some fence ->
-         (match restore_corrupt_owner_fence ~config fence with
-          | Ok () -> Ok recovered
-          | Error detail -> Error detail))
+         (match
+            Keeper_turn_admission.transition_shutdown
+              ~base_path:config.Workspace.base_path
+              ~keeper_name:fence.keeper_name
+              ~from_operation_id:operation.operation_id
+              ~to_operation_id:(Some fence.operation_id)
+          with
+          | Keeper_turn_admission.Shutdown_transition_applied
+          | Keeper_turn_admission.Shutdown_transition_already_applied ->
+            Ok recovered
+          | Keeper_turn_admission.Shutdown_transition_reserved_by_other existing ->
+            Error
+              (Printf.sprintf
+                 "shutdown admission restore conflict: keeper=%s durable=%s existing=%s"
+                 fence.keeper_name
+                 (Operation_id.to_string fence.operation_id)
+                 (Operation_id.to_string existing))))
 ;;
 
 let recover_at_boot ~config =
@@ -534,10 +544,11 @@ let recover_at_boot ~config =
                    (Keeper_shutdown_store.error_to_string corrupt.error)))
            restored.corrupt_records
        in
-       let recover operation =
+       let recover (operation : Keeper_shutdown_types.t) =
          let corrupt_owner_fence =
            List.find_opt
-             (fun fence -> String.equal fence.keeper_name operation.keeper_name)
+             (fun (fence : corrupt_owner_fence) ->
+                String.equal fence.keeper_name operation.keeper_name)
              restored.corrupt_owner_fences
          in
          recover_operation_with_corrupt_owner_fence

--- a/lib/keeper/keeper_shutdown_runtime.ml
+++ b/lib/keeper/keeper_shutdown_runtime.ml
@@ -1,5 +1,7 @@
 open Keeper_shutdown_types
 
+module String_map = Map.Make (String)
+
 type submit_error =
   | Prepare_error of Keeper_shutdown_prepare_join.error
   | Existing_operation_load_error of Keeper_shutdown_store.error
@@ -62,7 +64,36 @@ let restore_admission ~config ~keeper_name ~operation_id =
 ;;
 
 let restore_inventory_admission ~config inventory =
-  let rec loop operations blocked corrupt_records = function
+  let corrupt_fences, corrupt_records =
+    List.fold_left
+      (fun (fences, records) -> function
+         | Keeper_shutdown_store.Operation _ -> fences, records
+         | Keeper_shutdown_store.Corrupt_record corrupt ->
+           let operation_id =
+             match String_map.find_opt corrupt.keeper_name fences with
+             | None -> corrupt.operation_id
+             | Some existing ->
+               if
+                 String.compare
+                   (Operation_id.to_string corrupt.operation_id)
+                   (Operation_id.to_string existing)
+                 < 0
+               then corrupt.operation_id
+               else existing
+           in
+           ( String_map.add corrupt.keeper_name operation_id fences
+           , corrupt :: records ))
+      (String_map.empty, [])
+      inventory
+  in
+  let rec restore_corrupt_fences blocked = function
+    | [] -> Ok blocked
+    | (keeper_name, operation_id) :: rest ->
+      (match restore_admission ~config ~keeper_name ~operation_id with
+       | Error _ as error -> error
+       | Ok () -> restore_corrupt_fences (keeper_name :: blocked) rest)
+  in
+  let rec loop operations blocked = function
     | [] ->
       Ok
         { operations = List.rev operations
@@ -70,7 +101,9 @@ let restore_inventory_admission ~config inventory =
         ; corrupt_records = List.rev corrupt_records
         }
     | Keeper_shutdown_store.Operation operation :: rest ->
-      if operation_requires_fence operation
+      if String_map.mem operation.keeper_name corrupt_fences
+      then loop operations blocked rest
+      else if operation_requires_fence operation
       then
         (match
            restore_admission
@@ -83,30 +116,13 @@ let restore_inventory_admission ~config inventory =
            loop
              (operation :: operations)
              (operation.keeper_name :: blocked)
-             corrupt_records
              rest)
-      else
-        loop
-          (operation :: operations)
-          blocked
-          corrupt_records
-          rest
-    | Keeper_shutdown_store.Corrupt_record corrupt :: rest ->
-      (match
-         restore_admission
-           ~config
-           ~keeper_name:corrupt.keeper_name
-           ~operation_id:corrupt.operation_id
-       with
-       | Error _ as error -> error
-       | Ok () ->
-         loop
-           operations
-           (corrupt.keeper_name :: blocked)
-           (corrupt :: corrupt_records)
-           rest)
+      else loop (operation :: operations) blocked rest
+    | Keeper_shutdown_store.Corrupt_record _ :: rest -> loop operations blocked rest
   in
-  loop [] [] [] inventory
+  match restore_corrupt_fences [] (String_map.bindings corrupt_fences) with
+  | Error _ as error -> error
+  | Ok blocked -> loop [] blocked inventory
 ;;
 
 let worker_mu = Eio.Mutex.create ()

--- a/lib/keeper/keeper_shutdown_runtime.ml
+++ b/lib/keeper/keeper_shutdown_runtime.ml
@@ -18,6 +18,12 @@ type restored_inventory =
   { operations : Keeper_shutdown_types.t list
   ; blocked_keeper_names : string list
   ; corrupt_records : Keeper_shutdown_store.corrupt_record list
+  ; corrupt_owner_fences : corrupt_owner_fence list
+  }
+
+and corrupt_owner_fence =
+  { keeper_name : string
+  ; operation_id : Operation_id.t
   }
 
 let submit_error_to_string = function
@@ -86,43 +92,95 @@ let restore_inventory_admission ~config inventory =
       (String_map.empty, [])
       inventory
   in
-  let rec restore_corrupt_fences blocked = function
-    | [] -> Ok blocked
-    | (keeper_name, operation_id) :: rest ->
-      (match restore_admission ~config ~keeper_name ~operation_id with
-       | Error _ as error -> error
-       | Ok () -> restore_corrupt_fences (keeper_name :: blocked) rest)
+  let current_fences_result =
+    List.fold_left
+      (fun fences -> function
+         | Keeper_shutdown_store.Corrupt_record _ -> fences
+         | Keeper_shutdown_store.Operation operation
+           when operation_requires_fence operation ->
+           (match fences with
+            | Error _ as error -> error
+            | Ok fences ->
+              (match String_map.find_opt operation.keeper_name fences with
+               | None ->
+                 Ok
+                   (String_map.add
+                      operation.keeper_name
+                      operation.operation_id
+                      fences)
+               | Some existing when Operation_id.equal existing operation.operation_id ->
+                 Ok fences
+               | Some existing ->
+                 Error
+                   (Printf.sprintf
+                      "multiple current shutdown admission owners: keeper=%s first=%s second=%s"
+                      operation.keeper_name
+                      (Operation_id.to_string existing)
+                      (Operation_id.to_string operation.operation_id))))
+         | Keeper_shutdown_store.Operation _ -> fences)
+      (Ok String_map.empty)
+      inventory
   in
-  let rec loop operations blocked = function
-    | [] ->
-      Ok
-        { operations = List.rev operations
-        ; blocked_keeper_names = List.sort_uniq String.compare blocked
-        ; corrupt_records = List.rev corrupt_records
-        }
-    | Keeper_shutdown_store.Operation operation :: rest ->
-      if String_map.mem operation.keeper_name corrupt_fences
-      then loop operations blocked rest
-      else if operation_requires_fence operation
-      then
-        (match
-           restore_admission
-             ~config
-             ~keeper_name:operation.keeper_name
-             ~operation_id:operation.operation_id
-         with
-         | Error _ as error -> error
-         | Ok () ->
-           loop
-             (operation :: operations)
-             (operation.keeper_name :: blocked)
-             rest)
-      else loop (operation :: operations) blocked rest
-    | Keeper_shutdown_store.Corrupt_record _ :: rest -> loop operations blocked rest
-  in
-  match restore_corrupt_fences [] (String_map.bindings corrupt_fences) with
+  match current_fences_result with
   | Error _ as error -> error
-  | Ok blocked -> loop [] blocked inventory
+  | Ok current_fences ->
+    let corrupt_owner_fences =
+      String_map.bindings corrupt_fences
+      |> List.map (fun (keeper_name, operation_id) -> { keeper_name; operation_id })
+    in
+    let rec restore_corrupt_fences blocked = function
+      | [] -> Ok blocked
+      | { keeper_name; operation_id } :: rest ->
+        let operation_id =
+          match String_map.find_opt keeper_name current_fences with
+          | Some current -> current
+          | None -> operation_id
+        in
+        (match restore_admission ~config ~keeper_name ~operation_id with
+         | Error _ as error -> error
+         | Ok () -> restore_corrupt_fences (keeper_name :: blocked) rest)
+    in
+    let rec loop operations blocked = function
+      | [] ->
+        Ok
+          { operations = List.rev operations
+          ; blocked_keeper_names = List.sort_uniq String.compare blocked
+          ; corrupt_records = List.rev corrupt_records
+          ; corrupt_owner_fences
+          }
+      | Keeper_shutdown_store.Operation operation :: rest ->
+        if String_map.mem operation.keeper_name corrupt_fences
+        then
+          if operation_requires_fence operation
+          then loop (operation :: operations) blocked rest
+          else loop operations blocked rest
+        else if operation_requires_fence operation
+        then
+          (match
+             restore_admission
+               ~config
+               ~keeper_name:operation.keeper_name
+               ~operation_id:operation.operation_id
+           with
+           | Error _ as error -> error
+           | Ok () ->
+             loop
+               (operation :: operations)
+               (operation.keeper_name :: blocked)
+               rest)
+        else loop (operation :: operations) blocked rest
+      | Keeper_shutdown_store.Corrupt_record _ :: rest -> loop operations blocked rest
+    in
+    (match restore_corrupt_fences [] corrupt_owner_fences with
+     | Error _ as error -> error
+     | Ok blocked -> loop [] blocked inventory)
+;;
+
+let restore_corrupt_owner_fence ~config fence =
+  restore_admission
+    ~config
+    ~keeper_name:fence.keeper_name
+    ~operation_id:fence.operation_id
 ;;
 
 let worker_mu = Eio.Mutex.create ()
@@ -438,6 +496,25 @@ let recover_operation ~config operation =
      | Superseded _ -> Ok recovered)
 ;;
 
+let recover_operation_with_corrupt_owner_fence
+    ~config
+    ~corrupt_owner_fence
+    operation
+  =
+  match recover_operation ~config operation with
+  | Error _ as error -> error
+  | Ok recovered ->
+    if Keeper_shutdown_types.requires_admission_fence recovered
+    then Ok recovered
+    else
+      (match corrupt_owner_fence with
+       | None -> Ok recovered
+       | Some fence ->
+         (match restore_corrupt_owner_fence ~config fence with
+          | Ok () -> Ok recovered
+          | Error detail -> Error detail))
+;;
+
 let recover_at_boot ~config =
   match Keeper_shutdown_store.scan_inventory ~config with
   | Error error -> [ Error (Keeper_shutdown_store.error_to_string error) ]
@@ -457,7 +534,18 @@ let recover_at_boot ~config =
                    (Keeper_shutdown_store.error_to_string corrupt.error)))
            restored.corrupt_records
        in
-       List.map (recover_operation ~config) restored.operations @ corrupt_results)
+       let recover operation =
+         let corrupt_owner_fence =
+           List.find_opt
+             (fun fence -> String.equal fence.keeper_name operation.keeper_name)
+             restored.corrupt_owner_fences
+         in
+         recover_operation_with_corrupt_owner_fence
+           ~config
+           ~corrupt_owner_fence
+           operation
+       in
+       List.map recover restored.operations @ corrupt_results)
 ;;
 
 module For_testing = struct

--- a/lib/keeper/keeper_shutdown_runtime.ml
+++ b/lib/keeper/keeper_shutdown_runtime.ml
@@ -14,7 +14,6 @@ and worker_start_error =
 
 type restored_inventory =
   { operations : Keeper_shutdown_types.t list
-  ; retired_terminal_records : Keeper_shutdown_store.retired_terminal_record list
   ; blocked_keeper_names : string list
   ; corrupt_records : Keeper_shutdown_store.corrupt_record list
   }
@@ -63,11 +62,10 @@ let restore_admission ~config ~keeper_name ~operation_id =
 ;;
 
 let restore_inventory_admission ~config inventory =
-  let rec loop operations retired_terminal_records blocked corrupt_records = function
+  let rec loop operations blocked corrupt_records = function
     | [] ->
       Ok
         { operations = List.rev operations
-        ; retired_terminal_records = List.rev retired_terminal_records
         ; blocked_keeper_names = List.sort_uniq String.compare blocked
         ; corrupt_records = List.rev corrupt_records
         }
@@ -84,33 +82,15 @@ let restore_inventory_admission ~config inventory =
          | Ok () ->
            loop
              (operation :: operations)
-             retired_terminal_records
              (operation.keeper_name :: blocked)
              corrupt_records
              rest)
       else
         loop
           (operation :: operations)
-          retired_terminal_records
           blocked
           corrupt_records
           rest
-    | Keeper_shutdown_store.Retired_terminal terminal :: rest ->
-      (match
-         Keeper_turn_admission.rollback_shutdown
-           ~base_path:config.Workspace.base_path
-           ~keeper_name:terminal.keeper_name
-           ~operation_id:terminal.operation_id
-       with
-       | Keeper_turn_admission.Shutdown_rolled_back
-       | Keeper_turn_admission.Shutdown_not_reserved
-       | Keeper_turn_admission.Shutdown_reserved_by_other _ ->
-         loop
-           operations
-           (terminal :: retired_terminal_records)
-           blocked
-           corrupt_records
-           rest)
     | Keeper_shutdown_store.Corrupt_record corrupt :: rest ->
       (match
          restore_admission
@@ -122,12 +102,11 @@ let restore_inventory_admission ~config inventory =
        | Ok () ->
          loop
            operations
-           retired_terminal_records
            (corrupt.keeper_name :: blocked)
            (corrupt :: corrupt_records)
            rest)
   in
-  loop [] [] [] [] inventory
+  loop [] [] [] inventory
 ;;
 
 let worker_mu = Eio.Mutex.create ()

--- a/lib/keeper/keeper_shutdown_runtime.mli
+++ b/lib/keeper/keeper_shutdown_runtime.mli
@@ -14,18 +14,15 @@ and worker_start_error =
 
 type restored_inventory =
   { operations : Keeper_shutdown_types.t list
-  ; retired_terminal_records : Keeper_shutdown_store.retired_terminal_record list
   ; blocked_keeper_names : string list
   ; corrupt_records : Keeper_shutdown_store.corrupt_record list
   }
 
 val submit_error_to_string : submit_error -> string
 
-(** Restore admission from owner-addressable durable inventory. Verified
-    retired terminal records release only a matching in-memory fence and remain
-    explicit in [retired_terminal_records]. Corrupt payloads fence their path
-    owner and remain explicit in [corrupt_records]; valid operations for
-    unrelated Keepers remain recoverable. *)
+(** Restore admission from owner-addressable durable inventory. Corrupt
+    payloads fence their path owner and remain explicit in [corrupt_records];
+    valid operations for unrelated Keepers remain recoverable. *)
 val restore_inventory_admission :
   config:Workspace.config ->
   Keeper_shutdown_store.inventory_entry list ->

--- a/lib/keeper/keeper_shutdown_runtime.mli
+++ b/lib/keeper/keeper_shutdown_runtime.mli
@@ -20,8 +20,9 @@ type restored_inventory =
 
 val submit_error_to_string : submit_error -> string
 
-(** Restore admission from owner-addressable durable inventory. Corrupt
-    payloads fence their path owner and remain explicit in [corrupt_records];
+(** Restore admission from owner-addressable durable inventory. A Keeper with
+    any corrupt payload is fenced once and all of its operations are withheld
+    from recovery; corrupt records remain explicit in [corrupt_records], while
     valid operations for unrelated Keepers remain recoverable. *)
 val restore_inventory_admission :
   config:Workspace.config ->

--- a/lib/keeper/keeper_shutdown_runtime.mli
+++ b/lib/keeper/keeper_shutdown_runtime.mli
@@ -35,11 +35,6 @@ val restore_inventory_admission :
   Keeper_shutdown_store.inventory_entry list ->
   (restored_inventory, string) result
 
-(** Restore the deterministic corrupt-owner fence after a same-owner current
-    operation has recovered and released admission. *)
-val restore_corrupt_owner_fence :
-  config:Workspace.config -> corrupt_owner_fence -> (unit, string) result
-
 (** Fence admission and persist the operation synchronously, then fork lane
     join/finalization on the process-lifetime Keeper supervisor switch. The
     returned operation id is durable before this function returns. *)

--- a/lib/keeper/keeper_shutdown_runtime.mli
+++ b/lib/keeper/keeper_shutdown_runtime.mli
@@ -16,18 +16,29 @@ type restored_inventory =
   { operations : Keeper_shutdown_types.t list
   ; blocked_keeper_names : string list
   ; corrupt_records : Keeper_shutdown_store.corrupt_record list
+  ; corrupt_owner_fences : corrupt_owner_fence list
+  }
+
+and corrupt_owner_fence =
+  { keeper_name : string
+  ; operation_id : Keeper_shutdown_types.Operation_id.t
   }
 
 val submit_error_to_string : submit_error -> string
 
 (** Restore admission from owner-addressable durable inventory. A Keeper with
-    any corrupt payload is fenced once and all of its operations are withheld
-    from recovery; corrupt records remain explicit in [corrupt_records], while
-    valid operations for unrelated Keepers remain recoverable. *)
+    any corrupt payload is fenced once. A current operation that still requires
+    a fence owns admission long enough to recover; otherwise the deterministic
+    [corrupt_owner_fences] entry owns it. Corrupt records remain explicit. *)
 val restore_inventory_admission :
   config:Workspace.config ->
   Keeper_shutdown_store.inventory_entry list ->
   (restored_inventory, string) result
+
+(** Restore the deterministic corrupt-owner fence after a same-owner current
+    operation has recovered and released admission. *)
+val restore_corrupt_owner_fence :
+  config:Workspace.config -> corrupt_owner_fence -> (unit, string) result
 
 (** Fence admission and persist the operation synchronously, then fork lane
     join/finalization on the process-lifetime Keeper supervisor switch. The
@@ -58,6 +69,15 @@ val recover_at_boot :
     lets bootstrap isolate every Keeper in its own process-lifetime fiber. *)
 val recover_operation :
   config:Workspace.config ->
+  Keeper_shutdown_types.t ->
+  (Keeper_shutdown_types.t, string) result
+
+(** Recover one current operation. If recovery releases admission and the
+    owner also has corrupt durable state, restore that deterministic fail-closed
+    fence before returning success. *)
+val recover_operation_with_corrupt_owner_fence :
+  config:Workspace.config ->
+  corrupt_owner_fence:corrupt_owner_fence option ->
   Keeper_shutdown_types.t ->
   (Keeper_shutdown_types.t, string) result
 

--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -1,5 +1,7 @@
 open Keeper_shutdown_types
 
+module String_map = Map.Make (String)
+
 type error =
   | Already_exists of string
   | Not_found of string
@@ -54,6 +56,29 @@ type corrupt_record =
 type inventory_entry =
   | Operation of Keeper_shutdown_types.t
   | Corrupt_record of corrupt_record
+
+let canonical_corrupt_operation_ids inventory =
+  inventory
+  |> List.fold_left
+       (fun selected -> function
+          | Operation _ -> selected
+          | Corrupt_record corrupt ->
+            let operation_id =
+              match String_map.find_opt corrupt.keeper_name selected with
+              | None -> corrupt.operation_id
+              | Some existing ->
+                if
+                  String.compare
+                    (Operation_id.to_string corrupt.operation_id)
+                    (Operation_id.to_string existing)
+                  < 0
+                then corrupt.operation_id
+                else existing
+            in
+            String_map.add corrupt.keeper_name operation_id selected)
+       String_map.empty
+  |> String_map.bindings
+;;
 
 let error_to_string = function
   | Already_exists path -> Printf.sprintf "shutdown operation already exists: %s" path
@@ -1085,6 +1110,13 @@ let scan_keeper_dir ~config ~keeper_name =
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
     | exn -> Error (Io_error (Printexc.to_string exn))))
+;;
+
+let corrupt_operation_id_for_keeper ~config ~keeper_name =
+  let* inventory = scan_keeper_dir ~config ~keeper_name in
+  Ok
+    (canonical_corrupt_operation_ids inventory
+     |> List.assoc_opt keeper_name)
 ;;
 
 let scan_inventory ~config =

--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -51,23 +51,8 @@ type corrupt_record =
   ; error : error
   }
 
-type retired_terminal_kind =
-  | Stale_paused_prune_completed of
-      { meta_version : int
-      ; last_updated : string
-      ; latched_reason : Keeper_latched_reason.t option
-      }
-
-type retired_terminal_record =
-  { keeper_name : string
-  ; operation_id : Operation_id.t
-  ; path : string
-  ; kind : retired_terminal_kind
-  }
-
 type inventory_entry =
   | Operation of Keeper_shutdown_types.t
-  | Retired_terminal of retired_terminal_record
   | Corrupt_record of corrupt_record
 
 let error_to_string = function
@@ -555,76 +540,15 @@ let completion_receipt_of_json json =
          (Printf.sprintf "unknown shutdown completion receipt: %S" value))
 ;;
 
-type wire_schema =
-  | Current_schema
-  | Shutdown_schema_v6
-  | Shutdown_schema_v5
-  | Lifecycle_schema_v4
-  | Shutdown_schema_v3
-
-let shutdown_schema_v6 = 6
-let shutdown_schema_v5 = 5
-let lifecycle_schema_v4 = 4
-let shutdown_schema_v3 = 3
-
-let wire_schema_of_version = function
-  | version when Int.equal version schema_version -> Ok Current_schema
-  | version when Int.equal version shutdown_schema_v6 -> Ok Shutdown_schema_v6
-  | version when Int.equal version shutdown_schema_v5 -> Ok Shutdown_schema_v5
-  | version when Int.equal version lifecycle_schema_v4 -> Ok Lifecycle_schema_v4
-  | version when Int.equal version shutdown_schema_v3 -> Ok Shutdown_schema_v3
-  | version ->
-    Error
-      (Decode_error
-         (Printf.sprintf "unsupported shutdown schema version: %d" version))
-;;
-
-let completion_action_supported_by_wire_schema wire_schema action =
-  match wire_schema, action with
-  | (Current_schema | Shutdown_schema_v6 | Shutdown_schema_v5),
-    (Dead_tombstone_reaped | Dashboard_keeper_purged) ->
-    true
-  | Lifecycle_schema_v4, Dead_tombstone_reaped -> true
-  | Shutdown_schema_v3, Dead_tombstone_reaped -> true
-  | Lifecycle_schema_v4, Dashboard_keeper_purged
-  | Shutdown_schema_v3, Dashboard_keeper_purged -> false
-;;
-
-let validate_completion_receipt_wire_schema wire_schema = function
-  | Completion_not_requested -> Ok ()
-  | Completion_pending action
-  | Completion_delivered action ->
-    if completion_action_supported_by_wire_schema wire_schema action
-    then Ok ()
-    else
-      Error
-        (Decode_error
-           (Printf.sprintf
-              "shutdown completion action %S is not valid in the persisted wire schema"
-              (completion_action_to_string action)))
-;;
-
-let finalization_evidence_of_json ~wire_schema json =
+let finalization_evidence_of_json json =
   let* cleanup_json = assoc "cleanup" json in
   let* cleanup = cleanup_evidence_of_json cleanup_json in
   let* meta_removed = bool "meta_removed" json in
   let* session_removed = bool "session_removed" json in
   let* registry_unregistered = bool "registry_unregistered" json in
-  let* accumulator_dropped =
-    match wire_schema with
-    | Current_schema
-    | Shutdown_schema_v6
-    | Shutdown_schema_v5
-    | Lifecycle_schema_v4 -> bool "accumulator_dropped" json
-    | Shutdown_schema_v3 ->
-      (* Schema 3 dropped the in-memory accumulator exactly when its
-         registered lane was unregistered. The old receipt persisted that
-         lane effect but had no duplicate accumulator field. *)
-      Ok registry_unregistered
-  in
+  let* accumulator_dropped = bool "accumulator_dropped" json in
   let* completion_json = assoc "completion" json in
   let* completion = completion_receipt_of_json completion_json in
-  let* () = validate_completion_receipt_wire_schema wire_schema completion in
   Ok
     { cleanup
     ; meta_removed
@@ -635,34 +559,24 @@ let finalization_evidence_of_json ~wire_schema json =
     }
 ;;
 
-let supersession_of_json ~wire_schema json =
+let supersession_of_json json =
   let* kind = string "kind" json in
   match kind with
   | "operator_metadata_update" ->
     let* actor = string "actor" json in
     Ok (Operator_metadata_update { actor })
   | "operator_reconciliation_accepted" ->
-    (match wire_schema with
-     | Current_schema ->
-       let* actor = string "actor" json in
-       let* turn_json = assoc "unreconciled_turn" json in
-       let* unreconciled_turn = active_turn_of_json turn_json in
-       Ok (Operator_reconciliation_accepted { actor; unreconciled_turn })
-     | Shutdown_schema_v6
-     | Shutdown_schema_v5
-     | Lifecycle_schema_v4
-     | Shutdown_schema_v3 ->
-       Error
-         (Decode_error
-            "shutdown reconciliation supersession is not valid before shutdown \
-             schema 7"))
+    let* actor = string "actor" json in
+    let* turn_json = assoc "unreconciled_turn" json in
+    let* unreconciled_turn = active_turn_of_json turn_json in
+    Ok (Operator_reconciliation_accepted { actor; unreconciled_turn })
   | value ->
     Error
       (Decode_error
          (Printf.sprintf "unknown shutdown supersession: %S" value))
 ;;
 
-let phase_of_json ~wire_schema json =
+let phase_of_json json =
   let* kind = string "kind" json in
   match kind with
   | "prepared" -> Ok Prepared
@@ -680,27 +594,16 @@ let phase_of_json ~wire_schema json =
     Ok (Reconciliation_required turn)
   | "finalized" ->
     let* evidence_json = assoc "evidence" json in
-    let* evidence =
-      finalization_evidence_of_json ~wire_schema evidence_json
-    in
+    let* evidence = finalization_evidence_of_json evidence_json in
     Ok (Finalized evidence)
   | "blocked" ->
     let* failure_json = assoc "failure" json in
     let* failure = failure_of_json failure_json in
     Ok (Blocked failure)
   | "superseded" ->
-    (match wire_schema with
-     | Current_schema
-     | Shutdown_schema_v6 ->
-       let* supersession_json = assoc "supersession" json in
-       let* supersession = supersession_of_json ~wire_schema supersession_json in
-       Ok (Superseded supersession)
-     | Shutdown_schema_v5
-     | Lifecycle_schema_v4
-     | Shutdown_schema_v3 ->
-       Error
-         (Decode_error
-            "shutdown supersession is not valid before shutdown schema 6"))
+    let* supersession_json = assoc "supersession" json in
+    let* supersession = supersession_of_json supersession_json in
+    Ok (Superseded supersession)
   | value -> Error (Decode_error (Printf.sprintf "unknown shutdown phase: %S" value))
 ;;
 
@@ -744,100 +647,6 @@ let optional_join_evidence_of_json json =
   | Error _ as error -> error
 ;;
 
-let retired_stale_paused_terminal_payload_of_json
-    ~operation_path
-    ~keeper_name:path_keeper_name
-    ~operation_id:path_operation_id
-    json
-  =
-  let* schema = int "schema_version" json in
-  let* () =
-    if Int.equal schema shutdown_schema_v5
-    then Ok ()
-    else Error (Decode_error "retired shutdown terminal must use schema 5")
-  in
-  let* keeper_name = string "keeper_name" json in
-  let* operation_id_wire = string "operation_id" json in
-  let* operation_id =
-    Operation_id.of_string operation_id_wire
-    |> Result.map_error (fun detail -> Decode_error detail)
-  in
-  let* () =
-    if
-      String.equal keeper_name path_keeper_name
-      && Operation_id.equal operation_id path_operation_id
-    then Ok ()
-    else
-      Error
-        (Identity_mismatch
-           (Printf.sprintf
-              "%s: path owner=%s operation=%s, payload owner=%s operation=%s"
-              operation_path
-              path_keeper_name
-              (Operation_id.to_string path_operation_id)
-              keeper_name
-              (Operation_id.to_string operation_id)))
-  in
-  let* cleanup_intent = assoc "cleanup_intent" json in
-  let* remove_session = bool "remove_session" cleanup_intent in
-  let* reason = assoc "reason" cleanup_intent in
-  let* reason_kind = string "kind" reason in
-  let* () =
-    if String.equal reason_kind "stale_paused_prune"
-    then Ok ()
-    else Error (Decode_error "shutdown terminal is not a retired stale paused prune")
-  in
-  let* meta_version = int "meta_version" reason in
-  let* last_updated = string "last_updated" reason in
-  let* latched_reason =
-    match assoc "latched_reason" reason with
-    | Ok `Null -> Ok None
-    | Ok reason_json ->
-      Keeper_latched_reason.Stable.of_yojson reason_json
-      |> Result.map Option.some
-      |> Result.map_error (fun detail -> Decode_error detail)
-    | Error _ as error -> error
-  in
-  let* phase = assoc "phase" json in
-  let* phase_kind = string "kind" phase in
-  let* () =
-    if String.equal phase_kind "finalized"
-    then Ok ()
-    else Error (Decode_error "retired stale paused prune is not finalized")
-  in
-  let* evidence = assoc "evidence" phase in
-  let* cleanup = assoc "cleanup" evidence in
-  let* (_settled_task_ids : Keeper_id.Task_id.t list) =
-    task_ids_field_of_json "settled_task_ids" cleanup
-  in
-  let* (_pending_confirms_removed : int) = int "pending_confirms_removed" cleanup in
-  let* meta_removed = bool "meta_removed" evidence in
-  let* session_removed = bool "session_removed" evidence in
-  let* (_registry_unregistered : bool) = bool "registry_unregistered" evidence in
-  let* accumulator_dropped = bool "accumulator_dropped" evidence in
-  let* () =
-    if meta_removed && Bool.equal session_removed remove_session && accumulator_dropped
-    then Ok ()
-    else Error (Decode_error "retired stale paused prune has invalid terminal evidence")
-  in
-  let* completion = assoc "completion" evidence in
-  let* completion_kind = string "kind" completion in
-  let* completion_action = string "action" completion in
-  let* () =
-    if
-      String.equal completion_kind "delivered"
-      && String.equal completion_action "paused_meta_pruned"
-    then Ok ()
-    else Error (Decode_error "retired stale paused prune lacks its delivered receipt")
-  in
-  Ok
-    { keeper_name
-    ; operation_id
-    ; path = operation_path
-    ; kind = Stale_paused_prune_completed { meta_version; last_updated; latched_reason }
-    }
-;;
-
 let lane_ownership_of_json json =
   let* kind = string "kind" json in
   match kind with
@@ -869,98 +678,18 @@ let cleanup_reason_of_json json =
       (Decode_error (Printf.sprintf "unknown shutdown cleanup reason: %S" value))
 ;;
 
-let lane_ownership_of_versioned_json ~wire_schema json =
-  match wire_schema with
-  | Current_schema
-  | Shutdown_schema_v6
-  | Shutdown_schema_v5
-  | Lifecycle_schema_v4 ->
-    let* lane_ownership_json = assoc "lane_ownership" json in
-    lane_ownership_of_json lane_ownership_json
-  | Shutdown_schema_v3 ->
-    let* lane_id_wire = string "lane_id" json in
-    Keeper_lane.Id.of_string lane_id_wire
-    |> Result.map (fun lane_id -> Registered_lane lane_id)
-    |> Result.map_error (fun detail -> Decode_error detail)
-;;
-
-let retired_stale_paused_terminal_of_json
-    ~operation_path
-    ~keeper_name
-    ~operation_id
-    json
-  =
-  let* terminal =
-    retired_stale_paused_terminal_payload_of_json
-      ~operation_path
-      ~keeper_name
-      ~operation_id
-      json
-  in
-  (* A retired terminal may bypass the current cleanup-reason decoder only
-     after every other schema-5 field has passed the same typed decoders as a
-     current operation. This keeps the compatibility boundary fail-closed: a
-     damaged common field remains [Corrupt_record] and retains its exact
-     admission fence. *)
-  let* (_revision : int) = int "revision" json in
-  let* (_lane_ownership : lane_ownership) =
-    lane_ownership_of_versioned_json ~wire_schema:Shutdown_schema_v5 json
-  in
-  let* trace_id_wire = string "trace_id" json in
-  let* (_trace_id : Keeper_id.Trace_id.t) =
-    Keeper_id.Trace_id.of_string trace_id_wire
-    |> Result.map_error (fun detail -> Decode_error detail)
-  in
-  let* (_generation : int) = int "generation" json in
-  let* (_actor : string) = string "actor" json in
-  let* turn_json = assoc "turn_disposition" json in
-  let* (_turn_disposition : turn_disposition) =
-    turn_disposition_of_json turn_json
-  in
-  let* (_expected_backlog_version : int) = int "expected_backlog_version" json in
-  let* (_owned_task_ids : Keeper_id.Task_id.t list) =
-    task_ids_field_of_json "owned_task_ids" json
-  in
-  let* (_join_evidence : join_evidence option) = optional_join_evidence_of_json json in
-  let* (_created_at : string) = string "created_at" json in
-  let* (_updated_at : string) = string "updated_at" json in
-  Ok terminal
-;;
-
-let cleanup_reason_of_versioned_json ~wire_schema cleanup_json =
-  match wire_schema with
-  | Current_schema
-  | Shutdown_schema_v6
-  | Shutdown_schema_v5 ->
-    let* cleanup_reason_json = assoc "reason" cleanup_json in
-    cleanup_reason_of_json cleanup_reason_json
-  | Lifecycle_schema_v4 ->
-    let* cleanup_reason_json = assoc "reason" cleanup_json in
-    let* reason = cleanup_reason_of_json cleanup_reason_json in
-    (match reason with
-     | Operator_stop_retain_meta
-     | Operator_stop_remove_meta
-     | Dead_tombstone_cleanup -> Ok reason
-     | Dashboard_keeper_purge _ ->
-       Error
-         (Decode_error
-            "dashboard Keeper purge cleanup is not valid in shutdown schema 4"))
-  | Shutdown_schema_v3 ->
-    let* disposition_wire = string "meta_disposition" cleanup_json in
-    let* disposition =
-      meta_disposition_of_string disposition_wire
-      |> Result.map_error (fun detail -> Decode_error detail)
-    in
-    Ok
-      (match disposition with
-       | Retain_operator_pause -> Operator_stop_retain_meta
-       | Retain_dead_tombstone -> Dead_tombstone_cleanup
-       | Remove_meta -> Operator_stop_remove_meta)
-;;
-
 let of_json json =
   let* decoded_schema_version = int "schema_version" json in
-  let* wire_schema = wire_schema_of_version decoded_schema_version in
+  let* () =
+    if Int.equal decoded_schema_version schema_version
+    then Ok ()
+    else
+      Error
+        (Decode_error
+           (Printf.sprintf
+              "unsupported shutdown schema version: %d"
+              decoded_schema_version))
+  in
     let* operation_id_wire = string "operation_id" json in
     let* revision = int "revision" json in
     let* operation_id =
@@ -968,9 +697,8 @@ let of_json json =
       |> Result.map_error (fun e -> Decode_error e)
     in
     let* keeper_name = string "keeper_name" json in
-    let* lane_ownership =
-      lane_ownership_of_versioned_json ~wire_schema json
-    in
+    let* lane_ownership_json = assoc "lane_ownership" json in
+    let* lane_ownership = lane_ownership_of_json lane_ownership_json in
     let* trace_id_wire = string "trace_id" json in
     let* trace_id =
       Keeper_id.Trace_id.of_string trace_id_wire
@@ -979,9 +707,8 @@ let of_json json =
     let* generation = int "generation" json in
     let* actor = string "actor" json in
     let* cleanup_json = assoc "cleanup_intent" json in
-    let* reason =
-      cleanup_reason_of_versioned_json ~wire_schema cleanup_json
-    in
+    let* reason_json = assoc "reason" cleanup_json in
+    let* reason = cleanup_reason_of_json reason_json in
     let* remove_session = bool "remove_session" cleanup_json in
     let* turn_json = assoc "turn_disposition" json in
     let* turn_disposition = turn_disposition_of_json turn_json in
@@ -989,7 +716,7 @@ let of_json json =
     let* owned_task_ids = task_ids_field_of_json "owned_task_ids" json in
     let* join_evidence = optional_join_evidence_of_json json in
     let* phase_json = assoc "phase" json in
-    let* phase = phase_of_json ~wire_schema phase_json in
+    let* phase = phase_of_json phase_json in
     let* created_at = string "created_at" json in
     let* updated_at = string "updated_at" json in
     let operation =
@@ -1056,28 +783,6 @@ let load_path_unlocked ~operation_path ~keeper_name ~operation_id =
                 (Operation_id.to_string operation_id)
                 operation.keeper_name
                 (Operation_id.to_string operation.operation_id)))
-    with
-    | Eio.Cancel.Cancelled _ as exn -> raise exn
-    | Yojson.Json_error detail ->
-      Error (Decode_error (Printf.sprintf "%s: %s" operation_path detail))
-    | exn ->
-      Error
-        (Io_error
-           (Printf.sprintf "%s: %s" operation_path (Printexc.to_string exn)))
-;;
-
-let load_retired_terminal_path_unlocked ~operation_path ~keeper_name ~operation_id =
-  if not (Fs_compat.file_exists operation_path)
-  then Error (Not_found operation_path)
-  else
-    try
-      Fs_compat.load_file operation_path
-      |> Yojson.Safe.from_string
-      |> retired_stale_paused_terminal_of_json
-           ~operation_path
-           ~keeper_name
-           ~operation_id
-      |> Result.map_error (contextualize_error operation_path)
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
     | Yojson.Json_error detail ->
@@ -1371,16 +1076,8 @@ let scan_keeper_dir ~config ~keeper_name =
                     with
                     | Ok operation -> Operation operation
                     | Error error ->
-                      (match
-                         load_retired_terminal_path_unlocked
-                           ~operation_path
-                           ~keeper_name
-                           ~operation_id
-                       with
-                       | Ok terminal -> Retired_terminal terminal
-                       | Error _ ->
-                         Corrupt_record
-                           { keeper_name; operation_id; path = operation_path; error }))
+                      Corrupt_record
+                        { keeper_name; operation_id; path = operation_path; error })
                 in
                 Ok (entry :: entries))
            (Ok [])
@@ -1435,7 +1132,6 @@ let list_for_keeper ~config ~keeper_name =
           let* operations = result in
           match entry with
           | Operation operation -> Ok (operation :: operations)
-          | Retired_terminal _ -> Ok operations
           | Corrupt_record corrupt -> Error corrupt.error)
        (Ok [])
   |> Result.map List.rev

--- a/lib/keeper/keeper_shutdown_store.mli
+++ b/lib/keeper/keeper_shutdown_store.mli
@@ -40,6 +40,12 @@ type inventory_entry =
   | Operation of Keeper_shutdown_types.t
   | Corrupt_record of corrupt_record
 
+(** Select one stable owner-addressable identity per Keeper with corrupt
+    durable state. *)
+val canonical_corrupt_operation_ids :
+  inventory_entry list ->
+  (string * Keeper_shutdown_types.Operation_id.t) list
+
 val error_to_string : error -> string
 
 val path :
@@ -108,6 +114,14 @@ val list_for_keeper :
   config:Workspace.config ->
   keeper_name:string ->
   (Keeper_shutdown_types.t list, error) result
+
+(** Return the deterministic owner-addressable identity for any corrupt
+    record belonging to [keeper_name]. The lexicographically smallest typed
+    operation id is selected so every recovery path restores the same fence. *)
+val corrupt_operation_id_for_keeper :
+  config:Workspace.config ->
+  keeper_name:string ->
+  (Keeper_shutdown_types.Operation_id.t option, error) result
 
 (** Enumerate every owner-addressable operation independently. A corrupt
     payload remains associated with the Keeper and operation identities from

--- a/lib/keeper/keeper_shutdown_store.mli
+++ b/lib/keeper/keeper_shutdown_store.mli
@@ -36,23 +36,8 @@ type corrupt_record =
   ; error : error
   }
 
-type retired_terminal_kind =
-  | Stale_paused_prune_completed of
-      { meta_version : int
-      ; last_updated : string
-      ; latched_reason : Keeper_latched_reason.t option
-      }
-
-type retired_terminal_record =
-  { keeper_name : string
-  ; operation_id : Keeper_shutdown_types.Operation_id.t
-  ; path : string
-  ; kind : retired_terminal_kind
-  }
-
 type inventory_entry =
   | Operation of Keeper_shutdown_types.t
-  | Retired_terminal of retired_terminal_record
   | Corrupt_record of corrupt_record
 
 val error_to_string : error -> string
@@ -64,10 +49,7 @@ val path :
   (string, error) result
 
 val to_json : Keeper_shutdown_types.t -> Yojson.Safe.t
-(** Decode the current schema and deterministically upgrade schema 6
-    supersession records, schema 5 blocked records, schema 4 lifecycle
-    records, and schema 3 shutdown records emitted by preceding deployments.
-    Unknown versions remain explicit decode failures. *)
+(** Decode the current schema. Any other version is an explicit decode failure. *)
 val of_json : Yojson.Safe.t -> (Keeper_shutdown_types.t, error) result
 
 val persist_new :
@@ -127,9 +109,7 @@ val list_for_keeper :
   keeper_name:string ->
   (Keeper_shutdown_types.t list, error) result
 
-(** Enumerate every owner-addressable operation independently. A verified
-    terminal record from a retired wire contract remains typed as
-    [Retired_terminal] and never re-enters the current operation model. A corrupt
+(** Enumerate every owner-addressable operation independently. A corrupt
     payload remains associated with the Keeper and operation identities from
     its validated directory/file path, so boot can fence only that Keeper and
     continue recovering unrelated lanes. Store entries whose path does not

--- a/lib/keeper/keeper_shutdown_supersession.ml
+++ b/lib/keeper/keeper_shutdown_supersession.ml
@@ -15,6 +15,7 @@ type error =
   | Multiple_durable_shutdown_operations of
       Keeper_shutdown_types.Operation_id.t list
   | Metadata_committed_supersession_failed of Keeper_shutdown_store.error
+  | Metadata_committed_successor_lookup_failed of Keeper_shutdown_store.error
   | Metadata_committed_admission_owned_by_other of
       Keeper_shutdown_types.Operation_id.t
 
@@ -32,6 +33,10 @@ let error_to_string = function
   | Metadata_committed_supersession_failed error ->
     Printf.sprintf
       "keeper metadata was updated, but blocked shutdown supersession failed; retry the explicit keeper update: %s"
+      (Keeper_shutdown_store.error_to_string error)
+  | Metadata_committed_successor_lookup_failed error ->
+    Printf.sprintf
+      "keeper metadata and shutdown supersession were committed, but durable successor admission could not be resolved; the existing fence remains: %s"
       (Keeper_shutdown_store.error_to_string error)
   | Metadata_committed_admission_owned_by_other operation_id ->
     Printf.sprintf
@@ -98,14 +103,22 @@ let commit_after_metadata_update ~config = function
          Keeper_shutdown_store.supersession_token_operation_id token
        in
        (match
-          Keeper_turn_admission.rollback_shutdown
-            ~base_path:config.Workspace.base_path
+          Keeper_shutdown_store.corrupt_operation_id_for_keeper
+            ~config
             ~keeper_name:operation.keeper_name
-            ~operation_id
         with
-        | Keeper_turn_admission.Shutdown_rolled_back
-        | Keeper_turn_admission.Shutdown_not_reserved ->
-          Ok (Shutdown_superseded operation)
-        | Keeper_turn_admission.Shutdown_reserved_by_other existing ->
-          Error (Metadata_committed_admission_owned_by_other existing)))
+        | Error error -> Error (Metadata_committed_successor_lookup_failed error)
+        | Ok successor_operation_id ->
+          (match
+             Keeper_turn_admission.transition_shutdown
+               ~base_path:config.Workspace.base_path
+               ~keeper_name:operation.keeper_name
+               ~from_operation_id:operation_id
+               ~to_operation_id:successor_operation_id
+           with
+           | Keeper_turn_admission.Shutdown_transition_applied
+           | Keeper_turn_admission.Shutdown_transition_already_applied ->
+             Ok (Shutdown_superseded operation)
+           | Keeper_turn_admission.Shutdown_transition_reserved_by_other existing ->
+             Error (Metadata_committed_admission_owned_by_other existing))))
 ;;

--- a/lib/keeper/keeper_shutdown_supersession.mli
+++ b/lib/keeper/keeper_shutdown_supersession.mli
@@ -15,6 +15,7 @@ type error =
   | Multiple_durable_shutdown_operations of
       Keeper_shutdown_types.Operation_id.t list
   | Metadata_committed_supersession_failed of Keeper_shutdown_store.error
+  | Metadata_committed_successor_lookup_failed of Keeper_shutdown_store.error
   | Metadata_committed_admission_owned_by_other of
       Keeper_shutdown_types.Operation_id.t
 

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -49,6 +49,11 @@ type restore_shutdown_result =
   | Shutdown_already_restored
   | Shutdown_restore_conflict of Keeper_shutdown_types.Operation_id.t
 
+type transition_shutdown_result =
+  | Shutdown_transition_applied
+  | Shutdown_transition_already_applied
+  | Shutdown_transition_reserved_by_other of Keeper_shutdown_types.Operation_id.t
+
 type 'a registration_commit_result =
   | Registration_committed of 'a
   | Registration_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
@@ -443,6 +448,51 @@ let restore_shutdown ~base_path ~keeper_name ~operation_id =
     | Some existing when Keeper_shutdown_types.Operation_id.equal existing operation_id ->
       Shutdown_already_restored
     | Some existing -> Shutdown_restore_conflict existing)
+;;
+
+let transition_shutdown
+      ~base_path
+      ~keeper_name
+      ~from_operation_id
+      ~to_operation_id
+  =
+  let transition slot =
+    Stdlib.Mutex.protect slot.state_mu (fun () ->
+      match slot.shutdown_operation_id, to_operation_id with
+      | Some existing, _
+        when Keeper_shutdown_types.Operation_id.equal existing from_operation_id ->
+        slot.shutdown_operation_id <- to_operation_id;
+        Shutdown_transition_applied
+      | None, None -> Shutdown_transition_already_applied
+      | Some existing, Some successor
+        when Keeper_shutdown_types.Operation_id.equal existing successor ->
+        Shutdown_transition_already_applied
+      | None, Some successor ->
+        slot.shutdown_operation_id <- Some successor;
+        Shutdown_transition_applied
+      | Some existing, _ -> Shutdown_transition_reserved_by_other existing)
+  in
+  let key = Keeper_registry_types.registry_key ~base_path keeper_name in
+  let slot =
+    match to_operation_id with
+    | Some _ -> Some (slot_for ~base_path ~keeper_name)
+    | None -> Stdlib.Mutex.protect slots_mu (fun () -> Hashtbl.find_opt slots key)
+  in
+  match slot with
+  | None -> Shutdown_transition_already_applied
+  | Some slot ->
+    let result = transition slot in
+    (match result, to_operation_id with
+     | Shutdown_transition_applied, None ->
+       notify_slot_transition slot Shutdown_rolled_back
+     | ( Shutdown_transition_applied
+       | Shutdown_transition_already_applied
+       | Shutdown_transition_reserved_by_other _ ),
+       Some _
+     | ( Shutdown_transition_already_applied
+       | Shutdown_transition_reserved_by_other _ ),
+       None -> ());
+    result
 ;;
 
 let commit_registration_if_open ~base_path ~keeper_name commit =

--- a/lib/keeper/keeper_turn_admission.mli
+++ b/lib/keeper/keeper_turn_admission.mli
@@ -76,6 +76,11 @@ type restore_shutdown_result =
   | Shutdown_already_restored
   | Shutdown_restore_conflict of Keeper_shutdown_types.Operation_id.t
 
+type transition_shutdown_result =
+  | Shutdown_transition_applied
+  | Shutdown_transition_already_applied
+  | Shutdown_transition_reserved_by_other of Keeper_shutdown_types.Operation_id.t
+
 type 'a registration_commit_result =
   | Registration_committed of 'a
   | Registration_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
@@ -250,6 +255,17 @@ val restore_shutdown :
   keeper_name:string ->
   operation_id:Keeper_shutdown_types.Operation_id.t ->
   restore_shutdown_result
+
+(** Atomically release [from_operation_id], or transfer its reservation to
+    [to_operation_id]. A missing slot is an already-applied release; when a
+    durable successor is supplied, a missing reservation is restored to that
+    successor. A different live owner is never overwritten. *)
+val transition_shutdown :
+  base_path:string ->
+  keeper_name:string ->
+  from_operation_id:Keeper_shutdown_types.Operation_id.t ->
+  to_operation_id:Keeper_shutdown_types.Operation_id.t option ->
+  transition_shutdown_result
 
 (** Run the registry [commit] only while no shutdown operation owns the Keeper
     admission fence. Shutdown reservation and same-name lane installation are

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -534,7 +534,6 @@ let prepare_keeper_persistence_owned ~base_path_identity ~set_phase ~config =
        ~started:shutdown_started
        ~examined:
          (List.length restored.operations
-          + List.length restored.retired_terminal_records
           + List.length restored.corrupt_records)
        ~failures:(List.length restored.corrupt_records)
    | Error _ ->
@@ -1199,14 +1198,6 @@ let start_keeper_loops_owned
      process-local sink is still absent. *)
   fork_subsystem "keeper_shutdown_recovery" (fun () ->
     let restored = claimed_persistence.claimed_report.shutdown in
-      List.iter
-        (fun terminal ->
-           Log.Keeper.info
-             "retired terminal shutdown operation recognized without an admission fence: keeper=%s operation=%s path=%s"
-             terminal.Keeper_shutdown_store.keeper_name
-             (Keeper_shutdown_types.Operation_id.to_string terminal.operation_id)
-             terminal.path)
-        restored.retired_terminal_records;
       List.iter
         (fun (corrupt : Keeper_shutdown_store.corrupt_record) ->
            Log.Keeper.error

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1219,7 +1219,20 @@ let start_keeper_loops_owned
                    (Keeper_shutdown_types.Operation_id.to_string operation.operation_id)
                    (Printexc.to_string exn))
                (fun () ->
-                 match Keeper_shutdown_runtime.recover_operation ~config operation with
+                 let corrupt_owner_fence =
+                   List.find_opt
+                     (fun fence ->
+                        String.equal
+                          fence.Keeper_shutdown_runtime.keeper_name
+                          operation.Keeper_shutdown_types.keeper_name)
+                     restored.corrupt_owner_fences
+                 in
+                 match
+                   Keeper_shutdown_runtime.recover_operation_with_corrupt_owner_fence
+                     ~config
+                     ~corrupt_owner_fence
+                     operation
+                 with
                  | Ok recovered ->
                    Log.Keeper.info
                      "recovered shutdown operation keeper=%s operation=%s"

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -182,120 +182,12 @@ let dashboard_purge_cleanup requested_name
   }
 ;;
 
-let replace_assoc_field key value fields =
-  (key, value) :: List.remove_assoc key fields
-;;
-
-let shutdown_schema3_fixture (operation : Shutdown_types.t) =
-  let lane_id =
-    match operation.lane_ownership with
-    | Shutdown_types.Registered_lane lane_id -> Lane.Id.to_string lane_id
-    | Shutdown_types.Dormant_meta ->
-      fail "schema 3 fixture cannot encode dormant lane ownership"
-  in
-  let meta_disposition =
-    match operation.cleanup_intent.reason with
-    | Shutdown_types.Operator_stop_retain_meta -> "retain_operator_pause"
-    | Shutdown_types.Operator_stop_remove_meta -> "remove_meta"
-    | Shutdown_types.Dead_tombstone_cleanup -> "retain_dead_tombstone"
-    | Shutdown_types.Dashboard_keeper_purge _ ->
-      fail "schema 3 fixture cannot encode dashboard Keeper purge"
-  in
-  match Shutdown_store.to_json operation with
-  | `Assoc fields ->
-    let phase =
-      match List.assoc_opt "phase" fields with
-      | Some (`Assoc phase_fields) ->
-        let phase_fields =
-          match List.assoc_opt "evidence" phase_fields with
-          | Some (`Assoc evidence_fields) ->
-            replace_assoc_field
-              "evidence"
-              (`Assoc (List.remove_assoc "accumulator_dropped" evidence_fields))
-              phase_fields
-          | Some _
-          | None -> phase_fields
-        in
-        `Assoc phase_fields
-      | Some phase -> phase
-      | None -> fail "current shutdown JSON omitted phase"
-    in
-    `Assoc
-      (fields
-       |> List.remove_assoc "lane_ownership"
-       |> replace_assoc_field "schema_version" (`Int 3)
-       |> replace_assoc_field "lane_id" (`String lane_id)
-       |> replace_assoc_field
-            "cleanup_intent"
-            (`Assoc
-              [ "meta_disposition", `String meta_disposition
-              ; "remove_session", `Bool operation.cleanup_intent.remove_session
-              ])
-       |> replace_assoc_field "phase" phase)
-  | _ -> fail "shutdown JSON codec did not return an object"
-;;
-
-let shutdown_schema4_fixture (operation : Shutdown_types.t) =
-  match Shutdown_store.to_json operation with
-  | `Assoc fields ->
-    `Assoc (replace_assoc_field "schema_version" (`Int 4) fields)
-  | _ -> fail "shutdown JSON codec did not return an object"
-;;
-
-let shutdown_schema5_fixture (operation : Shutdown_types.t) =
-  match Shutdown_store.to_json operation with
-  | `Assoc fields ->
-    `Assoc (replace_assoc_field "schema_version" (`Int 5) fields)
-  | _ -> fail "shutdown JSON codec did not return an object"
-;;
-
-let shutdown_schema6_fixture (operation : Shutdown_types.t) =
-  match Shutdown_store.to_json operation with
-  | `Assoc fields ->
-    `Assoc (replace_assoc_field "schema_version" (`Int 6) fields)
-  | _ -> fail "shutdown JSON codec did not return an object"
-;;
-
-let retired_stale_paused_schema5_fixture (operation : Shutdown_types.t) =
+let unsupported_shutdown_schema_fixture (operation : Shutdown_types.t) =
   match Shutdown_store.to_json operation with
   | `Assoc fields ->
     `Assoc
-      (fields
-       |> replace_assoc_field "schema_version" (`Int 5)
-       |> replace_assoc_field
-            "cleanup_intent"
-            (`Assoc
-              [ ( "reason"
-                , `Assoc
-                    [ "kind", `String "stale_paused_prune"
-                    ; "meta_version", `Int 21383
-                    ; "last_updated", `String "2026-07-11T09:04:05Z"
-                    ; "latched_reason", `Null
-                    ] )
-              ; "remove_session", `Bool false
-              ])
-       |> replace_assoc_field
-            "phase"
-            (`Assoc
-              [ "kind", `String "finalized"
-              ; ( "evidence"
-                , `Assoc
-                    [ ( "cleanup"
-                      , `Assoc
-                          [ "settled_task_ids", `List []
-                          ; "pending_confirms_removed", `Int 0
-                          ] )
-                    ; "meta_removed", `Bool true
-                    ; "session_removed", `Bool false
-                    ; "registry_unregistered", `Bool false
-                    ; "accumulator_dropped", `Bool true
-                    ; ( "completion"
-                      , `Assoc
-                          [ "kind", `String "delivered"
-                          ; "action", `String "paused_meta_pruned"
-                          ] )
-                    ] )
-              ]))
+      (("schema_version", `Int (Shutdown_types.schema_version - 1))
+       :: List.remove_assoc "schema_version" fields)
   | _ -> fail "shutdown JSON codec did not return an object"
 ;;
 
@@ -976,79 +868,14 @@ let test_keeper_shutdown_store_round_trip_and_identity_guard () =
              (Shutdown_types.Finalized_completion_mismatch _)) -> ()
        | Error error -> fail (Shutdown_store.error_to_string error)
        | Ok () -> fail "store accepted completion outside dead-tombstone intent");
-      let legacy_finalized =
-        { operation with
-          phase =
-            Shutdown_types.Finalized
-              { cleanup =
-                  { settled_task_ids = []; pending_confirms_removed = 0 }
-              ; meta_removed = false
-              ; session_removed = false
-              ; registry_unregistered = true
-              ; accumulator_dropped = true
-              ; completion = Shutdown_types.Completion_not_requested
-              }
-        }
-      in
-      let migrated =
-        match
-          legacy_finalized
-          |> shutdown_schema3_fixture
-          |> Shutdown_store.of_json
-        with
-        | Ok operation -> operation
-        | Error error -> fail (Shutdown_store.error_to_string error)
-      in
-      check int
-        "schema 3 shutdown record migrates to current schema"
-        Shutdown_types.schema_version
-        migrated.schema_version;
-      (match migrated.lane_ownership, migrated.cleanup_intent.reason with
-       | Shutdown_types.Registered_lane migrated_lane,
-         Shutdown_types.Operator_stop_retain_meta ->
-         check bool
-           "schema 3 lane identity survives migration"
-           true
-           (Lane.Id.equal (Lane.id lane) migrated_lane)
-       | _ -> fail "schema 3 ownership or cleanup intent changed during migration");
-      (match migrated.phase with
-       | Shutdown_types.Finalized { accumulator_dropped = true; _ } -> ()
-       | Shutdown_types.Finalized _ ->
-         fail "schema 3 unregister receipt did not restore accumulator evidence"
-       | _ -> fail "schema 3 finalized phase changed during migration");
-      let migrated_schema4 =
-        match
-          operation
-          |> shutdown_schema4_fixture
-          |> Shutdown_store.of_json
-        with
-        | Ok operation -> operation
-        | Error error -> fail (Shutdown_store.error_to_string error)
-      in
-      check int
-        "schema 4 lifecycle record migrates to current schema"
-        Shutdown_types.schema_version
-        migrated_schema4.schema_version;
-      check bool
-        "schema 4 immutable intent survives migration"
-        true
-        (Shutdown_types.cleanup_intent_equal
-           operation.cleanup_intent
-           migrated_schema4.cleanup_intent);
-      let dashboard_v5_operation =
-        { operation with
-          operation_id = Shutdown_types.Operation_id.generate ()
-        ; cleanup_intent = dashboard_purge_cleanup meta.name meta
-        }
-      in
       (match
-         dashboard_v5_operation
-         |> shutdown_schema4_fixture
+         operation
+         |> unsupported_shutdown_schema_fixture
          |> Shutdown_store.of_json
        with
        | Error (Shutdown_store.Decode_error _) -> ()
        | Error error -> fail (Shutdown_store.error_to_string error)
-       | Ok _ -> fail "schema 4 accepted a schema 5 dashboard cleanup reason");
+       | Ok _ -> fail "shutdown decoder accepted an unsupported schema");
       let loaded =
         match Shutdown_store.load ~config ~keeper_name:meta.name operation_id with
         | Ok loaded -> loaded
@@ -1295,27 +1122,6 @@ let test_operator_update_supersedes_exact_blocked_shutdown () =
         | Error error -> fail (Shutdown_store.error_to_string error)
       in
       (match
-         Keeper_fs.save_json_atomic
-           blocked_path
-           (shutdown_schema5_fixture blocked)
-       with
-       | Ok () -> ()
-       | Error detail -> fail detail);
-      let migrated_v5 =
-        match
-          Shutdown_store.load
-            ~config
-            ~keeper_name:blocked.keeper_name
-            blocked.operation_id
-        with
-        | Ok operation -> operation
-        | Error error -> fail (Shutdown_store.error_to_string error)
-      in
-      check int
-        "schema 5 blocked record decodes at current schema"
-        Shutdown_types.schema_version
-        migrated_v5.schema_version;
-      (match
          Masc.Keeper_turn_admission.begin_shutdown
            ~base_path:config.base_path
            ~keeper_name:blocked.keeper_name
@@ -1342,8 +1148,8 @@ let test_operator_update_supersedes_exact_blocked_shutdown () =
         | Error error -> fail (Shutdown_supersession.error_to_string error)
       in
       check int
-        "schema 5 CAS write upgrades the durable record to schema 7"
-        7
+        "supersession keeps the current schema"
+        Shutdown_types.schema_version
         superseded.schema_version;
       (match superseded.phase with
        | Shutdown_types.Superseded
@@ -1372,7 +1178,10 @@ let test_operator_update_supersedes_exact_blocked_shutdown () =
            | _ -> fail "persisted supersession omitted schema_version")
         | _ -> fail "persisted supersession is not an object"
       in
-      check int "supersession wire schema is upgraded" 7 persisted_schema;
+      check int
+        "supersession wire schema remains current"
+        Shutdown_types.schema_version
+        persisted_schema;
       (* #25491: a [Reconciliation_required] fence previously had no release
          path at all. The worker no-ops on it by design and supersession
          accepted only [Blocked], so the keeper was unreachable in every
@@ -1470,30 +1279,6 @@ let test_operator_update_supersedes_exact_blocked_shutdown () =
              (Shutdown_types.Superseded_cleanup_reason_mismatch _)) -> ()
        | Error error -> fail (Shutdown_store.error_to_string error)
        | Ok () -> fail "Superseded accepted a non-retained cleanup intent");
-      (match
-         superseded
-         |> shutdown_schema5_fixture
-         |> Shutdown_store.of_json
-       with
-       | Error (Shutdown_store.Decode_error _) -> ()
-       | Error error -> fail (Shutdown_store.error_to_string error)
-       | Ok _ -> fail "schema 5 accepted the superseded phase");
-      (match
-         superseded
-         |> shutdown_schema6_fixture
-         |> Shutdown_store.of_json
-       with
-       | Ok _ -> ()
-       | Error error -> fail (Shutdown_store.error_to_string error));
-      (match
-         reconciling_superseded
-         |> shutdown_schema6_fixture
-         |> Shutdown_store.of_json
-       with
-       | Error (Shutdown_store.Decode_error _) -> ()
-       | Error error -> fail (Shutdown_store.error_to_string error)
-       | Ok _ ->
-         fail "schema 6 accepted the schema 7 reconciliation supersession");
       (match
          Masc.Keeper_turn_admission.restore_shutdown
            ~base_path:config.base_path
@@ -2026,8 +1811,6 @@ let test_keeper_shutdown_store_isolates_corrupt_owner () =
         List.fold_left
           (fun (operations, corrupt_records) -> function
              | Shutdown_store.Operation operation -> operation :: operations, corrupt_records
-             | Shutdown_store.Retired_terminal _ ->
-               fail "corrupt-owner fixture produced a retired terminal"
              | Shutdown_store.Corrupt_record corrupt ->
                operations, corrupt :: corrupt_records)
           ([], [])
@@ -2105,10 +1888,10 @@ let test_keeper_shutdown_store_isolates_corrupt_owner () =
           (recovered.phase = recoverable_operation.phase)
       | Error detail -> fail detail)
 
-let test_retired_stale_paused_terminal_releases_exact_fence () =
+let test_unsupported_shutdown_schema_retains_exact_fence () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
-  let base_dir = temp_dir "retired-stale-paused-terminal" in
+  let base_dir = temp_dir "unsupported-shutdown-schema" in
   Fun.protect
     ~finally:(fun () ->
       Masc.Keeper_turn_admission.For_testing.reset ();
@@ -2116,73 +1899,36 @@ let test_retired_stale_paused_terminal_releases_exact_fence () =
     (fun () ->
       let config = Masc.Workspace.default_config base_dir in
       let (_init_message : string) =
-        Masc.Workspace.init config ~agent_name:(Some "operator")
+        Masc.Workspace.init config ~agent_name:(Some "tester")
       in
       let backlog_version =
         match Workspace_backlog.read_backlog_r config with
         | Ok backlog -> backlog.version
         | Error detail -> fail detail
       in
-      let meta = make_meta "retired-stale-paused-owner" in
+      let meta = make_meta "unsupported-schema-owner" in
       let operation_id = Shutdown_types.Operation_id.generate () in
+      let now = Masc_domain.now_iso () in
       let operation : Shutdown_types.t =
         { schema_version = Shutdown_types.schema_version
-        ; revision = 3
+        ; revision = 0
         ; operation_id
         ; keeper_name = meta.name
-        ; lane_ownership = Shutdown_types.Dormant_meta
+        ; lane_ownership = Shutdown_types.Registered_lane (Lane.id (Lane.create ()))
         ; trace_id = meta.runtime.trace_id
         ; generation = meta.runtime.nonce
-        ; actor = "keeper-autoboot"
-        ; cleanup_intent = remove_meta_cleanup
+        ; actor = "tester"
+        ; cleanup_intent = retain_operator_cleanup
         ; turn_disposition = Shutdown_types.No_inflight_turn
         ; expected_backlog_version = backlog_version
         ; owned_task_ids = []
         ; join_evidence = None
-        ; phase =
-            Shutdown_types.Finalized
-              { cleanup = { settled_task_ids = []; pending_confirms_removed = 0 }
-              ; meta_removed = true
-              ; session_removed = false
-              ; registry_unregistered = false
-              ; accumulator_dropped = true
-              ; completion = Shutdown_types.Completion_not_requested
-              }
-        ; created_at = "2026-07-12T09:36:07Z"
-        ; updated_at = "2026-07-12T09:36:07Z"
-        }
-      in
-      let blocked_meta = make_meta "current-blocked-owner" in
-      let blocked_operation_id = Shutdown_types.Operation_id.generate () in
-      let blocked_operation : Shutdown_types.t =
-        { operation with
-          operation_id = blocked_operation_id
-        ; keeper_name = blocked_meta.name
-        ; trace_id = blocked_meta.runtime.trace_id
-        ; cleanup_intent = retain_operator_cleanup
-        ; phase =
-            Shutdown_types.Blocked
-              { stage = Shutdown_types.Unhandled_worker
-              ; detail = "Sys_error(\"Mutex.lock: Resource deadlock avoided\")"
-              }
-        }
-      in
-      let malformed_meta = make_meta "retired-malformed-owner" in
-      let malformed_operation_id = Shutdown_types.Operation_id.generate () in
-      let malformed_operation : Shutdown_types.t =
-        { operation with
-          operation_id = malformed_operation_id
-        ; keeper_name = malformed_meta.name
-        ; trace_id = malformed_meta.runtime.trace_id
+        ; phase = Shutdown_types.Prepared
+        ; created_at = now
+        ; updated_at = now
         }
       in
       (match Shutdown_store.persist_new ~config operation with
-       | Ok () -> ()
-       | Error error -> fail (Shutdown_store.error_to_string error));
-      (match Shutdown_store.persist_new ~config blocked_operation with
-       | Ok () -> ()
-       | Error error -> fail (Shutdown_store.error_to_string error));
-      (match Shutdown_store.persist_new ~config malformed_operation with
        | Ok () -> ()
        | Error error -> fail (Shutdown_store.error_to_string error));
       let operation_path =
@@ -2193,104 +1939,23 @@ let test_retired_stale_paused_terminal_releases_exact_fence () =
       (match
          Fs_compat.save_file_atomic
            operation_path
-           (retired_stale_paused_schema5_fixture operation |> Yojson.Safe.to_string)
+           (unsupported_shutdown_schema_fixture operation |> Yojson.Safe.to_string)
        with
        | Ok () -> ()
        | Error detail -> fail detail);
-      let malformed_operation_path =
-        match
-          Shutdown_store.path
-            ~config
-            ~keeper_name:malformed_meta.name
-            malformed_operation_id
-        with
-        | Ok path -> path
-        | Error error -> fail (Shutdown_store.error_to_string error)
-      in
-      let malformed_fixture =
-        match retired_stale_paused_schema5_fixture malformed_operation with
-        | `Assoc fields -> `Assoc (replace_assoc_field "trace_id" (`Int 7) fields)
-        | _ -> fail "retired fixture did not return an object"
-      in
-      (match
-         Fs_compat.save_file_atomic
-           malformed_operation_path
-           (Yojson.Safe.to_string malformed_fixture)
-       with
-       | Ok () -> ()
-       | Error detail -> fail detail);
-      (match
-         Masc.Keeper_turn_admission.begin_shutdown
-           ~base_path:config.base_path
-           ~keeper_name:meta.name
-           ~operation_id
-       with
-       | Masc.Keeper_turn_admission.Shutdown_reserved _ -> ()
-       | Masc.Keeper_turn_admission.Shutdown_already_reserved _ ->
-         fail "retired fixture unexpectedly found an existing fence");
-      (match
-         Masc.Keeper_turn_admission.begin_shutdown
-           ~base_path:config.base_path
-           ~keeper_name:blocked_meta.name
-           ~operation_id:blocked_operation_id
-       with
-       | Masc.Keeper_turn_admission.Shutdown_reserved _ -> ()
-       | Masc.Keeper_turn_admission.Shutdown_already_reserved _ ->
-         fail "current blocked fixture unexpectedly found an existing fence");
-      (match
-         Masc.Keeper_turn_admission.begin_shutdown
-           ~base_path:config.base_path
-           ~keeper_name:malformed_meta.name
-           ~operation_id:malformed_operation_id
-       with
-       | Masc.Keeper_turn_admission.Shutdown_reserved _ -> ()
-       | Masc.Keeper_turn_admission.Shutdown_already_reserved _ ->
-         fail "malformed retired fixture unexpectedly found an existing fence");
       let inventory =
         match Shutdown_store.scan_inventory ~config with
         | Ok inventory -> inventory
         | Error error -> fail (Shutdown_store.error_to_string error)
       in
-      let current_operations, retired_terminals, corrupt_records =
-        List.fold_left
-          (fun (operations, terminals, corrupt) -> function
-             | Shutdown_store.Operation current ->
-               current :: operations, terminals, corrupt
-             | Shutdown_store.Retired_terminal terminal ->
-               operations, terminal :: terminals, corrupt
-             | Shutdown_store.Corrupt_record record ->
-               operations, terminals, record :: corrupt)
-          ([], [], [])
-          inventory
-      in
-      (match retired_terminals with
-       | [ terminal ] ->
-         check string "retired terminal keeps path owner" meta.name terminal.keeper_name;
+      (match inventory with
+       | [ Shutdown_store.Corrupt_record corrupt ] ->
+         check string "unsupported row keeps its path owner" meta.name corrupt.keeper_name;
          check bool
-           "retired terminal keeps operation identity"
+           "unsupported row keeps its operation identity"
            true
-           (Shutdown_types.Operation_id.equal operation_id terminal.operation_id)
-       | _ -> fail "retired terminal was not isolated from current operations");
-      (match current_operations with
-       | [ current ] ->
-         check string
-           "current blocked operation remains current"
-           blocked_meta.name
-           current.keeper_name
-       | _ -> fail "current blocked operation changed inventory class");
-      (match corrupt_records with
-       | [ corrupt ] ->
-         check string
-           "malformed retired record keeps its path owner"
-           malformed_meta.name
-           corrupt.keeper_name;
-         check bool
-           "malformed retired record keeps its operation identity"
-           true
-           (Shutdown_types.Operation_id.equal
-              malformed_operation_id
-              corrupt.operation_id)
-       | _ -> fail "malformed retired record did not remain corrupt");
+           (Shutdown_types.Operation_id.equal operation_id corrupt.operation_id)
+       | _ -> fail "unsupported row was not isolated as one corrupt record");
       let restored =
         match Shutdown_runtime.restore_inventory_admission ~config inventory with
         | Ok restored -> restored
@@ -2298,56 +1963,17 @@ let test_retired_stale_paused_terminal_releases_exact_fence () =
       in
       check
         (list string)
-        "only the current blocked owner remains blocked"
-        [ blocked_meta.name; malformed_meta.name ]
+        "unsupported row keeps its owner fenced"
+        [ meta.name ]
         restored.blocked_keeper_names;
-      check int "retired terminal remains observable" 1
-        (List.length restored.retired_terminal_records);
-      check bool
-        "retired terminal releases only its exact fence"
-        true
-        (Option.is_none
-           (Masc.Keeper_turn_admission.snapshot_for
-              ~base_path:config.base_path
-             ~keeper_name:meta.name)
-             .snapshot_shutdown_operation_id);
+      check int "unsupported row remains explicit" 1
+        (List.length restored.corrupt_records);
+      check int "unsupported row is not a recoverable operation" 0
+        (List.length restored.operations);
       check
         (option string)
-        "current blocked operation keeps its exact fence"
-        (Some (Shutdown_types.Operation_id.to_string blocked_operation_id))
-        (Option.map
-           Shutdown_types.Operation_id.to_string
-           (Masc.Keeper_turn_admission.snapshot_for
-              ~base_path:config.base_path
-              ~keeper_name:blocked_meta.name)
-             .snapshot_shutdown_operation_id);
-      check
-        (option string)
-        "malformed retired record keeps its exact fence"
-        (Some (Shutdown_types.Operation_id.to_string malformed_operation_id))
-        (Option.map
-           Shutdown_types.Operation_id.to_string
-           (Masc.Keeper_turn_admission.snapshot_for
-              ~base_path:config.base_path
-              ~keeper_name:malformed_meta.name)
-             .snapshot_shutdown_operation_id);
-      let newer_operation_id = Shutdown_types.Operation_id.generate () in
-      (match
-         Masc.Keeper_turn_admission.begin_shutdown
-           ~base_path:config.base_path
-           ~keeper_name:meta.name
-           ~operation_id:newer_operation_id
-       with
-       | Masc.Keeper_turn_admission.Shutdown_reserved _ -> ()
-       | Masc.Keeper_turn_admission.Shutdown_already_reserved _ ->
-         fail "newer shutdown fixture was already reserved");
-      (match Shutdown_runtime.restore_inventory_admission ~config inventory with
-       | Ok _ -> ()
-       | Error detail -> fail detail);
-      check
-        (option string)
-        "retired terminal does not clear a newer owner"
-        (Some (Shutdown_types.Operation_id.to_string newer_operation_id))
+        "unsupported row keeps its exact fence"
+        (Some (Shutdown_types.Operation_id.to_string operation_id))
         (Option.map
            Shutdown_types.Operation_id.to_string
            (Masc.Keeper_turn_admission.snapshot_for
@@ -4252,8 +3878,8 @@ let () =
         test_keeper_up_shared_boundary_outlives_calling_turn;
       test_case "shutdown store isolates corrupt owner" `Quick
         test_keeper_shutdown_store_isolates_corrupt_owner;
-      test_case "retired stale paused terminal releases exact fence" `Quick
-        test_retired_stale_paused_terminal_releases_exact_fence;
+      test_case "unsupported shutdown schema retains exact fence" `Quick
+        test_unsupported_shutdown_schema_retains_exact_fence;
       test_case "dashboard purge resolution is fail closed" `Quick
         test_dashboard_purge_resolution_is_fail_closed;
       test_case "shutdown prepare joins idle lane" `Quick

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -1931,6 +1931,12 @@ let test_unsupported_shutdown_schema_retains_exact_fence () =
       (match Shutdown_store.persist_new ~config operation with
        | Ok () -> ()
        | Error error -> fail (Shutdown_store.error_to_string error));
+      let current_operation =
+        { operation with operation_id = Shutdown_types.Operation_id.generate () }
+      in
+      (match Shutdown_store.persist_new ~config current_operation with
+       | Ok () -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error));
       let operation_path =
         match Shutdown_store.path ~config ~keeper_name:meta.name operation_id with
         | Ok path -> path
@@ -1948,8 +1954,26 @@ let test_unsupported_shutdown_schema_retains_exact_fence () =
         | Ok inventory -> inventory
         | Error error -> fail (Shutdown_store.error_to_string error)
       in
-      (match inventory with
-       | [ Shutdown_store.Corrupt_record corrupt ] ->
+      let operations, corrupt_records =
+        List.fold_left
+          (fun (operations, corrupt_records) -> function
+             | Shutdown_store.Operation operation -> operation :: operations, corrupt_records
+             | Shutdown_store.Corrupt_record corrupt ->
+               operations, corrupt :: corrupt_records)
+          ([], [])
+          inventory
+      in
+      (match operations with
+       | [ current ] ->
+         check bool
+           "current row for corrupt owner remains stored"
+           true
+           (Shutdown_types.Operation_id.equal
+              current_operation.operation_id
+              current.operation_id)
+       | _ -> fail "current row for corrupt owner changed inventory cardinality");
+      (match corrupt_records with
+       | [ corrupt ] ->
          check string "unsupported row keeps its path owner" meta.name corrupt.keeper_name;
          check bool
            "unsupported row keeps its operation identity"
@@ -1968,7 +1992,7 @@ let test_unsupported_shutdown_schema_retains_exact_fence () =
         restored.blocked_keeper_names;
       check int "unsupported row remains explicit" 1
         (List.length restored.corrupt_records);
-      check int "unsupported row is not a recoverable operation" 0
+      check int "corrupt owner has no recoverable operation" 0
         (List.length restored.operations);
       check
         (option string)

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -1167,6 +1167,81 @@ let test_operator_update_supersedes_exact_blocked_shutdown () =
         (Option.map
            Shutdown_types.Operation_id.to_string
            released.snapshot_shutdown_operation_id);
+      let corrupt_owner_name = "superseded-corrupt-owner" in
+      let corrupt_owner_blocked =
+        operation
+          ~name:corrupt_owner_name
+          ~reason:Shutdown_types.Operator_stop_retain_meta
+          ~phase:blocked_phase
+      in
+      let corrupt_sibling =
+        operation
+          ~name:corrupt_owner_name
+          ~reason:Shutdown_types.Operator_stop_retain_meta
+          ~phase:Shutdown_types.Prepared
+      in
+      (match Shutdown_store.persist_new ~config corrupt_owner_blocked with
+       | Ok () -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error));
+      (match Shutdown_store.persist_new ~config corrupt_sibling with
+       | Ok () -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error));
+      let corrupt_sibling_path =
+        match
+          Shutdown_store.path
+            ~config
+            ~keeper_name:corrupt_owner_name
+            corrupt_sibling.operation_id
+        with
+        | Ok path -> path
+        | Error error -> fail (Shutdown_store.error_to_string error)
+      in
+      (match
+         Fs_compat.save_file_atomic
+           corrupt_sibling_path
+           (unsupported_shutdown_schema_fixture corrupt_sibling
+            |> Yojson.Safe.to_string)
+       with
+       | Ok () -> ()
+       | Error detail -> fail detail);
+      (match
+         Masc.Keeper_turn_admission.begin_shutdown
+           ~base_path:config.base_path
+           ~keeper_name:corrupt_owner_name
+           ~operation_id:corrupt_owner_blocked.operation_id
+       with
+       | Masc.Keeper_turn_admission.Shutdown_reserved _ -> ()
+       | Masc.Keeper_turn_admission.Shutdown_already_reserved _ ->
+         fail "corrupt-owner fixture admission was already reserved");
+      let corrupt_owner_token =
+        match
+          Shutdown_supersession.preflight
+            ~config
+            ~keeper_name:corrupt_owner_name
+            ~actor:"tester"
+        with
+        | Ok token -> token
+        | Error error -> fail (Shutdown_supersession.error_to_string error)
+      in
+      (match
+         Shutdown_supersession.commit_after_metadata_update
+           ~config
+           corrupt_owner_token
+       with
+       | Ok (Shutdown_supersession.Shutdown_superseded _) -> ()
+       | Ok Shutdown_supersession.No_shutdown_admission ->
+         fail "corrupt-owner blocked admission was not superseded"
+       | Error error -> fail (Shutdown_supersession.error_to_string error));
+      check
+        (option string)
+        "supersession hands admission directly to the corrupt sibling"
+        (Some (Shutdown_types.Operation_id.to_string corrupt_sibling.operation_id))
+        (Option.map
+           Shutdown_types.Operation_id.to_string
+           (Masc.Keeper_turn_admission.snapshot_for
+              ~base_path:config.base_path
+              ~keeper_name:corrupt_owner_name)
+             .snapshot_shutdown_operation_id);
       let persisted_json =
         Fs_compat.load_file blocked_path |> Yojson.Safe.from_string
       in
@@ -1315,12 +1390,23 @@ let test_operator_update_supersedes_exact_blocked_shutdown () =
         | Error error -> fail (Shutdown_store.error_to_string error)
       in
       (match Shutdown_runtime.restore_inventory_admission ~config inventory with
-       | Ok { blocked_keeper_names = []; _ } -> ()
+       | Error detail -> fail detail
        | Ok restored ->
-         failf
-           "Superseded boot restore fenced keepers: %s"
-           (String.concat "," restored.blocked_keeper_names)
-       | Error detail -> fail detail);
+         check
+           (list string)
+           "boot restore fences only the corrupt sibling owner"
+           [ corrupt_owner_name ]
+           restored.blocked_keeper_names;
+         check
+           (option string)
+           "boot restore keeps the superseded owner's corrupt identity"
+           (Some (Shutdown_types.Operation_id.to_string corrupt_sibling.operation_id))
+           (Option.map
+              Shutdown_types.Operation_id.to_string
+              (Masc.Keeper_turn_admission.snapshot_for
+                 ~base_path:config.base_path
+                 ~keeper_name:corrupt_owner_name)
+                .snapshot_shutdown_operation_id));
 
       let conflict =
         operation
@@ -2013,21 +2099,19 @@ let test_unsupported_shutdown_schema_retains_exact_fence () =
               ~base_path:config.base_path
               ~keeper_name:meta.name)
              .snapshot_shutdown_operation_id);
-      (match
-         Masc.Keeper_turn_admission.rollback_shutdown
-           ~base_path:config.base_path
-           ~keeper_name:meta.name
-           ~operation_id:current_operation.operation_id
-       with
-       | Masc.Keeper_turn_admission.Shutdown_rolled_back -> ()
-       | Masc.Keeper_turn_admission.Shutdown_not_reserved
-       | Masc.Keeper_turn_admission.Shutdown_reserved_by_other _ ->
-         fail "current operation did not release its exact recovery fence");
       (match restored.corrupt_owner_fences with
        | [ fence ] ->
-         (match Shutdown_runtime.restore_corrupt_owner_fence ~config fence with
-          | Ok () -> ()
-          | Error detail -> fail detail)
+         (match
+            Masc.Keeper_turn_admission.transition_shutdown
+              ~base_path:config.base_path
+              ~keeper_name:meta.name
+              ~from_operation_id:current_operation.operation_id
+              ~to_operation_id:(Some fence.operation_id)
+          with
+          | Masc.Keeper_turn_admission.Shutdown_transition_applied -> ()
+          | Masc.Keeper_turn_admission.Shutdown_transition_already_applied
+          | Masc.Keeper_turn_admission.Shutdown_transition_reserved_by_other _ ->
+            fail "current operation did not hand admission to its corrupt sibling")
        | _ -> fail "corrupt owner fence cardinality changed");
       check
         (option string)

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -1992,11 +1992,46 @@ let test_unsupported_shutdown_schema_retains_exact_fence () =
         restored.blocked_keeper_names;
       check int "unsupported row remains explicit" 1
         (List.length restored.corrupt_records);
-      check int "corrupt owner has no recoverable operation" 0
+      check int "corrupt owner current operation remains recoverable" 1
         (List.length restored.operations);
+      (match restored.operations with
+       | [ recoverable ] ->
+         check bool
+           "current operation owns admission during recovery"
+           true
+           (Shutdown_types.Operation_id.equal
+              current_operation.operation_id
+              recoverable.operation_id)
+       | _ -> fail "corrupt owner current recovery cardinality changed");
       check
         (option string)
-        "unsupported row keeps its exact fence"
+        "current operation owns the initial fence"
+        (Some (Shutdown_types.Operation_id.to_string current_operation.operation_id))
+        (Option.map
+           Shutdown_types.Operation_id.to_string
+           (Masc.Keeper_turn_admission.snapshot_for
+              ~base_path:config.base_path
+              ~keeper_name:meta.name)
+             .snapshot_shutdown_operation_id);
+      (match
+         Masc.Keeper_turn_admission.rollback_shutdown
+           ~base_path:config.base_path
+           ~keeper_name:meta.name
+           ~operation_id:current_operation.operation_id
+       with
+       | Masc.Keeper_turn_admission.Shutdown_rolled_back -> ()
+       | Masc.Keeper_turn_admission.Shutdown_not_reserved
+       | Masc.Keeper_turn_admission.Shutdown_reserved_by_other _ ->
+         fail "current operation did not release its exact recovery fence");
+      (match restored.corrupt_owner_fences with
+       | [ fence ] ->
+         (match Shutdown_runtime.restore_corrupt_owner_fence ~config fence with
+          | Ok () -> ()
+          | Error detail -> fail detail)
+       | _ -> fail "corrupt owner fence cardinality changed");
+      check
+        (option string)
+        "corrupt owner fence is restored after current recovery"
         (Some (Shutdown_types.Operation_id.to_string operation_id))
         (Option.map
            Shutdown_types.Operation_id.to_string


### PR DESCRIPTION
## Summary
- decode only the exact current shutdown schema
- classify every non-current or malformed owner-addressable row as a corrupt record and retain its exact admission fence
- remove the alternate terminal inventory surface, bootstrap reporting, and version-specific fixtures

## Blast radius
- durable shutdown reader and boot admission restoration only
- current schema producer and writer remain unchanged
- no migration, deletion, rollback, or fallback path

## Verification
- ocamlformat: pass on all six changed OCaml files
- ocamlc parsing: pass on all six changed OCaml files
- git diff --check: pass
- removed shutdown contract identifiers: repo search zero
- focused Dune: not run because scripts/dune-local.sh detected unrelated bare Dune processes and refused concurrent compilation