### PR TITLE
test(keeper): #27246 이 복원한 선언을 컴파일러가 지키게 한다

### DIFF
--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -1006,6 +1006,33 @@ let test_missing_identity_does_not_claim_an_occurrence_identity () =
   check_member_string "identity quarantine reason" "missing_stimulus_id" "reason" reason
 ;;
 
+
+(* The post-append fault seam is declared in the .mli as a boundary contract:
+   it must exist exactly once as a definition and once as a declaration, so the
+   fault path cannot acquire a second entry point.
+   [scripts/keeper_event_queue_projection_boundary_check.ml] asserts that shape
+   from outside the compiler, which is why an unused-declaration sweep read the
+   declaration as dead and removed it (#27230), turning main red.
+
+   This case holds the declaration from inside the compiler. It calls the seam
+   with a callback that does nothing but record that it ran, so removing the
+   declaration again is a compile error here rather than a red main later. *)
+let test_after_ledger_append_seam_is_reachable_through_the_interface () =
+  let ran = ref false in
+  let result =
+    Keeper_reaction_ledger.For_testing.with_after_ledger_append
+      ~after_ledger_append:(fun () ->
+        ran := true;
+        Ok ())
+      (fun () -> "body ran")
+  in
+  check string "the scoped body's value is returned" "body ran" result;
+  (* The seam installs the hook for the scope; whether this body triggers an
+     append is not this case's claim. What is claimed is that the declaration
+     exists and its type is the one the boundary check names. *)
+  ignore !ran
+;;
+
 let () =
   run
     "keeper_reaction_ledger"
@@ -1082,6 +1109,10 @@ let () =
             "reaction_kind string round-trip drift guard"
             `Quick
             test_reaction_kind_string_roundtrip
+        ; test_case
+            "after_ledger_append seam is reachable through the interface"
+            `Quick
+            test_after_ledger_append_seam_is_reachable_through_the_interface
         ] )
     ]
 ;;


### PR DESCRIPTION
## #27246 이 고친 것을 컴파일러가 지키게 한다

#27246 이 `For_testing.with_after_ledger_append` 선언을 복원해 main 을 초록으로 되돌렸다. 다만 그 선언을 지키는 것은 여전히 `scripts/keeper_event_queue_projection_boundary_check.ml` 하나이고, 그건 **CI 에서만 돈다.**

그래서 다음 unused-declaration 스윕이 같은 판단을 내리면 같은 일이 반복된다 — 지워지고, 로컬 빌드는 통과하고, main 이 빨개진 뒤에 알게 된다. #27230 이 정확히 그 경로였다.

## 수정

인터페이스를 통해 seam 을 호출하는 케이스 하나를 넣었다. 이제 선언을 지우면 `dune build` 가 즉시 깨진다.

**실패 능력 확인** — 선언을 다시 지워봤다:

```
Error: Unbound value Keeper_reaction_ledger.For_testing.with_after_ledger_append
```

## 이 케이스가 주장하지 않는 것

append 동작에 대해 아무 주장도 하지 않는다. scoped body 의 반환값이 그대로 돌아온다는 것만 확인하고, 그건 **선언이 boundary check 가 지목하는 타입으로 존재해야만** 성립하는 가장 작은 문장이다.

행동을 검사하려 들면 이 케이스가 append 경로의 변경에 흔들리고, 그러면 원래 목적(선언 고정)이 다른 이유로 빨개지는 잡음이 된다.

## 왜 스크립트 게이트로 부족한가

게이트 자체는 옳고 실제로 이번 사고를 잡았다. 문제는 **잡는 시점**이다. 컴파일러는 편집한 사람의 화면에서 잡고, CI 게이트는 push 후 26 분 뒤 main 에서 잡는다. 같은 계약이면 앞쪽이 낫다.
