### PR TITLE
refactor(keeper): 타입 필드를 가리던 tool-call outcome 문자열 제거

### DIFF
--- a/lib/keeper/keeper_agent_result.ml
+++ b/lib/keeper/keeper_agent_result.ml
@@ -6,11 +6,17 @@ open Keeper_agent_tool_surface
 type tool_call_detail =
   { tool_name : string
   ; provider : string
-  ; outcome : string
-      (** Progress-classification label retained for receipt compatibility. *)
   ; execution_outcome : Tool_result.tool_call_outcome
       (** Typed [Tool_result.Ok]/[Error] truth captured at the OAS hook boundary.
-          Turn-local only; durable audit is written by [Keeper_tool_call_log]. *)
+          Turn-local only; durable audit is written by [Keeper_tool_call_log].
+
+          A [string] rendering of this used to sit beside it, described as a
+          progress-classification label kept for receipt compatibility. Both
+          were derived from the same success bool on adjacent lines, and the
+          string was the one every reader consulted while this field -- the one
+          documented as the truth -- had none. The receipt JSON still carries
+          the rendering, produced here by
+          [Tool_result.string_of_tool_call_outcome]. *)
   ; typed_outcome : Keeper_tool_outcome.t option
   ; latency_ms : float
   ; task_id : string option
@@ -54,7 +60,8 @@ let tool_call_detail_to_json (detail : tool_call_detail) =
     ([
        ("tool_name", `String detail.tool_name);
        ("provider", `String detail.provider);
-       ("outcome", `String detail.outcome);
+       ( "outcome"
+       , `String (Tool_result.string_of_tool_call_outcome detail.execution_outcome) );
        ("latency_ms", `Float detail.latency_ms);
      ]
      @ typed_outcome_field

--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -3,13 +3,14 @@
 type tool_call_detail =
   { tool_name : string
   ; provider : string
-  ; outcome : string
-      (** Progress-classification label retained for receipt compatibility. *)
   ; execution_outcome : Tool_result.tool_call_outcome
       (** Typed [Tool_result.Ok]/[Error] truth captured at the OAS hook boundary.
-          This turn-local delivery signal is intentionally not part of
-          [tool_call_detail_to_json]; durable tool-call audit uses
-          [Keeper_tool_call_log]. *)
+          Durable tool-call audit uses [Keeper_tool_call_log].
+
+          [tool_call_detail_to_json] renders this into the receipt's ["outcome"]
+          string via [Tool_result.string_of_tool_call_outcome]. That string used
+          to be a second field derived from the same success bool, and it was
+          the one every reader consulted. *)
   ; typed_outcome : Keeper_tool_outcome.t option
   ; latency_ms : float
   ; task_id : string option

--- a/lib/keeper/keeper_agent_run_contract_helpers.ml
+++ b/lib/keeper/keeper_agent_run_contract_helpers.ml
@@ -1,11 +1,11 @@
 let keeper_tool_names_for_outcome ~(tool_calls : Keeper_agent_result.tool_call_detail list)
-      ~(outcome : string)
+      ~(outcome : Tool_result.tool_call_outcome)
   : string list
   =
   tool_calls
   |> List.rev
   |> List.filter_map (fun (detail : Keeper_agent_result.tool_call_detail) ->
-    if String.equal detail.outcome outcome
+    if detail.execution_outcome = outcome
     then Some (Keeper_tool_resolution.canonical_tool_name detail.tool_name)
     else None)
 ;;
@@ -17,7 +17,7 @@ let progress_keeper_tool_names_for_contract
   =
   match tool_calls with
   | [] -> actual_keeper_tool_names
-  | _ :: _ -> keeper_tool_names_for_outcome ~tool_calls ~outcome:"ok"
+  | _ :: _ -> keeper_tool_names_for_outcome ~tool_calls ~outcome:Tool_result.Ok
 ;;
 
 let observed_completion_evidence

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -212,14 +212,14 @@ let assemble_hooks
               ~input
               ~output_text
           in
-          let outcome =
-            if success then "ok" else "error"
-          in
           (match Keeper_registry.get ~base_path:config.base_path meta.name with
            | Some entry ->
              acc.meta <- entry.meta;
              meta_ref := entry.meta
            | None -> ());
+          let execution_outcome =
+            if success then Tool_result.Ok else Tool_result.Error
+          in
           let task_id =
             Keeper_run_tools_task_scope.task_id_scope_of_tool_call
               ~tool_name
@@ -229,9 +229,7 @@ let assemble_hooks
           acc.tool_calls
           <- { tool_name
              ; provider
-             ; outcome
-             ; execution_outcome =
-                 (if success then Tool_result.Ok else Tool_result.Error)
+             ; execution_outcome
              ; typed_outcome
              ; latency_ms = duration_ms
              ; task_id
@@ -254,7 +252,7 @@ let assemble_hooks
              | Some Keeper_tool_outcome.Progress -> "progress"
              | Some (Keeper_tool_outcome.No_progress _) -> "no_progress"
              | Some (Keeper_tool_outcome.Error _) -> "error"
-             | None -> outcome
+             | None -> Tool_result.string_of_tool_call_outcome execution_outcome
            in
            let turn_id =
              match acc.meta.Keeper_meta_contract.current_task_id with
@@ -279,7 +277,7 @@ let assemble_hooks
              ; tool_name
              ; keeper_id = acc.meta.name
              ; turn_id
-             ; outcome
+             ; outcome = Tool_result.string_of_tool_call_outcome execution_outcome
              ; typed_outcome = typed_outcome_str
              ; duration_ms
              ; output_text

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -947,7 +947,6 @@ let receipt_detail_of_provider_call
   in
   { tool_name = call.name
   ; provider
-  ; outcome = "ok"
   ; execution_outcome = Tool_result.Ok
   ; typed_outcome = Some Keeper_tool_outcome.Progress
   ; latency_ms = 1.0

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -205,7 +205,6 @@ let tool_call_detail_of_execution tool_name
   in
   { tool_name
   ; provider = "test"
-  ; outcome = Tool_result.string_of_tool_call_outcome execution_outcome
   ; execution_outcome
   ; typed_outcome = None
   ; latency_ms = 1.0

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -200,7 +200,6 @@ let tool_call ?(input = Some "input") ?(output = Some "output") tool_name
     : Masc.Keeper_agent_result.tool_call_detail =
   { tool_name
   ; provider = "test"
-  ; outcome = "ok"
   ; execution_outcome = Tool_result.Ok
   ; typed_outcome = None
   ; latency_ms = 1.

--- a/test/test_keeper_unified_claim_progress.ml
+++ b/test/test_keeper_unified_claim_progress.ml
@@ -57,11 +57,10 @@ let test_empty_no_tool_response_is_no_visible_output () =
     (result ~response_text_present:true)
 ;;
 
-let tool_call_detail ?(outcome = "ok") tool_name : KAR.tool_call_detail =
+let tool_call_detail ?(outcome = Tool_result.Ok) tool_name : KAR.tool_call_detail =
   { tool_name
   ; provider = "test"
-  ; outcome
-  ; execution_outcome = Tool_result.Ok
+  ; execution_outcome = outcome
   ; typed_outcome = None
   ; latency_ms = 1.0
   ; task_id = None
@@ -71,9 +70,17 @@ let tool_call_detail ?(outcome = "ok") tool_name : KAR.tool_call_detail =
   }
 ;;
 
+(* This used to pass ~outcome:"ok_no_progress", a third spelling the producer
+   never emits -- it sets Ok or Error from one success bool. The filter keeps
+   Ok, so any string but "ok" excluded the call, and the test read as though a
+   successful claim could be held back from contract progress. It cannot: on
+   this axis a successful claim is Ok and counts. What the name describes lives
+   on [typed_outcome] ([Keeper_tool_outcome.No_progress]), which this filter
+   does not consult. The cases below use the outcome that genuinely is not
+   progress. *)
 let test_contract_progress_filters_no_progress_tool_results () =
   let no_progress_only =
-    [ tool_call_detail ~outcome:"ok_no_progress" "keeper_task_claim" ]
+    [ tool_call_detail ~outcome:Tool_result.Error "keeper_task_claim" ]
   in
   check
     (list string)
@@ -89,7 +96,7 @@ let test_contract_progress_filters_no_progress_tool_results () =
     (KAR.For_testing.progress_keeper_tool_names_for_contract
        ~actual_keeper_tool_names:[ "keeper_task_claim"; "tool_execute" ]
        ~tool_calls:
-         [ tool_call_detail ~outcome:"ok_no_progress" "keeper_task_claim"
+         [ tool_call_detail ~outcome:Tool_result.Error "keeper_task_claim"
          ; tool_call_detail "tool_execute"
          ])
 ;;


### PR DESCRIPTION
## 문제

`Keeper_agent_result.tool_call_detail` 이 outcome 을 두 축으로 들고 있었다.

```ocaml
; outcome : string
    (** Progress-classification label retained for receipt compatibility. *)
; execution_outcome : Tool_result.tool_call_outcome
    (** Typed [Tool_result.Ok]/[Error] truth captured at the OAS hook boundary. *)
```

주석이 스스로 나눈다 — 문자열은 "레거시 호환용 라벨", 타입 쪽은 "**truth**".

**읽는 쪽은 정반대였다.**

| 필드 | `lib/` 소비자 |
|---|---|
| `outcome : string` | 3곳 — progress 필터, receipt JSON, `typed_outcome_str` 폴백 |
| `execution_outcome` (타입) | **0곳** |

타입 필드는 `keeper_run_tools_hooks` 에서 쓰이기만 하고 아무도 읽지 않았다. 테스트만 이 필드를 만든다 — 레코드가 요구하니까.

발산하지는 않았다. 둘 다 같은 `success` bool 에서 인접한 줄로 파생된다.

```ocaml
let outcome = if success then "ok" else "error" in
...
; execution_outcome = (if success then Tool_result.Ok else Tool_result.Error)
```

버그는 아니지만, 레코드가 "truth" 라고 표시한 필드를 아무도 안 보고 "레거시 호환" 이라고 표시한 문자열을 전부가 보고 있었다.

## 수정

문자열 필드 제거. `execution_outcome` 이 progress 필터의 매칭 대상이 되고, `tool_call_detail_to_json` 이 `Tool_result.string_of_tool_call_outcome` 으로 receipt 의 `"outcome"` 을 만든다.

```ocaml
let string_of_tool_call_outcome = function
  | Ok -> "ok" | Error -> "error" | Unknown -> "unknown"
```

생산자가 내는 두 값에 대해 렌더링이 정확히 일치하므로 **receipt JSON 은 바이트 단위로 동일**하다.

## 테스트가 만들어낸 세 번째 철자

`test_keeper_unified_claim_progress` 는 `~outcome:"ok_no_progress"` 를 넘겼다. 생산자는 그 철자를 내지 않는다.

필터가 `"ok"` 만 남기므로 다른 문자열이면 전부 제외됐고, 그래서 케이스가 "성공한 claim 이 contract progress 에서 빠질 수 있다" 처럼 읽혔다. **그럴 수 없다.** 이 축에서 성공한 claim 은 `Ok` 이고 집계된다.

그 이름이 서술하는 것은 `typed_outcome` (`Keeper_tool_outcome.No_progress`) 축에 있고, 이 필터는 그걸 보지 않는다. 케이스는 실제로 progress 가 아닌 outcome (`Tool_result.Error`) 을 쓰도록 바꿨고, 필터가 `typed_outcome` 을 참조하지 않는다는 사실은 **이 PR 에서 건드리지 않았다** — 동작 변경이라 별도 판단이 필요하다.

## 검증

- `dune build --root . @check` EXIT=0
- `test_keeper_unified_claim_progress`, `test_keeper_turn_outcome`, `test_gate_keeper_backend` OK
- `test_keeper_tool_dispatch_runtime` 은 5건 실패하지만 **베이스라인과 실패 집합이 `diff` 기준 동일** (변경 전에도 같은 5건)
- `scripts/check-doc-code-refs.sh`, `scripts/audit-keeper-tool-boundary-matrix.sh` PASS

RFC-WAIVED: 타입 필드를 중복하던 레거시 문자열 필드 제거. receipt JSON 과 관측 이벤트의 `"outcome"` 값은 불변. credential/identity, repo_manager, operator control plane, keeper sandbox, dashboard credential component, hooks, workflow 문서 어느 것도 건드리지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
