### PR TITLE
test(keeper): 스키마 드리프트로 깨져 있던 fixture 11건 수정 (CI 미실행 스위트)

### DIFF
--- a/test/stanzas/test_keeper_keepalive_helpers.inc
+++ b/test/stanzas/test_keeper_keepalive_helpers.inc
@@ -1,4 +1,4 @@
 (test
  (name test_keeper_keepalive_helpers)
  (modules test_keeper_keepalive_helpers)
- (libraries masc masc.config masc.keeper_metrics masc.keeper_runtime masc_workspace masc_types masc.keeper_registry alcotest eio eio_main unix))
+ (libraries masc_test_deps masc masc.config masc.keeper_metrics masc.keeper_runtime masc_workspace masc_types masc.keeper_registry alcotest eio eio_main unix))

--- a/test/test_dashboard_k2_feeds.ml
+++ b/test/test_dashboard_k2_feeds.ml
@@ -73,9 +73,8 @@ let keeper_meta name =
     Masc_test_deps.meta_of_json_fixture
       (`Assoc
           [ "name", `String name
-          ; "agent_name", `String name
+          ; "agent_name", `String (Masc.Keeper_identity.keeper_agent_name name)
           ; "trace_id", `String ("trace-" ^ name)
-          ; "runtime_id", `String (Keeper_config.default_runtime_id ())
           ])
   with
   | Ok meta -> meta

--- a/test/test_dashboard_keeper_cost_aggregates.ml
+++ b/test/test_dashboard_keeper_cost_aggregates.ml
@@ -27,10 +27,8 @@ let make_meta name =
       (`Assoc
         [
           ("name", `String name);
-          ("agent_name", `String name);
+          ("agent_name", `String (Masc.Keeper_identity.keeper_agent_name name));
           ("trace_id", `String ("trace-" ^ name));
-          ("runtime_id", `String "test-runtime");
-          ("last_model_used", `String "test-model");
         ])
   with
   | Ok meta -> meta

--- a/test/test_goal_metric_unevaluated.ml
+++ b/test/test_goal_metric_unevaluated.ml
@@ -80,7 +80,7 @@ let make_keeper_meta name =
     Masc_test_deps.meta_of_json_fixture
       (`Assoc
         [ ("name", `String name)
-        ; ("agent_name", `String ("agent-" ^ name))
+        ; ("agent_name", `String (Masc.Keeper_identity.keeper_agent_name name))
         ; ("trace_id", `String ("trace-" ^ name))
         ])
   with

--- a/test/test_keeper_compact_recovery_tool_surface.ml
+++ b/test/test_keeper_compact_recovery_tool_surface.ml
@@ -10,7 +10,7 @@ let make_meta name =
     Masc_test_deps.meta_of_json_fixture
       (`Assoc
         [ "name", `String name
-        ; "agent_name", `String (name ^ "-agent")
+        ; "agent_name", `String (Masc.Keeper_identity.keeper_agent_name name)
         ; "trace_id", `String (name ^ "-trace")
         ; "allowed_paths", `List [ `String "*" ]
         ])

--- a/test/test_keeper_connector_attention_wake.ml
+++ b/test/test_keeper_connector_attention_wake.ml
@@ -67,7 +67,7 @@ let make_meta name =
   let json =
     `Assoc
       [ ("name", `String name)
-      ; ("agent_name", `String ("agent-" ^ name))
+      ; ("agent_name", `String (Masc.Keeper_identity.keeper_agent_name name))
       ; ("trace_id", `String ("trace-conn-" ^ name))
       ]
   in

--- a/test/test_keeper_gate_effect_coverage.ml
+++ b/test/test_keeper_gate_effect_coverage.ml
@@ -26,7 +26,7 @@ let make_meta ?(always_allow = false) name =
     Masc_test_deps.meta_of_json_fixture
       (`Assoc
          [ "name", `String name
-         ; "agent_name", `String name
+         ; "agent_name", `String (Masc.Keeper_identity.keeper_agent_name name)
          ; "trace_id", `String ("trace-" ^ name)
          ; "allowed_paths", `List [ `String "*" ]
          ])

--- a/test/test_keeper_hooks_oas_log_shape.ml
+++ b/test/test_keeper_hooks_oas_log_shape.ml
@@ -59,7 +59,7 @@ let task_scope_meta () =
     Masc_test_deps.meta_of_json_fixture
       (`Assoc
         [ "name", `String "task-scope-test"
-        ; "agent_name", `String "task-scope-test"
+        ; "agent_name", `String "keeper-task-scope-test-agent"
         ; "trace_id", `String "trace-task-scope-test"
         ; "current_task_id", `String "task-meta"
         ])

--- a/test/test_keeper_identity_parse.ml
+++ b/test/test_keeper_identity_parse.ml
@@ -29,7 +29,11 @@ let test_explicit_keeper_name_is_not_nickname_canonicalized () =
   let json =
     `Assoc
       [ ("name", `String "personality-resync-test")
-      ; ("agent_name", `String "personality-resync-test")
+      ; (* keeper_meta_json_parse rejects an agent_name that is not
+           Keeper_identity.keeper_agent_name of the keeper name. The point of
+           this case is that [name] itself is not nickname-canonicalized, which
+           the assertion below still checks. *)
+        ("agent_name", `String "keeper-personality-resync-test-agent")
       ; ("trace_id", `String "personality-resync-test-001")
       ]
   in
@@ -57,20 +61,24 @@ let test_missing_trace_id () =
 let test_empty_trace_id () =
   match Masc_test_deps.meta_of_json_fixture (minimal_keeper_json ~trace_id:"") with
   | Error msg ->
-      check bool "error mentions missing trace_id"
+      (* keeper_meta_json_parse:102 says "trace_id must not be empty"; the
+         previous "missing trace_id" wording never appeared for this input. *)
+      check bool "error names the empty trace_id"
         true
         (String.length msg > 0
-         && (try ignore (Str.search_forward (Str.regexp_string "missing trace_id") msg 0); true
+         && (try ignore (Str.search_forward (Str.regexp_string "trace_id must not be empty") msg 0); true
              with Not_found -> false))
   | Ok _ -> fail "expected Error for empty trace_id"
 
 let test_invalid_trace_id () =
   match Masc_test_deps.meta_of_json_fixture (minimal_keeper_json ~trace_id:"..") with
   | Error msg ->
-      check bool "error mentions invalid trace_id"
+      (* keeper_meta_json_parse:106 and :369 both say "trace_id is invalid";
+         the previous assertion looked for the reversed "invalid trace_id". *)
+      check bool "error names the invalid trace_id"
         true
         (String.length msg > 0
-         && (try ignore (Str.search_forward (Str.regexp_string "invalid trace_id") msg 0); true
+         && (try ignore (Str.search_forward (Str.regexp_string "trace_id is invalid") msg 0); true
              with Not_found -> false))
   | Ok _ -> fail "expected Error for invalid trace_id '..'"
 

--- a/test/test_keeper_keepalive_helpers.ml
+++ b/test/test_keeper_keepalive_helpers.ml
@@ -37,11 +37,16 @@ let make_keepalive_meta ~name ~agent_name =
         ("name", `String name);
         ("agent_name", `String agent_name);
         ("trace_id", `String ("trace-" ^ name));
-        ("sandbox_profile", `String "local");
-        ("network_mode", `String "inherit");
+        (* sandbox_profile and network_mode left the JSON wire schema — they
+           arrive from keeper.toml now. This fixture only ever set them to the
+           record defaults ("local" / "inherit"), so dropping them changes
+           nothing this suite asserts. *)
       ]
   in
-  match Keeper_meta_json_parse.meta_of_json json with
+  (* The strict parser demands every persisted field; this suite only cares
+     about identity and task ownership, so it uses the fixture helper that
+     fills record defaults — the same seam the other keeper suites use. *)
+  match Masc_test_deps.meta_of_json_fixture json with
   | Error err -> fail ("meta_of_json failed: " ^ err)
   | Ok meta -> meta
 
@@ -187,13 +192,11 @@ let make_board_resume_meta name =
   let json =
     `Assoc
       [ ("name", `String name)
-      ; ("agent_name", `String ("keeper-" ^ name))
+      ; ("agent_name", `String (Masc.Keeper_identity.keeper_agent_name name))
       ; ("trace_id", `String ("trace-" ^ name))
-      ; ("sandbox_profile", `String "local")
-      ; ("network_mode", `String "inherit")
       ]
   in
-  match Keeper_meta_json_parse.meta_of_json json with
+  match Masc_test_deps.meta_of_json_fixture json with
   | Error err -> fail ("meta_of_json failed: " ^ err)
   | Ok meta -> meta
 ;;

--- a/test/test_keeper_lifecycle_chaos.ml
+++ b/test/test_keeper_lifecycle_chaos.ml
@@ -20,7 +20,7 @@ let make_meta name =
   let json =
     `Assoc
       [ ("name", `String name)
-      ; ("agent_name", `String ("agent-" ^ name))
+      ; ("agent_name", `String (Masc.Keeper_identity.keeper_agent_name name))
       ; ("trace_id", `String ("trace-chaos-" ^ name))
       ]
   in

--- a/test/test_keeper_local_profile_docker_playground.ml
+++ b/test/test_keeper_local_profile_docker_playground.ml
@@ -3,18 +3,23 @@ open Alcotest
 module KSD = Masc.Keeper_sandbox_docker
 module KT = Keeper_types
 
+(* [sandbox_profile] and [network_mode] still live on the keeper_meta record —
+   Keeper_sandbox_docker.effective_sandbox_profile reads them — but they left
+   the JSON wire schema, so keeper_meta_json_parse now rejects them as fields
+   outside the current schema. They arrive from keeper.toml instead. The fixture
+   therefore parses the wire fields and sets the two record fields directly,
+   which is what this suite is about. *)
 let make_meta ~name ~sandbox_profile ~network_mode =
   let json =
     `Assoc
       [ "name", `String name
-      ; "agent_name", `String ("agent-" ^ name)
+      ; "agent_name", `String (Masc.Keeper_identity.keeper_agent_name name)
       ; "trace_id", `String ("trace-" ^ name)
-      ; "sandbox_profile", `String (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox_profile)
-      ; "network_mode", `String (Keeper_types_profile_sandbox.network_mode_to_string network_mode)
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with
-  | Ok meta -> meta
+  | Ok meta ->
+    { meta with Masc.Keeper_meta_contract.sandbox_profile; network_mode }
   | Error err -> fail ("make_meta: " ^ err)
 
 let check_effective label expected meta =


### PR DESCRIPTION
## 무엇

키퍼 meta 스키마 드리프트로 실패하던 **11 개 스위트**의 fixture 를 현재 스키마에 맞춘다. 프로덕션 코드 변경 없음.

Refs #26993.

## 왜 안 보였나

이 11 개는 CI 실행 목록에 없다.

```
ci.yml 에 이름이 언급된 test_*   64
test/*.ml 파일                  835
```

`@check` 는 전부 **컴파일** 하므로 통과하고, 실행되지 않으니 단언 실패가 드러나지 않는다.

## 세 가지 드리프트 (전부 fixture 쪽)

### 1. `agent_name does not match canonical keeper identity`

`keeper_meta_json_parse.ml:367` 이 `Keeper_identity.keeper_agent_name` 와 대조한다. fixture 들이 제각각이었다 — `` `String name `` · `"agent-" ^ name` · `"keeper-" ^ name` · `name ^ "-agent"` · 리터럴.

전부 `Keeper_identity.keeper_agent_name name` 호출로 바꿨다. 정규형이 다시 바뀌어도 이 파일들을 또 훑을 필요가 없다.

### 2. `fields outside the current schema: runtime_id, last_model_used`

keeper meta 에서 은퇴했다. fixture 가 값을 넣기만 하고 되읽는 단언이 없어 제거했다.

### 3. `fields outside the current schema: sandbox_profile, network_mode`

이 둘은 **삭제가 아니라 이전** 이다 — JSON wire 스키마에서는 빠졌지만 `keeper_meta` 레코드에는 남아 있고(`Keeper_sandbox_docker.effective_sandbox_profile` 이 읽는다) 이제 keeper.toml 이 채운다.

- `test_keeper_local_profile_docker_playground` 는 그 필드가 **테스트의 주제** 라, 파싱 후 레코드에 직접 설정한다.
- `test_keeper_keepalive_helpers` 는 기본값(`local`/`inherit`)만 넣고 있었으므로 제거한다.

### 덤: strict 파서 진입점

두 스위트가 `Keeper_meta_json_parse.meta_of_json` 을 직접 불러 약 50 개 필드를 요구받고 있었다. 다른 키퍼 스위트들이 쓰는 `Masc_test_deps.meta_of_json_fixture` 로 바꿨다 (dune 스탠자 하나에 `masc_test_deps` 추가).

### 덤 2: 오류 문구 드리프트

`test_keeper_identity_parse` 가 파서가 더는 내지 않는 문구를 찾고 있었다.

```
테스트가 찾던 것   "missing trace_id"                    "invalid trace_id"
파서가 내는 것     "trace_id must not be empty" (:102)   "trace_id is invalid" (:106, :369)
```

## 로컬 검증

```
11 개 스위트 빌드 후 실행   통과 11 / 실패 0
ocamlformat --check        변경 .ml 전부 OK
변경 파일                  12 (테스트 11 + dune 스탠자 1)
```

## 손대지 않은 2 건

| 스위트 | 이유 |
|---|---|
| `test_keeper_memory_lane` | 라이브 librarian 설정을 읽어 환경 의존 |
| `test_keeper_latched_reason_wiring` | `retired auto-resume field is diagnostic only` 케이스가 **파서가 더는 지키지 않는 계약** 을 단언한다 — 은퇴 필드는 이제 진단 카운터가 아니라 거부다. fixture 이름 문제가 아니라 설계 판단이므로 추측하지 않았다. |

#26993 에 사유와 함께 남긴다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
