### PR TITLE
fix(validation): enforce declared schema bounds and name the failing field

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -955,6 +955,28 @@ jobs:
           chmod +x scripts/ci-run-tests.sh
           scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_verification"
 
+      # Declared JSON-Schema bounds (minimum/maximum/exclusiveMinimum/
+      # exclusiveMaximum/minLength/maxLength/minItems/maxItems) are dropped
+      # by Tool_bridge.params_of_json_schema, so for a long time nothing
+      # read them: keeper_artifact_read answered max_bytes=565244 with a
+      # message naming sha256 (2026-08-05 20:06:36, keeper kidsnote). These
+      # suites assert the bounds are enforced pre-dispatch, that every
+      # declaration masc holds is reachable and readable by that
+      # enforcement, and that artifact-read rejections name the field that
+      # actually failed without changing which requests are served.
+      - name: Run tool input constraint enforcement suite
+        id: tool_input_constraint_enforcement_suite
+        if: ${{ always() && steps.build_step.outcome == 'success' }}
+        env:
+          ME_ROOT: /tmp/me
+          CI_TEST_HEARTBEAT_SEC: 15
+          DUNE_JOBS: 1
+        run: |
+          mkdir -p /tmp/me
+          chmod +x scripts/ci-run-tests.sh
+          constraint_targets="@test/runtest-test_tool_schema_constraint_enforcement @test/runtest-test_keeper_artifact_read_request"
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . ${constraint_targets}"
+
       # The tool-call quality benchmark scores keeper runs against selectors
       # declared in benchmarks/data/tool_call_quality_cases.json. Those
       # selectors name descriptors in the live keeper registry, so deleting or

--- a/lib/keeper/keeper_artifact_read.ml
+++ b/lib/keeper/keeper_artifact_read.ml
@@ -22,41 +22,124 @@ type page =
   ; content : string
   }
 
+let minimum_offset = 0
+
+(** Why an integer-typed request field could not be read. [Yojson.Safe]
+    parses an integer literal that does not fit a native [int] into
+    [`Intlit], which this parser has always rejected — naming that case
+    keeps it distinguishable from "not an integer at all". *)
+type invalid_integer_field =
+  | Not_an_integer of { kind : string }
+  | Literal_out_of_int_range of { literal : string }
+  | Literal_not_a_json_integer of { literal : string }
+  | Below_minimum of
+      { value : int
+      ; minimum : int
+      }
+  | Above_maximum of
+      { value : int
+      ; maximum : int
+      }
+
+(** Which field of an artifact-read request failed, and why. Every
+    rejection carries its own field so the caller is never told to fix
+    [sha256] when [sha256] was correct. *)
+type invalid_request =
+  | Not_an_object of { kind : string }
+  | Sha256_missing
+  | Sha256_not_a_string of { kind : string }
+  | Sha256_malformed of Tool_output.invalid_sha256
+  | Offset_invalid of invalid_integer_field
+  | Max_bytes_invalid of invalid_integer_field
+
+let invalid_integer_field_to_string ~field = function
+  | Not_an_integer { kind } ->
+    Printf.sprintf "%s must be an integer, got %s" field kind
+  | Literal_out_of_int_range { literal } ->
+    Printf.sprintf
+      "%s integer literal %s is outside the native integer range"
+      field
+      literal
+  | Literal_not_a_json_integer { literal } ->
+    Printf.sprintf
+      "%s must be a JSON integer, got the unparsed integer literal %s"
+      field
+      literal
+  | Below_minimum { value; minimum } ->
+    Printf.sprintf "%s %d is below minimum %d" field value minimum
+  | Above_maximum { value; maximum } ->
+    Printf.sprintf "%s %d exceeds maximum %d" field value maximum
+;;
+
+let invalid_request_to_string = function
+  | Not_an_object { kind } -> Printf.sprintf "expected an object, got %s" kind
+  | Sha256_missing -> "sha256 is required"
+  | Sha256_not_a_string { kind } ->
+    Printf.sprintf "sha256 must be a string, got %s" kind
+  | Sha256_malformed invalid ->
+    Printf.sprintf
+      "sha256 is malformed: %s"
+      (Tool_output.invalid_sha256_to_string invalid)
+  | Offset_invalid detail -> invalid_integer_field_to_string ~field:"offset" detail
+  | Max_bytes_invalid detail ->
+    invalid_integer_field_to_string ~field:"max_bytes" detail
+;;
+
+let sha256_of_fields fields =
+  match List.assoc_opt "sha256" fields with
+  | None -> Error Sha256_missing
+  | Some (`String value) ->
+    (match Tool_output.validate_sha256 value with
+     | Ok () -> Ok value
+     | Error invalid -> Error (Sha256_malformed invalid))
+  | Some other -> Error (Sha256_not_a_string { kind = Json_util.kind_name other })
+;;
+
+(** Read one bounded integer field. [`Intlit] is matched explicitly rather
+    than swept into a wildcard: it is a distinct condition (an integer the
+    wire carried but OCaml cannot hold natively), and it stays rejected. *)
+let bounded_integer_of_fields fields ~field ~default ~minimum ~maximum =
+  let bounded value =
+    if value < minimum
+    then Error (Below_minimum { value; minimum })
+    else if value > maximum
+    then Error (Above_maximum { value; maximum })
+    else Ok value
+  in
+  match List.assoc_opt field fields with
+  | None -> Ok default
+  | Some (`Int value) -> bounded value
+  | Some (`Intlit literal) ->
+    (match int_of_string_opt literal with
+     | None -> Error (Literal_out_of_int_range { literal })
+     | Some _ -> Error (Literal_not_a_json_integer { literal }))
+  | Some other -> Error (Not_an_integer { kind = Json_util.kind_name other })
+;;
+
 let request_of_json = function
   | `Assoc fields ->
-    let sha256 =
-      match List.assoc_opt "sha256" fields with
-      | Some (`String value) -> Some value
-      | _ -> None
+    let ( let* ) = Result.bind in
+    let* sha256 = sha256_of_fields fields in
+    let* offset =
+      bounded_integer_of_fields
+        fields
+        ~field:"offset"
+        ~default:minimum_offset
+        ~minimum:minimum_offset
+        ~maximum:max_int
+      |> Result.map_error (fun detail -> Offset_invalid detail)
     in
-    let offset =
-      match List.assoc_opt "offset" fields with
-      | None -> Some 0
-      | Some (`Int value) -> Some value
-      | _ -> None
+    let* max_bytes =
+      bounded_integer_of_fields
+        fields
+        ~field:"max_bytes"
+        ~default:default_max_bytes
+        ~minimum:minimum_max_bytes
+        ~maximum:maximum_max_bytes
+      |> Result.map_error (fun detail -> Max_bytes_invalid detail)
     in
-    let max_bytes =
-      match List.assoc_opt "max_bytes" fields with
-      | None -> Some default_max_bytes
-      | Some (`Int value) -> Some value
-      | _ -> None
-    in
-    (match sha256, offset, max_bytes with
-     | Some sha256, Some offset, Some max_bytes
-       when offset >= 0
-            && max_bytes >= minimum_max_bytes
-            && max_bytes <= maximum_max_bytes ->
-       (match Tool_output.validate_sha256 sha256 with
-        | Ok () -> Ok { sha256; offset; max_bytes }
-        | Error invalid ->
-          Error (Tool_output.invalid_sha256_to_string invalid))
-     | _ ->
-       Error
-         (Printf.sprintf
-            "expected sha256, non-negative offset, and max_bytes %d..%d"
-            minimum_max_bytes
-            maximum_max_bytes))
-  | _ -> Error "expected an object"
+    Ok { sha256; offset; max_bytes }
+  | other -> Error (Not_an_object { kind = Json_util.kind_name other })
 ;;
 
 let invalid_input message =
@@ -191,7 +274,7 @@ let page (request : request) bytes =
 
 let handle ~base_path ~args =
   match request_of_json args with
-  | Error message -> invalid_input message
+  | Error invalid -> invalid_input (invalid_request_to_string invalid)
   | Ok request ->
     let store = Tool_blob_store.create ~base_path in
     (match

--- a/lib/keeper/keeper_artifact_read.mli
+++ b/lib/keeper/keeper_artifact_read.mli
@@ -68,6 +68,10 @@ val handle :
   base_path:string ->
   args:Yojson.Safe.t ->
   Keeper_tool_execution.t
+(** Total request boundary for every caller, including direct in-process uses
+    that do not traverse [Tool_input_validation]. The dispatch pre-hook rejects
+    the same declared bounds earlier, but never replaces this parser's ownership
+    of the handler input contract. *)
 
 module For_testing : sig
   val request_of_json : Yojson.Safe.t -> (request, invalid_request) result

--- a/lib/keeper/keeper_artifact_read.mli
+++ b/lib/keeper/keeper_artifact_read.mli
@@ -11,12 +11,44 @@ val default_max_bytes : int
 
 val maximum_max_bytes : int
 val minimum_max_bytes : int
+val minimum_offset : int
 
 type request =
   { sha256 : string
   ; offset : int
   ; max_bytes : int
   }
+
+(** Why an integer-typed request field could not be read. [Yojson.Safe]
+    represents an integer literal that exceeds the native [int] range as
+    [`Intlit]; that case is rejected under its own name instead of being
+    swept into a wildcard. *)
+type invalid_integer_field =
+  | Not_an_integer of { kind : string }
+  | Literal_out_of_int_range of { literal : string }
+  | Literal_not_a_json_integer of { literal : string }
+  | Below_minimum of
+      { value : int
+      ; minimum : int
+      }
+  | Above_maximum of
+      { value : int
+      ; maximum : int
+      }
+
+(** Which request field was rejected, and why. A caller whose [sha256] was
+    correct is never told to fix [sha256]. *)
+type invalid_request =
+  | Not_an_object of { kind : string }
+  | Sha256_missing
+  | Sha256_not_a_string of { kind : string }
+  | Sha256_malformed of Tool_output.invalid_sha256
+  | Offset_invalid of invalid_integer_field
+  | Max_bytes_invalid of invalid_integer_field
+
+val invalid_request_to_string : invalid_request -> string
+(** Renders one rejection into the [message] field of the
+    [{"ok":false,"error":"invalid_artifact_read","message":…}] envelope. *)
 
 type page_encoding =
   | Utf_8
@@ -38,7 +70,7 @@ val handle :
   Keeper_tool_execution.t
 
 module For_testing : sig
-  val request_of_json : Yojson.Safe.t -> (request, string) result
+  val request_of_json : Yojson.Safe.t -> (request, invalid_request) result
   val page : request -> string -> (page, string) result
   val page_to_json : page -> Yojson.Safe.t
 end

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -348,6 +348,369 @@ let schema_shape_error schema args =
   | [] -> one_of_required_shape_error schema args
 ;;
 
+(* ---------------------------------------------------------------- *)
+(* Declared range/length constraints                                  *)
+(*                                                                    *)
+(* [Tool_bridge.params_of_json_schema] projects a JSON Schema onto the *)
+(* OAS [tool_param] record, which carries name/type/required only.     *)
+(* Every minimum/maximum/minLength/maxLength/minItems/maxItems is      *)
+(* dropped there, so the SDK validation hook cannot see it. These      *)
+(* checks therefore read the raw JSON Schema masc already holds.       *)
+(* ---------------------------------------------------------------- *)
+
+type numeric_keyword =
+  | Minimum
+  | Maximum
+  | Exclusive_minimum
+  | Exclusive_maximum
+
+type count_keyword =
+  | Min_length
+  | Max_length
+  | Min_items
+  | Max_items
+
+let numeric_keyword_json_name = function
+  | Minimum -> "minimum"
+  | Maximum -> "maximum"
+  | Exclusive_minimum -> "exclusiveMinimum"
+  | Exclusive_maximum -> "exclusiveMaximum"
+;;
+
+let count_keyword_json_name = function
+  | Min_length -> "minLength"
+  | Max_length -> "maxLength"
+  | Min_items -> "minItems"
+  | Max_items -> "maxItems"
+;;
+
+let numeric_keywords = [ Minimum; Maximum; Exclusive_minimum; Exclusive_maximum ]
+let count_keywords = [ Min_length; Max_length; Min_items; Max_items ]
+
+let constraint_keyword_json_names =
+  List.map numeric_keyword_json_name numeric_keywords
+  @ List.map count_keyword_json_name count_keywords
+;;
+
+(** A rejection caused by declared constraints. [Argument_out_of_range] is
+    the caller's fault; [Schema_bound_malformed] is masc's — a declared
+    bound that cannot be read. Both fail closed, and both keep the field
+    path so the message names what to change. *)
+type constraint_failure =
+  | Argument_out_of_range of string
+  | Schema_bound_malformed of string
+
+type numeric_value =
+  | Numeric_int of int
+  | Numeric_float of float
+
+let numeric_of_json : Yojson.Safe.t -> numeric_value option = function
+  | `Int value -> Some (Numeric_int value)
+  | `Float value -> Some (Numeric_float value)
+  | `Intlit literal ->
+    (match int_of_string_opt literal with
+     | Some value -> Some (Numeric_int value)
+     | None ->
+       (match float_of_string_opt literal with
+        | Some value -> Some (Numeric_float value)
+        | None -> None))
+  | `Null | `Bool _ | `String _ | `Assoc _ | `List _ -> None
+;;
+
+let numeric_to_float = function
+  | Numeric_int value -> Float.of_int value
+  | Numeric_float value -> value
+;;
+
+(* Two ints compare exactly; anything else goes through float, which is
+   the widest common representation the wire can carry. *)
+let numeric_compare left right =
+  match left, right with
+  | Numeric_int left, Numeric_int right -> Int.compare left right
+  | (Numeric_int _ | Numeric_float _), (Numeric_int _ | Numeric_float _) ->
+    Float.compare (numeric_to_float left) (numeric_to_float right)
+;;
+
+let numeric_to_string = function
+  | Numeric_int value -> string_of_int value
+  | Numeric_float value -> Printf.sprintf "%g" value
+;;
+
+(* JSON Schema counts string length in characters, not bytes. Counting
+   bytes would reject a Korean title well under a declared maxLength. *)
+let utf8_character_count source =
+  let source_length = String.length source in
+  let rec loop index count =
+    if index >= source_length
+    then count
+    else (
+      let decoded = String.get_utf_8_uchar source index in
+      (* [utf_decode_length] is at least 1 even for an invalid byte, so the
+         walk always terminates. *)
+      loop (index + Uchar.utf_decode_length decoded) (count + 1))
+  in
+  loop 0 0
+;;
+
+let count_bound_of_json : Yojson.Safe.t -> int option = function
+  | `Int value when value >= 0 -> Some value
+  | `Float value
+    when Float.is_integer value
+         && value >= 0.0
+         && value <= Float.of_int Int.max_int -> Some (int_of_float value)
+  | `Intlit literal ->
+    (match int_of_string_opt literal with
+     | Some value when value >= 0 -> Some value
+     | Some _ | None -> None)
+  | `Int _
+  | `Float _
+  | `Null
+  | `Bool _
+  | `String _
+  | `Assoc _
+  | `List _
+  -> None
+;;
+
+let malformed_bound ~path ~keyword ~declared =
+  Schema_bound_malformed
+    (Printf.sprintf
+       "schema declares an unreadable %s for %s: %s"
+       keyword
+       path
+       (Yojson.Safe.to_string declared))
+;;
+
+(* A value whose JSON kind the keyword does not apply to is left alone:
+   the declared [type] is enforced by the OAS hook that already ran, so a
+   surviving mismatch means the schema itself pairs a keyword with an
+   incompatible type. [test_tool_input_validation] pins that no masc
+   schema does. *)
+let numeric_constraint_failure ~path ~keyword ~declared value =
+  match numeric_of_json value with
+  | None -> None
+  | Some actual ->
+    (match numeric_of_json declared with
+     | None ->
+       Some
+         (malformed_bound
+            ~path
+            ~keyword:(numeric_keyword_json_name keyword)
+            ~declared)
+     | Some bound ->
+       let comparison = numeric_compare actual bound in
+       let violated =
+         match keyword with
+         | Minimum -> comparison < 0
+         | Exclusive_minimum -> comparison <= 0
+         | Maximum -> comparison > 0
+         | Exclusive_maximum -> comparison >= 0
+       in
+       if not violated
+       then None
+       else (
+         let actual_text = numeric_to_string actual in
+         let bound_text = numeric_to_string bound in
+         Some
+           (Argument_out_of_range
+              (match keyword with
+               | Minimum ->
+                 Printf.sprintf
+                   "%s %s is below minimum %s"
+                   path
+                   actual_text
+                   bound_text
+               | Exclusive_minimum ->
+                 Printf.sprintf
+                   "%s %s is not greater than exclusiveMinimum %s"
+                   path
+                   actual_text
+                   bound_text
+               | Maximum ->
+                 Printf.sprintf
+                   "%s %s exceeds maximum %s"
+                   path
+                   actual_text
+                   bound_text
+               | Exclusive_maximum ->
+                 Printf.sprintf
+                   "%s %s is not less than exclusiveMaximum %s"
+                   path
+                   actual_text
+                   bound_text))))
+;;
+
+let count_constraint_failure ~path ~keyword ~declared value =
+  let measured =
+    match keyword, value with
+    | (Min_length | Max_length), `String text -> Some (utf8_character_count text)
+    | (Min_items | Max_items), `List items -> Some (List.length items)
+    | (Min_length | Max_length | Min_items | Max_items), _ -> None
+  in
+  match measured with
+  | None -> None
+  | Some actual ->
+    (match count_bound_of_json declared with
+     | None ->
+       Some
+         (malformed_bound ~path ~keyword:(count_keyword_json_name keyword) ~declared)
+     | Some bound ->
+       let violated =
+         match keyword with
+         | Min_length | Min_items -> actual < bound
+         | Max_length | Max_items -> actual > bound
+       in
+       if not violated
+       then None
+       else
+         Some
+           (Argument_out_of_range
+              (match keyword with
+               | Min_length ->
+                 Printf.sprintf
+                   "%s has %d character(s), below minLength %d"
+                   path
+                   actual
+                   bound
+               | Max_length ->
+                 Printf.sprintf
+                   "%s has %d character(s), above maxLength %d"
+                   path
+                   actual
+                   bound
+               | Min_items ->
+                 Printf.sprintf
+                   "%s has %d item(s), below minItems %d"
+                   path
+                   actual
+                   bound
+               | Max_items ->
+                 Printf.sprintf
+                   "%s has %d item(s), above maxItems %d"
+                   path
+                   actual
+                   bound)))
+;;
+
+let child_property_path parent name =
+  if String.equal parent "" then name else parent ^ "." ^ name
+;;
+
+let rec constraint_failures ~path schema value =
+  match schema with
+  | `Assoc schema_fields ->
+    let declared_here =
+      List.filter_map
+        (fun keyword ->
+           match
+             List.assoc_opt (numeric_keyword_json_name keyword) schema_fields
+           with
+           | None -> None
+           | Some declared -> numeric_constraint_failure ~path ~keyword ~declared value)
+        numeric_keywords
+      @ List.filter_map
+          (fun keyword ->
+             match
+               List.assoc_opt (count_keyword_json_name keyword) schema_fields
+             with
+             | None -> None
+             | Some declared -> count_constraint_failure ~path ~keyword ~declared value)
+          count_keywords
+    in
+    let nested =
+      match value with
+      | `Assoc value_fields ->
+        (match List.assoc_opt "properties" schema_fields with
+         | Some (`Assoc property_schemas) ->
+           List.concat_map
+             (fun (property_name, property_schema) ->
+                match List.assoc_opt property_name value_fields with
+                | None -> []
+                | Some property_value ->
+                  constraint_failures
+                    ~path:(child_property_path path property_name)
+                    property_schema
+                    property_value)
+             property_schemas
+         | _ -> [])
+      | `List items ->
+        (match List.assoc_opt "items" schema_fields with
+         | Some (`Assoc _ as item_schema) ->
+           List.concat
+             (List.mapi
+                (fun index item ->
+                   constraint_failures
+                     ~path:(Printf.sprintf "%s[%d]" path index)
+                     item_schema
+                     item)
+                items)
+         | _ -> [])
+      | _ -> []
+    in
+    declared_here @ nested
+  | _ -> []
+;;
+
+(** First declared-constraint failure for [args], or [None]. A malformed
+    bound is reported ahead of an out-of-range argument: masc's own schema
+    defect must not be blamed on the caller. *)
+let schema_constraint_failure schema args =
+  let failures = constraint_failures ~path:"" schema args in
+  match
+    List.find_opt
+      (function
+        | Schema_bound_malformed _ -> true
+        | Argument_out_of_range _ -> false)
+      failures
+  with
+  | Some malformed -> Some malformed
+  | None ->
+    (match failures with
+     | [] -> None
+     | first :: _ -> Some first)
+;;
+
+(** Every constraint declaration {!constraint_failures} can reach, as
+    ["<field path>:<keyword>"]. Compared in tests against a raw scan of the
+    whole schema so a declaration placed where the walker does not descend
+    (a [oneOf] branch, a tuple-form [items]) is caught instead of silently
+    unenforced. *)
+let rec constraint_declaration_paths_at ~path schema =
+  match schema with
+  | `Assoc schema_fields ->
+    let declared_here =
+      List.filter_map
+        (fun keyword_name ->
+           if List.mem_assoc keyword_name schema_fields
+           then Some (Printf.sprintf "%s:%s" path keyword_name)
+           else None)
+        constraint_keyword_json_names
+    in
+    let nested_properties =
+      match List.assoc_opt "properties" schema_fields with
+      | Some (`Assoc property_schemas) ->
+        List.concat_map
+          (fun (property_name, property_schema) ->
+             constraint_declaration_paths_at
+               ~path:(child_property_path path property_name)
+               property_schema)
+          property_schemas
+      | _ -> []
+    in
+    let nested_items =
+      match List.assoc_opt "items" schema_fields with
+      | Some (`Assoc _ as item_schema) ->
+        constraint_declaration_paths_at ~path:(path ^ "[]") item_schema
+      | _ -> []
+    in
+    declared_here @ nested_properties @ nested_items
+  | _ -> []
+;;
+
+let constraint_declaration_paths schema =
+  constraint_declaration_paths_at ~path:"" schema
+;;
+
 let retired_transition_alias_names ~name = function
   | `Assoc fields when String.equal name "masc_transition" ->
     fields
@@ -512,16 +875,32 @@ let validation_action ?schema ~name ~args () : Tool_dispatch.pre_hook_action =
            Option.map (validation_schema_of_json ~name:lookup_name) schema_opt
          in
          let hook = Agent_sdk.Tool_middleware.make_validation_hook ~lookup in
+         (* Declared ranges are checked only once the SDK has accepted the
+            declared types, so a mistyped value reports its type error
+            rather than a confusing range error. *)
          (match hook ~name ~args:prepared_args with
-    | Agent_sdk.Tool_middleware.Pass when not (Yojson.Safe.equal prepared_args args) ->
-      let reason = pass_reason ~schema:(Some schema) ~args ~prepared_args in
-      emit_validation_telemetry ~tool:name ~result:"pass" ~reason;
-      Log.Tool_validation.debug "tool_input_validation normalized args for %s" name;
-      Tool_dispatch.Proceed prepared_args
     | Agent_sdk.Tool_middleware.Pass ->
-      let reason = pass_reason ~schema:(Some schema) ~args ~prepared_args in
-      emit_validation_telemetry ~tool:name ~result:"pass" ~reason;
-      Tool_dispatch.Pass
+      (match schema_constraint_failure schema prepared_args with
+       | Some (Argument_out_of_range message) ->
+         reject_validation
+           ~name
+           ~reason:"invalid_args"
+           ~message:(Printf.sprintf "Tool '%s' %s" name message)
+       | Some (Schema_bound_malformed message) ->
+         reject_validation
+           ~name
+           ~reason:"malformed_schema"
+           ~message:(Printf.sprintf "Tool '%s' %s" name message)
+       | None ->
+         let reason = pass_reason ~schema:(Some schema) ~args ~prepared_args in
+         emit_validation_telemetry ~tool:name ~result:"pass" ~reason;
+         if Yojson.Safe.equal prepared_args args
+         then Tool_dispatch.Pass
+         else (
+           Log.Tool_validation.debug
+             "tool_input_validation normalized args for %s"
+             name;
+           Tool_dispatch.Proceed prepared_args))
     | Agent_sdk.Tool_middleware.Reject { message; _ } ->
       emit_validation_telemetry ~tool:name ~result:"fail" ~reason:"invalid_args";
       Log.Tool_validation.info "tool_input_validation rejected %s: %s" name message;

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -406,29 +406,39 @@ type numeric_value =
 
 let numeric_of_json : Yojson.Safe.t -> numeric_value option = function
   | `Int value -> Some (Numeric_int value)
-  | `Float value -> Some (Numeric_float value)
+  | `Float value when Float.is_finite value -> Some (Numeric_float value)
   | `Intlit literal ->
     (match int_of_string_opt literal with
      | Some value -> Some (Numeric_int value)
-     | None ->
-       (match float_of_string_opt literal with
-        | Some value -> Some (Numeric_float value)
-        | None -> None))
-  | `Null | `Bool _ | `String _ | `Assoc _ | `List _ -> None
+     | None -> None)
+  | `Float _ | `Null | `Bool _ | `String _ | `Assoc _ | `List _ -> None
 ;;
 
-let numeric_to_float = function
-  | Numeric_int value -> Float.of_int value
-  | Numeric_float value -> value
+(* Compare one native integer with one finite float without first rounding
+   the integer to IEEE-754. [float_of_int] loses units above 2^53, which can
+   otherwise make [maximum=9007199254740992.0] accept the integer one above
+   it. OCaml ints occupy [Sys.int_size - 1] value bits; the positive limit is
+   not itself representable as an int, while the negative limit is [min_int]. *)
+let compare_int_float integer floating =
+  let integer_magnitude_limit = Float.ldexp 1.0 (Sys.int_size - 1) in
+  if floating >= integer_magnitude_limit
+  then -1
+  else if floating < -.integer_magnitude_limit
+  then 1
+  else
+    let integral_part = int_of_float floating in
+    let comparison = Int.compare integer integral_part in
+    if comparison <> 0
+    then comparison
+    else Float.compare (Float.of_int integer) floating
 ;;
 
-(* Two ints compare exactly; anything else goes through float, which is
-   the widest common representation the wire can carry. *)
 let numeric_compare left right =
   match left, right with
   | Numeric_int left, Numeric_int right -> Int.compare left right
-  | (Numeric_int _ | Numeric_float _), (Numeric_int _ | Numeric_float _) ->
-    Float.compare (numeric_to_float left) (numeric_to_float right)
+  | Numeric_int left, Numeric_float right -> compare_int_float left right
+  | Numeric_float left, Numeric_int right -> -(compare_int_float right left)
+  | Numeric_float left, Numeric_float right -> Float.compare left right
 ;;
 
 let numeric_to_string = function
@@ -472,13 +482,23 @@ let count_bound_of_json : Yojson.Safe.t -> int option = function
   -> None
 ;;
 
+let schema_value_to_diagnostic_string = function
+  | `Float value when not (Float.is_finite value) ->
+    (match classify_float value with
+     | FP_nan -> "NaN"
+     | FP_infinite when value > 0.0 -> "Infinity"
+     | FP_infinite -> "-Infinity"
+     | FP_normal | FP_subnormal | FP_zero -> Printf.sprintf "%g" value)
+  | value -> Yojson.Safe.to_string value
+;;
+
 let malformed_bound ~path ~keyword ~declared =
   Schema_bound_malformed
     (Printf.sprintf
        "schema declares an unreadable %s for %s: %s"
        keyword
        path
-       (Yojson.Safe.to_string declared))
+       (schema_value_to_diagnostic_string declared))
 ;;
 
 (* A value whose JSON kind the keyword does not apply to is left alone:
@@ -487,17 +507,31 @@ let malformed_bound ~path ~keyword ~declared =
    incompatible type. [test_tool_input_validation] pins that no masc
    schema does. *)
 let numeric_constraint_failure ~path ~keyword ~declared value =
-  match numeric_of_json value with
-  | None -> None
-  | Some actual ->
-    (match numeric_of_json declared with
+  match numeric_of_json declared with
+  | None ->
+    Some
+      (malformed_bound
+         ~path
+         ~keyword:(numeric_keyword_json_name keyword)
+         ~declared)
+  | Some bound ->
+    (match numeric_of_json value with
      | None ->
-       Some
-         (malformed_bound
-            ~path
-            ~keyword:(numeric_keyword_json_name keyword)
-            ~declared)
-     | Some bound ->
+       (match value with
+        | `Float value when not (Float.is_finite value) ->
+          Some
+            (Argument_out_of_range
+               (Printf.sprintf "%s must be a finite number" path))
+        | `Intlit literal ->
+          Some
+            (Argument_out_of_range
+               (Printf.sprintf
+                  "%s integer literal %s is outside the native exact-comparison range"
+                  path
+                  literal))
+        | `Int _ | `Float _ | `Null | `Bool _ | `String _ | `Assoc _ | `List _ ->
+          None)
+     | Some actual ->
        let comparison = numeric_compare actual bound in
        let violated =
          match keyword with
@@ -651,20 +685,76 @@ let rec constraint_failures ~path schema value =
   | _ -> []
 ;;
 
+(** Malformed declarations are schema defects independently of whether the
+    corresponding optional argument was supplied. Checking them in a separate
+    schema-only walk keeps an omitted field from turning fail-closed validation
+    into a silent pass. *)
+let rec malformed_schema_bound_failures ~path schema =
+  match schema with
+  | `Assoc schema_fields ->
+    let declared_here =
+      List.filter_map
+        (fun keyword ->
+           match
+             List.assoc_opt (numeric_keyword_json_name keyword) schema_fields
+           with
+           | None -> None
+           | Some declared ->
+             (match numeric_of_json declared with
+              | Some _ -> None
+              | None ->
+                Some
+                  (malformed_bound
+                     ~path
+                     ~keyword:(numeric_keyword_json_name keyword)
+                     ~declared)))
+        numeric_keywords
+      @ List.filter_map
+          (fun keyword ->
+             match
+               List.assoc_opt (count_keyword_json_name keyword) schema_fields
+             with
+             | None -> None
+             | Some declared ->
+               (match count_bound_of_json declared with
+                | Some _ -> None
+                | None ->
+                  Some
+                    (malformed_bound
+                       ~path
+                       ~keyword:(count_keyword_json_name keyword)
+                       ~declared)))
+          count_keywords
+    in
+    let nested_properties =
+      match List.assoc_opt "properties" schema_fields with
+      | Some (`Assoc property_schemas) ->
+        List.concat_map
+          (fun (property_name, property_schema) ->
+             malformed_schema_bound_failures
+               ~path:(child_property_path path property_name)
+               property_schema)
+          property_schemas
+      | _ -> []
+    in
+    let nested_items =
+      match List.assoc_opt "items" schema_fields with
+      | Some (`Assoc _ as item_schema) ->
+        malformed_schema_bound_failures ~path:(path ^ "[]") item_schema
+      | _ -> []
+    in
+    declared_here @ nested_properties @ nested_items
+  | _ -> []
+;;
+
 (** First declared-constraint failure for [args], or [None]. A malformed
     bound is reported ahead of an out-of-range argument: masc's own schema
     defect must not be blamed on the caller. *)
 let schema_constraint_failure schema args =
-  let failures = constraint_failures ~path:"" schema args in
-  match
-    List.find_opt
-      (function
-        | Schema_bound_malformed _ -> true
-        | Argument_out_of_range _ -> false)
-      failures
-  with
-  | Some malformed -> Some malformed
-  | None ->
+  match malformed_schema_bound_failures ~path:"" schema with
+  | malformed :: _ -> Some malformed
+  | [] ->
+    let failures = constraint_failures ~path:"" schema args in
     (match failures with
      | [] -> None
      | first :: _ -> Some first)

--- a/lib/tool_input_validation.mli
+++ b/lib/tool_input_validation.mli
@@ -39,3 +39,14 @@ val schema_shape : Yojson.Safe.t -> schema_shape
 val schema_shape_json : Yojson.Safe.t -> Yojson.Safe.t
 (** JSON form of {!schema_shape}. Omits [one_of_required] and [schema_errors]
     when empty. *)
+
+val constraint_declaration_paths : Yojson.Safe.t -> string list
+(** Every declared range/length constraint that pre-dispatch validation can
+    reach, as ["<field path>:<keyword>"] — [minimum], [maximum],
+    [exclusiveMinimum], [exclusiveMaximum], [minLength], [maxLength],
+    [minItems], [maxItems].
+
+    Enforcement descends through [properties] and object-form [items] only.
+    A declaration placed anywhere else (a [oneOf] branch, a tuple-form
+    [items]) would never be enforced, so tests compare this list against a
+    raw scan of the whole schema. *)

--- a/test/dune
+++ b/test/dune
@@ -262,6 +262,8 @@
   test_keeper_sandbox_read_backend
   test_keeper_path_ssot
   test_tool_input_validation
+  test_tool_schema_constraint_enforcement
+  test_keeper_artifact_read_request
   test_tool_schema_oas_boundary
   test_task_completion_claim
   test_ocaml_north_star_task_lifecycle
@@ -557,6 +559,8 @@
   test_keeper_sandbox_read_backend
   test_keeper_path_ssot
   test_tool_input_validation
+  test_tool_schema_constraint_enforcement
+  test_keeper_artifact_read_request
   test_tool_schema_oas_boundary
   test_task_completion_claim
   test_ocaml_north_star_task_lifecycle

--- a/test/test_keeper_artifact_read_request.ml
+++ b/test/test_keeper_artifact_read_request.ml
@@ -1,0 +1,412 @@
+(** Per-field diagnostics for [keeper_artifact_read] request parsing.
+
+    Live failure 2026-08-05 20:06:36 (keeper kidsnote):
+    [{"max_bytes": 565244, "offset": 0, "sha256": "8ee32b2a…740c"}] was
+    answered with ["expected sha256, non-negative offset, and max_bytes
+    1..65536"]. The sha256 was correct; [max_bytes] was over the maximum.
+    One catch-all served seven distinct causes and named the innocent field
+    first.
+
+    These tests pin two things: every rejection now names the field that
+    actually failed, and the accept/reject decision itself is unchanged —
+    the same inputs are still accepted and still rejected. *)
+
+module R = Masc.Keeper_artifact_read
+
+let production_max_bytes = 565_244
+let production_sha256 = "8ee32b2a47387c0d0f7d30f93f476843c0a1e8804907d83aacd7a3ebf5c8740c"
+let valid_sha256 = String.make 64 'a'
+
+let string_contains haystack needle =
+  let needle_length = String.length needle in
+  let haystack_length = String.length haystack in
+  if needle_length > haystack_length
+  then false
+  else (
+    let found = ref false in
+    for index = 0 to haystack_length - needle_length do
+      if (not !found) && String.equal (String.sub haystack index needle_length) needle
+      then found := true
+    done;
+    !found)
+;;
+
+let message_of_rejection ~label json =
+  match R.For_testing.request_of_json json with
+  | Ok _ -> Alcotest.failf "%s: expected a rejection, got an accepted request" label
+  | Error invalid -> R.invalid_request_to_string invalid
+;;
+
+let check_names ~label ~message needles =
+  List.iter
+    (fun needle ->
+       Alcotest.(check bool)
+         (Printf.sprintf "%s names %S" label needle)
+         true
+         (string_contains message needle))
+    needles
+;;
+
+let check_omits ~label ~message needles =
+  List.iter
+    (fun needle ->
+       Alcotest.(check bool)
+         (Printf.sprintf "%s must not mention %S (got: %s)" label needle message)
+         false
+         (string_contains message needle))
+    needles
+;;
+
+(* --- The exact production request --------------------------------- *)
+
+let test_production_case_names_max_bytes () =
+  let message =
+    message_of_rejection
+      ~label:"production artifact read"
+      (`Assoc
+        [ "max_bytes", `Int production_max_bytes
+        ; "offset", `Int 0
+        ; "sha256", `String production_sha256
+        ])
+  in
+  check_names
+    ~label:"production artifact read"
+    ~message
+    [ "max_bytes"
+    ; string_of_int production_max_bytes
+    ; string_of_int R.maximum_max_bytes
+    ];
+  check_omits ~label:"production artifact read" ~message [ "sha256" ]
+;;
+
+(* A correct sha256 must never appear in the diagnosis, whatever else is
+   wrong with the request. *)
+let test_valid_sha256_never_blamed () =
+  List.iter
+    (fun (label, args) ->
+       let message = message_of_rejection ~label args in
+       check_omits ~label ~message [ "sha256" ])
+    [ ( "max_bytes over maximum"
+      , `Assoc
+          [ "sha256", `String valid_sha256; "max_bytes", `Int production_max_bytes ] )
+    ; ( "max_bytes under minimum"
+      , `Assoc [ "sha256", `String valid_sha256; "max_bytes", `Int 0 ] )
+    ; "negative offset", `Assoc [ "sha256", `String valid_sha256; "offset", `Int (-1) ]
+    ; ( "offset of the wrong type"
+      , `Assoc [ "sha256", `String valid_sha256; "offset", `String "0" ] )
+    ]
+;;
+
+(* --- One test per distinct rejection cause ------------------------- *)
+
+let test_max_bytes_above_maximum () =
+  let message =
+    message_of_rejection
+      ~label:"max_bytes above maximum"
+      (`Assoc
+        [ "sha256", `String valid_sha256
+        ; "max_bytes", `Int (R.maximum_max_bytes + 1)
+        ])
+  in
+  Alcotest.(check string)
+    "max_bytes above maximum"
+    (Printf.sprintf
+       "max_bytes %d exceeds maximum %d"
+       (R.maximum_max_bytes + 1)
+       R.maximum_max_bytes)
+    message
+;;
+
+let test_max_bytes_below_minimum () =
+  let message =
+    message_of_rejection
+      ~label:"max_bytes below minimum"
+      (`Assoc
+        [ "sha256", `String valid_sha256
+        ; "max_bytes", `Int (R.minimum_max_bytes - 1)
+        ])
+  in
+  Alcotest.(check string)
+    "max_bytes below minimum"
+    (Printf.sprintf
+       "max_bytes %d is below minimum %d"
+       (R.minimum_max_bytes - 1)
+       R.minimum_max_bytes)
+    message
+;;
+
+let test_offset_below_minimum () =
+  let message =
+    message_of_rejection
+      ~label:"negative offset"
+      (`Assoc [ "sha256", `String valid_sha256; "offset", `Int (-1) ])
+  in
+  Alcotest.(check string)
+    "negative offset"
+    (Printf.sprintf "offset -1 is below minimum %d" R.minimum_offset)
+    message
+;;
+
+let test_offset_wrong_type () =
+  let message =
+    message_of_rejection
+      ~label:"offset of the wrong type"
+      (`Assoc [ "sha256", `String valid_sha256; "offset", `String "0" ])
+  in
+  Alcotest.(check string)
+    "offset of the wrong type"
+    "offset must be an integer, got string"
+    message
+;;
+
+let test_max_bytes_wrong_type () =
+  let message =
+    message_of_rejection
+      ~label:"max_bytes of the wrong type"
+      (`Assoc [ "sha256", `String valid_sha256; "max_bytes", `Bool true ])
+  in
+  Alcotest.(check string)
+    "max_bytes of the wrong type"
+    "max_bytes must be an integer, got bool"
+    message
+;;
+
+(* [Yojson.Safe] parses an integer literal wider than a native [int] into
+   [`Intlit]. The old parser swept it into the catch-all; it is still
+   rejected, but under its own name. *)
+let test_max_bytes_out_of_native_int_range () =
+  let literal = "99999999999999999999999999" in
+  let message =
+    message_of_rejection
+      ~label:"max_bytes wider than a native int"
+      (`Assoc [ "sha256", `String valid_sha256; "max_bytes", `Intlit literal ])
+  in
+  Alcotest.(check string)
+    "max_bytes wider than a native int"
+    (Printf.sprintf
+       "max_bytes integer literal %s is outside the native integer range"
+       literal)
+    message
+;;
+
+let test_offset_unparsed_integer_literal () =
+  let message =
+    message_of_rejection
+      ~label:"offset as an unparsed integer literal"
+      (`Assoc [ "sha256", `String valid_sha256; "offset", `Intlit "7" ])
+  in
+  Alcotest.(check string)
+    "offset as an unparsed integer literal"
+    "offset must be a JSON integer, got the unparsed integer literal 7"
+    message
+;;
+
+let test_sha256_missing () =
+  let message =
+    message_of_rejection ~label:"sha256 missing" (`Assoc [ "offset", `Int 0 ])
+  in
+  Alcotest.(check string) "sha256 missing" "sha256 is required" message
+;;
+
+let test_sha256_wrong_type () =
+  let message =
+    message_of_rejection ~label:"sha256 of the wrong type" (`Assoc [ "sha256", `Int 5 ])
+  in
+  Alcotest.(check string)
+    "sha256 of the wrong type"
+    "sha256 must be a string, got int"
+    message
+;;
+
+let test_sha256_malformed () =
+  let message =
+    message_of_rejection
+      ~label:"sha256 malformed"
+      (`Assoc [ "sha256", `String (String.make 63 'a') ])
+  in
+  check_names ~label:"sha256 malformed" ~message [ "sha256"; "63" ]
+;;
+
+let test_not_an_object () =
+  let message = message_of_rejection ~label:"array payload" (`List []) in
+  Alcotest.(check string) "array payload" "expected an object, got array" message
+;;
+
+(* --- Accept/reject parity ------------------------------------------ *)
+
+(** The decision the parser made before per-field diagnostics existed,
+    transcribed from the pre-change [request_of_json]. The rewrite may only
+    change the message, never which requests are served. *)
+let legacy_accepts (json : Yojson.Safe.t) =
+  match json with
+  | `Assoc fields ->
+    let sha256 =
+      match List.assoc_opt "sha256" fields with
+      | Some (`String value) -> Some value
+      | _ -> None
+    in
+    let offset =
+      match List.assoc_opt "offset" fields with
+      | None -> Some 0
+      | Some (`Int value) -> Some value
+      | _ -> None
+    in
+    let max_bytes =
+      match List.assoc_opt "max_bytes" fields with
+      | None -> Some R.default_max_bytes
+      | Some (`Int value) -> Some value
+      | _ -> None
+    in
+    (match sha256, offset, max_bytes with
+     | Some sha256, Some offset, Some max_bytes
+       when offset >= 0
+            && max_bytes >= R.minimum_max_bytes
+            && max_bytes <= R.maximum_max_bytes ->
+       (match Tool_output.validate_sha256 sha256 with
+        | Ok () -> true
+        | Error _ -> false)
+     | _ -> false)
+  | _ -> false
+;;
+
+let parity_cases : (string * Yojson.Safe.t) list =
+  [ "minimal valid", `Assoc [ "sha256", `String valid_sha256 ]
+  ; "production sha256 with defaults", `Assoc [ "sha256", `String production_sha256 ]
+  ; ( "valid with explicit bounds"
+      , `Assoc
+          [ "sha256", `String valid_sha256
+          ; "offset", `Int 0
+          ; "max_bytes", `Int R.maximum_max_bytes
+          ] )
+    ; ( "max_bytes at minimum"
+      , `Assoc
+          [ "sha256", `String valid_sha256
+          ; "max_bytes", `Int R.minimum_max_bytes
+          ] )
+    ; ( "max_bytes one over maximum"
+      , `Assoc
+          [ "sha256", `String valid_sha256
+          ; "max_bytes", `Int (R.maximum_max_bytes + 1)
+          ] )
+    ; ( "production request"
+      , `Assoc
+          [ "max_bytes", `Int production_max_bytes
+          ; "offset", `Int 0
+          ; "sha256", `String production_sha256
+          ] )
+    ; ( "max_bytes zero"
+      , `Assoc [ "sha256", `String valid_sha256; "max_bytes", `Int 0 ] )
+    ; ( "negative offset"
+      , `Assoc [ "sha256", `String valid_sha256; "offset", `Int (-1) ] )
+    ; ( "large but in-range offset"
+      , `Assoc [ "sha256", `String valid_sha256; "offset", `Int 1_000_000 ] )
+    ; ( "offset as a string"
+      , `Assoc [ "sha256", `String valid_sha256; "offset", `String "0" ] )
+    ; ( "offset as an integer literal"
+      , `Assoc [ "sha256", `String valid_sha256; "offset", `Intlit "7" ] )
+    ; ( "max_bytes as an oversized integer literal"
+      , `Assoc
+          [ "sha256", `String valid_sha256
+          ; "max_bytes", `Intlit "99999999999999999999999999"
+          ] )
+    ; ( "max_bytes as a float"
+      , `Assoc [ "sha256", `String valid_sha256; "max_bytes", `Float 1024.0 ] )
+    ; ( "max_bytes null"
+      , `Assoc [ "sha256", `String valid_sha256; "max_bytes", `Null ] )
+    ; "sha256 missing", `Assoc [ "offset", `Int 0 ]
+    ; "sha256 null", `Assoc [ "sha256", `Null ]
+    ; "sha256 as an integer", `Assoc [ "sha256", `Int 5 ]
+    ; "sha256 too short", `Assoc [ "sha256", `String (String.make 63 'a') ]
+    ; "sha256 too long", `Assoc [ "sha256", `String (String.make 65 'a') ]
+    ; "sha256 uppercase", `Assoc [ "sha256", `String (String.make 64 'A') ]
+    ; "empty object", `Assoc []
+    ; "array payload", `List []
+    ; "string payload", `String valid_sha256
+    ; "null payload", `Null
+    ; ( "everything wrong at once"
+      , `Assoc
+          [ "sha256", `String "nope"
+          ; "offset", `Int (-5)
+          ; "max_bytes", `Int production_max_bytes
+          ] )
+    ]
+;;
+
+let test_accept_reject_set_is_unchanged () =
+  List.iter
+    (fun (label, args) ->
+       let accepted =
+         match R.For_testing.request_of_json args with
+         | Ok _ -> true
+         | Error _ -> false
+       in
+       Alcotest.(check bool)
+         (Printf.sprintf "accept/reject unchanged for %s" label)
+         (legacy_accepts args)
+         accepted)
+    parity_cases
+;;
+
+(* An accepted request must still carry the values it was given, including
+   the documented defaults for omitted fields. *)
+let test_accepted_request_fields () =
+  match
+    R.For_testing.request_of_json
+      (`Assoc [ "sha256", `String production_sha256; "max_bytes", `Int 1024 ])
+  with
+  | Error invalid ->
+    Alcotest.failf
+      "expected an in-range request to parse, got %s"
+      (R.invalid_request_to_string invalid)
+  | Ok request ->
+    Alcotest.(check string) "sha256" production_sha256 request.sha256;
+    Alcotest.(check int) "offset defaults to the minimum" R.minimum_offset request.offset;
+    Alcotest.(check int) "max_bytes" 1024 request.max_bytes
+;;
+
+let test_defaults_when_only_sha256_is_given () =
+  match R.For_testing.request_of_json (`Assoc [ "sha256", `String valid_sha256 ]) with
+  | Error invalid ->
+    Alcotest.failf
+      "expected a sha256-only request to parse, got %s"
+      (R.invalid_request_to_string invalid)
+  | Ok request ->
+    Alcotest.(check int) "offset default" R.minimum_offset request.offset;
+    Alcotest.(check int) "max_bytes default" R.default_max_bytes request.max_bytes
+;;
+
+let () =
+  Alcotest.run
+    "keeper_artifact_read_request"
+    [ ( "field_named_rejections"
+      , [ Alcotest.test_case "production max_bytes names max_bytes" `Quick
+            test_production_case_names_max_bytes
+        ; Alcotest.test_case "a valid sha256 is never blamed" `Quick
+            test_valid_sha256_never_blamed
+        ; Alcotest.test_case "max_bytes above maximum" `Quick
+            test_max_bytes_above_maximum
+        ; Alcotest.test_case "max_bytes below minimum" `Quick
+            test_max_bytes_below_minimum
+        ; Alcotest.test_case "offset below minimum" `Quick test_offset_below_minimum
+        ; Alcotest.test_case "offset of the wrong type" `Quick test_offset_wrong_type
+        ; Alcotest.test_case "max_bytes of the wrong type" `Quick
+            test_max_bytes_wrong_type
+        ; Alcotest.test_case "max_bytes wider than a native int" `Quick
+            test_max_bytes_out_of_native_int_range
+        ; Alcotest.test_case "offset as an unparsed integer literal" `Quick
+            test_offset_unparsed_integer_literal
+        ; Alcotest.test_case "sha256 missing" `Quick test_sha256_missing
+        ; Alcotest.test_case "sha256 of the wrong type" `Quick test_sha256_wrong_type
+        ; Alcotest.test_case "sha256 malformed" `Quick test_sha256_malformed
+        ; Alcotest.test_case "payload is not an object" `Quick test_not_an_object
+        ] )
+    ; ( "decision_parity"
+      , [ Alcotest.test_case "accept/reject set is unchanged" `Quick
+            test_accept_reject_set_is_unchanged
+        ; Alcotest.test_case "accepted request keeps its fields" `Quick
+            test_accepted_request_fields
+        ; Alcotest.test_case "omitted fields take their defaults" `Quick
+            test_defaults_when_only_sha256_is_given
+        ] )
+    ]
+;;

--- a/test/test_tool_output_washing_e2e.ml
+++ b/test/test_tool_output_washing_e2e.ml
@@ -67,7 +67,7 @@ let test_artifact_page_makes_progress () =
            ])
     with
     | Ok request -> request
-    | Error error -> Alcotest.fail error
+    | Error error -> Alcotest.fail (R.invalid_request_to_string error)
   in
   let emoji = "\240\159\152\128x" in
   let incident_sized_payload = String.make 2_500 'w' in
@@ -77,7 +77,7 @@ let test_artifact_page_makes_progress () =
         (`Assoc [ "sha256", `String (String.make 64 'a') ])
     with
     | Ok request -> request
-    | Error error -> Alcotest.fail error
+    | Error error -> Alcotest.fail (R.invalid_request_to_string error)
   in
   let incident_page =
     match R.For_testing.page default_request incident_sized_payload with

--- a/test/test_tool_schema_constraint_enforcement.ml
+++ b/test/test_tool_schema_constraint_enforcement.ml
@@ -1,0 +1,646 @@
+(** Pre-dispatch enforcement of declared JSON-Schema range/length bounds.
+
+    masc declares minimum/maximum/exclusiveMinimum/exclusiveMaximum/
+    minLength/maxLength/minItems/maxItems across its tool schemas, but
+    [Tool_bridge.params_of_json_schema] projects a schema onto the OAS
+    [tool_param] record (name/type/required), dropping every bound. The SDK
+    validation hook therefore never saw them, and a caller learned about an
+    out-of-range value only if the handler happened to re-check it — which
+    is how [keeper_artifact_read] answered [max_bytes=565244] with a message
+    that named [sha256] first (2026-08-05 20:06:36, keeper kidsnote).
+
+    These tests pin that the bounds are read from the raw schema, that the
+    rejection names the field and the bound, that a schema without a bound
+    is unaffected, and that every declaration masc holds sits somewhere the
+    enforcement walk actually reaches. *)
+
+open Masc
+
+let string_contains haystack needle =
+  let needle_length = String.length needle in
+  let haystack_length = String.length haystack in
+  if needle_length > haystack_length
+  then false
+  else (
+    let found = ref false in
+    for index = 0 to haystack_length - needle_length do
+      if (not !found) && String.equal (String.sub haystack index needle_length) needle
+      then found := true
+    done;
+    !found)
+;;
+
+let error_message result =
+  match Yojson.Safe.Util.member "error" (Tool_result.data result) with
+  | `String message -> message
+  | _ -> Yojson.Safe.to_string (Tool_result.data result)
+;;
+
+let expect_rejected ~label ~schema ~name ~args =
+  match Tool_input_validation.validate_args ~schema ~name ~args () with
+  | Ok forwarded ->
+    Alcotest.failf
+      "%s: expected a rejection, got %s"
+      label
+      (Yojson.Safe.to_string forwarded)
+  | Error result -> error_message result
+;;
+
+let expect_accepted ~label ~schema ~name ~args =
+  match Tool_input_validation.validate_args ~schema ~name ~args () with
+  | Ok forwarded -> forwarded
+  | Error result -> Alcotest.failf "%s: expected acceptance, got %s" label (error_message result)
+;;
+
+let check_names ~label ~message needles =
+  List.iter
+    (fun needle ->
+       Alcotest.(check bool)
+         (Printf.sprintf "%s names %S (got: %s)" label needle message)
+         true
+         (string_contains message needle))
+    needles
+;;
+
+let object_schema ?(required = []) properties : Yojson.Safe.t =
+  `Assoc
+    [ "type", `String "object"
+    ; "properties", `Assoc properties
+    ; "required", `List (List.map (fun name -> `String name) required)
+    ; "additionalProperties", `Bool false
+    ]
+;;
+
+(* --- The production tool, through its real schema ------------------ *)
+
+let find_schema_exn name schemas =
+  match
+    List.find_opt
+      (fun (schema : Masc_domain.tool_schema) -> String.equal schema.name name)
+      schemas
+  with
+  | Some schema -> schema.input_schema
+  | None -> Alcotest.failf "missing schema: %s" name
+;;
+
+let all_masc_schemas =
+  Config.raw_all_tool_schemas
+  @ Keeper_schema.schemas
+  @ Keeper_tool_descriptor.model_visible_schemas ()
+;;
+
+let keeper_artifact_read_schema = find_schema_exn "keeper_artifact_read" all_masc_schemas
+
+let production_max_bytes = 565_244
+let production_sha256 = "8ee32b2a47387c0d0f7d30f93f476843c0a1e8804907d83aacd7a3ebf5c8740c"
+
+let test_artifact_read_rejects_the_production_max_bytes () =
+  let message =
+    expect_rejected
+      ~label:"keeper_artifact_read max_bytes over maximum"
+      ~schema:keeper_artifact_read_schema
+      ~name:"keeper_artifact_read"
+      ~args:
+        (`Assoc
+          [ "max_bytes", `Int production_max_bytes
+          ; "offset", `Int 0
+          ; "sha256", `String production_sha256
+          ])
+  in
+  check_names
+    ~label:"keeper_artifact_read max_bytes over maximum"
+    ~message
+    [ "max_bytes"
+    ; string_of_int production_max_bytes
+    ; string_of_int Keeper_artifact_read.maximum_max_bytes
+    ]
+;;
+
+let test_artifact_read_accepts_an_in_range_max_bytes () =
+  let args =
+    `Assoc
+      [ "sha256", `String production_sha256
+      ; "offset", `Int 0
+      ; "max_bytes", `Int 4096
+      ]
+  in
+  let forwarded =
+    expect_accepted
+      ~label:"keeper_artifact_read in-range max_bytes"
+      ~schema:keeper_artifact_read_schema
+      ~name:"keeper_artifact_read"
+      ~args
+  in
+  Alcotest.(check bool) "args forwarded unchanged" true (Yojson.Safe.equal args forwarded)
+;;
+
+let test_artifact_read_accepts_the_maximum_itself () =
+  ignore
+    (expect_accepted
+       ~label:"keeper_artifact_read max_bytes at the maximum"
+       ~schema:keeper_artifact_read_schema
+       ~name:"keeper_artifact_read"
+       ~args:
+         (`Assoc
+           [ "sha256", `String production_sha256
+           ; "max_bytes", `Int Keeper_artifact_read.maximum_max_bytes
+           ])
+     : Yojson.Safe.t)
+;;
+
+let test_artifact_read_rejects_a_negative_offset () =
+  let message =
+    expect_rejected
+      ~label:"keeper_artifact_read negative offset"
+      ~schema:keeper_artifact_read_schema
+      ~name:"keeper_artifact_read"
+      ~args:
+        (`Assoc [ "sha256", `String production_sha256; "offset", `Int (-1) ])
+  in
+  check_names
+    ~label:"keeper_artifact_read negative offset"
+    ~message
+    [ "offset"; "-1"; "minimum 0" ]
+;;
+
+(* --- One test per keyword, on a minimal schema --------------------- *)
+
+let count_schema =
+  object_schema
+    [ ( "count"
+      , `Assoc [ "type", `String "integer"; "minimum", `Int 1; "maximum", `Int 10 ] )
+    ]
+;;
+
+let test_minimum_rejects_and_names_the_field () =
+  let message =
+    expect_rejected
+      ~label:"count below minimum"
+      ~schema:count_schema
+      ~name:"__constraint_minimum"
+      ~args:(`Assoc [ "count", `Int 0 ])
+  in
+  check_names ~label:"count below minimum" ~message [ "count"; "0"; "minimum 1" ]
+;;
+
+let test_maximum_rejects_and_names_the_field () =
+  let message =
+    expect_rejected
+      ~label:"count above maximum"
+      ~schema:count_schema
+      ~name:"__constraint_maximum"
+      ~args:(`Assoc [ "count", `Int 11 ])
+  in
+  check_names ~label:"count above maximum" ~message [ "count"; "11"; "maximum 10" ]
+;;
+
+let test_inclusive_bounds_accept_their_endpoints () =
+  List.iter
+    (fun value ->
+       ignore
+         (expect_accepted
+            ~label:(Printf.sprintf "count = %d" value)
+            ~schema:count_schema
+            ~name:"__constraint_endpoints"
+            ~args:(`Assoc [ "count", `Int value ])
+          : Yojson.Safe.t))
+    [ 1; 5; 10 ]
+;;
+
+let timeout_schema =
+  object_schema
+    [ ( "timeout_sec"
+      , `Assoc [ "type", `String "number"; "exclusiveMinimum", `Float 0.0 ] )
+    ]
+;;
+
+let test_exclusive_minimum_rejects_the_bound_itself () =
+  let message =
+    expect_rejected
+      ~label:"timeout_sec at exclusiveMinimum"
+      ~schema:timeout_schema
+      ~name:"__constraint_exclusive_minimum"
+      ~args:(`Assoc [ "timeout_sec", `Float 0.0 ])
+  in
+  check_names
+    ~label:"timeout_sec at exclusiveMinimum"
+    ~message
+    [ "timeout_sec"; "exclusiveMinimum" ]
+;;
+
+let test_exclusive_minimum_accepts_above_the_bound () =
+  ignore
+    (expect_accepted
+       ~label:"timeout_sec above exclusiveMinimum"
+       ~schema:timeout_schema
+       ~name:"__constraint_exclusive_minimum_ok"
+       ~args:(`Assoc [ "timeout_sec", `Float 0.5 ])
+     : Yojson.Safe.t)
+;;
+
+let exclusive_maximum_schema =
+  object_schema
+    [ ( "ratio"
+      , `Assoc [ "type", `String "number"; "exclusiveMaximum", `Float 1.0 ] )
+    ]
+;;
+
+let test_exclusive_maximum_rejects_the_bound_itself () =
+  let message =
+    expect_rejected
+      ~label:"ratio at exclusiveMaximum"
+      ~schema:exclusive_maximum_schema
+      ~name:"__constraint_exclusive_maximum"
+      ~args:(`Assoc [ "ratio", `Float 1.0 ])
+  in
+  check_names ~label:"ratio at exclusiveMaximum" ~message [ "ratio"; "exclusiveMaximum" ]
+;;
+
+let title_schema =
+  object_schema
+    [ ( "title"
+      , `Assoc
+          [ "type", `String "string"; "minLength", `Int 5; "maxLength", `Int 10 ] )
+    ]
+;;
+
+let test_min_length_rejects_and_names_the_field () =
+  let message =
+    expect_rejected
+      ~label:"title below minLength"
+      ~schema:title_schema
+      ~name:"__constraint_min_length"
+      ~args:(`Assoc [ "title", `String "abcd" ])
+  in
+  check_names ~label:"title below minLength" ~message [ "title"; "minLength 5" ]
+;;
+
+let test_max_length_rejects_and_names_the_field () =
+  let message =
+    expect_rejected
+      ~label:"title above maxLength"
+      ~schema:title_schema
+      ~name:"__constraint_max_length"
+      ~args:(`Assoc [ "title", `String "abcdefghijk" ])
+  in
+  check_names ~label:"title above maxLength" ~message [ "title"; "maxLength 10" ]
+;;
+
+(* JSON Schema counts characters, not bytes. Counting bytes would reject a
+   Korean title well inside its declared maxLength. *)
+let test_length_counts_characters_not_bytes () =
+  let ten_hangul_characters = "가나다라마바사아자차" in
+  Alcotest.(check int)
+    "fixture is 30 bytes"
+    30
+    (String.length ten_hangul_characters);
+  ignore
+    (expect_accepted
+       ~label:"ten Hangul characters within maxLength 10"
+       ~schema:title_schema
+       ~name:"__constraint_utf8_length"
+       ~args:(`Assoc [ "title", `String ten_hangul_characters ])
+     : Yojson.Safe.t);
+  let message =
+    expect_rejected
+      ~label:"eleven Hangul characters above maxLength 10"
+      ~schema:title_schema
+      ~name:"__constraint_utf8_length_over"
+      ~args:(`Assoc [ "title", `String (ten_hangul_characters ^ "카") ])
+  in
+  check_names
+    ~label:"eleven Hangul characters above maxLength 10"
+    ~message
+    [ "title"; "11 character(s)"; "maxLength 10" ]
+;;
+
+let tags_schema =
+  object_schema
+    [ ( "tags"
+      , `Assoc
+          [ "type", `String "array"
+          ; "items", `Assoc [ "type", `String "string" ]
+          ; "minItems", `Int 1
+          ; "maxItems", `Int 3
+          ] )
+    ]
+;;
+
+let test_min_items_rejects_and_names_the_field () =
+  let message =
+    expect_rejected
+      ~label:"tags below minItems"
+      ~schema:tags_schema
+      ~name:"__constraint_min_items"
+      ~args:(`Assoc [ "tags", `List [] ])
+  in
+  check_names ~label:"tags below minItems" ~message [ "tags"; "minItems 1" ]
+;;
+
+let test_max_items_rejects_and_names_the_field () =
+  let message =
+    expect_rejected
+      ~label:"tags above maxItems"
+      ~schema:tags_schema
+      ~name:"__constraint_max_items"
+      ~args:
+        (`Assoc
+          [ ( "tags"
+            , `List [ `String "a"; `String "b"; `String "c"; `String "d" ] )
+          ])
+  in
+  check_names ~label:"tags above maxItems" ~message [ "tags"; "maxItems 3" ]
+;;
+
+(* --- A schema without bounds must be unaffected -------------------- *)
+
+let unbounded_schema =
+  object_schema
+    [ "count", `Assoc [ "type", `String "integer" ]
+    ; "title", `Assoc [ "type", `String "string" ]
+    ; ( "tags"
+      , `Assoc [ "type", `String "array"; "items", `Assoc [ "type", `String "string" ] ]
+      )
+    ]
+;;
+
+let test_absent_constraints_change_nothing () =
+  let args =
+    `Assoc
+      [ "count", `Int (-999_999)
+      ; "title", `String ""
+      ; "tags", `List []
+      ]
+  in
+  let forwarded =
+    expect_accepted
+      ~label:"schema without declared bounds"
+      ~schema:unbounded_schema
+      ~name:"__constraint_absent"
+      ~args
+  in
+  Alcotest.(check bool) "args forwarded unchanged" true (Yojson.Safe.equal args forwarded)
+;;
+
+(* An absent optional field carries no value, so its bounds cannot apply. *)
+let test_absent_field_is_not_range_checked () =
+  ignore
+    (expect_accepted
+       ~label:"bounded field omitted"
+       ~schema:count_schema
+       ~name:"__constraint_absent_field"
+       ~args:(`Assoc [])
+     : Yojson.Safe.t)
+;;
+
+(* --- Nested declarations ------------------------------------------- *)
+
+let nested_schema =
+  object_schema
+    [ ( "pipeline"
+      , `Assoc
+          [ "type", `String "array"
+          ; ( "items"
+            , object_schema
+                [ ( "argv"
+                  , `Assoc
+                      [ "type", `String "array"
+                      ; "items", `Assoc [ "type", `String "string" ]
+                      ; "minItems", `Int 1
+                      ] )
+                ] )
+          ] )
+    ]
+;;
+
+let test_nested_item_constraint_is_enforced_with_its_path () =
+  let message =
+    expect_rejected
+      ~label:"empty argv in the second pipeline stage"
+      ~schema:nested_schema
+      ~name:"__constraint_nested"
+      ~args:
+        (`Assoc
+          [ ( "pipeline"
+            , `List
+                [ `Assoc [ "argv", `List [ `String "rg" ] ]
+                ; `Assoc [ "argv", `List [] ]
+                ] )
+          ])
+  in
+  check_names
+    ~label:"empty argv in the second pipeline stage"
+    ~message
+    [ "pipeline[1].argv"; "minItems 1" ]
+;;
+
+let test_nested_in_range_value_is_accepted () =
+  ignore
+    (expect_accepted
+       ~label:"non-empty argv in every pipeline stage"
+       ~schema:nested_schema
+       ~name:"__constraint_nested_ok"
+       ~args:
+         (`Assoc
+           [ ( "pipeline"
+             , `List
+                 [ `Assoc [ "argv", `List [ `String "rg" ] ]
+                 ; `Assoc [ "argv", `List [ `String "head"; `String "-5" ] ]
+                 ] )
+           ])
+     : Yojson.Safe.t)
+;;
+
+(* --- A bound masc cannot read is masc's defect, not the caller's ---- *)
+
+let malformed_numeric_bound_schema =
+  object_schema
+    [ "count", `Assoc [ "type", `String "integer"; "maximum", `String "10" ] ]
+;;
+
+(* The count keywords are the other half of the same contract, and a
+   different function reads their bound. A fixture that exercises only the
+   numeric half leaves minLength/maxLength/minItems/maxItems free to fail
+   open with every test still green. *)
+let malformed_count_bound_schema =
+  object_schema
+    [ "title", `Assoc [ "type", `String "string"; "maxLength", `String "10" ] ]
+;;
+
+let check_unreadable_bound_fails_closed ~schema ~args ~label names =
+  match
+    Tool_input_validation.validate_args
+      ~schema
+      ~name:"__constraint_malformed_bound"
+      ~args
+      ()
+  with
+  | Ok forwarded ->
+    Alcotest.failf
+      "expected an unreadable bound to fail closed, got %s"
+      (Yojson.Safe.to_string forwarded)
+  | Error result ->
+    let payload = Yojson.Safe.to_string (Tool_result.data result) in
+    Alcotest.(check bool)
+      "reason is malformed_schema"
+      true
+      (string_contains payload "malformed_schema");
+    check_names ~label ~message:(error_message result) names
+;;
+
+let test_unreadable_numeric_bound_fails_closed_as_a_schema_defect () =
+  check_unreadable_bound_fails_closed
+    ~schema:malformed_numeric_bound_schema
+    ~args:(`Assoc [ "count", `Int 5 ])
+    ~label:"unreadable maximum"
+    [ "count"; "maximum" ]
+;;
+
+let test_unreadable_count_bound_fails_closed_as_a_schema_defect () =
+  check_unreadable_bound_fails_closed
+    ~schema:malformed_count_bound_schema
+    ~args:(`Assoc [ "title", `String "abc" ])
+    ~label:"unreadable maxLength"
+    [ "title"; "maxLength" ]
+;;
+
+(* --- Every masc declaration must be reachable and readable ---------- *)
+
+let constraint_keyword_names =
+  [ "minimum"
+  ; "maximum"
+  ; "exclusiveMinimum"
+  ; "exclusiveMaximum"
+  ; "minLength"
+  ; "maxLength"
+  ; "minItems"
+  ; "maxItems"
+  ]
+;;
+
+(** Every constraint keyword anywhere in the schema JSON, regardless of
+    where it sits. Compared against
+    [Tool_input_validation.constraint_declaration_paths], which only sees
+    the places enforcement descends into. *)
+let rec raw_constraint_occurrences (json : Yojson.Safe.t) =
+  match json with
+  | `Assoc fields ->
+    List.concat_map
+      (fun (key, value) ->
+         let here = if List.mem key constraint_keyword_names then [ key, value ] else [] in
+         here @ raw_constraint_occurrences value)
+      fields
+  | `List items -> List.concat_map raw_constraint_occurrences items
+  | _ -> []
+;;
+
+let test_every_declaration_is_reachable_by_enforcement () =
+  List.iter
+    (fun (schema : Masc_domain.tool_schema) ->
+       let declared = List.length (raw_constraint_occurrences schema.input_schema) in
+       let reachable =
+         List.length
+           (Tool_input_validation.constraint_declaration_paths schema.input_schema)
+       in
+       Alcotest.(check int)
+         (Printf.sprintf
+            "%s: every declared constraint is reachable by enforcement"
+            schema.name)
+         declared
+         reachable)
+    all_masc_schemas
+;;
+
+(* A bound that enforcement cannot read turns every call to that tool into a
+   fail-closed rejection, so it must be caught here rather than in
+   production. *)
+let test_every_declared_bound_is_readable () =
+  List.iter
+    (fun (schema : Masc_domain.tool_schema) ->
+       List.iter
+         (fun (keyword, value) ->
+            let readable =
+              match keyword, value with
+              | ("minimum" | "maximum" | "exclusiveMinimum" | "exclusiveMaximum"), _ ->
+                (match value with
+                 | `Int _ | `Float _ -> true
+                 | `Intlit literal -> Option.is_some (int_of_string_opt literal)
+                 | _ -> false)
+              | ("minLength" | "maxLength" | "minItems" | "maxItems"), _ ->
+                (match value with
+                 | `Int bound -> bound >= 0
+                 | `Float bound -> Float.is_integer bound && bound >= 0.0
+                 | `Intlit literal ->
+                   (match int_of_string_opt literal with
+                    | Some bound -> bound >= 0
+                    | None -> false)
+                 | _ -> false)
+              | _, _ -> false
+            in
+            Alcotest.(check bool)
+              (Printf.sprintf
+                 "%s declares a readable %s (%s)"
+                 schema.name
+                 keyword
+                 (Yojson.Safe.to_string value))
+              true
+              readable)
+         (raw_constraint_occurrences schema.input_schema))
+    all_masc_schemas
+;;
+
+let () =
+  Alcotest.run
+    "tool_schema_constraint_enforcement"
+    [ ( "keeper_artifact_read"
+      , [ Alcotest.test_case "production max_bytes is rejected pre-dispatch" `Quick
+            test_artifact_read_rejects_the_production_max_bytes
+        ; Alcotest.test_case "an in-range max_bytes still passes" `Quick
+            test_artifact_read_accepts_an_in_range_max_bytes
+        ; Alcotest.test_case "the maximum itself is accepted" `Quick
+            test_artifact_read_accepts_the_maximum_itself
+        ; Alcotest.test_case "a negative offset is rejected" `Quick
+            test_artifact_read_rejects_a_negative_offset
+        ] )
+    ; ( "declared_keywords"
+      , [ Alcotest.test_case "minimum" `Quick test_minimum_rejects_and_names_the_field
+        ; Alcotest.test_case "maximum" `Quick test_maximum_rejects_and_names_the_field
+        ; Alcotest.test_case "inclusive endpoints are accepted" `Quick
+            test_inclusive_bounds_accept_their_endpoints
+        ; Alcotest.test_case "exclusiveMinimum rejects its bound" `Quick
+            test_exclusive_minimum_rejects_the_bound_itself
+        ; Alcotest.test_case "exclusiveMinimum accepts above its bound" `Quick
+            test_exclusive_minimum_accepts_above_the_bound
+        ; Alcotest.test_case "exclusiveMaximum rejects its bound" `Quick
+            test_exclusive_maximum_rejects_the_bound_itself
+        ; Alcotest.test_case "minLength" `Quick test_min_length_rejects_and_names_the_field
+        ; Alcotest.test_case "maxLength" `Quick test_max_length_rejects_and_names_the_field
+        ; Alcotest.test_case "length counts characters, not bytes" `Quick
+            test_length_counts_characters_not_bytes
+        ; Alcotest.test_case "minItems" `Quick test_min_items_rejects_and_names_the_field
+        ; Alcotest.test_case "maxItems" `Quick test_max_items_rejects_and_names_the_field
+        ] )
+    ; ( "unconstrained_schemas"
+      , [ Alcotest.test_case "no declared bounds, no new rejection" `Quick
+            test_absent_constraints_change_nothing
+        ; Alcotest.test_case "an omitted bounded field is not checked" `Quick
+            test_absent_field_is_not_range_checked
+        ] )
+    ; ( "nested_declarations"
+      , [ Alcotest.test_case "a nested item bound names its path" `Quick
+            test_nested_item_constraint_is_enforced_with_its_path
+        ; Alcotest.test_case "nested in-range values pass" `Quick
+            test_nested_in_range_value_is_accepted
+        ] )
+    ; ( "schema_health"
+      , [ Alcotest.test_case "an unreadable numeric bound fails closed" `Quick
+            test_unreadable_numeric_bound_fails_closed_as_a_schema_defect
+        ; Alcotest.test_case "an unreadable count bound fails closed" `Quick
+            test_unreadable_count_bound_fails_closed_as_a_schema_defect
+        ; Alcotest.test_case "every masc declaration is reachable" `Quick
+            test_every_declaration_is_reachable_by_enforcement
+        ; Alcotest.test_case "every masc bound is readable" `Quick
+            test_every_declared_bound_is_readable
+        ] )
+    ]
+;;

--- a/test/test_tool_schema_constraint_enforcement.ml
+++ b/test/test_tool_schema_constraint_enforcement.ml
@@ -256,6 +256,45 @@ let test_exclusive_maximum_rejects_the_bound_itself () =
   check_names ~label:"ratio at exclusiveMaximum" ~message [ "ratio"; "exclusiveMaximum" ]
 ;;
 
+let large_integer_maximum_schema =
+  object_schema
+    [ ( "value"
+      , `Assoc
+          [ "type", `String "number"
+          ; "maximum", `Float 9_007_199_254_740_992.0
+          ] )
+    ]
+;;
+
+let test_mixed_int_float_comparison_keeps_integer_precision () =
+  let message =
+    expect_rejected
+      ~label:"integer one above a large float maximum"
+      ~schema:large_integer_maximum_schema
+      ~name:"__constraint_large_mixed_number"
+      ~args:(`Assoc [ "value", `Int 9_007_199_254_740_993 ])
+  in
+  check_names
+    ~label:"integer one above a large float maximum"
+    ~message
+    [ "value"; "maximum" ]
+;;
+
+let test_oversized_integer_literal_fails_closed () =
+  let literal = "999999999999999999999999999999999999" in
+  let message =
+    expect_rejected
+      ~label:"integer literal outside exact comparison range"
+      ~schema:count_schema
+      ~name:"__constraint_oversized_intlit"
+      ~args:(`Assoc [ "count", `Intlit literal ])
+  in
+  check_names
+    ~label:"integer literal outside exact comparison range"
+    ~message
+    [ "count"; literal; "exact-comparison range" ]
+;;
+
 let title_schema =
   object_schema
     [ ( "title"
@@ -504,6 +543,28 @@ let test_unreadable_count_bound_fails_closed_as_a_schema_defect () =
     [ "title"; "maxLength" ]
 ;;
 
+let test_unreadable_optional_bound_fails_closed_when_field_is_absent () =
+  check_unreadable_bound_fails_closed
+    ~schema:malformed_numeric_bound_schema
+    ~args:(`Assoc [])
+    ~label:"unreadable optional maximum"
+    [ "count"; "maximum" ]
+;;
+
+let test_non_finite_numeric_bound_fails_closed () =
+  let schema =
+    object_schema
+      [ ( "ratio"
+        , `Assoc [ "type", `String "number"; "maximum", `Float Float.nan ] )
+      ]
+  in
+  check_unreadable_bound_fails_closed
+    ~schema
+    ~args:(`Assoc [])
+    ~label:"non-finite maximum"
+    [ "ratio"; "maximum" ]
+;;
+
 (* --- Every masc declaration must be reachable and readable ---------- *)
 
 let constraint_keyword_names =
@@ -563,13 +624,15 @@ let test_every_declared_bound_is_readable () =
               match keyword, value with
               | ("minimum" | "maximum" | "exclusiveMinimum" | "exclusiveMaximum"), _ ->
                 (match value with
-                 | `Int _ | `Float _ -> true
+                 | `Int _ -> true
+                 | `Float bound -> Float.is_finite bound
                  | `Intlit literal -> Option.is_some (int_of_string_opt literal)
                  | _ -> false)
               | ("minLength" | "maxLength" | "minItems" | "maxItems"), _ ->
                 (match value with
                  | `Int bound -> bound >= 0
-                 | `Float bound -> Float.is_integer bound && bound >= 0.0
+                 | `Float bound ->
+                   Float.is_finite bound && Float.is_integer bound && bound >= 0.0
                  | `Intlit literal ->
                    (match int_of_string_opt literal with
                     | Some bound -> bound >= 0
@@ -613,6 +676,10 @@ let () =
             test_exclusive_minimum_accepts_above_the_bound
         ; Alcotest.test_case "exclusiveMaximum rejects its bound" `Quick
             test_exclusive_maximum_rejects_the_bound_itself
+        ; Alcotest.test_case "mixed int/float comparison keeps integer precision" `Quick
+            test_mixed_int_float_comparison_keeps_integer_precision
+        ; Alcotest.test_case "oversized integer literal fails closed" `Quick
+            test_oversized_integer_literal_fails_closed
         ; Alcotest.test_case "minLength" `Quick test_min_length_rejects_and_names_the_field
         ; Alcotest.test_case "maxLength" `Quick test_max_length_rejects_and_names_the_field
         ; Alcotest.test_case "length counts characters, not bytes" `Quick
@@ -637,6 +704,10 @@ let () =
             test_unreadable_numeric_bound_fails_closed_as_a_schema_defect
         ; Alcotest.test_case "an unreadable count bound fails closed" `Quick
             test_unreadable_count_bound_fails_closed_as_a_schema_defect
+        ; Alcotest.test_case "an unreadable optional bound fails when omitted" `Quick
+            test_unreadable_optional_bound_fails_closed_when_field_is_absent
+        ; Alcotest.test_case "a non-finite numeric bound fails closed" `Quick
+            test_non_finite_numeric_bound_fails_closed
         ; Alcotest.test_case "every masc declaration is reachable" `Quick
             test_every_declaration_is_reachable_by_enforcement
         ; Alcotest.test_case "every masc bound is readable" `Quick


### PR DESCRIPTION
## 무엇이 일어났는가

2026-08-05 20:06:36, keeper `kidsnote`:

```
keeper_artifact_read {"max_bytes": 565244, "offset": 0,
                      "sha256": "8ee32b2a47387c0d0f7d30f93f476843c0a1e8804907d83aacd7a3ebf5c8740c"}
→ {"ok":false,"error":"invalid_artifact_read",
   "message":"expected sha256, non-negative offset, and max_bytes 1..65536"}
```

sha256은 실존하는 blob의 정확한 64자 소문자 hex였다. 실패한 것은 `max_bytes 565244 > 65536` 하나뿐인데, 메시지가 sha256을 먼저 말한다.

## 근본 원인 두 개

**1. 선언된 제약에 독자가 없다.** `lib/`에 `minimum`/`maximum`/`minLength`/`maxLength`/`minItems`/`maxItems` 선언이 82곳 있고, `rg -n 'assoc_opt "(minimum|maximum)"' lib/`는 0건을 돌려준다. `Tool_bridge.params_of_json_schema`가 스키마를 `{name; description; param_type; required}`로 투영하면서 제약을 버리기 때문에, dispatch 전 검증이 그것을 볼 수 없다.

**2. `request_of_json`이 원인 7개를 한 문장으로 뭉갠다.** `keeper_artifact_read.ml:53`의 `| _ ->`에 도달하는 경로: sha256 누락 / 비-string, offset·max_bytes가 정수 아님, offset<0, max_bytes<1, max_bytes>65536, `Intlit`. 전부 같은 문자열을 낸다.

## 변경

- `lib/tool_input_validation.ml` — masc가 이미 보유한 **원본 JSON 스키마**에서 선언된 bound를 읽어 dispatch 전에 강제한다. 읽을 수 없는 bound는 masc 자신의 결함이므로 **fail closed**.
- `lib/keeper/keeper_artifact_read.ml` — 필드마다 자기 `result`로 파싱해 어느 필드가 왜 틀렸는지 보존한다. `Intlit`(wire는 담았으나 OCaml native int로 표현 불가한 정수)은 wildcard에 흘리지 않고 명시적으로 이름 붙인다.

**`keeper_artifact_read.request_of_json` 자체의 수락/거부 집합은 바뀌지 않는다.** `decision_parity` 그룹이 그 parser 범위의 parity를 고정한다. 전역 dispatch에는 선언 bound 강제가 새로 생기므로, 지금까지 runtime이 조용히 보정하던 범위 밖 입력은 named error로 바뀐다.

## 블라스트 반경 (측정값)

기록된 호출 329,347건 대상. 새로 거부되는 것 90건:

| 툴·필드 | 선언 | 값 | 건수 |
|---|---|---|---|
| `keeper_tasks_list.limit` | `maximum: 100` | `200` | 83 |
| `keeper_board_post_get.comment_limit` | `minimum: 1` | `0` | 7 |

83건은 모델이 `maximum`을 통보받은 적이 없어서 생긴 것이다. SDK(`jeong-sik/oas`)가 스키마를 그대로 전달하도록 고쳐지면 (jeong-sik/oas#2938) 그 원인이 사라진다.

## 리뷰 후 계약 확인

- `keeper_tasks_list.limit`의 실제 model-tool handler는 `Keeper_tool_task_runtime`이며 이미 `1..100`으로 제한한다. `Keeper_tool_surface.keeper_list_body`의 무상한 limit은 별도 operator tool `masc_keeper_list`다.
- `masc_board_post_get.comment_limit=0`은 “댓글 없음”이 아니라 기존 runtime과 회귀 테스트에서 1로 조용히 보정된다. 따라서 declared minimum 1이 실제 계약이다.
- 이 PR은 숨은 보정을 명시적 거부로 hard-cut한다. jeong-sik/oas#2938은 모델이 같은 bound를 받아 범위 밖 입력을 애초에 만들지 않게 하는 별도 개선이며, 두 PR의 병합 순서는 서로를 차단하지 않는다.

## 검증

두 스위트 모두 `ci.yml`에 명시 배선했다 — catch-all `dune test` 게이트가 제거된 저장소라 배선하지 않은 스위트는 아예 돌지 않는다.

모든 테스트에 결함을 주입해 **실패할 수 있음을 증명**했다:

| 주입 | 결과 |
|---|---|
| `max_bytes` 상한 off-by-one (`>` → `>=`) | `decision_parity`만 적발. 13개 메시지 단언은 전부 눈이 멀었다 |
| `Intlit` arm 삭제 | `field_named_rejections` 7·8 실패 |
| `max_bytes` 실패를 `sha256`으로 보고 (원래 증상) | 6개 테스트 실패 |
| 숫자 bound 비교 반전 | 4개 실패 |
| 읽을 수 없는 bound를 fail-open으로 (numeric) | `schema_health` 실패 |
| 같은 결함을 count 키워드에 (minLength/maxLength/minItems/maxItems) | **처음엔 38개 전부 통과** — fixture가 numeric만 덮고 있었다. 이 PR에서 count fixture를 추가해 닫았고, 재주입으로 실패를 확인했다 |

로컬: `test_tool_schema_constraint_enforcement` 23건, `test_keeper_artifact_read_request` 16건 통과. `ocamlformat --check` 깨끗.

## 별건으로 남기는 것

`lib/board_tool_adapter/board_tool_post.ml:343-346`이 `comment_limit`을 `|> max 1 |> min max_comment_page_limit`으로 조용히 클램프한다. 강제가 켜지면 이 클램프는 도달 불가가 된다. 요청 범위 밖이라 이 PR에서 건드리지 않는다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LuvC4RDtTbxf4kJGdKFTA
