### PR TITLE
fix(dashboard): wire external-effect terminal event and goal_owner timeline

### DIFF
--- a/dashboard/src/api/dashboard-goals.test.ts
+++ b/dashboard/src/api/dashboard-goals.test.ts
@@ -180,6 +180,43 @@ describe('fetchDashboardGoalsTree decoding', () => {
     expect(result.tree[1]!.owner).toBeNull()
   })
 
+  it('decodes typed timeline events on tree nodes and drops malformed entries', async () => {
+    getMock.mockResolvedValue({
+      ...readyApprovalQueue,
+      tree: [
+        validNode('goal-1', 'Goal one', {
+          timeline_events: [
+            {
+              ts: '2026-08-05T01:00:00Z',
+              kind: 'goal_owner',
+              lane: 'goal',
+              title: 'Goal Owner',
+              summary: 'owner: <unassigned> -> dancer by operator',
+              severity: 'ok',
+            },
+            { kind: 'goal_owner' },
+          ],
+        }),
+        validNode('goal-2', 'Goal two'),
+      ],
+      summary: { ...emptySummary(), total_goals: 2, active_goals: 2 },
+    })
+
+    const result = await fetchDashboardGoalsTree()
+
+    expect(result.tree[0]!.timeline_events).toEqual([
+      {
+        ts: '2026-08-05T01:00:00Z',
+        kind: 'goal_owner',
+        lane: 'goal',
+        title: 'Goal Owner',
+        summary: 'owner: <unassigned> -> dancer by operator',
+        severity: 'ok',
+      },
+    ])
+    expect(result.tree[1]!.timeline_events).toEqual([])
+  })
+
   it('backfills missing attainment metric_evaluation from metric presence', async () => {
     getMock.mockResolvedValue({
       ...readyApprovalQueue,

--- a/dashboard/src/api/dashboard-goals.ts
+++ b/dashboard/src/api/dashboard-goals.ts
@@ -308,7 +308,9 @@ function decodeGoalTreeNode(raw: unknown): GoalTreeNode | null {
       tasks,
     }),
     completion_summary: decodeGoalCompletionSummary(raw.completion_summary),
-    timeline_events: Array.isArray(raw.timeline_events) ? raw.timeline_events : [],
+    timeline_events: asRecordArray(raw.timeline_events)
+      .map(decodeGoalDetailTimelineEvent)
+      .filter((event): event is GoalDetailTimelineEvent => event !== null),
     children,
     child_count: asInt(raw.child_count) ?? children.length,
     last_activity_at: asString(raw.last_activity_at, ''),

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -215,6 +215,35 @@ describe('ChatTranscript', () => {
     expect(container.querySelector('.chat-bubble')).toBeNull()
   })
 
+  it('renders a connector-delivered outcome as a terminal status, not assistant prose', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'connector-done-live',
+            role: 'assistant',
+            source: 'direct_assistant',
+            label: 'sangsu',
+            text: '',
+            rawText: '',
+            details: { turnOutcome: 'external_effect_completed' },
+          }),
+        ]}
+        emptyText="empty"
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const status = container.querySelector(
+      '[data-chat-control-status="external_effect_completed"]',
+    )
+    expect(status).not.toBeNull()
+    expect(status?.textContent).toContain('커넥터로 답변 완료')
+    expect(status?.textContent).toContain('해당 채널에서 확인')
+    expect(container.querySelector('.chat-bubble')).toBeNull()
+  })
+
   it('renders a typed continuation checkpoint as durable status, not assistant prose', () => {
     render(
       html`<${ChatTranscript}

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2572,7 +2572,7 @@ const CARD_BLOCK_TYPES: ReadonlySet<ChatBlock['t']> = new Set([
   'status',
 ])
 
-type ChatControlStatus = 'continuation_checkpoint' | 'external_effect_pending'
+type ChatControlStatus = 'continuation_checkpoint' | 'external_effect_pending' | 'external_effect_completed'
 
 function chatControlStatus(entry: KeeperConversationEntry): ChatControlStatus | null {
   const persistedStatus = (entry.blocks ?? []).find(
@@ -2580,7 +2580,9 @@ function chatControlStatus(entry: KeeperConversationEntry): ChatControlStatus | 
   )
   if (persistedStatus) return persistedStatus.kind
   const turnOutcome = entry.details?.turnOutcome
-  return turnOutcome === 'continuation_checkpoint' || turnOutcome === 'external_effect_pending'
+  return turnOutcome === 'continuation_checkpoint'
+    || turnOutcome === 'external_effect_pending'
+    || turnOutcome === 'external_effect_completed'
     ? turnOutcome
     : null
 }
@@ -2626,6 +2628,45 @@ function ChatControlStatusCard({
             </p>
             <p class="mt-0.5 text-xs leading-paragraph text-[var(--color-fg-muted)]">
               Keeper가 다음 주기에 이어서 처리합니다.
+            </p>
+          </div>
+        </div>
+        ${supportingBlocks.length > 0
+          ? html`<div class="mt-3"><${ChatBlocks} blocks=${supportingBlocks} fallbackText="" /></div>`
+          : null}
+      </article>
+    `
+  }
+
+  if (status === 'external_effect_completed') {
+    return html`
+      <article
+        class="w-full rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-subtle)] px-4 py-3.5"
+        role="status"
+        aria-live="polite"
+        data-chat-control-status="external_effect_completed"
+        data-chat-entry-id=${entry.id}
+        data-chat-turn-ref=${entry.turnRef ?? undefined}
+      >
+        <div class="flex items-start gap-3">
+          <div
+            class="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-full border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] text-[var(--color-fg-secondary)]"
+            aria-hidden="true"
+          >
+            <${ExternalLink} size=${18} />
+          </div>
+          <div class="min-w-0 flex-1">
+            <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+              <strong class="text-sm font-semibold text-[var(--color-fg-primary)]">커넥터로 답변 완료</strong>
+              ${timestamp
+                ? html`<span class="text-2xs tabular-nums text-[var(--color-fg-muted)]">${timestamp}</span>`
+                : null}
+            </div>
+            <p class="mt-1 text-sm leading-paragraph text-[var(--color-fg-secondary)]">
+              Keeper의 답변이 외부 커넥터(Slack/Discord)로 전송되었습니다.
+            </p>
+            <p class="mt-0.5 text-xs leading-paragraph text-[var(--color-fg-muted)]">
+              답변 내용은 해당 채널에서 확인할 수 있습니다.
             </p>
           </div>
         </div>

--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -1548,7 +1548,14 @@ describe('Work', () => {
                 is_terminal: false,
                 ready_to_request_completion: false,
               },
-              timeline_events: [{ kind: 'turn' }],
+              timeline_events: [{
+                ts: '2026-01-04T10:00:00Z',
+                kind: 'goal_owner',
+                lane: 'goal',
+                title: 'Goal Owner',
+                summary: 'owner: <unassigned> -> dancer by operator',
+                severity: 'ok',
+              }],
               last_activity_at: '2026-01-04T10:00:00Z',
               stagnation_seconds: 3600,
               linked_keeper_names: ['sangsu'],
@@ -1578,6 +1585,55 @@ describe('Work', () => {
         expect(dossier.textContent).toContain('keeper sangsu')
         expect(dossier.textContent).toContain('turn 42')
         expect(dossier.textContent).toContain('approvals 2')
+      })
+
+      it('expands the goal dossier timeline events behind the toggle', () => {
+        goals.value = [
+          { id: 'G-1', title: 'Goal One', priority: 5, phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-04' },
+        ]
+        tasks.value = []
+        goalTreeData.value = {
+          tree: [
+            goalTreeNode({
+              id: 'G-1',
+              title: 'Goal One',
+              priority: 5,
+              phase: 'executing',
+              timeline_events: [{
+                ts: '2026-01-04T10:00:00Z',
+                kind: 'goal_owner',
+                lane: 'goal',
+                title: 'Goal Owner',
+                summary: 'owner: <unassigned> -> dancer by operator',
+                severity: 'ok',
+              }],
+            }),
+          ],
+          summary: emptyGoalTreeSummary({ total_goals: 1, active_goals: 1 }),
+        }
+
+        render(html`<${Work} />`)
+
+        const goalCard = screen.getByTestId('goal-card')
+        fireEvent.click(goalCard.querySelector('.wk-goal-h')!)
+
+        const dossier = within(goalCard).getByTestId('goal-dossier')
+        const toggle = dossier.querySelector('[data-goal-dossier-timeline-toggle="G-1"]')
+        expect(toggle).not.toBeNull()
+        expect(toggle).toHaveAttribute('aria-expanded', 'false')
+        expect(dossier.querySelectorAll('[data-goal-dossier-timeline-event]')).toHaveLength(0)
+
+        fireEvent.click(toggle!)
+
+        expect(toggle).toHaveAttribute('aria-expanded', 'true')
+        const rows = dossier.querySelectorAll('[data-goal-dossier-timeline-event]')
+        expect(rows).toHaveLength(1)
+        expect(rows[0]!.textContent).toContain('goal_owner')
+        expect(rows[0]!.textContent).toContain('2026-01-04T10:00:00Z')
+        expect(rows[0]!.textContent).toContain('owner: <unassigned> -> dancer by operator')
+        // The count chip and its hook stay put while the list opens.
+        expect(dossier).toHaveAttribute('data-goal-dossier-timeline-count', '1')
+        expect(dossier.textContent).toContain('events 1')
       })
 
       it('renders tree-only Goal Store goals in the list without an execution goal mirror', () => {

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -443,6 +443,7 @@ function TaskEvidenceLedger({ rows }: { rows: readonly TaskEvidenceLedgerRow[] }
 }
 
 function GoalProjectionDossier({ node }: { node: GoalTreeNode | null | undefined }) {
+  const [timelineOpen, setTimelineOpen] = useState(false)
   if (!node) return null
 
   const completion = node.completion_summary ?? null
@@ -491,6 +492,18 @@ function GoalProjectionDossier({ node }: { node: GoalTreeNode | null | undefined
           <span class="wk-dossier-chip mono">last unavailable</span>
         `}
         <span class="wk-dossier-chip mono">events ${node.timeline_events.length}</span>
+        ${node.timeline_events.length > 0 ? html`
+          <button
+            type="button"
+            class="wk-dossier-chip mono"
+            style="cursor: pointer"
+            onClick=${() => setTimelineOpen(open => !open)}
+            aria-expanded=${timelineOpen}
+            data-goal-dossier-timeline-toggle=${node.id}
+          >
+            ${timelineOpen ? 'hide timeline' : 'show timeline'}
+          </button>
+        ` : null}
         <span class="wk-dossier-chip mono">stagnation ${node.stagnation_seconds == null ? 'unavailable' : `${node.stagnation_seconds}s`}</span>
         ${node.owner ? html`<span class="wk-dossier-chip mono">owner ${node.owner}</span>` : null}
         ${node.latest_keeper_ref ? html`<span class="wk-dossier-chip mono">keeper ${node.latest_keeper_ref}</span>` : null}
@@ -502,6 +515,20 @@ function GoalProjectionDossier({ node }: { node: GoalTreeNode | null | undefined
           <span class="wk-dossier-chip warn mono">approvals ${node.pending_approval_count}</span>
         ` : null}
       </div>
+
+      ${timelineOpen
+        ? node.timeline_events.map(event => html`
+          <div
+            key=${`${event.kind}:${event.lane}:${event.ts}`}
+            class="wk-dossier-row"
+            data-goal-dossier-timeline-event
+          >
+            <span class="wk-dossier-k">${event.kind}</span>
+            <span class="wk-dossier-chip mono">${event.ts}</span>
+            <span class=${`wk-dossier-chip ${event.severity} mono`}>${event.summary}</span>
+          </div>
+        `)
+        : null}
     </div>
   `
 }

--- a/dashboard/src/keeper-message.test.ts
+++ b/dashboard/src/keeper-message.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   formatKeeperVisibleReply,
+  keeperTurnOutcomeSuppressesReply,
   normalizeKeeperConversationDetails,
   normalizeKeeperToolResponse,
 } from './keeper-message'
@@ -211,6 +212,34 @@ describe('normalizeKeeperConversationDetails', () => {
     })
     expect(result?.turnOutcome).toBe('external_effect_pending')
     expect(result?.replyText).toBeNull()
+  })
+
+  it('decodes the typed connector delivery without reply prose', () => {
+    const result = normalizeKeeperConversationDetails({
+      reply: '',
+      turn_outcome: 'external_effect_completed',
+    })
+    expect(result?.turnOutcome).toBe('external_effect_completed')
+    expect(result?.replyText).toBeNull()
+  })
+})
+
+// ================================================================
+// keeperTurnOutcomeSuppressesReply
+// ================================================================
+
+describe('keeperTurnOutcomeSuppressesReply', () => {
+  it('suppresses terminal control outcomes, including connector delivery', () => {
+    expect(keeperTurnOutcomeSuppressesReply('continuation_checkpoint')).toBe(true)
+    expect(keeperTurnOutcomeSuppressesReply('external_effect_pending')).toBe(true)
+    expect(keeperTurnOutcomeSuppressesReply('external_effect_completed')).toBe(true)
+    expect(keeperTurnOutcomeSuppressesReply('no_visible_reply')).toBe(true)
+  })
+
+  it('does not suppress a visible reply or a missing outcome', () => {
+    expect(keeperTurnOutcomeSuppressesReply('visible_reply')).toBe(false)
+    expect(keeperTurnOutcomeSuppressesReply(null)).toBe(false)
+    expect(keeperTurnOutcomeSuppressesReply(undefined)).toBe(false)
   })
 })
 

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -372,6 +372,46 @@ describe('applyKeeperStreamEvent', () => {
     expect(activeStreamRequestId('sangsu')).toBeNull()
   })
 
+  it('finalizes a connector-delivered turn as a terminal status, not a hang', () => {
+    assistantEntry()
+    setActiveStreamRequestId('sangsu', 'kmsg_current')
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_REPLY_DETAILS',
+      value: {
+        request_id: 'kmsg_current',
+        reply: 'posted the answer to #ops on Slack',
+        turn_outcome: 'external_effect_completed',
+      },
+    })
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_EXTERNAL_EFFECT_COMPLETED',
+      value: null,
+    })).toBeNull()
+
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_REQUEST_TERMINAL',
+      value: {
+        request_id: 'kmsg_current',
+        status: 'done',
+        ok: true,
+      },
+    })).toBeNull()
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TEXT_MESSAGE_END',
+    })).toBeNull()
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.text).toBe('')
+    expect(entry?.rawText).toBe('posted the answer to #ops on Slack')
+    expect(entry?.delivery).toBe('delivered')
+    expect(entry?.streamState).toBeNull()
+    expect(entry?.details?.turnOutcome).toBe('external_effect_completed')
+    expect(activeStreamRequestId('sangsu')).toBeNull()
+  })
+
   it('does not leave successful terminal events in a live thinking state without reply details', () => {
     assistantEntry()
     setActiveStreamRequestId('sangsu', 'kmsg_current')

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -772,6 +772,26 @@ export function applyKeeperStreamEvent(
         }))
         return null
       }
+      if (event.name === 'KEEPER_EXTERNAL_EFFECT_COMPLETED') {
+        // The reply went out through an external connector (Slack/Discord), so
+        // there is no assistant text — finalize as a terminal control status
+        // instead of leaving the entry streaming.
+        flushPendingThinkingDeltas(keeperName, assistantEntryId)
+        updateThreadEntry(keeperName, assistantEntryId, entry => ({
+          ...entry,
+          details: {
+            ...(entry.details ?? {}),
+            turnOutcome: 'external_effect_completed',
+          },
+          text: '',
+          delivery: 'delivered',
+          streamState: null,
+          streamContract: keeperClientObservedSseStreamContract('queue_event', 'queue_request_event', {
+            eventName: 'KEEPER_EXTERNAL_EFFECT_COMPLETED',
+          }),
+        }))
+        return null
+      }
       if (event.name === 'KEEPER_REQUEST_TERMINAL') {
         flushPendingThinkingDeltas(keeperName, assistantEntryId)
         const terminal = isRecord(event.value) ? event.value : null

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -687,8 +687,10 @@ interface KeeperConversationUsage {
 
 // RFC-0232 P2: producer-typed turn outcome carried in the reply payload
 // (`turn_outcome`). `continuation_checkpoint` marks a resume-next-cycle
-// boundary, `external_effect_pending` marks a durable control wait, and
-// `no_visible_reply` marks a completed runtime turn with no assistant text.
+// boundary, `external_effect_pending` marks a durable control wait,
+// `external_effect_completed` marks a reply delivered by an external
+// connector (e.g. Slack/Discord), and `no_visible_reply` marks a completed
+// runtime turn with no assistant text.
 export type KeeperTurnOutcome =
   | 'visible_reply'
   | 'continuation_checkpoint'

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -765,7 +765,7 @@ export interface GoalTreeTaskProjection {
 }
 
 export interface GoalTreeActivityProjection {
-  timeline_events: unknown[]
+  timeline_events: GoalDetailTimelineEvent[]
   last_activity_at: string
   stagnation_seconds: number | null
   activity_observation: GoalFsmProjection['activity_observation']

--- a/lib/dashboard/dashboard_goals_types_timeline.ml
+++ b/lib/dashboard/dashboard_goals_types_timeline.ml
@@ -270,9 +270,8 @@ let goal_event_timeline_json event =
         let owner = payload_field "owner" |> json_to_string_opt in
         let actor = payload_field "actor" |> json_to_string_opt in
         (* DET-OK: [owner]/[previous_owner] are persisted goal_owner payload
-           fields; [Null] is the typed unassigned state, not unknown input.
-           The default only renders that state as "<unassigned>". *)
-        let side value = Option.value ~default:"<unassigned>" value in
+           fields; [Null] is the typed unassigned state, not unknown input. *)
+        let side value = Option.value ~default:"<unassigned>" value (* renders the typed unassigned state *) in
         ( "Goal Owner",
           (match actor with
           | Some actor_id ->

--- a/lib/dashboard/dashboard_goals_types_timeline.ml
+++ b/lib/dashboard/dashboard_goals_types_timeline.ml
@@ -260,6 +260,25 @@ let goal_event_timeline_json event =
           | "blocked" -> "bad"
           | "paused" -> "warn"
           | _ -> "ok") )
+    | "goal_owner" ->
+        (* Unlike the bracketed markers above, [<unassigned>] names a real
+           state, not a producer gap: workspace_goals.ml writes both sides of
+           the transition and [Null] means the goal was unassigned there. *)
+        let previous_owner =
+          payload_field "previous_owner" |> json_to_string_opt
+        in
+        let owner = payload_field "owner" |> json_to_string_opt in
+        let actor = payload_field "actor" |> json_to_string_opt in
+        let side value = Option.value ~default:"<unassigned>" value in
+        ( "Goal Owner",
+          (match actor with
+          | Some actor_id ->
+              Printf.sprintf "owner: %s -> %s by %s" (side previous_owner)
+                (side owner) actor_id
+          | None ->
+              Printf.sprintf "owner: %s -> %s" (side previous_owner)
+                (side owner)),
+          "ok" )
     | _ ->
         ("Goal Event", event_type, "ok")
   in

--- a/lib/dashboard/dashboard_goals_types_timeline.ml
+++ b/lib/dashboard/dashboard_goals_types_timeline.ml
@@ -269,6 +269,9 @@ let goal_event_timeline_json event =
         in
         let owner = payload_field "owner" |> json_to_string_opt in
         let actor = payload_field "actor" |> json_to_string_opt in
+        (* DET-OK: [owner]/[previous_owner] are persisted goal_owner payload
+           fields; [Null] is the typed unassigned state, not unknown input.
+           The default only renders that state as "<unassigned>". *)
         let side value = Option.value ~default:"<unassigned>" value in
         ( "Goal Owner",
           (match actor with

--- a/test/test_goal_metric_unevaluated.ml
+++ b/test/test_goal_metric_unevaluated.ml
@@ -383,6 +383,49 @@ let test_tree_node_projects_an_absent_owner_as_null () =
   check bool "an absent owner is explicit null" true
     (tree_field "owner" json = Some `Null)
 
+(* RFC-0362 §4.2 — a goal_owner event carries both sides of the transition,
+   but the default goal-event arm rendered only the bare kind string, so the
+   dashboard timeline counted the event without naming who lost or gained the
+   goal. *)
+let goal_owner_event ~previous_owner ~owner ~actor =
+  let owner_side = function Some value -> `String value | None -> `Null in
+  `Assoc
+    [ ("event_type", `String "goal_owner")
+    ; ("ts", `String "2026-08-05T01:00:00Z")
+    ; ("payload",
+       `Assoc
+         [ ("previous_owner", owner_side previous_owner)
+         ; ("owner", owner_side owner)
+         ; ("actor", `String actor)
+         ])
+    ]
+
+let test_goal_owner_timeline_names_the_transition () =
+  let json =
+    Timeline.goal_event_timeline_json
+      (goal_owner_event ~previous_owner:(Some "dancer") ~owner:(Some "sangsu")
+         ~actor:"operator")
+  in
+  check string "the transition names both owners" "owner: dancer -> sangsu by operator"
+    (json_str json "summary");
+  check string "kind stays the event type" "goal_owner" (json_str json "kind")
+
+let test_goal_owner_timeline_names_unassigned_sides () =
+  let assigned =
+    Timeline.goal_event_timeline_json
+      (goal_owner_event ~previous_owner:None ~owner:(Some "sangsu") ~actor:"operator")
+  in
+  check string "an unassigned previous owner is explicit"
+    "owner: <unassigned> -> sangsu by operator"
+    (json_str assigned "summary");
+  let cleared =
+    Timeline.goal_event_timeline_json
+      (goal_owner_event ~previous_owner:(Some "dancer") ~owner:None ~actor:"operator")
+  in
+  check string "an unassigned new owner is explicit"
+    "owner: dancer -> <unassigned> by operator"
+    (json_str cleared "summary")
+
 let () =
   run "goal metric unevaluated"
     [
@@ -420,5 +463,9 @@ let () =
             test_tree_node_projects_owner;
           test_case "tree node projects an absent owner as null" `Quick
             test_tree_node_projects_an_absent_owner_as_null;
+          test_case "goal_owner timeline names the transition" `Quick
+            test_goal_owner_timeline_names_the_transition;
+          test_case "goal_owner timeline names unassigned sides" `Quick
+            test_goal_owner_timeline_names_unassigned_sides;
         ] );
     ]


### PR DESCRIPTION
## 배경

1차(#27073)에 이어 최근 3일치 변경 재감사에서 발견한 대시보드 와이어링 갭 2건.

## GAP A — `KEEPER_EXTERNAL_EFFECT_COMPLETED` (#26954)

keeper가 Slack/Discord 커넥터로 직접 답변해 종결된 턴의 유일한 종료 신호인데, 대시보드가 이벤트 브랜치도 outcome 타입도 없어서 **성공한 턴이 streaming/hang 상태로 보이던** 문제.

- `KeeperTurnOutcome`에 `external_effect_completed` 추가 + normalize/suppress 시맨틱
- `keeper-stream.ts` CUSTOM 브랜치 추가: live entry를 `delivery: delivered`로 종결
- `ChatControlStatus`에 "커넥터로 답변 완료" 카드 추가 (checkpoint 카드 패턴)
- chat-history 스키마 변경 없음 (서버가 status block을 persist하지 않음을 확인)

## GAP B — `goal_owner` 타임라인 (#26951)

서버가 goal 재할당 이력을 `timeline_events`로 보내지만 대시보드는 개수 칩만 표시하고, 서버 projection도 summary를 `"goal_owner"` 문자열만 넣어 소유자 이름이 버려지던 문제.

- OCaml: `goal_owner` 전용 arm — summary를 `prev -> new by actor`(`<unassigned>` 처리 포함)로 생성
- FE: `timeline_events`를 기존 `GoalDetailTimelineEvent[]`로 타이핑 + element-wise decode
- goal dossier에 expandable 타임라인 리스트(건당 kind/ts/summary) 추가, 기존 count 칩/테스트 훅 유지

## 검증

- OCaml: `test_goal_metric_unevaluated.exe` 19/19 OK
- Dashboard: vitest touched 5파일 299/299 pass, `tsc --noEmit` clean

## 범위 밖 (후속 후보, 본 PR 미포함)

3일 범위 밖 기존 미소비 엔드포인트 12건은 별도 정리 예정: `/api/v1/runtime/params(+audit)`, `/api/v1/dashboard/eval-feed`, `/api/v1/runtime/config/fusion`, `/api/v1/activity/graph+swimlane`, `/api/v1/gate/events`, keeper `/person-notes` 등. `KEEPER_CONNECTED`(구형, 동일 부류)도 본 범위 밖.