### PR TITLE
fix(keeper): anchor tool-result demotion to the raw window cut

### DIFF
--- a/docs/rfc/RFC-0363-historical-tool-result-demotion.md
+++ b/docs/rfc/RFC-0363-historical-tool-result-demotion.md
@@ -71,11 +71,12 @@ RFC-0351 §4 타입 수명이 이미 이 줄을 적어놓았다:
 
 ## 3. 설계
 
-`model_input_projection` 안, `Runtime_model_input_tail_window.project` **앞**에 강등 단계를 둔다. 전송 사본만 바꾸고 durable state 는 건드리지 않는다 (RFC-0351 §3 L5 "history 재작성 없음").
+`model_input_projection` 안에서 원문 기준 cut 을 먼저 계산하고, 그 cut 이 이미 제외한 원자만 강등한 뒤 최종 cut 을 다시 계산한다. 전송 사본만 바꾸고 durable state 는 건드리지 않는다 (RFC-0351 §3 L5 "history 재작성 없음").
 
 ```
-demote ~retain_atoms messages   (* 순수 함수. 예산을 입력으로 받지 않는다 *)
-  |> project ~measure_message_bytes ~capacity_bytes ~reserved_bytes
+raw = project_with_drop ~measure_message_bytes ~capacity_bytes ~reserved_bytes messages
+demote ~demote_before:raw.dropped_atoms messages
+  |> project_with_drop ~measure_message_bytes ~capacity_bytes ~reserved_bytes
 ```
 
 ### 3.1 강등 대상 — 타입으로 판정한다
@@ -86,7 +87,7 @@ demote ~retain_atoms messages   (* 순수 함수. 예산을 입력으로 받지 
    `api_common.ml:304-321` — `content_blocks = Some blocks` 이면 `content` 는 **직렬화되지 않는다**. 그런 메시지의 `content` 를 마커로 바꾸면 크기가 전혀 줄지 않는데 추정기는 감소를 계상한다. 즉 추정이 **하한**이 되어, window 가 과소평가로 cut 하고 물질화된 요청이 예산을 넘는다. `Some` 은 이미지·문서를 담으며 마커로 표현할 수도 없다.
 2. `Tool_output.decode_from_oas content = Not_marker`
    `Decoded` 는 이미 강등된 것이고, **`Invalid_marker` 는 강등하지 않는다** — 마커 모양인데 파싱에 실패한 payload 를 blob 으로 다시 저장하면 손상을 고착시킨다. 세 경우를 exhaustive match 로 다룬다.
-3. 원자 인덱스 < `atom_count - retain_atoms`
+3. 원자 인덱스 < 원문 projection 의 `dropped_atoms`
 4. `upper_bound_demoted_bytes msg < measure_message_bytes msg`
 
 판단은 (a) 타입, (b) 정수 비교, (c) 바이트 비교뿐이다. 중요도 점수·문자열 분류·휴리스틱 임계값 없음 (RFC-0351 §2 원칙 2).
@@ -124,29 +125,25 @@ where saturating_ref = make_artifact_ref
 
 `val preview_max : int` 를 `tool_blob_store.mli` 에 공개하고, 강등은 그것만 참조한다.
 
-### 3.4 경계는 꼬리에서 움직인다 — 초안의 오류 정정
+### 3.4 경계는 원문 cut 에 고정한다
 
-초안은 강등 경계를 `atom_count` 로 양자화했다. 그것은 틀렸다: window 의 `drop` 은 `available_bytes` 로 결정되므로 두 경계는 **양자만 같고 트리거가 다르다**. `atom_count` 119 → 120 이고 예산이 넉넉해 `drop = 0` 인 순간, 강등 경계만 0 → 60 으로 뛰어 원자 0–59 가 원문에서 마커로 뒤집힌다. window jump 없는 **prompt-cache 전량 미스** — §1.2 가 인용한 #26535 의 비용 그 자체다.
+강등 경계가 `atom_count - N` 이면 새 원자 하나가 붙을 때마다 직전 원자 하나가 원문에서 마커로 바뀐다. 두 요청의 공통 prefix 는 항상 그 이동 지점에서 끊기므로, 매 턴 새 원자 1개가 아니라 최신 원문 N개를 다시 처리하게 된다. `N = 60`이면 prompt-cache 재처리량이 1 → 61 원자로 늘어난다.
 
-정정: 강등은 **최신 `retain_atoms` 개를 제외한 전부**로 정의한다. 예산과 무관한 순수 함수다.
+강등 자체가 별도의 나이·예산 경계를 소유하면 같은 문제가 반복된다. 권위는 이미 byte budget으로 계산되는 원문 tail-window cut 하나다:
 
-이 경계는 매 턴 1 원자씩 **꼬리 방향**으로 전진한다. 캐시는 prefix 로 매칭되므로, 오래된 쪽은 계속 마커로 고정돼 있고 바뀌는 지점은 캐시 커버리지의 **끝**이다. 커버리지는 줄지 않고 늘어난다. cut 은 여전히 머리에서 양자화된 채 움직인다 — 두 경계가 서로 다른 끝에 있으므로 간섭하지 않는다.
+1. 변경하지 않은 `messages`를 `project_with_drop`에 넣어 `dropped_atoms`를 얻는다.
+2. `index < dropped_atoms`인 tool result만 포화 마커 후보로 바꾼다.
+3. 줄어든 메시지로 최종 cut을 다시 계산한다.
 
-### 3.5 `retain_atoms`
+따라서 demotion 경계는 원문 cut이 움직일 때만 움직인다. 양자화 cut이 60으로 유지되는 동안 새 turn을 붙여도 같은 60개만 마커이고, 60 → 120으로 뛰는 순간 새 60개가 바뀌지만 그 원자들은 원문 요청에서도 바로 그 jump에 탈락한다. demotion이 prompt-cache 변경 빈도를 늘리지 않는다. exact cut fallback에서도 동일하다. raw cut이 매 turn 움직이는 상황에서는 demotion도 움직이지만, 원문 prefix가 이미 같은 빈도로 움직인다.
 
-RFC-0351 §3 이 최근 창을 명시적으로 허용한다:
-
-> L5 의 "최근 창"은 recency 구조이지 중요도 판단이 아니다. keeper 는 일직선 타임라인이므로 최근성은 타임라인의 구조 자체다.
-
-값은 실측 근거가 없다. 초기값을 `atoms_per_window` (60) 로 두고 §6 에서 측정 후 조정한다. 리터럴 금지 — named constant 로 `.mli` 에 공개하고 "empirically tuned, see RFC-0363 §6" 주석을 단다.
-
-### 3.6 물질화와 실패
+### 3.5 물질화와 실패
 
 1단계는 포화 후보로 측정만 한다. 2단계는 cut 을 살아남은 강등 메시지에 대해서만 `Tool_blob_store.put` 한다.
 
 `put` 실패 시 해당 메시지는 인라인으로 되돌린다. 그러면 실제 크기가 추정보다 **커지므로**, 물질화 후 반드시 재측정하고 초과 시 `project` 를 다시 돌린다. 조용한 통과 금지 — 실패는 typed 결과로 올라오고 카운터가 아니라 재조립으로 대응한다.
 
-### 3.7 blob 수명 — 강등 blob 은 파생 데이터다
+### 3.6 blob 수명 — 강등 blob 은 파생 데이터다
 
 강등이 만드는 blob 은 durable 참조를 갖지 않는다 (전송 사본은 영속되지 않는다). `tool_blob_maintenance.mli` 의 계약상:
 
@@ -203,8 +200,8 @@ RFC-0351 §3 이 최근 창을 명시적으로 허용한다:
 |---|---|
 | 상한이 하한이 되어 요청 초과 | §3.2 포화 후보를 실제 측정기로 통과. §6 테스트 2 |
 | `content_blocks = Some` 오계상 | §3.1 조건 1. §6 테스트 3 |
-| prompt-cache 회귀 | §3.4 꼬리 경계. §6 테스트 1. 실패 시 머지 금지 |
+| prompt-cache 회귀 | §3.4 원문 cut anchor. §6 테스트 1. 실패 시 머지 금지 |
 | `preview_max` 변경이 상한을 깸 | §3.3 export 후 단일 참조 |
-| `put` 실패 후 조용한 초과 | §3.6 재측정 필수. §6 테스트 5 |
-| 강등 blob GC 후 not-found | §3.7 — 파생 데이터, 다음 강등이 복원. typed not-found 필요 |
+| `put` 실패 후 조용한 초과 | §3.5 재측정 필수. §6 테스트 5 |
+| 강등 blob GC 후 not-found | §3.6 — 파생 데이터, 다음 강등이 복원. typed not-found 필요 |
 | checkpoint 는 계속 자람 | 본 RFC 비목표. 안 B 후속 RFC |

--- a/lib/keeper/keeper_model_input_demotion.ml
+++ b/lib/keeper/keeper_model_input_demotion.ml
@@ -1,12 +1,5 @@
 (** See [keeper_model_input_demotion.mli] for the contract (RFC-0363). *)
 
-(* Not derived from [Runtime_model_input_tail_window.atoms_per_window] even
-   though it currently shares its value: that quantum bounds how often the cut
-   moves the head of the list, this one is how much recent tool output stays
-   readable without a fetch. They answer different questions and are free to
-   diverge once RFC-0363 §6 measures this one. *)
-let retain_atoms = 60
-
 (* Every demoted body is stored and previewed as opaque text. The provider
    never sees these bytes again — it sees the marker — so the media type only
    has to be the one [materialize] and the placeholder agree on, or the
@@ -83,9 +76,8 @@ let saturating_marker ~bytes =
     None
 ;;
 
-let plan ~measure_message_bytes messages =
-  let labelled, atom_count = Runtime_model_input_tail_window.annotate messages in
-  let demote_before = atom_count - retain_atoms in
+let plan ~measure_message_bytes ~demote_before messages =
+  let labelled, _atom_count = Runtime_model_input_tail_window.annotate messages in
   if demote_before <= 0
   then { messages; pending = [] }
   else (

--- a/lib/keeper/keeper_model_input_demotion.mli
+++ b/lib/keeper/keeper_model_input_demotion.mli
@@ -22,24 +22,12 @@
     A marker cannot be produced without hashing and storing the bytes, and the
     transmitted list is rebuilt from durable state every turn, so demoting
     everything eagerly would re-store thousands of blobs per turn. Instead
-    {!plan} substitutes a saturating placeholder whose serialized size is an
-    upper bound on the real marker, the window cuts against that, and
-    {!materialize} stores only the messages that survived the cut. The real
-    marker is never larger than the placeholder, so a request that fit the
-    plan still fits after materialization. *)
-
-val retain_atoms : int
-(** How many of the newest atoms keep their tool-result bodies verbatim.
-
-    A recency window, not an importance judgement: RFC-0351 §3 admits it on
-    the grounds that a keeper is a single timeline, so recency is the
-    timeline's own structure. The boundary moves one atom per turn at the
-    {e tail} of the transmitted list while the cut moves at its {e head}, so
-    the two never fight over the same bytes and the stable prefix a prompt
-    cache matches only grows.
-
-    Initial value is empirical and unvalidated — RFC-0363 §6 is the measurement
-    that fixes it. *)
+    the unmodified history first chooses the authoritative window cut. {!plan}
+    substitutes a saturating placeholder only below that cut, the window cuts
+    again against the smaller messages, and {!materialize} stores only the
+    messages that survived. The real marker is never larger than the
+    placeholder, so a request that fit the plan still fits after
+    materialization. *)
 
 type pending
 (** A demotion chosen by {!plan} and not yet stored. Keyed internally by
@@ -55,12 +43,12 @@ type plan_result =
 
 val plan
   :  measure_message_bytes:(Agent_sdk.Types.message -> int)
+  -> demote_before:int
   -> Agent_sdk.Types.message list
   -> plan_result
-(** Choose demotions and substitute upper-bound placeholders. Pure: no I/O, no
-    hashing, and no dependence on the byte budget — the budget belongs to the
-    cut, and giving both stages the same trigger is what keeps the demotion
-    boundary off the head of the list.
+(** Choose demotions and substitute upper-bound placeholders. Pure: no I/O or
+    hashing. The byte budget stays in the cut; this function receives only the
+    exact cut result so it cannot invent a second moving boundary.
 
     A tool result is demoted only when all of these hold:
 
@@ -73,7 +61,11 @@ val plan
       demoted; [Invalid_marker] is marker-shaped content that failed to parse
       and is left exactly as-is rather than being stored as a blob, which would
       make a corrupt payload content-addressed and permanent.
-    - its atom index is older than the newest {!retain_atoms} atoms.
+    - its atom index is below [demote_before], which must be [dropped_atoms]
+      from {!Runtime_model_input_tail_window.project_with_drop} on the same
+      unmodified message list. The demotion boundary therefore moves only when
+      the authoritative raw cut moves; appending one turn cannot rewrite the
+      previous request's retained prefix.
     - the placeholder measures strictly smaller than the message does now.
       This replaces a size threshold: the encoded marker runs from about 125
       bytes to 1,154 depending on the preview's bytes, because

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -297,50 +297,62 @@ let budgeted_model_input_projection (ctx : try_provider_ctx)
       ~system_prompt:ctx.system_prompt
       ~tools:ctx.tools
   in
-  let cut candidate =
-    Runtime_model_input_tail_window.project
+  let raw_cut candidate =
+    Runtime_model_input_tail_window.project_with_drop
       ~measure_message_bytes
       ~capacity_bytes:ctx.max_request_body_bytes
       ~reserved_bytes
       candidate
   in
+  let cut candidate =
+    Result.map
+      (fun projection -> projection.Runtime_model_input_tail_window.messages)
+      (raw_cut candidate)
+  in
   fun messages ->
-    (* RFC-0363: aged tool-result bodies become blob markers before the cut is
-       chosen, so the same budget carries more atoms. [plan] only substitutes
-       upper-bound placeholders; the bytes are stored after the cut, for the
-       messages that survived it. An empty [base_path] means no blob store, so
-       there is nothing to demote into. *)
-    let planned =
-      if String.equal ctx.base_path ""
-      then
-        { Keeper_model_input_demotion.messages; pending = [] }
-      else Keeper_model_input_demotion.plan ~measure_message_bytes messages
-    in
+    (* RFC-0363: the unmodified history chooses the authoritative cut first.
+       Demotion may rewrite only atoms that cut already omitted, so appending a
+       turn cannot move the rewrite boundary unless the raw cut itself moves.
+       Markers can then buy some of those omitted atoms back without causing a
+       per-turn prompt-cache miss. *)
     let windowed =
-      match cut planned.Keeper_model_input_demotion.messages with
+      match raw_cut messages with
       | Error error ->
         Error (Runtime_model_input_tail_window.budget_error_to_string error)
-      | Ok windowed ->
+      | Ok raw_projection ->
+        let planned =
+          if String.equal ctx.base_path "" || raw_projection.dropped_atoms = 0
+          then { Keeper_model_input_demotion.messages; pending = [] }
+          else
+            Keeper_model_input_demotion.plan
+              ~measure_message_bytes
+              ~demote_before:raw_projection.dropped_atoms
+              messages
+        in
         (match planned.Keeper_model_input_demotion.pending with
-         | [] -> Ok windowed
+         | [] -> Ok raw_projection.messages
          | pending ->
-           let outcome =
-             Keeper_model_input_demotion.materialize
-               ~store:(Tool_blob_store.create ~base_path:ctx.base_path)
-               ~pending
-               windowed
-           in
-           if outcome.Keeper_model_input_demotion.reverted = 0
-           then Ok outcome.Keeper_model_input_demotion.messages
-           else
-             (* A restored body is larger than the placeholder the cut was
-                measured against, so the cut is no longer known to fit. Choose
-                it again against what will actually be sent. *)
-             (match cut outcome.Keeper_model_input_demotion.messages with
-              | Ok recut -> Ok recut
-              | Error error ->
-                Error
-                  (Runtime_model_input_tail_window.budget_error_to_string error)))
+           (match cut planned.Keeper_model_input_demotion.messages with
+            | Error error ->
+              Error (Runtime_model_input_tail_window.budget_error_to_string error)
+            | Ok windowed ->
+              let outcome =
+                Keeper_model_input_demotion.materialize
+                  ~store:(Tool_blob_store.create ~base_path:ctx.base_path)
+                  ~pending
+                  windowed
+              in
+              if outcome.Keeper_model_input_demotion.reverted = 0
+              then Ok outcome.Keeper_model_input_demotion.messages
+              else
+                (* A restored body is larger than the placeholder the cut was
+                   measured against, so the cut is no longer known to fit.
+                   Choose it again against what will actually be sent. *)
+                (match cut outcome.Keeper_model_input_demotion.messages with
+                 | Ok recut -> Ok recut
+                 | Error error ->
+                   Error
+                     (Runtime_model_input_tail_window.budget_error_to_string error))))
     in
     match windowed with
     | Error _ as error -> error

--- a/lib/runtime/runtime_model_input_tail_window.ml
+++ b/lib/runtime/runtime_model_input_tail_window.ml
@@ -29,6 +29,11 @@ type budget_error =
       ; newest_atom_bytes : int
       }
 
+type projection =
+  { messages : Agent_sdk.Types.message list
+  ; dropped_atoms : int
+  }
+
 let budget_error_to_string = function
   | Reservation_exceeds_capacity
       { capacity_bytes; reserved_bytes; undroppable_bytes } ->
@@ -172,7 +177,7 @@ let assemble ~drop ~messages labelled =
     | Some Agent_sdk.Types.System -> preamble_message :: kept)
 ;;
 
-let project
+let project_with_drop
     ~measure_message_bytes
     ~capacity_bytes
     ~reserved_bytes
@@ -203,13 +208,13 @@ let project
       (Reservation_exceeds_capacity
          { capacity_bytes; reserved_bytes; undroppable_bytes })
   else if atom_count = 0
-  then Ok messages
+  then Ok { messages; dropped_atoms = 0 }
   else (
     let per_atom, suffix =
       atom_suffix_bytes ~measure_message_bytes ~atom_count labelled
     in
     match quantized_drop ~available_bytes ~atom_count suffix with
-    | Some drop -> Ok (assemble ~drop ~messages labelled)
+    | Some drop -> Ok { messages = assemble ~drop ~messages labelled; dropped_atoms = drop }
     | None ->
       let drop = exact_drop ~available_bytes ~atom_count suffix in
       if drop >= atom_count
@@ -217,5 +222,15 @@ let project
         Error
           (Newest_atom_exceeds_available
              { available_bytes; newest_atom_bytes = per_atom.(atom_count - 1) })
-      else Ok (assemble ~drop ~messages labelled))
+      else Ok { messages = assemble ~drop ~messages labelled; dropped_atoms = drop })
+;;
+
+let project ~measure_message_bytes ~capacity_bytes ~reserved_bytes messages =
+  Result.map
+    (fun projection -> projection.messages)
+    (project_with_drop
+       ~measure_message_bytes
+       ~capacity_bytes
+       ~reserved_bytes
+       messages)
 ;;

--- a/lib/runtime/runtime_model_input_tail_window.ml
+++ b/lib/runtime/runtime_model_input_tail_window.ml
@@ -182,7 +182,7 @@ let project_with_drop
     ~capacity_bytes
     ~reserved_bytes
     (messages : Agent_sdk.Types.message list)
-  : (Agent_sdk.Types.message list, budget_error) result
+  : (projection, budget_error) result
   =
   let labelled, atom_count = annotate messages in
   (* Everything the cut cannot remove is charged before any atom is

--- a/lib/runtime/runtime_model_input_tail_window.mli
+++ b/lib/runtime/runtime_model_input_tail_window.mli
@@ -94,10 +94,28 @@ type budget_error =
           would separate a tool result from its call, so the request is
           refused instead. *)
 
+type projection =
+  { messages : Agent_sdk.Types.message list
+  ; dropped_atoms : int
+        (** Exact raw-history cut chosen for [messages]. Projection stages that
+            rewrite historical bytes use this as their cache-stable anchor: the
+            rewrite boundary moves only when the authoritative cut moves. *)
+  }
+
 val budget_error_to_string : budget_error -> string
 (** Diagnostic rendering carrying the measured values. Suitable as the
     [Error] payload of an [Agent_sdk.Agent.model_input_projection], which
     aborts the turn before request measurement or dispatch. *)
+
+val project_with_drop
+  :  measure_message_bytes:(Agent_sdk.Types.message -> int)
+  -> capacity_bytes:int
+  -> reserved_bytes:int
+  -> Agent_sdk.Types.message list
+  -> (projection, budget_error) result
+(** The canonical projection result, including the exact atom cut selected
+    from the unmodified input. [messages] is physically the input list when
+    [dropped_atoms = 0]. *)
 
 val project
   :  measure_message_bytes:(Agent_sdk.Types.message -> int)

--- a/test/test_keeper_model_input_demotion.ml
+++ b/test/test_keeper_model_input_demotion.ml
@@ -10,7 +10,7 @@
 
 module Demotion = Masc.Keeper_model_input_demotion
 module Types = Agent_sdk.Types
-module Window = Masc.Runtime_model_input_tail_window
+module Window = Runtime_model_input_tail_window
 
 (* The production encoder, not a test-local one: the bound is only meaningful
    against the encoder the window will use, and a simplified stand-in would

--- a/test/test_keeper_model_input_demotion.ml
+++ b/test/test_keeper_model_input_demotion.ml
@@ -10,6 +10,7 @@
 
 module Demotion = Masc.Keeper_model_input_demotion
 module Types = Agent_sdk.Types
+module Window = Masc.Runtime_model_input_tail_window
 
 (* The production encoder, not a test-local one: the bound is only meaningful
    against the encoder the window will use, and a simplified stand-in would
@@ -45,24 +46,14 @@ let assistant text : Types.message =
   }
 ;;
 
-(* One atom is an assistant turn plus the tool messages answering it, so a
-   history of [n] atoms needs [n] assistant messages to age the earliest ones
-   past [retain_atoms]. *)
 let history_with_tool_bodies bodies =
-  let aged =
-    List.concat
-      (List.mapi
-         (fun i body ->
-            [ assistant (Printf.sprintf "call %d" i)
-            ; tool_message ~id:(Printf.sprintf "call-%d" i) body
-            ])
-         bodies)
-  in
-  let recent =
-    List.init (Demotion.retain_atoms + 1) (fun i ->
-      assistant (Printf.sprintf "recent %d" i))
-  in
-  aged @ recent
+  List.concat
+    (List.mapi
+       (fun i body ->
+          [ assistant (Printf.sprintf "call %d" i)
+          ; tool_message ~id:(Printf.sprintf "call-%d" i) body
+          ])
+       bodies)
 ;;
 
 let content_of (m : Types.message) =
@@ -86,7 +77,7 @@ let markers messages = List.concat_map content_of messages
 let bound_holds_for body_label body =
   let store = Tool_blob_store.create ~base_path:(Filename.temp_dir "demote" "") in
   let messages = history_with_tool_bodies [ body ] in
-  let planned = Demotion.plan ~measure_message_bytes messages in
+  let planned = Demotion.plan ~measure_message_bytes ~demote_before:1 messages in
   match planned.Demotion.pending with
   | [] ->
     (* Not demoted: the only admissible reason is that the placeholder did not
@@ -131,7 +122,7 @@ let bound_holds_for body_label body =
 let demotion_actually_happens () =
   let body = String.make 4000 'a' in
   let messages = history_with_tool_bodies [ body ] in
-  let planned = Demotion.plan ~measure_message_bytes messages in
+  let planned = Demotion.plan ~measure_message_bytes ~demote_before:1 messages in
   Alcotest.(check int)
     "a 4KB ASCII tool body is demoted"
     1
@@ -173,14 +164,8 @@ let bound_is_sound () =
 let structured_results_are_not_demoted () =
   let body = String.make 4000 'a' in
   let blocks = Some [ Types.Text "structured" ] in
-  let messages =
-    List.concat
-      [ [ assistant "call"; tool_message ~content_blocks:blocks ~id:"c0" body ]
-      ; List.init (Demotion.retain_atoms + 1) (fun i ->
-          assistant (Printf.sprintf "recent %d" i))
-      ]
-  in
-  let planned = Demotion.plan ~measure_message_bytes messages in
+  let messages = [ assistant "call"; tool_message ~content_blocks:blocks ~id:"c0" body ] in
+  let planned = Demotion.plan ~measure_message_bytes ~demote_before:1 messages in
   Alcotest.(check int)
     "structured tool result yields no pending demotion"
     0
@@ -207,7 +192,7 @@ let invalid_markers_are_not_demoted () =
    | Tool_output.Not_marker | Tool_output.Decoded _ ->
      Alcotest.fail "fixture must decode as Invalid_marker");
   let messages = history_with_tool_bodies [ corrupt ] in
-  let planned = Demotion.plan ~measure_message_bytes messages in
+  let planned = Demotion.plan ~measure_message_bytes ~demote_before:1 messages in
   Alcotest.(check int)
     "corrupt marker yields no pending demotion"
     0
@@ -223,43 +208,35 @@ let stored_results_are_not_demoted_again () =
       (Tool_blob_store.put store ~bytes:(String.make 4000 'a') ~mime:"text/plain")
   in
   let messages = history_with_tool_bodies [ marker ] in
-  let planned = Demotion.plan ~measure_message_bytes messages in
+  let planned = Demotion.plan ~measure_message_bytes ~demote_before:1 messages in
   Alcotest.(check int)
     "an existing marker is not demoted again"
     0
     (List.length planned.Demotion.pending)
 ;;
 
-(* --- 5. Recent atoms keep their bodies --------------------------------- *)
+(* --- 5. Atoms retained by the raw cut keep their bodies ---------------- *)
 
-let recent_atoms_are_verbatim () =
-  let body = String.make 4000 'a' in
-  let messages =
-    List.concat
-      (List.init (Demotion.retain_atoms - 1) (fun i ->
-         [ assistant (Printf.sprintf "call %d" i)
-         ; tool_message ~id:(Printf.sprintf "c%d" i) body
-         ]))
-  in
-  let planned = Demotion.plan ~measure_message_bytes messages in
+let raw_cut_retained_atoms_are_verbatim () =
+  let old_body = String.make 4000 'a' in
+  let retained_body = String.make 4000 'b' in
+  let messages = history_with_tool_bodies [ old_body; retained_body ] in
+  let planned = Demotion.plan ~measure_message_bytes ~demote_before:1 messages in
   Alcotest.(check int)
-    "a history inside the retain window demotes nothing"
-    0
+    "only the atom below the raw cut is demoted"
+    1
     (List.length planned.Demotion.pending);
   Alcotest.(check bool)
-    "and the list is returned unchanged"
+    "the raw-cut-retained body stays verbatim"
     true
-    (planned.Demotion.messages == messages)
+    (List.exists
+       (fun content -> String.equal content retained_body)
+       (markers planned.Demotion.messages))
 ;;
 
-(* --- 6. The demotion boundary does not move the transmitted head ------- *)
+(* --- 6. The demotion boundary moves only with the raw cut -------------- *)
 
-(* RFC-0363 §3.4: the cut moves at the head of the transmitted list and the
-   demotion boundary at its tail, so growing the history by one atom must not
-   rewrite an older message that the cut still keeps. The first draft
-   quantized the boundary on atom_count, which flipped the oldest 60 atoms to
-   markers with no window jump — a full prompt-cache miss. *)
-let boundary_moves_at_the_tail () =
+let boundary_moves_only_with_the_raw_cut () =
   let body = String.make 4000 'a' in
   let build atoms =
     List.concat
@@ -268,20 +245,52 @@ let boundary_moves_at_the_tail () =
          ; tool_message ~id:(Printf.sprintf "c%d" i) body
          ]))
   in
-  let head_of atoms =
-    let planned = Demotion.plan ~measure_message_bytes (build atoms) in
-    (* The oldest tool body, which no growth in the tail should disturb. *)
-    List.nth_opt (markers planned.Demotion.messages) 0
+  let bytes messages =
+    List.fold_left (fun total message -> total + measure_message_bytes message) 0 messages
   in
-  let base = Demotion.retain_atoms + 10 in
-  let first = head_of base in
+  (* Sixty atoms plus slack for the fixed preamble fit; a sixty-first 4KB
+     result does not. The authoritative cut must therefore stay at 60 while
+     the raw suffix grows from 10 through 60 atoms, then jump to 120. *)
+  let capacity_bytes = bytes (build Window.atoms_per_window) + 1024 in
+  let projected atoms =
+    let messages = build atoms in
+    match
+      Window.project_with_drop
+        ~measure_message_bytes
+        ~capacity_bytes
+        ~reserved_bytes:0
+        messages
+    with
+    | Error error ->
+      Alcotest.fail (Window.budget_error_to_string error)
+    | Ok raw ->
+      let planned =
+        Demotion.plan
+          ~measure_message_bytes
+          ~demote_before:raw.dropped_atoms
+          messages
+      in
+      raw.dropped_atoms, List.length planned.Demotion.pending
+  in
+  let first_cut = Window.atoms_per_window in
   List.iter
-    (fun step ->
-       Alcotest.(check (option string))
-         (Printf.sprintf "oldest body is stable at +%d atoms" step)
-         first
-         (head_of (base + step)))
-    [ 1; 2; 3; 17; 59; 60; 61 ]
+    (fun atoms ->
+       let dropped, demoted = projected atoms in
+       Alcotest.(check int)
+         (Printf.sprintf "raw cut stays fixed at %d atoms" atoms)
+         first_cut
+         dropped;
+       Alcotest.(check int)
+         (Printf.sprintf "demotion stays anchored at %d atoms" atoms)
+         first_cut
+         demoted)
+    [ first_cut + 10; first_cut + 11; first_cut + 27; first_cut * 2 ];
+  let dropped, demoted = projected ((first_cut * 2) + 1) in
+  Alcotest.(check int) "raw cut advances by one window" (first_cut * 2) dropped;
+  Alcotest.(check int)
+    "demotion advances only with that raw cut"
+    (first_cut * 2)
+    demoted
 ;;
 
 let () =
@@ -308,15 +317,15 @@ let () =
             `Quick
             stored_results_are_not_demoted_again
         ; Alcotest.test_case
-            "recent atoms keep their bodies"
+            "raw-cut-retained atoms keep their bodies"
             `Quick
-            recent_atoms_are_verbatim
+            raw_cut_retained_atoms_are_verbatim
         ] )
     ; ( "stability"
       , [ Alcotest.test_case
-            "demotion boundary moves at the tail"
+            "demotion boundary moves only with the raw cut"
             `Quick
-            boundary_moves_at_the_tail
+            boundary_moves_only_with_the_raw_cut
         ] )
     ]
 ;;


### PR DESCRIPTION
## 문제

#27013 병합 전 리뷰에서 확인됐지만 반영되지 않은 prompt-cache P1 후속입니다.

기존 `demote_before = atom_count - 60`은 새 atom이 하나 붙을 때마다 직전 원문 atom 하나를 marker로 바꿉니다. 두 요청의 공통 prefix가 매번 그 지점에서 끊겨, 새로 처리되는 atom이 1개에서 61개로 늘어납니다.

원 리뷰: https://github.com/jeong-sik/masc/pull/27013#issuecomment-5193967544

## 변경

- raw history의 authoritative tail-window cut을 `project_with_drop`으로 노출합니다.
- demotion은 같은 원문에서 선택된 `dropped_atoms` 아래만 rewrite합니다.
- 최종 cut은 더 작은 marker 후보를 기준으로 다시 계산해 이전에 빠졌던 atom을 되살릴 수 있습니다.
- 별도 recency 경계 `retain_atoms`와 관련 문서·테스트를 완전히 제거합니다.
- raw cut이 60에서 유지되는 동안 demotion도 60에 고정되고, raw cut이 120으로 뛸 때만 함께 이동하는 회귀 테스트를 추가합니다.

## 검증

- touched OCaml `ocamlformat --check`: PASS
- touched ML/MLI parser: PASS
- `git diff --check`: PASS
- focused Dune: 외부 bare Dune 6개를 repo wrapper가 감지해 exit 75로 거부; 우회하지 않고 PR CI를 권위로 확인합니다.

Draft를 유지하며 exact-head CI와 재리뷰 전에는 병합하지 않습니다.
