### PR TITLE
fix(keeper): enum 밖 annotation kind 를 Comment 로 접지 않고 거부

### DIFF
--- a/lib/agent_observation/agent_observation.ml
+++ b/lib/agent_observation/agent_observation.ml
@@ -172,6 +172,12 @@ let annotation_kind_to_string = function
   | Bookmark -> "Bookmark"
 ;;
 
+let all_annotation_kinds = [ Comment; Decision; Question; Bookmark ]
+
+let valid_annotation_kind_strings =
+  List.map annotation_kind_to_string all_annotation_kinds
+;;
+
 let annotation_kind_of_string = function
   | "Comment" -> Some Comment
   | "Decision" -> Some Decision

--- a/lib/agent_observation/agent_observation.mli
+++ b/lib/agent_observation/agent_observation.mli
@@ -68,6 +68,11 @@ type annotation_kind =
   | Bookmark
 
 val annotation_kind_to_string : annotation_kind -> string
+
+val all_annotation_kinds : annotation_kind list
+val valid_annotation_kind_strings : string list
+(** The schema's enum, derived from the constructors rather than restated, so a
+    new kind cannot reach the wire without appearing here. *)
 val annotation_kind_of_string : string -> annotation_kind option
 
 type annotation_reference =

--- a/lib/keeper/keeper_tool_ide_runtime.ml
+++ b/lib/keeper/keeper_tool_ide_runtime.ml
@@ -24,7 +24,7 @@ let handle_ide_annotate_with_outcome
   let file_path = Safe_ops.json_string ~default:"" "file_path" args in
   let line_start = Safe_ops.json_int ~default:1 "line_start" args in
   let line_end = Safe_ops.json_int ~default:line_start "line_end" args in
-  let kind_str = Safe_ops.json_string ~default:"Comment" "kind" args in
+  let kind_member = Safe_ops.safe_member "kind" args in
   let content = Safe_ops.json_string ~default:"" "content" args in
   let goal_id = Safe_ops.json_string_opt "goal_id" args in
   let task_id = Safe_ops.json_string_opt "task_id" args in
@@ -45,11 +45,29 @@ let handle_ide_annotate_with_outcome
     match references_result with
     | Error msg -> reject msg
     | Ok references ->
-    let kind =
-      match Agent_observation.annotation_kind_of_string kind_str with
-      | Some k -> k
-      | None -> Agent_observation.Comment
+    (* The schema declares kind as an enum of the four constructors and
+       documents the default, so absence is Comment and anything else is a
+       client error. The previous shape defaulted twice — once for a missing or
+       non-string member, once for an unrecognised string — and both landed on
+       Comment, so {"kind":"decision"} (the casing an LLM reaches for) was
+       silently filed as a comment with no rejection and no log. *)
+    let kind_result =
+      match kind_member with
+      | `Null -> Ok Agent_observation.Comment
+      | `String raw ->
+        (match Agent_observation.annotation_kind_of_string raw with
+         | Some k -> Ok k
+         | None -> Error raw)
+      | other -> Error (Yojson.Safe.to_string other)
     in
+    match kind_result with
+    | Error raw ->
+      reject
+        (Printf.sprintf
+           "kind must be one of [%s], got %S."
+           (String.concat ", " Agent_observation.valid_annotation_kind_strings)
+           raw)
+    | Ok kind ->
     (* #23469 (task-1733): the keeper hands us a path relative to its own
        working root — the playground sandbox — so anchor it there before
        partition resolution, exactly like the file tools resolve it. The

--- a/test/test_agent_observation_bridge.ml
+++ b/test/test_agent_observation_bridge.ml
@@ -309,6 +309,50 @@ let test_write_region_snapshot_uses_tool_call_payload () =
   | rows -> failf "expected one write-region snapshot row, got %d" (List.length rows)
 ;;
 
+(* keeper_ide_annotate declares kind as a JSON-schema enum and the runtime
+   parses it back with annotation_kind_of_string. Two hand-written lists of the
+   same four names drift silently: before this test the runtime folded every
+   unrecognised value onto Comment, so a schema that grew a fifth kind would
+   have filed it as a comment rather than failing. Compare the two directly. *)
+let schema_kind_enum () =
+  let annotate =
+    List.find
+      (fun (t : Masc_domain.tool_schema) -> t.name = "keeper_ide_annotate")
+      Tool_shard_types.filesystem_tools
+  in
+  let open Yojson.Safe.Util in
+  annotate.input_schema
+  |> member "properties"
+  |> member "kind"
+  |> member "enum"
+  |> to_list
+  |> List.map to_string
+;;
+
+let test_annotation_kind_enum_matches_variants () =
+  check (list string)
+    "schema enum == annotation_kind constructors"
+    (schema_kind_enum ())
+    Agent_observation.valid_annotation_kind_strings
+;;
+
+let test_annotation_kind_parser_round_trips_every_kind () =
+  List.iter
+    (fun k ->
+      let s = Agent_observation.annotation_kind_to_string k in
+      match Agent_observation.annotation_kind_of_string s with
+      | Some back -> check bool ("round trip " ^ s) true (back = k)
+      | None -> failf "annotation_kind_of_string rejected %S" s)
+    Agent_observation.all_annotation_kinds
+;;
+
+let test_annotation_kind_parser_rejects_wrong_case () =
+  (* The casing an LLM reaches for. The runtime now rejects it instead of
+     filing the annotation as a Comment. *)
+  check bool "lowercase decision is not a kind" true
+    (Agent_observation.annotation_kind_of_string "decision" = None)
+;;
+
 let () =
   run
     "agent_observation_bridge"
@@ -342,6 +386,18 @@ let () =
             "write-region snapshot uses tool-call payload"
             `Quick
             test_write_region_snapshot_uses_tool_call_payload
+        ; test_case
+            "annotation kind enum matches variants"
+            `Quick
+            test_annotation_kind_enum_matches_variants
+        ; test_case
+            "annotation kind parser round trips every kind"
+            `Quick
+            test_annotation_kind_parser_round_trips_every_kind
+        ; test_case
+            "annotation kind parser rejects wrong case"
+            `Quick
+            test_annotation_kind_parser_rejects_wrong_case
         ] )
     ]
 ;;


### PR DESCRIPTION
## 무엇을

`keeper_ide_annotate` 의 `kind` 파싱을 스키마와 일치시킵니다. 부재는 `Comment`, enum 밖 값은 거부.

## 왜

스키마는 enum 을 선언합니다 (`tool_shard_types_schemas_filesystem.ml:148-158`):

```ocaml
; ( "kind"
  , `Assoc [ "type", `String "string"
           ; "enum", `List [ `String "Comment"; `String "Decision"
                           ; `String "Question"; `String "Bookmark" ]
           ; "description", `String "Annotation kind; defaults to Comment" ] )
```

런타임은 그것을 **두 번 기본값으로 뭉갰습니다**:

```ocaml
let kind_str = Safe_ops.json_string ~default:"Comment" "kind" args in   (* 1차 *)
...
match Agent_observation.annotation_kind_of_string kind_str with
| Some k -> k
| None -> Agent_observation.Comment                                      (* 2차 *)
```

`annotation_kind_of_string` 은 대소문자 구분 PascalCase 라, LLM 이 흔히 보내는 `{"kind":"decision"}` 이 **조용히 Comment 로 기록**됐습니다. 거부도 로그도 없습니다. 타입이 틀린 값(`{"kind":["Decision"]}`)도 같은 곳으로 갔습니다.

이건 같은 세션에서 고친 `keeper_write_file` 의 `mode` 와 동일한 형태입니다 — `Safe_ops.json_string` 이 "키 부재" 와 "키는 있는데 String 이 아님" 을 하나의 기본값으로 합치고, 호출자가 그 자리에 허용값을 넣었습니다.

## 어떻게

멤버를 직접 읽어 세 경우를 분리합니다:

```ocaml
let kind_result =
  match kind_member with
  | `Null -> Ok Agent_observation.Comment          (* 부재: 스키마가 문서화한 기본값 *)
  | `String raw ->
    (match Agent_observation.annotation_kind_of_string raw with
     | Some k -> Ok k
     | None -> Error raw)                          (* enum 밖 값 *)
  | other -> Error (Yojson.Safe.to_string other)   (* 타입 오류 *)
in
```

거부 메시지는 `mode` 와 같은 형태입니다: `kind must be one of [Comment, Decision, Question, Bookmark], got "decision".`

유효 값 목록은 **생성자에서 유도**합니다. 손으로 쓴 두 번째 목록을 만들지 않습니다:

```ocaml
let all_annotation_kinds = [ Comment; Decision; Question; Bookmark ]
let valid_annotation_kind_strings = List.map annotation_kind_to_string all_annotation_kinds
```

## 테스트

`test_agent_observation_bridge.ml` 에 3건 추가. **12/12 통과** (기존 8 + 신규 3).

- `annotation kind enum matches variants` — 스키마의 `enum` 배열과 `valid_annotation_kind_strings` 를 직접 비교합니다. 두 개의 손으로 쓴 네 이름 목록이 조용히 어긋나는 것을 막습니다. 이전에는 어긋나도 다섯 번째 kind 가 Comment 로 접혔을 뿐 아무도 몰랐습니다.
- `annotation kind parser round trips every kind` — `all_annotation_kinds` 를 순회하므로 생성자가 늘면 자동으로 커버됩니다.
- `annotation kind parser rejects wrong case` — `"decision"` 이 `None` 임을 고정합니다.

## 동작 변화

`{"kind":"decision"}` 같은 enum 밖 값이 이전에는 Comment 로 기록됐고 이제 `Policy_rejection` 으로 거부됩니다. 유효 입력과 `kind` 미지정의 동작은 불변입니다.

RFC-WAIVED: credential / identity / operator control action handler / keeper sandbox / hooks 어디에도 해당하지 않습니다. 파싱 경계에서 스키마가 이미 선언한 계약을 런타임이 지키게 하는 변경입니다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
