### PR TITLE
refactor(keeper): drain sixteen values no code can reach

### DIFF
--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -43,11 +43,6 @@ type hook_outputs = Keeper_run_tools_hook_accumulator.hook_outputs =
   }
 
 let freeze = Keeper_run_tools_hook_accumulator.freeze
-let record_requested_tool_names = Keeper_run_tools_hook_accumulator.record_requested_tool_names
-
-let task_scope_tool_names = Keeper_run_tools_task_scope.task_scope_tool_names
-let task_id_scope_of_tool_input = Keeper_run_tools_task_scope.task_id_scope_of_tool_input
-let task_id_scope_of_tool_call = Keeper_run_tools_task_scope.task_id_scope_of_tool_call
 
 (** Agent setup produced by Step 7.
 
@@ -71,6 +66,5 @@ type agent_setup = Keeper_run_tools_hooks.agent_setup =
   ; receipt_runtime_observation_ref : Runtime_observation.runtime_observation option ref
   ; receipt_response_text_present_ref : bool ref
   }
-
 
 let prepare_agent_setup = Keeper_run_tools_setup.prepare_agent_setup

--- a/lib/keeper/keeper_structured_output_schema.ml
+++ b/lib/keeper/keeper_structured_output_schema.ml
@@ -1,11 +1,7 @@
 (** Domain JSON schemas for keeper LLM sub-call parsers and exact-output flows. *)
 
 let string_schema = `Assoc [ "type", `String "string" ]
-let number_schema = `Assoc [ "type", `String "number" ]
 let integer_schema = `Assoc [ "type", `String "integer" ]
-let boolean_schema = `Assoc [ "type", `String "boolean" ]
-let nullable_string_schema = `Assoc [ "type", `List [ `String "string"; `String "null" ] ]
-let nullable_integer_schema = `Assoc [ "type", `List [ `String "integer"; `String "null" ] ]
 
 let string_array_schema =
   `Assoc [ "type", `String "array"; "items", string_schema ]
@@ -17,13 +13,6 @@ let enum_schema values =
   `Assoc
     [ "type", `String "string"
     ; "enum", `List (List.map (fun value -> `String value) values)
-    ]
-;;
-
-let nullable_enum_schema values =
-  `Assoc
-    [ "type", `List [ `String "string"; `String "null" ]
-    ; "enum", `List ((`Null) :: List.map (fun value -> `String value) values)
     ]
 ;;
 
@@ -73,7 +62,6 @@ let librarian_current_output_schema =
 (* Constant-size compaction boundary. The provider sees one contiguous run of
    typed eligible units and returns one faithful summary plus the first unit
    that remains exact. *)
-let compaction_plan_field_decisions = "decisions"
 let compaction_plan_field_unit_index = "unit_index"
 let compaction_plan_field_summary = "summary"
 let compaction_plan_field_keep_from_unit_index = "keep_from_unit_index"

--- a/lib/keeper/keeper_tag_dispatch.ml
+++ b/lib/keeper/keeper_tag_dispatch.ml
@@ -9,37 +9,6 @@
     See: mcp_server_eio_execute.ml dispatch_by_tag for the MCP server version.
     Issue: #4579 *)
 
-(** Helper: require Eio.Switch.t, return error if unavailable. *)
-let require_sw () =
-  match Eio_context.get_switch_opt () with
-  | Some sw -> Ok sw
-  | None -> Error "requires Eio switch (not available in keeper context)"
-;;
-
-(** Helper: require Eio clock, return error if unavailable. *)
-let require_clock () =
-  match Eio_context.get_clock_opt () with
-  | Some clock -> Ok clock
-  | None -> Error "requires Eio clock (not available in keeper context)"
-;;
-
-(** Helper: get optional proc_mgr via Process_eio fallback. *)
-let get_proc_mgr_opt () =
-  match Process_eio.get_proc_mgr () with
-  | Ok pm -> Some pm
-  | Error _ -> None
-;;
-
-(** Helper: require Eio net, return error if unavailable. *)
-let require_net () =
-  match Eio_context.get_net_opt () with
-  | Some net -> Ok net
-  | None -> Error "requires Eio net (not available in keeper context)"
-;;
-
-(** Helper: get optional net. *)
-let get_net_opt () = Eio_context.get_net_opt ()
-
 (** Stable string label for Otel_metric_store bucketing — keeps the
     metric [tag] dimension separated from per-tool [name]. *)
 let string_of_tag (tag : Tool_dispatch.module_tag) : string =
@@ -61,9 +30,6 @@ let string_of_tag (tag : Tool_dispatch.module_tag) : string =
   | Mod_operator -> "operator"
   | Mod_compact -> "compact"
 ;;
-
-(** Helper: get optional fs. *)
-let get_fs_opt () = Fs_compat.get_fs_opt ()
 
 (** Dispatch a tool by its module tag using keeper-available context.
 


### PR DESCRIPTION
## 무엇

#27042 인벤토리에서 **어떤 코드도 도달할 수 없는 값 16개** 를 지운다. 52줄 삭제, 0줄 추가.

각 값은 `.mli` 에 없고 자기 `.ml` 안에서도 호출되지 않는다. `-w +32` 가 전부 보고한다.

## `keeper_structured_output_schema.ml` — 6개

JSON Schema 타입 어휘를 대칭으로 채워놨는데 절반만 쓰인다.

| 삭제 | 유지 |
|---|---|
| `number_schema`, `boolean_schema`, `nullable_string_schema`, `nullable_integer_schema`, `nullable_enum_schema` | `string_schema`, `integer_schema`, `string_array_schema`, `array_schema`, `enum_schema`, `object_schema` |

`compaction_plan_field_decisions = "decisions"` 는 판정이 특히 분명하다. 바로 위 주석이 이미 다른 wire 형태를 서술한다 — "one contiguous run of typed eligible units and returns **one faithful summary plus the first unit** that remains exact". 그리고 테스트가 그 개념의 부재를 능동적으로 단언한다:

```ocaml
Alcotest.(check bool) "wire output has no per-unit decisions" false
  (Astring.String.is_infix ~affix:"decisions" (Yojson.Safe.to_string json));
```

필드는 사라졌는데 이름만 남았고, 테스트는 그 이름이 가리키는 것을 금지하고 있다. 삭제 후 주석은 그것을 실제로 구현하는 상수 3개 (`unit_index` / `summary` / `keep_from_unit_index`) 바로 위에 놓여 **더 정확해진다.**

## `keeper_tag_dispatch.ml` — 6개

`require_sw`, `require_clock`, `require_net`, `get_net_opt`, `get_proc_mgr_opt`, `get_fs_opt`. 각각 자기 docstring 을 달고 있다 ("Helper: require Eio clock, return error if unavailable").

`.mli` 가 export 하는 값은 **`dispatch` 하나** 다. 그리고 그 `dispatch` 는:

```ocaml
{ Task.Tool.config; agent_name; sw = Eio_context.get_switch_opt () }
```

`require_sw` 를 거치지 않고 `Eio_context` 를 직접 부른다. 다리를 놓고 다리 밑으로 건넜다.

모듈 헤더의 "Bridges the gap between keeper's available context (config, agent_name, **Eio globals**)" 는 삭제 후에도 참이다 — `dispatch` 가 여전히 Eio globals 에 도달한다. 고아 주석은 남지 않는다.

## `keeper_run_tools.ml` — 4개

```ocaml
let record_requested_tool_names = Keeper_run_tools_hook_accumulator.record_requested_tool_names
let task_scope_tool_names       = Keeper_run_tools_task_scope.task_scope_tool_names
let task_id_scope_of_tool_input = Keeper_run_tools_task_scope.task_id_scope_of_tool_input
let task_id_scope_of_tool_call  = Keeper_run_tools_task_scope.task_id_scope_of_tool_call
```

`.mli` 가 export 하지 않고 아무도 import 하지 않는 facade 재export. #27039 와 같은 형태다. 구현부는 원래 모듈에 그대로 있고, 바로 위의 `let freeze = ...` 는 살아있어 유지한다.

## 측정 (주장 아님)

전후 각각 별도 build directory 로 전체 스윕:

```
OCAMLPARAM='_,w=+32' DUNE_BUILD_DIR=/tmp/masc-w32X dune build --root . @check
```

| | values | files |
|---|---|---|
| before (`a36e89bff5`) | 112 | 67 |
| after | **96** | 64 |
| drained | 16 | — |
| newly appeared | 0 | — |

측정 함정 두 개를 실제로 밟아봤고 둘 다 **거짓 green** 을 낸다:

1. `_build` 를 일반 빌드와 공유하면 dune 이 `OCAMLPARAM` 을 의존성으로 추적하지 않아 아무것도 컴파일하지 않고 EXIT=0. (`scripts/audit-dead-surface.py:26` 에 기록된 함정)
2. 범위를 좁혀 `@lib/keeper/check` 로 돌려도 EXIT=0 이 나온다 — lib/keeper 에 47건이 있는데도. 별칭이 아무것도 빌드하지 않는다.

전체 `@check` 만 신뢰할 수 있다.

## 인벤토리 수치 정정

#27042 에 **111개** 로 적었는데 **112개** 다. 제 파서가 `^File "...", line (\d+)` 로 매칭해서, OCaml 이 여러 줄에 걸친 `val` 을 `lines 11-15` (복수형) 으로 보고하는 한 건을 놓쳤다:

```
File "lib/keeper/keeper_heartbeat_loop.mli", lines 11-15, characters 0-20:
Error (warning 32): unused value repair_identity_drift_for_keepalive.
```

이슈에 정정과 누락 항목을 코멘트로 남긴다.

## 이건 N-of-M 패치가 아니다

CLAUDE.md 워크어라운드 기준 3번은 "같은 변환을 사이트마다 따로 하면서 미완을 자인하는 것" 을 거부한다. 여기서 근본 해결은 **root `env` stanza 에서 `-w +32` 를 켜는 것** 이고, 그러려면 인벤토리가 비어 있어야 한다. 드레인은 그 전제조건이지 대체물이 아니다. 남은 96개는 #27042 에 전수 나열되어 있다.

## 검증

| 항목 | 결과 |
|---|---|
| `dune build @check` | EXIT=0 |
| `test_compaction_llm_summarizer` | 11 tests, Test Successful |
| `test_keeper_tag_dispatch` | 5 tests, Test Successful |
| `dune build @fmt` (변경 파일) | 실패 없음 (기존 `dune` 파일 실패만) |
| 절단면 고아 주석 | 0 |
| 열린 PR 과의 파일 충돌 | 0 (3개 파일 모두 미충돌 확인) |

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
