### PR TITLE
fix(test): board-coverage 픽스처가 디코더가 요구하는 agent_name 을 만들게 (죽어 있던 단언 5개)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -888,7 +888,8 @@ jobs:
             @test/runtest-test_error_body_wire_shape \
             @test/runtest-test_tool_registry_consistency \
             @test/runtest-test_tool_spec \
-            @test/runtest-test_tool_shard_coverage
+            @test/runtest-test_tool_shard_coverage \
+            @test/runtest-test_tool_board_coverage
 
       - name: Run completion-authority lookup surface suite
         # The judge's lookup tools reach the filesystem and Git inside a

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -92,7 +92,11 @@ let make_keeper_meta ?(name = "judge-keeper") () : Keeper_meta_contract.keeper_m
       (`Assoc
          [
            ("name", `String name);
-           ("agent_name", `String name);
+           (* The decoder requires the derived form, not the raw name
+              (keeper_meta_json_parse.ml:367). Passing [name] here made every
+              fixture in this file fail construction, which is why five of its
+              assertions have never run. *)
+           ("agent_name", `String (Masc.Keeper_identity.keeper_agent_name name));
            ("trace_id", `String "test-trace-board");
          ])
   with


### PR DESCRIPTION
## 무엇이 죽어 있었나

`test_tool_board_coverage` 는 모든 keeper_meta 를 `agent_name = name` 으로 만든다. 디코더는 **파생형**을 요구한다:

```ocaml
(* lib/keeper/keeper_meta_json_parse.ml:367 *)
String.equal agent_name (Keeper_identity.keeper_agent_name name)

(* keeper_identity.ml:88 *)
let keeper_agent_name name = Printf.sprintf "keeper-%s-agent" stable
(* "judge-keeper" -> "keeper-judge-keeper-agent" *)
```

그래서 `make_keeper_meta` 가 매번 raise 했고, 이 파일의 단언 5 개가 **한 번도 실행된 적이 없다**:

```
keeper board post preserves meta reason
keeper sub-board owner is runtime-bound
direct Board reaction binds keeper identity
model-visible Board maintenance dispatch
keeper board dispatch uses typed names
```

픽스처 한 줄을 고치면 **75/75** 다.

## CI 배선

이 suite 는 **어떤 workflow 에도 없었다.** 그래서 red 인 채로 아무도 모른 채 남아 있었다 — 바로 옆 Board projection (`#27155`) 작업 중 발견해 `#27156` 으로 남긴 건이다.

다른 schema-contract suite 옆에 넣었다. 배선 없이 픽스처만 고치면 다음에 또 조용히 죽는다.

## 실패할 수 있음을 증명

```
픽스처 한 줄 되돌림 → EXIT=1  "5 failures!"
복원                → EXIT=0  75/75
```

`audit-ci-test-targets` 도 새 타겟 포함해 통과(106 CI targets, all declared).

## 이 PR 이 하지 않는 것

5 개 단언이 이제 **처음으로 실행된다.** 전부 통과하므로 이 PR 은 결함을 드러내지 않는다 — 다만 그건 "그 5 개가 검사하던 계약이 오늘 온전하다" 는 뜻이지, 그 사이 온전했다는 뜻은 아니다. 픽스처가 깨진 시점부터 지금까지 그 계약은 무방비였다.

Closes #27156

RFC-WAIVED: 테스트 픽스처 1 줄 + CI 타겟 1 개. credential / operator control / keeper sandbox / hooks / workflow 문서 미접촉.

🤖 Generated with [Claude Code](https://claude.com/claude-code)