### PR TITLE
fix(tools): masc_runtime_ollama_probe is operator diagnostics, not Keeper work

### DIFF
--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1530,7 +1530,11 @@ let masc_local_runtime_descriptor
   let schema = definition.schema in
   cluster_descriptor_with_schema_source
     ~capability_identity:Internal_name_identity
-    ~keeper_model_projection:Internal_name
+    ~keeper_model_projection:
+      (Tool_schemas_local_runtime.keeper_model_exposure definition.operation
+       |> function
+       | Tool_schemas_local_runtime.Keeper_callable -> Internal_name
+       | Tool_schemas_local_runtime.Operator_diagnostic -> Operator_only)
     ~input_schema_source:Canonical_registry
     ~input_schema:schema.input_schema
     ~id:

--- a/lib/tool_schemas/tool_schemas_local_runtime.ml
+++ b/lib/tool_schemas/tool_schemas_local_runtime.ml
@@ -33,7 +33,7 @@ let keeper_model_exposure = function
        load/prompt-eval timings and a prefix-reuse inference. That is operator
        diagnostics, and the operator reads it through the dashboard route. It
        cost every Keeper turn 1,219 bytes of tool schema and was called 0 times
-       in the 6 days to 2026-08-06 (~/.masc/tool_usage/2026-08/). *)
+       in the 6 days to 2026-08-06 (the workspace tool_usage store). *)
     Operator_diagnostic
 ;;
 

--- a/lib/tool_schemas/tool_schemas_local_runtime.ml
+++ b/lib/tool_schemas/tool_schemas_local_runtime.ml
@@ -16,6 +16,27 @@ let operation_id = function
   | Ollama_probe -> "ollama_probe"
 ;;
 
+(* Who the tool is for. Both operations stay registered in the catalog — the
+   dashboard route /api/v1/dashboard/runtime-probe authorizes through
+   [with_tool_auth ~tool_name:"masc_runtime_ollama_probe"], and
+   [authorize_tool_for_role] refuses any name it cannot find there. The
+   question this answers is narrower: does the autonomous Keeper model see the
+   schema in its tool list every turn. *)
+type keeper_model_exposure =
+  | Keeper_callable
+  | Operator_diagnostic
+
+let keeper_model_exposure = function
+  | Verify -> Keeper_callable
+  | Ollama_probe ->
+    (* Native Ollama timing probe: repeated /api/generate calls whose output is
+       load/prompt-eval timings and a prefix-reuse inference. That is operator
+       diagnostics, and the operator reads it through the dashboard route. It
+       cost every Keeper turn 1,219 bytes of tool schema and was called 0 times
+       in the 6 days to 2026-08-06 (~/.masc/tool_usage/2026-08/). *)
+    Operator_diagnostic
+;;
+
 let definitions : definition list =
   [
     { operation = Verify; schema = {

--- a/lib/tool_schemas/tool_schemas_local_runtime.mli
+++ b/lib/tool_schemas/tool_schemas_local_runtime.mli
@@ -7,6 +7,16 @@ type definition =
   ; schema : Masc_domain.tool_schema
   }
 
+(** Whether the autonomous Keeper model carries this operation's schema in its
+    per-turn tool list. Both operations stay registered in the catalog either
+    way: [Operator_diagnostic] withholds only the model projection, and the
+    dashboard route still authorizes by tool name through
+    [Auth.authorize_tool_for_role], which refuses any unregistered name. *)
+type keeper_model_exposure =
+  | Keeper_callable
+  | Operator_diagnostic
+
 val operation_id : operation -> string
+val keeper_model_exposure : operation -> keeper_model_exposure
 val definitions : definition list
 val schemas : Masc_domain.tool_schema list

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -270,9 +270,7 @@ let test_registered_cluster_model_projections_are_explicit () =
   let keeper_model_names = Policy.keeper_model_tool_names () in
   List.iter
     (fun name -> check_projection name Descriptor.Internal_name)
-    [ "masc_runtime_verify"
-    ; "masc_runtime_ollama_probe"
-    ];
+    [ "masc_runtime_verify" ];
   List.iter
     (fun name -> check_projection name Descriptor.Internal_name)
     [ "keeper_library_read"
@@ -297,6 +295,14 @@ let test_registered_cluster_model_projections_are_explicit () =
       "masc_status"
     ; "masc_pause"
     ; "masc_resume"
+      (* Native Ollama timing probe. Its output is load/prompt-eval timings and
+         a prefix-reuse inference — operator diagnostics, read through
+         /api/v1/dashboard/runtime-probe. It carried 1,219 bytes of schema into
+         every Keeper turn and was called 0 times in the 6 days to 2026-08-06.
+         Registration is unchanged: that dashboard route authorizes with
+         [with_tool_auth ~tool_name:"masc_runtime_ollama_probe"], and
+         [Auth.authorize_tool_for_role] refuses any unregistered name. *)
+    ; "masc_runtime_ollama_probe"
     ];
   List.iter
     (fun (name, projected_by) ->


### PR DESCRIPTION
## What

`masc_runtime_ollama_probe` is operator diagnostics. Take it off the autonomous
Keeper model surface; leave everything else exactly as it is.

## Why

It probes native Ollama timing with repeated `/api/generate` calls and returns
load / prompt-eval timings plus a prefix-reuse inference. The operator reads
that through `/api/v1/dashboard/runtime-probe`, which 8 dashboard components
consume. No Keeper has a use for it.

It was on the Keeper model surface anyway, costing **1,219 bytes of tool schema
in every Keeper turn**. Calls in the 6 days to 2026-08-06
(`~/.masc/tool_usage/2026-08/`, 47,516 calls across 49 tools): **zero**.

For scale: tool schemas are 56,001 B/turn = 9.6% of a Keeper's input, against
9,847 B/turn (1.7%) for the entire system prompt.

## What does NOT change

Registration. The dashboard route authorizes with

```ocaml
with_tool_auth ~tool_name:"masc_runtime_ollama_probe"
```

and `Auth.authorize_tool_for_role` (`lib/auth/auth.ml:269`) answers any name it
cannot find in the catalog with `"use unregistered tool: …"`. Dropping the
catalog entry would 403 every dashboard poll, so this PR does not touch it.
`Tool_local_runtime_probe` (666 lines), its schema, its dispatch arm, and its
tests all stay.

## How

`keeper_model_projection: Operator_only` — the existing typed answer, already
used by `masc_status`, `masc_pause`, `masc_resume` for the same reason, and
already excluded by `model_visible_descriptors`.

The choice is typed on the operation
(`Tool_schemas_local_runtime.keeper_model_exposure`) rather than filtered at
the descriptor site, so the sibling states its own answer and a third operation
cannot be added without answering.

## Measured

| | before | after |
|---|---:|---:|
| model-visible descriptors | 98 | **97** |
| schema + description bytes per turn | 59,292 | **57,912** |

Verified directly: `masc_runtime_ollama_probe` absent from
`model_visible_descriptors ()`, `Tool_catalog.registered_metadata` still
resolves it, `masc_runtime_verify` still on the model surface.

## Not in scope

`masc_runtime_verify` is the sibling operation in the same module — also
operator-facing by description ("verify the active provider/runtime contract
used for swarm and benchmark runs"), also 0 calls in 6 days, 516 B. It is left
Keeper-callable because it was not part of this request. Flipping it is a
one-word change now that the choice is typed.

## Verification

```
dune build --force @test/runtest-test_keeper_tool_descriptor_registry_integrity \
  @test/runtest-test_keeper_gate_effect_coverage \
  @test/runtest-test_tool_local_runtime_probe \
  @test/runtest-test_capability_registry \
  @test/runtest-test_tool_shard_coverage \
  @test/runtest-test_tool_help_metadata_rfc_0195
→ 13 + 6 + 8 + 19 + 6 + 43 tests, all pass
```

`test_keeper_tool_descriptor_registry_integrity` pins the projection per tool;
this PR moves the entry from the `Internal_name` list to the `Operator_only`
list, which also asserts absence from the autonomous Keeper model bundle.

RFC-WAIVED: one descriptor's model projection plus its pinning test. No
credential, identity, operator-control, sandbox, hooks, or workflow surface; no
schema shape, no dispatch change, no catalog change, no behaviour change for
any existing caller.
