### PR TITLE
fix(keeper): 타입 틀린 write mode 를 overwrite 기본값 대신 거부

### DIFF
--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -1962,20 +1962,24 @@ let handle_file_write_with_outcome
      misspelled {"mode": "apend"} was rejected below — a type error was handled
      more permissively than a value error, in the destructive direction. Read
      the member so a non-string is rejected on the same path as a bad string.
-     An explicit JSON null still reads as absent: [safe_member] returns [`Null]
-     for both, and "null means take the default" is the schema's intent. *)
-  let mode_member = Safe_ops.safe_member "mode" args in
+     Keep absence distinct from an explicit JSON null: the schema permits an
+     omitted optional member, but a present member must be a string. *)
+  let mode_member =
+    match args with
+    | `Assoc members -> List.assoc_opt "mode" members
+    | _ -> None
+  in
   let mode_raw =
     match mode_member with
-    | `String s -> s
-    | `Null -> fs_write_mode_to_string Overwrite
-    | other -> Yojson.Safe.to_string other
+    | None -> fs_write_mode_to_string Overwrite
+    | Some (`String s) -> s
+    | Some other -> Yojson.Safe.to_string other
   in
   let mode_opt =
     match mode_member with
-    | `Null -> Some Overwrite
-    | `String s -> fs_write_mode_of_string_opt s
-    | _ -> None
+    | None -> Some Overwrite
+    | Some (`String s) -> fs_write_mode_of_string_opt s
+    | Some _ -> None
   in
   let after_gate ~confined ~target ~input continue =
     if confined_write_is_keeper_playground ~config ~meta confined

--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -1956,8 +1956,27 @@ let handle_file_write_with_outcome
   in
   let path = Safe_ops.json_string ~default:"" "path" args in
   let content = Safe_ops.json_string ~default:"" "content" args in
-  let mode_raw = Safe_ops.json_string ~default:"overwrite" "mode" args in
-  let mode_opt = fs_write_mode_of_string_opt mode_raw in
+  (* [Safe_ops.json_string] maps "key absent" and "key present but not a
+     string" onto the same default, and that default is the destructive mode.
+     {"mode": ["append"]} therefore reached Overwrite while the merely
+     misspelled {"mode": "apend"} was rejected below — a type error was handled
+     more permissively than a value error, in the destructive direction. Read
+     the member so a non-string is rejected on the same path as a bad string.
+     An explicit JSON null still reads as absent: [safe_member] returns [`Null]
+     for both, and "null means take the default" is the schema's intent. *)
+  let mode_member = Safe_ops.safe_member "mode" args in
+  let mode_raw =
+    match mode_member with
+    | `String s -> s
+    | `Null -> fs_write_mode_to_string Overwrite
+    | other -> Yojson.Safe.to_string other
+  in
+  let mode_opt =
+    match mode_member with
+    | `Null -> Some Overwrite
+    | `String s -> fs_write_mode_of_string_opt s
+    | _ -> None
+  in
   let after_gate ~confined ~target ~input continue =
     if confined_write_is_keeper_playground ~config ~meta confined
     then (

--- a/test/test_keeper_fs_edit_patch.ml
+++ b/test/test_keeper_fs_edit_patch.ml
@@ -917,7 +917,8 @@ let test_int_mode_is_rejected () =
     ~expected_error:(expected_mode_error value)
 
 (* The other half of the contract: absence still takes the documented
-   Overwrite default, and an explicit null reads as absence. *)
+   Overwrite default. A present null is not absence; the schema permits only a
+   string when [mode] is present, so it follows the rejection path above. *)
 let check_mode_defaults_to_overwrite ~label ~args_extra =
   setup @@ fun ~config ~meta ~playground ~publication_recovery ->
   let path = Filename.concat playground (label ^ ".txt") in
@@ -937,9 +938,9 @@ let check_mode_defaults_to_overwrite ~label ~args_extra =
 let test_absent_mode_defaults_to_overwrite () =
   check_mode_defaults_to_overwrite ~label:"absent-mode" ~args_extra:[]
 
-let test_null_mode_defaults_to_overwrite () =
-  check_mode_defaults_to_overwrite ~label:"null-mode"
-    ~args_extra:[ ("mode", `Null) ]
+let test_null_mode_is_rejected () =
+  check_invalid_mode_json_is_rejected ~label:"null-mode" ~mode_json:`Null
+    ~expected_error:(expected_mode_error `Null)
 
 let test_empty_mode_is_rejected () =
   check_invalid_mode_is_rejected ~label:"empty-mode" ~mode:""
@@ -1142,8 +1143,8 @@ let () =
             test_int_mode_is_rejected;
           Alcotest.test_case "absent mode defaults to overwrite" `Quick
             test_absent_mode_defaults_to_overwrite;
-          Alcotest.test_case "null mode defaults to overwrite" `Quick
-            test_null_mode_defaults_to_overwrite;
+          Alcotest.test_case "null mode rejected" `Quick
+            test_null_mode_is_rejected;
           Alcotest.test_case "public Edit uses explicit repo path" `Quick
             test_public_edit_file_uses_explicit_repo_path;
           Alcotest.test_case "public Write uses explicit repo path" `Quick

--- a/test/test_keeper_fs_edit_patch.ml
+++ b/test/test_keeper_fs_edit_patch.ml
@@ -871,7 +871,7 @@ let test_docker_runtime_leaf_swap_preserves_exact_effect () =
     "outside-append-missing"
     (Fs_compat.load_file outside_target)
 
-let check_invalid_mode_is_rejected ~label ~mode ~expected_error =
+let check_invalid_mode_json_is_rejected ~label ~mode_json ~expected_error =
   setup @@ fun ~config ~meta ~playground ~publication_recovery ->
   let path = Filename.concat playground (label ^ ".txt") in
   let raw =
@@ -882,7 +882,7 @@ let check_invalid_mode_is_rejected ~label ~mode ~expected_error =
         (`Assoc
           [
             ("path", `String path);
-            ("mode", `String mode);
+            ("mode", mode_json);
             ("content", `String "fresh");
           ])
       ()
@@ -892,6 +892,54 @@ let check_invalid_mode_is_rejected ~label ~mode ~expected_error =
     (Some expected_error)
     (parse_error raw);
   Alcotest.(check bool) "file not written" false (Fs_compat.file_exists path)
+
+let check_invalid_mode_is_rejected ~label ~mode ~expected_error =
+  check_invalid_mode_json_is_rejected ~label ~mode_json:(`String mode)
+    ~expected_error
+
+(* A mode that is not a string used to miss the rejection above entirely:
+   [Safe_ops.json_string] returned its "overwrite" default for every non-string
+   member, so {"mode": ["append"]} wrote in Overwrite while the misspelled
+   {"mode": "apend"} was refused. These pin the type-wrong value onto the same
+   path as the value-wrong one. *)
+let expected_mode_error value =
+  Printf.sprintf "mode must be one of [overwrite, append, patch], got %S."
+    (Yojson.Safe.to_string value)
+
+let test_list_mode_is_rejected () =
+  let value = `List [ `String "append" ] in
+  check_invalid_mode_json_is_rejected ~label:"list-mode" ~mode_json:value
+    ~expected_error:(expected_mode_error value)
+
+let test_int_mode_is_rejected () =
+  let value = `Int 42 in
+  check_invalid_mode_json_is_rejected ~label:"int-mode" ~mode_json:value
+    ~expected_error:(expected_mode_error value)
+
+(* The other half of the contract: absence still takes the documented
+   Overwrite default, and an explicit null reads as absence. *)
+let check_mode_defaults_to_overwrite ~label ~args_extra =
+  setup @@ fun ~config ~meta ~playground ~publication_recovery ->
+  let path = Filename.concat playground (label ^ ".txt") in
+  let raw =
+    handle_file_write ~turn_sandbox_factory:None ~config
+      ~meta
+      ~publication_recovery
+      ~args:
+        (`Assoc
+          ([ ("path", `String path); ("content", `String "fresh") ] @ args_extra))
+      ()
+  in
+  Alcotest.(check bool) (label ^ " ok=true") true (parse_ok raw);
+  Alcotest.(check bool) "file written" true (Fs_compat.file_exists path);
+  Alcotest.(check string) "overwrite content" "fresh" (Fs_compat.load_file path)
+
+let test_absent_mode_defaults_to_overwrite () =
+  check_mode_defaults_to_overwrite ~label:"absent-mode" ~args_extra:[]
+
+let test_null_mode_defaults_to_overwrite () =
+  check_mode_defaults_to_overwrite ~label:"null-mode"
+    ~args_extra:[ ("mode", `Null) ]
 
 let test_empty_mode_is_rejected () =
   check_invalid_mode_is_rejected ~label:"empty-mode" ~mode:""
@@ -1088,6 +1136,14 @@ let () =
             test_spaces_only_mode_is_rejected;
           Alcotest.test_case "tab-only mode rejected" `Quick
             test_tab_only_mode_is_rejected;
+          Alcotest.test_case "list mode rejected" `Quick
+            test_list_mode_is_rejected;
+          Alcotest.test_case "int mode rejected" `Quick
+            test_int_mode_is_rejected;
+          Alcotest.test_case "absent mode defaults to overwrite" `Quick
+            test_absent_mode_defaults_to_overwrite;
+          Alcotest.test_case "null mode defaults to overwrite" `Quick
+            test_null_mode_defaults_to_overwrite;
           Alcotest.test_case "public Edit uses explicit repo path" `Quick
             test_public_edit_file_uses_explicit_repo_path;
           Alcotest.test_case "public Write uses explicit repo path" `Quick


### PR DESCRIPTION
## 무엇을

`keeper_write_file` 의 `mode` 파싱 경계에서, **타입이 틀린 입력이 값이 틀린 입력보다 관대하게 처리되던 것**을 고칩니다. 그 관대함이 파괴적 쪽이었습니다.

## 왜

```ocaml
(* lib/core/safe_ops.ml:502 *)
let json_string ?(default = "") key json =
  match safe_member key json with
  | `String s -> s
  | _ -> default          (* ← "부재" 와 "String 이 아님" 이 같은 곳으로 *)
```

`keeper_tool_filesystem_runtime.ml:1953` 이 그 기본값으로 `"overwrite"` 를 씁니다:

| 입력 | 경로 | 결과 |
|---|---|---|
| `{"mode":"apend"}` (값 오류) | `` `String `` → `fs_write_mode_of_string_opt` → `None` | **거부** ✓ |
| `{"mode":["append"]}` (타입 오류) | `` `List `` → default `"overwrite"` | **파괴적 덮어쓰기** |
| `{"mode":42}` | `` `Int `` → default | **파괴적 덮어쓰기** |

거부 경로는 이미 잘 만들어져 있습니다 — `Policy_rejection` 과 `"mode must be one of [%s], got %S."` 메시지. 타입 오류가 그 경로에 도달하지 못했을 뿐입니다.

파서 주석이 이미 의도를 적어 놨습니다:

> *Sound partial parser: only canonical mode strings decode to a real variant. **Missing mode defaults before this parser**; explicit empty strings are invalid input.*

부재가 파서 앞에서 기본값을 타야 한다는 건 맞습니다. 문제는 **타입 오류도 파서 앞에서 기본값을 탔다**는 것입니다.

## 어떻게

멤버를 직접 읽어, String 이 아닌 값이 잘못된 String 과 **같은 경로**로 거부되게 합니다.

```ocaml
let mode_member = Safe_ops.safe_member "mode" args in
let mode_opt =
  match mode_member with
  | `Null -> Some Overwrite          (* 부재: 문서화된 기본값 *)
  | `String s -> fs_write_mode_of_string_opt s
  | _ -> None                        (* 타입 오류: 값 오류와 동일 처리 *)
in
```

`mode_raw` 는 거부 메시지의 `got %S` 를 위해 유지하되, 타입 오류일 때 `Yojson.Safe.to_string` 으로 실제 값을 보여줍니다.

명시적 JSON `null` 은 계속 부재로 읽힙니다 — `safe_member` 가 둘 다 `` `Null `` 을 반환하고, "null 은 기본값" 이 스키마 의도이기 때문입니다. 주석에 적었습니다.

## 범위

파싱 경계는 `:1953` 한 곳입니다. `:532` / `:545` 의 `fs_write_mode_of_string_opt mode_raw` 는 이미 검증된 값을 파라미터로 받으므로(`:2141 ~mode_raw:mode_label`, `:2489 ~mode_raw:"patch"`) 손대지 않았습니다.

같은 파일의 다른 `~default:""` (`path`, `content`, `old_string`, `new_string`)는 빈 문자열이 기본값이고 별도 필수 검사가 있어 이 부류가 아닙니다.

## 함께 보고 (이 PR 에 미포함)

`lib/keeper/keeper_tool_ide_runtime.ml:27` 이 같은 형태이고 **더 나쁩니다** — 거부 경로가 아예 없습니다:

```ocaml
let kind_str = Safe_ops.json_string ~default:"Comment" "kind" args in
...
match Agent_observation.annotation_kind_of_string kind_str with
| Some k -> k
| None -> Agent_observation.Comment      (* 이중 기본값, 둘 다 Comment *)
```

`annotation_kind_of_string` 은 대소문자 구분 PascalCase(`"Comment"` / `"Decision"` / `"Question"` / `"Bookmark"`)라 LLM 이 흔히 보내는 `{"kind":"decision"}` 이 **조용히 Comment 로 강등**됩니다. 로그도 거부도 없습니다.

포함하지 않은 이유: 고치는 방향이 제품 결정입니다 — (a) `mode` 처럼 거부하고 유효 값을 알려주기, (b) 대소문자 무시 파싱 후 진짜 미지 값만 거부. LLM 이 소문자를 상시 보낸다면 (a) 는 기존 annotate 호출을 깨뜨립니다. 스키마가 `kind` 를 enum 으로 선언하는지 특정하지 못해 판단을 넘깁니다.

RFC-WAIVED: credential / identity / operator control / hooks 어디에도 해당하지 않습니다. keeper sandbox 인접이지만 샌드박스 경계나 봉쇄 정책을 바꾸지 않고, 파싱 경계에서 잘못된 입력이 거부 경로에 도달하도록 좁히는 변경입니다. 유효 입력의 동작은 불변입니다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
