### PR TITLE
fix(server): bound tool-blob maintenance by the startup watchdog budget

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -14,6 +14,15 @@ let startup_config_resolution = Config_root_bootstrap.startup_config_resolution
 let oas_model_catalog_env_var_name = "OAS_MODEL_CATALOG"
 let oas_models_overlay_toml_filename = "oas-models-overlay.toml"
 
+(* Seconds withheld from tool-blob maintenance so the boot stages that follow
+   it (Runtime_params restore, credential audit, Domain_pool, Keeper gate
+   replay, lazy task groups, Discord/Slack/gRPC/WebSocket listeners) still fit
+   inside the startup watchdog. Those stages took ~2s on an idle host; the
+   reserve carries them at the ~10x slowdown observed when a concurrent build
+   saturates the disk, which is the condition under which maintenance
+   overran its host's watchdog. *)
+let blob_maintenance_boot_reserve_sec = 60.0
+
 let nonempty_env env name =
   match env name with
   | Some value ->
@@ -869,7 +878,17 @@ let initialize_owner_state_blocking
      persistence owners have not started yet, so startup is the sole
      quiescent scan/deletion boundary. A blob must remain unreferenced across
      two complete startup scans before deletion. A failed scan retains every
-     blob and does not make unrelated server startup unavailable. *)
+     blob.
+
+     The scan reads every durable consumer file, so its cost grows with
+     workspace size while the startup watchdog's budget does not: an
+     unbounded scan let the watchdog exit a server that was otherwise ready
+     to serve, which is the zombie-listener failure #3107 introduced the
+     watchdog to prevent, arriving through a different door. The scan
+     therefore gets an explicit deadline derived from the watchdog's
+     remaining time. Exhausting it aborts before the candidate snapshot is
+     written, so every blob is retained -- the same outcome as any other
+     scan failure. *)
   (match
      Eio_unix.run_in_systhread (fun () ->
        Keeper_wire_capture.prune_expired
@@ -885,26 +904,43 @@ let initialize_owner_state_blocking
        Log.Server.info
          "startup wire-capture retention: pruned %d expired day-file(s)"
          wire_capture_pruned;
-     (match
-        Eio_unix.run_in_systhread (fun () ->
-          Tool_blob_maintenance.run
-            ~base_path
-            ~mode:Tool_blob_maintenance.Delete_previous_candidates)
-      with
-      | Ok report ->
-        if report.candidates_recorded > 0 || report.deleted > 0
-        then
-          Log.Server.info
-            "startup tool blob maintenance: live=%d blobs=%d candidates=%d \
-             deleted=%d"
-            report.live_references
-            report.blobs_observed
-            report.candidates_recorded
-            report.deleted
-      | Error error ->
-        Log.Server.warn
-          "startup tool blob maintenance stopped; no further blobs were deleted: %s"
-          (Tool_blob_maintenance.error_to_string error)));
+     let maintenance_budget_sec =
+       Server_startup_state.remaining_watchdog_budget_sec
+         ~reserve_sec:blob_maintenance_boot_reserve_sec
+     in
+     if maintenance_budget_sec <= 0.0
+     then
+       Log.Server.warn
+         "startup tool blob maintenance skipped; the startup watchdog budget \
+          is already spent (reserve=%.0fs). Every blob is retained."
+         blob_maintenance_boot_reserve_sec
+     else (
+       let deadline_epoch_seconds =
+         Unix.gettimeofday () +. maintenance_budget_sec
+       in
+       match
+         Eio_unix.run_in_systhread (fun () ->
+           Tool_blob_maintenance.run
+             ~base_path
+             ~mode:Tool_blob_maintenance.Delete_previous_candidates
+             ~budget:(Tool_blob_maintenance.Bounded_by { deadline_epoch_seconds }))
+       with
+       | Ok report ->
+         if report.candidates_recorded > 0 || report.deleted > 0
+         then
+           Log.Server.info
+             "startup tool blob maintenance: live=%d blobs=%d candidates=%d \
+              deleted=%d"
+             report.live_references
+             report.blobs_observed
+             report.candidates_recorded
+             report.deleted
+       | Error error ->
+         Log.Server.warn
+           "startup tool blob maintenance stopped; no further blobs were \
+            deleted (budget=%.0fs): %s"
+           maintenance_budget_sec
+           (Tool_blob_maintenance.error_to_string error)));
   Runtime_settings.ensure_init ();
   Runtime_params.restore ~base_path;
   Log.Server.info "Runtime_params restored from %s" base_path;

--- a/lib/server_startup_state.ml
+++ b/lib/server_startup_state.ml
@@ -96,6 +96,12 @@ let default_watchdog_timeout_sec = 240.0
 
 let watchdog_timeout_sec () = Env_config.Transport.startup_watchdog_sec ()
 
+let remaining_watchdog_budget_sec ~reserve_sec =
+  Float.max
+    0.0
+    (watchdog_timeout_sec () -. elapsed_since_start () -. reserve_sec)
+;;
+
 let pending_lazy_tasks () =
   !state.pending_lazy_tasks
 

--- a/lib/server_startup_state.mli
+++ b/lib/server_startup_state.mli
@@ -58,6 +58,14 @@ val default_watchdog_timeout_sec : float
 (** Effective watchdog timeout from env, clamped to [[30, 600]]. *)
 val watchdog_timeout_sec : unit -> float
 
+(** Seconds a blocking init step may spend before the startup watchdog would
+    exit the process, with [reserve_sec] set aside for the boot stages that
+    run after that step. Clamped at [0.] so a caller that is already over
+    budget is told to skip rather than handed a negative deadline. Deriving a
+    sub-budget here keeps it tied to {!watchdog_timeout_sec} instead of
+    drifting as an independent constant. *)
+val remaining_watchdog_budget_sec : reserve_sec:float -> float
+
 (** Current snapshot as JSON:
     [{phase, state_ready, pending_lazy_tasks,
       last_error, path_diagnostics,

--- a/lib/tool_blob_store/tool_blob_maintenance.ml
+++ b/lib/tool_blob_store/tool_blob_maintenance.ml
@@ -4,6 +4,16 @@ type mode =
   | Observe_only
   | Delete_previous_candidates
 
+(* A scan that stops early must never reach the candidate snapshot. A partial
+   [live_references] set records still-referenced blobs as deletion
+   candidates, and two consecutive partial scans that miss the same durable
+   file intersect into a live blob. Budget exhaustion is therefore an [error]
+   like any other scan failure, so [run] short-circuits before
+   [save_candidate_snapshot]. *)
+type scan_budget =
+  | Unbounded
+  | Bounded_by of { deadline_epoch_seconds : float }
+
 type error =
   | Clustered_durable_roots_uncoordinated of
       { path : string
@@ -39,6 +49,11 @@ type error =
   | Candidate_snapshot_write_failed of
       { path : string
       ; detail : string
+      }
+  | Scan_budget_exhausted of
+      { elapsed_seconds : float
+      ; files_scanned : int
+      ; last_path : string
       }
   | Blob_listing_failed of Tool_blob_store.list_error
   | Blob_delete_failed of Tool_blob_store.delete_error
@@ -83,6 +98,13 @@ let error_to_string = function
       detail
   | Candidate_snapshot_write_failed { path; detail } ->
     Printf.sprintf "blob maintenance candidate snapshot write failed path=%s: %s" path detail
+  | Scan_budget_exhausted { elapsed_seconds; files_scanned; last_path } ->
+    Printf.sprintf
+      "durable scan budget exhausted after %.1fs and %d file(s) at path=%s; \
+       every blob is retained and no candidate snapshot was written"
+      elapsed_seconds
+      files_scanned
+      last_path
   | Blob_listing_failed error ->
     Printf.sprintf
       "blob listing failed path=%s: %s"
@@ -313,7 +335,29 @@ let reject_uncoordinated_cluster_roots ~base_path =
             }))
 ;;
 
-let live_references ~base_path =
+(* [files_scanned] rides along only so an exhausted budget can report how far
+   the traversal reached; it is dropped once the scan completes. *)
+type scan_progress =
+  { references : String_set.t
+  ; files_scanned : int
+  }
+
+let live_references ~base_path ~budget =
+  let started_at = Unix.gettimeofday () in
+  let within_budget () =
+    match budget with
+    | Unbounded -> true
+    | Bounded_by { deadline_epoch_seconds } ->
+      Unix.gettimeofday () <= deadline_epoch_seconds
+  in
+  let budget_exhausted path progress =
+    Error
+      (Scan_budget_exhausted
+         { elapsed_seconds = Unix.gettimeofday () -. started_at
+         ; files_scanned = progress.files_scanned
+         ; last_path = path
+         })
+  in
   let read_directory path =
     let inspect () =
       match
@@ -361,39 +405,45 @@ let live_references ~base_path =
                  Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message code)
              })
   in
-  let rec scan_entry path references =
-    try
-      match (Unix.lstat path).Unix.st_kind with
-      | Unix.S_DIR -> scan_directory path references
-      | Unix.S_REG ->
-        Result.map
-          (String_set.union references)
-          (references_in_file ~ownership_root:base_path path)
-      | Unix.S_LNK ->
+  let rec scan_entry path progress =
+    if not (within_budget ())
+    then budget_exhausted path progress
+    else (
+      try
+        match (Unix.lstat path).Unix.st_kind with
+        | Unix.S_DIR -> scan_directory path progress
+        | Unix.S_REG ->
+          Result.map
+            (fun found ->
+               { references = String_set.union progress.references found
+               ; files_scanned = progress.files_scanned + 1
+               })
+            (references_in_file ~ownership_root:base_path path)
+        | Unix.S_LNK ->
+          Error
+            (Durable_source_stat_failed
+               { path
+               ; reason = "symbolic links are not durable maintenance sources"
+               })
+        | Unix.S_CHR
+        | Unix.S_BLK
+        | Unix.S_FIFO
+        | Unix.S_SOCK ->
+          Ok progress
+      with
+      | Sys_error reason ->
+        Error (Durable_source_stat_failed { path; reason })
+      | Unix.Unix_error (code, fn, arg) ->
         Error
           (Durable_source_stat_failed
              { path
-             ; reason = "symbolic links are not durable maintenance sources"
-             })
-      | Unix.S_CHR
-      | Unix.S_BLK
-      | Unix.S_FIFO
-      | Unix.S_SOCK ->
-        Ok references
-    with
-    | Sys_error reason ->
-      Error (Durable_source_stat_failed { path; reason })
-    | Unix.Unix_error (code, fn, arg) ->
-      Error
-        (Durable_source_stat_failed
-           { path
-           ; reason =
-               Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message code)
-           })
-  and scan_directory path references =
+             ; reason =
+                 Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message code)
+             }))
+  and scan_directory path progress =
     match read_directory path with
     | Error _ as error -> error
-    | Ok None -> Ok references
+    | Ok None -> Ok progress
     | Ok (Some entries) ->
       entries
       |> Array.to_list
@@ -402,14 +452,14 @@ let live_references ~base_path =
            (fun result name ->
               Result.bind result (fun current ->
                 scan_entry (Filename.concat path name) current))
-           (Ok references)
+           (Ok progress)
   in
   durable_consumer_roots ~base_path
   |> List.fold_left
        (fun result root ->
-          Result.bind result (fun references ->
-            scan_directory root references))
-       (Ok String_set.empty)
+          Result.bind result (fun progress -> scan_directory root progress))
+       (Ok { references = String_set.empty; files_scanned = 0 })
+  |> Result.map (fun progress -> progress.references)
 ;;
 
 let candidate_snapshot_to_json candidates =
@@ -536,11 +586,11 @@ let save_candidate_snapshot ~base_path candidates =
     Error (Candidate_snapshot_write_failed { path; detail })
 ;;
 
-let run ~base_path ~mode =
+let run ~base_path ~mode ~budget =
   let open Result.Syntax in
   let* () = reject_uncoordinated_cluster_roots ~base_path in
   let store = Tool_blob_store.create ~base_path in
-  let* live = live_references ~base_path in
+  let* live = live_references ~base_path ~budget in
   let* previous_candidates = load_candidate_snapshot ~base_path in
   let* blob_list =
     match Tool_blob_store.list_all_result store with

--- a/lib/tool_blob_store/tool_blob_maintenance.mli
+++ b/lib/tool_blob_store/tool_blob_maintenance.mli
@@ -14,8 +14,9 @@
     hashes that were candidates in the previous durable snapshot and remain
     unreferenced in the new complete scan. Production calls it only at the
     quiescent startup boundary, so two complete startup scans are required.
-    A malformed reference, scan failure, candidate-store failure, or unlink
-    failure aborts visibly. Because the blob store is shared across clusters
+    A malformed reference, scan failure, exhausted scan budget, candidate-store
+    failure, or unlink failure aborts visibly. Because the blob store is shared
+    across clusters
     while several consumers are cluster-aware, any non-empty
     [<base>/.masc/clusters] tree currently disables maintenance fail-closed
     until cross-cluster writer quiescence has one coordination owner. *)
@@ -23,6 +24,17 @@
 type mode =
   | Observe_only
   | Delete_previous_candidates
+
+(** Wall-clock ceiling for one durable scan. [Bounded_by] aborts the traversal
+    with {!Scan_budget_exhausted} once [deadline_epoch_seconds] passes, which
+    short-circuits {!run} before the candidate snapshot is written: a partial
+    scan can never record a still-referenced blob as a deletion candidate.
+    Callers on a deadline (server startup, bounded by the startup watchdog)
+    must bound the scan; offline callers with no competing deadline pass
+    [Unbounded]. *)
+type scan_budget =
+  | Unbounded
+  | Bounded_by of { deadline_epoch_seconds : float }
 
 type error =
   | Clustered_durable_roots_uncoordinated of
@@ -60,6 +72,11 @@ type error =
       { path : string
       ; detail : string
       }
+  | Scan_budget_exhausted of
+      { elapsed_seconds : float
+      ; files_scanned : int
+      ; last_path : string
+      }
   | Blob_listing_failed of Tool_blob_store.list_error
   | Blob_delete_failed of Tool_blob_store.delete_error
 
@@ -72,4 +89,8 @@ type report =
 
 val error_to_string : error -> string
 val candidate_snapshot_path : base_path:string -> string
-val run : base_path:string -> mode:mode -> (report, error) result
+val run
+  :  base_path:string
+  -> mode:mode
+  -> budget:scan_budget
+  -> (report, error) result

--- a/test/test_tool_blob_store.ml
+++ b/test/test_tool_blob_store.ml
@@ -307,8 +307,10 @@ let test_sharding_layout () =
             (Sys.file_exists expected)
       | O.Inline _ -> Alcotest.fail "put returned Inline")
 
+(* Fixtures here hold a handful of small files and compete with no startup
+   watchdog, so they scan unbounded; the budget path has its own tests. *)
 let maintenance_ok ~base_path ~mode =
-  match M.run ~base_path ~mode with
+  match M.run ~base_path ~mode ~budget:M.Unbounded with
   | Ok report -> report
   | Error error ->
     Alcotest.failf "maintenance failed: %s" (M.error_to_string error)
@@ -455,7 +457,7 @@ let test_maintenance_rejects_uncoordinated_cluster_roots () =
            (`Assoc
              [ "response_text", `String (O.encode_for_oas (O.Stored blob)) ])
          ^ "\n");
-      (match M.run ~base_path ~mode:M.Delete_previous_candidates with
+      (match M.run ~base_path ~mode:M.Delete_previous_candidates ~budget:M.Unbounded with
        | Error
            (M.Clustered_durable_roots_uncoordinated
              { path; entries }) ->
@@ -496,7 +498,7 @@ let test_maintenance_malformed_reference_fails_closed () =
       in
       Fs_compat.mkdir_p (Filename.dirname source);
       Fs_compat.save_file source "{\"output\":\"[masc:blob garbage]\"}\n";
-      (match M.run ~base_path ~mode:M.Delete_previous_candidates with
+      (match M.run ~base_path ~mode:M.Delete_previous_candidates ~budget:M.Unbounded with
        | Error (M.Malformed_artifact_reference { path; line; _ }) ->
          Alcotest.(check string) "exact malformed source" source path;
          Alcotest.(check int) "exact malformed line" 1 line
@@ -652,7 +654,7 @@ let test_maintenance_malformed_normalized_blob_fails_closed () =
                    ] )
              ])
          ^ "\n");
-      (match M.run ~base_path ~mode:M.Delete_previous_candidates with
+      (match M.run ~base_path ~mode:M.Delete_previous_candidates ~budget:M.Unbounded with
        | Error
            (M.Malformed_structured_artifact_reference
              { path; line; _ }) ->
@@ -693,7 +695,7 @@ let test_maintenance_truncated_normalized_blob_fails_closed () =
       Fs_compat.save_file
         tool_call_log
         ("{\"output\":" ^ complete_reference);
-      (match M.run ~base_path ~mode:M.Delete_previous_candidates with
+      (match M.run ~base_path ~mode:M.Delete_previous_candidates ~budget:M.Unbounded with
        | Error
            (M.Malformed_structured_artifact_reference
              { path; line; _ }) ->
@@ -720,7 +722,7 @@ let test_maintenance_unlink_failure_is_typed () =
       Fs_compat.mkdir_p shard_dir;
       Unix.mkdir (Filename.concat shard_dir sha256) 0o755;
       ignore (maintenance_ok ~base_path ~mode:M.Observe_only);
-      match M.run ~base_path ~mode:M.Delete_previous_candidates with
+      match M.run ~base_path ~mode:M.Delete_previous_candidates ~budget:M.Unbounded with
       | Error
           (M.Blob_delete_failed
             { Tool_blob_store.sha256 = actual; _ }) ->
@@ -730,6 +732,104 @@ let test_maintenance_unlink_failure_is_typed () =
           "unexpected unlink error: %s"
           (M.error_to_string error)
       | Ok _ -> Alcotest.fail "unlink failure was silently skipped")
+
+(* --- Scan budget --- *)
+
+(* One durable consumer holding one live reference, plus one unreferenced
+   blob. A complete scan sees the live reference and records exactly one
+   candidate; a scan that stops before reading the consumer would see zero
+   live references and record both blobs as candidates. *)
+let with_one_live_and_one_dead_blob f =
+  with_temp_dir (fun base_path ->
+      let store = B.create ~base_path in
+      let live =
+        B.put store ~bytes:"live budget fixture output" ~mime:"text/plain"
+        |> stored_ref_exn
+      in
+      let dead =
+        B.put store ~bytes:"dead budget fixture output" ~mime:"text/plain"
+        |> stored_ref_exn
+      in
+      let durable_consumer =
+        Filename.concat
+          (Common.masc_dir_from_base_path ~base_path)
+          "keepers/keeper-a/sessions/history.jsonl"
+      in
+      Fs_compat.mkdir_p (Filename.dirname durable_consumer);
+      Fs_compat.save_file
+        durable_consumer
+        (Yojson.Safe.to_string
+           (`Assoc [ "output_ref", `String (O.encode_for_oas (O.Stored live)) ])
+         ^ "\n");
+      f ~base_path ~store ~live ~dead)
+
+let expired_budget () =
+  M.Bounded_by { deadline_epoch_seconds = Unix.gettimeofday () -. 1.0 }
+
+let test_maintenance_exhausted_budget_is_a_typed_error () =
+  with_one_live_and_one_dead_blob (fun ~base_path ~store:_ ~live:_ ~dead:_ ->
+      match
+        M.run
+          ~base_path
+          ~mode:M.Delete_previous_candidates
+          ~budget:(expired_budget ())
+      with
+      | Error (M.Scan_budget_exhausted { files_scanned; _ }) ->
+        Alcotest.(check int)
+          "aborted before reading any durable file"
+          0
+          files_scanned
+      | Error error ->
+        Alcotest.failf
+          "expected Scan_budget_exhausted, got: %s"
+          (M.error_to_string error)
+      | Ok _ -> Alcotest.fail "expired budget completed a full scan")
+
+(* The safety property the budget must not break: a partial scan sees fewer
+   live references than exist, so writing its candidate set would mark a
+   referenced blob for deletion on the next pass. *)
+let test_maintenance_exhausted_budget_leaves_candidate_snapshot_untouched () =
+  with_one_live_and_one_dead_blob (fun ~base_path ~store:_ ~live:_ ~dead ->
+      let complete = maintenance_ok ~base_path ~mode:M.Observe_only in
+      Alcotest.(check int) "complete scan records one candidate" 1
+        complete.candidates_recorded;
+      let snapshot_path = M.candidate_snapshot_path ~base_path in
+      let after_complete_scan = Fs_compat.load_file_opt snapshot_path in
+      Alcotest.(check bool)
+        "complete scan wrote a candidate snapshot"
+        true
+        (Option.is_some after_complete_scan);
+      (match
+         M.run
+           ~base_path
+           ~mode:M.Delete_previous_candidates
+           ~budget:(expired_budget ())
+       with
+       | Error (M.Scan_budget_exhausted _) -> ()
+       | Error error ->
+         Alcotest.failf
+           "expected Scan_budget_exhausted, got: %s"
+           (M.error_to_string error)
+       | Ok _ -> Alcotest.fail "expired budget completed a full scan");
+      Alcotest.(check (option string))
+        "partial scan did not rewrite the candidate snapshot"
+        after_complete_scan
+        (Fs_compat.load_file_opt snapshot_path);
+      Alcotest.(check bool)
+        "partial scan deleted nothing"
+        true
+        (Sys.file_exists
+           (Filename.concat
+              (Filename.concat (B.root_dir (B.create ~base_path))
+                 (String.sub dead.O.sha256 0 2))
+              dead.O.sha256)))
+
+let test_maintenance_unbounded_budget_still_completes () =
+  with_one_live_and_one_dead_blob (fun ~base_path ~store:_ ~live:_ ~dead:_ ->
+      let report = maintenance_ok ~base_path ~mode:M.Observe_only in
+      Alcotest.(check int) "one live reference" 1 report.live_references;
+      Alcotest.(check int) "two blobs observed" 2 report.blobs_observed;
+      Alcotest.(check int) "one candidate" 1 report.candidates_recorded)
 
 let test_maintenance_rejects_symbolic_link_shard () =
   with_temp_dir (fun base_path ->
@@ -741,7 +841,7 @@ let test_maintenance_rejects_symbolic_link_shard () =
         (Filename.concat outside (String.make 64 'a'))
         "outside";
       Unix.symlink outside (Filename.concat (B.root_dir store) "aa");
-      match M.run ~base_path ~mode:M.Observe_only with
+      match M.run ~base_path ~mode:M.Observe_only ~budget:M.Unbounded with
       | Error (M.Blob_listing_failed { Tool_blob_store.path; _ }) ->
         Alcotest.(check string)
           "exact symbolic-link shard"
@@ -773,7 +873,7 @@ let test_maintenance_rejects_symbolic_link_durable_source () =
       in
       Fs_compat.mkdir_p (Filename.dirname linked_source);
       Unix.symlink outside linked_source;
-      (match M.run ~base_path ~mode:M.Observe_only with
+      (match M.run ~base_path ~mode:M.Observe_only ~budget:M.Unbounded with
        | Error (M.Durable_source_stat_failed { path; _ }) ->
          Alcotest.(check string) "exact linked source" linked_source path
        | Error error ->
@@ -805,7 +905,7 @@ let test_maintenance_rejects_symbolic_link_candidate_snapshot () =
              ]));
       Sys.remove candidate_path;
       Unix.symlink outside candidate_path;
-      (match M.run ~base_path ~mode:M.Delete_previous_candidates with
+      (match M.run ~base_path ~mode:M.Delete_previous_candidates ~budget:M.Unbounded with
        | Error (M.Candidate_snapshot_read_failed { path; _ }) ->
          Alcotest.(check string) "exact linked snapshot" candidate_path path
        | Error error ->
@@ -1046,6 +1146,18 @@ let () =
             "maintenance rejects symbolic-link candidate snapshot"
             `Quick
             test_maintenance_rejects_symbolic_link_candidate_snapshot;
+          Alcotest.test_case
+            "maintenance exhausted budget is a typed error"
+            `Quick
+            test_maintenance_exhausted_budget_is_a_typed_error;
+          Alcotest.test_case
+            "maintenance exhausted budget leaves candidate snapshot untouched"
+            `Quick
+            test_maintenance_exhausted_budget_leaves_candidate_snapshot_untouched;
+          Alcotest.test_case
+            "maintenance unbounded budget still completes"
+            `Quick
+            test_maintenance_unbounded_budget_still_completes;
         ] );
       ( "atomicity",
         [


### PR DESCRIPTION
## 문제

`Tool_blob_maintenance.run`은 blocking init 안에서 durable consumer 8개 루트를 재귀 전수 스캔하며, 각 파일을 통째로 문자열에 적재하고 줄마다 JSON 파싱합니다. 이 워크스페이스 기준 **1.15 GB / 2,327 파일, warm 22초** — `Bootstrap completed in 23.7s`의 93%입니다.

startup watchdog은 240초 안에 `state_ready`에 도달하지 못하면 프로세스를 종료합니다. **두 예산 사이에 아무 관계가 없었습니다**: 스캔 비용은 워크스페이스 크기에 비례해 자라고, watchdog 예산은 자라지 않습니다.

### 2026-08-05 장애

부팅이 동시 빌드와 겹쳐 모든 init 단계가 약 10배 느려졌습니다.

| 단계 | 정상 부팅 | 장애 부팅 | 배율 |
|---|---:|---:|---:|
| State created | 0.1s | 0.6s | 6x |
| `prepare: transcript_tail` | 1.95s | 29.93s | 15x |
| blob 스캔 | 22s | >210s (미완료) | >9.5x |

```
08:02:11Z  keeper_persistence_prepare: stage=request 0.029673
           ⋯ 3분 28초, 로그 0건 ⋯
08:05:39Z  ERROR [watchdog] Server init did not complete within 240s
                  (elapsed=240.1s, phase=blocking). Exiting.
```

watchdog이 **서빙 준비가 끝난 서버를 종료**했습니다. #3107이 watchdog을 도입해 막으려던 zombie-listener 실패가 다른 문으로 들어온 것입니다. 이후 26분간 다운되어 있었습니다(부모 프로세스가 셸이라 자동 재시작 없음).

## 변경

`run`이 `scan_budget`을 필수 인자로 받습니다.

```ocaml
type scan_budget =
  | Unbounded
  | Bounded_by of { deadline_epoch_seconds : float }
```

`Bounded_by`가 만료되면 순회가 `Scan_budget_exhausted`로 중단됩니다. 이 에러는 `run`의 `let*` 체인을 `save_candidate_snapshot` **이전에** 단락시킵니다.

### 왜 그 위치여야 하는가

삭제 조건은 `previous_candidates ∩ current_candidates`입니다. **부분 스캔 결과를 스냅샷에 쓰면 살아있는 blob이 삭제됩니다** — 미스캔 파일에만 참조가 있는 blob이 candidate로 기록되고, 연속 두 번 같은 파일을 놓치면 교집합에 걸립니다. 기존 코드는 모든 에러가 스냅샷 쓰기 이전에 단락되는 것으로 이 불변식을 지키고 있었고, 예산 초과도 같은 모양을 따릅니다. 결과는 **모든 blob 보존** — 다른 스캔 실패와 동일합니다.

부팅 데드라인은 watchdog 잔여 시간에서 파생합니다:

```ocaml
val remaining_watchdog_budget_sec : reserve_sec:float -> float
(* watchdog_timeout_sec () - elapsed_since_start () - reserve_sec, 0 하한 *)
```

독립 상수 두 개가 따로 표류하지 않도록 `Server_startup_state`가 소유합니다. `reserve_sec`는 스캔 이후 부팅 단계(Runtime_params restore, Domain_pool, keeper gate replay, lazy task, Discord/Slack/gRPC/WS)에 남겨두는 몫이며, 관측치(idle 2초)와 장애 시 관측된 10배 저하를 근거로 60초입니다.

경쟁 데드라인이 없는 호출자는 `Unbounded`를 씁니다. **필수 인자로 만들어** 모든 호출부가 둘 중 무엇인지 명시하도록 강제했습니다.

## 이 PR이 고치지 않는 것

이 워크스페이스에서 스캔은 **한 번도 완주한 적이 없습니다 — 2026-08-01 이후 29부팅 중 0회**. 28회는 다음에서 중단됐습니다:

```
malformed artifact reference path=.../tool_calls/2026-07/30.jsonl line=7054 offset=35
```

해당 줄은 손상 데이터가 아니라 `keeper_artifact_read`의 **툴 설명문**입니다. `keeper_tool_descriptor.ml:1005,1653`이 설명문에 마커 문법을 예시로 인용하고, 그게 `route_evidence.description`으로 영속화되며, `artifact_refs_in_text`는 실제 마커와 마커 문법을 인용한 산문을 구별할 수단이 없습니다.

**별도 이슈로 분리했고, 반드시 이 PR 뒤에 와야 합니다.** 그 중단이 현재 `traces/`(956M)와 `trajectories/`(238M) 스캔을 막는 유일한 장치이기 때문에, 먼저 고치면 스캔이 2.35 GB로 늘어 watchdog kill이 확정적이 됩니다.

## 검증

- `test_tool_blob_store` **36/36 통과** (신규 예산 케이스 3개 포함)
- **음성 대조**: 데드라인 검사를 무력화하면 그것을 단언하는 2개만 `expired budget completed a full scan`으로 실패하고, unbounded 케이스는 통과 유지
- `test_server_runtime_bootstrap`: 실패 집합이 `origin/main`과 **바이트 동일** (기존 11건, 신규 0건)
- `dune build` clean, 변경 파일 전부 `@fmt` clean

## 변경 파일

| 파일 | 내용 |
|---|---|
| `lib/tool_blob_store/tool_blob_maintenance.{ml,mli}` | `scan_budget` 타입, `Scan_budget_exhausted` 변형, 순회 스레딩 |
| `lib/server_startup_state.{ml,mli}` | `remaining_watchdog_budget_sec` |
| `lib/server/server_runtime_bootstrap.ml` | 데드라인 파생, 예산 소진 시 스킵 경로, 낡은 주석 교정 |
| `test/test_tool_blob_store.ml` | 예산 케이스 3개, 기존 호출부 9곳 명시화 |

RFC-WAIVED: 변경 범위가 credential/identity/operator-control/sandbox/dashboard-credential/hooks 어디에도 해당하지 않음. blob maintenance와 startup watchdog 관련 RFC는 `docs/rfc/` 전수 검색 결과 없음.

WORKAROUND-WAIVED: 증상 억제가 아니라 **누락된 계약의 신설**임. 기존에는 무제한 하위 작업이 유한 부모 예산 안에 들어 있었고, 이 PR은 하위 예산을 부모에서 파생시켜 관계를 명시한다. 실패 모드는 catch-all이 아니라 typed variant(`Scan_budget_exhausted`)이며, 기존 실패 경로와 동일한 불변식(전량 보존)을 따른다. 문자열 분류기, 카운터, dedup, N-of-M 패치 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
