### PR TITLE
fix(workspace): 아무것도 쓰지 않은 하트비트가 성공을 보고하던 문제

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop_refresh_work.ml
+++ b/lib/keeper/keeper_heartbeat_loop_refresh_work.ml
@@ -36,9 +36,18 @@ let refresh_work_as_heartbeat
   then (
     let hb_ok =
       try
-        (* fire-and-forget: heartbeat persistence is enough; loop records only success/failure. *)
-        ignore (Workspace.heartbeat ctx.config ~agent_name:meta_after_proactive.agent_name);
-        true
+        (* Only a written last_seen is evidence the workspace took the write.
+           A missing or unreadable agent file returns without raising, and
+           counting that as a live workspace is what let the freshness clock
+           advance while nothing was being persisted. *)
+        match Workspace.heartbeat ctx.config ~agent_name:meta_after_proactive.agent_name with
+        | Workspace.Heartbeat_updated _ -> true
+        | Workspace.Agent_not_found _ | Workspace.Agent_file_invalid _ as outcome ->
+          Log.Keeper.debug
+            "heartbeat did not persist for %s: %s"
+            meta_after_proactive.name
+            (Workspace.heartbeat_message outcome);
+          false
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn ->

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -237,7 +237,9 @@ let execute_tool_eio
             if workspace_init_cached
             then (
               try
-                let (_ : string) = Workspace.heartbeat config ~agent_name in
+                let (_ : Workspace.heartbeat_outcome) =
+                  Workspace.heartbeat config ~agent_name
+                in
                 ()
               with
               | Eio.Cancel.Cancelled _ as exn -> raise exn

--- a/lib/tool_workspace.ml
+++ b/lib/tool_workspace.ml
@@ -568,18 +568,11 @@ let state_to_json st =
     [assertion_kind_to_string] / [assertion_kind_of_string_lenient]
     aren't updated. Same shape as #8546 / #8601 / #8592. *)
 let handle_heartbeat ~tool_name ~start_time ctx _args =
-  let message = Workspace.heartbeat ctx.config ~agent_name:ctx.agent_name in
-  (* Workspace.heartbeat returns "..." on failure (agent not found, invalid file) *)
-  let success =
-    not
-      (String.length message >= 3
-       && Char.code message.[0] = 0xe2
-       && Char.code message.[1] = 0x9a
-       && Char.code message.[2] = 0xa0)
-  in
-  if success
-  then Tool_result.ok ~tool_name ~start_time message
-  else
+  let outcome = Workspace.heartbeat ctx.config ~agent_name:ctx.agent_name in
+  let message = Workspace.heartbeat_message outcome in
+  match outcome with
+  | Workspace.Heartbeat_updated _ -> Tool_result.ok ~tool_name ~start_time message
+  | Workspace.Agent_not_found _ | Workspace.Agent_file_invalid _ ->
     (* RFC-0189: heartbeat failure stems from agent-state issues
        ("agent not found", "invalid file") that the caller can
        resolve (bind the session, refresh credentials).

--- a/lib/workspace/workspace_gc.ml
+++ b/lib/workspace/workspace_gc.ml
@@ -17,6 +17,16 @@ open Workspace_task_id
 
 (* heartbeat_in_workspace removed — workspaces are flattened (#4638). Use heartbeat. *)
 
+type heartbeat_outcome =
+  | Heartbeat_updated of string
+  | Agent_file_invalid of string
+  | Agent_not_found of string
+
+let heartbeat_message = function
+  | Heartbeat_updated actual_name -> Printf.sprintf "%s heartbeat updated" actual_name
+  | Agent_file_invalid actual_name -> Printf.sprintf "Invalid agent file for %s" actual_name
+  | Agent_not_found agent_name -> Printf.sprintf "Agent %s not found" agent_name
+
 let heartbeat config ~agent_name =
   ensure_initialized config;
   let actual_name = resolve_agent_name config agent_name in
@@ -28,13 +38,13 @@ let heartbeat config ~agent_name =
       | Ok agent ->
           let updated = { agent with last_seen = now_iso () } in
           write_json config agent_file (agent_to_yojson updated);
-          Printf.sprintf "%s heartbeat updated" actual_name
+          Heartbeat_updated actual_name
       | Error e ->
           Log.Workspace.debug "heartbeat: invalid agent JSON for %s: %s" actual_name e;
-          Printf.sprintf "Invalid agent file for %s" actual_name
+          Agent_file_invalid actual_name
     )
   end else
-    Printf.sprintf "Agent %s not found" agent_name
+    Agent_not_found agent_name
 
 (** Explicit age-based garbage collection. The caller must choose the retention
     horizon; this layer has no default retention policy. Agent lifecycle is not

--- a/lib/workspace/workspace_gc.mli
+++ b/lib/workspace/workspace_gc.mli
@@ -12,14 +12,30 @@
       startup; this module does not depend on the board layer
       directly. *)
 
+(** What a heartbeat did. Only [Heartbeat_updated] means the agent's
+    [last_seen] was written; the other two mean the call did nothing and are
+    not evidence that the workspace is writable.
+
+    This was a status string, and both readers got it wrong. The MCP handler
+    tested the first three bytes for a warning sign no branch here ever
+    emits — so every heartbeat reported success. The keeper's
+    work-as-heartbeat refresher treated any call that did not raise as a live
+    workspace, which a missing agent file satisfies. *)
+type heartbeat_outcome =
+  | Heartbeat_updated of string  (** resolved agent name *)
+  | Agent_file_invalid of string  (** resolved agent name *)
+  | Agent_not_found of string  (** requested agent name *)
+
+(** The status string the outcome used to be, byte for byte. *)
+val heartbeat_message : heartbeat_outcome -> string
+
 (** Update the agent's [last_seen] timestamp on disk.
 
     [agent_name] is resolved through {!Workspace_utils.resolve_agent_name}
-    so canonical/alias forms both work.  Returns a human-readable
-    status string (heartbeat updated / agent missing / file invalid).
-    The agent file is mutated under [with_file_lock]. *)
+    so canonical/alias forms both work. The agent file is mutated under
+    [with_file_lock]. *)
 val heartbeat :
-  Workspace_utils_backend_setup.config -> agent_name:string -> string
+  Workspace_utils_backend_setup.config -> agent_name:string -> heartbeat_outcome
 
 (** Run the explicit workspace garbage-collection pass. [days] has no default:
     the caller owns the retention decision rather than inheriting a fixed

--- a/test/dune
+++ b/test/dune
@@ -1948,6 +1948,8 @@
 
 (include stanzas/test_keeper_approval_queue.inc)
 
+(include stanzas/test_workspace_heartbeat_outcome.inc)
+
 (include stanzas/test_keeper_approval_resolved_history.inc)
 
 (include stanzas/test_keeper_toml_parser.inc)

--- a/test/stanzas/test_workspace_heartbeat_outcome.inc
+++ b/test/stanzas/test_workspace_heartbeat_outcome.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_workspace_heartbeat_outcome)
+ (modules test_workspace_heartbeat_outcome)
+ (libraries alcotest masc masc_test_deps eio_main unix))

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -756,8 +756,11 @@ let test_heartbeat_updates_lastseen () =
     let _ = Workspace.bind_session config ~agent_name:"gemini" ~capabilities:[] () in
 
     (* Send heartbeat *)
-    let result = Workspace.heartbeat config ~agent_name:"gemini" in
-    Alcotest.(check bool) "heartbeat success" true (contains_heartbeat result)
+    match Workspace.heartbeat config ~agent_name:"gemini" with
+    | Workspace.Heartbeat_updated _ -> ()
+    | outcome ->
+      Alcotest.failf "expected an update, got %S"
+        (Workspace.heartbeat_message outcome)
   )
 
 let test_is_agent_session_bound_after_default_join () =
@@ -943,8 +946,11 @@ let test_read_backlog_r_reports_parse_error_when_recovery_is_also_invalid () =
 let test_heartbeat_nonexistent_agent () =
   with_test_env (fun config ->
     (* Heartbeat for non-bound agent *)
-    let result = Workspace.heartbeat config ~agent_name:"nonexistent" in
-    Alcotest.(check bool) "heartbeat for nonexistent" true (contains_warning result)
+    match Workspace.heartbeat config ~agent_name:"nonexistent" with
+    | Workspace.Agent_not_found _ -> ()
+    | outcome ->
+      Alcotest.failf "expected the agent to be missing, got %S"
+        (Workspace.heartbeat_message outcome)
   )
 
 (* test_get_agents_status removed (2026-06-09): get_agents_status deleted with

--- a/test/test_workspace_heartbeat_outcome.ml
+++ b/test/test_workspace_heartbeat_outcome.ml
@@ -1,0 +1,116 @@
+(** A heartbeat that wrote nothing used to report success.
+
+    [Workspace.heartbeat] returned a status string with three spellings —
+    "<agent> heartbeat updated", "Agent <agent> not found", "Invalid agent file
+    for <agent>" — and both readers decided success without parsing it.
+
+    The MCP handler tested the first three bytes of the message against the
+    UTF-8 encoding of a warning sign. No branch of [heartbeat] emits one, so
+    the test could not fail and [masc_heartbeat] answered [Tool_result.ok] for
+    an agent that does not exist.
+
+    The keeper's work-as-heartbeat refresher treated any call that did not
+    raise as proof that a session-bound workspace was writable, and a missing
+    agent file returns without raising. That is the value it stamps into
+    [last_successful_heartbeat_ts] and uses to reset [consecutive_failures].
+
+    These cases pin the outcome an unwritten heartbeat now reports, and that
+    the rendered message is unchanged. *)
+
+open Alcotest
+
+module Q = Masc.Workspace
+
+let with_workspace f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "heartbeat-outcome-%d" (Unix.getpid ()))
+  in
+  let rec rm path =
+    if Sys.file_exists path
+    then
+      if Sys.is_directory path
+      then (
+        Array.iter (fun e -> rm (Filename.concat path e)) (Sys.readdir path);
+        Sys.rmdir path)
+      else Sys.remove path
+  in
+  rm dir;
+  Unix.mkdir dir 0o755;
+  Unix.putenv "MASC_BASE_PATH" dir;
+  let config = Q.default_config dir in
+  let (_ : string) = Q.init config ~agent_name:(Some "claude") in
+  Fun.protect
+    ~finally:(fun () ->
+      let (_ : string) = Q.reset config in
+      rm dir)
+    (fun () -> f config)
+;;
+
+let outcome_name = function
+  | Q.Heartbeat_updated _ -> "Heartbeat_updated"
+  | Q.Agent_file_invalid _ -> "Agent_file_invalid"
+  | Q.Agent_not_found _ -> "Agent_not_found"
+;;
+
+(* The defect in one case: nothing was written, and the old readers called it
+   a success. *)
+let test_unknown_agent_is_not_an_update () =
+  with_workspace (fun config ->
+    let outcome = Q.heartbeat config ~agent_name:"no-such-agent" in
+    check string "outcome" "Agent_not_found" (outcome_name outcome))
+;;
+
+let test_registered_agent_updates () =
+  with_workspace (fun config ->
+    let (_ : string) = Q.bind_session config ~agent_name:"alpha" ~capabilities:[] () in
+    let outcome = Q.heartbeat config ~agent_name:"alpha" in
+    check string "outcome" "Heartbeat_updated" (outcome_name outcome))
+;;
+
+(* Callers that log the outcome keep the strings they had. *)
+let test_messages_are_unchanged () =
+  check string "not found" "Agent ghost not found"
+    (Q.heartbeat_message (Q.Agent_not_found "ghost"));
+  check string "invalid" "Invalid agent file for alpha"
+    (Q.heartbeat_message (Q.Agent_file_invalid "alpha"));
+  check string "updated" "alpha heartbeat updated"
+    (Q.heartbeat_message (Q.Heartbeat_updated "alpha"))
+;;
+
+(* None of the messages carries the warning-sign prefix the MCP handler used to
+   look for, which is why that test always passed. *)
+let test_no_message_carries_a_warning_prefix () =
+  List.iter
+    (fun outcome ->
+      let message = Q.heartbeat_message outcome in
+      check bool
+        (Printf.sprintf "%s has no warning prefix" (outcome_name outcome))
+        false
+        (String.length message >= 3
+         && Char.code message.[0] = 0xe2
+         && Char.code message.[1] = 0x9a
+         && Char.code message.[2] = 0xa0))
+    [ Q.Heartbeat_updated "alpha"
+    ; Q.Agent_file_invalid "alpha"
+    ; Q.Agent_not_found "ghost"
+    ]
+;;
+
+let () =
+  Alcotest.run
+    "Workspace heartbeat outcome"
+    [ ( "outcome"
+      , [ test_case "an unknown agent is not an update" `Quick
+            test_unknown_agent_is_not_an_update
+        ; test_case "a registered agent updates" `Quick test_registered_agent_updates
+        ] )
+    ; ( "rendering"
+      , [ test_case "messages are unchanged" `Quick test_messages_are_unchanged
+        ; test_case "no message carries a warning prefix" `Quick
+            test_no_message_carries_a_warning_prefix
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 증상

`Workspace.heartbeat` 는 상태 문자열을 돌려주고, **두 독자 모두 그걸 파싱하지 않고 성공을 판정했다.**

### 1. `masc_heartbeat` — 존재하지 않는 에이전트에도 성공을 보고

```ocaml
let success =
  not (String.length message >= 3
       && Char.code message.[0] = 0xe2
       && Char.code message.[1] = 0x9a
       && Char.code message.[2] = 0xa0)
```

경고 표시(⚠)의 UTF-8 바이트를 검사한다. `heartbeat` 의 세 반환 경로 중 **어느 것도 그걸 내지 않는다.**

| 반환값 | 옛 판정 |
|---|---|
| `"<agent> heartbeat updated"` | success |
| `"Agent <agent> not found"` | **success** |
| `"Invalid agent file for <agent>"` | **success** |

즉 판정식은 항상 참이었고, 에이전트 파일이 없거나 깨져도 `Tool_result.ok` 가 나갔다.

### 2. keeper work-as-heartbeat — 쓰이지 않은 하트비트를 생존 증거로 집계

```ocaml
let hb_ok =
  try
    ignore (Workspace.heartbeat ctx.config ~agent_name:...);
    true
  with ... -> false
```

**예외가 나지 않으면 참**이다. 에이전트 파일이 없으면 `heartbeat` 는 예외 없이 `"Agent X not found"` 를 돌려주므로 `hb_ok = true` 가 되고, `last_successful_heartbeat_ts` 가 갱신되고 `consecutive_failures` 가 0 으로 리셋된다.

모듈 docstring 은 이렇게 말한다 — *"we count any successful Workspace.heartbeat against any session-bound workspace as evidence that the keeper is alive"*. 실제로는 예외를 던지지 않은 호출을 센다. 아무것도 persist 되지 않는 동안 freshness 시계가 계속 전진한다.

## 수정

```ocaml
type heartbeat_outcome =
  | Heartbeat_updated of string   (* resolved agent name *)
  | Agent_file_invalid of string
  | Agent_not_found of string

val heartbeat_message : heartbeat_outcome -> string
```

`Heartbeat_updated` 만 `last_seen` 이 쓰였다는 뜻이다. `heartbeat_message` 는 **세 문자열을 바이트 단위로 그대로** 렌더링하므로 로그와 도구 출력은 변하지 않는다.

- MCP 핸들러: 바이트 검사 제거, outcome 으로 분기. `Agent_not_found` / `Agent_file_invalid` 는 기존 의도대로 `Workflow_rejection`
- keeper refresher: `Heartbeat_updated` 만 `hb_ok`. 나머지는 DEBUG 로그 후 실패 (per-workspace 실패를 DEBUG 로 두는 기존 정책 유지)

## 테스트

기존 workspace 케이스 2개도 자기 문자열 술어를 쓰고 있었다 — 하나는 레거시 하트 이모지 접두사나 `"heartbeat updated"` 부분 문자열, 다른 하나는 **생산자가 내지 않는 그 경고 표시**. 둘 다 outcome 매칭으로 바꿨다.

새 `test_workspace_heartbeat_outcome` 4/4:
- 없는 에이전트 → `Agent_not_found` (옛 코드에서는 성공이었다)
- 등록된 에이전트 → `Heartbeat_updated`
- 세 메시지가 바이트 단위로 동일
- **세 메시지 중 어느 것도 경고 접두사를 갖지 않음** — 옛 검사가 실패할 수 없었던 이유를 못 박는다

## 검증

- `dune build --root . @check` EXIT=0
- 새 테스트 4/4, `test_workspace_state_recovery` OK
- `test_workspace` / `test_work_as_heartbeat` 는 실패하지만 **origin/main 기준 베이스라인과 실패 집합이 완전히 동일**하다 (각각 12건 / 2건, `diff` 결과 없음). 실패 항목은 `board_admin` backlog 카운트와 `keepalive_config sleep_chunk default` 로 이 변경과 무관
- `scripts/check-doc-code-refs.sh`, `scripts/audit-keeper-tool-boundary-matrix.sh` PASS

RFC-WAIVED: 상태 문자열을 typed outcome 으로 바꿔 두 독자가 같은 판정을 하도록 만든다. `lib/keeper/credential_*`, `lib/repo_manager/`, `lib/operator/operator_control*`, keeper sandbox, dashboard credential component, hooks, workflow 문서 어느 것도 건드리지 않는다. 디스크에 쓰이는 내용과 렌더링되는 문자열은 변하지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
