### PR TITLE
fix(keeper): drain 로그 레벨을 outcome 에서 유도 (main L6 게이트 red 해소)

### DIFF
--- a/lib/keeper/keeper_board_attention_worker.ml
+++ b/lib/keeper/keeper_board_attention_worker.ml
@@ -1805,10 +1805,22 @@ let run
                  ~execute
              with
              | Ok outcome ->
-               Log.Keeper.info
-                 "board_attention_worker_drain keeper=%s outcome=%s"
-                 keeper_name
-                 (drain_outcome_label outcome);
+               (* The level comes from the outcome, not from the call site.
+                  [Retry_later] means the durable partition is still undrained
+                  and the same candidate is re-inspected on the next wake, so a
+                  worker that never reaches [Drained] is a backlog that grows
+                  with nothing above Info to show for it. *)
+               let level =
+                 match outcome with
+                 | Drained -> Log.Info
+                 | Retry_later _ -> Log.Warn
+               in
+               Log.Keeper.emit
+                 level
+                 (Printf.sprintf
+                    "board_attention_worker_drain keeper=%s outcome=%s"
+                    keeper_name
+                    (drain_outcome_label outcome));
                ignore
                  (apply_drain_rearm contention_rearms outcome
                   : rearm_schedule option);


### PR DESCRIPTION
## main red 해소

`Meta Guards` → `CI Failure Visibility` L6 게이트가 main 에서 실패 중이다.

```
FAIL  L6 (outcome-carrying line + static info): 1 > baseline=0
      lib/keeper/keeper_board_attention_worker.ml:1808: Log.Keeper.info
```

원인은 `#26974` 가 추가한 drain 로그다. L6 규칙(`docs/spec/18-log-severity-taxonomy.md` § 3.6): **outcome 을 담은 로그 라인은 레벨을 그 outcome 값에서 유도해야 하고, `Info` 를 하드코딩하면 안 된다.**

## 왜 스타일 문제가 아닌가

`drain_outcome` 은 두 값이다:

| 값 | 의미 |
|---|---|
| `Drained` | 이 워커가 집을 수 있는 root 를 전부 비웠다 |
| `Retry_later` | **durable partition 이 안 비워진 채로 남았고** 같은 candidate 를 다음 wake 에 다시 집는다 |

`Retry_later` 는 백로그가 쌓이는 조건 그 자체다. 두 값을 같은 `Info` 로 찍으면, 워커가 영영 `Drained` 에 도달하지 못하는 상태와 정상 배수가 로그에서 구별되지 않는다. `#26863` 은 이 상태에서 pending 766 건이 누적된 이슈다.

레벨을 outcome 에서 유도한다:

```ocaml
let level =
  match outcome with
  | Drained -> Log.Info
  | Retry_later _ -> Log.Warn
in
Log.Keeper.emit level (Printf.sprintf "board_attention_worker_drain keeper=%s outcome=%s" ...)
```

`Log.<M>.emit level (Printf.sprintf ...)` 형태는 이 저장소의 기존 관용구다 (`server_dashboard_http_keeper_api_lifecycle_post.ml:215`).

`Retry_later` 의 두 reason (`retry_claim_contended` / `retry_generation_changed`) 은 `drain_outcome_label` 이 그대로 유지하므로, WARN 한 줄에서 claim 경합과 generation 이동이 여전히 구별된다.

## 로컬 검증

```
scripts/ci/check-log-severity-anti-patterns.sh   수정 전 exit 1  →  수정 후 exit 0
  L6: FAIL 1 > baseline=0                        →  OK 0
  delta: -8                                      →  -9
dune build @check                                 exit 0
```

게이트 스크립트를 origin/main 에서 먼저 돌려 실패를 재현한 뒤 수정했다. 즉 이 게이트는 실패할 능력이 있음이 이 브랜치에서 확인됐다.

## 검증하지 않은 것

- 이 WARN 이 라이브에서 실제로 몇 번 찍히는지. 현재 돌고 있는 바이너리는 `#26974` 이전(빌드 19:34:23 vs 머지 19:35:19)이라 이 로그 자체가 아직 배포된 적이 없다.
- 워커가 왜 멈추는지는 이 PR 이 답하지 않는다. 이 PR 은 멈춤이 WARN 으로 보이게 만들 뿐이다 — 진단은 `#26863`.

RFC-WAIVED: 로그 레벨 한 곳을 outcome 에서 유도하도록 바꾼다. 동작 변화 없음, 계약 변화 없음, main red 해소.
