### PR TITLE
chore(playground): sandbox_profile 이전 번들 경로 사슬 제거

### DIFF
--- a/lib/config/playground_paths.ml
+++ b/lib/config/playground_paths.ml
@@ -75,14 +75,6 @@ let sanitize_keeper_name (name : string) : string =
 let bundle_root (name : string) : string =
   Printf.sprintf "%s/%s/" all_playgrounds_prefix (sanitize_keeper_name name)
 
-(** Relative path [".masc/playground/<safe_name>/repos/"]. *)
-let repos_path (name : string) : string =
-  Printf.sprintf "%s/%s/repos/" all_playgrounds_prefix (sanitize_keeper_name name)
-
-(** Bundle directories in canonical order. *)
-let bundle_paths (name : string) : string list =
-  [ bundle_root name; repos_path name ]
-
 type playground_file_path =
   { keeper_name : string
   ; relative_path : string

--- a/lib/config/playground_paths.mli
+++ b/lib/config/playground_paths.mli
@@ -29,12 +29,6 @@ val sanitize_keeper_name : string -> string
 val bundle_root : string -> string
 (** Relative path [".masc/playground/<safe_name>/"] (trailing slash). *)
 
-val repos_path : string -> string
-(** Relative path [".masc/playground/<safe_name>/repos/"]. *)
-
-val bundle_paths : string -> string list
-(** Bundle directories in canonical order: [\[bundle_root; repos_path\]]. *)
-
 type playground_file_path =
   { keeper_name : string
   ; relative_path : string

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -780,7 +780,6 @@ let resolve_keeper_target_path = resolve_keeper_path_within_allowed_roots
    if it ever changes. *)
 let sanitize_keeper_name = Playground_paths.sanitize_keeper_name
 let playground_path_of_keeper = Playground_paths.bundle_root
-let playground_bundle_paths = Playground_paths.bundle_paths
 
 let sandbox_path_of_meta ~(meta : Keeper_meta_contract.keeper_meta) =
   Keeper_sandbox.allowed_root_rel_of_meta ~meta
@@ -789,13 +788,6 @@ let sandbox_path_of_meta ~(meta : Keeper_meta_contract.keeper_meta) =
 let sandbox_bundle_paths_of_meta ~(meta : Keeper_meta_contract.keeper_meta) =
   let root = sandbox_path_of_meta ~meta |> strip_trailing_slashes in
   [ root ^ "/"; root ^ "/repos/" ]
-;;
-
-let ensure_playground_bundle ~(config : Workspace.config) ~(name : string) : string list =
-  let root = project_root_of_config config in
-  playground_bundle_paths name
-  |> List.map (Filename.concat root)
-  |> List.map Keeper_fs.ensure_dir
 ;;
 
 let ensure_sandbox_bundle ~(config : Workspace.config) ~(meta : Keeper_meta_contract.keeper_meta)

--- a/lib/keeper/keeper_alerting_path.mli
+++ b/lib/keeper/keeper_alerting_path.mli
@@ -219,21 +219,12 @@ val sanitize_keeper_name : string -> string
 (** Re-export of [Playground_paths.bundle_root]. *)
 val playground_path_of_keeper : string -> string
 
-(** Re-export of [Playground_paths.repos_path]. *)
-(** Re-export of [Playground_paths.bundle_paths]. *)
-val playground_bundle_paths : string -> string list
-
 (** Sandbox host root path for [meta]. *)
 val sandbox_path_of_meta : meta:Keeper_meta_contract.keeper_meta -> string
 
 (** Sandbox bundle paths (root and repos/) for [meta]. *)
 val sandbox_bundle_paths_of_meta :
   meta:Keeper_meta_contract.keeper_meta -> string list
-
-(** Ensure the playground bundle dirs exist; returns the absolute
-    paths created. *)
-val ensure_playground_bundle :
-  config:Workspace.config -> name:string -> string list
 
 val ensure_sandbox_bundle :
   config:Workspace.config ->

--- a/test/test_playground_paths.ml
+++ b/test/test_playground_paths.ml
@@ -46,17 +46,6 @@ let test_bundle_root_format () =
     ".masc/playground/a_b/"
     (PP.bundle_root "a/b")
 
-let test_repos_path () =
-  check string "repos path"
-    ".masc/playground/sangsu/repos/"
-    (PP.repos_path "sangsu")
-
-let test_bundle_paths_order () =
-  check (list string) "bundle order: root, repos"
-    [ ".masc/playground/k1/";
-      ".masc/playground/k1/repos/" ]
-    (PP.bundle_paths "k1")
-
 let test_no_path_escape () =
   (* A poisoned name containing path separators must not produce a
      path that escapes the playground prefix. *)
@@ -101,9 +90,6 @@ let test_strip_canonical_to_short () =
     (PP.sanitize_keeper_name "keeper-sangsu-agent")
 
 let test_canonical_short_path_identity () =
-  check string "repos path identity"
-    (PP.repos_path "masc-improver")
-    (PP.repos_path "keeper-masc-improver-agent");
   check string "bundle_root identity"
     (PP.bundle_root "cheolsu")
     (PP.bundle_root "keeper-cheolsu-agent")
@@ -201,8 +187,6 @@ let () =
       ]);
       ("paths", [
         test_case "bundle_root format" `Quick test_bundle_root_format;
-        test_case "repos path" `Quick test_repos_path;
-        test_case "bundle_paths order" `Quick test_bundle_paths_order;
       ]);
       ("security", [
         test_case "no path escape" `Quick test_no_path_escape;


### PR DESCRIPTION
프로덕션 호출자가 0인 심볼 4개와 그 자기-테스트를 지웁니다. 순수 삭제, 47줄.

## 지운 것

| 심볼 | 위치 | 프로덕션 호출자 |
|---|---|---|
| `Playground_paths.repos_path` | `playground_paths.ml:79` | **0** |
| `Playground_paths.bundle_paths` | `:83` | **0** (`playground_bundle_paths` 만) |
| `Keeper_alerting_path.playground_bundle_paths` | `:783` | **0** (`ensure_playground_bundle` 만) |
| `Keeper_alerting_path.ensure_playground_bundle` | `:794` | **0** |

두 모듈에 걸친 닫힌 사슬입니다. 넷 다 `.mli` 로 노출돼 있어서 밖에서 보면 공개 API 처럼 보였습니다.

## 왜 살아 있는 것처럼 보였는가

`test_playground_paths.ml` 이 `repos_path` 와 `bundle_paths` 를 테스트하고 있었습니다. 죽은 코드를 테스트가 붙잡고 있는 형태입니다. 테스트도 같이 지웠습니다 — 사슬 밖에서 이 둘을 부르는 곳이 없으므로 커버리지 손실이 아닙니다.

## 그리고 죽은 쪽이 프로파일을 모르는 쪽입니다

```ocaml
let bundle_paths name = [ bundle_root name; repos_path name ]
```

`bundle_root` 는 Local 레이아웃입니다. Docker 프로파일 키퍼의 실제 루트는 `.masc/playground/docker/<safe>/` 입니다 (`keeper_sandbox_config.ml:70`). 즉 이 사슬은 sandbox_profile 도입 이전 버전이고, `ensure_sandbox_bundle_for_profile` → `sandbox_bundle_paths_of_meta` 로 대체된 뒤 지워지지 않았습니다.

살아 있는 경로는 그대로입니다: `keeper_turn_up_create.ml:145` 가 `ensure_sandbox_bundle_for_profile` 을 부릅니다.

## 검증

- `dune build @check` — exit 0 (전체 트리 타입 체크)
- `test_playground_paths` — 11/11 통과
- ocamlformat clean

## 범위 밖

`Playground_paths.parse_playground_file_path` 도 프로덕션 호출자가 0이지만 이 PR 에 넣지 않았습니다. `test_verification.ml` 이 `create_evidence_request` 헬퍼(8개 호출 지점)에서 픽스처를 만드는 데 쓰고 있어, 지우려면 그 헬퍼를 다시 써야 합니다. "참조가 없는 것을 지운다" 와 "테스트를 다시 쓰고 지운다" 는 위험이 다른 변경이라 나눴습니다. 후속으로 올립니다.

## 배경

`repos/` 문자열이 프로덕션 코드 9곳에 흩어져 있는 것을 조사하다 나왔습니다. 나머지(살아 있는 writer 들의 SSOT, `parse_playground_repo_path` 역파싱 — RFC-0343 §3.1)는 설계 판단이 필요해 별건입니다. 이 PR 은 그 판단과 무관하게 죽은 것만 지웁니다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
