### PR TITLE
fix(pulse): quiet-hour 테스트가 사본이 아니라 프로덕션을 돌게 한다

### DIFF
--- a/lib/masc_log/console_sink.ml
+++ b/lib/masc_log/console_sink.ml
@@ -116,11 +116,9 @@ module For_testing = struct
   (* Enqueue mode without the OS thread, so tests drain deterministically. *)
   let set_enqueue_active v = Atomic.set enqueue_active v
 
-  let queued_count () =
-    Mutex.lock mu;
-    let n = Queue.length queue in
-    Mutex.unlock mu;
-    n
+  (* The gauge in [Otel_runtime_observables] reads [queue_depth]; tests must
+     read that same function, not a second copy of its body. *)
+  let queued_count = queue_depth
 
   let drain_now () =
     Mutex.lock mu;

--- a/lib/pulse/pulse.ml
+++ b/lib/pulse/pulse.ml
@@ -87,27 +87,33 @@ let kst_hour clock =
   let t = Unix.gmtime (now clock) in
   (t.tm_hour + 9) mod 24
 
-(** Is the current hour within the quiet window? *)
-let is_quiet_hour clock rhythm =
-  let h = kst_hour clock in
-  let (qs, qe) = rhythm.quiet in
+(** Is [hour] within the quiet window?  Takes the hour rather than a clock so
+    the decision itself is a pure function of its inputs: the clock reading is
+    the caller's, and [For_testing] hands these out unchanged instead of
+    keeping a second copy that tests could pass while production drifted. *)
+let is_quiet_hour_at ~hour ~quiet_range =
+  let (qs, qe) = quiet_range in
   if qs <= qe then
     (* e.g., 1..6 *)
-    h >= qs && h < qe
+    hour >= qs && hour < qe
   else
     (* wrap-around, e.g., 22..6 *)
-    h >= qs || h < qe
+    hour >= qs || hour < qe
 
-(** Compute the effective interval for the next beat.
+(** Effective interval for a beat landing on [hour].
     Quiet hours stretch the base interval by 3x, clamped to [min, max]. *)
-let effective_interval clock rhythm =
+let effective_interval_at ~hour rhythm =
   let base =
-    if is_quiet_hour clock rhythm then
+    if is_quiet_hour_at ~hour ~quiet_range:rhythm.quiet then
       rhythm.base_s *. 3.0
     else
       rhythm.base_s
   in
   Float.max rhythm.min_s (Float.min rhythm.max_s base)
+
+(** Compute the effective interval for the next beat. *)
+let effective_interval clock rhythm =
+  effective_interval_at ~hour:(kst_hour clock) rhythm
 
 (* ── Consumer dispatch ───────────────────────────────────────── *)
 
@@ -305,17 +311,9 @@ let remove_consumer t name =
 
 (* ── Testing helpers ───────────────────────────────────────────── *)
 
+(* Re-exports, not copies: [test_pulse.ml] drives these names, so they have to
+   be the same functions [effective_interval] runs on every beat. *)
 module For_testing = struct
-  let is_quiet_hour_at ~hour ~quiet_range =
-    let (qs, qe) = quiet_range in
-    if qs <= qe then hour >= qs && hour < qe
-    else hour >= qs || hour < qe
-
-  let effective_interval_at ~hour rhythm =
-    let quiet = is_quiet_hour_at ~hour ~quiet_range:rhythm.quiet in
-    let base =
-      if quiet then rhythm.base_s *. 3.0
-      else rhythm.base_s
-    in
-    Float.max rhythm.min_s (Float.min rhythm.max_s base)
+  let is_quiet_hour_at = is_quiet_hour_at
+  let effective_interval_at = effective_interval_at
 end

--- a/lib/pulse/pulse.ml
+++ b/lib/pulse/pulse.ml
@@ -316,4 +316,11 @@ let remove_consumer t name =
 module For_testing = struct
   let is_quiet_hour_at = is_quiet_hour_at
   let effective_interval_at = effective_interval_at
+
+  (* The clock-taking wrapper the beat loop actually calls. Exposed so a test
+     can pin the delegation itself, which neither pure function reaches: a
+     wrapper that stopped consulting the rhythm, or read the hour from the
+     wrong place, would leave both of them passing. *)
+  let effective_interval_for_clock clock rhythm =
+    effective_interval (Clock clock) rhythm
 end

--- a/lib/pulse/pulse.mli
+++ b/lib/pulse/pulse.mli
@@ -142,4 +142,9 @@ module For_testing : sig
   val effective_interval_at : hour:int -> rhythm -> float
   (** [effective_interval_at ~hour rhythm] computes the interval in seconds.
       During quiet hours: base * 3.0, clamped to [min_s, max_s]. *)
+
+  val effective_interval_for_clock : _ Eio.Time.clock -> rhythm -> float
+  (** The clock-taking form the beat loop calls, reading the hour from
+      [clock] rather than taking it. Same result as
+      {!effective_interval_at} at that hour. *)
 end

--- a/test/test_pulse.ml
+++ b/test/test_pulse.ml
@@ -307,6 +307,40 @@ let () = test "quiet_hour_wrap_around" (fun () ->
   assert (not (q ~hour:21 ~quiet_range:range))
 )
 
+(* ── Test: the clock wrapper delegates to the pure form ──────── *)
+
+(* The two tests above drive the hour-parameterised functions directly. This
+   one drives the wrapper the beat loop calls, so the delegation is covered
+   too: a wrapper that ignored rhythm.quiet, or fed the pure form a constant,
+   would pass both of the others. Windows of (0,24) and (0,0) make the
+   expected answer independent of what hour the clock actually reports. *)
+let () = test "effective_interval_for_clock honours the quiet window" (fun () ->
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let base = { Pulse.base_s = 10.0; min_s = 1.0; max_s = 100.0; quiet = (0, 0) } in
+  let always_quiet = { base with Pulse.quiet = (0, 24) } in
+  let f = Pulse.For_testing.effective_interval_for_clock in
+  (* (0,0) is empty under qs <= qe, so no hour is quiet: plain base. *)
+  assert (Float.abs (f clock base -. 10.0) < 1e-9);
+  (* (0,24) covers every hour: base * 3, still inside [min_s, max_s]. *)
+  assert (Float.abs (f clock always_quiet -. 30.0) < 1e-9)
+)
+
+(* The clamp has to survive the wrapper as well, not just the pure form. *)
+let () = test "effective_interval_for_clock clamps the stretched interval" (fun () ->
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let capped =
+    { Pulse.base_s = 10.0; min_s = 1.0; max_s = 12.0; quiet = (0, 24) }
+  in
+  let floored =
+    { Pulse.base_s = 10.0; min_s = 40.0; max_s = 100.0; quiet = (0, 0) }
+  in
+  let f = Pulse.For_testing.effective_interval_for_clock in
+  assert (Float.abs (f clock capped -. 12.0) < 1e-9);
+  assert (Float.abs (f clock floored -. 40.0) < 1e-9)
+)
+
 (* ── Test: quiet hour — boundary cases ───────────────────────── *)
 
 let () = test "quiet_hour_boundary" (fun () ->


### PR DESCRIPTION
`pulse.ml` 이 quiet-window 판정을 **두 벌** 들고 있었다.

| | 호출자 |
|---|---|
| `is_quiet_hour` + `effective_interval` | beat 루프 (프로덕션) |
| `For_testing.is_quiet_hour_at` + `effective_interval_at` | `test_pulse.ml` |

quiet-hour 테스트 3개(normal range / wrap-around / boundary)는 **두 번째 사본만** 검증했다.

중복이 생긴 이유는 분명하다. 프로덕션 쌍이 Eio clock 을 받는데 `test_pulse.ml` 에는 clock 하네스가 없어서, 아래에 두는 대신 옆에 hour 형태를 하나 더 쓴 것이다.

## 뒤집었다

순수 `~hour` 함수가 정의가 되고, `effective_interval clock rhythm` 은 `effective_interval_at ~hour:(kst_hour clock) rhythm` 이 된다. `For_testing` 은 재서술이 아니라 **재수출**한다. `is_quiet_hour` 는 사라졌다 — 유일한 호출자가 `effective_interval` 이었고 둘 다 `.mli` 에 없었다.

## 측정

wrap-around 분기(`hour >= qs || hour < qe`)를 `false` 로 바꾸고 `test_pulse` 실행:

```
수정 전  →  통과       (사본은 그대로이므로)
수정 후  →  exit 1, quiet_hour_wrap_around 가 line 299 에서 실패
```

그 분기가 중요한 이유: 자정을 넘는 창(22..6)이 정확히 `qs <= qe` 가 못 덮는 경우이고, 운영자가 실제로 쓸 법한 유일한 값이다.

## 범위 밖 (측정만 하고 남김)

- `Keeper_status_runtime` 에 **세 번째 사본**이 있는데 형태가 `quiet_start < quiet_end && ...` 라, 자정 넘는 창이면 조용히 "quiet 아님" 으로 보고한다
- KST `+9` 오프셋이 두 모듈에 하드코딩돼 있다
- `rhythm.quiet` 는 리터럴 `(1, 6)` 이고, `MASC_AUTONOMY_QUIET_START/END` 는 keeper 쪽 라벨에만 닿는다
