### PR TITLE
refactor(goals): take the target unit from the target value, not English nouns

### DIFF
--- a/lib/dashboard/dashboard_goals_types.mli
+++ b/lib/dashboard/dashboard_goals_types.mli
@@ -81,20 +81,14 @@ val attainment_unit_to_string : attainment_unit -> string
 
 val contains_ci : string -> string -> bool
 
-val metric_word_tokens : string -> string list
-val metric_word_implies_percent : string -> bool
-val metric_implies_percent : string option -> bool
 
-val metric_count_token : string -> bool
-val metric_has_pull_request_phrase : string list -> bool
-val metric_supports_count_target : string option -> bool
 
 val target_value_implies_percent : string -> bool
 
 val strip_number_group_separators : string -> string
 val parse_first_float : string -> float option
 
-val parsed_target_unit : string option -> string -> attainment_unit
+val parsed_target_unit : string -> attainment_unit
 
 (** {1 Goal attainment JSON projection — pure tree → JSON converter} *)
 

--- a/lib/dashboard/dashboard_goals_types_attainment.ml
+++ b/lib/dashboard/dashboard_goals_types_attainment.ml
@@ -44,98 +44,6 @@ let metric_evaluation_of_goal (goal : Goal_store.goal) =
 
 
 
-(* Token-split that respects camelCase AND acronym boundaries.
-
-   - lower -> upper splits (so [successRate] -> [success; rate])
-   - upper -> upper-followed-by-lower splits (so [APIRatio] ->
-     [api; ratio]; [PRCount] -> [pr; count])
-   - consecutive uppercase letters not followed by a lowercase stay
-     glued (so [API] -> [api], [HTTP] -> [http])
-
-   Without the acronym rule, common acronym-prefixed metric names
-   regressed against percent inference: post-#13170 review noted
-   that names like [APIRatio] / [PRCount] still missed the percent
-   token even after the camelCase fix. The split point is the
-   *last* uppercase letter in a run -- that is the start of the
-   following lowercase word -- not every uppercase letter, so
-   abbreviations stay intact. *)
-let metric_word_tokens raw =
-  let len = String.length raw in
-  let tokens = ref [] in
-  let current = Buffer.create 16 in
-  let flush () =
-    if Buffer.length current > 0 then (
-      tokens := Buffer.contents current :: !tokens;
-      Buffer.clear current)
-  in
-  let is_lower c = c >= 'a' && c <= 'z' in
-  let is_upper c = c >= 'A' && c <= 'Z' in
-  let next_at i = if i + 1 < len then Some raw.[i + 1] else None in
-  let prev_at i = if i > 0 then Some raw.[i - 1] else None in
-  for i = 0 to len - 1 do
-    let ch = raw.[i] in
-    match ch with
-    | 'A' .. 'Z' ->
-        let prev_lower =
-          match prev_at i with Some c -> is_lower c | None -> false
-        in
-        let prev_upper =
-          match prev_at i with Some c -> is_upper c | None -> false
-        in
-        let next_lower =
-          match next_at i with Some c -> is_lower c | None -> false
-        in
-        if prev_lower then flush ()
-        else if prev_upper && next_lower then flush ();
-        Buffer.add_char current (Char.lowercase_ascii ch)
-    | 'a' .. 'z' | '0' .. '9' ->
-        Buffer.add_char current ch
-    | _ ->
-        flush ()
-  done;
-  flush ();
-  List.rev !tokens
-
-(* Post-#13131 review (P1): substring match on "rate"/"ratio"/"pct"
-   gave false positives for metric names like "iteration_rate"-vs-
-   "iterate", "operation"-vs-"ratio". Match against tokenized words
-   (alphanumerics split on punctuation) so only the actual metric
-   nouns trigger the percent inference. *)
-let metric_word_implies_percent token =
-  match token with
-  | "percent" | "pct" | "ratio" | "rate" | "completion" -> true
-  | _ -> false
-
-let metric_implies_percent metric =
-  match metric with
-  | None -> false
-  | Some raw ->
-      String_util.contains_substring_ci raw "%"
-      || List.exists metric_word_implies_percent (metric_word_tokens raw)
-
-let metric_count_token = function
-  | "task" | "tasks" | "todo" | "todos" | "issue" | "issues" | "ticket"
-  | "tickets" | "pr" | "prs" | "done" ->
-      true
-  | _ ->
-      false
-
-let metric_has_pull_request_phrase tokens =
-  let rec loop = function
-    | "pull" :: next :: _ when next = "request" || next = "requests" -> true
-    | _ :: rest -> loop rest
-    | [] -> false
-  in
-  loop tokens
-
-let metric_supports_count_target metric =
-  match metric with
-  | None -> true
-  | Some raw ->
-      let tokens = metric_word_tokens raw in
-      List.exists metric_count_token tokens
-      || metric_has_pull_request_phrase tokens
-
 let target_value_implies_percent raw =
   String_util.contains_substring_ci raw "%"
   || String_util.contains_substring_ci raw "percent"
@@ -186,11 +94,15 @@ let parse_first_float raw =
   in
   search 0
 
-let parsed_target_unit metric raw =
-  if target_value_implies_percent raw || metric_implies_percent metric then
-    Percent
-  else
-    Count
+(* The unit comes from the target value's own marker — "80%" is a percentage,
+   "12" is a count. It used to also be inferred from English nouns in the
+   goal's free-text metric name ("rate" / "ratio" / "completion" implied a
+   percentage; "task" / "issue" / "pr" / "done" were required before a count
+   target could be measured at all). On the live store that inference fired 0
+   times and the count gate blocked one goal outright — a Korean metric ending
+   in 수 (count), whose ASCII tokens are only ["end"; "to"; "end"]. *)
+let parsed_target_unit raw =
+  if target_value_implies_percent raw then Percent else Count
 
 let build_attainment_json ~state ~basis ~task_done_count ~task_count
     ~target_parse_status ~unit ~observed_value ~target_numeric ~attainment_pct
@@ -294,7 +206,7 @@ let goal_attainment_to_json (goal : Goal_store.goal) (node : tree_node) =
               unmeasured "invalid_target"
                 "Target value must be greater than zero."
           | Some target_numeric -> (
-              let unit = parsed_target_unit goal.metric raw in
+              let unit = parsed_target_unit raw in
               match unit with
               | Percent -> (
                   match task_completion_pct with
@@ -306,13 +218,13 @@ let goal_attainment_to_json (goal : Goal_store.goal) (node : tree_node) =
                       unmeasured ~unit ~target_numeric "no_linked_tasks"
                         "Percent target needs linked task evidence." )
               | Count ->
-                  if metric_supports_count_target goal.metric then
+                  if task_count > 0 then
                     measured ~basis:"metric_target_count" ~unit
                       ~observed_value:(float_of_int task_done_count)
                       ~target_numeric ~target_parse_status:"parseable"
                   else
-                    unmeasured ~unit ~target_numeric "unsupported_metric"
-                      "Numeric target is not mapped to a known count metric."
+                    unmeasured ~unit ~target_numeric "no_linked_tasks"
+                      "Count target needs linked task evidence."
               | Unknown ->
                   unmeasured "unsupported_metric"
                     "Target unit is unknown." ))

--- a/lib/dashboard/dashboard_goals_types_attainment.mli
+++ b/lib/dashboard/dashboard_goals_types_attainment.mli
@@ -17,20 +17,13 @@ val metric_evaluation_of_goal : Goal_store.goal -> metric_evaluation
 
 val contains_ci : string -> string -> bool
 
-val metric_word_tokens : string -> string list
-val metric_word_implies_percent : string -> bool
-val metric_implies_percent : string option -> bool
-
-val metric_count_token : string -> bool
-val metric_has_pull_request_phrase : string list -> bool
-val metric_supports_count_target : string option -> bool
 
 val target_value_implies_percent : string -> bool
 
 val strip_number_group_separators : string -> string
 val parse_first_float : string -> float option
 
-val parsed_target_unit : string option -> string -> attainment_unit
+val parsed_target_unit : string -> attainment_unit
 
 val build_attainment_json :
   state:string ->

--- a/test/test_goal_metric_unevaluated.ml
+++ b/test/test_goal_metric_unevaluated.ml
@@ -206,6 +206,42 @@ let test_unevaluated_metric_is_display_only_for_completion () =
   check string "executing goal is completion-ready" "ready_for_completion"
     (json_str json "state")
 
+(* The unit comes from the target value, not from English nouns in the metric
+   name. A Korean metric that ends in 수 (count) with a numeric target is
+   measured as a count; the removed word list required one of
+   task/todo/issue/ticket/pr/done to appear as an ASCII token, and this
+   metric tokenizes to ["end"; "to"; "end"], so it reported
+   [unsupported_metric] instead. *)
+let test_korean_count_metric_is_measured () =
+  let g =
+    make_goal ~metric:"end-to-end 설계+구현 완료 서비스 수" ~target_value:"1개 이상"
+      "g-ko" "korean count goal"
+  in
+  let node = make_node ~tasks:[ make_done_task "t1" ] g in
+  let json = A.goal_attainment_to_json g node in
+  check string "count target is measured" "metric_target_count"
+    (json_str json "basis");
+  check string "unit is a count" "count" (json_str json "unit");
+  check string "target parsed" "parseable" (json_str json "target_parse_status")
+
+(* A metric name whose words used to imply a percentage no longer does. Only
+   the target value's own marker selects [Percent]. *)
+let test_metric_word_does_not_select_percent () =
+  let g =
+    make_goal ~metric:"weekly completion rate" ~target_value:"12" "g-rate"
+      "rate-named goal"
+  in
+  let node = make_node ~tasks:[ make_done_task "t1" ] g in
+  let json = A.goal_attainment_to_json g node in
+  check string "unit follows the target value" "count" (json_str json "unit");
+  let pct_goal =
+    make_goal ~metric:"weekly completion rate" ~target_value:"80%" "g-pct"
+      "percent target"
+  in
+  let pct_json = A.goal_attainment_to_json pct_goal (make_node ~tasks:[ make_done_task "t1" ] pct_goal) in
+  check string "an explicit percent target still selects percent" "percent"
+    (json_str pct_json "unit")
+
 let test_keeper_receipt_timeline_missing_runtime_stays_missing () =
   let goal = make_goal "g7" "timeline" in
   let meta = make_keeper_meta "timeline-keeper" in
@@ -467,5 +503,9 @@ let () =
             test_goal_owner_timeline_names_the_transition;
           test_case "goal_owner timeline names unassigned sides" `Quick
             test_goal_owner_timeline_names_unassigned_sides;
+          test_case "korean count metric is measured" `Quick
+            test_korean_count_metric_is_measured;
+          test_case "metric wording does not select percent" `Quick
+            test_metric_word_does_not_select_percent;
         ] );
     ]


### PR DESCRIPTION
## 문제

목표(goal)의 달성도를 계산할 때, **목표가 퍼센트인지 개수인지**를 자유 텍스트 metric 이름의 영어 단어로 추론하고 있었다.

```ocaml
let metric_word_implies_percent token =
  match token with
  | "percent" | "pct" | "ratio" | "rate" | "completion" -> true
  | _ -> false

let metric_count_token = function
  | "task" | "tasks" | "todo" | "todos" | "issue" | "issues" | "ticket"
  | "tickets" | "pr" | "prs" | "done" -> true
  | _ -> false

let metric_has_pull_request_phrase tokens = (* "pull" 다음에 "request(s)" *)
```

두 역할을 했다.

1. metric 이름에 `rate` / `ratio` / `completion` 이 있으면 → `Percent`
2. metric 이름에 `task` / `issue` / `pr` / `done` 이 **없으면** 숫자 목표를 아예 측정하지 않고 `unsupported_metric` 으로 표시

## 실측: 목표 16 개

`~/me/.masc/goals.json` 전수에 현재 로직을 그대로 적용했다.

| 결과 | 개수 |
|---|---|
| `invalid_target` (첫 실수 ≤ 0) | 10 |
| `unparseable` | 2 |
| `no_target` | 1 |
| **COUNT 측정됨** | **2** |
| **COUNT 차단 → `unsupported_metric`** | **1** |
| **PERCENT (어느 경로로든)** | **0** |

- **퍼센트 추론은 한 번도 발동하지 않는다.** `metric_word_implies_percent` 도, `target_value_implies_percent` 도 0 회.
- 개수 게이트는 3 건에 관여해 **1 건을 차단한다.**

차단된 그 하나가 문제를 그대로 보여준다.

```
metric = "end-to-end 설계+구현 완료 서비스 수"
target = "1개 이상"
→ unsupported_metric ("Numeric target is not mapped to a known count metric.")
```

metric 이 끝에 **수** 라고 적혀 있는데 측정 불가로 표시된다. `metric_word_tokens` 가 ASCII 영숫자만 모으기 때문에 이 문자열의 토큰은 `["end"; "to"; "end"]` 뿐이고, 영어 목록 어디에도 없다.

`Task_completion_claim` (#27304) 과 같은 실패 방식이다 — **영어 단어 목록이 한국어를 조용히 떨어뜨린다.**

## 관측값은 어차피 task 에서 온다

이 모듈의 다른 주석이 이미 적어 두었다.

> A goal with a declared metric is `Metric_unevaluated` until a measurement source records an observation. ... even when `state` / `attainment_pct` look like progress, they are **task-derived**

`Percent` 이면 `task_completion_pct`, `Count` 이면 `task_done_count` 다. metric 텍스트는 **측정값에 전혀 영향을 주지 않는다.** 단어 목록이 정하는 것은 라벨과, 무언가를 보여줄지 말지뿐이었다.

## 무엇으로 바꿨나

단위는 **목표값 자신의 표기**에서 온다. `"80%"` 는 퍼센트, `"12"` 는 개수. 값의 단위 접미사를 읽는 것은 산문에서 의도를 추론하는 것과 다르다 — `parse_first_float` 가 이미 같은 문자열에서 숫자를 읽고 있다.

```ocaml
let parsed_target_unit raw =
  if target_value_implies_percent raw then Percent else Count
```

개수 측정 가능 여부는 **연결된 task 가 있는지**로 판정한다. 데이터이지 산문이 아니다.

```ocaml
| Count ->
    if task_count > 0 then measured ... else unmeasured "no_linked_tasks"
```

지운 것: `metric_word_tokens`, `metric_word_implies_percent`, `metric_implies_percent`, `metric_count_token`, `metric_has_pull_request_phrase`, `metric_supports_count_target` (`.ml` + 두 개의 `.mli`).

## 이 분류기는 이미 한 번 고쳐진 적이 있다

주석이 남아 있다.

> gave false positives for metric names like "iteration_rate"-vs-"iterate", "operation"-vs-"ratio". Match against tokenized words ... so only the actual metric nouns trigger the percent inference.

부분문자열 매치가 오탐을 내서 토큰 매치로 바꾼 이력이다. CLAUDE.md 의 "2번째 fix → 근본 수정 강제" 에 해당한다 — 세 번째로 한국어 단어를 추가하는 대신 판정 근거 자체를 바꿨다.

## 테스트

이 추론에는 **테스트가 하나도 없었다** (`rg` 로 `test/` 전수 확인). 실측 0 회 발동 + 테스트 0 건이었다.

두 건을 추가했다.

1. `korean count metric is measured` — 위 실제 목표를 그대로 픽스처로 써서 `metric_target_count` 로 측정되는지 확인
2. `metric wording does not select percent` — `"weekly completion rate"` metric + `"12"` 목표는 개수, 같은 metric + `"80%"` 목표는 퍼센트

**변경 전 lib 에 대고 돌려 둘 다 실패하는 것을 확인했다** (`git checkout origin/main -- lib/` 후 실행 → `FAIL count target is measured`).

WORKAROUND-WAIVED: 게이트의 STRING_CLASSIFIER 시그니처는 본문이 제거 대상 단어 목록을 인용해서 걸렸다. 이 PR 은 분류기를 추가하지 않고 6 개를 삭제한다.

## 검증

`dune build @check` 통과. `test_goal_metric_unevaluated` (신규 2 건 포함), `test_goal_store`, `test_goal_tools` 통과.

게이트: `check-determinism-contract`, `audit-catchall`, `check_silent_failure`, `check-variants`, `check-enum-string-safety`, `check_test_coverage` 통과.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
