### PR TITLE
docs: retire the prose left behind by three deletion PRs

### DIFF
--- a/lib/dashboard/dashboard_http_helpers.mli
+++ b/lib/dashboard/dashboard_http_helpers.mli
@@ -7,11 +7,9 @@
 
 (** {1 Environment-variable parsing} *)
 
-(** [true] iff the env var is set to ["1" | "true" | "yes" | "y"]
-    (case/whitespace insensitive). Default [false]. *)
-
 val bool_default_true_of_env : string -> bool
-(** Inverse default: [false] only when set to ["0" | "false" | "no" | "n"]. *)
+(** [false] only when the env var is set to ["0" | "false" | "no" | "n"]
+    (case/whitespace insensitive); [true] otherwise, including when unset. *)
 
 val int_of_env_default :
   string -> default:int -> min_v:int -> max_v:int -> int
@@ -23,7 +21,6 @@ val float_of_env_default :
 
 (** {1 Dashboard-tunable limits} *)
 
-
 val operator_snapshot_recent_completed_limit : unit -> int
 
 (** {1 Tag/detail parsing} *)
@@ -32,9 +29,6 @@ val bool_of_tag_value : string -> bool
 (** Truthy tag value: ["1" | "true" | "yes" | "y" | "on"], case-insensitive. *)
 
 (** {1 Numeric helpers} *)
-
-(** Nearest-rank percentile over a non-empty sorted copy of [values].
-    Returns [None] for the empty list. *)
 
 val safe_age_seconds_opt :
   now_ts:float -> event_ts:float -> int option
@@ -61,8 +55,6 @@ val json_string_field_opt : string -> Yojson.Safe.t -> string option
 
 val json_assoc_field : string -> Yojson.Safe.t -> Yojson.Safe.t
 (** Extract a record field; returns [`Assoc \[\]] on missing/wrong-type. *)
-
-(** Like {!json_assoc_field} but [None] when missing/wrong-type. *)
 
 (** {1 List helpers} *)
 

--- a/lib/dashboard_api_types/README.md
+++ b/lib/dashboard_api_types/README.md
@@ -11,11 +11,13 @@ response the Bonsai island consumes. Two consumers:
 - **Server** — `lib/dashboard/dashboard_http_*.ml` serialize via
   `<Module>.response_to_yojson` instead of hand-rolling
   `Yojson.Safe.t` trees.
-- **Client** — `dashboard_bonsai/src/*_types.ml` deserialize via
-  `<Module>.response_of_yojson`.
+- **Client** — `dashboard_bonsai/src/*_types.ml` restate the record by hand
+  and read it with `Yojson.Safe.Util`. The client does not link this
+  library, so it never calls a generated decoder.
 
-A schema change is a single `.ml` edit; both sides re-compile against the
-new type.
+Only the encoder is derived (`to_yojson`). A schema change is therefore two
+edits — this library, then the client mirror — and no compiler checks that
+the second one happened.
 
 ## Modules
 
@@ -48,9 +50,11 @@ Full ppx sharing is Phase 2.
 
 ## Guarantees we do **not** make
 
-- Field order in generated JSON — use `strict = false` so clients tolerate
-  extra fields and server can add without breaking the contract.
-- Variant tags — encoded as JSON strings (`"Live"` / `"Warn"` / `"Dead"`).
-  Renaming requires a paired server+client deploy.
+- Field order in generated JSON — the client reads each field by name with
+  `Yojson.Safe.Util.member`, so order is free and a field the mirror does not
+  know about is ignored rather than fatal.
+- Variant tags — `ppx_deriving_yojson` emits a one-element array
+  (`["Live"]` / `["Warn"]` / `["Dead"]`), not a bare string. Renaming a
+  constructor requires a paired server+client deploy.
 - Backward compatibility for removed fields — remove at end of a Bonsai
   migration phase only, never mid-release.

--- a/lib/dashboard_utils/dashboard_utils.mli
+++ b/lib/dashboard_utils/dashboard_utils.mli
@@ -1,7 +1,6 @@
 (** Dashboard utility primitives — small string/JSON helpers, severity
-    ranking, and three ADTs (health level, session lifecycle, tone) that
-    replace ad-hoc string matching across the dashboard, briefing, and
-    operator modules. *)
+    ranking, and two ADTs (health level, tone) that replace ad-hoc string
+    matching across the dashboard, briefing, and operator modules. *)
 
 (** {1 Time} *)
 
@@ -16,8 +15,6 @@ val first_some : 'a option -> 'a option -> 'a option
 
 val string_contains : needle:string -> string -> bool
 (** Case-sensitive substring test. *)
-
-(** [Some s] for non-empty trimmed text, [None] otherwise. *)
 
 val dedup_strings : string list -> string list
 (** Order-preserving deduplication via local [String_set]. *)
@@ -46,8 +43,6 @@ val string_field : ?default:string -> string -> Yojson.Safe.t -> string
 
 val list_field : string -> Yojson.Safe.t -> Yojson.Safe.t list
 (** Read [key] as a [`List]. Default [[]]. *)
-
-(** Wrap as [`List of `String]. *)
 
 (** {1 Ranking} *)
 
@@ -80,7 +75,6 @@ val is_keeper_offline : string -> bool
 val is_health_critical : health_level -> bool
 val is_health_warning : health_level -> bool
 val is_health_at_risk : health_level -> bool
-
 
 (** {1 Tone} *)
 

--- a/lib/workspace/workspace_utils_ops.mli
+++ b/lib/workspace/workspace_utils_ops.mli
@@ -163,15 +163,12 @@ val with_file_lock_impl :
   config -> string -> (unit -> 'a) -> 'a
 
 (** Cooperative file lock (Eio mutex for in-process, distributed
-    lock for FileSystem backend); explicit clock argument. *)
-
-(** Cooperative file lock; uses [Eio_context.get_clock_opt]. *)
+    lock for FileSystem backend); uses [Eio_context.get_clock_opt]. *)
 val with_file_lock : config -> string -> (unit -> 'a) -> 'a
 
 val with_file_lock_r_impl :
   ?clock:_ Eio.Time.clock ->
   config -> string -> (unit -> 'a) -> ('a, masc_error) result
-
 
 val with_file_lock_r :
   config -> string -> (unit -> 'a) -> ('a, masc_error) result

--- a/scripts/audit-dead-surface.py
+++ b/scripts/audit-dead-surface.py
@@ -43,19 +43,29 @@ WHAT THIS TOOL CANNOT DECIDE
 Unreachable is not the same as removable, and the difference is a judgement no
 scan makes for you. Categories found so far, each from an actual candidate:
 
-  Spec bridges. `recovery` exports `all_error_mode_tla_symbols`; nothing in
-  OCaml or `scripts/` reads it. If such a list exists so a conformance test can
-  enumerate the symbol set, deleting it removes the seam rather than dead
-  weight -- ask whoever owns the spec.
+  Spec bridges. A module may export an `all_*` symbol list or a
+  `*_to_tla_symbol` mapper that nothing in OCaml or `scripts/` reads, on the
+  theory that a conformance test enumerates it. Three questions decide whether
+  that is a seam or dead weight:
 
-  This category was settled once, against it. `keeper_composite_observer`
+    Does anything actually enumerate it? A consumer -- test, generator,
+    codegen step -- makes it a seam, and deleting it removes the check.
+
+    Is the type already pinned by an equality re-export (`type decision_stage
+    = Keeper_registry.decision_stage = ...`)? That is what fails the build
+    when a constructor is added upstream. A literal list cannot; it goes
+    stale in silence, so its existence is not evidence of a seam.
+
+    Does the spec it cites still exist? A `.tla` path in a comment outlives
+    the file it points at.
+
+  Answered once already, against the list: `keeper_composite_observer`
   exported `all_tla_actions`, `tla_action_of_string` and six `all_*` lists,
-  deleted in #26988: no conformance test enumerated any of them, and the spec
-  file they named no longer exists. What actually pins the spec's enums is the
-  equality-type re-export (`type decision_stage = Keeper_registry.decision_stage
-  = ...`), which fails the build when a constructor is added upstream. A literal
-  list cannot do that -- it goes stale silently. Look for the re-export before
-  concluding a list is the seam.
+  deleted in #26988. Nothing enumerated them, the re-export was doing the
+  work, and the spec file they named was gone.
+
+  Naming today's live examples here is what made this paragraph go stale
+  twice. State the test, not the roster.
 
   Alternative entry points onto a live path. `Audit_log` exported six wrappers
   over `log_action` and a second route into `Dated_jsonl.prune`. "Nothing calls

--- a/scripts/audit-dead-surface.py
+++ b/scripts/audit-dead-surface.py
@@ -43,12 +43,19 @@ WHAT THIS TOOL CANNOT DECIDE
 Unreachable is not the same as removable, and the difference is a judgement no
 scan makes for you. Categories found so far, each from an actual candidate:
 
-  Spec bridges. `keeper_composite_observer` exports `all_tla_actions`,
-  `tla_action_of_string` and siblings backing
-  `specs/keeper-state-machine/KeeperCompositeLifecycle.tla`; `recovery` exports
-  `all_error_mode_tla_symbols`. Nothing in OCaml or `scripts/` reads them. If
-  they exist so a conformance test can enumerate the symbol set, deleting them
-  removes the seam rather than dead weight -- ask whoever owns the spec.
+  Spec bridges. `recovery` exports `all_error_mode_tla_symbols`; nothing in
+  OCaml or `scripts/` reads it. If such a list exists so a conformance test can
+  enumerate the symbol set, deleting it removes the seam rather than dead
+  weight -- ask whoever owns the spec.
+
+  This category was settled once, against it. `keeper_composite_observer`
+  exported `all_tla_actions`, `tla_action_of_string` and six `all_*` lists,
+  deleted in #26988: no conformance test enumerated any of them, and the spec
+  file they named no longer exists. What actually pins the spec's enums is the
+  equality-type re-export (`type decision_stage = Keeper_registry.decision_stage
+  = ...`), which fails the build when a constructor is added upstream. A literal
+  list cannot do that -- it goes stale silently. Look for the re-export before
+  concluding a list is the seam.
 
   Alternative entry points onto a live path. `Audit_log` exported six wrappers
   over `log_action` and a second route into `Dated_jsonl.prune`. "Nothing calls


### PR DESCRIPTION
## 왜

#26988 · #26992 · #26996 이 코드를 지웠는데 그 코드를 설명하던 산문은 남았다. 적대적 검증(커밋별 skeptic 3명 + 독립 재현 검증)이 7건을 확인했고, **동작 결함은 0건**이다. 전부 사라진 심볼을 가리키는 텍스트다.

이 저장소는 `.mli` 에서 doc-after-val 관습을 쓴다. `val` 줄만 지우면 그 아래 주석이 **다음 val 위로 떠올라 그 함수의 문서로 렌더링된다.** 그래서 이건 단순 잔여물이 아니라 오문서다.

## 가장 나쁜 케이스

```ocaml
(** [true] iff the env var is set to ["1" | "true" | "yes" | "y"]
    (case/whitespace insensitive). Default [false]. *)

val bool_default_true_of_env : string -> bool
```

위 주석은 삭제된 `bool_of_env` 의 것이다. 지금은 `bool_default_true_of_env` 의 doc 으로 렌더링되는데, 이 함수는 **정확히 반대로 동작한다** (`dashboard_http_helpers.ml:6-11`: 미설정 시 `true`). 남아 있던 자기 doc 도 "Inverse default" 로 시작해 사라진 이름을 암묵 참조했다. 둘 다 동작 서술로 교체했다.

## 변경

| 파일 | 내용 |
|---|---|
| `dashboard_http_helpers.mli` | 고아 doc 3개 (`bool_of_env`, `percentile_int`, `json_record_field`) 제거, `bool_default_true_of_env` doc 자립화 |
| `dashboard_utils.mli` | 헤더 "three ADTs (health level, session lifecycle, tone)" → session_lifecycle 이 삭제됐으므로 two |
| `workspace_utils_ops.mli` | `with_file_lock_eio` 의 고아 doc — 버리지 않고 `with_file_lock` 쪽으로 흡수 |
| `dashboard_api_types/README.md` | 아래 |
| `audit-dead-surface.py` | 아래 |

`with_file_lock_eio` 건은 삭제 대신 흡수를 택했다. 그 주석의 "Eio mutex for in-process, distributed lock for FileSystem backend" 는 참인 정보이고, `with_file_lock` 이 `with_file_lock_impl` 에 위임하므로 (`workspace_utils_ops.ml:606-607`) 동일하게 적용된다. 살아있는 val 의 doc 에는 그 서술이 없었다.

## README 두 건

`response_of_yojson` 을 클라이언트 역직렬화 경로로 명시하는데, `Keepers.response_of_yojson` 이 그런 유일한 심볼이었고 #26992 가 지웠다. 그리고 `strict = false` 를 wire 호환 장치로 설명하는데 그 옵션도 같이 사라졌다.

실제 동작으로 교체했다: 클라이언트(`dashboard_bonsai/src/keepers_types.ml`)는 이 라이브러리를 **링크하지 않는다.** 레코드를 손으로 다시 적고 `Yojson.Safe.Util` 로 읽는다. 그래서 스키마 변경은 두 곳 편집이고, 두 번째를 했는지 컴파일러가 검사하지 않는다.

## 사전 존재 오류 3건 (같이 고침)

같은 파일을 이 결함 때문에 여는 김에 처리했다. 제 커밋 소행이 아니다.

- `dashboard_utils.mli` 고아 주석 2개 — 어떤 심볼도 서술하지 않음
- README "Variant tags — encoded as JSON strings (`"Live"`)" — **거짓**. 검증 중 미분 프로브(ocaml 5.5.0 / ppx_deriving_yojson 3.10.0, `71e3bd4b4c^` 와 `71e3bd4b4c` 를 같은 스위치에서 나란히 컴파일)가 실측:

  ```
  keeper_status Live -> ["Live"]
  payload -> {..."status":["Live"]...}
  ```

  1원소 배열이다. before/after 동일 — 이 커밋과 무관한 기존 오류.

  클라이언트는 두 형태를 다 받으므로 (`keepers_types.ml:86-87`) 실동작 버그는 없다. 다만 그 코드가 배열 쪽을 "ppx variant fallback" 이라 부르는데 서버가 실제 내보내는 게 배열이고 `` `String`` arm 이 죽은 가지다 — 별건이라 안 건드렸다.

## audit-dead-surface.py

이게 제일 해롭다. 이 파일의 "WHAT THIS TOOL CANNOT DECIDE" 가 **제가 방금 지운 심볼들을 "지우지 말고 스펙 소유자에게 물어봐" 의 정본 예시로** 쓰고 있었다.

```
Spec bridges. `keeper_composite_observer` exports `all_tla_actions`,
`tla_action_of_string` and siblings backing
`specs/keeper-state-machine/KeeperCompositeLifecycle.tla`; ...
```

셋 다 없다. 심볼 2개는 #26988 이 지웠고, **명시된 스펙 파일은 애초에 존재하지 않는다** (`ls specs/keeper-state-machine/` 에 없음).

다음 에이전트를 정반대로 인도하는 문서다. 살아있는 예시(`recovery.all_error_mode_tla_symbols`, `recovery.mli:130` 현존)로 교체하고, 결론난 판정을 기록했다: 스펙 enum 을 실제로 고정하는 건 리터럴 리스트가 아니라 equality-type 재export 다.

```ocaml
type decision_stage = Keeper_registry.decision_stage = ...
```

상류에 생성자가 추가되면 빌드가 깨진다. 리스트는 조용히 낡는다. 리스트를 seam 으로 단정하기 전에 재export 를 찾으라는 판별 기준을 남겼다.

## 범위 밖 (보고만)

- `keeper_composite_observer.mli` 가 존재하지 않는 `KeeperCompositeLifecycle.tla` 를 6곳에서 인용 (line anchor 4개 포함). #26988 은 그중 1곳만 제거. 나머지 5곳은 사전 존재.
- `docs/rfc/RFC-0071-inventory.csv` 4행이 이제 잘못된 줄을 가리킴. 단 검증자 측정으로 **제 커밋 이전에 이미 76행이 어긋나 있었다** (이후 80행). 4행만 손보는 건 N-of-M 패치라 제외. CSV·`exhaustive-guard.allowlist` 둘 다 CI 미연결.
- `to_yojson` 전환으로 `keepers.ml` 이 `scripts/lint/yojson-option-default.py` 범위에서 빠짐. 단 그 lint 는 `DECODING_DERIVERS = {"yojson","of_yojson"}` 로 **encoder-only 를 의도적으로 면제한다** (#10537). 규칙대로 동작한 것이고, #26992 본문이 이를 언급하지 않은 게 누락이다.

## 검증

| 항목 | 결과 |
|---|---|
| `dune build --root . @check` | EXIT=0 |
| `python3 -m py_compile scripts/audit-dead-surface.py` | EXIT=0 |
| `bash scripts/check-doc-truth.sh` | EXIT=0 |
| `git diff -U0 -- '*.mli'` 중 `val`/`type` 변경 | 0건 |

시그니처는 하나도 건드리지 않았다. 주석과 산문만이다.

## 검증 커버리지 한계

적대적 검증 워크플로의 18 에이전트 중 4개가 세션 한도로 실패했다: `lens:orphan-docs`, `lens:dynamic-paths`, `lens:build-level`, 그리고 `audit-dead-surface.py` 주장의 독립 재현. orphan-docs 스윕은 제가 직접 대신 돌렸다 (세 커밋의 삭제 식별자 84개를 저장소 전역 word-match). dynamic-paths 와 build-level 은 **미실행**이다.

Co-authored-by: MASC Agent <agent@masc.local>
Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>
