### PR TITLE
fix(board): 작성자 닉네임 모양으로 게시물을 삭제하던 GC 제거

### DIFF
--- a/lib/workspace/workspace_gc.ml
+++ b/lib/workspace/workspace_gc.ml
@@ -218,23 +218,12 @@ let gc config ~days () =
    | Error e ->
        results := Printf.sprintf "Backend pubsub cleanup failed: %s" (Backend_types.show_error e) :: !results);
 
-  (* 4. Hard-delete board artifacts (via hooks) *)
-  let board_artifact_count = (Atomic.get Workspace_hooks.cleanup_board_artifacts_fn) () in
-  if board_artifact_count > 0 then
-    results :=
-      Printf.sprintf "Removed %d board artifact post(s)"
-        board_artifact_count
-      :: !results
-  else
-    results := "No board artifacts" :: !results;
-
   log_event config (`Assoc [
     ("type", `String "gc");
     ("stale_tasks", `Int stale_count);
     ("old_messages", `Int !old_msg_count);
     ("preserved", `Int !preserved_count);
     ("pubsub_cleaned", `Int !pubsub_cleanup_count);
-    ("board_artifacts", `Int board_artifact_count);
     ("days", `Int days);
     ("ts", `String (now_iso ()));
   ]);

--- a/lib/workspace/workspace_hooks.ml
+++ b/lib/workspace/workspace_hooks.ml
@@ -130,12 +130,6 @@ let observe_task_transition_fn
       (fun _config ~agent_name:_ ~task_id:_ ~transition:_
            ~details:_ -> ())
 
-(** Board artifact cleanup — wraps Board_dispatch.list_posts + delete_post.
-    Returns number of deleted posts. *)
-let cleanup_board_artifacts_fn
-  : (unit -> int) Atomic.t
-  = Atomic.make (fun () -> 0)
-
 (** Invalidate dashboard execution cache on task mutation (add, transition).
     Wired by server bootstrap to avoid circular dependency between
     Workspace sub-modules and server dashboard surfaces. *)

--- a/lib/workspace/workspace_hooks.mli
+++ b/lib/workspace/workspace_hooks.mli
@@ -68,7 +68,6 @@ val observe_task_transition_fn : (Workspace_utils_backend_setup.config ->
             transition:Masc_domain.task_action ->
             details:Yojson.Safe.t -> unit)
            Atomic.t
-val cleanup_board_artifacts_fn : (unit -> int) Atomic.t
 val on_task_mutation_fn : (unit -> unit) Atomic.t
 
 val operator_pending_confirm_trace_id_fn : (string -> string) Atomic.t

--- a/lib/workspace_metric_hooks.ml
+++ b/lib/workspace_metric_hooks.ml
@@ -270,37 +270,6 @@ let install () =
     (Atomic.get Workspace_hooks.on_task_mutation_fn) ();
     observe_task_transition_event config ~agent_name ~task_id ~transition ~details);
 
-  Atomic.set Workspace_hooks.cleanup_board_artifacts_fn (fun () ->
-    let stale_system_daily_sec = 12.0 *. Masc_time_constants.hour in
-    let board_artifact_title title =
-      let title = String.lowercase_ascii (String.trim title) in
-      String.starts_with ~prefix:"[keeper daily]" title
-    in
-    let board_artifact_author author =
-      let author = String.lowercase_ascii (String.trim author) in
-      author = "auto-researcher"
-      || String.starts_with ~prefix:"qa-" author
-      || ((not (String.contains author ' ')) && String.ends_with ~suffix:"-probe" author)
-    in
-    let now = Time_compat.now () in
-    Board_dispatch.list_posts ~sort_by:Board_dispatch.Recent ~limit:5200 ()
-    |> List.fold_left
-         (fun removed (post : Board.post) ->
-            let author = Board.Agent_id.to_string post.author in
-            if
-              board_artifact_author author
-              || (String.equal (String.lowercase_ascii author) "keeper"
-                  && board_artifact_title post.title
-                  && now -. post.updated_at >= stale_system_daily_sec)
-            then (
-              match
-                Board_dispatch.delete_post ~post_id:(Board.Post_id.to_string post.id)
-              with
-              | Ok () -> removed + 1
-              | Error _ -> removed)
-            else removed)
-         0);
-
   Atomic.set Workspace_hooks.activity_emit_fn (fun config ~actor ?subject ~kind ~payload ~tags () ->
     try
       ignore


### PR DESCRIPTION
## 무엇을

보드 GC 가 **작성자 문자열 모양** 으로 하드 삭제 대상을 정했습니다.

```ocaml
author = "auto-researcher"
|| String.starts_with ~prefix:"qa-" author
|| ((not (String.contains author ' ')) && String.ends_with ~suffix:"-probe" author)
```

`post.author` 는 `Board.Agent_id` 라는 **내부 타입** 인데, 훅이 `to_string` 으로 풀어 접두/접미사로 되분류합니다. 이 모양에 걸린 게시물은 **나이 검사 없이** 삭제됩니다 — 12시간 가드는 별개인 `author="keeper"` + `"[keeper daily]"` 제목 분기에만 있습니다.

## 겨냥한 대상이 존재하지 않고, 실재하는 것을 잡습니다

- `auto-researcher` / `qa-*` / `*-probe` 작성자를 만드는 코드가 저장소에 **0건** 입니다.
- 이 훅 밖의 유일한 `qa-` 히트는 `nickname.ml` 자신의 docstring 인데, **`"qa-king-warm-heron" -> "qa-king"` 을 정상 닉네임 예시로 제시** 합니다.
- `"[keeper daily]"` 제목을 만드는 생산자도 **0건** 입니다.

즉 존재하지 않는 생산자를 겨냥하면서 **실재하는 닉네임 형태를 잡습니다.** 에이전트 이름을 `qa-review` 로 지으면 그 에이전트가 쓴 모든 게시물이 GC 됩니다.

## 좁히지 않고 지웁니다

"이 게시물은 버려도 되는 산출물" 은 **게시물의 성질** 이고, 그것을 작성자 이름에서 복원하는 건 추측입니다. 그리고 이 추측의 실패 모드가 **데이터 손실** 입니다. 진짜 마커는 게시물에 있어야 하고 그건 스키마 변경이지 이 술어의 수리가 아닙니다.

## 연쇄

installer 만 지우면 `Workspace_hooks.cleanup_board_artifacts_fn` 이 `fun () -> 0` 기본값에 갇히고 아무도 교체할 수 없게 됩니다 — #26917 이전의 `Board_effect_hooks` 와 같은 모양입니다. 그래서 훅 선언·`.mli`·`workspace_gc` 호출부·GC 로그의 `board_artifacts` 필드까지 함께 제거합니다. 그 필드를 읽는 대시보드 코드는 없습니다.

## 검증

`lib/masc.cma` 빌드 통과.

RFC-WAIVED: credential / identity / operator control action handler / keeper sandbox / hooks 게이트 대상이 아닙니다. 파괴적 동작을 **제거** 하는 변경이고 새 권한이나 경계를 만들지 않습니다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>