### PR TITLE
fix(keeper): delete four classifiers nothing calls

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -251,29 +251,6 @@ let is_auto_recoverable_runtime_exhausted_error (err : Agent_sdk.Error.sdk_error
   | None ->
       false
 
-let is_resumable_cli_session_error (err : Agent_sdk.Error.sdk_error) : bool =
-  match Keeper_turn_driver.classify_masc_internal_error err with
-  | Some (Keeper_turn_driver.Resumable_cli_session _) -> true
-  | Some (Keeper_turn_driver.Runtime_exhausted _)
-  | Some (Keeper_turn_driver.Capacity_backpressure _)
-  | Some (Keeper_turn_driver.Accept_rejected _)
-  (* RFC-0159 Phase A: opaque internal failures. *)
-  | Some (Keeper_turn_driver.Internal_unhandled_exception _)
-  | Some (Keeper_turn_driver.Internal_bridge_exception _)
-  | Some (Keeper_turn_driver.Internal_contract_rejected _)
-  | Some (Keeper_turn_driver.Incomplete_tool_transcript _)
-  | Some (Keeper_turn_driver.Terminal_effect_failed _)
-  | Some (Keeper_turn_driver.Receipt_persistence_failed _)
-  | Some (Keeper_turn_driver.Gate_replay_repair_required _)
-  | None ->
-      false
-
-let is_auto_recoverable_runtime_fail_open_error
-    (err : Agent_sdk.Error.sdk_error) : bool =
-  Keeper_runtime_failure_route.sdk_error_is_hard_quota err
-  || is_resumable_cli_session_error err
-  || is_auto_recoverable_runtime_exhausted_error err
-
 let is_accept_no_usable_progress_error (err : Agent_sdk.Error.sdk_error) : bool =
   match Keeper_turn_driver.classify_masc_internal_error err with
   | Some
@@ -335,13 +312,6 @@ let accept_rejection_degraded_retry_reason err =
      | Some `Thinking_only_no_progress -> Some Thinking_only_no_progress
      | None -> None)
   | None -> None
-
-let is_recoverable_no_progress_accept_rejection
-    (err : Agent_sdk.Error.sdk_error) : bool =
-  match accept_rejection_degraded_retry_reason err with
-  | Some (Empty_no_progress | Thinking_only_no_progress) ->
-    true
-  | Some _ | None -> false
 
 type degraded_retry =
   { next_runtime : string
@@ -609,14 +579,6 @@ let default_degraded_rotation_candidates
   | Some (Hard_quota | Rate_limit)
   | None ->
     default_candidates
-
-let normalize_rotation_candidates ~catalog_names candidates =
-  candidates
-  |> List.filter_map (fun candidate ->
-         let trimmed = String.trim candidate in
-         if String.equal trimmed "" then None
-         else Some (normalized_runtime_id ~catalog_names trimmed))
-  |> dedupe_keep_order
 
 let degraded_rotation_candidates
     ~catalog_names


### PR DESCRIPTION
## 무엇이 문제였나

`keeper_error_classify.ml` 은 오류를 분류하는 모듈인데, **아무도 부르지 않는 분류기 셋**을 들고 있었다. 셋 다 참조가 자기 정의 1 회뿐이고 `.mli` (val 23 개) 에도 없다.

각각을 마지막으로 손댄 커밋이 출처를 말한다 — **세 번의 서로 다른 삭제가 각각 하나씩 남겼다**:

| 죽은 분류기 | 남긴 커밋 |
|---|---|
| `is_auto_recoverable_runtime_fail_open_error` | `a7b9f1f8d0 [codex] remove cascade concept (#19600)` |
| `is_recoverable_no_progress_accept_rejection` | `7b62a87d44 refactor: replace Keeper governance with a nonhierarchical Gate (#24332)` |
| `normalize_rotation_candidates` | `a7b5f8b4d7 refactor(keeper): remove dead fail_open rotation pipeline` |

세 커밋 모두 "죽은 것을 치운다" 고 선언한 커밋이다.

## 연쇄

`is_auto_recoverable_runtime_fail_open_error` 를 지우자 그것만 부르던 `is_resumable_cli_session_error` 가 죽었다. 더 나올 것이 없을 때까지 반복해 2 라운드에 수렴했다. 총 38 줄.

호출처를 정규식으로 세는 방식은 이 두 번째 라운드를 못 본다.

## 검증

- `dune build --root . @check` — EXIT=0
- `test_keeper_classifier_helper.exe` — 7 케이스 통과
- `scripts/check-doc-code-refs.sh` — EXIT=0

## 측정 중 고친 것

`-w +32` 를 `lib/dune` 에 넣으려고 `(:standard ...)` 를 치환했는데, `lib/dune` 에는 그 필드가 아예 없어서 **치환이 무효였다**. 조건문이 `-w +32 not in text` 만 봐서 "적용됨" 이라고 출력했고, 이어진 빌드가 깨끗하게 나와 하마터면 "연쇄 없음" 으로 결론지을 뻔했다. `(flags ...)` 를 새로 삽입해 다시 재니 위의 연쇄가 나왔다.

## 범위 밖

같은 래칫을 `lib/` 전체에 켜면 **미사용 값 60 건**이 나온다. 이 PR 은 그 중 한 모듈만 다룬다. 나머지는 성격이 갈려 (vendored, `[@@deriving]` 산출물, 툴킷 미사용 부품, 헬퍼 패밀리 일부) 일괄 삭제 대상이 아니고, 군집마다 이력 확인이 필요하다. `lib/dune` 의 래칫은 되돌렸다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
