### PR TITLE
refactor(goal): delete the vestigial Complete transition outcome

### DIFF
--- a/lib/goal/goal_phase.ml
+++ b/lib/goal/goal_phase.ml
@@ -94,9 +94,6 @@ let action_of_string = function
 let parse_action s =
   String.trim s |> String.lowercase_ascii |> action_of_string
 
-type transition_outcome =
-  | Move_to of t
-  | Complete
 
 (* Every (phase, action) pair is stated. The catch-all this replaces absorbed
    22 of the 35 pairs, so adding a phase or an action compiled cleanly and the
@@ -111,24 +108,24 @@ let decide_transition ~phase ~(action : action) =
   in
   match phase, action with
   (* Executing: the only phase that can request completion. *)
-  | Executing, Request_complete -> Ok Complete
-  | Executing, Pause -> Ok (Move_to Paused)
-  | Executing, Block -> Ok (Move_to Blocked)
-  | Executing, Drop -> Ok (Move_to Dropped)
+  | Executing, Request_complete -> Ok Completed
+  | Executing, Pause -> Ok (Paused)
+  | Executing, Block -> Ok (Blocked)
+  | Executing, Drop -> Ok (Dropped)
   | Executing, (Resume | Unblock | Reopen) -> invalid
   (* Paused: resumes or drops; it is not blocked and not finished. *)
-  | Paused, Resume -> Ok (Move_to Executing)
-  | Paused, Drop -> Ok (Move_to Dropped)
+  | Paused, Resume -> Ok (Executing)
+  | Paused, Drop -> Ok (Dropped)
   | Paused, (Request_complete | Pause | Block | Unblock | Reopen) -> invalid
   (* Blocked: unblocks or drops. Completing while blocked would skip the
      impediment rather than resolve it. *)
-  | Blocked, Unblock -> Ok (Move_to Executing)
-  | Blocked, Drop -> Ok (Move_to Dropped)
+  | Blocked, Unblock -> Ok (Executing)
+  | Blocked, Drop -> Ok (Dropped)
   | Blocked, (Request_complete | Pause | Resume | Block | Reopen) -> invalid
   (* Completed and Dropped are terminal: only reopening leaves them. *)
-  | Completed, Reopen -> Ok (Move_to Executing)
-  | Completed, Drop -> Ok (Move_to Dropped)
+  | Completed, Reopen -> Ok (Executing)
+  | Completed, Drop -> Ok (Dropped)
   | Completed, (Request_complete | Pause | Resume | Block | Unblock) -> invalid
-  | Dropped, Reopen -> Ok (Move_to Executing)
+  | Dropped, Reopen -> Ok (Executing)
   | Dropped, (Request_complete | Pause | Resume | Block | Unblock | Drop) ->
     invalid

--- a/lib/goal/goal_phase.mli
+++ b/lib/goal/goal_phase.mli
@@ -53,13 +53,18 @@ val all_actions : action list
 
 (** Outcome of {!decide_transition}. [Move_to] is a direct phase change and
     [Complete] is the terminal success transition. *)
-type transition_outcome =
-  | Move_to of t
-  | Complete
 
 val decide_transition :
   phase:t ->
   action:action ->
-  (transition_outcome, string) result
-(** Pure transition decider. [Request_complete] completes directly from
-    [Executing]. Returns [Error msg] for invalid pairs. *)
+  (t, string) result
+(** Pure transition decider: the phase the goal moves to, or [Error msg] for
+    an invalid pair.
+
+    This returned a [transition_outcome] whose [Complete] arm was the
+    else-branch of a verifier-policy check — one of four outcomes alongside
+    [Open_verification] and [Open_approval], removed with the goal quorum
+    engine in #24332. With those gone [Complete] and [Move_to Completed] named
+    the same thing, and both consumers immediately collapsed one into the
+    other while the doc still called [Complete] a distinct terminal
+    transition. A phase is now just a phase. *)

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -312,12 +312,7 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args
        (match Goal_phase.decide_transition ~phase:goal.phase ~action with
         | Error msg ->
           error_result_typed ~tool_name ~start_time ~code:Conflict msg
-        | Ok outcome ->
-          let phase =
-            match outcome with
-            | Goal_phase.Complete -> Goal_phase.Completed
-            | Goal_phase.Move_to phase -> phase
-          in
+        | Ok phase ->
           (match update_goal_phase ctx goal ~phase ?note () with
            | Error msg ->
              error_result_typed ~tool_name ~start_time ~code:Internal_error msg


### PR DESCRIPTION
## 목표

`Goal_phase.transition_outcome` 을 제거한다. 두 갈래 중 하나가 나머지 하나와 같은 것을 가리키는 잔재였다.

## 근거 — 4갈래의 잔해

`72c3c3372f` (#9463, 2026-04-22) 가 goal FSM 과 quorum verification 을 도입할 때 outcome 은 넷이었다:

```ocaml
type transition_outcome = Move_to of t | Open_verification | Open_approval | Complete

  if has_effective_verifier_policy then Ok Open_verification
  else if require_completion_approval then Ok Open_approval
  else Ok Complete                                    (* "검증 불필요" 가지 *)
```

`7b62a87d44` (#24332, 2026-07-13) 가 goal quorum 엔진을 삭제하면서 `Open_verification` / `Open_approval` 이 사라졌고, **`Complete` 는 `Move_to Completed` 와 완전히 동일한 의미가 됐다.**

소비자 두 곳이 그걸 증명한다:

- `lib/workspace_goals.ml:317-320` — 다음 줄에서 즉시 `Completed` 로 접는다
- `lib/dashboard/dashboard_goals_types_health.ml:51-54` — `Ok _` 로 매치하고 payload 를 버린다

그런데 `goal_phase.mli:55` 는 여전히 `Complete` 를 *"the terminal success transition"* 이라고 설명한다. 별개 outcome 이 처리를 기다리는 것처럼 읽히고, **실제로 그렇게 읽힌다** — 이 PR 을 쓰기 전 조사에서 "여기가 goal 검증이 들어갈 자리" 로 해석했다. #24332 가 의도적으로 제거한 것의 빈 껍데기가 다음 사람을 같은 오독으로 이끈다.

## 변경

`decide_transition : phase:t -> action:action -> (t, string) result`

phase 를 직접 반환한다. `transition_outcome` 타입, `Move_to` 생성자, `workspace_goals.ml` 의 접는 match 가 사라진다.

동작 변화 없음. `Executing + Request_complete -> Completed` 는 전과 같다.

## 이 PR 이 하지 않는 것

**goal 검증자를 신설하지 않는다.** #24332 가 quorum 을 제거하며 명시한 비대칭을 유지한다:

> "Remove fixed caps, scores, quorum/promotion logic, failure-derived pauses, Memory/Goal/Board heuristics… **Task completion still requires the configured structured LLM verdict.**"

`RFC-0000-MASTER-ROADMAP.md:264` 도 같은 방향이다: "verifier pool 이나 timeout rescue 를 되살리지 않는다."

## 검증

- `dune build @check` — clean (`test/test_server_ide_http.ml` 은 main 에서 이미 컴파일 실패하며 본 PR 과 무관)
- 변경 3 파일, +23 / -26

RFC-WAIVED: 의미가 동일해진 두 생성자 중 하나를 제거한다. 새 설계 결정이 없고, 오히려 이미 내려진 결정(#24332)의 잔해를 치운다.
