### PR TITLE
refactor(keeper): hard-cut manifest event history

### DIFF
--- a/bin/masc_trace.ml
+++ b/bin/masc_trace.ml
@@ -228,7 +228,7 @@ let dump_runtime_manifests ~base_path ~keeper ~turn_id =
         "=== turn identity === keeper=%s keeper_turn_id=%d manifest_rows=%d \
          max_oas_turn_count=%s provider_attempts=%d/%d provider_lanes=%d \
          checkpoints_saved=%d receipts_appended=%d turn_finished=%d \
-         event_bus=%d correlation_id=%s compaction=%d/%d memory=%d/%d\n"
+         event_bus=%d correlation_id=%s compaction=%d/%d\n"
         keeper turn_id (List.length matches)
         (match max_oas_turn_count with
          | None -> "-"
@@ -242,9 +242,7 @@ let dump_runtime_manifests ~base_path ~keeper ~turn_id =
         (List.length event_bus_rows)
         event_bus_correlation
         (sum_event_bus_int "context_compact_started_count")
-        (sum_event_bus_int "context_compacted_count")
-        (count_event "memory_injected")
-        (count_event "memory_flushed");
+        (sum_event_bus_int "context_compacted_count");
       List.iter
         (fun (f, json) ->
           let ts = Option.value (string_field json "ts") ~default:"-" in

--- a/docs/audit/2026-06-28-keeper-restart-stale-turn-audit.md
+++ b/docs/audit/2026-06-28-keeper-restart-stale-turn-audit.md
@@ -84,11 +84,6 @@ P0: restarted keepers inherit old completed-turn metadata and immediately burn r
     - Surface: prompt resolver/config prompt store.
     - Status: follow-up; binary fallback is an SSOT risk if the external prompt is required.
 
-12. P1 compaction manifest event schema drift
-    - Root: dashboard reader surfaced unknown manifest events `memory_injected` / `memory_flushed`.
-    - Surface: `lib/keeper/keeper_runtime_manifest.ml`, `lib/keeper_registry/keeper_runtime_manifest_types.ml`, `lib/server/server_dashboard_http_keeper_api.ml`.
-    - Status: follow-up; current source appears to know these event names, so verify live binary freshness.
-
 13. P1 source entries accept-and-ignore invalid shape
     - Root: `source_entries_arg` ignores null/non-object/non-list sources instead of rejecting caller shape.
     - Surface: `lib/board_tool_adapter/board_tool_format.ml`.

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -768,18 +768,14 @@ let active_row (row : parsed_row) event : t =
 let decode_persisted_row json =
   match parse_row json with
   | Error _ as error -> error
-  | Ok row -> (
-      match classify_event_wire row.event_wire with
-      | Active_event event -> Ok (Active_row (active_row row event))
-      | Retired_event event -> Ok (Retired_row (row_identity row, event))
-      | Unsupported_event event -> Ok (Unsupported_row (row_identity row, event)))
+  | Ok row ->
+    (match event_kind_of_string row.event_wire with
+     | Some event -> Ok (Active_row (active_row row event))
+     | None -> Ok (Unsupported_row (row_identity row, row.event_wire)))
 
 let of_json json =
   match decode_persisted_row json with
   | Ok (Active_row row) -> Ok row
-  | Ok (Retired_row (_, event)) ->
-      Error
-        (Printf.sprintf "unknown event: %S" (retired_event_kind_to_string event))
   | Ok (Unsupported_row (_, event)) ->
       Error (Printf.sprintf "unknown event: %S" event)
   | Error _ as error -> error

--- a/lib/keeper/keeper_runtime_manifest.mli
+++ b/lib/keeper/keeper_runtime_manifest.mli
@@ -176,7 +176,7 @@ val to_json : t -> Yojson.Safe.t
 val public_to_json : t -> Yojson.Safe.t
 val public_projection_of_decision : Yojson.Safe.t -> Yojson.Safe.t
 (** Decode and validate the common persisted envelope before classifying its
-    event as active, retired, or genuinely unsupported. *)
+    event as active or unsupported. *)
 val decode_persisted_row : Yojson.Safe.t -> (decoded_row, string) result
 val of_json : Yojson.Safe.t -> (t, string) result
 

--- a/lib/keeper_registry/keeper_runtime_manifest_types.ml
+++ b/lib/keeper_registry/keeper_runtime_manifest_types.ml
@@ -84,68 +84,10 @@ let event_kind_of_string = function
   | "turn_finished" -> Some Turn_finished
   | _ -> None
 
-(** Event kinds that were valid in persisted schema-v1 manifests but whose
-    producers and product behavior have been retired. Keeping them outside
-    [event_kind] makes it impossible for current manifest producers to emit a
-    retired row while preserving a typed read boundary for durable history. *)
-type retired_event_kind =
-  | Memory_injected
-  | Memory_flushed
-  | Tool_lineage_recorded
-  | Tool_surface_selected
-  | Cascade_routed
-  | State_snapshot_sidecar_saved
-  | Working_state_sidecar_saved
-
-let all_retired_event_kinds =
-  [ Memory_injected
-  ; Memory_flushed
-  ; Tool_lineage_recorded
-  ; Tool_surface_selected
-  ; Cascade_routed
-  ; State_snapshot_sidecar_saved
-  ; Working_state_sidecar_saved
-  ]
-;;
-
-let retired_event_kind_to_string = function
-  | Memory_injected -> "memory_injected"
-  | Memory_flushed -> "memory_flushed"
-  | Tool_lineage_recorded -> "tool_lineage_recorded"
-  | Tool_surface_selected -> "tool_surface_selected"
-  | Cascade_routed -> "cascade_routed"
-  | State_snapshot_sidecar_saved -> "state_snapshot_sidecar_saved"
-  | Working_state_sidecar_saved -> "working_state_sidecar_saved"
-;;
-
-let retired_event_kind_of_string value =
-  List.find_opt
-    (fun event -> String.equal value (retired_event_kind_to_string event))
-    all_retired_event_kinds
-;;
-
-type event_wire_class =
-  | Active_event of event_kind
-  | Retired_event of retired_event_kind
-  | Unsupported_event of string
-
-let classify_event_wire value =
-  match event_kind_of_string value with
-  | Some event -> Active_event event
-  | None ->
-    (match retired_event_kind_of_string value with
-     | Some event -> Retired_event event
-     | None -> Unsupported_event value)
-;;
-
 type compaction_snapshot_event_class =
   | Compaction_snapshot_relevant
   | Compaction_snapshot_known_unrelated
   | Compaction_snapshot_unknown
-
-let known_unrelated_untyped_compaction_snapshot_events =
-  List.map retired_event_kind_to_string all_retired_event_kinds
-;;
 
 let classify_compaction_snapshot_typed_event = function
   | Event_bus_correlated
@@ -169,10 +111,9 @@ let classify_compaction_snapshot_typed_event = function
       Compaction_snapshot_known_unrelated
 
 let classify_compaction_snapshot_event event =
-  match classify_event_wire event with
-  | Active_event typed_event -> classify_compaction_snapshot_typed_event typed_event
-  | Retired_event _ -> Compaction_snapshot_known_unrelated
-  | Unsupported_event _ -> Compaction_snapshot_unknown
+  match event_kind_of_string event with
+  | Some typed_event -> classify_compaction_snapshot_typed_event typed_event
+  | None -> Compaction_snapshot_unknown
 
 (* ── Record types ────────────────────────────────────────────────────── *)
 
@@ -207,7 +148,6 @@ type row_identity = {
 
 type decoded_row =
   | Active_row of t
-  | Retired_row of row_identity * retired_event_kind
   | Unsupported_row of row_identity * string
 
 type turn_context = {

--- a/lib/keeper_registry/keeper_runtime_manifest_types.mli
+++ b/lib/keeper_registry/keeper_runtime_manifest_types.mli
@@ -20,38 +20,11 @@ val all_event_kinds : event_kind list
 val event_kind_to_string : event_kind -> string
 val event_kind_of_string : string -> event_kind option
 
-(** Persisted schema-v1 events whose producers are no longer part of the
-    active product. They are decode-only and cannot be passed to
-    [Keeper_runtime_manifest.make]. *)
-type retired_event_kind =
-  | Memory_injected
-  | Memory_flushed
-  | Tool_lineage_recorded
-  | Tool_surface_selected
-  | Cascade_routed
-  | State_snapshot_sidecar_saved
-  | Working_state_sidecar_saved
-
-val all_retired_event_kinds : retired_event_kind list
-val retired_event_kind_to_string : retired_event_kind -> string
-val retired_event_kind_of_string : string -> retired_event_kind option
-
-type event_wire_class =
-  | Active_event of event_kind
-  | Retired_event of retired_event_kind
-  | Unsupported_event of string
-
-(** Classify a manifest event wire once at the persistence boundary. Current
-    producers consume only [event_kind]; readers can observe retired and
-    genuinely unsupported wires without reintroducing their behavior. *)
-val classify_event_wire : string -> event_wire_class
-
 type compaction_snapshot_event_class =
   | Compaction_snapshot_relevant
   | Compaction_snapshot_known_unrelated
   | Compaction_snapshot_unknown
 
-val known_unrelated_untyped_compaction_snapshot_events : string list
 val classify_compaction_snapshot_event : string -> compaction_snapshot_event_class
 
 type links = {
@@ -76,20 +49,18 @@ type t = {
   links : links;
 }
 
-(** Identity retained for validated persisted rows whose event is no longer
-    constructible as an active [t]. *)
+(** Identity retained for a validated persisted row with an unsupported event. *)
 type row_identity = {
   keeper_name : string;
   trace_id : string;
   keeper_turn_id : int option;
 }
 
-(** Result of decoding the durable wire envelope. All three constructors have
+(** Result of decoding the durable wire envelope. Both constructors have
     passed schema and common-field validation; only [Active_row] is accepted
     by current producer-facing APIs. *)
 type decoded_row =
   | Active_row of t
-  | Retired_row of row_identity * retired_event_kind
   | Unsupported_row of row_identity * string
 
 type turn_context = {

--- a/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml
@@ -6,7 +6,6 @@
 open Server_dashboard_http_keeper_api_types
 
 type manifest_scan_diagnostic =
-  | Retired_event_row of Keeper_runtime_manifest.retired_event_kind
   | Unsupported_event_row of string
   | Invalid_manifest_row of string
   | Invalid_json_row of string
@@ -44,7 +43,6 @@ type runtime_manifest_scan =
   ; mutable scanned_lines : int
   ; scan_line_limit : int
   ; scan_scope : string
-  ; retired_event_counts : (Keeper_runtime_manifest.retired_event_kind, int) Hashtbl.t
   ; unsupported_event_counts : (string, int) Hashtbl.t
   ; mutable unsupported_event_count : int
   ; mutable unsupported_event_unattributed_count : int
@@ -98,7 +96,6 @@ let make_runtime_manifest_scan ~path ~limit ~scan_line_limit ~scan_scope =
   ; scanned_lines = 0
   ; scan_line_limit
   ; scan_scope
-  ; retired_event_counts = Hashtbl.create 7
   ; unsupported_event_counts = Hashtbl.create 7
   ; unsupported_event_count = 0
   ; unsupported_event_unattributed_count = 0
@@ -117,15 +114,6 @@ let queue_to_list queue =
   Queue.iter (fun value -> values := value :: !values) queue;
   List.rev !values
 
-let increment_count table key =
-  let current =
-    match Hashtbl.find_opt table key with
-    | Some count -> count
-    | None -> 0
-  in
-  Hashtbl.replace table key (current + 1)
-;;
-
 let increment_bounded_count table ~capacity key =
   match Hashtbl.find_opt table key with
   | Some current ->
@@ -139,7 +127,6 @@ let increment_bounded_count table ~capacity key =
 
 let record_manifest_scan_diagnostic scan diagnostic =
   (match diagnostic with
-   | Retired_event_row event -> increment_count scan.retired_event_counts event
    | Unsupported_event_row event ->
      scan.unsupported_event_count <- scan.unsupported_event_count + 1;
      if not (increment_bounded_count scan.unsupported_event_counts ~capacity:scan.limit event)
@@ -162,14 +149,7 @@ let sorted_count_rows table key_to_string =
     `Assoc [ "event", `String event; "count", `Int count ])
 ;;
 
-let count_total table = Hashtbl.fold (fun _ count total -> total + count) table 0
-
 let manifest_scan_diagnostic_to_json = function
-  | Retired_event_row event ->
-    `Assoc
-      [ "kind", `String "retired_event"
-      ; "event", `String (Keeper_runtime_manifest.retired_event_kind_to_string event)
-      ]
   | Unsupported_event_row event ->
     `Assoc [ "kind", `String "unsupported_event"; "event", `String event ]
   | Invalid_manifest_row detail ->
@@ -185,12 +165,6 @@ let runtime_manifest_scan_diagnostics_schema =
 let runtime_manifest_scan_diagnostics_json scan =
   `Assoc
     [ "schema", `String runtime_manifest_scan_diagnostics_schema
-    ; "retired_event_count", `Int (count_total scan.retired_event_counts)
-    ; ( "retired_event_counts"
-      , `List
-          (sorted_count_rows
-             scan.retired_event_counts
-             Keeper_runtime_manifest.retired_event_kind_to_string) )
     ; "unsupported_event_count", `Int scan.unsupported_event_count
     ; ( "unsupported_event_counts"
       , `List (sorted_count_rows scan.unsupported_event_counts Fun.id) )
@@ -360,9 +334,6 @@ let read_runtime_manifest_scan ~config ~keeper_name ~trace_id ?turn_id ~limit ()
             | Ok (Keeper_runtime_manifest.Active_row row)
               when manifest_row_matches ?turn_id keeper_name trace_id row ->
               update_runtime_manifest_scan scan row
-            | Ok (Keeper_runtime_manifest.Retired_row (identity, retired))
-              when manifest_identity_matches ?turn_id keeper_name trace_id identity ->
-              record_manifest_scan_diagnostic scan (Retired_event_row retired)
             | Ok (Keeper_runtime_manifest.Unsupported_row (identity, unsupported))
               when manifest_identity_matches ?turn_id keeper_name trace_id identity ->
               record_manifest_scan_diagnostic scan (Unsupported_event_row unsupported)

--- a/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.mli
+++ b/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.mli
@@ -4,7 +4,6 @@
     existing local call sites keep using the same names. *)
 
 type manifest_scan_diagnostic =
-  | Retired_event_row of Keeper_runtime_manifest.retired_event_kind
   | Unsupported_event_row of string
   | Invalid_manifest_row of string
   | Invalid_json_row of string
@@ -42,7 +41,6 @@ type runtime_manifest_scan =
   ; mutable scanned_lines : int
   ; scan_line_limit : int
   ; scan_scope : string
-  ; retired_event_counts : (Keeper_runtime_manifest.retired_event_kind, int) Hashtbl.t
   ; unsupported_event_counts : (string, int) Hashtbl.t
   ; mutable unsupported_event_count : int
   ; mutable unsupported_event_unattributed_count : int

--- a/test/test_server_dashboard_http_keeper_api_trace.ml
+++ b/test/test_server_dashboard_http_keeper_api_trace.ml
@@ -259,13 +259,13 @@ let test_runtime_manifest_scan_surfaces_diagnostics_without_repeat_warnings () =
     |> Keeper_runtime_manifest.to_json
   in
   let rows =
-    [ runtime_manifest_json_with_event active_row "state_snapshot_sidecar_saved"
-    ; runtime_manifest_json_with_event active_row "working_state_sidecar_saved"
-    ; runtime_manifest_json_with_event active_row "future_manifest_event"
-    ; runtime_manifest_json_with_event active_row "future_manifest_event_2"
-    ; runtime_manifest_json_with_event active_row "future_manifest_event_3"
+    [ runtime_manifest_json_with_event active_row "unsupported_manifest_event_1"
+    ; runtime_manifest_json_with_event active_row "unsupported_manifest_event_2"
+    ; runtime_manifest_json_with_event active_row "unsupported_manifest_event_3"
+    ; runtime_manifest_json_with_event active_row "unsupported_manifest_event_4"
+    ; runtime_manifest_json_with_event active_row "unsupported_manifest_event_5"
     ; runtime_manifest_json_with_field
-        (runtime_manifest_json_with_event active_row "state_snapshot_sidecar_saved")
+        (runtime_manifest_json_with_event active_row "unsupported_manifest_event_1")
         "schema_version"
         (`Int 2)
     ; runtime_manifest_json_without_field active_row "status"
@@ -306,16 +306,12 @@ let test_runtime_manifest_scan_surfaces_diagnostics_without_repeat_warnings () =
     "keeper.runtime_manifest_scan_diagnostics.v1"
     (diagnostics |> member "schema" |> to_string);
   check int
-    "retired rows counted"
-    2
-    (diagnostics |> member "retired_event_count" |> to_int);
-  check int
     "unsupported rows counted"
-    3
+    5
     (diagnostics |> member "unsupported_event_count" |> to_int);
   check int
     "unsupported rows outside the identity request bound are explicit"
-    1
+    3
     (diagnostics
      |> member "unsupported_event_unattributed_count"
      |> to_int);
@@ -327,8 +323,6 @@ let test_runtime_manifest_scan_surfaces_diagnostics_without_repeat_warnings () =
     "invalid json rows counted"
     1
     (diagnostics |> member "invalid_json_row_count" |> to_int);
-  let retired_counts = diagnostics |> member "retired_event_counts" |> to_list in
-  check int "retired kinds remain distinct" 2 (List.length retired_counts);
   let unsupported_counts =
     diagnostics |> member "unsupported_event_counts" |> to_list
   in
@@ -588,7 +582,7 @@ let () =
         ] )
     ; ( "runtime_manifest_scan"
       , [ test_case
-            "surfaces retired and unsupported rows without repeated warnings"
+            "surfaces unsupported rows without repeated warnings"
             `Quick
             test_runtime_manifest_scan_surfaces_diagnostics_without_repeat_warnings
         ] )


### PR DESCRIPTION
## Summary
- remove the decode-only manifest event enum, classifier, and decoded-row branch
- collapse every non-current event wire into the generic unsupported boundary
- remove retired-event dashboard diagnostics, CLI counters, fixtures, and stale audit context

## Verification
- `ocamlformat --inplace` on every changed OCaml file
- `ocamlc -stop-after parsing` on every changed OCaml file
- `git diff --check`
- exact removed identifier and wire-name search: zero matches
- focused `scripts/dune-local.sh build bin/masc_trace.exe test/test_server_dashboard_http_keeper_api_trace.exe` was refused because machine-wide bare Dune processes were active; no bypass was used, so CI remains build authority