### PR TITLE
fix(keeper): restore the seam declaration the boundary check requires

### DIFF
--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -149,7 +149,10 @@ val unavailable_fleet_summary_json : unit -> Yojson.Safe.t
     Kept here so schema and field ownership remain single-source. *)
 
 module For_testing : sig
-
+  val with_after_ledger_append
+    :  after_ledger_append:(unit -> (unit, string) result)
+    -> (unit -> 'a)
+    -> 'a
   (** Scoped post-append fault seam. The callback must invoke the canonical
       recovery projector; this seam cannot read or retire an outbox itself. *)
 end


### PR DESCRIPTION
## main 이 자기 경계 검사를 통과하지 못한다

```
$ bash scripts/check-keeper-event-queue-projection-boundary.sh; echo $?
[keeper-event-queue-projection-boundary] declaration with_after_ledger_append
  expected=[lib/keeper/keeper_reaction_ledger.mli:For_testing.with_after_ledger_append] actual=[]
1
```

`scripts/keeper_event_queue_projection_boundary_check.ml` 은 이 seam 을 아키텍처 계약으로 고정한다 (`targets` 목록 + `declaration_expectations`). 선언이 없으면 실패한다.

## 내가 지웠다

`#27230` (`refactor(lib): drop 29 For_testing declarations no test uses`) 이 그 선언을 지웠다. 판정 기준은 "테스트가 이름조차 언급하지 않고, 자기 모듈 밖 lib 코드에서도 참조되지 않는다" 였고 그 기준으로는 맞았다. 놓친 것은 **코드가 아니라 린트가 이 선언을 요구한다** 는 점이다.

`#27230` 이 지운 29 개 중 이 검사에 걸리는 것은 이것 하나뿐이다 — 같은 스크립트를 돌려 확인했다.

## 왜 지금까지 안 걸렸나

이 검사는 관련 경로가 바뀐 PR 에서만 돈다. `#27230` 이 머지될 때는 통과했거나 완료 전에 머지됐고, 그 뒤로 해당 파일을 건드리는 PR (#27234, #27238, #27242) 이 전부 여기서 막혀 있다.

## 고침

`.mli` 의 `For_testing` sig 에 `val` 을 되돌린다. 타입은 구현이 이미 갖고 있던 것이다 (`after_ledger_append:(unit -> (unit, string) result) -> (unit -> 'a) -> 'a`).

선언을 되돌리면 warning 32 도 함께 해결된다 — `.mli` 가 내보내는 값은 미사용 경고 대상이 아니므로, 이 seam 은 앞으로 "쓰이지 않는다" 는 이유로 다시 지워지지 않는다.

## 검증

`dune build @check` 통과. `scripts/check-keeper-event-queue-projection-boundary.sh` **OK** (변경 전에는 exit 1).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
