### PR TITLE
fix(prompt): stop the keeper prompt overstating the one-task limit

### DIFF
--- a/config/prompts/keeper.md
+++ b/config/prompts/keeper.md
@@ -109,10 +109,16 @@ better-suited Keeper leaves it unclaimed. If you look at one and decide against
 it, say why on the Task or the Board so the next Keeper reads a judgment rather
 than silence.
 
-You hold one Task at a time. While a Task you claimed is still open, a claim on
-another is refused and names both the Task you hold and how to hand it back. So
-pick the one you mean to work, then finish it or hand it back before claiming
-again — trying each candidate in turn only produces a run of refusals.
+You work one Task at a time. While a Task you claimed or started is still yours,
+a claim on another is refused and names both the Task you hold and how to hand
+it back. So pick the one you mean to work, then finish it or hand it back before
+claiming again — trying each candidate in turn only produces a run of refusals.
+
+A Task you submitted for verification is not one of those. It waits on a verdict
+you cannot produce, and it does not hold your next claim: it still shows as
+yours, and you claim the next work while it waits. Cancelling it to free
+yourself cancels the evidence you already submitted, and the verdict it was
+waiting for never lands.
 
 Your goals, memory, and repositories are work surfaces of their own. The Board
 is one of several places work lives, not the register that decides whether work

--- a/test/fixtures/keeper_system_prompt/assembled_prompt.golden
+++ b/test/fixtures/keeper_system_prompt/assembled_prompt.golden
@@ -105,10 +105,16 @@ better-suited Keeper leaves it unclaimed. If you look at one and decide against
 it, say why on the Task or the Board so the next Keeper reads a judgment rather
 than silence.
 
-You hold one Task at a time. While a Task you claimed is still open, a claim on
-another is refused and names both the Task you hold and how to hand it back. So
-pick the one you mean to work, then finish it or hand it back before claiming
-again — trying each candidate in turn only produces a run of refusals.
+You work one Task at a time. While a Task you claimed or started is still yours,
+a claim on another is refused and names both the Task you hold and how to hand
+it back. So pick the one you mean to work, then finish it or hand it back before
+claiming again — trying each candidate in turn only produces a run of refusals.
+
+A Task you submitted for verification is not one of those. It waits on a verdict
+you cannot produce, and it does not hold your next claim: it still shows as
+yours, and you claim the next work while it waits. Cancelling it to free
+yourself cancels the evidence you already submitted, and the verdict it was
+waiting for never lands.
 
 Your goals, memory, and repositories are work surfaces of their own. The Board
 is one of several places work lives, not the register that decides whether work

--- a/test/test_keeper_prompt_metrics.ml
+++ b/test/test_keeper_prompt_metrics.ml
@@ -378,11 +378,29 @@ let test_system_block_states_the_collaboration_surface () =
      without telling it the limit produces runs of refusals, so both belong in
      the same paragraph. *)
   check bool "the one-task-at-a-time limit is stated" true
-    (has_in prompt "You hold one Task at a time");
+    (has_in prompt "You work one Task at a time");
+  check bool "the limit names the two statuses that hold a claim" true
+    (has_in prompt "a Task you claimed or started is still yours");
   check bool "the refusal is described, not just the limit" true
     (has_in prompt "a claim on another is refused and names both the Task you hold");
   check bool "walking the candidate list is named as the wrong move" true
     (has_in prompt "trying each candidate in turn only produces a run of refusals");
+  (* That limit is narrower than it reads, and the prompt used to overstate it.
+     [active_owned_task_ids_for_agent] matches Claimed and InProgress only and
+     answers None for AwaitingVerification, so a submitted Task does not refuse
+     the next claim. Everything a keeper can see says otherwise: the world frame
+     renders it under "Current Task (held by you)", and the lifecycle refuses
+     Release from AwaitingVerification while admitting Cancel by the assignee,
+     so the only exit in view is the one that discards its own evidence. Live
+     workspace: of 56 cancelled tasks 10 had already written a verification
+     record, and task-128 states the belief in words -- "awaiting_verification
+     blocks claim". It does not. Pin the correction against silent widening. *)
+  check bool "a submitted Task is stated not to hold the next claim" true
+    (has_in prompt "A Task you submitted for verification is not one of those");
+  check bool "claiming while a verdict is pending is stated as available" true
+    (has_in prompt "you claim the next work while it waits");
+  check bool "cancelling submitted work is named as evidence loss" true
+    (has_in prompt "cancels the evidence you already submitted");
   (* Release exists under the other namespace: keeper_task_claim /
      keeper_task_done / keeper_task_create sit on the keeper_* surface while
      handing a task back is masc_transition with action "release".


### PR DESCRIPTION
## What

`keeper.md` stated the one-task-at-a-time limit more broadly than the claim gate
enforces it. Narrow the statement to the two statuses that actually hold a claim,
and name the exception.

No behaviour change — the claim gate already worked this way.

## The gap

`active_owned_task_ids_for_agent` (`lib/workspace/workspace_task_claim.ml:23`)
matches `Claimed` and `InProgress` and answers `None` for
`AwaitingVerification`. `workspace_task_schedule.ml:207` states the intent:

> AwaitingVerification is still excluded: it is no longer active implementation
> work for the claimant.

The prompt said:

> While a Task you claimed **is still open**, a claim on another is refused

A submitted Task is still open in plain reading. Everything else a keeper can
see agrees with the prompt rather than the code:

| Signal | What it tells the keeper |
|---|---|
| `keeper_unified_prompt.ml:132` | renders it under `### Current Task (held by you)` |
| `workspace_task_lifecycle.ml:128` | `Release` from `AwaitingVerification` → `Invalid_transition` |
| `workspace_task_lifecycle.ml:119` | `Cancel` by the assignee → admitted |

So a keeper that believes it is blocked has exactly one exit, and that exit
discards its own submitted evidence.

## Recorded design

`docs/rfc/RFC-0220-verification-scheduling-decouple.md` (Withdrawn, updated
2026-08-02) already states the rule the prompt contradicted:

> An `AwaitingVerification` task is a pending completion-authority obligation,
> **not Keeper work**. It cannot be claimed by a Keeper and never grants
> verifier authority through task ownership.

The code follows that. The prompt did not.

## Measured

`~/.masc/tasks/backlog.json`, 202 tasks:

| | n |
|---|---:|
| cancelled | 56 |
| …that had already written a verification record | **10** |
| cancel reasons naming "free claim capacity" over finished work | 8 |

`task-128` states the belief verbatim:

> Task overlaps with task-034 (already completed and released).
> **awaiting_verification blocks claim**

It does not.

Every cancelled task carries a non-empty `reason` (56/56) and `done` tasks carry
notes (139/140) — the recording paths are healthy. What was wrong was the rule
the keeper was recording against.

## Change

- `config/prompts/keeper.md` — "You work one Task at a time. While a Task you
  claimed or started is still yours…", plus a paragraph stating that a submitted
  Task does not hold the next claim and that cancelling it discards the evidence.
- `test/fixtures/keeper_system_prompt/assembled_prompt.golden` — refreshed in
  this commit (diff is the paragraph above and nothing else).
- `test/test_keeper_prompt_metrics.ml` — moved the existing literal pin to the
  new wording; added four assertions (the two held statuses, the exception,
  claim-while-waiting, evidence loss) so the rule cannot silently widen back.

## Verification

```
dune build --force @test/runtest-test_keeper_system_prompt_bytes \
                   @test/runtest-test_keeper_prompt_metrics \
                   @test/runtest-test_keeper_surface_presence_prompt
→ 2 + 16 + 22 tests, all pass
dune build @test/runtest-test_prompt_asset_sync @test/runtest-test_prompt_registry_defaults
→ 13 + 27 tests, all pass
```

All three targets in the CI `Run keeper prompt assembly suites` step were run.

## Not mine

`test/runtest-test_server_runtime_bootstrap` fails 5 assertions on
`origin/main` (health-json keeper capacity), byte-identical before and after
this change. It is not wired into `ci.yml`, so CI does not see it. Filed
separately rather than folded in here.

RFC-WAIVED: prompt text + its pinning test only. No credential, identity,
operator-control, sandbox, hooks, or workflow surface is touched; no schema,
no state machine, no behaviour change.
