### PR TITLE
chore(ratchet): 4주간 쌓인 구조 여유를 baseline 에 회수한다 (게이트가 안 무는 31줄)

### DIFF
--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -1,10 +1,10 @@
 {
   "_comment": "OCaml structural-debt baseline. Regenerate with scripts/ocaml-structure-ratchet.sh --regenerate.",
   "_metrics": "See scripts/ocaml-structure-ratchet.sh METRICS array.",
-  "keeper_mli_missing": 15,
+  "keeper_mli_missing": 13,
   "workspace_mli_missing": 2,
   "godsplit_count": 0,
-  "lib_dune_lines": 375,
+  "lib_dune_lines": 344,
   "inferred_dump_headers": 0,
   "lib_other_mli_missing": 0
 }


### PR DESCRIPTION
## 무엇이 문제였나

`scripts/ocaml-structure-ratchet.sh` 는 baseline 이 마지막으로 움직인 **2026-07-09** 이후 모든 CI 실행에서 같은 힌트를 찍어 왔다:

```
OK   keeper_mli_missing: 13 < baseline 15 (baseline can be lowered)
OK   lib_dune_lines: 344 < baseline 375 (baseline can be lowered)
Hint: 2 metric(s) dropped below baseline. Consider: --regenerate
```

4 주 동안 keeper 모듈 두 개가 `.mli` 를 얻었고 `lib/dune` 이 31 줄 줄었다. **그 성과가 하나도 고정되지 않았다.** 31 줄의 여유를 가진 ratchet 은 31 줄의 재-단일화를 조용히 통과시킨다 — 게이트가 자기가 못 잡을 회귀를 매번 알려주고 있던 셈이다.

## 이 PR 이 하는 것

`--regenerate` 출력. **두 지표를 낮추고 어느 것도 올리지 않는다:**

```
keeper_mli_missing   15 -> 13
lib_dune_lines      375 -> 344
```

나머지 4 지표(`workspace_mli_missing` 2 · `godsplit_count` 0 · `inferred_dump_headers` 0 · `lib_other_mli_missing` 0)는 이미 정확해 변화 없다.

**이 성과는 내 것이 아니다.** 여러 PR 에 걸쳐 쌓인 것이고 이 PR 은 그게 되새는 것만 막는다.

## 조인 baseline 이 실제로 무는지 증명

같은 프로브를 양쪽에 넣었다. `.mli` 없는 `lib/keeper` 모듈 하나 추가:

```
baseline 15 에서   EXIT=0   통과
baseline 13 에서   EXIT=2   FAIL keeper_mli_missing: 14 > baseline 13
```

처음엔 `Obj.magic` 을 주입해 봤는데 안 깨져서 무의미한 게이트인가 했다. **이 ratchet 이 보는 건 `.mli` 누락 · `godsplit` 마커 · `lib/dune` 줄 수**라 범위 밖을 찌른 것이었다. 게이트가 통과했다고 안심하기 전에 그 게이트가 무엇을 보는지부터 읽어야 한다.

## 트레이드오프

조이면 `.mli` 없는 keeper 모듈을 추가하려는 PR 이 막힌다. 그게 ratchet 의 목적이므로 의도된 비용이지만, 비용이 없다고 말하지는 않겠다.

RFC-WAIVED: 생성된 baseline 파일 1 개. credential / operator control / keeper sandbox / hooks / workflow 문서 미접촉.

🤖 Generated with [Claude Code](https://claude.com/claude-code)