### PR TITLE
refactor(dashboard): 양쪽 결과가 같던 lifecycle 분기 제거

### DIFF
--- a/lib/dashboard/dashboard_execution_builders.ml
+++ b/lib/dashboard/dashboard_execution_builders.ml
@@ -286,9 +286,10 @@ let continuity_row_of_keeper ~(now_ts : float) keeper : continuity_context =
       | Some ratio when ratio >= ctx_preparing -> Lc_preparing
       | Some ratio when ratio >= ctx_compacting -> Lc_compacting
       | Some _ | None ->
-          if last_action_ts > 0.0 then Lc_active
-          else if last_signal_ts > 0.0 then Lc_idle
-          else Lc_idle
+          (* Both outcomes of the signal test were Lc_idle, so the test
+             distinguished nothing. last_signal_ts still feeds last_signal_at
+             and signal_age_s; only this branch is gone. *)
+          if last_action_ts > 0.0 then Lc_active else Lc_idle
   in
   let (state, tone, note) =
     match liveness with


### PR DESCRIPTION
## 대상

keeper lifecycle 판정의 마지막 분기.

```ocaml
if last_action_ts > 0.0 then Lc_active
else if last_signal_ts > 0.0 then Lc_idle
else Lc_idle
```

`last_signal_ts` 를 검사하는데 **양쪽 결과가 `Lc_idle`** 이다. 아무것도 구분하지 않는다.

## 확인한 것

- **문자열 시절부터 그랬다.** `5a41e550f6` (lifecycle 문자열 → variant 전환) 이 `"idle"` 을 양쪽 다 `Lc_idle` 로 바꿨다
- **만들려던 죽은 상태가 없다.** `Lc_active` / `Lc_compacting` / `Lc_handoff_imminent` / `Lc_idle` / `Lc_offline` / `Lc_preparing` 여섯 생성자 전부 다른 곳에서 쓰인다
- **`last_signal_ts` 는 살아있다.** `last_signal_at` (100행) 과 `signal_age_s` (109행) 가 읽는다. 이 분기만 제거한다

## 전수

`lib/` 에서 같은 형태를 훑었다.

| 형태 | 결과 |
|---|---|
| 엄밀한 `then X else X` | 3건 중 2건은 정규식 오탐 (`else acc +`, `else base_messages @`), 실제는 이것 하나 |
| 모든 arm 이 같은 값인 `match` | 21건 — 확인해보니 **전부 CLAUDE.md 가 권장하는 명시적 열거**이거나 payload 추출 (`keeper_terminal_reason.to_wire` 8 arm 은 주석이 왕복 충실성을 설명한다) |
| 리스트 중복 원소 | 2건 — docker `-v` 두 개(볼륨 두 개), 주석 안 예시 |

즉 이 계열에서 실제로 남은 건 이 하나다.

## 검증

- `dune build --root . @check` EXIT=0
- `test_dashboard_briefing`, `test_dashboard_continuity_briefs` OK
- `scripts/check-doc-code-refs.sh`, `scripts/audit-keeper-tool-boundary-matrix.sh` PASS

RFC-WAIVED: 결과가 같은 분기 제거. lifecycle 판정 결과 불변. credential/identity, repo_manager, operator control plane, keeper sandbox, dashboard credential component, hooks, workflow 문서 어느 것도 건드리지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
