### PR TITLE
fix(health): stop the reaction-ledger section capping the fleet at 64

### DIFF
--- a/lib/server/server_routes_http_runtime_health_fleet.ml
+++ b/lib/server/server_routes_http_runtime_health_fleet.ml
@@ -8,16 +8,13 @@ open Server_auth
 open Server_routes_http_common
 open Server_routes_http_runtime_fleet_scan
 
-let take = List.take
-;;
-
 let keeper_reaction_ledger_health_json () =
   match current_server_state_opt () with
   | None -> Keeper_reaction_ledger.unavailable_fleet_summary_json ()
   | Some state ->
     let config = (Mcp_server.workspace_config state) in
     let keeper_names =
-      try Keeper_meta_store.keeper_names config |> sorted_unique_strings |> take 64 with
+      try Keeper_meta_store.keeper_names config |> sorted_unique_strings with
       | Eio.Cancel.Cancelled _ as exn -> raise exn
       | exn ->
         Log.Keeper.warn

--- a/lib/server/server_routes_http_runtime_health_fleet.mli
+++ b/lib/server/server_routes_http_runtime_health_fleet.mli
@@ -4,8 +4,6 @@
     Contains keeper reaction ledger, FD accountant, fleet resolution,
     runtime truth, and contract-verification health JSON renderers. *)
 
-val take : int -> 'a list -> 'a list
-
 val keeper_reaction_ledger_health_json : unit -> Yojson.Safe.t
 
 val keeper_turn_admission_health_json : unit -> Yojson.Safe.t


### PR DESCRIPTION
## 무엇이 문제였나

`keeper_reaction_ledger_health_json` 은 keeper 이름을 64 개로 자른 뒤 요약했다:

```ocaml
try Keeper_meta_store.keeper_names config |> sorted_unique_strings |> take 64 with
```

그리고 그 요약이 내보내는 `keeper_count` 는 **잘린 뒤의 길이**다 (`keeper_reaction_ledger.ml:1680`):

```ocaml
; "keeper_count", `Int (List.length keeper_names)
```

함대에 keeper 가 200 개여도 헬스 JSON 은 `keeper_count: 64` 를 안정적으로 보고한다. 65 번째 이후가 요약되지 않았다는 신호가 응답 어디에도 없어서, 운영자는 절단 여부를 알 수 없다.

## 왜 이 캡이 설계가 아닌가

같은 파일의 형제 함수 셋이 **같은 헬스 응답의 필드**다 (`server_routes_http_runtime_health_fleet.ml:251-256`):

| 필드 | keeper 목록 |
|---|---|
| `keeper_turn_admission` | 전체 |
| `keeper_board_event_collection` | 전체 |
| `keeper_reaction_ledger` | **`take 64`** |

셋 다 `Keeper_meta_store.keeper_names config |> sorted_unique_strings` 로 같은 목록을 읽고 keeper 당 작업을 한다. 응답 하나가 이미 두 섹션에서 전체 함대를 도는데 세 번째만 자른다.

`take 64` 는 원 기능 커밋 `43ebdd5fbc feat(keeper): surface reaction ledger health` (2026-05-17) 에서 들어왔고, **코드 주석도 커밋 메시지 근거도 없다**. 이후 `#18318` godfile 분할로 이 파일에 옮겨졌을 뿐이다.

`limit_per_keeper:20` 이 keeper 당 행 수를 이미 묶고 있으므로 비용은 keeper 수에 선형이고, 이는 다른 두 섹션이 이미 지불하는 것과 같은 차수다.

## 변경

- `take 64` 제거. 세 섹션이 같은 함대를 본다.
- `let take = List.take` 별칭과 `.mli` 의 `val take : int -> 'a list -> 'a list` 제거. 이 캡이 유일한 사용처였고, 공개돼 있었지만 외부 소비자는 0 곳이었다 (godfile 분할 때 `List.take` 재수출이 인터페이스로 샌 것).

## 검증

- `dune build --root . @check` — EXIT=0
- `grep -rn 'Server_routes_http_runtime_health_fleet\.take' lib/ bin/ test/` → 0 건 (공개면 제거 안전)
- `scripts/check-doc-code-refs.sh` — EXIT=0

## 테스트를 넣지 않은 이유

이 라우트들에 대한 테스트가 현재 없다. 절단이 사라졌음을 직접 보이려면 서버 상태에 keeper 65 개 이상을 세워야 하는 통합 설정이 필요하고, 그건 이 삭제 하나보다 큰 작업이다.

세 섹션이 같은 keeper 집합을 보고하는지 확인하는 불변식 테스트가 더 나은 방향이지만, 역시 서버 상태 하네스가 선행이라 분리했다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
