### PR TITLE
refactor(telemetry): 매칭되지 않는 tool_type 분기 5개 제거 (실행으로 확인)

### DIFF
--- a/lib/tool_telemetry.ml
+++ b/lib/tool_telemetry.ml
@@ -8,17 +8,21 @@ let tool_type_of_name name =
   match Tool_name.Board_name.of_string name with
   | Some _ -> "board"
   | None ->
+    (* Five arms used to sit here and none of them could match. Run over the
+       99 names [Keeper_tool_policy.keeper_model_tool_names] returns and the
+       counts are: masc_ 67, Board_name 21, grep/read/write/edit/execute 1
+       each, and mcp__masc__ / board_ / memory_ / library_ / surface_ zero.
+
+       The last three were aimed at tools that exist under different names.
+       keeper_memory_search, keeper_memory_write, keeper_library_search,
+       keeper_library_read, keeper_surface_read and keeper_surface_post all
+       carry a keeper_ prefix now, so they fall through to "other" alongside
+       WebSearch and the voice tools. Fixing the prefixes would change the
+       tool_type dimension for six tools, which is a metric contract call and
+       not made here — the arms that cannot fire are removed, the mislabelling
+       is left visible. *)
     if String.starts_with ~prefix:"masc_" name
     then "mcp"
-    else if String.starts_with ~prefix:"mcp__masc__" name
-    then "mcp"
-    else if String.starts_with ~prefix:"board_" name
-    then "board"
-    else if String.starts_with ~prefix:"memory_" name
-    then "memory"
-    else if String.starts_with ~prefix:"library_" name
-            || String.starts_with ~prefix:"surface_" name
-    then "read"
     else if name = "grep"
     then "read"
     else if String.starts_with ~prefix:"read" name

--- a/test/dune
+++ b/test/dune
@@ -1948,6 +1948,8 @@
 
 (include stanzas/test_keeper_approval_queue.inc)
 
+(include stanzas/test_tool_type_label.inc)
+
 (include stanzas/test_assertion_kind_mirror.inc)
 
 (include stanzas/test_workspace_heartbeat_outcome.inc)

--- a/test/stanzas/test_tool_type_label.inc
+++ b/test/stanzas/test_tool_type_label.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_tool_type_label)
+ (modules test_tool_type_label)
+ (libraries alcotest masc masc_test_deps))

--- a/test/test_tool_type_label.ml
+++ b/test/test_tool_type_label.ml
@@ -1,0 +1,101 @@
+(** Which tool_type labels the real tool surface actually produces.
+
+    [tool_type_of_name] carried five arms that could not match anything
+    [Keeper_tool_policy.keeper_model_tool_names] returns: the [mcp__masc__],
+    [board_], [memory_], [library_] and [surface_] prefixes. Counting matches
+    over those 99 names gives masc_ 67, Board_name 21, and one each for grep,
+    read, write, edit and execute.
+
+    The last three arms were aimed at tools that exist under other names.
+    keeper_memory_search, keeper_memory_write, keeper_library_search,
+    keeper_library_read, keeper_surface_read and keeper_surface_post carry a
+    keeper_ prefix, so they land in "other". These cases pin that as the
+    current answer rather than leaving it to be rediscovered — changing it
+    moves six tools to a different metric dimension value. *)
+
+open Alcotest
+
+module T = Masc.Tool_telemetry
+
+let keeper_tools () = Masc.Keeper_tool_policy.keeper_model_tool_names ()
+
+(* A guard over an empty surface passes by testing nothing. *)
+let test_surface_is_populated () =
+  let names = keeper_tools () in
+  check bool "the keeper tool surface is non-empty" true (names <> []);
+  check bool "and includes a board tool" true
+    (List.exists (fun n -> n = "masc_board_post") names)
+;;
+
+let label_counts names =
+  let tbl = Hashtbl.create 8 in
+  List.iter
+    (fun n ->
+      let l = T.tool_type_of_name n in
+      Hashtbl.replace tbl l (1 + Option.value ~default:0 (Hashtbl.find_opt tbl l)))
+    names;
+  tbl
+;;
+
+(* No name on the surface earns these; the arms that produced them are gone. *)
+let test_no_surface_tool_is_labelled_memory () =
+  let counts = label_counts (keeper_tools ()) in
+  check (option int) "memory is not produced" None (Hashtbl.find_opt counts "memory")
+;;
+
+let test_board_and_mcp_are_produced () =
+  let counts = label_counts (keeper_tools ()) in
+  List.iter
+    (fun label ->
+      match Hashtbl.find_opt counts label with
+      | Some n when n > 0 -> ()
+      | _ -> failf "%s is no longer produced by any tool on the surface" label)
+    [ "mcp"; "board" ]
+;;
+
+(* Board tools must keep their own label: the Board_name test runs before the
+   masc_ prefix, and losing that order would relabel 21 tools as mcp. *)
+let test_board_tools_are_not_labelled_mcp () =
+  check string "masc_board_post" "board" (T.tool_type_of_name "masc_board_post");
+  check string "masc_board_list" "board" (T.tool_type_of_name "masc_board_list")
+;;
+
+(* The six the removed arms were aiming at. This is the mislabelling, pinned. *)
+let test_keeper_prefixed_tools_fall_to_other () =
+  List.iter
+    (fun name -> check string name "other" (T.tool_type_of_name name))
+    [ "keeper_memory_search"
+    ; "keeper_memory_write"
+    ; "keeper_library_search"
+    ; "keeper_library_read"
+    ; "keeper_surface_read"
+    ; "keeper_surface_post"
+    ]
+;;
+
+let test_external_tool_names_keep_their_labels () =
+  List.iter
+    (fun (name, expected) -> check string name expected (T.tool_type_of_name name))
+    [ "Grep", "read"; "Read", "read"; "Write", "write"; "Edit", "write"
+    ; "Execute", "execute"; "WebSearch", "other"
+    ]
+;;
+
+let () =
+  Alcotest.run
+    "Tool type label"
+    [ ( "surface"
+      , [ test_case "is populated" `Quick test_surface_is_populated
+        ; test_case "produces mcp and board" `Quick test_board_and_mcp_are_produced
+        ; test_case "produces no memory label" `Quick
+            test_no_surface_tool_is_labelled_memory
+        ] )
+    ; ( "labels"
+      , [ test_case "board tools are not mcp" `Quick test_board_tools_are_not_labelled_mcp
+        ; test_case "keeper-prefixed tools fall to other" `Quick
+            test_keeper_prefixed_tools_fall_to_other
+        ; test_case "external tool names keep their labels" `Quick
+            test_external_tool_names_keep_their_labels
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 방법

지난 두 회차에 정규식으로 어휘를 뽑아 런타임 값이라 가정했다가 두 번 오판했다 (`include` 를 못 봄, `to_string` 이 접두사를 붙이는 걸 못 봄). 이번에는 **실제 함수를 실행**했다.

`Keeper_tool_policy.keeper_model_tool_names ()` 가 돌려주는 99개 이름에 `tool_type_of_name` 을 돌린 결과:

| 분기 | 매칭 |
|---|---|
| `Board_name.of_string` | 21 |
| `masc_` | 67 |
| `grep` / `read` / `write` / `edit` / `execute` | 각 1 |
| `mcp__masc__` | **0** |
| `board_` | **0** |
| `memory_` | **0** |
| `library_` | **0** |
| `surface_` | **0** |

## 발견

다섯 분기가 도달 불가고, 그중 셋이 노리던 도구는 **존재하는데 이름이 다르다.**

`"other"` 로 떨어지는 27개 안에 이것들이 있다.

```
keeper_memory_search   keeper_memory_write
keeper_library_search  keeper_library_read
keeper_surface_read    keeper_surface_post
```

분기는 `memory_` / `library_` / `surface_` 를 보는데 도구는 `keeper_` 접두사를 달고 있다. **이름이 바뀌었고 분류기가 따라가지 않았다.** 그래서 이 여섯은 WebSearch·voice 도구와 같은 `"other"` 버킷에 들어간다.

## 수정

발화할 수 없는 다섯 분기를 제거한다. **접두사는 고치지 않는다** — 고치면 여섯 도구의 `tool_type` 메트릭 차원 값이 바뀌고, 그건 대시보드/알럿이 걸려 있을 수 있는 계약이라 별도 판단이다. 주석과 테스트가 오늘의 라벨을 기록해서 그 판단이 증거를 갖게 한다.

**`Board_name` 검사가 `masc_` 앞에 있는 건 장식이 아니다.** `masc_board_post` 는 둘 다 매칭하므로 순서를 잃으면 21개가 `mcp` 로 재라벨된다. 테스트가 그걸 잡는다.

## 가드 확인

`Board_name` 분기를 무력화했다.

```
> [FAIL] surface 1 produces mcp and board
  [FAIL] labels  0 board tools are not mcp
```

되돌린 뒤 6/6 통과한다. 표면이 비면 통과하는 가드가 되지 않도록, 첫 케이스가 도구 목록이 비어있지 않고 `masc_board_post` 를 포함하는지 먼저 확인한다.

## 검증

- `dune build --root . @check` EXIT=0
- `test_tool_type_label` 6/6, `test_keeper_tool_duration_buckets` OK
- `scripts/check-doc-code-refs.sh`, `scripts/audit-keeper-tool-boundary-matrix.sh` PASS

**라벨 값은 하나도 바뀌지 않는다** — 제거된 분기는 발화한 적이 없다.

RFC-WAIVED: 매칭되지 않는 분류기 분기 제거와 회귀 가드 작성. 발행되는 `tool_type` 값 불변. credential/identity, repo_manager, operator control plane, keeper sandbox, dashboard credential component, hooks, workflow 문서 어느 것도 건드리지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
