### PR TITLE
fix(ci): preflight self-test 가 쓰려는 픽스처 디렉토리를 만들지 않는다 — 모든 PR 의 Build and Test 실패

### DIFF
--- a/scripts/check-runtime-deployment-preflight.sh
+++ b/scripts/check-runtime-deployment-preflight.sh
@@ -290,6 +290,10 @@ if [[ "$SELF_TEST" -eq 1 ]]; then
 
   malformed_current_root="$fixture_root/malformed-current"
   write_schedules "$malformed_current_root" running
+  # write_current_queue creates this directory; the malformed case writes the
+  # file directly and must create it too, or the redirect fails before the
+  # assertion it is setting up ever runs.
+  mkdir -p "$malformed_current_root/.masc/keepers/fixture"
   printf '{not-json\n' \
     >"$malformed_current_root/.masc/keepers/fixture/event-queue-v15.json"
   expect_failure malformed_current_queue "$malformed_current_root"


### PR DESCRIPTION
`Build and Test` 의 `Run runtime deployment preflight self-test` 스텝이 **main 에서 실패한다.** 이 스텝은 모든 PR 에서 돈다.

```
scripts/check-runtime-deployment-preflight.sh: line 293:
  .../malformed-current/.masc/keepers/fixture/event-queue-v15.json:
  No such file or directory
```

## 원인

`write_current_queue` 는 쓰기 전에 그 디렉토리를 `mkdir -p` 한다 (line 233).

malformed-current 케이스는 `write_current_queue` 를 **일부러 건너뛴다** — 정상 파일이 아니라 깨진 파일을 원하기 때문이다. 그래서 파일을 직접 쓰는데, `mkdir -p` 도 같이 건너뛴다. 리다이렉트가 **자기가 준비하려던 단언보다 먼저** 실패한다.

## 변경

`mkdir -p` 한 줄. 깨진 페이로드와 `expect_failure` 단언은 그대로다.

```
before   exit 1, "No such file or directory"
after    exit 0, "[runtime-deployment-preflight] self-test OK"
```

## 확인 과정 기록

처음엔 main 에서도 실패하는 것을 보고 "내 PR 과 무관"으로 넘겼는데, 그때의 실패는 **다른 원인**이었다 — `_build/default/bin/deployment_preflight_helper.exe` 를 로컬에서 빌드한 적이 없어서 헬퍼 부재로 죽은 것이다. 헬퍼를 빌드하고 다시 돌려서야 진짜 실패 지점이 나왔다.

결론은 우연히 같았지만 근거가 틀렸다. 로컬에서 CI 스크립트를 재현할 때 그 스크립트가 요구하는 빌드 산출물이 있는지부터 확인해야 한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
