### PR TITLE
refactor(keeper): recall renders a block, not a report nobody reads

### DIFF
--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -32,28 +32,22 @@ let recall_block ~revision ~updated_at ~facts =
     facts
 ;;
 
-type render_result =
-  { block : string
-  ; injected_fact_keys : string list
-  ; n_facts_in_store : int
-  ; failure_reason : unavailable_reason option
-  }
-
 (* A turn without recall injects nothing, and does so identically whether the
    store is empty or the read failed. The reason reaches the operator through
    the [MemoryOsRecallUnavailable] counter and the warn log at each call site.
    It does not reach the keeper: a paragraph stating that memory is missing
    makes the absence a fact the keeper can reason from, which is what the
-   removed keeper.memory_os_recall.unavailable asset did. *)
-let omit ?reason ~n_facts_in_store () =
+   removed keeper.memory_os_recall.unavailable asset did. Rendering therefore
+   yields the block alone — the empty string is the whole of "no recall". *)
+let omit ?reason () =
   Option.iter record_unavailable reason;
-  { block = ""; injected_fact_keys = []; n_facts_in_store; failure_reason = reason }
+  ""
 ;;
 
 let render_snapshot ~now:_ snapshot =
   let facts = snapshot.Keeper_memory_os_current.facts in
   match facts with
-  | [] -> omit ~n_facts_in_store:0 ()
+  | [] -> omit ()
   | _ ->
     let max_bytes = Env_config.KeeperMemoryOs.recall_facts_max_bytes () in
     (match Keeper_memory_os_budget.measure ~max_bytes facts with
@@ -62,35 +56,30 @@ let render_snapshot ~now:_ snapshot =
          "memory os recall fact payload exceeds byte budget actual_bytes=%d max_bytes=%d"
          actual_bytes
          max_bytes;
-       omit ~reason:Fact_budget_exceeded ~n_facts_in_store:(List.length facts) ()
+       omit ~reason:Fact_budget_exceeded ()
      | Fits _ ->
-       { block =
-           recall_block
-             ~revision:snapshot.revision
-             ~updated_at:(Masc_domain.iso8601_of_unix_seconds snapshot.updated_at)
-             ~facts:(Keeper_memory_os_budget.render_facts facts)
-       ; injected_fact_keys = List.map memory_id facts
-       ; n_facts_in_store = List.length facts
-       ; failure_reason = None
-       })
+       recall_block
+         ~revision:snapshot.revision
+         ~updated_at:(Masc_domain.iso8601_of_unix_seconds snapshot.updated_at)
+         ~facts:(Keeper_memory_os_budget.render_facts facts))
 ;;
 
 let render_context_result ~keepers_dir ~keeper_id ~now =
   match
     Keeper_memory_os_current.read_for_keepers_dir ~keepers_dir ~keeper_id
   with
-  | Ok None -> omit ~n_facts_in_store:0 ()
+  | Ok None -> omit ()
   | Ok (Some snapshot) -> render_snapshot ~now snapshot
   | Error message ->
     Log.Keeper.warn
       "memory os recall unavailable keeper=%s: %s"
       keeper_id
       message;
-    omit ~reason:Read_error ~n_facts_in_store:0 ()
+    omit ~reason:Read_error ()
 ;;
 
 let render_context ~keepers_dir ~keeper_id ~now () =
-  (render_context_result ~keepers_dir ~keeper_id ~now).block
+  render_context_result ~keepers_dir ~keeper_id ~now
 ;;
 
 let enabled () =
@@ -109,9 +98,9 @@ let render_if_enabled ~keepers_dir ~keeper_id ~now () =
           "memory os recall unavailable keeper=%s: %s"
           keeper_id
           (Printexc.to_string exn);
-        omit ~reason:Read_error ~n_facts_in_store:0 ()
+        omit ~reason:Read_error ()
     in
-    match String.trim result.block with
+    match String.trim result with
     | "" -> None
     | block -> Some block
 ;;

--- a/test/test_keeper_memory_os_current.ml
+++ b/test/test_keeper_memory_os_current.ml
@@ -315,6 +315,48 @@ let test_recall_read_failure_injects_no_block () =
   check string "unreadable snapshot injects no recall block" "" rendered
 ;;
 
+(* The recall byte budget is read at render time, so a snapshot that was
+   within budget when written can exceed it later — the budget is an env
+   knob, and facts accumulate. That arm injects nothing rather than a
+   truncated block, and it is the only recall path that discards facts it
+   successfully read. *)
+let test_recall_over_budget_injects_no_block () =
+  with_temp_keepers
+  @@ fun keepers_dir ->
+  let prompt_dir = Filename.concat keepers_dir "prompts" in
+  Unix.mkdir prompt_dir 0o755;
+  Prompt_registry.set_markdown_dir prompt_dir;
+  Prompt_registry.load_prompts_from_directory prompt_dir;
+  ignore (replace ~keepers_dir ~facts:[ fact ~claim:(String.make 256 'y') () ] () |> require_ok);
+  let key = Env_config.KeeperMemoryOs.recall_facts_max_bytes_env_key in
+  let previous = Sys.getenv_opt key in
+  let restore () =
+    match previous with
+    | Some value -> Unix.putenv key value
+    | None -> Unix.putenv key ""
+  in
+  Fun.protect ~finally:restore (fun () ->
+    Unix.putenv key "16";
+    let rendered =
+      Masc.Keeper_memory_os_recall.render_context
+        ~keepers_dir
+        ~keeper_id:"keeper"
+        ~now:240.0
+        ()
+    in
+    check string "over-budget recall injects no block" "" rendered);
+  Unix.putenv key "1048576";
+  let rendered_within_budget =
+    Masc.Keeper_memory_os_recall.render_context
+      ~keepers_dir
+      ~keeper_id:"keeper"
+      ~now:240.0
+      ()
+  in
+  check bool "same snapshot renders when the budget allows it" true
+    (String.length rendered_within_budget > 0)
+;;
+
 let test_snapshot_write_rejects_rendered_fact_payload_over_budget () =
   with_temp_keepers @@ fun keepers_dir ->
   match
@@ -637,6 +679,10 @@ let () =
             "recall read failure injects no block"
             `Quick
             test_recall_read_failure_injects_no_block
+        ; test_case
+            "recall over budget injects no block"
+            `Quick
+            test_recall_over_budget_injects_no_block
         ; test_case
             "snapshot rejects rendered facts over budget"
             `Quick


### PR DESCRIPTION
## 무엇

Memory-OS recall 이 반환하던 4 필드 레코드를 문자열 하나로 접는다. 나머지 3 필드는 모든 생성 지점에서 채워지고 어디에서도 읽히지 않았다.

```ocaml
type render_result =
  { block : string
  ; injected_fact_keys : string list      (* 읽는 곳 0 *)
  ; n_facts_in_store : int                (* 읽는 곳 0 *)
  ; failure_reason : unavailable_reason option   (* 읽는 곳 0 *)
  }
```

읽는 지점은 둘뿐이고 둘 다 `.block` 만 꺼낸다.

```ocaml
let render_context ... = (render_context_result ...).block
match String.trim result.block with "" -> None | block -> Some block
```

## 어떻게 찾았나

`-w +69` (unused-field) 를 루트에 켜고 트리 전체를 빌드해 **읽히지 않는 레코드 필드 38 건**을 얻었다. 그 중 이 셋이 확인된 사례다.

경고 자체는 그대로 쓸 수 없다. `Hashtbl` 키로 쓰이는 레코드는 필드를 구문상 읽지 않고 구조적 해시/비교로만 쓰기 때문에 **전부 오탐**으로 뜬다 (`keeper_runtime_trust_snapshot.Snapshot_cache.key` 5 필드, `keeper_board_attention_candidate` 의 `stat_*` 4 필드, `capability_head` 의 `dev`/`ino` 계열). 라쳇으로 올리려면 그 부류를 먼저 정리해야 하므로 이 PR 은 경고를 켜지 않는다.

## `failure_reason` 이 특히 그렇다

바로 위 주석이 이유를 이미 적어 두었다.

> The reason reaches the operator through the [MemoryOsRecallUnavailable] counter and the warn log at each call site. **It does not reach the keeper**: a paragraph stating that memory is missing makes the absence a fact the keeper can reason from, which is what the removed `keeper.memory_os_recall.unavailable` asset did.

즉 이 값이 소비되지 않는 것은 **의도**다. 그런데 반환 레코드에 실어 두면 다음 사람이 "여기 있으니 쓰면 되겠다"고 읽는다. 카운터와 로그가 이미 담당하는 것을 레코드에서도 나르는 상태가, 지워진 asset 을 되살리는 가장 짧은 길이었다.

## 부수 효과

턴마다 돌던 계산 세 개가 사라진다 — `List.map memory_id facts`, 그리고 `List.length facts` 두 번. 값은 채워지자마자 버려지고 있었다.

## 테스트

recall 의 **byte budget 초과** arm 을 덮는 테스트를 추가했다. 이 arm 은 recall 경로에서 **성공적으로 읽은 fact 를 버리는 유일한 지점**인데 아무것도 검사하지 않고 있었다 (쓰기 쪽 예산 거부는 `snapshot rejects rendered facts over budget` 가 이미 덮는다).

뮤테이션으로 검증했다: `Exceeds` arm 이 `omit` 대신 블록을 렌더하도록 고치면 이 테스트가 **실패한다** (`FAIL over-budget recall injects no block`). 원복 후 통과.

budget 은 렌더 시점에 env knob 에서 읽으므로, 쓸 때는 예산 안이던 스냅샷이 나중에 초과할 수 있다. 테스트는 같은 스냅샷을 예산 16 바이트에서 빈 문자열로, 1 MiB 에서 비어 있지 않은 블록으로 렌더해 그 경계를 고정한다.

## 검증

`dune build @check` 통과. `test_keeper_memory_os_current` 22 건 통과 (신규 1 건 포함).

게이트: `check-determinism-contract`, `audit-catchall`, `check_silent_failure`, `check-variants`, `check_test_coverage` 통과.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
