### PR TITLE
fix(ci): preflight self-test가 쓰는 fixture 디렉토리를 만든다 (모든 PR의 Build and Test 차단 중)

### DIFF
--- a/scripts/check-runtime-deployment-preflight.sh
+++ b/scripts/check-runtime-deployment-preflight.sh
@@ -290,6 +290,10 @@ if [[ "$SELF_TEST" -eq 1 ]]; then
 
   malformed_current_root="$fixture_root/malformed-current"
   write_schedules "$malformed_current_root" running
+  # This case writes a corrupt snapshot with no valid one, so it cannot borrow
+  # the directory from write_current_queue the way malformed-current-wal does.
+  # The two malformed-wal cases below prepare it the same way.
+  mkdir -p "$malformed_current_root/.masc/keepers/fixture"
   printf '{not-json\n' \
     >"$malformed_current_root/.masc/keepers/fixture/event-queue-v15.json"
   expect_failure malformed_current_queue "$malformed_current_root"


### PR DESCRIPTION
## 무엇

`Build and Test`의 runtime deployment preflight self-test가 **모든 PR에서 실패**하고 있다. 한 줄 수정.

```
scripts/check-runtime-deployment-preflight.sh: line 293:
  .../malformed-current/.masc/keepers/fixture/event-queue-v15.json: No such file or directory
```

## 원인

`malformed-current` 케이스가 `.masc/keepers/fixture/`에 손상된 스냅샷을 쓰는데 그 디렉토리를 만들지 않는다. **형제 케이스 셋은 전부 준비한다:**

| 케이스 | 디렉토리 준비 |
|---|---|
| `current` | `write_current_queue` (내부에서 `mkdir -p`) |
| `malformed-current` | **없음** ← 이것 |
| `malformed-current-wal` | `write_current_queue` |
| `wal-only` | `mkdir -p` |
| `malformed-wal-only` | `mkdir -p` |

`malformed-current`는 "유효한 스냅샷 없이 손상된 것만"인 케이스라 `write_current_queue`를 빌려올 수 없다. 그래서 두 malformed-wal 케이스와 같은 방식(`mkdir -p`)으로 준비한다.

## 언제 깨졌나

```
b1e2fd6b5a refactor(runtime): hard-cut event queue deployment generations (#26919)
```

이 스크립트를 건드린 유일한 최근 커밋이다.

## 통제 실험

같은 워크트리·같은 헬퍼 바이너리로 `mkdir` 줄만 빼고 재실행:

```
mkdir 없음   EXIT=1   ← CI와 동일한 오류 메시지
mkdir 있음   EXIT=0   [runtime-deployment-preflight] self-test OK
```

## 영향

이 스텝은 `Build and Test` 안에 있어서, 실패하는 동안 어떤 PR도 그 required check를 통과할 수 없다. 확인된 것만 #26931 · #26963 두 건이 이 스텝으로 red였다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

## main 이 red 다 (추가 실측)

이 스텝은 PR 만 막는 게 아니라 **main 자체를 세워두고 있다.**

```
마지막 green main run   45aa18e09   2026-08-05T05:30:47Z
#26919 머지             2026-08-05T05:56:11Z
이후                    53회 연속 failure
```

최근 main 실행 30회를 표본으로 잡으면 **30/30 failure**이고, 확인한 세 건(`f9083a9fd` · `4cfe6f874` · `89c484a32`) 모두 실패 잡이 `Build and Test` + `CI Gate`이며 `Build and Test` 안의 실패 스텝은 예외 없이 `Run runtime deployment preflight self-test` 하나다.

`main은 항상 배포 가능한 상태를 유지한다`는 규칙 기준으로 4시간째 위반 상태다.

## red 보다 큰 문제: 뒤따르는 게이트가 통째로 skip 된다

실패는 `Build and Test` 의 **step 9 하나**인데, 그 실패가 뒤 스텝들을 건너뛰게 만든다. main 실행 세 건(`f9083a9fd` · `4cfe6f874` · `89c484a32`)에서 동일하게 관측된다 — `failure:1 / skipped:11~12 / success:36~37`, 실패는 항상 step 9.

skip 되는 검증:

```
10  Check keeper event queue projection boundary
11  Sublib boundary gate against real dune graph (RFC-0056 G1)
12  Runtime TOML validity gate
13  Run workspace backlog revision ratchet
14  Run MCP authentication contract suites
15  Run keeper lane launch-order AST suite
19  Env knob catalog drift gate
20  SSE TypeScript codegen drift gate
22  Run OAS pin behavior suite
```

05:56 이후 main 에 들어간 모든 머지가 이 9 개 계약을 **검증받지 않고** 착지했다. 초록 게이트가 커버리지가 아니듯, 건너뛴 게이트는 통과가 아니다.

이 PR 이 늦게 들어갈수록 무검증 머지가 쌓인다.
