### PR TITLE
fix(tool-local-runtime): drop handlers dispatch cannot reach

### DIFF
--- a/lib/tool_local_runtime.ml
+++ b/lib/tool_local_runtime.ml
@@ -14,11 +14,8 @@ open Masc_domain
 module Core = Tool_local_runtime_core
 
 (* Re-export sub-module public values used by external callers *)
-let runtime_status_json = Tool_local_runtime_status.runtime_status_json
 let runtime_verify_json = Tool_local_runtime_verify.runtime_verify_json
 let runtime_ollama_probe_json = Tool_local_runtime_probe.runtime_ollama_probe_json
-let run_bench = Tool_local_runtime_bench.run_bench
-let provider_health_reachable = Tool_local_runtime_verify.provider_health_reachable
 let ollama_loaded_models_of_ps_json = Tool_local_runtime_probe.ollama_loaded_models_of_ps_json
 let ollama_probe_run_of_generate_json = Tool_local_runtime_probe.ollama_probe_run_of_generate_json
 let kv_cache_assessment_json = Tool_local_runtime_probe.kv_cache_assessment_json
@@ -40,45 +37,6 @@ let err_response ~tool_name ~start_time ~class_ msg : Core.tool_result =
     ~data
     (Yojson.Safe.to_string data)
 ;;
-
-let handle_models _ctx : Core.tool_result =
-  let tool_name = "masc_runtime_models" in
-  let start_time = Time_compat.now () in
-  match Core.fetch_models () with
-  | Error msg ->
-      err_response
-        ~tool_name
-        ~start_time
-        ~class_:Tool_result.Transient_error
-        msg
-  | Ok (url, models) ->
-      ok_response
-        ~tool_name
-        ~start_time
-        [
-          ( "result",
-            `Assoc
-              [
-                ("server_url", `String Env_config.Local_runtime.server_url);
-                ("endpoint", `String url);
-                ("source", `String "llama.cpp /v1/models");
-                ("models", `List (List.map (fun m -> `String m) models));
-                ("model_count", `Int (List.length models));
-              ] );
-        ]
-
-let handle_runtime_status _ctx args : Core.tool_result =
-  let tool_name = "masc_runtime_status" in
-  let start_time = Time_compat.now () in
-  let include_models =
-    match Json_util.assoc_member_opt "include_models" args with
-    | Some (`Bool flag) -> flag
-    | _ -> true
-  in
-  ok_response
-    ~tool_name
-    ~start_time
-    [ ("result", runtime_status_json ~include_models ()) ]
 
 let handle_runtime_verify _ctx args : Core.tool_result =
   let tool_name = "masc_runtime_verify" in
@@ -104,64 +62,6 @@ let handle_runtime_verify _ctx args : Core.tool_result =
       ( "result",
         runtime_verify_json ?runtime_pool ?expected_slots ?expected_ctx ?expected_model () );
     ]
-
-let handle_runtime_bench _ctx args : Core.tool_result =
-  let tool_name = "masc_runtime_bench" in
-  let start_time = Time_compat.now () in
-  let model_id = Json_util.get_string args "model" in
-  let runtime_pool = Json_util.get_string args "runtime_pool" in
-  let parallelism =
-    match Json_util.assoc_member_opt "parallelism" args with
-    | Some (`Int value) -> max 1 (min 128 value)
-    | Some (`Intlit value) -> (
-        match Core.parse_int_opt value with
-        | Some parsed -> max 1 (min 128 parsed)
-        | None -> 8)
-    | _ -> 8
-  in
-  let rounds =
-    match Json_util.assoc_member_opt "rounds" args with
-    | Some (`Int value) -> max 1 (min 8 value)
-    | Some (`Intlit value) -> (
-        match Core.parse_int_opt value with
-        | Some parsed -> max 1 (min 8 parsed)
-        | None -> 1)
-    | _ -> 1
-  in
-  let max_tokens =
-    match Json_util.assoc_member_opt "max_tokens" args with
-    | Some (`Int value) -> max 1 (min 128 value)
-    | Some (`Intlit value) -> (
-        match Core.parse_int_opt value with
-        | Some parsed -> max 1 (min 128 parsed)
-        | None -> 16)
-    | _ -> 16
-  in
-  let timeout_sec =
-    match Json_util.assoc_member_opt "timeout_sec" args with
-    | Some (`Int value) -> max 3 (min 120 value)
-    | Some (`Intlit value) -> (
-        match Core.parse_int_opt value with
-        | Some parsed -> max 3 (min 120 parsed)
-        | None -> 8)
-    | _ -> 8
-  in
-  let prompt =
-    match Json_util.assoc_member_opt "prompt" args with
-    | Some (`String value) when not (String.equal (String.trim value) "") -> String.trim value
-    | _ -> "Reply with exactly one short word: ready"
-  in
-  match
-    run_bench ?model_id ?runtime_pool ~parallelism ~rounds ~prompt
-      ~max_tokens ~timeout_sec ()
-  with
-  | Ok json -> ok_response ~tool_name ~start_time [ ("result", json) ]
-  | Error err ->
-      err_response
-        ~tool_name
-        ~start_time
-        ~class_:Tool_result.Runtime_failure
-        err
 
 let run_runtime_ollama_probe ?timeout_sec args : Core.tool_result =
   let tool_name = "masc_runtime_ollama_probe" in

--- a/lib/tool_local_runtime.mli
+++ b/lib/tool_local_runtime.mli
@@ -20,65 +20,17 @@
     kept on {!Tool_local_runtime_core}; this top-level module no
     longer re-exports that surface.
 
-    Internal: 5 [handle_*] functions ([handle_models],
-    [handle_runtime_status], [handle_runtime_verify],
-    [handle_runtime_bench], [handle_runtime_ollama_probe]) plus
-    the [Tool_spec.register] side-effect block stay private.  The
-    .mli pins the dispatch / schemas contract — handler bodies are
-    free to refactor. *)
+    Internal: the two [handle_*] functions [dispatch] routes to
+    ([handle_runtime_verify], [handle_runtime_ollama_probe]) plus the
+    [Tool_spec.register] side-effect block stay private.  The .mli pins
+    the dispatch / schemas contract — handler bodies are free to
+    refactor.
+
+    The re-exports left below are the ones tests reach through this
+    facade; the status / verify / bench adapters had no consumer at
+    all. *)
 
 (** {1 Status / verify / probe / bench re-exports} *)
-
-val runtime_status_json :
-  ?include_models:bool -> unit -> Yojson.Safe.t
-(** Re-export of {!Tool_local_runtime_status.runtime_status_json}. *)
-
-val runtime_verify_json :
-  ?runtime_pool:string ->
-  ?expected_slots:int ->
-  ?expected_ctx:int ->
-  ?expected_model:string ->
-  unit ->
-  Yojson.Safe.t
-(** Re-export of {!Tool_local_runtime_verify.runtime_verify_json}. *)
-
-val runtime_ollama_probe_json :
-  ?server_url:string ->
-  ?model:string ->
-  ?prompt:string ->
-  ?probe_runs:int ->
-  ?keep_alive:string ->
-  ?max_tokens:int ->
-  ?think_mode:Tool_local_runtime_probe.ollama_probe_think_mode ->
-  ?timeout_sec:int ->
-  ?ps_timeout_sec:int ->
-  ?generate_when_unloaded:bool ->
-  ?run_generate:bool ->
-  unit ->
-  Yojson.Safe.t
-(** Re-export of {!Tool_local_runtime_probe.runtime_ollama_probe_json}.
-    All parameters are optional with defaults: [probe_runs = 2],
-    [max_tokens = 16], [think_mode = Think_auto],
-    [timeout_sec = 6] (positive explicit values are preserved),
-    [ps_timeout_sec = 2],
-    [generate_when_unloaded = true], [run_generate = true].  Per
-    PR #20479 spirit: the tool itself (ollama [OLLAMA_LOAD_TIMEOUT])
-    owns hang protection; callers do not observe these timeouts. *)
-
-val run_bench :
-  ?model_id:string ->
-  ?runtime_pool:string ->
-  parallelism:int ->
-  rounds:int ->
-  prompt:string ->
-  max_tokens:int ->
-  timeout_sec:int ->
-  unit ->
-  (Yojson.Safe.t, string) Result.t
-(** Re-export of {!Tool_local_runtime_bench.run_bench}. *)
-
-val provider_health_reachable : status:int option -> bool
-(** Re-export of {!Tool_local_runtime_verify.provider_health_reachable}. *)
 
 val ollama_loaded_models_of_ps_json :
   Yojson.Safe.t -> [> `Assoc of (string * Yojson.Safe.t) list ] list


### PR DESCRIPTION
## 무엇이 문제였나

`tool_local_runtime.ml` 의 `.mli` 가 두 가지를 주장하는데 둘 다 사실이 아니었다.

**주장 1**: "Internal: **5** `handle_*` functions … stay private"

`dispatch` 가 닿는 이름은 둘뿐이다:

```ocaml
let dispatch ctx ~name ~args =
  match name with
  | "masc_runtime_verify" -> Some (handle_runtime_verify ctx args)
  | "masc_runtime_ollama_probe" -> Some (handle_runtime_ollama_probe ctx args)
  | _ -> None
```

나머지 셋(`handle_models`, `handle_runtime_status`, `handle_runtime_bench`)은 도달할 수 없다. `handle_models` 가 쓰는 도구명 `"masc_runtime_models"` 는 `schemas` 에도 없다.

이 셋을 마지막으로 손댄 커밋이 출처를 말해준다:

```
e63532eb85 2026-04-03 chore(tools): purge 61 zero-caller tools (-5.6K lines) (#4782)
```

**호출자 0 인 도구를 치우는 커밋이 핸들러 셋을 남겼다.**

**주장 2**: "deliberate status / verify / probe / bench **adapter exports**"

8 개 재수출 중 다섯(`runtime_status_json`, `run_bench`, `provider_health_reachable`, `runtime_verify_json`, `runtime_ollama_probe_json`)은 모듈 밖에서 아무도 쓰지 않는다.

## 광고-실행 불일치는 없었다

죽은 핸들러가 있으니 `schemas` 가 실행 불가 도구를 광고할 것이라고 가정했는데, 확인하니 아니었다. `Tool_schemas_local_runtime.schemas` 는 `masc_runtime_verify` 와 `masc_runtime_ollama_probe` 정확히 둘만 광고한다 — `dispatch` 가 처리하는 그 둘이다. 스키마 표면과 디스패치 표는 일치한다.

## 변경

- 도달 불가 핸들러 3 개 제거
- 소비자 0 인 재수출 5 개 제거 (`.ml` 에서 3 개, `.mli` 에서 5 개 — 둘은 파일 안에서 살아있는 핸들러가 쓰므로 `let` 은 남고 `val` 만 뺀다)
- `.mli` 헤더의 "5 handle_* functions" 서술을 사실에 맞게 수정

**남긴 것**: `ollama_loaded_models_of_ps_json` / `ollama_probe_run_of_generate_json` / `kv_cache_assessment_json` 은 `test/test_tool_local_runtime_probe.ml` 이 이 facade 를 통해 쓴다. 테스트가 하위 라이브러리를 직접 참조하도록 바꾸는 편이 나을 수 있지만, 그건 이 PR 이 고치는 것과 별개다.

157 줄 삭제, 9 줄 추가.

## 검증

- `dune build --root . @check` — EXIT=0
- `test_tool_local_runtime_probe.exe` — 19 케이스 통과 (남긴 재수출을 쓰는 테스트)
- `scripts/check-doc-code-refs.sh` — EXIT=0

## 측정 중 고친 것

처음 소비자를 셀 때 `grep -v 'tool_local_runtime'` 로 자기 파일을 걸렀는데, 이 패턴이 **파일명에도 매칭**해서 `test/test_tool_local_runtime_probe.ml` 의 사용을 통째로 가렸다. 그대로였다면 테스트가 쓰는 재수출 셋을 지웠을 것이다. 빌드가 `Unbound value` 로 잡아줬고, 심볼 기준(`Tool_local_runtime.<name>`)으로 다시 세어 표를 만들었다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
