### PR TITLE
fix(lib): close seven small libraries under the unused-value ratchet

### DIFF
--- a/lib/auth/dune
+++ b/lib/auth/dune
@@ -5,6 +5,8 @@
  (public_name masc.auth)
  (wrapped false)
  (private_modules auth_credential_base auth_metric_store)
+ (flags
+  (:standard -w +32))
  (libraries
   yojson
   base64

--- a/lib/config_dir_resolver/dune
+++ b/lib/config_dir_resolver/dune
@@ -13,4 +13,6 @@
  (name masc_config_dir_resolver)
  (public_name masc.config_dir_resolver)
  (wrapped false)
+ (flags
+  (:standard -w +32))
  (libraries masc_core masc.config masc.host_config masc_log yojson))

--- a/lib/keeper_metrics/dune
+++ b/lib/keeper_metrics/dune
@@ -17,4 +17,6 @@
   keeper_tool_outcome)
  (preprocess
   (pps ppx_enumerate))
+ (flags
+  (:standard -w +32))
  (libraries masc_core otel_metric_store time_compat unix yojson))

--- a/lib/otel_dispatch_hook/dune
+++ b/lib/otel_dispatch_hook/dune
@@ -5,6 +5,8 @@
  (public_name masc.otel_dispatch_hook)
  (wrapped false)
  (modules otel_dispatch_hook)
+ (flags
+  (:standard -w +32))
  (libraries
   eio
   opentelemetry

--- a/lib/otel_metrics/dune
+++ b/lib/otel_metrics/dune
@@ -10,4 +10,6 @@
  (name masc_otel_metrics)
  (public_name masc.otel_metrics)
  (wrapped false)
+ (flags
+  (:standard -w +32))
  (libraries opentelemetry opentelemetry.client))

--- a/lib/runtime_model/dune
+++ b/lib/runtime_model/dune
@@ -14,6 +14,8 @@
  (name masc_runtime_model)
  (public_name masc.runtime_model)
  (wrapped false)
+ (flags
+  (:standard -w +32))
  (libraries
   agent_sdk
   agent_sdk.llm_provider

--- a/lib/task/dune
+++ b/lib/task/dune
@@ -19,7 +19,7 @@
   tool_task_schemas
   workflow_rejection_payload)
  (flags
-  (:standard -w -4 -w +37))
+  (:standard -w -4 -w +32 -w +37))
  (libraries
   yojson
   unix


### PR DESCRIPTION
## 현재 상태: dune flags 전용 PR

사전 리뷰에서 확인된 대로, 이 PR이 지우던 죽은 값 10 개(`json_nonnegative_int`, `file_item`, `timed`, `cold_warm_phase` 연쇄, `metric_of_sample`, `runtime_prefix_of_provider_label` 연쇄, `task_log_info`)는 main에 이미 전량 반영되어 있다. rebase 후 남은 델타는 **일곱 라이브러리의 dune에 `-w +32` 래칫을 켜는 것뿐**이다.

| 라이브러리 | 추가 플래그 |
|---|---|
| `lib/auth` | `-w +32` |
| `lib/config_dir_resolver` | `-w +32` |
| `lib/keeper_metrics` | `-w +32` |
| `lib/otel_dispatch_hook` | `-w +32` |
| `lib/otel_metrics` | `-w +32` |
| `lib/runtime_model` | `-w +32` |
| `lib/task` | `-w +32` (기존 `-w -4 -w +37`에 합집합) |

삭제분이 main에 먼저 들어갔으므로 코드 변경은 없고, unused-value 래칫만 남긴다.

## 배경 (원 PR 설명)

원래 이 PR은 죽은 값을 하나씩만 갖고 있던 라이브러리 일곱 개를 닫는 PR이었다. 각각 그 값이 `-w +32` 위반의 전부였으므로 지우는 순간 래칫을 받는 구조였다(연쇄 포함 10 개, 59 줄, 네 라운드 수렴). 그 삭제분이 main에 선반영되면서 flags-only PR로 축소되었다.

- `cold_warm_phase` 연쇄: 시간 임계 분류기를 지우자 `startup_time` → `cold_phase_seconds` 가 연쇄로 죽음 — cold/warm 구분 전체가 무소비자였음
- `runtime_prefix_of_provider_label` 연쇄: 유일 소비자를 지우자 `find_profile_by_alias` 가 죽음 — provider label alias 조회 경로가 통째로 미사용이었음

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>