### PR TITLE
refactor(workspace,ide): drop 15 opens the signatures never use

### DIFF
--- a/lib/ide/ide_bridge.mli
+++ b/lib/ide/ide_bridge.mli
@@ -1,7 +1,6 @@
 (** IDE Bridge — collects Keeper activity events and surfaces them in
     the [.masc-ide/] partition structure for IDE consumption. *)
 
-open Ide_event_types
 
 type event_kind =
   | Tool

--- a/lib/workspace/task_cache_invariant.mli
+++ b/lib/workspace/task_cache_invariant.mli
@@ -7,8 +7,6 @@
 
     @since #13397 *)
 
-open Masc_domain
-open Workspace_utils
 
 (** Read the current task status directly from the backlog.
     Returns [None] when the task is absent or the backlog cannot be read. *)

--- a/lib/workspace/workspace_backlog.mli
+++ b/lib/workspace/workspace_backlog.mli
@@ -1,8 +1,6 @@
 (** Workspace backlog persistence — read / write the canonical
     [tasks/backlog.json] document with structural recovery. *)
 
-open Masc_domain
-open Workspace_utils
 
 val backlog_path : Workspace_utils_backend_setup.config -> string
 val backlog_lock_path : Workspace_utils_backend_setup.config -> string

--- a/lib/workspace/workspace_bootstrap.mli
+++ b/lib/workspace/workspace_bootstrap.mli
@@ -1,8 +1,6 @@
 (** Workspace bootstrap — initialize the default workspace state on
     first boot. *)
 
-open Masc_domain
-open Workspace_utils
 
 val default_workspace_state : Workspace_utils_backend_setup.config -> Masc_domain.workspace_state
 val ensure_workspace_bootstrap : Workspace_utils_backend_setup.config -> unit

--- a/lib/workspace/workspace_broadcast.mli
+++ b/lib/workspace/workspace_broadcast.mli
@@ -1,8 +1,6 @@
 (** Workspace broadcast — emit workspace-wide messages and the
     accompanying message-activity event. *)
 
-open Masc_domain
-open Workspace_utils
 
 (** RFC-0061: closed variants for broadcast envelope observability. *)
 type rewrite_reason =

--- a/lib/workspace/workspace_hooks.mli
+++ b/lib/workspace/workspace_hooks.mli
@@ -6,7 +6,6 @@
     no-ops; the runtime overrides each ref via the wiring in
     [lib/workspace.ml]. *)
 
-open Masc_domain
 
 type activity_entity = { kind: string; id: string }
 

--- a/lib/workspace/workspace_identity.mli
+++ b/lib/workspace/workspace_identity.mli
@@ -1,7 +1,6 @@
 (** Workspace identity helpers — session id, hostname, tty, and
     agent-name resolution. *)
 
-open Workspace_utils
 
 val generate_session_id : unit -> string
 (** Generate a 128-bit cryptographically random lowercase hex session ID.

--- a/lib/workspace/workspace_init.mli
+++ b/lib/workspace/workspace_init.mli
@@ -4,8 +4,6 @@
     agent claims, and a destructive [reset] helper for tests and explicit
     internal maintenance. *)
 
-open Masc_domain
-open Workspace_utils
 
 (** Initialise workspace state; session-binds [agent_name] when given. *)
 val init :

--- a/lib/workspace/workspace_state.mli
+++ b/lib/workspace/workspace_state.mli
@@ -1,7 +1,5 @@
 (** Workspace state — backlog, workspace state, and recovery helpers. *)
 
-open Masc_domain
-open Workspace_utils
 
 val normalized_string_list : string list -> string list
 


### PR DESCRIPTION
## 시그니처가 아무것도 쓰지 않는 `open` 15 개

`-w +33` (unused-open) 을 lib 전체에 걸어보면 `.mli` 15 곳에서 시그니처가 그 모듈의 이름을 하나도 쓰지 않은 채 `open` 만 하고 있다.

| 파일 | 지운 open |
|---|---|
| `workspace_state.mli`, `workspace_init.mli`, `workspace_broadcast.mli`, `workspace_backlog.mli`, `workspace_bootstrap.mli`, `task_cache_invariant.mli` | `Masc_domain`, `Workspace_utils` |
| `workspace_identity.mli` | `Workspace_utils` |
| `workspace_hooks.mli` | `Masc_domain` |
| `ide_bridge.mli` | `Ide_event_types` |

`.mli` 의 `open` 은 그 시그니처 안에서만 쓰인다. 아무 이름도 쓰지 않으면 읽는 사람에게 "이 인터페이스는 저 모듈에 기대고 있다" 는 잘못된 인상만 남긴다.

## 래칫은 이 PR 에 넣지 않는다

`-w +33` 을 켜면 위 15 개 외에 25 개가 더 나온다. 그런데 그쪽은 **한 번에 지울 수 없다**.

두 `open` 이 같은 이름을 제공하면 컴파일러는 가려진 쪽만 unused 로 보고한다. 한 번의 빌드 보고서를 근거로 보고된 것을 모두 지우면, 실제로 이름을 주던 쪽까지 함께 사라진다. 실제로 그렇게 해 봤다가 `workspace_task_create.ml` 이 `Unbound value backlog_lock_path` 로 깨졌다. 되돌렸다.

남은 25 개는 하나씩 지우고 매번 빌드하는 방식이 필요하다 — 이 PR 의 15 개와 성격이 다르므로 분리한다. 이 15 개는 `.mli` 안에서 서로 겹치지 않고, 제거 후 `dune build @check` 가 통과하는 것을 확인했다.

## 함께 확인한 것

같은 프로브에서 `-w +38` (unused extension constructor) 은 **0 건** 이었다. 선언만 되고 아무도 raise 하지 않는 예외는 없다.

## 검증

`dune build @check` 통과.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
