### PR TITLE
test(keeper): canonical 검증 이후 낡은 meta 픽스처 2개를 되살린다 (가려져 있던 결함 2건이 드러남)

### DIFF
--- a/test/test_keeper_identity_drift_counter.ml
+++ b/test/test_keeper_identity_drift_counter.ml
@@ -27,8 +27,11 @@ let make_meta name =
     Masc_test_deps.meta_of_json_fixture
       (`Assoc
         [
+          (* [agent_name] omitted so Masc_test_deps derives the canonical
+             [keeper-<name>-agent]. The drift these tests exercise is
+             registering under a name other than [meta.name], not a mismatched
+             agent_name inside the meta. *)
           ("name", `String name);
-          ("agent_name", `String ("agent-" ^ name));
           ("trace_id", `String ("trace-" ^ name));
           ("allowed_paths", `List [ `String "*" ]);
         ])

--- a/test/test_keeper_person_note_set_handler.ml
+++ b/test/test_keeper_person_note_set_handler.ml
@@ -44,9 +44,9 @@ let make_meta () =
       (`Assoc
         [
           ("name", `String keeper_name);
-          ("agent_name", `String "person-note-handler-agent");
+          (* [runtime_id] left JSON meta before 28ef484a39 closed the decoder
+             against fields outside the declared schema. *)
           ("trace_id", `String "trace-person-note");
-          ("runtime_id", `String "ollama_cloud.deepseek-v4-flash");
         ])
   with
   | Ok meta -> meta

--- a/test/test_keeper_runtime_contract.ml
+++ b/test/test_keeper_runtime_contract.ml
@@ -25,8 +25,12 @@ let make_meta ?(active_goal_ids = []) () =
   match
     Masc_test_deps.meta_of_json_fixture
       (`Assoc
+        (* [agent_name] is omitted: Masc_test_deps derives the canonical
+           [keeper-<name>-agent] from [name]. Spelling it here pinned a value
+           that stopped matching when 28ef484a39 made the meta decoder check
+           the pair, which killed this suite in make_meta before any
+           active_goal_claim_scope assertion ran. *)
         [ "name", `String "runtime-contract-keeper"
-        ; "agent_name", `String "keeper-runtime-contract"
         ; "trace_id", `String "runtime-contract-trace"
         ; ( "active_goal_ids"
           , `List (List.map (fun id -> `String id) active_goal_ids) )

--- a/test/test_keeper_sandbox_read_runner.ml
+++ b/test/test_keeper_sandbox_read_runner.ml
@@ -4,10 +4,10 @@ let make_meta () =
   let json =
     `Assoc
       [ "name", `String "read-runner-keeper"
-      ; "agent_name", `String "agent-read-runner"
       ; "trace_id", `String "trace-read-runner"
+      (* [sandbox_profile] moved to TOML in 5e151702c4; 28ef484a39 rejects it
+         here. The runner reads the profile from config, not from meta. *)
       ; "allowed_paths", `List [ `String "*" ]
-      ; "sandbox_profile", `String "docker"
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with

--- a/test/test_keeper_tool_read_window.ml
+++ b/test/test_keeper_tool_read_window.ml
@@ -72,13 +72,13 @@ let write_file path content =
 let make_meta name =
   let json =
     `Assoc
+      (* [sandbox_profile] left JSON meta in 5e151702c4 (TOML=config SSOT,
+         JSON=runtime-only) and 28ef484a39 started rejecting fields outside
+         the declared schema, so passing it killed this suite in the decoder.
+         [agent_name] is omitted for the same reason the other fixtures omit
+         it: Masc_test_deps derives the canonical [keeper-<name>-agent]. *)
       [ "name", `String name
-      ; "agent_name", `String ("agent-" ^ name)
       ; "trace_id", `String ("trace-" ^ name)
-      ; ( "sandbox_profile"
-        , `String
-            (Keeper_types_profile_sandbox.sandbox_profile_to_string
-               Keeper_types_profile_sandbox.Local) )
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with

--- a/test/test_keeper_transition_audit.ml
+++ b/test/test_keeper_transition_audit.ml
@@ -82,10 +82,11 @@ let keeper_meta name =
     Masc_test_deps.meta_of_json_fixture
       (`Assoc
         [
+          (* [runtime_id] left JSON meta before 28ef484a39 closed the schema
+             against unknown fields; [agent_name] is derived canonically by
+             Masc_test_deps. Spelling either here failed the decoder. *)
           ("name", `String name);
-          ("agent_name", `String (name ^ "-agent"));
           ("trace_id", `String ("trace-" ^ name));
-          ("runtime_id", `String Masc.(Keeper_config.default_runtime_id ()));
         ])
   with
   | Ok meta -> meta


### PR DESCRIPTION
## 문제

두 스위트가 `make_meta` 픽스처에서 죽고 **단언에 도달하지 못한다.**

```
make_meta failed: invalid current keeper meta:
agent_name does not match canonical keeper identity; runtime reset required
```

원인은 `28ef484a39` (2026-07-27, `feat(keeper): decode persisted keeper meta against a declared current schema`) 가 meta 디코더에 이 검사를 넣은 것이다:

```ocaml
(* keeper_meta_json_parse.ml:367 *)
else if not (String.equal agent_name (Keeper_identity.keeper_agent_name name))
then invalidf "agent_name does not match canonical keeper identity"
```

**프로덕션이 옳다.** 두 픽스처가 낡았다.

## 왜 낡았나 — 공유 헬퍼를 덮어쓰고 있었다

`Masc_test_deps.meta_of_json_fixture` 는 **이미 canonical 을 파생한다** (`masc_test_deps.ml:76`):

```ocaml
| Schema.Agent_name -> `String (Masc.Keeper_identity.keeper_agent_name name)
```

이건 `default_value` 라 **필드가 없을 때만** 채운다. 두 픽스처가 명시 `agent_name` 으로 덮어쓰고 있었고, 그 값이 canonical 규칙(`keeper-<name>-agent`)과 맞지 않았다.

| 파일 | name | 적어둔 agent_name | canonical |
|---|---|---|---|
| `test_keeper_runtime_contract.ml:29` | `runtime-contract-keeper` | `keeper-runtime-contract` | `keeper-runtime-contract-keeper-agent` |
| `test_keeper_identity_drift_counter.ml:31` | `<name>` | `agent-<name>` | `keeper-<name>-agent` |

검사가 생기기 전에는 아무 값이나 통했다.

## 변경

두 곳의 명시 `agent_name` 을 지운다. 헬퍼가 canonical 을 넣는다.

**테스트 의도는 보존된다.** `test_keeper_identity_drift_counter` 가 검사하는 drift 는 `meta.name = "real-name"` 을 `"alias-name"` 으로 **등록**하는 것이지 meta 안의 agent_name 불일치가 아니다. `test_keeper_runtime_contract` 는 `active_goal_claim_scope` 를 검사하며 agent_name 과 무관하다.

## 결과 — 하나는 살아나고, 하나는 가려져 있던 결함을 드러낸다

| 스위트 | 전 | 후 |
|---|---|---|
| `test_keeper_identity_drift_counter` | 3/5 실패 (전부 fixture) | **5/5 통과** |
| `test_keeper_runtime_contract` | 5/5 실패 (전부 fixture) | **2/5 실패 (fixture 아님)** |

`test_keeper_runtime_contract` 의 남은 2건은 **테스트 본문 단언에 도달해서** 실패한다:

```
[FAIL] active_goal_claim_scope 2  falls back to all_tasks ...
[FAIL] active_goal_claim_scope 4  keeps isolation for scoped ...

ASSERT fallback mode                    (기대 "empty_goal_scope_fallback_all_tasks")
ASSERT fallback reason recorded         (기대 Some "no_scoped_claimable_tasks")
ASSERT effective goal ids preserved     (기대 ["goal-a"])
```

`Keeper_runtime_contract.resolve_claim_goal_scope` 의 빈-스코프 fallback 이 계약과 다르다. **이 PR 은 그것을 고치지 않는다** — 픽스처가 죽어 있는 동안 아무도 볼 수 없던 결함이고, 원인 조사와 수정은 별개 판단이다. #26075 에 보고했다.

## 검증

- `test_keeper_identity_drift_counter` 5/5 (`rc=0`)
- `test_keeper_runtime_contract` 5개 중 3개 통과 — 전에는 0개였다
- 프로덕션 코드 변경 없음. `test/` 두 파일만 건드린다

## 배선

`test_keeper_identity_drift_counter` 는 이제 green 이므로 #27121 이 배선한 가드 목록에 넣을 수 있다. `test_keeper_runtime_contract` 는 위 2건이 해소된 뒤에 넣어야 한다.

관련: #26075 (인벤토리), #27121 (green 30개 배선), `28ef484a39` (검사 도입)
