### PR TITLE
[Gitflow] feat(keeper): add board attention worker start/drain logging (task-187)

### DIFF
--- a/lib/keeper/keeper_board_attention_worker.ml
+++ b/lib/keeper/keeper_board_attention_worker.ml
@@ -1709,6 +1709,14 @@ let drain_available
     ~execute
 ;;
 
+let drain_outcome_to_string = function
+  | Drained -> "drained"
+  | Retry_later { reason = Exact_claim_contended; _ } ->
+    "retry_exact_claim_contended"
+  | Retry_later { reason = Selected_generation_changed; _ } ->
+    "retry_selected_generation_changed"
+;;
+
 let run
       ~sw
       ~(clock : [> float Eio.Time.clock_ty ] Eio.Resource.t)
@@ -1728,6 +1736,10 @@ let run
          with_process_recovery_claim ~base_path ~keeper_name
          @@ fun owns_process_recovery ->
          let worker_epoch = Partition.Worker_epoch.generate () in
+         Log.Keeper.info
+           "board_attention_worker_start keeper=%s generation=%s"
+           keeper_name
+           (Partition.Worker_epoch.to_string worker_epoch);
          let fail stage detail =
            observe_error ~base_path ~keeper_name detail;
            Error { stage; detail }
@@ -1784,6 +1796,10 @@ let run
                  ~execute
              with
              | Ok outcome ->
+               Log.Keeper.info
+                 "board_attention_worker_drain keeper=%s outcome=%s"
+                 keeper_name
+                 (drain_outcome_to_string outcome);
                ignore
                  (apply_drain_rearm contention_rearms outcome
                   : rearm_schedule option);


### PR DESCRIPTION
## 배경

task-178/181에서 승인된 분석을 실제 코드로 구현한다. board attention worker(`lib/keeper/keeper_board_attention_worker.ml`)가 fork됐는지, drain을 시도했는지, pending을 발견했는지 전혀 로그로 알 수 없었다. task-175 실측(pending 425→1031, contention 0, worker failed 0)이 "worker가 살아서 돌고 있는지"를 알 수 없는 구분 불가 상태를 보여줬다.

## 변경 내용

`Log.Keeper.info` 레벨로 2줄 로그 추가:

1. **worker 시작 로그** — `run` 함수의 registration 성공 직후
   ```
   board_attention_worker_start keeper=%s generation=%s
   ```
   worker가 fork되어 등록됐음을 증명. generation 값으로 몇 번째 fork인지 추적.

2. **drain 결과 로그** — `drain_available_current` 반환 후 `await()` 재진입 전
   ```
   board_attention_worker_drain keeper=%s outcome=%s
   ```
   Drained / retry_exact_claim_contended / retry_selected_generation_changed 구분.

`drain_outcome_to_string` 헬퍼 추가로 drain_outcome을 로그 문자열로 변환.

## 검증

- `dune build lib/keeper/keeper_board_attention_worker.ml` 통과
- 기존 동작 회귀 없음 (로그 추가만, 제어 흐름 변경 없음)

## 수용 기준

- [x] Log.Keeper.info 레벨로 2줄 로그 추가
- [x] worker 시작 로그는 registration 성공 직후
- [x] drain 결과 로그는 drain_available_current 반환 후 await() 재진입 전
- [x] 기존 동작 회귀 없음 (컴파일 통과)
- [x] PR은 draft로 남기기