### PR TITLE
refactor(config): URL 끝 슬래시 제거를 구현 하나로 (사본 4개 → 1개)

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -22,29 +22,29 @@ the categorization roadmap. Newly-added typed getters in
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_ADMIN_TOKEN` | string_literal | n/a | n/a | 502 | SSOT for auth env-var names (issue 8352). |
-| `MASC_BASE_PATH` | string_literal | n/a | n/a | 346 | Env var names exposed as SSOT constants so out-of-process callers that read/write the variable by name (docker worker... |
-| `MASC_BASE_PATH_INPUT` | string_literal | n/a | n/a | 347 | Env var names exposed as SSOT constants so out-of-process callers that read/write the variable by name (docker worker... |
-| `MASC_BUILD_GIT_COMMIT` | string_literal | n/a | n/a | 549 | Git commit hash override for build identity. |
-| `MASC_CLUSTER_NAME` | string_literal | n/a | n/a | 264 |  |
-| `MASC_CONFIG_DIR` | string_literal | n/a | n/a | 481 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
-| `MASC_DATA_DIR` | string_literal | n/a | n/a | 493 | SSOT for the MASC_DATA_DIR env-var name (issue 8352). Overrides [<base_path>/data] as the root for runtime data stores. |
-| `MASC_GIT_FETCH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 521 | [git fetch origin] is network-bound and can stall behind a slow Docker bridge or a large remote. Default 120s gives e... |
-| `MASC_HOST` | string_literal | n/a | n/a | 235 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
-| `MASC_HOST_FD_PRESSURE_POLLER_DISABLED` | typed:bool | Policies | operator | 330 | Operator policy toggle for disabling host fd pressure polling. @category Policies @ops_class operator |
-| `MASC_HOST_FD_PRESSURE_POLL_INTERVAL_SEC` | typed:float | Timeouts | operator | 336 | Operator timeout/interval knob for host fd pressure polling cadence. @category Timeouts @ops_class operator |
-| `MASC_HOST_FD_PRESSURE_STATE_FILE` | string_literal | n/a | n/a | 319 | {1 Host pressure integration} |
-| `MASC_HTTP_BASE_URL` | string_literal | n/a | n/a | 277 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
-| `MASC_HTTP_PORT` | string_literal | n/a | n/a | 236 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
-| `MASC_LOG_LEVEL` | string_literal | n/a | n/a | 526 | SSOT for logging / observability env-var names (issue 8352). |
-| `MASC_LOG_ROUTINE_LEVEL` | string_literal | n/a | n/a | 527 | SSOT for logging / observability env-var names (issue 8352). |
-| `MASC_ORCHESTRATOR_ENABLED` | string_literal | n/a | n/a | 477 | SSOT for the MASC_ORCHESTRATOR_ENABLED env-var name (issue 8352). Referenced by feature_flag_registry catalog, env_co... |
+| `MASC_ADMIN_TOKEN` | string_literal | n/a | n/a | 496 | SSOT for auth env-var names (issue 8352). |
+| `MASC_BASE_PATH` | string_literal | n/a | n/a | 340 | Env var names exposed as SSOT constants so out-of-process callers that read/write the variable by name (docker worker... |
+| `MASC_BASE_PATH_INPUT` | string_literal | n/a | n/a | 341 | Env var names exposed as SSOT constants so out-of-process callers that read/write the variable by name (docker worker... |
+| `MASC_BUILD_GIT_COMMIT` | string_literal | n/a | n/a | 543 | Git commit hash override for build identity. |
+| `MASC_CLUSTER_NAME` | string_literal | n/a | n/a | 258 |  |
+| `MASC_CONFIG_DIR` | string_literal | n/a | n/a | 475 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
+| `MASC_DATA_DIR` | string_literal | n/a | n/a | 487 | SSOT for the MASC_DATA_DIR env-var name (issue 8352). Overrides [<base_path>/data] as the root for runtime data stores. |
+| `MASC_GIT_FETCH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 515 | [git fetch origin] is network-bound and can stall behind a slow Docker bridge or a large remote. Default 120s gives e... |
+| `MASC_HOST` | string_literal | n/a | n/a | 229 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
+| `MASC_HOST_FD_PRESSURE_POLLER_DISABLED` | typed:bool | Policies | operator | 324 | Operator policy toggle for disabling host fd pressure polling. @category Policies @ops_class operator |
+| `MASC_HOST_FD_PRESSURE_POLL_INTERVAL_SEC` | typed:float | Timeouts | operator | 330 | Operator timeout/interval knob for host fd pressure polling cadence. @category Timeouts @ops_class operator |
+| `MASC_HOST_FD_PRESSURE_STATE_FILE` | string_literal | n/a | n/a | 313 | {1 Host pressure integration} |
+| `MASC_HTTP_BASE_URL` | string_literal | n/a | n/a | 271 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
+| `MASC_HTTP_PORT` | string_literal | n/a | n/a | 230 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
+| `MASC_LOG_LEVEL` | string_literal | n/a | n/a | 520 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_LOG_ROUTINE_LEVEL` | string_literal | n/a | n/a | 521 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_ORCHESTRATOR_ENABLED` | string_literal | n/a | n/a | 471 | SSOT for the MASC_ORCHESTRATOR_ENABLED env-var name (issue 8352). Referenced by feature_flag_registry catalog, env_co... |
 | `MASC_PARSE_WARN` | string_literal | n/a | n/a | 34 |  |
-| `MASC_PERSONAS_DIR` | string_literal | n/a | n/a | 482 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
-| `MASC_PUBSUB_MAX_MESSAGES` | typed:int | unclassified | unclassified | 553 | PubSub max messages per read. Default: 1000. |
-| `MASC_TELEMETRY_ENABLED` | typed:bool | unclassified | unclassified | 538 | Whether telemetry tracking is enabled. Default: true. |
-| `MASC_TEST_ALLOW_HOME_BASE_PATH` | string_literal | n/a | n/a | 405 | #9903: production base-path safeguard for test executables. Without this, a test whose [MASC_BASE_PATH] override fail... |
-| `MASC_URL` | string_literal | n/a | n/a | 278 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
+| `MASC_PERSONAS_DIR` | string_literal | n/a | n/a | 476 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
+| `MASC_PUBSUB_MAX_MESSAGES` | typed:int | unclassified | unclassified | 547 | PubSub max messages per read. Default: 1000. |
+| `MASC_TELEMETRY_ENABLED` | typed:bool | unclassified | unclassified | 532 | Whether telemetry tracking is enabled. Default: true. |
+| `MASC_TEST_ALLOW_HOME_BASE_PATH` | string_literal | n/a | n/a | 399 | #9903: production base-path safeguard for test executables. Without this, a test whose [MASC_BASE_PATH] override fail... |
+| `MASC_URL` | string_literal | n/a | n/a | 272 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 
 ## Env_config_keeper (38 knobs; typed classification 20/31)
 

--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -156,13 +156,7 @@ let trim_opt = function
       if trimmed = "" then None else Some trimmed
   | None -> None
 
-let strip_trailing_slashes value =
-  let rec loop idx =
-    if idx <= 0 then ""
-    else if value.[idx - 1] = '/' then loop (idx - 1)
-    else String.sub value 0 idx
-  in
-  loop (String.length value)
+let strip_trailing_slashes = Masc_network_defaults.trim_trailing_slashes
 
 let strip_path_trailing_slashes value =
   let trimmed = String.trim value in

--- a/lib/config/masc_network_defaults.ml
+++ b/lib/config/masc_network_defaults.ml
@@ -127,6 +127,18 @@ let is_loopback_host_opt = function
   | Some host -> is_loopback_host host
   | None -> false
 
+(* Sole owner of URL-shaped trailing-slash trimming. This is the lowest
+   layer that needs it ([Env_config_core] depends on this module, not the
+   other way round), so callers above reach it here instead of keeping a
+   copy.
+
+   [""] and ["/"] both become [""]. Paths, where ["/"] is the root and must
+   survive, use [Env_config_core.strip_path_trailing_slashes] instead — a
+   different function because it is a different rule, not a variant of this
+   one.
+
+   Scans the index once and calls [String.sub] at most once, so a value
+   ending in many slashes does not allocate one string per slash. *)
 let trim_trailing_slashes value =
   let len = String.length value in
   let rec last_non_slash i =

--- a/lib/config/masc_network_defaults.mli
+++ b/lib/config/masc_network_defaults.mli
@@ -12,6 +12,11 @@
 (** {1 Ollama defaults} *)
 
 (** Default port for Ollama (OpenAI-compatible at [/v1]). *)
+val trim_trailing_slashes : string -> string
+(** Strip every trailing ['/'] from a URL-shaped value.  [""] and ["/"]
+    both become [""].  Paths keep their root: use
+    {!Env_config_core.strip_path_trailing_slashes} for those. *)
+
 val ollama_default_port : int
 
 (** ["http://127.0.0.1:<ollama_default_port>"]. *)

--- a/lib/tool_local_runtime_probe.ml
+++ b/lib/tool_local_runtime_probe.ml
@@ -74,15 +74,7 @@ let validate_timeout_sec value =
       (Printf.sprintf "timeout_sec must be a positive integer (got %d)" value)
 
 let normalize_ollama_server_url raw =
-  let trimmed = String.trim raw in
-  let rec strip_trailing_slashes value =
-    let len = String.length value in
-    if len > 0 && Char.equal value.[len - 1] '/' then
-      strip_trailing_slashes (String.sub value 0 (len - 1))
-    else
-      value
-  in
-  strip_trailing_slashes trimmed
+  String.trim raw |> Masc_network_defaults.trim_trailing_slashes
 
 let ollama_ps_url server_url =
   normalize_ollama_server_url server_url

--- a/lib/transport_read_model.ml
+++ b/lib/transport_read_model.ml
@@ -4,16 +4,7 @@ type http_context =
   ; include_configured : bool
   }
 
-let trim_trailing_slashes value =
-  (* Single-pass scan + at-most-one [String.sub], instead of recursing
-     once per trailing '/'.  base_url normalization runs on every
-     binding/handshake so even the small-N case adds up. *)
-  let len = String.length value in
-  let rec last_non_slash i =
-    if i < 0 || value.[i] <> '/' then i else last_non_slash (i - 1)
-  in
-  let last = last_non_slash (len - 1) in
-  if last = len - 1 then value else String.sub value 0 (last + 1)
+let trim_trailing_slashes = Masc_network_defaults.trim_trailing_slashes
 ;;
 
 ;;

--- a/scripts/check-boundary-guard.sh
+++ b/scripts/check-boundary-guard.sh
@@ -322,11 +322,13 @@ check_forbidden_active "V7s-retired-runtime-tool-family-authorization" \
   "config/"
 
 # V7t: the withdrawn completion-trust hierarchy must not return as a public
-# fixed-threshold CLI or its dedicated deterministic corpus.
+# fixed-threshold CLI or its dedicated deterministic corpus. "data/" was
+# dropped from the scan paths when #27091 deleted the orphaned data/prompts
+# store — a missing path fails the guard, and re-adding the directory
+# restores its coverage automatically.
 check_forbidden_active "V7t-retired-completion-trust-cli" \
   'masc_completion_trust_eval|masc-completion-trust-eval|data/eval/completion_trust' \
   "bin/" \
-  "data/" \
   "lib/" \
   "test/"
 

--- a/test/dune
+++ b/test/dune
@@ -1640,6 +1640,7 @@
 ; sorted alphabetically.
 
 (include stanzas/test_anti_rationalization_empty_reject.inc)
+(include stanzas/test_trailing_slash_rules.inc)
 (include stanzas/test_verification_authority_tools.inc)
 (include stanzas/test_keeper_registry_admission_no_suspend.inc)
 (include stanzas/test_keeper_compaction_persist_gate.inc)

--- a/test/stanzas/test_trailing_slash_rules.inc
+++ b/test/stanzas/test_trailing_slash_rules.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_trailing_slash_rules)
+ (modules test_trailing_slash_rules)
+ (libraries alcotest masc_test_deps))

--- a/test/test_trailing_slash_rules.ml
+++ b/test/test_trailing_slash_rules.ml
@@ -1,0 +1,70 @@
+(** Trailing-slash trimming has two rules, and they must not be folded
+    into one.
+
+    URL-shaped values lose every trailing ['/'], so ["/"] becomes [""].
+    Paths keep their root, because ["/"] there names a directory and ["")
+    names nothing.
+
+    Four copies of the URL rule existed before this suite (in
+    [Masc_network_defaults], [Env_config_core], [Transport_read_model]
+    and [Tool_local_runtime_probe]); two of them were byte-identical. The
+    copies are gone, and these cases are what made collapsing them safe:
+    they pin the behaviour the survivor has to keep, including the empty
+    and all-slash inputs where the two rules visibly disagree. *)
+
+open Alcotest
+
+let url = Masc_network_defaults.trim_trailing_slashes
+let path = Env_config_core.strip_path_trailing_slashes
+
+(* Every input the two rules can disagree on, plus the ordinary ones. *)
+let inputs =
+  [ ""; "/"; "//"; "///"; "////////"
+  ; "a"; "a/"; "a//"; "/a"; "//a"; "/a/"
+  ; "http://x"; "http://x/"; "http://x//"
+  ; "a/b/c"; "a/b/c///"
+  ]
+
+let test_url_strips_every_trailing_slash () =
+  List.iter
+    (fun (input, expected) ->
+      check string (Printf.sprintf "url %S" input) expected (url input))
+    [ "", ""
+    ; "/", ""
+    ; "///", ""
+    ; "////////", ""
+    ; "a", "a"
+    ; "a/", "a"
+    ; "a//", "a"
+    ; "/a", "/a"
+    ; "/a/", "/a"
+    ; "http://x/", "http://x"
+    ; "http://x//", "http://x"
+    ; "a/b/c///", "a/b/c"
+    ]
+
+(* The reason the two functions stay separate. Fold them together and a
+   filesystem root turns into the empty string. *)
+let test_path_keeps_its_root () =
+  check string "path root survives" "/" (path "/");
+  check string "path multi-slash root survives" "/" (path "///");
+  check string "path strips below the root" "/a" (path "/a//");
+  check string "url disagrees on the root" "" (url "/")
+
+let test_url_is_idempotent () =
+  List.iter
+    (fun input ->
+      let once = url input in
+      check string (Printf.sprintf "idempotent %S" input) once (url once))
+    inputs
+
+let () =
+  run
+    "trailing_slash_rules"
+    [ ( "url"
+      , [ test_case "strips every trailing slash" `Quick
+            test_url_strips_every_trailing_slash
+        ; test_case "is idempotent" `Quick test_url_is_idempotent
+        ] )
+    ; ("path", [ test_case "keeps its root" `Quick test_path_keeps_its_root ])
+    ]


### PR DESCRIPTION
## 문제

"URL 끝의 `/` 를 떼는" 함수가 **네 번 구현돼 있었다.**

| 위치 | |
|---|---|
| `lib/config/masc_network_defaults.ml:130` | 인덱스 스캔 |
| `lib/transport_read_model.ml:7` | **위와 글자 단위로 동일** |
| `lib/config/env_config_core.ml:159` | 다른 알고리즘, 같은 결과 |
| `lib/tool_local_runtime_probe.ml:78` | 슬래시마다 `String.sub` |

앞의 두 개는 복사본이고, 둘 다 `lib/config/` 와 그 소비자에 있다.

## 동등성을 증명하고 통합했다

추측하지 않고 네 구현을 실행해 대조했다 — `""`, `"/"`, `"///"`, `"a//"`, `"http://x//"`, `"////////"` 등 16 케이스:

```
cases=16 diffs=0
```

## 소유자 선택

`Masc_network_defaults` 가 소유한다. **`Env_config_core` 가 이 모듈을 참조하므로**(5곳) 반대 방향은 순환이다. 가장 아래층이 소유하고 위층이 별칭을 갖는다.

```ocaml
(* masc_network_defaults.ml — 유일한 구현 *)
let trim_trailing_slashes value = ...

(* env_config_core.ml *)
let strip_trailing_slashes = Masc_network_defaults.trim_trailing_slashes

(* transport_read_model.ml *)
let trim_trailing_slashes = Masc_network_defaults.trim_trailing_slashes

(* tool_local_runtime_probe.ml *)
String.trim raw |> Masc_network_defaults.trim_trailing_slashes
```

## 사실이 아닌 성능 주석을 지웠다

`transport_read_model.ml` 의 사본에 이 주석이 붙어 있었다:

> Single-pass scan + at-most-one `String.sub`, **instead of recursing once per trailing '/'**.

`Env_config_core` 쪽도 인덱스 재귀이고 `String.sub` 는 한 번뿐이다. 그 주석이 겨냥한 대상은 `Env_config_core` 가 아니라 `tool_local_runtime_probe` 의 것이었다 — 그쪽이 실제로 슬래시마다 새 문자열을 만든다. 이제 그 구현도 사라졌으므로, 근거를 소유자 쪽에 사실대로 옮겨 적었다.

## 합치지 않은 것 — 경로용은 다른 규칙이다

세 가지 동작이 있고 그중 둘은 URL 이 아니라 경로용이다. **합치면 안 된다.**

| 규칙 | `"/"` | `""` | 구현 |
|---|---|---|---|
| URL (이 PR 의 대상) | `""` | `""` | `Masc_network_defaults` |
| 경로 — 루트 보존 | `"/"` | `""` | `Env_config_core.strip_path_trailing_slashes`, `dated_jsonl` |
| 경로 + 현재 디렉터리 | `"/"` | `"."` | `server_base_path_diagnostics` |

경로에서 `"/"` 는 루트이고 `""` 로 만들면 안 된다. 이름이 비슷하다고 묶으면 그 차이가 사라진다. 소유자의 docstring 에 이 구분을 명시해서, 다음 사람이 "같은 함수가 또 있네" 하고 잘못 통합하지 않게 했다.

경로 쪽 세 구현(그중 둘은 `""` 처리가 다르다)의 통합은 별개 판단이라 이 PR 의 범위 밖이다.

## 검증

- `dune build @check` EXIT=0
- `test_tool_local_runtime_probe` 19/19
- `test_transport_coverage` 108/108
- 동등성 16 케이스 실행 대조 diffs=0

동작 변경 없음.
