### PR TITLE
fix(dashboard): findBy* 폴링 예산을 스위트 실행 환경에 맞춘다 (결정론적 실패 1건 제거)

### DIFF
--- a/dashboard/vitest-setup.ts
+++ b/dashboard/vitest-setup.ts
@@ -1,6 +1,15 @@
 import { expect, vi } from 'vitest'
 import { html } from 'htm/preact'
+import { configure } from '@testing-library/preact'
 import { toHaveNoViolations } from 'jest-axe'
+
+// testing-library polls findBy*/waitFor for 1000ms by default, a budget that
+// assumes the render has the machine to itself. Bisecting keeper-detail's
+// failure showed a count threshold, not a poisoning file: every 44-file subset
+// passed (taken from either end, so no file in the remainder is the cause) and
+// the 48-file set failed. Vitest's own per-test limit stays at its 5s default;
+// this raises only the poll budget.
+configure({ asyncUtilTimeout: 5000 })
 
 // Wire jest-axe's `toHaveNoViolations` matcher into Vitest's `expect`.
 // Lets `*.a11y.test.ts` files call `expect(await axe(node)).toHaveNoViolations()`.


### PR DESCRIPTION
## 무엇

`dashboard/vitest-setup.ts` 에 `configure({ asyncUtilTimeout: 5000 })` 를 추가한다.

testing-library 의 `findBy*` / `waitFor` 는 기본 **1000ms** 폴링이고, vitest 의 `testTimeout`(기본 5s) 과 별개다. 이 PR 은 폴링 예산만 올린다.

## 왜 — 이분 탐색 결과

`keeper-detail.test.ts > renders a live keeper detail route without tripping the monitoring error boundary` 가 전체 스위트에서 **5/5 실패**, 격리에서 **18/18 통과** 였다 (`#27106`).

재현 집합을 좁혔다:

```
전체 632 파일         실패
src/components 436    실패
src/components/k* 48  실패   ← 최소 재현
```

48 개 안에서 갈랐다:

```
head -24 + keeper-detail   통과
tail -24 + keeper-detail   통과
head -32 + keeper-detail   통과
head -40 + keeper-detail   통과
head -44 + keeper-detail   통과
tail -44 + keeper-detail   통과      ← 45~48 을 포함하는데도 통과
전체 48                    실패
```

**특정 파일이 원인이면 어느 쪽 44 에든 그 파일이 들어가는 조합이 있고 실패해야 한다.** 양 끝에서 잡은 44 가 둘 다 통과하고 48 만 실패하므로, 남는 설명은 **파일 개수**다. 44~48 사이에 임계가 있다.

즉 앞선 파일들이 남긴 상태가 아니라, 누적된 실행 부하에서 렌더 체인이 1 초 폴링 예산을 넘는다. `--no-file-parallelism` 직렬 실행에서도 재현되므로 병렬성 자체가 아니라 누적이다.

## 검증

수정 전 5 회 / 수정 후 3 회, 같은 명령:

```
수정 전                      수정 후
keeper-detail    5/5 실패     0/3
chat/primitives  2/5          1/3
auth-status      0/5          1/3
```

수정 후 run1 은 `Tests 8786 passed` — 전체 통과.

## 남는 것 — 이 PR 이 고치지 않는다

`chat/primitives` 와 `auth-status` 가 여전히 실행마다 0~1 건 흔들린다. 이 PR 이 제거하는 것은 **결정론적 실패 1 건**이고, 잔여 flake 는 별개 문제로 `#27106` 에 남는다. 표본이 3 회라 잔여 flake 의 성격(같은 임계인지 다른 원인인지)은 아직 확정하지 못했다.

## 왜 타임아웃을 올리는 것이 증상 억제가 아닌가

억제되는 프로덕션 결함이 없다. 폴링 예산은 테스트 하네스가 자기 실행 환경에 대해 갖는 인내심이고, 이 스위트는 632 파일을 한 프로세스에서 돌린다. 1 초 기본값은 렌더가 머신을 독점한다는 가정이며 이 스위트에는 맞지 않는다.

다만 정직하게: 이 값이 실제 렌더 지연을 가린다면 더 큰 임계에서 같은 실패가 돌아온다. 그때는 값을 다시 올리는 대신 스위트 분할이나 동시성 축소를 봐야 한다.

관련: #27106
