### PR TITLE
feat(keeper): board attention worker 의 시작과 drain 판정을 로그로 남긴다 (task-178)

### DIFF
--- a/lib/keeper/keeper_board_attention_worker.ml
+++ b/lib/keeper/keeper_board_attention_worker.ml
@@ -348,6 +348,17 @@ let reset_contention_rearms scheduler ~keep =
     removed
 ;;
 
+(* The drain verdict as one token. Retry_later carries its reason so a stuck
+   worker is distinguishable from a contended one: Exact_claim_contended means
+   another flow holds the claim, Selected_generation_changed means the partition
+   moved under this worker. *)
+let drain_outcome_label = function
+  | Drained -> "drained"
+  | Retry_later { reason = Exact_claim_contended; _ } -> "retry_claim_contended"
+  | Retry_later { reason = Selected_generation_changed; _ } ->
+    "retry_generation_changed"
+;;
+
 let apply_drain_rearm scheduler = function
   | Drained ->
     reset_contention_rearms scheduler ~keep:None;
@@ -1728,6 +1739,16 @@ let run
          with_process_recovery_claim ~base_path ~keeper_name
          @@ fun owns_process_recovery ->
          let worker_epoch = Partition.Worker_epoch.generate () in
+         (* Until this line existed, three states were byte-identical from
+            outside: the worker was never forked, it was forked and never
+            inspected the ledger, or it inspected and found nothing. Measured
+            2026-08-05 while pending grew 425 -> 1031 with zero contention
+            lines and zero worker failures, so the logs that did exist could
+            not tell them apart. *)
+         Log.Keeper.info
+           "board_attention_worker_start keeper=%s epoch=%s"
+           keeper_name
+           (Partition.Worker_epoch.to_string worker_epoch);
          let fail stage detail =
            observe_error ~base_path ~keeper_name detail;
            Error { stage; detail }
@@ -1784,6 +1805,10 @@ let run
                  ~execute
              with
              | Ok outcome ->
+               Log.Keeper.info
+                 "board_attention_worker_drain keeper=%s outcome=%s"
+                 keeper_name
+                 (drain_outcome_label outcome);
                ignore
                  (apply_drain_rearm contention_rearms outcome
                   : rearm_schedule option);
@@ -1810,6 +1835,7 @@ module For_testing = struct
   let make_contention_rearm_scheduler = make_contention_rearm_scheduler
   let schedule_contention_rearm = schedule_contention_rearm
   let reset_contention_rearms = reset_contention_rearms
+  let drain_outcome_label = drain_outcome_label
   let apply_drain_rearm = apply_drain_rearm
   let replay_completed_owner_wake = replay_completed_owner_wake
   let with_process_recovery_claim = with_process_recovery_claim

--- a/lib/keeper/keeper_board_attention_worker.mli
+++ b/lib/keeper/keeper_board_attention_worker.mli
@@ -94,6 +94,11 @@ val settle_one_completed :
 module For_testing : sig
   type rearm_scheduler
 
+  val drain_outcome_label : drain_outcome -> string
+  (** The drain verdict as one token, as logged. Retry_later keeps its reason
+      so a worker stuck on a moved generation is distinguishable from one
+      losing a claim race. *)
+
   val process_next_exact
     :  clock:_ Eio.Time.clock
     -> net:Eio_context.eio_net option

--- a/test/test_keeper_board_attention_worker.ml
+++ b/test/test_keeper_board_attention_worker.ml
@@ -2070,6 +2070,37 @@ let test_cross_domain_wake_is_coalesced_and_rearmed () =
     Alcotest.fail "worker lifetime left a stale wake registration"
 ;;
 
+(* The drain verdict must stay three distinguishable tokens. This is what the
+   worker logs, and it is the only thing that separates "drained, nothing to
+   do" from "could not claim" from "the partition moved under me". Collapsing
+   two of them back into one string would restore the state the measurement on
+   2026-08-05 found: pending 425 -> 1031 with zero contention lines and zero
+   worker failures, and no way to tell which of the three was happening. *)
+let test_drain_outcome_labels_stay_distinct () =
+  let contention =
+    { W.keeper_name = "k"
+    ; partition_id = "p"
+    ; generation = P.Generation.initial
+    }
+  in
+  let labels =
+    List.map
+      W.For_testing.drain_outcome_label
+      [ W.Drained
+      ; W.Retry_later { contention; reason = W.Exact_claim_contended }
+      ; W.Retry_later { contention; reason = W.Selected_generation_changed }
+      ]
+  in
+  Alcotest.(check (list string))
+    "one token per verdict"
+    [ "drained"; "retry_claim_contended"; "retry_generation_changed" ]
+    labels;
+  Alcotest.(check int)
+    "no two verdicts share a token"
+    3
+    (List.length (List.sort_uniq compare labels))
+;;
+
 let () =
   Alcotest.run
     "keeper_board_attention_worker"
@@ -2194,6 +2225,10 @@ let () =
             "cross-domain wake coalesces and rearms"
             `Quick
             test_cross_domain_wake_is_coalesced_and_rearmed
+        ; Alcotest.test_case
+            "drain outcome labels stay distinct"
+            `Quick
+            test_drain_outcome_labels_stay_distinct
         ] )
     ]
 ;;


### PR DESCRIPTION
`task-178` 에서 **rondo 가 특정한 두 지점**에 그가 지정한 레벨로 로그를 넣는다. 설계는 keeper 가 했고 이 PR 은 구현이다.

## 왜

밖에서 세 상태가 **바이트 단위로 동일**했다:

```
(a) worker 가 fork 되지 않음
(b) fork 됐지만 ledger 를 한 번도 안 봄
(c) fork 돼서 매번 할 일 없음으로 판정
```

실측 2026-08-05: pending 이 **425 -> 1031** 로 느는 동안 `board_attention_claim_contention` **0건**, `Board attention worker failed` **0건**. 있던 로그로는 셋을 구분할 수 없었다 (#26863).

## 무엇을

```
board_attention_worker_start keeper=%s epoch=%s
  Wake.register 성공 직후. fork 됐음을 증명하고 epoch 로 몇 번째인지 추적

board_attention_worker_drain keeper=%s outcome=%s
  drain_available_current 반환 후, await() 재진입 전
```

`drain_outcome_label` 이 판정을 **세 토큰으로 유지**한다:

| 토큰 | 뜻 |
|---|---|
| `drained` | 처리 완료, 할 일 없음 |
| `retry_claim_contended` | 다른 flow 가 claim 보유 |
| `retry_generation_changed` | partition 이 이 worker 밑에서 움직임 |

둘을 하나로 합치면 위 (b)/(c) 모호성이 되돌아온다. 테스트가 세 토큰과 **서로 겹치지 않음**을 고정한다.

## rondo 의 반대 논거와 반박 (인용)

> **반대**: drain 결과 로그는 매 drain 마다 찍히면 너무 많다
> **반박**: drain 은 wake signal 이 있을 때만 실행된다. pending 이 0 이면 즉시 `Drained` 반환. 부하는 `Log.Keeper.info` 1줄 수준.

레벨이 `info` 인 것도 그의 판단이다 — 정상 상태 전이이지 경보가 아니다.

## 검증

```
dune build @check                      clean
TEL gate                               PASS
ocamlformat --check (3 파일)            exit 0
test_keeper_board_attention_worker     30 -> 31 tests, 내 테스트 통과
```

기존 실패 5건은 **수정하지 않은 origin/main 에서 동일하게 재현**된다 (`5 failures! in 0.340s. 30 tests run.`). 그 테스트들은 라이브 워크스페이스를 읽는다 — 실패 메시지가 라이브 keeper 이름 `sangsu` 를 부른다. 별건이라 섞지 않는다.

## 산출물

`playground/rondo/artifacts/task-178-analysis.md` (2,460B), board post `p-d8ae1878ad6f3140321115c10b06c213`.

관련: #26863

🤖 Generated with [Claude Code](https://claude.com/claude-code)
