### PR TITLE
fix(dashboard): make Keeper lane live and restore compaction snapshots

### DIFF
--- a/dashboard/src/api/dashboard-tools-prompts.ts
+++ b/dashboard/src/api/dashboard-tools-prompts.ts
@@ -415,6 +415,29 @@ export interface DashboardKeeperWaitingInventory {
   global_waiting_on?: DashboardKeeperWaitingRow[]
 }
 
+function normalizeKeeperWaitingRow(row: DashboardKeeperWaitingRow): DashboardKeeperWaitingRow {
+  const source = parseDashboardKeeperWaitingSource(row.source)
+  if (!source) {
+    throw new Error(`Unknown keeper waiting inventory source: ${JSON.stringify(row.source)}`)
+  }
+  return { ...row, source }
+}
+
+export function normalizeKeeperWaitingInventory(
+  inventory: DashboardKeeperWaitingInventory,
+): DashboardKeeperWaitingInventory {
+  return {
+    ...inventory,
+    keepers: inventory.keepers.map(keeper => ({
+      ...keeper,
+      waiting_on: keeper.waiting_on.map(normalizeKeeperWaitingRow),
+    })),
+    ...(inventory.global_waiting_on
+      ? { global_waiting_on: inventory.global_waiting_on.map(normalizeKeeperWaitingRow) }
+      : {}),
+  }
+}
+
 // Keeper autonomous background (server_keeper_background.dashboard_json). Surfaces
 // per-keeper recurring tasks with the owning keeper's loop liveness as context.
 // Deferred async work (bg-shell / fusion / hitl) is NOT here — it is reused from
@@ -752,6 +775,7 @@ export function normalizeFullHealthResponse(
 }
 
 export async function fetchDashboardTools(opts?: AbortableRequestOptions): Promise<DashboardToolsResponse> {
+  await ensureDevToken()
   const raw = await get<DashboardToolsResponse>('/api/v1/dashboard/tools', { signal: opts?.signal })
   const normalizeScheduledAutomation = (
     rawAutomation: DashboardScheduledAutomation,
@@ -821,24 +845,8 @@ export async function fetchDashboardTools(opts?: AbortableRequestOptions): Promi
     // filter simply degrades to zero counts. Mirrors category/tier above.
     surfaces: t.surfaces ?? [],
   }))
-  const normalizeWaitingRow = (row: DashboardKeeperWaitingRow): DashboardKeeperWaitingRow => {
-    const source = parseDashboardKeeperWaitingSource(row.source)
-    if (!source) {
-      throw new Error(`Unknown keeper waiting inventory source: ${JSON.stringify(row.source)}`)
-    }
-    return { ...row, source }
-  }
   const normalizedWaitingInventory = raw.keeper_waiting_inventory
-    ? {
-        ...raw.keeper_waiting_inventory,
-        keepers: raw.keeper_waiting_inventory.keepers.map(keeper => ({
-          ...keeper,
-          waiting_on: keeper.waiting_on.map(normalizeWaitingRow),
-        })),
-        ...(raw.keeper_waiting_inventory.global_waiting_on
-          ? { global_waiting_on: raw.keeper_waiting_inventory.global_waiting_on.map(normalizeWaitingRow) }
-          : {}),
-      }
+    ? normalizeKeeperWaitingInventory(raw.keeper_waiting_inventory)
     : undefined
   const normalizedScheduledAutomation = raw.scheduled_automation
     ? normalizeScheduledAutomation(raw.scheduled_automation)
@@ -856,6 +864,18 @@ export async function fetchDashboardTools(opts?: AbortableRequestOptions): Promi
       ? { scheduled_automation: normalizedScheduledAutomation }
       : {}),
   }
+}
+
+export async function fetchKeeperWaitingInventory(
+  keeperName: string,
+  opts?: AbortableRequestOptions,
+): Promise<DashboardKeeperWaitingInventory> {
+  await ensureDevToken()
+  const raw = await get<DashboardKeeperWaitingInventory>(
+    `/api/v1/keepers/${encodeURIComponent(keeperName)}/waiting-inventory`,
+    { signal: opts?.signal },
+  )
+  return normalizeKeeperWaitingInventory(raw)
 }
 
 // --- Prompts (override management) ---

--- a/dashboard/src/api/dashboard-turn-records.test.ts
+++ b/dashboard/src/api/dashboard-turn-records.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const getMock = vi.hoisted(() => vi.fn())
+const ensureDevToken = vi.hoisted(() => vi.fn(async () => undefined))
 
 vi.mock('./core', () => ({
   get: getMock,
 }))
+vi.mock('./dev-token', () => ({ ensureDevToken }))
 
 import { fetchKeeperTurnRecords } from './dashboard-turn-records'
 

--- a/dashboard/src/api/dashboard-turn-records.ts
+++ b/dashboard/src/api/dashboard-turn-records.ts
@@ -3,6 +3,7 @@
 // from dashboard.ts so existing consumers (`from './api/dashboard'`) are unchanged.
 
 import { get, type AbortableRequestOptions } from './core'
+import { ensureDevToken } from './dev-token'
 import { isRecord, asBoolean, asNumber, asNullableString, asString, asRecordArray } from '../components/common/normalize'
 import { type TelemetryFreshnessMetadata } from './dashboard-shared'
 
@@ -1136,12 +1137,13 @@ function limitQueryString(limit?: number): string {
   return query ? `?${query}` : ''
 }
 
-export function fetchKeeperTurnRecords(
+export async function fetchKeeperTurnRecords(
   name: string,
   limit?: number,
   opts?: AbortableRequestOptions,
 ): Promise<TurnRecordsResponse> {
   const params = limitQueryString(limit)
+  await ensureDevToken()
   return get<Record<string, unknown>>(
     `/api/v1/keepers/${encodeURIComponent(name)}/turn-records${params}`,
     { signal: opts?.signal },
@@ -1152,12 +1154,13 @@ export function fetchKeeperTurnRecords(
   })
 }
 
-export function fetchKeeperCompactionSnapshots(
+export async function fetchKeeperCompactionSnapshots(
   name: string,
   limit?: number,
   opts?: AbortableRequestOptions,
 ): Promise<KeeperCompactionSnapshotsResponse> {
   const params = limitQueryString(limit)
+  await ensureDevToken()
   return get<Record<string, unknown>>(
     `/api/v1/keepers/${encodeURIComponent(name)}/compaction-snapshots${params}`,
     { signal: opts?.signal },

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -18,6 +18,7 @@ import {
   fetchDashboardGoalsTree,
   fetchDashboardBriefing,
   fetchDashboardTools,
+  fetchKeeperWaitingInventory,
   parseDashboardKeeperWaitingSource,
   fetchDashboardFullHealth,
   fetchKeeperToolCalls,
@@ -1014,6 +1015,38 @@ describe('fetchDashboardTools', () => {
     expect(parseDashboardKeeperWaitingSource(null)).toBeNull()
   })
 
+  it('reads the keeper-scoped waiting inventory after auth bootstrap', async () => {
+    const rawResponse = {
+      keeper_count: 1,
+      waiting_keeper_count: 1,
+      row_count: 1,
+      keepers: [{
+        keeper_name: 'kidsnote',
+        state: 'waiting',
+        waiting_count: 1,
+        waiting_on: [{
+          keeper_name: 'kidsnote',
+          source: 'event_queue_pending',
+          waiting_on: 'schedule_due',
+          next_action: 'keeper_consume_event',
+        }],
+      }],
+    }
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(rawResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchKeeperWaitingInventory('kidsnote')
+
+    expect(devTokenMock.ensureDevToken).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/keepers/kidsnote/waiting-inventory')
+    expect(result.keepers[0]?.waiting_on[0]?.source).toBe('event_queue_pending')
+  })
+
   it('fills missing category and tier with defaults', async () => {
     const rawResponse = {
       tool_inventory: {
@@ -1036,6 +1069,10 @@ describe('fetchDashboardTools', () => {
 
     const result = await fetchDashboardTools()
 
+    expect(devTokenMock.ensureDevToken).toHaveBeenCalledTimes(1)
+    expect(devTokenMock.ensureDevToken.mock.invocationCallOrder[0]).toBeLessThan(
+      fetchMock.mock.invocationCallOrder[0]!,
+    )
     const tools = result.tool_inventory.tools
     expect(tools[0]).toMatchObject({ name: 'tool_a', category: 'uncategorized', tier: '(unknown tier)' })
     expect(tools[1]).toMatchObject({ name: 'tool_b', category: 'keeper', tier: '(unknown tier)' })

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -254,6 +254,7 @@ export {
   fetchDashboardRuntimeProbe,
   fetchDashboardFullHealth,
   fetchDashboardTools,
+  fetchKeeperWaitingInventory,
   fetchDashboardPrompts,
   savePromptOverride,
   clearPromptOverride,

--- a/dashboard/src/api/dev-token.test.ts
+++ b/dashboard/src/api/dev-token.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   devTokenBootstrapStatus,
   ensureDevToken,
@@ -55,6 +55,57 @@ describe('ensureDevToken', () => {
     getStoredTokenMeta.mockReturnValue(null)
     currentDashboardActor.mockReturnValue('dashboard')
     isRemoteAccess.mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('waits through the exact server warm-up payload and continues bootstrap', async () => {
+    vi.useFakeTimers()
+    fetchWithTimeout
+      .mockResolvedValueOnce(jsonResponse({
+        status: 'initializing',
+        message: 'Server is warming up',
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        token: 'ready-dev-token',
+        actor: 'dashboard',
+        role: 'worker',
+      }))
+
+    const bootstrap = ensureDevToken()
+    await vi.advanceTimersByTimeAsync(1_000)
+    await bootstrap
+
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(2)
+    expect(setStoredToken).toHaveBeenCalledWith('ready-dev-token', {
+      source: 'dev',
+      actor: 'dashboard',
+      role: 'worker',
+    })
+    expect(devTokenBootstrapStatus.value).toBe('ok')
+  })
+
+  it('does not overwrite a manual token entered while the server is warming', async () => {
+    vi.useFakeTimers()
+    let token: string | null = null
+    let meta: { source: 'manual' } | null = null
+    getStoredToken.mockImplementation(() => token)
+    getStoredTokenMeta.mockImplementation(() => meta)
+    fetchWithTimeout
+      .mockResolvedValueOnce(jsonResponse({ status: 'initializing' }))
+
+    const bootstrap = ensureDevToken()
+    await Promise.resolve()
+    token = 'operator-token'
+    meta = { source: 'manual' }
+    await vi.advanceTimersByTimeAsync(1_000)
+    await bootstrap
+
+    expect(setStoredToken).not.toHaveBeenCalled()
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(1)
+    expect(token).toBe('operator-token')
   })
 
   it('retries after a transient network bootstrap failure in the same page load', async () => {

--- a/dashboard/src/api/dev-token.ts
+++ b/dashboard/src/api/dev-token.ts
@@ -11,6 +11,7 @@ import {
 } from './core'
 
 const DEV_TOKEN_FETCH_TIMEOUT_MS = 3000
+const DEV_TOKEN_WARMUP_RETRY_MS = 1_000
 
 let devTokenBootstrapPromise: Promise<void> | null = null
 let devTokenRefreshPromise: Promise<boolean> | null = null
@@ -20,6 +21,7 @@ let devTokenRefreshPromise: Promise<boolean> | null = null
  * distinguish "auth required but no token" from "network error" etc.
  *   idle       — not yet attempted
  *   fetching   — in-flight
+ *   warming    — server accepted HTTP but has not installed runtime state yet
  *   ok         — token stored
  *   no_endpoint — /dev-token returned 404 (loopback disabled or strict auth)
  *   invalid_response — endpoint response violated the exact token contract
@@ -28,6 +30,7 @@ let devTokenRefreshPromise: Promise<boolean> | null = null
 export type DevTokenBootstrapStatus =
   | 'idle'
   | 'fetching'
+  | 'warming'
   | 'ok'
   | 'no_endpoint'
   | 'invalid_response'
@@ -40,6 +43,11 @@ interface DevTokenBootstrapPayload {
   token?: unknown
   actor?: unknown
   role?: unknown
+  status?: unknown
+}
+
+function waitForWarmupRetry(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, DEV_TOKEN_WARMUP_RETRY_MS))
 }
 
 const REFRESHABLE_AUTH_CODES: ReadonlySet<DashboardAuthErrorCode> = new Set([
@@ -85,45 +93,57 @@ export async function ensureDevToken(): Promise<void> {
   if (devTokenBootstrapPromise) return devTokenBootstrapPromise
   devTokenBootstrapPromise = (async () => {
     const storedMeta = getStoredTokenMeta()
-    const storedToken = getStoredToken()
     ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'fetching'
-    try {
-      const res = await fetchWithTimeout(
-        '/api/v1/dashboard/dev-token',
-        { method: 'GET', headers: { Accept: 'application/json' } },
-        DEV_TOKEN_FETCH_TIMEOUT_MS,
-      )
-      if (!res.ok) {
-        if (res.status === 404 && storedMeta?.source === 'dev') {
-          clearStoredToken()
+    while (true) {
+      if (getStoredTokenMeta()?.source === 'manual' && getStoredToken()) return
+      try {
+        const res = await fetchWithTimeout(
+          '/api/v1/dashboard/dev-token',
+          { method: 'GET', headers: { Accept: 'application/json' } },
+          DEV_TOKEN_FETCH_TIMEOUT_MS,
+        )
+        if (!res.ok) {
+          if (res.status === 404 && storedMeta?.source === 'dev') {
+            clearStoredToken()
+          }
+          ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'no_endpoint'
+          if (isRetryableDevTokenStatus(res.status)) {
+            devTokenBootstrapPromise = null
+          }
+          return
         }
-        ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'no_endpoint'
-        if (isRetryableDevTokenStatus(res.status)) {
+        const payload = (await res.json()) as DevTokenBootstrapPayload
+        if (payload.status === 'initializing') {
+          ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'warming'
+          await waitForWarmupRetry()
+          continue
+        }
+        const token = typeof payload.token === 'string' ? payload.token.trim() : ''
+        if (!token || payload.actor !== 'dashboard' || payload.role !== 'worker') {
+          ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'invalid_response'
           devTokenBootstrapPromise = null
+          return
         }
+        const currentMeta = getStoredTokenMeta()
+        const currentToken = getStoredToken()
+        if (currentMeta?.source === 'manual') return
+        if (
+          token !== currentToken
+          || currentMeta?.source !== 'dev'
+        ) {
+          setStoredToken(token, {
+            source: 'dev',
+            actor: 'dashboard',
+            role: 'worker',
+          })
+        }
+        ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'ok'
         return
-      }
-      const payload = (await res.json()) as DevTokenBootstrapPayload
-      const token = typeof payload.token === 'string' ? payload.token.trim() : ''
-      if (!token || payload.actor !== 'dashboard' || payload.role !== 'worker') {
-        ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'invalid_response'
+      } catch {
+        ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'network'
         devTokenBootstrapPromise = null
         return
       }
-      if (
-        token !== storedToken
-        || storedMeta?.source !== 'dev'
-      ) {
-        setStoredToken(token, {
-          source: 'dev',
-          actor: 'dashboard',
-          role: 'worker',
-        })
-      }
-      ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'ok'
-    } catch {
-      ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'network'
-      devTokenBootstrapPromise = null
     }
   })()
   return devTokenBootstrapPromise

--- a/dashboard/src/components/auth-status.ts
+++ b/dashboard/src/components/auth-status.ts
@@ -79,6 +79,12 @@ function authBadgeSummary(): {
       label: 'Auth error',
     }
   }
+  if (!hasToken && bootstrap === 'warming') {
+    return {
+      dotColor: 'bg-[var(--color-status-warn)]',
+      label: 'Server warming up',
+    }
+  }
   // No token and bootstrap failed — show actionable prompt
   if (
     !hasToken

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -347,7 +347,7 @@ function disconnectionReasonLabel(): string {
   if (!hasToken && bootstrap === 'network') {
     return 'dashboard · server unreachable'
   }
-  if (!hasToken && bootstrap === 'fetching') {
+  if (!hasToken && (bootstrap === 'fetching' || bootstrap === 'warming')) {
     return 'dashboard · bootstrapping...'
   }
   if (!hasToken) {

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -994,7 +994,40 @@ describe('KeeperConversationPanel', () => {
     })
   })
 
+  it('does not open Admin-only queue controls for the loopback Worker session', async () => {
+    shellAuthSummary.value = { effective_role: 'worker', default_role: 'worker' } as typeof shellAuthSummary.value
+    mockedToolsData.value = {
+      keeper_waiting_inventory: {
+        keepers: [{
+          keeper_name: 'sangsu',
+          state: 'waiting',
+          waiting_count: 1,
+          sources: { chat_queue_pending: 1 },
+          waiting_on: [],
+        }],
+      },
+    }
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="Say something" layout="primary" />`,
+      container,
+    )
+
+    const button = await waitFor(() => {
+      const node = container.querySelector('[data-open-keeper-queue-control]') as HTMLButtonElement | null
+      expect(node?.disabled).toBe(true)
+      expect(node?.textContent).toContain('Admin 권한 필요')
+      return node!
+    })
+    fireEvent.click(button)
+
+    expect(container.querySelector('[data-keeper-queue-control-panel]')).toBeNull()
+    expect(fetchKeeperChatPending).not.toHaveBeenCalled()
+    expect(fetchKeeperEventQueuePending).not.toHaveBeenCalled()
+  })
+
   it('opens an operator drawer with exact durable chat and event queue evidence', async () => {
+    shellAuthSummary.value = { effective_role: 'admin', default_role: 'admin' } as typeof shellAuthSummary.value
     const receiptId = 'chatq_00000000-0000-4000-8000-000000000022'
     fetchKeeperChatPending.mockResolvedValue({
       keeperName: 'sangsu',
@@ -1082,6 +1115,7 @@ describe('KeeperConversationPanel', () => {
   })
 
   it('shows exact inflight and recovery evidence and resolves recovery with a fresh receipt fence', async () => {
+    shellAuthSummary.value = { effective_role: 'admin', default_role: 'admin' } as typeof shellAuthSummary.value
     const inflightReceiptId = 'chatq_00000000-0000-4000-8000-000000000031'
     const recoveryReceiptId = 'chatq_00000000-0000-4000-8000-000000000032'
     fetchKeeperChatPending.mockResolvedValue({
@@ -1251,6 +1285,7 @@ describe('KeeperConversationPanel', () => {
   })
 
   it('replays an ambiguous event mutation with the exact preserved operation identity', async () => {
+    shellAuthSummary.value = { effective_role: 'admin', default_role: 'admin' } as typeof shellAuthSummary.value
     fetchKeeperChatPending.mockResolvedValue({
       keeperName: 'sangsu',
       revision: '22',

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -3,6 +3,7 @@ import { AgentFailure, failureTypeFromDiagnostic } from './common/agent-failure'
 import { Markdown } from "./common/markdown"
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { keeperDirectChatAccess } from '../lib/keeper-chat-access'
+import { dashboardAuthAccess } from '../lib/dashboard-auth-access'
 import { isInFlightDelivery } from '../lib/keeper-delivery'
 import { formatTimeAgo, relativeTime, NO_TIME_INFO } from '../lib/format-time'
 import { isAbortError } from '../lib/async-state'
@@ -637,6 +638,8 @@ function ServerQueueStatus({
   currentExecution,
   readErrorAction,
   onInspect,
+  inspectAllowed,
+  inspectReason,
 }: {
   busy: boolean
   pendingCount: number
@@ -650,6 +653,8 @@ function ServerQueueStatus({
   currentExecution?: DashboardKeeperWaitingKeeper['current_execution']
   readErrorAction?: string | null
   onInspect: () => void
+  inspectAllowed: boolean
+  inspectReason: string | null
 }) {
   const projectionUnavailable = Boolean(projectionError) || !projectionReady || !projectionPresent
   if (
@@ -682,9 +687,11 @@ function ServerQueueStatus({
         <button
           type="button"
           class="font-semibold text-[var(--color-accent-fg)] underline decoration-dotted underline-offset-2"
+          disabled=${!inspectAllowed}
+          title=${inspectAllowed ? '서버 대기열 상세 및 제어' : inspectReason ?? 'Admin 권한이 필요합니다.'}
           onClick=${onInspect}
           data-open-keeper-queue-control
-        >Keeper 서버 대기열 상세/제어</button>
+        >${inspectAllowed ? 'Keeper 서버 대기열 상세/제어' : '대기열 상세/제어 · Admin 권한 필요'}</button>
         ${inflightCount > 0
           ? html`<span class="rounded-[var(--r-0)] border border-[var(--info-20)] bg-[var(--info-10)] px-2 py-0.5" data-server-chat-queue-state="inflight">처리 중 ${inflightCount}</span>`
           : null}
@@ -1259,11 +1266,8 @@ export function KeeperConversationPanel({
   const bumpQueue = () => setQueueVersion(v => v + 1)
   const isDrainingRef = useRef(false)
 
-  // Keep the shared keeper waiting inventory live on surfaces that do NOT
-  // render KeeperLaneSection (which is what normally polls it every 15 s).
-  // Mirror the lane strip's visibility-aware auto-refresh: pause while the tab
-  // is hidden, refresh immediately on focus/return, and return the cleanup so
-  // the busy chip / interrupt button cannot freeze on a stale snapshot.
+  // Keep the shared tools projection live for the conversation's busy chip and
+  // interrupt button. The right-side Lane has its own keeper-scoped read path.
   useEffect(() => {
     const unsubscribeToolsRefresh = subscribeToolsAutoRefresh()
     void reconcileKeeperChatReceipts(keeperName)
@@ -1376,6 +1380,7 @@ export function KeeperConversationPanel({
     if (newestEntryTsUnix !== null) advanceKeeperLastSeen(keeperName, newestEntryTsUnix)
   }
   const chatAccess = keeperDirectChatAccess(shellAuthSummary.value)
+  const queueControlAccess = dashboardAuthAccess(shellAuthSummary.value, 'admin')
   // Stable action object so the memoized ChatMessageBubble's shallow prop
   // compare can skip unchanged messages — an inline `{ ...onClick }` literal
   // would be a new reference each render and defeat the memo.
@@ -1607,9 +1612,11 @@ export function KeeperConversationPanel({
         ? inventoryEntry?.source_next_actions?.read_error?.[0] ?? inventoryEntry?.next_action
         : null}
       onInspect=${() => setQueueControlOpen(true)}
+      inspectAllowed=${queueControlAccess.allowed}
+      inspectReason=${queueControlAccess.reason}
     />
   `
-  const queueControlPanel = queueControlOpen
+  const queueControlPanel = queueControlOpen && queueControlAccess.allowed
     ? html`
         <${KeeperQueueControlPanel}
           keeperName=${keeperName}

--- a/dashboard/src/components/keeper-workspace/keeper-lane-section.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-lane-section.test.ts
@@ -1,0 +1,75 @@
+import { html } from 'htm/preact'
+import { cleanup, render, screen, waitFor } from '@testing-library/preact'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { DashboardKeeperWaitingInventory } from '../../api'
+
+const mocks = vi.hoisted(() => ({
+  fetchKeeperWaitingInventory: vi.fn(),
+  refresh: null as ((keeperName: string) => void) | null,
+  stopPolling: vi.fn(),
+  unregisterPush: vi.fn(),
+}))
+
+vi.mock('../../api', () => ({
+  fetchKeeperWaitingInventory: mocks.fetchKeeperWaitingInventory,
+}))
+vi.mock('../tools/tool-state', () => ({
+  KEEPER_WAITING_INVENTORY_REFRESH_MS: 15_000,
+}))
+vi.mock('../../lib/auto-refresh', () => ({
+  setupVisibleAutoRefresh: vi.fn(() => mocks.stopPolling),
+}))
+vi.mock('../../sse-store', () => ({
+  registerKeeperWaitingInventoryRefresh: vi.fn((refresh: (keeperName: string) => void) => {
+    mocks.refresh = refresh
+    return mocks.unregisterPush
+  }),
+}))
+vi.mock('../../dashboard-ws-state', () => ({
+  dashboardWsReady: { value: true },
+}))
+
+import { KeeperLaneSection } from './keeper-lane-strip'
+
+function inventory(): DashboardKeeperWaitingInventory {
+  return {
+    generated_at: '2026-08-05T08:00:00Z',
+    keeper_count: 1,
+    waiting_keeper_count: 1,
+    row_count: 1,
+    keepers: [{
+      keeper_name: 'kidsnote',
+      state: 'waiting',
+      waiting_count: 1,
+      waiting_on: [{
+        keeper_name: 'kidsnote',
+        source: 'event_queue_pending',
+        waiting_on: 'schedule_due',
+        next_action: 'keeper_consume_event',
+      }],
+    }],
+  }
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  mocks.refresh = null
+})
+
+describe('KeeperLaneSection', () => {
+  it('re-reads only the visible keeper when its WS invalidation arrives', async () => {
+    mocks.fetchKeeperWaitingInventory.mockResolvedValue(inventory())
+    render(html`<${KeeperLaneSection} keeper=${{ name: 'kidsnote', agent_name: 'agent-kidsnote' }} />`)
+
+    await waitFor(() => expect(screen.getByText('처리 대기 중')).toBeTruthy())
+    expect(mocks.fetchKeeperWaitingInventory).toHaveBeenCalledTimes(1)
+
+    mocks.refresh?.('rondo')
+    expect(mocks.fetchKeeperWaitingInventory).toHaveBeenCalledTimes(1)
+
+    mocks.refresh?.('kidsnote')
+    await waitFor(() => expect(mocks.fetchKeeperWaitingInventory).toHaveBeenCalledTimes(2))
+  })
+})

--- a/dashboard/src/components/keeper-workspace/keeper-lane-strip.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-lane-strip.test.ts
@@ -139,8 +139,8 @@ describe('KeeperLaneStrip', () => {
       />
     `)
     const text = el.textContent ?? ''
-    expect(text).toContain('레인')
-    expect(text).toContain('deferred')
+    expect(text).toContain('작업 대기열')
+    expect(text).toContain('외부 완료 대기 중')
     expect(text).toContain('dashboard_chat')
     expect(text).toContain('chat_lane')
     expect(text).toContain('keeper finish in flight turn')
@@ -160,7 +160,7 @@ describe('KeeperLaneStrip', () => {
     const text = el.textContent ?? ''
     expect(text).toContain('≥69')
     // the bare integer would assert a total the server never computed
-    expect(text).not.toMatch(/레인\s*69(?!\d)/)
+    expect(text).not.toMatch(/작업 대기열\s*69(?!\d)/)
     expect(el.querySelectorAll('[data-testid="keeper-lane-waiting-row"]').length).toBe(69)
   })
 
@@ -175,7 +175,7 @@ describe('KeeperLaneStrip', () => {
       />
     `)
     const note = el.querySelector('[data-testid="keeper-lane-truncation"]')?.textContent ?? ''
-    expect(note).toContain('external attention')
+    expect(note).toContain('외부 알림')
     expect(note).toContain('64')
     expect(note).toContain('실제 대기 건수는 더 많습니다')
   })
@@ -191,10 +191,10 @@ describe('KeeperLaneStrip', () => {
       />
     `)
     const sources = el.querySelector('[data-testid="keeper-lane-sources"]')?.textContent ?? ''
-    expect(sources).toContain('external attention ≥64')
+    expect(sources).toContain('외부 알림 ≥64')
     // chat_queue_pending was not capped, so it is an exact count
-    expect(sources).toContain('chat queue pending 5')
-    expect(sources).not.toContain('chat queue pending ≥5')
+    expect(sources).toContain('채팅 대기 5')
+    expect(sources).not.toContain('채팅 대기 ≥5')
   })
 
   it('renders an exact count and no truncation note when nothing was capped', () => {
@@ -220,11 +220,12 @@ describe('KeeperLaneStrip', () => {
         loading=${false}
         error=${null}
         autoRefreshMs=${15_000}
+        pushReady=${true}
       />
     `)
     const text = el.textContent ?? ''
-    expect(text).toContain('최근 서버 샘플')
-    expect(text).toContain('15초마다 재조회 · 숨김 탭에서는 중지')
+    expect(text).toContain('서버 기준')
+    expect(text).toContain('WS 즉시 반영 · 15초마다 상태 검산')
   })
 
   it('omits the auto-refresh label when the panel is not polling', () => {
@@ -238,6 +239,22 @@ describe('KeeperLaneStrip', () => {
       />
     `)
     expect(el.textContent ?? '').not.toContain('재조회')
+  })
+
+  it('shows polling as fallback instead of claiming live push while WS is unavailable', () => {
+    const el = mount(html`
+      <${KeeperLaneStrip}
+        keeper=${keeperFixture()}
+        inventory=${inventoryFixture()}
+        ready=${true}
+        loading=${false}
+        error=${null}
+        autoRefreshMs=${15_000}
+        pushReady=${false}
+      />
+    `)
+    expect(el.textContent ?? '').toContain('WS 연결 대기 · 15초마다 재조회')
+    expect(el.textContent ?? '').not.toContain('WS 즉시 반영')
   })
 
   it('renders an explicit gap when the keeper is absent from the inventory', () => {

--- a/dashboard/src/components/keeper-workspace/keeper-lane-strip.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-lane-strip.ts
@@ -1,10 +1,10 @@
 // Keeper Workspace — lane state section (#23507 PR-L1/L2, slice 1).
-// Consume-only surface over the already-served `keeper_waiting_inventory`
-// (`GET /api/v1/dashboard/tools`, same shared resource the Tools/Schedule
-// surfaces read): per-keeper lane state (idle/busy/waiting/deferred) plus
-// the waiting rows behind it. State strings and rows render exactly as the
-// server sent them — no client-side judgement — and a keeper absent from
-// the inventory renders an explicit data gap instead of a guessed "idle".
+// Consume-only surface over the keeper-scoped `keeper_waiting_inventory`
+// read model: per-keeper lane state (idle/busy/waiting/deferred) plus
+// the waiting rows behind it. The UI gives the closed server vocabulary clear
+// operator labels while preserving raw values in titles/details; a keeper
+// absent from the inventory renders an explicit data gap instead of a guessed
+// "idle".
 //
 // Counts are the one place that rule cuts the other way. `waiting_count` and
 // `sources` are both folds over a list the server already capped
@@ -15,7 +15,7 @@
 // as such.
 
 import { html } from 'htm/preact'
-import { useEffect } from 'preact/hooks'
+import { useEffect, useState } from 'preact/hooks'
 import type { VNode } from 'preact'
 import type { Keeper } from '../../types'
 import type {
@@ -23,13 +23,8 @@ import type {
   DashboardKeeperWaitingKeeper,
   DashboardKeeperWaitingRow,
 } from '../../api'
-import {
-  KEEPER_WAITING_INVENTORY_REFRESH_MS,
-  subscribeToolsAutoRefresh,
-  toolsData,
-  toolsError,
-  toolsLoading,
-} from '../tools/tool-state'
+import { fetchKeeperWaitingInventory } from '../../api'
+import { KEEPER_WAITING_INVENTORY_REFRESH_MS } from '../tools/tool-state'
 import { StatusChip } from '../common/status-chip'
 import {
   enumLabel,
@@ -38,19 +33,51 @@ import {
 } from '../tools/keeper-waiting-inventory-panel'
 import { formatDateTimeKo } from '../../lib/format-time'
 import { CountBadge } from '../v2/primitives-v2'
+import { dashboardWsReady } from '../../dashboard-ws-state'
+import { setupVisibleAutoRefresh } from '../../lib/auto-refresh'
+import { isAbortError } from '../../lib/async-state'
+import { registerKeeperWaitingInventoryRefresh } from '../../sse-store'
 
-// The strip mirrors a heavy server-side aggregation (per-keeper event-queue,
-// turn-admission, external-attention, HITL, schedule scans). It is refreshed
-// by polling — not server push — while the keeper detail is open, so a busy
-// fleet does not pay that aggregation on every event. 15s is tighter than the
-// 30s shared panel default because this is the live "what is this keeper
-// waiting on right now" surface; setupVisibleAutoRefresh still pauses when the
-// tab is hidden and refreshes immediately on focus/return.
+// Queue commits push a signal-only invalidation over WS. The 15s timer is a
+// missed-event verifier and focus-recovery path, not the primary update path.
 const LANE_REFRESH_MS = KEEPER_WAITING_INVENTORY_REFRESH_MS
 
-function formatLaneRefreshLabel(intervalMs: number): string {
+function formatLaneRefreshLabel(intervalMs: number, pushReady: boolean): string {
   const seconds = Math.max(1, Math.round(intervalMs / 1000))
-  return `${seconds}초마다 재조회 · 숨김 탭에서는 중지`
+  return pushReady
+    ? `WS 즉시 반영 · ${seconds}초마다 상태 검산`
+    : `WS 연결 대기 · ${seconds}초마다 재조회`
+}
+
+const LANE_STATE_LABELS: Record<string, string> = {
+  idle: '대기열 비어 있음',
+  busy: '현재 작업 처리 중',
+  waiting: '처리 대기 중',
+  deferred: '외부 완료 대기 중',
+}
+
+const LANE_SOURCE_LABELS: Record<string, string> = {
+  event_queue_pending: '자율 이벤트',
+  chat_queue_pending: '채팅 대기',
+  chat_queue_inflight: '채팅 처리 중',
+  chat_queue_recovery_required: '채팅 복구 필요',
+  chat_queue_persistence_blocked: '채팅 저장 복구 필요',
+  hitl_pending: '승인 대기',
+  external_attention: '외부 알림',
+  fusion_running: 'Fusion 실행 중',
+  schedule_waiting: '예약 실행',
+  turn_admission_waiting: '실행 슬롯 대기',
+  turn_admission_shutdown: '종료 정리',
+  operator_pending_confirm: '운영자 확인',
+  read_error: '읽기 오류',
+}
+
+function laneStateLabel(value: string): string {
+  return LANE_STATE_LABELS[value] ?? enumLabel(value)
+}
+
+function laneSourceLabel(value: string): string {
+  return LANE_SOURCE_LABELS[value] ?? enumLabel(value)
 }
 
 function inventoryEntry(
@@ -84,30 +111,38 @@ function boundedCount(value: number, truncated: boolean): string {
 
 /** Per-source counts, each marked with the server's own per-source truncation
  *  verdict. Sorted by count so the source driving the lane reads first. */
-function sourceBreakdown(entry: DashboardKeeperWaitingKeeper): string[] {
+function sourceBreakdown(entry: DashboardKeeperWaitingKeeper): Array<{
+  source: string
+  label: string
+  count: string
+}> {
   const truncated = entry.truncated_sources ?? {}
   return Object.entries(entry.sources ?? {})
     .sort(([, a], [, b]) => b - a)
-    .map(([source, count]) => `${enumLabel(source)} ${boundedCount(count, truncated[source] === true)}`)
+    .map(([source, count]) => ({
+      source,
+      label: laneSourceLabel(source),
+      count: boundedCount(count, truncated[source] === true),
+    }))
 }
 
 /** Sources the server reported as capped, for the attribution line. */
 function truncatedSourceLabels(entry: DashboardKeeperWaitingKeeper): string[] {
   return Object.entries(entry.truncated_sources ?? {})
     .filter(([, isTruncated]) => isTruncated)
-    .map(([source]) => enumLabel(source))
+    .map(([source]) => laneSourceLabel(source))
 }
 
 function LaneWaitingRow({ row }: { row: DashboardKeeperWaitingRow }): VNode {
   return html`
     <div data-testid="keeper-lane-waiting-row" class="grid gap-0.5 border-t border-[var(--color-border-subtle)] py-1.5 first:border-t-0">
       <div class="flex min-w-0 flex-wrap items-center gap-1.5">
-        <${StatusChip} tone=${sourceTone(row.source)} uppercase=${false}>${enumLabel(row.source)}<//>
+        <${StatusChip} tone=${sourceTone(row.source)} uppercase=${false} title=${row.source}>${laneSourceLabel(row.source)}<//>
         <span class="min-w-0 truncate font-mono text-2xs text-[var(--color-fg-primary)]">${row.waiting_on}</span>
       </div>
       <div class="flex flex-wrap gap-x-3 text-2xs text-[var(--color-fg-muted)]">
         ${row.since_iso ? html`<span>since ${formatDateTimeKo(row.since_iso)}</span>` : null}
-        <span class="font-mono">${enumLabel(row.next_action)}</span>
+        <span>다음 동작 · <span class="font-mono">${enumLabel(row.next_action)}</span></span>
       </div>
     </div>
   `
@@ -122,6 +157,7 @@ export function KeeperLaneStrip({
   loading,
   error,
   autoRefreshMs,
+  pushReady = false,
 }: {
   keeper: Keeper
   inventory: DashboardKeeperWaitingInventory | null | undefined
@@ -133,6 +169,8 @@ export function KeeperLaneStrip({
   /** when set, the container polls at this cadence — shown next to the
    *  snapshot time so the operator knows the panel refreshes on its own. */
   autoRefreshMs?: number
+  /** Whether the authenticated dashboard WS handshake completed. */
+  pushReady?: boolean
 }): VNode {
   const entry = inventoryEntry(inventory, keeper)
   const rows = entry?.waiting_on ?? []
@@ -144,7 +182,7 @@ export function KeeperLaneStrip({
   return html`
     <div class="ctx-sec" data-testid="keeper-lane-section">
       <h4 style=${{ display: 'flex', alignItems: 'center', gap: '7px' }}>
-        레인
+        작업 대기열
         ${waitingCount > 0
           ? html`<${CountBadge}>${boundedCount(waitingCount, countTruncated)}<//>`
           : null}
@@ -153,12 +191,7 @@ export function KeeperLaneStrip({
         ? html`
             <div class="grid gap-1.5">
               <div class="flex flex-wrap items-center gap-1.5">
-                <${StatusChip} tone=${stateTone(entry.state)} uppercase=${false}>${enumLabel(entry.state)}<//>
-                ${Object.keys(entry.source_next_actions ?? {}).length > 0
-                  ? html`<span class="font-mono text-2xs text-[var(--color-fg-muted)]">source별 next action</span>`
-                  : entry.next_action
-                    ? html`<span class="font-mono text-2xs text-[var(--color-fg-muted)]">${enumLabel(entry.next_action)}</span>`
-                    : null}
+                <${StatusChip} tone=${stateTone(entry.state)} uppercase=${false} title=${entry.state}>${laneStateLabel(entry.state)}<//>
               </div>
               ${rows.length > 0
                 ? html`
@@ -169,20 +202,29 @@ export function KeeperLaneStrip({
                     </div>
                   `
                 : null}
+              ${rows.length === 0
+                ? html`<div class="text-2xs text-[var(--color-fg-muted)]">${entry.state === 'busy' ? '새 작업은 현재 턴 뒤에 처리됩니다.' : '지금 기다리는 작업이 없습니다.'}</div>`
+                : null}
               ${countTruncated
                 ? html`<div class="text-2xs text-[var(--color-fg-muted)]" data-testid="keeper-lane-truncation">
                     서버 상한${rowLimit != null ? ` ${rowLimit}` : ''}에서 잘림${truncatedSources.length > 0 ? ` — ${truncatedSources.join(', ')}` : ''}. 실제 대기 건수는 더 많습니다.
                   </div>`
                 : null}
               ${breakdown.length > 0
-                ? html`<div class="font-mono text-2xs text-[var(--color-fg-muted)]" data-testid="keeper-lane-sources">
-                    ${breakdown.join(' · ')}
+                ? html`<div class="flex flex-wrap gap-1" data-testid="keeper-lane-sources">
+                    ${breakdown.map(item => html`
+                      <span
+                        key=${item.source}
+                        class="rounded-[var(--r-0)] bg-[var(--color-bg-hover)] px-2 py-0.5 text-2xs text-[var(--color-fg-secondary)]"
+                        title=${item.source}
+                      >${item.label} <span class="font-mono text-[var(--color-fg-primary)]">${item.count}</span></span>
+                    `)}
                   </div>`
                 : null}
               ${inventory?.generated_at
-                ? html`<div class="text-2xs text-[var(--color-fg-muted)]">최근 서버 샘플 ${formatDateTimeKo(inventory.generated_at)}${autoRefreshMs ? html` · ${formatLaneRefreshLabel(autoRefreshMs)}` : null}</div>`
+                ? html`<div class="text-2xs text-[var(--color-fg-muted)]">서버 기준 ${formatDateTimeKo(inventory.generated_at)}${autoRefreshMs ? html` · ${formatLaneRefreshLabel(autoRefreshMs, pushReady)}` : null}</div>`
                 : autoRefreshMs
-                  ? html`<div class="text-2xs text-[var(--color-fg-muted)]">${formatLaneRefreshLabel(autoRefreshMs)}</div>`
+                  ? html`<div class="text-2xs text-[var(--color-fg-muted)]">${formatLaneRefreshLabel(autoRefreshMs, pushReady)}</div>`
                   : null}
             </div>
           `
@@ -191,29 +233,96 @@ export function KeeperLaneStrip({
           : ready
             ? html`<${LaneGap}>서버가 keeper_waiting_inventory를 보내지 않았습니다.<//>`
             : error
-              ? html`<${LaneGap}>${`tools 응답 실패: ${error}`}<//>`
+              ? html`<${LaneGap}>${`대기열 응답 실패: ${error}`}<//>`
               : html`<div class="text-2xs text-[var(--color-fg-muted)]">${loading ? '레인 상태 로딩…' : '레인 상태 로딩 대기…'}</div>`}
     </div>
   `
 }
 
-/** Container: reads the shared tools resource, loads it once if absent, and
- *  keeps it live while mounted by polling on a visibility-aware interval
- *  (paused when the tab is hidden, refreshed immediately on focus/return).
- *  The shared resource is stale-while-revalidate, so each refetch swaps the
- *  inventory in place without flashing a loading gap. */
+type LaneInventoryState = {
+  keeperName: string
+  inventory: DashboardKeeperWaitingInventory | null
+  ready: boolean
+  loading: boolean
+  error: string | null
+}
+
+/** Read only this keeper's lane projection. WS queue mutations trigger the
+ *  primary refresh; the visibility-aware timer only verifies missed events. */
 export function KeeperLaneSection({ keeper }: { keeper: Keeper }): VNode {
+  const [state, setState] = useState<LaneInventoryState>({
+    keeperName: keeper.name,
+    inventory: null,
+    ready: false,
+    loading: true,
+    error: null,
+  })
+
   useEffect(() => {
-    return subscribeToolsAutoRefresh()
-  }, [])
+    let active = true
+    let controller: AbortController | null = null
+    const load = () => {
+      controller?.abort()
+      const requestController = new AbortController()
+      controller = requestController
+      setState(previous => ({
+        keeperName: keeper.name,
+        inventory: previous.keeperName === keeper.name ? previous.inventory : null,
+        ready: previous.keeperName === keeper.name && previous.ready,
+        loading: true,
+        error: null,
+      }))
+      void fetchKeeperWaitingInventory(keeper.name, { signal: requestController.signal })
+        .then(inventory => {
+          if (!active || requestController.signal.aborted) return
+          setState({
+            keeperName: keeper.name,
+            inventory,
+            ready: true,
+            loading: false,
+            error: null,
+          })
+        })
+        .catch((error: unknown) => {
+          if (!active || isAbortError(error)) return
+          setState(previous => ({
+            keeperName: keeper.name,
+            inventory: previous.keeperName === keeper.name ? previous.inventory : null,
+            ready: previous.keeperName === keeper.name && previous.ready,
+            loading: false,
+            error: error instanceof Error ? error.message : String(error),
+          }))
+        })
+    }
+    load()
+    const unregisterPush = registerKeeperWaitingInventoryRefresh(changedKeeper => {
+      if (changedKeeper === keeper.name) load()
+    })
+    const stopPolling = setupVisibleAutoRefresh(load, LANE_REFRESH_MS)
+    return () => {
+      active = false
+      controller?.abort()
+      unregisterPush()
+      stopPolling()
+    }
+  }, [keeper.name])
+
+  const current = state.keeperName === keeper.name ? state : {
+    keeperName: keeper.name,
+    inventory: null,
+    ready: false,
+    loading: true,
+    error: null,
+  }
   return html`
     <${KeeperLaneStrip}
       keeper=${keeper}
-      inventory=${toolsData.value?.keeper_waiting_inventory ?? null}
-      ready=${toolsData.value != null}
-      loading=${toolsLoading.value}
-      error=${toolsError.value}
+      inventory=${current.inventory}
+      ready=${current.ready}
+      loading=${current.loading}
+      error=${current.error}
       autoRefreshMs=${LANE_REFRESH_MS}
+      pushReady=${dashboardWsReady.value}
     />
   `
 }

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -44,10 +44,7 @@ import type { MemoryKeeper } from '../memory-inspector'
 import { keepers } from '../../store'
 import { KeeperLaneSection } from './keeper-lane-strip'
 import { openTaskDetail } from '../goals/task-detail-state'
-
-const LazyCompactionInspectorOverlay = lazy(async () => ({
-  default: (await import('./compaction-inspector-overlay')).CompactionInspectorOverlay,
-}))
+import { CompactionInspectorOverlay } from './compaction-inspector-overlay'
 
 const LazyMemoryInspector = lazy(async () => ({
   default: (await import('../memory-inspector')).MemoryInspector,
@@ -598,11 +595,7 @@ export function KeeperWorkspaceRail({
     </aside>
 
     ${overlay === 'compaction'
-      ? html`
-          <${Suspense} fallback=${html`<div class="turn-overlay" role="dialog" aria-modal="true">컴팩션 스냅샷 로딩…</div>`}>
-            <${LazyCompactionInspectorOverlay} keeper=${keeper} onClose=${() => setOverlay(null)} />
-          <//>
-        `
+      ? html`<${CompactionInspectorOverlay} keeper=${keeper} onClose=${() => setOverlay(null)} />`
       : null}
     ${overlay === 'memory'
       ? html`

--- a/dashboard/src/components/tools/tool-state-refresh.test.ts
+++ b/dashboard/src/components/tools/tool-state-refresh.test.ts
@@ -13,7 +13,6 @@ setupVisibleAutoRefresh.mockReturnValue(stopRefresh)
 
 vi.mock('../../api', () => ({ fetchDashboardTools }))
 vi.mock('../../lib/auto-refresh', () => ({ setupVisibleAutoRefresh }))
-vi.mock('../../sse-store', () => ({ registerKeeperChatQueueRefresh: vi.fn() }))
 
 import { subscribeToolsAutoRefresh } from './tool-state'
 

--- a/dashboard/src/components/tools/tool-state.ts
+++ b/dashboard/src/components/tools/tool-state.ts
@@ -5,11 +5,9 @@ import { signal, computed } from '@preact/signals'
 import { fetchDashboardTools, type DashboardToolsResponse, type DashboardToolInventoryItem } from '../../api'
 import { createManagedAsyncResource } from '../../lib/async-state'
 import { setupVisibleAutoRefresh } from '../../lib/auto-refresh'
-import { registerKeeperChatQueueRefresh } from '../../sse-store'
 
 // Managed (stale-while-revalidate): the previously loaded response stays
-// readable while a refetch is in flight. Panel-level polling — the keeper
-// lane strip re-fetches this shared resource on an interval — therefore
+// readable while a refetch is in flight. Panel-level polling therefore
 // keeps showing the last inventory instead of flashing a loading gap every
 // cycle. A plain createAsyncResource would blank the data on each load.
 const toolsResource = createManagedAsyncResource<DashboardToolsResponse>()
@@ -49,8 +47,8 @@ export const KEEPER_WAITING_INVENTORY_REFRESH_MS = 15_000
 let toolsRefreshSubscriberCount = 0
 let stopToolsRefresh: (() => void) | null = null
 
-/** Share one visibility-aware tools poller across every mounted Keeper lane
- * and conversation surface. The managed resource deduplicates fetch state;
+/** Share one visibility-aware tools poller across mounted tools, schedule,
+ * and Keeper conversation surfaces. The managed resource deduplicates fetch state;
  * this subscription also deduplicates the timer and global visibility/focus
  * listeners that trigger it. */
 export function subscribeToolsAutoRefresh(): () => void {
@@ -69,10 +67,6 @@ export function subscribeToolsAutoRefresh(): () => void {
     }
   }
 }
-
-registerKeeperChatQueueRefresh(() => {
-  void loadTools()
-})
 
 export function hasSurface(item: DashboardToolInventoryItem, surface: string): boolean {
   return (item.surfaces ?? []).includes(surface)

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -2,9 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { callMcpTool } = vi.hoisted(() => ({ callMcpTool: vi.fn() }))
 const { runOperatorAction } = vi.hoisted(() => ({ runOperatorAction: vi.fn() }))
-const { invalidateDashboardCache, refreshDashboard } = vi.hoisted(() => ({
+const { invalidateDashboardCache, refreshDashboard, shellAuthSummary } = vi.hoisted(() => ({
   invalidateDashboardCache: vi.fn(),
   refreshDashboard: vi.fn(async () => undefined),
+  shellAuthSummary: { value: { effective_role: 'admin', default_role: 'admin' } },
 }))
 const {
   cancelKeeperChatPendingReceipt,
@@ -68,7 +69,7 @@ vi.mock('./api/keeper', () => ({
   streamKeeperMessage,
 }))
 vi.mock('./api/dashboard', () => ({ fetchKeeperToolCalls }))
-vi.mock('./store', () => ({ invalidateDashboardCache, refreshDashboard }))
+vi.mock('./store', () => ({ invalidateDashboardCache, refreshDashboard, shellAuthSummary }))
 
 import {
   _resetLiveSendRequestOwnersForTests,
@@ -128,6 +129,7 @@ import type { ToolCallEntry } from './api/dashboard'
 import type { ChatBlock, KeeperConversationAttachment, KeeperStatusDetail } from './types'
 
 beforeEach(() => {
+  shellAuthSummary.value = { effective_role: 'admin', default_role: 'admin' }
   fetchKeeperChatPending.mockReset()
   fetchKeeperChatPending.mockImplementation(async (keeperName: string) => ({
     keeperName,
@@ -255,6 +257,14 @@ describe('reconcileKeeperChatReceipts', () => {
     fetchKeeperChatReceipt.mockReset()
     cancelKeeperChatPendingReceipt.mockReset()
     resolveKeeperChatRecovery.mockReset()
+  })
+
+  it('does not call the Admin-only receipt endpoint for a Worker session', async () => {
+    shellAuthSummary.value = { effective_role: 'worker', default_role: 'worker' }
+
+    await reconcileKeeperChatReceipts('echo')
+
+    expect(fetchKeeperChatPending).not.toHaveBeenCalled()
   })
 
   it('restores pending payload and controls source from the durable queue after reload', async () => {

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -26,8 +26,9 @@ import {
 } from './tool-call-output-store'
 import { asString, isRecord } from './components/common/normalize'
 import { keeperTurnOutcomeSuppressesReply } from './keeper-message'
-import { invalidateDashboardCache, refreshDashboard } from './store'
+import { invalidateDashboardCache, refreshDashboard, shellAuthSummary } from './store'
 import { isAbortError } from './lib/async-state'
+import { dashboardAuthAccess } from './lib/dashboard-auth-access'
 import { compareKeeperQueueRevisions } from './lib/keeper-chat-receipt'
 import type {
   ChatBlock,
@@ -835,6 +836,7 @@ async function handoffCancelledStreamToRequestPoll(
 export async function reconcileKeeperChatReceipts(name: string): Promise<void> {
   const keeperName = name.trim()
   if (!keeperName) return
+  if (!dashboardAuthAccess(shellAuthSummary.value, 'admin').allowed) return
   const generation = (keeperReceiptReconciliationGeneration.get(keeperName) ?? 0) + 1
   keeperReceiptReconciliationGeneration.set(keeperName, generation)
   const failures: string[] = []

--- a/dashboard/src/schemas/sse.test.ts
+++ b/dashboard/src/schemas/sse.test.ts
@@ -231,27 +231,21 @@ describe('SSEMessageSchema', () => {
     expect(r.success).toBe(false)
   })
 
-  it('accepts a typed Keeper chat-queue projection invalidation', () => {
+  it('accepts a typed Keeper waiting-inventory invalidation', () => {
     const r = SSEMessageSchema.safeParse({
-      type: 'keeper_chat_queue_changed',
+      type: 'keeper_waiting_inventory_changed',
       keeper_name: 'keeper-1',
-      revision: 7,
+      queue_kind: 'chat_queue',
       ts_unix: 1_712_000_000,
     })
     expect(r.success).toBe(true)
   })
 
   it.each([
-    { type: 'keeper_chat_queue_changed', revision: 7 },
-    { type: 'keeper_chat_queue_changed', keeper_name: 'keeper-1' },
-    { type: 'keeper_chat_queue_changed', keeper_name: 'keeper-1', revision: -1 },
-    { type: 'keeper_chat_queue_changed', keeper_name: 'keeper-1', revision: 1.5 },
-    {
-      type: 'keeper_chat_queue_changed',
-      keeper_name: 'keeper-1',
-      revision: Number.MAX_SAFE_INTEGER + 1,
-    },
-  ])('rejects an incomplete Keeper chat-queue invalidation: %o', value => {
+    { type: 'keeper_waiting_inventory_changed', queue_kind: 'chat_queue' },
+    { type: 'keeper_waiting_inventory_changed', keeper_name: 'keeper-1' },
+    { type: 'keeper_waiting_inventory_changed', keeper_name: 'keeper-1', queue_kind: 'unknown' },
+  ])('rejects an incomplete Keeper waiting-inventory invalidation: %o', value => {
     expect(SSEMessageSchema.safeParse(value).success).toBe(false)
   })
 

--- a/dashboard/src/schemas/sse.ts
+++ b/dashboard/src/schemas/sse.ts
@@ -58,7 +58,7 @@ const FIXED_SSE_EVENT_TYPES = new Set([
   'keeper_phase_changed',
   'keeper_composite_changed',
   'keeper_chat_appended',
-  'keeper_chat_queue_changed',
+  'keeper_waiting_inventory_changed',
   'ide_cursor_changed',
   'keeper_tool_call',
   'masc/keeper_tool_call',
@@ -340,12 +340,12 @@ export const SSEMessageSchema = schema<SSEMessage>((value) => {
     return fail('audio', 'Expected audio clip object')
   }
 
-  if (value.type === 'keeper_chat_queue_changed') {
+  if (value.type === 'keeper_waiting_inventory_changed') {
     if (typeof value.keeper_name !== 'string' || value.keeper_name.trim() === '') {
       return fail('keeper_name', 'Expected non-empty keeper_name')
     }
-    if (!Number.isSafeInteger(value.revision) || (value.revision as number) < 0) {
-      return fail('revision', 'Expected exact non-negative integer revision')
+    if (value.queue_kind !== 'chat_queue' && value.queue_kind !== 'event_queue') {
+      return fail('queue_kind', 'Expected chat_queue or event_queue queue_kind')
     }
   }
 

--- a/dashboard/src/sse-event-type-parity.test.ts
+++ b/dashboard/src/sse-event-type-parity.test.ts
@@ -38,7 +38,7 @@ const BACKEND_EMITTED: Record<string, string> = {
   execution_snapshot: '../lib/server/server_dashboard_http_execution_surfaces.ml',
   runtime_param_changed: '../lib/server/server_routes_http_routes_activity.ml',
   keeper_chat_appended: '../lib/keeper/keeper_chat_broadcast.ml',
-  keeper_chat_queue_changed: '../lib/keeper/keeper_chat_broadcast.ml',
+  keeper_waiting_inventory_changed: '../lib/keeper/keeper_waiting_inventory_broadcast.ml',
   ide_cursor_changed: '../lib/server/server_ide_http.ml',
   keeper_composite_changed: '../lib/server/server_mcp_transport_ws.ml',
   keeper_heartbeat: '../lib/keeper/keeper_heartbeat_snapshot.ml',

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -549,27 +549,46 @@ describe('setupServerPushReaction reconnect hydration', () => {
     expect(noteKeeperChatAppended).toHaveBeenCalledWith('echo', undefined, undefined)
   })
 
-  it('invalidates the authoritative Keeper chat-queue projection once per burst', async () => {
+  it('invalidates the authoritative Keeper waiting inventory once per burst', async () => {
     const { sseStore } = await loadSseStore()
     const refreshQueue = vi.fn()
-    sseStore.registerKeeperChatQueueRefresh(refreshQueue)
+    sseStore.registerKeeperWaitingInventoryRefresh(refreshQueue)
 
     sseStore.routeServerPushEvent({
-      type: 'keeper_chat_queue_changed',
+      type: 'keeper_waiting_inventory_changed',
       keeper_name: 'echo',
-      revision: 4,
+      queue_kind: 'chat_queue',
     })
     sseStore.routeServerPushEvent({
-      type: 'keeper_chat_queue_changed',
+      type: 'keeper_waiting_inventory_changed',
       keeper_name: 'echo',
-      revision: 5,
+      queue_kind: 'chat_queue',
     })
     vi.advanceTimersByTime(1_000)
     await flushAsyncWork()
 
     expect(refreshQueue).toHaveBeenCalledTimes(1)
+    expect(refreshQueue).toHaveBeenCalledWith('echo')
     expect(reconcileKeeperChatReceipts).toHaveBeenCalledTimes(1)
     expect(reconcileKeeperChatReceipts).toHaveBeenCalledWith('echo')
+  })
+
+  it('refreshes waiting inventory for event-queue changes without reading Admin chat receipts', async () => {
+    const { sseStore } = await loadSseStore()
+    const refreshQueue = vi.fn()
+    sseStore.registerKeeperWaitingInventoryRefresh(refreshQueue)
+
+    sseStore.routeServerPushEvent({
+      type: 'keeper_waiting_inventory_changed',
+      keeper_name: 'echo',
+      queue_kind: 'event_queue',
+    })
+    vi.advanceTimersByTime(1_000)
+    await flushAsyncWork()
+
+    expect(refreshQueue).toHaveBeenCalledTimes(1)
+    expect(refreshQueue).toHaveBeenCalledWith('echo')
+    expect(reconcileKeeperChatReceipts).not.toHaveBeenCalled()
   })
 
   it('forwards RFC-0235 audio clips on keeper_chat_appended to the chat handler', async () => {

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -111,10 +111,14 @@ export function registerKeeperTurnRefresh(fn: (keeperName: string) => void): voi
 // deliberately an invalidation signal, so the tools resource registers its
 // authoritative re-read here instead of this transport layer importing a UI
 // store or reconstructing Pending/Inflight state from event deltas.
-let _refreshKeeperChatQueueFn: (() => void) | null = null
-const pendingKeeperChatQueueRefreshNames = new Set<string>()
-export function registerKeeperChatQueueRefresh(fn: () => void): void {
-  _refreshKeeperChatQueueFn = fn
+const _refreshKeeperWaitingInventoryFns = new Set<(keeperName: string) => void>()
+const pendingKeeperWaitingInventoryRefreshNames = new Set<string>()
+const pendingKeeperChatReceiptRefreshNames = new Set<string>()
+export function registerKeeperWaitingInventoryRefresh(
+  fn: (keeperName: string) => void,
+): () => void {
+  _refreshKeeperWaitingInventoryFns.add(fn)
+  return () => _refreshKeeperWaitingInventoryFns.delete(fn)
 }
 
 const _refreshActivityFns = new Set<() => void>()
@@ -789,15 +793,25 @@ export function hydrateServerPushEvent(event: SSEEvent): boolean {
     return true
   }
 
-  if (event.type === 'keeper_chat_queue_changed') {
+  if (event.type === 'keeper_waiting_inventory_changed') {
     const keeperName = event.keeper_name?.trim() ?? ''
-    if (keeperName) pendingKeeperChatQueueRefreshNames.add(keeperName)
+    if (keeperName) {
+      pendingKeeperWaitingInventoryRefreshNames.add(keeperName)
+      if (event.queue_kind === 'chat_queue') {
+        pendingKeeperChatReceiptRefreshNames.add(keeperName)
+      }
+    }
     scheduleRefresh(
-      'keeper_chat_queue',
+      'keeper_waiting_inventory',
       () => {
-        const keeperNames = Array.from(pendingKeeperChatQueueRefreshNames)
-        pendingKeeperChatQueueRefreshNames.clear()
-        _refreshKeeperChatQueueFn?.()
+        const inventoryKeeperNames = Array.from(pendingKeeperWaitingInventoryRefreshNames)
+        pendingKeeperWaitingInventoryRefreshNames.clear()
+        for (const name of inventoryKeeperNames) {
+          for (const refresh of _refreshKeeperWaitingInventoryFns) refresh(name)
+        }
+        const keeperNames = Array.from(pendingKeeperChatReceiptRefreshNames)
+        pendingKeeperChatReceiptRefreshNames.clear()
+        if (keeperNames.length === 0) return
         void import('./keeper-runtime')
           .then(mod => Promise.all(
             keeperNames.map(name => mod.reconcileKeeperChatReceipts(name)),

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -33,7 +33,7 @@ export type SSEEventType =
   | 'keeper_phase_changed'
   | 'keeper_composite_changed'
   | 'keeper_chat_appended'
-  | 'keeper_chat_queue_changed'
+  | 'keeper_waiting_inventory_changed'
   | 'ide_cursor_changed'
   | 'keeper_tool_call'
   | 'masc/keeper_tool_call'
@@ -182,10 +182,9 @@ export interface SSEEvent {
   before_tokens?: number
   after_tokens?: number
   saved_tokens?: number
-  // Durable Keeper chat-queue projection invalidation. The event does not
-  // carry lifecycle truth; consumers re-read the receipt projection at this
-  // exact revision instead of reconstructing queue state from deltas.
-  revision?: number
+  // Waiting-inventory invalidation queue kind. The event carries no rows or
+  // revision ID; consumers re-read the authoritative projection.
+  queue_kind?: 'chat_queue' | 'event_queue'
   trigger?: string
   runtime?: string
   reason?: string

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -176,9 +176,9 @@ export default defineConfig(({ command }) => {
       ? {
           proxy: {
             '/api': proxyTarget,
-            '/mcp': { target: proxyTarget },
+            '/mcp': { target: proxyTarget, changeOrigin: true },
             '/sse': { target: proxyTarget },
-            '/ws': { target: proxyTarget, ws: true },
+            '/ws': { target: proxyTarget, ws: true, changeOrigin: true },
             '/yjs': { target: proxyTarget, ws: true },
           },
         }

--- a/docs/rfc/RFC-connector-deferred-reply-via-chat-queue.md
+++ b/docs/rfc/RFC-connector-deferred-reply-via-chat-queue.md
@@ -229,10 +229,10 @@ ID, source, timestamp, and lifecycle detail. Snapshot load failures appear as
 explicit `read_error` rows.
 
 Every committed mutation invokes one post-commit transition observer outside
-queue locks. The server emits `keeper_chat_queue_changed` with Keeper name and
-revision. This event is an invalidation signal: the Dashboard debounces it and
-rereads the authoritative waiting inventory instead of reconstructing state
-from deltas.
+queue locks. The server emits `keeper_waiting_inventory_changed` with Keeper
+name and queue kind. This event is an invalidation signal: the Dashboard debounces
+it and rereads the authoritative waiting inventory instead of reconstructing
+state from deltas.
 
 The chat composer renders server pending/inflight/read-error counts independently
 from browser-local drafts and from the Keeper's active turn state. The waiting

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 207 unique knobs across 8 modules.
+**Total**: 204 unique knobs across 8 modules.
 
-**Typed getter classification**: 38/120 tagged (`operator`: 38, `algorithm`: 0, `unclassified`: 82).
+**Typed getter classification**: 37/117 tagged (`operator`: 37, `algorithm`: 0, `unclassified`: 80).
 
 ## Env_config_core (23 knobs; typed classification 2/5)
 
@@ -46,31 +46,30 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_TEST_ALLOW_HOME_BASE_PATH` | string_literal | n/a | n/a | 405 | #9903: production base-path safeguard for test executables. Without this, a test whose [MASC_BASE_PATH] override fail... |
 | `MASC_URL` | string_literal | n/a | n/a | 278 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 
-## Env_config_keeper (39 knobs; typed classification 21/32)
+## Env_config_keeper (38 knobs; typed classification 20/31)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 584 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 518 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
+| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 575 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 509 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | feature_flag | n/a | n/a | 19 | Enable startup keeper bootstrap scan |
 | `MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC` | typed:float | unclassified | unclassified | 32 | Polling interval (seconds) for the lazy-startup wait loop in [server_bootstrap_loops.ml]. The autoboot fiber wakes up... |
 | `MASC_KEEPER_BOOTSTRAP_LISTENER_RETRY_INTERVAL_SEC` | typed:float | unclassified | unclassified | 44 | Polling interval (seconds) for the keeper-lifecycle listener retry loop in [server_bootstrap_loops.ml]. After a liste... |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 56 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
-| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 550 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 541 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
 | `MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT` | typed:int | Runtime | operator | 258 | Default item limit for [GET /keepers/:name/compaction-snapshots]. Default: 25. @category Runtime @ops_class operator |
 | `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER` | typed:int | Runtime | operator | 284 | Multiplier from requested item limit to manifest files scanned. Default: 4. @category Runtime @ops_class operator |
 | `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES` | typed:int | Runtime | operator | 274 | Minimum manifest files scanned before applying [limit * multiplier]. Default: 8. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES` | typed:int | Runtime | operator | 294 | Tail line count read from each selected manifest file. Default: 200. @category Runtime @ops_class operator |
 | `MASC_KEEPER_COMPACTION_SNAPSHOT_MAX_LIMIT` | typed:int | Runtime | operator | 264 | Maximum accepted item limit for the compaction snapshot endpoint. Default: 100. @category Runtime @ops_class operator |
 | `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 134 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
 | `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 142 | Enable keeper debug logging. Default: false. |
-| `MASC_KEEPER_DURABLE_QUEUE_STALE_SEC` | typed:float | Telemetry | operator | 443 | Durable event-queue backlog age threshold for fleet health degradation. The durable queue remains fully reported rega... |
-| `MASC_KEEPER_GENERATED_MEDIA_DIR_MAX_BYTES` | typed:int | Policies | operator | 381 | Maximum total bytes retained in [<masc_dir>/media] after opportunistic cleanup. Default is 500 MiB. Range: [1, 5 GiB]... |
-| `MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES` | typed:int | Policies | operator | 370 | Maximum raw generated-media bytes accepted by the durable store and serve route. Default is 10 MiB. Range: [1, 50 MiB... |
-| `MASC_KEEPER_GENERATED_MEDIA_RETENTION_SEC` | typed:float | Policies | operator | 392 | Maximum generated-media file age retained by opportunistic cleanup. Default is 24 hours. Range: [1 second, 30 days]. ... |
-| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 563 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
-| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | Thresholds | operator | 404 | Shared keepalive interval, read early so WorkAsHeartbeat can reference it. Any positive interval is valid; the schedu... |
-| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 425 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
+| `MASC_KEEPER_DURABLE_QUEUE_STALE_SEC` | typed:float | Telemetry | operator | 434 | Durable event-queue backlog age threshold for fleet health degradation. The durable queue remains fully reported rega... |
+| `MASC_KEEPER_GENERATED_MEDIA_DIR_MAX_BYTES` | typed:int | Policies | operator | 372 | Maximum total bytes retained in [<masc_dir>/media] after opportunistic cleanup. Default is 500 MiB. Range: [1, 5 GiB]... |
+| `MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES` | typed:int | Policies | operator | 361 | Maximum raw generated-media bytes accepted by the durable store and serve route. Default is 10 MiB. Range: [1, 50 MiB... |
+| `MASC_KEEPER_GENERATED_MEDIA_RETENTION_SEC` | typed:float | Policies | operator | 383 | Maximum generated-media file age retained by opportunistic cleanup. Default is 24 hours. Range: [1 second, 30 days]. ... |
+| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 554 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
+| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | Thresholds | operator | 395 | Shared keepalive interval, read early so WorkAsHeartbeat can reference it. Any positive interval is valid; the schedu... |
+| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 416 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
 | `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | string_literal | n/a | n/a | 174 |  |
 | `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 217 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
 | `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 229 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
@@ -78,17 +77,17 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_MEMORY_OS_RECALL_FACTS_MAX_BYTES` | typed:int | Policies | operator | 241 | Maximum UTF-8 bytes for the exact rendered fact lines injected by recall. The Librarian owns selection within this ca... |
 | `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | unclassified | unclassified | 64 | Maximum metrics file size in bytes before rotation (default: 10MB) |
 | `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | unclassified | unclassified | 67 | Number of rotated files to keep (default: 1, i.e. .1 only) |
-| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | Thresholds | operator | 467 | Interruptible sleep chunk size in seconds: the upper bound on how long a keeper's heartbeat sleep takes to notice a w... |
+| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | Thresholds | operator | 458 | Interruptible sleep chunk size in seconds: the upper bound on how long a keeper's heartbeat sleep takes to notice a w... |
 | `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 145 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
-| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 573 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
-| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | string_literal | n/a | n/a | 478 |  |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 331 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 341 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
-| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 321 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
+| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 564 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
+| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | string_literal | n/a | n/a | 469 |  |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 322 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 332 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
+| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 312 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
 | `MASC_KEEPER_WIRE_CAPTURE` | feature_flag | Policies | operator | 79 | Master switch for diagnostic MASC->OAS wire capture. Default off. @category Policies @ops_class operator |
 | `MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES` | typed:int | Policies | operator | 105 | Maximum bytes for the active [<masc_root>/wire-capture/YYYY-MM/DD.jsonl] file and maximum total bytes retained below ... |
 | `MASC_KEEPER_WIRE_CAPTURE_RETENTION_DAYS` | typed:int | Policies | operator | 94 | Maximum age for [<masc_root>/wire-capture] day files retained by the diagnostic MASC->OAS wire-capture harness. Defau... |
-| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 419 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
+| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 410 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
 
 ## Env_config_keeper_supervisor (2 knobs; typed classification 2/2)
 
@@ -97,79 +96,77 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_DEAD_TTL_SEC` | typed:float | Timeouts | operator | 11 | Dead tombstone TTL: seconds before Dead entries are cleaned up. @category Timeouts @ops_class operator |
 | `MASC_KEEPER_SUPERVISOR_SWEEP_SEC` | typed:float | Timeouts | operator | 7 | Interval between supervisor sweep runs (seconds). @category Timeouts @ops_class operator |
 
-## Env_config_runtime (69 knobs; typed classification 4/54)
+## Env_config_runtime (67 knobs; typed classification 4/52)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_AGENT_RATE_BURST` | typed:int | unclassified | unclassified | 311 | Per-agent burst capacity. Default: 50. |
-| `MASC_AGENT_RATE_LIMIT` | typed:float | unclassified | unclassified | 308 | Per-agent requests per second. Default: 20. |
-| `MASC_AGENT_TRANSPORT` | string_literal | n/a | n/a | 220 | Agent transport type variant (e.g. "grpc", "http", "ws"). |
-| `MASC_BOARD_FLUSHER_INBOX_CAPACITY` | typed:int | Concurrency | operator | 259 | Capacity of the board flusher inbox (scheduled sweep/flush messages enqueued by the sweeper). Single source of truth ... |
-| `MASC_BOARD_FLUSH_INTERVAL_SEC` | typed:float | unclassified | unclassified | 250 | Flush interval for board persistence (seconds). Default: 30. |
-| `MASC_BRIEFING_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 530 | Dashboard mission briefing cache TTL (seconds). Default: 300 (5 min). |
-| `MASC_CACHE_MAX_ENTRIES` | typed:int | unclassified | unclassified | 41 | Maximum total number of cache entries (default 1000) |
-| `MASC_CACHE_MAX_ENTRY_SIZE` | typed:int | unclassified | unclassified | 37 | Maximum size of a single cache entry value in bytes (default 100KB) |
-| `MASC_DASHBOARD_CTX_COMPACTING` | typed:float | unclassified | unclassified | 381 |  |
-| `MASC_DASHBOARD_CTX_HANDOFF_IMMINENT` | typed:float | unclassified | unclassified | 377 | Keeper context-ratio lifecycle thresholds. Higher ratio = closer to context limit = more urgency. |
-| `MASC_DASHBOARD_CTX_PREPARING` | typed:float | unclassified | unclassified | 379 |  |
-| `MASC_DASHBOARD_EXECUTION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 420 | Execution surface compute timeout (light + parameterized). Wraps two [Dashboard_cache.get_or_compute_with_timeout] si... |
-| `MASC_DASHBOARD_EXECUTION_TRUST_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 434 | Execution-trust surface compute timeout. Wraps [Dashboard_cache.get_or_compute_with_timeout] at [server_dashboard_htt... |
-| `MASC_DASHBOARD_KEEPER_ACTION_STALE_SEC` | typed:float | unclassified | unclassified | 372 | Keeper action-age threshold (seconds). Default: 3600 (1 hour). |
-| `MASC_DASHBOARD_MISSION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 444 | Mission card compute timeout. Wraps three [Dashboard_cache.get_or_compute_with_timeout] sites at [server_dashboard_ht... |
-| `MASC_DASHBOARD_RENDER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 477 | Maximum wall-clock for a single dashboard render ([Dashboard_execution.json_render]). Wraps the entire render pipelin... |
-| `MASC_DASHBOARD_SHELL_LIGHT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 464 | Shell render compute timeout (light path). Default 8s. Must remain strictly less than [shell_timeout_sec] so the spli... |
-| `MASC_DASHBOARD_SHELL_PREWARM_OUTER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 409 |  |
-| `MASC_DASHBOARD_SHELL_PREWARM_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 404 | Dashboard shell-cache pre-warm timeouts. The pre-warm fires once on server bootstrap. It is wrapped in two nested tim... |
-| `MASC_DASHBOARD_SHELL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 453 | Shell render compute timeout (full path). Used by [Dashboard_cache.get_or_compute_with_timeout] for the full shell re... |
-| `MASC_DASHBOARD_SIGNAL_LIVE_SEC` | typed:float | unclassified | unclassified | 368 | Duration (seconds) for a signal to count as "live". Default: 300 (5 min). |
-| `MASC_DASHBOARD_SIGNAL_QUIET_SEC` | typed:float | unclassified | unclassified | 364 | Duration (seconds) for borderline "quiet" warning. Default: 600 (10 min). |
-| `MASC_DASHBOARD_SIGNAL_STALE_SEC` | typed:float | unclassified | unclassified | 360 | Duration (seconds) after which a signal is considered stale. Default: 1200 (20 min). |
-| `MASC_EXECUTOR_DOMAIN_COUNT` | typed:int | Concurrency | operator | 53 | Shared executor worker-domain count override. Env: [MASC_EXECUTOR_DOMAIN_COUNT]. Default: unset, use {!Domain_pool}'s... |
-| `MASC_FULL_HEALTH_CRITICAL_FAILURE_THRESHOLD` | typed:int | unclassified | unclassified | 507 | Number of consecutive [/health?full=1] cache-refresh failures that must accumulate before [masc_full_health_refresh_c... |
-| `MASC_FULL_HEALTH_REFRESH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 495 | Full-health snapshot proactive refresh timeout (seconds). Caps a single [/health?full=1] cache refresh attempt in [Se... |
-| `MASC_GRPC_ENABLED` | feature_flag | n/a | n/a | 195 | Whether gRPC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
-| `MASC_GRPC_PORT` | string_literal | n/a | n/a | 191 | gRPC server port. Default: 8936. |
-| `MASC_GRPC_TARGET` | string_literal | n/a | n/a | 199 | gRPC client target address. Derived from grpc_port when unset. |
-| `MASC_HTTP_AUTH_STRICT` | feature_flag | n/a | n/a | 225 |  |
-| `MASC_JANITOR_INTERVAL_SEC` | typed:float | unclassified | unclassified | 546 | Bootstrap janitor tick interval (seconds). Drives the SSE/session/ rate-limit/webrtc reaper loop in [server_bootstrap... |
-| `MASC_LABEL_QUIET_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 522 | Dashboard label "quiet" threshold (seconds). Default: 300 (5 min). |
-| `MASC_LABEL_STUCK_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 526 | Dashboard label "stuck" threshold (seconds). Default: 900 (15 min). |
-| `MASC_LANE_PREFERENCE_TTL_S` | typed:float | Timeouts | operator | 349 | Sticky lane-candidate preference TTL (seconds). After a lane candidate succeeds, later turns on the same lane try it ... |
-| `MASC_LIST_PAGE_SIZE` | typed:int | unclassified | unclassified | 272 | Tool list page size, clamped to [10, 1024]. Default: 512. Re-readable within the process; not a guarantee of shell-le... |
-| `MASC_LOCAL_RUNTIME_COOLDOWN_SEC` | string_literal | n/a | n/a | 323 | Local runtime cooldown (seconds). |
-| `MASC_LOCAL_RUNTIME_DEBUG` | feature_flag | n/a | n/a | 319 | Enable local runtime debug logging. Default: false. |
-| `MASC_LOCAL_WORKER_HEARTBEAT_SEC` | typed:int | unclassified | unclassified | 326 | Local worker heartbeat interval (seconds). Default: 60. |
-| `MASC_METRICS_FLUSH_SEC` | typed:float | unclassified | unclassified | 518 | Tool metrics flush interval (seconds). Default: 300 (5 min). |
-| `MASC_OAS_SSE_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 334 | SSE drain interval (seconds). Default: 2.0. |
-| `MASC_ORCHESTRATOR_AGENT` | typed:string | unclassified | unclassified | 67 | Orchestrator agent name |
-| `MASC_ORCHESTRATOR_INTERVAL` | typed:float | unclassified | unclassified | 63 | Orchestrator check interval (seconds) |
-| `MASC_ORCHESTRATOR_MIN_PRIORITY` | typed:int | unclassified | unclassified | 70 |  |
-| `MASC_PUBLIC_TOOLS_EXTRA` | string_literal | n/a | n/a | 277 | Extra public tools (comma-separated names). |
-| `MASC_RATE_BURST` | typed:int | unclassified | unclassified | 305 | Burst capacity. Default: 150. |
-| `MASC_RATE_LIMIT` | typed:float | unclassified | unclassified | 302 | Requests per second. Default: 100. |
-| `MASC_RATE_LIMIT_BUCKET_TTL_SEC` | typed:int | unclassified | unclassified | 560 | Rate-limit bucket staleness TTL (seconds). Buckets with no traffic for this long are reaped by the janitor loop. Defa... |
-| `MASC_REPO_SYNC_INTERVAL_SEC` | typed:float | unclassified | unclassified | 552 | Repository auto-sync interval (seconds). The repo_sync fiber in [server_bootstrap_loops] wakes at this cadence to fet... |
+| `MASC_AGENT_RATE_BURST` | typed:int | unclassified | unclassified | 303 | Per-agent burst capacity. Default: 50. |
+| `MASC_AGENT_RATE_LIMIT` | typed:float | unclassified | unclassified | 300 | Per-agent requests per second. Default: 20. |
+| `MASC_AGENT_TRANSPORT` | string_literal | n/a | n/a | 212 | Agent transport type variant (e.g. "grpc", "http", "ws"). |
+| `MASC_BOARD_FLUSHER_INBOX_CAPACITY` | typed:int | Concurrency | operator | 251 | Capacity of the board flusher inbox (scheduled sweep/flush messages enqueued by the sweeper). Single source of truth ... |
+| `MASC_BOARD_FLUSH_INTERVAL_SEC` | typed:float | unclassified | unclassified | 242 | Flush interval for board persistence (seconds). Default: 30. |
+| `MASC_BRIEFING_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 522 | Dashboard mission briefing cache TTL (seconds). Default: 300 (5 min). |
+| `MASC_CACHE_MAX_ENTRIES` | typed:int | unclassified | unclassified | 33 | Maximum total number of cache entries (default 1000) |
+| `MASC_CACHE_MAX_ENTRY_SIZE` | typed:int | unclassified | unclassified | 29 | Maximum size of a single cache entry value in bytes (default 100KB) |
+| `MASC_DASHBOARD_CTX_COMPACTING` | typed:float | unclassified | unclassified | 373 |  |
+| `MASC_DASHBOARD_CTX_HANDOFF_IMMINENT` | typed:float | unclassified | unclassified | 369 | Keeper context-ratio lifecycle thresholds. Higher ratio = closer to context limit = more urgency. |
+| `MASC_DASHBOARD_CTX_PREPARING` | typed:float | unclassified | unclassified | 371 |  |
+| `MASC_DASHBOARD_EXECUTION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 412 | Execution surface compute timeout (light + parameterized). Wraps two [Dashboard_cache.get_or_compute_with_timeout] si... |
+| `MASC_DASHBOARD_EXECUTION_TRUST_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 426 | Execution-trust surface compute timeout. Wraps [Dashboard_cache.get_or_compute_with_timeout] at [server_dashboard_htt... |
+| `MASC_DASHBOARD_KEEPER_ACTION_STALE_SEC` | typed:float | unclassified | unclassified | 364 | Keeper action-age threshold (seconds). Default: 3600 (1 hour). |
+| `MASC_DASHBOARD_MISSION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 436 | Mission card compute timeout. Wraps three [Dashboard_cache.get_or_compute_with_timeout] sites at [server_dashboard_ht... |
+| `MASC_DASHBOARD_RENDER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 469 | Maximum wall-clock for a single dashboard render ([Dashboard_execution.json_render]). Wraps the entire render pipelin... |
+| `MASC_DASHBOARD_SHELL_LIGHT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 456 | Shell render compute timeout (light path). Default 8s. Must remain strictly less than [shell_timeout_sec] so the spli... |
+| `MASC_DASHBOARD_SHELL_PREWARM_OUTER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 401 |  |
+| `MASC_DASHBOARD_SHELL_PREWARM_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 396 | Dashboard shell-cache pre-warm timeouts. The pre-warm fires once on server bootstrap. It is wrapped in two nested tim... |
+| `MASC_DASHBOARD_SHELL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 445 | Shell render compute timeout (full path). Used by [Dashboard_cache.get_or_compute_with_timeout] for the full shell re... |
+| `MASC_DASHBOARD_SIGNAL_LIVE_SEC` | typed:float | unclassified | unclassified | 360 | Duration (seconds) for a signal to count as "live". Default: 300 (5 min). |
+| `MASC_DASHBOARD_SIGNAL_QUIET_SEC` | typed:float | unclassified | unclassified | 356 | Duration (seconds) for borderline "quiet" warning. Default: 600 (10 min). |
+| `MASC_DASHBOARD_SIGNAL_STALE_SEC` | typed:float | unclassified | unclassified | 352 | Duration (seconds) after which a signal is considered stale. Default: 1200 (20 min). |
+| `MASC_EXECUTOR_DOMAIN_COUNT` | typed:int | Concurrency | operator | 45 | Shared executor worker-domain count override. Env: [MASC_EXECUTOR_DOMAIN_COUNT]. Default: unset, use {!Domain_pool}'s... |
+| `MASC_FULL_HEALTH_CRITICAL_FAILURE_THRESHOLD` | typed:int | unclassified | unclassified | 499 | Number of consecutive [/health?full=1] cache-refresh failures that must accumulate before [masc_full_health_refresh_c... |
+| `MASC_FULL_HEALTH_REFRESH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 487 | Full-health snapshot proactive refresh timeout (seconds). Caps a single [/health?full=1] cache refresh attempt in [Se... |
+| `MASC_GRPC_ENABLED` | feature_flag | n/a | n/a | 187 | Whether gRPC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
+| `MASC_GRPC_PORT` | string_literal | n/a | n/a | 183 | gRPC server port. Default: 8936. |
+| `MASC_GRPC_TARGET` | string_literal | n/a | n/a | 191 | gRPC client target address. Derived from grpc_port when unset. |
+| `MASC_HTTP_AUTH_STRICT` | feature_flag | n/a | n/a | 217 |  |
+| `MASC_JANITOR_INTERVAL_SEC` | typed:float | unclassified | unclassified | 538 | Bootstrap janitor tick interval (seconds). Drives the SSE/session/ rate-limit/webrtc reaper loop in [server_bootstrap... |
+| `MASC_LABEL_QUIET_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 514 | Dashboard label "quiet" threshold (seconds). Default: 300 (5 min). |
+| `MASC_LABEL_STUCK_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 518 | Dashboard label "stuck" threshold (seconds). Default: 900 (15 min). |
+| `MASC_LANE_PREFERENCE_TTL_S` | typed:float | Timeouts | operator | 341 | Sticky lane-candidate preference TTL (seconds). After a lane candidate succeeds, later turns on the same lane try it ... |
+| `MASC_LIST_PAGE_SIZE` | typed:int | unclassified | unclassified | 264 | Tool list page size, clamped to [10, 1024]. Default: 512. Re-readable within the process; not a guarantee of shell-le... |
+| `MASC_LOCAL_RUNTIME_COOLDOWN_SEC` | string_literal | n/a | n/a | 315 | Local runtime cooldown (seconds). |
+| `MASC_LOCAL_RUNTIME_DEBUG` | feature_flag | n/a | n/a | 311 | Enable local runtime debug logging. Default: false. |
+| `MASC_LOCAL_WORKER_HEARTBEAT_SEC` | typed:int | unclassified | unclassified | 318 | Local worker heartbeat interval (seconds). Default: 60. |
+| `MASC_METRICS_FLUSH_SEC` | typed:float | unclassified | unclassified | 510 | Tool metrics flush interval (seconds). Default: 300 (5 min). |
+| `MASC_OAS_SSE_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 326 | SSE drain interval (seconds). Default: 2.0. |
+| `MASC_ORCHESTRATOR_AGENT` | typed:string | unclassified | unclassified | 59 | Orchestrator agent name |
+| `MASC_ORCHESTRATOR_INTERVAL` | typed:float | unclassified | unclassified | 55 | Orchestrator check interval (seconds) |
+| `MASC_ORCHESTRATOR_MIN_PRIORITY` | typed:int | unclassified | unclassified | 62 |  |
+| `MASC_PUBLIC_TOOLS_EXTRA` | string_literal | n/a | n/a | 269 | Extra public tools (comma-separated names). |
+| `MASC_RATE_BURST` | typed:int | unclassified | unclassified | 297 | Burst capacity. Default: 150. |
+| `MASC_RATE_LIMIT` | typed:float | unclassified | unclassified | 294 | Requests per second. Default: 100. |
+| `MASC_RATE_LIMIT_BUCKET_TTL_SEC` | typed:int | unclassified | unclassified | 552 | Rate-limit bucket staleness TTL (seconds). Buckets with no traffic for this long are reaped by the janitor loop. Defa... |
+| `MASC_REPO_SYNC_INTERVAL_SEC` | typed:float | unclassified | unclassified | 544 | Repository auto-sync interval (seconds). The repo_sync fiber in [server_bootstrap_loops] wakes at this cadence to fet... |
 | `MASC_SESSION_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 8 | Maximum session age before cleanup (seconds) |
 | `MASC_SESSION_SSE_GRACE_PERIOD_SEC` | typed:float | unclassified | unclassified | 13 | Grace period after SSE disconnect before reaping transport session (seconds). Prevents "Unknown Mcp-Session-Id" error... |
-| `MASC_SIDECAR_CONTROL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 586 | Subprocess timeout (seconds) for sidecar control commands — [stop], [tail], and similar quick housekeeping operatio... |
-| `MASC_SIDECAR_RECONCILE_BACKOFF_SEC` | typed:float | unclassified | unclassified | 574 | Backoff window (seconds) between repeated same-generation [running + unavailable] start dispatches. Default: 30 (matc... |
-| `MASC_SIDECAR_SCHEMA_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 602 | Subprocess timeout (seconds) for sidecar Python schema generation. Wraps [Process_eio.run_argv_with_status] at [serve... |
-| `MASC_SSE_BUFFER_TTL_SEC` | typed:float | unclassified | unclassified | 534 | SSE buffer TTL (seconds). Default: 300 (5 min). |
-| `MASC_STALLED_SESSION_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 538 | Operator digest stalled session threshold (seconds). Default: 300 (5 min). |
-| `MASC_STARTUP_WATCHDOG_SEC` | typed:float | unclassified | unclassified | 236 | Startup watchdog timeout, clamped to [30, 600]. Default: 240. Re-readable within the process, but operationally a boo... |
-| `MASC_TEMPO_DEFAULT_INTERVAL_SEC` | typed:float | unclassified | unclassified | 29 | Default polling interval (seconds) |
-| `MASC_TEMPO_MAX_INTERVAL_SEC` | typed:float | unclassified | unclassified | 25 | Maximum polling interval (seconds) - for idle tempo |
-| `MASC_TEMPO_MIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 21 | Minimum polling interval (seconds) - for urgent tempo |
-| `MASC_USE_H2` | string_literal | n/a | n/a | 214 | HTTP mode: typed variant for "auto", "h2_only", "h1_only". |
-| `MASC_WEBRTC_ENABLED` | feature_flag | n/a | n/a | 210 | Whether WebRTC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
-| `MASC_WEB_SEARCH_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 293 |  |
-| `MASC_WEB_SEARCH_FALLBACKS` | string_literal | n/a | n/a | 286 |  |
-| `MASC_WEB_SEARCH_PROVIDER` | string_literal | n/a | n/a | 280 |  |
-| `MASC_WEB_SEARCH_PROVIDER_ORDER` | string_literal | n/a | n/a | 283 |  |
-| `MASC_WEB_SEARCH_TIMEOUT_SEC` | typed:int | unclassified | unclassified | 289 |  |
-| `MASC_WORKSPACE_FILE_MAX_READ_BYTES` | typed:int | Policies | operator | 612 | Maximum bytes served by the IDE workspace file endpoint in one response. The route rejects larger files instead of ma... |
-| `MASC_WS_ENABLED` | feature_flag | n/a | n/a | 206 | Whether WebSocket transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at... |
-| `MASC_WS_PORT` | string_literal | n/a | n/a | 202 | WebSocket server port. Default: 8937. |
+| `MASC_SIDECAR_CONTROL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 578 | Subprocess timeout (seconds) for sidecar control commands — [stop], [tail], and similar quick housekeeping operatio... |
+| `MASC_SIDECAR_RECONCILE_BACKOFF_SEC` | typed:float | unclassified | unclassified | 566 | Backoff window (seconds) between repeated same-generation [running + unavailable] start dispatches. Default: 30 (matc... |
+| `MASC_SIDECAR_SCHEMA_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 594 | Subprocess timeout (seconds) for sidecar Python schema generation. Wraps [Process_eio.run_argv_with_status] at [serve... |
+| `MASC_SSE_BUFFER_TTL_SEC` | typed:float | unclassified | unclassified | 526 | SSE buffer TTL (seconds). Default: 300 (5 min). |
+| `MASC_STALLED_SESSION_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 530 | Operator digest stalled session threshold (seconds). Default: 300 (5 min). |
+| `MASC_STARTUP_WATCHDOG_SEC` | typed:float | unclassified | unclassified | 228 | Startup watchdog timeout, clamped to [30, 600]. Default: 240. Re-readable within the process, but operationally a boo... |
+| `MASC_TEMPO_DEFAULT_INTERVAL_SEC` | typed:float | unclassified | unclassified | 21 | Polling interval (seconds) published to operator surfaces |
+| `MASC_USE_H2` | string_literal | n/a | n/a | 206 | HTTP mode: typed variant for "auto", "h2_only", "h1_only". |
+| `MASC_WEBRTC_ENABLED` | feature_flag | n/a | n/a | 202 | Whether WebRTC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
+| `MASC_WEB_SEARCH_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 285 |  |
+| `MASC_WEB_SEARCH_FALLBACKS` | string_literal | n/a | n/a | 278 |  |
+| `MASC_WEB_SEARCH_PROVIDER` | string_literal | n/a | n/a | 272 |  |
+| `MASC_WEB_SEARCH_PROVIDER_ORDER` | string_literal | n/a | n/a | 275 |  |
+| `MASC_WEB_SEARCH_TIMEOUT_SEC` | typed:int | unclassified | unclassified | 281 |  |
+| `MASC_WORKSPACE_FILE_MAX_READ_BYTES` | typed:int | Policies | operator | 604 | Maximum bytes served by the IDE workspace file endpoint in one response. The route rejects larger files instead of ma... |
+| `MASC_WS_ENABLED` | feature_flag | n/a | n/a | 198 | Whether WebSocket transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at... |
+| `MASC_WS_PORT` | string_literal | n/a | n/a | 194 | WebSocket server port. Default: 8937. |
 
 ## Env_config_runtime_services (18 knobs; typed classification 8/14)
 
@@ -246,8 +243,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 134 |  |
 | `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 133 |  |
 | `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 458 |  |
-| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 484 |  |
-| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 492 |  |
+| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 480 |  |
+| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 488 |  |
 | `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 432 |  |
 | `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 434 |  |
 | `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 436 |  |
@@ -255,8 +252,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 444 |  |
 | `MASC_TELEMETRY_MAX_BYTES` | string_literal | n/a | n/a | 48 |  |
 | `MASC_TELEMETRY_RETENTION_DAYS` | string_literal | n/a | n/a | 45 |  |
-| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 474 |  |
-| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 476 |  |
+| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 470 |  |
+| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 472 |  |
 | `MASC_TLA_TRACE` | string_literal | n/a | n/a | 127 |  |
 | `MASC_WS_ACK_STALE_THRESHOLD_SEC` | string_literal | n/a | n/a | 91 |  |
 | `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 88 |  |

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -284,15 +284,6 @@ module KeeperCompactionSnapshots = struct
          "MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER")
   ;;
 
-  (** Tail line count read from each selected manifest file. Default: 200.
-      @category Runtime @ops_class operator *)
-  let manifest_tail_max_lines =
-    max
-      1
-      (get_int_nonneg
-         ~default:200
-         "MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES")
-  ;;
 end
 
 (** {1 Keeper Vision Tool Configuration} *)

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -96,7 +96,6 @@ module KeeperCompactionSnapshots : sig
   val max_limit : int
   val manifest_scan_min_files : int
   val manifest_scan_limit_multiplier : int
-  val manifest_tail_max_lines : int
 end
 
 (** {1 Keeper vision tool} *)

--- a/lib/keeper/keeper_chat_broadcast.ml
+++ b/lib/keeper/keeper_chat_broadcast.ml
@@ -105,24 +105,3 @@ let chat_appended ~keeper_name ~source ?content () =
     event, mirroring {!chat_appended}. *)
 let chat_appended_with_audio ~keeper_name ~source ~audio ?content () =
   do_broadcast ~keeper_name ~source ~audio:(Some audio) ?content ()
-
-let queue_changed ~keeper_name ~revision () =
-  try
-    Sse.broadcast
-      (`Assoc
-        [ ("type", `String "keeper_chat_queue_changed");
-          ("keeper_name", `String keeper_name);
-          ("revision", `String (Int64.to_string revision));
-          ("ts_unix", `Float (Time_compat.now ()));
-        ])
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn ->
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string SseBroadcastFailures)
-      ~labels:[ ("keeper", keeper_name); ("site", "queue_changed") ]
-      ();
-    Log.Keeper.warn
-      "keeper_chat_broadcast: queue_changed name=%s failed: %s"
-      keeper_name
-      (Printexc.to_string exn)

--- a/lib/keeper/keeper_chat_broadcast.mli
+++ b/lib/keeper/keeper_chat_broadcast.mli
@@ -41,14 +41,3 @@ val chat_appended :
     downstream. [content] is used to derive rich blocks for the event. *)
 val chat_appended_with_audio :
   keeper_name:string -> source:string -> audio:audio_clip -> ?content:string -> unit -> unit
-
-(** Broadcast a [keeper_chat_queue_changed] invalidation whenever a durable
-    receipt transition commits. [revision] is the exact queue projection
-    revision after that transition. Lifecycle truth is intentionally absent
-    from this event: dashboards re-read the authoritative receipt projection
-    instead of guessing Pending/Inflight/Delivered/Failed from deltas.
-
-    Same failure contract as {!chat_appended}: exceptions from
-    [Sse.broadcast] are counted and logged at WARN, {!Eio.Cancel.Cancelled}
-    propagates. *)
-val queue_changed : keeper_name:string -> revision:int64 -> unit -> unit

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -8,9 +8,12 @@
     registry Atomic state primitive. *)
 
 let publish_pending ~base_path name pending =
-  match Keeper_registry.get ~base_path name with
-  | None -> ()
-  | Some entry -> Atomic.set entry.event_queue pending
+  (match Keeper_registry.get ~base_path name with
+   | None -> ()
+   | Some entry -> Atomic.set entry.event_queue pending);
+  Keeper_waiting_inventory_broadcast.changed
+    ~keeper_name:name
+    ~source:Event_queue
 ;;
 
 type accepted_cancellation = Keeper_event_queue_persistence.accepted_cancellation =

--- a/lib/keeper/keeper_waiting_inventory_broadcast.ml
+++ b/lib/keeper/keeper_waiting_inventory_broadcast.ml
@@ -1,0 +1,28 @@
+type source = Chat_queue | Event_queue
+
+let source_to_string = function
+  | Chat_queue -> "chat_queue"
+  | Event_queue -> "event_queue"
+;;
+
+let changed ~keeper_name ~source =
+  try
+    Sse.broadcast
+      (`Assoc
+        [ "type", `String "keeper_waiting_inventory_changed"
+        ; "keeper_name", `String keeper_name
+        ; "queue_kind", `String (source_to_string source)
+        ; "ts_unix", `Float (Time_compat.now ())
+        ])
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string SseBroadcastFailures)
+      ~labels:[ "keeper", keeper_name; "site", "waiting_inventory_changed" ]
+      ();
+    Log.Keeper.warn
+      "keeper_waiting_inventory_broadcast: changed name=%s failed: %s"
+      keeper_name
+      (Printexc.to_string exn)
+;;

--- a/lib/keeper/keeper_waiting_inventory_broadcast.mli
+++ b/lib/keeper/keeper_waiting_inventory_broadcast.mli
@@ -1,0 +1,7 @@
+(** Invalidate the dashboard Keeper waiting-inventory read model after a
+    durable queue mutation. The event carries no queue rows or revision ID;
+    consumers re-read the authoritative waiting inventory. *)
+
+type source = Chat_queue | Event_queue
+
+val changed : keeper_name:string -> source:source -> unit

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1687,8 +1687,10 @@ let start_keeper_loops_owned
            delivered instead of sitting queued until the next unrelated wake. *)
         Keeper_chat_queue.set_transition_observer
           (Some
-             (fun ~keeper_name ~revision ->
-                Keeper_chat_broadcast.queue_changed ~keeper_name ~revision ();
+             (fun ~keeper_name ~revision:_ ->
+                Keeper_waiting_inventory_broadcast.changed
+                  ~keeper_name
+                  ~source:Chat_queue;
                 Keeper_chat_consumer.notify_transition ~keeper_name));
         (* A queued turn can fail preflight before it parks on the admission
            mutex. Release and shutdown rollback re-arm only a consumer attempt

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -17,7 +17,7 @@ let keeper_composite_cache_ttl_s = 5.0
 
 (* Bounded dashboard hydration defaults for the operator compaction inspector.
    These cap best-effort filesystem scans; [scan_truncated] in the response makes
-   the bound observable when there are more manifest files/rows than scanned. *)
+   the bound observable when there are more manifest segments than scanned. *)
 let compaction_snapshot_default_limit =
   Env_config.KeeperCompactionSnapshots.default_limit
 ;;
@@ -32,9 +32,7 @@ let compaction_snapshot_manifest_scan_limit_multiplier =
   Env_config.KeeperCompactionSnapshots.manifest_scan_limit_multiplier
 ;;
 
-let compaction_snapshot_manifest_tail_max_lines =
-  Env_config.KeeperCompactionSnapshots.manifest_tail_max_lines
-;;
+let compaction_snapshot_manifest_scan_max_bytes = 64 * 1024 * 1024
 
 (* Maximum number of trajectory/trace entries returned per query. *)
 let trajectory_max_limit = 500
@@ -308,11 +306,11 @@ let runtime_manifest_row_scope ~base_dir path line_no =
     line_no
 ;;
 
-let safe_regular_mtime ~base_dir path =
+let safe_regular_file_info ~base_dir path =
   try
     let st = Unix.stat path in
     if st.Unix.st_kind = Unix.S_REG
-    then Some st.Unix.st_mtime, []
+    then Some (st.Unix.st_mtime, st.Unix.st_size), []
     else None, []
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -329,6 +327,20 @@ let safe_regular_mtime ~base_dir path =
           ~scope:(runtime_manifest_file_scope ~base_dir path)
           ~error:(Printexc.to_string exn)
       ] )
+;;
+
+let is_runtime_manifest_segment_file name =
+  Filename.check_suffix name Keeper_runtime_manifest.manifest_file_suffix
+  ||
+  match String.rindex_opt name '.' with
+  | None -> false
+  | Some dot ->
+    let rotation = String.sub name (dot + 1) (String.length name - dot - 1) in
+    rotation <> ""
+    && String.for_all (fun c -> c >= '0' && c <= '9') rotation
+    && Filename.check_suffix
+         (String.sub name 0 dot)
+         Keeper_runtime_manifest.manifest_file_suffix
 ;;
 
 let runtime_manifest_paths ~config ~keeper_id ~limit =
@@ -351,24 +363,37 @@ let runtime_manifest_paths ~config ~keeper_id ~limit =
       let entries, read_errors =
         Sys.readdir dir
         |> Array.to_list
-        |> List.filter
-             (String.ends_with
-                ~suffix:Keeper_runtime_manifest.manifest_file_suffix)
+        |> List.filter is_runtime_manifest_segment_file
         |> List.fold_left
              (fun (entries, read_errors) file ->
         let path = Filename.concat dir file in
-        let mtime, errors = safe_regular_mtime ~base_dir:dir path in
+        let file_info, errors = safe_regular_file_info ~base_dir:dir path in
         let entries =
-          match mtime with
-          | Some mtime -> (path, mtime) :: entries
+          match file_info with
+          | Some (mtime, size) -> (path, mtime, size) :: entries
           | None -> entries
         in
         entries, List.rev_append errors read_errors)
              ([], [])
       in
-      let sorted_entries = List.sort (fun (_, a) (_, b) -> Float.compare b a) entries in
-      let scan_truncated = List.length sorted_entries > scan_limit in
-      ( sorted_entries |> compaction_snapshot_take scan_limit |> List.map fst
+      let sorted_entries =
+        List.sort (fun (_, a, _) (_, b, _) -> Float.compare b a) entries
+      in
+      let rec select selected_count selected_bytes selected = function
+        | [] -> List.rev selected, false
+        | _ when selected_count >= scan_limit -> List.rev selected, true
+        | (path, _, size) :: rest ->
+          if selected_bytes + size > compaction_snapshot_manifest_scan_max_bytes
+          then List.rev selected, true
+          else
+            select
+              (selected_count + 1)
+              (selected_bytes + size)
+              (path :: selected)
+              rest
+      in
+      let selected_paths, scan_truncated = select 0 0 [] sorted_entries in
+      ( selected_paths
       , List.rev read_errors
       , scan_truncated )
   with
@@ -390,11 +415,8 @@ let runtime_manifest_paths ~config ~keeper_id ~limit =
     , false )
 ;;
 
-let read_runtime_manifest_tail_rows ~base_dir path =
+let read_runtime_manifest_rows ~base_dir path =
   try
-    Dated_jsonl.load_tail_lines path
-      ~max_lines:compaction_snapshot_manifest_tail_max_lines
-    |> fun lines ->
     let compaction_snapshot_manifest_event_name = function
       | `Assoc fields -> (
           match List.assoc_opt "event" fields with
@@ -402,41 +424,56 @@ let read_runtime_manifest_tail_rows ~base_dir path =
           | _ -> None)
       | _ -> None
     in
-    let rec parse_manifest_row line_no rows read_errors rest json =
+    let parse_manifest_row line_no rows read_errors json =
       match Keeper_runtime_manifest.of_json json with
-      | Ok row -> loop (line_no + 1) (row :: rows) read_errors rest
+      | Ok row -> row :: rows, read_errors
       | Error msg ->
-        loop (line_no + 1) rows
-          (compaction_snapshot_read_error
-             ~scope:(runtime_manifest_row_scope ~base_dir path line_no)
-             ~error:msg
-           :: read_errors)
-          rest
-    and loop line_no rows read_errors = function
-      | [] -> List.rev rows, List.rev read_errors
-      | line :: rest ->
-      try
-        let json = Yojson.Safe.from_string line in
+        ( rows
+        , compaction_snapshot_read_error
+            ~scope:(runtime_manifest_row_scope ~base_dir path line_no)
+            ~error:msg
+          :: read_errors )
+    in
+    let input = open_in_bin path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr input)
+      (fun () ->
+    let rec loop line_no rows read_errors =
+      match input_line input with
+      | line ->
+        let trimmed = String.trim line in
+        if String.equal trimmed ""
+        then loop line_no rows read_errors
+        else
+          let next_line_no = line_no + 1 in
+          (try
+        let json = Yojson.Safe.from_string trimmed in
         (match compaction_snapshot_manifest_event_name json with
          | Some event -> (
            match Keeper_runtime_manifest.classify_compaction_snapshot_event event with
            | Keeper_runtime_manifest.Compaction_snapshot_known_unrelated ->
-             loop (line_no + 1) rows read_errors rest
+             loop next_line_no rows read_errors
            | Keeper_runtime_manifest.Compaction_snapshot_relevant
            | Keeper_runtime_manifest.Compaction_snapshot_unknown ->
-             parse_manifest_row line_no rows read_errors rest json)
-         | None -> parse_manifest_row line_no rows read_errors rest json)
+             let rows, read_errors =
+               parse_manifest_row next_line_no rows read_errors json
+             in
+             loop next_line_no rows read_errors)
+         | None ->
+           let rows, read_errors =
+             parse_manifest_row next_line_no rows read_errors json
+           in
+           loop next_line_no rows read_errors)
       with
           | Yojson.Json_error msg | Yojson.Safe.Util.Type_error (msg, _) ->
-            loop (line_no + 1) rows
+            loop next_line_no rows
               (compaction_snapshot_read_error
-                 ~scope:(runtime_manifest_row_scope ~base_dir path line_no)
+                 ~scope:(runtime_manifest_row_scope ~base_dir path next_line_no)
                  ~error:msg
-               :: read_errors)
-              rest
+               :: read_errors))
+      | exception End_of_file -> List.rev rows, List.rev read_errors
     in
-    let rows, read_errors = loop 1 [] [] lines in
-    rows, read_errors, List.length lines >= compaction_snapshot_manifest_tail_max_lines
+    loop 0 [] [])
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
@@ -445,7 +482,7 @@ let read_runtime_manifest_tail_rows ~base_dir path =
           ~scope:(runtime_manifest_file_scope ~base_dir path)
           ~error:(Printexc.to_string exn)
       ]
-    , false )
+    )
 ;;
 
 let compaction_snapshot_clock_refs decision =
@@ -871,17 +908,19 @@ let compaction_snapshots_json ~config ~keeper_id ~limit =
     runtime_manifest_paths ~config ~keeper_id ~limit
   in
   let rows_and_errors =
-    List.map (read_runtime_manifest_tail_rows ~base_dir:manifest_base_dir) manifest_paths
+    List.map (read_runtime_manifest_rows ~base_dir:manifest_base_dir) manifest_paths
   in
-  let manifest_rows = List.map (fun (rows, _, _) -> rows) rows_and_errors |> List.concat in
+  let manifest_rows =
+    rows_and_errors
+    |> List.rev
+    |> List.map fst
+    |> List.concat
+  in
   let manifest_read_errors =
     path_read_errors
-    @ (List.map (fun (_, read_errors, _) -> read_errors) rows_and_errors |> List.concat)
+    @ (List.map snd rows_and_errors |> List.concat)
   in
-  let tail_scan_truncated =
-    List.exists (fun (_, _, scan_truncated) -> scan_truncated) rows_and_errors
-  in
-  let scan_truncated = path_scan_truncated || tail_scan_truncated in
+  let scan_truncated = path_scan_truncated in
   let manifest_items =
     let manifest_rows = List.mapi (fun index row -> index, row) manifest_rows in
     manifest_rows
@@ -1648,6 +1687,24 @@ let handle_keeper_get_subroutes state req request reqd =
                 ("coverage_gaps", `List coverage_gaps);
                 ("entries", `List entries);
               ])
+      in
+      Http.Response.json_value ~compress:true ~request:req json reqd
+  else if ends_with "/waiting-inventory" then
+    let name = extract_name "/waiting-inventory" in
+    if String.length name = 0 then
+      respond_error reqd "keeper name is required"
+    else if not (Keeper_config.validate_name name) then
+      Http.Response.json_value ~status:`Bad_request
+        (`Assoc
+           [ ("error", `String (Printf.sprintf "invalid keeper name: %s" name)) ])
+        reqd
+    else
+      let config = Mcp_server.workspace_config state in
+      let json =
+        Domain_pool_ref.submit_io_or_inline (fun () ->
+          Server_keeper_waiting_inventory.dashboard_json_for_keeper
+            config
+            ~keeper_name:name)
       in
       Http.Response.json_value ~compress:true ~request:req json reqd
   else if ends_with "/feedback" then

--- a/lib/server_keeper_waiting_inventory.ml
+++ b/lib/server_keeper_waiting_inventory.ml
@@ -950,10 +950,12 @@ let pending_approval_read_error error =
   }
 ;;
 
-let dashboard_json_with_pending_reader ~read_pending config =
+let dashboard_json_with_pending_reader_scoped ?keeper_name ~read_pending config =
   let now = Time_compat.now () in
   let keeper_names, keeper_name_read_error_rows =
-    keeper_names_or_error_rows config
+    match keeper_name with
+    | Some name -> [ name ], []
+    | None -> keeper_names_or_error_rows config
   in
   let pending_approvals, pending_approval_state, pending_approval_read_error_rows =
     match read_pending ~base_path:config.Workspace.base_path with
@@ -1016,7 +1018,9 @@ let dashboard_json_with_pending_reader ~read_pending config =
             | Busy | Waiting | Deferred -> count + 1)
          0
   in
-  record_metrics ~now ~per_keeper ~global_rows;
+  (match keeper_name with
+   | None -> record_metrics ~now ~per_keeper ~global_rows
+   | Some _ -> ());
   `Assoc
     [ "schema", `String "masc.dashboard.keeper_waiting_inventory.v3"
     ; "source", `String "server_keeper_waiting_inventory"
@@ -1041,8 +1045,19 @@ let dashboard_json_with_pending_reader ~read_pending config =
     ]
 ;;
 
+let dashboard_json_with_pending_reader ~read_pending config =
+  dashboard_json_with_pending_reader_scoped ~read_pending config
+;;
+
 let dashboard_json config =
   dashboard_json_with_pending_reader
+    ~read_pending:Keeper_approval_queue.list_pending_entries_for_workspace
+    config
+;;
+
+let dashboard_json_for_keeper config ~keeper_name =
+  dashboard_json_with_pending_reader_scoped
+    ~keeper_name
     ~read_pending:Keeper_approval_queue.list_pending_entries_for_workspace
     config
 ;;

--- a/lib/server_keeper_waiting_inventory.mli
+++ b/lib/server_keeper_waiting_inventory.mli
@@ -4,6 +4,11 @@ val dashboard_json : Workspace.config -> Yojson.Safe.t
     join MASC stores, but it does not add a dashboard dependency to lower
     keeper/runtime libraries. *)
 
+val dashboard_json_for_keeper :
+  Workspace.config -> keeper_name:string -> Yojson.Safe.t
+(** The same typed projection narrowed to one keeper for latency-sensitive
+    detail surfaces. It does not overwrite fleet-wide waiting metrics. *)
+
 module For_testing : sig
   val dashboard_json_with_pending_reader :
     read_pending:

--- a/test/test_keeper_waiting_inventory.ml
+++ b/test/test_keeper_waiting_inventory.ml
@@ -249,6 +249,38 @@ let test_event_queue_pending_is_visible () =
      | rows -> failf "expected one queue row, got %d" (List.length rows))
 ;;
 
+let test_keeper_scoped_projection_excludes_other_keepers () =
+  with_workspace
+  @@ fun config ->
+  let requested_keeper = "waiting-inventory-requested" in
+  let other_keeper = "waiting-inventory-other" in
+  ensure_keeper config requested_keeper;
+  ensure_keeper config other_keeper;
+  List.iter
+    (fun keeper_name ->
+       Keeper_event_queue_persistence.persist
+         ~base_path:config.Workspace_utils_backend_setup.base_path
+         ~keeper_name
+         (queue_of_list
+            [ stimulus
+                ~post_id:("pending-" ^ keeper_name)
+                ~arrived_at:100.0
+                Keeper_event_queue.Bootstrap
+            ]))
+    [ requested_keeper; other_keeper ];
+  let json =
+    Server_keeper_waiting_inventory.dashboard_json_for_keeper
+      config
+      ~keeper_name:requested_keeper
+  in
+  check int "one scoped keeper" 1 (json_int_member "keeper_count" json);
+  check int "one scoped row" 1 (json_int_member "row_count" json);
+  check bool "requested keeper present" true
+    (Option.is_some (find_keeper json requested_keeper));
+  check bool "other keeper absent" true
+    (Option.is_none (find_keeper json other_keeper))
+;;
+
 let test_manual_compaction_waiting_row_has_typed_producer () =
   with_workspace
   @@ fun config ->
@@ -1015,6 +1047,8 @@ let () =
             test_event_queue_pending_is_visible
         ; test_case "manual compaction producer is typed" `Quick
             test_manual_compaction_waiting_row_has_typed_producer
+        ; test_case "keeper-scoped projection excludes other keepers" `Quick
+            test_keeper_scoped_projection_excludes_other_keepers
         ; test_case "chat queue pending rows are visible" `Quick
             test_chat_queue_pending_rows_are_visible
         ; test_case "chat queue recovery-required row is visible" `Quick

--- a/test/test_server_dashboard_http_keeper_api_trace.ml
+++ b/test/test_server_dashboard_http_keeper_api_trace.ml
@@ -3,6 +3,7 @@ open Masc
 module Trace = Server_dashboard_http_keeper_api_trace
 module Types = Server_dashboard_http_keeper_api_types
 module Checkpoints = Server_dashboard_http_keeper_api_checkpoints
+module Keeper_api = Server_dashboard_http_keeper_api
 module Runtime_lens_scan = Server_dashboard_http_keeper_runtime_manifest_scan
 module Runtime_lens_swimlane = Server_dashboard_http_keeper_runtime_lens_swimlane
 module T = Trajectory
@@ -544,6 +545,89 @@ let test_checkpoint_inventory_projects_missing_current () =
     (json |> member "current_error" = `Null)
 ;;
 
+let test_compaction_snapshots_read_rotated_manifest_beyond_old_tail () =
+  with_temp_dir @@ fun dir ->
+  let config = Workspace.default_config dir in
+  let keeper_name = "compaction-rotated" in
+  let trace_id = "trace-compaction-rotated" in
+  let active_path =
+    Keeper_runtime_manifest.path_for_trace config ~keeper_name ~trace_id
+  in
+  let rotated_path = active_path ^ ".1" in
+  Fs_compat.mkdir_p (Filename.dirname active_path);
+  let context_compacted =
+    let exact_evidence =
+      `Assoc
+        [ "slot_id", `String "slot-7"
+        ; "call_id", `String "call-7"
+        ; "target_identity_fingerprint", `String "target-7"
+        ; "catalog_generation_fingerprint", `String "catalog-7"
+        ; "catalog_evidence_sha256", `String "catalog-sha-7"
+        ; "plan_fingerprint", `String "plan-7"
+        ; "receipt_request_body_sha256", `String "request-sha-7"
+        ; "before_checkpoint_bytes", `Int 4096
+        ; "after_checkpoint_bytes", `Int 1024
+        ; "before_message_count", `Int 12
+        ; "after_message_count", `Int 4
+        ; "summarized_message_count", `Int 4
+        ; "dropped_message_count", `Int 8
+        ; "before_tool_use_count", `Int 3
+        ; "after_tool_use_count", `Int 3
+        ; "before_tool_result_count", `Int 3
+        ; "after_tool_result_count", `Int 3
+        ]
+    in
+    Keeper_runtime_manifest.make
+      ~ts:"2026-08-05T00:00:00Z"
+      ~keeper_name
+      ~trace_id
+      ~keeper_turn_id:7
+      ~event:Keeper_runtime_manifest.Context_compacted
+      ~decision:
+        (Keeper_runtime_manifest.with_compaction_outcome
+           ~compaction_outcome:Keeper_runtime_manifest.Checkpoint_committed
+           (`Assoc
+             [ "before_tokens", `Int 1200
+             ; "after_tokens", `Int 400
+             ; "exact_evidence", exact_evidence
+             ]))
+      ()
+  in
+  let unrelated index =
+    Keeper_runtime_manifest.make
+      ~ts:(Printf.sprintf "2026-08-05T00:%02d:%02dZ" (index / 60) (index mod 60))
+      ~keeper_name
+      ~trace_id
+      ~keeper_turn_id:7
+      ~event:Keeper_runtime_manifest.Turn_started
+      ()
+  in
+  let rotated_rows =
+    context_compacted :: List.init 250 (fun index -> unrelated (index + 1))
+  in
+  let render rows =
+    rows
+    |> List.map (fun row ->
+      Keeper_runtime_manifest.to_json row |> Yojson.Safe.to_string)
+    |> String.concat "\n"
+    |> fun content -> content ^ "\n"
+  in
+  Fs_compat.save_file rotated_path (render rotated_rows);
+  Fs_compat.save_file active_path (render [ unrelated 251 ]);
+  Unix.utimes rotated_path 1.0 1.0;
+  Unix.utimes active_path 2.0 2.0;
+  let json =
+    Keeper_api.compaction_snapshots_json ~config ~keeper_id:keeper_name ~limit:25
+  in
+  let open Yojson.Safe.Util in
+  check int "rotated compaction is visible" 1 (json |> member "count" |> to_int);
+  check bool "complete segment scan is not truncated" false
+    (json |> member "scan_truncated" |> to_bool);
+  let item = json |> member "items" |> to_list |> List.hd in
+  check int "before token count" 1200 (item |> member "before_tokens" |> to_int);
+  check int "after token count" 400 (item |> member "after_tokens" |> to_int)
+;;
+
 let () =
   Eio_main.run @@ fun env ->
   Masc_test_deps.init_eio_clock env;
@@ -603,6 +687,12 @@ let () =
             "projects missing current without failing inventory"
             `Quick
             test_checkpoint_inventory_projects_missing_current
+        ] )
+    ; ( "compaction_snapshots"
+      , [ test_case
+            "reads rotated compaction beyond the old tail window"
+            `Quick
+            test_compaction_snapshots_read_rotated_manifest_beyond_old_tail
         ] )
     ]
 ;;

--- a/test/test_sse_external_sub.ml
+++ b/test/test_sse_external_sub.ml
@@ -73,6 +73,43 @@ let test_broadcast_notifies_external () =
             with Not_found -> false);
     Masc.Sse.unsubscribe_external "test-broadcast")
 
+let test_waiting_inventory_changed_wire_contract () =
+  setup ();
+  Eio_main.run (fun _env ->
+    Masc.Sse.subscribe_external
+      ~id:"test-waiting-inventory-changed"
+      ~callback:(fun ev -> received_events := ev :: !received_events)
+      ();
+    Masc.Keeper_waiting_inventory_broadcast.changed
+      ~keeper_name:"kidsnote"
+      ~source:Event_queue;
+    Alcotest.(check int) "received invalidation" 1 (List.length !received_events);
+    let frame = List.hd !received_events in
+    let payload =
+      match Masc.Sse.data_payload_of_frame frame with
+      | Ok payload -> Yojson.Safe.from_string payload
+      | Error Masc.Sse.Missing_data_payload ->
+        Alcotest.fail "waiting inventory invalidation has no SSE data payload"
+    in
+    let open Yojson.Safe.Util in
+    Alcotest.(check string)
+      "event type"
+      "keeper_waiting_inventory_changed"
+      (payload |> member "type" |> to_string);
+    Alcotest.(check string)
+      "keeper name"
+      "kidsnote"
+      (payload |> member "keeper_name" |> to_string);
+    Alcotest.(check string)
+      "queue kind"
+      "event_queue"
+      (payload |> member "queue_kind" |> to_string);
+    Alcotest.(check bool)
+      "revision ID is absent"
+      true
+      (payload |> member "revision" = `Null);
+    Masc.Sse.unsubscribe_external "test-waiting-inventory-changed")
+
 let test_broadcast_skips_after_unsubscribe () =
   setup ();
   Eio_main.run (fun _env ->
@@ -282,6 +319,8 @@ let () =
     ("broadcast", [
       Alcotest.test_case "broadcast notifies external" `Quick
         test_broadcast_notifies_external;
+      Alcotest.test_case "waiting inventory invalidation wire contract" `Quick
+        test_waiting_inventory_changed_wire_contract;
       Alcotest.test_case "skips after unsubscribe" `Quick
         test_broadcast_skips_after_unsubscribe;
       Alcotest.test_case "error does not crash broadcast" `Quick


### PR DESCRIPTION
## What changed

- emit one typed `keeper_waiting_inventory_changed` invalidation after durable chat or autonomous event queue mutations
- refresh only the visible Keeper's waiting inventory over WebSocket invalidation, with the 15-second timer retained only for missed-event verification and focus recovery
- replace raw Lane vocabulary with clear queue state, source, and next-action labels while preserving server values for diagnostics
- gate Admin-only queue controls and chat receipt reconciliation for Worker dashboard sessions
- wait through the exact dev-token warm-up response and preserve a manually entered operator token
- make the Vite WebSocket and MCP proxies preserve the backend server authority
- read numeric runtime-manifest rotation segments for compaction snapshots, remove the obsolete 200-line tail knob, and keep the scan bounded to 64 MiB
- mount the compaction inspector directly so its request and diagnostic state are visible immediately

## Root cause

The Keeper detail Lane had no queue-wide push contract. It depended on periodically reloading the fleet-wide tools projection, so newly committed autonomous events and chat receipts were invisible until a later poll. The loopback dev-token endpoint's exact `initializing` response was also treated as an invalid token response, preventing authenticated dashboard transports during server warm-up.

Compaction history independently excluded `*.jsonl.<n>` rotation segments and inspected only the last 200 rows of active manifests. A real committed Rondo compaction was therefore present durably but could never appear in the inspector.

## Impact

The right-side Lane now converges from authoritative queue mutations without reconstructing lifecycle state in the browser. Operators can distinguish current work, queued autonomous stimuli, chat work, schedules, approvals, and external waits. Historical committed compactions in retained rotation segments become visible, and unavailable Admin controls no longer issue repeated 403 requests from Worker sessions.

## Local verification

- `pnpm exec tsc --noEmit --pretty false`
- focused Vitest: 11 files, 428 tests passed
- `pnpm run build`
- `ocamlformat --check` on all touched OCaml interfaces, implementations, and tests
- `ocamlc -stop-after parsing` on all touched OCaml interfaces, implementations, and tests
- focused OCaml link completed before the final main rebase: `lib/masc.cmxa` plus the three touched test executables
- focused regression executables after rebase: waiting inventory 18/18, SSE broadcast 5/5, compaction snapshots 1/1
- env-knob catalog regenerated from `lib/config/env_config_*.ml`; no drift remains
- `git diff --check`
- Playwright browser proof covered the Lane rendering, WebSocket handshake, and immediate compaction overlay. The new keeper-scoped endpoint used a fixture because the running backend predated this branch.

## Self-review and remaining proof

- queue bursts are coalesced for 800 ms, but every refresh rereads the authoritative Keeper-scoped projection
- compaction manifest hydration is capped at 64 MiB and reports `scan_truncated` instead of claiming completeness beyond the bound
- the live `8935` backend was stopped during rebuild, so deployed end-to-end proof remains pending
- the final rebased head could not reacquire the machine-wide Dune wrapper lock; exact-head OCaml compilation is delegated to PR CI, while parsing and the focused regression executables passed locally

RFC-WAIVED: this implements the existing waiting-inventory and connector queue contract; it does not change a gated credential, identity, sandbox, or operator-control subsystem.

WORKAROUND-WAIVED: the 800 ms UI coalescing only batches duplicate invalidations; it never suppresses a durable stimulus or substitutes for the authoritative queue reread.
