### PR TITLE
test(keeper): unbreak the busy-dashboard suite and stop pinning ACK prose

### DIFF
--- a/test/test_keeper_busy_dashboard_deferred.ml
+++ b/test/test_keeper_busy_dashboard_deferred.ml
@@ -124,7 +124,8 @@ let seed_keeper config =
     Masc_test_deps.meta_of_json_fixture
       (`Assoc
          [ "name", `String keeper_name
-         ; "agent_name", `String ("keeper-" ^ keeper_name)
+         ; ( "agent_name"
+           , `String (Masc.Keeper_identity.keeper_agent_name keeper_name) )
          ; "trace_id", `String ("trace-" ^ keeper_name)
          ])
     |> Result.get_ok
@@ -351,12 +352,11 @@ let test_shutdown_fenced_dashboard_ack_preserves_cause () =
      check "dashboard queued event carries shutdown operation id"
        (String.equal operation_id_text
           (json |> member "shutdown_operation_id" |> to_string));
-     check "dashboard ACK names the shutdown operation"
-       (Astring.String.is_infix
-          ~affix:("stopping under operation " ^ operation_id_text)
-          ack);
-     check "dashboard ACK promises the next active lane"
-       (Astring.String.is_infix ~affix:"for the next active lane" ack)
+     (* The operation id is asserted above on [shutdown_operation_id], which is
+        the typed carrier. The ACK body is operator-facing prose and has since
+        been localized, so matching English fragments in it pinned wording
+        rather than contract. *)
+     check "dashboard ACK is not empty" (String.trim ack <> "")
    | `Not_busy | `Queue_error _ ->
      check "shutdown-fenced dashboard message is durably queued" false);
   check "shutdown-fenced dashboard receipt stays Pending"


### PR DESCRIPTION
## `test_keeper_busy_dashboard_deferred` 는 main 에서 죽는다

이 스위트는 첫 번째 fixture 에서 예외로 프로세스가 죽는다.

```
Fatal error: exception Invalid_argument("result is Error _")
  Called from ... seed_keeper in test/test_keeper_busy_dashboard_deferred.ml, lines 124-130
```

`Result.get_ok` 가 감춘 실제 오류는 이것이다.

```
invalid current keeper meta: agent_name does not match canonical keeper identity; runtime reset required
```

fixture 가 `agent_name` 을 `"keeper-" ^ name` 으로 손수 조립한다. 정본은 `keeper-<name>-agent` 다 (`keeper_identity.mli:34`, `keeper_meta_json_parse.ml:364` 가 강제). 다른 테스트들은 정본 함수를 쓰거나(35 파일) 접미사까지 맞춰 쓰는데, 이 파일만 `-agent` 가 빠져 있다. 손수 조립을 `Keeper_identity.keeper_agent_name` 호출로 바꾼다.

## 그다음 드러난 두 실패는 문장을 고정하고 있었다

fixture 를 고치면 스위트가 끝까지 돌고 2 건이 실패한다.

```ocaml
check "dashboard ACK names the shutdown operation"
  (Astring.String.is_infix ~affix:("stopping under operation " ^ operation_id_text) ack);
check "dashboard ACK promises the next active lane"
  (Astring.String.is_infix ~affix:"for the next active lane" ack)
```

지금 ACK 는 이렇다.

```
busy-dashboard-keeper가 종료 중이에요. 다시 활동을 시작하면 이 메시지를 처리합니다.
```

메시지가 현지화되면서 영어 조각이 사라졌다. 중요한 것은 **바로 위 줄의 단언은 통과한다** 는 점이다.

```ocaml
check "dashboard queued event carries shutdown operation id"
  (String.equal operation_id_text (json |> member "shutdown_operation_id" |> to_string));
```

operation id 는 타입 있는 JSON 필드가 나르고 그 계약은 지켜지고 있다. 두 substring 단언은 계약이 아니라 **문구** 를 고정했고, 문구가 바뀌자 깨졌다. ACK 가 비어 있지 않은지만 확인하도록 바꾼다.

## 왜 아무도 몰랐나

`test_keeper_busy_dashboard_deferred` 는 `.github/workflows/ci.yml` 에 없다. 컴파일만 되고 실행되지 않는 스위트다.

미배선 스위트에서 무작위 10 개를 뽑아 돌려보니 2 개가 실패했고 (이 스위트와 `test_tools_coverage`), 별도로 발견한 `test_workspace_goal_index` 까지 하면 11 개 중 3 개다. 표본이 작아 비율은 단정하지 않는다.

## 검증

`dune build @check` 통과. `test_keeper_busy_dashboard_deferred` 전체 통과 (변경 전에는 프로세스가 죽었다).

CI 배선은 이 PR 에서 하지 않는다 — 스위트를 배선하면 미배선 카운트가 줄고 `audit-ci-test-targets.sh` 가 `UNWIRED_BASELINE` 을 같은 PR 에서 내리라고 요구하는데, 그 상수는 #27181 이 조정 중이다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
