### PR TITLE
docs(rfc): RFC-0361 — Goal 책임자와 intake 계약 (설계만)

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -345,6 +345,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0356 | Approval owns the effect (replay the approved payload, do not require byte-id... | Draft | - |
 | 0358 | 자율턴 신원과 exact raw-trace run을 turn record가 소유한다 | Implemented | - |
 | 0360 | Task actor provenance | Draft | - |
+| 0362 | Goal owner and the intake contract | Draft | - |
 | RFC-0034d-stale-agent-sync | d — release_stale_claims agent-side sync | Draft | - |
 | RFC-async-log-sink-durable-append-offload | Offload the structured-log durable append off the emitting fiber | Draft | - |
 | RFC-checkpoint-pinned-root-containment | Immutable boot-pinned root capability for checkpoint containment | Draft | - |

--- a/docs/rfc/RFC-0361-goal-owner-and-intake-contract.md
+++ b/docs/rfc/RFC-0361-goal-owner-and-intake-contract.md
@@ -1,0 +1,148 @@
+---
+rfc: "0361"
+title: "Goal owner and the intake contract"
+status: Draft
+created: 2026-08-05
+updated: 2026-08-05
+author: vincent
+supersedes: []
+superseded_by: null
+related: ["0267", "0245", "0357"]
+implementation_prs: []
+---
+
+## 1. Motivation
+
+A Goal cannot name who is responsible for it, so nobody turns a Goal into
+Tasks.
+
+Measured on the live workspace (base path `/Users/dancer/me`, 2026-08-05):
+
+```
+goals.json                     15 goals — executing 10, completed 4, blocked 1
+owner/assignee/responsible     no such field on the goal record
+executing goals with a task    0 of 10
+keepers with active_goal_ids   0 of 8
+goal_events.jsonl              12 lines, entire history
+```
+
+The ten executing Goals have produced no Task between them. The only
+keeper-side pointer, `keeper_meta.active_goal_ids`, is empty for every keeper.
+
+Work still enters the system, but through one accident:
+
+```
+tasks/backlog.json     169 tasks
+  kidsnote    121  (74 done, 47 cancelled)   72%
+  lane-smith   19
+  other 10 actors combined  29
+created per day        07-29: 104 · 07-30: 23 · 08-03: 16 · 08-04: 11 · 08-05: 0
+```
+
+`kidsnote` is 72% of all intake, and its config is the only one that looks
+outward (`제품과 프로젝트의 실제 사용 흐름을 점검`, `Github ... deployment
+상태를 확인`). That is a property of one keeper's instructions, not of the
+system's design. When that keeper went quiet, intake went to zero, and 47 of
+its tasks expired unclaimed.
+
+Everyone else is a consumer of a queue nothing fills. The observable
+consequences were measured separately and are already recorded: 11,316 reads
+against 5 creations over two months, a keeper posting the same unchanged
+status 26 times in 4.7 hours (#26861), 23 of one keeper's 29 stored memory
+facts being board snapshots written in place of work, and keepers writing
+rules that narrow their own scope (#26862).
+
+## 2. What already exists
+
+- **`Goal`** (`lib/goal/goal_store.ml:9`) —
+  `{ id; title; metric; target_value; due_date; priority; phase;
+  parent_goal_id; last_review_note; last_review_at; created_at; updated_at }`.
+  No owner.
+- **`masc_goal_upsert`** accepts `id, title, metric, target_value, due_date,
+  priority, parent_goal_id`. No owner.
+- **`masc_goal_list`**, **`masc_goal_transition`** — read and phase change.
+- **`keeper_meta.active_goal_ids`** — a keeper-side list. Its consumers are
+  `dashboard_briefing_assembly.ml:221`, `dashboard_execution_builders.ml:247`
+  and `:318`, `dashboard_http_keeper.ml:92` and `:744`, plus a test fixture.
+  **Every one of them renders it.** No scheduler, turn assembly, or claim path
+  reads it.
+- **Task↔Goal linkage** is solved and shipped (RFC-0267, PRs #21704/#21722):
+  `masc_task_set_goal`, `POST /api/v1/dashboard/tasks/assign-goal`, and the
+  `goal_id` projection on `/execution`. This RFC does not revisit that axis.
+
+## 3. The failure this RFC must not repeat
+
+`active_goal_ids` is the precedent. The field exists, the dashboard draws it,
+and no behavior depends on it — so a Goal being "held" by a keeper changes
+nothing, and today the field is empty everywhere without anyone noticing.
+
+**Adding `goal.owner` without a consumer produces a second `active_goal_ids`.**
+A field is not a contract. The contract is the sentence some code path says to
+the owner, and the evidence that the path runs.
+
+## 4. Proposal
+
+Three parts, shipped together. Any two without the third is the failure in §3.
+
+### 4.1 `goal.owner : string option`
+
+On the Goal record, not on the keeper. A Goal is the thing that has an owner;
+a keeper's list of goals is a projection of that, derivable on read the same
+way `build_task_goal_index_for_config` derives task→goal.
+
+`None` is legitimate and is the default: an unowned Goal is a stated intent
+nobody has picked up, which is a real and reportable state — not an error.
+
+### 4.2 `masc_goal_assign`
+
+```
+masc_goal_assign
+  goal_id  (required)
+  owner    (required; validated against the keeper registry; unknown -> error)
+```
+
+Both required. Omitting `owner` is a schema error, never an auto-pick. This
+mirrors RFC-0267 §Phase 2 deliberately: that RFC records that the earlier
+`masc_add_task` schema falsely claimed to "auto-link a single active goal",
+and #21653 removed the claim rather than implementing the guess.
+
+Reassignment and unassignment are in scope (an owner who cannot continue must
+be able to hand the Goal back); `Already_owned` is not an error, the transition
+is recorded in `goal_events`.
+
+### 4.3 The consumer — one path, and it must be named here
+
+The owner's turn states the Goal and asks for its next Task. Concretely: the
+turn assembly that already renders `Current Goal` sections gains, for a Goal
+this keeper owns whose phase is `executing`, the fact that **no Task is
+currently linked to it** — which is exactly the measurement in §1 (0 of 10) and
+is already computable from `build_goal_task_index_for_config`.
+
+That is the whole consumer. It states a fact the owner is positioned to act on.
+It does not add a gate, a cap, or a required action, and it names no empty case
+(see #26901: naming the empty branch is what produced the flood it replaced).
+
+**Acceptance:** a Goal with an owner and no linked Task must be observable in
+that owner's turn, demonstrated on the live workspace by the count in §1
+moving off 0. If it does not move, this RFC failed and the field should be
+removed rather than kept as decoration.
+
+## 5. Non-goals
+
+- **No auto-assignment.** Nothing picks an owner for a Goal.
+- **No required action.** The owner is told the state; whether to create a Task
+  is judgment. RFC-0357 was withdrawn (2026-08-04) precisely because admission
+  gating was the wrong lever and supply was the real problem; this RFC does not
+  reintroduce a gate.
+- **No multi-owner.** One owner or none. If shared ownership is needed later,
+  sub-goals via `parent_goal_id` already express it.
+- **Task↔Goal linkage is untouched** (RFC-0267, shipped).
+
+## 6. Open questions
+
+1. Does the owner projection replace `keeper_meta.active_goal_ids`, or coexist?
+   The measurement says the field is empty everywhere and read only by the
+   dashboard; deriving it from `goal.owner` on read would remove a second
+   source of truth.
+2. Should `phase = executing` with `owner = None` be surfaced to the operator?
+   It is the exact state of all ten live Goals and nothing reports it today.

--- a/docs/rfc/RFC-0362-goal-owner-and-intake-contract.md
+++ b/docs/rfc/RFC-0362-goal-owner-and-intake-contract.md
@@ -1,5 +1,5 @@
 ---
-rfc: "0361"
+rfc: "0362"
 title: "Goal owner and the intake contract"
 status: Draft
 created: 2026-08-05


### PR DESCRIPTION
설계만. 코드 변경 없음.

## 왜

**executing Goal 10개가 Task 를 하나도 낳지 않았다.** Goal 이 책임자를 지목할 수 없기 때문이다.

라이브 실측 (2026-08-05, base path `/Users/dancer/me`):

```
goals.json                     15 — executing 10 · completed 4 · blocked 1
owner/assignee/responsible     goal 레코드에 그런 필드 없음
executing goal 중 task 링크     0 / 10
active_goal_ids 보유 keeper     0 / 8
goal_events.jsonl              전체 역사 12줄
```

일은 들어오는데 **우연히** 들어온다:

```
tasks/backlog.json   169건
  kidsnote     121  (done 74 / cancelled 47)   72%
  lane-smith    19
  나머지 10 actor 합  29
일자별 생성   07-29: 104 · 07-30: 23 · 08-03: 16 · 08-04: 11 · 08-05: 0
```

`kidsnote` 가 전체 intake 의 72% 이고, 그 config 만 유일하게 바깥을 본다. **설계가 아니라 한 keeper 의 지시문 속성이다.** 그 keeper 가 조용해지자 생성이 0 이 됐고 47건이 unclaimed 로 만료됐다.

## 이 RFC 가 반복하면 안 되는 실패

`active_goal_ids` 가 선례다. 필드가 있고, 대시보드가 그리고, **어떤 동작도 그것에 의존하지 않는다.** 소비자 전수가 렌더링이다:

```
dashboard_briefing_assembly.ml:221 · dashboard_execution_builders.ml:247,318
dashboard_http_keeper.ml:92,744 · 테스트 픽스처
```

그래서 keeper 가 Goal 을 "들고 있어도" 아무것도 안 바뀌고, 오늘 그 필드는 **전 keeper 에서 비어 있는데 아무도 모른다.**

**소비자 없이 `goal.owner` 만 추가하면 `active_goal_ids` 가 하나 더 생긴다.** 필드는 계약이 아니다. 계약은 **어떤 코드 경로가 owner 에게 하는 말**이고, 그 경로가 실제로 돈다는 증거다.

## 제안 — 셋이 함께

| | |
|---|---|
| `goal.owner : string option` | Goal 쪽에. keeper 쪽 목록은 read-time 투영 (RFC-0267 의 task→goal 방식과 동일) |
| `masc_goal_assign` | 둘 다 필수. `owner` 생략은 스키마 오류이지 auto-pick 이 아님 |
| **소비자 하나** | owner 의 턴에서, 자기가 소유한 executing Goal 에 **연결된 Task 가 없다는 사실**을 말함 |

소비자가 말하는 그 사실이 §1 의 `0 / 10` 그대로이고, `build_goal_task_index_for_config` 로 이미 계산 가능하다. **게이트도 cap 도 강제 행동도 없고, 빈 경우를 이름 붙이지 않는다** (#26901 — 빈 분기를 명시한 것이 그 홍수를 만들었다).

## 수용 기준을 코드 속성이 아니라 실측으로

> owner 가 있고 링크된 Task 가 없는 Goal 이 그 owner 의 턴에서 관측돼야 하고, §1 의 `0 / 10` 이 **0 에서 움직여야 한다.**
> 움직이지 않으면 이 RFC 는 실패한 것이고, 필드는 장식으로 두지 말고 **제거**한다.

## Non-goals

- **auto-assignment 없음** — 아무것도 owner 를 대신 고르지 않는다
- **강제 행동 없음** — RFC-0357 이 2026-08-04 에 철회된 이유가 정확히 이것이다. admission 게이팅은 잘못된 레버였고 진짜 문제는 supply 였다
- **multi-owner 없음** — 필요하면 `parent_goal_id` 로 sub-goal
- **task↔goal 연결은 안 건드림** — RFC-0267, #21704/#21722 로 이미 배포됨

## 검증

```
scripts/check-doc-truth.sh   exit 0
```

관련: #26862 (도달 불가 조건), #26863 (관측 불가), #26840 (Goal 소유 부재 최초 기록)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
