### PR TITLE
fix(telemetry): let a tool's catalog declaration decide its tool_type

### DIFF
--- a/lib/tool_telemetry.ml
+++ b/lib/tool_telemetry.ml
@@ -3,37 +3,48 @@
 
 type trace_id = string
 
+(* Precedence: the board surface, then the MCP surface, then the catalog, then
+   the name chain.
+
+   The first two are surface labels and keep their existing meaning. The
+   catalog is the only place a tool declares what it *does*
+   ([Tool_catalog.metadata] carries [readonly : bool option]), so where that is
+   set it decides read-vs-write instead of the name.
+
+   Only four tools seen in live traffic declare it today, but one of them
+   (keeper_tasks_list) is 28% of all calls, so consulting the catalog moves the
+   "other" bucket from 57.0% to 27.6% of 94,784 recorded calls.
+
+   The name chain stays as the last resort for tools the catalog has not
+   classified — including Read / Write / Edit / Grep / Execute, whose names
+   happen to be the verb and which it labels correctly today. Dropping it in
+   favour of the catalog alone would push those 21,192 calls into "other" and
+   make the dimension worse. The way out is to declare [readonly] for the
+   remaining tools, not to grow the prefix list. *)
 let tool_type_of_name name =
-  let name = String.lowercase_ascii (String.trim name) in
+  let trimmed = String.trim name in
+  let name = String.lowercase_ascii trimmed in
   match Tool_name.Board_name.of_string name with
   | Some _ -> "board"
   | None ->
-    (* Five arms used to sit here and none of them could match. Run over the
-       99 names [Keeper_tool_policy.keeper_model_tool_names] returns and the
-       counts are: masc_ 67, Board_name 21, grep/read/write/edit/execute 1
-       each, and mcp__masc__ / board_ / memory_ / library_ / surface_ zero.
-
-       The last three were aimed at tools that exist under different names.
-       keeper_memory_search, keeper_memory_write, keeper_library_search,
-       keeper_library_read, keeper_surface_read and keeper_surface_post all
-       carry a keeper_ prefix now, so they fall through to "other" alongside
-       WebSearch and the voice tools. Fixing the prefixes would change the
-       tool_type dimension for six tools, which is a metric contract call and
-       not made here — the arms that cannot fire are removed, the mislabelling
-       is left visible. *)
     if String.starts_with ~prefix:"masc_" name
     then "mcp"
-    else if name = "grep"
-    then "read"
-    else if String.starts_with ~prefix:"read" name
-    then "read"
-    else if String.starts_with ~prefix:"write" name
-    then "write"
-    else if String.starts_with ~prefix:"edit" name
-    then "write"
-    else if String.starts_with ~prefix:"execute" name
-    then "execute"
-    else "other"
+    else (
+      match (Tool_catalog.metadata trimmed).readonly with
+      | Some true -> "read"
+      | Some false -> "write"
+      | None ->
+      if name = "grep"
+      then "read"
+      else if String.starts_with ~prefix:"read" name
+      then "read"
+      else if String.starts_with ~prefix:"write" name
+      then "write"
+      else if String.starts_with ~prefix:"edit" name
+      then "write"
+      else if String.starts_with ~prefix:"execute" name
+      then "execute"
+      else "other")
 ;;
 
 let counter_name = "tool_dispatch_total"

--- a/test/test_tool_type_label.ml
+++ b/test/test_tool_type_label.ml
@@ -73,6 +73,19 @@ let test_keeper_prefixed_tools_fall_to_other () =
     ]
 ;;
 
+(* The catalog is the first authority: where a tool declares [readonly], that
+   declaration decides read-vs-write instead of the name. keeper_tasks_list is
+   28% of recorded calls and read-only; the name chain labelled it "other". *)
+let test_catalog_declaration_beats_the_name_chain () =
+  List.iter
+    (fun (name, expected) -> check string name expected (T.tool_type_of_name name))
+    [ "keeper_tasks_list", "read"
+    ; "keeper_tools_list", "read"
+    ; "keeper_task_claim", "write"
+    ; "keeper_task_done", "write"
+    ]
+;;
+
 let test_external_tool_names_keep_their_labels () =
   List.iter
     (fun (name, expected) -> check string name expected (T.tool_type_of_name name))
@@ -94,6 +107,8 @@ let () =
       , [ test_case "board tools are not mcp" `Quick test_board_tools_are_not_labelled_mcp
         ; test_case "keeper-prefixed tools fall to other" `Quick
             test_keeper_prefixed_tools_fall_to_other
+        ; test_case "catalog declaration beats the name chain" `Quick
+            test_catalog_declaration_beats_the_name_chain
         ; test_case "external tool names keep their labels" `Quick
             test_external_tool_names_keep_their_labels
         ] )


### PR DESCRIPTION
## 실측: `tool_type` 차원의 57% 가 `"other"` 다

`tool_dispatch_total` 의 `tool_type` 라벨을 도구 **이름**에서 만든다. `~/me/.masc/tool_calls/` 의 실제 호출 **94,784 건 / 도구 98 종** 에 현재 함수를 적용한 결과:

| tool_type | 이전 | | 이후 | |
|---|---:|---:|---:|---:|
| **other** | 54,056 | **57.0%** | 26,183 | **27.6%** |
| read | 6,570 | 6.9% | 33,700 | 35.5% |
| write | 720 | 0.8% | 1,463 | 1.5% |
| execute | 13,408 | 14.1% | 13,408 | 14.1% |
| mcp | 12,526 | 13.2% | 12,526 | 13.2% |
| board | 7,522 | 7.9% | 7,522 | 7.9% |

`other` 안의 최다 항목이 `keeper_tasks_list` (27,126 건, 전체 호출의 **28.6%**) 이고 이것은 읽기다. `read` 라벨 전체(6,570)보다 컸다.

## 타입 소스는 카탈로그에 있다

`Tool_catalog.metadata` 가 도구마다 `readonly : bool option` 을 나른다. 이름으로 추측하던 것을 **선언이 있으면 선언이 정한다.**

```ocaml
match Tool_name.Board_name.of_string name with
| Some _ -> "board"
| None ->
  if String.starts_with ~prefix:"masc_" name then "mcp"
  else (match (Tool_catalog.metadata trimmed).readonly with
        | Some true -> "read"
        | Some false -> "write"
        | None -> (* 이름 체인 *))
```

순서가 중요하다. board 와 mcp 는 **표면** 라벨이라 먼저 두어 기존 의미를 유지하고, 카탈로그는 그 다음, 이름 체인이 마지막이다. 이 순서라서 **현재 맞게 붙던 라벨은 하나도 바뀌지 않는다.**

## 이름 체인을 남긴 이유

카탈로그만 쓰면 더 나빠진다. 실측으로 확인했다 — `Read` / `Write` / `Edit` / `Grep` / `Execute` (합계 21,192 건) 는 `readonly` 선언이 **없고**, 이름이 곧 동사라 이름 체인이 지금 맞게 분류한다. 카탈로그 단독으로 바꾸면 이 21k 가 전부 `other` 로 간다.

live traffic 27 개 이름에 `Tool_catalog.metadata` 를 직접 호출해 확인한 결과, 선언이 있는 것은 **4 개뿐**이다.

```
keeper_tasks_list   readonly=true      keeper_task_claim  readonly=false
keeper_tools_list   readonly=true      keeper_task_done   readonly=false
나머지 23 개 (keeper_board_*, keeper_surface_*, keeper_memory_*, Read/Write/Edit/Grep/Execute, WebSearch/WebFetch) 전부 readonly=NONE
```

넷뿐인데도 `other` 가 57.0% → 27.6% 로 내려가는 것은 그 중 하나가 트래픽의 28% 이기 때문이다.

**앞으로 갈 길은 나머지 도구에 `readonly` 를 선언하는 것이지 접두사 목록을 늘리는 것이 아니다.** 후자는 CLAUDE.md 워크어라운드 시그니처 2번이고, `keeper_task_claim` 처럼 이름만으로는 read/write 를 알 수 없는 것이 이미 있다. 남은 격차는 #27322 에 기록했다.

## 이전 작성자가 미룬 이유는 없어졌다

함수 위 주석이 여섯 개 도구의 오분류를 알고 있었고 "**metric contract call** and not made here" 라며 미뤄두었다. 그 계약의 소비자를 확인했다.

```
prometheus  Up 2 days, :9090 healthy — metric name 308 개, masc/tool 관련 0 개
prometheus.yml 의 masc scrape job  없음
Grafana 대시보드의 tool_type 참조  0
```

masc 는 scrape 엔드포인트를 노출하지 않는다. `tool_dispatch_total` 은 `Otel_metric_store` 에 쓰이고 아무도 읽지 않는다 — 깨질 외부 계약이 없다.

## 테스트

`catalog declaration beats the name chain` — 선언이 있는 네 도구가 read/write 로 나오는지 확인한다. 카탈로그 조회를 `None` 으로 막아 실패하는 것을 확인했다 (`FAIL keeper_tasks_list`).

기존 테스트 여섯 건은 그대로 통과한다 — `keeper_memory_search` 등 여섯 개가 여전히 `other` 라는 것을 고정하는 테스트 포함(그 여섯은 아직 선언이 없다).

## 검증

`dune build @check` 통과. `test_tool_type_label` (신규 1 건 포함), `test_keeper_tool_duration_buckets`, `test_tools_coverage` 합계 60 건 통과.

게이트: `check-determinism-contract`, `audit-catchall`, `check-variants`, `check-enum-string-safety`, `check-telemetry-coverage`, `check_test_coverage` 통과.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
