### PR TITLE
refactor: 생산자 없는 session 시대 필드 처단 (blocked_sessions / active_sessions)

### DIFF
--- a/dashboard/src/components/fleet-telemetry-panel.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.test.ts
@@ -99,7 +99,6 @@ const namespaceTruthResponse: DashboardNamespaceTruthResponse = {
   root: {},
   execution: {
     summary: {
-      active_sessions: 2,
       active_operations: 4,
       continuity_alerts: 1,
     },

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -166,8 +166,6 @@ export function normalizeExecutionTone(value: unknown): DashboardExecutionQueueI
 export function normalizeExecutionSummary(raw: unknown): DashboardExecutionSummary | null {
   if (!isRecord(raw)) return null
   return {
-    active_sessions: asNumber(raw.active_sessions),
-    blocked_sessions: asNumber(raw.blocked_sessions),
     active_operations: asNumber(raw.active_operations),
     blocked_operations: asNumber(raw.blocked_operations),
     runtime_pressure: asNumber(raw.runtime_pressure),

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -463,8 +463,10 @@ type DashboardExecutionContinuityState = 'healthy' | 'warning' | 'critical'
 type DashboardExecutionQueueKind = 'operation' | 'keeper'
 
 export interface DashboardExecutionSummary {
-  active_sessions?: number
-  blocked_sessions?: number
+  // `active_sessions` / `blocked_sessions` were the session-era pair, replaced
+  // by the `*_operations` fields below. Their producers went with the team
+  // session surfaces in #6363, so both had been permanently absent from every
+  // response since — declared, normalized, and never populated.
   active_operations?: number
   blocked_operations?: number
   runtime_pressure?: number

--- a/lib/server/server_dashboard_http_namespace_truth_support.ml
+++ b/lib/server/server_dashboard_http_namespace_truth_support.ml
@@ -139,32 +139,33 @@ let execution_summary_json execution_json =
   in
   let execution_keepers = json_list_field "keepers" execution_json |> take_n 20 in
   let has_text key json = json_string_field_opt key json |> Option.is_some in
-  let existing = json_assoc_field "summary" execution_json in
-  match Json_util.assoc_member_opt "blocked_sessions" existing with
-  | Some (`Int _ | `Intlit _) -> existing
-  | _ ->
-      `Assoc
-        [
-          ("active_operations", `Int (List.length execution_operation_briefs));
-          ( "blocked_operations",
-            `Int
-              (count_where execution_operation_briefs (has_text "blocker_summary"))
-          );
-          ( "worker_alerts",
-            `Int
-              (count_where execution_worker_support (fun row ->
-                   match json_string_field_opt "tone" row with
-                   | Some "warn" | Some "bad" -> true
-                   | _ -> false)) );
-          ( "continuity_alerts",
-            `Int
-              (count_where execution_continuity (fun row ->
-                   match json_string_field_opt "tone" row with
-                   | Some "warn" | Some "bad" -> true
-                   | _ -> false)) );
-          ("priority_items", `Int (List.length execution_queue));
-          ("keepers", `Int (List.length execution_keepers));
-        ]
+  (* This summary is always derived here. A pass-through arm used to return an
+     upstream [summary] whose [blocked_sessions] count was already an int, but
+     the team-session surfaces that produced that field were removed in #6363
+     and no producer has written it since — the arm could not be reached, so the
+     derivation below already ran on every request. Keeping the arm advertised a
+     pass-through path that does not exist. *)
+  `Assoc
+    [
+      ("active_operations", `Int (List.length execution_operation_briefs));
+      ( "blocked_operations",
+        `Int (count_where execution_operation_briefs (has_text "blocker_summary"))
+      );
+      ( "worker_alerts",
+        `Int
+          (count_where execution_worker_support (fun row ->
+               match json_string_field_opt "tone" row with
+               | Some "warn" | Some "bad" -> true
+               | _ -> false)) );
+      ( "continuity_alerts",
+        `Int
+          (count_where execution_continuity (fun row ->
+               match json_string_field_opt "tone" row with
+               | Some "warn" | Some "bad" -> true
+               | _ -> false)) );
+      ("priority_items", `Int (List.length execution_queue));
+      ("keepers", `Int (List.length execution_keepers));
+    ]
 
 let namespace_truth_dashboard_surface = "/api/v1/dashboard/namespace-truth"
 let namespace_truth_source = "namespace_truth_read_model"


### PR DESCRIPTION
## 무엇

`blocked_sessions` / `active_sessions` — **생산자가 없는데 세 곳이 읽고 있던 필드**를 처단한다. 동작 변화 없음.

## 근거

두 필드는 `#6363 refactor: remove remaining team session surfaces`에서 제거된 team session 개념의 잔재다. 그 뒤로 이 저장소 어디에서도 쓰이지 않았고, 대체물은 `active_operations` / `blocked_operations`다.

그런데 소비자 셋이 죽은 이름을 계속 읽고 있었다:

| 위치 | 하던 일 | 실제 |
|---|---|---|
| `server_dashboard_http_namespace_truth_support.ml` | `summary.blocked_sessions`가 int면 상류 summary를 통과시킴 | **도달 불가** — 아래 재구성이 매 요청 실행 |
| `types/dashboard-execution.ts` | 두 필드를 optional로 선언 | 항상 부재 |
| `store-normalizers.ts` | 두 필드를 정규화 | 항상 `undefined` |

컴포넌트에서 두 필드를 읽는 곳은 0건이라 화면에 그려진 적은 없다. OCaml 분기는 도달 불가였고 TS 필드는 항상 undefined였으므로 **동작은 그대로**다.

가드를 남겨두면 존재하지 않는 pass-through 경로가 있는 것처럼 읽힌다.

## 어떻게 찾았나

소비자가 읽는 JSON 필드 이름 중 생산자가 아무도 쓰지 않는 것을 스캔했다.

```
소비자 field read 238 · 생산자 field write 3563
생산자 없는 read      36
```

36건 중 **35건은 위양성**이었다 — 제 정규식이 놓친 형태로 생산되거나(23건은 라이브 데이터에 실제 존재), 영속되지 않는 HTTP 응답에만 사는 값들이었다. 저장소 전체에 생산자가 **한 곳도 없는** 것은 이 한 쌍뿐이다.

> 스캔 중 계측기가 한 번 저를 속였다. `rg '"evaluator_runtime"'`가 0건을 냈는데, 그 값은 JSON 안에 문자열로 박힌 JSON이라 `\"`로 이스케이프돼 있었다(plain=0 / escaped=1345). 최상위 필드로만 positive control을 잡아서 그 인코딩을 못 걸렀다. 이스케이프까지 처리해 다시 돌린 결과가 위 숫자다.

## 로컬 검증

```
dune build --root . @all                             EXIT=0
tsc --noEmit                                         EXIT=0
fleet-telemetry-panel + store-normalizers            38/38
check-determinism-contract                           EXIT=0
check-silent-failure-patterns                        EXIT=0
check-pr-hygiene                                     EXIT=0
```

`fleet-telemetry-panel.test.ts`의 fixture가 `active_sessions: 2`를 넣고 있었으나 단언하지는 않았다 — 타입에서 제거하면 타입 에러가 되므로 함께 지웠다.

RFC-WAIVED: 죽은 필드 제거이며 계약·동작 변화가 없다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
