### PR TITLE
fix(task): 단일 클레임 거부가 빠져나갈 경로를 스스로 말하게 (keeper.md 보상 문장 제거)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -867,8 +867,13 @@ jobs:
         # #26445) that predate this PR. Alcotest exits non-zero when
         # the name matches no suite, so a suite rename cannot silently
         # unwire this step.
+        # claim_next is wired for the same reason: the single-claim refusal
+        # carries its own correction hint (masc_transition action=release),
+        # which keeper.md no longer restates. An unrun assertion would let
+        # that hint rot back out of the message.
         run: |
           opam exec -- dune exec --root . test/test_workspace_coverage.exe -- test revision
+          opam exec -- dune exec --root . test/test_workspace_coverage.exe -- test claim_next
 
       - name: Run MCP authentication contract suites
         # @check compiles these suites but never runs them. Exercise both the

--- a/config/prompts/keeper.md
+++ b/config/prompts/keeper.md
@@ -108,11 +108,9 @@ it, say why on the Task or the Board so the next Keeper reads a judgment rather
 than silence.
 
 You hold one Task at a time. While a Task you claimed is still open, a claim on
-another is refused and names the one you are holding. So pick the one you mean
-to work, then finish it or hand it back before claiming again — trying each
-candidate in turn only produces a run of refusals. Handing a Task back is a
-status transition, not a Task-specific tool, and the refusal message names the
-Task you hold but not the way out.
+another is refused and names both the Task you hold and how to hand it back. So
+pick the one you mean to work, then finish it or hand it back before claiming
+again — trying each candidate in turn only produces a run of refusals.
 
 Your goals, memory, and repositories are work surfaces of their own. The Board
 is one of several places work lives, not the register that decides whether work

--- a/lib/workspace/workspace_task_schedule.ml
+++ b/lib/workspace/workspace_task_schedule.ml
@@ -239,7 +239,9 @@ let claim_next_r
              { agent with status = Busy; current_task = Some prev.id });
            let message =
              Printf.sprintf
-               "%s already holds [P%d] %s: %s."
+               "%s already holds [P%d] %s: %s. Finish it, or hand it back with \
+                masc_transition action=release and a handoff_context.summary, \
+                before claiming different work."
                agent_name
                prev.priority
                prev.id

--- a/test/fixtures/keeper_system_prompt/assembled_prompt.golden
+++ b/test/fixtures/keeper_system_prompt/assembled_prompt.golden
@@ -104,11 +104,9 @@ it, say why on the Task or the Board so the next Keeper reads a judgment rather
 than silence.
 
 You hold one Task at a time. While a Task you claimed is still open, a claim on
-another is refused and names the one you are holding. So pick the one you mean
-to work, then finish it or hand it back before claiming again — trying each
-candidate in turn only produces a run of refusals. Handing a Task back is a
-status transition, not a Task-specific tool, and the refusal message names the
-Task you hold but not the way out.
+another is refused and names both the Task you hold and how to hand it back. So
+pick the one you mean to work, then finish it or hand it back before claiming
+again — trying each candidate in turn only produces a run of refusals.
 
 Your goals, memory, and repositories are work surfaces of their own. The Board
 is one of several places work lives, not the register that decides whether work

--- a/test/test_keeper_prompt_metrics.ml
+++ b/test/test_keeper_prompt_metrics.ml
@@ -380,18 +380,27 @@ let test_system_block_states_the_collaboration_surface () =
   check bool "the one-task-at-a-time limit is stated" true
     (has_in prompt "You hold one Task at a time");
   check bool "the refusal is described, not just the limit" true
-    (has_in prompt "a claim on another is refused and names the one you are holding");
+    (has_in prompt "a claim on another is refused and names both the Task you hold");
   check bool "walking the candidate list is named as the wrong move" true
     (has_in prompt "trying each candidate in turn only produces a run of refusals");
-  (* Release exists, but under the other namespace: keeper_task_claim /
+  (* Release exists under the other namespace: keeper_task_claim /
      keeper_task_done / keeper_task_create sit on the keeper_* surface while
-     handing a task back is masc_transition with action "release" (101 live
-     calls). The refusal names the held task and nothing else, so a keeper that
-     only knows the keeper_task_* family has no route out of it. *)
-  check bool "handing back is located outside the task tool family" true
-    (has_in prompt "a status transition, not a Task-specific tool");
-  check bool "the refusal's silence about the way out is stated" true
-    (has_in prompt "names the Task you hold but not the way out")
+     handing a task back is masc_transition with action "release".
+
+     This used to be spelled out in the prompt, in two sentences pinned here
+     ("a status transition, not a Task-specific tool" and "names the Task you
+     hold but not the way out"), because the refusal message named the held
+     task and nothing else. The message now names masc_transition
+     action=release and the required handoff_context.summary, so the prompt no
+     longer restates it and these two assertions would pin prose that is gone.
+
+     The contract did not disappear, it moved. Its test moved with it:
+     test_workspace_coverage / claim_next "single-claim refusal names the
+     release path", which fails if the message drops any of the three tokens.
+     Asserting the prompt still describes the route would re-create the
+     duplication this removed. *)
+  check bool "the prompt points at the refusal instead of restating the route" true
+    (has_in prompt "names both the Task you hold and how to hand it back")
 
 let test_repository_checkout_authority_prompt () =
   let prompt =

--- a/test/test_workspace_coverage.ml
+++ b/test/test_workspace_coverage.ml
@@ -630,6 +630,31 @@ let test_claim_next_r_preserves_current_task () =
     | _ -> Alcotest.fail "second claim should succeed")
 ;;
 
+(** The single-claim refusal has to carry its own correction hint: the prompt
+    used to spell out the escape route in prose because the message named the
+    held Task but not the way out. *)
+let test_claim_next_refusal_names_the_release_path () =
+  with_test_env (fun config ->
+    let _ = Workspace.add_task config ~title:"Alpha" ~priority:1 ~description:"" in
+    let _ = Workspace.add_task config ~title:"Beta" ~priority:2 ~description:"" in
+    let _ = Workspace.claim_next_r config ~agent_name:"claude" () in
+    match Workspace.claim_next_r config ~agent_name:"claude" () with
+    | Workspace.Claim_next_claimed { message; _ } ->
+      Alcotest.(check bool)
+        "names the transition tool"
+        true
+        (str_contains message "masc_transition");
+      Alcotest.(check bool)
+        "names the release action"
+        true
+        (str_contains message "action=release");
+      Alcotest.(check bool)
+        "names the required handoff summary"
+        true
+        (str_contains message "handoff_context.summary")
+    | _ -> Alcotest.fail "second claim should be refused with the held task")
+;;
+
 let test_release_hard_stop_todo_stays_claimable () =
   with_test_env (fun config ->
     let claude = find_agent_name_by_prefix config "claude" in
@@ -2798,6 +2823,10 @@ let () =
             "#10421: preserved task result"
             `Quick
             test_claim_next_r_preserves_current_task
+        ; Alcotest.test_case
+            "single-claim refusal names the release path"
+            `Quick
+            test_claim_next_refusal_names_the_release_path
         ; Alcotest.test_case
             "release hard-stop persists policy, todo stays claimable"
             `Quick


### PR DESCRIPTION
## 왜

`keeper.md` 에 이런 문장이 있었다:

> Handing a Task back is a status transition, not a Task-specific tool, and **the refusal message names the Task you hold but not the way out.**

프롬프트 산문이 런타임 결함을 대신 지불하고 있었다. 실제 거부 메시지는:

```
keeper-x already holds [P2] task-123: Fix the thing.
```

여기서 끝난다. 다른 일을 하려는 Keeper 는 탈출구가 `masc_transition action=release` + `handoff_context.summary` 라는 걸 **이미 알고 있어야** 했다.

## 무엇을 바꿨나

메시지가 그 경로를 직접 말한다. `keeper.md` 는 보상 문장을 버린다(-2 줄).

**제약 자체는 남긴다.** `#10421` 이 자동 release 가 만든 hot-potato 루프를 기록하고 있다 — InProgress 작업이 Todo 로 떨어져 원 소유자가 끝내기 전에 다른 keeper 가 가져갔다. 줄인 것은 제약이 아니라 그 제약의 **마찰**이다.

## 새 단언이 실패할 수 있음을 증명

메시지를 되돌린 상태로 빌드:

```
claim_next 11  single-claim refusal names the r...   [FAIL]
  FAIL names the transition tool      Expected `true'  Received `false'
```

수정 복원 후 `claim_next` 21 tests / Test Successful.

## CI 배선

`claim_next` 를 CI 에 넣었다. 이 suite 는 **컴파일만 되고 실행된 적이 없다** — 해당 스텝은 `-- test revision` 만 돌린다. 배선 없이 단언을 추가했으면 아무것도 게이트하지 못했다.

그 스텝 주석이 인용하는 `observability` red 2 건(`#26445`)은 그대로 제외된다. workspace/task 를 건드리지 않는 트리에서 같은 바이너리를 돌려 **제 변경과 무관한 기존 결함**임을 확인했다(93 tests / 동일 2 failures).

RFC-WAIVED: credential / operator control / keeper sandbox / hooks / workflow 문서 어느 것도 건드리지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)