### PR TITLE
fix(dashboard): classify fusion run status events

### DIFF
--- a/dashboard/src/sse-event-type-parity.test.ts
+++ b/dashboard/src/sse-event-type-parity.test.ts
@@ -51,6 +51,7 @@ const BACKEND_EMITTED: Record<string, string> = {
   post_created: '../lib/keeper_runtime/keeper_event_queue.ml',
   project_snapshot: '../lib/server/server_mcp_transport_ws.ml',
   transport_health_snapshot: '../lib/server/server_dashboard_http_execution_surfaces.ml',
+  fusion_run_status: '../lib/fusion/fusion_sink.ml',
 }
 
 // event-type -> why it has no masc backend literal to bind to. Keep short and


### PR DESCRIPTION
## Summary
- classify the backend-emitted `fusion_run_status` route in the SSE event parity gate
- restore the Dashboard CI gate that failed after #26931 merged

## Verification
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/sse-event-type-parity.test.ts` (25 passed)
- `npx tsc --noEmit --pretty`
- `pnpm exec eslint src/sse-event-type-parity.test.ts` (0 errors; file outside configured lint targets)
- `git diff --check`