### PR TITLE
fix(ci): 게이트가 취소를 실패라고 부르지 않게 (취소 45 vs 실패 4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1906,6 +1906,12 @@ jobs:
           #     execution is HARD REQUIRED as well. Each test step lacks
           #     continue-on-error, so a test failure fails the Build and Test
           #     job and blocks merge.
+          # A cancelled job did not fail — it did not run. Both block, because
+          # a check that never ran cannot be evidence of anything, but they are
+          # printed apart: over the last 20 CI runs the job conclusions were 110
+          # success, 45 cancelled and 4 failure, so "FAIL dashboard cancelled"
+          # was the line a reader met eleven times more often than a real
+          # failure, and it sends them looking for a defect in the diff.
           check() {
             local name=$1
             local result=$2
@@ -1914,6 +1920,9 @@ jobs:
               printf 'PASS  %-20s %s\n' "$name" "$result"
             elif [[ "$mode" == "advisory" ]]; then
               printf 'WARN  %-20s %s (advisory, not blocking)\n' "$name" "$result"
+            elif [[ "$result" == "cancelled" ]]; then
+              printf 'STOP  %-20s cancelled — never ran, re-run to decide\n' "$name"
+              fail=1
             else
               printf 'FAIL  %-20s %s\n' "$name" "$result"
               fail=1

--- a/scripts/ci/check-gate-outcome-vocabulary.sh
+++ b/scripts/ci/check-gate-outcome-vocabulary.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# The CI Gate aggregator must not call a cancelled job a failed one.
+#
+# `check()` in ci.yml folds every needs.<job>.result into PASS / FAIL. Only
+# success and skipped pass, so cancelled printed as "FAIL <job> cancelled".
+# Over the last 20 CI runs the job conclusions were 110 success, 45 cancelled
+# and 4 failure — a reader met that line eleven times more often than a real
+# failure, and it sends them looking for a defect in the diff. Cancellation
+# means the check never ran; it still blocks, under its own word.
+#
+# This extracts check() straight out of ci.yml and drives it, so the assertion
+# tracks the workflow rather than a copy of it.
+#
+# Usage: check-gate-outcome-vocabulary.sh [--fail|--self-test]
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="$ROOT/.github/workflows/ci.yml"
+
+MODE="${1:---fail}"
+case "$MODE" in
+  --fail | --self-test) ;;
+  -h | --help)
+    sed -n '2,14p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+  *)
+    echo "Usage: $0 [--fail|--self-test]" >&2
+    exit 2
+    ;;
+esac
+
+[ -f "$WORKFLOW" ] || {
+  echo "[gate-outcome-vocabulary] missing $WORKFLOW" >&2
+  exit 2
+}
+
+# Lift the function body out of the workflow's run: block and strip its indent.
+extract_check() {
+  awk '
+    /^          check\(\) \{/ { grabbing = 1 }
+    grabbing {
+      line = $0
+      sub(/^          /, "", line)
+      print line
+      if (line == "}") exit
+    }
+  ' "$1"
+}
+
+drive() {
+  local body="$1" result="$2" mode="${3:-}"
+  # shellcheck disable=SC2016
+  bash -c "
+    fail=0
+    $body
+    check probe '$result' $mode
+    printf 'fail=%s\n' \"\$fail\"
+  "
+}
+
+body="$(extract_check "$WORKFLOW")"
+if [ -z "$body" ]; then
+  echo "[gate-outcome-vocabulary] could not find check() in ci.yml — did the" >&2
+  echo "aggregator move or change indentation? This check reads it verbatim." >&2
+  exit 1
+fi
+
+problems=0
+expect() {
+  local label="$1" result="$2" want_word="$3" want_fail="$4" mode="${5:-}"
+  local out
+  out="$(drive "$body" "$result" "$mode")"
+  local word fail
+  word="$(printf '%s\n' "$out" | head -1 | awk '{print $1}')"
+  fail="$(printf '%s\n' "$out" | sed -n 's/^fail=//p')"
+  if [ "$word" != "$want_word" ] || [ "$fail" != "$want_fail" ]; then
+    echo "  MISMATCH $label: got ${word}/fail=${fail}, want ${want_word}/fail=${want_fail}" >&2
+    problems=$((problems + 1))
+  elif [ "$MODE" = "--self-test" ]; then
+    # `[ ... ] && echo` as the last statement returns 1 in --fail mode, which
+    # under `set -e` ends the function — and the caller reads that as a
+    # mismatch. An if/elif has no exit status to leak.
+    echo "  ok $label -> ${word} fail=${fail}"
+  fi
+}
+
+expect "success passes"            success   PASS 0
+expect "skipped passes"            skipped   PASS 0
+expect "failure blocks as FAIL"    failure   FAIL 1
+expect "cancelled blocks as STOP"  cancelled STOP 1
+expect "advisory never blocks"     cancelled WARN 0 advisory
+
+if [ "$problems" -ne 0 ]; then
+  echo "[gate-outcome-vocabulary] the aggregator's outcome vocabulary changed" >&2
+  echo "A cancelled job must block under its own word, not as a failure." >&2
+  exit 1
+fi
+
+echo "[gate-outcome-vocabulary] OK: 5 outcomes map as declared"

--- a/scripts/ci/run-lint-suite.sh
+++ b/scripts/ci/run-lint-suite.sh
@@ -45,6 +45,8 @@ blocking_lints() {
   run_lint ".mli env knob exists" bash scripts/lint/mli-env-knob-exists.sh --fail
   run_lint "Guard scan targets exist self-test" bash scripts/lint/guard-scan-targets-exist.sh --self-test
   run_lint "Guard scan targets exist" bash scripts/lint/guard-scan-targets-exist.sh --fail
+  run_lint "CI gate outcome vocabulary self-test" bash scripts/ci/check-gate-outcome-vocabulary.sh --self-test
+  run_lint "CI gate outcome vocabulary" bash scripts/ci/check-gate-outcome-vocabulary.sh --fail
   run_lint "Opam cache freshness ratchet" bash scripts/ci/opam-cache-freshness.sh --check
   run_lint "Opam cache freshness self-test" bash scripts/ci/opam-cache-freshness.sh --self-test
   run_lint "No actionable-signal bool context" bash scripts/lint/no-actionable-signal-bool-context.sh


### PR DESCRIPTION
CI Gate 집계기의 `check()` 는 `needs.<job>.result` 를 두 단어로 접는다 — `success`/`skipped` 만 PASS 고 나머지는 전부 `FAIL <job> <result>`. **취소된 job 이 실패한 job 으로 읽힌다.**

## 실측 — 최근 CI run 20개의 job conclusion

| conclusion | 건수 |
|---|---|
| success | 110 |
| **cancelled** | **45** |
| skipped | 37 |
| failure | **4** |

`FAIL dashboard cancelled` 은 독자가 **진짜 실패보다 11배 자주** 만나는 줄이고, diff 에서 있지도 않은 결함을 찾게 만든다. **#27236 이 지금 정확히 그 상태다** — 나머지 검사는 전부 초록인데 `dashboard cancelled` 하나로 막혀 있다.

## 판정은 그대로, 문장만 바꾼다

취소는 여전히 막는다 — **돌지 않은 검사는 증거가 될 수 없다.** 다만 자기 단어로 말하게 했다:

```
STOP  dashboard            cancelled — never ran, re-run to decide
```

## 검증

`scripts/ci/check-gate-outcome-vocabulary.sh` 는 `ci.yml` 에서 `check()` 를 **그대로 들어내 실행한다** — 사본을 두면 드리프트하므로 워크플로를 직접 따라간다.

다섯 결과를 고정한다: `success`/`skipped` 통과, `failure` 는 FAIL 로 차단, `cancelled` 는 STOP 으로 차단, advisory 는 무엇을 보고하든 차단하지 않음.

**양방향 확인:**

```
수정 전 ci.yml → MISMATCH cancelled blocks as STOP (got FAIL), exit 1
수정 후        → OK: 5 outcomes map as declared, exit 0
```

## 만들면서 잡은 버그 2개

1. awk 추출기가 닫는 중괄호를 지나쳐 호출부까지 삼켰다 — 함수 대신 30줄을 실행해 전부 FAIL 로 떨어졌다
2. `[ "$MODE" = ... ] && echo` 가 함수의 마지막 문장이면 `set -e` 아래서 1을 반환한다 — `--self-test` 는 통과하는데 `--fail` 만 모든 케이스를 mismatch 로 보고했다

`--self-test` 만 돌렸으면 2번을 못 잡았다. shellcheck clean.
