### PR TITLE
fix(dashboard): count the fleet before truncating it

### DIFF
--- a/lib/server/server_dashboard_http_namespace_truth_support.ml
+++ b/lib/server/server_dashboard_http_namespace_truth_support.ml
@@ -128,16 +128,10 @@ let execution_summary_json execution_json =
     | Some (`List items) -> items
     | _ -> []
   in
-  let execution_operation_briefs =
-    json_list_field "operation_briefs" execution_json |> take_n 20
-  in
-  let execution_worker_support =
-    json_list_field "worker_support_briefs" execution_json |> take_n 10
-  in
-  let execution_continuity =
-    json_list_field "continuity_briefs" execution_json |> take_n 10
-  in
-  let execution_keepers = json_list_field "keepers" execution_json |> take_n 20 in
+  let execution_operation_briefs = json_list_field "operation_briefs" execution_json in
+  let execution_worker_support = json_list_field "worker_support_briefs" execution_json in
+  let execution_continuity = json_list_field "continuity_briefs" execution_json in
+  let execution_keepers = json_list_field "keepers" execution_json in
   let has_text key json = json_string_field_opt key json |> Option.is_some in
   (* This summary is always derived here. A pass-through arm used to return an
      upstream [summary] whose [blocked_sessions] count was already an int, but


### PR DESCRIPTION
## 문제

`execution_summary_json` 은 개수만 내보내는 메트릭 블록인데, 그 개수를 세기 전에 목록을 자른다.

```ocaml
let execution_operation_briefs =
  json_list_field "operation_briefs" execution_json |> take_n 20
in
let execution_worker_support =
  json_list_field "worker_support_briefs" execution_json |> take_n 10
in
let execution_continuity =
  json_list_field "continuity_briefs" execution_json |> take_n 10
in
let execution_keepers = json_list_field "keepers" execution_json |> take_n 20 in
```

이 블록이 내보내는 것은 리스트가 아니라 정수 여섯 개다.

| 메트릭 | 캡의 효과 |
|---|---|
| `active_operations` | 21개 이상이면 20 으로 보고 |
| `blocked_operations` | 앞 20개 안에서만 blocker 를 셈 |
| `worker_alerts` | 앞 10개 안에서만 `warn`/`bad` 를 셈 |
| `continuity_alerts` | 앞 10개 안에서만 셈 |
| `keepers` | 21개 이상이면 20 으로 보고 |
| `priority_items` | **캡 없음** — 이것만 참값 |

여섯 중 다섯이 잘리고 하나는 안 잘린다. 대시보드는 이 값들을 `asNumber` 로 그대로 읽어 운영자에게 숫자로 보여준다 (`store-normalizers.ts:173-177`).

## 캡이 아끼는 것이 없다

`json_list_field` 가 이미 리스트를 만든 뒤에 `take_n` 이 붙는다. 페이로드로 나가는 리스트가 없으므로 전송량도 줄지 않고, 개수 계산은 어느 쪽이든 O(n) 이다. 즉 이 캡은 비용을 아끼지 않고 값만 깎는다.

잘린 네 바인딩은 각각 이 블록 안에서만 쓰인다 (`execution_operation_briefs` 3회 = 정의 + 개수 2곳, 나머지 2회 = 정의 + 개수 1곳). 다른 소비자가 없으므로 캡을 걷어도 영향 범위는 이 여섯 숫자뿐이다.

같은 파일의 `take_n 8` / `take_n 10` (라인 544, 554) 은 attention 이벤트 **리스트 자체**를 내보내는 자리라 페이로드 캡으로 정당하다. 건드리지 않는다.

## 검증

`dune build @check` 통과. `test_dashboard_namespace_truth` 12건 통과.

(초안 시점에는 opam 스위치가 레포 선언 핀에서 밀려 있어 로컬 검증이 불가능했다. 스위치를 선언된 핀으로 되돌린 뒤 위 결과를 얻었다. 변경 자체는 `|> take_n N` 제거 네 곳이고 새 심볼을 도입하지 않는다.)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
