### PR TITLE
fix(dashboard): 서버가 실제로 서빙하는 엔드포인트 이름을 쓴다

### DIFF
--- a/dashboard/src/components/ide/decision-log-trace-bridge.ts
+++ b/dashboard/src/components/ide/decision-log-trace-bridge.ts
@@ -9,7 +9,7 @@ import {
  * RFC-0028 PR-δ producer: decision-log → keeper-trace bridge.
  *
  * Pure mapper — given a snapshot of KeeperDecision values
- * (from `/api/v1/keeper/decisions`) and a set of dedup keys that have
+ * (from `/api/v1/dashboard/keeper-decisions`) and a set of dedup keys that have
  * already been emitted, push trace events for the new ones and return
  * the updated set.
  *

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -1257,7 +1257,7 @@ describe('SettingsSurface', () => {
   it('runtime overview shows its own error state when the provider catalog is unavailable, without fabricating catalog cards', async () => {
     // PR-6 (bug #14/#15/#36): the settings surface no longer re-projects
     // /api/v1/dashboard/runtime-defaults into a fake runtime-provider-catalog
-    // shape when /api/v1/dashboard/runtime-providers fails — it shows the
+    // shape when /api/v1/providers fails — it shows the
     // catalog's own error state instead.
     apiMock.fetchRuntimeProviders.mockRejectedValueOnce(new Error('provider catalog unavailable'))
 

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -152,7 +152,7 @@ const SETTINGS_CONTROL_INVENTORY: readonly SettingsControlInventoryItem[] = [
     section: 'runtime',
     label: 'Runtime catalog cards',
     kind: 'live-read',
-    source: 'GET /api/v1/dashboard/runtime-providers',
+    source: 'GET /api/v1/providers',
     action: 'read-only projection',
   },
   {


### PR DESCRIPTION
대시보드가 이름 붙인 모든 `/api` 경로를 `lib/server` 의 `Http.Router` 선언 **188개**와 대조했다. 어긋나는 게 3건, 그중 `/api/v1/keepers/composite` 는 백엔드가 `prefix ^ "composite"` 로 조립해서 리터럴 비교에 안 걸린 오탐이다.

## 1. 운영자 출처 표가 없는 경로를 가리킨다

`settings-surface.ts` 는 각 행이 **데이터 출처를 운영자에게 알려주는 표**다.

| 행 | 이전 | 실제 |
|---|---|---|
| `runtime-catalog-summary` | `GET /api/v1/dashboard/runtime-providers` | `GET /api/v1/providers` |

`lib/` 에 그 경로를 서빙하는 코드가 없다. 카드는 `fetchRuntimeProviders` 가 채우고 그건 `/api/v1/providers` 를 부른다 (`dashboard-runtime.ts:1034`) — `runtime-catalog-resource.ts` 헤더에도 그렇게 적혀 있다.

형제 행들은 `/api/v1/dashboard/runtime-defaults` 를 정확히 가리킨다. 그래서 이 행도 똑같이 권위 있게 읽힌다.

## 2. docstring 이 없는 경로를 가리킨다

`decision-log-trace-bridge.ts` 헤더가 KeeperDecision 값의 출처를 `/api/v1/keeper/decisions` 라고 한다. 실제 fetcher 는 `dashboard-keeper-cost.ts:209` 의 `/api/v1/dashboard/keeper-decisions` 다.

## 게이트는 만들지 않았다

**fetch 호출은 이미 전부 해결된다.** 어긋난 둘은 라벨과 docstring 이라 fetch 경로가 닿지 않는다. 그리고 파라미터 라우트(`/api/v1/keepers/${name}/tool-calls` vs Router 템플릿)를 맞추려면 정규화가 필요한데, 지금 잡을 게 없는 상태에서 그 정규화는 오탐을 더 많이 만든다.

## 검증

`npx tsc --noEmit` exit 0, `settings-surface` 46/46.