### PR TITLE
refactor(lib): drop 29 For_testing declarations no test uses

### DIFF
--- a/lib/activity_graph/activity_graph.ml
+++ b/lib/activity_graph/activity_graph.ml
@@ -892,8 +892,6 @@ module For_testing = struct
   let reset_current_day_cache_for_testing = reset_current_day_cache_for_testing
   let reset_past_day_cache_for_testing = reset_past_day_cache_for_testing
   let current_day_parsed_line_count () = Atomic.get current_day_parse_counter
-  let current_day_cache_entry_count () =
-    Stdlib.Mutex.protect current_day_cache_mu (fun () -> Hashtbl.length current_day_cache)
   let past_day_cache_entry_count () =
     Past_day_path_map.cardinal (Atomic.get past_day_cache)
   let current_day_path = day_path

--- a/lib/activity_graph/activity_graph.mli
+++ b/lib/activity_graph/activity_graph.mli
@@ -151,13 +151,7 @@ module For_testing : sig
   (** Clears the [(path, mtime) -> event list] past-day cache. *)
 
   val current_day_parsed_line_count : unit -> int
-  (** Number of non-blank lines folded through the *incremental delta*
-      path since the last reset (excludes the initial cold-miss full
-      parse and the invalid-UTF-8 / shrink fallback rescans). Lets a
-      test prove that appending [n] lines behind a warm cache parses
-      exactly [n] lines, not the whole file. *)
 
-  val current_day_cache_entry_count : unit -> int
   val past_day_cache_entry_count : unit -> int
 
   val current_day_path : Workspace_utils.config -> string

--- a/lib/dashboard/dashboard_goals.mli
+++ b/lib/dashboard/dashboard_goals.mli
@@ -102,11 +102,4 @@ module For_testing : sig
     config:Workspace.config ->
     Yojson.Safe.t
 
-  val goal_detail_json_with_pending_reader :
-    read_pending:
-      (base_path:string ->
-      (Yojson.Safe.t list, Keeper_approval_queue.storage_error) result) ->
-    config:Workspace.config ->
-    goal_id:string ->
-    (Yojson.Safe.t, string) result
 end

--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -841,8 +841,6 @@ let install_agent_observation_sinks () =
    small thresholds without writing multi-megabyte segments. Not part of
    the production surface. *)
 module For_testing = struct
-  let default_max_segment_bytes = default_max_segment_bytes
-  let default_max_retained_segments = default_max_retained_segments
   let append_rotating = append_rotating
   let tail_read_lines = tail_read_lines
   let segment_paths_newest_first = segment_paths_newest_first

--- a/lib/ide/ide_bridge.mli
+++ b/lib/ide/ide_bridge.mli
@@ -112,8 +112,7 @@ val ingest_tool_event_from_hook :
     reaches these through [append_event]/[list_events] with the default
     thresholds. *)
 module For_testing : sig
-  val default_max_segment_bytes : int
-  val default_max_retained_segments : int
+
 
   (** Rotation-aware append: rotate the live segment out when it reaches
       [max_segment_bytes], append the row, then prune archives beyond

--- a/lib/keeper/hitl_summary_worker.mli
+++ b/lib/keeper/hitl_summary_worker.mli
@@ -55,11 +55,6 @@ module For_testing : sig
     :  entry:Keeper_approval_queue.pending_approval
     -> Yojson.Safe.t
 
-  val messages_for_summary
-    :  system_prompt:string
-    -> context_bundle:Yojson.Safe.t
-    -> Agent_sdk.Types.message list
-
   val parse_summary
     :  generated_at:float
     -> model_run_id:string
@@ -151,7 +146,7 @@ module For_testing : sig
       production [spawn]; the worker does not depend on test-only queue APIs. *)
 
   val flow_evidence : prepared_flow -> Agent_sdk.Exact_output.flow_evidence
-  val success_provenance_matches : Agent_sdk.Exact_output.flow_success -> bool
+
   val summary_version : int
   val lane_id : string
 end

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -122,10 +122,6 @@ module For_testing : sig
     -> tool_call_detail list
     -> (string * int) option
 
-  val provider_transcript_admission
-    :  Agent_sdk.Types.message list
-    -> (unit, Agent_sdk.Error.sdk_error) result
-
   val dispatch_after_provider_transcript_admission
     :  messages:Agent_sdk.Types.message list
     -> dispatch:(unit -> ('a, Agent_sdk.Error.sdk_error) result)

--- a/lib/keeper/keeper_chat_consumer.mli
+++ b/lib/keeper/keeper_chat_consumer.mli
@@ -127,5 +127,5 @@ module For_testing : sig
   val notify_transition : keeper_name:string -> unit
   val take_wake_nonblocking : unit -> string option
   val reset_wake_inbox : unit -> unit
-  val reset_persistence_blocked : unit -> unit
+
 end

--- a/lib/keeper/keeper_event_bridge.mli
+++ b/lib/keeper/keeper_event_bridge.mli
@@ -51,17 +51,4 @@ module For_testing : sig
     | Delivered
     | Retryable_failure of pending_relay * relay_stage * exn
 
-  val make_pending : Yojson.Safe.t -> pending_relay
-
-  val relay_max_queue_depth : int
-
-  val resolve_oas_event_retention_days : string option -> int option
-
-  val should_drain_subscription : pending_relay list -> bool
-
-  val deliver_pending_with :
-    append_json:(Yojson.Safe.t -> unit) ->
-    broadcast_json:(Yojson.Safe.t -> unit) ->
-    pending_relay ->
-    relay_result
 end

--- a/lib/keeper/keeper_event_queue_recovery.mli
+++ b/lib/keeper/keeper_event_queue_recovery.mli
@@ -103,18 +103,7 @@ module For_testing : sig
     | Claim_acquired of 'a
     | Claim_already_held
 
-  val with_owner_claim :
-    base_path:string ->
-    keeper_name:string ->
-    (unit -> 'a) ->
-    ('a claim_outcome, projection_error) result
-  (** Hold the canonical process-local owner claim while running the callback.
-      The claim-table mutex is not held while the callback runs. *)
 
-  val pending_transition_count_result :
-    base_path:string ->
-    keeper_name:string ->
-    (int, projection_error) result
   (** Read-only observation of the canonical durable outbox. No raw entry or
       transition-retirement capability crosses this testing boundary. *)
 end

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -149,10 +149,7 @@ val unavailable_fleet_summary_json : unit -> Yojson.Safe.t
     Kept here so schema and field ownership remain single-source. *)
 
 module For_testing : sig
-  val with_after_ledger_append :
-    after_ledger_append:(unit -> (unit, string) result) ->
-    (unit -> 'a) ->
-    'a
+
   (** Scoped post-append fault seam. The callback must invoke the canonical
       recovery projector; this seam cannot read or retire an outbox itself. *)
 end

--- a/lib/keeper/keeper_runtime_trust_snapshot.mli
+++ b/lib/keeper/keeper_runtime_trust_snapshot.mli
@@ -5,7 +5,7 @@ val summary_json :
   config:Workspace.config -> meta:Keeper_meta_contract.keeper_meta -> Yojson.Safe.t
 
 module For_testing : sig
-  val clear_snapshot_cache : unit -> unit
+
 
   val snapshot_json_inner_with_pending_reader :
     read_pending:

--- a/lib/keeper/keeper_tool_execute_runtime.mli
+++ b/lib/keeper/keeper_tool_execute_runtime.mli
@@ -53,12 +53,7 @@ module For_testing : sig
     args:Yojson.Safe.t ->
     cwd:string ->
     (string * Yojson.Safe.t) list
-  val execute_gate_input :
-    input:Yojson.Safe.t ->
-    cwd:string ->
-    sandbox_profile:string ->
-    sandbox_target:string ->
-    Yojson.Safe.t
+
   val redact_execute_output :
     base_path:string ->
     keeper_name:string ->

--- a/lib/keeper/keeper_tool_progress_identity.mli
+++ b/lib/keeper/keeper_tool_progress_identity.mli
@@ -14,5 +14,5 @@ val digest_tool_io :
   io_fingerprints option
 
 module For_testing : sig
-  val normalize_json : Yojson.Safe.t -> Yojson.Safe.t
+
 end

--- a/lib/keeper/keeper_transition_audit.mli
+++ b/lib/keeper/keeper_transition_audit.mli
@@ -67,7 +67,7 @@ val queue_depth : unit -> int
 
 module For_testing : sig
   val reset_state : unit -> unit
-  val clear_completed_turn_ring : keeper_name:string -> unit
+
   val observe_append_failure : site:string -> exn -> unit
   val queued_count : unit -> int
   val dropped_count : unit -> int

--- a/lib/keeper/keeper_turn_admission.mli
+++ b/lib/keeper/keeper_turn_admission.mli
@@ -347,10 +347,7 @@ val fleet_health_json :
 
 module For_testing : sig
   val reset : unit -> unit
-  (** Drop every slot. Only safe when no turn is in flight. *)
 
-  val with_unpublished_turn_lock :
-    base_path:string -> keeper_name:string -> (unit -> 'a) -> 'a
   (** Hold the raw turn mutex without publishing [in_flight_info]. Constructs
       the documented lock-to-observability window for deterministic admission
       regression tests. *)

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -8,7 +8,6 @@ module For_testing : sig
     | Terminal_checkpoint
     | Terminal_input_required
 
-  val terminal_outcome_of_result : Keeper_agent_run.run_result -> terminal_outcome
 
   val persist_terminal_turn_meta_for_outcome
     :  config:Workspace.config
@@ -22,11 +21,6 @@ module For_testing : sig
     -> updated_meta:Keeper_meta_contract.keeper_meta
     -> Keeper_agent_run.run_result
     -> unit
-
-  val acknowledge_pending_messages
-    :  Keeper_meta_contract.keeper_meta
-    -> Keeper_world_observation.world_observation
-    -> Keeper_meta_contract.keeper_meta
 
   type cycle_post_action =
     | Assign_task

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -245,10 +245,6 @@ val media_degrade_note :
 module For_testing : sig
   val with_oas_tool_of_masc_hook_unset : (unit -> 'a) -> 'a
 
-  val provider_http_observation_transport :
-    Llm_provider.Llm_transport.t -> Llm_provider.Llm_transport.t
-
-  val runtime_id_of_config : config -> string
 
   val stop_reason_of_cooperative_yield :
     turns_used:int -> cooperative_yield_reason -> stop_reason
@@ -264,8 +260,6 @@ module For_testing : sig
   val required_modalities_of_content_blocks :
     Agent_sdk.Types.content_block list -> string list
 
-  val content_blocks_of_messages :
-    Agent_sdk.Types.message list -> Agent_sdk.Types.content_block list
 
   val messages_for_run_with_checkpoint :
     checkpoint_messages:Agent_sdk.Types.message list ->
@@ -277,11 +271,6 @@ module For_testing : sig
     goal_blocks:Agent_sdk.Types.content_block list ->
     Agent_sdk.Types.content_block list
 
-  val content_blocks_for_run_with_checkpoint :
-    checkpoint_messages:Agent_sdk.Types.message list ->
-    initial_messages:Agent_sdk.Types.message list ->
-    goal_blocks:Agent_sdk.Types.content_block list ->
-    Agent_sdk.Types.content_block list
 
   val required_modalities_of_messages :
     Agent_sdk.Types.message list -> string list

--- a/lib/server/server_dashboard_http_delete_actions.mli
+++ b/lib/server/server_dashboard_http_delete_actions.mli
@@ -32,6 +32,5 @@ val handle_keeper_lifecycle_completion :
   (unit, string) result
 
 module For_testing : sig
-  val purge_dashboard_keeper_artifacts :
-    Workspace.config -> Keeper_shutdown_types.t -> (unit, string) result
+
 end

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -324,7 +324,7 @@ module For_testing : sig
     has_visible_blocks:bool ->
     has_tool_calls:bool ->
     [ `Visible_blocks | `Tool_calls_only | `Failure | `User_only ]
-  val format_surface_context : Yojson.Safe.t -> string
+
   val surface_context_to_instructions : Yojson.Safe.t -> string option
   val keeper_tool_failure_log_details :
     tool_name:string ->


### PR DESCRIPTION
## `For_testing` 이 테스트에 열어준 것 중 아무도 안 쓰는 29 개

`module For_testing : sig ... end` 은 테스트에 내부를 열어주려고만 존재한다. 그 안의 값을 테스트가 쓰지 않으면 아무도 쓰지 않는 인터페이스를 넓혀둔 것이다.

lib 전체를 세어 보면 `For_testing` 을 가진 `.mli` 가 124 개, 그 안의 `val` 이 489 개다. 그 중 **29 개** 는 `test/` 어디에서도 이름조차 나오지 않고, 자기 모듈 쌍(`.ml`/`.mli`) 밖의 lib 코드에서도 참조되지 않는다.

| 파일 | 지운 val |
|---|---|
| `keeper_event_bridge.mli` | `make_pending`, `relay_max_queue_depth`, `resolve_oas_event_retention_days`, `should_drain_subscription`, `deliver_pending_with` |
| `runtime_agent.mli` | `provider_http_observation_transport`, `runtime_id_of_config`, `content_blocks_of_messages`, `content_blocks_for_run_with_checkpoint` |
| `ide_bridge.mli` | `default_max_segment_bytes`, `default_max_retained_segments` |
| `keeper_event_queue_recovery.mli` | `with_owner_claim`, `pending_transition_count_result` |
| `hitl_summary_worker.mli` | `messages_for_summary`, `success_provenance_matches` |
| `keeper_unified_turn_success.mli` | `terminal_outcome_of_result`, `acknowledge_pending_messages` |
| 그 외 12 파일 | 각 1 개 |

## 무엇을 지웠고 무엇을 남겼나

**`.mli` 의 선언만 지운다.** 모듈 내부에서 그 값을 쓰는 코드는 비한정 호출이라 영향이 없고, 다른 lib 파일이 `For_testing` 경유로 쓰는 것은 애초에 대상에서 제외했다.

예외로 `.ml` 세 줄을 함께 지웠다. `ide_bridge` 의 두 개와 `activity_graph` 의 하나는 `For_testing` 안에서 상위 값을 그대로 재수출하기만 하던 줄이라, 선언이 사라지자 그 라이브러리에 켜둔 `-w +32` 가 미사용으로 잡았다. 그것이 이 방식의 확인 절차이기도 하다 — 인터페이스에서 빼고도 빌드가 통과하면 그 값을 필요로 하는 코드가 없었다는 뜻이다.

## 측정에서 한 번 틀렸다

처음에는 "`.ml` 의 구현까지 함께 지운다" 로 시작했다가 두 가지를 깼다.

- 판정 기준에서 **모듈 자기 자신의 `.ml` 을 제외** 해서, `ide_bridge` 안에서 실제로 쓰이던 `default_max_segment_bytes` 를 죽은 것으로 봤다.
- `.ml` 본문을 정규식 span 으로 지우다 `runtime_agent.ml` 의 문법을 깼다.

둘 다 되돌리고, 인터페이스만 건드리는 지금 방식으로 다시 했다. 정규식으로 구현 블록을 지우는 것은 이 저장소에서 이미 사고를 낸 방식이라(#27208 이 그 복구다) 쓰지 않는다.

## 검증

`dune build @check` 통과. 순감 91 삭제 / 11 추가 (20 파일).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
