### PR TITLE
test(keeper): drain 로그 레벨 매핑을 순수 함수로 추출하고 고정

### DIFF
--- a/lib/keeper/keeper_board_attention_worker.ml
+++ b/lib/keeper/keeper_board_attention_worker.ml
@@ -359,6 +359,15 @@ let drain_outcome_label = function
     "retry_generation_changed"
 ;;
 
+(* The drain line derives its level from the outcome it reports. [Retry_later]
+   leaves the durable partition undrained and re-arms the same contention, so a
+   worker that keeps returning it makes no progress while its candidate ledger
+   grows; at [Info] that state reads the same as normal draining. *)
+let drain_outcome_log_level = function
+  | Drained -> Log.Info
+  | Retry_later _ -> Log.Warn
+;;
+
 let apply_drain_rearm scheduler = function
   | Drained ->
     reset_contention_rearms scheduler ~keep:None;
@@ -1805,18 +1814,8 @@ let run
                  ~execute
              with
              | Ok outcome ->
-               (* The level comes from the outcome, not from the call site.
-                  [Retry_later] means the durable partition is still undrained
-                  and the same candidate is re-inspected on the next wake, so a
-                  worker that never reaches [Drained] is a backlog that grows
-                  with nothing above Info to show for it. *)
-               let level =
-                 match outcome with
-                 | Drained -> Log.Info
-                 | Retry_later _ -> Log.Warn
-               in
                Log.Keeper.emit
-                 level
+                 (drain_outcome_log_level outcome)
                  (Printf.sprintf
                     "board_attention_worker_drain keeper=%s outcome=%s"
                     keeper_name
@@ -1848,6 +1847,7 @@ module For_testing = struct
   let schedule_contention_rearm = schedule_contention_rearm
   let reset_contention_rearms = reset_contention_rearms
   let drain_outcome_label = drain_outcome_label
+  let drain_outcome_log_level = drain_outcome_log_level
   let apply_drain_rearm = apply_drain_rearm
   let replay_completed_owner_wake = replay_completed_owner_wake
   let with_process_recovery_claim = with_process_recovery_claim

--- a/lib/keeper/keeper_board_attention_worker.mli
+++ b/lib/keeper/keeper_board_attention_worker.mli
@@ -99,6 +99,10 @@ module For_testing : sig
       so a worker stuck on a moved generation is distinguishable from one
       losing a claim race. *)
 
+  val drain_outcome_log_level : drain_outcome -> Log.level
+  (** The level the drain line is emitted at, derived from the outcome.
+      [Retry_later] leaves the partition undrained, so it is not routine. *)
+
   val process_next_exact
     :  clock:_ Eio.Time.clock
     -> net:Eio_context.eio_net option

--- a/test/test_keeper_board_attention_worker.ml
+++ b/test/test_keeper_board_attention_worker.ml
@@ -2101,6 +2101,39 @@ let test_drain_outcome_labels_stay_distinct () =
     (List.length (List.sort_uniq compare labels))
 ;;
 
+(* A drain that returns Retry_later left the durable partition undrained and
+   re-armed the same contention, so the next wake re-inspects the same root.
+   Emitting that at the same level as a completed drain makes a worker that
+   never finishes read as routine while its candidate ledger grows (#26863). *)
+let test_undrained_outcomes_are_not_routine () =
+  let contention =
+    { W.keeper_name = "k"
+    ; partition_id = "p"
+    ; generation = P.Generation.initial
+    }
+  in
+  let level_name outcome =
+    match W.For_testing.drain_outcome_log_level outcome with
+    | Log.Debug -> "debug"
+    | Log.Info -> "info"
+    | Log.Warn -> "warn"
+    | Log.Error -> "error"
+  in
+  Alcotest.(check string)
+    "a completed drain is routine"
+    "info"
+    (level_name W.Drained);
+  Alcotest.(check string)
+    "a contended claim is not routine"
+    "warn"
+    (level_name (W.Retry_later { contention; reason = W.Exact_claim_contended }));
+  Alcotest.(check string)
+    "a moved generation is not routine"
+    "warn"
+    (level_name
+       (W.Retry_later { contention; reason = W.Selected_generation_changed }))
+;;
+
 let () =
   Alcotest.run
     "keeper_board_attention_worker"
@@ -2225,6 +2258,10 @@ let () =
             "cross-domain wake coalesces and rearms"
             `Quick
             test_cross_domain_wake_is_coalesced_and_rearmed
+        ; Alcotest.test_case
+            "undrained outcomes are not routine"
+            `Quick
+            test_undrained_outcomes_are_not_routine
         ; Alcotest.test_case
             "drain outcome labels stay distinct"
             `Quick


### PR DESCRIPTION
## 무엇

`#27002` 가 도입한 drain 로그 레벨 선택을 `drain_outcome_log_level` 로 추출하고 두 arm 을 모두 덮는 테스트를 붙인다.

`#27002` 의 테스트 커버리지 체크가 "Added 16 lines to covered code paths but no test files changed" 로 실패했는데, 그 PR 은 테스트가 붙기 전에 머지됐다. 머지된 브랜치에 push 해도 main 에 도달하지 않으므로 별도 PR 로 올린다.

## 왜 추출하는가

`#27002` 의 레벨 선택은 `emit` 호출 지점의 인라인 `match` 였다. 인라인이면 새 `drain_outcome` 변형이 추가될 때 호출 지점마다 따로 결정되고, 테스트가 겨눌 대상이 없다.

`drain_outcome -> Log.level` 전역 함수로 두면 exhaustive match 가 강제되고, 매핑이 테스트 한 곳에서 읽힌다.

## 테스트

`undrained outcomes are not routine` — 세 outcome 의 레벨을 이름으로 확인한다:

```
Drained                                  -> info
Retry_later Exact_claim_contended        -> warn
Retry_later Selected_generation_changed  -> warn
```

**Negative control**: `Retry_later -> Log.Info` 로 되돌리자 실패 5건 → 6건, 추가된 실패가 정확히 이 테스트(`test_undrained_outcomes_are_not_ro`)였다. 복구 후 재통과.

## 이 브랜치에서 확인된 별건 — main 의 기존 실패 5건

`test_keeper_board_attention_worker` 는 origin/main 에서 32건 중 **5건이 실패**한다. 이 PR 의 변경 이전부터다 (origin/main 기준 다른 브랜치에서 동일 재현).

```
[FAIL]  0   callback conversion, advancement, completion, settlement
[FAIL] 16   terminal root then sibling
[FAIL] 17   Completed start ...
[FAIL] 24   Requeued+Blocked ...
[FAIL] 27   same quarantine command CAS loser converges

ASSERT worker callback integration: exact completion lost its registered owner before projection: sangsu
```

그리고 이 스위트는 `.github/workflows/` 어디에도 배선돼 있지 않다 (`rg -c 'test_keeper_board_attention_worker' .github/workflows/*.yml` → 0). 그래서 main 이 green 인 채로 5건이 붉다.

이 PR 은 그 5건을 고치지 않는다. 별도 이슈로 올린다.

## 로컬 검증

```
dune build test/test_keeper_board_attention_worker.exe    exit 0
스위트 실행                                                32 tests, 새 테스트 [OK], 기존 실패 5건 유지
negative control                                          실패 6건 (새 테스트 포함) → 복구 후 5건
```

RFC-WAIVED: 순수 함수 추출 + 테스트 추가. 동작 변화 없음.
