### PR TITLE
fix(dashboard): 프롬프트 합계가 NOT SENT 행을 세어 컨텍스트를 2배로 보고한다

### DIFF
--- a/dashboard/src/components/keeper-prompt-assembly-panel.test.ts
+++ b/dashboard/src/components/keeper-prompt-assembly-panel.test.ts
@@ -233,3 +233,55 @@ describe('buildKeeperPromptAssemblyReport', () => {
     expect(affectedPrompts?.textContent).toContain('Affected prompts')
   })
 })
+
+// The "Total size" metric is what an operator sizes a keeper's context budget
+// against. Two stages carry messageSlot 'not sent' — 'registry-bootstrap'
+// re-lists keeper.system as source preparation, and 'manifest-edge' is the
+// post-assembly audit record. Summing every row counted keeper.system twice:
+// the live fleet panel read 15.3 KiB / 3,920 tok against a real model input of
+// 1,985 tok.
+describe('buildKeeperPromptAssemblyReport sent totals', () => {
+  it('excludes not-sent stages from the model-input totals', () => {
+    const body = 'x'.repeat(4096)
+    const report = buildKeeperPromptAssemblyReport([
+      prompt({
+        key: 'keeper.system',
+        effective: body,
+        file_path: '/tmp/.masc/config/prompts/keeper.system.md',
+        char_count: body.length,
+      }),
+    ])
+
+    const notSent = report.stages.filter(stage => stage.messageSlot === 'not sent')
+    expect(notSent.length).toBeGreaterThan(0)
+
+    const allBytes = report.rows.reduce((sum, row) => sum + row.bytes, 0)
+    const notSentBytes = notSent.reduce((sum, stage) => sum + stage.bytes, 0)
+
+    // The not-sent stages carry real bytes here, so the two totals must differ.
+    expect(notSentBytes).toBeGreaterThan(0)
+    expect(report.stats.sentPromptBytes).toBe(allBytes - notSentBytes)
+    expect(report.stats.sentPromptBytes).toBeLessThan(allBytes)
+  })
+
+  it('counts a prompt reused by a not-sent stage only once', () => {
+    const body = 'y'.repeat(2048)
+    const report = buildKeeperPromptAssemblyReport([
+      prompt({
+        key: 'keeper.system',
+        effective: body,
+        file_path: '/tmp/.masc/config/prompts/keeper.system.md',
+        char_count: body.length,
+      }),
+    ])
+
+    const systemStage = report.stages.find(stage => stage.id === 'base-system')
+    const sourceStage = report.stages.find(stage => stage.id === 'registry-bootstrap')
+    expect(sourceStage?.messageSlot).toBe('not sent')
+    // Both stages render keeper.system, so the naive all-rows sum is ~2x.
+    expect(sourceStage?.bytes).toBe(systemStage?.bytes)
+    expect(report.stats.sentEstimatedTokens).toBeLessThan(
+      report.rows.reduce((sum, row) => sum + row.estimatedTokens, 0),
+    )
+  })
+})

--- a/dashboard/src/components/keeper-prompt-assembly-panel.ts
+++ b/dashboard/src/components/keeper-prompt-assembly-panel.ts
@@ -95,8 +95,13 @@ export interface KeeperPromptAssemblyReport {
     missingRows: number
     warningCount: number
     criticalCount: number
-    promptBytes: number
-    estimatedTokens: number
+    // Only rows whose stage actually reaches the model. Two stages carry
+    // messageSlot 'not sent' — 'registry-bootstrap' (source preparation, which
+    // re-lists keeper.system) and 'manifest-edge' (the post-assembly audit
+    // record). Summing every row double-counted keeper.system and reported
+    // 3,920 tok against a real model input of 1,985 tok on the live fleet.
+    sentPromptBytes: number
+    sentEstimatedTokens: number
   }
 }
 
@@ -539,10 +544,11 @@ export function buildKeeperPromptAssemblyReport(
     ),
   ).sort()
 
-  const promptBytes = rows.reduce((sum, row) => sum + row.bytes, 0)
-  const estimatedTokens = rows.reduce((sum, row) => sum + row.estimatedTokens, 0)
   const criticalCount = warnings.filter(warning => warning.severity === 'critical').length
   const stages = buildStages(rows)
+  const sentStages = stages.filter(stage => stage.messageSlot !== 'not sent')
+  const sentPromptBytes = sentStages.reduce((sum, stage) => sum + stage.bytes, 0)
+  const sentEstimatedTokens = sentStages.reduce((sum, stage) => sum + stage.estimatedTokens, 0)
 
   return {
     rows,
@@ -555,8 +561,8 @@ export function buildKeeperPromptAssemblyReport(
       missingRows: rows.filter(row => row.missing).length,
       warningCount: warnings.length,
       criticalCount,
-      promptBytes,
-      estimatedTokens,
+      sentPromptBytes,
+      sentEstimatedTokens,
     },
   }
 }
@@ -901,7 +907,7 @@ function PromptCodexDocument({
       <div class="grid gap-4 p-4 xl:grid-cols-[minmax(0,1fr)_270px]">
         <article class="min-w-0 rounded-[var(--r-1)] border border-[#b58e48]/55 bg-[#ead9b5] p-4 text-[#2b2015] shadow-[0_1px_0_rgba(255,255,255,0.55)_inset,0_18px_46px_rgba(0,0,0,0.28)]">
           <div class="mb-4 grid gap-2 md:grid-cols-4">
-            <${CodexMetric} label="Total size" value=${`${formatBytes(report.stats.promptBytes)} · ${report.stats.estimatedTokens.toLocaleString()} tok`} detail="all" tone="neutral" />
+            <${CodexMetric} label="Total size" value=${`${formatBytes(report.stats.sentPromptBytes)} · ${report.stats.sentEstimatedTokens.toLocaleString()} tok`} detail="model input" tone="neutral" />
             <${CodexMetric} label="Preset size" value=${`${formatBytes(visible.bytes)} · ${visible.estimatedTokens.toLocaleString()} tok`} detail=${activePresetLabel} tone="info" />
             <${CodexMetric} label="Sources" value=${`${visible.rows.length.toLocaleString()} rows`} detail=${`${modelStages.length} model parts`} tone="ok" />
             <${CodexMetric} label="Attention" value=${`${visible.overrides} edited · ${visible.missing} missing`} detail="audit" tone=${visible.missing > 0 ? 'bad' : visible.overrides > 0 ? 'warn' : 'neutral'} />


### PR DESCRIPTION
## 문제

`#settings?section=prompts` 의 **TOTAL SIZE** / **PRESET SIZE** 가 keeper 가 실제로 받는 컨텍스트의
약 2배를 보고한다.

라이브 실측 (`http://127.0.0.1:8935/dashboard#settings?section=prompts`, v0.21.2):

```
TOTAL SIZE   all      15.3 KiB · 3,920 tok
PRESET SIZE  전체     15.3 KiB · 3,920 tok
SOURCES      4 model parts / 7 rows
```

같은 화면의 행 단위 값:

| # | prompt | 도착지 | 크기 |
|---|---|---|---|
| 1 | `keeper.system` | **NOT SENT** / source preparation | 7.6 KiB · 1,935 tok |
| 2 | `keeper.system` | SYSTEM MESSAGE / model input | 7.6 KiB · 1,935 tok |
| 3 | `(computed:world_observation)` | USER MESSAGE | 0 |
| 3 | `(computed:scheduled_automation)` | USER MESSAGE | 0 |
| 4 | `(computed)` | CONTEXT MESSAGE | 0 |
| 5 | `keeper.memory_os_recall.context` | FINAL MESSAGE | 197 B · 50 tok |
| 6 | `(computed)` | **NOT SENT** / audit evidence | 0 |

1행과 2행은 `fingerprint ef0d0d63` 로 동일한 파일이다. 실제 model input 은 1,935 + 50 = **1,985 tok**
인데 3,920 tok 으로 표시된다.

## 원인

`buildKeeperPromptAssemblyReport` 가 **모든 row** 를 합산했다
(`dashboard/src/components/keeper-prompt-assembly-panel.ts`):

```ts
const promptBytes = rows.reduce((sum, row) => sum + row.bytes, 0)
const estimatedTokens = rows.reduce((sum, row) => sum + row.estimatedTokens, 0)
```

`STAGES` 중 두 개는 스스로 `messageSlot: 'not sent'` 라고 선언한다:

- `registry-bootstrap` ("Prompt sources", `promptKeys: ['keeper.system']`) — 소스 준비 단계
- `manifest-edge` ("Audit trail") — 조립 후 감사 기록

`registry-bootstrap` 이 `keeper.system` 을 다시 나열하므로 같은 파일이 두 번 세어진다. 패널 자신이
행마다 `NOT SENT` 라고 표시하면서 합계에는 포함시켜 왔다.

## 변경

`stats.promptBytes` / `stats.estimatedTokens` → `stats.sentPromptBytes` / `stats.sentEstimatedTokens`
로 이름과 계산을 함께 바꾼다. `messageSlot !== 'not sent'` 인 stage 의 bytes/token 만 합산한다.
"Total size" 메트릭의 detail 은 `all` → `model input`.

이름을 바꾼 이유: 기존 필드를 남겨두면 소비자 0 인 죽은 값이 되고, 그대로 두면 이름이 계산과
어긋난다. 이 두 필드의 소비자는 이 패널의 메트릭 한 줄뿐이다 (`rg promptBytes|estimatedTokens
dashboard/src` — 다른 히트는 `keeper-detail-telemetry.ts` 의 동명 지역 변수로 무관).

파생 값 추가 아님 — 같은 값의 정의를 좁힌 것이고 blast radius 는 메트릭 1개다.
게이트 추가 없음.

## 검증

```
dashboard $ node_modules/.bin/vitest run src/components/keeper-prompt-assembly-panel.test.ts
  Test Files  1 passed (1)
  Tests  7 passed (7)

dashboard $ node_modules/.bin/tsc --noEmit    # 0 errors
dashboard $ node_modules/.bin/eslint src      # clean
```

Negative control — 합산을 `rows` 전체로 되돌리고 신규 테스트 2건 재실행:

```
× excludes not-sent stages from the model-input totals
    AssertionError: expected 8192 to be 4096
× counts a prompt reused by a not-sent stage only once
    AssertionError: expected 1024 to be less than 1024
Tests  2 failed | 5 passed (7)
```

첫 번째 실패가 배수를 직접 보여준다: 4,096 바이트 프롬프트 하나에 대해 수정 전 합계는 8,192 를
보고한다.

## 미검증

- 이 패널의 `PRESET SIZE` 는 preset 선택에 따라 별도 경로(`presetBytes`)로 계산된다. `전체` preset 이
  같은 3,920 을 보였으므로 같은 원인일 가능성이 높지만, preset 별 계산은 이 PR 에서 건드리지 않았다.

RFC-WAIVED: `dashboard/src/components/keeper-prompt-assembly-panel.ts` 는 `pr-rfc-check.sh` 의 RFC 요구
subsystem (credential / identity / operator control plane / keeper sandbox / dashboard credential
component / hooks / workflow 문서) 에 해당하지 않는다.
