### PR TITLE
refactor(schemas): 소비자 없는 scope 미러 제거, 실제 쓰이는 미러에 가드 작성

### DIFF
--- a/lib/tool_schemas/tool_schemas_agent.ml
+++ b/lib/tool_schemas/tool_schemas_agent.ml
@@ -2,10 +2,10 @@ open Masc_domain
 
 (** Issue #8501: hand-mirrored from
     [Tool_agent.valid_agent_card_action_strings]. masc_tool_schemas
-    only depends on masc_types so it cannot derive directly. The sync
-    regression test [test_types.ml :: keeper_tool_variants_ssot] catches
-    drift. Same shape as #8467/#8480/#8484/#8490/#8493 mirror+sync
-    pattern. *)
+    only depends on masc_types so it cannot derive directly.
+    [test_agent_card_action_mirror] compares the published
+    [masc_agent_card] enum against the owner's list, so drift fails there.
+    Same shape as #8467/#8480/#8484/#8490/#8493 mirror+sync pattern. *)
 
 let agent_card_action_enum_strings = [ "get"; "refresh" ]
 

--- a/lib/tool_schemas/tool_schemas_agent.mli
+++ b/lib/tool_schemas/tool_schemas_agent.mli
@@ -3,7 +3,7 @@
     [masc_tool_schemas] only depends on [masc_types], so enum strings
     that must stay in sync with {!Tool_agent} (which lives higher up
     the dep tree) are hand-mirrored here. The
-    [test_types.ml :: keeper_tool_variants_ssot] regression test catches
+    [test_agent_card_action_mirror] catches
     drift between the two sides.
 
     Issues: #8501 (mirror pattern), #8372 (agent_status enum derivation),

--- a/lib/tool_schemas/tool_schemas_misc.ml
+++ b/lib/tool_schemas/tool_schemas_misc.ml
@@ -2,14 +2,6 @@
 
 open Masc_domain
 
-(** Issue #8592: hand-mirrored from [Dashboard.valid_scope_strings].
-    Cycle constraint — Tool_schemas_misc is upstream of Dashboard.
-    The test [test_types.ml :: dashboard_scope_ssot] asserts this
-    mirror stays in sync with the SSOT so adding a 3rd scope
-    constructor fails compilation in [scope_to_string] AND fails the
-    test here, instead of silently dropping from the JSON Schema. *)
-let dashboard_scope_enum_strings = [ "all"; "current" ]
-
 type control_operation =
   | Pause
   | Resume

--- a/lib/tool_schemas/tool_schemas_misc.mli
+++ b/lib/tool_schemas/tool_schemas_misc.mli
@@ -5,11 +5,7 @@
     lists.  Adding / removing values requires synchronized
     updates at the SSOT (which lives in a downstream module
     that cannot be referenced here without re-introducing the
-    cycle).  A test invariant keeps the mirror aligned:
-
-    - [test_types.ml :: dashboard_scope_ssot] —
-      {!dashboard_scope_enum_strings} vs
-      [Dashboard.valid_scope_strings]
+    cycle).
 
     The [masc_config] category enum SSOT lives in
     [Tool_schemas_specs_types.config_category_enum_strings]
@@ -18,15 +14,6 @@
     [Env_config_snapshot.valid_config_category_strings]. *)
 
 (** {1 Enum string mirrors (SSOT)} *)
-
-val dashboard_scope_enum_strings : string list
-(** Mirror of [Dashboard.valid_scope_strings] (issue #8592).
-    Currently [\["all"; "current"\]] — adding a 3rd scope
-    constructor must fail [scope_to_string] compilation AND
-    the [dashboard_scope_ssot] test, instead of silently
-    dropping from the JSON Schema.  Hand-mirrored because
-    [Tool_schemas_misc] is upstream of [Dashboard] in the
-    dependency graph. *)
 
 (** {1 Tool schema list} *)
 

--- a/test/dune
+++ b/test/dune
@@ -1957,6 +1957,8 @@
 
 (include stanzas/test_assertion_kind_mirror.inc)
 
+(include stanzas/test_agent_card_action_mirror.inc)
+
 (include stanzas/test_workspace_heartbeat_outcome.inc)
 
 (include stanzas/test_keeper_approval_resolved_history.inc)
@@ -2562,4 +2564,3 @@
   (source_tree %{workspace_root}/config/prompts)
   %{workspace_root}/test/fixtures/keeper_system_prompt/assembled_prompt.golden)
  (libraries alcotest masc_test_deps))
-

--- a/test/stanzas/test_agent_card_action_mirror.inc
+++ b/test/stanzas/test_agent_card_action_mirror.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_agent_card_action_mirror)
+ (modules test_agent_card_action_mirror)
+ (libraries alcotest masc masc_test_deps masc.tool_schemas))

--- a/test/test_agent_card_action_mirror.ml
+++ b/test/test_agent_card_action_mirror.ml
@@ -1,0 +1,80 @@
+(** The agent-card action mirror, compared against its owner.
+
+    [Tool_schemas_agent] cannot depend on [Tool_agent] — masc_tool_schemas
+    only links masc_types — so it hand-copies the action vocabulary:
+
+      let agent_card_action_enum_strings = [ "get"; "refresh" ]
+
+    Its header says a sync regression test named
+    [test_types.ml :: keeper_tool_variants_ssot] catches drift. There is no
+    test_types.ml. Adding a third action breaks compilation in
+    [agent_card_action_to_string], which forces the owner's list to grow, and
+    then nothing makes the copy grow with it — the tool schema would keep
+    advertising two while the handler accepted three.
+
+    The copy is private to its library, so this compares the observable end:
+    the [enum] array in the published [masc_agent_card] schema against
+    [Tool_agent.valid_agent_card_action_strings]. *)
+
+open Alcotest
+
+(* Every enum array anywhere in a schema, at any nesting depth. *)
+let rec enum_arrays (json : Yojson.Safe.t) : string list list =
+  match json with
+  | `Assoc fields ->
+    List.concat_map
+      (fun (key, value) ->
+        match key, value with
+        | "enum", `List items ->
+          let strings =
+            List.filter_map (function `String s -> Some s | _ -> None) items
+          in
+          if strings = [] then [] else [ strings ]
+        | _ -> enum_arrays value)
+      fields
+  | `List items -> List.concat_map enum_arrays items
+  | _ -> []
+;;
+
+let agent_card_schema () =
+  match
+    List.find_opt
+      (fun (t : Masc_domain.tool_schema) -> String.equal t.name "masc_agent_card")
+      Tool_schemas_agent.schemas
+  with
+  | Some schema -> schema
+  | None -> failf "masc_agent_card is not among Tool_schemas_agent.schemas"
+;;
+
+let owner = Masc.Tool_agent.valid_agent_card_action_strings
+
+(* A guard that finds no enum passes for the wrong reason. *)
+let test_schema_publishes_an_enum () =
+  let enums = enum_arrays (agent_card_schema ()).input_schema in
+  check bool "masc_agent_card publishes at least one enum" true (enums <> []);
+  check bool "the owner list is non-empty" true (owner <> [])
+;;
+
+let test_published_enum_matches_the_owner () =
+  let enums = enum_arrays (agent_card_schema ()).input_schema in
+  if not (List.exists (fun e -> e = owner) enums)
+  then
+    failf
+      "no enum in masc_agent_card equals Tool_agent.valid_agent_card_action_strings \
+       (%s).\n\
+       The hand-copied agent_card_action_enum_strings has drifted.\n\
+       Published enums: %s"
+      (String.concat "|" owner)
+      (String.concat "  /  " (List.map (String.concat "|") enums))
+;;
+
+let () =
+  Alcotest.run
+    "Agent card action mirror"
+    [ ( "mirror"
+      , [ test_case "the schema publishes an enum" `Quick test_schema_publishes_an_enum
+        ; test_case "the published enum matches the owner" `Quick
+            test_published_enum_matches_the_owner
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 문제

`tool_schemas` 의 손 복사 enum 두 개가 모두 존재하지 않는 sync 테스트를 인용한다. 확인해보니 **둘의 상태가 정반대**였다.

### 1. `dashboard_scope_enum_strings` — 아무도 안 쓴다

`.mli` 주장:

> A test invariant keeps the mirror aligned: `[test_types.ml :: dashboard_scope_ssot]` — `{!dashboard_scope_enum_strings}` vs `[Dashboard.valid_scope_strings]`

`test_types.ml` 은 없고, **이 미러를 읽는 코드도 없다.**

| 위치 | 상태 |
|---|---|
| `tool_schemas_misc.ml:11` | 정의 |
| `tool_schemas_misc.mli` | `val` + docstring |
| `dashboard.ml:67` | docstring 언급 |
| **코드 소비자** | **0** |

같은 어휘의 실제 사용처는 `bin/gen_tool_descriptors.ml:61` 의 **또 다른 리터럴 복사본**이다. 그 실행 파일은 `masc.tool_schemas_specs` 만 링크해서 `Dashboard` 에 닿을 수 없다 — 그래서 자기 사본을 쓴다.

즉 이 미러는 **아무것도 위해 유지되고 있지 않았고, 아무것도 지키지 않았다.** `val` 과 정의를 지우고 빌드가 녹색인 것이 증명이다.

### 2. `agent_card_action_enum_strings` — 진짜 쓰인다

`tool_schemas_agent.ml:66` 이 `masc_agent_card` 의 action enum 으로 발행한다. 소유자는 `Tool_agent.valid_agent_card_action_strings` 다.

세 번째 action 을 추가하면 `agent_card_action_to_string` 컴파일이 깨져 **소유자 목록은 늘어난다.** 그 뒤 복사본을 늘리게 만드는 것은 없다 — 스키마는 둘을 광고하는데 핸들러는 셋을 받는 상태가 된다.

## 수정

- 미사용 미러 제거
- 사용되는 미러에 `test_agent_card_action_mirror` 작성 — 발행된 enum 을 소유자 목록과 대조
- 두 docstring 이 실재하는 것을 가리키도록 정정

## 가드 확인

소유자 목록을 확장해봤다.

```
> [FAIL] mirror 1 the published enum matches the owner
```

되돌린 뒤 2/2 통과한다. 미러가 비어 통과하지 않도록, 첫 케이스가 스키마에 enum 이 실제로 있고 소유자 목록이 비어있지 않은지 먼저 확인한다.

## 남긴 것

`bin/gen_tool_descriptors.ml` 의 리터럴 사본과 `Dashboard.valid_scope_strings` 사이의 중복은 그대로다. 닫으려면 그 생성기에 `masc` 의존을 주어야 하고, 그건 이 PR 보다 큰 판단이다.

## 검증

- `dune build --root . @check` EXIT=0
- `test_agent_card_action_mirror` 2/2
- `scripts/check-doc-code-refs.sh`, `scripts/audit-keeper-tool-boundary-matrix.sh` PASS

RFC-WAIVED: 소비자 0 인 미러 제거 + 실제 미러에 가드 작성 + 유령 테스트 인용 정정. 발행되는 스키마 enum 값은 불변. credential/identity, repo_manager, operator control plane, keeper sandbox, dashboard credential component, hooks, workflow 문서 어느 것도 건드리지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
