### PR TITLE
feat(dashboard): 완료 권한이 각 요청으로 무엇을 했는지 화면에 보인다 (RFC-0361 D6)

### DIFF
--- a/dashboard/src/api/dashboard-verification-runs.test.ts
+++ b/dashboard/src/api/dashboard-verification-runs.test.ts
@@ -1,0 +1,115 @@
+// RFC-0361 D4 — completion-authority review registry decoding.
+//
+// The registry exists so a review that produced no verdict is visible. These
+// cases pin that the decoder never turns such a row into something healthier
+// than it is, and that each outcome's cause survives into the one column the
+// panel shows.
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const getMock = vi.hoisted(() => vi.fn())
+
+vi.mock('./core', () => ({
+  get: getMock,
+}))
+
+import {
+  fetchVerificationRuns,
+  parseVerificationRunsResponse,
+} from './dashboard-verification-runs'
+
+afterEach(() => {
+  getMock.mockReset()
+})
+
+function row(overrides: Record<string, unknown> = {}) {
+  return {
+    verification_id: 'vrf-24b43c36',
+    task_id: 'task-136',
+    producer: 'keeper-kidsnote-agent',
+    authority_kind: 'system_llm_agent',
+    authority_actor: 'system-llm-agent-473b608e',
+    started_at: 1_754_000_000,
+    status: 'approved',
+    elapsed_s: 2.5,
+    evaluator_runtime: 'cross-verifier',
+    ...overrides,
+  }
+}
+
+describe('parseVerificationRunsResponse', () => {
+  it('maps a completed review onto the record shape', () => {
+    const parsed = parseVerificationRunsResponse({
+      generated_at: '2026-08-05T00:00:00Z',
+      count: 1,
+      runs: [row()],
+    })
+    expect(parsed.count).toBe(1)
+    expect(parsed.generatedAt).toBe('2026-08-05T00:00:00Z')
+    expect(parsed.runs[0]).toMatchObject({
+      verificationId: 'vrf-24b43c36',
+      taskId: 'task-136',
+      producer: 'keeper-kidsnote-agent',
+      authorityActor: 'system-llm-agent-473b608e',
+      status: 'approved',
+      elapsedSeconds: 2.5,
+      evaluatorRuntime: 'cross-verifier',
+    })
+  })
+
+  it('reads a rejection cause from `reason`', () => {
+    const parsed = parseVerificationRunsResponse({
+      runs: [row({ status: 'rejected', reason: 'aria attributes are not committed' })],
+    })
+    expect(parsed.runs[0].status).toBe('rejected')
+    expect(parsed.runs[0].cause).toBe('aria attributes are not committed')
+  })
+
+  it('reads a failure cause from `detail` and keeps the gate', () => {
+    const parsed = parseVerificationRunsResponse({
+      runs: [
+        row({ status: 'not_reviewed', gate: 'evaluator_unavailable', detail: 'no runtime' }),
+      ],
+    })
+    expect(parsed.runs[0].status).toBe('not_reviewed')
+    expect(parsed.runs[0].cause).toBe('no runtime')
+    expect(parsed.runs[0].gate).toBe('evaluator_unavailable')
+  })
+
+  it('maps an unrecognized status to `unknown` rather than a real outcome', () => {
+    // The backend emits a closed set, so an unrecognized value is a protocol
+    // break. Mapping it onto `approved` would let a garbled row claim a Task
+    // passed review; mapping it onto a specific failure would misattribute one.
+    const parsed = parseVerificationRunsResponse({
+      runs: [row({ status: 'probably_fine' })],
+    })
+    expect(parsed.runs[0].status).toBe('unknown')
+  })
+
+  it('drops rows with no verification id', () => {
+    const parsed = parseVerificationRunsResponse({
+      runs: [row(), row({ verification_id: '' }), { status: 'approved' }],
+    })
+    expect(parsed.runs).toHaveLength(1)
+  })
+
+  it('survives a malformed payload', () => {
+    expect(parseVerificationRunsResponse(null)).toEqual({
+      runs: [],
+      count: 0,
+      generatedAt: null,
+    })
+  })
+})
+
+describe('fetchVerificationRuns', () => {
+  it('reads the dashboard verification-runs endpoint', async () => {
+    getMock.mockResolvedValue({ runs: [row()], count: 1 })
+    const result = await fetchVerificationRuns()
+    expect(getMock).toHaveBeenCalledWith(
+      '/api/v1/dashboard/verification-runs',
+      expect.objectContaining({ signal: undefined }),
+    )
+    expect(result.runs).toHaveLength(1)
+  })
+})

--- a/dashboard/src/api/dashboard-verification-runs.ts
+++ b/dashboard/src/api/dashboard-verification-runs.ts
@@ -1,0 +1,105 @@
+// MASC Dashboard — completion-authority review registry fetcher + decoder.
+//
+// Backend: lib/verification_run_registry.ml (RFC-0361 D4)
+// Route:   GET /api/v1/dashboard/verification-runs
+//
+// Sibling of dashboard-fusion.ts and deliberately shaped the same way. Distinct
+// from the verification *requests* surface (dashboard-misc.ts): a request is
+// what a Keeper submitted, a run is what the completion authority did with it.
+// Only the registry shows a review that produced no verdict at all.
+
+import { isRecord, asInt, asNumber, asRecordArray, asString } from '../components/common/normalize'
+import { get, type AbortableRequestOptions } from './core'
+
+/** How a completion-authority review ended, mirroring the backend
+    Verification_run_registry.status_label vocabulary.
+
+    `unknown` is not a backend label. The backend emits a closed set, so an
+    unrecognized value can only come from a protocol break; mapping it to a real
+    outcome would let a garbled row pose as an approval or misattribute a
+    failure. See CLAUDE.md "Unknown → Permissive Default". */
+export type VerificationRunStatusLabel =
+  | 'running'
+  | 'approved'
+  | 'rejected'
+  | 'contract_rejected'
+  | 'not_reviewed'
+  | 'commit_failed'
+  | 'raised'
+  | 'unknown'
+
+const BACKEND_STATUSES: readonly string[] = [
+  'running',
+  'approved',
+  'rejected',
+  'contract_rejected',
+  'not_reviewed',
+  'commit_failed',
+  'raised',
+]
+
+/** One tracked review from the registry.
+
+    `cause` is the operator-readable reason the outcome happened, flattened from
+    the backend's per-outcome field (`reason` on a rejection, `detail` on the
+    failure shapes). Absent on `running` and `approved` — those are the only two
+    outcomes with nothing to explain. */
+export interface VerificationRunRecord {
+  verificationId: string
+  taskId: string
+  producer: string
+  authorityKind: string
+  authorityActor: string
+  startedAt: number // unix seconds
+  status: VerificationRunStatusLabel
+  elapsedSeconds?: number
+  evaluatorRuntime?: string
+  cause?: string
+  /** Which gate declined to produce a verdict; `not_reviewed` rows only. */
+  gate?: string
+}
+
+export interface DashboardVerificationRunsResponse {
+  runs: VerificationRunRecord[]
+  count: number
+  generatedAt: string | null
+}
+
+function asVerificationRunStatus(value: unknown): VerificationRunStatusLabel {
+  return typeof value === 'string' && BACKEND_STATUSES.includes(value)
+    ? (value as VerificationRunStatusLabel)
+    : 'unknown'
+}
+
+export function parseVerificationRunsResponse(raw: unknown): DashboardVerificationRunsResponse {
+  const root = isRecord(raw) ? raw : {}
+  const runs: VerificationRunRecord[] = asRecordArray(root.runs)
+    .map(row => ({
+      verificationId: asString(row.verification_id) ?? '',
+      taskId: asString(row.task_id) ?? '',
+      producer: asString(row.producer) ?? '',
+      authorityKind: asString(row.authority_kind) ?? '',
+      authorityActor: asString(row.authority_actor) ?? '',
+      startedAt: asNumber(row.started_at) ?? 0,
+      status: asVerificationRunStatus(row.status),
+      elapsedSeconds: asNumber(row.elapsed_s),
+      evaluatorRuntime: asString(row.evaluator_runtime),
+      // The backend names a rejection's cause `reason` and every failure shape's
+      // cause `detail`; the panel shows one column either way.
+      cause: asString(row.reason) ?? asString(row.detail),
+      gate: asString(row.gate),
+    }))
+    .filter(run => run.verificationId.length > 0)
+  return {
+    runs,
+    count: asInt(root.count) ?? runs.length,
+    generatedAt: asString(root.generated_at) ?? null,
+  }
+}
+
+export async function fetchVerificationRuns(
+  opts?: AbortableRequestOptions,
+): Promise<DashboardVerificationRunsResponse> {
+  const raw = await get<unknown>('/api/v1/dashboard/verification-runs', { signal: opts?.signal })
+  return parseVerificationRunsResponse(raw)
+}

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -51,6 +51,15 @@ export { reportToolHostFailure } from './tool-host-failure'
 export { fetchDashboardBootstrap, fetchDashboardShell } from './dashboard-hot'
 export type { FusionRunStatusLabel, FusionRunRecord, DashboardFusionRunsResponse } from './dashboard-fusion'
 export { parseFusionRunsResponse, fetchFusionRuns } from './dashboard-fusion'
+export type {
+  VerificationRunStatusLabel,
+  VerificationRunRecord,
+  DashboardVerificationRunsResponse,
+} from './dashboard-verification-runs'
+export {
+  parseVerificationRunsResponse,
+  fetchVerificationRuns,
+} from './dashboard-verification-runs'
 
 // --- Dashboard projections ---
 

--- a/dashboard/src/components/common/status-badge.ts
+++ b/dashboard/src/components/common/status-badge.ts
@@ -5,7 +5,10 @@ import type { ComponentChildren } from 'preact'
 import { statusLabel } from '../../lib/status-label'
 import { PHASE_TONE, type FleetTone, type KeeperPhaseToken } from '../../lib/fleet-tone'
 
-type StatusBadgeTone = 'ok' | 'warn' | 'bad' | 'info' | 'neutral'
+// Exported so a caller mapping its own closed status vocabulary onto these
+// tones names this type instead of restating the union — one definition of the
+// tone set, not one per panel.
+export type StatusBadgeTone = 'ok' | 'warn' | 'bad' | 'info' | 'neutral'
 
 interface StatusBadgeProps {
   status?: string

--- a/dashboard/src/components/verification-runs-panel.ts
+++ b/dashboard/src/components/verification-runs-panel.ts
@@ -1,0 +1,197 @@
+// VerificationRunsPanel — what the completion authority actually did.
+//
+// Consumes:
+//   GET /api/v1/dashboard/verification-runs   (RFC-0361 D4)
+//
+// Sits beside VerificationRequestsPanel and answers the other half of the
+// question. A *request* is what a Keeper submitted; a *run* is the review of
+// it. Before the registry, a review that produced no verdict — an unavailable
+// evaluator, a malformed verdict, a failed commit, a raise — left no trace at
+// all, so an operator could not tell a pending request from one whose review
+// had already run and come back empty.
+//
+// Pattern mirrors VerificationRequestsPanel: managed async resource + manual
+// refresh + 15s auto-tick, read-only table.
+
+import { html } from 'htm/preact'
+import { useEffect } from 'preact/hooks'
+import {
+  fetchVerificationRuns,
+  type DashboardVerificationRunsResponse,
+  type VerificationRunRecord,
+  type VerificationRunStatusLabel,
+} from '../api/dashboard'
+import { Btn } from './btn'
+import { EmptyState, ErrorState } from './common/feedback-state'
+import { StatusBadge, type StatusBadgeTone } from './common/status-badge'
+import { relativeTime } from '../lib/format-time'
+import type { ManagedAsyncResource } from '../lib/async-state'
+import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
+import { truncate } from '../lib/truncate'
+
+const AUTO_REFRESH_MS = 15_000
+
+/** Outcome → badge tone.
+ *
+ *  Exhaustive by design (no `default` arm): a new backend outcome must fail
+ *  type-checking here rather than silently render as neutral.
+ *
+ *  `rejected` is `info`, not a warning: a rejection returns the producer to
+ *  work, which is the review loop functioning. The tones that mean something
+ *  is wrong are the ones where no verdict reached the Task —
+ *  `not_reviewed` / `commit_failed` / `raised` — plus `unknown`, which can only
+ *  come from a protocol break and must never pose as healthy.
+ *
+ *  `contract_rejected` is `warn`: the Task was rejected without the configured
+ *  LLM ever running, so repeated rows point upstream at malformed evidence
+ *  rather than at judgment. */
+export function verificationRunTone(status: VerificationRunStatusLabel): StatusBadgeTone {
+  switch (status) {
+    case 'running':
+      return 'warn'
+    case 'approved':
+      return 'ok'
+    case 'rejected':
+      return 'info'
+    case 'contract_rejected':
+      return 'warn'
+    case 'not_reviewed':
+    case 'commit_failed':
+    case 'raised':
+    case 'unknown':
+      return 'bad'
+  }
+}
+
+/** Operator-facing label. Korean where the backend token is not itself the
+    clearest thing to show; the raw token stays available via the row title. */
+export function verificationRunLabel(status: VerificationRunStatusLabel): string {
+  switch (status) {
+    case 'running':
+      return '판정 중'
+    case 'approved':
+      return '승인'
+    case 'rejected':
+      return '거부'
+    case 'contract_rejected':
+      return '증거 계약 무효'
+    case 'not_reviewed':
+      return '판정 없음'
+    case 'commit_failed':
+      return '커밋 실패'
+    case 'raised':
+      return '예외'
+    case 'unknown':
+      return '알 수 없음'
+  }
+}
+
+function formatElapsed(seconds: number | undefined): string {
+  if (seconds == null) return '—'
+  if (seconds < 1) return `${Math.round(seconds * 1000)}ms`
+  return `${seconds.toFixed(1)}s`
+}
+
+async function loadData(resource: ManagedAsyncResource<DashboardVerificationRunsResponse>) {
+  await resource.load(async (signal) => fetchVerificationRuns({ signal }))
+}
+
+function ThLeft({ children }: { children: unknown }) {
+  return html`<th scope="col" class="text-left py-1 pr-2">${children}</th>`
+}
+
+function VerificationRunRow({ row }: { row: VerificationRunRecord }) {
+  return html`
+    <tr class="v2-workspace-row border-b border-[var(--color-border-default)] last:border-b-0 align-top">
+      <td class="py-2 pr-2">
+        <${StatusBadge}
+          tone=${verificationRunTone(row.status)}
+          label=${verificationRunLabel(row.status)}
+        />
+      </td>
+      <td class="py-2 pr-2">
+        <code class="text-[var(--color-fg-primary)]" title=${row.taskId}>
+          ${truncate(row.taskId, 20)}
+        </code>
+      </td>
+      <td class="py-2 pr-2 text-[var(--color-fg-primary)]">${row.producer}</td>
+      <td class="py-2 pr-2 text-[var(--color-fg-muted)]" title=${row.authorityActor}>
+        ${row.evaluatorRuntime ?? '—'}
+      </td>
+      <td class="py-2 pr-2 text-[var(--color-fg-muted)] tabular-nums whitespace-nowrap">
+        ${formatElapsed(row.elapsedSeconds)}
+      </td>
+      <td class="py-2 pr-2 text-[var(--color-fg-muted)] tabular-nums whitespace-nowrap">
+        ${relativeTime(new Date(row.startedAt * 1000).toISOString())}
+      </td>
+      <td class="py-2 text-[var(--color-fg-secondary)] break-words">
+        ${row.gate ? html`<code class="mr-1">${row.gate}</code>` : null}
+        ${row.cause ?? ''}
+      </td>
+    </tr>
+  `
+}
+
+export function VerificationRunsPanel() {
+  const resource = useManagedAsyncResource<DashboardVerificationRunsResponse>()
+
+  useEffect(() => {
+    void loadData(resource)
+    const id = setInterval(() => void loadData(resource), AUTO_REFRESH_MS)
+    return () => {
+      clearInterval(id)
+      resource.cancel()
+    }
+  }, [resource])
+
+  const current = resource.state.value
+  const data = current.data ?? null
+  const rows = data?.runs ?? []
+
+  return html`
+    <div class="v2-workspace-surface flex flex-col gap-3">
+      <div class="flex items-center gap-3 flex-wrap">
+        <h2 class="text-sm font-semibold text-[var(--color-fg-primary)]">판정 실행</h2>
+        <${Btn} class="v2-workspace-action" onClick=${() => void loadData(resource)}>
+          새로고침
+        <//>
+        ${current.loading
+          ? html`<span class="text-xs text-[var(--color-fg-muted)]" role="status">로딩 중...</span>`
+          : null}
+        ${data?.generatedAt
+          ? html`<span class="text-xs text-[var(--color-fg-muted)]">
+              updated · ${relativeTime(data.generatedAt)}
+            </span>`
+          : null}
+      </div>
+
+      ${current.error
+        ? html`<${ErrorState}>판정 실행 목록을 불러오지 못했습니다: ${current.error}<//>`
+        : rows.length === 0
+          ? html`<${EmptyState}>기록된 판정 실행이 없습니다.<//>`
+          : html`
+              <div class="overflow-x-auto">
+                <table class="w-full text-xs">
+                  <thead class="text-[var(--color-fg-muted)] border-b border-[var(--color-border-default)]">
+                    <tr>
+                      <${ThLeft}>결과<//>
+                      <${ThLeft}>태스크<//>
+                      <${ThLeft}>생산자<//>
+                      <${ThLeft}>판정 런타임<//>
+                      <${ThLeft}>소요<//>
+                      <${ThLeft}>시작<//>
+                      <${ThLeft}>사유<//>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    ${rows.map(
+                      (row) =>
+                        html`<${VerificationRunRow} key=${row.verificationId} row=${row} />`,
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            `}
+    </div>
+  `
+}

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -15,6 +15,7 @@ import { BoardSurface } from './board/board-surface'
 import { SubBoardSurface } from './board/sub-board-surface'
 import { PlanningPanel } from './planning-panel'
 import { VerificationRequestsPanel } from './verification-requests-panel'
+import { VerificationRunsPanel } from './verification-runs-panel'
 import { ErrorBoundary } from './common/error-boundary'
 import { LoadingState } from './common/feedback-state'
 import { VirtualList } from './common/virtual-list'
@@ -1625,7 +1626,12 @@ export function Work() {
               <${LazyRepositoryManagement} />
             <//>
           `
-          : html`<${VerificationRequestsPanel} />`
+          : html`
+            <div class="flex flex-col gap-4">
+              <${VerificationRequestsPanel} />
+              <${VerificationRunsPanel} />
+            </div>
+          `
         }
       <//>
     </div>

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -667,6 +667,26 @@ let add_routes ~sw ~clock router =
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
+  (* RFC-0361 D4: read-only snapshot of the completion-authority review registry
+     (in-progress + recently completed). Sibling of the fusion route above and
+     shaped identically; each run serializes through the shared
+     Verification_run_registry.run_to_yojson so the panel and any later SSE delta
+     read one shape. Registry reads are O(runs) in-memory, so no Dashboard_cache
+     layer. *)
+  |> Http.Router.get "/api/v1/dashboard/verification-runs" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let runs =
+           Verification_run_registry.list_runs (Verification_run_registry.global ())
+         in
+         let json =
+           `Assoc
+             [ ("generated_at", `String (Masc_domain.now_iso ()))
+             ; ("count", `Int (List.length runs))
+             ; ("runs", `List (List.map Verification_run_registry.run_to_yojson runs))
+             ]
+         in
+         Http.Response.json_value ~compress:true ~request:req json reqd
+       ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/workspace" (fun request reqd ->
        with_public_read handle_dashboard_workspace request reqd)
   (* Dev-only Worker bearer for the dashboard UI. Served exclusively when the


### PR DESCRIPTION
## 무엇

판정 실행을 대시보드에서 볼 수 있게 한다. RFC-0361의 2단계.

> **Base: `feat/verification-run-registry`** (#26931). 그 registry 위에 쌓인 스택 PR이라 diff는 대시보드 변경만 보인다.

RFC-0361 D6 (#26922). Refs #26915.

## 왜

검증 화면은 *요청*은 보여주지만 *판정*은 안 보여준다. 운영자는 아직 대기 중인 요청과, **판정이 이미 돌았는데 아무것도 못 내놓고 끝난** 요청을 구분할 수 없다. 후자가 #26931이 처음 기록하기 시작한 것들이고, 기록만 있고 나타날 자리가 없었다.

## 무엇이 추가되나

```
GET /api/v1/dashboard/verification-runs     fusion-runs 라우트 옆, 같은 모양
VerificationRunsPanel                        VerificationRequestsPanel 옆에 렌더
```

요청이 키퍼가 제출한 것이라면, 실행은 그것에 대한 판정이다. 두 패널을 같은 화면에 두면 그 짝이 드러난다.

표시: 결과 · 태스크 · 생산자 · 판정 런타임 · 소요 · 시작 · 사유

## 알 수 없는 상태를 진짜 결과로 만들지 않는다

```ts
// 백엔드는 닫힌 집합을 보낸다 → 인식 못 하는 값은 프로토콜 파손이다
return typeof value === 'string' && BACKEND_STATUSES.includes(value)
  ? (value as VerificationRunStatusLabel)
  : 'unknown'
```

`approved`로 매핑하면 깨진 행이 "이 태스크는 검증을 통과했다"고 주장하게 되고, 특정 실패로 매핑하면 엉뚱한 실패를 뒤집어씌운다. `unknown`은 백엔드 라벨이 아니라 프론트 전용이며 `bad` 톤으로 표시된다.

톤 매핑은 `default` 없이 exhaustive다 — 백엔드에 새 outcome이 생기면 여기서 타입 에러가 나야지 조용히 neutral로 렌더되면 안 된다.

`rejected`는 경고가 아니라 `info`다. 거부는 생산자를 작업으로 되돌리는 것이고 그건 루프가 작동하는 모습이다. `bad`인 것들은 **verdict가 Task에 닿지 못한** 경우들이다 — `not_reviewed` / `commit_failed` / `raised` / `unknown`.

`contract_rejected`는 `warn`: LLM이 아예 돌지 않고 거부됐으므로, 반복되면 판단이 아니라 상류의 증거 형식을 가리킨다.

## StatusBadgeTone export

`status-badge.ts`에 선언만 되고 export되지 않은 타입이었다. 제 패널에 union을 복제하면 톤 어휘의 두 번째 진실이 생기므로 정본을 export했다.

## 로컬 검증

```
dune build --root . @all                      EXIT=0
tsc --noEmit                                  EXIT=0  (직전 1개 → 0개, 타입체커가 실제로 봤다는 증거)
vitest dashboard-verification-runs.test.ts    7/7 OK
ocamlformat --check (변경 .ml)                 OK

check-determinism-contract                    EXIT=0
check-silent-failure-patterns                 EXIT=0
check-enum-string-safety                      EXIT=0
check-actor-consumer-wired                    EXIT=0
no-runtime-literal-outside-boundary-redaction EXIT=0
check-pr-hygiene                              EXIT=0
```

**테스트가 실패할 능력 증명**: 상태 디코더에 permissive default(`: 'approved'`)를 주입하니 unrecognized-status 케이스가 `FAIL`, exit 1. 되돌린 뒤 7/7.

> dune은 `--root .` 없이 실행하면 워크트리가 `.worktrees/` 아래라 부모 체크아웃으로 올라간다. 위 결과는 전부 `--root .` 고정으로 얻었다.

## 다음

| 단계 | 내용 |
|---|---|
| 3 | 판정자 정체성 (profile 축) |
| 4 | 조회 도구 + 프롬프트 |
| 5 | 라이브러리안 journal |

RFC-WAIVED: RFC-0361 (#26922) 이 이 변경의 설계 문서다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
