### PR TITLE
fix(settings): 아무것도 제어하지 않는 런타임 설정 4개 제거

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 208 unique knobs across 8 modules.
+**Total**: 207 unique knobs across 8 modules.
 
-**Typed getter classification**: 38/121 tagged (`operator`: 38, `algorithm`: 0, `unclassified`: 83).
+**Typed getter classification**: 38/120 tagged (`operator`: 38, `algorithm`: 0, `unclassified`: 82).
 
 ## Env_config_core (23 knobs; typed classification 2/5)
 
@@ -97,80 +97,79 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_DEAD_TTL_SEC` | typed:float | Timeouts | operator | 11 | Dead tombstone TTL: seconds before Dead entries are cleaned up. @category Timeouts @ops_class operator |
 | `MASC_KEEPER_SUPERVISOR_SWEEP_SEC` | typed:float | Timeouts | operator | 7 | Interval between supervisor sweep runs (seconds). @category Timeouts @ops_class operator |
 
-## Env_config_runtime (70 knobs; typed classification 4/55)
+## Env_config_runtime (69 knobs; typed classification 4/54)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_AGENT_RATE_BURST` | typed:int | unclassified | unclassified | 318 | Per-agent burst capacity. Default: 50. |
-| `MASC_AGENT_RATE_LIMIT` | typed:float | unclassified | unclassified | 315 | Per-agent requests per second. Default: 20. |
-| `MASC_AGENT_TRANSPORT` | string_literal | n/a | n/a | 227 | Agent transport type variant (e.g. "grpc", "http", "ws"). |
-| `MASC_BOARD_FLUSHER_INBOX_CAPACITY` | typed:int | Concurrency | operator | 266 | Capacity of the board flusher inbox (scheduled sweep/flush messages enqueued by the sweeper). Single source of truth ... |
-| `MASC_BOARD_FLUSH_INTERVAL_SEC` | typed:float | unclassified | unclassified | 257 | Flush interval for board persistence (seconds). Default: 30. |
-| `MASC_BRIEFING_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 537 | Dashboard mission briefing cache TTL (seconds). Default: 300 (5 min). |
+| `MASC_AGENT_RATE_BURST` | typed:int | unclassified | unclassified | 311 | Per-agent burst capacity. Default: 50. |
+| `MASC_AGENT_RATE_LIMIT` | typed:float | unclassified | unclassified | 308 | Per-agent requests per second. Default: 20. |
+| `MASC_AGENT_TRANSPORT` | string_literal | n/a | n/a | 220 | Agent transport type variant (e.g. "grpc", "http", "ws"). |
+| `MASC_BOARD_FLUSHER_INBOX_CAPACITY` | typed:int | Concurrency | operator | 259 | Capacity of the board flusher inbox (scheduled sweep/flush messages enqueued by the sweeper). Single source of truth ... |
+| `MASC_BOARD_FLUSH_INTERVAL_SEC` | typed:float | unclassified | unclassified | 250 | Flush interval for board persistence (seconds). Default: 30. |
+| `MASC_BRIEFING_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 530 | Dashboard mission briefing cache TTL (seconds). Default: 300 (5 min). |
 | `MASC_CACHE_MAX_ENTRIES` | typed:int | unclassified | unclassified | 41 | Maximum total number of cache entries (default 1000) |
 | `MASC_CACHE_MAX_ENTRY_SIZE` | typed:int | unclassified | unclassified | 37 | Maximum size of a single cache entry value in bytes (default 100KB) |
-| `MASC_DASHBOARD_CTX_COMPACTING` | typed:float | unclassified | unclassified | 388 |  |
-| `MASC_DASHBOARD_CTX_HANDOFF_IMMINENT` | typed:float | unclassified | unclassified | 384 | Keeper context-ratio lifecycle thresholds. Higher ratio = closer to context limit = more urgency. |
-| `MASC_DASHBOARD_CTX_PREPARING` | typed:float | unclassified | unclassified | 386 |  |
-| `MASC_DASHBOARD_EXECUTION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 427 | Execution surface compute timeout (light + parameterized). Wraps two [Dashboard_cache.get_or_compute_with_timeout] si... |
-| `MASC_DASHBOARD_EXECUTION_TRUST_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 441 | Execution-trust surface compute timeout. Wraps [Dashboard_cache.get_or_compute_with_timeout] at [server_dashboard_htt... |
-| `MASC_DASHBOARD_KEEPER_ACTION_STALE_SEC` | typed:float | unclassified | unclassified | 379 | Keeper action-age threshold (seconds). Default: 3600 (1 hour). |
-| `MASC_DASHBOARD_MISSION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 451 | Mission card compute timeout. Wraps three [Dashboard_cache.get_or_compute_with_timeout] sites at [server_dashboard_ht... |
-| `MASC_DASHBOARD_RENDER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 484 | Maximum wall-clock for a single dashboard render ([Dashboard_execution.json_render]). Wraps the entire render pipelin... |
-| `MASC_DASHBOARD_SHELL_LIGHT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 471 | Shell render compute timeout (light path). Default 8s. Must remain strictly less than [shell_timeout_sec] so the spli... |
-| `MASC_DASHBOARD_SHELL_PREWARM_OUTER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 416 |  |
-| `MASC_DASHBOARD_SHELL_PREWARM_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 411 | Dashboard shell-cache pre-warm timeouts. The pre-warm fires once on server bootstrap. It is wrapped in two nested tim... |
-| `MASC_DASHBOARD_SHELL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 460 | Shell render compute timeout (full path). Used by [Dashboard_cache.get_or_compute_with_timeout] for the full shell re... |
-| `MASC_DASHBOARD_SIGNAL_LIVE_SEC` | typed:float | unclassified | unclassified | 375 | Duration (seconds) for a signal to count as "live". Default: 300 (5 min). |
-| `MASC_DASHBOARD_SIGNAL_QUIET_SEC` | typed:float | unclassified | unclassified | 371 | Duration (seconds) for borderline "quiet" warning. Default: 600 (10 min). |
-| `MASC_DASHBOARD_SIGNAL_STALE_SEC` | typed:float | unclassified | unclassified | 367 | Duration (seconds) after which a signal is considered stale. Default: 1200 (20 min). |
+| `MASC_DASHBOARD_CTX_COMPACTING` | typed:float | unclassified | unclassified | 381 |  |
+| `MASC_DASHBOARD_CTX_HANDOFF_IMMINENT` | typed:float | unclassified | unclassified | 377 | Keeper context-ratio lifecycle thresholds. Higher ratio = closer to context limit = more urgency. |
+| `MASC_DASHBOARD_CTX_PREPARING` | typed:float | unclassified | unclassified | 379 |  |
+| `MASC_DASHBOARD_EXECUTION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 420 | Execution surface compute timeout (light + parameterized). Wraps two [Dashboard_cache.get_or_compute_with_timeout] si... |
+| `MASC_DASHBOARD_EXECUTION_TRUST_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 434 | Execution-trust surface compute timeout. Wraps [Dashboard_cache.get_or_compute_with_timeout] at [server_dashboard_htt... |
+| `MASC_DASHBOARD_KEEPER_ACTION_STALE_SEC` | typed:float | unclassified | unclassified | 372 | Keeper action-age threshold (seconds). Default: 3600 (1 hour). |
+| `MASC_DASHBOARD_MISSION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 444 | Mission card compute timeout. Wraps three [Dashboard_cache.get_or_compute_with_timeout] sites at [server_dashboard_ht... |
+| `MASC_DASHBOARD_RENDER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 477 | Maximum wall-clock for a single dashboard render ([Dashboard_execution.json_render]). Wraps the entire render pipelin... |
+| `MASC_DASHBOARD_SHELL_LIGHT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 464 | Shell render compute timeout (light path). Default 8s. Must remain strictly less than [shell_timeout_sec] so the spli... |
+| `MASC_DASHBOARD_SHELL_PREWARM_OUTER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 409 |  |
+| `MASC_DASHBOARD_SHELL_PREWARM_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 404 | Dashboard shell-cache pre-warm timeouts. The pre-warm fires once on server bootstrap. It is wrapped in two nested tim... |
+| `MASC_DASHBOARD_SHELL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 453 | Shell render compute timeout (full path). Used by [Dashboard_cache.get_or_compute_with_timeout] for the full shell re... |
+| `MASC_DASHBOARD_SIGNAL_LIVE_SEC` | typed:float | unclassified | unclassified | 368 | Duration (seconds) for a signal to count as "live". Default: 300 (5 min). |
+| `MASC_DASHBOARD_SIGNAL_QUIET_SEC` | typed:float | unclassified | unclassified | 364 | Duration (seconds) for borderline "quiet" warning. Default: 600 (10 min). |
+| `MASC_DASHBOARD_SIGNAL_STALE_SEC` | typed:float | unclassified | unclassified | 360 | Duration (seconds) after which a signal is considered stale. Default: 1200 (20 min). |
 | `MASC_EXECUTOR_DOMAIN_COUNT` | typed:int | Concurrency | operator | 53 | Shared executor worker-domain count override. Env: [MASC_EXECUTOR_DOMAIN_COUNT]. Default: unset, use {!Domain_pool}'s... |
-| `MASC_FULL_HEALTH_CRITICAL_FAILURE_THRESHOLD` | typed:int | unclassified | unclassified | 514 | Number of consecutive [/health?full=1] cache-refresh failures that must accumulate before [masc_full_health_refresh_c... |
-| `MASC_FULL_HEALTH_REFRESH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 502 | Full-health snapshot proactive refresh timeout (seconds). Caps a single [/health?full=1] cache refresh attempt in [Se... |
-| `MASC_GRPC_ENABLED` | feature_flag | n/a | n/a | 202 | Whether gRPC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
-| `MASC_GRPC_PORT` | string_literal | n/a | n/a | 198 | gRPC server port. Default: 8936. |
-| `MASC_GRPC_TARGET` | string_literal | n/a | n/a | 206 | gRPC client target address. Derived from grpc_port when unset. |
-| `MASC_HTTP_AUTH_STRICT` | feature_flag | n/a | n/a | 232 |  |
-| `MASC_JANITOR_INTERVAL_SEC` | typed:float | unclassified | unclassified | 553 | Bootstrap janitor tick interval (seconds). Drives the SSE/session/ rate-limit/webrtc reaper loop in [server_bootstrap... |
-| `MASC_LABEL_QUIET_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 529 | Dashboard label "quiet" threshold (seconds). Default: 300 (5 min). |
-| `MASC_LABEL_STUCK_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 533 | Dashboard label "stuck" threshold (seconds). Default: 900 (15 min). |
-| `MASC_LANE_PREFERENCE_TTL_S` | typed:float | Timeouts | operator | 356 | Sticky lane-candidate preference TTL (seconds). After a lane candidate succeeds, later turns on the same lane try it ... |
-| `MASC_LIST_PAGE_SIZE` | typed:int | unclassified | unclassified | 279 | Tool list page size, clamped to [10, 1024]. Default: 512. Re-readable within the process; not a guarantee of shell-le... |
-| `MASC_LOCAL_RUNTIME_COOLDOWN_SEC` | string_literal | n/a | n/a | 330 | Local runtime cooldown (seconds). |
-| `MASC_LOCAL_RUNTIME_DEBUG` | feature_flag | n/a | n/a | 326 | Enable local runtime debug logging. Default: false. |
-| `MASC_LOCAL_WORKER_HEARTBEAT_SEC` | typed:int | unclassified | unclassified | 333 | Local worker heartbeat interval (seconds). Default: 60. |
-| `MASC_MESSAGE_MAX_COUNT` | typed:int | unclassified | unclassified | 144 | Maximum number of message files to retain per workspace (default 200). Oldest messages (by filename sort) are deleted... |
-| `MASC_METRICS_FLUSH_SEC` | typed:float | unclassified | unclassified | 525 | Tool metrics flush interval (seconds). Default: 300 (5 min). |
-| `MASC_OAS_SSE_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 341 | SSE drain interval (seconds). Default: 2.0. |
+| `MASC_FULL_HEALTH_CRITICAL_FAILURE_THRESHOLD` | typed:int | unclassified | unclassified | 507 | Number of consecutive [/health?full=1] cache-refresh failures that must accumulate before [masc_full_health_refresh_c... |
+| `MASC_FULL_HEALTH_REFRESH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 495 | Full-health snapshot proactive refresh timeout (seconds). Caps a single [/health?full=1] cache refresh attempt in [Se... |
+| `MASC_GRPC_ENABLED` | feature_flag | n/a | n/a | 195 | Whether gRPC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
+| `MASC_GRPC_PORT` | string_literal | n/a | n/a | 191 | gRPC server port. Default: 8936. |
+| `MASC_GRPC_TARGET` | string_literal | n/a | n/a | 199 | gRPC client target address. Derived from grpc_port when unset. |
+| `MASC_HTTP_AUTH_STRICT` | feature_flag | n/a | n/a | 225 |  |
+| `MASC_JANITOR_INTERVAL_SEC` | typed:float | unclassified | unclassified | 546 | Bootstrap janitor tick interval (seconds). Drives the SSE/session/ rate-limit/webrtc reaper loop in [server_bootstrap... |
+| `MASC_LABEL_QUIET_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 522 | Dashboard label "quiet" threshold (seconds). Default: 300 (5 min). |
+| `MASC_LABEL_STUCK_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 526 | Dashboard label "stuck" threshold (seconds). Default: 900 (15 min). |
+| `MASC_LANE_PREFERENCE_TTL_S` | typed:float | Timeouts | operator | 349 | Sticky lane-candidate preference TTL (seconds). After a lane candidate succeeds, later turns on the same lane try it ... |
+| `MASC_LIST_PAGE_SIZE` | typed:int | unclassified | unclassified | 272 | Tool list page size, clamped to [10, 1024]. Default: 512. Re-readable within the process; not a guarantee of shell-le... |
+| `MASC_LOCAL_RUNTIME_COOLDOWN_SEC` | string_literal | n/a | n/a | 323 | Local runtime cooldown (seconds). |
+| `MASC_LOCAL_RUNTIME_DEBUG` | feature_flag | n/a | n/a | 319 | Enable local runtime debug logging. Default: false. |
+| `MASC_LOCAL_WORKER_HEARTBEAT_SEC` | typed:int | unclassified | unclassified | 326 | Local worker heartbeat interval (seconds). Default: 60. |
+| `MASC_METRICS_FLUSH_SEC` | typed:float | unclassified | unclassified | 518 | Tool metrics flush interval (seconds). Default: 300 (5 min). |
+| `MASC_OAS_SSE_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 334 | SSE drain interval (seconds). Default: 2.0. |
 | `MASC_ORCHESTRATOR_AGENT` | typed:string | unclassified | unclassified | 67 | Orchestrator agent name |
 | `MASC_ORCHESTRATOR_INTERVAL` | typed:float | unclassified | unclassified | 63 | Orchestrator check interval (seconds) |
 | `MASC_ORCHESTRATOR_MIN_PRIORITY` | typed:int | unclassified | unclassified | 70 |  |
-| `MASC_PUBLIC_TOOLS_EXTRA` | string_literal | n/a | n/a | 284 | Extra public tools (comma-separated names). |
-| `MASC_RATE_BURST` | typed:int | unclassified | unclassified | 312 | Burst capacity. Default: 150. |
-| `MASC_RATE_LIMIT` | typed:float | unclassified | unclassified | 309 | Requests per second. Default: 100. |
-| `MASC_RATE_LIMIT_BUCKET_TTL_SEC` | typed:int | unclassified | unclassified | 567 | Rate-limit bucket staleness TTL (seconds). Buckets with no traffic for this long are reaped by the janitor loop. Defa... |
-| `MASC_REPO_SYNC_INTERVAL_SEC` | typed:float | unclassified | unclassified | 559 | Repository auto-sync interval (seconds). The repo_sync fiber in [server_bootstrap_loops] wakes at this cadence to fet... |
+| `MASC_PUBLIC_TOOLS_EXTRA` | string_literal | n/a | n/a | 277 | Extra public tools (comma-separated names). |
+| `MASC_RATE_BURST` | typed:int | unclassified | unclassified | 305 | Burst capacity. Default: 150. |
+| `MASC_RATE_LIMIT` | typed:float | unclassified | unclassified | 302 | Requests per second. Default: 100. |
+| `MASC_RATE_LIMIT_BUCKET_TTL_SEC` | typed:int | unclassified | unclassified | 560 | Rate-limit bucket staleness TTL (seconds). Buckets with no traffic for this long are reaped by the janitor loop. Defa... |
+| `MASC_REPO_SYNC_INTERVAL_SEC` | typed:float | unclassified | unclassified | 552 | Repository auto-sync interval (seconds). The repo_sync fiber in [server_bootstrap_loops] wakes at this cadence to fet... |
 | `MASC_SESSION_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 8 | Maximum session age before cleanup (seconds) |
 | `MASC_SESSION_SSE_GRACE_PERIOD_SEC` | typed:float | unclassified | unclassified | 13 | Grace period after SSE disconnect before reaping transport session (seconds). Prevents "Unknown Mcp-Session-Id" error... |
-| `MASC_SIDECAR_CONTROL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 593 | Subprocess timeout (seconds) for sidecar control commands — [stop], [tail], and similar quick housekeeping operatio... |
-| `MASC_SIDECAR_RECONCILE_BACKOFF_SEC` | typed:float | unclassified | unclassified | 581 | Backoff window (seconds) between repeated same-generation [running + unavailable] start dispatches. Default: 30 (matc... |
-| `MASC_SIDECAR_SCHEMA_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 609 | Subprocess timeout (seconds) for sidecar Python schema generation. Wraps [Process_eio.run_argv_with_status] at [serve... |
-| `MASC_SSE_BUFFER_TTL_SEC` | typed:float | unclassified | unclassified | 541 | SSE buffer TTL (seconds). Default: 300 (5 min). |
-| `MASC_STALLED_SESSION_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 545 | Operator digest stalled session threshold (seconds). Default: 300 (5 min). |
-| `MASC_STARTUP_WATCHDOG_SEC` | typed:float | unclassified | unclassified | 243 | Startup watchdog timeout, clamped to [30, 600]. Default: 240. Re-readable within the process, but operationally a boo... |
+| `MASC_SIDECAR_CONTROL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 586 | Subprocess timeout (seconds) for sidecar control commands — [stop], [tail], and similar quick housekeeping operatio... |
+| `MASC_SIDECAR_RECONCILE_BACKOFF_SEC` | typed:float | unclassified | unclassified | 574 | Backoff window (seconds) between repeated same-generation [running + unavailable] start dispatches. Default: 30 (matc... |
+| `MASC_SIDECAR_SCHEMA_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 602 | Subprocess timeout (seconds) for sidecar Python schema generation. Wraps [Process_eio.run_argv_with_status] at [serve... |
+| `MASC_SSE_BUFFER_TTL_SEC` | typed:float | unclassified | unclassified | 534 | SSE buffer TTL (seconds). Default: 300 (5 min). |
+| `MASC_STALLED_SESSION_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 538 | Operator digest stalled session threshold (seconds). Default: 300 (5 min). |
+| `MASC_STARTUP_WATCHDOG_SEC` | typed:float | unclassified | unclassified | 236 | Startup watchdog timeout, clamped to [30, 600]. Default: 240. Re-readable within the process, but operationally a boo... |
 | `MASC_TEMPO_DEFAULT_INTERVAL_SEC` | typed:float | unclassified | unclassified | 29 | Default polling interval (seconds) |
 | `MASC_TEMPO_MAX_INTERVAL_SEC` | typed:float | unclassified | unclassified | 25 | Maximum polling interval (seconds) - for idle tempo |
 | `MASC_TEMPO_MIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 21 | Minimum polling interval (seconds) - for urgent tempo |
-| `MASC_USE_H2` | string_literal | n/a | n/a | 221 | HTTP mode: typed variant for "auto", "h2_only", "h1_only". |
-| `MASC_WEBRTC_ENABLED` | feature_flag | n/a | n/a | 217 | Whether WebRTC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
-| `MASC_WEB_SEARCH_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 300 |  |
-| `MASC_WEB_SEARCH_FALLBACKS` | string_literal | n/a | n/a | 293 |  |
-| `MASC_WEB_SEARCH_PROVIDER` | string_literal | n/a | n/a | 287 |  |
-| `MASC_WEB_SEARCH_PROVIDER_ORDER` | string_literal | n/a | n/a | 290 |  |
-| `MASC_WEB_SEARCH_TIMEOUT_SEC` | typed:int | unclassified | unclassified | 296 |  |
-| `MASC_WORKSPACE_FILE_MAX_READ_BYTES` | typed:int | Policies | operator | 619 | Maximum bytes served by the IDE workspace file endpoint in one response. The route rejects larger files instead of ma... |
-| `MASC_WS_ENABLED` | feature_flag | n/a | n/a | 213 | Whether WebSocket transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at... |
-| `MASC_WS_PORT` | string_literal | n/a | n/a | 209 | WebSocket server port. Default: 8937. |
+| `MASC_USE_H2` | string_literal | n/a | n/a | 214 | HTTP mode: typed variant for "auto", "h2_only", "h1_only". |
+| `MASC_WEBRTC_ENABLED` | feature_flag | n/a | n/a | 210 | Whether WebRTC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
+| `MASC_WEB_SEARCH_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 293 |  |
+| `MASC_WEB_SEARCH_FALLBACKS` | string_literal | n/a | n/a | 286 |  |
+| `MASC_WEB_SEARCH_PROVIDER` | string_literal | n/a | n/a | 280 |  |
+| `MASC_WEB_SEARCH_PROVIDER_ORDER` | string_literal | n/a | n/a | 283 |  |
+| `MASC_WEB_SEARCH_TIMEOUT_SEC` | typed:int | unclassified | unclassified | 289 |  |
+| `MASC_WORKSPACE_FILE_MAX_READ_BYTES` | typed:int | Policies | operator | 612 | Maximum bytes served by the IDE workspace file endpoint in one response. The route rejects larger files instead of ma... |
+| `MASC_WS_ENABLED` | feature_flag | n/a | n/a | 206 | Whether WebSocket transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at... |
+| `MASC_WS_PORT` | string_literal | n/a | n/a | 202 | WebSocket server port. Default: 8937. |
 
 ## Env_config_runtime_services (18 knobs; typed classification 8/14)
 
@@ -226,9 +225,9 @@ the categorization roadmap. Newly-added typed getters in
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALLOW_ANONYMOUS_MUTATIONS` | string_literal | n/a | n/a | 29 |  |
-| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 408 |  |
-| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 412 |  |
-| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 414 |  |
+| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 406 |  |
+| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 410 |  |
+| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 412 |  |
 | `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 148 |  |
 | `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 218 |  |
 | `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 220 |  |
@@ -236,8 +235,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S` | string_literal | n/a | n/a | 158 |  |
 | `MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S` | string_literal | n/a | n/a | 190 |  |
 | `MASC_DECISION_AUDIT_RING_CAPACITY` | string_literal | n/a | n/a | 230 |  |
-| `MASC_DEFAULT_MODEL` | string_literal | n/a | n/a | 374 |  |
-| `MASC_DEFAULT_PROVIDER` | string_literal | n/a | n/a | 376 |  |
+| `MASC_DEFAULT_MODEL` | string_literal | n/a | n/a | 372 |  |
+| `MASC_DEFAULT_PROVIDER` | string_literal | n/a | n/a | 374 |  |
 | `MASC_DISCORD_STATUS_STALE_SEC` | string_literal | n/a | n/a | 222 |  |
 | `MASC_GRPC_STREAM_MAX_BUFFER` | string_literal | n/a | n/a | 81 |  |
 | `MASC_HTTP_HOST` | string_literal | n/a | n/a | 21 |  |
@@ -246,18 +245,18 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_AUTONOMOUS_MAX_TOKENS` | string_literal | n/a | n/a | 136 |  |
 | `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 134 |  |
 | `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 133 |  |
-| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 460 |  |
-| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 486 |  |
-| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 494 |  |
-| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 434 |  |
-| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 436 |  |
-| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 438 |  |
-| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 440 |  |
-| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 446 |  |
+| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 458 |  |
+| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 484 |  |
+| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 492 |  |
+| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 432 |  |
+| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 434 |  |
+| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 436 |  |
+| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 438 |  |
+| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 444 |  |
 | `MASC_TELEMETRY_MAX_BYTES` | string_literal | n/a | n/a | 48 |  |
 | `MASC_TELEMETRY_RETENTION_DAYS` | string_literal | n/a | n/a | 45 |  |
-| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 476 |  |
-| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 478 |  |
+| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 474 |  |
+| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 476 |  |
 | `MASC_TLA_TRACE` | string_literal | n/a | n/a | 127 |  |
 | `MASC_WS_ACK_STALE_THRESHOLD_SEC` | string_literal | n/a | n/a | 91 |  |
 | `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 88 |  |

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -137,13 +137,6 @@ end
 
 (** {1 Message GC Configuration} *)
 
-module Message = struct
-  (** Maximum number of message files to retain per workspace (default 200).
-      Oldest messages (by filename sort) are deleted when count exceeds this. *)
-  let max_count =
-    get_int ~default:200 "MASC_MESSAGE_MAX_COUNT"
-end
-
 (** {1 Transport Configuration} *)
 
 module Transport = struct

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -73,12 +73,6 @@ module Voice : sig
   val audio_test_tone_timeout_sec : float
 end
 
-(** {1 Message GC} *)
-
-module Message : sig
-  val max_count : int
-end
-
 (** {1 Transport} *)
 
 module Transport : sig

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -363,8 +363,6 @@ let memory_entries =
 
 let message_gc_entries =
   [
-    entry ~default:"200" "MASC_MESSAGE_MAX_COUNT"
-      "Maximum message files retained per workspace";
   ]
 
 let model_routing_entries =

--- a/lib/runtime_settings.ml
+++ b/lib/runtime_settings.ml
@@ -106,38 +106,6 @@ let register_bool ~key ~default ?meta () =
     ?meta
     ()
 
-(** Register a string parameter with a maximum length. *)
-let register_string ~key ~default ~max_len ?meta () =
-  Runtime_params.register
-    ~key
-    ~default
-    ~validate:(fun v ->
-      if String.length v > 0 && String.length v <= max_len then Ok ()
-      else Error (Printf.sprintf "%s must be 1-%d chars" key max_len))
-    ~serialize:(fun v -> `String v)
-    ~deserialize:deserialize_string
-    ?meta
-    ()
-
-
-(* ── board_policy surface ────────────────────────────────────── *)
-
-let message_max_count =
-  register_int
-    ~key:"message.max_count"
-    ~default:(fun () -> Env_config_runtime.Message.max_count)
-    ~min:10 ~max:10000
-    ()
-
-(* ── inference_config surface ──────────────────────────────────────── *)
-
-let inference_default_model =
-  register_string
-    ~key:"inference.default_model"
-    ~default:(fun () -> "auto")
-    ~max_len:100
-    ()
-
 (* ── dashboard surface (display-only) ────────────────────────── *)
 
 (** Maximum path length before truncation in dashboard output. *)
@@ -224,17 +192,6 @@ let dashboard_agent_stuck_threshold_sec =
     ()
 
 (* ── cost_policy surface ──────────────────────────────────────── *)
-
-(** Per-session advisory cost threshold in USD.
-    Default 0.50: based on observed keeper sessions averaging $0.02-0.15
-    (local llama + GLM fallback). 0.50 is ~3x worst-case observed session cost.
-    Used for reporting/warnings only; it must not gate execution. *)
-let _cost_max_session_usd =
-  register_float
-    ~key:"cost.max_session_usd"
-    ~default:(fun () -> 0.50)
-    ~min:0.01 ~max:50.0
-    ()
 
 (* ── keeper_lifecycle surface ────────────────────────────────── *)
 
@@ -329,21 +286,6 @@ type surface = {
 let surfaces =
   [
     {
-      id = "board_policy";
-      description = "Message retention cap";
-      param_keys = [ "message.max_count" ];
-    };
-    {
-      id = "inference_config";
-      description = "Default MODEL model";
-      param_keys = [ "inference.default_model" ];
-    };
-    {
-      id = "cost_policy";
-      description = "Per-session cost limits for keeper execution";
-      param_keys = [ "cost.max_session_usd" ];
-    };
-    {
       id = "keeper_lifecycle";
       description = "Keeper heartbeat and supervisor timing";
       param_keys = [
@@ -368,7 +310,6 @@ let surfaces =
       param_keys = [
         "keeper.turn.temperature";
         "keeper.turn.max_output_tokens";
-        "keeper.turn.llama_slots";
         "keeper.turn.batch_limit";
       ];
     };
@@ -400,7 +341,6 @@ let surfaces =
 (** Force module initialization to guarantee all params are registered
     before [Runtime_params.restore]. Call from server bootstrap. *)
 let ensure_init () =
-  let (_ : _) = Runtime_params.get message_max_count in
   let (_ : _) = Runtime_params.get dashboard_max_path_length in
   let (_ : _) = Runtime_params.get dashboard_max_message_length in
   let (_ : _) = Runtime_params.get dashboard_max_pending_tasks in

--- a/lib/runtime_settings.mli
+++ b/lib/runtime_settings.mli
@@ -8,30 +8,16 @@
     Surfaces (groups of related params published as a single
     runtime settings group, see {!surface}):
 
-    - [board_policy] — message retention cap
-    - [inference_config] — default model
-    - [cost_policy] — per-session cost reporting threshold
     - [keeper_lifecycle] — heartbeat / supervisor / restart limits
     - [keeper_handoff] — handoff threshold / cooldown / pressure
     - [keeper_diagnostics] — snapshot / hb tuning / profiling ring
     - [keeper_turn] / [keeper_proactive] / [keeper_rules] — keeper LLM tuning surfaces
     - [dashboard] — display-only thresholds + truncation lengths
 
-    Internal: 6 deserialization / validation helpers stay
-    private — \[validate_float_range], \[validate_int_range],
-    \[deserialize_float], \[deserialize_int],
-    \[deserialize_string], \[deserialize_bool].  Plus 25+
-    keeper.turn / keeper.proactive / keeper.rule param handles +
-    \[message_max_count] +
-    \[_cost_max_session_usd] are
-    intentionally unexported — these are reachable only via
-    {!Runtime_params.get_by_key} (runtime settings UI) and are pinned
-    in the {!surfaces} catalog by string key. *)
-
-(** {1 Inference} *)
-
-val inference_default_model : string Runtime_params.param
-(** Default LLM model label.  Validation: 1-100 chars. *)
+    Internal: the deserialization / validation helpers stay private,
+    as do the 25+ keeper.turn / keeper.proactive / keeper.rule param
+    handles — those are reachable through the runtime settings UI by
+    string key and are pinned in the {!surfaces} catalog. *)
 
 (** {1 Keeper lifecycle} *)
 

--- a/test/test_runtime_params.ml
+++ b/test/test_runtime_params.ml
@@ -276,28 +276,27 @@ let () =
   in
 
   let test_runtime_settings () =
-    (* Verify that runtime_settings registered params *)
+    (* ensure_init forces both this module's registrations and
+       Keeper_config's; the surfaces below pin keys from each. *)
+    Runtime_settings.ensure_init ();
     let entries = Runtime_params.registry () in
     let has key =
       List.exists (fun (k, _, _, _, _) -> k = key) entries
     in
-    Alcotest.(check bool) "inference.default_model registered"
-      true (has "inference.default_model");
-    (* Validate surfaces *)
+    (* Every surface must name keys that are actually registered. A surface
+       pinning a key nothing registers puts a control in the settings UI with
+       nothing behind it. *)
     let surfaces = Runtime_settings.surfaces in
     Alcotest.(check bool) "has surfaces" true (List.length surfaces > 0);
-    let surface_ids =
-      List.map (fun (s : Runtime_settings.surface) -> s.id) surfaces
-    in
-    Alcotest.(check bool) "inference_config surface"
-      true (List.mem "inference_config" surface_ids)
-  in
-
-  let test_runtime_settings_validation () =
-    (* Default inference model should reject empty string *)
-    (match Runtime_params.set Runtime_settings.inference_default_model "" with
-     | Error _ -> ()
-     | Ok () -> Alcotest.fail "should reject empty model name")
+    List.iter
+      (fun (surface : Runtime_settings.surface) ->
+        List.iter
+          (fun key ->
+            Alcotest.(check bool)
+              (Printf.sprintf "%s pins registered key %s" surface.id key)
+              true (has key))
+          surface.param_keys)
+      surfaces
   in
 
   let test_dashboard_params_registered () =
@@ -525,7 +524,6 @@ let () =
       ( "runtime_settings",
         [
           Alcotest.test_case "registration" `Quick test_runtime_settings;
-          Alcotest.test_case "validation" `Quick test_runtime_settings_validation;
           Alcotest.test_case "dashboard params registered" `Quick
             test_dashboard_params_registered;
           Alcotest.test_case "dashboard surface" `Quick test_dashboard_surface;


### PR DESCRIPTION
## 증상

런타임 설정 UI 는 `Runtime_settings.surfaces` 를 읽어 그룹을 보여주고, 오퍼레이터는 거기 pin 된 키를 `Runtime_params.set_by_key` 로 설정할 수 있다. 그 컨트롤 중 **4개가 아무것도 하지 않는다.**

### 읽는 코드가 없는 파라미터 3개

| surface | 표시되는 설명 | 키 | 읽는 곳 |
|---|---|---|---|
| `board_policy` | Message retention cap | `message.max_count` | 0 |
| `inference_config` | Default MODEL model | `inference.default_model` | 0 |
| `cost_policy` | Per-session cost limits for keeper execution | `cost.max_session_usd` | 0 |

등록된 17개 키를 전수 확인해서 나온 결과다. 나머지 14개는 전부 소비자가 있다.

그중 둘은 **실제 메커니즘을 가린다.**

- 메시지는 `workspace_gc` 가 **나이 기준**(`ts < cutoff_iso`)으로 지운다. 개수 기준 정리는 존재하지 않는다. `message.max_count` 가 기본값을 가져오던 `MASC_MESSAGE_MAX_COUNT` 도 읽는 곳이 0 인데, `docs/runtime-tunables.md` 에는 이렇게 실려 있었다 — *"Oldest messages (by filename sort) are deleted when count exceeds this."* 그 정책은 없다.
- 기본 모델은 `Env_config_runtime.Ollama.default_model` 에서 온다. `inference.default_model` 을 바꿔도 모델은 바뀌지 않는다.

### 등록조차 되지 않은 키 1개

`keeper_turn` surface 가 `keeper.turn.llama_slots` 를 pin 한다. 이 문자열은 **저장소 전체에서 그 목록에 딱 한 번** 나온다. 등록하는 코드가 없으므로 `set_by_key` 는 `unknown parameter: keeper.turn.llama_slots` 를 돌려준다. UI 는 뒤에 아무것도 없는 컨트롤을 광고하고 있었다.

## 수정

네 개를 제거했다. 연쇄로:

- `register_string` — 호출 지점이 inference 파라미터 하나뿐이라 같이 제거
- `Env_config_runtime.Message` 모듈과 `MASC_MESSAGE_MAX_COUNT` — `docs/runtime-tunables.md` 재생성 (CI drift gate 대상)
- `.mli` 헤더가 나열하던 세 surface 설명과 "reachable only via `Runtime_params.get_by_key`" 문구 정정

저장된 오버라이드는 안전하다. `Runtime_params.restore` 는 미등록 키를 조용히 건너뛴다 (`| None -> ()`).

## 테스트

기존 `registration` 테스트는 이랬다.

```ocaml
Alcotest.(check bool) "inference.default_model registered" true (has "inference.default_model");
...
Alcotest.(check bool) "inference_config surface" true (List.mem "inference_config" surface_ids)
```

죽은 파라미터가 존재한다는 것과 그 surface 가 있다는 것만 확인했다. 뒤에 뭐가 있는지는 검증 대상이 아니었다.

이제 모든 surface 를 돌면서 pin 된 키가 실제로 등록됐는지 확인한다. **`llama_slots` 를 잡아낸 게 이 검사다.**

`Runtime_settings.ensure_init ()` 를 먼저 부른다 — `keeper.turn.*` / `keeper.proactive.*` 는 `Keeper_config` 가 등록하고, `ensure_init` 이 그 초기화를 강제한다 (부트스트랩도 `Runtime_params.restore` 앞에서 같은 순서를 지킨다).

## 검증

- `dune build --root . @check` EXIT=0
- `test_runtime_params` 21/21, `test_misc_coverage` OK
- `bin/env_knob_catalog.exe` 재생성 후 diff 클린
- `scripts/check-doc-code-refs.sh`, `scripts/audit-keeper-tool-boundary-matrix.sh` PASS

187줄 삭제 / 95줄 추가.

RFC-WAIVED: 읽는 코드가 없는 설정 파라미터 3개와 등록되지 않은 surface 키 1개 제거. credential/identity, repo_manager, operator control plane, keeper sandbox, dashboard credential component, hooks, workflow 문서 어느 것도 건드리지 않는다. 살아있는 14개 파라미터의 키·기본값·검증 범위는 변하지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
