### PR TITLE
fix(telemetry): join the two tool-call streams on execution_id, not proximity

### DIFF
--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -420,6 +420,7 @@ let record_runtime_mcp_keeper_tool_trace
     ~(arguments : Yojson.Safe.t)
     ~(message : string)
     ~(disposition : ('completed, 'deferred, 'failed) Tool_result.disposition)
+    ~(execution_id : Ids.Execution_id.t)
     ~(duration_ms : int) : unit =
   let ctx =
     runtime_mcp_keeper_log_context_of_entry
@@ -427,9 +428,6 @@ let record_runtime_mcp_keeper_tool_trace
       entry
       ~arguments
   in
-  (* RFC-0233 PR-1: one mint per execution at this dispatch boundary;
-     the tool_calls row and the trajectory row below share the value. *)
-  let execution_id = Ids.Execution_id.generate () in
   let success =
     match disposition with
     | Tool_result.Completed _ | Tool_result.Deferred _ -> true
@@ -654,6 +652,14 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
       |> List.find_opt (fun (entry : Keeper_registry.registry_entry) ->
         String.equal entry.meta.agent_name agent_name)
   in
+  (* RFC-0233 PR-1: one mint per execution at this dispatch boundary. The
+     tool_calls row, the trajectory row and the [Tool_called] telemetry event
+     all carry this value, so a reader of two streams can tell one physical
+     call reported twice from two calls. Minted only when a keeper owns the
+     call, because that is when a tool_calls row is written. *)
+  let execution_id =
+    Option.map (fun _ -> Ids.Execution_id.generate ()) keeper_entry
+  in
   let source : Tool_registry.call_source =
     match keeper_entry with
     | Some _ -> Agent_internal
@@ -690,6 +696,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
                 ?session_id:telemetry_session_id
                 ?operation_id:telemetry_operation_id
                 ?worker_run_id:telemetry_worker_run_id
+                ?execution_id:(Option.map Ids.Execution_id.to_string execution_id)
                 ?failure_class:telemetry_failure_class
                 ?error_kind:telemetry_error_kind
                 ?error_message:error_detail
@@ -778,8 +785,8 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
     | Some tid -> tid
     | None -> request_id_trace_fallback
   in
-  (match keeper_entry with
-   | Some entry ->
+  (match keeper_entry, execution_id with
+   | Some entry, Some execution_id ->
        (try
           record_runtime_mcp_keeper_tool_trace
             ?mcp_session_id
@@ -788,10 +795,11 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
             ~arguments
             ~message
             ~disposition:result
+            ~execution_id
             ~duration_ms
         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
           log_mcp_exn ~label:"runtime MCP keeper tool trace failed" exn)
-   | None -> ());
+   | Some _, None | None, _ -> ());
   let status = status_of_result result in
   let envelope =
     `Assoc [

--- a/lib/mcp_server_eio_call_tool.mli
+++ b/lib/mcp_server_eio_call_tool.mli
@@ -99,6 +99,7 @@ val record_runtime_mcp_keeper_tool_trace :
   arguments:Yojson.Safe.t ->
   message:string ->
   disposition:('completed, 'deferred, 'failed) Tool_result.disposition ->
+  execution_id:Ids.Execution_id.t ->
   duration_ms:int ->
   unit
 (** Persists a single tool-call trace row for the keeper.

--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -37,6 +37,12 @@ type event =
       session_id: string option [@default None];
       operation_id: string option [@default None];
       worker_run_id: string option [@default None];
+      (* RFC-0233 canonical join key, minted once at the dispatch boundary.
+         The tool_calls row for the same execution carries the identical
+         value, so a consumer reading both streams can tell one physical
+         call reported twice from two calls. [None] on lanes that write no
+         tool_calls row — nothing there is a duplicate to begin with. *)
+      execution_id: string option [@default None];
       error_kind: error_kind option [@default None];
       error_message: string option [@default None];
       exit_code: int option [@default None];
@@ -425,7 +431,8 @@ let nonempty_error_kind_opt value =
   | None -> None
 
 let track_tool_called ?fs config ~tool_name ~success ~duration_ms ?agent_id
-    ?source ?session_id ?operation_id ?worker_run_id ?failure_class ?error_kind
+    ?source ?session_id ?operation_id ?worker_run_id ?execution_id
+    ?failure_class ?error_kind
     ?error_message ?exit_code ?stderr_excerpt () =
   let failure_class = if success then None else failure_class in
   let error_kind =
@@ -447,6 +454,7 @@ let track_tool_called ?fs config ~tool_name ~success ~duration_ms ?agent_id
          session_id;
          operation_id;
          worker_run_id;
+         execution_id;
          error_kind;
          error_message;
          exit_code;

--- a/lib/telemetry_eio.mli
+++ b/lib/telemetry_eio.mli
@@ -56,6 +56,7 @@ type event =
       session_id : string option; [@default None]
       operation_id : string option; [@default None]
       worker_run_id : string option; [@default None]
+      execution_id : string option; [@default None]
       error_kind : error_kind option; [@default None]
       error_message : string option; [@default None]
       exit_code : int option; [@default None]
@@ -187,6 +188,7 @@ val track_tool_called :
   ?session_id:string ->
   ?operation_id:string ->
   ?worker_run_id:string ->
+  ?execution_id:string ->
   ?failure_class:Tool_result.tool_failure_class ->
   ?error_kind:error_kind ->
   ?error_message:string ->

--- a/lib/telemetry_unified/telemetry_unified.ml
+++ b/lib/telemetry_unified/telemetry_unified.ml
@@ -226,48 +226,16 @@ let string_field name json =
     if value = "" then None else Some value
 ;;
 
-let bool_field name json =
-  Json_field.bool json name |> Json_field.to_option
-;;
+module Execution_id_set = Set.Make (String)
 
-let drop_prefix prefix value =
-  if String.starts_with ~prefix value then
-    String.sub value (String.length prefix)
-      (String.length value - String.length prefix)
-  else value
-
-let drop_suffix suffix value =
-  if String.ends_with ~suffix value then
-    String.sub value 0 (String.length value - String.length suffix)
-  else value
-
-let canonical_actor_name value =
-  value
-  |> String.trim
-  |> drop_prefix "keeper-"
-  |> drop_suffix "-agent"
-
-type tool_call_signature = {
-  actor : string;
-  tool : string;
-  success : bool option;
-  ts : float;
-}
-
-let tool_call_signature ?success ~actor ~tool ~ts () =
-  let actor = canonical_actor_name actor in
-  let tool = String.trim tool in
-  if actor = "" || tool = "" || ts <= 0.0 then None
-  else Some { actor; tool; success; ts }
-
-let tool_call_io_signature json =
+(* Both streams report the same physical tool call. [execution_id] is the
+   RFC-0233 join key: minted once at the MCP dispatch boundary, written to
+   the tool_calls row and carried on the [Tool_called] event for the same
+   execution. A row without one is not matched against — an unidentified
+   event is kept, because nothing proves it is a duplicate. *)
+let tool_call_io_execution_id json =
   match string_field "source" json with
-  | Some "tool_call_io" ->
-    (match string_field "keeper" json, string_field "tool" json with
-     | Some actor, Some tool ->
-       tool_call_signature ?success:(bool_field "success" json) ~actor ~tool
-         ~ts:(extract_ts json) ()
-     | _ -> None)
+  | Some "tool_call_io" -> string_field "execution_id" json
   | _ -> None
 
 let tool_called_detail_from_fields fields =
@@ -284,58 +252,25 @@ let tool_called_event_detail json =
   | Some "agent_event", `Assoc fields -> tool_called_detail_from_fields fields
   | _ -> None
 
-let keeper_tool_called_signature json =
+let keeper_tool_called_execution_id json =
   match tool_called_event_detail json with
   | None -> None
-  | Some detail ->
-    (match string_field "agent_id" detail, string_field "tool_name" detail with
-     | Some actor, Some tool ->
-       tool_call_signature ?success:(bool_field "success" detail) ~actor ~tool
-         ~ts:(extract_ts json) ()
-     | _ -> None)
-
-(* WORKAROUND: the two sources report the same physical tool call with no
-   shared identifier, so sameness is inferred from proximity.
-
-   A [tool_call_io] row carries ts / keeper / tool / input / output / success /
-   duration_ms / runtime_contract / action_radius. The [Tool_called] agent
-   event carries agent_id / tool_name / success / duration_ms plus session_id,
-   operation_id and worker_run_id. Nothing is common to both that identifies a
-   call, so matching on actor + tool + outcome within a window is what the
-   schemas allow.
-
-   Where it is wrong: two genuinely distinct calls of the same tool by the same
-   actor with the same outcome, closer together than the window, look like one
-   report of one call — and [suppress_shadow_keeper_tool_events] drops the
-   agent-side event for the second.
-
-   Root fix: give the durable tool-call row a call identifier that the agent
-   event also carries, and key on that. That is a schema change to a durable
-   store and both producers, so it is not done here. *)
-let shadow_dedup_window_sec = 5.0
-
-let same_tool_call_signature left right =
-  String.equal left.actor right.actor
-  && String.equal left.tool right.tool
-  &&
-  (match left.success, right.success with
-   | Some a, Some b -> Bool.equal a b
-   | None, None -> true
-   | Some _, None | None, Some _ -> false)
-  && abs_float (left.ts -. right.ts) <= shadow_dedup_window_sec
+  | Some detail -> string_field "execution_id" detail
 
 let suppress_shadow_keeper_tool_events entries =
-  let tool_call_io =
-    List.filter_map tool_call_io_signature entries
+  let logged_executions =
+    entries
+    |> List.filter_map tool_call_io_execution_id
+    |> List.fold_left (fun acc id -> Execution_id_set.add id acc) Execution_id_set.empty
   in
-  if tool_call_io = [] then entries
+  if Execution_id_set.is_empty logged_executions
+  then entries
   else
     List.filter
       (fun json ->
-        match keeper_tool_called_signature json with
-        | None -> true
-        | Some signature ->
-          not (List.exists (same_tool_call_signature signature) tool_call_io))
+         match keeper_tool_called_execution_id json with
+         | None -> true
+         | Some execution_id -> not (Execution_id_set.mem execution_id logged_executions))
       entries
 
 (* ── Entry tagging ──────────────────────────────────── *)

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -660,6 +660,7 @@ let test_record_runtime_mcp_keeper_tool_trace_logs_and_broadcasts () =
             ])
         ~message:"command exited 1"
         ~disposition:(Tool_result.Failed Tool_result.Runtime_failure)
+        ~execution_id:(Ids.Execution_id.generate ())
         ~duration_ms:87;
       let rows =
         Masc.Keeper_tool_call_log.read_recent ~keeper_name ~n:1 ()

--- a/test/test_telemetry_eio_coverage.ml
+++ b/test/test_telemetry_eio_coverage.ml
@@ -138,6 +138,7 @@ let test_event_tool_called () =
     session_id = Some "mcp-session-1";
     operation_id = Some "op-1";
     worker_run_id = Some "run-1";
+    execution_id = None;
     error_kind = Some (error_kind "timeout");
     error_message = Some "timed out after 30s";
     exit_code = None;

--- a/test/test_telemetry_eio_pbt.ml
+++ b/test/test_telemetry_eio_pbt.ml
@@ -65,6 +65,7 @@ let gen_event : Telemetry_eio.event QCheck.Gen.t =
       let* session_id = opt_string in
       let* operation_id = opt_string in
       let* worker_run_id = opt_string in
+      let* execution_id = opt_string in
       let* error_kind = opt_string in
       let* error_message = opt_string in
       let* exit_code = opt_int in
@@ -80,6 +81,7 @@ let gen_event : Telemetry_eio.event QCheck.Gen.t =
              session_id;
              operation_id;
              worker_run_id;
+             execution_id;
              error_kind = Option.map Telemetry_eio.error_kind_of_string error_kind;
              error_message;
              exit_code;
@@ -112,6 +114,7 @@ let tool_called_option_keys =
     "session_id";
     "operation_id";
     "worker_run_id";
+    "execution_id";
     "error_kind";
     "error_message";
     "exit_code";
@@ -134,6 +137,7 @@ let saturated_tool_called : Telemetry_eio.event_record =
           session_id = Some "mcp-session";
           operation_id = Some "op-1";
           worker_run_id = Some "wr-1";
+          execution_id = Some "exec-1";
           error_kind = Some (Telemetry_eio.error_kind_of_string "failure");
           error_message = Some "boom";
           exit_code = Some 1;

--- a/test/test_telemetry_unified.ml
+++ b/test/test_telemetry_unified.ml
@@ -260,6 +260,7 @@ let test_shadow_keeper_tool_called_deduped_from_unified_view () =
                   ("success", `Bool true);
                   ("duration_ms", `Int 12);
                   ("agent_id", `String "keeper-sangsu-agent");
+                  ("execution_id", `String "exec-a");
                 ];
             ] );
       ];
@@ -272,6 +273,7 @@ let test_shadow_keeper_tool_called_deduped_from_unified_view () =
         ("tool", `String "masc_status");
         ("success", `Bool true);
         ("duration_ms", `Float 12.0);
+        ("execution_id", `String "exec-a");
       ];
   ];
   let result =
@@ -292,6 +294,111 @@ let test_shadow_keeper_tool_called_deduped_from_unified_view () =
   in
   Alcotest.(check int) "source-filtered agent event remains available" 1
     (List.length raw_agent_entries)
+
+(* Two physical calls of the same tool by the same keeper with the same
+   outcome, one second apart. Sameness is decided by [execution_id], so both
+   agent events survive. The proximity match this replaced treated any two
+   such calls inside a five-second window as one report of one call and
+   dropped the second agent event. *)
+let test_distinct_calls_within_the_old_window_are_both_kept () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "telem_distinct_calls" in
+  let telemetry_dir = Filename.concat dir ".masc/telemetry" in
+  let tool_calls_dir = Filename.concat dir ".masc/tool_calls" in
+  Fs_compat.mkdir_p telemetry_dir;
+  Fs_compat.mkdir_p tool_calls_dir;
+  let agent_event ~ts ~execution_id =
+    `Assoc
+      [
+        ("timestamp", `Float ts);
+        ( "event",
+          `List
+            [
+              `String "Tool_called";
+              `Assoc
+                [
+                  ("tool_name", `String "masc_status");
+                  ("success", `Bool true);
+                  ("duration_ms", `Int 12);
+                  ("agent_id", `String "keeper-sangsu-agent");
+                  ("execution_id", `String execution_id);
+                ];
+            ] );
+      ]
+  in
+  let io_row ~ts ~execution_id =
+    `Assoc
+      [
+        ("ts", `Float ts);
+        ("keeper", `String "sangsu");
+        ("tool", `String "masc_status");
+        ("success", `Bool true);
+        ("duration_ms", `Float 12.0);
+        ("execution_id", `String execution_id);
+      ]
+  in
+  write_jsonl telemetry_dir
+    [ agent_event ~ts:1000.2 ~execution_id:"exec-1"
+    ; agent_event ~ts:1001.2 ~execution_id:"exec-2"
+    ];
+  (* Only the first call reached the durable tool_calls store. *)
+  write_jsonl tool_calls_dir [ io_row ~ts:1000.0 ~execution_id:"exec-1" ];
+  let result =
+    Telemetry_unified.read_unified_result ~base_path:dir
+      ~masc_root:(masc_root dir)
+      ~sources:[ Telemetry_unified.Agent_event; Telemetry_unified.Tool_call_io ]
+      ()
+  in
+  let sources =
+    result.entries |> List.map (json_string_field "source") |> List.sort compare
+  in
+  Alcotest.(check (list string))
+    "the unmatched agent event survives alongside the logged row"
+    [ "agent_event"; "tool_call_io" ]
+    sources
+
+(* An agent event with no [execution_id] cannot be proven to duplicate any
+   row, so it is kept. *)
+let test_agent_event_without_execution_id_is_kept () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "telem_unidentified_call" in
+  let telemetry_dir = Filename.concat dir ".masc/telemetry" in
+  let tool_calls_dir = Filename.concat dir ".masc/tool_calls" in
+  Fs_compat.mkdir_p telemetry_dir;
+  Fs_compat.mkdir_p tool_calls_dir;
+  write_jsonl telemetry_dir
+    [ `Assoc
+        [ ("timestamp", `Float 1000.2)
+        ; ( "event"
+          , `List
+              [ `String "Tool_called"
+              ; `Assoc
+                  [ ("tool_name", `String "masc_status")
+                  ; ("success", `Bool true)
+                  ; ("duration_ms", `Int 12)
+                  ; ("agent_id", `String "keeper-sangsu-agent")
+                  ] ] ) ]
+    ];
+  write_jsonl tool_calls_dir
+    [ `Assoc
+        [ ("ts", `Float 1000.0)
+        ; ("keeper", `String "sangsu")
+        ; ("tool", `String "masc_status")
+        ; ("success", `Bool true)
+        ; ("duration_ms", `Float 12.0)
+        ; ("execution_id", `String "exec-a")
+        ]
+    ];
+  let result =
+    Telemetry_unified.read_unified_result ~base_path:dir
+      ~masc_root:(masc_root dir)
+      ~sources:[ Telemetry_unified.Agent_event; Telemetry_unified.Tool_call_io ]
+      ()
+  in
+  Alcotest.(check int) "unidentified agent event is not suppressed" 2
+    (List.length result.entries)
 
 (* ── Keeper metrics discovery ────────────────────── *)
 
@@ -1323,6 +1430,10 @@ let () =
             test_keeper_tool_called_scope_promoted_for_filters;
           Alcotest.test_case "dedupe shadow agent tool_called" `Quick
             test_shadow_keeper_tool_called_deduped_from_unified_view;
+          Alcotest.test_case "distinct calls in the old window both survive"
+            `Quick test_distinct_calls_within_the_old_window_are_both_kept;
+          Alcotest.test_case "agent event without execution_id is kept" `Quick
+            test_agent_event_without_execution_id_is_kept;
           Alcotest.test_case "keeper metrics" `Quick test_keeper_metrics_per_keeper;
           Alcotest.test_case "keeper metrics fast path keeps noisy top n" `Quick
             test_keeper_metrics_fast_path_preserves_noisy_keeper_top_n;


### PR DESCRIPTION
## 문제

`telemetry_unified` 는 같은 도구 호출이 두 스트림에 각각 실리는 것을 중복 제거한다. 판정 기준이 **근접도**였다.

```ocaml
let shadow_dedup_window_sec = 5.0

let same_tool_call_signature left right =
  String.equal left.actor right.actor
  && String.equal left.tool right.tool
  && (* success 비교 *)
  && abs_float (left.ts -. right.ts) <= shadow_dedup_window_sec
```

바로 위 주석이 `WORKAROUND:` 라벨을 달고 결함을 스스로 적어 두었다.

> Where it is wrong: two genuinely distinct calls of the same tool by the same actor with the same outcome, closer together than the window, look like one report of one call — and `suppress_shadow_keeper_tool_events` **drops the agent-side event for the second**.
>
> Root fix: give the durable tool-call row a call identifier that the agent event also carries, and key on that.

## 조인 키는 이미 한쪽에 있었다

주석은 "Nothing is common to both that identifies a call" 이라고 적었지만, `tool_calls` 행은 **`execution_id` 를 이미 싣고 있다**. RFC-0233 이 정한 canonical join key 다.

```ocaml
(* record_runtime_mcp_keeper_tool_trace 안 *)
let execution_id = Ids.Execution_id.generate () in
Keeper_tool_call_log.log_call ... ~execution_id ...
```

없는 쪽은 `Telemetry_eio.Tool_called` 이벤트였다. 그리고 그 mint 지점이 **너무 안쪽**이었다 — `record_runtime_mcp_keeper_tool_trace` 는 텔레메트리 emit 보다 나중에 불리는 별개 함수다.

## 무엇을 바꿨나

**mint 를 한 단계 올렸다.** `handle_call_tool_eio` 가 dispatch 경계에서 한 번 만들고, `tool_calls` 행과 `Tool_called` 이벤트 양쪽에 넘긴다.

```ocaml
(* keeper 가 호출을 소유할 때만 mint — 그때만 tool_calls 행이 쓰인다 *)
let execution_id =
  Option.map (fun _ -> Ids.Execution_id.generate ()) keeper_entry
in
```

**중복 판정이 집합 조회가 됐다.**

```ocaml
let suppress_shadow_keeper_tool_events entries =
  let logged_executions = (* tool_call_io 행들의 execution_id *) in
  List.filter
    (fun json ->
       match keeper_tool_called_execution_id json with
       | None -> true
       | Some execution_id -> not (Execution_id_set.mem execution_id logged_executions))
    entries
```

시간창도, actor/tool/outcome 비교도, `success` 옵션의 3-way 비교도 없다. `execution_id` 가 없는 이벤트는 **남긴다** — 중복이라는 증거가 없기 때문이다.

## 두 번째 결함

기존 코드는 `tool_calls` 행을 아예 쓰지 않는 레인의 이벤트도 지웠다. `server_routes_http_keeper_stream.ml` 의 `track_tool_called` 두 곳은 `masc_keeper_msg` 를 기록하고 `Keeper_tool_call_log` 를 부르지 않는다. 그 이벤트에 대응하는 행이 없으니 중복일 수 없는데, actor/tool/outcome 이 우연히 맞고 5 초 안이면 사라졌다.

이제 그 이벤트들은 `execution_id` 가 없으므로 항상 남는다.

## 테스트 — 뮤테이션으로 검증

두 회귀를 고정하는 테스트를 추가했다.

1. `distinct calls in the old window both survive` — 같은 keeper 가 같은 도구를 1 초 간격으로 두 번 호출(둘 다 성공), `tool_calls` 행은 첫 번째만. 이제 두 번째 agent 이벤트가 살아남는다.
2. `agent event without execution_id is kept` — `execution_id` 없는 이벤트는 억제되지 않는다.

**변경 전 트리에 대고 돌려 둘 다 실패하는 것을 확인했다** (`git checkout origin/main -- lib/telemetry_unified/telemetry_unified.ml` 후 실행).

```
> [FAIL] read 5  distinct calls in the old window both su...
  [FAIL] read 6  agent event without execution_id is kept.
```

기존 `dedupe shadow agent tool_called` 는 두 행에 같은 `execution_id` 를 넣어 계속 억제되는 것을 확인한다.

## 캐스케이드

근접도 비교가 사라지자 `tool_call_signature` 레코드, `same_tool_call_signature`, `shadow_dedup_window_sec` 와 함께 `bool_field` / `canonical_actor_name` / `drop_prefix` / `drop_suffix` 의 독자가 없어졌다. 루트 `-w +32` (#27220) 가 잡아줬다. 함께 지웠다 — 순감 92 줄.

`Tool_called` 의 옵션 필드가 하나 늘었으므로 PBT 의 `tool_called_option_keys` 목록과 saturated 레코드도 갱신했다. 그 테스트는 "모든 옵션 키를 null 로 만들거나 빼도 파싱된다"를 주장하므로 목록을 안 늘리면 새 필드가 검사되지 않는다.

## 이 PR 과 무관한 발견

`test_telemetry_eio_pbt` 의 `JSON round-trip` 프로퍼티가 **시드에 따라 실패한다**. `QCheck.Gen.float` 이 `nan` 을 만들면 라운드트립이 깨진다. 3 회 실행 중 1 회 실패했고, 실패 표본에 `Task_started` 도 나오므로 이 PR 과 무관하다. 미배선 스위트라 CI 가 못 본다. 이슈 #27300 으로 분리했다.

## 검증

`dune build @check` 통과.

`test_telemetry_unified` (신규 2 건 포함), `test_telemetry_eio_coverage`, `test_mcp_server_eio_call_tool`, `test_telemetry_error_occurred_wire_10358` 통과. `test_telemetry_eio_pbt` 는 위 시드 이슈로 간헐 실패 — 이 PR 이 건드린 `Tool_called: nulling any optional key` / `dropping any optional key` 두 프로퍼티는 매 실행 통과한다.

게이트: `check-determinism-contract`, `audit-catchall`, `check_silent_failure`, `check-variants`, `check-telemetry-coverage`, `check_test_coverage` 통과.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
