### PR TITLE
fix(keeper): owner 정산 상한을 전달 기준으로 (폐기 판정이 슬롯을 잡지 않도록)

### DIFF
--- a/lib/keeper/keeper_board_attention_worker.ml
+++ b/lib/keeper/keeper_board_attention_worker.ml
@@ -1581,51 +1581,89 @@ let replay_completed_owner_wake
     Ok (Some (wake_owner ~base_path ~keeper_name))
 ;;
 
+(* What this boundary rations is admission into the Keeper, and only a
+   [Relevant] verdict admits anything: [Candidate.consume_judged] enqueues a
+   stimulus and wakes the owner for [Relevant], and writes one consumed record
+   for [Not_relevant]. Counting a discarded signal against the same per-turn
+   slot puts every relevant verdict behind however many irrelevant ones share
+   its [created_at] order, which is the shape RFC-0334 removed when it deleted
+   the fanout limit and arrival window. Settle the discards, stop on the
+   delivery. *)
+let settles_without_admitting (item : Partition.completed_item) =
+  match item.judgment.Candidate.verdict.Keeper_board_attention_judgment.decision with
+  | Keeper_board_attention_judgment.Not_relevant -> true
+  | Keeper_board_attention_judgment.Relevant -> false
+;;
+
 let settle_one_completed
       ~base_path
       ~keeper_name
   =
-  let* completed = completed_in_order ~base_path ~keeper_name in
-  match completed with
-  | [] -> Ok No_completed_partition
-  | partition :: _ ->
+  let settle_head partition =
     let* partition =
       confirm_loaded_completed
         ~base_path
         "completed owner settlement"
         partition
     in
-    (match partition.state with
-     | Partition.Completed { item; _ } ->
-       let* (_ : Candidate.candidate) =
-         Candidate.apply_judgment_and_deliver
-           ~base_path
-           ~keeper_name
-           ~candidate_id:item.candidate_id
-           ~judgment:item.judgment
-       in
-       let* settled =
-         Partition.settle
-           ~now:(Time_compat.now ())
-           ~base_path
-           ~partition
-       in
-       let* remaining = completed_in_order ~base_path ~keeper_name in
-       let continuation_wake =
-         match remaining with
-         | [] -> None
-         | _ :: _ -> Some (owner_wake ~base_path ~keeper_name)
-       in
-       Ok
-         (Partition_settled
-            { candidate_id = settled.candidate_id; continuation_wake })
-     | Partition.Ready
-     | Partition.Running _
-     | Partition.Settled _
-     | Partition.Blocked _ ->
-       Error
-         ("completed partition query returned non-Completed state: "
-          ^ partition.partition_id))
+    match partition.Partition.state with
+    | Partition.Completed { item; _ } ->
+      let* (_ : Candidate.candidate) =
+        Candidate.apply_judgment_and_deliver
+          ~base_path
+          ~keeper_name
+          ~candidate_id:item.candidate_id
+          ~judgment:item.judgment
+      in
+      let* settled =
+        Partition.settle ~now:(Time_compat.now ()) ~base_path ~partition
+      in
+      Ok (settled, settles_without_admitting item)
+    | Partition.Ready
+    | Partition.Running _
+    | Partition.Settled _
+    | Partition.Blocked _ ->
+      Error
+        ("completed partition query returned non-Completed state: "
+         ^ partition.partition_id)
+  in
+  (* Terminates: every iteration settles one partition out of [completed], and
+     the list is the snapshot taken before the loop. Completions the worker
+     adds while this runs are left for the continuation wake. *)
+  let rec settle_until_admission ~last_settled ~discarded = function
+    | [] -> Ok (last_settled, discarded)
+    | partition :: rest ->
+      let* settled, discarded_only = settle_head partition in
+      if discarded_only
+      then
+        settle_until_admission
+          ~last_settled:settled
+          ~discarded:(discarded + 1)
+          rest
+      else Ok (settled, discarded)
+  in
+  let* completed = completed_in_order ~base_path ~keeper_name in
+  match completed with
+  | [] -> Ok No_completed_partition
+  | first :: _ ->
+    let* settled, discarded =
+      settle_until_admission ~last_settled:first ~discarded:0 completed
+    in
+    if discarded > 0
+    then
+      Log.Keeper.info
+        "board_attention_discards_settled keeper=%s count=%d"
+        keeper_name
+        discarded;
+    let* remaining = completed_in_order ~base_path ~keeper_name in
+    let continuation_wake =
+      match remaining with
+      | [] -> None
+      | _ :: _ -> Some (owner_wake ~base_path ~keeper_name)
+    in
+    Ok
+      (Partition_settled
+         { candidate_id = settled.Partition.candidate_id; continuation_wake })
 ;;
 
 let recovered_mutex = Stdlib.Mutex.create ()

--- a/test/test_keeper_board_attention_worker.ml
+++ b/test/test_keeper_board_attention_worker.ml
@@ -28,8 +28,32 @@ let rec remove_tree path =
     else Sys.remove path
 ;;
 
+(* Completing a partition projects it onto the keeper's registry entry
+   (keeper_board_attention_worker.ml:637); without one the projection fails
+   with "exact completion lost its registered owner" before any assertion in
+   the test body is reached. The registry is process-local, so a fresh temp
+   base_path starts with no owner. test_keeper_board_attention_exact_flow.ml:75
+   carries the same helper for the same reason. *)
+let register_owner ~base_path keeper_name =
+  match Masc.Keeper_registry.get ~base_path keeper_name with
+  | Some _ -> ()
+  | None ->
+    let meta =
+      Masc_test_deps.meta_of_json_fixture
+        (`Assoc
+          [ "name", `String keeper_name
+          ; "trace_id", `String ("trace-" ^ keeper_name)
+          ])
+      |> Result.get_ok
+    in
+    ignore
+      (Masc.Keeper_registry.register_offline ~base_path keeper_name meta
+       : Masc.Keeper_registry.registry_entry)
+;;
+
 let with_temp_base name f =
   let base_path = Filename.temp_dir name "" in
+  register_owner ~base_path "sangsu";
   Fun.protect ~finally:(fun () -> remove_tree base_path) (fun () -> f base_path)
 ;;
 
@@ -345,6 +369,75 @@ let test_worker_exact_callback_integration_and_owner_settlement () =
   match (load_one_candidate ~base_path).status, (load_one_partition ~base_path).state with
   | A.Consumed { delivery = A.Not_relevant; _ }, P.Settled _ -> ()
   | _ -> Alcotest.fail "owner settlement did not consume and settle the judgment"
+;;
+
+(* The owner slot rations admission into the Keeper, and only a Relevant
+   verdict admits anything. A Not_relevant completion writes one consumed
+   record and enqueues nothing, so holding the slot for it puts every relevant
+   verdict behind however many irrelevant ones precede it in created_at order
+   (#26863: 48 relevant behind 459 discards, worst at position 202). *)
+let test_discards_do_not_hold_the_owner_delivery_slot () =
+  with_temp_base "board-attention-worker-discard-drain" @@ fun base_path ->
+  let discarded =
+    record ~base_path (candidate ~id:"candidate-discarded" ~recorded_at:1.0 ())
+  in
+  let admitted =
+    record ~base_path (candidate ~id:"candidate-admitted" ~recorded_at:2.0 ())
+  in
+  let judge_next decision =
+    let execute ~before_dispatch ~before_advance prepared =
+      let attempt = provenance ("attempt-" ^ A.(prepared.candidate_id)) in
+      ok "bind" (before_dispatch attempt);
+      ignore before_advance;
+      Ok (judgment attempt decision)
+    in
+    match
+      ok
+        "judge next pending"
+        (process ~base_path ~prepare:(fun candidate -> Ok candidate) ~execute)
+    with
+    | W.Judgment_completed { candidate_id; _ } -> candidate_id
+    | W.Idle
+    | W.Contended _
+    | W.Rescan_later _
+    | W.Candidate_already_consumed _
+    | W.Partition_blocked _ -> Alcotest.fail "fixture did not complete a judgment"
+  in
+  let first = judge_next J.Not_relevant in
+  let second = judge_next J.Relevant in
+  Alcotest.(check string)
+    "the discard is judged first"
+    discarded.candidate_id
+    first;
+  Alcotest.(check string)
+    "the admission is judged second"
+    admitted.candidate_id
+    second;
+  (match
+     ok "owner settlement" (W.settle_one_completed ~base_path ~keeper_name:"sangsu")
+   with
+   | W.Partition_settled { candidate_id; _ } ->
+     Alcotest.(check string)
+       "one call reaches the relevant verdict behind the discard"
+       admitted.candidate_id
+       candidate_id
+   | W.No_completed_partition -> Alcotest.fail "no completion was settled");
+  Alcotest.(check int)
+    "the relevant verdict reached the Keeper queue"
+    1
+    (relevant_delivery_count ~base_path ~candidate_id:admitted.candidate_id);
+  List.iter
+    (fun (candidate : A.candidate) ->
+       match
+         List.find_opt
+           (fun (c : A.candidate) ->
+              String.equal c.candidate_id candidate.candidate_id)
+           (ok "load" (A.load_candidates ~base_path ~keeper_name:"sangsu"))
+       with
+       | Some { status = A.Consumed _; _ } -> ()
+       | Some _ | None ->
+         Alcotest.failf "candidate %s was left unsettled" candidate.candidate_id)
+    [ discarded; admitted ]
 ;;
 
 let test_setup_error_stops_before_claim_without_hot_retry () =
@@ -2262,6 +2355,10 @@ let () =
             "undrained outcomes are not routine"
             `Quick
             test_undrained_outcomes_are_not_routine
+        ; Alcotest.test_case
+            "discards do not hold the owner delivery slot"
+            `Quick
+            test_discards_do_not_hold_the_owner_delivery_slot
         ; Alcotest.test_case
             "drain outcome labels stay distinct"
             `Quick


### PR DESCRIPTION
`#27015` 를 흡수한다 (같은 파일, 같은 스위트, 새 테스트가 그 수정 없이는 검증 불가). 27015 는 닫는다.

## 무엇

`settle_one_completed` 이 owner 턴 슬롯을 **전달(delivery)** 기준으로 쓰게 한다. 폐기 정산은 슬롯을 잡지 않는다.

## 왜

이 경계가 배급하는 것은 **keeper 안으로의 admission** 이다. 그런데 admission 을 만드는 것은 `Relevant` 뿐이다 (`keeper_board_attention_candidate.ml:1921`):

| verdict | 하는 일 |
|---|---|
| `Relevant` | `enqueue_if_missing_durable_result` + `request_owner_wake` |
| `Not_relevant` | `mark_consumed` — **파일 쓰기 한 번. enqueue 없음, wake 없음** |

`completed_in_order` 는 `created_at` 오름차순 FIFO 다 (`:1529`). 그래서 아무것도 전달하지 않는 정산이 앞에 있으면 relevant 판정은 그 뒤에서 턴당 1칸씩 기다린다.

라이브 실측 (`#26863`, 2026-08-05 21:27):

```
판정완료-미적용 507건
    459 (90%)  not_relevant
     48 ( 9%)  relevant

keeper           relevant 대기   앞에 막힌 not_relevant   가장 오래된 relevant
  code-reviewer            11                     192                  20.2h
  taskmaster               27                      56                   5.9h
  sangsu                    9                      59                   5.5h
  analyst                   1                      29                   3.8h

최악 대기 순번 202번째
```

**LLM 이 "이 keeper 가 봐야 한다" 고 판정하고 비용까지 쓴 48건이, keeper 를 전혀 건드리지 않는 459건 뒤에 줄 서 있다.**

## 선례

`docs/rfc/RFC-0334-board-mailbox-turn-digest.md` (Superseded):

> The earlier design coupled Board delivery to a local fanout limit and an arrival-time batching window. That made **a process-local scheduling choice decide which Keepers could observe a persisted Board event.**

턴당 1건 정산 상한은 같은 문장이 적용되는 자리다. 이 PR 은 상한을 없애지 않고 **올바른 대상(전달)에 건다.**

## 어떻게

```ocaml
let settles_without_admitting item =
  match item.judgment.Candidate.verdict.decision with
  | Not_relevant -> true
  | Relevant -> false
```

`settle_until_admission` 이 선두의 폐기를 정산하며 진행하고 **첫 전달에서 멈춘다.** 종료성: 매 반복이 루프 진입 전에 찍은 `completed` 스냅샷에서 하나씩 소비한다. 루프 도중 워커가 추가하는 완료는 기존과 동일하게 continuation wake 로 넘어간다.

폐기가 있었으면 `board_attention_discards_settled keeper=%s count=%d` 를 남긴다 — 한 턴이 몇 개를 흘려보냈는지 운영자가 본다.

반환 타입(`settlement`)은 그대로다.

## 흡수한 #27015

`with_temp_base` 가 keeper 를 프로세스 로컬 레지스트리에 등록한다. 완료 partition 은 owner 엔트리로 투영되는데 (`keeper_board_attention_worker.ml:637`) 임시 base_path 에는 owner 가 없어, 스위트 32건 중 5건이 본문 단언 전에 죽고 있었다.

가드는 `#25711` (`e530c44aa6`, 07-26) 이 도입했고 같은 커밋이 이 테스트 파일도 +165 줄 고쳤지만 등록은 추가하지 않았다. 스위트가 CI 에 배선돼 있지 않아 10일간 붉었다.

프로덕션 영향은 없다:

```bash
rg -c 'lost its registered owner|board attention worker stopped|Board attention worker failed' \
   ~/.masc/logs/system_log_2026-08-0*.jsonl        # 0건 (5파일)
rg -c 'board_attention_worker_drain' ~/.masc/logs/system_log_2026-08-05.jsonl   # 69 (positive control)
```

## 검증

```
dune build lib/masc.cmxa                                exit 0
test_keeper_board_attention_worker                      33 tests, 1 failure
```

남은 1건은 `#27009` 의 `same quarantine command CAS loser converges` — 수동 quarantine 명령 경로이고 이 PR 과 무관하다. origin/main 에서도 실패한다.

**새 테스트** `discards do not hold the owner delivery slot`: not_relevant 를 먼저, relevant 를 나중에 완료시킨 뒤 `settle_one_completed` 를 **한 번** 호출해 relevant 가 반환·전달되는지 확인한다.

**Negative control**: `settles_without_admitting` 을 항상 `false` 로 되돌리자(= 기존 동작) 실패 1건 → 2건, 추가된 실패가 정확히 이 테스트였다. 복구 후 재통과.

## 검증하지 않은 것

- 라이브에서 backlog 가 실제로 몇 턴에 빠지는지. 현재 바이너리 배포 후 `board_attention_discards_settled` 카운트로 확인할 수 있다.
- 한 턴이 최대 몇 건을 정산하게 되는지의 상한. 스냅샷 크기로 자연히 묶이지만 숫자로 고정하지 않았다 — 고정하면 그게 다시 RFC-0334 가 지운 종류의 로컬 스케줄링 선택이 된다.

관련: #26863 · #27009 · #27015(흡수)
