### PR TITLE
chore(tools): drop the inventory field nothing computes and nothing reads

### DIFF
--- a/dashboard/src/api/dashboard-tools-prompts.ts
+++ b/dashboard/src/api/dashboard-tools-prompts.ts
@@ -14,7 +14,6 @@ export interface DashboardToolInventoryItem {
   description: string
   category: string
   category_description?: string | null
-  enabled_in_current_mode: boolean
   direct_call_allowed: boolean
   required_permission?: string | null
   doc_refs: string[]

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -137,7 +137,6 @@ function makeToolItem(overrides: Partial<DashboardToolInventoryItem> = {}): Dash
     name: 'tool',
     description: '',
     category: 'uncategorized',
-    enabled_in_current_mode: false,
     direct_call_allowed: false,
     doc_refs: [],
     prompt_hints: [],

--- a/dashboard/src/components/tools/tool-state.test.ts
+++ b/dashboard/src/components/tools/tool-state.test.ts
@@ -12,7 +12,6 @@ function makeItem(overrides: Partial<DashboardToolInventoryItem> = {}): Dashboar
     description: 'A test tool',
     category: 'shell',
     category_description: null,
-    enabled_in_current_mode: true,
     direct_call_allowed: true,
     required_permission: null,
     doc_refs: [],

--- a/lib/tool_misc_introspection.ml
+++ b/lib/tool_misc_introspection.ml
@@ -32,7 +32,6 @@ type tool_result = Tool_result.result
 
 let tool_inventory_json _ctx ~include_hidden =
   (* Returns all tool schemas from catalog with metadata.
-     enabled_in_current_mode=false because this is dashboard context (no keeper).
      Keeper model visibility is the complete descriptor-declared surface. *)
   let surface_map : (string, string list) Hashtbl.t = Hashtbl.create 256 in
   let add_surface name s =
@@ -103,7 +102,6 @@ let tool_inventory_json _ctx ~include_hidden =
                 ("registered_schema", `Bool true);
                 ( "dispatch_registered",
                   `Bool (Option.is_some (Tool_dispatch.lookup_tag schema.name)) );
-                ("enabled_in_current_mode", `Bool false);
                 ("direct_call_allowed", `Bool (Tool_catalog.allow_direct_call schema.name));
                 ("doc_refs", `List (List.map (fun value -> `String value) help_entry.doc_refs));
                 ("prompt_hints", `List (List.map (fun value -> `String value) help_entry.prompt_hints));

--- a/lib/tool_misc_introspection.mli
+++ b/lib/tool_misc_introspection.mli
@@ -26,11 +26,7 @@ val tool_inventory_json :
   Yojson.Safe.t
 (** [tool_inventory_json _ctx ~include_hidden]
     returns the tool catalog snapshot.
-
-    [enabled_in_current_mode] is reported as [false] because this
-    is the dashboard context (no keeper) — pinned at the contract
-    seam to prevent operator dashboards from incorrectly showing
-    keeper-only tools as active. *)
+ *)
 
 (** {1 Tool handlers}
 


### PR DESCRIPTION
## What

`tool_inventory_json` emitted `("enabled_in_current_mode", `Bool false)` as a
literal for every entry — **129 of 129** on the live workspace. Remove it.

## Why

The `.mli` explained the constant rather than a computation:

> `[enabled_in_current_mode]` is reported as `[false]` because this is the
> dashboard context (no keeper) — pinned at the contract seam to prevent
> operator dashboards from incorrectly showing keeper-only tools as active.

Nothing reads it. Repo-wide sweep:

| consumer | what it does |
|---|---|
| `dashboard/src/api/dashboard-tools-prompts.ts:17` | declares it in the interface |
| `tool-state.test.ts`, `settings-surface.test.ts` | set it in fixtures |
| any component | **none** — no render, no filter, no branch |

## It has already been misread as a measurement

`reports/keeper-schedule-dashboard-todo-2026-06-21.md`:

> All live schedule tools report `direct_call_allowed=true` and
> `dispatch_registered=true`, but `surfaces=[]` and
> **`enabled_in_current_mode=false`**.

That is cited as evidence the schedule tools are inactive. The second half was
true of all 129 tools, including the ones being called that minute. A field
whose value is a constant reads as a decision when none is being made.

The two report files keep the phrase — they are dated findings, and rewriting
what a past audit observed would be worse than leaving it.

## Verification

```
dune build lib/                                        → clean
dune build --force @test/runtest-test_tool_help_metadata_rfc_0195 \
  @test/runtest-test_capability_registry \
  @test/runtest-test_tool_shard_coverage                → 13 + 6 + 6 pass

cd dashboard && npm run typecheck                       → clean
npx vitest run … tool-state.test.ts settings-surface.test.ts
                                                        → 2 files, 77 tests pass
```

`scripts/check-ssot.sh` clean; `scripts/check_test_coverage.py` passes — both
run from the worktree root.

No open PR touches any of these five files.

RFC-WAIVED: one wire field removed after a repo-wide consumer sweep showed no
reader. No schema shape a consumer branches on, no state machine, no
credential/identity/operator surface.
