### PR TITLE
fix(dashboard): wire goal owner, oas telemetry push, raw trace ref

### DIFF
--- a/dashboard/src/api/dashboard-goals.test.ts
+++ b/dashboard/src/api/dashboard-goals.test.ts
@@ -164,6 +164,22 @@ describe('fetchDashboardGoalsTree decoding', () => {
     expect(result.tree[0]!.children[0]!.id).toBe('goal-child')
   })
 
+  it('decodes goal owner from the tree node payload', async () => {
+    getMock.mockResolvedValue({
+      ...readyApprovalQueue,
+      tree: [
+        validNode('goal-owned', 'Owned goal', { owner: 'dancer' }),
+        validNode('goal-unowned', 'Unowned goal'),
+      ],
+      summary: { ...emptySummary(), total_goals: 2, active_goals: 2 },
+    })
+
+    const result = await fetchDashboardGoalsTree()
+
+    expect(result.tree[0]!.owner).toBe('dancer')
+    expect(result.tree[1]!.owner).toBeNull()
+  })
+
   it('backfills missing attainment metric_evaluation from metric presence', async () => {
     getMock.mockResolvedValue({
       ...readyApprovalQueue,

--- a/dashboard/src/api/dashboard-goals.ts
+++ b/dashboard/src/api/dashboard-goals.ts
@@ -297,6 +297,7 @@ function decodeGoalTreeNode(raw: unknown): GoalTreeNode | null {
     target_value: targetValue,
     due_date: asNullableString(raw.due_date),
     parent_goal_id: asNullableString(raw.parent_goal_id),
+    owner: asNullableString(raw.owner),
     attainment,
     tasks,
     task_count: taskCount,

--- a/dashboard/src/components/goals/goal-tree.test.ts
+++ b/dashboard/src/components/goals/goal-tree.test.ts
@@ -73,6 +73,7 @@ function makeGoal(id: string, title: string, children: GoalTreeNode[] = []): Goa
     target_value: null,
     due_date: null,
     parent_goal_id: null,
+    owner: null,
     attainment: {
       state: 'unmeasured',
       basis: 'unmeasured',

--- a/dashboard/src/components/keeper-turn-inspector.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector.test.ts
@@ -562,6 +562,43 @@ describe('KeeperTurnInspector v2 drawer', () => {
     expect(meta).not.toContain('stop')
     expect(meta).not.toContain('deepseek-v4-flash')
     expect(meta).toContain('n/a')
+    // no raw trace run ref on this row — honest absence, never a fabricated one
+    expect(meta).toContain('raw tracen/a')
+  })
+
+  it('renders the raw trace run ref in the meta tab when the record carries one', async () => {
+    const response = turnRecordsWithMemoryOs()
+    response.entries[1] = {
+      ...response.entries[1]!,
+      record: {
+        ...response.entries[1]!.record,
+        raw_trace_run_ref: {
+          worker_run_id: 'wr-01H',
+          path: '.masc/keepers/albini/raw-trace/wr-01H.jsonl',
+          start_seq: 3,
+          end_seq: 9,
+          agent_name: 'keeper-albini-agent',
+          session_id: 'trace-active',
+        },
+      },
+    }
+    fetchKeeperTurnRecordsMock.mockResolvedValue(response)
+
+    const { container } = render(html`<${KeeperTurnInspector} keeperName="albini" />`)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('T42')
+    })
+
+    fireEvent.click(container.querySelector('.kti-turn-summary')!)
+    fireEvent.click(container.querySelector('[data-testid="turn-tab-meta"]')!)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('실행 메타데이터')
+    })
+
+    const meta = container.querySelector('.kti-kv')?.textContent ?? ''
+    expect(meta).toContain('raw tracewr-01H · seq 3-9')
   })
 
   it.each([

--- a/dashboard/src/components/keeper-turn-inspector.ts
+++ b/dashboard/src/components/keeper-turn-inspector.ts
@@ -418,6 +418,14 @@ function thinkingChipLabel(record: TurnRecordEntry): string {
   return '—'
 }
 
+// lib/types/turn_record.ml:127-135 — the exact-run reference into the keeper's
+// raw-trace store. Display only: the run id plus the seq window within it.
+function rawTraceRunRefLabel(record: TurnRecordEntry): string {
+  const ref = record.raw_trace_run_ref
+  if (!ref) return 'n/a'
+  return `${ref.worker_run_id} · seq ${ref.start_seq}-${ref.end_seq}`
+}
+
 // RFC-0233 §8 — compact "NNNK" form of the runtime's context window, or
 // "미상" when the record has no context_window (render absence, not 200K).
 function formatCtxWindowK(cw: number | null | undefined): string {
@@ -977,6 +985,7 @@ function MetaTab({ record, t, source }: { record: TurnRecordEntry; t: TurnDetail
         <span class="k">measured phase duration</span><span class="v">${t.measuredDurationMs != null ? formatMsCompact(t.measuredDurationMs) : 'none'}</span>
         <span class="k">est. cost${record.price_input_per_million != null ? '' : ' · 가격 미구성'}</span><span class="v">${t.cost != null ? `$${t.cost.toFixed(3)}` : '미상'}</span>
         <span class="k">finish_reason</span><span class="v">${record.finish_reason ?? 'n/a'}</span>
+        <span class="k">raw trace</span><span class="v" title=${record.raw_trace_run_ref?.path ?? undefined}>${rawTraceRunRefLabel(record)}</span>
         <span class="k">source</span><span class="v">${source}</span>
       </div>
     </div>

--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -623,4 +623,45 @@ describe('RuntimeMonitor', () => {
     expect(container.textContent).toContain('no-usage')
     expect(container.textContent).not.toContain('no-usage/no-usage')
   })
+
+  it('renders the latest oas telemetry sample from the push-fed read model', async () => {
+    const { latestOasTelemetrySample } = await import('../oas-telemetry-store')
+    latestOasTelemetrySample.value = {
+      provider_id: 'runtime',
+      model_id: 'runtime',
+      ttfb_ms: 121.4,
+      total_duration_ms: 845.2,
+      throughput_tokens_per_s: 42.1,
+      cost_usd: 0.003,
+      status_kind: 'success',
+      recorded_at: 1_712_000_000.5,
+    }
+    const { RuntimeMonitor } = await import('./runtime-monitor')
+
+    render(h(RuntimeMonitor, {}), container)
+    await waitFor(
+      () => container.querySelector('[data-testid="oas-latest-telemetry-sample"]') != null,
+      'oas latest telemetry sample line',
+    )
+
+    const line = container.querySelector('[data-testid="oas-latest-telemetry-sample"]')?.textContent ?? ''
+    expect(line).toContain('oas latest · runtime')
+    expect(line).toContain('ttfb 121ms')
+    expect(line).toContain('total 845ms')
+    expect(line).toContain('42.1 tok/s')
+    expect(line).toContain('success')
+    latestOasTelemetrySample.value = null
+  })
+
+  it('omits the oas telemetry sample line before any push arrives', async () => {
+    const { RuntimeMonitor } = await import('./runtime-monitor')
+
+    render(h(RuntimeMonitor, {}), container)
+    await waitFor(
+      () => container.textContent?.includes('runpod_mtp.qwen') ?? false,
+      'runtime binding',
+    )
+
+    expect(container.querySelector('[data-testid="oas-latest-telemetry-sample"]')).toBeNull()
+  })
 })

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -23,6 +23,7 @@ import { TextInput } from './common/input'
 import { Table, type TableColumn } from './common/table'
 import type { ManagedAsyncResource } from '../lib/async-state'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
+import { latestOasTelemetrySample } from '../oas-telemetry-store'
 import { formatCost, formatNumber, formatPct1 } from '../lib/format-number'
 import { errorToString, MISSING_DATA_DASH } from '../lib/format-string'
 import { formatTimeHms } from '../lib/format-time'
@@ -820,6 +821,7 @@ export function RuntimeMonitor() {
   const probe = current.data?.probe ?? null
   const probeError = current.data?.probeError ?? null
   const providerProbes = providerProbeMap(probe)
+  const oasLatest = latestOasTelemetrySample.value
 
   // filterModelMetrics was called twice per render (no-results check + the
   // sorted list) with identical args. Memoize once and reuse so it runs at most
@@ -1007,6 +1009,11 @@ export function RuntimeMonitor() {
             delta=${{ direction: 'flat', text: `${formatNumber(metrics?.models.reduce((sum, m) => sum + (m.total_tool_calls ?? 0), 0))} tool calls` }}
           />
         </div>
+        ${oasLatest
+          ? html`<div class="mb-3 text-2xs text-[var(--color-fg-muted)]" data-testid="oas-latest-telemetry-sample">
+              oas latest · ${oasLatest.provider_id} · ttfb ${formatNumber(oasLatest.ttfb_ms, 0)}ms · total ${formatNumber(oasLatest.total_duration_ms, 0)}ms${oasLatest.throughput_tokens_per_s != null ? ` · ${formatNumber(oasLatest.throughput_tokens_per_s, 1)} tok/s` : ''}${oasLatest.cost_usd != null ? ` · ${formatCost(oasLatest.cost_usd)}` : ''} · ${oasLatest.status_kind}
+            </div>`
+          : null}
         <div class="flex items-center justify-end mb-2">
           <${TextInput}
             type="search"

--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -113,6 +113,7 @@ function goalTreeNode(overrides: Partial<GoalTreeNode> = {}): GoalTreeNode {
     target_value: null,
     due_date: null,
     parent_goal_id: null,
+    owner: null,
     attainment: {
       state: 'unmeasured',
       basis: 'unmeasured',
@@ -1552,6 +1553,7 @@ describe('Work', () => {
               stagnation_seconds: 3600,
               linked_keeper_names: ['sangsu'],
               pending_approval_count: 2,
+              owner: 'dancer',
               latest_keeper_ref: 'sangsu',
               latest_turn_ref: 42,
             }),
@@ -1572,6 +1574,7 @@ describe('Work', () => {
         expect(dossier.textContent).toContain('request completion')
         expect(dossier.textContent).toContain('state in_progress')
         expect(dossier.textContent).toContain('tasks 3/4')
+        expect(dossier.textContent).toContain('owner dancer')
         expect(dossier.textContent).toContain('keeper sangsu')
         expect(dossier.textContent).toContain('turn 42')
         expect(dossier.textContent).toContain('approvals 2')

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -491,6 +491,7 @@ function GoalProjectionDossier({ node }: { node: GoalTreeNode | null | undefined
         `}
         <span class="wk-dossier-chip mono">events ${node.timeline_events.length}</span>
         <span class="wk-dossier-chip mono">stagnation ${node.stagnation_seconds == null ? 'unavailable' : `${node.stagnation_seconds}s`}</span>
+        ${node.owner ? html`<span class="wk-dossier-chip mono">owner ${node.owner}</span>` : null}
         ${node.latest_keeper_ref ? html`<span class="wk-dossier-chip mono">keeper ${node.latest_keeper_ref}</span>` : null}
         ${node.latest_turn_ref != null ? html`<span class="wk-dossier-chip mono">turn ${node.latest_turn_ref}</span>` : null}
         ${node.linked_keeper_names.map((name) => html`

--- a/dashboard/src/oas-telemetry-store.test.ts
+++ b/dashboard/src/oas-telemetry-store.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  hydrateOasTelemetrySample,
+  latestOasTelemetrySample,
+} from './oas-telemetry-store'
+
+function validTelemetryEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'oas_telemetry_sample',
+    provider_id: 'runtime',
+    model_id: 'runtime',
+    payload: {
+      sample: {
+        ttfb_ms: 120.5,
+        total_duration_ms: 845.2,
+        throughput_tokens_per_s: 42.1,
+        cost_usd: 0.003,
+        status: { kind: 'success' },
+      },
+      recorded_at: 1_712_000_000.5,
+    },
+    ts_unix: 1_712_000_000.5,
+    ...overrides,
+  }
+}
+
+afterEach(() => {
+  latestOasTelemetrySample.value = null
+})
+
+describe('oas telemetry store', () => {
+  it('hydrates the latest sample from the push payload without an HTTP fetch', () => {
+    hydrateOasTelemetrySample(validTelemetryEvent())
+
+    expect(latestOasTelemetrySample.value).toEqual({
+      provider_id: 'runtime',
+      model_id: 'runtime',
+      ttfb_ms: 120.5,
+      total_duration_ms: 845.2,
+      throughput_tokens_per_s: 42.1,
+      cost_usd: 0.003,
+      status_kind: 'success',
+      recorded_at: 1_712_000_000.5,
+    })
+  })
+
+  it('replaces the previous sample with the newest push', () => {
+    hydrateOasTelemetrySample(validTelemetryEvent())
+    hydrateOasTelemetrySample(validTelemetryEvent({
+      payload: {
+        sample: {
+          ttfb_ms: 90,
+          total_duration_ms: 400,
+          status: { kind: 'error', transient: true },
+        },
+        recorded_at: 1_712_000_001,
+      },
+    }))
+
+    expect(latestOasTelemetrySample.value?.ttfb_ms).toBe(90)
+    expect(latestOasTelemetrySample.value?.status_kind).toBe('error')
+    expect(latestOasTelemetrySample.value?.throughput_tokens_per_s).toBeNull()
+    expect(latestOasTelemetrySample.value?.recorded_at).toBe(1_712_000_001)
+  })
+
+  it('ignores malformed payloads instead of fabricating a sample', () => {
+    hydrateOasTelemetrySample({ provider_id: 'runtime', payload: { recorded_at: 1 } })
+    hydrateOasTelemetrySample({
+      provider_id: 'runtime',
+      payload: { sample: {}, recorded_at: 'bad' },
+    })
+
+    expect(latestOasTelemetrySample.value).toBeNull()
+  })
+})

--- a/dashboard/src/oas-telemetry-store.ts
+++ b/dashboard/src/oas-telemetry-store.ts
@@ -1,0 +1,43 @@
+// Latest OAS inference telemetry sample — a small read model fed directly by
+// the `oas_telemetry_sample` server push. The event payload already carries
+// the sample (schema-validated at the SSE boundary, schemas/sse.ts), so the
+// store hydrates from the push with zero HTTP fetch. Wire shape: sample +
+// recorded_at as emitted by lib/runtime/dashboard_oas_bridge.ml
+// (sample_entry_to_yojson), with provider/model labels at the envelope top.
+
+import { signal } from '@preact/signals'
+import { asNumber, asString, isRecord } from './components/common/normalize'
+
+export type OasTelemetrySampleView = {
+  provider_id: string
+  model_id: string
+  ttfb_ms: number
+  total_duration_ms: number
+  throughput_tokens_per_s: number | null
+  cost_usd: number | null
+  status_kind: string
+  recorded_at: number
+}
+
+export const latestOasTelemetrySample = signal<OasTelemetrySampleView | null>(null)
+
+export function hydrateOasTelemetrySample(event: {
+  provider_id?: unknown
+  model_id?: unknown
+  payload?: unknown
+}): void {
+  const payload = isRecord(event.payload) ? event.payload : null
+  const sample = payload && isRecord(payload.sample) ? payload.sample : null
+  const recordedAt = payload ? asNumber(payload.recorded_at) : null
+  if (!sample || recordedAt == null) return
+  latestOasTelemetrySample.value = {
+    provider_id: asString(event.provider_id) ?? '',
+    model_id: asString(event.model_id) ?? '',
+    ttfb_ms: asNumber(sample.ttfb_ms) ?? 0,
+    total_duration_ms: asNumber(sample.total_duration_ms) ?? 0,
+    throughput_tokens_per_s: asNumber(sample.throughput_tokens_per_s) ?? null,
+    cost_usd: asNumber(sample.cost_usd) ?? null,
+    status_kind: isRecord(sample.status) ? (asString(sample.status.kind) ?? 'unknown') : 'unknown',
+    recorded_at: recordedAt,
+  }
+}

--- a/dashboard/src/sse-event-type-parity.test.ts
+++ b/dashboard/src/sse-event-type-parity.test.ts
@@ -44,6 +44,7 @@ const BACKEND_EMITTED: Record<string, string> = {
   keeper_composite_changed: '../lib/server/server_mcp_transport_ws.ml',
   keeper_heartbeat: '../lib/keeper/keeper_heartbeat_snapshot.ml',
   keeper_turn_complete: '../lib/keeper/keeper_hooks_oas.ml',
+  oas_telemetry_sample: '../lib/runtime/dashboard_oas_bridge.ml',
   namespace_truth_snapshot: '../lib/server/server_mcp_transport_ws.ml',
   operator_digest: '../lib/server/server_dashboard_http_core_digest_refresh.ml',
   operator_snapshot: '../lib/server/server_mcp_transport_ws.ml',

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -40,6 +40,7 @@ const requestNamespaceTruthNow = vi.fn<() => void>()
 const requestNamespaceTruth = vi.fn<() => void>()
 const showToast = vi.fn<(message: string, kind?: string, durationMs?: number) => void>()
 const replayOasRuntimeTelemetry = vi.fn<() => Promise<void>>(async () => {})
+const hydrateOasTelemetrySample = vi.fn<(event: unknown) => void>()
 const compositeTick = signal({ name: '', ts_unix: 0 })
 const hydrateFleetCompositeSnapshot = vi.fn<(payload: unknown) => void>()
 const hydrateGoalTreeSnapshot = vi.fn<(payload: unknown) => boolean>(() => true)
@@ -90,6 +91,9 @@ async function loadSseStore() {
     replayOasRuntimeTelemetry,
     applyOasRuntimeEvent: vi.fn(),
   }))
+  vi.doMock('./oas-telemetry-store', () => ({
+    hydrateOasTelemetrySample,
+  }))
   vi.doMock('./composite-signals', () => ({
     compositeTick,
     hydrateFleetCompositeSnapshot,
@@ -131,6 +135,7 @@ describe('setupServerPushReaction reconnect hydration', () => {
     showToast.mockClear()
     replayOasRuntimeTelemetry.mockClear()
     replayOasRuntimeTelemetry.mockResolvedValue(undefined)
+    hydrateOasTelemetrySample.mockClear()
     refreshActiveKeeperChatHistory.mockReset()
     reconcileKeeperChatReceipts.mockReset()
     reconcileKeeperChatReceipts.mockResolvedValue(undefined)
@@ -159,6 +164,7 @@ describe('setupServerPushReaction reconnect hydration', () => {
     vi.doUnmock('./tab-refresh')
     vi.doUnmock('./components/common/toast')
     vi.doUnmock('./oas-runtime-store')
+    vi.doUnmock('./oas-telemetry-store')
     vi.doUnmock('./composite-signals')
     vi.doUnmock('./goal-tree-state')
     vi.doUnmock('./router')
@@ -664,6 +670,27 @@ describe('setupServerPushReaction reconnect hydration', () => {
 
     expect(compositeTick.value).toEqual({ name: 'qa-king', ts_unix: 1710000000.123 })
     expect(hydrateFleetCompositeSnapshot).not.toHaveBeenCalled()
+  })
+
+  it('routes oas_telemetry_sample to the telemetry read model without an HTTP refresh', async () => {
+    const { sseStore } = await loadSseStore()
+
+    // The push payload carries the sample itself (schemas/sse.ts validates the
+    // envelope), so the read model hydrates directly — nothing to re-fetch.
+    sseStore.routeServerPushEvent({
+      type: 'oas_telemetry_sample',
+      provider_id: 'runtime',
+      model_id: 'runtime',
+      payload: {
+        sample: { ttfb_ms: 120.5, total_duration_ms: 845.2, status: { kind: 'success' } },
+        recorded_at: 1_712_000_000,
+      },
+      ts_unix: 1_712_000_000,
+    })
+    await flushAsyncWork()
+
+    expect(hydrateOasTelemetrySample).toHaveBeenCalledTimes(1)
+    expect(refreshExecution).not.toHaveBeenCalled()
   })
 
   it('routes board reaction changes through the board refresh budget', async () => {

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -63,6 +63,7 @@ import {
 import { showToast } from './components/common/toast'
 import type { ErrorCode } from './types/error'
 import { parseOasPayloadOrNull } from './schemas/sse-event-payload'
+import { hydrateOasTelemetrySample } from './oas-telemetry-store'
 import {
   SSE_APPROVAL_PENDING_EVENT,
   SSE_APPROVAL_RESOLVED_EVENT,
@@ -780,6 +781,14 @@ export function hydrateServerPushEvent(event: SSEEvent): boolean {
 
   if (event.type === 'keeper_heartbeat') {
     handleKeeperHeartbeat(event)
+    return true
+  }
+
+  // The payload is the sample itself (schema-validated at the boundary), so
+  // the read model hydrates from the push directly — zero HTTP fetch. The
+  // runtime monitor renders latestOasTelemetrySample; nothing to refresh.
+  if (event.type === 'oas_telemetry_sample') {
+    hydrateOasTelemetrySample(event)
     return true
   }
 

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -752,6 +752,7 @@ export interface GoalTreeMetricProjection {
   target_value: string | null
   due_date: string | null
   parent_goal_id: string | null
+  owner: string | null
   attainment: GoalAttainmentProjection
 }
 

--- a/lib/dashboard/dashboard_goals.ml
+++ b/lib/dashboard/dashboard_goals.ml
@@ -142,6 +142,7 @@ let rec tree_node_to_json ?(events_for_goal = fun _ -> []) node =
       ("target_value", Json_util.string_opt_to_json goal.target_value);
       ("due_date", Json_util.string_opt_to_json goal.due_date);
       ("parent_goal_id", Json_util.string_opt_to_json goal.parent_goal_id);
+      ("owner", Json_util.string_opt_to_json goal.owner);
       ("attainment", attainment);
       ("tasks", `List (List.map task_to_tree_json node.tasks));
       ("task_count", `Int (List.length node.tasks));

--- a/test/test_goal_metric_unevaluated.ml
+++ b/test/test_goal_metric_unevaluated.ml
@@ -350,6 +350,39 @@ let test_tree_task_without_cancellation_carries_no_cancellation_fields () =
   check bool "no reason on a completed task" false
     (Option.is_some (tree_field "reason" json))
 
+(* RFC-0362 — the goal's [owner] reaches the dashboard only through this tree
+   projection: the store serializes it (goal_store.ml) and goal_owner events
+   carry it, but the tree JSON is what the goals surface decodes.
+   [Dashboard_goals.tree_node] is a nominal copy of [Acc.tree_node], so the
+   node is built against the renderer's own type. *)
+let make_dashboard_tree_node goal : Dashboard_goals.tree_node =
+  {
+    goal;
+    children = [];
+    tasks = [];
+    last_activity_at = iso_now ();
+    stagnation_seconds = Some 0;
+    linked_keeper_names = [];
+    pending_approval_count = 0;
+    latest_keeper_ref = None;
+    latest_turn_ref = None;
+    activity_observation = "none";
+  }
+
+let test_tree_node_projects_owner () =
+  let goal = { (make_goal "goal-owned" "Owned goal") with owner = Some "dancer" } in
+  let json = Dashboard_goals.tree_node_to_json (make_dashboard_tree_node goal) in
+  check (option string) "the owner is projected" (Some "dancer")
+    (match tree_field "owner" json with Some (`String v) -> Some v | _ -> None)
+
+let test_tree_node_projects_an_absent_owner_as_null () =
+  let json =
+    Dashboard_goals.tree_node_to_json
+      (make_dashboard_tree_node (make_goal "goal-plain" "Plain goal"))
+  in
+  check bool "an absent owner is explicit null" true
+    (tree_field "owner" json = Some `Null)
+
 let () =
   run "goal metric unevaluated"
     [
@@ -383,5 +416,9 @@ let () =
             test_tree_task_omits_an_absent_cancellation_reason;
           test_case "non-cancelled tree task carries no cancellation fields" `Quick
             test_tree_task_without_cancellation_carries_no_cancellation_fields;
+          test_case "tree node projects the goal owner" `Quick
+            test_tree_node_projects_owner;
+          test_case "tree node projects an absent owner as null" `Quick
+            test_tree_node_projects_an_absent_owner_as_null;
         ] );
     ]


### PR DESCRIPTION
## 배경

최근 3일간 main에 머지된 백엔드 변경 중 대시보드 와이어링이 빠진 3건을 조사해 연결한다.

## GAP 1 — Goal owner (RFC-0362, #26951)

- `lib/dashboard/dashboard_goals.ml` `tree_node_to_json`이 `owner`를보내지 않던 것을 추가
- FE: `GoalTreeMetricProjection.owner` 타입 + decode + goal dossier에 owner chip 렌더
- 테스트: OCaml 2건(owner 있음/없음), FE decode/render 테스트

## GAP 2 — `oas_telemetry_sample` SSE 이벤트 (#27027)

- 스키마만 선언되고 라우트가 없어 silently drop 되던 것을 `sse-store.ts`에 exact-match 라우트 추가
- 새 read model `oas-telemetry-store.ts`(push payload hydrate, HTTP 없음 — `keeper_heartbeat` 패턴)
- runtime-monitor에 최신 샘플 라인(provider/ttfb/total/tok·s/cost/status) 렌더
- parity 테스트 `BACKEND_EMITTED` 갱신
- (`/oas/telemetry/recent|summary` REST fetch는 범위 밖 — push payload가 이미 전체 샘플을 운반)

## GAP 3 — `raw_trace_run_ref` (#27033)

- 디코드만 되고 표시가 없던 것을 turn inspector meta 블록에 `raw trace` 행으로 표시 (display only, trace content fetch 없음)

## 검증

- OCaml: `scripts/dune-local.sh build test/test_goal_metric_unevaluated.exe` → 17/17 OK
- Dashboard: vitest touched 8파일 184/184 pass, `tsc --noEmit` clean, eslint clean