### PR TITLE
fix(tool): library confidence 가 없거나 숫자가 아니면 거부한다 (0.7 기본값이 리뷰를 건너뛰었다)

### DIFF
--- a/lib/tool_library.ml
+++ b/lib/tool_library.ml
@@ -194,12 +194,21 @@ type confidence_read =
   | Confidence of float
   | Confidence_absent
   | Confidence_not_a_number
+  | Confidence_out_of_range
+
+let confidence_in_range value =
+  Float.is_finite value
+  && Stdlib.Float.compare value 0.0 >= 0
+  && Stdlib.Float.compare value 1.0 <= 0
 
 let read_confidence args =
   match Json_util.assoc_member_opt "confidence" args with
   | None | Some `Null -> Confidence_absent
-  | Some (`Float value) -> Confidence value
-  | Some (`Int value) -> Confidence (Float.of_int value)
+  | Some (`Float value) ->
+    if confidence_in_range value then Confidence value else Confidence_out_of_range
+  | Some (`Int value) ->
+    let value = Float.of_int value in
+    if confidence_in_range value then Confidence value else Confidence_out_of_range
   | Some _ -> Confidence_not_a_number
 
 (* Free-form library content remains opaque text. *)
@@ -312,7 +321,7 @@ let handle_add ~tool_name ~start_time ctx args : Tool_result.result =
     | Some _ -> begin
       match read_confidence args with
       | Confidence_absent -> missing_required ~tool_name ~start_time "confidence"
-      | Confidence_not_a_number ->
+      | Confidence_not_a_number | Confidence_out_of_range ->
         workflow_err ~tool_name ~start_time
           "confidence must be a number between 0.0 and 1.0"
       | Confidence confidence -> begin
@@ -375,7 +384,7 @@ let handle_promote ~tool_name ~start_time ctx args : Tool_result.result =
   else
     match read_confidence args with
     | Confidence_absent -> missing_required ~tool_name ~start_time "confidence"
-    | Confidence_not_a_number ->
+    | Confidence_not_a_number | Confidence_out_of_range ->
       workflow_err ~tool_name ~start_time
         "confidence must be a number between 0.0 and 1.0"
     | Confidence new_confidence

--- a/lib/tool_library.ml
+++ b/lib/tool_library.ml
@@ -185,6 +185,23 @@ let query_required ~tool_name ~start_time =
 let missing_required ~tool_name ~start_time field =
   workflow_err ~tool_name ~start_time (sprintf "%s is required" field)
 
+(* [confidence] decides whether a document is filed for review or published
+   straight into the library, and both schemas mark it required. Reading it
+   with a default would put an omitted field, an explicit null and a
+   non-number on the same value, and every one of those defaults landed on
+   the publishing side of the threshold. *)
+type confidence_read =
+  | Confidence of float
+  | Confidence_absent
+  | Confidence_not_a_number
+
+let read_confidence args =
+  match Json_util.assoc_member_opt "confidence" args with
+  | None | Some `Null -> Confidence_absent
+  | Some (`Float value) -> Confidence value
+  | Some (`Int value) -> Confidence (Float.of_int value)
+  | Some _ -> Confidence_not_a_number
+
 (* Free-form library content remains opaque text. *)
 let text_ok ~tool_name ~start_time body : Tool_result.result =
   Tool_result.ok ~tool_name ~start_time body
@@ -276,7 +293,6 @@ let handle_read ~tool_name ~start_time _ctx args : Tool_result.result =
 let handle_add ~tool_name ~start_time ctx args : Tool_result.result =
   let title = Json_util.get_string args "title" |> Option.value ~default:"" in
   let source = Json_util.get_string args "source" |> Option.value ~default:"direct_experience" in
-  let confidence = Json_util.get_float args "confidence" |> Option.value ~default:0.7 in
   let tags = Json_util.get_string_list args "tags" in
   let content = Json_util.get_string args "content" |> Option.value ~default:"" in
 
@@ -294,6 +310,12 @@ let handle_add ~tool_name ~start_time ctx args : Tool_result.result =
        (sprintf "Invalid source. Must be one of: %s"
          (String.concat ", " valid_source_strings))
     | Some _ -> begin
+      match read_confidence args with
+      | Confidence_absent -> missing_required ~tool_name ~start_time "confidence"
+      | Confidence_not_a_number ->
+        workflow_err ~tool_name ~start_time
+          "confidence must be a number between 0.0 and 1.0"
+      | Confidence confidence -> begin
       (* Determine destination based on confidence *)
       let dest_dir = if Stdlib.Float.compare confidence library_confidence_threshold < 0 then candidates_dir () else library_root () in
       let date = Time_compat.now () |> Unix.localtime in
@@ -328,7 +350,11 @@ verified_by: []
       (* Write file *)
       try
         Out_channel.with_open_text filepath (fun oc -> Out_channel.output_string oc full_content);
-        let status = if Stdlib.Float.compare confidence 0.5 < 0 then "candidate (needs verification)" else "library" in
+        let status =
+          if Stdlib.Float.compare confidence library_confidence_threshold < 0
+          then "candidate (needs verification)"
+          else "library"
+        in
         text_ok ~tool_name ~start_time
           (sprintf "Document added to %s: %s" status filepath)
       with
@@ -339,19 +365,24 @@ verified_by: []
                (Tool_error.to_string (Tool_error.of_exn exn)))
     end
   end
+  end
 
 (* Promote candidate to library *)
 let handle_promote ~tool_name ~start_time ctx args : Tool_result.result =
   let topic = Json_util.get_string args "topic"
     |> Option.value ~default:"" in
-  let new_confidence = Json_util.get_float args "confidence"
-    |> Option.value ~default:0.7 in
-
   if String.equal topic "" then topic_required ~tool_name ~start_time
-  else if Stdlib.Float.compare new_confidence 0.5 < 0 then
-    workflow_err ~tool_name ~start_time
-      "confidence must be >= 0.5 to promote"
-  else begin
+  else
+    match read_confidence args with
+    | Confidence_absent -> missing_required ~tool_name ~start_time "confidence"
+    | Confidence_not_a_number ->
+      workflow_err ~tool_name ~start_time
+        "confidence must be a number between 0.0 and 1.0"
+    | Confidence new_confidence
+      when Stdlib.Float.compare new_confidence library_confidence_threshold < 0 ->
+      workflow_err ~tool_name ~start_time
+        (sprintf "confidence must be >= %.1f to promote" library_confidence_threshold)
+    | Confidence new_confidence -> begin
     let topic_lower = String.lowercase_ascii topic in
     let candidates = list_documents ~include_candidates:true () |> List.filter (fun f ->
       string_contains ~needle:"/candidates/" f &&
@@ -440,7 +471,11 @@ let tool_definitions = [
   ("masc_library_read", {|Read a specific library document by topic name.|}, [
     ("topic", "string", true, "Topic name or partial match (e.g., 'eio-mutex')");
   ]);
-  ("masc_library_add", {|Add a new document to the library. Documents with confidence < 0.5 go to candidates/.|}, [
+  ("masc_library_add",
+   sprintf
+     "Add a new document to the library. Documents with confidence < %.1f go to candidates/."
+     library_confidence_threshold,
+   [
     ("title", "string", true, "Document title");
     ("source", "string", true,
      sprintf "Source type: %s" (String.concat ", " valid_source_strings));
@@ -450,7 +485,8 @@ let tool_definitions = [
   ]);
   ("masc_library_promote", {|Promote a candidate document to the main library after verification.|}, [
     ("topic", "string", true, "Topic name to promote");
-    ("confidence", "number", true, "New confidence score (must be >= 0.5)");
+    ("confidence", "number", true,
+     sprintf "New confidence score (must be >= %.1f)" library_confidence_threshold);
   ]);
   ("masc_library_search", {|Search library documents by content or tags.|}, [
     ("query", "string", false, "Search query; empty or missing returns a workflow error");

--- a/test/test_tool_library_coverage.ml
+++ b/test/test_tool_library_coverage.ml
@@ -202,6 +202,7 @@ let test_read_by_title_case_insensitive_partial () =
     let _ = dispatch_exn ctx ~name:"masc_library_add" ~args:(`Assoc [
       ("title", `String "Root Cause: Orphan Count Analysis");
       ("content", `String "details about orphan counting");
+      ("confidence", `Float 0.9);
     ]) in
     let read_args = `Assoc [("topic", `String "root cause: orphan count")] in
     let (ok, _) = dispatch_exn ctx ~name:"masc_library_read" ~args:read_args in
@@ -215,6 +216,7 @@ let test_read_by_slug_still_works () =
     let _ = dispatch_exn ctx ~name:"masc_library_add" ~args:(`Assoc [
       ("title", `String "Slug Query Doc");
       ("content", `String "slug body");
+      ("confidence", `Float 0.9);
     ]) in
     let read_args = `Assoc [("topic", `String "slug-query")] in
     let (ok, _) = dispatch_exn ctx ~name:"masc_library_read" ~args:read_args in
@@ -278,11 +280,87 @@ let test_add_low_confidence () =
     Alcotest.(check bool) "response confirms add" true (msg_contains ~needle:"added" msg || msg_contains ~needle:"success" msg || msg_contains ~needle:"librar" msg)
   )
 
+(* [confidence] is required by both schemas and decides whether the document
+   is filed for review or published straight into the library. Reading it with
+   a default put an omitted field, an explicit null and a non-number on the
+   same value, and that value was on the publishing side of the threshold. *)
+let test_add_rejects_absent_confidence () =
+  with_temp_base_path (fun ctx ->
+    let args = `Assoc [
+      ("title", `String "unscored knowledge");
+      ("content", `String "No confidence supplied.");
+    ] in
+    let (ok, msg) = dispatch_exn ctx ~name:"masc_library_add" ~args in
+    Alcotest.(check bool) "absent confidence is rejected" false ok;
+    Alcotest.(check bool) "error names the field" true
+      (msg_contains ~needle:"confidence" msg)
+  )
+
+let test_add_rejects_null_confidence () =
+  with_temp_base_path (fun ctx ->
+    let args = `Assoc [
+      ("title", `String "null scored knowledge");
+      ("content", `String "Explicit null.");
+      ("confidence", `Null);
+    ] in
+    let (ok, msg) = dispatch_exn ctx ~name:"masc_library_add" ~args in
+    Alcotest.(check bool) "null confidence is rejected" false ok;
+    Alcotest.(check bool) "error names the field" true
+      (msg_contains ~needle:"confidence" msg)
+  )
+
+let test_add_rejects_non_numeric_confidence () =
+  with_temp_base_path (fun ctx ->
+    List.iter
+      (fun (label, value) ->
+        let args = `Assoc [
+          ("title", `String ("badly scored " ^ label));
+          ("content", `String "Confidence is not a number.");
+          ("confidence", value);
+        ] in
+        let (ok, msg) = dispatch_exn ctx ~name:"masc_library_add" ~args in
+        Alcotest.(check bool) (label ^ " is rejected") false ok;
+        Alcotest.(check bool) (label ^ " error names the field") true
+          (msg_contains ~needle:"confidence" msg))
+      [ ("string", `String "0.9")
+      ; ("list", `List [ `Float 0.9 ])
+      ; ("bool", `Bool true)
+      ]
+  )
+
+(* An integer 1 is a number the JSON encoder is entitled to emit for 1.0. *)
+let test_add_accepts_integer_confidence () =
+  with_temp_base_path (fun ctx ->
+    let args = `Assoc [
+      ("title", `String "integer scored knowledge");
+      ("content", `String "Confidence arrived as an int.");
+      ("confidence", `Int 1);
+    ] in
+    let (ok, _) = dispatch_exn ctx ~name:"masc_library_add" ~args in
+    Alcotest.(check bool) "integer confidence is accepted" true ok
+  )
+
+let test_promote_rejects_unusable_confidence () =
+  with_temp_base_path (fun ctx ->
+    List.iter
+      (fun (label, fields) ->
+        let args = `Assoc (("topic", `String "anything") :: fields) in
+        let (ok, msg) = dispatch_exn ctx ~name:"masc_library_promote" ~args in
+        Alcotest.(check bool) (label ^ " is rejected") false ok;
+        Alcotest.(check bool) (label ^ " error names the field") true
+          (msg_contains ~needle:"confidence" msg))
+      [ ("absent confidence", [])
+      ; ("null confidence", [ ("confidence", `Null) ])
+      ; ("string confidence", [ ("confidence", `String "0.9") ])
+      ]
+  )
+
 let test_add_with_tags () =
   with_temp_base_path (fun ctx ->
     let args = `Assoc [
       ("title", `String "tagged knowledge");
       ("content", `String "Content with tags.");
+      ("confidence", `Float 0.8);
       ("tags", `List [`String "ocaml"; `String "testing"]);
     ] in
     let (ok, msg) = dispatch_exn ctx ~name:"masc_library_add" ~args in
@@ -447,6 +525,16 @@ let () =
       Alcotest.test_case "invalid source" `Quick test_add_invalid_source;
       Alcotest.test_case "success" `Quick test_add_success;
       Alcotest.test_case "low confidence" `Quick test_add_low_confidence;
+      Alcotest.test_case "absent confidence rejected" `Quick
+        test_add_rejects_absent_confidence;
+      Alcotest.test_case "null confidence rejected" `Quick
+        test_add_rejects_null_confidence;
+      Alcotest.test_case "non-numeric confidence rejected" `Quick
+        test_add_rejects_non_numeric_confidence;
+      Alcotest.test_case "integer confidence accepted" `Quick
+        test_add_accepts_integer_confidence;
+      Alcotest.test_case "promote rejects unusable confidence" `Quick
+        test_promote_rejects_unusable_confidence;
       Alcotest.test_case "with tags" `Quick test_add_with_tags;
     ]);
     ("library_search", [

--- a/test/test_tool_library_coverage.ml
+++ b/test/test_tool_library_coverage.ml
@@ -340,6 +340,22 @@ let test_add_accepts_integer_confidence () =
     Alcotest.(check bool) "integer confidence is accepted" true ok
   )
 
+let test_add_rejects_out_of_range_confidence () =
+  with_temp_base_path (fun ctx ->
+    List.iter
+      (fun (label, value) ->
+        let args = `Assoc [
+          ("title", `String ("out of range " ^ label));
+          ("content", `String "Confidence is outside its declared domain.");
+          ("confidence", value);
+        ] in
+        let (ok, msg) = dispatch_exn ctx ~name:"masc_library_add" ~args in
+        Alcotest.(check bool) (label ^ " is rejected") false ok;
+        Alcotest.(check bool) (label ^ " error states the range") true
+          (msg_contains ~needle:"between 0.0 and 1.0" msg))
+      [ ("negative", `Float (-0.1)); ("above one", `Float 1.1) ]
+  )
+
 let test_promote_rejects_unusable_confidence () =
   with_temp_base_path (fun ctx ->
     List.iter
@@ -352,6 +368,8 @@ let test_promote_rejects_unusable_confidence () =
       [ ("absent confidence", [])
       ; ("null confidence", [ ("confidence", `Null) ])
       ; ("string confidence", [ ("confidence", `String "0.9") ])
+      ; ("negative confidence", [ ("confidence", `Float (-0.1)) ])
+      ; ("confidence above one", [ ("confidence", `Float 1.1) ])
       ]
   )
 
@@ -533,6 +551,8 @@ let () =
         test_add_rejects_non_numeric_confidence;
       Alcotest.test_case "integer confidence accepted" `Quick
         test_add_accepts_integer_confidence;
+      Alcotest.test_case "out-of-range confidence rejected" `Quick
+        test_add_rejects_out_of_range_confidence;
       Alcotest.test_case "promote rejects unusable confidence" `Quick
         test_promote_rejects_unusable_confidence;
       Alcotest.test_case "with tags" `Quick test_add_with_tags;


### PR DESCRIPTION
## 증상

`masc_library_add` 는 `confidence` 로 문서의 행선지를 정한다. 도구 설명이 그대로 말한다.

> Add a new document to the library. Documents with confidence < 0.5 go to `candidates/`.

그런데 핸들러는 이렇게 읽었다.

```ocaml
let confidence = Json_util.get_float args "confidence" |> Option.value ~default:0.7 in
```

`Json_util.get_float` 는 `` `Float`` / `` `Int`` 만 `Some` 을 돌려준다. 따라서 **필드 누락, 명시적 `null`, 숫자가 아닌 값** 셋이 전부 `0.7` 로 접힌다. 0.7 은 임계값 0.5 보다 크므로 **셋 다 리뷰를 건너뛰고 `library/` 에 바로 게시된다**.

`confidence` 는 두 스키마 모두에서 required 다 (`tool_schemas_library.ml:99`, compact 목록의 `true`).

`masc_library_promote` 는 같은 읽기로 더 직접적이다.

```ocaml
let new_confidence = Json_util.get_float args "confidence" |> Option.value ~default:0.7 in
if ... else if new_confidence < 0.5 then reject
```

`{"topic":"x"}` 만 보내면 0.7 이 되어 게이트를 통과하고, 후보 문서가 검증 없이 승격된다.

같은 형태를 #26907 에서 고친 적이 있다. 거기서는 `{"mode":["append"]}` 가 파괴적 overwrite 에 도달하는 동안 `{"mode":"apend"}` 는 거부되었다.

## 수정

```ocaml
type confidence_read =
  | Confidence of float
  | Confidence_absent
  | Confidence_not_a_number

let read_confidence args =
  match Json_util.assoc_member_opt "confidence" args with
  | None | Some `Null -> Confidence_absent
  | Some (`Float value) -> Confidence value
  | Some (`Int value) -> Confidence (Float.of_int value)
  | Some _ -> Confidence_not_a_number
```

두 핸들러가 세 경우를 구분해서 처리한다. 부재는 `confidence is required`, 숫자가 아니면 `confidence must be a number between 0.0 and 1.0`. `` `Int 1`` 은 JSON 인코더가 `1.0` 대신 낼 수 있는 값이라 그대로 받는다.

검증 순서는 기존 그대로 두었다 (title → content → source → confidence). `source` 를 먼저 보므로 잘못된 source 의 에러 메시지가 바뀌지 않는다.

## 임계값 중복

`library_confidence_threshold = 0.5` 가 있는데 판정 4곳 중 1곳만 상수를 쓰고 나머지는 `0.5` 리터럴이었다 (`:353` 상태 문자열, `:373` promote 게이트, `:375` 에러 문구, 도구 설명 2곳). 전부 상수에서 파생시켰다.

## 검증

- `dune build --root . @check` EXIT=0
- `test_tool_library_coverage` 27/27
- `scripts/check-doc-code-refs.sh`, `scripts/audit-keeper-tool-boundary-matrix.sh` PASS

새 케이스 5개: 부재/`null`/문자열·리스트·불리언 거부, `` `Int`` 수용, promote 3종 거부.

기존 테스트 3곳이 `confidence` 없이 문서를 심고 있었다 (`read by case-insensitive partial title`, `read by slug still works`, `with tags`). 세 테스트 모두 read/tags 를 검증하는 것이지 confidence 를 검증하는 게 아니므로 시드에 필수 필드를 채웠다.

RFC-WAIVED: MCP 도구 하나의 required 필드 파싱을 관대한 기본값에서 명시적 거부로 바꾼다. credential/identity, repo_manager, operator control plane, keeper sandbox, dashboard credential component, hooks, workflow 문서 중 어느 것도 건드리지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
