### PR TITLE
fix(tool): route the dispatch outcome label through its owning module

### DIFF
--- a/lib/keeper/keeper_tool_registered_runtime.ml
+++ b/lib/keeper/keeper_tool_registered_runtime.ml
@@ -64,12 +64,7 @@ let handle_masc_tool_with_outcome
                        ~name
                        ~args
                    in
-                   let outcome =
-                     match result with
-                     | Some _ -> "handled"
-                     | None -> "no_handler"
-                   in
-                   result, outcome)
+                   result, Dispatch_outcome.(to_string (of_result_option result)))
             in
             (match result with
              | Some tr -> Keeper_tool_execution.of_tool_result tr

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -454,12 +454,7 @@ let execute_tool_eio
                        (* Keep MCP tools/call on the shared post-dispatch
                           transformer and observer contract. *)
                        let r = Tool_dispatch_emit.finalize_from_handler r in
-                       let outcome =
-                         match r with
-                         | Some _ -> "handled"
-                         | None -> "no_handler"
-                       in
-                       r, outcome)
+                       r, Dispatch_outcome.(to_string (of_result_option r)))
                    in
                    result
                  in

--- a/lib/tool/dispatch_outcome.ml
+++ b/lib/tool/dispatch_outcome.ml
@@ -16,6 +16,14 @@ type t =
   | No_handler
 [@@deriving show, eq]
 
+(* The dispatch paths all decide the outcome from the same thing: whether
+   the handler produced a result. Deriving it here keeps that decision, and
+   the label it maps to, in one place. *)
+let of_result_option = function
+  | Some _ -> Handled
+  | None -> No_handler
+;;
+
 let to_string = function
   | Handled -> "handled"
   | No_handler -> "no_handler"

--- a/lib/tool/dispatch_outcome.mli
+++ b/lib/tool/dispatch_outcome.mli
@@ -23,6 +23,12 @@ type t =
           miss).  The string outcome ["no_handler"] maps to this arm. *)
 [@@deriving show, eq]
 
+(** [of_result_option r] is the outcome a handler result denotes:
+    [Some _] is {!Handled}, [None] is {!No_handler}.  Every dispatch path
+    makes this same decision, so they share it rather than each writing
+    the match — and, with {!to_string}, the label it produces. *)
+val of_result_option : 'a option -> t
+
 (** [to_string t] returns the label used by Otel_metric_store counters /
     [Tool_telemetry.with_span] outcome strings ("handled" / "no_handler"). *)
 val to_string : t -> string

--- a/lib/tool/tool_dispatch.ml
+++ b/lib/tool/tool_dispatch.ml
@@ -220,18 +220,9 @@ let guarded_dispatch ~(token : Tool_token.t) ~args () : Tool_result.result optio
       (* Finalization is done inline because [Tool_dispatch] cannot depend on
          [Tool_dispatch_emit] without creating a dependency cycle.  Observers
          receive the exact handler result and cannot mutate it. *)
-      let typed_outcome : Dispatch_outcome.t =
-        match r with
-        | Some _ -> Handled
-        | None -> No_handler
-      in
+      let typed_outcome = Dispatch_outcome.of_result_option r in
       run_dispatch_observers typed_outcome r;
-      let outcome =
-        match r with
-        | Some _ -> "handled"
-        | None -> "no_handler"
-      in
-      r, outcome)
+      r, Dispatch_outcome.to_string typed_outcome)
   in
   result
 ;;

--- a/lib/tool_surface/tool_dispatch_emit.ml
+++ b/lib/tool_surface/tool_dispatch_emit.ml
@@ -19,10 +19,5 @@ let finalize ~(outcome : Dispatch_outcome.t) (r : Tool_result.result option)
 ;;
 
 let finalize_from_handler (r : Tool_result.result option) : Tool_result.result option =
-  let outcome : Dispatch_outcome.t =
-    match r with
-    | Some _ -> Handled
-    | None -> No_handler
-  in
-  finalize ~outcome r
+  finalize ~outcome:(Dispatch_outcome.of_result_option r) r
 ;;

--- a/test/test_dispatch_outcome_total.ml
+++ b/test/test_dispatch_outcome_total.ml
@@ -68,6 +68,75 @@ let test_string_vocabulary_parity () =
     (Option.is_some (Dispatch_outcome.of_string "no_handler"))
 ;;
 
+
+(* ── of_result_option and the label a real dispatch emits ── *)
+
+(* Three sites (Tool_dispatch, Mcp_server_eio_execute,
+   Keeper_tool_registered_runtime) each wrote `match r with Some _ ->
+   "handled" | None -> "no_handler"` by hand while this module's .mli
+   claimed to own that label. They now go through of_result_option +
+   to_string. *)
+
+let test_of_result_option_maps_both_arms () =
+  (check bool)
+    "Some _ is Handled"
+    true
+    (Dispatch_outcome.equal Dispatch_outcome.Handled
+       (Dispatch_outcome.of_result_option (Some ())));
+  (check bool)
+    "None is No_handler"
+    true
+    (Dispatch_outcome.equal Dispatch_outcome.No_handler
+       (Dispatch_outcome.of_result_option None))
+;;
+
+(* Every arm must be reachable from some option input, or one of them has
+   no producer -- the condition that shrank this sum from 5 arms to 2. *)
+let test_of_result_option_reaches_every_arm () =
+  let produced =
+    [ Dispatch_outcome.of_result_option (Some ()); Dispatch_outcome.of_result_option None ]
+  in
+  List.iter
+    (fun arm ->
+      (check bool)
+        (Printf.sprintf "%s is produced by of_result_option"
+           (Dispatch_outcome.to_string arm))
+        true
+        (List.exists (Dispatch_outcome.equal arm) produced))
+    Dispatch_outcome.all_arms
+;;
+
+(* End to end: the label guarded_dispatch hands the span wrapper must be
+   the one this module produces. A hand-written literal reintroduced at any
+   dispatch site fails here. *)
+let captured_label = ref None
+
+let capturing_wrapper ?force_new_trace_id:_ ?surface:_ ~tool_name:_ body =
+  let result, label = body (fun () -> None) in
+  captured_label := Some label;
+  result, label
+;;
+
+let dispatch_label_for ~tool_name =
+  captured_label := None;
+  Tool_dispatch.set_span_wrapper capturing_wrapper;
+  match Tool_token.mint_with ~validate:(fun _ -> true) ~name:tool_name with
+  | Error message -> Alcotest.failf "could not mint a token for %s: %s" tool_name message
+  | Ok token ->
+    let _ = Tool_dispatch.guarded_dispatch ~token ~args:(`Assoc []) () in
+    !captured_label
+;;
+
+let test_dispatch_emits_the_owned_label () =
+  match dispatch_label_for ~tool_name:"tool-that-is-not-registered" with
+  | None -> Alcotest.fail "the span wrapper was never handed a label"
+  | Some label ->
+    (check string)
+      "an unregistered tool reports the No_handler label"
+      (Dispatch_outcome.to_string Dispatch_outcome.No_handler)
+      label
+;;
+
 let () =
   Alcotest.run
     "RFC-0084 PR-10 Dispatch_outcome typed"
@@ -77,6 +146,12 @@ let () =
         ; test_case "round-trip-string-label" `Quick test_round_trip_string_label
         ; test_case "of-string-unknown-returns-none" `Quick test_of_string_unknown_returns_none
         ; test_case "string-vocabulary-parity" `Quick test_string_vocabulary_parity
+        ; test_case "of-result-option-maps-both-arms" `Quick
+            test_of_result_option_maps_both_arms
+        ; test_case "of-result-option-reaches-every-arm" `Quick
+            test_of_result_option_reaches_every_arm
+        ; test_case "dispatch-emits-the-owned-label" `Quick
+            test_dispatch_emits_the_owned_label
         ] )
     ]
 ;;


### PR DESCRIPTION
## 무엇이 문제였나

`lib/tool/dispatch_outcome.mli` 는 자기가 span 라벨의 소유자라고 선언한다:

```
(** [to_string t] returns the label used by Otel_metric_store counters /
    [Tool_telemetry.with_span] outcome strings ("handled" / "no_handler"). *)
val to_string : t -> string
```

**그런데 그 라벨을 만드는 곳 중 이 함수를 부르는 데가 없었다.** 세 곳이 손으로 같은 문자열을 썼다:

```ocaml
let outcome = match r with Some _ -> "handled" | None -> "no_handler" in
```

- `lib/tool/tool_dispatch.ml:231` — 바로 네 줄 위에서 같은 판정으로 `typed_outcome` 을 이미 만들어 놓고 문자열은 따로 유도했다
- `lib/mcp_server_eio_execute.ml:459`
- `lib/keeper/keeper_tool_registered_runtime.ml:69`

네 번째로 `lib/tool_surface/tool_dispatch_emit.ml` 이 같은 `option -> t` 매치를 또 갖고 있었다.

`to_string` 을 바꾸면 이 세 생산자는 옛 어휘를 계속 내보내고, 같은 모듈의 `of_string` (fail-closed 파서) 은 그걸 파싱하지 못한다. 문자열 이벤트는 생산자를 전수하지 않으면 갈라진다.

## 변경

타입 소유 모듈에 전(total) 변환 하나를 두고 네 곳을 전부 거기로 보냈다:

```ocaml
val of_result_option : 'a option -> t
```

`tool_dispatch.ml` 은 이제 판정을 한 번만 한다 — `of_result_option` 으로 `typed_outcome` 을 만들고, 관측자에게 넘긴 뒤, 같은 값의 `to_string` 을 라벨로 쓴다.

`lib/` 와 `bin/` 에 남은 `"handled"` / `"no_handler"` 리터럴은 `dispatch_outcome.ml` 안의 정의 두 개뿐이다.

## 테스트

`test/test_dispatch_outcome_total.ml` 에 3 케이스 추가:

- `of_result_option` 이 두 arm 을 정확히 매핑하는지
- `of_result_option` 이 `all_arms` 를 **전부** 도달하는지 (생산자 없는 arm 은 이 sum 을 5→2 로 줄인 조건이었다)
- **end-to-end**: `set_span_wrapper` 로 라벨을 가로채, 등록되지 않은 도구를 `guarded_dispatch` 했을 때 실제로 나오는 라벨이 `Dispatch_outcome.to_string No_handler` 와 같은지

마지막 케이스가 이 PR 이 막으려는 것을 직접 지킨다. 디스패치 지점에 리터럴을 다시 넣으면:

```
[FAIL] dispatch-emits-the-owned-label
   Expected: `"no_handler"'
   Received: `"no_handler_drifted"'
```

## 검증

- `dune build --root . @check` — EXIT=0
- `test_dispatch_outcome_total.exe` — 8 케이스 통과
- 리터럴 재도입 프로브로 실패 확인 (위 출력), 복원 후 통과
- `scripts/check-doc-code-refs.sh`, `scripts/audit-keeper-tool-boundary-matrix.sh` — 둘 다 EXIT=0

## 범위 밖

네 개의 dispatch observer 가 모두 `| Dispatch_outcome.Handled, Some r -> ... | _ -> ()` 로 같은 모양을 반복한다. `Dispatch_outcome.t` 는 2-생성자라 열거가 사소하지만, 관측자 계약을 바꾸는 일이라 분리했다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
