### PR TITLE
refactor(dashboard): keepers payload 이 쓰는 방향만 생성

### DIFF
--- a/lib/dashboard_api_types/keepers.ml
+++ b/lib/dashboard_api_types/keepers.ml
@@ -18,7 +18,7 @@ type keeper_status =
   | Live
   | Warn
   | Dead
-[@@deriving yojson]
+[@@deriving to_yojson]
 
 (** One tool-span in a keeper's cycle, positioned as a percentage of the
     last-60-min window. *)
@@ -28,14 +28,14 @@ type keeper_lane_frame = {
   width : int;                  (* width %, 0..100 *)
   label : string;
 }
-[@@deriving yojson { strict = false }]
+[@@deriving to_yojson]
 
 (** One sample on the 60-min context-pressure polyline. *)
 type keeper_ctx_sample = {
   t_minus_min : int;            (* minutes ago, 0..60 *)
   ctx_pct : int;                (* 0..100 *)
 }
-[@@deriving yojson { strict = false }]
+[@@deriving to_yojson]
 
 (** Total run-state classification (#16, 38-bug campaign PR-5). Mirrors
     [Keeper_composite_observer.run_state]; see .mli for why this library
@@ -44,7 +44,7 @@ type keeper_run_state_kind =
   | In_turn
   | Waiting
   | Suspended
-[@@deriving yojson]
+[@@deriving to_yojson]
 
 (** Per-kind fields are [None] / [[]] when not applicable to [kind]. *)
 type keeper_run_state = {
@@ -57,7 +57,7 @@ type keeper_run_state = {
   skip_reasons : string list;     [@default []]
   phase : string option;          [@default None]
 }
-[@@deriving yojson { strict = false }]
+[@@deriving to_yojson]
 
 (** Per-keeper summary. *)
 type keeper = {
@@ -74,7 +74,7 @@ type keeper = {
   ctx_history : keeper_ctx_sample list;   [@default []]
   run_state : keeper_run_state;
 }
-[@@deriving yojson { strict = false }]
+[@@deriving to_yojson]
 
 (** Top-level response. *)
 type response = {
@@ -83,4 +83,4 @@ type response = {
   workspace : string option;         [@default None]
   generated_at : string;        (* ISO-8601 UTC *)
 }
-[@@deriving yojson { strict = false }]
+[@@deriving to_yojson]

--- a/lib/dashboard_api_types/keepers.mli
+++ b/lib/dashboard_api_types/keepers.mli
@@ -11,7 +11,6 @@ type keeper_status =
   | Warn
   | Dead
 
-val keeper_status_of_yojson : Yojson.Safe.t -> keeper_status Ppx_deriving_yojson_runtime.error_or
 val keeper_status_to_yojson : keeper_status -> Yojson.Safe.t
 
 (** One tool-span in a keeper's cycle, positioned as a percentage of the
@@ -23,7 +22,6 @@ type keeper_lane_frame = {
   label : string;
 }
 
-val keeper_lane_frame_of_yojson : Yojson.Safe.t -> keeper_lane_frame Ppx_deriving_yojson_runtime.error_or
 val keeper_lane_frame_to_yojson : keeper_lane_frame -> Yojson.Safe.t
 
 (** One sample on the 60-min context-pressure polyline. *)
@@ -32,7 +30,6 @@ type keeper_ctx_sample = {
   ctx_pct : int;       (** 0..100 *)
 }
 
-val keeper_ctx_sample_of_yojson : Yojson.Safe.t -> keeper_ctx_sample Ppx_deriving_yojson_runtime.error_or
 val keeper_ctx_sample_to_yojson : keeper_ctx_sample -> Yojson.Safe.t
 
 (** Total run-state classification (#16, 38-bug campaign PR-5). Mirrors
@@ -45,7 +42,6 @@ type keeper_run_state_kind =
   | Waiting
   | Suspended
 
-val keeper_run_state_kind_of_yojson : Yojson.Safe.t -> keeper_run_state_kind Ppx_deriving_yojson_runtime.error_or
 val keeper_run_state_kind_to_yojson : keeper_run_state_kind -> Yojson.Safe.t
 
 (** Per-kind fields are [None] / [[]] when not applicable to [kind] — e.g.
@@ -61,7 +57,6 @@ type keeper_run_state = {
   phase : string option;
 }
 
-val keeper_run_state_of_yojson : Yojson.Safe.t -> keeper_run_state Ppx_deriving_yojson_runtime.error_or
 val keeper_run_state_to_yojson : keeper_run_state -> Yojson.Safe.t
 
 (** Per-keeper summary. *)
@@ -80,7 +75,6 @@ type keeper = {
   run_state : keeper_run_state;
 }
 
-val keeper_of_yojson : Yojson.Safe.t -> keeper Ppx_deriving_yojson_runtime.error_or
 val keeper_to_yojson : keeper -> Yojson.Safe.t
 
 (** Top-level response. *)
@@ -91,5 +85,4 @@ type response = {
   generated_at : string;       (** ISO-8601 UTC *)
 }
 
-val response_of_yojson : Yojson.Safe.t -> response Ppx_deriving_yojson_runtime.error_or
 val response_to_yojson : response -> Yojson.Safe.t


### PR DESCRIPTION
## 대상

`lib/dashboard_api_types/keepers.ml` 이 와이어 타입 7개 전부에 `[@@deriving yojson]` 을 걸어 **양방향**을 생성한다. 쓰이는 것은 한 방향뿐이다.

| 심볼 | 호출자 |
|---|---|
| `response_to_yojson` | `server_routes_http_pages.ml:494` |
| `keeper_status_of_yojson` · `keeper_lane_frame_of_yojson` · `keeper_ctx_sample_of_yojson` · `keeper_run_state_kind_of_yojson` · `keeper_run_state_of_yojson` · `keeper_of_yojson` · `response_of_yojson` | **없음** |

## 파싱하는 쪽이 이 코드를 안 쓴다

클라이언트가 스스로 밝힌다 — `dashboard_bonsai/src/keepers_types.ml`:

```
Mirror of [lib/dashboard_api_types/keepers.ml] (the server SSOT), parsed
manually with Yojson.Safe.Util to keep the client ppx surface small.
Server uses [ppx_deriving_yojson] — client does not carry that ppx into
js_of_ocaml compilation.
```

`dashboard_bonsai/src/dune` 는 `masc_dashboard_api_types` 를 링크하지 않는다. 서버는 직렬화만 하고, 클라이언트는 손으로 파싱한다. 생성된 파서 7개는 양쪽 어디에도 소비자가 없다.

## 변경

```diff
-[@@deriving yojson { strict = false }]
+[@@deriving to_yojson]
```

7개 타입에 동일. `.mli` 에서 `*_of_yojson` val 7줄 삭제. `{ strict = false }` 는 파싱 측 옵션이라 같이 사라진다.

## 와이어가 바뀌지 않았음을 실측

이 payload 를 검증하는 테스트가 없어서 직접 쟀다. 필드를 채운 `response` 값을 `response_to_yojson` 으로 직렬화해 출력하는 probe 실행파일을 만들고, 변경 전/후 각각 돌렸다.

```
BEFORE 395 bytes
AFTER  395 bytes
diff   차이 없음 (바이트 단위 일치)
```

probe 는 커밋하지 않았다.

`[@default None]` / `[@default []]` 는 **남겼다.** 출력에서 기본값과 같은 필드를 생략하는 동작이 직렬화 측에도 걸려 있다 — 위 출력에서 `last_tool` 이 빠져 있는 것이 그 증거다. 지웠다면 와이어가 변한다.

## 검증

| 항목 | 결과 |
|---|---|
| `dune build --root . @check` | EXIT=0 |
| 와이어 바이트 비교 | 395 = 395, diff 없음 |
| `scripts/check-doc-truth.sh` | EXIT=0 |
| `dune build @fmt` | 변경 파일에 diff 없음 |

14줄 삭제, 7줄 추가(deriving 어노테이션 교체).
