### PR TITLE
fix(core): 고아로 오인돼 삭제된 atomic_util.mli 복원 — 열린 PR 전부의 ratchet red 원인

### DIFF
--- a/lib/core/atomic_util.mli
+++ b/lib/core/atomic_util.mli
@@ -1,0 +1,6 @@
+(** Lock-free atomic update helpers. *)
+
+(** [update r f] atomically replaces the contents of [r] with [f (Atomic.get r)],
+    retrying with a fresh read if a concurrent writer changed [r] between the read
+    and the compare-and-set. *)
+val update : 'a Atomic.t -> ('a -> 'a) -> unit


### PR DESCRIPTION
열려 있는 모든 PR 이 이것 하나 때문에 red 다.

```
FAIL lib_other_mli_missing: 1 > baseline 0
```

## 두 PR 이 서로를 못 보고 엇갈렸다

```
#26813  lib/core/atomic_util.ml   생성 (+6)   — 동일 구현 55건 공통화
#26832  lib/core/atomic_util.mli  삭제 (−6)   — 사유: "an interface file whose
                                                .ml was deleted at some point"
```

`#26832` 는 `.ml` 없는 고아 `.mli` 로 판단했는데, 그 시점엔 `#26813` 이 **`.ml` 을 이미 되살려 놓은 뒤**였다. 그리고 그 `.ml` 은 지금도 이렇게 시작한다:

```ocaml
(* See atomic_util.mli for the contract. *)
```

`Atomic_util.update` 소비자는 둘이다 — `server_mcp_transport_http_conn.ml`, `server_mcp_transport_http_session.ml`.

## 변경

`25156ca2b1^` 에서 **그대로 복원**했다. 새로 쓴 내용은 없다.

```ocaml
(** Lock-free atomic update helpers. *)

(** [update r f] atomically replaces the contents of [r] with [f (Atomic.get r)],
    retrying with a fresh read if a concurrent writer changed [r] between the read
    and the compare-and-set. *)
val update : 'a Atomic.t -> ('a -> 'a) -> unit
```

## 검증

```
scripts/ocaml-structure-ratchet.sh   before: exit 2 (FAIL lib_other_mli_missing)
                                     after:  OCaml structure ratchet: OK
ocamlformat --check                  exit 0
```

## 어떻게 여기까지 왔나

두 PR 모두 CI conclusion 에 `success` 없이 머지됐다. 오늘 같은 경로로 main 에 들어온 결함이 이것으로 네 번째다:

| | 결함 | 상태 |
|---|---|---|
| 1 | `board_votes.ml` stray semicolon ×2 — main 파싱 불가 | #26890 으로 수정 |
| 2 | `keeper_tool_visibility_projection` 매트릭스 stale | #26890 / #26894 |
| 3 | `test_keeper_wake_turn_context` 3건 red | 미해결 |
| 4 | `lib_other_mli_missing` | **이 PR** |

측정: 최근 머지 12건 중 11건이 head SHA 에 CI success 기록 없이 cancelled 만 있다. 별도로 `task-173` 에 올려 두었다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
