### PR TITLE
refactor(operator): delete the synthesized keeper_probe recommendations

### DIFF
--- a/lib/operator/operator_digest.ml
+++ b/lib/operator/operator_digest.ml
@@ -187,24 +187,7 @@ let external_attention_projection item =
       evidence = external_attention_evidence item;
     }
   in
-  let recommended_action =
-    {
-      action_type = "keeper_probe";
-      target_type = Operator_action_constants.keeper_target_type;
-      target_id = Some item.keeper_name;
-      severity;
-      reason = "Inspect pending external attention";
-      suggested_payload =
-        `Assoc
-          [
-            ("source", `String "operator_digest");
-            ("keeper", `String item.keeper_name);
-            ("event_id", `String item.event_id);
-            ("conversation_id", `String item.conversation.conversation_id);
-          ];
-    }
-  in
-  (attention_item, recommended_action)
+  attention_item
 
 let keeper_attention_projection config (meta : Keeper_meta_contract.keeper_meta) =
   let attention_fields = Keeper_status_bridge.attention_fields_json config meta in
@@ -213,9 +196,6 @@ let keeper_attention_projection config (meta : Keeper_meta_contract.keeper_meta)
   else
     let blocker_fields = Keeper_status_bridge.runtime_blocker_fields_json config meta in
     let reason = assoc_string_field "attention_reason" attention_fields in
-    let next_human_action =
-      assoc_string_field "next_human_action" attention_fields
-    in
     let runtime_blocker_class =
       assoc_string_field "runtime_blocker_class" blocker_fields
     in
@@ -246,29 +226,7 @@ let keeper_attention_projection config (meta : Keeper_meta_contract.keeper_meta)
         evidence;
       }
     in
-    let action_reason =
-      match next_human_action with
-      | Some action -> Printf.sprintf "Inspect keeper attention: %s" action
-      | None -> "Inspect keeper attention"
-    in
-    let recommended_action =
-      {
-        action_type = "keeper_probe";
-        target_type = Operator_action_constants.keeper_target_type;
-        target_id = Some meta.name;
-        severity;
-        reason = action_reason;
-        suggested_payload =
-          `Assoc
-            [
-              ("source", `String "operator_digest");
-              ("keeper", `String meta.name);
-              ("reason", Json_util.string_opt_to_json reason);
-              ("next_human_action", Json_util.string_opt_to_json next_human_action);
-            ];
-      }
-    in
-    Some (attention_item, recommended_action)
+    Some attention_item
 
 let keeper_attention_projection_items config =
   let keeper_names = Keeper_meta_store.keeper_names config in
@@ -344,7 +302,7 @@ let digest_json ?actor ?target_type ?target_id:_target_id ?include_workers:_incl
     | Some Operator_action_constants.Workspace ->
         let confirm_scope = pending_confirm_scope ?actor config in
         let keeper_attention =
-          keeper_attention_projection_items config |> List.map fst
+          keeper_attention_projection_items config
         in
         let attention_items =
           build_workspace_attention_items config


### PR DESCRIPTION
## 무엇

`operator_digest.ml` 이 만드는 `keeper_probe` 추천 조치 두 개를 지운다. 아무도 읽지 않고, 저장소가 이미 이 개념을 폐기했다.

## 저장소가 먼저 폐기했다

`operator_digest_guidance.ml` 에 이렇게 적혀 있다.

```
Only an operator judgment — an LLM's own recorded decision — may carry a
recommended action. The read-model fallback used to synthesise one in
OCaml (action_type="keeper_probe", reason="Inspect pending external
attention") and hand it to the model as though a decision had been made;
the summary below states the observed condition instead.
```

"used to synthesise" 라고 쓰여 있지만, 그 리터럴 두 개가 지금도 `operator_digest.ml` 에 그대로 있다.

```ocaml
(* 190 행 *)  reason = "Inspect pending external attention";
(* 254 행 *)  reason = Printf.sprintf "Inspect keeper attention: %s" action
```

출력 경로에서만 빠졌고 코드에서는 빠지지 않았다.

## 아무도 읽지 않는다

두 생산자가 튜플을 만든다.

```ocaml
let external_attention_projection item = ... (attention_item, recommended_action)
let keeper_attention_projection ...     = ... Some (attention_item, recommended_action)
```

유일한 소비자가 이것이다.

```ocaml
keeper_attention_projection_items config |> List.map fst
```

`snd` 를 읽는 코드는 `lib/ test/ scripts/` 어디에도 없다 (`rg -n "external_attention_projection|keeper_attention_projection"` 결과 6 건 전부 위 세 함수의 정의와 호출). `test_keeper_waiting_inventory.ml` 의 `test_external_attention_projection_is_bounded` 는 이름만 겹치는 동명이인으로, `Server_keeper_waiting_inventory.dashboard_json` 을 검사한다.

## 왜 이걸 지우는가

`recommended_action` 이 존재한다는 사실 자체가 하류에 잘못된 기대를 만든다. `dashboard_briefing` 은 사건과 조치를 잇는 링크가 없다는 이유로 문자열 유사도와 손으로 적은 `kind -> action_type` 표로 그 링크를 지어내고 있었다 (#27281). 생산자가 링크를 **가지고 있으면서 버린다**는 사실이 그 우회를 정당한 것처럼 보이게 한다.

지금 상태는 셋 중 최악이다. 링크는 만들어지고, 버려지고, 하류에서 추측으로 복원된다. 이 PR 은 첫 번째를 없앤다 — 링크를 만들지 않으므로, 나중에 필요해지면 "이미 있었는데 왜 안 쓰지" 대신 "이 링크를 어디서 만들 것인가"로 시작하게 된다.

## 정보 손실 없음

`next_human_action` 은 synthesized action 의 `reason` 과 payload 로만 쓰였다. 삭제 후에도 attention item 의 `evidence` 안에 그대로 실린다.

```ocaml
("attention", `Assoc attention_fields)   (* attention_fields 가 next_human_action 을 포함 *)
```

`keeper_status_bridge.ml:225` 가 그 필드를 넣는 곳이다.

## 남겨둔 것

`workspace_recommendations _config = dedup_recommendations []` — 인자를 무시하고 항상 빈 목록을 반환한다. 소비자 `operator_control_snapshot.ml:615` 는 그 결과로 `recommendation_summary` 를 만드는데, 언제나 빈 요약이다. 같은 부류지만 `lib/operator/operator_control*` 는 RFC 게이트 대상이라 이 PR 범위에 넣지 않았다.

## 검증

`dune build @check` 통과. `test_dashboard_briefing`, `test_operator_control_snapshot`, `test_dashboard_http_core`, `test_dashboard_tool_host_events` 합계 91 건 통과. `check_test_coverage` 통과.

순감 42 줄. 새 동작이 없어 붙일 테스트가 없다 — 지운 값들은 관측 가능한 출력에 도달한 적이 없고, 위 4 개 스위트가 다이제스트 출력의 회귀 없음을 확인한다. `check_test_coverage` 가 이미 통과하므로 skip 표식은 넣지 않았다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
