### PR TITLE
refactor(runtime): drop match_prefixes, a matcher RFC-0206 R4 forbade porting

### DIFF
--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -134,7 +134,6 @@ export interface DashboardRuntimeDeclaredModelSpec {
   top_k?: number | null
   min_p?: number | null
   capabilities?: DashboardRuntimeDeclaredModelCapabilities | null
-  match_prefixes: string[]
 }
 
 export interface DashboardRuntimeDeclaredBindingSpec {
@@ -600,7 +599,6 @@ function decodeRuntimeDeclaredModelSpec(raw: unknown): DashboardRuntimeDeclaredM
     top_k: asNumber(raw.top_k) ?? null,
     min_p: asNumber(raw.min_p) ?? null,
     capabilities: decodeRuntimeDeclaredModelCapabilities(raw.capabilities),
-    match_prefixes: asStringArray(raw.match_prefixes),
   }
 }
 

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -3238,7 +3238,6 @@ describe('fetchRuntimeProviders', () => {
                   supports_computer_use: false,
                   supports_code_execution: true,
                 },
-                match_prefixes: ['Qwen/'],
               },
               binding: {
                 provider_id: 'runpod_mtp',

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -785,7 +785,6 @@ const mocks = vi.hoisted(() => {
                 supports_response_format_json: true,
                 supports_structured_output: true,
               },
-              match_prefixes: ['Qwen/'],
             },
             binding: {
               provider_id: 'runpod_mtp',

--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -97,7 +97,6 @@ function runtimeProviderFixture(runtimeId: string): DashboardRuntimeProviderSnap
       model: {
         id: modelId,
         api_name: 'model-api',
-        match_prefixes: ['model-'],
         capabilities: {
           source: 'runtime.toml',
           thinking_control_format: 'reasoning-effort',

--- a/dashboard/src/components/keeper-runtime-model-editor.test.ts
+++ b/dashboard/src/components/keeper-runtime-model-editor.test.ts
@@ -254,7 +254,6 @@ function makeRuntimeProvider(runtimeId: string, providerName: string, modelName:
           supports_seed_with_images: true,
           supports_code_execution: true,
         },
-        match_prefixes: [`${modelName}-`],
       },
       binding: {
         provider_id: runtimeId.split('.')[0],

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -484,7 +484,6 @@ describe('KeeperWorkspaceRail', () => {
                 supports_computer_use: false,
                 supports_code_execution: true,
               },
-              match_prefixes: ['minimax'],
             },
             binding: {
               provider_id: 'ollama_cloud',

--- a/dashboard/src/components/runtime-environment-editor.test.ts
+++ b/dashboard/src/components/runtime-environment-editor.test.ts
@@ -337,7 +337,6 @@ describe('RuntimeEnvironmentEditor capability projection', () => {
             supports_response_format_json: true,
             supports_structured_output: true,
           },
-          match_prefixes: [],
         },
         binding: {
           provider_id: 'ollama_cloud',

--- a/dashboard/src/components/runtime-health-snapshot.test.ts
+++ b/dashboard/src/components/runtime-health-snapshot.test.ts
@@ -109,7 +109,6 @@ function providerPayload(overrides: Record<string, unknown> = {}) {
             preserve_thinking: true,
             thinking_support: true,
             max_thinking_budget: 4096,
-            match_prefixes: ['Qwen/'],
             capabilities: {
               thinking_control_format: 'chat-template-kwargs',
               max_output_tokens: 8192,

--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -235,7 +235,6 @@ describe('RuntimeMonitor', () => {
                 supports_computer_use: true,
                 supports_code_execution: true,
               },
-              match_prefixes: ['Qwen/'],
             },
             binding: {
               provider_id: 'runpod_mtp',

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -470,7 +470,6 @@ function runtimeParameterDetailRows(
     detailRow('declared model', 'format', declaredFormat),
     detailRow('declared model', 'inputs', runtimeDeclaredInputText(provider)),
     detailRow('declared model', 'controls', runtimeDeclaredModelControlText(provider)),
-    detailRow('declared model', 'match prefixes', stringArrayText(declaredModel?.match_prefixes)),
     detailRow('binding', 'provider.model', textList([binding?.provider_id, binding?.model_id])),
     detailRow('binding', 'default', boolText(binding?.is_default)),
     detailRow('binding', 'concurrency', numberText(binding?.max_concurrent)),

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -1151,7 +1151,6 @@ describe('SettingsSurface', () => {
                 supports_computer_use: false,
                 supports_code_execution: true,
               },
-              match_prefixes: ['m1'],
             },
             binding: {
               provider_id: 'provider-a',

--- a/dashboard/src/components/tools/config-resolution-panel.test.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.test.ts
@@ -107,7 +107,6 @@ function runtimeProvidersPayload() {
               supports_response_format_json: true,
               supports_structured_output: true,
             },
-            match_prefixes: ['Qwen/'],
           },
           binding: {
             provider_id: 'runpod_mtp',

--- a/dashboard/src/lib/runtime-provider-summary.ts
+++ b/dashboard/src/lib/runtime-provider-summary.ts
@@ -244,7 +244,6 @@ export function runtimeCatalogDeclaredSpec(item: DashboardRuntimeProviderSnapsho
     samplingConfig.length > 0 ? `sampling-config:${samplingConfig.join(',')}` : null,
     sampling.length > 0 ? `sampling:${sampling.join(',')}` : null,
     controls.length > 0 ? `controls:${controls.join(',')}` : null,
-    spec.model?.match_prefixes.length ? `match:${spec.model.match_prefixes.join(',')}` : null,
     spec.binding?.is_default ? 'default' : null,
     typeof spec.binding?.max_concurrent === 'number' ? `concurrency:${spec.binding.max_concurrent}` : null,
     typeof spec.binding?.price_input === 'number' ? `price-in:${spec.binding.price_input}` : null,

--- a/docs/rfc/RFC-0206-runtime-concept-runtime-rebirth.md
+++ b/docs/rfc/RFC-0206-runtime-concept-runtime-rebirth.md
@@ -41,7 +41,7 @@ Runtime은 하나의 완전히 materialize된 (Provider × Model × Binding) tri
 | `capabilities` | 10-field provider 행동 record + `capabilities_default` | `runtime_capabilities` |
 | `model_capabilities` | 24-field record (`Llm_provider.Capabilities` 미러) + default | `runtime_model_capabilities` |
 | `provider` | Layer 1 record (id/display_name/protocol/api_format/transport/is_non_interactive/credentials/capabilities/headers). log·healthcheck sub-record는 v1에서 parse-and-ignore | `runtime_provider` |
-| `model_spec` | Layer 2 record (id/api_name/tools_support/max_context/thinking_support/max_thinking_budget/streaming/capabilities/match_prefixes) | `runtime_model_spec` |
+| `model_spec` | Layer 2 record (id/api_name/tools_support/max_context/thinking_support/max_thinking_budget/streaming/capabilities). `match_prefixes` 는 R4 가 matcher 포팅을 금지했으므로 필드도 두지 않는다 | `runtime_model_spec` |
 | `binding` | Layer 3 record (provider_id/model_id/is_default/optional max_concurrent/price_*/keep_alive/num_ctx) + `binding_key` | `runtime_binding` |
 | `config` | `{ providers; models; bindings; default_runtime_id }` — **routes/system_targets/profiles/aliases DROP** | `runtime_config` minus routing |
 

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -149,10 +149,9 @@ let model_capabilities_default =
   }
 ;;
 
-(** [models.<id>] — capability declaration. [match_prefixes] empty = match only
-    exact [api_name] equality; non-empty = match any requested model id starting
-    with one of the prefixes (longest-prefix-first; resolver lives outside the
-    schema and is added only if a binding needs fuzzy resolution — RFC-0206 R4). *)
+(** [models.<id>] — capability declaration. A requested model id resolves by
+    exact [api_name] equality. RFC-0206 R4 forbids porting the longest-prefix
+    matcher until a binding actually requires fuzzy resolution. *)
 type model_spec =
   { id : string
   ; api_name : string
@@ -186,7 +185,6 @@ type model_spec =
         the materialized OAS [Provider_config]. [None] leaves the caller/OAS
         profile unchanged. *)
   ; capabilities : model_capabilities option
-  ; match_prefixes : string list
   }
 [@@deriving show, eq]
 

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -124,7 +124,6 @@ type model_spec =
   ; top_k : int option
   ; min_p : float option
   ; capabilities : model_capabilities option
-  ; match_prefixes : string list
   }
 [@@deriving show, eq]
 

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -693,27 +693,6 @@ let parse_model (id : string) (tbl : Otoml.t)
       | Some t ->
         Result.map Option.some (parse_model_capabilities ~path:(path ^ ".capabilities") t)
     in
-    let match_prefixes =
-      match Otoml.find_opt tbl Fun.id [ "match-prefixes" ] with
-      | None -> []
-      | Some v ->
-        (* RFC-0145 — narrow to the only exception [Otoml.get_array]
-           raises on a wrong-typed value.  Unrelated runtime exceptions
-           propagate. *)
-        (try
-           Otoml.get_array Otoml.get_string v
-           |> List.filter_map (fun s ->
-             let trimmed = String.trim s in
-             if String.length trimmed = 0
-             then (
-               Log.Runtime.warn "runtime_toml: %s.match-prefixes contains empty entry, ignoring" path;
-               None)
-             else Some trimmed)
-         with
-         | Otoml.Type_error _ ->
-           Log.Runtime.warn "runtime_toml: %s.match-prefixes — expected string array, ignoring" path;
-           [])
-    in
     let temperature_result = temperature_opt_field ~path tbl in
     let top_p_result = probability_opt_field ~path ~key:"top-p" tbl in
     let top_k_result = positive_int_opt_field ~path ~key:"top-k" tbl in
@@ -741,9 +720,7 @@ let parse_model (id : string) (tbl : Otoml.t)
         ; top_p
         ; top_k
         ; min_p
-        ; capabilities
-        ; match_prefixes
-        })
+        ; capabilities        })
 ;;
 
 let parse_models (toml : Otoml.t)

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1639,7 +1639,6 @@ let runtime_declared_spec_json (rt : Runtime.t) =
           ; "top_k", Json_util.int_opt_to_json rt.model.top_k
           ; "min_p", Json_util.float_opt_to_json rt.model.min_p
           ; "capabilities", runtime_declared_model_capabilities_json rt.model.capabilities
-          ; "match_prefixes", Json_util.json_string_list rt.model.match_prefixes
           ] )
     ; ( "binding"
       , `Assoc

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -56,7 +56,6 @@ let qwen_model =
   ; top_k = None
   ; min_p = None
   ; capabilities = None
-  ; match_prefixes = []
   }
 
 let runpod_binding =


### PR DESCRIPTION
## 문제

`runtime.toml` 의 `models.<id>.match-prefixes` 는 파싱되고, 검증되고, 빈 항목에는 경고까지 찍고, `model_spec` 에 저장되고, 대시보드 wire 로 나가고, 화면에 한 줄로 렌더된다.

```
detailRow('declared model', 'match prefixes', stringArrayText(declaredModel?.match_prefixes))
```

**그 값을 읽어 매칭하는 코드는 없다.** 모델 id 는 `api_name` 완전 일치로만 해석된다.

스키마 주석이 스스로 그렇게 적어 두었다.

```ocaml
(** [match_prefixes] empty = match only exact [api_name] equality; non-empty =
    match any requested model id starting with one of the prefixes
    (longest-prefix-first; resolver lives outside the schema and is added only
    if a binding needs fuzzy resolution — RFC-0206 R4). *)
```

앞 문장은 동작을 서술하고 뒤 괄호는 그 동작이 없다고 말한다. 읽는 사람이 앞을 믿으면 틀린다.

## 왜 이렇게 됐나

`fd2244290a` 가 Cascade 에 `match_prefixes` **필드 + longest-prefix-first lookup** 을 함께 넣었다. `be2efb288c` 가 Cascade 를 걷어내며 lookup 이 사라졌고, `14cf14fe81` (RFC-0206 P1-P3) 이 Runtime 기판으로 필드만 옮겼다.

RFC-0206 R4 는 명시적으로 금지한다.

> validator dual-mode·longest-prefix model matching은 binding이 실제 fuzzy resolution을 요구하기 전엔 포팅 금지.

RFC 는 지켜졌다 — matcher 는 오지 않았다. 그런데 **설정 키와 표시 줄은 왔다.** 운영자는 `match-prefixes = ["Qwen/"]` 을 쓸 수 있고, 파서가 받아주고, 대시보드가 `match prefixes: Qwen/` 이라고 보여주고, 아무 요청도 그 규칙으로 라우팅되지 않는다.

## 근거

`match_prefixes` 를 참조하는 곳 전부 (OCaml):

| 위치 | 하는 일 |
|---|---|
| `runtime_toml.ml:696` | TOML 에서 읽음 |
| `runtime_schema.ml:189`, `.mli:127` | 필드 선언 |
| `server_dashboard_http_runtime_info.ml:1642` | JSON 으로 내보냄 |
| `test_runtime_provider_auth_headers.ml:59` | 픽스처 `[]` |

읽어서 **판정에 쓰는 곳은 0**. `rg -n "match_prefixes" lib/ bin/ test/ scripts/` 전체 결과가 위 표다. 모델 id 에 대한 prefix 매칭 구현도 없다 (`rg "longest.prefix" lib/` → `http_server_eio` 의 HTTP 라우팅뿐, 무관하고 살아있음).

저장소 안 어떤 `.toml` 도 `match-prefixes` 를 선언하지 않는다. 대시보드 테스트 픽스처 9개가 값을 넣고 있었지만, 그 값이 무엇을 바꾸는지 검사하는 assertion 은 없다.

## 무엇을 지웠나

- `runtime_schema.{ml,mli}` — 필드, 그리고 없는 동작을 서술하던 주석
- `runtime_toml.ml` — 파싱 블록 25 줄 (빈 항목/타입 오류 경고 포함)
- `server_dashboard_http_runtime_info.ml` — wire 필드
- `dashboard/src/api/dashboard-runtime.ts` — 타입 + 디코더
- `dashboard/src/components/runtime-monitor.ts` — `match prefixes` 표시 줄
- `dashboard/src/lib/runtime-provider-summary.ts` — 요약 문자열의 `match:…` 조각
- 픽스처 9개 + OCaml 픽스처 1개

`models.<id>` 테이블에는 unknown-key 검사가 없다 (그 검사는 `exact_output_lanes` 전용). 그래서 기존 config 에 `match-prefixes` 가 남아 있어도 **오늘과 똑같이** 무시된다 — 새로 에러가 나지 않는다. 오늘은 "읽고 나서 무시", 이 PR 이후는 "읽지 않음"이고, 관측 가능한 차이는 대시보드가 더 이상 없는 규칙을 광고하지 않는다는 것뿐이다.

RFC-0206 §layer 표에서 `model_spec` 필드 목록도 고쳤다. R4 문장 자체는 그대로다 — 금지는 여전히 유효하고, 이 PR 은 그 금지를 필드 수준까지 관철한다. 나중에 binding 이 실제로 fuzzy resolution 을 요구하면 그때 matcher 와 필드를 **함께** 넣으면 된다.

## 검증

`dune build @check` 통과. `npm run typecheck` 통과.

OCaml: `test_runtime_provider_auth_headers` 46, `test_exact_output_catalog_precedence` / `test_legacy_protocol_alias_rejected` / `test_runtime_model_temperature_toml` / `test_runtime_config_validity` / `test_thinking_control_format_unknown_error` 합계 89, `test_gate_hitl_runtime_info` / `test_masc_runtime_events` 10 통과.

Dashboard: 건드린 10개 파일 전부 — `dashboard.test.ts`, `runtime-monitor`, `keeper-config-panel`, `keeper-detail-runtime`, `keeper-runtime-model-editor`, `keeper-workspace-rail`, `runtime-environment-editor`, `runtime-health-snapshot`, `settings-surface`, `config-resolution-panel` — 359 건 통과.

게이트: `check-determinism-contract`, `check-doc-code-refs`, `check-doc-truth`, `audit-catchall`, `check-variants`, `check-enum-string-safety`, `audit-path-ssot`, `check_silent_failure`, `check_test_coverage` 전부 통과.

순감 42 줄.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
