### PR TITLE
refactor(dashboard): stop guessing which action answered which incident

### DIFF
--- a/dashboard/src/mission-normalizers-entities.ts
+++ b/dashboard/src/mission-normalizers-entities.ts
@@ -74,7 +74,6 @@ export function normalizeAttentionQueueItem(raw: unknown): DashboardMissionAtten
     summary,
     target_type: targetType,
     target_id: asString(raw.target_id) ?? null,
-    top_action: normalizeRecommendedAction(raw.top_action),
     related_agent_names: asStringArray(raw.related_agent_names),
     evidence,
     evidence_preview: asStringArray(raw.evidence_preview),

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -46,7 +46,6 @@ export interface DashboardMissionAttentionQueueItem {
   summary: string
   target_type: string
   target_id?: string | null
-  top_action?: OperatorRecommendedAction | null
   related_agent_names: string[]
   evidence?: unknown
   evidence_preview: string[]

--- a/lib/dashboard/dashboard_briefing.ml
+++ b/lib/dashboard/dashboard_briefing.ml
@@ -2,7 +2,6 @@ include Dashboard_utils
 
 type attention_context = Dashboard_briefing_assembly.attention_context = {
   severity : string;
-  has_action : bool;
   related_agent_names : string list;
   json : Yojson.Safe.t;
 }
@@ -11,29 +10,6 @@ let top_item items =
   match items with
   | item :: _ -> item
   | [] -> `Null
-
-let matching_action_for_incident incident actions =
-  let target_type = string_field "target_type" incident in
-  let target_id = String_util.trim_to_option (string_field "target_id" incident) in
-  let candidates =
-    actions
-    |> List.filter (fun action ->
-           let action_target_type = string_field "target_type" action in
-           let action_target_id = String_util.trim_to_option (string_field "target_id" action) in
-           String.equal action_target_type target_type
-           &&
-           match target_id, action_target_id with
-           | Some left, Some right -> String.equal left right
-           | None, None -> true
-           | _ -> false)
-  in
-  match
-    List.find_opt
-      (Dashboard_briefing_assembly.action_matches_incident incident)
-      candidates
-  with
-  | Some action -> Some action
-  | None -> (match candidates with action :: _ -> Some action | [] -> None)
 
 let rec evidence_preview_strings json =
   match json with
@@ -51,7 +27,7 @@ let is_internal_attention incident =
   Operator_digest_types.is_workspace_target_type
     (string_field "target_type" incident)
 
-let build_attention_queue incidents actions =
+let build_attention_queue incidents =
   let public_incidents =
     incidents
     |> List.filter (fun incident -> not (is_internal_attention incident))
@@ -71,7 +47,6 @@ let build_attention_queue incidents actions =
                | Some actor -> [ actor ]
                | None -> [])
            in
-           let top_action = matching_action_for_incident incident actions in
            let id =
              Printf.sprintf "%s:%s:%s" kind target_type
                (match target_id with Some value -> value | None -> "none")
@@ -79,7 +54,6 @@ let build_attention_queue incidents actions =
            Some
              {
                severity;
-               has_action = Option.is_some top_action;
                related_agent_names;
                json =
                  `Assoc
@@ -90,16 +64,16 @@ let build_attention_queue incidents actions =
                      ("summary", `String summary);
                      ("target_type", `String target_type);
                      ("target_id", Json_util.string_opt_to_json target_id);
-                     ("top_action", Json_util.option_to_yojson (fun value -> value) top_action);
                      ("related_agent_names", `List (List.map (fun value -> `String value) related_agent_names));
                      ("evidence", member_assoc "evidence" incident);
                      ("evidence_preview", `List (List.map (fun value -> `String value) (evidence_preview_strings (member_assoc "evidence" incident))));
                    ];
              })
-  |> List.sort (fun left right ->
-         let by_severity = Int.compare (severity_rank right.severity) (severity_rank left.severity) in
-         if by_severity <> 0 then by_severity
-         else Bool.compare right.has_action left.has_action)
+  (* Stable, so incidents of equal severity keep the operator digest's own
+     order. The previous tie-break ranked "has a matching action" first, and
+     that flag was a guess (see {!Dashboard_briefing_assembly}). *)
+  |> List.stable_sort (fun left right ->
+         Int.compare (severity_rank right.severity) (severity_rank left.severity))
 
 
 type briefing_projection = {
@@ -171,7 +145,7 @@ let build_projection ?actor ~config ~sw ~clock
              (severity_rank (string_field ~default:"ok" "severity" left)))
   in
   let recommended_actions = list_field "recommended_actions" digest_json in
-  let attention_queue = build_attention_queue incidents recommended_actions in
+  let attention_queue = build_attention_queue incidents in
   let keeper_items =
     match member_assoc "keepers" snapshot_json |> member_assoc "items" with
     | `List items -> items

--- a/lib/dashboard/dashboard_briefing_agents.ml
+++ b/lib/dashboard/dashboard_briefing_agents.ml
@@ -7,7 +7,6 @@ include Dashboard_utils
 
 type attention_context = {
   severity : string;
-  has_action : bool;
   related_agent_names : string list;
   json : Yojson.Safe.t;
 }

--- a/lib/dashboard/dashboard_briefing_agents.mli
+++ b/lib/dashboard/dashboard_briefing_agents.mli
@@ -30,7 +30,6 @@ val dedup_strings : string list -> string list
 
 type attention_context = {
   severity : string;
-  has_action : bool;
   related_agent_names : string list;
   json : Yojson.Safe.t;
 }

--- a/lib/dashboard/dashboard_briefing_assembly.ml
+++ b/lib/dashboard/dashboard_briefing_assembly.ml
@@ -114,54 +114,6 @@ let is_internal_action action =
   Operator_digest_types.is_workspace_target_type
     (string_field "target_type" action)
 
-let incident_action_types kind =
-  match kind with
-  | "spawn_failure_present" -> [ "task_inject" ]
-  | "detached_actor_present"
-  | "empty_note_turn_present"
-  | "low_confidence_routing"
-  | "routing_escalation_present" -> [ "broadcast" ]
-  | "planned_worker_without_turn" -> [ "task_inject"; "broadcast" ]
-  | "local64_role_gap" -> [ "task_inject" ]
-  | "stalled_session" -> [ "namespace_pause" ]
-  | "command_issue_pressure"
-  | "command_routing_confidence"
-  | "command_quality_per_token"
-  | "command_verification_gate_failures"
-  | "command_rework_rate"
-  | "command_artifact_scope_drift"
-  | "command_cache_contention"
-  | "command_speculative_posture"
-  | "intent_blocked"
-  | "intent_handoff_ready" -> [ "broadcast" ]
-  | _ -> []
-
-let action_matches_incident incident action =
-  let target_type = string_field "target_type" incident in
-  let target_id = String_util.trim_to_option (string_field "target_id" incident) in
-  let action_target_type = string_field "target_type" action in
-  let action_target_id = String_util.trim_to_option (string_field "target_id" action) in
-  let same_target =
-    String.equal action_target_type target_type
-    &&
-    match target_id, action_target_id with
-    | Some left, Some right -> String.equal left right
-    | None, None -> true
-    | _ -> false
-  in
-  if not same_target then false
-  else
-    let incident_summary = normalized_text_key (string_field "summary" incident) in
-    let action_reason = normalized_text_key (string_field "reason" action) in
-    let reason_matches =
-      incident_summary <> "" && action_reason <> ""
-      && String.equal incident_summary action_reason
-    in
-    if reason_matches then true
-    else
-      let action_type = string_field "action_type" action in
-      List.mem action_type (incident_action_types (string_field "kind" incident))
-
 let build_keeper_briefs (config : Workspace.config) (keepers : Yojson.Safe.t list) =
   let all_entries = Keeper_registry.all ~base_path:config.base_path () in
   let registry_lookup name =
@@ -240,12 +192,20 @@ let build_keeper_briefs (config : Workspace.config) (keepers : Yojson.Safe.t lis
          else Float.compare right.last_seen_ts left.last_seen_ts)
   |> List.map (fun (row : keeper_context) -> row.json)
 
+(* An attention row and an action row are separate signals. The operator
+   digest gives no link between them: [recommended_action] is free-form JSON
+   an operator judgment wrote, and an attention item is a read-model
+   observation, so nothing in either says which one answers which. This used
+   to guess -- normalized-prose equality of the incident summary against the
+   action reason, else a hand-written kind -> action_type table -- and stamp
+   the single workspace recommendation onto every incident whose kind the
+   table happened to list. Both rows are still emitted; neither claims the
+   other. *)
 let build_internal_signals incidents actions =
   let internal_incidents =
     incidents
     |> List.filter is_internal_attention
     |> List.map (fun incident ->
-           let action = List.find_opt (action_matches_incident incident) actions in
            {
              pressure_rank = severity_rank (string_field ~default:"warn" "severity" incident);
              last_seen_ts = 0.0;
@@ -259,22 +219,13 @@ let build_internal_signals incidents actions =
                    ("target_type", member_assoc "target_type" incident);
                    ("target_id", member_assoc "target_id" incident);
                    ("attention", incident);
-                   ("action", Json_util.option_to_yojson (fun value -> value) action);
+                   ("action", `Null);
                  ];
            })
-  in
-  let matched_internal_action_keys =
-    internal_incidents
-    |> List.filter_map (fun row ->
-           match member_assoc "action" row.json with
-           | `Assoc _ as action -> Some (action_identity action)
-           | _ -> None)
   in
   let internal_actions =
     actions
     |> List.filter is_internal_action
-    |> List.filter (fun action ->
-           not (List.mem (action_identity action) matched_internal_action_keys))
     |> List.map (fun action ->
            {
              pressure_rank = severity_rank (string_field ~default:"warn" "severity" action);

--- a/lib/dashboard/dashboard_briefing_assembly.mli
+++ b/lib/dashboard/dashboard_briefing_assembly.mli
@@ -20,9 +20,7 @@
     ([lane_pressure_ctx_ratio] tuning constant,
     [keeper_tool_audit_json_fields],
     [is_internal_action] / [is_internal_incident],
-    [incident_action_types],
-    [identity_digest], [action_identity],
-    [matched_internal_action_keys], [severity_rank],
+    [identity_digest], [action_identity], [severity_rank],
     [option_to_json] / [Json_util.string_opt_to_json] /
     [string_list_json] envelope helpers,
     [parse_iso_opt] / [trim_to_option],
@@ -47,20 +45,8 @@ val build_internal_signals :
   Yojson.Safe.t list ->
   Yojson.Safe.t list ->
   Yojson.Safe.t list
-(** [build_internal_signals incidents actions] fuses the
-    operator's incident + recommended-action streams into
-    one internal-signal list, sorted by descending
-    pressure rank. *)
-
-(** {1 Incident / action pairing} *)
-
-val action_matches_incident : Yojson.Safe.t -> Yojson.Safe.t -> bool
-(** [action_matches_incident incident action] returns [true]
-    when [action] targets the same [target_type] /
-    [target_id] pair as [incident] and either its
-    normalized [reason] equals the incident's normalized
-    [summary] (both non-empty), or its [action_type] is one
-    of the types listed for the incident's [kind].  Returns
-    [false] on a target mismatch.  Shared with
-    {!Dashboard_briefing}, which pairs the same operator
-    digest streams. *)
+(** [build_internal_signals incidents actions] emits the operator's incident
+    and recommended-action streams as one internal-signal list, sorted by
+    descending pressure rank. Each row carries the stream it came from and
+    leaves the other field [null]: the digest records no link between an
+    attention item and a recommended action, so none is asserted. *)

--- a/test/test_dashboard_briefing.ml
+++ b/test/test_dashboard_briefing.ml
@@ -298,6 +298,68 @@ let test_dashboard_briefing_keeper_tool_audit_keeps_inband_tools_without_evidenc
       check bool "no observed tools without evidence" true
         ((brief |> member "latest_tool_names" |> to_list) = []))
 
+(* An internal signal reports one stream. The operator digest records no link
+   between an attention item and a recommended action, so a row must not fill
+   in the other side, and no action may be dropped for having been "matched"
+   to an incident. The removed matcher did both: normalized-prose equality of
+   summary vs reason, else a kind -> action_type table, which attached the one
+   workspace recommendation to every incident whose kind that table listed. *)
+let test_internal_signals_do_not_pair_streams () =
+  let workspace = Lib.Operator_action_constants.workspace_target_type in
+  let incident kind summary =
+    `Assoc
+      [
+        ("kind", `String kind);
+        ("severity", `String "warn");
+        ("summary", `String summary);
+        ("target_type", `String workspace);
+        ("target_id", `Null);
+      ]
+  in
+  let action action_type reason =
+    `Assoc
+      [
+        ("action_type", `String action_type);
+        ("severity", `String "warn");
+        ("reason", `String reason);
+        ("target_type", `String workspace);
+        ("target_id", `Null);
+      ]
+  in
+  let incidents =
+    [
+      (* kind the deleted table mapped to "broadcast" *)
+      incident "intent_blocked" "Namespace intent is blocked";
+      (* reason identical to the action's, which the deleted prose
+         comparison treated as proof of a response *)
+      incident "stalled_session" "Pause the namespace";
+    ]
+  in
+  let actions = [ action "broadcast" "Pause the namespace" ] in
+  let signals =
+    Dashboard_briefing_assembly.build_internal_signals incidents actions
+  in
+  let open Yojson.Safe.Util in
+  let of_type wanted =
+    signals
+    |> List.filter (fun row -> to_string (member "signal_type" row) = wanted)
+  in
+  Alcotest.(check int) "both incidents kept" 2 (List.length (of_type "attention"));
+  Alcotest.(check int) "the action is still its own row" 1
+    (List.length (of_type "action"));
+  List.iter
+    (fun row ->
+      Alcotest.(check bool)
+        "an attention row claims no action" true
+        (member "action" row = `Null))
+    (of_type "attention");
+  List.iter
+    (fun row ->
+      Alcotest.(check bool)
+        "an action row claims no attention" true
+        (member "attention" row = `Null))
+    (of_type "action")
+
 let test_dashboard_keeper_unknown_context_is_informational () =
   let dir = test_dir () in
   Fun.protect
@@ -413,5 +475,7 @@ let () =
             test_dashboard_briefing_keeper_tool_audit_keeps_inband_tools_without_evidence;
           Alcotest.test_case "unknown keeper context is informational" `Quick
             test_dashboard_keeper_unknown_context_is_informational;
+          Alcotest.test_case "internal signals do not pair the two streams"
+            `Quick test_internal_signals_do_not_pair_streams;
         ] );
     ]


### PR DESCRIPTION
## 문제

미션 대시보드는 각 사건(attention item)에 "이 조치가 그 사건에 대한 대응"이라고 붙여 왔다. 근거는 두 가지였다.

```ocaml
let incident_summary = normalized_text_key (string_field "summary" incident) in
let action_reason = normalized_text_key (string_field "reason" action) in
if String.equal incident_summary action_reason then true
else List.mem action_type (incident_action_types (string_field "kind" incident))
```

1. 사건 요약과 조치 사유를 **소문자화 + 공백 접기 + 512 바이트 절단** 후 문자열 비교
2. 실패하면 손으로 적은 `kind -> action_type` 표 (17 개 kind, `_ -> []`)

둘 다 인과의 증거가 아니다.

## 데이터에 링크가 없다

`operator_digest` 가 워크스페이스 다이제스트를 만들 때:

- `attention_items` — read model 이 관측한 것
- `recommended_actions` — `active_guidance` 가 넘긴 것. `fresh_operator_judgment` 가 찾은 **operator judgment 하나**의 `recommended_action` 필드이고, 그 타입은 `Yojson.Safe.t option` 이다. LLM 이 쓴 자유 형식 JSON 이라 `action_type` / `reason` / `target_type` 어느 것도 검증되지 않는다.

두 스트림 어디에도 "이 조치는 저 사건에 대한 것"이라는 필드가 없다. 그래서 위 두 규칙이 그것을 지어냈다.

**1번(문장 일치)** — 한쪽은 read model 이 만든 관측 문장, 다른 쪽은 LLM 이 쓴 산문이다. 정규화 후 바이트 단위로 같아지는 건 한쪽이 다른 쪽을 복사했을 때뿐인데, 그런 생산자는 없다.

**2번(kind 표)** — 이쪽이 실제로 판정한다. `recommended_actions` 는 **최대 1 개**(`Some value -> [ value ] | None -> []`)이고 전부 워크스페이스 대상이다. 그 하나가 표에 실린 kind 를 가진 **모든** 사건에 붙는다. `List.find_opt` 은 사건마다 독립으로 돌기 때문에, 사건 5 개가 각각 "이 조치로 처리됨"을 주장하는 화면이 나온다. 그리고 `matched_internal_action_keys` 가 그 조치를 독립 행 목록에서 **제거**하므로, 조치는 자기 자리를 잃고 남의 이름표가 된다.

## 생산자는 링크를 갖고 있었고 버렸다

`operator_digest.ml` 은 사건과 조치를 **쌍으로** 만든다.

```ocaml
let keeper_attention_projection ... = Some (attention_item, recommended_action)
let external_attention_projection item = ... (attention_item, recommended_action)
```

유일한 소비자가 이것이다.

```ocaml
keeper_attention_projection_items config |> List.map fst
```

`snd` 는 아무도 읽지 않는다. 진짜 링크가 튜플 안에 있는데 `List.map fst` 로 버려지고, 하류에서 문자열 유사도로 되짚었다. (그 버려지는 `recommended_action` 값들 자체도 죽은 코드다 — 별건으로 다룬다.)

## 무엇을 바꿨나

- `action_matches_incident`, `incident_action_types` 삭제 (`.ml` + `.mli`)
- `matching_action_for_incident` 삭제. 이 함수는 매처가 실패하면 `candidates :: _` 로 **같은 대상의 아무 조치나** 집어 들었으므로, 매처는 어느 쪽을 고를지만 바꾸고 붙일지 말지는 바꾸지 않았다
- attention queue 행에서 `top_action` 제거, `attention_context.has_action` 제거
- 정렬: `List.sort` 에서 `List.stable_sort` 로. 기존 2 차 키가 `has_action` 이었는데 그 값이 지어낸 것이었다. 이제 같은 severity 안에서는 다이제스트 자신의 순서를 유지한다
- `build_internal_signals`: attention 행은 `action: null`, action 행은 `attention: null`. 매칭됐다는 이유로 조치를 목록에서 빼던 `matched_internal_action_keys` 제거
- TS: `DashboardMissionAttentionQueueItem.top_action` 과 그 normalizer 제거

`dashboard_briefing.ml:193` 의 `top_action` 은 남는다. 그건 `top_item projection.recommended_actions` — 목록의 첫 항목이고 어떤 사건에 대한 대응이라고 주장하지 않는다.

## 화면에서 무엇이 달라지나

`top_action`(attention queue 행)과 `action`(internal signal 행)은 **어디에서도 렌더되지 않았다.** TS 타입에 있고 normalizer 가 디코드하지만 렌더 경로가 없다 (`attention_queue` 소비자는 `dashboard-shell.ts` 의 개수와 `summarizeAttentionPreview` 뿐이고 둘 다 이 필드를 읽지 않는다, `internal_signals` 소비자는 `mission-actions.ts` 의 길이 검사뿐).

실제로 달라지는 것은 둘이다.

1. 같은 severity 내 사건 정렬이 "지어낸 매칭 있음 우선"에서 다이제스트 순서 유지로 바뀐다
2. 사건에 매칭됐다는 이유로 숨겨지던 워크스페이스 조치가 이제 항상 자기 행으로 나온다 (**정보 손실 없음, 오히려 복구**)

## 검증

새 테스트 `internal signals do not pair the two streams` 를 추가했다. 표가 `broadcast` 로 매핑하던 kind 하나와, 조치 사유와 **글자 그대로 같은** 요약을 가진 사건 하나를 넣어 옛 규칙 두 가지를 모두 발동시킨다.

이 테스트를 **변경 전 트리**에 대고 돌려 실패를 확인했다 (`git checkout origin/main -- lib/dashboard/` 후 실행 → `FAIL the action is still its own row`). 변경 후 통과.

`dune build @check` 통과. `npm run typecheck` 통과.

OCaml: `test_dashboard_briefing` (신규 1 건 포함), `test_dashboard_briefing_sections`, `test_briefing_sections`, `test_briefing_gaps`, `test_briefing_json_helpers`, `test_briefing_compactors` 통과.

Dashboard: `mission-normalizers`, `mission-normalizers-entities`, `dashboard-shell` 80 건 통과.

게이트: `check-determinism-contract`, `audit-catchall`, `check-variants`, `check-enum-string-safety`, `check_silent_failure`, `check-doc-code-refs`, `check_test_coverage` 통과.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
