### PR TITLE
refactor(server): remove the unroutable activity SSE stream endpoint

### DIFF
--- a/lib/server/server_activity_http.ml
+++ b/lib/server/server_activity_http.ml
@@ -30,14 +30,6 @@ let kind_filters deps request =
 
 (* workspace_filter removed — namespace retired (#unify-namespace). *)
 
-let last_event_id request =
-  match Httpun.Headers.get request.Httpun.Request.headers "last-event-id" with
-  | Some raw -> (
-      match int_of_string_opt (String.trim raw) with
-      | Some value -> max 0 value
-      | None -> 0)
-  | None -> 0
-
 (* RFC-0201 Step 1.  Default-shaped queries (kinds=[], after_seq=0)
    read from [Dashboard_snapshot.current ()].activity_events_default —
    the snapshot is refreshed every interval_sec by the background
@@ -210,18 +202,6 @@ let swimlane_http_json ~deps ~state request =
       Activity_graph.agent_spans_json (Mcp_server.workspace_config state) ~limit
         ?since_ms ())
 
-let stream_headers ~deps origin =
-  Httpun.Headers.of_list
-    ([
-       ("content-type", "text/event-stream");
-       ("cache-control", "no-cache");
-       ("connection", "keep-alive");
-       ("x-accel-buffering", "no");
-     ]
-    @ deps.cors_headers origin)
-
-let keepalive_interval_s = 30.0
-
 type stream_info = {
   session_id : string;
   client_id : int;
@@ -231,121 +211,3 @@ type stream_info = {
   mutable closed : bool;
 }
 
-let send_raw info data =
-  Eio.Mutex.use_rw ~protect:true info.mutex (fun () ->
-      if !(info.stop) || info.closed || Httpun.Body.Writer.is_closed info.writer then
-        false
-      else
-        try
-          Httpun.Body.Writer.write_string info.writer data;
-          Httpun.Body.Writer.flush info.writer (fun _ -> ());
-          true
-        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-          Log.Social.warn "send_raw write failed: %s" (Printexc.to_string exn);
-          info.closed <- true;
-          false)
-
-let close_stream info =
-  Eio.Mutex.use_rw ~protect:true info.mutex (fun () ->
-      if not info.closed then begin
-        info.closed <- true;
-        info.stop := true;
-        if not (Httpun.Body.Writer.is_closed info.writer) then
-          Httpun.Body.Writer.close info.writer
-      end)
-
-(* Keepalive loop for an activity SSE stream. Sleeps [interval_s] then calls
-   [send]; repeats until [stop] is set or [send] returns [false] (the client is
-   gone — writer closed / write failed). Setting [stop] on a [false] send makes
-   a disconnected client terminate the loop instead of spinning on the
-   server-lifetime switch until shutdown.
-
-   Root cause of #21562: the previous loop did [ignore (send_raw …)] and only
-   re-checked [info.stop], which nothing on the disconnect path ever set — so
-   one fiber leaked per disconnected SSE client. [Eio.Time.sleep] is a
-   cancellation point, so cancelling the owning switch still interrupts a
-   parked loop promptly and [Eio.Cancel.Cancelled] propagates to the caller for
-   fiber teardown. The blocking wait is injected as [sleep] so the loop's
-   control flow is deterministic and unit-testable in isolation from the clock.
-   Exposed for unit testing. *)
-let run_keepalive_loop ~sleep ~stop ~send =
-  let rec loop () =
-    if not !stop
-    then begin
-      sleep ();
-      if not !stop then if send () then loop () else stop := true
-    end
-  in
-  loop ()
-
-let handle_stream ~deps ~state request reqd =
-  let origin = deps.get_origin request in
-  let session_id =
-    Mcp_session.get_or_generate (deps.get_session_id_any request)
-  in
-
-  let kinds = kind_filters deps request in
-  let replay_limit =
-    deps.int_query_param request "limit" ~default:500
-    |> Server_utils.clamp ~min_v:1 ~max_v:1000
-  in
-  let after_seq =
-    max (last_event_id request)
-      (deps.int_query_param request "after_seq" ~default:0)
-  in
-  let headers = stream_headers ~deps origin in
-  let response = Httpun.Response.create ~headers `OK in
-  let writer = Httpun.Reqd.respond_with_streaming reqd response in
-  let info_ref : stream_info option ref = ref None in
-  let push event =
-    match !info_ref with
-    | Some info ->
-        if not (send_raw info event) then
-          Activity_graph.unregister_if_current info.session_id info.client_id
-    | None -> ()
-  in
-  let client_id =
-    Activity_graph.register session_id ~push ~last_seq:after_seq
-      ~kind_filters:kinds ()
-  in
-  let info =
-    {
-      session_id;
-      client_id;
-      writer;
-      mutex = Eio.Mutex.create ();
-      stop = ref false;
-      closed = false;
-    }
-  in
-  info_ref := Some info;
-  ignore
-    (send_raw info
-       (Server_mcp_transport_http_headers.sse_comment_with_retry
-          ~comment:(Printf.sprintf "activity-stream after=%d" after_seq)));
-  let replay =
-    Activity_graph.list_events (Mcp_server.workspace_config state) ~kinds
-      ~after_seq ~limit:replay_limit ()
-  in
-  List.iter (fun value -> ignore (send_raw info (Activity_graph.format_sse_event value))) replay;
-  (match (deps.get_switch (), deps.get_clock ()) with
-  | Some sw, Some clock ->
-      Eio.Fiber.fork ~sw (fun () ->
-          Fun.protect
-            ~finally:(fun () ->
-              Activity_graph.unregister_if_current info.session_id info.client_id)
-            (fun () ->
-              match
-                run_keepalive_loop
-                  ~sleep:(fun () -> Eio.Time.sleep clock keepalive_interval_s)
-                  ~stop:info.stop
-                  ~send:(fun () -> send_raw info ": keepalive\n\n")
-              with
-              | () -> close_stream info
-              | exception (Eio.Cancel.Cancelled _ as e) -> raise e
-              | exception exn ->
-                  Log.Social.warn "activity keepalive fiber exception: %s"
-                    (Printexc.to_string exn);
-                  close_stream info))
-  | None, _ | Some _, None -> ());
-  ()

--- a/lib/server/server_activity_http.mli
+++ b/lib/server/server_activity_http.mli
@@ -53,16 +53,6 @@ val slice_default_events_to_limit :
     ["limit"], and ["next_after_seq"] accordingly.  Pure —
     exposed for unit testing ({!Test_server_activity_http}). *)
 
-val run_keepalive_loop :
-  sleep:(unit -> unit) -> stop:bool ref -> send:(unit -> bool) -> unit
-(** [run_keepalive_loop ~sleep ~stop ~send] runs the SSE keepalive loop:
-    [sleep ()] then [send ()], repeating until [stop] is set or [send] returns
-    [false] (the client disconnected), at which point [stop] is set so a
-    disconnected client terminates the loop instead of spinning on the
-    server-lifetime switch until shutdown (#21562).  The blocking wait is
-    injected as [sleep] so the control flow is deterministic — exposed for unit
-    testing ({!Test_server_activity_http}). *)
-
 (** {1 JSON dispatchers}
 
     All three take [~deps ~state request] and return a

--- a/test/test_server_activity_http.ml
+++ b/test/test_server_activity_http.ml
@@ -115,44 +115,9 @@ let test_count_and_limit_updated () =
   check (option int) "count updated" (Some 2) (get_int_field "count" got);
   check (option int) "limit updated" (Some 2) (get_int_field "limit" got)
 
-(* #21562 regression: the keepalive loop must terminate when the client is
-   gone ([send] returns [false]) instead of spinning on the server-lifetime
-   switch until shutdown.  [sleep] is injected as a no-op so the control flow
-   is exercised deterministically without a clock. *)
-let test_keepalive_loop_terminates_on_client_gone () =
-  let stop = ref false in
-  let sends = ref 0 in
-  let send () =
-    incr sends;
-    (* client alive for two keepalives, disconnected on the third *)
-    !sends < 3
-  in
-  Server_activity_http.run_keepalive_loop ~sleep:(fun () -> ()) ~stop ~send;
-  check bool "stop is set once the client is gone" true !stop;
-  check int "loop halts on the failing send (no further iterations)" 3 !sends
-
-(* The loop must also honour an externally-set [stop] (e.g. [close_stream]
-   from the disconnect path) at the top guard. *)
-let test_keepalive_loop_honours_external_stop () =
-  let stop = ref false in
-  let sends = ref 0 in
-  let send () =
-    incr sends;
-    stop := true;
-    true
-  in
-  Server_activity_http.run_keepalive_loop ~sleep:(fun () -> ()) ~stop ~send;
-  check int "loop halts at the top guard after external stop" 1 !sends
-
 let () =
   run "Server_activity_http"
-    [ ( "keepalive_loop"
-      , [ test_case "terminates when client is gone" `Quick
-            test_keepalive_loop_terminates_on_client_gone
-        ; test_case "honours external stop" `Quick
-            test_keepalive_loop_honours_external_stop
-        ] )
-    ; ( "slice_default_events_to_limit"
+    [ ( "slice_default_events_to_limit"
       , [ test_case "len < limit" `Quick test_len_lt_limit
         ; test_case "len == limit" `Quick test_len_eq_limit
         ; test_case "len > limit" `Quick test_len_gt_limit


### PR DESCRIPTION
## 무엇

닿을 수 없는 activity SSE 스트림 엔드포인트와 그것만 쓰던 것들을 지운다.

- `handle_stream` (71 줄) — SSE 핸들러
- `run_keepalive_loop` + `.mli` 의 `val`
- 헬퍼 5 개: `stream_headers`, `keepalive_interval_s`, `send_raw`, `close_stream`, `last_event_id`
- `test_server_activity_http` 의 keepalive 테스트 2 개

## 닿을 수 없다는 근거

`Server_routes_http_routes_activity` 가 등록하는 activity 라우트는 셋뿐이다.

```
/api/v1/activity/events    -> Server_activity_http.events_http_json
/api/v1/activity/graph     -> Server_activity_http.graph_http_json
/api/v1/activity/swimlane  -> Server_activity_http.swimlane_http_json
```

`handle_stream` 을 부르는 라우트가 없고, `server_activity_http.mli` 에 `val handle_stream` 도 없다. 즉 라이브러리 안에서도 밖에서도 호출자가 없다. `lib/server` 를 `-w +32` 로 빌드하면 unused value 로 잡힌다.

라우트는 #19852 (`refactor(dashboard): purge dead dashboard surfaces`) 가 걷어냈고 핸들러만 남았다. 대시보드는 스트림을 쓰지 않는다 — `ide-activity-panel.ts:227` 이 `/api/v1/activity/events?limit=50` 을 폴링한다.

## 테스트를 함께 지우는 이유

`run_keepalive_loop` 의 유일한 프로덕션 호출자가 `handle_stream` 이었다. `.mli` 는 이 함수를 "exposed for unit testing" 이라고 적어 두었고, 실제로 `test_server_activity_http` 가 두 케이스를 돌린다 — #21562 회귀(클라이언트가 사라지면 keepalive 루프가 멈춰야 한다)를 고정하는 테스트다.

그 회귀 수정 자체는 옳았지만, 고정 대상이 사라지면 테스트는 도달 불가능한 코드를 검증하게 된다. 기능과 함께 보낸다. 이 문단이 그 기록이다.

## 이 PR 이 미사용 값 정리와 분리된 이유

#27203 이 같은 측정에서 나온 28 개를 지웠지만 `handle_stream` 은 빼두었다. 이건 값 하나가 아니라 **엔드포인트 하나와 그 테스트** 를 없애는 기능 제거라, 라우팅·클라이언트·이력을 확인한 근거가 따로 필요했다.

## 검증

`dune build @check` 통과. `test_server_activity_http` 7 건, `test_activity_graph` 20 건 통과. 순감 184 줄.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
