### PR TITLE
fix(lint): 인터페이스가 이름 붙인 env knob 이 실재하는지 검사

### DIFF
--- a/lib/local_runtime_pool/local_runtime_pool.mli
+++ b/lib/local_runtime_pool/local_runtime_pool.mli
@@ -122,9 +122,10 @@ val runtime_id_of_base_url : string -> string
 
 val parse_errors : unit -> string list
 (** Returns the [pool_state.parse_errors] list.  Populated
-    when [load_runtimes_from_env] could not interpret the
-    [MASC_LOCAL_LLM_ENDPOINTS] entry; surfaced to the
-    operator dashboard. *)
+    when [load_runtimes_from_env] could not interpret an
+    entry of [LLM_ENDPOINTS] — the SDK's
+    [Llm_provider.Discovery.llm_endpoints_env_var], not a
+    MASC-prefixed name; surfaced to the operator dashboard. *)
 
 val snapshots : unit -> runtime_snapshot list
 (** Read-only projection of every {!runtime} into a

--- a/lib/server/server_discord_in_process_gateway.mli
+++ b/lib/server/server_discord_in_process_gateway.mli
@@ -15,9 +15,8 @@
        {!Channel_gate_discord_state.send_message} when streaming never
        starts or fails.
 
-    Always-on by design: there is no [MASC_DISCORD_BUILTIN]-style
-    toggle. The legacy Python sidecar is gone — there is no
-    fallback path to switch back to. If
+    Always-on by design: there is no toggle and no fallback transport to
+    switch to. If
     [DISCORD_BOT_TOKEN] is unset the gateway logs a warning and
     skips startup; the server still boots normally.
 

--- a/lib/server/session_lifecycle_event.mli
+++ b/lib/server/session_lifecycle_event.mli
@@ -15,7 +15,10 @@ type evict_reason =
   | Cap_exceeded
       (** oldest-eviction triggered by [max_clients] cap. *)
   | Idle_timeout
-      (** [cleanup_stale] crossed [MASC_TRANSPORT_IDLE_EVICT_SEC]. *)
+      (** [cleanup_stale] crossed its idle age. The bound is
+          [Sse.cleanup_stale]'s own [?max_age_s] default of 1800 s, applied
+          because the caller passes no argument; RFC-0099 PR-5 is where the
+          transport keep-alive knobs become configuration. *)
   | Backpressure
       (** mailbox-full beyond drain grace, or {!Fd_accountant} pressure
           escalation (RFC-0101 §3.6, 5 s sustained). *)

--- a/scripts/ci/run-lint-suite.sh
+++ b/scripts/ci/run-lint-suite.sh
@@ -41,6 +41,8 @@ blocking_lints() {
   run_lint "Raw font-size px" bash scripts/lint/no-raw-font-size-px.sh
   run_lint "OCaml comment terminator trap" bash scripts/lint/no-ocaml-comment-terminator-trap.sh
   run_lint "Timeout env knob ceiling (RFC-0138)" bash scripts/lint/timeout-env-ceiling.sh
+  run_lint ".mli env knob exists self-test" bash scripts/lint/mli-env-knob-exists.sh --self-test
+  run_lint ".mli env knob exists" bash scripts/lint/mli-env-knob-exists.sh --fail
   run_lint "Opam cache freshness ratchet" bash scripts/ci/opam-cache-freshness.sh --check
   run_lint "Opam cache freshness self-test" bash scripts/ci/opam-cache-freshness.sh --self-test
   run_lint "No actionable-signal bool context" bash scripts/lint/no-actionable-signal-bool-context.sh

--- a/scripts/lint/mli-env-knob-exists.sh
+++ b/scripts/lint/mli-env-knob-exists.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# An interface that names a MASC_* env var is telling a reader that setting it
+# does something. That claim is only true if some code reads the name, some
+# test pins its behaviour, or some script exports it.
+#
+# The class this closes, found by sweeping every MASC_* name in lib/**/*.mli
+# against the rest of the tree:
+#
+#   MASC_LOCAL_LLM_ENDPOINTS      the reader takes LLM_ENDPOINTS; the MASC_
+#                                 name existed nowhere, so an operator
+#                                 following the interface set nothing
+#   MASC_TRANSPORT_IDLE_EVICT_SEC RFC-0099 lists it under PR-5, still
+#                                 unchecked; the bound is a literal default
+#   MASC_DISCORD_BUILTIN          named only to say it was removed
+#
+# A knob exercised solely by a test still passes: MASC_FSM_GUARD_ASSERT is
+# named in keeper_fsm_guard_runtime.mli to state that setting it does not
+# re-enable soft mode, and test_keeper_fsm_guard_actions.ml holds that
+# invariant. Documented + pinned is not the failure this looks for.
+#
+# Usage: mli-env-knob-exists.sh [--fail|--print|--self-test]
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+MODE="${1:---fail}"
+case "$MODE" in
+  --fail | --print | --self-test) ;;
+  -h | --help)
+    sed -n '2,20p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+  *)
+    echo "Usage: $0 [--fail|--print|--self-test]" >&2
+    exit 2
+    ;;
+esac
+
+command -v rg >/dev/null 2>&1 || {
+  echo "[mli-env-knob-exists] required tool missing: rg" >&2
+  exit 2
+}
+
+# Names claimed by an interface, and names the tree actually exercises.
+# Search roots are disjoint on suffix, so a name found only in .mli files
+# cannot appear in the second list.
+collect_claimed() {
+  rg --no-filename --only-matching '\bMASC_[A-Z0-9_]{3,}\b' \
+    --glob '*.mli' "$1/lib" 2>/dev/null | sort -u
+}
+
+# Only OCaml sources count as evidence. A shell script that exports a name
+# proves nothing when no code reads it, and this file names the knobs it was
+# written to catch — scanning scripts/ would let the checker whitelist its own
+# findings.
+collect_exercised() {
+  rg --no-filename --only-matching '\bMASC_[A-Z0-9_]{3,}\b' \
+    --glob '*.ml' "$1/lib" "$1/bin" "$1/test" 2>/dev/null | sort -u
+}
+
+report() {
+  local tree="$1"
+  comm -23 <(collect_claimed "$tree") <(collect_exercised "$tree")
+}
+
+case "$MODE" in
+  --print)
+    report "$ROOT"
+    exit 0
+    ;;
+  --self-test)
+    # Prove the check can fail: a scratch tree whose interface names a knob
+    # nothing reads must be reported, and the same tree with a reader must not.
+    scratch="$(mktemp -d -t mli-env-knob.XXXXXX)"
+    trap 'rm -rf "$scratch"' EXIT
+    mkdir -p "$scratch/lib" "$scratch/bin" "$scratch/test" "$scratch/scripts"
+    printf '(** [MASC_SELF_TEST_PHANTOM] does nothing. *)\nval f : unit -> unit\n' \
+      >"$scratch/lib/probe.mli"
+    if [ "$(report "$scratch")" != "MASC_SELF_TEST_PHANTOM" ]; then
+      echo "[mli-env-knob-exists] self-test: an unread knob was not reported" >&2
+      exit 1
+    fi
+    printf 'let f () = ignore (Sys.getenv_opt "MASC_SELF_TEST_PHANTOM")\n' \
+      >"$scratch/lib/probe.ml"
+    if [ -n "$(report "$scratch")" ]; then
+      echo "[mli-env-knob-exists] self-test: a read knob was still reported" >&2
+      exit 1
+    fi
+    echo "[mli-env-knob-exists] self-test OK"
+    exit 0
+    ;;
+esac
+
+orphans="$(report "$ROOT")"
+claimed_count="$(collect_claimed "$ROOT" | wc -l | tr -d ' ')"
+
+if [ -z "$orphans" ]; then
+  echo "[mli-env-knob-exists] OK: ${claimed_count} knobs named in .mli, every one exercised"
+  exit 0
+fi
+
+echo "[mli-env-knob-exists] an interface names a knob nothing reads:" >&2
+while IFS= read -r knob; do
+  [ -n "$knob" ] || continue
+  echo "  $knob" >&2
+  rg --line-number --glob '*.mli' --no-heading "\b${knob}\b" "$ROOT/lib" 2>/dev/null |
+    sed "s|$ROOT/|    |" >&2
+done <<<"$orphans"
+echo >&2
+echo "Either wire the knob, or state what the code actually does." >&2
+exit 1


### PR DESCRIPTION
`lib/**/*.mli` 의 모든 `MASC_*` 를 OCaml 소스와 대조했더니, **읽는 코드가 없는 knob 을 설명하는 인터페이스가 3건** 나왔다. 인터페이스가 knob 이름을 적는 건 "설정하면 뭔가 된다"는 약속이다.

| knob | 실상 |
|---|---|
| `MASC_LOCAL_LLM_ENDPOINTS` | 실제 리더는 `Llm_provider.Discovery.parse_llm_endpoints_env`, 그 `llm_endpoints_env_var` 는 **`LLM_ENDPOINTS`**. `MASC_` 접두 철자는 masc 에도 SDK 에도 없다 — 운영자가 이 docstring 대로 설정하면 아무 일도 안 일어난다 |
| `MASC_TRANSPORT_IDLE_EVICT_SEC` | RFC-0099 **PR-5 미체크**. 실제 경계는 `Sse.cleanup_stale` 의 `?max_age_s` 기본값 `1800.0` 이고 `server_bootstrap_maintenance.ml:561` 은 인자를 안 넘긴다 |
| `MASC_DISCORD_BUILTIN` | 제거됐다는 말을 하려고만 이름이 남아 있다 (RFC-0203 legacy purge) |

## 네 번째로 보이지만 아닌 것

`MASC_FSM_GUARD_ASSERT` 도 "더 이상 soft-mode escape hatch 가 아니다"라고 `.mli` 에 적혀 있다. 하지만 `test_keeper_fsm_guard_actions.ml` 이 `"0"` 을 넣고 `Assert_failure` 가 그대로 전파되는지 단정한다. **문서 + 테스트로 고정된 불변식**은 이 검사가 허용해야 하는 모양이다.

## Transport knob 을 배선하지 않은 이유

`MASC_TRANSPORT_IDLE_EVICT_SEC` 의 형제 3개(`KEEPALIVE_SEC`/`RESUME_WINDOW_SEC`/`MAX_CLIENTS`)도 똑같이 안 읽힌다. RFC-0099 는 이 넷을 "keep-alive SSOT + CI hard-coded constant ban" 으로 묶어 PR-5 에 배정해 뒀다. 여기서 하나만 배선하면 그 PR 의 범위를 쪼개는 셈이라, docstring 이 현재 코드를 말하게 하고 PR-5 를 가리키게만 했다.

## 게이트

`scripts/lint/mli-env-knob-exists.sh` — `.mli` 의 주장을 `lib`/`bin`/`test` 의 `*.ml` 과 대조한다.

`scripts/` 는 증거로 세지 않는다. 이름을 export 하는 셸 스크립트는 읽는 코드가 없으면 아무것도 증명하지 못하고, **이 스크립트 자체가 잡으려는 knob 3개의 이름을 주석에 담고 있어서** `scripts/` 를 훑으면 검사기가 자기 발견을 화이트리스트한다. 첫 버전이 실제로 그랬고, 수정 전 트리를 "clean" 이라고 보고했다.

## 검증

양방향으로 확인했다.

```
수정 전 트리 → 3건 모두 지목, exit 1
수정 후      → OK: 122 knobs named in .mli, every one exercised
--self-test  → 팬텀 knob 을 만들어 지목되는지, 리더를 붙이면 사라지는지 확인
shellcheck   → clean
```

lint suite 에 `--self-test` 와 `--fail` 을 함께 등록했다 (저장소 관례).
