### PR TITLE
fix(ci): 양쪽 입력을 다 못 읽던 TLA variant 스캔 수정

### DIFF
--- a/scripts/ci/check-tla-variant-sync.sh
+++ b/scripts/ci/check-tla-variant-sync.sh
@@ -27,13 +27,22 @@ fi
 # ── 2. Collect OCaml variant constructors for known lifecycle types ────────────
 echo ""
 echo "=== Scan: OCaml lifecycle variants ==="
+# The last three used to be listed under lib/keeper_registry_types_<x>/ —
+# directories that do not exist. rg skipped them silently (2>/dev/null) and the
+# OCaml side of the comparison was built from two files instead of five.
 variant_sources=(
   lib/keeper_types/keeper_types.ml
   lib/keeper/keeper_registry_types.ml
-  lib/keeper_registry_types_turn_phase/keeper_registry_types_turn_phase.ml
-  lib/keeper_registry_types_decision/keeper_registry_types_decision.ml
-  lib/keeper_registry_types_compaction/keeper_registry_types_compaction.ml
+  lib/keeper_registry/keeper_registry_types_turn_phase.ml
+  lib/keeper_registry/keeper_registry_types_decision.ml
+  lib/keeper_registry/keeper_registry_types_compaction.ml
 )
+for src in "${variant_sources[@]}"; do
+  if [ ! -f "$src" ]; then
+    echo "FAIL: variant source $src not found — the OCaml side of the scan is incomplete"
+    exit 1
+  fi
+done
 lifecycle_variants=$(
   rg '^\s*\|\s+([A-Z][a-zA-Z_0-9]*)' \
     "${variant_sources[@]}" \
@@ -44,9 +53,18 @@ echo "  Found $(echo "$lifecycle_variants" | grep -c . || true) constructors"
 # ── 3. Collect TLA+ variable domain literals (heuristic: strings in PlusCal) ──
 echo ""
 echo "=== Scan: TLA+ lifecycle domain literals ==="
+# ripgrep has no built-in "tla" file type: --type tla exits with
+# "unrecognized file type", 2>/dev/null hid the message and || true turned the
+# failure into an empty set. This scan reported "Found 0 PascalCase literals"
+# on every run since it was written, so section 5 below -- guarded on this
+# being non-empty -- never compared anything. A glob reads the same files.
 tla_domains=$(
-  rg '"([A-Z][a-zA-Z_0-9]*)"' specs/ --type tla -o -r '$1' 2>/dev/null | sort -u || true
+  rg '"([A-Z][a-zA-Z_0-9]*)"' specs/ --glob '*.tla' --no-filename -o -r '$1' 2>/dev/null | sort -u || true
 )
+if [ -z "$tla_domains" ]; then
+  echo "FAIL: no PascalCase literals found under specs/ — the scan is not reading the specs"
+  exit 1
+fi
 echo "  Found $(echo "$tla_domains" | grep -c . || true) PascalCase literals"
 
 # ── 4. Collect event type strings from JSON schema or event modules ────────────
@@ -59,24 +77,25 @@ if [ -n "$event_types" ]; then
   echo "  Found $(echo "$event_types" | grep -c . || true) event type strings"
 fi
 
-# ── 5. TLA+ vs OCaml diff (heuristic: PascalCase TLA+ literal vs constructor) ─
-if [ -n "$tla_domains" ] && [ -n "$lifecycle_variants" ]; then
-  only_in_tla=$(comm -23 <(echo "$tla_domains") <(echo "$lifecycle_variants") | grep -v '^$' || true)
-  if [ -n "$only_in_tla" ]; then
-    echo ""
-    echo "WARN: TLA+ PascalCase literals not found as OCaml constructors (drift risk):"
-    echo "$only_in_tla" | sed 's/^/  /'
-    echo "  (This is a heuristic match — PascalCase TLA+ may map to snake_case OCaml.)"
-    echo "  (Run 'make check-variants' for the authoritative per-type check.)"
-  fi
-fi
+# Section 5 used to diff the two sets above and WARN on PascalCase literals
+# with no matching OCaml constructor. It never ran -- the TLA+ side was empty
+# because of the --type tla bug -- and it cannot be turned on as written: the
+# OCaml side samples five keeper-registry files while the TLA+ side spans all
+# 42 specs, so constructors that live elsewhere (Masc_domain's Claimed,
+# Cancelled, ...) read as drift. All 70 literals report. Its own text already
+# deferred to check-variants.sh for "the authoritative per-type check", and
+# that script does the comparison properly, per type, with the spec named.
+# The counts above stay: they are now true, which is the point of this change.
 
 # ── 6. Flag OCaml files without corresponding TLA+ spec ───────────────────────
 for variant_file in lib/keeper_types/keeper_types.ml lib/keeper/keeper_types_profile.ml; do
   if [ -f "$variant_file" ]; then
     base=$(basename "$variant_file" .ml)
-    if [ ! -f "specs/${base}.tla" ]; then
-      echo "INFO: $variant_file has no matching specs/${base}.tla (not required, but note for 3-way sync)"
+    # Specs live in subdirectories (specs/keeper-state-machine/..., specs/auth/...),
+    # so the flat specs/<base>.tla path this used to test could never exist and
+    # the INFO fired regardless of what is on disk.
+    if [ -z "$(find specs -name "${base}.tla" -print -quit 2>/dev/null)" ]; then
+      echo "INFO: $variant_file has no matching ${base}.tla under specs/ (not required, but note for 3-way sync)"
     fi
   fi
 done


### PR DESCRIPTION
## 문제

`check-tla-variant-sync.sh` 는 매 실행 두 개의 수치를 찍는데 **둘 다 틀렸다.**

### `Found 0 PascalCase literals`

```bash
rg '"([A-Z][a-zA-Z_0-9]*)"' specs/ --type tla -o -r '$1' 2>/dev/null | sort -u || true
```

```
$ rg ... --type tla
rg: unrecognized file type: tla
```

ripgrep 에 `tla` 파일 타입이 없다. `2>/dev/null` 이 메시지를 숨기고 `|| true` 가 실패를 빈 집합으로 바꿨다. **이 스캔은 spec 을 한 번도 읽은 적이 없다.** glob 으로 바꾸면 70개가 나온다.

### `Found 39 constructors`

OCaml 소스 다섯 중 셋이 존재하지 않는 디렉토리를 가리켰다.

```
없음: lib/keeper_registry_types_turn_phase/keeper_registry_types_turn_phase.ml
없음: lib/keeper_registry_types_decision/keeper_registry_types_decision.ml
없음: lib/keeper_registry_types_compaction/keeper_registry_types_compaction.ml
있음: lib/keeper_registry/keeper_registry_types_{turn_phase,decision,compaction}.ml
```

`rg` 가 없는 경로를 조용히 건너뛰어 **다섯 중 둘만** 스캔했다. 경로를 고치면 110개다.

## 근본 수정

둘 다 이제 **빈 결과가 아니라 실패**다.

```
FAIL: no PascalCase literals found under specs/ — the scan is not reading the specs
FAIL: variant source lib/nope/missing.ml not found — the OCaml side of the scan is incomplete
```

입력을 못 읽어서 0 을 보고하는 스캔은 드리프트에 대해 아무 말도 하지 않는다. 이 건이 그렇게 깨진 채로 남아 있었다.

## 섹션 5 는 켜지 않고 제거한다

두 집합을 diff 해서 WARN 하는 부분이다. 한 번도 실행된 적이 없고, **지금 켜면 70개 전부가 드리프트로 보고된다** — OCaml 표본은 keeper 레지스트리 5파일이고 TLA+ 쪽은 42개 spec 전체라, `Masc_domain` 의 `Claimed` / `Cancelled` 처럼 표본 밖에 사는 생성자가 전부 미매칭으로 잡힌다.

스크립트 자신의 출력이 이미 이렇게 말한다.

> (This is a heuristic match — PascalCase TLA+ may map to snake_case OCaml.)
> (Run 'make check-variants' for the authoritative per-type check.)

그 authoritative 검사는 **#27079 에서 실제로 동작하게 만들었다** (없는 spec 을 가리켜 죽어 있던 turn_phase 검사 활성화). 그래서 이 휴리스틱 diff 는 70줄 노이즈로 켜는 대신 제거하고, 근거를 주석에 남긴다.

## 섹션 6

`specs/<base>.tla` 평면 경로를 검사했는데 spec 은 `specs/keeper-state-machine/`, `specs/auth/` 등 하위에 있다. 디스크 상태와 무관하게 INFO 가 떴다. `find specs -name` 으로 바꿨다.

## 검증

```
Found 110 constructors      (이전 39)
Found 70 PascalCase literals (이전 0)
EXIT=0
```

소스를 없는 경로로 바꾸면 `EXIT=1` 로 실패한다. 되돌리면 0.

RFC-WAIVED: CI 스캔이 입력을 실제로 읽게 하고, 못 읽으면 실패하게 하고, 켤 수 없는 휴리스틱 비교를 제거한다. 프로덕션 코드 변경 없음. credential/identity, repo_manager, operator control plane, keeper sandbox, dashboard credential component, hooks, workflow 문서 어느 것도 건드리지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
