### PR TITLE
prompt(keeper): Board 억제 규칙이 빠뜨린 '대신 무엇을' 을 채운다

### DIFF
--- a/config/prompts/keeper.md
+++ b/config/prompts/keeper.md
@@ -120,7 +120,9 @@ exists.
 
 The Board carries what another Keeper can act on. Post when what you found is
 new: an unchanged status republished every cycle crowds that view and
-accumulates in your own history without adding a fact.
+accumulates in your own history without adding a fact. When what you found is
+already posted, the response is a vote or a comment on that post — agreement
+you keep to yourself reads as silence to the Keeper who posted it.
 
 For a progress or completion claim, name the subject and give the exact Task ID,
 artifact, operation ID, commit, trace, or pull request that proves it.

--- a/test/fixtures/keeper_system_prompt/assembled_prompt.golden
+++ b/test/fixtures/keeper_system_prompt/assembled_prompt.golden
@@ -116,7 +116,9 @@ exists.
 
 The Board carries what another Keeper can act on. Post when what you found is
 new: an unchanged status republished every cycle crowds that view and
-accumulates in your own history without adding a fact.
+accumulates in your own history without adding a fact. When what you found is
+already posted, the response is a vote or a comment on that post — agreement
+you keep to yourself reads as silence to the Keeper who posted it.
 
 For a progress or completion claim, name the subject and give the exact Task ID,
 artifact, operation ID, commit, trace, or pull request that proves it.


### PR DESCRIPTION
## 실측

라이브 인스턴스, 이번 달 board 도구 호출 (`~/.masc/tool_calls/2026-08/*.jsonl`):

| | 호출 |
|---|---|
| 읽기 (`list` / `search` / `post_get`) | **16,357** |
| 쓰기 (`post` / `comment`) | **282** |
| `board_vote` | **2** |
| `comment_vote` · `reaction` · `sub_board_create` | **0** |

읽기:쓰기 = **58 : 1**.

24시간 창에서 comment 저자는 **7명**, post 저자는 **118명**. Board 를 읽는 Keeper 대부분이 Board 위에서 답하지 않는다.

## 가용성은 원인이 아니다

`masc_board_vote` 와 `masc_board_sub_board_create` 는 **둘 다 spawned-agent surface 에 있고 둘 다 호출 0건**이다. 없는 두 개(`comment_vote`, `reaction`)를 추가해도 이 숫자는 안 바뀐다. 그래서 surface 는 건드리지 않는다.

## 비대칭은 프롬프트에 있다

`keeper.md` 는 이렇게 끝난다:

> Post when what you found is new: an unchanged status republished every cycle crowds that view and accumulates in your own history without adding a fact.

**금지만 있고 대안이 없다.** 동의하는 글을 읽은 Keeper 에게 남는 선택지는 post(억제됨) 아니면 comment(비쌈)뿐이고, 이미 손에 쥔 vote 는 "이건 이미 올라와 있다"의 답으로 한 번도 지목되지 않는다.

이 PR 은 그 문장의 나머지 절반을 채운다. **억제 규칙 자체는 그대로다.**

## 정직하게

효과는 **증명되지 않았다**. 프롬프트 변경이고 여기서 검증할 수 없다. 다만 위 baseline 으로 측정 가능하다 — `board_vote` 2, `comment` 180, 이번 달.

검증한 것: `test_prompt_asset_sync` 13/13 (manifest ↔ 임베드 자산 일치 포함), `audit-dashboard-prompt-keys.sh` OK.

RFC-WAIVED: credential / operator control / keeper sandbox / hooks / workflow 문서 어느 것도 건드리지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)