### PR TITLE
fix(keeper): 드레인 로그 레벨을 outcome에서 파생한다 — main Meta Guards 복구 (#26981)

### DIFF
--- a/lib/keeper/keeper_board_attention_worker.ml
+++ b/lib/keeper/keeper_board_attention_worker.ml
@@ -359,6 +359,23 @@ let drain_outcome_label = function
     "retry_generation_changed"
 ;;
 
+(* Severity for the drain verdict line, chosen from the outcome rather than the
+   call site (docs/spec/18-log-severity-taxonomy.md).
+
+   [Drained] is the expected lifecycle success this worker exists to produce, so
+   it is [Info]. Both [Retry_later] reasons are ordinary concurrency outcomes —
+   the claim is held elsewhere, or the partition moved — and the re-arm applied
+   alongside the log is what represents them, so the line is [Debug] diagnostic
+   detail on an already represented event.
+
+   Neither is [Warn]: the taxonomy reserves that for a requested operation that
+   returned an explicit failure, and warning on every contention would bury the
+   real ones. *)
+let drain_outcome_log_level : drain_outcome -> Log.level = function
+  | Drained -> Log.Info
+  | Retry_later _ -> Log.Debug
+;;
+
 let apply_drain_rearm scheduler = function
   | Drained ->
     reset_contention_rearms scheduler ~keep:None;
@@ -1805,7 +1822,11 @@ let run
                  ~execute
              with
              | Ok outcome ->
-               Log.Keeper.info
+               (match drain_outcome_log_level outcome with
+                | Log.Debug -> Log.Keeper.debug
+                | Log.Info -> Log.Keeper.info
+                | Log.Warn -> Log.Keeper.warn
+                | Log.Error -> Log.Keeper.error)
                  "board_attention_worker_drain keeper=%s outcome=%s"
                  keeper_name
                  (drain_outcome_label outcome);
@@ -1836,6 +1857,7 @@ module For_testing = struct
   let schedule_contention_rearm = schedule_contention_rearm
   let reset_contention_rearms = reset_contention_rearms
   let drain_outcome_label = drain_outcome_label
+  let drain_outcome_log_level = drain_outcome_log_level
   let apply_drain_rearm = apply_drain_rearm
   let replay_completed_owner_wake = replay_completed_owner_wake
   let with_process_recovery_claim = with_process_recovery_claim

--- a/lib/keeper/keeper_board_attention_worker.mli
+++ b/lib/keeper/keeper_board_attention_worker.mli
@@ -99,6 +99,13 @@ module For_testing : sig
       so a worker stuck on a moved generation is distinguishable from one
       losing a claim race. *)
 
+  val drain_outcome_log_level : drain_outcome -> Log.level
+  (** Severity the drain verdict line is emitted at, derived from the outcome
+      rather than fixed at the call site
+      (docs/spec/18-log-severity-taxonomy.md). Exposed so the mapping is
+      asserted directly: the line itself sits inside the worker's fiber loop,
+      where a test cannot observe which logger ran. *)
+
   val process_next_exact
     :  clock:_ Eio.Time.clock
     -> net:Eio_context.eio_net option

--- a/test/test_keeper_board_attention_worker.ml
+++ b/test/test_keeper_board_attention_worker.ml
@@ -2076,6 +2076,38 @@ let test_cross_domain_wake_is_coalesced_and_rearmed () =
    two of them back into one string would restore the state the measurement on
    2026-08-05 found: pending 425 -> 1031 with zero contention lines and zero
    worker failures, and no way to tell which of the three was happening. *)
+(* The drain verdict line takes its severity from the outcome, not from the call
+   site (docs/spec/18-log-severity-taxonomy.md; enforced by the L6 gate in
+   scripts/ci/check-log-severity-anti-patterns.sh at baseline 0). The log call
+   sits inside the worker's fiber loop where a test cannot observe which logger
+   ran, so the mapping is asserted here directly. *)
+let test_drain_outcome_selects_its_log_level () =
+  let contention =
+    { W.keeper_name = "k"
+    ; partition_id = "p"
+    ; generation = P.Generation.initial
+    }
+  in
+  let level = W.For_testing.drain_outcome_log_level in
+  Alcotest.(check bool)
+    "a completed drain is expected lifecycle success"
+    true
+    (level W.Drained = Log.Info);
+  (* Both retries are ordinary concurrency outcomes: the re-arm represents the
+     event, so the line is diagnostic detail on it. Warn is reserved for a
+     requested operation that returned an explicit failure. *)
+  Alcotest.(check bool)
+    "a contended claim is diagnostic detail, not a warning"
+    true
+    (level (W.Retry_later { contention; reason = W.Exact_claim_contended })
+     = Log.Debug);
+  Alcotest.(check bool)
+    "a moved generation is diagnostic detail, not a warning"
+    true
+    (level (W.Retry_later { contention; reason = W.Selected_generation_changed })
+     = Log.Debug)
+;;
+
 let test_drain_outcome_labels_stay_distinct () =
   let contention =
     { W.keeper_name = "k"
@@ -2229,6 +2261,10 @@ let () =
             "drain outcome labels stay distinct"
             `Quick
             test_drain_outcome_labels_stay_distinct
+        ; Alcotest.test_case
+            "drain outcome selects its log level"
+            `Quick
+            test_drain_outcome_selects_its_log_level
         ] )
     ]
 ;;


### PR DESCRIPTION
## 무엇

main 의 `Meta Guards` 를 복구한다. `#26974` 가 넣은 드레인 판정 로그가 L6 게이트를 위반하고 있다.

Closes #26981.

```
FAIL  L6 (outcome-carrying line + static info): 1 > baseline=0
      lib/keeper/keeper_board_attention_worker.ml:1808:Log.Keeper.info
```

main 의 `Meta Guards` 는 `450e25e69`(= #26974) 부터 연속 failure 다. 그 이전은 통과했다.

## 규칙

`scripts/ci/check-log-severity-anti-patterns.sh` §L6, baseline **0** (strict):

> An outcome-carrying line must derive its level from the outcome value, not hardcode `[Info]`.

주석에 따르면 2026-06-03 에 알려진 3개 사이트를 같은 PR 에서 고치고 baseline 을 0 으로 잠갔다 — 새 static-Info outcome 라인은 무조건 실패한다.

## 심각도 선택

추측하지 않고 `docs/spec/18-log-severity-taxonomy.md` 의 표를 그대로 적용했다.

| outcome | 레벨 | taxonomy 근거 |
|---|---|---|
| `Drained` | `Info` | "Expected lifecycle ... success" — 이 worker 가 존재하는 이유 |
| `Retry_later { Exact_claim_contended }` | `Debug` | "Optional diagnostic detail for an otherwise represented event" |
| `Retry_later { Selected_generation_changed }` | `Debug` | 위와 같음 |

`Retry_later` 를 `Warn` 으로 두지 않은 이유: taxonomy 의 `Warn` 은 "the requested local operation returned an **explicit failure**" 인데, 두 reason 은 실패가 아니라 평범한 동시성 결과다 — claim 을 다른 흐름이 쥐고 있거나 파티션이 이동했을 뿐이고, 같은 파일 :353 주석도 그렇게 설명한다. 그리고 contention 마다 경고를 내면 진짜 경고가 묻힌다.

`Retry_later` 를 `Debug` 로 둘 수 있는 근거는 바로 아래 `apply_drain_rearm` 이 재예약을 수행한다는 것이다 — 사건 자체는 이미 표현되고, 이 로그는 거기 붙는 진단 정보다.

> 세 arm 이 전부 `Info` 를 반환하는 match 로 게이트만 통과시키는 방식은 쓰지 않았다. 그건 lint 를 통과시키려고 모양만 갖춘 것이라 CLAUDE.md 의 워크어라운드 거부 기준에 걸린다.

## 영향

게이트는 `lib/` 전체를 스캔하므로 **main 위로 rebase 한 모든 PR 이 이 실패를 물려받는다.** 확인된 것: #26978 — 대시보드 TypeScript 2 파일만 건드리는 PR 인데 이 OCaml 로그 규칙으로 red 였다.

## 로컬 검증

```
check-log-severity-anti-patterns.sh    EXIT=0   (L6: 0)
dune build --root . @all               EXIT=0
ocamlformat --check (변경 파일)          OK

check-determinism-contract             EXIT=0
check-silent-failure-patterns          EXIT=0
check-enum-string-safety               EXIT=0
check-actor-consumer-wired             EXIT=0
check-ssot-spawn-drift                 EXIT=0
check-pr-hygiene                       EXIT=0
```

**통제 실험**: 같은 워크트리에서 이 변경만 stash 하면 게이트가 동일한 L6 라인으로 exit 1, 되돌리면 exit 0.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
