### PR TITLE
chore: regenerate the prompt golden after #26901

### DIFF
--- a/test/fixtures/keeper_system_prompt/assembled_prompt.golden
+++ b/test/fixtures/keeper_system_prompt/assembled_prompt.golden
@@ -102,15 +102,13 @@ candidate in turn only produces a run of refusals. Handing a Task back is a
 status transition, not a Task-specific tool, and the refusal message names the
 Task you hold but not the way out.
 
-When the board is genuinely empty, that is a fact about supply, not a conclusion
-that there is nothing to do. Your goals, memory, and repositories are still
-there to work from.
+Your goals, memory, and repositories are work surfaces of their own. The Board
+is one of several places work lives, not the register that decides whether work
+exists.
 
-If nothing is actionable after inspecting current state, give a concise no-work
-report as your answer for the turn and stop there. A no-work report is not a
-Board post. The Board carries what another Keeper can act on; an unchanged
-status republished every cycle crowds that view and accumulates in your own
-history without adding a fact. Post when what you found is new.
+The Board carries what another Keeper can act on. Post when what you found is
+new: an unchanged status republished every cycle crowds that view and
+accumulates in your own history without adding a fact.
 
 For a progress or completion claim, name the subject and give the exact Task ID,
 artifact, operation ID, commit, trace, or pull request that proves it.


### PR DESCRIPTION
## 문제

main 의 프롬프트 스위트가 실패한다.

```
expected 8556 bytes, got 8377
```

#26901 (`fix(keeper): state no empty case at all`) 이 `config/prompts/keeper.system.md` 를 고치면서 조립 골든을 갱신하지 않았다. 변경 파일은 프롬프트 asset 과 `test_keeper_prompt_metrics.ml` 두 개였고 픽스처가 빠졌다.

## 변경

골든을 현재 main 의 실제 조립 결과로 재생성했다. 프롬프트 텍스트나 조립 코드는 건드리지 않는다.

재생성본 확인: 드리프트 마커·복구 블록 0건, `<system>` / `<identity_anchor>` / `<workspace>` / `<identity>` 구조 정상.

## 검증

```
$ dune build --root . @test/runtest-test_keeper_system_prompt_bytes \
                     @test/runtest-test_keeper_prompt_metrics
EXIT=0   (FAIL 0건)
```

## 참고

이 골든은 #26830 이 넣었고, 이번이 첫 드리프트 검출이다. 프롬프트를 바꾸는 PR 은 같은 커밋에서 골든을 교체해야 한다 — 실패 메시지가 바이트 길이·최초 분기 오프셋을 주고, 실제 출력을 `<golden>.actual` 로 남긴다.

RFC-WAIVED: 골든 픽스처 재생성 1건. credential/identity/auth, operator control, keeper sandbox, dashboard credential component, hooks, workflow 문서 어디에도 해당하지 않는다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
