### PR TITLE
refactor(trajectory): remove the fabricated per-tool cost estimate

### DIFF
--- a/dashboard/src/api/dashboard-keeper-tool-stats.ts
+++ b/dashboard/src/api/dashboard-keeper-tool-stats.ts
@@ -13,7 +13,6 @@ export type ToolStat = {
   avg_duration_ms: number
   p95_duration_ms: number
   max_duration_ms: number
-  total_cost_usd: number
   last_used_at: string
 }
 
@@ -43,7 +42,6 @@ function decodeToolStat(raw: unknown): ToolStat | null {
     avg_duration_ms: asNumber(raw.avg_duration_ms, 0),
     p95_duration_ms: asNumber(raw.p95_duration_ms, 0),
     max_duration_ms: asNumber(raw.max_duration_ms, 0),
-    total_cost_usd: asNumber(raw.total_cost_usd, 0),
     last_used_at: asString(raw.last_used_at, ''),
   }
 }

--- a/dashboard/src/api/dashboard-keeper-trajectory.ts
+++ b/dashboard/src/api/dashboard-keeper-trajectory.ts
@@ -23,7 +23,6 @@ export type TrajectoryEntry = {
   result?: string | null
   duration_ms?: number
   error?: string | null
-  cost_usd?: number
   // Thinking-specific fields
   content?: string
   content_length?: number

--- a/dashboard/src/components/journey-panel.test.ts
+++ b/dashboard/src/components/journey-panel.test.ts
@@ -30,7 +30,6 @@ function trajectory(): TrajectoryResponse {
         gate: { status: 'pass' },
         result: 'old result',
         duration_ms: 120,
-        cost_usd: 0.002,
       },
     ],
   }

--- a/dashboard/src/components/journey-panel.ts
+++ b/dashboard/src/components/journey-panel.ts
@@ -11,7 +11,7 @@ import {
   fetchKeeperRuntimeTrace,
   type KeeperRuntimeTraceResponse,
 } from '../api/keeper'
-import { formatCost, formatMsCompact } from '../lib/format-number'
+import { formatMsCompact } from '../lib/format-number'
 import { errorToString } from '../lib/format-string'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 import { keepers } from '../store'
@@ -296,7 +296,6 @@ function WaterfallEntryRow({
               <span class="font-mono text-3xs ${entry.durationMs != null ? durationColor(entry.durationMs) : 'text-[var(--color-fg-disabled)]'}">
                 ${formatMaybeDuration(entry.durationMs)}
               </span>
-              <span class="font-mono text-3xs text-[var(--color-fg-muted)]">${formatCost(entry.costUsd, '$0')}</span>
             </div>
             ${entry.toolArgs
               ? html`<div class="truncate font-mono text-3xs text-[var(--color-fg-muted)]">${formatArgs(entry.toolArgs)}</div>`
@@ -354,9 +353,6 @@ function WaterfallTurnRow({
           <span class="rounded-[var(--r-1)] border border-[var(--color-border-default)] px-1.5 py-0.5 font-mono text-[var(--color-fg-muted)]">
             tool time ${formatMaybeDuration(turn.totalDurationMs)}
           </span>
-          <span class="rounded-[var(--r-1)] border border-[var(--color-border-default)] px-1.5 py-0.5 font-mono text-[var(--color-fg-muted)]">
-            cost ${formatCost(turn.totalCostUsd, '$0')}
-          </span>
         </div>
       </div>
 
@@ -407,7 +403,6 @@ function WaterfallBody({
         <${MetricCell} label="tools" value=${summary.toolCallCount} tone="ok" />
         <${MetricCell} label="failures" value=${summary.failureCount} tone=${summary.failureCount > 0 ? 'bad' : 'ok'} />
         <${MetricCell} label="tool time" value=${formatMaybeDuration(summary.totalDurationMs)} />
-        <${MetricCell} label="cost" value=${formatCost(summary.totalCostUsd, '$0')} />
       </div>
 
       <div class="flex flex-wrap items-center justify-between gap-2 text-3xs text-[var(--color-fg-muted)]">

--- a/dashboard/src/components/journey-waterfall-state.test.ts
+++ b/dashboard/src/components/journey-waterfall-state.test.ts
@@ -145,7 +145,6 @@ describe('buildJourneyWaterfall', () => {
           gate: { status: 'pass' },
           result: 'old result',
           duration_ms: 250,
-          cost_usd: 0.001,
         },
       ]),
       toolCalls: toolCalls([
@@ -169,7 +168,6 @@ describe('buildJourneyWaterfall', () => {
     expect(model.turns[0]?.thinkingCount).toBe(1)
     expect(model.turns[0]?.toolCallCount).toBe(1)
     expect(model.turns[0]?.runtimeEvidence?.maxOasTurnCount).toBe(4)
-    expect(model.summary.totalCostUsd).toBe(0.001)
     const toolEntry = model.turns[0]?.entries.find(entry => entry.kind === 'tool_call')
     expect(toolEntry?.source).toBe('trajectory+tool_call_log')
     expect(toolEntry?.toolArgs).toEqual({ file_path: '/tmp/current' })

--- a/dashboard/src/components/journey-waterfall-state.ts
+++ b/dashboard/src/components/journey-waterfall-state.ts
@@ -32,7 +32,6 @@ export interface JourneyWaterfallEntry {
   thinkingContent: string | null
   thinkingRedacted: boolean
   durationMs: number | null
-  costUsd: number | null
   gateReason: string | null
   error: string | null
   sessionId: string | null
@@ -68,7 +67,6 @@ export interface JourneyWaterfallTurn {
   failureCount: number
   gateRejectedCount: number
   totalDurationMs: number
-  totalCostUsd: number
   runtimeEvidence: JourneyWaterfallRuntimeEvidence | null
 }
 
@@ -80,7 +78,6 @@ export interface JourneyWaterfallSummary {
   failureCount: number
   gateRejectedCount: number
   totalDurationMs: number
-  totalCostUsd: number
   timelineStartTs: number | null
   timelineEndTs: number | null
   runtimeEvidence: JourneyWaterfallRuntimeEvidence | null
@@ -158,7 +155,6 @@ function entryFromTraceEvent(event: UnifiedTraceEvent): JourneyWaterfallEntry | 
     thinkingContent: event.thinkingContent ?? null,
     thinkingRedacted: event.thinkingRedacted === true,
     durationMs: event.duration_ms ?? null,
-    costUsd: event.cost_usd ?? null,
     gateReason: event.gate?.reason ?? null,
     error: event.error ?? null,
     sessionId: event.sessionId ?? null,
@@ -228,7 +224,6 @@ function buildTurn(
     failureCount: sortedEntries.filter(entry => entry.status === 'failure').length,
     gateRejectedCount: sortedEntries.filter(entry => entry.status === 'gate_rejected').length,
     totalDurationMs: toolEntries.reduce((sum, entry) => sum + (entry.durationMs ?? 0), 0),
-    totalCostUsd: toolEntries.reduce((sum, entry) => sum + (entry.costUsd ?? 0), 0),
     runtimeEvidence,
   }
 }
@@ -286,7 +281,6 @@ export function buildJourneyWaterfall(input: JourneyWaterfallInput): JourneyWate
       failureCount: allTurnEntries.filter(entry => entry.status === 'failure').length,
       gateRejectedCount: allTurnEntries.filter(entry => entry.status === 'gate_rejected').length,
       totalDurationMs: turns.reduce((sum, turn) => sum + turn.totalDurationMs, 0),
-      totalCostUsd: turns.reduce((sum, turn) => sum + turn.totalCostUsd, 0),
       timelineStartTs: allTurnEntries[0]?.ts ?? null,
       timelineEndTs: allTurnEntries.at(-1)?.ts ?? null,
       runtimeEvidence,

--- a/dashboard/src/components/keeper-tool-telemetry.test.ts
+++ b/dashboard/src/components/keeper-tool-telemetry.test.ts
@@ -14,7 +14,6 @@ function mkStat(name: string, overrides: Partial<ToolStat> = {}): ToolStat {
     avg_duration_ms: 10,
     p95_duration_ms: 20,
     max_duration_ms: 30,
-    total_cost_usd: 0,
     last_used_at: '2026-04-17T00:00:00Z',
     ...overrides,
   }

--- a/dashboard/src/components/keeper-tool-telemetry.ts
+++ b/dashboard/src/components/keeper-tool-telemetry.ts
@@ -8,7 +8,7 @@ import { fetchKeeperToolStats } from '../api/dashboard'
 import type { ToolStat, HourlyBucket, ToolStatsResponse, TelemetryFreshnessMetadata } from '../api/dashboard'
 import { lastEvent } from '../sse'
 import { toolCategory, durationColor, normalizeToolName } from './tool-call-shared'
-import { formatCost, formatMsCompact } from '../lib/format-number'
+import { formatMsCompact } from '../lib/format-number'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 import { TextInput } from './common/input'
 import { SectionCap } from './common/section-cap'
@@ -231,7 +231,6 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
     `
   }
 
-  const totalCost = s.tools.reduce((sum, t) => sum + t.total_cost_usd, 0)
   const maxCount = s.tools[0]?.call_count ?? 1
 
   // Find tools with highest p95
@@ -254,11 +253,6 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
         <${StatusChip} tone="neutral" uppercase=${false} class="gap-1 py-1">
           <span class="font-mono font-medium text-[var(--color-fg-secondary)]">${s.totalEntries}</span> 호출
         <//>
-        ${totalCost > 0 ? html`
-          <${StatusChip} tone="info" uppercase=${false} class="gap-1 py-1">
-            <span class="font-mono font-medium text-[var(--color-accent-fg)]">${formatCost(totalCost)}</span>
-          <//>
-        ` : null}
         <${StatusChip} tone="neutral" uppercase=${false} class="gap-1 py-1 text-[var(--color-fg-disabled)]">
           ${s.windowHours}h 기간
         <//>

--- a/dashboard/src/components/session-trace/session-trace-state.test.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.test.ts
@@ -284,7 +284,6 @@ describe('buildTraceEvents', () => {
           result: 'file contents',
           duration_ms: 50,
           gate: { status: 'pass' },
-          cost_usd: 0.001,
           error: null,
         }],
       },
@@ -353,7 +352,6 @@ describe('buildTraceEvents', () => {
           result: 'trajectory result',
           duration_ms: 50,
           gate: { status: 'pass' },
-          cost_usd: 0.001,
           error: null,
         }],
       },
@@ -409,7 +407,6 @@ describe('buildTraceEvents', () => {
           result: 'trajectory result',
           duration_ms: 812,
           gate: { status: 'pass' },
-          cost_usd: 0.001,
           error: null,
           execution_id: 'exec-1712397700000-duration',
         }],
@@ -507,7 +504,6 @@ describe('buildTraceEvents', () => {
           result: 'trajectory result',
           duration_ms: 50,
           gate: { status: 'pass' },
-          cost_usd: 0.001,
           error: null,
           execution_id: 'exec-1712397700000-002a',
         }],
@@ -568,7 +564,6 @@ describe('buildTraceEvents', () => {
           result: 'a',
           duration_ms: 50,
           gate: { status: 'pass' },
-          cost_usd: 0.001,
           error: null,
           execution_id: 'exec-1712397700000-0001',
         }],
@@ -621,7 +616,6 @@ describe('buildTraceEvents', () => {
           result: 'legacy',
           duration_ms: 50,
           gate: { status: 'pass' },
-          cost_usd: 0.001,
           error: null,
         }],
       },
@@ -686,12 +680,15 @@ describe('buildTraceEvents', () => {
 })
 
 describe('getTraceSummary', () => {
-  it('counts tool_call events and accumulates cost', () => {
+  // Trajectory-sourced tool calls carry no cost. The dollar figure in the trace
+  // summary comes from OAS lifecycle events, which are the only events that
+  // report a cost the provider actually charged.
+  it('counts tool_call events; the dollar total comes from OAS events only', () => {
     traceSlots.value = {
       'keeper-a': {
         events: [
-          { id: '1', ts: 1000, ts_iso: '', kind: 'tool_call', sourceLane: 'masc', summary: 'read', detail: {}, cost_usd: 0.01 },
-          { id: '2', ts: 2000, ts_iso: '', kind: 'tool_call', sourceLane: 'masc', summary: 'edit', detail: {}, cost_usd: 0.02 },
+          { id: '1', ts: 1000, ts_iso: '', kind: 'tool_call', sourceLane: 'masc', summary: 'read', detail: {} },
+          { id: '2', ts: 2000, ts_iso: '', kind: 'tool_call', sourceLane: 'masc', summary: 'edit', detail: {} },
           { id: '3', ts: 3000, ts_iso: '', kind: 'broadcast', sourceLane: 'masc', summary: 'hello', detail: {} },
         ],
         loading: false,
@@ -706,7 +703,7 @@ describe('getTraceSummary', () => {
     const summary = getTraceSummary('keeper-a')
     expect(summary.tool_call_count).toBe(2)
     expect(summary.broadcast_count).toBe(1)
-    expect(summary.total_cost_usd).toBeCloseTo(0.03)
+    expect(summary.total_cost_usd).toBe(0)
   })
 
   it('accumulates OAS tokens and cost from lifecycle events', () => {

--- a/dashboard/src/components/session-trace/session-trace-state.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.ts
@@ -245,7 +245,6 @@ export function getTraceSummary(agent: string): TraceSummary {
     switch (e.kind) {
       case 'tool_call':
         tool_call_count++
-        total_cost_usd += e.cost_usd ?? 0
         break
       case 'oas_tool':
         oas_tool_count++
@@ -738,7 +737,6 @@ function trajectoryEntryToTrace(
     gate: entry.gate,
     turn: entry.turn,
     round: entry.round,
-    cost_usd: entry.cost_usd,
     executionId: entry.execution_id,
     error: entry.error,
   }

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -575,7 +575,6 @@ let make_hooks
                result = Some safe_output;
                duration_ms = trajectory_duration_ms duration_ms;
                error = (if outcome = Tool_result.Ok then None else Some safe_output);
-               cost_usd = Trajectory.tool_cost_estimate tool_name;
                execution_id =
                  Some (Ids.Execution_id.to_string execution_id);
              }

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -392,7 +392,6 @@ let record_runtime_mcp_keeper_trajectory
       result = Some safe_output;
       duration_ms;
       error;
-      cost_usd = Trajectory.tool_cost_estimate tool_name;
       execution_id = Some (Ids.Execution_id.to_string execution_id);
     }
   in

--- a/lib/trajectory/trajectory.ml
+++ b/lib/trajectory/trajectory.ml
@@ -30,7 +30,6 @@ type tool_call_entry = {
   result : string option;           (** None if gated/pending, Some output *)
   duration_ms : int;                (** Wall-clock execution time *)
   error : string option;            (** Exception message if failed *)
-  cost_usd : float;                 (** Estimated cost of this call *)
   execution_id : string option;
       (** RFC-0233 canonical join key minted at the dispatch boundary; the
           tool_calls JSONL row for the same execution carries the identical
@@ -64,7 +63,6 @@ type trajectory = {
   started_at : float;
   ended_at : float;
   entries : tool_call_entry list;
-  total_cost_usd : float;
   total_turns : int;
   total_tool_calls : int;
   outcome : trajectory_outcome;
@@ -91,26 +89,6 @@ type thinking_entry = {
 type trajectory_line =
   | Tool_call of tool_call_entry
   | Thinking of thinking_entry
-
-(* ================================================================ *)
-(* Cost estimation                                                  *)
-(* ================================================================ *)
-
-(* model_token_pricing and estimate_turn_cost removed (#3029).
-   Pricing belongs to OAS runtime, not MASC.
-   MASC records cost_usd from OAS responses via emit_cost_event. *)
-
-(** Rough per-call cost estimates for keeper tools.
-    Most are local/free; only MODEL-calling tools have cost. *)
-let tool_cost_estimate (tool_name : string) : float =
-  match tool_name with
-  (* MODEL-intensive tools *)
-  | "masc_board_post" -> 0.002
-  | "masc_board_comment" -> 0.001
-  | "tool_execute" -> 0.0001
-  | "tool_edit_file" | "tool_write_file" -> 0.0001
-  (* Read-only tools are essentially free *)
-  | _ -> 0.0
 
 (* ================================================================ *)
 (* JSON serialization                                               *)
@@ -174,7 +152,6 @@ let entry_to_json ?(result_max_len = default_result_truncation)
               else `String r) );
        ("duration_ms", `Int e.duration_ms);
        ("error", Json_util.string_opt_to_json e.error);
-       ("cost_usd", `Float e.cost_usd);
      ]
     @ (match e.execution_id with
        | Some id -> [ ("execution_id", `String id) ]
@@ -214,7 +191,6 @@ let trajectory_to_json (t : trajectory) : Yojson.Safe.t =
     ("generation", `Int t.generation);
     ("started_at", `Float t.started_at);
     ("ended_at", `Float t.ended_at);
-    ("total_cost_usd", `Float t.total_cost_usd);
     ("total_turns", `Int t.total_turns);
     ("total_tool_calls", `Int t.total_tool_calls);
     ("outcome", outcome_to_json t.outcome);
@@ -275,7 +251,6 @@ let tool_call_entry_of_json (json : Yojson.Safe.t) :
                  | None | Some `Null -> None
                  | Some (`String s) -> Some s
                  | Some _ -> None);
-              cost_usd = (match Json_util.assoc_member_opt "cost_usd" json with Some (`Float f) -> f | Some (`Int n) -> Float.of_int n | _ -> 0.0);
               execution_id =
                 (match Json_util.assoc_member_opt "execution_id" json with
                  | Some (`String s) -> Some s
@@ -519,7 +494,6 @@ let append_summary ~(masc_root : string) ~(keeper_name : string) ~(trace_id : st
     ("keeper_name", `String traj.keeper_name);
     ("trace_id", `String traj.trace_id);
     ("generation", `Int traj.generation);
-    ("total_cost_usd", `Float traj.total_cost_usd);
     ("total_turns", `Int traj.total_turns);
     ("total_tool_calls", `Int traj.total_tool_calls);
     ("outcome", outcome_to_json traj.outcome);
@@ -548,7 +522,6 @@ type pending_entry = {
 
 type accumulator = {
   mutable entries : tool_call_entry list;
-  mutable total_cost : float;
   mutable total_calls : int;
   mutable turn : int;
   keeper_name : string;
@@ -582,7 +555,6 @@ let unregister_accumulator (acc : accumulator) =
 let create_accumulator ?on_flush_error ~masc_root ~keeper_name ~trace_id ~generation () : accumulator =
   let acc = {
     entries = [];
-    total_cost = 0.0;
     total_calls = 0;
     turn = 0;
     keeper_name;
@@ -616,7 +588,6 @@ let set_turn (acc : accumulator) (turn : int) : unit =
 let record_entry ?runtime_contract ?action_radius ?on_persist_error
     (acc : accumulator) (entry : tool_call_entry) : unit =
   acc.entries <- entry :: acc.entries;
-  acc.total_cost <- acc.total_cost +. entry.cost_usd;
   acc.total_calls <- acc.total_calls + 1;
   (* Store on_persist_error for use during batch flush *)
   (match on_persist_error, acc.on_flush_error with
@@ -684,7 +655,6 @@ let finalize (acc : accumulator) (outcome : trajectory_outcome) : trajectory =
     started_at = acc.started_at;
     ended_at = Time_compat.now ();
     entries = List.rev acc.entries;
-    total_cost_usd = acc.total_cost;
     total_turns = acc.turn;
     total_tool_calls = acc.total_calls;
     outcome;
@@ -711,7 +681,6 @@ type tool_stat = {
   avg_duration_ms : int;
   p95_duration_ms : int;
   max_duration_ms : int;
-  total_cost_usd : float;
   last_used_at : string;
 }
 
@@ -730,7 +699,7 @@ let p95_of_sorted (durations : int array) : int =
     durations.(idx)
 
 let aggregate_tool_stats (entries : tool_call_entry list) : tool_stat list =
-  let tbl : (string, int list * int * int * float * float * string) Hashtbl.t =
+  let tbl : (string, int list * int * int * float * string) Hashtbl.t =
     Hashtbl.create 32
   in
   List.iter (fun (e : tool_call_entry) ->
@@ -740,15 +709,15 @@ let aggregate_tool_stats (entries : tool_call_entry list) : tool_stat list =
       let succ = if is_failure then 0 else 1 in
       let fail = if is_failure then 1 else 0 in
       Hashtbl.replace tbl e.tool_name
-        ([e.duration_ms], succ, fail, e.cost_usd, e.ts, e.ts_iso)
-    | Some (durations, succ, fail, cost, max_ts, max_iso) ->
+        ([e.duration_ms], succ, fail, e.ts, e.ts_iso)
+    | Some (durations, succ, fail, max_ts, max_iso) ->
       let succ' = if is_failure then succ else succ + 1 in
       let fail' = if is_failure then fail + 1 else fail in
       let (ts', iso') = if e.ts > max_ts then (e.ts, e.ts_iso) else (max_ts, max_iso) in
       Hashtbl.replace tbl e.tool_name
-        (e.duration_ms :: durations, succ', fail', cost +. e.cost_usd, ts', iso')
+        (e.duration_ms :: durations, succ', fail', ts', iso')
   ) entries;
-  let stats = Hashtbl.fold (fun name (durations, succ, fail, cost, _max_ts, last_iso) acc ->
+  let stats = Hashtbl.fold (fun name (durations, succ, fail, _max_ts, last_iso) acc ->
     let count = succ + fail in
     let total_dur = List.fold_left (+) 0 durations in
     let avg = if count > 0 then total_dur / count else 0 in
@@ -762,7 +731,6 @@ let aggregate_tool_stats (entries : tool_call_entry list) : tool_stat list =
       avg_duration_ms = avg;
       p95_duration_ms = p95_of_sorted sorted;
       max_duration_ms = max_d;
-      total_cost_usd = cost;
       last_used_at = last_iso;
     } :: acc
   ) tbl [] in
@@ -797,7 +765,6 @@ let tool_stat_to_json (s : tool_stat) : Yojson.Safe.t =
     ("avg_duration_ms", `Int s.avg_duration_ms);
     ("p95_duration_ms", `Int s.p95_duration_ms);
     ("max_duration_ms", `Int s.max_duration_ms);
-    ("total_cost_usd", `Float s.total_cost_usd);
     ("last_used_at", `String s.last_used_at);
   ]
 

--- a/lib/trajectory/trajectory.mli
+++ b/lib/trajectory/trajectory.mli
@@ -20,7 +20,6 @@ type tool_call_entry = {
   result : string option;
   duration_ms : int;
   error : string option;
-  cost_usd : float;
   execution_id : string option;
       (** RFC-0233 canonical join key shared with the tool_calls JSONL row
           for the same execution. [None] only for rows written by paths
@@ -52,7 +51,6 @@ type trajectory = {
   started_at : float;
   ended_at : float;
   entries : tool_call_entry list;
-  total_cost_usd : float;
   total_turns : int;
   total_tool_calls : int;
   outcome : trajectory_outcome;
@@ -80,7 +78,6 @@ type trajectory_line =
 
 (** {1 Cost estimation} *)
 
-val tool_cost_estimate : string -> float
 (** Rough per-call cost estimate for keeper tools. *)
 
 (** {1 JSON serialization} *)
@@ -172,7 +169,6 @@ type pending_entry = {
 
 type accumulator = {
   mutable entries : tool_call_entry list;
-  mutable total_cost : float;
   mutable total_calls : int;
   mutable turn : int;
   keeper_name : string;
@@ -236,7 +232,6 @@ type tool_stat = {
   avg_duration_ms : int;
   p95_duration_ms : int;
   max_duration_ms : int;
-  total_cost_usd : float;
   last_used_at : string;
 }
 

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -969,7 +969,6 @@ let trajectory_entry_of_provider_call ~ts ~turn ~round
   ; result = Some {|{"ok":true}|}
   ; duration_ms = 1
   ; error = None
-  ; cost_usd = Trajectory.tool_cost_estimate call.name
   ; execution_id = Some ("exec-" ^ call.call_id)
   }
 

--- a/test/test_trajectory.ml
+++ b/test/test_trajectory.ml
@@ -7,22 +7,6 @@ let () =
   ignore (Unix.gettimeofday ())
 
 (* ================================================================ *)
-(* Test: tool_cost_estimate returns expected values                   *)
-(* ================================================================ *)
-
-let test_tool_cost_known () =
-  let cost = Trajectory.tool_cost_estimate "masc_board_post" in
-  Alcotest.(check (float 0.001)) "board_post cost" 0.002 cost
-
-let test_tool_cost_unknown () =
-  let cost = Trajectory.tool_cost_estimate "nonexistent_tool" in
-  Alcotest.(check (float 0.0001)) "unknown tool default cost" 0.0 cost
-
-let test_tool_cost_bash () =
-  let cost = Trajectory.tool_cost_estimate "tool_execute" in
-  Alcotest.(check (float 0.0001)) "bash cost" 0.0001 cost
-
-(* ================================================================ *)
 (* Test: gate_decision types                                         *)
 (* ================================================================ *)
 
@@ -56,7 +40,6 @@ let test_create_accumulator () =
       ~masc_root:dir ~keeper_name:"test-keeper"
       ~trace_id:"trace-001" ~generation:0 () in
     Alcotest.(check int) "initial turn" 0 acc.Trajectory.turn;
-    Alcotest.(check (float 0.0001)) "initial cost" 0.0 acc.Trajectory.total_cost;
     Alcotest.(check int) "initial entries" 0 (List.length acc.Trajectory.entries))
 
 (* ================================================================ *)
@@ -79,12 +62,11 @@ let test_record_entry () =
       result = Some "/home/test";
       duration_ms = 50;
       error = None;
-      cost_usd = 0.0001;
       execution_id = Some "exec-1000-0001";
     } in
     Trajectory.record_entry acc entry;
     Alcotest.(check int) "entries count" 1 (List.length acc.Trajectory.entries);
-    Alcotest.(check (float 0.0001)) "total cost" 0.0001 acc.Trajectory.total_cost)
+    ())
 
 (* ================================================================ *)
 (* Test: increment_turn                                              *)
@@ -136,14 +118,13 @@ let test_finalize () =
       tool_name = "tool_execute"; args_json = "{}";
       gate_decision = Trajectory.Pass;
       result = Some "ok"; duration_ms = 100;
-      error = None; cost_usd = 0.0001;
+      error = None;
       execution_id = None;
     } in
     Trajectory.record_entry acc entry;
     let traj = Trajectory.finalize acc Trajectory.Completed in
     Alcotest.(check int) "total turns" 1 traj.Trajectory.total_turns;
     Alcotest.(check int) "total calls" 1 traj.Trajectory.total_tool_calls;
-    Alcotest.(check (float 0.0001)) "total cost" 0.0001 traj.Trajectory.total_cost_usd;
     Alcotest.(check string) "trace_id" "trace-006" traj.Trajectory.trace_id)
 
 (* ================================================================ *)
@@ -175,7 +156,7 @@ let test_calls_in_current_turn () =
       tool_name = tool; args_json = "{}";
       gate_decision = Trajectory.Pass;
       result = Some "ok"; duration_ms = 10;
-      error = None; cost_usd = 0.001;
+      error = None;
       execution_id = None;
     } in
     Trajectory.record_entry acc (mk "tool_execute");
@@ -251,29 +232,26 @@ let test_task_id_null_when_none () =
     | `Null -> ()
     | _ -> Alcotest.fail "Expected task_id to be null when not set")
 
-(* model_pricing tests removed — model_token_pricing / estimate_turn_cost
-   deleted from Trajectory (#3029). Pricing belongs to OAS runtime. *)
-
 (* ================================================================ *)
 (* Test: aggregate_tool_stats                                        *)
 (* ================================================================ *)
 
-let mk_entry ?(ts = 1000.0) ?(error = None) ?(gate = Trajectory.Pass) name dur cost ts_iso =
+let mk_entry ?(ts = 1000.0) ?(error = None) ?(gate = Trajectory.Pass) name dur ts_iso =
   { Trajectory.
     ts; ts_iso; turn = 1; round = 0;
     tool_name = name; args_json = "{}";
     gate_decision = gate;
     result = Some "ok"; duration_ms = dur;
-    error; cost_usd = cost;
+    error;
     execution_id = None;
   }
 
 let test_aggregate_basic () =
   let entries = [
-    mk_entry "tool_execute" 100 0.001 "2026-04-06T10:00:00Z";
-    mk_entry "tool_execute" 200 0.002 "2026-04-06T10:01:00Z";
-    mk_entry "tool_execute" 300 0.001 "2026-04-06T10:02:00Z";
-    mk_entry "tool_read_file" 50 0.0 "2026-04-06T10:03:00Z";
+    mk_entry "tool_execute" 100 "2026-04-06T10:00:00Z";
+    mk_entry "tool_execute" 200 "2026-04-06T10:01:00Z";
+    mk_entry "tool_execute" 300 "2026-04-06T10:02:00Z";
+    mk_entry "tool_read_file" 50 "2026-04-06T10:03:00Z";
   ] in
   let stats = Trajectory.aggregate_tool_stats entries in
   Alcotest.(check int) "tool count" 2 (List.length stats);
@@ -288,9 +266,9 @@ let test_aggregate_basic () =
 
 let test_aggregate_with_errors () =
   let entries = [
-    mk_entry "tool_execute" 100 0.001 "2026-04-06T10:00:00Z";
-    mk_entry ~error:(Some "timeout") "tool_execute" 5000 0.001 "2026-04-06T10:01:00Z";
-    mk_entry ~gate:(Trajectory.Reject "denied") "tool_execute" 0 0.0 "2026-04-06T10:02:00Z";
+    mk_entry "tool_execute" 100 "2026-04-06T10:00:00Z";
+    mk_entry ~error:(Some "timeout") "tool_execute" 5000 "2026-04-06T10:01:00Z";
+    mk_entry ~gate:(Trajectory.Reject "denied") "tool_execute" 0 "2026-04-06T10:02:00Z";
   ] in
   let stats = Trajectory.aggregate_tool_stats entries in
   Alcotest.(check int) "tool count" 1 (List.length stats);
@@ -306,7 +284,7 @@ let test_aggregate_empty () =
 let test_aggregate_p95 () =
   (* 20 entries: durations 100, 200, ..., 2000. p95 index = round(20 * 0.95) = 19 -> 2000 *)
   let entries = List.init 20 (fun i ->
-    mk_entry "tool_execute" ((i + 1) * 100) 0.0
+    mk_entry "tool_execute" ((i + 1) * 100)
       (Printf.sprintf "2026-04-06T10:%02d:00Z" i)
   ) in
   let stats = Trajectory.aggregate_tool_stats entries in
@@ -320,8 +298,8 @@ let test_aggregate_p95 () =
 
 let test_hourly_single_bucket () =
   let entries = [
-    { (mk_entry "tool_execute" 100 0.0 "2026-04-06T10:05:00Z") with Trajectory.ts = 1743937500.0 };
-    { (mk_entry "tool_execute" 100 0.0 "2026-04-06T10:30:00Z") with Trajectory.ts = 1743939000.0 };
+    { (mk_entry "tool_execute" 100 "2026-04-06T10:05:00Z") with Trajectory.ts = 1743937500.0 };
+    { (mk_entry "tool_execute" 100 "2026-04-06T10:30:00Z") with Trajectory.ts = 1743939000.0 };
   ] in
   let timeline = Trajectory.hourly_timeline entries in
   (* Both entries fall in the same hour bucket (25 min apart) *)
@@ -332,8 +310,8 @@ let test_hourly_single_bucket () =
 
 let test_hourly_with_errors () =
   let entries = [
-    { (mk_entry "tool_execute" 100 0.0 "2026-04-06T10:05:00Z") with Trajectory.ts = 1743937500.0 };
-    { (mk_entry ~error:(Some "fail") "tool_execute" 100 0.0 "2026-04-06T10:30:00Z") with Trajectory.ts = 1743939000.0 };
+    { (mk_entry "tool_execute" 100 "2026-04-06T10:05:00Z") with Trajectory.ts = 1743937500.0 };
+    { (mk_entry ~error:(Some "fail") "tool_execute" 100 "2026-04-06T10:30:00Z") with Trajectory.ts = 1743939000.0 };
   ] in
   let timeline = Trajectory.hourly_timeline entries in
   let b = List.hd timeline in
@@ -356,7 +334,6 @@ let test_tool_stat_json_roundtrip () =
     avg_duration_ms = 150;
     p95_duration_ms = 500;
     max_duration_ms = 800;
-    total_cost_usd = 0.01;
     last_used_at = "2026-04-06T12:00:00Z";
   } in
   let json = Trajectory.tool_stat_to_json stat in
@@ -390,7 +367,6 @@ let test_entry_to_json_includes_contract_and_radius () =
     result = Some "/tmp/work";
     duration_ms = 25;
     error = None;
-    cost_usd = 0.0001;
     execution_id = Some "exec-1000-0001";
   } in
   let runtime_contract =
@@ -431,7 +407,7 @@ let test_execution_id_roundtrip () =
     ts = 1000.0; ts_iso = "2026-06-12T00:00:00Z"; turn = 3; round = 1;
     tool_name = "tool_execute"; args_json = "{}";
     gate_decision = Trajectory.Pass;
-    result = Some "ok"; duration_ms = 10; error = None; cost_usd = 0.0;
+    result = Some "ok"; duration_ms = 10; error = None;
     execution_id = Some "exec-1718150400000-0001";
   } in
   (match Trajectory.tool_call_entry_of_json (Trajectory.entry_to_json entry) with
@@ -501,7 +477,7 @@ let test_read_entries_since () =
     Fs_compat.mkdir_p traj_dir;
     let path = Filename.concat traj_dir "trace-100.jsonl" in
     let entry_json ts = Printf.sprintf
-      {|{"ts":%.1f,"ts_iso":"2026-04-06T10:00:00Z","turn":1,"round":0,"tool_name":"tool_execute","args":{},"result":"ok","duration_ms":100,"error":null,"cost_usd":0.001}|}
+      {|{"ts":%.1f,"ts_iso":"2026-04-06T10:00:00Z","turn":1,"round":0,"tool_name":"tool_execute","args":{},"result":"ok","duration_ms":100,"error":null}|}
       ts
     in
     let oc = open_out path in
@@ -525,9 +501,9 @@ let test_read_entries_since_result_parses_gate_summary () =
     let path = Filename.concat traj_dir "trace-101.jsonl" in
     let rows =
       [
-        {|{"ts":1000.0,"ts_iso":"2026-04-06T10:00:00Z","turn":1,"round":1,"tool_name":"tool_execute","args":{},"gate":{"status":"pass"},"result":"ok","duration_ms":100,"error":null,"cost_usd":0.001}|};
-        {|{"ts":2000.0,"ts_iso":"2026-04-06T10:01:00Z","turn":1,"round":2,"tool_name":"tool_execute","args":{},"gate":{"status":"reject","reason":"blocked"},"result":null,"duration_ms":0,"error":"blocked","cost_usd":0.0}|};
-        {|{"ts":3000.0,"ts_iso":"2026-04-06T10:02:00Z","turn":1,"round":3,"tool_name":"tool_execute","args":{},"result":"legacy","duration_ms":10,"error":null,"cost_usd":0.001}|};
+        {|{"ts":1000.0,"ts_iso":"2026-04-06T10:00:00Z","turn":1,"round":1,"tool_name":"tool_execute","args":{},"gate":{"status":"pass"},"result":"ok","duration_ms":100,"error":null}|};
+        {|{"ts":2000.0,"ts_iso":"2026-04-06T10:01:00Z","turn":1,"round":2,"tool_name":"tool_execute","args":{},"gate":{"status":"reject","reason":"blocked"},"result":null,"duration_ms":0,"error":"blocked"}|};
+        {|{"ts":3000.0,"ts_iso":"2026-04-06T10:02:00Z","turn":1,"round":3,"tool_name":"tool_execute","args":{},"result":"legacy","duration_ms":10,"error":null}|};
       ]
     in
     let oc = open_out path in
@@ -576,7 +552,7 @@ let test_read_recent_lines_skips_malformed_rows () =
         ~generation:0 ()
     in
     Trajectory.record_entry acc
-      (mk_entry "tool_execute" 10 0.0 "2026-07-01T00:00:00Z");
+      (mk_entry "tool_execute" 10 "2026-07-01T00:00:00Z");
     Trajectory.flush_pending acc;
     write_raw_line ~masc_root:dir ~keeper_name:"test-keeper"
       ~trace_id:"trace-malformed" "{not valid json";
@@ -603,8 +579,8 @@ let test_read_recent_lines_skips_malformed_rows () =
 let test_summary_row_not_counted_as_malformed () =
   let lines =
     [
-      {|{"ts":1000.0,"ts_iso":"2026-07-01T00:00:00Z","turn":1,"round":0,"tool_name":"tool_execute","args":{},"result":"ok","duration_ms":10,"error":null,"cost_usd":0.0}|}
-    ; {|{"type":"trajectory_summary","keeper_name":"k","trace_id":"t","generation":0,"total_cost_usd":0.0,"total_turns":0,"total_tool_calls":0,"outcome":{"status":"completed"},"task_id":null,"started_at":0.0,"ended_at":0.0}|}
+      {|{"ts":1000.0,"ts_iso":"2026-07-01T00:00:00Z","turn":1,"round":0,"tool_name":"tool_execute","args":{},"result":"ok","duration_ms":10,"error":null}|}
+    ; {|{"type":"trajectory_summary","keeper_name":"k","trace_id":"t","generation":0,"total_turns":0,"total_tool_calls":0,"outcome":{"status":"completed"},"task_id":null,"started_at":0.0,"ended_at":0.0}|}
     ; "{not valid json"
     ]
   in
@@ -633,7 +609,6 @@ let next_round_row ~turn ~round : Yojson.Safe.t =
       ("result", `String "ok");
       ("duration_ms", `Int 1);
       ("error", `Null);
-      ("cost_usd", `Float 0.0);
     ]
 
 let next_round_summary_row : Yojson.Safe.t =
@@ -832,7 +807,7 @@ let check_tool_call label expected = function
 let test_dedupe_thinking_lines_uses_structural_key () =
   let tool_call =
     Trajectory.Tool_call
-      (mk_entry ~ts:1000.5 "tool_execute" 20 0.0 "2026-06-29T00:00:00Z")
+      (mk_entry ~ts:1000.5 "tool_execute" 20 "2026-06-29T00:00:00Z")
   in
   let lines =
     [
@@ -923,11 +898,6 @@ let test_persist_response_content_per_turn_full () =
 
 let () =
   Alcotest.run "Trajectory" [
-    ("tool_cost", [
-      Alcotest.test_case "known tool cost" `Quick test_tool_cost_known;
-      Alcotest.test_case "unknown tool cost" `Quick test_tool_cost_unknown;
-      Alcotest.test_case "bash tool cost" `Quick test_tool_cost_bash;
-    ]);
     ("gate_decision", [
       Alcotest.test_case "pass" `Quick test_gate_decision_pass;
       Alcotest.test_case "reject" `Quick test_gate_decision_reject;

--- a/test/test_trajectory_atomicity.ml
+++ b/test/test_trajectory_atomicity.ml
@@ -60,7 +60,6 @@ let make_entry ~tid ~seq : Trajectory.tool_call_entry =
     result = None;
     duration_ms = 0;
     error = None;
-    cost_usd = 0.0;
     execution_id = None;
   }
 


### PR DESCRIPTION
## 문제

`Trajectory.tool_cost_estimate` 는 툴 이름 문자열을 네 개의 지어낸 상수로 매핑한다.

```ocaml
(** Rough per-call cost estimates for keeper tools. *)
let tool_cost_estimate (tool_name : string) : float =
  match tool_name with
  | "masc_board_post" -> 0.002
  | "masc_board_comment" -> 0.001
  | "tool_execute" -> 0.0001
  | "tool_edit_file" | "tool_write_file" -> 0.0001
  | _ -> 0.0
```

`Trajectory.tool_call_entry` 를 만드는 곳은 lib 전체에 **두 곳뿐이고 둘 다 이 함수를 쓴다** (`mcp_server_eio_call_tool.ml:395`, `keeper_hooks_oas.ml:578`). 즉 프로덕션의 모든 trajectory 엔트리 비용이 발명된 값이다. `masc_board_post` 가 왜 `tool_execute` 의 20배인지, 게시가 왜 "MODEL-intensive" 인지 코드에도 주석에도 근거가 없다.

## 이게 어디까지 갔나

발명된 숫자가 합산돼 **달러로 표시된다**. 대시보드 세 패널, 다섯 지점:

| 표시 | 경로 |
|---|---|
| 도구 텔레메트리 패널의 비용 칩 | `tool_stat.total_cost_usd` → `keeper-tool-telemetry.ts:234,259` |
| journey 턴별 `cost $X` | `JourneyWaterfallTurn.totalCostUsd` → `journey-panel.ts:358` |
| journey 요약 `cost` MetricCell | `JourneyWaterfallSummary.totalCostUsd` → `journey-panel.ts:410` |
| journey 항목별 비용 | `entry.costUsd` → `journey-panel.ts:299` |
| 세션 트레이스 요약 달러의 tool_call 몫 | `session-trace-state.ts` `case 'tool_call'` 누적 |

MASC 에는 **진짜 비용 채널이 이미 있다**. `trajectory.ml` 의 주석이 그 사실을 적어두고도 추정기를 남겨뒀다:

> `model_token_pricing` and `estimate_turn_cost` removed (#3029). Pricing belongs to OAS runtime, not MASC. MASC records `cost_usd` from OAS responses via `emit_cost_event`.

실제 원장은 `keeper_hooks_oas.ml` 의 `Keeper_hooks_oas_cost_events` 로, `#10318` 이 `float option` + 출처 귀속(`computed` / `oas_cost_unreported` / `cost_source_unmetered_provider`)까지 붙여 자기 서술적으로 만들었다. 발명된 상수 채널은 그 옆에 나란히 살아 있었다.

## 무엇을 남겼나 (경계)

OAS 가 보고한 비용은 **전부 그대로 둔다**. 경계는 타입으로 확인했다 — `oas-runtime-store.ts:294` 가 OAS 런타임 이벤트의 kind 를 `'lifecycle' | 'oas_tool' | 'oas_turn' | 'oas_context'` 로 한정한다. `'tool_call'` 은 그 목록에 없고, trajectory 매핑(`session-trace-state.ts`)에서만 생성된다.

따라서:

- **남음**: 세션 트레이스 요약의 `$X` 표시와 `case 'lifecycle'` 누적, 항목별 `비용:` 표시, `UnifiedTraceEvent.cost_usd`, `dashboard-keeper-cost.ts` 원장 API, keeper 런타임 usage 의 `total_cost_usd`. 이들은 OAS 실측이다.
- **삭제**: `case 'tool_call'` 누적과 trajectory → trace 매핑의 `cost_usd`, 그리고 위 표의 나머지 전부.

`tool_agent_timeline.ml` 의 자체 합계(이벤트 detail 에서 `cost_usd` 를 읽음)와 `tui_decode` 의 `k_total_cost_usd`(keeper 런타임 usage 출처)는 다른 채널이라 건드리지 않았다.

## 삭제 범위

OCaml — `Trajectory` 에서 `tool_cost_estimate`, `tool_call_entry.cost_usd`, `trajectory.total_cost_usd`, `tool_stat.total_cost_usd`, 누산기의 `total_cost` 및 JSON 직렬화/역직렬화. 생산자 2곳과 테스트 3개 파일.

TypeScript — `ToolStat.total_cost_usd`, `TrajectoryEntry.cost_usd`, `JourneyWaterfallEntry.costUsd` 와 두 개의 `totalCostUsd`, 그리고 대응하는 렌더링.

## 검증

- `dune build @check` 통과. 필드를 지운 뒤 컴파일러가 의존 지점을 전수 열거했고 전부 처리했다.
- `test_trajectory` 43건, `test_trajectory_atomicity` 1건, `test_gate_keeper_backend` 103건 통과.
- `npm run typecheck` 통과, 대시보드 테스트 통과.
- `session-trace-state.test.ts` 의 "counts tool_call events and accumulates cost" 는 발명된 경로를 단언하고 있었다. 새 계약을 고정하도록 고쳤다 — tool_call 은 세지되 달러 합계는 OAS 이벤트에서만 온다. lifecycle 비용 누적을 단언하는 옆 테스트는 그대로 통과한다.

순감 141 삭제 / 40 추가.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
