### PR TITLE
fix(dashboard): PredecessorSection이 한 번도 렌더된 적 없다 — normalizeTask가 predecessor_task_id를 버린다

### DIFF
--- a/dashboard/src/store-normalizers.test.ts
+++ b/dashboard/src/store-normalizers.test.ts
@@ -121,6 +121,23 @@ describe('normalizeTaskStatus', () => {
     })
   })
 
+  // PredecessorSection guards on this field and returns null when it is absent,
+  // so dropping it here makes the lineage link unrenderable no matter what the
+  // backend sends. The overlay's own test asserts on its source text, which
+  // cannot observe that.
+  it('carries the predecessor link through to the store', () => {
+    expect(normalizeTask({
+      id: 'task-2',
+      title: 'Successor task',
+      predecessor_task_id: 'task-1',
+    })).toMatchObject({ predecessor_task_id: 'task-1' })
+  })
+
+  it('reports an absent predecessor as null, not undefined', () => {
+    expect(normalizeTask({ id: 'task-3', title: 'Root task' }))
+      .toMatchObject({ predecessor_task_id: null })
+  })
+
 })
 
 describe('normalizeMessage', () => {

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -136,6 +136,10 @@ export function normalizeTask(raw: unknown): Task | null {
     completed_at: asString(raw.completed_at),
     cancelled_by: asString(raw.cancelled_by) ?? null,
     reason: asString(raw.reason) ?? null,
+    // The backend has emitted this since RFC-0323 G-8 and PredecessorSection
+    // reads it, but it was never copied here, so every task reached the store
+    // with it undefined and the section returned null on its first guard.
+    predecessor_task_id: asString(raw.predecessor_task_id) ?? null,
     contract,
     handoff_context: handoffContext,
     execution_links: executionLinks,


### PR DESCRIPTION
## 무엇

`PredecessorSection` 이 **한 번도 렌더된 적이 없다.** `normalizeTask` 가 `predecessor_task_id` 를 복사하지 않아서다. 한 줄 추가 + 테스트 2건.

## 경로

```
backend  types_core.ml:744          "predecessor_task_id" 방출
   ↓
store.ts:875   .map(normalizeTask)  ← 여기서 탈락
   ↓
tasks (공유 signal)
   ↓
task-detail-overlay.ts:276
   const predecessorId = task.predecessor_task_id
   if (!predecessorId) return null   ← 항상 여기서 종료
```

`store.ts` 가 유일한 출처다 — 태스크 목록을 `normalizeTask` 로 통과시킨 뒤 오버레이가 읽는 signal 에 쓴다. 타입은 필드를 선언하고 있었고(`types/core.ts:73`), 컴포넌트는 읽고 있었고, 백엔드는 보내고 있었다. 정규화만 빠뜨렸다.

## 이걸 지키던 테스트가 관측할 수 없었던 이유

RFC-0323 G-9 의 테스트는 **자기 소스 파일을 읽어 문자열을 확인한다**:

```ts
const src = readFileSync(SOURCE, 'utf-8')
expect(src).toContain('function PredecessorSection')
expect(src).toContain('task.predecessor_task_id')
```

코드에 그 글자가 있는지만 보므로, 값이 도착하든 말든 통과한다. 이 PR 이 추가하는 두 케이스는 `normalizeTask` 의 **출력**을 단언한다.

## 로컬 검증

```
tsc --noEmit                                          EXIT=0
store-normalizers + task-detail-overlay.class          25/25
```

**테스트가 실패할 능력 증명**: 추가한 필드를 빼면(= 이 PR 이전 상태) 새 케이스 2건이 `FAIL`, exit 1.

```
FAIL  carries the predecessor link through to the store
FAIL  reports an absent predecessor as null, not undefined
Tests  2 failed | 20 passed (22)
```

## 어떻게 찾았나

TS 인터페이스가 선언한 필드 중 그 인터페이스를 만드는 normalizer 가 한 번도 set 하지 않는 것을 스캔했다. 후보 7 건 중 6 건은 normalizer 짝짓기 오류(위양성)였고, 이 한 건이 실재했다.

같은 스캔이 잡은 `DashboardFullHealthResponse.health_detail` 은 위양성이다 — `dashboard.test.ts` 가 `expect(result.health_detail).toBe('full')` 로 실제 단언한다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
