### PR TITLE
fix(task): 종료 상태 거부 3종이 '대신 무엇을' 을 말하게 (#27138 과 같은 결함, 이미 테스트가 있었다)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -889,7 +889,8 @@ jobs:
             @test/runtest-test_tool_registry_consistency \
             @test/runtest-test_tool_spec \
             @test/runtest-test_tool_shard_coverage \
-            @test/runtest-test_tool_board_coverage
+            @test/runtest-test_tool_board_coverage \
+            @test/runtest-test_tool_task_coverage
 
       - name: Run completion-authority lookup surface suite
         # The judge's lookup tools reach the filesystem and Git inside a

--- a/lib/task/tool_task_contract_gate.ml
+++ b/lib/task/tool_task_contract_gate.ml
@@ -30,17 +30,21 @@ let completion_state_error ~(task_id : string) ~(agent_name : string)
       Some
         (Masc_domain.Task (Masc_domain.Task_error.InvalidState
            (Printf.sprintf
-              "task %s is already done by %s"
-              task_id assignee)))
+              "task %s is already done by %s; to re-run it, create a new task \
+               with predecessor_task_id set to %s"
+              task_id assignee task_id)))
     | Masc_domain.Cancelled { cancelled_by; _ } ->
       Some
         (Masc_domain.Task (Masc_domain.Task_error.InvalidState
            (Printf.sprintf
-              "task %s was cancelled by %s"
-              task_id cancelled_by)))
+              "task %s was cancelled by %s; to re-run it, create a new task \
+               with predecessor_task_id set to %s"
+              task_id cancelled_by task_id)))
     | Masc_domain.AwaitingVerification { assignee; _ } ->
       Some
         (Masc_domain.Task (Masc_domain.Task_error.InvalidState
            (Printf.sprintf
-              "task %s has a pending verification workflow for %s"
+              "task %s has a pending verification workflow for %s; resolve it \
+               with an operator or auto-judge verdict before another \
+               transition — this tool cannot produce one"
               task_id assignee)))

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -88,7 +88,7 @@ echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, al
 # authority tools, memory journal) without lowering the baseline. A PR that
 # wires a suite must lower this number in the same PR, or this check goes red
 # for everyone.
-UNWIRED_BASELINE=747
+UNWIRED_BASELINE=744
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1060,7 +1060,12 @@ let () = test "handle_transition_submit_rejects_registered_keeper_alias"
            ])
     in
     assert (not (Tool_result.is_success result));
-    assert (str_contains (Tool_result.message result) "requires owning the task");
+    (* Pin the fact, not the phrasing: the refusal has to name the identity that
+       actually owns the task, so a reader can tell an ownership rejection from
+       an incidental FSM one. The old assertion pinned the literal "requires
+       owning the task", which the message stopped using while still rejecting
+       for exactly this reason. *)
+    assert (str_contains (Tool_result.message result) "keeper-executor-agent");
     assert_task_claimed_by ctx "keeper-executor-agent"))
 
 let () = test "keeper_reconciliation_ignores_prefix_matched_agent"


### PR DESCRIPTION
## 이 저장소에는 이미 그 원칙을 강제하는 테스트가 있었다

`test_tool_task_coverage` 에 이름부터 그런 테스트가 있다 — `handle_transition_done_on_awaiting_verification_is_explicit`. 고정하던 건 "거부하라" 가 아니라 **"거부하면서 빠져나갈 길을 말하라"** 였다:

```ocaml
assert (not (Tool_result.is_success result));                (* 통과 *)
assert (str_contains msg "pending verification workflow");   (* 통과 *)
assert (str_contains msg "resolve it");                      (* 실패 *)
```

안내 절반이 사라져 있었다. 그 suite 가 **어떤 workflow 에도 없어서** 아무도 몰랐다.

`#27138` 에서 고친 것이 정확히 같은 결함이다 — 단일 클레임 거부가 들고 있는 Task 만 말하고 `masc_transition action=release` 를 안 말했고, `keeper.md` 가 그 공백을 산문으로 메우고 있었다. **원칙을 강제하는 검사가 이미 있었는데 red 이고 안 돌아서, 나는 그걸 처음부터 다시 발견해야 했다.**

## 세 arm 을 모두 고친다

종료 상태 게이트의 세 갈래가 같은 형태다 — 무엇이 잘못됐는지만 말하고 무엇을 하라를 안 말한다. 하나만 고치면 CLAUDE.md 의 "PR #X only fixed M of N sites" 시그니처다.

| 상태 | 추가된 안내 |
|---|---|
| `Done` | `predecessor_task_id` 로 새 task 를 만드는 재실행 경로 |
| `Cancelled` | 동일 |
| `AwaitingVerification` | operator / auto-judge verdict, **그리고 이 도구는 그걸 만들 수 없다는 사실** |

`Done` / `Cancelled` 문구는 지어낸 게 아니다. `tool_task_schemas.ml:47` 이 이미 적고 있다 — *"To re-run completed work, create a new task with predecessor_task_id instead of touching the done one."*

## 같은 suite 의 두 번째 실패는 반대 경우다

별칭 신원 거부 메시지가 이렇게 바뀌었다:

```
Invalid transition: claimed -> submit_for_verification
  (task-001, agent=keeper-executor, current_assignee=keeper-executor-agent)
```

테스트가 고정하던 `"requires owning the task"` 보다 **더 많은 정보를 준다.** 동작도 온전하다 — 같은 파일 line 1536 에서 소유자가 submit 하고 성공을 단언하며 통과한다.

그래서 여기는 코드가 아니라 **단언을 옮긴다**: 문구가 아니라 사실(메시지가 실제 소유자를 명시하는가)을 고정한다. 그러면 "거부됐다" 가 아니라 "**소유권 때문에** 거부됐다" 를 계속 증명한다.

## 양방향 검증

```
게이트에서 안내 제거      1 failure!
테스트에 옛 문구 복원     1 failure!
둘 다 제자리             Test Successful
```

`dune build @check` clean · `audit-ci-test-targets` clean · ocamlformat clean.

`"was cancelled by"` 를 고정하는 형제 suite (`test_keeper_unified_verification_surface`) 도 통과한다 — 추가분이 접미사라 부분 문자열 단언이 계속 맞는다.

## CI 배선

`test_tool_task_coverage` 를 다른 contract suite 옆에 넣었다. 배선 없이 고치면 다음에 또 조용히 사라진다 — 이 PR 이 그 증거다.

관련: `#27207` (이 suite 를 포함한 미배선 red 표본 조사) · `#27138` (같은 결함, 다른 지점) · `#27206` (같은 계열, 픽스처 수리 + 배선)

RFC-WAIVED: 오류 메시지 3 개 + 테스트 단언 1 개 + CI 타겟 1 개. credential / operator control / keeper sandbox / hooks / workflow 문서 미접촉.

🤖 Generated with [Claude Code](https://claude.com/claude-code)