### PR TITLE
ci: 이미 통과하는 불변식 가드 30개를 실제로 돌린다 (컴파일만 되고 실행 안 되던 것)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -823,6 +823,52 @@ jobs:
             @test/runtest-test_tool_registry_consistency \
             @test/runtest-test_tool_spec
 
+      - name: Run invariant and SSOT guard suites
+        # These assert on repository shape -- baselines, mirrors, vocabulary
+        # parity, path SSOTs -- rather than on behaviour, so @check compiles
+        # them and nothing runs them. A guard that never runs stops guarding:
+        # test_masc_dirname_ssot sat red on main for a week for exactly this
+        # reason (#27117), and #26075 found the same shape by tripping over it.
+        #
+        # Every suite here was executed against origin/main before being added.
+        # Four more guards in this family are red today and are deliberately
+        # NOT listed, so this step cannot go green by ignoring them:
+        # test_masc_dirname_ssot, test_keeper_runtime_contract,
+        # test_keeper_identity_drift_counter,
+        # test_keeper_supervisor_persona_drift_order (#26075 comment).
+        run: |
+          opam exec -- dune build --root . \
+            @test/runtest-test_assertion_kind_mirror \
+            @test/runtest-test_base_path_prod_guard \
+            @test/runtest-test_bind_required_guard_counter \
+            @test/runtest-test_board_persistence_load_contract \
+            @test/runtest-test_clean_only_bug_mirrors \
+            @test/runtest-test_contract_harness_auth_script \
+            @test/runtest-test_eio_guard_yield_meter \
+            @test/runtest-test_event_bus_subscription_contract \
+            @test/runtest-test_fs_compat_home_guard \
+            @test/runtest-test_guarded_dispatch_telemetry \
+            @test/runtest-test_keeper_checkpoint_stale_guard \
+            @test/runtest-test_keeper_contract_classifier_pure \
+            @test/runtest-test_keeper_fsm_guard_actions \
+            @test/runtest-test_keeper_invariant \
+            @test/runtest-test_keeper_invocation_contract_hints \
+            @test/runtest-test_keeper_path_ssot \
+            @test/runtest-test_keeper_phase_drift_contract \
+            @test/runtest-test_keepers_runtime_dir_ssot \
+            @test/runtest-test_mcp_h1_h2_admission_parity \
+            @test/runtest-test_nickname_words_ssot \
+            @test/runtest-test_oas_canonical_delegation_contract \
+            @test/runtest-test_oas_message_constructor_contract \
+            @test/runtest-test_otel_port_ssot \
+            @test/runtest-test_release_train_guard_script \
+            @test/runtest-test_rfc_0086_keeper_namespace_invariant \
+            @test/runtest-test_server_base_path_guard \
+            @test/runtest-test_sse_retry_ssot \
+            @test/runtest-test_task_cache_invariant_13397 \
+            @test/runtest-test_tool_contract_truth \
+            @test/runtest-test_voice_command_descriptor_parity
+
       - name: Run keeper lane launch-order AST suite
         # Asserts on lib/keeper sources through Ast_grep, so @check cannot run
         # it. It sat outside every target list while one of its counts was


### PR DESCRIPTION
## 문제

불변식을 지키라고 만든 가드 스위트 30개가 **CI 에서 실행되지 않는다.** `@check` 가 컴파일만 하고 아무도 돌리지 않는다.

이 저장소는 catch-all `dune test` 게이트를 제거했고, `ci.yml` 이 `@test/runtest-<name>` 로 **명시 배선한 것만** 돈다. 워크플로 전체에 `dune test` / `@runtest`(디렉터리) / `dune build @all` 이 하나도 없다.

```
등록 테스트 실행파일 : 830
CI 가 실행하는 것    :  55   (6.6%)
```

## 안 돌면 지키지 못한다 — 실측

`test_masc_dirname_ssot` 은 잘 만든 baseline 래칫이다 (docstring 에 Jane Street expect-test / Facebook retest / Google golden files 선행 사례 인용, 재생성 명령 제공). 그런데 **깨끗한 main 에서 일주일 넘게 red** 였다. 07-28 의 `playground_paths.ml` 변경이 baseline 키를 바꿨고 재생성이 안 됐는데, 아무도 몰랐다 — CI 가 안 돌리기 때문이다 (#27117).

#26075 도 같은 형태로 2건을 "부딪혀서" 찾았다고 적었다. 그쪽 날짜도 07-28 이다.

## 변경

미배선 775개 중 이름에 `ssot|guard|parity|mirror|drift|invariant|baseline|contract` 가 든 **34개**를 골라 `origin/main` 깨끗한 워크트리에서 전부 실행했다.

| 분류 | 개수 |
|---|---|
| PASS | **30** |
| GENUINE_FAIL | 4 |
| FIXTURE_DEAD | 0 |
| NO_BUILD | 0 |

**green 인 30개만 배선한다.**

## red 4개는 일부러 넣지 않았다

이 스텝이 "빠뜨려서 green" 이 되지 않도록, 주석에 네 개를 이름으로 적어뒀다.

| 스위트 | 상태 |
|---|---|
| `test_masc_dirname_ssot` | baseline 래칫 위반 2건 (#27117) |
| `test_keeper_supervisor_persona_drift_order` | 1/2 실패 — **#25491 회귀 방지 가드** |
| `test_keeper_identity_drift_counter` | 3/5 실패 |
| `test_keeper_runtime_contract` | **5/5 전멸** — goal claim scope 격리 |

넷 다 `FIXTURE_DEAD` 가 아니라 **단언까지 도달해서 실패**한다. fixture 가 죽은 게 아니라 지키라던 불변식이 실제로 깨져 있다. 상세는 #26075 코멘트.

이 PR 은 그 넷을 고치지 않는다 — 각각 별개 판단이 필요하고, 30개를 즉시 돌리는 것과 묶으면 둘 다 늦어진다.

## 새 게이트가 아니다

이미 저장소가 작성하고 `test/dune` 에 등록한 테스트를 **실제로 돌게** 하는 것이다. 새 제약을 만들지 않는다. #25854 가 목표로 하는 "전량 CI required gate" 의 방향과 같고, 그 전체 작업 없이 얻을 수 있는 부분집합이다.

## 검증

CI 가 부를 방식 그대로 30개 타겟을 한 번에 돌렸다:

```
$ dune build --root . $(cat targets)   # 30 targets
...
Test Successful in 0.069s. 3 tests run.
RC=0
```

- 타겟 수 30 확인
- `python3 -c "yaml.safe_load(...)"` YAML 유효성 확인
- 실행 시간 합계는 초 단위 (대부분 0.1s 미만, 최장 `test_release_train_guard_script` 4.5s)

## 남은 것

775 → 745. 나머지는 #26075 의 전수 인벤토리 대상이다. 이 PR 은 그중 **불변식을 지키는 성격이라 안 돌면 존재 이유가 사라지는** 부분집합만 처리한다.
