### PR TITLE
fix(keeper): retain raw traces by TurnRecord reachability

### DIFF
--- a/docs/rfc/RFC-0358-autonomous-turn-kind-on-turn-record.md
+++ b/docs/rfc/RFC-0358-autonomous-turn-kind-on-turn-record.md
@@ -47,14 +47,24 @@ timestamp, tool name/status/duration만 포함한다. Raw thinking, assistant bl
 tool call id, tool arguments, tool results는 이 surface에 존재하지 않는다.
 
 Raw trace path는 해당 keeper의 `raw-traces` directory에 있는 regular JSONL
-file이어야 한다. 다른 경로, 삭제된 file, incompatible record, summary failure는
-명시적으로 log하고 skip한다.
+file이어야 한다. 다른 경로, current window 안에서 예기치 않게 삭제된 file,
+incompatible record, summary failure는 명시적으로 log하고 skip한다.
+`raw_trace_run_ref = None`은 sink degrade 또는 exact run 생성 전 종료를 뜻하는
+typed absence이므로 경고 없이 skip한다.
 
 ## 3. 보존과 UI cap
 
-Writer와 reader의 bound는 모두 200이다. Disk retention 밖의 본문을 UI가 볼
-수 있다고 주장하지 않는다. Dashboard thread cap 200은 direct conversation에만
-적용하며, server에서 별도 bound된 autonomous rows는 direct rows를 축출하지 않는다.
+Reader와 retention은 동일한 최근 TurnRecord 200행을 단일 경계로 사용한다.
+Retention은 그 window의 exact `raw_trace_run_ref`를 reachability root로 보호한다.
+파일 생성 순서나 파일 개수만으로 삭제 대상을 고르지 않는다. Cleanup은 현재
+TurnRecord commit 시도 뒤에만 실행하므로 반쯤 작성된 sink를 삭제 대상으로 보지
+않는다. Window 밖의 참조와 참조되지 않은 완료/중단 trace만 정리한다. TurnRecord
+window를 읽거나 decode할 수 없으면 cleanup은 fail-open으로 아무것도 삭제하지
+않으며 Keeper turn을 막지 않는다. 삭제 파일 수, reachability root 불확실성으로
+건너뛴 횟수, unlink 실패 수는 각각 typed counter로 노출한다.
+
+Dashboard thread cap 200은 direct conversation에만 적용하며, server에서 별도
+bound된 autonomous rows는 direct rows를 축출하지 않는다.
 
 ## 4. 저장 경계
 

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -195,13 +195,7 @@ let keeper_raw_trace_sink
          ~path
          ()
      with
-     | Ok sink ->
-       let (_removed : int) =
-         Keeper_types_support.prune_keeper_raw_trace_turn_files
-           config
-           meta.name
-       in
-       Sink_ready sink
+     | Ok sink -> Sink_ready sink
      | Error err -> Sink_degraded err)
 ;;
 
@@ -225,6 +219,47 @@ let raw_trace_for_dispatch
       "raw-trace sink degraded; dispatching turn untraced: %s"
       (Agent_sdk.Error.to_string err);
     None
+;;
+
+let prune_raw_traces_after_turn_record
+      ~(config : Workspace.config)
+      ~(meta : Keeper_meta_contract.keeper_meta)
+      (raw_trace : Agent_sdk.Raw_trace.t option)
+  =
+  match raw_trace with
+  | None -> ()
+  | Some _ ->
+    (match Keeper_raw_trace_retention.prune ~config ~keeper_name:meta.name () with
+     | Error error ->
+       Otel_metric_store.inc_counter
+         Keeper_metrics.(to_string RawTraceRetentionSkipped)
+         ~labels:[ "keeper", meta.name ]
+         ();
+       Log.Keeper.warn ~keeper_name:meta.name
+         "raw-trace retention skipped after TurnRecord commit without gating the turn: %s"
+         (Keeper_raw_trace_retention.error_to_string error)
+     | Ok { removed; deletion_failures; _ } ->
+       if removed > 0
+       then
+         Otel_metric_store.inc_counter
+           Keeper_metrics.(to_string RawTraceRetentionDeleted)
+           ~labels:[ "keeper", meta.name ]
+           ~delta:(float_of_int removed)
+           ();
+       (match deletion_failures with
+        | [] -> ()
+        | first :: rest ->
+          let failure_count = 1 + List.length rest in
+          Otel_metric_store.inc_counter
+            Keeper_metrics.(to_string RawTraceRetentionUnlinkFailed)
+            ~labels:[ "keeper", meta.name ]
+            ~delta:(float_of_int failure_count)
+            ();
+          Log.Keeper.warn ~keeper_name:meta.name
+            "raw-trace retention completed with %d unlink failure(s); first=%s: %s"
+            failure_count
+            first.path
+            first.detail))
 ;;
 
 let provider_transcript_admission messages =
@@ -306,6 +341,7 @@ module For_testing = struct
     normalize_response_text_for_finalization
   let keeper_raw_trace_sink = keeper_raw_trace_sink
   let raw_trace_for_dispatch = raw_trace_for_dispatch
+  let prune_raw_traces_after_turn_record = prune_raw_traces_after_turn_record
   let runtime_yield_reason = runtime_yield_reason
   let repeated_exact_tool_call = repeated_exact_tool_call
   let provider_transcript_admission = provider_transcript_admission
@@ -765,6 +801,7 @@ let run_turn
          ~max_context
          ();
        (* Section 3: Dispatch — call Keeper_turn_driver.run_named / Agent.run. *)
+       let raw_trace = raw_trace_for_dispatch ~config ~meta in
        let turn_result =
          let cooperative_yield_probe =
            Some
@@ -931,10 +968,7 @@ let run_turn
                  degrades to [None] (turn runs untraced, typed record
                  emitted) — sink trouble never fails the turn pre-dispatch. *)
          (match
-                 call_run_named
-                   ?raw_trace:(raw_trace_for_dispatch ~config ~meta)
-                   ~initial_messages:history_messages
-                   ()
+                 call_run_named ?raw_trace ~initial_messages:history_messages ()
                with
                | Error e -> Error e
                | Ok result ->
@@ -1295,6 +1329,7 @@ let run_turn
           ~blocks
           ~input_components
           ();
+        prune_raw_traces_after_turn_record ~config ~meta raw_trace;
         (* RFC-0233 §2.3 PR-4: project the same record onto the ambient
            turn span. Both turn drivers (unified "invoke_agent <keeper>"
            and direct "keeper_turn") keep their span open across this

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -87,9 +87,8 @@ module For_testing : sig
     -> (string, Agent_sdk.Error.sdk_error) result
 
   (** OAS raw-trace sink for keeper turns: a fresh per-turn file under
-      [Keeper_types_support.keeper_raw_trace_dir], pruned to
-      [Keeper_types_support.raw_trace_retained_turn_files]. The dispatch
-      section passes it into [Keeper_turn_driver.run_named] so
+      [Keeper_types_support.keeper_raw_trace_dir]. The dispatch section passes
+      it into [Keeper_turn_driver.run_named] so
       [run_result.trace_ref]/[run_validation] are populated. *)
   val keeper_raw_trace_sink
     :  config:Workspace.config
@@ -104,6 +103,15 @@ module For_testing : sig
     :  config:Workspace.config
     -> meta:Keeper_meta_contract.keeper_meta
     -> Agent_sdk.Raw_trace.t option
+
+  (** Run reference-aware cleanup only after the current TurnRecord commit
+      attempt. A missing/degraded sink is a no-op; cleanup failure is logged
+      and never changes the turn result. *)
+  val prune_raw_traces_after_turn_record
+    :  config:Workspace.config
+    -> meta:Keeper_meta_contract.keeper_meta
+    -> Agent_sdk.Raw_trace.t option
+    -> unit
 
   val runtime_yield_reason
     :  autonomous_yield_request

--- a/lib/keeper/keeper_autonomous_turn_source.ml
+++ b/lib/keeper/keeper_autonomous_turn_source.ml
@@ -9,7 +9,7 @@ type turn =
   ; trace : Keeper_chat_blocks.trace_step list
   }
 
-let default_limit = 200
+let default_limit = Keeper_raw_trace_retention.history_limit
 
 let sdk_run_ref (run_ref : Turn_record.raw_trace_run_ref) : Agent_sdk.Raw_trace.run_ref =
   { worker_run_id = run_ref.worker_run_id
@@ -109,11 +109,7 @@ let trace_step_of_trajectory = function
 let turn_of_record ~config ~keeper_name (record : Turn_record.t) =
   match record.turn_kind, record.raw_trace_run_ref with
   | Turn_record.Direct, _ -> None
-  | Turn_record.Autonomous, None ->
-    Log.Keeper.warn ~keeper_name
-      "autonomous turn source: current turn record %s has no exact raw-trace run"
-      (Ids.Turn_ref.to_string record.turn_ref);
-    None
+  | Turn_record.Autonomous, None -> None
   | Turn_record.Autonomous, Some run_ref ->
     let dir = Keeper_types_support.keeper_raw_trace_dir config keeper_name in
     if not (String.equal record.keeper keeper_name)

--- a/lib/keeper/keeper_autonomous_turn_source.mli
+++ b/lib/keeper/keeper_autonomous_turn_source.mli
@@ -14,7 +14,9 @@ type turn =
   }
 
 val default_limit : int
-(** Newest current-schema turn records inspected per request. *)
+(** Newest current-schema turn records inspected per request. Shared with
+    {!Keeper_raw_trace_retention.history_limit}; retention cannot evict an
+    exact run that this reader still considers current. *)
 
 val load_recent :
   config:Workspace.config ->
@@ -23,7 +25,8 @@ val load_recent :
   ?since:float ->
   unit ->
   turn list
-(** Returns exact-run autonomous turns oldest-first. Strictly incompatible
-    turn records, missing/pruned raw traces, non-regular files, and failed run
-    summaries are logged and skipped. There is no legacy decoder or fallback
-    classifier. *)
+(** Returns exact-run autonomous turns oldest-first. [Autonomous] records with
+    no exact run are a typed absence and are skipped without a warning.
+    Strictly incompatible records, unexpectedly missing/non-regular referenced
+    traces, and failed run summaries are logged and skipped. There is no legacy
+    decoder or fallback classifier. *)

--- a/lib/keeper/keeper_raw_trace_retention.ml
+++ b/lib/keeper/keeper_raw_trace_retention.ml
@@ -1,0 +1,133 @@
+module String_set = Set.Make (String)
+
+let history_limit = 200
+
+type deletion_failure =
+  { path : string
+  ; detail : string
+  }
+
+type summary =
+  { removed : int
+  ; retained_references : int
+  ; candidate_files : int
+  ; deletion_failures : deletion_failure list
+  }
+
+type error =
+  | Turn_record_store_unreadable of string
+  | Malformed_turn_record of
+      { path : string
+      ; line_number : int option
+      ; detail : string
+      }
+  | Incompatible_turn_record of string
+  | Wrong_keeper_turn_record of
+      { expected : string
+      ; actual : string
+      }
+  | Invalid_raw_trace_reference of string
+  | Raw_trace_directory_unreadable of string
+
+let error_to_string = function
+  | Turn_record_store_unreadable detail ->
+    Printf.sprintf "cannot read current TurnRecord window: %s" detail
+  | Malformed_turn_record { path; line_number; detail } ->
+    Printf.sprintf "malformed TurnRecord path=%s line=%s: %s"
+      path
+      (Option.fold ~none:"unknown" ~some:string_of_int line_number)
+      detail
+  | Incompatible_turn_record detail ->
+    Printf.sprintf "incompatible current TurnRecord: %s" detail
+  | Wrong_keeper_turn_record { expected; actual } ->
+    Printf.sprintf "TurnRecord keeper mismatch: expected=%s actual=%s" expected actual
+  | Invalid_raw_trace_reference path ->
+    Printf.sprintf "TurnRecord raw-trace reference is outside the keeper store: %s" path
+  | Raw_trace_directory_unreadable detail ->
+    Printf.sprintf "cannot read keeper raw-trace directory: %s" detail
+;;
+
+let path_is_in_store ~dir path =
+  String.equal (Filename.dirname path) dir
+  && Filename.check_suffix path Keeper_types_support.raw_trace_file_extension
+;;
+
+let protected_references ~config ~keeper_name ~dir =
+  let store = Keeper_types_support.keeper_turn_record_store config keeper_name in
+  match Dated_jsonl.read_recent_result store history_limit with
+  | Error error ->
+    Error
+      (Turn_record_store_unreadable (Dated_jsonl.read_error_to_string error))
+  | Ok entries ->
+    let rec collect protected = function
+      | [] -> Ok protected
+      | Dated_jsonl.Malformed_json { path; line_number; detail } :: _ ->
+        Error (Malformed_turn_record { path; line_number; detail })
+      | Dated_jsonl.Parsed json :: rest ->
+        (match Turn_record.of_json json with
+         | Error detail -> Error (Incompatible_turn_record detail)
+         | Ok record when not (String.equal record.keeper keeper_name) ->
+           Error
+             (Wrong_keeper_turn_record
+                { expected = keeper_name; actual = record.keeper })
+         | Ok { raw_trace_run_ref = None; _ } -> collect protected rest
+         | Ok { raw_trace_run_ref = Some run_ref; _ } ->
+           if path_is_in_store ~dir run_ref.path
+           then collect (String_set.add run_ref.path protected) rest
+           else Error (Invalid_raw_trace_reference run_ref.path))
+    in
+    collect String_set.empty entries
+;;
+
+let regular_trace_files dir =
+  let entries =
+    try Ok (Sys.readdir dir) with
+    | Sys_error detail -> Error (Raw_trace_directory_unreadable detail)
+  in
+  match entries with
+  | Error _ as error -> error
+  | Ok entries ->
+    Ok
+      (entries
+       |> Array.to_list
+       |> List.filter_map (fun entry ->
+         if Filename.check_suffix entry Keeper_types_support.raw_trace_file_extension
+         then
+           let path = Filename.concat dir entry in
+           (match Unix.lstat path with
+            | { Unix.st_kind = Unix.S_REG; _ } -> Some path
+            | _ -> None
+            | exception Unix.Unix_error _ -> None)
+         else None))
+;;
+
+let prune ~config ~keeper_name () =
+  let dir = Keeper_types_support.keeper_raw_trace_dir config keeper_name in
+  match protected_references ~config ~keeper_name ~dir with
+  | Error _ as error -> error
+  | Ok references ->
+    (match regular_trace_files dir with
+     | Error _ as error -> error
+     | Ok files ->
+       let candidates =
+         List.filter (fun path -> not (String_set.mem path references)) files
+       in
+       let removed, deletion_failures =
+         List.fold_left
+           (fun (removed, failures) path ->
+             try
+               Sys.remove path;
+               removed + 1, failures
+             with
+             | Sys_error detail ->
+               removed, { path; detail } :: failures)
+           (0, [])
+           candidates
+       in
+       Ok
+         { removed
+         ; retained_references = String_set.cardinal references
+         ; candidate_files = List.length candidates
+         ; deletion_failures = List.rev deletion_failures
+         })
+;;

--- a/lib/keeper/keeper_raw_trace_retention.mli
+++ b/lib/keeper/keeper_raw_trace_retention.mli
@@ -1,0 +1,53 @@
+(** Reference-aware retention for per-turn Keeper raw traces.
+
+    The current TurnRecord window is the reachability root. A trace named by
+    one of those records is never a deletion candidate. Cleanup runs only
+    after the current TurnRecord commit attempt, so an unreferenced file is
+    diagnostic garbage, not an in-flight write. *)
+
+val history_limit : int
+(** Number of newest physical TurnRecord rows inspected by both the dashboard
+    reader and retention. This is the single source of truth for RFC-0358. *)
+
+type deletion_failure =
+  { path : string
+  ; detail : string
+  }
+
+type summary =
+  { removed : int
+  ; retained_references : int
+  ; candidate_files : int
+  ; deletion_failures : deletion_failure list
+  }
+
+type error =
+  | Turn_record_store_unreadable of string
+  | Malformed_turn_record of
+      { path : string
+      ; line_number : int option
+      ; detail : string
+      }
+  | Incompatible_turn_record of string
+  | Wrong_keeper_turn_record of
+      { expected : string
+      ; actual : string
+      }
+  | Invalid_raw_trace_reference of string
+  | Raw_trace_directory_unreadable of string
+
+val error_to_string : error -> string
+
+val prune :
+  config:Workspace.config ->
+  keeper_name:string ->
+  unit ->
+  (summary, error) result
+(** Delete regular [.jsonl] files that are unreachable from the newest
+    {!history_limit} TurnRecords. Callers invoke this only after the current
+    TurnRecord commit attempt, never while its raw trace is still being
+    written.
+
+    Any uncertainty while reading or decoding the reachability root returns
+    [Error] before deletion (fail-open). Individual unlink failures are
+    collected in [summary] and never fail the Keeper turn. *)

--- a/lib/keeper/keeper_types_support.ml
+++ b/lib/keeper/keeper_types_support.ml
@@ -89,20 +89,6 @@ let keeper_runtime_dir config name =
 let raw_traces_dirname = "raw-traces"
 let raw_trace_file_extension = ".jsonl"
 
-(** Retention bound for the per-turn raw-trace store.  This is log
-    retention, not a behavioral cap: every turn still runs and still
-    traces; only the oldest persisted turn files beyond this count are
-    deleted at sink-creation time.  The steady-state on-disk bound is
-    [raw_trace_retained_turn_files + 1] files per keeper (the freshly
-    created turn file materializes after the prune that precedes it).
-
-    The count also bounds how far back the dashboard chat can show an
-    autonomous turn's public final text: the turn record keeps typed
-    identity and exact-run metadata, but the raw-trace store owns the body.
-    Dashboard display requirements do not enlarge this diagnostic-store
-    retention policy. *)
-let raw_trace_retained_turn_files = 200
-
 let keeper_raw_trace_dir config name =
   Filename.concat
     (Filename.concat (Workspace.keepers_runtime_dir config) name)
@@ -148,47 +134,6 @@ let keeper_raw_trace_turn_path config name =
     else candidate
   in
   fresh 0
-
-(** Delete the oldest per-turn raw-trace files beyond
-    [raw_trace_retained_turn_files].  Deterministic: candidates are the
-    [.jsonl] entries of the raw-traces dir sorted by file name ascending
-    (the zero-padded timestamp prefix makes that chronological), and the
-    excess prefix of that order is removed.  Total: a missing dir or a
-    failed unlink is logged and skipped, never raised — retention runs on
-    the turn dispatch path and must not gate keeper liveness.  Returns the
-    number of files removed. *)
-let prune_keeper_raw_trace_turn_files config name =
-  let dir = keeper_raw_trace_dir config name in
-  let entries =
-    try Sys.readdir dir with
-    | Sys_error _ -> [||]
-  in
-  let trace_files =
-    entries
-    |> Array.to_list
-    |> List.filter (fun entry ->
-      Filename.check_suffix entry raw_trace_file_extension)
-    |> List.sort String.compare
-  in
-  let excess = List.length trace_files - raw_trace_retained_turn_files in
-  if excess <= 0 then 0
-  else begin
-    let removed = ref 0 in
-    List.iteri
-      (fun idx entry ->
-        if idx < excess then begin
-          let path = Filename.concat dir entry in
-          try
-            Sys.remove path;
-            incr removed
-          with
-          | Sys_error msg ->
-            Log.Keeper.warn ~keeper_name:name
-              "raw-trace retention: failed to remove %s: %s" path msg
-        end)
-      trace_files;
-    !removed
-  end
 
 let keeper_generation_index_path config name =
   Filename.concat

--- a/lib/keeper/keeper_types_support.mli
+++ b/lib/keeper/keeper_types_support.mli
@@ -44,15 +44,8 @@ val keeper_turn_record_store : Workspace.config -> string -> Dated_jsonl.t
     effects. *)
 val keeper_raw_trace_dir : Workspace.config -> string -> string
 
-(** Retention bound for the per-turn raw-trace diagnostic store. The oldest
-    turn files beyond this count are removed by
-    {!prune_keeper_raw_trace_turn_files}. This also bounds public final-text
-    availability for {!Keeper_autonomous_turn_source}; dashboard display
-    requirements do not control this policy. *)
-val raw_trace_retained_turn_files : int
-
 (** File extension of a per-turn raw-trace file, including the dot. The
-    writer's retention scan and {!Keeper_autonomous_turn_source}'s read
+    retention scan and {!Keeper_autonomous_turn_source}'s read
     both select directory entries by this suffix. *)
 val raw_trace_file_extension : string
 
@@ -63,13 +56,6 @@ val raw_trace_file_extension : string
     created — callers on the dispatch path must degrade, not fail the
     turn (see [Keeper_agent_run.raw_trace_sink_outcome]). *)
 val keeper_raw_trace_turn_path : Workspace.config -> string -> string
-
-(** Remove the oldest per-turn raw-trace files beyond
-    {!raw_trace_retained_turn_files}, ordered by file name ascending
-    (chronological via the zero-padded timestamp prefix). Total: missing
-    dir or failed unlinks are logged and skipped. Returns the number of
-    files removed. *)
-val prune_keeper_raw_trace_turn_files : Workspace.config -> string -> int
 
 val keeper_generation_index_path : Workspace.config -> string -> string
 

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -196,6 +196,9 @@ type t =
   | KeeperToolCallRetryLoop     (* counter: consecutive identical tool calls with errors *)
   | ShellIrEffectTotal          (* counter: fine-grained Shell IR effect decomposition *)
   | RawTraceSinkDegraded        (* counter: raw-trace sink create failed; turn dispatched untraced *)
+  | RawTraceRetentionDeleted   (* counter: unreachable raw-trace files deleted after TurnRecord commit *)
+  | RawTraceRetentionSkipped   (* counter: retention skipped because the reachability root was uncertain *)
+  | RawTraceRetentionUnlinkFailed (* counter: unreachable raw-trace files that could not be deleted *)
   | WireCaptureResponseSuppressed (* counter: keeper-visible response suppressed before wire capture *)
   | WireCaptureWriteFailures    (* counter: wire-capture write raised an exception *)
   | WireCaptureRecordSkipped    (* counter: wire-capture record dropped by current-file byte cap *)
@@ -408,6 +411,10 @@ let to_string = function
   | KeeperToolCallRetryLoop -> "masc_keeper_tool_call_retry_loop_total"
   | ShellIrEffectTotal -> "masc_keeper_shell_ir_effect_total"
   | RawTraceSinkDegraded -> "masc_keeper_raw_trace_sink_degraded_total"
+  | RawTraceRetentionDeleted -> "masc_keeper_raw_trace_retention_deleted_total"
+  | RawTraceRetentionSkipped -> "masc_keeper_raw_trace_retention_skipped_total"
+  | RawTraceRetentionUnlinkFailed ->
+    "masc_keeper_raw_trace_retention_unlink_failed_total"
   | WireCaptureResponseSuppressed ->
     "masc_keeper_wire_capture_response_suppressed_total"
   | WireCaptureWriteFailures -> "masc_keeper_wire_capture_write_failures_total"

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -186,6 +186,9 @@ type t =
   | KeeperToolCallRetryLoop
   | ShellIrEffectTotal
   | RawTraceSinkDegraded
+  | RawTraceRetentionDeleted
+  | RawTraceRetentionSkipped
+  | RawTraceRetentionUnlinkFailed
   | WireCaptureResponseSuppressed
   | WireCaptureWriteFailures
   | WireCaptureRecordSkipped

--- a/test/test_keeper_raw_trace_sink.ml
+++ b/test/test_keeper_raw_trace_sink.ml
@@ -14,9 +14,9 @@
       creation still fails, the turn dispatches untraced with a typed
       degrade record ([Sink_degraded] -> warn log + counter), never a
       pre-dispatch error.
-    - P1b: the store is bounded — one fresh JSONL per turn under
-      [.masc/keepers/<name>/raw-traces/], deterministically pruned to
-      [Keeper_types_support.raw_trace_retained_turn_files].
+    - P1b: the store is bounded by TurnRecord reachability — after the current
+      commit attempt, every exact run referenced by the RFC-0358 window
+      survives, while orphan/unreachable regular JSONL files are removed.
     - Consumer level: a traced turn yields non-[None]
       [run_result.trace_ref]/[run_validation] via exactly the projection
       [Runtime_agent.run] performs. *)
@@ -104,6 +104,54 @@ let materialize_turn ~(meta : Keeper_meta_contract.keeper_meta) ~turn sink =
        ~final_text:(Some (Printf.sprintf "done-%d" turn))
        ~stop_reason:(Some "end_turn") ~error:None)
 
+let write_turn_record config ~(meta : Keeper_meta_contract.keeper_meta) ~turn
+    ~raw_trace_path =
+  let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+  let raw_trace_run_ref : Turn_record.raw_trace_run_ref =
+    { worker_run_id = Printf.sprintf "run-%d" turn
+    ; path = raw_trace_path
+    ; start_seq = 1
+    ; end_seq = 1
+    ; agent_name = meta.name
+    ; session_id = trace_id
+    }
+  in
+  Keeper_turn_record_writer.write
+    ~config
+    ~keeper_name:meta.name
+    ~agent_name:meta.agent_name
+    ~generation:meta.runtime.nonce
+    ~turn_kind:Turn_record.Autonomous
+    ~trace_id
+    ~absolute_turn:turn
+    ~runtime_profile:"test-runtime"
+    ~model:(Some "test-model")
+    ~finish_reason:(Some "completed")
+    ~context_window:None
+    ~price_input_per_million:None
+    ~price_output_per_million:None
+    ~request_latency_ms:None
+    ~ttfrc_ms:None
+    ~request_wire_observation:None
+    ~raw_trace_run_ref:(Some raw_trace_run_ref)
+    ~sampling:
+      { temperature = None
+      ; top_p = None
+      ; max_tokens = None
+      ; thinking_budget = None
+      ; enable_thinking = None
+      }
+    ~usage:
+      { input_tokens = None
+      ; output_tokens = None
+      ; cache_creation_input_tokens = None
+      ; cache_read_input_tokens = None
+      }
+    ~execution_ids:[]
+    ~blocks:[]
+    ~input_components:None
+    ()
+
 (* Per-turn store lives under the keepers runtime dir — the SSOT shared
    with the metrics/receipt stores — and every call hands out a fresh
    file so [Raw_trace.create] never reads previous turns. *)
@@ -187,7 +235,9 @@ let test_per_turn_files_isolate_turns () =
     let (_ref : Agent_sdk.Raw_trace.run_ref) =
       materialize_turn ~meta ~turn sink
     in
-    Agent_sdk.Raw_trace.file_path sink
+    let path = Agent_sdk.Raw_trace.file_path sink in
+    write_turn_record config ~meta ~turn ~raw_trace_path:path;
+    path
   in
   let path1 = run_once ~turn:1 in
   let path2 = run_once ~turn:2 in
@@ -284,81 +334,148 @@ let test_degraded_sink_dispatches_untraced () =
         "degrade emits the typed RawTraceSinkDegraded counter"
         (before +. 1.0) (degrade_count ()))
 
-(* P1b: deterministic retention — oldest-by-name (= oldest-by-time via
-   the zero-padded timestamp prefix) files beyond the named bound are
-   removed; non-.jsonl entries are not candidates; pruning is idempotent. *)
-let test_prune_removes_oldest_beyond_retention () =
+let prune_or_fail config =
+  match
+    Keeper_raw_trace_retention.prune
+      ~config
+      ~keeper_name
+      ()
+  with
+  | Ok summary -> summary
+  | Error error ->
+    Alcotest.fail
+      ("reference-aware prune failed: "
+       ^ Keeper_raw_trace_retention.error_to_string error)
+
+(* P1b: TurnRecord reachability, not file age or raw file count, owns
+   retention. Orphans may sort before, between, or after referenced traces;
+   every current reference and the admitted sink survives. *)
+let test_prune_preserves_current_references_and_removes_orphans () =
+  with_workspace @@ fun config ->
+  let meta = make_test_meta () in
+  let dir = Keeper_types_support.keeper_raw_trace_dir config keeper_name in
+  Fs_compat.mkdir_p dir;
+  let name_of i = Printf.sprintf "turn-%013d-0000-%06d.jsonl" i i in
+  let referenced =
+    List.init 3 (fun i -> Filename.concat dir (name_of ((i * 10) + 10)))
+  in
+  List.iteri
+    (fun i path ->
+      write_file path "{}\n";
+      write_turn_record config ~meta ~turn:(i + 1) ~raw_trace_path:path)
+    referenced;
+  let orphans =
+    [ Filename.concat dir (name_of 1)
+    ; Filename.concat dir (name_of 15)
+    ; Filename.concat dir (name_of 99)
+    ]
+  in
+  List.iter (fun path -> write_file path "{}\n") orphans;
+  let non_trace = Filename.concat dir "not-a-trace.tmp" in
+  write_file non_trace "keep\n";
+  let summary = prune_or_fail config in
+  Alcotest.(check int) "all orphan regular traces removed" 3 summary.removed;
+  Alcotest.(check int) "all current references retained" 3
+    summary.retained_references;
+  List.iter
+    (fun path ->
+      Alcotest.(check bool) ("referenced trace survives: " ^ path) true
+        (Sys.file_exists path))
+    referenced;
+  List.iter
+    (fun path ->
+      Alcotest.(check bool) ("orphan trace removed: " ^ path) false
+        (Sys.file_exists path))
+    orphans;
+  Alcotest.(check bool) "non-jsonl file is not a retention candidate" true
+    (Sys.file_exists non_trace)
+
+(* A malformed current reachability root must never be converted into a
+   destructive guess. The entire cleanup is skipped and every file survives. *)
+let test_prune_fails_open_on_incompatible_turn_record () =
   with_workspace @@ fun config ->
   let dir = Keeper_types_support.keeper_raw_trace_dir config keeper_name in
   Fs_compat.mkdir_p dir;
-  let n_extra = 7 in
-  let total = Keeper_types_support.raw_trace_retained_turn_files + n_extra in
-  let name_of i = Printf.sprintf "turn-%013d-0000-%06d.jsonl" i i in
-  for i = 0 to total - 1 do
-    write_file (Filename.concat dir (name_of i)) "{}\n"
-  done;
-  write_file (Filename.concat dir "not-a-trace.tmp") "keep\n";
-  Alcotest.(check int) "prune removes exactly the excess" n_extra
-    (Keeper_types_support.prune_keeper_raw_trace_turn_files config keeper_name);
-  for i = 0 to n_extra - 1 do
-    Alcotest.(check bool)
-      (Printf.sprintf "oldest file %d removed" i)
-      false
-      (Sys.file_exists (Filename.concat dir (name_of i)))
-  done;
-  Alcotest.(check bool) "retention boundary file survives" true
-    (Sys.file_exists (Filename.concat dir (name_of n_extra)));
-  Alcotest.(check bool) "newest file survives" true
-    (Sys.file_exists (Filename.concat dir (name_of (total - 1))));
-  Alcotest.(check bool) "non-jsonl entries are not retention candidates" true
-    (Sys.file_exists (Filename.concat dir "not-a-trace.tmp"));
-  Alcotest.(check int) "second prune is a no-op" 0
-    (Keeper_types_support.prune_keeper_raw_trace_turn_files config keeper_name)
+  let orphan = Filename.concat dir "turn-0000000000001-0000-000001.jsonl" in
+  write_file orphan "{}\n";
+  Dated_jsonl.append
+    (Keeper_types_support.keeper_turn_record_store config keeper_name)
+    (`Assoc []);
+  (match
+     Keeper_raw_trace_retention.prune
+       ~config
+       ~keeper_name
+       ()
+   with
+   | Error (Keeper_raw_trace_retention.Incompatible_turn_record _) -> ()
+   | Error error ->
+     Alcotest.fail
+       ("unexpected typed prune error: "
+        ^ Keeper_raw_trace_retention.error_to_string error)
+  | Ok _ -> Alcotest.fail "incompatible TurnRecord must skip cleanup");
+  Alcotest.(check bool) "orphan survives fail-open cleanup" true
+    (Sys.file_exists orphan)
 
-(* P1b end-to-end: creating sinks turn after turn keeps the store at the
-   documented steady-state bound (retained + the freshly materialized
-   turn file), with the oldest turn files the ones pruned.
-
-   The store is filled to the retention boundary with placeholder turn
-   files instead of by running [retained] real turns. The subject here is
-   the sink -> prune wiring, which three real sinks exercise as well as
-   thousands do; running the full retention count of real turns costs
-   ~50s and asserts nothing the placeholders do not. Prune ordering and
-   idempotence are asserted directly in
-   [test_prune_removes_oldest_beyond_retention].
-
-   Placeholder names carry a zero-based index where the writer stamps the
-   current epoch millisecond, so they always sort below a freshly minted
-   turn file and are the prune candidates. *)
-let test_sink_creation_enforces_retention_bound () =
+(* The shared 200-row boundary is exact: a reference in row 1 falls out when
+   row 201 commits, while rows 2..201 remain protected. *)
+let test_prune_uses_shared_turn_record_window () =
   with_workspace @@ fun config ->
   let meta = make_test_meta () in
-  let retained = Keeper_types_support.raw_trace_retained_turn_files in
+  let dir = Keeper_types_support.keeper_raw_trace_dir config keeper_name in
+  Fs_compat.mkdir_p dir;
+  let path_of turn =
+    Filename.concat dir
+      (Printf.sprintf "turn-%013d-0000-%06d.jsonl" turn turn)
+  in
+  for turn = 1 to Keeper_raw_trace_retention.history_limit + 1 do
+    let path = path_of turn in
+    write_file path "{}\n";
+    write_turn_record config ~meta ~turn ~raw_trace_path:path
+  done;
+  let summary = prune_or_fail config in
+  Alcotest.(check int) "only the reference outside the shared window is removed"
+    1 summary.removed;
+  Alcotest.(check bool) "row outside the current window is unreachable" false
+    (Sys.file_exists (path_of 1));
+  Alcotest.(check bool) "oldest row inside the current window survives" true
+    (Sys.file_exists (path_of 2));
+  Alcotest.(check bool) "newest row survives" true
+    (Sys.file_exists
+       (path_of (Keeper_raw_trace_retention.history_limit + 1)))
+
+(* End-to-end wiring: cleanup runs after the TurnRecord commit attempt, so the
+   just-committed exact path is reachable before any orphan is removed. *)
+let test_post_commit_cleanup_prunes_orphan_and_preserves_reference () =
+  with_workspace @@ fun config ->
+  let meta = make_test_meta () in
   let dir = Keeper_types_support.keeper_raw_trace_dir config meta.name in
   Fs_compat.mkdir_p dir;
-  let placeholder i = Printf.sprintf "turn-%013d-0000-%06d.jsonl" i i in
-  for i = 0 to retained - 1 do
-    write_file (Filename.concat dir (placeholder i)) "{}\n"
-  done;
-  let oldest_placeholder = Filename.concat dir (placeholder 0) in
-  let last_path = ref "" in
-  for turn = 1 to 3 do
-    let sink =
-      sink_or_fail "keeper_raw_trace_sink"
-        (Keeper_agent_run.For_testing.keeper_raw_trace_sink ~config ~meta)
-    in
-    let (_ref : Agent_sdk.Raw_trace.run_ref) =
-      materialize_turn ~meta ~turn sink
-    in
-    last_path := Agent_sdk.Raw_trace.file_path sink
-  done;
-  Alcotest.(check int) "store is bounded at retained + 1 files"
-    (retained + 1)
-    (List.length (jsonl_files dir));
-  Alcotest.(check bool) "oldest turn file was pruned" false
-    (Sys.file_exists oldest_placeholder);
-  Alcotest.(check bool) "newest turn file was retained" true
-    (Sys.file_exists !last_path)
+  let referenced = Filename.concat dir "turn-0000000000001-0000-000001.jsonl" in
+  let orphan = Filename.concat dir "turn-9999999999998-0000-999998.jsonl" in
+  write_file referenced "{}\n";
+  write_turn_record config ~meta ~turn:1 ~raw_trace_path:referenced;
+  write_file orphan "{}\n";
+  let sink =
+    sink_or_fail "keeper_raw_trace_sink"
+      (Keeper_agent_run.For_testing.keeper_raw_trace_sink ~config ~meta)
+  in
+  let current_path = Agent_sdk.Raw_trace.file_path sink in
+  let (_ref : Agent_sdk.Raw_trace.run_ref) =
+    materialize_turn ~meta ~turn:2 sink
+  in
+  write_turn_record config ~meta ~turn:2 ~raw_trace_path:current_path;
+  Keeper_agent_run.For_testing.prune_raw_traces_after_turn_record
+    ~config
+    ~meta
+    (Some sink);
+  Alcotest.(check bool) "previous referenced trace survives cleanup" true
+    (Sys.file_exists referenced);
+  Alcotest.(check bool) "orphan is removed even when it sorts newest" false
+    (Sys.file_exists orphan);
+  Alcotest.(check bool) "just-committed trace survives cleanup" true
+    (Sys.file_exists current_path);
+  Alcotest.(check int) "only reference plus current sink remain" 2
+    (List.length (jsonl_files dir))
 
 let response ?(content = []) ?(stop_reason = Agent_sdk.Types.EndTurn) () =
   {
@@ -445,8 +562,9 @@ let repo_root () =
    ~goal:user_message, which doc-comment mentions of run_named never carry),
    ?raw_trace must be passed. This is the regression that motivated the fix:
    the parameter existed end-to-end but the dispatch never supplied it.
-   The companion check pins the option to the degrade adapter so a future
-   edit cannot silently reintroduce a hard (turn-failing) dependency. *)
+   The companion checks pin the option to the degrade adapter and keep
+   retention after TurnRecord publication, so a future edit cannot silently
+   reintroduce a hard dependency or pre-dispatch cleanup. *)
 let test_keeper_dispatch_passes_raw_trace () =
   let root = repo_root () in
   let rel_path = "lib/keeper/keeper_agent_run.ml" in
@@ -476,8 +594,30 @@ let test_keeper_dispatch_passes_raw_trace () =
         (raw_trace_for_dispatch), not a turn-failing require"
        rel_path)
     true
-    (Astring.String.is_infix ~affix:"?raw_trace:(raw_trace_for_dispatch"
-       source)
+    (Astring.String.is_infix
+       ~affix:"let raw_trace = raw_trace_for_dispatch ~config ~meta"
+       source
+     && Astring.String.is_infix
+          ~affix:"call_run_named ?raw_trace ~initial_messages"
+          source);
+  let record_write =
+    Astring.String.find_sub ~sub:"Keeper_turn_record_writer.write" source
+  in
+  let cleanup_after_write =
+    Option.bind record_write (fun start ->
+      Astring.String.find_sub
+        ~start
+        ~sub:"prune_raw_traces_after_turn_record ~config ~meta raw_trace"
+        source)
+  in
+  Alcotest.(check bool)
+    (Printf.sprintf
+       "%s: raw-trace cleanup must run only after the TurnRecord commit attempt"
+       rel_path)
+    true
+    (match record_write, cleanup_after_write with
+     | Some write_at, Some cleanup_at -> cleanup_at > write_at
+     | _ -> false)
 
 let () =
   Alcotest.run "keeper_raw_trace_sink"
@@ -496,10 +636,14 @@ let () =
             test_corrupt_history_does_not_block_sink;
           Alcotest.test_case "degraded sink dispatches untraced" `Quick
             test_degraded_sink_dispatches_untraced;
-          Alcotest.test_case "retention prunes oldest beyond bound" `Quick
-            test_prune_removes_oldest_beyond_retention;
-          Alcotest.test_case "sink creation enforces retention bound" `Quick
-            test_sink_creation_enforces_retention_bound;
+          Alcotest.test_case "retention preserves refs and removes orphans" `Quick
+            test_prune_preserves_current_references_and_removes_orphans;
+          Alcotest.test_case "retention fails open on incompatible record" `Quick
+            test_prune_fails_open_on_incompatible_turn_record;
+          Alcotest.test_case "retention shares reader's exact window" `Quick
+            test_prune_uses_shared_turn_record_window;
+          Alcotest.test_case "post-commit cleanup is reference-aware" `Quick
+            test_post_commit_cleanup_prunes_orphan_and_preserves_reference;
           Alcotest.test_case "traced turn yields result-level fields" `Quick
             test_traced_turn_yields_result_level_fields;
           Alcotest.test_case "dispatch passes ?raw_trace" `Quick


### PR DESCRIPTION
## What changed

- replace filename/count-based Keeper raw-trace pruning with TurnRecord reachability
- share the newest-200-row boundary between retention and the autonomous-turn reader
- run cleanup after the current TurnRecord is published
- fail open before deletion when the TurnRecord window is unreadable, malformed, incompatible, or points outside the Keeper store
- treat `raw_trace_run_ref = None` as typed absence while preserving warnings for genuinely missing referenced traces
- expose typed counters for deleted files, skipped retention, and unlink failures

## Why

The old sink-creation prune retained the newest 200 filenames independently of the 200 TurnRecords consumed by the dashboard. Extra and incomplete trace files could therefore evict a still-referenced exact run, leaving a dangling TurnRecord path and producing repeated `exact raw-trace file is missing` warnings during history projection.

The new contract follows explicit reachability/ownership models used by Git and Kubernetes, plus Tempo's publish-before-compaction ordering: TurnRecord is the visibility root, and cleanup never guesses when that root is uncertain.

## Impact

- exact autonomous turns in the current dashboard window keep their trace payloads
- normal untraced turns no longer create misleading warnings
- a missing referenced file remains an actionable integrity warning
- storage remains bounded to the reader-visible TurnRecord window plus transient files until the next successful cleanup
- cleanup failures do not gate Keeper liveness

## Validation

- `MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_raw_trace_sink.exe test/test_keeper_autonomous_turn_source.exe`
- `_build/default/test/test_keeper_raw_trace_sink.exe` — 12/12 passed
- `_build/default/test/test_keeper_autonomous_turn_source.exe` — 12/12 passed
- `ocamlformat --check` on all changed OCaml files
- `git diff --check`
- `scripts/ci/check-determinism-contract.sh`
- `python3 scripts/ci/check-fun-protect-finally-guard.py`
