### PR TITLE
refactor(dashboard): drop the invented readiness score, show the status

### DIFF
--- a/dashboard/src/components/fleet-telemetry-panel.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.test.ts
@@ -119,7 +119,6 @@ const namespaceTruthResponse: DashboardNamespaceTruthResponse = {
   },
   readiness: {
     status: 'warn',
-    score: 0.67,
     decision_required_count: 1,
     blocking_count: 2,
     pillars: [
@@ -127,7 +126,6 @@ const namespaceTruthResponse: DashboardNamespaceTruthResponse = {
         key: 'execution_safety',
         label: 'Execution Safety',
         status: 'ok',
-        score: 1,
         summary: 'Sandbox and approval posture are visible.',
         blocking_reasons: [],
         metrics: { keeper_count: 2 },
@@ -136,7 +134,6 @@ const namespaceTruthResponse: DashboardNamespaceTruthResponse = {
         key: 'autonomy_reliability',
         label: 'Autonomy Reliability',
         status: 'warn',
-        score: 0.5,
         summary: 'One keeper is asking for intervention.',
         blocking_reasons: ['1 keeper has a pending Gate request.'],
         metrics: { decision_required: 1 },
@@ -919,7 +916,6 @@ describe('FleetTelemetryPanel', () => {
       attention_events: [],
       readiness: {
         ...namespaceTruthResponse.readiness!,
-        score: 0.9,
         status: 'ok',
       },
     })

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -183,7 +183,7 @@ function ReadinessPillarCard({ pillar }: { pillar: DashboardReadinessPillar }) {
       <div class="flex items-center justify-between gap-3">
         <div class="text-2xs font-medium text-[var(--text)]">${pillar.label}</div>
         <div class="font-mono text-2xs ${readinessStatusClass(pillar.status)}">
-          ${pillar.score.toFixed(2)}
+          ${pillar.status}
         </div>
       </div>
       <div class="mt-1 text-3xs ${readinessStatusClass(pillar.status)}">${pillar.summary}</div>
@@ -252,7 +252,7 @@ function ControlWorkspacePanel({ state }: { state: FleetTelemetryState }) {
       <div class="grid grid-cols-1 gap-3 xl:grid-cols-4">
         <${SummaryCard}
           title="준비 상태"
-          value=${readiness.score.toFixed(2)}
+          value=${readiness.status}
           detail=${`차단 ${readiness.blocking_count} · 결정 필요 ${readiness.decision_required_count}.`}
           tone=${readinessTone(readiness.status)}
         />

--- a/dashboard/src/namespace-truth-normalizers.test.ts
+++ b/dashboard/src/namespace-truth-normalizers.test.ts
@@ -323,7 +323,6 @@ describe('normalizeNamespaceTruth', () => {
     const result = normalizeNamespaceTruth({
       readiness: {
         status: 'warn',
-        score: 0.61,
         decision_required_count: 2,
         blocking_count: 3,
         pillars: [
@@ -331,7 +330,6 @@ describe('normalizeNamespaceTruth', () => {
             key: 'execution_safety',
             label: 'Execution Safety',
             status: 'ok',
-            score: 1,
             summary: 'Sandbox posture is visible.',
             blocking_reasons: [],
             metrics: { keeper_count: 4 },
@@ -340,7 +338,6 @@ describe('normalizeNamespaceTruth', () => {
             key: 'goal_coherence',
             label: 'Goal Coherence',
             status: 'warn',
-            score: 0.25,
             summary: 'One keeper is unscoped.',
             blocking_reasons: ['1 keeper has no active goal link.'],
             metrics: { unscoped_keepers: 1 },
@@ -362,7 +359,6 @@ describe('normalizeNamespaceTruth', () => {
 
     expect(result.readiness).not.toBeNull()
     expect(result.readiness!.status).toBe('warn')
-    expect(result.readiness!.score).toBe(0.61)
     expect(result.readiness!.decision_required_count).toBe(2)
     expect(result.readiness!.pillars).toHaveLength(2)
     expect(result.readiness!.pillars[1]!.blocking_reasons).toEqual(['1 keeper has no active goal link.'])

--- a/dashboard/src/namespace-truth-normalizers.ts
+++ b/dashboard/src/namespace-truth-normalizers.ts
@@ -51,13 +51,11 @@ function normalizeReadinessPillar(raw: unknown): DashboardReadinessPillar | null
   const label = asString(raw.label)
   const status = asString(raw.status)
   const summary = asString(raw.summary)
-  const score = asNumber(raw.score)
-  if (!key || !label || !status || !summary || score == null) return null
+  if (!key || !label || !status || !summary) return null
   return {
     key,
     label,
     status,
-    score,
     summary,
     blocking_reasons: asStringArray(raw.blocking_reasons),
     metrics: isRecord(raw.metrics)
@@ -76,11 +74,9 @@ function normalizeReadinessPillar(raw: unknown): DashboardReadinessPillar | null
 function normalizeReadiness(raw: unknown): DashboardReadinessSummary | null {
   if (!isRecord(raw)) return null
   const status = asString(raw.status)
-  const score = asNumber(raw.score)
-  if (!status || score == null) return null
+  if (!status) return null
   return {
     status,
-    score,
     decision_required_count: asNumber(raw.decision_required_count) ?? 0,
     blocking_count: asNumber(raw.blocking_count) ?? 0,
     pillars: extractArray(raw.pillars)

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -374,7 +374,6 @@ export interface DashboardReadinessPillar {
   key: string
   label: string
   status: 'ok' | 'warn' | 'bad' | string
-  score: number
   summary: string
   blocking_reasons: string[]
   metrics?: Record<string, number>
@@ -382,7 +381,6 @@ export interface DashboardReadinessPillar {
 
 export interface DashboardReadinessSummary {
   status: 'ok' | 'warn' | 'bad' | string
-  score: number
   decision_required_count: number
   blocking_count: number
   pillars: DashboardReadinessPillar[]

--- a/lib/server/server_dashboard_http_namespace_truth_support.ml
+++ b/lib/server/server_dashboard_http_namespace_truth_support.ml
@@ -231,11 +231,6 @@ let task_is_active task =
   | Some ("todo" | "claimed" | "in_progress" | "awaiting_verification") -> true
   | _ -> false
 
-let readiness_score_of_status = function
-  | "bad" -> 40
-  | "warn" -> 72
-  | _ -> 100
-
 let summary_of_reasons ~ok_message reasons =
   match reasons with
   | [] -> ok_message
@@ -245,13 +240,11 @@ let metrics_json entries =
   `Assoc (List.map (fun (key, value) -> (key, `Int value)) entries)
 
 let readiness_pillar_json ~key ~label ~status ~ok_message ~reasons ~metrics =
-  let score = readiness_score_of_status status in
   `Assoc
     [
       ("key", `String key);
       ("label", `String label);
       ("status", `String status);
-      ("score", `Int score);
       ("summary", `String (summary_of_reasons ~ok_message reasons));
       ("blocking_reasons", `List (List.map (fun reason -> `String reason) reasons));
       ("metrics", metrics_json metrics);
@@ -478,15 +471,6 @@ let derive_readiness_and_attention ~execution_json ~execution_summary
     then "warn"
     else "ok"
   in
-  let overall_score =
-    match pillars with
-    | [] -> 100
-    | _ ->
-        List.fold_left
-          (fun acc pillar -> acc + json_int_field "score" pillar ~default:100)
-          0 pillars
-        / List.length pillars
-  in
   let blocking_count =
     pending_visible + runtime_blocker_count + unassigned_active_tasks
     + missing_audit_live_count
@@ -546,7 +530,6 @@ let derive_readiness_and_attention ~execution_json ~execution_summary
   ( `Assoc
       [
         ("status", `String overall_status);
-        ("score", `Int overall_score);
         ("decision_required_count", `Int pending_visible);
         ("blocking_count", `Int blocking_count);
         ("pillars", `List pillars);


### PR DESCRIPTION
## 문제

fleet 준비 상태 패널이 표시하는 점수는 상태 문자열을 지어낸 숫자로 바꾼 것이다.

```ocaml
let readiness_score_of_status = function
  | "bad" -> 40
  | "warn" -> 72
  | _ -> 100
```

40 과 72 의 출처는 코드에도 주석에도 없다. 그리고 이 값은 같은 JSON 객체 안에서 `status` 바로 옆에 실린다 — `status` 가 이미 가진 정보를 숫자로 다시 쓴 것이라 새로 알려주는 것이 없다.

`_ -> 100` 은 **모르는 상태를 만점으로 승격**한다. CLAUDE.md "AI 코드 생성 안티패턴 #2 — Unknown → Permissive Default" 이고, 방향이 위험한 쪽이다.

## 어떻게 커졌나

`overall_score` 는 pillar 점수들의 평균인데, **방금 만든 JSON 에서 `"score"` 를 도로 파싱해서** 계산한다.

```ocaml
let overall_score =
  match pillars with
  | [] -> 100
  | _ ->
      List.fold_left
        (fun acc pillar -> acc + json_int_field "score" pillar ~default:100)
        0 pillars
      / List.length pillars
```

- 타입이 있는 값을 두고 JSON 왕복을 한다.
- `~default:100` 으로 permissive default 가 한 겹 더 붙는다.
- pillar 가 없으면 `[] -> 100` — 근거가 0건이면 만점이다.
- 정수 나눗셈 결과가 `fleet-telemetry-panel.ts` 에서 `.toFixed(2)` 로 렌더링된다. 값이 40/72/100 셋뿐인데 소수점 두 자리로 없는 정밀도를 가장한다.

## 스케일조차 어긋나 있었다

대시보드 테스트 픽스처는 이 값을 **0~1 비율**로 알고 있다.

```ts
// fleet-telemetry-panel.test.ts
status: 'ok',   score: 1,
status: 'warn', score: 0.5,
// namespace-truth-normalizers.test.ts
expect(result.readiness!.score).toBe(0.61)
```

서버는 40 / 72 / 100 을 보낸다. 생산자와 소비자가 스케일 자체를 다르게 알고 있었고 아무도 눈치채지 못했다 — 숫자가 무의미하니 틀려도 티가 나지 않는다.

## 무엇으로 대체하나

`overall_status` 는 pillar 상태에서 직접 계산된다 (하나라도 `bad` 면 `bad`, `warn` 이 있으면 `warn`, 아니면 `ok`). 정보를 보존하는 집계이고 점수 없이 성립한다.

표시는 점수 대신 상태를 낸다. `readinessStatusClass(pillar.status)` / `readinessTone(readiness.status)` 가 이미 색을 결정하고 있었으므로 색은 그대로다.

- pillar 카드: `${pillar.score.toFixed(2)}` → `${pillar.status}`
- 요약 카드 "준비 상태": `value=${readiness.score.toFixed(2)}` → `value=${readiness.status}`

`"70.00"` 은 어느 pillar 가 나쁜지 말해주지 않는다. `"bad"` 는 말해준다. 패널의 나머지 정보(각 pillar 의 `summary`, `blocking_reasons`, `blocking_count`, `decision_required_count`)는 모두 실제 조건에서 세는 값이라 그대로 둔다.

## 파급력

TypeScript 쪽 normalizer 는 `score` 가 없으면 **객체 전체를 버린다** (`if (!key || ... || score == null) return null`). 서버만 고치면 대시보드가 pillar 를 전부 드롭한다. 그래서 양쪽을 같은 PR 로 바꾼다.

`score` 라는 이름은 board 투표 점수, eval calibration 등 다른 모듈에도 있다. 이 PR 이 건드리는 것은 `server_dashboard_http_namespace_truth_support.ml` 의 readiness pillar 계열뿐이다.

## 검증

- `dune build @check` 통과, `test_dashboard_namespace_truth` 12건 통과.
- `npm run typecheck` 통과, `fleet-telemetry-panel` + `namespace-truth-normalizers` 47건 통과.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
