### PR TITLE
refactor(verification): 아무도 만들지 않는 검증 기준 3개 제거 (Contains/Not_contains/Schema_match)

### DIFF
--- a/lib/completion_authority_agent.ml
+++ b/lib/completion_authority_agent.ml
@@ -161,19 +161,9 @@ let required_string_list_field ~context name fields =
 let completion_contract_of_request
       (request : Verification.verification_request)
   =
-  let rec custom_criteria index acc = function
-    | [] -> Ok (List.rev acc)
-    | Verification.Custom description :: rest ->
-      custom_criteria (index + 1) (description :: acc) rest
-    | Verification.Schema_match _ :: _
-    | Verification.Contains _ :: _
-    | Verification.Not_contains _ :: _ ->
-      Error
-        (Printf.sprintf
-           "verification request criteria[%d] is not a persisted custom completion contract"
-           index)
+  let completion_contract =
+    List.map (fun (Verification.Custom description) -> description) request.criteria
   in
-  let* completion_contract = custom_criteria 0 [] request.criteria in
   let completion_contract =
     match completion_contract with
     | [] -> None

--- a/lib/dashboard/dashboard_verification.ml
+++ b/lib/dashboard/dashboard_verification.ml
@@ -23,14 +23,9 @@ let clamp_limit limit =
   else if l > max_limit then max_limit
   else l
 
-(** Criteria carry the "completion_contract" in their Custom text.
-    Non-Custom criteria (Contains, Schema_match, ...) are automated checks,
-    not contract text, so we skip them here. *)
+(** Criteria carry the "completion_contract" in their Custom text. *)
 let completion_contract_of_criteria (criteria : V.criterion list) : string list =
-  List.filter_map (function
-    | V.Custom text -> Some text
-    | V.Contains _ | V.Not_contains _ | V.Schema_match _ -> None
-  ) criteria
+  List.map (fun (V.Custom text) -> text) criteria
 
 (** Read one required current-schema evidence list. Empty arrays are valid;
     missing or malformed fields carry a public projection error. No legacy

--- a/lib/verification.ml
+++ b/lib/verification.ml
@@ -13,45 +13,28 @@
 
 open Result.Syntax
 
-(** Verification criteria *)
-type criterion =
-  | Schema_match of Yojson.Safe.t   (** Output matches JSON schema *)
-  | Contains of string              (** Output must contain string *)
-  | Not_contains of string          (** Output must not contain string *)
-  | Custom of string                (** Natural language criterion for verifier *)
+(** A verification criterion. One constructor, because one is what is
+    produced: [Verification_protocol.submit_request_spec] builds the list with
+    [List.map (fun s -> Custom s)] over the task's completion contract, and
+    [Completion_authority_agent.completion_contract_of_request] accepts only
+    [Custom].
+
+    Three more used to sit here — [Schema_match], [Contains] and
+    [Not_contains]. Nothing ever constructed them; their only appearance
+    outside this module was the arm that rejected them with "criteria[i] is not
+    a persisted custom completion contract". Verifying a deliverable by testing
+    whether its text contains a substring was never wired, and the wire tag is
+    kept so the JSON shape does not change. *)
+type criterion = Custom of string  (** Natural-language criterion for a verifier *)
 [@@deriving show, eq]
 
 let criterion_to_yojson = function
-  | Schema_match schema ->
-      `Assoc [("type", `String "schema_match"); ("schema", schema)]
-  | Contains s ->
-      `Assoc [("type", `String "contains"); ("value", `String s)]
-  | Not_contains s ->
-      `Assoc [("type", `String "not_contains"); ("value", `String s)]
   | Custom s ->
       `Assoc [("type", `String "custom"); ("description", `String s)]
 
 let criterion_of_yojson = function
   | `Assoc fields ->
       (match List.assoc_opt "type" fields with
-       | Some (`String "schema_match") ->
-           (match List.assoc_opt "schema" fields with
-            | Some schema -> Ok (Schema_match schema)
-            | None -> Error "schema_match requires 'schema' field")
-       | Some (`String "contains") ->
-           let* value =
-             match List.assoc_opt "value" fields with
-             | Some (`String s) -> Ok s
-             | _ -> Error "contains requires 'value' string field"
-           in
-           Ok (Contains value)
-       | Some (`String "not_contains") ->
-           let* value =
-             match List.assoc_opt "value" fields with
-             | Some (`String s) -> Ok s
-             | _ -> Error "not_contains requires 'value' string field"
-           in
-           Ok (Not_contains value)
        | Some (`String "custom") ->
            let* description =
              match List.assoc_opt "description" fields with

--- a/lib/verification.mli
+++ b/lib/verification.mli
@@ -5,11 +5,10 @@
 
 (** {1 Types} *)
 
-type criterion =
-  | Schema_match of Yojson.Safe.t
-  | Contains of string
-  | Not_contains of string
-  | Custom of string
+(** One constructor, because one is what is produced: request criteria are
+    built as [Custom] over the task's completion contract, and the completion
+    authority accepts only [Custom]. The wire tag stays ["custom"]. *)
+type criterion = Custom of string
 
 val show_criterion : criterion -> string
 val equal_criterion : criterion -> criterion -> bool

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -116,12 +116,7 @@ let test_rejected_verdict_event_preserves_wire_type () =
 (* --- Criterion tests --- *)
 
 let test_criterion_roundtrip () =
-  let criteria = [
-    V.Schema_match (`Assoc [("type", `String "string")]);
-    V.Contains "hello";
-    V.Not_contains "error";
-    V.Custom "output should be helpful";
-  ] in
+  let criteria = [ V.Custom "output should be helpful"; V.Custom "" ] in
   List.iter (fun c ->
     let json = V.criterion_to_yojson c in
     match V.criterion_of_yojson json with
@@ -136,7 +131,14 @@ let test_criterion_of_yojson_errors () =
     (`String "not an object", "not object");
     (`Assoc [], "missing type");
     (`Assoc [("type", `String "banana")], "unknown type");
-    (`Assoc [("type", `String "contains")], "contains missing value");
+    (* The three criteria that no producer ever built -- a substring check, its
+       negation and a schema match -- are gone. A persisted request naming one
+       is now rejected at the parse instead of loading and being refused by the
+       completion authority. *)
+    (`Assoc [("type", `String "contains"); ("value", `String "hello")], "contains");
+    (`Assoc [("type", `String "not_contains"); ("value", `String "err")], "not_contains");
+    (`Assoc [("type", `String "schema_match"); ("schema", `Assoc [])], "schema_match");
+    (`Assoc [("type", `String "custom")], "custom missing description");
   ] in
   List.iter (fun (json, label) ->
     match V.criterion_of_yojson json with
@@ -1062,7 +1064,7 @@ let test_raw_workspace_submission_notifies_once () =
 let test_create_and_load () =
   with_temp_dir (fun base_path ->
     match V.create_request ~base_path ~task_id:"task-1"
-        ~output:(`String "result") ~criteria:[V.Contains "result"]
+        ~output:(`String "result") ~criteria:[V.Custom "result"]
         ~worker:"claude" () with
     | Error e -> Alcotest.fail e
     | Ok req ->
@@ -1083,7 +1085,7 @@ let test_create_and_load () =
 let test_delete_request () =
   with_temp_dir (fun base_path ->
     match V.create_request ~base_path ~task_id:"task-1"
-        ~output:(`String "result") ~criteria:[V.Contains "result"]
+        ~output:(`String "result") ~criteria:[V.Custom "result"]
         ~worker:"claude" () with
     | Error e -> Alcotest.fail e
     | Ok req ->


### PR DESCRIPTION
## 문제

`Verification.criterion` 이 네 생성자를 갖는다.

```ocaml
type criterion =
  | Schema_match of Yojson.Safe.t   (** Output matches JSON schema *)
  | Contains of string              (** Output must contain string *)
  | Not_contains of string          (** Output must not contain string *)
  | Custom of string                (** Natural language criterion for verifier *)
```

**앞의 셋은 `lib/` `bin/` 어디에서도 생성되지 않는다.** criteria 리스트를 만드는 유일한 곳은 `verification_protocol.ml:62` 이고

```ocaml
let criteria = List.map (fun s -> Verification.Custom s)
  (match task.contract with Some c -> c.completion_contract | None -> [])
```

`Custom` 만 만든다.

## 셋의 유일한 등장은 거부하는 자리였다

| 위치 | 하는 일 |
|---|---|
| `completion_authority_agent.ml` | `"verification request criteria[%d] is not a persisted custom completion contract"` 에러 |
| `dashboard_verification.ml` | `filter_map` 으로 걸러냄 |

대시보드 주석은 이렇게 말한다.

> Non-Custom criteria (Contains, Schema_match, ...) are **automated checks**, not contract text

**그런 자동 검사는 없다.** `verification.mli` 는 평가 함수를 노출하지 않고, criterion 을 평가하는 코드도 저장소에 없다. `Contains` — 산출물 텍스트가 문자열을 포함하면 검증 통과 — 는 배선된 적이 없다.

## 수정

```ocaml
type criterion = Custom of string
```

와이어 태그는 `"custom"` 그대로라 **영속된 요청의 JSON 모양은 바뀌지 않는다.** 제거된 타입을 담은 레코드는 이제 파싱에서 거부된다 — 로드된 뒤 completion authority 가 거부하던 것과 결과는 같고 한 단계 앞이다. 그리고 그런 파일을 쓴 적이 없다 (`read_drop` 은 파일 단위 계수라 목록 전체가 죽지도 않는다).

소비자 둘 다 거부 경로를 잃는다 — `completion_contract_of_request` 는 `map` 이 되고, 대시보드의 `filter_map` 도 `map` 이 된다.

## 테스트

`test_criterion_roundtrip` 은 네 생성자를 **자기가 만들어서** 왕복시켰다. 그래서 통과했다. 프로덕션이 그중 셋에 닿지 않는다는 사실은 검증 대상이 아니었다.

이제 존재하는 하나를 덮고, 파싱 에러 케이스가 제거된 세 타입(`contains` / `not_contains` / `schema_match`) 이 거부되는 것을 못 박는다.

## 검증

- `dune build --root . @check` EXIT=0
- `test_verification` OK, `test_dashboard_verification` OK
- `scripts/check-doc-code-refs.sh`, `scripts/audit-keeper-tool-boundary-matrix.sh` PASS

63줄 삭제 / 32줄 추가.

RFC-WAIVED: 생산자가 0 인 생성자 3개와 그것들을 거부하던 경로 제거. 와이어 포맷·검증 동작·완료 계약 내용 모두 불변. credential/identity, repo_manager, operator control plane, keeper sandbox, dashboard credential component, hooks, workflow 문서 어느 것도 건드리지 않는다.

WORKAROUND-WAIVED: 이 PR 은 분류기를 추가하거나 강화하지 않는다. 반대로 문자열 포함 검사로 검증하려던 미배선 생성자(`Contains` / `Not_contains`)를 **삭제**한다. 게이트가 STRING_CLASSIFIER 로 매칭한다면 본문이 제거 대상을 인용했기 때문이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
