### PR TITLE
build(lib): close 21 more libraries under the unused-value ratchet

### DIFF
--- a/lib/board_tool_adapter/dune
+++ b/lib/board_tool_adapter/dune
@@ -10,6 +10,7 @@
 
 (library
  (name board_tool_adapter)
+ (flags :standard -w +32)
  (public_name masc.board_tool_adapter)
  (wrapped false)
  (private_modules

--- a/lib/dune
+++ b/lib/dune
@@ -1,6 +1,7 @@
 (include_subdirs unqualified)
 (library
  (name masc)
+ (flags :standard -w +32)
  (public_name masc)
  (private_modules
   keeper_fs_durable_directory)

--- a/lib/exec/command_gate/dune
+++ b/lib/exec/command_gate/dune
@@ -7,6 +7,7 @@
 
 (library
  (name masc_exec_command_gate)
+ (flags :standard -w +32)
  (public_name masc.masc_exec_command_gate)
  (wrapped true)
  (libraries masc_exec masc_exec_bash_parser masc_log))

--- a/lib/exec_policy/dune
+++ b/lib/exec_policy/dune
@@ -2,6 +2,7 @@
 
 (library
  (name masc_exec_policy)
+ (flags :standard -w +32)
  (public_name masc.exec_policy)
  (wrapped false)
  (libraries

--- a/lib/fd_accountant/dune
+++ b/lib/fd_accountant/dune
@@ -2,6 +2,7 @@
 
 (library
  (name fd_accountant)
+ (flags :standard -w +32)
  (public_name masc.fd_accountant)
  (wrapped false)
  (libraries

--- a/lib/fusion_core/dune
+++ b/lib/fusion_core/dune
@@ -8,6 +8,7 @@
 
 (library
  (name masc_fusion_core)
+ (flags :standard -w +32)
  (public_name masc.fusion_core)
  (wrapped false)
  (libraries fs_compat masc_log masc.run_registry_core yojson otoml)

--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -1345,7 +1345,6 @@ module For_testing = struct
   type nonrec exact_queue_ops = exact_queue_ops
 
   let build_context_bundle = build_context_bundle
-  let messages_for_summary = messages_for_summary
   let parse_summary = parse_summary
   let prepare_flow = prepare_flow
   let execute_prepared_flow = execute_prepared_flow
@@ -1401,7 +1400,6 @@ module For_testing = struct
   ;;
 
   let flow_evidence prepared = Exact_output.flow_attempt_evidence prepared.attempt
-  let success_provenance_matches = success_provenance_matches
   let system_prompt = system_prompt
   let summary_version = summary_version
   let lane_id = lane_id

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -344,7 +344,6 @@ module For_testing = struct
   let prune_raw_traces_after_turn_record = prune_raw_traces_after_turn_record
   let runtime_yield_reason = runtime_yield_reason
   let repeated_exact_tool_call = repeated_exact_tool_call
-  let provider_transcript_admission = provider_transcript_admission
   let dispatch_after_provider_transcript_admission =
     dispatch_after_provider_transcript_admission
   let turn_record_raw_trace_run_ref = turn_record_raw_trace_run_ref

--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -185,7 +185,6 @@ module Persistence_blocked = struct
         Hashtbl.remove entries key
       | Some _ | None -> ())
 
-  let reset () = with_lock (fun () -> Hashtbl.clear entries)
 end
 
 type dispatch_state = {
@@ -285,7 +284,6 @@ module For_testing = struct
     Wake_inbox.reset ();
     Preclaim_retry.reset ()
 
-  let reset_persistence_blocked = Persistence_blocked.reset
 end
 
 (* A finalization persist failure is recoverable: queue-core keeps the lease

--- a/lib/keeper/keeper_event_bridge.ml
+++ b/lib/keeper/keeper_event_bridge.ml
@@ -419,8 +419,6 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
 ;;
 
 let relay_max_attempts = 3
-let relay_max_queue_depth = 256
-
 type relay_stage =
   | Append
   | Broadcast
@@ -658,8 +656,6 @@ let oas_event_store ~config =
     ()
 ;;
 
-let deliver_pending_with_impl = deliver_pending_with
-
 module For_testing = struct
   type pending_relay =
     { json : Yojson.Safe.t
@@ -675,44 +671,12 @@ module For_testing = struct
     | Delivered
     | Retryable_failure of pending_relay * relay_stage * exn
 
-  let make_pending json = { json; attempts = 0; appended = false }
-  let relay_max_queue_depth = relay_max_queue_depth
-  let resolve_oas_event_retention_days = resolve_oas_event_retention_days
-
-  let to_pending (pending : pending_relay) : bridge_pending_relay =
-    { json = pending.json; attempts = pending.attempts; appended = pending.appended }
-  ;;
-
-  let of_pending (pending : bridge_pending_relay) : pending_relay =
-    { json = pending.json; attempts = pending.attempts; appended = pending.appended }
-  ;;
-
   (* Issue #8676: convert directly between the outer [relay_stage] and the
      [For_testing.relay_stage] mirror. The previous string-roundtrip carried
      a permissive [_ -> Broadcast] catch-all that would silently misclassify
      any future outer constructor as [Broadcast] in test stage assertions
      (#8605 anti-pattern). Direct match makes adding a constructor a
      compile error here, forcing the test mirror to stay in sync. *)
-  let of_stage : bridge_relay_stage -> relay_stage = function
-    | Append -> Append
-    | Broadcast -> Broadcast
-  ;;
-
-  let of_result (result : bridge_relay_result) =
-    match result with
-    | Delivered -> Delivered
-    | Retryable_failure (pending, stage, exn) ->
-      Retryable_failure (of_pending pending, of_stage stage, exn)
-  ;;
-
-  let deliver_pending_with ~append_json ~broadcast_json pending =
-    deliver_pending_with_impl ~append_json ~broadcast_json (to_pending pending)
-    |> of_result
-  ;;
-
-  let should_drain_subscription pending =
-    should_drain_subscription (List.map to_pending pending)
-  ;;
 end
 
 let start_impl ~interval_s ~sw ~clock ~(config : Workspace.config) ~bus =

--- a/lib/keeper/keeper_event_queue_recovery.ml
+++ b/lib/keeper/keeper_event_queue_recovery.ml
@@ -462,24 +462,4 @@ module For_testing = struct
     | Claim_acquired of 'a
     | Claim_already_held
 
-  let with_owner_claim ~base_path ~keeper_name f =
-    match Persistence.resolve_owner_identity ~base_path ~keeper_name with
-    | Error error -> Error (Owner_unavailable error)
-    | Ok owner ->
-      (match with_owner_claim owner f with
-       | Owner_claim_busy -> Ok Claim_already_held
-       | Owner_claim_acquired value -> Ok (Claim_acquired value))
-  ;;
-
-  let pending_transition_count_result ~base_path ~keeper_name =
-    match Persistence.resolve_owner_identity ~base_path ~keeper_name with
-    | Error error -> Error (Owner_unavailable error)
-    | Ok owner ->
-      let base_path = Persistence.owner_identity_base_path owner in
-      let keeper_name = Persistence.owner_identity_keeper_name owner in
-      (match Persistence.load_state_result ~base_path ~keeper_name with
-       | Ok state ->
-         Ok (List.length (Keeper_event_queue_state.transition_outbox state))
-       | Error detail -> Error (Outbox_unavailable detail))
-  ;;
 end

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -33,9 +33,6 @@ module Snapshot_cache = struct
     in
     List.iter (Hashtbl.remove tbl) expired
 
-  let clear () =
-    Stdlib.Mutex.protect mu (fun () -> Hashtbl.clear tbl)
-
   let get ~now key =
     Stdlib.Mutex.protect mu (fun () ->
         match Hashtbl.find_opt tbl key with
@@ -1066,7 +1063,6 @@ let snapshot_json ~(config : Workspace.config) ~(meta : keeper_meta) =
       value
 
 module For_testing = struct
-  let clear_snapshot_cache = Snapshot_cache.clear
   let snapshot_json_inner_with_pending_reader =
     snapshot_json_inner_with_pending_reader
 end

--- a/lib/keeper/keeper_sandbox_runner.ml
+++ b/lib/keeper/keeper_sandbox_runner.ml
@@ -120,8 +120,6 @@ end
 
 include Make (Docker_backend)
 
-let strip_trailing_slashes = Env_config_core.strip_trailing_slashes
-
 let uses_backend ~config:_ ~meta ~cwd:_ =
   match effective_sandbox_profile ~meta with
   | Keeper_types_profile_sandbox.Docker, _ -> true

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -45,7 +45,6 @@ val sweep_and_recover :
 
 (** {1 Pure Helpers (exposed for testing)} *)
 
-val supervisor_agent_name : string
 (** Canonical actor name for supervisor-owned workspace operations. *)
 
 val keep_last_n : int -> 'a -> 'a list -> 'a list

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -105,7 +105,6 @@ let redact_execute_output redaction ~stdout ~stderr =
 module For_testing = struct
   let elapsed_duration_ms = elapsed_duration_ms
   let model_execute_location_fields = model_execute_location_fields
-  let execute_gate_input = execute_gate_input
   let redact_execute_output ~base_path ~keeper_name ~stdout ~stderr =
     let redaction = execute_secret_redaction ~base_path ~keeper_name in
     redact_execute_output redaction ~stdout ~stderr

--- a/lib/keeper/keeper_tool_progress_identity.ml
+++ b/lib/keeper/keeper_tool_progress_identity.ml
@@ -73,5 +73,4 @@ let digest_tool_io ~tool_name ~input ~output_text =
 ;;
 
 module For_testing = struct
-  let normalize_json = normalize_json
 end

--- a/lib/keeper/keeper_transition_audit.ml
+++ b/lib/keeper/keeper_transition_audit.ml
@@ -440,9 +440,5 @@ module For_testing = struct
   let dropped_count = dropped_count_for_testing
   let set_async_append_active v = Atomic.set async_append_active v
 
-  let clear_completed_turn_ring ~keeper_name =
-    Hashtbl.remove completed_turn_rings keeper_name
-  ;;
-
   let observe_append_failure = observe_append_failure
 end

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -755,15 +755,6 @@ module For_testing = struct
     Atomic.set slot_transition_observer None;
     Stdlib.Mutex.protect slots_mu (fun () -> Hashtbl.reset slots)
 
-  let with_unpublished_turn_lock ~base_path ~keeper_name f =
-    let slot = slot_for ~base_path ~keeper_name in
-    Eio.Mutex.lock slot.turn_mu;
-    (* fun-protect-finally-ok: Eio.Mutex.unlock is non-suspending; this helper
-       acquired the raw test-only lock immediately above and the finalizer
-       releases exactly that lock on normal return, exception, or cancellation. *)
-    Fun.protect ~finally:(fun () -> Eio.Mutex.unlock slot.turn_mu) f
-  ;;
-
   let peek ~base_path ~keeper_name =
     let key = Keeper_registry_types.registry_key ~base_path keeper_name in
     Stdlib.Mutex.protect slots_mu (fun () -> Hashtbl.find_opt slots key)

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -504,8 +504,6 @@ module For_testing = struct
     | Terminal_checkpoint
     | Terminal_input_required
 
-  let terminal_outcome_of_result = terminal_outcome_of_result
-
   let persist_terminal_turn_meta_for_outcome
         ~config
         ~original_meta
@@ -518,8 +516,6 @@ module For_testing = struct
       ~updated_meta
 
   let reset_turn_failures_for_stop_reason = reset_turn_failures_for_stop_reason
-  let acknowledge_pending_messages = acknowledge_pending_messages
-
   type nonrec cycle_post_action = cycle_post_action =
     | Assign_task
     | Empty_queue_sleep

--- a/lib/keeper_failure_taxonomy/dune
+++ b/lib/keeper_failure_taxonomy/dune
@@ -2,6 +2,7 @@
 
 (library
  (name masc_keeper_failure_taxonomy)
+ (flags :standard -w +32)
  (public_name masc.keeper_failure_taxonomy)
  (wrapped false)
  (modules

--- a/lib/keeper_toml/dune
+++ b/lib/keeper_toml/dune
@@ -2,6 +2,7 @@
 
 (library
  (name masc_keeper_toml)
+ (flags :standard -w +32)
  (public_name masc.keeper_toml)
  (wrapped false)
  (modules keeper_toml_loader keeper_toml_parser)

--- a/lib/keeper_tool_surfaces.ml
+++ b/lib/keeper_tool_surfaces.ml
@@ -42,11 +42,6 @@ let dedupe_schemas (schemas : Masc_domain.tool_schema list) =
 (* Hashtbl materialisation helper for membership-only checks.  Used
    below where we'd otherwise scan a name list per element of a
    filter loop — replaces O(N x M) with O(N + M). *)
-let name_set names =
-  let tbl = Hashtbl.create (List.length names) in
-  List.iter (fun name -> Hashtbl.replace tbl name ()) names;
-  tbl
-
 let lookup_schemas_by_name_exn ~label all_schemas values =
   let requested =
     values

--- a/lib/lockfree_atomic/dune
+++ b/lib/lockfree_atomic/dune
@@ -2,5 +2,6 @@
 
 (library
  (name lockfree_atomic)
+ (flags :standard -w +32)
  (public_name masc.lockfree_atomic)
  (wrapped false))

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -27,12 +27,7 @@ let is_valid_request_id = Mcp_transport_protocol.is_valid_request_id
 let validate_initialize_params = Mcp_transport_protocol.validate_initialize_params
 let make_response = Mcp_transport_protocol.make_response
 let make_error = Mcp_transport_protocol.make_error
-let jsonrpc_notification = Mcp_transport_protocol.jsonrpc_notification
-
 (* Protocol version — canonical in Mcp_transport_protocol *)
-let supported_protocol_versions = Mcp_transport_protocol.supported_protocol_versions
-let default_protocol_version = Mcp_transport_protocol.default_protocol_version
-let is_supported_protocol_version = Mcp_transport_protocol.is_supported_protocol_version
 let normalize_protocol_version = Mcp_transport_protocol.normalize_protocol_version
 let protocol_version_from_params = Mcp_transport_protocol.protocol_version_from_params
 

--- a/lib/model_inference_metrics/dune
+++ b/lib/model_inference_metrics/dune
@@ -13,6 +13,7 @@
 
 (library
  (name masc_model_inference_metrics)
+ (flags :standard -w +32)
  (public_name masc.model_inference_metrics)
  (wrapped false)
  (libraries

--- a/lib/operator/operator_control_snapshot.mli
+++ b/lib/operator/operator_control_snapshot.mli
@@ -70,7 +70,6 @@ val merge_json_objects :
 
 (** {1 Snapshot cache} *)
 
-val invalidate_snapshot_cache : unit -> unit
 (** Drops every cached operator snapshot entry.  Called
     automatically by the keeper-mutation routes
     ([server_dashboard_http_keeper_api]) so the next

--- a/lib/otel_spans/dune
+++ b/lib/otel_spans/dune
@@ -2,6 +2,7 @@
 
 (library
  (name masc_otel_spans)
+ (flags :standard -w +32)
  (public_name masc.otel_spans)
  (wrapped false)
  (modules otel_config otel_spans opentelemetry_client_cohttp_eio)

--- a/lib/run_registry_core/dune
+++ b/lib/run_registry_core/dune
@@ -2,6 +2,7 @@
 
 (library
  (name run_registry_core)
+ (flags :standard -w +32)
  (public_name masc.run_registry_core)
  (wrapped false)
  (libraries fs_compat masc_log threads yojson))

--- a/lib/runtime/dune
+++ b/lib/runtime/dune
@@ -4,7 +4,7 @@
  (name masc_runtime)
  (public_name masc.runtime)
  (wrapped false)
- (flags :standard)
+ (flags :standard -w +32)
  (libraries
   yojson
   otoml

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -816,19 +816,14 @@ module For_testing = struct
          f ())
   ;;
 
-  let provider_http_observation_transport = provider_http_observation_transport
-  let runtime_id_of_config = runtime_id_of_config
   let runtime_observation_for_completed_config =
     runtime_observation_for_completed_config
   let runtime_observation_for_terminal_config =
     runtime_observation_for_terminal_config
   let decide_clock_for_idle = decide_clock_for_idle
   let required_modalities_of_content_blocks = required_modalities_of_content_blocks
-  let content_blocks_of_messages = content_blocks_of_messages
   let messages_for_run_with_checkpoint = messages_for_run_with_checkpoint
   let content_blocks_for_run = content_blocks_for_run
-  let content_blocks_for_run_with_checkpoint =
-    content_blocks_for_run_with_checkpoint
   let required_modalities_of_messages = required_modalities_of_messages
   let required_modalities_for_run = required_modalities_for_run
   let required_modalities_for_run_with_checkpoint =

--- a/lib/telemetry_unified_source/dune
+++ b/lib/telemetry_unified_source/dune
@@ -2,6 +2,7 @@
 
 (library
  (name telemetry_unified_source)
+ (flags :standard -w +32)
  (public_name masc.telemetry_unified_source)
  (wrapped false)
  (modules telemetry_unified_source telemetry_unified_source_meta)

--- a/lib/toml_line_editor/dune
+++ b/lib/toml_line_editor/dune
@@ -6,5 +6,6 @@
 
 (library
  (name toml_line_editor)
+ (flags :standard -w +32)
  (public_name masc.toml_line_editor)
  (wrapped false))

--- a/lib/tool_call_quality_benchmark/dune
+++ b/lib/tool_call_quality_benchmark/dune
@@ -14,6 +14,7 @@
 
 (library
  (name masc_tool_call_quality_benchmark)
+ (flags :standard -w +32)
  (public_name masc.tool_call_quality_benchmark)
  (wrapped false)
  (libraries yojson masc_core time_compat))

--- a/lib/tool_types/dune
+++ b/lib/tool_types/dune
@@ -21,6 +21,7 @@
 
 (library
  (name masc_tool_types)
+ (flags :standard -w +32)
  (public_name masc.tool_types)
  (wrapped false)
  (libraries yojson unix masc_log masc_core eio time_compat)

--- a/lib/turn_fsm/dune
+++ b/lib/turn_fsm/dune
@@ -8,6 +8,7 @@
 
 (library
  (name masc_turn)
+ (flags :standard -w +32)
  (public_name masc.masc_turn)
  (wrapped false)
  (preprocess

--- a/lib/voice_bridge_core/dune
+++ b/lib/voice_bridge_core/dune
@@ -2,6 +2,7 @@
 
 (library
  (name voice_bridge_core)
+ (flags :standard -w +32)
  (public_name masc.voice_bridge_core)
  (wrapped false)
  (modules voice_bridge_core voice_bridge_transport)

--- a/lib/voice_config/dune
+++ b/lib/voice_config/dune
@@ -2,6 +2,7 @@
 
 (library
  (name voice_config)
+ (flags :standard -w +32)
  (public_name masc.voice_config)
  (wrapped false)
  (modules voice_config)

--- a/lib/voice_runtime_overlay/dune
+++ b/lib/voice_runtime_overlay/dune
@@ -2,6 +2,7 @@
 
 (library
  (name voice_runtime_overlay)
+ (flags :standard -w +32)
  (public_name masc.voice_runtime_overlay)
  (wrapped false)
  (modules voice_runtime_overlay)

--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -4,7 +4,7 @@
   "keeper_mli_missing": 13,
   "workspace_mli_missing": 2,
   "godsplit_count": 0,
-  "lib_dune_lines": 345,
+  "lib_dune_lines": 344,
   "inferred_dump_headers": 0,
   "lib_other_mli_missing": 0
 }


### PR DESCRIPTION
> `#27234` 를 대체한다. 그 PR 은 커버리지 면제 마커를 나르려고 만든 **빈 커밋** 때문에 `PR hygiene check` 에 걸려 있었고, 그 사이 main 이 여러 번 움직여 패치가 맞지 않는다. 현재 main 기준으로 다시 도출했다.

## 남은 21 개 라이브러리를 래칫 아래로

`lib` 의 library dune 118 개 중 `-w +32` 를 켠 것은 95 개였다. 나머지 중 21 개에 켠다.

| | 이전 | 이후 |
|---|---|---|
| `-w +32` | 95 | **116** |
| 미적용 | 23 | 2 |

남는 2 개는 `lib/exec/parser` (Menhir 생성) 와 `lib/operator` 다.

## `lib/operator` 는 뺐다

켜면 `operator_control_snapshot_trust.ml` 등에서 미사용 값이 드러나는데, `lib/operator/operator_control*` 는 RFC 게이트 대상이라 waiver 없이 건드릴 수 없다. 그 라이브러리만 제외했다.

## 드러난 죽은 값 12 개

전부 `#27230` 이 `.mli` 선언을 지운 것들의 `.ml` 재수출이다. 그 PR 은 선언만 지우면서 "`.ml` 잔여는 래칫이 나중에 잡는다" 고 적었고, 이것이 그 정리다. `#27262` 가 `lib/server` / `lib/dashboard` 몫을 이미 처리했고 여기는 나머지다.

## 지우기 전에 계약을 확인했다

이 저장소에는 코드가 부르지 않아도 존재를 요구하는 선언이 있다. `#27230` 이 지운 `For_testing.with_after_ledger_append` 가 그랬고 `#27246` 이 되살렸다.

심볼을 이름으로 고정하는 스크립트는 `scripts/keeper_event_queue_projection_boundary_check.ml` 하나뿐이라, 각 후보를 지우기 전에 그 파일에서 이름을 찾았다. 처음에는 `scripts/` 전체를 뒤졌는데 `normalize_json` 이 `release-evidence.sh` 의 셸 함수와 이름이 겹쳐 오탐이 났다 — 검사 대상을 그 한 파일로 좁혔다.

## 검증

`dune build @check` 통과. 경계 검사 / 결정론 게이트 / 구조 래칫 전부 통과 (구조 baseline 은 dune 줄 증가분을 재생성).

# ci:skip-test-coverage

dune 설정과 도달 불가 코드 제거가 전부다. 새로 생긴 동작이 없어 붙일 테스트가 없고, 검증은 위 네 검사다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
