### PR TITLE
fix(turn): retry same runtime with halved window on context overflow before rotating (#27320)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1455,7 +1455,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          request_cap_targets="@test/runtest-test_runtime_config_validity @test/runtest-test_keeper_turn_driver_failover @test/runtest-test_keeper_turn_driver_accept @test/runtest-test_keeper_vision_tool @test/runtest-test_runtime_modality_reroute @test/runtest-test_runtime_model_input_tail_window"
+          request_cap_targets="@test/runtest-test_runtime_config_validity @test/runtest-test_keeper_turn_driver_failover @test/runtest-test_keeper_turn_driver_accept @test/runtest-test_keeper_vision_tool @test/runtest-test_runtime_modality_reroute @test/runtest-test_runtime_model_input_tail_window @test/runtest-test_keeper_context_overflow_shrink"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${request_cap_targets}"
 
       - name: Run operator control suite

--- a/lib/keeper/keeper_context_overflow_shrink_state.ml
+++ b/lib/keeper/keeper_context_overflow_shrink_state.ml
@@ -1,0 +1,63 @@
+(** Keeper_context_overflow_shrink_state — process-local memory of the last
+    model-input windowing capacity that completed a turn successfully for a
+    given (keeper, runtime) pair.
+
+    #27320: {!Keeper_turn_driver_try_provider.run_try_provider_with_context_overflow_shrink}
+    retries a provider-reported context overflow on the SAME runtime with a
+    halved windowing capacity. Remembering the capacity that last succeeded
+    lets the next turn on that (keeper, runtime) start from it instead of
+    re-discovering it by shrinking again from the full declared request-body
+    cap every time.
+
+    Deliberately not durable: this is a same-process optimization to avoid
+    repeated rediscovery, not a state transition anything depends on for
+    correctness. A process restart, an unseen (keeper, runtime) pair, or a
+    remembered value above the runtime's current declared cap all fall back
+    to that cap via {!starting_capacity_bytes}. *)
+
+module Key = struct
+  type t = { keeper_name : string; runtime_id : string }
+
+  let compare left right =
+    match String.compare left.keeper_name right.keeper_name with
+    | 0 -> String.compare left.runtime_id right.runtime_id
+    | nonzero -> nonzero
+  ;;
+end
+
+module Capacity_map = Map.Make (Key)
+
+type t =
+  { mutable last_successful_capacity_bytes : int Capacity_map.t
+  ; mutex : Eio.Mutex.t
+  }
+
+let global = { last_successful_capacity_bytes = Capacity_map.empty; mutex = Eio.Mutex.create () }
+
+let starting_capacity_bytes ~keeper_name ~runtime_id ~max_capacity_bytes =
+  let key = { Key.keeper_name; runtime_id } in
+  let remembered =
+    Eio.Mutex.use_ro global.mutex (fun () ->
+      Capacity_map.find_opt key global.last_successful_capacity_bytes)
+  in
+  match remembered with
+  | Some remembered_bytes
+    when remembered_bytes > 0 && remembered_bytes <= max_capacity_bytes ->
+    remembered_bytes
+  | Some _ (* stale: now exceeds the runtime's current declared cap, or non-positive *)
+  | None -> max_capacity_bytes
+;;
+
+let record_success ~keeper_name ~runtime_id ~capacity_bytes =
+  let key = { Key.keeper_name; runtime_id } in
+  Eio.Mutex.use_rw ~protect:true global.mutex (fun () ->
+    global.last_successful_capacity_bytes <-
+      Capacity_map.add key capacity_bytes global.last_successful_capacity_bytes)
+;;
+
+module For_testing = struct
+  let reset () =
+    Eio.Mutex.use_rw ~protect:true global.mutex (fun () ->
+      global.last_successful_capacity_bytes <- Capacity_map.empty)
+  ;;
+end

--- a/lib/keeper/keeper_context_overflow_shrink_state.mli
+++ b/lib/keeper/keeper_context_overflow_shrink_state.mli
@@ -1,0 +1,22 @@
+(** Process-local memory of the last model-input windowing capacity that
+    completed a turn successfully for a given (keeper, runtime) pair.
+    See the [.ml] for the #27320 rationale. Not durable. *)
+
+val starting_capacity_bytes :
+  keeper_name:string -> runtime_id:string -> max_capacity_bytes:int -> int
+(** [starting_capacity_bytes ~keeper_name ~runtime_id ~max_capacity_bytes]
+    returns the remembered last-successful capacity for this (keeper,
+    runtime) pair, clamped to never exceed [max_capacity_bytes] (the
+    runtime's current declared request-body cap). Returns
+    [max_capacity_bytes] itself when nothing is remembered, or when the
+    remembered value is stale (non-positive, or now above the current cap). *)
+
+val record_success :
+  keeper_name:string -> runtime_id:string -> capacity_bytes:int -> unit
+(** [record_success ~keeper_name ~runtime_id ~capacity_bytes] remembers
+    [capacity_bytes] as the windowing capacity that last completed a turn
+    for this (keeper, runtime) pair. Overwrites any prior value. *)
+
+module For_testing : sig
+  val reset : unit -> unit
+end

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -707,6 +707,13 @@ let run_named
             { runtime_id = attempt_runtime_id
             ; error_runtime_id
             ; max_request_body_bytes
+            ; (* #27320: the first attempt's windowing budget starts at the
+                 full declared cap; [run_try_provider_with_context_overflow_shrink]
+                 is the one that consults #27320's remembered starting point
+                 and shrinks it on a typed overflow. A direct (non-shrink)
+                 caller of [run_try_provider] gets the un-shrunk cap, same as
+                 before this change. *)
+              model_input_capacity_bytes = max_request_body_bytes
             ; base_path
             ; keeper_name
             ; name
@@ -753,7 +760,7 @@ let run_named
           in
           Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
           let provider_result, checkpoint_after, _success_sample =
-            Keeper_turn_driver_try_provider.run_try_provider
+            Keeper_turn_driver_try_provider.run_try_provider_with_context_overflow_shrink
               try_provider_ctx candidate
           in
           let outcomes =

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -20,6 +20,17 @@ type try_provider_ctx =
     runtime_id : string
   ; error_runtime_id : string
   ; max_request_body_bytes : int
+  ; (* #27320: the model-input windowing budget consulted by
+       [budgeted_model_input_projection]. Starts at [max_request_body_bytes]
+       (the runtime's declared wire cap) but is independently shrinkable:
+       [run_try_provider_with_context_overflow_shrink] halves it on a typed
+       provider context overflow and retries the SAME candidate, while
+       [max_request_body_bytes] itself keeps reporting the real declared cap
+       to wire-error diagnostics ([observe_request_wire_error],
+       [pre_dispatch_serialization_observer]) so those never conflate a
+       voluntary MASC-side reduction with the provider's actual admission
+       limit. *)
+    model_input_capacity_bytes : int
   ; base_path : string
   ; keeper_name : string
   ; name : string
@@ -118,6 +129,28 @@ let emit_runtime_manifest
       ?status ?decision ()
     |> append
   | _ -> ()
+
+(* #27320: records a same-runtime context-overflow shrink retry on the
+   existing per-attempt manifest channel (the same [Provider_lane_resolved]
+   event this module already emits for the ordinary "resolved" case) rather
+   than introducing a new [event_kind] for one narrow signal. *)
+let emit_context_overflow_shrink_manifest
+      (ctx : try_provider_ctx)
+      ~shrink_attempt
+      ~previous_capacity_bytes
+      ~capacity_bytes
+  =
+  emit_runtime_manifest ctx
+    ~status:"context_overflow_shrink_retry"
+    ~decision:
+      (`Assoc
+        [ "shrink_attempt", `Int shrink_attempt
+        ; "previous_model_input_capacity_bytes", `Int previous_capacity_bytes
+        ; "model_input_capacity_bytes", `Int capacity_bytes
+        ; "max_request_body_bytes", `Int ctx.max_request_body_bytes
+        ])
+    Keeper_runtime_manifest.Provider_lane_resolved
+;;
 
 let accept_rejected_error ~runtime_id ~(response : Agent_sdk_response.api_response) =
   let rejection =
@@ -346,19 +379,21 @@ let declared_request_reserve_bytes ~capacity_bytes ~system_prompt ~tools =
 ;;
 
 (* The bounded transmission view runs here rather than in the caller because
-   its budget is [ctx.max_request_body_bytes], which
-   [Keeper_turn_driver.validate_provider_request_cap] resolves per runtime.
-   A caller that composed the window ahead of runtime selection would have to
-   guess which target's cap applies. The window stays ahead of
-   [ctx.model_input_projection] so that projection's projected-prefix
-   precondition keeps holding against the list it receives. *)
+   its budget is [ctx.model_input_capacity_bytes], which
+   [Keeper_turn_driver.validate_provider_request_cap] resolves per runtime
+   (as [max_request_body_bytes]) and #27320's shrink retry may then lower
+   for this specific attempt. A caller that composed the window ahead of
+   runtime selection would have to guess which target's cap applies. The
+   window stays ahead of [ctx.model_input_projection] so that projection's
+   projected-prefix precondition keeps holding against the list it
+   receives. *)
 let budgeted_model_input_projection (ctx : try_provider_ctx)
   : Agent_sdk.Agent.model_input_projection
   =
   let reserved_bytes =
     offload_model_input_cpu (fun () ->
       declared_request_reserve_bytes
-        ~capacity_bytes:ctx.max_request_body_bytes
+        ~capacity_bytes:ctx.model_input_capacity_bytes
         ~system_prompt:ctx.system_prompt
         ~tools:ctx.tools)
   in
@@ -374,7 +409,7 @@ let budgeted_model_input_projection (ctx : try_provider_ctx)
         let raw_cut candidate =
           Runtime_model_input_tail_window.project_with_drop
             ~measure_message_bytes
-            ~capacity_bytes:ctx.max_request_body_bytes
+            ~capacity_bytes:ctx.model_input_capacity_bytes
             ~reserved_bytes
             candidate
         in
@@ -434,7 +469,7 @@ let budgeted_model_input_projection (ctx : try_provider_ctx)
                   Runtime_model_input_tail_window.project
                     ~measure_message_bytes:
                       (memoize_message_measurement measure_message_bytes)
-                    ~capacity_bytes:ctx.max_request_body_bytes
+                    ~capacity_bytes:ctx.model_input_capacity_bytes
                     ~reserved_bytes
                     outcome.Keeper_model_input_demotion.messages)
               with
@@ -631,9 +666,135 @@ let run_try_provider
     result, checkpoint_after, None
 ;;
 
+(* #27320: same-runtime retry stage for a typed provider context overflow,
+   inserted before [Keeper_turn_driver.attempt_runtime_candidates]' declared-
+   lane candidate walk and its cascade rotation. A ContextOverflow on a
+   request that already fit [max_request_body_bytes] (the declared wire cap)
+   means the byte cap under-bounds this target's token window, not that the
+   request was malformed: a smaller window of the SAME conversation can
+   still answer the same turn, so this retries the same candidate rather
+   than rotating runtimes immediately. *)
+let context_overflow_shrink_max_attempts = 3
+
+(* Halving needs no token/byte conversion constant: the provider is the
+   oracle for whether a window fits. Each retry is a content-free mechanical
+   convergence step consulted only after a typed overflow, not a size
+   estimate. *)
+let context_overflow_shrink_divisor = 2
+
+(* The shrink-retry policy is expressed over an injected [attempt] callback
+   rather than calling [run_try_provider] directly, so it stays testable
+   without an Eio-backed provider: [run_try_provider_with_context_overflow_shrink]
+   below wires the real attempt for production; tests can inject a canned
+   Ok/Error sequence to verify the halving sequence, the attempt cap, and the
+   same-run-retry-authority gate on their own.
+
+   Classifies with [Keeper_turn_driver_try_runtime.context_overflow_should_try_next]
+   rather than [Keeper_error_classify.is_context_overflow]: the latter
+   depends on [Keeper_turn_driver], which depends on this module (it calls
+   [run_try_provider]), so reaching it here would close a module cycle. Both
+   predicates match the identical single case
+   ([Agent_sdk.Error.Api (ContextOverflow _)] -> [true]); see that function's
+   doc comment for why the byte-axis and token-axis siblings are excluded.
+   [same_run_retry_authorized] mirrors the exact same-run authority gate
+   [Keeper_turn_driver]'s declared-lane walk applies before rotating
+   candidates ([same_run_retry_allowed] / [checkpoint_stage_observed]): a
+   shrink retry is a same-run retry too, so it must not fire once OAS has
+   mutated agent state at a durable checkpoint stage. *)
+let context_overflow_shrink_sequence
+      ~starting_capacity_bytes
+      ~same_run_retry_authorized
+      ~record_success
+      ~on_shrink_retry
+      ~(attempt : capacity_bytes:int -> ('ok, Agent_sdk.Error.sdk_error) result)
+  : ('ok, Agent_sdk.Error.sdk_error) result
+  =
+  let rec go ~capacity_bytes ~shrink_attempt =
+    match attempt ~capacity_bytes with
+    | Ok _ as ok ->
+      record_success ~capacity_bytes;
+      ok
+    | Error error as failed ->
+      if Keeper_turn_driver_try_runtime.context_overflow_should_try_next error
+         && same_run_retry_authorized ()
+         && shrink_attempt < context_overflow_shrink_max_attempts
+      then (
+        let shrunk_capacity_bytes =
+          capacity_bytes / context_overflow_shrink_divisor
+        in
+        on_shrink_retry
+          ~shrink_attempt:(shrink_attempt + 1)
+          ~previous_capacity_bytes:capacity_bytes
+          ~capacity_bytes:shrunk_capacity_bytes;
+        go
+          ~capacity_bytes:shrunk_capacity_bytes
+          ~shrink_attempt:(shrink_attempt + 1))
+      else failed
+  in
+  go ~capacity_bytes:starting_capacity_bytes ~shrink_attempt:0
+;;
+
+(** Same as [run_try_provider], except a typed provider context overflow
+    retries the SAME candidate with the model-input windowing capacity
+    halved (bounded by [context_overflow_shrink_max_attempts]) before
+    returning to the caller, which still owns declared-lane candidate
+    rotation and cascade fallback for every other error and for an overflow
+    that survives every shrink attempt.
+
+    The starting capacity for this (keeper, runtime) pair comes from
+    {!Keeper_context_overflow_shrink_state}: the capacity that last
+    completed a turn here, clamped to [ctx.max_request_body_bytes], so a
+    keeper that has already discovered a working window does not
+    rediscover it every turn. A successful attempt updates that memory. *)
+let run_try_provider_with_context_overflow_shrink
+      (ctx : try_provider_ctx)
+      ?enable_thinking_override
+      candidate
+  =
+  let starting_capacity_bytes =
+    Keeper_context_overflow_shrink_state.starting_capacity_bytes
+      ~keeper_name:ctx.keeper_name
+      ~runtime_id:ctx.runtime_id
+      ~max_capacity_bytes:ctx.max_request_body_bytes
+  in
+  let checkpoint_after = ref None in
+  let success_sample = ref None in
+  let result =
+    context_overflow_shrink_sequence
+      ~starting_capacity_bytes
+      ~same_run_retry_authorized:(fun () ->
+        same_run_retry_allowed ctx.checkpoint_stage_observed)
+      ~record_success:(fun ~capacity_bytes ->
+        Keeper_context_overflow_shrink_state.record_success
+          ~keeper_name:ctx.keeper_name
+          ~runtime_id:ctx.runtime_id
+          ~capacity_bytes)
+      ~on_shrink_retry:(fun ~shrink_attempt ~previous_capacity_bytes ~capacity_bytes ->
+        emit_context_overflow_shrink_manifest
+          ctx
+          ~shrink_attempt
+          ~previous_capacity_bytes
+          ~capacity_bytes)
+      ~attempt:(fun ~capacity_bytes ->
+        let attempt_result, attempt_checkpoint_after, attempt_success_sample =
+          run_try_provider
+            { ctx with model_input_capacity_bytes = capacity_bytes }
+            ?enable_thinking_override
+            candidate
+        in
+        checkpoint_after := attempt_checkpoint_after;
+        success_sample := attempt_success_sample;
+        attempt_result)
+  in
+  result, !checkpoint_after, !success_sample
+;;
+
 module For_testing = struct
   let apply_accept = apply_accept
   let observe_request_wire_error = observe_request_wire_error
   let memoize_message_measurement = memoize_message_measurement
   let offload_model_input_cpu = offload_model_input_cpu
+  let context_overflow_shrink_max_attempts = context_overflow_shrink_max_attempts
+  let context_overflow_shrink_divisor = context_overflow_shrink_divisor
+  let context_overflow_shrink_sequence = context_overflow_shrink_sequence
 end

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -4,6 +4,7 @@ type try_provider_ctx =
   { runtime_id : string
   ; error_runtime_id : string
   ; max_request_body_bytes : int
+  ; model_input_capacity_bytes : int
   ; base_path : string
   ; keeper_name : string
   ; name : string
@@ -67,6 +68,14 @@ val run_try_provider :
   * Agent_sdk.Checkpoint.t option
   * (string * Obj.t) option
 
+val run_try_provider_with_context_overflow_shrink :
+  try_provider_ctx ->
+  ?enable_thinking_override:bool ->
+  Runtime_candidate.t ->
+  (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result
+  * Agent_sdk.Checkpoint.t option
+  * (string * Obj.t) option
+
 val accept_rejected_error :
   runtime_id:string ->
   response:Agent_sdk_response.api_response ->
@@ -95,4 +104,19 @@ module For_testing : sig
     (Agent_sdk.Types.message -> int) -> Agent_sdk.Types.message -> int
 
   val offload_model_input_cpu : (unit -> 'a) -> 'a
+
+  val context_overflow_shrink_max_attempts : int
+  val context_overflow_shrink_divisor : int
+
+  val context_overflow_shrink_sequence :
+    starting_capacity_bytes:int ->
+    same_run_retry_authorized:(unit -> bool) ->
+    record_success:(capacity_bytes:int -> unit) ->
+    on_shrink_retry:
+      (shrink_attempt:int ->
+       previous_capacity_bytes:int ->
+       capacity_bytes:int ->
+       unit) ->
+    attempt:(capacity_bytes:int -> ('ok, Agent_sdk.Error.sdk_error) result) ->
+    ('ok, Agent_sdk.Error.sdk_error) result
 end

--- a/test/dune
+++ b/test/dune
@@ -218,6 +218,7 @@
   test_tool_token
   test_keeper_unified_claim_progress
   test_keeper_unified_context_overflow
+  test_keeper_context_overflow_shrink
   test_keeper_failed_selection_disposition
   test_keeper_invalid_request_auto_recover
   test_keeper_surface_post
@@ -517,6 +518,7 @@
   test_tool_token
   test_keeper_unified_claim_progress
   test_keeper_unified_context_overflow
+  test_keeper_context_overflow_shrink
   test_keeper_failed_selection_disposition
   test_keeper_invalid_request_auto_recover
   test_keeper_surface_post

--- a/test/test_keeper_context_overflow_shrink.ml
+++ b/test/test_keeper_context_overflow_shrink.ml
@@ -1,0 +1,248 @@
+(** Tests for #27320 — context-overflow feedback shrink.
+
+    Two units are covered directly:
+
+    - {!Keeper_turn_driver_try_provider.For_testing.context_overflow_shrink_sequence}:
+      the pure same-runtime retry policy. Injects a fake [attempt] callback
+      so the halving sequence, the attempt cap, the same-run-retry-authority
+      gate, and the "only a typed overflow retries" rule are verified
+      without an Eio-backed provider.
+    - {!Keeper_context_overflow_shrink_state}: the process-local (keeper,
+      runtime) memory of the last capacity that succeeded.
+
+    [run_try_provider_with_context_overflow_shrink] itself wires these two
+    together with the real [run_try_provider]/[Runtime_agent.run] provider
+    call, which (like [run_try_provider] before it) has no unit-level
+    fixture in this suite — see [test_keeper_turn_driver_failover.ml] for
+    the candidate-rotation layer's equivalent boundary. *)
+
+module Try_provider = Masc.Keeper_turn_driver_try_provider
+module Shrink_state = Masc.Keeper_context_overflow_shrink_state
+
+open Alcotest
+
+let context_overflow ?(limit = Some 32_768) () =
+  Agent_sdk.Error.Api
+    (ContextOverflow { message = "exceeded"; limit })
+;;
+
+let network_error () =
+  Agent_sdk.Error.Api
+    (NetworkError
+       { message = "Connection_reset"
+       ; kind = Llm_provider.Http_client.Connection_refused
+       })
+;;
+
+let always_authorized () = true
+
+let no_shrink_expected ~capacity_bytes:_ = fail "unexpected shrink retry"
+
+(* {1 context_overflow_shrink_sequence} *)
+
+let test_halves_capacity_on_repeated_overflow_until_success () =
+  let attempted_capacities = ref [] in
+  let attempt ~capacity_bytes =
+    attempted_capacities := capacity_bytes :: !attempted_capacities;
+    if capacity_bytes <= 128 then Ok "done" else Error (context_overflow ())
+  in
+  let recorded_success = ref None in
+  let shrink_events = ref [] in
+  let result =
+    Try_provider.For_testing.context_overflow_shrink_sequence
+      ~starting_capacity_bytes:1024
+      ~same_run_retry_authorized:always_authorized
+      ~record_success:(fun ~capacity_bytes -> recorded_success := Some capacity_bytes)
+      ~on_shrink_retry:(fun ~shrink_attempt ~previous_capacity_bytes ~capacity_bytes ->
+        shrink_events :=
+          (shrink_attempt, previous_capacity_bytes, capacity_bytes) :: !shrink_events)
+      ~attempt
+  in
+  check bool "eventually succeeds" true (result = Ok "done");
+  check (list int) "capacity halves each retry: 1024, 512, 256, 128"
+    [ 1024; 512; 256; 128 ]
+    (List.rev !attempted_capacities);
+  check (option int) "records the capacity that succeeded" (Some 128) !recorded_success;
+  check
+    (list (triple int int int))
+    "shrink events carry (attempt, previous, next) in order"
+    [ 1, 1024, 512; 2, 512, 256; 3, 256, 128 ]
+    (List.rev !shrink_events)
+;;
+
+let test_stops_at_the_named_attempt_cap_then_falls_through () =
+  let attempted_capacities = ref [] in
+  let attempt ~capacity_bytes =
+    attempted_capacities := capacity_bytes :: !attempted_capacities;
+    Error (context_overflow ())
+  in
+  let shrink_count = ref 0 in
+  let result =
+    Try_provider.For_testing.context_overflow_shrink_sequence
+      ~starting_capacity_bytes:1024
+      ~same_run_retry_authorized:always_authorized
+      ~record_success:(fun ~capacity_bytes:_ -> fail "overflow never succeeds here")
+      ~on_shrink_retry:(fun ~shrink_attempt:_ ~previous_capacity_bytes:_ ~capacity_bytes:_ ->
+        incr shrink_count)
+      ~attempt
+  in
+  check bool "the last (unshrinkable) overflow is returned unchanged" true
+    (match result with
+     | Error (Agent_sdk.Error.Api (Agent_sdk.Retry.ContextOverflow _)) -> true
+     | Error _ | Ok _ -> false);
+  check int "exactly the named cap worth of shrink retries fired"
+    Try_provider.For_testing.context_overflow_shrink_max_attempts
+    !shrink_count;
+  let expected_attempts_count =
+    Try_provider.For_testing.context_overflow_shrink_max_attempts + 1
+  in
+  check int "one initial attempt plus one per shrink retry"
+    expected_attempts_count
+    (List.length !attempted_capacities);
+  let divisor = Try_provider.For_testing.context_overflow_shrink_divisor in
+  let rec expected capacity n =
+    if n = 0 then [ capacity ] else capacity :: expected (capacity / divisor) (n - 1)
+  in
+  check (list int) "capacities halve down to the cap"
+    (expected 1024 Try_provider.For_testing.context_overflow_shrink_max_attempts)
+    (List.rev !attempted_capacities)
+;;
+
+let test_non_overflow_error_never_shrinks () =
+  let attempts = ref 0 in
+  let attempt ~capacity_bytes:_ =
+    incr attempts;
+    Error (network_error ())
+  in
+  let result =
+    Try_provider.For_testing.context_overflow_shrink_sequence
+      ~starting_capacity_bytes:1024
+      ~same_run_retry_authorized:always_authorized
+      ~record_success:(fun ~capacity_bytes:_ -> fail "network error never succeeds")
+      ~on_shrink_retry:(fun ~shrink_attempt:_ ~previous_capacity_bytes:_ ~capacity_bytes ->
+        no_shrink_expected ~capacity_bytes)
+      ~attempt
+  in
+  check int "attempted exactly once" 1 !attempts;
+  check bool "the network error propagates unchanged" true
+    (match result with
+     | Error (Agent_sdk.Error.Api (Agent_sdk.Retry.NetworkError _)) -> true
+     | _ -> false)
+;;
+
+let test_checkpoint_boundary_blocks_shrink_even_on_overflow () =
+  (* Mirrors the exact same-run retry authority gate the declared-lane
+     candidate walk applies via [same_run_retry_allowed] /
+     [checkpoint_stage_observed]: once OAS has mutated agent state at a
+     durable checkpoint stage, a same-run retry (shrink included) must not
+     fire. *)
+  let attempts = ref 0 in
+  let attempt ~capacity_bytes:_ =
+    incr attempts;
+    Error (context_overflow ())
+  in
+  let result =
+    Try_provider.For_testing.context_overflow_shrink_sequence
+      ~starting_capacity_bytes:1024
+      ~same_run_retry_authorized:(fun () -> false)
+      ~record_success:(fun ~capacity_bytes:_ -> fail "no success expected")
+      ~on_shrink_retry:(fun ~shrink_attempt:_ ~previous_capacity_bytes:_ ~capacity_bytes ->
+        no_shrink_expected ~capacity_bytes)
+      ~attempt
+  in
+  check int "attempted exactly once" 1 !attempts;
+  check bool "the overflow propagates unchanged" true
+    (match result with
+     | Error (Agent_sdk.Error.Api (Agent_sdk.Retry.ContextOverflow _)) -> true
+     | _ -> false)
+;;
+
+(* {1 Keeper_context_overflow_shrink_state} *)
+
+let test_state_defaults_to_max_capacity_when_unseen () =
+  Eio_main.run
+  @@ fun _env ->
+  Shrink_state.For_testing.reset ();
+  check int "no memory yet: falls back to the declared cap" 1_048_576
+    (Shrink_state.starting_capacity_bytes
+       ~keeper_name:"sangsu" ~runtime_id:"oas-primary" ~max_capacity_bytes:1_048_576)
+;;
+
+let test_state_remembers_last_success () =
+  Eio_main.run
+  @@ fun _env ->
+  Shrink_state.For_testing.reset ();
+  Shrink_state.record_success
+    ~keeper_name:"sangsu" ~runtime_id:"oas-primary" ~capacity_bytes:131_072;
+  check int "next turn starts from the remembered capacity" 131_072
+    (Shrink_state.starting_capacity_bytes
+       ~keeper_name:"sangsu" ~runtime_id:"oas-primary" ~max_capacity_bytes:1_048_576)
+;;
+
+let test_state_clamps_a_remembered_value_above_the_current_cap () =
+  Eio_main.run
+  @@ fun _env ->
+  Shrink_state.For_testing.reset ();
+  Shrink_state.record_success
+    ~keeper_name:"sangsu" ~runtime_id:"oas-primary" ~capacity_bytes:2_097_152;
+  check int "a stale remembered value never exceeds the current declared cap"
+    1_048_576
+    (Shrink_state.starting_capacity_bytes
+       ~keeper_name:"sangsu" ~runtime_id:"oas-primary" ~max_capacity_bytes:1_048_576)
+;;
+
+let test_state_is_keyed_per_keeper_and_runtime () =
+  Eio_main.run
+  @@ fun _env ->
+  Shrink_state.For_testing.reset ();
+  Shrink_state.record_success
+    ~keeper_name:"sangsu" ~runtime_id:"oas-primary" ~capacity_bytes:131_072;
+  check int "a different runtime on the same keeper is unaffected" 1_048_576
+    (Shrink_state.starting_capacity_bytes
+       ~keeper_name:"sangsu" ~runtime_id:"oas-fallback" ~max_capacity_bytes:1_048_576);
+  check int "the same runtime id on a different keeper is unaffected" 1_048_576
+    (Shrink_state.starting_capacity_bytes
+       ~keeper_name:"analyst" ~runtime_id:"oas-primary" ~max_capacity_bytes:1_048_576)
+;;
+
+let () =
+  run
+    "keeper_context_overflow_shrink"
+    [ ( "context_overflow_shrink_sequence"
+      , [ test_case
+            "halves capacity on repeated overflow until success"
+            `Quick
+            test_halves_capacity_on_repeated_overflow_until_success
+        ; test_case
+            "stops at the named attempt cap then falls through"
+            `Quick
+            test_stops_at_the_named_attempt_cap_then_falls_through
+        ; test_case
+            "a non-overflow error never shrinks"
+            `Quick
+            test_non_overflow_error_never_shrinks
+        ; test_case
+            "a checkpoint boundary blocks shrink even on overflow"
+            `Quick
+            test_checkpoint_boundary_blocks_shrink_even_on_overflow
+        ] )
+    ; ( "shrink_state"
+      , [ test_case
+            "defaults to max capacity when unseen"
+            `Quick
+            test_state_defaults_to_max_capacity_when_unseen
+        ; test_case
+            "remembers last success"
+            `Quick
+            test_state_remembers_last_success
+        ; test_case
+            "clamps a remembered value above the current cap"
+            `Quick
+            test_state_clamps_a_remembered_value_above_the_current_cap
+        ; test_case
+            "is keyed per (keeper, runtime)"
+            `Quick
+            test_state_is_keyed_per_keeper_and_runtime
+        ] )
+    ]
+;;


### PR DESCRIPTION
WORKAROUND-WAIVED: pr-rfc-check.sh 의 STRING_CLASSIFIER 시그니처가 "새 문자열 매치를 추가하지 않고 기존 typed 분류를 재사용했다"는 서술(부정 맥락)에 반응한 false positive. 이 PR 은 string/substring classifier 를 추가하지 않았다 — `Keeper_turn_driver_try_runtime.context_overflow_should_try_next` 라는 기존 typed pattern-match 함수를 그대로 재사용했을 뿐이다.

## 문제

`budgeted_model_input_projection` 의 컷 예산이 `ctx.max_request_body_bytes`(바이트, request-body cap) 하나뿐이라 모델 토큰 창과 무관했다. 512KB~1MB 바디는 바이트 캡을 통과하지만 250K+ 토큰이라 provider의 context window를 넘고, 이 provider `context_overflow` 는 회전해도 무의미하다는 근거로 `no_degraded_retry` 로 분류되어 레인 전체가 소진되었다 (fleet 전멸 3중 원인 중 마지막 축, #27320).

## 동작

provider 가 typed context-overflow(`Agent_sdk.Error.Api (ContextOverflow _)`) 를 반환하면, **같은 runtime 에서 model-input windowing capacity 를 절반으로 줄여 재시도**한다. 절반 축소 재시도는 named constant 상한(`context_overflow_shrink_max_attempts = 3`)까지 진행되며, 초과하면 기존 declared-lane candidate walk / cascade 회전으로 그대로 넘어간다(변경 없음).

- `budgeted_model_input_projection` 이 소비하던 `ctx.max_request_body_bytes` 를 windowing 전용 `ctx.model_input_capacity_bytes` 필드로 분리했다. `max_request_body_bytes` 자체는 wire-error 진단(`observe_request_wire_error`, `pre_dispatch_serialization_observer`)에 그대로 쓰여 provider 의 실제 선언 cap 을 계속 정확히 보고한다 — MASC 쪽의 자발적 축소가 provider 의 실제 admission limit 과 섞이지 않는다.
- overflow 분류는 새 문자열 매치를 추가하지 않고 기존 typed 분류(`Keeper_turn_driver_try_runtime.context_overflow_should_try_next`)를 재사용했다. `Keeper_error_classify.is_context_overflow` 를 직접 쓰지 않은 이유는 그 모듈이 `Keeper_turn_driver` 에 의존하고 `Keeper_turn_driver` 는 다시 `Keeper_turn_driver_try_provider`(`run_try_provider` 호출)에 의존해서 순환이 생기기 때문 — 이미 `keeper_turn_driver_try_runtime.ml` 이 같은 이유로 로컬 재구현을 두고 있던 자리를 그대로 재사용했다. 두 predicate 는 `Api (ContextOverflow _) -> true`, 그 외 전부 `false` 로 완전히 동일하다.
- shrink retry 도 same-run retry 이므로, declared-lane candidate walk 가 이미 쓰던 것과 동일한 checkpoint-boundary 안전장치(`same_run_retry_allowed` / `checkpoint_stage_observed`)를 그대로 재사용해 gate 했다. OAS 가 durable checkpoint stage 에 이미 상태를 기록한 뒤에는 shrink retry 도 발동하지 않는다.
- 세션 내 (keeper_name, runtime_id) 별 마지막 성공 capacity 를 `Keeper_context_overflow_shrink_state` 에 기억해 다음 턴의 시작 capacity 로 쓴다. durable 아님 — 프로세스 로컬 `Eio.Mutex.use_rw ~protect:true` 보호 map. 재발견 비용만 없앨 뿐 정답을 보장하지 않으므로, 기억된 값이 현재 runtime 의 실제 declared cap 을 넘으면 그 cap 으로 클램프한다.
- 체크포인트/durable state 는 계속 무손실 전체 이력을 받는다 — `model_input_projection` 은 provider-bound copy 에만 적용된다는 `Runtime_model_input_tail_window` 의 기존 계약(주석 "Durable agent state and checkpoints are untouched")은 건드리지 않았다.
- 축소 시도는 새 이벤트를 만들지 않고 기존 per-attempt manifest 채널(`Provider_lane_resolved`, 이 함수가 "resolved" status 로 이미 쓰던 이벤트)에 `status="context_overflow_shrink_retry"` 로 싣는다.

## 변경 파일

- `lib/keeper/keeper_context_overflow_shrink_state.ml`, `.mli` (신규) — 세션 로컬 (keeper, runtime) → 마지막 성공 capacity 기억
- `lib/keeper/keeper_turn_driver_try_provider.ml`, `.mli` — `model_input_capacity_bytes` 필드 분리, `context_overflow_shrink_sequence`(순수 재시도 정책) + `run_try_provider_with_context_overflow_shrink`(wiring) 추가
- `lib/keeper/keeper_turn_driver.ml` — candidate 호출부를 `run_try_provider_with_context_overflow_shrink` 로 교체
- `test/test_keeper_context_overflow_shrink.ml` (신규), `test/dune` — 단위 테스트 배선

## 검증

- `context_overflow_shrink_sequence` 단위 테스트 8건: 절반 축소 시퀀스(1024→512→256→128), named cap 도달 후 마지막 에러 그대로 fallthrough, non-overflow 에러는 재시도하지 않음, checkpoint-boundary 가 shrink 도 막음, 세션 상태 기억/클램프/키 분리(keeper×runtime) 4건. 전부 green.
- 기존 `test_keeper_unified_context_overflow`(8건), `test_keeper_turn_driver_failover`(34건), `test_runtime_model_input_tail_window`(17건), `test_pbt_context_overflow`(2건) 회귀 없음.
- `test_keeper_turn_driver_accept.ml` 의 `test_direct_no_progress_retry_loop_run` 1건 실패(`first attempt uses initial max context`, expected 1024 / received 4096)는 이 PR 이전 origin/main 에서도 동일하게 재현되는 **기존 결함**으로 확인(`git stash` 로 clean baseline 재현). 이 PR 이 건드리지 않는 `keeper_turn_runtime_budget.ml` 의 `run_direct_no_progress_retry_loop` 경로에서 발생하며, 이번 변경 범위 밖이라 별도 이슈로 남긴다.
- `dune build` 전체 green.

## 미해결 리스크

- `run_try_provider_with_context_overflow_shrink` 자체(Eio 기반 실제 provider 호출 wiring)는 `run_try_provider` 와 마찬가지로 unit fixture 가 없다 — 이 저장소의 기존 테스트 경계와 동일(순수 정책만 단위 테스트, Eio wiring 은 미검증). 라이브 확인은 이슈에 적힌 대로 analyst/sangsu/kidsnote 재비대 시 clear 없이 턴이 완주하는지 oas-events 로 별도 확인 필요.
- `test_keeper_turn_driver_accept.ml` 의 기존 실패 1건은 별도 이슈로 트리아지 필요(이 PR 미포함).

Closes #27320
