### PR TITLE
chore: 모듈 밖에서 아무도 안 쓰는 .mli export 16건 비공개화

### DIFF
--- a/lib/auth/auth_oauth.mli
+++ b/lib/auth/auth_oauth.mli
@@ -38,9 +38,6 @@ val max_pending_codes : unit -> int
 val pkce_s256 : string -> string
 (** RFC 7636 S256 transform using unpadded base64url. *)
 
-val valid_pkce_value : string -> bool
-(** RFC 7636 verifier/challenge character and length check (43..128). *)
-
 val parse_scopes : string option -> (scope list, error) result
 (** Parse a space-delimited scope request.  Missing/blank means
     [[Mcp_tools]]. Duplicate scopes are collapsed in declaration order, and
@@ -53,8 +50,6 @@ val effective_role :
   scope list ->
   (Masc_domain.agent_role, error) result
 (** OAuth scopes may preserve or reduce the bootstrap role, never increase it. *)
-
-val validate_loopback_redirect_uri : string -> (unit, error) result
 
 type client = {
   client_id : string;

--- a/lib/board_addressing/board_addressing.mli
+++ b/lib/board_addressing/board_addressing.mli
@@ -26,12 +26,6 @@
 val target_prefix : string
 (** ["@"] — the single-at direct-target prefix. *)
 
-val broadcast_selector_prefix : string
-(** ["@@"] — the double-at broadcast selector prefix. *)
-
-val broadcast_all_selector : string
-(** ["all"] — the only universally supported broadcast selector. *)
-
 val trim_token_edges : string -> string
 (** Trim non-word characters from both ends of a token, keeping internal
     ones.  Word chars are [A-Za-z0-9@_-]; ['.'] is NOT a word char, so

--- a/lib/fs_compat/capability_head.ml
+++ b/lib/fs_compat/capability_head.ml
@@ -50,9 +50,6 @@ type snapshot =
 
 let snapshot_row snapshot = snapshot.row
 let snapshot_cursor snapshot = snapshot.cursor
-let snapshot_settlement_warnings (snapshot : snapshot) =
-  snapshot.settlement_warnings
-
 type error =
   | Invalid_leaf of string
   | Invalid_row of string

--- a/lib/fs_compat/capability_head.mli
+++ b/lib/fs_compat/capability_head.mli
@@ -47,9 +47,6 @@ type snapshot
 
 val snapshot_row : snapshot -> string option
 val snapshot_cursor : snapshot -> cursor
-val cursor_equal : cursor -> cursor -> bool
-val snapshot_settlement_warnings : snapshot -> settlement_warning list
-
 type error =
   | Invalid_leaf of string
   | Invalid_row of string

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -600,12 +600,6 @@ let durable_state_result ~base_path name =
     ~keeper_name:name
 ;;
 
-let existing_durable_state_result ~base_path name =
-  Keeper_event_queue_persistence.load_existing_state_result
-    ~base_path
-    ~keeper_name:name
-;;
-
 let reprioritize_pending_result
       ~base_path
       name

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -266,13 +266,6 @@ val durable_state_result :
     Absence of both the current snapshot and transition WAL is the valid empty
     state used before the first durable enqueue. *)
 
-val existing_durable_state_result :
-  base_path:string -> string -> (Keeper_event_queue_state.t, string) result
-(** Read the same durable state when the caller is interpreting the absence of
-    prior work. A snapshot or transition WAL proves the owner exists; absence
-    of both is an explicit error and therefore cannot become evidence that an
-    occurrence was lost. *)
-
 val reprioritize_pending_result :
   base_path:string ->
   string ->

--- a/lib/keeper_runtime/keeper_internal_error.mli
+++ b/lib/keeper_runtime/keeper_internal_error.mli
@@ -155,7 +155,6 @@ type masc_internal_error =
       detail : string;
     }
 
-val gate_replay_repair_stage_to_string : gate_replay_repair_stage -> string
 val masc_internal_error_prefix : string
 
 val runtime_runner_execute_site : string

--- a/lib/keeper_runtime/keeper_runtime_failure_route.ml
+++ b/lib/keeper_runtime/keeper_runtime_failure_route.ml
@@ -268,19 +268,6 @@ let terminal_class_label = function
   | Terminal_effect_workflow_rejection -> "terminal_effect_workflow_rejection"
   | Internal_opaque -> "internal_opaque"
 
-let failure_provenance_label = function
-  | Oas_api_error -> "oas_api_error"
-  | Oas_provider_error -> "oas_provider_error"
-  | Oas_agent_error -> "oas_agent_error"
-  | Oas_mcp_error -> "oas_mcp_error"
-  | Oas_config_error -> "oas_config_error"
-  | Oas_serialization_error -> "oas_serialization_error"
-  | Oas_io_error -> "oas_io_error"
-  | Oas_orchestration_error -> "oas_orchestration_error"
-  | Oas_internal_error -> "oas_internal_error"
-  | Masc_internal_error -> "masc_internal_error"
-  | Completion_contract -> "completion_contract"
-
 let route_class_label = function
   | Retry_after_observed { retry_class; _ } -> retry_class_label retry_class
   | Rotate_now { rotate } -> rotate_class_label rotate

--- a/lib/keeper_runtime/keeper_runtime_failure_route.mli
+++ b/lib/keeper_runtime/keeper_runtime_failure_route.mli
@@ -125,11 +125,6 @@ val route_kind_label : route -> string
 
 val retry_class_label : retry_class -> string
 val rotate_class_label : rotate_class -> string
-val terminal_class_label : terminal_class -> string
-
-val failure_provenance_label : failure_provenance -> string
-(** Stable telemetry label. *)
-
 val route_class_label : route -> string
 (** The route's class label ([retry_class_label] / [rotate_class_label] /
     [terminal_class_label] respectively). *)

--- a/lib/server/server_oauth_metadata.mli
+++ b/lib/server/server_oauth_metadata.mli
@@ -5,9 +5,6 @@
 val base_url : Server_request_authority.authority -> string
 val resource : Server_request_authority.authority -> string
 val protected_resource_metadata_url : Server_request_authority.authority -> string
-val authorization_endpoint : Server_request_authority.authority -> string
-val token_endpoint : Server_request_authority.authority -> string
-val registration_endpoint : Server_request_authority.authority -> string
 val challenge : Server_request_authority.authority -> string
 val challenge_for_authority : Server_request_authority.authority -> string
 (** OAuth discovery challenge when built-in OAuth is enabled on loopback;

--- a/lib/server/server_oauth_service.mli
+++ b/lib/server/server_oauth_service.mli
@@ -24,8 +24,6 @@ val ensure_optional_string_subset :
   string list ->
   (unit, Auth_oauth.error) result
 
-val oauth_error_description : Auth_oauth.error -> string
-
 val oauth_error_status :
   Auth_oauth.error ->
   [ `Bad_request | `Internal_server_error | `Service_unavailable | `Unauthorized ]

--- a/lib/server/server_routes_http_dashboard_dev_token.mli
+++ b/lib/server/server_routes_http_dashboard_dev_token.mli
@@ -23,7 +23,6 @@ type dashboard_dev_token =
 
 val dashboard_dev_token_path : string -> string
 val dashboard_dev_token_pending_path : string -> string
-val token_error_code : token_error -> string
 val token_error_to_string : token_error -> string
 val request_error_status : request_error -> Httpun.Status.t
 val request_error_code : request_error -> string

--- a/lib/server/server_routes_http_runtime_fleet_scan.mli
+++ b/lib/server/server_routes_http_runtime_fleet_scan.mli
@@ -121,8 +121,6 @@ type keeper_execution_snapshot = {
   owners : keeper_execution_owner list;
   executable_names : string list;
 }
-val keeper_non_executable_cause_to_wire :
-  keeper_non_executable_cause -> string
 val empty_keeper_execution_snapshot : keeper_execution_snapshot
 val keeper_execution_snapshot :
   Workspace.config -> keeper_execution_snapshot


### PR DESCRIPTION
## 무엇을

`scripts/audit-dead-surface.py --exports` 가 지목한 16건을 처리합니다. 13파일 −57줄.

## 두 부류로 갈립니다

**13건은 죽은 export** — 자기 `.ml` 안에서는 쓰이는데 `.mli` 가 외부에 공개하고 아무도 안 씁니다. `val` 만 지워 모듈 사설로 만들고 구현은 그대로 둡니다.

- `authorization_endpoint` — 자기 정의 3줄 아래에서 metadata 문서를 만듭니다
- `valid_pkce_value` — challenge 와 verifier 양쪽을 검사합니다
- `keeper_non_executable_cause_to_wire` — 두 곳에서 직렬화합니다

**3건은 죽은 코드** — 내부 사용도 0입니다. `lib/dune` 이 `-w` 를 설정하지 않아 dune dev 프로파일 기본값(`@30..39`, 경고 32가 **에러**)을 쓰므로, export 만 지우면 컴파일이 깨집니다. 구현도 함께 제거합니다:

| 대상 | 정체 |
|---|---|
| `capability_head.snapshot_settlement_warnings` | 한 줄짜리 필드 읽기 |
| `keeper_registry_event_queue.existing_durable_state_result` | `Keeper_event_queue_persistence` 래퍼 |
| `keeper_runtime_failure_route.failure_provenance_label` | 11개 arm 라벨 매핑 |

## 파사드 플래그 해석

감사 도구의 `behind a facade re-export` 는 **모듈이** `fs_compat` / `keeper_turn_driver` / `server_routes_http_runtime` 를 통해 재수출된다는 뜻이지 **값이** 따로 재수출된다는 뜻이 아닙니다. 그 파사드들은 `include module type of` 를 쓰므로 원본 `.mli` 를 좁히면 함께 좁아집니다.

편집 후 16건 전부에 대해 정의 `.ml` 밖 참조가 0임을 확인했습니다.

## 검증

```
Doc code_refs OK
[keeper-tool-boundary-matrix] OK - 125 scoped keeper files covered
lib/config 미변경 → env 노브 카탈로그 재생성 불필요
```

전체 dune 빌드는 돌리지 않았습니다 — CI 가 1차 검증입니다. 이 변경은 성격상 컴파일러가 판정합니다: 밖에서 쓰는 곳이 하나라도 있으면 빌드가 깨집니다.

RFC-WAIVED: credential / identity / operator control action handler / keeper sandbox / hooks 어디에도 해당하지 않습니다. 공개 표면을 좁히는 변경이고 살아있는 동작은 불변입니다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>