### PR TITLE
fix(keeper-toml): make the typed accessors exhaustive over toml_value

### DIFF
--- a/lib/keeper_toml/keeper_toml_loader.ml
+++ b/lib/keeper_toml/keeper_toml_loader.ml
@@ -19,32 +19,52 @@ include Keeper_toml_parser
 let toml_string_opt (doc : toml_doc) (key : string) : string option =
   match List.assoc_opt key doc with
   | Some (Toml_string s) -> Some s
-  | _ -> None
+  | Some
+      ( Toml_int _ | Toml_float _ | Toml_bool _ | Toml_string_array _ | Toml_array _
+      | Toml_table _ | Toml_inline_table _ | Toml_table_array _ | Toml_offset_datetime _
+      | Toml_local_datetime _ | Toml_local_date _ | Toml_local_time _ )
+  | None -> None
 ;;
 
 let toml_int_opt (doc : toml_doc) (key : string) : int option =
   match List.assoc_opt key doc with
   | Some (Toml_int i) -> Some i
-  | _ -> None
+  | Some
+      ( Toml_string _ | Toml_float _ | Toml_bool _ | Toml_string_array _ | Toml_array _
+      | Toml_table _ | Toml_inline_table _ | Toml_table_array _ | Toml_offset_datetime _
+      | Toml_local_datetime _ | Toml_local_date _ | Toml_local_time _ )
+  | None -> None
 ;;
 
 let toml_float_opt (doc : toml_doc) (key : string) : float option =
   match List.assoc_opt key doc with
   | Some (Toml_float f) -> Some f
   | Some (Toml_int i) -> Some (float_of_int i)
-  | _ -> None
+  | Some
+      ( Toml_string _ | Toml_bool _ | Toml_string_array _ | Toml_array _ | Toml_table _
+      | Toml_inline_table _ | Toml_table_array _ | Toml_offset_datetime _
+      | Toml_local_datetime _ | Toml_local_date _ | Toml_local_time _ )
+  | None -> None
 ;;
 
 let toml_bool_opt (doc : toml_doc) (key : string) : bool option =
   match List.assoc_opt key doc with
   | Some (Toml_bool b) -> Some b
-  | _ -> None
+  | Some
+      ( Toml_string _ | Toml_int _ | Toml_float _ | Toml_string_array _ | Toml_array _
+      | Toml_table _ | Toml_inline_table _ | Toml_table_array _ | Toml_offset_datetime _
+      | Toml_local_datetime _ | Toml_local_date _ | Toml_local_time _ )
+  | None -> None
 ;;
 
 let toml_string_list (doc : toml_doc) (key : string) : string list =
   match List.assoc_opt key doc with
   | Some (Toml_string_array xs) -> xs
-  | _ -> []
+  | Some
+      ( Toml_string _ | Toml_int _ | Toml_float _ | Toml_bool _ | Toml_array _
+      | Toml_table _ | Toml_inline_table _ | Toml_table_array _ | Toml_offset_datetime _
+      | Toml_local_datetime _ | Toml_local_date _ | Toml_local_time _ )
+  | None -> []
 ;;
 
 (* ================================================================ *)
@@ -311,7 +331,9 @@ let rec otoml_value_of_toml_value = function
 let render_toml_value = function
   | Toml_table _ | Toml_table_array _ ->
     Error "standard tables and table arrays cannot be rendered as key assignments"
-  | value ->
+  | ( Toml_string _ | Toml_int _ | Toml_float _ | Toml_bool _ | Toml_string_array _
+    | Toml_array _ | Toml_inline_table _ | Toml_offset_datetime _ | Toml_local_datetime _
+    | Toml_local_date _ | Toml_local_time _ ) as value ->
     Result.map
       (fun value -> Otoml.Printer.to_string value |> String.trim)
       (otoml_value_of_toml_value value)

--- a/lib/keeper_toml/keeper_toml_parser.ml
+++ b/lib/keeper_toml/keeper_toml_parser.ml
@@ -38,7 +38,11 @@ let rec toml_value_of_otoml = function
          (fun value strings ->
            match value, strings with
            | Toml_string string, Some strings -> Some (string :: strings)
-           | _, _ -> None)
+           | Toml_string _, None -> None
+           | ( Toml_int _ | Toml_float _ | Toml_bool _ | Toml_string_array _
+             | Toml_array _ | Toml_table _ | Toml_inline_table _ | Toml_table_array _
+             | Toml_offset_datetime _ | Toml_local_datetime _ | Toml_local_date _
+             | Toml_local_time _ ), _ -> None)
          values
          (Some [])
      with

--- a/test/dune
+++ b/test/dune
@@ -1967,6 +1967,8 @@
 
 (include stanzas/test_keeper_toml_loader.inc)
 
+(include stanzas/test_keeper_toml_accessor_matrix.inc)
+
 (include stanzas/test_keeper_runtime_config_leaf.inc)
 
 (include stanzas/test_local_review_script.inc)

--- a/test/stanzas/test_keeper_toml_accessor_matrix.inc
+++ b/test/stanzas/test_keeper_toml_accessor_matrix.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_toml_accessor_matrix)
+ (modules test_keeper_toml_accessor_matrix)
+ (libraries alcotest masc.keeper_toml))

--- a/test/test_keeper_toml_accessor_matrix.ml
+++ b/test/test_keeper_toml_accessor_matrix.ml
@@ -1,0 +1,133 @@
+(** Every typed accessor, against every constructor of [toml_value].
+
+    The accessors used to decide through [| _ -> None] over a closed
+    13-constructor variant, so a new TOML value kind was absorbed silently.
+    They now enumerate the rejected constructors, which makes the compiler
+    refuse to build when the variant grows.
+
+    Writing those or-patterns by hand is the part the compiler cannot check:
+    dropping a constructor from one list only shows up as a non-exhaustive
+    match, but putting a constructor in the wrong accessor's accepting arm
+    compiles fine and changes behaviour. This walks the full matrix so the
+    answer for each (accessor, constructor) pair is pinned. *)
+
+open Alcotest
+
+module L = Keeper_toml_loader
+
+(* One witness per constructor, in the order the type declares them. A
+   constructor added to toml_value belongs here too -- and the count case
+   below fails until it is. *)
+let witnesses : (string * L.toml_value) list =
+  [ "Toml_string", L.Toml_string "s"
+  ; "Toml_int", L.Toml_int 7
+  ; "Toml_float", L.Toml_float 1.5
+  ; "Toml_bool", L.Toml_bool true
+  ; "Toml_string_array", L.Toml_string_array [ "a"; "b" ]
+  ; "Toml_array", L.Toml_array [ L.Toml_int 1 ]
+  ; "Toml_table", L.Toml_table [ "k", L.Toml_int 1 ]
+  ; "Toml_inline_table", L.Toml_inline_table [ "k", L.Toml_int 1 ]
+  ; "Toml_table_array", L.Toml_table_array [ L.Toml_table [] ]
+  ; "Toml_offset_datetime", L.Toml_offset_datetime "1979-05-27T07:32:00Z"
+  ; "Toml_local_datetime", L.Toml_local_datetime "1979-05-27T07:32:00"
+  ; "Toml_local_date", L.Toml_local_date "1979-05-27"
+  ; "Toml_local_time", L.Toml_local_time "07:32:00"
+  ]
+;;
+
+let key = "keeper.value"
+let doc_of value : L.toml_doc = [ key, value ]
+
+(* A matrix over an empty witness list would pass by testing nothing. *)
+let test_every_constructor_has_a_witness () =
+  check int "one witness per toml_value constructor" 13 (List.length witnesses);
+  check bool "names are distinct" true
+    (List.length (List.sort_uniq String.compare (List.map fst witnesses)) = 13)
+;;
+
+(* [accepts] names the constructors the accessor answers for; every other
+   constructor must fall through. *)
+let matrix name ~accepts ~run ~is_reject =
+  List.iter
+    (fun (ctor, value) ->
+      let got = run (doc_of value) in
+      let expected_reject = not (List.mem ctor accepts) in
+      if expected_reject && not (is_reject got)
+      then failf "%s accepted %s; it should only accept %s" name ctor
+             (String.concat ", " accepts)
+      else if (not expected_reject) && is_reject got
+      then failf "%s rejected %s, which it is supposed to accept" name ctor)
+    witnesses
+;;
+
+let test_string_opt () =
+  matrix "toml_string_opt" ~accepts:[ "Toml_string" ]
+    ~run:(fun d -> L.toml_string_opt d key)
+    ~is_reject:(fun r -> r = None);
+  check (option string) "value round-trips" (Some "s")
+    (L.toml_string_opt (doc_of (L.Toml_string "s")) key)
+;;
+
+let test_int_opt () =
+  matrix "toml_int_opt" ~accepts:[ "Toml_int" ]
+    ~run:(fun d -> L.toml_int_opt d key)
+    ~is_reject:(fun r -> r = None);
+  check (option int) "value round-trips" (Some 7)
+    (L.toml_int_opt (doc_of (L.Toml_int 7)) key)
+;;
+
+(* toml_float_opt is the one accessor that accepts two constructors: an int
+   is widened. Losing that arm would be a silent behaviour change. *)
+let test_float_opt () =
+  matrix "toml_float_opt" ~accepts:[ "Toml_float"; "Toml_int" ]
+    ~run:(fun d -> L.toml_float_opt d key)
+    ~is_reject:(fun r -> r = None);
+  check (option (float 0.0001)) "float passes through" (Some 1.5)
+    (L.toml_float_opt (doc_of (L.Toml_float 1.5)) key);
+  check (option (float 0.0001)) "int is widened" (Some 7.0)
+    (L.toml_float_opt (doc_of (L.Toml_int 7)) key)
+;;
+
+let test_bool_opt () =
+  matrix "toml_bool_opt" ~accepts:[ "Toml_bool" ]
+    ~run:(fun d -> L.toml_bool_opt d key)
+    ~is_reject:(fun r -> r = None);
+  check (option bool) "value round-trips" (Some true)
+    (L.toml_bool_opt (doc_of (L.Toml_bool true)) key)
+;;
+
+(* This one rejects with [] rather than None. *)
+let test_string_list () =
+  matrix "toml_string_list" ~accepts:[ "Toml_string_array" ]
+    ~run:(fun d -> L.toml_string_list d key)
+    ~is_reject:(fun r -> r = []);
+  check (list string) "value round-trips" [ "a"; "b" ]
+    (L.toml_string_list (doc_of (L.Toml_string_array [ "a"; "b" ])) key)
+;;
+
+(* A key that is not in the document is the other rejection path, and it
+   shares an arm with the wrong-constructor case. *)
+let test_missing_key () =
+  let empty : L.toml_doc = [] in
+  check (option string) "string" None (L.toml_string_opt empty key);
+  check (option int) "int" None (L.toml_int_opt empty key);
+  check (option (float 0.0001)) "float" None (L.toml_float_opt empty key);
+  check (option bool) "bool" None (L.toml_bool_opt empty key);
+  check (list string) "string list" [] (L.toml_string_list empty key)
+;;
+
+let () =
+  Alcotest.run
+    "Keeper toml accessor matrix"
+    [ ( "witnesses"
+      , [ test_case "cover every constructor" `Quick test_every_constructor_has_a_witness ] )
+    ; ( "accessors"
+      , [ test_case "toml_string_opt" `Quick test_string_opt
+        ; test_case "toml_int_opt" `Quick test_int_opt
+        ; test_case "toml_float_opt" `Quick test_float_opt
+        ; test_case "toml_bool_opt" `Quick test_bool_opt
+        ; test_case "toml_string_list" `Quick test_string_list
+        ; test_case "a missing key" `Quick test_missing_key
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 무엇이 문제였나

`Keeper_toml` 의 타입별 접근자는 닫힌 13-생성자 variant `toml_value` 위에서 catch-all 로 판정한다:

```ocaml
let toml_string_opt (doc : toml_doc) (key : string) : string option =
  match List.assoc_opt key doc with
  | Some (Toml_string s) -> Some s
  | _ -> None
```

TOML 값 종류가 추가되면 이 arm 들이 조용히 흡수한다. CLAUDE.md 가 이름 붙인 FSM Sparse Match 안티패턴이고, RFC-0071 의 (b)-class 다.

## 측정

`toml_value` 에 생성자 하나(`Toml_probe`)를 추가하고 빌드했을 때 `lib/keeper_toml` 안에서 깨지는 사이트:

| | 사이트 |
|---|---|
| 수정 전 | **1** (`otoml_value_of_toml_value` — 원래 exhaustive) |
| 수정 후 | **8** |

7 개가 조용히 흡수하고 있었다. 실제 컴파일러 출력:

```
File "lib/keeper_toml/keeper_toml_loader.ml", lines 20-26:
Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
  Here is an example of a case that is not matched: Some (Toml_probe _)
```

참고로 이 variant 를 소비하는 다른 4 개 모듈은 **이미 명시 열거**한다 — `keeper_types_profile_toml_parser`, `keeper_types_profile_oas_env`, `keeper_runtime_config`, `server_routes_http_routes_sidecar`. 정의를 소유한 라이브러리 자신의 접근자만 예외였다.

## 변경

catch-all 7 개를 or-pattern 명시 열거로 교체. 동작 변화 없음 — 각 접근자는 여전히 자기 타입이 아니면 `None`/`[]` 를 준다. 달라지는 건 새 생성자가 추가될 때 컴파일이 깨진다는 것뿐이다.

- `toml_string_opt` / `toml_int_opt` / `toml_float_opt` / `toml_bool_opt` / `toml_string_list`
- `render_toml_value` 의 `| value ->` fallthrough
- `keeper_toml_parser.ml` 의 문자열 배열 fold (`| _, _ -> None`)

## 남긴 것

`keeper_toml_parser.ml` 의 두 사이트는 **`Otoml.t`** 위의 매치다 (`flatten_table`, `parse_string`). 외부 라이브러리 variant 를 열거하면 의존성 마이너 업데이트에 깨지므로 손대지 않았다. RFC-0071 은 이 부류를 (a)-class 로 분류한다.

그래서 이 PR 은 `lib/keeper_toml/dune` 에 `-w +4` 를 켜지 **않는다**. 켜려면 저 두 사이트에 arm 수준 `[@warning "-4"]` 를 붙여야 하는데, 그건 별도 판단이다. 명시 열거만으로도 warning 8 (partial-match) 이 새 생성자를 잡으므로 목적은 달성된다.

## 테스트

컴파일러는 or-pattern 이 exhaustive 한지는 보지만, **각 생성자가 올바른 접근자의 수용 arm 에 들어갔는지는 보지 않는다**. 하나를 옮겨도 컴파일은 통과하고 동작만 바뀐다. 그래서 5x13 행렬 전수를 핀으로 박았다 (`test/test_keeper_toml_accessor_matrix.ml`).

- 접근자별 수용 생성자 집합, 나머지 전부의 거부
- `toml_float_opt` 만 하는 int → float 확장
- `toml_string_list` 만 쓰는 `[]` 거부 (다른 넷은 `None`)
- 키 부재 경로 (잘못된 생성자와 arm 을 공유한다)
- witness 목록이 13 개 전부를 덮는지 (빈 행렬이 통과하는 것을 막는다)

오배치를 실제로 잡는지 확인: `toml_float_opt` 에서 `Toml_int` arm 을 빼면
`toml_float_opt rejected Toml_int, which it is supposed to accept` 로 실패한다.

## 검증

- `dune build --root . @check` — EXIT=0
- 위 표의 1 → 8 측정 (생성자 주입 후 빌드, 양방향)
- 신규 테스트 7 케이스 통과
- `scripts/check-doc-code-refs.sh` — EXIT=0

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
