### PR TITLE
fix(lib): delete twelve root-level values nothing calls

### DIFF
--- a/lib/keeper_voice_local.ml
+++ b/lib/keeper_voice_local.ml
@@ -6,8 +6,6 @@
 
     @since 2.95.0 *)
 
-let trim_opt = Env_config_core.trim_opt
-
 let resolved_base_path_opt () =
   match (Host_config.from_env ()).base_path with
   | Some path -> Some path

--- a/lib/run_eio.ml
+++ b/lib/run_eio.ml
@@ -17,8 +17,6 @@ type run_record = {
   updated_at: string;
 }
 
-let now_iso () = Masc_domain.now_iso ()
-
 let run_record_to_json (r : run_record) : Yojson.Safe.t =
   `Assoc [
     ("task_id", `String r.task_id);

--- a/lib/runtime_settings.ml
+++ b/lib/runtime_settings.ml
@@ -54,14 +54,6 @@ let deserialize_int json =
            "deserialize_int: expected JSON integer (`Int or whole-valued `Float), got %s"
            (Json_util.kind_name other))
 
-let deserialize_string json =
-  match json with
-  | `String s -> Ok s
-  | other ->
-      Error
-        (Printf.sprintf "deserialize_string: expected JSON string, got %s"
-           (Json_util.kind_name other))
-
 let deserialize_bool json =
   match json with
   | `Bool b -> Ok b

--- a/lib/sdk_tool_contract.ml
+++ b/lib/sdk_tool_contract.ml
@@ -13,8 +13,6 @@ type sdk_tool_binding = {
 
 let assoc_field name value = (name, value)
 
-let json_string value = `String value
-
 let string_prop = Tool_schema_dsl.string_prop
 let object_schema = Tool_schema_dsl.object_schema
 

--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -21,8 +21,6 @@ let error_kind_of_yojson = function
 let pp_error_kind fmt kind =
   Format.pp_print_string fmt (error_kind_to_string kind)
 
-let show_error_kind = error_kind_to_string
-
 (** Telemetry event types *)
 type event =
   | Agent_session_bound of { agent_id: string; capabilities: string list }

--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -44,9 +44,6 @@ type context = {
 let json_ok ~tool_name ~start_time (json : Yojson.Safe.t) : Tool_result.result =
   Tool_result.make_ok ~tool_name ~start_time ~data:json ()
 
-let text_ok ~tool_name ~start_time body : Tool_result.result =
-  Tool_result.ok ~tool_name ~start_time body
-
 let workflow_err_envelope ~tool_name ~start_time ~code msg : Tool_result.result =
   let data =
     Tool_args.error_assoc
@@ -60,19 +57,6 @@ let workflow_err_envelope ~tool_name ~start_time ~code msg : Tool_result.result 
     ~start_time
     ~data
     (Yojson.Safe.to_string data)
-
-let workflow_err_plain ~tool_name ~start_time msg : Tool_result.result =
-  Tool_result.make_err
-    ~tool_name
-    ~class_:Tool_result.Workflow_rejection
-    ~start_time
-    msg
-
-let result_to_response ~tool_name ~start_time = function
-  | Ok msg -> text_ok ~tool_name ~start_time msg
-  | Error e ->
-      workflow_err_plain ~tool_name ~start_time
-        (Masc_domain.masc_error_to_string e)
 
 let dedupe_keep_order values =
   let seen = Hashtbl.create (List.length values) in

--- a/lib/tool_local_runtime_core.ml
+++ b/lib/tool_local_runtime_core.ml
@@ -90,16 +90,6 @@ let find_flag_value tokens flag =
 
 let has_flag tokens flag = List.exists (String.equal flag) tokens
 
-let server_port_of_url url =
-  let trimmed = String.trim url in
-  match String.rindex_opt trimmed ':' with
-  | None -> None
-  | Some idx ->
-      let port =
-        String.sub trimmed (idx + 1) (String.length trimmed - idx - 1)
-      in
-      parse_int_opt port
-
 let process_to_yojson (process : llama_process) =
   `Assoc
     [

--- a/lib/tool_workspace.ml
+++ b/lib/tool_workspace.ml
@@ -551,14 +551,6 @@ let inspect_state ctx =
   { task_claimed; current_task_set }
 ;;
 
-let state_to_json st =
-  `Assoc
-    [ "task_claimed", `Bool st.task_claimed
-    ; "current_task_set", `Bool st.current_task_set
-    ; "session_active", `Bool false
-    ]
-;;
-
 (* ── State check (assertion-based verification) ────────────────── *)
 
 (** Issue #8636: SSOT for [masc_check] assertion vocabulary. Schema

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -95,13 +95,6 @@ let inc_relay_drop_marker_failure () =
   Otel_metric_store.inc_counter Otel_metric_store.metric_oas_sse_relay_drop_marker_failures ()
 ;;
 
-let set_sse_queue_depth ~session_id depth =
-  Otel_metric_store.set_gauge
-    Otel_metric_store.metric_sse_stream_queue_depth
-    ~labels:[ "session_id", session_id ]
-    (float_of_int depth)
-;;
-
 let set_sse_queue_snapshot ~avg_depth ~max_depth ~hot_sessions =
   Otel_metric_store.set_gauge Otel_metric_store.metric_sse_queue_depth_avg avg_depth;
   Otel_metric_store.set_gauge Otel_metric_store.metric_sse_queue_depth_max (float_of_int max_depth);

--- a/lib/workspace_assertions.ml
+++ b/lib/workspace_assertions.ml
@@ -66,14 +66,6 @@ let check_assertion st assertion =
       ]
 ;;
 
-let state_to_json st =
-  `Assoc
-    [ "task_claimed", `Bool st.task_claimed
-    ; "current_task_set", `Bool st.current_task_set
-    ; "session_active", `Bool false
-    ]
-;;
-
 let handle_check ~(inspect_state : context -> agent_state) ~tool_name ~start_time ctx args
   =
   let st = inspect_state ctx in


### PR DESCRIPTION
## 무엇이 문제였나

메인 `masc` 라이브러리의 최상위 `lib/*.ml` 에 아무도 부르지 않는 값 열두 개가 있었다 (표면 10 + 연쇄 2). 65 줄.

| 값 | 파일 |
|---|---|
| `state_to_json` | `tool_workspace.ml` |
| `state_to_json` | `workspace_assertions.ml` |
| `set_sse_queue_depth` | `transport_metrics.ml` |
| `result_to_response` → `text_ok`, `workflow_err_plain` | `tool_agent.ml` |
| `server_port_of_url` | `tool_local_runtime_core.ml` |
| `deserialize_string` | `runtime_settings.ml` |
| `show_error_kind` | `telemetry_eio.ml` |
| `json_string` | `sdk_tool_contract.ml` |
| `now_iso` | `run_eio.ml` |
| `trim_opt` | `keeper_voice_local.ml` |

## 셋이 이름 이상을 말한다

**`state_to_json` 이 두 파일에 같은 모양으로 있고 둘 다 죽었다.** `tool_workspace.ml` 과 `workspace_assertions.ml` 이 각각 `task_claimed` / `current_task_set` 를 JSON 으로 내보내는 함수를 들고 있는데, 어느 쪽도 호출자가 없다. 같은 상태를 두 곳에서 직렬화하려던 흔적이 양쪽 다 소비자를 잃은 채 남았다.

**`set_sse_queue_depth` 가 죽었다는 것은 `metric_sse_stream_queue_depth` 게이지에 생산자가 없다는 뜻이다.** 대시보드에서 그 값이 비어 보이는 이유가 "큐가 늘 비어서" 가 아니라 "아무도 쓰지 않아서" 다. `#27159` 의 `log_summary_state_error` (`ApprovalQueueFailures` 의 유일한 `auto_judge_summary_transition` 생산자) 와 같은 부류다.

**`result_to_response` 는 두 단계 연쇄를 만들었다** — 그것만 부르던 `text_ok` 가 죽고, 이어서 `workflow_err_plain` 이 죽었다. `tool_agent` 의 응답 포장 경로가 통째로 미사용이었다.

## 검증

- `dune build --root . @check` — EXIT=0
- 연쇄: `lib/dune` 에 `-w +32` 를 임시로 켜고 **이 배치의 열 파일로 한정해** 세 라운드에 수렴, 재확인 후 되돌렸다
- `scripts/check-doc-code-refs.sh` — EXIT=0

첫 시도에서 연쇄 루프의 필터가 `lib/*.ml` 전체를 잡아 다른 PR 소관 (`capability_registry`, `mcp_prompt_surface` — `#27173`) 과 의도적으로 남겨둔 `eval_harness` 까지 지웠다. 되돌리고 파일 목록을 이 배치로 한정해 다시 했다.

## 래칫

메인 `masc` 라이브러리는 아직 죽은 값이 남아 `-w +32` 를 켤 수 없다. `#27173` 과 이 PR 이 함께 들어가면 최상위 `lib/*.ml` 은 `eval_harness.ml` 세 건만 남는다. 그건 하네스 코드라 삭제 대신 별도 판단이 필요하다 (`.mli` 공개면 10 개, 생성자 없는 채로 남은 채점 기계).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
