### PR TITLE
fix(ci): run test_task_status_vocabulary, which nothing ran

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -890,7 +890,8 @@ jobs:
             @test/runtest-test_tool_spec \
             @test/runtest-test_tool_shard_coverage \
             @test/runtest-test_tool_board_coverage \
-            @test/runtest-test_tool_task_coverage
+            @test/runtest-test_tool_task_coverage \
+            @test/runtest-test_task_status_vocabulary
 
       - name: Run completion-authority lookup surface suite
         # The judge's lookup tools reach the filesystem and Git inside a


### PR DESCRIPTION
## What

`audit-ci-test-targets.sh` has been failing on `main` since
`test_task_status_vocabulary` was added without a CI target — **740 unwired
against a baseline of 739**. That blocks **Meta Guards on every open PR**.

The script's own comment names this exact situation:

> A PR that wires a suite must lower this number in the same PR, **or this
> check goes red for everyone.**

Wiring it brings the count back to 739, so `UNWIRED_BASELINE` is unchanged.

## Why wire it rather than raise the baseline

The suite is worth running. Its header states the failure it exists to catch:

> `task_status_schema_witnesses` … becomes `valid_task_status_strings`, which
> is the enum `tool_shard_types_schemas_taskboard` publishes — so a forgotten
> witness **tells a model the status is not a legal value while the parser
> happily** accepts it.

Compile-only, that assertion executes never and could have held nothing.

## Evidence

```
175d5a0095  [ci-test-targets] OK   - 739 suites unwired, at baseline   exit 0
origin/main [ci-test-targets] FAIL - 740 suites unwired (baseline 739) exit 2

diff of the unwired sets, each computed in its own clean worktree:
  main only: test_task_status_vocabulary
  base only: (none)
```

After this change:

```
[ci-test-targets] OK - 117 CI targets, all declared in test/dune
[ci-test-targets] OK - 739 suites unwired, at baseline          exit 0
```

## Verification

```
dune build --force @test/runtest-test_task_status_vocabulary \
                   @test/runtest-test_tool_task_coverage
→ 4 + 87 tests, all pass

scripts/audit-ci-test-targets.sh                      exit 0
ci.yml parses as YAML
```

## Method note

A first attempt to diff the unwired sets checked both refs into a single
worktree and over-counted both sides: `git checkout <ref> -- test/stanzas` adds
that ref's files without removing the ones only `main` has, so the
`test/stanzas/*.inc` glob saw the union. Running the script itself at
`175d5a0095` (which reports 739) is what exposed it; the numbers above come
from two clean worktrees.

RFC-WAIVED: one CI target added so an existing test executes. No source change,
no baseline change, no schema, no state machine.
