### PR TITLE
fix(command-gate): report verdicts through the canonical logger

### DIFF
--- a/lib/exec/command_gate/dune
+++ b/lib/exec/command_gate/dune
@@ -9,4 +9,4 @@
  (name masc_exec_command_gate)
  (public_name masc.masc_exec_command_gate)
  (wrapped true)
- (libraries masc_exec masc_exec_bash_parser logs))
+ (libraries masc_exec masc_exec_bash_parser masc_log))

--- a/lib/exec/command_gate/shell_command_gate.ml
+++ b/lib/exec/command_gate/shell_command_gate.ml
@@ -217,40 +217,41 @@ let too_complex_reason_tag = function
 let log_verdict ~source = function
   | Allow _ -> ()
   | Reject { context; reason; diagnostic } ->
-    Logs.warn (fun m ->
-      m
-        "Shell_command_gate.reject source=%s verdict=%s reason=%s diagnostic=%s stage_bins=%s"
-        source
-        (verdict_tag (Reject { context; reason; diagnostic }))
-        (reject_reason_tag reason)
-        diagnostic
-        (String.concat "," context.stage_bins))
+    Log.Gate.warn
+      "Shell_command_gate.reject source=%s verdict=%s reason=%s diagnostic=%s stage_bins=%s"
+      source
+      (verdict_tag (Reject { context; reason; diagnostic }))
+      (reject_reason_tag reason)
+      diagnostic
+      (String.concat "," context.stage_bins)
   | Cannot_parse { reason } ->
-    Logs.warn (fun m ->
-      m
-        "Shell_command_gate.cannot_parse source=%s verdict=%s reason=%s"
-        source
-        (verdict_tag (Cannot_parse { reason }))
-        (parse_reason_tag reason))
+    Log.Gate.warn
+      "Shell_command_gate.cannot_parse source=%s verdict=%s reason=%s"
+      source
+      (verdict_tag (Cannot_parse { reason }))
+      (parse_reason_tag reason)
   | Too_complex { reason } ->
-    Logs.warn (fun m ->
-      m
-        "Shell_command_gate.too_complex source=%s verdict=%s reason=%s"
-        source
-        (verdict_tag (Too_complex { reason }))
-        (too_complex_reason_tag reason))
+    Log.Gate.warn
+      "Shell_command_gate.too_complex source=%s verdict=%s reason=%s"
+      source
+      (verdict_tag (Too_complex { reason }))
+      (too_complex_reason_tag reason)
+;;
+
+(* The verdict with no logging. [gate_raw] reaches the policy through here
+   rather than through [gate_typed], so one call reports one source. *)
+let decide_typed ~ir ~syntax_policy ~sandbox =
+  match parse_only_to_stages (PD.Parsed ir) with
+  | Error (`Cannot_parse reason) -> Cannot_parse { reason }
+  | Error (`Too_complex reason) -> Too_complex { reason }
+  | Ok stages -> apply_policy ~syntax_policy ~sandbox ~stages
 ;;
 
 let gate_typed ~ir ~syntax_policy ~sandbox () : verdict =
   (* Typed callers have already crossed their schema boundary, so this
      entrypoint intentionally skips raw-string parsing while preserving
      the same policy and verdict surface as [gate_raw]. *)
-  let verdict =
-    match parse_only_to_stages (PD.Parsed ir) with
-    | Error (`Cannot_parse reason) -> Cannot_parse { reason }
-    | Error (`Too_complex reason) -> Too_complex { reason }
-    | Ok stages -> apply_policy ~syntax_policy ~sandbox ~stages
-  in
+  let verdict = decide_typed ~ir ~syntax_policy ~sandbox in
   log_verdict ~source:"typed" verdict;
   verdict
 ;;
@@ -258,7 +259,7 @@ let gate_typed ~ir ~syntax_policy ~sandbox () : verdict =
 let gate_raw ~text ~syntax_policy ~sandbox () : verdict =
   let verdict =
     match Masc_exec_bash_parser.Bash.parse_string text with
-    | PD.Parsed ir -> gate_typed ~ir ~syntax_policy ~sandbox ()
+    | PD.Parsed ir -> decide_typed ~ir ~syntax_policy ~sandbox
     | PD.Parse_error _ -> Cannot_parse { reason = Parse_error }
     | PD.Parse_aborted reason -> Cannot_parse { reason = Parse_aborted reason }
     | PD.Too_complex reason ->

--- a/test/dune
+++ b/test/dune
@@ -318,7 +318,8 @@
   test_board_context_inference_resolution
   test_runtime_model_input_tail_window
   test_keeper_model_input_demotion
-  test_workspace_handoff_boundary)
+  test_workspace_handoff_boundary
+  test_exec_command_gate_log_sink)
  (modules
   test_keeper_cooldown_cause_23438
   test_keeper_lifecycle_gate
@@ -615,7 +616,8 @@
   test_board_context_inference_resolution
   test_runtime_model_input_tail_window
   test_keeper_model_input_demotion
-  test_workspace_handoff_boundary)
+  test_workspace_handoff_boundary
+  test_exec_command_gate_log_sink)
  (libraries
   masc_test_deps masc_schedule multimodal bigstringaf masc.keeper_checkpoint_ref))
 

--- a/test/test_exec_command_gate_log_sink.ml
+++ b/test/test_exec_command_gate_log_sink.ml
@@ -1,0 +1,136 @@
+(** The command gate's verdict log, checked at its sink.
+
+    [log_verdict] reported through the external [logs] library. Nothing in
+    this tree ever calls [Logs.set_reporter], so that library keeps its
+    default [nop_reporter] and discarded every line: the gate's three
+    warn sites were the only [logs] users under lib/, and none of their
+    output existed. They now report through [Log.Gate], whose in-memory
+    ring is what these cases read.
+
+    The second contract is arity. [gate_raw] used to reach the policy by
+    calling [gate_typed], which logs, and then logged again itself — one
+    rejected command produced two lines, source=typed and source=raw.
+    Nothing surfaced that while the output went nowhere, and restoring
+    the sink without splitting the decision out would have made the
+    duplicate the visible behaviour. *)
+
+open Alcotest
+
+module Gate = Masc_exec_command_gate.Shell_command_gate
+module Ring = Log.Ring
+
+let sandbox = Gate.host_sandbox
+
+let no_pipes : Gate.syntax_policy = { redirect_allowed = false; allow_pipes = false }
+let with_pipes : Gate.syntax_policy = { redirect_allowed = false; allow_pipes = true }
+
+(* A rejected two-stage pipeline: the shape test_exec_shell_command_gate
+   pins as Pipes_not_allowed { stages = 2 }. *)
+let rejected_command = "rg foo | head -20"
+
+(* [since_seq] is exclusive and the ring's first entry carries seq 0, so an
+   empty ring has to sit below it rather than at it. *)
+let ring_cursor () =
+  match Ring.recent ~limit:1 () with
+  | entry :: _ -> entry.Ring.seq
+  | [] -> -1
+;;
+
+(* The Gate entries a single call appends, oldest first. *)
+let gate_entries_of run =
+  let cursor = ring_cursor () in
+  let verdict = run () in
+  let entries =
+    Ring.recent ~since_seq:cursor ~module_filter:"Gate" ~order:`Oldest_first ()
+  in
+  verdict, entries
+;;
+
+let contains ~needle haystack =
+  let hn = String.length haystack and nn = String.length needle in
+  let rec go i =
+    if i + nn > hn then false
+    else if String.sub haystack i nn = needle then true
+    else go (i + 1)
+  in
+  go 0
+;;
+
+(* Positive control: if the module filter or the ring were wrong, every
+   case below would report "the gate logged nothing" for the wrong
+   reason. This pins that Log.Gate reaches the ring at all. *)
+let test_ring_receives_gate_logs () =
+  let cursor = ring_cursor () in
+  Log.Gate.warn "probe %d" 1;
+  match Ring.recent ~since_seq:cursor ~module_filter:"Gate" ~order:`Oldest_first () with
+  | [ entry ] ->
+    check bool "the probe reached the ring" true
+      (contains ~needle:"probe 1" entry.Ring.message)
+  | other -> failf "expected the probe alone, got %d entries" (List.length other)
+;;
+
+let test_allowed_command_logs_nothing () =
+  let verdict, entries =
+    gate_entries_of (fun () -> Gate.gate_raw ~text:"ls" ~syntax_policy:with_pipes ~sandbox ())
+  in
+  (match verdict with
+   | Gate.Allow _ -> ()
+   | other -> failf "expected Allow, got %s" (Gate.verdict_tag other));
+  check int "an allowed command logs nothing" 0 (List.length entries)
+;;
+
+(* The regression: one call, one line. Before the split this was two. *)
+let test_raw_rejection_logs_once () =
+  let verdict, entries =
+    gate_entries_of (fun () ->
+      Gate.gate_raw ~text:rejected_command ~syntax_policy:no_pipes ~sandbox ())
+  in
+  (match verdict with
+   | Gate.Reject _ -> ()
+   | other -> failf "expected Reject, got %s" (Gate.verdict_tag other));
+  match entries with
+  | [ entry ] ->
+    check bool
+      (Printf.sprintf "the line names the raw entrypoint: %s" entry.Ring.message)
+      true
+      (contains ~needle:"source=raw" entry.Ring.message);
+    check bool "and names the verdict" true
+      (contains ~needle:"Shell_command_gate.reject" entry.Ring.message)
+  | other ->
+    failf
+      "gate_raw logged %d lines for one command (%s); it reached the policy \
+       through gate_typed and both logged"
+      (List.length other)
+      (String.concat " | " (List.map (fun e -> e.Ring.message) other))
+;;
+
+let test_typed_pipeline_rejection_logs_once () =
+  let verdict, entries =
+    gate_entries_of (fun () -> Gate.lower_typed_pipeline ~stages:[] ~sandbox ())
+  in
+  (match verdict with
+   | Gate.Cannot_parse _ -> ()
+   | other -> failf "expected Cannot_parse for an empty pipeline, got %s" (Gate.verdict_tag other));
+  match entries with
+  | [ entry ] ->
+    check bool
+      (Printf.sprintf "the line names the typed-pipeline entrypoint: %s" entry.Ring.message)
+      true
+      (contains ~needle:"source=typed_pipeline" entry.Ring.message)
+  | other -> failf "expected one line, got %d" (List.length other)
+;;
+
+let () =
+  Alcotest.run
+    "Command gate log sink"
+    [ ( "sink"
+      , [ test_case "Log.Gate reaches the ring" `Quick test_ring_receives_gate_logs
+        ; test_case "an allowed command logs nothing" `Quick test_allowed_command_logs_nothing
+        ] )
+    ; ( "arity"
+      , [ test_case "a raw rejection logs once" `Quick test_raw_rejection_logs_once
+        ; test_case "a typed-pipeline rejection logs once" `Quick
+            test_typed_pipeline_rejection_logs_once
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 무엇이 문제였나

`Shell_command_gate.log_verdict` 는 외부 `logs` 라이브러리로 보고한다. 이 트리 어디에도 `Logs.set_reporter` 호출이 없다:

```
$ grep -rn 'Logs.set_reporter\|Logs.set_level\|Logs_fmt' lib/ bin/ test/ --include='*.ml'
(없음)
```

`logs` 는 reporter 를 설정하지 않으면 `nop_reporter` 를 유지한다. 실행으로 확인했다:

```ocaml
let () =
  Logs.warn (fun m -> m "THIS-SHOULD-APPEAR-IF-REPORTED");
  prerr_endline "probe-finished"
```
```
$ ./probe.exe 2>&1
probe-finished
```

즉 게이트 거절 기록은 존재하지 않았다. `log_verdict` 는 `gate_typed` / `gate_raw` / `lower_typed_pipeline` 세 진입점 전부에서 호출되므로, 모든 거절·파싱실패·복잡도초과 판정의 로그가 통째로 사라지고 있었다.

이 3 개 호출부가 `lib/` 에서 외부 `logs` 를 쓰는 유일한 자리였다 (`lib/otel_spans` 의 `Logs.resource_logs` 는 OpenTelemetry protobuf 로 동명이인).

## 두 번째 결함: 한 호출에 두 줄

`gate_raw` 는 `gate_typed` 를 거쳐 정책에 도달했고, `gate_typed` 가 로그를 남긴 뒤 `gate_raw` 가 다시 남겼다. 거절된 명령 하나가 `source=typed`, `source=raw` 두 줄을 만든다. 출력이 아무 데도 안 나가는 동안에는 드러나지 않았다.

싱크만 살리고 이걸 두면 중복이 관측 가능한 동작이 되고, 이후 "log dedup" 워크어라운드를 부른다. 그래서 판정 코어(`decide_typed`)를 분리해 `gate_raw` 가 `gate_typed` 를 우회하게 했다. 진입점당 정확히 한 줄.

## 변경

- `log_verdict` 의 `Logs.warn` 3 곳 → `Log.Gate.warn`. 포맷 문자열과 필드는 그대로.
- `lib/exec/command_gate/dune`: `logs` → `masc_log`. `masc_log` 의존은 `unix/yojson/eio/...` 뿐이라 순환 없음.
- `decide_typed` 추출. `gate_typed` 의 판정 로직은 그대로 옮겼고 `.mli` 공개면 변화 없음.

## 검증

- `dune build --root . @check` — EXIT=0
- `test/test_exec_shell_command_gate.exe` — 14 tests, 기존 판정 회귀 없음
- 신규 `test/test_exec_command_gate_log_sink.ml` — 4 cases, `Log.Ring` 에서 직접 읽는다
  - positive control: `Log.Gate` 가 ring 에 닿는지 (필터가 틀리면 나머지가 엉뚱한 이유로 실패)
  - Allow 는 0 줄
  - raw 거절은 1 줄, `source=raw`
  - typed-pipeline 거절은 1 줄, `source=typed_pipeline`
- 회귀 탐지 확인: `gate_raw` 를 `gate_typed` 호출로 되돌리면 arity 케이스가 두 줄을 모두 인용하며 실패한다
- `scripts/ci/check-logging-consistency.sh` 위반 32 → 29 (이 검사는 아직 CI 에 배선돼 있지 않다)
- `check-doc-code-refs.sh` / `audit-keeper-tool-boundary-matrix.sh` / `check-variants.sh` 모두 EXIT=0

## 남는 것

`scripts/ci/check-logging-consistency.sh` 는 어디서도 호출되지 않는다. 나머지 29 건은 성격이 갈린다 — `bin/fusion_run.ml` 10 건은 harness 의 사용자 대상 CLI 출력이라 allowlist 가 맞고, `lib/ide` 8 건은 `Log` 에 대응 모듈이 없어 정본 표면에 모듈을 추가할지 결정이 필요하다. 이 PR 범위 밖.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
