### PR TITLE
refactor(dashboard): 회수된 서버 별칭의 클라이언트 잔재 제거

### DIFF
--- a/dashboard/src/api/core.test.ts
+++ b/dashboard/src/api/core.test.ts
@@ -481,7 +481,7 @@ describe('get bootstrap warm-up mapping', () => {
     expect(data.message).toContain('warming up')
   })
 
-  it('remaps namespace/workspace-truth aliases the same as project-snapshot', async () => {
+  it('remaps the namespace-truth alias the same as project-snapshot', async () => {
     const fetchMock = vi.fn().mockImplementation(() =>
       Promise.resolve(
         new Response('{"error":"not initialized"}', {
@@ -498,10 +498,6 @@ describe('get bootstrap warm-up mapping', () => {
     const legacyNamespace = await get<{ status?: string; message?: string }>('/api/v1/dashboard/namespace-truth')
     expect(legacyNamespace.status).toBe('initializing')
     expect(legacyNamespace.message).toContain('warming up')
-
-    const data = await get<{ status?: string; message?: string }>('/api/v1/dashboard/workspace-truth')
-    expect(data.status).toBe('initializing')
-    expect(data.message).toContain('warming up')
   })
 
   it('maps execution not-initialized 5xx to empty execution payload', async () => {

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -401,7 +401,6 @@ const DASHBOARD_BOOTSTRAP_WARM_PATHS = new Set([
   '/api/v1/dashboard/shell',
   '/api/v1/dashboard/project-snapshot',
   '/api/v1/dashboard/namespace-truth',
-  '/api/v1/dashboard/workspace-truth',
   '/api/v1/dashboard/execution',
   '/api/v1/dashboard/planning',
   '/api/v1/dashboard/briefing',
@@ -547,7 +546,6 @@ function bootstrapInitializingPayload(path: string): unknown | null {
       }
     case '/api/v1/dashboard/project-snapshot':
     case '/api/v1/dashboard/namespace-truth':
-    case '/api/v1/dashboard/workspace-truth':
       return {
         status: 'initializing',
         generated_at: generatedAt,

--- a/dashboard/src/namespace-truth-normalizers.test.ts
+++ b/dashboard/src/namespace-truth-normalizers.test.ts
@@ -43,10 +43,7 @@ describe('normalizeNamespaceTruth', () => {
     const result = normalizeNamespaceTruth({
       generated_at_iso: '2026-04-17T10:00:00Z',
       dashboard_surface: '/api/v1/dashboard/namespace-truth',
-      dashboard_aliases: [
-        '/api/v1/dashboard/project-snapshot',
-        '/api/v1/dashboard/workspace-truth',
-      ],
+      dashboard_aliases: ['/api/v1/dashboard/project-snapshot'],
       source: 'namespace_truth_read_model',
       retention: {
         scope: 'dashboard_namespace_truth',
@@ -60,7 +57,7 @@ describe('normalizeNamespaceTruth', () => {
 
     expect(result.generated_at_iso).toBe('2026-04-17T10:00:00Z')
     expect(result.dashboard_surface).toBe('/api/v1/dashboard/namespace-truth')
-    expect(result.dashboard_aliases).toContain('/api/v1/dashboard/workspace-truth')
+    expect(result.dashboard_aliases).toEqual(['/api/v1/dashboard/project-snapshot'])
     expect(result.source).toBe('namespace_truth_read_model')
     expect(result.retention?.scope).toBe('dashboard_namespace_truth')
     expect(result.retention?.execution_input).toBe('/api/v1/dashboard/execution')


### PR DESCRIPTION
## 문제

대시보드 클라이언트가 서버에 없는 엔드포인트 `/api/v1/dashboard/workspace-truth` 를 실재하는 것처럼 다룬다.

서버가 선언하는 별칭은 하나뿐이다.

```ocaml
(* lib/server/server_dashboard_http_namespace_truth_support.ml:167 *)
let namespace_truth_aliases = [ "/api/v1/dashboard/project-snapshot" ]
```

그리고 `test/test_dashboard_namespace_truth.ml:202` 가 **회수 상태를 단정**한다.

```ocaml
check bool "workspace-truth alias retired" ... |> List.mem "/api/v1/dashboard/workspace-truth"
```

RFC-0138 §"Steps 1-3" 이 그 별칭이 PR #16738 로 붙었다고 기록한다. 이후 서버에서 회수됐고, 클라이언트만 남았다.

## 확인

`/api/v1/dashboard/workspace-truth` 는 `lib/` 어디에도 문자열로 없고 접두사 조합으로도 만들어지지 않는다. warm-path 집합의 나머지 6개는 모두 서버 파일 2~5곳에 존재한다.

```
shell              서버파일:3   project-snapshot   서버파일:3
namespace-truth    서버파일:3   execution          서버파일:5
planning           서버파일:2   briefing           서버파일:2
workspace-truth    서버파일:0
```

## 변경

- `DASHBOARD_BOOTSTRAP_WARM_PATHS` 에서 항목 제거 (`core.ts:404`)
- 부트스트랩 placeholder switch case 제거 (`core.ts:550`)
- `core.test.ts` 의 별칭 케이스에서 해당 fetch 제거, 이름을 실제 범위에 맞게 수정
- `namespace-truth-normalizers.test.ts` 의 fixture 가 서버가 실제로 보내는 별칭만 담도록 수정

## 동작 변화

이전에는 `get('/api/v1/dashboard/workspace-truth')` 가 네트워크에 가기 전에 warm-path 단락에 걸려 `status: "initializing"` 을 돌려줬다. 없는 엔드포인트가 "준비 중"으로 보였다. 이제는 단락되지 않는다.

## 검증

```
npx tsc --noEmit            → 0
npx vitest run core.test.ts namespace-truth-normalizers.test.ts
  Test Files 2 passed / Tests 63 passed
```

## 남은 판단

이 PR 이후 `workspace-truth` 라는 이름이 남는 곳은 회수를 단정하는 OCaml 테스트와 RFC-0138 의 이력뿐이다. 그 테스트는 이름이 되돌아오는 걸 막는 계약이라 그대로 뒀다. 폐기된 개념의 이름을 코드에 남기지 않는 쪽을 원하면 같이 지운다.

발견 경위: 하드코딩 스윕에서 TS 라우트 리터럴 85개와 OCaml 라우트 리터럴 178개를 대조. 관련 #27299, #27283.
