### PR TITLE
fix(schedule): make the status transitions exhaustive and join the ratchet

### DIFF
--- a/lib/schedule/dune
+++ b/lib/schedule/dune
@@ -16,6 +16,8 @@
   schedule_service
   schedule_runner
   schedule_runner_status)
+ (flags
+  (:standard -w +4 -w +32))
  (libraries
   digestif
   masc_workspace

--- a/lib/schedule/schedule_domain.ml
+++ b/lib/schedule/schedule_domain.ml
@@ -835,5 +835,9 @@ let mark_due ~now (request : schedule_request) =
   | Scheduled | Due when expired_at ~now request ->
     { request with status = Expired }
   | Scheduled when request.due_at <= now -> { request with status = Due }
-  | _ -> request
+  (* Not yet due, or already Due and not yet expired. *)
+  | Scheduled | Due -> request
+  (* Running is the executor's to move; the four terminal states never
+     transition again. *)
+  | Running | Succeeded | Failed | Cancelled | Expired -> request
 ;;

--- a/lib/schedule/schedule_store.ml
+++ b/lib/schedule/schedule_store.ml
@@ -394,7 +394,7 @@ let validate_initial_request (request : Schedule_domain.schedule_request) =
   else
     match request.status with
     | Scheduled -> Ok ()
-    | _ ->
+    | Due | Running | Succeeded | Failed | Cancelled | Expired ->
       Error
         (Invalid_initial_status
            "new requests must start scheduled")
@@ -566,7 +566,9 @@ let cancel_matching config ~should_cancel =
              (Printf.sprintf
                 "cannot cancel running schedule %s while retiring its consumer"
                 request.schedule_id))
-      | request :: rest -> cancel (request :: schedules) changed rest
+      (* Already terminal: nothing to cancel, and no error to raise. *)
+      | ({ status = Succeeded | Failed | Cancelled | Expired; _ } as request) :: rest ->
+        cancel (request :: schedules) changed rest
     in
     let* schedules, changed = cancel [] false state.schedules in
     if changed

--- a/test/test_schedule_domain.ml
+++ b/test/test_schedule_domain.ml
@@ -286,6 +286,66 @@ let test_wake_record_roundtrip () =
       decoded.payload_digest
 ;;
 
+
+(* {1 mark_due transition matrix}
+
+   [mark_due] decided the pass-through case with [| _ -> request], so a new
+   schedule_status silently stayed put -- the FSM Sparse Match shape from
+   CLAUDE.md. It now enumerates, and these cases pin what each status does
+   under the three inputs the guards distinguish. Iterating
+   [all_schedule_statuses] means a new status joins the matrix on its own. *)
+
+let with_status status (request : schedule_request) = { request with status }
+
+let mark_due_matrix ~label ~now ~expires_at ~expected =
+  List.iter
+    (fun status ->
+      let before = with_status status (request ?expires_at ()) in
+      let after = mark_due ~now before in
+      check_status
+        (Printf.sprintf "%s: %s" label (schedule_status_to_string status))
+        (expected status)
+        after.status)
+    all_schedule_statuses
+;;
+
+(* A matrix over an empty status list would pass by testing nothing. *)
+let test_all_statuses_is_populated () =
+  check int "every schedule_status is in all_schedule_statuses" 7
+    (List.length all_schedule_statuses)
+;;
+
+(* Expiry wins over becoming due: now is past both due_at and expires_at. *)
+let test_mark_due_expiry_precedes_due () =
+  mark_due_matrix ~label:"expired" ~now:300.0 ~expires_at:(Some 150.0)
+    ~expected:(function
+      | Scheduled | Due -> Expired
+      | (Running | Succeeded | Failed | Cancelled | Expired) as s -> s)
+;;
+
+(* Past due_at, no expiry: only Scheduled advances. *)
+let test_mark_due_advances_scheduled_only () =
+  mark_due_matrix ~label:"due" ~now:250.0 ~expires_at:None
+    ~expected:(function
+      | Scheduled -> Due
+      | (Due | Running | Succeeded | Failed | Cancelled | Expired) as s -> s)
+;;
+
+(* Before due_at: nothing moves. *)
+let test_mark_due_leaves_early_requests_alone () =
+  mark_due_matrix ~label:"not yet due" ~now:150.0 ~expires_at:None
+    ~expected:(fun s -> s)
+;;
+
+(* The record is returned untouched for pass-through statuses. *)
+let test_mark_due_preserves_other_fields () =
+  let before = with_status Running (request ~expires_at:150.0 ()) in
+  let after = mark_due ~now:300.0 before in
+  check string "schedule instance id" before.schedule_instance_id
+    after.schedule_instance_id;
+  check (float 0.0001) "due_at" before.due_at after.due_at
+;;
+
 let () =
   run "Schedule_domain"
     [
@@ -319,6 +379,19 @@ let () =
             test_cron_recurrence_finds_occurrence_beyond_five_years;
           test_case "cron recurrence rejects impossible calendar date" `Quick
             test_cron_recurrence_rejects_impossible_calendar_date;
+        ] );
+      ( "mark_due",
+        [
+          test_case "all_schedule_statuses is populated" `Quick
+            test_all_statuses_is_populated;
+          test_case "expiry precedes becoming due" `Quick
+            test_mark_due_expiry_precedes_due;
+          test_case "only Scheduled advances to Due" `Quick
+            test_mark_due_advances_scheduled_only;
+          test_case "requests before due_at are untouched" `Quick
+            test_mark_due_leaves_early_requests_alone;
+          test_case "pass-through preserves other fields" `Quick
+            test_mark_due_preserves_other_fields;
         ] );
       ( "codec",
         [


### PR DESCRIPTION
## 무엇이 문제였나

`lib/schedule` 은 7-생성자 `schedule_status` 위에서 세 곳이 catch-all 로 판정했다. 그 중 하나는 **FSM 전이 자체**다:

```ocaml
let mark_due ~now (request : schedule_request) =
  match request.status with
  | Scheduled | Due when expired_at ~now request -> { request with status = Expired }
  | Scheduled when request.due_at <= now -> { request with status = Due }
  | _ -> request
```

상태가 추가되면 조용히 제자리에 머문다. CLAUDE.md §"AI 코드 생성 안티패턴 #4" 가 지목한 FSM Sparse Match 이고, 거기 인용된 사고(keeper_registry `validate_decision_transition` 런타임 `Assert_failure`, 2026-05-08)와 같은 모양이다.

## 측정

`schedule_status` 에 생성자 하나를 추가하고 빌드했을 때 `lib/schedule` 안에서 깨지는 사이트:

| | 사이트 |
|---|---|
| 수정 전 | **6** |
| 수정 후 | **9** |

새로 잡히는 3 개가 정확히 이 PR 이 고친 곳이다:

- `schedule_domain.ml` `mark_due` — 전이
- `schedule_store.ml` 초기 상태 가드 (`| _ -> Error "new requests must start scheduled"`)
- `schedule_store.ml` cancel 루프의 말단 상태 pass-through

이 variant 는 이미 나머지 6 곳과 외부 3 개 모듈(`tool_schedule`, `keeper_world_observation`, `server_keeper_waiting_inventory`)에서 **명시 열거**되고 있었다. 이 3 개가 예외였다.

## 변경

- 세 catch-all 을 생성자 명시 열거로 교체. 동작 변화 없음.
- `lib/schedule/dune` 에 `(:standard -w +4 -w +32)` 추가 — 이제 이 라이브러리는 warning 4 래칫에 들어간다 (기존 ~50 개 서브 라이브러리와 같은 값).

`mark_due` 는 `when` 가드를 쓰므로 가드 없는 arm 이 모든 생성자를 덮어야 exhaustive 가 된다. 그래서 "아직 due 가 아니거나 이미 Due" 와 "Running + 말단 4 상태" 를 나눠 적었다 — 둘 다 결과는 pass-through 지만 이유가 다르다.

## 테스트

컴파일러는 열거가 exhaustive 한지는 보지만 **각 상태가 올바른 arm 에 들어갔는지는 안 본다**. `mark_due` 의 전이 행렬을 `all_schedule_statuses` 순회로 핀으로 박았다 (`test/test_schedule_domain.ml`, 신규 5 케이스):

- 만료가 due 승격보다 우선하는지 (now 가 `due_at` 과 `expires_at` 을 둘 다 지난 경우)
- `due_at` 을 지났고 만료는 없을 때 `Scheduled` 만 `Due` 로 가는지
- `due_at` 이전에는 아무것도 안 움직이는지
- pass-through 가 다른 필드를 보존하는지
- `all_schedule_statuses` 가 7 개를 다 담는지 (빈 행렬이 통과하는 것을 막는다)

`all_schedule_statuses` 를 순회하므로 상태가 추가되면 행렬이 자동으로 커진다.

전이 변경을 실제로 잡는지 확인: 만료 arm 에서 `Due` 를 빼면
`FAIL expired: due — Expected: "expired", Received: "due"` 로 실패한다.

## 검증

- `dune build --root . @check` — EXIT=0 (래칫 켠 상태)
- 위 표의 6 → 9 측정 (생성자 주입 후 빌드, 양방향)
- `test_schedule_domain.exe` — 24 케이스 통과
- `scripts/check-doc-code-refs.sh` — EXIT=0

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
