### PR TITLE
fix(ci): stop counting dune files as testable covered code

### DIFF
--- a/scripts/check_test_coverage.py
+++ b/scripts/check_test_coverage.py
@@ -61,6 +61,13 @@ def load_non_code_suffixes(path=NON_CODE_SUFFIXES_PATH):
 
 NON_CODE_SUFFIXES = load_non_code_suffixes()
 
+# Build configuration under covered paths. These have no suffix, so the
+# suffix policy in .ci/test-coverage-non-code-suffixes.txt cannot express
+# them, and they are exactly what is_covered_code_file's docstring excludes:
+# no unit test can exercise a dune stanza. Without this, a PR that adds a
+# compiler flag to four libraries' dune files is asked for tests.
+BUILD_CONFIG_NAMES = frozenset({"dune", "dune-project", "dune-workspace"})
+
 DEPENDENCY_LOCKFILE_NAMES = frozenset(
     {"bun.lock", "bun.lockb", "package-lock.json", "pnpm-lock.yaml", "yarn.lock"}
 )
@@ -222,12 +229,15 @@ def is_covered_code_file(path):
     """Return true for executable code files, filtering out non-code assets.
 
     Symmetric counterpart to is_test_file: that positively identifies test
-    files; this negatively filters non-executable assets (CSS/HTML/MD/images)
-    that no unit test can exercise, so they do not trigger the "added covered
-    lines with no test" rule. See #23083.
+    files; this negatively filters non-executable assets (CSS/HTML/MD/images,
+    and build configuration such as dune) that no unit test can exercise, so
+    they do not trigger the "added covered lines with no test" rule.
+    See #23083.
     """
-    suffix = PurePosixPath(path).suffix.lower()
-    return suffix not in NON_CODE_SUFFIXES
+    normalized = PurePosixPath(path.replace("\\", "/"))
+    if normalized.name in BUILD_CONFIG_NAMES:
+        return False
+    return normalized.suffix.lower() not in NON_CODE_SUFFIXES
 
 
 def get_changed_test_files():

--- a/scripts/test_check_test_coverage.py
+++ b/scripts/test_check_test_coverage.py
@@ -73,6 +73,12 @@ class CheckTestCoverageTest(unittest.TestCase):
         self.assertTrue(coverage.is_covered_code_file("dashboard/app.ts"))
         self.assertTrue(coverage.is_covered_code_file("config/runtime.toml"))
         self.assertTrue(coverage.is_covered_code_file("dashboard/package-lock.json"))
+        # Build configuration has no suffix, so the suffix policy cannot
+        # express it; no unit test can exercise a dune stanza.
+        self.assertFalse(coverage.is_covered_code_file("lib/board/dune"))
+        self.assertFalse(coverage.is_covered_code_file("dune-project"))
+        # A file merely named like one stays covered.
+        self.assertTrue(coverage.is_covered_code_file("lib/dune_helpers.ml"))
 
     def test_non_code_suffixes_come_from_repo_policy_file(self):
         self.assertEqual(


### PR DESCRIPTION
## 무엇이 문제였나

`is_covered_code_file` 은 **확장자**로 비실행 자산을 거른다:

```python
suffix = PurePosixPath(path).suffix.lower()
return suffix not in NON_CODE_SUFFIXES
```

`dune` 파일은 확장자가 없다. `PurePosixPath("lib/board/dune").suffix` 는 `""` 이고 `"" not in NON_CODE_SUFFIXES` 이므로 **실행 코드로 집계된다.**

그러면 게이트의 두 번째 규칙이 걸린다:

```
changed_code_files > 3 && added_code_lines > 0 && test_files == 0 -> fail
```

라이브러리 네 곳의 dune 에 컴파일러 플래그 한 줄씩 추가하는 PR 이 **"테스트를 추가하라"** 로 실패한다. dune stanza 를 실행할 수 있는 unit test 는 없다.

## 이 함수의 docstring 이 이미 기준을 적어놨다

> negatively filters non-executable assets (CSS/HTML/MD/images) **that no unit test can exercise**, so they do not trigger the "added covered lines with no test" rule

빌드 설정은 정확히 그 부류다. 다만 확장자가 없어서 `.ci/test-coverage-non-code-suffixes.txt` 로는 표현할 수 없다 — 그 로더는 `.` 로 시작하지 않는 항목을 `ValueError` 로 거부한다.

## 변경

basename 기반 면제를 추가했다. 선례가 이미 있다 — `DEPENDENCY_LOCKFILE_NAMES` 가 같은 방식으로 `bun.lock` / `package-lock.json` 을 다룬다.

```python
BUILD_CONFIG_NAMES = frozenset({"dune", "dune-project", "dune-workspace"})
```

`config/runtime.toml` 같은 설정/데이터 형식은 그대로 covered 로 남는다. 정책 파일의 주석이 그렇게 하라고 적고 있다 (*"Keep config/data formats covered unless their validation policy moves here"*).

## 검증

- `python3 scripts/test_check_test_coverage.py` — 13 케이스 통과
- 술어 직접 확인: `lib/board/dune` → False, `dune-project` → False, `lib/app.ml` → True, `config/runtime.toml` → True
- 이름만 닮은 파일은 그대로 covered: `lib/dune_helpers.ml` → True (테스트에 케이스 추가)

## 이해 상충 고지

이 변경은 **내가 연 PR 아홉 개를 통과시킨다** — `#27123`, `#27150`, `#27152`, `#27154`, `#27159`, `#27161`, `#27167`, `#27169` 등 죽은 코드를 지우고 그 라이브러리에 `-w +32` 를 켜는 PR 들이다.

그래서 판단 기준을 내 PR 이 아니라 게이트 자신의 문서에 두었다: dune 은 unit test 로 실행할 수 없고, 그게 이 함수가 거르겠다고 선언한 것이다. 이 변경이 없어도 그 PR 들은 "테스트를 추가하라" 를 만족시킬 방법이 없다 — 삭제된 코드에는 테스트할 대상이 없기 때문이다.

리뷰에서 다르게 보신다면, 대안은 dune 변경을 별도 PR 로 분리하는 것이다. 그건 삭제와 그 삭제가 가능하게 한 래칫을 갈라놓는다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
