### PR TITLE
refactor(discovery-cache): 존재하지 않는 테스트를 위해 열려 있던 backdoor 를 닫는다

### DIFF
--- a/lib/dashboard/dashboard_goals.mli
+++ b/lib/dashboard/dashboard_goals.mli
@@ -12,10 +12,9 @@
       the per-keeper goal projection.
     - {b dashboard envelope} ({!dashboard_goals_tree_json})
       consumed by [server_dashboard_http] +
-      [test/test_dashboard_goals].
+      [test/test_goal_metric_unevaluated].
     - {b per-goal detail} ({!goal_detail_json}) consumed
-      by [server_dashboard_http] +
-      [test/test_dashboard_goals].
+      by [server_dashboard_http].
 
     Internal helpers stay private at this boundary
     ([goal_status_color], [build_goal_events_projection],

--- a/lib/discovery_cache/discovery_cache.mli
+++ b/lib/discovery_cache/discovery_cache.mli
@@ -17,12 +17,10 @@
     I/O. Two concurrent refreshers may both probe; that is
     wasteful but correct, and the 30 s TTL narrows the window.
 
-    Test-only mutable state ([cached_endpoints] /
-    [cache_updated_at]) is exposed deliberately —
-    [test_tool_local_runtime_verify] needs to seed and restore
-    the cache before / after exercising consumers. The .mli
-    documents this so a future "make these private" refactor
-    sees the test contract it would break. *)
+    The cache cells themselves are private. They were exposed for a
+    [test_tool_local_runtime_verify] suite that seeds and restores them, and
+    that suite does not exist -- no file, no module, no caller anywhere. The
+    only way in is {!get_cached_or_refresh}. *)
 
 (** {1 Type aliases} *)
 
@@ -40,21 +38,6 @@ val set_env :
     probing. Called once at server init by
     [server_runtime_bootstrap]; safe to re-call (last-writer-wins
     on the underlying [Atomic.t]). *)
-
-(** {1 Cache state (test-visible)} *)
-
-val cached_endpoints : endpoint_info list ref
-(** Current cached probe result. Exposed for the
-    [test_tool_local_runtime_verify] suite which needs to seed
-    a deterministic value and restore the original after the
-    test. Production callers should go through
-    {!get_cached_or_refresh} instead. *)
-
-val cache_updated_at : float Atomic.t
-(** Unix timestamp of the most recent successful refresh. The
-    TTL check in {!get_cached_or_refresh} reads this without
-    taking the cache mutex. Exposed for the same testing
-    reason as {!cached_endpoints}. *)
 
 (** {1 Refresh + read} *)
 


### PR DESCRIPTION
## 문제

`discovery_cache.mli` 가 캐시 셀 두 개를 노출하면서 이유를 적어두었다.

> Test-only mutable state (`[cached_endpoints]` / `[cache_updated_at]`) is exposed deliberately — **`[test_tool_local_runtime_verify]` needs to seed and restore the cache** before / after exercising consumers. The .mli documents this so a future "make these private" refactor **sees the test contract it would break**.

**`test_tool_local_runtime_verify` 는 존재하지 않는다.** 파일도, 모듈도, 어디의 호출자도 없다. 그리고 두 셀은 `discovery_cache.ml` 밖에 독자가 0 이다.

refactor 가 깨뜨릴까 봐 문서로 지켜둔 계약이 **아무것도 아니었다.**

```ocaml
val cached_endpoints : endpoint_info list ref
(** ... Production callers should go through {!get_cached_or_refresh} instead. *)

val cache_updated_at : float Atomic.t
(** ... Exposed for the same testing reason as {!cached_endpoints}. *)
```

같은 `.mli` 가 프로덕션에는 `get_cached_or_refresh` 를 쓰라고 이미 말하고 있다. 노출의 유일한 근거가 없는 테스트였다.

CLAUDE.md 워크어라운드 거부 체크리스트 6번 — *"test backdoor (`set_X_for_test` / `reset_for_test`) 노출"* — 에 해당하고, 그 backdoor 를 정당화하던 테스트가 없다.

## 수정

둘 다 다시 비공개. 들어가는 길은 `get_cached_or_refresh` 하나다.

**빌드가 증명한다**: `.mli` 에서 두 `val` 을 지운 뒤 `@check` 가 통과한다 — 모듈 밖에서 참조하는 코드가 없다는 뜻이다.

## 같이 고친 인용

`dashboard_goals.mli` 가 두 함수에 대해 `test/test_dashboard_goals` 를 인용한다. 이것도 없다.

실제 테스트 소비자는 `test_goal_metric_unevaluated` 이고 **둘 중 하나만** 쓴다. 나머지 하나는 `server_dashboard_http` 뿐이다. 두 줄 모두 실재하는 것을 가리키도록 고쳤다.

## 검증

- `dune build --root . @check` EXIT=0
- `test_tool_local_runtime_probe`, `test_local_runtime_pool`, `test_goal_metric_unevaluated` OK
- `scripts/check-doc-code-refs.sh`, `scripts/audit-keeper-tool-boundary-matrix.sh` PASS

`.mli` 두 개만 변경. `.ml` 은 손대지 않았고 런타임 동작은 불변이다.

RFC-WAIVED: 존재하지 않는 테스트를 위해 노출돼 있던 가변 상태 두 개를 비공개로 되돌리고, 없는 테스트를 가리키던 인용을 실재하는 것으로 고친다. credential/identity, repo_manager, operator control plane, keeper sandbox, dashboard credential component, hooks, workflow 문서 어느 것도 건드리지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
