### PR TITLE
fix: 결측 boolean 을 허용 쪽 답으로 읽던 두 곳

### DIFF
--- a/dashboard/src/components/agent-detail-timeline.ts
+++ b/dashboard/src/components/agent-detail-timeline.ts
@@ -98,7 +98,11 @@ const timelineSearchQuery = signal('')
 export function ToolCallEventRow({ evt, idx }: { evt: AgentTimelineEvent; idx: number }) {
   const d = evt.detail as Record<string, unknown>
   const toolName = (d.tool_name as string) ?? 'unknown'
-  const success = d.success !== false
+  // null means the emitter's success field was missing or unreadable. It used
+  // to render as ok here (`!== false`) while the server filled the same gap
+  // with true, so a damaged row looked like a successful call from both
+  // ends. Keep the three states apart.
+  const success = typeof d.success === 'boolean' ? d.success : null
   const durationMs = d.duration_ms as number | undefined
   const errorMsg = d.error as string | null
   const args = d.args as Record<string, unknown> | string | undefined
@@ -120,9 +124,11 @@ export function ToolCallEventRow({ evt, idx }: { evt: AgentTimelineEvent; idx: n
         ${durationMs != null
           ? html`<span class="text-2xs font-mono ${durationColor(durationMs)}">${formatMsCompact(durationMs)}</span>`
           : null}
-        ${success
+        ${success === true
           ? html`<span class="text-2xs px-1.5 py-0.5 rounded-[var(--r-1)] bg-[var(--ok-soft)] text-[var(--color-status-ok)]">ok</span>`
-          : html`<span class="text-2xs px-1.5 py-0.5 rounded-[var(--r-1)] bg-[var(--bad-10)] text-[var(--color-status-err)]">err</span>`}
+          : success === false
+            ? html`<span class="text-2xs px-1.5 py-0.5 rounded-[var(--r-1)] bg-[var(--bad-10)] text-[var(--color-status-err)]">err</span>`
+            : html`<span class="text-2xs px-1.5 py-0.5 rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-secondary)]" title="이 행에 success 필드가 없거나 읽을 수 없습니다">미상</span>`}
         ${isKeeperInTurn
           ? html`<span class="text-2xs px-1.5 py-0.5 rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-secondary)]" data-tool-source="keeper_in_turn" title="keeper가 자기 턴 안에서 실행한 도구">턴 내</span>`
           : null}

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -607,7 +607,21 @@ let add_delete_action_routes router =
              | None ->
                  respond_error ~request:req reqd (invalid_request "post_id")
              | Some post_id ->
-             let pinned = Safe_ops.json_bool ~default:true "pinned" json in
+             (* [json_bool] folds "key absent" and "value unparseable" onto the
+                same default, and this default pins. {"pinned":"nope"} therefore
+                pinned the post while plainly meaning something else. Absence
+                still pins — that is the route's name — but a value the parser
+                cannot read is a client error. *)
+             match
+               (match Yojson.Safe.Util.member "pinned" json with
+                | `Null -> Ok true
+                | _ ->
+                  (match Safe_ops.json_bool_opt "pinned" json with
+                   | Some b -> Ok b
+                   | None -> Error ()))
+             with
+             | Error () -> respond_error ~request:req reqd (invalid_request "pinned")
+             | Ok pinned ->
              match Board_dispatch.set_pinned ~post_id ~pinned with
              | Ok () -> respond_ok ~request:req reqd
              | Error err ->

--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -298,9 +298,10 @@ let tool_call_events (config : Workspace.config) ~agent_name ~limit :
        let tool_name =
          Safe_ops.json_string ~default:"unknown" "tool_name" e.payload
        in
-       let success =
-         Safe_ops.json_bool ~default:true "success" e.payload
-       in
+       (* The emitter always records success, so a missing or unreadable field
+          means the row is damaged. Defaulting to true rendered such a row as a
+          succeeded call. Carry the uncertainty instead. *)
+       let success = Safe_ops.json_bool_opt "success" e.payload in
        let duration_ms =
          Safe_ops.json_int ~default:0 "duration_ms" e.payload
        in
@@ -320,7 +321,7 @@ let tool_call_events (config : Workspace.config) ~agent_name ~limit :
              `Assoc
                [
                  ("tool_name", `String tool_name);
-                 ("success", `Bool success);
+                 ("success", Json_util.bool_opt_to_json success);
                  ("duration_ms", `Int duration_ms);
                  ("error", Json_util.string_opt_to_json error_str);
                  ("source", Json_util.string_opt_to_json source_str);


### PR DESCRIPTION
## 무엇을

`Safe_ops.json_bool ~default:true` 두 곳을 고칩니다. 그 헬퍼는 **키 부재** 와 **파싱 불가 값** 에 같은 기본값을 돌려줍니다.

## 1. `POST /api/v1/dashboard/board/pin` — 변경 엔드포인트

```ocaml
let pinned = Safe_ops.json_bool ~default:true "pinned" json in
match Board_dispatch.set_pinned ~post_id ~pinned with
```

`parse_bool_string` 은 `1/true/yes/on` 과 `0/false/no/off` 밖의 값에 `None` 을 돌려줍니다. 그래서 `{"pinned":"nope"}` 가 기본값을 타 **핀을 겁니다** — 호출자가 분명 다른 의도였는데.

부재는 계속 핀을 겁니다(경로 이름이 그러하므로). 읽을 수 없는 값은 이제 `invalid_request "pinned"` 로 답합니다.

## 2. `tool_agent_timeline` — 미상을 성공으로 단정

emitter 가 `success` 를 항상 기록하므로 결측은 **손상된 행** 을 뜻하는데, `~default:true` 가 그것을 성공한 호출로 렌더했습니다. 이제 `bool option` 을 흘려 `null` 을 방출합니다.

## 백엔드만 고치면 무의미했습니다

`agent-detail-timeline.ts:101` 이 이렇게 읽습니다:

```ts
const success = d.success !== false
```

**`null` 이 `true` 와 똑같이 ok 로 렌더됩니다.** 양쪽 끝이 같은 구멍을 같은 낙관으로 메우고 있었습니다. 행이 이제 `ok` / `err` / `미상` 3분기입니다.

## 같은 형태의 네 번째

| PR | 헬퍼 | 기본값 |
|---|---|---|
| #26907 | `json_string` | `overwrite` (파괴적) |
| #26936 | `json_string` | `Comment` |
| #26941 | `json_string` | `memory` |
| 이 PR | `json_bool` | `true` ×2 |

전부 타입/파싱 오류가 값 오류보다 관대하게 처리됐고, 관대함의 방향이 허용 쪽이었습니다.

## 고치지 않은 것

`reputation_ledger_v2.ml:151-152` 가 같은 패턴이지만 그 원장은 **프로덕션 writer 가 0** 입니다(`.masc/reputation_v2` 디렉터리가 생성되지 않음). 실행되지 않는 코드입니다.

## 검증

`lib/masc.cma` 빌드 통과 — 두 변경 다 타입이 바뀌므로 컴파일러가 소비 지점을 강제했습니다.

RFC-WAIVED: credential / identity / operator control action handler / keeper sandbox / hooks 어디에도 해당하지 않습니다. 파싱 경계를 좁히는 변경이고 유효 입력의 동작은 불변입니다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>