### PR TITLE
refactor(jsonl-writer): 읽는 쪽이 필터링하는 day 키를 레이아웃 소유자가 갖는다 (재구현 6곳 → 1곳)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -971,6 +971,14 @@ jobs:
           opam exec -- dune build --root . \
             @test/runtest-test_repos_relative_path
 
+      - name: Run JSONL day-key suite
+        # The key and the writer's path have to name the same day. A reader
+        # that drifts does not error -- it filters a layout the writer does
+        # not produce and comes back empty, which @check cannot see.
+        run: |
+          opam exec -- dune build --root . \
+            @test/runtest-test_jsonl_day_key
+
       - name: Run keeper lane launch-order AST suite
         # Asserts on lib/keeper sources through Ast_grep, so @check cannot run
         # it. It sat outside every target list while one of its counts was

--- a/lib/dune
+++ b/lib/dune
@@ -69,6 +69,7 @@
   masc.lockfree_atomic
   masc.run_registry_core
   masc.json_field
+  masc.jsonl_writer
   masc.pool_metrics
   masc.otel_metric_store
   masc.otel_spans

--- a/lib/jsonl_writer/jsonl_writer.ml
+++ b/lib/jsonl_writer/jsonl_writer.ml
@@ -7,14 +7,27 @@ type dated_path =
 
 
 
-let dated_path ~base_dir ~ts =
+(* One gmtime call behind both the path the writer picks and the key readers
+   filter with. Keeping them on separate calls is what lets one side drift to
+   local time while the other stays UTC — the reader then looks in a different
+   file than the writer wrote, for the hours where the two calendars disagree. *)
+let utc_calendar_day ts =
   let tm = Unix.gmtime ts in
-  let month_dir =
-    Printf.sprintf "%04d-%02d" (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1)
-  in
-  let day_file = Printf.sprintf "%02d.jsonl" tm.Unix.tm_mday in
+  tm.Unix.tm_year + 1900, tm.Unix.tm_mon + 1, tm.Unix.tm_mday
+;;
+
+let dated_path ~base_dir ~ts =
+  let year, month, day = utc_calendar_day ts in
+  let month_dir = Printf.sprintf "%04d-%02d" year month in
+  let day_file = Printf.sprintf "%02d.jsonl" day in
   let path = Filename.concat (Filename.concat base_dir month_dir) day_file in
   { base_dir; month_dir; day_file; path }
+;;
+
+let day_key ~ts =
+  let year, month, day = utc_calendar_day ts in
+  Printf.sprintf "%04d-%02d-%02d" year month day
+;;
 
 let dated_path_now ~base_dir =
   (* NDT-OK: this helper is the runtime write boundary for date-split JSONL;

--- a/lib/jsonl_writer/jsonl_writer.mli
+++ b/lib/jsonl_writer/jsonl_writer.mli
@@ -19,6 +19,17 @@ val dated_path : base_dir:string -> ts:float -> dated_path
 val dated_path_now : base_dir:string -> dated_path
 (** Return the dated path for the current UTC day. *)
 
+val day_key : ts:float -> string
+(** ["YYYY-MM-DD"] naming the same UTC day whose file {!dated_path} picks for
+    [ts]. Both come from one [Unix.gmtime] call.
+
+    This is the key [Dated_jsonl.read_range ~since ~until] splits back into
+    month and day to select files, so a reader that derives it independently
+    is one edit away from filtering a layout the writer does not produce.
+
+    Not for [Log]'s ring, which names flat [system_log_YYYY-MM-DD.jsonl]
+    files and shares only the format, not the layout. *)
+
 val append_jsonl : path:string -> Yojson.Safe.t -> unit
 (** Append one JSON value as a JSONL row using the common per-path writer. *)
 

--- a/lib/keeper/keeper_accountability_types_codec.ml
+++ b/lib/keeper/keeper_accountability_types_codec.ml
@@ -205,14 +205,7 @@ let resolution_event_to_json (event : resolution_event) =
      @ option_string_field "reason" event.reason)
 ;;
 
-let event_date_string ts =
-  let tm = Unix.gmtime ts in
-  Printf.sprintf
-    "%04d-%02d-%02d"
-    (tm.Unix.tm_year + 1900)
-    (tm.Unix.tm_mon + 1)
-    tm.Unix.tm_mday
-;;
+let event_date_string ts = Jsonl_writer.day_key ~ts
 
 let claim_event_of_json json =
   match json_string_opt "event_type" json with

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -1972,19 +1972,12 @@ let resolved_approval_json_of_audit_event json =
     ]
 ;;
 
-(* Day key for the [YYYY-MM/DD.jsonl] layout. Must stay UTC: the write path
-   ([Jsonl_writer.dated_path]) picks the day file with [Unix.gmtime], so a
-   local-time key here would look in the wrong file for the hours where the
-   two calendars disagree. Pinned by
-   [test_keeper_approval_resolved_history.ml]. *)
-let audit_day_string_of_ts ts =
-  let tm = Unix.gmtime ts in
-  Printf.sprintf
-    "%04d-%02d-%02d"
-    (tm.Unix.tm_year + 1900)
-    (tm.Unix.tm_mon + 1)
-    tm.Unix.tm_mday
-;;
+(* Day key for the [YYYY-MM/DD.jsonl] layout. The reasoning this comment used
+   to carry -- must stay UTC, because the write path picks the day file with
+   [Unix.gmtime] and a local-time key would look in the wrong file -- now lives
+   where it can be enforced: both come from one [Unix.gmtime] call inside
+   [Jsonl_writer]. Still pinned by [test_keeper_approval_resolved_history.ml]. *)
+let audit_day_string_of_ts ts = Jsonl_writer.day_key ~ts
 
 let clamp_int value ~low ~high = max low (min high value)
 

--- a/lib/keeper/keeper_compact_audit.ml
+++ b/lib/keeper/keeper_compact_audit.ml
@@ -253,11 +253,7 @@ let prune_older_than ~base_path ~retention_days =
 
 (* ── Read ──────────────────────────────────────────────────────── *)
 
-let iso_of_unix ts =
-  let tm = Unix.gmtime ts in
-  Printf.sprintf "%04d-%02d-%02d"
-    (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday
-
+let iso_of_unix ts = Jsonl_writer.day_key ~ts
 let read_events ~base_path ~since ~until ?keeper () :
   (row list, write_error) result =
   let filter_keeper rec_keeper =

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -655,14 +655,7 @@ let read_recent ?keeper_name ?(n = 100) () : Yojson.Safe.t list =
     ring_keep_last ~n ~keep raw)
 ;;
 
-let iso_date_of_unix ts =
-  let tm = Unix.gmtime ts in
-  Printf.sprintf
-    "%04d-%02d-%02d"
-    (tm.Unix.tm_year + 1900)
-    (tm.Unix.tm_mon + 1)
-    tm.Unix.tm_mday
-;;
+let iso_date_of_unix ts = Jsonl_writer.day_key ~ts
 
 let ts_of_entry (json : Yojson.Safe.t) : float option =
   match json with

--- a/lib/reputation_ledger_v2.ml
+++ b/lib/reputation_ledger_v2.ml
@@ -63,13 +63,7 @@ let get_store (config : Workspace.config) : Dated_jsonl.t =
         Hashtbl.replace store_cache base_path store;
         store)
 
-let event_date_string ts =
-  let tm = Unix.gmtime ts in
-  Printf.sprintf "%04d-%02d-%02d"
-    (tm.Unix.tm_year + 1900)
-    (tm.Unix.tm_mon + 1)
-    tm.Unix.tm_mday
-
+let event_date_string ts = Jsonl_writer.day_key ~ts
 let opt_string_field key = function
   | Some s ->
       let trimmed = String.trim s in

--- a/lib/telemetry_unified/dune
+++ b/lib/telemetry_unified/dune
@@ -11,6 +11,7 @@
   fs_compat
   otel_metric_store
   masc.json_field
+  masc.jsonl_writer
   masc.telemetry_coverage_gap
   masc.telemetry_unified_source
   masc_core

--- a/lib/telemetry_unified/telemetry_unified.ml
+++ b/lib/telemetry_unified/telemetry_unified.ml
@@ -77,11 +77,7 @@ let extract_ts (json : Yojson.Safe.t) : float =
        |> Option.value ~default:0.0)
   | _ -> 0.0
 
-let day_string_of_unix_seconds ts =
-  let tm = Unix.gmtime ts in
-  Printf.sprintf "%04d-%02d-%02d"
-    (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday
-
+let day_string_of_unix_seconds ts = Jsonl_writer.day_key ~ts
 let effective_day_window ?since_ts ?until_ts () =
   match since_ts, until_ts with
   | None, None -> None

--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -4,7 +4,7 @@
   "keeper_mli_missing": 13,
   "workspace_mli_missing": 2,
   "godsplit_count": 0,
-  "lib_dune_lines": 344,
+  "lib_dune_lines": 345,
   "inferred_dump_headers": 0,
   "lib_other_mli_missing": 0
 }

--- a/test/dune
+++ b/test/dune
@@ -1709,6 +1709,8 @@
 (include stanzas/test_discord_observability.inc)
 (include stanzas/test_gate_connector_observability.inc)
 
+(include stanzas/test_jsonl_day_key.inc)
+
 (include stanzas/test_discord_rest_client.inc)
 
 (include stanzas/test_slack_rest_client.inc)

--- a/test/stanzas/test_jsonl_day_key.inc
+++ b/test/stanzas/test_jsonl_day_key.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_jsonl_day_key)
+ (modules test_jsonl_day_key)
+ (libraries alcotest masc.jsonl_writer unix))

--- a/test/test_jsonl_day_key.ml
+++ b/test/test_jsonl_day_key.ml
@@ -1,0 +1,94 @@
+(** Pins the day key to the day file the writer actually picks.
+
+    [Dated_jsonl.read_range ~since ~until] splits ["YYYY-MM-DD"] back into
+    month and day and string-compares those against the [YYYY-MM/DD.jsonl]
+    layout. Six readers used to build that key from their own [Unix.gmtime]
+    call. The failure mode if one drifts is not an error: the reader looks in
+    a different file than the writer wrote, and returns nothing for the hours
+    where the two calendars disagree.
+
+    So the property under test is not "the format is YYYY-MM-DD" but "the key
+    and the path name the same day". *)
+
+open Alcotest
+
+(* Instants chosen so a non-UTC reader lands on a different calendar day than
+   the writer: both sides of UTC midnight, and both sides of the KST offset. *)
+let instants =
+  [ "epoch", 0.0
+  ; "2025-07-31 23:59:59Z — already 08-01 in KST", 1754006399.0
+  ; "2025-08-01 00:00:00Z", 1754006400.0
+  ; "2025-08-01 00:00:01Z", 1754006401.0
+  ; "2025-07-31 22:00:00Z — already 08-01 in KST", 1753999200.0
+  ; "1969-12-31 23:59:59Z — already 1970-01-01 in KST", -1.0
+  ]
+;;
+
+let test_key_matches_the_path () =
+  List.iter
+    (fun (label, ts) ->
+      let dated = Jsonl_writer.dated_path ~base_dir:"/store" ~ts in
+      let expected = dated.Jsonl_writer.month_dir ^ "-" ^ Filename.remove_extension dated.Jsonl_writer.day_file in
+      check string (label ^ ": key names the file the writer picks") expected (Jsonl_writer.day_key ~ts))
+    instants
+;;
+
+let test_key_shape () =
+  check string "epoch" "1970-01-01" (Jsonl_writer.day_key ~ts:0.0);
+  check
+    string
+    "one second before UTC midnight stays on the earlier day"
+    "2025-07-31"
+    (Jsonl_writer.day_key ~ts:1754006399.0);
+  check
+    string
+    "UTC midnight rolls over"
+    "2025-08-01"
+    (Jsonl_writer.day_key ~ts:1754006400.0);
+  check
+    string
+    "one second before the epoch is the previous day, not the epoch"
+    "1969-12-31"
+    (Jsonl_writer.day_key ~ts:(-1.0))
+;;
+
+(* The writer is UTC by construction, so this restates the contract from the
+   reader's side: whatever the host's timezone is, the key does not move. *)
+let test_key_ignores_host_timezone () =
+  (* 2025-07-31 23:59:59Z. On any host east of UTC this is already 08-01
+     locally, which is the hour where a local-time reader would miss the
+     file. *)
+  let ts = 1754006399.0 in
+  let utc = Jsonl_writer.day_key ~ts in
+  let local_tm = Unix.localtime ts in
+  let local_day =
+    Printf.sprintf
+      "%04d-%02d-%02d"
+      (local_tm.Unix.tm_year + 1900)
+      (local_tm.Unix.tm_mon + 1)
+      local_tm.Unix.tm_mday
+  in
+  check string "the key is the UTC day" "2025-07-31" utc;
+  if String.equal local_day utc
+  then
+    (* Runner is on UTC, so this instant cannot demonstrate the difference.
+       The path check above still holds it to the writer. *)
+    ()
+  else
+    check
+      bool
+      "on a non-UTC host the local day differs, and the key does not follow it"
+      true
+      (not (String.equal local_day utc))
+;;
+
+let () =
+  run
+    "jsonl day key"
+    [ ( "writer agreement"
+      , [ test_case "key names the writer's file" `Quick test_key_matches_the_path
+        ; test_case "pinned strings" `Quick test_key_shape
+        ; test_case "does not follow the host timezone" `Quick test_key_ignores_host_timezone
+        ] )
+    ]
+;;


### PR DESCRIPTION
#27143 을 구현한다.

## 문제

`Jsonl_writer.dated_path` 가 행이 어느 `YYYY-MM/DD.jsonl` 파일에 들어갈지 정한다. `Dated_jsonl.read_range ~since ~until` 은 `"YYYY-MM-DD"` 키를 받아 **다시 month/day 로 쪼개** 파일을 고른다 (`dated_jsonl.ml:998-1012`).

읽는 쪽 6곳이 그 키를 **자기 `Unix.gmtime` 호출로** 만들었다. 쓰기와 읽기가 구조가 아니라 관례로 일치했다.

`keeper_approval_queue` 는 이미 알고 있었다:

> Must stay UTC: the write path (`[Jsonl_writer.dated_path]`) picks the day file with `[Unix.gmtime]`, so a local-time key here would look in the wrong file for the hours where the two calendars disagree.

진단은 정확한데, 결론이 `dated_path` 호출이 아니라 **`gmtime` 재구현 + 테스트 하나로 고정**이었다.

## 변경

`Jsonl_writer` 안에 `utc_calendar_day` 하나를 두고 경로와 키가 **같은 `gmtime` 호출**에서 나온다.

```ocaml
let utc_calendar_day ts =
  let tm = Unix.gmtime ts in
  tm.Unix.tm_year + 1900, tm.Unix.tm_mon + 1, tm.Unix.tm_mday

let dated_path ~base_dir ~ts = let year, month, day = utc_calendar_day ts in ...
let day_key ~ts = let year, month, day = utc_calendar_day ts in Printf.sprintf "%04d-%02d-%02d" ...
```

위임 6곳: `keeper_approval_queue`, `keeper_accountability_types_codec`, `keeper_compact_audit`, `keeper_tool_call_log`, `reputation_ledger_v2`, `telemetry_unified`.

## 이슈 본문에서 8곳이라고 썼는데 6곳이다

각 소비지점을 열어보니 **포맷은 같은데 레이아웃이 다른** 것이 2건 섞여 있었다. 코멘트로 정정했고 이 PR 은 정정본을 따른다.

| 제외 | 이유 |
|---|---|
| `masc_log/log.ml` | Ring 은 `system_log_YYYY-MM-DD.jsonl` **평면 파일**이다. 월 디렉터리 구조와 무관하다 |
| `keeper_runtime_manifest_housekeeping` | `today_key` 는 경로가 아니라 "오늘 이미 prune 했나" Hashtbl 키다 |

날짜 포맷이 같아 보인다고 묶으면 #27094 에서 URL 끝 슬래시와 경로 끝 슬래시를 가른 판단이 무너진다. `.mli` 에 `Log` 는 대상이 아니라고 명시했다.

## dune

`jsonl_writer` 의 의존은 `fs_compat unix yojson` 뿐이다. 추가한 두 곳(`masc`, `telemetry_unified`)은 셋 다 이미 갖고 있어 **클로저가 늘지 않는다.**

(전이 의존으로는 모듈이 안 보인다는 걸 #27133 에서 CI 가 가르쳐줬다. 이번엔 직접 선언했다.)

## 테스트

이 결함은 **에러를 안 낸다.** 드리프트한 리더는 쓰기가 만들지 않는 레이아웃을 필터링하고 빈 결과를 돌려준다. `@check` 로는 안 보인다.

두 가지를 고정한다:
1. `day_key ~ts` 가 `dated_path ~ts` 가 고른 파일과 **같은 날을 지칭**한다
2. 절대 문자열 — UTC 자정 전후, epoch 이전, KST 로는 이미 다음 날인 시각

결함 주입으로 확인 (writer 를 `localtime` 으로):
```
[FAIL] pinned strings.
[FAIL] does not follow the host timezone.
```
1번은 안 깨진다 — 양쪽이 같은 함수를 쓰므로 구조적으로 일치한다. 그게 이 PR 의 목적이고, 절대값 고정이 나머지를 잡는다.

CI 스텝 추가.

## 검증

```
dune build @check                      clean
test_jsonl_day_key                     3/3 (신규)
test_keeper_approval_resolved_history  10/10
test_telemetry_unified                 37/37
test_keeper_catchup_digest             1 failure — 수정 없는 origin/main 에서
                                       동일하게 실패 (FAIL paused_now), 무관
```

메타 게이트 7종 로컬 rc=0.

커밋 `c85f8659c8`, base `5adabb8dc3`.
