### PR TITLE
fix(keeper): main red — #27230 이 반만 적용한 For_testing 제거를 마무리

### DIFF
--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -427,20 +427,6 @@ let project_event_queue_transition_outbox_result
     ~base_path
     ~keeper_name
 
-module For_testing = struct
-  let with_after_ledger_append ~after_ledger_append f =
-    Stdlib.Mutex.lock after_ledger_append_hook_mutex;
-    let previous =
-      Atomic.exchange after_ledger_append_hook (Some after_ledger_append)
-    in
-    Fun.protect
-      ~finally:(fun () ->
-        Atomic.set after_ledger_append_hook previous;
-        Stdlib.Mutex.unlock after_ledger_append_hook_mutex)
-      f
-  ;;
-end
-
 let assoc_field name = function
   | `Assoc fields -> List.assoc_opt name fields
   | _ -> None

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -147,9 +147,3 @@ val fleet_summary_json :
 val unavailable_fleet_summary_json : unit -> Yojson.Safe.t
 (** Canonical empty fleet projection used when server state is unavailable.
     Kept here so schema and field ownership remain single-source. *)
-
-module For_testing : sig
-
-  (** Scoped post-append fault seam. The callback must invoke the canonical
-      recovery projector; this seam cannot read or retire an outbox itself. *)
-end

--- a/scripts/keeper_event_queue_projection_boundary_check.ml
+++ b/scripts/keeper_event_queue_projection_boundary_check.ml
@@ -23,7 +23,6 @@ let targets =
   ; "project_transition_outbox_result"
   ; "run_after_ledger_append_hook"
   ; "transition_outbox_result"
-  ; "with_after_ledger_append"
   ]
 ;;
 
@@ -672,8 +671,6 @@ let run () =
       , [ persistence_ml, "project_transition_outbox_result" ] )
     ; "run_after_ledger_append_hook", []
     ; "transition_outbox_result", []
-    ; ( "with_after_ledger_append"
-      , [ ledger_ml, "For_testing.with_after_ledger_append" ] )
     ]
   in
   let declaration_expectations =
@@ -686,8 +683,6 @@ let run () =
       , [ persistence_mli, "project_transition_outbox_result" ] )
     ; "run_after_ledger_append_hook", []
     ; "transition_outbox_result", []
-    ; ( "with_after_ledger_append"
-      , [ ledger_mli, "For_testing.with_after_ledger_append" ] )
     ]
   in
   run_pattern_fixture_tests ();
@@ -716,7 +711,6 @@ let run () =
       , [ ledger_ml, "project_event_queue_transition_outbox_result" ] )
     ; "run_after_ledger_append_hook", []
     ; "transition_outbox_result", []
-    ; "with_after_ledger_append", []
     ];
   List.iter
     (fun (name, expected) ->


### PR DESCRIPTION
**main 이 빨갛다.** `Check keeper event queue projection boundary` 가 실패한다:

```
declaration with_after_ledger_append
  expected=[lib/keeper/keeper_reaction_ledger.mli:For_testing.with_after_ledger_append]
  actual=[]
```

## 원인 — 세 짝 중 하나만 지워졌다

`#27230`("drop 29 For_testing declarations no test uses")의 판단은 **옳았다** — 이 함수를 부르는 테스트가 0건이다. 다만 지운 건 `val` 한 줄뿐이고, 그게 선언하던 것을 가리키는 게 셋 남았다:

| 위치 | 남은 것 |
|---|---|
| `keeper_reaction_ledger.mli` | docstring 만 든 **빈 `module For_testing : sig … end`** |
| `keeper_reaction_ledger.ml` | 구현 12줄 |
| `keeper_event_queue_projection_boundary_check.ml` | 심볼을 지명한 기대 **4곳** |

가드가 `.ml`/`.mli` 를 그 목록과 대조하므로, 셋 중 하나만 지우면 집합이 어긋나고 가드가 그걸 보고한다.

## 셋 다 제거

빈 시그니처도 함께 지워야 했다. 구현만 지우면 `module For_testing is required but not provided` 로 빌드가 깨진다 — 실제로 그 오류가 **세 번째 조각이 남아 있다는 걸 드러냈다.**

훅 인프라는 남긴다. `after_ledger_append_hook` 은 다른 참조가 7건이고 `run_after_ledger_append_hook` 은 가드의 심볼 목록에 있다. 죽은 건 그 위의 **테스트 seam 하나**뿐이다.

## 반경

`#27230` 은 `Build and Test`·`CI Gate`·`check` 가 **이미 빨간 상태로** 11:22 에 머지됐고, 그 뒤 **11개 커밋이 빨간 main 위에 착지했다.** 이슈 #26972 가 기록한 것과 같은 모양이다.

## 검증

```
dune build --root . @check                              exit 0
scripts/check-keeper-event-queue-projection-boundary.sh exit 0
```
