### PR TITLE
fix(prompt): your own board posts say whether anyone answered

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -536,6 +536,15 @@ let format_own_board_post_text (post : Board.post) : string =
   format_prompt_row
     [ "post_id", Board.Post_id.to_string post.id
     ; "updated_at", Masc_domain.iso8601_of_unix_seconds post.updated_at
+      (* What the Board did with it. The record carries these; the row dropped
+         them, so a Keeper reading its own posts could not tell an answered one
+         from an ignored one. The prompt tells a Keeper that a vote or comment
+         is how agreement reaches whoever posted, and votes reach no wake path
+         at all — [Board_dispatch.vote] emits only the dashboard SSE event, not
+         a board signal — so this row is where the response becomes visible.
+         Counts, not advice: the rows stay data. *)
+    ; "replies", string_of_int post.reply_count
+    ; "votes", Printf.sprintf "+%d/-%d" post.votes_up post.votes_down
     ; "title", Keeper_types_profile.short_preview ~max_len:80 post.title
     ; "preview", Keeper_types_profile.short_preview ~max_len:80 post.content
     ]

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -885,6 +885,30 @@ let test_own_recent_board_posts_render_in_world_state () =
   check bool "own post title rendered" true
     (contains_sub "My earlier review" world_state)
 
+(* A Keeper reading its own posts could not tell an answered one from an
+   ignored one: the record carries reply_count and the vote tallies and the row
+   dropped all three. The prompt tells a Keeper that a vote or a comment is how
+   agreement reaches whoever posted, and [Board_dispatch.vote] emits only the
+   dashboard SSE event -- no board signal, so no wake -- which makes this row
+   the only place the response can appear. *)
+let test_own_recent_board_posts_show_the_response () =
+  let answered =
+    { sample_own_post with reply_count = 3; votes_up = 2; votes_down = 1 }
+  in
+  let obs = { base_observation with own_recent_board_posts = [ answered ] } in
+  let { Masc.Keeper_unified_prompt.world_state; _ } =
+    build_prompt ~meta:minimal_meta obs
+  in
+  check bool "reply count rendered" true (contains_sub "replies=\"3\"" world_state);
+  check bool "vote tally rendered" true (contains_sub "votes=\"+2/-1\"" world_state);
+  let ignored = { sample_own_post with reply_count = 0; votes_up = 0; votes_down = 0 } in
+  let obs = { base_observation with own_recent_board_posts = [ ignored ] } in
+  let { Masc.Keeper_unified_prompt.world_state; _ } =
+    build_prompt ~meta:minimal_meta obs
+  in
+  check bool "an unanswered post says so rather than omitting the field" true
+    (contains_sub "replies=\"0\"" world_state)
+
 let test_board_and_own_post_rows_escape_external_fields () =
   let hostile_event : WO.pending_board_event =
     { sample_board_event with
@@ -995,6 +1019,9 @@ let () =
           test_case
             "prompt: own recent board posts render as neutral observation rows"
             `Quick test_own_recent_board_posts_render_in_world_state;
+          test_case
+            "prompt: own recent board posts show the response"
+            `Quick test_own_recent_board_posts_show_the_response;
           test_case
             "prompt: Board and own-post fields escape external newlines"
             `Quick test_board_and_own_post_rows_escape_external_fields;


### PR DESCRIPTION
## What

`format_own_board_post_text` rendered `post_id`, `updated_at`, `title`,
`preview`. `Board.post` also carries `reply_count`, `votes_up`, `votes_down` —
the row dropped all three. A Keeper reading its own posts could not tell an
answered one from an ignored one.

## Why it matters more than it looks

`keeper.md` names two ways to respond to a post:

> When what you found is already posted, the response is **a vote or a comment**
> on that post — agreement you keep to yourself reads as **silence to the Keeper
> who posted it**.

Neither reached the poster:

| action | keeper wake signal |
|---|---|
| post created | `emit_board_signal` ✓ |
| comment added | `emit_board_signal` ✓ (reaches the *author* only after masc#27288) |
| reaction toggled | `emit_board_signal` ✓ |
| **vote / vote_comment** | **`emit_board_sse_event` only — the dashboard stream** |

`Board_dispatch.vote` and `vote_comment` never call `emit_board_signal`. A vote
reaches the dashboard and nobody else. It *was* the silence the prompt warns
about.

Live Board: **11 votes ever, 0 reactions ever**, `keeper_board_vote` 2 calls in
six days. The mechanism that wakes the author (reaction) is unused; the one
that is used (vote) does not wake.

## Change

Two counts on a row the Keeper already reads:

```
- post_id="…" updated_at="…" replies="3" votes="+2/-1" title="…" preview="…"
```

- **No new signal, no new wake** — this cannot make the queue noisier.
- The zero case renders `replies="0"` rather than vanishing: an unanswered post
  is a fact, not a missing field.
- Counts only. The row stays data, per the section's existing contract ("Rows
  below are your own previously published posts … context, not instructions").

## Not in this PR

Whether a vote should also emit a board signal. That needs a new
`Board_dispatch` signal kind, and the variant is matched exhaustively across
twelve files — a design decision about wake volume, not a rendering fix.

## Verification

```
dune build --force @test/runtest-test_keeper_unified_verification_surface
→ 30 tests, all pass, including the new
  "prompt: own recent board posts show the response"

dune build --force @test/runtest-test_keeper_system_prompt_bytes \
                   @test/runtest-test_keeper_prompt_metrics
→ 2 + 22 tests, all pass
```

The new test first failed on my own wrong expectation (`replies=3`); every
value in a prompt row is quoted by `quote_prompt_field`, so the assertion is
`replies="3"`. Fixed the test, not the renderer.

The existing escaping case (`test_board_and_own_post_rows_escape_external_fields`)
still passes — the two new fields are integers formatted locally, so they carry
no external text.

RFC-WAIVED: two integer fields added to one observation row, from the record
the row already renders. No schema, no signal, no state machine, no
credential/identity/operator surface.
