### PR TITLE
fix(dashboard): mention 판정을 한 글자 membership 에서 실제 mention 표면으로 (#27324)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1537,7 +1537,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_dashboard_persona_name @test/runtest-test_keeper_model_input_demotion @test/runtest-test_tool_type_label @test/runtest-test_verification_authority_tools"
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_dashboard_persona_name @test/runtest-test_dashboard_briefing @test/runtest-test_keeper_model_input_demotion @test/runtest-test_tool_type_label @test/runtest-test_verification_authority_tools"
 
       - name: Run transport harness suite
         id: transport_harness_suite

--- a/lib/dashboard/dashboard_briefing_agents.ml
+++ b/lib/dashboard/dashboard_briefing_agents.ml
@@ -50,18 +50,18 @@ let latest_message_to agent_name messages =
   let lowered = String.lowercase_ascii (String.trim agent_name) in
   List.fold_left
     (fun best (message : Masc_domain.message) ->
-      let content = String.lowercase_ascii message.content in
       let from_self = String.equal (String.lowercase_ascii (String.trim message.from_agent)) lowered in
       let mentioned =
-        (* [lowered] can be "" for a degenerate agent record with an empty or
-           whitespace-only name (agent_of_yojson accepts "name":""; the brief
-           loop does not drop empties — cf. the [agent_name <> ""] guard on the
-           event path). Without this length check [String.get lowered 0] would
-           raise Invalid_argument and crash the briefing fiber. *)
+        (* Mention identity comes from the message's own mention surface —
+           the typed [mention] field plus @word tokens in the body, both via
+           {!Dashboard_workspace.mentions_of_message} (the one extractor the
+           workspace read model already uses). The [lowered <> ""] guard
+           keeps a degenerate agent record with an empty/whitespace name
+           (agent_of_yojson accepts "name":"") from matching anything. *)
         String.length lowered > 0
-        && String.contains content '@'
-        && (String.contains content (String.get lowered 0)
-            || String.contains content (String.get lowered (String.length lowered - 1)))
+        && List.exists
+             (fun target -> String.equal (String.lowercase_ascii target) lowered)
+             (Dashboard_workspace.mentions_of_message message)
       in
       if from_self || not mentioned
       then best

--- a/lib/dashboard/dashboard_workspace.mli
+++ b/lib/dashboard/dashboard_workspace.mli
@@ -1,1 +1,7 @@
 val json : config:Workspace.config -> ?me:string -> limit:int -> unit -> Yojson.Safe.t
+
+val mentions_of_message : Masc_domain.message -> string list
+(** Every agent name this message mentions: the typed [mention] field first,
+    then @word tokens parsed from the body, deduplicated in order. The one
+    mention extractor for dashboard read models — consumers must not grow
+    their own content scanners (#27324). *)

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -88,7 +88,7 @@ echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, al
 # authority tools, memory journal) without lowering the baseline. A PR that
 # wires a suite must lower this number in the same PR, or this check goes red
 # for everyone.
-UNWIRED_BASELINE=739
+UNWIRED_BASELINE=738
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/test/test_dashboard_briefing.ml
+++ b/test/test_dashboard_briefing.ml
@@ -431,12 +431,12 @@ let test_dashboard_keeper_unknown_context_is_informational () =
          |> member "reason"
          |> to_string))
 
-let make_message ~seq ~from_agent ~content : Types.message =
+let make_message ?mention ~seq ~from_agent ~content () : Types.message =
   { seq;
     from_agent;
     msg_type = "broadcast";
     content;
-    mention = None;
+    mention;
     timestamp = "";
     trace_context = None;
     expires_at = None;
@@ -445,7 +445,7 @@ let make_message ~seq ~from_agent ~content : Types.message =
 (* Regression: a degenerate agent record with an empty/whitespace name must not
    crash latest_message_to (String.get on an empty [lowered]). *)
 let test_latest_message_to_empty_name_safe () =
-  let msgs = [ make_message ~seq:1 ~from_agent:"alice" ~content:"hey @bob ping" ] in
+  let msgs = [ make_message ~seq:1 ~from_agent:"alice" ~content:"hey @bob ping" () ] in
   (match Dashboard_briefing_agents.latest_message_to "" msgs with
    | None -> ()
    | Some _ -> Alcotest.fail "empty name must not match a mention");
@@ -456,6 +456,49 @@ let test_latest_message_to_empty_name_safe () =
   | Some (m : Types.message) -> Alcotest.(check int) "matched seq" 1 m.seq
   | None -> Alcotest.fail "expected @bob mention to match"
 
+(* #27324 regression: the old detector was single-character membership —
+   content contains '@' AND (first or last char of the name anywhere) — so for
+   agent "claude" any message with '@' plus a 'c' or 'e' counted as addressed
+   to claude. These pin real mention semantics. *)
+let test_latest_message_to_requires_real_mention () =
+  (* '@' present, and both 'c' and 'e' appear, but nothing mentions claude. *)
+  let msgs =
+    [ make_message ~seq:1 ~from_agent:"alice" ~content:"meeting @ 3pm — everyone come" () ]
+  in
+  match Dashboard_briefing_agents.latest_message_to "claude" msgs with
+  | None -> ()
+  | Some _ -> Alcotest.fail "'@' plus stray name letters is not a mention"
+
+let test_latest_message_to_longer_handle_is_not_a_mention () =
+  let msgs =
+    [ make_message ~seq:1 ~from_agent:"alice" ~content:"@claude-dev take this" () ]
+  in
+  match Dashboard_briefing_agents.latest_message_to "claude" msgs with
+  | None -> ()
+  | Some _ -> Alcotest.fail "@claude-dev must not read as a mention of claude"
+
+let test_latest_message_to_reads_typed_mention_field () =
+  (* No '@' anywhere in the body: the typed [mention] field alone must carry. *)
+  let msgs =
+    [ make_message ~seq:4 ~from_agent:"alice" ~content:"please review the plan"
+        ~mention:"claude" () ]
+  in
+  match Dashboard_briefing_agents.latest_message_to "claude" msgs with
+  | Some (m : Types.message) -> Alcotest.(check int) "typed mention seq" 4 m.seq
+  | None -> Alcotest.fail "typed mention field must reach the agent"
+
+let test_latest_message_to_prefers_latest_mention () =
+  let msgs =
+    [ make_message ~seq:2 ~from_agent:"alice" ~content:"@claude first ping" ();
+      make_message ~seq:7 ~from_agent:"bob" ~content:"@claude second ping" ();
+      make_message ~seq:9 ~from_agent:"claude" ~content:"@claude talking about myself" () ]
+  in
+  match Dashboard_briefing_agents.latest_message_to "claude" msgs with
+  | Some (m : Types.message) ->
+      (* seq 9 is from claude itself and must be skipped. *)
+      Alcotest.(check int) "latest non-self mention" 7 m.seq
+  | None -> Alcotest.fail "expected a mention to match"
+
 let () =
   Alcotest.run "Dashboard Mission"
     [
@@ -463,6 +506,14 @@ let () =
         [
           Alcotest.test_case "latest_message_to tolerates empty agent name"
             `Quick test_latest_message_to_empty_name_safe;
+          Alcotest.test_case "latest_message_to requires a real mention"
+            `Quick test_latest_message_to_requires_real_mention;
+          Alcotest.test_case "latest_message_to rejects longer handles"
+            `Quick test_latest_message_to_longer_handle_is_not_a_mention;
+          Alcotest.test_case "latest_message_to reads the typed mention field"
+            `Quick test_latest_message_to_reads_typed_mention_field;
+          Alcotest.test_case "latest_message_to prefers the latest non-self mention"
+            `Quick test_latest_message_to_prefers_latest_mention;
           Alcotest.test_case "projection groups root-cause lanes" `Quick
             test_dashboard_briefing_projection;
           Alcotest.test_case "http mission keeps full contract" `Quick


### PR DESCRIPTION
## 무엇

`latest_message_to` 의 mention 판정을 한 글자 membership 검사에서 **메시지의 실제 mention 표면**(typed `mention` 필드 + body 의 `@word` 토큰, `Dashboard_workspace.mentions_of_message` 재사용)으로 교체.

## 왜

기존 판정: content 에 `'@'` 존재 AND (이름의 **첫 글자 또는 끝 글자**가 아무 데나 존재). agent `claude` 는 `'@'` + `'c'` 또는 `'e'` 가 있는 모든 메시지가 "나에게 온 메시지"로 분류되어 operator briefing 의 `recent_input_preview` 가 무관한 메시지로 오염됨 (#27324, heuristic-purge 감사 P0 확정).

## 어떻게

- `Dashboard_workspace.mentions_of_message` 를 .mli 로 노출 — 이미 workspace read model 이 쓰는 유일 추출기. 세 번째 파서를 만들지 않음 (SSOT).
- 행동 변화 3건: ① 가짜 양성 제거(버그) ② `@claude-dev` 가 `claude` mention 으로 오인되지 않음 ③ typed mention 필드만 있고 body 에 '@' 없는 메시지도 도달 (기존엔 누락).
- `test_dashboard_briefing` 스위트를 dashboard CI 스텝에 배선 (선언만 있고 미실행이었음) + `UNWIRED_BASELINE` 739→738 로 이득 고정.

## 검증

- 로컬 `@test/runtest-test_dashboard_briefing` 12/12 통과 (신규 4 케이스: 가짜 양성/긴 핸들/typed 필드 단독/최신 non-self 우선).
- `audit-ci-test-targets.sh`: 118 targets / 738 unwired = baseline OK.
- 변경 파일 ocamlformat --check 통과.

RFC-WAIVED: dashboard briefing 읽기 경로의 버그 수정 — credential/operator/hooks gated subsystem 비접촉, 신규 계약 없음.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
