### PR TITLE
refactor(config): 삭제 대상을 정하는 보존 기본값이 세 곳에 흩어져 있던 것을 getter 하나로

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1049,6 +1049,18 @@ jobs:
           opam exec -- dune build --root . \
             @test/runtest-test_env_snapshot_reports_applied_default
 
+      - name: Run JSONL retention getter contract suite
+        # Pins the digest fallback contract: the getter must report a
+        # non-positive override as-is (that's how "pruning disabled" reaches
+        # the caller) while the exported default stays positive (the bound a
+        # caller substitutes instead). @check compiles this but does not run
+        # it, and the PR that introduced the getter tripped this exact
+        # failure mode once -- the getter silently swallowed the override and
+        # returned the default instead.
+        run: |
+          opam exec -- dune build --root . \
+            @test/runtest-test_jsonl_retention_window
+
       - name: Run keeper lane launch-order AST suite
         # Asserts on lib/keeper sources through Ast_grep, so @check cannot run
         # it. It sat outside every target list while one of its counts was

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,11 +14,11 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 204 unique knobs across 8 modules.
+**Total**: 205 unique knobs across 8 modules.
 
-**Typed getter classification**: 37/116 tagged (`operator`: 37, `algorithm`: 0, `unclassified`: 79).
+**Typed getter classification**: 38/117 tagged (`operator`: 38, `algorithm`: 0, `unclassified`: 79).
 
-## Env_config_core (23 knobs; typed classification 2/5)
+## Env_config_core (24 knobs; typed classification 3/6)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
@@ -36,6 +36,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_HOST_FD_PRESSURE_STATE_FILE` | string_literal | n/a | n/a | 332 | {1 Host pressure integration} |
 | `MASC_HTTP_BASE_URL` | string_literal | n/a | n/a | 290 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 | `MASC_HTTP_PORT` | string_literal | n/a | n/a | 249 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
+| `MASC_JSONL_RETENTION_DAYS` | typed:int | Policies | operator | 579 | Day-file retention for the JSONL stores under [.masc]. Default: 30. Read by the startup prune, the periodic maintenan... |
 | `MASC_LOG_LEVEL` | string_literal | n/a | n/a | 539 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_LOG_ROUTINE_LEVEL` | string_literal | n/a | n/a | 540 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_ORCHESTRATOR_ENABLED` | string_literal | n/a | n/a | 490 | SSOT for the MASC_ORCHESTRATOR_ENABLED env-var name (issue 8352). Referenced by feature_flag_registry catalog, env_co... |

--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -565,4 +565,17 @@ let build_git_commit_opt () =
 let pubsub_max_messages () =
   get_int ~default:1000 "MASC_PUBSUB_MAX_MESSAGES"
 
+(** Day-file retention for the JSONL stores under [.masc]. Default: 30.
+
+    Read by the startup prune, the periodic maintenance prune, and the
+    catch-up digest's look-back clamp. Those three decide which day files
+    are deleted and how far a digest may scan; a default that differed
+    between them would delete data one of them still expects to read.
+
+    @category Policies @ops_class operator *)
+let default_jsonl_retention_days = 30
+
+let jsonl_retention_days () =
+  get_int ~default:default_jsonl_retention_days "MASC_JSONL_RETENTION_DAYS"
+
 (** {1 Keeper Defaults} *)

--- a/lib/config/env_config_core.mli
+++ b/lib/config/env_config_core.mli
@@ -48,6 +48,17 @@ val get_int_nonneg : default:int -> string -> int
     [int] does not exist, so the only extra rejection vs {!get_int}
     is [v < 0]. *)
 
+val default_jsonl_retention_days : int
+(** The value {!jsonl_retention_days} falls back to.  Exposed because a
+    caller that treats a non-positive override as "pruning disabled" needs
+    a positive bound of its own, and re-reading the getter would hand back
+    the same non-positive value. *)
+
+val jsonl_retention_days : unit -> int
+(** [MASC_JSONL_RETENTION_DAYS], default 30.  Day-file retention for the
+    JSONL stores under [.masc], shared by the startup prune, the periodic
+    maintenance prune, and the catch-up digest look-back clamp. *)
+
 val get_float_nonneg : default:float -> string -> float
 (** Like {!get_float} but floors all non-finite (NaN, +∞, -∞) and
     negative parses at [default].  Use for env vars whose call

--- a/lib/keeper_catchup_digest.ml
+++ b/lib/keeper_catchup_digest.ml
@@ -8,20 +8,14 @@ let digest_items_cap = 20
    payload out without limit; the digest reports at most this many failures. *)
 let read_errors_cap = 50
 
-let jsonl_retention_env = "MASC_JSONL_RETENTION_DAYS"
-let default_jsonl_retention_days = 30
-
-(* Retention SSOT is MASC_JSONL_RETENTION_DAYS, read the same way as startup
-   and periodic pruning. The digest still uses the default when pruning is
-   disabled with a non-positive value; otherwise an old cursor could trigger
-   an unbounded synchronous scan from a dashboard read. *)
+(* Retention SSOT is [Env_config_core.jsonl_retention_days], the same
+   getter the startup and periodic prunes call. The digest still falls back
+   to the default when pruning is disabled with a non-positive value;
+   otherwise an old cursor could trigger an unbounded synchronous scan from
+   a dashboard read. *)
 let jsonl_retention_scan_days () =
-  let days =
-    Safe_ops.get_env_int_logged
-      jsonl_retention_env
-      ~default:default_jsonl_retention_days
-  in
-  if days > 0 then days else default_jsonl_retention_days
+  let days = Env_config_core.jsonl_retention_days () in
+  if days > 0 then days else Env_config_core.default_jsonl_retention_days
 ;;
 
 (* Termination guard for the backward chat paging loop: each page walks at

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -648,7 +648,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
            last_prune := now;
            try
              let days =
-               Safe_ops.get_env_int_logged "MASC_JSONL_RETENTION_DAYS" ~default:30
+               Env_config_core.jsonl_retention_days ()
              in
              let masc = Workspace.masc_dir (Mcp_server.workspace_config state) in
              let prune_dir dir =

--- a/lib/server/server_runtime_startup_maintenance.ml
+++ b/lib/server/server_runtime_startup_maintenance.ml
@@ -161,7 +161,7 @@ let prune_shared_jsonl_stores ~prune_dir ~days ~masc_root =
 let startup_prune_jsonl (state : Mcp_server.server_state) =
   (try
      let days =
-       Safe_ops.get_env_int_logged "MASC_JSONL_RETENTION_DAYS" ~default:30
+       Env_config_core.jsonl_retention_days ()
      in
      let masc = Workspace.masc_dir (Mcp_server.workspace_config state) in
      let prune_dir dir =

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -88,7 +88,7 @@ echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, al
 # authority tools, memory journal) without lowering the baseline. A PR that
 # wires a suite must lower this number in the same PR, or this check goes red
 # for everyone.
-UNWIRED_BASELINE=734
+UNWIRED_BASELINE=733
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/test/dune
+++ b/test/dune
@@ -1647,6 +1647,7 @@
 
 (include stanzas/test_anti_rationalization_empty_reject.inc)
 (include stanzas/test_dedup_rules.inc)
+(include stanzas/test_jsonl_retention_window.inc)
 (include stanzas/test_trailing_slash_rules.inc)
 (include stanzas/test_repos_relative_path.inc)
 (include stanzas/test_metric_zero_cell_declaration.inc)

--- a/test/stanzas/test_jsonl_retention_window.inc
+++ b/test/stanzas/test_jsonl_retention_window.inc
@@ -1,0 +1,6 @@
+; Per-file dune stanza for the JSONL retention-window suite.
+
+(test
+ (name test_jsonl_retention_window)
+ (modules test_jsonl_retention_window)
+ (libraries alcotest masc_test_deps))

--- a/test/test_jsonl_retention_window.ml
+++ b/test/test_jsonl_retention_window.ml
@@ -1,0 +1,76 @@
+(** One retention window decides which JSONL day files get deleted.
+
+    Three readers act on it: the startup prune, the periodic maintenance
+    prune, and the catch-up digest's look-back clamp. They used to spell
+    [MASC_JSONL_RETENTION_DAYS] and its default separately, so a default
+    changed in one place would have let one prune delete files another
+    still expected to read.
+
+    They now share {!Env_config_core.jsonl_retention_days}. What this
+    suite pins is the pair of properties the digest's fallback depends
+    on: the getter reports a non-positive override verbatim (that is how
+    "pruning disabled" reaches a caller), and the exported default is
+    positive (that is what the digest clamps its scan to instead). *)
+
+open Alcotest
+
+let env_name = "MASC_JSONL_RETENTION_DAYS"
+
+let with_env value f =
+  let prev = Sys.getenv_opt env_name in
+  (match value with Some v -> Unix.putenv env_name v | None -> Unix.putenv env_name "");
+  Fun.protect
+    ~finally:(fun () ->
+      match prev with Some v -> Unix.putenv env_name v | None -> Unix.putenv env_name "")
+    f
+
+let test_unset_yields_the_exported_default () =
+  with_env None @@ fun () ->
+  check int "unset falls back to the exported default"
+    Env_config_core.default_jsonl_retention_days
+    (Env_config_core.jsonl_retention_days ())
+
+let test_override_is_honoured () =
+  with_env (Some "7") @@ fun () ->
+  check int "override wins" 7 (Env_config_core.jsonl_retention_days ())
+
+(* The digest reads a non-positive value as "pruning disabled" and then
+   substitutes the default. That only works if the getter passes the
+   non-positive value through rather than swallowing it. *)
+let test_non_positive_override_reaches_the_caller () =
+  with_env (Some "0") @@ fun () ->
+  check int "zero is reported, not replaced" 0 (Env_config_core.jsonl_retention_days ());
+  with_env (Some "-1") @@ fun () ->
+  check int "negative is reported, not replaced" (-1)
+    (Env_config_core.jsonl_retention_days ())
+
+(* ... and only if the default the caller substitutes is itself usable as
+   a scan bound. A non-positive default would make the digest's fallback
+   loop back to "disabled" and scan without limit. *)
+let test_exported_default_is_a_usable_bound () =
+  check bool "default is positive" true
+    (Env_config_core.default_jsonl_retention_days > 0)
+
+(* Malformed input is not an override. *)
+let test_unparseable_falls_back () =
+  with_env (Some "thirty") @@ fun () ->
+  check int "non-numeric falls back to the default"
+    Env_config_core.default_jsonl_retention_days
+    (Env_config_core.jsonl_retention_days ())
+
+let () =
+  run
+    "jsonl_retention_window"
+    [ ( "getter"
+      , [ test_case "unset yields the exported default" `Quick
+            test_unset_yields_the_exported_default
+        ; test_case "override is honoured" `Quick test_override_is_honoured
+        ; test_case "non-positive reaches the caller" `Quick
+            test_non_positive_override_reaches_the_caller
+        ; test_case "unparseable falls back" `Quick test_unparseable_falls_back
+        ] )
+    ; ( "default"
+      , [ test_case "is a usable scan bound" `Quick
+            test_exported_default_is_a_usable_bound
+        ] )
+    ]


### PR DESCRIPTION
## 문제

`MASC_JSONL_RETENTION_DAYS` 는 어떤 day-file 을 **디스크에서 지울지** 정하는 값이다. 세 곳이 각자 읽었고, 그중 둘은 이름과 기본값을 리터럴로 적었다.

```
server_bootstrap_maintenance.ml:651   Safe_ops.get_env_int_logged "MASC_JSONL_RETENTION_DAYS" ~default:30
server_runtime_startup_maintenance.ml:164  (같은 줄)
keeper_catchup_digest.ml:11-12        let jsonl_retention_env = "..." / let default_jsonl_retention_days = 30
```

세 번째가 자기 주석에 이렇게 적어뒀다:

> Retention SSOT is MASC_JSONL_RETENTION_DAYS, **read the same way as startup and periodic pruning.**

그런데 그 상수들은 `.mli` 에 없는 **private** 이고, 지목된 두 곳은 이 모듈을 참조조차 하지 않는다. **SSOT 선언은 있고 강제는 없었다.**

기본값이 한쪽에서만 바뀌면 startup prune 과 periodic prune 이 서로 다른 보존 창으로 파일을 지운다.

## 변경

`Env_config_core` 에 getter 하나를 두고 셋이 그걸 부른다.

```ocaml
let default_jsonl_retention_days = 30

let jsonl_retention_days () =
  get_int ~default:default_jsonl_retention_days "MASC_JSONL_RETENTION_DAYS"
```

`Env_config_core` 를 고른 이유: 세 모듈 모두 도달 가능하고, 역참조가 없어 순환이 생기지 않는다 (확인함).

기본값 상수도 함께 노출한다. catch-up digest 가 "비양수 override = pruning 비활성" 을 만났을 때 **자기 스캔 상한으로 쓸 양수**가 필요한데, getter 를 다시 부르면 같은 비양수가 돌아오기 때문이다. `.mli` 에 그 이유를 적었다.

## 중간에 넣었다가 잡은 버그

처음엔 digest 의 fallback 을 이렇게 썼다:

```ocaml
if days > 0 then days else Env_config_core.jsonl_retention_days ()   (* 틀림 *)
```

같은 함수를 다시 부르므로 비양수가 그대로 나온다. 원본은 기본값 30 으로 떨어졌다. 컴파일은 통과했고 동작만 달라지는 변경이었다. 기본값 상수를 노출해 고쳤다.

## 부수 효과 — 카탈로그에 등재된다

이 knob 은 `docs/runtime-tunables.md` 에 **없었다.** 생성기가 `lib/config/env_config_*.ml` 만 스캔하는데, 세 read 지점이 전부 그 밖에 있었기 때문이다.

`Env_config_core` 로 옮기면서 자동으로 잡힌다:

```
$ ./_build/default/bin/env_knob_catalog.exe docs/runtime-tunables.md
wrote docs/runtime-tunables.md (entries=205 files=10)   ← 204 였다

| `MASC_JSONL_RETENTION_DAYS` | typed:int | ... | 564 | Day-file retention ... Default: 30. |
```

#27086 이 세어둔 **미문서화 21개 중 하나**가 줄었다.

## 검증

- `dune build @check` EXIT=0
- `env_knob_catalog` 재생성 → entries 204 → 205, 해당 knob 등재 확인
- `check-boundary-guard.sh` RC=0
- `test_keeper_catchup_digest` 1건 실패 — **main 베이스라인도 동일하게 1건 실패한다** (`ASSERT coverage.chat lower_bound false`, keeper meta 픽스처가 필수 필드를 못 채워 나는 실패로 이 PR 과 무관)

동작 변경 없음. 세 지점이 읽는 값과 fallback 이 이전과 같다.

## 확인하고 대상이 아니라고 판정한 것

같은 스윕에서 본 것들:

- `lib/` 의 `failwith` 23건, `List.hd`/`Option.get` 1건 — 부분 함수 규율이 잡혀 있다
- `assert (…)` 123건 중 대부분이 `lib/exec/test/` — 그 디렉터리는 `(include_subdirs no)` 를 가진 별도 내부 라이브러리의 자체 `(tests)` 타겟이라 프로덕션에 안 들어간다
- `env_config_snapshot.ml` 의 선언 기본값 vs 실제 코드 기본값 — `MASC_TELEMETRY_RETENTION_DAYS`(30), `MASC_TELEMETRY_MAX_BYTES`(52428800), `MASC_RATE_LIMIT`(100.0) 표본 3개 전부 일치, 드리프트 없음
- `activity_graph.ml:363` 의 "the existing 24h [MASC_JSONL_RETENTION_DAYS]" — 모순처럼 보이지만 "24h" 는 **스윕 주기**이고 같은 문장에 "default 30 days" 가 따로 있다. 그 주석은 오히려 이 안티패턴("Scattered Hardcoded Defaults")을 명시적으로 인용하며 새 상수를 만들지 않은 이유를 적어뒀다
