### PR TITLE
feat(keeper): live tool-call progress broadcast for queued chat turns

### DIFF
--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -6,6 +6,7 @@ import {
   appendAssistantToolTraceStep,
   appendAssistantThinkingDelta,
   appendThreadEntry,
+  applyKeeperTurnProgress,
   attachKeeperAudioClip,
   chatHistoryEntriesFromRest,
   finalizeAssistantEntry,
@@ -1534,5 +1535,105 @@ describe('RFC-0235 audio clip normalization', () => {
     })
     expect(attached).toBe(false)
     expect(keeperThreads.value.echo?.[0]?.audio).toBeUndefined()
+  })
+})
+
+describe('applyKeeperTurnProgress (keeper_chat_turn_progress broadcast)', () => {
+  beforeEach(() => {
+    keeperThreads.value = {}
+  })
+
+  function progress(partial: Partial<Parameters<typeof applyKeeperTurnProgress>[1]>) {
+    return {
+      runId: 'run-1',
+      kind: 'tool_call_start' as const,
+      toolCallId: 'tc-1',
+      toolName: 'Grep',
+      receiptIds: ['chatq-1'],
+      ...partial,
+    }
+  }
+
+  it('creates a synthetic placeholder with a pending step when no in-flight entry exists', () => {
+    applyKeeperTurnProgress('taskmaster', progress({}))
+    const entries = keeperThreads.value.taskmaster ?? []
+    expect(entries).toHaveLength(1)
+    const placeholder = entries[0]!
+    expect(placeholder.id).toBe('turn-progress-run-1')
+    expect(placeholder.role).toBe('assistant')
+    expect(placeholder.delivery).toBe('streaming')
+    expect(placeholder.queueReceiptIds).toEqual(['chatq-1'])
+    expect(placeholder.traceSteps).toEqual([
+      expect.objectContaining({ kind: 'tool', toolCallId: 'tc-1', name: 'Grep', status: 'pending' }),
+    ])
+  })
+
+  it('marks the step ok on tool_call_end', () => {
+    applyKeeperTurnProgress('taskmaster', progress({}))
+    applyKeeperTurnProgress('taskmaster', progress({ kind: 'tool_call_end', toolName: null }))
+    const step = keeperThreads.value.taskmaster?.[0]?.traceSteps?.[0]
+    expect(step?.kind).toBe('tool')
+    expect(step?.kind === 'tool' && step.status).toBe('ok')
+  })
+
+  it('is idempotent per tool call id', () => {
+    applyKeeperTurnProgress('taskmaster', progress({}))
+    applyKeeperTurnProgress('taskmaster', progress({}))
+    const placeholder = keeperThreads.value.taskmaster?.[0]
+    expect(keeperThreads.value.taskmaster).toHaveLength(1)
+    expect(placeholder?.traceSteps).toHaveLength(1)
+  })
+
+  it('attaches to an existing in-flight assistant entry instead of creating a placeholder', () => {
+    appendThreadEntry('taskmaster', {
+      id: 'queued-reply',
+      role: 'assistant',
+      source: 'direct_assistant',
+      label: 'taskmaster',
+      text: '',
+      rawText: null,
+      timestamp: null,
+      delivery: 'queued',
+      streamState: 'opening',
+      details: null,
+    })
+    applyKeeperTurnProgress('taskmaster', progress({}))
+    const entries = keeperThreads.value.taskmaster ?? []
+    expect(entries).toHaveLength(1)
+    expect(entries[0]!.id).toBe('queued-reply')
+    expect(entries[0]!.traceSteps).toHaveLength(1)
+  })
+
+  it('ignores tool_call_end for a step this client never saw start', () => {
+    applyKeeperTurnProgress('taskmaster', progress({ kind: 'tool_call_end', toolName: null }))
+    const entries = keeperThreads.value.taskmaster ?? []
+    // Placeholder may exist but must not gain an unnamed step.
+    expect(entries[0]?.traceSteps ?? []).toHaveLength(0)
+  })
+
+  it('converges: history merge folds the trace and drops the placeholder', () => {
+    applyKeeperTurnProgress('taskmaster', progress({}))
+    applyKeeperTurnProgress('taskmaster', progress({ kind: 'tool_call_end', toolName: null }))
+    mergeServerHistoryEntries('taskmaster', [
+      {
+        id: 'hist-assistant-1',
+        role: 'assistant',
+        source: 'direct_assistant',
+        label: 'taskmaster',
+        text: '코드 탐색 완료',
+        rawText: '코드 탐색 완료',
+        timestamp: '2026-08-05T06:40:00.000Z',
+        delivery: 'history',
+        streamState: null,
+        details: null,
+        queueReceiptIds: ['chatq-1'],
+      },
+    ])
+    const entries = keeperThreads.value.taskmaster ?? []
+    expect(entries).toHaveLength(1)
+    expect(entries[0]!.id).toBe('hist-assistant-1')
+    expect(entries[0]!.traceSteps).toEqual([
+      expect.objectContaining({ kind: 'tool', toolCallId: 'tc-1', name: 'Grep', status: 'ok' }),
+    ])
   })
 })

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -1382,6 +1382,71 @@ export function markAssistantToolTraceErrored(
   if (!found) warnMissingToolTrace('error patch', name, entryId, id)
 }
 
+/** Live tool-call progress broadcast ([keeper_chat_turn_progress]) for
+ *  queued/consumer-side turns, whose chat body otherwise stays silent until
+ *  the terminal transcript commit. Attaches trace steps to the newest
+ *  in-flight assistant entry (the queue placeholder, which already carries
+ *  the receipt identity that converges with history); when no in-flight
+ *  entry exists (e.g. a second browser), a synthetic placeholder keyed by
+ *  run id is created carrying the same receipt ids so the standard
+ *  history-convergence path folds its trace into the canonical transcript
+ *  row at turn end. Idempotent per tool call via [toolCallId] upsert. */
+export interface KeeperTurnProgress {
+  runId: string
+  kind: 'tool_call_start' | 'tool_call_end'
+  toolCallId: string
+  toolName?: string | null
+  receiptIds?: string[]
+}
+
+export function applyKeeperTurnProgress(name: string, progress: KeeperTurnProgress): void {
+  const toolCallId = nonBlankToolCallId(progress.toolCallId)
+  const runId = progress.runId.trim()
+  if (!toolCallId || !runId) return
+  const entries = keeperThreads.value[name] ?? []
+  const inFlight = [...entries].reverse().find(
+    entry => entry.role === 'assistant' && isInFlightDelivery(entry.delivery),
+  )
+  let entryId = inFlight?.id
+  if (!entryId) {
+    entryId = `turn-progress-${runId}`
+    if (!entries.some(entry => entry.id === entryId)) {
+      const receiptIds = (progress.receiptIds ?? [])
+        .map(receiptId => receiptId.trim())
+        .filter(receiptId => receiptId.length > 0)
+      appendThreadEntry(name, withoutUndefined({
+        id: entryId,
+        role: 'assistant' as const,
+        source: 'direct_assistant' as const,
+        label: name,
+        text: '',
+        rawText: null,
+        timestamp: null,
+        delivery: 'streaming' as const,
+        streamState: 'streaming' as const,
+        streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', {
+          eventName: 'keeper_chat_turn_progress',
+        }),
+        queueReceiptIds: receiptIds.length > 0 ? receiptIds : undefined,
+        details: null,
+      }))
+    }
+  }
+  if (progress.kind === 'tool_call_start') {
+    const toolName = progress.toolName?.trim()
+    if (!toolName) return
+    appendAssistantToolTraceStep(name, entryId, { toolCallId, name: toolName })
+    return
+  }
+  // tool_call_end carries no tool name, so only close a step this client saw
+  // start; an unnamed step cannot be rendered for a mid-turn attach.
+  const entry = (keeperThreads.value[name] ?? []).find(candidate => candidate.id === entryId)
+  const hasStep = entry?.traceSteps?.some(
+    step => step.kind === 'tool' && step.toolCallId === toolCallId,
+  ) ?? false
+  if (hasStep) markAssistantToolTraceEnded(name, entryId, toolCallId)
+}
+
 export function finalizeAssistantEntry(
   name: string,
   entryId: string,

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -20,6 +20,7 @@ import { appendLiveToolCall } from './components/session-trace/session-trace-liv
 import { scheduleSessionTraceReload } from './components/session-trace/session-trace-state'
 import { recordSseCompaction } from './components/keeper-workspace/compaction-snapshots'
 import { appendAuditEntry } from './live-store'
+import { applyKeeperTurnProgress } from './keeper-state'
 import { isCrashedPhase } from './lib/keeper-predicates'
 import {
   parseOasPayload,
@@ -595,6 +596,25 @@ function handleEvent(event: SSEEvent): void {
           toolIoRedacted: event.tool_io_redacted === true,
         })
       }
+      break
+    }
+    case 'keeper_chat_turn_progress': {
+      // Live tool-call progress for queued/consumer-side turns — no journal
+      // entry (keeper_tool_call already journals completions); this feeds the
+      // chat thread directly.
+      const keeperName = event.name ?? agent
+      const runId = event.run_id?.trim()
+      const toolCallId = event.tool_call_id
+      const kind = event.kind
+      if (!keeperName || !runId || !toolCallId) break
+      if (kind !== 'tool_call_start' && kind !== 'tool_call_end') break
+      applyKeeperTurnProgress(keeperName, {
+        runId,
+        kind,
+        toolCallId,
+        toolName: event.tool_name ?? null,
+        receiptIds: event.receipt_ids,
+      })
       break
     }
     case 'keeper_tool_skipped': {

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -33,6 +33,7 @@ export type SSEEventType =
   | 'keeper_phase_changed'
   | 'keeper_composite_changed'
   | 'keeper_chat_appended'
+  | 'keeper_chat_turn_progress'
   | 'keeper_waiting_inventory_changed'
   | 'keeper_compaction_snapshots_changed'
   | 'oas_telemetry_sample'
@@ -255,6 +256,12 @@ export interface SSEEvent {
   // duration_sec?, device_id? }`. Optional; assistant transcript rows
   // render a user-gesture play button when present.
   audio?: SSEAudioClip
+  // keeper_chat_turn_progress: live tool-call progress for queued/
+  // consumer-side turns. `kind` is 'tool_call_start' | 'tool_call_end';
+  // receipt_ids carries the queue-lane producer identity so a live progress
+  // placeholder converges with the persisted transcript row at turn end.
+  tool_call_id?: string
+  receipt_ids?: string[]
 }
 
 // RFC-0235 P1: nested audio payload inside `keeper_chat_appended` events.

--- a/lib/keeper/keeper_chat_broadcast.ml
+++ b/lib/keeper/keeper_chat_broadcast.ml
@@ -105,3 +105,48 @@ let chat_appended ~keeper_name ~source ?content () =
     event, mirroring {!chat_appended}. *)
 let chat_appended_with_audio ~keeper_name ~source ~audio ?content () =
   do_broadcast ~keeper_name ~source ~audio:(Some audio) ?content ()
+
+type turn_progress_kind =
+  | Tool_call_started
+  | Tool_call_ended
+
+let turn_progress_kind_to_string = function
+  | Tool_call_started -> "tool_call_start"
+  | Tool_call_ended -> "tool_call_end"
+
+let turn_progress_to_json ~keeper_name ~run_id ~kind ~tool_call_id ~tool_name
+    ~receipt_ids =
+  `Assoc
+    ([ ("type", `String "keeper_chat_turn_progress")
+     ; ("name", `String keeper_name)
+     ; ("run_id", `String run_id)
+     ; ("kind", `String (turn_progress_kind_to_string kind))
+     ; ("tool_call_id", `String tool_call_id)
+     ; ("ts_unix", `Float (Time_compat.now ()))
+     ]
+     @ (match tool_name with
+        | None -> []
+        | Some tool_name -> [ ("tool_name", `String tool_name) ])
+     @
+     match receipt_ids with
+     | [] -> []
+     | receipt_ids ->
+       [ ("receipt_ids", `List (List.map (fun id -> `String id) receipt_ids)) ])
+
+let turn_progress ~keeper_name ~run_id ~kind ~tool_call_id ?tool_name
+    ?(receipt_ids = []) () =
+  try
+    Sse.broadcast
+      (turn_progress_to_json ~keeper_name ~run_id ~kind ~tool_call_id ~tool_name
+         ~receipt_ids)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string SseBroadcastFailures)
+      ~labels:[ ("keeper", keeper_name); ("site", "chat_turn_progress") ]
+      ();
+    Log.Keeper.warn
+      "keeper_chat_broadcast: turn_progress name=%s failed: %s"
+      keeper_name
+      (Printexc.to_string exn)

--- a/lib/keeper/keeper_chat_broadcast.mli
+++ b/lib/keeper/keeper_chat_broadcast.mli
@@ -41,3 +41,45 @@ val chat_appended :
     downstream. [content] is used to derive rich blocks for the event. *)
 val chat_appended_with_audio :
   keeper_name:string -> source:string -> audio:audio_clip -> ?content:string -> unit -> unit
+
+(** Kind of a [keeper_chat_turn_progress] event. *)
+type turn_progress_kind =
+  | Tool_call_started
+  | Tool_call_ended
+
+val turn_progress_kind_to_string : turn_progress_kind -> string
+
+(** Serialize a [keeper_chat_turn_progress] event. Exposed for unit tests. *)
+val turn_progress_to_json :
+  keeper_name:string ->
+  run_id:string ->
+  kind:turn_progress_kind ->
+  tool_call_id:string ->
+  tool_name:string option ->
+  receipt_ids:string list ->
+  Yojson.Safe.t
+
+(** Broadcast a [keeper_chat_turn_progress] SSE event when a turn executes a
+    tool call, so dashboard clients watching a queued/consumer-side turn see
+    live progress in the chat thread instead of a silent gap until
+    {!chat_appended}. Slice-less like {!chat_appended}: it rides the WS
+    raw-forward catch-all to every authenticated session, and the dashboard
+    applies it idempotently keyed by [tool_call_id].
+
+    [receipt_ids] carries the queue-lane producer identity for queued turns
+    so the dashboard's history-convergence machinery can fold a live progress
+    placeholder into the canonical transcript row at turn end.
+
+    Carries tool identity only — never args or results — so no redaction is
+    needed at this boundary. Exceptions from [Sse.broadcast] are counted on
+    the [keeper_sse_broadcast_failures] counter (site [chat_turn_progress])
+    and logged at WARN. {!Eio.Cancel.Cancelled} propagates. *)
+val turn_progress :
+  keeper_name:string ->
+  run_id:string ->
+  kind:turn_progress_kind ->
+  tool_call_id:string ->
+  ?tool_name:string ->
+  ?receipt_ids:string list ->
+  unit ->
+  unit

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -2676,6 +2676,17 @@ let process_single_turn ~user_row_origin ~submission
                   | `Stream_event of Agent_sdk.Types.sse_event
                   ])))
   in
+  (* Queue-lane producer identity shared with the persisted transcript row;
+     lets the dashboard fold a live progress placeholder into the canonical
+     history entry at turn end. *)
+  let progress_receipt_ids =
+    match submission with
+    | Queued_receipt { receipt_ids; _ } ->
+        List.map
+          Keeper_chat_delivery_identity.Receipt_id.to_string
+          (Keeper_chat_delivery_identity.Receipt_ids.to_list receipt_ids)
+    | Direct_request -> []
+  in
   let rec consume_worker_events bridge_state =
     match next_worker_projection () with
     | `Client_disconnected -> None
@@ -2684,7 +2695,27 @@ let process_single_turn ~user_row_origin ~submission
           translate_oas_stream_event ~redact_text
             ~base_dir:base_path bridge_state evt
         in
-        List.iter (Keeper_chat_events.publish events) translated.chat_events;
+        List.iter
+          (fun event ->
+            Keeper_chat_events.publish events event;
+            (* Tap tool-call progress for dashboard clients watching a
+               queued/consumer-side turn: their chat body stays silent until
+               the terminal transcript commit otherwise. Idempotent on the
+               dashboard keyed by [tool_call_id], so direct-stream turns may
+               broadcast as well. *)
+            (match event with
+             | Keeper_chat_events.Tool_call_start
+                 { tool_call_id; tool_call_name } ->
+                 Keeper_chat_broadcast.turn_progress ~keeper_name:agent_name
+                   ~run_id ~kind:Keeper_chat_broadcast.Tool_call_started
+                   ~tool_call_id ~tool_name:tool_call_name
+                   ~receipt_ids:progress_receipt_ids ()
+             | Keeper_chat_events.Tool_call_end { tool_call_id } ->
+                 Keeper_chat_broadcast.turn_progress ~keeper_name:agent_name
+                   ~run_id ~kind:Keeper_chat_broadcast.Tool_call_ended
+                   ~tool_call_id ~receipt_ids:progress_receipt_ids ()
+             | _ -> ()))
+          translated.chat_events;
         consume_worker_events translated.bridge_state
     | `Completion (Completion_queued_turn_deferred rejection) ->
         let message =

--- a/test/dune
+++ b/test/dune
@@ -1710,6 +1710,11 @@
  (modules test_keeper_chat_slack)
  (libraries alcotest masc_test_deps))
 
+(test
+ (name test_keeper_chat_broadcast)
+ (modules test_keeper_chat_broadcast)
+ (libraries alcotest masc_test_deps))
+
 (include stanzas/test_ci_run_tests_script.inc)
 
 (include stanzas/test_contract_harness_auth_script.inc)

--- a/test/test_keeper_chat_broadcast.ml
+++ b/test/test_keeper_chat_broadcast.ml
@@ -1,0 +1,59 @@
+module B = Masc.Keeper_chat_broadcast
+
+let yojson_testable =
+  Alcotest.testable
+    (fun fmt json -> Format.fprintf fmt "%s" (Yojson.Safe.to_string json))
+    ( = )
+
+let fields_without_ts_unix json =
+  match json with
+  | `Assoc fields ->
+      (match List.assoc_opt "ts_unix" fields with
+       | Some (`Float _) -> ()
+       | _ -> Alcotest.fail "ts_unix missing or not a float");
+      List.remove_assoc "ts_unix" fields
+  | _ -> Alcotest.fail "expected assoc payload"
+
+let test_tool_call_started_payload () =
+  let json =
+    B.turn_progress_to_json ~keeper_name:"taskmaster" ~run_id:"run-1"
+      ~kind:B.Tool_call_started ~tool_call_id:"tc-1" ~tool_name:(Some "Grep")
+      ~receipt_ids:[ "chatq-1"; "chatq-2" ]
+  in
+  Alcotest.(check (list (pair string yojson_testable)))
+    "start payload"
+    [ ("type", `String "keeper_chat_turn_progress")
+    ; ("name", `String "taskmaster")
+    ; ("run_id", `String "run-1")
+    ; ("kind", `String "tool_call_start")
+    ; ("tool_call_id", `String "tc-1")
+    ; ("tool_name", `String "Grep")
+    ; ("receipt_ids", `List [ `String "chatq-1"; `String "chatq-2" ])
+    ]
+    (fields_without_ts_unix json)
+
+let test_tool_call_ended_payload () =
+  let json =
+    B.turn_progress_to_json ~keeper_name:"taskmaster" ~run_id:"run-1"
+      ~kind:B.Tool_call_ended ~tool_call_id:"tc-1" ~tool_name:None
+      ~receipt_ids:[]
+  in
+  Alcotest.(check (list (pair string yojson_testable)))
+    "end payload omits tool_name and empty receipt_ids"
+    [ ("type", `String "keeper_chat_turn_progress")
+    ; ("name", `String "taskmaster")
+    ; ("run_id", `String "run-1")
+    ; ("kind", `String "tool_call_end")
+    ; ("tool_call_id", `String "tc-1")
+    ]
+    (fields_without_ts_unix json)
+
+let () =
+  Alcotest.run "keeper_chat_broadcast"
+    [ ( "turn_progress"
+      , [ Alcotest.test_case "tool_call_start payload" `Quick
+            test_tool_call_started_payload
+        ; Alcotest.test_case "tool_call_end payload" `Quick
+            test_tool_call_ended_payload
+        ] )
+    ]


### PR DESCRIPTION
## 문제

큐에 적재된 keeper 채팅 턴(taskmaster 등)이 멀티턴 도구 체이닝을 도는 동안 대시보드 대화창 본문이 턴 종료까지 완전히 침묵 — 상단 상태 헤더만 갱신되어 먹통/큐 정체로 오해하게 됨 (Refs #27056).

## 원인

`process_single_turn`이 턴당 `Keeper_chat_events` 스트림에 `Tool_call_start/end` 등 중간 이벤트를 이미 발행하지만, 큐 소비자 경로에서는 Discord/Slack 어댑터만 소비하거나 `drain_events`로 폐기 — 대시보드 SSE 허브 도달 경로 부재.

## 변경

**서버 (OCaml)**
- `Keeper_chat_broadcast.turn_progress`: slice-less SSE `keeper_chat_turn_progress` (kind=tool_call_start|tool_call_end, tool_call_id, tool_name?, receipt_ids). tool identity만 전달(args/result 없음 → redaction 불필요), 실패 시 기존 `keeper_sse_broadcast_failures` 카운터/WARN 패턴.
- `consume_worker_events` publish 지점에 탭. `Eio.Stream` competing-consumer 문제를 피하기 위해 제2 구독자가 아닌 publish 탭 방식. 큐 턴은 `receipt_ids`를 실어 프론트의 기존 히스토리 수렴 기계(receipt 조인)가 placeholder를 자동 정리하도록 함.

**대시보드 (TS)**
- `sse.ts`: `keeper_chat_turn_progress` 라우팅 arm (저널 스팸 없이 채팅 스레드로 직행).
- `keeper-state.ts` `applyKeeperTurnProgress`: 최신 in-flight assistant 엔트리(큐 placeholder)에 기존 trace-step 기계로 부착. 없으면 run-id 키 synthetic placeholder 생성. `toolCallId` upsert 멱등 — 인터랙티브 스트림과의 중복 자연 흡수. 종료 시 history refetch가 기존 수렴 로직으로 placeholder를 정리.

## 검증

- OCaml: 신규 `test_keeper_chat_broadcast` 2개 통과, 인접 `test_keeper_chat_consumer_{delivery,dispatch}`, `test_keeper_stream_tool_accum` 통과, `ocamlformat --check` 통과 (full runtest는 CI에 위임)
- 대시보드: `tsc --noEmit` 통과, vitest 165/165 (신규 6개: synthetic 생성/종료 마킹/멱등/기존 placeholder 부착/end-without-start 무시/히스토리 수렴), eslint 클린

## 후속 (이 PR 범위 밖)

- args 스트리밍/thinking 델타 중계 (YAGNI로 제외)
- `~/me/AGENTS.md`의 `docs/COMMAND-PLANE-RUNBOOK.md` 참조가 이 repo에 없음 (stale 참조)