### PR TITLE
fix(ci): wire the task_status vocabulary suite #27031 added

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -945,6 +945,7 @@ jobs:
             @test/runtest-test_server_base_path_guard \
             @test/runtest-test_sse_retry_ssot \
             @test/runtest-test_task_cache_invariant_13397 \
+            @test/runtest-test_task_status_vocabulary \
             @test/runtest-test_tool_contract_truth \
             @test/runtest-test_voice_command_descriptor_parity
 


### PR DESCRIPTION
## main 이 red 다

`Meta Guards / Check CI test targets` 가 **main 에서 실패한다.**

```
$ git checkout main && bash scripts/audit-ci-test-targets.sh
[ci-test-targets] FAIL - 740 suites are declared but never run in CI (baseline 739)
```

열려 있는 모든 PR 이 이것을 물려받는다. 지금 확인한 것만 4 건(#27310, #27313, #27314, #27319)이 이 한 가지 이유로 `Meta Guards` 가 빨갛다.

## 원인

`#27031` (`test(types): compare the two hand-kept task_status vocabularies`) 이 스위트를 추가하면서 CI 배선을 하지 않았다.

```
 test/dune                                    |   2 +
 test/stanzas/test_task_status_vocabulary.inc |   5 +
 test/test_task_status_vocabulary.ml          | 144 +++++++++++++++++++++++++++
```

`ci.yml` 변경은 0 줄이다. 스크립트 주석이 정확히 이 경우를 경고하고 있었다.

> A PR that wires a suite must lower this number in the same PR, or this check goes red for everyone.

반대 방향도 같다 — 스위트를 추가하면 배선하거나 baseline 을 올려야 한다.

## 무엇을 했나

`ci.yml` 에 `@test/runtest-test_task_status_vocabulary` 를 추가했다.

**baseline 은 건드리지 않았다.** 배선으로 740 → 739 가 되어 `#27283` 이 확보한 지점을 그대로 유지한다. baseline 을 740 으로 올리는 쪽은 스위트를 영구히 미실행으로 남기므로 택하지 않았다.

## 왜 배선이 옳은가

이 스위트는 **통과한다** (4 건). 컴파일만 되고 실행되지 않는 상태였다는 뜻이고, 그 상태에서는 스위트가 고정하려던 계약 — `task_status` 어휘 두 벌이 어긋나지 않는다 — 이 아무것도 지키지 못한다.

```
$ opam exec -- dune build --root . @test/runtest-test_task_status_vocabulary
4 [OK]
```

## 검증

`bash scripts/audit-ci-test-targets.sh` → `OK - 739 suites unwired, at baseline`.

`ci.yml` 한 줄 외의 변경 없음.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
