### PR TITLE
fix(dashboard): narrow execution trust projection

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -970,32 +970,150 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
     ("total", `Int (List.length summaries));
   ]
 
-let execution_trust_dashboard_json (config : Workspace.config) : Yojson.Safe.t =
-  let keepers =
-    match keepers_dashboard_json ~compact:true config with
-    | `Assoc fields -> (
-        match List.assoc_opt "keepers" fields with
-        | Some (`List rows) ->
-          rows
-          |> List.map (fun row ->
-                 `Assoc
-                   [
-                     ("name", Option.value ~default:`Null (Json_util.assoc_member_opt "name" row));
-                     ("agent_name", Option.value ~default:`Null (Json_util.assoc_member_opt "agent_name" row));
-                     ("keeper_id", Option.value ~default:`Null (Json_util.assoc_member_opt "keeper_id" row));
-                     ("phase", Option.value ~default:`Null (Json_util.assoc_member_opt "phase" row));
-                     ( "pipeline_stage",
-                       Option.value ~default:`Null (Json_util.assoc_member_opt "pipeline_stage" row) );
-                     ("status", Option.value ~default:`Null (Json_util.assoc_member_opt "status" row));
-                     ("trace_id", Option.value ~default:`Null (Json_util.assoc_member_opt "trace_id" row));
-                     ("generation", Option.value ~default:`Null (Json_util.assoc_member_opt "generation" row));
-                     ("current_task_id", Option.value ~default:`Null (Json_util.assoc_member_opt "current_task_id" row));
-                     ("active_goal_ids", Option.value ~default:`Null (Json_util.assoc_member_opt "active_goal_ids" row));
-                     ("trust", Option.value ~default:`Null (Json_util.assoc_member_opt "trust" row));
-                   ])
-        | _ -> [])
-    | _ -> []
+let execution_trust_row_of_dashboard_row row =
+  let field key =
+    (* sound-partial: invalid-profile and degraded rows intentionally omit
+       inapplicable fields; the established execution-trust wire value for
+       those absent fields is JSON null. *)
+    match Json_util.assoc_member_opt key row with
+    | Some value -> value
+    | None -> `Null
   in
+  `Assoc
+    [ ("name", field "name")
+    ; ("agent_name", field "agent_name")
+    ; ("keeper_id", field "keeper_id")
+    ; ("phase", field "phase")
+    ; ("pipeline_stage", field "pipeline_stage")
+    ; ("status", field "status")
+    ; ("trace_id", field "trace_id")
+    ; ("generation", field "generation")
+    ; ("current_task_id", field "current_task_id")
+    ; ("active_goal_ids", field "active_goal_ids")
+    ; ("trust", field "trust")
+    ]
+
+let execution_trust_row_of_meta
+      ~(now_ts : float)
+      (config : Workspace.config)
+      (m : Keeper_meta_contract.keeper_meta)
+  =
+  let agent =
+    Keeper_status_runtime.parse_agent_status config ~agent_name:m.agent_name
+  in
+  let keepalive_running = runtime_keepalive_running config m in
+  let registry_entry =
+    Keeper_registry.get ~base_path:config.base_path m.name
+  in
+  let phase, pipeline_stage =
+    match registry_entry with
+    | Some entry ->
+      ( `String (Keeper_state_machine.phase_to_string entry.phase)
+      , Keeper_status_runtime.pipeline_stage_of_phase entry.phase )
+    | None -> `Null, "offline"
+  in
+  (* [keeper_surface_status] depends only on the diagnostic health state. The
+     reply-history fields in [keeper_diagnostic_json] do not participate in
+     that state, so the trust surface must not read the conversation log. *)
+  let diagnostic =
+    Keeper_status_runtime.keeper_diagnostic_json
+      ~meta:m
+      ~agent_status:agent
+      ~keepalive_running
+      ~history_items:[]
+      ~now_ts
+  in
+  `Assoc
+    [ ("name", `String m.name)
+    ; ("agent_name", `String m.agent_name)
+    ; ( "keeper_id"
+      , match m.keeper_id with
+        | Some keeper_id -> `String (Keeper_id.Uid.to_string keeper_id)
+        | None -> `Null )
+    ; ("phase", phase)
+    ; ("pipeline_stage", `String pipeline_stage)
+    ; ( "status"
+      , `String
+          (Keeper_status_runtime.keeper_surface_status
+             ~agent_status:agent
+             ~diagnostic) )
+    ; ("trace_id", `String (Keeper_id.Trace_id.to_string m.runtime.trace_id))
+    ; ("generation", `Int m.runtime.nonce)
+    ; ( "current_task_id"
+      , Json_util.string_opt_to_json
+          (Option.map Keeper_id.Task_id.to_string m.current_task_id) )
+    ; ( "active_goal_ids"
+      , `List (List.map (fun goal_id -> `String goal_id) m.active_goal_ids) )
+    ; ("trust", keeper_trust_json ~include_receipt:false config m)
+    ]
+
+let execution_trust_keeper_rows (config : Workspace.config) =
+  let names =
+    keeper_names config @ Keeper_meta_store.configured_keeper_names config
+    |> List.sort_uniq String.compare
+  in
+  let now_ts = Time_compat.now () in
+  let results = Array.make (List.length names) None in
+  Eio.Fiber.all
+    (List.mapi
+       (fun idx name () ->
+         let row =
+           try
+             match
+               Keeper_types_profile.load_keeper_profile_defaults_result_for_base_path
+                 ~base_path:config.base_path
+                 name
+             with
+             | Error error ->
+               Some
+                 (invalid_profile_dashboard_row ~keeper_name:name error
+                  |> execution_trust_row_of_dashboard_row)
+             | Ok _ ->
+               (match Keeper_meta_store.read_meta config name with
+                | Error _ | Ok None -> None
+                | Ok (Some meta) ->
+                  Some (execution_trust_row_of_meta ~now_ts config meta))
+           with
+           | Eio.Cancel.Cancelled _ as exn -> raise exn
+           | exn ->
+             let error = Printexc.to_string exn in
+             Keeper_fd_pressure.note_exception
+               ~site:"keeper_dashboard.worker"
+               exn;
+             Log.Dashboard.error
+               "keeper dashboard worker error (%s): %s"
+               name
+               error;
+             (try
+                match Keeper_meta_store.read_meta config name with
+                | Ok (Some meta) ->
+                  Some
+                    (degraded_keeper_dashboard_row
+                       ~site:"keeper_dashboard_worker_exception"
+                       ~error
+                       meta
+                     |> execution_trust_row_of_dashboard_row)
+                | Error _ | Ok None -> None
+              with
+              | Eio.Cancel.Cancelled _ as exn -> raise exn
+              | fallback_exn ->
+                Log.Dashboard.error
+                  "keeper dashboard degraded fallback failed (%s): %s"
+                  name
+                  (Printexc.to_string fallback_exn);
+                None)
+         in
+         results.(idx) <- row)
+       names);
+  Array.to_list results |> List.filter_map Fun.id
+
+let execution_trust_dashboard_json (config : Workspace.config) : Yojson.Safe.t =
+  (* This surface is refreshed every minute. Building it from the generalized
+     Keeper dashboard projection used to scan metrics, histories, goals,
+     profiles, crash logs, and runtime contracts only to discard all but these
+     eleven fields. Keep the producer specialized so refresh work stays
+     proportional to execution-trust evidence. *)
+  let keepers = execution_trust_keeper_rows config in
   let now = Unix.gettimeofday () in
   let keeper_names = keeper_names config in
   let keepers_root = Workspace.keepers_runtime_dir config in

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1500,6 +1500,130 @@ let test_dashboard_proof_route_registered_in_http_routers () =
   check bool "HTTP/2 dashboard proof route registered" true
     (contains_substring h2 "\"/api/v1/dashboard/proof\"")
 
+let config_sync_runtime_toml =
+  {|[runtime]
+default = "test_provider.test_model"
+[providers.test_provider]
+display-name = "Test Provider"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:1"
+[models.test_model]
+api-name = "test-model"
+max-context = 8192
+tools-support = true
+streaming = true
+[test_provider.test_model]
+is-default = true
+max-concurrent = 1
+|}
+
+let execution_trust_keeper_row_keys =
+  [ "active_goal_ids"
+  ; "agent_name"
+  ; "current_task_id"
+  ; "generation"
+  ; "keeper_id"
+  ; "name"
+  ; "phase"
+  ; "pipeline_stage"
+  ; "status"
+  ; "trace_id"
+  ; "trust"
+  ]
+
+let test_execution_trust_uses_narrow_keeper_projection () =
+  with_test_env @@ fun ~env:_ ~sw:_ ~config ->
+  ignore (Workspace.init config ~agent_name:None);
+  let runtime_path = Filename.concat config.Workspace.base_path "runtime.toml" in
+  write_file runtime_path config_sync_runtime_toml;
+  (match Runtime.init_default ~config_path:runtime_path with
+   | Ok () -> ()
+   | Error error -> failf "runtime init: %s" error);
+  let name = "execution-trust-narrow-projection" in
+  let meta =
+    match
+      Masc_test_deps.meta_of_json_fixture
+        (`Assoc
+          [ "name", `String name
+          ; "agent_name", `String (Masc.Keeper_identity.keeper_agent_name name)
+          ; "trace_id", `String "execution-trust-narrow-trace"
+          ])
+    with
+    | Ok meta ->
+      { meta with
+        runtime = { meta.runtime with nonce = 17 }
+      ; active_goal_ids = [ "goal-narrow-1" ]
+      }
+    | Error error -> failf "meta fixture: %s" error
+  in
+  (match Masc.Keeper_meta_store.write_meta config meta with
+   | Ok () -> ()
+   | Error error -> failf "write meta: %s" error);
+  let json = Dashboard_http_keeper.execution_trust_dashboard_json config in
+  let open Yojson.Safe.Util in
+  let row =
+    match json |> member "keepers" |> to_list with
+    | [ row ] -> row
+    | rows -> failf "expected one execution-trust row, got %d" (List.length rows)
+  in
+  let full_row =
+    match
+      Dashboard_http_keeper.keepers_dashboard_json ~compact:true config
+      |> member "keepers"
+      |> to_list
+    with
+    | [ full_row ] -> full_row
+    | rows -> failf "expected one full Keeper row, got %d" (List.length rows)
+  in
+  let full_row_field key =
+    Option.value ~default:`Null (Json_util.assoc_member_opt key full_row)
+  in
+  let expected_row =
+    `Assoc
+      (List.map
+         (fun key -> key, full_row_field key)
+         [ "name"
+         ; "agent_name"
+         ; "keeper_id"
+         ; "phase"
+         ; "pipeline_stage"
+         ; "status"
+         ; "trace_id"
+         ; "generation"
+         ; "current_task_id"
+         ; "active_goal_ids"
+         ; "trust"
+         ])
+  in
+  check bool "narrow row preserves the full projection wire values" true
+    (Yojson.Safe.equal expected_row row);
+  let keys =
+    match row with
+    | `Assoc fields -> List.map fst fields |> List.sort String.compare
+    | _ -> fail "execution-trust keeper row must be an object"
+  in
+  check (list string) "wire field set remains exact"
+    execution_trust_keeper_row_keys keys;
+  check string "name" name (row |> member "name" |> to_string);
+  check string "agent name" (Masc.Keeper_identity.keeper_agent_name name)
+    (row |> member "agent_name" |> to_string);
+  check string "trace id" "execution-trust-narrow-trace"
+    (row |> member "trace_id" |> to_string);
+  check int "generation" 17 (row |> member "generation" |> to_int);
+  check (list string) "active goals" [ "goal-narrow-1" ]
+    (row |> member "active_goal_ids" |> to_list |> List.map to_string);
+  check bool "trust summary remains populated" true
+    (match row |> member "trust" with `Assoc _ -> true | _ -> false)
+
+let test_execution_trust_does_not_call_full_keeper_projection () =
+  let source = read_file "lib/dashboard/dashboard_http_keeper.ml" in
+  check bool
+    "execution-trust refresh cannot reintroduce the full compact projection"
+    false
+    (contains_substring
+       source
+       "keepers_dashboard_json ~compact:true")
+
 let test_gate_mode_change_json_separates_saved_mode_from_recovery () =
   let open Yojson.Safe.Util in
   let change : Masc.Keeper_gate_mode.change =
@@ -2932,23 +3056,6 @@ let test_context_shrink_detection () =
     (shrink (with_max_override base (Some 1000)) [ ("name", `String "shrink-fixture") ])
 ;;
 
-let config_sync_runtime_toml =
-  {|[runtime]
-default = "test_provider.test_model"
-[providers.test_provider]
-display-name = "Test Provider"
-protocol = "openai-compatible-http"
-endpoint = "http://127.0.0.1:1"
-[models.test_model]
-api-name = "test-model"
-max-context = 8192
-tools-support = true
-streaming = true
-[test_provider.test_model]
-is-default = true
-max-concurrent = 1
-|}
-
 let prepare_config_sync_keeper config name =
   let runtime_path = Filename.concat config.Workspace.base_path "runtime.toml" in
   write_file runtime_path config_sync_runtime_toml;
@@ -3244,6 +3351,10 @@ let () =
             test_operator_snapshot_publication_rejects_stale_races;
           test_case "proof payload exposes submission index" `Quick
             test_dashboard_proof_http_json_surfaces_submission_index;
+          test_case "execution trust uses narrow Keeper projection" `Quick
+            test_execution_trust_uses_narrow_keeper_projection;
+          test_case "execution trust cannot call full Keeper projection" `Quick
+            test_execution_trust_does_not_call_full_keeper_projection;
           test_case "offline keeper composite exposes secret projection" `Quick
             test_offline_keeper_composite_exposes_secret_projection;
           test_case "state diagram runtime projection redacts live evidence" `Quick


### PR DESCRIPTION
## What changed

- Replace the `execution-trust` refresh's generalized `keepers_dashboard_json ~compact:true` call with a purpose-built Keeper read model.
- Preserve the exact 11-field Keeper wire contract, including invalid-profile and degraded fallbacks.
- Add behavioral parity coverage against the former compact projection and a structural guard preventing the full projection from returning.

## Root cause

The minute-level execution-trust refresh needed only identity, lifecycle, status, and trust fields, but it built the whole compact Keeper dashboard row first. That path scans metrics and conversation history and computes goals, runtime contracts, crash diagnostics, and other sections that the execution-trust payload discards. This PR replaces that generalized producer with a read model for the exact 11-field wire contract.

This follows #27027: push invalidation removed browser polling, while this PR narrows one remaining background producer to the data it serves.

## Allocation measurement

On OCaml 5.5.0 at current head `3a4d9c367177263b373003fa62b21548e77aec4a`, the existing parity fixture was temporarily instrumented with `Gc.allocated_bytes`. Both paths were warmed, `Gc.full_major` ran before each sample, and five fresh test processes measured one call with one Keeper:

- former `keepers_dashboard_json ~compact:true`: 62,825–62,863 allocated words
- new `execution_trust_dashboard_json`: 17,379–17,417 allocated words
- reduction: 72.28–72.35%

Command: `_build/default/test/test_dashboard_http_core.exe test --color=never -v 'dashboard behavior contracts' 2`

This measurement establishes lower allocation for this fixture only. It does not establish that this producer caused process-wide GC pauses or latency in other requests; those causal claims are intentionally omitted.

## Validation

- `scripts/dune-local.sh build test/test_dashboard_http_core.exe`
- `test_dashboard_http_core.exe test "dashboard behavior contracts"`: 7/7 passed
- `scripts/ocaml-structure-ratchet.sh`
- `scripts/silent-failure-ratchet.sh`
- Exact wire-value parity with the previous compact projection is covered by test.
