### PR TITLE
fix(observability): cut previews at a UTF-8 boundary, not a byte index

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1158,6 +1158,24 @@ jobs:
           chmod +x scripts/ci-run-tests.sh
           scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_channel_gate_content_length_knob"
 
+      # Redaction is the last thing every observability payload passes through,
+      # so a defect here is not scoped to one field: a preview truncated inside
+      # a multibyte character makes the whole JSON response undecodable and the
+      # panel that reads it renders nothing. test_observability_redact carried a
+      # max-length case from the start and compiled on every run, but was never
+      # named here, so it never executed and the byte-indexed cut survived.
+      - name: Run observability redaction suite
+        id: observability_redaction_suite
+        if: ${{ always() && steps.build_step.outcome == 'success' }}
+        env:
+          ME_ROOT: /tmp/me
+          CI_TEST_HEARTBEAT_SEC: 15
+          DUNE_JOBS: 1
+        run: |
+          mkdir -p /tmp/me
+          chmod +x scripts/ci-run-tests.sh
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_observability_redact"
+
       - name: Run verification behavior suite
         id: verification_behavior_suite
         if: ${{ always() && steps.build_step.outcome == 'success' }}

--- a/lib/observability_redact.ml
+++ b/lib/observability_redact.ml
@@ -135,10 +135,21 @@ let redact_patterns (s : string) : string =
 let redact_text (s : string) : string =
   redact_patterns s
 
+(* [max_len] is a byte budget, but the strings that reach here are UTF-8 and
+   [String.sub s 0 max_len] lands inside a multibyte character whenever one
+   straddles the boundary, leaving a lead byte with no continuation. The damage
+   is not local to the field: a consumer that decodes the whole payload fails on
+   all of it. The dashboard's exact-lane panel rendered nothing for this reason
+   — one Korean board comment crossing the 1024-byte preview boundary made
+   [response.json()] throw, and 68 runs went unshown.
+
+   [String_util.utf8_char_boundary] is the existing answer to this (8+ callers
+   already route through that module's UTF-8 helpers); only the cut index moves,
+   so the byte budget and the suffix behave exactly as before. *)
 let truncate ?(max_len = default_max_len) (s : string) : string =
   let s = String.trim s in
   if String.length s <= max_len then s
-  else String.sub s 0 max_len ^ "...(truncated)"
+  else String.sub s 0 (String_util.utf8_char_boundary s max_len) ^ "...(truncated)"
 
 (* Blob markers (see [Tool_output.encode_for_oas]) carry structural fields
    (sha256/bytes/mime) the dashboard needs to render the marker as a "Stored

--- a/test/test_observability_redact.ml
+++ b/test/test_observability_redact.ml
@@ -27,6 +27,72 @@ let test_max_length_enforced () =
   Alcotest.(check bool) "within limit" true
     (String.length preview <= 220)
 
+(* A byte-indexed cut splits a multibyte character and the result is not valid
+   UTF-8. That breaks the whole payload, not the field: the dashboard's
+   exact-lane panel rendered nothing because one Korean board comment crossed
+   the 1024-byte preview boundary and [response.json()] threw. *)
+let is_valid_utf8 (s : string) : bool =
+  let len = String.length s in
+  let rec go i =
+    if i >= len then true
+    else
+      let c = Char.code s.[i] in
+      let width =
+        if c < 0x80 then 1
+        else if c land 0xE0 = 0xC0 then 2
+        else if c land 0xF0 = 0xE0 then 3
+        else if c land 0xF8 = 0xF0 then 4
+        else 0
+      in
+      if width = 0 || i + width > len then false
+      else
+        let rec conts k =
+          k = width || (Char.code s.[i + k] land 0xC0 = 0x80 && conts (k + 1))
+        in
+        conts 1 && go (i + width)
+  in
+  go 0
+
+let truncation_suffix = "...(truncated)"
+
+let test_truncate_keeps_utf8_valid () =
+  (* "\xea\xb0\x80" is 3 bytes, so sweeping max_len exercises every cut
+     position modulo the character width. *)
+  let korean = String.concat "" (List.init 200 (fun _ -> "\xea\xb0\x80")) in
+  for max_len = 1 to 40 do
+    let out = Observability_redact.redact_preview ~max_len korean in
+    Alcotest.(check bool)
+      (Printf.sprintf "valid utf8 at max_len=%d" max_len)
+      true (is_valid_utf8 out);
+    let body =
+      let n = String.length out - String.length truncation_suffix in
+      if n >= 0 && String.sub out n (String.length truncation_suffix) = truncation_suffix
+      then String.sub out 0 n
+      else out
+    in
+    Alcotest.(check bool)
+      (Printf.sprintf "body within budget at max_len=%d" max_len)
+      true
+      (String.length body <= max_len)
+  done
+
+let test_truncate_ascii_cuts_exactly_at_budget () =
+  let ascii = String.make 100 'x' in
+  let out = Observability_redact.redact_preview ~max_len:40 ascii in
+  Alcotest.(check string) "ascii cut is unaffected by the boundary walk"
+    (String.make 40 'x' ^ truncation_suffix)
+    out
+
+let test_preview_json_strings_keeps_utf8_valid () =
+  (* The path the exact-lane registry takes for every run it records. *)
+  let korean = String.concat "" (List.init 600 (fun _ -> "\xec\x88\x98\xec\x9a\xa9")) in
+  let json = `Assoc [ ("content", `String korean) ] in
+  let out =
+    Observability_redact.preview_json_strings ~max_len:1024 json
+    |> Yojson.Safe.to_string
+  in
+  Alcotest.(check bool) "serialized preview is valid utf8" true (is_valid_utf8 out)
+
 let test_short_input_unchanged () =
   let input = "hello world" in
   let preview = Observability_redact.redact_preview input in
@@ -231,6 +297,12 @@ let () =
           Alcotest.test_case "API key redacted" `Quick test_api_key_redacted;
           Alcotest.test_case "URL credential redacted" `Quick test_url_credential_redacted;
           Alcotest.test_case "max length enforced" `Quick test_max_length_enforced;
+          Alcotest.test_case "truncate keeps utf8 valid" `Quick
+            test_truncate_keeps_utf8_valid;
+          Alcotest.test_case "truncate cuts ascii exactly at budget" `Quick
+            test_truncate_ascii_cuts_exactly_at_budget;
+          Alcotest.test_case "preview_json_strings keeps utf8 valid" `Quick
+            test_preview_json_strings_keeps_utf8_valid;
           Alcotest.test_case "short input unchanged" `Quick test_short_input_unchanged;
           Alcotest.test_case "redact_text does not truncate" `Quick
             test_redact_text_does_not_truncate;


### PR DESCRIPTION
## 증상

대시보드 **Monitor → Internal Agents** 패널이 아무것도 안 보여줍니다. librarian lane 은 그 시점에 60건이 기록돼 있었고 1건이 실행 중이었습니다.

## 측정

```
$ curl -s http://localhost:8935/api/v1/dashboard/exact-lane-runs -o lanes.json
HTTP 200, count=68
   {"lane":"librarian_exact","actor":"rondo","status":"running", ...}

$ python3 -c 'open("lanes.json","rb").read().decode("utf-8")'
UnicodeDecodeError: invalid continuation byte at byte 6089

'(truncated)' 52개  →  그중 문자 중간에서 끝난 것 6개
잘린 본문 바이트 길이: 1024, 1032, 1035, 1038, 1040 ...
```

백엔드는 정상입니다. 데이터도 있습니다. 브라우저 `response.json()` 이 byte 6089 에서 던지므로 **패널 전체가 렌더에 실패**합니다 — 댓글 하나가 잘린 게 아니라 목록이 통째로 안 뜹니다.

## 원인

```ocaml
String.sub s 0 max_len ^ "...(truncated)"
```

`String.sub` 은 바이트 연산입니다. `max_len` 번째 바이트가 3바이트 한글 음절 중간이면 선행 바이트만 남습니다. 잘린 문자열이 1024 가 아니라 1032/1035/1038 바이트인 것도 같은 이유입니다 — 절단기가 문자 경계를 모릅니다.

경로:

```
Exact_lane_run_registry.register_running
  |> Observability_redact.redact_json_value
  |> Observability_redact.preview_json_strings ~max_len:1024
       → redact_preview → truncate → String.sub
```

방아쇠는 평범합니다. 1024 바이트 경계를 넘는 한국어 board 댓글 하나면 됩니다.

## 수정

`String_util` 이 이미 소유하고 있습니다. `utf8_char_boundary` 는 주어진 바이트 위치 이하에서 문자가 끝나는 가장 큰 인덱스를 돌려주고, 이 모듈의 UTF-8 헬퍼는 이미 8곳이 씁니다.

```diff
-  else String.sub s 0 max_len ^ "...(truncated)"
+  else String.sub s 0 (String_util.utf8_char_boundary s max_len) ^ "...(truncated)"
```

절단 인덱스만 움직입니다. 바이트 예산과 suffix 동작은 그대로고, ASCII 는 여전히 정확히 `max_len` 에서 잘립니다.

## 아이러니

`preview_json_strings` 의 `.mli` 가 이 실패 양상을 이미 이름 붙여뒀습니다.

> Use this instead of `Yojson.Safe.to_string |> String.sub` … **blind byte truncation chops through sha256 and strands the marker.**

blob 마커가 잘리는 걸 막으려고 만든 우회로인데, 자기가 보호하려던 문자열 leaf 에 같은 blind byte truncation 을 적용했습니다.

## 테스트가 있었는데 안 돌고 있었습니다

`test_observability_redact.ml` 은 처음부터 `test_max_length_enforced` 를 갖고 있었고 매 빌드마다 컴파일됐지만, **`ci.yml` 에 이름이 없어 한 번도 실행되지 않았습니다.** 모든 observability payload 가 지나는 경로의 결함이 살아남을 수 있었던 이유입니다.

이 PR 이 배선합니다.

```yaml
- name: Run observability redaction suite
  run: scripts/ci-run-tests.sh "... @test/runtest-test_observability_redact"
```

## 검증

게이트는 PASS 가 아니라 **수정을 되돌렸을 때 실패하는지**로 확인했습니다.

| | |
|---|---|
| 수정 되돌린 트리 | **EXIT=1**, `ASSERT valid utf8 at max_len=1` — 새 케이스 2개만 실패, 나머지 18개 통과 |
| 수정 적용 | **EXIT=0**, `Test Successful … 20 tests run` |
| `dune build @check` | EXIT=0 |
| `check-ocaml-compile-authority.sh` | EXIT=0 |

ASCII 케이스를 따로 둔 이유는 경계 보정이 ASCII 를 짧게 만들지 않는다는 걸 고정하기 위해서입니다. 한글 케이스는 `max_len` 을 1..40 으로 훑어 문자 폭 3 에 대한 모든 나머지 위치를 지납니다.

## 남은 것 (이 PR 범위 밖)

`hitl_auto_judge` 와 `compaction` lane 은 레코드가 **0건**입니다. 생산자는 각각 `hitl_summary_worker.ml:1211`, `keeper_compaction_llm_summarizer.ml:900` 에 있는데 등록된 흔적이 없습니다. 파싱 실패와 무관한 별개 문제라 따로 봐야 합니다.

RFC-WAIVED: `String.sub` 의 절단 인덱스를 기존 SSOT 헬퍼로 교체하는 단일 변경입니다. credential / identity / operator control / sandbox / hooks 를 건드리지 않습니다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
