### PR TITLE
docs(spec): 저장소가 이미 지운 서브시스템을 스펙에서도 지운다 (없는 파일 21개, 만족 불가 불변식 1개)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,6 +512,7 @@ jobs:
           echo "=== Running meta bug-class gates (see #9516 #9517 #9519 #9521) ==="
           bash scripts/ci/check-ssot-spawn-drift.sh
           bash scripts/check-spec-truth.sh
+          python3 scripts/ci/check-spec-file-refs.py
           bash scripts/ci/check-silent-failure-patterns.sh
           bash scripts/ci/check-enum-string-safety.sh
           bash scripts/ci/check-masc-oas-boundary.sh

--- a/docs/spec/02-types-and-invariants.md
+++ b/docs/spec/02-types-and-invariants.md
@@ -401,7 +401,7 @@ lookup 후, tag별로 적합한 모듈 컨텍스트를 지연 생성한다. 제�
 
 ### 4.4 Tool_result.result (structured)
 
-**소스**: `lib/tool_result.mli`
+**소스**: `lib/tool_types/tool_result.mli`
 
 ```ocaml
 type success_payload = {
@@ -474,28 +474,6 @@ module Registry : sig
   val count : registry -> int
 end
 ```
-
----
-
-## 6. Agent Ecosystem Types (RETIRED)
-
-`lib/agent_ecosystem.mli`와 `agent_lifecycle`, `agent_profile`, `lineage`, `extended` 타입은 dead code sweep (#2848)에서 `lib/anti_fake`, `lib/agent_neo4j`와 함께 제거됐다 (-1368 LOC). 현재 agent identity는 `lib/client_identity.ml` 하나로 정리됐고, 생명주기 추적은 `lib/workspace/workspace_lifecycle.ml` + `observe_agent_lifecycle` hook이 담당한다.
-
----
-
-## 7. Checkpoint Types (RETIRED)
-
-`lib/checkpoint_types.ml`는 Time-Travel checkpoint 실험을 지원하던 전용 타입 모듈이었고, 현재 repo에서 제거됐다. `checkpoint_status` 7-variant FSM(`Pending`/`InProgress`/`Interrupted`/`Completed`/`Rejected`/`Reverted`/`Branched`)과 `checkpoint_info` record는 더 이상 어떤 subsystem도 참조하지 않는다 (`grep -rn checkpoint_status lib/ test/` → 0 hits).
-
-체크포인트 개념이 남아 있는 곳은 keeper turn lifecycle(`lib/keeper/keeper_turn_lifecycle.ml`)에 통합된 per-turn resume snapshot뿐이며, 별도 타입 모듈로는 더 이상 노출되지 않는다.
-
----
-
-## 8. Context Budget Types (RETIRED)
-
-`lib/context_budget_manager.mli`는 MASC 레벨의 `compression_phase` 4-variant FSM(`None_phase`/`Compact_tools`/`Drop_low`/`Summarize`)과 `Budget_tracker` API(`record_tool_schemas`, `record_turn`, `usage_ratio`, `current_phase`)를 노출하던 모듈이었고, 현재 repo에서 제거됐다. `grep -rn compression_phase lib/ test/` → 0 hits.
-
-현재 기준은 `feedback_budget-belongs-in-oas.md` 메모리에 기록된 경계 원칙이다. Raw token 수/컨텍스트 한도 추적은 OAS(agent_sdk)가 소유하고, MASC는 OAS가 내보내는 추상 신호(ratio/status)만 소비한다. 환경변수 `MASC_CONTEXT_BUDGET_MAX` 역시 더 이상 active runtime에서 읽히지 않는다.
 
 ---
 
@@ -576,14 +554,6 @@ type rate_limit_error = {
   category : rate_limit_category;
 }
 ```
-
----
-
-## 10. Structured Message Types (RETIRED)
-
-`lib/message_schema.mli`는 swarm 내부 메시지를 위한 `validation_mode` 3-variant, `structured_message` 5-variant(`TaskUpdate`/`StatusReport`/`Request`/`Response`/`Freeform`), `swarm_envelope` record를 노출하던 모듈이었고, Gen37에서 frontmatter code_refs 정리 시점에 #2848 dead-code sweep과 함께 제거된 것이 확인됐다. `grep -rn "validation_mode\|swarm_envelope" lib/ test/` → 0 hits.
-
-현재 workspace collaboration 경로는 `board_posts` + keeper FSM으로 통합됐으며 별도 "structured message / envelope" 타입 레이어는 노출되지 않는다. Swarm 문맥에서 message delivery 의미론이 필요하면 `docs/spec/11-board.md`를 참조한다.
 
 ---
 

--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -40,20 +40,16 @@ Keeper는 외부 세계를 관찰(`world_observation`)하고, 프롬프트를 �
 graph LR
   subgraph Types
     KT[keeper_types] --> KC[keeper_config]
-    KT --> KCT[keeper_contract]
   end
   subgraph Context
-    KWC[working_context] --> KEC[exec_context] --> KCS[checkpoint_store]
+    KCC[context_core] --> KCR[context_runtime] --> KCS[checkpoint_store]
   end
   subgraph Memory
-    KMO[memory_os_io] --> KMR[memory_recall]
+    KMO[memory_os_current] --> KMR[memory_os_recall]
   end
   subgraph Turn
     KUT[unified_turn] --> KAR[agent_run] --> KTO[tools_oas]
     KAR --> KHO[hooks_oas]
-  end
-  subgraph Decision
-    KD --> KL[learning]
   end
   subgraph Completion Authority
     CA[system LLM agent] --> CV[typed verdict]
@@ -74,9 +70,8 @@ graph LR
 | Config | `keeper_config.ml`, `keeper_toml_loader.ml` | 2 |
 | Context | `keeper_context_core.ml`, `keeper_context_runtime.ml`, `keeper_checkpoint_store.ml` | 3 |
 | Memory | `keeper_memory*.ml` (bank, policy, recall) | 4 |
-| Prompt / Skill | `keeper_prompt.ml`, `keeper_unified_prompt.ml`, `keeper_skill_routing.ml` | 3 |
+| Prompt | `keeper_prompt.ml`, `keeper_unified_prompt.ml` | 2 |
 | Turn Execution | `keeper_agent_run.ml`, `keeper_unified_turn.ml`, `keeper_tools_oas.ml`, `keeper_hooks_oas.ml` | 4 |
-| Decision | `keeper_deliberation.ml` | 1 |
 | Supervision | `keeper_supervisor.ml`, `keeper_keepalive.ml`, `keeper_world_observation.ml` | 3 |
 | MCP Surface | `keeper_turn.ml`, `keeper_status.ml`, `keeper_persona.ml`, `keeper_schema.ml` | 4 |
 | Alerting / Metrics | `keeper_alerting*.ml`, `keeper_status_runtime*.ml`, `keeper_status_detail.ml` | 6+ |
@@ -87,7 +82,7 @@ graph LR
 
 ### 3.1 keeper_meta
 
-Keeper의 전체 상태를 담는 레코드. `lib/keeper/keeper_types.ml`에 정의되며, 약 100개 필드를 가진다.
+Keeper의 전체 상태를 담는 레코드. `lib/keeper_types/keeper_types.ml`에 정의되며, 약 100개 필드를 가진다.
 
 **소스**: `keeper_types.ml` (lines 9-106)
 
@@ -344,11 +339,7 @@ turn, and latency values remain observations.
 
 시나리오 기반 행동 평가. `scenario`(goal + graders + tool expectations) -> `Deterministic`(Exact/Contains/Regex) 또는 `ModelBased`(MODEL 채점) grader -> weight 합산 점수.
 
-### 7.3 Anti-Fake (retired)
-
-테스트 코드 품질 점수화 모듈(`lib/anti_fake.ml`)은 #2848 dead-code sweep에서 제거됐다. 테스트 품질은 현재 alcotest + QCheck assertion 및 CI의 `test_ci_hardening_source.ml` contract test가 담당한다.
-
-### 7.4 Trajectory (`lib/trajectory.ml`)
+### 7.3 Trajectory (`lib/trajectory/trajectory.ml`)
 
 Tool call을 `.masc/trajectories/{name}/{trace_id}.jsonl`에 JSONL 기록. 용도: replay, cost 추적, eval 입력.
 
@@ -459,25 +450,6 @@ Keeper는 idle 상태에서 주기적으로 자발적 행동을 생성한다.
 
 ---
 
-## 12. Learning System (retired)
-
-전용 learning 모듈(`lib/keeper/keeper_learning.ml`, `keeper_feedback_tool.ml`)은 #2589 dead-module sweep에서 제거됐다. decision_record JSONL 스키마와 `record_decision`/`record_outcome`/`record_feedback` 파이프라인도 runtime에서 사라졌다. 심의 기록은 현재 `keeper_deliberation.ml` + trajectory(`lib/trajectory.ml`) + procedural memory(`lib/procedural_memory.ml`)가 나눠 담당한다.
-
----
-
-## 13. Skill Routing
-
-**소스**: `lib/keeper/keeper_skill_routing.ml`
-
-Keeper turn에서 어떤 "skill" 경로를 사용할지 결정:
-
-허용 skill 목록: `masc-heartbeat`, `masc-keeper-autonomy`
-
-선택 모드:
-- `SkillSelectAgent`: MODEL에 skill 선택을 위임하는 단일 모드
-
----
-
 ## 14. Invariants
 
 ### INV-KEEPER-001: keeper_meta.name 유효성
@@ -563,18 +535,16 @@ External memory projection은 제거됐다. 남은 경계 이슈는 keeper conte
 
 | 문서 | 경로 |
 |------|------|
-| Keeper Types | `lib/keeper/keeper_types.ml` |
+| Keeper Types | `lib/keeper_types/keeper_types.ml` |
 | Context Core | `lib/keeper/keeper_context_core.ml` (구 `keeper_working_context.ml` 흡수) |
 | Execution Context | `lib/keeper/keeper_context_runtime.ml` |
 | Agent Run | `lib/keeper/keeper_agent_run.ml` |
 | Unified Turn | `lib/keeper/keeper_unified_turn.ml` |
-| Deliberation | `lib/keeper/keeper_deliberation.ml` |
 | Task verification evidence | `lib/workspace/workspace_task_verification.ml` |
 | OAS hook observations | `lib/keeper/keeper_hooks_oas.ml` |
 | Eval Harness | `lib/eval_harness.ml` |
-| Trajectory | `lib/trajectory.ml` |
+| Trajectory | `lib/trajectory/trajectory.ml` |
 | Supervisor | `lib/keeper/keeper_supervisor.ml` |
 | Config | `lib/keeper/keeper_config.ml` |
 | TOML Example | `config/keepers/janitor.toml` |
-| Memory facade | `lib/memory.mli` |
 | Memory: keeper 재설계 | `memory/project_dashboard-keeper-detail-redesign.md` |

--- a/docs/spec/09-server-transport.md
+++ b/docs/spec/09-server-transport.md
@@ -18,7 +18,7 @@ code_refs:
 |------|-----|
 | Status | Draft |
 | Team | Server |
-| Maps to | `lib/server/`, `lib/sse.ml`, `lib/transport.ml`, `lib/http_server_eio.ml`, `lib/http_server_h2.ml`, `lib/mcp_server_eio*.ml`, `bin/main_eio.ml`, `bin/main_stdio_eio.ml` |
+| Maps to | `lib/server/`, `lib/sse.ml`, `lib/transport.ml`, `lib/http_server_eio.ml`, `lib/mcp_server_eio*.ml`, `bin/main_eio.ml`, `bin/main_stdio_eio.ml` |
 | Dependencies | 02-types-and-invariants |
 | Modules | 61 |
 | LOC | ~17,700 |
@@ -865,7 +865,6 @@ sequenceDiagram
 | `oas_event_bridge.ml` | 56 | OAS -> SSE 이벤트 브릿지 |
 | `transport.ml` | 674 | 프로토콜 바인딩 추상화 + OpenAPI 생성 |
 | `http_server_eio.ml` | 675 | httpun-eio 래퍼 (Router, Compression) |
-| `http_server_h2.ml` | 325 | h2-eio 래퍼 |
 | `auth.ml` | 435 | 인증/인가 코어 |
 
 ### 18.2 Server Sub-library (lib/server/)

--- a/docs/spec/11-board.md
+++ b/docs/spec/11-board.md
@@ -16,7 +16,7 @@ code_refs:
 |------|-----|
 | Status | Draft |
 | Team | Workspace |
-| Maps to | `lib/board_types/` (sub-library), `lib/board.ml`, `lib/board_tool_adapter/board_tool.ml` facade and adapter submodules (successor to former `lib/tool_vote.ml` + `lib/tool_social.ml`) |
+| Maps to | `lib/board_types/` (sub-library), `lib/board.ml`, `lib/board_tool_adapter/board_tool.ml` facade and adapter submodules |
 | Dependencies | 09-server-transport |
 | LOC | ~4.1K |
 

--- a/docs/spec/15-testing.md
+++ b/docs/spec/15-testing.md
@@ -14,7 +14,7 @@ code_refs:
 |------|-----|
 | Status | Draft |
 | Team | Foundation |
-| Maps to | `test/`, `lib/keeper/keeper_gate.ml`, `lib/keeper/keeper_approval_queue.ml`, `lib/eval_harness.ml`, `lib/trajectory.ml` |
+| Maps to | `test/`, `lib/keeper/keeper_gate.ml`, `lib/keeper/keeper_approval_queue.ml`, `lib/eval_harness.ml`, `lib/trajectory/trajectory.ml` |
 | Dependencies | (all subsystem specs) |
 | Test Files | `test/dune`와 포함 stanza가 SSOT |
 
@@ -85,7 +85,6 @@ Correctness gate가 아닌 orchestration/benchmark/behavior 실험. Runbook과 �
 |------|---------|----------|
 | Keeper fleet proof | `scripts/harness/workload/agent_swarm_live.sh` | `docs/BENCHMARK-RUNBOOK.md` |
 | Supervised delivery | - | `docs/SUPERVISOR-MODE.md` |
-| TRPG smoke | `scripts/run_trpg_grimland_smoke.sh` | - |
 | Local runtime capacity | `scripts/llama-runtime-pool.sh` | `docs/PERFORMANCE-SLO.md` |
 
 규칙: proof artifact, report, runtime 전제, 모델 선택 근거를 함께 남긴다.
@@ -159,13 +158,7 @@ type scenario = {
 - `Deterministic`: 필드(result/tool_name/error)에 대한 Exact/Contains/Regex/NotContains 매칭. 0 지연.
 - `ModelBased`: LLM에 rubric과 결과를 제출하여 0.0-1.0 점수 산출. 비용 발생.
 
-### 5.3 Anti-Fake (RETIRED)
-
-`lib/anti_fake.ml`는 허위 테스트 패턴 감지(`assert true`, `let _ =`, `(* TODO *)` 등에 대한 자동 감점 + `score_result`/`audit_summary` 집계)를 제공하던 모듈이었고, #2848 dead-code sweep에서 `lib/agent_ecosystem`/`lib/agent_neo4j`와 함께 제거됐다 (`grep -rn anti_fake lib/ test/` → 0 hits).
-
-현재는 `scripts/check-test-quality.sh`와 `eval_harness`의 trajectory-level assertion 검증이 그 역할을 부분 승계하며, 전용 테스트 품질 게이트는 노출되지 않는다.
-
-### 5.4 Trajectory (lib/trajectory.ml)
+### 5.4 Trajectory (`lib/trajectory/trajectory.ml`)
 
 Keeper tool call의 JSONL 기반 궤적 로깅. 결정적 재생, 비용 누적, 엔트로피 탐지, eval_harness 연동을 지원한다.
 
@@ -202,12 +195,6 @@ Task completion claim -> configured LLM verification
 
 cost / token / turn -> observation and aggregation only
 ```
-
-### 5.6 Keeper Contract (RETIRED)
-
-`lib/keeper/keeper_contract.ml`는 keeper 정책/런타임 enum의 typed 표현(예: workspace-targeting enum legacy variant)을 제공했고, single-workspace 통합 과정에서 해당 타입이 제거됐다 (`grep -rn 'type .*scope' lib/keeper` 기준 legacy scope enum hit 없음).
-
-Keeper 관련 enum의 현재 typed boundary는 05-keeper-agent 스펙의 §2 module table을 따른다.
 
 ---
 
@@ -264,7 +251,7 @@ bisect-ppx-report html --coverage-path _coverage
 
 ### 7.2 Coverage 파일 분포
 
-100개의 `*_coverage.ml` 파일이 커버리지 보강 목적으로 존재한다. 이 파일들은 기존 테스트에서 누락된 경로를 보완하며, anti_fake 검증을 통과해야 한다.
+100개의 `*_coverage.ml` 파일이 커버리지 보강 목적으로 존재한다. 이 파일들은 기존 테스트에서 누락된 경로를 보완한다.
 
 ---
 
@@ -289,7 +276,6 @@ bisect-ppx-report html --coverage-path _coverage
 - **INV-T2**: Env-gated 테스트는 필수 환경변수 부재 시 skip 또는 not run으로 처리한다. 실패가 아니다.
 - **INV-T3**: 구조 경계 테스트는 명령 문자열이나 도구 이름에서 권한 의미를 추론하지 않는다.
 - **INV-T4**: 한 Gate 요청의 pending/HITL 상태는 다른 Keeper 또는 같은 Keeper의 독립 작업 lane을 중단시키지 않는다.
-- **INV-T5**: `anti_fake` penalty 패턴에 매칭되는 테스트 파일은 `quality_tier`에서 경고 또는 위험으로 분류된다.
 - **INV-T6**: Contract harness는 외부 서버에 의존하지 않는다. Hermetic bootstrap 경로만 사용한다.
 
 ---

--- a/scripts/ci/check-spec-file-refs.py
+++ b/scripts/ci/check-spec-file-refs.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Fail when docs/spec/ names a source file that does not exist.
+
+These documents are what an agent or a new reader is pointed at for "how the
+system works". A path that no longer resolves is worse than no path: it sends
+the reader looking for a module the repository deliberately deleted, and it
+reads as current because everything around it is.
+
+Scope is docs/spec/ only. RFCs and audits are dated records — an RFC proposing
+a module that was never built, or an audit describing files since removed, is
+supposed to keep saying so.
+
+check-spec-truth.sh covers the other direction for TLA+ specs (annotations
+pointing at OCaml sources). This is the same idea for prose.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+SPEC = REPO / "docs" / "spec"
+
+# Backtick-quoted repo-relative source paths. Globs (`keeper_memory*.ml`) and
+# directories are deliberately not matched — they are prose, not references.
+REFERENCE = re.compile(
+    r"`((?:lib|bin|test|scripts|dashboard/src|proto)/[A-Za-z0-9_./-]+"
+    r"\.(?:ml|mli|ts|tsx|py|sh|tla|cfg))`"
+)
+
+
+def main() -> int:
+    if not SPEC.is_dir():
+        print(f"FAIL: {SPEC} is missing")
+        return 1
+
+    checked = 0
+    missing: list[tuple[str, int, str]] = []
+    for doc in sorted(SPEC.rglob("*.md")):
+        text = doc.read_text()
+        for match in REFERENCE.finditer(text):
+            checked += 1
+            path = match.group(1)
+            if not (REPO / path).exists():
+                lineno = text.count("\n", 0, match.start()) + 1
+                missing.append((str(doc.relative_to(REPO)), lineno, path))
+
+    print(f"=== spec file references: {checked} checked ===")
+    if not checked:
+        print("FAIL: no references found — the pattern stopped matching")
+        return 1
+    if not missing:
+        print("PASS: every referenced source file exists")
+        return 0
+
+    print("FAIL: docs/spec names source files that do not exist:")
+    for doc, lineno, path in missing:
+        print(f"  {doc}:{lineno} -> {path}")
+    print()
+    print("Moved: update the path. Deleted: remove the claim, including any")
+    print("'this was retired in #N' note — a tombstone is still dead context.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 문제

`docs/spec/` 이 **존재하지 않는 소스 파일 21개**를 가리킨다. 전부 저장소가 **의도적으로 지운** 것이고, 삭제 커밋이 이유까지 적어뒀다.

| 모듈 | 삭제 커밋 |
|---|---|
| `keeper_deliberation.ml` | #26826 "remove the deliberation surface **nothing supplies**" |
| `keeper_skill_routing` | #20232 통합, 지금은 어떤 skill-routing 모듈도 없다 |
| `keeper_learning.ml` | #2589 "delete 14 **dead** modules" |
| `anti_fake.ml` | #2848 "remove **dead** anti_fake, agent_ecosystem, agent_neo4j" |
| `tool_social` / `tool_vote` | #2820 "remove **dead** tool_social and tool_vote" |
| `http_server_h2.ml` | #27038 "remove the H2 wrapper **nothing calls**" |
| `memory.mli` | #26128 "remove the legacy keeper memory bank" |
| `procedural_memory.ml` | #24332 Keeper governance → nonhierarchical Gate |

스펙은 여전히 **Deliberation 과 Skill Routing 을 살아있는 섹션과 모듈 테이블 행으로** 싣고 있었다.

그리고 05 의 §12 는 "Learning 은 제거됐고 그 일은 이제 `keeper_deliberation.ml` + trajectory + `procedural_memory.ml` 가 나눠 담당한다" 고 적어뒀다 — **셋 다 그 이후 삭제됐다.** 폐기 안내문이 자기들끼리 가리키고 있었다.

## 낡은 게 아니라 틀린 것 2건

`15-testing.md`:

```
§7.2   "이 파일들은 ... anti_fake 검증을 통과해야 한다"
INV-T5 "anti_fake penalty 패턴에 매칭되는 테스트 파일은 quality_tier 에서
        경고 또는 위험으로 분류된다"
```

#2848 이후 존재하지 않는 검사를 **통과하라는 요구**와, 아무것도 만족시킬 수 없는 **선언된 불변식**이다. 둘 다 제거했다.

## 묘비도 지웠다

02 와 15 의 `(RETIRED)` 섹션 6개를 통째로 삭제했다. 남겨두면 그 자체가 죽은 컨텍스트고, 위에서 본 대로 서로를 가리키기 시작한다.

## mermaid 그래프

05 의 `Decision` subgraph 는 유일한 엣지가 `KD --> KL[learning]` 이었다. **`KD` 는 라벨 정의가 아예 없고**, `KL` 은 삭제된 모듈이다. subgraph 를 제거했다.

Context / Memory 노드는 개명 전 이름이었다 (`working_context`, `exec_context`, `memory_os_io`). 실제 존재하는 모듈로 맞췄다 — 테이블의 파일명 24개를 전수 확인해 살아있는 22개는 건드리지 않았다.

## 이동한 6개는 경로만 고쳤다

`keeper_types`, `trajectory`, `tool_result`, `system_error_class` — 삭제가 아니라 이동이다. basename 검색으로 갈랐다.

## 가드

`scripts/ci/check-spec-file-refs.py` 가 `docs/spec` 이 없는 파일을 가리키면 실패한다.

**범위는 `docs/spec` 뿐이다.** RFC 와 audit 은 날짜 있는 기록이다 — 만들지 않은 모듈을 제안한 RFC 나 이후 삭제된 파일을 서술한 audit 은 계속 그렇게 말해야 한다. (참고로 `docs/` 전체로는 505건이 안 맞는데, 대부분이 그 부류다.)

`check-spec-truth.sh` 가 TLA+ 쪽 같은 방향을 이미 지킨다. 이건 산문 쪽이다.

## 검증

```
before: 106 references, 21 absent
after:   86 references,  0 absent
결함 주입 (경로 하나 rename) -> FAIL + file:line
```

커밋 `d26adfb5b4`, base `4226df9abc`.
