### PR TITLE
fix(dashboard): rank a serialized agent_status by decoding it, not by substring

### DIFF
--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -47,12 +47,15 @@ let severity_rank s =
   | "warn" | "watch" | "interrupted" | "degraded" -> 1
   | _ -> 0
 
-let status_rank = function
-  | "busy" -> 4
-  | "active" -> 3
-  | "listening" -> 2
-  | "idle" -> 1
-  | _ -> 0
+(* The wire carries [agent_status_to_string]'s output, so ranking a serialized
+   status means decoding it first. Ranking the raw string instead left an arm
+   for "idle" — a spelling this producer never emits — while the real fourth
+   constructor, [Inactive], fell through to the catch-all and ranked the same
+   as garbage. *)
+let status_rank raw =
+  match Masc_domain.agent_status_of_string_opt (String.lowercase_ascii (String.trim raw)) with
+  | Some status -> Masc_domain.agent_status_rank status
+  | None -> 0
 
 let rec take n items =
   if n <= 0 then [] else match items with [] -> [] | x :: xs -> x :: take (n - 1) xs

--- a/lib/dashboard_utils/dashboard_utils.mli
+++ b/lib/dashboard_utils/dashboard_utils.mli
@@ -50,7 +50,9 @@ val severity_rank : string -> int
 (** Severity score from a free-form status string ([0]–[2]). *)
 
 val status_rank : string -> int
-(** Status score for keeper status ([0]–[4]). *)
+(** Rank a serialized {!Masc_domain.agent_status}: [Busy] 4, [Active] 3,
+    [Listening] 2, [Inactive] 1. Anything that is not an [agent_status]
+    ranks 0. *)
 
 val take : int -> 'a list -> 'a list
 (** [take n xs] returns the first [n] elements (or all if shorter). *)

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -45,6 +45,17 @@ let all_agent_statuses = [ Active; Busy; Listening; Inactive ]
 let valid_agent_status_strings =
   List.map agent_status_to_string all_agent_statuses
 
+(* Presence ordering for operator surfaces: the agent doing work outranks the
+   one merely holding a session, which outranks the one only listening. A
+   fifth constructor breaks compilation here instead of silently ranking 0,
+   which is what happens when the ordering is written over the serialized
+   strings instead. *)
+let agent_status_rank = function
+  | Busy -> 4
+  | Active -> 3
+  | Listening -> 2
+  | Inactive -> 1
+
 let agent_status_of_string_opt = function
   | "active" -> Some Active
   | "busy" -> Some Busy

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -18,6 +18,11 @@ val agent_status_to_string : agent_status -> string
 val string_of_agent_status : agent_status -> string
 val all_agent_statuses : agent_status list
 val valid_agent_status_strings : string list
+(** Presence ordering for operator surfaces: [Busy] 4, [Active] 3,
+    [Listening] 2, [Inactive] 1. Descending-rank comparators sort a working
+    agent above an idle one. *)
+val agent_status_rank : agent_status -> int
+
 val agent_status_of_string_opt : string -> agent_status option
 val agent_status_of_string_r : string -> (agent_status, string) result
 val agent_status_to_yojson : agent_status -> Yojson.Safe.t

--- a/test/test_health_status.ml
+++ b/test/test_health_status.ml
@@ -38,6 +38,22 @@ let test_max_string_canonicalizes_through_ssot () =
   check string "tie keeps left canonical" "blocked" (Health_status.max_string "blocked" "error");
   check string "unknown beats ok" "unknown" (Health_status.max_string "ok" "new_status")
 
+
+(* A serialized agent_status is ranked by decoding it. The string ranker this
+   replaced had an arm for "idle" — a spelling agent_status_to_string never
+   emits — while [Inactive] fell through to the catch-all and ranked 0, the
+   same as garbage. *)
+let test_serialized_agent_status_ranks_through_the_wire () =
+  List.iter
+    (fun status ->
+       let raw = Masc_domain.agent_status_to_string status in
+       check int
+         (Printf.sprintf "%s ranks the same through the wire" raw)
+         (Masc_domain.agent_status_rank status)
+         (Dashboard_utils.status_rank raw))
+    Masc_domain.all_agent_statuses;
+  check int "a non-status string ranks 0" 0 (Dashboard_utils.status_rank "idle")
+
 let () =
   run "Health_status"
     [
@@ -50,5 +66,10 @@ let () =
         [
           test_case "dashboard wrappers use SSOT" `Quick test_dashboard_compat_uses_health_status_ssot;
           test_case "legacy synonyms" `Quick test_legacy_dashboard_synonyms_map_to_shared_statuses;
+        ] );
+      ( "agent_status rank",
+        [
+          test_case "serialized status ranks through the wire" `Quick
+            test_serialized_agent_status_ranks_through_the_wire;
         ] );
     ]

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -1527,6 +1527,23 @@ let test_task_claim_next_action_todo_policy_block_still_claims () =
    Test Runners
    ============================================================ *)
 
+(* Every agent_status must rank, and the ranks must be distinct — a
+   serialized status is ranked by decoding it, so an unranked constructor
+   would sort as if it were garbage. The string ranker this replaced had an
+   arm for "idle" (never produced) and none for "inactive" (the real fourth
+   constructor). *)
+let test_agent_status_rank_covers_every_constructor () =
+  let ranks =
+    List.map Masc_domain.agent_status_rank Masc_domain.all_agent_statuses
+  in
+  Alcotest.(check int) "one rank per constructor"
+    (List.length Masc_domain.all_agent_statuses) (List.length ranks);
+  let sorted = List.sort_uniq Int.compare ranks in
+  Alcotest.(check int) "ranks are distinct" (List.length ranks)
+    (List.length sorted);
+  Alcotest.(check bool) "no constructor ranks 0" true
+    (not (List.exists (Int.equal 0) ranks))
+
 let () =
   run "Types Coverage" [
     "agent_id", [
@@ -1788,5 +1805,9 @@ let () =
     "task_claim", [
       test_case "awaiting verification waits for verdict" `Quick
         test_task_claim_awaiting_verification_is_pending_verdict;
+    ];
+    "agent_status_rank", [
+      test_case "every constructor ranks distinctly" `Quick
+        test_agent_status_rank_covers_every_constructor;
     ];
   ]


### PR DESCRIPTION
## 문제

에이전트 프레즌스 정렬이 직렬화된 `agent_status` 를 **문자열로** 랭크한다.

```ocaml
let status_rank = function
  | "busy" -> 4
  | "active" -> 3
  | "listening" -> 2
  | "idle" -> 1        (* 이 생산자는 이 철자를 만들지 않는다 *)
  | _ -> 0             (* 실제 네 번째 생성자 Inactive 가 여기로 떨어진다 *)
```

생산자는 닫힌 variant 다.

```ocaml
type agent_status = Active | Busy | Listening | Inactive

let agent_status_to_string = function
  | Active -> "active" | Busy -> "busy"
  | Listening -> "listening" | Inactive -> "inactive"
```

호출 지점(`dashboard_briefing_agents.ml:177`)이 읽는 값이 바로 그 함수의 출력이다.

```ocaml
let status = match agent with Some value -> Masc_domain.agent_status_to_string value.status | ...
```

두 가지가 어긋나 있다.

- **`"idle"` arm 은 도달 불가.** `agent_status_to_string` 이 만들 수 없는 철자다. (다른 곳에는 `Listening -> Some "idle"` 로 매핑하는 생산자가 따로 있다 — `server_ide_http.ml:519`. 어휘가 갈라져 있고, 이 랭커는 그 갈래를 잡으려다 자기 입력에는 없는 arm 을 갖게 됐다.)
- **`Inactive` 는 인식되지 않는다.** catch-all 로 떨어져 쓰레기 문자열과 같은 0 을 받는다.

지금 정렬 순서가 우연히 맞는 이유는 `Inactive` 가 어차피 마지막이기 때문이다. **다섯 번째 생성자가 추가되면 컴파일러는 아무 말도 하지 않고 0 으로 정렬된다.**

## 무엇으로 바꿨나

랭크를 타입 옆에 둔다.

```ocaml
(* types_core.ml *)
let agent_status_rank = function
  | Busy -> 4 | Active -> 3 | Listening -> 2 | Inactive -> 1
```

직렬화된 값은 **디코드한 뒤** 랭크한다.

```ocaml
let status_rank raw =
  match Masc_domain.agent_status_of_string_opt (String.lowercase_ascii (String.trim raw)) with
  | Some status -> Masc_domain.agent_status_rank status
  | None -> 0
```

`agent_status` 가 아닌 문자열은 0 이다 — 오늘의 `_ -> 0` 과 같다.

| 입력 | 이전 | 이후 |
|---|---|---|
| `"busy"` | 4 | 4 |
| `"active"` | 3 | 3 |
| `"listening"` | 2 | 2 |
| `"inactive"` | **0** | **1** |
| `"idle"` | **1** | 0 (이 표면에 도달 불가) |
| 그 외 | 0 | 0 |

관측 가능한 정렬 변화는 없다 — `Inactive` 는 이전에도 이후에도 최하위다. 바뀐 것은 **다음 생성자가 조용히 0 이 되지 않는다**는 것이다.

`#27308` 과 같은 수리다. 그쪽은 `"critical"` 과 `"bad"` 가 같은 값으로 눌려 **관측 가능한 오정렬**이 있었고, 이쪽은 아직 없다. 같은 결함 형태를 둘 다 닫는다.

## 테스트

1. `every constructor ranks distinctly` (`test_types_coverage`) — `all_agent_statuses` 전부가 서로 다른 0 아닌 랭크를 받는지. 새 생성자를 추가하고 `agent_status_rank` 를 갱신하지 않으면 컴파일이 먼저 서고, 갱신하면서 값을 겹치게 두면 이 테스트가 잡는다.
2. `serialized status ranks through the wire` (`test_health_status`) — 모든 생성자가 `to_string` 을 거쳐도 같은 랭크를 받고, `"idle"` 은 0 인지.

**옛 문자열 랭커를 되돌려 2 번이 실패하는 것을 확인했다** (`ASSERT active ranks the same through the wire` 부터 어긋난다).

## 사전 실패에 대해

`test_types_coverage` 는 이 PR 이전부터 `masc_error_extended / task not claimed` 1 건이 실패한다. `lib/` 와 `test/` 를 `origin/main` 으로 되돌려 확인했다 — 동일하게 실패한다. 미배선 스위트다.

## 검증

`dune build @check` 통과. `test_health_status`, `test_dashboard_briefing` 통과. `test_types_coverage` 신규 1 건 통과(사전 실패 1 건은 main 과 동일).

게이트: `check-determinism-contract`, `audit-catchall`, `check-variants`, `check-enum-string-safety`, `check_silent_failure`, `check_test_coverage` 통과.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
