### PR TITLE
docs(sidecar): 로그 파일 날짜가 로컬 시간인 이유를 코드에 남긴다

### DIFF
--- a/lib/server/server_routes_http_sidecar_paths.ml
+++ b/lib/server/server_routes_http_sidecar_paths.ml
@@ -106,6 +106,13 @@ let missing_sidecar_dir_message ?sidecar_root ?project_root ~base_path id =
     searched_text
 ;;
 
+(* Local time on purpose, and the one place in this repository where that is
+   the correct answer for a filename. The names this has to match are produced
+   by the sidecar launchers — sidecars/{slack,telegram,imessage}-bot/run.sh all
+   build "$LOG_DIR/<id>-sidecar-$(date +%Y%m%d).log", and `date` without -u is
+   the host's calendar. Switching this to UTC would make the lookup miss the
+   live file for the whole UTC-offset window, which is #10392's failure with
+   the reader and writer swapped. Change it only together with those scripts. *)
 let today_yyyymmdd () =
   let tm = Unix.localtime (Unix.time ()) in
   Printf.sprintf "%04d%02d%02d" (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday


### PR DESCRIPTION
`server_routes_http_sidecar_paths.today_yyyymmdd` 는 **이미 존재하는 파일**의 이름을 만든다. 그 이름을 만드는 쪽은 사이드카 런처다:

```
sidecars/slack-bot/run.sh:32     LOG_FILE="$LOG_DIR/slack-sidecar-$(date +%Y%m%d).log"
sidecars/telegram-bot/run.sh:30  ...
sidecars/imessage-bot/run.sh:35  ...
```

`date` 에 `-u` 가 없으므로 호스트 달력이다. 즉 여기서 `Unix.localtime` 이 **정답**이고, `lib/` 안의 파일명 중 그게 참인 유일한 자리다.

## 왜 적어야 하는가

근거가 코드 어디에도 없다. 반면 #10392 는 **정반대** 결함을 고쳤다 — `masc_log` 가 day 파일 이름을 localtime 으로 만드는데 엔트리는 UTC였다 — 그리고 UTC 관례를 고정하는 테스트를 남겼다.

그래서 `Unix.localtime` 호출 지점을 훑는 사람은 이걸 같은 버그로 읽는다. 실제로 이번 스윕에서 후보로 올라왔다. UTC 로 정규화하면 UTC 오프셋 구간 내내 조회가 살아있는 파일을 놓치는데 **에러가 나지 않는다** — `first_existing_or_first` 가 존재하지 않는 경로로 폴백한다.

## 함께 확인한 것

`lib/` 의 `Unix.localtime` 사용처 6곳을 전부 판정했다.

| 위치 | 판정 |
|---|---|
| `dashboard.ml:380` | 사람이 읽는 표시용 |
| `tool_library.ml:263` | 문서 파일명, 작성자 날짜 |
| `activity_graph.ml:607` | 요일×시간 히트맵 |
| `masc_log/log.ml:171` | 표시용 (#10392 이후 남은 것) |
| `sidecar_paths.ml:110` | **이 PR** |
| `keeper_decision_audit.ml:184` | #27210 에서 수정 (프루너는 gmtime 인데 쓰기는 localtime) |

주석만 바꿨다. `dune build @check` exit 0.