### PR TITLE
feat(dashboard): 내부 에이전트 실행과 도구 증거를 관측한다

### DIFF
--- a/dashboard/src/api/dashboard-exact-lane-runs.test.ts
+++ b/dashboard/src/api/dashboard-exact-lane-runs.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { parseExactLaneRunsResponse } from './dashboard-exact-lane-runs'
+
+describe('parseExactLaneRunsResponse', () => {
+  it('decodes one completed exact lane record', () => {
+    const parsed = parseExactLaneRunsResponse({
+      generated_at: '2026-08-06T00:00:00Z',
+      count: 1,
+      runs: [{
+        run_id: 'exact-librarian-1',
+        lane: 'librarian_exact',
+        subject_id: 'trace-1',
+        actor: 'keeper-a',
+        started_at: 1,
+        input: { message_count: 4 },
+        status: 'succeeded',
+        elapsed_s: 0.4,
+        output: { fact_count: 3 },
+      }],
+    })
+    expect(parsed.runs[0]).toMatchObject({
+      lane: 'librarian_exact',
+      status: 'succeeded',
+      input: { message_count: 4 },
+      output: { fact_count: 3 },
+    })
+  })
+
+  it('rejects an unknown lane instead of guessing', () => {
+    expect(() => parseExactLaneRunsResponse({
+      generated_at: '2026-08-06T00:00:00Z',
+      count: 1,
+      runs: [{
+        run_id: 'x', lane: 'mystery', subject_id: 's', actor: 'a',
+        started_at: 1, input: {}, status: 'running',
+      }],
+    })).toThrow('unknown value')
+  })
+})

--- a/dashboard/src/api/dashboard-exact-lane-runs.ts
+++ b/dashboard/src/api/dashboard-exact-lane-runs.ts
@@ -1,0 +1,120 @@
+import { isRecord } from '../components/common/normalize'
+import { get, type AbortableRequestOptions } from './core'
+
+export type ExactLane =
+  | 'librarian_exact'
+  | 'hitl_auto_judge'
+  | 'board_attention_exact'
+  | 'compaction_exact'
+
+export type ExactLaneRunStatus = 'running' | 'succeeded' | 'cancelled' | 'failed'
+
+export interface ExactLaneRunRecord {
+  runId: string
+  lane: ExactLane
+  subjectId: string
+  actor: string
+  startedAt: number
+  input: unknown
+  status: ExactLaneRunStatus
+  elapsedSeconds?: number
+  output?: unknown
+  code?: string
+  detail?: string
+}
+
+export interface DashboardExactLaneRunsResponse {
+  runs: ExactLaneRunRecord[]
+  count: number
+  generatedAt: string
+}
+
+const LANES: readonly string[] = [
+  'librarian_exact',
+  'hitl_auto_judge',
+  'board_attention_exact',
+  'compaction_exact',
+]
+const STATUSES: readonly string[] = ['running', 'succeeded', 'cancelled', 'failed']
+
+function fail(message: string): never {
+  throw new Error(`Invalid exact lane runs response: ${message}`)
+}
+
+function string(value: unknown, context: string): string {
+  if (typeof value !== 'string' || value.trim() === '') fail(`${context} must be a non-empty string`)
+  return value
+}
+
+function number(value: unknown, context: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    fail(`${context} must be a non-negative finite number`)
+  }
+  return value
+}
+
+function exactFields(
+  value: Record<string, unknown>,
+  required: readonly string[],
+  optional: readonly string[],
+  context: string,
+): void {
+  const expected = new Set([...required, ...optional])
+  const missing = required.filter(key => !(key in value))
+  const unknown = Object.keys(value).filter(key => !expected.has(key))
+  if (missing.length > 0 || unknown.length > 0) {
+    fail(`${context} fields mismatch (missing=[${missing.join(',')}], unknown=[${unknown.join(',')}])`)
+  }
+}
+
+function parseRun(raw: unknown, index: number): ExactLaneRunRecord {
+  const context = `runs[${index}]`
+  if (!isRecord(raw)) fail(`${context} must be an object`)
+  const status = string(raw.status, `${context}.status`)
+  if (!STATUSES.includes(status)) fail(`${context}.status has unknown value ${JSON.stringify(status)}`)
+  const lane = string(raw.lane, `${context}.lane`)
+  if (!LANES.includes(lane)) fail(`${context}.lane has unknown value ${JSON.stringify(lane)}`)
+  const base = ['run_id', 'lane', 'subject_id', 'actor', 'started_at', 'input', 'status']
+  const required = status === 'running'
+    ? base
+    : status === 'failed'
+      ? [...base, 'elapsed_s', 'output', 'code', 'detail']
+      : [...base, 'elapsed_s', 'output']
+  exactFields(raw, required, [], context)
+  return {
+    runId: string(raw.run_id, `${context}.run_id`),
+    lane: lane as ExactLane,
+    subjectId: string(raw.subject_id, `${context}.subject_id`),
+    actor: string(raw.actor, `${context}.actor`),
+    startedAt: number(raw.started_at, `${context}.started_at`),
+    input: raw.input,
+    status: status as ExactLaneRunStatus,
+    elapsedSeconds: status === 'running' ? undefined : number(raw.elapsed_s, `${context}.elapsed_s`),
+    output: status === 'running' ? undefined : raw.output,
+    code: status === 'failed' ? string(raw.code, `${context}.code`) : undefined,
+    detail: status === 'failed' ? string(raw.detail, `${context}.detail`) : undefined,
+  }
+}
+
+export function parseExactLaneRunsResponse(raw: unknown): DashboardExactLaneRunsResponse {
+  if (!isRecord(raw)) fail('root must be an object')
+  exactFields(raw, ['runs', 'count', 'generated_at'], [], 'root')
+  if (!Array.isArray(raw.runs)) fail('root.runs must be an array')
+  if (!Number.isSafeInteger(raw.count) || (raw.count as number) < 0) {
+    fail('root.count must be a non-negative safe integer')
+  }
+  const runs = raw.runs.map(parseRun)
+  if (raw.count !== runs.length) fail('root.count must match runs.length')
+  return {
+    runs,
+    count: raw.count as number,
+    generatedAt: string(raw.generated_at, 'root.generated_at'),
+  }
+}
+
+export async function fetchExactLaneRuns(
+  opts?: AbortableRequestOptions,
+): Promise<DashboardExactLaneRunsResponse> {
+  const raw = await get<unknown>('/api/v1/dashboard/exact-lane-runs', { signal: opts?.signal })
+  return parseExactLaneRunsResponse(raw)
+}

--- a/dashboard/src/api/dashboard-verification-runs.test.ts
+++ b/dashboard/src/api/dashboard-verification-runs.test.ts
@@ -44,6 +44,7 @@ function row(overrides: Record<string, unknown> = {}) {
     started_at: 1_754_000_000,
     status: 'approved',
     elapsed_s: 2.5,
+    tools: [],
     evaluator_runtime: 'cross-verifier',
     ...overrides,
   }
@@ -67,6 +68,31 @@ describe('parseVerificationRunsResponse', () => {
       elapsedSeconds: 2.5,
       evaluatorRuntime: 'cross-verifier',
     })
+  })
+
+  it('preserves ordered typed tool evidence', () => {
+    const parsed = parseVerificationRunsResponse({
+      generated_at: '2026-08-05T00:00:00Z',
+      count: 1,
+      runs: [row({
+        tools: [{
+          tool_name: 'report_review_verdict',
+          input: { verdict: 'APPROVE' },
+          disposition: 'completed',
+          output_excerpt: 'Completion verdict recorded: APPROVE',
+          output_truncated: false,
+          duration_ms: 1.25,
+        }],
+      })],
+    })
+    expect(onlyRun(parsed).tools).toEqual([{
+      toolName: 'report_review_verdict',
+      input: { verdict: 'APPROVE' },
+      disposition: 'completed',
+      outputExcerpt: 'Completion verdict recorded: APPROVE',
+      outputTruncated: false,
+      durationMs: 1.25,
+    }])
   })
 
   it('reads a rejection cause from `reason`', () => {

--- a/dashboard/src/api/dashboard-verification-runs.ts
+++ b/dashboard/src/api/dashboard-verification-runs.ts
@@ -22,6 +22,17 @@ export type VerificationRunStatusLabel =
   | 'commit_failed'
   | 'raised'
 
+export type VerificationToolDisposition = 'completed' | 'deferred' | 'failed'
+
+export interface VerificationToolObservation {
+  toolName: string
+  input: unknown
+  disposition: VerificationToolDisposition
+  outputExcerpt: string
+  outputTruncated: boolean
+  durationMs: number
+}
+
 const BACKEND_STATUSES: readonly string[] = [
   'running',
   'approved',
@@ -51,6 +62,7 @@ export interface VerificationRunRecord {
   cause?: string
   /** Which gate declined to produce a verdict; `not_reviewed` rows only. */
   gate?: string
+  tools?: VerificationToolObservation[]
 }
 
 export interface DashboardVerificationRunsResponse {
@@ -102,6 +114,36 @@ function verificationStatus(value: unknown, context: string): VerificationRunSta
   return value as VerificationRunStatusLabel
 }
 
+function parseTool(raw: unknown, context: string): VerificationToolObservation {
+  if (!isRecord(raw)) protocolError(`${context} must be an object`)
+  exactFields(raw, [
+    'tool_name',
+    'input',
+    'disposition',
+    'output_excerpt',
+    'output_truncated',
+    'duration_ms',
+  ], [], context)
+  if (raw.disposition !== 'completed' && raw.disposition !== 'deferred' && raw.disposition !== 'failed') {
+    protocolError(`${context}.disposition has unknown value ${JSON.stringify(raw.disposition)}`)
+  }
+  if (typeof raw.output_truncated !== 'boolean') {
+    protocolError(`${context}.output_truncated must be a boolean`)
+  }
+  const durationMs = finiteNumber(raw.duration_ms, `${context}.duration_ms`)
+  if (durationMs < 0) protocolError(`${context}.duration_ms must be non-negative`)
+  return {
+    toolName: nonEmptyString(raw.tool_name, `${context}.tool_name`),
+    input: raw.input,
+    disposition: raw.disposition,
+    outputExcerpt: typeof raw.output_excerpt === 'string'
+      ? raw.output_excerpt
+      : protocolError(`${context}.output_excerpt must be a string`),
+    outputTruncated: raw.output_truncated,
+    durationMs,
+  }
+}
+
 const RUN_BASE_FIELDS = [
   'verification_id',
   'task_id',
@@ -122,21 +164,21 @@ function parseRun(raw: unknown, index: number): VerificationRunRecord {
     case 'running':
       break
     case 'approved':
-      requiredOutcomeFields = ['elapsed_s']
+      requiredOutcomeFields = ['elapsed_s', 'tools']
       optionalFields = ['evaluator_runtime']
       break
     case 'rejected':
-      requiredOutcomeFields = ['elapsed_s', 'reason']
+      requiredOutcomeFields = ['elapsed_s', 'reason', 'tools']
       optionalFields = ['evaluator_runtime']
       break
     case 'not_reviewed':
-      requiredOutcomeFields = ['elapsed_s', 'gate', 'detail']
+      requiredOutcomeFields = ['elapsed_s', 'gate', 'detail', 'tools']
       optionalFields = ['evaluator_runtime']
       break
     case 'contract_rejected':
     case 'commit_failed':
     case 'raised':
-      requiredOutcomeFields = ['elapsed_s', 'detail']
+      requiredOutcomeFields = ['elapsed_s', 'detail', 'tools']
       optionalFields = ['evaluator_runtime']
       break
   }
@@ -149,6 +191,11 @@ function parseRun(raw: unknown, index: number): VerificationRunRecord {
   if (elapsedSeconds != null && elapsedSeconds < 0) {
     protocolError(`${context}.elapsed_s must be non-negative`)
   }
+  const tools = status === 'running'
+    ? undefined
+    : Array.isArray(raw.tools)
+      ? raw.tools.map((tool, toolIndex) => parseTool(tool, `${context}.tools[${toolIndex}]`))
+      : protocolError(`${context}.tools must be an array`)
   return {
     verificationId: nonEmptyString(raw.verification_id, `${context}.verification_id`),
     taskId: nonEmptyString(raw.task_id, `${context}.task_id`),
@@ -168,6 +215,7 @@ function parseRun(raw: unknown, index: number): VerificationRunRecord {
     gate: status === 'not_reviewed'
       ? nonEmptyString(raw.gate, `${context}.gate`)
       : undefined,
+    tools,
   }
 }
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -60,6 +60,14 @@ export {
   parseVerificationRunsResponse,
   fetchVerificationRuns,
 } from './dashboard-verification-runs'
+export {
+  fetchExactLaneRuns,
+  parseExactLaneRunsResponse,
+  type DashboardExactLaneRunsResponse,
+  type ExactLane,
+  type ExactLaneRunRecord,
+  type ExactLaneRunStatus,
+} from './dashboard-exact-lane-runs'
 
 // --- Dashboard projections ---
 

--- a/dashboard/src/components/internal-agents-monitor.test.ts
+++ b/dashboard/src/components/internal-agents-monitor.test.ts
@@ -1,0 +1,60 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { html } from 'htm/preact'
+
+const api = vi.hoisted(() => ({
+  fetchExactLaneRuns: vi.fn(),
+  fetchVerificationRuns: vi.fn(),
+  fetchFusionRuns: vi.fn(),
+}))
+
+vi.mock('../api/dashboard', () => api)
+vi.mock('../sse-store', () => ({
+  registerInternalAgentRefresh: vi.fn(() => vi.fn()),
+}))
+
+import { InternalAgentsMonitor } from './internal-agents-monitor'
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('InternalAgentsMonitor', () => {
+  it('expands a verification run and shows its ordered tool evidence', async () => {
+    api.fetchExactLaneRuns.mockResolvedValue({ runs: [], count: 0, generatedAt: 'now' })
+    api.fetchFusionRuns.mockResolvedValue({ runs: [], count: 0, generatedAt: 'now' })
+    api.fetchVerificationRuns.mockResolvedValue({
+      count: 1,
+      generatedAt: 'now',
+      runs: [{
+        verificationId: 'vrf-1',
+        taskId: 'task-1',
+        producer: 'keeper-a',
+        authorityKind: 'system_llm_agent',
+        authorityActor: 'judge-1',
+        startedAt: 1,
+        status: 'approved',
+        elapsedSeconds: 0.2,
+        evaluatorRuntime: 'reviewer-runtime',
+        tools: [{
+          toolName: 'report_review_verdict',
+          input: { verdict: 'APPROVE' },
+          disposition: 'completed',
+          outputExcerpt: 'Completion verdict recorded: APPROVE',
+          outputTruncated: false,
+          durationMs: 2,
+        }],
+      }],
+    })
+
+    render(html`<${InternalAgentsMonitor} />`)
+    await waitFor(() => expect(screen.getByText('Verification')).toBeTruthy())
+    fireEvent.click(screen.getByRole('button', { name: /Verification task-1/i }))
+    expect(await screen.findByText(/report_review_verdict/)).toBeTruthy()
+    expect(screen.getByText(/Completion verdict recorded: APPROVE/)).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Judge' }))
+    expect(screen.queryByText('report_review_verdict')).toBeNull()
+  })
+})

--- a/dashboard/src/components/internal-agents-monitor.ts
+++ b/dashboard/src/components/internal-agents-monitor.ts
@@ -1,0 +1,245 @@
+import { html } from 'htm/preact'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks'
+import {
+  fetchExactLaneRuns,
+  fetchFusionRuns,
+  fetchVerificationRuns,
+  type ExactLaneRunRecord,
+  type FusionRunRecord,
+  type VerificationRunRecord,
+} from '../api/dashboard'
+import { registerInternalAgentRefresh } from '../sse-store'
+import { Btn } from './btn'
+import { EmptyState, ErrorState } from './common/feedback-state'
+import { StatusBadge, type StatusBadgeTone } from './common/status-badge'
+import { relativeTime } from '../lib/format-time'
+
+type Filter = 'all' | 'librarian' | 'judge' | 'verification' | 'fusion'
+type Row =
+  | { source: 'exact'; id: string; run: ExactLaneRunRecord }
+  | { source: 'verification'; id: string; run: VerificationRunRecord }
+  | { source: 'fusion'; id: string; run: FusionRunRecord }
+
+const FILTERS: Array<{ id: Filter; label: string }> = [
+  { id: 'all', label: 'All' },
+  { id: 'librarian', label: 'Librarian' },
+  { id: 'judge', label: 'Judge' },
+  { id: 'verification', label: 'Verification' },
+  { id: 'fusion', label: 'Fusion' },
+]
+
+function laneLabel(row: Row): string {
+  if (row.source === 'verification') return 'Verification'
+  if (row.source === 'fusion') return 'Fusion'
+  switch (row.run.lane) {
+    case 'librarian_exact': return 'Librarian'
+    case 'hitl_auto_judge': return 'Auto Judge'
+    case 'board_attention_exact': return 'Board Judge'
+    case 'compaction_exact': return 'Compaction'
+  }
+}
+
+function status(row: Row): string {
+  return row.run.status
+}
+
+function tone(row: Row): StatusBadgeTone {
+  const value = status(row)
+  if (value === 'succeeded' || value === 'completed' || value === 'approved') return 'ok'
+  if (value === 'running') return 'warn'
+  if (value === 'rejected') return 'info'
+  return 'bad'
+}
+
+function actor(row: Row): string {
+  if (row.source === 'verification') return row.run.evaluatorRuntime ?? row.run.authorityActor
+  if (row.source === 'fusion') return row.run.keeper
+  return row.run.actor
+}
+
+function subject(row: Row): string {
+  if (row.source === 'verification') return row.run.taskId
+  if (row.source === 'fusion') return row.run.runId
+  return row.run.subjectId
+}
+
+function startedAt(row: Row): number {
+  return row.run.startedAt
+}
+
+function elapsed(row: Row): number | undefined {
+  return row.source === 'fusion' ? undefined : row.run.elapsedSeconds
+}
+
+function formatElapsed(value: number | undefined): string {
+  if (value == null) return '—'
+  return value < 1 ? `${Math.round(value * 1000)}ms` : `${value.toFixed(1)}s`
+}
+
+function pretty(value: unknown): string {
+  return JSON.stringify(value, null, 2) ?? 'null'
+}
+
+function Details({ row }: { row: Row }) {
+  if (row.source === 'verification') {
+    const tools = row.run.tools ?? []
+    return html`
+      <div class="grid gap-3 p-3 bg-[var(--color-bg-surface)] border-t border-[var(--color-border-default)]">
+        <div>
+          <div class="text-3xs uppercase tracking-wide text-[var(--color-fg-muted)] mb-1">Evidence path</div>
+          <code class="text-xs">producer ${row.run.producer} → ${row.run.authorityKind} → ${row.run.status}</code>
+        </div>
+        <div>
+          <div class="text-3xs uppercase tracking-wide text-[var(--color-fg-muted)] mb-1">Tools (${tools.length})</div>
+          ${tools.length === 0
+            ? html`<p class="text-xs text-[var(--color-fg-muted)]">No tools invoked in this verification run.</p>`
+            : html`<ol class="grid gap-2">
+                ${tools.map((tool, index) => html`
+                  <li key=${`${row.id}-${index}`} class="rounded border border-[var(--color-border-default)] p-2">
+                    <div class="flex flex-wrap items-center gap-2 text-xs">
+                      <strong>${index + 1}. ${tool.toolName}</strong>
+                      <code>${tool.disposition}</code>
+                      <span class="text-[var(--color-fg-muted)]">${tool.durationMs.toFixed(0)}ms</span>
+                    </div>
+                    <div class="grid gap-2 mt-2 md:grid-cols-2">
+                      <pre class="overflow-auto text-3xs whitespace-pre-wrap">${pretty(tool.input)}</pre>
+                      <pre class="overflow-auto text-3xs whitespace-pre-wrap">${tool.outputExcerpt}${tool.outputTruncated ? '\n… truncated' : ''}</pre>
+                    </div>
+                  </li>
+                `)}
+              </ol>`}
+        </div>
+      </div>
+    `
+  }
+  if (row.source === 'exact') {
+    return html`
+      <div class="grid gap-3 p-3 bg-[var(--color-bg-surface)] border-t border-[var(--color-border-default)] md:grid-cols-2">
+        <div>
+          <div class="text-3xs uppercase tracking-wide text-[var(--color-fg-muted)] mb-1">Input evidence</div>
+          <pre class="overflow-auto text-3xs whitespace-pre-wrap">${pretty(row.run.input)}</pre>
+        </div>
+        <div>
+          <div class="text-3xs uppercase tracking-wide text-[var(--color-fg-muted)] mb-1">Result</div>
+          <pre class="overflow-auto text-3xs whitespace-pre-wrap">${pretty(row.run.output ?? { code: row.run.code, detail: row.run.detail })}</pre>
+        </div>
+        <p class="text-xs text-[var(--color-fg-muted)] md:col-span-2">Tools: none. This exact-output lane performs one structured model execution, not MASC tool dispatch.</p>
+      </div>
+    `
+  }
+  return html`
+    <div class="p-3 bg-[var(--color-bg-surface)] border-t border-[var(--color-border-default)] text-xs">
+      <p>Preset <code>${row.run.preset}</code> · status <code>${row.run.status}</code></p>
+      ${row.run.error ? html`<p class="mt-1 text-[var(--color-danger)]">${row.run.failureCode}: ${row.run.error}</p>` : null}
+      <p class="mt-2 text-[var(--color-fg-muted)]">Fusion participant and judge detail remains on the Fusion surface; this row uses the same run registry.</p>
+    </div>
+  `
+}
+
+function matches(row: Row, filter: Filter): boolean {
+  if (filter === 'all') return true
+  if (filter === 'verification') return row.source === 'verification'
+  if (filter === 'fusion') return row.source === 'fusion'
+  if (filter === 'librarian') return row.source === 'exact' && row.run.lane === 'librarian_exact'
+  return row.source === 'exact'
+    && (row.run.lane === 'hitl_auto_judge' || row.run.lane === 'board_attention_exact')
+}
+
+export function InternalAgentsMonitor() {
+  const [rows, setRows] = useState<Row[]>([])
+  const [filter, setFilter] = useState<Filter>('all')
+  const [expanded, setExpanded] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [errors, setErrors] = useState<string[]>([])
+  const refreshVersion = useRef(0)
+
+  const refresh = useCallback(async () => {
+    const version = ++refreshVersion.current
+    setLoading(true)
+    const [exact, verification, fusion] = await Promise.allSettled([
+      fetchExactLaneRuns(),
+      fetchVerificationRuns(),
+      fetchFusionRuns(),
+    ])
+    const next: Row[] = []
+    const failures: string[] = []
+    if (exact.status === 'fulfilled') {
+      next.push(...exact.value.runs.map(run => ({ source: 'exact' as const, id: `exact:${run.runId}`, run })))
+    } else failures.push(`Exact lanes: ${String(exact.reason)}`)
+    if (verification.status === 'fulfilled') {
+      next.push(...verification.value.runs.map(run => ({ source: 'verification' as const, id: `verification:${run.verificationId}`, run })))
+    } else failures.push(`Verification: ${String(verification.reason)}`)
+    if (fusion.status === 'fulfilled') {
+      next.push(...fusion.value.runs.map(run => ({ source: 'fusion' as const, id: `fusion:${run.runId}`, run })))
+    } else failures.push(`Fusion: ${String(fusion.reason)}`)
+    if (version !== refreshVersion.current) return
+    next.sort((a, b) => startedAt(b) - startedAt(a))
+    setRows(next)
+    setErrors(failures)
+    setLoading(false)
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+    const unregister = registerInternalAgentRefresh(() => { void refresh() })
+    return () => {
+      unregister()
+      refreshVersion.current += 1
+    }
+  }, [refresh])
+
+  const visible = useMemo(() => rows.filter(row => matches(row, filter)), [rows, filter])
+
+  return html`
+    <section class="v2-monitoring-surface grid gap-3" data-testid="internal-agents-monitor">
+      <div class="flex flex-wrap items-center gap-2">
+        <h2 class="text-sm font-semibold text-[var(--color-fg-primary)]">Internal Agent Runs</h2>
+        <span class="text-xs text-[var(--color-fg-muted)]">${rows.length} observed</span>
+        <${Btn} class="v2-monitoring-action ml-auto" onClick=${() => void refresh()} disabled=${loading}>
+          ${loading ? 'Loading…' : 'Refresh'}
+        <//>
+      </div>
+      <p class="text-xs text-[var(--color-fg-muted)]">Typed run records from Librarian, Judge, Verification, Compaction, and Fusion. Updates arrive through WebSocket invalidation; HTTP snapshots remain the source of truth.</p>
+      <div class="flex flex-wrap gap-1" role="group" aria-label="Internal agent filters">
+        ${FILTERS.map(item => html`
+          <button
+            key=${item.id}
+            type="button"
+            class=${`rounded px-2 py-1 text-xs border ${filter === item.id ? 'border-[var(--color-accent)] text-[var(--color-fg-primary)]' : 'border-[var(--color-border-default)] text-[var(--color-fg-muted)]'}`}
+            aria-pressed=${filter === item.id}
+            onClick=${() => setFilter(item.id)}
+          >${item.label}</button>
+        `)}
+      </div>
+      ${errors.length > 0 ? html`<${ErrorState}>${errors.join(' · ')}<//>` : null}
+      ${!loading && visible.length === 0
+        ? html`<${EmptyState}>No internal agent runs for this filter.<//>`
+        : html`<div class="grid gap-2">
+            ${visible.map(row => {
+              const open = expanded === row.id
+              return html`
+                <article key=${row.id} class="v2-monitoring-card rounded border border-[var(--color-border-default)] overflow-hidden">
+                  <button
+                    type="button"
+                    class="w-full grid grid-cols-[auto_1fr_auto] gap-3 items-center p-3 text-left"
+                    aria-expanded=${open}
+                    onClick=${() => setExpanded(open ? null : row.id)}
+                  >
+                    <${StatusBadge} tone=${tone(row)} label=${status(row)} />
+                    <span class="min-w-0">
+                      <strong class="block text-xs text-[var(--color-fg-primary)]">${laneLabel(row)}</strong>
+                      <code class="block truncate text-3xs text-[var(--color-fg-muted)]" title=${subject(row)}>${subject(row)}</code>
+                    </span>
+                    <span class="text-right text-3xs text-[var(--color-fg-muted)]">
+                      <span class="block">${actor(row)}</span>
+                      <span class="block">${formatElapsed(elapsed(row))} · ${relativeTime(new Date(startedAt(row) * 1000).toISOString())}</span>
+                    </span>
+                  </button>
+                  ${open ? html`<${Details} row=${row} />` : null}
+                </article>
+              `
+            })}
+          </div>`}
+    </section>
+  `
+}

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -11,6 +11,7 @@ import { SurfaceHeader } from './common/surface-header'
 
 export type StatusSection =
   | 'observatory' | 'journey' | 'agents' | 'runtime'
+  | 'internal-agents'
   | 'fleet-health' | 'transport-health'
   | 'feature-health'
 
@@ -37,6 +38,9 @@ const LazyAgentsUnified = lazy(async () => ({
 }))
 const LazyRuntimePanel = lazy(async () => ({
   default: (await import('./runtime-panel')).RuntimePanel,
+}))
+const LazyInternalAgentsMonitor = lazy(async () => ({
+  default: (await import('./internal-agents-monitor')).InternalAgentsMonitor,
 }))
 const LazyFleetHealthPanel = lazy(async () => ({
   default: (await import('./fleet-health-panel')).FleetHealthPanel,
@@ -70,6 +74,8 @@ function renderSection(section: StatusSection) {
       return html`<${LazyJourneyPanel} />`
     case 'runtime':
       return html`<${LazyRuntimePanel} />`
+    case 'internal-agents':
+      return html`<${LazyInternalAgentsMonitor} />`
     case 'fleet-health':
       return html`<${LazyFleetHealthPanel} />`
     case 'transport-health':

--- a/dashboard/src/components/verification-runs-panel.ts
+++ b/dashboard/src/components/verification-runs-panel.ts
@@ -28,8 +28,7 @@ import { relativeTime } from '../lib/format-time'
 import type { ManagedAsyncResource } from '../lib/async-state'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 import { truncate } from '../lib/truncate'
-
-const AUTO_REFRESH_MS = 15_000
+import { registerInternalAgentRefresh } from '../sse-store'
 
 /** Outcome → badge tone.
  *
@@ -134,9 +133,9 @@ export function VerificationRunsPanel() {
 
   useEffect(() => {
     void loadData(resource)
-    const id = setInterval(() => void loadData(resource), AUTO_REFRESH_MS)
+    const unregister = registerInternalAgentRefresh(() => { void loadData(resource) })
     return () => {
-      clearInterval(id)
+      unregister()
       resource.cancel()
     }
   }, [resource])

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -290,7 +290,7 @@ describe('monitoring navigation labels', () => {
     expect(ids).not.toContain('sessions')
   })
 
-  it('surfaces four primary Monitor lanes and keeps support diagnostics routeable', () => {
+  it('surfaces five primary Monitor lanes and keeps support diagnostics routeable', () => {
     const sections = visibleSectionItemsForTab('monitoring')
     const allSections = sectionItemsForTab('monitoring')
     const ids = sections.map(item => item.id)
@@ -298,7 +298,7 @@ describe('monitoring navigation labels', () => {
 
     expect(defaultParamsForTab('monitoring')).toEqual({ section: 'agents' })
     expect(ids).toEqual([
-      'agents', 'fleet-health', 'runtime', 'observatory',
+      'agents', 'internal-agents', 'fleet-health', 'runtime', 'observatory',
     ])
     expect(ids).toContain('agents')
     expect(ids).toContain('fleet-health')
@@ -327,6 +327,7 @@ describe('monitoring navigation labels', () => {
     const sections = visibleSectionItemsForTab('monitoring')
     expect(sections.map(section => section.id)).toEqual([
       'agents',
+      'internal-agents',
       'fleet-health',
       'runtime',
       'observatory',

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -52,6 +52,7 @@ type SurfaceSectionId =
   // monitoring
   | 'observatory'
   | 'agents'
+  | 'internal-agents'
   | 'runtime'
   | 'fleet-health'   // Phase 1: absorbs telemetry + fleet + tool-quality + Gate monitoring
   | 'transport-health' // Hidden support route for transport diagnostics; linked from Runtime.
@@ -329,6 +330,12 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: 'Keeper Fleet',
       description: 'Live and configured keeper roster.',
       params: { section: 'agents' },
+    },
+    {
+      id: 'internal-agents',
+      label: 'Internal Agents',
+      description: 'Nondeterministic runs and tool evidence.',
+      params: { section: 'internal-agents' },
     },
     {
       id: 'fleet-health',

--- a/dashboard/src/refresh-scope.ts
+++ b/dashboard/src/refresh-scope.ts
@@ -1,6 +1,6 @@
 import type { RouteState } from './types'
 
-export type RouteRefreshTarget = 'execution' | 'board' | 'operator' | 'activity' | 'fusion' | 'ide'
+export type RouteRefreshTarget = 'execution' | 'board' | 'operator' | 'activity' | 'fusion' | 'internalAgents' | 'ide'
 
 export function routeWantsRefreshTarget(
   routeState: Pick<RouteState, 'tab' | 'params'>,
@@ -19,6 +19,9 @@ export function routeWantsRefreshTarget(
       // The fusion run-status panel only mounts on the top-level fusion surface,
       // so its registry refetch is scoped to that route (RFC-0266 Phase 4).
       return routeState.tab === 'fusion'
+    case 'internalAgents':
+      return (routeState.tab === 'monitoring' && routeState.params.section === 'internal-agents')
+        || (routeState.tab === 'workspace' && routeState.params.section === 'verification')
     case 'ide':
       // The IDE workspace store is an app-lifetime singleton, so its live push
       // refresh must be scoped to the code surface — otherwise a keeper editing

--- a/dashboard/src/schemas/sse.test.ts
+++ b/dashboard/src/schemas/sse.test.ts
@@ -385,6 +385,14 @@ describe('parseSSEMessage', () => {
     warnSpy.mockRestore()
   })
 
+  it('keeps internal agent invalidations at the websocket parse boundary', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const msg = parseSSEMessage({ type: 'internal_agent_runs_changed' })
+    expect(msg?.type).toBe('internal_agent_runs_changed')
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
   it('keeps gate_mode_changed events instead of dropping them as schema drift', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const msg = parseSSEMessage({

--- a/dashboard/src/schemas/sse.ts
+++ b/dashboard/src/schemas/sse.ts
@@ -72,6 +72,7 @@ const FIXED_SSE_EVENT_TYPES = new Set([
   // parse boundary, before the live WS router (sse-store.ts routeServerPushEvent
   // -> SIMPLE_ROUTES['fusion_run_status'] -> refreshFusionRuns) can dispatch it.
   'fusion_run_status',
+  'internal_agent_runs_changed',
   'client_input_approved',
   'client_input_rejected',
   'client_input_updated',

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -466,6 +466,35 @@ describe('setupServerPushReaction reconnect hydration', () => {
     expect(refreshFusionRuns).not.toHaveBeenCalled()
   })
 
+  it('refreshes the mounted internal-agent registry immediately from websocket invalidation', async () => {
+    const { sseStore } = await loadSseStore()
+    route.value = { tab: 'monitoring', params: { section: 'internal-agents' }, postId: null }
+    const refresh = vi.fn()
+    const unregister = sseStore.registerInternalAgentRefresh(refresh)
+
+    sseStore.routeServerPushEvent({ type: 'internal_agent_runs_changed' })
+    vi.advanceTimersByTime(1)
+    await flushAsyncWork()
+
+    expect(refresh).toHaveBeenCalledTimes(1)
+    unregister()
+  })
+
+  it('refreshes Fusion rows inside Internal Agents from the existing Fusion websocket event', async () => {
+    const { sseStore } = await loadSseStore()
+    route.value = { tab: 'monitoring', params: { section: 'internal-agents' }, postId: null }
+    const refresh = vi.fn()
+    const unregister = sseStore.registerInternalAgentRefresh(refresh)
+
+    sseStore.routeServerPushEvent({ type: 'fusion_run_status' })
+    vi.advanceTimersByTime(1)
+    await flushAsyncWork()
+
+    expect(refresh).toHaveBeenCalledTimes(1)
+    expect(refreshFusionRuns).not.toHaveBeenCalled()
+    unregister()
+  })
+
   it('routes keeper_tool_call to the IDE workspace refresh while on the code surface', async () => {
     const { sseStore } = await loadSseStore()
     route.value = { tab: 'code', params: {}, postId: null }

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -139,6 +139,14 @@ export function registerActivityRefresh(fn: () => void): () => void {
   }
 }
 
+const _refreshInternalAgentFns = new Set<() => void>()
+export function registerInternalAgentRefresh(fn: () => void): () => void {
+  _refreshInternalAgentFns.add(fn)
+  return () => {
+    _refreshInternalAgentFns.delete(fn)
+  }
+}
+
 // IDE workspace live-refresh subscribers. The app-lifetime workspace-store
 // singleton registers here so a keeper's file edits / tool runs refresh the
 // tree/diff/file view without a re-navigation. A Set (not a single slot)
@@ -236,6 +244,7 @@ const SIMPLE_ROUTES: Record<string, SimpleRoute> = {
   // Without this entry the live WS router dropped the event and the run-status
   // panel only refreshed on the ~120s periodic poll / route revisit (RFC-0266 Phase 4).
   fusion_run_status:    { target: 'fusion' },
+  internal_agent_runs_changed: { target: 'internalAgents', debounceMs: 0 },
 }
 
 const BOARD_HEARTH_REFRESH_EVENTS = new Set([
@@ -261,6 +270,9 @@ const REFRESH_FNS: Record<RefreshTarget, () => void> = {
     for (const fn of _refreshActivityFns) fn()
   },
   fusion:    () => { void refreshFusionRuns() },
+  internalAgents: () => {
+    for (const fn of _refreshInternalAgentFns) fn()
+  },
   ide:       () => {
     for (const fn of _refreshIdeFns) fn()
   },
@@ -609,6 +621,9 @@ export function routeServerPushEvent(event: SSEEvent): void {
     if (BOARD_HEARTH_REFRESH_EVENTS.has(routedType)) {
       scheduleBoardHearthsRefresh(simpleRoute.debounceMs)
     }
+  }
+  if (routedType === 'fusion_run_status') {
+    scheduleTargetRefresh('internalAgents', REFRESH_FNS.internalAgents, 0)
   }
 
   for (const { prefix, target } of PREFIX_ROUTES) {

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -44,6 +44,7 @@ export type SSEEventType =
   | 'masc/keeper_turn_complete'
   // RFC-0266 Phase 4: fusion run-status transitions pushed to the dashboard.
   | 'fusion_run_status'
+  | 'internal_agent_runs_changed'
   | 'client_input_approved'
   | 'client_input_rejected'
   | 'client_input_updated'

--- a/lib/completion_authority_agent.ml
+++ b/lib/completion_authority_agent.ml
@@ -455,6 +455,10 @@ let process_task_once
      a committed verdict emitted a durable event. *)
   let registry = Verification_run_registry.global () in
   let started_at = Eio.Time.now runtime.clock in
+  let tools = ref [] in
+  let on_tool_result ~input result =
+    tools := Verification_run_registry.observe_tool_result ~input result :: !tools
+  in
   Verification_run_registry.register_running
     registry
     ~verification_id
@@ -468,6 +472,7 @@ let process_task_once
       registry
       ~verification_id
       ~outcome
+      ~tools:(List.rev !tools)
       ?evaluator_runtime
       ~elapsed_s:(Eio.Time.now runtime.clock -. started_at)
       ();
@@ -507,6 +512,7 @@ let process_task_once
           ?completion_contract:prepared.completion_contract
           ~required_evidence:prepared.required_artifacts
           ~verify_gate_evidence:[]
+          ~on_tool_result
           prepared.review_request
       in
       let evaluator_runtime = result.evaluator_runtime in

--- a/lib/exact_lane_run_registry.ml
+++ b/lib/exact_lane_run_registry.ml
@@ -1,0 +1,264 @@
+type lane =
+  | Librarian
+  | Hitl_auto_judge
+  | Board_attention
+  | Compaction
+
+type outcome =
+  | Succeeded
+  | Cancelled
+  | Failed of
+      { code : string
+      ; detail : string
+      }
+
+type run_status =
+  | Running
+  | Completed of
+      { outcome : outcome
+      ; elapsed_s : float
+      ; output : Yojson.Safe.t
+      }
+
+type run =
+  { run_id : string
+  ; lane : lane
+  ; subject_id : string
+  ; actor : string
+  ; started_at : float
+  ; input : Yojson.Safe.t
+  ; status : run_status
+  }
+
+let lane_key = function
+  | Librarian -> "librarian_exact"
+  | Hitl_auto_judge -> "hitl_auto_judge"
+  | Board_attention -> "board_attention_exact"
+  | Compaction -> "compaction_exact"
+;;
+
+let lane_of_key = function
+  | "librarian_exact" -> Ok Librarian
+  | "hitl_auto_judge" -> Ok Hitl_auto_judge
+  | "board_attention_exact" -> Ok Board_attention
+  | "compaction_exact" -> Ok Compaction
+  | value -> Error (Printf.sprintf "unknown exact lane %S" value)
+;;
+
+let outcome_label = function
+  | Succeeded -> "succeeded"
+  | Cancelled -> "cancelled"
+  | Failed _ -> "failed"
+;;
+
+module Payload = struct
+  type registration =
+    { lane : lane
+    ; subject_id : string
+    ; actor : string
+    ; input : Yojson.Safe.t
+    }
+
+  type completion =
+    { outcome : outcome
+    ; elapsed_s : float
+    ; output : Yojson.Safe.t
+    }
+
+  let name = "exact_lane_run_registry"
+  let running_noun = "exact lane run(s)"
+  let restart_reason = "exact-output fibers do not survive server restart"
+
+  let registration_to_yojson registration =
+    `Assoc
+      [ "lane", `String (lane_key registration.lane)
+      ; "subject_id", `String registration.subject_id
+      ; "actor", `String registration.actor
+      ; "input", registration.input
+      ]
+  ;;
+
+  let registration_of_yojson json =
+    let ( let* ) = Result.bind in
+    let* fields = Run_registry_core.Json.object_fields json in
+    let* () =
+      Run_registry_core.Json.exact_fields
+        ~required:[ "lane"; "subject_id"; "actor"; "input" ]
+        fields
+    in
+    let* lane_key = Run_registry_core.Json.string_field "lane" fields in
+    let* lane = lane_of_key lane_key in
+    let* subject_id = Run_registry_core.Json.string_field "subject_id" fields in
+    let* actor = Run_registry_core.Json.string_field "actor" fields in
+    let* input =
+      match List.assoc_opt "input" fields with
+      | Some value -> Ok value
+      | None -> Error "missing field input"
+    in
+    Ok { lane; subject_id; actor; input }
+  ;;
+
+  let completion_to_yojson completion =
+    let detail =
+      match completion.outcome with
+      | Succeeded | Cancelled -> []
+      | Failed { code; detail } -> [ "code", `String code; "detail", `String detail ]
+    in
+    `Assoc
+      ([ "outcome", `String (outcome_label completion.outcome)
+       ; "elapsed_s", `Float completion.elapsed_s
+       ; "output", completion.output
+       ]
+       @ detail)
+  ;;
+
+  let completion_of_yojson json =
+    let ( let* ) = Result.bind in
+    let* fields = Run_registry_core.Json.object_fields json in
+    let* label = Run_registry_core.Json.string_field "outcome" fields in
+    let detail_fields =
+      match label with
+      | "succeeded" | "cancelled" -> Ok []
+      | "failed" -> Ok [ "code"; "detail" ]
+      | value -> Error (Printf.sprintf "unknown exact lane outcome %S" value)
+    in
+    let* detail_fields = detail_fields in
+    let* () =
+      Run_registry_core.Json.exact_fields
+        ~required:([ "outcome"; "elapsed_s"; "output" ] @ detail_fields)
+        fields
+    in
+    let* elapsed_s = Run_registry_core.Json.float_field "elapsed_s" fields in
+    let* output =
+      match List.assoc_opt "output" fields with
+      | Some value -> Ok value
+      | None -> Error "missing field output"
+    in
+    let* outcome =
+      match label with
+      | "succeeded" -> Ok Succeeded
+      | "cancelled" -> Ok Cancelled
+      | "failed" ->
+        let* code = Run_registry_core.Json.string_field "code" fields in
+        let* detail = Run_registry_core.Json.string_field "detail" fields in
+        Ok (Failed { code; detail })
+      | value -> Error (Printf.sprintf "unknown exact lane outcome %S" value)
+    in
+    Ok { outcome; elapsed_s; output }
+  ;;
+end
+
+module Store = Run_registry_core.Make (Payload)
+
+type t = Store.t
+
+let change_observer_fn : (unit -> unit) Atomic.t = Atomic.make (fun () -> ())
+
+let notify_changed () =
+  try (Atomic.get change_observer_fn) () with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Log.Keeper.warn
+      "exact_lane_run_registry change observer failed: %s"
+      (Printexc.to_string exn)
+;;
+
+let create = Store.create
+let replay = Store.replay
+let max_completed_retained = Store.max_completed_retained
+
+let register_running t ~run_id ~lane ~subject_id ~actor ~started_at ~input =
+  let input =
+    input
+    |> Observability_redact.redact_json_value
+    |> Observability_redact.preview_json_strings ~max_len:1024
+  in
+  Store.register
+    t
+    ~id:run_id
+    ~started_at
+    ~registration:{ Payload.lane; subject_id; actor; input };
+  notify_changed ()
+;;
+
+let mark_completed t ~run_id ~outcome ~elapsed_s ~output =
+  let output =
+    output
+    |> Observability_redact.redact_json_value
+    |> Observability_redact.preview_json_strings ~max_len:1024
+  in
+  let completion = { Payload.outcome; elapsed_s; output } in
+  match Store.complete t ~id:run_id ~completion with
+  | `Completed -> notify_changed ()
+  | `Unknown -> ()
+;;
+
+let run_of_entry (entry : Store.entry) =
+  let status =
+    match entry.status with
+    | Store.Running -> Running
+    | Store.Completed completion ->
+      Completed
+        { outcome = completion.outcome
+        ; elapsed_s = completion.elapsed_s
+        ; output = completion.output
+        }
+  in
+  { run_id = entry.id
+  ; lane = entry.registration.lane
+  ; subject_id = entry.registration.subject_id
+  ; actor = entry.registration.actor
+  ; started_at = entry.started_at
+  ; input = entry.registration.input
+  ; status
+  }
+;;
+
+let list_runs t = List.map run_of_entry (Store.list_entries t)
+let get t ~run_id = Option.map run_of_entry (Store.get t ~id:run_id)
+
+let status_label = function
+  | Running -> "running"
+  | Completed { outcome; _ } -> outcome_label outcome
+;;
+
+let run_to_yojson run =
+  let base =
+    [ "run_id", `String run.run_id
+    ; "lane", `String (lane_key run.lane)
+    ; "subject_id", `String run.subject_id
+    ; "actor", `String run.actor
+    ; "started_at", `Float run.started_at
+    ; "input", run.input
+    ; "status", `String (status_label run.status)
+    ]
+  in
+  let completion =
+    match run.status with
+    | Running -> []
+    | Completed { outcome; elapsed_s; output } ->
+      let detail =
+        match outcome with
+        | Succeeded | Cancelled -> []
+        | Failed { code; detail } -> [ "code", `String code; "detail", `String detail ]
+      in
+      [ "elapsed_s", `Float elapsed_s; "output", output ] @ detail
+  in
+  `Assoc (base @ completion)
+;;
+
+type global_install_error = Already_installed
+
+module Global = Run_registry_core.Global (struct
+    type nonrec t = t
+
+    let initial = create ()
+  end)
+
+let global = Global.current
+
+let install_global registry =
+  match Global.install registry with
+  | Ok () -> Ok ()
+  | Error Global.Already_installed -> Error Already_installed
+;;

--- a/lib/exact_lane_run_registry.mli
+++ b/lib/exact_lane_run_registry.mli
@@ -1,0 +1,74 @@
+(** Durable observation records for model-driven Keeper exact-output lanes. *)
+
+type lane =
+  | Librarian
+  | Hitl_auto_judge
+  | Board_attention
+  | Compaction
+
+type outcome =
+  | Succeeded
+  | Cancelled
+  | Failed of
+      { code : string
+      ; detail : string
+      }
+
+type run_status =
+  | Running
+  | Completed of
+      { outcome : outcome
+      ; elapsed_s : float
+      ; output : Yojson.Safe.t
+      }
+
+type run =
+  { run_id : string
+  ; lane : lane
+  ; subject_id : string
+  ; actor : string
+  ; started_at : float
+  ; input : Yojson.Safe.t
+  ; status : run_status
+  }
+
+type t
+
+val create : ?path:string -> unit -> t
+val replay : string -> t
+
+val register_running
+  :  t
+  -> run_id:string
+  -> lane:lane
+  -> subject_id:string
+  -> actor:string
+  -> started_at:float
+  -> input:Yojson.Safe.t
+  -> unit
+
+val mark_completed
+  :  t
+  -> run_id:string
+  -> outcome:outcome
+  -> elapsed_s:float
+  -> output:Yojson.Safe.t
+  -> unit
+
+val list_runs : t -> run list
+val get : t -> run_id:string -> run option
+val lane_key : lane -> string
+val outcome_label : outcome -> string
+val status_label : run_status -> string
+val run_to_yojson : run -> Yojson.Safe.t
+
+(** Called after a registry mutation is durable/in-memory-visible. The server
+    installs a WS invalidation broadcaster; tests and library-only users keep
+    the no-op default. *)
+val change_observer_fn : (unit -> unit) Atomic.t
+
+type global_install_error = Already_installed
+
+val global : unit -> t
+val install_global : t -> (unit, global_install_error) result
+val max_completed_retained : int

--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -1182,6 +1182,38 @@ let spawn_with
   | Error detail -> Error detail
   | Ok prepared ->
     let clock = Eio_context.get_clock_opt () in
+    let registry = Exact_lane_run_registry.global () in
+    let run_id = Random_id.prefixed ~prefix:"exact-hitl-judge-" ~bytes:16 in
+    let started_at = Time_compat.now () in
+    let observed_summary = ref None in
+    let on_summary summary =
+      observed_summary := Some summary;
+      on_summary summary
+    in
+    Exact_lane_run_registry.register_running
+      registry
+      ~run_id
+      ~lane:Exact_lane_run_registry.Hitl_auto_judge
+      ~subject_id:entry.id
+      ~actor:entry.keeper_name
+      ~started_at
+      ~input:
+        (`Assoc
+           [ "tool_name", `String entry.tool_name
+           ; "turn_id", Json_util.int_opt_to_json entry.turn_id
+           ; "task_id", Json_util.string_opt_to_json entry.task_id
+           ; "goal_id", Json_util.string_opt_to_json entry.goal_id
+           ; "goal_ids", `List (List.map (fun goal -> `String goal) entry.goal_ids)
+           ; "partial_context", `Bool (Option.is_none entry.request_context)
+           ]);
+    let complete outcome output =
+      Exact_lane_run_registry.mark_completed
+        registry
+        ~run_id
+        ~outcome
+        ~elapsed_s:(Time_compat.now () -. started_at)
+        ~output
+    in
     Eio.Fiber.fork ~sw (fun () ->
     let execution_outcome =
       try
@@ -1217,26 +1249,58 @@ let spawn_with
       | exn -> `Uncertain exn
     in
     match execution_outcome with
-    | `Completed -> on_finish Conclusive_terminalization
+    | `Completed ->
+      let output =
+        match !observed_summary with
+        | Some summary -> hitl_context_summary_to_yojson summary
+        | None -> `Assoc [ "terminal", `String "conclusive_terminalization" ]
+      in
+      complete Exact_lane_run_registry.Succeeded output;
+      on_finish Conclusive_terminalization
     | `Cancelled (cancellation, cancellation_backtrace) ->
+      complete Exact_lane_run_registry.Cancelled `Null;
       on_finish Terminalization_persistence_uncertain;
       Printexc.raise_with_backtrace cancellation cancellation_backtrace
     | `Cancelled_uncertain
         (cancellation, cancellation_backtrace, _detail) ->
+      complete Exact_lane_run_registry.Cancelled `Null;
       on_finish Terminalization_persistence_uncertain;
       Printexc.raise_with_backtrace cancellation cancellation_backtrace
     | `Cancelled_identity_unbound
         (cancellation, cancellation_backtrace) ->
+      complete Exact_lane_run_registry.Cancelled `Null;
       on_finish Terminalization_identity_unbound;
       Printexc.raise_with_backtrace cancellation cancellation_backtrace
     | `Cancelled_rejected
         (cancellation, cancellation_backtrace, _rejection) ->
+      complete Exact_lane_run_registry.Cancelled `Null;
       on_finish Terminalization_rejected;
       Printexc.raise_with_backtrace cancellation cancellation_backtrace
     | `Identity_unbound ->
+      complete
+        (Exact_lane_run_registry.Failed
+           { code = "terminalization_identity_unbound"
+           ; detail = "exact attempt identity was not durably bound"
+           })
+        `Null;
       on_finish Terminalization_identity_unbound
-    | `Rejected _ -> on_finish Terminalization_rejected
+    | `Rejected rejection ->
+      let detail =
+        Keeper_approval_queue.exact_attempt_error_to_string
+          (Exact_attempt_rejected rejection)
+      in
+      complete
+        (Exact_lane_run_registry.Failed
+           { code = "terminalization_rejected"; detail })
+        `Null;
+      on_finish Terminalization_rejected
     | `Uncertain uncertainty ->
+      complete
+        (Exact_lane_run_registry.Failed
+           { code = "terminalization_persistence_uncertain"
+           ; detail = Printexc.to_string uncertainty
+           })
+        `Null;
       on_finish Terminalization_persistence_uncertain;
       raise uncertainty);
     Ok Worker_forked

--- a/lib/keeper/keeper_board_attention_exact_flow.ml
+++ b/lib/keeper/keeper_board_attention_exact_flow.ml
@@ -357,6 +357,25 @@ let observe_terminal prepared result =
 ;;
 
 let execute_current ?clock ~before_dispatch ~before_advance prepared =
+  let registry = Exact_lane_run_registry.global () in
+  let run_id = Random_id.prefixed ~prefix:"exact-board-attention-" ~bytes:16 in
+  let started_at = Time_compat.now () in
+  Exact_lane_run_registry.register_running
+    registry
+    ~run_id
+    ~lane:Exact_lane_run_registry.Board_attention
+    ~subject_id:prepared.candidate.candidate_id
+    ~actor:prepared.candidate.keeper_name
+    ~started_at
+    ~input:prepared.candidate.judgment_request;
+  let complete outcome output =
+    Exact_lane_run_registry.mark_completed
+      registry
+      ~run_id
+      ~outcome
+      ~elapsed_s:(Time_compat.now () -. started_at)
+      ~output
+  in
   let bound = ref None in
   let oas_before_dispatch receipt =
     let current = attempt_provenance receipt in
@@ -415,30 +434,51 @@ let execute_current ?clock ~before_dispatch ~before_advance prepared =
       Error (Exact_execution_failed (evidence_provenance evidence))
   in
   let result =
-    match
-      Exact_output.execute_flow_once
-        ~net:prepared.net
-        ?clock
-        ~before_measurement_dispatch:(fun _ -> Ok ())
-        ~on_measurement_terminal:(fun _ -> Ok ())
-        ~before_dispatch:oas_before_dispatch
-        ~before_advance:oas_before_advance
-        ~validate
-        prepared.attempt
+    try
+      match
+        Exact_output.execute_flow_once
+          ~net:prepared.net
+          ?clock
+          ~before_measurement_dispatch:(fun _ -> Ok ())
+          ~on_measurement_terminal:(fun _ -> Ok ())
+          ~before_dispatch:oas_before_dispatch
+          ~before_advance:oas_before_advance
+          ~validate
+          prepared.attempt
+      with
+      | Ok success -> Ok success.accepted
+      | Error (Exact_output.Flow_execution_terminal { cause; _ }) ->
+        terminal_error cause
+      | Error
+          (Exact_output.Flow_semantic_candidates_exhausted { rejections; _ }) ->
+        let rejection =
+          List.fold_left
+            (fun _ rejection -> rejection)
+            rejections.first
+            rejections.rest
+        in
+        Error rejection.rejection
     with
-    | Ok success -> Ok success.accepted
-    | Error (Exact_output.Flow_execution_terminal { cause; _ }) ->
-      terminal_error cause
-    | Error
-        (Exact_output.Flow_semantic_candidates_exhausted { rejections; _ }) ->
-      let rejection =
-        List.fold_left
-          (fun _ rejection -> rejection)
-          rejections.first
-          rejections.rest
-      in
-      Error rejection.rejection
+    | Eio.Cancel.Cancelled _ as exn ->
+      complete Exact_lane_run_registry.Cancelled `Null;
+      raise exn
+    | exn ->
+      complete
+        (Exact_lane_run_registry.Failed
+           { code = "board_attention_raised"; detail = Printexc.to_string exn })
+        `Null;
+      raise exn
   in
+  (match result with
+   | Ok judgment ->
+     complete
+       Exact_lane_run_registry.Succeeded
+       (Keeper_board_attention_candidate.judgment_to_yojson judgment)
+   | Error _ ->
+     let code = result |> terminal_outcome |> terminal_outcome_to_string in
+     complete
+       (Exact_lane_run_registry.Failed { code; detail = code })
+       (`Assoc [ "terminal_outcome", `String code ]));
   observe_terminal prepared result;
   result
 ;;

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -870,6 +870,20 @@ let summarization_failure_of_callback = function
   | Authority_rejected -> Exact_execution_authority_rejected
 ;;
 
+let summarization_failure_detail = function
+  | Exact_lane_unconfigured -> "exact_lane_unconfigured"
+  | Exact_target_selection_failed -> "exact_target_selection_failed"
+  | Exact_admission_failed -> "exact_admission_failed"
+  | Exact_attempt_start_failed -> "exact_attempt_start_failed"
+  | Exact_execution_context_unavailable -> "exact_execution_context_unavailable"
+  | Exact_execution_authority_absent -> "exact_execution_authority_absent"
+  | Exact_execution_authority_rejected -> "exact_execution_authority_rejected"
+  | Exact_flow_already_started -> "exact_flow_already_started"
+  | Exact_execution_terminal terminal ->
+    Keeper_compaction_outcome.exact_execution_terminal_to_string terminal
+  | Invalid_plan -> "invalid_plan"
+;;
+
 let execute_prepared_lane_current
       ~keeper_name
       ~net
@@ -877,6 +891,30 @@ let execute_prepared_lane_current
       ?before_dispatch_authority
       prepared_lane
   =
+  let registry = Exact_lane_run_registry.global () in
+  let run_id = Random_id.prefixed ~prefix:"exact-compaction-" ~bytes:16 in
+  let started_at = Time_compat.now () in
+  Exact_lane_run_registry.register_running
+    registry
+    ~run_id
+    ~lane:Exact_lane_run_registry.Compaction
+    ~subject_id:(Int64.to_string prepared_lane.registry_generation)
+    ~actor:keeper_name
+    ~started_at
+    ~input:
+      (`Assoc
+         [ "registry_generation", `Intlit (Int64.to_string prepared_lane.registry_generation)
+         ; "slot_ids", `List (List.map (fun id -> `String id) prepared_lane.ordered_slot_ids)
+         ; "source_unit_count", `Int (List.length prepared_lane.window.source_units)
+         ]);
+  let complete outcome output =
+    Exact_lane_run_registry.mark_completed
+      registry
+      ~run_id
+      ~outcome
+      ~elapsed_s:(Time_compat.now () -. started_at)
+      ~output
+  in
   (* Process-local derived state only. It identifies the exact OAS candidate
      whose dispatch callback passed, so cancellation can retain that source.
      It is not persisted and does not compete with OAS execution ownership. *)
@@ -967,7 +1005,14 @@ let execute_prepared_lane_current
              observation.slot_id
              observation.call_id)
         !authorized_observation;
+      complete Exact_lane_run_registry.Cancelled `Null;
       Printexc.raise_with_backtrace cancellation raw_bt
+    | exn ->
+      complete
+        (Exact_lane_run_registry.Failed
+           { code = "compaction_raised"; detail = Printexc.to_string exn })
+        `Null;
+      raise exn
   in
   let project_execution () =
   match execution with
@@ -1056,7 +1101,34 @@ let execute_prepared_lane_current
       ; exact_execution_evidence = exact_execution_evidence flow_success
       }
   in
-  project_execution ()
+  let result = project_execution () in
+  (match result with
+   | Ok completed ->
+     let evidence = completed.exact_execution_evidence in
+     complete
+       Exact_lane_run_registry.Succeeded
+       (`Assoc
+          [ ( "summary_excerpt"
+            , `String
+                (Observability_redact.redact_preview
+                   ~max_len:512
+                   completed.plan.summary) )
+          ; "summary_bytes", `Int (String.length completed.plan.summary)
+          ; "keep_from_unit_index", `Int completed.plan.keep_from_unit_index
+          ; "slot_id", `String evidence.slot_id
+          ; "call_id", `String evidence.call_id
+          ; "target_identity_fingerprint", `String evidence.target_identity_fingerprint
+          ; "catalog_generation_fingerprint", `String evidence.catalog_generation_fingerprint
+          ; "catalog_evidence_sha256", `String evidence.catalog_evidence_sha256
+          ; "plan_fingerprint", `String evidence.plan_fingerprint
+          ; "request_body_sha256", `String evidence.receipt_request_body_sha256
+          ])
+   | Error failure ->
+     let detail = summarization_failure_detail failure in
+     complete
+       (Exact_lane_run_registry.Failed { code = "compaction_failed"; detail })
+       `Null);
+  result
 ;;
 
 let execute_prepared_lane

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -437,39 +437,93 @@ let run_best_effort
     try
       match Eio_context.get_net_opt (), Eio_context.get_clock_opt () with
       | Some net, Some clock ->
-        (match
-           extract_and_commit_with_exact_output_classified
-             ~clock
-             ~net
-             ~keepers_dir
-             ~keeper_id
-             ~expected_revision
-             inp
+        let registry = Exact_lane_run_registry.global () in
+        let run_id = Random_id.prefixed ~prefix:"exact-librarian-" ~bytes:16 in
+        let started_at = Eio.Time.now clock in
+        let current_fact_count =
+          match inp.current with
+          | None -> 0
+          | Some current -> List.length current.facts
+        in
+        Exact_lane_run_registry.register_running
+          registry
+          ~run_id
+          ~lane:Exact_lane_run_registry.Librarian
+          ~subject_id:trace_id
+          ~actor:keeper_id
+          ~started_at
+          ~input:
+            (`Assoc
+               [ "generation", `Int inp.generation
+               ; "message_count", `Int (List.length inp.messages)
+               ; "current_fact_count", `Int current_fact_count
+               ; "max_recall_fact_bytes", `Int inp.max_recall_fact_bytes
+               ]);
+        let complete outcome output =
+          Exact_lane_run_registry.mark_completed
+            registry
+            ~run_id
+            ~outcome
+            ~elapsed_s:(Eio.Time.now clock -. started_at)
+            ~output
+        in
+        (try
+           match
+             extract_and_commit_with_exact_output_classified
+               ~clock
+               ~net
+               ~keepers_dir
+               ~keeper_id
+               ~expected_revision
+               inp
+           with
+           | Ok snapshot ->
+             complete
+               Exact_lane_run_registry.Succeeded
+               (`Assoc
+                  [ "revision", `Int snapshot.revision
+                  ; "fact_count", `Int (List.length snapshot.facts)
+                  ; "added_count", `Int (List.length snapshot.change.added)
+                  ; "removed_count", `Int (List.length snapshot.change.removed)
+                  ]);
+             cadence_record_success ~keeper_id ~trace_id;
+             Log.Keeper.info
+               ~keeper_name:keeper_id
+               "memory os librarian committed current snapshot revision=%d facts=%d added=%d removed=%d"
+               snapshot.revision
+               (List.length snapshot.facts)
+               (List.length snapshot.change.added)
+               (List.length snapshot.change.removed)
+           | Error error ->
+             let detail = extraction_error_to_string error in
+             complete
+               (Exact_lane_run_registry.Failed
+                  { code = "librarian_failed"; detail })
+               `Null;
+             Otel_metric_store.inc_counter
+               Keeper_metrics.(to_string MemoryOsLibrarianFailures)
+               ~labels:[ "keeper", keeper_id; "site", "memory_os_librarian" ]
+               ();
+             let deferred = should_record_cadence_backoff_after_error error in
+             if deferred then cadence_record_attempt ~keeper_id ~trace_id;
+             log_failure_with_snapshot_severity
+               ~keepers_dir
+               ~keeper_id
+               (Printf.sprintf
+                  "memory os librarian failed lane=%s: %s; cadence deferred=%b"
+                  exact_lane_id
+                  detail
+                  deferred)
          with
-         | Ok snapshot ->
-           cadence_record_success ~keeper_id ~trace_id;
-           Log.Keeper.info
-             ~keeper_name:keeper_id
-             "memory os librarian committed current snapshot revision=%d facts=%d added=%d removed=%d"
-             snapshot.revision
-             (List.length snapshot.facts)
-             (List.length snapshot.change.added)
-             (List.length snapshot.change.removed)
-         | Error error ->
-           Otel_metric_store.inc_counter
-             Keeper_metrics.(to_string MemoryOsLibrarianFailures)
-             ~labels:[ "keeper", keeper_id; "site", "memory_os_librarian" ]
-             ();
-           let deferred = should_record_cadence_backoff_after_error error in
-           if deferred then cadence_record_attempt ~keeper_id ~trace_id;
-           log_failure_with_snapshot_severity
-             ~keepers_dir
-             ~keeper_id
-             (Printf.sprintf
-                "memory os librarian failed lane=%s: %s; cadence deferred=%b"
-                exact_lane_id
-                (extraction_error_to_string error)
-                deferred))
+         | Eio.Cancel.Cancelled _ as exn ->
+           complete Exact_lane_run_registry.Cancelled `Null;
+           raise exn
+         | exn ->
+           complete
+             (Exact_lane_run_registry.Failed
+                { code = "librarian_raised"; detail = Printexc.to_string exn })
+             `Null;
+           raise exn)
       | _ ->
         Log.Keeper.warn
           ~keeper_name:keeper_id

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -687,6 +687,20 @@ let add_routes ~sw ~clock router =
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/exact-lane-runs" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let runs =
+           Exact_lane_run_registry.list_runs (Exact_lane_run_registry.global ())
+         in
+         let json =
+           `Assoc
+             [ ("generated_at", `String (Masc_domain.now_iso ()))
+             ; ("count", `Int (List.length runs))
+             ; ("runs", `List (List.map Exact_lane_run_registry.run_to_yojson runs))
+             ]
+         in
+         Http.Response.json_value ~compress:true ~request:req json reqd
+       ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/workspace" (fun request reqd ->
        with_public_read handle_dashboard_workspace request reqd)
   (* Dev-only Worker bearer for the dashboard UI. Served exclusively when the

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -634,7 +634,7 @@ let startup_failure_disposition ~state_ready =
 
 type owner_initialization_error =
   | Runtime_config_path_unavailable
-  | Run_registry_already_installed of [ `Fusion | `Verification ]
+  | Run_registry_already_installed of [ `Exact_lane | `Fusion | `Verification ]
   | Runtime_default_initialization_failed of Runtime.strict_init_error
   | Keeper_persistence_preparation_failed of
       Server_bootstrap_loops.keeper_persistence_prepare_error
@@ -671,6 +671,8 @@ let owner_initialization_error_to_string = function
     "Fusion run registry already has a process owner"
   | Run_registry_already_installed `Verification ->
     "Verification run registry already has a process owner"
+  | Run_registry_already_installed `Exact_lane ->
+    "Exact lane run registry already has a process owner"
   | Runtime_default_initialization_failed error ->
     "Runtime.init_default_degraded failed: "
     ^ Runtime.strict_init_error_to_string error
@@ -767,6 +769,25 @@ let initialize_owner_state_blocking
      raise
        (Owner_initialization_failed
           (Run_registry_already_installed `Verification)));
+  let exact_lane_registry =
+    Filename.concat masc_dir "exact-lane-runs.jsonl"
+    |> Exact_lane_run_registry.replay
+  in
+  (match Exact_lane_run_registry.install_global exact_lane_registry with
+   | Ok () -> ()
+   | Error Exact_lane_run_registry.Already_installed ->
+     raise
+       (Owner_initialization_failed
+          (Run_registry_already_installed `Exact_lane)));
+  let broadcast_internal_agent_runs_changed () =
+    Sse.broadcast (`Assoc [ "type", `String "internal_agent_runs_changed" ])
+  in
+  Atomic.set
+    Verification_run_registry.change_observer_fn
+    broadcast_internal_agent_runs_changed;
+  Atomic.set
+    Exact_lane_run_registry.change_observer_fn
+    broadcast_internal_agent_runs_changed;
   (* [main_eio] caches the normalized operator input before entering Eio.
      Replace that preflight value with the canonical owner identity before
      [Workspace.default_config_uncached] constructs its backend, otherwise the

--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -136,7 +136,7 @@ val startup_failure_disposition : state_ready:bool -> startup_failure_dispositio
 
 type owner_initialization_error =
   | Runtime_config_path_unavailable
-  | Run_registry_already_installed of [ `Fusion | `Verification ]
+  | Run_registry_already_installed of [ `Exact_lane | `Fusion | `Verification ]
   | Runtime_default_initialization_failed of Runtime.strict_init_error
   | Keeper_persistence_preparation_failed of
       Server_bootstrap_loops.keeper_persistence_prepare_error

--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -37,8 +37,9 @@ let run_llm_reviewer_fn
      evaluator_runtime:string ->
      prompt:string ->
      report_tool_schema:Types_core.tool_schema ->
+     on_tool_result:(input:Yojson.Safe.t -> Tool_result.result -> unit) ->
      unit -> (verdict option, Agent_sdk.Error.sdk_error) result) Atomic.t
-  = Atomic.make (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ () ->
+  = Atomic.make (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~on_tool_result:_ () ->
       Error (Agent_sdk.Error.Internal "Workspace_hooks: run_llm_reviewer_fn not connected"))
 
 (** Issue #8436: schema enum used to be hand-rolled as a 2-element
@@ -286,6 +287,7 @@ let review
       ?(required_evidence = [])
       ?(verify_gate_evidence = [])
       ?(on_verdict : review_result -> unit = fun _ -> ())
+      ?(on_tool_result : input:Yojson.Safe.t -> Tool_result.result -> unit = fun ~input:_ _ -> ())
       ?(few_shot_block = "")
       ?(sw : Eio.Switch.t option = None)
       ~base_path
@@ -358,6 +360,7 @@ let review
              ~evaluator_runtime
              ~prompt
              ~report_tool_schema:report_review_verdict_schema
+             ~on_tool_result
              ()
          with
          | Eio.Cancel.Cancelled _ as exn -> raise exn

--- a/lib/task/anti_rationalization.mli
+++ b/lib/task/anti_rationalization.mli
@@ -41,6 +41,7 @@ val review
   -> ?required_evidence:string list
   -> ?verify_gate_evidence:string list
   -> ?on_verdict:(review_result -> unit)
+  -> ?on_tool_result:(input:Yojson.Safe.t -> Tool_result.result -> unit)
   -> ?few_shot_block:string
   -> ?sw:Eio.Switch.t option
   -> base_path:string
@@ -69,6 +70,7 @@ val run_llm_reviewer_fn
       -> evaluator_runtime:string
       -> prompt:string
       -> report_tool_schema:Types_core.tool_schema
+      -> on_tool_result:(input:Yojson.Safe.t -> Tool_result.result -> unit)
       -> unit
       -> (verdict option, Agent_sdk.Error.sdk_error) result)
        Atomic.t

--- a/lib/verification_run_registry.ml
+++ b/lib/verification_run_registry.ml
@@ -9,12 +9,22 @@ type outcome =
   | Commit_failed of { detail : string }
   | Raised of { detail : string }
 
+type tool_observation =
+  { tool_name : string
+  ; input : Yojson.Safe.t
+  ; disposition : (unit, unit, unit) Tool_result.disposition
+  ; output_excerpt : string
+  ; output_truncated : bool
+  ; duration_ms : float
+  }
+
 type run_status =
   | Running
   | Completed of
       { outcome : outcome
       ; evaluator_runtime : string option
       ; elapsed_s : float
+      ; tools : tool_observation list
       }
 
 type run =
@@ -48,6 +58,7 @@ module Payload = struct
     { outcome : outcome
     ; evaluator_runtime : string option
     ; elapsed_s : float
+    ; tools : tool_observation list
     }
 
   let name = "verification_run_registry"
@@ -92,9 +103,20 @@ module Payload = struct
   ;;
 
   let completion_to_yojson completion =
+    let tool_to_yojson tool =
+      `Assoc
+        [ "tool_name", `String tool.tool_name
+        ; "input", tool.input
+        ; "disposition", `String (Tool_result.string_of_disposition tool.disposition)
+        ; "output_excerpt", `String tool.output_excerpt
+        ; "output_truncated", `Bool tool.output_truncated
+        ; "duration_ms", `Float tool.duration_ms
+        ]
+    in
     let fields =
       [ "outcome", `String (outcome_label completion.outcome)
       ; "elapsed_s", `Float completion.elapsed_s
+      ; "tools", `List (List.map tool_to_yojson completion.tools)
       ]
       @ outcome_fields completion.outcome
       @
@@ -120,7 +142,7 @@ module Payload = struct
     let* required_detail_fields = required_detail_fields in
     let* () =
       Run_registry_core.Json.exact_fields
-        ~required:([ "outcome"; "elapsed_s" ] @ required_detail_fields)
+        ~required:([ "outcome"; "elapsed_s"; "tools" ] @ required_detail_fields)
         ~optional:[ "evaluator_runtime" ]
         fields
     in
@@ -128,6 +150,62 @@ module Payload = struct
     let* evaluator_runtime =
       Run_registry_core.Json.optional_string_field "evaluator_runtime" fields
     in
+    let* tools_json =
+      match List.assoc_opt "tools" fields with
+      | Some (`List tools) -> Ok tools
+      | Some _ -> Error "field tools must be an array"
+      | None -> Error "missing field tools"
+    in
+    let tool_of_yojson json =
+      let* fields = Run_registry_core.Json.object_fields json in
+      let* () =
+        Run_registry_core.Json.exact_fields
+          ~required:
+            [ "tool_name"
+            ; "input"
+            ; "disposition"
+            ; "output_excerpt"
+            ; "output_truncated"
+            ; "duration_ms"
+            ]
+          fields
+      in
+      let* tool_name = Run_registry_core.Json.string_field "tool_name" fields in
+      let* input =
+        match List.assoc_opt "input" fields with
+        | Some value -> Ok value
+        | None -> Error "missing field input"
+      in
+      let* disposition_wire =
+        Run_registry_core.Json.string_field "disposition" fields
+      in
+      let* disposition = Tool_result.unit_disposition_of_string disposition_wire in
+      let* output_excerpt =
+        Run_registry_core.Json.string_field "output_excerpt" fields
+      in
+      let* output_truncated =
+        match List.assoc_opt "output_truncated" fields with
+        | Some (`Bool value) -> Ok value
+        | Some _ -> Error "field output_truncated must be a boolean"
+        | None -> Error "missing field output_truncated"
+      in
+      let* duration_ms = Run_registry_core.Json.float_field "duration_ms" fields in
+      Ok
+        { tool_name
+        ; input
+        ; disposition
+        ; output_excerpt
+        ; output_truncated
+        ; duration_ms
+        }
+    in
+    let rec parse_tools acc = function
+      | [] -> Ok (List.rev acc)
+      | tool :: rest ->
+        let* tool = tool_of_yojson tool in
+        parse_tools (tool :: acc) rest
+    in
+    let* tools = parse_tools [] tools_json in
     let* outcome =
       match label with
       | "approved" -> Ok Approved
@@ -149,7 +227,7 @@ module Payload = struct
         Ok (Raised { detail })
       | other -> Error (Printf.sprintf "unknown verification outcome %S" other)
     in
-    Ok { outcome; evaluator_runtime; elapsed_s }
+    Ok { outcome; evaluator_runtime; elapsed_s; tools }
   ;;
 end
 
@@ -160,6 +238,17 @@ type t = Store.t
 let create = Store.create
 let replay = Store.replay
 let max_completed_retained = Store.max_completed_retained
+
+let change_observer_fn : (unit -> unit) Atomic.t = Atomic.make (fun () -> ())
+
+let notify_changed () =
+  try (Atomic.get change_observer_fn) () with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Log.Task.warn
+      "verification_run_registry change observer failed: %s"
+      (Printexc.to_string exn)
+;;
 
 let register_running
       t
@@ -174,14 +263,40 @@ let register_running
     t
     ~id:verification_id
     ~started_at
-    ~registration:{ Payload.task_id; producer; authority_kind; authority_actor }
+    ~registration:{ Payload.task_id; producer; authority_kind; authority_actor };
+  notify_changed ()
 ;;
 
-let mark_completed t ~verification_id ~outcome ?evaluator_runtime ~elapsed_s () =
-  let completion = { Payload.outcome; evaluator_runtime; elapsed_s } in
+let mark_completed t ~verification_id ~outcome ~tools ?evaluator_runtime ~elapsed_s () =
+  let completion = { Payload.outcome; evaluator_runtime; elapsed_s; tools } in
   match Store.complete t ~id:verification_id ~completion with
-  | `Completed -> ()
+  | `Completed -> notify_changed ()
   | `Unknown -> ()
+;;
+
+let observe_tool_result ~input (result : Tool_result.result) =
+  let disposition =
+    match result with
+    | Tool_result.Completed _ -> Tool_result.Completed ()
+    | Tool_result.Deferred _ -> Tool_result.Deferred ()
+    | Tool_result.Failed _ -> Tool_result.Failed ()
+  in
+  let output_excerpt, output_truncated =
+    let redacted = Tool_result.message result |> Observability_redact.redact_text in
+    Keeper_text_processing.truncate_utf8_prefix
+      ~max_bytes:1024
+      redacted
+  in
+  { tool_name = Tool_result.tool_name result
+  ; input =
+      (input
+       |> Observability_redact.redact_json_value
+       |> Observability_redact.preview_json_strings ~max_len:512)
+  ; disposition
+  ; output_excerpt
+  ; output_truncated
+  ; duration_ms = Tool_result.duration_ms result
+  }
 ;;
 
 let run_of_entry (entry : Store.entry) =
@@ -193,6 +308,7 @@ let run_of_entry (entry : Store.entry) =
         { outcome = completion.outcome
         ; evaluator_runtime = completion.evaluator_runtime
         ; elapsed_s = completion.elapsed_s
+        ; tools = completion.tools
         }
   in
   { verification_id = entry.id
@@ -236,8 +352,20 @@ let run_to_yojson run =
   let completion_fields =
     match run.status with
     | Running -> []
-    | Completed { outcome; evaluator_runtime; elapsed_s } ->
-      [ "elapsed_s", `Float elapsed_s ]
+    | Completed { outcome; evaluator_runtime; elapsed_s; tools } ->
+      let tool_to_yojson tool =
+        `Assoc
+          [ "tool_name", `String tool.tool_name
+          ; "input", tool.input
+          ; "disposition", `String (Tool_result.string_of_disposition tool.disposition)
+          ; "output_excerpt", `String tool.output_excerpt
+          ; "output_truncated", `Bool tool.output_truncated
+          ; "duration_ms", `Float tool.duration_ms
+          ]
+      in
+      [ "elapsed_s", `Float elapsed_s
+      ; "tools", `List (List.map tool_to_yojson tools)
+      ]
       @ outcome_detail_fields outcome
       @
       (match evaluator_runtime with

--- a/lib/verification_run_registry.mli
+++ b/lib/verification_run_registry.mli
@@ -11,12 +11,22 @@ type outcome =
   | Commit_failed of { detail : string }
   | Raised of { detail : string }
 
+type tool_observation =
+  { tool_name : string
+  ; input : Yojson.Safe.t
+  ; disposition : (unit, unit, unit) Tool_result.disposition
+  ; output_excerpt : string
+  ; output_truncated : bool
+  ; duration_ms : float
+  }
+
 type run_status =
   | Running
   | Completed of
       { outcome : outcome
       ; evaluator_runtime : string option
       ; elapsed_s : float
+      ; tools : tool_observation list
       }
 
 type run =
@@ -48,6 +58,7 @@ val mark_completed
   :  t
   -> verification_id:string
   -> outcome:outcome
+  -> tools:tool_observation list
   -> ?evaluator_runtime:string
   -> elapsed_s:float
   -> unit
@@ -60,6 +71,11 @@ val get : t -> verification_id:string -> run option
 val outcome_label : outcome -> string
 val status_label : run_status -> string
 val run_to_yojson : run -> Yojson.Safe.t
+val observe_tool_result : input:Yojson.Safe.t -> Tool_result.result -> tool_observation
+
+(** Called after a registry mutation is visible. The server installs a WS
+    invalidation broadcaster; library-only users keep the no-op default. *)
+val change_observer_fn : (unit -> unit) Atomic.t
 type global_install_error = Already_installed
 
 val global : unit -> t

--- a/lib/workspace_metric_hooks.ml
+++ b/lib/workspace_metric_hooks.ml
@@ -314,12 +314,12 @@ let install () =
 
   Atomic.set Task.Anti_rationalization.outcome_observer_fn record_anti_rationalization_outcome;
 
-  Atomic.set Task.Anti_rationalization.run_llm_reviewer_fn (fun ~base_path ?sw ~evaluator_runtime ~prompt ~report_tool_schema () ->
+  Atomic.set Task.Anti_rationalization.run_llm_reviewer_fn (fun ~base_path ?sw ~evaluator_runtime ~prompt ~report_tool_schema ~on_tool_result () ->
     let verdict_ref = ref None in
     let protocol_error_ref = ref None in
     let dispatch ~name ~args =
       let start_time = Time_compat.now () in
-      match !verdict_ref with
+      let result = match !verdict_ref with
       | Some verdict ->
         let detail =
           Printf.sprintf
@@ -350,6 +350,9 @@ let install () =
              ~tool_name:name
              ~start_time
              (Printf.sprintf "Invalid verdict format: %s" msg))
+      in
+      on_tool_result ~input:args result;
+      result
     in
     let apply_review_verdict_output_contract provider_cfg =
       Ok

--- a/test/dune
+++ b/test/dune
@@ -2535,6 +2535,7 @@
 (include stanzas/test_dashboard_continuity_briefs.inc)
 
 (include stanzas/test_verification_run_registry.inc)
+(include stanzas/test_exact_lane_run_registry.inc)
 
 ; The tool-call quality benchmark reads its case set and evidence fixture from
 ; repo-root JSON (benchmarks/data, test/fixtures) rather than from sandbox
@@ -2563,4 +2564,3 @@
   (source_tree %{workspace_root}/config/prompts)
   %{workspace_root}/test/fixtures/keeper_system_prompt/assembled_prompt.golden)
  (libraries alcotest masc_test_deps))
-

--- a/test/stanzas/test_exact_lane_run_registry.inc
+++ b/test/stanzas/test_exact_lane_run_registry.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_exact_lane_run_registry)
+ (modules test_exact_lane_run_registry)
+ (libraries alcotest masc_test_deps masc.run_registry_core))

--- a/test/test_anti_rationalization_empty_reject.ml
+++ b/test/test_anti_rationalization_empty_reject.ml
@@ -33,7 +33,7 @@ let test_explicit_base_path_reaches_reviewer () =
   in
   let received = ref None in
   with_reviewer
-    (fun ~base_path ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ () ->
+    (fun ~base_path ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~on_tool_result:_ () ->
        received := Some base_path;
        Ok None)
     (fun () ->
@@ -51,7 +51,7 @@ let configure_prompt_registry () =
 
 let test_structured_tool_is_the_only_semantic_verdict () =
   with_reviewer
-    (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ () ->
+    (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~on_tool_result:_ () ->
        Ok (Some AR.Approve))
     (fun () ->
        let result = review () in
@@ -67,7 +67,7 @@ let test_structured_tool_is_the_only_semantic_verdict () =
 
 let test_response_text_is_never_parsed_as_verdict () =
   with_reviewer
-    (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ () ->
+    (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~on_tool_result:_ () ->
        Ok None)
     (fun () ->
        let result = review () in
@@ -80,7 +80,7 @@ let test_response_text_is_never_parsed_as_verdict () =
 
 let test_evaluator_failure_is_unavailable_not_reject () =
   with_reviewer
-    (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ () ->
+    (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~on_tool_result:_ () ->
        Error (Agent_sdk.Error.Internal "review transport unavailable"))
     (fun () ->
        let result = review () in

--- a/test/test_completion_trust_harness.ml
+++ b/test/test_completion_trust_harness.ml
@@ -20,7 +20,7 @@ type reviewer_response =
 
 let reviewer_response = ref (Reviewer_verdict AR.Approve)
 
-let reviewer ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ () =
+let reviewer ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~on_tool_result:_ () =
   match !reviewer_response with
   | Reviewer_verdict verdict -> Ok (Some verdict)
   | Reviewer_unavailable ->

--- a/test/test_exact_lane_run_registry.ml
+++ b/test/test_exact_lane_run_registry.ml
@@ -1,0 +1,60 @@
+open Alcotest
+module R = Masc.Exact_lane_run_registry
+
+let remove_if_exists path =
+  try Sys.remove path with
+  | Sys_error _ -> ()
+;;
+
+let test_round_trip_preserves_exact_evidence () =
+  let path = Filename.temp_file "exact-lane-runs-" ".jsonl" in
+  remove_if_exists path;
+  let registry = R.create ~path () in
+  R.register_running
+    registry
+    ~run_id:"run-1"
+    ~lane:R.Librarian
+    ~subject_id:"trace-1"
+    ~actor:"keeper-a"
+    ~started_at:10.0
+    ~input:(`Assoc [ "message_count", `Int 4 ]);
+  R.mark_completed
+    registry
+    ~run_id:"run-1"
+    ~outcome:R.Succeeded
+    ~elapsed_s:0.5
+    ~output:(`Assoc [ "fact_count", `Int 3 ]);
+  let replayed = R.replay path in
+  let original = R.get registry ~run_id:"run-1" |> Option.get |> R.run_to_yojson in
+  let restored = R.get replayed ~run_id:"run-1" |> Option.get |> R.run_to_yojson in
+  check string "round trip" (Yojson.Safe.to_string original) (Yojson.Safe.to_string restored);
+  remove_if_exists path
+;;
+
+let test_running_shape_has_no_invented_completion () =
+  let registry = R.create () in
+  R.register_running
+    registry
+    ~run_id:"run-live"
+    ~lane:R.Board_attention
+    ~subject_id:"candidate-1"
+    ~actor:"keeper-a"
+    ~started_at:20.0
+    ~input:`Null;
+  let run = R.get registry ~run_id:"run-live" |> Option.get in
+  check string "status" "running" (R.status_label run.status);
+  match R.run_to_yojson run with
+  | `Assoc fields ->
+    check bool "no elapsed" false (List.mem_assoc "elapsed_s" fields);
+    check bool "no output" false (List.mem_assoc "output" fields)
+  | _ -> fail "run serializer must emit an object"
+;;
+
+let () =
+  run
+    "exact_lane_run_registry"
+    [ ( "registry"
+      , [ test_case "durable exact evidence" `Quick test_round_trip_preserves_exact_evidence
+        ; test_case "running shape" `Quick test_running_shape_has_no_invented_completion
+        ] )
+    ]

--- a/test/test_telemetry_task_transition_10358.ml
+++ b/test/test_telemetry_task_transition_10358.ml
@@ -115,7 +115,7 @@ let test_masc_transition_claim_done_emits_task_lifecycle () =
      structured APPROVE so the [done] transition reaches its terminal state and
      emits the lifecycle telemetry under test. *)
   Atomic.set Task.Anti_rationalization.run_llm_reviewer_fn
-    (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ () ->
+    (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~on_tool_result:_ () ->
       Ok (Some Task.Anti_rationalization.Approve));
   Atomic.set Workspace_hooks.get_default_runtime_id_fn
     (fun () -> "test-evaluator-runtime");

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -99,7 +99,7 @@ let install_test_hooks () =
     (Filename.concat (repo_root ()) "config/prompts");
   Atomic.set Workspace_hooks.get_default_runtime_id_fn Runtime.get_default_runtime_id;
   Atomic.set Task.Anti_rationalization.run_llm_reviewer_fn
-    (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ () ->
+    (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~on_tool_result:_ () ->
        Ok (Some Task.Anti_rationalization.Approve))
 
 let with_env name value_opt f =
@@ -1394,7 +1394,7 @@ let () = test "handle_transition_force_is_not_a_done_action" (fun () ->
             String.equal agent_name "admin-agent");
        let reviewer_called = ref false in
        Atomic.set Task.Anti_rationalization.run_llm_reviewer_fn
-         (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ () ->
+         (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~on_tool_result:_ () ->
             reviewer_called := true;
             Ok (Some Task.Anti_rationalization.Approve));
        let result =

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -672,7 +672,7 @@ let test_system_llm_agent_commits_without_a_keeper_verifier () =
           let reviewer_called, resolve_reviewer_called = Eio.Promise.create () in
           let verdict_committed, resolve_verdict_committed = Eio.Promise.create () in
           Atomic.set Masc.Task.Anti_rationalization.run_llm_reviewer_fn
-            (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ () ->
+            (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~on_tool_result:_ () ->
                Eio.Promise.resolve resolve_reviewer_called ();
                Ok (Some Masc.Task.Anti_rationalization.Approve));
           Atomic.set Workspace_hooks.verification_notify_verdict_fn
@@ -829,7 +829,7 @@ let test_system_llm_agent_uses_persisted_request_contract_snapshot () =
           let verdict_committed, resolve_verdict_committed = Eio.Promise.create () in
           let captured_prompt = ref None in
           Atomic.set Masc.Task.Anti_rationalization.run_llm_reviewer_fn
-            (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt ~report_tool_schema:_ () ->
+            (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt ~report_tool_schema:_ ~on_tool_result:_ () ->
                captured_prompt := Some prompt;
                Eio.Promise.resolve resolve_reviewer_called ();
                Ok (Some Masc.Task.Anti_rationalization.Approve));

--- a/test/test_verification_run_registry.ml
+++ b/test/test_verification_run_registry.ml
@@ -119,6 +119,7 @@ let test_outcome_detail_reaches_the_surface () =
          t
          ~verification_id:"vrf-detail"
          ~outcome
+         ~tools:[]
          ~evaluator_runtime:"cross-verifier"
          ~elapsed_s:2.5
          ();
@@ -152,7 +153,7 @@ let test_outcomes_survive_replay () =
        let path = fresh_path (".{" ^ label ^ "}.jsonl") in
        let t = R.create ~path () in
        register t ~verification_id:"vrf-replay" ~started_at:50.0;
-       R.mark_completed t ~verification_id:"vrf-replay" ~outcome ~elapsed_s:1.0 ();
+       R.mark_completed t ~verification_id:"vrf-replay" ~outcome ~tools:[] ~elapsed_s:1.0 ();
        let replayed = R.replay path in
        (match R.get replayed ~verification_id:"vrf-replay" with
         | None -> fail ("completed review lost on replay: " ^ label)
@@ -172,7 +173,7 @@ let test_replay_drops_running_reviews () =
   let path = fresh_path ".running.jsonl" in
   let t = R.create ~path () in
   register t ~verification_id:"vrf-done" ~started_at:10.0;
-  R.mark_completed t ~verification_id:"vrf-done" ~outcome:E.Approved ~elapsed_s:1.0 ();
+  R.mark_completed t ~verification_id:"vrf-done" ~outcome:E.Approved ~tools:[] ~elapsed_s:1.0 ();
   register t ~verification_id:"vrf-stale" ~started_at:20.0;
   let replayed = R.replay path in
   (* The review fiber dies with the process and the authority rescans
@@ -198,6 +199,7 @@ let test_retry_replaces_the_prior_attempt () =
     t
     ~verification_id:"vrf-retry"
     ~outcome:(E.Not_reviewed { gate = "invalid_verdict"; detail = "no tool call" })
+    ~tools:[]
     ~elapsed_s:1.0
     ();
   (* A deferred review is retried under a fresh authority actor; the table must
@@ -225,6 +227,7 @@ let test_unknown_completion_is_not_persisted () =
     t
     ~verification_id:"vrf-unknown"
     ~outcome:E.Approved
+    ~tools:[]
     ~elapsed_s:1.0
     ();
   check int "unknown completion creates no row" 0 (List.length (R.list_runs t));
@@ -275,7 +278,7 @@ let test_completed_runs_are_pruned () =
   for i = 1 to total do
     let verification_id = Printf.sprintf "vrf-%03d" i in
     register t ~verification_id ~started_at:(float_of_int i);
-    R.mark_completed t ~verification_id ~outcome:E.Approved ~elapsed_s:0.5 ()
+    R.mark_completed t ~verification_id ~outcome:E.Approved ~tools:[] ~elapsed_s:0.5 ()
   done;
   check
     int
@@ -304,6 +307,47 @@ let test_global_lifecycle_rejects_reinstallation () =
    | Ok () -> fail "second installation replaced the owner"
    | Error Lifecycle.Already_installed -> ());
   check int "first owner remains active" 1 (Lifecycle.current ())
+;;
+
+let test_tool_result_keeps_typed_disposition_and_input () =
+  let result =
+    Tool_result.ok
+      ~tool_name:"report_review_verdict"
+      ~start_time:(Time_compat.now ())
+      "Completion verdict recorded: APPROVE"
+  in
+  let tool =
+    R.observe_tool_result
+      ~input:(`Assoc [ "verdict", `String "APPROVE" ])
+      result
+  in
+  let t = R.create () in
+  register t ~verification_id:"vrf-tools" ~started_at:10.0;
+  R.mark_completed
+    t
+    ~verification_id:"vrf-tools"
+    ~outcome:E.Approved
+    ~tools:[ tool ]
+    ~elapsed_s:0.1
+    ();
+  let json = R.get t ~verification_id:"vrf-tools" |> Option.get |> R.run_to_yojson in
+  match field json "tools" with
+  | Some (`List [ `Assoc fields ]) ->
+    check
+      (option string)
+      "tool name"
+      (Some "report_review_verdict")
+      (match List.assoc_opt "tool_name" fields with
+       | Some (`String value) -> Some value
+       | _ -> None);
+    check
+      (option string)
+      "typed disposition"
+      (Some "completed")
+      (match List.assoc_opt "disposition" fields with
+       | Some (`String value) -> Some value
+       | _ -> None)
+  | _ -> fail "completed review must serialize one tool observation"
 ;;
 
 let () =
@@ -341,6 +385,10 @@ let () =
             `Quick
             test_missing_outcome_payload_is_an_error
         ; test_case "completed runs are pruned" `Quick test_completed_runs_are_pruned
+        ; test_case
+            "tool evidence keeps input and typed disposition"
+            `Quick
+            test_tool_result_keeps_typed_disposition_and_input
         ; test_case
             "global registry has one installation owner"
             `Quick


### PR DESCRIPTION
## Summary
- add durable exact-lane run records for Librarian, HITL Auto Judge, Board Judge, and Compaction
- append redacted ordered Tool_result evidence to completion-authority verification runs
- add Monitoring > Internal Agents with unified Verification, exact-lane, and Fusion rows
- replace Verification polling with route-scoped WebSocket invalidation and SSOT refetch

## Safety
- exact lane and tool previews pass through Observability_redact before persistence
- unknown lanes, statuses, dispositions, and record fields fail strict decoding
- events are invalidation only; HTTP registries remain authoritative
- overlapping refreshes are generation-guarded so an older response cannot overwrite a newer snapshot

## Verification
- scripts/dune-local.sh build lib/masc.cmxa lib/server/masc_server.cmxa test/test_verification_run_registry.exe test/test_exact_lane_run_registry.exe
- test_verification_run_registry.exe: 12 passed
- test_exact_lane_run_registry.exe: 2 passed
- dashboard pnpm typecheck
- dashboard focused Vitest: 176 passed
- dashboard pnpm build
- Playwright Chromium: opened Monitoring/Internal Agents, expanded Verification, verified tool input/disposition/output, switched Judge filter
