### PR TITLE
fix(metrics): 리터럴로 나가던 유일한 카운터를 선언한다 (알림용인데 healthy 일 때 /metrics 에 없음)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -929,6 +929,13 @@ jobs:
             @test/runtest-test_tool_contract_truth \
             @test/runtest-test_voice_command_descriptor_parity
 
+      - name: Run metric zero-cell declaration suite
+        # A counter emitted as a bare string still compiles and still counts;
+        # what it loses is the 0-cell, and only a running store shows that.
+        run: |
+          opam exec -- dune build --root . \
+            @test/runtest-test_metric_zero_cell_declaration
+
       - name: Run keeper lane launch-order AST suite
         # Asserts on lib/keeper sources through Ast_grep, so @check cannot run
         # it. It sat outside every target list while one of its counts was

--- a/lib/otel_metric_store/otel_builtin_metric_names.ml
+++ b/lib/otel_metric_store/otel_builtin_metric_names.ml
@@ -140,3 +140,12 @@ let metric_telemetry_cache_rescans =
   Otel_metric_store_core.declare_counter "masc_telemetry_summary_cache_rescans_total"
 let metric_telemetry_scanned_bytes =
   Otel_metric_store_core.declare_counter "masc_telemetry_snapshot_scanned_bytes_total"
+
+(* The dashboard cache patcher drops a lifecycle event it cannot decode and
+   bumps this so `rate(...)` sees the encoding regression. It was emitted with
+   a bare string at both of its call sites, which is the one thing
+   [declare_counter] exists to prevent: an unfired counter that is never
+   registered is absent from /metrics rather than 0, so an alert written
+   against it cannot be validated until the failure it watches for happens. *)
+let metric_keeper_lifecycle_malformed =
+  Otel_metric_store_core.declare_counter "masc_keeper_lifecycle_malformed_total"

--- a/lib/otel_metric_store/otel_builtin_metric_names.mli
+++ b/lib/otel_metric_store/otel_builtin_metric_names.mli
@@ -133,3 +133,9 @@ val metric_telemetry_cache_rescans : string
 (** #20677: bytes folded by incremental telemetry readers.  Labels:
     [store]. *)
 val metric_telemetry_scanned_bytes : string
+
+(** A keeper lifecycle event reached the dashboard cache patcher without a
+    decodable [event]/[keeper_name] pair, so the cache invalidation it carried
+    was dropped. Declared rather than emitted bare so the 0-cell exports while
+    the fleet is healthy. *)
+val metric_keeper_lifecycle_malformed : string

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1272,7 +1272,7 @@ let start_keeper_loops_owned
                         ~event
                     | None ->
                       Otel_metric_store.inc_counter
-                        "masc_keeper_lifecycle_malformed_total"
+                        Otel_metric_store.metric_keeper_lifecycle_malformed
                         ())
                  | None, _ | Some _, None ->
                    (* P3 cleanup: previously malformed lifecycle events
@@ -1283,7 +1283,9 @@ let start_keeper_loops_owned
                        lets `rate(...)` alerts catch the regression
                        even though the dashboard cache continues to
                        degrade gracefully (just stale, not broken). *)
-                   Otel_metric_store.inc_counter "masc_keeper_lifecycle_malformed_total" ())
+                   Otel_metric_store.inc_counter
+                     Otel_metric_store.metric_keeper_lifecycle_malformed
+                     ())
               | _ -> Log.Dashboard.debug "ignored non-lifecycle event")
            events;
          if events <> []

--- a/test/dune
+++ b/test/dune
@@ -1649,6 +1649,7 @@
 
 (include stanzas/test_anti_rationalization_empty_reject.inc)
 (include stanzas/test_trailing_slash_rules.inc)
+(include stanzas/test_metric_zero_cell_declaration.inc)
 (include stanzas/test_verification_authority_tools.inc)
 (include stanzas/test_keeper_registry_admission_no_suspend.inc)
 (include stanzas/test_keeper_compaction_persist_gate.inc)

--- a/test/stanzas/test_metric_zero_cell_declaration.inc
+++ b/test/stanzas/test_metric_zero_cell_declaration.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_metric_zero_cell_declaration)
+ (modules test_metric_zero_cell_declaration)
+ (libraries alcotest otel_metric_store))

--- a/test/test_metric_zero_cell_declaration.ml
+++ b/test/test_metric_zero_cell_declaration.ml
@@ -1,0 +1,74 @@
+(** A declared counter exports its 0-cell before it ever fires.
+
+    [Otel_metric_store_core.declare_counter] exists to remove the
+    absence-vs-zero ambiguity: a counter that has not fired IS 0, so the
+    unlabeled cell is registered at module-init time. A name passed straight to
+    [inc_counter] skips that, and the series does not exist until the first
+    increment.
+
+    masc_keeper_lifecycle_malformed_total was the one metric in lib/ emitted
+    that way, and the comment at its call site says it exists so
+    [rate(...)] alerts catch a lifecycle encoding regression -- an alert that
+    cannot be written, let alone validated, while the series is missing.
+
+    [get_metric_value] is the discriminator the assertion needs:
+    [None] for absent, [Some 0.] for registered-and-unfired.
+    [metric_value_or_zero] cannot tell those apart, which is the ambiguity
+    itself. *)
+
+open Alcotest
+
+let value name = Otel_metric_store_core.get_metric_value name ()
+
+let check_zero_cell label name =
+  match value name with
+  | Some observed ->
+    check (float 0.0) (label ^ ": exports 0 before firing") 0.0 observed
+  | None ->
+    failf
+      "%s: %S is absent from the store, so declare_counter never ran for it"
+      label
+      name
+;;
+
+let test_lifecycle_malformed_is_declared () =
+  check_zero_cell
+    "keeper lifecycle malformed"
+    Otel_builtin_metric_names.metric_keeper_lifecycle_malformed
+;;
+
+(* Control: a counter that was already declared. If this one were absent too,
+   the assertion above would be measuring test setup rather than the fix. *)
+let test_control_counter_is_declared () =
+  check_zero_cell "telemetry coverage gap" Otel_builtin_metric_names.metric_telemetry_coverage_gap
+;;
+
+(* The discriminator has to actually discriminate: a name nothing declares must
+   read as absent, not as zero. Without this, the two cases above would pass
+   against any implementation that returned Some 0.0 for everything. *)
+let test_undeclared_name_reads_absent () =
+  match value "masc_counter_that_no_module_declares_total" with
+  | None -> ()
+  | Some observed ->
+    failf
+      "an undeclared name read as %f; get_metric_value cannot distinguish \
+       absent from zero, so the other cases here prove nothing"
+      observed
+;;
+
+let () =
+  run
+    "metric zero-cell declaration"
+    [ ( "declared counters"
+      , [ test_case
+            "keeper lifecycle malformed"
+            `Quick
+            test_lifecycle_malformed_is_declared
+        ; test_case "control counter" `Quick test_control_counter_is_declared
+        ; test_case
+            "undeclared name reads absent"
+            `Quick
+            test_undeclared_name_reads_absent
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 문제

`lib/` 와 `bin/` 전체에서 metric 이름이 **선언 상수가 아니라 리터럴로** `inc_counter` 에 들어가는 곳은 하나뿐이다. 그리고 그 하나가 같은 함수 안에서 **두 번** 나온다.

```ocaml
(* server_bootstrap_loops.ml:1275, :1286 *)
Otel_metric_store.inc_counter "masc_keeper_lifecycle_malformed_total" ()
```

이 이름은 어떤 `otel_*_metric_names` 모듈에도 없다.

## 그게 무엇을 잃는지는 소스가 적어뒀다

`otel_metric_store_core.ml:62-65`:

> **Zero-fill declaration**: registers the unlabeled 0-cell at module-init time ... Counters only: a counter that has not fired IS 0, so exporting the 0-cell **removes the absence-vs-zero ambiguity**

`declare_counter` 는 `register_counter` 를 부르고 이름을 돌려준다. 선언하지 않은 카운터는 **처음 증가하기 전까지 `/metrics` 에 없다.**

그런데 이 카운터의 존재 이유가 호출 지점 주석에 적혀 있다:

> Bumping a Otel_metric_store counter lets **`rate(...)` alerts** catch the regression

**건강한 상태에서 존재하지 않는 시계열에는 알림을 걸 수 없고, 감시하려는 장애가 일어나기 전에는 검증도 못 한다.** `declare_counter` 가 정확히 그걸 없애려고 있는데, 유일하게 그 규율 밖에 있는 카운터가 하필 알림용이다.

## 변경

다른 keeper 카운터들 옆(`Otel_builtin_metric_names`)에 선언하고 두 호출 지점이 상수를 부른다.

**첫 시도는 컴파일이 안 됐다** — `Otel_builtin_metric_names.` 를 직접 썼는데 `lib/server` 는 그 leaf 라이브러리가 아니라 `masc` 파사드(`lib/otel_metric_store.ml`, 9개 name 모듈을 `include`)를 통해 이 상수들에 닿는다. `Otel_metric_store.` 로 고쳤고 **dune 변경 0**이다.

(`telemetry_unified` / `dated_jsonl` 이 `Otel_builtin_metric_names.` 를 직접 쓰는 건 그쪽이 leaf 라이브러리를 직접 의존해서고, 층이 달라 둘 다 맞다.)

## 검증

```
lib/ + bin/ 리터럴 metric 이름 emission: 1 -> 0
dune build @check                        clean
determinism / telemetry-coverage / enum-string / silent-failure   rc=0
```

동작 변경은 하나다: 이 카운터가 이제 fleet 이 건강할 때도 0 으로 export 된다. 그게 목적이다.

커밋 `c3c9b9aae9`, base `76c8f2aaf1`.

## 주의

`audit-ci-test-targets.sh` 는 이 브랜치에서도 rc=2 인데 **main 이 red** 이기 때문이다 (#27177 이 고친다). 이 변경과 무관하다.
