### PR TITLE
fix(ci): 없는 spec 을 가리켜 죽어 있던 turn_phase TLA 검사 활성화

### DIFF
--- a/scripts/check-variants.sh
+++ b/scripts/check-variants.sh
@@ -203,11 +203,15 @@ fi
 # ── Check 2: turn_phase (OCaml) vs TurnPhaseSet in TLA+ ─────────────────────
 
 echo ""
-echo "=== Check 2: turn_phase (OCaml) vs KeeperRuntimeLifecycle.tla domain ==="
+echo "=== Check 2: turn_phase (OCaml) vs KeeperTurnCycle.tla domain ==="
 
-KR_TYPES_ML="lib/keeper/keeper_registry_types.ml"
 KR_TURN_PHASE_ML="lib/keeper_registry/keeper_registry_types_turn_phase.ml"
-KCL_TLA="specs/keeper-state-machine/KeeperRuntimeLifecycle.tla"
+# Was specs/keeper-state-machine/KeeperRuntimeLifecycle.tla, a path with no file
+# behind it. Both branches below skipped on the missing file and the script
+# still exited 0, so this check reported nothing for as long as the name was
+# wrong. TurnPhaseSet lives here and in KeeperDecisionPipeline.tla with the
+# same seven members.
+KCL_TLA="specs/keeper-state-machine/KeeperTurnCycle.tla"
 
 if [ -f "$KR_TURN_PHASE_ML" ]; then
   # turn_phase constructors (strip "Turn_" prefix, lowercase for TLA+ comparison)
@@ -229,7 +233,8 @@ if [ -f "$KR_TURN_PHASE_ML" ]; then
         echo "      (Add 'TurnPhaseSet == {\"idle\", ...}' to the spec for automated sync)"
       fi
     else
-      echo "INFO: ${KCL_TLA} not found — TLA+ turn_phase check skipped"
+      echo "FAIL: ${KCL_TLA} not found — turn_phase cannot be cross-checked"
+      exit_code=1
     fi
   else
     echo "WARN: could not extract OCaml turn_phase from ${KR_TURN_PHASE_ML}"
@@ -238,33 +243,12 @@ else
   echo "WARN: ${KR_TURN_PHASE_ML} not found — turn_phase check skipped"
 fi
 
-# ── Check 3: runtime_state (OCaml) vs RuntimeSet in TLA+ ────────────────────
-
-echo ""
-echo "=== Check 3: runtime_state (OCaml) vs KeeperRuntimeLifecycle.tla domain ==="
-
-if [ -f "$KR_TYPES_ML" ]; then
-  ocaml_runtime=$(extract_ocaml_type "$KR_TYPES_ML" "runtime_state" \
-    | sed 's/Runtime_//' | tr '[:upper:]' '[:lower:]' | sort -u)
-
-  if [ -n "$ocaml_runtime" ]; then
-    if [ -f "$KCL_TLA" ]; then
-      # Extract from the RuntimeSet == {"..."} definition in the TLA+ spec.
-      # Reads the canonical set literal — no hardcoded values needed here.
-      tla_runtime=$(extract_tla_set_literals "$KCL_TLA" "RuntimeSet")
-      if [ -n "$tla_runtime" ]; then
-        check_pair "OCaml(runtime_state)" "$ocaml_runtime" "TLA+(RuntimeSet)" "$tla_runtime"
-      else
-        echo "INFO: RuntimeSet definition not found in ${KCL_TLA} — runtime_state check skipped"
-        echo "      (Add 'RuntimeSet == {\"idle\", ...}' to the spec for automated sync)"
-      fi
-    else
-      echo "INFO: ${KCL_TLA} not found — TLA+ runtime_state check skipped"
-    fi
-  fi
-else
-  echo "WARN: ${KR_TYPES_ML} not found — runtime_state check skipped"
-fi
+# Check 3 compared an OCaml [runtime_state] variant in
+# lib/keeper/keeper_registry_types.ml against RuntimeSet in the TLA+ spec.
+# No such variant exists: the only runtime_state in the tree is
+# [type runtime_state = string] in keeper_composite_observer, and no OCaml type
+# carries the spec's selecting/trying states. The check named a spec file that
+# does not exist and an OCaml type that does not exist, and printed nothing.
 
 # ── Check 4: PHASE_STYLES coverage (TypeScript) vs KeeperPhase ───────────────
 


### PR DESCRIPTION
## 문제

`check-variants.sh` 는 네 개의 cross-language 검사를 돌리고 **PASS 를 보고하는데, 그중 둘이 아무것도 하지 않았다.**

Check 2 와 3 이 둘 다 이 경로를 읽는다.

```
specs/keeper-state-machine/KeeperRuntimeLifecycle.tla
```

**그 경로에 파일이 있었던 적이 없다.** 두 분기 모두 INFO 한 줄을 찍고 skip 했고, 스크립트는 그대로 exit 0 이었다.

```
=== Check 2: turn_phase (OCaml) vs KeeperRuntimeLifecycle.tla domain ===
INFO: specs/keeper-state-machine/KeeperRuntimeLifecycle.tla not found — TLA+ turn_phase check skipped

=== Check 3: runtime_state (OCaml) vs KeeperRuntimeLifecycle.tla domain ===
                                            ← 출력조차 없다

=== check-variants: PASS ===
```

## Check 2 — 이름만 틀렸다

`TurnPhaseSet` 은 `KeeperTurnCycle.tla` 와 `KeeperDecisionPipeline.tla` 에 같은 일곱 멤버로 정의돼 있다.

| | |
|---|---|
| TLA `TurnPhaseSet` | idle prompting routing executing compacting finalizing exhausted |
| OCaml `turn_phase` | idle prompting routing executing compacting finalizing exhausted |

정확히 일치한다. `KeeperTurnCycle.tla` 를 가리키게 하니 **첫 실제 실행에서 통과한다.**

```
OK: OCaml(turn_phase) <-> TLA+(TurnPhaseSet) in sync (7 variants)
```

## spec 부재는 이제 실패다

INFO skip 이 아니라 `exit_code=1` 이다. **입력이 없을 때 아무 말도 하지 않는 검사는 검사가 아니다** — 이 건이 그렇게 죽어 있었다.

## Check 3 — 제거

OCaml `runtime_state` variant 를 `RuntimeSet` 과 비교하는데, **그 variant 가 없다.**

- 저장소의 유일한 `runtime_state` 는 `keeper_composite_observer` 의 `type runtime_state = string` (별칭)
- spec 의 `selecting` / `trying` 상태를 가진 OCaml 타입이 없다 (`runtime_attempt_fsm`, `attempt_state` 확인)

존재하지 않는 spec 과 존재하지 않는 타입을 비교하며 아무것도 출력하지 않았다. 근거를 주석으로 남기고 삭제한다.

## 가드 확인

양방향으로 깨봤다.

```
# TurnPhaseSet 에 멤버 추가
FAIL: variant drift between OCaml(turn_phase) and TLA+(TurnPhaseSet)
    probe_drift
EXIT=1

# KCL_TLA 를 없는 파일로
FAIL: specs/keeper-state-machine/DoesNotExist.tla not found — turn_phase cannot be cross-checked
EXIT=1
```

둘 다 되돌린 뒤 EXIT=0.

## 검증

- `bash scripts/check-variants.sh` EXIT=0, Check 2 가 실제로 7 variants 를 대조
- Check 1(OCaml phase ↔ TypeScript KeeperPhase), Check 4(PHASE_STYLES) 는 불변

31줄 삭제 / 15줄 추가.

RFC-WAIVED: CI 검사 스크립트가 존재하는 spec 을 가리키게 하고, 입력 부재를 실패로 만들고, 양쪽이 없는 검사를 제거한다. 프로덕션 코드 변경 없음. credential/identity, repo_manager, operator control plane, keeper sandbox, dashboard credential component, hooks, workflow 문서 어느 것도 건드리지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
