### PR TITLE
test(keeper): main 에서 red 인 두 스위트 수리 + CI 배선

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1178,6 +1178,24 @@ jobs:
           chmod +x scripts/ci-run-tests.sh
           scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_sse_coverage @test/runtest-test_ag_ui_coverage @test/runtest-test_sse_storm_e2e"
 
+      # Keeper prompt and tool-bundle contracts. Both suites assert on rendered
+      # prompt text and on a meta the production decoder must accept, and both
+      # went red without a failing check: @check compiles them and no runtest
+      # target ran them. masc#24651 and masc#26123 removed prompt directives and
+      # masc#26823 re-wrapped the merged asset; the assertions drifted silently
+      # through all three.
+      - name: Run keeper prompt and tool-bundle contract suites
+        id: keeper_prompt_contract_suites
+        if: ${{ always() && steps.build_step.outcome == 'success' }}
+        env:
+          ME_ROOT: /tmp/me
+          CI_TEST_HEARTBEAT_SEC: 15
+          DUNE_JOBS: 1
+        run: |
+          mkdir -p /tmp/me
+          chmod +x scripts/ci-run-tests.sh
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_wake_turn_context @test/runtest-test_warn_root_causes"
+
       - name: Run transport harness suite
         id: transport_harness_suite
         if: ${{ always() && steps.build_step.outcome == 'success' }}

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -6,9 +6,12 @@
       admitted the turn (before: current_task_id only suppressed guidance).
    2. [turn_decision] threads the scheduler's real cycle decision into the
       wake-reason section, so stimulus-driven wakes render their reason.
-   3. [?active_goal_summaries] renders goal titles next to ids, and a keeper
-      WITH goals receives a self-direction directive (parity with the
-      pre-existing no-goal branch). *)
+   3. [?active_goal_summaries] renders goal titles next to ids.
+
+   The third item once also pinned a self-direction directive for a keeper that
+   holds goals, mirroring a no-goal branch. masc#26123 ("stop the runtime
+   choosing the agent's next tool") removed both branches on purpose, so what is
+   pinned here now is their absence. *)
 
 open Alcotest
 
@@ -152,6 +155,32 @@ let contains ~needle haystack =
   in
   loop 0
 
+(* Prose assertions match a sentence, not a line. The prompt assets are
+   hard-wrapped markdown, so a needle that spans a wrap point fails on a space
+   the file writes as a newline — masc#26823 re-wrapped the merged asset and
+   broke an assertion whose sentence was still there, word for word. Collapse
+   runs of whitespace on both sides so re-wrapping prose stays invisible here
+   while deleting the sentence still fails. *)
+let collapse_whitespace text =
+  let buf = Buffer.create (String.length text) in
+  let in_space = ref false in
+  String.iter
+    (fun c ->
+      match c with
+      | ' ' | '\t' | '\n' | '\r' ->
+        if not !in_space then Buffer.add_char buf ' ';
+        in_space := true
+      | c ->
+        Buffer.add_char buf c;
+        in_space := false)
+    text;
+  Buffer.contents buf
+;;
+
+let contains_prose ~needle haystack =
+  contains ~needle:(collapse_whitespace needle) (collapse_whitespace haystack)
+;;
+
 let count_occurrences ~needle haystack =
   let needle_length = String.length needle in
   let haystack_length = String.length haystack in
@@ -231,7 +260,11 @@ let test_current_task_section_renders () =
     (contains ~needle:"- Prior handoff: lexer done, parser half-wired" user);
   check bool "handoff next step" true
     (contains ~needle:"- Suggested next step: wire parser to store" user);
-  check bool "continue-or-release directive" true
+  (* masc#24651 cut the "continue it or release it with a handoff summary"
+     directive from this section; masc#26123 then made not choosing the agent's
+     next action the standing policy. The section states what is held and what
+     the prior handoff said, and stops there. *)
+  check bool "section does not direct the next action" false
     (contains ~needle:"release it with a handoff summary" user)
 
 let test_current_task_section_absent_without_task () =
@@ -387,11 +420,11 @@ let test_direct_and_autonomous_share_system_prompt () =
      explicitly, and absent evidence blocks rather than licenses a guess —
      is now stated in the merged [keeper.system] body. *)
   check bool "shared contract carries repository checkout policy" true
-    (contains
+    (contains_prose
        ~needle:"handle a behind, diverged, dirty, unregistered, or unavailable"
        direct_system_prompt);
   check bool "shared contract refuses to infer checkout state" true
-    (contains
+    (contains_prose
        ~needle:"Missing, ambiguous, or stale checkout evidence is a blocker"
        direct_system_prompt)
 
@@ -584,10 +617,15 @@ let test_goal_holder_gets_self_direction_directive () =
       ~turn_decision:goal_turn_decision ~current_task:Inputs.No_current_task
       ~observation:base_observation ()
   in
-  check bool "goal-holder directive present" true
+  (* masc#26123 removed both self-direction branches. The prompt states the
+     goals a keeper holds and leaves the choice of next action to it, so the
+     directive that used to accompany them must not come back. *)
+  check bool "no self-direction directive for a goal holder" false
     (contains ~needle:"advance one of your active" system);
-  check bool "defer is stated as valid" true
+  check bool "no defer directive either" false
     (contains ~needle:"Deferring is a valid choice" system);
+  check bool "the goal itself is still named" true
+    (contains ~needle:"goal-x" system);
   let no_goal_turn_decision =
     WO.keeper_cycle_decision ~meta base_observation
   in
@@ -596,9 +634,9 @@ let test_goal_holder_gets_self_direction_directive () =
       ~turn_decision:no_goal_turn_decision ~current_task:Inputs.No_current_task
       ~observation:base_observation ()
   in
-  check bool "no-goal branch keeps its own directive" true
+  check bool "no-goal branch directs nothing either" false
     (contains ~needle:"You have no active goal" no_goal_system);
-  check bool "goal-holder directive absent without goals" false
+  check bool "and carries no goal-holder directive" false
     (contains ~needle:"advance one of your active" no_goal_system)
 
 let () =

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -60,9 +60,15 @@ let publication_recovery_turn_context ~registry ~keeper_name =
     }
 ;;
 
+(* [agent_name] is not free-form: keeper_meta_json_parse rejects a persisted
+   meta whose agent_name is not [Keeper_identity.keeper_agent_name name]
+   ("keeper-<name>-agent"). Spelling it out here as [name] made every test in
+   this suite that builds a meta fail at construction. Derive it the same way
+   production does so a change to the canonical form breaks in one place. *)
 let make_meta ?(name = "test-keeper") () : Keeper_meta_contract.keeper_meta =
   match Masc_test_deps.meta_of_json_fixture
-    (`Assoc [("name", `String name); ("agent_name", `String name);
+    (`Assoc [("name", `String name);
+             ("agent_name", `String (Keeper_identity.keeper_agent_name name));
              ("trace_id", `String "test-trace-warn")]) with
   | Ok meta -> meta
   | Error e -> failwith (Printf.sprintf "make_meta failed: %s" e)
@@ -257,10 +263,20 @@ let test_missing_current_task_reconciled_before_transition_hint () =
           match description with
           | None -> fail "masc_transition not found in bundle"
           | Some description ->
-            check bool "missing task hint removed" false
+            (* masc#26123 stopped the runtime injecting task state into tool
+               descriptions: the reconciled "No task currently assigned" hint
+               went with the stale "not found in backlog" one. The contract is
+               now stronger than either — the description states what the tool
+               does and carries no turn-specific state at all, even though this
+               keeper holds a current_task_id that no backlog resolves. That
+               commit updated the registry-integrity suite and missed this one,
+               which no runtest target runs. *)
+            check bool "no stale task hint" false
               (string_contains description "not found in backlog");
-            check bool "reconciled hint asks for claim/list" true
-              (string_contains description "No task currently assigned")))
+            check bool "no reconciled task hint either" false
+              (string_contains description "No task currently assigned");
+            check string "description is the static capability statement"
+              "Transition a task to a new status." description))
 
 let test_tool_bundle_does_not_emit_full_universe_assignment () =
   ignore (init_registry ());


### PR DESCRIPTION
## 문제

두 스위트가 `main` 에서 red 입니다. 둘 다 어떤 runtest 타깃에도 없어서 `@check` 가 컴파일만 하고, 아무 체크도 빨개지지 않았습니다.

```
test_warn_root_causes           5 failures! in 0.300s.  9 tests run.
test_keeper_wake_turn_context   3 failures! in 0.023s. 15 tests run.
```

프로덕션 변경 **4 건**이 이 앞을 그냥 지나갔습니다.

## test_warn_root_causes — 5 건

### 5 건이 픽스처 한 줄

```ocaml
(`Assoc [("name", `String name); ("agent_name", `String name); …])
```

`keeper_meta_json_parse.ml:367` 은 `agent_name` 이 `Keeper_identity.keeper_agent_name name` (`"keeper-<name>-agent"`) 과 정확히 같기를 요구하고 아니면 거부합니다.

```
make_meta failed: invalid current keeper meta:
  agent_name does not match canonical keeper identity; runtime reset required
```

meta 를 만드는 모든 테스트가 **생성 시점에** 죽었습니다. 프로덕션과 같은 방식으로 파생하도록 고쳤습니다 — canonical 형식이 바뀌면 한 곳에서 깨집니다.

### 남은 1 건 — masc#26123 이 지운 동적 힌트

`masc_transition` 설명에 주입되던 task 상태 힌트를 `29fa165932` (#26123, *stop the runtime choosing the agent's next tool*) 가 제거했습니다. 그 커밋은 `test_keeper_tool_descriptor_registry_integrity.ml` 은 갱신하고 **이 스위트는 빠뜨렸습니다.**

```
$ git show --stat 29fa165932 | grep test_
 ...st_keeper_tool_descriptor_registry_integrity.ml |  18 ---
```

현재 설명은 정적 문장 하나입니다. 그건 두 힌트 중 어느 쪽보다 **강한 계약**이므로 그것을 단언합니다 — 이 keeper 가 backlog 에 없는 `current_task_id` 를 들고 있는데도 설명에 턴별 상태가 전혀 없다는 것.

## test_keeper_wake_turn_context — 3 건

### 2 건 — 제거된 지시문

`masc#24651` 이 Current Task 섹션에서 *"release it with a handoff summary"* 를 잘랐고, `masc#26123` 이 "런타임이 다음 행동을 고르지 않는다" 를 상시 정책으로 만들면서 goal-holder / no-goal 자기지시 분기를 **양쪽 다** 제거했습니다.

폐기된 정책을 단언하던 자리를 **부재 단언**으로 바꿨습니다. 파일 헤더 주석도 그 정책을 서술하고 있어 함께 정정했습니다.

### 1 건 — 문장은 살아 있고 줄바꿈만 옮겨감

```ocaml
~needle:"Missing, ambiguous, or stale checkout evidence is a blocker"
```

이 문장은 `config/prompts/keeper.system.md` 에 **글자 그대로 있습니다.**

```
134: checkout explicitly. Missing, ambiguous, or stale checkout evidence is a
135: blocker, not permission to infer a value.
```

`masc#26823` 이 7 개 asset 을 하나로 합치며 re-wrap 했고, needle 의 공백 자리에 파일은 개행을 씁니다. 개념이 사라진 게 아니라 **줄바꿈 위치가 옮겨간 것**입니다.

prose 단언은 양쪽 공백을 collapse 해서 비교하도록 했습니다. re-wrap 은 보이지 않게 되고, 문장을 지우면 여전히 실패합니다.

## 프로덕션 버그는 없습니다

`"stable contract is byte-identical across turn entrypoints"` 는 **수정 없이 통과합니다.** autonomous 와 direct 시스템 프롬프트는 갈라지지 않았습니다. 처음에 이 단언이 실패한 줄 알고 두 프롬프트를 diff 했는데, 실패한 것은 같은 테스트의 뒤쪽 문자열 단언이었습니다.

## 검증

```
test_keeper_wake_turn_context   3 failures  →  Test Successful. 15 tests run.
test_warn_root_causes           5 failures  →  Test Successful.  9 tests run.

$ dune build --root . @test/runtest-test_keeper_wake_turn_context @test/runtest-test_warn_root_causes
Test Successful in 0.439s. 9 tests run.     (CI 가 부를 alias 그대로)

$ ocamlformat --check <touched>   EXIT=0
$ ci.yml YAML 파싱               OK
```

**Negative control** — 픽스처의 canonical 파생만 되돌리면:

```
5 failures! in 1.016s. 9 tests run.
```

원래 5 건이 그대로 돌아옵니다. 복원하면 다시 9/9.

## CI 배선

두 스위트를 runtest 타깃으로 등록했습니다. 이게 없으면 고친 단언도 그것이 대체한 단언과 똑같이 미집행 상태입니다.

같은 세션에서 확인된 김에 적습니다 — `test_keeper_tool_descriptor_registry_integrity` 도 타깃이 없었고, `#26924` 에서 함께 배선했습니다. 세 스위트 모두 keeper 프롬프트/도구 계약을 다루는데 아무도 실행하지 않고 있었습니다.

RFC-WAIVED: 테스트와 CI 배선만 바꿉니다. `lib/` 변경 없음.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
