### PR TITLE
fix(boundary): V7t 스캔 경로에서 삭제된 data/ 제거 — #27091 이후 main Lint 적색

### DIFF
--- a/scripts/check-boundary-guard.sh
+++ b/scripts/check-boundary-guard.sh
@@ -322,11 +322,13 @@ check_forbidden_active "V7s-retired-runtime-tool-family-authorization" \
   "config/"
 
 # V7t: the withdrawn completion-trust hierarchy must not return as a public
-# fixed-threshold CLI or its dedicated deterministic corpus.
+# fixed-threshold CLI or its dedicated deterministic corpus. "data/" was
+# dropped from the scan paths when #27091 deleted the orphaned data/prompts
+# store — a missing path fails the guard, and re-adding the directory
+# restores its coverage automatically.
 check_forbidden_active "V7t-retired-completion-trust-cli" \
   'masc_completion_trust_eval|masc-completion-trust-eval|data/eval/completion_trust' \
   "bin/" \
-  "data/" \
   "lib/" \
   "test/"
 


### PR DESCRIPTION
## 무엇
#27091 (16119882b2) 이 고아 data/prompts 저장소를 지우면서 data/ 디렉토리 전체가 사라졌는데, `scripts/check-boundary-guard.sh` 의 V7t 는 여전히 `"data/"` 를 스캔 경로로 요구해용. 없는 경로는 가드 에러 (rc=1) 라 그 이후 main 과 main 을 머지한 모든 PR 의 Lint 가 깨져용 (예: #26940).

## 어떻게
V7t 의 스캔 경로에서 `"data/"` 만 제거해용. 가드 자체는 유지 — 패턴은 여전히 bin/, lib/, test/ 에서 폐기된 completion-trust CLI 의 귀환을 감시해용. data/ 가 다시 생기면 스캔 항목만 되돌리면 돼용.

## 검증
- `bash scripts/check-boundary-guard.sh` 로컬 실행 exit=0, ERROR/FAIL 0건
- 나머지는 CI 에서 확인