### PR TITLE
fix(build): restore main after the #27200 consolidation

### DIFF
--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -20,7 +20,14 @@ type harness_verdict_item =
   ; fallback_reason : string option
   }
 
-type pre_compact_event = Keeper_compact_policy.pre_compact_event
+type pre_compact_event = Keeper_compact_policy.pre_compact_event =
+  { timestamp : float
+  ; keeper_name : string
+  ; checkpoint_bytes : int
+  ; message_count : int
+  ; strategies : string list
+  ; trigger : Compaction_trigger.t
+  }
 
 (** Wake-time payload observation.
 

--- a/lib/gate/channel_gate_connector.ml
+++ b/lib/gate/channel_gate_connector.ml
@@ -1,5 +1,7 @@
 (** Channel_gate_connector -- connector interface and registry.
 
+    @since 2.260.0 *)
+
 type ready_info = {
   ready_bot_user_id : string;
   ready_at : string;

--- a/lib/operator/operator_pending_confirm.ml
+++ b/lib/operator/operator_pending_confirm.ml
@@ -26,7 +26,18 @@ let normalized_actor ~context_actor = function
       let trimmed = String.trim context_actor in
       if trimmed = "" || String.equal trimmed "unknown" then "unknown" else trimmed
 
-type pending_confirm = Workspace_hooks.operator_pending_confirm_request
+type pending_confirm = Workspace_hooks.operator_pending_confirm_request = {
+  token : string;
+  trace_id : string;
+  actor : string;
+  action_type : string;
+  target_type : string;
+  target_id : string option;
+  payload : Yojson.Safe.t;
+  delegated_tool : string;
+  created_at : string;
+  expires_at : string option;
+}
 
 type pending_confirm_scope = {
   actor_filter : string option;

--- a/lib/tool_agent.mli
+++ b/lib/tool_agent.mli
@@ -19,6 +19,9 @@ val valid_agent_card_action_strings : string list
 (** Dispatch handler. Returns Some Tool_result.result if handled, None otherwise *)
 val dispatch : context -> name:string -> args:Yojson.Safe.t -> Tool_result.result option
 
+val json_ok :
+  tool_name:string -> start_time:float -> Yojson.Safe.t -> Tool_result.result
+
 val schemas : Masc_domain.tool_schema list
 
 (** Handle masc_get_metrics *)

--- a/lib/transport_read_model.mli
+++ b/lib/transport_read_model.mli
@@ -32,6 +32,9 @@ type http_context = {
       [transport_status_json] output (operator-only flag — UI
       never sets it). *)
 
+val configured_http_port : unit -> int
+val configured_http_host : unit -> string
+
 val normalize_advertised_host : string -> string
 (** [normalize_advertised_host host] returns the trimmed
     [host], unless it is one of the loopback aliases — in


### PR DESCRIPTION
## main 이 빌드되지 않는다

`origin/main` (`59939d9cc6`) 에서 `dune build @check` 가 실패한다. 근본 오류는 하나이고 나머지는 그 캐스케이드처럼 보이지만, 실제로는 #27200 (`refactor(lib): consolidate isomorphic duplicate functions and redundant record types`) 이 남긴 서로 다른 다섯 개다.

## 무엇이 깨졌나

### 1. 모듈 doc 주석이 닫히지 않아 파일 전체를 삼킨다

`lib/gate/channel_gate_connector.ml` 에서 #27200 이 주석의 **닫는 줄** 을 새 타입 선언으로 덮어썼다.

```diff
 (** Channel_gate_connector -- connector interface and registry.
 
-    @since 2.260.0 *)
+type ready_info = {
+  ready_bot_user_id : string;
+  ready_at : string;
+}
```

`*)` 가 사라져 1 행 주석이 35 행까지 삼키고, `Comment not terminated` 로 `masc` 라이브러리 전체가 무너진다. 이 오류가 다른 모듈의 `Unbound value` 를 대량으로 유발해서 원인이 가려진다.

`ready_info` 를 이 파일로 옮기려던 의도는 맞다. 삽입 위치만 주석 안이었다. 닫는 줄을 되돌리고 타입은 주석 뒤에 둔다.

### 2. 레코드 타입이 단순 약칭으로 바뀌어 필드가 스코프에서 사라진다 (2 건)

```ocaml
type pending_confirm = Workspace_hooks.operator_pending_confirm_request
type pre_compact_event = Keeper_compact_policy.pre_compact_event
```

OCaml 에서 단순 약칭은 레코드 필드를 스코프로 들여오지 않는다. 그래서 같은 모듈의 `{ token; trace_id; ... }` 생성 지점이 `Unbound record field token` 으로 죽는다. 필드를 함께 적는 재수출 등식으로 편다.

```ocaml
type pending_confirm = Workspace_hooks.operator_pending_confirm_request = {
  token : string; ...
}
```

### 3. 통합 대상이 `.mli` 에 노출되지 않았다 (3 건)

`Tool_agent.json_ok`, `Transport_read_model.configured_http_port`, `Transport_read_model.configured_http_host` 는 구현에는 있지만 각 `.mli` 에 `val` 이 없다. #27200 이 호출부를 이 모듈들로 돌려놓고 인터페이스를 갱신하지 않았다.

## 검증

`dune build @check` 통과. 변경은 `*)` 한 줄 복원, 레코드 등식 2 개, `val` 3 개 추가뿐이고 동작을 바꾸는 코드는 없다.

## 왜 CI 가 못 잡았는지는 확인하지 못했다

#27200 은 merge 되었고 그 시점 이후 main 이 이 상태다. CI 가 통과한 이유(캐시된 아티팩트, race, 스킵 조건 중 무엇인지)는 이 PR 에서 다루지 않는다 — 지금 필요한 것은 main 을 다시 세우는 것이고, 그 조사는 별건이다.

# ci:skip-test-coverage

추가된 28 줄은 전부 복원이다 — 재수출 등식의 레코드 필드 목록과 `.mli` 의 `val` 항목, 그리고 주석 종결자 한 줄. 새로 생긴 동작이 없으므로 붙일 테스트가 없고, 이 변경의 검증은 `dune build @check` 자체다 (깨진 것이 빌드였다).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
