### PR TITLE
build(dated_jsonl): turn on the unused-value warning it had deferred

### DIFF
--- a/lib/dated_jsonl/dune
+++ b/lib/dated_jsonl/dune
@@ -3,12 +3,12 @@
 (library
  (name dated_jsonl)
  (public_name masc.dated_jsonl)
- ; RFC-0071 §3.4 Phase 5 ratchet: warning 4 (fragile pattern match) on;
- ; warning 32 (unused value declaration) stays off (pre-existing). Both
- ; live in the single (flags ...) stanza so the effective warning mask is
- ; not split across (flags)/(ocamlc_flags)/(ocamlopt_flags).
+ ; RFC-0071 §3.4 Phase 5 ratchet: warnings 4 (fragile pattern match), 32
+ ; (unused value declaration) and 37 (unused constructor) are on. All live
+ ; in the single (flags ...) stanza so the effective warning mask is not
+ ; split across (flags)/(ocamlc_flags)/(ocamlopt_flags).
  (flags
-  (:standard -w -32 -w +4 -w +37))
+  (:standard -w +32 -w +4 -w +37))
  (libraries
   fs_compat
   jsonl_writer


### PR DESCRIPTION
## 마지막 남은 명시적 opt-out

lib 의 library dune 120 개 중 미사용 값 경고(warning 32) 상태는 이렇다.

| 상태 | 개수 |
|---|---|
| `-w +32` (켬) | 82 |
| `-w -32` (**명시적으로 끔**) | **1** |
| 미지정 | 37 |

끄고 있는 하나가 `lib/dated_jsonl` 이다.

```
 ; RFC-0071 §3.4 Phase 5 ratchet: warning 4 (fragile pattern match) on;
 ; warning 32 (unused value declaration) stays off (pre-existing). ...
 (flags
  (:standard -w -32 -w +4 -w +37))
```

주석이 스스로 적어둔 대로 "pre-existing" 을 이유로 한 유예다. 그런데 지금 켜 보면 **막아야 할 것이 없다** — `-w -32` 를 `-w +32` 로 바꾸고 `dune build @check` 가 그대로 통과한다.

유예의 근거가 사라졌으므로 켠다. 주석도 실제 상태(4 / 32 / 37 셋 다 켬)로 고친다.

## 왜 이게 의미가 있나

꺼진 경고는 조용히 빚을 받는다. 이 라이브러리는 지금 깨끗하지만, 켜두지 않으면 다음에 들어오는 미사용 값이 아무 저항 없이 남는다. 이번 세션에서 `lib/server` 와 `lib/dashboard` 를 열어보니 재수출 별칭과 미사용 정의가 도합 50 개 넘게 쌓여 있었는데(#27201, #27203), 그 두 라이브러리도 래칫이 없던 곳이다.

## 남은 37 개는 이 PR 에서 다루지 않는다

`(flags ...)` 를 아예 두지 않은 라이브러리가 37 개 있다. 그쪽은 필드를 새로 넣어야 하고, 넣는 순간 무엇이 드러날지는 라이브러리마다 확인이 필요하다. 별도로 다룬다.

(초안 과정에서 그 37 개를 한 번에 패치하려다 실패했다. 여러 줄로 쓰인 `(flags\n (:standard ...))` 를 한 줄 정규식이 놓쳐 `flags` 필드를 두 번 넣었고 dune 이 거부했다. 되돌렸고, 이 PR 은 그 시도를 담지 않는다.)

## 검증

`dune build @check` 통과.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
