### PR TITLE
feat(dashboard): 라이브러리안이 무엇을 결정했는지 보여준다 (실패 9건의 이유 포함)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -981,6 +981,14 @@ jobs:
           opam exec -- dune build --root . \
             @test/runtest-test_jsonl_day_key
 
+      - name: Run memory journal projection suite
+        # The librarian's failed passes reach the dashboard through this
+        # projection. A torn line presented as a commit would make a damaged
+        # journal read as a healthy shorter one, and that compiles either way.
+        run: |
+          opam exec -- dune build --root . \
+            @test/runtest-test_keeper_memory_journal_projection
+
       - name: Run operator note lifetime suite
         # RFC-0366. A note that renders twice is a standing rule the operator
         # never wrote — the #26729 shape. @check compiles "renders once then

--- a/dashboard/src/api/dashboard-memory-journal.test.ts
+++ b/dashboard/src/api/dashboard-memory-journal.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fetchKeeperMemoryJournal } from './dashboard-memory-journal'
+import { clearStoredToken, setStoredToken } from './core'
+
+// A Response body reads once and ensureDevToken consumes the first, so each
+// call needs a fresh instance rather than one shared mock value.
+function stubFetch(payload: unknown) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockImplementation(
+      async () =>
+        new Response(JSON.stringify(payload), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    ),
+  )
+  setStoredToken('journal-test-token', { source: 'manual' })
+}
+
+afterEach(() => {
+  clearStoredToken()
+  vi.unstubAllGlobals()
+})
+
+const committed = {
+  ok: true,
+  outcome: 'committed',
+  recorded_at: 1786000000,
+  revision: 223,
+  source: { kind: 'librarian', trace_id: 'trace-a', generation: 1 },
+  change: { added: [{ claim: 'x' }], removed: [], retained: 3 },
+  dropped: [{ memory_id: 'id:gone', reason: 'superseded by the openssl decision' }],
+}
+
+const failed = {
+  ok: true,
+  outcome: 'failed',
+  recorded_at: 1786000100,
+  trace_id: 'trace-b',
+  kind: 'runtime_context_unavailable',
+  detail: 'Eio net/clock context unavailable',
+  snapshot_present: false,
+  cadence_deferred: false,
+}
+
+function payload(entries: unknown[], undecodable = 0) {
+  return { keeper: 'kidsnote', returned: entries.length, undecodable_lines: undecodable, entries }
+}
+
+describe('memory journal', () => {
+  it('keeps a commit and a failure as different members', async () => {
+    stubFetch(payload([committed, failed]))
+    const journal = await fetchKeeperMemoryJournal('kidsnote')
+    const [first, second] = journal.entries
+    expect(first?.ok).toBe(true)
+    expect(first && first.ok && first.outcome).toBe('committed')
+    expect(second && second.ok && second.outcome).toBe('failed')
+    // A failure has no revision to read, which is the point of the split.
+    if (first?.ok && first.outcome === 'committed') expect(first.revision).toBe(223)
+    if (second?.ok && second.outcome === 'failed') {
+      expect(second.detail).toBe('Eio net/clock context unavailable')
+      expect(second.kind).toBe('runtime_context_unavailable')
+    }
+  })
+
+  // Drop reasons ride this line and nothing else stores them.
+  it('carries the librarian drop reasons', async () => {
+    stubFetch(payload([committed]))
+    const journal = await fetchKeeperMemoryJournal('kidsnote')
+    const entry = journal.entries[0]
+    if (!entry?.ok || entry.outcome !== 'committed') throw new Error('expected a commit')
+    expect(entry.drops).toHaveLength(1)
+    expect(entry.drops[0]?.reason).toBe('superseded by the openssl decision')
+  })
+
+  it('keeps a torn line in place with its reason', async () => {
+    stubFetch(payload([committed, { ok: false, error: 'not valid JSON' }], 1))
+    const journal = await fetchKeeperMemoryJournal('kidsnote')
+    expect(journal.undecodableLines).toBe(1)
+    expect(journal.entries[1]).toEqual({ ok: false, error: 'not valid JSON' })
+  })
+
+  // An outcome from a wider build must not be rendered as something else —
+  // that would describe a pass that never happened.
+  it('rejects the payload when an outcome is unknown', async () => {
+    stubFetch(payload([{ ...committed, outcome: 'deferred' }]))
+    await expect(fetchKeeperMemoryJournal('kidsnote')).rejects.toThrow('memory journal')
+  })
+
+  it('rejects a commit whose change block is missing', async () => {
+    const { change: _change, ...withoutChange } = committed
+    stubFetch(payload([withoutChange]))
+    await expect(fetchKeeperMemoryJournal('kidsnote')).rejects.toThrow('memory journal')
+  })
+})

--- a/dashboard/src/api/dashboard-memory-journal.ts
+++ b/dashboard/src/api/dashboard-memory-journal.ts
@@ -1,0 +1,160 @@
+// MASC Dashboard — the librarian's own account of each pass.
+//
+// Route: GET /api/v1/keepers/:name/memory-journal
+//
+// The internal-agents monitor could already show that a librarian pass ran.
+// This is what the pass decided: what it kept, what it dropped and why, or —
+// for the case an operator actually opens — why it produced nothing.
+
+import { get, type AbortableRequestOptions } from './core'
+import { ensureDevToken } from './dev-token'
+import { isRecord, asNumber, asString } from '../components/common/normalize'
+
+export type MemoryJournalDrop = {
+  readonly memoryId: string
+  readonly reason: string
+}
+
+// A committed pass wrote a revision. A failed pass did not, so the two are
+// separate members rather than one shape with nulls — a reader that has to
+// check a null to tell them apart will eventually forget to.
+export type MemoryJournalEntry =
+  | {
+      readonly ok: true
+      readonly outcome: 'committed'
+      readonly recordedAt: number
+      readonly revision: number
+      readonly traceId: string
+      readonly added: number
+      readonly removed: number
+      readonly retained: number
+      readonly drops: readonly MemoryJournalDrop[]
+    }
+  | {
+      readonly ok: true
+      readonly outcome: 'failed'
+      readonly recordedAt: number
+      readonly traceId: string
+      readonly kind: string
+      readonly detail: string
+      readonly snapshotPresent: boolean
+      readonly cadenceDeferred: boolean
+    }
+  | { readonly ok: false; readonly error: string }
+
+export type MemoryJournal = {
+  readonly keeper: string
+  readonly returned: number
+  readonly undecodableLines: number
+  readonly entries: readonly MemoryJournalEntry[]
+}
+
+function decodeDrop(raw: unknown): MemoryJournalDrop | null {
+  if (!isRecord(raw)) return null
+  const memoryId = asString(raw.memory_id)
+  const reason = asString(raw.reason)
+  return memoryId == null || reason == null ? null : { memoryId, reason }
+}
+
+function decodeCommitted(raw: Record<string, unknown>): MemoryJournalEntry | null {
+  const recordedAt = asNumber(raw.recorded_at)
+  const revision = asNumber(raw.revision)
+  if (recordedAt == null || revision == null) return null
+  if (!isRecord(raw.source) || !isRecord(raw.change)) return null
+  const traceId = asString(raw.source.trace_id)
+  const retained = asNumber(raw.change.retained)
+  if (traceId == null || retained == null) return null
+  if (!Array.isArray(raw.change.added) || !Array.isArray(raw.change.removed)) return null
+  const drops: MemoryJournalDrop[] = []
+  if (raw.dropped !== undefined) {
+    if (!Array.isArray(raw.dropped)) return null
+    for (const item of raw.dropped) {
+      const drop = decodeDrop(item)
+      // The librarian's drop reasons ride this line and nothing else stores
+      // them. Skipping one loses it for good.
+      if (drop === null) return null
+      drops.push(drop)
+    }
+  }
+  return {
+    ok: true,
+    outcome: 'committed',
+    recordedAt,
+    revision,
+    traceId,
+    added: raw.change.added.length,
+    removed: raw.change.removed.length,
+    retained,
+    drops,
+  }
+}
+
+function decodeFailed(raw: Record<string, unknown>): MemoryJournalEntry | null {
+  const recordedAt = asNumber(raw.recorded_at)
+  const traceId = asString(raw.trace_id)
+  const kind = asString(raw.kind)
+  const detail = asString(raw.detail)
+  const snapshotPresent = typeof raw.snapshot_present === 'boolean' ? raw.snapshot_present : null
+  const cadenceDeferred = typeof raw.cadence_deferred === 'boolean' ? raw.cadence_deferred : null
+  if (recordedAt == null || traceId == null || kind == null || detail == null) return null
+  if (snapshotPresent === null || cadenceDeferred === null) return null
+  return {
+    ok: true,
+    outcome: 'failed',
+    recordedAt,
+    traceId,
+    kind,
+    detail,
+    snapshotPresent,
+    cadenceDeferred,
+  }
+}
+
+function decodeEntry(raw: unknown): MemoryJournalEntry | null {
+  if (!isRecord(raw)) return null
+  if (raw.ok === false) {
+    const error = asString(raw.error)
+    return error == null ? null : { ok: false, error }
+  }
+  if (raw.ok !== true) return null
+  switch (raw.outcome) {
+    case 'committed':
+      return decodeCommitted(raw)
+    case 'failed':
+      return decodeFailed(raw)
+    default:
+      // An outcome this build does not know came from a wider one. Rendering
+      // it as something else would describe a pass that never happened.
+      return null
+  }
+}
+
+export async function fetchKeeperMemoryJournal(
+  name: string,
+  limit?: number,
+  opts?: AbortableRequestOptions,
+): Promise<MemoryJournal> {
+  await ensureDevToken()
+  const params = limit == null ? '' : `?limit=${encodeURIComponent(String(limit))}`
+  return get<Record<string, unknown>>(
+    `/api/v1/keepers/${encodeURIComponent(name)}/memory-journal${params}`,
+    { signal: opts?.signal },
+  ).then((raw) => {
+    if (!isRecord(raw) || !Array.isArray(raw.entries)) {
+      throw new Error('유효하지 않은 memory journal payload')
+    }
+    const keeper = asString(raw.keeper)
+    const returned = asNumber(raw.returned)
+    const undecodableLines = asNumber(raw.undecodable_lines)
+    if (keeper == null || returned == null || undecodableLines == null) {
+      throw new Error('유효하지 않은 memory journal payload')
+    }
+    const entries: MemoryJournalEntry[] = []
+    for (const item of raw.entries) {
+      const entry = decodeEntry(item)
+      if (entry === null) throw new Error('유효하지 않은 memory journal payload')
+      entries.push(entry)
+    }
+    return { keeper, returned, undecodableLines, entries }
+  })
+}

--- a/dashboard/src/components/internal-agents-monitor.ts
+++ b/dashboard/src/components/internal-agents-monitor.ts
@@ -8,6 +8,10 @@ import {
   type FusionRunRecord,
   type VerificationRunRecord,
 } from '../api/dashboard'
+import {
+  fetchKeeperMemoryJournal,
+  type MemoryJournal,
+} from '../api/dashboard-memory-journal'
 import { registerInternalAgentRefresh } from '../sse-store'
 import { Btn } from './btn'
 import { EmptyState, ErrorState } from './common/feedback-state'
@@ -76,6 +80,83 @@ function formatElapsed(value: number | undefined): string {
   return value < 1 ? `${Math.round(value * 1000)}ms` : `${value.toFixed(1)}s`
 }
 
+function LibrarianJournal({ keeper }: { keeper: string }) {
+  const [journal, setJournal] = useState<MemoryJournal | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    fetchKeeperMemoryJournal(keeper, 20, { signal: controller.signal })
+      .then(setJournal)
+      .catch((reason: unknown) => {
+        if (controller.signal.aborted) return
+        setError(reason instanceof Error ? reason.message : String(reason))
+      })
+    return () => controller.abort()
+  }, [keeper])
+
+  if (error !== null) {
+    return html`<p class="text-xs text-[var(--color-danger)]">기억 저널을 읽지 못했습니다: ${error}</p>`
+  }
+  if (journal === null) {
+    return html`<p class="text-xs text-[var(--color-fg-muted)]">기억 저널 읽는 중…</p>`
+  }
+  if (journal.entries.length === 0) {
+    return html`<p class="text-xs text-[var(--color-fg-muted)]">이 keeper 는 아직 저널 라인이 없습니다.</p>`
+  }
+
+  return html`
+    <div class="grid gap-2">
+      <div class="text-3xs uppercase tracking-wide text-[var(--color-fg-muted)]">
+        기억 저널 · 최근 ${journal.entries.length}건
+        ${journal.undecodableLines > 0
+          ? html`<span class="text-[var(--color-danger)]"> · 읽지 못한 줄 ${journal.undecodableLines}</span>`
+          : null}
+      </div>
+      <ol class="grid gap-1">
+        ${journal.entries.map((entry, index) => {
+          if (!entry.ok) {
+            return html`<li key=${index} class="rounded border border-[var(--color-danger)] p-2 text-3xs">
+              <strong class="text-[var(--color-danger)]">읽지 못한 줄</strong>
+              <span class="block text-[var(--color-fg-muted)]">${entry.error}</span>
+            </li>`
+          }
+          if (entry.outcome === 'failed') {
+            return html`<li key=${index} class="rounded border border-[var(--color-danger)] p-2 text-3xs">
+              <div class="flex flex-wrap gap-2">
+                <strong class="text-[var(--color-danger)]">실패</strong>
+                <code>${entry.kind}</code>
+                <span class="text-[var(--color-fg-muted)]">
+                  스냅샷 ${entry.snapshotPresent ? '있음' : '없음'}
+                  ${entry.cadenceDeferred ? ' · 주기 연기' : ''}
+                </span>
+              </div>
+              <span class="block mt-1 text-[var(--color-fg-muted)]">${entry.detail}</span>
+            </li>`
+          }
+          return html`<li key=${index} class="rounded border border-[var(--color-border-default)] p-2 text-3xs">
+            <div class="flex flex-wrap gap-2">
+              <strong>revision ${entry.revision}</strong>
+              <span class="text-[var(--color-fg-muted)]">
+                추가 ${entry.added} · 제거 ${entry.removed} · 유지 ${entry.retained}
+              </span>
+            </div>
+            ${entry.drops.length > 0
+              ? html`<ul class="mt-1 grid gap-0.5">
+                  ${entry.drops.map((drop, dropIndex) => html`
+                    <li key=${dropIndex} class="text-[var(--color-fg-muted)]">
+                      버림 — ${drop.reason}
+                    </li>
+                  `)}
+                </ul>`
+              : null}
+          </li>`
+        })}
+      </ol>
+    </div>
+  `
+}
+
 function pretty(value: unknown): string {
   return JSON.stringify(value, null, 2) ?? 'null'
 }
@@ -124,6 +205,11 @@ function Details({ row }: { row: Row }) {
           <pre class="overflow-auto text-3xs whitespace-pre-wrap">${pretty(row.run.output ?? { code: row.run.code, detail: row.run.detail })}</pre>
         </div>
         <p class="text-xs text-[var(--color-fg-muted)] md:col-span-2">Tools: none. This exact-output lane performs one structured model execution, not MASC tool dispatch.</p>
+        ${row.run.lane === 'librarian_exact'
+          ? html`<div class="md:col-span-2 border-t border-[var(--color-border-default)] pt-3">
+              <${LibrarianJournal} keeper=${row.run.actor} />
+            </div>`
+          : null}
       </div>
     `
   }

--- a/lib/keeper/keeper_memory_os_current.ml
+++ b/lib/keeper/keeper_memory_os_current.ml
@@ -666,3 +666,45 @@ let upsert_fact
       ~facts
       ())
 ;;
+
+(* Read-side projection. The write-side [journal_entry_to_json] above encodes a
+   committed snapshot for the append; this projects a line that was read back,
+   including the shapes that only exist on the failure path. Reusing the
+   existing field encoders keeps one owner for source/change on the wire. *)
+let decoded_journal_entry_to_json = function
+  | Journal_committed { recorded_at; revision; source; change; dropped } ->
+    `Assoc
+      ([ "outcome", `String committed_outcome
+       ; "recorded_at", `Float recorded_at
+       ; "revision", `Int revision
+       ; "source", source_to_json source
+       ; "change", change_to_json change
+       ]
+       @
+       match dropped with
+       | None -> []
+       | Some statements ->
+         [ "dropped", `List (List.map dropped_statement_to_json statements) ])
+  | Journal_failed
+      { recorded_at; trace_id; kind; detail; snapshot_present; cadence_deferred } ->
+    `Assoc
+      [ "outcome", `String failed_outcome
+      ; "recorded_at", `Float recorded_at
+      ; "trace_id", `String trace_id
+      ; "kind", `String (librarian_failure_kind_to_string kind)
+      ; "detail", `String detail
+      ; "snapshot_present", `Bool snapshot_present
+      ; "cadence_deferred", `Bool cadence_deferred
+      ]
+;;
+
+(* A line this build could not decode keeps its position and says why. Dropping
+   it would make a journal with a torn line read as a shorter one, and the
+   operator counting passes is the one who would be misled. *)
+let journal_line_to_json = function
+  | Ok entry ->
+    (match decoded_journal_entry_to_json entry with
+     | `Assoc fields -> `Assoc (("ok", `Bool true) :: fields)
+     | json -> json)
+  | Error reason -> `Assoc [ "ok", `Bool false; "error", `String reason ]
+;;

--- a/lib/keeper/keeper_memory_os_current.mli
+++ b/lib/keeper/keeper_memory_os_current.mli
@@ -106,6 +106,17 @@ val read_journal_tail :
   -> limit:int
   -> (journal_entry, string) result list
 
+(** Wire projection of one decoded line. The two constructors project to
+    different shapes rather than one shape with null fields: a committed pass
+    has a revision and a failed one does not, and a reader that has to check a
+    null to tell them apart will eventually forget to. *)
+val decoded_journal_entry_to_json : journal_entry -> Yojson.Safe.t
+
+(** Wire projection of one line as read, including the ones this build could
+    not decode. An undecodable line keeps its position and carries its reason,
+    so a journal with a torn line is distinguishable from a shorter one. *)
+val journal_line_to_json : (journal_entry, string) result -> Yojson.Safe.t
+
 val list_keeper_ids_for_keepers_dir : keepers_dir:string -> string list
 
 val read_for_keepers_dir :

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1931,6 +1931,45 @@ let handle_keeper_get_subroutes state req request reqd =
        | Error (`Io msg) ->
          Http.Response.json_value ~status:`Internal_server_error
            (`Assoc [ ("error", `String msg) ]) reqd)
+  else if ends_with "/memory-journal" then
+    (* Why this keeper's memory looks the way it does. The librarian's passes
+       reach disk here — committed and failed alike since RFC-0361 Part 5 — and
+       the internal-agents monitor could show that a pass ran but not what it
+       decided. A failed pass is the case an operator actually opens. *)
+    let name = extract_name "/memory-journal" in
+    if not (Keeper_config.validate_name name)
+    then
+      Http.Response.json_value ~status:`Bad_request
+        (`Assoc
+           [ "error", `String (Printf.sprintf "invalid keeper name: %s" name) ])
+        reqd
+    else (
+      let limit =
+        Server_utils.int_query_param req "limit" ~default:50 |> max 1 |> min 500
+      in
+      let config = Mcp_server.workspace_config state in
+      let keepers_dir = Keeper_types_support.keeper_dir_ config in
+      let lines =
+        Keeper_memory_os_current.read_journal_tail
+          ~keepers_dir
+          ~keeper_id:name
+          ~limit
+      in
+      let undecodable =
+        List.length (List.filter (function Error _ -> true | Ok _ -> false) lines)
+      in
+      Http.Response.json_value ~compress:true ~request:req
+        (`Assoc
+           [ "keeper", `String name
+           ; "dashboard_surface", `String "/api/v1/keepers/:name/memory-journal"
+           ; "returned", `Int (List.length lines)
+           ; (* Reported rather than hidden: a journal this build cannot fully
+                read is a different observation from a shorter one. *)
+             "undecodable_lines", `Int undecodable
+           ; ( "entries"
+             , `List (List.map Keeper_memory_os_current.journal_line_to_json lines) )
+           ])
+        reqd)
   else if ends_with "/operator-note" then
     (* RFC-0366. Read-only here: the operator asks whether a note is pending or
        which turn consumed it. The write surface belongs to the operator control

--- a/test/dune
+++ b/test/dune
@@ -2601,3 +2601,5 @@
 (include stanzas/test_keeper_prompt_capture.inc)
 
 (include stanzas/test_keeper_operator_note.inc)
+
+(include stanzas/test_keeper_memory_journal_projection.inc)

--- a/test/stanzas/test_keeper_memory_journal_projection.inc
+++ b/test/stanzas/test_keeper_memory_journal_projection.inc
@@ -1,0 +1,7 @@
+; The librarian journal as the dashboard sees it. A failed pass and a commit
+; must project to different shapes, and a torn line must keep its place.
+
+(test
+ (name test_keeper_memory_journal_projection)
+ (modules test_keeper_memory_journal_projection)
+ (libraries alcotest masc masc_test_deps unix yojson))

--- a/test/test_keeper_memory_journal_projection.ml
+++ b/test/test_keeper_memory_journal_projection.ml
@@ -1,0 +1,231 @@
+(* The librarian's journal, projected for the dashboard.
+
+   The internal-agents monitor could already show that a librarian pass ran.
+   What it could not show is what the pass decided, and a failed pass is the
+   case an operator actually opens. These cases hold the properties that make
+   the projection worth trusting: a failure and a commit are different shapes,
+   an undecodable line keeps its place, and the drop reasons survive. *)
+
+module Current = Masc.Keeper_memory_os_current
+module Types = Masc.Keeper_memory_os_types
+module U = Yojson.Safe.Util
+
+let keeper = "test-keeper"
+
+let temp_dir () =
+  let path =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-journal-%d-%d" (Unix.getpid ()) (Random.bits ()))
+  in
+  Unix.mkdir path 0o700;
+  path
+;;
+
+let rec rm_rf path =
+  match Unix.lstat path with
+  | { st_kind = Unix.S_DIR; _ } ->
+    Sys.readdir path |> Array.iter (fun e -> rm_rf (Filename.concat path e));
+    (try Unix.rmdir path with Unix.Unix_error _ -> ())
+  | _ -> (try Unix.unlink path with Unix.Unix_error _ -> ())
+  | exception Unix.Unix_error _ -> ()
+;;
+
+let with_keepers_dir f =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = temp_dir () in
+  Eio.Switch.run
+  @@ fun sw ->
+  Eio.Switch.on_release sw (fun () -> rm_rf dir);
+  f dir
+;;
+
+let append_raw ~keepers_dir line =
+  let path = Current.journal_path_for_keepers_dir ~keepers_dir ~keeper_id:keeper in
+  let out = open_out_gen [ Open_append; Open_creat ] 0o644 path in
+  output_string out (line ^ "\n");
+  close_out out
+;;
+
+let read_json ~keepers_dir =
+  Current.read_journal_tail ~keepers_dir ~keeper_id:keeper ~limit:50
+  |> List.map Current.journal_line_to_json
+;;
+
+let field json name = U.member name json
+
+(* A failure has no revision. Projecting both shapes into one object with null
+   fields would make a reader check a null to tell them apart, and a reader
+   that has to check will eventually forget. *)
+let test_failure_and_commit_project_to_different_shapes () =
+  with_keepers_dir (fun keepers_dir ->
+    Current.append_librarian_failure
+      ~keepers_dir
+      ~keeper_id:keeper
+      ~now:1_700_000_000.0
+      ~trace_id:"trace-a"
+      ~kind:Exact_execution_failure
+      ~detail:"provider returned 503"
+      ~snapshot_present:true
+      ~cadence_deferred:true;
+    let fact : Types.fact =
+      { claim = "a claim"; category = Fact; first_seen = 1_700_000_000.0 }
+    in
+    (match
+       Current.replace
+         ~keepers_dir
+         ~keeper_id:keeper
+         ~expected_revision:None
+         ~now:1_700_000_100.0
+         ~source:{ kind = Librarian; trace_id = "trace-b"; generation = 1 }
+         ~facts:[ fact ]
+         ()
+     with
+     | Ok _ -> ()
+     | Error reason -> Alcotest.failf "replace failed: %s" reason);
+    match read_json ~keepers_dir with
+    | [ failed; committed ] ->
+      Alcotest.(check bool) "both lines decoded" true
+        (U.to_bool (field failed "ok") && U.to_bool (field committed "ok"));
+      Alcotest.(check string) "failure outcome" "failed"
+        (U.to_string (field failed "outcome"));
+      Alcotest.(check string) "commit outcome" "committed"
+        (U.to_string (field committed "outcome"));
+      Alcotest.(check string) "failure names its kind" "exact_execution_failure"
+        (U.to_string (field failed "kind"));
+      Alcotest.(check bool) "failure carries no revision" true
+        (field failed "revision" = `Null);
+      Alcotest.(check int) "commit carries its revision" 1
+        (U.to_int (field committed "revision"));
+      Alcotest.(check bool) "commit carries no failure kind" true
+        (field committed "kind" = `Null)
+    | lines -> Alcotest.failf "expected two lines, got %d" (List.length lines))
+;;
+
+(* The whole reason the failure line exists: an operator asking why memory did
+   not advance needs the detail, not just that something failed. *)
+let test_failure_carries_its_detail_and_deferral () =
+  with_keepers_dir (fun keepers_dir ->
+    Current.append_librarian_failure
+      ~keepers_dir
+      ~keeper_id:keeper
+      ~now:1_700_000_000.0
+      ~trace_id:"trace-a"
+      ~kind:Runtime_context_unavailable
+      ~detail:"Eio net/clock context unavailable"
+      ~snapshot_present:false
+      ~cadence_deferred:false;
+    match read_json ~keepers_dir with
+    | [ line ] ->
+      Alcotest.(check string) "detail survives"
+        "Eio net/clock context unavailable"
+        (U.to_string (field line "detail"));
+      Alcotest.(check bool) "snapshot presence is stated" false
+        (U.to_bool (field line "snapshot_present"));
+      Alcotest.(check bool) "cadence deferral is stated" false
+        (U.to_bool (field line "cadence_deferred"));
+      Alcotest.(check string) "trace id survives" "trace-a"
+        (U.to_string (field line "trace_id"))
+    | lines -> Alcotest.failf "expected one line, got %d" (List.length lines))
+;;
+
+(* A torn line occupies its own position. Collapsing it would make a damaged
+   journal read as a shorter one, and the operator counting passes is the one
+   who would be misled. *)
+let test_undecodable_line_keeps_its_position_and_reason () =
+  with_keepers_dir (fun keepers_dir ->
+    Current.append_librarian_failure
+      ~keepers_dir ~keeper_id:keeper ~now:1.0 ~trace_id:"before"
+      ~kind:Domain_output_invalid ~detail:"d" ~snapshot_present:true
+      ~cadence_deferred:false;
+    append_raw ~keepers_dir "{not json";
+    Current.append_librarian_failure
+      ~keepers_dir ~keeper_id:keeper ~now:2.0 ~trace_id:"after"
+      ~kind:Domain_output_invalid ~detail:"d" ~snapshot_present:true
+      ~cadence_deferred:false;
+    match read_json ~keepers_dir with
+    | [ before; torn; after ] ->
+      Alcotest.(check string) "first is intact" "before"
+        (U.to_string (field before "trace_id"));
+      Alcotest.(check bool) "torn line is marked" false (U.to_bool (field torn "ok"));
+      Alcotest.(check bool) "and carries a reason" true
+        (String.length (U.to_string (field torn "error")) > 0);
+      Alcotest.(check string) "third is intact" "after"
+        (U.to_string (field after "trace_id"))
+    | lines -> Alcotest.failf "expected three lines, got %d" (List.length lines))
+;;
+
+(* A line written before the outcome tag existed decodes to Error, and the
+   projection says so rather than presenting it as a commit. *)
+let test_untagged_legacy_line_is_reported_not_reinterpreted () =
+  with_keepers_dir (fun keepers_dir ->
+    append_raw
+      ~keepers_dir
+      {|{"recorded_at":1.0,"revision":3,"source":{"kind":"librarian","trace_id":"t","generation":3},"change":{"added":[],"removed":[],"retained":0}}|};
+    match read_json ~keepers_dir with
+    | [ line ] ->
+      Alcotest.(check bool) "not presented as decoded" false (U.to_bool (field line "ok"));
+      Alcotest.(check bool) "and not presented as a commit" true
+        (field line "outcome" = `Null)
+    | lines -> Alcotest.failf "expected one line, got %d" (List.length lines))
+;;
+
+(* Drop reasons are the librarian's own account of what it forgot. They ride
+   the journal line and nothing else stores them, so losing them in the
+   projection loses them entirely. *)
+let test_drop_reasons_survive_the_projection () =
+  with_keepers_dir (fun keepers_dir ->
+    let fact : Types.fact =
+      { claim = "kept"; category = Fact; first_seen = 1_700_000_000.0 }
+    in
+    match
+      Current.replace
+        ~keepers_dir
+        ~keeper_id:keeper
+        ~dropped_statements:
+          [ { memory_id = "id:gone"; reason = "superseded by the openssl decision" } ]
+        ~expected_revision:None
+        ~now:1_700_000_000.0
+        ~source:{ kind = Librarian; trace_id = "trace-a"; generation = 1 }
+        ~facts:[ fact ]
+        ()
+    with
+    | Error reason -> Alcotest.failf "replace failed: %s" reason
+    | Ok _ ->
+      (match read_json ~keepers_dir with
+       | [ line ] ->
+         let dropped = U.to_list (field line "dropped") in
+         Alcotest.(check int) "one drop statement" 1 (List.length dropped);
+         (match dropped with
+          | [ statement ] ->
+            Alcotest.(check string) "the reason survives"
+              "superseded by the openssl decision"
+              (U.to_string (field statement "reason"))
+          | _ -> Alcotest.fail "expected one statement")
+       | lines -> Alcotest.failf "expected one line, got %d" (List.length lines)))
+;;
+
+let () =
+  Random.self_init ();
+  Alcotest.run
+    "keeper memory journal projection"
+    [ ( "shape"
+      , [ Alcotest.test_case "failure and commit project to different shapes" `Quick
+            test_failure_and_commit_project_to_different_shapes
+        ; Alcotest.test_case "failure carries its detail and deferral" `Quick
+            test_failure_carries_its_detail_and_deferral
+        ] )
+    ; ( "honesty"
+      , [ Alcotest.test_case "undecodable line keeps its position and reason" `Quick
+            test_undecodable_line_keeps_its_position_and_reason
+        ; Alcotest.test_case "untagged legacy line is reported, not reinterpreted" `Quick
+            test_untagged_legacy_line_is_reported_not_reinterpreted
+        ] )
+    ; ( "content"
+      , [ Alcotest.test_case "drop reasons survive the projection" `Quick
+            test_drop_reasons_survive_the_projection
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 돌았다는 것 말고, 무엇을 결정했는지

`InternalAgentsMonitor` 는 이미 Librarian 실행을 나열한다. 라이브 실측:

```
librarian_exact        90 건
board_attention_exact  61 건
결과: succeeded 138 / failed 9 / cancelled 1
```

**그 9 건이 왜 실패했는지는 화면에 없다.** 지금까지는 호스트에서 `.masc/keepers/<name>.memory-journal.jsonl` 을 직접 열어야 했다.

```
GET /api/v1/keepers/:name/memory-journal
```

## 커밋과 실패는 다른 모양으로 나간다

RFC-0361 Part 5 가 committed / failed 를 같은 저널에 닫힌 outcome 태그로 올렸다. 이 투영은 둘 다 내되 **하나의 모양에 null 을 채우지 않는다.**

```
commit  → { outcome: "committed", revision, source, change, dropped? }
failure → { outcome: "failed", kind, detail, snapshot_present, cadence_deferred }
```

null 을 확인해야 둘을 구별하는 독자는 언젠가 그 확인을 잊는다.

## 버림 사유가 이 라인에만 있다

librarian 의 `dropped[].reason` 은 저널 라인이 유일한 저장처다. 투영에서 놓치면 영영 사라진다. 그래서 행까지 그대로 나른다 — **#26729 가 필요로 했는데 없던 것**이 정확히 이것이다.

## 읽지 못한 줄

위치를 지키고 사유를 달고 나가며, 응답이 그 개수를 보고한다. 줄이 찢어진 저널과 그냥 짧은 저널은 다른 관측이다. outcome 태그 이전에 쓰인 줄도 커밋으로 재해석하지 않고 **읽지 못함**으로 보고한다.

## 검증

OCaml 5 케이스 + 클라이언트 5 케이스.

**게이트 능력** — 이 투영이 막는 붕괴를 양쪽에 주입했다:

| 주입 | 실패한 케이스 |
|---|---|
| 찢어진 줄을 커밋으로 표시 | `honesty` 2 건 |
| 미지 outcome 을 커밋으로 디코드 | `rejects the payload when an outcome is unknown` |

OCaml 그룹 이름을 `honesty` 로 둔 것도 그래서다 — 실패 출력이 무엇이 깨졌는지 그대로 말한다.

`ci.yml` 배선 완료. 대시보드 `tsc` clean, **639 파일 / 8,839 테스트** 통과.

## 범위 밖

Librarian 레인에서만 렌더한다. 다른 레인은 기존 input/result 뷰 그대로이고 아무것도 바뀌지 않는다. Judge (`board_attention_exact` 61 건) 는 저널에 해당하는 저장소가 없어 같은 방식이 안 되고, 별도 작업이다.

RFC-WAIVED: RFC-0361 Part 5 (main 병합됨) 가 저널 계약을 정의했고, 이 PR 은 그 계약을 읽어 화면에 도달시킬 뿐이다. 프롬프트에 들어가는 것을 바꾸지 않는다.
