### PR TITLE
fix(ci): TOML 문법 검사가 15개 중 6개만 읽던 문제

### DIFF
--- a/scripts/check-toml-syntax.sh
+++ b/scripts/check-toml-syntax.sh
@@ -5,6 +5,7 @@ echo "Checking TOML syntax..."
 python3 -c '
 import sys
 import glob
+import os
 
 # Try importing tomllib (Python 3.11+) or tomli (older versions)
 try:
@@ -16,9 +17,22 @@ except ImportError:
         print("Error: Python 3.11+ (tomllib) or the tomli package is required for TOML validation.")
         sys.exit(1)
 
-files = glob.glob("config/**/*.toml", recursive=True)
+# Was config/**/*.toml, which left nine files unchecked -- including the four
+# keeper profiles under presets/classic/keepers/ that carry the same [keeper]
+# tables as config/keepers/ and are meant to be copied there.
+SKIP = ("_build/", ".git/", ".worktrees/", ".claude/", "node_modules/",
+        "viewer/target/", "archive/")
+files = [p for p in glob.glob("**/*.toml", recursive=True)
+         if not p.startswith(SKIP)]
+
+# A glob that matches nothing used to print "All 0 TOML files parsed
+# successfully" and exit 0, so a moved directory would have read as a pass.
+if not files:
+    print("Error: no TOML files found — the syntax check is not reading the repository.")
+    sys.exit(1)
+
 has_error = False
-for f in files:
+for f in sorted(files):
     try:
         with open(f, "rb") as file:
             tomllib.load(file)


### PR DESCRIPTION
## 문제

`check-toml-syntax.sh` 가 `config/**/*.toml` 만 본다. 저장소의 TOML 15개 중 **6개**다.

빠진 9개 중 넷이 keeper 프로필이다.

```
presets/classic/keepers/backend.toml
presets/classic/keepers/frontend.toml
presets/classic/keepers/qa.toml
presets/classic/keepers/tech_lead.toml
```

`config/keepers/*.toml` 와 **같은 모양**이다.

```toml
[keeper]
autoboot_enabled = true
persona_name = "backend"
```

`presets/README.md § classic` 의 one-touch preset — `config/keepers/` 로 복사해 쓰라고 존재한다. 즉 여기 문법 오류가 나면 **검사를 통과해서 배포되고, 누군가 preset 을 적용할 때 처음 드러난다.**

나머지는 `railway.toml`, release-evidence 픽스처 2개, viewer 의 `Cargo.toml` / `Trunk.toml` 이다.

## 빈 결과가 통과였다

```python
files = glob.glob("config/**/*.toml", recursive=True)
...
print(f"All {len(files)} TOML files parsed successfully.")
```

디렉토리가 옮겨지거나 이름이 바뀌면 `files` 가 비고 **"All 0 TOML files parsed successfully"** 를 찍고 exit 0 이다.

이 저장소에서 같은 형태로 죽어 있던 CI 검사를 이번 주에 둘 고쳤다 — `--type tla` 로 spec 을 한 번도 못 읽던 스캔(#27082), 없는 spec 을 가리켜 skip 하던 turn_phase 검사(#27079). **입력을 못 읽고 0 을 보고하는 검사는 검사가 아니다.**

## 수정

- glob 을 저장소 전체로 넓히고 빌드/벤더 디렉토리만 제외 → **6개에서 15개로**
- 매칭이 0 이면 실패

**오늘 15개 전부 파싱된다.** 새로 깨지는 것은 없다.

## 두 실패 경로 확인

```
# preset 에 문법 오류
Syntax error in presets/classic/keepers/backend.toml: Illegal character '\n' (at line 22, column 29)
EXIT=1

# glob 이 아무것도 못 찾을 때
Error: no TOML files found — the syntax check is not reading the repository.
EXIT=1
```

둘 다 되돌린 뒤 EXIT=0.

RFC-WAIVED: CI 검사 범위를 실제 파일 집합으로 넓히고 빈 결과를 실패로 만든다. 프로덕션 코드 변경 없음. credential/identity, repo_manager, operator control plane, keeper sandbox, dashboard credential component, hooks, workflow 문서 어느 것도 건드리지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
