### PR TITLE
refactor(lib): collapse two shadowed duplicate definitions

### DIFF
--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -644,8 +644,6 @@ let () =
 
 (* -- Updater helpers -- *)
 
-let now_iso () = Masc_domain.now_iso ()
-
 let map_runtime (f : agent_runtime_state -> agent_runtime_state) (m : keeper_meta)
   : keeper_meta
   =

--- a/lib/server/server_startup_takeover.ml
+++ b/lib/server/server_startup_takeover.ml
@@ -263,13 +263,16 @@ let wait_for_pid_exit ?(poll_interval_sec = 0.1) ~timeout_sec pid =
   loop ()
 ;;
 
-let rec write_all fd payload off len =
-  if len > 0
-  then (
-    let written = Unix.write_substring fd payload off len in
-    if written = 0
-    then raise End_of_file
-    else write_all fd payload (off + written) (len - written))
+let write_all fd content =
+  let rec loop offset =
+    if offset < String.length content
+    then
+      let written =
+        Unix.write_substring fd content offset (String.length content - offset)
+      in
+      if written = 0 then raise End_of_file else loop (offset + written)
+  in
+  loop 0
 ;;
 
 let status_line_from_buffer buf =
@@ -348,7 +351,7 @@ let probe_liveness ?(timeout_sec = 3.0) ?(path = Server_health_paths.liveness) p
              path
              port
          in
-         write_all socket request 0 (String.length request);
+         write_all socket request;
          match read_status_line socket ~timeout_sec with
          | Some line -> status_line_is_healthy line
          | None -> false))
@@ -588,18 +591,6 @@ let acquire_pid_lock
   |> function
   | Already_running _ as result -> result
   | Acquired -> claim_pid_file path
-;;
-
-let write_all fd content =
-  let rec loop offset =
-    if offset < String.length content
-    then
-      let written =
-        Unix.write_substring fd content offset (String.length content - offset)
-      in
-      if written = 0 then raise End_of_file else loop (offset + written)
-  in
-  loop 0
 ;;
 
 let release_base_path_lease lease =


### PR DESCRIPTION
## 문제

한 파일 안에서 같은 이름을 두 번 정의하면 뒤가 앞을 가린다. 컴파일은 통과하고, 그 이름의 호출 지점이 파일 내 **위치** 에 따라 서로 다른 함수를 부른다.

lib/ 전체를 훑어 두 곳을 찾았다.

### 1. `server_startup_takeover.ml` — 같은 이름, 두 구현

```ocaml
(* 266 행 *)
let rec write_all fd payload off len = ...   (* 351 행이 호출 *)

(* 593 행 *)
let write_all fd content = ...               (* 1268 행이 호출 *)
```

두 구현은 **의미가 같다**. 둘 다 `Unix.write_substring` 을 반복하고, 0 바이트 쓰기에 `End_of_file` 을 던진다. 차이는 호출 규약뿐이다 — 앞쪽은 오프셋과 길이를 호출자가 계산하고, 뒤쪽은 문자열 하나만 받는다.

문제는 읽는 쪽이다. 1268 행에서 `write_all fd payload` 를 보고 정의를 찾으면 파일에서 먼저 나오는 266 행이 잡히는데, 그건 그 호출 지점이 실제로 부르는 함수가 아니다. 인자 개수가 달라서 지금은 타입 오류로 드러나겠지만, 두 구현의 동작이 갈라지는 순간에는 조용히 갈라진다.

호출자가 오프셋을 계산하지 않아도 되는 뒤쪽 형태를 남기고 266 행에 둔다. 351 행의 호출은 `write_all socket request 0 (String.length request)` → `write_all socket request` 가 된다.

### 2. `keeper_meta_contract.ml` — 같은 이름, 같은 몸통

```ocaml
(* 9 행 *)   let now_iso () = Masc_domain.now_iso ()
(* 647 행 *) let now_iso () = Masc_domain.now_iso ()
```

글자 그대로 동일하다. 동작 차이는 없고 순수 중복이라 뒤쪽을 지운다. 9 행 정의가 파일 전체를 덮는다.

## 측정 방법과 오탐 하나

`lib/**/*.ml` 에서 최상위 `let <name>` 의 이름 빈도를 세어 2 회 이상인 것을 찾았다. 결과는 3 건이었고 그 중 하나(`tool_schemas_schedule.ml` 의 `definition`)는 **오탐** 이다 — 정규식이 `let definitions : definition list` 에서 역추적해 `definition` 을 잡았다. 실제 중복 정의는 위 두 건뿐이다.

## 검증

`dune build @check` 통과. `test_server_startup_takeover` 28 건 통과.

# ci:skip-test-coverage

추가된 11 줄은 `write_all` 의 fd/content 구현을 593 행에서 266 행으로 **옮긴 것** 이다. 같은 몸통이 파일 안에서 자리를 바꿨고, 사라진 쪽은 의미가 동일한 중복 구현이다. 새로 생긴 동작이 없어 붙일 테스트가 없다.

기존 `test_server_startup_takeover` 28 건이 통과하는 것으로 회귀 없음을 확인했다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
