### PR TITLE
refactor(lib): remove six unread record fields and one orphaned type

### DIFF
--- a/lib/gate/discord_gateway_state.ml
+++ b/lib/gate/discord_gateway_state.ml
@@ -265,7 +265,6 @@ type t =
   ; config : config
   ; reconnect_attempts : int        (* Exponential backoff exponent. *)
   ; last_seq : int option           (* Latest dispatch sequence number. *)
-  ; heartbeat_interval_ms : int option  (* From Op_hello, used by Heartbeat_tick. *)
   ; resume_gateway_url : string option  (* From READY, used by Resuming. *)
   ; resume_context : (string * int option) option
     (* (session_id, last_seq_at_disconnect). Set when leaving Connected
@@ -286,7 +285,6 @@ let create ~config =
   ; config
   ; reconnect_attempts = 0
   ; last_seq = None
-  ; heartbeat_interval_ms = None
   ; resume_gateway_url = None
   ; resume_context = None
   ; awaiting_hello_since_mono = None
@@ -788,7 +786,6 @@ let handle_hello t (frame : frame) =
            in
            ( { t with
                state = next_state
-             ; heartbeat_interval_ms = Some interval_ms
              ; awaiting_hello_since_mono = None
              }
            , [ Schedule_heartbeat { interval_ms }

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -146,8 +146,7 @@ type intake_token =
   }
 
 type token =
-  { slot : slot
-  ; mutable active : bool
+  { mutable active : bool
   ; mutable before_dispatch_authority : (unit -> (unit, string) result) option
   }
 
@@ -234,7 +233,7 @@ let peek_shutdown slot = Stdlib.Mutex.protect slot.state_mu (fun () -> slot.shut
    cancellation cannot leak the slot; the exception arm releases on every
    raise out of [f], including [Eio.Cancel.Cancelled]. *)
 let run_locked_with_token slot ~lane f =
-  let token = { slot; active = true; before_dispatch_authority = None } in
+  let token = { active = true; before_dispatch_authority = None } in
   let admission =
     Stdlib.Mutex.protect slot.state_mu (fun () ->
       match slot.shutdown_operation_id with

--- a/lib/runtime/runtime_observation.ml
+++ b/lib/runtime/runtime_observation.ml
@@ -218,7 +218,7 @@ type runtime_metrics_capture = {
   mutable next_attempt_index : int;
   mutable attempts_rev : runtime_attempt list;
   mutable fallback_events_rev : runtime_fallback_event list;
-  mutable streaming : streaming_metrics_capture;
+  streaming : streaming_metrics_capture;
 }
 
 (* Non-redacted JSON encoders for the internal audit log

--- a/lib/server/server_activity_http.ml
+++ b/lib/server/server_activity_http.ml
@@ -202,12 +202,3 @@ let swimlane_http_json ~deps ~state request =
       Activity_graph.agent_spans_json (Mcp_server.workspace_config state) ~limit
         ?since_ms ())
 
-type stream_info = {
-  session_id : string;
-  client_id : int;
-  writer : Httpun.Body.Writer.t;
-  mutex : Eio.Mutex.t;
-  stop : bool ref;
-  mutable closed : bool;
-}
-

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -351,13 +351,11 @@ type keeper_persistence_base_path =
 
 type prepared_keeper_persistence =
   { base_path : keeper_persistence_base_path
-  ; config : Workspace.config
   ; report : keeper_persistence_report
   }
 
 type claimed_keeper_persistence =
   { claimed_base_path : keeper_persistence_base_path
-  ; claimed_config : Workspace.config
   ; claimed_report : keeper_persistence_report
   }
 
@@ -676,7 +674,6 @@ let prepare_keeper_persistence_owned ~base_path_identity ~set_phase ~config =
          report.examined report.projected report.pending);
   let prepared =
     { base_path = base_path_identity
-    ; config
     ; report =
         { shutdown
         ; queue = queue_recovery
@@ -880,7 +877,6 @@ let rec claim_prepared_keeper_persistence ~config prepared =
      | Ok () ->
       let claimed =
         { claimed_base_path = prepared.base_path
-        ; claimed_config = prepared.config
         ; claimed_report = prepared.report
         }
       in

--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -323,7 +323,6 @@ type path_resolution =
 
 type workspace_file = {
   lexical_path : string;
-  resolved_base : string;
   resolved_path : string;
 }
 
@@ -374,7 +373,6 @@ let resolve_workspace_file base requested =
             Ok
               {
                 lexical_path = full;
-                resolved_base;
                 resolved_path = resolved_full;
               }
 

--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -23,7 +23,6 @@ type submit_request_spec =
   { criteria : Verification.criterion list
   ; output : Yojson.Safe.t
   ; request_kind : string
-  ; request_summary : string
   ; next_action : string
   ; board_type : string
   ; board_title : string
@@ -88,7 +87,6 @@ let submit_request_spec ~(config : Workspace.config) ~(task : Masc_domain.task)
   { criteria
   ; output
   ; request_kind
-  ; request_summary
   ; next_action
   ; board_type
   ; board_title


### PR DESCRIPTION
## 무엇

읽히지 않는 레코드 필드 6 개와 고아가 된 타입 1 개를 지운다. 전부 **모든 생성 지점에서 채워지고 어디에서도 읽히지 않는다**.

| 위치 | 필드 | 왜 죽었나 |
|---|---|---|
| `server_activity_http.ml` | `stream_info` 타입 전체 (6 필드) | #27211 이 SSE 핸들러를 지우며 고아가 됨. 참조 0 |
| `discord_gateway_state.ml` | `heartbeat_interval_ms` | 주석은 "used by Heartbeat_tick" 이라고 적혀 있지만 `handle_heartbeat_tick` 은 이 필드를 보지 않는다 |
| `keeper_turn_admission.ml` | `token.slot` | `release ()` 가 `slot` 을 클로저로 잡으므로 토큰의 사본은 쓰이지 않는다 |
| `verification_protocol.ml` | `submit_request_spec.request_summary` | 값은 JSON 으로 나가고, 레코드 필드는 아무도 읽지 않는다 |
| `server_routes_http_routes_workspace.ml` | `resolved_base` | 계산 결과를 지역 변수로 쓰고, 레코드에도 넣어 두었다 |
| `server_bootstrap_loops.ml` | `claimed_config`, `prepared.config` | 아래 참조 |

`runtime_observation.ml` 의 `mutable streaming` 은 필드가 재대입된 적이 없어 `mutable` 만 뗐다 (안쪽 레코드의 필드는 계속 변경된다).

## `heartbeat_interval_ms` 가 특히 그렇다

```ocaml
; heartbeat_interval_ms : int option  (* From Op_hello, used by Heartbeat_tick. *)
```

`handle_heartbeat_tick` 전문을 읽으면 `t.last_seq`, `t.awaiting_hello_since_mono`, `t.resume_context`, `t.reconnect_attempts` 를 쓰고 이 필드는 쓰지 않는다. 실제로 간격을 전달하는 것은 hello 처리에서 나가는 **효과** 다.

```ocaml
Schedule_heartbeat { interval_ms }   (* 지역 변수 interval_ms, 필드가 아니다 *)
```

I/O 계층이 타이머를 소유하고, 재연결마다 Discord 가 Hello 를 다시 보내므로 `Schedule_heartbeat` 도 다시 나간다. 상태 레코드의 사본은 아무 역할이 없다. 동작은 옳고 **주석만 거짓**이었다 — 그리고 그 주석 때문에 이 필드는 "쓰이는 값"으로 읽힌다.

## 캐스케이드 하나

`claimed_config` 를 지우자 `prepared_keeper_persistence.config` 가 드러났다. 유일한 독자가 `claimed_config = prepared.config` 였기 때문이다. 즉 `Workspace.config` 를 두 단계에 걸쳐 나르고 아무도 읽지 않았다.

**첫 번째를 지우기 전에는 두 번째가 보이지 않는다.** 한 번에 하나씩 지우고 다시 빌드해야 나오는 종류다.

## 어떻게 찾았나

`-w +32` 는 필드를 잡지 못한다. 루트 `dune` 의 `env` 스탠자를 잠시 이렇게 바꿔 전수를 얻었다.

```lisp
(flags (:standard -w +69 -warn-error -69))
```

`-warn-error -69` 라서 빌드가 서지 않고 경고만 쌓인다. 최초 38 건.

**경고를 그대로 믿으면 안 된다.** `Hashtbl` 키나 다형 비교로만 읽히는 레코드는 필드를 구문상 읽지 않으므로 전부 오탐으로 뜬다.

- `Keeper_runtime_trust_snapshot.Snapshot_cache.key` 5 필드 — `(key, entry) Hashtbl.t` 의 키
- `keeper_board_attention_candidate` 의 `stat_dev`/`ino`/`mtime`/`size` — 캐시 동일성
- `fs_compat/capability_head` 의 `dev`/`ino`/`parent_*`/`lock_*` — TOCTOU 동일성 비교

이 PR 은 그래서 경고를 **켜지 않는다**. 프로브로만 쓴다. 라쳇으로 올리려면 위 부류를 먼저 정리해야 하고, 그건 별개 판단이다.

## 손대지 않은 것

- `lib/auth/auth_oauth.ml` 의 `issued_at_unix` — 같은 이름의 레코드가 둘이고 한쪽은 살아있다. auth 경로라 별도로 다룬다.
- `dashboard_gate_metrics.rejection_event.keeper_name` — ring 자체는 `gate_tool_events_json` 으로 살아있고, 이 필드만 JSON 에 안 들어간다. **지울지 JSON 에 넣을지는 제품 판단**이라 범위 밖으로 뒀다.

## 검증

`dune build @check` 통과. 프로브 재실행 결과 이 PR 이 건드린 모듈에서 unused-field 0.

건드린 모듈의 스위트 128 건 통과 — `test_discord_gateway_state`, `test_discord_gateway_client`, `test_discord_wss_lifecycle`, `test_keeper_turn_admission`, `test_server_activity_http`, `test_dashboard_gate_metrics`, `test_keeper_runtime_observation_boundaries`. `test_keeper_mutex_coverage` 49 건 통과.

`test_server_runtime_bootstrap` 은 **이 PR 이전부터 4 건 실패한다**. `server_bootstrap_loops.ml` 만 `origin/main` 으로 되돌려 같은 스위트를 돌려 확인했다 — 동일하게 88 건 중 4 건 실패. CI 에 배선되지 않은 741 개 스위트 중 하나라 main 이 초록으로 유지되고 있었다. 이슈 #27292 로 분리했다.

`# ci:skip-test-coverage` — 컴파일러가 "읽히지 않는다"를 증명한 필드는 동작을 바꿀 수 없으므로 변경 전후를 가르는 테스트를 쓸 수 없다. 게이트가 실제로 트립한 뒤에 붙였다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
