### PR TITLE
fix(ci): UNWIRED_BASELINE 을 747 로 — suite 를 배선한 PR 둘이 baseline 을 안 내렸다 (main red)

### DIFF
--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -83,7 +83,12 @@ echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, al
 # 765 -> 748 when the declaration parser above was fixed. The first check
 # exited before this one could run, so the baseline had gone stale by 17 while
 # suites were being wired.
-UNWIRED_BASELINE=748
+#
+# 748 -> 747 after #27139 and #27134 each wired one more suite (verification
+# authority tools, memory journal) without lowering the baseline. A PR that
+# wires a suite must lower this number in the same PR, or this check goes red
+# for everyone.
+UNWIRED_BASELINE=747
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then


### PR DESCRIPTION
## 문제

`Meta Guards` → `Check CI test targets` 가 main 과 모든 오픈 PR에서 exit 2:

```
[ci-test-targets] unwired suites 747 < baseline 748 — lower UNWIRED_BASELINE in scripts/audit-ci-test-targets.sh to hold the gain
```

## 원인

- #27177 이 선언 파서를 고치며 baseline 을 765 → 748 로 맞췄다.
- 이후 #27139 (verification authority tools) 와 #27134 (memory journal) 가 suite 를 하나씩 ci.yml 에 배선하면서 baseline 을 내리지 않았다 → unwired 747 < baseline 748.

## 수정

`UNWIRED_BASELINE` 748 → 747 한 줄 + 상수 위 주석에 "suite 를 배선하는 PR은 같은 PR에서 이 숫자를 내려야 한다" 는 규칙을 명시.

## 검증 (로컬, origin/main @ 6d77dce847)

```
$ bash scripts/audit-ci-test-targets.sh
[ci-test-targets] OK - 102 CI targets, all declared in test/dune
[ci-test-targets] OK - 747 suites unwired, at baseline   (EXIT 0)
```

Related: #27139, #27134, #27177