### PR TITLE
fix(tools): keeper_task_done says done; it submits for verification

### DIFF
--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1812,7 +1812,12 @@ let internal_descriptors : t list =
       ~capability_identity:Internal_name_identity
       "done"
       "keeper_task_done"
-      "Mark the claimed MASC task as done."
+      (* The name says done; the handler issues submit_for_verification
+         (keeper_tool_task_runtime.ml:806). Saying "done" here left the model
+         expecting a terminal state and finding AwaitingVerification. *)
+      "Submit the claimed MASC task for verification with evidence. The task \
+       waits for a completion authority's verdict; it does not become done \
+       here, and it does not hold your next claim while it waits."
       ~readonly:false
   (* ── RFC-0182 §3.1 — masc_task_* cluster (7 entries) ─────────── *)
   ; masc_task_descriptor "add" "masc_add_task"

--- a/lib/tool_surface/tool_help_registry.ml
+++ b/lib/tool_surface/tool_help_registry.ml
@@ -150,23 +150,24 @@ let manual_help_entry name =
         {
           name;
           short_description =
-            "Mark your owned task done with a result summary and evidence_refs.";
+            "Submit your owned task for verification with a result summary and evidence_refs.";
           when_to_use =
             "Use when the current keeper has finished an owned task and can cite concrete evidence_refs.";
           key_constraints =
             [
-              "Caller must own the task unless using a force tool.";
-              "evidence_refs must include at least one locally validated base-path artifact, local git commit, or .masc trace/turn/receipt artifact when marking work done.";
+              "Caller must own the task; no tool overrides task ownership.";
+              "evidence_refs must include at least one locally validated base-path artifact, local git commit, or .masc trace/turn/receipt artifact.";
+              "The task moves to awaiting_verification, not done. Only a completion authority commits the verdict.";
             ];
           details_markdown =
-            "Completes the task directly. For PR-bearing work, include the PR URL or artifact reference in evidence_refs instead of using a separate verification-evidence wrapper.";
+            "Issues submit_for_verification. The task waits for an operator or auto-judge verdict, which no Keeper can produce; it does not hold your next claim while it waits, and cancelling it discards the evidence you just submitted. For PR-bearing work, include the PR URL or artifact reference in evidence_refs.";
           doc_refs = [];
-          prompt_hints = [ "Prefer this over retired task verification wrapper tools." ];
+          prompt_hints = [];
           examples =
             [
               "task_id='task-123' result='Implemented the task; checks passed.' evidence_refs=['artifact:review-42']";
             ];
-          alternatives = [];
+          alternatives = [ "masc_transition" ];
         }
   | "keeper_memory_write" ->
       Some

--- a/lib/tool_surface/tool_shard_types_schemas_taskboard.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_taskboard.ml
@@ -125,9 +125,12 @@ let taskboard_tools : Masc_domain.tool_schema list =
     }
   ; { name = "keeper_task_done"
     ; description =
-        "Mark your claimed task as complete with a result summary and trusted \
-         evidence_refs. The task must be claimed by you. The completion gate \
-         accepts task completion only when evidence_refs contains a \
+        "Submit your claimed task for verification with a result summary and \
+         trusted evidence_refs. The task must be claimed by you. This does not \
+         make the task done: it moves to awaiting_verification and waits for a \
+         completion authority's verdict, which no Keeper can produce. It also \
+         does not hold your next claim while it waits. The completion gate \
+         accepts the submission only when evidence_refs contains a \
          reviewer-inspectable PR, commit, trace, receipt, or URL reference; \
          pure-placeholder results ('done', 'ok', etc.) are rejected."
     ; input_schema =

--- a/test/test_tool_help_metadata_rfc_0195.ml
+++ b/test/test_tool_help_metadata_rfc_0195.ml
@@ -133,6 +133,10 @@ let test_entry_json_omits_empty_fields () =
       "empty alternatives list omitted from JSON" false (has_key "alternatives")
   | _ -> Alcotest.fail "entry_json must return an Assoc"
 
+(* The omitted-when-empty half is covered by [test_entry_json_omits_empty_fields]
+   on keeper_time_now. This fixture exists for the opposite property, so it
+   asserts inclusion on both list fields rather than reusing one entry to prove
+   emission and omission at once. *)
 let test_entry_json_includes_populated_fields () =
   let entry = lookup "keeper_task_done" in
   let json = Registry.entry_json entry in
@@ -142,7 +146,7 @@ let test_entry_json_includes_populated_fields () =
     Alcotest.(check bool)
       "populated examples list emitted in JSON" true (has_key "examples");
     Alcotest.(check bool)
-      "empty alternatives list omitted from JSON" false (has_key "alternatives")
+      "populated alternatives list emitted in JSON" true (has_key "alternatives")
   | _ -> Alcotest.fail "entry_json must return an Assoc"
 
 let () =


### PR DESCRIPTION
## What

`keeper_task_done` issues `submit_for_verification`. Every model-facing text for
it said it makes the task done. Correct all three; no behaviour change.

Follow-on to #27249, which fixed the prompt half of the same boundary.

## The contradiction

`keeper_tool_task_runtime.ml:806`:

```ocaml
let action = "submit_for_verification" in
```

Nothing this tool can do makes a task `done`: `Done_action` answers
`Verification_submission_required` from every non-terminal status, and
completion commits through `commit_verdict_r` on the completion-authority
boundary.

| Surface | Said |
|---|---|
| `keeper_tool_descriptor.ml:1815` (what the model sees) | "Mark the claimed MASC task as done." |
| `tool_shard_types_schemas_taskboard.ml:127` (canonical) | "Mark your claimed task as complete…" |
| `tool_help_registry.ml:162` (what `masc_tool_help` returns) | "**Completes the task directly.**" |

`masc_transition`, in the same surface, already states the rule correctly:

> Completion requires the assignee to submit evidence, then wait for an
> authenticated human-operator or typed auto-judge verdict outside this tool.
> Direct done and approve/reject are deliberately unavailable here.

So does `keeper_task_claim`'s canonical description ("awaiting_verification
tasks are pending a verdict from the system LLM agent at the
completion-authority boundary"). The completion tool was the one surface that
did not.

## Three dead claims in the same help entry

Each verified absent from the tree, not assumed:

| Claim | Check |
|---|---|
| "Caller must own the task **unless using a force tool**" | no force task tool exists |
| "instead of using a separate **verification-evidence wrapper**" | no such tool |
| "Prefer this over **retired** task verification wrapper tools" | verification is required, not retired |

## Why it matters (live workspace, 202 tasks)

| | n |
|---|---:|
| cancelled | 56 |
| …that had already written a verification record | 10 |
| cancel reasons naming "free claim capacity" over finished work | 8 |

A keeper told the task "completes directly", then finding it in
`awaiting_verification`, has been misled twice about the same boundary.

## Change

- `keeper_tool_descriptor.ml` — the model-facing description now says it submits
  for verification, names the wait, and states it does not hold the next claim.
- `tool_shard_types_schemas_taskboard.ml` — same correction on the canonical
  schema; the evidence_refs gate wording is unchanged.
- `tool_help_registry.ml` — rewrote the manual entry: dead claims removed, the
  awaiting_verification outcome added as a key constraint, `alternatives` points
  at `masc_transition`.
- `test_tool_help_metadata_rfc_0195.ml` — that suite used `keeper_task_done` as
  its "populated fields" fixture while asserting `alternatives` was *absent*.
  The omission case already has its own test on `keeper_time_now`, so the
  populated fixture now asserts inclusion on both list fields.

The RFC-0195 dangling-alternatives guard caught a first attempt that put prose in
`alternatives`; it is a bare tool name now.

## Verification

```
dune build --force @test/runtest-test_tool_help_metadata_rfc_0195 \
  @test/runtest-test_tool_help_registry_shard_coverage_10101 \
  @test/runtest-test_tool_shard_coverage \
  @test/runtest-test_tool_task_coverage \
  @test/runtest-test_capability_registry
→ 13 + 4 + 6 + 6 + 87 tests, all pass

dune build --force @test/runtest-test_keeper_system_prompt_bytes \
  @test/runtest-test_keeper_prompt_metrics \
  @test/runtest-test_keeper_surface_presence_prompt
→ 2 + 16 + 22 tests, all pass
```

Repo-wide sweep for the five removed strings returns nothing.

RFC-WAIVED: tool description text and its pinning test only. No credential,
identity, operator-control, sandbox, hooks, or workflow surface; no schema
shape, no state machine, no behaviour change.
