### PR TITLE
fix(fs-compat): one operation label mapping, not two

### DIFF
--- a/lib/fs_compat/capability_recovery_obligation.mli
+++ b/lib/fs_compat/capability_recovery_obligation.mli
@@ -535,6 +535,12 @@ module For_testing : sig
   val area_directory : store -> area -> Eio.Fs.dir_ty Eio.Path.t
 end
 
+(** The label an {!operation} carries in failure JSON.  Exported because
+    [Capability_recovery_reconciler] renders the same field and kept its
+    own copy of the 17 arms; two mappings for one type drift apart the
+    moment an operation is added. *)
+val operation_to_string : operation -> string
+
 val validation_error_to_string : validation_error -> string
 val failure_to_string : failure -> string
 val transition_error_to_string : transition_error -> string

--- a/lib/fs_compat/capability_recovery_reconciler.ml
+++ b/lib/fs_compat/capability_recovery_reconciler.ml
@@ -1621,26 +1621,6 @@ let core_subject_to_yojson = function
       ]
 ;;
 
-let core_operation_to_string = function
-  | Core.Inspect_directory -> "inspect_directory"
-  | Core.Create_directory -> "create_directory"
-  | Core.Open_directory -> "open_directory"
-  | Core.Close_directory -> "close_directory"
-  | Core.Sync_directory -> "sync_directory"
-  | Core.Read_directory -> "read_directory"
-  | Core.Inspect_record -> "inspect_record"
-  | Core.Open_record -> "open_record"
-  | Core.Read_record -> "read_record"
-  | Core.Decode_record -> "decode_record"
-  | Core.Create_record -> "create_record"
-  | Core.Apply_permissions -> "apply_permissions"
-  | Core.Write_record -> "write_record"
-  | Core.Sync_record -> "sync_record"
-  | Core.Close_record -> "close_record"
-  | Core.Verify_record_identity -> "verify_record_identity"
-  | Core.Remove_record -> "remove_record"
-;;
-
 let core_failure_cause_to_yojson = function
   | Core.Validation_failed error ->
     `Assoc
@@ -1680,7 +1660,7 @@ let core_failure_cause_to_yojson = function
 
 let core_failure_to_yojson (failure : Core.failure) =
   `Assoc
-    [ "operation", `String (core_operation_to_string failure.operation)
+    [ "operation", `String (Core.operation_to_string failure.operation)
     ; "subject", core_subject_to_yojson failure.subject
     ; "cause", core_failure_cause_to_yojson failure.cause
     ]


### PR DESCRIPTION
## 무엇이 문제였나

`Capability_recovery_obligation.operation` 의 문자열 라벨이 **두 곳에 정의**돼 있었다.

- `capability_recovery_obligation.ml:1173` `operation_to_string` — 타입 소유 모듈
- `capability_recovery_reconciler.ml:1624` `core_operation_to_string` — 사본

`capability_recovery_reconciler.ml:1` 은 `module Core = Capability_recovery_obligation` 이다. 별칭이므로 **같은 타입**이고, 두 매핑은 17 arm 전부 문자열까지 동일했다 (arm 단위로 대조 확인).

사본이 생긴 이유는 명확하다: 소유 모듈의 `.mli` 가 `operation_to_string` 을 내보내지 않아 reconciler 가 부를 수 없었다.

두 매핑 모두 실패 JSON 의 같은 `"operation"` 필드를 렌더한다:

```ocaml
(* obligation.ml:1252 *)   (operation_to_string failure.operation)
(* reconciler.ml:1683 *)   `String (core_operation_to_string failure.operation)
```

operation 이 추가되면 컴파일러는 두 매핑 모두에 arm 을 요구하지만, **한쪽 라벨만 바꾸는 변경은 아무것도 막지 못한다** — 같은 필드가 소비자에 따라 다른 문자열을 싣게 된다.

## 변경

- `.mli` 에 `val operation_to_string : operation -> string` 노출
- reconciler 의 17-arm 사본 삭제, `Core.operation_to_string` 호출로 교체

동작 변화 없음 — 두 매핑이 이미 동일했으므로 JSON 출력은 바이트 단위로 같다.

## 검증

- `dune build --root . @check` — EXIT=0
- 삭제 전 두 매핑을 arm 단위로 대조: 17/17 동일 (constructor → literal 전부 일치)
- `scripts/check-doc-code-refs.sh` — EXIT=0

## 테스트를 넣지 않은 이유

`Capability_recovery_obligation` 은 `fs_compat_internal` 소속이고, 테스트가 내부 모듈에 닿는 정해진 통로는 `fs_compat_test_support` 의 `*_for_testing` 모듈이다. 이 타입은 거기 없다.

남는 미보증 속성은 **라벨 유일성** 이다 — 두 operation 이 같은 문자열을 쓰면 JSON 에서 조용히 합쳐지고 타입 시스템은 반대하지 않는다. 그걸 검증하려면 `fs_compat_test_support` 에 노출 모듈을 하나 추가해야 하는데, 이 PR 이 고치는 것(사본 제거)과 별개의 경계 결정이라 분리했다.

## 같은 원인의 다른 후보

`to_string` 어휘가 다른 파일에서 손으로 재작성된 곳을 전수했다 (어휘 235 개 중 3 개 이상 리터럴이 겹치는 파일 쌍). 이 건이 가장 크다 (17/17 양방향). 다음 후보:

- `keeper_internal_error.ml::network_error_kind_to_string` ↔ `keeper/keeper_agent_error.ml` (7/7)
- `keeper_internal_error.ml::gate_replay_repair_stage_to_string` ↔ `keeper/keeper_gate_replay.ml` (7/7)
- `keeper_chat_queue.ml::unix_file_kind_to_string` — 3 개 파일에 동일 어휘

뒤 두 건은 `keeper_runtime` 과 `keeper` 사이라 의존 방향 때문에 사본이 구조적일 수 있다. 별도 확인이 필요해 이 PR 에 넣지 않았다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
