### PR TITLE
refactor(task,goal): name the actor role, and close the goal FSM matrix

### DIFF
--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -83,7 +83,7 @@ function goalTreeTask(overrides: Partial<GoalTreeTask> = {}): GoalTreeTask {
   return {
     id: 'task-tree',
     title: 'Tree task',
-    status: 'completed',
+    status: 'done',
     status_color: GOAL_FIXTURE_OK_COLOR,
     priority: 2,
     assignee: null,
@@ -1228,7 +1228,36 @@ describe('Work', () => {
         expect(screen.getByTestId('work-view-list').classList.contains('on')).toBe(true)
       })
 
-      it('includes recursive goal tree tasks in KPIs and kanban, normalizing completed to done', () => {
+      // The tree used to speak its own status spelling ("completed" for done,
+      // "pending" for todo) and the frontend translated it. Both sides now use
+      // Masc_domain.task_status_to_string, so the fixture carries the spelling
+      // the backend actually emits and no translation is involved.
+      it('surfaces an unrecognised tree status as unknown instead of translating it', () => {
+        // The removed map silently rewrote a second vocabulary into the first.
+        // With one spelling there is nothing to translate, so a status the
+        // domain never produces must read as unknown and keep its raw text
+        // rather than being guessed into a neighbouring state.
+        goals.value = [
+          { id: 'G-1', title: 'Goal One', priority: 1, phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        ]
+        goalTreeData.value = {
+          tree: [
+            goalTreeNode({
+              id: 'G-1',
+              tasks: [goalTreeTask({ id: 'T-legacy', title: 'Legacy spelling', status: 'completed' })],
+            }),
+          ],
+          summary: emptyGoalTreeSummary({ total_goals: 1, total_tasks: 1 }),
+        }
+
+        render(html`<${Work} />`)
+        fireEvent.click(screen.getByTestId('work-view-kanban'))
+
+        const doneCol = screen.getByTestId('kanban-col-done')
+        expect(doneCol.textContent).not.toContain('Legacy spelling')
+      })
+
+      it('includes recursive goal tree tasks in KPIs and kanban', () => {
         goals.value = [
           { id: 'G-1', title: 'Goal One', priority: 1, phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
           { id: 'G-child', title: 'Child Goal', priority: 2, phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
@@ -1239,14 +1268,14 @@ describe('Work', () => {
             goalTreeNode({
               id: 'G-1',
               tasks: [
-                goalTreeTask({ id: 'T-root', title: 'Root completed task', goal_id: 'G-1', status: 'completed' }),
+                goalTreeTask({ id: 'T-root', title: 'Root completed task', goal_id: 'G-1', status: 'done' }),
               ],
               children: [
                 goalTreeNode({
                   id: 'G-child',
                   title: 'Child Goal',
                   tasks: [
-                    goalTreeTask({ id: 'T-child', title: 'Child completed task', goal_id: 'G-child', status: 'completed' }),
+                    goalTreeTask({ id: 'T-child', title: 'Child completed task', goal_id: 'G-child', status: 'done' }),
                   ],
                 }),
               ],
@@ -1349,7 +1378,7 @@ describe('Work', () => {
             goalTreeNode({
               id: 'G-1',
               tasks: [
-                goalTreeTask({ id: 'T-goal', title: 'Goal store task', goal_id: 'G-1', status: 'completed' }),
+                goalTreeTask({ id: 'T-goal', title: 'Goal store task', goal_id: 'G-1', status: 'done' }),
               ],
             }),
           ],
@@ -1451,11 +1480,11 @@ describe('Work', () => {
           tree: [
             goalTreeNode({
               id: 'G-1',
-              tasks: [goalTreeTask({ id: 'T-1', goal_id: 'G-1', status: 'completed' })],
+              tasks: [goalTreeTask({ id: 'T-1', goal_id: 'G-1', status: 'done' })],
               children: [
                 goalTreeNode({
                   id: 'G-1',
-                  tasks: [goalTreeTask({ id: 'T-2', goal_id: 'G-1', status: 'completed' })],
+                  tasks: [goalTreeTask({ id: 'T-2', goal_id: 'G-1', status: 'done' })],
                 }),
               ],
             }),

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -8,7 +8,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { route, navigate } from '../router'
 import { goals, tasks, keepers, executionTaskTotal } from '../store'
 import { goalTreeData } from '../goal-tree-state'
-import { normalizeTask } from '../store-normalizers'
+import { normalizeTask, normalizeTaskStatus } from '../store-normalizers'
 import { WORK_UNLINKED_GOAL_TITLE } from '../lib/work-copy'
 import { BoardModerationSurface } from './board/board-moderation-surface'
 import { BoardSurface } from './board/board-surface'
@@ -206,20 +206,13 @@ function isClaimableBacklogTask(task: Task): boolean {
   return (task.status ?? 'todo') === 'todo' && !hasTaskAssignee(task)
 }
 
-const GOAL_STORE_TASK_STATUS: Readonly<Record<string, NonNullable<Task['status']>>> = {
-  pending: 'todo',
-  todo: 'todo',
-  claimed: 'claimed',
-  in_progress: 'in_progress',
-  inprogress: 'in_progress',
-  awaiting_verification: 'awaiting_verification',
-  completed: 'done',
-  done: 'done',
-  cancelled: 'cancelled',
-  blocked: 'blocked',
-  paused: 'paused',
-  unknown: 'unknown',
-}
+// The Goal Store tree now speaks the domain's own status spelling
+// (Masc_domain.task_status_to_string), the same one the execution payload uses.
+// This map existed to absorb a second vocabulary — "pending" for todo,
+// "completed" for done — that dashboard_goals_types_accessor emitted on its
+// own. Issues #8412 and #8364 already ruled that emitters must route through
+// the Variant SSOT; the goals path had missed it. With one spelling there is
+// nothing left to translate, so tree statuses parse exactly like execution ones.
 
 interface GoalStoreTaskStatus {
   readonly status: NonNullable<Task['status']>
@@ -228,11 +221,10 @@ interface GoalStoreTaskStatus {
 
 function normalizeGoalStoreTaskStatus(value: unknown): GoalStoreTaskStatus {
   const raw = typeof value === 'string' ? value.trim() : ''
-  const token = raw.toLowerCase()
-  const status = GOAL_STORE_TASK_STATUS[token]
-  return status
-    ? { status, status_raw: status === 'unknown' ? raw : null }
-    : { status: 'unknown', status_raw: raw || null }
+  const status = normalizeTaskStatus(raw)
+  return status === undefined || status === 'unknown'
+    ? { status: 'unknown', status_raw: raw || null }
+    : { status, status_raw: null }
 }
 
 function goalProgressCounts(goalTasks: Task[]): GoalProgressCounts {

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -542,15 +542,7 @@ let model_map_of_keeper_rows keepers =
     keepers
 ;;
 
-let task_updated_at (task : Masc_domain.task) =
-  match task.task_status with
-  | Masc_domain.Done { completed_at; _ } -> completed_at
-  | Masc_domain.Cancelled { cancelled_at; _ } -> cancelled_at
-  | Masc_domain.InProgress { started_at; _ } -> started_at
-  | Masc_domain.AwaitingVerification { submitted_at; _ } -> submitted_at
-  | Masc_domain.Claimed { claimed_at; _ } -> claimed_at
-  | Masc_domain.Todo -> task.created_at
-;;
+let task_updated_at = Masc_domain.task_last_transition_at
 
 let task_completed_at (task : Masc_domain.task) =
   match task.task_status with

--- a/lib/dashboard/dashboard_execution_builders.ml
+++ b/lib/dashboard/dashboard_execution_builders.ml
@@ -51,12 +51,12 @@ let ctx_compacting       = Env_config.Dashboard.ctx_compacting
     SSOT: [Env_config.Dashboard] module. *)
 let keeper_action_stale_sec = Env_config.Dashboard.keeper_action_stale_sec
 
+(* "who did or is doing it", which includes Done — that is
+   [task_performer_of_status], not the ownership helper. This used to be a
+   local re-implementation, which is how the execution payload and the goal
+   tree came to disagree about a completed Task's assignee. *)
 let task_assignee (task : Masc_domain.task) =
-  match task.task_status with
-  | Claimed { assignee; _ } | InProgress { assignee; _ }
-  | AwaitingVerification { assignee; _ } | Done { assignee; _ } ->
-      Some assignee
-  | Todo | Cancelled _ -> None
+  Masc_domain.task_performer_of_status task.task_status
 
 let last_message_map messages =
   let table = Hashtbl.create 32 in

--- a/lib/dashboard/dashboard_goals_types.mli
+++ b/lib/dashboard/dashboard_goals_types.mli
@@ -40,7 +40,6 @@ val task_is_linked_to_goal :
 val task_linkage_source_opt :
   ?goal_task_index:(string, string list) Hashtbl.t -> Masc_domain.task -> string -> string option
 val task_assignee : Masc_domain.task -> string option
-val task_status_label : Masc_domain.task -> string
 val task_is_terminal : Masc_domain.task -> bool
 val task_is_done : Masc_domain.task -> bool
 val task_updated_at : Masc_domain.task -> string
@@ -146,7 +145,7 @@ val goal_fsm_to_json :
 (** {1 Color helpers + task tree JSON projection (pure)} *)
 
 val goal_phase_color : Goal_phase.t -> string
-val task_status_color : string -> string
+val task_status_color : Masc_domain.task_status -> string
 
 val task_to_tree_json : Masc_domain.task * string -> Yojson.Safe.t
 val task_summary_to_json : (Masc_domain.task * string) list -> Yojson.Safe.t

--- a/lib/dashboard/dashboard_goals_types_accessor.ml
+++ b/lib/dashboard/dashboard_goals_types_accessor.ml
@@ -59,14 +59,6 @@ let task_linkage_source_opt ?(goal_task_index = Hashtbl.create 0) (task : Masc_d
 let task_assignee (task : Masc_domain.task) : string option =
   Masc_domain.task_assignee_of_status task.task_status
 
-let task_status_label (task : Masc_domain.task) : string =
-  match task.task_status with
-  | Masc_domain.Todo -> "pending"
-  | Masc_domain.Claimed _ -> "claimed"
-  | Masc_domain.InProgress _ -> "in_progress"
-  | Masc_domain.AwaitingVerification _ -> "awaiting_verification"
-  | Masc_domain.Done _ -> "completed"
-  | Masc_domain.Cancelled _ -> "cancelled"
 
 let task_is_terminal (task : Masc_domain.task) : bool =
   Masc_domain.task_status_is_terminal task.task_status

--- a/lib/dashboard/dashboard_goals_types_accessor.ml
+++ b/lib/dashboard/dashboard_goals_types_accessor.ml
@@ -56,8 +56,12 @@ let task_linkage_source_opt ?(goal_task_index = Hashtbl.create 0) (task : Masc_d
   then Some "explicit"
   else None
 
+(* The tree feeds the same Work surface as the execution payload, so it must
+   answer the same question: who did or is doing the work. Using the ownership
+   helper here made a completed Task show its performer via execution and
+   nobody via the tree. *)
 let task_assignee (task : Masc_domain.task) : string option =
-  Masc_domain.task_assignee_of_status task.task_status
+  Masc_domain.task_performer_of_status task.task_status
 
 
 let task_is_terminal (task : Masc_domain.task) : bool =
@@ -66,14 +70,7 @@ let task_is_terminal (task : Masc_domain.task) : bool =
 let task_is_done (task : Masc_domain.task) : bool =
   Masc_domain.task_status_is_done task.task_status
 
-let task_updated_at (task : Masc_domain.task) : string =
-  match task.task_status with
-  | Masc_domain.Done { completed_at; _ } -> completed_at
-  | Masc_domain.Cancelled { cancelled_at; _ } -> cancelled_at
-  | Masc_domain.InProgress { started_at; _ } -> started_at
-  | Masc_domain.AwaitingVerification { submitted_at; _ } -> submitted_at
-  | Masc_domain.Claimed { claimed_at; _ } -> claimed_at
-  | Masc_domain.Todo -> task.created_at
+let task_updated_at = Masc_domain.task_last_transition_at
 
 let dedupe_sort values =
   values |> List.sort_uniq String.compare

--- a/lib/dashboard/dashboard_goals_types_accessor.mli
+++ b/lib/dashboard/dashboard_goals_types_accessor.mli
@@ -40,7 +40,6 @@ val task_is_linked_to_goal :
 val task_linkage_source_opt :
   ?goal_task_index:(string, string list) Hashtbl.t -> Masc_domain.task -> string -> string option
 val task_assignee : Masc_domain.task -> string option
-val task_status_label : Masc_domain.task -> string
 val task_is_terminal : Masc_domain.task -> bool
 val task_is_done : Masc_domain.task -> bool
 val task_updated_at : Masc_domain.task -> string

--- a/lib/dashboard/dashboard_goals_types_timeline.ml
+++ b/lib/dashboard/dashboard_goals_types_timeline.ml
@@ -23,24 +23,27 @@ let goal_phase_color = function
   | Goal_phase.Completed -> "#60a5fa"
   | Goal_phase.Dropped -> "#6b7280"
 
-let task_status_color status_label =
-  match status_label with
-  | "pending" -> "#6b7280"
-  | "claimed" -> "#f59e0b"
-  | "in_progress" -> "#3b82f6"
-  | "awaiting_verification" -> "#a78bfa"
-  | "completed" -> "#4ade80"
-  | "cancelled" -> "#ef4444"
-  | _ -> "#888888"
+(* Exhaustive on [task_status], not a string match with a grey catch-all. The
+   catch-all silently absorbed every label it did not recognise, which is how a
+   second status vocabulary survived here: "pending"/"completed" coloured fine
+   while the SSOT spelling "todo"/"done" fell through to grey. A new status now
+   breaks this match instead of rendering as unknown. *)
+let task_status_color (status : Masc_domain.task_status) =
+  match status with
+  | Masc_domain.Todo -> "#6b7280"
+  | Masc_domain.Claimed _ -> "#f59e0b"
+  | Masc_domain.InProgress _ -> "#3b82f6"
+  | Masc_domain.AwaitingVerification _ -> "#a78bfa"
+  | Masc_domain.Done _ -> "#4ade80"
+  | Masc_domain.Cancelled _ -> "#ef4444"
 
 let task_to_tree_json ((task, linkage_source) : Masc_domain.task * string) =
-  let status = task_status_label task in
   `Assoc
     ([
       ("id", `String task.id);
       ("title", `String task.title);
-      ("status", `String status);
-      ("status_color", `String (task_status_color status));
+      ("status", `String (Masc_domain.task_status_to_string task.task_status));
+      ("status_color", `String (task_status_color task.task_status));
       ("priority", `Int task.priority);
       ("assignee", Json_util.string_opt_to_json (task_assignee task));
       ("linkage_source", `String linkage_source);
@@ -103,14 +106,19 @@ let task_summary_to_json tasks =
   let unassigned_count = ref 0 in
   List.iter
     (fun ((task, linkage_source) : Masc_domain.task * string) ->
-      let status = task_status_label task in
-      bump by_status status;
+      bump by_status (Masc_domain.task_status_to_string task.task_status);
       bump by_linkage_source linkage_source;
       if task_is_done task then incr done_count;
       if task_is_terminal task then incr terminal_count else incr open_count;
-      if String.equal status "awaiting_verification" then
-        incr awaiting_verification_count;
-      if String.equal status "cancelled" then incr cancelled_count;
+      (* One exhaustive match over the variant instead of two string equalities
+         against a label that had its own spelling. *)
+      (match task.task_status with
+       | Masc_domain.AwaitingVerification _ -> incr awaiting_verification_count
+       | Masc_domain.Cancelled _ -> incr cancelled_count
+       | Masc_domain.Todo
+       | Masc_domain.Claimed _
+       | Masc_domain.InProgress _
+       | Masc_domain.Done _ -> ());
       match task_assignee task with None -> incr unassigned_count | Some _ -> ())
     tasks;
   let total = List.length tasks in
@@ -255,7 +263,7 @@ let build_goal_timeline node linked_keepers approvals goal_events =
   let task_events =
     node.tasks
     |> List.map (fun ((task, linkage_source) : Masc_domain.task * string) ->
-           let status = task_status_label task in
+           let status = Masc_domain.task_status_to_string task.task_status in
            timeline_event_json ~ts:(task_updated_at task) ~kind:"task"
              ~lane:("task:" ^ task.id)
              ~title:task.title

--- a/lib/dashboard/dashboard_goals_types_timeline.mli
+++ b/lib/dashboard/dashboard_goals_types_timeline.mli
@@ -3,7 +3,7 @@
 open Dashboard_goals_types_accessor
 
 val goal_phase_color : Goal_phase.t -> string
-val task_status_color : string -> string
+val task_status_color : Masc_domain.task_status -> string
 
 val task_to_tree_json : Masc_domain.task * string -> Yojson.Safe.t
 val task_summary_to_json : (Masc_domain.task * string) list -> Yojson.Safe.t

--- a/lib/goal/goal_phase.ml
+++ b/lib/goal/goal_phase.ml
@@ -98,20 +98,37 @@ type transition_outcome =
   | Move_to of t
   | Complete
 
+(* Every (phase, action) pair is stated. The catch-all this replaces absorbed
+   22 of the 35 pairs, so adding a phase or an action compiled cleanly and the
+   new combinations silently became "invalid" — the same FSM sparse-match class
+   that produced a runtime Assert_failure in keeper_registry. The compiler now
+   refuses a matrix with a hole in it. *)
 let decide_transition ~phase ~(action : action) =
+  let invalid =
+    Error
+      (Printf.sprintf "invalid goal transition: %s -> %s"
+         (to_string phase) (action_to_string action))
+  in
   match phase, action with
+  (* Executing: the only phase that can request completion. *)
   | Executing, Request_complete -> Ok Complete
   | Executing, Pause -> Ok (Move_to Paused)
   | Executing, Block -> Ok (Move_to Blocked)
   | Executing, Drop -> Ok (Move_to Dropped)
+  | Executing, (Resume | Unblock | Reopen) -> invalid
+  (* Paused: resumes or drops; it is not blocked and not finished. *)
   | Paused, Resume -> Ok (Move_to Executing)
   | Paused, Drop -> Ok (Move_to Dropped)
+  | Paused, (Request_complete | Pause | Block | Unblock | Reopen) -> invalid
+  (* Blocked: unblocks or drops. Completing while blocked would skip the
+     impediment rather than resolve it. *)
   | Blocked, Unblock -> Ok (Move_to Executing)
   | Blocked, Drop -> Ok (Move_to Dropped)
+  | Blocked, (Request_complete | Pause | Resume | Block | Reopen) -> invalid
+  (* Completed and Dropped are terminal: only reopening leaves them. *)
   | Completed, Reopen -> Ok (Move_to Executing)
   | Completed, Drop -> Ok (Move_to Dropped)
+  | Completed, (Request_complete | Pause | Resume | Block | Unblock) -> invalid
   | Dropped, Reopen -> Ok (Move_to Executing)
-  | _ ->
-      Error
-        (Printf.sprintf "invalid goal transition: %s -> %s"
-           (to_string phase) (action_to_string action))
+  | Dropped, (Request_complete | Pause | Resume | Block | Unblock | Drop) ->
+    invalid

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -319,22 +319,63 @@ let task_status_icon = function
   | Done _ -> "✅"
   | Cancelled _ -> "🚫"
 
-(** Display assignee for task status.
-    Cancelled surfaces [cancelled_by]; Todo yields "unclaimed".
-    For ownership checks returning [option], use [task_assignee_of_status]. *)
-let task_display_assignee = function
-  | Claimed { assignee; _ } | InProgress { assignee; _ } | Done { assignee; _ }
-  | AwaitingVerification { assignee; _ } -> assignee
-  | Cancelled { cancelled_by; _ } -> cancelled_by
-  | Todo -> "unclaimed"
+(** Who acted on a Task, and in what relationship.
 
-(** Extract assignee as [Some string], or [None] for Todo/Cancelled.
-    Canonical ownership-check helper — used by task_state, gRPC, etc. *)
-let task_assignee_of_status = function
-  | Claimed { assignee; _ } -> Some assignee
-  | InProgress { assignee; _ } -> Some assignee
-  | AwaitingVerification { assignee; _ } -> Some assignee
-  | Todo | Done _ | Cancelled _ -> None
+    Every status carries an actor and a role, but a bare [string option]
+    records only the name and drops the role. Callers then disagreed about
+    what the name meant: three separate [task_assignee] implementations
+    existed, differing on [Done] (assignee or nobody) and on [Cancelled]
+    (nobody or the canceller). A completed Task therefore showed an owner on
+    one surface and none on another, and a cancelled Task named its canceller
+    as its assignee.
+
+    Naming the role makes the disagreement impossible to write: a [Canceller]
+    cannot be passed where a [Holder] is expected, and a new status has to
+    state which role it carries. The three questions callers actually ask are
+    derived below, each total over this sum. *)
+type task_actor =
+  | Unassigned
+  | Holder of string  (** Claimed or InProgress: currently doing the work. *)
+  | Submitter of string  (** AwaitingVerification: submitted, awaiting a verdict. *)
+  | Completer of string  (** Done: finished the work. *)
+  | Canceller of string  (** Cancelled: ended the work. Never its assignee. *)
+
+let task_actor_of_status = function
+  | Todo -> Unassigned
+  | Claimed { assignee; _ } -> Holder assignee
+  | InProgress { assignee; _ } -> Holder assignee
+  | AwaitingVerification { assignee; _ } -> Submitter assignee
+  | Done { assignee; _ } -> Completer assignee
+  | Cancelled { cancelled_by; _ } -> Canceller cancelled_by
+
+let task_actor_name = function
+  | Unassigned -> None
+  | Holder name | Submitter name | Completer name | Canceller name -> Some name
+
+(** Who owes work on this Task now. [Done] and [Cancelled] owe nothing, so
+    they answer [None] even though both carry a name. Canonical
+    ownership-check helper — used by task_state, gRPC, etc. *)
+let task_assignee_of_status status =
+  match task_actor_of_status status with
+  | Holder name | Submitter name -> Some name
+  | Unassigned | Completer _ | Canceller _ -> None
+
+(** Who did or is doing the work, including after completion. Distinct from
+    ownership: a finished Task has no one responsible but does have someone
+    who finished it. [Cancelled] answers [None] — the canceller ended the work
+    rather than performing it, and travels as [cancelled_by] instead. *)
+let task_performer_of_status status =
+  match task_actor_of_status status with
+  | Holder name | Submitter name | Completer name -> Some name
+  | Unassigned | Canceller _ -> None
+
+(** Total rendering of the actor for a surface that must print something.
+    [Cancelled] surfaces its canceller and [Todo] yields "unclaimed"; neither
+    is an ownership claim. *)
+let task_display_assignee status =
+  match task_actor_of_status status with
+  | Unassigned -> "unclaimed"
+  | Holder name | Submitter name | Completer name | Canceller name -> name
 
 (** Terminal states: [Done] or [Cancelled]. No further transitions possible.
     Exhaustive match — adding a constructor forces an update here. *)
@@ -668,6 +709,19 @@ let task_claim_next_action_is_claimable task =
   | Claim_now -> true
   | Skip_claim _ -> false
 ;;
+
+(** When the Task last changed state, read from the timestamp its own status
+    carries. [Todo] has no transition of its own and falls back to creation.
+    Defined once: two byte-identical copies lived in the execution and goals
+    projections, one per surface. *)
+let task_last_transition_at (task : task) =
+  match task.task_status with
+  | Done { completed_at; _ } -> completed_at
+  | Cancelled { cancelled_at; _ } -> cancelled_at
+  | InProgress { started_at; _ } -> started_at
+  | AwaitingVerification { submitted_at; _ } -> submitted_at
+  | Claimed { claimed_at; _ } -> claimed_at
+  | Todo -> task.created_at
 
 (* Manual yojson for task *)
 let task_to_yojson t =

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -114,7 +114,28 @@ val task_status_to_string : task_status -> string
 val string_of_task_status : task_status -> string
 val task_status_icon : task_status -> string
 val task_display_assignee : task_status -> string
+(** Who acted on a Task, and in what relationship. A bare [string option]
+    records the name and drops the role, which let three separate local
+    [task_assignee] helpers disagree about [Done] and [Cancelled]. Naming the
+    role makes that disagreement unwritable, and a new status must state which
+    role it carries. *)
+type task_actor =
+  | Unassigned
+  | Holder of string
+  | Submitter of string
+  | Completer of string
+  | Canceller of string
+
+val task_actor_of_status : task_status -> task_actor
+
+val task_actor_name : task_actor -> string option
+
+(** Who owes work now. [Done] and [Cancelled] owe nothing. *)
 val task_assignee_of_status : task_status -> string option
+
+(** Who did or is doing the work, including after completion. [Cancelled]
+    answers [None]: its canceller ended the work rather than performing it. *)
+val task_performer_of_status : task_status -> string option
 val task_status_is_terminal : task_status -> bool
 val task_status_is_done : task_status -> bool
 val all_task_status_names : string list
@@ -196,6 +217,11 @@ type task =
   ; do_not_reclaim_reason : string option [@default None]
   }
 [@@deriving show]
+
+(** When the Task last changed state, from the timestamp its status carries.
+    [Todo] falls back to creation. Defined once: two byte-identical copies
+    lived in the execution and goals projections, one per surface. *)
+val task_last_transition_at : task -> string
 
 val task_to_yojson : task -> Yojson.Safe.t
 val task_of_yojson : Yojson.Safe.t -> (task, string) result

--- a/lib/workspace_status_rendering.ml
+++ b/lib/workspace_status_rendering.ml
@@ -47,13 +47,10 @@ let task_status_badge = function
   | Masc_domain.Done _ -> ("✅", "done")
   | Masc_domain.Cancelled _ -> ("🚫", "cancelled")
 
-let task_assignee = function
-  | Masc_domain.Claimed { assignee; _ }
-  | Masc_domain.InProgress { assignee; _ }
-  | Masc_domain.AwaitingVerification { assignee; _ }
-  | Masc_domain.Done { assignee; _ } -> assignee
-  | Masc_domain.Cancelled { cancelled_by; _ } -> cancelled_by
-  | Masc_domain.Todo -> "unclaimed"
+(* Total render of the actor, not an assignee accessor: the old name claimed
+   a cancelled Task's canceller was its assignee. [task_display_assignee] is
+   the shared definition this duplicated verbatim. *)
+let task_assignee = Masc_domain.task_display_assignee
 
 let active_task_assignee = function
   | Masc_domain.Claimed { assignee; _ }


### PR DESCRIPTION
## 목표

Task 의 "누가" 를 역할까지 포함해 타입으로 올리고, Goal FSM 의 전이 행렬을 닫는다. #26910 위에 쌓는다.

## 1. `task_assignee` 세 구현이 서로 다른 답을 냈다

| 정의 | Todo | **Done** | Cancelled |
|---|---|---|---|
| `Masc_domain.task_assignee_of_status` | None | **None** | None |
| `dashboard_execution_builders` | None | **Some assignee** | None |
| `dashboard_goals_types_accessor` | None | **None** | None |
| `workspace_status_rendering` | `"unclaimed"` | assignee | **`cancelled_by`** |

같은 완료 Task 가 execution 경유로는 담당자가 있고 goal tree 경유로는 없다. 그리고 취소된 Task 의 **취소자를 담당자라고 부른다**.

원인은 `string option` 이 **행위자의 이름만 남기고 역할을 버린다**는 것이다. 어느 헬퍼를 불렀는지에 의미가 숨었다.

## 2. 역할을 타입으로

```ocaml
type task_actor =
  | Unassigned
  | Holder of string      (* Claimed, InProgress *)
  | Submitter of string   (* AwaitingVerification *)
  | Completer of string   (* Done *)
  | Canceller of string   (* Cancelled. 담당자가 아니다 *)
```

세 질문이 이 sum 위의 total 함수 파생이 된다:

| 함수 | 질문 | Done | Cancelled |
|---|---|---|---|
| `task_assignee_of_status` | 지금 누가 책임지나 | None | None |
| `task_performer_of_status` | 누가 했거나 하고 있나 | Some | None |
| `task_display_assignee` | 화면에 뭘 찍나 (total) | 이름 | 취소자 |

`Canceller` 를 `Holder` 자리에 넘길 수 없다. 새 상태를 추가하면 어느 역할인지 말해야 컴파일된다.

## 3. 중복 제거

- `dashboard_execution_builders.task_assignee` — 로컬 재구현 → `task_performer_of_status`
- `workspace_status_rendering.task_assignee` — `task_display_assignee` 를 그대로 베낀 것 → 위임
- `task_updated_at` — **바이트 동일 복제 2벌** → `Masc_domain.task_last_transition_at` 하나
- goals 의 `task_assignee` — ownership 을 쓰고 있어 execution 과 다시 갈렸다 → `task_performer_of_status`

## 4. Goal FSM 전이 행렬을 닫았다

`Goal_phase.decide_transition` 이 5 phase × 7 action = **35 쌍 중 13 쌍만 명시**하고 나머지 22 쌍을 `| _ ->` 로 삼켰다. phase 나 action 을 추가해도 컴파일이 통과하고 새 조합은 조용히 "invalid" 가 된다 — CLAUDE.md 가 명시한 FSM sparse match 이고, keeper_registry 의 런타임 `Assert_failure` 가 선례다.

35 쌍을 전부 명시했다. 동작은 그대로다.

## 검증

- `dune build @check` — 변경 파일 전부 통과
- `test_dashboard_http_core` 69/69, `test_task_transition_broadcast` 11/11
- meta gate: determinism / silent-failure / enum-string 전부 0
- **회귀 증명**: `Dropped` 쌍 하나를 빼면 컴파일러가 non-exhaustive 로 잡는다. 이전 catch-all 은 조용히 통과시켰다

## 미검증 / 알려진 사항

- `test/test_server_ide_http.ml` 는 main 에서 이미 컴파일 실패한다 (stash 후 재현 확인). 본 PR 과 무관
- `test_goal_metric_unevaluated` 1건, `test_workspace_coverage` 2건은 main 기준선과 **동일한 실패 집합** (stash 로 대조 확인)
- 동작 변화 1건: goal tree 의 `assignee` 가 완료 Task 에서 이제 담당자를 보여준다. execution 경유와 값이 일치하게 만드는 변경이며, 정보가 사라지는 방향이 아니다

RFC-WAIVED: 중복 정의 통합과 FSM 행렬 명시화다. 새 설계 결정이 없고, 역할 sum 은 기존 세 구현이 각자 갖고 있던 의미를 이름으로 옮긴 것이다.
