### PR TITLE
fix(operator): 판단자가 말한 적 없는 confidence 를 지어내지 않는다

### DIFF
--- a/lib/operator/operator_control_action.ml
+++ b/lib/operator/operator_control_action.ml
@@ -44,7 +44,24 @@ let judgment_write_json (ctx : 'a context) args =
     in
     let fresh_until_unix = now_unix +. float_of_int fresh_ttl_sec in
     let fresh_until = Masc_domain.iso8601_of_unix_seconds fresh_until_unix in
-    let confidence = get_float args "confidence" 0.5 in
+    (* No default. An omitted [confidence] used to become 0.5, which put "the
+       judge did not say" and "the judge is half sure" on one number in the
+       operator digest. The schema declares the field required with bounds; a
+       caller that omits it or sends something else is told which field. *)
+    let* confidence =
+      match Json_util.assoc_member_opt "confidence" args with
+      | Some (`Float value) -> Ok value
+      | Some (`Int value) -> Ok (float_of_int value)
+      | Some _ -> Error "confidence must be a number between 0.0 and 1.0"
+      | None -> Error "confidence is required"
+    in
+    let* confidence =
+      if Float.is_finite confidence
+         && Float.compare confidence 0.0 >= 0
+         && Float.compare confidence 1.0 <= 0
+      then Ok confidence
+      else Error "confidence must be a number between 0.0 and 1.0"
+    in
     let keeper_name =
       match get_string_opt args "keeper_name" with
       | Some raw ->

--- a/lib/operator/operator_judgment.ml
+++ b/lib/operator/operator_judgment.ml
@@ -101,6 +101,25 @@ let of_yojson json =
     in
     let* generated_at_unix = required_unix "generated_at_unix" in
     let* fresh_until_unix = required_unix "fresh_until_unix" in
+    (* [confidence] is the judge's own statement about a judgment an operator
+       reads. An absent or malformed value is not 0.0 — that spelling would put
+       "no opinion recorded" and "certain this is wrong" on the same number in
+       the digest a human decides from. Every record this module writes carries
+       the field, so a record without one is a corrupt record, not an old one. *)
+    let* confidence =
+      match Json_util.assoc_member_opt "confidence" json with
+      | Some (`Float value) -> Ok value
+      | Some (`Int value) -> Ok (float_of_int value)
+      | Some _ -> Error "invalid confidence"
+      | None -> Error "missing confidence"
+    in
+    let* confidence =
+      if Float.is_finite confidence
+         && Float.compare confidence 0.0 >= 0
+         && Float.compare confidence 1.0 <= 0
+      then Ok confidence
+      else Error "confidence out of range"
+    in
     Ok
       {
         judgment_id = (match Json_util.assoc_member_opt "judgment_id" json with Some (`String s) -> s | _ -> "");
@@ -111,11 +130,7 @@ let of_yojson json =
           Json_util.get_string json "status"
           |> Option.value ~default:"active";
         summary = (match Json_util.assoc_member_opt "summary" json with Some (`String s) -> s | _ -> "");
-        confidence =
-          (match Json_util.assoc_member_opt "confidence" json with
-          | Some (`Float value) -> value
-          | Some (`Int value) -> float_of_int value
-          | _ -> 0.0);
+        confidence;
         generated_at = (match Json_util.assoc_member_opt "generated_at" json with Some (`String s) -> s | _ -> "");
         generated_at_unix;
         fresh_until = (match Json_util.assoc_member_opt "fresh_until" json with Some (`String s) -> s | _ -> "");
@@ -212,7 +227,7 @@ let record config ~surface ~target_type ~target_id ~summary ~confidence
       target_id;
       status = "active";
       summary = String.trim summary;
-      confidence = max 0.0 (min 1.0 confidence);
+      confidence;
       generated_at;
       generated_at_unix;
       fresh_until;

--- a/lib/operator/operator_tool.ml
+++ b/lib/operator/operator_tool.ml
@@ -614,7 +614,17 @@ let judgment_write_schema =
                     ] );
                 ("target_id", `Assoc [ ("type", `String "string") ]);
                 ("summary", `Assoc [ ("type", `String "string") ]);
-                ("confidence", `Assoc [ ("type", `String "number") ]);
+                ( "confidence",
+                  `Assoc
+                    [
+                      ("type", `String "number");
+                      ("minimum", `Float 0.0);
+                      ("maximum", `Float 1.0);
+                      ( "description",
+                        `String
+                          "How sure the judge is, 0.0-1.0. Shown to the \
+                           operator; no code compares it." );
+                    ] );
                 ("fresh_ttl_sec", `Assoc [ ("type", `String "integer") ]);
                 ("keeper_name", `Assoc [ ("type", `String "string") ]);
                 ("model_name", `Assoc [ ("type", `String "string") ]);
@@ -629,7 +639,10 @@ let judgment_write_schema =
                 ("fallback_used", `Assoc [ ("type", `String "boolean") ]);
                 ("disagreement_with_truth", `Assoc [ ("type", `String "boolean") ]);
               ] );
-          ("required", `List [ `String "surface"; `String "target_type"; `String "summary" ]);
+          ("required",
+           `List
+             [ `String "surface"; `String "target_type"; `String "summary";
+               `String "confidence" ]);
         ];
   }
 

--- a/test/test_operator_control_judgment.ml
+++ b/test/test_operator_control_judgment.ml
@@ -300,6 +300,48 @@ let test_confirm_consumes_pending_token_before_delegated_action_fails () =
       in
       Alcotest.(check int) "pending confirm consumed" 0 (List.length pending_confirms))
 
+(* [confidence] used to default to 0.5 when omitted and was clamped into range
+   on the way to disk. Both spellings put a number the judge never stated into
+   the operator digest, next to ["authoritative": true]. No code compares the
+   value, so a fabricated one is indistinguishable from a stated one — the
+   operator is the only reader, and they cannot tell. *)
+let test_operator_judgment_requires_stated_confidence () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Workspace.default_config base_dir in
+      ignore (Workspace.init config ~agent_name:(Some "operator-judge"));
+      let ctx = operator_ctx env sw config "operator-judge" in
+      let write confidence_fields =
+        Operator_control.judgment_write_json ctx
+          (`Assoc
+            ([ ("surface", `String "command.namespace");
+               ("target_type", `String "workspace");
+               ("summary", `String "Judgment without a stated confidence.") ]
+             @ confidence_fields))
+      in
+      List.iter
+        (fun (label, fields) ->
+          match write fields with
+          | Error message ->
+            Alcotest.(check bool)
+              (label ^ " names the field") true
+              (Astring.String.is_infix ~affix:"confidence" message)
+          | Ok _ -> Alcotest.failf "%s must be rejected, got Ok" label)
+        [ ("omitted confidence", []);
+          ("string confidence", [ ("confidence", `String "0.9") ]);
+          ("null confidence", [ ("confidence", `Null) ]);
+          ("negative confidence", [ ("confidence", `Float (-0.1)) ]);
+          ("confidence above one", [ ("confidence", `Float 1.1) ]) ];
+      (* An integer 1 is a number a JSON encoder may emit for 1.0. *)
+      match write [ ("confidence", `Int 1) ] with
+      | Ok _ -> ()
+      | Error message -> Alcotest.failf "integer confidence must be accepted: %s" message)
+
+
 let tests =
   [
     Alcotest.test_case "digest prefers fresh operator judgment" `Quick
@@ -314,6 +356,8 @@ let tests =
       test_operator_judgment_rejects_retired_target_type_aliases;
     Alcotest.test_case "requires numeric timestamps" `Quick
       test_operator_judgment_requires_numeric_timestamps;
+    Alcotest.test_case "requires a stated confidence" `Quick
+      test_operator_judgment_requires_stated_confidence;
     Alcotest.test_case "confirm consumes token before delegated action failure" `Quick
       test_confirm_consumes_pending_token_before_delegated_action_fails;
   ]


### PR DESCRIPTION
## 문제

`operator_judgment.confidence` 는 판정을 내린 주체가 자기 판정에 대해 말하는 숫자다. **비교하는 코드가 0건**이고, `operator_digest_guidance.ml:32` 이 digest JSON 에 복사해 사람이 읽는다 — `"authoritative": true` 바로 옆에서.

그 값이 세 곳에서 조용히 만들어지고 있었다.

| 위치 | 하던 일 |
|---|---|
| `operator_control_action.ml:47` | `get_float args "confidence" 0.5` — 생략/비숫자면 **0.5** |
| `operator_judgment.ml:118` | 저장된 레코드 디코드 시 `_ -> 0.0` |
| `operator_judgment.ml:215` | `max 0.0 (min 1.0 confidence)` — 범위 밖 값을 **조용히 잘라서** 기록 |

읽는 사람이 유일한 소비자인데, 그 사람은 `0.5` 가 "판단자가 반쯤 확신함"인지 "판단자가 아무 말도 안 함"인지 구분할 방법이 없다. `5.0` 을 보낸 호출자의 값이 `1.0` 으로 기록된 것도 알 수 없다.

## 변경

세 곳 모두 typed 거부로 바꾼다.

- **도구 입력** — 생략 / `null` / 비숫자 / 범위 밖을 `Error` 로 돌려주고 필드 이름을 말한다. 기본값 없음.
- **디코더** — `of_yojson` 이 이미 `result` 이고 `required_unix` 라는 같은 모양의 헬퍼를 갖고 있다. 그 관습을 따라 `missing confidence` / `invalid confidence` / `confidence out of range` 를 낸다.
- **클램프 제거** — 입력이 검증되면 `max 0.0 (min 1.0 ...)` 은 도달 불가다.

스키마에 `minimum: 0.0` / `maximum: 1.0` 을 선언하고 `required` 에 넣는다. 지금은 `("confidence", {"type": "number"})` 뿐이라 경계가 어디에도 적혀 있지 않다.

## 레거시 데이터 아님

이 모듈이 쓴 레코드는 `to_yojson` (`:68`) 이 항상 `("confidence", \`Float ...)` 를 낸다. **필드 없는 레코드는 구버전이 아니라 손상된 레코드다.** 마이그레이션 코드는 넣지 않는다.

## 이 축을 없애지 않은 이유

같은 세션에서 `tool_library` 의 `confidence` 는 통째로 걷어냈다 (#27040). 거긴 그 숫자가 **문서가 어느 폴더로 갈지 결정**했고, 소비자(search/read)가 그 구분을 무시하고 있었다 — 아무것도 하지 않는 게이트였다.

여기는 다르다. 이 값은 게이트가 아니라 **사람에게 보여주는 기록**이고, digest 를 읽는 운영자가 실제 소비자다. 판단자가 얼마나 확신했는지는 사람이 결정할 때 쓸 수 있는 정보다. 없앨 게 아니라 **지어내지 않게** 하는 게 맞다.

## 검증

- `dune build @check` EXIT=0
- `test_operator_control_judgment` 8/8 (회귀 테스트 1건 추가: 생략 / 문자열 / null / 음수 / 1.0 초과 거부, 정수 `1` 수용)
- **결함 주입으로 테스트가 실패할 수 있음을 증명**했다:

  ```
  | None -> Ok 0.5  (* 주입 *)
  → [FAIL] requires a stated confidence
    ASSERT omitted confidence must be rejected, got Ok
  복원 후 8/8 통과
  ```

## 관련

- #26973 이 `tool_library` 의 같은 permissive default 패턴을 고쳤다
- #27020 이 선언된 스키마 bound 를 dispatch 전에 강제한다. 이 PR 이 `minimum`/`maximum` 을 선언하므로 그 강제 범위에 들어간다 — 두 PR 은 서로를 막지 않는다
