### PR TITLE
refactor(tempo): 한 번도 돌지 않은 적응형 컨트롤러 제거

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 208 unique knobs across 8 modules.
+**Total**: 206 unique knobs across 8 modules.
 
-**Typed getter classification**: 38/121 tagged (`operator`: 38, `algorithm`: 0, `unclassified`: 83).
+**Typed getter classification**: 38/119 tagged (`operator`: 38, `algorithm`: 0, `unclassified`: 81).
 
 ## Env_config_core (23 knobs; typed classification 2/5)
 
@@ -97,80 +97,78 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_DEAD_TTL_SEC` | typed:float | Timeouts | operator | 11 | Dead tombstone TTL: seconds before Dead entries are cleaned up. @category Timeouts @ops_class operator |
 | `MASC_KEEPER_SUPERVISOR_SWEEP_SEC` | typed:float | Timeouts | operator | 7 | Interval between supervisor sweep runs (seconds). @category Timeouts @ops_class operator |
 
-## Env_config_runtime (70 knobs; typed classification 4/55)
+## Env_config_runtime (68 knobs; typed classification 4/53)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_AGENT_RATE_BURST` | typed:int | unclassified | unclassified | 318 | Per-agent burst capacity. Default: 50. |
-| `MASC_AGENT_RATE_LIMIT` | typed:float | unclassified | unclassified | 315 | Per-agent requests per second. Default: 20. |
-| `MASC_AGENT_TRANSPORT` | string_literal | n/a | n/a | 227 | Agent transport type variant (e.g. "grpc", "http", "ws"). |
-| `MASC_BOARD_FLUSHER_INBOX_CAPACITY` | typed:int | Concurrency | operator | 266 | Capacity of the board flusher inbox (scheduled sweep/flush messages enqueued by the sweeper). Single source of truth ... |
-| `MASC_BOARD_FLUSH_INTERVAL_SEC` | typed:float | unclassified | unclassified | 257 | Flush interval for board persistence (seconds). Default: 30. |
-| `MASC_BRIEFING_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 537 | Dashboard mission briefing cache TTL (seconds). Default: 300 (5 min). |
-| `MASC_CACHE_MAX_ENTRIES` | typed:int | unclassified | unclassified | 41 | Maximum total number of cache entries (default 1000) |
-| `MASC_CACHE_MAX_ENTRY_SIZE` | typed:int | unclassified | unclassified | 37 | Maximum size of a single cache entry value in bytes (default 100KB) |
-| `MASC_DASHBOARD_CTX_COMPACTING` | typed:float | unclassified | unclassified | 388 |  |
-| `MASC_DASHBOARD_CTX_HANDOFF_IMMINENT` | typed:float | unclassified | unclassified | 384 | Keeper context-ratio lifecycle thresholds. Higher ratio = closer to context limit = more urgency. |
-| `MASC_DASHBOARD_CTX_PREPARING` | typed:float | unclassified | unclassified | 386 |  |
-| `MASC_DASHBOARD_EXECUTION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 427 | Execution surface compute timeout (light + parameterized). Wraps two [Dashboard_cache.get_or_compute_with_timeout] si... |
-| `MASC_DASHBOARD_EXECUTION_TRUST_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 441 | Execution-trust surface compute timeout. Wraps [Dashboard_cache.get_or_compute_with_timeout] at [server_dashboard_htt... |
-| `MASC_DASHBOARD_KEEPER_ACTION_STALE_SEC` | typed:float | unclassified | unclassified | 379 | Keeper action-age threshold (seconds). Default: 3600 (1 hour). |
-| `MASC_DASHBOARD_MISSION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 451 | Mission card compute timeout. Wraps three [Dashboard_cache.get_or_compute_with_timeout] sites at [server_dashboard_ht... |
-| `MASC_DASHBOARD_RENDER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 484 | Maximum wall-clock for a single dashboard render ([Dashboard_execution.json_render]). Wraps the entire render pipelin... |
-| `MASC_DASHBOARD_SHELL_LIGHT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 471 | Shell render compute timeout (light path). Default 8s. Must remain strictly less than [shell_timeout_sec] so the spli... |
-| `MASC_DASHBOARD_SHELL_PREWARM_OUTER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 416 |  |
-| `MASC_DASHBOARD_SHELL_PREWARM_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 411 | Dashboard shell-cache pre-warm timeouts. The pre-warm fires once on server bootstrap. It is wrapped in two nested tim... |
-| `MASC_DASHBOARD_SHELL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 460 | Shell render compute timeout (full path). Used by [Dashboard_cache.get_or_compute_with_timeout] for the full shell re... |
-| `MASC_DASHBOARD_SIGNAL_LIVE_SEC` | typed:float | unclassified | unclassified | 375 | Duration (seconds) for a signal to count as "live". Default: 300 (5 min). |
-| `MASC_DASHBOARD_SIGNAL_QUIET_SEC` | typed:float | unclassified | unclassified | 371 | Duration (seconds) for borderline "quiet" warning. Default: 600 (10 min). |
-| `MASC_DASHBOARD_SIGNAL_STALE_SEC` | typed:float | unclassified | unclassified | 367 | Duration (seconds) after which a signal is considered stale. Default: 1200 (20 min). |
-| `MASC_EXECUTOR_DOMAIN_COUNT` | typed:int | Concurrency | operator | 53 | Shared executor worker-domain count override. Env: [MASC_EXECUTOR_DOMAIN_COUNT]. Default: unset, use {!Domain_pool}'s... |
-| `MASC_FULL_HEALTH_CRITICAL_FAILURE_THRESHOLD` | typed:int | unclassified | unclassified | 514 | Number of consecutive [/health?full=1] cache-refresh failures that must accumulate before [masc_full_health_refresh_c... |
-| `MASC_FULL_HEALTH_REFRESH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 502 | Full-health snapshot proactive refresh timeout (seconds). Caps a single [/health?full=1] cache refresh attempt in [Se... |
-| `MASC_GRPC_ENABLED` | feature_flag | n/a | n/a | 202 | Whether gRPC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
-| `MASC_GRPC_PORT` | string_literal | n/a | n/a | 198 | gRPC server port. Default: 8936. |
-| `MASC_GRPC_TARGET` | string_literal | n/a | n/a | 206 | gRPC client target address. Derived from grpc_port when unset. |
-| `MASC_HTTP_AUTH_STRICT` | feature_flag | n/a | n/a | 232 |  |
-| `MASC_JANITOR_INTERVAL_SEC` | typed:float | unclassified | unclassified | 553 | Bootstrap janitor tick interval (seconds). Drives the SSE/session/ rate-limit/webrtc reaper loop in [server_bootstrap... |
-| `MASC_LABEL_QUIET_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 529 | Dashboard label "quiet" threshold (seconds). Default: 300 (5 min). |
-| `MASC_LABEL_STUCK_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 533 | Dashboard label "stuck" threshold (seconds). Default: 900 (15 min). |
-| `MASC_LANE_PREFERENCE_TTL_S` | typed:float | Timeouts | operator | 356 | Sticky lane-candidate preference TTL (seconds). After a lane candidate succeeds, later turns on the same lane try it ... |
-| `MASC_LIST_PAGE_SIZE` | typed:int | unclassified | unclassified | 279 | Tool list page size, clamped to [10, 1024]. Default: 512. Re-readable within the process; not a guarantee of shell-le... |
-| `MASC_LOCAL_RUNTIME_COOLDOWN_SEC` | string_literal | n/a | n/a | 330 | Local runtime cooldown (seconds). |
-| `MASC_LOCAL_RUNTIME_DEBUG` | feature_flag | n/a | n/a | 326 | Enable local runtime debug logging. Default: false. |
-| `MASC_LOCAL_WORKER_HEARTBEAT_SEC` | typed:int | unclassified | unclassified | 333 | Local worker heartbeat interval (seconds). Default: 60. |
-| `MASC_MESSAGE_MAX_COUNT` | typed:int | unclassified | unclassified | 144 | Maximum number of message files to retain per workspace (default 200). Oldest messages (by filename sort) are deleted... |
-| `MASC_METRICS_FLUSH_SEC` | typed:float | unclassified | unclassified | 525 | Tool metrics flush interval (seconds). Default: 300 (5 min). |
-| `MASC_OAS_SSE_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 341 | SSE drain interval (seconds). Default: 2.0. |
-| `MASC_ORCHESTRATOR_AGENT` | typed:string | unclassified | unclassified | 67 | Orchestrator agent name |
-| `MASC_ORCHESTRATOR_INTERVAL` | typed:float | unclassified | unclassified | 63 | Orchestrator check interval (seconds) |
-| `MASC_ORCHESTRATOR_MIN_PRIORITY` | typed:int | unclassified | unclassified | 70 |  |
-| `MASC_PUBLIC_TOOLS_EXTRA` | string_literal | n/a | n/a | 284 | Extra public tools (comma-separated names). |
-| `MASC_RATE_BURST` | typed:int | unclassified | unclassified | 312 | Burst capacity. Default: 150. |
-| `MASC_RATE_LIMIT` | typed:float | unclassified | unclassified | 309 | Requests per second. Default: 100. |
-| `MASC_RATE_LIMIT_BUCKET_TTL_SEC` | typed:int | unclassified | unclassified | 567 | Rate-limit bucket staleness TTL (seconds). Buckets with no traffic for this long are reaped by the janitor loop. Defa... |
-| `MASC_REPO_SYNC_INTERVAL_SEC` | typed:float | unclassified | unclassified | 559 | Repository auto-sync interval (seconds). The repo_sync fiber in [server_bootstrap_loops] wakes at this cadence to fet... |
+| `MASC_AGENT_RATE_BURST` | typed:int | unclassified | unclassified | 310 | Per-agent burst capacity. Default: 50. |
+| `MASC_AGENT_RATE_LIMIT` | typed:float | unclassified | unclassified | 307 | Per-agent requests per second. Default: 20. |
+| `MASC_AGENT_TRANSPORT` | string_literal | n/a | n/a | 219 | Agent transport type variant (e.g. "grpc", "http", "ws"). |
+| `MASC_BOARD_FLUSHER_INBOX_CAPACITY` | typed:int | Concurrency | operator | 258 | Capacity of the board flusher inbox (scheduled sweep/flush messages enqueued by the sweeper). Single source of truth ... |
+| `MASC_BOARD_FLUSH_INTERVAL_SEC` | typed:float | unclassified | unclassified | 249 | Flush interval for board persistence (seconds). Default: 30. |
+| `MASC_BRIEFING_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 529 | Dashboard mission briefing cache TTL (seconds). Default: 300 (5 min). |
+| `MASC_CACHE_MAX_ENTRIES` | typed:int | unclassified | unclassified | 33 | Maximum total number of cache entries (default 1000) |
+| `MASC_CACHE_MAX_ENTRY_SIZE` | typed:int | unclassified | unclassified | 29 | Maximum size of a single cache entry value in bytes (default 100KB) |
+| `MASC_DASHBOARD_CTX_COMPACTING` | typed:float | unclassified | unclassified | 380 |  |
+| `MASC_DASHBOARD_CTX_HANDOFF_IMMINENT` | typed:float | unclassified | unclassified | 376 | Keeper context-ratio lifecycle thresholds. Higher ratio = closer to context limit = more urgency. |
+| `MASC_DASHBOARD_CTX_PREPARING` | typed:float | unclassified | unclassified | 378 |  |
+| `MASC_DASHBOARD_EXECUTION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 419 | Execution surface compute timeout (light + parameterized). Wraps two [Dashboard_cache.get_or_compute_with_timeout] si... |
+| `MASC_DASHBOARD_EXECUTION_TRUST_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 433 | Execution-trust surface compute timeout. Wraps [Dashboard_cache.get_or_compute_with_timeout] at [server_dashboard_htt... |
+| `MASC_DASHBOARD_KEEPER_ACTION_STALE_SEC` | typed:float | unclassified | unclassified | 371 | Keeper action-age threshold (seconds). Default: 3600 (1 hour). |
+| `MASC_DASHBOARD_MISSION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 443 | Mission card compute timeout. Wraps three [Dashboard_cache.get_or_compute_with_timeout] sites at [server_dashboard_ht... |
+| `MASC_DASHBOARD_RENDER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 476 | Maximum wall-clock for a single dashboard render ([Dashboard_execution.json_render]). Wraps the entire render pipelin... |
+| `MASC_DASHBOARD_SHELL_LIGHT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 463 | Shell render compute timeout (light path). Default 8s. Must remain strictly less than [shell_timeout_sec] so the spli... |
+| `MASC_DASHBOARD_SHELL_PREWARM_OUTER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 408 |  |
+| `MASC_DASHBOARD_SHELL_PREWARM_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 403 | Dashboard shell-cache pre-warm timeouts. The pre-warm fires once on server bootstrap. It is wrapped in two nested tim... |
+| `MASC_DASHBOARD_SHELL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 452 | Shell render compute timeout (full path). Used by [Dashboard_cache.get_or_compute_with_timeout] for the full shell re... |
+| `MASC_DASHBOARD_SIGNAL_LIVE_SEC` | typed:float | unclassified | unclassified | 367 | Duration (seconds) for a signal to count as "live". Default: 300 (5 min). |
+| `MASC_DASHBOARD_SIGNAL_QUIET_SEC` | typed:float | unclassified | unclassified | 363 | Duration (seconds) for borderline "quiet" warning. Default: 600 (10 min). |
+| `MASC_DASHBOARD_SIGNAL_STALE_SEC` | typed:float | unclassified | unclassified | 359 | Duration (seconds) after which a signal is considered stale. Default: 1200 (20 min). |
+| `MASC_EXECUTOR_DOMAIN_COUNT` | typed:int | Concurrency | operator | 45 | Shared executor worker-domain count override. Env: [MASC_EXECUTOR_DOMAIN_COUNT]. Default: unset, use {!Domain_pool}'s... |
+| `MASC_FULL_HEALTH_CRITICAL_FAILURE_THRESHOLD` | typed:int | unclassified | unclassified | 506 | Number of consecutive [/health?full=1] cache-refresh failures that must accumulate before [masc_full_health_refresh_c... |
+| `MASC_FULL_HEALTH_REFRESH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 494 | Full-health snapshot proactive refresh timeout (seconds). Caps a single [/health?full=1] cache refresh attempt in [Se... |
+| `MASC_GRPC_ENABLED` | feature_flag | n/a | n/a | 194 | Whether gRPC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
+| `MASC_GRPC_PORT` | string_literal | n/a | n/a | 190 | gRPC server port. Default: 8936. |
+| `MASC_GRPC_TARGET` | string_literal | n/a | n/a | 198 | gRPC client target address. Derived from grpc_port when unset. |
+| `MASC_HTTP_AUTH_STRICT` | feature_flag | n/a | n/a | 224 |  |
+| `MASC_JANITOR_INTERVAL_SEC` | typed:float | unclassified | unclassified | 545 | Bootstrap janitor tick interval (seconds). Drives the SSE/session/ rate-limit/webrtc reaper loop in [server_bootstrap... |
+| `MASC_LABEL_QUIET_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 521 | Dashboard label "quiet" threshold (seconds). Default: 300 (5 min). |
+| `MASC_LABEL_STUCK_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 525 | Dashboard label "stuck" threshold (seconds). Default: 900 (15 min). |
+| `MASC_LANE_PREFERENCE_TTL_S` | typed:float | Timeouts | operator | 348 | Sticky lane-candidate preference TTL (seconds). After a lane candidate succeeds, later turns on the same lane try it ... |
+| `MASC_LIST_PAGE_SIZE` | typed:int | unclassified | unclassified | 271 | Tool list page size, clamped to [10, 1024]. Default: 512. Re-readable within the process; not a guarantee of shell-le... |
+| `MASC_LOCAL_RUNTIME_COOLDOWN_SEC` | string_literal | n/a | n/a | 322 | Local runtime cooldown (seconds). |
+| `MASC_LOCAL_RUNTIME_DEBUG` | feature_flag | n/a | n/a | 318 | Enable local runtime debug logging. Default: false. |
+| `MASC_LOCAL_WORKER_HEARTBEAT_SEC` | typed:int | unclassified | unclassified | 325 | Local worker heartbeat interval (seconds). Default: 60. |
+| `MASC_MESSAGE_MAX_COUNT` | typed:int | unclassified | unclassified | 136 | Maximum number of message files to retain per workspace (default 200). Oldest messages (by filename sort) are deleted... |
+| `MASC_METRICS_FLUSH_SEC` | typed:float | unclassified | unclassified | 517 | Tool metrics flush interval (seconds). Default: 300 (5 min). |
+| `MASC_OAS_SSE_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 333 | SSE drain interval (seconds). Default: 2.0. |
+| `MASC_ORCHESTRATOR_AGENT` | typed:string | unclassified | unclassified | 59 | Orchestrator agent name |
+| `MASC_ORCHESTRATOR_INTERVAL` | typed:float | unclassified | unclassified | 55 | Orchestrator check interval (seconds) |
+| `MASC_ORCHESTRATOR_MIN_PRIORITY` | typed:int | unclassified | unclassified | 62 |  |
+| `MASC_PUBLIC_TOOLS_EXTRA` | string_literal | n/a | n/a | 276 | Extra public tools (comma-separated names). |
+| `MASC_RATE_BURST` | typed:int | unclassified | unclassified | 304 | Burst capacity. Default: 150. |
+| `MASC_RATE_LIMIT` | typed:float | unclassified | unclassified | 301 | Requests per second. Default: 100. |
+| `MASC_RATE_LIMIT_BUCKET_TTL_SEC` | typed:int | unclassified | unclassified | 559 | Rate-limit bucket staleness TTL (seconds). Buckets with no traffic for this long are reaped by the janitor loop. Defa... |
+| `MASC_REPO_SYNC_INTERVAL_SEC` | typed:float | unclassified | unclassified | 551 | Repository auto-sync interval (seconds). The repo_sync fiber in [server_bootstrap_loops] wakes at this cadence to fet... |
 | `MASC_SESSION_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 8 | Maximum session age before cleanup (seconds) |
 | `MASC_SESSION_SSE_GRACE_PERIOD_SEC` | typed:float | unclassified | unclassified | 13 | Grace period after SSE disconnect before reaping transport session (seconds). Prevents "Unknown Mcp-Session-Id" error... |
-| `MASC_SIDECAR_CONTROL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 593 | Subprocess timeout (seconds) for sidecar control commands — [stop], [tail], and similar quick housekeeping operatio... |
-| `MASC_SIDECAR_RECONCILE_BACKOFF_SEC` | typed:float | unclassified | unclassified | 581 | Backoff window (seconds) between repeated same-generation [running + unavailable] start dispatches. Default: 30 (matc... |
-| `MASC_SIDECAR_SCHEMA_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 609 | Subprocess timeout (seconds) for sidecar Python schema generation. Wraps [Process_eio.run_argv_with_status] at [serve... |
-| `MASC_SSE_BUFFER_TTL_SEC` | typed:float | unclassified | unclassified | 541 | SSE buffer TTL (seconds). Default: 300 (5 min). |
-| `MASC_STALLED_SESSION_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 545 | Operator digest stalled session threshold (seconds). Default: 300 (5 min). |
-| `MASC_STARTUP_WATCHDOG_SEC` | typed:float | unclassified | unclassified | 243 | Startup watchdog timeout, clamped to [30, 600]. Default: 240. Re-readable within the process, but operationally a boo... |
-| `MASC_TEMPO_DEFAULT_INTERVAL_SEC` | typed:float | unclassified | unclassified | 29 | Default polling interval (seconds) |
-| `MASC_TEMPO_MAX_INTERVAL_SEC` | typed:float | unclassified | unclassified | 25 | Maximum polling interval (seconds) - for idle tempo |
-| `MASC_TEMPO_MIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 21 | Minimum polling interval (seconds) - for urgent tempo |
-| `MASC_USE_H2` | string_literal | n/a | n/a | 221 | HTTP mode: typed variant for "auto", "h2_only", "h1_only". |
-| `MASC_WEBRTC_ENABLED` | feature_flag | n/a | n/a | 217 | Whether WebRTC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
-| `MASC_WEB_SEARCH_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 300 |  |
-| `MASC_WEB_SEARCH_FALLBACKS` | string_literal | n/a | n/a | 293 |  |
-| `MASC_WEB_SEARCH_PROVIDER` | string_literal | n/a | n/a | 287 |  |
-| `MASC_WEB_SEARCH_PROVIDER_ORDER` | string_literal | n/a | n/a | 290 |  |
-| `MASC_WEB_SEARCH_TIMEOUT_SEC` | typed:int | unclassified | unclassified | 296 |  |
-| `MASC_WORKSPACE_FILE_MAX_READ_BYTES` | typed:int | Policies | operator | 619 | Maximum bytes served by the IDE workspace file endpoint in one response. The route rejects larger files instead of ma... |
-| `MASC_WS_ENABLED` | feature_flag | n/a | n/a | 213 | Whether WebSocket transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at... |
-| `MASC_WS_PORT` | string_literal | n/a | n/a | 209 | WebSocket server port. Default: 8937. |
+| `MASC_SIDECAR_CONTROL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 585 | Subprocess timeout (seconds) for sidecar control commands — [stop], [tail], and similar quick housekeeping operatio... |
+| `MASC_SIDECAR_RECONCILE_BACKOFF_SEC` | typed:float | unclassified | unclassified | 573 | Backoff window (seconds) between repeated same-generation [running + unavailable] start dispatches. Default: 30 (matc... |
+| `MASC_SIDECAR_SCHEMA_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 601 | Subprocess timeout (seconds) for sidecar Python schema generation. Wraps [Process_eio.run_argv_with_status] at [serve... |
+| `MASC_SSE_BUFFER_TTL_SEC` | typed:float | unclassified | unclassified | 533 | SSE buffer TTL (seconds). Default: 300 (5 min). |
+| `MASC_STALLED_SESSION_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 537 | Operator digest stalled session threshold (seconds). Default: 300 (5 min). |
+| `MASC_STARTUP_WATCHDOG_SEC` | typed:float | unclassified | unclassified | 235 | Startup watchdog timeout, clamped to [30, 600]. Default: 240. Re-readable within the process, but operationally a boo... |
+| `MASC_TEMPO_DEFAULT_INTERVAL_SEC` | typed:float | unclassified | unclassified | 21 | Polling interval (seconds) published to operator surfaces |
+| `MASC_USE_H2` | string_literal | n/a | n/a | 213 | HTTP mode: typed variant for "auto", "h2_only", "h1_only". |
+| `MASC_WEBRTC_ENABLED` | feature_flag | n/a | n/a | 209 | Whether WebRTC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
+| `MASC_WEB_SEARCH_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 292 |  |
+| `MASC_WEB_SEARCH_FALLBACKS` | string_literal | n/a | n/a | 285 |  |
+| `MASC_WEB_SEARCH_PROVIDER` | string_literal | n/a | n/a | 279 |  |
+| `MASC_WEB_SEARCH_PROVIDER_ORDER` | string_literal | n/a | n/a | 282 |  |
+| `MASC_WEB_SEARCH_TIMEOUT_SEC` | typed:int | unclassified | unclassified | 288 |  |
+| `MASC_WORKSPACE_FILE_MAX_READ_BYTES` | typed:int | Policies | operator | 611 | Maximum bytes served by the IDE workspace file endpoint in one response. The route rejects larger files instead of ma... |
+| `MASC_WS_ENABLED` | feature_flag | n/a | n/a | 205 | Whether WebSocket transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at... |
+| `MASC_WS_PORT` | string_literal | n/a | n/a | 201 | WebSocket server port. Default: 8937. |
 
 ## Env_config_runtime_services (18 knobs; typed classification 8/14)
 
@@ -247,8 +245,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 134 |  |
 | `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 133 |  |
 | `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 460 |  |
-| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 486 |  |
-| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 494 |  |
+| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 482 |  |
+| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 490 |  |
 | `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 434 |  |
 | `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 436 |  |
 | `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 438 |  |
@@ -256,8 +254,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 446 |  |
 | `MASC_TELEMETRY_MAX_BYTES` | string_literal | n/a | n/a | 48 |  |
 | `MASC_TELEMETRY_RETENTION_DAYS` | string_literal | n/a | n/a | 45 |  |
-| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 476 |  |
-| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 478 |  |
+| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 472 |  |
+| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 474 |  |
 | `MASC_TLA_TRACE` | string_literal | n/a | n/a | 127 |  |
 | `MASC_WS_ACK_STALE_THRESHOLD_SEC` | string_literal | n/a | n/a | 91 |  |
 | `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 88 |  |

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -16,15 +16,7 @@ end
 (** {1 Tempo (Polling Interval) Configuration} *)
 
 module Tempo = struct
-  (** Minimum polling interval (seconds) - for urgent tempo *)
-  let min_interval_seconds =
-    get_float ~default:60.0 "MASC_TEMPO_MIN_INTERVAL_SEC"
-
-  (** Maximum polling interval (seconds) - for idle tempo *)
-  let max_interval_seconds =
-    get_float ~default:600.0 "MASC_TEMPO_MAX_INTERVAL_SEC"
-
-  (** Default polling interval (seconds) *)
+  (** Polling interval (seconds) published to operator surfaces *)
   let default_interval_seconds =
     get_float ~default:300.0 "MASC_TEMPO_DEFAULT_INTERVAL_SEC"
 end

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -19,8 +19,6 @@ end
 (** {1 Tempo (polling interval)} *)
 
 module Tempo : sig
-  val min_interval_seconds : float
-  val max_interval_seconds : float
   val default_interval_seconds : float
 end
 

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -464,11 +464,7 @@ let telemetry_entries =
 let tempo_entries =
   [
     entry ~default:"300.0" "MASC_TEMPO_DEFAULT_INTERVAL_SEC"
-      "Default polling interval (seconds)";
-    entry ~default:"600.0" "MASC_TEMPO_MAX_INTERVAL_SEC"
-      "Maximum polling interval for idle tempo (seconds)";
-    entry ~default:"60.0" "MASC_TEMPO_MIN_INTERVAL_SEC"
-      "Minimum polling interval for urgent tempo (seconds)";
+      "Polling interval published to operator surfaces (seconds)";
   ]
 
 let test_entries =

--- a/lib/tempo.ml
+++ b/lib/tempo.ml
@@ -1,148 +1,21 @@
-(** MASC Tempo Control - Dynamic Orchestrator Interval
+(** Tempo — the orchestrator polling interval published to operator surfaces.
 
-    Cluster tempo control for adaptive orchestration:
-    - Urgent tasks (priority 1-2) → Fast tempo (60s)
-    - Normal tasks (priority 3) → Normal tempo (300s)
-    - Idle (no tasks) → Slow tempo (600s)
+    This was an adaptive controller: it read the backlog, mapped the priority
+    mix to a fast/normal/slow interval, and persisted the choice to
+    [.masc/tempo.json]. Nothing ever called the adjusting half, so the file was
+    never written and every read returned the configured default. What the
+    dashboards showed as a tempo was that constant.
 
-    Storage: .masc/tempo.json
-*)
+    The constant is what remains. It is still published, so operator surfaces
+    keep their field, and it is now visibly a setting rather than a
+    measurement.
 
-(** Tempo configuration *)
-type tempo_config = {
-  min_interval_s: float;      (* Minimum interval (fast tempo) *)
-  max_interval_s: float;      (* Maximum interval (slow tempo) *)
-  default_interval_s: float;  (* Default interval *)
-  adaptive: bool;             (* Enable adaptive tempo *)
-}
+    The number is [MASC_TEMPO_DEFAULT_INTERVAL_SEC], which is not the interval
+    the orchestrator actually runs at -- that is
+    [Env_config.Orchestrator.check_interval_seconds]. Reconciling the two
+    changes what operator surfaces report and is left to its own change. *)
 
-(** Current tempo state *)
-type tempo_state = {
-  current_interval_s: float;
-  last_adjusted: float;
-  reason: string;
-}
+type tempo_state = { current_interval_s : float }
 
-(** Default configuration - from Env_config *)
-let default_config = {
-  min_interval_s = Env_config.Tempo.min_interval_seconds;
-  max_interval_s = Env_config.Tempo.max_interval_seconds;
-  default_interval_s = Env_config.Tempo.default_interval_seconds;
-  adaptive = true;
-}
-
-(** Get tempo file path *)
-let tempo_file (config : Workspace_utils.config) =
-  Filename.concat (Workspace_utils.masc_dir config) "tempo.json"
-
-(** State to JSON *)
-let state_to_json (state : tempo_state) : Yojson.Safe.t =
-  `Assoc [
-    ("current_interval_s", `Float state.current_interval_s);
-    ("last_adjusted", `Float state.last_adjusted);
-    ("reason", `String state.reason);
-  ]
-
-(** State from JSON *)
-let state_of_json (json : Yojson.Safe.t) : tempo_state option =
-  let current_interval_s = Json_util.get_float json "current_interval_s" in
-  let last_adjusted = Json_util.get_float json "last_adjusted" in
-  let reason = Json_util.get_string json "reason" in
-  match current_interval_s, last_adjusted, reason with
-  | Some current_interval_s, Some last_adjusted, Some reason ->
-    Some { current_interval_s; last_adjusted; reason }
-  | _ -> None
-
-(** Load current tempo state *)
-let load_state (config : Workspace_utils.config) : tempo_state =
-  let default_state = { current_interval_s = default_config.default_interval_s;
-                        last_adjusted = 0.0; reason = "default" } in
-  let path = tempo_file config in
-  if Sys.file_exists path then
-    match Safe_ops.read_json_file_safe path with
-    | Ok json ->
-      (match state_of_json json with Some state -> state | None -> default_state)
-    | Error e ->
-        Log.Workspace.debug "tempo: state load failed (%s): %s" path e;
-        default_state
-  else
-    { current_interval_s = default_config.default_interval_s;
-      last_adjusted = 0.0;
-      reason = "default" }
-
-(** Save tempo state *)
-let save_state (config : Workspace_utils.config) (state : tempo_state) : unit =
-  let path = tempo_file config in
-  let masc_dir = Workspace_utils.masc_dir config in
-  Fs_compat.mkdir_p masc_dir;
-  let json = state_to_json state in
-  let content = Yojson.Safe.pretty_to_string json in
-  Fs_compat.save_file path content
-
-(** Set tempo manually *)
-let set_tempo (config : Workspace_utils.config) ~interval_s ~reason : tempo_state =
-  let clamped =
-    max default_config.min_interval_s
-      (min default_config.max_interval_s interval_s)
-  in
-  let state = {
-    current_interval_s = clamped;
-    last_adjusted = Time_compat.now ();
-    reason;
-  } in
-  save_state config state;
-  state
-
-(** Get current tempo *)
-let get_tempo (config : Workspace_utils.config) : tempo_state =
-  load_state config
-
-let is_pending_task (task : Masc_domain.task) : bool =
-  not (Masc_domain.task_status_is_terminal task.task_status)
-
-(** Calculate adaptive tempo based on task urgency *)
-let calculate_adaptive_tempo (tasks : Masc_domain.task list) : float * string =
-  if tasks = [] then
-    (default_config.max_interval_s, "idle - no pending tasks")
-  else
-    let urgent_count = List.filter (fun t -> t.Masc_domain.priority <= 2) tasks |> List.length in
-    let high_count = List.filter (fun t -> t.Masc_domain.priority = 3) tasks |> List.length in
-    if urgent_count > 0 then
-      (default_config.min_interval_s,
-       Printf.sprintf "fast - %d urgent task(s)" urgent_count)
-    else if high_count > 0 then
-      (default_config.default_interval_s,
-       Printf.sprintf "normal - %d pending task(s)" high_count)
-    else
-      (default_config.max_interval_s,
-       Printf.sprintf "slow - %d low priority task(s)" (List.length tasks))
-
-(** Adjust tempo adaptively based on current tasks *)
-let adjust_tempo (config : Workspace_utils.config) : tempo_state =
-  let tasks = Workspace.get_tasks_raw config in
-  let pending = List.filter is_pending_task tasks in
-  let (interval, reason) = calculate_adaptive_tempo pending in
-  let state = set_tempo config ~interval_s:interval ~reason in
-  state
-
-(** Format tempo state for display *)
-let format_state (state : tempo_state) : string =
-  let interval_str =
-    if state.current_interval_s < 120.0 then
-      Printf.sprintf "%.0fs" state.current_interval_s
-    else
-      Printf.sprintf "%.1fm" (state.current_interval_s /. 60.0)
-  in
-  let age =
-    let elapsed = Time_compat.now () -. state.last_adjusted in
-    if elapsed < 60.0 then "just now"
-    else if elapsed < Masc_time_constants.hour then Printf.sprintf "%.0fm ago" (elapsed /. 60.0)
-    else Printf.sprintf "%.1fh ago" (elapsed /. Masc_time_constants.hour)
-  in
-  Printf.sprintf "⏱️ Tempo: %s (%s, adjusted %s)" interval_str state.reason age
-
-(** Reset tempo to default *)
-let reset_tempo (config : Workspace_utils.config) : tempo_state =
-  set_tempo config
-    ~interval_s:default_config.default_interval_s
-    ~reason:"reset to default"
+let get_tempo (_config : Workspace_utils.config) : tempo_state =
+  { current_interval_s = Env_config.Tempo.default_interval_seconds }

--- a/lib/tempo.mli
+++ b/lib/tempo.mli
@@ -1,81 +1,9 @@
-(** MASC Tempo Control — Dynamic Orchestrator Interval.
+(** Tempo — the orchestrator polling interval published to operator surfaces.
 
-    Cluster tempo control for adaptive orchestration:
-    - Urgent tasks (priority 1-2) → Fast tempo (min_interval_s)
-    - Normal tasks (priority 3) → Normal tempo (default_interval_s)
-    - Idle (no pending tasks) → Slow tempo (max_interval_s)
+    The value is [MASC_TEMPO_DEFAULT_INTERVAL_SEC], a setting rather than a
+    measurement: nothing adjusts it at runtime, and it is not the interval the
+    orchestrator runs at ([Env_config.Orchestrator.check_interval_seconds]). *)
 
-    Storage: [.masc/tempo.json]. *)
+type tempo_state = { current_interval_s : float }
 
-(** {1 Types} *)
-
-type tempo_config = {
-  min_interval_s : float;      (** Minimum interval (fast tempo) *)
-  max_interval_s : float;      (** Maximum interval (slow tempo) *)
-  default_interval_s : float;
-  adaptive : bool;             (** Enable adaptive tempo *)
-}
-
-type tempo_state = {
-  current_interval_s : float;
-  last_adjusted : float;
-  reason : string;
-}
-
-(** {1 Configuration} *)
-
-(** Loaded from [Env_config.Tempo.*_interval_seconds]. [adaptive = true]. *)
-val default_config : tempo_config
-
-(** [tempo_file config] = [<masc_dir(config)>/tempo.json]. *)
-val tempo_file : Workspace_utils.config -> string
-
-(** {1 State serialisation} *)
-
-val state_to_json : tempo_state -> Yojson.Safe.t
-
-(** Returns [None] on [Yojson.Safe.Util.Type_error] (logged). *)
-val state_of_json : Yojson.Safe.t -> tempo_state option
-
-(** {1 State I/O} *)
-
-(** Reads [.masc/tempo.json]. On missing file or load/parse failure
-    returns a [default_config.default_interval_s] state with reason
-    ["default"]. *)
-val load_state : Workspace_utils.config -> tempo_state
-
-(** Persists [state] to [tempo_file config] (creates parent dir). *)
-val save_state : Workspace_utils.config -> tempo_state -> unit
-
-(** {1 Tempo adjustment} *)
-
-(** [set_tempo config ~interval_s ~reason] clamps [interval_s] to
-    [[min_interval_s; max_interval_s]], updates [last_adjusted], and
-    persists. *)
-val set_tempo :
-  Workspace_utils.config -> interval_s:float -> reason:string -> tempo_state
-
-(** Alias for {!load_state}. *)
 val get_tempo : Workspace_utils.config -> tempo_state
-
-val is_pending_task : Masc_domain.task -> bool
-
-(** [(interval, reason)] derived from priority mix:
-    - any task with [priority <= 2] → [min_interval_s]
-    - else any task with [priority = 3] → [default_interval_s]
-    - else → [max_interval_s]
-    - empty list → [max_interval_s] with ["idle - no pending tasks"]. *)
-val calculate_adaptive_tempo : Masc_domain.task list -> float * string
-
-(** Adjusts tempo from [Workspace.get_tasks_raw config] via
-    {!calculate_adaptive_tempo} and persists. *)
-val adjust_tempo : Workspace_utils.config -> tempo_state
-
-(** {1 Presentation} *)
-
-(** Human-readable status line:
-    ["⏱️ Tempo: <Ns|N.Nm> (<reason>, adjusted <just now|Nm ago|N.Nh ago>)"]. *)
-val format_state : tempo_state -> string
-
-(** Writes [default_interval_s] with reason ["reset to default"]. *)
-val reset_tempo : Workspace_utils.config -> tempo_state

--- a/test/test_misc_coverage.ml
+++ b/test/test_misc_coverage.ml
@@ -130,22 +130,9 @@ let test_env_session_max_age () =
   let max_age = Env_config.Session.max_age_seconds in
   check bool "positive max_age" true (max_age > 0.0)
 
-let test_env_tempo_min () =
-  let min = Env_config.Tempo.min_interval_seconds in
-  check bool "positive min" true (min > 0.0)
-
-let test_env_tempo_max () =
-  let max = Env_config.Tempo.max_interval_seconds in
-  check bool "positive max" true (max > 0.0)
-
 let test_env_tempo_default () =
   let default = Env_config.Tempo.default_interval_seconds in
   check bool "positive default" true (default > 0.0)
-
-let test_env_tempo_ordering () =
-  let min = Env_config.Tempo.min_interval_seconds in
-  let max = Env_config.Tempo.max_interval_seconds in
-  check bool "min <= max" true (min <= max)
 
 let test_env_orchestrator_interval () =
   let interval = Env_config.Orchestrator.check_interval_seconds in
@@ -200,10 +187,7 @@ let () =
       test_case "max_age" `Quick test_env_session_max_age;
     ];
     "env_config.tempo", [
-      test_case "min" `Quick test_env_tempo_min;
-      test_case "max" `Quick test_env_tempo_max;
       test_case "default" `Quick test_env_tempo_default;
-      test_case "ordering" `Quick test_env_tempo_ordering;
     ];
     "env_config.orchestrator", [
       test_case "interval" `Quick test_env_orchestrator_interval;

--- a/test/test_tempo_coverage.ml
+++ b/test/test_tempo_coverage.ml
@@ -1,479 +1,55 @@
-(** Tempo Module Coverage Tests
+(** What Tempo publishes.
 
-    Tests for MASC Tempo Control:
-    - state_to_json / state_of_json: JSON serialization
-    - is_pending_task: task status classification
-    - calculate_adaptive_tempo: tempo calculation logic
-*)
+    This file used to cover an adaptive controller: JSON round-trips for a
+    persisted state, a pending-task classifier, and a priority-to-interval
+    calculation with fast/normal/slow arms. None of it ran in production --
+    nothing called the adjusting half, so the state file was never written and
+    every read returned the configured default. The tests passed because they
+    called the functions themselves.
+
+    What is left is the constant those surfaces were actually showing, so these
+    cases check that: the published interval is the configured one, and it does
+    not vary with the workspace it is asked about. *)
 
 open Alcotest
 
 module Tempo = Masc.Tempo
-module Types = Masc_domain
+module Env_config = Env_config
 
-(* ============================================================
-   state_to_json Tests
-   ============================================================ *)
+let config_for base_path = Masc.Workspace.default_config base_path
 
-let test_state_to_json_has_fields () =
-  let state : Tempo.tempo_state = {
-    current_interval_s = 300.0;
-    last_adjusted = 1704067200.0;
-    reason = "test reason";
-  } in
-  let json = Tempo.state_to_json state in
-  match json with
-  | `Assoc fields ->
-    check bool "has current_interval_s" true (List.mem_assoc "current_interval_s" fields);
-    check bool "has last_adjusted" true (List.mem_assoc "last_adjusted" fields);
-    check bool "has reason" true (List.mem_assoc "reason" fields)
-  | _ -> fail "expected Assoc"
+let test_publishes_the_configured_interval () =
+  let tempo = Tempo.get_tempo (config_for "/tmp/tempo-coverage-a") in
+  check
+    (float 0.001)
+    "published interval is MASC_TEMPO_DEFAULT_INTERVAL_SEC"
+    Env_config.Tempo.default_interval_seconds
+    tempo.Tempo.current_interval_s
 
-let test_state_to_json_interval_value () =
-  let state : Tempo.tempo_state = {
-    current_interval_s = 60.0;
-    last_adjusted = 0.0;
-    reason = "fast";
-  } in
-  let json = Tempo.state_to_json state in
-  match json with
-  | `Assoc fields ->
-    (match List.assoc_opt "current_interval_s" fields with
-     | Some (`Float f) -> check (float 0.1) "interval" 60.0 f
-     | _ -> fail "expected Float")
-  | _ -> fail "expected Assoc"
+(* The signature still takes a config because operator surfaces pass one. It is
+   a setting, so two workspaces must report the same number -- a difference
+   would mean something is adjusting it again. *)
+let test_does_not_vary_by_workspace () =
+  let a = Tempo.get_tempo (config_for "/tmp/tempo-coverage-a") in
+  let b = Tempo.get_tempo (config_for "/tmp/tempo-coverage-b") in
+  check
+    (float 0.001)
+    "same interval for two workspaces"
+    a.Tempo.current_interval_s
+    b.Tempo.current_interval_s
 
-let test_state_to_json_reason_value () =
-  let state : Tempo.tempo_state = {
-    current_interval_s = 300.0;
-    last_adjusted = 0.0;
-    reason = "normal tempo";
-  } in
-  let json = Tempo.state_to_json state in
-  match json with
-  | `Assoc fields ->
-    (match List.assoc_opt "reason" fields with
-     | Some (`String s) -> check string "reason" "normal tempo" s
-     | _ -> fail "expected String")
-  | _ -> fail "expected Assoc"
-
-(* ============================================================
-   state_of_json Tests
-   ============================================================ *)
-
-let test_state_of_json_valid () =
-  let json = `Assoc [
-    ("current_interval_s", `Float 300.0);
-    ("last_adjusted", `Float 1704067200.0);
-    ("reason", `String "test");
-  ] in
-  match Tempo.state_of_json json with
-  | Some state ->
-    check (float 0.1) "interval" 300.0 state.current_interval_s;
-    check string "reason" "test" state.reason
-  | None -> fail "expected Some"
-
-let test_state_of_json_missing_field () =
-  let json = `Assoc [
-    ("current_interval_s", `Float 300.0);
-  ] in
-  match Tempo.state_of_json json with
-  | None -> ()
-  | Some _ -> fail "expected None for missing fields"
-
-let test_state_of_json_invalid_type () =
-  let json = `Assoc [
-    ("current_interval_s", `String "not a float");
-    ("last_adjusted", `Float 0.0);
-    ("reason", `String "test");
-  ] in
-  match Tempo.state_of_json json with
-  | None -> ()
-  | Some _ -> fail "expected None for invalid type"
-
-let test_state_of_json_not_assoc () =
-  let json = `String "not an object" in
-  match Tempo.state_of_json json with
-  | None -> ()
-  | Some _ -> fail "expected None for non-object"
-
-let test_state_of_json_roundtrip () =
-  let original : Tempo.tempo_state = {
-    current_interval_s = 600.0;
-    last_adjusted = 1704067200.0;
-    reason = "slow tempo - idle";
-  } in
-  let json = Tempo.state_to_json original in
-  match Tempo.state_of_json json with
-  | Some state ->
-    check (float 0.1) "interval" original.current_interval_s state.current_interval_s;
-    check string "reason" original.reason state.reason
-  | None -> fail "roundtrip failed"
-
-(* ============================================================
-   is_pending_task Tests
-   ============================================================ *)
-
-let make_task ~id ~status : Masc_domain.task = {
-  id;
-  title = "Test Task";
-  description = "";
-  task_status = status;
-  priority = 3;
-  files = [];
-  created_at = "2024-01-01T00:00:00Z";
-  created_by = None;
-  predecessor_task_id = None;
-  contract = None; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None;
-}
-
-let test_is_pending_task_todo () =
-  let task = make_task ~id:"t1" ~status:Masc_domain.Todo in
-  check bool "todo is pending" true (Tempo.is_pending_task task)
-
-let test_is_pending_task_claimed () =
-  let task = make_task ~id:"t2" ~status:(Masc_domain.Claimed { assignee = "claude"; claimed_at = "2024-01-01T00:00:00Z" }) in
-  check bool "claimed is pending" true (Tempo.is_pending_task task)
-
-let test_is_pending_task_in_progress () =
-  let task = make_task ~id:"t3" ~status:(Masc_domain.InProgress { assignee = "claude"; started_at = "2024-01-01T00:00:00Z" }) in
-  check bool "in_progress is pending" true (Tempo.is_pending_task task)
-
-let test_is_pending_task_done () =
-  let task = make_task ~id:"t4" ~status:(Masc_domain.Done { assignee = "claude"; completed_at = "2024-01-01T00:00:00Z"; notes = None }) in
-  check bool "done is not pending" false (Tempo.is_pending_task task)
-
-let test_is_pending_task_cancelled () =
-  let task = make_task ~id:"t5" ~status:(Masc_domain.Cancelled { cancelled_by = "user"; cancelled_at = "2024-01-01T00:00:00Z"; reason = Some "test" }) in
-  check bool "cancelled is not pending" false (Tempo.is_pending_task task)
-
-(* ============================================================
-   calculate_adaptive_tempo Tests
-   ============================================================ *)
-
-let make_task_with_priority ~id ~priority : Masc_domain.task = {
-  id;
-  title = "Task";
-  description = "";
-  task_status = Masc_domain.Todo;
-  priority;
-  files = [];
-  created_at = "2024-01-01T00:00:00Z";
-  created_by = None;
-  predecessor_task_id = None;
-  contract = None; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None;
-}
-
-let test_calculate_adaptive_tempo_empty () =
-  let (interval, reason) = Tempo.calculate_adaptive_tempo [] in
-  check (float 0.1) "max interval for empty" 600.0 interval;
-  check bool "reason not empty" true (String.length reason > 0)
-
-let test_calculate_adaptive_tempo_urgent () =
-  let tasks = [
-    make_task_with_priority ~id:"t1" ~priority:1;
-    make_task_with_priority ~id:"t2" ~priority:3;
-  ] in
-  let (interval, reason) = Tempo.calculate_adaptive_tempo tasks in
-  check (float 0.1) "min interval for urgent" 60.0 interval;
-  check bool "reason contains fast" true
-    (try let _ = Str.search_forward (Str.regexp "fast") reason 0 in true
-     with Not_found -> false)
-
-let test_calculate_adaptive_tempo_priority_2 () =
-  let tasks = [make_task_with_priority ~id:"t1" ~priority:2] in
-  let (interval, _) = Tempo.calculate_adaptive_tempo tasks in
-  check (float 0.1) "min interval for priority 2" 60.0 interval
-
-let test_calculate_adaptive_tempo_normal () =
-  let tasks = [
-    make_task_with_priority ~id:"t1" ~priority:3;
-    make_task_with_priority ~id:"t2" ~priority:3;
-  ] in
-  let (interval, reason) = Tempo.calculate_adaptive_tempo tasks in
-  check (float 0.1) "default interval for normal" 300.0 interval;
-  check bool "reason contains normal" true
-    (try let _ = Str.search_forward (Str.regexp "normal") reason 0 in true
-     with Not_found -> false)
-
-let test_calculate_adaptive_tempo_low_priority () =
-  let tasks = [
-    make_task_with_priority ~id:"t1" ~priority:4;
-    make_task_with_priority ~id:"t2" ~priority:5;
-  ] in
-  let (interval, reason) = Tempo.calculate_adaptive_tempo tasks in
-  check (float 0.1) "max interval for low priority" 600.0 interval;
-  check bool "reason contains slow" true
-    (try let _ = Str.search_forward (Str.regexp "slow") reason 0 in true
-     with Not_found -> false)
-
-(* ============================================================
-   tempo_file Tests
-   ============================================================ *)
-
-module Workspace_utils = Workspace_utils
-
-let make_test_config ~base_path : Workspace_utils.config =
-  let backend_config : Backend_types.config = {
-    base_path;
-    node_id = "test-node";
-    cluster_name = "default";
-    pubsub_max_messages = 1000;
-  } in
-  let memory_backend = Backend.Memory.create () in
-  {
-    Workspace_utils.base_path;
-    workspace_path = base_path;
-    lock_expiry_minutes = 30;
-    backend_config;
-    backend = Workspace_utils.Memory memory_backend;
-  }
-
-let test_tempo_file_basic () =
-  let cfg = make_test_config ~base_path:"/home/user/project" in
-  let result = Tempo.tempo_file cfg in
-  check string "tempo file path" "/home/user/project/.masc/tempo.json" result
-
-let test_tempo_file_with_trailing_slash () =
-  let cfg = make_test_config ~base_path:"/home/user/project/" in
-  let result = Tempo.tempo_file cfg in
-  (* Filename.concat handles trailing slash *)
-  check bool "ends with tempo.json" true (String.length result > 0)
-
-let test_tempo_file_relative_path () =
-  let cfg = make_test_config ~base_path:"./myproject" in
-  let result = Tempo.tempo_file cfg in
-  check string "relative tempo path" "./myproject/.masc/tempo.json" result
-
-let test_tempo_file_empty_path () =
-  let cfg = make_test_config ~base_path:"" in
-  let result = Tempo.tempo_file cfg in
-  check string "empty base path" ".masc/tempo.json" result
-
-(* ============================================================
-   tempo_config Type Tests
-   ============================================================ *)
-
-let test_tempo_config_type () =
-  let cfg : Tempo.tempo_config = {
-    min_interval_s = 30.0;
-    max_interval_s = 900.0;
-    default_interval_s = 300.0;
-    adaptive = false;
-  } in
-  check (float 0.1) "min" 30.0 cfg.min_interval_s;
-  check (float 0.1) "max" 900.0 cfg.max_interval_s;
-  check (float 0.1) "default" 300.0 cfg.default_interval_s;
-  check bool "adaptive" false cfg.adaptive
-
-let test_tempo_config_edge_values () =
-  let cfg : Tempo.tempo_config = {
-    min_interval_s = 1.0;
-    max_interval_s = 3600.0;
-    default_interval_s = 60.0;
-    adaptive = true;
-  } in
-  check bool "min < max" true (cfg.min_interval_s < cfg.max_interval_s);
-  check bool "default in range" true
-    (cfg.default_interval_s >= cfg.min_interval_s &&
-     cfg.default_interval_s <= cfg.max_interval_s)
-
-(* ============================================================
-   tempo_state Type Tests
-   ============================================================ *)
-
-let test_tempo_state_type () =
-  let state : Tempo.tempo_state = {
-    current_interval_s = 120.0;
-    last_adjusted = 1704067200.0;
-    reason = "custom reason";
-  } in
-  check (float 0.1) "interval" 120.0 state.current_interval_s;
-  check (float 0.1) "last_adjusted" 1704067200.0 state.last_adjusted;
-  check string "reason" "custom reason" state.reason
-
-let test_tempo_state_zero_values () =
-  let state : Tempo.tempo_state = {
-    current_interval_s = 0.0;
-    last_adjusted = 0.0;
-    reason = "";
-  } in
-  check (float 0.1) "zero interval" 0.0 state.current_interval_s;
-  check (float 0.1) "zero time" 0.0 state.last_adjusted;
-  check string "empty reason" "" state.reason
-
-(* ============================================================
-   format_state Tests (Pure Function)
-   ============================================================ *)
-
-let test_format_state_fast_tempo () =
-  let state : Tempo.tempo_state = {
-    current_interval_s = 60.0;
-    last_adjusted = Unix.gettimeofday ();  (* just now *)
-    reason = "fast - 1 urgent task(s)";
-  } in
-  let formatted = Tempo.format_state state in
-  check bool "contains tempo" true
-    (try let _ = Str.search_forward (Str.regexp "Tempo") formatted 0 in true
-     with Not_found -> false);
-  check bool "contains 60s" true
-    (try let _ = Str.search_forward (Str.regexp "60s") formatted 0 in true
-     with Not_found -> false)
-
-let test_format_state_normal_tempo () =
-  let state : Tempo.tempo_state = {
-    current_interval_s = 300.0;
-    last_adjusted = Unix.gettimeofday ();
-    reason = "normal tempo";
-  } in
-  let formatted = Tempo.format_state state in
-  check bool "contains 5.0m" true
-    (try let _ = Str.search_forward (Str.regexp "5\\.0m") formatted 0 in true
-     with Not_found -> false)
-
-let test_format_state_slow_tempo () =
-  let state : Tempo.tempo_state = {
-    current_interval_s = 600.0;
-    last_adjusted = Unix.gettimeofday ();
-    reason = "idle";
-  } in
-  let formatted = Tempo.format_state state in
-  check bool "contains 10.0m" true
-    (try let _ = Str.search_forward (Str.regexp "10\\.0m") formatted 0 in true
-     with Not_found -> false)
-
-let test_format_state_shows_reason () =
-  let state : Tempo.tempo_state = {
-    current_interval_s = 60.0;
-    last_adjusted = Unix.gettimeofday ();
-    reason = "urgent tasks present";
-  } in
-  let formatted = Tempo.format_state state in
-  check bool "contains reason" true
-    (try let _ = Str.search_forward (Str.regexp "urgent tasks present") formatted 0 in true
-     with Not_found -> false)
-
-let test_format_state_old_adjustment () =
-  let state : Tempo.tempo_state = {
-    current_interval_s = 300.0;
-    last_adjusted = Unix.gettimeofday () -. 3600.0;  (* 1 hour ago *)
-    reason = "test";
-  } in
-  let formatted = Tempo.format_state state in
-  check bool "contains hours ago" true
-    (try let _ = Str.search_forward (Str.regexp "h ago") formatted 0 in true
-     with Not_found -> false)
-
-let test_format_state_minutes_ago () =
-  let state : Tempo.tempo_state = {
-    current_interval_s = 300.0;
-    last_adjusted = Unix.gettimeofday () -. 120.0;  (* 2 minutes ago *)
-    reason = "test";
-  } in
-  let formatted = Tempo.format_state state in
-  check bool "contains minutes ago" true
-    (try let _ = Str.search_forward (Str.regexp "m ago") formatted 0 in true
-     with Not_found -> false)
-
-let test_format_state_just_now () =
-  let state : Tempo.tempo_state = {
-    current_interval_s = 300.0;
-    last_adjusted = Unix.gettimeofday () -. 5.0;  (* 5 seconds ago *)
-    reason = "test";
-  } in
-  let formatted = Tempo.format_state state in
-  check bool "contains just now" true
-    (try let _ = Str.search_forward (Str.regexp "just now") formatted 0 in true
-     with Not_found -> false)
-
-let test_format_state_emoji () =
-  let state : Tempo.tempo_state = {
-    current_interval_s = 60.0;
-    last_adjusted = Unix.gettimeofday ();
-    reason = "test";
-  } in
-  let formatted = Tempo.format_state state in
-  check bool "contains timer emoji" true
-    (String.length formatted > 0 && String.get formatted 0 <> ' ')
-
-(* ============================================================
-   default_config Tests
-   ============================================================ *)
-
-let test_default_config_min () =
-  check bool "min positive" true (Tempo.default_config.min_interval_s > 0.0)
-
-let test_default_config_max () =
-  check bool "max > min" true (Tempo.default_config.max_interval_s > Tempo.default_config.min_interval_s)
-
-let test_default_config_default () =
-  check bool "default in range" true
-    (Tempo.default_config.default_interval_s >= Tempo.default_config.min_interval_s &&
-     Tempo.default_config.default_interval_s <= Tempo.default_config.max_interval_s)
-
-let test_default_config_adaptive () =
-  check bool "adaptive enabled" true Tempo.default_config.adaptive
-
-(* ============================================================
-   Test Runners
-   ============================================================ *)
+let test_interval_is_usable_as_a_period () =
+  let tempo = Tempo.get_tempo (config_for "/tmp/tempo-coverage-a") in
+  check bool "interval is positive" true (tempo.Tempo.current_interval_s > 0.0)
 
 let () =
-  run "Tempo Coverage" [
-    "state_to_json", [
-      test_case "has fields" `Quick test_state_to_json_has_fields;
-      test_case "interval value" `Quick test_state_to_json_interval_value;
-      test_case "reason value" `Quick test_state_to_json_reason_value;
-    ];
-    "state_of_json", [
-      test_case "valid" `Quick test_state_of_json_valid;
-      test_case "missing field" `Quick test_state_of_json_missing_field;
-      test_case "invalid type" `Quick test_state_of_json_invalid_type;
-      test_case "not assoc" `Quick test_state_of_json_not_assoc;
-      test_case "roundtrip" `Quick test_state_of_json_roundtrip;
-    ];
-    "is_pending_task", [
-      test_case "todo" `Quick test_is_pending_task_todo;
-      test_case "claimed" `Quick test_is_pending_task_claimed;
-      test_case "in_progress" `Quick test_is_pending_task_in_progress;
-      test_case "done" `Quick test_is_pending_task_done;
-      test_case "cancelled" `Quick test_is_pending_task_cancelled;
-    ];
-    "calculate_adaptive_tempo", [
-      test_case "empty" `Quick test_calculate_adaptive_tempo_empty;
-      test_case "urgent" `Quick test_calculate_adaptive_tempo_urgent;
-      test_case "priority 2" `Quick test_calculate_adaptive_tempo_priority_2;
-      test_case "normal" `Quick test_calculate_adaptive_tempo_normal;
-      test_case "low priority" `Quick test_calculate_adaptive_tempo_low_priority;
-    ];
-    "tempo_file", [
-      test_case "basic" `Quick test_tempo_file_basic;
-      test_case "with trailing slash" `Quick test_tempo_file_with_trailing_slash;
-      test_case "relative path" `Quick test_tempo_file_relative_path;
-      test_case "empty path" `Quick test_tempo_file_empty_path;
-    ];
-    "tempo_config_type", [
-      test_case "all fields" `Quick test_tempo_config_type;
-      test_case "edge values" `Quick test_tempo_config_edge_values;
-    ];
-    "tempo_state_type", [
-      test_case "all fields" `Quick test_tempo_state_type;
-      test_case "zero values" `Quick test_tempo_state_zero_values;
-    ];
-    "default_config", [
-      test_case "min positive" `Quick test_default_config_min;
-      test_case "max > min" `Quick test_default_config_max;
-      test_case "default in range" `Quick test_default_config_default;
-      test_case "adaptive" `Quick test_default_config_adaptive;
-    ];
-    "format_state", [
-      test_case "fast tempo" `Quick test_format_state_fast_tempo;
-      test_case "normal tempo" `Quick test_format_state_normal_tempo;
-      test_case "slow tempo" `Quick test_format_state_slow_tempo;
-      test_case "shows reason" `Quick test_format_state_shows_reason;
-      test_case "old adjustment" `Quick test_format_state_old_adjustment;
-      test_case "minutes ago" `Quick test_format_state_minutes_ago;
-      test_case "just now" `Quick test_format_state_just_now;
-      test_case "emoji" `Quick test_format_state_emoji;
-    ];
-  ]
+  Alcotest.run
+    "Tempo"
+    [ ( "published interval"
+      , [ test_case "is the configured one" `Quick
+            test_publishes_the_configured_interval
+        ; test_case "does not vary by workspace" `Quick
+            test_does_not_vary_by_workspace
+        ; test_case "is positive" `Quick test_interval_is_usable_as_a_period
+        ] )
+    ]


### PR DESCRIPTION
## 증상

`lib/tempo.ml` 은 스스로를 적응형 오케스트레이션이라고 기술한다.

> - Urgent tasks (priority 1-2) → Fast tempo (60s)
> - Normal tasks (priority 3) → Normal tempo (300s)
> - Idle (no tasks) → Slow tempo (600s)
>
> Storage: `.masc/tempo.json`

`calculate_adaptive_tempo` 는 정확히 그대로 구현되어 있다. **호출하는 곳이 없다.**

| 함수 | `lib/`+`bin/` 호출자 |
|---|---|
| `get_tempo` | 6 |
| `adjust_tempo` | 0 |
| `calculate_adaptive_tempo` | 0 |
| `set_tempo` | 0 |
| `reset_tempo` | 0 |
| `format_state` | 0 |

읽는 함수 하나만 쓰인다. 쓰는 함수는 전부 0 이다. 따라서 `.masc/tempo.json` 은 생성된 적이 없고, `load_state` 는 항상 파일 없음 분기를 타고, 여섯 소비자가 발행하는 `tempo_interval_s` 는 전부 `Env_config.Tempo.default_interval_seconds` 상수다.

대시보드 푸터가 그걸 이렇게 찍는다.

```
-- Tempo: 300s | Locks: 4
```

적응한다는 이름으로 설정값을 보여주고 있었다.

## 수정

`get_tempo` 가 그 상수를 직접 돌려주고, 모듈 문서가 그렇게 말한다. **호출 지점 6곳과 발행되는 필드는 건드리지 않았다** — 어떤 operator surface 도 모양이 바뀌지 않는다.

`MASC_TEMPO_MIN_INTERVAL_SEC` / `MASC_TEMPO_MAX_INTERVAL_SEC` 는 적응 분기 전용이었으므로 같이 제거하고 `docs/runtime-tunables.md` 를 재생성했다 (`bin/env_knob_catalog.exe`, CI drift gate 대상). `MASC_TEMPO_DEFAULT_INTERVAL_SEC` 는 발행되는 숫자라 남는다.

## 테스트

`test_tempo_coverage.ml` 은 479 줄로 이 기계를 검증하고 있었다 — `state_to_json` 왕복, `is_pending_task` 분류, `calculate_adaptive_tempo` 의 fast/normal/slow 분기. **테스트가 직접 호출했기 때문에 통과했다.** 프로덕션 경로가 한 번도 그 함수들에 닿지 않는다는 사실은 검증 대상이 아니었다.

이제 표면이 실제로 받는 것을 확인한다: 발행되는 값이 설정값과 같은가, 워크스페이스가 달라도 같은가(달라지면 뭔가가 다시 조정하고 있다는 뜻), 주기로 쓸 수 있는 양수인가.

## 남긴 것 — 별도 변경 필요

발행되는 숫자는 **오케스트레이터가 실제로 도는 주기가 아니다.** 그건 `Env_config.Orchestrator.check_interval_seconds` (`MASC_ORCHESTRATOR_INTERVAL`, 기본 300초) 이고, `MASC_TEMPO_DEFAULT_INTERVAL_SEC` 와 연결된 적이 없다. `MASC_TEMPO_DEFAULT_INTERVAL_SEC=5` 로 두면 화면 숫자만 바뀌고 아무 루프도 빨라지지 않는다.

둘을 일치시키면 operator surface 가 보고하는 값이 바뀌고, 그 중 하나가 `lib/operator/operator_control_snapshot_workspace.ml` 이다. `operator_control*` 은 RFC 필수 subsystem 이고 `docs/rfc/` 에 tempo/orchestrator-interval RFC 가 없다. 이 PR 범위 밖으로 두고 별도 RFC 로 다룬다.

## 검증

- `dune build --root . @check` EXIT=0
- `test_tempo_coverage` 3/3, `test_misc_coverage` 21/21
- `bin/env_knob_catalog.exe` 재생성 후 `git diff` 클린
- `scripts/check-doc-code-refs.sh`, `scripts/audit-keeper-tool-boundary-matrix.sh` PASS

799줄 삭제 / 144줄 추가.

RFC-WAIVED: 호출자가 0 인 적응 로직과 그 전용 env knob 2개 제거. `lib/operator/`, credential/identity, repo_manager, keeper sandbox, dashboard credential component, hooks, workflow 문서 어느 것도 건드리지 않는다. 발행되는 JSON 필드와 그 값은 변하지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
