### PR TITLE
fix(board): keeper projection 이 끝까지 구현된 두 기능을 모델에게서 가린 것 (저자 필터 · 댓글 스레드)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -821,7 +821,8 @@ jobs:
             @test/runtest-test_server_auth_dashboard_actor_resolution \
             @test/runtest-test_error_body_wire_shape \
             @test/runtest-test_tool_registry_consistency \
-            @test/runtest-test_tool_spec
+            @test/runtest-test_tool_spec \
+            @test/runtest-test_tool_shard_coverage
 
       - name: Run keeper lane launch-order AST suite
         # Asserts on lib/keeper sources through Ast_grep, so @check cannot run

--- a/lib/tool_surface/tool_shard_types_board_keeper_projection.ml
+++ b/lib/tool_surface/tool_shard_types_board_keeper_projection.ml
@@ -160,6 +160,22 @@ let schemas : Masc_domain.tool_schema list =
                              match). Pass your own keeper name to avoid self-referential \
                              loops when reading the board." )
                   ] )
+                ; ( "exclude_system"
+                  , `Assoc
+                      [ "type", `String "boolean"
+                      ; ( "description"
+                        , `String
+                            "Exclude system posts such as task verdict receipts and \
+                             Activity Reports (default: false)." )
+                      ] )
+                ; ( "exclude_automation"
+                  , `Assoc
+                      [ "type", `String "boolean"
+                      ; ( "description"
+                        , `String
+                            "Exclude automation posts such as heartbeats and probes \
+                             (default: false)." )
+                      ] )
                 ; ( "if_revision"
                   , `Assoc
                       [ "type", `String "string"

--- a/lib/tool_surface/tool_shard_types_board_keeper_projection.ml
+++ b/lib/tool_surface/tool_shard_types_board_keeper_projection.ml
@@ -212,6 +212,14 @@ let schemas : Masc_domain.tool_schema list =
                       [ "type", `String "string"
                       ; "description", `String "Comment content"
                       ] )
+                ; ( "parent_id"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description"
+                        , `String
+                            "Optional comment ID to reply under, threading this comment \
+                             beneath another Keeper's instead of flat on the post." )
+                      ] )
                 ] )
           ; "required", `List [ `String "post_id"; `String "content" ]
           ; "additionalProperties", `Bool false

--- a/test/test_tool_shard_coverage.ml
+++ b/test/test_tool_shard_coverage.ml
@@ -228,6 +228,21 @@ let test_keeper_board_list_can_exclude_machine_posts () =
       [ "exclude_system"; "exclude_automation" ]
 ;;
 
+(* Same class: the handler reads parent_id (board_tool_post.ml:404) and the
+   renderer already builds the reply tree from it (board_tool_format.ml:183),
+   but the projection dropped it -- so a Keeper could reply to a post and never
+   to another Keeper's comment. *)
+let test_keeper_board_comment_can_reply_to_a_comment () =
+  let schema = required_keeper_board_schema Tool_name.Board_name.Board_comment in
+  match get_json_assoc "properties" schema.input_schema with
+  | None -> Alcotest.fail "masc_board_comment missing properties"
+  | Some properties ->
+    Alcotest.(check bool)
+      "parent_id reaches the Keeper model"
+      true
+      (List.mem_assoc "parent_id" properties)
+;;
+
 let test_ide_annotation_schema_uses_opaque_references () =
   let schema =
     schema_by_name "keeper_ide_annotate" Tool_shard_types.filesystem_tools
@@ -308,6 +323,10 @@ let () =
             "board list can exclude machine posts"
             `Quick
             test_keeper_board_list_can_exclude_machine_posts
+        ; Alcotest.test_case
+            "board comment can reply to a comment"
+            `Quick
+            test_keeper_board_comment_can_reply_to_a_comment
         ; Alcotest.test_case
             "IDE opaque references"
             `Quick

--- a/test/test_tool_shard_coverage.ml
+++ b/test/test_tool_shard_coverage.ml
@@ -210,6 +210,24 @@ let test_masc_board_post_schema_supports_judgment () =
       (List.mem_assoc "quantitative_evidence" properties)
 ;;
 
+(* The Board is majority machine-authored (task verdict receipts, heartbeats).
+   The handler reads exclude_system / exclude_automation straight from args and
+   Board_dispatch.list_posts implements both, but the Keeper projection is a
+   closed schema: a knob it omits is not merely unadvertised, it is rejected. *)
+let test_keeper_board_list_can_exclude_machine_posts () =
+  let schema = required_keeper_board_schema Tool_name.Board_name.Board_list in
+  match get_json_assoc "properties" schema.input_schema with
+  | None -> Alcotest.fail "masc_board_list missing properties"
+  | Some properties ->
+    List.iter
+      (fun field ->
+         Alcotest.(check bool)
+           (field ^ " reaches the Keeper model")
+           true
+           (List.mem_assoc field properties))
+      [ "exclude_system"; "exclude_automation" ]
+;;
+
 let test_ide_annotation_schema_uses_opaque_references () =
   let schema =
     schema_by_name "keeper_ide_annotate" Tool_shard_types.filesystem_tools
@@ -286,6 +304,10 @@ let () =
             "board post judgment"
             `Quick
             test_masc_board_post_schema_supports_judgment
+        ; Alcotest.test_case
+            "board list can exclude machine posts"
+            `Quick
+            test_keeper_board_list_can_exclude_machine_posts
         ; Alcotest.test_case
             "IDE opaque references"
             `Quick


### PR DESCRIPTION
Keeper Board projection 이 **정본 스키마가 광고하고, 핸들러가 읽고, 렌더러까지 구현한** 기능 두 개를 떨어뜨리고 있었다. 그 projection 은 `additionalProperties: false` 라, 광고만 안 된 게 아니라 **keeper 가 그 인자를 보내면 거부된다.**

계열 전수를 먼저 확인하고 **두 곳을 한 PR 에 담는다** — 한 곳만 고치고 "1 of 2" 를 자인하면 그 자체가 워크어라운드 시그니처다.

---

## 1. `board_list` — 저자 필터

라이브 24 시간 Board 게시물 **280 건** 중 **217 건(78%)이 기계 저자**다 (`system` 108 · `system-llm-agent-<hash>` 109). `post_kind` 로는 `system` 219 · `automation` 57 · **`direct` 4**.

이번 달 `board_list` 호출은 **12,080 회**. 그 전부가 이 뷰를 받았다.

```
board_dispatch.ml            ?exclude_system ?exclude_automation   구현
board_tool_post.ml:209       get_bool args "exclude_system"        핸들러가 읽음
board_tool_schemas.ml        정본 스키마에 둘 다 광고
keeper projection            ← 탈락
```

`exclude_system` 의 유일한 공급자는 대시보드 HTTP 라우트였다. **사람이 쓰는 UI 에는 스위치가 있고 keeper 에게는 없었다.**

### 정정: 이걸 "노이즈" 라고 부르지 않는다

처음 이 PR 을 열 때 78% 를 노이즈로 서술했다. **데이터가 그걸 지지하지 않는다.** board attention 판정 5,074 건을 저자별로 교차하면:

| | 기계 저자 글 | keeper 글 |
|---|---:|---:|
| 판정 건수 | 3,012 | 2,062 |
| `relevant` | 798 | 315 |
| **relevant 비율** | **26.5%** | **16.2%** |

기계 글이 keeper 글보다 관련성 판정을 **더 자주** 받는다. 판정 영수증(`Approved task task-177`)은 그 task 를 가진 keeper 에게 실제로 관련 있는 정보다.

**그리고 keeper 쪽 16.2% 는 그대로 읽으면 안 된다.** hearth 별로 쪼개면 한 keeper 의 주제 이탈 게시물이 끌어내린 값이다:

| `ops` (주 작업 채널) 후보 1,018 | relevant |
|---|---:|
| 한 keeper 의 `[영화 이야기]` 글 **408** | **0 (0.0%)** |
| 나머지 610 | 136 (**22.3%**) |

그 408 건은 전부 `sangsu` 한 명이고, 같은 제목 계열 591 건 중 `movie` hearth 에 있는 건 73 건뿐이다. 즉 갈 곳이 있는 내용이 주 채널에 올라가 있고, 다른 모든 keeper 의 attention 파이프라인이 그 408 건에 LLM 판정을 한 번씩 썼다.

이건 코드 결함이 아니라 한 keeper 의 게시 행동이므로 이 PR 에서 고치지 않는다. 다만 "keeper 글은 관련성이 낮다" 는 결론을 이 숫자로 내리면 틀린다 — 그 keeper 를 빼면 `ops` 22.3%, `research` 30.0%, `lane-smith` 32.0%, `verification` 25.0% 다.

그래서 이 인자의 근거는 "노이즈 제거" 가 아니라 **선택권**이다: 지금 keeper 는 저자 구성을 고를 수 없고, 동료 논의만 읽고 싶을 때 그렇게 요청할 방법이 없다. 기본값은 `false` 이므로 아무 동작도 바뀌지 않는다.

## 2. `board_comment` — 댓글 스레드

```
board_tool_post.ml:404       get_string_opt args "parent_id"
board_tool_post.ml:444       ?parent_id 전달
board_tool_format.ml:183     렌더러가 이미 답글 트리를 구성
board_tool_schemas.ml:408    정본 스키마가 광고
keeper projection            ← 탈락
```

| | |
|---|---:|
| 댓글 총계 | 290 |
| 그중 답글(`parent_id`) | **6** |
| 24 시간 105 건 중 답글 | **0** |

비대칭이 결정적 단서다 — `masc_board_post` 는 `thread_id` 를 **받는다**. 글 수준 스레드는 주고 댓글 수준 스레드는 뺏었다. keeper 는 글에 답할 수 있고 **다른 keeper 의 댓글에는 답할 수 없다.**

---

## 나머지 탈락 항목은 같은 계열이 아니다

한 곳만 보고 멈추지 않고 전수 diff 를 냈다:

| 탈락 | 판정 |
|---|---|
| `author` · `voter` | 신원은 런타임 바인딩 — **떨어뜨리는 게 맞다** |
| `title` · `body` | projection 은 `content` 를 쓴다 — 손실이 아니라 **형태 변경** |
| `post_kind` · `ttl_hours` · `visibility` | 런타임이 정하는 값 |
| `limit` · `offset` · `random` · `since` | 페이지네이션, 의도된 축소 |

Task 도 확인했다. `keeper_board_schema` 가 **유일한 narrowing projection** 이고 task 도구는 `taskboard_tools` 를 그대로 쓴다 — 이 결함 계열은 Board 한정이다.

## 검증

두 단언 모두 **실패할 수 있음을 증명**했다:

```
projection 되돌림 → ASSERT exclude_system reaches the Keeper model   Expected true / Received false
projection 되돌림 → ASSERT parent_id reaches the Keeper model        Expected true / Received false
복원            → Keeper tool catalog 13/13
```

`dune build @check` clean · ocamlformat clean.

**새 동작은 없다.** 핸들러·dispatch·렌더러는 처음부터 이 인자들을 처리하고 있었고, 두 필터의 기본값은 `false` 다.

## CI 배선

`test_tool_shard_coverage` 를 다른 schema-contract suite 옆에 넣었다. `@check` 가 컴파일만 하고 아무도 실행하지 않았다 — 배선 없이 단언만 추가하면 게이트가 아니다.

## 이 PR 이 하지 않는 것

`test_tool_board_coverage` 기존 실패 5 건 → **#27156**. 무관한 트리와 깨끗한 `ME_ROOT` 에서도 동일하고 어떤 workflow 에도 배선돼 있지 않다.

RFC-WAIVED: 스키마 속성 3 개 복원. credential / operator control / keeper sandbox / hooks / workflow 문서 미접촉.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
