### PR TITLE
fix(perf): remove repeated Keeper turn projection work

### DIFF
--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -364,6 +364,8 @@ describe('setupServerPushReaction reconnect hydration', () => {
 
   it('refreshes only the scoped Keeper status on turn complete', async () => {
     const { sseStore } = await loadSseStore()
+    const refreshKeeperTurn = vi.fn<(keeperName: string) => void>()
+    sseStore.registerKeeperTurnRefresh(refreshKeeperTurn)
     route.value = { tab: 'keepers', params: { keeper: 'qa-king' }, postId: null }
 
     sseStore.routeServerPushEvent({
@@ -378,6 +380,8 @@ describe('setupServerPushReaction reconnect hydration', () => {
     // snapshot here is both premature and expensive. The registered
     // keeper-scoped status reader remains the authoritative immediate refresh.
     expect(refreshExecution).not.toHaveBeenCalled()
+    expect(refreshKeeperTurn).toHaveBeenCalledTimes(1)
+    expect(refreshKeeperTurn).toHaveBeenCalledWith('qa-king')
   })
 
   it('normalizes MASC broadcast aliases before route-scoped execution refresh', async () => {

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -362,7 +362,7 @@ describe('setupServerPushReaction reconnect hydration', () => {
 
   })
 
-  it('forces execution refresh on keeper turn complete for live roster status', async () => {
+  it('refreshes only the scoped Keeper status on turn complete', async () => {
     const { sseStore } = await loadSseStore()
     route.value = { tab: 'keepers', params: { keeper: 'qa-king' }, postId: null }
 
@@ -374,8 +374,10 @@ describe('setupServerPushReaction reconnect hydration', () => {
     vi.advanceTimersByTime(1_000)
     await flushAsyncWork()
 
-    expect(refreshExecution).toHaveBeenCalledTimes(1)
-    expect(refreshExecution).toHaveBeenCalledWith({ force: true })
+    // The SDK hook precedes durable commit, so rebuilding the global execution
+    // snapshot here is both premature and expensive. The registered
+    // keeper-scoped status reader remains the authoritative immediate refresh.
+    expect(refreshExecution).not.toHaveBeenCalled()
   })
 
   it('normalizes MASC broadcast aliases before route-scoped execution refresh', async () => {

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -216,7 +216,10 @@ const SIMPLE_ROUTES: Record<string, SimpleRoute> = {
   keeper_compaction:    { target: 'execution', force: true },
   keeper_guardrail:     { target: 'execution', force: true },
   keeper_phase_changed: { target: 'execution', force: true },
-  keeper_turn_complete: { target: 'execution', force: true },
+  // A turn-complete hook precedes the durable TurnRecord commit and does not
+  // mutate the execution cache. The selected Keeper is refreshed through the
+  // scoped status reader in [handleKeeperLifecycle]; the proactive canonical
+  // execution snapshot updates the roster without a per-turn global rebuild.
   // Board content — emitted by lib/mcp_tool_runtime_board.ml
   board_post:          { target: 'board' },
   'masc/board_post':    { target: 'board' },

--- a/lib/keeper/keeper_agent_prompt_metrics.ml
+++ b/lib/keeper/keeper_agent_prompt_metrics.ml
@@ -82,8 +82,7 @@ let provider_content_messages
 let empty_prompt_segment_metrics =
   { bytes = 0; fingerprint = None }
 
-let prompt_segment_metrics_of_text (text : string) : prompt_segment_metrics =
-  let text = Inference_utils.sanitize_text_utf8 text in
+let prompt_segment_metrics_of_sanitized_text (text : string) : prompt_segment_metrics =
   {
     bytes = String.length text;
     fingerprint =
@@ -92,14 +91,28 @@ let prompt_segment_metrics_of_text (text : string) : prompt_segment_metrics =
        else Some Digestif.SHA256.(digest_string text |> to_hex));
   }
 
-let build_prompt_metrics ~(system_prompt : string) ~(dynamic_context : string)
+let prompt_segment_metrics_of_text (text : string) : prompt_segment_metrics =
+  prompt_segment_metrics_of_sanitized_text
+    (Inference_utils.sanitize_text_utf8 text)
+
+let build_prompt_metrics_with_sanitizer ~sanitize
+    ~(system_prompt : string) ~(dynamic_context : string)
     ~(user_message : string) : prompt_metrics =
-  let system_prompt = Inference_utils.sanitize_text_utf8 system_prompt in
-  let dynamic_context = Inference_utils.sanitize_text_utf8 dynamic_context in
-  let user_message = Inference_utils.sanitize_text_utf8 user_message in
-  let system_prompt_metrics = prompt_segment_metrics_of_text system_prompt in
-  let dynamic_context_metrics = prompt_segment_metrics_of_text dynamic_context in
-  let user_message_metrics = prompt_segment_metrics_of_text user_message in
+  let system_prompt = sanitize system_prompt in
+  let dynamic_context = sanitize dynamic_context in
+  let user_message = sanitize user_message in
+  (* These values were sanitized above for the fingerprint input. Reusing that
+     exact text avoids scanning every prompt segment a second time merely to
+     compute byte lengths and per-segment digests. *)
+  let system_prompt_metrics =
+    prompt_segment_metrics_of_sanitized_text system_prompt
+  in
+  let dynamic_context_metrics =
+    prompt_segment_metrics_of_sanitized_text dynamic_context
+  in
+  let user_message_metrics =
+    prompt_segment_metrics_of_sanitized_text user_message
+  in
   let fingerprint_input =
     `Assoc
       [
@@ -120,6 +133,17 @@ let build_prompt_metrics ~(system_prompt : string) ~(dynamic_context : string)
     dynamic_context_segment = dynamic_context_metrics;
     user_message_segment = user_message_metrics;
   }
+
+let build_prompt_metrics ~system_prompt ~dynamic_context ~user_message =
+  build_prompt_metrics_with_sanitizer
+    ~sanitize:Inference_utils.sanitize_text_utf8
+    ~system_prompt
+    ~dynamic_context
+    ~user_message
+
+module For_testing = struct
+  let build_prompt_metrics_with_sanitizer = build_prompt_metrics_with_sanitizer
+end
 
 let prompt_segment_metrics_to_json (segment : prompt_segment_metrics) :
     Yojson.Safe.t =

--- a/lib/keeper/keeper_agent_prompt_metrics.mli
+++ b/lib/keeper/keeper_agent_prompt_metrics.mli
@@ -56,6 +56,15 @@ val build_prompt_metrics :
   user_message:string ->
   prompt_metrics
 
+module For_testing : sig
+  val build_prompt_metrics_with_sanitizer :
+    sanitize:(string -> string) ->
+    system_prompt:string ->
+    dynamic_context:string ->
+    user_message:string ->
+    prompt_metrics
+end
+
 val prompt_segment_metrics_to_json :
   prompt_segment_metrics -> Yojson.Safe.t
 

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -860,6 +860,7 @@ let run_turn
          let checkpoint_sidecar =
                 ctx_work.checkpoint.Agent_sdk.Checkpoint.working_context
          in
+         let last_persisted_checkpoint_ref = ref None in
          let checkpoint_sink (snapshot : Agent_sdk.Agent.checkpoint_snapshot) =
                 Option.iter (fun observe -> observe snapshot.stage) on_checkpoint_stage;
                 (* OAS's per-turn pipeline builds checkpoints with an empty
@@ -883,7 +884,10 @@ let run_turn
                     ~session_dir:session.session_dir
                     checkpoint
                 with
-                | Ok _ -> Ok ()
+                | Ok (Keeper_checkpoint_store.Saved _) ->
+                  last_persisted_checkpoint_ref := Some checkpoint;
+                  Ok ()
+                | Ok (Keeper_checkpoint_store.Stale_noop _) -> Ok ()
                 | Error _ as error -> error
          in
          let call_run_named ?raw_trace ~initial_messages () =
@@ -1081,7 +1085,10 @@ let run_turn
                              ~session ~append_manifest ~model
                              ~acc
                              ~actual_keeper_tool_names
-                             ~result ~final_oas_turn_ordinal
+                             ~result
+                             ~last_persisted_checkpoint:
+                               !last_persisted_checkpoint_ref
+                             ~final_oas_turn_ordinal
                              ~checkpoint_persistence_error
                              ~post_turn_t0 ~runtime_id_string
                              ~history_messages

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -109,7 +109,12 @@ let canonical_success_replay_checkpoint
            ; working_context = None
            }
          else
-           let base_messages = history_messages @ current_suffix in
+           (* [split] already proved that [checkpoint.messages] is exactly the
+              validated history prefix followed by [current_suffix]. Keep that
+              immutable list when no replay edit is required: rebuilding the
+              prefix here hid that the pipeline checkpoint had already been
+              durably persisted. *)
+           let base_messages = checkpoint.messages in
            let messages =
              if
                List.exists
@@ -206,6 +211,45 @@ let checkpoint_for_replay_persistence
       checkpoint
 ;;
 
+(* OAS constructs the mutation-boundary checkpoint and then installs the same
+   immutable message values on the agent state. The list spines are rebuilt, so
+   list physical equality is too strict; comparing each message record by
+   identity proves the state boundary without hashing or scanning large text and
+   tool-result bodies. *)
+let rec messages_share_values_by_identity left right =
+  match left, right with
+  | [], [] -> true
+  | left_message :: left_rest, right_message :: right_rest
+    when left_message == right_message ->
+    messages_share_values_by_identity left_rest right_rest
+  | _ -> false
+;;
+
+let select_finalization_checkpoint
+    ~(last_persisted_checkpoint : Agent_sdk.Checkpoint.t option)
+    (result_checkpoint : Agent_sdk.Checkpoint.t) =
+  match last_persisted_checkpoint with
+  | Some persisted
+    when Int.equal persisted.turn_count result_checkpoint.turn_count
+         && messages_share_values_by_identity
+              persisted.messages
+              result_checkpoint.messages ->
+    persisted, true
+  | Some _ | None -> result_checkpoint, false
+;;
+
+let finalization_checkpoint_already_persisted
+    ~source_already_persisted
+    ~(source : Agent_sdk.Checkpoint.t)
+    ~(patched : Agent_sdk.Checkpoint.t)
+    ~replay_suffix_pruned =
+  source_already_persisted
+  && Option.is_none replay_suffix_pruned
+  && String.equal source.session_id patched.session_id
+  && source.messages == patched.messages
+  && source.working_context == patched.working_context
+;;
+
 module For_testing = struct
   let replay_suffix_prune_reason_to_string =
     replay_suffix_prune_reason_to_string
@@ -213,6 +257,10 @@ module For_testing = struct
   let checkpoint_for_replay_persistence = checkpoint_for_replay_persistence
   let replay_response_text_for_capture = replay_response_text_for_capture
   let replay_response_text_for_persistence = replay_response_text_for_persistence
+  let select_finalization_checkpoint = select_finalization_checkpoint
+
+  let finalization_checkpoint_already_persisted =
+    finalization_checkpoint_already_persisted
 
   let wire_capture_response_suppression_reasons =
     wire_capture_response_suppression_reasons
@@ -222,7 +270,6 @@ module For_testing = struct
 
   let emit_wire_capture_response_suppressed_metrics =
     emit_wire_capture_response_suppressed_metrics
-
 end
 
 let finalize
@@ -237,6 +284,7 @@ let finalize
     ~(acc : Keeper_run_tools.hook_accumulator)
     ~actual_keeper_tool_names
     ~(result : Runtime_agent.run_result)
+    ~last_persisted_checkpoint
     ~final_oas_turn_ordinal
     ~checkpoint_persistence_error
     ~post_turn_t0
@@ -298,7 +346,12 @@ let finalize
    | _ -> ());
   let saved_checkpoint_result =
     match result.checkpoint with
-    | Some checkpoint ->
+    | Some result_checkpoint ->
+      let checkpoint, source_already_persisted =
+        select_finalization_checkpoint
+          ~last_persisted_checkpoint
+          result_checkpoint
+      in
       let checkpoint_for_save_result =
         checkpoint_for_replay_persistence
           ~history_messages
@@ -315,12 +368,25 @@ let finalize
               ~keeper_name:meta.name
               ~detail)
        | Ok (patched, replay_suffix_pruned) ->
-         (match
-            Keeper_checkpoint_store.save_oas_classified
-              ~session_dir:session.session_dir
-              patched
-          with
-       | Ok (Keeper_checkpoint_store.Saved _) ->
+         let already_persisted =
+           finalization_checkpoint_already_persisted
+             ~source_already_persisted
+             ~source:checkpoint
+             ~patched
+             ~replay_suffix_pruned
+         in
+         let save_outcome =
+           if already_persisted
+           then Ok `Reused
+           else
+             Keeper_checkpoint_store.save_oas_classified
+               ~session_dir:session.session_dir
+               patched
+             |> Result.map (fun outcome -> `Written outcome)
+         in
+         (match save_outcome with
+       | Ok `Reused
+       | Ok (`Written (Keeper_checkpoint_store.Saved _)) ->
          append_manifest ~site:"checkpoint_saved"
            ~keeper_turn_id:manifest_keeper_turn_id
            ~oas_turn_count:result.turns
@@ -341,6 +407,7 @@ let finalize
                    | Some reason ->
                      `String (replay_suffix_prune_reason_to_string reason)
                    | None -> `Null) );
+                ("pipeline_checkpoint_reused", `Bool already_persisted);
                 ( "completion_contract_result"
                 , `String
                     (Keeper_execution_receipt
@@ -349,8 +416,8 @@ let finalize
                ])
            Keeper_runtime_manifest.Checkpoint_saved;
          Ok (Some patched)
-       | Ok (Keeper_checkpoint_store.Stale_noop
-                { incoming_turn_count; known_turn_count }) ->
+       | Ok (`Written (Keeper_checkpoint_store.Stale_noop
+                { incoming_turn_count; known_turn_count })) ->
          Log.Keeper.warn ~keeper_name:meta.name
            "runtime=%s OAS checkpoint stale no-op: incoming turn_count=%d, last saved=%d"
            (Keeper_meta_contract.runtime_id_of_meta meta)

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -280,14 +280,36 @@ let patch_checkpoint_last_assistant
       | Agent_sdk.Types.Text _ :: rest -> patch_content replaced acc rest
       | block :: rest -> patch_content replaced (block :: acc) rest
     in
-    Agent_sdk.Types.make_message
-      ~role:Agent_sdk.Types.Assistant
-      (patch_content false [] msg.Agent_sdk.Types.content)
+    let content = patch_content false [] msg.Agent_sdk.Types.content in
+    let rec content_unchanged left right =
+      match left, right with
+      | [], [] -> true
+      | Agent_sdk.Types.Text left :: left_rest,
+        Agent_sdk.Types.Text right :: right_rest
+        when String.equal left right ->
+        content_unchanged left_rest right_rest
+      | left_block :: left_rest, right_block :: right_rest
+        when left_block == right_block ->
+        content_unchanged left_rest right_rest
+      | _ -> false
+    in
+    if content_unchanged content msg.Agent_sdk.Types.content
+       && Option.is_none msg.name
+       && Option.is_none msg.tool_call_id
+       && msg.metadata = []
+    then msg
+    else
+      Agent_sdk.Types.make_message
+        ~role:Agent_sdk.Types.Assistant
+        content
   in
   let rec patch_last_assistant suffix_rev = function
     | [] -> cp.messages
     | msg :: older_rev when msg.Agent_sdk.Types.role = Agent_sdk.Types.Assistant ->
-        List.rev_append older_rev (patch_assistant_message msg :: suffix_rev)
+        let patched = patch_assistant_message msg in
+        if patched == msg
+        then cp.messages
+        else List.rev_append older_rev (patched :: suffix_rev)
     | msg :: older_rev -> patch_last_assistant (msg :: suffix_rev) older_rev
   in
   let messages =

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -263,18 +263,59 @@ let measure_message_bytes (message : Agent_sdk.Types.message) =
     (Yojson.Safe.to_string (Keeper_context_core.message_to_json message))
 ;;
 
+module Message_identity = struct
+  type t = Agent_sdk.Types.message
+
+  let equal left right = left == right
+
+  let mix accumulator value = ((accumulator * 65599) lxor value) land max_int
+
+  (* A constant-work string hint keeps the hash independent of tool-result body
+     size. Equality remains physical, so collisions only share a bucket. *)
+  let string_hint value =
+    let length = String.length value in
+    if length = 0
+    then 0
+    else
+      let sample index = Char.code (String.unsafe_get value index) in
+      mix
+        (mix (mix (mix length (sample 0)) (sample (length / 3)))
+           (sample ((2 * length) / 3)))
+        (sample (length - 1))
+  ;;
+
+  let optional_string_hint = function
+    | None -> 0
+    | Some value -> string_hint value
+  ;;
+
+  let role_hint = function
+    | Agent_sdk.Types.System -> 1
+    | Agent_sdk.Types.User -> 2
+    | Agent_sdk.Types.Assistant -> 3
+    | Agent_sdk.Types.Tool -> 4
+  ;;
+
+  let hash (message : t) =
+    mix
+      (mix (role_hint message.role) (optional_string_hint message.name))
+      (optional_string_hint message.tool_call_id)
+  ;;
+end
+
+module Message_measurement_cache = Hashtbl.Make (Message_identity)
+
 let memoize_message_measurement measure =
-  (* The projection is small (normally bounded by the tail-window atoms), and
-     physical comparison is constant-time. A polymorphic hash table would
-     still hash the contents of large strings inside each message, recreating
-     the very scan this cache is meant to eliminate. *)
-  let cache = ref [] in
+  (* A polymorphic hash would scan large strings inside the message. This
+     table hashes only constant-size identity hints, then confirms hits with
+     physical equality. *)
+  let cache = Message_measurement_cache.create 128 in
   fun message ->
-    match List.find_opt (fun (cached, _) -> cached == message) !cache with
-    | Some (_, bytes) -> bytes
+    match Message_measurement_cache.find_opt cache message with
+    | Some bytes -> bytes
     | None ->
       let bytes = measure message in
-      cache := (message, bytes) :: !cache;
+      Message_measurement_cache.add cache message bytes;
       bytes
 ;;
 

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -263,28 +263,18 @@ let measure_message_bytes (message : Agent_sdk.Types.message) =
     (Yojson.Safe.to_string (Keeper_context_core.message_to_json message))
 ;;
 
-module Message_identity = struct
-  type t = Agent_sdk.Types.message
-
-  let equal left right = left == right
-
-  (* Messages are immutable. [Hashtbl.hash] is bounded, so this avoids a full
-     content traversal while preserving the hash/equality contract for the
-     same record identity. Structural collisions are harmless because [equal]
-     remains physical. *)
-  let hash = Hashtbl.hash
-end
-
-module Message_measurement_cache = Hashtbl.Make (Message_identity)
-
 let memoize_message_measurement measure =
-  let cache = Message_measurement_cache.create 128 in
+  (* The projection is small (normally bounded by the tail-window atoms), and
+     physical comparison is constant-time. A polymorphic hash table would
+     still hash the contents of large strings inside each message, recreating
+     the very scan this cache is meant to eliminate. *)
+  let cache = ref [] in
   fun message ->
-    match Message_measurement_cache.find_opt cache message with
-    | Some bytes -> bytes
+    match List.find_opt (fun (cached, _) -> cached == message) !cache with
+    | Some (_, bytes) -> bytes
     | None ->
       let bytes = measure message in
-      Message_measurement_cache.add cache message bytes;
+      cache := (message, bytes) :: !cache;
       bytes
 ;;
 

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -319,6 +319,14 @@ let memoize_message_measurement measure =
       bytes
 ;;
 
+(* Model-input projection walks the durable message history and encodes every
+   candidate it measures. Live Keeper checkpoints carry tens of thousands of
+   messages, so doing that work on the main Eio domain starves unrelated HTTP
+   fibers even though no provider call has started yet. The server installs a
+   shared CPU-weighted [Domain_pool]; non-Eio/unit callers retain the typed
+   inline fallback owned by [Domain_pool_ref]. *)
+let offload_model_input_cpu f = Domain_pool_ref.submit_cpu_or_inline f
+
 let declared_request_reserve_bytes ~capacity_bytes ~system_prompt ~tools =
   let tool_schema_bytes =
     List.fold_left
@@ -348,73 +356,92 @@ let budgeted_model_input_projection (ctx : try_provider_ctx)
   : Agent_sdk.Agent.model_input_projection
   =
   let reserved_bytes =
-    declared_request_reserve_bytes
-      ~capacity_bytes:ctx.max_request_body_bytes
-      ~system_prompt:ctx.system_prompt
-      ~tools:ctx.tools
+    offload_model_input_cpu (fun () ->
+      declared_request_reserve_bytes
+        ~capacity_bytes:ctx.max_request_body_bytes
+        ~system_prompt:ctx.system_prompt
+        ~tools:ctx.tools)
   in
   fun messages ->
-    (* The raw cut and demotion plan both measure immutable message records.
-       Cache only for this projection call so repeated candidates are encoded
-       once without retaining a long-lived Keeper's historical message graph. *)
-    let measure_message_bytes =
-      memoize_message_measurement measure_message_bytes
-    in
-    let raw_cut candidate =
-      Runtime_model_input_tail_window.project_with_drop
-        ~measure_message_bytes
-        ~capacity_bytes:ctx.max_request_body_bytes
-        ~reserved_bytes
-        candidate
-    in
-    let cut candidate =
-      Result.map
-        (fun projection -> projection.Runtime_model_input_tail_window.messages)
-        (raw_cut candidate)
-    in
-    (* RFC-0363: the unmodified history chooses the authoritative cut first.
-       Demotion may rewrite only atoms that cut already omitted, so appending a
-       turn cannot move the rewrite boundary unless the raw cut itself moves.
-       Markers can then buy some of those omitted atoms back without causing a
-       per-turn prompt-cache miss. *)
-    let windowed =
-      match raw_cut messages with
-      | Error error ->
-        Error (Runtime_model_input_tail_window.budget_error_to_string error)
-      | Ok raw_projection ->
-        let planned =
-          if String.equal ctx.base_path "" || raw_projection.dropped_atoms = 0
-          then { Keeper_model_input_demotion.messages; pending = [] }
-          else
-            Keeper_model_input_demotion.plan
-              ~measure_message_bytes
-              ~demote_before:raw_projection.dropped_atoms
-              messages
+    let planned_and_windowed =
+      offload_model_input_cpu (fun () ->
+        (* The raw cut and demotion plan both measure immutable message records.
+           Cache only for this worker-domain job so repeated candidates are
+           encoded once without retaining a long-lived Keeper's history. *)
+        let measure_message_bytes =
+          memoize_message_measurement measure_message_bytes
         in
+        let raw_cut candidate =
+          Runtime_model_input_tail_window.project_with_drop
+            ~measure_message_bytes
+            ~capacity_bytes:ctx.max_request_body_bytes
+            ~reserved_bytes
+            candidate
+        in
+        let cut candidate =
+          Result.map
+            (fun projection ->
+               projection.Runtime_model_input_tail_window.messages)
+            (raw_cut candidate)
+        in
+        (* RFC-0363: the unmodified history chooses the authoritative cut first.
+           Demotion rewrites only atoms omitted by that cut, so appending a turn
+           cannot move the rewrite boundary unless the raw cut itself moves. *)
+        match raw_cut messages with
+        | Error error ->
+          Error (Runtime_model_input_tail_window.budget_error_to_string error)
+        | Ok raw_projection ->
+          let planned =
+            if String.equal ctx.base_path "" || raw_projection.dropped_atoms = 0
+            then { Keeper_model_input_demotion.messages; pending = [] }
+            else
+              Keeper_model_input_demotion.plan
+                ~measure_message_bytes
+                ~demote_before:raw_projection.dropped_atoms
+                messages
+          in
+          (match planned.Keeper_model_input_demotion.pending with
+           | [] -> Ok (planned, raw_projection.messages)
+           | _ ->
+             (match cut planned.Keeper_model_input_demotion.messages with
+              | Error error ->
+                Error
+                  (Runtime_model_input_tail_window.budget_error_to_string error)
+              | Ok windowed -> Ok (planned, windowed))))
+    in
+    let windowed =
+      match planned_and_windowed with
+      | Error _ as error -> error
+      | Ok (planned, windowed) ->
         (match planned.Keeper_model_input_demotion.pending with
-         | [] -> Ok raw_projection.messages
+         | [] -> Ok windowed
          | pending ->
-           (match cut planned.Keeper_model_input_demotion.messages with
-            | Error error ->
-              Error (Runtime_model_input_tail_window.budget_error_to_string error)
-            | Ok windowed ->
-              let outcome =
-                Keeper_model_input_demotion.materialize
-                  ~store:(Tool_blob_store.create ~base_path:ctx.base_path)
-                  ~pending
-                  windowed
-              in
-              if outcome.Keeper_model_input_demotion.reverted = 0
-              then Ok outcome.Keeper_model_input_demotion.messages
-              else
-                (* A restored body is larger than the placeholder the cut was
-                   measured against, so the cut is no longer known to fit.
-                   Choose it again against what will actually be sent. *)
-                (match cut outcome.Keeper_model_input_demotion.messages with
-                 | Ok recut -> Ok recut
-                 | Error error ->
-                   Error
-                     (Runtime_model_input_tail_window.budget_error_to_string error))))
+           (* Blob materialization performs filesystem I/O and therefore stays
+              on the owning Eio fiber rather than in the CPU domain pool. *)
+           let outcome =
+             Keeper_model_input_demotion.materialize
+               ~store:(Tool_blob_store.create ~base_path:ctx.base_path)
+               ~pending
+               windowed
+           in
+           if outcome.Keeper_model_input_demotion.reverted = 0
+           then Ok outcome.Keeper_model_input_demotion.messages
+           else
+             (* A restored body is larger than the measured placeholder, so the
+                final cut must be selected again against the actual payload. *)
+             (match
+                offload_model_input_cpu (fun () ->
+                  Runtime_model_input_tail_window.project
+                    ~measure_message_bytes:
+                      (memoize_message_measurement measure_message_bytes)
+                    ~capacity_bytes:ctx.max_request_body_bytes
+                    ~reserved_bytes
+                    outcome.Keeper_model_input_demotion.messages)
+              with
+              | Ok recut -> Ok recut
+              | Error error ->
+                Error
+                  (Runtime_model_input_tail_window.budget_error_to_string error)))
     in
     match windowed with
     | Error _ as error -> error
@@ -608,4 +635,5 @@ module For_testing = struct
   let apply_accept = apply_accept
   let observe_request_wire_error = observe_request_wire_error
   let memoize_message_measurement = memoize_message_measurement
+  let offload_model_input_cpu = offload_model_input_cpu
 end

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -263,6 +263,31 @@ let measure_message_bytes (message : Agent_sdk.Types.message) =
     (Yojson.Safe.to_string (Keeper_context_core.message_to_json message))
 ;;
 
+module Message_identity = struct
+  type t = Agent_sdk.Types.message
+
+  let equal left right = left == right
+
+  (* Messages are immutable. [Hashtbl.hash] is bounded, so this avoids a full
+     content traversal while preserving the hash/equality contract for the
+     same record identity. Structural collisions are harmless because [equal]
+     remains physical. *)
+  let hash = Hashtbl.hash
+end
+
+module Message_measurement_cache = Hashtbl.Make (Message_identity)
+
+let memoize_message_measurement measure =
+  let cache = Message_measurement_cache.create 128 in
+  fun message ->
+    match Message_measurement_cache.find_opt cache message with
+    | Some bytes -> bytes
+    | None ->
+      let bytes = measure message in
+      Message_measurement_cache.add cache message bytes;
+      bytes
+;;
+
 let declared_request_reserve_bytes ~capacity_bytes ~system_prompt ~tools =
   let tool_schema_bytes =
     List.fold_left
@@ -297,19 +322,25 @@ let budgeted_model_input_projection (ctx : try_provider_ctx)
       ~system_prompt:ctx.system_prompt
       ~tools:ctx.tools
   in
-  let raw_cut candidate =
-    Runtime_model_input_tail_window.project_with_drop
-      ~measure_message_bytes
-      ~capacity_bytes:ctx.max_request_body_bytes
-      ~reserved_bytes
-      candidate
-  in
-  let cut candidate =
-    Result.map
-      (fun projection -> projection.Runtime_model_input_tail_window.messages)
-      (raw_cut candidate)
-  in
   fun messages ->
+    (* The raw cut and demotion plan both measure immutable message records.
+       Cache only for this projection call so repeated candidates are encoded
+       once without retaining a long-lived Keeper's historical message graph. *)
+    let measure_message_bytes =
+      memoize_message_measurement measure_message_bytes
+    in
+    let raw_cut candidate =
+      Runtime_model_input_tail_window.project_with_drop
+        ~measure_message_bytes
+        ~capacity_bytes:ctx.max_request_body_bytes
+        ~reserved_bytes
+        candidate
+    in
+    let cut candidate =
+      Result.map
+        (fun projection -> projection.Runtime_model_input_tail_window.messages)
+        (raw_cut candidate)
+    in
     (* RFC-0363: the unmodified history chooses the authoritative cut first.
        Demotion may rewrite only atoms that cut already omitted, so appending a
        turn cannot move the rewrite boundary unless the raw cut itself moves.
@@ -545,4 +576,5 @@ let run_try_provider
 module For_testing = struct
   let apply_accept = apply_accept
   let observe_request_wire_error = observe_request_wire_error
+  let memoize_message_measurement = memoize_message_measurement
 end

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -90,4 +90,7 @@ module For_testing : sig
         option ->
     Agent_sdk.Error.sdk_error ->
     unit
+
+  val memoize_message_measurement :
+    (Agent_sdk.Types.message -> int) -> Agent_sdk.Types.message -> int
 end

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -93,4 +93,6 @@ module For_testing : sig
 
   val memoize_message_measurement :
     (Agent_sdk.Types.message -> int) -> Agent_sdk.Types.message -> int
+
+  val offload_model_input_cpu : (unit -> 'a) -> 'a
 end

--- a/test/test_domain_pool.ml
+++ b/test/test_domain_pool.ml
@@ -173,6 +173,26 @@ let test_ref_submits_to_shared_pool () =
         (worker_domain <> main_domain);
       R.clear_for_tests ()))
 
+let test_keeper_model_input_projection_uses_shared_pool () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      let previous = R.get () in
+      Eio.Switch.on_release sw (fun () ->
+        match previous with
+        | None -> R.clear_for_tests ()
+        | Some pool -> R.set pool);
+      let pool =
+        D.create ~sw ~domain_count:1 (Eio.Stdenv.domain_mgr env)
+      in
+      R.set pool;
+      let caller_domain = Domain.self () in
+      let projection_domain =
+        Masc.Keeper_turn_driver_try_provider.For_testing
+        .offload_model_input_cpu Domain.self
+      in
+      check bool "Keeper model-input CPU work leaves the Eio domain" true
+        (projection_domain <> caller_domain)))
+
 let test_ref_inline_from_raw_domain_with_pool () =
   Eio_main.run (fun env ->
     Eio.Switch.run (fun sw ->
@@ -233,6 +253,8 @@ let () =
     "ref", [
       test_case "inline when absent" `Quick test_ref_runs_inline_when_absent;
       test_case "submits to shared pool" `Quick test_ref_submits_to_shared_pool;
+      test_case "Keeper model-input projection uses shared pool" `Quick
+        test_keeper_model_input_projection_uses_shared_pool;
       test_case "inline from raw domain with pool installed" `Quick
         test_ref_inline_from_raw_domain_with_pool;
     ];

--- a/test/test_keeper_model_input_demotion.ml
+++ b/test/test_keeper_model_input_demotion.ml
@@ -293,6 +293,43 @@ let boundary_moves_only_with_the_raw_cut () =
     demoted
 ;;
 
+(* The production pipeline first compares original/demoted messages, then
+   measures the planned list again to place the byte window. A per-projection
+   identity cache must reuse every candidate measurement without retaining
+   structurally equal but independently allocated messages. *)
+let projection_reuses_candidate_measurements () =
+  let bodies = List.init 20 (fun _ -> String.make 4000 'a') in
+  let messages = history_with_tool_bodies bodies in
+  let raw_measurements = ref 0 in
+  let measured message =
+    incr raw_measurements;
+    measure_message_bytes message
+  in
+  let measure_message_bytes =
+    Masc.Keeper_turn_driver_try_provider.For_testing
+    .memoize_message_measurement measured
+  in
+  let planned = Demotion.plan ~measure_message_bytes messages in
+  Alcotest.(check int)
+    "fixture creates one candidate per aged tool result"
+    20
+    (List.length planned.Demotion.pending);
+  (match
+     Window.project
+       ~measure_message_bytes
+       ~capacity_bytes:max_int
+       ~reserved_bytes:0
+       planned.Demotion.messages
+   with
+   | Error error ->
+     Alcotest.fail (Window.budget_error_to_string error)
+   | Ok _ -> ());
+  Alcotest.(check int)
+    "each original, candidate, and preamble identity is encoded once"
+    122
+    !raw_measurements
+;;
+
 let () =
   Alcotest.run
     "keeper_model_input_demotion"
@@ -326,6 +363,10 @@ let () =
             "demotion boundary moves only with the raw cut"
             `Quick
             boundary_moves_only_with_the_raw_cut
-        ] )
+        ; Alcotest.test_case
+            "projection reuses candidate measurements"
+            `Quick
+            projection_reuses_candidate_measurements
+         ] )
     ]
 ;;

--- a/test/test_keeper_model_input_demotion.ml
+++ b/test/test_keeper_model_input_demotion.ml
@@ -293,10 +293,10 @@ let boundary_moves_only_with_the_raw_cut () =
     demoted
 ;;
 
-(* The production pipeline first compares original/demoted messages, then
-   measures the planned list again to place the byte window. A per-projection
-   identity cache must reuse every candidate measurement without retaining
-   structurally equal but independently allocated messages. *)
+(* The production pipeline measures the raw history, rewrites only atoms below
+   that cut, then measures the planned list. This fixture makes every atom
+   eligible so the per-projection identity cache must reuse every candidate
+   measurement without retaining independently allocated equal messages. *)
 let projection_reuses_candidate_measurements () =
   let bodies = List.init 20 (fun _ -> String.make 4000 'a') in
   let messages = history_with_tool_bodies bodies in
@@ -309,7 +309,9 @@ let projection_reuses_candidate_measurements () =
     Masc.Keeper_turn_driver_try_provider.For_testing
     .memoize_message_measurement measured
   in
-  let planned = Demotion.plan ~measure_message_bytes messages in
+  let planned =
+    Demotion.plan ~measure_message_bytes ~demote_before:max_int messages
+  in
   Alcotest.(check int)
     "fixture creates one candidate per aged tool result"
     20
@@ -321,12 +323,16 @@ let projection_reuses_candidate_measurements () =
        ~reserved_bytes:0
        planned.Demotion.messages
    with
-   | Error error ->
+  | Error error ->
      Alcotest.fail (Window.budget_error_to_string error)
    | Ok _ -> ());
+  let expected_unique_measurements =
+    List.length messages + List.length planned.Demotion.pending + 1
+    (* The window's synthetic preamble. *)
+  in
   Alcotest.(check int)
     "each original, candidate, and preamble identity is encoded once"
-    122
+    expected_unique_measurements
     !raw_measurements
 ;;
 

--- a/test/test_keeper_prompt_metrics.ml
+++ b/test/test_keeper_prompt_metrics.ml
@@ -162,6 +162,24 @@ let test_prompt_metrics_use_exact_utf8_bytes () =
         (List.mem_assoc "estimated_total_tokens" fields)
   | _ -> fail "prompt metrics must serialize as an object"
 
+let test_prompt_metrics_sanitizes_each_segment_once () =
+  let calls = ref [] in
+  let sanitize text =
+    calls := text :: !calls;
+    text
+  in
+  let _metrics =
+    KAPM.For_testing.build_prompt_metrics_with_sanitizer
+      ~sanitize
+      ~system_prompt:"system"
+      ~dynamic_context:"dynamic"
+      ~user_message:"user"
+  in
+  check (list string)
+    "one sanitizer pass per prompt segment"
+    [ "system"; "dynamic"; "user" ]
+    (List.rev !calls)
+
 let test_hard_constraints_in_system_only () =
   let tp = build_separated () in
   let has_in sys s =
@@ -685,6 +703,8 @@ let () =
             test_total_bytes_preserved;
           test_case "exact UTF-8 byte metrics" `Quick
             test_prompt_metrics_use_exact_utf8_bytes;
+          test_case "sanitizes each segment once" `Quick
+            test_prompt_metrics_sanitizes_each_segment_once;
         ] );
       ( "separation_harness",
         [

--- a/test/test_keeper_replay_checkpoint.ml
+++ b/test/test_keeper_replay_checkpoint.ml
@@ -115,6 +115,80 @@ let test_patch_last_assistant_preserves_typed_reasoning () =
     (has_content (function Thinking _ -> true | _ -> false) patched.messages)
 ;;
 
+let test_finalization_reuses_matching_pipeline_checkpoint () =
+  let open Agent_sdk.Types in
+  let history = [ message User [ Text "question" ] ] in
+  let messages = history @ [ message Assistant [ Text "final" ] ] in
+  let persisted =
+    { (checkpoint ~working_context:None messages) with
+      session_id = "new-session"
+    }
+  in
+  let rebuilt =
+    { persisted with
+      messages = List.map Fun.id persisted.messages
+    ; created_at = persisted.created_at +. 1.0
+    ; context = Agent_sdk.Context.copy persisted.context
+    }
+  in
+  let selected, source_already_persisted =
+    Finalize.select_finalization_checkpoint
+      ~last_persisted_checkpoint:(Some persisted)
+      rebuilt
+  in
+  Alcotest.(check bool)
+    "matching pipeline checkpoint selected"
+    true
+    (source_already_persisted && selected == persisted);
+  let patched, replay_suffix_pruned =
+    Finalize.checkpoint_for_replay_persistence
+      ~history_messages:history
+      ~session_id:"new-session"
+      ~response_text:"final"
+      selected
+    |> expect_ok
+  in
+  Alcotest.(check bool)
+    "canonical no-op preserves the durable message spine"
+    true
+    (patched.messages == persisted.messages);
+  Alcotest.(check bool)
+    "final duplicate persistence is unnecessary"
+    true
+    (Finalize.finalization_checkpoint_already_persisted
+       ~source_already_persisted
+       ~source:selected
+       ~patched
+       ~replay_suffix_pruned)
+;;
+
+let test_finalization_does_not_reuse_distinct_message_state () =
+  let open Agent_sdk.Types in
+  let persisted =
+    checkpoint ~working_context:None
+      [ message User [ Text "question" ]; message Assistant [ Text "old" ] ]
+  in
+  let rebuilt =
+    match persisted.messages with
+    | [] -> Alcotest.fail "test checkpoint must contain messages"
+    | first :: rest ->
+      let copied_first = { first with metadata = first.metadata } in
+      { persisted with
+        messages = copied_first :: rest
+      ; created_at = persisted.created_at +. 1.0
+      }
+  in
+  let selected, source_already_persisted =
+    Finalize.select_finalization_checkpoint
+      ~last_persisted_checkpoint:(Some persisted)
+      rebuilt
+  in
+  Alcotest.(check bool)
+    "distinct message spine keeps the rebuilt checkpoint"
+    true
+    ((not source_already_persisted) && selected == rebuilt)
+;;
+
 let test_contract_observation_preserves_current_turn_suffix () =
   let open Agent_sdk.Types in
   let history =
@@ -570,6 +644,14 @@ let () =
             "contract observation preserves current turn"
             `Quick
             test_contract_observation_preserves_current_turn_suffix
+        ; Alcotest.test_case
+            "finalization reuses matching pipeline checkpoint"
+            `Quick
+            test_finalization_reuses_matching_pipeline_checkpoint
+        ; Alcotest.test_case
+            "finalization rejects distinct message state"
+            `Quick
+            test_finalization_does_not_reuse_distinct_message_state
         ; Alcotest.test_case
             "contract observation rejects prefix mismatch"
             `Quick


### PR DESCRIPTION
## Problem

The live Keeper detail surface still showed episodic multi-second stalls after #27027. Read-only runtime and browser probes found four per-turn costs independent of ordinary HTTP cache hits:

- every `keeper_turn_complete` push forced a synchronous rebuild of the full dashboard execution projection and then hydrated the ~164 KB response in the browser;
- Keeper request admission re-encoded demotion candidates in the immediately following byte-window pass, while prompt metrics scanned each already-sanitized segment a second time;
- the entire model-input demotion/window projection encoded a 15,000+ message durable history on the main Eio domain, starving unrelated HTTP fibers before the provider call began;
- MASC persisted OAS's final mutation-boundary checkpoint and then rebuilt and persisted the same completed state again during response finalization.

The turn-complete hook precedes the durable `TurnRecord` commit, so the global execution rebuild was also too early to be authoritative. The selected Keeper already re-reads its scoped status through `masc_keeper_status`, while the canonical execution refresh loop publishes roster snapshots.

## Change

- stop routing `keeper_turn_complete` to global `execution?force=1`; retain the Keeper-scoped status refresh;
- cache canonical message byte measurements with projection-local constant-work identity hints plus pointer comparison, without structural body hashing;
- execute request-reserve encoding and the pure demotion/window plan on the server's shared CPU-weighted `Domain_pool`, keeping blob materialization and its I/O contract on the owning fiber;
- reuse already-sanitized prompt segments for byte/fingerprint metrics;
- retain the last successfully persisted OAS pipeline checkpoint and reuse it at finalization only when the turn matches and every immutable message value has the same identity;
- preserve the durable message spine when replay canonicalization is a semantic no-op, while keeping media-degraded, pruned, sidecar, stale, and changed-message paths on the existing durable save transaction;
- add exact call-count, worker-domain, and checkpoint-identity regressions for the repeated-work paths.

The request-measurement cache is deliberately per projection, not Keeper-global, so it cannot retain an unbounded history graph. CPU offload changes only where pure projection work executes; it does not alter the selected byte window or move blob-store I/O across domains. Checkpoint reuse does not hash or scan large text/tool-result bodies and does not suppress an OAS mutation-boundary save.

## Product comparison

This follows the same narrow-refresh principle exposed by [TanStack Query's keyed invalidation](https://tanstack.com/query/latest/docs/reference/QueryClient) and [Apollo Client's normalized entity cache](https://www.apollographql.com/docs/react/caching/overview): update or re-read the smallest authoritative projection instead of forcing every active consumer through a global snapshot. MASC keeps its existing typed server SSOT and does not add a client-side heuristic or a second data model.

## Evidence

- the supplied browser trace showed unrelated small dashboard endpoints completing together after 4.5-7.7 s, consistent with scheduler starvation rather than one slow route;
- a fresh 5 s live process sample placed the main domain in `Keeper_model_input_demotion -> measure_message_bytes -> Keeper_context_core.message_to_json`, with `Yojson` string encoding, UTF-8 sanitization, and stop-the-world GC visible in the same stacks;
- live old bundle before: `keeper_turn_complete` still caused `execution?force=1` during a Keeper-detail observation;
- rebuilt production bundle, served over the live API/WS origin: three real `keeper_turn_complete` events during 10 s caused zero `execution?force=1` requests, with Client WS connected and no console errors;
- 20-candidate canonical-encoder fixture: 142 potential measurements become 122 actual measurements, removing all 20 duplicate candidate encodes (14.1% fewer calls);
- prompt metric fixture: exactly one sanitizer call per system/dynamic/user segment instead of two;
- live Analyst checkpoint pair: both files were 16,219,497 bytes with 15,517+ messages and the same turn; deleting only `created_at` produced the same SHA-256 (`8ed6c9d3...`), proving a full duplicate encode/write;
- the new reuse guard rejects a structurally equal checkpoint when even one message value is not the same immutable object, so changed replay state still persists;
- the worker-domain regression observes projection CPU work on a domain distinct from the caller's Eio domain.

This proves eliminated and isolated work, not end-to-end deployed latency. Runtime/browser latency must be remeasured after a matching binary and dashboard bundle are deployed.

## Verification

- `test_domain_pool.exe`: 18 passed
- `test_keeper_model_input_demotion.exe`: 8 passed
- `test_keeper_prompt_metrics.exe`: 22 passed
- `test_keeper_replay_checkpoint.exe`: 16 passed
- `sse-store.test.ts`: 43 passed
- dashboard ESLint (changed files): passed
- dashboard TypeScript typecheck: passed
- dashboard production build: passed
- targeted OCaml builds for the focused test executables: passed
- changed OCaml files `ocamlformat --check`: passed
- `git diff --check`: passed
- `scripts/ocaml-structure-ratchet.sh`: passed
- `scripts/oas-boundary-ratchet.sh`: passed
