### PR TITLE
fix(lib): #27208 + #27218 이중 수리가 남긴 val 중복 선언 4개 제거 (main 컴파일 깨짐)

### DIFF
--- a/lib/tool_agent.mli
+++ b/lib/tool_agent.mli
@@ -19,9 +19,6 @@ val valid_agent_card_action_strings : string list
 (** Dispatch handler. Returns Some Tool_result.result if handled, None otherwise *)
 val dispatch : context -> name:string -> args:Yojson.Safe.t -> Tool_result.result option
 
-val json_ok :
-  tool_name:string -> start_time:float -> Yojson.Safe.t -> Tool_result.result
-
 val schemas : Masc_domain.tool_schema list
 
 (** JSON success result with [~data:json], consolidated here so sibling

--- a/lib/transport_read_model.mli
+++ b/lib/transport_read_model.mli
@@ -33,9 +33,6 @@ type http_context = {
       [transport_status_json] output (operator-only flag — UI
       never sets it). *)
 
-val configured_http_port : unit -> int
-val configured_http_host : unit -> string
-
 val normalize_advertised_host : string -> string
 (** [normalize_advertised_host host] returns the trimmed
     [host], unless it is one of the loopback aliases — in


### PR DESCRIPTION
## 문제

#27200 컴파일 깨짐을 #27208(플릿)과 #27218(본 PR 작성자)이 같은 시간대에 독립 수리하면서 main 에 중복 선언이 생김:

- `lib/tool_agent.mli`: `val json_ok` 2회 (line 22, 29)
- `lib/transport_read_model.mli`: `val configured_http_port` 2회 (line 36, 94), `val configured_http_host` 2회 (line 37, 98)

→ 모든 소비자가 `Multiple definition of the value name` 으로 컴파일 실패.

## 수정

각 .mli 에서 문서 없는 쪽 1쌍을 삭제, 문서화된 쌍만 유지 (2파일, -8줄).

## 검증

`scripts/dune-local.sh build lib/` → exit 0 (로컬, origin/main @ 99a80bd1ce 기준)

Related: #27200, #27208, #27218