### PR TITLE
refactor(gate): Discord API 버전을 한 곳에서 정의

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -966,6 +966,17 @@ jobs:
             @test/runtest-test_gate_connector_observability \
             @test/runtest-test_discord_observability
 
+      - name: Run Discord API version pinning suites
+        # The version now has one definition, and these two suites are what
+        # holds it: test_discord_gateway_state asserts Open_wss carries
+        # ?v=10, test_discord_rest_client asserts the /api/v10 paths. Both
+        # already made those assertions and neither ran in CI, so a bump
+        # could land with the assertions untouched. 33 + 118 pass here.
+        run: |
+          opam exec -- dune build --root . \
+            @test/runtest-test_discord_gateway_state \
+            @test/runtest-test_discord_rest_client
+
       - name: Run repos relative-path suite
         # The stored default must stay relative: Repo_store.local_path concats
         # it onto the base path, so an absolute value resolves twice.

--- a/lib/gate/discord_api_version.ml
+++ b/lib/gate/discord_api_version.ml
@@ -1,0 +1,1 @@
+let current = 10

--- a/lib/gate/discord_api_version.mli
+++ b/lib/gate/discord_api_version.mli
@@ -1,0 +1,13 @@
+(** The Discord API version this client speaks.
+
+    Discord carries one version number across both surfaces we use.
+    The REST API takes it in the request path — "You should specify
+    which version to use by including it in the request path like
+    [https://discord.com/api/v{version_number}]" — and the gateway
+    takes it in the [v] query parameter, which the gateway docs
+    define as "API Version to use" over that same version list.
+
+    So it lives here once, and both callers build their URLs from
+    it rather than spelling the number again. *)
+
+val current : int

--- a/lib/gate/discord_gateway_state.ml
+++ b/lib/gate/discord_gateway_state.ml
@@ -10,8 +10,6 @@
    incomplete transition surfaces as an explicit, named failure
    rather than a silent no-op or catch-all swallow. *)
 
-let protocol_version = 10
-
 (* ── Opcodes ────────────────────────────────────────────────────── *)
 
 type opcode =
@@ -256,7 +254,12 @@ let trigger_policy_to_string = function
 
 (* ── Opaque state ──────────────────────────────────────────────── *)
 
-let gateway_url = "wss://gateway.discord.gg/?v=10&encoding=json"
+(* [v] is the API version, per the gateway docs' query-parameter table, so
+   it comes from the one place that number is defined. *)
+let gateway_url =
+  Printf.sprintf
+    "wss://gateway.discord.gg/?v=%d&encoding=json"
+    Discord_api_version.current
 
 module StringMap = Map.Make (String)
 

--- a/lib/gate/discord_gateway_state.mli
+++ b/lib/gate/discord_gateway_state.mli
@@ -23,12 +23,6 @@
     - docs/rfc/RFC-0203-discord-builtin-gateway.md §Modules
     - Discord Developer Docs — Gateway v10 opcodes and lifecycle *)
 
-(** {1 Identity} *)
-
-(** The protocol version we speak. Pinned, single-valued (Discord
-    promises v10 stability; future bumps are a separate RFC). *)
-val protocol_version : int  (** [10]. *)
-
 (** {1 Opcodes — closed sum of the ones we handle} *)
 
 (** Discord Gateway opcodes. Closed sum: only the opcodes this client

--- a/lib/gate/discord_rest_client.ml
+++ b/lib/gate/discord_rest_client.ml
@@ -22,6 +22,11 @@ let pp_error fmt = function
    Messages longer than this must be split into multiple payloads. *)
 let message_content_limit = 2000
 
+(* Discord takes the API version in the request path. Built from the
+   shared constant so the gateway and REST surfaces cannot drift apart. *)
+let api_base =
+  Printf.sprintf "https://discord.com/api/v%d" Discord_api_version.current
+
 (* Discord requires a specific User-Agent format:
    "DiscordBot ($url, $version)". *)
 let user_agent =
@@ -35,8 +40,8 @@ let auth_headers ~token =
 let build_request ~token ~channel_id ~content ?reply_to_message_id () =
   let url =
     Printf.sprintf
-      "https://discord.com/api/v10/channels/%s/messages"
-      channel_id
+      "%s/channels/%s/messages"
+      api_base channel_id
   in
   let headers =
     ("Content-Type", "application/json") :: auth_headers ~token
@@ -55,8 +60,8 @@ let build_request ~token ~channel_id ~content ?reply_to_message_id () =
 let build_typing_request ~token ~channel_id () =
   let url =
     Printf.sprintf
-      "https://discord.com/api/v10/channels/%s/typing"
-      channel_id
+      "%s/channels/%s/typing"
+      api_base channel_id
   in
   (url, auth_headers ~token, "")
 
@@ -160,8 +165,8 @@ let truncate_to_limit content =
 let build_edit_request ~token ~channel_id ~message_id ~content () =
   let url =
     Printf.sprintf
-      "https://discord.com/api/v10/channels/%s/messages/%s"
-      channel_id message_id
+      "%s/channels/%s/messages/%s"
+      api_base channel_id message_id
   in
   let headers =
     ("Content-Type", "application/json") :: auth_headers ~token
@@ -271,8 +276,8 @@ let image_embed ~url ~caption =
 let build_embed_request ~token ~channel_id ~content ?embeds () =
   let url =
     Printf.sprintf
-      "https://discord.com/api/v10/channels/%s/messages"
-      channel_id
+      "%s/channels/%s/messages"
+      api_base channel_id
   in
   let headers =
     ("Content-Type", "application/json") :: auth_headers ~token
@@ -294,8 +299,8 @@ let build_edit_embed_request ~token ~channel_id ~message_id
       ~content ?embeds () =
   let url =
     Printf.sprintf
-      "https://discord.com/api/v10/channels/%s/messages/%s"
-      channel_id message_id
+      "%s/channels/%s/messages/%s"
+      api_base channel_id message_id
   in
   let headers =
     ("Content-Type", "application/json") :: auth_headers ~token

--- a/lib/gate/dune
+++ b/lib/gate/dune
@@ -17,6 +17,7 @@
   channel_gate_telegram_state
   channel_gate_metrics
   connector_ingress_lane
+  discord_api_version
   discord_observability
   gate_connector_observability
   discord_gateway_client

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -88,7 +88,7 @@ echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, al
 # authority tools, memory journal) without lowering the baseline. A PR that
 # wires a suite must lower this number in the same PR, or this check goes red
 # for everyone.
-UNWIRED_BASELINE=744
+UNWIRED_BASELINE=739
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then


### PR DESCRIPTION
## 문제

Discord API 버전 하나가 코드에 7벌 있었다.

- `discord_gateway_state.mli` 가 `val protocol_version : int` 를 "The protocol version we speak" 로 내보냄 — **소비자 0**
- 실제 접속 URL 은 `"wss://gateway.discord.gg/?v=10&encoding=json"` 문자열 안에 별도로 박힘
- `discord_rest_client.ml` 의 `https://discord.com/api/v10/...` 5곳

이름이 붙은 유일한 값이 아무도 안 쓰는 그 하나였다. `protocol_version` 을 11로 바꿔도 접속은 계속 v10 으로 나간다.

공식 문서 기준 두 표면은 같은 손잡이다. REST 는 "specify which version to use by including it in the request path like `https://discord.com/api/v{version_number}`" (docs.discord.com/developers/reference), 게이트웨이의 `v` 파라미터는 "API Version to use" 로 같은 버전 목록을 가리킨다 (docs.discord.com/developers/events/gateway).

## 변경

- `lib/gate/discord_api_version.{ml,mli}` 신규 — `val current : int` 하나
- 게이트웨이 URL 과 REST 5개 경로가 전부 이 값에서 생성
- 소비자 0이던 `val protocol_version` 은 `.mli` 에서 제거

## 검증

`Discord_api_version.current` 를 11로 올렸을 때:

```
test_discord_gateway_state  exit=1
test_discord_rest_client    exit=1
```

10으로 되돌리면 둘 다 exit=0. 단일 정의가 두 표면에 모두 닿는다.

## CI 배선

두 스위트 모두 **CI 에서 돌지 않고 있었다**. 단정은 이미 있었다 — `test_discord_gateway_state.ml:1586` 이 `Open_wss` 의 `?v=10` 을, `test_discord_rest_client.ml` 이 `/api/v10` 경로 5개를 잡는다. 실행이 안 됐을 뿐이라 버전 변경이 단정을 그대로 둔 채 머지될 수 있었다.

둘 다 로컬 통과(33 + 118)라서 ci.yml 에 물렸고, `UNWIRED_BASELINE` 744 → 739 (실측 739, 스크립트 지시대로 정확값).

## 남은 것

`discord_rest_client.ml:27` 의 User-Agent `"DiscordBot (https://github.com/jeong-sik/masc, 0.1)"` 에 박힌 `0.1` 은 `dune-project` 버전과 무관하게 굳어 있다. 범위가 달라 건드리지 않았다.
