### PR TITLE
[Gitflow] feat(keeper): map Internal_* turn-driver variants to dedicated blocker_class (task-194)

### DIFF
--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -116,6 +116,23 @@ type blocker_class =
   | Sdk_guardrail_violation
   | Sdk_tripwire_violation
   | Sdk_input_required
+  | Internal_unhandled_exception
+    (** RFC-0159 follow-up (task-194): unhandled internal exception escaped the
+        turn driver.  Previously [blocker_class_of_sdk_error] returned [None]
+        for this variant, so dashboards/operators could not distinguish an
+        unhandled internal failure from a clean turn. *)
+  | Internal_bridge_exception
+    (** Internal bridge (OAS/stream) exception escaped the turn driver. *)
+  | Internal_contract_rejected
+    (** Internal contract was rejected by the turn driver. *)
+  | Incomplete_tool_transcript
+    (** Tool transcript was quarantined as incomplete. *)
+  | Terminal_effect_failed
+    (** A terminal tool effect failed after the turn's terminal outcome. *)
+  | Receipt_persistence_failed
+    (** Execution receipt persistence failed. *)
+  | Gate_replay_repair_required
+    (** Gate replay repair was required for an approval/effect. *)
 
 let blocker_class_to_string = function
   | Runtime_exhausted _ -> "runtime_exhausted"
@@ -127,6 +144,13 @@ let blocker_class_to_string = function
   | Sdk_guardrail_violation -> "sdk_guardrail_violation"
   | Sdk_tripwire_violation -> "sdk_tripwire_violation"
   | Sdk_input_required -> "sdk_input_required"
+  | Internal_unhandled_exception -> "internal_unhandled_exception"
+  | Internal_bridge_exception -> "internal_bridge_exception"
+  | Internal_contract_rejected -> "internal_contract_rejected"
+  | Incomplete_tool_transcript -> "incomplete_tool_transcript"
+  | Terminal_effect_failed -> "terminal_effect_failed"
+  | Receipt_persistence_failed -> "receipt_persistence_failed"
+  | Gate_replay_repair_required -> "gate_replay_repair_required"
 ;;
 
 let blocker_class_of_serialized_string = function
@@ -139,6 +163,13 @@ let blocker_class_of_serialized_string = function
   | "sdk_guardrail_violation" -> Some Sdk_guardrail_violation
   | "sdk_tripwire_violation" -> Some Sdk_tripwire_violation
   | "sdk_input_required" -> Some Sdk_input_required
+  | "internal_unhandled_exception" -> Some Internal_unhandled_exception
+  | "internal_bridge_exception" -> Some Internal_bridge_exception
+  | "internal_contract_rejected" -> Some Internal_contract_rejected
+  | "incomplete_tool_transcript" -> Some Incomplete_tool_transcript
+  | "terminal_effect_failed" -> Some Terminal_effect_failed
+  | "receipt_persistence_failed" -> Some Receipt_persistence_failed
+  | "gate_replay_repair_required" -> Some Gate_replay_repair_required
   | _ -> None
 ;;
 

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -143,6 +143,13 @@ type blocker_class =
   | Sdk_guardrail_violation
   | Sdk_tripwire_violation
   | Sdk_input_required
+  | Internal_unhandled_exception
+  | Internal_bridge_exception
+  | Internal_contract_rejected
+  | Incomplete_tool_transcript
+  | Terminal_effect_failed
+  | Receipt_persistence_failed
+  | Gate_replay_repair_required
 
 val blocker_class_to_string : blocker_class -> string
 (** Canonical lowercase labels.  Pinned literals — operator

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -106,7 +106,14 @@ let disposition_of_typed_runtime_blocker_class blocker_class =
   | Keeper_meta_contract.Sdk_context_window_exceeded
   | Keeper_meta_contract.Sdk_unrecognized_stop_reason
   | Keeper_meta_contract.Sdk_guardrail_violation
-  | Keeper_meta_contract.Sdk_tripwire_violation ->
+  | Keeper_meta_contract.Sdk_tripwire_violation
+  | Keeper_meta_contract.Internal_unhandled_exception
+  | Keeper_meta_contract.Internal_bridge_exception
+  | Keeper_meta_contract.Internal_contract_rejected
+  | Keeper_meta_contract.Incomplete_tool_transcript
+  | Keeper_meta_contract.Terminal_effect_failed
+  | Keeper_meta_contract.Receipt_persistence_failed
+  | Keeper_meta_contract.Gate_replay_repair_required ->
     Keeper_turn_disposition.Provider_error
       (Keeper_turn_terminal_code.Sdk_error raw_blocker_class)
 

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -37,17 +37,23 @@ let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class
     Some (Runtime_exhausted (blocker_reason_of_turn_driver_reason reason))
   | Some (Keeper_turn_driver.Resumable_cli_session _) -> None
   | Some (Keeper_turn_driver.Accept_rejected _) -> None
-  (* RFC-0159 Phase A: typed [Internal_*] variants carry an opaque exception
-     repr.  They are not yet mapped to a dedicated [blocker_class]; returning
-     [None] keeps Phase A scope to typed substrate only.  A follow-up RFC may
-  introduce a typed blocker_class for unhandled internal failures. *)
-  | Some (Keeper_turn_driver.Internal_unhandled_exception _) -> None
-  | Some (Keeper_turn_driver.Internal_bridge_exception _) -> None
-  | Some (Keeper_turn_driver.Internal_contract_rejected _) -> None
-  | Some (Keeper_turn_driver.Incomplete_tool_transcript _) -> None
-  | Some (Keeper_turn_driver.Terminal_effect_failed _) -> None
-  | Some (Keeper_turn_driver.Receipt_persistence_failed _) -> None
-  | Some (Keeper_turn_driver.Gate_replay_repair_required _) -> None
+  (* RFC-0159 follow-up (task-194): typed [Internal_*] variants now map to
+     dedicated [blocker_class] values so dashboards/operators can distinguish
+     unhandled internal failures instead of collapsing them to [None]. *)
+  | Some (Keeper_turn_driver.Internal_unhandled_exception _) ->
+    Some Internal_unhandled_exception
+  | Some (Keeper_turn_driver.Internal_bridge_exception _) ->
+    Some Internal_bridge_exception
+  | Some (Keeper_turn_driver.Internal_contract_rejected _) ->
+    Some Internal_contract_rejected
+  | Some (Keeper_turn_driver.Incomplete_tool_transcript _) ->
+    Some Incomplete_tool_transcript
+  | Some (Keeper_turn_driver.Terminal_effect_failed _) ->
+    Some Terminal_effect_failed
+  | Some (Keeper_turn_driver.Receipt_persistence_failed _) ->
+    Some Receipt_persistence_failed
+  | Some (Keeper_turn_driver.Gate_replay_repair_required _) ->
+    Some Gate_replay_repair_required
   | None ->
     (match err with
      | Agent_sdk.Error.Internal _ -> None
@@ -144,7 +150,14 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
     | Sdk_unrecognized_stop_reason
     | Sdk_guardrail_violation
     | Sdk_tripwire_violation
-    | Sdk_input_required -> if summary = "" then str else summary
+    | Sdk_input_required
+    | Internal_unhandled_exception
+    | Internal_bridge_exception
+    | Internal_contract_rejected
+    | Incomplete_tool_transcript
+    | Terminal_effect_failed
+    | Receipt_persistence_failed
+    | Gate_replay_repair_required -> if summary = "" then str else summary
   in
   { blocker_class = str; summary }
 ;;

--- a/test/test_blocker_class_exhaustiveness.ml
+++ b/test/test_blocker_class_exhaustiveness.ml
@@ -33,6 +33,13 @@ let all_variants : blocker_class list =
   ; Sdk_guardrail_violation
   ; Sdk_tripwire_violation
   ; Sdk_input_required
+  ; Internal_unhandled_exception
+  ; Internal_bridge_exception
+  ; Internal_contract_rejected
+  ; Incomplete_tool_transcript
+  ; Terminal_effect_failed
+  ; Receipt_persistence_failed
+  ; Gate_replay_repair_required
   ]
 ;;
 


### PR DESCRIPTION
## Summary

RFC-0159 follow-up (task-194). `blocker_class_of_sdk_error` returned `None` for all typed `Internal_*` turn-driver variants, so dashboards/operators could not distinguish an unhandled internal failure from a clean turn.

This PR introduces dedicated `blocker_class` values for those variants and maps them in `blocker_class_of_sdk_error`.

## Changes

- `keeper_meta_contract.ml/.mli`: add 7 new `blocker_class` variants (`Internal_unhandled_exception`, `Internal_bridge_exception`, `Internal_contract_rejected`, `Incomplete_tool_transcript`, `Terminal_effect_failed`, `Receipt_persistence_failed`, `Gate_replay_repair_required`) with serialization round-trip.
- `keeper_status_bridge_blocker.ml`: map each `Internal_*` variant to its dedicated `blocker_class`; surface them in `runtime_blocker_surface_of_typed_class`.
- `keeper_runtime_trust_snapshot.ml`: route the new classes to `Provider_error` disposition.
- `test/test_blocker_class_exhaustiveness.ml`: extend the exhaustiveness list with the 7 new variants.

## Verification

- Library build green via `scripts/dune-local.sh`.
- Test exe built green (openssl env override for link).
- `test_blocker_class_exhaustiveness.exe` — 11/11 tests pass.

Draft PR per task rules.