### PR TITLE
fix(path-ssot): 앵커 없는 allowlist 한 줄이 가리고 있던 RFC-0121 위반을 드러낸다

### DIFF
--- a/.ci/path-ssot-allowlist.txt
+++ b/.ci/path-ssot-allowlist.txt
@@ -21,17 +21,12 @@ lib/ide/ide_paths.ml
 
 # Audit-only Leak-11 detector for pre-fix orphan egress files
 # (keeper_egress_audit.ml, RFC commit 2026-04-27).
-lib/keeper/keeper_egress_audit.ml:54
 
 # default_local_path / repositories.toml local_path TOML default value
 # is cwd/base-path-relative by on-disk design (RFC-0121 §6 deferred).
-let default_local_path id = Filename.concat ".masc/repos" id
-Option.value ~default:(Filename.concat ".masc/repos" id)
 
 # Config_dir_resolver is the SSOT itself; these comment examples document the
 # bypass pattern the audit forbids outside this module.
-helpers instead of [Filename.concat base_path ".masc/..."] string-literal
-Layout SSOT: callers stop computing [Filename.concat base_path ".masc/X"]
 
 # Self-reference inside the audit script and RFC text.
 scripts/audit-path-ssot.sh
@@ -44,13 +39,10 @@ docs/rfc/RFC-0121-config-dir-resolution-single-active-root.md
 # shrink to zero once #16084 .. #16099 are all in main.
 #
 # PR-2 #16096 (repo_manager triangle):
-lib/repo_manager/credential_store.ml:6
 lib/repo_manager/repo_store.ml:6
 lib/repo_manager/keeper_repo_mapping.ml:8
-lib/auth_resolve.ml:63
 #
 # PR-3 #16097 (host_config + server + shutdown):
 lib/host_config/host_config.ml:173
 lib/host_config/host_config.ml:174
-lib/server/server_routes_http_routes_credentials.ml:111
 lib/shutdown_hooks.ml:138

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -959,6 +959,13 @@ jobs:
             @test/runtest-test_gate_connector_observability \
             @test/runtest-test_discord_observability
 
+      - name: Run repos relative-path suite
+        # The stored default must stay relative: Repo_store.local_path concats
+        # it onto the base path, so an absolute value resolves twice.
+        run: |
+          opam exec -- dune build --root . \
+            @test/runtest-test_repos_relative_path
+
       - name: Run keeper lane launch-order AST suite
         # Asserts on lib/keeper sources through Ast_grep, so @check cannot run
         # it. It sat outside every target list while one of its counts was

--- a/lib/config_dir_resolver/config_dir_resolver.ml
+++ b/lib/config_dir_resolver/config_dir_resolver.ml
@@ -536,8 +536,15 @@ let credentials_dir ~base_path =
 let agent_runtime_dir ~base_path =
   Filename.concat (masc_root ~base_path) "runtime/agent"
 
-let repos_dir ~base_path =
-  Filename.concat (masc_root ~base_path) "repos"
+let repos_dirname = "repos"
+
+let repos_dir ~base_path = Filename.concat (masc_root ~base_path) repos_dirname
+
+(* Base-path-relative, because Repo_manager stores repository.local_path
+   relative and resolves it later: Repo_store.local_path does
+   [Filename.concat base_path repo.local_path]. An absolute [repos_dir] would
+   be resolved a second time. *)
+let repos_relative_path ~id = Filename.concat (Filename.concat Common.masc_dirname repos_dirname) id
 
 let tmp_dir ~base_path =
   Filename.concat (masc_root ~base_path) "tmp"

--- a/lib/config_dir_resolver/config_dir_resolver.mli
+++ b/lib/config_dir_resolver/config_dir_resolver.mli
@@ -142,6 +142,16 @@ val agent_runtime_dir : base_path:string -> string
 val repos_dir : base_path:string -> string
 (** [<base_path>/.masc/repos/]. Managed repository checkouts. *)
 
+val repos_relative_path : id:string -> string
+(** [".masc/repos/<id>"], relative to the base path.
+
+    [Repo_manager_types.repository.local_path] is stored relative and resolved
+    by [Repo_store.local_path], which concats it onto the base path. A caller
+    that needs that default must not use {!repos_dir}: the result would be
+    resolved twice. Before this existed the HTTP repository constructor built
+    the literal inline, and the RFC-0121 audit did not see it because an
+    unanchored allowlist entry suppressed the pattern repo-wide. *)
+
 val tmp_dir : base_path:string -> string
 (** [<base_path>/.masc/tmp/]. Short-lived process artifacts. *)
 

--- a/lib/server/server_routes_http_routes_repositories.ml
+++ b/lib/server/server_routes_http_routes_repositories.ml
@@ -236,8 +236,11 @@ let parse_repository_json body_str =
                 url;
                 local_path =
                   (* New repository requests may omit the managed checkout
-                     location; the HTTP constructor owns that choice. *)
-                  Option.value ~default:(Filename.concat ".masc/repos" id)
+                     location; the HTTP constructor owns that choice. The
+                     default is base-path-relative because Repo_store.local_path
+                     concats it onto the base path. *)
+                  Option.value
+                    ~default:(Config_dir_resolver.repos_relative_path ~id)
                     raw_local_path;
                 aliases;
                 default_branch = Option.value ~default:"main" raw_default_branch;

--- a/test/dune
+++ b/test/dune
@@ -1649,6 +1649,7 @@
 
 (include stanzas/test_anti_rationalization_empty_reject.inc)
 (include stanzas/test_trailing_slash_rules.inc)
+(include stanzas/test_repos_relative_path.inc)
 (include stanzas/test_metric_zero_cell_declaration.inc)
 (include stanzas/test_verification_authority_tools.inc)
 (include stanzas/test_keeper_registry_admission_no_suspend.inc)

--- a/test/stanzas/test_repos_relative_path.inc
+++ b/test/stanzas/test_repos_relative_path.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_repos_relative_path)
+ (modules test_repos_relative_path)
+ (libraries alcotest masc.config_dir_resolver))

--- a/test/test_repos_relative_path.ml
+++ b/test/test_repos_relative_path.ml
@@ -1,0 +1,64 @@
+(** [repos_relative_path] must stay relative, and resolve to [repos_dir].
+
+    [Repo_manager_types.repository.local_path] is stored relative:
+    [Repo_store.local_path ~base_path repo] returns
+    [Filename.concat base_path repo.local_path]. So the default the HTTP
+    repository constructor writes into that field has to be relative too —
+    handing it {!Config_dir_resolver.repos_dir}, which is absolute, would
+    resolve the base path twice.
+
+    The constructor used to build ".masc/repos/<id>" inline. The RFC-0121
+    audit did not report it: .ci/path-ssot-allowlist.txt carried the pattern
+    as an entry with no file anchor, and the audit matches allowlist lines as
+    substrings of the whole rg output line, so that one suppressed the pattern
+    everywhere it appeared. *)
+
+open Alcotest
+
+let test_is_relative () =
+  let path = Config_dir_resolver.repos_relative_path ~id:"repo-1" in
+  check string "the stored default" ".masc/repos/repo-1" path;
+  check bool "not absolute" false (Filename.is_relative path = false)
+;;
+
+(* The property that matters: resolving it once lands on the managed checkout
+   directory. Swapping in the absolute accessor breaks this, which is the
+   mistake the relative form exists to prevent. *)
+let test_resolves_onto_repos_dir () =
+  let base_path = "/srv/masc-base" in
+  let id = "repo-1" in
+  check
+    string
+    "base_path + relative default == repos_dir + id"
+    (Filename.concat (Config_dir_resolver.repos_dir ~base_path) id)
+    (Filename.concat base_path (Config_dir_resolver.repos_relative_path ~id))
+;;
+
+(* The directory segment is named once. If repos_dir stopped agreeing with the
+   relative form, a reader and a writer would disagree about where checkouts
+   live. *)
+let test_one_directory_name () =
+  let base_path = "/srv/masc-base" in
+  check
+    bool
+    "the relative form is a suffix of the absolute one"
+    true
+    (let absolute = Config_dir_resolver.repos_dir ~base_path in
+     let relative = Config_dir_resolver.repos_relative_path ~id:"x" in
+     let parent = Filename.dirname relative in
+     String.length absolute >= String.length parent
+     && String.equal
+          (String.sub absolute (String.length absolute - String.length parent) (String.length parent))
+          parent)
+;;
+
+let () =
+  run
+    "repos relative path"
+    [ ( "config_dir_resolver"
+      , [ test_case "stays relative" `Quick test_is_relative
+        ; test_case "resolves onto repos_dir" `Quick test_resolves_onto_repos_dir
+        ; test_case "one directory name" `Quick test_one_directory_name
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 문제 — allowlist 한 줄이 게이트를 통과시키고 있었다

`.ci/path-ssot-allowlist.txt` 는 자기 형식을 `<file>:<rg-match-substring>` 로 문서화하고 이렇게 경고한다:

> Use the most specific substring you can — **overly broad entries mask real regressions.**

그런데 파일 부분이 없는 항목이 있었다:

```
Option.value ~default:(Filename.concat ".masc/repos" id)
```

`audit-path-ssot.sh:43` 는 allowlist 를 `grep -vFf` 로 **출력 줄 전체(`path:lineno:text`)에 대한 고정 문자열**로 매칭한다. 경로가 없는 줄은 그 코드 패턴을 **어디에 있든 억제한다.**

그 한 줄만 지우고 돌리면 게이트가 빨개진다:

```
=== [FAIL] lib resolver-bypass (inline .masc/<sub> concat) ===
lib/server/server_routes_http_routes_repositories.ml:240:
   Option.value ~default:(Filename.concat ".masc/repos" id)
```

## 그 사이트는 의도는 맞고 도구가 없었다

`repository.local_path` 는 **상대 경로로 저장**되고 `Repo_store.local_path` 가 나중에 해석한다:

```ocaml
let local_path ~base_path repo = Filename.concat base_path repo.local_path
```

그래서 `Config_dir_resolver.repos_dir`(절대)를 쓰면 **base_path 가 두 번 붙는다.** 상대 접근자가 없어서 리터럴을 직접 적은 것이다.

`Config_dir_resolver.repos_relative_path ~id` 를 추가했다. 겸사 `repos_dir` 도 `"repos"` 리터럴을 반복하지 않고 `repos_dirname` 을 부른다.

## allowlist 정리

| 제거 | 건수 | |
|---|---|---|
| 파일 앵커 없음 | 2 | 하나는 위 억제, 하나는 `#` 를 잃은 주석 |
| 삭제된 파일 지목 | 4 | `keeper_egress_audit`, `repo_manager/credential_store`, `auth_resolve`, `server_routes_http_routes_credentials` |

16줄 → 8줄, 전부 존재하는 파일에 앵커됐다.

## 검증

```
dune build @check          clean
audit-path-ssot            OK (0 violations)
test_repos_relative_path   3/3 (신규, CI 배선)
determinism / telemetry-coverage   rc=0
```

결함 주입 (접근자를 절대 경로로):
```
[FAIL] stays relative.
[FAIL] resolves onto repos_dir.
```

핵심 단언은 두 번째다 — **`base_path + 상대경로 == repos_dir + id`**. 절대 접근자를 잘못 끼우면 깨진다.

## 어떻게 찾았나

배선된 가드들의 baseline/allowlist 파일을 전수로 훑으며 (a) 존재하지 않는 파일을 지목하는 항목, (b) 형식을 벗어난 항목을 셌다. `path-ssot-allowlist` 가 16개 중 6개가 죽어 있었고, 그중 하나가 실제로 위반을 가리고 있었다.

`ci/logging-consistency-allowlist.txt` 도 16개 중 1개(`bin/trace_to_tla.ml`)가 죽어 있다 — 그쪽은 게이트 자체가 미배선이라 #27184 에서 다룬다.

Refs RFC-0121

커밋 `85856f8319`, base `a89edc2400`.
