### PR TITLE
refactor(server): drop the shadowed duplicate in the LSP proxy signature

### DIFF
--- a/lib/server/server_ide_lsp_proxy.ml
+++ b/lib/server/server_ide_lsp_proxy.ml
@@ -1459,9 +1459,5 @@ module For_testing = struct
     Option.map lsp_method_classification (lsp_method_of_string method_)
   ;;
 
-  type lang = resolved_lang =
-    | Known_lang of string
-    | Unknown_lang
-
   let resolve_lang = resolve_lang
 end

--- a/lib/server/server_ide_lsp_proxy.mli
+++ b/lib/server/server_ide_lsp_proxy.mli
@@ -12,17 +12,6 @@ module For_testing : sig
   val resolve_relative : base:string -> string -> string option
   val workspace_root_for_initialize : base_path:string -> string -> string
   val initialize_result_json : unit -> Yojson.Safe.t
-  val inbound_dispatch_worker_count : int
-
-  (** [resolve_lang relative] classifies a workspace-relative path's language
-      (task-1691): [Known_lang lang_id] when a language server is mapped, else
-      [Unknown_lang]. *)
-  type lang =
-    | Known_lang of string
-    | Unknown_lang
-
-  val resolve_lang : string -> lang
-
   (** Fixed size of the inbound LSP dispatch worker pool
       ([Lsp_proxy_limits.inbound_dispatch_worker_count]); >1 keeps slow LSP
       init off the socket read path. *)


### PR DESCRIPTION
## 문제

`server_ide_lsp_proxy.mli` 의 `module For_testing : sig` 안에 같은 이름이 두 번 선언되어 있다.

```ocaml
module For_testing : sig
  ...
  val inbound_dispatch_worker_count : int          (* 15 행 *)

  (** ... [Known_lang lang_id] when a language server is mapped ... *)
  type lang =
    | Known_lang of string
    | Unknown_lang

  val resolve_lang : string -> lang                (* 24 행 *)

  (** Fixed size of the inbound LSP dispatch worker pool ... *)
  val inbound_dispatch_worker_count : int          (* 29 행 — 같은 이름 *)

  type resolved_lang =
    | Known_lang of string
    | Unknown_lang

  (** ... unknown extensions are [Unknown_lang] rather than a permissive default. *)
  val resolve_lang : string -> resolved_lang       (* 38 행 — 같은 이름, 다른 타입 *)
```

`resolve_lang` 은 두 번 선언되고 반환 타입이 다르다 (`lang` / `resolved_lang`). 두 타입의 생성자는 `Known_lang of string | Unknown_lang` 으로 동일하다. `lang` → `resolved_lang` 이름 변경에서 옛 선언이 남은 것이다.

시그니처에서는 뒤가 앞을 가리므로 컴파일은 통과한다. `lib/server` 를 `-w +32` 로 빌드해야 앞쪽 두 `val` 이 unused-value 로 드러난다.

## 왜 지금 문제인가

`.mli` 는 이 모듈이 무엇을 약속하는지 읽는 자리다. 지금은 같은 함수가 두 개의 다른 타입으로 적혀 있어서, 읽는 사람이 어느 쪽이 계약인지 알 수 없다. 특히 뒤쪽 선언의 주석이 "unknown extensions are `Unknown_lang` rather than a permissive default" 라는 **판정 규칙** 을 명시하는데, 앞쪽 낡은 선언이 그 옆에 나란히 있으면 규칙이 두 번 서술된 것처럼 보인다.

## 무엇을 지웠나

- `.mli`: 앞쪽 `val inbound_dispatch_worker_count`, 그 뒤 주석과 `type lang`, `val resolve_lang : string -> lang`.
- `.ml`: `For_testing` 안의 `type lang = resolved_lang = { ... }` 재수출 별칭. 타입 이름 `lang` 을 참조하는 코드는 lib/ test/ 어디에도 없다 (테스트는 생성자 `Lsp.Known_lang` / `Lsp.Unknown_lang` 만 쓰고, 그것은 `resolved_lang` 에서 나온다).

뒤쪽 블록(`inbound_dispatch_worker_count`, `resolved_lang`, `resolve_lang`)은 그대로 두었다. 테스트가 쓰는 것이 그쪽이다.

## 검증

`dune build @check` 통과. `test_server_ide_lsp_proxy` 15 건 통과. 순감 15 줄.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
