### PR TITLE
refactor(dashboard): 서버가 더 보내지 않는 provider discovery 디코더 제거

### DIFF
--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -8,15 +8,6 @@ import { ensureDevToken } from './dev-token'
 import type { RuntimeDefaultsResponse } from './schemas/runtime-defaults'
 import type { RuntimeResolvedResponse } from './schemas/runtime-resolved'
 
-interface DashboardRuntimeProviderDiscovery {
-  healthy?: boolean
-  discovered_model?: string | null
-  ctx_size?: number | null
-  total_slots?: number | null
-  busy_slots?: number | null
-  idle_slots?: number | null
-}
-
 export interface DashboardRuntimeParameterPolicy {
   reasoning_toggle_wire?: string | null
   reasoning_replay_policy?: string | null
@@ -266,7 +257,6 @@ export interface DashboardRuntimeProviderSnapshot {
   source?: string | null
   endpoint_url?: string | null
   note?: string | null
-  discovery?: DashboardRuntimeProviderDiscovery | null
 }
 
 export interface DashboardRuntimeAssignment {
@@ -693,18 +683,6 @@ function decodeRuntimeEffectiveCapabilities(raw: unknown): DashboardRuntimeEffec
   }
 }
 
-function decodeRuntimeProviderDiscovery(raw: unknown): DashboardRuntimeProviderDiscovery | null {
-  if (!isRecord(raw)) return null
-  return {
-    healthy: asBoolean(raw.healthy),
-    discovered_model: asNullableString(raw.discovered_model),
-    ctx_size: asNumber(raw.ctx_size) ?? null,
-    total_slots: asNumber(raw.total_slots) ?? null,
-    busy_slots: asNumber(raw.busy_slots) ?? null,
-    idle_slots: asNumber(raw.idle_slots) ?? null,
-  }
-}
-
 function decodeRuntimeProviderSnapshot(raw: unknown): DashboardRuntimeProviderSnapshot | null {
   if (!isRecord(raw)) return null
   const provider = asString(raw.provider)
@@ -767,7 +745,6 @@ function decodeRuntimeProviderSnapshot(raw: unknown): DashboardRuntimeProviderSn
     source: asNullableString(raw.source),
     endpoint_url: asNullableString(raw.endpoint_url),
     note: asNullableString(raw.note),
-    discovery: decodeRuntimeProviderDiscovery(raw.discovery),
   }
 }
 

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -3252,11 +3252,6 @@ describe('fetchRuntimeProviders', () => {
               },
             },
             source: 'runtime.toml',
-            discovery: {
-              healthy: true,
-              discovered_model: 'Qwen/Qwen3-32B',
-              ctx_size: 200000,
-            },
           },
           {
             provider: 'openai.gpt',
@@ -3399,8 +3394,6 @@ describe('fetchRuntimeProviders', () => {
     expect(result.providers[0]?.declared_spec?.model?.min_p).toBe(0.07)
     expect(result.providers[0]?.declared_spec?.binding?.max_concurrent).toBe(4)
     expect(result.providers[1]?.temperature).toBeNull()
-    expect(result.providers[0]?.discovery?.discovered_model).toBe('Qwen/Qwen3-32B')
-    expect(result.providers[0]?.discovery?.ctx_size).toBe(200000)
     expect(result.assignment_status?.status).toBe('degraded')
     expect(result.assignment_status?.assignment_count).toBe(2)
     expect(result.assignment_status?.assigned_runtimes).toEqual(['openai.gpt'])

--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -251,14 +251,6 @@ describe('RuntimeMonitor', () => {
           source: 'runtime.toml',
           endpoint_url: 'https://example.invalid/v1',
           note: 'verified by runtime discovery',
-          discovery: {
-            healthy: true,
-            discovered_model: 'Qwen/Qwen3-32B',
-            ctx_size: 200000,
-            total_slots: 4,
-            busy_slots: 1,
-            idle_slots: 3,
-          },
         },
       ],
     })
@@ -406,8 +398,6 @@ describe('RuntimeMonitor', () => {
     expect(container.textContent).toContain('task:transcription · native-stream')
     expect(container.textContent).toContain('seed+images')
     expect(container.textContent).toContain('code-exec')
-    expect(container.textContent).toContain('discovered · Qwen/Qwen3-32B')
-    expect(container.textContent).toContain('idle · 3')
   })
 
   it('falls back to provider snapshot model count and auth kind when live probe rows are absent', async () => {

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -154,7 +154,6 @@ function runtimeProviderTone(provider: DashboardRuntimeProviderSnapshot): string
     return 'warn'
   }
   if (provider.available === false) return 'bad'
-  if (provider.discovery?.healthy === false) return 'warn'
   if (provider.available === true) return 'ok'
   return 'warn'
 }
@@ -166,7 +165,7 @@ function runtimeStatusLabel(provider: DashboardRuntimeProviderSnapshot): string 
   if (advertised === 'offline') return 'offline'
   if (provider.available === true) return 'available'
   if (provider.available === false) return 'unavailable'
-  return provider.discovery?.healthy === false ? 'degraded' : 'unknown'
+  return 'unknown'
 }
 
 function runtimeRequestToolChoiceText(provider: DashboardRuntimeProviderSnapshot): string | null {
@@ -973,17 +972,6 @@ export function RuntimeMonitor() {
                     : null}
                   ${liveProbe?.error
                     ? html`<div class="text-2xs text-[var(--status-bad)]">${liveProbe.error}</div>`
-                    : null}
-                  ${provider.discovery
-                    ? html`<div class="grid grid-cols-2 gap-3 text-xs text-[var(--color-fg-secondary)] pt-2 border-t border-[var(--color-border-default)]/50">
-                        <div>discovery · ${provider.discovery.healthy ? 'healthy' : 'degraded'}</div>
-                        <div class="min-w-0 truncate" title=${provider.discovery.discovered_model ?? MISSING_DATA_DASH}>
-                          discovered · ${provider.discovery.discovered_model ?? MISSING_DATA_DASH}
-                        </div>
-                        <div>ctx · ${formatNumber(provider.discovery.ctx_size)}</div>
-                        <div>slots · ${formatNumber(provider.discovery.busy_slots)}/${formatNumber(provider.discovery.total_slots)}</div>
-                        <div>idle · ${formatNumber(provider.discovery.idle_slots)}</div>
-                      </div>`
                     : null}
                 </article>
               `})

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -248,7 +248,6 @@ function makeRuntimeProvider(
     source: 'runtime.toml',
     endpoint_url: 'https://runtime.example/v1',
     note: null,
-    discovery: null,
     ...overrides,
   }
 }


### PR DESCRIPTION
## 문제

대시보드가 provider payload 의 `discovery` 하위 객체를 디코드하고 렌더하는데, **서버는 그 키를 보내지 않는다.**

`/api/v1/providers` 는 `Server_dashboard_http_runtime_info.runtime_inventory_json ()` 을 내보낸다 (`server_routes_http_routes_provider_runs.ml:177`). 그 모듈에 `discovery`, `discovered_model`, `ctx_size`, `total_slots`, `busy_slots`, `idle_slots` 중 어느 것도 없다. 저장소 전체에서 `"discovery"` 를 JSON 키로 쓰는 OCaml 코드가 없다.

서버 쪽은 **#25236 에서 걷혔다**.

```
$ git show fee407a37f -- lib/ | rg '^-.*discovery|^-.*total_slots'
--- a/lib/discovery_cache/discovery_history.ml
-        "discovery"
-  total_slots : int option;
```

클라이언트 디코더는 #6295 에서 들어와 #22261 barrel split 을 거쳐 그대로 남았다.

## 결과

`raw.discovery` 가 항상 `undefined` 라 `decodeRuntimeProviderDiscovery` 는 언제나 `null` 을 돌려준다. 그래서 두 분기가 절대 발화하지 않는다.

```ts
if (provider.discovery?.healthy === false) return 'warn'                  // 항상 false
return provider.discovery?.healthy === false ? 'degraded' : 'unknown'     // 항상 'unknown'
```

runtime monitor 는 provider 를 `degraded` 로 표시할 수 없다. UI 의 discovery 블록(ctx/slots/idle)도 렌더되지 않는다.

## 변경

- `DashboardRuntimeProviderDiscovery` 타입, `discovery` 필드, `decodeRuntimeProviderDiscovery`, 대입부 제거
- `runtime-monitor.ts` 의 두 분기 정리 (`runtimeStatusLabel` 은 `'unknown'` 고정)
- 렌더 블록 제거
- 테스트 3곳의 픽스처와 단정 정리 — 서버가 안 보내는 payload 를 모델링하고 있었다

## 검증

```
npx tsc --noEmit  → 0
npx vitest run runtime-monitor.test.ts dashboard.test.ts settings-surface.test.ts
  Test Files 3 passed / Tests 174 passed
```

## 판단이 필요한 부분

`degraded` 표시가 의도된 기능이라면 서버가 다시 discovery 를 내보내야 한다. 다만 #25236 이 `discovery_history` 모듈째 지운 걸 보면 회수가 의도였던 것으로 읽힌다. 되살릴 계획이면 이 PR 대신 서버 쪽 RFC 가 먼저다.

발견 경위: TS 가 읽는 필드 1361개와 OCaml 리터럴을 대조. 같은 형태의 선행 건은 #27302 (회수된 라우트 별칭의 클라이언트 잔재).
