### PR TITLE
test(tools): point the schema tests at the registry the server serves

### DIFF
--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -2,8 +2,11 @@
 
 open Masc_domain
 
-let schema_inventory = Tools.all_schemas_extended
-let registered_schema_inventory = Masc.Config.raw_all_tool_schemas
+(* One inventory: the registry the server actually serves. [Tools] used to
+   expose a separate [all_schemas_extended] list that no production code read,
+   and these tests validated that list instead of this one. *)
+let schema_inventory = Masc.Config.raw_all_tool_schemas
+let registered_schema_inventory = schema_inventory
 
 let find_schema_in schemas name =
   List.find_opt
@@ -81,12 +84,18 @@ let test_all_schemas_not_empty () =
   Alcotest.(check bool) "all_schemas is not empty"
     true (List.length schema_inventory > 0)
 
+(* A floor on the tool count pins nothing: it breaks whenever tools are
+   consolidated and says nothing about which tool is wrong. The invariants
+   worth holding are the ones below -- every schema names itself, describes
+   itself, and no two share a name. *)
 let test_all_schemas_count () =
-  (* Verify we have at least 50 tools defined (post-pruning floor) *)
-  let count = List.length schema_inventory in
-  Alcotest.(check bool) "at least 50 tools defined"
-    true (count >= 50);
-  Printf.printf "Total tool schemas: %d\n" count
+  List.iter
+    (fun (schema : Masc_domain.tool_schema) ->
+      Alcotest.(check bool)
+        (Printf.sprintf "%s has a description" schema.name)
+        true
+        (String.trim schema.description <> ""))
+    schema_inventory
 
 let test_schema_has_required_fields () =
   List.iter (fun schema ->
@@ -108,11 +117,25 @@ let test_schema_names_are_unique () =
   Alcotest.(check int) "all schema names are unique"
     (List.length names) (List.length unique_names)
 
+(* The registry uses three namespaces, not one: [masc_] for coordination,
+   [keeper_] for keeper-scoped surfaces, [tool_] for exec/file primitives.
+   Pinning the set is what catches an unprefixed or typo'd tool name; the
+   earlier single-[masc_] rule held only because these tests ran against a
+   47-schema list the server never served. *)
+let tool_name_namespaces = [ "masc_"; "keeper_"; "tool_" ]
+
 let test_all_names_start_with_masc () =
-  List.iter (fun schema ->
-    Alcotest.(check bool) (Printf.sprintf "%s starts with masc_" schema.name)
-      true (String.length schema.name >= 5 && String.sub schema.name 0 5 = "masc_")
-  ) schema_inventory
+  List.iter
+    (fun (schema : Masc_domain.tool_schema) ->
+      Alcotest.(check bool)
+        (Printf.sprintf "%s uses a known namespace" schema.name)
+        true
+        (List.exists
+           (fun prefix ->
+             String.length schema.name >= String.length prefix
+             && String.equal (String.sub schema.name 0 (String.length prefix)) prefix)
+           tool_name_namespaces))
+    schema_inventory
 
 (* ============================================================ *)
 (* 2. Schema Inventory Lookup Tests                              *)


### PR DESCRIPTION
## 이 테스트는 서버가 서빙하지 않는 목록을 검사하고 있었다

```ocaml
let schema_inventory = Tools.all_schemas_extended        (* 47 개 *)
let registered_schema_inventory = Masc.Config.raw_all_tool_schemas  (* 118 개 *)
```

파일 안에서 `schema_inventory` 는 14 번 쓰이고 `registered_schema_inventory` 는 바인딩과 헬퍼 정의 2 줄이 전부다. 즉 거의 모든 단언이 47 개짜리 목록에 걸려 있었다.

그런데 **`Tools.all_schemas_extended` 는 프로덕션에서 아무도 읽지 않는다.** 레포 전체 참조가 두 개뿐이다 — 이 테스트의 5 행, 그리고 `keeper_tool_descriptor.ml:903` 의 주석 한 줄.

서버가 실제로 서빙하는 것은 `Config.raw_all_tool_schemas` 다. `unified_tool_registry.ml:120` 이 여기서 LLM 가시 스키마를 등록하고, `mcp_server_eio_tool_profile.ml:111` 이 가시성을 이 목록으로 정의한다.

## 돌려놓자 두 가지가 드러났다

### 1. `masc_` 접두사 규약은 실제 규약이 아니다

`test_all_names_start_with_masc` 는 모든 도구가 `masc_` 로 시작한다고 단언한다. 살아 있는 레지스트리에서는 **118 개 중 28 개가 위반** 한다.

```
keeper_time_now, keeper_context_status, keeper_memory_search, keeper_memory_write,
keeper_tools_list, keeper_ide_annotate, keeper_voice_speak, ... (keeper_ 24 개)
tool_read_file, tool_edit_file, tool_write_file, tool_search_files, tool_execute (tool_ 5 개)
```

레지스트리는 세 네임스페이스를 쓴다 — 조정 계열 `masc_`, keeper 범위 `keeper_`, exec/파일 원시 도구 `tool_`. 단일 `masc_` 규칙은 47 개짜리 목록에 우연히 `masc_` 만 있었기 때문에 통과하고 있었다.

세 네임스페이스 집합에 속하는지로 바꾼다. 이건 실제 규칙이고, 접두사 없는 도구나 오타를 잡는다.

### 2. `count >= 50` 은 아무것도 고정하지 않는다

```ocaml
(* Verify we have at least 50 tools defined (post-pruning floor) *)
Alcotest.(check bool) "at least 50 tools defined" true (count >= 50)
```

`#7184` 가 65 개 도구를 정리한 직후 세운 하한이다. 지금 47 이라 실패한다. 도구가 통합될 때마다 손으로 내려야 하고, 깨져도 **어느 도구가 잘못됐는지 말해주지 않는다**. 스키마마다 설명이 비어 있지 않은지 보는 단언으로 바꾼다 — 형제 테스트(고유 이름, 필수 필드)와 같은 성격의 실제 불변식이다.

## 왜 아무도 몰랐나

`test_tools_coverage` 는 `.github/workflows/ci.yml` 에 없다. 선언되어 있지만 실행되지 않는 스위트다.

무작위 표본 10 개를 빌드해 돌려보니 2 개가 실패했다 (`test_tools_coverage`, `test_keeper_busy_dashboard_deferred` — 후자는 `Invalid_argument("result is Error _")` 로 죽는다). 별도로 발견한 `test_workspace_goal_index` 까지 하면 11 개 중 3 개다. 표본이 작으니 비율을 단정하지는 않는다.

`audit-ci-test-targets.sh` 가 이 위험을 이미 문서화하고 있다 — "A suite outside ci.yml is compile-only: it never executes, so its assertions can outlive the code they pin."

## 이 PR 이 하지 않는 것

- **스위트를 ci.yml 에 배선하지 않는다.** 배선하면 미배선 카운트가 1 줄고, 그 감사는 카운트가 baseline 아래로 내려가면 실패해서 같은 PR 에서 `UNWIRED_BASELINE` 을 함께 내려야 한다. 그 상수는 지금 #27181 이 조정 중이라 충돌한다. 그 PR 이 정리되면 배선을 별도로 낸다.
- **`Tools.all_schemas_extended` 를 지우지 않는다.** 프로덕션 소비자가 없지만 같은 모듈의 `find_tool` 이 그것을 참조하고, `find_tool` 도 소비자가 없어서 함께 지워야 한다. 죽은 표면 제거는 이 PR 의 주장(테스트가 잘못된 목록을 봤다)과 별개라 분리한다.

## 검증

`dune build @check` 통과. `test_tools_coverage` 50 건 통과 (변경 전에는 1 건 실패).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
