### PR TITLE
fix(dashboard): 멀쩡한 화면이 '안 보인다'가 되는 세 경로 (배지 오분류 + 딥링크 + 백그라운드 탭 WS 정지)

### DIFF
--- a/dashboard/src/components/auth-status.test.ts
+++ b/dashboard/src/components/auth-status.test.ts
@@ -40,6 +40,7 @@ vi.mock('../lib/dashboard-actor', () => ({
 vi.mock('./common/toast', () => ({ showToast: vi.fn() }))
 
 import { AuthStatus, __resetForTests } from './auth-status'
+import { shellAuthSummary } from '../store'
 
 const flushUi = (): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, 30))
@@ -134,5 +135,83 @@ describe('AuthStatus popover behavior (Iter 2)', () => {
       expect(container.querySelector('[role="dialog"]')).toBeNull()
     })
     expect(document.activeElement).toBe(trigger)
+  })
+})
+
+// The badge is the first thing an operator reads when a panel looks empty, so
+// it has to separate "you have not signed in" from "the system rejected you".
+// A red "Auth error" on a dashboard whose data is loading fine sends people
+// looking for an outage that is not there — observed on a live fleet where
+// every HTTP surface returned 200 and the badge still read Auth error.
+describe('AuthStatus badge distinguishes absent credentials from rejected ones', () => {
+  let container: HTMLElement
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    __resetForTests()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    document.body.innerHTML = ''
+    ;(shellAuthSummary as { value: unknown }).value = null
+    __resetForTests()
+  })
+
+  function renderWith(summary: Record<string, unknown>): string {
+    ;(shellAuthSummary as { value: unknown }).value = summary
+    render(html`<${AuthStatus} />`, container)
+    return container.textContent ?? ''
+  }
+
+  it('reads "Login required" when no token was ever sent', () => {
+    const text = renderWith({
+      enabled: true,
+      require_token: true,
+      token_present: false,
+      token_valid: false,
+      auth_error_code: 'missing_token',
+    })
+    expect(text).toContain('Login required')
+    expect(text).not.toContain('Auth error')
+  })
+
+  it('reads "Auth error" when a token was sent and rejected', () => {
+    const text = renderWith({
+      enabled: true,
+      require_token: true,
+      token_present: true,
+      token_valid: false,
+      auth_error_code: 'invalid_token',
+    })
+    expect(text).toContain('Auth error')
+    expect(text).not.toContain('Login required')
+  })
+
+  it('treats an actor mismatch as a rejection, not a missing credential', () => {
+    const text = renderWith({
+      enabled: true,
+      require_token: true,
+      token_present: true,
+      token_valid: false,
+      auth_error_code: 'actor_mismatch',
+    })
+    expect(text).toContain('Auth error')
+  })
+
+  it('reads verified when the token checks out', () => {
+    const text = renderWith({
+      enabled: true,
+      require_token: true,
+      token_present: true,
+      token_valid: true,
+      effective_agent: 'dashboard',
+      effective_role: 'worker',
+    })
+    expect(text).toContain('Verified')
+    expect(text).not.toContain('Auth error')
+    expect(text).not.toContain('Login required')
   })
 })

--- a/dashboard/src/components/auth-status.ts
+++ b/dashboard/src/components/auth-status.ts
@@ -63,7 +63,15 @@ function authBadgeSummary(): {
   const validated = summary?.token_valid === true
   const role = summary?.effective_role ?? summary?.default_role ?? 'unknown'
   const actor = summary?.effective_agent ?? summary?.token_agent ?? currentDashboardActor()
-  const hasError = summary?.auth_error_code != null || (summary?.token_present === true && !validated)
+  // `missing_token` says no credential was sent. That is the operator's next
+  // action, not a broken system, and it already has a label below. Folding it
+  // into the error branch showed a red "Auth error" on a dashboard whose data
+  // was loading fine, which reads as an outage and sends people looking for
+  // one. Every other code means a credential was sent and rejected.
+  const errorCode = summary?.auth_error_code ?? null
+  const credentialRejected =
+    (errorCode != null && errorCode !== 'missing_token')
+    || (summary?.token_present === true && !validated)
   const hasToken = !!dashboardBearerToken()
   const bootstrap = devTokenBootstrapStatus.value
 
@@ -73,10 +81,16 @@ function authBadgeSummary(): {
       label: `Verified @${actor} · ${role}`,
     }
   }
-  if (hasError) {
+  if (credentialRejected) {
     return {
       dotColor: 'bg-[var(--color-status-err)] shadow-[0_0_6px_rgb(var(--err-glow)/0.45)]',
       label: 'Auth error',
+    }
+  }
+  if (errorCode === 'missing_token' && !hasToken && bootstrap !== 'warming') {
+    return {
+      dotColor: 'bg-[var(--color-status-err)] shadow-[0_0_6px_rgb(var(--err-glow)/0.45)]',
+      label: 'Login required',
     }
   }
   if (!hasToken && bootstrap === 'warming') {

--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -1556,3 +1556,95 @@ describe('dashboard websocket route subscriptions', () => {
     )
   })
 })
+
+// A monitoring dashboard is left in a background tab by design, and a hidden
+// tab never paints — requestAnimationFrame does not fire there at all
+// (measured: 0 callbacks over 3.4s in Chrome). Scheduling inbound delivery on
+// rAF alone therefore stopped the transport whenever the tab went to the
+// background: the dashboard/hello reply sat in the inbound queue until the
+// RPC timed out, the socket closed, and the reconnect hit the same wall.
+//
+// These cases drive the real scheduler. Every other test in this file
+// delivers through MockWebSocket.receive(), which calls flushPendingInbound()
+// itself and so never exercises scheduleFlush() — which is why the stall was
+// invisible here.
+describe('dashboard ws inbound delivery while the tab is hidden', () => {
+  let visibility: DocumentVisibilityState = 'visible'
+
+  function setVisibility(next: DocumentVisibilityState): void {
+    visibility = next
+    document.dispatchEvent(new Event('visibilitychange'))
+  }
+
+  function installVisibilityStub(): void {
+    visibility = 'visible'
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => visibility,
+    })
+  }
+
+  // A hidden tab does not paint, so a frame callback is recorded and never
+  // invoked. Anything that only runs on a frame never runs.
+  function installNeverFiringFrames(): FrameRequestCallback[] {
+    const frames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => frames.push(cb))
+    vi.stubGlobal('cancelAnimationFrame', () => {})
+    return frames
+  }
+
+  // Deliberately not MockWebSocket.receive(): that helper flushes by hand and
+  // would answer the question this test is asking.
+  function deliverRaw(socket: MockWebSocket, payload: unknown): void {
+    socket.onmessage?.({ data: JSON.stringify(payload) } as MessageEvent)
+  }
+
+  afterEach(() => {
+    // The stub is an own property shadowing the prototype getter; removing it
+    // restores the real one. Reflect.deleteProperty rather than `delete`,
+    // which the readonly declaration rejects.
+    Reflect.deleteProperty(document, 'visibilityState')
+  })
+
+  it('completes the handshake in a tab that never paints', async () => {
+    installVisibilityStub()
+    const frames = installNeverFiringFrames()
+    installWebSocketMocks()
+    setVisibility('hidden')
+
+    await connectDashboardWS({ tab: 'overview', params: {} })
+    const socket = mockSockets[0]!
+    socket.open()
+    const hello = parseRpc(socket, 0)
+    deliverRaw(socket, { jsonrpc: '2.0', id: hello.id, result: {} })
+
+    // The timer path the hidden branch takes, not a frame.
+    await new Promise(resolve => setTimeout(resolve, 0))
+    await flushPromises()
+
+    expect(dashboardWsReady.value).toBe(true)
+    expect(frames).toHaveLength(0)
+  })
+
+  it('does not strand the queue on a frame scheduled before the tab hid', async () => {
+    installVisibilityStub()
+    installNeverFiringFrames()
+    installWebSocketMocks()
+
+    await connectDashboardWS({ tab: 'overview', params: {} })
+    const socket = mockSockets[0]!
+    socket.open()
+    const hello = parseRpc(socket, 0)
+    // Queued while visible: this takes the frame path, and that frame is
+    // still outstanding when the tab hides. The handle it left behind used to
+    // make every later scheduleFlush() a no-op.
+    deliverRaw(socket, { jsonrpc: '2.0', id: hello.id, result: {} })
+    expect(dashboardWsReady.value).toBe(false)
+
+    setVisibility('hidden')
+    await new Promise(resolve => setTimeout(resolve, 0))
+    await flushPromises()
+
+    expect(dashboardWsReady.value).toBe(true)
+  })
+})

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -248,28 +248,82 @@ function dashboardWsUnavailableMessage(reason?: string): string {
   return reason ? `dashboard websocket unavailable: ${reason}` : 'dashboard websocket unavailable'
 }
 
-// Phase 2 (PR-4.6): rAF accumulator for inbound WS messages.
+// Phase 2 (PR-4.6): accumulator for inbound WS messages.
 // Instead of processing every WS frame immediately (which can trigger
-// multiple signal writes / renders), we buffer them and flush on the
-// next animation frame.  This bounds update frequency to 60 Hz and
-// lets batch() coalesce all signal mutations in a single frame.
+// multiple signal writes / renders), we buffer them and flush together so a
+// burst produces one render rather than one per frame.
+//
+// While the tab paints, the next animation frame is the right moment: it
+// bounds update frequency to the display rate and lets batch() coalesce
+// every signal mutation into a single frame. A hidden tab never paints, so
+// requestAnimationFrame never fires there — measured at 0 callbacks over
+// 3.4s in a background tab. Scheduling the flush on rAF alone therefore
+// stopped inbound delivery entirely whenever the tab was in the background,
+// RPC replies included: the dashboard/hello reply sat in this queue until
+// sendRpc timed out (DASHBOARD_WS_RPC_TIMEOUT_MS), the socket closed, and
+// the reconnect hit the same wall. A monitoring dashboard is left in a
+// background tab by design, so that was its normal operating mode.
+//
+// While hidden there is no paint to batch against, so the flush runs on a
+// timer instead. Browsers clamp timers in hidden pages to roughly 1 Hz,
+// which is two orders of magnitude inside the RPC timeout.
 const pendingInbound: Array<string | unknown> = []
 let flushHandle = 0
+let flushHandleKind: 'frame' | 'timer' | null = null
+
+function documentIsHidden(): boolean {
+  return typeof document !== 'undefined' && document.visibilityState === 'hidden'
+}
+
+function cancelScheduledFlush(): void {
+  if (!flushHandle) return
+  // Passing a timer handle to cancelAnimationFrame cancels nothing and
+  // leaves the callback armed, so the handle's origin picks the call rather
+  // than whichever canceller happens to be defined.
+  if (flushHandleKind === 'frame') cancelAnimationFrame(flushHandle)
+  else clearTimeout(flushHandle)
+  flushHandle = 0
+  flushHandleKind = null
+}
 
 function scheduleFlush(): void {
   if (flushHandle) return
-  if (typeof requestAnimationFrame === 'undefined') {
-    // Fallback for non-browser environments (e.g. vitest with happy-dom).
+  // requestAnimationFrame is also absent in non-browser environments
+  // (e.g. vitest with happy-dom), which takes the same timer path.
+  if (documentIsHidden() || typeof requestAnimationFrame === 'undefined') {
+    flushHandleKind = 'timer'
     flushHandle = setTimeout(() => {
       flushHandle = 0
+      flushHandleKind = null
       flushPending()
     }, 0) as unknown as number
     return
   }
+  flushHandleKind = 'frame'
   flushHandle = requestAnimationFrame(() => {
     flushHandle = 0
+    flushHandleKind = null
     flushPending()
   })
+}
+
+// A frame callback scheduled while the tab was visible never runs once the
+// tab stops painting, and the handle it left behind makes scheduleFlush() a
+// no-op — the queue would stay stranded for as long as the tab is hidden,
+// which is the same stall in a narrower window. Re-arm on the mechanism that
+// matches the new state, and on the way back deliver what accumulated
+// without waiting for the next frame.
+function handleVisibilityChange(): void {
+  const hidden = documentIsHidden()
+  if (hidden && flushHandleKind !== 'frame') return
+  cancelScheduledFlush()
+  if (pendingInbound.length === 0) return
+  if (hidden) scheduleFlush()
+  else flushPending()
+}
+
+if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
+  document.addEventListener('visibilitychange', handleVisibilityChange)
 }
 
 function flushPending(): void {
@@ -286,27 +340,13 @@ function flushPending(): void {
 
 function clearPendingInbound(): void {
   pendingInbound.length = 0
-  if (flushHandle) {
-    if (typeof cancelAnimationFrame !== 'undefined') {
-      cancelAnimationFrame(flushHandle)
-    } else {
-      clearTimeout(flushHandle)
-    }
-    flushHandle = 0
-  }
+  cancelScheduledFlush()
 }
 
 /** Test-only helper: synchronously flush any pending inbound messages.
- *  Production code should never call this — the rAF loop owns timing. */
+ *  Production code should never call this — the scheduled flush owns timing. */
 export function flushPendingInbound(): void {
-  if (flushHandle) {
-    if (typeof cancelAnimationFrame !== 'undefined') {
-      cancelAnimationFrame(flushHandle)
-    } else {
-      clearTimeout(flushHandle)
-    }
-    flushHandle = 0
-  }
+  cancelScheduledFlush()
   flushPending()
 }
 

--- a/dashboard/src/router.test.ts
+++ b/dashboard/src/router.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import {
+  initRouter,
   navigate,
   navigateToPost,
   replaceRoute,
@@ -451,5 +452,41 @@ describe('redirect-ledger contract (RFC-0048 §4.3)', () => {
       }
     }
     expect(empty).toEqual([])
+  })
+})
+
+// A URL that names a destination must reach it or say it cannot. Landing on
+// overview is a silent answer: the person who wrote the link concludes the
+// screen does not exist. Observed while looking for the Internal Agents panel,
+// which was rendering fine the whole time.
+describe('deep links written by hand', () => {
+  function bootWith(pathname: string, search: string, hash = ''): void {
+    window.history.replaceState(null, '', `${pathname}${search}${hash}`)
+    initRouter()
+  }
+
+  it('resolves the tab from a query on /dashboard', () => {
+    bootWith('/dashboard', '?tab=monitoring&section=internal-agents')
+    expect(route.value.tab).toBe('monitoring')
+    expect(route.value.params.section).toBe('internal-agents')
+  })
+
+  // The server answers the dashboard at the root too, so the same link written
+  // without /dashboard is the same request.
+  it('resolves the tab from a query on the root path', () => {
+    bootWith('/', '?tab=monitoring&section=internal-agents')
+    expect(route.value.tab).toBe('monitoring')
+    expect(route.value.params.section).toBe('internal-agents')
+  })
+
+  it('still lands on overview when the query names no tab', () => {
+    bootWith('/dashboard', '?section=internal-agents')
+    expect(route.value.tab).toBe('overview')
+  })
+
+  it('keeps the canonical hash form working', () => {
+    bootWith('/dashboard', '', '#monitoring?section=internal-agents')
+    expect(route.value.tab).toBe('monitoring')
+    expect(route.value.params.section).toBe('internal-agents')
   })
 })

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -205,11 +205,23 @@ function hashLooksLikeQuery(rawHashBody: string): boolean {
 
 function parsePathname(pathname: string, search: string): RouteState | null {
   const segments = pathname.replace(/^\/+/, '').split('/').filter(Boolean)
+  // The server serves the dashboard at both / and /dashboard, so a link
+  // written as /?tab=monitoring is the same request as /dashboard?tab=…. It
+  // used to fall through to the default route, which is a silent answer to a
+  // URL that named a destination.
+  if (segments.length === 0) {
+    return parseSegments([], parseParams(search.replace(/^\?/, '')))
+  }
   if (segments[0] !== 'dashboard') return null
 
   const sub = segments.slice(1)
-  if (sub.length === 0) return { ...DEFAULT_ROUTE, params: parseParams(search.replace(/^\?/, '')) }
   if (sub[0] === 'assets' || sub[0] === 'credits') return null
+  // /dashboard?tab=monitoring&section=… is the shape a person writes by hand,
+  // and it used to land on overview: this returned DEFAULT_ROUTE with the
+  // params attached, so `tab` rode along as a parameter of the wrong tab.
+  // parseSegments already resolves a tab from the query when the path carries
+  // none, so hand it the empty segment list rather than answering first.
+  if (sub.length === 0) return parseSegments([], parseParams(search.replace(/^\?/, '')))
 
   const params = parseParams(search.replace(/^\?/, ''))
   return parseSegments(sub, params)


### PR DESCRIPTION
멀쩡히 동작하는 화면이 사용자에게 "안 보인다"로 도달하는 세 경로. 셋 다 서버·데이터는 정상이고, 클라이언트가 스스로 막았다.

## 1. "토큰 없음"을 "인증 오류"로 표시

`auth-status` 가 `auth_error_code` 유무만 보고 빨간 `Auth error` 배지를 세웠다. 로그인 전 정상 상태인 `missing_token` 도 여기 걸려, 처음 연 사용자에게 고장으로 보인다.

`missing_token` 은 자격증명 거부가 아니라 아직 제출되지 않은 상태다. 거부(`credentialRejected`)와 미제출을 분리하고, 후자는 `Login required` 로 안내한다.

## 2. 손으로 쓴 딥링크가 이름한 화면에 도달하지 못함

서버는 대시보드를 `/` 와 `/dashboard` 양쪽에서 서빙한다. `/?tab=monitoring&section=…` 과 `/dashboard?tab=…` 은 사람이 실제로 쓰는 형태인데, `parsePathname` 이 둘 다 `null` 로 흘려보내 `#overview` 로 착지했다. 목적지를 명시한 URL에 조용한 답을 준 것이다.

`parseSegments` 는 경로에 탭이 없으면 쿼리에서 탭을 해석한다. 먼저 답하지 말고 그 함수에 빈 세그먼트를 넘긴다.

## 3. 페인트하지 않는 탭에서 WS 인바운드가 전면 정지

`requestAnimationFrame` 은 페인트 프리미티브다. 숨겨진 탭은 페인트하지 않으므로 rAF 가 **아예 발화하지 않는다** — 백그라운드 Chrome 탭에서 3.4초간 실측 0회(정상 ~180회). 인바운드 WebSocket 프레임 전부가 그 뒤에 스케줄되어 있었다.

결과는 백그라운드 대시보드가 세션을 수립하지 못하는 것이다. `dashboard/hello` 응답이 도착해 `pendingInbound` 에 들어가고, `sendRpc` 가 `DASHBOARD_WS_RPC_TIMEOUT_MS`(30초)에 도달할 때까지 그대로 있는다. 소켓이 닫히고 재연결이 같은 벽에 부딪힌다. transport beacon 은 탭이 숨겨져 있는 내내 `Client WS · handshaking` 을 표시한다.

**모니터링 대시보드는 백그라운드 탭에 열어두는 게 설계된 사용 형태다.** 이건 예외 경로가 아니라 주 경로였다.

숨겨진 동안에는 배칭할 페인트가 없으므로 타이머로 flush 한다. 브라우저는 숨겨진 페이지의 타이머를 약 1 Hz 로 클램프하며, 이는 RPC 타임아웃의 두 자릿수 안쪽이다. 다시 보이면 다음 프레임을 기다리지 않고 즉시 flush 하고, 탭이 숨겨질 때 남아 있던 프레임 콜백은 취소 후 재무장한다 — 그 핸들이 남아 있으면 이후 모든 `scheduleFlush()` 가 no-op 이 되어 두 번째 경로로 큐가 고착된다.

취소는 이제 핸들의 출처로 호출을 고른다. 이전에는 `cancelAnimationFrame` 이 정의돼 있기만 하면 그걸 썼는데, 타이머 핸들에 주면 아무것도 취소하지 않는다. 이제 두 경로가 같은 환경에서 동시에 살아 있다.

## 검증

기존 테스트는 전부 `MockWebSocket.receive()` 로 전달하는데, 이 헬퍼가 `flushPendingInbound()` 를 직접 호출한다. 그래서 `scheduleFlush()` 는 한 번도 실행된 적이 없고, 고착이 여기서 보이지 않았다.

추가한 두 케이스는 실제 스케줄러를 돌린다. 수정을 되돌린 상태에서 둘 다 실패하는 것을 먼저 확인했다:

```
negative control (dashboard-ws.ts stash):
  × completes the handshake in a tab that never paints
  × does not strand the queue on a frame scheduled before the tab hid
  Tests  2 failed | 49 skipped (51)
```

수정 후:

```
dashboard  Test Files 639 passed (639)  Tests 8849 passed (8849)
tsc --noEmit  exit=0
eslint        exit=0
```

## 재현

```js
// 백그라운드 탭에서
let raf = 0; const step = () => { raf++; requestAnimationFrame(step) }
requestAnimationFrame(step)
setTimeout(() => console.log({ raf, hidden: document.hidden }), 3000)
// → { raf: 0, hidden: true }
```

RFC-WAIVED: 세 건 모두 기존 계약을 바꾸지 않는 클라이언트 결함 수정이다. credential/identity/operator/sandbox/hooks 어느 subsystem 도 건드리지 않는다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
