### PR TITLE
fix(task): #27228 이 claim 경로에서 복제한 재실행 안내를 되돌린다

### DIFF
--- a/lib/task/tool_task_contract_gate.ml
+++ b/lib/task/tool_task_contract_gate.ml
@@ -30,16 +30,14 @@ let completion_state_error ~(task_id : string) ~(agent_name : string)
       Some
         (Masc_domain.Task (Masc_domain.Task_error.InvalidState
            (Printf.sprintf
-              "task %s is already done by %s; to re-run it, create a new task \
-               with predecessor_task_id set to %s"
-              task_id assignee task_id)))
+              "task %s is already done by %s"
+              task_id assignee)))
     | Masc_domain.Cancelled { cancelled_by; _ } ->
       Some
         (Masc_domain.Task (Masc_domain.Task_error.InvalidState
            (Printf.sprintf
-              "task %s was cancelled by %s; to re-run it, create a new task \
-               with predecessor_task_id set to %s"
-              task_id cancelled_by task_id)))
+              "task %s was cancelled by %s"
+              task_id cancelled_by)))
     | Masc_domain.AwaitingVerification { assignee; _ } ->
       Some
         (Masc_domain.Task (Masc_domain.Task_error.InvalidState


### PR DESCRIPTION
## 무엇이 잘못됐나

`#27228` 이 종료 상태 거부 **세 arm 을 같은 형태로 보고** 안내를 넣었다. 그중 둘은 건드리지 말았어야 했다.

`workspace_task_claim.ml:151` 이 이미 같은 안내를 하고 있고, **더 많이 말한다**:

```
"Task %s is %s — completed work is terminal. To run it again,
 create a new task with predecessor_task_id=%s (masc_add_task, RFC-0323)."
```

`#27228` 이 쓴 것:

```
"task %s is already done by %s; to re-run it, create a new task
 with predecessor_task_id set to %s"
```

기존 것은 **도구 이름(`masc_add_task`)과 근거(`RFC-0323`)** 를 말하고, 새 것은 둘 다 안 말한다. 둘을 다 두면 같은 지시가 다른 문구로 두 곳에 있게 되고, 이미 4 파일 7 곳에 흩어진 `"predecessor_task_id"` 리터럴에 **여덟 번째**를 더한다. 이 저장소 규칙은 리터럴이 2 곳이면 상수로 뽑으라는 것이지 복사하라는 게 아니다.

## 남기는 것

`AwaitingVerification` arm 은 유지한다. **그건 중복이 아니었다** — 안내가 실제로 사라져 있었고, `test_tool_task_coverage` 의 `handle_transition_done_on_awaiting_verification_is_explicit` 가 `"resolve it"` 을 고정한 채 배선 없이 red 였으며, 다른 어디에도 그 말이 없다.

## 내 판단 오류

세 arm 을 **하나의 형태로 본 것**이 오류다. "하나만 고치면 N-of-M 시그니처" 라는 기준을 적용했는데, 그 기준은 *같은 결함이 N 곳에 있을 때* 의 것이다. 여기서는 셋 중 둘이 이미 다른 곳에 주인이 있었고 **실제로 빠진 것은 하나뿐**이었다. 전수를 세는 것과 전수를 고치는 것은 다르다.

## 검증

`test_tool_task_coverage` 통과 유지 · `dune build @check` clean.

관련: `#27228` (원 PR) · `#27207` (이 suite 를 찾은 스윕)

RFC-WAIVED: 오류 메시지 2 개 원복. credential / operator control / keeper sandbox / hooks / workflow 문서 미접촉.

🤖 Generated with [Claude Code](https://claude.com/claude-code)