### PR TITLE
fix(dashboard): overview 도메인 카드가 지어낸 '없음' 을 없앤다 (목표 · 보드)

### DIFF
--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -29,7 +29,7 @@ import type {
   TelemetryEntry,
   TelemetrySourceSummary,
 } from '../../api/dashboard'
-import { keepers } from '../../store'
+import { keepers, boardPosts, boardTotal, lastBoardRefreshAt } from '../../store'
 import type { Goal } from '../../types/core'
 
 const overviewMocks = vi.hoisted(() => ({
@@ -1206,5 +1206,66 @@ describe('Overview prototype surface', () => {
     } finally {
       keepers.value = previousKeepers
     }
+  })
+})
+
+// The overview route subscribes to GLOBAL + `execution` slices only and never
+// calls refreshBoard, so `boardPosts` is empty on every fresh load of #overview.
+// The card used to render that empty length as "전체 포스트 0" while #board and
+// the post store both held posts, so an operator reading the home screen saw a
+// fabricated zero rather than "not loaded".
+describe('Overview board domain card', () => {
+  afterEach(() => {
+    cleanup()
+    boardPosts.value = []
+    boardTotal.value = null
+    lastBoardRefreshAt.value = null
+  })
+
+  function boardCardText(container: Element): string {
+    return container.querySelector('[data-testid="domain-board"] .ov-dcard-body')?.textContent?.trim() ?? ''
+  }
+
+  it('reports not-loaded instead of 0 when the board store was never hydrated', () => {
+    boardPosts.value = []
+    boardTotal.value = null
+    lastBoardRefreshAt.value = null
+
+    const { container } = render(h(Overview, null))
+    const body = container.querySelector('[data-testid="domain-board"] .ov-dcard-body')
+
+    expect(body?.querySelector('.ov-empty')).not.toBeNull()
+    expect(boardCardText(container)).not.toContain('0')
+    expect(container.querySelector('[data-testid="domain-board"] .ov-stat-row')).toBeNull()
+  })
+
+  it('labels the loaded rows as loaded, not total, while the server pages the result', () => {
+    boardPosts.value = [
+      { id: 'p-1', author: 'a', title: 't1', content: 'c1', created_at: '2026-08-05T00:00:00Z' },
+      { id: 'p-2', author: 'b', title: 't2', content: 'c2', created_at: '2026-08-05T00:00:01Z' },
+    ] as unknown as typeof boardPosts.value
+    boardTotal.value = null
+    lastBoardRefreshAt.value = '2026-08-05T00:00:02Z'
+
+    const { container } = render(h(Overview, null))
+    const text = boardCardText(container)
+
+    expect(text).toContain('불러온 포스트')
+    expect(text).toContain('2')
+    expect(text).not.toContain('전체 포스트')
+  })
+
+  it('shows the server total when the response carried one', () => {
+    boardPosts.value = [
+      { id: 'p-1', author: 'a', title: 't1', content: 'c1', created_at: '2026-08-05T00:00:00Z' },
+    ] as unknown as typeof boardPosts.value
+    boardTotal.value = 441
+    lastBoardRefreshAt.value = '2026-08-05T00:00:02Z'
+
+    const { container } = render(h(Overview, null))
+    const text = boardCardText(container)
+
+    expect(text).toContain('전체 포스트')
+    expect(text).toContain('441')
   })
 })

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -19,7 +19,7 @@ import { html } from 'htm/preact'
 import { useEffect, useMemo } from 'preact/hooks'
 import { AgentAvatar } from './agent-avatar'
 import { SCHED_TERMINAL_NORMALIZED } from '../v2/schedule-constants'
-import { tasks, keepers, boardPosts, goals, fusionRuns } from '../../store'
+import { tasks, keepers, boardPosts, boardTotal, lastBoardRefreshAt, goals, fusionRuns } from '../../store'
 import type { Agent, Task, Keeper, Message, BoardPost, Goal, KeeperRuntimeBlockerClass } from '../../types/core'
 import type {
   DashboardScheduledAutomation,
@@ -1426,9 +1426,23 @@ function OverviewDomainSection({
         </div>
       <//>
 
-      <!-- BOARD · overview.jsx:233-237 -->
+      <!-- BOARD · overview.jsx:233-237
+           The overview route subscribes to the GLOBAL + execution slices only
+           (dashboardSlicesForRoute in dashboard-ws.ts) and never calls
+           refreshBoard, so boardPosts is empty here on every fresh load.
+           Rendering its length printed "전체 포스트 0" while the board route
+           and the post store both held posts. lastBoardRefreshAt stays null
+           until refreshBoard or hydrateBoardSnapshot runs, so it separates
+           "never loaded" from "loaded and empty". boardTotal is null whenever
+           the server pages the result (server_dashboard_http.ml emits total
+           only when the whole result fits the fetched window), so the
+           loaded-rows count is labelled as such instead of as a total. -->
       <${DomainCard} title="보드" linkLabel="보드" nav=${{ tab: 'board' }} testId="domain-board">
-        <div class="ov-stat-row"><span class="k">전체 포스트</span><span class="v mono">${boardPosts.value.length}</span></div>
+        ${lastBoardRefreshAt.value === null
+          ? html`<div class="ov-mini-list"><div class="ov-mini-empty ov-empty">보드 데이터 미연결</div></div>`
+          : boardTotal.value !== null
+            ? html`<div class="ov-stat-row"><span class="k">전체 포스트</span><span class="v mono">${boardTotal.value}</span></div>`
+            : html`<div class="ov-stat-row"><span class="k">불러온 포스트</span><span class="v mono">${boardPosts.value.length}</span></div>`}
       <//>
 
       <!-- CONNECTORS · overview.jsx:240-249 (no live connector store yet) -->

--- a/dashboard/src/tab-refresh.test.ts
+++ b/dashboard/src/tab-refresh.test.ts
@@ -58,7 +58,17 @@ describe('refreshPlanForRoute', () => {
     expect(refreshPlanForRoute({
       tab: 'overview',
       params: {},
-    })).toEqual(['shell', 'namespaceTruth', 'missionSnapshot', 'execution'])
+    })).toEqual(['shell', 'namespaceTruth', 'missionSnapshot', 'execution', 'goals'])
+  })
+
+  // The overview 작업·목표 card reads the flat `goals` signal. Only the `goals`
+  // refresher populates it, so leaving it out of the overview plan made a fresh
+  // #overview load print "활성 목표 없음" against a live 15-goal planning store.
+  it('includes the goals refresher so the overview goal card has a source', () => {
+    expect(refreshPlanForRoute({
+      tab: 'overview',
+      params: {},
+    })).toContain('goals')
   })
 
   it('hydrates the top-level keepers workspace from live execution state', () => {

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -67,7 +67,12 @@ const HIDDEN_DIAGNOSTIC_FALLBACK_PLAN: readonly RefreshTask[] = ['namespaceTruth
 export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params'>): RefreshTask[] {
   switch (routeState.tab) {
     case 'overview':
-      return ['shell', 'namespaceTruth', 'missionSnapshot', 'execution']
+      // The overview 작업·목표 card renders the flat `goals` signal, which only
+      // the `goals` (planning fetch) refresher populates — the same gap the
+      // `workspace` branch below already documents. Without it a fresh
+      // #overview load printed "활성 목표 없음" while masc_goal_list returned
+      // 15 goals with executing phases.
+      return ['shell', 'namespaceTruth', 'missionSnapshot', 'execution', 'goals']
     case 'keepers':
       // 'activeKeeperChat' re-hydrates the open conversation panel's transcript
       // (guard-respecting no-op when already loaded). It matters on SSE


### PR DESCRIPTION
## 문제

`#overview` 홈의 "도메인 현황" 카드 2개가 데이터가 있는데도 없다고 렌더한다.

라이브 실측 — `#overview` 하드 리로드 후 8초(“Server data warming” 배너 해제 후) 시점 DOM:

```
domain-work    = 활성 목표 없음
domain-board   = 전체 포스트0
domain-schedule= 예약 자동화 projection 미연결 / runner: ok / tick 86 ...
domain-fleet   = 6실행 2주의 2압박 8전체
```

같은 시각 서버 실측:

| 소스 | 값 |
|---|---|
| `masc_goal_list` | **15 goals** (`goal-backlog-kidsnote-zero` 등 phase=executing 포함) |
| `#board` 피드 | 108 |
| `~/me/.masc/board_posts.jsonl` 고유 id | 441 |

## 원인

### (1) 목표 카드 — refresh plan 누락

`refreshPlanForRoute`(`dashboard/src/tab-refresh.ts`)의 overview 분기가
`['shell', 'namespaceTruth', 'missionSnapshot', 'execution']` 였다. `goals` 시그널을 채우는 유일한
refresher 는 `goals`(planning fetch) 인데 목록에 없다. 그래서 이 라우트에서 `goals` 는 계속 `[]` 다.

같은 파일의 `workspace` 분기가 **이미 동일한 결함을 문서화하고 고쳐 놓았다**:

> Before this branch, landing on the default Work board returned [] and left both signals empty, so the
> board showed 0 goals / 0 jobs even though live planning/execution data existed.

overview 에 같은 한 줄을 적용한다.

### (2) 보드 카드 — 없는 데이터를 0 으로 위장

overview 라우트는 board 슬라이스를 구독하지 않고(`dashboardSlicesForRoute`, `dashboard-ws.ts:398-420`,
같은 파일 주석: "there is no unscoped board slice subscription") `refreshBoard()` 도 호출하지 않는다.
네트워크 로그 실측: 하드 리로드 시 요청은 `/api/v1/dashboard/runtime-probe` 1건뿐.

따라서 `boardPosts` 는 사용자가 같은 SPA 세션에서 `#board` 를 방문하기 전까지 `[]` 이고, 카드는 그
길이를 "전체 포스트" 라벨과 함께 `0` 으로 출력했다. (`#board` 를 한 번 방문하면 store 가 남아 108 로
바뀐다 — 즉 "홈만 본 사용자"에게만 거짓말한다.)

두 번째 층: 로드된 뒤에도 `boardPosts.value.length` 는 총계가 아니다. `server_dashboard_http.ml:127` 이
페이징된 응답에서 `total` 을 `null` 로 낸다 (`fetched_len` 은 `offset+limit+1` 로 캡된 값 — `has_more` 를
두 번째 쿼리 없이 답하려는 의도된 설계). 그러므로 `.length` 를 "전체 포스트" 라고 부르는 것 자체가 거짓이다.

보드는 fetch 를 붙이지 않는다. `/api/v1/dashboard/board` 는 서버 주석 기준 hot fleet 에서 30-44s 로
측정된 경로이고, 홈 화면이 카운트 하나 때문에 그 비용을 낼 이유가 없다. 대신 미로드 상태를 정직하게
표시한다 — 같은 그리드의 예약/커넥터 카드가 이미 쓰는 표현이다.

## 변경

`tab-refresh.ts` — overview plan 에 `'goals'` 추가 (1줄).

`overview.ts` 보드 카드 — 한 곳:
- `lastBoardRefreshAt === null` → `보드 데이터 미연결`
- `boardTotal !== null` → `전체 포스트 <total>`
- 그 외 → `불러온 포스트 <length>`

게이트/제약 추가 없음. 새 API 없음. 새 파생 상태 없음 — `boardTotal` / `lastBoardRefreshAt` 는 이미
store 에 있던 시그널이고 읽기만 한다.

## 검증

```
dashboard $ node_modules/.bin/vitest run src/tab-refresh.test.ts src/components/overview/overview.test.ts
  Test Files  2 passed (2)
  Tests  119 passed (119)

dashboard $ node_modules/.bin/tsc --noEmit    # 0 errors
dashboard $ node_modules/.bin/eslint src      # clean
```

Negative control — 각 변경을 되돌리고 신규 테스트 재실행:

보드 카드 (3건 전부 실패):
```
× reports not-loaded instead of 0 when the board store was never hydrated
    AssertionError: expected null not to be null
× labels the loaded rows as loaded, not total, while the server pages the result
    AssertionError: expected '전체 포스트2' to contain '불러온 포스트'
× shows the server total when the response carried one
    AssertionError: expected '전체 포스트1' to contain '441'
```

목표 refresh plan (2건 실패):
```
× hydrates overview from project snapshot and mission snapshot
    AssertionError: expected [ 'shell', 'namespaceTruth', …(2) ] to deeply equal [ …(3) ]
× includes the goals refresher so the overview goal card has a source
    AssertionError: expected [ 'shell', 'namespaceTruth', …(2) ] to include 'goals'
```

보드 세 번째 실패가 (2) 의 두 번째 층을 직접 보여준다: 서버가 441 을 줬는데도 수정 전 코드는 로드된
행 수 1 을 "전체 포스트" 로 출력했다.

## 미검증

- `#board` 헤더 "108개 포스트" 와 서브보드 카운트(전체 188 / verification 333) 와 디스크 441 이 서로
  어긋나는 문제는 이 PR 범위 밖. 각각 스코프/필터가 다른지 별도 확인 필요.
- `domain-connectors` 의 "커넥터 데이터 미연결" 은 그대로 둔다 — 실제로 live connector store 가 없다
  (`overview.ts` 주석 "no live connector store yet"). 데이터가 없는 것과 있는데 못 읽는 것은 다르다.

RFC-WAIVED: `dashboard/src/components/overview/`, `dashboard/src/tab-refresh.ts` 는
`pr-rfc-check.sh` 의 RFC 요구 subsystem (credential / identity / operator control plane /
keeper sandbox / dashboard credential component / hooks / workflow 문서) 에 해당하지 않는다.
