### PR TITLE
fix(server): runtime.toml 실패 카운터가 세지 않던 세 번째 실패

### DIFF
--- a/lib/keeper_runtime/keeper_runtime_config.ml
+++ b/lib/keeper_runtime/keeper_runtime_config.ml
@@ -180,6 +180,40 @@ let validate_stream_idle_timeout doc =
       | Keeper_toml_loader.Toml_local_time _) ->
     Error (Printf.sprintf "%s: expected a numeric TOML value" key)
 
+(* Bootstrap labels its failure counter from this. It used to recover the label
+   by re-reading the rendered message for a "read " or "parse " prefix, which
+   left the validate failure — and any future one — incrementing nothing, while
+   the counter's help text advertised those two as the whole domain. *)
+type load_failure_kind =
+  | Read
+  | Parse
+  | Validate
+
+let load_failure_kind_label = function
+  | Read -> "read_error"
+  | Parse -> "parse_error"
+  | Validate -> "validate_error"
+;;
+
+let all_load_failure_kinds = [ Read; Parse; Validate ]
+
+let load_failure_kind_labels = List.map load_failure_kind_label all_load_failure_kinds
+
+type load_failure =
+  { kind : load_failure_kind
+  ; message : string
+  }
+
+let load_failure_to_string { kind; message } =
+  let verb =
+    match kind with
+    | Read -> "read"
+    | Parse -> "parse"
+    | Validate -> "validate"
+  in
+  Printf.sprintf "%s %s" verb message
+;;
+
 let load_and_apply ~base_path =
   let path = toml_path ~base_path in
   if not (Sys.file_exists path) then
@@ -187,14 +221,15 @@ let load_and_apply ~base_path =
   else
     match read_file path with
     | Error msg ->
-      Error (Printf.sprintf "read %s: %s" path msg)
+      Error { kind = Read; message = Printf.sprintf "%s: %s" path msg }
     | Ok content ->
       match Keeper_toml_loader.parse_toml content with
       | Error msg ->
-        Error (Printf.sprintf "parse %s: %s" path msg)
+        Error { kind = Parse; message = Printf.sprintf "%s: %s" path msg }
       | Ok doc ->
         (match validate_stream_idle_timeout doc with
-         | Error msg -> Error (Printf.sprintf "validate %s: %s" path msg)
+         | Error msg ->
+           Error { kind = Validate; message = Printf.sprintf "%s: %s" path msg }
          | Ok () ->
            let count =
              List.fold_left

--- a/lib/keeper_runtime/keeper_runtime_config.mli
+++ b/lib/keeper_runtime/keeper_runtime_config.mli
@@ -33,7 +33,27 @@
     Returns [Ok num_overrides] (count of TOML keys actually applied,
     excluding those preempted by existing env vars), or [Error msg] on
     parse failure.  Missing file is not an error: returns [Ok 0]. *)
-val load_and_apply : base_path:string -> (int, string) result
+(** Why [load_and_apply] failed. The bootstrap counter labels itself from this
+    rather than re-reading the rendered message, so a new constructor forces a
+    label rather than silently counting nothing. *)
+type load_failure_kind =
+  | Read
+  | Parse
+  | Validate
+
+type load_failure =
+  { kind : load_failure_kind
+  ; message : string
+  }
+
+val load_failure_kind_label : load_failure_kind -> string
+val all_load_failure_kinds : load_failure_kind list
+val load_failure_kind_labels : string list
+
+val load_failure_to_string : load_failure -> string
+(** Renders as before: "read <path>: <detail>", "parse …", "validate …". *)
+
+val load_and_apply : base_path:string -> (int, load_failure) result
 
 (** Read the raw TOML value for [env_name] from the shadow registry.
     Returns [None] when the key was absent from [runtime.toml]

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -425,24 +425,16 @@ let () =
     ~help:
       "Total Keeper_runtime_config.load_and_apply failures. Bootstrap logs WARN; \
        this counter exposes the same event to monitoring aggregation. Labels: \
-       reason in {read_error | parse_error}."
+       reason in {read_error | parse_error | validate_error}, derived from \
+       Keeper_runtime_config.load_failure_kind."
     ()
 
-let record_runtime_toml_load_failure msg =
-  let reason =
-    if String.starts_with ~prefix:"read " msg
-    then Some "read_error"
-    else if String.starts_with ~prefix:"parse " msg
-    then Some "parse_error"
-    else None
-  in
-  Option.iter
-    (fun reason ->
-       Otel_metric_store.inc_counter
-         metric_keeper_runtime_config_load_failures
-         ~labels:[ "reason", reason ]
-      ())
-    reason
+let record_runtime_toml_load_failure (failure : Keeper_runtime_config.load_failure) =
+  Otel_metric_store.inc_counter
+    metric_keeper_runtime_config_load_failures
+    ~labels:
+      [ "reason", Keeper_runtime_config.load_failure_kind_label failure.kind ]
+    ()
 
 let create_server_state ~sw ~base_path ?input_base_path ~clock ~mono_clock ~net
     ~proc_mgr ~fs ?env ()
@@ -500,8 +492,9 @@ let create_server_state ~sw ~base_path ?input_base_path ~clock ~mono_clock ~net
    | Ok 0 -> ()
    | Ok n ->
        Log.Server.info "runtime.toml: applied %d override(s)" n
-   | Error msg ->
-       record_runtime_toml_load_failure msg;
+   | Error failure ->
+       record_runtime_toml_load_failure failure;
+       let msg = Keeper_runtime_config.load_failure_to_string failure in
        Log.Server.error "runtime.toml load failed: %s" msg;
        raise (Env_config_core.Config_error msg));
   Keeper_runtime_resolved.init ();

--- a/test/test_runtime_toml_overrides.ml
+++ b/test/test_runtime_toml_overrides.ml
@@ -63,7 +63,7 @@ let test_missing_file_returns_zero () =
   match Keeper_runtime_config.load_and_apply ~base_path with
   | Ok 0 -> ()
   | Ok n -> failf "expected 0 overrides, got %d" n
-  | Error msg -> failf "unexpected error: %s" msg
+  | Error msg -> failf "unexpected error: %s" (Keeper_runtime_config.load_failure_to_string msg)
 
 
 let test_applies_sleep_and_throttle_overrides () =
@@ -174,7 +174,7 @@ let test_load_and_apply_records_boot_override () =
     with_base_path @@ fun base_path ->
     write_toml base_path "[turn]\nstream_idle_timeout_sec = 42\n";
     match Keeper_runtime_config.load_and_apply ~base_path with
-    | Error msg -> failf "unexpected error: %s" msg
+    | Error msg -> failf "unexpected error: %s" (Keeper_runtime_config.load_failure_to_string msg)
     | Ok n ->
       check int "applied count" 1 n;
       check (option string) "boot override stored"
@@ -208,7 +208,7 @@ let test_explicit_config_dir_wins_over_base_path () =
   let override_config_dir = Filename.concat override_root ".masc/config" in
   with_env "MASC_CONFIG_DIR" (Some override_config_dir) @@ fun () ->
   match Keeper_runtime_config.load_and_apply ~base_path with
-  | Error msg -> failf "unexpected error: %s" msg
+  | Error msg -> failf "unexpected error: %s" (Keeper_runtime_config.load_failure_to_string msg)
   | Ok n ->
     check int "applied count" 1 n;
     check (option string) "explicit config dir stored"
@@ -233,7 +233,7 @@ let test_resolved_runtime_freezes_toml_values_after_init () =
     "[turn]\n\
      stream_idle_timeout_sec = 50\n";
   (match Keeper_runtime_config.load_and_apply ~base_path with
-   | Error msg -> failf "unexpected error: %s" msg
+   | Error msg -> failf "unexpected error: %s" (Keeper_runtime_config.load_failure_to_string msg)
    | Ok _ -> ());
   Keeper_runtime_resolved.init ();
   Config_boot_overrides.set "MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC" "90";
@@ -267,7 +267,7 @@ let test_resolved_stream_idle_timeout_uses_toml () =
   with_base_path @@ fun base_path ->
   write_toml base_path "[turn]\nstream_idle_timeout_sec = 75\n";
   (match Keeper_runtime_config.load_and_apply ~base_path with
-   | Error msg -> failf "unexpected error: %s" msg
+   | Error msg -> failf "unexpected error: %s" (Keeper_runtime_config.load_failure_to_string msg)
    | Ok _ -> ());
   Keeper_runtime_resolved.init ();
   let runtime = Keeper_runtime_resolved.current () in
@@ -283,7 +283,7 @@ let test_resolved_runtime_prefers_env_over_toml () =
   write_toml base_path "[turn]\nstream_idle_timeout_sec = 50\n";
   with_env "MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC" (Some "55") @@ fun () ->
   (match Keeper_runtime_config.load_and_apply ~base_path with
-   | Error msg -> failf "unexpected error: %s" msg
+   | Error msg -> failf "unexpected error: %s" (Keeper_runtime_config.load_failure_to_string msg)
    | Ok _ -> ());
   Keeper_runtime_resolved.init ();
   let runtime = Keeper_runtime_resolved.current () in
@@ -339,13 +339,14 @@ let test_stream_idle_timeout_invalid_toml_returns_error () =
   write_toml base_path "[turn]\nstream_idle_timeout_sec = 0\n";
   match Keeper_runtime_config.load_and_apply ~base_path with
   | Ok _ -> fail "expected non-positive stream idle timeout to be rejected"
-  | Error message ->
+  | Error failure ->
+    check bool "classified as a validate failure" true
+      (failure.Keeper_runtime_config.kind = Keeper_runtime_config.Validate);
     check bool "diagnostic names the TOML key" true
-      (String.starts_with ~prefix:"validate " message
-       && String.ends_with
-            ~suffix:
-              "turn.stream_idle_timeout_sec: expected a finite, positive number of seconds"
-            message)
+      (String.ends_with
+         ~suffix:
+           "turn.stream_idle_timeout_sec: expected a finite, positive number of seconds"
+         (Keeper_runtime_config.load_failure_to_string failure))
 
 let test_stream_idle_timeout_toml_wrong_type_returns_error () =
   with_clean_boot_overrides @@ fun () ->
@@ -353,12 +354,14 @@ let test_stream_idle_timeout_toml_wrong_type_returns_error () =
   write_toml base_path "[turn]\nstream_idle_timeout_sec = \"120\"\n";
   match Keeper_runtime_config.load_and_apply ~base_path with
   | Ok _ -> fail "expected string stream idle timeout to be rejected"
-  | Error message ->
+  | Error failure ->
+    check bool "classified as a validate failure" true
+      (failure.Keeper_runtime_config.kind = Keeper_runtime_config.Validate);
     check bool "diagnostic requires a numeric TOML value" true
       (String.ends_with
          ~suffix:
            "turn.stream_idle_timeout_sec: expected a numeric TOML value"
-         message)
+         (Keeper_runtime_config.load_failure_to_string failure))
 
 let test_resolved_cli_subprocess_idle_default_120s () =
   with_clean_boot_overrides @@ fun () ->
@@ -385,11 +388,41 @@ let test_resolved_cli_subprocess_idle_from_toml () =
   with_base_path @@ fun base_path ->
   write_toml base_path "[turn]\ncli_subprocess_idle_sec = 45\n";
   (match Keeper_runtime_config.load_and_apply ~base_path with
-   | Error msg -> failf "unexpected error: %s" msg
+   | Error msg -> failf "unexpected error: %s" (Keeper_runtime_config.load_failure_to_string msg)
    | Ok _ -> ());
   Keeper_runtime_resolved.init ();
   check (float 0.0001) "cli_subprocess_idle from toml"
     45.0 (Keeper_runtime_resolved.cli_subprocess_idle_sec ())
+
+(* The bootstrap counter labels itself from load_failure_kind. Its help text
+   enumerates the labels, so a constructor added without a label — or a label
+   added without a constructor — has to break here rather than at whatever
+   dashboard reads the metric. *)
+let test_every_failure_kind_has_a_label () =
+  check (list string) "labels cover the constructors"
+    [ "read_error"; "parse_error"; "validate_error" ]
+    Keeper_runtime_config.load_failure_kind_labels;
+  check int "one label per constructor"
+    (List.length Keeper_runtime_config.all_load_failure_kinds)
+    (List.length Keeper_runtime_config.load_failure_kind_labels)
+;;
+
+let test_rendering_keeps_the_verb_prefix () =
+  List.iter
+    (fun (kind, verb) ->
+      let rendered =
+        Keeper_runtime_config.load_failure_to_string
+          { Keeper_runtime_config.kind; message = "x: y" }
+      in
+      check bool
+        (verb ^ " prefix preserved")
+        true
+        (String.starts_with ~prefix:(verb ^ " ") rendered))
+    [ Keeper_runtime_config.Read, "read"
+    ; Keeper_runtime_config.Parse, "parse"
+    ; Keeper_runtime_config.Validate, "validate"
+    ]
+;;
 
 let () =
   run "runtime_toml_overrides"
@@ -401,6 +434,10 @@ let () =
         ; test_case "applies lifecycle enabled overrides (RFC-0297 P0-1)" `Quick test_applies_lifecycle_enabled_overrides
         ; test_case "parse error returns Error" `Quick test_parse_error_returns_error
         ; test_case "load_and_apply records boot override" `Quick test_load_and_apply_records_boot_override
+        ; test_case "every failure kind has a label" `Quick
+            test_every_failure_kind_has_a_label
+        ; test_case "rendering keeps the verb prefix" `Quick
+            test_rendering_keeps_the_verb_prefix
         ; test_case "explicit MASC_CONFIG_DIR wins over base path" `Quick test_explicit_config_dir_wins_over_base_path
         ; test_case "float value round trip" `Quick test_float_value_round_trip
         ; test_case "resolved runtime freezes toml values after init" `Quick test_resolved_runtime_freezes_toml_values_after_init


### PR DESCRIPTION
## 무엇을

메트릭 라벨을 **렌더된 메시지에서 되읽던** 분류기를 타입으로 바꿉니다.

```ocaml
if String.starts_with ~prefix:"read " msg then Some "read_error"
else if String.starts_with ~prefix:"parse " msg then Some "parse_error"
else None
```

## 왜

`load_and_apply` 는 **세 가지** 실패를 냅니다:

| 생산 | 옛 라벨 |
|---|---|
| `"read %s: %s"` | `read_error` ✓ |
| `"parse %s: %s"` | `parse_error` ✓ |
| `"validate %s: %s"` | **`None` → 카운터 미증가** |

`runtime.toml` 에 `stream_idle_timeout_sec = 0` 을 쓰면 부팅이 실패하고, 로그가 남고, `Config_error` 가 올라가는데 **카운터는 0으로 남습니다.**

그리고 카운터의 help 문자열이 `Labels: reason in {read_error | parse_error}` 라고 그 둘이 전부인 것처럼 선언합니다. 그래서 이 구멍이 "이건 안 세는 것" 이 아니라 **"이런 일은 안 일어남"** 으로 읽힙니다.

## 어떻게

```ocaml
type load_failure_kind = Read | Parse | Validate
type load_failure = { kind : load_failure_kind; message : string }
```

라벨은 생성자에서 나옵니다. `load_failure_to_string` 이 이전과 **동일하게** 렌더하므로(`"read <path>: <detail>"`) 로그 줄과 `Config_error` 페이로드는 불변입니다. help 문자열에 `validate_error` 를 넣고 유도 출처를 명시했습니다.

## 테스트가 이미 알고 있었습니다

`test_runtime_toml_overrides` 의 두 케이스가 **`String.starts_with ~prefix:"validate "` 를 이미 검사** 하고 있었습니다. 즉 세 번째 실패 종류는 알려져 있었고 **메트릭 분류기만 몰랐습니다.**

그 둘을 생성자 검사로 바꿨습니다 — 그게 이 PR 의 요점입니다. 그리고 2건을 추가했습니다:

- 라벨 목록이 생성자 목록과 **1:1** 일 것 — 생성자를 늘리고 라벨을 안 붙이면 여기서 깨집니다
- 각 종류가 렌더 시 동사 접두사를 유지할 것

**26/26 통과**, `lib/masc.cma` 빌드 통과.

RFC-WAIVED: credential / identity / operator control action handler / keeper sandbox / hooks 어디에도 해당하지 않습니다. 관측 라벨의 유도 방식을 문자열에서 타입으로 옮기고 누락된 세 번째 라벨을 추가합니다. 로그와 예외 페이로드는 바이트 동일합니다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>