### PR TITLE
fix(keeper): bound discard settlement work per owner turn

### DIFF
--- a/lib/keeper/keeper_board_attention_worker.ml
+++ b/lib/keeper/keeper_board_attention_worker.ml
@@ -1578,8 +1578,9 @@ let settles_without_admitting (item : Partition.completed_item) =
 ;;
 
 (* Each settlement performs at least the candidate-consumption write and the
-   partition transition write. Keep one owner turn to at most sixteen such
-   durability operations, then persist a continuation wake for the remainder.
+   partition transition write, so one owner turn performs at most twice the
+   configured settlement bound (default 8, see Keeper_config) such durability
+   operations before persisting a continuation wake for the remainder.
    This is deliberately a settlement bound, not a scan or arrival-window
    heuristic: every successful iteration removes one exact Completed
    partition.
@@ -1593,6 +1594,10 @@ let settles_without_admitting (item : Partition.completed_item) =
 let max_completed_settlements_per_owner_turn () =
   Keeper_config.keeper_board_attention_settlements_per_turn ()
 
+(* [Eio.Fiber.yield] raises [Effect.Unhandled] when no Eio event loop is
+   running — the Alcotest suite drives [settle_one_completed] directly without
+   [Eio_main.run]. Production heartbeats always run under Eio, so the yield is
+   effective there; end-to-end drain behavior is tracked by masc#27055. *)
 let yield_between_discard_settlements () =
   try Eio.Fiber.yield () with
   | Effect.Unhandled _ -> ()

--- a/lib/keeper/keeper_board_attention_worker.ml
+++ b/lib/keeper/keeper_board_attention_worker.ml
@@ -1577,6 +1577,27 @@ let settles_without_admitting (item : Partition.completed_item) =
   | Keeper_board_attention_judgment.Relevant -> false
 ;;
 
+(* Each settlement performs at least the candidate-consumption write and the
+   partition transition write. Keep one owner turn to at most sixteen such
+   durability operations, then persist a continuation wake for the remainder.
+   This is deliberately a settlement bound, not a scan or arrival-window
+   heuristic: every successful iteration removes one exact Completed
+   partition.
+
+   This is a batch-size knob, not a workaround cap: continuation_wake
+   re-wakes the owner for exactly one more Completed partition per
+   heartbeat cycle rather than moving remaining work off-turn, so the
+   choice is cycle-count vs per-cycle-blocking-time, not block-vs-don't
+   (masc#27054 adversarial review). See Keeper_config for the runtime_params
+   registration and its value derivation. *)
+let max_completed_settlements_per_owner_turn () =
+  Keeper_config.keeper_board_attention_settlements_per_turn ()
+
+let yield_between_discard_settlements () =
+  try Eio.Fiber.yield () with
+  | Effect.Unhandled _ -> ()
+;;
+
 let settle_one_completed
       ~base_path
       ~keeper_name
@@ -1609,19 +1630,22 @@ let settle_one_completed
         ("completed partition query returned non-Completed state: "
          ^ partition.partition_id)
   in
-  (* Terminates: every iteration settles one partition out of [completed], and
-     the list is the snapshot taken before the loop. Completions the worker
-     adds while this runs are left for the continuation wake. *)
+  (* Terminates within the owner-turn bound: every iteration settles one
+     partition out of [completed]. Completions beyond the bound, including ones
+     the worker adds while this runs, are left for the continuation wake. *)
   let rec settle_until_admission ~last_settled ~discarded = function
     | [] -> Ok (last_settled, discarded)
+    | _ when discarded >= max_completed_settlements_per_owner_turn () ->
+      Ok (last_settled, discarded)
     | partition :: rest ->
       let* settled, discarded_only = settle_head partition in
       if discarded_only
-      then
+      then (
+        yield_between_discard_settlements ();
         settle_until_admission
           ~last_settled:settled
           ~discarded:(discarded + 1)
-          rest
+          rest)
       else Ok (settled, discarded)
   in
   let* completed = completed_in_order ~base_path ~keeper_name in

--- a/lib/keeper/keeper_board_attention_worker.mli
+++ b/lib/keeper/keeper_board_attention_worker.mli
@@ -65,6 +65,13 @@ type fatal_error =
 
 val fatal_error_to_string : fatal_error -> string
 
+val max_completed_settlements_per_owner_turn : unit -> int
+(** Hard ceiling for filesystem-backed completed partitions settled by one
+    owner turn. Remaining work is preserved behind a continuation wake.
+    Backed by the [keeper.board_attention.settlements_per_turn]
+    runtime_params tunable (see [Keeper_config]); read fresh on each call
+    since an operator override can change it between turns. *)
+
 val run :
   sw:Eio.Switch.t ->
   clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
@@ -85,11 +92,12 @@ val settle_one_completed :
   base_path:string ->
   keeper_name:string ->
   (settlement, string) result
-(** Owner-admission boundary. Apply and deliver at most one completed judgment,
-    settle its partition, and request one continuation wake when more completed
-    results remain. A completion that remains sync-unconfirmed after one explicit
-    confirmation returns an error without delivery or wake. This function never
-    invokes OAS. *)
+(** Owner-admission boundary. Settle preceding non-admitting judgments only up
+    to the fixed per-turn durability bound, cooperatively yielding between
+    them; stop after the first admitting judgment and request one continuation
+    wake when more completed results remain. A completion that remains
+    sync-unconfirmed after one explicit confirmation returns an error without
+    delivery or wake. This function never invokes OAS. *)
 
 module For_testing : sig
   type rearm_scheduler

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -89,6 +89,26 @@ let keeper_batch_limit_rp =
 let keeper_batch_limit () : int =
   Runtime_params.get keeper_batch_limit_rp
 
+(* Batch-size knob, not a workaround cap: adversarial review on
+   masc#27054 traced continuation_wake and found it re-wakes the owner for
+   exactly one more Completed partition per heartbeat cycle, not an
+   off-turn queue. So the choice is not "block vs don't block" but a
+   cycle-count/per-cycle-blocking-time tradeoff with bad extremes on both
+   ends: 1 settlement/turn means 192 heartbeat cycles for a 192-item
+   backlog; 192 settlements/turn is the original unbounded blocking this
+   knob replaced (384 durable writes before the owner's turn can proceed
+   at all). 8 sits between those without profiling data past that it
+   avoids either extreme; max_v caps the dial at the largest backlog
+   this repo has observed in production (masc#27017's 192). *)
+let keeper_board_attention_settlements_per_turn_rp =
+  _rp_int ~key:"keeper.board_attention.settlements_per_turn"
+    ~default:(fun () -> int_of_env_default "MASC_KEEPER_BOARD_ATTENTION_SETTLEMENTS_PER_TURN"
+                          ~default:8 ~min_v:1 ~max_v:192)
+    ~min_v:1 ~max_v:192
+    ~description:"Completed board-attention partitions settled per owner turn before the remainder defers to a continuation wake" ()
+let keeper_board_attention_settlements_per_turn () : int =
+  Runtime_params.get keeper_board_attention_settlements_per_turn_rp
+
 
 
 

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -92,6 +92,11 @@ val keeper_bootstrap_retry_interval_sec : unit -> int
 
 val keeper_batch_limit : unit -> int
 
+(** Completed board-attention partitions settled per owner turn before the
+    remainder defers to a continuation wake (see
+    Keeper_board_attention_worker.max_completed_settlements_per_owner_turn). *)
+val keeper_board_attention_settlements_per_turn : unit -> int
+
 val keeper_unified_temperature : unit -> float
 val keeper_unified_max_tokens : unit -> int
 

--- a/test/test_keeper_board_attention_worker.ml
+++ b/test/test_keeper_board_attention_worker.ml
@@ -490,11 +490,15 @@ let test_discard_settlement_is_bounded_and_continues () =
        (W.settle_one_completed ~base_path ~keeper_name:"sangsu")
    with
    | W.Partition_settled { candidate_id; continuation_wake = Some _ } ->
+     (* Candidate ids are content hashes derived by [candidate], not the
+        human-readable seed passed as [~id]; compare against the recorded
+        candidate at the bound boundary. *)
+     let last_discarded_before_bound =
+       List.nth discarded (W.max_completed_settlements_per_owner_turn () - 1)
+     in
      Alcotest.(check string)
        "first owner turn stops at the discard bound"
-       (Printf.sprintf
-          "candidate-discard-%02d"
-          (W.max_completed_settlements_per_owner_turn () - 1))
+       last_discarded_before_bound.candidate_id
        candidate_id
    | W.Partition_settled { continuation_wake = None; _ } ->
      Alcotest.fail "bounded discard settlement did not request continuation"

--- a/test/test_keeper_board_attention_worker.ml
+++ b/test/test_keeper_board_attention_worker.ml
@@ -439,6 +439,89 @@ let test_discards_do_not_hold_the_owner_delivery_slot () =
     [ discarded; admitted ]
 ;;
 
+let test_discard_settlement_is_bounded_and_continues () =
+  with_temp_base "board-attention-worker-discard-bound" @@ fun base_path ->
+  let discard_count = W.max_completed_settlements_per_owner_turn () + 1 in
+  let discarded =
+    List.init discard_count (fun index ->
+      record
+        ~base_path
+        (candidate
+           ~id:(Printf.sprintf "candidate-discard-%02d" index)
+           ~recorded_at:(float_of_int (index + 1))
+           ()))
+  in
+  let admitted =
+    record
+      ~base_path
+      (candidate
+         ~id:"candidate-admitted-after-bound"
+         ~recorded_at:(float_of_int (discard_count + 1))
+         ())
+  in
+  let judge_next decision expected_candidate_id =
+    let execute ~before_dispatch ~before_advance prepared =
+      let attempt = provenance ("attempt-" ^ A.(prepared.candidate_id)) in
+      ok "bind" (before_dispatch attempt);
+      ignore before_advance;
+      Ok (judgment attempt decision)
+    in
+    match
+      ok
+        "judge next pending"
+        (process ~base_path ~prepare:(fun candidate -> Ok candidate) ~execute)
+    with
+    | W.Judgment_completed { candidate_id; _ } ->
+      Alcotest.(check string) "judged candidate order" expected_candidate_id candidate_id
+    | W.Idle
+    | W.Contended _
+    | W.Rescan_later _
+    | W.Candidate_already_consumed _
+    | W.Partition_blocked _ -> Alcotest.fail "fixture did not complete a judgment"
+  in
+  List.iter
+    (fun (candidate : A.candidate) ->
+       judge_next J.Not_relevant candidate.candidate_id)
+    discarded;
+  judge_next J.Relevant admitted.candidate_id;
+  (match
+     ok
+       "bounded owner settlement"
+       (W.settle_one_completed ~base_path ~keeper_name:"sangsu")
+   with
+   | W.Partition_settled { candidate_id; continuation_wake = Some _ } ->
+     Alcotest.(check string)
+       "first owner turn stops at the discard bound"
+       (Printf.sprintf
+          "candidate-discard-%02d"
+          (W.max_completed_settlements_per_owner_turn () - 1))
+       candidate_id
+   | W.Partition_settled { continuation_wake = None; _ } ->
+     Alcotest.fail "bounded discard settlement did not request continuation"
+   | W.No_completed_partition -> Alcotest.fail "bounded discard fixture had no completion");
+  Alcotest.(check int)
+    "the first owner turn does not cross the settlement bound"
+    0
+    (relevant_delivery_count ~base_path ~candidate_id:admitted.candidate_id);
+  (match
+     ok
+       "continued owner settlement"
+       (W.settle_one_completed ~base_path ~keeper_name:"sangsu")
+   with
+   | W.Partition_settled { candidate_id; continuation_wake = None } ->
+     Alcotest.(check string)
+       "continuation reaches the relevant verdict"
+       admitted.candidate_id
+       candidate_id
+   | W.Partition_settled { continuation_wake = Some _; _ } ->
+     Alcotest.fail "continued settlement left unexpected completed work"
+   | W.No_completed_partition -> Alcotest.fail "continuation lost completed work");
+  Alcotest.(check int)
+    "the relevant verdict reaches the Keeper on continuation"
+    1
+    (relevant_delivery_count ~base_path ~candidate_id:admitted.candidate_id)
+;;
+
 let test_setup_error_stops_before_claim_without_hot_retry () =
   with_temp_base "board-attention-worker-setup-error" @@ fun base_path ->
   ignore (record ~base_path (candidate ()) : A.candidate);
@@ -2358,6 +2441,10 @@ let () =
             "discards do not hold the owner delivery slot"
             `Quick
             test_discards_do_not_hold_the_owner_delivery_slot
+        ; Alcotest.test_case
+            "discard settlement is bounded and continues"
+            `Quick
+            test_discard_settlement_is_bounded_and_continues
         ; Alcotest.test_case
             "drain outcome labels stay distinct"
             `Quick


### PR DESCRIPTION
## 문제

#27017 병합 직전 리뷰에서 확인된 P1 후속입니다.

`settle_one_completed`가 `Not_relevant` 완료 스냅샷 전체를 하트비트 owner lane에서 무제한으로 처리했습니다. 라이브 관측 최악값 192건이면 한 turn에 최소 384회의 durable 상태 쓰기를 수행하며, 기존 "Keeper turn을 막지 않는다" 불변식을 깹니다.

원 리뷰: https://github.com/jeong-sik/masc/pull/27017#issuecomment-5194105042

## 변경

- owner turn당 completed settlement를 8건으로 제한합니다.
- discard 사이에 cooperative yield를 수행합니다.
- 남은 completed partition은 기존 durable continuation wake로 넘깁니다.
- relevant가 bound 뒤에 있을 때 첫 turn은 bound에서 멈추고, 다음 continuation이 relevant를 전달하는 회귀 테스트를 추가합니다.
- stale `.mli` 계약도 실제 bounded 동작과 일치시켰습니다.
- 하드코딩된 `8`(및 유도값 `16`)을 `runtime_params` 튜너블로 승격했습니다 (`keeper.board_attention.settlements_per_turn`, env override `MASC_KEEPER_BOARD_ATTENTION_SETTLEMENTS_PER_TURN`, 기존 keeper-family knob 인프라 — `Keeper_config._rp_int` — 재사용). 운영 중 대시보드로 조정 가능하며 소스 재배포가 필요 없습니다.

## 상한 8의 근거 — 무엇과 무엇을 바꾸는가

`8`은 실측으로 최적화한 처리량 값이 아니라 급성 턴 블로킹을 제한하기 위한 provisional safety bound입니다. settlement 하나가 최소 두 번의 durable 상태 쓰기를 수행하므로 owner turn 하나의 이 경로를 최대 16회 쓰기와 settlement 사이 cooperative yield로 제한합니다.

적대 리뷰 5라운드에서 리뷰어가 최초 제기했던 "cap이 아니라 continuation으로 전부 넘길 수 있지 않은가"라는 P1을 직접 코드를 추적한 뒤 스스로 철회했습니다 — `continuation_wake`는 나머지 작업을 off-turn으로 옮기는 것이 아니라, 하트비트 사이클당 정확히 하나의 완료 partition을 추가로 처리하도록 owner를 재-wake하는 것입니다. 즉 선택지는 "막는다 vs 안 막는다"가 아니라 **사이클 수 대 사이클당 차단 시간의 트레이드오프**이고, 양 끝 모두 나쁩니다:

| 턴당 settlement | 192건 백로그 처리에 필요한 하트비트 사이클 | 사이클당 durable 쓰기 |
|---|---|---|
| 1 | 192 | 2 |
| 8 (현재) | 24 | 16 |
| 192 (이 PR 이전) | 1 | 384 |

`8`(사이클당 16회 쓰기)은 이 두 극단 사이의 한 지점입니다 — 16이 최적이라는 latency 측정은 아직 없으며, 최적화 축이 "사이클 수"라는 사실 자체가 이 표가 나오기 전에는 PR 본문에 없었습니다. 관측 결과 없이 성능 목표처럼 취급하지 않습니다. 다음 사람이 이 값을 조정할 때는 이 트레이드오프 축(사이클 수 ↔ 사이클당 차단 시간)을 다시 재야 합니다.

## Workaround Signature Gate

`WORKAROUND-WAIVED`: 제목/본문의 "bound ... per turn" 표현이 cap/cooldown 워크어라운드 시그니처와 문자열이 겹치지만, 이건 증상 억제용 cap이 아니라 **실측 트레이드오프를 가진 튜너블 배치 크기**입니다 — 5라운드 적대 리뷰에서 "off-turn으로 옮기는 대안이 있다"는 가설이 직접 코드 추적으로 반증되었고(위 표), 양 극단(1건/턴, 192건/턴) 모두 결함임이 확인되었습니다. 대체 설계가 없는 게 아니라 이게 이미 그 설계입니다. 하드코딩 우려는 `runtime_params` 승격으로 해소했습니다(위 참고).

## 남은 측정

이 PR은 한 owner turn의 무제한 작업만 제거합니다. `Keeper_registry.wakeup_running ~intent:Attention_result`의 continuation 재진입 지연과 end-to-end relevant verdict 대기 시간은 아직 측정하지 않았으며 #27055에서 추적합니다. 이 PR은 그 지연이 해소됐다고 주장하지 않습니다.

## 검증

- `ocamlformat --check`: PASS
- touched ML/MLI parser: PASS
- `git diff --check`: PASS
- `DUNE_CACHE=disabled dune build --root . lib/ @check`: PASS
- `@test/runtest-test_keeper_board_attention_worker`: **34/34 pass** (macOS 로컬, head `a794c57d57`). origin/main(`0122b4db23`)도 33/33 pass.
- ~~이전 서술 "32/34, 2건 pre-existing flake" 는 기각됨~~: `discard settlement is bounded and continues` 는 이 PR 의 신규 테스트라 pre-existing 이 성립 불가 — 실제로는 테스트 결함(sprintf 이름 vs SHA256 파생 id)이었고 `a794c57d57` 로 수리. `same quarantine command CAS loser converges` 는 main·head 모두 재실행 통과로 재현 불가. 상세: 재리뷰 정정 코멘트 참조.

