### PR TITLE
fix(dashboard): group autonomous history by exact turn

### DIFF
--- a/dashboard/src/components/chat/autonomous-turn-group.test.ts
+++ b/dashboard/src/components/chat/autonomous-turn-group.test.ts
@@ -1,8 +1,8 @@
 // Autonomous keeper turns in the chat transcript.
 //
 // These rows have no chat-store row; the backend projects final text and work
-// trace from the exact recorded autonomous run. A keeper wakes far more often
-// than anyone talks to it, so consecutive turns remain collapsed.
+// trace from the exact recorded autonomous run. Each exact turn is its own
+// collapsed group, so adjacent wakes remain distinguishable in the transcript.
 import { describe, expect, it } from 'vitest'
 import type { KeeperConversationEntry } from '../../types'
 import { buildChatRenderUnits } from './primitives'
@@ -32,15 +32,23 @@ const tool = (id: string): KeeperConversationEntry =>
   entry(id, { role: 'tool', source: 'tool_result' })
 
 describe('buildChatRenderUnits — autonomous turns', () => {
-  it('folds a run of consecutive autonomous turns into one unit', () => {
+  it('keeps each consecutive autonomous turn in its own collapsed unit', () => {
     const units = buildChatRenderUnits(
       [user('u1'), autonomous('a1'), autonomous('a2'), autonomous('a3'), user('u2')],
       true,
     )
-    expect(units.map((unit) => unit.kind)).toEqual(['entry', 'autonomousGroup', 'entry'])
-    const group = units[1]
-    if (group?.kind !== 'autonomousGroup') throw new Error('expected an autonomousGroup')
-    expect(group.entries.map((e) => e.id)).toEqual(['a1', 'a2', 'a3'])
+    expect(units.map((unit) => unit.kind)).toEqual([
+      'entry',
+      'autonomousGroup',
+      'autonomousGroup',
+      'autonomousGroup',
+      'entry',
+    ])
+    expect(
+      units
+        .filter((unit) => unit.kind === 'autonomousGroup')
+        .map((group) => group.entry.id),
+    ).toEqual(['a1', 'a2', 'a3'])
   })
 
   it('keeps separate runs separate so conversation between them stays in place', () => {
@@ -52,10 +60,10 @@ describe('buildChatRenderUnits — autonomous turns', () => {
   })
 
   it('folds autonomous turns even when tool grouping is off', () => {
-    // Collapsing them guards against their volume; it is not a preference
-    // about how tool calls render.
+    // Collapsing each exact turn guards against its detail volume; it is not a
+    // preference about how tool calls render.
     const units = buildChatRenderUnits([autonomous('a1'), autonomous('a2')], false)
-    expect(units.map((unit) => unit.kind)).toEqual(['autonomousGroup'])
+    expect(units.map((unit) => unit.kind)).toEqual(['autonomousGroup', 'autonomousGroup'])
   })
 
   it('closes an open tool run before starting an autonomous group', () => {

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -3812,25 +3812,12 @@ const TurnWorkBundle = memo(function TurnWorkBundle({
 // transcript stops yanking the viewport while old messages are read.
 const STICK_TO_BOTTOM_THRESHOLD_PX = 80
 
-/** "21:44–00:28" for a collapsed run. Returns null when no turn in the run
- *  carried a timestamp, so the header omits the range instead of showing a
- *  fabricated one. */
-function autonomousGroupSpanLabel(entries: KeeperConversationEntry[]): string | null {
-  const start = timeLabel(entries[0]?.timestamp)
-  const end = timeLabel(entries[entries.length - 1]?.timestamp)
-  if (!start && !end) return null
-  if (!start) return end
-  if (!end || start === end) return start
-  return `${start}–${end}`
-}
-
-/** A run of consecutive autonomous turns, collapsed into a single row. Starts
- *  closed: these turns are the keeper working on its own, and the transcript's
- *  subject is the conversation around them. Expanding renders each turn through
- *  TurnWorkBundle — the same component a direct turn uses. Each expanded row
- *  renders the exact run's final text and typed work trace. */
+/** One autonomous turn, collapsed into a single row. Starts closed: the turn is
+ *  the keeper working on its own, and the transcript's subject is the
+ *  conversation around it. Expanding renders the exact turn's final text and
+ *  typed work trace through the same surfaces a direct turn uses. */
 function AutonomousTurnGroup({
-  entries,
+  entry,
   showMetadata,
   variant,
   showSourceBadge,
@@ -3839,7 +3826,7 @@ function AutonomousTurnGroup({
   toolOutputHydrationContract,
   action,
 }: {
-  entries: KeeperConversationEntry[]
+  entry: KeeperConversationEntry
   showMetadata?: boolean
   variant: ChatTranscriptVariant
   showSourceBadge: boolean
@@ -3849,7 +3836,7 @@ function AutonomousTurnGroup({
   action?: ChatTranscriptAction
 }) {
   const [open, setOpen] = useState(false)
-  const span = autonomousGroupSpanLabel(entries)
+  const timestamp = timeLabel(entry.timestamp)
   return html`
     <div class="chat-block-trace ${open ? 'open' : ''}">
       <button
@@ -3860,11 +3847,11 @@ function AutonomousTurnGroup({
       >
         <span class="chat-block-trace-chev">${open ? '▾' : '▸'}</span>
         <span class="chat-block-trace-label">자율턴</span>
-        <span class="chat-block-trace-count">${entries.length}개</span>
-        ${span ? html`<span class="chat-block-trace-meta">${span}</span>` : null}
+        <span class="chat-block-trace-count">1개</span>
+        ${timestamp ? html`<span class="chat-block-trace-meta">${timestamp}</span>` : null}
       </button>
       ${open
-        ? entries.map((entry) => (entry.traceSteps?.length ?? 0) > 0
+        ? (entry.traceSteps?.length ?? 0) > 0
           ? html`<${TurnWorkBundle}
               key=${entry.id}
               tools=${[]}
@@ -3884,7 +3871,7 @@ function AutonomousTurnGroup({
               variant=${variant}
               showSourceBadge=${showSourceBadge}
               action=${action}
-            />`)
+            />`
         : null}
     </div>
   `
@@ -3894,11 +3881,12 @@ type ChatRenderUnit =
   | { kind: 'entry'; entry: KeeperConversationEntry }
   | { kind: 'toolGroup'; id: string; entries: KeeperConversationEntry[] }
   | { kind: 'turnBundle'; id: string; entries: KeeperConversationEntry[]; entry: KeeperConversationEntry }
-  // A run of turns the keeper took on its own, collapsed into one row. Kept
+  // One turn the keeper took on its own, collapsed into one row. Kept
   // separate from turnBundle because these are not answers to anyone: a keeper
-  // wakes on the order of once a minute, so rendering each one inline would
-  // bury the conversation it sits between.
-  | { kind: 'autonomousGroup'; id: string; entries: KeeperConversationEntry[] }
+  // wakes on the order of once a minute, so rendering each turn expanded would
+  // bury the conversation it sits between. The exact turn remains the group
+  // boundary; adjacent autonomous turns must never merge into one giant run.
+  | { kind: 'autonomousGroup'; id: string; entry: KeeperConversationEntry }
 
 function entryTurnRef(entry: KeeperConversationEntry): string | null {
   const value = entry.turnRef?.trim()
@@ -3951,7 +3939,6 @@ export function buildChatRenderUnits(
 ): ChatRenderUnit[] {
   const units: ChatRenderUnit[] = []
   let run: KeeperConversationEntry[] = []
-  let autonomousRun: KeeperConversationEntry[] = []
   const flush = () => {
     if (run.length === 0) return
     const first = run[0]
@@ -3959,23 +3946,13 @@ export function buildChatRenderUnits(
     units.push({ kind: 'toolGroup', id: `tracegroup-${first.id}`, entries: run })
     run = []
   }
-  // Autonomous turns collapse whether or not tool folding is on: grouping them
-  // guards against their volume, it is not a tool-rendering preference.
-  const flushAutonomous = () => {
-    if (autonomousRun.length === 0) return
-    const first = autonomousRun[0]
-    if (!first) return
-    units.push({ kind: 'autonomousGroup', id: `autonomous-${first.id}`, entries: autonomousRun })
-    autonomousRun = []
-  }
   for (const entry of entries) {
     if (isAutonomousTurnEntry(entry)) {
       // Any open tool run belongs to the direct turn that preceded this wake.
       flush()
-      autonomousRun.push(entry)
+      units.push({ kind: 'autonomousGroup', id: `autonomous-${entry.id}`, entry })
       continue
     }
-    flushAutonomous()
     if (!groupToolCalls) {
       units.push({ kind: 'entry', entry })
       continue
@@ -4012,12 +3989,11 @@ export function buildChatRenderUnits(
     }
   }
   flush()
-  flushAutonomous()
   return units
 }
 
 function unitTimestamp(unit: ChatRenderUnit): string | null {
-  const ts = unit.kind === 'entry'
+  const ts = unit.kind === 'entry' || unit.kind === 'autonomousGroup'
     ? unit.entry.timestamp
     : unit.entries[0]?.timestamp ?? (unit.kind === 'turnBundle' ? unit.entry.timestamp : null)
   return ts ?? null
@@ -4078,7 +4054,7 @@ function renderChatTranscriptBody(opts: {
     if (unit.kind === 'autonomousGroup') {
       out.push(html`<${AutonomousTurnGroup}
         key=${unit.id}
-        entries=${unit.entries}
+        entry=${unit.entry}
         showMetadata=${showMetadata}
         variant=${variant}
         showSourceBadge=${showSourceBadge}


### PR DESCRIPTION
## Summary

- render every typed autonomous history row as its own collapsed chat group
- make the autonomous render-unit boundary singular at the type level
- preserve independent expand/collapse state for each exact autonomous turn

## Product impact

- User-visible change: consecutive autonomous turns appear as separate compact groups instead of one giant group; each group expands independently.

## Evidence

- Focused Vitest: 11 passed.
- TypeScript typecheck, full dashboard lint, and production build passed.
- Playwright fixture interaction rendered two consecutive turns as two `1개` groups and independently expanded both.
- Screenshot: `/tmp/masc-autonomous-turn-per-group-20260805.png` (local operator evidence).

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/5
provenance: operator_proxy
stages:
  - name: focused_vitest
    result: pass
  - name: typescript_typecheck
    result: pass
  - name: dashboard_lint
    result: pass
  - name: production_build
    result: pass
  - name: playwright_interaction
    result: pass
```

## GOAL LOOP ACT checklist

- [x] Observe — consecutive typed autonomous rows reproduced as one merged render unit by the existing regression test.
- [x] Orient — the renderer accumulated every adjacent `source=autonomous_turn` entry into one maximal run.
- [x] Decide — the backend already supplies exact `autonomous_turn.turn_id`; one typed row is the non-heuristic UI boundary.
- [x] Act — removed the run accumulator and made the render unit carry a singular entry.
- [x] Verify — focused tests, typecheck, lint, build, and Playwright interaction passed.
- [x] Loop — no remaining follow-up for this bounded grouping defect.

## Review evidence

- Codex adversarial self-review removed the residual array/span representation so merging multiple autonomous turns is no longer representable by the `autonomousGroup` type.

## Linked issue

- Relates #26878

## Variant addition checklist

- [ ] **OCaml** — N/A: no OCaml variant changed.
- [ ] **TypeScript** — N/A: no shared union member added, removed, or renamed.
- [ ] **TLA+ spec** — N/A: no protocol/domain literal changed.
- [ ] **Event / JSON schema** — N/A: no event or JSON schema changed.
- [ ] **`make check-variants` passes** — N/A: no variant surface changed.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/autonomous-turn-per-group-20260805` → `main` · 1 commit(s) · synced 2026-08-05T06:13:32Z

| sha | subject | date |
|---|---|---|
| `526bab50b` | fix(dashboard): group autonomous history by exact turn | 2026-08-05 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->