### PR TITLE
fix(task): refuse an evidence reference the store cannot read, at submit

### DIFF
--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -304,6 +304,19 @@ let parse_keeper_task_done_evidence_refs args =
          | `String ref_ :: rest ->
            if Task.Completion_review.blank_evidence_ref ref_
            then Error "evidence_refs must contain only non-empty strings."
+           else if Task.Completion_review.unresolvable_evidence_ref ref_
+           then
+             (* The masc_transition boundary refuses the same entries; this
+                parser states it in keeper vocabulary. Without it the store
+                snapshots a payload-free invalid reference and the reviewer
+                rejects for missing evidence, which reads as a verdict on the
+                work rather than on the reference form. *)
+             Error
+               (Printf.sprintf
+                  "evidence_refs entries must be %s. Nothing else can be read \
+                   back at review. Wrap a Board post id, a commit, a URL, or \
+                   any narrative as note:<text>."
+                  Task.Completion_review.resolvable_evidence_ref_forms)
            else collect (String.trim ref_ :: acc) rest
          | _ :: _ -> Error "evidence_refs must be an array of non-empty strings."
        in

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -315,8 +315,9 @@ let parse_keeper_task_done_evidence_refs args =
                (Printf.sprintf
                   "evidence_refs entries must be %s. Nothing else can be read \
                    back at review. Wrap a Board post id, a commit, a URL, or \
-                   any narrative as note:<text>."
-                  Task.Completion_review.resolvable_evidence_ref_forms)
+                   any narrative as %s."
+                  Task.Completion_review.resolvable_evidence_ref_forms
+                  Task.Completion_review.note_evidence_ref_form)
            else collect (String.trim ref_ :: acc) rest
          | _ :: _ -> Error "evidence_refs must be an array of non-empty strings."
        in

--- a/lib/task/tool_task_args.ml
+++ b/lib/task/tool_task_args.ml
@@ -129,6 +129,28 @@ let parse_handoff_context ~(agent_name : string)
                   \"evidence_refs\": [\"%s\"]}."
                  (Masc_domain.task_action_to_string action)
                  handoff_example_evidence_ref)
+          else if
+            (* The verification store would snapshot these as payload-free
+               invalid references, and the reviewer reads an invalid reference
+               as unavailable evidence. Refusing here names the accepted forms
+               while the caller can still act; accepting turns one malformed
+               reference into a resubmit loop that no rejection reason
+               explains. *)
+            List.exists Tool_task_completion_review.unresolvable_evidence_ref
+              handoff_context.evidence_refs
+          then
+            Error
+              (Printf.sprintf
+                 "handoff_context.evidence_refs entries must be %s for \
+                  action=%s. The verification store cannot read any other \
+                  form, and the reviewer sees it as missing evidence. Wrap \
+                  narrative, a Board post id, a commit, or a URL as %s. \
+                  Example: {\"summary\": \"tests green\", \"evidence_refs\": \
+                  [\"%s\"]}."
+                 Tool_task_completion_review.resolvable_evidence_ref_forms
+                 (Masc_domain.task_action_to_string action)
+                 "note:<text>"
+                 handoff_example_evidence_ref)
           else if String.equal summary "" then
             if summary_required then
               Error

--- a/lib/task/tool_task_args.ml
+++ b/lib/task/tool_task_args.ml
@@ -149,7 +149,7 @@ let parse_handoff_context ~(agent_name : string)
                   [\"%s\"]}."
                  Tool_task_completion_review.resolvable_evidence_ref_forms
                  (Masc_domain.task_action_to_string action)
-                 "note:<text>"
+                 Tool_task_completion_review.note_evidence_ref_form
                  handoff_example_evidence_ref)
           else if String.equal summary "" then
             if summary_required then

--- a/lib/task/tool_task_completion_review.ml
+++ b/lib/task/tool_task_completion_review.ml
@@ -33,6 +33,8 @@ let resolvable_evidence_ref_forms =
   String.concat " or " Workspace_verification_store.resolvable_reference_forms
 ;;
 
+let note_evidence_ref_form = Workspace_verification_store.note_reference_form
+
 let non_empty_trimmed_strings values =
   values
   |> List.filter_map (fun value ->

--- a/lib/task/tool_task_completion_review.ml
+++ b/lib/task/tool_task_completion_review.ml
@@ -12,6 +12,27 @@
    semantics locally on raw JSON for keeper-vocabulary error messages. *)
 let blank_evidence_ref value = String.equal (String.trim value) ""
 
+(* The same boundary rule, one step further: an entry the verification store
+   cannot read is refused where the caller can still fix it, instead of being
+   snapshotted as [Evidence_invalid_reference] and surfacing later as a
+   reviewer REJECT the submitter cannot act on. Live case (2026-08-05):
+   task-174 resubmitted the same `board:p-…` reference and was rejected 59
+   times in two hours before one approval — 49% of every rejection the
+   completion authority issued. The shape decision stays the store's; this is
+   a call into it, not a second copy of the accepted prefixes. *)
+let unresolvable_evidence_ref value =
+  match
+    Workspace_verification_store.classify_evidence_reference (String.trim value)
+  with
+  | Workspace_verification_store.Unresolvable_reference -> true
+  | Workspace_verification_store.Artifact_reference _
+  | Workspace_verification_store.Note_reference _ -> false
+;;
+
+let resolvable_evidence_ref_forms =
+  String.concat " or " Workspace_verification_store.resolvable_reference_forms
+;;
+
 let non_empty_trimmed_strings values =
   values
   |> List.filter_map (fun value ->

--- a/lib/task/tool_task_completion_review.mli
+++ b/lib/task/tool_task_completion_review.mli
@@ -5,6 +5,17 @@ val blank_evidence_ref : string -> bool
     predicate for evidence-ref boundary checks (RFC-0337 decision 4):
     boundaries reject flagged entries instead of silently dropping them. *)
 
+val unresolvable_evidence_ref : string -> bool
+(** [true] when {!Workspace_verification_store.classify_evidence_reference}
+    answers [Unresolvable_reference] — the store would snapshot the entry as a
+    payload-free invalid reference, which the reviewer must then read as
+    unavailable evidence. Same boundary rule as {!blank_evidence_ref}: refuse
+    it where the caller can still correct it. *)
+
+val resolvable_evidence_ref_forms : string
+(** The accepted reference forms, joined for an error message that has to tell
+    a caller what to write instead. *)
+
 val non_empty_trimmed_strings : string list -> string list
 
 val concrete_verification_evidence_refs :

--- a/lib/task/tool_task_completion_review.mli
+++ b/lib/task/tool_task_completion_review.mli
@@ -16,6 +16,12 @@ val resolvable_evidence_ref_forms : string
 (** The accepted reference forms, joined for an error message that has to tell
     a caller what to write instead. *)
 
+val note_evidence_ref_form : string
+(** The note form alone, for the sentence that tells a caller how to carry
+    narrative. Taken from
+    {!Workspace_verification_store.note_reference_form} so the prose cannot
+    name a prefix the classifier no longer matches. *)
+
 val non_empty_trimmed_strings : string list -> string list
 
 val concrete_verification_evidence_refs :

--- a/lib/tool_surface/tool_shard_types_schemas_taskboard.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_taskboard.ml
@@ -159,12 +159,17 @@ let taskboard_tools : Masc_domain.tool_schema list =
                       ; "minItems", `Int 1
                       ; ( "description"
                         , `String
-                            "Trusted references substantiating completion. At least \
-                             one reference must validate against local state: an \
-                             existing base-path file/file:// URI, local git commit \
-                             hash, or .masc trace/turn/receipt ref that resolves on \
-                             disk. Result text, URLs, PR numbers, and trace-shaped \
-                             labels alone do not satisfy the task-completion gate." )
+                            "Trusted references substantiating completion. Every \
+                             entry must be artifact:<producer-root-relative-path> \
+                             or note:<text>; nothing else can be read back at \
+                             review, so this tool refuses it here rather than \
+                             letting the reviewer see missing evidence. An \
+                             artifact: path is opened and snapshotted, and that \
+                             is what satisfies the completion gate. A Board post \
+                             id, a commit, a PR number, or a file:// URI is \
+                             narrative until something opens it: pass it as \
+                             note:<text> next to an artifact: entry, never on \
+                             its own." )
                       ] )
                 ; ( "notes"
                   , `Assoc

--- a/lib/tool_surface/tool_shard_types_schemas_taskboard.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_taskboard.ml
@@ -129,10 +129,12 @@ let taskboard_tools : Masc_domain.tool_schema list =
          trusted evidence_refs. The task must be claimed by you. This does not \
          make the task done: it moves to awaiting_verification and waits for a \
          completion authority's verdict, which no Keeper can produce. It also \
-         does not hold your next claim while it waits. The completion gate \
-         accepts the submission only when evidence_refs contains a \
-         reviewer-inspectable PR, commit, trace, receipt, or URL reference; \
-         pure-placeholder results ('done', 'ok', etc.) are rejected."
+         does not hold your next claim while it waits. Every evidence_refs \
+         entry must be artifact:<producer-root-relative-path> or note:<text>; \
+         this tool refuses any other form at submit. Only an artifact: path is \
+         opened and snapshotted for the reviewer — a note: entry is text the \
+         reviewer reads but cannot inspect. Pure-placeholder results ('done', \
+         'ok', etc.) are rejected."
     ; input_schema =
         `Assoc
           [ "type", `String "object"

--- a/lib/workspace/workspace_verification_store.ml
+++ b/lib/workspace/workspace_verification_store.ml
@@ -515,6 +515,32 @@ let strip_prefix ~prefix value =
          (String.length value - String.length prefix))
   else None
 
+(* The shape this store can read, decided without touching the filesystem.
+   [snapshot_submitted_evidence_item] below is the only producer of evidence
+   snapshots and answers [Evidence_invalid_reference] for anything else, so the
+   submit boundaries ask this instead of restating the prefixes: a reference
+   form added here reaches every caller, and one cannot be accepted at submit
+   and then be unreadable at review. *)
+type reference_form =
+  | Artifact_reference of string
+  | Note_reference of string
+  | Unresolvable_reference
+
+let classify_evidence_reference reference =
+  match strip_prefix ~prefix:artifact_reference_prefix reference with
+  | Some relative_path -> Artifact_reference relative_path
+  | None ->
+    (match strip_prefix ~prefix:note_reference_prefix reference with
+     | Some note when not (String.equal (String.trim note) "") ->
+       Note_reference note
+     | Some _ | None -> Unresolvable_reference)
+;;
+
+let resolvable_reference_forms =
+  [ artifact_reference_prefix ^ "<producer-root-relative-path>"
+  ; note_reference_prefix ^ "<text>"
+  ]
+
 let valid_producer_relative_path path =
   Filename.is_relative path
   && not (String.equal path "")
@@ -544,18 +570,15 @@ let inspect_producer_relative_artifact ~base_path ~worker ~reference relative_pa
       Evidence_artifact { reference; content; bytes; truncated }
 
 let snapshot_submitted_evidence_item ~base_path ~worker reference =
-  match strip_prefix ~prefix:artifact_reference_prefix reference with
-  | Some relative_path ->
+  match classify_evidence_reference reference with
+  | Artifact_reference relative_path ->
     inspect_producer_relative_artifact
       ~base_path
       ~worker
       ~reference
       relative_path
-  | None ->
-    (match strip_prefix ~prefix:note_reference_prefix reference with
-     | Some note when not (String.equal (String.trim note) "") ->
-       Evidence_note note
-     | Some _ | None -> Evidence_invalid_reference)
+  | Note_reference note -> Evidence_note note
+  | Unresolvable_reference -> Evidence_invalid_reference
 
 let snapshot_submitted_evidence_json ~base_path ~worker references =
   `List

--- a/lib/workspace/workspace_verification_store.ml
+++ b/lib/workspace/workspace_verification_store.ml
@@ -536,10 +536,12 @@ let classify_evidence_reference reference =
      | Some _ | None -> Unresolvable_reference)
 ;;
 
-let resolvable_reference_forms =
-  [ artifact_reference_prefix ^ "<producer-root-relative-path>"
-  ; note_reference_prefix ^ "<text>"
-  ]
+let artifact_reference_form =
+  artifact_reference_prefix ^ "<producer-root-relative-path>"
+;;
+
+let note_reference_form = note_reference_prefix ^ "<text>"
+let resolvable_reference_forms = [ artifact_reference_form; note_reference_form ]
 
 let valid_producer_relative_path path =
   Filename.is_relative path

--- a/lib/workspace/workspace_verification_store.mli
+++ b/lib/workspace/workspace_verification_store.mli
@@ -93,6 +93,11 @@ val classify_evidence_reference : string -> reference_form
     a reference cannot be admitted at submit and then be unreadable at review,
     and a new form added here reaches every caller. *)
 
+val artifact_reference_form : string
+val note_reference_form : string
+(** One accepted form each, spelled from the prefix this module matches on, so
+    an error message naming a single form cannot drift from the classifier. *)
+
 val resolvable_reference_forms : string list
 (** The accepted forms, spelled for an error message that has to tell a caller
     what to write instead. *)

--- a/lib/workspace/workspace_verification_store.mli
+++ b/lib/workspace/workspace_verification_store.mli
@@ -79,6 +79,24 @@ val read_regular_file_prefix :
     a live read and its snapshot cannot disagree about the same file: one byte
     cap, one policy for a multi-byte sequence cut by that cap, one failure
     vocabulary. *)
+(** The reference shapes this store can read, decided without touching the
+    filesystem. *)
+type reference_form =
+  | Artifact_reference of string
+  | Note_reference of string
+  | Unresolvable_reference
+
+val classify_evidence_reference : string -> reference_form
+(** Shape of an evidence reference as {!snapshot_submitted_evidence_json} will
+    read it. This module is the only producer of evidence snapshots, so the
+    submit boundaries call this rather than restating the accepted prefixes:
+    a reference cannot be admitted at submit and then be unreadable at review,
+    and a new form added here reaches every caller. *)
+
+val resolvable_reference_forms : string list
+(** The accepted forms, spelled for an error message that has to tell a caller
+    what to write instead. *)
+
 val snapshot_submitted_evidence_json :
   base_path:string ->
   worker:string ->

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -743,8 +743,18 @@ let () = test "handle_transition_release_requires_handoff_for_strict_task" (fun 
               [
                 ("summary", `String "blocked on integration fixture");
                 ("next_step", `String "reproduce with real fixture");
+                (* Was ["task-001"; "session:test"]. Neither is a form the
+                   verification store can read, so both were snapshotted as
+                   payload-free invalid references and this case asserted
+                   success on evidence that is invisible at review. The
+                   boundary now refuses them; the case keeps its subject
+                   (strict release requires a handoff) with references that
+                   survive to the reviewer. *)
                 ( "evidence_refs",
-                  `List [ `String "task-001"; `String "session:test" ] );
+                  `List
+                    [ `String "note:task-001"
+                    ; `String "note:session test transcript"
+                    ] );
               ] );
         ])
   in
@@ -788,6 +798,73 @@ let () = test "handle_transition_rejects_blank_evidence_ref_entries" (fun () ->
   assert (not (Tool_result.is_success result));
   assert ((Tool_result.failure_class result) = Some Tool_result.Workflow_rejection);
   assert (str_contains (Tool_result.message result) "must contain only non-empty strings")
+)
+
+(* The same boundary rule for a reference the verification store cannot read.
+   Accepting it snapshots a payload-free invalid reference, and the reviewer
+   reads that as unavailable evidence — a verdict the submitter cannot act on
+   because nothing names the reference form as the fault. Live: task-174 resent
+   the same `board:p-…` entry and drew 59 rejections in two hours. *)
+let () = test "handle_transition_rejects_unresolvable_evidence_ref_entries" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ =
+    Task.Tool.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc [ ("title", `String "Unresolvable evidence task") ])
+  in
+  let _ = Task.Tool.handle_claim ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [ ("task_id", `String "task-001") ]) in
+  let reject reference =
+    let result =
+      Task.Tool.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
+        (`Assoc
+          [
+            ("task_id", `String "task-001");
+            ("action", `String "release");
+            ( "handoff_context",
+              `Assoc
+                [
+                  ("summary", `String "handing off");
+                  ("evidence_refs", `List [ `String reference ]);
+                ] );
+          ])
+    in
+    assert (not (Tool_result.is_success result));
+    assert ((Tool_result.failure_class result) = Some Tool_result.Workflow_rejection);
+    assert (str_contains (Tool_result.message result) "note:<text>")
+  in
+  (* Every form the live workspace actually submitted and had rejected. *)
+  reject "board:p-b8655a197dcf2f5da46655e10b3acbd1";
+  reject "file:///Users/x/repo/out.diff";
+  reject "https://github.com/o/r/pull/1";
+  reject "artifacts/relative/but/unprefixed.md";
+  reject "task-002:approved"
+)
+
+let () = test "handle_transition_accepts_resolvable_evidence_ref_forms" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ =
+    Task.Tool.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc [ ("title", `String "Resolvable evidence task") ])
+  in
+  let _ = Task.Tool.handle_claim ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [ ("task_id", `String "task-001") ]) in
+  let result =
+    Task.Tool.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc
+        [
+          ("task_id", `String "task-001");
+          ("action", `String "release");
+          ( "handoff_context",
+            `Assoc
+              [
+                ("summary", `String "handing off");
+                ( "evidence_refs"
+                , `List
+                    [ `String "artifact:out/report.md"
+                    ; `String "note:board post p-b8655a19 carries the rationale"
+                    ] );
+              ] );
+        ])
+  in
+  assert (Tool_result.is_success result)
 )
 
 let () = test "handle_transition_entry_action_rejects_blank_evidence_ref_entries" (fun () ->


### PR DESCRIPTION
## What

The verification store reads exactly two evidence-reference forms. Everything
else becomes a payload-free `Evidence_invalid_reference`, and `verification.md`
tells the reviewer to read an unreadable item as unavailable evidence and
REJECT. Refuse those references at submit, where the caller can still fix them.

Implements direction 3 of #27278.

## The loop this closes

Live workspace, 2026-08-05: `task-174` resubmitted the same
`board:p-b8655a19…` reference and drew **59 rejections in two hours** before one
approval — **49% of every rejection the completion authority has issued**.

| completion-authority verdicts | n |
|---|---:|
| APPROVE | 58 |
| REJECT | 121 |
| …of which `task-174` alone | **59** |

Rejections per task across 86 judged tasks: `0×34 · 1×44 · 2×4 · 3×2 · 4×1 · 59×1`.

The rejection reasons named the symptom exactly — "The only inspectable
artifact (the board post with the preservation rationale) is marked
`artifact_unreadable`" — and the keeper had no way to learn that the *reference
form*, not the work, was the fault.

## How

`Workspace_verification_store` now exposes the shape decision it was already
making inline:

```ocaml
type reference_form =
  | Artifact_reference of string
  | Note_reference of string
  | Unresolvable_reference

val classify_evidence_reference : string -> reference_form
```

`snapshot_submitted_evidence_item` calls it, and so do both submit boundaries —
the `masc_transition` handoff parser and the `keeper_task_done` parser, which
`tool_task_completion_review.ml`'s own comment already names as the two
enforcement sites for the sibling `blank_evidence_ref` rule (RFC-0337 decision
4: "boundaries reject flagged entries instead of silently dropping them").

Neither boundary restates the accepted prefixes. A form added to the store
reaches both, and a reference cannot be admitted at submit and unreadable at
review.

## Schema correction

`keeper_task_done` advertised forms the store never accepted:

> an existing base-path **file/file:// URI**, local git **commit hash**, or
> **.masc trace/turn/receipt ref** that resolves on disk

The store deliberately refuses absolute paths — its own `.mli` says "Bare and
absolute references are persisted as a payload-free typed invalid-reference
item". Those were invalid on arrival. The description now states the two forms
and says to carry a Board post id, commit, PR number, or `file://` URI as
`note:<text>` beside an `artifact:` entry.

`masc_transition`'s description was already correct ("Bare and absolute paths
are invalid") and is unchanged.

## Blast radius — measured, not assumed

Live backlog, 367 `handoff_context.evidence_refs` entries:

| form | n |
|---|---:|
| `note:` | 191 |
| `artifact:` | 104 |
| `file:` | 38 |
| bare | 27 |
| `task-NNN:` | 5 |
| `https:` | 1 |
| ISO timestamp | 2 |

**72 (20%) are neither form.** All 72 are already unreadable at review — this
moves their failure from a reviewer verdict the submitter cannot act on, to the
call that can still fix it, with a message naming what to write instead.

## Test fixture that encoded the old behaviour

`test_tool_task_coverage`'s strict-release case submitted `["task-001";
"session:test"]` and asserted success — evidence invisible to the reviewer. Its
subject (strict release requires a handoff) is unchanged; the fixture now uses
references that survive to review, with a comment saying why.

Two new cases pin the boundary, covering every form the live workspace actually
submitted (`board:`, `file://`, `https://`, bare path, `task-NNN:`) plus the
accepted pair.

## Verification

```
dune build --force @test/runtest-test_tool_task_coverage \
                   @test/runtest-test_tool_shard_coverage
→ 89 + 13 tests, all pass
```

`test_keeper_task_outcomes`, `test_keeper_accountability`,
`test_operator_control_judgment` have pre-existing local failures
(accountability 2; outcomes 2, 3, 8, 9). Verified byte-identical on
`origin/main` by reverting all eight files and re-running — the failure sets
`diff` clean.

`scripts/check-ssot.sh` clean, run from the worktree root.

RFC-WAIVED: one boundary check that refuses references the store already
refuses, its SSOT accessor, and the schema text that advertised the wrong
forms. No new field, no state machine, no credential/identity/operator surface.
The only behaviour change is where an already-doomed reference fails.
