### PR TITLE
refactor(prompt): keeper_prompt_names 를 prompt_registry 로 — 마지막 리터럴 키 제거

### DIFF
--- a/lib/keeper_metrics/dune
+++ b/lib/keeper_metrics/dune
@@ -7,7 +7,6 @@
  (modules
   keeper_measurement
   keeper_metrics
-  keeper_prompt_names
   keeper_timing
   keeper_memory_recall_exn_class
   keeper_chat_store_operation

--- a/lib/prompt_registry/dune
+++ b/lib/prompt_registry/dune
@@ -7,7 +7,8 @@
   prompt_registry_types
   prompt_override_persistence
   prompt_registry_store
-  prompt_registry)
+  prompt_registry
+  keeper_prompt_names)
  (wrapped false)
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4) + unused-value ratchet (warning 32)
  (flags

--- a/lib/prompt_registry/keeper_prompt_names.ml
+++ b/lib/prompt_registry/keeper_prompt_names.ml
@@ -7,6 +7,7 @@
 let system = "keeper.system"
 let board_attention_judgment_batch = "keeper.board_attention_judgment_batch"
 let gate_judgment = "keeper.gate_judgment"
+let verification_anti_rationalization = "verification.anti_rationalization"
 let memory_os_recall_context = "keeper.memory_os_recall.context"
 let memory_os_recall_unavailable = "keeper.memory_os_recall.unavailable"
 let librarian_current_selection = "keeper.librarian.current_selection"

--- a/lib/prompt_registry/keeper_prompt_names.mli
+++ b/lib/prompt_registry/keeper_prompt_names.mli
@@ -11,6 +11,7 @@ val system : string
 
 val board_attention_judgment_batch : string
 val gate_judgment : string
+val verification_anti_rationalization : string
 val memory_os_recall_context : string
 val memory_os_recall_unavailable : string
 val librarian_current_selection : string

--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -156,7 +156,9 @@ let build_prompt ?(few_shot_block = "") ?completion_contract
     ; "calibration_section", calibration_section
     ]
   in
-  Prompt_registry.render_prompt_template "verification.anti_rationalization" vars
+  Prompt_registry.render_prompt_template
+    Keeper_prompt_names.verification_anti_rationalization
+    vars
 ;;
 
 (* ================================================================ *)


### PR DESCRIPTION
프롬프트 읽는 지점 전수 조사 후 남은 마지막 불일치 하나.

## 전수 결과

| 읽는 지점 | 자산 | 경로 |
|---|---|---|
| `keeper_prompt.ml:30` | `keeper.system` | 이름 상수 |
| `keeper_librarian_runtime.ml:189` | `keeper.librarian.current_selection` | 이름 상수 |
| `keeper_memory_os_recall.ml:33,78` | `keeper.memory_os_recall.{context,unavailable}` | 이름 상수 |
| `keeper_board_attention_exact_flow.ml:72` | `keeper.board_attention_judgment_batch` | 이름 상수 |
| `hitl_summary_worker.ml:11` | `keeper.gate_judgment` | 이름 상수 |
| **`anti_rationalization.ml:159`** | `verification.anti_rationalization` | **문자열 직접** |

모델 메시지를 만드는 15개 파일도 확인했다 — **System 역할에 리터럴 지시문을 넣는 곳은 0건**이다.

## 왜 하나만 문자열이었나

**자리가 잘못돼 있었다.** 상수가 `keeper_metrics` 에 살고, `lib/task` 는 그 라이브러리에 의존하지 않는다. 문자열 하나 때문에 의존성 간선을 추가하는 건 경계 위반이다.

그런데 프롬프트 이름 상수는 **메트릭 관심사가 아니라 레지스트리 관심사**다. 그리고 프롬프트를 읽는 모든 소비자는 `render_prompt_template` 를 부르기 위해 **이미 `masc.prompt_registry` 에 의존한다.** 그래서 옮기면 새 의존성이 어디에도 생기지 않는다.

```
lib/keeper_metrics/keeper_prompt_names.{ml,mli}
  -> lib/prompt_registry/keeper_prompt_names.{ml,mli}
두 dune 의 (modules ...) 갱신
verification_anti_rationalization 추가 후 호출부 교체
```

## 프롬프트 정리 최종 상태

| | 시작 | 지금 |
|---|---|---|
| 자산 | 22 | **7** |
| 등록 경로 | 2종 | **1종** |
| 로더 | 2개 (`Prompt_registry` + `Keeper_prompt_external`) | **1개** (#26921) |
| 하드코딩 본문 | — | **0** |
| 상수 위치 | `keeper_metrics` | **`prompt_registry`** |

## 검증

```
dune build @check                 clean (0줄)
test_prompt_registry_defaults     27/27
test_keeper_prompt_metrics        21/21
scripts/ocaml-structure-ratchet.sh  OK
ocamlformat --check               exit 0
```

관련: #26921 (자산 10→7, 두 번째 로더 제거)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
