### PR TITLE
refactor(lib): remove types and constructors nothing builds

### DIFF
--- a/lib/keeper/keeper_event_bridge.ml
+++ b/lib/keeper/keeper_event_bridge.ml
@@ -645,10 +645,6 @@ let rec process_pending ?store_ref acc = function
          process_pending ?store_ref ({ pending with attempts = attempt } :: acc) rest))
 ;;
 
-type bridge_pending_relay = pending_relay
-type bridge_relay_stage = relay_stage
-type bridge_relay_result = relay_result
-
 let oas_event_store ~config =
   let retention_days = oas_event_retention_days () in
   Dated_jsonl.create
@@ -656,29 +652,6 @@ let oas_event_store ~config =
     ?retention_days
     ()
 ;;
-
-module For_testing = struct
-  type pending_relay =
-    { json : Yojson.Safe.t
-    ; attempts : int
-    ; appended : bool
-    }
-
-  type relay_stage =
-    | Append
-    | Broadcast
-
-  type relay_result =
-    | Delivered
-    | Retryable_failure of pending_relay * relay_stage * exn
-
-  (* Issue #8676: convert directly between the outer [relay_stage] and the
-     [For_testing.relay_stage] mirror. The previous string-roundtrip carried
-     a permissive [_ -> Broadcast] catch-all that would silently misclassify
-     any future outer constructor as [Broadcast] in test stage assertions
-     (#8605 anti-pattern). Direct match makes adding a constructor a
-     compile error here, forcing the test mirror to stay in sync. *)
-end
 
 let start_impl ~interval_s ~sw ~clock ~(config : Workspace.config) ~bus =
   let store = ref (oas_event_store ~config) in

--- a/lib/keeper/keeper_event_bridge.mli
+++ b/lib/keeper/keeper_event_bridge.mli
@@ -36,19 +36,3 @@ val start_with_interval :
     Exposed for unit testing. *)
 val native_event_to_json : Agent_sdk.Event_bus.event -> Yojson.Safe.t option
 
-module For_testing : sig
-  type pending_relay = private {
-    json : Yojson.Safe.t;
-    attempts : int;
-    appended : bool;
-  }
-
-  type relay_stage = private
-    | Append
-    | Broadcast
-
-  type relay_result = private
-    | Delivered
-    | Retryable_failure of pending_relay * relay_stage * exn
-
-end

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -165,10 +165,6 @@ let worker_lifecycle_classification_of_result = function
     Explicit model-label execution must never silently substitute a
     discovery-only model. Callers are expected to validate labels
     before reaching this helper. *)
-type label_resolution_error =
-  Runtime_transport.label_resolution_error =
-  | Invalid_model_label of string
-
 let label_resolution_error_to_string =
   Runtime_transport.label_resolution_error_to_string
 

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -304,35 +304,11 @@ let is_dashboard_cache_timeout_json = function
 
 module Shell_projection_trace = Server_dashboard_shell_projection_trace
 
-type shell_projection_timing = Shell_projection_trace.shell_projection_timing =
-  { projection_label : string
-  ; projection_ms : int
-  }
-
 type shell_projection_trace_status =
   Shell_projection_trace.shell_projection_trace_status =
   | Shell_trace_running
   | Shell_trace_finished
   | Shell_trace_failed
-
-type shell_projection_trace = Shell_projection_trace.shell_projection_trace =
-  { trace_light : bool
-  ; trace_started_at : float
-  ; mutable trace_status : shell_projection_trace_status
-  ; mutable trace_active : string list
-  ; mutable trace_completed : shell_projection_timing list
-  ; mutable trace_finished_at : float option
-  }
-
-type shell_projection_trace_snapshot =
-  Shell_projection_trace.shell_projection_trace_snapshot =
-  { snapshot_status : shell_projection_trace_status
-  ; snapshot_light : bool
-  ; snapshot_elapsed_ms : int
-  ; snapshot_active : string list
-  ; snapshot_completed : shell_projection_timing list
-  ; snapshot_finished_at : float option
-  }
 
 let shell_projection_trace_start = Shell_projection_trace.start
 let shell_projection_trace_start_projection = Shell_projection_trace.start_projection

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -293,14 +293,12 @@ let runtime_config_path_error_status message =
   else `Internal_server_error
 
 type runtime_config_write_operation =
-  | Runtime_config_reload
   | Runtime_config_raw_save
   | Runtime_config_routing of runtime_route_lane * string option
   | Runtime_config_routing_list of runtime_route_lane * string list
   | Runtime_config_assignment of string * string option
 
 let runtime_config_write_operation_details = function
-  | Runtime_config_reload -> [ ("operation", `String "reload") ]
   | Runtime_config_raw_save -> [ ("operation", `String "raw_save") ]
   | Runtime_config_routing (lane, runtime_id) ->
     [ ("operation", `String "routing")


### PR DESCRIPTION
## 무엇

아무도 만들지 않는 타입 6 개와 생성자 5 개를 지운다. `-w +32+34+37+38` 프로브로 전수를 뽑았다.

## 1. `keeper_event_bridge` — 지워진 함수가 남긴 껍데기 (7 건)

`For_testing` 모듈이 바깥 타입의 **거울**을 들고 있다.

```ocaml
module For_testing = struct
  type pending_relay = { json : Yojson.Safe.t; attempts : int; appended : bool }
  type relay_stage = Append | Broadcast
  type relay_result = Delivered | Retryable_failure of pending_relay * relay_stage * exn

  (* Issue #8676: convert directly between the outer [relay_stage] and the
     [For_testing.relay_stage] mirror. ... Direct match makes adding a
     constructor a compile error here, forcing the test mirror to stay in sync. *)
end
```

**주석이 약속하는 변환 함수가 모듈 안에 없다.** 생성자 4 개 전부 build 되지 않고, 바깥 별칭 3 개(`bridge_pending_relay` / `bridge_relay_stage` / `bridge_relay_result`)도 참조 0 이다.

원인은 **내가 만든 #27269** 다. warning 32 가 `to_pending` / `of_pending` / `of_stage` / `of_result` / `deliver_pending_with` 를 미사용 값으로 지목했고 PR 이 그것들을 지웠는데, warning 34/37 이 꺼져 있어서 **그 함수들이 쓰던 타입은 남았다**. 함수가 사라졌으니 "생성자를 추가하면 여기서 컴파일 에러가 난다"는 주석의 보증도 같이 사라졌는데, 주석만 남아 지금도 그 보증이 있는 것처럼 읽힌다.

`.mli` 의 `For_testing` 도 `private` 타입 3 개만 노출하고 생성 함수가 없다. `Keeper_event_bridge.For_testing` 을 쓰는 코드는 `lib/` `test/` `scripts/` 어디에도 없다. 심볼을 이름으로 고정하는 계약 검사(`scripts/keeper_event_queue_projection_boundary_check.ml`)도 이 이름들을 잡지 않는다 — 그 파일이 pin 하는 `For_testing` 은 `keeper_reaction_ledger` 쪽 하나뿐이다.

## 2. `Runtime_config_reload` — 아무도 발행하지 않는 조작

```ocaml
type runtime_config_write_operation =
  | Runtime_config_reload            (* 만드는 곳 0 *)
  | Runtime_config_raw_save
  | Runtime_config_routing of ...
```

`runtime_config_write_operation_details` 에 `("operation", `String "reload")` 를 내는 arm 이 있어서 **살아있는 것처럼 보인다**. 실제로는 어떤 라우트도 이 생성자를 만들지 않으므로 감사 로그에 `operation: "reload"` 가 찍힌 적이 없다. 대시보드 TS 에도 `"reload"` 를 기대하는 코드가 없다.

## 3. 쓰이지 않는 재노출 별칭 3 건

- `runtime_agent.ml` 의 `type label_resolution_error = Runtime_transport.label_resolution_error = ...` — `.mli` 는 이 지역 이름 대신 `Runtime_transport.label_resolution_error` 를 완전 수식으로 쓴다.
- `server_dashboard_http_core.ml` 의 `shell_projection_trace` / `shell_projection_trace_snapshot` — `.mli` 가 이름을 부르지 않는다.

`shell_projection_trace_status` 는 **남긴다.** 별칭이 아니라 같은 파일 459/502/505 행이 `Shell_trace_finished` / `Shell_trace_failed` 를 실제로 만든다.

## 캐스케이드 하나

두 trace 레코드를 지우자 `shell_projection_timing` 별칭의 독자가 사라져 프로브에 새로 떴다. 첫 번째를 지우기 전에는 보이지 않는 종류라, 지우고 다시 프로브를 돌려야 나온다. 함께 지웠다.

## 남긴 것

`dashboard_briefing_sections.mli:6` 의 `([> float Eio.Time.clock_ty ] as 'a)` — `as 'a` 바인딩이 한 번만 쓰여 warning 34 가 뜬다. 타입은 동일하고 Eio resource 시그니처라 별건으로 둔다.

## 프로브 방법과 한계

루트 `dune` 의 `env` 스탠자를 잠시 이렇게 둔다.

```lisp
(flags (:standard -w +32+34+37+38 -warn-error -34-37-38))
```

`-warn-error` 로 새 경고만 빼면 빌드가 서지 않고 전수가 쌓인다. 최초 13 건 → 이 PR 이후 2 건 (`as 'a`, 그리고 #27293 이 이미 지운 `stream_info`).

**증분 빌드 주의**: dune 이 재컴파일한 모듈만 경고를 내므로, 두 번째 프로브의 숫자는 전수가 아니라 "건드린 범위가 깨끗한가"로만 읽어야 한다.

이 PR 은 경고를 **켜지 않는다**. 프로브로만 쓴다.

## 검증

`dune build @check` 통과. `test_stop_reason_label`, `test_keeper_execution_join`, `test_rfc_0085_pr16_dashboard_http_core_rename`, `test_server_dashboard_http_keeper_api_trace` 34 건 통과. `test_dashboard_http_core` 외 118 건 통과.

게이트: `check-determinism-contract`, `audit-catchall`, `check-variants`, `check_silent_failure`, `check-enum-string-safety`, `check_test_coverage` 통과.

순감 73 줄.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
