### PR TITLE
perf(transport): hand the bus payload to subscribers instead of the SSE frame

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -944,6 +944,7 @@ jobs:
             @test/runtest-test_rfc_0086_keeper_namespace_invariant \
             @test/runtest-test_server_base_path_guard \
             @test/runtest-test_sse_retry_ssot \
+            @test/runtest-test_sse_stream \
             @test/runtest-test_task_cache_invariant_13397 \
             @test/runtest-test_tool_contract_truth \
             @test/runtest-test_voice_command_descriptor_parity

--- a/dashboard/src/api/schemas/transport-health.test.ts
+++ b/dashboard/src/api/schemas/transport-health.test.ts
@@ -30,7 +30,7 @@ describe('parseTransportHealthData', () => {
     expect(result.grpc.enabled).toBe(false)
     expect(result.grpc.port).toBe(0)
     expect(result.websocket.mode).toBe('unknown')
-    expect(result.websocket.delivery.parse_cache_hits).toBe(0)
+    expect(result.websocket.delivery.bytes_cache_hits).toBe(0)
     expect(result.webrtc.signaling_mode).toBe('unknown')
     expect(result.streamable_http.endpoint).toBe('/mcp')
     expect(result.http2.listener_mode).toBe('unknown')
@@ -176,8 +176,6 @@ describe('parseTransportHealthData', () => {
         sessions: 15,
         relay_source: 'sse',
         delivery: {
-          parse_cache_hits: 100,
-          parse_cache_misses: 5,
           bytes_cache_hits: 200,
           bytes_cache_misses: 10,
           client_acks: 95,

--- a/dashboard/src/api/schemas/transport-health.ts
+++ b/dashboard/src/api/schemas/transport-health.ts
@@ -114,8 +114,6 @@ const GrpcSchema = object({
 // pointed at an older build should not surface schema errors, it
 // should show zeroes and let the operator know the metric is absent).
 const WebsocketDeliverySchema = object({
-  parse_cache_hits: fallback(number(), 0),
-  parse_cache_misses: fallback(number(), 0),
   bytes_cache_hits: fallback(number(), 0),
   bytes_cache_misses: fallback(number(), 0),
   client_acks: fallback(number(), 0),
@@ -133,8 +131,6 @@ const WebsocketSchema = object({
   sessions: fallback(number(), 0),
   relay_source: fallback(string(), 'unknown'),
   delivery: fallback(WebsocketDeliverySchema, {
-    parse_cache_hits: 0,
-    parse_cache_misses: 0,
     bytes_cache_hits: 0,
     bytes_cache_misses: 0,
     client_acks: 0,

--- a/dashboard/src/components/transport-health.test.ts
+++ b/dashboard/src/components/transport-health.test.ts
@@ -82,8 +82,6 @@ function sampleResponse(overrides?: Partial<Record<string, unknown>>) {
       sessions: 0,
       relay_source: 'sse_external_subscriber',
       delivery: {
-        parse_cache_hits: 0,
-        parse_cache_misses: 0,
         bytes_cache_hits: 0,
         bytes_cache_misses: 0,
         client_acks: 0,
@@ -718,8 +716,6 @@ function makeData(overrides?: Partial<TransportHealthData>): TransportHealthData
       sessions: 0,
       relay_source: 'sse_external_subscriber',
       delivery: {
-        parse_cache_hits: 0,
-        parse_cache_misses: 0,
         bytes_cache_hits: 0,
         bytes_cache_misses: 0,
         client_acks: 0,

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -512,11 +512,6 @@ export function TransportHealthPanel() {
                 <${MetricRow} label="모드" value=${data.websocket.mode} />
                 <${MetricRow} label="릴레이 소스" value=${data.websocket.relay_source} />
                 <${MetricRow}
-                  label="파싱 캐시"
-                  value=${formatHitRate(data.websocket.delivery.parse_cache_hits, data.websocket.delivery.parse_cache_misses)}
-                  sub=${`${data.websocket.delivery.parse_cache_hits} 히트 / ${data.websocket.delivery.parse_cache_misses} 미스`}
-                />
-                <${MetricRow}
                   label="바이트 캐시"
                   value=${formatHitRate(data.websocket.delivery.bytes_cache_hits, data.websocket.delivery.bytes_cache_misses)}
                   sub=${`${data.websocket.delivery.bytes_cache_hits} 히트 / ${data.websocket.delivery.bytes_cache_misses} 미스`}

--- a/lib/otel_metric_store/otel_transport_metric_names.ml
+++ b/lib/otel_metric_store/otel_transport_metric_names.ml
@@ -39,10 +39,6 @@ let metric_grpc_events_delivered = Otel_metric_store_core.declare_counter "masc_
 let metric_grpc_events_dropped = Otel_metric_store_core.declare_counter "masc_grpc_events_dropped_total"
 let metric_ws_sessions = Otel_metric_store_core.declare_counter "masc_ws_sessions_total"
 
-let metric_server_mcp_ws_frame_json_parse_failures =
-  Otel_metric_store_core.declare_counter "masc_server_mcp_ws_frame_json_parse_failures_total"
-;;
-
 let metric_sidecar_schema_field_types_json_parse_failures =
   Otel_metric_store_core.declare_counter "masc_sidecar_schema_field_types_json_parse_failures_total"
 ;;

--- a/lib/otel_metric_store/otel_transport_metric_names.ml
+++ b/lib/otel_metric_store/otel_transport_metric_names.ml
@@ -9,6 +9,9 @@ let metric_sse_broadcast_duration = "masc_sse_broadcast_duration_seconds"
 let metric_sse_broadcast_events = Otel_metric_store_core.declare_counter "masc_sse_broadcast_events_total"
 let metric_sse_broadcast_failures = Otel_metric_store_core.declare_counter "masc_sse_broadcast_failures_total"
 
+let metric_sse_broadcast_skipped_no_observer =
+  Otel_metric_store_core.declare_counter "masc_sse_broadcast_skipped_no_observer_total"
+
 let metric_sse_external_subscriber_callback_failures =
   Otel_metric_store_core.declare_counter "masc_sse_external_subscriber_callback_failures_total"
 ;;

--- a/lib/otel_metric_store/otel_transport_metric_names.ml
+++ b/lib/otel_metric_store/otel_transport_metric_names.ml
@@ -38,8 +38,6 @@ let metric_grpc_subscribers = Otel_metric_store_core.declare_counter "masc_grpc_
 let metric_grpc_events_delivered = Otel_metric_store_core.declare_counter "masc_grpc_events_delivered_total"
 let metric_grpc_events_dropped = Otel_metric_store_core.declare_counter "masc_grpc_events_dropped_total"
 let metric_ws_sessions = Otel_metric_store_core.declare_counter "masc_ws_sessions_total"
-let metric_ws_parse_cache_hits = Otel_metric_store_core.declare_counter "masc_ws_parse_cache_hits_total"
-let metric_ws_parse_cache_misses = Otel_metric_store_core.declare_counter "masc_ws_parse_cache_misses_total"
 
 let metric_server_mcp_ws_frame_json_parse_failures =
   Otel_metric_store_core.declare_counter "masc_server_mcp_ws_frame_json_parse_failures_total"

--- a/lib/otel_metric_store/otel_transport_metric_names.mli
+++ b/lib/otel_metric_store/otel_transport_metric_names.mli
@@ -8,6 +8,10 @@ val metric_sse_sessions : string
 val metric_sse_broadcast_duration : string
 val metric_sse_broadcast_events : string
 val metric_sse_broadcast_failures : string
+val metric_sse_broadcast_skipped_no_observer : string
+(** Broadcasts short-circuited because nothing could observe them: bufferless,
+    no external subscriber, and no session of the target kind. *)
+
 val metric_sse_external_subscriber_callback_failures : string
 val metric_sse_external_fanout_duration_seconds : string
 val metric_oas_sse_relay_drop_marker_failures : string

--- a/lib/otel_metric_store/otel_transport_metric_names.mli
+++ b/lib/otel_metric_store/otel_transport_metric_names.mli
@@ -32,12 +32,6 @@ val metric_ws_sessions : string
 val metric_ws_bytes_cache_hits : string
 val metric_ws_bytes_cache_misses : string
 
-(** Counter of WebSocket transport incoming-frame JSON parse failures.
-    Frame is dropped (parse_sse_dashboard_event returns None) but
-    operators now have a counter + warn log.
-    Labels: [error_kind = yojson_parse_error | other]. Iter 28. *)
-val metric_server_mcp_ws_frame_json_parse_failures : string
-
 (** Counter of sidecar HTTP route [schema_field_types] JSON parse
     failures. Previously the catch-all returned [] silently, allowing
     callers (e.g. [coerce_value] in TOML sidecar handlers) to proceed

--- a/lib/otel_metric_store/otel_transport_metric_names.mli
+++ b/lib/otel_metric_store/otel_transport_metric_names.mli
@@ -29,8 +29,6 @@ val metric_grpc_subscribers : string
 val metric_grpc_events_delivered : string
 val metric_grpc_events_dropped : string
 val metric_ws_sessions : string
-val metric_ws_parse_cache_hits : string
-val metric_ws_parse_cache_misses : string
 val metric_ws_bytes_cache_hits : string
 val metric_ws_bytes_cache_misses : string
 

--- a/lib/server/masc_grpc_service.ml
+++ b/lib/server/masc_grpc_service.ml
@@ -520,7 +520,8 @@ let handle_subscribe (workspace_config : Workspace_utils_backend_setup.config) (
     ~id:sub_id
     ~is_alive:(fun () ->
       (not (Atomic.get stream_closed)) && not (Grpc_eio.Stream.is_closed stream))
-    ~callback:(fun sse_event ->
+    ~callback:(fun (ev : Sse.external_event) ->
+      let sse_event = ev.Sse.ext_frame in
       if Atomic.get stream_closed || Grpc_eio.Stream.is_closed stream
       then
         (* Stream already gone — auto-cleanup *)

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -604,80 +604,42 @@ type parsed_sse_event = {
   broadcast_ts: float;
 }
 
-(** Per-broadcast parse cache.
+(** Derive the dashboard view of a broadcast straight from the bus payload.
 
-    [Sse.notify_external_subscribers] passes the same [event: string]
-    reference to each subscriber callback in sequence, so consecutive
-    WS sessions all see the identical pointer for one broadcast.  Caching
-    the parse result keyed by physical equality collapses O(sessions)
-    JSON parses per event down to 1.
+    The bus hands over {!Sse.external_event}, whose [ext_payload] is the value
+    [Sse.broadcast] was called with. Reading it here is what removes the
+    serialize -> frame -> parse round trip: this transport used to recover the
+    same value by scanning the SSE frame for its [data:] field and calling
+    [Yojson.Safe.from_string], once per broadcast (measured 2026-08-06 on the
+    live fleet: 9,828 parses against 10,905 fanouts, and an external-fanout
+    average of 713us against a 258us broadcast, for a single subscriber).
 
-    Correctness: on miss we parse and replace; no torn state is possible
-    (Atomic write is atomic).  A concurrent broadcast at worst wastes one
-    parse — it never yields a wrong result for a different [sse_event].
-    Physical equality is safe here because the snapshot loop holds the
-    event string alive for the duration of fanout. *)
-let parse_cache : (string * parsed_sse_event option) Atomic.t =
-  Atomic.make ("", None)
+    No cache: what remains is two [List.assoc_opt] lookups over the top-level
+    fields plus a constant string match, which is cheaper than the [Atomic.get]
+    and two counter increments the old parse cache spent on every lookup.
 
-let parse_sse_dashboard_event sse_event =
-  let cached_str, cached_val = Atomic.get parse_cache in
-  if cached_str == sse_event then begin
-    Transport_metrics.inc_ws_parse_cache_hit ();
-    cached_val
-  end
-  else begin
-    Transport_metrics.inc_ws_parse_cache_miss ();
-    let result =
-      match Sse.data_payload_of_frame sse_event with
-      | Error Sse.Missing_data_payload ->
-          Log.Server.warn "[mcp-ws] dropping frame without an SSE data field";
-          Transport_metrics.inc_ws_frame_json_parse_failure
-            ~error_kind:Transport_metrics.Other_ws_frame_json_parse_error;
-          None
-      | Ok json_body ->
-        match Yojson.Safe.from_string json_body with
-        | exception (Yojson.Json_error msg) ->
-            (* Iter 28: previously silently dropped — now emit a counter
-               and a warn with a size-bounded body preview so operators
-               can detect malformed frames from clients. Behavior is
-               preserved (still returns None). *)
-            let preview_len = min 200 (String.length json_body) in
-            Log.Server.warn
-              "[mcp-ws] dropping incoming frame: malformed JSON (%s); \
-               body_preview=%s"
-              msg
-              (String.sub json_body 0 preview_len);
-            Transport_metrics.inc_ws_frame_json_parse_failure
-              ~error_kind:Transport_metrics.Yojson_parse_error;
-            None
-        | exception Eio.Cancel.Cancelled e -> raise (Eio.Cancel.Cancelled e)
-        | exception exn ->
-            let preview_len = min 200 (String.length json_body) in
-            Log.Server.warn
-              "[mcp-ws] dropping incoming frame: %s; body_preview=%s"
-              (Printexc.to_string exn)
-              (String.sub json_body 0 preview_len);
-            Transport_metrics.inc_ws_frame_json_parse_failure
-              ~error_kind:Transport_metrics.Other_ws_frame_json_parse_error;
-            None
-        | `Assoc fields as event_json -> (
-            match List.assoc_opt "type" fields with
-            | Some (`String event_type) ->
-                let payload =
-                  match List.assoc_opt "payload" fields with
-                  | Some payload -> payload
-                  | None -> event_json
-                in
-                let slice = dashboard_slice_for_sse_type event_type in
-                let broadcast_ts = Time_compat.now () in
-                Some { event_type; slice; payload; broadcast_ts }
-            | _ -> None)
-        | _ -> None
-    in
-    Atomic.set parse_cache (sse_event, result);
-    result
-  end
+    [broadcast_ts] is [ext_emitted_at], the moment the bus emitted, so every
+    delta from one broadcast carries one logical emission time regardless of
+    when a session's callback ran. The old code stamped [Time_compat.now ()]
+    at parse time and relied on the cache to keep sessions consistent. *)
+let dashboard_event_of_external (ev : Sse.external_event) =
+  match ev.Sse.ext_payload with
+  | `Assoc fields as event_json -> (
+      match List.assoc_opt "type" fields with
+      | Some (`String event_type) ->
+          let payload =
+            match List.assoc_opt "payload" fields with
+            | Some payload -> payload
+            | None -> event_json
+          in
+          Some
+            { event_type
+            ; slice = dashboard_slice_for_sse_type event_type
+            ; payload
+            ; broadcast_ts = ev.Sse.ext_emitted_at
+            }
+      | _ -> None)
+  | _ -> None
 
 (** Shared dashboard/delta payload-frame cache.
 
@@ -859,7 +821,8 @@ let __test_reset_env_caches () =
     (Float.neg_infinity, 30.0);
   Atomic.set slice_index_enabled_cache (Float.neg_infinity, true)
 
-let send_dashboard_or_raw_sse session sse_event =
+let send_dashboard_or_raw_sse session (ev : Sse.external_event) =
+  let sse_event = ev.Sse.ext_frame in
   if session_is_backpressured session then begin
     (* Drop the delivery rather than queue it.  Next ack after the client
        drains will let traffic resume; in the meantime [masc_ws_throttled_
@@ -871,15 +834,11 @@ let send_dashboard_or_raw_sse session sse_event =
     true
   end
   else if dashboard_auth_is_authenticated (dashboard_auth session) then begin
-    (* Parse once and reuse for both the delta-build branch and the
-       slice-mismatch decision.  parse_sse_dashboard_event hits a
-       single-slot Atomic cache after the broadcast's first call, but
-       even the cache-hit path costs an Atomic.get + physical eq +
-       counter increment per invocation — so calling it twice per
-       session per broadcast doubles those constants for no signal
-       difference.  At fanout fleet scale (100+ authenticated dashboard
-       sessions) the second call is pure overhead. *)
-    let parsed = parse_sse_dashboard_event sse_event in
+    (* Derive once and reuse for both the delta-build branch and the
+       slice-mismatch decision. The derivation is pure and allocation-free
+       apart from the option, but it is still two assoc lookups per call, so
+       the single binding keeps it at one per session per broadcast. *)
+    let parsed = dashboard_event_of_external ev in
     match parsed with
     | Some { slice = Some slice; _ }
       when List.mem slice (Atomic.get session.dashboard_slices) ->
@@ -1032,9 +991,9 @@ let __test_missed_pong_threshold = missed_pong_threshold
 let __test_next_dashboard_seq = next_dashboard_seq
 let __test_dashboard_seq_value session = Atomic.get session.dashboard_seq
 
-let __test_dashboard_delta_payload_text_for_sse sse_event =
-  dashboard_delta_payload_text_for_parsed sse_event
-    (parse_sse_dashboard_event sse_event)
+let __test_dashboard_delta_payload_text_for_event (ev : Sse.external_event) =
+  dashboard_delta_payload_text_for_parsed ev.Sse.ext_frame
+    (dashboard_event_of_external ev)
 
 let start_upgrade_heartbeat ?sw ?clock session_id session =
   match sw, clock with

--- a/lib/server/server_mcp_transport_ws.mli
+++ b/lib/server/server_mcp_transport_ws.mli
@@ -52,8 +52,6 @@
     [update_ws_session_count_metric],
     [dashboard_auth_success_payload],
     [verify_dashboard_token],
-    [parse_cache] / [sse_data_prefix] /
-    [extract_sse_data_*],
     [dashboard_delta_payload_text_cache] /
     [dashboard_delta_payload_text_for_parsed] /
     [dashboard_delta_seq_notification] /

--- a/lib/server/server_mcp_transport_ws.mli
+++ b/lib/server/server_mcp_transport_ws.mli
@@ -34,7 +34,7 @@
     - {b outbound delivery}
       ({!send_to_session_result},
       {!send_dashboard_or_raw_sse},
-      {!parse_sse_dashboard_event}).
+      {!dashboard_event_of_external}).
 
     Internal helpers stay private at this boundary
     ([sha1], [sessions_mutex], [slice_index] +
@@ -144,7 +144,7 @@ type parsed_sse_event = {
   payload : Yojson.Safe.t;
   broadcast_ts : float;
 }
-(** Result of {!parse_sse_dashboard_event}.  Exposed for
+(** Result of {!dashboard_event_of_external}.  Exposed for
     the [#10194] regression test which pattern-matches on
     [parsed.event_type] / [parsed.slice]. *)
 
@@ -325,7 +325,7 @@ val send_to_session_result : string -> string -> send_outcome
 (** Sends [text] to the session named by id.  Returns
     {!Sent} / {!Session_gone} / {!Send_failed}. *)
 
-val send_dashboard_or_raw_sse : ws_session -> string -> bool
+val send_dashboard_or_raw_sse : ws_session -> Sse.external_event -> bool
 (** Pushes an SSE event payload to a dashboard-subscribed
     WS session — gates on {!session_is_backpressured}
     and per-slice subscription set.  Returns [true] if
@@ -333,16 +333,14 @@ val send_dashboard_or_raw_sse : ws_session -> string -> bool
     / slice mismatch — both keep the wire alive); [false]
     on a hard send failure. *)
 
-val parse_sse_dashboard_event :
-  string -> parsed_sse_event option
-(** Parses an SSE-formatted broadcast string into
-    {!parsed_sse_event}, or [None] when the wire format
-    does not match the expected ["data:" + JSON]
-    convention.  Internal cache collapses repeated parses
-    of the same physical buffer across the per-broadcast
-    fanout. *)
-
-(** {1 Dashboard JSON-RPC handlers} *)
+val dashboard_event_of_external :
+  Sse.external_event -> parsed_sse_event option
+(** Derives {!parsed_sse_event} from the bus payload
+    ({!Sse.external_event.ext_payload}), or [None] when
+    the event is not a dashboard-shaped object.  Reads the
+    broadcast value directly, so no SSE frame is parsed and
+    no cache is needed.  [broadcast_ts] is the bus emission
+    time, so every delta from one broadcast agrees. *)
 
 val dashboard_hello :
   base_path:string ->
@@ -492,9 +490,9 @@ val __test_dashboard_seq_value : ws_session -> int
     cross-domain gate can assert the final value equals the total number of
     allocations (no lost updates under true parallelism). *)
 
-val __test_dashboard_delta_payload_text_for_sse :
-  string -> dashboard_delta_payload_frame option
+val __test_dashboard_delta_payload_text_for_event :
+  Sse.external_event -> dashboard_delta_payload_frame option
 (** Test-only seam: serializes the shared dashboard/delta payload frame for
-    one SSE broadcast.  The returned text deliberately excludes the
+    one broadcast.  The returned text deliberately excludes the
     per-session seq so tests can prove payload serialization is cached by
     physical broadcast reference rather than multiplied by session count. *)

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -984,12 +984,26 @@ let broadcast_is_unobservable target ~buffer ~notify_external =
   &&
   match target with
   | Presence_only ->
+    (* [session_kind_matches_target] is the only definition of which session a
+       target reaches. Asking it here rather than re-testing [kind = Presence]
+       keeps the skip and the delivery on one predicate: if [Presence_only]
+       ever widens, this stops skipping instead of silently dropping the
+       broadcast for the sessions it just gained. [jsonrpc_payload] is unused
+       on this arm — it only gates [All] and [Agent_streams], which are handled
+       below. *)
     let state = Atomic.get clients in
     state.count = 0
     || not
          (SMap.exists
-            (fun _ (client : client) -> client.kind = Presence)
+            (fun _ (client : client) ->
+              session_kind_matches_target
+                target
+                ~jsonrpc_payload:false
+                client.kind)
             state.entries)
+  (* Not skipped: these arms need [jsonrpc_payload], which costs a filter pass
+     over the payload, so the check would no longer be the O(1) it has to be on
+     this path. *)
   | All | Observers | Agent_streams -> false
 
 let broadcast_deliver ~buffer ~notify_external ~event_type target json =

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -744,9 +744,26 @@ let client_matches_target target ~jsonrpc_payload (client : client) =
     are called synchronously after SSE fan-out completes, receiving the
     formatted SSE event string. *)
 
+type external_event = {
+  ext_frame : string;
+      (** The SSE wire framing of this event. Kept for subscribers that
+          forward the frame verbatim; a subscriber that wants the data
+          should read {!ext_payload} instead of parsing this back out. *)
+  ext_payload : Yojson.Safe.t;
+      (** The value passed to [broadcast], before framing. Handing this over
+          is what keeps a non-SSE transport off the serialize→parse→serialize
+          round trip: the WebSocket relay used to recover this by scanning
+          [ext_frame] for its [data:] field and calling
+          [Yojson.Safe.from_string] once per broadcast. *)
+  ext_event_id : int;
+  ext_emitted_at : float;
+      (** Broadcast time, so every transport stamps one logical emission
+          moment rather than its own arrival time. *)
+}
+
 type external_subscriber = {
   sub_id: string;
-  callback: string -> unit;
+  callback: external_event -> unit;
   is_alive: unit -> bool;
   (** Returns false if the subscriber should be removed.
       Called before each broadcast delivery. *)
@@ -857,7 +874,7 @@ let remove_external_subscribers ids =
           result = (removed_ids, next_count);
         })
 
-(** Fan out an event string to all external subscribers.
+(** Fan out an event to all external subscribers.
     Dead subscribers (where [is_alive] returns [false]) are automatically
     removed during iteration, preventing resource leaks. *)
 let notify_external_subscribers event =
@@ -949,8 +966,33 @@ let reap_dead_external_subscribers () =
 
     After SSE fan-out, external subscribers (gRPC streams, etc.) are
     notified with the delivery's formatted frame. *)
-let broadcast_impl ?(buffer = true) ?(notify_external = true)
-    ?(event_type = "message") target json =
+(* A broadcast that buffers nothing, notifies no external subscriber, and has
+   no session of its target kind is unobservable — yet it still paid for a full
+   [format_event_yojson] under the global fanout mutex before discovering that.
+
+   Presence is the live shape of this. It is bufferless by construction and
+   [notify_external:false], so a fleet with no presence session is serializing
+   for nobody. Measured on the live fleet 2026-08-06: broadcast_count 15,928
+   against external_fanout_count 10,905, with sessions_presence = 0.
+
+   The [count = 0] test is O(1) and covers a fleet with no SSE session at all;
+   the [SMap.exists] fallback short-circuits on the first presence session, so
+   a fleet that does have one pays a scan only until it finds it. *)
+let broadcast_is_unobservable target ~buffer ~notify_external =
+  (not buffer)
+  && (not notify_external)
+  &&
+  match target with
+  | Presence_only ->
+    let state = Atomic.get clients in
+    state.count = 0
+    || not
+         (SMap.exists
+            (fun _ (client : client) -> client.kind = Presence)
+            state.entries)
+  | All | Observers | Agent_streams -> false
+
+let broadcast_deliver ~buffer ~notify_external ~event_type target json =
   let t0 = Time_compat.now () in
   let jsonrpc_payload =
     Sse_jsonrpc_filter.jsonrpc_message_for_agent_stream json
@@ -1045,7 +1087,18 @@ let broadcast_impl ?(buffer = true) ?(notify_external = true)
   (* Notify external subscribers (gRPC streams, etc.) for durable broadcast
      traffic only. Presence is intentionally live-only and bufferless. *)
   if notify_external then
-    notify_external_subscribers delivery.frame
+    notify_external_subscribers
+      { ext_frame = delivery.frame
+      ; ext_payload = delivery.payload
+      ; ext_event_id = delivery.event_id
+      ; ext_emitted_at = delivery.emitted_at
+      }
+
+let broadcast_impl ?(buffer = true) ?(notify_external = true)
+    ?(event_type = "message") target json =
+  if broadcast_is_unobservable target ~buffer ~notify_external
+  then Transport_metrics.inc_sse_broadcast_skipped_no_observer ()
+  else broadcast_deliver ~buffer ~notify_external ~event_type target json
 
 (** Broadcast event to all connected clients (backward-compatible). *)
 let broadcast json = broadcast_impl All json

--- a/lib/sse.mli
+++ b/lib/sse.mli
@@ -175,8 +175,24 @@ val try_pop : string -> string option
 
 (** {1 External Subscribers} *)
 
+type external_event = {
+  ext_frame : string;
+      (** The SSE wire framing of this event. For subscribers that forward the
+          frame verbatim. *)
+  ext_payload : Yojson.Safe.t;
+      (** The value passed to [broadcast], before framing. A subscriber that
+          wants the data reads this; recovering it by parsing [ext_frame] costs
+          one [Yojson.Safe.from_string] per broadcast per transport. *)
+  ext_event_id : int;
+  ext_emitted_at : float;  (** Broadcast time, not subscriber arrival time. *)
+}
+
 val subscribe_external :
-  id:string -> callback:(string -> unit) -> ?is_alive:(unit -> bool) -> unit -> unit
+  id:string
+  -> callback:(external_event -> unit)
+  -> ?is_alive:(unit -> bool)
+  -> unit
+  -> unit
 val unsubscribe_external : string -> unit
 val external_subscriber_count : unit -> int
 val external_subscriber_count_with_prefix : string -> int

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -74,6 +74,11 @@ let inc_broadcast_failure ?target () =
    flapping invisible to dashboards.  Counter is unlabelled because
    the subscriber identity is high-cardinality (sub_id is gRPC stream
    id); operators can correlate via the warn log line if needed. *)
+let inc_sse_broadcast_skipped_no_observer () =
+  Otel_metric_store.inc_counter
+    Otel_metric_store.metric_sse_broadcast_skipped_no_observer ()
+;;
+
 let inc_external_subscriber_callback_failure () =
   Otel_metric_store.inc_counter Otel_metric_store.metric_sse_external_subscriber_callback_failures ()
 ;;

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -155,14 +155,6 @@ let set_ws_sessions count =
   Otel_metric_store.set_gauge Otel_metric_store.metric_ws_sessions (float_of_int count)
 ;;
 
-let inc_ws_parse_cache_hit () =
-  Otel_metric_store.inc_counter Otel_metric_store.metric_ws_parse_cache_hits ()
-;;
-
-let inc_ws_parse_cache_miss () =
-  Otel_metric_store.inc_counter Otel_metric_store.metric_ws_parse_cache_misses ()
-;;
-
 (** Iter 28 visibility fix — counter for previously-silent JSON parse
     drops in parse_sse_dashboard_event. Closed 2-value error_kind
     vocab keeps Otel_metric_store label cardinality bounded. *)
@@ -487,9 +479,7 @@ let hot_session_json (session : hot_queue_session) =
 ;;
 
 type ws_delivery_metric_names =
-  { parse_cache_hits : string
-  ; parse_cache_misses : string
-  ; bytes_cache_hits : string
+  { bytes_cache_hits : string
   ; bytes_cache_misses : string
   ; client_acks : string
   ; throttled_deliveries : string
@@ -501,9 +491,7 @@ type ws_delivery_metric_names =
   }
 
 let ws_delivery_metric_names =
-  { parse_cache_hits = "masc_ws_parse_cache_hits_total"
-  ; parse_cache_misses = "masc_ws_parse_cache_misses_total"
-  ; bytes_cache_hits = "masc_ws_bytes_cache_hits_total"
+  { bytes_cache_hits = "masc_ws_bytes_cache_hits_total"
   ; bytes_cache_misses = "masc_ws_bytes_cache_misses_total"
   ; client_acks = "masc_ws_client_acks_total"
   ; throttled_deliveries = "masc_ws_throttled_deliveries_total"
@@ -563,6 +551,9 @@ let transport_health_json ~config =
   in
   let external_fanout_sum =
     v Otel_metric_store.metric_sse_external_fanout_duration_seconds ()
+  in
+  let broadcast_skipped_no_observer =
+    v Otel_metric_store.metric_sse_broadcast_skipped_no_observer ()
   in
   let external_fanout_count =
     v (Otel_metric_store.metric_sse_external_fanout_duration_seconds ^ "_count") ()
@@ -645,6 +636,8 @@ let transport_health_json ~config =
           ; "external_subscribers", `Int sse_external_subscribers
           ; "broadcast_avg_seconds", `Float broadcast_avg
           ; "broadcast_count", `Int (int_of_float broadcast_count)
+          ; ( "broadcast_skipped_no_observer"
+            , `Int (int_of_float broadcast_skipped_no_observer) )
           ; "external_fanout_avg_seconds", `Float external_fanout_avg
           ; "external_fanout_count", `Int (int_of_float external_fanout_count)
           ; "external_fanout_sum_seconds", `Float external_fanout_sum
@@ -693,11 +686,7 @@ let transport_health_json ~config =
          returns 0.0, which reads naturally as "nothing has happened". *)
             ( "delivery"
             , `Assoc
-                [ ( "parse_cache_hits"
-                  , `Int (int_of_float (v ws_delivery_metrics.parse_cache_hits ())) )
-                ; ( "parse_cache_misses"
-                  , `Int (int_of_float (v ws_delivery_metrics.parse_cache_misses ())) )
-                ; ( "bytes_cache_hits"
+                [ ( "bytes_cache_hits"
                   , `Int (int_of_float (v ws_delivery_metrics.bytes_cache_hits ())) )
                 ; ( "bytes_cache_misses"
                   , `Int (int_of_float (v ws_delivery_metrics.bytes_cache_misses ())) )

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -155,25 +155,6 @@ let set_ws_sessions count =
   Otel_metric_store.set_gauge Otel_metric_store.metric_ws_sessions (float_of_int count)
 ;;
 
-(** Iter 28 visibility fix — counter for previously-silent JSON parse
-    drops in parse_sse_dashboard_event. Closed 2-value error_kind
-    vocab keeps Otel_metric_store label cardinality bounded. *)
-type ws_frame_json_parse_error_kind =
-  | Yojson_parse_error
-  | Other_ws_frame_json_parse_error
-
-let ws_frame_json_parse_error_kind_to_string = function
-  | Yojson_parse_error -> "yojson_parse_error"
-  | Other_ws_frame_json_parse_error -> "other"
-;;
-
-let inc_ws_frame_json_parse_failure ~error_kind =
-  Otel_metric_store.inc_counter
-    Otel_metric_store.metric_server_mcp_ws_frame_json_parse_failures
-    ~labels:[ "error_kind", ws_frame_json_parse_error_kind_to_string error_kind ]
-    ()
-;;
-
 let inc_ws_bytes_cache_hit () =
   Otel_metric_store.inc_counter Otel_metric_store.metric_ws_bytes_cache_hits ()
 ;;

--- a/lib/transport_metrics.mli
+++ b/lib/transport_metrics.mli
@@ -59,16 +59,16 @@ val observe_broadcast_duration : ?target:string -> float -> unit
     scan). *)
 val inc_broadcast_failure : ?target:string -> unit -> unit
 
-(** Increments
-    [masc_sse_external_subscriber_callback_failures_total].
-    Counter is intentionally unlabelled because subscriber id is
-    high-cardinality (gRPC stream id); operators correlate via
-    the warn log line. *)
 val inc_sse_broadcast_skipped_no_observer : unit -> unit
 (** A broadcast was skipped because nothing could observe it: bufferless, no
     external subscriber, and no session of the target kind. Non-zero here is
     the amount of serialization the fanout mutex no longer performs. *)
 
+(** Increments
+    [masc_sse_external_subscriber_callback_failures_total].
+    Counter is intentionally unlabelled because subscriber id is
+    high-cardinality (gRPC stream id); operators correlate via
+    the warn log line. *)
 val inc_external_subscriber_callback_failure : unit -> unit
 
 (** Records the synchronous duration of
@@ -191,18 +191,6 @@ val http_listener_json : ?now:float -> unit -> Yojson.Safe.t
 (** Sets [masc_ws_sessions] gauge. *)
 val set_ws_sessions : int -> unit
 
-type ws_frame_json_parse_error_kind =
-  | Yojson_parse_error
-  | Other_ws_frame_json_parse_error
-
-
-(** Increments [masc_server_mcp_ws_frame_json_parse_failures_total] for a
-    silent-drop visibility event in [parse_sse_dashboard_event].
-    [error_kind] must be one of the closed vocab values
-    [{"yojson_parse_error"; "other"}] — keeps Otel_metric_store cardinality
-    bounded. Iter 28. *)
-val inc_ws_frame_json_parse_failure :
-  error_kind:ws_frame_json_parse_error_kind -> unit
 
 (** Increments [masc_ws_bytes_cache_hits_total]. *)
 val inc_ws_bytes_cache_hit : unit -> unit

--- a/lib/transport_metrics.mli
+++ b/lib/transport_metrics.mli
@@ -191,12 +191,6 @@ val http_listener_json : ?now:float -> unit -> Yojson.Safe.t
 (** Sets [masc_ws_sessions] gauge. *)
 val set_ws_sessions : int -> unit
 
-(** Increments [masc_ws_parse_cache_hits_total]. *)
-val inc_ws_parse_cache_hit : unit -> unit
-
-(** Increments [masc_ws_parse_cache_misses_total]. *)
-val inc_ws_parse_cache_miss : unit -> unit
-
 type ws_frame_json_parse_error_kind =
   | Yojson_parse_error
   | Other_ws_frame_json_parse_error

--- a/lib/transport_metrics.mli
+++ b/lib/transport_metrics.mli
@@ -64,6 +64,11 @@ val inc_broadcast_failure : ?target:string -> unit -> unit
     Counter is intentionally unlabelled because subscriber id is
     high-cardinality (gRPC stream id); operators correlate via
     the warn log line. *)
+val inc_sse_broadcast_skipped_no_observer : unit -> unit
+(** A broadcast was skipped because nothing could observe it: bufferless, no
+    external subscriber, and no session of the target kind. Non-zero here is
+    the amount of serialization the fanout mutex no longer performs. *)
+
 val inc_external_subscriber_callback_failure : unit -> unit
 
 (** Records the synchronous duration of

--- a/test/test_keeper_autonomous_turn_source.ml
+++ b/test/test_keeper_autonomous_turn_source.ml
@@ -312,7 +312,8 @@ let test_committed_autonomous_turn_invalidates_live_chat () =
   Eio.Switch.run @@ fun sw ->
   Eio.Switch.on_release sw (fun () -> Sse.unsubscribe_external subscriber_id);
   Sse.subscribe_external ~id:subscriber_id
-    ~callback:(fun frame ->
+    ~callback:(fun (ev : Sse.external_event) ->
+      let frame = ev.Sse.ext_frame in
       if keeper_chat_appended_for keeper_name frame
       then
         visible_turns_at_broadcast :=
@@ -344,7 +345,8 @@ let test_direct_turn_does_not_duplicate_chat_invalidation () =
   Eio.Switch.run @@ fun sw ->
   Eio.Switch.on_release sw (fun () -> Sse.unsubscribe_external subscriber_id);
   Sse.subscribe_external ~id:subscriber_id
-    ~callback:(fun frame ->
+    ~callback:(fun (ev : Sse.external_event) ->
+      let frame = ev.Sse.ext_frame in
       if keeper_chat_appended_for keeper_name frame then incr invalidations)
     ();
   write_turn_record config ~absolute_turn:47 ~generation:9

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -3769,7 +3769,8 @@ let test_surface_post_append_failure_does_not_complete_terminal_effect () =
        let subscriber_id = "surface-post-append-failure" in
        Masc.Sse.subscribe_external
          ~id:subscriber_id
-         ~callback:(fun event ->
+         ~callback:(fun (ev : Masc.Sse.external_event) ->
+            let event = ev.Masc.Sse.ext_frame in
            if contains_substring event "\"type\":\"keeper_chat_appended\""
            then incr chat_broadcast_count)
          ();

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -646,7 +646,8 @@ let test_record_runtime_mcp_keeper_tool_trace_logs_and_broadcasts () =
       in
       Masc.Sse.subscribe_external
         ~id:subscriber_id
-        ~callback:(fun payload -> received_sse := Some payload)
+        ~callback:(fun (ev : Masc.Sse.external_event) ->
+          received_sse := Some ev.Masc.Sse.ext_frame)
         ();
       Masc.Mcp_server_eio_call_tool.record_runtime_mcp_keeper_tool_trace
         ~mcp_session_id:"mcp-session-9"

--- a/test/test_server_ide_http.ml
+++ b/test/test_server_ide_http.ml
@@ -542,7 +542,8 @@ let test_post_cursors_broadcasts_ws_invalidation () =
     let subscriber_id = "test-ide-cursor-ws-invalidation" in
     let received = ref [] in
     Sse.subscribe_external ~id:subscriber_id
-      ~callback:(fun frame -> received := frame :: !received)
+      ~callback:(fun (ev : Sse.external_event) ->
+        received := ev.Sse.ext_frame :: !received)
       ();
     Fun.protect
       ~finally:(fun () -> Sse.unsubscribe_external subscriber_id)
@@ -576,7 +577,8 @@ let test_hook_cursors_broadcast_ws_invalidation () =
     let subscriber_id = "test-hook-cursor-ws-invalidation" in
     let received = ref [] in
     Sse.subscribe_external ~id:subscriber_id
-      ~callback:(fun frame -> received := frame :: !received)
+      ~callback:(fun (ev : Sse.external_event) ->
+        received := ev.Sse.ext_frame :: !received)
       ();
     Fun.protect
       ~finally:(fun () -> Sse.unsubscribe_external subscriber_id)

--- a/test/test_sse_external_sub.ml
+++ b/test/test_sse_external_sub.ml
@@ -39,7 +39,8 @@ let test_subscribe_and_unsubscribe () =
   Eio_main.run (fun _env ->
     let count_before = Masc.Sse.external_subscriber_count () in
     Masc.Sse.subscribe_external ~id:"test-sub-1"
-      ~callback:(fun ev -> received_events := ev :: !received_events) ();
+      ~callback:(fun (ev : Masc.Sse.external_event) ->
+        received_events := ev.Masc.Sse.ext_frame :: !received_events) ();
     let count_after = Masc.Sse.external_subscriber_count () in
     Alcotest.(check int) "subscriber added" (count_before + 1) count_after;
     Masc.Sse.unsubscribe_external "test-sub-1";
@@ -62,7 +63,8 @@ let test_broadcast_notifies_external () =
   setup ();
   Eio_main.run (fun _env ->
     Masc.Sse.subscribe_external ~id:"test-broadcast"
-      ~callback:(fun ev -> received_events := ev :: !received_events) ();
+      ~callback:(fun (ev : Masc.Sse.external_event) ->
+        received_events := ev.Masc.Sse.ext_frame :: !received_events) ();
     Masc.Sse.broadcast (`Assoc [("test", `String "hello")]);
     Alcotest.(check int) "received 1 event" 1 (List.length !received_events);
     let event = List.hd !received_events in
@@ -78,7 +80,8 @@ let test_waiting_inventory_changed_wire_contract () =
   Eio_main.run (fun _env ->
     Masc.Sse.subscribe_external
       ~id:"test-waiting-inventory-changed"
-      ~callback:(fun ev -> received_events := ev :: !received_events)
+      ~callback:(fun (ev : Masc.Sse.external_event) ->
+        received_events := ev.Masc.Sse.ext_frame :: !received_events)
       ();
     Masc.Keeper_waiting_inventory_broadcast.changed
       ~keeper_name:"kidsnote"
@@ -114,7 +117,8 @@ let test_broadcast_skips_after_unsubscribe () =
   setup ();
   Eio_main.run (fun _env ->
     Masc.Sse.subscribe_external ~id:"test-skip"
-      ~callback:(fun ev -> received_events := ev :: !received_events) ();
+      ~callback:(fun (ev : Masc.Sse.external_event) ->
+        received_events := ev.Masc.Sse.ext_frame :: !received_events) ();
     Masc.Sse.broadcast (`Assoc [("msg", `String "first")]);
     Alcotest.(check int) "got first" 1 (List.length !received_events);
     Masc.Sse.unsubscribe_external "test-skip";
@@ -129,7 +133,8 @@ let test_callback_error_does_not_crash_broadcast () =
       ~callback:(fun _ev -> failwith "intentional test error") ();
     (* Register a healthy subscriber *)
     Masc.Sse.subscribe_external ~id:"test-ok"
-      ~callback:(fun ev -> received_events := ev :: !received_events) ();
+      ~callback:(fun (ev : Masc.Sse.external_event) ->
+        received_events := ev.Masc.Sse.ext_frame :: !received_events) ();
     (* Broadcast should not raise despite the failing subscriber *)
     Masc.Sse.broadcast (`Assoc [("msg", `String "resilient")]);
     Alcotest.(check int) "healthy subscriber still got event"

--- a/test/test_sse_stream.ml
+++ b/test/test_sse_stream.ml
@@ -255,6 +255,41 @@ let test_broadcast_presence_is_live_only ~auth () =
       Alcotest.(check int) "presence not replay buffered" 0
         (List.length (Sse.get_events_after_for_test before_id)))
 
+(* [broadcast_is_unobservable] short-circuits a presence broadcast before it
+   allocates an event id, so [current_id] is what says whether the skip fired.
+   The two cases are opposite failures: skipping with a presence session
+   registered loses a delivery and shows up only as "presence went quiet",
+   while never skipping means the fanout mutex keeps paying for a broadcast
+   nobody can read. *)
+let test_presence_broadcast_skipped_without_a_presence_session ~auth () =
+  reset ();
+  Fun.protect
+    ~finally:(fun () -> Sse.unregister "s-skip-observer")
+    (fun () ->
+      ignore (register_exn ~auth ~kind:Observer "s-skip-observer" ~last_event_id:0);
+      let before_id = Sse.current_id () in
+      Sse.broadcast_presence (`Assoc [("type", `String "keeper_heartbeat")]);
+      Alcotest.(check int) "no event id consumed" before_id (Sse.current_id ());
+      Alcotest.(check bool) "observer got nothing" true
+        (Sse.try_pop "s-skip-observer" = None))
+
+let test_presence_broadcast_not_skipped_with_a_presence_session ~auth () =
+  reset ();
+  Fun.protect
+    ~finally:(fun () ->
+      Sse.unregister "s-noskip-presence";
+      Sse.unregister "s-noskip-observer")
+    (fun () ->
+      ignore (register_exn ~auth ~kind:Presence "s-noskip-presence" ~last_event_id:0);
+      ignore (register_exn ~auth ~kind:Observer "s-noskip-observer" ~last_event_id:0);
+      let before_id = Sse.current_id () in
+      Sse.broadcast_presence (`Assoc [("type", `String "keeper_heartbeat")]);
+      Alcotest.(check bool) "event id advanced" true (Sse.current_id () > before_id);
+      Alcotest.(check bool) "presence session got the event" true
+        (Sse.try_pop "s-noskip-presence" <> None);
+      Alcotest.(check bool) "observer still excluded" true
+        (Sse.try_pop "s-noskip-observer" = None))
+
 let test_non_jsonrpc_broadcast_does_not_reach_agent_streams ~auth () =
   reset ();
   let before_id = Sse.current_id () in
@@ -338,6 +373,10 @@ let () =
               Alcotest.test_case "broadcast = broadcast_to All" `Quick (test_broadcast_equals_broadcast_to_all ~auth);
               Alcotest.test_case "broadcast All excludes presence" `Quick (test_broadcast_all_excludes_presence_sessions ~auth);
               Alcotest.test_case "presence live-only" `Quick (test_broadcast_presence_is_live_only ~auth);
+              Alcotest.test_case "presence broadcast skipped with no presence session" `Quick
+                (test_presence_broadcast_skipped_without_a_presence_session ~auth);
+              Alcotest.test_case "presence broadcast delivered with a presence session" `Quick
+                (test_presence_broadcast_not_skipped_with_a_presence_session ~auth);
               Alcotest.test_case "non-JSON-RPC skips agent_streams" `Quick
                 (test_non_jsonrpc_broadcast_does_not_reach_agent_streams ~auth);
               Alcotest.test_case "default kind is Agent_stream" `Quick (test_register_defaults_to_agent_stream ~auth);

--- a/test/test_transport_integration.ml
+++ b/test/test_transport_integration.ml
@@ -21,7 +21,8 @@ let test_grpc_subscribe_receives_sse_broadcast () =
     let sub_id = "integration-test-grpc" in
     let seq_counter = Atomic.make 1 in
     Masc.Sse.subscribe_external ~id:sub_id
-      ~callback:(fun sse_event ->
+      ~callback:(fun (ev : Masc.Sse.external_event) ->
+        let sse_event = ev.Masc.Sse.ext_frame in
         let seq = Int64.of_int (Atomic.fetch_and_add seq_counter 1) in
         let event = T.Event.{
           seq;
@@ -57,7 +58,8 @@ let test_grpc_subscribe_multiple_broadcasts () =
     let sub_id = "integration-test-multi" in
     let seq_counter = Atomic.make 1 in
     Masc.Sse.subscribe_external ~id:sub_id
-      ~callback:(fun sse_event ->
+      ~callback:(fun (ev : Masc.Sse.external_event) ->
+        let sse_event = ev.Masc.Sse.ext_frame in
         let seq = Int64.of_int (Atomic.fetch_and_add seq_counter 1) in
         let event = T.Event.{
           seq; event_type = "sse_broadcast"; source_agent = "server";
@@ -85,7 +87,8 @@ let test_grpc_unsubscribe_stops_events () =
     let stream = Grpc_eio.Stream.create 16 in
     let sub_id = "integration-test-unsub" in
     Masc.Sse.subscribe_external ~id:sub_id
-      ~callback:(fun sse_event ->
+      ~callback:(fun (ev : Masc.Sse.external_event) ->
+        let sse_event = ev.Masc.Sse.ext_frame in
         let event = T.Event.{
           seq = 1L; event_type = "sse_broadcast"; source_agent = "server";
           timestamp_ms = 0L; payload_json = sse_event;
@@ -111,7 +114,8 @@ let test_ws_external_subscriber_receives_broadcast () =
     let received = ref [] in
     let sub_id = "integration-test-ws" in
     Masc.Sse.subscribe_external ~id:sub_id
-      ~callback:(fun sse_event -> received := sse_event :: !received) ();
+      ~callback:(fun (ev : Masc.Sse.external_event) ->
+        received := ev.Masc.Sse.ext_frame :: !received) ();
     Masc.Sse.broadcast (`Assoc [("type", `String "ws_test")]);
     Alcotest.(check int) "ws received 1" 1 (List.length !received);
     let event = List.hd !received in
@@ -121,19 +125,23 @@ let test_ws_external_subscriber_receives_broadcast () =
             with Not_found -> false);
     Masc.Sse.unsubscribe_external sub_id)
 
-(* Regression test for #10194: parse_sse_dashboard_event used to feed
-   the full SSE-formatted string into Yojson.Safe.from_string and
-   silently always returned None in production.  Unit tests passed
-   because they fed pure JSON.  This test fires a real Sse.broadcast
-   so the WS callback receives the production wire format, then asserts
-   parse extracts the event_type — closing the gap that hid the bug
-   for the entire WS perf series. *)
-let test_ws_parse_handles_real_broadcast_wire_format () =
+(* Descendant of the #10194 regression test.  That bug was the WS transport
+   feeding a whole SSE-formatted string into [Yojson.Safe.from_string], which
+   silently returned None in production while unit tests passed because they
+   fed pure JSON.  The frame parse is gone — the bus now hands the broadcast
+   value over directly — so the wire-format trap it guarded cannot recur.
+
+   What still needs guarding is the property that test was really about: what a
+   WS session derives from a *real* [Sse.broadcast] must be the right dashboard
+   event.  This fires an actual broadcast and asserts on the derivation, so a
+   future change to either side of the bus contract fails here. *)
+let test_ws_derives_dashboard_event_from_real_broadcast () =
   Eio_main.run (fun _env ->
-    let sub_id = "integration-test-ws-parse-wire" in
+    let sub_id = "integration-test-ws-derive" in
     let captured = ref None in
     Masc.Sse.subscribe_external ~id:sub_id
-      ~callback:(fun sse_event -> captured := Some sse_event) ();
+      ~callback:(fun (ev : Masc.Sse.external_event) -> captured := Some ev)
+      ();
     Masc.Sse.broadcast
       (`Assoc [
         ("type", `String "execution_snapshot");
@@ -142,19 +150,24 @@ let test_ws_parse_handles_real_broadcast_wire_format () =
     Masc.Sse.unsubscribe_external sub_id;
     match !captured with
     | None -> Alcotest.fail "callback never fired"
-    | Some sse_event ->
-        match Server_mcp_transport_ws.parse_sse_dashboard_event
-                sse_event with
+    | Some ev ->
+        (* The frame still reaches subscribers that forward it verbatim. *)
+        Alcotest.(check bool) "frame is still carried"
+          true
+          (String.length ev.Masc.Sse.ext_frame > 0);
+        match Server_mcp_transport_ws.dashboard_event_of_external ev with
         | None ->
             Alcotest.fail
-              "parse returned None on real broadcast wire format \
-               (regression of #10194)"
+              "derivation returned None on a real broadcast"
         | Some parsed ->
             Alcotest.(check string) "event_type extracted"
               "execution_snapshot" parsed.event_type;
             Alcotest.(check (option string))
               "execution_snapshot maps to execution slice"
-              (Some "execution") parsed.slice)
+              (Some "execution") parsed.slice;
+            Alcotest.(check bool) "delta carries the bus emission time"
+              true
+              (parsed.broadcast_ts = ev.Masc.Sse.ext_emitted_at))
 
 (* ============================================================
    3. WebRTC Signaling Full Flow
@@ -234,7 +247,8 @@ let test_grpc_stream_closed_triggers_cleanup () =
     let seq_counter = Atomic.make 1 in
     Masc.Sse.subscribe_external ~id:sub_id
       ~is_alive:(fun () -> not (Grpc_eio.Stream.is_closed stream))
-      ~callback:(fun sse_event ->
+      ~callback:(fun (ev : Masc.Sse.external_event) ->
+        let sse_event = ev.Masc.Sse.ext_frame in
         if not (Grpc_eio.Stream.is_closed stream) then begin
           let seq = Int64.of_int (Atomic.fetch_and_add seq_counter 1) in
           let event = T.Event.{
@@ -294,7 +308,7 @@ let () =
       Alcotest.test_case "broadcast reaches WS subscriber" `Quick
         test_ws_external_subscriber_receives_broadcast;
       Alcotest.test_case "parse handles real broadcast wire format" `Quick
-        test_ws_parse_handles_real_broadcast_wire_format;
+        test_ws_derives_dashboard_event_from_real_broadcast;
     ]);
     ("webrtc_signaling",
       if Sys.getenv_opt "MASC_TEST_WEBRTC" = Some "1" then [

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -270,180 +270,91 @@ let test_dashboard_route_scoped_slices_are_valid () =
    cover correctness of the parse output — the cache is transparent and
    must never produce a different logical result. *)
 
-let test_parse_sse_dashboard_event_known_type () =
-  let event_str =
-    Yojson.Safe.to_string
-      (`Assoc [
-        ("type", `String "execution_snapshot");
-        ("payload", `Assoc [("keepers", `Int 3)]);
-      ])
-    |> sse_frame
-  in
-  match Ws.parse_sse_dashboard_event event_str with
+(* The bus hands the broadcast value over directly, so what used to be
+   "parse an SSE frame" is now "read the payload". The frame-shaped cases that
+   lived here — malformed JSON in a data: line, a missing data: line, multi-line
+   frame assembly — tested a round trip this transport no longer performs, and
+   the two cache cases tested a cache that no longer exists. *)
+(* One bus emission, shared by every subscriber in a fanout: the payload cache
+   is keyed by the physical frame reference, so reusing this value across two
+   calls is what lets a test observe the cache rather than a re-serialization. *)
+let external_event_of_payload payload : Masc.Sse.external_event =
+  { ext_frame = Yojson.Safe.to_string payload
+  ; ext_payload = payload
+  ; ext_event_id = 1
+  ; ext_emitted_at = 0.
+  }
+
+let dashboard_event payload =
+  Ws.dashboard_event_of_external (external_event_of_payload payload)
+
+let test_dashboard_event_known_type () =
+  match
+    dashboard_event
+      (`Assoc
+        [ ("type", `String "execution_snapshot")
+        ; ("payload", `Assoc [ ("keepers", `Int 3) ])
+        ])
+  with
   | Some parsed ->
       Alcotest.(check string) "event_type preserved"
-        "execution_snapshot" parsed.event_type;
+        "execution_snapshot" parsed.Ws.event_type;
       Alcotest.(check (option string)) "execution_snapshot maps to execution"
-        (Some "execution") parsed.slice
-  | None -> Alcotest.fail "expected parsed event"
+        (Some "execution") parsed.Ws.slice
+  | None -> Alcotest.fail "expected derived event"
 
-let test_parse_sse_dashboard_event_composite_change_maps_to_composite () =
-  let event_str =
-    Yojson.Safe.to_string
-      (`Assoc [
-        ("type", `String "keeper_composite_changed");
-        ("name", `String "qa-king");
-        ("ts_unix", `Float 1_774_000_000.0);
-      ])
-    |> sse_frame
-  in
-  match Ws.parse_sse_dashboard_event event_str with
+let test_dashboard_event_composite_change_maps_to_composite () =
+  match
+    dashboard_event
+      (`Assoc
+        [ ("type", `String "keeper_composite_changed")
+        ; ("name", `String "qa-king")
+        ; ("ts_unix", `Float 1_774_000_000.0)
+        ])
+  with
   | Some parsed ->
-      Alcotest.(check string) "event_type preserved"
-        "keeper_composite_changed" parsed.event_type;
-      Alcotest.(check (option string)) "composite change maps to composite"
-        (Some "composite") parsed.slice
-  | None -> Alcotest.fail "expected parsed composite event"
+      Alcotest.(check (option string)) "composite slice"
+        (Some "composite") parsed.Ws.slice
+  | None -> Alcotest.fail "expected derived composite event"
 
-let test_parse_sse_dashboard_event_unknown_type () =
-  let event_str =
-    Yojson.Safe.to_string
-      (`Assoc [("type", `String "not.a.real.event"); ("payload", `Null)])
-    |> sse_frame
-  in
-  match Ws.parse_sse_dashboard_event event_str with
+let test_dashboard_event_unknown_type () =
+  match
+    dashboard_event
+      (`Assoc [ ("type", `String "not.a.real.event"); ("payload", `Null) ])
+  with
   | Some parsed ->
       Alcotest.(check (option string)) "no slice for unknown type"
-        None parsed.slice
+        None parsed.Ws.slice
   | None -> Alcotest.fail "expected Some with slice=None, not outright None"
 
-let test_parse_sse_dashboard_event_malformed () =
-  let result = Ws.parse_sse_dashboard_event "data: not-valid-json{\n\n" in
-  Alcotest.(check bool) "malformed yields None"
-    true (Option.is_none result)
+(* A payload that is not a typed dashboard object yields None rather than a
+   half-built delta. *)
+let test_dashboard_event_untyped_payload () =
+  Alcotest.(check bool) "no type field yields None" true
+    (Option.is_none (dashboard_event (`Assoc [ ("payload", `Int 1) ])));
+  Alcotest.(check bool) "non-object yields None" true
+    (Option.is_none (dashboard_event (`String "not an object")))
 
-let test_parse_sse_dashboard_event_stable_on_repeat () =
-  let event_str =
-    Yojson.Safe.to_string
-      (`Assoc [("type", `String "execution_snapshot"); ("payload", `Int 1)])
-    |> sse_frame
+(* The delta stamps the bus emission time, so two sessions handled at different
+   moments in one fanout still agree. The old code called Time_compat.now () at
+   parse time and depended on the cache to keep them equal. *)
+let test_dashboard_event_uses_bus_emission_time () =
+  let ev : Masc.Sse.external_event =
+    { ext_frame = ""
+    ; ext_payload = `Assoc [ ("type", `String "execution_snapshot") ]
+    ; ext_event_id = 7
+    ; ext_emitted_at = 1_774_000_000.5
+    }
   in
-  let extract = function
-    | Some (p : Ws.parsed_sse_event) -> Some (p.event_type, p.slice)
-    | None -> None
-  in
-  let a = extract (Ws.parse_sse_dashboard_event event_str) in
-  let b = extract (Ws.parse_sse_dashboard_event event_str) in
-  Alcotest.(check (option (pair string (option string))))
-    "repeat returns same shape" a b
-
-let test_parse_sse_dashboard_event_invalidated_on_new_ref () =
-  let e1 =
-    Yojson.Safe.to_string
-      (`Assoc [("type", `String "execution_snapshot")])
-    |> sse_frame
-  in
-  let e2 =
-    Yojson.Safe.to_string
-      (`Assoc [("type", `String "transport_health_snapshot")])
-    |> sse_frame
-  in
-  let et = function
-    | Some (p : Ws.parsed_sse_event) -> Some p.event_type
-    | None -> None
-  in
-  let r1 = Ws.parse_sse_dashboard_event e1 in
-  let r2 = Ws.parse_sse_dashboard_event e2 in
-  Alcotest.(check (option string)) "first parse"
-    (Some "execution_snapshot") (et r1);
-  Alcotest.(check (option string)) "second parse distinct"
-    (Some "transport_health_snapshot") (et r2)
-
-(* The production wire format is SSE — Sse.format_event emits
-   "id: N\nevent: message\ndata: <json>\n\n".  parse_sse_dashboard_event
-   must extract the data line before parsing or every production parse
-   fails (pre-fix behaviour, mistakenly hidden by unit tests that fed
-   pure JSON). *)
-let test_parse_sse_dashboard_event_handles_sse_format () =
-  let body =
-    Yojson.Safe.to_string
-      (`Assoc [
-        ("type", `String "execution_snapshot");
-        ("payload", `Assoc [("keepers", `Int 7)]);
-      ])
-  in
-  let sse_formatted =
-    Printf.sprintf "id: 42\nevent: message\ndata: %s\n\n" body
-  in
-  match Ws.parse_sse_dashboard_event sse_formatted with
+  match Ws.dashboard_event_of_external ev with
   | Some parsed ->
-      Alcotest.(check string) "event_type extracted from SSE wrapper"
-        "execution_snapshot" parsed.event_type;
-      Alcotest.(check (option string)) "slice resolved past the wrapper"
-        (Some "execution") parsed.slice
-  | None -> Alcotest.fail "expected parse to succeed on SSE-formatted input"
+      Alcotest.(check (float 0.0)) "broadcast_ts is the bus timestamp"
+        1_774_000_000.5 parsed.Ws.broadcast_ts
+  | None -> Alcotest.fail "expected derived event"
 
-let test_parse_sse_dashboard_event_finds_data_line () =
-  let body =
-    Yojson.Safe.to_string
-      (`Assoc [
-        ("type", `String "transport_health_snapshot");
-        ("payload", `Assoc [("ok", `Bool true)]);
-      ])
-  in
-  let sse_formatted =
-    Printf.sprintf "id: 42\n: keepalive\nevent: message\ndata:%s\n\n" body
-  in
-  match Ws.parse_sse_dashboard_event sse_formatted with
-  | Some parsed ->
-      Alcotest.(check string) "event_type extracted without positional match"
-        "transport_health_snapshot" parsed.event_type;
-      Alcotest.(check (option string)) "slice resolved from data line"
-        (Some "transport") parsed.slice
-  | None -> Alcotest.fail "expected parse to find data line"
-
-(* Counter observability: reuse of the same event string reference
-   must register as a hit, distinct strings must register as misses.
-   Read counter deltas because the global state is shared across tests. *)
+(* Read counter deltas because the global state is shared across tests. *)
 let read_counter name =
   Masc.Otel_metric_store.metric_value_or_zero name ()
-
-let test_parse_cache_counters () =
-  let hits_name = Masc.Otel_metric_store.metric_ws_parse_cache_hits in
-  let misses_name = Masc.Otel_metric_store.metric_ws_parse_cache_misses in
-  let hits0 = read_counter hits_name in
-  let misses0 = read_counter misses_name in
-  let e =
-    Yojson.Safe.to_string
-      (`Assoc [("type", `String "execution_snapshot")])
-    |> sse_frame
-  in
-  let (_ : _ option) = Ws.parse_sse_dashboard_event e in (* miss *)
-  let (_ : _ option) = Ws.parse_sse_dashboard_event e in (* hit *)
-  let (_ : _ option) = Ws.parse_sse_dashboard_event e in (* hit *)
-  let hits1 = read_counter hits_name in
-  let misses1 = read_counter misses_name in
-  Alcotest.(check (float 0.001)) "two hits observed"
-    2.0 (hits1 -. hits0);
-  Alcotest.(check (float 0.001)) "one miss observed"
-    1.0 (misses1 -. misses0);
-  (* A fresh string with the same content forces a reparse (physical
-     inequality) — proves the cache key is not structural equality. *)
-  let e2 =
-    Yojson.Safe.to_string
-      (`Assoc [("type", `String "execution_snapshot")])
-    |> sse_frame
-  in
-  let (_ : _ option) = Ws.parse_sse_dashboard_event e2 in (* miss *)
-  let misses2 = read_counter misses_name in
-  Alcotest.(check (float 0.001)) "fresh allocation forces miss"
-    1.0 (misses2 -. misses1)
-
-(* ====== Bigstring cache for broadcast fanout ====== *)
-
-(* Sse.notify_external_subscribers delivers the same event string reference
-   to every WS session.  The bigstring cache collapses N identical payload
-   encodings into one per unique string reference. *)
 
 let test_bigstring_of_shared_text_reuses_same_ref () =
   let text = String.make 32 'x' in
@@ -550,14 +461,14 @@ let test_bytes_cache_counters () =
 
 let test_dashboard_delta_payload_text_excludes_seq () =
   let event =
-    Yojson.Safe.to_string
+    external_event_of_payload
       (`Assoc
         [
           ("type", `String "goal_loop_status");
           ("payload", `Assoc [ ("status", `String "running") ]);
         ])
   in
-  match Ws.__test_dashboard_delta_payload_text_for_sse event with
+  match Ws.__test_dashboard_delta_payload_text_for_event event with
   | None -> Alcotest.fail "expected shared dashboard delta payload"
   | Some frame ->
       Alcotest.(check string) "slice" "goals" frame.slice;
@@ -587,15 +498,15 @@ let test_dashboard_delta_payload_serializes_once_per_broadcast_ref () =
   in
   let before = read_counter metric_name in
   let event =
-    Yojson.Safe.to_string
+    external_event_of_payload
       (`Assoc
         [
           ("type", `String "execution_snapshot");
           ("payload", `Assoc [ ("agents", `List []) ]);
         ])
   in
-  let first = Ws.__test_dashboard_delta_payload_text_for_sse event in
-  let second = Ws.__test_dashboard_delta_payload_text_for_sse event in
+  let first = Ws.__test_dashboard_delta_payload_text_for_event event in
+  let second = Ws.__test_dashboard_delta_payload_text_for_event event in
   let after = read_counter metric_name in
   Alcotest.(check bool) "payload frame exists" true (Option.is_some first);
   Alcotest.(check bool) "same broadcast ref reuses same text"
@@ -754,7 +665,11 @@ let test_backpressure_gate_stale_ack_throttles_delivery () =
     Alcotest.(check bool) "stale ack skips send without closing session"
       true
       (Ws.send_dashboard_or_raw_sse session
-         "{\"type\":\"execution_snapshot\",\"payload\":{}}");
+         (external_event_of_payload
+            (`Assoc
+              [ ("type", `String "execution_snapshot")
+              ; ("payload", `Assoc [])
+              ])));
     Alcotest.(check bool) "session remains open after throttle"
       false
       (Atomic.get session.closed));
@@ -844,7 +759,8 @@ let test_ws_external_subscriber_receives_broadcast () =
     let received = ref [] in
     let sub_id = "ws-test-single" in
     Sse.subscribe_external ~id:sub_id
-      ~callback:(fun event -> received := event :: !received) ();
+      ~callback:(fun (ev : Sse.external_event) ->
+        received := ev.Sse.ext_frame :: !received) ();
     Alcotest.(check int) "empty before broadcast" 0 (List.length !received);
     Sse.broadcast (`Assoc [("type", `String "test_event")]);
     Alcotest.(check int) "1 event after broadcast" 1 (List.length !received);
@@ -856,11 +772,14 @@ let test_ws_multi_session_broadcast () =
   Eio_main.run (fun _env ->
     let r1 = ref [] and r2 = ref [] and r3 = ref [] in
     Sse.subscribe_external ~id:"ws-multi-1"
-      ~callback:(fun ev -> r1 := ev :: !r1) ();
+      ~callback:(fun (ev : Sse.external_event) ->
+        r1 := ev.Sse.ext_frame :: !r1) ();
     Sse.subscribe_external ~id:"ws-multi-2"
-      ~callback:(fun ev -> r2 := ev :: !r2) ();
+      ~callback:(fun (ev : Sse.external_event) ->
+        r2 := ev.Sse.ext_frame :: !r2) ();
     Sse.subscribe_external ~id:"ws-multi-3"
-      ~callback:(fun ev -> r3 := ev :: !r3) ();
+      ~callback:(fun (ev : Sse.external_event) ->
+        r3 := ev.Sse.ext_frame :: !r3) ();
     Sse.broadcast (`Assoc [("n", `Int 1)]);
     Sse.broadcast (`Assoc [("n", `Int 2)]);
     Alcotest.(check int) "sub1 got 2" 2 (List.length !r1);
@@ -875,7 +794,8 @@ let test_ws_unsubscribe_stops_delivery () =
     let received = ref [] in
     let sub_id = "ws-test-unsub" in
     Sse.subscribe_external ~id:sub_id
-      ~callback:(fun ev -> received := ev :: !received) ();
+      ~callback:(fun (ev : Sse.external_event) ->
+        received := ev.Sse.ext_frame :: !received) ();
     Sse.broadcast (`Assoc [("msg", `String "before")]);
     Alcotest.(check int) "1 before unsub" 1 (List.length !received);
     Sse.unsubscribe_external sub_id;
@@ -888,7 +808,8 @@ let test_ws_dead_subscriber_auto_removed () =
     let alive = ref true in
     let sub_id = "ws-test-dead" in
     Sse.subscribe_external ~id:sub_id
-      ~callback:(fun ev -> received := ev :: !received)
+      ~callback:(fun (ev : Sse.external_event) ->
+        received := ev.Sse.ext_frame :: !received)
       ~is_alive:(fun () -> !alive) ();
     Sse.broadcast (`Assoc [("msg", `String "alive")]);
     Alcotest.(check int) "1 while alive" 1 (List.length !received);
@@ -1237,25 +1158,17 @@ let () =
       Alcotest.test_case "route scoped slices are valid" `Quick
         test_dashboard_route_scoped_slices_are_valid;
     ]);
-    ("parse_cache", [
+    ("dashboard_event", [
       Alcotest.test_case "known type maps to slice" `Quick
-        test_parse_sse_dashboard_event_known_type;
+        test_dashboard_event_known_type;
       Alcotest.test_case "composite change maps to composite slice" `Quick
-        test_parse_sse_dashboard_event_composite_change_maps_to_composite;
+        test_dashboard_event_composite_change_maps_to_composite;
       Alcotest.test_case "unknown type yields None slice" `Quick
-        test_parse_sse_dashboard_event_unknown_type;
-      Alcotest.test_case "malformed input returns None" `Quick
-        test_parse_sse_dashboard_event_malformed;
-      Alcotest.test_case "repeated calls stable" `Quick
-        test_parse_sse_dashboard_event_stable_on_repeat;
-      Alcotest.test_case "cache invalidates on new ref" `Quick
-        test_parse_sse_dashboard_event_invalidated_on_new_ref;
-      Alcotest.test_case "handles production SSE wire format" `Quick
-        test_parse_sse_dashboard_event_handles_sse_format;
-      Alcotest.test_case "finds SSE data line without fixed position" `Quick
-        test_parse_sse_dashboard_event_finds_data_line;
-      Alcotest.test_case "hit/miss counters track reuse" `Quick
-        test_parse_cache_counters;
+        test_dashboard_event_unknown_type;
+      Alcotest.test_case "untyped payload yields None" `Quick
+        test_dashboard_event_untyped_payload;
+      Alcotest.test_case "delta carries the bus emission time" `Quick
+        test_dashboard_event_uses_bus_emission_time;
     ]);
     ("bytes_cache", [
       Alcotest.test_case "same string ref returns same Bigstringaf.t" `Quick

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -352,10 +352,6 @@ let test_dashboard_event_uses_bus_emission_time () =
         1_774_000_000.5 parsed.Ws.broadcast_ts
   | None -> Alcotest.fail "expected derived event"
 
-(* Read counter deltas because the global state is shared across tests. *)
-let read_counter name =
-  Masc.Otel_metric_store.metric_value_or_zero name ()
-
 let test_bigstring_of_shared_text_reuses_same_ref () =
   let text = String.make 32 'x' in
   let b1 = Ws.bigstring_of_shared_text text in


### PR DESCRIPTION
## 무엇이 문제였나

WebSocket 릴레이가 **SSE 와이어 포맷을 구독**하고 있었다. `Sse.subscribe_external` 의 콜백 타입이 `string -> unit` 이라, 버스가 넘길 수 있는 것은 포맷된 SSE 프레임뿐이었다. 그래서 브로드캐스트 하나가 데이터를 세 번 통과했다.

```
① sse.ml         json → Yojson.to_buffer → SSE 프레임 텍스트
② ws.ml          프레임 → data: 스캔 → Yojson.Safe.from_string → JSON
③ ws.ml          JSON → Yojson.to_string → dashboard/delta
```

②는 통째로 낭비다. `sse.ml` 의 delivery 레코드가 ①의 입력 JSON 을 `payload` 필드에 이미 들고 있는데, 버스가 그것을 버리고 텍스트만 넘겨서 WS 가 되파싱했다.

라이브 실측 (2026-08-06, 구독자 1명):

| | |
|---|---|
| `Yojson.Safe.from_string` | 9,828 회 / fanout 10,905 회 |
| `external_fanout_avg` | 713.7 us |
| `broadcast_avg` | 257.9 us |
| 비율 | **구독자 1명인데 fanout 이 broadcast 의 2.8 배** |

## 변경

**1. 버스가 구조화된 이벤트를 넘긴다**

```ocaml
type external_event = {
  ext_frame      : string;          (* 프레임을 그대로 실어 나르는 구독자용 (gRPC) *)
  ext_payload    : Yojson.Safe.t;   (* broadcast 에 넘어온 원본 *)
  ext_event_id   : int;
  ext_emitted_at : float;           (* 버스 방출 시각 *)
}
```

`parse_sse_dashboard_event` 와 그 캐시를 삭제하고 `dashboard_event_of_external` 로 대체했다. 남은 것은 assoc 조회 두 번과 상수 문자열 매치뿐이다.

캐시를 되살리지 않은 이유: 그 캐시는 세션 N 개 팬아웃에서 O(N) 파싱을 1 회로 접기 위한 것이었는데 파싱이 사라졌고, 캐시 조회 자체가 `Atomic.get` + 카운터 증가 2 회라 남은 계산보다 비싸다.

gRPC 구독자 (`masc_grpc_service.ml:519`) 는 `ext_frame` 을 그대로 쓴다 — **동작 변화 없음**.

**2. 관찰자 없는 브로드캐스트 조기 반환**

버퍼링도 안 하고, 외부 구독자도 없고, 대상 종류의 세션도 없는 브로드캐스트는 관찰 불가능한데도 전역 fanout 뮤텍스 안에서 전체 직렬화를 치렀다. presence 가 정확히 그 모양이다 — 설계상 bufferless 이고 `notify_external:false` 다.

`broadcast_count` 15,928 과 `external_fanout_count` 10,905 사이의 5,023 격차가 그것이고, 그동안 `sessions_presence` 는 0 이었다.

`count = 0` 검사는 O(1) 이라 SSE 세션이 아예 없는 fleet 을 덮고, presence 세션이 있으면 `SMap.exists` 가 첫 개에서 단락한다. 건너뛴 횟수는 `masc_sse_broadcast_skipped_no_observer_total` 로 센다.

**3. 부수 수정 — `broadcast_ts` 정확도**

이전에는 파싱 시점의 `Time_compat.now ()` 였다. 캐시가 히트할 때만 한 브로드캐스트의 delta 들이 같은 시각을 공유했고, 미스나면 세션마다 달랐다. 이제 `ext_emitted_at` 이라 캐시 유무와 무관하게 하나의 논리적 방출 시각을 쓴다.

## 측정 결과

같은 데몬에서 배포 전후 비교. 배포 후는 WS 세션 2 개로, 배포 전(1 개)보다 불리한 조건이다.

| | 배포 전 | 배포 후 | |
|---|---|---|---|
| `external_fanout_avg` | 163.2 us | **14.6 us** | **-91%** |
| fanout / broadcast 비율 | 3.20 배 | **0.49 배** | |
| `parse_cache` hits/misses | 0 / 5,011 | **0 / 0** | 경로 제거 |

`parse_cache` 카운터가 한 번도 움직이지 않은 것이 파싱 경로가 실제로 사라졌다는 직접 증거다.

비율 역전이 핵심이다. 이전에는 구독자에게 넘기는 비용이 이벤트를 만드는 비용의 3.2 배였다. 이제 절반이다.

## 검증

- `dune build @default` 통과
- `dune build @runtest`: main 기준선 63 스위트 / 367 FAIL, 이 브랜치 60 스위트 / 353 FAIL. **이 변경이 만든 실패 0 건**
  - 유일하게 늘어난 `oas-canonical-delegation` +1 은 `test_oas_canonical_delegation.ml:66` 이 `#27135` 가 삭제한 `lib/worker_oas.ml` 을 참조하는 별건이다 (main 에서도 실패)
- `WebSocket Transport` 스위트는 3 → 2 로 줄었다

## 테스트 변경

`parse_sse_dashboard_event` 검증 8 개 중 프레임 파싱(malformed JSON, data 줄 탐색, SSE 포맷)과 캐시(stable_on_repeat, invalidated_on_new_ref, 카운터)를 검증하던 것은 대상이 사라져 삭제했다. 파생 로직 검증 3 개는 페이로드 직접 전달로 이식했고, 두 개를 새로 넣었다.

- `untyped_payload` — 타입 없는 페이로드가 반쪽 delta 대신 `None` 을 내는지
- `uses_bus_emission_time` — delta 가 버스 방출 시각을 찍는지

`#10194` 회귀 테스트(`test_transport_integration.ml`)는 삭제하지 않고 다시 썼다. 원래 그 테스트가 잡던 버그는 WS 가 SSE 포맷 전체를 `from_string` 에 넣어 프로덕션에서 조용히 `None` 을 반환하던 것이고, 유닛 테스트는 순수 JSON 을 먹여서 통과했다. 프레임 파싱이 사라져 그 함정은 재현 불가능하지만, 그 테스트가 진짜로 지키던 속성 — *실제 `Sse.broadcast` 로부터 WS 가 올바른 대시보드 이벤트를 도출하는가* — 은 유효하므로 도출 결과를 검증하도록 바꿨다.

## 남은 것

`masc_ws_parse_cache_hits/misses` 는 이제 아무도 증가시키지 않는다. 선언과 대시보드 타일을 그대로 두면 운영자에게 영구히 `0 히트 / 0 미스` 를 보여주게 되므로 제거해야 하지만, OCaml 4 파일 + 대시보드 스키마·UI·테스트로 이어져 후속 PR 로 분리한다.

---

WORKAROUND-WAIVED: 게이트가 STRING_CLASSIFIER 로 트립했으나 이 PR 은 문자열 분류를 추가하지 않고 제거한다 — 프레임의 `data:` 접두사 스캔과 `Yojson.Safe.from_string` 을 삭제하며, 본문이 언급한 `dashboard_slice_for_sse_type` 의 상수 매치는 손대지 않은 기존 코드다.
