### PR TITLE
refactor(audit): 감사 severity 가 default 로 넘기던 action 들을 열거한다

### DIFF
--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -312,22 +312,38 @@ let audit_entry_id ~timestamp ~agent_id ~action =
 (** Map outcome + action to O2 severity string. *)
 let audit_severity ~action ~outcome =
   match outcome with
-  | Failure _ -> (match action with
-    | AuthFailure | CircuitOpen -> "error"
-    | _ -> "warn")
-  | Success -> (match action with
-    | AuthSuccess -> "info"
-    | GateDecision d -> (match d with
-      | Gate_deny | Gate_unauthorized -> "warn"
-      | _ -> "info")
-    | CircuitClose -> "warn"
-    (* A successful runtime.toml write rewrites global keeper routing
-       (RFC-0273 §3.2: the highest-risk surface). Surface it above
-       routine info events so a severity-filtered audit scan catches it,
-       consistent with [CircuitClose] elevating a significant successful
-       transition to "warn". *)
-    | RuntimeConfigWrite -> "warn"
-    | _ -> "info")
+  | Failure _ ->
+    (match action with
+     | AuthFailure | CircuitOpen -> "error"
+     | ClaimTask | StartTask | DoneTask | CancelTask | ReleaseTask | Broadcast
+     | Suspend | ToolCall _ | AuthSuccess | CircuitClose | SearchRefinement
+     | GateDecision _ | RuntimeConfigWrite | Custom _ | Unknown _ ->
+       "warn")
+  | Success ->
+    (match action with
+     | AuthSuccess -> "info"
+     | GateDecision d ->
+       (match d with
+        | Gate_deny | Gate_unauthorized -> "warn"
+        | Gate_allow | Gate_require_confirmation | Gate_confirm | Gate_expired
+        | Gate_other _ ->
+          "info")
+     | CircuitClose -> "warn"
+     (* A successful runtime.toml write rewrites global keeper routing
+        (RFC-0273 §3.2: the highest-risk surface). Surface it above
+        routine info events so a severity-filtered audit scan catches it,
+        consistent with [CircuitClose] elevating a significant successful
+        transition to "warn". *)
+     | RuntimeConfigWrite -> "warn"
+     (* Enumerated rather than swept into a default: severity is the key a
+        filtered audit scan reads, and RuntimeConfigWrite above is the record
+        of what a default costs -- it sat at "info" until someone noticed the
+        highest-risk surface was hidden among routine events. A new action now
+        has to be placed here. *)
+     | ClaimTask | StartTask | DoneTask | CancelTask | ReleaseTask | Broadcast
+     | Suspend | ToolCall _ | AuthFailure | CircuitOpen | SearchRefinement
+     | Custom _ | Unknown _ ->
+       "info")
 
 (** Build a human-readable one-line summary from action + details. *)
 let audit_summary ~action ~details =
@@ -444,7 +460,10 @@ let audit_target ~action ~details =
   | Suspend -> extract_str "target_agent"
   | RuntimeConfigWrite -> extract_str "path"
   | Custom _ -> extract_str "tool_name"
-  | _ -> None
+  (* These carry no single subject worth putting in the one-line summary. *)
+  | Broadcast | AuthSuccess | AuthFailure | CircuitOpen | CircuitClose
+  | SearchRefinement | Unknown _ ->
+    None
 
 let audit_event_severity (entry : audit_entry) =
   audit_severity ~action:entry.action ~outcome:entry.outcome


### PR DESCRIPTION
## 문제

`audit_severity` 는 severity 필터가 걸린 감사 스캔이 읽는 값이다. 그런데 `action` variant (17개) 를 두 default 로 쓸어담았다.

```ocaml
| Failure _ -> (match action with
  | AuthFailure | CircuitOpen -> "error"
  | _ -> "warn")                       (* 나머지 15개 *)
| Success -> (match action with
  | AuthSuccess -> "info"
  | GateDecision d -> (match d with
    | Gate_deny | Gate_unauthorized -> "warn"
    | _ -> "info")                     (* 나머지 5개 *)
  | CircuitClose -> "warn"
  | RuntimeConfigWrite -> "warn"
  | _ -> "info")                       (* 나머지 12개 *)
```

## 이 파일이 이미 그 대가를 기록하고 있다

`RuntimeConfigWrite` 옆 주석이다.

> A successful runtime.toml write rewrites global keeper routing (RFC-0273 §3.2: **the highest-risk surface**). Surface it **above routine info events so a severity-filtered audit scan catches it**

이 action 은 default 를 물려받아 `"info"` 였다. 최고 위험 표면이 routine 이벤트 사이에 묻혀 있었고, **누군가 알아채서** 특례를 넣어야 했다. 다음 action 도 같은 자리에서 시작한다.

## 수정

세 매치 모두 생성자를 전부 이름으로 부른다 — action 17개, gate decision 7개. 새 생성자가 생기면 물려받는 대신 **놓여야 한다**.

`audit_summary` 의 primary-field 매치도 같은 방식으로 열거했다.

**오늘 존재하는 어떤 action 도 severity 나 summary 필드가 바뀌지 않는다.**

## 검증

- `dune build --root . @check` EXIT=0 — 경고 없이 통과했다는 것이 열거 완전성의 증거다
- `test_audit_log`, `test_dashboard_tool_host_events`, `test_dispatch_telemetry_gap` OK
- `scripts/check-doc-code-refs.sh`, `scripts/audit-keeper-tool-boundary-matrix.sh` PASS

근거: CLAUDE.md "AI 코드 생성 안티패턴 §4 FSM Sparse Match / `_ -> false` Catch-all" — catch-all 을 쓰지 않고 모든 케이스를 명시해 새 variant 추가 시 컴파일 타임에 누락을 잡는다.

RFC-WAIVED: catch-all 을 명시적 열거로 바꾸는 변경. 기존 action 의 severity·summary 값 불변. credential/identity, repo_manager, operator control plane, keeper sandbox, dashboard credential component, hooks, workflow 문서 어느 것도 건드리지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
