### PR TITLE
fix(test): board-attention worker 스위트가 keeper owner 를 등록하도록 (main 실패 5→1)

### DIFF
--- a/test/test_keeper_board_attention_worker.ml
+++ b/test/test_keeper_board_attention_worker.ml
@@ -28,8 +28,32 @@ let rec remove_tree path =
     else Sys.remove path
 ;;
 
+(* Completing a partition projects it onto the keeper's registry entry
+   (keeper_board_attention_worker.ml:637); without one the projection fails
+   with "exact completion lost its registered owner" before any assertion in
+   the test body is reached. The registry is process-local, so a fresh temp
+   base_path starts with no owner. test_keeper_board_attention_exact_flow.ml:75
+   carries the same helper for the same reason. *)
+let register_owner ~base_path keeper_name =
+  match Masc.Keeper_registry.get ~base_path keeper_name with
+  | Some _ -> ()
+  | None ->
+    let meta =
+      Masc_test_deps.meta_of_json_fixture
+        (`Assoc
+          [ "name", `String keeper_name
+          ; "trace_id", `String ("trace-" ^ keeper_name)
+          ])
+      |> Result.get_ok
+    in
+    ignore
+      (Masc.Keeper_registry.register_offline ~base_path keeper_name meta
+       : Masc.Keeper_registry.registry_entry)
+;;
+
 let with_temp_base name f =
   let base_path = Filename.temp_dir name "" in
+  register_owner ~base_path "sangsu";
   Fun.protect ~finally:(fun () -> remove_tree base_path) (fun () -> f base_path)
 ;;
 


### PR DESCRIPTION
## 무엇

`test_keeper_board_attention_worker` 의 `with_temp_base` 가 keeper 를 프로세스 로컬 레지스트리에 등록하도록 한다. `#27009` 의 5건 중 **4건**이 해소된다.

```
origin/main    5 failures! in 0.090s. 32 tests run.
이 브랜치      1 failure!  in 0.09s.  32 tests run.
```

## 원인

완료된 partition 은 keeper 의 레지스트리 엔트리로 투영된다 (`keeper_board_attention_worker.ml:637`):

```ocaml
match Keeper_registry.get ~base_path completed.Partition.keeper_name with
| Some owner -> Ok (Completion_projected (completed, owner))
| None -> Error ("exact completion lost its registered owner before projection: " ^ ...)
```

`Keeper_registry` 는 in-memory (`Atomic.get registry` 위의 `StringMap`) 이고 키는 `registry_key ~base_path name` 이다. `with_temp_base` 는 매번 새 임시 디렉토리를 만들므로 owner 가 없는 상태에서 시작한다. 그래서 테스트 본문의 단언에 닿기 전에 투영이 실패했다.

형제 스위트 `test_keeper_board_attention_exact_flow.ml:75` 에 같은 이유의 같은 헬퍼가 이미 있다. 이 스위트에만 없었다.

## 프로덕션 영향은 없다

이 에러 경로는 라이브에서 한 번도 발화하지 않았다.

```bash
rg -c 'lost its registered owner|board attention worker stopped|Board attention worker failed' \
   ~/.masc/logs/system_log_2026-08-0*.jsonl
# 0건 (5개 파일)

# positive control — 같은 명령 형태로 알려진 문자열
rg -c 'board_attention_worker_drain' ~/.masc/logs/system_log_2026-08-05.jsonl
# 69
```

프로덕션에서는 lane 시작 시 keeper 가 등록되므로 owner 가 항상 존재한다. 테스트만 그 전제를 안 세웠다.

## 언제부터

가드는 `#25711` (`e530c44aa6`, 2026-07-26) 이 도입했다. 같은 커밋이 이 테스트 파일도 +165 줄 수정했지만 등록은 추가하지 않았다. 스위트가 `.github/workflows/` 어디에도 배선돼 있지 않아 10일간 붉은 채로 남았다.

## 남은 1건 — 이 PR 이 고치지 않는다

```
[FAIL] 27  same quarantine command CAS loser converges
ASSERT same command CAS loser converges: partition_state_conflict
```

등록과 무관한 별개 원인이다. `Q.For_testing.execute_with_before_partition_commit` 의 CAS 패자 수렴 경로에서 production 과 테스트 기대가 어긋난다. `#27009` 에 남긴다.

**따라서 이 PR 은 스위트를 CI 에 배선하지 않는다.** 1건이 남은 상태로 배선하면 main 이 red 가 된다. 배선은 27번이 해소된 뒤다.

## 검증

```
dune build test/test_keeper_board_attention_worker.exe   exit 0
스위트 실행                                              32 tests, 1 failure (main 은 5)
```

before/after 가 그 자체로 대조군이다 — `register_owner` 호출 한 줄의 유무로 실패가 5건 ↔ 1건 사이를 오간다.

관련: #27009 · #26863
