### PR TITLE
fix(keeper-registry): enumerate the events with no TLA+ precondition

### DIFF
--- a/lib/keeper_registry/keeper_state_machine.ml
+++ b/lib/keeper_registry/keeper_state_machine.ml
@@ -352,8 +352,8 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
        exclusivity).  Operator_clear_requested is deliberately *not*
        arm-enforced beyond the terminal guard — see its arm below for
        the operator escape-hatch rationale.
-   Other events have no spec preconditions beyond NotTerminal and
-   fall through the catch-all.  The overflow-lifecycle preconditions
+   Other events have no spec preconditions beyond NotTerminal and are
+   listed explicitly in the final arm.  The overflow-lifecycle preconditions
    (Context_overflow_detected, Auto_compact_triggered) were retired with
    their events (#26546).
 
@@ -406,13 +406,37 @@ let check_event_precondition (c : conditions) (ev : event)
        to make the deliberate minimal precondition explicit — adding any
        check beyond NotTerminal would weaken the operator escape-hatch. *)
     Ok ()
-  (* Other events have no TLA+ state preconditions beyond what
+  (* The remaining events have no TLA+ state preconditions beyond what
      [apply_event]'s terminal guard already enforces; their semantics
      are encoded in [update_conditions] + [derive_phase] (e.g.
      [Heartbeat_failed] always flips [heartbeat_healthy] to false
-     regardless of prior state).  Adding speculative arms here would
-     drift from the spec. *)
-  | _ -> Ok ()
+     regardless of prior state).  Adding speculative checks here would
+     drift from the spec.
+
+     They are listed rather than caught by [| _ ->] so that adding an
+     event forces this decision to be made once, in this arm, instead of
+     inheriting Ok () silently.  Listing is not a check: the answer for
+     every event below is still "no precondition". *)
+  | Heartbeat_ok
+  | Heartbeat_failed _
+  | Turn_succeeded
+  | Turn_failed _
+  | Context_measured _
+  | Compaction_started
+  | Compaction_completed
+  | Compaction_failed _
+  | Handoff_started
+  | Handoff_completed _
+  | Handoff_failed _
+  | Operator_pause
+  | Operator_resume
+  | Operator_stop _
+  | Stop_requested
+  | Drain_complete
+  | Fiber_started
+  | Fiber_terminated _
+  | Supervisor_restart_attempt _
+  | Credential_archived -> Ok ()
 ;;
 
 (* ── apply_event ───────────────────────────────────────── *)

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -2223,6 +2223,18 @@ let () =
         ] )
     ; ( "precondition_layer"
       , [ test_case
+            "every event constructor has a witness"
+            `Quick
+            KSP.test_event_witnesses_cover_the_variant
+        ; test_case
+            "no precondition fires from healthy Running"
+            `Quick
+            KSP.test_no_precondition_fires_from_healthy_running
+        ; test_case
+            "only Operator_compact_requested reacts to buffer-op flags"
+            `Quick
+            KSP.test_only_operator_compact_reacts_to_buffer_flags
+        ; test_case
             "Operator_compact_requested requires ~compaction_active"
             `Quick
             KSP.test_pre_operator_compact_during_compaction

--- a/test/test_keeper_state_machine_preconditions.ml
+++ b/test/test_keeper_state_machine_preconditions.ml
@@ -34,6 +34,119 @@ let apply_err ~current_phase ~conditions ~event =
   | Error e -> e
 ;;
 
+
+(* ── Event precondition coverage ───────────────────────── *)
+
+(* [check_event_precondition] used to end in [| _ -> Ok ()], so an event
+   added to the variant inherited "no precondition" without anyone
+   deciding that. It now enumerates, and a new constructor breaks that
+   match.
+
+   This [event_tag] match is exhaustive for the same reason: it makes a new
+   constructor break this file too, so [all_events] below cannot quietly
+   fall behind the type it is supposed to cover. *)
+let event_tag : SM.event -> string = function
+  | SM.Heartbeat_ok -> "heartbeat_ok"
+  | SM.Heartbeat_failed _ -> "heartbeat_failed"
+  | SM.Turn_succeeded -> "turn_succeeded"
+  | SM.Turn_failed _ -> "turn_failed"
+  | SM.Context_measured _ -> "context_measured"
+  | SM.Compaction_started -> "compaction_started"
+  | SM.Compaction_completed -> "compaction_completed"
+  | SM.Compaction_failed _ -> "compaction_failed"
+  | SM.Handoff_started -> "handoff_started"
+  | SM.Handoff_completed _ -> "handoff_completed"
+  | SM.Handoff_failed _ -> "handoff_failed"
+  | SM.Operator_pause -> "operator_pause"
+  | SM.Operator_resume -> "operator_resume"
+  | SM.Operator_stop _ -> "operator_stop"
+  | SM.Stop_requested -> "stop_requested"
+  | SM.Drain_complete -> "drain_complete"
+  | SM.Fiber_started -> "fiber_started"
+  | SM.Fiber_terminated _ -> "fiber_terminated"
+  | SM.Supervisor_restart_attempt _ -> "supervisor_restart_attempt"
+  | SM.Credential_archived -> "credential_archived"
+  | SM.Operator_compact_requested -> "operator_compact_requested"
+  | SM.Operator_clear_requested _ -> "operator_clear_requested"
+;;
+
+let all_events : SM.event list =
+  [ SM.Heartbeat_ok
+  ; SM.Heartbeat_failed { consecutive = 1 }
+  ; SM.Turn_succeeded
+  ; SM.Turn_failed { consecutive = 1 }
+  ; SM.Context_measured
+      { context_ratio = 0.1
+      ; message_count = 1
+      ; token_count = 1
+      ; context_actions = { SM.compact = false; handoff = false }
+      }
+  ; SM.Compaction_started
+  ; SM.Compaction_completed
+  ; SM.Compaction_failed { reason = "probe" }
+  ; SM.Handoff_started
+  ; SM.Handoff_completed { new_trace_id = "trace"; generation = 1 }
+  ; SM.Handoff_failed { reason = "probe" }
+  ; SM.Operator_pause
+  ; SM.Operator_resume
+  ; SM.Operator_stop { remove_meta = false }
+  ; SM.Stop_requested
+  ; SM.Drain_complete
+  ; SM.Fiber_started
+  ; SM.Fiber_terminated
+      { outcome = "ok"; provider_id = None; http_status = None }
+  ; SM.Supervisor_restart_attempt { attempt = 1 }
+  ; SM.Credential_archived
+  ; SM.Operator_compact_requested
+  ; SM.Operator_clear_requested { preserve_system = true; reason = "probe" }
+  ]
+;;
+
+(* A coverage list shorter than the variant would silently test less. *)
+let test_event_witnesses_cover_the_variant () =
+  check int "one witness per event constructor" 22 (List.length all_events);
+  check int "witness tags are distinct" 22
+    (List.length (List.sort_uniq String.compare (List.map event_tag all_events)))
+;;
+
+let precondition_reason ~conditions event =
+  match SM.apply_event ~current_phase:SM.Running ~conditions ~event ~now:1000.0 with
+  | Error (SM.Precondition_violation { reason; _ }) -> Some reason
+  | Error _ | Ok _ -> None
+;;
+
+(* From healthy Running conditions no event has an unmet precondition. The
+   two events that carry one are gated on buffer-op flags, which are false
+   here. *)
+let test_no_precondition_fires_from_healthy_running () =
+  List.iter
+    (fun event ->
+      match precondition_reason ~conditions:running_conditions event with
+      | None -> ()
+      | Some reason ->
+        failf "%s hit a precondition from healthy Running: %s" (event_tag event) reason)
+    all_events
+;;
+
+(* Operator_compact_requested is the one event with buffer-op preconditions,
+   and it must be the only one that reacts to those flags. *)
+let test_only_operator_compact_reacts_to_buffer_flags () =
+  List.iter
+    (fun (label, conditions) ->
+      List.iter
+        (fun event ->
+          let hit = precondition_reason ~conditions event <> None in
+          let expected = event_tag event = "operator_compact_requested" in
+          if hit && not expected
+          then failf "%s hit a precondition under %s" (event_tag event) label
+          else if expected && not hit
+          then failf "operator_compact_requested did not reject under %s" label)
+        all_events)
+    [ "compaction_active", { running_conditions with SM.compaction_active = true }
+    ; "handoff_active", { running_conditions with SM.handoff_active = true }
+    ]
+;;
+
 let outcome_kind_of = function
   | A.Passed -> "passed"
   | A.Policy_failed _ -> "policy_failed"


### PR DESCRIPTION
## 무엇이 문제였나

`check_event_precondition` 은 TLA+ 전제조건을 검사하는 함수인데, 22 개 `event` 생성자 중 2 개만 명시하고 나머지를 catch-all 로 받았다:

```ocaml
  (* Other events have no TLA+ state preconditions ... Adding speculative
     arms here would drift from the spec. *)
  | _ -> Ok ()
```

이벤트가 추가되면 아무도 판단하지 않은 채 `Ok ()` 를 물려받는다. 이 모듈은 CLAUDE.md §"AI 코드 생성 안티패턴 #4" 가 사고 사례로 인용한 바로 그 `keeper_registry` FSM 이다 (`validate_decision_transition` 런타임 `Assert_failure`, 2026-05-08).

주석의 논지("speculative arm 추가는 스펙에서 벗어난다")는 맞다. 하지만 **명시 열거는 검사 추가가 아니다** — 20 개 이벤트의 답은 여전히 "전제조건 없음" 이고, 달라지는 건 새 이벤트가 이 판단을 한 번 강제한다는 것뿐이다.

## 측정

`event` 에 생성자 하나를 추가하고 빌드했을 때 `keeper_state_machine*` 에서 깨지는 사이트:

| | 사이트 |
|---|---|
| 수정 전 | **5** |
| 수정 후 | **6** |

새로 잡히는 것이 `keeper_state_machine.ml` 의 `check_event_precondition` 이다. 나머지 5 개(전이 테이블 3 곳, JSON 인코더, `.mli`)는 원래부터 강제하고 있었다 — **전제조건 검사만 예외**였다.

## 변경

- catch-all 을 20 개 이벤트 명시 열거로 교체. 동작 변화 없음.
- 함수 위 주석의 "fall through the catch-all" 을 사실에 맞게 수정.

`lib/keeper_registry/dune` 에 `-w +4` 는 켜지 **않았다**. 같이 붙는 `-w +32` 가 `keeper_id.ml` 의 미사용 값들을 잡는데, 그건 별개 관심사라 범위가 커진다. 명시 열거만으로 warning 8 (partial-match) 이 새 이벤트를 잡으므로 목적은 달성된다.

## 테스트

컴파일러는 열거가 exhaustive 한지는 보지만, 테스트의 witness 목록이 타입을 따라가는지는 안 본다. 그래서 테스트 안에도 **exhaustive match** (`event_tag`) 를 넣었다 — 새 생성자는 이 파일의 컴파일도 깨뜨리므로 `all_events` 가 조용히 뒤처질 수 없다.

`test/test_keeper_state_machine_preconditions.ml` 신규 3 케이스:

- 22 개 생성자마다 witness 가 있는지 (빈/짧은 목록이 통과하는 것을 막는다)
- 건강한 Running 상태에서 어떤 이벤트도 전제조건에 걸리지 않는지
- buffer-op 플래그(`compaction_active` / `handoff_active`)에 반응하는 이벤트가 `Operator_compact_requested` **하나뿐**인지

전제조건 추가를 실제로 잡는지 확인: 말단 arm 에 `Error (Precondition_violation ...)` 를 넣으면 뒤 두 케이스가 실패하고, witness 커버리지는 (variant 가 안 변했으므로) 통과한다.

## 검증

- `dune build --root . @check` — EXIT=0
- 위 표의 5 → 6 측정 (생성자 주입 후 빌드, 양방향)
- `test_keeper_state_machine.exe` — 105 케이스 통과
- `scripts/check-doc-code-refs.sh` — EXIT=0

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
