### PR TITLE
fix(lint): RFC-0132 스캐너가 코드로 읽는 주석 수정 (main 빨간불)

### DIFF
--- a/lib/keeper/keeper_status_runtime.ml
+++ b/lib/keeper/keeper_status_runtime.ml
@@ -222,8 +222,8 @@ let keeper_reply_snapshot_of_history (history_items : Yojson.Safe.t list) =
    decoded. [meta.runtime.proactive_rt.last_reason] used to be searched for
    error keywords, but its producer documents it as display detail and a
    successful cycle formats it as "unified:tools=[...]" — so a cycle that
-   called masc_runtime_status matched the "runtime" keyword and reported the
-   keeper as degraded. *)
+   called masc_runtime_status matched one of those keywords on the tool name
+   alone and reported the keeper as degraded. *)
 let keeper_error_hint ~agent_status = json_string_opt "error" agent_status
 
 (* A live signal newer than the persisted error snapshot means


### PR DESCRIPTION
main 이 `Lint Suite` → `Boundary redaction SSOT (RFC-0132 PR-3)` 에서 실패합니다.

보고된 위반 1건이 **주석**입니다:

```
lib/keeper/keeper_status_runtime.ml:225:
  called masc_runtime_status matched the "runtime" keyword and reported the
```

`scripts/lint/no-runtime-literal-outside-boundary-redaction.sh` 가 스캔 대상에서 따옴표 친 `"runtime"` 을 찾는데 **OCaml 주석을 벗기지 않습니다.** #26917 에서 키워드 분류기를 왜 지웠는지 설명한 문장이 새 인라인 리터럴로 잡혔습니다.

키워드를 인용하지 않고 메커니즘만 서술하도록 고쳤습니다. 잃는 정보가 없습니다 — 같은 문장이 이미 매치가 툴 이름에서 일어났다고 말합니다.

게이트가 `RFC-0132-EXEMPT` 마커를 탈출구로 제시하지만, 그 마커는 **코드** 면제를 선언하는 것이고 여기엔 면제할 코드가 없습니다.

## 같은 부류가 오늘만 두 번째입니다

| 린트 | 걸린 것 |
|---|---|
| `check-determinism-contract.sh` | `Option.value ~default:max_float` 를 설명한 주석 |
| `no-runtime-literal-outside-boundary-redaction.sh` | 위 주석 |

**둘 다 수정을 설명하는 주석에 걸렸습니다.** 스캔 전 주석 스트리핑이 근본 수정이고 별도 변경으로 남깁니다.

## 검증

```
rfc0132_pr3_violations                              0
[no-runtime-literal-outside-boundary-redaction] OK
```

RFC-WAIVED: 주석 문구 한 줄 수정입니다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>