### PR TITLE
fix(keeper): preserve failed tool results in the checkpoint purge

### DIFF
--- a/lib/keeper/keeper_checkpoint_purge.ml
+++ b/lib/keeper/keeper_checkpoint_purge.ml
@@ -81,14 +81,21 @@ let strip_reasoning_blocks (message : Agent_sdk.Types.message) =
   { message with Agent_sdk.Types.content = List.rev kept }, stripped
 ;;
 
-(* R3: replace a tool result's payload with the fixed marker while keeping the
-   [tool_use_id] pairing and the typed delivery outcome. *)
+(* R3: replace a SUCCESSFUL tool result's payload with the fixed marker while
+   keeping the [tool_use_id] pairing and the typed delivery outcome.
+   Failed results ([Tool_failed]) are exempt: their payload is the feedback
+   the keeper reads on later turns and the only lesson evidence the librarian
+   could learn from, and the exemption is a type-level distinction (the typed
+   outcome), not content classification — RFC-0351 §2 permits judging by
+   type. *)
 let clear_tool_result_blocks (message : Agent_sdk.Types.message) =
   let cleared_count = ref 0 in
   let content =
     List.map
       (fun block ->
          match block with
+         | Agent_sdk.Types.ToolResult { outcome = Agent_sdk.Types.Tool_failed _; _ }
+           -> block
          | Agent_sdk.Types.ToolResult
              ({ content; json; content_blocks; _ } as result) ->
            if String.equal content cleared_tool_result_content

--- a/lib/keeper/keeper_checkpoint_purge.mli
+++ b/lib/keeper/keeper_checkpoint_purge.mli
@@ -11,6 +11,12 @@
     - R3 tool-result clear: [ToolResult] blocks in closed tool cycles have
       their content replaced by {!cleared_tool_result_content}, preserving the
       [tool_use_id]/[ToolUse] pairing (the cycle stays a valid closed unit).
+      Failed results ([Tool_failed]) are exempt and pass through byte-exact:
+      their payload is the feedback the keeper reads on later turns and the
+      only error evidence the durable history carries. The exemption is a
+      type-level distinction (the typed outcome), not content classification,
+      so it stays inside RFC-0351 §2's "judge by type, integer, or byte
+      comparison only" rule.
 
     R2 and R3 run before R1: stripping reasoning can make previously distinct
     assistant messages byte-identical, and duplicate grouping sees only the

--- a/test/test_keeper_checkpoint_purge.ml
+++ b/test/test_keeper_checkpoint_purge.ml
@@ -29,6 +29,22 @@ let cycle id =
   ; { (block_message Types.Tool [ tool_result id ]) with tool_call_id = Some id }
   ]
 
+let tool_error_result ?(content = "raw tool error") id : Types.content_block =
+  Types.ToolResult
+    { tool_use_id = id
+    ; content
+    ; outcome =
+        Types.Tool_failed
+          { failure_kind = Types.Recoverable_tool_error; error_class = None }
+    ; json = Some (`Assoc [ "error", `String "boom" ])
+    ; content_blocks = None
+    }
+
+let error_cycle id =
+  [ block_message Types.Assistant [ tool_use id ]
+  ; { (block_message Types.Tool [ tool_error_result id ]) with tool_call_id = Some id }
+  ]
+
 let unsigned_thinking text : Types.content_block =
   Types.Thinking { content = text; signature = None }
 
@@ -143,6 +159,29 @@ let test_tool_result_clear_preserves_pairing () =
   match Masc.Keeper_compaction_unit.validate purged with
   | Ok () -> ()
   | Error _ -> Alcotest.fail "cleared cycle no longer validates"
+
+let test_error_tool_result_is_never_cleared () =
+  (* R3 clears successful payloads only: an error result is feedback and
+     lesson evidence, so its payload, json, and outcome all survive. *)
+  let messages = error_cycle "a" @ cycle "b" in
+  let purged, report = run messages in
+  Alcotest.(check int)
+    "only the successful result is cleared"
+    1
+    report.tool_results_cleared;
+  (match List.nth purged 1 with
+   | { Types.content = [ Types.ToolResult { content; json; outcome; _ } ]; _ } ->
+     Alcotest.(check string) "error payload survives" "raw tool error" content;
+     Alcotest.(check bool) "error json untouched" true (Option.is_some json);
+     (match outcome with
+      | Types.Tool_failed _ -> ()
+      | _ -> Alcotest.fail "error outcome must survive the purge")
+   | _ -> Alcotest.fail "error cycle lost its ToolResult block");
+  let twice, _ = run purged in
+  Alcotest.(check (list string))
+    "preserved errors make the second purge the identity too"
+    (message_texts purged)
+    (message_texts twice)
 
 let test_protected_tail_is_byte_exact () =
   let wake = text_message Types.User "(autonomous wake)" in
@@ -315,6 +354,10 @@ let () =
             "tool result clear preserves pairing"
             `Quick
             test_tool_result_clear_preserves_pairing
+        ; Alcotest.test_case
+            "error tool result is never cleared"
+            `Quick
+            test_error_tool_result_is_never_cleared
         ; Alcotest.test_case
             "strip-revealed duplicates collapse in one pass"
             `Quick


### PR DESCRIPTION
## Problem

R3 (`clear_tool_result_blocks`) cleared **every** `ToolResult` payload in closed tool cycles, including `Tool_failed` ones. The typed outcome flag survived, but the error text did not — so a purged checkpoint permanently loses the only durable evidence of *why* a tool failed:

- the feedback the keeper re-reads on later turns (self-correction loop)
- the raw material the librarian's `lesson` category ("a failure AND the correction drawn from it") is meant to distill

Confirmed live on the sangsu checkpoint (purged 2026-08-04): dozens of `is_error=true` payloads replaced by the fixed marker.

## Root cause (from git archaeology)

- The uniform R3 clear was deliberate (`947c98b68f`, RFC-0351) — RFC-0351 §2 bans importance scores / string classification / heuristic thresholds in the deterministic layer
- But the *error-text* consequence has **no recorded discussion anywhere** — an unexamined implication of the type-uniformity rule, not a reasoned decision

## Fix

Exempt `Tool_failed` results from R3; they pass through byte-exact. This is a **type-level distinction (the typed outcome), not content classification**, so it stays inside RFC-0351 §2's "judge by type, integer, or byte comparison only" rule. The `.mli` rule contract now states this explicitly so the next reader finds the rationale.

## Peer evidence

| harness | error feedback next turn | deterministic trim | durable transcript |
|---|---|---|---|
| OpenClaw | verbatim | no `isError` exemption | never destroyed |
| claude-code | verbatim + `is_error:true` | microcompact: no distinction | JSONL append-only |
| hermes-agent | verbatim + guardrails | no exemption (short errors survive) | summary must carry exact errors |
| orca-agent | `ERROR:` text | no distinction (short errors survive) | recent tail protected |

None of the four destroys the durable error record — the purge was the only component that did. (The librarian input-side omission is a separate issue, to be handled in a follow-up.)

## Verification

- TDD: new test `error tool result is never cleared` failed first for the expected reason (2 cleared vs 1), then green; 14/14 pass
- `dune build lib/keeper bin/masc_checkpoint_purge.exe` clean
- Live dry-run on the sangsu checkpoint (nothing written): **R3 cleared 3,488 = successful clearable 3,515 − errors 27** — all 27 error payloads now preserved, cross-checked by independent scan
- Idempotence preserved (error preservation keeps the second pass an identity — pinned in the new test)