### PR TITLE
chore(specs): refresh the stale INDEX.md hash

### DIFF
--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-07-18T06:06:32Z (HEAD: 9a49a1d1a2)
+Generated: 2026-08-06T11:04:14Z (HEAD: 42a3896de2)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -71,7 +71,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | File | Module | Kind | cfg | buggy | Invariants / Properties | Source Hash |
 |------|--------|------|-----|-------|-------------------------|---------------|
 | KeeperDeadRevivalTransaction.tla | KeeperDeadRevivalTransaction | manual | 1 | 0 | clean={inv:TypeOK, inv:SingleOwner, inv:NoUnjournaledPartialCommit, inv:LiveMatchesDurable, inv:NewerGenerationPreserved} | 4d80b169aa92 |
-| KeeperDecisionPipeline.tla | KeeperDecisionPipeline | manual | 2 | 1 | clean={inv:TypeOK, inv:Safety, prop:Liveness} buggy={inv:DecisionBoundaryRequiresMeasurement} | 7077b7639f77 |
+| KeeperDecisionPipeline.tla | KeeperDecisionPipeline | manual | 2 | 1 | clean={inv:TypeOK, inv:Safety, prop:Liveness} buggy={inv:DecisionBoundaryRequiresMeasurement} | 2f736860c52f |
 | KeeperDwellMonotone.tla | KeeperDwellMonotone | manual | 2 | 1 | clean={inv:Safety} buggy={inv:DwellNonNegative} | eb079ef5c342 |
 | KeeperEventQueue.tla | KeeperEventQueue | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | cf9b1da37ed0 |
 | KeeperHeartbeat.tla | KeeperHeartbeat | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | d143b5beae39 |


### PR DESCRIPTION
## 무엇

`specs/INDEX.md`가 기록한 `KeeperDecisionPipeline.tla` 본문 해시가 낡았습니다. `scripts/gen-tla-index.sh`로 재생성했고, 움직인 필드는 해시 하나입니다.

```
- | KeeperDecisionPipeline.tla | … | 7077b7639f77 |
+ | KeeperDecisionPipeline.tla | … | 2f736860c52f |
```

## 왜 낡았나

게이트를 우회한 게 아닙니다. `#26988`에서 drift-check가 **실제로 실패**했고(`conclusion: failure`, 11:22:29Z), PR은 **2분 36초 뒤 머지**됐습니다(11:25:05Z).

`main`의 required status check는 `CI Gate` 하나뿐이고 `tla-index.yml`은 거기 포함되지 않습니다. 검사는 정확히 보고했고, 아무것도 바뀌지 않았습니다.

## 범위

해시만 고칩니다. 재발 메커니즘은 그대로입니다 — 다음 spec 편집이 같은 조건으로 다시 만듭니다. required 지정은 저장소 설정 변경이라 이 PR 범위 밖입니다.

## 검증

```
$ bash scripts/gen-tla-index.sh > /tmp/INDEX.new.md
$ diff <(grep -v '^Generated: ' specs/INDEX.md) <(grep -v '^Generated: ' /tmp/INDEX.new.md)
(차이 없음)
```

RFC-WAIVED: 생성된 인덱스 파일의 해시 필드 1개 갱신. 동작 변경 없음.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
