### PR TITLE
refactor(keeper): 숙청이 남긴 중복 runtime-id 비교 정리

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -362,9 +362,7 @@ let fallback_runtime_for_unavailable_profile
   in
   if not (String.equal normalized_effective normalized_base)
   then Some normalized_base
-  else if
-    String.equal normalized_effective (Keeper_config.default_runtime_id ())
-    || String.equal normalized_effective (Keeper_config.default_runtime_id ())
+  else if String.equal normalized_effective (Keeper_config.default_runtime_id ())
   then None
   else Some (Keeper_config.default_runtime_id ())
 
@@ -391,7 +389,6 @@ let degraded_retry_after_recoverable_error
   in
   if effective_is_declared_phase_buffer
      || effective_is_declared_phase_recovery
-     || String.equal normalized_effective (Keeper_config.default_runtime_id ())
      || String.equal normalized_effective (Keeper_config.default_runtime_id ())
   then None
   else if Keeper_runtime_failure_route.sdk_error_is_hard_quota err then
@@ -555,12 +552,9 @@ let recoverable_runtime_failure_reason (err : Agent_sdk.Error.sdk_error) =
 let normalized_runtime_id ~catalog_names name =
   let trimmed = String.trim name in
   if List.exists (String.equal trimmed) catalog_names then trimmed
-  else if
-    String.equal trimmed (Keeper_config.default_runtime_id ())
-    || String.equal trimmed (Keeper_config.default_runtime_id ())
-    || String.equal trimmed (Keeper_config.default_runtime_id ())
+  else if String.equal trimmed (Keeper_config.default_runtime_id ())
   then trimmed
-  else String.trim trimmed
+  else trimmed
 
 let runtime_catalog_names () =
   match Runtime.get_runtime_ids () with


### PR DESCRIPTION
## 발견

`keeper_error_classify` 의 세 곳이 같은 값을 두세 번 비교한다.

```ocaml
String.equal trimmed (Keeper_config.default_runtime_id ())
|| String.equal trimmed (Keeper_config.default_runtime_id ())
|| String.equal trimmed (Keeper_config.default_runtime_id ())
```

`git log -L` 이 이유를 보여준다.

```
원래     phase_buffer_cascade_name || phase_recovery_cascade_name || tool_required_cascade_name
#19506   default_cascade_name() || default_cascade_name() || default_cascade_name()
#19596   default_runtime_id()   || default_runtime_id()   || default_runtime_id()
```

`#19506` 의 제목이 *"collapse dead per-phase cascade names (cascade→Runtime 숙청 2)"* 다. 셋이 죽었다고 판단해 하나로 모았고, **모양은 남겼다.** `#19596` 이 이름만 바꿨다.

그래서 코드가 여전히 세 가지를 구분하는 것처럼 읽힌다. 숙청의 잔해다.

## 수정

각 disjunction 을 실제로 수행하는 하나의 비교로 만든다. `normalized_runtime_id` 의 마지막 분기가 이미 trim 된 바인딩을 다시 trim 하던 것도 정리한다 (`String.trim trimmed` → `trimmed`).

**동작 변화 없음**: 반복 호출은 한 호출 안에서 같은 config 를 읽고, disjunction 은 첫 항에서 단락된다.

## 전수

`lib/` 전체에서 인접한 중복 disjunct 를 훑었다. **이 파일 4곳이 전부다** (559/560 은 3연속의 앞 두 쌍).

## 검증

- `dune build --root . @check` EXIT=0
- `test_keeper_cooldown_cause_23438`, `test_keeper_invalid_request_auto_recover`, `test_keeper_runtime_observation_boundaries`, `test_keeper_sdk_error_typed_bridge` OK
- `scripts/check-doc-code-refs.sh`, `scripts/audit-keeper-tool-boundary-matrix.sh` PASS

9줄 삭제 / 3줄 추가.

RFC-WAIVED: 리팩터가 남긴 중복 비교 정리. 분류 결과·runtime id 판정 전부 불변. credential/identity, repo_manager, operator control plane, keeper sandbox, dashboard credential component, hooks, workflow 문서 어느 것도 건드리지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
