### PR TITLE
test(types): 유령 test_types.ml 이 지킨다던 task_status 어휘 가드를 실제로 작성

### DIFF
--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -412,9 +412,10 @@ let task_status_is_done = function
     - String identity: schema enum is the actual function image, so
       renames cannot desync.
 
-    The remaining hand-coded axis is the witness list's length —
-    [test_types.ml] pins it at 6, so adding a constructor without
-    adding a witness here breaks that test.
+    The remaining hand-coded axis is the witness list itself.
+    [test_task_status_vocabulary] compares it against the arms of
+    [task_status_of_yojson], so a status one side knows and the other does
+    not fails there.
 
     Order matches the FSM lifecycle (Todo -> Claimed -> InProgress ->
     AwaitingVerification -> Done | Cancelled) for readable schema docs. *)

--- a/test/dune
+++ b/test/dune
@@ -1979,6 +1979,8 @@
 
 (include stanzas/test_agent_card_action_mirror.inc)
 
+(include stanzas/test_task_status_vocabulary.inc)
+
 (include stanzas/test_workspace_heartbeat_outcome.inc)
 
 (include stanzas/test_http_auth_strict_flag.inc)

--- a/test/stanzas/test_task_status_vocabulary.inc
+++ b/test/stanzas/test_task_status_vocabulary.inc
@@ -1,0 +1,5 @@
+(test
+ (name test_task_status_vocabulary)
+ (modules test_task_status_vocabulary)
+ (deps %{project_root}/lib/types/types_core.ml)
+ (libraries alcotest masc masc_test_deps))

--- a/test/test_task_status_vocabulary.ml
+++ b/test/test_task_status_vocabulary.ml
@@ -1,0 +1,144 @@
+(** The two hand-kept task_status lists, compared.
+
+    [types_core.ml] documents that only one axis is left unguarded:
+
+      The remaining hand-coded axis is the witness list's length —
+      [test_types.ml] pins it at 6, so adding a constructor without adding a
+      witness here breaks that test.
+
+    There is no test_types.ml. And a length pin would not have caught the
+    mistake it describes: adding a constructor bumps nothing until a witness
+    is added, so the count simply stays where it was.
+
+    What is actually at risk is that two lists carry the same vocabulary and
+    neither forces the other. [task_status_to_string] is exhaustive, so a new
+    constructor must be given a string. Nothing makes anyone add it to
+    [task_status_schema_witnesses], and nothing makes anyone give it an arm in
+    [task_status_of_yojson]. The witnesses become
+    [valid_task_status_strings], which is the enum
+    [tool_shard_types_schemas_taskboard] publishes — so a forgotten witness
+    tells a model the status is not a legal value while the parser happily
+    accepts it.
+
+    This reads the parser's arms out of the source and requires every status
+    it accepts to be one the schema advertises, and every advertised status to
+    be one the parser recognises. *)
+
+open Alcotest
+
+module D = Masc_domain
+
+(* The runtest action runs in the test directory; the stanza stages the source
+   beside it under the build root. *)
+let types_core_path = "../lib/types/types_core.ml"
+
+let read_file path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+;;
+
+(* Index of [needle] in [haystack] at or after [from], if present. *)
+let find_from haystack needle from =
+  let hn = String.length haystack and nn = String.length needle in
+  let rec go i =
+    if i + nn > hn then None
+    else if String.sub haystack i nn = needle then Some i
+    else go (i + 1)
+  in
+  go from
+;;
+
+(* Status tags [task_status_of_yojson] dispatches on: the quoted arms between
+   its definition and its unknown-status fallback. *)
+let parser_status_tags () =
+  let source = read_file types_core_path in
+  match find_from source "let task_status_of_yojson" 0 with
+  | None -> []
+  | Some start ->
+    let stop =
+      match find_from source "Unknown task status" start with
+      | Some stop -> stop
+      | None -> String.length source
+    in
+    String.sub source start (stop - start)
+    |> String.split_on_char '\n'
+    |> List.concat_map (fun line ->
+      let trimmed = String.trim line in
+      (* Arms may be or-patterns: | "todo" | "deferred" -> ... Take every
+         quoted tag on the line, not the first. *)
+      if String.length trimmed > 4 && String.starts_with ~prefix:"| \"" trimmed
+      then (
+        let rec quoted acc i =
+          match String.index_from_opt trimmed i '"' with
+          | None -> List.rev acc
+          | Some opening ->
+            (match String.index_from_opt trimmed (opening + 1) '"' with
+             | None -> List.rev acc
+             | Some closing ->
+               quoted
+                 (String.sub trimmed (opening + 1) (closing - opening - 1) :: acc)
+                 (closing + 1))
+        in
+        quoted [] 0)
+      else [])
+;;
+
+(* A guard that extracts nothing passes for the wrong reason. *)
+let test_extraction_finds_the_parser_arms () =
+  let tags = parser_status_tags () in
+  check bool
+    (Printf.sprintf "%s yields parser arms" types_core_path)
+    true
+    (tags <> []);
+  check bool "todo is among them" true (List.mem "todo" tags)
+;;
+
+let test_every_parsed_status_is_advertised () =
+  List.iter
+    (fun tag ->
+      check bool
+        (Printf.sprintf "parser tag %S is in valid_task_status_strings" tag)
+        true
+        (List.mem tag D.valid_task_status_strings))
+    (parser_status_tags ())
+;;
+
+(* The reverse: a status the schema offers that the parser rejects outright
+   would be advertised and unusable. Field-level errors are fine here -- the
+   probe omits payload fields on purpose; only the unknown-tag branch matters. *)
+let test_every_advertised_status_is_recognised () =
+  List.iter
+    (fun status ->
+      let probe = `Assoc [ ("status", `String status) ] in
+      match D.task_status_of_yojson probe with
+      | Ok _ -> ()
+      | Error message ->
+        check bool
+          (Printf.sprintf "%S is a status the parser knows (%s)" status message)
+          false
+          (String.length message >= 19 && String.sub message 0 19 = "Unknown task status"))
+    D.valid_task_status_strings
+;;
+
+let test_witnesses_and_parser_agree_in_size () =
+  let tags = List.sort_uniq String.compare (parser_status_tags ()) in
+  let advertised = List.sort_uniq String.compare D.valid_task_status_strings in
+  check (list string) "parser tags equal the advertised statuses" advertised tags
+;;
+
+let () =
+  Alcotest.run
+    "Task status vocabulary"
+    [ ( "extraction"
+      , [ test_case "finds the parser arms" `Quick test_extraction_finds_the_parser_arms ] )
+    ; ( "agreement"
+      , [ test_case "every parsed status is advertised" `Quick
+            test_every_parsed_status_is_advertised
+        ; test_case "every advertised status is recognised" `Quick
+            test_every_advertised_status_is_recognised
+        ; test_case "the two sets are equal" `Quick test_witnesses_and_parser_agree_in_size
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 문제

`types_core.ml` 이 남은 위험을 이렇게 적어두었다.

> The remaining hand-coded axis is the witness list's length — **`[test_types.ml]` pins it at 6**, so adding a constructor without adding a witness here breaks that test.

두 가지가 틀렸다.

1. **`test_types.ml` 은 존재하지 않는다** (lib 25곳이 인용하는 유령 모듈)
2. **길이 고정은 그 실수를 잡지 못한다.** 생성자를 추가해도 목격자를 넣기 전까지 개수는 그대로 6 이다

## 실제 노출

같은 어휘를 담은 손수 관리하는 리스트가 둘이고, 서로를 강제하지 않는다.

| | 강제되는가 |
|---|---|
| `task_status_to_string` 에 arm 추가 | **예** (exhaustive match) |
| `task_status_schema_witnesses` 에 목격자 추가 | 아니오 (평범한 리스트 리터럴) |
| `task_status_of_yojson` 에 arm 추가 | 아니오 |

목격자는 `valid_task_status_strings` 가 되고, 그게 `tool_shard_types_schemas_taskboard.ml:24` 가 발행하는 **도구 스키마 enum** 이다. 목격자를 빠뜨리면 **모델에게는 그 상태가 유효하지 않다고 알려지는데 파서는 받아들인다.**

## 수정

`task_status_of_yojson` 의 arm 을 소스에서 읽어 두 집합이 양방향으로 같은지 요구한다. (#27023 의 TLA parity 가드와 같은 기법 — spec/소스를 `(deps)` 로 stage 해서 runtest 에서 읽는다.)

## 세 방향으로 깨서 확인

각각 되돌렸다.

| 깨뜨린 것 | 잡은 케이스 |
|---|---|
| 파서에 arm 추가, 목격자는 그대로 | every parsed status is advertised |
| 목격자 제거, 파서 arm 유지 | every parsed status is advertised |
| 파서 arm 이름 변경 | every advertised status is recognised |

**첫 시도는 통과해버렸다.** 추출기가 or-패턴에서 앞 태그만 읽어서 `| "todo" | "deferred" ->` 가 `"todo"` 하나로 보였다. arm 줄의 모든 인용 태그를 가져오도록 고쳤고, 그 뒤 의도대로 실패한다.

읽지 못하면 통과하는 가드가 되지 않도록, 첫 케이스가 추출 결과가 비어있지 않고 `"todo"` 를 포함하는지 먼저 확인한다.

## 검증

- `dune build --root . @check` EXIT=0
- `dune build @test/runtest-test_task_status_vocabulary` 4/4
- `scripts/check-doc-code-refs.sh`, `scripts/audit-keeper-tool-boundary-matrix.sh` PASS

프로덕션 변경은 없다. `types_core.ml` 은 docstring 만 고쳐서 실재하는 가드를 가리킨다.

RFC-WAIVED: 유령 테스트를 인용하던 자리에 실제 가드를 작성한다. 타입·문자열·스키마 enum 전부 불변. credential/identity, repo_manager, operator control plane, keeper sandbox, dashboard credential component, hooks, workflow 문서 어느 것도 건드리지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
