### PR TITLE
fix(keeper): main red — #27230 이 지운 선언은 스크립트가 검사하는 경계 계약이었다

### DIFF
--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -149,7 +149,16 @@ val unavailable_fleet_summary_json : unit -> Yojson.Safe.t
     Kept here so schema and field ownership remain single-source. *)
 
 module For_testing : sig
-
+  val with_after_ledger_append :
+    after_ledger_append:(unit -> (unit, string) result) ->
+    (unit -> 'a) ->
+    'a
   (** Scoped post-append fault seam. The callback must invoke the canonical
-      recovery projector; this seam cannot read or retire an outbox itself. *)
+      recovery projector; this seam cannot read or retire an outbox itself.
+
+      This declaration is part of the projection boundary contract that
+      [scripts/keeper_event_queue_projection_boundary_check.ml] enforces: the
+      seam must exist exactly once as a definition and once as a declaration,
+      so the fault path cannot acquire a second entry point. No test calls it,
+      which is why an unused-declaration sweep read it as dead. *)
 end


### PR DESCRIPTION
## main 이 red 다

`Build and Test` → `Check keeper event queue projection boundary`:

```
declaration with_after_ledger_append
  expected=[lib/keeper/keeper_reaction_ledger.mli:For_testing.with_after_ledger_append]
  actual=[]
```

## 원인

#27230 이 "no test uses" 로 `For_testing` 선언 29 개를 지웠다. **28 개는 맞다.** 이것 하나가 다르다.

호출하는 테스트는 없다. 대신 `scripts/keeper_event_queue_projection_boundary_check.ml` 이 **그 선언의 존재 자체를 경계 계약으로 검사**한다 — post-append fault seam 은 정의 1 개와 선언 1 개로만 존재해야 하고, 그래야 fault 경로가 두 번째 진입점을 얻지 못한다.

```ocaml
; ( "with_after_ledger_append"
  , [ ledger_mli, "For_testing.with_after_ledger_append" ] )
```

`.ml` 정의는 남았다. 즉 **seam 은 여전히 도달 가능한데 그것을 한정하는 선언만 사라진** 상태였고, 검사기는 정확히 그 비대칭을 잡으려고 존재한다.

## 왜 스윕이 놓쳤나

소비자를 `test/` 에서만 셌기 때문이다. 선언은 **호출되는 것이 아니라 존재를 확인당하는 방식**으로도 소비된다. 그 형태는 call site 를 grep 해도 안 나온다.

29 개 중 스크립트가 이름으로 요구하는 것은 이 하나뿐이다 (전수 확인함).

## 수정

선언을 복원하고, **왜 여기 있는지**를 주석에 적었다. 다음 스윕이 이걸 다시 부채로 읽지 않도록.

```
scripts/check-keeper-event-queue-projection-boundary.sh
→ [keeper-event-queue-projection-boundary] OK
```

`dune build @check` green, ocamlformat clean.
