### PR TITLE
fix(test): restore initial-runtime max_context fixture and wire CI (#27331)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1455,7 +1455,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          request_cap_targets="@test/runtest-test_runtime_config_validity @test/runtest-test_keeper_turn_driver_failover @test/runtest-test_keeper_vision_tool @test/runtest-test_runtime_modality_reroute @test/runtest-test_runtime_model_input_tail_window"
+          request_cap_targets="@test/runtest-test_runtime_config_validity @test/runtest-test_keeper_turn_driver_failover @test/runtest-test_keeper_turn_driver_accept @test/runtest-test_keeper_vision_tool @test/runtest-test_runtime_modality_reroute @test/runtest-test_runtime_model_input_tail_window"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${request_cap_targets}"
 
       - name: Run operator control suite

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -88,7 +88,7 @@ echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, al
 # authority tools, memory journal) without lowering the baseline. A PR that
 # wires a suite must lower this number in the same PR, or this check goes red
 # for everyone.
-UNWIRED_BASELINE=739
+UNWIRED_BASELINE=738
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -903,6 +903,28 @@ let test_direct_no_progress_retry_loop_runs_fallback_attempt () =
       ; effective_budget = 4096
       }
     in
+    (* #27331: distinct from [retry_context_resolution] on purpose. The two
+       assertions below ("first attempt uses initial max context" = 1024,
+       "final max context comes from fallback runtime" = 4096) exist to prove
+       [run_direct_no_progress_retry_loop] threads each attempt's OWN
+       [runtime_execution.max_context] through instead of reusing whichever
+       runtime happened to run first. #26177 migrated this call site from
+       [~initial_max_context:1024] to [~initial_execution] but built the new
+       value via [retry_execution], which carries [retry_context_resolution]
+       (4096) — collapsing the two runtimes onto one budget and silently
+       making the first assertion false. Restoring a resolution of its own
+       is the fix; the sibling test below (2048, its own record) shows the
+       migration done correctly. *)
+    let initial_context_resolution
+        : Masc.Keeper_context_runtime.max_context_resolution =
+      { requested_override = None
+      ; primary_budget = 1024
+      ; runtime_budget = 1024
+      ; runtime_budget_source = Some Runtime.Capability
+      ; requested_context_window = 1024
+      ; effective_budget = 1024
+      }
+    in
     let attempts = ref [] in
     let published = ref [] in
     let selected = ref [] in
@@ -917,8 +939,12 @@ let test_direct_no_progress_retry_loop_runs_fallback_attempt () =
       ; temperature = 0.0
       }
     in
-    let initial_execution =
-      retry_execution "runtime.direct-empty"
+    let initial_execution : Masc.Keeper_turn_runtime_budget.runtime_execution =
+      { runtime_id = "runtime.direct-empty"
+      ; max_context_resolution = initial_context_resolution
+      ; max_context = initial_context_resolution.requested_context_window
+      ; temperature = 0.0
+      }
     in
     let result =
       Masc.Keeper_turn_runtime_budget.run_direct_no_progress_retry_loop


### PR DESCRIPTION
## 원인

`64866f65001` (`test(keeper): remove brittle context source assertion (#26177)`)이 `run_direct_no_progress_retry_loop`의 시그니처를 `~initial_runtime`/`~initial_max_context`(분리된 두 인자)에서 `~initial_execution:runtime_execution`(단일 레코드)로 마이그레이션했다. 이 API 변경 자체는 정당하다. 문제는 `test_direct_no_progress_retry_loop_runs_fallback_attempt`의 마이그레이션 방식이다: `initial_execution`을 fallback(재시도) runtime 전용 헬퍼 `retry_execution`(4096을 물고 있는 `retry_context_resolution`)로 만들면서, 리터럴 `~initial_max_context:1024`가 조용히 4096으로 바뀌었다. 같은 커밋에서 옮겨진 단언(`"first attempt uses initial max context" = 1024`)은 그대로 남아 불일치가 발생했다.

같은 커밋의 다른 테스트(`test_direct_retry_loop_publishes_non_retry_terminal_cascade`)는 같은 마이그레이션을 올바르게 처리했다 — `retry_execution`을 재사용하지 않고 독립된 레코드(2048)를 새로 만들었다. 이 대조가 "4096 재사용"이 사양 변경이 아니라 실수라는 근거다.

## 정본 판정: 1024 유지

`keeper_turn_runtime_budget.ml`의 `run_direct_no_progress_retry_loop`는 호출자가 넘긴 `runtime_execution.max_context` 필드를 그대로 읽을 뿐 override하지 않는다. 프로덕션에서 `initial_execution`은 `Keeper_unified_turn_pre_dispatch.build_runtime_execution` → `Keeper_context_runtime.resolve_max_context_resolution_for_runtime_id` → `Runtime.get_runtime_by_id`로 **실제 capability catalog**에서 해석된다. 1024/2048/4096은 실제 runtime 설정값이 아니라, "서로 다른 두 runtime의 max_context가 각자 올바르게 전파되는지"를 증명하기 위한 테스트 전용 임의 상수다. 프로덕션 로직은 회귀하지 않았다 — 버그는 테스트 fixture에 한정된다. `4096`을 새 정본으로 받아들이면 두 assertion이 같은 값을 비교하게 되어 이 테스트가 원래 검증하려던 "per-runtime max_context 전파"를 증명하지 못하는 tautology가 된다.

상세 근거: #27331 코멘트 (https://github.com/jeong-sik/masc/issues/27331#issuecomment-5211071891)

## 수정

- `test/test_keeper_turn_driver_accept.ml`: `initial_execution`을 위한 독립된 `initial_context_resolution`(1024)을 복원. `retry_execution` 재사용 대신 fallback 레코드와 명시적으로 분리했다. `#26177`의 API 마이그레이션(`~initial_execution`) 자체는 되돌리지 않았다.
- `.github/workflows/ci.yml`: `test_keeper_turn_driver_accept`가 CI에 전혀 배선되어 있지 않았다(`@check`만 통과, 어떤 스텝도 실행하지 않음) — 그래서 이 assertion 실패가 9일 넘게 감지되지 않았다. `test_keeper_turn_driver_failover`/`test_runtime_model_input_tail_window`와 같은 계열인 "Keeper request-cap suite" 스텝에 `@test/runtest-test_keeper_turn_driver_accept`를 추가했다.
- `scripts/audit-ci-test-targets.sh`: `UNWIRED_BASELINE`을 739 → 738로 1 낮췄다(스크립트 자체 규칙: 배선하는 PR은 같은 PR에서 낮춰야 한다).

## 검증

- `bash scripts/audit-ci-test-targets.sh` → `118 CI targets, all declared in test/dune` / `738 suites unwired, at baseline` (PASS)
- `dune build --root . @check` 전체 green
- `test_keeper_turn_driver_accept.exe` 36/36 green (수정 전 1건 실패하던 것 포함)
- `test_keeper_turn_driver_failover.exe` 34/34 green (회귀 없음)

## bisect

최초 실패 커밋 `64866f65001`, 마지막 green 부모 `9c7e0a929e` — 둘은 직접 부모-자식 관계라 diff 하나로 원인이 특정된다(`git log --oneline 9c7e0a929e..64866f65001`가 커밋 1개만 반환). 부모 커밋을 실제로 재빌드해 재현하려 했으나, 그 시점 이후 시스템에 설치된 `agent_sdk`/`llm_provider` OPAM 패키지가 새 variant(`ProviderWireError`/`ProviderReportedError`)를 얻으면서 그 커밋의 `lib/`가 오늘 환경과 맞물리지 않아 무관한 이유로 컴파일이 안 됨을 확인 — 과거 커밋의 바이너리 재현이 이 환경에서 신뢰할 수 없다는 것도 이슈 코멘트에 기록했다. 대신 diff 자체가 결정적 증거이고, 수정 후 CURRENT main 기준 빌드+테스트로 fix를 직접 검증했다.

Closes #27331
