### PR TITLE
fix(keeper): delete three more values nothing calls

### DIFF
--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -56,12 +56,6 @@ end
 
 module Completion_contract_result = Keeper_completion_contract_result_label
 
-let completion_contract_result_from_receipt receipt =
-  match json_string_opt_member "completion_contract_result" receipt with
-  | Some raw -> Completion_contract_result.of_string raw
-  | None -> None
-;;
-
 let terminal_reason_from_decision json =
   match json_member "terminal_reason" json with
   | `Assoc _ as terminal_reason -> Keeper_turn_terminal.of_json terminal_reason
@@ -380,32 +374,6 @@ let next_human_action_or_terminal ~needs_attention ~latest_next_action
   | Some _ as value -> value
   | None when needs_attention -> latest_next_action
   | None -> None
-
-let disposition_fields_json ~(config : Workspace.config) ~(meta : keeper_meta) :
-    Yojson.Safe.t =
-  let pending_approval_projection =
-    pending_approval_projection ~base_path:config.base_path
-      ~keeper_name:meta.name
-  in
-  let runtime_blocker_fields =
-    Keeper_status_bridge.runtime_blocker_fields_json config meta
-  in
-  let disposition, disposition_reason =
-    disposition_of_snapshot ~pending_approval_projection
-      ~runtime_blocker_fields
-  in
-  let latest_receipt = Keeper_execution_receipt.latest_json config meta.name in
-  let disposition, disposition_reason, _, _ =
-    effective_disposition_fields
-      ~approval_queue_available:(Option.is_none pending_approval_projection.error)
-      ~fallback_disposition:disposition
-      ~fallback_reason:disposition_reason latest_receipt
-  in
-  `Assoc
-    [
-      ("disposition", `String disposition);
-      ("disposition_reason", `String disposition_reason);
-    ]
 
 let decision_log_persistence_surface = "keeper_runtime_trust_decision_log"
 

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -102,20 +102,6 @@ let is_fiber_unresolved_blocker_class blocker_class =
   String.equal blocker_class (blocker_class_to_string Fiber_unresolved)
 ;;
 
-let runtime_blocker_surface_of_masc_internal_error = function
-  | Keeper_turn_driver.Accept_rejected _
-  | Keeper_turn_driver.Runtime_exhausted _
-  | Keeper_turn_driver.Capacity_backpressure _
-  | Keeper_turn_driver.Resumable_cli_session _
-  | Keeper_turn_driver.Internal_unhandled_exception _
-  | Keeper_turn_driver.Internal_bridge_exception _
-  | Keeper_turn_driver.Internal_contract_rejected _
-  | Keeper_turn_driver.Incomplete_tool_transcript _
-  | Keeper_turn_driver.Terminal_effect_failed _
-  | Keeper_turn_driver.Receipt_persistence_failed _
-  | Keeper_turn_driver.Gate_replay_repair_required _ ->
-    None
-
 let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
   : runtime_blocker_surface
   =


### PR DESCRIPTION
## 무엇이 문제였나

`lib/keeper/` 의 마지막 세 개 — 46 줄. 연쇄 없음.

| 값 | 파일 |
|---|---|
| `runtime_blocker_surface_of_masc_internal_error` | `keeper_status_bridge_blocker.ml` |
| `completion_contract_result_from_receipt` | `keeper_runtime_trust_snapshot.ml` |
| `disposition_fields_json` | 같은 파일 |

## 아무것도 분류하지 않는 분류기

`runtime_blocker_surface_of_masc_internal_error` 는 `Keeper_turn_driver` 의 내부 오류 11 개 생성자를 **전부 열거하고 전부 `None` 을 반환**한다:

```ocaml
let runtime_blocker_surface_of_masc_internal_error = function
  | Keeper_turn_driver.Accept_rejected _
  | Keeper_turn_driver.Runtime_exhausted _
  | … 11 개 …
  | Keeper_turn_driver.Gate_replay_repair_required _ ->
    None
```

내부 오류 중 blocker 표면으로 올라가는 것이 하나도 없다는 뜻이고, 그 결론을 아무도 읽지 않는다.

## 지우기 전에 확인한 것

CLAUDE.md 는 모든 생성자를 열거해 새 생성자가 결정을 강제하게 하는 것을 권장한다. 그래서 이 함수가 그 타입의 **유일한** 결정 지점인지 확인했다 — 아니었다.

`Capacity_backpressure` 를 매치하는 파일이 15 개 있고, 그 중 `keeper_oas_execution_error_phase.ml`, `keeper_internal_error.ml`, `keeper_runtime_failure_route.ml`, `keeper_terminal_reason.ml`, `keeper_error_classify.ml` 이 살아있는 exhaustive 분류기다. 새 생성자는 여전히 컴파일 타임에 잡힌다.

호출자 없는 열거는 결정을 강제하지 못한다 — 강제하는 것은 살아있는 매치들이다.

## 검증

- `dune build --root . @check` — EXIT=0
- 연쇄: `-w +32` 임시 적용, 한 라운드에 수렴
- `scripts/check-doc-code-refs.sh` — EXIT=0

## 남은 것

이 PR 로 `lib/keeper/` 의 죽은 값은 `keeper_sandbox_*` 두 건만 남는다. 그건 CLAUDE.md 의 RFC 게이트 대상이라 RFC 인용이 선행돼야 한다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
