### PR TITLE
fix(keeper): project connector activity without tool chatter

### DIFF
--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -4,10 +4,8 @@
     message. Subsequent deltas PATCH the message content at most once per
     [min_edit_interval_s] (rate limit: 5 edits / 5 s per channel).
     [Text_message_end] and [Run_finished] force a final PATCH so the user
-    always sees the complete text.
-
-    Tool embed visualization: [Tool_call_start] sends a blue "Running…"
-    embed; [Tool_call_end] edits it to green "Done". *)
+    always sees the complete text. Tool activity stays on Discord's native
+    typing surface and never creates standalone messages. *)
 
 (* Minimum seconds between PATCH edits. Discord allows 5 edits per 5 s;
    1.0 s is 80 % of that budget, leaving headroom for the final edit. *)
@@ -118,114 +116,12 @@ let edit_message ?clock ~token ~channel_id ~message_id ~content () =
         message_id err_str;
       Error err
 
-(* ── Tool embed helpers ──────────────────────────────────────────── *)
-
-(* [tool_msgs] maps tool_call_id → tool_msg_entry. We store the Discord
-   message id, the tool name, and optional argument/result summaries so the
-   "done" edit can preserve the title and enrich the embed without relying
-   on the end event carrying them. *)
-type tool_msg_entry =
-  { discord_message_id : string
-  ; tool_call_name : string
-  ; args_summary : string option
-  ; result_summary : string option
-  }
-
-let find_tool_msg tool_msgs tool_call_id =
-  List.assoc_opt tool_call_id tool_msgs
-
-let remove_tool_msg tool_msgs tool_call_id =
-  List.filter (fun (k, _) -> k <> tool_call_id) tool_msgs
-
-let update_tool_context tool_msgs tool_call_id ~args_summary ~result_summary =
-  List.map
-    (fun (id, entry) ->
-       if id = tool_call_id then
-         let new_args =
-           match entry.args_summary with
-           | None -> Some args_summary
-           | Some _ -> entry.args_summary
-         in
-         let new_result =
-           match result_summary with
-           | Some _ -> result_summary
-           | None -> entry.result_summary
-         in
-         (id, { entry with args_summary = new_args; result_summary = new_result })
-       else (id, entry))
-    tool_msgs
-
 (* Truncate a string to [max_len], appending "…" when truncated.
    Separate from [truncate] above which truncates to Discord message
    limit with redaction. *)
 let truncate_to ~max_len s =
   if String.length s <= max_len then s
   else String.sub s 0 (max_len - 1) ^ "…"
-
-(* Discord embed title limit is 256 characters. *)
-let tool_embed_title ~tool_name =
-  let prefix = "🔧 " in
-  let budget = 256 - String.length prefix in
-  prefix ^ truncate_to ~max_len:budget tool_name
-
-(* Send a "running" embed for a tool call. Returns the Discord message
-   id so we can edit it to "done" later. *)
-let send_tool_running ?clock ~token ~channel_id ~tool_call_name () =
-  let embed =
-    { Discord_rest_client.title = tool_embed_title ~tool_name:tool_call_name
-    ; description = Some "Running…"
-    ; url = None
-    ; color = Discord_rest_client.color_blue
-    ; image = None
-    ; fields = []
-    }
-  in
-  match Discord_rest_client.send_embed_message
-          ?clock ~token ~channel_id ~content:"" ~embeds:[embed] () with
-  | Ok msg_id -> Some msg_id
-  | Error err ->
-      let err_str = Format.asprintf "%a" Discord_rest_client.pp_error err in
-      Log.Keeper.warn
-        "keeper_chat_discord: send_tool_running failed: %s" err_str;
-      None
-
-(* Edit a "running" embed to "done", preserving the original tool name and
-   enriching it with optional argument and result summaries. *)
-let send_tool_done ?clock ~token ~channel_id ~message_id ~tool_call_name
-    ~args_summary ~result_summary () =
-  let fields =
-    [ ( "args"
-      , truncate_to ~max_len:Discord_rest_client.embed_field_value_limit
-          args_summary
-      , false )
-    ]
-  in
-  let fields =
-    match result_summary with
-    | None -> fields
-    | Some summary ->
-        ( "result"
-        , truncate_to ~max_len:Discord_rest_client.embed_field_value_limit
-            summary
-        , false )
-        :: fields
-  in
-  let embed =
-    { Discord_rest_client.title = tool_embed_title ~tool_name:tool_call_name
-    ; description = Some "✅ Done"
-    ; url = None
-    ; color = Discord_rest_client.color_green
-    ; image = None
-    ; fields
-    }
-  in
-  match Discord_rest_client.edit_embed_message
-          ?clock ~token ~channel_id ~message_id ~content:"" ~embeds:[embed] () with
-  | Ok () -> ()
-  | Error err ->
-      let err_str = Format.asprintf "%a" Discord_rest_client.pp_error err in
-      Log.Keeper.warn
-        "keeper_chat_discord: send_tool_done failed: %s" err_str
 
 (* ── Rich block delivery helpers ─────────────────────────────────── *)
 
@@ -378,7 +274,7 @@ let combine_delivery_results primary overflow =
   | Ok () -> overflow
 
 let adapter_loop_with_transport ~token ~channel_id ~events ~post_message
-    ~edit_message ~send_message ?clock ?base_url
+    ~edit_message ~send_message ?show_activity ?clock ?base_url
     ?(on_send_result = fun _ -> ()) () =
   let base_url =
     match base_url with
@@ -386,99 +282,77 @@ let adapter_loop_with_transport ~token ~channel_id ~events ~post_message
     | None -> None
   in
   let external_effect_completed = ref false in
-  (* Streaming state:
-     - msg_id: Some once the initial POST succeeds
-     - last_edit_time: wall-clock of last PATCH (rate limiting)
-     - last_edited_text: content sent by last POST/PATCH (skip no-op edits)
-     - tool_msgs: tool_call_id → (discord_message_id, tool_call_name,
-       args_summary option, result_summary option) *)
-  let rec loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url
-      ~(tool_msgs : (string * tool_msg_entry) list) =
+  let activity_error_logged = ref false in
+  let refresh_activity () =
+    match show_activity with
+    | None -> ()
+    | Some show ->
+        (match show () with
+         | Ok () -> ()
+         | Error err when not !activity_error_logged ->
+             activity_error_logged := true;
+             Log.Keeper.warn
+               "keeper_chat_discord: native activity refresh failed: %s"
+               (Format.asprintf "%a" Discord_rest_client.pp_error err)
+         | Error _ -> ())
+  in
+  let rec loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text =
+    let continue ?(acc_text = acc_text) ?(msg_id = msg_id)
+        ?(last_edit_time = last_edit_time)
+        ?(last_edited_text = last_edited_text) () =
+      loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text
+    in
     match Keeper_chat_events.subscribe events with
     | Text_delta text ->
         let acc_text = acc_text ^ text in
         let patch_content = streaming_patch_content acc_text in
         (match msg_id with
+         | None when String.length patch_content = 0 -> continue ~acc_text ()
          | None ->
-             (* First stable segment — POST to create the message. *)
-             if String.length patch_content = 0 then
-               loop ~acc_text ~msg_id:None ~last_edit_time
-                 ~last_edited_text ~base_url ~tool_msgs
-             else
-               (match post_message ~content:patch_content
-               with
-                | Ok created_id ->
-                    loop ~acc_text
-                      ~msg_id:(Some created_id)
-                      ~last_edit_time:(now ())
-                      ~last_edited_text:patch_content
-                      ~base_url ~tool_msgs
-                | Error err ->
-                    let err_str =
-                      Format.asprintf "%a" Discord_rest_client.pp_error err
-                    in
-                    Log.Keeper.warn
-                      "keeper_chat_discord: streaming POST failed: %s" err_str;
-                    (* Keep accumulating; will try again on next delta. *)
-                    loop ~acc_text ~msg_id:None
-                      ~last_edit_time ~last_edited_text ~base_url ~tool_msgs)
+             (match post_message ~content:patch_content with
+              | Ok created_id ->
+                  continue ~acc_text ~msg_id:(Some created_id)
+                    ~last_edit_time:(now ()) ~last_edited_text:patch_content ()
+              | Error err ->
+                  Log.Keeper.warn
+                    "keeper_chat_discord: streaming POST failed: %s"
+                    (Format.asprintf "%a" Discord_rest_client.pp_error err);
+                  continue ~acc_text ())
          | Some mid ->
              let elapsed = now () -. last_edit_time in
-             if patch_content = last_edited_text then
-               loop ~acc_text ~msg_id ~last_edit_time
-                 ~last_edited_text ~base_url ~tool_msgs
-             else if elapsed >= min_edit_interval_s then begin
-               match edit_message ~message_id:mid ~content:patch_content with
-               | Ok () ->
-                   loop ~acc_text ~msg_id
-                     ~last_edit_time:(now ())
-                     ~last_edited_text:patch_content
-                     ~base_url ~tool_msgs
-               | Error err ->
-                   let err_str =
-                     Format.asprintf "%a" Discord_rest_client.pp_error err
-                   in
-                   Log.Keeper.warn
-                     "keeper_chat_discord: streaming PATCH failed (msg=%s): %s"
-                     mid err_str;
-                   (* Keep the last successful edit state so a later delta or
-                      the terminal PATCH retries the unsent content. *)
-                   loop ~acc_text ~msg_id ~last_edit_time
-                     ~last_edited_text ~base_url ~tool_msgs
-             end else
-               (* Rate limited — skip this PATCH. *)
-               loop ~acc_text ~msg_id ~last_edit_time
-                 ~last_edited_text ~base_url ~tool_msgs)
+             if patch_content = last_edited_text then continue ~acc_text ()
+             else if elapsed < min_edit_interval_s then continue ~acc_text ()
+             else
+               (match edit_message ~message_id:mid ~content:patch_content with
+                | Ok () ->
+                    continue ~acc_text ~last_edit_time:(now ())
+                      ~last_edited_text:patch_content ()
+                | Error err ->
+                    Log.Keeper.warn
+                      "keeper_chat_discord: streaming PATCH failed (msg=%s): %s"
+                      mid
+                      (Format.asprintf "%a" Discord_rest_client.pp_error err);
+                    continue ~acc_text ()))
     | Text_message_end ->
-        (* Force a final PATCH for this text message if content changed. *)
         let final_content = truncate acc_text in
         (match msg_id with
          | Some mid when final_content <> last_edited_text ->
              (match edit_message ~message_id:mid ~content:final_content with
               | Ok () ->
-                  loop ~acc_text ~msg_id
-                    ~last_edit_time:(now ())
-                    ~last_edited_text:final_content
-                    ~base_url ~tool_msgs
+                  continue ~last_edit_time:(now ())
+                    ~last_edited_text:final_content ()
               | Error err ->
-                  let err_str =
-                    Format.asprintf "%a" Discord_rest_client.pp_error err
-                  in
                   Log.Keeper.warn
                     "keeper_chat_discord: text-end PATCH failed (msg=%s): %s"
-                    mid err_str;
-                  loop ~acc_text ~msg_id ~last_edit_time
-                    ~last_edited_text ~base_url ~tool_msgs)
-         | _ ->
-             loop ~acc_text ~msg_id ~last_edit_time
-               ~last_edited_text ~base_url ~tool_msgs)
+                    mid
+                    (Format.asprintf "%a" Discord_rest_client.pp_error err);
+                  continue ())
+         | _ -> continue ())
     | Run_finished { run_id = _ } ->
         let final_result =
           match msg_id with
           | None when !external_effect_completed -> Ok ()
           | None ->
-              (* No stable streaming segment was posted. The terminal fallback
-                 is the primary delivery and its result owns the receipt. *)
               if String.length acc_text = 0 then
                 Error
                   (Discord_rest_client.Other
@@ -492,31 +366,23 @@ let adapter_loop_with_transport ~token ~channel_id ~events ~post_message
                 | None -> Ok ()
                 | Some overflow -> send_message ~content:overflow
               in
-              (* Overflow is attempted even after a failed PATCH. The first
-                 primary failure remains the terminal result. *)
               combine_delivery_results patch_result overflow_result
         in
         on_send_result final_result;
-        send_text_rich_embeds ?clock ~token ~channel_id acc_text;
-        (* Loop exits after one turn. *)
-        ()
+        send_text_rich_embeds ?clock ~token ~channel_id acc_text
     | External_effect_completed ->
         external_effect_completed := true;
-        loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url
-          ~tool_msgs
+        continue ()
     | Event_error { message } ->
-        on_send_result (send_message ~content:("Keeper error: " ^ message));
-        (* Loop exits after error. *)
-        ()
+        on_send_result (send_message ~content:("Keeper error: " ^ message))
     | Run_started { run_id = _; thread_id = _ } ->
+        refresh_activity ();
         loop ~acc_text:"" ~msg_id:None ~last_edit_time:0.0
-          ~last_edited_text:"" ~base_url ~tool_msgs:[]
-    | Text_message_start { message_id = _; role = _ } ->
-        loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
+          ~last_edited_text:""
+    | Text_message_start _ -> continue ()
     | Custom { name; value = _ } ->
-        Log.Keeper.debug
-          "keeper_chat_discord: custom event %s" name;
-        loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
+        Log.Keeper.debug "keeper_chat_discord: custom event %s" name;
+        continue ()
     | Oas_stream_connected
     | Oas_stream_message_start _
     | Oas_stream_message_delta _
@@ -526,8 +392,7 @@ let adapter_loop_with_transport ~token ~channel_id ~events ~post_message
     | Oas_content_block_stop _
     | Oas_thinking_delta _
     | Oas_thinking_signature_delta _
-    | Oas_media_delta _ ->
-        loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
+    | Oas_media_delta _ -> continue ()
     | Oas_stream_protocol_error error ->
         ignore
           (send_message
@@ -535,71 +400,44 @@ let adapter_loop_with_transport ~token ~channel_id ~events ~post_message
                ("Keeper stream protocol: "
                 ^ Keeper_chat_events.stream_protocol_error_summary error)
             : (unit, error) result);
-        loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
-    | Tool_call_start { tool_call_id; tool_call_name } ->
-        let tool_msgs =
-          match send_tool_running ?clock ~token ~channel_id ~tool_call_name () with
-          | Some discord_msg_id ->
-              let entry =
-                { discord_message_id = discord_msg_id
-                ; tool_call_name
-                ; args_summary = None
-                ; result_summary = None
-                }
-              in
-              (tool_call_id, entry) :: tool_msgs
-          | None -> tool_msgs
-        in
-        loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
-    | Tool_call_args { tool_call_id = _; delta = _ } ->
-        (* Args stream is not visualized — only start/end matters. *)
-        loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
-    | Tool_call_args_snapshot { tool_call_id = _; snapshot = _ } ->
-        (* Args stream is not visualized — only start/end matters. *)
-        loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
-    | Tool_call_end { tool_call_id } ->
-        (match find_tool_msg tool_msgs tool_call_id with
-         | Some entry ->
-             let args_summary = Option.value entry.args_summary ~default:"" in
-             send_tool_done ?clock ~token ~channel_id
-               ~message_id:entry.discord_message_id
-               ~tool_call_name:entry.tool_call_name ~args_summary
-               ~result_summary:entry.result_summary ();
-             let tool_msgs = remove_tool_msg tool_msgs tool_call_id in
-             loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
-         | None ->
-             (* No running embed was created (send failed earlier). *)
-             loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs)
+        continue ()
+    | Tool_call_start _ ->
+        refresh_activity ();
+        continue ()
+    | Tool_call_args _
+    | Tool_call_args_snapshot _
+    | Tool_call_end _
+    | Tool_context_block _ -> continue ()
     | Link_block { url; title; description; image } ->
         send_link_block ?clock ~token ~channel_id ~url ~title ~description ~image ();
-        loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
+        continue ()
     | Image_block { url; caption } ->
         send_image_block ?clock ~token ~channel_id ~url ~caption ();
-        loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
+        continue ()
     | Status_block { kind } ->
-        let acc_text = Keeper_chat_blocks.status_kind_connector_text kind in
-        loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
+        continue
+          ~acc_text:(Keeper_chat_blocks.status_kind_connector_text kind) ()
     | Audio_block { token; mime = _; message_text; duration_sec } ->
         send_audio_block ?clock ~token ~channel_id ~base_url ~audio_token:token
           ~message_text ~duration_sec ();
-        loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
-    | Tool_context_block { tool_call_id; name = _; args_summary; result_summary }
-      ->
-        let tool_msgs =
-          if List.mem_assoc tool_call_id tool_msgs then
-            update_tool_context tool_msgs tool_call_id ~args_summary
-              ~result_summary
-          else begin
-            Log.Keeper.debug
-              "keeper_chat_discord: tool_context for unknown tool_call_id=%s"
-              tool_call_id;
-            tool_msgs
-          end
-        in
-        loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
+        continue ()
   in
-  loop ~acc_text:"" ~msg_id:None ~last_edit_time:0.0
-    ~last_edited_text:"" ~base_url ~tool_msgs:[]
+  let run () =
+    loop ~acc_text:"" ~msg_id:None ~last_edit_time:0.0
+      ~last_edited_text:""
+  in
+  match clock, show_activity with
+  | Some clock, Some _ ->
+      Eio.Fiber.first
+        run
+        (fun () ->
+           let rec refresh_loop () =
+             Eio.Time.sleep clock 8.0;
+             refresh_activity ();
+             refresh_loop ()
+           in
+           refresh_loop ())
+  | _ -> run ()
 
 let adapter_loop ~clock ~token ~channel_id ~events ?base_url
     ?(on_send_result = fun _ -> ()) () =
@@ -609,6 +447,8 @@ let adapter_loop ~clock ~token ~channel_id ~events ?base_url
     ~edit_message:(fun ~message_id ~content ->
       edit_message ~clock ~token ~channel_id ~message_id ~content ())
     ~send_message:(fun ~content -> send_message ~clock ~token ~channel_id ~content ())
+    ~show_activity:(fun () ->
+      Discord_rest_client.trigger_typing ~clock ~token ~channel_id ())
     ~clock ?base_url ~on_send_result ()
 
 module For_testing = struct

--- a/lib/keeper/keeper_chat_discord.mli
+++ b/lib/keeper/keeper_chat_discord.mli
@@ -9,6 +9,10 @@
     delimiter arrives, so partial secret-like tokens are not published
     before the redactor can see the complete token.
 
+    While the run is active, the production adapter refreshes Discord's
+    native typing indicator. Tool lifecycle events refresh that indicator
+    but never create standalone tool messages.
+
     @since 2.145.0 *)
 
 val min_edit_interval_s : float
@@ -52,8 +56,9 @@ val adapter_loop :
     - [Link_block], [Image_block], [Audio_block]: send rich block embeds
     - [Status_block]: replace the terminal assistant text with typed status UI
       or messages.
-    - [Tool_context_block]: enriches the matching tool embed with argument
-      and result summaries on [Tool_call_end].
+    - [Tool_call_start], [Tool_call_args], [Tool_call_args_snapshot],
+      [Tool_call_end], and [Tool_context_block]: no message projection;
+      activity stays on Discord's native typing surface.
 
     [base_url] is used to build public voice-audio URLs; when omitted the
     configured {!Env_config_core.masc_http_base_url} is used.
@@ -97,13 +102,16 @@ module For_testing : sig
     post_message:(content:string -> (string, error) result) ->
     edit_message:(message_id:string -> content:string -> (unit, error) result) ->
     send_message:(content:string -> (unit, error) result) ->
+    ?show_activity:(unit -> (unit, error) result) ->
     ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
     ?base_url:string ->
     ?on_send_result:((unit, error) result -> unit) ->
     unit ->
     unit
-  (** Test seam for the text-delivery transport. Production uses
+  (** Test seam for the text-delivery and activity transports. Production uses
       {!Discord_rest_client}; tests can inject exact POST/PATCH outcomes while
-      exercising the real event-loop state machine. Rich side-message helpers
-      remain production-backed and should not be emitted by transport tests. *)
+      exercising the real event-loop state machine. [show_activity] represents
+      one native typing refresh; its failure is observational and never settles
+      [on_send_result]. Rich side-message helpers remain production-backed and
+      should not be emitted by transport tests. *)
 end

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -123,23 +123,6 @@ let audio_block_json ~base_url ~token ~message_text =
     ; ("text", `Assoc [ ("type", `String "mrkdwn"); ("text", `String text) ])
     ]
 
-let tool_context_block_json ~name ~args_summary ~result_summary =
-  let name = redact name |> escape_mrkdwn_text in
-  let args_summary = redact args_summary |> escape_mrkdwn_text in
-  let result =
-    match result_summary with
-    | None -> ""
-    | Some r -> Printf.sprintf "\nresult: %s" (redact r |> escape_mrkdwn_text)
-  in
-  let text =
-    Printf.sprintf "*Tool:* %s\nargs: %s%s" name args_summary result
-    |> truncate_block_text
-  in
-  `Assoc
-    [ ("type", `String "section")
-    ; ("text", `Assoc [ ("type", `String "mrkdwn"); ("text", `String text) ])
-    ]
-
 let code_block_json ~source ~caption =
   let language = Option.value caption ~default:"code" in
   let body =
@@ -252,6 +235,44 @@ let build_message_body ~channel ~content ~blocks ?thread_ts () =
   in
   `Assoc fields |> Yojson.Safe.to_string
 
+let build_thread_status_body ~channel ~thread_ts ~status =
+  `Assoc
+    [ "channel_id", `String channel
+    ; "thread_ts", `String thread_ts
+    ; "status", `String status
+    ]
+  |> Yojson.Safe.to_string
+
+let set_thread_status ?clock
+    ?(timeout_sec = Masc_http_client.default_request_timeout_sec)
+    ~token ~channel ~thread_ts ~status () =
+  let body = build_thread_status_body ~channel ~thread_ts ~status in
+  match
+    Masc_http_client.post_sync ?clock ~timeout_sec
+      ~url:"https://slack.com/api/assistant.threads.setStatus"
+      ~headers:
+        [ "Authorization", "Bearer " ^ token
+        ; "Content-Type", "application/json"
+        ]
+      ~body ()
+  with
+  | Error err -> Error (Network err)
+  | Ok (code, response_body) when code < 200 || code >= 300 ->
+      Error (Http_status { code; body = response_body })
+  | Ok (_, response_body) ->
+      (try
+         let json = Yojson.Safe.from_string response_body in
+         match Json_util.get_bool json "ok" with
+         | Some true -> Ok ()
+         | Some false ->
+             (match Json_util.get_string json "error" with
+              | Some error -> Error (Slack_api { error })
+              | None -> Error (Other "Slack setStatus returned ok=false"))
+         | None -> Error (Other "Slack setStatus response is missing ok")
+       with
+       | Yojson.Json_error msg ->
+           Error (Other ("Slack setStatus JSON parse error: " ^ msg)))
+
 let send_message_with_blocks ?clock
     ?(timeout_sec = Masc_http_client.default_request_timeout_sec)
     ?thread_ts ~token ~channel ~content ~blocks () =
@@ -311,9 +332,29 @@ let adapter_loop_with_transport
     ~(send_plain : content:string -> (unit, error) result)
     ~(send_blocks :
        content:string -> blocks:Yojson.Safe.t list -> (unit, error) result)
+    ?set_activity_status
     ?base_url
     ?(on_send_result = fun _ -> ()) () =
   let external_effect_completed = ref false in
+  let activity_error_logged = ref false in
+  let last_activity_status = ref None in
+  let update_activity status =
+    if !last_activity_status <> Some status then begin
+      last_activity_status := Some status;
+      match set_activity_status with
+      | None -> ()
+      | Some set_status ->
+          (match set_status ~status with
+           | Ok () -> ()
+           | Error error when not !activity_error_logged ->
+               activity_error_logged := true;
+               Log.Keeper.warn
+                 "keeper_chat_slack: native activity update failed: %s"
+                 (Format.asprintf "%a" pp_error error)
+           | Error _ -> ())
+    end
+  in
+  let clear_activity () = update_activity "" in
   let rec loop ~acc_text ~acc_blocks ~run_id_opt =
     match Keeper_chat_events.subscribe events with
     | Text_delta text ->
@@ -334,14 +375,17 @@ let adapter_loop_with_transport
             on_send_result
               (Error (Other "Slack terminal reply contained no text or blocks"))
         end;
+        clear_activity ();
         ()
     | External_effect_completed ->
         external_effect_completed := true;
         loop ~acc_text ~acc_blocks ~run_id_opt
     | Event_error { message } ->
         on_send_result (send_plain ~content:("Keeper error: " ^ message));
+        clear_activity ();
         ()
     | Run_started { run_id; thread_id = _ } ->
+        update_activity "답변을 준비하고 있어요…";
         loop ~acc_text:"" ~acc_blocks:[] ~run_id_opt:(Some run_id)
     | Text_message_start { message_id = _; role = _ } ->
         loop ~acc_text ~acc_blocks ~run_id_opt
@@ -375,7 +419,10 @@ let adapter_loop_with_transport
              "keeper_chat_slack: protocol diagnostic delivery failed: %s"
              (Format.asprintf "%a" pp_error error));
         loop ~acc_text ~acc_blocks ~run_id_opt
-    | Tool_call_start _ | Tool_call_args _ | Tool_call_args_snapshot _ | Tool_call_end _ ->
+    | Tool_call_start _ ->
+        update_activity "필요한 작업을 진행하고 있어요…";
+        loop ~acc_text ~acc_blocks ~run_id_opt
+    | Tool_call_args _ | Tool_call_args_snapshot _ | Tool_call_end _ ->
         loop ~acc_text ~acc_blocks ~run_id_opt
     | Link_block { url; title; description; image = _ } ->
         let block = link_block_json ~url ~title ~description in
@@ -389,23 +436,30 @@ let adapter_loop_with_transport
     | Audio_block { token; mime = _; message_text; duration_sec = _ } ->
         let block = audio_block_json ~base_url ~token ~message_text in
         loop ~acc_text ~acc_blocks:(add_block acc_blocks block) ~run_id_opt
-    | Tool_context_block { tool_call_id = _; name; args_summary; result_summary }
-      ->
-        let block =
-          tool_context_block_json ~name ~args_summary ~result_summary
-        in
-        loop ~acc_text ~acc_blocks:(add_block acc_blocks block) ~run_id_opt
+    | Tool_context_block _ ->
+        loop ~acc_text ~acc_blocks ~run_id_opt
   in
   loop ~acc_text:"" ~acc_blocks:[] ~run_id_opt:None
 
 let adapter_loop ~clock ~token ~channel ?thread_ts ~events ?base_url
     ?on_send_result () =
+  let set_activity_status =
+    match thread_ts with
+    | Some thread_ts ->
+        Some
+          (fun ~status ->
+             set_thread_status ~clock ~token ~channel ~thread_ts ~status ())
+    | None ->
+        Log.Keeper.debug
+          "keeper_chat_slack: native activity unavailable without thread_ts";
+        None
+  in
   adapter_loop_with_transport
     ~send_plain:(fun ~content ->
       send_message ~clock ?thread_ts ~token ~channel ~content ())
     ~send_blocks:(fun ~content ~blocks ->
       send_message_with_blocks ~clock ?thread_ts ~token ~channel ~content ~blocks ())
-    ~events ?base_url ?on_send_result ()
+    ~events ?set_activity_status ?base_url ?on_send_result ()
 
 module For_testing = struct
   let escape_mrkdwn_text = escape_mrkdwn_text
@@ -415,10 +469,10 @@ module For_testing = struct
   let link_block_json = link_block_json
   let image_block_json = image_block_json
   let audio_block_json = audio_block_json
-  let tool_context_block_json = tool_context_block_json
   let content_blocks_of_text = content_blocks_of_text
   let final_message_blocks = final_message_blocks
   let build_message_body = build_message_body
+  let build_thread_status_body = build_thread_status_body
 
   let adapter_loop = adapter_loop_with_transport
 end

--- a/lib/keeper/keeper_chat_slack.mli
+++ b/lib/keeper/keeper_chat_slack.mli
@@ -2,7 +2,9 @@
 
     Subscribes to a [Keeper_chat_events] stream, accumulates assistant
     text deltas and rich Block Kit blocks, and sends the final reply to
-    a Slack channel via the Web API when the run finishes.
+    a Slack channel via the Web API when the run finishes. When the reply
+    belongs to a thread, the production adapter projects active work through
+    Slack's native assistant thread status.
 
     @since 2.145.0 *)
 
@@ -71,11 +73,12 @@ val adapter_loop :
     blocks on the event stream until [Run_finished] or [Error], then sends
     the accumulated text (or error message) to the given Slack channel.
 
-    Rich events ([Link_block], [Image_block], [Status_block], [Audio_block],
-    [Tool_context_block]) are rendered as Slack Block Kit sections and
-    included alongside the final message. [Tool_call_start],
+    Rich events ([Link_block], [Image_block], [Status_block], [Audio_block])
+    are rendered as Slack Block Kit sections and included alongside the final
+    message. [Tool_call_start],
     [Tool_call_args], [Tool_call_args_snapshot], and [Tool_call_end] are
-    ignored for live streaming.
+    projected only as native activity; [Tool_context_block] is not exposed in
+    the conversation.
 
     [base_url] is used to build public voice-audio URLs; when omitted the
     configured {!Env_config_core.masc_http_base_url} is used.
@@ -107,9 +110,6 @@ module For_testing : sig
   val audio_block_json :
     base_url:string option -> token:string -> message_text:string -> Yojson.Safe.t
 
-  val tool_context_block_json :
-    name:string -> args_summary:string -> result_summary:string option -> Yojson.Safe.t
-
   val content_blocks_of_text : string -> Yojson.Safe.t list
   (** Same as {!content_blocks_of_text}; exposed for unit testing. *)
 
@@ -128,14 +128,20 @@ module For_testing : sig
   (** Pure chat.postMessage JSON builder used to prove deferred replies retain
       the originating Slack thread. *)
 
+  val build_thread_status_body :
+    channel:string -> thread_ts:string -> status:string -> string
+  (** Pure [assistant.threads.setStatus] JSON builder. *)
+
   val adapter_loop :
     events:Keeper_chat_events.keeper_chat_event Eio.Stream.t ->
     send_plain:(content:string -> (unit, error) result) ->
     send_blocks:(content:string -> blocks:Yojson.Safe.t list -> (unit, error) result) ->
+    ?set_activity_status:(status:string -> (unit, error) result) ->
     ?base_url:string ->
     ?on_send_result:((unit, error) result -> unit) ->
     unit ->
     unit
   (** Test seam for the outbound transport. It runs the production terminal
-      settlement state machine with injected Slack sends. *)
+      settlement state machine with injected Slack sends and native activity
+      status updates. Activity failures never settle terminal delivery. *)
 end

--- a/test/test_keeper_chat_discord.ml
+++ b/test/test_keeper_chat_discord.ml
@@ -5,7 +5,7 @@ module D = Masc.Keeper_chat_discord.For_testing
 let contains haystack needle =
   String_util.contains_substring haystack needle
 
-let run_adapter events ~post_message ~edit_message ~send_message =
+let run_adapter ?show_activity events ~post_message ~edit_message ~send_message =
   Eio_main.run
   @@ fun _env ->
   let stream = Masc.Keeper_chat_events.create () in
@@ -13,6 +13,7 @@ let run_adapter events ~post_message ~edit_message ~send_message =
   let outcomes = ref [] in
   D.adapter_loop ~token:"test-token" ~channel_id:"test-channel"
     ~events:stream ~post_message ~edit_message ~send_message
+    ?show_activity
     ~on_send_result:(fun result -> outcomes := result :: !outcomes) ();
   List.rev !outcomes
 
@@ -306,6 +307,42 @@ let test_external_effect_status_replaces_assistant_preface () =
     [ "승인 대기: 외부 작업을 실행하기 전에 확인이 필요합니다." ]
     (List.rev !edits)
 
+let test_tool_activity_uses_native_surface_without_messages () =
+  let activity_refreshes = ref 0 in
+  let final_sends = ref [] in
+  let outcomes =
+    run_adapter
+      ~show_activity:(fun () ->
+        incr activity_refreshes;
+        Error (Discord_rest_client.Network "typing unavailable"))
+      [ Masc.Keeper_chat_events.Run_started
+          { run_id = "run-tool"; thread_id = "thread-tool" }
+      ; Masc.Keeper_chat_events.Tool_call_start
+          { tool_call_id = "call-1"; tool_call_name = "keeper_surface_read" }
+      ; Masc.Keeper_chat_events.Tool_context_block
+          { tool_call_id = "call-1"
+          ; name = "keeper_surface_read"
+          ; args_summary = "surface=discord"
+          ; result_summary = Some "private tool result"
+          }
+      ; Masc.Keeper_chat_events.Tool_call_end { tool_call_id = "call-1" }
+      ; Masc.Keeper_chat_events.Text_delta "done"
+      ; Masc.Keeper_chat_events.Run_finished { run_id = "run-tool" }
+      ]
+      ~post_message:(fun ~content:_ ->
+        fail "tool activity and one-word final reply must not stream POST")
+      ~edit_message:(fun ~message_id:_ ~content:_ ->
+        fail "tool activity must not create a message to edit")
+      ~send_message:(fun ~content ->
+        final_sends := content :: !final_sends;
+        Ok ())
+  in
+  check int "run start and tool start refresh native activity" 2
+    !activity_refreshes;
+  check (list string) "only the final reply is sent" [ "done" ]
+    (List.rev !final_sends);
+  check_single_ok "activity failure does not affect delivery" outcomes
+
 let () =
   run "keeper_chat_discord"
     [ ( "streaming-redaction"
@@ -335,6 +372,8 @@ let () =
             test_error_reply_callback_once
         ; test_case "typed status replaces assistant preface" `Quick
             test_external_effect_status_replaces_assistant_preface
+        ; test_case "tool activity uses native surface" `Quick
+            test_tool_activity_uses_native_surface_without_messages
         ] )
     ; ( "rich-blocks"
       , [ test_case "audio URL uses base URL" `Quick

--- a/test/test_keeper_chat_slack.ml
+++ b/test/test_keeper_chat_slack.ml
@@ -84,28 +84,6 @@ let test_audio_block_escapes_message_text () =
   check bool "raw mention removed" false (contains s "<@U123>");
   check bool "message escaped" true (contains s "&lt;@U123&gt; &amp; done")
 
-let test_tool_context_block_renders_tool () =
-  let json =
-    S.tool_context_block_json ~name:"read_file" ~args_summary:"path: foo.txt"
-      ~result_summary:(Some "contents")
-  in
-  let s = json_string json in
-  check bool "type section" true (contains s "\"type\":\"section\"");
-  check bool "tool name" true (contains s "*Tool:* read_file");
-  check bool "args" true (contains s "args: path: foo.txt");
-  check bool "result" true (contains s "result: contents")
-
-let test_tool_context_block_escapes_summaries () =
-  let json =
-    S.tool_context_block_json ~name:"<tool>" ~args_summary:"<@U123> & args"
-      ~result_summary:(Some "result > ok")
-  in
-  let s = json_string json in
-  check bool "raw mention removed" false (contains s "<@U123>");
-  check bool "name escaped" true (contains s "&lt;tool&gt;");
-  check bool "args escaped" true (contains s "&lt;@U123&gt; &amp; args");
-  check bool "result escaped" true (contains s "result &gt; ok")
-
 let test_truncate_to_limit_keeps_utf8_boundary () =
   let s = String.concat "" (List.init 10 (fun _ -> "가")) in
   let truncated = S.truncate_to_limit s 4 in
@@ -210,12 +188,13 @@ let test_final_message_blocks_merges_text_and_event_blocks () =
   check bool "event block preserved" true
     (contains second "https://event.example.com")
 
-let run_adapter events ~send_plain ~send_blocks =
+let run_adapter ?set_activity_status events ~send_plain ~send_blocks =
   Eio_main.run @@ fun _env ->
   let stream = Masc.Keeper_chat_events.create () in
   List.iter (Masc.Keeper_chat_events.publish stream) events;
   let outcomes = ref [] in
   S.adapter_loop ~events:stream ~send_plain ~send_blocks
+    ?set_activity_status
     ~on_send_result:(fun result -> outcomes := result :: !outcomes)
     ();
   List.rev !outcomes
@@ -340,6 +319,57 @@ let test_message_body_preserves_reply_thread () =
   check string "reply thread retained" "1710000000.123456"
     (body |> member "thread_ts" |> to_string)
 
+let test_thread_status_body_uses_assistant_contract () =
+  let body =
+    S.build_thread_status_body ~channel:"C-status"
+      ~thread_ts:"1710000000.654321" ~status:"답변을 준비하고 있어요…"
+    |> Yojson.Safe.from_string
+  in
+  let open Yojson.Safe.Util in
+  check string "channel_id" "C-status"
+    (body |> member "channel_id" |> to_string);
+  check string "thread_ts" "1710000000.654321"
+    (body |> member "thread_ts" |> to_string);
+  check string "status" "답변을 준비하고 있어요…"
+    (body |> member "status" |> to_string)
+
+let test_native_activity_failure_does_not_affect_delivery () =
+  let statuses = ref [] in
+  let sends = ref [] in
+  let outcomes =
+    run_adapter
+      ~set_activity_status:(fun ~status ->
+        statuses := status :: !statuses;
+        Error (Masc.Keeper_chat_slack.Slack_api { error = "missing_scope" }))
+      [ Masc.Keeper_chat_events.Run_started
+          { run_id = "run-activity"; thread_id = "thread-activity" }
+      ; Masc.Keeper_chat_events.Tool_call_start
+          { tool_call_id = "call-activity"
+          ; tool_call_name = "keeper_surface_post"
+          }
+      ; Masc.Keeper_chat_events.Tool_context_block
+          { tool_call_id = "call-activity"
+          ; name = "keeper_surface_post"
+          ; args_summary = "private args"
+          ; result_summary = Some "private result"
+          }
+      ; Masc.Keeper_chat_events.Tool_call_end
+          { tool_call_id = "call-activity" }
+      ; Masc.Keeper_chat_events.Text_delta "final"
+      ; Masc.Keeper_chat_events.Run_finished { run_id = "run-activity" }
+      ]
+      ~send_plain:(fun ~content:_ -> fail "final reply uses blocks sender")
+      ~send_blocks:(fun ~content ~blocks:_ ->
+        sends := content :: !sends;
+        Ok ())
+  in
+  check (list string) "typed activity lifecycle"
+    [ "답변을 준비하고 있어요…"; "필요한 작업을 진행하고 있어요…"; "" ]
+    (List.rev !statuses);
+  check (list string) "tool context is not exposed" [ "final" ]
+    (List.rev !sends);
+  check bool "delivery still succeeds" true (outcomes = [ Ok () ])
+
 let () =
   run "keeper_chat_slack"
     [
@@ -359,10 +389,6 @@ let () =
             test_audio_block_renders_voice_link
         ; test_case "audio block escapes message text" `Quick
             test_audio_block_escapes_message_text
-        ; test_case "tool context block renders tool" `Quick
-            test_tool_context_block_renders_tool
-        ; test_case "tool context block escapes summaries" `Quick
-            test_tool_context_block_escapes_summaries
         ; test_case "truncate keeps utf8 boundary" `Quick
             test_truncate_to_limit_keeps_utf8_boundary
         ; test_case "block limit adds visible omission notice" `Quick
@@ -399,9 +425,13 @@ let () =
             test_completed_external_effect_settles_without_duplicate_send
         ; test_case "typed external-effect status settles successfully" `Quick
             test_adapter_external_effect_status_is_terminal_success
+        ; test_case "native activity failure is isolated" `Quick
+            test_native_activity_failure_does_not_affect_delivery
         ] )
     ; ( "thread-routing"
       , [ test_case "deferred reply keeps thread_ts" `Quick
             test_message_body_preserves_reply_thread
+        ; test_case "assistant status body uses thread contract" `Quick
+            test_thread_status_body_uses_assistant_contract
         ] )
     ]


### PR DESCRIPTION
## What changed

- Remove per-tool Discord `Running` / `Done` embeds and tool detail messages.
- Keep Discord activity on the native typing indicator, refreshed every 8 seconds while the typed run is active.
- Project Slack activity through `assistant.threads.setStatus` for threaded replies.
- Stop exposing tool names, arguments, and results in Slack conversation blocks.
- Treat activity transport failures as observable warnings without changing the final delivery receipt.

## Why

Connector adapters were projecting internal `Tool_call_*` events as user-visible chat messages. A normal `keeper_surface_read` followed by `keeper_surface_post` therefore looked like several bot replies even though it was one Keeper turn.

The Keeper tool surface is optional: no required or named tool choice is configured for this path, and the existing Keeper hook explicitly relaxes strict choices to `Auto`. This change does not alter tool selection, execution, scheduling, prompts, or terminal-effect semantics; it only changes connector projection.

## User impact

- Discord: native typing during work, then one final answer; no `surface_read` / `surface_post` cards.
- Slack: one native thread status during work, then the final answer; no tool context block.
- Unsupported or failed activity APIs never block or falsify the final reply outcome.

## Validation

- `scripts/dune-local.sh build test/test_keeper_chat_discord.exe test/test_keeper_chat_slack.exe test/test_keeper_chat_consumer_delivery.exe`
- `_build/default/test/test_keeper_chat_discord.exe` — 19/19 passed
- `_build/default/test/test_keeper_chat_slack.exe` — 28/28 passed
- `_build/default/test/test_keeper_chat_consumer_delivery.exe` — all checks passed
- `ocamlformat --check` on all six changed OCaml files
- `git diff --check`
