### PR TITLE
fix(ci): boundary guard 가 사라진 data/ 를 스캔해 main 과 모든 PR 을 막고 있다

### DIFF
--- a/scripts/check-boundary-guard.sh
+++ b/scripts/check-boundary-guard.sh
@@ -323,10 +323,14 @@ check_forbidden_active "V7s-retired-runtime-tool-family-authorization" \
 
 # V7t: the withdrawn completion-trust hierarchy must not return as a public
 # fixed-threshold CLI or its dedicated deterministic corpus.
+# [data/] was dropped from this list when #27091 removed its last tracked
+# files; git does not carry empty directories, so a fresh checkout has no
+# such path and the guard errored on every PR. The pattern still names
+# [data/eval/completion_trust], so the corpus returning under that path is
+# caught the moment any scanned tree references it.
 check_forbidden_active "V7t-retired-completion-trust-cli" \
   'masc_completion_trust_eval|masc-completion-trust-eval|data/eval/completion_trust' \
   "bin/" \
-  "data/" \
   "lib/" \
   "test/"
 


### PR DESCRIPTION
## 증상

`Lint :: Check MASC/OAS boundary ratchet` 이 **main 에서 실패한다.**

```
BOUNDARY ERROR: V7t-retired-completion-trust-cli — path data/ does not exist
```

`pull_request` 이벤트는 merge ref 를 검사하므로 **열린 PR 전부가 이 실패를 물려받는다.** 확인된 것만 #27094, #27095.

## 원인

`#27091` (`chore: delete the orphaned data/prompts store`) 이 `data/prompts/` 의 4개 파일을 지웠다. 그게 `data/` 아래 유일한 tracked 파일이었다.

```
$ git ls-tree -r --name-only origin/main -- data/ | wc -l
0
```

git 은 빈 디렉터리를 담지 않으므로 새 체크아웃에는 `data/` 가 아예 없다. 그런데 `scripts/check-boundary-guard.sh:329` 가 guard `V7t` 의 스캔 경로로 `"data/"` 를 넘기고, 스크립트는 선언된 경로가 없으면 에러를 낸다.

로컬 작업 트리에는 untracked 잔여물로 `data/` 가 남아 있는 경우가 많아 재현되지 않는다. 깨끗한 `origin/main` 체크아웃에서 재현했다.

## 수정

`V7t` 의 경로 목록에서 `data/` 를 뺀다.

**탐지 능력은 줄지 않는다.** 이 guard 의 패턴이 여전히 `data/eval/completion_trust` 를 문자열로 포함하므로, 그 코퍼스가 어떤 경로로든 돌아오면 `bin/` `lib/` `test/` 중 어디서 참조되는 순간 걸린다. 없어진 디렉터리를 스캔 대상으로 유지하는 것이 탐지에 기여하는 부분은 없다.

## 검증

- 수정 전 (깨끗한 `origin/main` 체크아웃): `BOUNDARY ERROR ... data/ does not exist`
- 수정 후: `bash scripts/check-boundary-guard.sh` RC=0
- 나머지 guard 가 선언한 경로 전수 확인 — 존재하지 않는 것 0건

## 관련

#27091 (원인), #27094 / #27095 (차단됨)