### PR TITLE
fix(test): verdict 알림이 아니라 verification run 의 완료를 기다린다 (main red, 열린 PR 전부 차단)

### DIFF
--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -659,19 +659,47 @@ let test_system_llm_agent_commits_without_a_keeper_verifier () =
       Atomic.get Workspace_hooks.verification_notify_verdict_fn
     in
     let previous_submitted = Atomic.get Workspace_hooks.verification_submitted_fn in
+    let previous_change_observer =
+      Atomic.get Masc.Verification_run_registry.change_observer_fn
+    in
     Fun.protect
       ~finally:(fun () ->
         Atomic.set Workspace_hooks.get_default_runtime_id_fn previous_runtime;
         Atomic.set Masc.Task.Anti_rationalization.run_llm_reviewer_fn previous_reviewer;
         Atomic.set Workspace_hooks.verification_notify_verdict_fn previous_notification;
-        Atomic.set Workspace_hooks.verification_submitted_fn previous_submitted)
+        Atomic.set Workspace_hooks.verification_submitted_fn previous_submitted;
+        Atomic.set
+          Masc.Verification_run_registry.change_observer_fn
+          previous_change_observer)
       (fun () ->
         Atomic.set Workspace_hooks.get_default_runtime_id_fn
           (fun () -> "test-system-evaluator");
         Eio.Switch.run (fun sw ->
           let reviewer_called, resolve_reviewer_called = Eio.Promise.create () in
           let verdict_committed, resolve_verdict_committed = Eio.Promise.create () in
+          let run_completed, resolve_run_completed = Eio.Promise.create () in
           let committed_verification_id = ref None in
+          (* The verdict notification fires inside Workspace.commit_verdict_r,
+             which the authority evaluates as an argument to its own [complete]
+             -- so mark_completed necessarily runs after it. That order is not
+             incidental: a failed commit becomes the Commit_failed outcome, so
+             the outcome cannot be known before the commit is attempted. Waiting
+             on the notification and then reading the registry therefore always
+             observes Running. Wait for the registry's own change instead. *)
+          Atomic.set Masc.Verification_run_registry.change_observer_fn (fun () ->
+            previous_change_observer ();
+            match !committed_verification_id with
+            | None -> ()
+            | Some verification_id ->
+              (match
+                 Masc.Verification_run_registry.get
+                   (Masc.Verification_run_registry.global ())
+                   ~verification_id
+               with
+               | Some { status = Masc.Verification_run_registry.Completed _; _ }
+                 when not (Eio.Promise.is_resolved run_completed) ->
+                 Eio.Promise.resolve resolve_run_completed ()
+               | _ -> ()));
           Atomic.set Masc.Task.Anti_rationalization.run_llm_reviewer_fn
             (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result () ->
                on_tool_result
@@ -718,6 +746,7 @@ let test_system_llm_agent_commits_without_a_keeper_verifier () =
            | Error error -> Alcotest.fail (Masc_domain.masc_error_to_string error));
           Eio.Promise.await reviewer_called;
           Eio.Promise.await verdict_committed;
+          Eio.Promise.await run_completed;
           let verification_id =
             match !committed_verification_id with
             | Some verification_id -> verification_id


### PR DESCRIPTION
#27140 을 닫는다. **main red 고, `Build and Test` 가 required 라 열린 PR 전부가 자기 변경과 무관하게 막혀 있다.**

## 증상

```
[FAIL]  completion_authority  7  system LLM commits without Keeper verifier
ASSERT verification run stayed running after verdict commit
1 failure! in 0.206s. 42 tests run.
```

내 변경이 아니라는 것부터 확인했다 — 서로 무관한 PR 두 개(#27132 `.mli` 타입 삭제, #27123 fs-compat state 삭제)에서 글자 단위로 같은 실패가 났고, 변경 없는 워크트리에서도 재현됐다.

## 레이스가 아니다

테스트는 `verification_notify_verdict_fn` 을 기다린 뒤 레지스트리를 읽고 `Completed` 를 기대한다. 항상 `Running` 이 나온다.

`completion_authority_agent.ml:468`:

```ocaml
let complete ?evaluator_runtime (process_outcome, outcome) =
  Verification_run_registry.mark_completed registry ~verification_id ~outcome ... ;
  process_outcome
```

인자는 호출 **전에** 전부 평가된다. `process_outcome` 은 `commit_verdict` 의 결과이고 알림은 그 안의 `Workspace.commit_verdict_r` 에서 발화한다. 따라서 `mark_completed` 는 **반드시** 알림 뒤다. 결정론적이다.

## 프로덕션이 맞다

처음엔 프로덕션 순서를 뒤집는 쪽도 후보로 적었는데(#27140 본문), 그건 불가능하다:

```ocaml
| Error error ->
  ( defer ~task_id:task.id ~verification_id ~authority ~reason:detail
  , Verification_run_registry.Commit_failed { detail } )
```

**커밋 실패 자체가 outcome 이다.** 커밋을 시도하기 전에는 outcome 을 알 수 없으므로 먼저 기록할 수 없다. 지금 순서가 옳다.

## 변경

테스트가 알림 대신 **레지스트리 자신의 변화**를 기다린다. `Verification_run_registry.change_observer_fn` 은 이미 공개돼 있고 `mark_completed` 가 이미 부른다 (`verification_run_registry.ml:273`).

프로덕션 변경 0, 새 테스트 훅 0. 기존 훅 3개와 같은 방식으로 `Fun.protect` 에서 복원한다.

## 검증

```
before: 1 failure!        42 tests run
after:  Test Successful.  42 tests run   (4.602s)
```

로컬 메타 게이트 rc=0: determinism, enum-string-safety, telemetry-coverage, silent-failure.

## 유입 지점

`cc2225e52c` (#26931, RFC-0361 D4, 머지 2026-08-05T23:11Z) 가 레지스트리와 이 테스트를 함께 들여왔다. 그 이후 main 커밋 10개 중 이 경로를 건드린 건 0건이다. #26931 의 checks 는 머지 시점에 전부 `fail` 이고 대부분 duration 0 — 브랜치 삭제로 취소된 상태다.

## 확인한 커밋

base `5adabb8dc3`, 커밋 `fc5534c949`. 재현은 `cf68b4fcee` 에서도 동일.
