### PR TITLE
fix(lint): make the path-SSOT allowlist report its own rot

### DIFF
--- a/.ci/path-ssot-allowlist.txt
+++ b/.ci/path-ssot-allowlist.txt
@@ -4,45 +4,10 @@
 # Lines starting with '#' are comments. Use the most specific substring
 # you can — overly broad entries mask real regressions.
 #
-# Two categories live here:
-#   (A) Intentional permanent exceptions  — documented in source.
-#   (B) Transitional baseline             — sites known to be touched by
-#       an in-flight RFC-0121 PR; remove each as the PR merges.
+# Every entry must suppress a hit the audit currently produces.
+# audit-path-ssot.sh exits 2 on entries that suppress nothing, so an entry
+# whose site was deleted or rewritten is caught instead of accumulating.
 # ---------------------------------------------------------------------
 
-# ============================================================
-# (A) Intentional permanent exceptions
-# ============================================================
-
-# IDE store kept deliberately under .masc-ide/ (RFC-0128 §4.6).
-# The audit gate does not match .masc-ide today, but a future scan
-# extension might. Anchor the carve-out here.
-lib/ide/ide_paths.ml
-
-# Audit-only Leak-11 detector for pre-fix orphan egress files
-# (keeper_egress_audit.ml, RFC commit 2026-04-27).
-
-# default_local_path / repositories.toml local_path TOML default value
-# is cwd/base-path-relative by on-disk design (RFC-0121 §6 deferred).
-
-# Config_dir_resolver is the SSOT itself; these comment examples document the
-# bypass pattern the audit forbids outside this module.
-
-# Self-reference inside the audit script and RFC text.
+# The audit script quotes the patterns it forbids, so it matches itself.
 scripts/audit-path-ssot.sh
-docs/rfc/RFC-0121-config-dir-resolution-single-active-root.md
-
-# ============================================================
-# (B) Transitional baseline (in-flight RFC-0121 PRs)
-# ============================================================
-# Remove an entry as soon as the listed PR merges. The set should
-# shrink to zero once #16084 .. #16099 are all in main.
-#
-# PR-2 #16096 (repo_manager triangle):
-lib/repo_manager/repo_store.ml:6
-lib/repo_manager/keeper_repo_mapping.ml:8
-#
-# PR-3 #16097 (host_config + server + shutdown):
-lib/host_config/host_config.ml:173
-lib/host_config/host_config.ml:174
-lib/shutdown_hooks.ml:138

--- a/scripts/audit-path-ssot.sh
+++ b/scripts/audit-path-ssot.sh
@@ -18,7 +18,10 @@
 # Exit codes:
 #   0  clean
 #   1  violations found
-#   2  ripgrep missing
+#   2  the gate could not be trusted: ripgrep missing, or the allowlist
+#      carries entries that suppress nothing. Both mean the run says less
+#      than it appears to, which is why neither shares code 1 with a real
+#      violation.
 
 set -u
 
@@ -44,10 +47,15 @@ filter_allowed() {
   fi
 }
 
+RAW_HITS="$(mktemp)"
+trap 'rm -f "$RAW_HITS"' EXIT
+
 scan() {
   local label="$1" pattern="$2"; shift 2
-  local hits
-  hits=$(rg -n "$pattern" "$@" 2>/dev/null | filter_allowed)
+  local raw hits
+  raw=$(rg -n "$pattern" "$@" 2>/dev/null)
+  printf '%s\n' "$raw" >>"$RAW_HITS"
+  hits=$(printf '%s\n' "$raw" | filter_allowed)
   if [ -n "$hits" ]; then
     echo "=== [FAIL] $label ===" >&2
     echo "$hits" >&2
@@ -78,9 +86,31 @@ scan "non-canonical MASC env var" \
   '\bMASC_HOME\b|\bMASC_ROOT\b' \
   lib/ scripts/ docs/ start-masc.sh
 
-if [ "$VIOLATIONS" -eq 0 ]; then
-  echo "audit-path-ssot: OK (0 violations)"
+# Stale allowlist entries: a substring that suppresses nothing is not a
+# carve-out, it is debris. Kept as its own exit code so a rotting list is
+# distinguishable from a real regression.
+STALE=0
+if [ "$ALLOWLIST" != "/dev/null" ]; then
+  while IFS= read -r entry; do
+    [ -z "$entry" ] && continue
+    if ! grep -qF -- "$entry" "$RAW_HITS"; then
+      if [ "$STALE" -eq 0 ]; then
+        echo "audit-path-ssot: stale allowlist entries (suppress nothing):" >&2
+      fi
+      echo "  $entry" >&2
+      STALE=$((STALE + 1))
+    fi
+  done < <(grep -vE '^[[:space:]]*(#|$)' "$ALLOWLIST")
+fi
+
+if [ "$VIOLATIONS" -eq 0 ] && [ "$STALE" -eq 0 ]; then
+  echo "audit-path-ssot: OK (0 violations, 0 stale allowlist entries)"
   exit 0
+fi
+
+if [ "$VIOLATIONS" -eq 0 ]; then
+  echo "audit-path-ssot: ${STALE} stale allowlist entry/entries; remove them." >&2
+  exit 2
 fi
 
 cat >&2 <<'EOM'


### PR DESCRIPTION
## 리뷰 대응 (`41654d867` 기준 리뷰)

**P1 — #27191과의 충돌**: 해소했습니다. #27191이 먼저 머지됐고(2026-08-06 06:21), `Config_dir_resolver.repos_relative_path`를 추가해 근본 수정을 넣었습니다. 리뷰 권고대로 rebase 후 해당 항목을 **버렸습니다**. "의도된 영구 예외"라는 분류는 철회합니다 — 도구 부재로 인한 일시 예외가 맞았습니다.

**P2 — 헤더 exit code 문서**: 갱신했습니다.

```
#   2  the gate could not be trusted: ripgrep missing, or the allowlist
#      carries entries that suppress nothing. Both mean the run says less
#      than it appears to, which is why neither shares code 1 with a real
#      violation.
```

**P3 — CONFLICTING**: `origin/main`으로 rebase 완료.

## 이 PR이 하는 일

allowlist는 rg 출력에 대한 substring 매치라, 항목이 가리키던 사이트가 지워지거나 재작성되면 조용히 아무것도 억제하지 않게 됩니다. `audit-path-ssot.sh`가 각 항목을 raw 스캔 결과와 대조해 **아무것도 억제하지 않으면 exit 2**로 보고합니다.

allowlist를 읽는 lint 18개 중 10개가 이미 같은 코드로 stale을 자가 탐지합니다. 새 관습이 아닙니다.

## 측정

main의 8개 항목에 게이트를 돌린 결과 **7개가 죽어 있습니다**.

| 항목 | 판정 근거 |
|---|---|
| `lib/repo_manager/repo_store.ml:6` | #16096 머지(2026-05-18). 6번 줄은 이제 "RFC-0121 fix 적용됨" 주석 |
| `lib/repo_manager/keeper_repo_mapping.ml:8` | 동일 |
| `lib/host_config/host_config.ml:173`, `:174` | #16097 머지(2026-05-18). 해당 줄은 `\| None -> fallback` / `in` |
| `lib/shutdown_hooks.ml:138` | 동일. 무관한 주석 |
| `docs/rfc/RFC-0121-…md` | inline-concat 스캔은 `lib/`만 읽고, `docs/`를 읽는 스캔은 `MASC_HOME`/`MASC_ROOT`만 찾음 — 구조적으로 매치 불가 |
| `lib/ide/ide_paths.ml` | 아래 참조 |

(B) 블록 5개는 자기 헤더가 "Remove an entry as soon as the listed PR merges"라고 적어둔 것들입니다. 두 PR 모두 **2026-05-18에 머지**됐습니다.

## 판단이 필요한 항목 하나

`lib/ide/ide_paths.ml`은 측정이 아니라 논증이 필요합니다. 주석이 스스로 이렇게 말합니다:

> The audit gate does not match `.masc-ide` today, but a future scan extension might.

존재하지 않는 스캔을 위한 allowlist 항목은 무엇에 대해서도 검증할 수 없고, 영원히 stale로 읽힙니다. 지웠습니다. 스캔 확장이 실제로 들어오면 그때 **매치되는 hit을 근거로** 다시 추가하면 됩니다.

살아남은 건 1개 — 감사 스크립트가 자신이 금지하는 패턴을 인용하므로 자기 소스에 매치됩니다.

## 검증

```
$ bash scripts/audit-path-ssot.sh
audit-path-ssot: OK (0 violations, 0 stale allowlist entries)
EXIT=0

$ echo 'lib/this_file_does_not_exist.ml:999' >> .ci/path-ssot-allowlist.txt
$ bash scripts/audit-path-ssot.sh
audit-path-ssot: stale allowlist entries (suppress nothing):
  lib/this_file_does_not_exist.ml:999
EXIT=2

$ # (제거 후) EXIT=0
```

게이트는 PASS가 아니라 **트립하는지로** 검증했습니다.

RFC-WAIVED: `pr-rfc-check.sh` EXIT=0. 변경 범위는 `.ci/` allowlist 데이터와 `scripts/` lint 스크립트뿐이고, RFC 필수 subsystem(credential / identity / operator control / sandbox / hooks)을 건드리지 않습니다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
