### PR TITLE
fix(keeper): stop copying the replayed conversation into every wire-capture record

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -531,9 +531,9 @@ let run_turn
       ~turn_start
       ~seq_ref
   in
-  let digest_text = Turn_helpers.digest_text in
+  let digest_text = Keeper_context_digest.text in
   let digest_message_texts_as_joined =
-    Turn_helpers.digest_message_texts_as_joined
+    Keeper_context_digest.message_texts_as_joined
   in
   append_manifest ~site:"checkpoint_loaded"
     ~keeper_turn_id:manifest_keeper_turn_id

--- a/lib/keeper/keeper_agent_run_turn_helpers.ml
+++ b/lib/keeper/keeper_agent_run_turn_helpers.ml
@@ -142,19 +142,6 @@ let emit_turn_end_safely ~keeper_name () =
         keeper_name
         (Printexc.to_string e)
 
-let digest_text text = Digest.to_hex (Digest.string text)
-
-let digest_message_texts_as_joined messages =
-  let module Hash = Digestif.MD5 in
-  let rec loop ctx = function
-    | [] -> ctx
-    | [ message ] -> Hash.feed_string ctx (Agent_sdk.Types.text_of_message message)
-    | message :: rest ->
-        let ctx = Hash.feed_string ctx (Agent_sdk.Types.text_of_message message) in
-        loop (Hash.feed_string ctx "\n") rest
-  in
-  Hash.(to_hex (get (loop empty messages)))
-
 let runtime_manifest_context ~keeper_name ~agent_name ~trace_id ~generation
     ~keeper_turn_id : Keeper_runtime_manifest.turn_context =
   {

--- a/lib/keeper/keeper_agent_run_turn_helpers.mli
+++ b/lib/keeper/keeper_agent_run_turn_helpers.mli
@@ -16,8 +16,6 @@ val registry_progress_on_event :
   unit
 
 val emit_turn_end_safely : keeper_name:string -> unit -> unit
-val digest_text : string -> string
-val digest_message_texts_as_joined : Agent_sdk.Types.message list -> string
 
 val runtime_manifest_context :
   keeper_name:string ->

--- a/lib/keeper/keeper_context_digest.ml
+++ b/lib/keeper/keeper_context_digest.ml
@@ -1,0 +1,16 @@
+(** See [keeper_context_digest.mli]. *)
+
+let text value = Digest.to_hex (Digest.string value)
+
+let message_texts_as_joined messages =
+  let module Hash = Digestif.MD5 in
+  let rec loop ctx = function
+    | [] -> ctx
+    | [ message ] ->
+      Hash.feed_string ctx (Agent_sdk.Types.text_of_message message)
+    | message :: rest ->
+      let ctx = Hash.feed_string ctx (Agent_sdk.Types.text_of_message message) in
+      loop (Hash.feed_string ctx "\n") rest
+  in
+  Hash.(to_hex (get (loop empty messages)))
+;;

--- a/lib/keeper/keeper_context_digest.mli
+++ b/lib/keeper/keeper_context_digest.mli
@@ -1,0 +1,17 @@
+(** Content digests for the parts of a keeper turn's model input.
+
+    One implementation, because the values are compared across stores: the
+    [context_injected] runtime manifest and the diagnostic wire capture both
+    name the same replayed history, and a row from one joins to a row from the
+    other only while the two digests are computed the same way. Both producers
+    sit on opposite sides of the [Keeper_run_tools] dependency chain, so the
+    algorithm lives below both rather than in either. *)
+
+val text : string -> string
+(** MD5 hex of a rendered prompt block. *)
+
+val message_texts_as_joined : Agent_sdk.Types.message list -> string
+(** MD5 hex of the message texts joined by newline, in order. The empty list
+    digests as the empty string, so a turn with no replayed history is not
+    distinguishable from one whose messages all rendered empty — the message
+    count recorded alongside it carries that distinction. *)

--- a/lib/keeper/keeper_wire_capture.ml
+++ b/lib/keeper/keeper_wire_capture.ml
@@ -157,16 +157,17 @@ let capture_request ~base_path ~masc_root ~keeper_name ~turn_id ~sdk_turn
       let redacted_tools =
         List.map (redact_json_strings redaction) raw_tools
       in
-      let history =
-        List.map
-          (fun (m : Agent_sdk.Types.message) ->
-             `Assoc
-               [ ("role", `String (Agent_sdk.Types.role_to_string m.role))
-               ; ( "text"
-                 , `String
-                     (redact redaction (Agent_sdk.Types.text_of_message m)) )
-               ])
-          history_messages
+      (* The replayed conversation is not copied into this record. It is
+         already durable in the OAS checkpoint and its [oas-snapshot-*]
+         history, and [capture_request] fires once per SDK turn, so
+         embedding it made one record as large as the checkpoint itself
+         (measured 2026-08-05: 14,465 messages = 9.8MB per record, which
+         exhausts the 64MiB day-file budget after 7 records and skips every
+         request after that). [history_messages_digest] is the same MD5 the
+         [context_injected] runtime manifest records, so a capture row joins
+         to the manifest row and to the checkpoint that holds the text. *)
+      let history_messages_digest =
+        Keeper_context_digest.message_texts_as_joined history_messages
       in
       let payload : Yojson.Safe.t =
         `Assoc
@@ -193,7 +194,7 @@ let capture_request ~base_path ~masc_root ~keeper_name ~turn_id ~sdk_turn
           ; ("tools", `List redacted_tools)
           ; ("user_message", `String (redact redaction user_message))
           ; ("history_message_count", `Int (List.length history_messages))
-          ; ("history", `List history)
+          ; ("history_messages_digest", `String history_messages_digest)
           ]
       in
       write_payload ~masc_root ~keeper_name ~turn_id payload)

--- a/lib/keeper/keeper_wire_capture.mli
+++ b/lib/keeper/keeper_wire_capture.mli
@@ -1,13 +1,25 @@
 (** Env-gated capture of the MASC->OAS request boundary (redacted).
 
     Records the effective request parameters MASC hands to OAS per SDK turn —
-    system prompt, extra system context, tool schemas, user message, and the
-    replayed conversation history ([initial_messages]) — so
+    system prompt, extra system context, tool schemas, and user message — so
     degenerate-repetition feedback loops can be diagnosed from the actual
-    input rather than from digests/sizes. Tool schemas use the same
-    {!Agent_sdk.Tool.schema_to_json} projection OAS prepares for the provider.
-    String content is passed through {!Llm_provider.Secret_redactor} and the exact
-    {!Keeper_secret_redaction} projection snapshot before it is written.
+    input rather than from digests/sizes. These are the parameters no other
+    durable store holds: the OAS checkpoint keeps [system_prompt] and the
+    replayed messages, but nothing else keeps the per-turn injected context.
+    Tool schemas use the same {!Agent_sdk.Tool.schema_to_json} projection OAS
+    prepares for the provider. String content is passed through
+    {!Llm_provider.Secret_redactor} and the exact {!Keeper_secret_redaction}
+    projection snapshot before it is written.
+
+    The replayed conversation itself is recorded as [history_message_count]
+    and [history_messages_digest] rather than as text. The text is already
+    durable in the checkpoint and its [oas-snapshot-*] history, and this
+    function runs once per SDK turn: embedding it made one record as large as
+    the checkpoint (measured 2026-08-05 on a live keeper: 14,465 messages =
+    9.8MB per record, exhausting the 64MiB day-file budget after 7 records and
+    skipping every request after that). The digest is the same MD5 the
+    [context_injected] runtime manifest records, so a capture row joins to
+    the manifest row and to the checkpoint that holds the text.
 
     Writes are best-effort and dated under
     [<masc_root>/wire-capture/YYYY-MM/DD.jsonl] (same [Dated_jsonl] per-day
@@ -19,10 +31,13 @@
 
     Motivation: the request boundary is the primary suspect for
     self-reinforcing repetition — the keeper's own prior visible text is
-    replayed into [initial_messages] with no content-level dedup guard. This
-    capture makes that input observable. Provider-independent structural
-    redaction is composed with the exact Keeper secret projection snapshot;
-    token formats are never inferred from product prefixes or lengths. See
+    replayed into [initial_messages] with no content-level dedup guard. The
+    replayed text is readable from the checkpoint; what was unreadable is the
+    context this module injects on top of it, and what {!capture_response}
+    pairs with it is the output that becomes the next turn's replayed input.
+    Provider-independent structural redaction is composed with the exact
+    Keeper secret projection snapshot; token formats are never inferred from
+    product prefixes or lengths. See
     [docs/masc-keeper-repetition-blast-radius-design-2026-07-02.html] (Phase O).
 
     Disabled unless [MASC_KEEPER_WIRE_CAPTURE] is enabled through the feature
@@ -73,7 +88,9 @@ val capture_request :
     snapshot; [masc_root] must already be the effective cluster-aware MASC
     root. [tool_schema_bytes] records the byte length of the exact unredacted
     compact JSON schema array while [tools] stores its recursively redacted
-    content. *)
+    content. [history_messages] is consumed for [history_message_count] and
+    [history_messages_digest] only; the messages themselves are not written
+    (see the module header). *)
 
 val capture_response :
   base_path:string ->

--- a/test/test_keeper_wire_capture.ml
+++ b/test/test_keeper_wire_capture.ml
@@ -4,6 +4,7 @@
     one redacted dated jsonl with the expected fields. *)
 
 module Wire = Masc.Keeper_wire_capture
+module Context_digest = Masc.Keeper_context_digest
 module Keeper_metrics = Keeper_metrics
 module Metrics = Masc.Otel_metric_store
 module Secret_projection = Masc.Keeper_secret_projection
@@ -263,16 +264,45 @@ let enabled_writes_redacted () =
     check_json_string "user message recorded" "user_message" "hello world" json;
     check_json_int "history_message_count recorded" "history_message_count" 2
       json;
-    check_json_list_length "history length" "history" 2 json;
-    let history_json = json_list "history" json in
-    (match history_json with
-     | [ assistant; user ] ->
-       check_json_string "assistant role recorded" "role" "assistant" assistant;
-       check_json_string "assistant text recorded" "text"
-         "좋아, 연구 시작한다" assistant;
-       check_json_string "user role recorded" "role" "user" user;
-       check_json_string "user text recorded" "text" "continue" user
-     | _ -> Alcotest.fail "history shape should have been checked above"))
+    check_json_string "history digest matches the manifest projection"
+      "history_messages_digest"
+      (Context_digest.message_texts_as_joined history)
+      json;
+    Alcotest.(check bool) "replayed message text is not written" false
+      (contains ~needle:"좋아, 연구 시작한다" content))
+
+(* The record must not scale with the replayed conversation: [capture_request]
+   runs once per SDK turn, so a per-message payload made a single record as
+   large as the checkpoint and exhausted the day-file byte budget within a few
+   turns. Growing the history by three orders of magnitude must leave the
+   record the same size apart from the message count. *)
+let record_size_is_independent_of_history_length () =
+  with_flag "1" (fun () ->
+    let capture ~history_messages =
+      let base = Filename.temp_dir "wirecap_size" "" in
+      Wire.capture_request ~base_path:base ~masc_root:base
+        ~keeper_name:"sangsu" ~turn_id:1 ~sdk_turn:1 ~system_prompt:"sys"
+        ~extra_system_context:None ~user_message:"u" ~history_messages
+        ~tools:[] ();
+      match find_jsonl base with
+      | [ path ] -> String.length (read_file path)
+      | files ->
+        Alcotest.failf "expected one jsonl, got %d" (List.length files)
+    in
+    let long_history =
+      List.init 2000 (fun i ->
+        Agent_sdk.Types.assistant_msg
+          (Printf.sprintf "replayed turn %d: %s" i (String.make 200 'x')))
+    in
+    let short = capture ~history_messages:[] in
+    let long = capture ~history_messages:long_history in
+    (* The only length difference is the decimal width of the message count. *)
+    Alcotest.(check bool)
+      (Printf.sprintf
+         "2000-message history must not inflate the record (short=%d long=%d)"
+         short long)
+      true
+      (abs (long - short) < 32))
 
 let request_captures_exact_redacted_tool_schemas () =
   with_flag "1" (fun () ->
@@ -613,6 +643,8 @@ let () =
             request_capture_failure_is_best_effort;
           Alcotest.test_case "trace_id is emitted when provided" `Quick
             request_trace_id_emitted;
+          Alcotest.test_case "record size is independent of history length"
+            `Quick record_size_is_independent_of_history_length;
         ] );
       ( "capture_response",
         [


### PR DESCRIPTION
## 문제

`Keeper_wire_capture.capture_request` 는 재생된 대화 전체를 레코드마다 복사한다. 이 함수는 **SDK 턴마다** 호출된다 (`keeper_run_tools_hooks.ml:547`, `BeforeTurnParams` 훅).

라이브 keeper 실측 (2026-08-05, analyst, `trace-1785189111840-00000`):

| | |
|---|---|
| `history` messages | 14,465 |
| `{role,text}` JSON | **9.8 MB** |
| 레코드 1개 | **≈ 9.9 MB** |
| `MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES` 기본값 | 64 MiB |
| → day file 소진까지 | **6.8 레코드** |
| 이 trace 의 SDK 턴 수 | 2,671 |

플래그를 켜면 첫 keeper 턴 몇 초 만에 day file 이 차고, 이후 모든 request 가 `Current_file_byte_cap` 으로 스킵된다. cap 을 천장(1 GiB)까지 올려도 103 레코드 = 여전히 몇 분. 진단 하네스가 스스로를 즉시 무력화한다.

## 원인

재생된 대화는 이미 durable 하다. OAS 체크포인트 (`<trace_id>.json`) 와 그 `oas-snapshot-*` 히스토리가 같은 `messages` 배열을 담고 있고, 그게 스냅샷이 12 MB 인 이유다. wire capture 는 그걸 SDK 턴마다 다시 복사했다.

## 변경

`history` 텍스트를 `history_messages_digest` 로 대체한다. `history_message_count` 는 유지.

digest 는 `context_injected` 런타임 매니페스트가 기록하는 것과 **같은 MD5** 여야 한다 (`keeper_agent_run.ml:638`). 그래야 capture row 가 manifest row 와, 그리고 텍스트를 보유한 체크포인트와 join 된다.

그런데 두 생산자는 `Keeper_run_tools` 의존 사슬 양쪽에 있어 직접 참조하면 사이클이 생긴다:

```
Keeper_agent_run_turn_helpers -> Keeper_run_tools -> Keeper_run_tools_hooks
  -> Keeper_wire_capture -> Keeper_agent_run_turn_helpers
```

그래서 `digest_text` / `digest_message_texts_as_joined` 를 `Keeper_context_digest` (`text` / `message_texts_as_joined`) 로 분리한다. 의존은 `Digestif` + `Agent_sdk.Types` 뿐이라 양쪽 아래에 놓인다. 알고리즘 복제 대신 모듈 분리를 택한 이유는 두 digest 가 어긋나는 순간 join 이 조용히 깨지기 때문이다.

대화 자체는 capture 스트림에서 재구성된다: 각 턴의 `user_message` (request row) + `response_text` (response row). mli 가 원래 명시한 관계 그대로 — "turn N's response is turn N+1's replayed history input".

레코드가 계속 보유하는 것 (다른 어떤 durable store 에도 없는 것):
- `system_prompt`
- `extra_system_context` — dynamic context(world state) + temporal summary + memory OS recall 블록이 모두 여기 조립된다 (`keeper_run_tools_hooks.ml:358-388`)
- `user_message`
- `tools`

## 측정

| | before | after |
|---|---|---|
| 레코드 크기 (analyst) | 9.9 MB | 76 KB |
| 64 MiB day file 수용량 | 6.8 | ~880 |

76 KB 의 79% 는 tool schema (98개, 60 KB) 로, 값이 5-7 종류뿐인데 매 레코드 반복된다. fidelity 트레이드오프가 있어 이 PR 범위 밖으로 둔다.

## Blob 참조

`tool_blob_maintenance.durable_consumer_basenames` 는 `"wire-capture"` 와 `"traces"` 를 **둘 다** 스캔한다 (`tool_blob_maintenance.ml:230-240`). history 텍스트 안의 blob 참조는 체크포인트/스냅샷이 계속 보유하므로 이 변경으로 고아가 되지 않는다. 부수 효과로 진단 스토어가 blob 을 retention 기간 동안 pin 하던 동작이 사라진다.

## 테스트

- `enabled_writes_redacted`: `history_messages_digest` 가 manifest projection 과 일치하는지, 재생 메시지 텍스트가 기록되지 않는지 확인
- `record_size_is_independent_of_history_length` (신규): 빈 history 와 2,000 메시지 history 의 레코드 바이트 차이가 32 미만 — 메시지 카운트의 십진 자릿수 폭만큼만 차이 나야 한다

## 검증

- `dune build test/test_keeper_wire_capture.exe` — exit 0
- `DUNE_SOURCEROOT=$PWD ./_build/default/test/test_keeper_wire_capture.exe` — **18/18 pass**
- wire capture 파일을 읽는 다른 소비자 없음 (`rg '"history"' lib/ test/ dashboard/src`)
- `digest_text` / `digest_message_texts_as_joined` 의 기존 호출자는 `keeper_agent_run.ml` 뿐이며 새 모듈로 전환됨

## 운영 메모

이 PR 은 레코드를 9.9 MB → 76 KB 로 줄이지만, 남은 76 KB 의 79% 는 값이 5-7 종류뿐인 tool schema 다. 활성 keeper 6개가 15시간에 `context_injected` 11,441회 = 763 레코드/시간이므로:

| `MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES` | day file 소진 |
|---|---|
| 64 MiB (기본) | 69분 |
| 1 GiB (천장) | 18.5시간 |

상시 캡처를 하려면 cap 상향이 필요하고, retention 3일을 실제 3일로 쓰려면 tool schema 반복 제거가 추가로 필요하다 (16 KB/레코드 → 87시간).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
