### PR TITLE
fix(keeper): one network_error_kind label mapping, not two

### DIFF
--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -219,15 +219,7 @@ let agent_error_terminal_reason_code = function
     Printf.sprintf "agent_error_input_required:request_id=%s" request_id
 ;;
 
-let network_error_kind_to_wire = function
-  | Llm_provider.Http_client.Connection_refused -> "connection_refused"
-  | Llm_provider.Http_client.Dns_failure -> "dns_failure"
-  | Llm_provider.Http_client.Tls_error -> "tls_error"
-  | Llm_provider.Http_client.Timeout -> "timeout"
-  | Llm_provider.Http_client.Local_resource_exhaustion -> "local_resource_exhaustion"
-  | Llm_provider.Http_client.End_of_file -> "end_of_file"
-  | Llm_provider.Http_client.Unknown -> "unknown"
-;;
+let network_error_kind_to_wire = Keeper_internal_error.network_error_kind_to_string
 
 let provider_timeout_suffix = function
   | None -> ""

--- a/lib/keeper_runtime/keeper_internal_error.mli
+++ b/lib/keeper_runtime/keeper_internal_error.mli
@@ -66,6 +66,13 @@ type accept_rejection_kind =
   | Accept_no_usable_progress
   | Accept_predicate_rejected
 
+(** The wire label for a {!Llm_provider.Http_client.network_error_kind}.
+    Exported because [Keeper_agent_error] renders the same seven kinds for
+    its own [network_kind] field and kept a byte-identical copy; two
+    mappings for one type can be renamed apart. *)
+val network_error_kind_to_string :
+  Llm_provider.Http_client.network_error_kind -> string
+
 val accept_rejection_kind_to_string : accept_rejection_kind -> string
 val accept_rejection_kind_of_string : string -> accept_rejection_kind option
 


### PR DESCRIPTION
## 무엇이 문제였나

`Llm_provider.Http_client.network_error_kind` (외부 SDK 타입) 의 7 개 라벨이 **두 곳에 정의**돼 있었고, 두 매핑은 constructor 단위로 완전히 같았다.

- `lib/keeper_runtime/keeper_internal_error.ml:380` `network_error_kind_to_string` — 역함수 `network_error_kind_of_string` 까지 갖춘 왕복 쌍
- `lib/keeper/keeper_agent_error.ml:222` `network_error_kind_to_wire` — 사본

사본이 생긴 이유는 #27113 과 같다: 하위 모듈의 `.mli` 가 `network_error_kind_to_string` 을 내보내지 않아 상위가 부를 수 없었다.

두 라벨은 서로 다른 필드로 나간다 — 하위는 `transport_error_kind` (자기 파서가 되읽는다), 상위는 `network_kind` (`keeper_event_bridge_error_json.ml` 2 곳). 같은 필드가 아니므로 지금 당장 깨지는 것은 없다. 다만 같은 타입의 같은 종류를 두 필드가 다르게 부르게 되는 데는 한쪽 라벨을 고치는 것으로 충분하고, 컴파일러는 그걸 막지 않는다.

## 변경

- `keeper_internal_error.mli` 에 `val network_error_kind_to_string` 노출
- `keeper_agent_error.network_error_kind_to_wire` 를 그 함수로 위임

이름은 남겼다 — 이 함수가 어느 wire 필드를 채우는지 호출부에서 읽히는 편이 낫고, 호출 3 곳을 건드리지 않는다. 동작 변화 없음 (두 매핑이 이미 같았다).

## 검증

- `dune build --root . @check` — EXIT=0
- 위임 전 두 매핑을 constructor 단위로 대조: 7/7 동일
- `scripts/check-doc-code-refs.sh` — EXIT=0

## 이 스윕에서 확인한 음성 3 건

`to_string` 어휘 재작성 후보 112 개 중 상위를 훑었다. 고치지 않은 것들과 그 이유:

- **`repair_stage`** (`keeper_runtime` 7 종 ↔ `keeper` 7 종, 문자열 동일): `keeper_runtime` 이 하위라 `lib/keeper/` 를 볼 수 없어 사본이 구조적이고, 두 출력이 서로 다른 싱크로 간다 (JSON `"stage"` 필드 vs 사람이 읽는 로그 텍스트). 통합은 두 개념이 하나인지에 대한 설계 판단이 필요하다.
- **`phase_to_string` ↔ `keeper_status_runtime`** (9/12): 거짓 양성. `fiber_health` / `keeper_health` 라는 별개 타입들이 `dead` / `offline` 같은 흔한 상태 단어를 공유했을 뿐이다.
- **`stimulus_kind`** (`keeper_reaction_ledger` 11 종 ↔ `keeper_event_queue` 12 종, 10 개 겹침): 깨끗하다. 문자열이 경계를 넘지 않고 `stimulus_kind_of_event_queue` 라는 **catch-all 없는 exhaustive 타입 변환**이 있다. 어휘 차이(`board_attention` → `Board_signal` 병합, `manual_compaction_requested` → `Manual_compaction` 개명)는 그 변환에 명시돼 컴파일러 검증을 받는다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
