### PR TITLE
fix(ci): test/dune 한 줄에 이름 둘일 때 둘 다 센다 (main red — 선언된 타겟이 누락으로 읽힘)

### DIFF
--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -25,7 +25,18 @@ referenced="$(mktemp)"
 trap 'rm -f "$declared" "$referenced"' EXIT
 
 # Test executables: every module listed in a (names ...) block or a (name X).
-grep -oE '^\s+test_[a-z_0-9]+' test/dune | tr -d ' ' > "$declared"
+# Field-wise, not one match per line: test/dune puts two names on a line in
+# two places, and `grep -o` with a `^` anchor only ever reports the first. That
+# is how this check came to report test_task_cache_invariant_13397 as missing
+# while (names ...) declared it. The trailing `)` closing a (names ...) list is
+# stripped so the last entry in each block still counts.
+awk '/^[[:space:]]+test_[a-z_0-9]+/ {
+       for (i = 1; i <= NF; i++) {
+         name = $i
+         sub(/\)+$/, "", name)
+         if (name ~ /^test_[a-z_0-9]+$/) print name
+       }
+     }' test/dune > "$declared"
 grep -oE '\(name test_[a-z_0-9]+\)' test/dune | sed 's/(name //;s/)//' >> "$declared"
 # Explicitly named aliases, e.g. (alias runtest-dashboard-http-behavior-contracts).
 grep -oE '\(alias runtest-[a-z_0-9-]+\)' test/dune \
@@ -66,9 +77,13 @@ echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, al
 # assert deleted text for months. Three were found this way in one day
 # (#26811 benchmark, the prompt suites, test_keeper_wake_turn_context).
 #
-# Frozen as a ratchet rather than a hard zero: 765 is where it stands, and a
+# Frozen as a ratchet rather than a hard zero: this is where it stands, and a
 # PR that adds a suite without wiring it makes that number grow.
-UNWIRED_BASELINE=765
+#
+# 765 -> 748 when the declaration parser above was fixed. The first check
+# exited before this one could run, so the baseline had gone stale by 17 while
+# suites were being wired.
+UNWIRED_BASELINE=748
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then


### PR DESCRIPTION
**main red 이고 `Meta Guards` 는 required 라, 이 게이트를 지나는 모든 PR 이 막힌다.**

## 증상

```
$ bash scripts/audit-ci-test-targets.sh     # 수정 없는 origin/main
[ci-test-targets] FAIL - ci.yml names targets test/dune does not declare
  - test_task_cache_invariant_13397
rc=2
```

## 그런데 test/dune 은 그걸 선언한다

`test/dune:916` 에서 시작하는 `(names ...)` 블록 안, **985행**:

```
  test_task_status_label_10421  test_task_cache_invariant_13397
```

**한 줄에 이름 둘.** 검사는 이렇게 읽었다:

```bash
grep -oE '^\s+test_[a-z_0-9]+' test/dune
```

`grep -o` 에 `^` 앵커를 걸면 **줄당 한 번만, 항상 첫 번째**를 보고한다. 두 번째 이름은 보이지 않았고, 선언된 타겟이 누락으로 읽혔다.

`test/test_task_cache_invariant_13397.ml` 도 존재하고 1139행(`(modules ...)`)에도 있다.

## 수정 — 필드 단위

awk 로 줄의 모든 필드를 본다. 다만 `(names ...)` 를 닫는 **뒤따르는 `)` 를 벗겨야** 한다. 마지막 항목 5개가 그 형태이기 때문이다:

```
test_board_metrics_labels)
test_board_moderation)
test_tool_args_envelope)
test_exec_command_gate_log_sink)
test_exact_output_catalog_precedence_fixture)
```

`)` 를 안 벗긴 첫 시도는 이 5개를 잃었다 — **false positive 1건을 5건으로 바꿀 뻔했다.** `comm` 으로 두 집합을 대조해 잡았다.

결과: declared 506 → 507, **엄격한 상위집합** (잃은 항목 0).

## 두 번째 검사가 처음으로 돌았다

첫 검사가 먼저 exit 해서 지금까지 실행된 적이 없다. 이제 돌아보니:

```
unwired suites 748 < baseline 765 — lower UNWIRED_BASELINE to hold the gain
```

그동안 스위트가 배선되는 사이 baseline 이 **17만큼 낡아 있었다.** 래칫이 요구하는 대로 748 로 내렸다.

## 검증

```
before: rc=2, 첫 검사 FAIL
after:  rc=0, "99 CI targets, all declared" + "748 unwired, at baseline"
```

결함 주입 (`ci.yml` 의 타겟 하나를 없는 이름으로 rename):
```
FAIL - ci.yml names targets test/dune does not declare
  - test_does_not_exist_at_all
```

커밋 `7171442f94`, base `76c8f2aaf1`.

## 같은 부류를 오늘 세 번 봤다

줄 단위 스캔이 필드/블록을 놓치는 버그다. 내 `check-env-snapshot-default-drift.py` 도 같은 이유로 자기가 존재하는 이유인 리더를 못 봤고(#27160), `~default:` 스캔도 앞줄을 끌어왔다. **줄이 아니라 구조를 봐야 한다.**
