### PR TITLE
fix(lib): close four more libraries under the unused-value ratchet

### DIFF
--- a/lib/goal/dune
+++ b/lib/goal/dune
@@ -11,6 +11,8 @@
  (name masc_goal)
  (public_name masc.masc_goal)
  (wrapped false)
+ (flags
+  (:standard -w +32))
  (libraries
   masc_types
   masc_core

--- a/lib/telemetry_unified/dune
+++ b/lib/telemetry_unified/dune
@@ -5,6 +5,8 @@
  (public_name masc.telemetry_unified)
  (wrapped false)
  (modules telemetry_unified)
+ (flags
+  (:standard -w +32))
  (libraries
   dated_jsonl
   eio

--- a/lib/telemetry_unified/telemetry_unified.ml
+++ b/lib/telemetry_unified/telemetry_unified.ml
@@ -222,10 +222,6 @@ let coverage_gap_status_fields gaps source ~latest_ts =
 
 (* ── Semantic duplicate suppression ───────────────── *)
 
-let assoc_field name = function
-  | `Assoc fields -> List.assoc_opt name fields
-  | _ -> None
-
 let string_field name json =
   match Json_field.string json name |> Json_field.to_option with
   | None -> None

--- a/lib/tool/dune
+++ b/lib/tool/dune
@@ -31,6 +31,8 @@
  (name masc_tool_dispatch)
  (public_name masc.masc_tool_dispatch)
  (wrapped false)
+ (flags
+  (:standard -w +32))
  (libraries
   masc_types
   masc_core

--- a/lib/tool_surface/dune
+++ b/lib/tool_surface/dune
@@ -27,6 +27,8 @@
   tool_shard_types_schemas_search_files
   tool_shard_types_schemas_taskboard
   tool_shard_types_schemas_voice)
+ (flags
+  (:standard -w +32))
  (libraries
   masc_types
   masc_core


### PR DESCRIPTION
## 무엇을 하는가

`#27167` 과 같은 형태로, 죽은 값만 치우면 닫히는 라이브러리 네 개를 더 닫는다.

| 라이브러리 | 죽은 값 |
|---|---|
| `lib/telemetry_unified` | `assoc_field` |
| `lib/tool` | `keeper_shard_vote` |
| `lib/tool_surface` | `validate_short_description` |
| `lib/goal` | `normalize_lower`, `active_goals` |

5 개, 14 줄. 연쇄 없음.

## 둘이 맥락을 갖는다

**`validate_short_description`** 은 도구 도움말의 짧은 설명을 검사하는 validator 였다:

```ocaml
not (String.contains entry.short_description '\n')
&& String.length (String.trim entry.short_description) > 0
&& String.length entry.short_description <= 140
```

줄바꿈 금지, 비어있지 않을 것, 140 자 이하 — 세 규칙과 매직 상수 하나를 들고 있는데 **부르는 곳이 없다.** 도움말 등록이 이 검사를 통과하지 않고 이뤄지고 있었다는 뜻이다.

**`keeper_shard_vote`** 는 형제 넷 중 유일하게 죽은 것이다. `keeper_shard_read` / `_write` / `_add_task` 는 `explicit_metadata` 에서 쓰이는데 `CanVote` 짜리만 소비자가 없다. `scripts/check-boundary-guard.sh` 는 "retired runtime-shard worldview" 를 은퇴 개념으로 명시하고 있으며, 이건 그 정리에서 남은 한 조각이다.

## 넣지 않은 것

`lib/fusion_core` 의 `equal_result` / `pp_result` 두 개는 뺐다. `-w +32` 가 죽었다고 말하지만, 이 둘은 `[@@deriving eq, show]` 가 `result` 를 품은 타입에 붙을 때 ppx 가 호출하는 **지원 헬퍼 형태**다. 지금 호출자가 없는 것은 맞지만 잔여물이 아니라 관용구의 일부이므로, 다른 판단 기준이 필요하다.

`lib/otel_spans` 의 세 개도 뺐다 — 상류에서 가져온 vendored 파일이다.

## 검증

- `dune build --root . @check` — EXIT=0 (네 곳 모두 `-w +32` 켠 상태)
- 연쇄 확인: 한 라운드에 수렴 (새로 죽는 값 없음)
- 네 dune 모두 `-w +32` 확인
- `scripts/check-doc-code-refs.sh` — EXIT=0

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
