### PR TITLE
prompt(keeper): 쓴 Goal 이 주인 없이 태어난다는 사실을 말한다

### DIFF
--- a/config/prompts/keeper.md
+++ b/config/prompts/keeper.md
@@ -50,7 +50,9 @@ bookkeeping. Reaching a goal means moving through them.
   someone else's, vote on a post or a comment, search what already exists, and
   open a sub-board when a topic deserves its own room.
 - **Goal** — durable intent that outlives any single turn. Write one, move it
-  along, and read the ones already open.
+  along, and read the ones already open. A Goal you write has no owner until
+  someone takes it: an unowned Goal is intent nobody picked up, not an error,
+  and taking one is a move you can make.
 - **Task** — a concrete unit of work. Create one for work you can name, claim
   one you intend to do, finish it with evidence.
 - **Schedule** — work that belongs at a later time rather than now.

--- a/test/fixtures/keeper_system_prompt/assembled_prompt.golden
+++ b/test/fixtures/keeper_system_prompt/assembled_prompt.golden
@@ -46,7 +46,9 @@ bookkeeping. Reaching a goal means moving through them.
   someone else's, vote on a post or a comment, search what already exists, and
   open a sub-board when a topic deserves its own room.
 - **Goal** — durable intent that outlives any single turn. Write one, move it
-  along, and read the ones already open.
+  along, and read the ones already open. A Goal you write has no owner until
+  someone takes it: an unowned Goal is intent nobody picked up, not an error,
+  and taking one is a move you can make.
 - **Task** — a concrete unit of work. Create one for work you can name, claim
   one you intend to do, finish it with evidence.
 - **Schedule** — work that belongs at a later time rather than now.


### PR DESCRIPTION
## 문장이 행동을 권하고 그 결과 앞에서 멈춘다

```
- **Goal** — durable intent that outlives any single turn. Write one, move it
  along, and read the ones already open.
```

RFC-0362 §4.1 이 이 문장이 빠뜨린 기본값을 적고 있다:

> `None` is legitimate and is the default: an unowned Goal is a stated intent nobody has picked up, which is a real and reportable state — **not an error**.

스키마가 그 설계를 그대로 따른다:

| tool | 속성 |
|---|---|
| `masc_goal_upsert` | `id, title, metric, target_value, due_date, priority, parent_goal_id` — **owner 없음** |
| `masc_goal_assign` | `goal_id` + `owner` |

즉 Goal 을 쓰면 **아무도 소유하지 않은 것**이 나오고, 소유자를 주는 건 별개의 의도적 행위다. **이 줄을 읽는 keeper 는 그걸 알 방법이 없다.**

## 라이브

6 일간:

```
masc_goal_upsert   1 회
masc_goal_assign   1 회
keeper 10 개 중 goal 을 가진 것   1 개 (sangsu, 100%) · 나머지 9 개 0%
```

분포가 gradient 가 아니라 **binary** 다 — 배정의 지문이다 (`#27147`).

## RFC 가 금지하는 것과 이 PR 이 하는 것

§5 는 **"No auto-assignment. Nothing picks an owner for a Goal."** 시스템이 고르는 것을 금지한다. keeper 가 스스로 가져가는 것은 그 대상이 아니다.

이 PR 은 **기본값과 가능성만 말한다.** 가져가라고 지시하지 않고, 도구 이름도 적지 않는다 — 프롬프트 자신의 규칙이 *"The active typed schema is the sole callable catalog... never infer another from prompt prose"* 이기 때문이다.

## 같은 형태를 세 번째로 고친다

| PR | 멈춘 지점 |
|---|---|
| `#27144` | 게시를 억제하면서 대안을 안 말함 |
| `#27138` | 거부가 탈출 경로를 안 말함 |
| **이 PR** | **행동을 권하면서 그 결과를 안 말함** |

## 검증

golden 을 같은 커밋에서 갱신했다 — 8858 → 9013, diff 는 추가한 세 줄뿐이고 그 외 변화 없음.

```
test_keeper_system_prompt_bytes       EXIT=0
test_keeper_prompt_metrics            EXIT=0
test_keeper_surface_presence_prompt   EXIT=0
test_prompt_asset_sync                EXIT=0
audit-dashboard-prompt-keys           EXIT=0
```

## 정직하게

효과는 증명되지 않았다. 프롬프트 변경이고 여기서 검증할 수 없다. 위 baseline (`upsert` 1, `assign` 1, 9/10 이 goal 없음) 으로 측정 가능하다. 움직이지 않으면 병목은 문장이 아니라 다른 층이고, 그때는 프롬프트를 더 만질 게 아니다.

관련: `#27147` (측정) · RFC-0362 · `#27144` · `#27138`

RFC-WAIVED: 프롬프트 문장 3 줄 + golden. credential / operator control / keeper sandbox / hooks / workflow 문서 미접촉.

🤖 Generated with [Claude Code](https://claude.com/claude-code)