### PR TITLE
fix(diagnostics): one spelling for Unix.file_kind, not three

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -2203,14 +2203,7 @@ let rec private_jsonl_transaction_error_to_string = function
   | Unexpected_transaction_file_kind kind ->
     Printf.sprintf
       "private JSONL transaction target has unexpected file kind: %s"
-      (match kind with
-       | Unix.S_REG -> "regular"
-       | Unix.S_DIR -> "directory"
-       | Unix.S_CHR -> "character-device"
-       | Unix.S_BLK -> "block-device"
-       | Unix.S_LNK -> "symbolic-link"
-       | Unix.S_FIFO -> "fifo"
-       | Unix.S_SOCK -> "socket")
+      (file_kind_to_string kind)
   | Ambiguous_transaction_file_identity { path; link_count } ->
     Printf.sprintf
       "private JSONL transaction path has ambiguous hard-link identity: %s (links=%d)"

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -1223,14 +1223,6 @@ type regular_path_observation =
   | Path_absent
   | Regular_path of Unix.stats
 
-let unix_file_kind_to_string = function
-  | Unix.S_REG -> "regular"
-  | Unix.S_DIR -> "directory"
-  | Unix.S_CHR -> "character_device"
-  | Unix.S_BLK -> "block_device"
-  | Unix.S_LNK -> "symbolic_link"
-  | Unix.S_FIFO -> "fifo"
-  | Unix.S_SOCK -> "socket"
 
 let inspect_regular_or_absent path =
   match Unix.lstat path with
@@ -1247,7 +1239,7 @@ let inspect_regular_or_absent path =
       (Printf.sprintf
          "owned chat queue path is not a regular file: path=%s kind=%s"
          path
-         (unix_file_kind_to_string st_kind))
+         (Fs_compat.file_kind_to_string st_kind))
 
 let same_regular_identity left right =
   left.Unix.st_kind = Unix.S_REG
@@ -4128,7 +4120,7 @@ let classify_keeper_directory_entries_blocking entries_path entries =
              , load_error Invalid_path ~path:entry_path
                  (Printf.sprintf
                     "Keeper chat queue inventory entry has unsupported kind %s"
-                    (unix_file_kind_to_string st_kind)) )
+                    (Fs_compat.file_kind_to_string st_kind)) )
              :: inventory.rejected_entries
          ; observed_entries = (entry_name, stats) :: inventory.observed_entries
          }

--- a/lib/server_base_path_diagnostics.ml
+++ b/lib/server_base_path_diagnostics.ml
@@ -66,14 +66,6 @@ let unix_error_to_string err op arg =
   in
   Printf.sprintf "%s%s: %s" op target (Unix.error_message err)
 
-let file_kind_to_shape = function
-  | Unix.S_REG -> "regular"
-  | Unix.S_DIR -> "directory"
-  | Unix.S_CHR -> "character_device"
-  | Unix.S_BLK -> "block_device"
-  | Unix.S_LNK -> "symlink"
-  | Unix.S_FIFO -> "fifo"
-  | Unix.S_SOCK -> "socket"
 
 let inspect_regular_current_task path =
   try
@@ -94,11 +86,11 @@ let inspect_current_task_path effective_masc_root =
         (path, shape, error)
     | kind ->
         ( path,
-          file_kind_to_shape kind,
+          Fs_compat.file_kind_to_string kind,
           Some
             (Printf.sprintf
                "expected absent or a regular read/write file, got %s"
-               (file_kind_to_shape kind)) )
+               (Fs_compat.file_kind_to_string kind)) )
   with
   | Unix.Unix_error (Unix.ENOENT, _, _) -> (path, "absent", None)
   | Unix.Unix_error (err, op, arg) ->

--- a/test/dune
+++ b/test/dune
@@ -2525,6 +2525,8 @@
 (include stanzas/test_keeper_hitl_resolution_prompt.inc)
 (include stanzas/test_fs_compat_capability_write.inc)
 
+(include stanzas/test_file_kind_vocabulary.inc)
+
 (test
  (name test_fs_compat_capability_head)
  (modules test_fs_compat_capability_head)

--- a/test/stanzas/test_file_kind_vocabulary.inc
+++ b/test/stanzas/test_file_kind_vocabulary.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_file_kind_vocabulary)
+ (modules test_file_kind_vocabulary)
+ (libraries alcotest fs_compat unix))

--- a/test/test_file_kind_vocabulary.ml
+++ b/test/test_file_kind_vocabulary.ml
@@ -1,0 +1,64 @@
+(** The single vocabulary for rendering [Unix.file_kind] in diagnostics.
+
+    Four sites rendered this type independently and three spellings were
+    in play: [S_REG] was "regular_file" here but "regular" in
+    keeper_chat_queue, server_base_path_diagnostics and an inline match
+    inside fs_compat itself; [S_LNK] was "symbolic_link", "symlink" and
+    "symbolic-link". An operator reading two messages about the same path
+    saw its kind named differently.
+
+    The three copies now call {!Fs_compat.file_kind_to_string}. The labels
+    are pinned here because nothing else does: they are operator-facing
+    strings with no schema behind them, so a rename should be a visible
+    diff rather than a silent divergence. *)
+
+open Alcotest
+
+let kinds : (string * Unix.file_kind) list =
+  [ "S_REG", Unix.S_REG
+  ; "S_DIR", Unix.S_DIR
+  ; "S_CHR", Unix.S_CHR
+  ; "S_BLK", Unix.S_BLK
+  ; "S_LNK", Unix.S_LNK
+  ; "S_FIFO", Unix.S_FIFO
+  ; "S_SOCK", Unix.S_SOCK
+  ]
+;;
+
+(* Unix.file_kind has exactly these seven; a list shorter than that would
+   test less than it claims. *)
+let test_every_kind_is_covered () =
+  check int "seven file kinds" 7 (List.length kinds)
+;;
+
+let test_labels () =
+  List.iter
+    (fun (ctor, expected, kind) ->
+      check string ctor expected (Fs_compat.file_kind_to_string kind))
+    [ "S_REG", "regular_file", Unix.S_REG
+    ; "S_DIR", "directory", Unix.S_DIR
+    ; "S_CHR", "character_device", Unix.S_CHR
+    ; "S_BLK", "block_device", Unix.S_BLK
+    ; "S_LNK", "symbolic_link", Unix.S_LNK
+    ; "S_FIFO", "fifo", Unix.S_FIFO
+    ; "S_SOCK", "socket", Unix.S_SOCK
+    ]
+;;
+
+(* Two kinds sharing a label would make a diagnostic ambiguous. *)
+let test_labels_are_distinct () =
+  let labels = List.map (fun (_, k) -> Fs_compat.file_kind_to_string k) kinds in
+  check int "labels are pairwise distinct" (List.length labels)
+    (List.length (List.sort_uniq String.compare labels))
+;;
+
+let () =
+  Alcotest.run
+    "File kind vocabulary"
+    [ ( "vocabulary"
+      , [ test_case "every kind is covered" `Quick test_every_kind_is_covered
+        ; test_case "labels" `Quick test_labels
+        ; test_case "labels are distinct" `Quick test_labels_are_distinct
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 무엇이 문제였나

`Unix.file_kind` 를 진단 메시지에 렌더하는 코드가 **네 곳**에 있었고, 철자가 **세 계열**로 갈렸다.

| | S_REG | S_CHR | S_LNK |
|---|---|---|---|
| `owned_directory_chain` (= `Fs_compat.file_kind_to_string`, 공개 API) | `regular_file` | `character_device` | `symbolic_link` |
| `keeper/keeper_chat_queue.ml` | `regular` | `character_device` | `symbolic_link` |
| `server_base_path_diagnostics.ml` | `regular` | `character_device` | **`symlink`** |
| `fs_compat/fs_compat.ml:2206` (인라인) | `regular` | **`character-device`** | **`symbolic-link`** |

공용 렌더러가 없어서 생긴 일이 아니다. `Fs_compat.file_kind_to_string` 은 **이미 `.mli` 에 공개**돼 있었고, `fs_compat` 자신이 거의 같은 문장에 쓰고 있었다:

```
(* fs_compat 이 쓰는 것 *)      "owned file path is not a regular file path=%s kind=%s"
(* keeper_chat_queue 의 사본 *)  "owned chat queue path is not a regular file: path=%s kind=%s"
```

같은 경로에 대한 두 메시지를 본 운영자는 그 종류가 다르게 불리는 것을 본다. 네 번째 사본은 정본을 내보내는 바로 그 파일 안에 있으면서 하이픈을 쓴다.

## 변경

세 사본을 지우고 `Fs_compat.file_kind_to_string` 호출로 교체. `lib/` 에 남은 `Unix.file_kind` 렌더링은 `owned_directory_chain.ml` 하나다 (나머지 `S_REG` 매치 3 곳은 문자열이 아니라 제어 흐름이다).

**운영자에게 보이는 문자열이 바뀐다.** `regular` → `regular_file`, `symlink` → `symbolic_link`, `character-device` → `character_device`. 어느 철자를 정본으로 삼을지 임의로 고르지 않았다 — 이미 공개돼 있고 fs_compat 자신이 쓰던 것으로 모았다. 테스트·대시보드·문서 어디에도 이 어휘를 고정한 곳은 없어서 (`grep "regular_file" test/ dashboard/src docs/` → 0 건) 깨지는 계약은 확인되지 않았다.

## 테스트

`test/test_file_kind_vocabulary.ml` — 7 개 종류의 라벨을 값으로 고정하고, 라벨이 서로 다른지 확인한다.

이 문자열들은 스키마가 없는 운영자용 출력이라 아무것도 지켜주지 않는다. 값을 박아두면 이름 변경이 조용한 분기가 아니라 리뷰에 보이는 diff 가 된다.

## 검증

- `dune build --root . @check` — EXIT=0
- `test_file_kind_vocabulary.exe` — 3 케이스 통과
- 삭제 전 네 매핑을 constructor 단위로 대조 (위 표가 그 결과)
- `scripts/check-doc-code-refs.sh` — EXIT=0

## 어떻게 찾았나

`to_string` 류 함수 235 개에서 어휘를 추출하고, 그 리터럴이 다른 파일에서 `-> "lit"` 형태로 재작성된 경우를 셌다. 한 파일에 같은 어휘가 3 개 이상 나타나는 쌍만 신호로 봤다 (후보 112 개). 이 건은 3 개 파일에 걸쳐 있어 상위에 올라왔다. 같은 스윕에서 나온 #27113 (`operation_to_string` 17/17 중복) 은 별도로 처리했다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
