### PR TITLE
fix(board): a comment on your own post wakes you

### DIFF
--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -328,6 +328,10 @@ let board_signal_stimulus
       (match reason with
        | Board_wake.Explicit_mention | Board_wake.Broadcast ->
          Keeper_event_queue.Immediate
+       (* A comment on the keeper's own post is a thread event, so it keeps
+          the thread priority. This change's subject is that it wakes at all;
+          raising it to Immediate would be a separate queue decision. *)
+       | Board_wake.Comment_on_self_post
        | Board_wake.Thread_reply_after_self_comment
        | Board_wake.Reaction_after_self_activity ->
          Keeper_event_queue.Normal)
@@ -652,6 +656,7 @@ let wakeup_relevant_keeper_for_board_signal
                       match reason with
                       | Board_wake.Broadcast -> Keeper_registry.Broadcast_signal
                       | Board_wake.Explicit_mention
+                      | Board_wake.Comment_on_self_post
                       | Board_wake.Thread_reply_after_self_comment
                       | Board_wake.Reaction_after_self_activity ->
                         Keeper_registry.Reactive_signal

--- a/lib/keeper/keeper_world_observation_board_signal.ml
+++ b/lib/keeper/keeper_world_observation_board_signal.ml
@@ -327,6 +327,11 @@ type wake_reason =
   | Broadcast
       (** The exact [@@all] Keeper Board address selected every non-author
           lane. *)
+  | Comment_on_self_post
+      (** An external comment arrived on a post the keeper authored. The
+          reaction path already woke the author of the post it landed on; the
+          comment path checked only whether the keeper had itself commented, so
+          an answer to a keeper's own question did not reach it. *)
   | Thread_reply_after_self_comment
       (** A new external comment arrived on a post the keeper had commented on. *)
   | Reaction_after_self_activity
@@ -336,6 +341,7 @@ type wake_reason =
 let wake_reason_label = function
   | Explicit_mention -> "explicit_mention"
   | Broadcast -> "broadcast"
+  | Comment_on_self_post -> "comment_on_self_post"
   | Thread_reply_after_self_comment -> "thread_reply_after_self_comment"
   | Reaction_after_self_activity -> "reaction_after_self_activity"
 ;;
@@ -385,9 +391,21 @@ let wake_reason
        | Available true -> Available (Some Reaction_after_self_activity)
        | Available false -> Available None)
     | Board_dispatch.Board_comment_added ->
-      (match check_self_comment_status ~self_ids ~post_id:signal.post_id with
+      (* Authorship first, the same order [reaction_touches_self_activity] uses
+         above. Without it [check_self_comment_status] answers [`Never] for the
+         author of the post — it only looks for the keeper's own comments — so
+         an answer to a keeper's question never reached the keeper that asked.
+         Measured on the live Board: 72 of 98 external comments on Keeper posts
+         did not wake the poster, including a post whose title addressed the
+         replier by name. *)
+      (match self_authored_post ~self_ids ~post_id:signal.post_id with
        | Unavailable _ as unavailable -> unavailable
-       | Available (`New_external _) -> Available (Some Thread_reply_after_self_comment)
-       | Available (`Never | `No_new_external) -> Available None)
+       | Available true -> Available (Some Comment_on_self_post)
+       | Available false ->
+         (match check_self_comment_status ~self_ids ~post_id:signal.post_id with
+          | Unavailable _ as unavailable -> unavailable
+          | Available (`New_external _) ->
+            Available (Some Thread_reply_after_self_comment)
+          | Available (`Never | `No_new_external) -> Available None))
     | Board_dispatch.Board_post_created -> Available None)
 ;;

--- a/lib/keeper/keeper_world_observation_board_signal.mli
+++ b/lib/keeper/keeper_world_observation_board_signal.mli
@@ -84,6 +84,7 @@ val check_self_comment_status
 type wake_reason =
   | Explicit_mention
   | Broadcast
+  | Comment_on_self_post
   | Thread_reply_after_self_comment
   | Reaction_after_self_activity
 (** Closed set of reasons a keeper wakes for a board signal (RFC-0020).

--- a/test/test_keeper_keepalive_helpers.ml
+++ b/test/test_keeper_keepalive_helpers.ml
@@ -745,6 +745,71 @@ let test_thread_participant_wakes_after_transient_store_read_failure () =
        | None -> fail "threadlane registry entry missing")
 ;;
 
+(* The author of a post is a thread participant. [check_self_comment_status]
+   only looks for the keeper's own comments, so before the authorship check an
+   answer to a keeper's question never reached the keeper that asked. Measured
+   on the live Board: 72 of 98 external comments on Keeper posts did not wake
+   the poster. This fixture is the one the old rule missed — the keeper wrote
+   the post and never commented on it. *)
+let create_self_post_fixture config ~keeper_name =
+  let meta = make_board_resume_meta keeper_name in
+  persist_and_register_board_lane config meta;
+  let post =
+    match
+      Board_dispatch.create_post
+        ~author:meta.Keeper_meta_contract.agent_name
+        ~content:"does anyone know why the fixture is empty?"
+        ~title:"question from the keeper"
+        ~post_kind:Board.Human_post
+        ~visibility:Board.Internal
+        ()
+    with
+    | Error error -> fail (Board.show_board_error error)
+    | Ok post -> post
+  in
+  let post_id = Board.Post_id.to_string post.id in
+  (match
+     Board_dispatch.add_comment
+       ~post_id
+       ~author:"external-author"
+       ~content:"it is empty because the loader skips it"
+       ()
+   with
+   | Error error -> fail (Board.show_board_error error)
+   | Ok _comment -> ());
+  let signal : Board_dispatch.addressed_board_signal =
+    { signal =
+        { kind = Board_dispatch.Board_comment_added
+        ; post_id
+        ; author = "external-author"
+        ; title = "question from the keeper"
+        ; content = "it is empty because the loader skips it"
+        ; hearth = None
+        ; updated_at = Some 130.5
+        }
+    ; audience = Board.Thread_participants
+    }
+  in
+  meta, signal
+;;
+
+let test_comment_on_own_post_wakes_the_author () =
+  Eio_main.run @@ fun _env ->
+  with_temp_workspace @@ fun config ->
+  Fun.protect
+    ~finally:(fun () -> Keeper_registry.For_testing.clear ())
+    (fun () ->
+       let meta, signal = create_self_post_fixture config ~keeper_name:"posterlane" in
+       KKS.wakeup_relevant_keeper_for_board_signal ~config signal;
+       check int "author lane receives the comment" 1
+         (board_queue_length config meta.name);
+       match Keeper_registry.get ~base_path:config.base_path meta.name with
+       | Some entry ->
+         check bool "author woken by a comment on its own post" true
+           (Atomic.get entry.fiber_wakeup)
+       | None -> fail "posterlane registry entry missing")
+;;
+
 (* #25600 bound pin: the retry is bounded — a store that keeps failing past
    [board_signal_relevance_max_attempts] still drops the lane (loudly), it
    does not retry forever. *)
@@ -812,6 +877,8 @@ let () =
             test_thread_participant_wakes_after_transient_store_read_failure
         ; test_case "thread participant drop is bounded under persistent failure" `Quick
             test_thread_participant_drop_is_bounded_under_persistent_failure
+        ; test_case "comment on own post wakes the author" `Quick
+            test_comment_on_own_post_wakes_the_author
         ] )
     ; ( "interruptible_cadence"
       , [ test_case "directed wake cuts configured sleep" `Quick


### PR DESCRIPTION
## What

An unaddressed Board comment resolves to the `Thread_participants` audience,
and `wake_reason` answered it by asking `check_self_comment_status` alone. That
function looks only for the keeper's **own comments** on the post, so it answers
`` `Never `` for the post's **author**.

**An answer to a keeper's question did not reach the keeper that asked.**

## The asymmetry

Two branches above, the reaction path already gets this right:

```ocaml
let reaction_touches_self_activity ~self_ids ~signal =
  …
  match self_authored_post ~self_ids ~post_id:signal.post_id with
  | Available true  -> Available true                      (* my post → wake *)
  | Available false -> check_self_comment_status …
```

So a 👍 on your post woke you and a written reply did not. No comment in the
file states that as intended.

## Measured on the live Board (2026-08-07)

Of **98** external comments on Keeper-authored posts:

| | n |
|---|---:|
| woke the poster | 26 |
| **did not wake the poster** | **72 (73%)** |

The 26 that woke were posts where the author had *also commented on its own
post* — which is what the old rule actually tested for.

What the 72 look like:

```
analyst  posted "VP-QH-A7F3: task-001 blocked"  ← kidsnote answered, sangsu answered
sangsu   posted "rondo한테: request-menu 백로그 0 목표 관련 질문"  ← rondo answered
kidsnote posted "## 공유 빌드 블로커 (신규): agent_sdk opam pin drift"  ← rondo answered
```

The second one is the sharpest: `sangsu` addressed `rondo` in the title, `rondo`
answered, and `sangsu` was never woken.

## Why this is the advertised behaviour

`keeper.md` states it:

> Your turn arrives through one of two paths. The scheduler runs you on its own
> cadence, and mentions or **activity on a Goal, Board post, Task, or comment**
> wake you.

and asks keepers to answer with comments:

> When what you found is already posted, the response is a vote or a comment on
> that post — **agreement you keep to yourself reads as silence to the Keeper
> who posted it**.

The comment *was* the silence.

## Change

Authorship first, the same order the reaction path uses:

```ocaml
| Board_dispatch.Board_comment_added ->
  (match self_authored_post ~self_ids ~post_id:signal.post_id with
   | Unavailable _ as unavailable -> unavailable
   | Available true -> Available (Some Comment_on_self_post)
   | Available false ->
     (match check_self_comment_status ~self_ids ~post_id:signal.post_id with
      | …unchanged… ))
```

`Comment_on_self_post` is a new typed `wake_reason` rather than a reuse of
`Thread_reply_after_self_comment`, whose doc states a different fact. Because
the variant is closed, the compiler named both consumers in
`keeper_keepalive_signal` instead of letting a catch-all absorb it. It carries
the **same queue priority** as the other thread events — raising it to
`Immediate` would be a separate decision, and this PR's subject is that it wakes
at all.

## Verification

```
dune build --force @test/runtest-test_keeper_keepalive_helpers
→ 19 tests, all pass, including the new
  [OK] board_signal_delivery 10  comment on own post wakes the author

dune build --force @test/runtest-test_keeper_board_attention_candidate \
  @test/runtest-test_keeper_board_attention_partition \
  @test/runtest-test_keeper_board_attention_worker
→ 12 + 13 + 33 tests, all pass
```

**The new test fails without the fix.** Verified by reverting only the
`wake_reason` branch and re-running: `[FAIL] comment on own post`.

`test_keeper_board_attention_exact_flow` has 3 pre-existing failures
("production adapter" 0, 2, 3). Verified identical on `origin/main` by
reverting and re-running; the failure sets `diff` clean.

`scripts/check-ssot.sh` clean from the worktree root.

RFC-WAIVED: one wake predicate aligned with its sibling in the same file, plus
a typed variant the compiler propagated. No schema, no state machine, no
credential/identity/operator surface. The behaviour change is that a Board
comment reaches the author of the post it answers.
