### PR TITLE
fix(keeper): generation 경합에서 진 quarantine 명령이 수렴하도록 + board attention 스위트 CI 배선

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1121,6 +1121,21 @@ jobs:
           prompt_targets="@test/runtest-test_keeper_system_prompt_bytes @test/runtest-test_keeper_prompt_metrics @test/runtest-test_keeper_surface_presence_prompt"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${prompt_targets}"
 
+      - name: Run board attention suite
+        id: board_attention_suite
+        if: ${{ always() && steps.build_step.outcome == 'success' }}
+        env:
+          ME_ROOT: /tmp/me
+          CI_TEST_HEARTBEAT_SEC: 15
+          DUNE_JOBS: 1
+        run: |
+          mkdir -p /tmp/me
+          chmod +x scripts/ci-run-tests.sh
+          # test_keeper_board_attention_candidate is left out: it has one unrelated
+          # non-finite-float failure on main, tracked separately.
+          board_attention_targets="@test/runtest-test_keeper_board_attention_worker @test/runtest-test_keeper_board_attention_partition"
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . ${board_attention_targets}"
+
       - name: Run tool blob retention suite
         id: tool_blob_retention_suite
         if: ${{ always() && steps.build_step.outcome == 'success' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1131,9 +1131,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          # test_keeper_board_attention_candidate is left out: it has one unrelated
-          # non-finite-float failure on main, tracked separately.
-          board_attention_targets="@test/runtest-test_keeper_board_attention_worker @test/runtest-test_keeper_board_attention_partition"
+          board_attention_targets="@test/runtest-test_keeper_board_attention_worker @test/runtest-test_keeper_board_attention_partition @test/runtest-test_keeper_board_attention_candidate"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${board_attention_targets}"
 
       - name: Run tool blob retention suite

--- a/lib/keeper/keeper_board_attention_quarantine_command.ml
+++ b/lib/keeper/keeper_board_attention_quarantine_command.ml
@@ -358,13 +358,20 @@ let commit_partition_ready ~base_path command partition =
   | Partition.Blocked _ ->
     (match Partition.requeue_blocked ~base_path ~partition with
      | Error detail -> Error (Partition_state_conflict detail)
-     | Ok (Partition.Cursor_conflict _) ->
+     (* Both conflicts say the same thing — the partition moved under this
+        command between the read and the write. A cursor conflict re-read and
+        decided; a generation conflict did not, so an identical concurrent
+        command whose winner already produced the exact Ready this one wanted
+        was reported as a failure. [reload_same_generation_ready] is what
+        makes that judgement: it converges only on Ready at the direct
+        successor of the observed Blocked generation, and still errors when
+        the partition really did advance to Running, Completed, or Settled. *)
+     | Ok (Partition.Cursor_conflict _)
+     | Ok (Partition.Generation_conflict _) ->
        reload_same_generation_ready
          ~base_path
          ~expected_blocked:partition
          command
-     | Ok (Partition.Generation_conflict detail) ->
-       Error (Partition_state_conflict detail)
      | Ok (Partition.Requeued transition) ->
        confirm_requeue ~base_path transition)
   | Partition.Ready -> confirm_ready_partition ~base_path partition

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -588,9 +588,15 @@ let test_non_finite_complete_request_evidence_is_rejected () =
     }
   in
   let locations =
-    [ ( "signal.updated_at"
+    [ (* signal.updated_at is a typed field, so the record's own finiteness
+         check answers before the JSON canonicalizer walks the request, and it
+         names the field rather than the enclosing object. The untyped
+         locations below keep the canonicalizer's generic message, which is why
+         they pin no detail. *)
+      ( "signal.updated_at"
       , Some
-          "invalid Board attention candidate: candidate.signal contains a non-finite number"
+          "invalid Board attention candidate: candidate.signal.updated_at must \
+           be finite"
       , at_signal )
     ; "post.created_at", None, at_post
     ; "comment.created_at", None, at_comment


### PR DESCRIPTION
`#27009` 의 마지막 실패를 닫고, 스위트를 CI 에 배선한다.

## 결함

동일한 manual quarantine 명령 둘이 경합하면 **진 쪽이 수렴하지 않고 에러를 낸다.**

`commit_partition_ready` (`keeper_board_attention_quarantine_command.ml:356`) 의 형제 arm 이 비대칭이었다:

```ocaml
| Ok (Partition.Cursor_conflict _) -> reload_same_generation_ready ...   (* 재조회 후 판정 *)
| Ok (Partition.Generation_conflict detail) -> Error (Partition_state_conflict detail)
```

둘 다 "읽기와 쓰기 사이에 partition 이 내 밑에서 움직였다" 는 같은 사실을 말한다. cursor 쪽은 다시 읽고 판단하는데 generation 쪽은 보지도 않는다.

그 결과, **이긴 쪽이 이미 진 쪽이 원하던 그 Ready 를 만들어 놓은 경우**에도 실패로 보고된다. `requeue_blocked` 는 stale 스냅샷을 보고 `Observe_generation_conflict "partition already advanced beyond the observed Blocked generation"` 을 돌려주는데 (`keeper_board_attention_partition.ml:1608`), 그 arm 은 `Ready` 를 `Running`/`Completed`/`Settled` 와 한 덩어리로 묶는다. 직후 계승 generation 의 `Ready` 는 정확히 원하던 상태이고 나머지 셋은 진짜로 넘어간 것인데도 구별하지 않는다.

## 수정

두 conflict 를 같은 재조회로 보낸다. 판정은 이미 `reload_same_generation_ready` 안에 있다:

```ocaml
| Partition.Ready
  when Partition.Generation.is_direct_successor
         ~previous:expected_blocked.generation partition.generation ->
  confirm_ready_partition
```

직후 계승자인 `Ready` 에만 수렴하고, `Running`/`Completed`/`Settled` 로 진짜 넘어갔으면 여전히 에러다. cursor 재시도 한도(`requeue_cursor_retry_limit = 2`)도 그대로 적용된다.

## 진단 경로

실패 메시지가 `partition_state_conflict` 라벨뿐이라 어느 분기인지 알 수 없었다. `execution_error_label` 이 `Partition_state_conflict _` 로 detail 을 버린다. 테스트에서 detail 을 임시로 노출시켜 `"partition already advanced beyond the observed Blocked generation"` 을 얻고, 그 문자열로 발화 지점을 특정했다.

## 검증

```
test_keeper_board_attention_worker    33 tests, Test Successful   (main 은 1 failure)
test_keeper_board_attention_partition 13 tests, Test Successful
dune build @test/runtest-...worker @test/runtest-...partition   exit 0
```

**Negative control**: `Generation_conflict` 를 다시 즉시 에러로 되돌리자 실패 1건, 그것이 정확히 27번 `same quarantine command CAS loser converges`. 복구 후 33/33.

## CI 배선

`test_keeper_board_attention_worker` 와 `..._partition` 을 `Run board attention suite` 스텝으로 배선한다. 이 스위트들은 `.github/workflows/` 어디에도 없었고, 그래서 `#25711` (07-26) 이 깨뜨린 5건이 10일간 붉은 채로 남았다.

`test_keeper_board_attention_candidate` 는 **뺐다.** main 에서 별개 실패 1건이 있다:

```
[FAIL] durable candidate 6  non-finite complete request ev...
ASSERT NaN at signal.updated_at error
```

non-finite float 처리 문제로 이 PR 과 무관하다. 초록이 아닌 스위트를 배선하면 main 이 red 가 되므로 별건으로 남긴다.

## 검증하지 않은 것

- 이 경합이 라이브에서 실제로 몇 번 일어나는지. quarantine 수동 명령은 운영자 액션이라 빈도가 낮고, 로그에서 세지 않았다.

Closes #27009 (부분 — candidate 스위트 1건은 별건)
