### PR TITLE
refactor(gate): 커넥터 outcome 어휘를 하나로 (손으로 유지하던 미러 2개 → 컴파일러가 강제)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -825,12 +825,14 @@ jobs:
 
       - name: Run connector observability label contract
         # These strings are metric label values, so a rename is a wire change
-        # that compiles. @check cannot catch that, and the pre-existing
-        # test_discord_observability is itself unwired (part of the inventory
-        # in #26075), so nothing was running here at all.
+        # that compiles. @check cannot catch that, and test_discord_observability
+        # was never wired into any target list, so nothing was running here at
+        # all. It passes 8/8 on this branch, so it joins rather than staying in
+        # the #26075 inventory.
         run: |
           opam exec -- dune build --root . \
-            @test/runtest-test_gate_connector_observability
+            @test/runtest-test_gate_connector_observability \
+            @test/runtest-test_discord_observability
 
       - name: Run keeper lane launch-order AST suite
         # Asserts on lib/keeper sources through Ast_grep, so @check cannot run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -823,6 +823,15 @@ jobs:
             @test/runtest-test_tool_registry_consistency \
             @test/runtest-test_tool_spec
 
+      - name: Run connector observability label contract
+        # These strings are metric label values, so a rename is a wire change
+        # that compiles. @check cannot catch that, and the pre-existing
+        # test_discord_observability is itself unwired (part of the inventory
+        # in #26075), so nothing was running here at all.
+        run: |
+          opam exec -- dune build --root . \
+            @test/runtest-test_gate_connector_observability
+
       - name: Run keeper lane launch-order AST suite
         # Asserts on lib/keeper sources through Ast_grep, so @check cannot run
         # it. It sat outside every target list while one of its counts was

--- a/lib/gate/discord_observability.ml
+++ b/lib/gate/discord_observability.ml
@@ -1,9 +1,6 @@
 (** Discord connector observability helpers. *)
 
-type gateway_route =
-  | Control
-  | Triggered
-  | Ambient
+include Gate_connector_observability
 
 type gateway_event =
   | Ready
@@ -20,57 +17,12 @@ type reconnect_outcome =
   | Reconnect_succeeded
   | Reconnect_failed
 
-type inbound_outcome =
-  | Dropped_unbound
-  | Dispatch_unavailable
-  | Gate_error
-  | Empty_reply
-  | Reply_sent
-  | Reply_send_error
-
-type ambient_outcome =
-  | Ambient_recorded
-  | Ambient_binding_store_error
-  | Ambient_dropped_unbound
-  | Ambient_dropped_empty
-  | Ambient_dropped_too_long
-
-type reply_outcome =
-  | Reply_empty
-  | Reply_send_ok
-  | Reply_send_failed
-
-let gateway_route_label = function
-  | Control -> "control"
-  | Triggered -> "triggered"
-  | Ambient -> "ambient"
-
 let gateway_event_label = function
   | Ready -> "ready"
   | Message_create -> "message_create"
   | Reaction_add -> "reaction_add"
   | Ignored -> "ignored"
   | Open_wss -> "open_wss"
-
-let inbound_outcome_label = function
-  | Dropped_unbound -> "dropped_unbound"
-  | Dispatch_unavailable -> "dispatch_unavailable"
-  | Gate_error -> "gate_error"
-  | Empty_reply -> "empty_reply"
-  | Reply_sent -> "reply_sent"
-  | Reply_send_error -> "reply_send_error"
-
-let ambient_outcome_label = function
-  | Ambient_recorded -> "recorded"
-  | Ambient_binding_store_error -> "binding_store_error"
-  | Ambient_dropped_unbound -> "dropped_unbound"
-  | Ambient_dropped_empty -> "dropped_empty"
-  | Ambient_dropped_too_long -> "dropped_too_long"
-
-let reply_outcome_label = function
-  | Reply_empty -> "empty"
-  | Reply_send_ok -> "sent"
-  | Reply_send_failed -> "send_error"
 
 let reconnect_method_label = function
   | Resume -> "resume"

--- a/lib/gate/discord_observability.mli
+++ b/lib/gate/discord_observability.mli
@@ -4,10 +4,19 @@
     message, or keeper identifiers are exported. Runtime identity stays in
     JSONL logs and connector status surfaces. *)
 
-type gateway_route =
-  | Control
-  | Triggered
-  | Ambient
+(** The outcome vocabularies and their labels come from
+    {!Gate_connector_observability}, shared with the Slack connector — the
+    counters differ, the [outcome] values do not. The gateway event vocabulary
+    and the reconnect types are Discord's own.
+
+    The [struct include] form is what carries the type equations out; without
+    it this signature would re-declare the variants and seal them, so
+    [Discord_observability.Reply_sent] would stop being the shared
+    constructor. *)
+
+include module type of struct
+  include Gate_connector_observability
+end
 
 type gateway_event =
   | Ready
@@ -24,31 +33,7 @@ type reconnect_outcome =
   | Reconnect_succeeded
   | Reconnect_failed
 
-type inbound_outcome =
-  | Dropped_unbound
-  | Dispatch_unavailable
-  | Gate_error
-  | Empty_reply
-  | Reply_sent
-  | Reply_send_error
-
-type ambient_outcome =
-  | Ambient_recorded
-  | Ambient_binding_store_error
-  | Ambient_dropped_unbound
-  | Ambient_dropped_empty
-  | Ambient_dropped_too_long
-
-type reply_outcome =
-  | Reply_empty
-  | Reply_send_ok
-  | Reply_send_failed
-
-val gateway_route_label : gateway_route -> string
 val gateway_event_label : gateway_event -> string
-val inbound_outcome_label : inbound_outcome -> string
-val ambient_outcome_label : ambient_outcome -> string
-val reply_outcome_label : reply_outcome -> string
 val reconnect_method_label : reconnect_method -> string
 val reconnect_outcome_label : reconnect_outcome -> string
 

--- a/lib/gate/dune
+++ b/lib/gate/dune
@@ -18,6 +18,7 @@
   channel_gate_metrics
   connector_ingress_lane
   discord_observability
+  gate_connector_observability
   discord_gateway_client
   discord_gateway_state
   discord_rest_client

--- a/lib/gate/gate_connector_observability.ml
+++ b/lib/gate/gate_connector_observability.ml
@@ -1,0 +1,61 @@
+(** Outcome vocabularies every chat connector reports, and their metric
+    labels.
+
+    Slack and Discord write to different counters but tag them with the same
+    [outcome] values. Keeping one declaration means adding a constructor
+    breaks the label function once, for every connector, instead of leaving
+    the second one to be noticed by hand. What stays per-connector is what
+    genuinely differs: the gateway event vocabulary, and Discord's reconnect
+    types.
+
+    Closed sums so a new outcome forces a label decision at compile time. *)
+
+type gateway_route =
+  | Control
+  | Triggered
+  | Ambient
+
+type inbound_outcome =
+  | Dropped_unbound
+  | Dispatch_unavailable
+  | Gate_error
+  | Empty_reply
+  | Reply_sent
+  | Reply_send_error
+
+type ambient_outcome =
+  | Ambient_recorded
+  | Ambient_binding_store_error
+  | Ambient_dropped_unbound
+  | Ambient_dropped_empty
+  | Ambient_dropped_too_long
+
+type reply_outcome =
+  | Reply_empty
+  | Reply_send_ok
+  | Reply_send_failed
+
+let gateway_route_label = function
+  | Control -> "control"
+  | Triggered -> "triggered"
+  | Ambient -> "ambient"
+
+let inbound_outcome_label = function
+  | Dropped_unbound -> "dropped_unbound"
+  | Dispatch_unavailable -> "dispatch_unavailable"
+  | Gate_error -> "gate_error"
+  | Empty_reply -> "empty_reply"
+  | Reply_sent -> "reply_sent"
+  | Reply_send_error -> "reply_send_error"
+
+let ambient_outcome_label = function
+  | Ambient_recorded -> "recorded"
+  | Ambient_binding_store_error -> "binding_store_error"
+  | Ambient_dropped_unbound -> "dropped_unbound"
+  | Ambient_dropped_empty -> "dropped_empty"
+  | Ambient_dropped_too_long -> "dropped_too_long"
+
+let reply_outcome_label = function
+  | Reply_empty -> "empty"
+  | Reply_send_ok -> "sent"
+  | Reply_send_failed -> "send_error"

--- a/lib/gate/gate_connector_observability.mli
+++ b/lib/gate/gate_connector_observability.mli
@@ -1,0 +1,45 @@
+(** Outcome vocabularies every chat connector reports, and their metric
+    labels.
+
+    Slack and Discord write to different counters but tag them with the same
+    [outcome] values. Keeping one declaration means adding a constructor
+    breaks the label function once, for every connector, instead of leaving
+    the second one to be noticed by hand. What stays per-connector is what
+    genuinely differs: the gateway event vocabulary, and Discord's reconnect
+    types.
+
+    Closed sums so a new outcome forces a label decision at compile time.
+
+    Both connectors re-export this module, so [Slack_observability.Reply_sent]
+    and [Discord_observability.Reply_sent] name the same constructor of the
+    same type. *)
+
+type gateway_route =
+  | Control
+  | Triggered
+  | Ambient
+
+type inbound_outcome =
+  | Dropped_unbound
+  | Dispatch_unavailable
+  | Gate_error
+  | Empty_reply
+  | Reply_sent
+  | Reply_send_error
+
+type ambient_outcome =
+  | Ambient_recorded
+  | Ambient_binding_store_error
+  | Ambient_dropped_unbound
+  | Ambient_dropped_empty
+  | Ambient_dropped_too_long
+
+type reply_outcome =
+  | Reply_empty
+  | Reply_send_ok
+  | Reply_send_failed
+
+val gateway_route_label : gateway_route -> string
+val inbound_outcome_label : inbound_outcome -> string
+val ambient_outcome_label : ambient_outcome -> string
+val reply_outcome_label : reply_outcome -> string

--- a/lib/gate/slack_observability.ml
+++ b/lib/gate/slack_observability.ml
@@ -6,10 +6,7 @@
     Connection-level counters (reconnect/close) live in the I/O layer and are
     added when {!Slack_socket_client} grows observability. *)
 
-type gateway_route =
-  | Control
-  | Triggered
-  | Ambient
+include Gate_connector_observability
 
 type gateway_event =
   | Hello
@@ -18,57 +15,12 @@ type gateway_event =
   | Reaction_added
   | Ignored
 
-type inbound_outcome =
-  | Dropped_unbound
-  | Dispatch_unavailable
-  | Gate_error
-  | Empty_reply
-  | Reply_sent
-  | Reply_send_error
-
-type ambient_outcome =
-  | Ambient_recorded
-  | Ambient_binding_store_error
-  | Ambient_dropped_unbound
-  | Ambient_dropped_empty
-  | Ambient_dropped_too_long
-
-type reply_outcome =
-  | Reply_empty
-  | Reply_send_ok
-  | Reply_send_failed
-
-let gateway_route_label = function
-  | Control -> "control"
-  | Triggered -> "triggered"
-  | Ambient -> "ambient"
-
 let gateway_event_label = function
   | Hello -> "hello"
   | Message_create -> "message_create"
   | App_mention -> "app_mention"
   | Reaction_added -> "reaction_added"
   | Ignored -> "ignored"
-
-let inbound_outcome_label = function
-  | Dropped_unbound -> "dropped_unbound"
-  | Dispatch_unavailable -> "dispatch_unavailable"
-  | Gate_error -> "gate_error"
-  | Empty_reply -> "empty_reply"
-  | Reply_sent -> "reply_sent"
-  | Reply_send_error -> "reply_send_error"
-
-let ambient_outcome_label = function
-  | Ambient_recorded -> "recorded"
-  | Ambient_binding_store_error -> "binding_store_error"
-  | Ambient_dropped_unbound -> "dropped_unbound"
-  | Ambient_dropped_empty -> "dropped_empty"
-  | Ambient_dropped_too_long -> "dropped_too_long"
-
-let reply_outcome_label = function
-  | Reply_empty -> "empty"
-  | Reply_send_ok -> "sent"
-  | Reply_send_failed -> "send_error"
 
 let inc name ~labels =
   Otel_metric_store_core.inc_counter name ~labels ()

--- a/lib/gate/slack_observability.mli
+++ b/lib/gate/slack_observability.mli
@@ -1,12 +1,19 @@
 (** Slack connector observability helpers (RFC-0317).
 
-    Mirrors {!Discord_observability} for the Slack in-process gateway. Closed
-    sums so a new event/outcome forces a label decision at compile time. *)
+    The outcome vocabularies and their labels come from
+    {!Gate_connector_observability}, shared with the Discord connector — the
+    counters differ, the [outcome] values do not. Only the gateway event
+    vocabulary is Slack's own. Closed sums so a new event/outcome forces a
+    label decision at compile time.
 
-type gateway_route =
-  | Control
-  | Triggered
-  | Ambient
+    The [struct include] form is what carries the type equations out; without
+    it this signature would re-declare the variants and seal them, so
+    [Slack_observability.Reply_sent] would stop being the shared
+    constructor. *)
+
+include module type of struct
+  include Gate_connector_observability
+end
 
 type gateway_event =
   | Hello
@@ -15,31 +22,7 @@ type gateway_event =
   | Reaction_added
   | Ignored
 
-type inbound_outcome =
-  | Dropped_unbound
-  | Dispatch_unavailable
-  | Gate_error
-  | Empty_reply
-  | Reply_sent
-  | Reply_send_error
-
-type ambient_outcome =
-  | Ambient_recorded
-  | Ambient_binding_store_error
-  | Ambient_dropped_unbound
-  | Ambient_dropped_empty
-  | Ambient_dropped_too_long
-
-type reply_outcome =
-  | Reply_empty
-  | Reply_send_ok
-  | Reply_send_failed
-
-val gateway_route_label : gateway_route -> string
 val gateway_event_label : gateway_event -> string
-val inbound_outcome_label : inbound_outcome -> string
-val ambient_outcome_label : ambient_outcome -> string
-val reply_outcome_label : reply_outcome -> string
 
 val record_gateway_event : route:gateway_route -> gateway_event -> unit
 (** Increment [masc_slack_gateway_events_total] with [event] and [route]

--- a/test/dune
+++ b/test/dune
@@ -1700,6 +1700,7 @@
 (include stanzas/test_discord_presence_bridge.inc)
 
 (include stanzas/test_discord_observability.inc)
+(include stanzas/test_gate_connector_observability.inc)
 
 (include stanzas/test_discord_rest_client.inc)
 

--- a/test/stanzas/test_gate_connector_observability.inc
+++ b/test/stanzas/test_gate_connector_observability.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_gate_connector_observability)
+ (modules test_gate_connector_observability)
+ (libraries alcotest masc.gate))

--- a/test/test_gate_connector_observability.ml
+++ b/test/test_gate_connector_observability.ml
@@ -1,0 +1,127 @@
+(** Pins the connector outcome vocabulary that Slack and Discord share.
+
+    These strings are metric label values, so changing one is a wire change
+    for anything aggregating across connectors. Before
+    {!Gate_connector_observability} existed the two modules each declared
+    their own copy and [Slack_observability]'s docstring described itself as
+    a mirror of Discord's — a mirror the compiler could not check.
+    [test_discord_observability] pinned eight of the mappings from one side;
+    the rest were unpinned.
+
+    The [same_type_as_*] bindings below are the point of the module: they only
+    compile while both connectors name the same constructor of the same type.
+    A signature that re-declared the variants without the type equation would
+    seal them and break these lines. *)
+
+open Alcotest
+
+module Shared = Gate_connector_observability
+module Slack = Slack_observability
+module Discord = Discord_observability
+
+let same_type_as_slack : Shared.inbound_outcome = Slack.Reply_sent
+let same_type_as_discord : Shared.inbound_outcome = Discord.Reply_sent
+let ambient_shared : Shared.ambient_outcome = Slack.Ambient_recorded
+let reply_shared : Shared.reply_outcome = Discord.Reply_send_ok
+let route_shared : Shared.gateway_route = Slack.Triggered
+
+let test_both_connectors_name_one_type () =
+  check
+    bool
+    "Slack.Reply_sent and Discord.Reply_sent are the same value"
+    true
+    (same_type_as_slack = same_type_as_discord);
+  check
+    string
+    "and the shared label function accepts either"
+    (Discord.inbound_outcome_label same_type_as_slack)
+    (Slack.inbound_outcome_label same_type_as_discord);
+  check string "ambient" "recorded" (Shared.ambient_outcome_label ambient_shared);
+  check string "reply" "sent" (Shared.reply_outcome_label reply_shared);
+  check string "route" "triggered" (Shared.gateway_route_label route_shared)
+;;
+
+(* Exhaustive rather than a sample: the compiler forces a label for a new
+   constructor, but it cannot tell you the label you chose is the one the
+   dashboards already query. *)
+let test_gateway_route_labels () =
+  List.iter
+    (fun (value, expected) ->
+      check string expected expected (Shared.gateway_route_label value))
+    [ Shared.Control, "control"; Shared.Triggered, "triggered"; Shared.Ambient, "ambient" ]
+;;
+
+let test_inbound_outcome_labels () =
+  List.iter
+    (fun (value, expected) ->
+      check string expected expected (Shared.inbound_outcome_label value))
+    [ Shared.Dropped_unbound, "dropped_unbound"
+    ; Shared.Dispatch_unavailable, "dispatch_unavailable"
+    ; Shared.Gate_error, "gate_error"
+    ; Shared.Empty_reply, "empty_reply"
+    ; Shared.Reply_sent, "reply_sent"
+    ; Shared.Reply_send_error, "reply_send_error"
+    ]
+;;
+
+let test_ambient_outcome_labels () =
+  List.iter
+    (fun (value, expected) ->
+      check string expected expected (Shared.ambient_outcome_label value))
+    [ Shared.Ambient_recorded, "recorded"
+    ; Shared.Ambient_binding_store_error, "binding_store_error"
+    ; Shared.Ambient_dropped_unbound, "dropped_unbound"
+    ; Shared.Ambient_dropped_empty, "dropped_empty"
+    ; Shared.Ambient_dropped_too_long, "dropped_too_long"
+    ]
+;;
+
+let test_reply_outcome_labels () =
+  List.iter
+    (fun (value, expected) ->
+      check string expected expected (Shared.reply_outcome_label value))
+    [ Shared.Reply_empty, "empty"
+    ; Shared.Reply_send_ok, "sent"
+    ; Shared.Reply_send_failed, "send_error"
+    ]
+;;
+
+(* The event vocabularies are deliberately not shared: the two platforms do
+   not emit the same events. Pinning them here records that the split is a
+   decision, not an oversight. *)
+let test_event_vocabularies_stay_separate () =
+  check string "slack hello" "hello" (Slack.gateway_event_label Slack.Hello);
+  check string "discord ready" "ready" (Discord.gateway_event_label Discord.Ready);
+  check
+    string
+    "discord open_wss has no Slack counterpart"
+    "open_wss"
+    (Discord.gateway_event_label Discord.Open_wss);
+  check
+    string
+    "both spell the one event they share the same way"
+    (Discord.gateway_event_label Discord.Message_create)
+    (Slack.gateway_event_label Slack.Message_create)
+;;
+
+let () =
+  run
+    "gate connector observability"
+    [ ( "one vocabulary"
+      , [ test_case
+            "both connectors name one type"
+            `Quick
+            test_both_connectors_name_one_type
+        ; test_case "gateway_route labels" `Quick test_gateway_route_labels
+        ; test_case "inbound_outcome labels" `Quick test_inbound_outcome_labels
+        ; test_case "ambient_outcome labels" `Quick test_ambient_outcome_labels
+        ; test_case "reply_outcome labels" `Quick test_reply_outcome_labels
+        ] )
+    ; ( "per-connector"
+      , [ test_case
+            "event vocabularies stay separate"
+            `Quick
+            test_event_vocabularies_stay_separate
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 문제

`slack_observability` 와 `discord_observability` 가 **같은 타입 4개 + 같은 레이블 함수 4개**를 각자 선언한다. 생성자 17개, 문자열 17개가 `.ml` 과 `.mli` 양쪽에 — 즉 같은 선언이 **4번** 적혀 있다.

Slack 쪽 docstring 이 스스로 이렇게 적어뒀다:

> **Mirrors** {!Discord_observability} for the Slack in-process gateway.
> **Closed sums so a new event/outcome forces a label decision at compile time.**

두 번째 문장은 **한 커넥터 안에서만** 참이다. Discord 의 `inbound_outcome` 에 생성자를 추가해도 Slack 은 컴파일이 깨지지 않는다. 손으로 유지하는 미러다.

이 문자열들은 metric label 값이라, 한쪽만 바뀌면 커넥터를 가로질러 집계하는 쪽이 조용히 갈라진다.

## 어떻게 찾았나

`lib/` 전체에서 top-level `let` 본문을 정규화해 해시로 묶었다. 파일 2개 이상에 같은 본문이 있는 경우가 **117건**이고, 그중 이 쌍이 가장 명확했다 — 두 파일 사이에 함수가 4개.

## 변경

`Gate_connector_observability` 가 공유 4종을 소유하고 두 커넥터가 `include` 한다.

**커넥터별로 남긴 것**은 실제로 다르기 때문이다:

| | Slack | Discord |
|---|---|---|
| `gateway_event` | `Hello` `App_mention` `Reaction_added` | `Ready` `Open_wss` `Reaction_add` |
| reconnect 타입 | 없음 (I/O 레이어) | `reconnect_method` / `reconnect_outcome` |

호출처 55곳은 그대로다 — `include` 라 `Slack_observability.Reply_sent` 가 계속 해석된다.

## `.mli` 형태가 중요하다

```ocaml
include module type of struct
  include Gate_connector_observability
end
```

`struct include` 없이 `module type of` 만 쓰면 시그니처가 variant 를 **등식 없이 재선언**해 봉인한다. 그러면 `Slack.Reply_sent` 와 `Discord.Reply_sent` 가 이름만 같고 통일되지 않는 별개 타입이 된다 — #27132 가 이 저장소에서 제거하는 바로 그 결함이다. 두 `.mli` 주석에 이유를 적어뒀다.

## 테스트

기존 `test_discord_observability` 는 레이블 17개 중 **8개를** 한쪽에서만 고정한다. 그리고 **CI 에서 안 돈다** (#26075 인벤토리 대상).

새 스위트는:
1. 17개 전부 고정 — 컴파일러는 "레이블을 정하라" 까지만 강제하고, 정한 값이 대시보드가 조회하는 그 값인지는 모른다
2. **두 커넥터가 한 타입임을 컴파일 타임에 증명** — 봉인되면 이 줄들이 안 컴파일된다

```ocaml
let same_type_as_slack : Shared.inbound_outcome = Slack.Reply_sent
let same_type_as_discord : Shared.inbound_outcome = Discord.Reply_sent
```

3. 이벤트 어휘가 갈라져 있는 것이 **결정이지 누락이 아님**을 기록

CI 스텝을 추가했다. `test_discord_observability` 는 여전히 안 돈다 — green 인지 확인하지 못한 채 배선하면 CI 를 빨갛게 만들 수 있어서 이 PR 에 넣지 않았다.

## 규모

`+276 / -156`. 선언 중복 ~156줄이 사라지고 공유 모듈 106줄 + 테스트 127줄이 생긴다.

## 검증

로컬 빌드 대신 CI. 커밋 `5c1aab3515`, base `cf68b4fcee`.
