### PR TITLE
fix(local-runtime-pool): delete four values nothing calls

### DIFF
--- a/lib/local_runtime_pool/dune
+++ b/lib/local_runtime_pool/dune
@@ -5,6 +5,8 @@
  (public_name masc.local_runtime_pool)
  (wrapped false)
  (modules local_runtime_pool)
+ (flags
+  (:standard -w +4 -w +32))
  (libraries
   agent_sdk.llm_provider
   eio

--- a/lib/local_runtime_pool/local_runtime_pool.ml
+++ b/lib/local_runtime_pool/local_runtime_pool.ml
@@ -45,14 +45,6 @@ let default_parallel_hint = 12
 
 let wall_now () = Unix.gettimeofday ()
 
-let float_of_env_default name ~default =
-  match Sys.getenv_opt name with
-  | None -> default
-  | Some raw ->
-      match float_of_string_opt (String.trim raw) with
-      | Some value when value > 0.0 -> value
-      | _ -> default
-
 let cooldown_seconds () =
   match Env_config.Worker.local_runtime_cooldown_sec_opt () with
   | Some raw ->
@@ -194,42 +186,6 @@ let refresh_runtime_metrics (runtime : runtime) =
       { runtime with queue_depth; cooldown_until = None; failure_streak = 0 }
   | _ -> { runtime with queue_depth }
 
-let normalize_runtime_json json =
-  let base_url = Json_util.get_string json "base_url" |> trim_opt in
-  match base_url with
-  | None -> Error "runtime.base_url is required"
-  | Some base_url ->
-      let id =
-        Json_util.get_string json "id" |> trim_opt
-        |> Option.value ~default:(runtime_id_of_base_url base_url)
-      in
-      let model = Json_util.get_string json "model" |> trim_opt in
-      let max_concurrency =
-        match json |> Json_util.assoc_member_opt "max_concurrency" with
-        | Some (`Int value) -> max 1 value
-        | Some (`Intlit raw) -> (
-            match parse_int_opt raw with
-            | Some value -> max 1 value
-            | None -> default_parallel_hint)
-        | _ -> default_parallel_hint
-      in
-      Ok
-        {
-          id;
-          base_url;
-          model;
-          max_concurrency;
-          active_slots = 0;
-          queue_depth = 0;
-          latency_ema_ms = None;
-          failure_streak = 0;
-          cooldown_until = None;
-          last_error = None;
-          total_started = 0;
-          total_success = 0;
-          total_failure = 0;
-        }
-
 let default_runtime () =
   let base_url = Env_config.Local_runtime.server_url in
   {
@@ -248,31 +204,6 @@ let default_runtime () =
     total_success = 0;
     total_failure = 0;
   }
-
-let runtime_from_endpoint base_url =
-  {
-    id = runtime_id_of_base_url base_url;
-    base_url;
-    model = trim_opt (Env_config.Local_runtime.worker_model_opt ());
-    max_concurrency =
-      int_of_env_default "LLAMA_SERVER_PARALLEL_HINT"
-        ~default:default_parallel_hint;
-    active_slots = 0;
-    queue_depth = 0;
-    latency_ema_ms = None;
-    failure_streak = 0;
-    cooldown_until = None;
-    last_error = None;
-    total_started = 0;
-    total_success = 0;
-    total_failure = 0;
-  }
-
-let parse_llm_endpoints raw =
-  raw
-  |> String.split_on_char ','
-  |> List.filter_map (fun item -> trim_opt (Some item))
-  |> List.map runtime_from_endpoint
 
 let current_fingerprint () =
   String.concat "||"


### PR DESCRIPTION
## 무엇이 문제였나

`local_runtime_pool.ml` 이 아무도 부르지 않는 값 네 개를 들고 있었다. `.mli` 로 노출되지도 않아 파일 밖에서 부를 수도 없다.

가장 분명한 것은 `parse_llm_endpoints` 다. 마지막으로 손댄 커밋이

```
8f5582af73 refactor(runtime): drop dead OAS 0.212.0 APIs — guardrails, idle, endpoints (#24433)
```

**endpoints API 를 지운 커밋**이고, 파서만 남았다. `LLM_ENDPOINTS` 류 환경 노브도 repo 어디에도 없다.

나머지 셋:

| 값 | 상태 |
|---|---|
| `parse_llm_endpoints` | #24433 이 지운 API 의 잔여물 |
| `runtime_from_endpoint` | 위 파서만 쓰던 헬퍼 — 연쇄로 죽음 |
| `normalize_runtime_json` | 호출자 없음 (#20171 경계 승격 이후) |
| `float_of_env_default` | 호출자 없음. 같은 이름 helper 가 `lib/server/` 에서 따로 쓰이지만 이 사본은 노출되지 않아 그쪽과 무관하다 |

## 어떻게 찾았고 어떻게 지웠나

컴파일러가 찾고 컴파일러가 연쇄를 따라갔다. `-w +32` (`unused-value-declaration`) 를 켜면 셋이 나오고, `parse_llm_endpoints` 를 지우면 `runtime_from_endpoint` 가 새로 죽는다. 더 나올 것이 없을 때까지 반복했다 — 2 라운드.

정규식으로 "호출처 0 건" 을 세는 방식은 이 연쇄를 못 본다. 첫 라운드만 보고 멈춘다.

## 변경

- 죽은 값 4 개 제거 (69 줄)
- `lib/local_runtime_pool/dune` 에 `(:standard -w +4 -w +32)` 추가

두 번째 항목이 가능해진 것은 삭제의 부수 효과다. 이 라이브러리는 `-w +4` (fragile-match) 때문에 #27101 의 래칫 대상에서 빠져 있었는데, 그 fragile match 들이 지운 함수 안에 있었다. 죽은 코드를 치우니 표준 플래그 쌍으로 깨끗하게 빌드된다.

`#27101` 은 이 파일을 건드리지 않으므로 충돌하지 않는다.

## 검증

- `dune build --root . @check` — EXIT=0 (`-w +4 -w +32` 켠 상태)
- 연쇄가 멈출 때까지 반복 후 `-w +32` 경고 0 건
- `scripts/check-doc-code-refs.sh` — EXIT=0

## 남은 것

같은 스윕에서 다른 라이브러리의 미사용 값도 나왔다. 성격이 갈려 이 PR 에 넣지 않았다:

- `lib/otel_spans/opentelemetry_client_cohttp_eio.ml` (3 건) — 상류에서 가져온 vendored 파일. 상류와 가깝게 두는 편이 맞다.
- `lib/fusion_core/fusion_types.ml` 의 `equal_result` / `pp_result` — `[@@deriving]` 산출물로 보인다. 손으로 지울 대상이 아니다.
- `lib/tool/tool_catalog.ml` 의 `keeper_shard_vote` — 형제 셋(`read`/`write`/`add_task`)은 쓰이는데 이것만 죽었다. boundary guard 가 "retired runtime-shard worldview" 를 은퇴 개념으로 지목하고 있어 별도로 볼 값이 있다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
