### PR TITLE
fix(lib): drop five vestigial rec flags and four unused type declarations

### DIFF
--- a/lib/fs_compat/capability_head.ml
+++ b/lib/fs_compat/capability_head.ml
@@ -117,8 +117,6 @@ module Lease = struct
 
   module Held = Hashtbl.Make (Key)
 
-  type token = Key.t
-
   let mutex = Mutex.create ()
   let held = Held.create 32
 

--- a/lib/gate/slack_gateway_state.ml
+++ b/lib/gate/slack_gateway_state.ml
@@ -141,7 +141,7 @@ let ack_effect env =
   match env.envelope_id with Some id -> [ Send_ack { envelope_id = id } ] | None -> []
 ;;
 
-let rec step t ~now_mono input =
+let step t ~now_mono input =
   let log lvl msg = [ Log { level = lvl; message = msg } ] in
   match (t.state, input) with
   | (Disconnected | Reconnect_pending _), Connect_requested ->

--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -166,8 +166,6 @@ type rollup = {
 }
 [@@deriving yojson]
 
-type upsert_kind = [ `created | `updated ]
-
 let parse_goal_phase = function
   | Some s -> Goal_phase.parse s
   | None -> None

--- a/lib/keeper/keeper_agent_run_turn_helpers.ml
+++ b/lib/keeper/keeper_agent_run_turn_helpers.ml
@@ -37,7 +37,7 @@ let evict_oldest state =
     ; size = state.size - 1
     }
 
-let rec mark_task_link ~keeper ~task_id ~trace_id =
+let mark_task_link ~keeper ~task_id ~trace_id =
   let key = (keeper, task_id, trace_id) in
   let rec loop () =
     let state = Atomic.get link_task_cache_state in

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -432,7 +432,7 @@ let decision_child_scope scope key =
   then Compaction_evidence
   else scope
 
-let rec public_projection_of_decision decision =
+let public_projection_of_decision decision =
   let rec project scope path = function
     | `Assoc fields ->
         let allowlist = decision_allowlist scope in

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -131,7 +131,7 @@ let repos_in_playground host_root =
     with
     | Sys_error _ -> [])
 
-let rec skip_worktree_prefix = function
+let skip_worktree_prefix = function
   | ".worktrees" :: _branch :: rest -> rest
   | "./.worktrees" :: _branch :: rest -> rest
   | other -> other

--- a/lib/mcp_transport_protocol/mcp_transport_protocol.ml
+++ b/lib/mcp_transport_protocol/mcp_transport_protocol.ml
@@ -309,7 +309,7 @@ let protocol_version_2026_07_28 = "2026-07-28"
 let protocol_version_draft_2026_v1 = "DRAFT-2026-v1"
 
 let supported_protocol_versions =
-  let rec add acc version =
+  let add acc version =
     if List.mem version acc then acc else acc @ [ version ]
   in
   List.fold_left add []

--- a/lib/tool_misc_web_fetch.ml
+++ b/lib/tool_misc_web_fetch.ml
@@ -342,13 +342,6 @@ type fetch_response =
   ; body : string
   }
 
-type http_fetch =
-  timeout_sec:int ->
-  headers:(string * string) list ->
-  max_response_bytes:int ->
-  string ->
-  (fetch_response, fetch_failure) Result.t
-
 let resolve_redirect_url ~base_url target =
   Uri.resolve "" (Uri.of_string base_url) (Uri.of_string target) |> Uri.to_string
 

--- a/lib/types/ids.ml
+++ b/lib/types/ids.ml
@@ -245,7 +245,6 @@ end = struct
           (Printf.sprintf "Expected string for Keeper_id (received %s)"
              (Json_util.kind_name other))
   module Keeper_name = struct
-    type t = string
     let is_valid s =
       let len = String.length s in
       len > 0 && len <= 64 &&


### PR DESCRIPTION
## 무엇을 하는가

컴파일러가 짚은 두 부류를 정리한다. 코드 아홉 곳, 17 줄.

**불필요한 `rec` 5 곳** (`-w +39`, `unused-rec-flag`) — 재귀 호출을 잃었는데 `rec` 만 남은 함수:

| 함수 | 파일 |
|---|---|
| `step` | `gate/slack_gateway_state.ml` |
| `mark_task_link` | `keeper/keeper_agent_run_turn_helpers.ml` |
| `public_projection_of_decision` | `keeper/keeper_runtime_manifest.ml` |
| `skip_worktree_prefix` | `keeper/keeper_turn_sandbox_runtime.ml` |
| `add` | `mcp_transport_protocol/mcp_transport_protocol.ml` |

**미사용 타입 선언 4 개** (`-w +34`):

| 타입 | 파일 |
|---|---|
| `upsert_kind = [ \`created \| \`updated ]` | `goal/goal_store.ml` |
| `http_fetch` (함수 타입 별칭) | `tool_misc_web_fetch.ml` |
| `token = Key.t` | `fs_compat/capability_head.ml` |
| `t = string` (in `Keeper_name`) | `types/ids.ml` |

## 두 `rec` 는 지우기 전에 의도를 확인했다

이름이 반복을 암시하는 둘은 "재귀가 사고로 사라진 것" 일 수 있어 본문을 읽었다.

- `skip_worktree_prefix` 는 `".worktrees" :: _branch :: rest -> rest` 로 접두사를 **정확히 한 번** 벗긴다. worktree 접두사는 중첩되지 않으므로 단일 단계가 맞다.
- `step` 은 `(state, input) -> (state, effects)` FSM 단계다. 입력 하나가 전이 하나를 만들므로 재귀가 없는 것이 정상이다.

둘 다 `rec` 만 흔적으로 남은 것이다. `rec` 제거는 이름 해석에만 영향을 주고, 자기 참조가 없으므로 동작이 바뀌지 않는다.

## 미사용 타입 넷은 무엇이었나

`token = Key.t` 와 `t = string` 은 어느 시그니처도 참조하지 않는 문서용 별칭이다 — 의도를 적지만 강제하지 않는다. `upsert_kind` 와 `http_fetch` 는 소비자를 잃은 선언이다.

## 검증

- `dune build --root . @check` — EXIT=0
- `test_keeper_sandbox_containment` — 통과 (`skip_worktree_prefix` 가 속한 경로)
- `scripts/check-doc-code-refs.sh` — EXIT=0

## 래칫을 켜지 않은 이유

`-w +39` / `-w +34` 를 켜려면 dune 110 개를 건드려야 하고, 그건 별개 PR 이다. `#27123` 이 이미 `-w +37` 로 같은 자리를 수정 중이라 충돌한다. 이 PR 은 경고가 짚은 것만 치운다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
