### PR TITLE
fix(dashboard): route goal-tree task status through the Variant SSOT

### DIFF
--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -83,7 +83,7 @@ function goalTreeTask(overrides: Partial<GoalTreeTask> = {}): GoalTreeTask {
   return {
     id: 'task-tree',
     title: 'Tree task',
-    status: 'completed',
+    status: 'done',
     status_color: GOAL_FIXTURE_OK_COLOR,
     priority: 2,
     assignee: null,
@@ -1228,7 +1228,36 @@ describe('Work', () => {
         expect(screen.getByTestId('work-view-list').classList.contains('on')).toBe(true)
       })
 
-      it('includes recursive goal tree tasks in KPIs and kanban, normalizing completed to done', () => {
+      // The tree used to speak its own status spelling ("completed" for done,
+      // "pending" for todo) and the frontend translated it. Both sides now use
+      // Masc_domain.task_status_to_string, so the fixture carries the spelling
+      // the backend actually emits and no translation is involved.
+      it('surfaces an unrecognised tree status as unknown instead of translating it', () => {
+        // The removed map silently rewrote a second vocabulary into the first.
+        // With one spelling there is nothing to translate, so a status the
+        // domain never produces must read as unknown and keep its raw text
+        // rather than being guessed into a neighbouring state.
+        goals.value = [
+          { id: 'G-1', title: 'Goal One', priority: 1, phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        ]
+        goalTreeData.value = {
+          tree: [
+            goalTreeNode({
+              id: 'G-1',
+              tasks: [goalTreeTask({ id: 'T-legacy', title: 'Legacy spelling', status: 'completed' })],
+            }),
+          ],
+          summary: emptyGoalTreeSummary({ total_goals: 1, total_tasks: 1 }),
+        }
+
+        render(html`<${Work} />`)
+        fireEvent.click(screen.getByTestId('work-view-kanban'))
+
+        const doneCol = screen.getByTestId('kanban-col-done')
+        expect(doneCol.textContent).not.toContain('Legacy spelling')
+      })
+
+      it('includes recursive goal tree tasks in KPIs and kanban', () => {
         goals.value = [
           { id: 'G-1', title: 'Goal One', priority: 1, phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
           { id: 'G-child', title: 'Child Goal', priority: 2, phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
@@ -1239,14 +1268,14 @@ describe('Work', () => {
             goalTreeNode({
               id: 'G-1',
               tasks: [
-                goalTreeTask({ id: 'T-root', title: 'Root completed task', goal_id: 'G-1', status: 'completed' }),
+                goalTreeTask({ id: 'T-root', title: 'Root completed task', goal_id: 'G-1', status: 'done' }),
               ],
               children: [
                 goalTreeNode({
                   id: 'G-child',
                   title: 'Child Goal',
                   tasks: [
-                    goalTreeTask({ id: 'T-child', title: 'Child completed task', goal_id: 'G-child', status: 'completed' }),
+                    goalTreeTask({ id: 'T-child', title: 'Child completed task', goal_id: 'G-child', status: 'done' }),
                   ],
                 }),
               ],
@@ -1349,7 +1378,7 @@ describe('Work', () => {
             goalTreeNode({
               id: 'G-1',
               tasks: [
-                goalTreeTask({ id: 'T-goal', title: 'Goal store task', goal_id: 'G-1', status: 'completed' }),
+                goalTreeTask({ id: 'T-goal', title: 'Goal store task', goal_id: 'G-1', status: 'done' }),
               ],
             }),
           ],
@@ -1451,11 +1480,11 @@ describe('Work', () => {
           tree: [
             goalTreeNode({
               id: 'G-1',
-              tasks: [goalTreeTask({ id: 'T-1', goal_id: 'G-1', status: 'completed' })],
+              tasks: [goalTreeTask({ id: 'T-1', goal_id: 'G-1', status: 'done' })],
               children: [
                 goalTreeNode({
                   id: 'G-1',
-                  tasks: [goalTreeTask({ id: 'T-2', goal_id: 'G-1', status: 'completed' })],
+                  tasks: [goalTreeTask({ id: 'T-2', goal_id: 'G-1', status: 'done' })],
                 }),
               ],
             }),

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -8,7 +8,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { route, navigate } from '../router'
 import { goals, tasks, keepers, executionTaskTotal } from '../store'
 import { goalTreeData } from '../goal-tree-state'
-import { normalizeTask } from '../store-normalizers'
+import { normalizeTask, normalizeTaskStatus } from '../store-normalizers'
 import { WORK_UNLINKED_GOAL_TITLE } from '../lib/work-copy'
 import { BoardModerationSurface } from './board/board-moderation-surface'
 import { BoardSurface } from './board/board-surface'
@@ -206,20 +206,13 @@ function isClaimableBacklogTask(task: Task): boolean {
   return (task.status ?? 'todo') === 'todo' && !hasTaskAssignee(task)
 }
 
-const GOAL_STORE_TASK_STATUS: Readonly<Record<string, NonNullable<Task['status']>>> = {
-  pending: 'todo',
-  todo: 'todo',
-  claimed: 'claimed',
-  in_progress: 'in_progress',
-  inprogress: 'in_progress',
-  awaiting_verification: 'awaiting_verification',
-  completed: 'done',
-  done: 'done',
-  cancelled: 'cancelled',
-  blocked: 'blocked',
-  paused: 'paused',
-  unknown: 'unknown',
-}
+// The Goal Store tree now speaks the domain's own status spelling
+// (Masc_domain.task_status_to_string), the same one the execution payload uses.
+// This map existed to absorb a second vocabulary — "pending" for todo,
+// "completed" for done — that dashboard_goals_types_accessor emitted on its
+// own. Issues #8412 and #8364 already ruled that emitters must route through
+// the Variant SSOT; the goals path had missed it. With one spelling there is
+// nothing left to translate, so tree statuses parse exactly like execution ones.
 
 interface GoalStoreTaskStatus {
   readonly status: NonNullable<Task['status']>
@@ -228,11 +221,10 @@ interface GoalStoreTaskStatus {
 
 function normalizeGoalStoreTaskStatus(value: unknown): GoalStoreTaskStatus {
   const raw = typeof value === 'string' ? value.trim() : ''
-  const token = raw.toLowerCase()
-  const status = GOAL_STORE_TASK_STATUS[token]
-  return status
-    ? { status, status_raw: status === 'unknown' ? raw : null }
-    : { status: 'unknown', status_raw: raw || null }
+  const status = normalizeTaskStatus(raw)
+  return status === undefined || status === 'unknown'
+    ? { status: 'unknown', status_raw: raw || null }
+    : { status, status_raw: null }
 }
 
 function goalProgressCounts(goalTasks: Task[]): GoalProgressCounts {

--- a/lib/dashboard/dashboard_goals_types.mli
+++ b/lib/dashboard/dashboard_goals_types.mli
@@ -40,7 +40,6 @@ val task_is_linked_to_goal :
 val task_linkage_source_opt :
   ?goal_task_index:(string, string list) Hashtbl.t -> Masc_domain.task -> string -> string option
 val task_assignee : Masc_domain.task -> string option
-val task_status_label : Masc_domain.task -> string
 val task_is_terminal : Masc_domain.task -> bool
 val task_is_done : Masc_domain.task -> bool
 val task_updated_at : Masc_domain.task -> string
@@ -146,7 +145,7 @@ val goal_fsm_to_json :
 (** {1 Color helpers + task tree JSON projection (pure)} *)
 
 val goal_phase_color : Goal_phase.t -> string
-val task_status_color : string -> string
+val task_status_color : Masc_domain.task_status -> string
 
 val task_to_tree_json : Masc_domain.task * string -> Yojson.Safe.t
 val task_summary_to_json : (Masc_domain.task * string) list -> Yojson.Safe.t

--- a/lib/dashboard/dashboard_goals_types_accessor.ml
+++ b/lib/dashboard/dashboard_goals_types_accessor.ml
@@ -59,14 +59,6 @@ let task_linkage_source_opt ?(goal_task_index = Hashtbl.create 0) (task : Masc_d
 let task_assignee (task : Masc_domain.task) : string option =
   Masc_domain.task_assignee_of_status task.task_status
 
-let task_status_label (task : Masc_domain.task) : string =
-  match task.task_status with
-  | Masc_domain.Todo -> "pending"
-  | Masc_domain.Claimed _ -> "claimed"
-  | Masc_domain.InProgress _ -> "in_progress"
-  | Masc_domain.AwaitingVerification _ -> "awaiting_verification"
-  | Masc_domain.Done _ -> "completed"
-  | Masc_domain.Cancelled _ -> "cancelled"
 
 let task_is_terminal (task : Masc_domain.task) : bool =
   Masc_domain.task_status_is_terminal task.task_status

--- a/lib/dashboard/dashboard_goals_types_accessor.mli
+++ b/lib/dashboard/dashboard_goals_types_accessor.mli
@@ -40,7 +40,6 @@ val task_is_linked_to_goal :
 val task_linkage_source_opt :
   ?goal_task_index:(string, string list) Hashtbl.t -> Masc_domain.task -> string -> string option
 val task_assignee : Masc_domain.task -> string option
-val task_status_label : Masc_domain.task -> string
 val task_is_terminal : Masc_domain.task -> bool
 val task_is_done : Masc_domain.task -> bool
 val task_updated_at : Masc_domain.task -> string

--- a/lib/dashboard/dashboard_goals_types_timeline.ml
+++ b/lib/dashboard/dashboard_goals_types_timeline.ml
@@ -23,24 +23,27 @@ let goal_phase_color = function
   | Goal_phase.Completed -> "#60a5fa"
   | Goal_phase.Dropped -> "#6b7280"
 
-let task_status_color status_label =
-  match status_label with
-  | "pending" -> "#6b7280"
-  | "claimed" -> "#f59e0b"
-  | "in_progress" -> "#3b82f6"
-  | "awaiting_verification" -> "#a78bfa"
-  | "completed" -> "#4ade80"
-  | "cancelled" -> "#ef4444"
-  | _ -> "#888888"
+(* Exhaustive on [task_status], not a string match with a grey catch-all. The
+   catch-all silently absorbed every label it did not recognise, which is how a
+   second status vocabulary survived here: "pending"/"completed" coloured fine
+   while the SSOT spelling "todo"/"done" fell through to grey. A new status now
+   breaks this match instead of rendering as unknown. *)
+let task_status_color (status : Masc_domain.task_status) =
+  match status with
+  | Masc_domain.Todo -> "#6b7280"
+  | Masc_domain.Claimed _ -> "#f59e0b"
+  | Masc_domain.InProgress _ -> "#3b82f6"
+  | Masc_domain.AwaitingVerification _ -> "#a78bfa"
+  | Masc_domain.Done _ -> "#4ade80"
+  | Masc_domain.Cancelled _ -> "#ef4444"
 
 let task_to_tree_json ((task, linkage_source) : Masc_domain.task * string) =
-  let status = task_status_label task in
   `Assoc
     ([
       ("id", `String task.id);
       ("title", `String task.title);
-      ("status", `String status);
-      ("status_color", `String (task_status_color status));
+      ("status", `String (Masc_domain.task_status_to_string task.task_status));
+      ("status_color", `String (task_status_color task.task_status));
       ("priority", `Int task.priority);
       ("assignee", Json_util.string_opt_to_json (task_assignee task));
       ("linkage_source", `String linkage_source);
@@ -103,14 +106,19 @@ let task_summary_to_json tasks =
   let unassigned_count = ref 0 in
   List.iter
     (fun ((task, linkage_source) : Masc_domain.task * string) ->
-      let status = task_status_label task in
-      bump by_status status;
+      bump by_status (Masc_domain.task_status_to_string task.task_status);
       bump by_linkage_source linkage_source;
       if task_is_done task then incr done_count;
       if task_is_terminal task then incr terminal_count else incr open_count;
-      if String.equal status "awaiting_verification" then
-        incr awaiting_verification_count;
-      if String.equal status "cancelled" then incr cancelled_count;
+      (* One exhaustive match over the variant instead of two string equalities
+         against a label that had its own spelling. *)
+      (match task.task_status with
+       | Masc_domain.AwaitingVerification _ -> incr awaiting_verification_count
+       | Masc_domain.Cancelled _ -> incr cancelled_count
+       | Masc_domain.Todo
+       | Masc_domain.Claimed _
+       | Masc_domain.InProgress _
+       | Masc_domain.Done _ -> ());
       match task_assignee task with None -> incr unassigned_count | Some _ -> ())
     tasks;
   let total = List.length tasks in
@@ -255,7 +263,7 @@ let build_goal_timeline node linked_keepers approvals goal_events =
   let task_events =
     node.tasks
     |> List.map (fun ((task, linkage_source) : Masc_domain.task * string) ->
-           let status = task_status_label task in
+           let status = Masc_domain.task_status_to_string task.task_status in
            timeline_event_json ~ts:(task_updated_at task) ~kind:"task"
              ~lane:("task:" ^ task.id)
              ~title:task.title

--- a/lib/dashboard/dashboard_goals_types_timeline.mli
+++ b/lib/dashboard/dashboard_goals_types_timeline.mli
@@ -3,7 +3,7 @@
 open Dashboard_goals_types_accessor
 
 val goal_phase_color : Goal_phase.t -> string
-val task_status_color : string -> string
+val task_status_color : Masc_domain.task_status -> string
 
 val task_to_tree_json : Masc_domain.task * string -> Yojson.Safe.t
 val task_summary_to_json : (Masc_domain.task * string) list -> Yojson.Safe.t


### PR DESCRIPTION
## 목표

Goal 경로가 task 상태를 자기 철자로 부르던 것을 Variant SSOT 하나로 되돌린다.

## 문제

`dashboard_goals_types_accessor.task_status_label` 이 `Todo → "pending"`, `Done → "completed"` 를 내보냈다. 나머지 20개 모듈은 `Masc_domain.task_status_to_string` (`"todo"`, `"done"`) 을 쓴다.

이 판정은 이미 내려져 있었다:

> Issue #8412: previously emitted `status="completed"`, but `Masc_domain.task_status_to_string Done = "done"` — the string "completed" is never produced by the Variant SSOT. Sister bug to #8364. Routing through the Variant guarantees the string matches what every other emitter and parser sees.
> — `lib/response/response.ml:255`

goals 경로만 이 판정을 놓쳤고, 그 결과 프론트에 `GOAL_STORE_TASK_STATUS` 12항목 번역 맵이 생겼다 — 같은 6개 상태의 철자 3벌을 다시 하나로 접는 맵이다.

## 왜 살아남았나

`task_status_color` 가 **label 문자열**에 매치하면서 `_ -> "#888888"` catch-all 을 갖고 있었다. 두 번째 어휘는 색이 제대로 나오고, SSOT 철자였다면 회색으로 떨어졌을 것이다. catch-all 이 분기를 보이지 않게 유지했다.

## 변경

| 대상 | 조치 |
|---|---|
| `task_status_label` (goals) | 삭제. 호출부는 `Masc_domain.task_status_to_string` |
| `task_status_color` | `string -> string` → `task_status -> string`, exhaustive (catch-all 제거) |
| `String.equal status "cancelled"` / `"awaiting_verification"` | exhaustive variant 매치 1개로 통합 |
| `GOAL_STORE_TASK_STATUS` (12항목) | 삭제 |
| `normalizeGoalStoreTaskStatus` | `normalizeTaskStatus` 위임 |

미지 철자는 `unknown` + raw 보존이다. 퇴역 철자용 호환 shim 은 넣지 않았다 (`projects.md` 과거 버전 데이터 규칙).

## 검증

- `dune build @check` — 변경 파일 전부 통과
- `test_dashboard_http_core` 69/69, `test_goal_metric_unevaluated` 14/15, `test_task_transition_broadcast` 11/11, `test_keeper_task_cancellation_wake` 10/10
- dashboard `work.test.ts` 59/59, `dashboard-goals.test.ts` 12/12, `tsc --noEmit` clean
- meta gate: determinism / silent-failure / enum-string 전부 0
- **회귀 증명**: 번역 맵을 되살리면 신규 테스트 1건 실패

## 미검증 / 알려진 사항

- `test/test_server_ide_http.ml` 는 main 에서 이미 컴파일 실패한다 (stash 후 재현 확인). 본 PR 과 무관
- `test_goal_metric_unevaluated` 의 실패 1건은 pre-existing keeper meta fixture drift (`agent_name does not match canonical keeper identity`), 본 PR 이 건드리지 않는 테스트
- wire 값이 바뀐다 (`pending`→`todo`, `completed`→`done`). tree 어휘 소비자를 OCaml/dashboard 전수 조사했고 대시보드 외 소비자는 발견되지 않았다

RFC-WAIVED: 이미 결정된 규칙(#8412, #8364 — Variant SSOT 경유)을 누락된 사이트에 적용하는 변경이다. 새 설계 결정이 없다.
