### PR TITLE
docs(rfc): RFC-0362 정정 — active_goal_ids 는 죽은 필드가 아니다

### DIFF
--- a/docs/rfc/RFC-0362-goal-owner-and-intake-contract.md
+++ b/docs/rfc/RFC-0362-goal-owner-and-intake-contract.md
@@ -61,24 +61,34 @@ rules that narrow their own scope (#26862).
 - **`masc_goal_upsert`** accepts `id, title, metric, target_value, due_date,
   priority, parent_goal_id`. No owner.
 - **`masc_goal_list`**, **`masc_goal_transition`** — read and phase change.
-- **`keeper_meta.active_goal_ids`** — a keeper-side list. Its consumers are
-  `dashboard_briefing_assembly.ml:221`, `dashboard_execution_builders.ml:247`
-  and `:318`, `dashboard_http_keeper.ml:92` and `:744`, plus a test fixture.
-  **Every one of them renders it.** No scheduler, turn assembly, or claim path
-  reads it.
+- **`keeper_meta.active_goal_ids`** — a keeper-side list, and **not a dead
+  field**. 113 files carry 360 references. Beyond the dashboard renderers it
+  drives behavior: `Keeper_goal_assignment_wake` (RFC-0315 P3 W0) enqueues a
+  `Keeper_event_queue.Goal_assigned` stimulus for each id that newly enters the
+  list and signals the keeper's Running lane, with edge semantics that fire only
+  on additions; `Keeper_goal_reconciliation_wake` is its sibling. It is also
+  read by `keeper_unified_prompt` (`<available_goals>` and `### Active Goals`),
+  `keeper_world_observation`, the board-attention `keeper_context`, the TOML
+  parser, and the four `keeper_turn_up` modules.
+
+  Its emptiness on the live workspace (0 of 8 keepers) means **nobody assigns**,
+  not that nobody reads.
 - **Task↔Goal linkage** is solved and shipped (RFC-0267, PRs #21704/#21722):
   `masc_task_set_goal`, `POST /api/v1/dashboard/tasks/assign-goal`, and the
   `goal_id` projection on `/execution`. This RFC does not revisit that axis.
 
 ## 3. The failure this RFC must not repeat
 
-`active_goal_ids` is the precedent. The field exists, the dashboard draws it,
-and no behavior depends on it — so a Goal being "held" by a keeper changes
-nothing, and today the field is empty everywhere without anyone noticing.
-
-**Adding `goal.owner` without a consumer produces a second `active_goal_ids`.**
 A field is not a contract. The contract is the sentence some code path says to
-the owner, and the evidence that the path runs.
+the owner, and the evidence that the path runs. `goal.owner` shipped without a
+consumer would be a value the dashboard draws and nothing acts on.
+
+The first draft of this section named `active_goal_ids` as that precedent and
+was wrong: it reads behavior, not just pixels (§2). The correction does not
+weaken the rule, it sharpens what the rule is about — **a field earns its place
+from the path that reads it, and the claim that no such path exists has to be
+measured, not assumed.** The measurement that produced the false claim was a
+single grep whose hits happened to be dashboard files.
 
 ## 4. Proposal
 
@@ -141,8 +151,10 @@ removed rather than kept as decoration.
 ## 6. Open questions
 
 1. Does the owner projection replace `keeper_meta.active_goal_ids`, or coexist?
-   The measurement says the field is empty everywhere and read only by the
-   dashboard; deriving it from `goal.owner` on read would remove a second
-   source of truth.
+   They are not duplicates: `active_goal_ids` is keeper -> goals and **fires a
+   wake on assignment**; `goal.owner` is goal -> keeper and states a fact. A
+   replacement is only sound if changing `owner` produces the same
+   `Goal_assigned` stimulus, and it costs 360 references across 113 files. Not
+   attempted here.
 2. Should `phase = executing` with `owner = None` be surfaced to the operator?
    It is the exact state of all ten live Goals and nothing reports it today.


### PR DESCRIPTION
RFC-0362 §2·§3 이 사실이 아닌 것을 단정했고, **그 위에 RFC 의 중심 논거가 서 있었다.**

## 무엇이 틀렸나

원문:

> **Every one of them renders it.** No scheduler, turn assembly, or claim path reads it.

실제:

```
Keeper_goal_assignment_wake (RFC-0315 P3 W0)
  active_goal_ids 에 새로 들어온 id 마다
  Keeper_event_queue.Goal_assigned 스티뮬러스를 enqueue 하고
  keeper 의 Running lane 에 신호한다. 추가에만 발화하는 edge semantics.

Keeper_goal_reconciliation_wake  형제 모듈
```

그 밖에도 `keeper_unified_prompt`(`<available_goals>`, `### Active Goals`), `keeper_world_observation`, board-attention `keeper_context`, TOML 파서, `keeper_turn_up` 4모듈이 읽는다.

**113개 파일, 360개 참조.**

라이브에서 비어 있는 것(8명 중 0)은 **아무도 배정하지 않아서**이지 **아무도 읽지 않아서**가 아니다.

## 어떻게 틀렸나

한 번의 grep 결과가 우연히 전부 `dashboard_*` 파일이었고, 그걸 "소비자 전수"로 단정했다. §3 을 그 판정 위에 썼다.

## §3 을 어떻게 고쳤나

규칙 자체는 살아 있다 — 소비자 없는 필드는 장식이다. 다만 **예시가 틀렸으므로 예시를 빼고 규칙이 무엇에 관한 것인지 날카롭게 했다**:

> a field earns its place from the path that reads it, and **the claim that no such path exists has to be measured, not assumed.** The measurement that produced the false claim was a single grep whose hits happened to be dashboard files.

## §6 open question 1

두 필드는 중복이 아니다:

| | `active_goal_ids` | `goal.owner` |
|---|---|---|
| 방향 | keeper → goals | goal → keeper |
| 하는 일 | **배정 시 wake 발화** | 소유 사실 진술 |

대체는 `owner` 변경이 **같은 `Goal_assigned` 스티뮬러스를 내보낼 때만** 성립하고, 비용은 113파일 360참조다. 이 RFC 에서 시도하지 않는다.

## 검증

```
scripts/check-doc-truth.sh          exit 0
scripts/rfc-generate-index.py --check  exit 0
```

관련: #26929 (RFC), #26951 (구현)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
