### PR TITLE
fix(keeper): persist autonomous conversation turns

### DIFF
--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -270,6 +270,7 @@ describe('MCP 2026-07-28 dashboard client', () => {
 
   it('bootstraps a loopback dev token before the single MCP request', async () => {
     getStoredToken.mockReturnValue(null)
+    getStoredTokenMeta.mockReturnValue(null)
     fetchWithTimeout
       .mockResolvedValueOnce(new Response(JSON.stringify({
         token: 'loopback-dev-token', actor: 'dashboard', role: 'worker',

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -141,9 +141,10 @@ export function isVisibleDirectConversationEntry(entry: KeeperConversationEntry)
     && entry.source !== 'system'
 }
 
-/** Turns the keeper ran on its own (projected from typed turn records, never
- *  persisted to the chat store). Shown without the internal toggle because the
- *  transcript folds them into one collapsed group rather than listing each. */
+/** Turns the keeper ran on its own. Their semantic conversation is persisted
+ *  in the OAS checkpoint; typed turn records provide a stable dashboard
+ *  projection without duplicating it into the chat store. Shown without the
+ *  internal toggle and folded into one collapsed group. */
 export function isAutonomousTurnEntry(entry: KeeperConversationEntry): boolean {
   return entry.source === 'autonomous_turn'
 }

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -648,12 +648,11 @@ export type KeeperConversationSource =
   | 'direct_assistant'
   | 'world_state_prompt'
   | 'internal_assistant'
-  // A keeper turn that ran without anyone addressing the keeper. These rows
-  // are not in the chat store — RFC-0351 §5 keeps the wake marker and inert
-  // prose out of the durable transcript — and are projected from the raw-trace
-  // store by Keeper_autonomous_turn_source. Visible by default but folded into
-  // one collapsed group, because they outnumber direct conversation heavily
-  // (a keeper wakes on the order of once a minute).
+  // A keeper turn that ran without anyone addressing the keeper. Its ordinary
+  // User/Assistant/Tool exchange is durable in the OAS checkpoint; these
+  // dashboard-only rows avoid duplicating that conversation in the chat store
+  // and are projected by Keeper_autonomous_turn_source. Visible by default but
+  // folded into one collapsed group, because a keeper may wake once a minute.
   | 'autonomous_turn'
   | 'tool_result'
   | 'system'

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -547,7 +547,7 @@ let run_turn
      and user message append — Keeper_run_prompt. *)
   let prompt_user_turn_record =
     match hitl_resolution with
-    | Some _ -> Keeper_run_prompt.Skip_uninformative_wake
+    | Some _ -> Keeper_run_prompt.Skip_already_checkpointed_user_turn
     | None -> user_turn_record
   in
   let prompt_ctx =
@@ -1047,7 +1047,6 @@ let run_turn
                              ~session ~append_manifest ~model
                              ~acc
                              ~actual_keeper_tool_names
-                             ~user_turn_record
                              ~result ~final_oas_turn_ordinal
                              ~checkpoint_persistence_error
                              ~post_turn_t0 ~runtime_id_string

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -22,15 +22,8 @@ let replay_response_text_for_capture ~suppress_visible_response ~response_text =
   else Some response_text
 ;;
 
-let replay_response_text_for_persistence
-      ~(turn_effect_record : Keeper_run_prompt.turn_effect_record)
-      ~suppress_visible_response
-      ~response_text
-  =
-  match turn_effect_record with
-  | Keeper_run_prompt.Inert_autonomous_turn -> None
-  | Keeper_run_prompt.Meaningful_turn ->
-    replay_response_text_for_capture ~suppress_visible_response ~response_text
+let replay_response_text_for_persistence ~suppress_visible_response ~response_text =
+  replay_response_text_for_capture ~suppress_visible_response ~response_text
 ;;
 
 type wire_capture_response_suppression_reason =
@@ -60,28 +53,6 @@ let emit_wire_capture_response_suppressed_metrics ~keeper_name reasons =
     reasons
 ;;
 
-(* RFC-0351 S1 / #25462: a [Skip_uninformative_wake] turn records nothing in
-   the MASC-side stores (#25515), but the OAS run still receives the wake
-   marker as its goal and appends it to the transcript as a user message —
-   so every completed bare wake persisted one more byte-identical marker
-   into the checkpoint (343 measured in one keeper before the offline
-   purge). The typed turn record gates the drop; the exact sentinel
-   equality is a defence against the record ever being paired with a
-   different user message, not a classifier. *)
-let drop_leading_wake_marker ~user_turn_record current_suffix =
-  match user_turn_record, current_suffix with
-  | ( Keeper_run_prompt.Skip_uninformative_wake
-    , ({ Agent_sdk.Types.role = Agent_sdk.Types.User
-       ; content = [ Agent_sdk.Types.Text text ]
-       ; _
-       }
-       :: rest) )
-    when String.equal text Keeper_unified_prompt.autonomous_wake_marker ->
-    rest, true
-  | (Keeper_run_prompt.Skip_uninformative_wake | Keeper_run_prompt.Record_user_turn), _
-    -> current_suffix, false
-;;
-
 let is_trailing_blank_assistant (message : Agent_sdk.Types.message) =
   match message.role, message.content with
   | Agent_sdk.Types.Assistant, [] -> true
@@ -106,8 +77,6 @@ let canonical_success_replay_checkpoint
       ~(history_messages : Agent_sdk.Types.message list)
       ~(session_id : string)
       ~(response_text : string)
-      ~(user_turn_record : Keeper_run_prompt.user_turn_record)
-      ~(turn_effect_record : Keeper_run_prompt.turn_effect_record)
       (checkpoint : Agent_sdk.Checkpoint.t)
   =
   match
@@ -115,27 +84,7 @@ let canonical_success_replay_checkpoint
       ~prefix:history_messages
       checkpoint.Agent_sdk.Checkpoint.messages
   with
-  | Ok original_current_suffix ->
-    (match turn_effect_record with
-     | Keeper_run_prompt.Inert_autonomous_turn ->
-       (* The provider may have produced thinking and idle prose, but this turn
-          had no durable input, Keeper tool effect, or external delivery. Keep
-          the canonical pre-turn history byte-for-byte and discard the whole
-          provider-only suffix. The prefix split above remains the safety gate:
-          an unrelated checkpoint can never be rewritten as this history. *)
-       Ok
-         ( { checkpoint with
-             Agent_sdk.Checkpoint.session_id
-           ; messages = history_messages
-           ; working_context = None
-           }
-         , (match original_current_suffix with
-            | [] -> None
-            | _ :: _ -> Some Canonical_success_replay) )
-     | Keeper_run_prompt.Meaningful_turn ->
-       let current_suffix, wake_marker_dropped =
-         drop_leading_wake_marker ~user_turn_record original_current_suffix
-       in
+  | Ok current_suffix ->
        (* A blank visible response is not authority to erase typed replay. The
           suffix may contain an actual user input, ToolUse/ToolResult pair,
           thinking, or media whose effect has already happened. Remove only an
@@ -147,7 +96,7 @@ let canonical_success_replay_checkpoint
          else current_suffix, false
        in
        let replay_suffix_pruned =
-         if wake_marker_dropped || blank_assistant_dropped
+         if blank_assistant_dropped
          then Some Canonical_success_replay
          else None
        in
@@ -183,7 +132,7 @@ let canonical_success_replay_checkpoint
        in
        Ok
          ( checkpoint
-         , replay_suffix_pruned ))
+         , replay_suffix_pruned )
   | Error _ ->
     Error
       "refusing to save checkpoint: canonical replay persistence requires \
@@ -216,8 +165,6 @@ let checkpoint_for_replay_persistence
       ~(session_id : string)
       ~(response_text : string)
       ?(stop_reason = Runtime_agent.Completed)
-      ?(user_turn_record = Keeper_run_prompt.Record_user_turn)
-      ?(turn_effect_record = Keeper_run_prompt.Meaningful_turn)
       (checkpoint : Agent_sdk.Checkpoint.t)
   =
   match stop_reason with
@@ -256,8 +203,6 @@ let checkpoint_for_replay_persistence
       ~history_messages
       ~session_id
       ~response_text
-      ~user_turn_record
-      ~turn_effect_record
       checkpoint
 ;;
 
@@ -291,7 +236,6 @@ let finalize
     ~model
     ~(acc : Keeper_run_tools.hook_accumulator)
     ~actual_keeper_tool_names
-    ~(user_turn_record : Keeper_run_prompt.user_turn_record)
     ~(result : Runtime_agent.run_result)
     ~final_oas_turn_ordinal
     ~checkpoint_persistence_error
@@ -309,12 +253,6 @@ let finalize
     ?continuation_delivery_channel
     () =
   let completion_contract_result = acc.receipt_completion_contract_result in
-  let turn_effect_record =
-    Keeper_run_prompt.turn_effect_record_of_turn
-      ~user_turn_record
-      ~tool_calls_made:(actual_keeper_tool_names <> [])
-      ~external_delivery_routed:(Option.is_some continuation_delivery_channel)
-  in
   let control_checkpoint =
     Keeper_agent_run_response_text.stop_reason_suppresses_visible_response
       result.stop_reason
@@ -339,7 +277,6 @@ let finalize
   receipt_response_text_present_ref := raw_response_text_present;
   let replay_response_text =
     replay_response_text_for_persistence
-      ~turn_effect_record
       ~suppress_visible_response
       ~response_text
   in
@@ -369,8 +306,6 @@ let finalize
             (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
           ~response_text
           ~stop_reason:result.stop_reason
-          ~user_turn_record
-          ~turn_effect_record
           checkpoint
       in
       (match checkpoint_for_save_result with
@@ -471,7 +406,6 @@ let finalize
       ~oas_turn_count:result.turns
       ~actual_tools:actual_keeper_tool_names
       ~librarian_messages
-      ~turn_effect_record
       ~post_turn_t0
       ~inference_telemetry:result.response.telemetry
       ();

--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -12,19 +12,13 @@ let run
   ~oas_turn_count
   ~actual_tools
   ~librarian_messages
-  ~(turn_effect_record : Keeper_run_prompt.turn_effect_record)
   ~post_turn_t0
   ~inference_telemetry
   ()
   =
-  (* (1) deterministic write and (2) LLM librarian extraction run on this
-     keeper's memory lane (RFC-0257), detached from the turn lane, as TWO
-     separate submissions rather than one bundled unit (masc#25052 P3):
-     a librarian call stuck on provider queue wait must not hold the
-     deterministic unit's reservation. Both units still share the keeper's
-     per-keeper mutex (RFC-0257's fairness boundary is unchanged); meta/config
-     are immutable snapshots, so using them after the turn returns does not
-     race a later turn. *)
+  (* LLM Librarian extraction runs on this Keeper's memory lane (RFC-0257),
+     detached from the turn lane. Meta/config are immutable snapshots, so using
+     them after the turn returns does not race a later turn. *)
   (* The librarian toggle is owned at this admission boundary. Disabled or
      invalid configuration must not submit a lane unit, read the current
      snapshot, advance cadence, or emit Librarian runtime failures. *)
@@ -32,90 +26,75 @@ let run
     match Env_config.KeeperMemoryOs.librarian_config_state () with
     | Disabled | Invalid -> ()
     | Enabled ->
-      (match turn_effect_record with
-       | Keeper_run_prompt.Meaningful_turn ->
-         let keepers_dir =
-           Config_dir_resolver.keepers_dir_for_base_path
-             ~base_path:config.Workspace.base_path
-         in
-         let run_admitted_librarian () =
-           match
-             Keeper_memory_os_current.read_for_keepers_dir
-               ~keepers_dir
-               ~keeper_id:meta.name
-           with
-           | Error detail ->
-             Otel_metric_store.inc_counter
-               Keeper_metrics.(to_string MemoryOsLibrarianFailures)
-               ~labels:[ "keeper", meta.name; "site", "memory_os_current_read" ]
-               ();
-             Log.Keeper.warn
-               ~keeper_name:meta.name
-               "memory os librarian skipped: current snapshot unavailable: %s"
-               detail
-           | Ok current ->
-             let current_selection, expected_revision =
-               match current with
-               | None -> None, None
-               | Some snapshot ->
-                 ( Some
-                     { Keeper_librarian.facts = snapshot.facts }
-                 , Some snapshot.revision )
-             in
-             let trace_id =
-               Keeper_id.Trace_id.to_string meta.runtime.trace_id
-             in
-             (* Same persona SSOT as the keeper's own system prompt
-                ([Keeper_unified_prompt.build_system_prompt]). Loaded here on
-                the memory lane — off the turn path — so the librarian judges
-                retention through the identity the keeper currently lives
-                with. *)
-             let persona =
-               Keeper_types_profile.load_resolved_persona_extended
-                 ~keeper_name:meta.name
-                 ~profile_defaults
-                 ()
-             in
-             let librarian_input : Keeper_librarian.input =
-               { turn_ref = Ids.Turn_ref.make ~trace_id ~absolute_turn:turn
-               ; generation
-               ; persona
-               ; current = current_selection
-               ; max_recall_fact_bytes =
-                   Env_config.KeeperMemoryOs.recall_facts_max_bytes ()
-               ; messages = librarian_messages
-               }
-             in
-             Keeper_librarian_runtime.run_best_effort
-               ~keepers_dir
-               ~keeper_id:meta.name
-               ~expected_revision
-               librarian_input
-         in
-         let librarian_series () =
-           (* Submission is asynchronous. Re-check the same live SSOT at the
-              execution boundary so an ON -> OFF/INVALID change while queued
-              remains a real kill switch before snapshot I/O or provider work. *)
-           match Env_config.KeeperMemoryOs.librarian_config_state () with
-           | Disabled | Invalid -> ()
-           | Enabled -> run_admitted_librarian ()
-         in
-         let (_ : Keeper_memory_lane.outcome) =
-           Keeper_memory_lane.submit
-             ~base_path:config.Workspace.base_path
-             ~keeper_name:meta.name
-             ~lane:Keeper_memory_lane.Librarian
-             librarian_series
-         in
-         ()
-       | Keeper_run_prompt.Inert_autonomous_turn ->
-         (* Not submitted at all, so the cadence counter does not advance
-            either: an idle stretch leaves the extraction budget untouched
-            instead of spending it on prose about the idleness. *)
-         Otel_metric_store.inc_counter
-           Keeper_metrics.(to_string MemoryOsInertTurnExtractionSkipped)
-           ~labels:[ "keeper", meta.name ]
-           ())
+      let keepers_dir =
+        Config_dir_resolver.keepers_dir_for_base_path
+          ~base_path:config.Workspace.base_path
+      in
+      let run_admitted_librarian () =
+        match
+          Keeper_memory_os_current.read_for_keepers_dir
+            ~keepers_dir
+            ~keeper_id:meta.name
+        with
+        | Error detail ->
+          Otel_metric_store.inc_counter
+            Keeper_metrics.(to_string MemoryOsLibrarianFailures)
+            ~labels:[ "keeper", meta.name; "site", "memory_os_current_read" ]
+            ();
+          Log.Keeper.warn
+            ~keeper_name:meta.name
+            "memory os librarian skipped: current snapshot unavailable: %s"
+            detail
+        | Ok current ->
+          let current_selection, expected_revision =
+            match current with
+            | None -> None, None
+            | Some snapshot ->
+              Some { Keeper_librarian.facts = snapshot.facts }, Some snapshot.revision
+          in
+          let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+          (* Same persona SSOT as the keeper's own system prompt
+             ([Keeper_unified_prompt.build_system_prompt]). Loaded here on
+             the memory lane — off the turn path — so the librarian judges
+             retention through the identity the keeper currently lives with. *)
+          let persona =
+            Keeper_types_profile.load_resolved_persona_extended
+              ~keeper_name:meta.name
+              ~profile_defaults
+              ()
+          in
+          let librarian_input : Keeper_librarian.input =
+            { turn_ref = Ids.Turn_ref.make ~trace_id ~absolute_turn:turn
+            ; generation
+            ; persona
+            ; current = current_selection
+            ; max_recall_fact_bytes =
+                Env_config.KeeperMemoryOs.recall_facts_max_bytes ()
+            ; messages = librarian_messages
+            }
+          in
+          Keeper_librarian_runtime.run_best_effort
+            ~keepers_dir
+            ~keeper_id:meta.name
+            ~expected_revision
+            librarian_input
+      in
+      let librarian_series () =
+        (* Submission is asynchronous. Re-check the same live SSOT at the
+           execution boundary so an ON -> OFF/INVALID change while queued
+           remains a real kill switch before snapshot I/O or provider work. *)
+        match Env_config.KeeperMemoryOs.librarian_config_state () with
+        | Disabled | Invalid -> ()
+        | Enabled -> run_admitted_librarian ()
+      in
+      let (_ : Keeper_memory_lane.outcome) =
+        Keeper_memory_lane.submit
+          ~base_path:config.Workspace.base_path
+          ~keeper_name:meta.name
+          ~lane:Keeper_memory_lane.Librarian
+          librarian_series
+      in
+      ()
   in
   submit_librarian_if_enabled ();
   (* Post-turn timing evidence is logged to decisions.jsonl. The keyword

--- a/lib/keeper/keeper_agent_run_post_turn_memory.mli
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.mli
@@ -17,7 +17,6 @@ val run :
   oas_turn_count:int ->
   actual_tools:string list ->
   librarian_messages:Agent_sdk.Types.message list ->
-  turn_effect_record:Keeper_run_prompt.turn_effect_record ->
   post_turn_t0:float ->
   inference_telemetry:Agent_sdk.Types.inference_telemetry option ->
   unit ->
@@ -41,10 +40,6 @@ val run :
     Disabled or invalid configuration does not submit a Librarian unit or read
     its snapshot. An admitted asynchronous unit re-checks the live setting
     before snapshot I/O so disabling it while queued remains effective. When
-    enabled, [turn_effect_record] admits only [Meaningful_turn]; on
-    [Inert_autonomous_turn] the librarian unit is never submitted, so its
-    cadence counter does not advance and an idle stretch spends no extraction
-    budget.
-    The deterministic write series runs either way: a model-owned
-    [keeper_memory_write] on an otherwise inert turn is an explicit decision to
-    remember, not an extraction from prose. *)
+    enabled, every completed conversation turn is eligible for Librarian
+    extraction; the Librarian owns semantic selection rather than a scheduler-
+    side external-effect heuristic. *)

--- a/lib/keeper/keeper_autonomous_turn_source.ml
+++ b/lib/keeper/keeper_autonomous_turn_source.ml
@@ -1,6 +1,8 @@
 (* Dashboard read model for autonomous keeper turns. Turn identity is
-   producer-owned in Turn_record; the exact raw trace supplies the final
-   response and a content-free activity projection for that recorded OAS run. *)
+   producer-owned in Turn_record and is used only to address/dedupe this
+   projection; durable semantic continuity comes from the Keeper checkpoint.
+   The exact raw trace supplies the final response and a content-free activity
+   projection for that recorded OAS run. *)
 
 type turn =
   { turn_id : string

--- a/lib/keeper/keeper_run_prompt.ml
+++ b/lib/keeper/keeper_run_prompt.ml
@@ -17,57 +17,18 @@ type turn_prompt_context =
   ; ctx_work : Keeper_context_runtime.working_context
   }
 
-(* RFC-0351 section 5 / #25462: an autonomous wake whose user turn is only the
-   [autonomous_wake_marker] constant carries nothing forward — the observation
-   frame it stands for rides [dynamic_context], rebuilt fresh every turn and
-   never persisted. Recording it anyway appends a byte-identical message per
-   wake, which is pure transcript duplication (analyst: the same 147B message
-   x359, part of a 25.7% exact-dup share). The distinction is typed here rather
-   than inferred from the message text. *)
+(* Ordinary user turns, including the tiny autonomous [Continue.] cue, are
+   durable conversation messages. A resumed HITL checkpoint can already own
+   the exact current input; that exceptional replay path skips only the second
+   append, never because the content is judged uninformative. *)
 type user_turn_record =
   | Record_user_turn
       (** The user turn carries content later turns need: an operator message,
-          a HITL resolution, or chat-lane input. *)
-  | Skip_uninformative_wake
-      (** Autonomous wake marker alone. Neither appended to the working context
-          nor persisted to session history. *)
-
-(* The unified lane's user turn is the wake marker constant unless a HITL
-   resolution was appended to it, so the presence of that resolution is the
-   whole signal. Extracted from the lane call site to keep the mapping
-   unit-testable and to keep the decision out of the message text. *)
-let user_turn_record_of_hitl_resolution : _ option -> user_turn_record
-  = function
-  | None -> Skip_uninformative_wake
-  | Some _ -> Record_user_turn
-;;
-
-type turn_effect_record =
-  | Meaningful_turn
-  | Inert_autonomous_turn
-
-(* One typed decision owns both replay persistence and librarian extraction.
-   A model response is not itself an external effect: scheduled idle prose has
-   no consumer, yet previously accumulated in the checkpoint and then became
-   librarian input. Existing execution facts are sufficient:
-
-   - operator/HITL input is durable input,
-   - any Keeper tool call may have changed or observed state needed later,
-   - a routed continuation has an external consumer.
-
-   No response-text classifier or duplicate field comparison is involved. *)
-let turn_effect_record_of_turn
-      ~(user_turn_record : user_turn_record)
-      ~(tool_calls_made : bool)
-      ~(external_delivery_routed : bool)
-  : turn_effect_record
-  =
-  match user_turn_record with
-  | Skip_uninformative_wake
-    when not tool_calls_made && not external_delivery_routed ->
-    Inert_autonomous_turn
-  | Skip_uninformative_wake | Record_user_turn -> Meaningful_turn
-;;
+          a HITL resolution, chat-lane input, or the autonomous continuation
+          cue. *)
+  | Skip_already_checkpointed_user_turn
+      (** The resumed OAS checkpoint already owns this exact user turn. Do not
+          append or persist a second copy before replay. *)
 
 type extra_system_context_assembly =
   { extra_system_context : string option
@@ -172,7 +133,7 @@ let build_turn_context
   let ctx_work =
     match user_turn_record with
     | Record_user_turn -> Keeper_context_runtime.append ctx_work user_msg
-    | Skip_uninformative_wake -> ctx_work
+    | Skip_already_checkpointed_user_turn -> ctx_work
   in
   (match user_turn_record, is_retry with
    | Record_user_turn, false ->
@@ -180,7 +141,7 @@ let build_turn_context
        ~source:history_user_source
        session
        user_msg
-   | Record_user_turn, true | Skip_uninformative_wake, _ -> ());
+   | Record_user_turn, true | Skip_already_checkpointed_user_turn, _ -> ());
   { turn_system_prompt
   ; dynamic_context
   ; memory_context

--- a/lib/keeper/keeper_run_prompt.mli
+++ b/lib/keeper/keeper_run_prompt.mli
@@ -19,44 +19,13 @@ type turn_prompt_context =
 
 type user_turn_record =
   | Record_user_turn
-  | Skip_uninformative_wake
+  | Skip_already_checkpointed_user_turn
 (** Whether this turn's user message belongs in the durable transcript.
 
-    [Skip_uninformative_wake] is the autonomous wake marker on its own: a
-    constant whose observation frame rides [dynamic_context], rebuilt fresh
-    every turn. Recording it appends a byte-identical message per wake and
-    becomes pure duplication — one keeper accumulated the same 147B message
-    x359 (RFC-0351 section 5, #25462). The distinction is typed, not inferred
-    from message text. *)
-
-val user_turn_record_of_hitl_resolution : _ option -> user_turn_record
-(** Map the unified lane's HITL resolution slot to a transcript decision.
-    Absent resolution means the user turn is the bare wake marker. *)
-
-type turn_effect_record =
-  | Meaningful_turn
-  | Inert_autonomous_turn
-(** Whether the completed turn produced anything that belongs in durable
-    replay or post-turn memory extraction.
-
-    [Inert_autonomous_turn] means the input was only the autonomous wake
-    marker, no Keeper tool ran, and no external continuation route exists.
-    Model-authored prose alone is not a durable effect: persisting it makes an
-    idle fleet grow its transcript and then teaches the librarian about that
-    idleness.
-
-    The decision uses existing execution facts only. It does not inspect
-    response text, compare rendered messages, or introduce another completion
-    proof contract. *)
-
-val turn_effect_record_of_turn
-  :  user_turn_record:user_turn_record
-  -> tool_calls_made:bool
-  -> external_delivery_routed:bool
-  -> turn_effect_record
-(** [Inert_autonomous_turn] only when the wake was bare, no tool ran, and no
-    external continuation delivery is routed. Operator/HITL input, any tool
-    execution, or a routed continuation makes the turn meaningful. *)
+    [Record_user_turn] is the ordinary path, including autonomous [Continue.]
+    turns. [Skip_already_checkpointed_user_turn] is reserved for a resumed
+    checkpoint that already contains the exact current input, so replay does
+    not append a duplicate. The distinction is typed, not inferred from text. *)
 
 type extra_system_context_assembly =
   { extra_system_context : string option

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -23,13 +23,10 @@ type turn_prompt_parts = {
   user_message : string;
 }
 
-(* Persisted user-turn content for autonomous wake turns. The observation
-   frame is carried in [world_state] (per-turn dynamic context) — persisting
-   it re-feeds the model its own observations and starves compaction
-   (#25193: 943/945 user messages were identical frames). *)
-let autonomous_wake_marker =
-  "(autonomous wake — the current observation frame is provided per-turn in \
-   system context)"
+(* Ordinary user input for an autonomous continuation. The durable checkpoint
+   carries this cue and the assistant/tool suffix in normal conversation order;
+   the fresh observation frame alone rides [world_state] and stays ephemeral. *)
+let autonomous_wake_marker = "Continue."
 
 let format_pending_messages
       (messages : Keeper_world_observation_message_scope.pending_message list)

--- a/lib/keeper/keeper_unified_prompt.mli
+++ b/lib/keeper/keeper_unified_prompt.mli
@@ -24,15 +24,18 @@ type turn_prompt_parts = {
           every turn. Inject as per-turn [dynamic_context]; never append
           to the persisted message history. *)
   user_message : string;
-      (** Persisted user-turn content: genuine utterances only. For
-          autonomous wake turns this is {!autonomous_wake_marker}; HITL
-          resolutions are appended by the turn driver. *)
+      (** Current user-turn input. Operator utterances are durable. For an
+          autonomous continuation this is {!autonomous_wake_marker}, which is
+          also durable: each cycle is an ordinary next user turn followed by
+          its assistant/tool suffix. HITL resolutions are appended by the turn
+          driver. *)
 }
 
 val autonomous_wake_marker : string
-(** Persisted user-turn content for autonomous wake turns. Constant and
-    tiny by design: the observation frame lives in
-    {!turn_prompt_parts.world_state}, not in the message history. *)
+(** Durable input for an autonomous continuation. It is appended to the same
+    checkpoint as the following assistant/tool suffix. The fresh observation
+    frame lives separately in {!turn_prompt_parts.world_state} and is never
+    persisted. *)
 
 val format_current_task : Masc_domain.task -> string
 

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -210,14 +210,11 @@ let run (ctx : ctx)
                  ~world_observation:observation
                  ~generation:run_generation
                  ~history_user_source:"world_state_prompt"
-                 (* RFC-0351 section 5 / #25462: on this lane the user turn is
-                    the wake marker constant unless a HITL resolution was
-                    appended to it. A bare marker carries nothing forward — the
-                    observation frame rides dynamic_context — so recording it
-                    only accumulates byte-identical duplicates. *)
-                 ~user_turn_record:
-                   (Keeper_run_prompt.user_turn_record_of_hitl_resolution
-                      hitl_resolution)
+                 (* This is an ordinary durable conversation turn. The current
+                    observation remains ephemeral dynamic context, while the
+                    tiny [Continue.] cue and assistant response preserve normal
+                    multi-turn ordering without a separate turn identity. *)
+                 ~user_turn_record:Keeper_run_prompt.Record_user_turn
                  ~history_assistant_source:"internal_assistant"
                  ~degraded_retry_applied:
                    (Option.is_some turn_state.degraded_retry_info)

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -182,7 +182,6 @@ type t =
   | MemoryRecallReadErrors
   | MemoryOsRecallUnavailable
   | MemoryOsExplicitFactWrite
-  | MemoryOsInertTurnExtractionSkipped
   | RuntimeRequestWireBytes
   | RuntimeHttpProbeJsonParseFailures
   | VisionAnalyze
@@ -393,8 +392,6 @@ let to_string = function
       "masc_keeper_memory_os_recall_unavailable_total"
   | MemoryOsExplicitFactWrite ->
       "masc_keeper_memory_os_explicit_fact_write_total"
-  | MemoryOsInertTurnExtractionSkipped ->
-      "masc_keeper_memory_os_inert_turn_extraction_skipped_total"
   | RuntimeRequestWireBytes -> "masc_keeper_runtime_request_wire_bytes"
   | RuntimeHttpProbeJsonParseFailures ->
       "masc_runtime_http_probe_json_parse_failures_total"

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -173,7 +173,6 @@ type t =
   | MemoryRecallReadErrors
   | MemoryOsRecallUnavailable
   | MemoryOsExplicitFactWrite
-  | MemoryOsInertTurnExtractionSkipped
   | RuntimeRequestWireBytes
   | RuntimeHttpProbeJsonParseFailures
   | VisionAnalyze

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1074,10 +1074,11 @@ let keeper_chat_history_freshness config name =
   Printf.sprintf "%s|%s|%s" chat_stamp trace_stamp turn_record_stamp
 ;;
 
-(* An autonomous turn is not a chat-store row (see
-   {!Keeper_autonomous_turn_source}): this read projection carries a typed
-   [autonomous_turn] identity so the dashboard groups it separately from
-   conversation. Final text and work trace come from the same exact OAS run. *)
+(* The canonical autonomous User/Assistant/Tool exchange lives in the Keeper's
+   OAS checkpoint, not as duplicate chat-store rows. This read projection uses
+   typed turn identity only for stable dashboard grouping and exact raw-trace
+   lookup; it is not the Keeper's semantic continuity mechanism. Final text
+   and work trace come from the same exact OAS run. *)
 let autonomous_turn_json (turn : Keeper_autonomous_turn_source.turn) =
   let trace_fields =
     match turn.trace with

--- a/test/test_keeper_memory_lane.ml
+++ b/test/test_keeper_memory_lane.ml
@@ -34,11 +34,7 @@ let rec remove_tree path =
 let make_meta name : Masc.Keeper_meta_contract.keeper_meta =
   match
     Masc_test_deps.meta_of_json_fixture
-      (`Assoc
-         [ "name", `String name
-         ; "agent_name", `String name
-         ; "trace_id", `String ("trace-" ^ name)
-         ])
+      (`Assoc [ "name", `String name ])
   with
   | Ok meta -> meta
   | Error detail -> Alcotest.failf "keeper meta fixture failed: %s" detail
@@ -55,7 +51,6 @@ let run_post_turn ~config ~meta ~turn =
     ~oas_turn_count:1
     ~actual_tools:[]
     ~librarian_messages:[]
-    ~turn_effect_record:Masc.Keeper_run_prompt.Meaningful_turn
     ~post_turn_t0:(Time_compat.now ())
     ~inference_telemetry:None
     ()
@@ -456,10 +451,11 @@ let test_post_turn_librarian_live_config_boundaries () =
             ~base_path:config.base_path
         in
         if poison_snapshot
-        then
+        then (
+          Fs_compat.mkdir_p keepers_dir;
           Unix.mkdir
             (Memory_current.path_for_keepers_dir ~keepers_dir ~keeper_id:keeper_name)
-            0o755;
+            0o755);
         Unix.putenv env_key "true";
         let started, set_started = Eio.Promise.create () in
         let release, set_release = Eio.Promise.create () in

--- a/test/test_keeper_replay_checkpoint.ml
+++ b/test/test_keeper_replay_checkpoint.ml
@@ -1,7 +1,8 @@
 (** Regression tests for the live OAS checkpoint replay contract.
 
-    These tests deliberately exercise typed checkpoint messages. Retired
-    model-authored prose state is not a checkpoint authority. *)
+    These tests deliberately exercise typed checkpoint messages. A successful
+    assistant response is durable conversation state even when the autonomous
+    cycle has no external effect. *)
 
 module Finalize = Masc.Keeper_agent_run_finalize_response.For_testing
 module Replay_prefix = Masc.Keeper_replay_prefix
@@ -9,6 +10,8 @@ module Replay_prefix = Masc.Keeper_replay_prefix
 let message role content =
   Agent_sdk.Types.{ role; content; name = None; tool_call_id = None; metadata = [] }
 ;;
+
+let text_of_message = Agent_sdk.Types.text_of_message
 
 let checkpoint ?(working_context = Some (`Assoc [])) messages =
   Agent_sdk.Checkpoint.
@@ -412,98 +415,112 @@ let test_media_degraded_projection_persists_canonical_checkpoint () =
         (persisted.messages = canonical_history @ [ current_assistant ]))
 ;;
 
-(* RFC-0351 S1 / #25462: a completed bare-wake turn with no tool or external
-   delivery must leave the replay transcript unchanged. The provider still
-   receives the wake marker and may answer with idle prose, but neither is a
-   durable effect. *)
+(* Each autonomous cycle is an ordinary durable user/assistant exchange. This
+   continuation boundary does not depend on a tool call, an external delivery,
+   or a turn identifier. *)
 let wake_marker_text = Masc.Keeper_unified_prompt.autonomous_wake_marker
 
-let wake_persistence ~user_turn_record ~turn_effect_record ~response_text messages =
+let wake_persistence ~history_messages ~response_text messages =
   Finalize.checkpoint_for_replay_persistence
-    ~history_messages:
-      Agent_sdk.Types.
-        [ { role = User
-          ; content = [ Text "seed" ]
-          ; name = None
-          ; tool_call_id = None
-          ; metadata = []
-          }
-        ]
+    ~history_messages
     ~session_id:"new-session"
     ~response_text
-    ~user_turn_record
-    ~turn_effect_record
     (checkpoint messages)
 ;;
 
 let history_seed = [ message Agent_sdk.Types.User [ Agent_sdk.Types.Text "seed" ] ]
 
-let test_inert_wake_does_not_persist_internal_assistant () =
+let test_autonomous_response_is_durable_conversation () =
   Alcotest.(check (option string))
-    "idle prose has no replay authority"
-    None
+    "assistant response is durable without an external effect"
+    (Some "I will inspect the queue next.")
     (Finalize.replay_response_text_for_persistence
-       ~turn_effect_record:Masc.Keeper_run_prompt.Inert_autonomous_turn
        ~suppress_visible_response:false
-       ~response_text:"observed, nothing to do");
-  Alcotest.(check (option string))
-    "meaningful turn keeps replay text"
-    (Some "delivered reply")
-    (Finalize.replay_response_text_for_persistence
-       ~turn_effect_record:Masc.Keeper_run_prompt.Meaningful_turn
-       ~suppress_visible_response:false
-       ~response_text:"delivered reply")
+       ~response_text:"I will inspect the queue next.")
 ;;
 
-let test_inert_wake_does_not_grow_replay () =
+let test_autonomous_turn_persists_cue_and_assistant () =
   let open Agent_sdk.Types in
   let suffix =
     [ message User [ Text wake_marker_text ]
-    ; message Assistant [ Text "observed, nothing to do" ]
+    ; message Assistant [ Text "I will inspect the queue next." ]
     ]
   in
   let patched, _ =
     wake_persistence
-      ~user_turn_record:Masc.Keeper_run_prompt.Skip_uninformative_wake
-      ~turn_effect_record:Masc.Keeper_run_prompt.Inert_autonomous_turn
-      ~response_text:"observed, nothing to do"
+      ~history_messages:history_seed
+      ~response_text:"I will inspect the queue next."
       (history_seed @ suffix)
     |> expect_ok
   in
   Alcotest.(check int)
-    "inert wake leaves only the pre-turn history"
-    1
+    "assistant joins the durable conversation"
+    3
     (List.length patched.messages);
+  Alcotest.(check string)
+    "assistant intent survives"
+    "I will inspect the queue next."
+    (patched.messages |> List.rev |> List.hd |> text_of_message);
   Alcotest.(check bool)
-    "no message carries the wake marker"
-    false
+    "ordinary continuation cue is durable"
+    true
     (List.exists
        (fun (m : message) -> m.content = [ Text wake_marker_text ])
        patched.messages)
 ;;
 
-let test_recorded_turn_keeps_identical_marker_text () =
+let test_two_autonomous_cycles_continue_same_conversation () =
   let open Agent_sdk.Types in
-  let suffix =
+  let first_response = "I will inspect the queue next." in
+  let first_suffix =
     [ message User [ Text wake_marker_text ]
-    ; message Assistant [ Text "reply" ]
+    ; message Assistant [ Text first_response ]
     ]
   in
-  let patched, _ =
+  let first, _ =
     wake_persistence
-      ~user_turn_record:Masc.Keeper_run_prompt.Record_user_turn
-      ~turn_effect_record:Masc.Keeper_run_prompt.Meaningful_turn
-      ~response_text:"reply"
-      (history_seed @ suffix)
+      ~history_messages:history_seed
+      ~response_text:first_response
+      (history_seed @ first_suffix)
     |> expect_ok
   in
-  Alcotest.(check int)
-    "recorded turn persists the user message even with marker text"
-    3
-    (List.length patched.messages)
+  with_temp_dir (fun session_dir ->
+    (match
+       Masc.Keeper_checkpoint_store.save_oas_classified ~session_dir first
+     with
+     | Ok (Masc.Keeper_checkpoint_store.Saved _) -> ()
+     | Ok (Masc.Keeper_checkpoint_store.Stale_noop _) ->
+       Alcotest.fail "first autonomous checkpoint was classified as stale"
+     | Error detail -> Alcotest.fail ("first checkpoint save failed: " ^ detail));
+    let reloaded =
+      match
+        Masc.Keeper_checkpoint_store.load_oas
+          ~session_dir
+          ~session_id:"new-session"
+      with
+      | Ok checkpoint -> checkpoint
+      | Error _ -> Alcotest.fail "first autonomous checkpoint did not reload"
+    in
+    let second_response = "The queue inspection is complete." in
+    let second_suffix =
+      [ message User [ Text wake_marker_text ]
+      ; message Assistant [ Text second_response ]
+      ]
+    in
+    let second, _ =
+      wake_persistence
+        ~history_messages:reloaded.messages
+        ~response_text:second_response
+        (reloaded.messages @ second_suffix)
+      |> expect_ok
+    in
+    Alcotest.(check (list string))
+      "both ordinary turns survive save, reload, and conversation order"
+      [ "seed"; wake_marker_text; first_response; wake_marker_text; second_response ]
+      (List.map text_of_message second.messages))
 ;;
 
-let test_skipped_wake_leaves_non_marker_suffix_untouched () =
+let test_non_marker_user_turn_is_untouched () =
   let open Agent_sdk.Types in
   let suffix =
     [ message User [ Text "an actual user question" ]
@@ -512,34 +529,32 @@ let test_skipped_wake_leaves_non_marker_suffix_untouched () =
   in
   let patched, _ =
     wake_persistence
-      ~user_turn_record:Masc.Keeper_run_prompt.Skip_uninformative_wake
-      ~turn_effect_record:Masc.Keeper_run_prompt.Meaningful_turn
+      ~history_messages:history_seed
       ~response_text:"reply"
       (history_seed @ suffix)
     |> expect_ok
   in
   Alcotest.(check int)
-    "a non-marker leading user message survives the skip record"
+    "ordinary user message remains in replay"
     3
     (List.length patched.messages)
 ;;
 
-let test_skipped_wake_blank_response_drops_only_inert_suffix () =
+let test_blank_response_drops_only_blank_assistant () =
   let open Agent_sdk.Types in
   let suffix =
     [ message User [ Text wake_marker_text ]; message Assistant [ Text "" ] ]
   in
   let patched, _ =
     wake_persistence
-      ~user_turn_record:Masc.Keeper_run_prompt.Skip_uninformative_wake
-      ~turn_effect_record:Masc.Keeper_run_prompt.Inert_autonomous_turn
+      ~history_messages:history_seed
       ~response_text:""
       (history_seed @ suffix)
     |> expect_ok
   in
   Alcotest.(check int)
-    "blank canonicalization keeps only the pre-turn history"
-    1
+    "blank canonicalization keeps the current user turn"
+    2
     (List.length patched.messages)
 ;;
 
@@ -584,25 +599,25 @@ let () =
             `Quick
             test_media_degraded_projection_persists_canonical_checkpoint
         ; Alcotest.test_case
-            "inert wake does not persist internal assistant"
+            "autonomous response is durable conversation"
             `Quick
-            test_inert_wake_does_not_persist_internal_assistant
+            test_autonomous_response_is_durable_conversation
         ; Alcotest.test_case
-            "inert wake does not grow replay"
+            "autonomous turn persists cue and assistant"
             `Quick
-            test_inert_wake_does_not_grow_replay
+            test_autonomous_turn_persists_cue_and_assistant
         ; Alcotest.test_case
-            "recorded turn keeps identical marker text"
+            "two autonomous cycles continue one conversation"
             `Quick
-            test_recorded_turn_keeps_identical_marker_text
+            test_two_autonomous_cycles_continue_same_conversation
         ; Alcotest.test_case
-            "skipped wake leaves non-marker suffix untouched"
+            "non-marker user turn is untouched"
             `Quick
-            test_skipped_wake_leaves_non_marker_suffix_untouched
+            test_non_marker_user_turn_is_untouched
         ; Alcotest.test_case
-            "skipped wake blank response drops only inert suffix"
+            "blank response drops only blank assistant"
             `Quick
-            test_skipped_wake_blank_response_drops_only_inert_suffix
+            test_blank_response_drops_only_blank_assistant
         ] )
     ]
 ;;

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -832,58 +832,15 @@ let test_world_state_never_in_persisted_user_message () =
   check bool "persisted user message carries no board observation" false
     (contains_sub "### Board Activity" user_message)
 
-(* RFC-0351 section 5 / #25462: splitting the frame out of the user message
-   (above) left the marker itself still being recorded once per wake, so the
-   duplication moved from bytes to message count — one keeper accumulated 359
-   copies of the same 147B constant, part of a 25.7% exact-dup transcript
-   share. A bare wake now skips the transcript entirely; only a turn carrying a
-   HITL resolution is recorded. *)
-let test_bare_autonomous_wake_is_not_recorded () =
-  check bool "bare autonomous wake skips the transcript" true
-    (Masc.Keeper_run_prompt.user_turn_record_of_hitl_resolution None
-     = Masc.Keeper_run_prompt.Skip_uninformative_wake);
-  check bool "a turn carrying a HITL resolution is recorded" true
-    (Masc.Keeper_run_prompt.user_turn_record_of_hitl_resolution (Some ())
-     = Masc.Keeper_run_prompt.Record_user_turn)
-
-(* One execution-fact decision now owns both replay persistence and librarian
-   extraction. A routed continuation is meaningful without a tool call; idle
-   model prose on a scheduled bare wake is not. *)
-let test_turn_effect_record () =
-  let decide ~user_turn_record ~tool_calls_made ~external_delivery_routed =
-    Masc.Keeper_run_prompt.turn_effect_record_of_turn
-      ~user_turn_record ~tool_calls_made ~external_delivery_routed
+(* An autonomous cycle is an ordinary next user turn in the same durable
+   conversation. Only the observation frame is kept out of history. *)
+let test_autonomous_continuation_is_an_ordinary_user_turn () =
+  let { Masc.Keeper_unified_prompt.user_message; _ } =
+    build_prompt ~meta:minimal_meta base_observation
   in
-  check bool "bare wake with no effect is inert" true
-    (decide
-       ~user_turn_record:Masc.Keeper_run_prompt.Skip_uninformative_wake
-       ~tool_calls_made:false
-       ~external_delivery_routed:false
-     = Masc.Keeper_run_prompt.Inert_autonomous_turn);
-  check bool "bare wake that ran a tool is meaningful" true
-    (decide
-       ~user_turn_record:Masc.Keeper_run_prompt.Skip_uninformative_wake
-       ~tool_calls_made:true
-       ~external_delivery_routed:false
-     = Masc.Keeper_run_prompt.Meaningful_turn);
-  check bool "routed continuation is meaningful without a tool" true
-    (decide
-       ~user_turn_record:Masc.Keeper_run_prompt.Skip_uninformative_wake
-       ~tool_calls_made:false
-       ~external_delivery_routed:true
-     = Masc.Keeper_run_prompt.Meaningful_turn);
-  check bool "operator/HITL input is meaningful without a tool" true
-    (decide
-       ~user_turn_record:Masc.Keeper_run_prompt.Record_user_turn
-       ~tool_calls_made:false
-       ~external_delivery_routed:false
-     = Masc.Keeper_run_prompt.Meaningful_turn);
-  check bool "operator/HITL input with a tool call is meaningful" true
-    (decide
-       ~user_turn_record:Masc.Keeper_run_prompt.Record_user_turn
-       ~tool_calls_made:true
-       ~external_delivery_routed:true
-     = Masc.Keeper_run_prompt.Meaningful_turn)
+  check string "autonomous continuation uses a compact ordinary cue"
+    "Continue."
+    user_message
 
 let post_id_exn s =
   match Masc.Board.Post_id.of_string s with
@@ -1051,10 +1008,7 @@ let () =
             "invariant: world-state frame never enters the persisted user message"
             `Quick test_world_state_never_in_persisted_user_message;
           test_case
-            "invariant: a bare autonomous wake is not recorded in the transcript"
-            `Quick test_bare_autonomous_wake_is_not_recorded;
-          test_case
-            "invariant: one turn-effect record owns replay and librarian"
-            `Quick test_turn_effect_record;
+            "invariant: autonomous continuation is an ordinary user turn"
+            `Quick test_autonomous_continuation_is_an_ordinary_user_turn;
         ] );
     ]


### PR DESCRIPTION
## What changed

- Treat every scheduled autonomous cycle as an ordinary durable `User("Continue.")` turn followed by its Assistant/Tool suffix in the same OAS checkpoint.
- Remove the `Inert_autonomous_turn` / external-effect heuristic that discarded successful model responses and skipped Librarian admission.
- Keep fresh world observation in per-turn dynamic context while preserving conversation order across save, reload, compaction, and the next cycle.
- Keep `turn_id` only as dashboard projection/trace identity; it does not provide semantic continuity.
- Repair the touched memory-lane fixture so its live configuration boundary test reaches the behavior it asserts.

## Why

The autonomous lane classified a bare wake as uninformative and then discarded the entire provider suffix when the turn made no tool call or external delivery. That erased assistant plans such as “I will inspect the queue next,” so the next scheduled cycle could not continue the Keeper's own prior intent even though the Keeper had a durable checkpoint.

Persistence now follows the normal multi-turn model: stable instructions plus one durable conversation checkpoint, with fresh world state supplied ephemerally on each cycle. No turn identifier is required to reconstruct meaning.

## Validation

- `test_keeper_replay_checkpoint.exe` — 14 passed, including two autonomous cycles across checkpoint save/reload
- `test_keeper_unified_verification_surface.exe` — 29 passed
- `test_keeper_memory_lane.exe` — 11 passed
- `test_keeper_context_core_dedup.exe` — 15 passed
- `test_compaction_llm_summarizer.exe` — 11 passed
- `test_keeper_post_turn_wirein_order.exe` — 12 passed with loopback fixture
- Dashboard Vitest: 148 passed across keeper state, autonomous grouping, and config editing
- Dashboard `tsc --noEmit` passed
- `git diff --check` passed
