### PR TITLE
refactor(resilience): drop four TLA mirrors whose spec was deleted in #24332

### DIFF
--- a/lib/resilience/recovery.ml
+++ b/lib/resilience/recovery.ml
@@ -176,35 +176,6 @@ let execute_strategy : type a.
         (fun () -> Aborted { reason })
         aborted
 
-(* TLA+ taxonomy mirrors for specs/resilience/ResilienceDegradation.tla.
-   Payload-bearing constructors cannot use ppx_tla's [all_states], so
-   the exhaustive functions below are the typed contract and the lists
-   are the set surface consumed by parity tests. *)
-let error_mode_to_tla_symbol = function
-  | TransientError _ -> "Transient"
-  | PermanentError _ -> "Permanent"
-  | ResourceExhausted _ -> "ResourceExhausted"
-  | AmbiguityError _ -> "Ambiguity"
-  | ConsensusError _ -> "Consensus"
-  | DegradationRequired _ -> "Degradation"
-
-let all_error_mode_tla_symbols =
-  [ "Transient";
-    "Permanent";
-    "ResourceExhausted";
-    "Ambiguity";
-    "Consensus";
-    "Degradation";
-  ]
-
-let strategy_to_tla_symbol : type a. a strategy -> string = function
-  | Retry _ -> "Retry"
-  | Fallback _ -> "Fallback"
-  | Handoff _ -> "Handoff"
-  | Abort _ -> "Abort"
-
-let all_strategy_tla_symbols = [ "Retry"; "Fallback"; "Handoff"; "Abort" ]
-
 (* ── Convenience constructors ─────────────────────────────────── *)
 
 let transient ~detail ?(max_retries = 3) ?(backoff_ms = 200) () =

--- a/lib/resilience/recovery.mli
+++ b/lib/resilience/recovery.mli
@@ -121,21 +121,6 @@ type _ strategy =
   | Abort : { reason : string; cleanup : unit -> unit }
       -> [> `Abort ] strategy
 
-(** TLA+ symbol for {!error_mode}, matching
-    [specs/resilience/ResilienceDegradation.tla] [ErrorModes]. *)
-val error_mode_to_tla_symbol : error_mode -> string
-
-(** Complete TLA+ [ErrorModes] mirror for payload-bearing
-    {!error_mode} constructors. *)
-val all_error_mode_tla_symbols : string list
-
-(** TLA+ symbol for {!strategy}, matching
-    [specs/resilience/ResilienceDegradation.tla] [Strategies]. *)
-val strategy_to_tla_symbol : 'a strategy -> string
-
-(** Complete TLA+ [Strategies] mirror for {!strategy}. *)
-val all_strategy_tla_symbols : string list
-
 (** {1 Untyped classification} *)
 
 val classify_string : string -> error_mode


### PR DESCRIPTION
## 무엇

`lib/resilience/recovery` 가 export 하던 TLA 심볼 미러 4개를 지운다. 이들이 미러링하는 스펙은 **2년치 PR 전에 삭제됐다.**

| 심볼 | 저장소 전체 참조 |
|---|---|
| `error_mode_to_tla_symbol` | 0 |
| `all_error_mode_tla_symbols` | 0 |
| `strategy_to_tla_symbol` | 0 |
| `all_strategy_tla_symbols` | 0 |

## 스펙이 없다

`.mli` 가 지목한 파일:

```
(** TLA+ symbol for {!error_mode}, matching
    [specs/resilience/ResilienceDegradation.tla] [ErrorModes]. *)
```

`specs/resilience/` 디렉터리 자체가 없다. `ResilienceDegradation.tla` 는 #12175 가 추가했고 **#24332 (`7b62a87d44`, "replace Keeper governance with a nonhierarchical Gate") 가 삭제했다.** 그 커밋은 TLA 스펙 58개를 지웠는데, 이 미러 4개와 스펙 경로를 인용하는 주석은 남겼다.

## 주석의 주장이 거짓이다

```ocaml
(* TLA+ taxonomy mirrors for specs/resilience/ResilienceDegradation.tla.
   ... the lists are the set surface consumed by parity tests. *)
```

parity test 는 없다. 확인한 것:

- `test/resilience/test_degradation.ml` — `Recovery.default_strategy` 를 **주석에서만** 언급. 심볼 함수 미사용.
- `test/test_multimodal_resilience_audit_composition.ml:120-129` — 매핑을 자기가 다시 구현한다. parity check 가 아니라 실패 메시지 라벨이고, 한 케이스는 **문자열이 다르다**: 테스트는 `"DegradationRequired"`, 모듈은 `"Degradation"`.

두 번째가 요점이다. 이 리스트들이 실제 parity 계약이었다면 그 불일치를 잡았어야 한다. 아무도 안 읽으니 조용히 갈라진 채로 있었다.

## 컴파일러가 증명했다

정적 스캔의 주장이 아니다. 먼저 `.mli` 에서 4개 `val` 을 빼고 빌드했다. `lib/resilience/dune` 은 `-w +32` 래칫이 걸려 있다:

```
File "lib/resilience/recovery.ml", line 183:
Error (warning 32 [unused-value-declaration]): unused value error_mode_to_tla_symbol.
line 191: unused value all_error_mode_tla_symbols.
line 200: unused value strategy_to_tla_symbol.
line 206: unused value all_strategy_tla_symbols.
```

네 개 전부 — 모듈 **내부에서도** 호출자가 없다는 뜻이다. 그 다음 구현부를 지웠다.

## 왜 리스트가 계약이 될 수 없나

주석은 "payload-bearing constructors cannot use ppx_tla's `[all_states]`, so the exhaustive functions are the typed contract and the lists are the set surface" 라고 한다. 앞 절반은 참이다 — `error_mode_to_tla_symbol` 의 exhaustive match 는 생성자가 추가되면 컴파일이 깨진다. 뒷 절반은 거짓이다. 리터럴 리스트는 아무것도 강제하지 않는다. 옆의 `match` 에 팔이 하나 늘어도 리스트는 조용히 낡는다.

이건 #26988 이 `keeper_composite_observer` 에서 지운 것과 같은 패턴이고, 판정도 같다.

## 검증

| 항목 | 결과 |
|---|---|
| `dune build --root . @check` | EXIT=0 |
| `@test/resilience/runtest` | test_recovery / test_degradation / test_keeper_bridge 전부 통과 |
| `test_multimodal_resilience_audit_composition` | 9 checks passed |
| `scripts/audit-tla-annotation-drift.sh` | EXIT=0 (10 constructors / 2 type-set pairs, 0 drift) |
| `scripts/check-doc-truth.sh` | EXIT=0 |

tla-annotation-drift 게이트는 `[@@deriving tla]` 타입만 추적한다. 지운 수기 미러는 애초에 그 안에 없었다 — 이것 자체가 이들이 어떤 자동 검사에도 걸려 있지 않았다는 증거다.

44줄 삭제, 0줄 추가.

## 남은 것 (별건)

#24332 가 지운 스펙 58개 중 **16개가 아직 살아있는 코드에서 인용된다.** 다수가 존재하지 않는 파일의 줄 번호를 가리킨다.

| 스펙 | 인용 수 |
|---|---|
| `KeeperReconcileLiveness` | 11 (`keeper_state_machine.ml:35` 이 "Authoritative spec mirror" 라 부름) |
| `KeeperTaskAcquisition` | 8 |
| `KeeperCompositeLifecycle` | 7 (`keeper_composite_observer.mli`, line anchor 4개) |
| `KeeperCoreTriad` | 3 |
| 그 외 12개 | 각 1–2 |

이건 sed 대상이 아니다. 각 주석마다 참인 동작 서술과 거짓 권위 주장이 섞여 있어 사이트별 판단이 필요하다. 별도 PR 로 처리한다.

Co-authored-by: MASC Agent <agent@masc.local>
Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>
