### PR TITLE
refactor(keeper): stop citing TLA specs deleted in #24332

### DIFF
--- a/.github/workflows/tla-annotation-drift.yml
+++ b/.github/workflows/tla-annotation-drift.yml
@@ -19,7 +19,6 @@ on:
     paths:
       - 'specs/keeper-state-machine/**'
       - 'lib/keeper/keeper_registry.ml'
-      - 'lib/keeper/keeper_state_machine.ml'
       - 'lib/keeper_registry/**'
       - 'lib/runtime/runtime_fsm.ml'
       - 'lib/runtime/runtime_fsm.mli'
@@ -40,7 +39,6 @@ on:
     paths:
       - 'specs/keeper-state-machine/**'
       - 'lib/keeper/keeper_registry.ml'
-      - 'lib/keeper/keeper_state_machine.ml'
       - 'lib/keeper_registry/**'
       - 'lib/runtime/runtime_fsm.ml'
       - 'lib/runtime/runtime_fsm.mli'

--- a/lib/keeper/keeper_composite_observer.mli
+++ b/lib/keeper/keeper_composite_observer.mli
@@ -2,8 +2,7 @@
 
     Projects a [Keeper_registry.registry_entry] into a composite snapshot
     spanning Decision / Runtime / Memory / Compaction sub-FSMs as
-    specified in RFC-0003 and
-    [specs/keeper-state-machine/KeeperCompositeLifecycle.tla].
+    specified in RFC-0003.
 
     Contract:
     - Pure read. No mutation, no I/O, no event emission.
@@ -40,7 +39,7 @@ type compaction_stage = Keeper_registry.compaction_stage =
   | Compaction_compacting
   | Compaction_done
 
-(** Named TLA invariants mirrored as OCaml variants. *)
+(** Named composite invariants, one variant per {!invariants_check} field. *)
 type invariant_key =
   | Invariant_phase_turn_alignment
   | Invariant_no_runtime_before_measurement
@@ -48,7 +47,7 @@ type invariant_key =
   | Invariant_event_priority_monotone
   | Invariant_phase_derivation_agreement
 
-(** Safety invariants from KeeperCompositeLifecycle.tla.
+(** Composite-level safety invariants.
     Each field is [true] when the invariant holds for the observed
     snapshot. A [false] value signals a composite-level safety violation
     that the dashboard should surface to the operator. *)
@@ -69,29 +68,32 @@ val bump_invariant_violations :
 
 (** {2 Pure invariant predicates}
 
-    The [check_*] functions below mirror the composite TLA+
-    [SafetyInvariant] conjuncts and the runtime phase-derivation
-    agreement check. They are exposed so cross-FSM joint tests
-    ([test/test_keeper_fsm_joints.ml]) can drive realistic state
-    combinations through the same predicates that production
-    [compute_invariants] uses, without having to construct a full
-    {!Keeper_registry.registry_entry} value.
+    The [check_*] functions below are the conjuncts of the composite
+    safety invariant plus the runtime phase-derivation agreement check.
+    They are exposed so tests can drive state combinations through the
+    same predicates production [compute_invariants] uses, without having
+    to construct a full {!Keeper_registry.registry_entry} value.
+    [test/test_event_priority_monotone_pbt.ml] does this for
+    {!check_event_priority_monotone_pure}; the other four have no test of
+    their own.
 
     Pure: no side effects, no clock, no I/O. *)
 
-(** Mirror of TLA+ I1 [PhaseTurnAlignment] (KeeperCompositeLifecycle.tla:354):
-    when KSM is in [Compacting], the turn phase must also be
-    [Turn_compacting]; conversely no other KSM phase may carry a live
-    [Turn_compacting]. *)
+(** [PhaseTurnAlignment]: when KSM is in [Compacting], the turn phase must
+    also be [Turn_compacting]; conversely no other KSM phase may carry a
+    live [Turn_compacting]. *)
 val check_phase_turn_alignment : Keeper_state_machine.phase -> Keeper_registry.packed_turn_phase -> bool
 
-(** Mirror of TLA+ I3 [CompactionAtomicity] (KeeperCompositeLifecycle.tla:368):
+(** [CompactionAtomicity]:
     [(kmc_compaction = compacting) <=> (phase = Compacting)]. *)
 val check_compaction_atomicity : Keeper_state_machine.phase -> Keeper_registry.packed_compaction_stage -> bool
 
-(** Mirror of TLA+ I2 [NoRuntimeBeforeMeasurement]
-    (KeeperCompositeLifecycle.tla:361): runtime selection past [idle]
-    requires a captured measurement. *)
+(** [NoRuntimeBeforeMeasurement] is specified as: runtime selection past
+    [idle] requires a captured measurement. The implementation discards both
+    arguments and returns [true], so
+    [masc_keeper_invariant_violations_total\{invariant="NoRuntimeBeforeMeasurement"\}]
+    cannot increment and the dashboard always reports this one as holding.
+    Tracked in #26989 — do not read a [true] here as a verified invariant. *)
 val check_no_runtime_before_measurement :
   runtime_state:runtime_state -> measurement_captured:bool -> bool
 
@@ -111,9 +113,8 @@ type event_priority_state = {
   ep_has_pending_measurement : bool;
 }
 
-(** Pure predicate for TLA+ I4 [EventPriorityMonotone]
-    (KeeperCompositeLifecycle.tla:374): at most one measurement binding
-    per turn, and a live measurement excludes a pending one. *)
+(** Pure predicate for [EventPriorityMonotone]: at most one measurement
+    binding per turn, and a live measurement excludes a pending one. *)
 val check_event_priority_monotone_pure : event_priority_state -> bool
 
 (** Frozen outcome of the most recently completed turn (RFC-0003
@@ -351,7 +352,7 @@ val decision_stage_to_string : Keeper_registry.packed_decision_stage -> string
 (** Stringify the runtime-state compatibility field. *)
 val runtime_state_to_string : runtime_state -> string
 
-(** Stringify [compaction_stage]. Mirrors KeeperCompactionLifecycle.tla. *)
+(** Stringify [compaction_stage]. *)
 val compaction_stage_to_string : Keeper_registry.packed_compaction_stage -> string
 
 val invariant_key_to_string : invariant_key -> string

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -365,7 +365,7 @@ let assign_keeper_task_from_directive ~agent_name ~task_id =
            task_id_string
            err
        | Ok () ->
-         (* Cycle 44: KeeperTaskAcquisition.tla SubmitTask post-action
+         (* SubmitTask post-action
             guard pins that the directive successfully attached the
             [task_id] to the keeper's meta. The [@@fsm_guard] PPX
             routes the assertion through [wrap_unit ~stage:"guard"]

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -191,7 +191,7 @@ let post_turn_complete_heartbeat ~(turn_running : bool ref) = ignore turn_runnin
 let post_wakeup_signal ~(wakeup : bool Atomic.t) = ignore wakeup
   [@@fsm_guard "Atomic.get wakeup = true"]
 
-(* SubmitTask (KeeperTaskAcquisition.tla, Cycle 44): an external
+(* SubmitTask: an external
    producer (operator directive in this case) attaches a task_id to the
    keeper's [current_task_id]. The post-action invariant is that the
    meta carries the assigned id after [persist_directive_meta_update]

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -11,30 +11,15 @@
 
     Extracted from Keeper_context_runtime as part of #4955 god-file split.
 
-    Spec navigation (OCaml -> TLA+) — plan §19 anchor pattern.  Sibling
-    Authoritative spec
-    mirror is [specs/keeper-state-machine/KeeperGenerationLineage.tla].
+    Generation-lineage properties this tail maintains: identity is stable
+    across generations, trace_id is replaced per generation, ancestry is
+    append-only, and checkpoint commit preserves checkpoint-valid /
+    checkpoint-generation parity once the keeper is back to idle. While an
+    in-flight turn is still resolving, the compaction phase feeds into
+    [keeper_phase] = "running".
 
-    Spec lines 10-13 already cite this module as one of three modeled
-    OCaml sources:
-      - lib/keeper/keeper_post_turn.ml   (this file — post-turn pipeline)
-      - lib/keeper_types/keeper_types.mli (type lineage — anchor deferred)
-
-    This block is the reverse-direction citation so code search for
-    "KeeperGenerationLineage" lands here.
-
-    Post-turn -> spec mapping:
-      Compaction phase    feeds into [keeper_phase] = "running" while
-                          the in-flight turn is still resolving.
-      Checkpoint commit    preserves the spec's checkpoint-valid /
-                          checkpoint-generation parity invariant.
-
-    Spec scope (line 4-8): same identity across generations,
-    trace_id replacement, append-only ancestry, checkpoint lineage
-    parity once back to idle.
-
-    Spec out-of-scope (line 15-18 in spec): explicit compaction requests,
-    Agent.run turn loop, and long-term memory recall. *)
+    Out of scope here: explicit compaction requests, the [Agent.run] turn
+    loop, and long-term memory recall. *)
 
 open Keeper_types
 open Keeper_meta_contract

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -1,7 +1,6 @@
 (** Durable keeper stimulus -> reaction ledger.
 
-    This is the runtime mirror for the KeeperReactionLiveness L1/L5
-    contract: queue-visible stimuli and queue transition reactions are
+    Queue-visible stimuli and queue transition reactions are
     written to a replayable JSONL store under
     [.masc/keepers/<keeper>/reaction-ledger/v5/YYYY-MM/DD.jsonl].  The
     generation namespace is a hard boundary: older stores are neither read nor

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -139,19 +139,17 @@ let record_execution_receipt_gap
       (Printexc.to_string exn)
 ;;
 
-(* -- KeeperTaskAcquisition.tla spec-action runtime guards (Cycle 44) ---
+(* -- Task-acquisition runtime guards ------------------------------------
 
-   Identity helpers carrying [@@fsm_guard] payloads that mirror the
-   honest actions of [specs/keeper-state-machine/KeeperTaskAcquisition.tla].
-   Each helper is wrapped at the call site by
+   Identity helpers carrying [@@fsm_guard] payloads, one per honest
+   task-acquisition action. Each helper is wrapped at the call site by
    [Keeper_fsm_guard_runtime.wrap_unit] so an [Assert_failure] from a
    PPX-injected guard increments the Otel_metric_store violation counter and
-   re-raises. Bug-action [TaskRejected] is NOT
-   instrumented -- it is the failure mode these guards are designed to
-   detect.
+   re-raises. [TaskRejected] is NOT instrumented -- it is the failure mode
+   these guards are designed to detect.
 
-   This pattern follows PR #11696 (Cycle 43, KeeperHeartbeat closeout)
-   which introduced [Keeper_fsm_guard_runtime]. *)
+   This pattern follows PR #11696, which introduced
+   [Keeper_fsm_guard_runtime]. *)
 
 (* AssignTask: the typed channel decision is the authority. Reactive stimuli
    include event-queue triggers that need not appear in the observation. *)
@@ -166,8 +164,8 @@ let post_empty_queue_sleep ~(channel : string) =
 [@@fsm_guard "channel = \"scheduled_autonomous\""]
 ;;
 
-(* TurnComplete (KeeperTaskAcquisition.tla, Cycle 45 follow-up to
-   PR #11716): the [run_keeper_cycle] body has produced an [Ok meta]
+(* TurnComplete (follow-up to PR #11716): the [run_keeper_cycle] body has
+   produced an [Ok meta]
    for this cycle. The post-action invariant pins that
    [cycle_completed] is true before the result is returned -- catches
    a regression where a future refactor splits the bottom of

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -300,15 +300,10 @@ let run_keeper_cycle
   | Ok { entry; publication_recovery } ->
   let meta = entry.meta in
   let channel = turn_decision.channel in
-  (* Spec navigation: see specs/keeper-state-machine/KeeperTaskAcquisition.tla
-     (Cycle 8/Tier B2, PR #11412).  Action mapping:
-     SubmitTask=external producers, AssignTask=channel decision below,
-     EmptyQueueSleep=scheduled_autonomous else, TurnComplete=run_turn body,
-     TaskRejected=NoTaskOrphan invariant (every claim reaches Ok/Error). *)
-  (* Cycle 45: KeeperTaskAcquisition.tla TurnComplete bracket — the
-     cycle_completed flag is set to true on the [Ok updated_meta] return at
-     the end of this function; an [Error _] branch leaves it false and
-     skips the wrap, mirroring the spec's "completed-on-success" semantics. *)
+  (* TurnComplete bracket — the cycle_completed flag is set to true on the
+     [Ok updated_meta] return at the end of this function; an [Error _]
+     branch leaves it false and skips the wrap, so completion is recorded
+     on success only. *)
   (* 0. Phase gate + state-aware runtime routing.
      The gate owns turn executability; select_runtime remains a total helper
      so dashboards/tests can inspect the same routing contract for blocked
@@ -389,8 +384,7 @@ let run_keeper_cycle
      the top of the function body, rather than burying early-exits in
      deeply nested match arms.
 
-     State-aware runtime routing (TLA+ KeeperCoreTriad.SelectRuntime)
-     resumes inside [main_path]. *)
+     State-aware runtime routing resumes inside [main_path]. *)
   let main_path (turn_state : Keeper_unified_turn_execution.turn_state)
     : (turn_success, Agent_sdk.Error.sdk_error) result
       * Keeper_unified_turn_execution.turn_state
@@ -1115,7 +1109,7 @@ dominant source of the observed CAS race exhaustion after
                   in
                   (match success with
                    | Keeper_unified_turn_success.Completed updated_meta ->
-                     (* Cycle 45: KeeperTaskAcquisition.tla TurnComplete post-action. *)
+                     (* TurnComplete post-action. *)
                      let turn_state =
                        { turn_state with cycle_completed = true }
                      in

--- a/lib/keeper_registry/keeper_state_machine.ml
+++ b/lib/keeper_registry/keeper_state_machine.ml
@@ -31,59 +31,6 @@ let is_terminal = function
 
 (* ── derive_phase ──────────────────────────────────────── *)
 
-(* Spec navigation (OCaml priority -> TLA+ line) — plan §3 Tier C1 Phase 0
-   anchor. Authoritative spec mirror is KeeperReconcileLiveness.tla:88-101
-   (DerivePhase operator). The priority runtime below is preserved
-   verbatim; this block adds OCaml -> spec citations so drift is
-   grep-discoverable from this side too.
-
-     Priority | Spec citation
-     ---------+----------------------------------------------------------
-       1      | KeeperReconcileLiveness.tla:89-90 (Stopped: drain_complete
-              |   AND ~compaction_active AND ~handoff_active)
-       2      | (no spec — see Note A: launch_pending is pre-FSM)
-       3a-c   | KeeperReconcileLiveness.tla:91-93 (Dead/Restarting/Crashed)
-              |   boundary/KeeperRecoveryOrchestration.tla:53-57 (recovery)
-       4      | KeeperReconcileLiveness.tla:94 (Draining)
-       5      | KeeperReconcileLiveness.tla:96 (Paused — operator_paused)
-       7a     | KeeperReconcileLiveness.tla:97 (HandingOff)
-              |   KeeperConditionsGovernPhase.tla:96-100 (Transition action)
-       7b     | KeeperReconcileLiveness.tla:98 (Compacting)
-              |   KeeperCompactionLifecycle.tla:171-184 (Compacting cycle)
-       7c     | (retired #26546 — Overflowed is no longer derived; the
-              |   phase variant survives only to decode historical records)
-       8      | KeeperReconcileLiveness.tla:99 (Failing — health degraded)
-       9      | KeeperReconcileLiveness.tla:100 (Running)
-              |   KeeperCoreTriad.tla:147,316 (turn_healthy=true -> Running)
-      10      | KeeperReconcileLiveness.tla:101 (Offline fallback)
-
-   Reverse direction (spec -> this function) anchors:
-     KeeperReconcileLiveness.tla:86      "matching OCaml derive_phase"
-     KeeperConditionsGovernPhase.tla:44  cites line 351 (HandingOff)
-     KeeperCoreTriad.tla:147,316         cites Running mirror
-     bug-models/KeeperPhaseRace.tla:7-10 cites this function entry
-
-   Classification (plan §1 4-way):
-     Note A — Resolved. Priority 2 Offline (launch_pending AND
-       ~fiber_alive) is mirrored by
-       specs/keeper-state-machine/KeeperLaunchPending.tla, a 3-phase
-       projection (Offline / Running / Dead) with bug-action
-       FiberStartedWithoutClearing. The lifecycle audit cites
-       keeper_registry.ml:340 (set), this file:520 (clear in FSM),
-       keeper_registry.ml:407 (clear on death) — all three sources
-       are anchored in the spec's source-citation block.
-     Note B — Retired (#26546). Overflowed phase derivation was removed
-       together with the automatic overflow-compaction trigger; no
-       condition maps to Overflowed anymore.
-
-   C1 follow-up scope (plan §3, sequenced):
-     - Phase 1 (per-priority): convert each branch to `let try_<action>
-       state` mirroring the corresponding TLA+ Next-action enablement.
-     - Phase 2 (compile-time): exhaustiveness ratchet — every spec
-       action has exactly one OCaml try_ counterpart.
-     - Phase 3 (optional, plan §11.1 not adopted by default): runtime
-       gate `emit_phase_transition` — review hook only, not production. *)
-
 let derive_phase (c : conditions) : phase =
   (* Priority order: first match wins.
 

--- a/lib/keeper_registry/keeper_state_machine.mli
+++ b/lib/keeper_registry/keeper_state_machine.mli
@@ -118,14 +118,13 @@ type context_actions = {
 
     Violating this rule — for example, by emitting [Compaction_started]
     from a separate async monitor fiber while a turn is still in flight
-    — reopens the {b KeepalivePhaseConsistency} safety bug formalized in
-    [specs/bug-models/KeepalivePhaseConsistency.tla]. That spec's
-    [NoDrainTransition] / [GhostDispatch] actions are the exact
-    counterexamples TLC will find.
+    — reopens the {b KeepalivePhaseConsistency} safety bug: the keepalive
+    loop then observes the keeper in [Compacting] or [HandingOff] at its
+    dispatch decision point, which is exactly what the structural pairing
+    above rules out.
 
     If a future change needs another origin for these events, add it to
-    the registry origin guard and re-verify the TLA+ spec against the new
-    code path. *)
+    the registry origin guard. *)
 type event =
   | Heartbeat_ok
   | Heartbeat_failed of { consecutive : int }

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -2118,8 +2118,7 @@ let handle_keeper_get_subroutes state req request reqd =
         state_diagram_runtime_fsm_mermaid runtime_projection
       in
       (* Compaction sub-FSM: only emit a diagram when the keeper is in
-         the [Compacting] phase. The three nodes mirror
-         [specs/bug-models/MemoryCompaction.tla]. *)
+         the [Compacting] phase. *)
       let compaction_submachine_mermaid =
         match current with
         | Keeper_state_machine.Compacting ->


### PR DESCRIPTION
## 무엇

`lib/` 의 주석이 **존재하지 않는 TLA 스펙 파일을, 상당수는 줄 번호까지 붙여서 인용한다.** 그 인용을 걷어낸다.

코드는 한 줄도 바뀌지 않는다. `git diff -U0` 에서 `let` / `val` / `type` / `module` 로 시작하는 변경 라인은 0건이다.

## 근거

`7b62a87d44` (#24332, "replace Keeper governance with a nonhierarchical Gate") 가 TLA 스펙 **58개**를 지웠다. 스펙은 갔는데 그걸 가리키는 인용망은 남았다.

| 삭제된 스펙 | `lib/` 인용 |
|---|---|
| `KeeperReconcileLiveness` | 10 |
| `KeeperTaskAcquisition` | 6 |
| `KeeperCompositeLifecycle` | 6 |
| `KeeperCoreTriad` | 3 |
| `KeeperConditionsGovernPhase` | 2 |
| `KeeperGenerationLineage` | 2 |
| `KeeperCompactionLifecycle` | 2 |
| `KeepalivePhaseConsistency` · `KeeperRecoveryOrchestration` · `KeeperPhaseRace` · `KeeperLaunchPending` · `MemoryCompaction` · `KeeperReactionLiveness` | 각 1 |

## 가장 큰 덩어리

`keeper_state_machine.ml:34-85` — 52줄. 블록이 스스로 밝힌 목적:

```
   The priority runtime below is preserved verbatim; this block adds
   OCaml -> spec citations so drift is grep-discoverable from this side too.
```

반대편이 없으니 발견할 drift 가 없다. 표 15행이 `KeeperReconcileLiveness.tla:89-90`, `:91-93`, `:94`, `:96` … 로 없는 파일의 줄을 가리키고, "Reverse direction (spec -> this function) anchors" 4행은 그 스펙들이 이 함수를 도로 가리킨다고 주장한다. 마지막엔 그 스펙들의 Next-action 에 맞춰 exhaustiveness ratchet 을 짓겠다는 3단계 계획이 붙어 있다.

통째로 삭제했다. 바로 아래 `derive_phase` 안의 설계 노트(우선순위가 왜 이 순서인지, TLC 가 찾았던 Stopped/버퍼 교착)는 파일 경로를 인용하지 않고 살아있는 가드를 설명하므로 그대로 뒀다.

## 판단이 필요했던 곳

기계적 삭제가 아니다. 대부분의 주석은 **참인 동작 서술 + 거짓 권위 주장** 이 섞여 있어 사이트별로 갈랐다.

- `keeper_turn_helpers.ml` — `[@@fsm_guard]` 는 살아있는 장치다 (`Keeper_fsm_guard_runtime.wrap_unit` → Otel 위반 카운터). 스펙 경로만 빼고 기계 설명은 유지.
- `keeper_state_machine.mli:121` — 구조적 불변식 경고. `[specs/bug-models/KeepalivePhaseConsistency.tla]` 와 "TLC will find" / "re-verify the TLA+ spec" 을 제거하고, 그 문단이 이미 서술한 실제 실패 양상(keepalive 가 dispatch 시점에 `Compacting`/`HandingOff` 를 관측)으로 교체. **버그 이름은 남겼다** — 파일이 아니라 실패 양상의 이름이다.
- `keeper_post_turn.ml` — "This block is the reverse-direction citation so code search for `KeeperGenerationLineage` lands here." 그 이름은 이제 저장소 어디에도 없다. 블록을 지우되 그 안의 lineage 속성(세대 간 identity 유지, trace_id 교체, append-only ancestry, checkpoint parity)은 모듈 자체 서술로 남겼다.

## 곁가지로 드러난 것 (같이 고침)

`keeper_composite_observer.mli` 가 `check_*` export 를 정당화하며 `[test/test_keeper_fsm_joints.ml]` 이 이를 구동한다고 적었다. **그 파일은 없다.** 실제 소비자는 `test/test_event_priority_monotone_pbt.ml` 이고 다섯 개 중 하나만 구동한다. 사실대로 적고 나머지 넷에 테스트가 없다는 것도 명시했다.

같은 파일에서 `check_no_runtime_before_measurement` 의 doc 도 고쳤다. 구현은:

```ocaml
let check_no_runtime_before_measurement ~runtime_state ~measurement_captured =
  let _ = runtime_state, measurement_captured in
  true
```

인자를 버리고 무조건 `true`. 즉 `masc_keeper_invariant_violations_total{invariant="NoRuntimeBeforeMeasurement"}` 는 증가할 수 없고 대시보드는 이 불변식을 **항상 성립으로 표시한다.** #26989 로 추적 중이며, 이 PR 에서는 고치지 않되 doc 이 그 거짓을 재승인하지 않도록 실제 동작을 적었다. 여기 뜬 `true` 를 검증된 불변식으로 읽지 말라는 문장을 넣었다.

## 검증

| 항목 | 결과 |
|---|---|
| `dune build --root . @check` | EXIT=0 |
| `test_event_priority_monotone_pbt` | EXIT=0 |
| `test_clean_only_bug_mirrors` | 3 tests, Test Successful |
| `scripts/audit-tla-annotation-drift.sh` | EXIT=0 |
| `scripts/audit-ocaml-spec-nav-line-refs.sh` | EXIT=0 |
| `scripts/check-doc-truth.sh` | EXIT=0 |
| 변경된 코드 라인 (`let`/`val`/`type`/`module`) | 0 |

수용 기준: 머지 후 `lib/` 와 `bin/` 에서 #24332 가 지운 스펙 이름이 하나도 매치되지 않는다. 예외는 위에 적은 `KeepalivePhaseConsistency` 버그 이름 하나, 그리고 PR #27024 가 지우는 `ResilienceDegradation` 3건이다.

## 죽은 CI path filter 하나 (2번째 커밋)

`.github/workflows/tla-annotation-drift.yml` 이 `lib/keeper/keeper_state_machine.ml` 을 path filter 로 감시하는데, 그 경로는 `3a14ed415d` (#20008) 가 파일을 `lib/keeper_registry/` 로 옮긴 뒤 존재하지 않는다. pull_request / push 두 목록 모두에서 아무것도 매치하지 않았다.

커버리지는 그대로다 — 같은 목록의 `lib/keeper_registry/**` 가 실제 경로를 잡는다. `lib/keeper/keeper_registry.ml` 항목은 그 파일이 실재하므로 남겼다.

## 커버리지 게이트

`# ci:skip-test-coverage`

`check_test_coverage.py` 가 "Added 57 lines to covered code paths but no test files changed" 로 트립했다. 그 57줄은 전부 다시 쓴 주석이다. 게이트는 raw 추가 라인을 세지 코드 여부를 보지 않는다.

주장으로 넘기지 않고 증명했다. 중첩 주석 / char 리터럴 / 문자열을 올바로 처리하는 OCaml 렉서로 변경 전후 소스에서 주석을 제거하고 비교했다:

```
IDENTICAL  lib/keeper/keeper_composite_observer.mli
IDENTICAL  lib/keeper/keeper_keepalive.ml
IDENTICAL  lib/keeper/keeper_keepalive_signal.ml
IDENTICAL  lib/keeper/keeper_post_turn.ml
IDENTICAL  lib/keeper/keeper_reaction_ledger.mli
IDENTICAL  lib/keeper/keeper_turn_helpers.ml
IDENTICAL  lib/keeper/keeper_unified_turn.ml
IDENTICAL  lib/keeper_registry/keeper_state_machine.ml
IDENTICAL  lib/keeper_registry/keeper_state_machine.mli
IDENTICAL  lib/server/server_dashboard_http_keeper_api.ml

files compared: 10   comment-stripped differences: 0
```

테스트할 새 동작이 없다. 기존 테스트는 그대로 통과한다 (위 표).

## 범위 밖 (보고만)

- `test/test_clean_only_bug_mirrors.ml` — Alcotest 그룹 라벨 `"KeeperTraceSpec"` 이 삭제된 스펙 이름이다. 다만 이 테스트는 버그 모델을 OCaml 로 인코딩해 검증할 뿐 스펙 파일을 읽지 않고, 같은 파일의 `"KeeperTurnCycle"` 은 살아있는 스펙이다. `lib/` 범위 밖이라 남겼다.
- `scripts/audit-ocaml-spec-nav-line-refs.sh` 가 **"0 citation(s) verified across 729 file(s)"** 를 출력한다. "zero OCaml-docstring line-ref drift 를 강제한다"고 baseline 파일이 적고 있으나 실제로 검증하는 citation 이 0건이다. 공허하게 통과하는 게이트다.

Co-authored-by: MASC Agent <agent@masc.local>
Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>
