### PR TITLE
refactor(keeper): 비교하는 곳이 없는 tool-diversity 임계값 제거

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -580,7 +580,6 @@ let run_keepalive_unified_turn
       in
       Keeper_tool_diversity.record_underused_tool_metrics
         ~keeper_name:meta_after_triage.name
-        ~available_tools
         tool_diversity_summary;
       let audit_wall_clock = Time_compat.now () in
       let tool_diversity_entropy =

--- a/lib/keeper/keeper_tool_diversity.ml
+++ b/lib/keeper/keeper_tool_diversity.ml
@@ -1,18 +1,14 @@
-(** Keeper_tool_diversity — Information-theoretic tool usage analysis.
+(** Keeper_tool_diversity — Shannon entropy of a keeper's tool usage.
 
-    Measures Shannon entropy of a keeper's tool usage distribution to detect
-    exploitation-only behavior (low entropy = same tools repeated).
-    When entropy falls below a threshold, generates a deterministic hint
-    that the LLM (non-deterministic layer) can use to explore new tools.
+    Two values leave this module, both as telemetry: the normalized entropy,
+    which the heartbeat loop writes into the keeper's decision audit record,
+    and the count of allowed tools the keeper has barely called, which is
+    published as a gauge. Nothing branches on either -- no turn is skipped,
+    no prompt is altered, no tool is offered or withheld because of them.
 
-    The boundary is strict:
-    - Deterministic: entropy calculation, threshold comparison, hint text
-    - Non-deterministic: LLM decides whether/how to act on the hint
-
-    Based on:
-    - Shannon (1948) entropy H = -Σ p(x) log2(p(x))
-    - Pathak et al. (2017) curiosity-driven exploration via intrinsic reward
-    - The max entropy for N tools is log2(N); we normalize to [0,1]
+    H = -Σ p(x) log2(p(x)) over the call counts; the maximum for N tools is
+    log2(N), so dividing by it puts the result in [0,1] where 1 is a
+    perfectly uniform spread.
 
     @since 2.258.0 *)
 
@@ -30,7 +26,6 @@ type diversity_summary = {
   entropy : float;
   normalized_entropy : float;  (** [0,1] where 1 = perfectly uniform *)
   underused_tools : string list;
-  overused_tools : string list;
 }
 
 (** Shannon entropy in bits from a list of counts.
@@ -63,15 +58,6 @@ let compute_diversity ~(available_tools : string list)
   let n_available = List.length available_tools in
   let raw_h = shannon_entropy counts in
   let norm_h = normalized_entropy ~n_categories:n_available raw_h in
-  (* Overused: tools with > 2x average share *)
-  let avg_share =
-    if n_available = 0 then 0.0
-    else Float.of_int total_calls /. Float.of_int n_available
-  in
-  let overused = stats
-    |> List.filter (fun s -> Float.of_int s.count > avg_share *. 2.0)
-    |> List.map (fun s -> s.name)
-  in
   (* Underused: available tools never called or called < 1% *)
   let module SS = Set_util.StringSet in
   let used_set =
@@ -87,9 +73,9 @@ let compute_diversity ~(available_tools : string list)
   in
   { total_calls; unique_tools; available_tools = n_available;
     entropy = raw_h; normalized_entropy = norm_h;
-    underused_tools = underused; overused_tools = overused }
+    underused_tools = underused }
 
-let record_underused_tool_metrics ~keeper_name ~available_tools:_ summary =
+let record_underused_tool_metrics ~keeper_name summary =
   let underused_tools =
     List.sort_uniq String.compare summary.underused_tools
   in
@@ -97,13 +83,6 @@ let record_underused_tool_metrics ~keeper_name ~available_tools:_ summary =
     Keeper_metrics.(to_string ToolUnderusedAllowedCount)
     ~labels:[ ("keeper", keeper_name) ]
     (float_of_int (List.length underused_tools))
-
-(** Default normalized entropy threshold.  Below this, the keeper is
-    considered to be in an exploitation-only pattern.
-    Empirical: a keeper using 5 of 25 tools at roughly equal rates
-    has normalized entropy ~0.43.  We set the threshold at 0.35 to
-    allow some specialization while catching extreme loops. *)
-let default_entropy_threshold = 0.35
 
 (** Convert in-memory tool_call_entry list (from Keeper_registry.tool_usage_of)
     into tool_stat list. This avoids file I/O and uses the live data. *)

--- a/lib/keeper/keeper_tool_diversity.mli
+++ b/lib/keeper/keeper_tool_diversity.mli
@@ -1,8 +1,8 @@
-(** Keeper_tool_diversity — Information-theoretic tool usage analysis.
+(** Keeper_tool_diversity — Shannon entropy of a keeper's tool usage.
 
-    Measures Shannon entropy of tool usage to detect exploitation-only
-    behavior.  Generates deterministic hints for the LLM to explore
-    underused tools.
+    Both outputs are telemetry: the normalized entropy reaches the keeper's
+    decision audit record, and the count of barely-called allowed tools is
+    published as a gauge. Nothing branches on either.
 
     @since 2.258.0 *)
 
@@ -18,18 +18,12 @@ type diversity_summary = {
   entropy : float;
   normalized_entropy : float;
   underused_tools : string list;
-  overused_tools : string list;
 }
 
 val shannon_entropy : int list -> float
 val normalized_entropy : n_categories:int -> float -> float
 val compute_diversity : available_tools:string list -> tool_stat list -> diversity_summary
-val record_underused_tool_metrics :
-  keeper_name:string ->
-  available_tools:string list ->
-  diversity_summary ->
-  unit
+val record_underused_tool_metrics : keeper_name:string -> diversity_summary -> unit
 (** Emit the aggregate underused-tool count. Per-tool heartbeat gauges are
     intentionally avoided to keep OTel series cardinality bounded by keeper. *)
-val default_entropy_threshold : float
 val stats_of_registry_entries : (string * Keeper_types.tool_call_entry) list -> tool_stat list

--- a/test/test_tool_diversity.ml
+++ b/test/test_tool_diversity.ml
@@ -58,8 +58,7 @@ let test_underused_tool_metrics_record_aggregate_count () =
   in
   check int "summary underused count" 1
     (List.length summary.underused_tools);
-  Masc.Keeper_tool_diversity.record_underused_tool_metrics
-    ~keeper_name ~available_tools summary;
+  Masc.Keeper_tool_diversity.record_underused_tool_metrics ~keeper_name summary;
   check (float 0.001) "one underused allowed tool" 1.0
     (Masc.Otel_metric_store.metric_value_or_zero
        Keeper_metrics.(to_string ToolUnderusedAllowedCount)


### PR DESCRIPTION
## 문제

`Keeper_tool_diversity` 의 헤더가 구현하지 않는 계약을 기술한다.

> When entropy falls below a threshold, generates a deterministic hint that the LLM (non-deterministic layer) can use to explore new tools.
>
> - Deterministic: entropy calculation, **threshold comparison, hint text**

힌트 텍스트는 저장소 어디에도 없고, `default_entropy_threshold` 를 읽는 코드도 없다. 프롬프트를 만드는 지점은 명시적으로 다른 말을 한다 (`keeper_unified_turn.ml:538`):

```
(* 2. Build unified prompt — diversity entropy recorded in decision_audit
   (keeper_keepalive.ml), not injected into prompt (...). *)
```

## 실제로 하는 일

두 값이 나가고 둘 다 텔레메트리다.

| 값 | 도착지 | 분기 |
|---|---|---|
| `normalized_entropy` | heartbeat loop → `Keeper_decision_audit` 레코드 | 없음 |
| `underused_tools` 개수 | `ToolUnderusedAllowedCount` 게이지 | 없음 |

턴이 건너뛰어지지도, 프롬프트가 바뀌지도, 도구가 더/덜 제공되지도 않는다. 헤더를 그대로 기술하도록 고쳤다.

## 제거

- **`default_entropy_threshold = 0.35`** — 읽는 곳 0건. docstring 은 이 숫자에 "경험적" 근거("5/25 도구를 균등하게 쓰면 정규화 엔트로피 ~0.43")까지 붙여두었지만 비교하는 코드가 없다.
- **`overused_tools`** — `평균 점유율 × 2` 규칙으로 계산해서 레코드에 넣지만 읽는 곳 0건 (모듈 내부 포함).
- **`record_underused_tool_metrics ~available_tools`** — 함수 본문이 `~available_tools:_` 로 버린다. 호출자 2곳이 리스트를 만들어 넘기고 버려졌다. 시그니처에서 제거.

`shannon_entropy`, `normalized_entropy`, `compute_diversity`, `stats_of_registry_entries` 는 그대로다. 텔레메트리 두 값도 그대로 나간다 — 게이지는 외부에서 스크랩될 수 있으므로 건드리지 않았다.

## 검증

- `dune build --root . @check` EXIT=0
- `test_tool_diversity` 9/9 (QCheck 포함)
- `scripts/check-doc-code-refs.sh`, `scripts/audit-keeper-tool-boundary-matrix.sh` PASS

RFC-WAIVED: 읽는 곳이 없는 상수/필드/인자 제거와 헤더 정정. credential/identity, repo_manager, operator control plane, keeper sandbox, dashboard credential component, hooks, workflow 문서 중 어느 것도 건드리지 않는다. 나가는 메트릭과 감사 필드의 값은 변하지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
