### PR TITLE
fix(gate): 세 군데가 광고하는데 아무도 읽지 않던 content-length knob 배선

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1117,6 +1117,18 @@ jobs:
       # suite asserts routed identities and stored payloads, never source
       # text or log wording. It stayed compile-only under @check, so
       # regression tests added there (#26625, #26657) never ran.
+      - name: Run channel-gate content-length knob suite
+        id: channel_gate_content_length_knob_suite
+        if: ${{ always() && steps.build_step.outcome == 'success' }}
+        env:
+          ME_ROOT: /tmp/me
+          CI_TEST_HEARTBEAT_SEC: 15
+          DUNE_JOBS: 1
+        run: |
+          mkdir -p /tmp/me
+          chmod +x scripts/ci-run-tests.sh
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_channel_gate_content_length_knob"
+
       - name: Run verification behavior suite
         id: verification_behavior_suite
         if: ${{ always() && steps.build_step.outcome == 'success' }}

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -216,8 +216,8 @@ let cache_entries =
 let channel_gate_entries =
   [
     entry ~default:"(none)" "MASC_CHANNEL_GATE_DEDUP_TTL_SEC"
-      "Dedup TTL (seconds, clamped 10-3600)";
-    entry ~default:"(none)" "MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH"
+      "Dedup TTL (seconds, floored at 1)";
+    entry ~default:"4000" "MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH"
       "Max content length (clamped 100-16000)";
     entry ~default:"30" "MASC_DISCORD_STATUS_STALE_SEC"
       "Discord status stale threshold (seconds)";

--- a/lib/gate/channel_gate.ml
+++ b/lib/gate/channel_gate.ml
@@ -71,7 +71,12 @@ type streaming_dispatch_fn =
 
 (* ── Configuration ──────────────────────────────────────────── *)
 
-let max_content_length () = 4000
+(* [max 1] for the same reason as the sibling below: the caller compares
+   [String.length trimmed > max_content_length ()], so a non-positive setting
+   would reject every inbound message instead of raising the ceiling. *)
+let max_content_length () =
+  Env_config_core.get_int ~default:4000 "MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH"
+  |> max 1
 
 let dedup_ttl_sec () =
   Env_config_core.get_int ~default:3600 "MASC_CHANNEL_GATE_DEDUP_TTL_SEC"

--- a/lib/gate/channel_gate.mli
+++ b/lib/gate/channel_gate.mli
@@ -150,7 +150,7 @@ val error_json : string -> Yojson.Safe.t
 (** {1 Configuration} *)
 
 val max_content_length : unit -> int
-(** [MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH], default 4000. *)
+(** [MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH], default 4000, floored at 1. *)
 
 val dedup_ttl_sec : unit -> float
 (** [MASC_CHANNEL_GATE_DEDUP_TTL_SEC], default 3600.0. *)

--- a/test/dune
+++ b/test/dune
@@ -1865,6 +1865,8 @@
 
 (include stanzas/test_keeper_cwd_response.inc)
 
+(include stanzas/test_channel_gate_content_length_knob.inc)
+
 (include stanzas/test_keeper_terminal_reason_typed.inc)
 
 (include stanzas/test_keeper_tool_name.inc)

--- a/test/stanzas/test_channel_gate_content_length_knob.inc
+++ b/test/stanzas/test_channel_gate_content_length_knob.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_channel_gate_content_length_knob)
+ (modules test_channel_gate_content_length_knob)
+ (libraries alcotest masc_test_deps))

--- a/test/test_channel_gate_content_length_knob.ml
+++ b/test/test_channel_gate_content_length_knob.ml
@@ -1,0 +1,70 @@
+(** [MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH] has to reach the ceiling it names.
+
+    Three surfaces described this knob — [docs/runtime-tunables.md],
+    [Env_config_snapshot], and [Channel_gate]'s own signature ("default 4000")
+    — while the body was [let max_content_length () = 4000] and read nothing.
+    An operator raising it got 4000, silently, and the Discord and Slack
+    gateways kept rejecting messages at the old ceiling.
+
+    [Env_config_core.raw_value_opt] goes to [Unix.getenv] on every call with no
+    memo, so [putenv] here is observed by the next read. *)
+
+open Alcotest
+
+let with_knob value f =
+  let restore =
+    match Sys.getenv_opt "MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH" with
+    | Some previous -> fun () -> Unix.putenv "MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH" previous
+    | None -> fun () -> Unix.putenv "MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH" ""
+  in
+  Unix.putenv "MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH" value;
+  Fun.protect ~finally:restore f
+;;
+
+let test_default_when_unset () =
+  with_knob "" (fun () ->
+    check int "unset keeps the documented 4000" 4000 (Masc.Channel_gate.max_content_length ()))
+;;
+
+let test_knob_raises_the_ceiling () =
+  with_knob "8000" (fun () ->
+    check int "the setting is applied" 8000 (Masc.Channel_gate.max_content_length ()))
+;;
+
+(* The caller compares [String.length trimmed > max_content_length ()], so a
+   non-positive ceiling rejects every message rather than admitting more. The
+   floor keeps a hostile or fat-fingered setting from turning the gate into a
+   total block. *)
+let test_non_positive_is_floored () =
+  with_knob "0" (fun () ->
+    check int "zero cannot silence the channel" 1 (Masc.Channel_gate.max_content_length ()));
+  with_knob "-1" (fun () ->
+    check int "negative cannot silence the channel" 1 (Masc.Channel_gate.max_content_length ()))
+;;
+
+(* A value the parser rejects must fall back to the default, not to zero.
+   MASC_PARSE_WARN is pinned off so the assertion states this module's
+   behaviour rather than whatever strict-mode setting the runner inherited —
+   under strict mode the shared getter raises instead of defaulting. *)
+let test_malformed_falls_back_to_default () =
+  let previous = Sys.getenv_opt "MASC_PARSE_WARN" in
+  Unix.putenv "MASC_PARSE_WARN" "false";
+  Fun.protect
+    ~finally:(fun () ->
+      Unix.putenv "MASC_PARSE_WARN" (Option.value previous ~default:""))
+    (fun () ->
+      with_knob "not-a-number" (fun () ->
+        check int "malformed keeps the default" 4000 (Masc.Channel_gate.max_content_length ())))
+;;
+
+let () =
+  run
+    "channel gate content length knob"
+    [ ( "max_content_length"
+      , [ test_case "default when unset" `Quick test_default_when_unset
+        ; test_case "knob raises the ceiling" `Quick test_knob_raises_the_ceiling
+        ; test_case "non-positive is floored" `Quick test_non_positive_is_floored
+        ; test_case "malformed falls back" `Quick test_malformed_falls_back_to_default
+        ] )
+    ]
+;;

--- a/test/test_channel_gate_content_length_knob.ml
+++ b/test/test_channel_gate_content_length_knob.ml
@@ -23,12 +23,12 @@ let with_knob value f =
 
 let test_default_when_unset () =
   with_knob "" (fun () ->
-    check int "unset keeps the documented 4000" 4000 (Masc.Channel_gate.max_content_length ()))
+    check int "unset keeps the documented 4000" 4000 (Channel_gate.max_content_length ()))
 ;;
 
 let test_knob_raises_the_ceiling () =
   with_knob "8000" (fun () ->
-    check int "the setting is applied" 8000 (Masc.Channel_gate.max_content_length ()))
+    check int "the setting is applied" 8000 (Channel_gate.max_content_length ()))
 ;;
 
 (* The caller compares [String.length trimmed > max_content_length ()], so a
@@ -37,9 +37,9 @@ let test_knob_raises_the_ceiling () =
    total block. *)
 let test_non_positive_is_floored () =
   with_knob "0" (fun () ->
-    check int "zero cannot silence the channel" 1 (Masc.Channel_gate.max_content_length ()));
+    check int "zero cannot silence the channel" 1 (Channel_gate.max_content_length ()));
   with_knob "-1" (fun () ->
-    check int "negative cannot silence the channel" 1 (Masc.Channel_gate.max_content_length ()))
+    check int "negative cannot silence the channel" 1 (Channel_gate.max_content_length ()))
 ;;
 
 (* A value the parser rejects must fall back to the default, not to zero.
@@ -54,7 +54,7 @@ let test_malformed_falls_back_to_default () =
       Unix.putenv "MASC_PARSE_WARN" (Option.value previous ~default:""))
     (fun () ->
       with_knob "not-a-number" (fun () ->
-        check int "malformed keeps the default" 4000 (Masc.Channel_gate.max_content_length ())))
+        check int "malformed keeps the default" 4000 (Channel_gate.max_content_length ())))
 ;;
 
 let () =


### PR DESCRIPTION
`MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` 는 **설명하는 곳 3군데, 읽는 곳 0군데**였다.

| 위치 | 주장 |
|---|---|
| `docs/runtime-tunables.md:230` | 튜너블 목록에 등재 |
| `env_config_snapshot.ml:220` | 운영자 스냅샷에 노출 |
| `channel_gate.mli:153` | "default 4000" |

본문: `let max_content_length () = 4000`. `git log -S` 상 이 파일에 wiring 이 있던 커밋이 없다 — `.mli` 의 약속은 #7457 이 파일을 옮긴 이래 그대로다.

이 값은 in-process 게이트웨이 두 곳이 메시지를 거부하는 상한이다 (`server_discord_in_process_gateway.ml:484`, `server_slack_in_process_gateway.ml:512`). 운영자가 8000 으로 올려도 4000 이고, 아무 진단도 없다.

## 수정

형제 함수 `dedup_ttl_sec` 와 같은 형태로 `Env_config_core` 를 읽는다. `max 1` 도 같은 이유다 — 호출부가 `String.length trimmed > max_content_length ()` 라서, 0 이나 음수면 상한이 올라가는 게 아니라 **모든 메시지가 거부된다**.

인접한 거짓 주장 2개도 같이 고쳤다:

| | 이전 | 실제 |
|---|---|---|
| 이 knob 의 스냅샷 default | `(none)` | 4000 |
| dedup 엔트리 설명 | `clamped 10-3600` | `max 1` 뿐, 상한 없음 |

`MASC_CHANNEL_GATE_DEDUP_TTL_SEC=999999` 는 999999 로 그대로 적용된다. 1시간으로 캡되지 않는다.

## 테스트

- 미설정 → 4000
- `8000` → 8000 (실제로 반영되는지)
- `0`, `-1` → 1 (채널이 통째로 막히지 않는지)
- 파싱 실패 → 4000. `MASC_PARSE_WARN` 을 명시적으로 off 로 고정해 러너 환경에 의존하지 않게 했다

## 카탈로그

`docs/runtime-tunables.md` 는 default 컬럼이 없고, `bin/env_knob_catalog.ml` 은 `lib/config/env_config_*.ml` 을 읽는다. 거기서 라인 수도 knob 집합도 안 바뀌어 재생성 불필요.

## #27160 과의 겹침

둘 다 `env_config_snapshot.ml` 을 만진다 (다른 줄). #27160 은 `"(none)"` 사각지대를 막는 게이트를 넣는데, 이 PR 이 이 knob 에 `~default:4000` 리더를 추가하므로 스냅샷 엔트리도 `"4000"` 으로 맞춰야 그 게이트가 통과한다. 두 PR 은 어느 순서로 머지돼도 각자 정합적이다.
