### PR TITLE
fix startup blob scan watchdog starvation

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -885,9 +885,26 @@ let initialize_owner_state_blocking
        Log.Server.info
          "startup wire-capture retention: pruned %d expired day-file(s)"
          wire_capture_pruned;
+     let watchdog_remaining_seconds =
+       max
+         0.0
+         (Server_startup_state.watchdog_timeout_sec ()
+          -. Server_startup_state.elapsed_since_start ())
+     in
+     (* The scan is synchronous because deletion is valid only at this
+        quiescent startup boundary. Give it half of the remaining watchdog
+        window so a growing durable store cannot consume readiness authority;
+        a budget failure retains the prior candidates and every blob. *)
+     let max_scan_seconds = watchdog_remaining_seconds /. 2.0 in
+     Log.Server.info
+       "startup tool blob maintenance: max_scan_seconds=%.1f \
+        watchdog_remaining_seconds=%.1f"
+       max_scan_seconds
+       watchdog_remaining_seconds;
      (match
         Eio_unix.run_in_systhread (fun () ->
           Tool_blob_maintenance.run
+            ~max_scan_seconds
             ~base_path
             ~mode:Tool_blob_maintenance.Delete_previous_candidates)
       with

--- a/lib/tool_blob_store/dune
+++ b/lib/tool_blob_store/dune
@@ -15,4 +15,13 @@
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4) + unused-value ratchet (warning 32)
  (flags
   (:standard -w +4 -w +32))
- (libraries digestif digestif.c unix yojson fs_compat masc_core))
+ (libraries
+  digestif
+  digestif.c
+  unix
+  yojson
+  fs_compat
+  masc_core
+  mtime
+  mtime.clock
+  mtime.clock.os))

--- a/lib/tool_blob_store/tool_blob_maintenance.ml
+++ b/lib/tool_blob_store/tool_blob_maintenance.ml
@@ -28,6 +28,13 @@ type error =
       ; line : int
       ; detail : string
       }
+  | Scan_budget_exhausted of
+      { path : string
+      ; max_duration_sec : float
+      ; elapsed_seconds : float
+      ; files_examined : int
+      ; bytes_examined : int64
+      }
   | Candidate_snapshot_invalid of
       { path : string
       ; detail : string
@@ -74,6 +81,21 @@ let error_to_string = function
       path
       line
       detail
+  | Scan_budget_exhausted
+      { path
+      ; max_duration_sec
+      ; elapsed_seconds
+      ; files_examined
+      ; bytes_examined
+      } ->
+    Printf.sprintf
+      "scan budget exhausted path=%s max_duration_seconds=%.3f \
+       elapsed_seconds=%.3f files_examined=%d bytes_examined=%Ld"
+      path
+      max_duration_sec
+      elapsed_seconds
+      files_examined
+      bytes_examined
   | Candidate_snapshot_invalid { path; detail } ->
     Printf.sprintf "blob maintenance candidate snapshot invalid path=%s: %s" path detail
   | Candidate_snapshot_read_failed { path; detail } ->
@@ -102,6 +124,45 @@ let candidate_snapshot_path ~base_path =
        (Common.masc_dir_from_base_path ~base_path)
        "tool_blob_maintenance")
     "candidates.json"
+;;
+
+type scan_budget =
+  { started_at : Mtime.t
+  ; max_duration_sec : float
+  ; mutable files_examined : int
+  ; mutable bytes_examined : int64
+  }
+
+let scan_elapsed_seconds budget =
+  Mtime.Span.to_float_ns (Mtime.span budget.started_at (Mtime_clock.now ()))
+  /. 1e9
+;;
+
+let check_scan_budget budget_opt ~path =
+  match budget_opt with
+  | None -> Ok ()
+  | Some budget ->
+    let elapsed_seconds = scan_elapsed_seconds budget in
+    if elapsed_seconds < budget.max_duration_sec
+    then Ok ()
+    else
+      Error
+        (Scan_budget_exhausted
+           { path
+           ; max_duration_sec = budget.max_duration_sec
+           ; elapsed_seconds
+           ; files_examined = budget.files_examined
+           ; bytes_examined = budget.bytes_examined
+           })
+;;
+
+let note_file_examined budget_opt payload =
+  match budget_opt with
+  | None -> ()
+  | Some budget ->
+    budget.files_examined <- budget.files_examined + 1;
+    budget.bytes_examined <-
+      Int64.add budget.bytes_examined (Int64.of_int (String.length payload))
 ;;
 
 let add_references ~path ~line references text =
@@ -168,7 +229,9 @@ let rec references_in_json ~path ~line references = function
     Ok references
 ;;
 
-let references_in_file ~ownership_root path =
+let references_in_file ~scan_budget ~ownership_root path =
+  let open Result.Syntax in
+  let* () = check_scan_budget scan_budget ~path in
   match Fs_compat.load_owned_regular_file ~ownership_root path with
   | Error error ->
     Error
@@ -182,20 +245,24 @@ let references_in_file ~ownership_root path =
       (Durable_source_read_failed
          { path; reason = "durable source disappeared during scan" })
   | Ok (Some payload) ->
-    try
-      references_in_json
-        ~path
-        ~line:1
-        String_set.empty
-        (Yojson.Safe.from_string payload)
-    with
-    | Yojson.Json_error _ ->
-      payload
-      |> String.split_on_char '\n'
-      |> List.fold_left
-           (fun (line_number, result) line ->
-              let next =
-                Result.bind result (fun references ->
+    note_file_examined scan_budget payload;
+    let* () = check_scan_budget scan_budget ~path in
+    let parsed =
+      try
+        references_in_json
+          ~path
+          ~line:1
+          String_set.empty
+          (Yojson.Safe.from_string payload)
+      with
+      | Yojson.Json_error _ ->
+        payload
+        |> String.split_on_char '\n'
+        |> List.fold_left
+             (fun (line_number, result) line ->
+                let next =
+                  let* references = result in
+                  let* () = check_scan_budget scan_budget ~path in
                   try
                     references_in_json
                       ~path
@@ -219,11 +286,15 @@ let references_in_file ~ownership_root path =
                         ~path
                         ~line:line_number
                         references
-                        line)
-              in
-              line_number + 1, next)
-           (1, Ok String_set.empty)
-      |> snd
+                        line
+                in
+                line_number + 1, next)
+             (1, Ok String_set.empty)
+        |> snd
+    in
+    let* references = parsed in
+    let* () = check_scan_budget scan_budget ~path in
+    Ok references
 ;;
 
 let durable_consumer_basenames =
@@ -313,7 +384,7 @@ let reject_uncoordinated_cluster_roots ~base_path =
             }))
 ;;
 
-let live_references ~base_path =
+let live_references ~scan_budget ~base_path =
   let read_directory path =
     let inspect () =
       match
@@ -362,13 +433,15 @@ let live_references ~base_path =
              })
   in
   let rec scan_entry path references =
+    let open Result.Syntax in
+    let* () = check_scan_budget scan_budget ~path in
     try
       match (Unix.lstat path).Unix.st_kind with
       | Unix.S_DIR -> scan_directory path references
       | Unix.S_REG ->
         Result.map
           (String_set.union references)
-          (references_in_file ~ownership_root:base_path path)
+          (references_in_file ~scan_budget ~ownership_root:base_path path)
       | Unix.S_LNK ->
         Error
           (Durable_source_stat_failed
@@ -391,6 +464,8 @@ let live_references ~base_path =
                Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message code)
            })
   and scan_directory path references =
+    let open Result.Syntax in
+    let* () = check_scan_budget scan_budget ~path in
     match read_directory path with
     | Error _ as error -> error
     | Ok None -> Ok references
@@ -536,11 +611,24 @@ let save_candidate_snapshot ~base_path candidates =
     Error (Candidate_snapshot_write_failed { path; detail })
 ;;
 
-let run ~base_path ~mode =
+let run ?max_scan_seconds ~base_path ~mode =
   let open Result.Syntax in
   let* () = reject_uncoordinated_cluster_roots ~base_path in
   let store = Tool_blob_store.create ~base_path in
-  let* live = live_references ~base_path in
+  let scan_budget =
+    Option.map
+      (fun max_duration_sec ->
+         { started_at = Mtime_clock.now ()
+         ; max_duration_sec
+         ; files_examined = 0
+         ; bytes_examined = 0L
+         })
+      max_scan_seconds
+  in
+  let* live = live_references ~scan_budget ~base_path in
+  let* () =
+    check_scan_budget scan_budget ~path:(candidate_snapshot_path ~base_path)
+  in
   let* previous_candidates = load_candidate_snapshot ~base_path in
   let* blob_list =
     match Tool_blob_store.list_all_result store with

--- a/lib/tool_blob_store/tool_blob_maintenance.mli
+++ b/lib/tool_blob_store/tool_blob_maintenance.mli
@@ -48,6 +48,13 @@ type error =
       ; line : int
       ; detail : string
       }
+  | Scan_budget_exhausted of
+      { path : string
+      ; max_duration_sec : float
+      ; elapsed_seconds : float
+      ; files_examined : int
+      ; bytes_examined : int64
+      }
   | Candidate_snapshot_invalid of
       { path : string
       ; detail : string
@@ -72,4 +79,12 @@ type report =
 
 val error_to_string : error -> string
 val candidate_snapshot_path : base_path:string -> string
-val run : base_path:string -> mode:mode -> (report, error) result
+val run :
+  ?max_scan_seconds:float ->
+  base_path:string ->
+  mode:mode ->
+  (report, error) result
+(** [run ?max_scan_seconds] aborts a partial durable-consumer scan before
+    publishing a candidate snapshot or deleting blobs when the monotonic
+    elapsed-time budget is exhausted. Omitting the budget preserves the
+    unbounded administrative maintenance operation. *)

--- a/test/test_tool_blob_store.ml
+++ b/test/test_tool_blob_store.ml
@@ -510,6 +510,53 @@ let test_maintenance_malformed_reference_fails_closed () =
         (Some "must survive malformed source")
         (fetch_ok store ~sha256:blob.sha256))
 
+let test_maintenance_scan_budget_fails_closed_before_deletion () =
+  with_temp_dir (fun base_path ->
+      let store = B.create ~base_path in
+      let blob =
+        B.put store ~bytes:"must survive exhausted scan budget" ~mime:"text/plain"
+        |> stored_ref_exn
+      in
+      let observed = maintenance_ok ~base_path ~mode:M.Observe_only in
+      Alcotest.(check int)
+        "unreferenced blob is a prior candidate"
+        1
+        observed.candidates_recorded;
+      let candidate_path = M.candidate_snapshot_path ~base_path in
+      let candidate_before = Fs_compat.load_file candidate_path in
+      (match
+         M.run
+           ~max_scan_seconds:0.0
+           ~base_path
+           ~mode:M.Delete_previous_candidates
+       with
+       | Error
+           (M.Scan_budget_exhausted
+             { max_duration_sec
+             ; files_examined
+             ; bytes_examined
+             ; _
+             }) ->
+         Alcotest.(check bool)
+           "exact zero budget"
+           true
+           (Float.equal max_duration_sec 0.0);
+         Alcotest.(check int) "no file read after exhaustion" 0 files_examined;
+         Alcotest.(check int64) "no bytes read after exhaustion" 0L bytes_examined
+       | Error error ->
+         Alcotest.failf
+           "unexpected scan-budget error: %s"
+           (M.error_to_string error)
+       | Ok _ -> Alcotest.fail "exhausted scan budget reached deletion");
+      Alcotest.(check string)
+        "prior candidate snapshot is unchanged"
+        candidate_before
+        (Fs_compat.load_file candidate_path);
+      Alcotest.(check (option string))
+        "candidate blob is retained"
+        (Some "must survive exhausted scan budget")
+        (fetch_ok store ~sha256:blob.sha256))
+
 let test_maintenance_does_not_scan_repository_mirrors () =
   with_temp_dir (fun base_path ->
       let store = B.create ~base_path in
@@ -1002,6 +1049,10 @@ let () =
             "maintenance malformed reference fails closed"
             `Quick
             test_maintenance_malformed_reference_fails_closed;
+          Alcotest.test_case
+            "maintenance scan budget fails closed before deletion"
+            `Quick
+            test_maintenance_scan_budget_fails_closed_before_deletion;
           Alcotest.test_case
             "maintenance keeps wire-capture reference within retention"
             `Quick


### PR DESCRIPTION
## What changed

- add an optional monotonic elapsed-time budget to `Tool_blob_maintenance.run`
- check that budget at directory, file, and JSONL-row boundaries
- fail closed with typed `Scan_budget_exhausted` evidence before publishing a candidate snapshot or deleting any blob
- give startup blob maintenance half of the watchdog window remaining after persistence recovery
- add regression coverage proving an exhausted scan leaves both the prior candidate snapshot and candidate blob unchanged

## Root cause

The 2026-08-05 live startup completed Keeper transcript/request recovery, then spent the rest of the 240-second startup window in the synchronous tool-blob reference scan. The durable scan currently walks roughly 2.5 GiB across 2,518 files; `keepers` alone is about 974 MiB. Because the scan had no internal time budget, the watchdog exited the process while startup remained in `phase=blocking`.

The maintenance operation remains synchronous at the quiescent startup boundary. Moving it post-readiness would allow durable writers to race the two-complete-scan deletion contract, so this change bounds the scan cooperatively instead.

## Impact

A growing or resource-contended durable store can no longer consume the complete remaining readiness window. Budget exhaustion is observable and retains all blobs; a later complete startup scan can resume the existing two-scan retention policy.

## Validation

- `ocamlc -stop-after parsing` passed for the changed `.mli` and three changed `.ml` files
- `ocamlformat --check` passed for all changed OCaml files
- `git diff --check` passed against current `origin/main`
- focused Dune build was not executed: `scripts/dune-local.sh` refused three starts because unrelated bare Dune processes were active; the shared lock was not bypassed and those processes were not terminated
- draft CI is the build/test authority for this head
