### PR TITLE
test(workspace-utils): replace four cases that asserted nothing

### DIFF
--- a/test/test_workspace_utils_coverage.ml
+++ b/test/test_workspace_utils_coverage.ml
@@ -295,33 +295,6 @@ let test_env_opt_home () =
   | None -> ()  (* Some systems might not have HOME *)
 
 (* ============================================================
-   storage_backend Type Tests
-   ============================================================ *)
-
-let test_storage_backend_memory_variant () =
-  (* Just test that the type exists and can be constructed indirectly *)
-  let _ : string = "Memory" in
-  ()
-
-let test_storage_backend_filesystem_variant () =
-  let _ : string = "FileSystem" in
-  ()
-
-(* ============================================================
-   config Record Tests
-   ============================================================ *)
-
-let test_config_base_path_type () =
-  (* config record has base_path: string *)
-  let _ : string = "test_path" in
-  ()
-
-let test_config_lock_expiry_type () =
-  (* config record has lock_expiry_minutes: int *)
-  let _ : int = 30 in
-  ()
-
-(* ============================================================
    strip_prefix Tests
    ============================================================ *)
 
@@ -535,6 +508,32 @@ let make_test_config ~base_path ~cluster_name : Workspace_utils.config =
     backend_config;
     backend = Workspace_utils.Memory memory_backend;
   }
+
+(* ============================================================
+   storage_backend / config Tests
+
+   These replaced four cases that bound a literal and returned unit
+   ([let _ : string = "Memory" in ()]). They named the type in a comment
+   and never referenced it, so they passed whatever Workspace_utils did.
+   ============================================================ *)
+
+(* Exhaustive on purpose: a third storage_backend breaks this file, which
+   is the part a value-based case cannot cover -- FileSystem needs an Eio
+   fs capability, so only its arm is pinned here. *)
+let storage_backend_tag : Workspace_utils.storage_backend -> string = function
+  | Workspace_utils.Memory _ -> "memory"
+  | Workspace_utils.FileSystem _ -> "filesystem"
+
+let test_storage_backend_memory_is_tagged () =
+  let backend = Workspace_utils.Memory (Backend.Memory.create ()) in
+  check string "memory backend" "memory" (storage_backend_tag backend)
+
+let test_config_carries_its_fields () =
+  let cfg = make_test_config ~base_path:"/tmp/cfg" ~cluster_name:"c1" in
+  check string "base_path" "/tmp/cfg" cfg.Workspace_utils.base_path;
+  check string "workspace_path" "/tmp/cfg" cfg.Workspace_utils.workspace_path;
+  check int "lock_expiry_minutes" 30 cfg.Workspace_utils.lock_expiry_minutes;
+  check string "backend" "memory" (storage_backend_tag cfg.Workspace_utils.backend)
 
 let test_masc_root_dir_default_cluster () =
   let cfg = make_test_config ~base_path:"/home/user/project" ~cluster_name:"default" in
@@ -756,12 +755,10 @@ let () =
       test_case "home" `Quick test_env_opt_home;
     ];
     "storage_backend", [
-      test_case "memory variant" `Quick test_storage_backend_memory_variant;
-      test_case "filesystem variant" `Quick test_storage_backend_filesystem_variant;
+      test_case "memory is tagged" `Quick test_storage_backend_memory_is_tagged;
     ];
     "config", [
-      test_case "base_path type" `Quick test_config_base_path_type;
-      test_case "lock_expiry type" `Quick test_config_lock_expiry_type;
+      test_case "carries its fields" `Quick test_config_carries_its_fields;
     ];
     "strip_prefix", [
       test_case "basic" `Quick test_strip_prefix_basic;


### PR DESCRIPTION
## 무엇이 문제였나

`test/test_workspace_utils_coverage.ml` 의 네 케이스가 리터럴을 묶고 unit 을 반환했다:

```ocaml
let test_storage_backend_memory_variant () =
  (* Just test that the type exists and can be constructed indirectly *)
  let _ : string = "Memory" in
  ()

let test_config_lock_expiry_type () =
  (* config record has lock_expiry_minutes: int *)
  let _ : int = 30 in
  ()
```

주석은 무엇을 확인하려 했는지 말하지만, 코드는 대상 타입을 **한 번도 참조하지 않는다**. `Workspace_utils` 를 통째로 지워도 네 케이스는 통과한다. 검사한 것은 OCaml 이 `"Memory"` 를 `string` 으로 본다는 사실뿐이다.

## 변경

네 케이스를 두 개로 교체했다.

- `test_storage_backend_memory_is_tagged` — 실제 `Backend.Memory.create ()` 로 값을 만들어 태그를 확인한다.
- `test_config_carries_its_fields` — 파일에 이미 있던 `make_test_config` 로 config 를 만들어 `base_path` / `workspace_path` / `lock_expiry_minutes` / `backend` 를 확인한다.

값으로 덮을 수 없는 부분은 exhaustive match 가 맡는다:

```ocaml
let storage_backend_tag : Workspace_utils.storage_backend -> string = function
  | Workspace_utils.Memory _ -> "memory"
  | Workspace_utils.FileSystem _ -> "filesystem"
```

`FileSystem` 은 Eio fs 능력이 필요해 값을 만들기 무거우므로, 그 arm 은 컴파일 타임에만 고정된다. 세 번째 backend 가 추가되면 이 파일이 컴파일되지 않는다 — 원래 케이스들이 약속했지만 지키지 못하던 것이다.

## 검증

- `dune build --root . @check` — EXIT=0
- `test_workspace_utils_coverage.exe` — 76 케이스 통과 (78 → 76: no-op 4 개가 실제 2 개로)
- **가드가 무는지 확인**: `storage_backend` 에 생성자를 하나 넣으면
  `File "test/test_workspace_utils_coverage.ml", lines 523-525 ... function` 에서 컴파일이 실패한다. 제거하면 EXIT=0.

## 어떻게 찾았고, 그 방법이 왜 믿을 게 못 되는가

Alcotest 로 등록된 함수 중 `check` / `fail` 계열에 (헬퍼를 따라가도) 닿지 않는 것을 정규식으로 셌다. 이 수치를 **세 번 고쳤다**:

1. 처음 128 건 — 로컬 단언 헬퍼(`expect_error` 등)를 안 따라갔다
2. 50 건 — `let f x = function` 형태 헬퍼를 정의로 못 잡았다 (등호 뒤 `function`)
3. 29 건 — 여러 줄 파라미터 목록(`let f\n  ?(a = false)\n  () =`)을 못 잡았다. `test_goal_reconciliation_*` 두 건은 단언 13 개짜리 공용 헬퍼로 위임하는 정상 테스트였다

29 건 중에도 이름이 `does_not_raise` / `nonexistent` 인 것들은 "예외가 안 난다" 가 곧 단언이라 정당하다. 실제로 아무것도 확인하지 않는 것으로 확인된 것은 이 파일의 네 건뿐이다.

OCaml 정의를 정규식으로 훑는 방식은 이 세 형태 모두에서 조용히 틀린다. 남은 후보를 수치로 보고하지 않는 이유다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
