### PR TITLE
fix(dashboard): replace Keeper polling with push invalidation

### DIFF
--- a/dashboard/src/api/dashboard-turn-records.ts
+++ b/dashboard/src/api/dashboard-turn-records.ts
@@ -304,6 +304,7 @@ export type KeeperCompactionSnapshotsResponse = {
   readonly read_error_count: number
   readonly read_errors: { scope: string; error: string }[]
   readonly scan_truncated: boolean
+  readonly hydration_status: 'warming' | 'ready' | 'failed'
   readonly items: KeeperCompactionSnapshot[]
 }
 
@@ -1113,7 +1114,13 @@ function decodeKeeperCompactionSnapshotsResponse(raw: unknown): KeeperCompaction
   const keeper = asString(raw.keeper)
   const source = asString(raw.source)
   const producer = asString(raw.producer)
-  if (!schema || !keeper || !source || !producer) return null
+  const hydration_status =
+    raw.hydration_status === 'warming'
+    || raw.hydration_status === 'ready'
+    || raw.hydration_status === 'failed'
+      ? raw.hydration_status
+      : null
+  if (!schema || !keeper || !source || !producer || !hydration_status) return null
   return {
     schema,
     keeper,
@@ -1124,6 +1131,7 @@ function decodeKeeperCompactionSnapshotsResponse(raw: unknown): KeeperCompaction
     read_error_count: asNumber(raw.read_error_count, 0) ?? 0,
     read_errors: decodeReadErrors(raw.read_errors),
     scan_truncated: asBoolean(raw.scan_truncated) ?? false,
+    hydration_status,
     items: asRecordArray(raw.items)
       .map(decodeKeeperCompactionSnapshot)
       .filter((item): item is KeeperCompactionSnapshot => item !== null),
@@ -1157,9 +1165,13 @@ export async function fetchKeeperTurnRecords(
 export async function fetchKeeperCompactionSnapshots(
   name: string,
   limit?: number,
-  opts?: AbortableRequestOptions,
+  opts?: AbortableRequestOptions & { refresh?: boolean },
 ): Promise<KeeperCompactionSnapshotsResponse> {
-  const params = limitQueryString(limit)
+  const query = new URLSearchParams()
+  if (limit != null) query.set('limit', String(limit))
+  if (opts?.refresh === true) query.set('refresh', 'true')
+  const encoded = query.toString()
+  const params = encoded ? `?${encoded}` : ''
   await ensureDevToken()
   return get<Record<string, unknown>>(
     `/api/v1/keepers/${encodeURIComponent(name)}/compaction-snapshots${params}`,

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -561,6 +561,7 @@ describe('keeper tool telemetry fetchers', () => {
         read_error_count: 1,
         read_errors: [{ scope: 'runtime_manifest_row:/tmp/bad.jsonl:1', error: 'bad row' }],
         scan_truncated: false,
+        hydration_status: 'ready',
         items: [
           {
             id: 'manifest:trace-a:context_compacted:2026-06-26T03:03:00Z',
@@ -713,6 +714,11 @@ describe('keeper tool telemetry fetchers', () => {
     expect(result.items[2]?.cause).toBe('lifecycle cleanup failed')
     expect(result.items).toHaveLength(3)
     expect(result.items.some(item => item.trace_id === 'trace-contradictory')).toBe(false)
+
+    await fetchKeeperCompactionSnapshots('keeper-alpha', 2, { refresh: true })
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      '/api/v1/keepers/keeper-alpha/compaction-snapshots?limit=2&refresh=true',
+    )
   })
 })
 

--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -270,6 +270,7 @@ describe('MCP 2026-07-28 dashboard client', () => {
 
   it('bootstraps a loopback dev token before the single MCP request', async () => {
     getStoredToken.mockReturnValue(null)
+    getStoredTokenMeta.mockReturnValue(null)
     fetchWithTimeout
       .mockResolvedValueOnce(new Response(JSON.stringify({
         token: 'loopback-dev-token', actor: 'dashboard', role: 'worker',

--- a/dashboard/src/components/keeper-shared-hydration.integration.test.ts
+++ b/dashboard/src/components/keeper-shared-hydration.integration.test.ts
@@ -27,8 +27,9 @@ const {
   streamKeeperMessage: vi.fn(),
 }))
 
-const { fetchKeeperToolCalls } = vi.hoisted(() => ({
+const { fetchKeeperToolCalls, fetchKeeperWaitingInventory } = vi.hoisted(() => ({
   fetchKeeperToolCalls: vi.fn(async (): Promise<{ entries: ToolCallEntry[] }> => ({ entries: [] })),
+  fetchKeeperWaitingInventory: vi.fn(async () => ({ keepers: [] })),
 }))
 
 vi.mock('../api/keeper', () => ({
@@ -41,7 +42,10 @@ vi.mock('../api/keeper', () => ({
   streamKeeperMessage,
 }))
 
-vi.mock('../api/dashboard', () => ({ fetchKeeperToolCalls }))
+vi.mock('../api/dashboard', () => ({
+  fetchKeeperToolCalls,
+  fetchKeeperWaitingInventory,
+}))
 vi.mock('../api/mcp', () => ({ callMcpTool: vi.fn() }))
 vi.mock('../api/core', () => ({ runOperatorAction: vi.fn() }))
 vi.mock('../store', async () => {

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -61,14 +61,12 @@ const { invalidateDashboardCache, refreshDashboard } = vi.hoisted(() => ({
   refreshDashboard: vi.fn(async () => undefined),
 }))
 
-// Mutable handle for the `tools/tool-state` module mock. `vi.mock` is hoisted
+// Mutable handle for the keeper-scoped inventory mock. `vi.mock` is hoisted
 // above `let` declarations, so the shared state must itself be created inside
-// `vi.hoisted` to avoid the temporal dead zone. Tests inject a
-// `keeper_waiting_inventory` by setting `mockedToolsData.value` before render.
-const { mockedToolsData, mockedToolsError, subscribeToolsAutoRefresh } = vi.hoisted(() => ({
+// `vi.hoisted` to avoid the temporal dead zone.
+const { mockedToolsData, mockedToolsError } = vi.hoisted(() => ({
   mockedToolsData: { value: null as unknown },
   mockedToolsError: { value: null as string | null },
-  subscribeToolsAutoRefresh: vi.fn(() => vi.fn()),
 }))
 
 vi.mock('../keeper-actions', () => ({
@@ -148,17 +146,17 @@ vi.mock('../store', async (importOriginal) => {
   }
 })
 
-// Mock the shared tools resource so the busy chip can be driven by an injected
-// `keeper_waiting_inventory` and so `KeeperConversationPanel`'s mount-time
-// `loadTools()` does not perform a real fetch. `toolsData` mirrors the signal
-// shape (`{ value }`) the component reads via `toolsData.value?.keeper_waiting_inventory`.
-vi.mock('../components/tools/tool-state', () => ({
-  toolsData: mockedToolsData,
-  toolsLoading: { value: false },
-  toolsError: mockedToolsError,
-  KEEPER_WAITING_INVENTORY_REFRESH_MS: 15_000,
-  subscribeToolsAutoRefresh,
-  loadTools: vi.fn(),
+vi.mock('../keeper-waiting-inventory-store', () => ({
+  keeperWaitingInventoryState: () => ({
+    inventory: (mockedToolsData.value as {
+      keeper_waiting_inventory?: unknown
+    } | null)?.keeper_waiting_inventory ?? null,
+    ready: mockedToolsData.value !== null,
+    loading: false,
+    error: mockedToolsError.value,
+  }),
+  subscribeKeeperWaitingInventory: vi.fn(() => vi.fn()),
+  refreshKeeperWaitingInventory: vi.fn(async () => undefined),
 }))
 
 vi.mock('./common/toast', () => ({
@@ -263,7 +261,6 @@ describe('KeeperConversationPanel', () => {
     shellAuthSummary.value = null
     mockedToolsData.value = null
     mockedToolsError.value = null
-    subscribeToolsAutoRefresh.mockClear()
     _resetChatStoreForTests()
     vi.mocked(sendKeeperThreadMessage).mockReset()
     vi.mocked(sendKeeperThreadMessage).mockResolvedValue(undefined)

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -81,13 +81,11 @@ import {
   toolCallOutputsCoveredThroughMs,
 } from '../tool-call-output-store'
 import {
-  KEEPER_WAITING_INVENTORY_REFRESH_MS,
-  loadTools,
-  subscribeToolsAutoRefresh,
-  toolsData,
-  toolsError,
-} from './tools/tool-state'
-import { setupVisibleAutoRefresh } from '../lib/auto-refresh'
+  keeperWaitingInventoryState,
+  refreshKeeperWaitingInventory,
+  subscribeKeeperWaitingInventory,
+} from '../keeper-waiting-inventory-store'
+import { registerKeeperWaitingInventoryRefresh } from '../sse-store'
 import { chatShowInternal, chatShowMetadata } from '../lib/chat-view-prefs'
 import {
   cancelKeeperChatPendingReceipt,
@@ -107,11 +105,6 @@ import {
   type KeeperEventQueuePendingSnapshot,
   type KeeperEventQueueReplayableAction,
 } from '../api'
-
-// Mirrors `LANE_REFRESH_MS` in keeper-workspace/keeper-lane-strip.ts. That
-// const is module-local there, so we keep the same 15 s cadence here rather
-// than exporting it cross-file for a single consumer.
-const BUSY_REFRESH_MS = KEEPER_WAITING_INVENTORY_REFRESH_MS
 
 
 function GhostButton({
@@ -784,14 +777,9 @@ function KeeperQueueControlPanel({
   }
   useEffect(() => {
     void load()
-    // Without this the queue rows are fetched once and never again, while the
-    // parent's 15s tools poll keeps re-rendering the panel — so formatTimeAgo
-    // ticks '도착 N분 전' upward on rows that may already have been consumed.
-    // Same cadence and visibility gating the receipt strip below already uses;
-    // load(false) keeps a surfaced error visible across polls.
-    return setupVisibleAutoRefresh(() => {
-      void load(false)
-    }, BUSY_REFRESH_MS)
+    return registerKeeperWaitingInventoryRefresh(changedKeeper => {
+      if (changedKeeper === keeperName) void load(false)
+    })
   }, [keeperName])
   const eventRows = eventSnapshot?.pending ?? []
   const activeChatRows = (keeper?.waiting_on ?? [])
@@ -810,14 +798,14 @@ function KeeperQueueControlPanel({
       await Promise.all([
         reconcileKeeperChatReceipts(keeperName),
         load(),
-        loadTools(),
+        refreshKeeperWaitingInventory(keeperName),
       ])
     } catch (cause) {
       const message = cause instanceof Error ? cause.message : String(cause)
       await Promise.allSettled([
         reconcileKeeperChatReceipts(keeperName),
         load(false),
-        loadTools(),
+        refreshKeeperWaitingInventory(keeperName),
       ])
       setError(message)
       showToast(message, 'error')
@@ -837,7 +825,7 @@ function KeeperQueueControlPanel({
           recovery => recovery.operation.operationId !== operation.operationId,
         ))
       }
-      await Promise.all([load(), loadTools()])
+      await Promise.all([load(), refreshKeeperWaitingInventory(keeperName)])
     } catch (cause) {
       const message = cause instanceof Error ? cause.message : String(cause)
       if (cause instanceof KeeperEventQueueOperationError) {
@@ -853,7 +841,7 @@ function KeeperQueueControlPanel({
           recovery,
         ])
       }
-      await Promise.allSettled([load(false), loadTools()])
+      await Promise.allSettled([load(false), refreshKeeperWaitingInventory(keeperName)])
       setError(message)
       showToast(message, 'error')
     } finally {
@@ -1114,10 +1102,9 @@ function KeeperQueueControlPanel({
           : null}
       </div>
       <div class="grid gap-2 border-t border-[var(--color-border-subtle)] pt-3">
-        <!-- eventSnapshot is fetched once per keeperName and after operator actions; it
-             does not poll. Falling back to the 15s-refreshed waiting inventory (the same
-             source 채팅 대기/배송 복구 already use) keeps the count from reading 0 before
-             the one-shot fetch resolves or after it throws. -->
+        <!-- eventSnapshot is fetched on mount, typed queue invalidation, and operator
+             actions. The shared keeper-scoped inventory keeps the count from reading 0
+             before that read resolves or after it throws. -->
         <div class="text-xs font-semibold text-[var(--color-fg-secondary)]">자율 이벤트 대기 ${eventSnapshot?.totalPending ?? keeper?.sources?.event_queue_pending ?? 0}</div>
         ${eventRecoveries.map(recovery => {
           const operationId = recovery.operation.operationId
@@ -1266,25 +1253,22 @@ export function KeeperConversationPanel({
   const bumpQueue = () => setQueueVersion(v => v + 1)
   const isDrainingRef = useRef(false)
 
-  // Keep the shared tools projection live for the conversation's busy chip and
-  // interrupt button. The right-side Lane has its own keeper-scoped read path.
+  // The conversation and Lane share one keeper-scoped projection. Typed queue
+  // invalidations, focus recovery, and WS reconnects refresh it without a timer.
   useEffect(() => {
-    const unsubscribeToolsRefresh = subscribeToolsAutoRefresh()
+    const unsubscribeInventory = subscribeKeeperWaitingInventory(keeperName)
     void reconcileKeeperChatReceipts(keeperName)
-    const stopReceiptRefresh = setupVisibleAutoRefresh(() => {
-      void reconcileKeeperChatReceipts(keeperName)
-    }, BUSY_REFRESH_MS)
     return () => {
-      stopReceiptRefresh()
-      unsubscribeToolsRefresh()
+      unsubscribeInventory()
     }
   }, [keeperName])
 
+  const inventoryState = keeperWaitingInventoryState(keeperName)
   const inventoryEntry = useMemo(() => {
-    const inv = toolsData.value?.keeper_waiting_inventory
+    const inv = inventoryState.inventory
     if (!inv) return null
     return inv.keepers.find(k => k.keeper_name === keeperName) ?? null
-  }, [keeperName, toolsData.value])
+  }, [keeperName, inventoryState.inventory])
 
   // External-system sync: merge the server-persisted transcript
   // (.masc/keeper_chat/<name>.jsonl) on mount so the conversation
@@ -1332,11 +1316,9 @@ export function KeeperConversationPanel({
     inventoryEntry?.sources?.chat_queue_persistence_blocked ?? 0,
   )
   const serverQueueReadErrorCount = Math.max(0, inventoryEntry?.sources?.read_error ?? 0)
-  const toolsProjectionError = toolsError.value
-  const toolsProjectionReady = toolsData.value !== null
-  const toolsProjectionPresent = Boolean(
-    toolsData.value?.keeper_waiting_inventory && inventoryEntry,
-  )
+  const inventoryProjectionError = inventoryState.error
+  const inventoryProjectionReady = inventoryState.ready
+  const inventoryProjectionPresent = Boolean(inventoryState.inventory && inventoryEntry)
   const visibleThread = useMemo(
     () =>
       sending && !thread.some(isActiveAssistantEntry)
@@ -1604,9 +1586,9 @@ export function KeeperConversationPanel({
       recoveryRequiredCount=${serverRecoveryRequiredCount}
       persistenceBlockedCount=${serverPersistenceBlockedCount}
       readErrorCount=${serverQueueReadErrorCount}
-      projectionError=${toolsProjectionError}
-      projectionReady=${toolsProjectionReady}
-      projectionPresent=${toolsProjectionPresent}
+      projectionError=${inventoryProjectionError}
+      projectionReady=${inventoryProjectionReady}
+      projectionPresent=${inventoryProjectionPresent}
       currentExecution=${inventoryEntry?.current_execution}
       readErrorAction=${serverQueueReadErrorCount > 0
         ? inventoryEntry?.source_next_actions?.read_error?.[0] ?? inventoryEntry?.next_action

--- a/dashboard/src/components/keeper-workspace/compaction-inspector-overlay.ts
+++ b/dashboard/src/components/keeper-workspace/compaction-inspector-overlay.ts
@@ -19,6 +19,7 @@ import {
   keeperCompactionSnapshots,
   type CompactionSnapshot,
 } from './compaction-snapshots'
+import { registerKeeperCompactionRefresh } from '../../sse-store'
 
 type CompactionReadError = {
   readonly scope: string
@@ -27,6 +28,7 @@ type CompactionReadError = {
 
 type CompactionSnapshotLoadState = {
   readonly loading: boolean
+  readonly hydrationStatus: 'warming' | 'ready' | 'failed' | null
   readonly error: string | null
   readonly payloadCount: number | null
   readonly decodedCount: number | null
@@ -308,6 +310,7 @@ export function CompactionInspectorOverlay({
   const [idx, setIdx] = useState(0)
   const [loadState, setLoadState] = useState<CompactionSnapshotLoadState>({
     loading: true,
+    hydrationStatus: null,
     error: null,
     payloadCount: null,
     decodedCount: null,
@@ -340,58 +343,67 @@ export function CompactionInspectorOverlay({
   }, [onClose])
 
   useEffect(() => {
-    const controller = new AbortController()
+    let controller: AbortController | null = null
     let active = true
-    setLoadState({
-      loading: true,
-      error: null,
-      payloadCount: null,
-      decodedCount: null,
-      payloadSource: null,
-      payloadProducer: null,
-      payloadLimit: null,
-      readErrorCount: 0,
-      readErrors: [],
-      scanTruncated: false,
-    })
     setHydratedState({ keeperName: keeper.name, events: [] })
-    void fetchKeeperCompactionSnapshots(keeper.name, undefined, { signal: controller.signal })
-      .then((payload) => {
-        if (!active) return
-        const next = hydrateCompactionSnapshots(keeper.name, payload.items)
-        setHydratedState({ keeperName: keeper.name, events: next })
-        setLoadState({
-          loading: false,
-          error: null,
-          payloadCount: payload.count,
-          decodedCount: payload.items.length,
-          payloadSource: payload.source,
-          payloadProducer: payload.producer,
-          payloadLimit: payload.limit,
-          readErrorCount: payload.read_error_count,
-          readErrors: payload.read_errors,
-          scanTruncated: payload.scan_truncated,
-        })
+    const load = (forceRefresh: boolean) => {
+      controller?.abort()
+      const requestController = new AbortController()
+      controller = requestController
+      setLoadState(previous => ({ ...previous, loading: true, error: null }))
+      void fetchKeeperCompactionSnapshots(keeper.name, undefined, {
+        signal: requestController.signal,
+        refresh: forceRefresh,
       })
-      .catch((err: unknown) => {
-        if (!active) return
-        if (err instanceof DOMException && err.name === 'AbortError') return
-        setLoadState({
-          loading: false,
-          error: err instanceof Error ? err.message : String(err),
-          payloadCount: null,
-          decodedCount: null,
-          payloadSource: null,
-          payloadProducer: null,
-          payloadLimit: null,
-          readErrorCount: 0,
-          readErrors: [],
-          scanTruncated: false,
+        .then((payload) => {
+          if (!active || requestController.signal.aborted) return
+          if (payload.hydration_status === 'ready') {
+            const next = hydrateCompactionSnapshots(keeper.name, payload.items)
+            setHydratedState({ keeperName: keeper.name, events: next })
+          }
+          const failure = payload.hydration_status === 'failed'
+            ? payload.read_errors[0]?.error ?? '백그라운드 hydration 실패'
+            : null
+          setLoadState({
+            loading: payload.hydration_status === 'warming',
+            hydrationStatus: payload.hydration_status,
+            error: failure,
+            payloadCount: payload.count,
+            decodedCount: payload.items.length,
+            payloadSource: payload.source,
+            payloadProducer: payload.producer,
+            payloadLimit: payload.limit,
+            readErrorCount: payload.read_error_count,
+            readErrors: payload.read_errors,
+            scanTruncated: payload.scan_truncated,
+          })
         })
-      })
+        .catch((err: unknown) => {
+          if (!active || requestController.signal.aborted) return
+          if (err instanceof DOMException && err.name === 'AbortError') return
+          setLoadState({
+            loading: false,
+            hydrationStatus: 'failed',
+            error: err instanceof Error ? err.message : String(err),
+            payloadCount: null,
+            decodedCount: null,
+            payloadSource: null,
+            payloadProducer: null,
+            payloadLimit: null,
+            readErrorCount: 0,
+            readErrors: [],
+            scanTruncated: false,
+          })
+        })
+    }
+    load(true)
+    const unregister = registerKeeperCompactionRefresh((changedKeeper, reason) => {
+      if (changedKeeper === keeper.name) load(reason === 'source_changed')
+    })
     return () => {
       active = false
-      controller.abort()
+      controller?.abort()
+      unregister()
     }
   }, [keeper.name])
 

--- a/dashboard/src/components/keeper-workspace/keeper-lane-section.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-lane-section.test.ts
@@ -7,18 +7,11 @@ import type { DashboardKeeperWaitingInventory } from '../../api'
 const mocks = vi.hoisted(() => ({
   fetchKeeperWaitingInventory: vi.fn(),
   refresh: null as ((keeperName: string) => void) | null,
-  stopPolling: vi.fn(),
   unregisterPush: vi.fn(),
 }))
 
 vi.mock('../../api', () => ({
   fetchKeeperWaitingInventory: mocks.fetchKeeperWaitingInventory,
-}))
-vi.mock('../tools/tool-state', () => ({
-  KEEPER_WAITING_INVENTORY_REFRESH_MS: 15_000,
-}))
-vi.mock('../../lib/auto-refresh', () => ({
-  setupVisibleAutoRefresh: vi.fn(() => mocks.stopPolling),
 }))
 vi.mock('../../sse-store', () => ({
   registerKeeperWaitingInventoryRefresh: vi.fn((refresh: (keeperName: string) => void) => {
@@ -28,6 +21,10 @@ vi.mock('../../sse-store', () => ({
 }))
 vi.mock('../../dashboard-ws-state', () => ({
   dashboardWsReady: { value: true },
+  dashboardWsReconnectCount: {
+    value: 0,
+    subscribe: vi.fn(() => vi.fn()),
+  },
 }))
 
 import { KeeperLaneSection } from './keeper-lane-strip'

--- a/dashboard/src/components/keeper-workspace/keeper-lane-strip.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-lane-strip.test.ts
@@ -211,7 +211,7 @@ describe('KeeperLaneStrip', () => {
     expect(el.querySelector('[data-testid="keeper-lane-truncation"]')).toBeNull()
   })
 
-  it('shows the auto-refresh cadence beside the snapshot time when polling', () => {
+  it('shows push delivery beside the snapshot time when WS is ready', () => {
     const el = mount(html`
       <${KeeperLaneStrip}
         keeper=${keeperFixture()}
@@ -219,16 +219,16 @@ describe('KeeperLaneStrip', () => {
         ready=${true}
         loading=${false}
         error=${null}
-        autoRefreshMs=${15_000}
         pushReady=${true}
       />
     `)
     const text = el.textContent ?? ''
     expect(text).toContain('서버 기준')
-    expect(text).toContain('WS 즉시 반영 · 15초마다 상태 검산')
+    expect(text).toContain('WS 즉시 반영')
+    expect(text).not.toContain('초마다')
   })
 
-  it('omits the auto-refresh label when the panel is not polling', () => {
+  it('omits the push label while WS is unavailable', () => {
     const el = mount(html`
       <${KeeperLaneStrip}
         keeper=${keeperFixture()}
@@ -238,23 +238,8 @@ describe('KeeperLaneStrip', () => {
         error=${null}
       />
     `)
-    expect(el.textContent ?? '').not.toContain('재조회')
-  })
-
-  it('shows polling as fallback instead of claiming live push while WS is unavailable', () => {
-    const el = mount(html`
-      <${KeeperLaneStrip}
-        keeper=${keeperFixture()}
-        inventory=${inventoryFixture()}
-        ready=${true}
-        loading=${false}
-        error=${null}
-        autoRefreshMs=${15_000}
-        pushReady=${false}
-      />
-    `)
-    expect(el.textContent ?? '').toContain('WS 연결 대기 · 15초마다 재조회')
     expect(el.textContent ?? '').not.toContain('WS 즉시 반영')
+    expect(el.textContent ?? '').not.toContain('재조회')
   })
 
   it('renders an explicit gap when the keeper is absent from the inventory', () => {

--- a/dashboard/src/components/keeper-workspace/keeper-lane-strip.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-lane-strip.ts
@@ -15,7 +15,7 @@
 // as such.
 
 import { html } from 'htm/preact'
-import { useEffect, useState } from 'preact/hooks'
+import { useEffect } from 'preact/hooks'
 import type { VNode } from 'preact'
 import type { Keeper } from '../../types'
 import type {
@@ -23,8 +23,6 @@ import type {
   DashboardKeeperWaitingKeeper,
   DashboardKeeperWaitingRow,
 } from '../../api'
-import { fetchKeeperWaitingInventory } from '../../api'
-import { KEEPER_WAITING_INVENTORY_REFRESH_MS } from '../tools/tool-state'
 import { StatusChip } from '../common/status-chip'
 import {
   enumLabel,
@@ -34,20 +32,10 @@ import {
 import { formatDateTimeKo } from '../../lib/format-time'
 import { CountBadge } from '../v2/primitives-v2'
 import { dashboardWsReady } from '../../dashboard-ws-state'
-import { setupVisibleAutoRefresh } from '../../lib/auto-refresh'
-import { isAbortError } from '../../lib/async-state'
-import { registerKeeperWaitingInventoryRefresh } from '../../sse-store'
-
-// Queue commits push a signal-only invalidation over WS. The 15s timer is a
-// missed-event verifier and focus-recovery path, not the primary update path.
-const LANE_REFRESH_MS = KEEPER_WAITING_INVENTORY_REFRESH_MS
-
-function formatLaneRefreshLabel(intervalMs: number, pushReady: boolean): string {
-  const seconds = Math.max(1, Math.round(intervalMs / 1000))
-  return pushReady
-    ? `WS 즉시 반영 · ${seconds}초마다 상태 검산`
-    : `WS 연결 대기 · ${seconds}초마다 재조회`
-}
+import {
+  keeperWaitingInventoryState,
+  subscribeKeeperWaitingInventory,
+} from '../../keeper-waiting-inventory-store'
 
 const LANE_STATE_LABELS: Record<string, string> = {
   idle: '대기열 비어 있음',
@@ -148,27 +136,22 @@ function LaneWaitingRow({ row }: { row: DashboardKeeperWaitingRow }): VNode {
   `
 }
 
-/** Pure presentational part — container feeds it from the shared tools
- *  resource; tests feed it fixtures. */
+/** Pure presentational part; tests feed it fixtures. */
 export function KeeperLaneStrip({
   keeper,
   inventory,
   ready,
   loading,
   error,
-  autoRefreshMs,
   pushReady = false,
 }: {
   keeper: Keeper
   inventory: DashboardKeeperWaitingInventory | null | undefined
-  /** true once the shared tools resource has a response body — separates
+  /** true once the keeper-scoped resource has a response body — separates
    *  "field absent from the response" from "response not fetched yet". */
   ready: boolean
   loading: boolean
   error: string | null
-  /** when set, the container polls at this cadence — shown next to the
-   *  snapshot time so the operator knows the panel refreshes on its own. */
-  autoRefreshMs?: number
   /** Whether the authenticated dashboard WS handshake completed. */
   pushReady?: boolean
 }): VNode {
@@ -222,10 +205,8 @@ export function KeeperLaneStrip({
                   </div>`
                 : null}
               ${inventory?.generated_at
-                ? html`<div class="text-2xs text-[var(--color-fg-muted)]">서버 기준 ${formatDateTimeKo(inventory.generated_at)}${autoRefreshMs ? html` · ${formatLaneRefreshLabel(autoRefreshMs, pushReady)}` : null}</div>`
-                : autoRefreshMs
-                  ? html`<div class="text-2xs text-[var(--color-fg-muted)]">${formatLaneRefreshLabel(autoRefreshMs, pushReady)}</div>`
-                  : null}
+                ? html`<div class="text-2xs text-[var(--color-fg-muted)]">서버 기준 ${formatDateTimeKo(inventory.generated_at)}${pushReady ? ' · WS 즉시 반영' : ''}</div>`
+                : null}
             </div>
           `
         : inventory
@@ -239,81 +220,14 @@ export function KeeperLaneStrip({
   `
 }
 
-type LaneInventoryState = {
-  keeperName: string
-  inventory: DashboardKeeperWaitingInventory | null
-  ready: boolean
-  loading: boolean
-  error: string | null
-}
-
-/** Read only this keeper's lane projection. WS queue mutations trigger the
- *  primary refresh; the visibility-aware timer only verifies missed events. */
+/** Read only this keeper's lane projection. Queue commits and reconnects
+ * invalidate the shared keeper-scoped store; no periodic poll is mounted. */
 export function KeeperLaneSection({ keeper }: { keeper: Keeper }): VNode {
-  const [state, setState] = useState<LaneInventoryState>({
-    keeperName: keeper.name,
-    inventory: null,
-    ready: false,
-    loading: true,
-    error: null,
-  })
-
   useEffect(() => {
-    let active = true
-    let controller: AbortController | null = null
-    const load = () => {
-      controller?.abort()
-      const requestController = new AbortController()
-      controller = requestController
-      setState(previous => ({
-        keeperName: keeper.name,
-        inventory: previous.keeperName === keeper.name ? previous.inventory : null,
-        ready: previous.keeperName === keeper.name && previous.ready,
-        loading: true,
-        error: null,
-      }))
-      void fetchKeeperWaitingInventory(keeper.name, { signal: requestController.signal })
-        .then(inventory => {
-          if (!active || requestController.signal.aborted) return
-          setState({
-            keeperName: keeper.name,
-            inventory,
-            ready: true,
-            loading: false,
-            error: null,
-          })
-        })
-        .catch((error: unknown) => {
-          if (!active || isAbortError(error)) return
-          setState(previous => ({
-            keeperName: keeper.name,
-            inventory: previous.keeperName === keeper.name ? previous.inventory : null,
-            ready: previous.keeperName === keeper.name && previous.ready,
-            loading: false,
-            error: error instanceof Error ? error.message : String(error),
-          }))
-        })
-    }
-    load()
-    const unregisterPush = registerKeeperWaitingInventoryRefresh(changedKeeper => {
-      if (changedKeeper === keeper.name) load()
-    })
-    const stopPolling = setupVisibleAutoRefresh(load, LANE_REFRESH_MS)
-    return () => {
-      active = false
-      controller?.abort()
-      unregisterPush()
-      stopPolling()
-    }
+    return subscribeKeeperWaitingInventory(keeper.name)
   }, [keeper.name])
 
-  const current = state.keeperName === keeper.name ? state : {
-    keeperName: keeper.name,
-    inventory: null,
-    ready: false,
-    loading: true,
-    error: null,
-  }
+  const current = keeperWaitingInventoryState(keeper.name)
   return html`
     <${KeeperLaneStrip}
       keeper=${keeper}
@@ -321,7 +235,6 @@ export function KeeperLaneSection({ keeper }: { keeper: Keeper }): VNode {
       ready=${current.ready}
       loading=${current.loading}
       error=${current.error}
-      autoRefreshMs=${LANE_REFRESH_MS}
       pushReady=${dashboardWsReady.value}
     />
   `

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -108,6 +108,7 @@ vi.mock('../../api/dashboard', async (importOriginal) => {
       read_error_count: 0,
       read_errors: [],
       scan_truncated: false,
+      hydration_status: 'ready',
       items: [
         {
           id: 'manifest:trace-cmp:event_bus_correlated:2026-06-26T03:03:00Z',
@@ -1006,6 +1007,7 @@ describe('KeeperWorkspaceRail', () => {
       read_error_count: 0,
       read_errors: [],
       scan_truncated: false,
+      hydration_status: 'ready',
       items: [
         {
           id: 'manifest:trace-failed:context_compacted:2026-06-03T11:02:00Z',
@@ -1064,6 +1066,7 @@ describe('KeeperWorkspaceRail', () => {
         { scope: 'runtime_manifest_row:trace-cmp.jsonl:1', error: 'unknown event: "old_event"' },
       ],
       scan_truncated: true,
+      hydration_status: 'ready',
       items: [
         {
           id: 'manifest:trace-live:context_compacted:2026-06-03T11:01:24Z',
@@ -1130,6 +1133,7 @@ describe('KeeperWorkspaceRail', () => {
         { scope: 'runtime_manifest_row:trace-a.jsonl:2', error: 'unknown event: "memory_flushed"' },
       ],
       scan_truncated: true,
+      hydration_status: 'ready',
       items: [],
     })
 
@@ -1161,6 +1165,7 @@ describe('KeeperWorkspaceRail', () => {
       read_error_count: 0,
       read_errors: [],
       scan_truncated: false,
+      hydration_status: 'ready',
       items: [],
     })
 

--- a/dashboard/src/components/memory-inspector.test.ts
+++ b/dashboard/src/components/memory-inspector.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { cleanup, render, waitFor } from '@testing-library/preact'
 import { html } from 'htm/preact'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   MemoryInspector,
   factCategoryMeta,
@@ -17,6 +17,7 @@ import {
   type MemoryKeeper,
 } from './memory-inspector'
 import { type MemoryOsFact, type TurnRecordRow } from '../api/dashboard'
+import { clearStoredToken, setStoredToken } from '../api/core'
 
 const keeper: MemoryKeeper = {
   id: 'masc-improver',
@@ -125,8 +126,13 @@ function stubFetch(payload: unknown = turnRecordsPayload()) {
   return fetchMock
 }
 
+beforeEach(() => {
+  setStoredToken('memory-inspector-test-token', { source: 'manual' })
+})
+
 afterEach(() => {
   cleanup()
+  clearStoredToken()
   vi.unstubAllGlobals()
 })
 

--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -199,7 +199,7 @@ async function connectReadyDashboard(): Promise<MockWebSocket> {
   socket.receive({
     jsonrpc: '2.0',
     id: subscribe.id,
-    result: { snapshot: { seq: 1, slices: {} } },
+    result: {},
   })
   await flushPromises()
   return socket
@@ -280,7 +280,7 @@ describe('dashboardSlicesForRoute', () => {
     })).toContain('execution')
   })
 
-  it('keeps board route snapshots HTTP-owned while subscribing goals and fleet FSM slices', () => {
+  it('keeps board data HTTP-owned while subscribing goals and fleet FSM slices', () => {
     expect(dashboardSlicesForRoute({ tab: 'board', params: {} }))
       .toEqual([
         'namespace',
@@ -573,7 +573,7 @@ describe('dashboard websocket route subscriptions', () => {
     firstSocket.receive({
       jsonrpc: '2.0',
       id: subscribe.id,
-      result: { snapshot: { seq: 1, slices: {} } },
+      result: {},
     })
     await flushPromises()
     expect(dashboardWsReady.value).toBe(true)
@@ -613,7 +613,7 @@ describe('dashboard websocket route subscriptions', () => {
     const hello = parseRpc(socket, 0)
     socket.receive({ jsonrpc: '2.0', id: hello.id, result: {} })
     const subscribe = parseRpc(socket, 1)
-    socket.receive({ jsonrpc: '2.0', id: subscribe.id, result: { snapshot: { seq: 1, slices: {} } } })
+    socket.receive({ jsonrpc: '2.0', id: subscribe.id, result: {} })
     await flushPromises()
     expect(dashboardWsReady.value).toBe(true)
 
@@ -633,7 +633,7 @@ describe('dashboard websocket route subscriptions', () => {
     const hello = parseRpc(socket, 0)
     socket.receive({ jsonrpc: '2.0', id: hello.id, result: {} })
     const subscribe = parseRpc(socket, 1)
-    socket.receive({ jsonrpc: '2.0', id: subscribe.id, result: { snapshot: { seq: 1, slices: {} } } })
+    socket.receive({ jsonrpc: '2.0', id: subscribe.id, result: {} })
     await flushPromises()
     expect(dashboardWsReady.value).toBe(true)
 
@@ -689,7 +689,7 @@ describe('dashboard websocket route subscriptions', () => {
     const hello = parseRpc(socket, 0)
     socket.receive({ jsonrpc: '2.0', id: hello.id, result: {} })
     const subscribe = parseRpc(socket, 1)
-    socket.receive({ jsonrpc: '2.0', id: subscribe.id, result: { snapshot: { seq: 1, slices: {} } } })
+    socket.receive({ jsonrpc: '2.0', id: subscribe.id, result: {} })
     await flushPromises()
     expect(dashboardWsReady.value).toBe(true)
 
@@ -712,7 +712,7 @@ describe('dashboard websocket route subscriptions', () => {
     const hello = parseRpc(socket, 0)
     socket.receive({ jsonrpc: '2.0', id: hello.id, result: {} })
     const subscribe = parseRpc(socket, 1)
-    socket.receive({ jsonrpc: '2.0', id: subscribe.id, result: { snapshot: { seq: 1, slices: {} } } })
+    socket.receive({ jsonrpc: '2.0', id: subscribe.id, result: {} })
     await flushPromises()
     expect(dashboardWsReady.value).toBe(true)
 
@@ -736,7 +736,7 @@ describe('dashboard websocket route subscriptions', () => {
     const hello = parseRpc(socket, 0)
     socket.receive({ jsonrpc: '2.0', id: hello.id, result: {} })
     const subscribe = parseRpc(socket, 1)
-    socket.receive({ jsonrpc: '2.0', id: subscribe.id, result: { snapshot: { seq: 1, slices: {} } } })
+    socket.receive({ jsonrpc: '2.0', id: subscribe.id, result: {} })
     await flushPromises()
     expect(dashboardWsReady.value).toBe(true)
 
@@ -759,7 +759,7 @@ describe('dashboard websocket route subscriptions', () => {
     const hello = parseRpc(socket, 0)
     socket.receive({ jsonrpc: '2.0', id: hello.id, result: {} })
     const subscribe = parseRpc(socket, 1)
-    socket.receive({ jsonrpc: '2.0', id: subscribe.id, result: { snapshot: { seq: 1, slices: {} } } })
+    socket.receive({ jsonrpc: '2.0', id: subscribe.id, result: {} })
     await flushPromises()
     expect(dashboardWsReady.value).toBe(true)
 
@@ -854,7 +854,7 @@ describe('dashboard websocket route subscriptions', () => {
     freshSocket.receive({
       jsonrpc: '2.0',
       id: subscribe.id,
-      result: { snapshot: { seq: 1, slices: {} } },
+      result: {},
     })
     await flushPromises()
     expect(dashboardWsReady.value).toBe(true)
@@ -915,7 +915,7 @@ describe('dashboard websocket route subscriptions', () => {
     socket.receive({
       jsonrpc: '2.0',
       id: subscribe.id,
-      result: { snapshot: { seq: 7, slices: {} } },
+      result: {},
     })
     await flushPromises()
   })
@@ -1066,7 +1066,7 @@ describe('dashboard websocket route subscriptions', () => {
     socket.receive({
       jsonrpc: '2.0',
       id: subscribe.id,
-      result: { snapshot: { seq: 1, slices: {} } },
+      result: {},
     })
     await flushPromises()
 
@@ -1101,7 +1101,7 @@ describe('dashboard websocket route subscriptions', () => {
     socket.receive({
       jsonrpc: '2.0',
       id: subscribe.id,
-      result: { snapshot: { seq: 1, slices: {} } },
+      result: {},
     })
     await flushPromises()
     sseStoreMocks.hydrateDashboardSlice.mockClear()
@@ -1117,7 +1117,7 @@ describe('dashboard websocket route subscriptions', () => {
       },
     })
 
-    expect(dashboardWsLastSeq.value).toBe(1)
+    expect(dashboardWsLastSeq.value).toBe(0)
     expect(dashboardWsEventCount60s.value).toBe(1)
     expect(socket.sent).toHaveLength(sentBeforeDelta)
     expect(sseStoreMocks.hydrateDashboardSlice).toHaveBeenCalledWith(
@@ -1141,7 +1141,7 @@ describe('dashboard websocket route subscriptions', () => {
     socket.receive({
       jsonrpc: '2.0',
       id: subscribe.id,
-      result: { snapshot: { seq: 1, slices: {} } },
+      result: {},
     })
     await flushPromises()
     sseStoreMocks.hydrateDashboardSlice.mockClear()
@@ -1175,7 +1175,7 @@ describe('dashboard websocket route subscriptions', () => {
     socket.receive({
       jsonrpc: '2.0',
       id: subscribe.id,
-      result: { snapshot: { seq: 1, slices: {} } },
+      result: {},
     })
     await flushPromises()
     sseStoreMocks.hydrateDashboardSlice.mockClear()
@@ -1210,7 +1210,7 @@ describe('dashboard websocket route subscriptions', () => {
     socket.receive({
       jsonrpc: '2.0',
       id: subscribe.id,
-      result: { snapshot: { seq: 1, slices: {} } },
+      result: {},
     })
     await flushPromises()
     sseStoreMocks.hydrateDashboardSlice.mockClear()
@@ -1250,7 +1250,7 @@ describe('dashboard websocket route subscriptions', () => {
     socket.receive({
       jsonrpc: '2.0',
       id: subscribe.id,
-      result: { snapshot: { seq: 1, slices: {} } },
+      result: {},
     })
     await flushPromises()
     dashboardWsLastSeq.value = 0
@@ -1292,7 +1292,7 @@ describe('dashboard websocket route subscriptions', () => {
     socket.receive({
       jsonrpc: '2.0',
       id: subscribe.id,
-      result: { snapshot: { seq: 1, slices: {} } },
+      result: {},
     })
     await flushPromises()
 
@@ -1344,7 +1344,7 @@ describe('dashboard websocket route subscriptions', () => {
     expect(mockSockets[1]!.readyState).toBe(MockWebSocket.CONNECTING)
   })
 
-  it('ignores stale subscribe snapshots that arrive after a newer route subscription', async () => {
+  it('treats subscribe responses as acknowledgements without mutating delta sequence', async () => {
     installWebSocketMocks()
 
     await connectDashboardWS({ tab: 'overview', params: {} })
@@ -1358,7 +1358,7 @@ describe('dashboard websocket route subscriptions', () => {
     socket.receive({
       jsonrpc: '2.0',
       id: initialSubscribe.id,
-      result: { snapshot: { seq: 1, slices: {} } },
+      result: {},
     })
     await flushPromises()
     dashboardWsLastSeq.value = 0
@@ -1378,7 +1378,7 @@ describe('dashboard websocket route subscriptions', () => {
     socket.receive({
       jsonrpc: '2.0',
       id: staleSubscribe.id,
-      result: { snapshot: { seq: 11, slices: {} } },
+      result: {},
     })
     await stalePromise
     expect(dashboardWsLastSeq.value).toBe(0)
@@ -1386,10 +1386,10 @@ describe('dashboard websocket route subscriptions', () => {
     socket.receive({
       jsonrpc: '2.0',
       id: latestSubscribe.id,
-      result: { snapshot: { seq: 22, slices: {} } },
+      result: {},
     })
     await latestPromise
-    expect(dashboardWsLastSeq.value).toBe(22)
+    expect(dashboardWsLastSeq.value).toBe(0)
   })
 
   it('rejects in-flight subscribe RPCs when the socket closes', async () => {
@@ -1406,7 +1406,7 @@ describe('dashboard websocket route subscriptions', () => {
     socket.receive({
       jsonrpc: '2.0',
       id: initialSubscribe.id,
-      result: { snapshot: { seq: 1, slices: {} } },
+      result: {},
     })
     await flushPromises()
 
@@ -1436,7 +1436,7 @@ describe('dashboard websocket route subscriptions', () => {
     socket.receive({
       jsonrpc: '2.0',
       id: initialSubscribe.id,
-      result: { snapshot: { seq: 1, slices: {} } },
+      result: {},
     })
     await flushPromises()
 
@@ -1470,7 +1470,7 @@ describe('dashboard websocket route subscriptions', () => {
     socket.receive({
       jsonrpc: '2.0',
       id: initialSubscribe.id,
-      result: { snapshot: { seq: 1, slices: {} } },
+      result: {},
     })
     await flushPromises()
 
@@ -1490,14 +1490,14 @@ describe('dashboard websocket route subscriptions', () => {
     socket.receive({
       jsonrpc: '2.0',
       id: subscribe.id,
-      result: { snapshot: { seq: 99, slices: {} } },
+      result: {},
     })
     await flushPromises()
 
-    expect(dashboardWsLastSeq.value).toBe(1)
+    expect(dashboardWsLastSeq.value).toBe(0)
   })
 
-  it('ignores board slice snapshots and deltas because the board list is HTTP-owned', async () => {
+  it('ignores board deltas because the board list is HTTP-owned', async () => {
     installWebSocketMocks()
 
     await connectDashboardWS({ tab: 'workspace', params: { section: 'board' } })
@@ -1511,7 +1511,7 @@ describe('dashboard websocket route subscriptions', () => {
     socket.receive({
       jsonrpc: '2.0',
       id: initialSubscribe.id,
-      result: { snapshot: { seq: 1, slices: { board: { posts: [] } } } },
+      result: {},
     })
     await flushPromises()
     sseStoreMocks.hydrateDashboardSlice.mockClear()
@@ -1532,7 +1532,7 @@ describe('dashboard websocket route subscriptions', () => {
     socket.receive({
       jsonrpc: '2.0',
       id: routeSubscribe.id,
-      result: { snapshot: { seq: 3, slices: { execution: { agents: [] } } } },
+      result: {},
     })
     await switchPromise
     sseStoreMocks.hydrateDashboardSlice.mockClear()

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -418,11 +418,9 @@ export function dashboardSlicesForRoute(routeState: DashboardRouteState): string
     slices.add('goals')
   }
   // Board rows are actor/filter scoped (`voter`, blind-vote policy, author and
-  // hearth filters) and are loaded through refreshBoard's HTTP query. The WS
-  // snapshot provider is route-scoped only, so subscribing the board slice here
-  // can hydrate the list with a different query immediately after the route HTTP
-  // refresh. Raw board events still reach the client and schedule/increment
-  // board refreshes through sse-store.
+  // hearth filters) and are loaded through refreshBoard's HTTP query. Raw board
+  // events still reach the client and schedule/increment board refreshes through
+  // sse-store; there is no unscoped board slice subscription.
   if (routeState.tab === 'monitoring') {
     const section = routeState.params.section
     if (section === 'observatory' || section === 'journey' || section === 'agents') {
@@ -650,25 +648,6 @@ function handleRpcResponse(raw: JsonObject): boolean {
   return true
 }
 
-function applySnapshot(raw: unknown): void {
-  batch(() => {
-    const snapshot = raw as { slices?: unknown; seq?: unknown }
-    if (typeof snapshot.seq === 'number') {
-      dashboardWsLastSeq.value = snapshot.seq
-    }
-    const slices = snapshot.slices as Record<string, unknown> | undefined
-    if (!slices || typeof slices !== 'object') return
-    for (const [slice, payload] of Object.entries(slices)) {
-      hydrateRouteDashboardSlice(slice, payload)
-    }
-  })
-}
-
-function applySubscribeResult(raw: unknown): void {
-  const result = raw as { snapshot?: unknown }
-  if (result.snapshot) applySnapshot(result.snapshot)
-}
-
 function applyDelta(raw: unknown): void {
   batch(() => {
     const delta = raw as {
@@ -709,10 +688,6 @@ function hydrateRouteDashboardSlice(slice: string, payload: unknown, eventType?:
 function handleNotification(raw: JsonObject): boolean {
   if (raw.method === 'dashboard/delta') {
     applyDelta(raw.params)
-    return true
-  }
-  if (raw.method === 'dashboard/snapshot') {
-    applySnapshot(raw.params)
     return true
   }
   return false
@@ -835,12 +810,11 @@ export async function subscribeDashboardRoute(routeState: DashboardRouteState): 
   if (key === lastSubscribeKey) return
   lastSubscribeKey = key
   try {
-    const result = await sendRpc('dashboard/subscribe', {
+    await sendRpc('dashboard/subscribe', {
       route: routeKey(desired),
       slices,
     })
     if (lastSubscribeKey !== key) return
-    applySubscribeResult(result)
   } catch (err) {
     if (lastSubscribeKey === key) lastSubscribeKey = ''
     throw err
@@ -908,7 +882,7 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
     void sendRpc('dashboard/hello', {
       protocol: 'dashboard-ws.v1',
       token: token ?? undefined,
-      features: ['snapshot', 'delta', 'mode_snapshot'],
+      features: ['delta', 'mode_snapshot'],
     })
       .then(() => {
         if (socket !== ws) return

--- a/dashboard/src/keeper-waiting-inventory-store.test.ts
+++ b/dashboard/src/keeper-waiting-inventory-store.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  fetchKeeperWaitingInventory: vi.fn(),
+  pushRefresh: null as ((keeperName: string) => void) | null,
+  reconnectSubscribers: new Set<(count: number) => void>(),
+}))
+
+vi.mock('./api', () => ({
+  fetchKeeperWaitingInventory: mocks.fetchKeeperWaitingInventory,
+}))
+
+vi.mock('./sse-store', () => ({
+  registerKeeperWaitingInventoryRefresh: vi.fn((refresh: (keeperName: string) => void) => {
+    mocks.pushRefresh = refresh
+    return () => { mocks.pushRefresh = null }
+  }),
+}))
+
+vi.mock('./dashboard-ws-state', () => ({
+  dashboardWsReconnectCount: {
+    value: 0,
+    subscribe: (subscriber: (count: number) => void) => {
+      mocks.reconnectSubscribers.add(subscriber)
+      return () => mocks.reconnectSubscribers.delete(subscriber)
+    },
+  },
+}))
+
+import {
+  keeperWaitingInventoryState,
+  subscribeKeeperWaitingInventory,
+} from './keeper-waiting-inventory-store'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  mocks.fetchKeeperWaitingInventory.mockReset()
+  mocks.pushRefresh = null
+  mocks.reconnectSubscribers.clear()
+})
+
+describe('keeper waiting inventory store', () => {
+  it('shares one scoped request and refreshes from push without installing a timer', async () => {
+    let resolveFirst!: (value: { keepers: never[] }) => void
+    mocks.fetchKeeperWaitingInventory.mockImplementationOnce(() => new Promise(resolve => {
+      resolveFirst = resolve
+    }))
+    mocks.fetchKeeperWaitingInventory.mockResolvedValue({ keepers: [] })
+    const intervalSpy = vi.spyOn(window, 'setInterval')
+
+    const stopLane = subscribeKeeperWaitingInventory('kidsnote')
+    const stopConversation = subscribeKeeperWaitingInventory('kidsnote')
+    expect(mocks.fetchKeeperWaitingInventory).toHaveBeenCalledTimes(1)
+    expect(intervalSpy).not.toHaveBeenCalled()
+
+    mocks.pushRefresh?.('rondo')
+    expect(mocks.fetchKeeperWaitingInventory).toHaveBeenCalledTimes(1)
+    mocks.pushRefresh?.('kidsnote')
+    expect(mocks.fetchKeeperWaitingInventory).toHaveBeenCalledTimes(1)
+
+    resolveFirst({ keepers: [] })
+    await vi.waitFor(() => {
+      expect(mocks.fetchKeeperWaitingInventory).toHaveBeenCalledTimes(2)
+      expect(keeperWaitingInventoryState('kidsnote').loading).toBe(false)
+    })
+
+    const visibility = vi.spyOn(document, 'visibilityState', 'get')
+    visibility.mockReturnValue('hidden')
+    document.dispatchEvent(new Event('visibilitychange'))
+    expect(mocks.fetchKeeperWaitingInventory).toHaveBeenCalledTimes(2)
+
+    visibility.mockReturnValue('visible')
+    document.dispatchEvent(new Event('visibilitychange'))
+    await vi.waitFor(() => {
+      expect(mocks.fetchKeeperWaitingInventory).toHaveBeenCalledTimes(3)
+    })
+
+    stopConversation()
+    stopLane()
+  })
+})

--- a/dashboard/src/keeper-waiting-inventory-store.ts
+++ b/dashboard/src/keeper-waiting-inventory-store.ts
@@ -1,0 +1,146 @@
+import { signal } from '@preact/signals'
+import type { DashboardKeeperWaitingInventory } from './api'
+import { fetchKeeperWaitingInventory } from './api'
+import { dashboardWsReconnectCount } from './dashboard-ws-state'
+import { registerKeeperWaitingInventoryRefresh } from './sse-store'
+
+export type KeeperWaitingInventoryState = {
+  readonly inventory: DashboardKeeperWaitingInventory | null
+  readonly ready: boolean
+  readonly loading: boolean
+  readonly error: string | null
+}
+
+const EMPTY_STATE: KeeperWaitingInventoryState = {
+  inventory: null,
+  ready: false,
+  loading: false,
+  error: null,
+}
+
+export const keeperWaitingInventoryStates = signal<
+  Record<string, KeeperWaitingInventoryState>
+>({})
+
+const subscriberCounts = new Map<string, number>()
+const inFlight = new Map<string, Promise<void>>()
+const pendingInvalidations = new Set<string>()
+let stopPushRefresh: (() => void) | null = null
+let stopReconnectRefresh: (() => void) | null = null
+let lastReconnectCount = dashboardWsReconnectCount.value
+
+function stateFor(keeperName: string): KeeperWaitingInventoryState {
+  return keeperWaitingInventoryStates.value[keeperName] ?? EMPTY_STATE
+}
+
+function setState(keeperName: string, state: KeeperWaitingInventoryState): void {
+  keeperWaitingInventoryStates.value = {
+    ...keeperWaitingInventoryStates.value,
+    [keeperName]: state,
+  }
+}
+
+export function keeperWaitingInventoryState(
+  keeperName: string,
+): KeeperWaitingInventoryState {
+  return stateFor(keeperName)
+}
+
+/** One keeper-scoped authoritative read. Concurrent consumers share the same
+ * request; the last good projection remains visible while it refreshes. */
+export function refreshKeeperWaitingInventory(keeperName: string): Promise<void> {
+  const existing = inFlight.get(keeperName)
+  if (existing) return existing
+
+  const previous = stateFor(keeperName)
+  setState(keeperName, { ...previous, loading: true, error: null })
+  const request = fetchKeeperWaitingInventory(keeperName)
+    .then(inventory => {
+      setState(keeperName, {
+        inventory,
+        ready: true,
+        loading: false,
+        error: null,
+      })
+    })
+    .catch((cause: unknown) => {
+      const current = stateFor(keeperName)
+      setState(keeperName, {
+        ...current,
+        loading: false,
+        error: cause instanceof Error ? cause.message : String(cause),
+      })
+    })
+    .finally(() => {
+      if (inFlight.get(keeperName) !== request) return
+      inFlight.delete(keeperName)
+      if (
+        pendingInvalidations.delete(keeperName)
+        && (subscriberCounts.get(keeperName) ?? 0) > 0
+      ) {
+        void refreshKeeperWaitingInventory(keeperName)
+      }
+    })
+  inFlight.set(keeperName, request)
+  return request
+}
+
+/** Preserve one trailing authoritative read when an invalidation arrives
+ * during an in-flight read. This prevents burst coalescing from losing the
+ * final queue state. */
+function invalidateKeeperWaitingInventory(keeperName: string): void {
+  if (inFlight.has(keeperName)) {
+    pendingInvalidations.add(keeperName)
+    return
+  }
+  void refreshKeeperWaitingInventory(keeperName)
+}
+
+function refreshActiveKeepers(): void {
+  if (document.visibilityState !== 'visible') return
+  for (const [keeperName, count] of subscriberCounts) {
+    if (count > 0) invalidateKeeperWaitingInventory(keeperName)
+  }
+}
+
+function startRecoveryListeners(): void {
+  if (stopPushRefresh) return
+  stopPushRefresh = registerKeeperWaitingInventoryRefresh(keeperName => {
+    if ((subscriberCounts.get(keeperName) ?? 0) > 0) {
+      invalidateKeeperWaitingInventory(keeperName)
+    }
+  })
+  stopReconnectRefresh = dashboardWsReconnectCount.subscribe(count => {
+    if (count !== lastReconnectCount) {
+      lastReconnectCount = count
+      refreshActiveKeepers()
+    }
+  })
+  window.addEventListener('focus', refreshActiveKeepers)
+  document.addEventListener('visibilitychange', refreshActiveKeepers)
+}
+
+function stopRecoveryListeners(): void {
+  stopPushRefresh?.()
+  stopPushRefresh = null
+  stopReconnectRefresh?.()
+  stopReconnectRefresh = null
+  window.removeEventListener('focus', refreshActiveKeepers)
+  document.removeEventListener('visibilitychange', refreshActiveKeepers)
+}
+
+/** Subscribe a mounted Keeper surface to push invalidations and event-based
+ * recovery. There is deliberately no periodic timer. */
+export function subscribeKeeperWaitingInventory(keeperName: string): () => void {
+  const previous = subscriberCounts.get(keeperName) ?? 0
+  subscriberCounts.set(keeperName, previous + 1)
+  if (subscriberCounts.size === 1 && previous === 0) startRecoveryListeners()
+  void refreshKeeperWaitingInventory(keeperName)
+
+  return () => {
+    const next = Math.max(0, (subscriberCounts.get(keeperName) ?? 0) - 1)
+    if (next === 0) subscriberCounts.delete(keeperName)
+    else subscriberCounts.set(keeperName, next)
+    if (subscriberCounts.size === 0) stopRecoveryListeners()
+  }
+}

--- a/dashboard/src/schemas/sse.test.ts
+++ b/dashboard/src/schemas/sse.test.ts
@@ -241,12 +241,51 @@ describe('SSEMessageSchema', () => {
     expect(r.success).toBe(true)
   })
 
+  it('accepts the exact runtime telemetry sample envelope', () => {
+    const r = SSEMessageSchema.safeParse({
+      type: 'oas_telemetry_sample',
+      payload: {
+        sample: { provider_id: 'private', model_id: 'private', status: 'ok' },
+        recorded_at: 1_712_000_000,
+      },
+      provider_id: 'runtime',
+      model_id: 'runtime',
+      ts_unix: 1_712_000_000,
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it.each([
+    { payload: { sample: {}, recorded_at: 1 }, provider_id: 'runtime' },
+    { payload: { sample: {}, recorded_at: 'bad' }, provider_id: 'runtime', model_id: 'runtime' },
+    { payload: { recorded_at: 1 }, provider_id: 'runtime', model_id: 'runtime' },
+  ])('rejects malformed runtime telemetry sample envelopes: %o', value => {
+    expect(SSEMessageSchema.safeParse({ type: 'oas_telemetry_sample', ...value }).success).toBe(false)
+  })
+
   it.each([
     { type: 'keeper_waiting_inventory_changed', queue_kind: 'chat_queue' },
     { type: 'keeper_waiting_inventory_changed', keeper_name: 'keeper-1' },
     { type: 'keeper_waiting_inventory_changed', keeper_name: 'keeper-1', queue_kind: 'unknown' },
   ])('rejects an incomplete Keeper waiting-inventory invalidation: %o', value => {
     expect(SSEMessageSchema.safeParse(value).success).toBe(false)
+  })
+
+  it('accepts a typed compaction snapshot cache completion', () => {
+    expect(SSEMessageSchema.safeParse({
+      type: 'keeper_compaction_snapshots_changed',
+      keeper_name: 'keeper-1',
+      status: 'ready',
+      ts_unix: 1_712_000_000,
+    }).success).toBe(true)
+  })
+
+  it('rejects compaction snapshot cache completion without a closed status', () => {
+    expect(SSEMessageSchema.safeParse({
+      type: 'keeper_compaction_snapshots_changed',
+      keeper_name: 'keeper-1',
+      status: 'warming',
+    }).success).toBe(false)
   })
 
   it('accepts a gate_mode_changed event with a null previous_mode', () => {

--- a/dashboard/src/schemas/sse.ts
+++ b/dashboard/src/schemas/sse.ts
@@ -59,6 +59,8 @@ const FIXED_SSE_EVENT_TYPES = new Set([
   'keeper_composite_changed',
   'keeper_chat_appended',
   'keeper_waiting_inventory_changed',
+  'keeper_compaction_snapshots_changed',
+  'oas_telemetry_sample',
   'ide_cursor_changed',
   'keeper_tool_call',
   'masc/keeper_tool_call',
@@ -151,6 +153,8 @@ const STRING_FIELDS = new Set([
   'actor',
   'changed_at',
   'kind',
+  'provider_id',
+  'model_id',
 ])
 
 const NUMBER_FIELDS = new Set([
@@ -346,6 +350,36 @@ export const SSEMessageSchema = schema<SSEMessage>((value) => {
     }
     if (value.queue_kind !== 'chat_queue' && value.queue_kind !== 'event_queue') {
       return fail('queue_kind', 'Expected chat_queue or event_queue queue_kind')
+    }
+  }
+
+  if (value.type === 'keeper_compaction_snapshots_changed') {
+    if (typeof value.keeper_name !== 'string' || value.keeper_name.trim() === '') {
+      return fail('keeper_name', 'Expected non-empty keeper_name')
+    }
+    if (value.status !== 'ready' && value.status !== 'failed') {
+      return fail('status', 'Expected ready or failed compaction snapshot status')
+    }
+  }
+
+  if (value.type === 'oas_telemetry_sample') {
+    if (typeof value.provider_id !== 'string' || value.provider_id.trim() === '') {
+      return fail('provider_id', 'Expected non-empty provider_id')
+    }
+    if (typeof value.model_id !== 'string' || value.model_id.trim() === '') {
+      return fail('model_id', 'Expected non-empty model_id')
+    }
+    if (!isRecord(value.payload)) {
+      return fail('payload', 'Expected telemetry payload object')
+    }
+    if (!isRecord(value.payload.sample)) {
+      return fail('payload.sample', 'Expected telemetry sample object')
+    }
+    if (
+      typeof value.payload.recorded_at !== 'number'
+      || !Number.isFinite(value.payload.recorded_at)
+    ) {
+      return fail('payload.recorded_at', 'Expected finite recorded_at')
     }
   }
 

--- a/dashboard/src/sse-event-type-parity.test.ts
+++ b/dashboard/src/sse-event-type-parity.test.ts
@@ -39,6 +39,7 @@ const BACKEND_EMITTED: Record<string, string> = {
   runtime_param_changed: '../lib/server/server_routes_http_routes_activity.ml',
   keeper_chat_appended: '../lib/keeper/keeper_chat_broadcast.ml',
   keeper_waiting_inventory_changed: '../lib/keeper/keeper_waiting_inventory_broadcast.ml',
+  keeper_compaction_snapshots_changed: '../lib/server/server_dashboard_http_keeper_api.ml',
   ide_cursor_changed: '../lib/server/server_ide_http.ml',
   keeper_composite_changed: '../lib/server/server_mcp_transport_ws.ml',
   keeper_heartbeat: '../lib/keeper/keeper_heartbeat_snapshot.ml',
@@ -55,6 +56,8 @@ const BACKEND_EMITTED: Record<string, string> = {
 // justified; every entry is an event the FE routes but masc lib/ does not emit.
 const FE_ONLY_OR_EXTERNAL: Record<string, string> = {
   'oas:agent_failed':
+    'OAS-subsystem event bridged into the masc SSE stream, not emitted by masc lib/ (oas: prefix).',
+  'oas:context_compacted':
     'OAS-subsystem event bridged into the masc SSE stream, not emitted by masc lib/ (oas: prefix).',
 }
 

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -549,7 +549,7 @@ describe('setupServerPushReaction reconnect hydration', () => {
     expect(noteKeeperChatAppended).toHaveBeenCalledWith('echo', undefined, undefined)
   })
 
-  it('invalidates the authoritative Keeper waiting inventory once per burst', async () => {
+  it('delivers every Keeper inventory invalidation immediately while coalescing receipt reads', async () => {
     const { sseStore } = await loadSseStore()
     const refreshQueue = vi.fn()
     sseStore.registerKeeperWaitingInventoryRefresh(refreshQueue)
@@ -564,11 +564,13 @@ describe('setupServerPushReaction reconnect hydration', () => {
       keeper_name: 'echo',
       queue_kind: 'chat_queue',
     })
+    expect(refreshQueue).toHaveBeenCalledTimes(2)
+    expect(refreshQueue).toHaveBeenNthCalledWith(1, 'echo')
+    expect(refreshQueue).toHaveBeenNthCalledWith(2, 'echo')
+    expect(reconcileKeeperChatReceipts).not.toHaveBeenCalled()
     vi.advanceTimersByTime(1_000)
     await flushAsyncWork()
 
-    expect(refreshQueue).toHaveBeenCalledTimes(1)
-    expect(refreshQueue).toHaveBeenCalledWith('echo')
     expect(reconcileKeeperChatReceipts).toHaveBeenCalledTimes(1)
     expect(reconcileKeeperChatReceipts).toHaveBeenCalledWith('echo')
   })
@@ -583,12 +585,33 @@ describe('setupServerPushReaction reconnect hydration', () => {
       keeper_name: 'echo',
       queue_kind: 'event_queue',
     })
+    expect(refreshQueue).toHaveBeenCalledTimes(1)
+    expect(refreshQueue).toHaveBeenCalledWith('echo')
     vi.advanceTimersByTime(1_000)
     await flushAsyncWork()
 
-    expect(refreshQueue).toHaveBeenCalledTimes(1)
-    expect(refreshQueue).toHaveBeenCalledWith('echo')
     expect(reconcileKeeperChatReceipts).not.toHaveBeenCalled()
+  })
+
+  it('forces compaction hydration from the typed source event, then re-reads on cache completion', async () => {
+    const { sseStore } = await loadSseStore()
+    const refreshCompaction = vi.fn()
+    sseStore.registerKeeperCompactionRefresh(refreshCompaction)
+
+    sseStore.routeServerPushEvent({
+      type: 'oas:context_compacted',
+      agent_name: 'echo',
+      before_tokens: 100,
+      after_tokens: 40,
+    })
+    sseStore.routeServerPushEvent({
+      type: 'keeper_compaction_snapshots_changed',
+      keeper_name: 'echo',
+      status: 'ready',
+    })
+
+    expect(refreshCompaction).toHaveBeenNthCalledWith(1, 'echo', 'source_changed')
+    expect(refreshCompaction).toHaveBeenNthCalledWith(2, 'echo', 'ready')
   })
 
   it('forwards RFC-0235 audio clips on keeper_chat_appended to the chat handler', async () => {

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -107,18 +107,28 @@ export function registerKeeperTurnRefresh(fn: (keeperName: string) => void): voi
   _keeperTurnRefreshFn = fn
 }
 
-// The tools payload owns the Keeper waiting/receipt projection. The queue push is
-// deliberately an invalidation signal, so the tools resource registers its
-// authoritative re-read here instead of this transport layer importing a UI
-// store or reconstructing Pending/Inflight state from event deltas.
+// Queue push is an invalidation signal. Keeper-scoped read models register
+// their authoritative re-read here instead of reconstructing queue state from
+// event deltas.
 const _refreshKeeperWaitingInventoryFns = new Set<(keeperName: string) => void>()
-const pendingKeeperWaitingInventoryRefreshNames = new Set<string>()
 const pendingKeeperChatReceiptRefreshNames = new Set<string>()
 export function registerKeeperWaitingInventoryRefresh(
   fn: (keeperName: string) => void,
 ): () => void {
   _refreshKeeperWaitingInventoryFns.add(fn)
   return () => _refreshKeeperWaitingInventoryFns.delete(fn)
+}
+
+type KeeperCompactionRefreshReason = 'source_changed' | 'ready' | 'failed'
+const _refreshKeeperCompactionFns = new Set<(
+  keeperName: string,
+  reason: KeeperCompactionRefreshReason,
+) => void>()
+export function registerKeeperCompactionRefresh(
+  fn: (keeperName: string, reason: KeeperCompactionRefreshReason) => void,
+): () => void {
+  _refreshKeeperCompactionFns.add(fn)
+  return () => _refreshKeeperCompactionFns.delete(fn)
 }
 
 const _refreshActivityFns = new Set<() => void>()
@@ -572,6 +582,14 @@ function eventMatchesActiveBoardFilters(event: SSEEvent): boolean {
 }
 
 export function routeServerPushEvent(event: SSEEvent): void {
+  if (event.type === 'oas:context_compacted') {
+    const keeperName = event.agent_name?.trim() ?? ''
+    if (keeperName) {
+      for (const refresh of _refreshKeeperCompactionFns) {
+        refresh(keeperName, 'source_changed')
+      }
+    }
+  }
   if (hydrateServerPushEvent(event)) {
     return
   }
@@ -796,35 +814,39 @@ export function hydrateServerPushEvent(event: SSEEvent): boolean {
   if (event.type === 'keeper_waiting_inventory_changed') {
     const keeperName = event.keeper_name?.trim() ?? ''
     if (keeperName) {
-      pendingKeeperWaitingInventoryRefreshNames.add(keeperName)
+      for (const refresh of _refreshKeeperWaitingInventoryFns) refresh(keeperName)
       if (event.queue_kind === 'chat_queue') {
         pendingKeeperChatReceiptRefreshNames.add(keeperName)
+        scheduleRefresh(
+          'keeper_chat_receipts',
+          () => {
+            const keeperNames = Array.from(pendingKeeperChatReceiptRefreshNames)
+            pendingKeeperChatReceiptRefreshNames.clear()
+            void import('./keeper-runtime')
+              .then(mod => Promise.all(
+                keeperNames.map(name => mod.reconcileKeeperChatReceipts(name)),
+              ))
+              .catch(err => {
+                console.warn(
+                  '[server-push] keeper chat receipt reconciliation unavailable',
+                  err instanceof Error ? err.message : err,
+                )
+              })
+          },
+          SSE_KEEPER_THREAD_DEBOUNCE_MS,
+        )
       }
     }
-    scheduleRefresh(
-      'keeper_waiting_inventory',
-      () => {
-        const inventoryKeeperNames = Array.from(pendingKeeperWaitingInventoryRefreshNames)
-        pendingKeeperWaitingInventoryRefreshNames.clear()
-        for (const name of inventoryKeeperNames) {
-          for (const refresh of _refreshKeeperWaitingInventoryFns) refresh(name)
-        }
-        const keeperNames = Array.from(pendingKeeperChatReceiptRefreshNames)
-        pendingKeeperChatReceiptRefreshNames.clear()
-        if (keeperNames.length === 0) return
-        void import('./keeper-runtime')
-          .then(mod => Promise.all(
-            keeperNames.map(name => mod.reconcileKeeperChatReceipts(name)),
-          ))
-          .catch(err => {
-            console.warn(
-              '[server-push] keeper chat receipt reconciliation unavailable',
-              err instanceof Error ? err.message : err,
-            )
-          })
-      },
-      SSE_KEEPER_THREAD_DEBOUNCE_MS,
-    )
+    return true
+  }
+
+  if (event.type === 'keeper_compaction_snapshots_changed') {
+    const keeperName = event.keeper_name?.trim() ?? ''
+    if (keeperName && (event.status === 'ready' || event.status === 'failed')) {
+      for (const refresh of _refreshKeeperCompactionFns) {
+        refresh(keeperName, event.status)
+      }
+    }
     return true
   }
 

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -34,6 +34,8 @@ export type SSEEventType =
   | 'keeper_composite_changed'
   | 'keeper_chat_appended'
   | 'keeper_waiting_inventory_changed'
+  | 'keeper_compaction_snapshots_changed'
+  | 'oas_telemetry_sample'
   | 'ide_cursor_changed'
   | 'keeper_tool_call'
   | 'masc/keeper_tool_call'
@@ -187,6 +189,8 @@ export interface SSEEvent {
   queue_kind?: 'chat_queue' | 'event_queue'
   trigger?: string
   runtime?: string
+  provider_id?: string
+  model_id?: string
   reason?: string
   // Keeper phase transition fields
   prev_phase?: string

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -958,6 +958,223 @@ let compaction_snapshots_json ~config ~keeper_id ~limit =
     ]
 ;;
 
+type compaction_snapshot_cache_entry =
+  { body : Yojson.Safe.t
+  ; refreshed_at : float
+  }
+
+let compaction_snapshot_cache :
+    (string, compaction_snapshot_cache_entry) Hashtbl.t =
+  Hashtbl.create 16
+;;
+
+(* [true] means a force-refresh arrived while the current scan was running, so
+   completion must schedule exactly one trailing scan. *)
+let compaction_snapshot_refreshes : (string, bool) Hashtbl.t = Hashtbl.create 16
+let compaction_snapshot_cache_mu = Stdlib.Mutex.create ()
+let compaction_snapshot_cache_max_entries = 128
+
+let with_compaction_snapshot_cache_lock f =
+  Stdlib.Mutex.lock compaction_snapshot_cache_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock compaction_snapshot_cache_mu)
+    f
+;;
+
+let compaction_snapshot_cache_key config keeper_id limit =
+  String.concat "\x00" [ config.Workspace.base_path; keeper_id; string_of_int limit ]
+;;
+
+let compaction_snapshot_with_hydration_status status = function
+  | `Assoc fields ->
+    `Assoc
+      (("hydration_status", `String status)
+       :: List.remove_assoc "hydration_status" fields)
+  | body -> body
+;;
+
+let compaction_snapshot_empty_json ~keeper_id ~limit ~status ~read_errors =
+  `Assoc
+    [ "schema", `String "keeper.compaction_snapshots.v1"
+    ; "keeper", `String keeper_id
+    ; "source", `String "runtime_manifest|keeper_meta"
+    ; "producer", `String "keeper_runtime_manifest|keeper_meta_store"
+    ; "limit", `Int limit
+    ; "count", `Int 0
+    ; "read_error_count", `Int (List.length read_errors)
+    ; ( "read_errors"
+      , `List
+          (List.map
+             (fun error ->
+               `Assoc
+                 [ "scope", `String "background_hydration"
+                 ; "error", `String error
+                 ])
+             read_errors) )
+    ; "scan_truncated", `Bool false
+    ; "items", `List []
+    ; "hydration_status", `String status
+    ]
+;;
+
+let broadcast_compaction_snapshot_refresh ~keeper_id ~status =
+  match
+    Sse.broadcast
+      (`Assoc
+         [ "type", `String "keeper_compaction_snapshots_changed"
+         ; "keeper_name", `String keeper_id
+         ; "status", `String status
+         ; "ts_unix", `Float (Time_compat.now ())
+         ])
+  with
+  | () -> ()
+  | exception Eio.Cancel.Cancelled _ -> ()
+  | exception exn ->
+    Log.Dashboard.warn
+      "keeper compaction snapshot completion broadcast failed: keeper=%s status=%s error=%s"
+      keeper_id status (Printexc.to_string exn)
+;;
+
+let finish_compaction_snapshot_refresh key ~keeper_id body =
+  let refresh_again =
+    with_compaction_snapshot_cache_lock (fun () ->
+      let refresh_again =
+        match Hashtbl.find_opt compaction_snapshot_refreshes key with
+        | Some pending -> pending
+        | None ->
+          Log.Dashboard.warn
+            "keeper compaction snapshot refresh completed without an in-flight marker: keeper=%s"
+            keeper_id;
+          false
+      in
+      if not (Hashtbl.mem compaction_snapshot_cache key)
+      then
+        Server_utils.evict_oldest_if_full
+          ~max_entries:compaction_snapshot_cache_max_entries
+          ~age_of:(fun entry -> entry.refreshed_at)
+          compaction_snapshot_cache;
+      Hashtbl.replace compaction_snapshot_cache key
+        { body; refreshed_at = Time_compat.now () };
+      Hashtbl.remove compaction_snapshot_refreshes key;
+      refresh_again)
+  in
+  let status =
+    match body with
+    | `Assoc fields ->
+      (match List.assoc_opt "hydration_status" fields with
+       | Some (`String value) -> value
+       | _ -> "failed")
+    | _ -> "failed"
+  in
+  broadcast_compaction_snapshot_refresh ~keeper_id ~status;
+  refresh_again
+;;
+
+let rec start_compaction_snapshot_refresh
+    ~config
+    ~keeper_id
+    ~limit
+    ~force_refresh
+    key
+  =
+  let admitted =
+    with_compaction_snapshot_cache_lock (fun () ->
+      if Hashtbl.mem compaction_snapshot_refreshes key
+      then begin
+        if force_refresh
+        then Hashtbl.replace compaction_snapshot_refreshes key true;
+        false
+      end
+      else begin
+        Hashtbl.add compaction_snapshot_refreshes key false;
+        true
+      end)
+  in
+  if not admitted
+  then true
+  else
+    match Eio_context.get_switch_opt () with
+    | None ->
+      with_compaction_snapshot_cache_lock (fun () ->
+        Hashtbl.remove compaction_snapshot_refreshes key);
+      false
+    | Some sw ->
+      let run () =
+        let finish body =
+          let refresh_again =
+            finish_compaction_snapshot_refresh key ~keeper_id body
+          in
+          if refresh_again
+          then
+            ignore
+              (start_compaction_snapshot_refresh ~config ~keeper_id ~limit
+                 ~force_refresh:false key)
+        in
+        match
+          Domain_pool_ref.submit_io_or_inline (fun () ->
+            compaction_snapshots_json ~config ~keeper_id ~limit)
+        with
+        | body ->
+          finish
+            (compaction_snapshot_with_hydration_status "ready" body)
+        | exception Eio.Cancel.Cancelled _ ->
+          with_compaction_snapshot_cache_lock (fun () ->
+            Hashtbl.remove compaction_snapshot_refreshes key)
+        | exception exn ->
+          let error = Printexc.to_string exn in
+          Log.Dashboard.warn
+            "keeper compaction snapshot hydration failed: keeper=%s error=%s"
+            keeper_id error;
+          finish
+            (compaction_snapshot_empty_json ~keeper_id ~limit ~status:"failed"
+               ~read_errors:[ error ])
+      in
+      (match Eio.Fiber.fork ~sw run with
+       | () -> true
+       | exception exn ->
+         with_compaction_snapshot_cache_lock (fun () ->
+           Hashtbl.remove compaction_snapshot_refreshes key);
+         Log.Dashboard.warn
+           "keeper compaction snapshot background fork failed: keeper=%s error=%s"
+           keeper_id (Printexc.to_string exn);
+         false)
+;;
+
+let cached_compaction_snapshots_json
+    ~config
+    ~keeper_id
+    ~limit
+    ~force_refresh
+  =
+  let limit = limit |> max 1 |> min compaction_snapshot_max_limit in
+  let key = compaction_snapshot_cache_key config keeper_id limit in
+  let now = Time_compat.now () in
+  let cached =
+    with_compaction_snapshot_cache_lock (fun () ->
+      Hashtbl.find_opt compaction_snapshot_cache key)
+  in
+  let stale =
+    match cached with
+    | None -> true
+    | Some entry -> now -. entry.refreshed_at >= keeper_hot_path_cache_ttl_s
+  in
+  let scheduled =
+    if force_refresh || stale
+    then
+      start_compaction_snapshot_refresh ~config ~keeper_id ~limit ~force_refresh
+        key
+    else true
+  in
+  match cached with
+  | Some entry -> entry.body
+  | None when scheduled ->
+    compaction_snapshot_empty_json ~keeper_id ~limit ~status:"warming"
+      ~read_errors:[]
+  | None ->
+    compaction_snapshot_empty_json ~keeper_id ~limit ~status:"failed"
+      ~read_errors:[ "background refresh context unavailable" ]
+;;
+
 let cached_keeper_runtime_trace_json config name ?trace_id ?turn_id ~limit () =
   let cache_key =
     keeper_runtime_trace_cache_key config name ?trace_id ?turn_id ~limit ()
@@ -1743,9 +1960,12 @@ let handle_keeper_get_subroutes state req request reqd =
         |> max 1 |> min compaction_snapshot_max_limit
       in
       let config = Mcp_server.workspace_config state in
+      let force_refresh =
+        Server_utils.bool_query_param req "refresh" ~default:false
+      in
       let json =
-        Domain_pool_ref.submit_io_or_inline (fun () ->
-          compaction_snapshots_json ~config ~keeper_id:name ~limit)
+        cached_compaction_snapshots_json ~config ~keeper_id:name ~limit
+          ~force_refresh
       in
       Http.Response.json_value ~compress:true ~request:req
         json reqd

--- a/lib/server/server_dashboard_http_keeper_api.mli
+++ b/lib/server/server_dashboard_http_keeper_api.mli
@@ -258,3 +258,17 @@ val compaction_snapshots_json :
     first, then keeper meta as a latest-only fallback, and emits only event
     metadata/token counts/provenance — never raw prompt or compacted context
     text. Exported for JSON contract tests. *)
+
+val cached_compaction_snapshots_json :
+  config:Workspace.config ->
+  keeper_id:string ->
+  limit:int ->
+  force_refresh:bool ->
+  Yojson.Safe.t
+(** Non-blocking HTTP projection. Returns a cached snapshot immediately, or a
+    typed [warming] envelope on a cold miss, and performs the manifest scan on
+    the shared IO pool from a background fiber. A completed refresh broadcasts
+    [keeper_compaction_snapshots_changed] so mounted clients re-read once.
+    Concurrent reads share one scan; a force refresh received during that scan
+    preserves exactly one trailing scan so the final source change is not
+    lost. *)

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -439,12 +439,6 @@ let dashboard_session_result session =
 let find_session session_id =
   with_sessions_rw (fun () -> Hashtbl.find_opt sessions session_id)
 
-let dashboard_snapshot_provider : (string -> Yojson.Safe.t option) ref =
-  ref (fun _slice -> None)
-
-let set_dashboard_snapshot_provider provider =
-  dashboard_snapshot_provider := provider
-
 let dashboard_auth_success_payload session =
   `Assoc
     [
@@ -453,7 +447,6 @@ let dashboard_auth_success_payload session =
       ( "capabilities",
         `Assoc
           [
-            ("snapshot", `Bool true);
             ("delta", `Bool true);
             ("mode_snapshot", `Bool true);
           ] );
@@ -503,23 +496,6 @@ let dashboard_hello ~base_path ~session_id ?token () =
     (Unix.gettimeofday () -. start_time);
   result
 
-let dashboard_snapshot session =
-  let slices =
-    Atomic.get session.dashboard_slices
-    |> List.filter_map (fun slice ->
-           match !dashboard_snapshot_provider slice with
-           | Some json -> Some (slice, json)
-           | None -> None)
-    |> List.sort (fun (a, _) (b, _) -> String.compare a b)
-  in
-  `Assoc
-    [
-      ("protocol", `String "dashboard-ws.v1");
-      ("seq", `Int (next_dashboard_seq session));
-      ( "route", Json_util.string_opt_to_json (Atomic.get session.dashboard_route) );
-      ("slices", `Assoc slices);
-    ]
-
 let dashboard_subscribe ~session_id ?route ~slices () =
   match find_session session_id with
   | None -> Error "WebSocket session not found"
@@ -546,7 +522,6 @@ let dashboard_subscribe ~session_id ?route ~slices () =
               (`Assoc
                 [
                   ("session", dashboard_session_result session);
-                  ("snapshot", dashboard_snapshot session);
                 ])
       end
 

--- a/lib/server/server_mcp_transport_ws.mli
+++ b/lib/server/server_mcp_transport_ws.mli
@@ -30,8 +30,7 @@
     - {b dashboard JSON-RPC handlers}
       ({!dashboard_hello}, {!dashboard_subscribe},
       {!dashboard_unsubscribe}, {!dashboard_ping},
-      {!dashboard_ack},
-      {!set_dashboard_snapshot_provider}).
+      {!dashboard_ack}).
     - {b outbound delivery}
       ({!send_to_session_result},
       {!send_dashboard_or_raw_sse},
@@ -51,9 +50,8 @@
     [dashboard_session_result], [find_session],
     [detach_session_for_close] / [close_detached_session_wsd] /
     [update_ws_session_count_metric],
-    [dashboard_snapshot_provider] cell,
     [dashboard_auth_success_payload],
-    [verify_dashboard_token], [dashboard_snapshot],
+    [verify_dashboard_token],
     [parse_cache] / [sse_data_prefix] /
     [extract_sse_data_*],
     [dashboard_delta_payload_text_cache] /
@@ -346,12 +344,6 @@ val parse_sse_dashboard_event :
 
 (** {1 Dashboard JSON-RPC handlers} *)
 
-val set_dashboard_snapshot_provider :
-  (string -> Yojson.Safe.t option) -> unit
-(** Installs the per-slice snapshot lookup used by
-    {!dashboard_subscribe} when seeding initial state.
-    Called once at server bootstrap. *)
-
 val dashboard_hello :
   base_path:string ->
   session_id:string ->
@@ -359,8 +351,8 @@ val dashboard_hello :
   unit ->
   (Yojson.Safe.t, string) result
 (** Authenticates the dashboard session.  [Ok payload]
-    on success carries the protocol version + per-slice
-    snapshot; [Error msg] otherwise (unknown session,
+    on success carries the protocol version + capabilities;
+    [Error msg] otherwise (unknown session,
     bad token, etc). *)
 
 val dashboard_subscribe :

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1434,47 +1434,6 @@ let run ~sw ~env ~host ~port ~base_path ?input_base_path ~make_routes ~make_requ
               Log.Server.warn "gRPC keeper client init failed: %s"
                 (Printexc.to_string exn))
        | Http | Ws | Webrtc | Local -> ());
-      Server_mcp_transport_ws.set_dashboard_snapshot_provider (function
-        | "shell" ->
-            Some
-              (Server_dashboard_http.dashboard_shell_payload_json ~light:true
-                 (Mcp_server.workspace_config state))
-        | "execution" ->
-            Some (Server_dashboard_http.dashboard_execution_snapshot_json ())
-        | "operator" ->
-            Some
-              (`Assoc
-                [
-                  ( "snapshot",
-                    Server_dashboard_http.operator_snapshot_cache_diagnostics_json
-                      () );
-                  ( "digest",
-                    Server_dashboard_http.cached_surface_json
-                      Server_dashboard_http.operator_digest_cache );
-                ])
-        | "transport" ->
-            Some (Server_dashboard_http.dashboard_transport_health_snapshot_json ())
-        | "namespace" ->
-            Server_dashboard_http.namespace_truth_snapshot_from_caches state
-        | "composite" ->
-            Some
-              (Server_dashboard_http.dashboard_fleet_composite_json
-                 ~config:(Mcp_server.workspace_config state) ())
-        | "board" ->
-            Some
-              (Server_dashboard_http.dashboard_board_json
-                 ~sort_by:Board_dispatch.Recent ~exclude_system:true
-                 ~limit:100 ~offset:0 ())
-        | "goals" ->
-            Some
-              (Server_dashboard_http.dashboard_goals_snapshot_json
-                 ~config:(Mcp_server.workspace_config state))
-        | "ide" ->
-            Some
-              (Server_dashboard_http.dashboard_ide_snapshot_json
-                 ~config:(Mcp_server.workspace_config state))
-        | _ ->
-            None);
       let dispatch_ws_inbound_message ws_session_id body_str =
           let jsonrpc_id_opt body =
             match Yojson.Safe.from_string body with

--- a/test/test_server_dashboard_http_keeper_api_trace.ml
+++ b/test/test_server_dashboard_http_keeper_api_trace.ml
@@ -628,9 +628,39 @@ let test_compaction_snapshots_read_rotated_manifest_beyond_old_tail () =
   check int "after token count" 400 (item |> member "after_tokens" |> to_int)
 ;;
 
+let test_compaction_snapshots_cache_returns_warming_then_ready () =
+  with_temp_dir (fun dir ->
+    let config = Workspace.default_config dir in
+    let keeper_id = "cache-hydration-keeper" in
+    let hydration_status json =
+      Yojson.Safe.Util.(json |> member "hydration_status" |> to_string)
+    in
+    let cold =
+      Keeper_api.cached_compaction_snapshots_json ~config ~keeper_id ~limit:25
+        ~force_refresh:true
+    in
+    check string "cold miss is explicit" "warming" (hydration_status cold);
+    let rec await_ready remaining =
+      let current =
+        Keeper_api.cached_compaction_snapshots_json ~config ~keeper_id ~limit:25
+          ~force_refresh:false
+      in
+      match hydration_status current with
+      | "ready" -> current
+      | "warming" when remaining > 0 ->
+        Time_compat.sleep 0.005;
+        await_ready (remaining - 1)
+      | status -> failf "unexpected hydration status: %s" status
+    in
+    let ready = await_ready 200 in
+    check int "ready empty inventory" 0
+      Yojson.Safe.Util.(ready |> member "count" |> to_int))
+;;
+
 let () =
   Eio_main.run @@ fun env ->
-  Masc_test_deps.init_eio_clock env;
+  Eio.Switch.run @@ fun sw ->
+  Masc_test_deps.init_eio_clock ~sw env;
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   run
     "Server_dashboard_http_keeper_api_trace"
@@ -693,6 +723,10 @@ let () =
             "reads rotated compaction beyond the old tail window"
             `Quick
             test_compaction_snapshots_read_rotated_manifest_beyond_old_tail
+        ; test_case
+            "returns warming before background hydration completes"
+            `Quick
+            test_compaction_snapshots_cache_returns_warming_then_ready
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

- replace Keeper Lane/conversation periodic reads with one keeper-scoped store driven by typed WebSocket invalidations
- deliver inventory invalidations immediately; concurrent reads are single-flight with one trailing read so burst updates cannot lose the final state
- make `dashboard/subscribe` ACK-only and delete the synchronous dashboard snapshot provider/bootstrap chain
- move compaction manifest hydration off the HTTP request path into a bounded background cache with typed `warming | ready | failed` state and WS completion invalidation
- preserve one trailing compaction scan when a force-refresh arrives during an active scan
- accept the exact `oas_telemetry_sample` bridge envelope instead of silently dropping it as schema drift

Fixes #26998.

## Product comparison

- Slack Events API requires an immediate 2xx acknowledgement and recommends queueing work outside the acknowledgement path. `dashboard/subscribe` now follows that boundary: a 3 ms ACK no longer performs snapshot hydration.
- Kubernetes list/watch starts from an authoritative read and then follows change notifications, with a fresh read after reconnect when continuity is uncertain. Keeper inventory now uses the HTTP snapshot as SSOT, typed signal-only invalidations while connected, and authoritative focus/reconnect recovery.
- Grafana Live multiplexes push channels over one WebSocket to remove per-widget polling. Keeper inventory and compaction completion now use the existing dashboard stream rather than independent interval timers.

References: [Slack Events API](https://api.slack.com/apis/connections/events-api), [Kubernetes API watch](https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes), [Grafana Live](https://grafana.com/docs/grafana/latest/setup-grafana/set-up-grafana-live/).

The push events deliberately remain signal-only. They never become a second state authority: HTTP owns the initial and recovery snapshots, and an invalidation that arrives during an in-flight read schedules exactly one trailing authoritative read.

## Browser evidence

Measured against an isolated branch server with Keeper autoboot and external gateways disabled:

- `dashboard/subscribe`: previous timeout (>30 s configured RPC budget) -> 3 ms ACK
- Keeper waiting inventory: 1 ms TTFB / 1 ms total; no `/api/v1/dashboard/tools` request on Keeper navigation
- compaction snapshots: previous 6,221 ms request-path scan -> 3 ms immediate response plus one 3 ms completion re-read
- mounted Keeper + compaction surface for 16 seconds: 0 waiting-inventory periodic requests, 0 tools requests, 0 compaction periodic requests
- dashboard WS remained connected; browser console and page-error streams were empty

The isolated dataset is intentionally small. It proves request-path ownership and no-polling behavior; rotated/heavy manifest scan correctness is covered by the OCaml regression test.

## Verification

- TypeScript typecheck: pass
- focused Vitest bundle: 338/338 pass
- immediate invalidation/single-flight regressions: 44/44 pass
- CI fixture isolation follow-up: 27/27 pass
- OCaml format and parser checks: pass
- compaction trace executable previously passed 15/15 and `bin/main_eio.exe` linked on this implementation
- current-head focused Dune rerun is delegated to CI because unrelated sessions are running bare Dune processes and the repo wrapper correctly refuses additional local concurrency

## Architecture notes

- HTTP remains the authoritative initial read; WS carries typed invalidations/deltas only.
- No interval is installed by the Keeper inventory store or compaction inspector.
- Focus/visibility and WS reconnect are recovery events, not polling.
- The compaction cache is process-bounded (128 completed keys), keyed by base path, keeper, and limit, and never performs the manifest scan on the HTTP handler fiber.
