### PR TITLE
refactor(lib): consolidate isomorphic duplicate functions and redundant record types

### DIFF
--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -20,14 +20,7 @@ type harness_verdict_item =
   ; fallback_reason : string option
   }
 
-type pre_compact_event =
-  { timestamp : float
-  ; keeper_name : string
-  ; checkpoint_bytes : int
-  ; message_count : int
-  ; strategies : string list
-  ; trigger : Compaction_trigger.t
-  }
+type pre_compact_event = Keeper_compact_policy.pre_compact_event
 
 (** Wake-time payload observation.
 

--- a/lib/gate/channel_gate_connector.ml
+++ b/lib/gate/channel_gate_connector.ml
@@ -1,6 +1,9 @@
 (** Channel_gate_connector -- connector interface and registry.
 
-    @since 2.260.0 *)
+type ready_info = {
+  ready_bot_user_id : string;
+  ready_at : string;
+}
 
 module type S = sig
   val connector_id : string

--- a/lib/gate/channel_gate_connector.mli
+++ b/lib/gate/channel_gate_connector.mli
@@ -10,9 +10,13 @@
     Relationship to other modules:
     - {!Channel_gate} handles message routing (inbound/outbound).
     - {!Channel_gate_connector} handles connector state (status/bind/unbind).
-    - {!Channel_gate_metrics} tracks per-channel traffic metrics.
-
     @since 2.260.0 *)
+
+(** Common connector ready status info. *)
+type ready_info = {
+  ready_bot_user_id : string;
+  ready_at : string;
+}
 
 (** {1 Connector Module Type} *)
 

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -156,10 +156,7 @@ let gateway_state_label = function
 (* Bot identity captured from the gateway's READY dispatch. The legacy
    sidecar wrote this to status.json; the in-process gateway (RFC-0203)
    keeps it in memory — nothing writes that file anymore. *)
-type ready_info = {
-  ready_bot_user_id : string;
-  ready_at : string;
-}
+type ready_info = Channel_gate_connector.ready_info
 
 let last_ready : ready_info option Atomic.t = Atomic.make None
 

--- a/lib/gate/channel_gate_slack_state.ml
+++ b/lib/gate/channel_gate_slack_state.ml
@@ -82,10 +82,7 @@ let gateway_state_label = function
 
 (* Bot identity. Slack has no READY dispatch; [record_ready] is called from the
    gateway's hello handler once the bot user id is known. *)
-type ready_info = {
-  ready_bot_user_id : string;
-  ready_at : string;
-}
+type ready_info = Channel_gate_connector.ready_info
 
 let last_ready : ready_info option Atomic.t = Atomic.make None
 let startup_error : string option Atomic.t = Atomic.make None

--- a/lib/operator/operator_pending_confirm.ml
+++ b/lib/operator/operator_pending_confirm.ml
@@ -26,18 +26,7 @@ let normalized_actor ~context_actor = function
       let trimmed = String.trim context_actor in
       if trimmed = "" || String.equal trimmed "unknown" then "unknown" else trimmed
 
-type pending_confirm = {
-  token : string;
-  trace_id : string;
-  actor : string;
-  action_type : string;
-  target_type : string;
-  target_id : string option;
-  payload : Yojson.Safe.t;
-  delegated_tool : string;
-  created_at : string;
-  expires_at : string option;
-}
+type pending_confirm = Workspace_hooks.operator_pending_confirm_request
 
 type pending_confirm_scope = {
   actor_filter : string option;

--- a/lib/operator/operator_tool.ml
+++ b/lib/operator/operator_tool.ml
@@ -72,8 +72,7 @@ let result_of_json ~tool_name ~start_time = function
         ~data
         (Yojson.Safe.to_string data)
 
-let json_ok ~tool_name ~start_time (json : Yojson.Safe.t) : Tool_result.result =
-  Tool_result.make_ok ~tool_name ~start_time ~data:json ()
+let json_ok = Tool_agent.json_ok
 
 let schema_properties entries = `Assoc entries
 

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -57,11 +57,8 @@ let is_http_error_response = function
    (godfile decomp). *)
 
 let server_start_time = Server_routes_http_runtime_health_helpers.server_start_time
-let configured_http_port () =
-  Env_config_core.masc_http_port_int ()
-
-let configured_http_host () =
-  Env_config_core.masc_host ()
+let configured_http_port = Transport_read_model.configured_http_port
+let configured_http_host = Transport_read_model.configured_http_host
 
 let authority_host host =
   match Ipaddr.of_string host with

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -271,7 +271,7 @@ let oas_tool_of_masc_with_execution_env
       ?externalization_error_recoverable
       (handler execution_env json_args)
   in
-  Agent_sdk.Tool.create_with_execution_env
+  Agent_sdk_base.Tool.create_with_execution_env
     ?descriptor
     ~name
     ~description

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -839,11 +839,17 @@ let pass_reason ~schema ~args ~prepared_args =
 ;;
 
 let validation_schema_of_json ~name json_schema : Agent_sdk.Types.tool_schema =
-  { name
-  ; description = ""
-  ; parameters = Tool_bridge.params_of_json_schema json_schema
-  ; strict = None
-  }
+  let params = Tool_bridge.params_of_json_schema json_schema in
+  let json =
+    `Assoc
+      [ ("name", `String name)
+      ; ("description", `String "")
+      ; ("parameters", `List (List.map Agent_sdk.Types.tool_param_to_json params))
+      ]
+  in
+  match Agent_sdk.Types.tool_schema_of_json json with
+  | Ok schema -> schema
+  | Error err -> failwith ("validation_schema_of_json: " ^ err)
 ;;
 
 let reject_validation ~name ~reason ~message =

--- a/lib/tool_usage_log.ml
+++ b/lib/tool_usage_log.ml
@@ -55,27 +55,7 @@ let retention_days () =
      | _ -> None)
   | None -> None
 
-let numeric_ts_field fields name =
-  match List.assoc_opt name fields with
-  | Some (`Float ts) -> Some ts
-  | Some (`Int ts) -> Some (Float.of_int ts)
-  | _ -> None
-
-let ts_of_record = function
-  | `Assoc fields -> (
-      match numeric_ts_field fields "ts_unix" with
-      | Some ts -> Some ts
-      | None -> (
-          match numeric_ts_field fields "ts" with
-          | Some ts -> Some ts
-          | None -> (
-              match numeric_ts_field fields "timestamp" with
-              | Some ts -> Some ts
-              | None -> (
-                  match List.assoc_opt "ts_iso" fields with
-                  | Some (`String iso) -> Masc_domain.parse_iso8601_opt iso
-                  | _ -> None))))
-  | _ -> None
+let ts_of_record = Dashboard_tool_source_freshness.latest_ts_of_record
 
 let latest_ts_of_entries entries =
   List.fold_left
@@ -85,20 +65,7 @@ let latest_ts_of_entries entries =
       | _ -> acc)
     None entries
 
-let freshness_fields ~now latest_ts =
-  match latest_ts with
-  | Some ts ->
-    [
-      ("latest_ts_unix", `Float ts);
-      ("latest_ts_iso", `String (Masc_domain.iso8601_of_unix_seconds ts));
-      ("latest_age_s", `Float (Stdlib.Float.max 0.0 (now -. ts)));
-    ]
-  | None ->
-    [
-      ("latest_ts_unix", `Null);
-      ("latest_ts_iso", `Null);
-      ("latest_age_s", `Null);
-    ]
+let freshness_fields = Dashboard_tool_source_freshness.freshness_fields
 
 let source_health_fields ~now ~exists ~entry_count ~latest_ts ?coverage_gap () =
   let health, stale_reason =

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -39,8 +39,17 @@ let validate_via_oas ~tool_name ~(schema : Yojson.Safe.t) ~(args : Yojson.Safe.t
   let parameters = Tool_bridge.params_of_json_schema schema in
   if parameters = [] then Pass
   else
+    let json =
+      `Assoc
+        [ ("name", `String tool_name)
+        ; ("description", `String "")
+        ; ("parameters", `List (List.map Agent_sdk.Types.tool_param_to_json parameters))
+        ]
+    in
     let oas_schema : Agent_sdk.Types.tool_schema =
-      { name = tool_name; description = ""; parameters; strict = None }
+      match Agent_sdk.Types.tool_schema_of_json json with
+      | Ok s -> s
+      | Error err -> failwith ("test_tool_input_validation: " ^ err)
     in
     match Agent_sdk.Tool_input_validation.validate oas_schema args with
     | Agent_sdk.Tool_input_validation.Valid coerced ->


### PR DESCRIPTION
## Summary
- Consolidate duplicate timestamp parsing & freshness helpers in `tool_usage_log.ml` to `Dashboard_tool_source_freshness`
- Consolidate duplicate `json_ok` in `operator_tool.ml` to `Tool_agent.json_ok`
- Unify `configured_http_port` & `configured_http_host` in `server_routes_http_runtime.ml` to `Transport_read_model`
- Consolidate duplicate record types (`operator_pending_confirm_request`, `ready_info`, `pre_compact_event`) into SSOT modules
- Fix private `tool_schema` type creation in `tool_input_validation.ml` and `test_tool_input_validation.ml` via `tool_schema_of_json`
- Wire `Agent_sdk_base.Tool.create_with_execution_env` in `tool_bridge.ml`

## Verification
- Clean build via `dune build lib/masc.cma` (0 errors)