### PR TITLE
feat(verification): 판정자에게 생산자의 도구를 준다 — #27139 의 손수 만든 도구를 대체 (RFC-0361 D1)

### DIFF
--- a/lib/completion_authority_agent.ml
+++ b/lib/completion_authority_agent.ml
@@ -505,25 +505,40 @@ let process_task_once
                 this verdict has no judging runtime to name. *)
            ~evaluator_runtime:None)
     | Ok prepared ->
-      (* The lookup surface is bound to the producer under review, so the same
-         judge gets a different root on the next task. [assignee] is the worker
-         the evidence snapshot was materialized against — [prepare_review]
+      (* The lookup surface borrows the producer's own keeper meta, so the same
+         judge reaches a different tree on the next task. [assignee] is the
+         worker the evidence snapshot was materialized against — [prepare_review]
          rejects the request when it disagrees with [request.worker], so the
-         two cannot name different trees. *)
-      let lookup_tools =
-        Verification_authority_tools.create
-          ~base_path:runtime.config.base_path
-          ~producer:assignee
+         two cannot name different trees.
+
+         A producer with no readable meta leaves the judge on the snapshot
+         alone. The prompt says so in that case rather than advertising tools
+         whose every call would fail, and the reason is logged: a review that
+         could not reach the tree is a different event from one that chose not
+         to look. *)
+      let lookup =
+        match
+          Verification_authority_tools.create
+            ~config:runtime.config
+            ~producer:assignee
+        with
+        | Ok lookup_tools ->
+          Task.Anti_rationalization.Lookup_tools
+            { schemas = Verification_authority_tools.schemas lookup_tools
+            ; dispatch = Verification_authority_tools.dispatch lookup_tools
+            }
+        | Error reason ->
+          Log.Task.warn
+            "[verification-lookup] surface unavailable producer=%s: %s"
+            assignee
+            reason;
+          Task.Anti_rationalization.No_lookup_surface
       in
       let result =
         Task.Anti_rationalization.review
           ~base_path:runtime.config.base_path
           ~sw:(Some runtime.sw)
-          ~lookup:
-            (Task.Anti_rationalization.Lookup_tools
-               { schemas = Verification_authority_tools.schemas lookup_tools
-               ; dispatch = Verification_authority_tools.dispatch lookup_tools
-               })
+          ~lookup
           ?completion_contract:prepared.completion_contract
           ~required_evidence:prepared.required_artifacts
           ~verify_gate_evidence:[]

--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -154,8 +154,9 @@ let lookup_section = function
     sprintf
       "\n\
        <live_lookup>\n\
-       You can read the producer's tree directly with these read-only tools: %s. \
-       They are confined to that producer's root and cannot change anything.\n\n\
+       You hold the producer's own tools, pointed at the producer's tree: %s. \
+       They run inside that producer's sandbox — the same jail the producer \
+       worked in — and they are not restricted to reading.\n\n\
        The snapshot is what was true when the work was submitted. A lookup is what \
        is true now. Both are evidence, and disagreement between them is also \
        evidence: a file the snapshot shows and the tree no longer contains was \
@@ -165,6 +166,14 @@ let lookup_section = function
        and reading the file cannot tell you which of the two you are looking at. \
        Ask what differs from the last commit before treating a file's contents as \
        the completed work.\n\n\
+       A claim about behaviour is not settled by reading the code that makes it. \
+       If the submitter says a build succeeds or a test passes, run it. You are \
+       judging the work, not the description of the work.\n\n\
+       Because these tools can change the tree, one rule binds you: do not repair \
+       what you are judging. If a build fails, that is a finding, not a task. \
+       Fixing it and then approving produces work no one verified — yours. Every \
+       call you make is recorded against this review, so a verdict reached after \
+       you changed the tree is visible as exactly that.\n\n\
        A note claiming a path, a commit, or a command result is still not proof by \
        itself. The difference is that you can now check the claims that name \
        something in the producer's tree, so approving without checking an \

--- a/lib/verification_authority_tools.ml
+++ b/lib/verification_authority_tools.ml
@@ -6,188 +6,98 @@
    fails to compile. *)
 type tool =
   | Read_file
-  | Git_status
+  | Search_files
+  | Execute
 
 let tool_name = function
-  | Read_file -> "verification_read_file"
-  | Git_status -> "verification_git_status"
+  | Read_file -> "tool_read_file"
+  | Search_files -> "tool_search_files"
+  | Execute -> "tool_execute"
 ;;
 
-let all_tools = [ Read_file; Git_status ]
+let all_tools = [ Read_file; Search_files; Execute ]
 
 let tool_of_name name =
   List.find_opt (fun tool -> String.equal (tool_name tool) name) all_tools
 ;;
 
-type t = { ownership_root : string }
+type t =
+  { ownership_root : string
+  ; config : Workspace.config
+  ; producer_meta : Keeper_meta_contract.keeper_meta
+  }
 
-let create ~base_path ~producer =
-  let project_root = Workspace_verification_store.project_root_of_base_path base_path in
-  let ownership_root =
-    Keeper_sandbox_config.host_root_abs_of_agent ~base_path:project_root
-      ~agent_name:producer
-    |> Env_config_core.strip_trailing_slashes
-  in
-  { ownership_root }
+let create ~config ~producer =
+  match Keeper_meta_store.read_meta config producer with
+  | Error message ->
+    Error (Printf.sprintf "producer %s meta unreadable: %s" producer message)
+  | Ok None ->
+    Error
+      (Printf.sprintf
+         "producer %s has no keeper meta; there is no tree to inspect"
+         producer)
+  | Ok (Some producer_meta) ->
+    let project_root =
+      Workspace_verification_store.project_root_of_base_path config.base_path
+    in
+    let ownership_root =
+      Keeper_sandbox_config.host_root_abs_of_agent
+        ~base_path:project_root
+        ~agent_name:producer
+      |> Env_config_core.strip_trailing_slashes
+    in
+    Ok { ownership_root; config; producer_meta }
 ;;
 
 let ownership_root t = t.ownership_root
-
-(* A producer-relative path becomes an absolute one by folding its segments
-   onto the ownership root. Empty segments are dropped so ["a//b"] and ["a/b"]
-   name the same file and [""] names the root itself. [.] and [..] are left
-   alone here on purpose: [Fs_compat]'s ownership chain already refuses them,
-   and a second refusal in this module would be a second place to keep the
-   containment rule correct. *)
-let absolute_of_relative t relative =
-  String.split_on_char '/' relative
-  |> List.filter (fun segment -> not (String.equal segment ""))
-  |> List.fold_left Filename.concat t.ownership_root
-;;
 
 (* ================================================================ *)
 (* Schemas                                                          *)
 (* ================================================================ *)
 
-let path_property description =
-  ( "path"
-  , `Assoc [ "type", `String "string"; "description", `String description ] )
+(* The keeper catalog is the source. Restating a description here would let a
+   judge and a producer read different documentation for the same tool, and the
+   one that drifts is always the copy. *)
+let schema_of_tool tool : Types_core.tool_schema option =
+  List.find_opt
+    (fun (schema : Types_core.tool_schema) ->
+       String.equal schema.name (tool_name tool))
+    Tool_shard.all_keeper_tool_schemas
 ;;
 
-let schema_of_tool tool : Types_core.tool_schema =
-  match tool with
-  | Git_status ->
-    { name = tool_name Git_status
-    ; description =
-        "Report which files in the producer's checkout differ from the last \
-         commit. Answers whether the work under review reached a commit or only \
-         exists in a working tree that the next task can discard. The evidence \
-         snapshot cannot answer this: it records file contents at submission, \
-         not whether those contents are durable."
-    ; input_schema =
-        `Assoc
-          [ "type", `String "object"
-          ; ( "properties"
-            , `Assoc
-                [ path_property
-                    "Producer-relative path of the checkout to inspect, for \
-                     example \"masc\". Use \"\" for the producer root itself."
-                ] )
-          ; "required", `List [ `String "path" ]
-          ]
-    }
-  | Read_file ->
-    { name = tool_name Read_file
-    ; description =
-        "Read a file from the producer's tree. The path is relative to the \
-         producer's root, the same way an artifact: evidence reference is. Reads \
-         the same byte prefix the evidence snapshot reads, so a file that was \
-         truncated in the snapshot is truncated here too."
-    ; input_schema =
-        `Assoc
-          [ "type", `String "object"
-          ; ( "properties"
-            , `Assoc
-                [ path_property
-                    "Producer-relative file path, for example \
-                     \"lib/keeper/keeper_turn.ml\"."
-                ] )
-          ; "required", `List [ `String "path" ]
-          ]
-    }
-;;
-
-let schemas _t = List.map schema_of_tool all_tools
-
-(* ================================================================ *)
-(* Implementations                                                  *)
-(* ================================================================ *)
-
-let read_file t ~relative =
-  let target = absolute_of_relative t relative in
-  match Workspace_verification_store.read_regular_file_prefix ~ownership_root:t.ownership_root target with
-  | Error failure ->
-    Error
-      (Printf.sprintf "%s: %s" relative
-         (Workspace_verification_store.evidence_read_failure_code failure))
-  | Ok (content, bytes, truncated) ->
-    Ok
-      (Printf.sprintf "%s (%d bytes%s)\n%s" relative bytes
-         (if truncated then ", truncated" else "")
-         content)
-;;
-
-(* The argv is a constant. The model supplies a directory to run in and nothing
-   else, so a write subcommand is not something this tool rejects — it is
-   something the tool cannot express. An argv whitelist would put the same
-   guarantee behind a string comparison that has to stay correct as Git grows
-   subcommands; this way the type of the input is a path. *)
-let git_status_argv = [ "--no-optional-locks"; "status"; "--porcelain=v1" ]
-
-(* [Repo_git.run_git] drops blank lines, so an empty result and a clean tree
-   are the same list. Saying "clean" is a claim about the tree; the caller has
-   to be able to tell that from a Git invocation that returned nothing because
-   it failed, and [run_git] already separates those into [Error]. *)
-let git_status t ~relative =
-  let target = absolute_of_relative t relative in
-  match Fs_compat.inspect_owned_directory_chain ~ownership_root:t.ownership_root target with
-  | Error rejection ->
-    Error
-      (Printf.sprintf "%s: %s"
-         (if String.equal relative "" then "." else relative)
-         (Fs_compat.owned_directory_chain_rejection_to_string rejection))
-  | Ok Fs_compat.Owned_directory_missing ->
-    Error
-      (Printf.sprintf "%s: no such directory in the producer's tree"
-         (if String.equal relative "" then "." else relative))
-  | Ok (Fs_compat.Owned_directory _) ->
-    (match Repo_git.run_git ~cwd:target git_status_argv with
-     | Error message -> Error (Printf.sprintf "%s: %s" relative message)
-     | Ok [] ->
-       Ok
-         (Printf.sprintf
-            "%s: working tree clean — every tracked change is committed"
-            (if String.equal relative "" then "." else relative))
-     | Ok lines ->
-       Ok
-         (Printf.sprintf
-            "%s: %d path(s) differ from the last commit\n%s"
-            (if String.equal relative "" then "." else relative)
-            (List.length lines)
-            (String.concat "\n" lines)))
-;;
+let schemas _t = List.filter_map schema_of_tool all_tools
 
 (* ================================================================ *)
 (* Dispatch                                                         *)
 (* ================================================================ *)
 
-(* How one lookup ended. A closed sum rather than a string because the log
-   level is derived from it: a rejected lookup reported at the same level as a
-   resolved one is invisible in exactly the case an operator needs to see. *)
+(* How one call ended. A closed sum rather than a string because the log level
+   is derived from it: a rejected call reported at the same level as a resolved
+   one is invisible in exactly the case an operator needs to see. *)
 type lookup_outcome =
   | Resolved
   | Rejected
   | Unknown_tool
-  | Invalid_argument
+  | Missing_schema
 
 let lookup_outcome_label = function
   | Resolved -> "resolved"
   | Rejected -> "rejected"
   | Unknown_tool -> "unknown_tool"
-  | Invalid_argument -> "invalid_argument"
+  | Missing_schema -> "missing_schema"
 ;;
 
 let lookup_outcome_level = function
   | Resolved -> Log.Info
-  | Rejected | Unknown_tool | Invalid_argument -> Log.Warn
+  | Rejected | Unknown_tool | Missing_schema -> Log.Warn
 ;;
 
-(* What the judge looked at, and whether it got an answer. An operator reading
-   the logs otherwise cannot tell a review that inspected the tree from one that
+(* What the judge ran, and whether it got an answer. An operator reading the
+   logs otherwise cannot tell a review that inspected the tree from one that
    only read the submitted snapshot, and that difference is the whole point of
-   this surface. Content is never logged — only the path asked for, which is
-   already the model's own argument. *)
-let log_lookup t ~name ~argument ~outcome =
+   this surface. Output is never logged — only the tool name and the model's own
+   arguments, which the run registry records anyway. *)
+let log_call t ~name ~argument ~outcome =
   Log.Task.emit
     (lookup_outcome_level outcome)
     (Printf.sprintf
@@ -198,30 +108,77 @@ let log_lookup t ~name ~argument ~outcome =
        (lookup_outcome_label outcome))
 ;;
 
+(* [Keeper_tool_execution.t] carries the runtime's own disposition. A failed
+   call has to reach the model as [Error]: handing back [raw_output] on both
+   paths would let a build that never ran read like one that produced no
+   findings. *)
+let result_of_execution (execution : Keeper_tool_execution.t) =
+  match execution.disposition with
+  | Tool_result.Completed () -> Ok execution.raw_output
+  | Tool_result.Failed _ | Tool_result.Deferred () -> Error execution.raw_output
+;;
+
+(* The producer's meta binds the jail. [turn_sandbox_factory] is a keeper-turn
+   construct and the judge has no turn of its own, so a producer on a Docker
+   profile resolves no sandbox and the runtime returns its own error — the judge
+   is told the tree is unreachable rather than silently inspecting the host. *)
+let run t tool ~args =
+  match tool with
+  | Read_file ->
+    Keeper_tool_filesystem_runtime.handle_read_file_with_outcome
+      ~turn_sandbox_factory:None
+      ~config:t.config
+      ~meta:t.producer_meta
+      ~args
+    |> result_of_execution
+  | Search_files ->
+    Keeper_tool_command_runtime.handle_tool_search_files_with_outcome
+      ~turn_sandbox_factory:None
+      ~config:t.config
+      ~meta:t.producer_meta
+      ~args
+    |> result_of_execution
+  | Execute ->
+    Keeper_tool_command_runtime.handle_tool_execute_with_outcome
+      ~turn_sandbox_factory:None
+      ~config:t.config
+      ~meta:t.producer_meta
+      ~args
+      ()
+    |> result_of_execution
+;;
+
 let dispatch t ~name ~args =
   match tool_of_name name with
   | None ->
     let detail =
-      Printf.sprintf "unknown tool %s; this review offers %s" name
+      Printf.sprintf
+        "unknown tool %s; this review offers %s"
+        name
         (String.concat ", " (List.map tool_name all_tools))
     in
-    log_lookup t ~name ~argument:"" ~outcome:Unknown_tool;
+    log_call t ~name ~argument:"" ~outcome:Unknown_tool;
     Error detail
   | Some tool ->
-    (* The tool addresses the producer's tree by a [path] argument. The match
-       on [tool] stays exhaustive, so a new tool with a different input fails
-       to compile here rather than silently reading a missing key. *)
-    (match Json_util.require_string args "path" with
-     | Error detail ->
-       log_lookup t ~name ~argument:"" ~outcome:Invalid_argument;
-       Error detail
-     | Ok relative ->
-       let result =
-         match tool with
-         | Read_file -> read_file t ~relative
-         | Git_status -> git_status t ~relative
+    (* A tool the evaluator was never offered cannot be answered here either:
+       [schemas] filters on the keeper catalog, so a name that resolves to a
+       constructor but has no schema was not in the surface the model saw. *)
+    (match schema_of_tool tool with
+     | None ->
+       let detail =
+         Printf.sprintf
+           "tool %s is not in the keeper schema catalog for this build"
+           name
        in
-       log_lookup t ~name ~argument:relative
+       log_call t ~name ~argument:"" ~outcome:Missing_schema;
+       Error detail
+     | Some _ ->
+       let argument = Yojson.Safe.to_string args in
+       let result = run t tool ~args in
+       log_call
+         t
+         ~name
+         ~argument
          ~outcome:(match result with Ok _ -> Resolved | Error _ -> Rejected);
        result)
 ;;

--- a/lib/verification_authority_tools.mli
+++ b/lib/verification_authority_tools.mli
@@ -1,4 +1,5 @@
-(** Read-only lookup surface for the completion authority (RFC-0361 D1).
+(** The producer's own tool surface, lent to the completion authority
+    (RFC-0361 D1).
 
     The judge decides whether submitted work is real. Until now its only tool
     was [report_review_verdict], so the submitter's evidence snapshot was the
@@ -7,51 +8,82 @@
     case is task-136 — the judge approved an uncommitted working tree and had
     no way to observe that the work was not committed anywhere.
 
-    This tool lets the judge look at the producer's tree itself. It is read-only
-    by construction. A judge that can write would repair what it
-    should reject, and nothing verifies that repair.
+    {1 The same instruments, not a smaller set}
+
+    The tools here are the keeper tools the producer itself ran — [tool_read_file],
+    [tool_search_files], [tool_execute] — bound to the producer's meta rather
+    than to a judge of its own. Nothing is re-implemented.
+
+    A curated read-only surface was the earlier design and it was wrong twice
+    over. A hand-written tool answers only the question its author anticipated,
+    so every new question costs a release; and the questions that decide a
+    verdict are not a fixed set. "Do the tests pass" cannot be answered by
+    reading files at all — it needs the build to run. A judge that can only read
+    the claim that tests pass is judging the claim, not the work.
+
+    The judge therefore holds the producer's execution authority, writes
+    included. That is a deliberate trade: it can repair what it should reject,
+    and nothing verifies that repair. What makes the trade payable is that every
+    call it makes is recorded — {!Verification_run_registry} keeps the tool
+    observations on the run, so a verdict reached after the judge changed the
+    tree is visible as such instead of being indistinguishable from one reached
+    by reading.
 
     {1 Containment}
 
-    Every path is resolved under
-    [Keeper_sandbox_config.host_root_abs_of_agent ~agent_name:producer], the
-    same ownership root {!Workspace_verification_store} uses when it
-    materializes an [artifact:] reference. The root is computed per producer,
-    so it differs from review to review. No isolation logic is introduced here
-    — a second containment implementation would be a second truth about which
-    bytes a judge may read.
+    Paths resolve through the producer's own sandbox jail, which is what the
+    keeper runtimes already enforce for the producer. Borrowing the producer's
+    meta borrows its jail: the judge reaches exactly the tree the work happened
+    in, and nothing outside it.
 
-    File reads go through {!Workspace_verification_store.read_regular_file_prefix},
-    which is also the snapshot reader. A live read and its snapshot counterpart
-    therefore share one byte cap, one UTF-8 policy, and one failure vocabulary,
-    and cannot report differently about the same file.
+    This is also why the surface is not rooted at
+    [Keeper_sandbox_config.host_root_abs_of_agent]. That root is the bundle
+    directory; the checkout the producer commits in lives below it under
+    [repos/]. A tool rooted there would answer "not a repository" for every
+    producer while looking like a working check. The sandbox jail resolves to
+    where the producer actually worked.
 
-    {1 What is deliberately absent}
+    {1 The Gate posture is the producer's}
 
-    There is no tool that reports whether the producer's work is committed.
-    That question needs the repository the producer commits in, and this root
-    is not it: [Playground_paths.bundle_root] is the bundle directory, and
-    checkouts live one level below it under [repos/]. Running git at the root
-    would answer "not a repository" for every producer while looking like a
-    working check. Which checkout is authoritative is [Repo_manager]'s
-    keeper-to-repository mapping to answer, not this module's to guess. *)
+    [tool_execute] submits through the external-effect Gate, and the Gate reads
+    [meta.always_allow] — the producer's switch, since the producer's meta is
+    what this surface carries. A producer that runs effects without approval
+    gives its judge the same, and a producer whose effects queue for approval
+    gives its judge a queued effect too.
+
+    That second case is a dead end, and deliberately so rather than by
+    oversight. A queued effect resolves by waking the keeper that submitted it;
+    the judge is one review with no wake path, so it receives the deferral as a
+    failed call and has to reach a verdict without that answer. Granting the
+    judge a bypass would let it run effects on a tree whose owner is not
+    allowed to, which is a larger hole than the one it closes.
+
+    {1 Not a keeper}
+
+    Borrowing a producer's meta does not enrol the judge as a keeper: no
+    registry entry, no sandbox of its own, no lifecycle, no persona, and none of
+    the task, board, memory, or voice tools. It holds three instruments pointed
+    at someone else's tree for the length of one review. *)
 
 type t
 
-val create : base_path:string -> producer:string -> t
-(** Bind a lookup surface to one producer's ownership root. [base_path] is the
-    workspace BasePath the review was started with; the root is derived from it
-    exactly as the evidence snapshot derives it. *)
+val create :
+  config:Workspace.config -> producer:string -> (t, string) result
+(** Bind a surface to one producer by loading that producer's keeper meta.
+    [Error] when the producer has no readable meta — a judge with no tree to
+    look at is told so rather than handed a surface that fails on every call. *)
 
 val ownership_root : t -> string
-(** The absolute directory every tool in this surface is confined to. Exposed
-    so the prompt can name the boundary the judge is looking through. *)
+(** The producer's bundle root, for naming the boundary in the prompt. Tool
+    calls resolve through the sandbox jail rather than this string. *)
 
 val schemas : t -> Types_core.tool_schema list
-(** The tool schemas to hand the evaluator, in a stable order. *)
+(** The tool schemas to hand the evaluator, in a stable order. These are the
+    keeper schemas verbatim: a judge and a producer read the same description of
+    the same tool. *)
 
 val dispatch : t -> name:string -> args:Yojson.Safe.t -> (string, string) result
-(** Execute one lookup call. [Error] carries a message meant for the model:
-    an unknown tool name, a malformed argument, or a containment rejection.
-    Every outcome is one of those two constructors — a call never resolves to
-    a plausible-looking empty result. *)
+(** Run one call against the producer's tree. [Error] carries a message meant
+    for the model: an unknown tool name, or the runtime's own failure text.
+    Every outcome is one of those two constructors — a call never resolves to a
+    plausible-looking empty result. *)

--- a/test/test_verification_authority_tools.ml
+++ b/test/test_verification_authority_tools.ml
@@ -1,14 +1,20 @@
-(* RFC-0361 D1: the completion authority's read-only lookup surface.
+(* RFC-0361 D1: the completion authority runs the producer's own tools.
 
    The properties under test are the ones that decide whether a judge can be
-   trusted with the surface at all: it cannot read outside the producer's root,
-   it cannot be handed a name it silently ignores, and it reports failure
-   instead of a clean-looking empty answer. *)
+   trusted with the surface: it offers exactly the keeper schemas rather than a
+   restatement of them, every advertised name reaches an implementation, a
+   producer with no meta yields no surface instead of one that fails on every
+   call, and a failed run reaches the model as a failure rather than as output
+   that could be mistaken for a clean result. *)
 
+module Keeper_meta_store = Masc.Keeper_meta_store
+module Tool_shard = Masc.Tool_shard
 module VAT = Masc.Verification_authority_tools
 module AR = Masc.Task.Anti_rationalization
 
-let temp_base_path () =
+let producer = "test-producer"
+
+let temp_dir () =
   let path =
     Filename.concat
       (Filename.get_temp_dir_name ())
@@ -18,82 +24,116 @@ let temp_base_path () =
   path
 ;;
 
-let rec mkdir_p path =
-  if not (Sys.file_exists path)
-  then (
-    mkdir_p (Filename.dirname path);
-    Unix.mkdir path 0o700)
+let rec rm_rf path =
+  match Unix.lstat path with
+  | { st_kind = Unix.S_DIR; _ } ->
+    Sys.readdir path
+    |> Array.iter (fun entry -> rm_rf (Filename.concat path entry));
+    (try Unix.rmdir path with Unix.Unix_error _ -> ())
+  | _ -> (try Unix.unlink path with Unix.Unix_error _ -> ())
+  | exception Unix.Unix_error _ -> ()
 ;;
 
-let write_file path contents =
-  mkdir_p (Filename.dirname path);
-  let channel = open_out_bin path in
-  Fun.protect
-    ~finally:(fun () -> close_out channel)
-    (fun () -> output_string channel contents)
+(* [agent_name] is deliberately omitted: [meta_of_json_fixture] fills in the
+   canonical [Keeper_identity.keeper_agent_name], so this fixture cannot drift
+   from the identity rule the meta parser enforces.
+
+   [always_allow] is the producer's own Gate posture, and the judge borrows it
+   with the meta — [Keeper_tool_execute_runtime] reads
+   [meta.always_allow] and nothing else. It is set here because a deferred
+   effect is not an answer: the judge is one review with no wake path, so a
+   producer that defers gives it a dead end rather than a result. That is the
+   real behaviour for a non-always-allow producer and it is stated in the
+   surface docs; these cases exercise the branch where the effect runs. *)
+let ensure_producer config name =
+  match
+    Result.bind
+      (Masc_test_deps.meta_of_json_fixture
+         (`Assoc [ "name", `String name; "always_allow", `Bool true ]))
+      (Keeper_meta_store.write_meta config)
+  with
+  | Ok _ -> ()
+  | Error err -> Alcotest.failf "write keeper meta failed: %s" err
 ;;
 
-(* A surface bound to a producer whose root exists and holds [files]. *)
-let with_surface files f =
-  let base_path = temp_base_path () in
-  let surface = VAT.create ~base_path ~producer:"test-producer" in
-  let root = VAT.ownership_root surface in
-  mkdir_p root;
-  List.iter
-    (fun (relative, contents) -> write_file (Filename.concat root relative) contents)
-    files;
-  f surface root
+(* A workspace holding one producer keeper, and the surface bound to it. *)
+let with_surface f =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = temp_dir () in
+  Eio.Switch.run
+  @@ fun sw ->
+  Eio.Switch.on_release sw (fun () -> rm_rf dir);
+  let config = Workspace_core.default_config dir in
+  ignore (Workspace_core.init config ~agent_name:(Some "test"));
+  (* [tool_execute] submits through the external-effect Gate, which refuses to
+     run at all until its durable store exists. Without this the execute cases
+     would fail on missing infrastructure and prove nothing about the surface. *)
+  (match Masc.Keeper_approval_queue.install_persistence ~base_path:dir with
+   | Ok _ -> ()
+   | Error err ->
+     Alcotest.failf
+       "gate store install failed: %s"
+       (Masc.Keeper_approval_queue.install_error_to_string err));
+  ensure_producer config producer;
+  match VAT.create ~config ~producer with
+  | Error reason -> Alcotest.failf "surface creation failed: %s" reason
+  | Ok surface -> f config surface
 ;;
 
-let dispatch_result surface ~name ~args = VAT.dispatch surface ~name ~args
-
-let test_read_file_returns_content () =
-  with_surface [ "lib/answer.ml", "let answer = 42\n" ] (fun surface _root ->
-    match
-      dispatch_result surface ~name:"verification_read_file"
-        ~args:(`Assoc [ "path", `String "lib/answer.ml" ])
-    with
-    | Error detail -> Alcotest.failf "expected a read, got error: %s" detail
-    | Ok output ->
-      Alcotest.(check bool)
-        "content is present"
-        true
-        (Astring.String.is_infix ~affix:"let answer = 42" output))
-;;
-
-let test_read_file_outside_root_is_rejected () =
-  with_surface [ "inside.txt", "in\n" ] (fun surface root ->
-    (* A sibling of the producer root, reachable only by escaping it. *)
-    write_file (Filename.concat (Filename.dirname root) "outside.txt") "out\n";
-    match
-      dispatch_result surface ~name:"verification_read_file"
-        ~args:(`Assoc [ "path", `String "../outside.txt" ])
-    with
-    | Ok output -> Alcotest.failf "escape should not read; got %s" output
-    | Error _ -> ())
+(* The judge and the producer must read one description of one tool. A schema
+   restated here would drift from the catalog, and the copy is always the one
+   that drifts. *)
+let test_schemas_are_the_keeper_schemas () =
+  with_surface (fun _config surface ->
+    let offered = VAT.schemas surface in
+    let names =
+      List.map (fun (schema : Masc_domain.tool_schema) -> schema.name) offered
+    in
+    Alcotest.(check (list string))
+      "the surface is read, search, execute"
+      [ "tool_read_file"; "tool_search_files"; "tool_execute" ]
+      names;
+    List.iter
+      (fun (schema : Masc_domain.tool_schema) ->
+         match
+           List.find_opt
+             (fun (catalog : Masc_domain.tool_schema) ->
+                String.equal catalog.name schema.name)
+             Tool_shard.all_keeper_tool_schemas
+         with
+         | None ->
+           Alcotest.failf "%s is not in the keeper catalog" schema.name
+         | Some catalog ->
+           Alcotest.(check string)
+             (schema.name ^ " description is the catalog's")
+             catalog.description
+             schema.description)
+      offered)
 ;;
 
 (* A judge that calls a name this surface does not offer must be told so. A
    dropped call would read to the model as a tool that returned nothing. *)
 let test_unknown_tool_name_is_an_error () =
-  with_surface [] (fun surface _root ->
-    match dispatch_result surface ~name:"verification_write_file" ~args:(`Assoc []) with
+  with_surface (fun _config surface ->
+    match VAT.dispatch surface ~name:"tool_write_file" ~args:(`Assoc []) with
     | Ok output -> Alcotest.failf "unknown tool should not succeed; got %s" output
     | Error detail ->
       Alcotest.(check bool)
         "names the offered tools"
         true
-        (Astring.String.is_infix ~affix:"verification_read_file" detail))
+        (Astring.String.is_infix ~affix:"tool_execute" detail))
 ;;
 
 (* Every advertised schema must reach an implementation. Advertising a name
    dispatch does not know would put a tool in the model's list that always
-   fails. *)
+   fails with "unknown tool". *)
 let test_every_schema_name_dispatches () =
-  with_surface [] (fun surface _root ->
+  with_surface (fun _config surface ->
     List.iter
       (fun (schema : Masc_domain.tool_schema) ->
-         match dispatch_result surface ~name:schema.name ~args:(`Assoc []) with
+         match VAT.dispatch surface ~name:schema.name ~args:(`Assoc []) with
          | Ok _ -> ()
          | Error detail ->
            Alcotest.(check bool)
@@ -103,23 +143,125 @@ let test_every_schema_name_dispatches () =
       (VAT.schemas surface))
 ;;
 
-(* RFC-0361 D2. The prompt states what the evaluator can see, and the two
+(* Where the judge's process would run is the safety property this layer owns.
+   The keeper runtime resolves it and reports the resolution back, so the
+   assertion is on that resolution rather than on process output: whether the
+   effect then executes or defers is the Gate's decision, and standing the Gate
+   and its Auto Judge up belongs to an integration test, not here.
+
+   The judge borrows the producer's meta, so it borrows the producer's jail. A
+   [cwd] of "." must land in the producer's playground — not the host, not
+   another keeper's tree, and not the workspace root. *)
+let test_execute_resolves_inside_the_producer_playground () =
+  with_surface (fun _config surface ->
+    let root = VAT.ownership_root surface in
+    let report =
+      match
+        VAT.dispatch
+          surface
+          ~name:"tool_execute"
+          ~args:
+            (`Assoc
+               [ "argv", `List [ `String "echo"; `String "durable-marker" ]
+               ; "cwd", `String "."
+               ])
+      with
+      | Ok output | Error output -> output
+    in
+    Alcotest.(check bool)
+      "the resolved working directory is the producer playground"
+      true
+      (Astring.String.is_infix ~affix:root report);
+    Alcotest.(check bool)
+      "the resolution names the playground scope"
+      true
+      (Astring.String.is_infix ~affix:"playground_root" report))
+;;
+
+(* An escape must not resolve. A judge that can point [cwd] outside the
+   producer's jail reaches trees no one authorized it to touch, and with write
+   capability that is not a read of the wrong file but a change to it. *)
+let test_execute_cannot_escape_the_producer_playground () =
+  with_surface (fun _config surface ->
+    match
+      VAT.dispatch
+        surface
+        ~name:"tool_execute"
+        ~args:
+          (`Assoc
+             [ "argv", `List [ `String "echo"; `String "escaped" ]
+             ; "cwd", `String "../../.."
+             ])
+    with
+    | Ok output ->
+      Alcotest.failf "an escaping cwd must not resolve; got %s" output
+    | Error detail ->
+      Alcotest.(check bool)
+        "the rejection does not report a resolved playground scope"
+        false
+        (Astring.String.is_infix ~affix:"\"scope\":\"playground_root\"" detail))
+;;
+
+(* A run that failed must not read like a run that produced nothing. Handing
+   back [raw_output] on both paths would let a build that never started look
+   like one with no findings — the exact shape that made task-136 approvable. *)
+let test_a_failed_run_is_an_error_not_empty_output () =
+  with_surface (fun _config surface ->
+    match
+      VAT.dispatch
+        surface
+        ~name:"tool_execute"
+        ~args:
+          (`Assoc
+             [ "argv", `List [ `String "false" ]
+             ; "cwd", `String "."
+             ])
+    with
+    | Ok output ->
+      Alcotest.failf "a non-zero exit must not resolve as success; got %s" output
+    | Error _ -> ())
+;;
+
+(* A producer with no keeper meta has no tree to point at. Handing back a
+   surface anyway would advertise three tools whose every call fails, which
+   reads to the model as a broken tree rather than as an absent one. *)
+let test_unknown_producer_yields_no_surface () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = temp_dir () in
+  Eio.Switch.run
+  @@ fun sw ->
+  Eio.Switch.on_release sw (fun () -> rm_rf dir);
+  let config = Workspace_core.default_config dir in
+  ignore (Workspace_core.init config ~agent_name:(Some "test"));
+  match VAT.create ~config ~producer:"no-such-producer" with
+  | Ok _ -> Alcotest.fail "a producer with no meta must not yield a surface"
+  | Error reason ->
+    Alcotest.(check bool)
+      "the reason names the producer"
+      true
+      (Astring.String.is_infix ~affix:"no-such-producer" reason)
+;;
+
+(* RFC-0361 D2. The prompt states what the evaluator can do, and the two
    surfaces are different claims. Rendering the toolless text for a
-   tool-carrying review is the exact gap D1 exists to close. *)
+   tool-carrying review is the exact gap D1 exists to close, and the tool text
+   must not repeat the read-only promise this surface no longer keeps. *)
 let test_prompt_states_the_available_surface () =
-  with_surface [] (fun surface _root ->
+  with_surface (fun _config surface ->
     let request : AR.review_request =
-      { agent_name = "test-producer"
+      { agent_name = producer
       ; task_title = "t"
       ; task_description = "d"
       ; completion_notes = "n"
-      ; task_id = "task-1"
+      ; task_id = "task-001"
       ; evidence_refs = []
       }
     in
     let render lookup =
       match AR.build_prompt ~lookup request with
-      | Ok prompt -> prompt
+      | Ok text -> text
       | Error detail -> Alcotest.failf "prompt render failed: %s" detail
     in
     let without = render AR.No_lookup_surface in
@@ -135,147 +277,50 @@ let test_prompt_states_the_available_surface () =
     Alcotest.(check bool)
       "toolless prompt does not advertise a tool"
       false
-      (Astring.String.is_infix ~affix:"verification_read_file" without);
+      (Astring.String.is_infix ~affix:"tool_execute" without);
     Alcotest.(check bool)
       "tool prompt names the tools"
       true
-      (Astring.String.is_infix ~affix:"verification_read_file" with_tools);
+      (Astring.String.is_infix ~affix:"tool_execute" with_tools);
     Alcotest.(check bool)
       "tool prompt does not deny having tools"
       false
       (Astring.String.is_infix
          ~affix:"You have no tool that opens anything else"
-         with_tools))
-;;
-
-let git_in dir args =
-  let quoted = List.map Filename.quote args |> String.concat " " in
-  let command =
-    Printf.sprintf
-      "cd %s && git %s >/dev/null 2>&1"
-      (Filename.quote dir)
-      quoted
-  in
-  match Sys.command command with
-  | 0 -> ()
-  | code -> Alcotest.failf "git %s failed with %d" quoted code
-;;
-
-(* A checkout with one committed file, so a later edit is the only thing that
-   can differ from the commit. *)
-let init_repo dir =
-  mkdir_p dir;
-  git_in dir [ "init"; "--quiet" ];
-  git_in dir [ "config"; "user.email"; "test@example.invalid" ];
-  git_in dir [ "config"; "user.name"; "test" ];
-  write_file (Filename.concat dir "committed.ml") "let committed = true\n";
-  git_in dir [ "add"; "committed.ml" ];
-  git_in dir [ "commit"; "--quiet"; "-m"; "initial" ]
-;;
-
-let git_status_of surface ~path =
-  dispatch_result surface ~name:"verification_git_status"
-    ~args:(`Assoc [ "path", `String path ])
-;;
-
-(* The task-136 shape: the work is present in the tree and reads back exactly
-   as submitted, but nothing committed it, so the next task's cleanup discards
-   it. Reading the file cannot distinguish this from finished work. *)
-let test_uncommitted_work_is_named () =
-  with_surface [] (fun surface root ->
-    let repo = Filename.concat root "checkout" in
-    init_repo repo;
-    write_file (Filename.concat repo "aria.ml") "let aria_label = \"close\"\n";
-    match git_status_of surface ~path:"checkout" with
-    | Error detail -> Alcotest.failf "expected a status, got error: %s" detail
-    | Ok output ->
-      Alcotest.(check bool)
-        "the uncommitted file is named"
-        true
-        (Astring.String.is_infix ~affix:"aria.ml" output);
-      Alcotest.(check bool)
-        "the answer does not claim the tree is clean"
-        false
-        (Astring.String.is_infix ~affix:"working tree clean" output))
-;;
-
-let test_committed_work_reports_clean () =
-  with_surface [] (fun surface root ->
-    let repo = Filename.concat root "checkout" in
-    init_repo repo;
-    match git_status_of surface ~path:"checkout" with
-    | Error detail -> Alcotest.failf "expected a status, got error: %s" detail
-    | Ok output ->
-      Alcotest.(check bool)
-        "a committed tree reports clean"
-        true
-        (Astring.String.is_infix ~affix:"working tree clean" output))
-;;
-
-let test_git_status_outside_root_is_rejected () =
-  with_surface [] (fun surface root ->
-    let outside = Filename.concat (Filename.dirname root) "outside-repo" in
-    init_repo outside;
-    match git_status_of surface ~path:"../outside-repo" with
-    | Ok output -> Alcotest.failf "escape should not report status; got %s" output
-    | Error detail ->
-      Alcotest.(check bool)
-        "the rejection names the boundary"
-        true
-        (Astring.String.is_infix ~affix:"outside" (String.lowercase_ascii detail)))
-;;
-
-let test_git_status_on_a_missing_directory_is_an_error () =
-  with_surface [] (fun surface _root ->
-    match git_status_of surface ~path:"no-such-checkout" with
-    | Ok output ->
-      Alcotest.failf "a missing directory must not read as clean; got %s" output
-    | Error detail ->
-      Alcotest.(check bool)
-        "the error says the directory is absent rather than clean"
-        false
-        (Astring.String.is_infix ~affix:"clean" detail))
-;;
-
-let test_git_status_on_a_non_repository_is_an_error () =
-  with_surface [ "plain/file.txt", "not a repo\n" ] (fun surface _root ->
-    match git_status_of surface ~path:"plain" with
-    | Ok output ->
-      Alcotest.failf "a non-repository must not read as clean; got %s" output
-    | Error detail ->
-      Alcotest.(check bool)
-        "a Git failure is not reported as a clean tree"
-        false
-        (Astring.String.is_infix ~affix:"clean" detail))
+         with_tools);
+    Alcotest.(check bool)
+      "tool prompt does not promise the surface cannot change anything"
+      false
+      (Astring.String.is_infix ~affix:"cannot change anything" with_tools);
+    Alcotest.(check bool)
+      "tool prompt forbids repairing the work under review"
+      true
+      (Astring.String.is_infix ~affix:"do not repair what you are judging" with_tools))
 ;;
 
 let () =
   Random.self_init ();
   Alcotest.run
     "verification authority tools"
-    [ ( "containment"
-      , [ Alcotest.test_case "read file returns content" `Quick
-            test_read_file_returns_content
-        ; Alcotest.test_case "read outside root is rejected" `Quick
-            test_read_file_outside_root_is_rejected
-        ; Alcotest.test_case "git status outside root is rejected" `Quick
-            test_git_status_outside_root_is_rejected
-        ] )
-    ; ( "durability"
-      , [ Alcotest.test_case "uncommitted work is named" `Quick
-            test_uncommitted_work_is_named
-        ; Alcotest.test_case "committed work reports clean" `Quick
-            test_committed_work_reports_clean
-        ; Alcotest.test_case "missing directory is an error" `Quick
-            test_git_status_on_a_missing_directory_is_an_error
-        ; Alcotest.test_case "non-repository is an error" `Quick
-            test_git_status_on_a_non_repository_is_an_error
+    [ ( "surface"
+      , [ Alcotest.test_case "schemas are the keeper schemas" `Quick
+            test_schemas_are_the_keeper_schemas
+        ; Alcotest.test_case "unknown producer yields no surface" `Quick
+            test_unknown_producer_yields_no_surface
         ] )
     ; ( "dispatch"
       , [ Alcotest.test_case "unknown tool name is an error" `Quick
             test_unknown_tool_name_is_an_error
         ; Alcotest.test_case "every schema name dispatches" `Quick
             test_every_schema_name_dispatches
+        ] )
+    ; ( "execution"
+      , [ Alcotest.test_case "execute resolves inside the producer playground" `Quick
+            test_execute_resolves_inside_the_producer_playground
+        ; Alcotest.test_case "execute cannot escape the producer playground" `Quick
+            test_execute_cannot_escape_the_producer_playground
+        ; Alcotest.test_case "a failed run is an error, not empty output" `Quick
+            test_a_failed_run_is_an_error_not_empty_output
         ] )
     ; ( "prompt"
       , [ Alcotest.test_case "prompt states the available surface" `Quick


### PR DESCRIPTION
## 판정자에게 생산자의 도구를 준다

`tool_read_file` · `tool_search_files` · `tool_execute` — **생산자가 직접 쓰던 키퍼 도구**를 생산자 meta 에 묶어 판정자에게 넘긴다. 새로 구현한 게 없다.

## #27139 이 틀렸던 이유 (이 PR 이 대체한다)

#27139 는 `verification_git_status` 하나를 상수 argv 로 손수 만들었다. 두 겹으로 틀렸다.

**손으로 만든 도구는 작성자가 예상한 질문에만 답한다.** 판정을 가르는 질문은 고정된 집합이 아니고, 새 질문마다 릴리즈가 든다.

더 결정적으로 — **"테스트가 통과하는가"는 파일을 읽어서 답할 수 없다.** 빌드를 돌려야 한다. 통과한다는 *주장* 만 읽을 수 있는 판정자는 작업이 아니라 주장을 판정한다.

## 첫 버전이 실제로 깨져 있었다 (테스트가 못 잡음)

`.mli` 가 이미 적어둔 사실이다.

> `Playground_paths.bundle_root` 는 번들 디렉토리이고, 체크아웃은 그 아래 `repos/` 에 있다. 루트에서 git 을 돌리면 모든 생산자에 대해 "not a repository" 를 답하면서 동작하는 검사처럼 보인다.

내 테스트는 하위 디렉토리에 저장소를 만들어서 통과했다. 실제 배치에서는 빗나간다.

생산자 meta 를 빌리면 **jail 도 함께 빌린다** — 샌드박스가 생산자가 실제로 일한 곳으로 해석하므로 이 문제 자체가 없다.

```
cwd "."        → scope: playground_root, 생산자 playground
cwd "../../.." → code: cwd_outside_sandbox, scope: outside_playground
```

## 쓰기 권한 — 되돌린 것과 그 대가

이 브랜치의 앞선 read-only 주장을 뒤집는다. **의도된 거래다.**

판정자는 거부해야 할 것을 수리할 수 있고, 그 수리는 아무도 검증하지 않는다. 이걸 지불 가능하게 만드는 건 **모든 호출이 기록된다**는 것이다 (RFC-0361 D4, #26931) — 판정자가 트리를 바꾼 뒤 낸 verdict 은 그렇게 보인다.

프롬프트가 규칙을 직접 말한다.

> Because these tools can change the tree, one rule binds you: do not repair what you are judging. If a build fails, that is a finding, not a task.

그리고 더 이상 `cannot change anything` 을 약속하지 않는다 — 거짓이 됐다. 테스트가 그 문구의 부재를 단언한다.

## Gate 자세는 생산자 것이다 (새 정책 없음)

`tool_execute` 는 external-effect Gate 를 통과하고, Gate 는 `meta.always_allow` 를 읽는다. 그건 **생산자의 스위치**다.

| 생산자 | 판정자 |
|---|---|
| always_allow | 효과가 바로 실행 |
| 승인 대기 | 효과가 **deferred** |

deferred 는 판정자에게 막다른 길이다 — 대기 중 효과는 제출한 키퍼를 깨워서 해소되는데, 판정자는 일회성 리뷰라 깨어날 경로가 없다. 실패한 호출로 받고 그 답 없이 판정해야 한다.

**우회를 주지 않았다.** 우회는 소유자가 허용되지 않은 트리에서 판정자가 효과를 실행하게 만든다 — 닫는 구멍보다 큰 구멍이다. 막다른 길을 남기고 `.mli` 에 명시했다.

## meta 없는 생산자

표면을 만들지 않는다(`create` 가 `Error`). 프롬프트는 스냅샷이 유일한 증거라고 말한다 — 매 호출이 실패할 도구 3개를 광고하는 대신. 사유는 로그에 남는다: 트리에 **닿지 못한** 리뷰와 **보지 않기로 한** 리뷰는 다른 사건이다.

## 검증 — 8 케이스

이 계층이 소유한 속성은 **봉쇄**다. 효과가 실행되는지 지연되는지는 Gate 의 결정이고 Auto Judge 까지 세우는 건 통합 테스트 영역이라, 단언은 런타임이 보고하는 **해석 결과**에 건다.

**게이트 능력**: "실패한 실행을 성공으로 보고" 결함을 주입했더니 **2 건**이 실패했다 — escape 케이스와 failed-run 케이스.

```
주입 전: Test Successful. 8 tests run.
주입 후: [FAIL] execute cannot escape the producer playground
         [FAIL] a failed run is an error, not empty output
원복 후: Test Successful. 8 tests run.
```

**ci.yml 에 배선했다.** 이 스위트는 **돌고 있지 않았다** — #26994 의 봉쇄 케이스가 컴파일만 되고 실행된 적이 없다.

## 키퍼가 되지 않는다

생산자 meta 를 빌리는 것이 판정자를 키퍼로 등록하지 않는다. 레지스트리 항목 없음, 자기 샌드박스 없음, 라이프사이클 없음, 페르소나 없음, task·board·memory·voice 도구 없음. **한 리뷰 동안 남의 트리를 향한 도구 3개**를 든다.

RFC-WAIVED: RFC-0361 이 설계 문서다 (main 병합됨). 이 PR 은 D1 의 남은 부분이며, RFC 가 제안한 "인자 화이트리스트 + 조회 전용" 에서 "생산자 도구 차용 + 실행 포함" 으로 바꾼 근거를 본문에 적었다.
