### PR TITLE
refactor(auth): Masc.Auth → Auth_leaf → Auth 재수출 체인 붕괴 (RFC-0292 완료)

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -33,7 +33,6 @@ module Keeper_tool_call_log = Masc.Keeper_tool_call_log
 module Graphql_api = Masc.Graphql_api
 module Types = Masc_domain
 module Tempo = Masc.Tempo
-module Auth = Masc.Auth
 module Board = Masc.Board
 module Board_curation = Masc.Board_curation
 module Board_dispatch = Masc.Board_dispatch

--- a/docs/observability/auth-credential-metrics.md
+++ b/docs/observability/auth-credential-metrics.md
@@ -2,7 +2,6 @@
 status: reference
 last_verified: 2026-06-05
 code_refs:
-  - lib/auth.ml
   - lib/auth/auth.mli
   - lib/auth/auth_metric_store.ml
   - lib/otel_metric_store.ml
@@ -47,7 +46,7 @@ events that can be queried as a rate in the active backend. The audit pass
 (2026-05-14) confirmed no genuine duplication; the only addition needed was
 flow + heartbeat surfaces to catch what the snapshot gauges cannot show.
 
-## γ Classifier (lib/auth.ml)
+## γ Classifier
 
 `classify_bare_for_canonical` is the pure read-only predicate that decides whether a bare-form file is alive or dead. It returns one of three variants:
 

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -1,7 +1,0 @@
-(** Compatibility facade for [Masc.Auth].
-
-    The implementation lives in the leaf [masc.auth] library.  Keep this module
-    as a thin re-export so the parent [masc] library does not carry a second
-    authentication implementation that can drift from the leaf SSOT. *)
-
-include Auth_leaf

--- a/lib/auth/auth_leaf.ml
+++ b/lib/auth/auth_leaf.ml
@@ -1,7 +1,0 @@
-(** Re-export surface for the parent [Masc.Auth] facade.
-
-    The leaf library owns the implementation in [Auth]. The parent [masc]
-    library cannot refer to that module as [Auth] from inside its own
-    [Auth] facade, so it depends on this distinct module name instead. *)
-
-include Auth

--- a/lib/auth/auth_leaf.mli
+++ b/lib/auth/auth_leaf.mli
@@ -1,3 +1,0 @@
-(** Re-export surface for the parent [Masc.Auth] facade. *)
-
-include module type of Auth

--- a/test/stanzas/test_auth_bearer_mismatch_9786.inc
+++ b/test/stanzas/test_auth_bearer_mismatch_9786.inc
@@ -1,4 +1,4 @@
 (test
  (name test_auth_bearer_mismatch_9786)
  (modules test_auth_bearer_mismatch_9786)
- (libraries masc masc_types alcotest unix))
+ (libraries masc masc.auth masc_types alcotest unix))

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -4,7 +4,7 @@
 let () = Mirage_crypto_rng_unix.use_default ()
 
 open Alcotest
-module Auth = Masc.Auth
+module Auth = Auth
 module Tool_spec = Tool_spec
 module Tool_dispatch = Tool_dispatch
 module Types = Masc_domain

--- a/test/test_auth_ambiguous_lookup_9786.ml
+++ b/test/test_auth_ambiguous_lookup_9786.ml
@@ -77,7 +77,7 @@ let collision_lookup_total () =
     Masc.Otel_metric_store.metric_auth_credential_hash_collision
 
 let first_match_for_hash ~base ~token_hash =
-  Masc.Auth.list_credentials base
+  Auth.list_credentials base
   |> List.find (fun (cred : Masc_domain.agent_credential) ->
        String.equal cred.token token_hash)
   |> fun cred -> cred.agent_name
@@ -95,12 +95,12 @@ let test_metric_names_stable () =
 let test_single_match_no_counter () =
   with_temp_base (fun base ->
     let raw_token = "single_match_raw_token_9786" in
-    let hash = Masc.Auth.sha256_hash raw_token in
+    let hash = Auth.sha256_hash raw_token in
     write_cred ~base ~agent_name:"keeper-only" ~token_hash:hash;
     let before_ambiguous = ambiguous_counter_for ~first_match:"keeper-only" in
     let before_ambiguous_total = ambiguous_lookup_total () in
     let before_collision_total = collision_lookup_total () in
-    let result = Masc.Auth.find_credential_by_token base ~token:raw_token in
+    let result = Auth.find_credential_by_token base ~token:raw_token in
     (match result with
      | Ok _ -> ()
      | Error e ->
@@ -123,7 +123,7 @@ let test_single_match_no_counter () =
 let test_duplicate_hash_rejects_collision () =
   with_temp_base (fun base ->
     let raw_token = "duplicate_raw_token_9786" in
-    let hash = Masc.Auth.sha256_hash raw_token in
+    let hash = Auth.sha256_hash raw_token in
     (* Two credentials hashing to the same token but with different
        agent_name fields: a collision, not merely an ambiguous lookup. *)
     write_cred ~base ~agent_name:"alpha-keeper" ~token_hash:hash;
@@ -136,7 +136,7 @@ let test_duplicate_hash_rejects_collision () =
     let before_ambiguous_other = ambiguous_counter_for ~first_match:other_match in
     let before_collision = collision_counter_for ~left_agent:first_match ~right_agent:other_match in
     let before_collision_total = collision_lookup_total () in
-    let result = Masc.Auth.find_credential_by_token base ~token:raw_token in
+    let result = Auth.find_credential_by_token base ~token:raw_token in
     (match result with
      | Ok cred ->
        Alcotest.fail
@@ -164,7 +164,7 @@ let test_duplicate_hash_rejects_collision () =
 let test_repeated_lookups_accumulate () =
   with_temp_base (fun base ->
     let raw_token = "repeat_raw_token_9786" in
-    let hash = Masc.Auth.sha256_hash raw_token in
+    let hash = Auth.sha256_hash raw_token in
     write_cred ~base ~agent_name:"repeat-a" ~token_hash:hash;
     write_cred ~base ~agent_name:"repeat-b" ~token_hash:hash;
     let first_match = first_match_for_hash ~base ~token_hash:hash in
@@ -175,7 +175,7 @@ let test_repeated_lookups_accumulate () =
     let before_collision = collision_counter_for ~left_agent:first_match ~right_agent:other_match in
     for _ = 1 to 3 do
       let (_ : (Masc_domain.agent_credential, Masc_domain.masc_error) result) =
-        Masc.Auth.find_credential_by_token base ~token:raw_token
+        Auth.find_credential_by_token base ~token:raw_token
       in
       ()
     done;

--- a/test/test_auth_credential_hash_collision.ml
+++ b/test/test_auth_credential_hash_collision.ml
@@ -25,14 +25,14 @@ let base_credential ~agent_name ~role =
 let test_compare_equal_credentials () =
   let a = base_credential ~agent_name:"alice" ~role:Masc_domain.Worker in
   let b = base_credential ~agent_name:"alice" ~role:Masc_domain.Worker in
-  match Masc.Auth.compare_credentials ~token_hash_prefix a b with
+  match Auth.compare_credentials ~token_hash_prefix a b with
   | Equal -> ()
   | Different _ -> Alcotest.fail "expected Equal for identical credentials"
 
 let test_compare_different_agent_name () =
   let a = base_credential ~agent_name:"alice" ~role:Masc_domain.Worker in
   let b = base_credential ~agent_name:"bob" ~role:Masc_domain.Worker in
-  match Masc.Auth.compare_credentials ~token_hash_prefix a b with
+  match Auth.compare_credentials ~token_hash_prefix a b with
   | Equal -> Alcotest.fail "expected Different for distinct agent_name"
   | Different log ->
     Alcotest.(check string) "left agent" "alice" log.left_agent;
@@ -40,20 +40,20 @@ let test_compare_different_agent_name () =
     Alcotest.(check bool) "has agent_name diff" true
       (List.exists
          (function
-           | Masc.Auth.Agent_name _ -> true
+           | Auth.Agent_name _ -> true
            | _ -> false)
          log.field_diffs)
 
 let test_compare_different_role () =
   let a = base_credential ~agent_name:"alice" ~role:Masc_domain.Worker in
   let b = base_credential ~agent_name:"alice" ~role:Masc_domain.Admin in
-  match Masc.Auth.compare_credentials ~token_hash_prefix a b with
+  match Auth.compare_credentials ~token_hash_prefix a b with
   | Equal -> Alcotest.fail "expected Different for distinct role"
   | Different log ->
     Alcotest.(check bool) "has role diff" true
       (List.exists
          (function
-           | Masc.Auth.Role _ -> true
+           | Auth.Role _ -> true
            | _ -> false)
          log.field_diffs)
 
@@ -100,9 +100,9 @@ let write_cred ~base ~agent_name ~role ~token_hash =
 let test_unknown_token_is_mismatch () =
   with_temp_base (fun base ->
     let raw = "known_raw_token_collision" in
-    let hash = Masc.Auth.sha256_hash raw in
+    let hash = Auth.sha256_hash raw in
     write_cred ~base ~agent_name:"alice" ~role:Masc_domain.Worker ~token_hash:hash;
-    match Masc.Auth.find_credential_by_token base ~token:"totally-unknown-token" with
+    match Auth.find_credential_by_token base ~token:"totally-unknown-token" with
     | Ok cred ->
       Alcotest.fail
         (Printf.sprintf "expected mismatch for unknown token, got %s" cred.agent_name)
@@ -111,9 +111,9 @@ let test_unknown_token_is_mismatch () =
 let test_single_match_returns_ok () =
   with_temp_base (fun base ->
     let raw = "single_match_collision" in
-    let hash = Masc.Auth.sha256_hash raw in
+    let hash = Auth.sha256_hash raw in
     write_cred ~base ~agent_name:"alice" ~role:Masc_domain.Worker ~token_hash:hash;
-    match Masc.Auth.find_credential_by_token base ~token:raw with
+    match Auth.find_credential_by_token base ~token:raw with
     | Ok cred -> Alcotest.(check string) "resolved agent" "alice" cred.agent_name
     | Error e ->
       Alcotest.fail
@@ -122,10 +122,10 @@ let test_single_match_returns_ok () =
 let test_artificially_equal_hashes_reject () =
   with_temp_base (fun base ->
     let raw = "shared_raw_token_collision" in
-    let hash = Masc.Auth.sha256_hash raw in
+    let hash = Auth.sha256_hash raw in
     write_cred ~base ~agent_name:"alice" ~role:Masc_domain.Worker ~token_hash:hash;
     write_cred ~base ~agent_name:"bob" ~role:Masc_domain.Worker ~token_hash:hash;
-    match Masc.Auth.find_credential_by_token base ~token:raw with
+    match Auth.find_credential_by_token base ~token:raw with
     | Ok cred ->
       Alcotest.fail
         (Printf.sprintf "expected collision error, got Ok for %s" cred.agent_name)

--- a/test/test_auth_credential_index_cache.ml
+++ b/test/test_auth_credential_index_cache.ml
@@ -23,7 +23,7 @@
 let () = Mirage_crypto_rng_unix.use_default ()
 
 open Alcotest
-module Auth = Masc.Auth
+module Auth = Auth
 
 let setup_test_workspace () =
   let unique_id =

--- a/test/test_auth_load_credential_of.ml
+++ b/test/test_auth_load_credential_of.ml
@@ -58,7 +58,7 @@ let test_exact_match_load_ok () =
     write_cred ~base ~agent_name:"keeper-sangsu-agent"
       ~token_hash:"abc123";
     match
-      Masc.Auth.load_credential_of base
+      Auth.load_credential_of base
         ~ctx_agent_name:"keeper-sangsu-agent"
         ~resolved_credential_stem:"keeper-sangsu-agent"
     with
@@ -67,24 +67,24 @@ let test_exact_match_load_ok () =
         print_endline "PASS: exact match -> Ok cred"
     | Error e ->
         Printf.printf "FAIL: expected Ok, got Error %s\n"
-          (Masc.Auth.show_load_credential_error e);
+          (Auth.show_load_credential_error e);
         exit 1)
 
 let test_exact_match_missing_returns_credential_missing () =
   with_temp_base (fun base ->
     (* No cred file written *)
     match
-      Masc.Auth.load_credential_of base
+      Auth.load_credential_of base
         ~ctx_agent_name:"keeper-ghost-agent"
         ~resolved_credential_stem:"keeper-ghost-agent"
     with
     | Ok _ ->
         print_endline "FAIL: expected Credential_missing, got Ok";
         exit 1
-    | Error (Masc.Auth.Credential_missing { ctx_agent_name }) ->
+    | Error (Auth.Credential_missing { ctx_agent_name }) ->
         assert (ctx_agent_name = "keeper-ghost-agent");
         print_endline "PASS: missing file -> Credential_missing"
-    | Error (Masc.Auth.Credential_mismatch _) ->
+    | Error (Auth.Credential_mismatch _) ->
         print_endline "FAIL: expected Credential_missing, got Credential_mismatch";
         exit 1)
 
@@ -96,18 +96,18 @@ let test_mismatch_rejects_even_when_resolved_stem_exists () =
     write_cred ~base ~agent_name:"keeper-sangsu-agent"
       ~token_hash:"canonical-token";
     match
-      Masc.Auth.load_credential_of base
+      Auth.load_credential_of base
         ~ctx_agent_name:"keeper-sangsu-agent"
         ~resolved_credential_stem:"sangsu"
     with
     | Ok _ ->
         print_endline "FAIL: expected Credential_mismatch, got Ok (silent fallback)";
         exit 1
-    | Error (Masc.Auth.Credential_missing _) ->
+    | Error (Auth.Credential_missing _) ->
         print_endline "FAIL: expected Credential_mismatch, got Credential_missing";
         exit 1
     | Error
-        (Masc.Auth.Credential_mismatch
+        (Auth.Credential_mismatch
            { ctx_agent_name; resolved_credential_stem }) ->
         assert (ctx_agent_name = "keeper-sangsu-agent");
         assert (resolved_credential_stem = "sangsu");
@@ -117,18 +117,18 @@ let test_mismatch_rejects_even_when_resolved_stem_exists () =
 let test_mismatch_rejects_even_when_neither_exists () =
   with_temp_base (fun base ->
     match
-      Masc.Auth.load_credential_of base
+      Auth.load_credential_of base
         ~ctx_agent_name:"keeper-a-agent"
         ~resolved_credential_stem:"b"
     with
     | Ok _ ->
         print_endline "FAIL: expected Credential_mismatch";
         exit 1
-    | Error (Masc.Auth.Credential_missing _) ->
+    | Error (Auth.Credential_missing _) ->
         print_endline "FAIL: ctx<>stem must take mismatch branch even when nothing exists";
         exit 1
     | Error
-        (Masc.Auth.Credential_mismatch
+        (Auth.Credential_mismatch
            { ctx_agent_name; resolved_credential_stem }) ->
         assert (ctx_agent_name = "keeper-a-agent");
         assert (resolved_credential_stem = "b");

--- a/test/test_auth_token_uniqueness_audit.ml
+++ b/test/test_auth_token_uniqueness_audit.ml
@@ -51,14 +51,14 @@ let write_cred ~base ~agent_name ~token_hash =
 
 let test_empty_store_returns_empty () =
   with_temp_base (fun base ->
-    let groups = Masc.Auth.audit_token_uniqueness base in
+    let groups = Auth.audit_token_uniqueness base in
     Alcotest.(check int) "empty store" 0 (List.length groups))
 
 let test_unique_tokens_return_empty () =
   with_temp_base (fun base ->
     write_cred ~base ~agent_name:"alpha" ~token_hash:"hash_alpha_12345678";
     write_cred ~base ~agent_name:"beta"  ~token_hash:"hash_beta_12345678_";
-    let groups = Masc.Auth.audit_token_uniqueness base in
+    let groups = Auth.audit_token_uniqueness base in
     Alcotest.(check int) "no duplicate groups" 0 (List.length groups))
 
 let test_shared_token_surfaces_pair () =
@@ -66,7 +66,7 @@ let test_shared_token_surfaces_pair () =
     let shared = "shared_token_hash_value_with_enough_length" in
     write_cred ~base ~agent_name:"keeper-sangsu-agent" ~token_hash:shared;
     write_cred ~base ~agent_name:"nick0cave-sage-heron" ~token_hash:shared;
-    let groups = Masc.Auth.audit_token_uniqueness base in
+    let groups = Auth.audit_token_uniqueness base in
     match groups with
     | [ (prefix, agents) ] ->
         Alcotest.(check int) "exactly 2 agents in group"
@@ -89,7 +89,7 @@ let test_mixed_unique_and_shared () =
     write_cred ~base ~agent_name:"shared-a" ~token_hash:shared;
     write_cred ~base ~agent_name:"shared-b" ~token_hash:shared;
     write_cred ~base ~agent_name:"unique-2" ~token_hash:"unique_hash_CCC_long";
-    let groups = Masc.Auth.audit_token_uniqueness base in
+    let groups = Auth.audit_token_uniqueness base in
     Alcotest.(check int) "one duplicate group" 1 (List.length groups);
     match groups with
     | [ (_, agents) ] ->

--- a/test/test_cancel_wall_bucket.ml
+++ b/test/test_cancel_wall_bucket.ml
@@ -5,7 +5,7 @@
     fails before that drift can ship. *)
 
 (* [masc] is a wrapped library, so reach the new module through its
-   namespace (the same pattern existing tests use, e.g. [Masc.Auth]). *)
+   namespace (the same pattern existing tests use, e.g. [Auth]). *)
 module Cancel_wall_bucket = Masc.Cancel_wall_bucket
 
 let label = Alcotest.(check string)

--- a/test/test_config_coverage.ml
+++ b/test/test_config_coverage.ml
@@ -6,7 +6,7 @@
 open Alcotest
 
 module Config = Masc.Config
-module Auth = Masc.Auth
+module Auth = Auth
 module Tool_catalog = Tool_catalog
 module Tool_help_registry = Tool_help_registry
 module Tool_shard = Masc.Tool_shard

--- a/test/test_credential_alias_10440.ml
+++ b/test/test_credential_alias_10440.ml
@@ -10,7 +10,7 @@ module Types = Masc_domain
 let () = Mirage_crypto_rng_unix.use_default ()
 
 open Alcotest
-module Auth = Masc.Auth
+module Auth = Auth
 
 let setup_test_workspace () =
   let unique_id =

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -3,7 +3,7 @@ module Types = Masc_domain
 let () = Mirage_crypto_rng_unix.use_default ()
 
 module Lib = Masc
-module Auth = Masc.Auth
+module Auth = Auth
 module Keeper_chat_queue = Masc.Keeper_chat_queue
 module Workspace = Masc.Workspace
 

--- a/test/test_dashboard_namespace_truth.ml
+++ b/test/test_dashboard_namespace_truth.ml
@@ -276,7 +276,7 @@ let test_dashboard_namespace_truth_keeper_only_workspace_not_reported_empty () =
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let module Mcp_server = Lib.Mcp_server in
       Eio.Switch.run (fun sw ->
-        Lib.Auth.disable_auth dir;
+        Auth.disable_auth dir;
         let state =
           Lib.Mcp_server_eio.create_state_eio
             ~sw
@@ -331,7 +331,7 @@ let test_dashboard_namespace_truth_mixed_runtime_counts () =
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let module Mcp_server = Lib.Mcp_server in
       Eio.Switch.run (fun sw ->
-        Lib.Auth.disable_auth dir;
+        Auth.disable_auth dir;
         let state =
           Lib.Mcp_server_eio.create_state_eio
             ~sw

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -3154,12 +3154,12 @@ let test_dashboard_keeper_purge_finalizes_artifacts_and_receipt () =
         Filename.concat (Workspace.agents_dir config) "unrelated.json"
       in
       write_file unrelated_path "{}";
-      Masc.Auth.save_credential
+      Auth.save_credential
         config.base_path
         { id = None
         ; agent_id = None
         ; agent_name = meta.agent_name
-        ; token = Masc.Auth.sha256_hash "dashboard-purge-token"
+        ; token = Auth.sha256_hash "dashboard-purge-token"
         ; role = Masc_domain.Worker
         ; created_at = Masc_domain.now_iso ()
         ; expires_at = None
@@ -3273,7 +3273,7 @@ let test_dashboard_keeper_purge_finalizes_artifacts_and_receipt () =
         ; configuration_path
         ; agent_path
         ; agent_metrics_dir
-        ; Masc.Auth.credential_file config.base_path meta.agent_name
+        ; Auth.credential_file config.base_path meta.agent_name
         ]
         @ sidecar_paths
       in

--- a/test/test_mcp_auth_gate.ml
+++ b/test/test_mcp_auth_gate.ml
@@ -100,9 +100,9 @@ let has_result response =
 let setup_auth_workspace () =
   let base_path = temp_dir () in
   let state = Mcp_eio.For_testing.create_state ~base_path () in
-  ignore (Masc.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
+  ignore (Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
   let raw_token =
-    match Masc.Auth.create_token base_path ~agent_name:"test-agent" ~role:Masc_domain.Worker with
+    match Auth.create_token base_path ~agent_name:"test-agent" ~role:Masc_domain.Worker with
     | Ok (token, _cred) -> token
     | Error e -> fail (Masc_domain.masc_error_to_string e)
   in

--- a/test/test_mcp_h1_h2_admission_parity.ml
+++ b/test/test_mcp_h1_h2_admission_parity.ml
@@ -5,7 +5,7 @@ module Request_context = Server_mcp_request_context
 module Headers = Server_mcp_transport_http_headers
 module Negotiation = Mcp_transport_protocol.Http_negotiation
 module Mcp_store = Masc.Session.McpSessionStore
-module Auth = Masc.Auth
+module Auth = Auth
 
 let request_trust_policy =
   match

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1132,7 +1132,7 @@ let test_handle_request_tools_call_transition_claim_guidance () =
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
   let state = Mcp_eio.For_testing.create_state ~base_path () in
-  Masc.Auth.disable_auth base_path;
+  Auth.disable_auth base_path;
   let sid = "mcp-transition-claim-guidance" in
   let init_result =
     Mcp_eio.execute_tool_eio ~sw ~clock
@@ -1191,7 +1191,7 @@ let test_handle_request_tools_call_transition_done_requires_llm_verdict () =
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
   let state = Mcp_eio.For_testing.create_state ~base_path () in
-  Masc.Auth.disable_auth base_path;
+  Auth.disable_auth base_path;
   let sid = "mcp-transition-done-guidance" in
   let init_result =
     Mcp_eio.execute_tool_eio ~sw ~clock
@@ -1281,7 +1281,7 @@ let test_handle_request_tools_call_transition_claim_requires_action () =
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
   let state = Mcp_eio.For_testing.create_state ~base_path () in
-  Masc.Auth.disable_auth base_path;
+  Auth.disable_auth base_path;
   let sid = "mcp-deprecated-claim-alias" in
   let init_result =
     Mcp_eio.execute_tool_eio ~sw ~clock
@@ -1572,9 +1572,9 @@ let test_execute_tool_generated_agent_name_uses_token_identity () =
 
   let base_path = temp_dir () in
   let state = Mcp_eio.For_testing.create_state ~base_path () in
-  ignore (Masc.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
+  ignore (Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
   let raw_token =
-    match Masc.Auth.create_token base_path ~agent_name:"stable-admin" ~role:Masc_domain.Admin with
+    match Auth.create_token base_path ~agent_name:"stable-admin" ~role:Masc_domain.Admin with
     | Ok (token, _cred) -> token
     | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e)
   in
@@ -1601,13 +1601,13 @@ let test_execute_tool_actor_mismatch_reports_typed_code () =
   let base_path = temp_dir () in
   let state = Mcp_eio.For_testing.create_state ~base_path () in
   ignore
-    (Masc.Auth.enable_auth
+    (Auth.enable_auth
        base_path
        ~require_token:true
        ~agent_name:"bootstrap-admin");
   let raw_token =
     match
-      Masc.Auth.create_token
+      Auth.create_token
         base_path
         ~agent_name:"codex"
         ~role:Masc_domain.Worker
@@ -1716,9 +1716,9 @@ let test_execute_tool_explicit_generated_alias_claim_next_not_rewritten_by_token
   let base_path = temp_dir () in
   let state = Mcp_eio.For_testing.create_state ~base_path () in
   ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None);
-  ignore (Masc.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
+  ignore (Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
   let raw_token =
-    match Masc.Auth.create_token base_path ~agent_name:"stable-admin" ~role:Masc_domain.Admin with
+    match Auth.create_token base_path ~agent_name:"stable-admin" ~role:Masc_domain.Admin with
     | Ok (token, _cred) -> token
     | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e)
   in
@@ -1749,9 +1749,9 @@ let test_execute_tool_explicit_generated_alias_transition_not_rewritten_by_token
   let base_path = temp_dir () in
   let state = Mcp_eio.For_testing.create_state ~base_path () in
   ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None);
-  ignore (Masc.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
+  ignore (Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
   let raw_token =
-    match Masc.Auth.create_token base_path ~agent_name:"stable-admin" ~role:Masc_domain.Admin with
+    match Auth.create_token base_path ~agent_name:"stable-admin" ~role:Masc_domain.Admin with
     | Ok (token, _cred) -> token
     | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e)
   in
@@ -1789,9 +1789,9 @@ let test_execute_tool_hyphenated_generated_alias_claim_next_rejected_without_mut
   let base_path = temp_dir () in
   let state = Mcp_eio.For_testing.create_state ~base_path () in
   ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None);
-  ignore (Masc.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
+  ignore (Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
   let raw_token =
-    match Masc.Auth.create_token base_path ~agent_name:"qa-king" ~role:Masc_domain.Admin with
+    match Auth.create_token base_path ~agent_name:"qa-king" ~role:Masc_domain.Admin with
     | Ok (token, _cred) -> token
     | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e)
   in
@@ -1828,7 +1828,7 @@ let test_execute_tool_claim_next_requires_auth_before_mutation () =
   let base_path = temp_dir () in
   let state = Mcp_eio.For_testing.create_state ~base_path () in
   ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None);
-  ignore (Masc.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
+  ignore (Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
   ignore (Masc.Workspace.bind_session (Mcp_server.workspace_config state) ~agent_name:"uncredentialed-agent" ~capabilities:[] ());
   ignore
     (Masc.Workspace.add_task (Mcp_server.workspace_config state) ~title:"claim-next-auth-preflight"
@@ -1857,7 +1857,7 @@ let test_execute_tool_transition_requires_auth_before_mutation () =
   let base_path = temp_dir () in
   let state = Mcp_eio.For_testing.create_state ~base_path () in
   ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None);
-  ignore (Masc.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
+  ignore (Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
   ignore (Masc.Workspace.bind_session (Mcp_server.workspace_config state) ~agent_name:"uncredentialed-agent" ~capabilities:[] ());
   ignore
     (Masc.Workspace.add_task (Mcp_server.workspace_config state) ~title:"transition-auth-preflight"
@@ -1892,9 +1892,9 @@ let test_execute_tool_add_task_with_admin_token_without_join () =
   let base_path = temp_dir () in
   let state = Mcp_eio.For_testing.create_state ~base_path () in
   ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None);
-  ignore (Masc.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
+  ignore (Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
   let raw_token =
-    match Masc.Auth.create_token base_path ~agent_name:"stable-admin" ~role:Masc_domain.Admin with
+    match Auth.create_token base_path ~agent_name:"stable-admin" ~role:Masc_domain.Admin with
     | Ok (token, _cred) -> token
     | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e)
   in
@@ -2278,7 +2278,7 @@ let test_handle_request_tools_list_internal_keeper_runtime_hides_keeper_internal
     ~finally:(fun () -> cleanup_dir base_path)
     (fun () ->
       let state = Mcp_eio.For_testing.create_state ~base_path () in
-      let token = Masc.Auth.ensure_internal_keeper_token base_path in
+      let token = Auth.ensure_internal_keeper_token base_path in
       let request = Yojson.Safe.to_string (`Assoc [
         ("jsonrpc", `String "2.0");
         ("id", `Int 119);
@@ -2321,7 +2321,7 @@ let test_handle_request_tools_call_internal_keeper_runtime_rejects_retired_execu
         (Keeper_registry.For_testing.register ~base_path keeper_name
            (make_keeper_meta ~agent_name:keeper_agent_name keeper_name));
       let state = Mcp_eio.For_testing.create_state ~base_path () in
-      let token = Masc.Auth.ensure_internal_keeper_token base_path in
+      let token = Auth.ensure_internal_keeper_token base_path in
       let request = Yojson.Safe.to_string (`Assoc [
         ("jsonrpc", `String "2.0");
         ("id", `Int 120);

--- a/test/test_mcp_server_eio_tool_dispatch.ml
+++ b/test/test_mcp_server_eio_tool_dispatch.ml
@@ -24,7 +24,7 @@ let cleanup_dir dir =
 
 let create_admin_token ?(agent_name = "stable-admin") base_path =
   match
-    Masc.Auth.create_token base_path ~agent_name ~role:Masc_domain.Admin
+    Auth.create_token base_path ~agent_name ~role:Masc_domain.Admin
   with
   | Ok (token, _cred) -> token
   | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e)

--- a/test/test_mcp_session_coverage.ml
+++ b/test/test_mcp_session_coverage.ml
@@ -14,7 +14,7 @@ open Alcotest
 
 module Http_transport = Server_mcp_transport_http
 module Actor_injection = Server_mcp_actor_injection
-module Auth = Masc.Auth
+module Auth = Auth
 
 let setup_test_workspace () =
   let unique_id =

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -342,7 +342,7 @@ let make_fixture sw ~proc_mgr ~fs ~net ~mono_clock clock ~base_path init_mode =
   seed_persona_dir base_path tool_matrix_agent_name;
   let auth_token =
     match
-      Masc.Auth.create_token base_path ~agent_name:tool_matrix_agent_name
+      Auth.create_token base_path ~agent_name:tool_matrix_agent_name
         ~role:Masc_domain.Admin
     with
     | Ok (token, _cred) -> token

--- a/test/test_operator_mcp_e2e.ml
+++ b/test/test_operator_mcp_e2e.ml
@@ -365,10 +365,10 @@ let with_server ?(host = "127.0.0.1") ?(enable_auth = true) f =
   Mirage_crypto_rng_unix.use_default ();
   let supervisor_token, planner_token, implementer_a_token, implementer_b_token =
     if enable_auth then begin
-      ignore (Masc.Auth.enable_auth config.base_path ~require_token:true ~agent_name:"test-supervisor");
+      ignore (Auth.enable_auth config.base_path ~require_token:true ~agent_name:"test-supervisor");
       let supervisor_token =
         match
-          Masc.Auth.create_token config.base_path ~agent_name:supervisor_nickname
+          Auth.create_token config.base_path ~agent_name:supervisor_nickname
             ~role:Masc_domain.Admin
         with
         | Ok (token, _cred) -> token
@@ -379,7 +379,7 @@ let with_server ?(host = "127.0.0.1") ?(enable_auth = true) f =
       in
       let create_worker_token agent_name =
         match
-          Masc.Auth.create_token config.base_path ~agent_name
+          Auth.create_token config.base_path ~agent_name
             ~role:Masc_domain.Worker
         with
         | Ok (token, _cred) -> token
@@ -393,7 +393,7 @@ let with_server ?(host = "127.0.0.1") ?(enable_auth = true) f =
         create_worker_token implementer_a_nickname,
         create_worker_token implementer_b_nickname )
     end else
-      (Masc.Auth.save_auth_config config.base_path
+      (Auth.save_auth_config config.base_path
          { Masc_domain.default_auth_config with enabled = false; require_token = false };
       ("", "", "", "")
       )

--- a/test/test_provider_http_error.ml
+++ b/test/test_provider_http_error.ml
@@ -6,7 +6,7 @@
     types. *)
 
 (* [masc] is a wrapped library, so reach the new module through its
-   namespace (the same pattern existing tests use, e.g. [Masc.Auth]).
+   namespace (the same pattern existing tests use, e.g. [Auth]).
    [Llm_provider] comes from agent_sdk.llm_provider and is bound directly. *)
 module Provider_http_error = Masc.Provider_http_error
 

--- a/test/test_server_auth_dashboard_actor_resolution.ml
+++ b/test/test_server_auth_dashboard_actor_resolution.ml
@@ -83,7 +83,7 @@ let test_rejected_credential_cannot_supply_actor_hint () =
 
 let test_malformed_credential_cannot_become_anonymous () =
   with_temp_base_path @@ fun base_path ->
-  Masc.Auth.save_auth_config
+  Auth.save_auth_config
     base_path
     { Masc_domain.default_auth_config with enabled = true; require_token = false };
   let request =
@@ -161,7 +161,7 @@ let expect_observer_admitted ~base_path request message =
 
 let test_mcp_auth_surfaces_preserve_typed_reasons () =
   with_temp_base_path @@ fun base_path ->
-  Masc.Auth.save_auth_config
+  Auth.save_auth_config
     base_path
     { Masc_domain.default_auth_config with enabled = true; require_token = true };
   let observer = observer_request () in
@@ -206,12 +206,12 @@ let test_mcp_auth_surfaces_preserve_typed_reasons () =
 
 let test_credential_source_precedence_and_observer_query_state () =
   with_temp_base_path @@ fun base_path ->
-  Masc.Auth.save_auth_config
+  Auth.save_auth_config
     base_path
     { Masc_domain.default_auth_config with enabled = true; require_token = false };
   let save_token agent_name raw_token =
     match
-      Masc.Auth.save_raw_token_credential
+      Auth.save_raw_token_credential
         base_path
         ~agent_name
         ~role:Masc_domain.Worker
@@ -274,7 +274,7 @@ let test_authenticated_owner_overrides_request_hint () =
   with_temp_base_path @@ fun base_path ->
   let token = "owner-token" in
   (match
-     Masc.Auth.save_raw_token_credential
+     Auth.save_raw_token_credential
        base_path
        ~agent_name:"credential-owner"
        ~role:Masc_domain.Worker

--- a/test/test_server_ide_http.ml
+++ b/test/test_server_ide_http.ml
@@ -8,7 +8,7 @@
 
 open Alcotest
 
-module Auth = Masc.Auth
+module Auth = Auth
 module Http = Masc.Http_server_eio
 module Json = Yojson.Safe.Util
 module Sse = Masc.Sse


### PR DESCRIPTION
구현 하나에 닿는 데 모듈 세 개, 그중 둘은 순수 `include` 다.

```
lib/auth.ml            (Masc.Auth)  include Auth_leaf
lib/auth/auth_leaf.ml               include Auth
lib/auth/auth.ml                    구현
```

`auth_leaf` 는 부모 facade 가 `Auth` 라는 이름을 차지해서 자기 자신을 `include` 할 수 없기 때문에만 존재한다 — 자기 docstring 에 그렇게 적혀 있다. 위를 지우면 중간이 존재할 이유도 사라진다. `auth_leaf` 의 소비자는 `lib/auth.ml:7` 하나였다.

## RFC-0292 의 마지막 항목

이 PR 은 `docs/rfc/RFC-0292-complete-lib-auth-dedup.md` 를 완료한다. 그 RFC 의 5개 중 4개는 이미 main 에서 사라졌는데 `implementation_prs` 는 여전히 비어 있다. `auth.ml` 이 마지막이고, 그 사이 355줄 drift 사본에서 7줄 facade 로 줄어 있었다.

## 죽은 별칭

`bin/main_eio.ml` 의 `module Auth = Masc.Auth` 는 한 번도 쓰이지 않았다 — `bin/` 전체에서 `Auth` 등장이 그 한 줄뿐이다. 재배선이 아니라 삭제했다.

## 재배선

소비자는 `masc_auth` leaf 의 bare `Auth` 로 옮긴다. `wrapped false` 이고 `bin/dune:11` 과 `test/deps/dune` (`re_export masc.auth`) 이 이미 직접 의존한다. 22파일 79곳.

`lib/` 내부에서 `Auth.` 를 쓰던 형제 모듈들은 이제 facade 대신 leaf 로 해석된다. `auth_leaf.mli` 가 `include module type of Auth` 였으므로 시그니처가 동일하다.

## grep 이 못 본 두 곳 — 컴파일러가 잡았다

| 위치 | 형태 |
|---|---|
| `test_dashboard_namespace_truth.ml:279,334` | `module Lib = Masc` 경유 `Lib.Auth.disable_auth` |
| `test_auth_bearer_mismatch_9786.inc` | 스탠자에 `masc` 만 있고 `masc.auth` 가 없어 부모 경유로 해석 중이었다 |

`Masc` 를 별칭으로 두는 테스트가 15개(`Lib`) + 1개(`M`) 있고, 그중 `.Auth.` 를 부르는 건 위 2줄뿐임을 전수 확인했다.

## 검증

`dune build --root . @check` → **exit 0, 출력 0바이트**.
