### PR TITLE
feat(verification): verdict 투영에 판정한 런타임을 싣는다 (RFC-0361 D3, 축소)

### DIFF
--- a/lib/completion_authority_agent.ml
+++ b/lib/completion_authority_agent.ml
@@ -404,6 +404,7 @@ let commit_verdict
       ~notes
       ~verdict_label
       ~on_commit
+      ~(evaluator_runtime : string option)
   =
   match
     Workspace.commit_verdict_r
@@ -413,6 +414,7 @@ let commit_verdict
       ~task_id:task.id
       ~verification_id
       ~notes
+      ?evaluator_runtime
       ()
   with
   | Ok _ ->
@@ -493,7 +495,10 @@ let process_task_once
            ~notes:rejection_reason
            ~verdict_label:"rejected_contract"
            ~on_commit:
-             (Verification_run_registry.Contract_rejected { detail = reason }))
+             (Verification_run_registry.Contract_rejected { detail = reason })
+             (* The evidence contract was rejected before any evaluator ran, so
+                this verdict has no judging runtime to name. *)
+           ~evaluator_runtime:None)
     | Ok prepared ->
       let result =
         Task.Anti_rationalization.review
@@ -548,7 +553,8 @@ let process_task_once
               ~notes
               ~verdict_label:
                 (Task.Anti_rationalization.verdict_constructor_name review_verdict)
-              ~on_commit))
+              ~on_commit
+              ~evaluator_runtime:(Some evaluator_runtime)))
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->

--- a/lib/workspace/workspace_task.mli
+++ b/lib/workspace/workspace_task.mli
@@ -55,7 +55,13 @@ val transition_task_outcome_r :
     Separate from {!transition_task_outcome_r} because a verdict is not an agent
     action. The caller must authenticate or otherwise validate the authority
     before constructing its provenance value. This is the only path that
-    resolves an [AwaitingVerification] obligation. *)
+    resolves an [AwaitingVerification] obligation.
+
+    [evaluator_runtime] names the configured runtime that produced the verdict,
+    and lands in every structured projection alongside the authority identity.
+    The authority actor is a fresh id per review and so groups nothing; the
+    runtime key is what a verdict history can be aggregated on. Omit it for a
+    human operator verdict, where no evaluator ran. *)
 val commit_verdict_r :
   config ->
   authority:Masc_domain.completion_authority ->
@@ -63,6 +69,7 @@ val commit_verdict_r :
   task_id:string ->
   verification_id:string ->
   ?notes:string ->
+  ?evaluator_runtime:string ->
   unit ->
   transition_outcome Masc_domain.masc_result
 

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -769,6 +769,7 @@ let commit_verdict_r
       ~task_id
       ~verification_id
       ?(notes = "")
+      ?evaluator_runtime
       ()
   : transition_outcome Masc_domain.masc_result
   =
@@ -941,6 +942,18 @@ let commit_verdict_r
              | Masc_domain.Verdict_approved -> Event_kind.Task.Approved
              | Masc_domain.Verdict_rejected _ -> Event_kind.Task.Rejected
            in
+           (* [authority_actor] is a fresh id per review, so it identifies the
+              run and nothing else — grouping 74 verdicts by it yields 74 groups.
+              [evaluator_runtime] is the config key that bound the provider and
+              model which judged, so it is the axis a verdict history can
+              actually be aggregated on. It was already computed and carried in
+              the review notes blob; every structured projection dropped it.
+              [None] for a human operator verdict, where no evaluator ran. *)
+           let evaluator_runtime_field =
+             match evaluator_runtime with
+             | None -> []
+             | Some runtime -> [ "evaluator_runtime", `String runtime ]
+           in
            let authority_fields =
              [ "task_id", `String task_id
              ; "authority_kind", `String authority_kind
@@ -948,6 +961,7 @@ let commit_verdict_r
              ; "producer", `String producer
              ; "verification_id", `String verification_id
              ]
+             @ evaluator_runtime_field
            in
            (* The task status deliberately stays a small lifecycle sum: a
               rejection returns the producer to [InProgress]. Keep the

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -999,6 +999,82 @@ let test_rejected_verdict_audit_preserves_reason () =
         "system_llm_agent"
         (json |> member "authority_kind" |> to_string))
 
+(* The judging runtime is the only axis a verdict history can be grouped on:
+   [authority_actor] is minted fresh per review, so 74 verdicts carry 74 distinct
+   actors. The runtime was already computed and carried inside the review notes
+   blob, but every structured projection dropped it. *)
+let test_verdict_audit_names_the_judging_runtime () =
+  with_eio_temp_dir (fun base_path ->
+    let config = W.default_config base_path in
+    ignore (W.init config ~agent_name:(Some "runtime-producer"));
+    ignore
+      (W.add_task
+         config
+         ~title:"name the judging runtime"
+         ~priority:1
+         ~description:"the durable audit must say which runtime judged");
+    let backlog = W.read_backlog config in
+    let tasks =
+      List.map
+        (fun (task : Masc_domain.task) ->
+           if String.equal task.id "task-001"
+           then
+             { task with
+               task_status =
+                 Masc_domain.AwaitingVerification
+                   { assignee = "runtime-producer"
+                   ; started_at = "2026-08-05T00:00:00Z"
+                   ; submitted_at = Masc_domain.now_iso ()
+                   ; verification_id = "vrf-runtime-named"
+                   }
+             }
+           else task)
+        backlog.tasks
+    in
+    W.write_backlog config { backlog with tasks };
+    (match
+       W.commit_verdict_r
+         config
+         ~authority:
+           (Masc_domain.System_llm_agent { agent_run_id = "system-runtime-agent" })
+         ~verdict:Masc_domain.Verdict_approved
+         ~task_id:"task-001"
+         ~verification_id:"vrf-runtime-named"
+         ~evaluator_runtime:"cross-verifier-model"
+         ()
+     with
+     | Error error -> Alcotest.fail (Masc_domain.masc_error_to_string error)
+     | Ok _ -> ());
+    let open Unix in
+    let tm = gmtime (gettimeofday ()) in
+    let month = Printf.sprintf "%04d-%02d" (tm.tm_year + 1900) (tm.tm_mon + 1) in
+    let day = Printf.sprintf "%02d.jsonl" tm.tm_mday in
+    let events_dir = Filename.concat (CU.masc_dir_from_base_path ~base_path) "events" in
+    let event_path = Filename.concat (Filename.concat events_dir month) day in
+    let event =
+      Fs_compat.load_jsonl event_path
+      |> List.find_opt (fun json ->
+        match json with
+        | `Assoc fields ->
+          (match List.assoc_opt "type" fields with
+           | Some (`String value) -> String.equal value "task_completion_verdict"
+           | _ -> false)
+        | _ -> false)
+    in
+    match event with
+    | None -> Alcotest.fail "verdict audit event was not persisted"
+    | Some json ->
+      let open Yojson.Safe.Util in
+      Alcotest.(check string)
+        "audit names the runtime that judged"
+        "cross-verifier-model"
+        (json |> member "evaluator_runtime" |> to_string);
+      Alcotest.(check string)
+        "audit still carries the run-scoped actor"
+        "system-runtime-agent"
+        (json |> member "authority_actor" |> to_string))
+;;
+
 let test_raw_workspace_submission_notifies_once () =
   with_eio_temp_dir (fun base_path ->
     Masc.Workspace_metric_hooks.install ();
@@ -1985,6 +2061,8 @@ let () =
         test_system_llm_agent_uses_persisted_request_contract_snapshot;
       Alcotest.test_case "rejected verdict audit keeps reason" `Quick
         test_rejected_verdict_audit_preserves_reason;
+      Alcotest.test_case "verdict audit names the judging runtime" `Quick
+        test_verdict_audit_names_the_judging_runtime;
     ];
     "workspace_boundary", [
       Alcotest.test_case "raw submit notifies once" `Quick


### PR DESCRIPTION
## 무엇

verdict 투영에 **판정한 런타임 이름**을 싣는다. RFC-0361 3단계(축소된 형태).

> **Base: `feat/verification-run-registry`** (#26931). diff는 이 변경만 보인다.

Refs #26914, #26915.

## 왜

구조화된 verdict 투영은 `authority_kind` · `authority_actor` · `producer` · `verification_id`를 나르지만 **누가 판정했는지**는 안 나른다.

```
durable task_completion_verdict 이벤트   144건
distinct authority_actor                 144
2건 이상 판정한 actor                       0
```

actor는 판정마다 새로 만들어지므로 **run을 식별할 뿐 아무것도 묶지 못합니다.** verdict 이력을 집계할 축이 없었다.

그런데 그 축은 이미 계산되고 있었다 — `review_notes`가 `evaluator_runtime`을 JSON으로 만들어 notes 블롭에 넣는다. `authority_fields`가 그냥 빠뜨려서, task_activity payload와 durable 이벤트 **양쪽**에서 사라졌다.

## 무엇을 했나

`commit_verdict_r`에 `?evaluator_runtime`을 추가하고 authority identity 옆에 싣는다. 그 파일이 이미 선언한 자리다:

> Authority provenance is recorded here as structured fields. It is deliberately NOT written into `Done.notes` ... nothing parsed it.

호출 측은 `string option` **필수 라벨**이다 — 증거 계약 거부 경로(LLM이 안 돌았음)가 침묵으로 흘러가지 않고 `None`을 명시해야 한다.

```ocaml
(* 판정된 verdict *)          ~evaluator_runtime:(Some evaluator_runtime)
(* 증거 계약 사전 거부 *)      ~evaluator_runtime:None
```

## RFC 대비 축소

RFC-0361 D3은 `System_llm_agent` variant에 `profile` 필드를 추가하자고 썼다. 실측해보니 **축은 이미 존재하고 투영에서만 버려지고 있었다.**

| | RFC 원안 | 실제 필요 |
|---|---|---|
| variant 변경 | O | **X** |
| `keeper_event_queue` decode 경로 | O | **X** |
| 레거시 이벤트 마이그레이션 | 고민 필요 | **불필요** |
| 새 개념 이름(`profile`) | 도입 | **불필요** — `evaluator_runtime`이 이미 `[runtime].cross_verifier`가 바인딩한 provider+model 키다 |

같은 문자열에 두 번째 이름을 붙이면 정보는 안 늘고 개념만 는다.

## 로컬 검증

```
dune build --root . @all                     EXIT=0
test_verification.exe                        42/42  (41 → +1)
test_verification_run_registry.exe            9/9
ocamlformat --check (변경 4파일)               전부 OK
check-determinism-contract                   EXIT=0
check-silent-failure-patterns                EXIT=0
check-enum-string-safety                     EXIT=0
check-actor-consumer-wired                   EXIT=0
check-pr-hygiene                             EXIT=0
```

**테스트가 실패할 능력 증명**: `authority_fields`에서 필드를 빼면 새 케이스가 `FAIL`, exit 1.

> 첫 주입 시도는 **컴파일이 안 됐고**(unused variable), 그래서 옛 바이너리가 돌아 "통과"로 보였다. 빌드 exit code를 확인하고 나서야 알았다. 두 번째 주입은 컴파일되고 정상적으로 실패한다. 결함 주입은 *컴파일된 뒤* 실패해야 증거다.

## 부재 케이스

기존 `test_rejected_verdict_audit_preserves_reason`이 이 인자 없이 `commit_verdict_r`를 호출하므로, 필드를 항상 싣도록 만들면 그 테스트가 깨진다 — 이미 통제 역할을 한다.

RFC-WAIVED: RFC-0361 (#26922) 이 설계 문서이며, 이 변경은 그 D3을 실측에 맞춰 축소한 것이다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
