### PR TITLE
refactor(task): 완료 기준과 실행 식별자를 분리하고 계약 생성기를 제거

### DIFF
--- a/dashboard/src/components/ide/ide-keeper-work-panel.ts
+++ b/dashboard/src/components/ide/ide-keeper-work-panel.ts
@@ -288,14 +288,8 @@ function taskExecutionRouteContext(task: Task): {
   readonly telemetryQuery: string | null
   readonly hasTelemetry: boolean
 } {
-  const sessionId = firstNonEmptyString(
-    task.execution_links?.session_id,
-    task.contract?.links?.session_id,
-  )
-  const operationId = firstNonEmptyString(
-    task.execution_links?.operation_id,
-    task.contract?.links?.operation_id,
-  )
+  const sessionId = firstNonEmptyString(task.execution_links?.session_id)
+  const operationId = firstNonEmptyString(task.execution_links?.operation_id)
   return {
     sessionId,
     operationId,

--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -514,10 +514,6 @@ describe('Work', () => {
             strict: true,
             completion_contract: ['merge-ready proof'],
             required_evidence: ['typed test evidence'],
-            links: {
-              session_id: null,
-              operation_id: 'op-contract',
-            },
           },
           handoff_context: {
             summary: '',
@@ -537,7 +533,6 @@ describe('Work', () => {
       expect(ledger.textContent).toContain('sess-ledger')
       expect(ledger.textContent).toContain('op-ledger')
       expect(ledger.textContent).toContain('strict')
-      expect(ledger.textContent).toContain('op-contract')
       expect(ledger.textContent).toContain('merge-ready proof')
       expect(ledger.textContent).toContain('typed test evidence')
       expect(ledger.textContent).toContain('receipt-1')

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -396,12 +396,6 @@ function taskEvidenceLedgerRows(task: Task): TaskEvidenceLedgerRow[] {
       tone: contract.strict ? 'warn' : undefined,
     })
   }
-  if (contract?.links?.session_id) {
-    rows.push({ key: 'contract:session', label: 'contract session', value: contract.links.session_id })
-  }
-  if (contract?.links?.operation_id) {
-    rows.push({ key: 'contract:operation', label: 'contract operation', value: contract.links.operation_id })
-  }
   appendEvidenceList(rows, 'completion', contract?.completion_contract, 'completion')
   appendEvidenceList(rows, 'required evidence', contract?.required_evidence, 'required')
   appendEvidenceList(rows, 'inspect evidence', contract?.inspect_gate_evidence, 'inspect')

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -96,12 +96,6 @@ export function normalizeTask(raw: unknown): Task | null {
         required_evidence: asStringArray(raw.contract.required_evidence),
         inspect_gate_evidence: asStringArray(raw.contract.inspect_gate_evidence),
         verify_gate_evidence: asStringArray(raw.contract.verify_gate_evidence),
-        links: isRecord(raw.contract.links)
-          ? {
-              operation_id: asString(raw.contract.links.operation_id) ?? null,
-              session_id: asString(raw.contract.links.session_id) ?? null,
-            }
-          : null,
       }
     : null
   const handoffContext = isRecord(raw.handoff_context)

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -87,7 +87,6 @@ interface TaskContract {
   required_evidence?: string[]
   inspect_gate_evidence?: string[]
   verify_gate_evidence?: string[]
-  links?: TaskExecutionLinks | null
 }
 
 interface TaskHandoffContext {

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -547,9 +547,9 @@ let task_completed_at (task : Masc_domain.task) =
 ;;
 
 let task_execution_links_json (task : Masc_domain.task) =
-  match task.contract with
-  | Some contract -> Masc_domain.task_execution_links_to_yojson contract.links
-  | None -> `Null
+  match task.execution_links with
+  | { operation_id = None; session_id = None } -> `Null
+  | links -> Masc_domain.task_execution_links_to_yojson links
 ;;
 
 (* RFC-0267 Phase 1: project the registry's canonical goal_id onto the wire.

--- a/lib/dashboard/dashboard_execution_builders.ml
+++ b/lib/dashboard/dashboard_execution_builders.ml
@@ -411,7 +411,7 @@ let task_operation_updated_at (task : Masc_domain.task) =
   | Masc_domain.Todo -> task.created_at
 
 let task_operation_id (task : Masc_domain.task) =
-  match Option.bind task.contract (fun contract -> contract.links.operation_id) with
+  match task.execution_links.operation_id with
   | Some operation_id -> (
       match String_util.trim_to_option operation_id with
       | Some operation_id -> operation_id

--- a/lib/dashboard/dashboard_execution_builders.ml
+++ b/lib/dashboard/dashboard_execution_builders.ml
@@ -443,7 +443,7 @@ let build_operation_contexts ~(tasks : Masc_domain.task list) =
                      ("task_status", `String (Masc_domain.task_status_to_string task.task_status));
                      ("objective", `String task.title);
                      ("updated_at", `String updated_at);
-                     ("source", `String "task_contract");
+                     ("source", `String "task_execution_links");
                      ("task_id", `String task.id);
                      ("severity", `String (Dashboard_utils.string_of_tone severity));
                      ( "handoff",

--- a/lib/task/tool_task_args.ml
+++ b/lib/task/tool_task_args.ml
@@ -6,20 +6,35 @@
 
     @since God file decomposition — extracted from tool_task.ml *)
 
+let task_contract_keys =
+  [ "strict"
+  ; "completion_contract"
+  ; "required_evidence"
+  ; "inspect_gate_evidence"
+  ; "verify_gate_evidence"
+  ]
+
+let parse_task_contract_object = function
+  | `Assoc fields as json ->
+    Result.bind
+      (Json_util.reject_unknown_fields
+         ~surface:"contract"
+         ~allowed:task_contract_keys
+         fields)
+      (fun () -> Masc_domain.task_contract_of_yojson json)
+  | other ->
+    Error
+      (Printf.sprintf
+         "contract must be an object when provided (received %s)"
+         (Json_util.kind_name other))
+
 let parse_task_contract args =
   match Json_util.assoc_member_opt "contract" args with
   | None | Some `Null -> Ok None
-  | Some (`Assoc _ as json) -> (
-      match Masc_domain.task_contract_of_yojson json with
-      | Ok contract -> Ok (Some contract)
-      | Error error ->
-          Error
-            (Printf.sprintf "Invalid contract payload: %s" error))
-  | Some other ->
-      Error
-        (Printf.sprintf
-           "contract must be an object when provided (received %s)"
-           (Json_util.kind_name other))
+  | Some json ->
+    parse_task_contract_object json
+    |> Result.map Option.some
+    |> Result.map_error (Printf.sprintf "Invalid contract payload: %s")
 
 let handoff_example_evidence_ref =
   Filename.concat Common.masc_dirname "harness-evidence/proof.json"

--- a/lib/task/tool_task_args.mli
+++ b/lib/task/tool_task_args.mli
@@ -3,6 +3,11 @@
 val parse_task_contract :
   Yojson.Safe.t -> (Masc_domain.task_contract option, string) result
 
+(** Decode a present public tool [contract] value. Unlike the permissive
+    persisted-data decoder, this boundary rejects unknown and duplicate fields. *)
+val parse_task_contract_object :
+  Yojson.Safe.t -> (Masc_domain.task_contract, string) result
+
 val is_internal_marker : string -> bool
 
 val unknown_args : valid_keys:string list -> Yojson.Safe.t -> string list

--- a/lib/task/tool_task_handlers.ml
+++ b/lib/task/tool_task_handlers.ml
@@ -320,14 +320,11 @@ let handle_batch_add_tasks ?created_by ~tool_name ~start_time ctx args =
     let contract =
       match Json_util.assoc_member_opt "contract" t with
       | None | Some `Null -> Ok None
-      | Some (`Assoc _ as json) -> (
-          match Masc_domain.task_contract_of_yojson json with
-          | Ok contract -> Ok (Some contract)
-          | Error error ->
-              Error
-                (Printf.sprintf "item[%d]: invalid contract payload: %s" idx
-                   error))
-      | Some _ -> Error (Printf.sprintf "item[%d]: contract must be an object" idx)
+      | Some json ->
+        parse_task_contract_object json
+        |> Result.map Option.some
+        |> Result.map_error (fun error ->
+          Printf.sprintf "item[%d]: invalid contract payload: %s" idx error)
     in
     if String.equal title "" then
       Error (Printf.sprintf "item[%d]: title cannot be empty" idx)

--- a/lib/task/tool_task_schemas.ml
+++ b/lib/task/tool_task_schemas.ml
@@ -76,6 +76,7 @@ Example: %s({title: 'Fix login bug', priority: 1, description: 'Users cannot log
         ]);
         ("contract", `Assoc [
           ("type", `String "object");
+          ("additionalProperties", `Bool false);
           ("description", `String "What counts as done for this task, and what evidence shows it. Recorded at creation and never rewritten. Omit it and the task carries no criteria.");
           ("properties", `Assoc [
             ("strict", `Assoc [ ("type", `String "boolean") ]);
@@ -126,6 +127,7 @@ Example: masc_batch_add_tasks({tasks: [{title: 'Task A', priority: 2}, {title: '
               ]);
               ("contract", `Assoc [
                 ("type", `String "object");
+                ("additionalProperties", `Bool false);
                 ("properties", `Assoc [
                   ("strict", `Assoc [ ("type", `String "boolean") ]);
                   ("completion_contract", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);

--- a/lib/task/tool_task_schemas.ml
+++ b/lib/task/tool_task_schemas.ml
@@ -42,6 +42,7 @@ let schemas : Masc_domain.tool_schema list = [
     description = Printf.sprintf
       "Add a new task to the backlog for agents to claim. \
 Task contracts provide completion/evidence context to the judge; they do not select a completion lane. \
+Write one when you know what done looks like: none is derived from the title, so a task without a contract reaches the judge with no criteria and is judged against a standard the worker never saw. \
 Every task must be submitted for an out-of-band system LLM completion-authority verdict. \
 submit_for_verification creates an asynchronous review state that no agent or Keeper can claim. The application-owned system LLM agent reads the immutable submitted-evidence snapshot and commits the typed verdict; an authenticated human operator is the separate HITL path. \
 To re-run completed work, create a new task with predecessor_task_id instead of touching the done one. \
@@ -75,20 +76,13 @@ Example: %s({title: 'Fix login bug', priority: 1, description: 'Users cannot log
         ]);
         ("contract", `Assoc [
           ("type", `String "object");
-          ("description", `String "Optional persisted task contract for strict deterministic completion gating.");
+          ("description", `String "What counts as done for this task, and what evidence shows it. Recorded at creation and never rewritten. Omit it and the task carries no criteria.");
           ("properties", `Assoc [
             ("strict", `Assoc [ ("type", `String "boolean") ]);
             ("completion_contract", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);
             ("required_evidence", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);
             ("inspect_gate_evidence", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);
             ("verify_gate_evidence", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);
-            ("links", `Assoc [
-              ("type", `String "object");
-              ("properties", `Assoc [
-                ("operation_id", `Assoc [ ("type", `String "string") ]);
-                ("session_id", `Assoc [ ("type", `String "string") ]);
-              ]);
-            ]);
           ]);
         ]);
       ]);
@@ -100,10 +94,9 @@ Example: %s({title: 'Fix login bug', priority: 1, description: 'Users cannot log
     description = Printf.sprintf
       "Add multiple tasks in one call (more efficient than repeated %s). \
 Use when: loading sprint backlog, importing from JIRA, creating related tasks. \
-Tasks default to the same advisory verification contract/evidence requirements as %s. \
+A task carries a completion contract only if you write one; none is derived from the title. \
 Each task gets unique ID (task-XXX). Atomic: all succeed or all fail. \
 Example: masc_batch_add_tasks({tasks: [{title: 'Task A', priority: 2}, {title: 'Task B', goal_id: 'g-124'}]})"
-      masc_add_task_name
       masc_add_task_name;
     input_schema = `Assoc [
       ("type", `String "object");

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -551,7 +551,7 @@ type task_contract = {
   required_evidence : string list; [@default []]
   inspect_gate_evidence : string list; [@default []]
   verify_gate_evidence : string list; [@default []]
-} [@@deriving show, yojson { strict = true }]
+} [@@deriving show, yojson { strict = false }]
 
 (** Handoff context persisted across release/reclaim cycles *)
 type task_reclaim_policy =

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -532,7 +532,18 @@ type task_execution_links = {
   session_id : string option; [@default None]
 } [@@deriving show, yojson { strict = false }]
 
+(** No producer has been linked yet. A task starts here and stays here until a
+    runtime records the operation or session that carried it out. *)
+let no_execution_links = { operation_id = None; session_id = None }
+
 (** Task contract - persisted completion criteria and evidence facts.
+
+    Written once, when the task is created, and never rewritten: what counts as
+    done cannot change while the task runs. Execution identifiers live on the
+    task itself ([execution_links]) because they arrive afterwards — keeping
+    them here forced every link update to rewrite the contract, and a contract
+    that had to exist to be rewritten was manufactured with a placeholder
+    criterion.
 
     [completion_contract], [required_evidence], and [verify_gate_evidence] are
     supplied to the completion authority as task facts. The workspace FSM never
@@ -551,7 +562,6 @@ type task_contract = {
   required_evidence : string list; [@default []]
   inspect_gate_evidence : string list; [@default []]
   verify_gate_evidence : string list; [@default []]
-  links : task_execution_links; [@default { operation_id = None; session_id = None }]
 } [@@deriving show, yojson { strict = false }]
 
 (** Handoff context persisted across release/reclaim cycles *)
@@ -643,6 +653,10 @@ type task = {
      side registry). *)
   predecessor_task_id: string option; [@default None]
   contract: task_contract option; [@default None]
+  (* Runtime identifiers attached after the task is created, by whichever
+     execution picks it up. Separate from [contract] so linking them never
+     touches what counts as done. *)
+  execution_links: task_execution_links; [@default no_execution_links]
   handoff_context: task_handoff_context option; [@default None]
   cycle_count: int; [@default 0]
   reclaim_policy: task_reclaim_policy option; [@default None]
@@ -760,10 +774,19 @@ let task_to_yojson t =
     | Some contract ->
         with_predecessor @ [ ("contract", task_contract_to_yojson contract) ]
   in
-  let with_handoff_context = match t.handoff_context with
-    | None -> with_contract
-    | Some handoff_context ->
+  (* Omitted while unlinked, so a task carries the key only once an execution
+     claimed it. *)
+  let with_execution_links =
+    match t.execution_links with
+    | { operation_id = None; session_id = None } -> with_contract
+    | links ->
         with_contract
+        @ [ ("execution_links", task_execution_links_to_yojson links) ]
+  in
+  let with_handoff_context = match t.handoff_context with
+    | None -> with_execution_links
+    | Some handoff_context ->
+        with_execution_links
         @
         [ ( "handoff_context",
             task_handoff_context_to_yojson handoff_context ) ]
@@ -811,6 +834,13 @@ let task_of_yojson json =
            | Ok contract -> Some contract
            | Error _ -> None)
     in
+    let execution_links = match m "execution_links" with
+      | `Null -> no_execution_links
+      | links_json ->
+          (match task_execution_links_of_yojson links_json with
+           | Ok links -> links
+           | Error _ -> no_execution_links)
+    in
     let handoff_context = match m "handoff_context" with
       | `Null -> None
       | handoff_json ->
@@ -842,6 +872,7 @@ let task_of_yojson json =
             created_by;
             predecessor_task_id;
             contract;
+            execution_links;
             handoff_context;
             cycle_count;
             reclaim_policy;

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -530,7 +530,7 @@ let task_status_of_yojson json =
 type task_execution_links = {
   operation_id : string option; [@default None]
   session_id : string option; [@default None]
-} [@@deriving show, yojson { strict = false }]
+} [@@deriving show, yojson { strict = true }]
 
 (** No producer has been linked yet. A task starts here and stays here until a
     runtime records the operation or session that carried it out. *)
@@ -539,30 +539,19 @@ let no_execution_links = { operation_id = None; session_id = None }
 (** Task contract - persisted completion criteria and evidence facts.
 
     Written once, when the task is created, and never rewritten: what counts as
-    done cannot change while the task runs. Execution identifiers live on the
-    task itself ([execution_links]) because they arrive afterwards — keeping
-    them here forced every link update to rewrite the contract, and a contract
-    that had to exist to be rewritten was manufactured with a placeholder
-    criterion.
+    done cannot change while the task runs. Runtime evidence producers are
+    recorded independently on the task itself as [execution_links].
 
     [completion_contract], [required_evidence], and [verify_gate_evidence] are
     supplied to the completion authority as task facts. The workspace FSM never
-    interprets their prose, counts entries, or derives a completion verdict.
-
-    A [required_tools : string list] field was also removed (2026-06-03,
-    same fan-in-0 pattern): it was deprecated and ignored by task claim
-    routing, always normalized to [[]] by [Workspace_task_classify], had no
-    production reader, and the keeper turn layer rejects the [required_tools]
-    key outright (#19806, [Keeper_config_text]). Later cleanup removed the
-    same-named dashboard and tool-call benchmark fields too, so the string no
-    longer names any task, dashboard, or benchmark contract surface. *)
+    interprets their prose, counts entries, or derives a completion verdict. *)
 type task_contract = {
   strict : bool; [@default false]
   completion_contract : string list; [@default []]
   required_evidence : string list; [@default []]
   inspect_gate_evidence : string list; [@default []]
   verify_gate_evidence : string list; [@default []]
-} [@@deriving show, yojson { strict = false }]
+} [@@deriving show, yojson { strict = true }]
 
 (** Handoff context persisted across release/reclaim cycles *)
 type task_reclaim_policy =
@@ -764,7 +753,7 @@ let task_to_yojson t =
     | None -> base
     | Some created_by -> base @ [("created_by", `String created_by)]
   in
-  (* Omitted when None (created_by pattern): old readers never see the key. *)
+  (* Omitted when no predecessor exists. *)
   let with_predecessor = match t.predecessor_task_id with
     | None -> with_created_by
     | Some p -> with_created_by @ [("predecessor_task_id", `String p)]
@@ -791,7 +780,7 @@ let task_to_yojson t =
         [ ( "handoff_context",
             task_handoff_context_to_yojson handoff_context ) ]
   in
-  (* cycle_count omitted when 0 for backward-compat on existing backlogs. *)
+  (* A zero cycle count is the implicit initial state. *)
   let with_cycle_count =
     if t.cycle_count = 0 then with_handoff_context
     else with_handoff_context @ [("cycle_count", `Int t.cycle_count)]
@@ -815,6 +804,7 @@ let task_to_yojson t =
 let task_of_yojson json =
   let req key = Json_util.get_string_with_default json ~key ~default:"" in
   let opt key = Json_util.get_string json key in
+  let member key = Json_util.assoc_member_opt key json in
   let m key = Option.value ~default:`Null (Json_util.assoc_member_opt key json) in
   try
     let id = req "id" in
@@ -824,22 +814,18 @@ let task_of_yojson json =
     let files = Json_util.get_string_list json "files" in
     let created_at = req "created_at" in
     let created_by = opt "created_by" in
-    (* Absent or non-string value degrades to None — a decode Error here would
-       make backlog_of_yojson silently drop the whole task. *)
+    (* The predecessor link is optional. *)
     let predecessor_task_id = opt "predecessor_task_id" in
-    let contract = match m "contract" with
-      | `Null -> None
-      | contract_json ->
-          (match task_contract_of_yojson contract_json with
-           | Ok contract -> Some contract
-           | Error _ -> None)
+    let contract_result =
+      match member "contract" with
+      | None | Some `Null -> Ok None
+      | Some contract_json ->
+        Result.map Option.some (task_contract_of_yojson contract_json)
     in
-    let execution_links = match m "execution_links" with
-      | `Null -> no_execution_links
-      | links_json ->
-          (match task_execution_links_of_yojson links_json with
-           | Ok links -> links
-           | Error _ -> no_execution_links)
+    let execution_links_result =
+      match member "execution_links" with
+      | None -> Ok no_execution_links
+      | Some links_json -> task_execution_links_of_yojson links_json
     in
     let handoff_context = match m "handoff_context" with
       | `Null -> None
@@ -858,8 +844,8 @@ let task_of_yojson json =
            | Error _ -> None)
     in
     let do_not_reclaim_reason = opt "do_not_reclaim_reason" in
-    match task_status_of_yojson json with
-    | Ok task_status ->
+    match contract_result, execution_links_result, task_status_of_yojson json with
+    | Ok contract, Ok execution_links, Ok task_status ->
         Ok
           {
             id;
@@ -878,7 +864,9 @@ let task_of_yojson json =
             reclaim_policy;
             do_not_reclaim_reason;
           }
-    | Error e -> Error e
+    | Error error, _, _ -> Error ("task.contract corrupt: " ^ error)
+    | _, Error error, _ -> Error ("task.execution_links corrupt: " ^ error)
+    | _, _, Error error -> Error error
   with e -> Error (Printexc.to_string e)
 
 (** Message - broadcast or direct *)

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -165,7 +165,7 @@ type task_contract =
   ; inspect_gate_evidence : string list [@default []]
   ; verify_gate_evidence : string list [@default []]
   }
-[@@deriving show, yojson { strict = true }]
+[@@deriving show, yojson { strict = false }]
 
 type task_reclaim_policy =
   | Allow_reclaim

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -152,7 +152,7 @@ type task_execution_links =
   { operation_id : string option [@default None]
   ; session_id : string option [@default None]
   }
-[@@deriving show, yojson { strict = false }]
+[@@deriving show, yojson { strict = true }]
 
 (** No producer has been linked yet. A task starts here and stays here until a
     runtime records the operation or session that carried it out. *)
@@ -165,7 +165,7 @@ type task_contract =
   ; inspect_gate_evidence : string list [@default []]
   ; verify_gate_evidence : string list [@default []]
   }
-[@@deriving show, yojson { strict = false }]
+[@@deriving show, yojson { strict = true }]
 
 type task_reclaim_policy =
   | Allow_reclaim

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -154,14 +154,16 @@ type task_execution_links =
   }
 [@@deriving show, yojson { strict = false }]
 
+(** No producer has been linked yet. A task starts here and stays here until a
+    runtime records the operation or session that carried it out. *)
+val no_execution_links : task_execution_links
+
 type task_contract =
   { strict : bool [@default false]
   ; completion_contract : string list [@default []]
   ; required_evidence : string list [@default []]
   ; inspect_gate_evidence : string list [@default []]
   ; verify_gate_evidence : string list [@default []]
-  ; links : task_execution_links
-        [@default { operation_id = None; session_id = None }]
   }
 [@@deriving show, yojson { strict = false }]
 
@@ -216,6 +218,11 @@ type task =
         (** RFC-0323 W2: write-once lineage pointer to the terminal task this
             one re-runs. Set only at creation; transitions carry it through. *)
   ; contract : task_contract option [@default None]
+  ; execution_links : task_execution_links
+        [@default no_execution_links]
+        (** Runtime identifiers attached after creation by whichever execution
+            picks the task up. Separate from [contract] so linking them never
+            rewrites what counts as done. *)
   ; handoff_context : task_handoff_context option [@default None]
   ; cycle_count : int [@default 0]
   ; reclaim_policy : task_reclaim_policy option [@default None]

--- a/lib/workspace/workspace_task.ml
+++ b/lib/workspace/workspace_task.ml
@@ -306,29 +306,20 @@ let link_task_execution_artifacts_r
           (match List.find_opt (fun (task : task) -> task.id = task_id) backlog.tasks with
            | None -> Error (Masc_domain.Task (Masc_domain.Task_error.NotFound task_id))
            | Some task ->
-             let existing_contract =
-               ensure_task_contract_for_verification
-                 ?contract:task.contract
-                 ~title:task.title
-                 ~description:task.description
+             (* Only execution identity moves here. The contract is whatever the
+                task was created with, including absent. *)
+             let updated_links =
+               merge_execution_links
+                 task.execution_links
+                 ?session_id
+                 ?operation_id
                  ()
-             in
-             let updated_contract =
-               { existing_contract with
-                 links =
-                   merge_execution_links
-                     existing_contract.links
-                     ?session_id
-                     ?operation_id
-                     ()
-               }
-               |> normalize_task_contract
              in
              let new_tasks =
                List.map
                  (fun (candidate : task) ->
                     if candidate.id = task_id
-                    then { candidate with contract = Some updated_contract }
+                    then { candidate with execution_links = updated_links }
                     else candidate)
                  backlog.tasks
              in

--- a/lib/workspace/workspace_task_classify.ml
+++ b/lib/workspace/workspace_task_classify.ml
@@ -81,90 +81,24 @@ let same_task_actor _config left right =
   String.equal left right
 ;;
 
-let normalize_execution_links (links : Masc_domain.task_execution_links) =
-  { operation_id = trim_opt links.operation_id
-  ; session_id = trim_opt links.session_id
-  }
-;;
-
+(** Trim and drop blanks from a contract a caller stated. Shaping only — there
+    is deliberately no counterpart that produces a contract from a task that
+    lacks one. A criterion derived from the title ("Task scope satisfied:
+    <title>") answers "what counts as done" with "being done", so a verifier
+    reading it learns nothing and falls back to a standard of its own, which
+    the worker never sees. A task states its criteria or has none, and
+    [contract = None] says which. *)
 let normalize_task_contract (contract : Masc_domain.task_contract) =
   { contract with
     completion_contract = normalized_string_list contract.completion_contract
   ; required_evidence = normalized_string_list contract.required_evidence
   ; inspect_gate_evidence = normalized_string_list contract.inspect_gate_evidence
   ; verify_gate_evidence = normalized_string_list contract.verify_gate_evidence
-  ; links = normalize_execution_links contract.links
   }
 ;;
 
-let empty_task_contract =
-  { strict = false
-  ; completion_contract = []
-  ; required_evidence = []
-  ; inspect_gate_evidence = []
-  ; verify_gate_evidence = []
-  ; links = { operation_id = None; session_id = None }
-  }
-;;
-
-(* RFC-0311 Phase 1: the default verification contract declares no *specific*
-   descriptive evidence entries. The prior default
-   [ "completion_notes"; "reviewable_evidence_ref" ] could be satisfied only by
-   pasting those two literal tokens into the completion notes. That mechanism
-   simultaneously over-blocked unaware keepers and let a completion be faked by
-   copying labels. [required_evidence] now serves only as a fact supplied to the
-   completion authority; the workspace FSM does not interpret it. *)
-let default_verification_evidence_refs = []
-
-let first_line text =
-  match String.index_opt text '\n' with
-  | Some idx -> String.sub text 0 idx
-  | None -> text
-;;
-
-let truncate ~max_len text =
-  if String.length text <= max_len then text else String.sub text 0 max_len ^ "..."
-;;
-
-let default_completion_contract_text ~title ~description =
-  let title = String.trim title in
-  let description = description |> String.trim |> first_line in
-  if description = ""
-  then Printf.sprintf "Task scope satisfied: %s" title
-  else
-    truncate
-      ~max_len:220
-      (Printf.sprintf "Task scope satisfied: %s - %s" title description)
-;;
-
-let ensure_task_contract_for_verification ?contract ~title ~description () =
-  let base =
-    match contract with
-    | Some contract -> normalize_task_contract contract
-    | None -> empty_task_contract
-  in
-  let completion_contract =
-    if base.completion_contract <> []
-    then base.completion_contract
-    else [ default_completion_contract_text ~title ~description ]
-  in
-  let required_evidence =
-    if base.required_evidence <> []
-    then base.required_evidence
-    (* A verify-only task can describe verifier input separately. *)
-    else if base.verify_gate_evidence <> []
-    then []
-    else default_verification_evidence_refs
-  in
-  let verify_gate_evidence =
-    if base.verify_gate_evidence <> []
-    then base.verify_gate_evidence
-    else required_evidence
-  in
-  normalize_task_contract
-    { base with completion_contract; required_evidence; verify_gate_evidence }
-;;
-
+(** Record which runtime carried the task out. Later identifiers win; blanks do
+    not overwrite what is already recorded. *)
 let merge_execution_links
       (existing : Masc_domain.task_execution_links)
       ?session_id

--- a/lib/workspace/workspace_task_classify.mli
+++ b/lib/workspace/workspace_task_classify.mli
@@ -61,25 +61,12 @@ val working_agents : config -> string list
     actor identity; name-shape aliases have no ownership authority. *)
 val same_task_actor : config -> string -> string -> bool
 
-val normalize_execution_links
-  :  Masc_domain.task_execution_links
-  -> Masc_domain.task_execution_links
-
 val normalize_task_contract : Masc_domain.task_contract -> Masc_domain.task_contract
-val empty_task_contract : Masc_domain.task_contract
 
-val default_verification_evidence_refs : string list
-val first_line : string -> string
-val truncate : max_len:int -> string -> string
-val default_completion_contract_text : title:string -> description:string -> string
-
-val ensure_task_contract_for_verification
-  :  ?contract:Masc_domain.task_contract
-  -> title:string
-  -> description:string
-  -> unit
-  -> Masc_domain.task_contract
-
+(** [merge_execution_links existing ?session_id ?operation_id ()] keeps the
+    identifiers already linked and adds the ones supplied. It touches only
+    execution identity — completion criteria are written when the task is
+    created and are not derived, defaulted, or rewritten anywhere. *)
 val merge_execution_links
   :  Masc_domain.task_execution_links
   -> ?session_id:string

--- a/lib/workspace/workspace_task_create.ml
+++ b/lib/workspace/workspace_task_create.ml
@@ -146,12 +146,7 @@ let add_task_with_result
              Printf.sprintf "task-%03d" (next_task_number config backlog)
            in
            let contract =
-             Some
-               (Workspace_task_classify.ensure_task_contract_for_verification
-                  ?contract
-                  ~title
-                  ~description
-                  ())
+             Option.map Workspace_task_classify.normalize_task_contract contract
            in
            let new_task =
              { id = task_id
@@ -167,6 +162,7 @@ let add_task_with_result
              ; handoff_context = None
              ; cycle_count = 0
              ; reclaim_policy = None
+             ; execution_links = Masc_domain.no_execution_links
              ; do_not_reclaim_reason = None
              }
            in
@@ -266,12 +262,9 @@ let batch_add_tasks_internal_with_result ?created_by config tasks =
                 let task_id = Printf.sprintf "task-%03d" !next_num in
                 incr next_num;
                 let contract =
-                  Some
-                    (Workspace_task_classify.ensure_task_contract_for_verification
-                       ?contract
-                       ~title
-                       ~description
-                       ())
+                  Option.map
+                    Workspace_task_classify.normalize_task_contract
+                    contract
                 in
                 let task =
                   { id = task_id
@@ -289,6 +282,7 @@ let batch_add_tasks_internal_with_result ?created_by config tasks =
                   ; handoff_context = None
                   ; cycle_count = 0
                   ; reclaim_policy = None
+                  ; execution_links = Masc_domain.no_execution_links
                   ; do_not_reclaim_reason = None
                   }
                 in

--- a/test/test_dashboard_goal_id_projection.ml
+++ b/test/test_dashboard_goal_id_projection.ml
@@ -25,6 +25,7 @@ let make_task ~id =
   ; handoff_context = None
   ; cycle_count = 0
   ; reclaim_policy = None
+  ; execution_links = Masc_domain.no_execution_links
   ; do_not_reclaim_reason = None
   }
 ;;

--- a/test/test_dashboard_recent_terminal_tasks.ml
+++ b/test/test_dashboard_recent_terminal_tasks.ml
@@ -43,6 +43,7 @@ let task ~id ~status =
   ; handoff_context = None
   ; cycle_count = 0
   ; reclaim_policy = None
+  ; execution_links = Masc_domain.no_execution_links
   ; do_not_reclaim_reason = None
   }
 ;;

--- a/test/test_goal_metric_unevaluated.ml
+++ b/test/test_goal_metric_unevaluated.ml
@@ -58,6 +58,7 @@ let make_done_task id : MD.task =
     handoff_context = None;
     cycle_count = 0;
     reclaim_policy = None;
+    execution_links = Masc_domain.no_execution_links;
     do_not_reclaim_reason = None;
   }
 

--- a/test/test_keeper_catchup_digest.ml
+++ b/test/test_keeper_catchup_digest.ml
@@ -123,6 +123,7 @@ let task ?handoff_context ~id ~title ~status () : Masc_domain.task =
   ; handoff_context
   ; cycle_count = 0
   ; reclaim_policy = None
+  ; execution_links = Masc_domain.no_execution_links
   ; do_not_reclaim_reason = None
   }
 ;;

--- a/test/test_keeper_keepalive_helpers.ml
+++ b/test/test_keeper_keepalive_helpers.ml
@@ -66,6 +66,7 @@ let make_in_progress_task ~id ~assignee : Types.task =
     handoff_context = None;
     cycle_count = 0;
     reclaim_policy = None;
+    execution_links = Masc_domain.no_execution_links;
     do_not_reclaim_reason = None;
   }
 

--- a/test/test_keeper_self_authored_task_exclusion.ml
+++ b/test/test_keeper_self_authored_task_exclusion.ml
@@ -38,6 +38,7 @@ let task ?created_by ?(task_status = Masc_domain.Todo) id : Masc_domain.task =
   ; handoff_context = None
   ; cycle_count = 0
   ; reclaim_policy = None
+  ; execution_links = Masc_domain.no_execution_links
   ; do_not_reclaim_reason = None
   }
 ;;

--- a/test/test_keeper_task_cancellation_wake.ml
+++ b/test/test_keeper_task_cancellation_wake.ml
@@ -73,6 +73,7 @@ let seed_task ?handoff_context config ~task_id ~created_by ~status =
     ; handoff_context
     ; cycle_count = 0
     ; reclaim_policy = None
+    ; execution_links = Masc_domain.no_execution_links
     ; do_not_reclaim_reason = None
     }
   in

--- a/test/test_keeper_task_outcomes.ml
+++ b/test/test_keeper_task_outcomes.ml
@@ -343,7 +343,6 @@ let strict_contract : Masc_domain.task_contract =
   ; required_evidence = []
   ; inspect_gate_evidence = []
   ; verify_gate_evidence = []
-  ; links = { operation_id = None; session_id = None }
   }
 
 let test_strict_done_submits_for_verification () =

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -205,6 +205,7 @@ let make_task ?(handoff_context = None) ~task_status () : Masc_domain.task =
     handoff_context;
     cycle_count = 0;
     reclaim_policy = None;
+    execution_links = Masc_domain.no_execution_links;
     do_not_reclaim_reason = None;
   }
 

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -56,11 +56,6 @@ let empty_contract : Masc_domain.task_contract =
     required_evidence = [];
     inspect_gate_evidence = [];
     verify_gate_evidence = [];
-    links =
-      {
-        operation_id = None;
-        session_id = None;
-      };
   }
 
 let extract_json_from_text text =

--- a/test/test_orphan_surfacer.ml
+++ b/test/test_orphan_surfacer.ml
@@ -27,6 +27,7 @@ let make_task ~id ~status : MD.task =
   ; handoff_context = None
   ; cycle_count = 0
   ; reclaim_policy = None
+  ; execution_links = Masc_domain.no_execution_links
   ; do_not_reclaim_reason = None
   }
 

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1204,6 +1204,7 @@ let make_task ?(title = "Task") ?(description = "") ~id ~status () : Types.task 
     handoff_context = None;
     cycle_count = 0;
     reclaim_policy = None;
+    execution_links = Masc_domain.no_execution_links;
     do_not_reclaim_reason = None;
   }
 

--- a/test/test_task_cache_invariant_13397.ml
+++ b/test/test_task_cache_invariant_13397.ml
@@ -95,6 +95,7 @@ let make_task ~id ~status =
   ; handoff_context = None
   ; cycle_count = 0
   ; reclaim_policy = None
+  ; execution_links = Masc_domain.no_execution_links
   ; do_not_reclaim_reason = None
   }
 

--- a/test/test_task_transition_broadcast.ml
+++ b/test/test_task_transition_broadcast.ml
@@ -62,6 +62,7 @@ let make_task ~id ~status : D.task =
   ; handoff_context = None
   ; cycle_count = 0
   ; reclaim_policy = None
+  ; execution_links = Masc_domain.no_execution_links
   ; do_not_reclaim_reason = None
   }
 ;;

--- a/test/test_tool_task_args.ml
+++ b/test/test_tool_task_args.ml
@@ -41,13 +41,21 @@ let test_object_contract () =
       fail
         (Printf.sprintf "object contract must be Ok (Some _), got Error %s" e)
 
-(* A present-but-non-object contract is the ONLY Error case. The catch-all must
-   not swallow this into a silent default; the canonical parser additionally
-   names the received JSON kind in its message. *)
+(* A present-but-non-object contract is an Error. The catch-all must not swallow
+   this into a silent default; the canonical parser additionally names the
+   received JSON kind in its message. *)
 let test_wrong_type_contract () =
   match T.parse_task_contract (`Assoc [ ("contract", `String "nope") ]) with
   | Error _ -> ()
   | Ok _ -> fail "non-object contract must be Error, not Ok"
+
+let test_unknown_contract_field_is_rejected () =
+  match
+    T.parse_task_contract
+      (`Assoc [ "contract", `Assoc [ "links", `Assoc [] ] ])
+  with
+  | Error _ -> ()
+  | Ok _ -> fail "unknown contract field must be Error, not silently dropped"
 
 let () =
   run "Task.Args"
@@ -56,5 +64,7 @@ let () =
         ; test_case "explicit null -> Ok None" `Quick test_explicit_null_contract
         ; test_case "object -> Ok (Some _)" `Quick test_object_contract
         ; test_case "wrong type -> Error" `Quick test_wrong_type_contract
+        ; test_case "unknown field -> Error" `Quick
+            test_unknown_contract_field_is_rejected
         ] )
     ]

--- a/test/test_tool_task_args.ml
+++ b/test/test_tool_task_args.ml
@@ -49,13 +49,25 @@ let test_wrong_type_contract () =
   | Error _ -> ()
   | Ok _ -> fail "non-object contract must be Error, not Ok"
 
-let test_unknown_contract_field_is_rejected () =
+(* [links] is the field this change removes from the contract, and main writes
+   it on every task a keeper executes (keeper_agent_run_phase5_task_link.ml:27).
+   The decoder must read past it: it also decodes the persisted backlog, where
+   one rejected task fails the whole file (workspace_backlog.ml:17) and stops
+   every keeper's claim and transition. A field we deleted is not corruption.
+
+   Wrong types stay Error — see [test_wrong_type_contract]. That is the split:
+   unknown key ignored, malformed value rejected. *)
+let test_removed_contract_field_still_decodes () =
   match
     T.parse_task_contract
       (`Assoc [ "contract", `Assoc [ "links", `Assoc [] ] ])
   with
-  | Error _ -> ()
-  | Ok _ -> fail "unknown contract field must be Error, not silently dropped"
+  | Ok _ -> ()
+  | Error detail ->
+    fail
+      (Printf.sprintf
+         "a contract carrying the removed [links] key must still decode: %s"
+         detail)
 
 let () =
   run "Task.Args"
@@ -64,7 +76,7 @@ let () =
         ; test_case "explicit null -> Ok None" `Quick test_explicit_null_contract
         ; test_case "object -> Ok (Some _)" `Quick test_object_contract
         ; test_case "wrong type -> Error" `Quick test_wrong_type_contract
-        ; test_case "unknown field -> Error" `Quick
-            test_unknown_contract_field_is_rejected
+        ; test_case "removed field still decodes" `Quick
+            test_removed_contract_field_still_decodes
         ] )
     ]

--- a/test/test_tool_task_args.ml
+++ b/test/test_tool_task_args.ml
@@ -49,25 +49,53 @@ let test_wrong_type_contract () =
   | Error _ -> ()
   | Ok _ -> fail "non-object contract must be Error, not Ok"
 
-(* [links] is the field this change removes from the contract, and main writes
-   it on every task a keeper executes (keeper_agent_run_phase5_task_link.ml:27).
-   The decoder must read past it: it also decodes the persisted backlog, where
-   one rejected task fails the whole file (workspace_backlog.ml:17) and stops
-   every keeper's claim and transition. A field we deleted is not corruption.
-
-   Wrong types stay Error — see [test_wrong_type_contract]. That is the split:
-   unknown key ignored, malformed value rejected. *)
-let test_removed_contract_field_still_decodes () =
+let test_public_contract_rejects_removed_field () =
   match
     T.parse_task_contract
       (`Assoc [ "contract", `Assoc [ "links", `Assoc [] ] ])
   with
+  | Error _ -> ()
+  | Ok _ -> fail "public contract input must reject the removed [links] field"
+
+let test_persisted_contract_accepts_removed_field () =
+  match Masc_domain.task_contract_of_yojson (`Assoc [ "links", `Assoc [] ]) with
   | Ok _ -> ()
   | Error detail ->
     fail
       (Printf.sprintf
-         "a contract carrying the removed [links] key must still decode: %s"
+         "persisted contract carrying removed [links] must still decode: %s"
          detail)
+
+let test_public_contract_rejects_duplicate_field () =
+  match
+    T.parse_task_contract
+      (`Assoc
+        [ ( "contract"
+          , `Assoc [ "strict", `Bool true; "strict", `Bool false ] )
+        ])
+  with
+  | Error _ -> ()
+  | Ok _ -> fail "public contract input must reject duplicate fields"
+
+let test_current_contract_shape_decodes () =
+  match
+    T.parse_task_contract
+      (`Assoc
+        [ ( "contract"
+          , `Assoc
+              [ "strict", `Bool true
+              ; "completion_contract", `List [ `String "done" ]
+              ; "required_evidence", `List [ `String "test" ]
+              ; "inspect_gate_evidence", `List [ `String "review" ]
+              ; "verify_gate_evidence", `List [ `String "ci" ]
+              ] )
+        ])
+  with
+  | Ok (Some contract) ->
+    check bool "strict" true contract.strict;
+    check (list string) "completion contract" [ "done" ] contract.completion_contract
+  | Ok None -> fail "current contract object must decode to Some"
+  | Error detail -> fail (Printf.sprintf "current contract must decode: %s" detail)
 
 let () =
   run "Task.Args"
@@ -76,7 +104,13 @@ let () =
         ; test_case "explicit null -> Ok None" `Quick test_explicit_null_contract
         ; test_case "object -> Ok (Some _)" `Quick test_object_contract
         ; test_case "wrong type -> Error" `Quick test_wrong_type_contract
-        ; test_case "removed field still decodes" `Quick
-            test_removed_contract_field_still_decodes
+        ; test_case "public removed field -> Error" `Quick
+            test_public_contract_rejects_removed_field
+        ; test_case "persisted removed field still decodes" `Quick
+            test_persisted_contract_accepts_removed_field
+        ; test_case "public duplicate field -> Error" `Quick
+            test_public_contract_rejects_duplicate_field
+        ; test_case "current contract shape -> Ok" `Quick
+            test_current_contract_shape_decodes
         ] )
     ]

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -202,7 +202,6 @@ let make_task_contract ?(strict = false) ?(completion_contract = [])
     required_evidence;
     inspect_gate_evidence;
     verify_gate_evidence;
-    links = { operation_id = None; session_id = None };
   }
 
 let add_priority_task ctx ~title =
@@ -650,13 +649,17 @@ let () = test "handle_add_task_persists_contract" (fun () ->
   | _ -> failwith "expected exactly one task"
 )
 
-let () = test "handle_add_task_injects_default_verification_contract" (fun () ->
+(* A caller who states no completion criteria gets a task that says so. The
+   handler used to fill the gap with "Task scope satisfied: <title>", which
+   read as stated criteria to everything downstream while telling a verifier
+   nothing. *)
+let () = test "handle_add_task_omits_contract_when_unstated" (fun () ->
   let ctx = make_test_ctx () in
   let result =
     Task.Tool.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc
         [
-          ("title", `String "Default verification task");
+          ("title", `String "Unstated criteria task");
           ("description", `String "Need verifier-visible evidence.");
         ])
   in
@@ -664,21 +667,16 @@ let () = test "handle_add_task_injects_default_verification_contract" (fun () ->
   match Workspace.get_tasks_raw ctx.config with
   | [ task ] -> (
       match task.contract with
+      | None -> ()
       | Some contract ->
-          assert (not contract.strict);
-          assert (contract.completion_contract <> []);
-          (* The default contract carries task facts, not magic-token evidence
-             requirements. The LLM reviewer judges the completion claim in
-             context; this layer does not search for required substrings. *)
-          assert (contract.required_evidence = []);
-          assert (contract.verify_gate_evidence = []);
-          assert (str_contains (List.hd contract.completion_contract)
-                    "Default verification task")
-      | None -> failwith "expected default verification contract")
+          failwith
+            (Printf.sprintf
+               "expected no contract, got completion_contract=[%s]"
+               (String.concat "; " contract.completion_contract)))
   | _ -> failwith "expected exactly one task"
 )
 
-let () = test "handle_batch_add_tasks_injects_default_verification_contracts" (fun () ->
+let () = test "handle_batch_add_tasks_omits_contract_when_unstated" (fun () ->
   let ctx = make_test_ctx () in
   let result =
     Task.Tool.handle_batch_add_tasks ~tool_name:"test_tool" ~start_time:0.0 ctx
@@ -698,14 +696,13 @@ let () = test "handle_batch_add_tasks_injects_default_verification_contracts" (f
   List.iter
     (fun (task : Masc_domain.task) ->
        match task.contract with
+       | None -> ()
        | Some contract ->
-           (* Default verification contract is injected (completion_contract
-              present); RFC-0311 §8: it no longer carries magic-token
-              required/verify evidence. *)
-           assert (contract.completion_contract <> []);
-           assert (contract.required_evidence = []);
-           assert (contract.verify_gate_evidence = [])
-       | None -> failwith "expected default verification contract for batch task")
+           failwith
+             (Printf.sprintf
+                "expected no contract for %s, got completion_contract=[%s]"
+                task.id
+                (String.concat "; " contract.completion_contract)))
     tasks
 )
 

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -2606,6 +2606,59 @@ let () = test "handle_batch_add_tasks_rejects_unknown_item_fields" (fun () ->
        "Unknown argument(s): retired_tool_policy_field")
 )
 
+let () = test "handle_batch_add_tasks_rejects_removed_contract_field" (fun () ->
+  let ctx = make_test_ctx () in
+  let args =
+    `Assoc
+      [ ( "tasks"
+        , `List
+            [ `Assoc
+                [ "title", `String "Task 1"
+                ; "contract", `Assoc [ "links", `Assoc [] ]
+                ]
+            ] )
+      ]
+  in
+  let result =
+    Task.Tool.handle_batch_add_tasks
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      ctx
+      args
+  in
+  assert (not (Tool_result.is_success result));
+  assert
+    (str_contains
+       (Tool_result.message result)
+       "contract contains unsupported field links"))
+
+let () = test "handle_batch_add_tasks_rejects_duplicate_contract_field" (fun () ->
+  let ctx = make_test_ctx () in
+  let args =
+    `Assoc
+      [ ( "tasks"
+        , `List
+            [ `Assoc
+                [ "title", `String "Task 1"
+                ; ( "contract"
+                  , `Assoc [ "strict", `Bool true; "strict", `Bool false ] )
+                ]
+            ] )
+      ]
+  in
+  let result =
+    Task.Tool.handle_batch_add_tasks
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      ctx
+      args
+  in
+  assert (not (Tool_result.is_success result));
+  assert
+    (str_contains
+       (Tool_result.message result)
+       "contract contains duplicate field strict"))
+
 (* Test helper functions *)
 let () = test "get_string_present" (fun () ->
   let args = `Assoc [("key", `String "value")] in

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -352,6 +352,13 @@ let test_masc_add_task_schema () =
                 Alcotest.(check bool) "goal_id does not label omitted links orphaned" false
                   (contains_substring ~needle:"orphaned" description)
             | None -> Alcotest.fail "masc_add_task missing goal_id property")
+          ; (match List.assoc_opt "contract" props with
+             | Some contract_schema ->
+               Alcotest.(check (option bool))
+                 "contract rejects additional properties"
+                 (Some false)
+                 (get_json_bool "additionalProperties" contract_schema)
+             | None -> Alcotest.fail "masc_add_task missing contract property")
        | None -> Alcotest.fail "masc_add_task missing properties");
       (match get_json_list "required" schema.input_schema with
        | Some reqs ->
@@ -376,7 +383,18 @@ let test_masc_batch_add_tasks_schema () =
                           Alcotest.(check bool) "item has title" true
                             (List.mem_assoc "title" item_props);
                           Alcotest.(check bool) "item has goal_id" true
-                            (List.mem_assoc "goal_id" item_props)
+                            (List.mem_assoc "goal_id" item_props);
+                          (match List.assoc_opt "contract" item_props with
+                           | Some contract_schema ->
+                             Alcotest.(check (option bool))
+                               "item contract rejects additional properties"
+                               (Some false)
+                               (get_json_bool
+                                  "additionalProperties"
+                                  contract_schema)
+                           | None ->
+                             Alcotest.fail
+                               "masc_batch_add_tasks item missing contract")
                       | _ -> Alcotest.fail "masc_batch_add_tasks item missing properties");
                      (match List.assoc_opt "required" item_fields with
                       | Some (`List item_reqs) ->

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -605,7 +605,7 @@ let test_backlog_to_yojson_with_tasks () =
     created_at = "2024-01-15T12:00:00Z";
     created_by = None;
     predecessor_task_id = None;
-    contract = None; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None;
+    contract = None; execution_links = Masc_domain.no_execution_links; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None;
   } in
   let b : Masc_domain.backlog = { tasks = [task]; last_updated = "2024-01-15T12:00:00Z"; version = 2 } in
   let json = Masc_domain.backlog_to_yojson b in
@@ -1361,7 +1361,7 @@ let test_task_to_yojson () =
     created_at = "2024-01-15T12:00:00Z";
     created_by = None;
     predecessor_task_id = None;
-    contract = None; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None;
+    contract = None; execution_links = Masc_domain.no_execution_links; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None;
   } in
   let json = Masc_domain.task_to_yojson t in
   match json with
@@ -1409,6 +1409,7 @@ let test_task_reclaim_gate_ignores_free_text_without_policy () =
     handoff_context = None;
     cycle_count = 9;
     reclaim_policy = None;
+    execution_links = Masc_domain.no_execution_links;
     do_not_reclaim_reason = Some "worktree path not found";
   } in
   match Masc_domain.task_claim_decision t with
@@ -1434,6 +1435,7 @@ let test_task_reclaim_gate_blocks_only_typed_policy () =
     handoff_context = None;
     cycle_count = 0;
     reclaim_policy = Some Masc_domain.Block_reclaim;
+    execution_links = Masc_domain.no_execution_links;
     do_not_reclaim_reason = Some "operator hard stop";
   } in
   match Masc_domain.task_claim_decision t with
@@ -1464,6 +1466,7 @@ let test_task_claim_awaiting_verification_is_pending_verdict () =
     handoff_context = None;
     cycle_count = 0;
     reclaim_policy = None;
+    execution_links = Masc_domain.no_execution_links;
     do_not_reclaim_reason = None;
   } in
   (match Masc_domain.task_claim_decision t with
@@ -1512,6 +1515,7 @@ let test_task_claim_next_action_todo_policy_block_still_claims () =
     handoff_context = None;
     cycle_count = 0;
     reclaim_policy = Some Masc_domain.Block_reclaim;
+    execution_links = Masc_domain.no_execution_links;
     do_not_reclaim_reason = Some "operator hard stop";
   } in
   match Masc_domain.task_claim_next_action t with

--- a/test/test_types_utils_coverage.ml
+++ b/test/test_types_utils_coverage.ml
@@ -388,7 +388,7 @@ let test_task_roundtrip () =
     created_at = "2024-01-01T00:00:00Z";
     created_by = None;
     predecessor_task_id = None;
-    contract = None; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None;
+    contract = None; execution_links = Masc_domain.no_execution_links; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None;
   } in
   let json = Masc_domain.task_to_yojson task in
   let result = Masc_domain.task_of_yojson json in
@@ -406,13 +406,13 @@ let test_backlog_roundtrip () =
         created_at = "2024-01-01T00:00:00Z";
         created_by = None;
         predecessor_task_id = None;
-        contract = None; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None };
+        contract = None; execution_links = Masc_domain.no_execution_links; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None };
       { id = "t2"; title = "Task 2"; description = "Desc 2";
         task_status = Done { assignee = "a"; completed_at = "2024-01-02T00:00:00Z"; notes = None };
         priority = 2; files = []; created_at = "2024-01-01T01:00:00Z";
         created_by = None;
         predecessor_task_id = None;
-        contract = None; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None };
+        contract = None; execution_links = Masc_domain.no_execution_links; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None };
     ];
     last_updated = "2024-01-02T00:00:00Z";
     version = 5;

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -910,7 +910,6 @@ let test_system_llm_agent_uses_persisted_request_contract_snapshot () =
             ; required_evidence = [ "persisted required artifact" ]
             ; inspect_gate_evidence = []
             ; verify_gate_evidence = [ "persisted gate artifact" ]
-            ; links = { operation_id = None; session_id = None }
             }
           in
           let config = W.default_config base_path in

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -1482,7 +1482,6 @@ let strict_contract : Masc_domain.task_contract =
     required_evidence = [ "artifact:deliverable" ]
   ; inspect_gate_evidence = []
   ; verify_gate_evidence = []
-  ; links = { operation_id = None; session_id = None }
   }
 
 let test_strict_task_done_requires_verification_submission () =

--- a/test/test_workspace_coverage.ml
+++ b/test/test_workspace_coverage.ml
@@ -2864,8 +2864,81 @@ let test_execution_links_codec_omits_empty () =
   | Error e -> Alcotest.fail ("decode with key failed: " ^ e)
 ;;
 
+let set_json_member key value = function
+  | `Assoc fields -> `Assoc ((key, value) :: List.remove_assoc key fields)
+  | other -> other
+;;
+
+let test_task_codec_rejects_unknown_contract_fields () =
+  let task =
+    gc_make_task ~id:"task-l2" ~created_at:gc_ancient_ts ~status:Masc_domain.Todo
+  in
+  let legacy_contract =
+    `Assoc
+      [ ( "links"
+        , `Assoc
+            [ "operation_id", `String "op-old"
+            ; "session_id", `String "session-old"
+            ] )
+      ]
+  in
+  let json =
+    Masc_domain.task_to_yojson task
+    |> set_json_member "contract" legacy_contract
+  in
+  (match Masc_domain.task_of_yojson json with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "unknown task.contract field was silently dropped");
+  let backlog_json =
+    `Assoc
+      [ "tasks", `List [ json ]
+      ; "last_updated", `String "2026-08-05T00:00:00Z"
+      ; "version", `Int 1
+      ]
+  in
+  match Masc_domain.backlog_of_yojson backlog_json with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "corrupt task.contract was accepted by backlog decoder"
+;;
+
+let test_task_codec_rejects_malformed_execution_links () =
+  let task =
+    gc_make_task ~id:"task-l3" ~created_at:gc_ancient_ts ~status:Masc_domain.Todo
+  in
+  let base = Masc_domain.task_to_yojson task in
+  (match
+     base
+     |> set_json_member "execution_links" (`Assoc [])
+     |> Masc_domain.task_of_yojson
+   with
+   | Ok decoded ->
+     Alcotest.(check bool)
+       "empty execution links stay unlinked"
+       true
+       (decoded.execution_links = Masc_domain.no_execution_links)
+   | Error error ->
+     Alcotest.failf "empty execution_links must remain valid: %s" error);
+  List.iter
+    (fun malformed ->
+       match
+         base
+         |> set_json_member "execution_links" malformed
+         |> Masc_domain.task_of_yojson
+       with
+       | Error _ -> ()
+       | Ok _ ->
+         Alcotest.failf
+           "malformed execution_links was silently defaulted: %s"
+           (Yojson.Safe.to_string malformed))
+    [ `Null
+    ; `String "op-1"
+    ; `Assoc [ "operation_id", `Int 7 ]
+    ; `Assoc [ "unknown", `String "value" ]
+    ]
+;;
+
 let test_predecessor_codec_absent_and_malformed () =
-  (* Encoder omits the key when None (old readers never see it). *)
+  (* Encoder omits the key when no predecessor exists. *)
   let without =
     gc_make_task ~id:"task-c1" ~created_at:gc_ancient_ts ~status:Masc_domain.Todo
   in
@@ -2875,7 +2948,7 @@ let test_predecessor_codec_absent_and_malformed () =
     "key omitted when None"
     false
     (List.mem "predecessor_task_id" keys);
-  (* Absent key decodes to None (pre-W2 backlogs parse unchanged). *)
+  (* Absent key decodes to None. *)
   (match Masc_domain.task_of_yojson json with
    | Ok t ->
      Alcotest.(check (option string)) "absent -> None" None t.predecessor_task_id
@@ -2889,8 +2962,7 @@ let test_predecessor_codec_absent_and_malformed () =
        (Some "task-000")
        t.predecessor_task_id
    | Error e -> Alcotest.fail ("round-trip decode failed: " ^ e));
-  (* Malformed value degrades to None instead of erroring — a decode Error
-     would make backlog_of_yojson silently drop the whole task. *)
+  (* A non-string value does not define a predecessor edge. *)
   let malformed =
     match json with
     | `Assoc kvs -> `Assoc (kvs @ [ "predecessor_task_id", `Int 7 ])
@@ -3213,6 +3285,14 @@ let () =
             "execution_links codec omits the empty value"
             `Quick
             test_execution_links_codec_omits_empty
+        ; Alcotest.test_case
+            "unknown contract fields are rejected"
+            `Quick
+            test_task_codec_rejects_unknown_contract_fields
+        ; Alcotest.test_case
+            "malformed execution links are rejected"
+            `Quick
+            test_task_codec_rejects_malformed_execution_links
         ] )
     ]
 ;;

--- a/test/test_workspace_coverage.ml
+++ b/test/test_workspace_coverage.ml
@@ -2869,7 +2869,7 @@ let set_json_member key value = function
   | other -> other
 ;;
 
-let test_task_codec_rejects_unknown_contract_fields () =
+let test_task_codec_accepts_removed_contract_fields () =
   let task =
     gc_make_task ~id:"task-l2" ~created_at:gc_ancient_ts ~status:Masc_domain.Todo
   in
@@ -2887,8 +2887,9 @@ let test_task_codec_rejects_unknown_contract_fields () =
     |> set_json_member "contract" legacy_contract
   in
   (match Masc_domain.task_of_yojson json with
-   | Error _ -> ()
-   | Ok _ -> Alcotest.fail "unknown task.contract field was silently dropped");
+   | Ok _ -> ()
+   | Error error ->
+     Alcotest.failf "persisted removed task.contract field was rejected: %s" error);
   let backlog_json =
     `Assoc
       [ "tasks", `List [ json ]
@@ -2897,8 +2898,9 @@ let test_task_codec_rejects_unknown_contract_fields () =
       ]
   in
   match Masc_domain.backlog_of_yojson backlog_json with
-  | Error _ -> ()
-  | Ok _ -> Alcotest.fail "corrupt task.contract was accepted by backlog decoder"
+  | Ok _ -> ()
+  | Error error ->
+    Alcotest.failf "backlog with removed task.contract field was rejected: %s" error
 ;;
 
 let test_task_codec_rejects_malformed_execution_links () =
@@ -3286,9 +3288,9 @@ let () =
             `Quick
             test_execution_links_codec_omits_empty
         ; Alcotest.test_case
-            "unknown contract fields are rejected"
+            "removed contract fields remain readable"
             `Quick
-            test_task_codec_rejects_unknown_contract_fields
+            test_task_codec_accepts_removed_contract_fields
         ; Alcotest.test_case
             "malformed execution links are rejected"
             `Quick

--- a/test/test_workspace_coverage.ml
+++ b/test/test_workspace_coverage.ml
@@ -2341,6 +2341,7 @@ let gc_make_task ~id ~created_at ~status : Masc_domain.task =
   ; handoff_context = None
   ; cycle_count = 0
   ; reclaim_policy = None
+  ; execution_links = Masc_domain.no_execution_links
   ; do_not_reclaim_reason = None
   }
 ;;
@@ -2585,6 +2586,7 @@ let test_append_archive_tasks () =
       ; handoff_context = None
       ; cycle_count = 0
       ; reclaim_policy = None
+      ; execution_links = Masc_domain.no_execution_links
       ; do_not_reclaim_reason = None
       }
     in
@@ -2712,6 +2714,154 @@ let test_predecessor_blank_treated_as_none () =
     | Error e ->
       Alcotest.fail
         ("blank predecessor rejected: " ^ Workspace.add_task_error_to_string e))
+;;
+
+(* ============================================================ *)
+(* Contract vs. execution links — one concept, one field         *)
+(* ============================================================ *)
+
+let task_of config task_id =
+  match
+    List.find_opt
+      (fun (t : Masc_domain.task) -> String.equal t.id task_id)
+      (Workspace.read_backlog config).tasks
+  with
+  | Some t -> t
+  | None -> Alcotest.fail (Printf.sprintf "%s missing from backlog" task_id)
+;;
+
+let test_task_without_contract_keeps_none () =
+  with_test_env (fun config ->
+    match
+      Workspace.add_task_with_result
+        config
+        ~title:"Unstated criteria"
+        ~priority:2
+        ~description:"body text a title-derived criterion would have swallowed"
+    with
+    | Error e -> Alcotest.fail ("add_task rejected: " ^ Workspace.add_task_error_to_string e)
+    | Ok created ->
+      let task = task_of config created.task_id in
+      Alcotest.(check bool)
+        "creation states no criteria rather than inventing them"
+        true
+        (task.contract = None))
+;;
+
+let test_link_execution_artifacts_leaves_contract_alone () =
+  with_test_env (fun config ->
+    let stated : Masc_domain.task_contract =
+      { strict = false
+      ; completion_contract = [ "dashboard renders the linked run" ]
+      ; required_evidence = [ "artifact:run.log" ]
+      ; inspect_gate_evidence = []
+      ; verify_gate_evidence = [ "artifact:run.log" ]
+      }
+    in
+    match
+      Workspace.add_task_with_result
+        config
+        ~contract:stated
+        ~title:"Stated criteria"
+        ~priority:2
+        ~description:""
+    with
+    | Error e -> Alcotest.fail ("add_task rejected: " ^ Workspace.add_task_error_to_string e)
+    | Ok created ->
+      (match
+         Workspace.link_task_execution_artifacts_r
+           config
+           ~task_id:created.task_id
+           ~session_id:"session-alpha"
+           ~operation_id:"op-beta"
+           ()
+       with
+       | Error err ->
+         Alcotest.failf "link failed: %s" (Masc_domain.show_masc_error err)
+       | Ok _ -> ());
+      let task = task_of config created.task_id in
+      Alcotest.(check (option string))
+        "session id lands on the task"
+        (Some "session-alpha")
+        task.execution_links.session_id;
+      Alcotest.(check (option string))
+        "operation id lands on the task"
+        (Some "op-beta")
+        task.execution_links.operation_id;
+      Alcotest.(check (list string))
+        "linking did not rewrite the stated criteria"
+        stated.completion_contract
+        (match task.contract with
+         | Some c -> c.completion_contract
+         | None -> Alcotest.fail "linking dropped the stated contract"))
+;;
+
+let test_link_execution_artifacts_does_not_create_a_contract () =
+  with_test_env (fun config ->
+    match
+      Workspace.add_task_with_result
+        config
+        ~title:"Unstated criteria, later linked"
+        ~priority:2
+        ~description:""
+    with
+    | Error e -> Alcotest.fail ("add_task rejected: " ^ Workspace.add_task_error_to_string e)
+    | Ok created ->
+      (match
+         Workspace.link_task_execution_artifacts_r
+           config
+           ~task_id:created.task_id
+           ~session_id:"session-gamma"
+           ()
+       with
+       | Error err ->
+         Alcotest.failf "link failed: %s" (Masc_domain.show_masc_error err)
+       | Ok _ -> ());
+      let task = task_of config created.task_id in
+      Alcotest.(check (option string))
+        "session id lands on the task"
+        (Some "session-gamma")
+        task.execution_links.session_id;
+      Alcotest.(check bool)
+        "recording who ran it does not state what done means"
+        true
+        (task.contract = None))
+;;
+
+let test_execution_links_codec_omits_empty () =
+  let task = gc_make_task ~id:"task-l1" ~created_at:gc_ancient_ts ~status:Masc_domain.Todo in
+  let keys =
+    match Masc_domain.task_to_yojson task with
+    | `Assoc kvs -> List.map fst kvs
+    | _ -> []
+  in
+  Alcotest.(check bool)
+    "unlinked task writes no execution_links key"
+    false
+    (List.mem "execution_links" keys);
+  (match Masc_domain.task_of_yojson (Masc_domain.task_to_yojson task) with
+   | Ok decoded ->
+     Alcotest.(check bool)
+       "absent key decodes to no links"
+       true
+       (decoded.execution_links = Masc_domain.no_execution_links)
+   | Error e -> Alcotest.fail ("decode without key failed: " ^ e));
+  let linked =
+    { task with
+      execution_links = { operation_id = Some "op-1"; session_id = Some "sess-1" }
+    }
+  in
+  match Masc_domain.task_of_yojson (Masc_domain.task_to_yojson linked) with
+  | Ok decoded ->
+    Alcotest.(check (option string))
+      "operation id round-trips"
+      (Some "op-1")
+      decoded.execution_links.operation_id;
+    Alcotest.(check (option string))
+      "session id round-trips"
+      (Some "sess-1")
+      decoded.execution_links.session_id
+  | Error e -> Alcotest.fail ("decode with key failed: " ^ e)
 ;;
 
 let test_predecessor_codec_absent_and_malformed () =
@@ -3045,6 +3195,24 @@ let () =
             "codec absent and malformed"
             `Quick
             test_predecessor_codec_absent_and_malformed
+        ] )
+    ; ( "task contract vs execution links"
+      , [ Alcotest.test_case
+            "creation without a contract keeps None"
+            `Quick
+            test_task_without_contract_keeps_none
+        ; Alcotest.test_case
+            "linking leaves a stated contract alone"
+            `Quick
+            test_link_execution_artifacts_leaves_contract_alone
+        ; Alcotest.test_case
+            "linking does not create a contract"
+            `Quick
+            test_link_execution_artifacts_does_not_create_a_contract
+        ; Alcotest.test_case
+            "execution_links codec omits the empty value"
+            `Quick
+            test_execution_links_codec_omits_empty
         ] )
     ]
 ;;

--- a/test/test_workspace_goal_index.ml
+++ b/test/test_workspace_goal_index.ml
@@ -42,6 +42,7 @@ let make_task ~id ~status =
   ; handoff_context = None
   ; cycle_count = 0
   ; reclaim_policy = None
+  ; execution_links = Masc_domain.no_execution_links
   ; do_not_reclaim_reason = None
   }
 ;;

--- a/test/test_workspace_handoff_boundary.ml
+++ b/test/test_workspace_handoff_boundary.ml
@@ -40,6 +40,7 @@ let task ?handoff_context ~status id : Domain.task =
   ; created_by = Some "operator"
   ; predecessor_task_id = None
   ; contract = None
+  ; execution_links = Domain.no_execution_links
   ; handoff_context
   ; cycle_count = 0
   ; reclaim_policy = None

--- a/test/test_workspace_task_lifecycle.ml
+++ b/test/test_workspace_task_lifecycle.ml
@@ -245,6 +245,7 @@ let task_with_status task_status : D.task =
   ; handoff_context = None
   ; cycle_count = 0
   ; reclaim_policy = None
+  ; execution_links = Masc_domain.no_execution_links
   ; do_not_reclaim_reason = None
   }
 ;;

--- a/test/test_workspace_task_verification_phase_e.ml
+++ b/test/test_workspace_task_verification_phase_e.ml
@@ -20,6 +20,7 @@ let dummy_task ?contract ?handoff_context () : Masc_domain.task =
   ; handoff_context
   ; cycle_count = 0
   ; reclaim_policy = None
+  ; execution_links = Masc_domain.no_execution_links
   ; do_not_reclaim_reason = None
   }
 
@@ -53,7 +54,6 @@ let test_contracted_task_keeps_requirements_out_of_submitted_refs () =
     ; required_evidence = [ "test_keeper_lifecycle PASS" ]
     ; inspect_gate_evidence = []
     ; verify_gate_evidence = [ "PR #18810 merged" ]
-    ; links = { operation_id = None; session_id = None }
     }
   in
   let task = dummy_task ~contract () in


### PR DESCRIPTION
## 변경

- `task.contract`는 작업 생성 시 진술되는 완료 기준과 증거 사실만 담고 이후 변경하지 않습니다.
- 실행 중 생기는 `operation_id`와 `session_id`는 `task.execution_links`에만 기록합니다.
- 완료 기준이 주어지지 않은 작업은 `contract = None`으로 유지합니다.
- 실행 링크 갱신은 계약을 생성하거나 다시 쓰지 않습니다.
- Dashboard의 실행 경로와 증거 표시는 `task.execution_links`만 읽습니다.

## 저장 경계

- `task_contract`와 `task_execution_links` JSON decoder는 미지 필드를 거부합니다.
- `execution_links`가 없으면 아직 연결되지 않은 작업이며, 빈 객체도 같은 상태입니다.
- 존재하는 `execution_links`가 `null`, 다른 JSON 타입, 잘못된 필드 타입, 또는 미지 필드를 담으면 backlog 전체 읽기가 명시적으로 실패합니다.
- 따라서 데이터가 현재 스키마를 만족하는 상태에서만 이 변경을 활성화할 수 있습니다.

## 활성화 차단

#27030(운영 판단, 2026-08-07)으로 해소됨: **activation 시 live `contract.links` 66~72건을 폐기합니다** — pre-release no-migration 정책(사용자 상시 지침 인용, "출시 전 마이그레이션 금지, 백지 유리하면 백지") 적용. `contract.links`는 완료/진행 중 태스크의 보조 증거 포인터였고, activation 이후 신규 기록은 `task.execution_links`가 대체합니다. compatibility reader나 dual read/write는 넣지 않습니다 — 조용한 손실이 아니라 명시된 폐기입니다.

이 판단은 pre-release 정책에 의존하며 출시 후에는 무효입니다.

## 검증

- `ocamlformat` 적용
- 변경 OCaml 4개 파일 `ocamlc -stop-after parsing` 통과
- `git diff --check` 통과
- Dashboard `tsc --noEmit` 통과
- Dashboard 관련 Vitest 2개 파일, 67개 테스트 통과
- repo wrapper focused build는 다른 세션의 bare Dune 프로세스 2개를 감지해 exit 75로 거부됨; 잠금 우회 없이 PR CI에서 확인

