### PR TITLE
fix(dashboard): main red — 삭제된 lineage 패널이 쓰던 import 6개 제거

### DIFF
--- a/dashboard/src/components/keeper-detail-history.ts
+++ b/dashboard/src/components/keeper-detail-history.ts
@@ -1,6 +1,5 @@
 import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
-import { formatPct1 } from '../lib/format-number'
 import { unixSecondsToDate } from '../lib/format-time'
 import { ActionButton } from './common/button'
 import { requestConfirm } from './common/confirm-dialog'
@@ -14,12 +13,7 @@ import {
 } from '../api/keeper'
 import { TextInput } from './common/input'
 import { Checkbox } from './common/checkbox'
-import { TimeAgo } from './common/time-ago'
-import { keeperStatusDetails } from '../keeper-state'
-import { isRecord } from './common/normalize'
 import { showToast } from './common/toast'
-import { PanelCard } from './common/panel-card'
-import { SectionHeader } from './common/section-header'
 import { StatusChip, type StatusChipTone } from './common/status-chip'
 
 function SnapshotBadge({ tone, children }: { tone: 'accent' | 'neutral' | 'ok' | 'warn' | 'bad'; children: unknown }) {


### PR DESCRIPTION
`#27199` 가 `GenerationLineagePanel` 을 지우면서 그 패널만 쓰던 import 6개를 남겼다. `noUnusedLocals` 아래 `tsc --noEmit` 이 실패하고 **main 이 빨갛다**.

```
src/components/keeper-detail-history.ts(3,1): TS6133: 'formatPct1' is declared but its value is never read.
                              (17,1): TS6133: 'TimeAgo'
                              (18,1): TS6133: 'keeperStatusDetails'
                              (19,1): TS6133: 'isRecord'
                              (21,1): TS6133: 'PanelCard'
                              (22,1): TS6133: 'SectionHeader'
```

6개 모두 파일 내 참조 0. 로컬 `npx tsc --noEmit` **exit 0**.

## 왜 #27199 의 CI 가 못 잡았나

열린 지 25초 만에 머지됐고, `ci-cancel-closed-pr.yml` 이 진행 중이던 12개 job 을 전부 취소했다. Dashboard job 은 main 에서 처음 돌았다.

## 별건

`keeper-detail.test.ts` 의 `renders a live keeper detail route` 가 로컬에서 5179ms/5000ms timeout 으로 실패한다. 단정 실패가 아니라 시간 초과라 baseline 대조가 필요하다 — 이 PR 범위 밖으로 두고 따로 확인한다.