### PR TITLE
chore(keeper): 호출자 없는 board-attention settlement 래퍼 제거

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -147,12 +147,6 @@ let consume_deferred_runtime_lane_hint hint_ref expected =
 
 exception Event_queue_cycle_failed of string
 
-type board_attention_settlement_outcome =
-  | Board_attention_settled of
-      Keeper_board_attention_worker.settlement
-  | Board_attention_settlement_deferred of
-      Keeper_turn_admission.autonomous_block
-
 let connector_attention_event_ids_of_stimuli stimuli =
   List.filter_map
     (fun (stimulus : Keeper_event_queue.stimulus) ->
@@ -322,21 +316,6 @@ let turn_status_event ~turn_fail_count : Keeper_state_machine.event =
   if turn_fail_count > 0
   then Keeper_state_machine.Turn_failed { consecutive = turn_fail_count }
   else Keeper_state_machine.Turn_succeeded
-;;
-
-let settle_board_attention_on_owner_lane ~base_path ~keeper_name =
-  match
-    Keeper_turn_admission.run_if_free
-      ~base_path
-      ~keeper_name
-      (fun () ->
-         Keeper_board_attention_worker.settle_one_completed
-           ~base_path
-           ~keeper_name)
-  with
-  | `Ran (Ok settlement) -> Ok (Board_attention_settled settlement)
-  | `Ran (Error detail) -> Error detail
-  | `Busy block -> Ok (Board_attention_settlement_deferred block)
 ;;
 
 let run_keepalive_unified_turn


### PR DESCRIPTION
## 무엇

`settle_board_attention_on_owner_lane` 과 그 반환 타입 `board_attention_settlement_outcome` (생성자 2개) 를 제거한다.

## 왜

호출자가 없다.

```
rg -n 'settle_board_attention_on_owner_lane|board_attention_settlement_outcome|Board_attention_settlement_deferred' lib/ test/
  lib/keeper/keeper_heartbeat_loop.ml:150   type 정의
  lib/keeper/keeper_heartbeat_loop.ml:153   생성자
  lib/keeper/keeper_heartbeat_loop.ml:327   함수 정의
  lib/keeper/keeper_heartbeat_loop.ml:339   자기 본문
```

정의 4줄이 전부다. `keeper_heartbeat_loop.mli` 에도 없다.

살아 있는 정산 경로는 `run_keepalive_unified_turn` 안의 `Keeper_board_attention_worker.settle_one_completed` 직접 호출 하나뿐이다 (`keeper_heartbeat_loop.ml:398`).

죽은 래퍼를 두면 정산이 `Keeper_turn_admission.run_if_free` 로 어드미션 가드된다고 읽힌다. 실제로는 가드가 없다 — `#26863` 진단 중 실제로 이 오독을 했다.

`run_if_free` 자체는 production 호출자 6곳이 남아 있어 그대로 둔다.

## 로컬 검증

```
dune build @check    exit 0
```

RFC-WAIVED: 참조 0건인 private 바인딩 제거. 동작 변화 없음.