### PR TITLE
refactor(activity-graph): remove the semantic_weight event-kind heuristic

### DIFF
--- a/lib/activity_graph/activity_graph.ml
+++ b/lib/activity_graph/activity_graph.ml
@@ -641,7 +641,6 @@ let graph_json config ?(kinds = []) ?(limit = 500)
             label = node.label;
             status = node.status;
             weight = node.weight;
-            semantic_weight = node.semantic_weight;
             last_event_at = node.last_event_at;
             meta = node.meta;
           }

--- a/lib/activity_graph/activity_graph_reducer.ml
+++ b/lib/activity_graph/activity_graph_reducer.ml
@@ -8,7 +8,6 @@ type node_acc = {
   mutable label : string;
   mutable status : node_status;
   mutable weight : int;
-  mutable semantic_weight : float;
   mutable last_event_at : string;
   mutable meta : Yojson.Safe.t;
 }
@@ -37,32 +36,12 @@ let is_generic_status = function
   | Todo | Claimed | In_progress | Done | Cancelled
   | Posted | Discussed | Workspace -> false
 
-(* Semantic weight multiplier by event kind.
-   Completion events score high; routine lifecycle events score low. *)
-let semantic_multiplier kind =
-  match tool_execution_event_kind_of_string kind with
-  | Some (External_tool_called | Keeper_in_turn_tool_executed) -> 0.3
-  | None ->
-    (match kind with
-  | "task.done" | "task.approved" -> 5.0
-  | "task.created" | "task.claimed" -> 3.0
-  | "board.posted" | "board.voted" -> 2.0
-  | "task.started" | "task.released" | "task.cancelled" -> 1.5
-  | "message.broadcast" | "message.mentioned" -> 1.0
-  | "board.commented" -> 1.0
-  | "agent.session_bound" -> 0.5
-  | "keeper.compaction" -> 0.5
-     | "keeper.turn_completed" -> 0.4
-     | _ -> 1.0)
-
 let ensure_node (nodes : (string, node_acc) Hashtbl.t) ~(id : string)
     ~(kind : string) ~(label : string)
-    ~(status : node_status) ~(ts_iso : string) ~(meta : Yojson.Safe.t)
-    ~(sw_delta : float) =
+    ~(status : node_status) ~(ts_iso : string) ~(meta : Yojson.Safe.t) =
   match Hashtbl.find_opt nodes id with
   | Some node ->
       node.weight <- node.weight + 1;
-      node.semantic_weight <- node.semantic_weight +. sw_delta;
       node.last_event_at <- ts_iso;
       if node.label = id || node.label = "" then node.label <- label;
       if status <> Unset
@@ -78,13 +57,12 @@ let ensure_node (nodes : (string, node_acc) Hashtbl.t) ~(id : string)
           label;
           status;
           weight = 1;
-          semantic_weight = sw_delta;
           last_event_at = ts_iso;
           meta;
         }
 
 let ensure_entity_node (nodes : (string, node_acc) Hashtbl.t) value
-    ~fallback_status ~ts_iso ~meta ~sw_delta =
+    ~fallback_status ~ts_iso ~meta =
   let node_id = entity_node_id value in
   let label =
     match payload_string "label" meta with
@@ -92,7 +70,7 @@ let ensure_entity_node (nodes : (string, node_acc) Hashtbl.t) value
     | None -> value.id
   in
   ensure_node nodes ~id:node_id ~kind:value.kind ~label ~status:fallback_status
-    ~ts_iso ~meta ~sw_delta;
+    ~ts_iso ~meta;
   node_id
 
 let ensure_edge (edges : (string, edge_acc) Hashtbl.t) ~source ~target ~kind
@@ -118,16 +96,15 @@ let ensure_edge (edges : (string, edge_acc) Hashtbl.t) ~source ~target ~kind
         }
 
 let reduce_event ~nodes ~edges (value : event) =
-  let sw = semantic_multiplier value.kind in
   let workspace_node_id = "workspace:" ^ value.workspace_id in
   ensure_node nodes ~id:workspace_node_id ~kind:"workspace" ~label:value.workspace_id
-    ~status:Workspace ~ts_iso:value.ts_iso ~meta:default_meta ~sw_delta:sw;
+    ~status:Workspace ~ts_iso:value.ts_iso ~meta:default_meta;
   let actor_id =
     match value.actor with
     | Some actor ->
         let id =
           ensure_entity_node nodes actor ~fallback_status:Active
-            ~ts_iso:value.ts_iso ~meta:value.payload ~sw_delta:sw
+            ~ts_iso:value.ts_iso ~meta:value.payload
         in
         ensure_edge edges ~source:id ~target:workspace_node_id ~kind:"belongs_to"
           ~active:true ~ts_iso:value.ts_iso ~meta:default_meta;
@@ -139,7 +116,7 @@ let reduce_event ~nodes ~edges (value : event) =
     | Some subject ->
         let id =
           ensure_entity_node nodes subject ~fallback_status:Observed
-            ~ts_iso:value.ts_iso ~meta:value.payload ~sw_delta:sw
+            ~ts_iso:value.ts_iso ~meta:value.payload
         in
         ensure_edge edges ~source:id ~target:workspace_node_id ~kind:"belongs_to"
           ~active:true ~ts_iso:value.ts_iso ~meta:default_meta;
@@ -221,7 +198,7 @@ let reduce_event ~nodes ~edges (value : event) =
               (ensure_entity_node nodes
                  { kind = "agent"; id = name }
                  ~fallback_status:Active ~ts_iso:value.ts_iso
-                 ~meta:value.payload ~sw_delta:sw)
+                 ~meta:value.payload)
         | None -> actor_id
       in
       (match (completer_id, subject_id) with

--- a/lib/activity_graph/activity_graph_reducer.mli
+++ b/lib/activity_graph/activity_graph_reducer.mli
@@ -7,8 +7,7 @@
     Hashtbl-backed accumulators on every refresh.
 
     Internal: [entity_node_id], [payload_string], [is_generic_status],
-    [semantic_multiplier], [ensure_node], [ensure_entity_node],
-    [ensure_edge].  All consumed only inside {!reduce_event}.  Future
+    [ensure_node], [ensure_entity_node], [ensure_edge].  All consumed only inside {!reduce_event}.  Future
     "expose lower-level reducers" PR can reopen explicitly. *)
 
 (** {1 Accumulator types} *)
@@ -19,7 +18,6 @@ type node_acc = {
   mutable label : string;
   mutable status : Activity_graph_types.node_status;
   mutable weight : int;
-  mutable semantic_weight : float;
   mutable last_event_at : string;
   mutable meta : Yojson.Safe.t;
 }
@@ -62,10 +60,4 @@ val reduce_event :
     + If [value.subject = Some subject], same with fallback status
       [Observed].
     + Apply event-kind-specific edges between actor / subject /
-      workspace (e.g. [task.assigned] -> actor->subject [assigned] edge).
-
-    Semantic weight delta applied to nodes:
-    {!Activity_graph_types}-tagged kinds map to fixed multipliers
-    (completion = 5.0, lifecycle = 3.0, routine = 1.0, default 1.0).
-    Pinned at the contract seam — operators see [semantic_weight]
-    in dashboards as the "importance" axis. *)
+      workspace (e.g. [task.assigned] -> actor->subject [assigned] edge). *)

--- a/lib/activity_graph/activity_graph_types.ml
+++ b/lib/activity_graph/activity_graph_types.ml
@@ -83,7 +83,6 @@ type graph_node = {
   label : string;
   status : node_status;
   weight : int;
-  semantic_weight : float;
   last_event_at : string;
   meta : Yojson.Safe.t;
 }
@@ -324,7 +323,6 @@ let graph_node_to_yojson (value : graph_node) =
       ("label", `String value.label);
       ("status", `String (node_status_to_string value.status));
       ("weight", `Int value.weight);
-      ("semantic_weight", `Float value.semantic_weight);
       ("last_event_at", `String value.last_event_at);
       ("meta", value.meta);
     ]

--- a/lib/activity_graph/activity_graph_types.mli
+++ b/lib/activity_graph/activity_graph_types.mli
@@ -70,7 +70,6 @@ type graph_node = {
   label : string;
   status : node_status;
   weight : int;
-  semantic_weight : float;
   last_event_at : string;
   meta : Yojson.Safe.t;
 }


### PR DESCRIPTION
## 무엇을 지웠나

`Activity_graph_reducer.semantic_multiplier` 와 그것이 채우던 `semantic_weight` 필드 전체.

```ocaml
(* Semantic weight multiplier by event kind.
   Completion events score high; routine lifecycle events score low. *)
let semantic_multiplier kind =
  match tool_execution_event_kind_of_string kind with
  | Some (External_tool_called | Keeper_in_turn_tool_executed) -> 0.3
  | None ->
    (match kind with
     | "task.done" | "task.approved" -> 5.0
     | "task.created" | "task.claimed" -> 3.0
     | "board.posted" | "board.voted" -> 2.0
     | "task.started" | "task.released" | "task.cancelled" -> 1.5
     | "message.broadcast" | "message.mentioned" -> 1.0
     | "board.commented" -> 1.0
     | "agent.session_bound" -> 0.5
     | "keeper.compaction" -> 0.5
     | "keeper.turn_completed" -> 0.4
     | _ -> 1.0)
```

## 왜

**1. 문자열 분류기 + 근거 없는 매직 상수.** 이벤트 종류를 문자열로 매치해 8개의 상수(5.0 / 3.0 / 2.0 / 1.5 / 1.0 / 0.5 / 0.4 / 0.3)를 매긴다. 이 비율의 출처는 코드에도 주석에도 없다. `task.done` 이 왜 `board.posted` 의 2.5배인지 답할 근거가 없다.

**2. `| _ -> 1.0` 이 미지 이벤트를 정상값으로 승격.** 처음 보는 이벤트 종류가 `message.broadcast` / `board.commented` 와 **같은 무게**를 받는다. CLAUDE.md "AI 코드 생성 안티패턴 #2 — Unknown → Permissive Default" 그대로다. 이벤트 종류가 늘어도 컴파일러가 알려주지 않는다.

**3. 아무도 읽지 않는다.** 이게 결정적이다.

`semantic_weight` 는 노드마다 누적되고 JSON 으로 직렬화된다. 그 다음이 없다.

| 소비자 후보 | 참조 |
|---|---|
| lib/ 의 분기·정렬·절단 | 0 (`activity_graph.ml:644` 의 레코드 생성이 유일한 참조, 노드 정렬 키는 `id`) |
| test/ | 0 |
| dashboard/ (TypeScript) | 0 |
| repo 전체 비-OCaml (.ts / .json / .yaml / .md) | 0 |

`rg 'semantic_weight|semanticWeight'` 를 `_build` 와 `.ml`/`.mli` 제외 전체에 돌려 0건. 대시보드는 `activity_graph_changed` SSE 알림만 받고 노드 객체를 파싱하지 않는다.

**4. `.mli` 가 없는 계약을 주장하고 있었다.**

```
Pinned at the contract seam — operators see [semantic_weight]
in dashboards as the "importance" axis.
```

대시보드에 그런 축은 없다. 이 문장이 남아 있는 한 다음 사람은 이 휴리스틱을 계약으로 알고 보존한다 — 죽은 개념이 컨텍스트를 재생산하는 자리라서 문장까지 같이 지웠다.

미지 이벤트가 조용히 1.0 을 받는 매직 상수 합계를 HTTP / MCP 표면에 "importance" 로 내보내는 것은, 안 내보내는 것보다 나쁘다. 읽는 쪽(운영자든 에이전트든)이 노이즈 위에서 판단하게 된다.

## 파급력

`sw_delta` 배선은 `activity_graph_reducer.ml` 안 9곳으로 닫혀 있었다. `ensure_node` / `ensure_entity_node` 의 인자와 `reduce_event` 의 `let sw = ...` 를 함께 제거했다.

`tool_execution_event_kind_of_string` 은 `semantic_multiplier` 밖에서도 쓰이므로(`reducer.ml:142`) 남긴다.

JSON 응답에서 `semantic_weight` 키가 사라진다. 이 키를 고정하는 테스트·스키마·타입 정의는 위 표대로 존재하지 않는다.

## 검증

- `dune build @check` 통과. 필드를 지운 뒤에도 타입 오류가 없다는 것 자체가 아무 소비자도 없었다는 증거다.
- `test_activity_graph.exe` 20건 전부 통과.
- 순감 44 삭제 / 9 추가.

# ci:skip-test-coverage

순수 삭제 PR 이라 테스트할 새 코드 경로가 없다. 커버리지 게이트는 5개 파일 변경 + 테스트 파일 0 으로 트립하는데, 이 변경이 만드는 것은 코드가 아니라 부재다. 부재를 고정하는 테스트(`semantic_weight` 키가 없음을 확인)는 묘비이므로 넣지 않는다. 기존 `test_activity_graph.exe` 20건이 그대로 통과하는 것으로 회귀 없음을 확인했다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
