### PR TITLE
refactor(board): 손으로 유지하던 재수출 5줄을 include 로, 그리고 거짓이 된 facade 계약 문서 수정

### DIFF
--- a/lib/board/board.ml
+++ b/lib/board/board.ml
@@ -1,7 +1,3 @@
 include Board_votes
 
-let audience_for_post = Board_audience.audience_for_post
-let audience_for_comment = Board_audience.audience_for_comment
-let audience_for_reaction = Board_audience.audience_for_reaction
-let audience_label = Board_audience.audience_label
-let direct_targets_of_text = Board_audience.direct_targets_of_text
+include Board_audience

--- a/lib/board/board.mli
+++ b/lib/board/board.mli
@@ -1,35 +1,32 @@
 (** Board — top-level public facade for the board store.
 
-    The .ml is a single line: [include Board_votes].  This
-    .mli mirrors the runtime with [include module type of
-    struct include Board_votes end] so type identity is
-    preserved end-to-end across the four-hop chain
-    {!Board_types} → {!Board_core_classify} →
-    {!Board_core_payload} (runtimed inside {!Board_core}) →
-    {!Board_core} → {!Board_votes} → {!Board}.
+    The runtime is two [include]s, and this .mli mirrors both
+    with [include module type of] so type identity is
+    preserved end to end.
 
-    Callers reach the entire board surface — store /
-    persistence / classification / payload normalisation /
-    voting / karma / flair — through {!Board.X} unqualified
-    after [open Masc].  478 dotted [Board.X] call sites
-    in lib + bin + test all resolve through this runtime.
+    - {!Board_votes} carries the store / persistence /
+      classification / payload / voting / karma / flair
+      surface, itself layered as
+      {!Board_types} → {!Board_core_classify} →
+      {!Board_core_payload} (runtimed inside {!Board_core}) →
+      {!Board_core} → {!Board_votes}.
+    - {!Board_audience} carries the audience and mention
+      resolution surface.  Both reach {!Board_types}; OCaml
+      resolves the repeated definitions to the same types, so
+      including both is not a conflict.
 
-    No locally-defined surface; this facade has no
-    behavioural code of its own.  Every entry visible from
-    {!Board} traces back to one of the four upstream
-    modules. *)
+    Callers reach the whole surface through {!Board.X}
+    unqualified after [open Masc].
+
+    No behavioural code of its own: every entry visible from
+    {!Board} is defined in {!Board_votes} or
+    {!Board_audience}, and both are re-exported whole rather
+    than by a hand-listed subset that could fall behind. *)
 
 include module type of struct
   include Board_votes
 end
 
-val audience_for_post
-  :  visibility:visibility
-  -> title:string
-  -> content:string
-  -> (audience, board_error) result
-
-val audience_for_comment : content:string -> (audience, board_error) result
-val audience_for_reaction : audience
-val audience_label : audience -> string
-val direct_targets_of_text : string -> Agent_id.t list
+include module type of struct
+  include Board_audience
+end


### PR DESCRIPTION
## 문제

`board.mli` 헤더는 62개 파일이 `Board.X` 로 접근하는 표면의 계약 문서다. 그 헤더의 진술 네 개가 사실과 다르다.

| 진술 | 실제 |
|---|---|
| "The .ml is a **single line**: `include Board_votes`" | `include Board_votes` + `Board_audience` 재수출 5줄 |
| "the **four-hop** chain" 뒤에 6개 모듈 나열 | 나열이 5-hop |
| "**478** dotted `Board.X` call sites" | 실측 1,296 occurrence / 62 파일 |
| "every entry traces back to one of **the four upstream modules**" | 5개 항목이 나열에 없는 `Board_audience` 에서 온다 |

마지막이 실질적이다. 헤더가 설명하는 체인에 `Board_audience` 가 아예 없는데, 같은 파일 아래쪽에 그 모듈의 함수 5개가 `val` 로 선언돼 있다.

## 손으로 유지하던 5줄이 불필요했다

`board.ml` 이 `Board_audience` 를 `include` 하지 않고 함수 5개를 하나씩 재수출하고 있었다. 왜 그런지 근거가 어디에도 없다.

가설을 세우고 **실제로 시험했다** — `include Board_audience` 로 바꿔 빌드:

```
$ dune build @check
(에러 없음)
```

충돌하지 않는다. 두 모듈 모두 `Board_types` 에 도달하지만 OCaml 이 반복된 정의를 같은 타입으로 해석한다.

(처음엔 "`Board_types` 중복 때문에 include 할 수 없다"를 이유로 적었다가, 검증해보니 틀려서 지웠다. 사실이 아닌 설명을 고치는 PR 에 사실이 아닌 설명을 넣을 뻔했다.)

## 변경

- `board.ml` — `Board_audience` 재수출 5줄 → `include Board_audience`
- `board.mli` — 대응하는 `val` 5개 → `include module type of struct include Board_audience end`
- 헤더를 실제 구조에 맞게 다시 씀

`Board_audience.mli` 의 공개 함수는 정확히 5개이고 `board.ml` 이 그 5개를 모두 재수출하고 있었다. **허용 목록이 아니라 손으로 유지하는 완전 미러였다.** 완전 미러는 미러로 표현하는 편이 맞다 — `Board_audience` 에 함수가 추가되면 자동으로 따라가고, 뒤처질 수 없다.

## 숫자를 다시 넣지 않았다

"478 call sites" 같은 값은 넣는 순간 낡기 시작한다. 실제로 1,296 까지 벌어졌다. 대신 구조를 기술했다.

## 검증

- `dune build @check` EXIT=0 (`.ml` 이 `.mli` 에 대해 검사되므로 공개 표면 동일성이 컴파일러로 확인된다)
- `test_board_activity_cache` 5/5, `test_board_author_identity_10297` 8/8
- 동작 변경 없음 — 재수출 방식만 바뀐다

## 관련

#27088 과 같은 계열이다. 그쪽은 존재하지 않는 `sleep 3600` 을 설명하던 `.mli` 를 지웠고, 이쪽은 존재하지 않는 "single line" 을 설명하던 `.mli` 를 고친다. 계약 문서의 거짓 진술은 그 계약을 읽고 코드를 쓰는 사람과 에이전트에게 그대로 전달된다.
