### PR TITLE
test(turn-fsm): turn_fsm.mli 가 존재한다고 주장하던 TLA parity 가드를 실제로 작성

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -934,6 +934,7 @@ jobs:
             @test/runtest-test_keeper_invocation_contract_hints \
             @test/runtest-test_keeper_path_ssot \
             @test/runtest-test_keeper_phase_drift_contract \
+            @test/runtest-test_keeper_turn_fsm_tla_parity \
             @test/runtest-test_keepers_runtime_dir_ssot \
             @test/runtest-test_mcp_h1_h2_admission_parity \
             @test/runtest-test_nickname_words_ssot \

--- a/lib/turn_fsm/turn_fsm.ml
+++ b/lib/turn_fsm/turn_fsm.ml
@@ -160,6 +160,30 @@ type transition_action =
   | HonorStopSignal
   | TerminalStutter
 
+(* Every constructor above. [transition_action_label] is exhaustive, so a new
+   one fails to compile there first; this list is what lets a test walk the set
+   and compare it against the TLA+ spec's Next disjunction. *)
+let all_transition_actions =
+  [ StartTurn
+  ; PhaseGateSkip
+  ; PhaseGateOk
+  ; RuntimeRouted
+  ; RuntimeUnavailable
+  ; ProviderResponded
+  ; ProviderTimeout
+  ; StreamYieldsTool
+  ; ToolReturned
+  ; StreamComplete
+  ; FinishTurn
+  ; ReceiptLost
+  ; NoToolCapableProvider
+  ; ProviderError
+  ; GenericFail
+  ; SupervisorRequestsStop
+  ; HonorStopSignal
+  ; TerminalStutter
+  ]
+
 let transition_action_label = function
   | StartTurn -> "StartTurn"
   | PhaseGateSkip -> "PhaseGateSkip"

--- a/lib/turn_fsm/turn_fsm.mli
+++ b/lib/turn_fsm/turn_fsm.mli
@@ -87,6 +87,11 @@ type transition_action =
   | TerminalStutter
 (** Runtime image of [KeeperTurnFSM.tla] [Next] actions. *)
 
+(** Every [transition_action] constructor. Exposed so the TLA+ parity guard can
+    walk the set; [transition_action_label] is exhaustive, so a new constructor
+    fails to compile there before it can be missed here. *)
+val all_transition_actions : transition_action list
+
 val transition_action_label : transition_action -> string
 
 type transition_context = {

--- a/test/dune
+++ b/test/dune
@@ -1983,6 +1983,8 @@
 
 (include stanzas/test_task_status_vocabulary.inc)
 
+(include stanzas/test_keeper_turn_fsm_tla_parity.inc)
+
 (include stanzas/test_workspace_heartbeat_outcome.inc)
 
 (include stanzas/test_http_auth_strict_flag.inc)

--- a/test/stanzas/test_keeper_turn_fsm_tla_parity.inc
+++ b/test/stanzas/test_keeper_turn_fsm_tla_parity.inc
@@ -1,0 +1,5 @@
+(test
+ (name test_keeper_turn_fsm_tla_parity)
+ (modules test_keeper_turn_fsm_tla_parity)
+ (deps %{project_root}/specs/keeper-turn-fsm/KeeperTurnFSM.tla)
+ (libraries alcotest masc masc_test_deps masc.masc_turn))

--- a/test/test_keeper_turn_fsm_tla_parity.ml
+++ b/test/test_keeper_turn_fsm_tla_parity.ml
@@ -1,0 +1,125 @@
+(** The parity guard [turn_fsm.mli] says verifies parity.
+
+    Its header states that the [@tla.*] annotations "bind states + the
+    transition matrix to that spec" and that [test_keeper_turn_fsm_tla_parity]
+    verifies it. No such module existed. What did exist —
+    [test_keeper_turn_fsm_emit]'s [test_transition_actions_cover_tla_next] —
+    hand-lists transitions and checks each produces the expected label; it never
+    opens the [.tla]. [scripts/tla-check.sh] runs TLC over the spec, which
+    checks the spec against its own invariants, not against OCaml.
+
+    So nothing compared the two vocabularies. This does: it reads the [Next]
+    disjunction out of the spec and requires every action named there to exist
+    as a [transition_action].
+
+    The reverse does not hold and is not asserted as equality. Five OCaml
+    actions have no counterpart in [Next] — the phase gate pair, the two
+    routing failures, and the generic failure. They are listed below rather
+    than tolerated silently, so a sixth has to be looked at. *)
+
+open Alcotest
+
+module F = Turn_fsm
+
+(* The runtest action runs in the test directory; the dune stanza stages the
+   spec beside it under the build root. *)
+let spec_path = "../specs/keeper-turn-fsm/KeeperTurnFSM.tla"
+
+(* Actions the spec's Next disjunction admits. Lines look like "    \/ Name". *)
+let tla_next_actions () =
+  let contents =
+    let ic = open_in spec_path in
+    Fun.protect
+      ~finally:(fun () -> close_in ic)
+      (fun () -> really_input_string ic (in_channel_length ic))
+  in
+  let lines = String.split_on_char '\n' contents in
+  let rec collect acc in_next = function
+    | [] -> List.rev acc
+    | line :: rest ->
+      let trimmed = String.trim line in
+      if (not in_next) && String.equal trimmed "Next =="
+      then collect acc true rest
+      else if in_next
+      then
+        if String.length trimmed > 3 && String.starts_with ~prefix:"\\/" trimmed
+        then collect (String.trim (String.sub trimmed 2 (String.length trimmed - 2)) :: acc) true rest
+        else if String.equal trimmed ""
+        then collect acc true rest
+        else List.rev acc (* Next block ended *)
+      else collect acc false rest
+  in
+  collect [] false lines
+;;
+
+let ocaml_action_labels () =
+  List.map F.transition_action_label F.all_transition_actions
+;;
+
+(* A guard that reads nothing passes for the wrong reason. *)
+let test_spec_is_readable_and_names_actions () =
+  let actions = tla_next_actions () in
+  check bool
+    (Printf.sprintf "%s yields a non-empty Next disjunction" spec_path)
+    true
+    (actions <> []);
+  check bool "Next names StartTurn" true (List.mem "StartTurn" actions)
+;;
+
+let test_every_spec_action_exists_in_ocaml () =
+  let labels = ocaml_action_labels () in
+  List.iter
+    (fun action ->
+      check bool
+        (Printf.sprintf "spec action %s has a transition_action" action)
+        true
+        (List.mem action labels))
+    (tla_next_actions ())
+;;
+
+(* The five below are OCaml-side refinements the spec does not model. Pinning
+   the set means adding a sixth fails here instead of widening the gap
+   quietly. *)
+let expected_ocaml_only =
+  [ "GenericFail"
+  ; "NoToolCapableProvider"
+  ; "PhaseGateOk"
+  ; "PhaseGateSkip"
+  ; "ProviderError"
+  ]
+;;
+
+let test_ocaml_only_actions_are_the_listed_ones () =
+  let spec = tla_next_actions () in
+  let extra =
+    ocaml_action_labels ()
+    |> List.filter (fun label -> not (List.mem label spec))
+    |> List.sort String.compare
+  in
+  check (list string) "OCaml actions absent from the spec's Next" expected_ocaml_only extra
+;;
+
+let test_labels_are_distinct () =
+  let labels = ocaml_action_labels () in
+  check int
+    "every transition_action has its own label"
+    (List.length labels)
+    (List.length (List.sort_uniq String.compare labels))
+;;
+
+let () =
+  Alcotest.run
+    "Keeper turn FSM TLA parity"
+    [ ( "spec"
+      , [ test_case "is readable and names actions" `Quick
+            test_spec_is_readable_and_names_actions
+        ] )
+    ; ( "parity"
+      , [ test_case "every spec action exists in OCaml" `Quick
+            test_every_spec_action_exists_in_ocaml
+        ; test_case "OCaml-only actions are the listed ones" `Quick
+            test_ocaml_only_actions_are_the_listed_ones
+        ; test_case "labels are distinct" `Quick test_labels_are_distinct
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 문제

`turn_fsm.mli` 헤더가 이렇게 말한다.

> Formal contract: `specs/keeper-turn-fsm/KeeperTurnFSM.tla`. The `[@tla.*]` / `[@@deriving tla]` annotations bind states + the transition matrix to that spec; **`[test_keeper_turn_fsm_tla_parity]` verifies parity**.

**그 모듈은 존재하지 않는다.**

존재하는 것들은 다른 걸 검사한다.

| | 하는 일 | parity 를 보는가 |
|---|---|---|
| `test_keeper_turn_fsm_emit` 의 `test_transition_actions_cover_tla_next` | 전이를 **손으로 나열**하고 각각이 기대한 라벨을 내는지 확인 | `.tla` 를 열지 않는다 |
| `scripts/tla-check.sh` | spec 에 TLC 실행 (clean + buggy cfg) | spec 을 spec 자신의 불변식과 대조한다 |

이름이 `cover_tla_next` 인데 TLA 파일을 읽지 않으므로, 그 목록과 spec 은 서로 독립적으로 흘러간다. **두 어휘를 대조하는 코드가 없었다.**

## 실제 차이

| | 개수 |
|---|---|
| TLA `Next` 액션 | 13 |
| OCaml `transition_action` | 18 |

TLA 13개는 전부 OCaml 에 있다. OCaml 전용이 5개다 — `PhaseGateSkip`, `PhaseGateOk`, `NoToolCapableProvider`, `ProviderError`, `GenericFail`.

## 수정

`.mli` 가 이름 붙인 모듈을 실제로 만들었다. spec 의 `Next` disjunction 을 읽어서 거기 이름 붙은 모든 액션이 `transition_action` 으로 존재하는지 요구한다.

반대 방향은 **동등성으로 주장하지 않는다.** OCaml 전용 5개는 목록으로 못박아서, 여섯 번째가 생기면 조용히 벌어지는 대신 여기서 실패한다.

`turn_fsm` 에 `all_transition_actions` 를 추가했다. `transition_action_label` 은 그대로 exhaustive 하므로, 새 생성자는 목록에서 누락되기 **전에** 거기서 컴파일이 깨진다.

## 가드가 진짜인지 증명

양방향으로 깨봤다.

```
# spec 에 액션 추가
ASSERT spec action ProbeUnmodelledAction has a transition_action
> [FAIL] parity 0 every spec action exists in OCaml

# OCaml 에 생성자 추가
FAIL OCaml actions absent from the spec's Next
> [FAIL] parity 1 OCaml-only actions are the listed ones
```

둘 다 되돌린 뒤 4/4 통과한다.

spec 파일은 dune stanza 의 `(deps %{project_root}/specs/keeper-turn-fsm/KeeperTurnFSM.tla)` 로 stage 되고 runtest 액션에서 읽는다. **읽지 못하면 통과하는 가드가 되지 않도록**, 첫 케이스가 `Next` 파싱 결과가 비어있지 않고 `StartTurn` 을 포함하는지 먼저 확인한다.

## 검증

- `dune build --root . @check` EXIT=0
- `dune build @test/runtest-test_keeper_turn_fsm_tla_parity` 4/4
- `test_keeper_turn_fsm_emit` OK (기존 테스트 불변)
- `scripts/check-doc-code-refs.sh`, `scripts/audit-keeper-tool-boundary-matrix.sh` PASS

프로덕션 코드 변경은 `all_transition_actions` 추가뿐이고 동작에 영향이 없다.

RFC-WAIVED: `.mli` 가 존재한다고 주장하던 가드를 실제로 작성한다. FSM 전이·상태·라벨 전부 불변. credential/identity, repo_manager, operator control plane, keeper sandbox, dashboard credential component, hooks, workflow 문서 어느 것도 건드리지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
