### PR TITLE
fix(build): remove the re-exports #27230 left for the ratchet to find

### DIFF
--- a/lib/dashboard/dashboard_goals.ml
+++ b/lib/dashboard/dashboard_goals.ml
@@ -356,7 +356,4 @@ let dashboard_goals_tree_json ~(config : Workspace.config) =
 module For_testing = struct
   let dashboard_goals_tree_json_with_pending_reader =
     dashboard_goals_tree_json_with_pending_reader
-
-  let goal_detail_json_with_pending_reader =
-    goal_detail_json_with_pending_reader
 end

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -535,10 +535,6 @@ let keeper_purge_submit_status = function
   | Existing_operation_intent_mismatch _ -> `Conflict
 ;;
 
-module For_testing = struct
-  let purge_dashboard_keeper_artifacts = purge_dashboard_keeper_artifacts
-end
-
 let respond_keeper_purge_operation_accepted ~request reqd operation =
   match operation.Keeper_shutdown_types.cleanup_intent.reason with
   | Keeper_shutdown_types.Dashboard_keeper_purge context ->

--- a/lib/server/server_dashboard_http_delete_actions.mli
+++ b/lib/server/server_dashboard_http_delete_actions.mli
@@ -30,7 +30,3 @@ val handle_keeper_lifecycle_completion :
   Keeper_shutdown_types.t ->
   Keeper_shutdown_types.completion_action ->
   (unit, string) result
-
-module For_testing : sig
-
-end

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -3330,7 +3330,6 @@ module For_testing = struct
     queued_delivery_outcome_of_turn_ref
   let committed_delivery_outcome = committed_delivery_outcome
   let empty_reply_delivery_plan = empty_reply_delivery_plan
-  let format_surface_context = format_surface_context
   let surface_context_to_instructions = surface_context_to_instructions
   let keeper_tool_failure_log_details = keeper_tool_failure_log_details
   let keeper_chat_stream_headers = keeper_chat_stream_headers


### PR DESCRIPTION
## main 이 빌드되지 않는다

```
$ dune build @check
lib/server/server_routes_http_keeper_stream.ml:3333: unused value format_surface_context
lib/server/server_dashboard_http_delete_actions.ml:539: unused value purge_dashboard_keeper_artifacts
lib/dashboard/dashboard_goals.ml:360: unused value goal_detail_json_with_pending_reader
```

## 내 PR 두 개가 겹쳐서 생겼다

`#27230` 이 `For_testing` 의 `.mli` 선언 29 개를 지웠다. 그때는 그 라이브러리들에 미사용 값 경고가 꺼져 있어서 `.ml` 쪽 재수출이 남아도 빌드가 통과했다. 그 PR 본문에 "`.ml` 잔여는 래칫이 나중에 잡는다" 고 적었다.

`#27242` 가 `lib/server` 와 `lib/dashboard` 에 `-w +32` 를 켜면서 그 잔여가 드러났다. 예고한 대로 잡혔지만, 두 PR 사이에 정리가 들어가지 않아 main 이 red 가 됐다.

## 지운 것

세 개 모두 상위 값을 그대로 재수출하던 한 줄이고, `.mli` 에도 없고 (`#27230` 이 지웠다) 한정 참조도 0 이다.

`server_dashboard_http_delete_actions` 는 `For_testing` 이 그 한 줄뿐이라 모듈이 비었고, `.mli` 에 남아 있던 빈 `module For_testing : sig end` 도 함께 지웠다.

## 계약 검사부터 확인했다

이 저장소는 코드가 부르지 않아도 존재를 요구하는 선언이 있다. `#27230` 이 지운 `For_testing.with_after_ledger_append` 가 그랬고, `keeper_event_queue_projection_boundary_check.ml` 이 그것을 아키텍처 seam 으로 고정한다 — `#27246` 이 선언을 되살리는 쪽으로 이미 고쳤다.

그래서 이번 세 개는 지우기 전에 `rg <name> scripts/` 로 확인했다. 셋 다 0 이다. `scripts/check-keeper-event-queue-projection-boundary.sh` 도 통과한다.

## 검증

`dune build @check` 통과 (변경 전 실패). 경계 검사 통과. 12 줄 삭제.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
