### PR TITLE
fix(keeper): make the task goal lookup total

### DIFF
--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -213,7 +213,13 @@ let no_eligible_exclusion_summary =
 
 let find_task_goal_id config task_id =
   let index = Workspace_goal_index.build_task_goal_index_for_config config in
-  try Some (List.hd (Hashtbl.find index task_id)) with Not_found -> None
+  (* [Not_found] only covers the missing-key case. [List.hd] raises
+     [Failure "hd"], which this arm would not catch, so match the list
+     instead: the builder appends every goal id, but that invariant lives in
+     Workspace_goal_index and is not visible in the type here. *)
+  match Hashtbl.find_opt index task_id with
+  | Some (goal_id :: _) -> Some goal_id
+  | Some [] | None -> None
 ;;
 
 let merge_current_task_id ~(latest : keeper_meta) ~(caller : keeper_meta) =


### PR DESCRIPTION
## 문제

```ocaml
let find_task_goal_id config task_id =
  let index = Workspace_goal_index.build_task_goal_index_for_config config in
  try Some (List.hd (Hashtbl.find index task_id)) with Not_found -> None
```

`try ... with Not_found` 은 `Hashtbl.find` 의 키 부재만 잡는다. 같은 `try` 안의 `List.hd` 는 빈 리스트에서 `Failure "hd"` 를 던지므로 이 arm 이 잡지 못한다. 즉 이 가드가 보호한다고 읽히는 범위와 실제 범위가 다르다.

지금은 터지지 않는다. `Workspace_goal_index.build_task_goal_index` 가 항상 `existing @ [ goal_id ]` 로 최소 한 원소를 넣기 때문이다. 그러나 그 불변식은 다른 모듈에 있고 여기 타입에는 나타나지 않는다 — 인덱스 빌더가 빈 리스트를 넣는 날 이 함수는 `None` 이 아니라 예외로 죽는다.

## 고침

```ocaml
match Hashtbl.find_opt index task_id with
| Some (goal_id :: _) -> Some goal_id
| Some [] | None -> None
```

부분 함수를 없애고 빈 리스트 경우를 명시한다. 현재 불변식 아래에서 동작은 같다.

## 범위

lib/ 에 `try ... Hashtbl.find ... with Not_found` 는 7 곳 있는데, 나머지 6 곳은 `try Hashtbl.find k with Not_found -> default` 순수 관용구로 `try` 안에 부분 함수가 없다. 이 한 곳만 다르다. 고친 뒤 lib/ 의 `List.hd` / `Option.get` 사용은 0 이다.

## 검증

`dune build @check` 통과.

`test_workspace_goal_index` 는 main 에서 이미 4 건 실패한다 (이 변경 전후 동일). 별건이라 이 PR 에서 다루지 않는다 — 그 스위트는 `ci.yml` 에 없어서 실행되지 않는다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
