### PR TITLE
fix(keeper): settle connector direct posts exactly once

### DIFF
--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -145,11 +145,11 @@ let busy_ack_reply_text ?in_flight (request : Gate_protocol.message_request) =
     | None -> ""
     | Some { Keeper_turn_admission.lane; started_at = _ } ->
         Printf.sprintf
-          " Current turn: %s."
+          " (현재 턴: %s)"
           (Keeper_turn_admission.lane_to_string lane)
   in
   Printf.sprintf
-    "%s is busy; your message is %s (request_id=%s).%s"
+    "⏳ [%s] 님이 작업을 처리 중입니다 (status=%s, request_id=%s).%s"
     request.destination_id
     status
     request.request_id
@@ -168,31 +168,33 @@ let busy_ack_reply_text_queued
     | None -> ""
     | Some { Keeper_turn_admission.lane; started_at = _ } ->
         Printf.sprintf
-          " Current turn: %s."
+          " (현재 턴: %s)"
           (Keeper_turn_admission.lane_to_string lane)
   in
   match admission_rejection.shutdown_operation_id, recovery_required_count with
   | Some operation_id, 0 ->
       Printf.sprintf
-        "%s is stopping under shutdown operation %s; your message is durably \
-         queued and will wait for the next active lane (receipt_id=%s).%s"
+        "⏳ [%s] 님이 종료 절차 진행 중입니다 (%s). 메시지는 안전하게 대기 \
+         중입니다 (receipt_id=%s).%s"
         keeper_name
         (Keeper_shutdown_types.Operation_id.to_string operation_id)
         receipt_id in_flight_text
   | Some operation_id, recovery_required_count ->
       Printf.sprintf
-        "%s is stopping under shutdown operation %s; your message is durably queued, but this Keeper lane also has %d receipt(s) awaiting explicit delivery recovery and cannot dispatch automatically (receipt_id=%s).%s"
+        "⏳ [%s] 님이 종료 절차 진행 중입니다 (%s). 대기 메시지 %d건이 \
+         존재합니다 (receipt_id=%s).%s"
         keeper_name
         (Keeper_shutdown_types.Operation_id.to_string operation_id)
         recovery_required_count receipt_id in_flight_text
   | None, 0 ->
       Printf.sprintf
-        "%s is busy; your message is queued and will be answered once the current \
-        turn finishes (receipt_id=%s).%s"
+        "⏳ [%s] 님이 현재 답변을 작성 중입니다. 턴이 마무리되면 \
+         답변드리겠습니다 (receipt_id=%s).%s"
         keeper_name receipt_id in_flight_text
   | None, recovery_required_count ->
       Printf.sprintf
-        "%s accepted your message durably, but this Keeper lane has %d receipt(s) awaiting explicit delivery recovery and cannot dispatch automatically (receipt_id=%s).%s"
+        "⏳ [%s] 님이 메시지를 접수했습니다. 복구 대기 턴 %d건 처리 후 \
+         응대됩니다 (receipt_id=%s).%s"
         keeper_name recovery_required_count receipt_id in_flight_text
 
 let chat_queue_message_request ~channel ~channel_user_id ~keeper_name

--- a/lib/keeper/keeper_agent_result.ml
+++ b/lib/keeper/keeper_agent_result.ml
@@ -71,6 +71,7 @@ let tool_names_of_calls (tool_calls : tool_call_detail list) : string list =
 (** Result of a single Agent.run() keeper turn. *)
 type run_result =
   { response_text : string
+  ; turn_outcome : Keeper_turn_outcome.t
   ; model_used : string
   ; prompt_metrics : prompt_metrics
   ; ctx_composition : ctx_composition_metrics

--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -26,6 +26,7 @@ type operator_disposition =
 (** Result of a single Agent.run() keeper turn. *)
 type run_result =
   { response_text : string
+  ; turn_outcome : Keeper_turn_outcome.t
   ; model_used : string
   ; prompt_metrics : Keeper_agent_prompt_metrics.prompt_metrics
   ; ctx_composition : Keeper_agent_prompt_metrics.ctx_composition_metrics

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1016,13 +1016,31 @@ let run_turn
                       with
                       | Error e -> Error e
                       | Ok response_text ->
-                        (match !final_oas_turn_ordinal_ref with
-                         | None ->
+                        let turn_outcome =
+                          match s.terminal_effect_state () with
+                          | Keeper_tools_oas.Terminal_effect_completed ->
+                            Ok Keeper_turn_outcome.External_effect_completed
+                          | Keeper_tools_oas.Terminal_effect_failed failure ->
+                            Error
+                              (Agent_sdk.Error.Internal
+                                 ("successful Keeper run retained a failed terminal effect: "
+                                  ^ failure.diagnostic))
+                          | Keeper_tools_oas.Terminal_effect_open
+                          | Keeper_tools_oas.Deferred_tool_result
+                          | Keeper_tools_oas.External_effect_deferred ->
+                            Ok
+                              (Keeper_turn_outcome.of_result_surface
+                                 ~response_text
+                                 result.stop_reason)
+                        in
+                        (match turn_outcome, !final_oas_turn_ordinal_ref with
+                         | Error e, _ -> Error e
+                         | Ok _, None ->
                            Error
                              (Agent_sdk.Error.Internal
                                 "successful Agent.run returned without an \
                                  AfterTurn ordinal")
-                         | Some final_oas_turn_ordinal ->
+                         | Ok turn_outcome, Some final_oas_turn_ordinal ->
                            Keeper_agent_run_finalize_response.finalize
                              ~config ~meta ~generation ~profile_defaults
                              ~manifest_keeper_turn_id
@@ -1038,6 +1056,7 @@ let run_turn
                              ~receipt_response_text_present_ref
                              ~history_assistant_source
                              ~raw_response_text:response_text
+                             ~turn_outcome
                              ?continuation_delivery_channel
                              ~capture_replay_response:
                                (fun ~response_text ->

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -304,6 +304,7 @@ let finalize
     ~receipt_response_text_present_ref
     ~history_assistant_source
     ~raw_response_text
+    ~turn_outcome
     ~capture_replay_response
     ?continuation_delivery_channel
     () =
@@ -476,6 +477,7 @@ let finalize
       ();
     Ok
       { response_text
+      ; turn_outcome
       ; model_used = model
       ; prompt_metrics
       ; ctx_composition

--- a/lib/keeper/keeper_chat_blocks.ml
+++ b/lib/keeper/keeper_chat_blocks.ml
@@ -105,6 +105,8 @@ let connector_projection ~turn_outcome ~reply =
     Connector_status { kind = Continuation_checkpoint }
   | Keeper_turn_outcome.External_effect_pending, _ ->
     Connector_status { kind = External_effect_pending }
+  | Keeper_turn_outcome.External_effect_completed, _ ->
+    Connector_no_visible_reply
   | Keeper_turn_outcome.Visible_reply, Some reply ->
     let reply = String.trim reply in
     if String.equal reply ""

--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -385,6 +385,7 @@ let adapter_loop_with_transport ~token ~channel_id ~events ~post_message
     | Some b -> Some (Masc_network_defaults.normalize_loopback_base_url b)
     | None -> None
   in
+  let external_effect_completed = ref false in
   (* Streaming state:
      - msg_id: Some once the initial POST succeeds
      - last_edit_time: wall-clock of last PATCH (rate limiting)
@@ -474,6 +475,7 @@ let adapter_loop_with_transport ~token ~channel_id ~events ~post_message
     | Run_finished { run_id = _ } ->
         let final_result =
           match msg_id with
+          | None when !external_effect_completed -> Ok ()
           | None ->
               (* No stable streaming segment was posted. The terminal fallback
                  is the primary delivery and its result owns the receipt. *)
@@ -498,6 +500,10 @@ let adapter_loop_with_transport ~token ~channel_id ~events ~post_message
         send_text_rich_embeds ?clock ~token ~channel_id acc_text;
         (* Loop exits after one turn. *)
         ()
+    | External_effect_completed ->
+        external_effect_completed := true;
+        loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url
+          ~tool_msgs
     | Event_error { message } ->
         on_send_result (send_message ~content:("Keeper error: " ^ message));
         (* Loop exits after error. *)

--- a/lib/keeper/keeper_chat_events.ml
+++ b/lib/keeper/keeper_chat_events.ml
@@ -33,6 +33,7 @@ type keeper_chat_event =
   | Text_message_start of { message_id : string; role : role }
   | Text_delta of string
   | Text_message_end
+  | External_effect_completed
   | Run_finished of { run_id : string }
   | Event_error of { message : string }
   | Custom of { name : string; value : Yojson.Safe.t }

--- a/lib/keeper/keeper_chat_events.mli
+++ b/lib/keeper/keeper_chat_events.mli
@@ -43,6 +43,10 @@ type keeper_chat_event =
   | Text_message_start of { message_id : string; role : role }
   | Text_delta of string
   | Text_message_end
+  | External_effect_completed
+      (** A terminal tool already delivered the reply outside this adapter.
+          Connector adapters settle the receipt without emitting another
+          text message. *)
   | Run_finished of { run_id : string }
   | Event_error of { message : string }
   | Custom of { name : string; value : Yojson.Safe.t }

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -313,6 +313,7 @@ let adapter_loop_with_transport
        content:string -> blocks:Yojson.Safe.t list -> (unit, error) result)
     ?base_url
     ?(on_send_result = fun _ -> ()) () =
+  let external_effect_completed = ref false in
   let rec loop ~acc_text ~acc_blocks ~run_id_opt =
     match Keeper_chat_events.subscribe events with
     | Text_delta text ->
@@ -320,16 +321,23 @@ let adapter_loop_with_transport
     | Text_message_end ->
         loop ~acc_text ~acc_blocks ~run_id_opt
     | Run_finished { run_id = _ } ->
-        let blocks =
-          final_message_blocks ~content:acc_text
-            ~event_blocks:(List.rev acc_blocks)
-        in
-        if String.length acc_text > 0 || List.length blocks > 0
-        then on_send_result (send_blocks ~content:acc_text ~blocks)
-        else
-          on_send_result
-            (Error (Other "Slack terminal reply contained no text or blocks"));
+        if !external_effect_completed
+        then on_send_result (Ok ())
+        else begin
+          let blocks =
+            final_message_blocks ~content:acc_text
+              ~event_blocks:(List.rev acc_blocks)
+          in
+          if String.length acc_text > 0 || List.length blocks > 0
+          then on_send_result (send_blocks ~content:acc_text ~blocks)
+          else
+            on_send_result
+              (Error (Other "Slack terminal reply contained no text or blocks"))
+        end;
         ()
+    | External_effect_completed ->
+        external_effect_completed := true;
+        loop ~acc_text ~acc_blocks ~run_id_opt
     | Event_error { message } ->
         on_send_result (send_plain ~content:("Keeper error: " ^ message));
         ()

--- a/lib/keeper/keeper_invocation_contract.ml
+++ b/lib/keeper/keeper_invocation_contract.ml
@@ -274,6 +274,7 @@ let result_contract_of_status = function
      | Error _ -> Failed
      | Ok Keeper_turn_outcome.Continuation_checkpoint -> Yielded
      | Ok Keeper_turn_outcome.External_effect_pending -> Yielded
+     | Ok Keeper_turn_outcome.External_effect_completed
      | Ok Keeper_turn_outcome.Visible_reply
      | Ok Keeper_turn_outcome.No_visible_reply -> Completed)
 ;;

--- a/lib/keeper/keeper_surface_post.ml
+++ b/lib/keeper/keeper_surface_post.ml
@@ -9,9 +9,31 @@ let dashboard_label = "dashboard"
 let discord_label = "discord"
 let slack_label = "slack"
 
-let resolve_target ~surface ~channel_id ?(bound_discord_channels = [])
+let resolve_target ~surface ~channel_id ?continuation_channel
+    ?(bound_discord_channels = [])
     ?(bound_slack_channels = []) () : (post_target, string) result =
   let surface = String.trim surface in
+  let continuation_channel_id =
+    match continuation_channel with
+    | Some (Keeper_continuation_channel.Discord { channel_id; _ })
+      when String.equal surface discord_label ->
+      Some channel_id
+    | Some (Keeper_continuation_channel.Slack { channel_id; _ })
+      when String.equal surface slack_label ->
+      Some channel_id
+    | Some
+        ( Keeper_continuation_channel.Dashboard _
+        | Keeper_continuation_channel.Discord _
+        | Keeper_continuation_channel.Slack _
+        | Keeper_continuation_channel.Unrouted _ )
+    | None ->
+      None
+  in
+  let channel_id =
+    match channel_id with
+    | Some _ as explicit -> explicit
+    | None -> continuation_channel_id
+  in
   if String.equal surface dashboard_label then Ok To_dashboard
   else if String.equal surface discord_label then
     let bound = List.map String.trim bound_discord_channels in

--- a/lib/keeper/keeper_surface_post.mli
+++ b/lib/keeper/keeper_surface_post.mli
@@ -2,7 +2,8 @@
 
     Decision layer behind the [keeper_surface_post] tool: resolve which
     lane a post goes to, purely from the requested surface label, the
-    optional channel id, and the keeper's current Discord/Slack bindings.
+    optional channel id, the typed continuation channel, and the keeper's
+    current Discord/Slack bindings.
     Posting to a surface the keeper is not bound to is an error, not a
     no-op (RFC-0223 §4 P4). All transport I/O stays in the runtime
     handler. *)
@@ -26,6 +27,7 @@ val slack_label : string
 val resolve_target :
   surface:string ->
   channel_id:string option ->
+  ?continuation_channel:Keeper_continuation_channel.t ->
   ?bound_discord_channels:string list ->
   ?bound_slack_channels:string list ->
   unit ->
@@ -35,10 +37,12 @@ val resolve_target :
       function only routes.
     - ["dashboard"] → [To_dashboard].
     - ["discord"] → the bound channel when exactly one exists; the
-      given [channel_id] when it is among the bindings; an error
+      given [channel_id], or the exact matching typed continuation channel,
+      when it is among the bindings; an error
       naming the bound channels when ambiguous, unbound, or the id is
       not bound.
     - ["slack"] → same semantics against [bound_slack_channels].
+      A continuation for another connector never supplies an id.
     - any other label → error: P4 ships discord + dashboard + slack
       (generic gate connectors have no send surface yet). *)
 

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -697,6 +697,7 @@ let handle_surface_post_with_outcome
        | Ok bound_slack_channels ->
        match
          Keeper_surface_post.resolve_target ~surface ~channel_id
+           ?continuation_channel
            ~bound_slack_channels ~bound_discord_channels ()
        with
       | Error message ->

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -898,9 +898,7 @@ let run_keeper_invocation_turn_admitted_inner
                   ( Keeper_turn_outcome.wire_key,
                     `String
                       (Keeper_turn_outcome.to_label
-                         (Keeper_turn_outcome.of_result_surface
-                            ~response_text:result.response_text
-                            result.stop_reason)) );
+                         result.turn_outcome) );
                   ("model", `String surface_model_used);
                   ("model_used_raw", `String surface_model_used);
                   ("turns", `Int result.turn_count);

--- a/lib/keeper/keeper_turn_outcome.ml
+++ b/lib/keeper/keeper_turn_outcome.ml
@@ -5,6 +5,7 @@
 type t =
   | Visible_reply
   | Continuation_checkpoint
+  | External_effect_completed
   | External_effect_pending
   | No_visible_reply
 
@@ -12,22 +13,28 @@ let equal a b =
   match (a, b) with
   | Visible_reply, Visible_reply
   | No_visible_reply, No_visible_reply
+  | External_effect_completed, External_effect_completed
   | External_effect_pending, External_effect_pending
   | Continuation_checkpoint, Continuation_checkpoint ->
       true
-  | (Visible_reply | Continuation_checkpoint | External_effect_pending
-    | No_visible_reply), _ ->
+  | ( Visible_reply
+    | Continuation_checkpoint
+    | External_effect_completed
+    | External_effect_pending
+    | No_visible_reply ), _ ->
     false
 
 let to_label = function
   | Visible_reply -> "visible_reply"
   | Continuation_checkpoint -> "continuation_checkpoint"
+  | External_effect_completed -> "external_effect_completed"
   | External_effect_pending -> "external_effect_pending"
   | No_visible_reply -> "no_visible_reply"
 
 let of_label = function
   | "visible_reply" -> Some Visible_reply
   | "continuation_checkpoint" -> Some Continuation_checkpoint
+  | "external_effect_completed" -> Some External_effect_completed
   | "external_effect_pending" -> Some External_effect_pending
   | "no_visible_reply" -> Some No_visible_reply
   | _ -> None

--- a/lib/keeper/keeper_turn_outcome.mli
+++ b/lib/keeper/keeper_turn_outcome.mli
@@ -3,7 +3,8 @@
     The keeper reply payload declares at the write boundary whether its
     [reply] text is model output ([Visible_reply]), absent from the
     visible surface ([No_visible_reply]), a continuation boundary
-    ([Continuation_checkpoint]), or a durable external-effect wait
+    ([Continuation_checkpoint]), a completed terminal external delivery
+    ([External_effect_completed]), or a durable external-effect wait
     ([External_effect_pending]). Consumers (lane persistence, stream
     terminal, direct-reply surface, dashboard) match on the decoded
     variant; control state is never synthesized into assistant prose. *)
@@ -11,6 +12,7 @@
 type t =
   | Visible_reply
   | Continuation_checkpoint
+  | External_effect_completed
   | External_effect_pending
   | No_visible_reply
 
@@ -18,7 +20,8 @@ val equal : t -> t -> bool
 
 val to_label : t -> string
 (** Closed wire labels: ["visible_reply"] / ["continuation_checkpoint"] /
-    ["external_effect_pending"] / ["no_visible_reply"]. *)
+    ["external_effect_completed"] / ["external_effect_pending"] /
+    ["no_visible_reply"]. *)
 
 val of_label : string -> t option
 (** Inverse of {!to_label}; [None] on any other string. *)

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -35,8 +35,7 @@ let append_decision_record
     | Some r
       when String.trim r.response_text <> ""
            && Keeper_turn_outcome.equal
-                (Keeper_turn_outcome.of_result_surface
-                   ~response_text:r.response_text r.stop_reason)
+                r.turn_outcome
                 Keeper_turn_outcome.Visible_reply ->
         Some (short_preview r.response_text)
     | _ -> None

--- a/lib/keeper/keeper_unified_metrics_result.ml
+++ b/lib/keeper/keeper_unified_metrics_result.ml
@@ -44,8 +44,7 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
   (* Visible-output preview follows the typed result surface. *)
   let is_visible_reply =
     Keeper_turn_outcome.equal
-      (Keeper_turn_outcome.of_result_surface
-         ~response_text:result.response_text result.stop_reason)
+      result.turn_outcome
       Keeper_turn_outcome.Visible_reply
   in
   let validated_evidence = visible_run_validation result in

--- a/lib/keeper/keeper_unified_metrics_support.ml
+++ b/lib/keeper/keeper_unified_metrics_support.ml
@@ -312,7 +312,7 @@ let validated_evidence_preview
 
 (* RFC-0232: the scheduled-autonomous "what is this keeper doing" preview, by
    precedence. [is_visible_reply] is the typed reply-surface outcome
-   ([Keeper_turn_outcome.of_result_surface]) — an OAS turn-limit observation
+   carried by [Keeper_agent_result.turn_outcome] — an OAS turn-limit observation
    may have no visible reply text, and a
    completed runtime turn may still have no visible reply. Neither case may be
    sniffed as model output, so visible model text only wins when the outcome is

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -1055,6 +1055,7 @@ let direct_reply_terminal_error ?(has_visible_blocks = false) payload_json_opt v
        turn_outcome, String_util.trim_to_option visible_reply, has_visible_blocks
      with
      | Keeper_turn_outcome.Continuation_checkpoint, _, _ -> None
+     | Keeper_turn_outcome.External_effect_completed, _, _ -> None
      | Keeper_turn_outcome.External_effect_pending, _, _ -> None
      | Keeper_turn_outcome.No_visible_reply, _, true -> None
      | Keeper_turn_outcome.Visible_reply, None, true -> None
@@ -1086,7 +1087,9 @@ let persisted_reply_blocks ~turn_outcome media_blocks =
       [ Keeper_chat_blocks.Status
           { kind = Keeper_chat_blocks.External_effect_pending }
       ]
-  | (Keeper_turn_outcome.Visible_reply | Keeper_turn_outcome.No_visible_reply),
+  | ( Keeper_turn_outcome.Visible_reply
+    | Keeper_turn_outcome.External_effect_completed
+    | Keeper_turn_outcome.No_visible_reply ),
     media_blocks ->
     media_blocks
 
@@ -2295,6 +2298,20 @@ let process_single_turn ~user_row_origin ~submission
                    | Keeper_turn_outcome.Visible_reply, Some visible_reply ->
                        persist_assistant_reply ~assistant_content:visible_reply
                        |> delivered_after_persist ~content:visible_reply
+                   | Keeper_turn_outcome.External_effect_completed, _ ->
+                       Result.bind
+                         (persist_tool_calls_only ())
+                         (fun () ->
+                            Keeper_chat_broadcast.chat_appended
+                              ~keeper_name:payload.name
+                              ~source:chat_source
+                              ();
+                            if queued_turn
+                            then
+                              Ok
+                                (Some
+                                   (queued_delivery_outcome_of_turn_ref turn_ref))
+                            else Ok None)
                    | Keeper_turn_outcome.External_effect_pending, _ ->
                        persist_assistant_reply ~assistant_content:""
                        |> delivered_after_persist
@@ -2766,6 +2783,7 @@ let process_single_turn ~user_row_origin ~submission
           let suppress_terminal_reply =
             match turn_outcome with
             | Keeper_turn_outcome.Continuation_checkpoint
+            | Keeper_turn_outcome.External_effect_completed
             | Keeper_turn_outcome.External_effect_pending
             | Keeper_turn_outcome.No_visible_reply ->
                 true
@@ -2787,6 +2805,11 @@ let process_single_turn ~user_row_origin ~submission
                     { name = "KEEPER_REPLY_DETAILS";
                       value = redact_json payload_json })
            | None -> ());
+          if
+            Keeper_turn_outcome.equal turn_outcome
+              Keeper_turn_outcome.External_effect_completed
+          then
+            Keeper_chat_events.publish events External_effect_completed;
           if
             Keeper_turn_outcome.equal turn_outcome
               Keeper_turn_outcome.External_effect_pending
@@ -2979,6 +3002,8 @@ let handle_keeper_chat_stream ~sw ~clock ~submitted_by state request reqd payloa
                   make_event ~thread_id:!current_thread_id ~run_id:!current_run_id
                     ~message_id:!current_message_id Text_message_end)
             then loop ()
+        | External_effect_completed ->
+            if send_custom "KEEPER_EXTERNAL_EFFECT_COMPLETED" `Null then loop ()
         | Oas_stream_connected ->
             if send_custom "KEEPER_CONNECTED" `Null then loop ()
         | Oas_stream_message_start { provider_message_id; model; usage } ->

--- a/test/test_keeper_chat_discord.ml
+++ b/test/test_keeper_chat_discord.ml
@@ -190,6 +190,26 @@ let test_adapter_empty_terminal_is_local_error () =
       (contains message "contained no text")
   | _ -> fail "empty terminal settles once with a local delivery error"
 
+let test_completed_external_effect_settles_without_duplicate_send () =
+  let sends = ref 0 in
+  let outcomes =
+    run_adapter
+      [ Masc.Keeper_chat_events.External_effect_completed
+      ; Masc.Keeper_chat_events.Run_finished { run_id = "run-effect" }
+      ]
+      ~post_message:(fun ~content:_ ->
+        incr sends;
+        Ok "unexpected-stream-message")
+      ~edit_message:(fun ~message_id:_ ~content:_ ->
+        incr sends;
+        Ok ())
+      ~send_message:(fun ~content:_ ->
+        incr sends;
+        Ok ())
+  in
+  check int "completed effect makes no Discord call" 0 !sends;
+  check_single_ok "completed effect settles the receipt" outcomes
+
 let test_terminal_callback_reports_final_patch_failure () =
   let patch_calls = ref 0 in
   let outcomes =
@@ -305,6 +325,8 @@ let () =
             test_terminal_callback_once_for_fallback_post
         ; test_case "empty terminal is local-only" `Quick
             test_adapter_empty_terminal_is_local_error
+        ; test_case "completed effect sends no duplicate reply" `Quick
+            test_completed_external_effect_settles_without_duplicate_send
         ; test_case "callback reports final PATCH failure" `Quick
             test_terminal_callback_reports_final_patch_failure
         ; test_case "callback reports overflow failure" `Quick

--- a/test/test_keeper_chat_slack.ml
+++ b/test/test_keeper_chat_slack.ml
@@ -285,6 +285,24 @@ let test_adapter_empty_terminal_is_error () =
       (contains message "no text or blocks")
   | _ -> fail "empty terminal must settle exactly once with an error"
 
+let test_completed_external_effect_settles_without_duplicate_send () =
+  let sends = ref 0 in
+  let outcomes =
+    run_adapter
+      [ Masc.Keeper_chat_events.External_effect_completed
+      ; Masc.Keeper_chat_events.Run_finished { run_id = "run-effect" }
+      ]
+      ~send_plain:(fun ~content:_ ->
+        incr sends;
+        Ok ())
+      ~send_blocks:(fun ~content:_ ~blocks:_ ->
+        incr sends;
+        Ok ())
+  in
+  check int "completed effect makes no Slack call" 0 !sends;
+  check bool "completed effect settles the receipt" true
+    (outcomes = [ Ok () ])
+
 let test_adapter_external_effect_status_is_terminal_success () =
   let sends = ref [] in
   let outcomes =
@@ -377,6 +395,8 @@ let () =
             test_protocol_diagnostic_cannot_mask_final_failure
         ; test_case "empty terminal is explicit failure" `Quick
             test_adapter_empty_terminal_is_error
+        ; test_case "completed effect sends no duplicate reply" `Quick
+            test_completed_external_effect_settles_without_duplicate_send
         ; test_case "typed external-effect status settles successfully" `Quick
             test_adapter_external_effect_status_is_terminal_success
         ] )

--- a/test/test_keeper_surface_post.ml
+++ b/test/test_keeper_surface_post.ml
@@ -58,6 +58,43 @@ let test_discord_multiple_bindings_require_channel_id () =
     (resolve ~surface:"discord" ~channel_id:(Some "222")
        ~bound_discord_channels:[ "111"; "222" ] ())
 
+let test_discord_continuation_selects_exact_bound_channel () =
+  let continuation_channel =
+    match
+      Keeper_continuation_channel.discord
+        ~guild_id:(Some "guild")
+        ~channel_id:"222"
+        ~parent_channel_id:None
+        ~thread_id:None
+        ~user_id:"user"
+    with
+    | Ok channel -> channel
+    | Error message -> fail message
+  in
+  check (result target string) "typed continuation channel"
+    (Ok (SP.To_discord { channel_id = "222" }))
+    (resolve ~surface:"discord" ~channel_id:None ~continuation_channel
+       ~bound_discord_channels:[ "111"; "222" ] ())
+
+let test_mismatched_continuation_does_not_select_channel () =
+  let continuation_channel =
+    match
+      Keeper_continuation_channel.slack
+        ~team_id:(Some "team")
+        ~channel_id:"222"
+        ~thread_ts:None
+        ~user_id:"user"
+    with
+    | Ok channel -> channel
+    | Error message -> fail message
+  in
+  match
+    resolve ~surface:"discord" ~channel_id:None ~continuation_channel
+      ~bound_discord_channels:[ "111"; "222" ] ()
+  with
+  | Error _ -> ()
+  | Ok _ -> fail "a Slack continuation selected a Discord channel"
+
 let test_discord_foreign_channel_id_is_error () =
   match
     resolve ~surface:"discord" ~channel_id:(Some "999")
@@ -96,6 +133,23 @@ let test_slack_multiple_bindings_require_channel_id () =
   check (result target string) "explicit channel_id picks one"
     (Ok (SP.To_slack { channel_id = "BBB"; blocks = None }))
     (resolve ~surface:"slack" ~channel_id:(Some "BBB")
+       ~bound_discord_channels:[] ~bound_slack_channels:[ "AAA"; "BBB" ] ())
+
+let test_slack_continuation_selects_exact_bound_channel () =
+  let continuation_channel =
+    match
+      Keeper_continuation_channel.slack
+        ~team_id:(Some "team")
+        ~channel_id:"BBB"
+        ~thread_ts:(Some "thread")
+        ~user_id:"user"
+    with
+    | Ok channel -> channel
+    | Error message -> fail message
+  in
+  check (result target string) "typed Slack continuation channel"
+    (Ok (SP.To_slack { channel_id = "BBB"; blocks = None }))
+    (resolve ~surface:"slack" ~channel_id:None ~continuation_channel
        ~bound_discord_channels:[] ~bound_slack_channels:[ "AAA"; "BBB" ] ())
 
 let test_slack_foreign_channel_id_is_error () =
@@ -193,6 +247,10 @@ let () =
             test_discord_single_binding_resolves_implicitly;
           test_case "multiple bindings require channel_id" `Quick
             test_discord_multiple_bindings_require_channel_id;
+          test_case "Discord continuation selects exact bound channel" `Quick
+            test_discord_continuation_selects_exact_bound_channel;
+          test_case "mismatched continuation stays ambiguous" `Quick
+            test_mismatched_continuation_does_not_select_channel;
           test_case "foreign channel_id is an error" `Quick
             test_discord_foreign_channel_id_is_error;
           test_case "slack unbound is an error" `Quick
@@ -201,6 +259,8 @@ let () =
             test_slack_single_binding_resolves_implicitly;
           test_case "slack multiple bindings require channel_id" `Quick
             test_slack_multiple_bindings_require_channel_id;
+          test_case "Slack continuation selects exact bound channel" `Quick
+            test_slack_continuation_selects_exact_bound_channel;
           test_case "slack foreign channel_id is an error" `Quick
             test_slack_foreign_channel_id_is_error;
           test_case "unsupported surfaces are errors" `Quick

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -876,6 +876,7 @@ let () =
       }
     in
     { response_text = "completed"
+    ; turn_outcome = Masc.Keeper_turn_outcome.Visible_reply
     ; model_used = "test-model"
     ; prompt_metrics
     ; ctx_composition

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -25,6 +25,7 @@ let outcome : TO.t testable =
 let all =
   [ TO.Visible_reply
   ; TO.Continuation_checkpoint
+  ; TO.External_effect_completed
   ; TO.External_effect_pending
   ; TO.No_visible_reply
   ]
@@ -89,6 +90,18 @@ let test_external_effect_wait_is_typed_status () =
   check outcome "external effect remains typed with blank text"
     TO.External_effect_pending
     (TO.of_result_surface ~response_text:"" stop_reason)
+
+let test_external_effect_completed_has_no_direct_reply_error () =
+  let payload_json =
+    `Assoc
+      [ TO.wire_key, `String (TO.to_label TO.External_effect_completed)
+      ; "reply", `String ""
+      ]
+  in
+  check (option string) "terminal surface delivery is already visible" None
+    (Stream.For_testing.direct_reply_terminal_error
+       (Some payload_json)
+       "")
 
 let test_external_effect_status_survives_server_projection () =
   let turn_outcome =
@@ -352,6 +365,9 @@ let test_payload_decode () =
   check outcome "visible label" TO.Visible_reply
     (decoded_exn
        (payload [ (TO.wire_key, `String "visible_reply") ]));
+  check outcome "completed external effect label" TO.External_effect_completed
+    (decoded_exn
+       (payload [ (TO.wire_key, `String "external_effect_completed") ]));
   check outcome "no visible reply label" TO.No_visible_reply
     (decoded_exn
        (payload [ (TO.wire_key, `String "no_visible_reply") ]));
@@ -613,6 +629,16 @@ let test_connector_projection_keeps_continuation_typed () =
   | Connector_text _ | Connector_no_visible_reply ->
     fail "continuation checkpoint must remain a typed connector status"
 
+let test_connector_projection_suppresses_completed_external_effect () =
+  match
+    Masc.Keeper_chat_blocks.connector_projection
+      ~turn_outcome:TO.External_effect_completed
+      ~reply:None
+  with
+  | Connector_no_visible_reply -> ()
+  | Connector_status _ | Connector_text _ ->
+    fail "completed external effect must not emit a duplicate connector reply"
+
 let test_direct_reply_projection_keeps_external_wait_typed () =
   match
     Ops.direct_reply_projection
@@ -640,6 +666,8 @@ let () =
           test_case "of_result_surface" `Quick test_of_result_surface;
           test_case "external effect wait is typed status" `Quick
             test_external_effect_wait_is_typed_status;
+          test_case "completed external effect has no direct reply error" `Quick
+            test_external_effect_completed_has_no_direct_reply_error;
           test_case "external effect status survives server projection" `Quick
             test_external_effect_status_survives_server_projection;
           test_case "external effect status becomes persisted chat block" `Quick
@@ -682,6 +710,8 @@ let () =
             test_connector_projection_keeps_external_wait_typed;
           test_case "connector projection keeps continuation typed" `Quick
             test_connector_projection_keeps_continuation_typed;
+          test_case "connector projection suppresses completed effect" `Quick
+            test_connector_projection_suppresses_completed_external_effect;
           test_case "direct reply keeps external wait typed" `Quick
             test_direct_reply_projection_keeps_external_wait_typed;
         ] );


### PR DESCRIPTION
## Summary

- preserve the typed `Terminal_effect_completed` boundary as `external_effect_completed` through the Keeper result, reply payload, stream, and connector receipt settlement
- route `keeper_surface_post` to the exact typed Discord/Slack continuation channel when `channel_id` is omitted, while retaining explicit binding validation
- restore the unified Korean busy/queued ACK copy for the shared Discord/Slack Gate backend

## Incident evidence

The live Discord turn at 2026-08-05 16:22–16:23 KST ran sequentially:

1. `keeper_surface_read` succeeded
2. `keeper_surface_post` failed because multiple Discord bindings made the omitted `channel_id` ambiguous
3. the retry with the exact channel succeeded
4. the run then emitted `Keeper completed without a visible reply`

The direct post had already delivered the visible reply. Finalization discarded the typed terminal-effect completion and reclassified the intentionally empty provider result as `no_visible_reply`, so the connector emitted a false terminal error.

## Verification

- `ocamlformat --check` on all touched OCaml files
- `git diff --check`
- focused build:
  - `scripts/dune-local.sh build test/test_keeper_surface_post.exe test/test_keeper_turn_outcome.exe test/test_keeper_chat_discord.exe test/test_keeper_chat_slack.exe test/test_keeper_terminal_reason_typed.exe`
- passing:
  - `test_keeper_surface_post.exe` — 16 tests
  - `test_keeper_turn_outcome.exe` — 27 tests
  - `test_keeper_chat_discord.exe` — 18 tests
  - `test_keeper_chat_slack.exe` — 28 tests
- `test_keeper_terminal_reason_typed.exe` compiles and its 115,200-case typed matrix passes, but two pre-existing reactive-success assertions fail identically on current `main`; tracked separately in #26950

## Runtime boundary

No live runtime restart or deployment was performed. The inspected runtime was still serving commit `7ddcc49038`; this PR is source-only until deployed.
