### PR TITLE
fix(ci): unwired 래칫이 개선에 실패하지 않게 (오늘만 main red 3회)

### DIFF
--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -105,9 +105,13 @@ if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then
   exit 2
 fi
 
+# Below the baseline is an improvement, not a defect, so it reports and passes.
+# Failing here made every suite-wiring PR turn main red until someone edited
+# this number: 748 went red, #27181 set 747, and 746 was red again within the
+# hour. scripts/ocaml-structure-ratchet.sh already treats its own drift-down
+# this way ("baseline can be lowered", exit 0); this now matches it.
 if [ "$unwired" -lt "$UNWIRED_BASELINE" ]; then
-  echo "[ci-test-targets] unwired suites ${unwired} < baseline ${UNWIRED_BASELINE} — lower UNWIRED_BASELINE in $0 to hold the gain"
-  exit 2
+  echo "[ci-test-targets] OK - ${unwired} suites unwired, ${UNWIRED_BASELINE} baseline — lower UNWIRED_BASELINE in $0 to hold the gain"
+else
+  echo "[ci-test-targets] OK - ${unwired} suites unwired, at baseline"
 fi
-
-echo "[ci-test-targets] OK - ${unwired} suites unwired, at baseline"


### PR DESCRIPTION
## 문제

`scripts/audit-ci-test-targets.sh` 는 unwired 카운트가 `UNWIRED_BASELINE` **아래로** 내려가면 `exit 2` 한다. 그래서 suite 를 배선하는 PR 은 누군가 숫자를 고칠 때까지 **main 을 red 로 만든다.**

가설이 아니라 오늘 몇 시간 사이 세 번 일어났다:

```
748   red   #27139 · #27134 가 각각 한 개씩 배선, baseline 그대로
747   red   #27181 이 04:51 에 내림 → 한 시간 안에 또 하나 배선됨
746   red   현재
```

## 형제 래칫은 이미 반대로 한다

```
scripts/ocaml-structure-ratchet.sh:231
  OK   $name: $current < baseline $baseline (baseline can be lowered)
```

거기서는 drift-down 이 **정보**고 `drift_up > 0` 일 때만 실패한다. 같은 저장소에 정반대 정책의 래칫 둘이 있었고, 그중 하나만 main 을 반복해서 깨뜨렸다.

이 PR 은 둘을 일치시킨다. **초과 실패(진짜 회귀 — 돌던 suite 가 멈춤)는 그대로다.**

## 양방향 검증

```
746 < 747 baseline    EXIT=0   "lower UNWIRED_BASELINE to hold the gain" 출력
746 > 700 baseline    EXIT=2   FAIL - 746 suites are declared but never run
```

마지막 줄이 baseline 미만인데도 `at baseline` 이라고 찍던 것도 고쳤다.

## 왜 이게 제약 완화인가

개선에 실패하는 래칫은 **이득을 고정하지 못한다.** 다음 사람의 PR 을 그 사람이 하지 않은 일로 red 로 만들 뿐이다. 배선한 사람이 baseline 을 같이 내리면 가장 좋고 그건 스크립트가 계속 안내한다 — 다만 안 내렸다고 남의 PR 을 막을 이유는 없다.

RFC-WAIVED: 스크립트 1 개, 종료 코드 한 분기. credential / operator control / keeper sandbox / hooks / workflow 문서 미접촉.

🤖 Generated with [Claude Code](https://claude.com/claude-code)