### PR TITLE
fix(dashboard): point prompt panels at the block the server actually sends

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,6 +427,15 @@ jobs:
       - name: Run deploy preflight safety contract
         run: bash test/test_deploy_preflight.sh
 
+      # Deleting a prompt asset is a server-side change that leaves the
+      # dashboard's key strings syntactically valid, so a panel keeps rendering
+      # a block that silently resolves to empty. #26823 folded keeper.world,
+      # keeper.capabilities and keeper.constitution into keeper.system and the
+      # config panel kept decoding all three. Unconditional: the drift appears
+      # when either config/prompts or dashboard/src moves.
+      - name: Check dashboard prompt keys
+        run: bash scripts/audit-dashboard-prompt-keys.sh
+
       - name: Check doc truth
         if: needs.changes.outputs.doc_truth == 'true'
         run: |

--- a/dashboard/src/api/dashboard-keeper-config.ts
+++ b/dashboard/src/api/dashboard-keeper-config.ts
@@ -183,9 +183,7 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
     prompt: {
       instructions: asNullableString(prompt.instructions) ?? '',
       system_prompt_blocks: {
-        constitution: normalizePromptBlock(promptBlocks.constitution, 'keeper.constitution'),
-        world: normalizePromptBlock(promptBlocks.world, 'keeper.world'),
-        capabilities: normalizePromptBlock(promptBlocks.capabilities, 'keeper.capabilities'),
+        system: normalizePromptBlock(promptBlocks.system, 'keeper.system'),
       },
       effective_system_prompt: asNullableString(prompt.effective_system_prompt) ?? '',
       assembled_system_prompt: asNullableString(prompt.assembled_system_prompt) ?? '',

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -43,9 +43,7 @@ function makeKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
     prompt: {
       instructions: 'Prefer direct remediation',
       system_prompt_blocks: {
-        constitution: { key: 'keeper.constitution', source: 'file', text: 'constitution text' },
-        world: { key: 'keeper.world', source: 'override', text: 'world text' },
-        capabilities: { key: 'keeper.capabilities', source: 'file', text: 'capabilities text' },
+        system: { key: 'keeper.system', source: 'file', text: 'system text' },
       },
       effective_system_prompt: 'full prompt',
       assembled_system_prompt: 'assembled prompt',
@@ -1448,7 +1446,7 @@ describe('KeeperConfigPanel', () => {
     expect(container.textContent).toContain('조립 추적')
     expect(container.querySelector('.kasm')).not.toBeNull()
     // 3 base blocks + instructions + goals = 5 segments
-    expect(container.querySelectorAll('.kasm-seg').length).toBe(5)
+    expect(container.querySelectorAll('.kasm-seg').length).toBe(3)
     // only prompt.instructions is overridden → exactly one win badge
     const winBadges = container.querySelectorAll('.kasm-seg-win')
     expect(winBadges.length).toBe(1)
@@ -1536,7 +1534,7 @@ describe('buildKcfAssemblySegments', () => {
       sources: { ...base.sources, override_fields: ['prompt.instructions'] },
     })
     const segs = buildKcfAssemblySegments(c)
-    expect(segs.map((s) => s.src)).toEqual(['base', 'base', 'base', 'override', 'goals'])
+    expect(segs.map((s) => s.src)).toEqual(['base', 'override', 'goals'])
     const instrSeg = segs.find((s) => s.field.includes('instructions'))
     expect(instrSeg?.win).toBe(true)
     expect(instrSeg?.src).toBe('override')
@@ -1549,7 +1547,7 @@ describe('buildKcfAssemblySegments', () => {
       workspace: { ...base.workspace, active_goals: [] },
     })
     const segs = buildKcfAssemblySegments(c)
-    expect(segs.map((s) => s.field)).toEqual(['헌법', '세계관', '능력'])
+    expect(segs.map((s) => s.field)).toEqual(['공유 시스템'])
     expect(segs.every((s) => s.src === 'base')).toBe(true)
   })
 })

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -1196,9 +1196,7 @@ export function buildKcfAssemblySegments(c: KeeperConfig): KcfAssemblySegment[] 
   const segments: KcfAssemblySegment[] = []
   const blocks = c.prompt.system_prompt_blocks
   const baseBlocks: readonly (readonly [string, { key: string; source: string; text: string }])[] = [
-    ['헌법', blocks.constitution],
-    ['세계관', blocks.world],
-    ['능력', blocks.capabilities],
+    ['공유 시스템', blocks.system],
   ]
   for (const [label, block] of baseBlocks) {
     if (block.text.trim() !== '') {
@@ -1824,9 +1822,7 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
     </div>
     ${promptPreviewTab.value === 'blocks'
       ? html`
-          <${PromptBlock} title="헌법" block=${c.prompt.system_prompt_blocks.constitution} />
-          <${PromptBlock} title="세계관" block=${c.prompt.system_prompt_blocks.world} />
-          <${PromptBlock} title="능력" block=${c.prompt.system_prompt_blocks.capabilities} />
+          <${PromptBlock} title="공유 시스템" block=${c.prompt.system_prompt_blocks.system} />
         `
       : promptPreviewTab.value === 'system'
         ? html`<${LongText} text=${c.prompt.assembled_system_prompt || c.prompt.effective_system_prompt} truncateAt=${null} />`

--- a/dashboard/src/components/keeper-prompt-assembly-panel.test.ts
+++ b/dashboard/src/components/keeper-prompt-assembly-panel.test.ts
@@ -10,7 +10,7 @@ afterEach(() => {
 
 function prompt(overrides: Partial<DashboardPromptItem>): DashboardPromptItem {
   return {
-    key: 'keeper.world',
+    key: 'keeper.system',
     category: 'keeper',
     description: 'Keeper prompt',
     current: '',
@@ -33,22 +33,26 @@ describe('buildKeeperPromptAssemblyReport', () => {
   it('maps keeper prompt sources into assembly rows', () => {
     const report = buildKeeperPromptAssemblyReport([
       prompt({
-        key: 'keeper.world',
+        key: 'keeper.system',
         effective: 'world override',
         override_value: 'world override',
         source: 'override',
         has_override: true,
-        file_path: '/tmp/.masc/config/prompts/keeper.world.md',
-      }),
-      prompt({
-        key: 'keeper.capabilities',
-        effective: 'tool policy',
-        file_path: '/tmp/.masc/config/prompts/keeper.capabilities.md',
+        file_path: '/tmp/.masc/config/prompts/keeper.system.md',
       }),
     ])
 
-    expect(report.stats.totalRows).toBeGreaterThan(10)
-    expect(report.stats.overrideRows).toBeGreaterThanOrEqual(2)
+    // Every prompt the server listed reaches a row, plus the two computed
+    // rows the world stage contributes. Pinned by what the input supplies
+    // rather than a threshold: the previous `> 10` encoded the stage specs'
+    // former key list, so folding keeper.world/capabilities/constitution into
+    // keeper.system (#26823) failed it without any behavior changing.
+    expect(report.rows.filter(row => row.promptKey.startsWith('keeper.')).length)
+      .toBeGreaterThanOrEqual(3)
+    expect(report.rows.some(row => row.promptKey === '(computed:world_observation)')).toBe(true)
+    // One stage key is supplied and overridden; the other is deliberately
+    // absent so the missing-row path below stays exercised.
+    expect(report.stats.overrideRows).toBeGreaterThanOrEqual(1)
     expect(report.stages.map(stage => stage.title)).toEqual(
       expect.arrayContaining(['Prompt sources', 'System rules', 'World message']),
     )
@@ -59,22 +63,24 @@ describe('buildKeeperPromptAssemblyReport', () => {
       'turn-soft-context',
       'oas-hook',
     ])
-    expect(report.stages.find(stage => stage.id === 'unified-world')?.promptCount).toBe(1)
+    // The world message carries no prompt asset: keeper.turn_intent was its
+    // only one and #26823 removed it. Its two rows are computed observations.
+    expect(report.stages.find(stage => stage.id === 'unified-world')?.promptCount).toBe(0)
     expect(report.rows.find(row => row.promptKey === '(computed:world_observation)')?.source).toBe('computed')
     expect(report.rows.find(row => row.promptKey === '(computed:scheduled_automation)')?.source).toBe('computed')
     expect(report.activePromptRoots).toEqual(['/tmp/.masc/config/prompts'])
-    expect(report.rows.find(row => row.promptKey === 'keeper.world')?.source).toBe('override')
-    expect(report.rows.find(row => row.promptKey === 'keeper.recovery_block')?.missing).toBe(true)
+    expect(report.rows.find(row => row.promptKey === 'keeper.system')?.source).toBe('override')
+    expect(report.rows.find(row => row.promptKey === 'keeper.memory_os_recall.context')?.missing).toBe(true)
   })
 
   it('detects stale argument shapes in effective prompt text', () => {
     const report = buildKeeperPromptAssemblyReport([
       prompt({
-        key: 'keeper.tool_hints',
+        key: 'keeper.system',
         effective: 'Call keeper_task_done { notes: "evidence" }',
       }),
       prompt({
-        key: 'keeper.capabilities',
+        key: 'keeper.memory_os_recall.context',
         effective: 'Use keeper_pr_create and repos/masc/lib/foo.ml for PR work',
       }),
     ])
@@ -92,7 +98,7 @@ describe('buildKeeperPromptAssemblyReport', () => {
   it('labels host-storage prompt residue without legacy-era wording', () => {
     const report = buildKeeperPromptAssemblyReport([
       prompt({
-        key: 'keeper.world',
+        key: 'keeper.system',
         effective: 'Do not pass .masc/playground/name/repos/foo as a tool path.',
       }),
     ])
@@ -107,17 +113,17 @@ describe('buildKeeperPromptAssemblyReport', () => {
       <${KeeperPromptAssemblyPanel}
         prompts=${[
           prompt({
-            key: 'keeper.world',
+            key: 'keeper.system',
             effective: 'world override',
             override_value: 'world override',
             source: 'override',
             has_override: true,
-            file_path: '/tmp/.masc/config/prompts/keeper.world.md',
+            file_path: '/tmp/.masc/config/prompts/keeper.system.md',
           }),
           prompt({
-            key: 'keeper.capabilities',
+            key: 'keeper.memory_os_recall.context',
             effective: 'tool policy',
-            file_path: '/tmp/.masc/config/prompts/keeper.capabilities.md',
+            file_path: '/tmp/.masc/config/prompts/keeper.memory_os_recall.context.md',
           }),
         ]}
       />
@@ -135,14 +141,14 @@ describe('buildKeeperPromptAssemblyReport', () => {
     expect(container.textContent).toContain('Prompt roots')
     expect(container.querySelector('[data-prompt-minimap]')).not.toBeNull()
     expect(container.querySelector('[data-prompt-source-roots]')?.textContent).toContain('/tmp/.masc/config/prompts')
-    expect(container.querySelectorAll('[data-prompt-document-row]').length).toBeGreaterThan(10)
+    expect(container.querySelectorAll('[data-prompt-document-row]').length).toBeGreaterThan(0)
     expect(defaultRoute?.textContent).toContain('system')
     expect(defaultRoute?.textContent).toContain('user')
     expect(defaultRoute?.textContent).toContain('final')
     expect(defaultRoute?.textContent).toContain('Final context')
     expect(defaultRoute?.textContent).toContain('scheduler signals')
-    expect(defaultRoute?.textContent).toContain('keeper.world')
-    expect(defaultRoute?.textContent).toContain('/tmp/.masc/config/prompts/keeper.world.md')
+    expect(defaultRoute?.textContent).toContain('keeper.system')
+    expect(defaultRoute?.textContent).toContain('/tmp/.masc/config/prompts/keeper.system.md')
     expect(defaultRoute?.textContent).toContain('world override')
     expect(defaultRoute?.textContent).toContain('tool policy')
     expect(defaultRoute?.textContent).toContain('fingerprint')
@@ -187,7 +193,7 @@ describe('buildKeeperPromptAssemblyReport', () => {
     expect(rawFileList).not.toBeNull()
     expect(rawFileList?.hasAttribute('open')).toBe(false)
     expect(rawFileList?.querySelector('summary')?.textContent).toContain('Raw prompt files')
-    expect(evidence?.textContent).toContain('keeper.world')
+    expect(evidence?.textContent).toContain('keeper.system')
     expect(evidence?.textContent).toContain('(computed:scheduled_automation)')
     expect(evidence?.textContent).toContain('fingerprint')
 
@@ -206,7 +212,7 @@ describe('buildKeeperPromptAssemblyReport', () => {
       <${KeeperPromptAssemblyPanel}
         prompts=${[
           prompt({
-            key: 'keeper.world',
+            key: 'keeper.system',
             effective: 'Do not pass .masc/playground/name/repos/foo as a tool path.',
           }),
         ]}

--- a/dashboard/src/components/keeper-prompt-assembly-panel.ts
+++ b/dashboard/src/components/keeper-prompt-assembly-panel.ts
@@ -116,7 +116,7 @@ const STAGES: AssemblyStageSpec[] = [
     role: 'source_prep',
     messageSlot: 'not sent',
     summary: 'MASC picks the active text from defaults, files, or saved edits.',
-    promptKeys: ['keeper.world', 'keeper.capabilities'],
+    promptKeys: ['keeper.system'],
   },
   {
     id: 'base-system',
@@ -126,12 +126,7 @@ const STAGES: AssemblyStageSpec[] = [
     role: 'model_input',
     messageSlot: 'system',
     summary: 'Identity, rules, and safety boundaries.',
-    promptKeys: [
-      'keeper.constitution',
-      'keeper.world',
-      'keeper.capabilities',
-      'keeper.recovery_block',
-    ],
+    promptKeys: ['keeper.system'],
   },
   {
     id: 'unified-world',
@@ -141,7 +136,7 @@ const STAGES: AssemblyStageSpec[] = [
     role: 'model_input',
     messageSlot: 'user',
     summary: 'Current task, workspace state, scheduler signals, and turn intent.',
-    promptKeys: ['keeper.turn_intent'],
+    promptKeys: [],
     computedRows: [
       { id: 'world-observation', promptKey: '(computed:world_observation)' },
       { id: 'scheduled-automation', promptKey: '(computed:scheduled_automation)' },
@@ -155,7 +150,7 @@ const STAGES: AssemblyStageSpec[] = [
     role: 'model_input',
     messageSlot: 'context',
     summary: 'Recent continuity and memory hints.',
-    promptKeys: ['keeper.reply_guidelines'],
+    promptKeys: [],
   },
   {
     id: 'oas-hook',

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -56,7 +56,7 @@ const promptApiMock = vi.hoisted(() => ({
   fetchDashboardPrompts: vi.fn(async () => ({
     prompts: [
       {
-        key: 'keeper.world',
+        key: 'keeper.system',
         category: 'keeper',
         description: 'Shared world prompt',
         current: 'Hello {{keeper}} in {{namespace}}',
@@ -64,7 +64,7 @@ const promptApiMock = vi.hoisted(() => ({
         effective: 'Hello {{keeper}} in {{namespace}}',
         file_value: 'Hello {{keeper}} in {{namespace}}',
         override_value: null,
-        file_path: 'fixture/config/prompts/keeper.world.md',
+        file_path: 'fixture/config/prompts/keeper.system.md',
         file_exists: true,
         source: 'file' as const,
         has_override: false,

--- a/dashboard/src/components/tools/prompt-book-panel.ts
+++ b/dashboard/src/components/tools/prompt-book-panel.ts
@@ -27,11 +27,10 @@ function basename(path: string): string {
 }
 
 // Family classification (client curation). The server exposes category/file_path
-// but not a "does this feed the keeper turn" flag — keeper.librarian.system.md is
-// category=keeper yet never assembles into a turn — so the feedsTurn split is
-// authored here. Ordered specific→generic: the first matching rule wins, so
-// keeper.turn_intent / librarian / judge are classified before the generic
-// keeper.* family. An unmatched prompt falls to an explicit Other bucket rather
+// but not a "does this feed the keeper turn" flag — the librarian and judge
+// prompts are category=keeper yet never assemble into a turn — so the feedsTurn
+// split is authored here. Ordered specific→generic: the first matching rule
+// wins, so librarian / judge are classified before the generic keeper.* family. An unmatched prompt falls to an explicit Other bucket rather
 // than being silently folded into a feeding family.
 interface FamilyDef {
   id: string
@@ -43,14 +42,6 @@ interface FamilyDef {
 }
 
 const FAMILY_DEFS: readonly FamilyDef[] = [
-  {
-    id: 'turn_intent',
-    family: 'Turn Intent · 조각',
-    feedsTurn: true,
-    order: 2,
-    note: 'unified.system 렌더 뒤 Turn Intent 가이드로 이어붙는 조각 (큐레이션)',
-    match: h => h.includes('keeper.turn_intent'),
-  },
   {
     id: 'librarian',
     family: 'Librarian · 메모리',

--- a/dashboard/src/components/tools/prompt-registry-panel.test.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.test.ts
@@ -57,7 +57,7 @@ const HELPER_FIXTURES: DashboardPromptItem[] = [
 function defaultPromptItems(): DashboardPromptItem[] {
   return [
     makePrompt({
-      key: 'keeper.world',
+      key: 'keeper.system',
       category: 'keeper',
       description: 'world block',
       current: 'override world',
@@ -65,7 +65,7 @@ function defaultPromptItems(): DashboardPromptItem[] {
       effective: 'override world',
       file_value: 'file world',
       override_value: 'override world',
-      file_path: 'fixture/config/prompts/keeper.world.md',
+      file_path: 'fixture/config/prompts/keeper.system.md',
       source: 'override',
       has_override: true,
       char_count: 14,
@@ -141,8 +141,8 @@ describe('PromptRegistryPanel', () => {
     expect(container.querySelector('.v2-lab-panel')).not.toBeNull()
     expect(container.querySelector('.v2-lab-row')).not.toBeNull()
     expect(container.textContent).toContain('프롬프트 레지스트리')
-    expect(container.textContent).toContain('keeper.world')
-    expect(container.textContent).toContain('fixture/config/prompts/keeper.world.md')
+    expect(container.textContent).toContain('keeper.system')
+    expect(container.textContent).toContain('fixture/config/prompts/keeper.system.md')
     expect(container.querySelector('[data-prompt-preset-switcher]')).not.toBeNull()
     expect(container.querySelector('[data-prompt-destinations]')?.textContent).toContain('System rules')
     expect(container.querySelector('[data-prompt-destinations]')?.textContent).toContain('system')

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -1382,18 +1382,12 @@ interface KeeperSupervisorDiagnostics {
 
 interface KeeperConfigPrompt {
   instructions: string
+  // The server emits exactly one shared block. keeper.constitution,
+  // keeper.world and keeper.capabilities were folded into keeper.system by
+  // #26823; decoding them produced three empty blocks and the panel rendered
+  // nothing for the shared prompt.
   system_prompt_blocks: {
-    constitution: {
-      key: string
-      source: string
-      text: string
-    }
-    world: {
-      key: string
-      source: string
-      text: string
-    }
-    capabilities: {
+    system: {
       key: string
       source: string
       text: string

--- a/scripts/audit-dashboard-prompt-keys.sh
+++ b/scripts/audit-dashboard-prompt-keys.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Fail when dashboard production code names a prompt key the server cannot emit.
+#
+# The dashboard decodes and labels prompt blocks by key string. Deleting a
+# prompt asset is a server-side change that leaves those strings syntactically
+# valid, so a panel keeps rendering a block that resolves to empty instead of
+# failing. That happened after #26823 folded keeper.world / keeper.capabilities
+# / keeper.constitution into keeper.system: the config panel decoded three
+# blocks the server no longer sends and rendered nothing, and the assembly
+# panel described six stages whose keys were gone.
+#
+# Scope is position-based, not prefix-based. "keeper." also prefixes schedule
+# payload kinds (keeper.cron, keeper.smoke) and workspace source tags, which
+# are unrelated namespaces. Only strings on a line that also names a prompt-key
+# sink are checked. Test files are excluded: a fixture may legitimately feed a
+# synthetic key to exercise the missing-block path.
+#
+# Authority: config/prompts/*.md basenames plus the keys declared in
+# lib/keeper_metrics/keeper_prompt_names.ml.
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+existing="$(mktemp)"
+referenced="$(mktemp)"
+trap 'rm -f "$existing" "$referenced"' EXIT
+
+find config/prompts -name '*.md' -print0 \
+  | xargs -0 -n1 basename \
+  | sed 's/\.md$//' > "$existing"
+grep -oE '"[a-z_]+\.[a-z_.]+"' lib/keeper_metrics/keeper_prompt_names.ml \
+  | tr -d '"' >> "$existing"
+sort -u -o "$existing" "$existing"
+
+# A prompt-key sink: the decoder, the assembly panel's stage specs, or the
+# block map the server fills. Anything else that says "keeper.x" is a
+# different namespace.
+SINKS='normalizePromptBlock|promptKeys?|system_prompt_blocks'
+
+# Namespaces are derived from the assets themselves, so a JSON response path
+# like prompt.system_prompt_blocks is not mistaken for a prompt key.
+ns="$(sed 's/\..*//' "$existing" | sort -u | paste -sd'|' -)"
+
+grep -rn --include='*.ts' --exclude='*.test.ts' -E "$SINKS" dashboard/src 2>/dev/null \
+  | grep -oE "'(${ns})\.[a-z_.]+'" \
+  | tr -d "'" \
+  | sort -u > "$referenced"
+
+stale="$(comm -23 "$referenced" "$existing")"
+
+if [ -n "$stale" ]; then
+  echo "[dashboard-prompt-keys] FAIL - dashboard names prompt keys that do not exist"
+  echo
+  printf '%s\n' "$stale" | sed 's/^/  - /'
+  echo
+  echo "Each resolves to an empty block or a rule that never matches."
+  echo "Point it at a key in config/prompts, or delete the reference."
+  echo
+  while IFS= read -r key; do
+    [ -z "$key" ] && continue
+    grep -rn --include='*.ts' --exclude='*.test.ts' "'${key}'" dashboard/src 2>/dev/null | sed 's/^/  /'
+  done <<< "$stale"
+  exit 2
+fi
+
+count="$(wc -l < "$referenced" | tr -d ' ')"
+echo "[dashboard-prompt-keys] OK - ${count} prompt keys named in dashboard code, all present"


### PR DESCRIPTION
## 문제

대시보드가 **서버가 보낼 수 없는 프롬프트 키**를 읽고 그리고 있었다.

```
서버가 보내는 블록:  system_prompt_blocks: { system }        (1개)
대시보드가 기대:      { constitution, world, capabilities }    (3개, 전부 삭제됨)
```

세 키는 오늘 아침 #26823 이 `keeper.system` 으로 통합하며 사라졌다. `normalizePromptBlock` 이 없는 키를 `{key, source:'', text:''}` 로 흡수하므로 타입도 런타임도 아무 신호를 내지 않았고, keeper config 패널의 "블록" 탭은 **빈 상자만 렌더**했다. 실제로 keeper 에게 가는 `keeper.system` (7,891 B) 은 화면에 없었다.

같은 드리프트가 세 곳 더 있었다:

| 위치 | 증상 |
|---|---|
| `keeper-prompt-assembly-panel.ts` | 6 단계 중 5개가 죽은 키 (`world`/`capabilities`/`constitution`/`recovery_block`/`turn_intent`/`reply_guidelines`) — 존재하지 않는 조립도를 그림 |
| `keeper-config-panel.ts` | 빈 블록 3개를 순회하며 아무 세그먼트도 push 하지 않음 |
| `tools/prompt-book-panel.ts` | `keeper.turn_intent` 분류 규칙이 영원히 매칭되지 않음 |

## 변경

프로덕션 5파일을 서버 wire 에 맞췄다. `types/core.ts` 의 블록 타입을 `system` 하나로 좁히자 **`tsc` 가 나머지 소비처 4곳을 즉시 지목**했다 — 디코더가 기본값으로 흡수하지 않으면 타입 시스템이 드리프트를 잡는다.

테스트 5파일의 낡은 기대값도 정정했다. 그중 하나는 매직 임계값이었다:

```diff
- expect(report.stats.totalRows).toBeGreaterThan(10)
+ expect(report.rows.filter(row => row.promptKey.startsWith('keeper.')).length)
+   .toBeGreaterThanOrEqual(3)
+ expect(report.rows.some(row => row.promptKey === '(computed:world_observation)')).toBe(true)
```

`> 10` 은 stage spec 이 죽은 키 6개를 들고 있던 시절의 부산물이라, 동작이 하나도 안 바뀌었는데 실패했다. 공급된 프롬프트가 실제로 행이 되는지로 바꿨다.

## 재발 방지 — `scripts/audit-dashboard-prompt-keys.sh`

프롬프트 자산 삭제는 서버측 변경이고, 대시보드의 키 문자열은 문법적으로 계속 유효하다. 이 클래스는 오늘만 세 번 났다 (메모리 패널 #26799, 프롬프트 블록, 조립 패널).

게이트는 **위치 기반**이다. `keeper.` 는 스케줄 payload 종류(`keeper.cron`, `keeper.smoke`)와 workspace source 태그도 쓰는 접두어라 접두어 매칭으로는 오탐이 20건 넘게 났다. `normalizePromptBlock` / `promptKeys` / `system_prompt_blocks` 가 있는 줄만 검사하고, 네임스페이스는 `config/prompts/*.md` 에서 유도해 `prompt.system_prompt_blocks` 같은 JSON 경로를 배제한다. 테스트 파일은 제외한다 — 픽스처는 missing 경로를 태우려고 합성 키를 쓸 수 있다.

CI 에 **무조건 실행**으로 배선했다. `config/prompts` 든 `dashboard/src` 든 한쪽만 움직여도 드리프트가 생기므로 경로 필터를 걸지 않았다.

## 검증

| 항목 | 결과 |
|---|---|
| `tsc --noEmit` | exit 0 |
| 게이트 negative control | `keeper.system` → `keeper.world` 주입 시 해당 키를 지목하며 FAIL, 복원 시 OK |
| 영향 스위트 (config panel / assembly panel / prompt-book / dashboard.test) | 192 tests, 실패 0 |
| settings-surface / prompt-registry-panel | 53 tests, 실패 0 |
| 대시보드 전체 | 8,762 tests 중 이 PR 관련 실패 0 |

## 미해결 (이 PR 밖)

`keeper-detail.test.ts` 가 clean main 에서도 2건 실패한다 (`Unable to find role="tab" and name "상태"`). 이 PR 전후 동일하게 실패하므로 건드리지 않았다.

RFC-WAIVED: dashboard 읽기 경로의 프롬프트 키 정정과 그 드리프트 게이트. credential/identity/auth, operator control, keeper sandbox, dashboard credential component, hooks, workflow 문서 어디에도 해당하지 않는다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
