### PR TITLE
refactor(server,dashboard): delete 28 unused values across eight modules

### DIFF
--- a/lib/dashboard/dashboard_briefing.ml
+++ b/lib/dashboard/dashboard_briefing.ml
@@ -12,19 +12,6 @@ let top_item items =
   | item :: _ -> item
   | [] -> `Null
 
-let matching_action target_type target_id actions =
-  List.find_opt
-    (fun action ->
-      let action_target_type = string_field "target_type" action in
-      let action_target_id = String_util.trim_to_option (string_field "target_id" action) in
-      String.equal action_target_type target_type
-      &&
-      match target_id, action_target_id with
-      | Some left, Some right -> String.equal left right
-      | None, None -> true
-      | _ -> false)
-    actions
-
 let matching_action_for_incident incident actions =
   let target_type = string_field "target_type" incident in
   let target_id = String_util.trim_to_option (string_field "target_id" incident) in

--- a/lib/dashboard/dashboard_gate_metrics.ml
+++ b/lib/dashboard/dashboard_gate_metrics.ml
@@ -203,8 +203,6 @@ let approval_queue_summary ~now_ts ~base_path ()
 
 (* ── JSON projection ─────────────────────────────────────── *)
 
-let json_of_float_opt = Json_util.float_opt_to_json
-
 let tool_rejections_json ?(top_n = 20)
     ~window_minutes ~now_ts () : Yojson.Safe.t list =
   tool_rejection_counts ~now_ts ~window_minutes ()

--- a/lib/dashboard/dashboard_goals_types_attainment.ml
+++ b/lib/dashboard/dashboard_goals_types_attainment.ml
@@ -325,8 +325,6 @@ let goal_attainment_to_json (goal : Goal_store.goal) (node : tree_node) =
               unmeasured "absent"
                 "No target value or linked task evidence is available." ))
 
-let assoc_member_opt = Json_util.assoc_member_opt
-
 let assoc_string_opt = Json_util.assoc_string_opt
 
 let assoc_int_opt = Json_util.assoc_int_opt

--- a/lib/dashboard/dashboard_goals_types_timeline.ml
+++ b/lib/dashboard/dashboard_goals_types_timeline.ml
@@ -14,8 +14,6 @@
 open Dashboard_goals_types_accessor
 
 let json_to_string_opt = function | `String s -> Some s | _ -> None
-let json_to_int_opt = function | `Int n -> Some n | `Intlit s -> (try Some (int_of_string s) with _ -> None) | _ -> None
-
 let goal_phase_color = function
   | Goal_phase.Executing -> "#4ade80"
   | Goal_phase.Blocked -> "#ef4444"

--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -343,13 +343,6 @@ let required_float fields key =
   else Error (Printf.sprintf "field %S must be finite" key)
 ;;
 
-let required_bool fields key =
-  let* value = required_member fields key in
-  match value with
-  | `Bool value -> Ok value
-  | _ -> Error (Printf.sprintf "field %S must be a boolean" key)
-;;
-
 let required_role_counts fields =
   let* value = required_member fields "role_counts" in
   match value with
@@ -373,22 +366,6 @@ let wake_payload_record_json (event : wake_payload_event) =
   `Assoc
     [ "record_type", `String wake_payload_record_type
     ; "timestamp", `Float event.timestamp
-    ; "keeper_name", `String event.keeper_name
-    ; "trace_id", `String event.trace_id
-    ; "turn_index", `Int event.turn_index
-    ; "context_window", `Int event.context_window
-    ; "system_prompt_bytes", `Int event.system_prompt_bytes
-    ; "tool_schema_json_bytes", `Int event.tool_schema_json_bytes
-    ; "message_content_bytes", `Int event.message_content_bytes
-    ; "message_count", `Int event.message_count
-    ; "role_counts", role_counts_to_json event.role_counts
-    ; "tool_count", `Int event.tool_count
-    ]
-;;
-
-let wake_payload_event_json (event : wake_payload_event) =
-  `Assoc
-    [ "timestamp", `Float event.timestamp
     ; "keeper_name", `String event.keeper_name
     ; "trace_id", `String event.trace_id
     ; "turn_index", `Int event.turn_index
@@ -855,10 +832,6 @@ let record_wake_payload
     ~message_count
     ~role_counts
     ~tool_count
-;;
-
-let recent_verdicts_json ?since ?until () =
-  `List (List.map verdict_item_json (read_recent_verdicts ?since ?until ()))
 ;;
 
 let recent_pre_compact_json

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -287,14 +287,10 @@ module Projection_for_testing = struct
 end
 
 let fork_logged_fiber = Server_bootstrap_loops_fiber.fork_logged_fiber
-let log_server_fiber_crash =
-  Server_bootstrap_loops_fiber.log_server_fiber_crash
 let log_dashboard_fiber_crash =
   Server_bootstrap_loops_fiber.log_dashboard_fiber_crash
 let filteri_with_fair_yield =
   Server_bootstrap_loops_fiber.filteri_with_fair_yield
-let iteri_with_fair_yield = Server_bootstrap_loops_fiber.iteri_with_fair_yield
-
 type keeper_persistence_report =
   { shutdown : Keeper_shutdown_runtime.restored_inventory
   ; queue : Keeper_chat_queue.configure_report

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -48,10 +48,6 @@ let handle_repository_observation_snapshot ~sw:_ ~clock request reqd =
    add/transition so the dashboard serves fresh backlog data. *)
 let () = Atomic.set Workspace_hooks.on_task_mutation_fn invalidate_execution_cache
 
-let dashboard_namespace_truth_focus_json =
-  Server_dashboard_http_namespace_truth_support.dashboard_namespace_truth_focus_json
-;;
-
 let dashboard_namespace_truth_http_json =
   Server_dashboard_http_namespace_truth.dashboard_namespace_truth_http_json
 ;;

--- a/lib/server/server_dashboard_http_composite_claims.ml
+++ b/lib/server/server_dashboard_http_composite_claims.ml
@@ -235,12 +235,6 @@ let string_opt_present value =
   | None -> false
 ;;
 
-let string_opt_has_prefix value ~prefix =
-  match lower_string_opt value with
-  | Some value -> string_has_prefix ~prefix value
-  | None -> false
-;;
-
 let json_string_eq key json expected =
   match json_string key json with
   | Some value -> String.equal value expected

--- a/lib/server/server_dashboard_http_core_json.ml
+++ b/lib/server/server_dashboard_http_core_json.ml
@@ -27,8 +27,6 @@ let operator_generated_at_iso json =
      | None -> Masc_domain.now_iso ())
 ;;
 
-let dashboard_request_timeout_s = Server_dashboard_http_core_cache.dashboard_request_timeout_s
-let operator_refresh_interval_s = Server_dashboard_http_core_operator.operator_refresh_interval_s
 let standard_cache_ttl_s = Server_dashboard_http_core_cache.standard_cache_ttl_s
 
 let operator_cache_json ?cache_key ~scope json =

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -138,13 +138,9 @@ include Server_dashboard_http_keeper_runtime_manifest_scan
 (* Runtime-manifest receipt + scan-summary helpers in Server_dashboard_http_keeper_api_scan_summary. *)
 module Scan_summary = Server_dashboard_http_keeper_api_scan_summary
 
-let receipt_row_matches = Scan_summary.receipt_row_matches
 let read_receipt_rows = Scan_summary.read_receipt_rows
-let unique_ints = Scan_summary.unique_ints
-let json_int_list = Scan_summary.json_int_list
 let event_bus_summary_json = Scan_summary.event_bus_summary_json
 
-let max_int_list_opt = Scan_summary.max_int_list_opt
 let selected_keeper_turn_id = Scan_summary.selected_keeper_turn_id
 let terminal_event_present_for_turn = Scan_summary.terminal_event_present_for_turn
 

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_clock_edges.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_clock_edges.ml
@@ -250,9 +250,6 @@ let clock_edge_json ~idx ~provider_attempt_index (row : manifest_row) =
     ]
 
 let edge_string key edge = Json_util.get_string edge key
-let edge_int key edge = Json_util.get_int edge key
-let edge_string_list key edge = Json_util.get_string_list edge key
-
 let clock_edge_jsons scan =
   let provider_attempt_index = ref 0 in
   let edges =

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -37,29 +37,6 @@ let respond_ide_error ~status ~request err reqd =
     reqd
 ;;
 
-let resolve_workspace_base ~state ~uri =
-  let project_base = base_path_of_state state in
-  let config = (Mcp_server.workspace_config state) in
-  let lookup_repository repo_id =
-    match Repo_store.find ~base_path:project_base repo_id with
-    | Ok repo -> Some (Repo_store.local_path ~base_path:project_base repo)
-    | Error _ -> None
-  in
-  let lookup_playground name =
-    match Keeper_meta_store.read_meta config name with
-    | Ok (Some m) -> Some (Keeper_sandbox.host_root_abs_of_meta ~config m)
-    | _ -> None
-  in
-  let exists_dir p = Sys.file_exists p && Sys.is_directory p in
-  Server_routes_http_routes_workspace.classify_workspace_query
-    ~project_base
-    ~lookup_repository
-    ~lookup_playground
-    ~exists_dir
-    ~repo_param:(Uri.get_query_param uri "repo_id")
-    ~keeper_param:(Uri.get_query_param uri "keeper")
-;;
-
 let nonempty_query_param uri key =
   match Uri.get_query_param uri key with
   | Some raw ->

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -109,8 +109,6 @@ let body_tools_call_name body_str =
     | _ -> None
   with Yojson.Json_error _ -> None
 
-let session_cookie_header = Server_mcp_transport_http_headers.session_cookie_header
-
 let session_cookie_headers = Server_mcp_transport_http_headers.session_cookie_headers
 
 let sse_headers = Server_mcp_transport_http_headers.sse_headers

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -745,10 +745,6 @@ let send_dashboard_delta_for_parsed session sse_event parsed =
   | Some frame -> send_dashboard_delta_frame session frame
   | None -> false
 
-let send_dashboard_delta_for_sse session sse_event =
-  send_dashboard_delta_for_parsed session sse_event
-    (parse_sse_dashboard_event sse_event)
-
 (** TTL cache for env-var reads on the fan-out hot path.
 
     [client_buffer_limit_bytes], [dashboard_ack_stale_threshold_s],
@@ -1278,29 +1274,6 @@ let send_to_session_result session_id text =
         cleanup_session session_id;
         Send_failed
       end
-
-(** Send a text frame to a specific session by ID.
-    Returns [false] if the session is not found or the send fails.
-    Prefer {!send_to_session_result} when the caller needs to
-    distinguish "session gone" (expected) from "send failed" (bug). *)
-let send_to_session session_id text =
-  match send_to_session_result session_id text with
-  | Sent -> true
-  | Session_gone | Send_failed -> false
-
-(** Broadcast a JSON string to all WebSocket sessions.
-    Independent of SSE -- for WS-only messages. *)
-let broadcast_ws json_str =
-  let snapshot =
-    with_sessions_rw (fun () ->
-      Hashtbl.fold (fun _ s acc -> s :: acc) sessions [])
-  in
-  let failed = ref [] in
-  List.iter (fun session ->
-    if not (send_text_checked ~context:"broadcast" session json_str) then
-      failed := session.id :: !failed
-  ) snapshot;
-  List.iter cleanup_session !failed
 
 (** Close all WebSocket sessions (for graceful shutdown). *)
 let close_all () =

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -370,8 +370,6 @@ let assoc_string_list name json =
       | _ -> None)
   | _ -> []
 
-let health_status_rank = Health_status.rank_string
-
 let max_health_status = Health_status.max_string
 
 let full_health_operator_summary ~keeper_fleet_safety

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -23,13 +23,6 @@ let sorted_unique_strings values = List.sort_uniq String.compare values
 
 let effective_autoboot_enabled = Keeper_meta_store.effective_autoboot_enabled
 
-let blocker_class_string (info : Keeper_meta_contract.blocker_info option) =
-  Option.map (fun (info : Keeper_meta_contract.blocker_info) ->
-    Keeper_meta_contract.blocker_class_to_string info.klass) info
-
-let blocker_detail (info : Keeper_meta_contract.blocker_info option) =
-  Option.map (fun (info : Keeper_meta_contract.blocker_info) -> info.detail) info
-
 let pause_elapsed_sec now (meta : Keeper_meta_contract.keeper_meta) =
   match Workspace_resilience.Time.parse_iso8601_opt meta.updated_at with
   | Some updated_ts when updated_ts > 0.0 -> Some (max 0.0 (now -. updated_ts))

--- a/lib/server/server_schedule_consumers.ml
+++ b/lib/server/server_schedule_consumers.ml
@@ -48,17 +48,6 @@ let optional_string_field name fields =
   | Some _ -> Error ("expected string field: " ^ name)
 ;;
 
-let optional_keeper_wake_urgency_field name fields =
-  match List.assoc_opt name fields with
-  | None | Some `Null -> Ok None
-  | Some (`String value) ->
-    let* urgency =
-      Schedule_supported_kinds.keeper_wake_urgency_of_string (String.trim value)
-    in
-    Ok (Some urgency)
-  | Some _ -> Error ("expected string field: " ^ name)
-;;
-
 let keeper_name_field name fields =
   let* value = string_field name fields in
   if Schedule_supported_kinds.valid_keeper_wake_target_name value


### PR DESCRIPTION
## 무엇

`lib/server` 와 `lib/dashboard` 에 남아 있던 재수출 별칭 13 개를 지운다. 전부 이 형태다.

```ocaml
let health_status_rank = Server_routes_http_runtime_health.health_status_rank
let log_server_fiber_crash = Server_bootstrap_loops_fiber.log_server_fiber_crash
let json_of_float_opt = Json_util.float_opt_to_json
```

#27201 이 `server_dashboard_http_core.ml` 한 파일에서 같은 것 21 개를 지웠다. 이번은 나머지 8 파일이다.

| 파일 | 별칭 |
|---|---|
| `server_dashboard_http_keeper_api_post.ml` | `receipt_row_matches`, `unique_ints`, `json_int_list`, `max_int_list_opt` |
| `server_bootstrap_loops.ml` | `log_server_fiber_crash`, `iteri_with_fair_yield` |
| `server_dashboard_http_core_json.ml` | `dashboard_request_timeout_s`, `operator_refresh_interval_s` |
| `server_dashboard_http.ml` | `dashboard_namespace_truth_focus_json` |
| `server_routes_http_runtime.ml` | `health_status_rank` |
| `server_mcp_transport_http.ml` | `session_cookie_header` |
| `dashboard_gate_metrics.ml` | `json_of_float_opt` |
| `dashboard_goals_types_attainment.ml` | `assoc_member_opt` |

## 죽었다는 근거

13 개 모두 해당 모듈의 `.mli` 에 없다. `.mli` 가 내보내는 값은 warning 32 가 면제되므로, 경고가 났다는 사실 자체가 인터페이스에 없다는 뜻이고, 인터페이스에 없으면 라이브러리 밖에서 닿을 수 없다. `lib/server` 와 `lib/dashboard` 를 `-w +32` 로 빌드하면 이 13 개가 잡히므로 라이브러리 안에도 소비자가 없다.

지운 뒤 `dune build @check` 통과. 추가된 줄 0, 삭제 22 줄.

## 실정의 15 개 — 건별 판정

같은 측정에서 별칭이 아닌 실제 정의 16 개도 잡힌다. 기계적으로 지울 수 없어서 하나씩 판정했다.

| 값 | 판정 |
|---|---|
| `required_bool`, `edge_int`, `edge_string_list`, `json_to_int_opt` | 형제 모듈에 살아 있는 동명 정의가 있고 이쪽 사본만 호출자 없음 |
| `wake_payload_event_json` | 같은 타입을 받는 `wake_payload_record_json` 이 대체 |
| `matching_action` | `Dashboard_briefing_assembly.action_matches_incident` 가 대체 (`.mli` 노출, 호출됨) |
| `send_to_session`, `send_dashboard_delta_for_sse` | 호출자가 직접 쓰는 `_result` / `_for_parsed` 위의 얇은 래퍼 |
| `broadcast_ws` | "SSE 와 무관한 WS 전용 브로드캐스트" 라고 주석이 용도를 **주장** 하지만 호출자가 없다. #2491 에서 들어온 뒤 한 번도 배선되지 않았다 |
| `optional_keeper_wake_urgency_field` | 어느 생산자도 쓰지 않는 payload 필드를 파싱한다. 소비자는 `default_keeper_wake_urgency` 를 쓴다 |
| `blocker_class_string`, `blocker_detail`, `string_opt_has_prefix`, `recent_verdicts_json`, `resolve_workspace_base` | 호출자도 동명 정의도 없음 |

### 16 번째는 뺐다

`server_activity_http.handle_stream` (71 줄) 도 미사용이다. 확인해 보니 라우트는 #19852 가 걷어냈고 대시보드는 `/api/v1/activity/events` 폴링만 쓴다. 다만 지우면 SSE 헬퍼 5 개(`stream_headers`, `keepalive_interval_s`, `send_raw`, `close_stream`, `last_event_id`)와 `run_keepalive_loop`, 그리고 그것을 쓰는 `test_server_activity_http` 까지 따라 죽는다. 그건 미사용 값 정리가 아니라 **기능 제거** 라 별도 PR 로 뺀다.

### 이 부류를 닫는 것은 래칫이다

`lib/server` / `lib/dashboard` 의 dune 에 `-w +32` 를 켜면 새 미사용 값이 빌드를 세운다. 이번 세션에서 다른 12 개 라이브러리에 같은 방식으로 켰다. 다만 지금 켜면 #27201 이 지우는 `server_dashboard_http_core.ml` 의 21 개에서 걸리므로, 두 PR 이 머지된 뒤 별도 PR 로 켠다. 그때 `server_ide_lsp_proxy.mli` 의 `For_testing` 미사용 멤버 2 개도 함께 정리한다.

## 검증

`dune build @check` 통과.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
