### PR TITLE
fix(ci): 커버리지 게이트가 docstring 을 '테스트가 필요한 코드'로 세지 않게

### DIFF
--- a/scripts/check_test_coverage.py
+++ b/scripts/check_test_coverage.py
@@ -250,14 +250,89 @@ def get_changed_test_files():
     return [f for f in stdout.strip().split("\n") if f and is_test_file(f)]
 
 
+OCAML_SUFFIXES = {".ml", ".mli"}
+SLASH_COMMENT_SUFFIXES = {".ts", ".tsx", ".js", ".jsx", ".css", ".scss"}
+
+
+def comment_line_numbers(text, suffix):
+    """1-indexed lines of [text] that hold nothing but comment.
+
+    A line counts only when every non-blank character on it is inside a
+    comment, so `let x = 1 (* note *)` stays code. OCaml block comments nest,
+    which a regex cannot track — the depth counter is why this reads the file
+    rather than the diff hunk: a continuation line in the middle of a block
+    carries no marker of its own, and those are most of a docstring.
+    """
+    if suffix in OCAML_SUFFIXES:
+        openers, closers, line_comment = ["(*"], ["*)"], None
+    elif suffix in SLASH_COMMENT_SUFFIXES:
+        openers, closers, line_comment = ["/*"], ["*/"], "//"
+    else:
+        return set()
+
+    comment_only = set()
+    depth = 0
+    for lineno, line in enumerate(text.split("\n"), 1):
+        saw_code = False
+        i = 0
+        while i < len(line):
+            two = line[i : i + 2]
+            if depth == 0 and line_comment and two == line_comment:
+                break  # rest of the line is comment
+            if two in openers:
+                depth += 1
+                i += 2
+                continue
+            if depth > 0 and two in closers:
+                depth -= 1
+                i += 2
+                continue
+            if depth == 0 and not line[i].isspace():
+                saw_code = True
+            i += 1
+        if not saw_code:
+            comment_only.add(lineno)
+    return comment_only
+
+
+def added_line_numbers(path):
+    """1-indexed new-file line numbers this PR added to [path]."""
+    stdout = run_diff_or_fail(["git", "diff", "-U0", pr_diff_range(), "--", path])
+    added, cursor = [], 0
+    for line in stdout.split("\n"):
+        if line.startswith("@@"):
+            try:
+                cursor = int(line.split("+", 1)[1].split(",", 1)[0].split(" ", 1)[0])
+            except (IndexError, ValueError):
+                cursor = 0
+            continue
+        if cursor and line.startswith("+") and not line.startswith("+++"):
+            added.append(cursor)
+            cursor += 1
+    return added
+
+
 def get_added_lines_count(files):
-    """Count added lines in changed files."""
+    """Count added lines that are not comment.
+
+    A documentation-only change to an .mli is entirely comment, so counting raw
+    `+` lines made this rule unsatisfiable for it: the only way out was the
+    manual opt-out marker, used once in the last 200 commits. A gate that fires
+    on changes it cannot be satisfied by teaches readers to merge past it.
+    """
     total = 0
     for f in files:
-        stdout = run_diff_or_fail(["git", "diff", pr_diff_range(), "--", f])
-        for line in stdout.split("\n"):
-            if line.startswith("+") and not line.startswith("+++"):
-                total += 1
+        try:
+            content = subprocess.run(
+                ["git", "show", f"HEAD:{f}"],
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout
+        except subprocess.CalledProcessError:
+            content = ""
+        comments = comment_line_numbers(content, PurePosixPath(f).suffix.lower())
+        total += sum(1 for n in added_line_numbers(f) if n not in comments)
     return total
 
 

--- a/scripts/test_check_test_coverage.py
+++ b/scripts/test_check_test_coverage.py
@@ -256,5 +256,72 @@ class CheckTestCoverageTest(unittest.TestCase):
         self.assertIn("Changed 4 files", out.getvalue())
 
 
+class CommentLineNumbersTest(unittest.TestCase):
+    """A docstring is not code the gate can ask for a test of.
+
+    Every `+` line used to count, so a documentation-only change to an .mli
+    could not satisfy this rule at all — the only way past was the manual
+    `# ci:skip-test-coverage` marker, used once in the last 200 commits.
+
+    These are the cases a line-oriented regex gets wrong: most of a docstring
+    is continuation lines carrying no marker, and OCaml block comments nest.
+    """
+
+    def assert_comment_lines(self, suffix, text, expected, label):
+        self.assertEqual(
+            coverage.comment_line_numbers(text, suffix), expected, msg=label
+        )
+
+    def test_block_continuation_lines_are_comment(self):
+        self.assert_comment_lines(
+            ".mli",
+            "(** doc\n    more doc\n    still doc *)\nval f : int",
+            {1, 2, 3},
+            "continuation lines carry no marker of their own",
+        )
+
+    def test_trailing_comment_does_not_make_the_line_comment(self):
+        self.assert_comment_lines(
+            ".ml",
+            "let x = 1 (* note *)\n(* pure *)\nlet y = 2",
+            {2},
+            "code with a trailing comment is still code",
+        )
+
+    def test_ocaml_block_comments_nest(self):
+        self.assert_comment_lines(
+            ".ml",
+            "(* outer (* inner *) still outer *)\nlet z = 3",
+            {1},
+            "the inner close must not end the outer comment",
+        )
+
+    def test_code_shaped_text_inside_a_comment_is_comment(self):
+        self.assert_comment_lines(
+            ".ml",
+            "(* a\nlet fake = 1\n*)\nlet real = 2",
+            {1, 2, 3},
+            "a commented-out binding is not an added code line",
+        )
+
+    def test_typescript_line_and_block_comments(self):
+        self.assert_comment_lines(
+            ".ts",
+            "// line\nconst a = 1\n/* b\n c */\nconst d = 2",
+            {1, 3, 4},
+            "both comment forms",
+        )
+
+    def test_typescript_trailing_line_comment_is_code(self):
+        self.assert_comment_lines(
+            ".ts", "const a = 1 // trailing", set(), "trailing // is not comment-only"
+        )
+
+    def test_suffix_without_comment_syntax_counts_every_line(self):
+        self.assert_comment_lines(
+            ".json", '{"a": 1}', set(), "unknown suffix stays conservative"
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`get_added_lines_count` 는 `+` 로 시작하는 줄을 전부 센다 — **주석과 코드를 구분하지 않는다.** 그래서 문서만 바꾼 PR 은 이 규칙을 **만족시킬 방법이 없다**. 주석을 덮는 테스트는 존재할 수 없기 때문이다.

남은 길은 수동 opt-out(`# ci:skip-test-coverage`) 뿐인데, **최근 200 커밋 중 1건**만 쓴다. 나머지는 그냥 빨간 채로 머지된다. 만족시킬 수 없는 조건으로 발동하는 게이트는 읽히지 않게 된다.

## 실측 — #27240 (주석만 18파일 변경) 재생

| 규칙 | 결과 |
|---|---|
| 모든 `+` 줄 (현행) | **79줄** → 발동 (79 > 10) |
| 주석 제외 (이 PR) | **0줄** → 침묵 |

## 왜 diff 가 아니라 파일 내용을 읽는가

docstring 의 대부분은 **자기 마커가 없는 연속줄**이고, OCaml 블록 주석은 **중첩**된다. 줄 단위 정규식은 둘 다 못 본다. 그래서 변경된 파일의 post-image 를 훑어 주석 구간을 깊이 카운터로 계산한다.

한 줄의 **모든 비공백 문자가 주석 안에 있을 때만** 주석으로 센다 — `let x = 1 (* note *)` 는 코드다. 스캐너가 모르는 확장자는 모든 줄을 코드로 세서, 못 보는 곳에서는 보수적으로 남는다.

`is_covered_code_file` 이 이미 같은 이유로 확장자 기준 비실행 자산을 걸러낸다 (#23083). 이건 그 규칙의 **줄 단위 판**이다 — 확장자는 코드인데 diff 는 아닌 경우.

## 테스트

`scripts/test_check_test_coverage.py` 에 7개 추가. 전부 줄 단위 정규식이 틀리는 모양이다:

- 블록 주석 연속줄 (마커 없음)
- 중첩 주석 — 안쪽 `*)` 가 바깥을 닫으면 안 됨
- 주석 안의 `let fake = 1`
- 양쪽 언어의 후행 주석 (코드로 남아야 함)
- 스캐너가 모르는 확장자

**20 tests OK.**
