### PR TITLE
test(schemas): docstring 이 지켜진다던 assertion-kind 미러에 실제 가드 작성

### DIFF
--- a/lib/tool_schemas/tool_schemas_workspace_core.ml
+++ b/lib/tool_schemas/tool_schemas_workspace_core.ml
@@ -10,10 +10,9 @@ open Masc_domain
     [Tool_workspace.valid_assertion_strings]. Cycle constraint —
     [Tool_schemas_workspace_core] is upstream of [Tool_workspace] (the schema
     library lives in [masc_tool_schemas], the handler is in [masc]).
-    The test [test_types.ml :: assertion_kind_ssot] asserts this mirror
-    stays in sync with the SSOT so adding a 6th assertion kind fails
-    compilation in [assertion_kind_to_string] AND fails the test here,
-    instead of silently dropping from the JSON Schema. *)
+    [test_assertion_kind_mirror] compares the enum [masc_check] publishes
+    against the owner's list, so a kind that grows on one side and not the
+    other fails there instead of silently dropping from the JSON Schema. *)
 let assertion_kind_enum_strings =
   [ "task_claimed"; "current_task_set" ]
 

--- a/lib/tool_schemas/tool_schemas_workspace_core.mli
+++ b/lib/tool_schemas/tool_schemas_workspace_core.mli
@@ -7,7 +7,7 @@
 
     Issue #8636: [assertion_kind_enum_strings] hand-mirrors
     {!Tool_workspace.valid_assertion_strings}; the sync regression test
-    [test_types.ml :: assertion_kind_ssot] catches drift. *)
+    [test_assertion_kind_mirror] catches drift. *)
 
 (** Enum of valid [masc_check] assertion strings. *)
 val assertion_kind_enum_strings : string list

--- a/test/dune
+++ b/test/dune
@@ -1948,6 +1948,8 @@
 
 (include stanzas/test_keeper_approval_queue.inc)
 
+(include stanzas/test_assertion_kind_mirror.inc)
+
 (include stanzas/test_workspace_heartbeat_outcome.inc)
 
 (include stanzas/test_keeper_approval_resolved_history.inc)

--- a/test/stanzas/test_assertion_kind_mirror.inc
+++ b/test/stanzas/test_assertion_kind_mirror.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_assertion_kind_mirror)
+ (modules test_assertion_kind_mirror)
+ (libraries alcotest masc masc_test_deps masc.tool_schemas))

--- a/test/test_assertion_kind_mirror.ml
+++ b/test/test_assertion_kind_mirror.ml
@@ -1,0 +1,94 @@
+(** The assertion-kind mirror, compared against its owner.
+
+    [Tool_schemas_workspace_core] lives in masc_tool_schemas and the handler
+    lives in masc, so the schema library cannot reach the owner and hand-copies
+    the vocabulary:
+
+      let assertion_kind_enum_strings = [ "task_claimed"; "current_task_set" ]
+
+    Its header says [test_types.ml :: assertion_kind_ssot] keeps that in sync.
+    There is no test_types.ml. Adding a kind breaks compilation in
+    [assertion_kind_to_string], which forces the owner's list to grow, and
+    nothing then makes the copy grow with it — [masc_check] would keep
+    advertising the old set while the handler accepted the new one.
+
+    The copy is a plain list in another library, so this compares the
+    observable end: the [enum] array [masc_check] publishes, against
+    [Workspace_assertions.valid_assertion_strings]. *)
+
+open Alcotest
+
+(* Every enum array anywhere in a schema, at any nesting depth. The assertion
+   enum sits under items of an array property, not at the top level. *)
+let rec enum_arrays (json : Yojson.Safe.t) : string list list =
+  match json with
+  | `Assoc fields ->
+    List.concat_map
+      (fun (key, value) ->
+        match key, value with
+        | "enum", `List items ->
+          let strings =
+            List.filter_map (function `String s -> Some s | _ -> None) items
+          in
+          if strings = [] then [] else [ strings ]
+        | _ -> enum_arrays value)
+      fields
+  | `List items -> List.concat_map enum_arrays items
+  | _ -> []
+;;
+
+let check_schema () =
+  match
+    List.find_opt
+      (fun (t : Masc_domain.tool_schema) -> String.equal t.name "masc_check")
+      Tool_schemas_workspace_core.schemas
+  with
+  | Some schema -> schema
+  | None -> failf "masc_check is not among Tool_schemas_workspace_core.schemas"
+;;
+
+let owner = Masc.Workspace_assertions.valid_assertion_strings
+
+(* A guard that finds no enum passes for the wrong reason. *)
+let test_schema_publishes_an_enum () =
+  let enums = enum_arrays (check_schema ()).input_schema in
+  check bool "masc_check publishes at least one enum" true (enums <> []);
+  check bool "the owner list is non-empty" true (owner <> [])
+;;
+
+let test_published_enum_matches_the_owner () =
+  let enums = enum_arrays (check_schema ()).input_schema in
+  if not (List.exists (fun e -> e = owner) enums)
+  then
+    failf
+      "no enum in masc_check equals Workspace_assertions.valid_assertion_strings \
+       (%s).\n\
+       The hand-copied assertion_kind_enum_strings has drifted.\n\
+       Published enums: %s"
+      (String.concat "|" owner)
+      (String.concat "  /  " (List.map (String.concat "|") enums))
+;;
+
+(* Every advertised kind must be one the handler's parser recognises, so a copy
+   that grows a value the handler rejects fails here too. *)
+let test_every_advertised_kind_parses () =
+  List.iter
+    (fun kind ->
+      match Masc.Workspace_assertions.assertion_kind_of_string_lenient kind with
+      | Some _ -> ()
+      | None -> failf "advertised assertion %S is not one the handler accepts" kind)
+    owner
+;;
+
+let () =
+  Alcotest.run
+    "Assertion kind mirror"
+    [ ( "mirror"
+      , [ test_case "the schema publishes an enum" `Quick test_schema_publishes_an_enum
+        ; test_case "the published enum matches the owner" `Quick
+            test_published_enum_matches_the_owner
+        ; test_case "every advertised kind parses" `Quick
+            test_every_advertised_kind_parses
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 문제

`Tool_schemas_workspace_core` 는 `masc_tool_schemas` 에 있고 핸들러는 `masc` 에 있어서, 스키마 라이브러리가 assertion 어휘를 **손으로 복사**한다.

```ocaml
let assertion_kind_enum_strings = [ "task_claimed"; "current_task_set" ]
```

헤더가 이렇게 말한다.

> The test `[test_types.ml :: assertion_kind_ssot]` asserts this mirror stays in sync with the SSOT so adding a **6th** assertion kind fails compilation in `[assertion_kind_to_string]` AND fails the test here.

두 가지가 어긋나 있다.

1. **`test_types.ml` 은 존재하지 않는다**
2. **assertion kind 는 2개다** (`Task_claimed`, `Current_task_set`). "6번째" 라는 산문이 그것이 서술하던 어휘보다 오래 살아남았다

미러 자체는 현재 SSOT 와 일치한다. 드리프트가 있는 게 아니라, **드리프트를 막는 것이 없다.**

## 무엇이 위험한가

| | 강제되는가 |
|---|---|
| `assertion_kind_to_string` 에 arm 추가 | **예** (exhaustive match) |
| 소유자 `all_assertion_kinds` 확장 | 위 컴파일 에러가 사실상 강제 |
| **스키마 라이브러리의 복사본 확장** | **아니오** |

복사본이 뒤처지면 `masc_check` 는 옛 집합을 광고하고 핸들러는 새 값을 받는다.

## 수정

`test_assertion_kind_mirror` — `masc_check` 가 발행하는 enum 을 `Workspace_assertions.valid_assertion_strings` 와 대조하고, 광고되는 모든 kind 가 `assertion_kind_of_string_lenient` 로 파싱되는지 확인한다.

미러가 비어 통과하지 않도록, 첫 케이스가 스키마에 enum 이 실제로 있고 소유자 목록이 비어있지 않은지 먼저 본다.

## 가드 확인

소유자 목록을 확장했다.

```
> [FAIL] mirror 1 the published enum matches the owner
  [FAIL] mirror 2 every advertised kind parses
```

되돌린 뒤 3/3 통과한다.

## 검증

- `dune build --root . @check` EXIT=0
- `test_assertion_kind_mirror` 3/3
- `scripts/check-doc-code-refs.sh`, `scripts/audit-keeper-tool-boundary-matrix.sh` PASS

프로덕션 코드 변경 없음. `.ml` / `.mli` 의 docstring 이 실재하는 가드를 가리키도록 고친 것뿐이다.

## 참고

이 세션에서 같은 형태의 미러 가드를 세 곳에 썼다 — #26940 (enum mirrors 4종), #27034 (agent_card_action), 그리고 이것. 셋 다 열려 있어 서로의 파일을 건드리지 않았다. 먼저 머지되는 것을 기준으로 한 파일로 합치는 게 낫다.

RFC-WAIVED: 유령 테스트를 인용하던 자리에 실제 가드를 작성하고 낡은 산문을 정정한다. 스키마 enum 값·assertion 어휘·핸들러 동작 전부 불변. credential/identity, repo_manager, operator control plane, keeper sandbox, dashboard credential component, hooks, workflow 문서 어느 것도 건드리지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
