### PR TITLE
docs(rfc): RFC-0267 을 Implemented 로 — 두 단계 모두 2026-06 에 배포됨

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -267,7 +267,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0264 | Memory OS recall outcome-anchored eval harness | Draft | - |
 | 0265 | Withdraw MASC modality capability rerouting | Withdrawn | - |
 | 0266 | Fusion async-completion wake + in-progress 가시성 | Draft | - |
-| 0267 | Make task↔goal links visible and explicitly assignable | Draft | - |
+| 0267 | Make task↔goal links visible and explicitly assignable | Implemented | - |
 | 0269 | Process Critic Loop for Keeper Work Traces | Draft | - |
 | 0270 | CI Gate merge guard: block merges on a non-success CI Gate and trip on red main | Draft | - |
 | 0271 | Withdraw progress-based turn rejection and pause | Withdrawn | - |

--- a/docs/rfc/RFC-0267-task-goal-linkage-projection-and-explicit-assignment.md
+++ b/docs/rfc/RFC-0267-task-goal-linkage-projection-and-explicit-assignment.md
@@ -1,14 +1,14 @@
 ---
 rfc: "0267"
 title: "Make task↔goal links visible and explicitly assignable"
-status: Draft
+status: Implemented
 created: 2026-06-20
-updated: 2026-06-20
+updated: 2026-08-05
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0245"]
-implementation_prs: []
+implementation_prs: ["21704", "21722"]
 ---
 
 ## 1. Motivation


### PR DESCRIPTION
RFC-0267 은 `status: Draft` / `implementation_prs: []` 인데 **두 단계 모두 트리에 있다.**

| RFC 요구 | 구현 | PR |
|---|---|---|
| Phase 1 — `/execution` 경계에서 `goal_id` 투영 | `dashboard_execution.ml:561` `task_canonical_goal_id`, `:575` `task_json ~goal_task_index`, `:590` `("goal_id", ...)` | #21704 |
| Phase 2 — 명시적 배정, 타입 오류 | `lib/task/task_goal_assignment.{ml,mli}` — `Unknown_task`, `Already_linked_to_goals` | #21722 |
| MCP 도구 `masc_task_set_goal` | `keeper_tool_descriptor.ml:1883` | #21722 |
| HTTP 라우트 | `POST /api/v1/dashboard/tasks/assign-goal` | #21722 |
| FE 배정 컨트롤 | `dashboard/src/components/task-manage/task-manage-state.ts` | #21722 |

## 낡은 상태는 무해하지 않다

오늘 이 RFC 를 읽고 **Phase 1 이 미구현이라고 결론 내린 뒤 구현을 시작했다.** 내가 확인한 파일(`dashboard_execution_builders.ml`)에는 keeper 의 `active_goal_ids` 만 있고, 투영은 `dashboard_execution.ml` 에 있다. 배포된 작업에 붙은 Draft 마커가 정확히 그 오독을 불렀다.

같은 종류를 오늘 이미 한 번 처리했다 — #26864 (코드에 없는 심볼을 설명하던 `.mli` 주석 2건). 죽은 문서는 읽는 사람을 **멈추게 하지 않고 틀린 방향으로 자신 있게 보낸다.**

## 라이브 확인

연결 레지스트리는 살아 있다:

```
tasks/goal_task_links.json   last_updated 2026-08-05T06:02:52Z
goal-request-menu-zero       task-159,160,161,164,166,167,176  (7건)
```

즉 Phase 2 는 **지금도 쓰이고 있다.**

## 검증

```
scripts/check-doc-truth.sh   exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
