### PR TITLE
refactor(keeper): claim 경로의 sparse match 두 곳을 열거로 닫는다

### DIFF
--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -623,7 +623,12 @@ let handle_keeper_task_tool_with_outcome
          | Some { task_status = Masc_domain.InProgress _; _ } -> false
          | Some { task_status = Masc_domain.Done _ | Masc_domain.Cancelled _
                  | Masc_domain.AwaitingVerification _; _ } -> false
-         | _ -> true
+         | Some { task_status = Masc_domain.Todo | Masc_domain.Claimed _; _ } -> true
+         (* The claim above succeeded, so the task was in the backlog a moment
+            ago. If a concurrent write removed it, the Start dispatch below
+            fails and auto_started_ok records that -- the message then does not
+            claim the task was auto-started. *)
+         | None -> true
        in
        if needs_start then begin
          let start_result =
@@ -742,7 +747,10 @@ let handle_keeper_task_tool_with_outcome
           , Keeper_tool_outcome.to_json
               (Keeper_tool_outcome.Error
                  { reason = Printf.sprintf "keeper_task_claim rejected: %s" e }) )
-      | _ -> None
+      (* A claimed task carries no typed_outcome field. Keeper_tool_outcome
+         .is_nonprogress reads its absence the same as Progress, and adding the
+         field here would change the tool payload. *)
+      | Workspace.Claim_next_claimed _ -> None
     in
     let payload =
       Yojson.Safe.to_string


### PR DESCRIPTION
## 문제

`keeper_tool_task_runtime.ml` 의 claim 경로에 닫힌 variant 에 대한 sparse match 가 둘 있고, **둘 다 이름을 부르지 않은 바로 그 케이스를 숨긴다.**

### 1. `needs_start` — 방금 claim 한 태스크를 auto-start 할지

```ocaml
match List.find_opt (fun t -> String.equal t.id task_id) tasks with
| Some { task_status = InProgress _; _ } -> false
| Some { task_status = Done _ | Cancelled _ | AwaitingVerification _; _ } -> false
| _ -> true
```

`| _ -> true` 가 셋을 삼킨다 — `Todo`, `Claimed`, 그리고 **`None`(백로그에 태스크가 없음)**.

앞의 둘은 거기 있는 게 맞다. 세 번째는 claim 과 재조회 사이의 동시 쓰기이고, 같이 묶은 탓에 `task_status` 에 생성자가 하나 추가되면 아무도 고르지 않은 채 "start 한다" 로 떨어진다.

바로 위 주석이 이 가드를 왜 넣었는지 설명한다 — *"dispatching Start produces an InvalidState transition error every cycle"*. `None` 은 정확히 그 실패를 다시 만든다 (다른 이유로).

### 2. `typed_outcome_field` — claim 결과의 typed outcome

`Claim_next_*` 는 생성자가 넷이다 (`claimed` / `no_eligible` / `no_unclaimed` / `error`). 셋을 이름으로 처리하고 `| _ -> None` 이 **성공 케이스 하나**를 삼킨다. 다섯 번째 생성자가 생기면 "typed outcome 없음" 을 물려받는다.

## 수정

둘 다 열거했다. 컴파일러가 묻게 된다.

**동작은 바뀌지 않는다.**

- 사라진 태스크는 여전히 `true` 이고 아래 Start dispatch 가 실패하며 `auto_started_ok` 가 그걸 기록한다 — 메시지가 "auto-started" 를 주장하지 않는다. 조용한 실패가 아니다
- claim 된 태스크는 여전히 `typed_outcome` 필드를 싣지 않는다. `Keeper_tool_outcome.is_nonprogress` 가 부재를 `Progress` 와 같게 읽는다 (`| Some Progress | None -> false`). 여기서 필드를 추가하면 도구 페이로드가 바뀌므로 하지 않았다

각 케이스에 왜 그런지 주석을 달았다.

## 검증

- `dune build --root . @check` EXIT=0 — 경고 없이 통과했다는 것 자체가 열거가 완전하다는 증거다 (누락이 있으면 non-exhaustive match 경고가 난다)
- `test_keeper_unified_claim_progress`, `test_auth`, `test_bind_required_guard_counter`, `test_auth_bearer_mismatch_9786` OK
- `scripts/check-doc-code-refs.sh`, `scripts/audit-keeper-tool-boundary-matrix.sh` PASS

근거: CLAUDE.md "AI 코드 생성 안티패턴 §4 FSM Sparse Match / `_ -> false` Catch-all" — 전이 매트릭스에 catch-all 을 쓰지 않고 모든 쌍을 명시해 새 variant 추가 시 컴파일 타임에 누락을 잡는다.

RFC-WAIVED: catch-all 두 개를 명시적 열거로 바꾸는 변경. 동작·페이로드·메시지 모두 불변. credential/identity, repo_manager, operator control plane, keeper sandbox, dashboard credential component, hooks, workflow 문서 어느 것도 건드리지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
