### PR TITLE
chore(tool): 아무도 진단하지 않는 토큰 타임스탬프 제거

### DIFF
--- a/lib/tool/tool_dispatch.mli
+++ b/lib/tool/tool_dispatch.mli
@@ -27,8 +27,12 @@ val register_module : schemas:Masc_domain.tool_schema list -> handler:handler ->
    result transformation, and dispatch observer fan-out. *)
 
 val mint_token : name:string -> (Tool_token.t, string) Result.t
-(** Mint a [Tool_token.t] validated against static routes or the tag registry.
-    Thread-safe (protected by dispatch_mu). *)
+(** Mint a [Tool_token.t] whose name is present in the tag registry.
+    Thread-safe (protected by dispatch_mu).
+
+    Note the asymmetry: this checks [tag_registry] while [guarded_dispatch]
+    looks the handler up in [registry]. A name registered in one and not the
+    other mints a token that then dispatches to nothing. *)
 
 (** {2 Dispatch Hooks And Observers}
 

--- a/lib/tool/tool_token.ml
+++ b/lib/tool/tool_token.ml
@@ -19,11 +19,11 @@ module Float = Stdlib.Float
 
     See [tool_token.mli] for API documentation. *)
 
-type t = { name : string; minted_at : float }
+type t = { name : string }
 
 let mint_with ~validate ~name =
   if validate name then
-    Ok { name; minted_at = Unix.gettimeofday () }
+    Ok { name }
   else
     Error (Printf.sprintf "not in current tool set: %s" name)
 

--- a/lib/tool/tool_token.mli
+++ b/lib/tool/tool_token.mli
@@ -8,9 +8,10 @@
 
     Phase 1A of Tool Gate architecture (#4381). *)
 
-type t = private { name : string; minted_at : float }
-(** Immutable token. [name] is the validated tool name.
-    [minted_at] is [Unix.gettimeofday ()] at mint time (diagnostic). *)
+type t = private { name : string }
+(** Immutable token carrying the validated tool name. The [private] type is the
+    whole point: a value of this type cannot be fabricated, so holding one is
+    the proof that [mint_with]'s predicate accepted the name. *)
 
 val mint_with : validate:(string -> bool) -> name:string -> (t, string) Result.t
 (** [mint_with ~validate ~name] returns [Ok token] when [validate name] is

--- a/test/test_tool_token.ml
+++ b/test/test_tool_token.ml
@@ -40,8 +40,7 @@ let register_test_tool ~tool_name ~handler =
 let test_mint_success () =
   match Tool_token.mint_with ~validate:(Hashtbl.mem full_tbl) ~name:"masc_status" with
   | Ok token ->
-    check string "name preserved" "masc_status" token.name;
-    check bool "minted_at > 0" true (token.minted_at > 0.0)
+    check string "name preserved" "masc_status" token.name
   | Error e -> fail e
 
 let test_mint_failure () =
@@ -80,16 +79,13 @@ let test_token_name_readable () =
   match Tool_token.mint_with ~validate:(Hashtbl.mem full_tbl) ~name:"masc_heartbeat" with
   | Ok token ->
     (* Private type: fields are readable *)
-    check string "name field" "masc_heartbeat" token.name;
-    check bool "minted_at is recent" true
-      (token.minted_at > 0.0 && token.minted_at <= Unix.gettimeofday () +. 1.0)
+    check string "name field" "masc_heartbeat" token.name
   | Error e -> fail e
 
-(* Private type: { name = "fake"; minted_at = 0. } would be a compile error.
-   This is a structural guarantee, not a runtime test.
-   Uncomment below to verify:
+(* Private type: { name = "fake" } would be a compile error. This is a
+   structural guarantee, not a runtime test. Uncomment below to verify:
 
-   let _compile_error = { Tool_token.name = "fake"; minted_at = 0. }
+   let _compile_error = { Tool_token.name = "fake" }
 *)
 
 (* ================================================================ *)


### PR DESCRIPTION
## 무엇을

`Tool_token.t` 의 `minted_at` 필드와 `tool_dispatch.mli` 의 유령 문구를 제거합니다.

## `minted_at` — 자기 존재를 검증하는 폐회로

`.mli` 가 `"[minted_at] is [Unix.gettimeofday ()] at mint time (diagnostic)"` 라고 적었습니다. 진단하는 곳이 없습니다:

```
grep -rn 'minted_at' lib/ bin/ test/
  → 생성자, .mli 문장, 그리고 test_tool_token 의 단정 2건
```

그 단정 2건은 **`> 0.0` 이고 미래가 아님** 을 검사합니다. 즉 **읽고 있는 필드가 존재한다는 것을 검증** 합니다. #26917 에서 `record_gate_decision` 주변에 있던 `test_gate_decision_shape` 와 같은 폐회로입니다.

그리고 디스패치마다 `gettimeofday` 를 한 번씩 호출해 채웁니다.

## 토큰의 요점은 남습니다

```ocaml
type t = private { name : string }
```

`private` 이라 조작할 수 없고, 값을 들고 있다는 사실 자체가 "`mint_with` 의 술어가 이 이름을 받아들였다" 의 증거입니다. 테스트의 컴파일 에러 주석도 그대로 그것을 보여줍니다.

## 유령 문구

`tool_dispatch.mli` 가 `mint_token` 을 *"validated against **static routes** or the tag registry"* 라고 설명하는데, **`static routes` 라는 표현이 저장소의 그 한 줄에만 존재** 합니다. 구현은 `tag_registry` 만 봅니다.

## 그 문구가 가리고 있던 비대칭

```ocaml
:299  mint_token       → Hashtbl.mem tag_registry n
:211  guarded_dispatch → Hashtbl.find_opt registry name
```

**민팅은 `tag_registry` 를 검사하고 디스패치는 `registry` 를 조회합니다.** 다른 테이블입니다. 한쪽에만 등록된 이름은 토큰이 정상 발급되고 디스패치에서 아무 데도 닿지 않습니다 — **증명이 정작 필요한 명제를 덮지 않습니다.**

이걸 고치려면 "토큰이 무엇을 증명해야 하고 무엇을 실어 날라야 하는가" 를 정해야 합니다(관련: `surface_of_tool_name` 이 같은 이름을 문자열 접두사로 재분류하는 것도 이 결정에 딸립니다). 그래서 **바꾸지 않고 `.mli` 에 기록만** 했습니다.

## 검증

`test_tool_token` 9/9 통과, `lib/masc.cma` 빌드 통과.

RFC-WAIVED: credential / identity / operator control action handler / keeper sandbox / hooks 어디에도 해당하지 않습니다. 읽히지 않는 필드와 거짓 문구를 제거하고 실제 동작은 바꾸지 않습니다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>