### PR TITLE
docs: stop citing RFC files that do not exist

### DIFF
--- a/dashboard/design-system/RFC/0022-ide-plane-assembly.md
+++ b/dashboard/design-system/RFC/0022-ide-plane-assembly.md
@@ -13,7 +13,6 @@
   - RFC 0020 (Layered Overlay System — LAYERS toggle framework)
   - RFC 0021 (Anchored Thread Rail — CONVERSATION rail data model)
 - **Blocks**: RFC 0023, 0025, 0026 (모두 본 RFC 의 application)
-- **Sister RFC**: repo `docs/rfc/RFC-0033-worktree-status-sse.md` (server side)
 - **SSOT audit**: `dashboard/design-system/audits/2026-04-30-ide-mockup-vs-v0.4-mapping.md`
 - **GitHub Issues**: #13197 (P0-A) · #13198 (P0-B) · #13199 (P1-A) · #13200 (P1-B) · #13201 (P2)
 

--- a/docs/TRACK1-MULTIAGENT-IDE-MVP.md
+++ b/docs/TRACK1-MULTIAGENT-IDE-MVP.md
@@ -30,8 +30,6 @@ ids, keeper slots, board semantics, or branch-visualization policy.
 
 ## Layer Model
 
-Track 1 follows `docs/rfc/RFC-0017-ocaml-crdt-boundary.md`.
-
 | Layer | Writer | Dashboard contract |
 |-------|--------|--------------------|
 | Authority | OCaml runtime | Existing RPC/REST/CAS transitions only |

--- a/docs/observability/dashboard-surface-metrics.md
+++ b/docs/observability/dashboard-surface-metrics.md
@@ -63,7 +63,6 @@ redirect sources, neither of which is in flight.
 ## Related
 
 - RFC-0049 — `docs/rfc/RFC-0049-surface-telemetry-foundation.md`
-- RFC-0048 — `docs/rfc/RFC-0048-dashboard-ia-phase-2.md` (primary consumer)
 - PR-1 #14245 — telemetry foundation
 - PR-1.1 #14251 — ocamlformat follow-up
 - RFC-0217 — single OTel backend; local scrape reports removed

--- a/scripts/lint/dashboard-ssot-agent-status.sh
+++ b/scripts/lint/dashboard-ssot-agent-status.sh
@@ -10,10 +10,15 @@
 # in-tree count of qualifying literal compares is zero — new
 # regressions are caught at lint time instead of audit time.
 #
-# Reference RFC: docs/rfc/RFC-0139-dashboard-agent-status-ssot.md
+# Reference RFC: docs/rfc/RFC-0139-agent-status-vocabulary-ssot.md
+# That RFC is Withdrawn, and what it withdrew is the proposal to keep a
+# second status vocabulary in the dashboard. The rule this guard enforces
+# is the one the withdrawal states positively: the dashboard may project
+# typed source facts but must not infer lifecycle from presentation
+# labels. The guard outlives the proposal it came from.
 #
 # Signals checked:
-#   §10-1  `<bound_name>.status === '<literal>'` where the bound name
+#   S-1    `<bound_name>.status === '<literal>'` where the bound name
 #          is one of the conventional agent-shaped identifiers
 #          (`agent`, `agents`, `a`, `userAgent`, callback param) and
 #          the literal is in the closed AgentStatus union. The
@@ -40,7 +45,7 @@ fi
 
 violations=()
 
-# §10-1 — Agent.status raw literal comparison.
+# S-1 — Agent.status raw literal comparison.
 #
 # Match `<agent_identifier>.status === '<AgentStatus literal>'`. The
 # left operand identifier set is curated to the conventional names
@@ -61,7 +66,7 @@ agent_literal_compares=$(
 )
 if [[ -n "$agent_literal_compares" ]]; then
   while IFS= read -r line; do
-    [[ -n "$line" ]] && violations+=("§10-1 agent.status literal comparison:$line")
+    [[ -n "$line" ]] && violations+=("S-1 agent.status literal comparison:$line")
   done <<< "$agent_literal_compares"
 fi
 
@@ -72,7 +77,7 @@ unmatched_violations=()
 # matched (clean run) — bash treats an empty array as unbound otherwise.
 for v in "${violations[@]:-}"; do
   [[ -z "$v" ]] && continue
-  path_line=$(echo "$v" | sed -E 's/^§10-[0-9]+ [^:]+://' | cut -d: -f1,2)
+  path_line=$(echo "$v" | sed -E 's/^S-[0-9]+ [^:]+://' | cut -d: -f1,2)
   if grep -Fxq "$path_line" <<< "$allowlist_lines"; then
     continue
   fi
@@ -88,7 +93,7 @@ if [[ -n "$allowlist_lines" ]]; then
     found=0
     for v in "${violations[@]:-}"; do
       [[ -z "$v" ]] && continue
-      path_line=$(echo "$v" | sed -E 's/^§10-[0-9]+ [^:]+://' | cut -d: -f1,2)
+      path_line=$(echo "$v" | sed -E 's/^S-[0-9]+ [^:]+://' | cut -d: -f1,2)
       if [[ "$path_line" == "$entry" ]]; then
         found=1
         break
@@ -101,7 +106,7 @@ if [[ -n "$allowlist_lines" ]]; then
 fi
 
 if (( ${#unmatched_violations[@]} > 0 )); then
-  echo "RFC-0139 §10 SSOT guard — ${#unmatched_violations[@]} new violation(s):"
+  echo "RFC-0139 SSOT guard — ${#unmatched_violations[@]} new violation(s):"
   for v in "${unmatched_violations[@]}"; do
     echo "  $v"
   done
@@ -116,7 +121,7 @@ if (( ${#unmatched_violations[@]} > 0 )); then
 fi
 
 if (( ${#stale_allowlist[@]} > 0 )); then
-  echo "RFC-0139 §10 SSOT guard — ${#stale_allowlist[@]} stale allowlist entry/entries:"
+  echo "RFC-0139 SSOT guard — ${#stale_allowlist[@]} stale allowlist entry/entries:"
   for entry in "${stale_allowlist[@]}"; do
     echo "  $entry"
   done
@@ -124,5 +129,5 @@ if (( ${#stale_allowlist[@]} > 0 )); then
 fi
 
 violations_count=${#violations[@]}
-echo "RFC-0139 §10 SSOT guard: clean (${violations_count} allowlisted violation(s))"
+echo "RFC-0139 SSOT guard: clean (${violations_count} allowlisted violation(s))"
 exit 0

--- a/scripts/silent-fallback-acknowledged.sh
+++ b/scripts/silent-fallback-acknowledged.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
-# silent-fallback-acknowledged.sh — RFC-0109 Phase 2 P0 infrastructure.
+# silent-fallback-acknowledged.sh — RFC-0126 Phase 2b staging.
 #
 # Lists every [@@silent_fallback_acknowledged "..."] attribute occurrence
 # in the OCaml codebase.  Currently 0 sites — the attribute name is
-# reserved for the Phase 2 ppxlib lint described in
-# docs/rfc/RFC-0109-silent-fallback-discipline.md §6.2.
+# reserved for the Phase 2b ppxlib lint described in
+# docs/rfc/RFC-0126-silent-fallback-discipline.md. Phase 2a landed as
+# scripts/lint/no-unknown-permissive-default.sh; 2b is not started and
+# is blocked on RFC-0106.
 #
 # Until Phase 2 is implemented, this script gives a baseline count and a
 # `rg`-style table that PR review can quote.  When Phase 2 lints, the
@@ -23,7 +25,7 @@
 #   - cannot enforce attribute *placement* on a wildcard arm.
 #
 # These limitations are intentional: a regex baseline gives operators a
-# count today without paying the ppxlib build cost.  Phase 2 supersedes.
+# count today without paying the ppxlib build cost.  Phase 2b supersedes.
 
 set -euo pipefail
 
@@ -52,4 +54,4 @@ rm -f /tmp/silent_fallback_hits.$$
 echo "---"
 echo "total: ${count}"
 echo "attribute_name: ${ATTR_NAME}"
-echo "rfc: docs/rfc/RFC-0109-silent-fallback-discipline.md §6.2"
+echo "rfc: docs/rfc/RFC-0126-silent-fallback-discipline.md"


### PR DESCRIPTION
## 무엇

`docs/rfc/RFC-NNNN-slug.md` 형태로 인용하는데 그 파일이 디스크에 없는 곳 5개를 고친다.

두 종류가 있고 **두 번째가 더 나쁘다**:

| | 증상 | 독자가 겪는 일 |
|---|---|---|
| dangling | 번호 자체가 미사용 | 따라가면 없다. 뭔가 잘못됐음을 안다 |
| repointed | 번호가 **다른 문서**로 해석됨 | 실재하는 문서가 열린다. 인용이 유효해 보인다 |

## repointed 2건 — 둘 다 스크립트

### `scripts/lint/dashboard-ssot-agent-status.sh` (ci.yml 에 연결됨)

`RFC-0139-dashboard-agent-status-ssot.md` 를 인용한다. 실제 RFC-0139 는:

- 파일명 `RFC-0139-agent-status-vocabulary-ssot.md`
- 제목 "Withdraw parallel agent and judge status hierarchies"
- `status: Withdrawn` (2026-07-13)
- 헤딩 2개, **§10 없음**

그런데 이 가드는 실패 메시지 3곳에서 `RFC-0139 §10 SSOT guard` 를 출력하고, 모든 위반을 `§10-1` 로 태깅한다. 실재하지 않는 절을 운영자에게 보여준다.

**가드는 지우지 않았다.** RFC-0139 가 철회한 것은 *대시보드에 두 번째 status 어휘를 두자는 제안* 이고, 철회문은 금지를 명시적으로 남긴다 — "the dashboard may project typed source facts, but it must not infer lifecycle from presentation labels." 가드가 강제하는 게 정확히 그것이다. 근거 문서가 철회됐다는 사실이 가드를 무용하게 만들지 않는다. 다음 독자가 "철회된 제안에서 나왔으니 지우자"고 판단하지 않도록 헤더에 적었다.

### `§10-1` 라벨은 장식이 아니다

```sh
violations+=("§10-1 agent.status literal comparison:$line")     # 생산
path_line=$(echo "$v" | sed -E 's/^§10-[0-9]+ [^:]+://' | ...)  # 제거 (2곳)
```

접두사를 붙였다 벗겨서 allowlist 키(`path:line`)를 만든다. 헤더만 고치면 코드와 어긋나고, 생산부만 고치면 **allowlist 가 조용히 매칭을 멈춘다.** 4곳을 함께 `S-1` 로 바꾸고 왕복 검증했다:

| 단계 | 기대 | 실제 |
|---|---|---|
| 합성 위반 주입 | exit 1, 위반 출력 | `S-1 agent.status literal comparison:dashboard/src/__lint_probe.ts:2` / EXIT=1 |
| 그 `path:line` 을 allowlist 에 추가 | exit 0, count 1 | `clean (1 allowlisted violation(s))` / EXIT=0 |
| probe 제거 + allowlist 복원 | exit 0, count 0 | `clean (0 allowlisted violation(s))` / EXIT=0 |

### `scripts/silent-fallback-acknowledged.sh`

`RFC-0109-silent-fallback-discipline.md` 를 인용한다. RFC-0109 는 지금 `cdal-goal-integration-contract` 이고, silent-fallback RFC 는 **0126** 이다.

0126 으로 옮기면서 그 RFC 가 실제로 말하는 것도 적었다: Phase 2a 는 **다른 스크립트** (`scripts/lint/no-unknown-permissive-default.sh`) 로 이미 착지했고, 이 스크립트가 대기 중인 ppxlib 단계는 2b 이며 시작되지 않았고 RFC-0106 에 막혀 있다. 검증 못 한 `§6.2` 는 뺐다.

이 스크립트는 삭제하지 않았다. 스캔 결과가 0 이고 아무도 호출하지 않지만, docstring 이 "Currently 0 sites" 라고 스스로 밝히고 RFC-0126 이 Phase 2b 를 pending 으로 명시한다. 거짓 주장이 아니라 정직한 미완이다. 틀린 건 RFC 번호뿐이었다.

## dangling 3건 — 문서

| 파일 | 인용 |
|---|---|
| `docs/TRACK1-MULTIAGENT-IDE-MVP.md` | `RFC-0017-ocaml-crdt-boundary.md` |
| `dashboard/design-system/RFC/0022-ide-plane-assembly.md` | `RFC-0033-worktree-status-sse.md` |
| `docs/observability/dashboard-surface-metrics.md` | `RFC-0048-dashboard-ia-phase-2.md` |

0017 / 0033 / 0048 은 **어떤 파일도 쓰지 않는 번호** 이고, 해당 주제를 다른 번호로 가진 RFC 도 없다. 주석을 붙이는 대신 주장을 지웠다.

## 검증

| 항목 | 결과 |
|---|---|
| `shellcheck` (수정한 2개 스크립트) | EXIT=0 |
| `scripts/lint/dashboard-ssot-agent-status.sh` | EXIT=0, clean (0) |
| 위 3단계 왕복 테스트 | 통과 |
| `scripts/check-doc-truth.sh` | EXIT=0 |
| `scripts/silent-fallback-acknowledged.sh` | EXIT=0, `total: 0` (변화 없음) |
| 저장소 전체 재스캔 | 5 → 0 |

재스캔 후 남는 6건은 전부 `scripts/pr_axis_check.py` 안의 테스트 픽스처다 (`{"number": 1, "added_rfc_files": ["docs/rfc/RFC-0289-foo.md"]}`). 의도된 것이므로 두었다.

**`lib/` 과 `bin/` 에는 해결되지 않는 RFC 인용이 처음부터 0건이었다.** #27028 이 정리한 프로덕션 소스는 이 축에서도 깨끗하다.

## 범위 밖 (보고만)

`docs/rfc/` 에 **번호가 겹치는 RFC 가 16개** 있다 — 296개 번호에 315개 파일. 예: RFC-0038 3개 (`opaque-identifier-types` / `phase-2-keeper-identity-canonical` / `runtime-routing-intent-preservation`), RFC-0107 3개, RFC-0284 3개.

CI 에 RFC 번호 충돌 검사가 있지만 (#27013 / #27022 에서 실제로 트립했다) main 에는 19개 중복 파일이 남아 있다 — 신규 PR 만 검사하는 것으로 보인다. `RFC-NNNN` 만 쓴 인용은 어느 문서를 가리키는지 결정할 수 없다. 재번호는 그 번호를 가리키는 모든 인용을 깨므로 별도 판단이 필요하다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
