### PR TITLE
refactor(dashboard): delete the unreferenced severity_rank duplicate

### DIFF
--- a/lib/dashboard/dashboard_execution_helpers.ml
+++ b/lib/dashboard/dashboard_execution_helpers.ml
@@ -59,14 +59,6 @@ let cap_string_list ?(limit = execution_tool_preview_limit) values =
 
 let dedup_strings = Dashboard_utils.dedup_strings
 
-(** severity_rank works on raw JSON strings — broader matching than Dashboard_utils.tone_rank.
-    Used by dashboard_briefing / dashboard_briefing_assembly for external JSON data. *)
-let severity_rank = function
-  | "bad" | "critical" | "failed" -> 2
-  | "warn" | "blocked" | "paused" | "interrupted" -> 1
-  | _ -> 0
-
-
 let dashboard_fixture_name ?fixture () =
   let fixtures_enabled = Env_config.Dashboard_config.fixtures_enabled () in
   if not fixtures_enabled then None

--- a/lib/dashboard/dashboard_execution_helpers.mli
+++ b/lib/dashboard/dashboard_execution_helpers.mli
@@ -100,7 +100,6 @@ val take : int -> 'a list -> 'a list
 val latest_iso_timestamp : string option list -> string option
 val compact_text : ?max_len:int -> string -> string
 val dedup_strings : string list -> string list
-val severity_rank : string -> int
 val dashboard_fixture_name : ?fixture:string -> unit -> string option
 val execution_tool_preview_limit : int
 val cap_string_list : ?limit:int -> string list -> string list


### PR DESCRIPTION
## 무엇

`Dashboard_execution_helpers.severity_rank` 를 지운다. 호출자가 없다.

```ocaml
(** severity_rank works on raw JSON strings — broader matching than Dashboard_utils.tone_rank.
    Used by dashboard_briefing / dashboard_briefing_assembly for external JSON data. *)
let severity_rank = function
  | "bad" | "critical" | "failed" -> 2
  | "warn" | "blocked" | "paused" | "interrupted" -> 1
  | _ -> 0
```

## 주석이 두 가지를 틀렸다

**"Used by dashboard_briefing / dashboard_briefing_assembly"** — 아니다. 두 파일 모두 `include Dashboard_utils` 로 시작한다 (`dashboard_briefing.ml:1`, `dashboard_briefing_agents.ml:6` → `dashboard_briefing_assembly.ml:9` 가 그것을 include). 그래서 그 파일들의 `severity_rank` 호출 5곳은 전부 **`Dashboard_utils.severity_rank`** 로 해석된다. 이름이 같아서 주석이 맞아 보였을 뿐이다.

**"broader matching than Dashboard_utils.tone_rank"** — `tone_rank : tone -> int` 는 `tone` 타입에 대한 함수라 문자열 매칭과 비교 대상이 아니다. 그리고 실제 이름이 겹치는 `Dashboard_utils.severity_rank` 와 비교하면 더 넓지도 않다. 서로 빠진 값이 다를 뿐이다.

| | `Dashboard_utils.severity_rank` | 이 함수 |
|---|---|---|
| → 2 | `bad` `risk` `critical` | `bad` `critical` `failed` |
| → 1 | `warn` `watch` `interrupted` `degraded` | `warn` `blocked` `paused` `interrupted` |

## 호출자 0 의 근거

- 한정 호출 `Dashboard_execution_helpers.severity_rank` — lib/ test/ 통틀어 0건.
- 이 모듈을 `include` 하는 세 모듈(`dashboard_execution.ml`, `dashboard_execution_builders.ml`, `dashboard_execution_fixture.ml`)에서 bare `severity_rank` 호출 0건.
- 그 세 모듈을 다시 include 하는 곳은 `dashboard_execution.ml` 뿐이고 거기서도 0건.
- test/ 의 `severity_rank` 호출은 전부 타입 기반 `Operator_digest.severity_rank : operator_severity -> int` 다.
- `.mli` 에서 `val severity_rank` 를 함께 지운 뒤 `dune build @check` 가 통과한다. export 를 지우고도 빌드가 되는 것이 참조 0 의 증명이다.

## 남겨둔 것

`Dashboard_utils.severity_rank` 는 살아 있으므로 건드리지 않는다. 그 표의 `risk` / `watch` 는 현재 어느 생산자도 내보내지 않지만(`` `String "risk" `` / `` `String "watch" `` 각 0건), `_ -> 0` 이라 무해하고, 이 PR 이 주장하는 범위(호출자 0 인 함수 삭제) 밖이다.

살아 있는 경로의 어휘는 실제로 맞는다. `attention_items` 의 생산자는 `operator_digest_types.attention_item_to_yojson` 이고 `operator_severity_to_string` 으로 `critical` / `bad` / `warn` 만 낸다 — 셋 다 올바르게 랭크된다. 이 PR 은 오분류를 고치는 것이 아니라 죽은 중복을 지우는 것이다.

## 검증

`dune build @check` 통과. `test_dashboard_briefing` 7건 통과.

WORKAROUND-WAIVED: 게이트의 STRING_CLASSIFIER 시그니처가 본문에 인용된 분류기 표에 걸린 오탐이다. 시그니처가 겨냥하는 것은 문자열 분류기의 *추가/보강*이고, 이 PR 은 호출자 0 인 분류기를 *삭제*한다 (분류 arm 순증 0, 순감 7줄). 남는 `Dashboard_utils.severity_rank` 에는 arm 을 하나도 더하지 않는다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
