### PR TITLE
refactor(task): derive the next-actions hint instead of restating the FSM

### DIFF
--- a/lib/workspace/workspace_task_classify.ml
+++ b/lib/workspace/workspace_task_classify.ml
@@ -257,35 +257,21 @@ let task_status_to_string = Masc_domain.task_status_to_string
 let task_assignee_of_status = Masc_domain.task_assignee_of_status
 
 (** Issue #7646: symmetric to [task_assignee_of_status]. When a transition
-    fails for a reason other than ownership mismatch, surface what
-    actions ARE legal from the current state so the LLM stops
-    guess-retrying.
+    fails for a reason other than ownership mismatch, surface what actions ARE
+    legal from the current state so the LLM stops guess-retrying.
 
-    Exhaustive [match] over [Masc_domain.task_status]: adding a 7th constructor
-    will fail to compile. Each branch lists actions that
-    [transition_task_r]'s match-arms accept for that status — keep this
-    in sync if you add new transitions there. *)
-let valid_next_actions_for_status : Masc_domain.task_status -> Masc_domain.task_action list =
-  function
-  | Masc_domain.Todo -> [ Masc_domain.Claim; Masc_domain.Release; Masc_domain.Cancel ]
-  | Masc_domain.Claimed _ ->
-    [ Masc_domain.Start
-    ; Masc_domain.Submit_for_verification
-    ; Masc_domain.Release
-    ; Masc_domain.Cancel
-    ]
-  | Masc_domain.InProgress _ ->
-    [ Masc_domain.Submit_for_verification
-    ; Masc_domain.Release
-    ; Masc_domain.Cancel
-    ]
-  | Masc_domain.AwaitingVerification _ ->
-    (* No agent action applies. The verdict is issued by a completion authority
-       through [Workspace_task_lifecycle.decide_verdict], which is not part of
-       the agent action surface. Distinct from the terminal case below: this
-       obligation is still live, it just is not an agent's to advance. *)
-    []
-  | Masc_domain.Done _ | Masc_domain.Cancelled _ -> [] (* terminal *)
+    Derived from the FSM rather than restated beside it. This was a
+    hand-maintained match whose own doc said "keep this in sync if you add new
+    transitions there", while [Workspace_task_lifecycle.valid_next_actions] —
+    which asks [decide] directly and therefore cannot drift — sat unused next
+    to it. The hint can no longer disagree with the transition it describes.
+
+    [same_agent:true]: the hint is shown to the actor that just failed a
+    transition on a task it owns. Ownership mismatch is reported separately and
+    suppresses this hint entirely, so the not-same-agent projection is never
+    the one rendered. *)
+let valid_next_actions_for_status (status : Masc_domain.task_status) =
+  Workspace_task_lifecycle.valid_next_actions ~same_agent:true ~task_status:status
 ;;
 
 let next_actions_hint status =

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -2106,7 +2106,9 @@ let () = test "transition_submit_for_verification_todo_rejects_instead_of_alias"
       (str_contains
          (Tool_result.message result)
          "Invalid transition: todo -> submit_for_verification");
-    assert (str_contains (Tool_result.message result) "valid_next_actions=[claim;release;cancel]");
+    (* Order follows [Masc_domain.all_task_actions], which the hint is now
+       derived from, rather than the hand-written order it used to restate. *)
+    assert (str_contains (Tool_result.message result) "valid_next_actions=[claim;cancel;release]");
     assert_task_todo ctx)
 )
 


### PR DESCRIPTION
## 목표

`valid_next_actions` 힌트를 FSM 에서 파생시킨다. 같은 답을 내는 구현이 둘 있었고, **드리프트할 수 있는 쪽이 살아 있었다.**

## 문제

`workspace_task_classify.valid_next_actions_for_status` 는 손으로 유지하는 match 였고, 자기 doc 이 이렇게 적혀 있었다:

> "Each branch lists actions that `[transition_task_r]`'s match-arms accept for that status — **keep this in sync if you add new transitions there**."

두 줄 떨어진 곳에 `Workspace_task_lifecycle.valid_next_actions` 가 있다. `all_task_actions` 전체를 `decide` 에 물어보므로 **구조적으로 드리프트가 불가능**하다. 그리고 저장소 전체에 **호출자가 0** 이었다 — 테스트 포함.

correct-by-construction 인 쪽이 죽어 있고, 거짓말할 수 있는 쪽이 살아 있었다.

## 변경

```ocaml
let valid_next_actions_for_status (status : Masc_domain.task_status) =
  Workspace_task_lifecycle.valid_next_actions ~same_agent:true ~task_status:status
```

`same_agent:true` 인 이유: 힌트는 자기가 소유한 task 에서 transition 에 실패한 actor 에게 보인다. ownership mismatch 는 별도로 보고되며 이 힌트를 아예 억제하므로, not-same-agent 투사는 렌더되지 않는다.

## 두 구현의 차이

**집합은 같았다. 순서가 달랐다.**

| | Todo 에서의 힌트 |
|---|---|
| 손 목록 | `[claim; release; cancel]` |
| 파생 | `[claim; cancel; release]` — `all_task_actions` 선언 순서 |

테스트 하나가 옛 순서를 고정하고 있었다. 파생 순서로 갱신하고 이유를 주석에 남겼다.

집합이 일치했다는 건 **지금까지는 힌트가 맞았다**는 뜻이다. 이 PR 은 버그를 고치는 게 아니라 **앞으로 틀릴 수 없게** 만든다.

## 검증

- `dune build @check` clean
- `test_tool_task_coverage` 2건, `test_tool_workspace_coverage` 1건 — **둘 다 main 기준선과 동일** (본 변경을 stash 하고 측정해 대조)
- meta gate: determinism / silent-failure / enum-string 전부 0

## 알려진 사항

- 이 두 스위트는 warm build 에서 flaky 하다. 측정 중 같은 커밋에서 2→3→2 로 흔들렸다. 최종 수치는 빌드가 안정된 뒤 연속 3회 실행에서 얻었고, 기준선도 같은 방식으로 쟀다
- `test/test_server_ide_http.ml` 는 main 에서 이미 컴파일 실패하며 본 PR 과 무관

RFC-WAIVED: 동일한 답을 내는 두 구현 중 파생 가능한 쪽으로 통합한다. 새 설계 결정이 없다.
