### PR TITLE
fix(keeper): 이미 끝난 goal 을 keeper 에게 계속 제시하던 문제

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1000,6 +1000,23 @@ jobs:
           chmod +x scripts/ci-run-tests.sh
           scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_goal_store"
 
+      # Goal phase projection: active_goal_ids records assignment and is never
+      # cleared when a goal reaches a terminal phase, so both prompt surfaces
+      # have to consult the store's phase. The suite seeds one goal per phase in
+      # a real workspace and asserts the rendered sets, which compile-only under
+      # @check does not exercise.
+      - name: Run keeper goal phase projection suite
+        id: keeper_goal_phase_projection_suite
+        if: ${{ always() && steps.build_step.outcome == 'success' }}
+        env:
+          ME_ROOT: /tmp/me
+          CI_TEST_HEARTBEAT_SEC: 15
+          DUNE_JOBS: 1
+        run: |
+          mkdir -p /tmp/me
+          chmod +x scripts/ci-run-tests.sh
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_goal_phase_projection"
+
       # Schedule occurrence reclaim: an occurrence the consumer durably accepted
       # is [Execution_dispatched] until a correlated completion path settles it,
       # so nothing in the scheduler finishes it on its own. The suite drives a

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -600,15 +600,23 @@ let effective_instructions ~(meta : Keeper_meta_contract.keeper_meta)
   | None -> meta.instructions
 ;;
 
+(* Titles for the goals the world observation already narrowed to the ones a
+   keeper can still progress. [meta.active_goal_ids] records assignment and is
+   never cleared when a goal reaches a terminal phase, so this resolves the
+   same phase question the observation does — a keeper must not be handed a
+   Completed goal under a heading that calls it available. *)
 let active_goal_summaries
       ~(config : Workspace.config)
       ~(meta : Keeper_meta_contract.keeper_meta)
   =
-  List.map
+  List.filter_map
     (fun goal_id ->
        match Goal_store.get_goal config ~goal_id with
-       | Some { Goal_store.title; _ } -> (goal_id, title)
-       | None -> (goal_id, ""))
+       | Some { Goal_store.title; phase; _ } ->
+         if Goal_phase.admits_self_directed_progress phase
+         then Some (goal_id, title)
+         else None
+       | None -> Some (goal_id, ""))
     meta.active_goal_ids
 ;;
 

--- a/lib/keeper/keeper_unified_prompt.mli
+++ b/lib/keeper/keeper_unified_prompt.mli
@@ -56,9 +56,13 @@ val active_goal_summaries :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->
   (string * string) list
-(** Resolve every active goal id for the stable prompt contract. Unknown ids
-    remain present with an empty title so every entrypoint renders the same
-    bare-id fallback. *)
+(** Resolve the active goal ids a keeper can still progress, for the stable
+    prompt contract. [meta.active_goal_ids] records assignment and is never
+    cleared when a goal reaches a terminal phase, so ids whose stored phase
+    fails {!Goal_phase.admits_self_directed_progress} are dropped rather than
+    announced as available work. Unknown ids remain present with an empty title
+    so every entrypoint renders the same bare-id fallback: an assigned goal that
+    no longer exists is a different fault and stays visible. *)
 
 val build_system_prompt :
   meta:Keeper_meta_contract.keeper_meta ->

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -1148,6 +1148,28 @@ let collect_board_events_without_advancing_cursor
     ~meta
 ;;
 
+(* [meta.active_goal_ids] records which goals were assigned to this keeper. It
+   is not cleared when a goal reaches a terminal phase, and
+   [resolve_active_goal_ids] only checks that the id exists — so a Completed or
+   Dropped goal stays on the list indefinitely. The store's phase is the
+   authority on whether the goal is still work, and
+   [Goal_phase.admits_self_directed_progress] is the exhaustive predicate for
+   it. Filtering here keeps the observation honest for every reader, instead of
+   leaving each prompt surface to remember the question.
+
+   An id the store cannot resolve is kept: that is a different fault (an
+   assigned goal that no longer exists) and dropping it here would replace a
+   visible inconsistency with a silent one. *)
+let live_active_goal_ids ~(config : Workspace.config) (meta : keeper_meta) =
+  List.filter
+    (fun goal_id ->
+      match Goal_store.get_goal config ~goal_id with
+      | Some { Goal_store.phase; _ } ->
+        Goal_phase.admits_self_directed_progress phase
+      | None -> true)
+    meta.active_goal_ids
+;;
+
 let observe
       ~(pending_board_events : pending_board_event list option)
       ~(config : Workspace.config)
@@ -1185,7 +1207,7 @@ let observe
   { pending_messages
   ; pending_board_events
   ; idle_seconds
-  ; active_goals = meta.active_goal_ids
+  ; active_goals = live_active_goal_ids ~config meta
   ; unclaimed_task_count
   ; claimable_task_count
   ; failed_task_count
@@ -1220,7 +1242,7 @@ let observe_direct_keeper_msg ~(config : Workspace.config) ~(meta : keeper_meta)
   { pending_messages = []
   ; pending_board_events = []
   ; idle_seconds = compute_idle_seconds ~meta
-  ; active_goals = meta.active_goal_ids
+  ; active_goals = live_active_goal_ids ~config meta
   ; unclaimed_task_count
   ; claimable_task_count
   ; failed_task_count

--- a/test/dune
+++ b/test/dune
@@ -1043,6 +1043,7 @@
   test_goal_tools
   test_goal_upsert_fsm_bypass_10247
   test_goal_store
+  test_keeper_goal_phase_projection
   test_goal_metric_unevaluated
   test_string_util
   test_prompt_asset_sync
@@ -1194,6 +1195,7 @@
   test_goal_tools
   test_goal_upsert_fsm_bypass_10247
   test_goal_store
+  test_keeper_goal_phase_projection
   test_goal_metric_unevaluated
   test_string_util
   test_prompt_asset_sync

--- a/test/test_keeper_goal_phase_projection.ml
+++ b/test/test_keeper_goal_phase_projection.ml
@@ -1,0 +1,162 @@
+(** A keeper is handed only the goals it can still progress.
+
+    [keeper_meta.active_goal_ids] records which goals were assigned to a keeper.
+    Nothing removes an id when the goal reaches a terminal phase, and
+    [resolve_active_goal_ids] only checks that the id exists — so a Completed or
+    Dropped goal stays on the list indefinitely.
+
+    Two prompt surfaces read that list: [<available_goals>] in the system prompt
+    (via {!Keeper_unified_prompt.active_goal_summaries}) and [### Active Goals]
+    in the per-turn world state (via [world_observation.active_goals]). Both
+    announced terminal goals as this keeper's work, on every turn, under
+    headings that call them available.
+
+    [Goal_phase.admits_self_directed_progress] is the exhaustive predicate for
+    the question and had no callers. These tests pin both surfaces to it. *)
+
+open Alcotest
+open Masc
+
+let temp_dir () =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "test_keeper_goal_phase_%d_%d" (Unix.getpid ())
+         (Random.int 1_000_000))
+  in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  dir
+;;
+
+let with_workspace f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> Fs_compat.remove_tree dir)
+    (fun () ->
+      let config = Workspace.default_config dir in
+      ignore (Workspace.init config ~agent_name:(Some "test"));
+      f config)
+;;
+
+let goal_in phase id title =
+  let ts = Masc_domain.now_iso () in
+  { Goal_store.id
+  ; title
+  ; metric = None
+  ; target_value = None
+  ; due_date = None
+  ; priority = 3
+  ; phase
+  ; parent_goal_id = None
+  ; last_review_note = None
+  ; last_review_at = None
+  ; created_at = ts
+  ; updated_at = ts
+  }
+;;
+
+(* One goal per phase, so a future phase added to [Goal_phase.t] shows up here
+   as an unclassified id rather than silently inheriting a neighbour's verdict. *)
+let seed_all_phases config =
+  Goal_store.write_state config
+    { version = 1
+    ; updated_at = Masc_domain.now_iso ()
+    ; goals =
+        [ goal_in Goal_phase.Executing "goal-executing" "still work"
+        ; goal_in Goal_phase.Blocked "goal-blocked" "waiting on someone"
+        ; goal_in Goal_phase.Paused "goal-paused" "set aside"
+        ; goal_in Goal_phase.Completed "goal-completed" "already achieved"
+        ; goal_in Goal_phase.Dropped "goal-dropped" "abandoned"
+        ]
+    }
+;;
+
+let meta_with_goals ids =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+         [ "name", `String "goal-phase-keeper"
+         ; "trace_id", `String "test-trace-goal-phase"
+         ; "active_goal_ids", `List (List.map (fun id -> `String id) ids)
+         ])
+  with
+  | Ok m -> m
+  | Error e -> failwith ("meta_of_json failed: " ^ e)
+;;
+
+let all_ids =
+  [ "goal-executing"
+  ; "goal-blocked"
+  ; "goal-paused"
+  ; "goal-completed"
+  ; "goal-dropped"
+  ]
+;;
+
+let test_system_prompt_surface_drops_terminal_goals () =
+  with_workspace @@ fun config ->
+  seed_all_phases config;
+  let meta = meta_with_goals all_ids in
+  let summaries = Keeper_unified_prompt.active_goal_summaries ~config ~meta in
+  let ids = List.map fst summaries in
+  check (list string) "only a progressable goal is offered" [ "goal-executing" ]
+    ids;
+  check (option string) "its title still resolves" (Some "still work")
+    (List.assoc_opt "goal-executing" summaries)
+;;
+
+let test_world_observation_drops_terminal_goals () =
+  with_workspace @@ fun config ->
+  seed_all_phases config;
+  let meta = meta_with_goals all_ids in
+  let observation =
+    Keeper_world_observation.observe ~pending_board_events:(Some []) ~config
+      ~meta
+  in
+  check (list string) "the per-turn frame agrees with the system prompt"
+    [ "goal-executing" ] observation.Keeper_world_observation.active_goals
+;;
+
+let test_unresolved_goal_id_stays_visible () =
+  (* An assigned goal that no longer exists is a different fault. Dropping it
+     alongside the terminal ones would replace a visible inconsistency with a
+     silent one, so it keeps its bare-id rendering. *)
+  with_workspace @@ fun config ->
+  seed_all_phases config;
+  let meta = meta_with_goals [ "goal-completed"; "goal-vanished" ] in
+  let summaries = Keeper_unified_prompt.active_goal_summaries ~config ~meta in
+  check (list string) "the terminal goal goes, the unknown id stays"
+    [ "goal-vanished" ] (List.map fst summaries);
+  check (option string) "unknown id renders with no title" (Some "")
+    (List.assoc_opt "goal-vanished" summaries)
+;;
+
+let test_no_goals_surface_when_all_are_terminal () =
+  with_workspace @@ fun config ->
+  seed_all_phases config;
+  let meta = meta_with_goals [ "goal-completed"; "goal-dropped" ] in
+  check (list string) "no goal block rather than an empty-looking one" []
+    (List.map fst (Keeper_unified_prompt.active_goal_summaries ~config ~meta));
+  let observation =
+    Keeper_world_observation.observe ~pending_board_events:(Some []) ~config
+      ~meta
+  in
+  check (list string) "and the frame carries none either" []
+    observation.Keeper_world_observation.active_goals
+;;
+
+let () =
+  run "keeper_goal_phase_projection"
+    [ ( "prompt surfaces"
+      , [ test_case "system prompt drops terminal goals" `Quick
+            test_system_prompt_surface_drops_terminal_goals
+        ; test_case "world observation drops terminal goals" `Quick
+            test_world_observation_drops_terminal_goals
+        ; test_case "unresolved goal id stays visible" `Quick
+            test_unresolved_goal_id_stays_visible
+        ; test_case "all-terminal yields no goals at either surface" `Quick
+            test_no_goals_surface_when_all_are_terminal
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 문제

`keeper_meta.active_goal_ids` 는 **배정 기록**입니다. goal 이 terminal phase 에 도달해도 아무도 이 목록에서 지우지 않고, `resolve_active_goal_ids` 는 id 의 **존재만** 검사합니다. 그래서 Completed / Dropped goal 이 무기한 남습니다.

그 목록을 읽는 프롬프트 표면이 **둘**인데 어느 쪽도 phase 를 묻지 않았습니다.

```ocaml
(* active_goal_summaries → <system> … <available_goals> *)
| Some { Goal_store.title; _ } -> (goal_id, title)

(* world_observation → ## Current World State / ### Active Goals *)
; active_goals = meta.active_goal_ids
```

record 패턴이 goal 을 **가져와 놓고** `phase` 를 `_` 로 버립니다. 끝난 goal 이 살아있는 일감과 똑같이 렌더되고, **같은 프롬프트에 두 번**, 매 턴, 둘 다 "available" / "Active" 라는 제목 아래 들어갑니다.

## 라이브 증거

sangsu 의 조립된 시스템 프롬프트 (11,123 자) 에서:

```
208:  - goal-request-menu-zero Reduce request-menu service task backlog to 0   ← <available_goals>
216:  - goal-request-menu-zero — Reduce request-menu service task backlog to 0 ← ### Active Goals (1)
```

그 goal 의 실제 상태:

```json
{ "id": "goal-request-menu-zero",
  "phase": "completed",
  "last_review_note": "request-menu 백로그 0 달성. 모든 linked task terminal:
     task-159 done(오타 수정, vrf-7c6f51be 승인), task-160/161 cancelled...",
  "last_review_at": "2026-08-04T12:54:12Z" }
```

**검증까지 거쳐 어제 닫힌 목표입니다.** 그런데 sangsu 의 최근 tool call 166 건이 **전부** 이 goal id 에 귀속돼 있고, 그중 93% 가 `keeper_board_list`(78) + `keeper_tasks_list`(76) 입니다. 2 시간 13 분 동안 끝난 목표를 재확인했습니다. 각 턴의 결론도 스스로 그렇게 말합니다.

> "스케줄 keepalive 턴이야. … **태스크: 백로그 0 (goal-request-menu-zero 달성 상태)**"

store 가 이미 기록해 둔 결론을 매 턴 다시 도출하고 있었습니다.

## 이미 있던 답

`Goal_phase.admits_self_directed_progress` 가 정확히 이 질문의 exhaustive 술어입니다.

```ocaml
(* Phases from which a keeper can make self-directed progress on the goal. *)
let admits_self_directed_progress = function
  | Executing -> true
  | Blocked | Paused | Completed | Dropped -> false
```

**소비자가 0 건이었습니다.** 술어는 맞게 정의돼 있고 아무도 부르지 않았습니다.

## 변경

두 표면 모두 이 술어를 통과시킵니다. observation 쪽은 **만들어지는 지점**에서 걸러, 이후 모든 독자가 답을 물려받습니다.

```ocaml
let live_active_goal_ids ~config meta =
  List.filter
    (fun goal_id ->
      match Goal_store.get_goal config ~goal_id with
      | Some { Goal_store.phase; _ } -> Goal_phase.admits_self_directed_progress phase
      | None -> true)
    meta.active_goal_ids
```

`None` 은 유지합니다. 배정됐는데 존재하지 않는 goal 은 **다른 결함**(`resolve_active_goal_ids` 가 write 시점에 거부하는 상태)이고, 여기서 같이 숨기면 보이는 불일치를 조용한 불일치로 바꾸게 됩니다.

### 시도했다가 되돌린 것

처음에는 렌더 지점에서 summaries 를 권위로 삼아 걸렀는데, `test_keeper_wake_turn_context` 가 **`observation.active_goals` 가 목록의 권위이고 summaries 는 제목만 보강한다**는 계약을 담고 있어 2 건이 깨졌습니다 (`partial summaries preserve missing ids`). 계약이 맞으므로 필터를 observation 구성 지점으로 옮겼습니다.

## 검증

**새 스위트 `test_keeper_goal_phase_projection`** — 실제 workspace 에 phase 당 goal 하나씩 심고 두 표면을 고정합니다. phase 를 하나씩 다 심는 이유는, `Goal_phase.t` 에 새 phase 가 생기면 이웃의 판정을 조용히 물려받지 않고 분류되지 않은 id 로 드러나게 하려는 것입니다.

```
$ dune build --root . @test/runtest-test_keeper_goal_phase_projection
Test Successful in 0.746s. 4 tests run.
```

**Negative control** — 수정 두 곳을 되돌리고 테스트만 남기면:

```
4 failures! in 0.352s. 4 tests run.
```

복원하면 다시 4/4 통과합니다.

**회귀 없음** — `test_keeper_wake_turn_context` 의 실패 집합이 `origin/main` baseline 과 **완전히 동일**합니다 (3 건: `current task layer 0`·`7`, `goal titles and parity 2`). 이 3 건은 이 PR 이전부터 main 에서 실패 중입니다.

```
$ ./_build/default/test/test_keeper_prompt_metrics.exe   22 tests run
$ ocamlformat --check <touched>                          EXIT=0
```

## CI 배선

새 스위트를 `@test/runtest-` 타깃으로 등록했습니다. 이게 필요한 이유가 있습니다 — **이 영역을 덮는 기존 스위트 `test_keeper_wake_turn_context` 는 어떤 runtest 타깃에도 없습니다.**

```
$ grep -c "test_keeper_wake_turn_context" .github/workflows/ci.yml
0
```

그래서 main 의 3 건 실패가 보이지 않았고, compile-only `@check` 로는 이번 결함도 잡히지 않았을 것입니다.

RFC-WAIVED: `lib/keeper/keeper_unified_prompt.ml`, `keeper_world_observation.ml` 은 RFC 사전 발견 대상 subsystem (credential / identity / operator control / sandbox / hooks) 이 아닙니다. 이 변경은 새 계약을 만들지 않고, 이미 선언된 `Goal_phase` 계약을 소비하지 않던 두 지점을 잇습니다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
