### PR TITLE
fix(auth): 에러 분류기를 계약이 주장하는 만큼 실제로 닫는다

### DIFF
--- a/lib/auth/auth_error_kind.ml
+++ b/lib/auth/auth_error_kind.ml
@@ -52,7 +52,16 @@ let classify : Masc_domain.t -> t = function
   | Masc_domain.Agent (Masc_domain.Agent_error.NotFound _) -> Agent_not_found
   | Masc_domain.System (Masc_domain.System_error.IoError _) -> Io_error
   | Masc_domain.System (Masc_domain.System_error.InvalidJson _) -> Invalid_json
-  | _ -> Other
+  (* Named rather than swept, so the closure this module documents is the one
+     the compiler enforces: every Auth_error constructor is placed above, and a
+     new one cannot reach [Other] without an edit here. The remaining families
+     have no auth-relevant label of their own. *)
+  | Masc_domain.Agent _
+  | Masc_domain.System _
+  | Masc_domain.Task _
+  | Masc_domain.RateLimitExceeded _
+  | Masc_domain.CacheError _ ->
+    Other
 
 let all =
   [ Token_mismatch


### PR DESCRIPTION
## 문제

`auth_error_kind.ml` 헤더가 이 variant 가 존재하는 이유를 명시한다.

> The variant is closed so that any new auth-relevant `Masc_domain.t` constructor that needs its own label **requires an explicit code change here, not a silent fall-through to `["other"]`**.

그런데 `classify` 가 이렇게 끝난다.

```ocaml
| Masc_domain.System (Masc_domain.System_error.InvalidJson _) -> Invalid_json
| _ -> Other
```

**그게 바로 그 fall-through 다.** 새 `Auth_error` 생성자는 편집도 경고도 없이 `"other"` 메트릭 라벨과 로그 라인을 가져간다. 이 라벨은 `.mli` 가 *"stable string label used in otel_metric_store metric dimensions"* 라고 못박은 값이다.

## 수정

모든 family 를 이름으로 부른다.

**컴파일러가 중간에 한마디 했다.** 처음에 `| Masc_domain.Auth _` 를 sweep 목록에 넣었더니 `warning 12 [redundant-subpat]` 로 거부됐다 — `Auth_error` 다섯 생성자가 이미 전부 위에 놓여 있다는 증명이다. 그래서 뺐다.

## 닫혔다는 것의 증명

catch-all 을 없앤 뒤 `Masc_error.Auth_error.t` 에 생성자를 하나 추가해봤다.

```
Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
```

빌드가 깨진다 (warning 8 은 이 프로파일에서 fatal). 추가한 생성자는 되돌렸고, 되돌린 뒤 `@check` 는 다시 통과한다.

## 남는 것

`Agent` / `System` / `Task` / `RateLimitExceeded` / `CacheError` 는 여전히 `Other` 로 간다. auth 관련 라벨이 따로 없기 때문이고, **이름으로 적어두었으므로** 최상위 family 가 새로 생기면 그것도 눈에 들어온다.

**오늘 존재하는 어떤 에러도 분류가 바뀌지 않는다.**

## 검증

- `dune build --root . @check` EXIT=0
- `test_auth_error_kind`, `test_auth_error_kind_dashboard_fallback`, `test_mcp_error_code`, `test_auth`, `test_auth_bearer_mismatch_9786` OK
- `scripts/check-doc-code-refs.sh`, `scripts/audit-keeper-tool-boundary-matrix.sh` PASS

RFC-WAIVED: 이 변경은 인증 정책을 만들지 않는다. 모듈이 문서로 약속한 폐쇄성을 컴파일러가 강제하도록 catch-all 을 명시적 열거로 바꾼다. 기존 에러의 분류·메트릭 라벨·로그 문자열 전부 불변. `lib/keeper/credential_*`, `lib/repo_manager/`, `lib/operator/operator_control*`, keeper sandbox, dashboard credential component, hooks, workflow 문서 어느 것도 건드리지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
