### PR TITLE
docs: odoc 이 못 푸는 문서 참조·마크업 정리 (경고 557→424, 존재하지 않는 테스트 인용 11곳)

### DIFF
--- a/lib/board/board_votes.mli
+++ b/lib/board/board_votes.mli
@@ -54,8 +54,8 @@ val all_vote_directions : vote_direction list
 val vote_direction_of_string_opt : string -> vote_direction option
 (** Sound partial parser: case-insensitive, trims whitespace, and
     accepts only ["up"] / ["down"].  Empty or unknown input returns
-    [None] (no silent permissive fallback).  Pinned for
-    behaviour-tests under {!test/test_types}. *)
+    [None] (no silent permissive fallback).  No suite pins this
+    parser today. *)
 
 (** {1 Vote log path} *)
 

--- a/lib/config/env_config_snapshot.mli
+++ b/lib/config/env_config_snapshot.mli
@@ -7,10 +7,9 @@
     - {!valid_config_category_strings} consumed by
       [tool_schemas_misc] when generating the
       [masc_config] tool enum + by
-      [test/test_types].
+      [test/test_tool_descriptors_gen.ml].
     - {!all_categories} consumed by
-      [env_config_introspect] +
-      [test/test_types].
+      [env_config_introspect].
     - {!to_json} consumed by [env_config] (the
       facade) + [env_config_introspect].
 

--- a/lib/dashboard/dashboard.ml
+++ b/lib/dashboard/dashboard.ml
@@ -65,10 +65,10 @@ type scope =
 (** Issue #8592: SSOT helpers for [scope]. The witness function and
     canonical string list are mirrored in the JSON Schema layer
     ([Tool_schemas_misc.dashboard_scope_enum_strings]) — direct
-    dependency would cycle. The test [test_types.ml ::
-    dashboard_scope_ssot] asserts the mirror stays in sync. Adding a
-    new constructor here forces a compile error in [scope_to_string]
-    and fails the schema mirror test instead of silently dropping
+    dependency would cycle. No suite asserts the mirror stays in sync:
+    [dashboard_scope_ssot] does not exist. Adding a new constructor here
+    forces a compile error in [scope_to_string], which is the only thing
+    standing between a new scope and silently dropping
     from the enum. *)
 let scope_to_string = function
   | All -> "all"

--- a/lib/keeper/keeper_event_publisher.ml
+++ b/lib/keeper/keeper_event_publisher.ml
@@ -37,9 +37,10 @@ let masc_publish event =
     (\[reconciled\] / \[dead_cleaned\] / \[admission_denied\]) — exactly the events that signal supervisor
     recovery actions where observability matters most. Subscribe to
     {!Keeper_lifecycle_events.all_event_names} to receive the full
-    stream; the sync test in [test_types.ml ::
-    lifecycle_events_ssot] asserts every literal still emitted by
-    [Keeper_supervisor] / [Keeper_keepalive] lives in the SSOT. *)
+    stream.  A sync test asserting every literal emitted by
+    [Keeper_supervisor] / [Keeper_keepalive] lives in the SSOT was cited
+    here as [test_types.ml :: lifecycle_events_ssot]; neither the file
+    nor the test exists (#22071). *)
 (* #8856 / #8605 family: [event] is now the unified
    [Keeper_lifecycle_events.lifecycle_event] variant -- typos at the
    16 supervisor/keepalive call sites fail to compile. JSON wire

--- a/lib/operator/operator_control_snapshot.mli
+++ b/lib/operator/operator_control_snapshot.mli
@@ -16,8 +16,8 @@
       [server_dashboard_http_keeper_api]).
     - {!valid_snapshot_view_strings},
       {!snapshot_view_of_string_opt}, {!snapshot_view}
-      (consumed by [tool_operator] tool schema +
-      [test/test_types]).
+      (consumed by the [tool_operator] tool schema; no suite pins
+      the view vocabulary today).
     - {!align_keeper_runtime_status}
       (test-only direct caller).
     - {!get_payload} (runtime-include

--- a/lib/server/server_dashboard_http_execution_surfaces.mli
+++ b/lib/server/server_dashboard_http_execution_surfaces.mli
@@ -7,10 +7,9 @@
     [module Execution_surfaces = ...] alias and reaches
     {!execution_cache} +
     {!broadcast_namespace_truth_ref} through it.  Plus
-    direct dotted callers and a
-    [let module S = ...] inline alias in
-    [test/test_types.ml] for the
-    lifecycle-event patcher family.
+    direct dotted callers.  A [let module S = ...] inline alias for
+    the lifecycle-event patcher family was cited in
+    [test/test_types.ml], which does not exist.
 
     External surface (22 entries):
     - {b cache cells} ({!execution_cache},

--- a/lib/tool_library.ml
+++ b/lib/tool_library.ml
@@ -29,8 +29,9 @@ open Printf
     independently — the docstring drifted (claimed 3, runtime had 4).
     The witness pattern below is the standard Variant SSOT shape used by
     #8486 (tail_order), #8467 (sandbox_profile), #8592 (dashboard scope).
-    Adding a 5th source forces compile errors in [source_to_string] and
-    fails the [library_source_ssot] test in test_types.ml. *)
+    Adding a 5th source forces compile errors in [source_to_string].
+    There is no [library_source_ssot] test; the compile errors are the
+    whole guard. *)
 type library_source =
   | Direct_experience
   | Research

--- a/lib/tool_library.mli
+++ b/lib/tool_library.mli
@@ -15,8 +15,9 @@
     Issue #8601 SSOT shape: {!library_source} variant +
     {!source_to_string} + {!valid_source_strings} +
     {!source_of_string_opt} are kept in sync — adding a 5th
-    constructor forces compile errors in [source_to_string] and
-    fails the [library_source_ssot] test in [test_types.ml].
+    constructor forces compile errors in [source_to_string].  There is
+    no [library_source_ssot] test; the compile errors are the whole
+    guard.
 
     Internal: \[all_sources], the \[frontmatter] type +
     \[parse_frontmatter] + \[list_documents], and \[handle_list] /
@@ -43,8 +44,7 @@ val source_to_string : library_source -> string
 val all_sources : library_source list
 (** [all_sources] is the canonical witness list — one entry per
     {!library_source} constructor (in declaration order).  Used
-    by {!valid_source_strings} and by behaviour-tests under
-    {!test/test_types}. *)
+    by {!valid_source_strings}. *)
 
 val valid_source_strings : string list
 (** [valid_source_strings] is [List.map source_to_string

--- a/lib/tool_workspace.mli
+++ b/lib/tool_workspace.mli
@@ -46,14 +46,14 @@ type assertion_kind = Workspace_assertions.assertion_kind =
 
 (** [assertion_kind_to_string k] returns the canonical lowercase
     label for [k].  Re-export of
-    {!Workspace_assertions.assertion_kind_to_string}; pinned for
-    behaviour-tests under {!test/test_types}. *)
+    {!Workspace_assertions.assertion_kind_to_string}.  No suite pins
+    this label set today. *)
 val assertion_kind_to_string : assertion_kind -> string
 
 (** [all_assertion_kinds] is the canonical witness list — one
     entry per {!assertion_kind} constructor.  Re-export of
-    {!Workspace_assertions.all_assertion_kinds}; pinned for
-    behaviour-tests under {!test/test_types}. *)
+    {!Workspace_assertions.all_assertion_kinds}.  No suite pins the
+    witness list against the constructor set today. *)
 val all_assertion_kinds : assertion_kind list
 
 (** [valid_assertion_strings] is the canonical list of

--- a/lib/workspace/workspace_utils.mli
+++ b/lib/workspace/workspace_utils.mli
@@ -3,7 +3,7 @@
     Pure facade — the .ml is 3 [include] statements bringing
     in 3 sub-modules.  This .mli mirrors the runtime with
     [include module type of] so callers can reach every sub-
-    module symbol via {!Workspace_utils.X} and type identity is
+    module symbol via [Workspace_utils.X] and type identity is
     preserved end-to-end:
 
     - {!Workspace_utils_backend_setup} — backend probe + git-root
@@ -20,10 +20,11 @@
     facade and sub-modules stay in sync.
 
     Type identity is preserved across the runtime — callers
-    can interleave {!Workspace_utils.X} and the source modules'
+    can interleave [Workspace_utils.X] and the source modules'
     [X] freely (the [config] type, for example, is the same
     nominal type whether reached via {!Workspace_utils.config} or
-    {!Workspace_utils_paths_backend.config}). *)
+    {!Workspace_utils_backend_setup.config}, which is where it is
+    declared). *)
 
 include module type of struct
   include Workspace_utils_backend_setup


### PR DESCRIPTION
`dune build @doc` 가 **미해결 참조 459건**을 보고한다. 그리고 **아무도 그걸 돌리지 않는다** — `odoc` 은 `masc.opam.locked:136` 에 `with-doc` 로 선언돼 있지만 워크플로에도 lint suite 에도 `@doc` 배선이 없다. `lib/` 의 ocamldoc 상호참조 **664회**를 지금까지 무엇도 검사한 적이 없다.

## 존재하지 않는 테스트를 가리키는 11곳

`test/test_types.ml` 은 저장소에 없다. `.mli` 6개가 "이 값은 거기 behaviour-test 로 고정돼 있다"고 독자에게 말한다. 이름을 밝힌 테스트들도 없다:

| 인용된 테스트 | 실재하는 test 파일 |
|---|---|
| `library_source_ssot` | **0** |
| `dashboard_scope_ssot` | **0** |
| `lifecycle_events_ssot` | **0** (한 주석이 "인용됐었다"고만 언급) |
| `all_assertion_kinds` 고정 | **0** |
| `valid_snapshot_view_strings` 고정 | **0** |
| `valid_config_category_strings` | 1 — `test/test_tool_descriptors_gen.ml` |

실재하는 하나는 정확한 경로로 바꿨다. 나머지는 사실대로 "고정하는 스위트가 없다"고 적었다.

**의도는 지웠지 않고 남겼다.** `no suite pins this today` 는 다음 사람에게 무엇을 추가해야 하는지 말하고, `pinned for behaviour-tests` 는 이미 됐다고 말한다. 후자가 거짓이었다.

## 마크업 오류 2곳 — 459건 중 96건의 원인

`{!Workspace_utils.X}` 의 `X` 는 "임의의 심볼" 자리표시자인데 참조 문법으로 써서 odoc 이 실제로 `X` 를 찾으려 했다. `[Workspace_utils.X]` 로 고쳤다.

바로 옆 예시가 **틀린 모듈**을 가리켰다 — `config` 타입은 `Workspace_utils_backend_setup` 에 선언돼 있지 `Workspace_utils_paths_backend` 가 아니다. facade 의 `include` 확장을 타고 이 둘이 459건 중 **96건**을 만들었다.

## 건드리지 않은 것

- `keeper_lifecycle_events.ml` 은 이미 "인용된 테스트가 존재하지 않는다(#22071)"고 정직하게 적어 뒀다
- `types_core.ml` 의 두 주장은 **#27031** 이 다룬다 — 그 PR 은 `test_task_status_vocabulary.ml` 이라는 다른 이름으로 실제 가드를 만든다. 나머지 10곳은 손대지 않으므로 이 PR 과 보완 관계다

## 검증

```
미해결 참조     459 → 358
test_types 참조   7 → 0
dune build @check  exit 0
```

## 별건 제안

`@doc` 를 CI 에 배선할 가치가 있어 보이지만 이 PR 범위 밖이다. 458건 중 약 50건은 외부 패키지(`Eio`, `Agent_sdk`, `Unix` …) 라 odoc 이 그 문서 없이는 못 푸는 한계고, 나머지는 baseline 래칫이 필요하다. 별도 이슈로 올린다.


## 2차 커밋 — 여는 쪽만 이스케이프된 괄호 75건

`\[effective_cluster_name]` 는 `[` 만 이스케이프하고 `]` 를 남긴다. odoc 이 리터럴 괄호 뒤 짝 없는 괄호로 읽어 **10개 `.mli` 에서 95회 경고**한다.

같은 파일 안에서 형태가 섞인다 — `tool_workspace.mli` 는 세 줄 간격으로 `\[credential_state]` 와 `[handle_status]`, `graphql_api.mli` 는 한 줄에 `\[page_info] / [\'a edge]`.

전부 식별자 마크업 의도라 75건을 되돌렸다. 2건은 남겼다 — `graphql_api.mli` 의 `[\[0, max_first]]` 는 코드 안의 닫힌 구간 표기라 안쪽 이스케이프가 실제로 일한다.

정규식 두 번 돌렸다. 1차는 식별자만 받아 `\[fetch_*]` 와 `\[initial_cache_capacity = 32]` 를 놓쳤고, 문자 클래스를 넓혀 잡되 중첩 형태는 "닫는 쪽이 이스케이프되지 않을 것" 조건으로 제외했다.

```
Unpaired ']'        95 → 2
총 경고            557 → 424
참조 실패          358 → 358
```

**참조 실패가 안 움직인 게 핵심 검증이다.** `[x]` 는 참조가 아니라 코드라, 이스케이프를 풀어도 새 미해결 대상이 생길 수 없다.


---

RFC-WAIVED: 주석 전용 변경. `lib/operator/operator_control_snapshot.mli` 에서 바뀐 것은 존재하지 않는 테스트(`test/test_types`)를 인용하던 docstring 한 문장뿐이며, credential/identity/operator-control 의 타입·값·동작은 건드리지 않는다 (`dune build @check` exit 0, diff 는 주석 라인만).
