### PR TITLE
[Gitflow] feat(scripts): wire real metrics collection into feedback-loop.sh Measure step (task-190)

### DIFF
--- a/scripts/ci/run-lint-suite.sh
+++ b/scripts/ci/run-lint-suite.sh
@@ -70,6 +70,7 @@ blocking_lints() {
   run_lint "Workflow YAML syntax" bash scripts/lint/yaml-syntax.sh
   run_lint "Board SLO extractor fixture" bash scripts/test-board-slo-extractor.sh
   run_lint "Branch protection 401 counter fixture" bash scripts/test-main-branch-protection-counter.sh
+  run_lint "Feedback-loop metrics fixture" bash scripts/test-feedback-loop-metrics.sh
   run_lint "audit-path-ssot" bash scripts/audit-path-ssot.sh
 }
 

--- a/scripts/feedback-loop.sh
+++ b/scripts/feedback-loop.sh
@@ -52,16 +52,18 @@ for i in $(seq 1 "$ITERATIONS"); do
   BUILD_START=$(now_ms)
   # time -v (Linux) / time -l (macOS) captures peak RSS + CPU time. Its report
   # is merged into the captured output so we can extract metrics without losing
-  # build logs. `|| true` keeps the build's own exit status in BUILD_STATUS.
+  # build logs. The command substitution's exit status is the build's own.
   if [ "$IS_DARWIN" = "1" ]; then
-    BUILD_TIME_REPORT=$(/usr/bin/time -l "$REPO_DIR/scripts/dune-local.sh" build "$DUNE_BUILD_TARGET" 2>&1 || true)
+    BUILD_TIME_REPORT=$(/usr/bin/time -l "$REPO_DIR/scripts/dune-local.sh" build "$DUNE_BUILD_TARGET" 2>&1) && BUILD_STATUS=0 || BUILD_STATUS=$?
   else
-    BUILD_TIME_REPORT=$(/usr/bin/time -v "$REPO_DIR/scripts/dune-local.sh" build "$DUNE_BUILD_TARGET" 2>&1 || true)
+    BUILD_TIME_REPORT=$(/usr/bin/time -v "$REPO_DIR/scripts/dune-local.sh" build "$DUNE_BUILD_TARGET" 2>&1) && BUILD_STATUS=0 || BUILD_STATUS=$?
   fi
-  BUILD_STATUS=$?
   BUILD_END=$(now_ms)
   BUILD_DURATION=$((BUILD_END - BUILD_START))
-  BUILD_MEM_KB=$(echo "$BUILD_TIME_REPORT" | grep "maximum resident set size" | awk '{for(i=1;i<=NF;i++) if($i ~ /^[0-9]+$/) {print $i; exit}}' || echo "0")
+  # GNU time -v prints "Maximum resident set size (kbytes): N" (capital M),
+  # BSD time -l prints "  N  maximum resident set size" (lowercase) — match
+  # case-insensitively and take the first numeric field on the line.
+  BUILD_MEM_KB=$(echo "$BUILD_TIME_REPORT" | grep -i "maximum resident set size" | awk '{for(i=1;i<=NF;i++) if($i ~ /^[0-9]+$/) {print $i; exit}}')
   if [ "$BUILD_STATUS" -ne 0 ]; then
     echo "$BUILD_TIME_REPORT"
     echo "{\"iteration\":$i,\"phase\":\"build\",\"status\":\"failed\"}" >> "$LOG_FILE"

--- a/scripts/feedback-loop.sh
+++ b/scripts/feedback-loop.sh
@@ -15,23 +15,55 @@ LOG_FILE="${LOG_DIR}/${TARGET}_${TIMESTAMP}.jsonl"
 DUNE_BUILD_TARGET="${MASC_LOCAL_DUNE_TARGET:-bin/main_eio.exe}"
 RUN_FULL_TESTS="${MASC_LOCAL_FULL_DUNE_TESTS:-0}"
 
+# Detect platform so metrics collection uses the right tools.
+# Linux: /usr/bin/time -v, stat -c %s, /proc/self/status
+# macOS: /usr/bin/time -l, stat -f %z, ps -o rss
+IS_DARWIN=0
+if [ "$(uname -s)" = "Darwin" ]; then
+  IS_DARWIN=1
+fi
+
+# Portable epoch-milliseconds. BSD `date` (macOS) does not support %N, so fall
+# back to perl (Time::HiRes) and finally to whole seconds * 1000.
+now_ms() {
+  if command -v perl >/dev/null 2>&1; then
+    perl -MTime::HiRes=time -e 'printf "%d\n", int(time()*1000)'
+  else
+    echo "$(( $(date +%s) * 1000 ))"
+  fi
+}
+
 mkdir -p "$LOG_DIR"
 
 echo "🔄 Starting feedback loop: $ITERATIONS iterations for $TARGET"
 echo "📝 Logging to: $LOG_FILE"
 
-for i in $(seq 1 $ITERATIONS); do
+for i in $(seq 1 "$ITERATIONS"); do
   echo ""
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
   echo "🔁 Iteration $i / $ITERATIONS"
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
   
-  START_TIME=$(date +%s%3N)
+  START_TIME=$(now_ms)
   
   # 1. Build a focused target by default. Full-suite validation belongs in CI
   # unless this local loop explicitly opts in.
   echo "🔨 Building $DUNE_BUILD_TARGET..."
-  if ! "$REPO_DIR/scripts/dune-local.sh" build "$DUNE_BUILD_TARGET" 2>&1; then
+  BUILD_START=$(now_ms)
+  # time -v (Linux) / time -l (macOS) captures peak RSS + CPU time. Its report
+  # is merged into the captured output so we can extract metrics without losing
+  # build logs. `|| true` keeps the build's own exit status in BUILD_STATUS.
+  if [ "$IS_DARWIN" = "1" ]; then
+    BUILD_TIME_REPORT=$(/usr/bin/time -l "$REPO_DIR/scripts/dune-local.sh" build "$DUNE_BUILD_TARGET" 2>&1 || true)
+  else
+    BUILD_TIME_REPORT=$(/usr/bin/time -v "$REPO_DIR/scripts/dune-local.sh" build "$DUNE_BUILD_TARGET" 2>&1 || true)
+  fi
+  BUILD_STATUS=$?
+  BUILD_END=$(now_ms)
+  BUILD_DURATION=$((BUILD_END - BUILD_START))
+  BUILD_MEM_KB=$(echo "$BUILD_TIME_REPORT" | grep "maximum resident set size" | awk '{for(i=1;i<=NF;i++) if($i ~ /^[0-9]+$/) {print $i; exit}}' || echo "0")
+  if [ "$BUILD_STATUS" -ne 0 ]; then
+    echo "$BUILD_TIME_REPORT"
     echo "{\"iteration\":$i,\"phase\":\"build\",\"status\":\"failed\"}" >> "$LOG_FILE"
     echo "❌ Build failed at iteration $i"
     continue
@@ -40,30 +72,50 @@ for i in $(seq 1 $ITERATIONS); do
   # 2. Test
   if [ "$RUN_FULL_TESTS" = "1" ]; then
     echo "🧪 Testing full suite..."
+    TEST_START=$(now_ms)
     TEST_OUTPUT=$(
       CI_TEST_HEARTBEAT_SEC=30 \
         "$REPO_DIR/scripts/ci-run-tests.sh" \
         "$REPO_DIR/scripts/dune-local.sh test" 2>&1 || true
     )
+    TEST_END=$(now_ms)
+    TEST_DURATION=$((TEST_END - TEST_START))
     TEST_PASSED=$(echo "$TEST_OUTPUT" | grep -c "Test Successful" || echo "0")
     TEST_FAILED=$(echo "$TEST_OUTPUT" | grep -c "FAILED\|Error" || echo "0")
   else
     echo "🧪 Skipping full local test suite. Set MASC_LOCAL_FULL_DUNE_TESTS=1 to opt in."
     TEST_PASSED=0
     TEST_FAILED=0
+    TEST_DURATION=0
   fi
   
-  # 3. Measure (run metrics if available)
+  # 3. Measure — collect real per-iteration metrics.
   echo "📊 Measuring..."
-  # TODO: 실제 metrics 수집 연동
+  # Binary size of the build artifact, if it exists.
+  BIN_SIZE_BYTES=0
+  BIN_PATH="$REPO_DIR/_build/default/$DUNE_BUILD_TARGET"
+  if [ -n "$DUNE_BUILD_TARGET" ] && [ -f "$BIN_PATH" ]; then
+    if [ "$IS_DARWIN" = "1" ]; then
+      BIN_SIZE_BYTES=$(stat -f %z "$BIN_PATH" 2>/dev/null || echo "0")
+    else
+      BIN_SIZE_BYTES=$(stat -c %s "$BIN_PATH" 2>/dev/null || echo "0")
+    fi
+  fi
+  # Peak RSS of this shell (approximation of the iteration's memory footprint).
+  SHELL_PEAK_RSS_KB=0
+  if [ "$IS_DARWIN" = "1" ]; then
+    SHELL_PEAK_RSS_KB=$(ps -o rss= -p $$ 2>/dev/null | awk '{print $1}' || echo "0")
+  else
+    SHELL_PEAK_RSS_KB=$(awk '/VmHWM/{print $2}' /proc/self/status 2>/dev/null || echo "0")
+  fi
   
-  END_TIME=$(date +%s%3N)
+  END_TIME=$(now_ms)
   DURATION=$((END_TIME - START_TIME))
   
   # Log result
-  echo "{\"iteration\":$i,\"phase\":\"complete\",\"tests_passed\":$TEST_PASSED,\"tests_failed\":$TEST_FAILED,\"duration_ms\":$DURATION,\"timestamp\":\"$(date -Iseconds)\"}" >> "$LOG_FILE"
+  echo "{\"iteration\":$i,\"phase\":\"complete\",\"tests_passed\":$TEST_PASSED,\"tests_failed\":$TEST_FAILED,\"duration_ms\":$DURATION,\"build_duration_ms\":$BUILD_DURATION,\"build_mem_kb\":$BUILD_MEM_KB,\"test_duration_ms\":$TEST_DURATION,\"bin_size_bytes\":$BIN_SIZE_BYTES,\"shell_peak_rss_kb\":$SHELL_PEAK_RSS_KB,\"timestamp\":\"$(date -Iseconds)\"}" >> "$LOG_FILE"
   
-  echo "✅ Iteration $i complete: $TEST_PASSED passed, $TEST_FAILED failed (${DURATION}ms)"
+  echo "✅ Iteration $i complete: $TEST_PASSED passed, $TEST_FAILED failed (${DURATION}ms, build ${BUILD_DURATION}ms, ${BUILD_MEM_KB}KB peak)"
   
   # 4. Check if we should stop early (all tests passing, no improvements possible)
   if [ "$TEST_FAILED" -eq "0" ] && [ "$i" -gt 5 ]; then
@@ -85,6 +137,9 @@ cat "$LOG_FILE" | jq -s '
     successful: [.[] | select(.phase == "complete")] | length,
     avg_duration_ms: ([.[] | select(.duration_ms) | .duration_ms] | add / length),
     total_tests_passed: [.[] | select(.tests_passed) | .tests_passed] | add,
-    total_tests_failed: [.[] | select(.tests_failed) | .tests_failed] | add
+    total_tests_failed: [.[] | select(.tests_failed) | .tests_failed] | add,
+    avg_build_duration_ms: ([.[] | select(.build_duration_ms) | .build_duration_ms] | add / length),
+    avg_build_mem_kb: ([.[] | select(.build_mem_kb) | .build_mem_kb] | add / length),
+    avg_bin_size_bytes: ([.[] | select(.bin_size_bytes) | .bin_size_bytes] | add / length)
   }
 ' 2>/dev/null || echo "(install jq for summary)"

--- a/scripts/test-feedback-loop-metrics.sh
+++ b/scripts/test-feedback-loop-metrics.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Fixture test for scripts/feedback-loop.sh Measure step (task-190).
+#
+# Verifies that the "3. Measure" step collects real per-iteration metrics into
+# the JSONL LOG_FILE instead of being a no-op:
+#   - build_duration_ms is a positive integer
+#   - build_mem_kb is a positive integer (from /usr/bin/time peak RSS)
+#   - bin_size_bytes matches the mock build artifact size
+#   - shell_peak_rss_kb is a positive integer
+#   - the summary (jq) aggregates the new metric fields
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+FEEDBACK_LOOP="$REPO_ROOT/scripts/feedback-loop.sh"
+
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/feedback-loop-metrics.XXXXXX")"
+trap 'rm -rf "$fixture"' EXIT
+
+# Build a minimal fake repo layout: scripts/dune-local.sh (mock build) and a
+# mock build artifact at _build/default/bin/main_eio.exe.
+mkdir -p "$fixture/scripts" "$fixture/_build/default/bin" "$fixture/logs"
+
+cat >"$fixture/scripts/dune-local.sh" <<'MOCK'
+#!/usr/bin/env bash
+# Mock dune-local.sh: succeed immediately so the loop reaches the Measure step.
+exit 0
+MOCK
+chmod +x "$fixture/scripts/dune-local.sh"
+
+# Deterministic mock artifact so bin_size_bytes is assertable.
+printf 'mock-binary' >"$fixture/_build/default/bin/main_eio.exe"
+expected_size="$(stat -f %z "$fixture/_build/default/bin/main_eio.exe" 2>/dev/null \
+  || stat -c %s "$fixture/_build/default/bin/main_eio.exe")"
+
+cp "$FEEDBACK_LOOP" "$fixture/scripts/feedback-loop.sh"
+
+# Run one iteration. The mock build is instant, so the loop completes quickly.
+(
+  cd "$fixture"
+  ./scripts/feedback-loop.sh 1 >/dev/null 2>&1
+)
+
+log_file="$(find "$fixture/logs/feedback-loop/" -name '*.jsonl' -type f | head -1)"
+if [[ -z "$log_file" ]]; then
+  echo "FAIL: no JSONL log file produced" >&2
+  exit 1
+fi
+
+row="$(head -1 "$log_file")"
+
+failures=0
+check() {
+  local label="$1" got="$2"
+  if [[ -z "$got" || "$got" == "null" ]]; then
+    echo "FAIL: ${label} is missing/empty (got '${got}')" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+check_num() {
+  local label="$1" got="$2"
+  if ! [[ "$got" =~ ^[0-9]+$ ]] || [[ "$got" -eq 0 ]]; then
+    echo "FAIL: ${label} should be a positive integer (got '${got}')" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+# Extract fields from the JSONL row.
+build_duration="$(printf '%s' "$row" | jq -r '.build_duration_ms')"
+build_mem="$(printf '%s' "$row" | jq -r '.build_mem_kb')"
+bin_size="$(printf '%s' "$row" | jq -r '.bin_size_bytes')"
+shell_rss="$(printf '%s' "$row" | jq -r '.shell_peak_rss_kb')"
+phase="$(printf '%s' "$row" | jq -r '.phase')"
+
+check "phase" "$phase"
+[[ "$phase" == "complete" ]] || { echo "FAIL: phase should be complete (got '$phase')" >&2; failures=$((failures + 1)); }
+check_num "build_duration_ms" "$build_duration"
+check_num "build_mem_kb" "$build_mem"
+check_num "shell_peak_rss_kb" "$shell_rss"
+
+if [[ "$bin_size" != "$expected_size" ]]; then
+  echo "FAIL: bin_size_bytes should be $expected_size (got '$bin_size')" >&2
+  failures=$((failures + 1))
+fi
+
+# Summary must aggregate the new metric fields without error.
+summary="$(cd "$fixture" && ./scripts/feedback-loop.sh 1 2>/dev/null | sed -n '/^{/,/^}/p' || true)"
+if ! printf '%s' "$summary" | jq -e '.avg_build_duration_ms > 0' >/dev/null 2>&1; then
+  echo "FAIL: summary should aggregate avg_build_duration_ms" >&2
+  failures=$((failures + 1))
+fi
+
+if ((failures > 0)); then
+  echo "feedback-loop metrics fixture: ${failures} failure(s)" >&2
+  exit 1
+fi
+echo "feedback-loop metrics fixture: OK"

--- a/scripts/test-feedback-loop-metrics.sh
+++ b/scripts/test-feedback-loop-metrics.sh
@@ -30,8 +30,14 @@ chmod +x "$fixture/scripts/dune-local.sh"
 
 # Deterministic mock artifact so bin_size_bytes is assertable.
 printf 'mock-binary' >"$fixture/_build/default/bin/main_eio.exe"
-expected_size="$(stat -f %z "$fixture/_build/default/bin/main_eio.exe" 2>/dev/null \
-  || stat -c %s "$fixture/_build/default/bin/main_eio.exe")"
+# Platform-branch like the script under test: GNU stat treats "-f %z" as a
+# file-system query that succeeds, so a macOS-first fallback chain silently
+# yields the wrong number on Linux instead of falling back.
+if [ "$(uname -s)" = "Darwin" ]; then
+  expected_size="$(stat -f %z "$fixture/_build/default/bin/main_eio.exe")"
+else
+  expected_size="$(stat -c %s "$fixture/_build/default/bin/main_eio.exe")"
+fi
 
 cp "$FEEDBACK_LOOP" "$fixture/scripts/feedback-loop.sh"
 


### PR DESCRIPTION
## Summary

Wires real per-iteration metrics collection into the `feedback-loop.sh` "3. Measure" step, replacing the `# TODO: 실제 metrics 수집 연동` no-op.

## Changes

- **scripts/feedback-loop.sh**: collect build_duration_ms, build_mem_kb, test_duration_ms, bin_size_bytes, shell_peak_rss_kb. Portable now_ms() helper and Linux/macOS platform detection.
- **scripts/test-feedback-loop-metrics.sh**: new fixture test.
- **scripts/ci/run-lint-suite.sh**: register the new fixture test.

## Verification

- shellcheck clean on both scripts.
- `scripts/ci/run-lint-suite.sh blocking` — all 35 lints pass.
- Fixture test fails on pre-change script, passes after.

Closes task-190