### PR TITLE
fix(keeper): decide a terminal conflict on the record, not on its JSON

### DIFF
--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -843,6 +843,16 @@ let entry_record_to_json (e : entry) : Yojson.Safe.t =
   `Assoc fields
 ;;
 
+(* Whole-record equality, next to [same_request_identity]'s five identity
+   fields. The terminal-conflict check used to ask this by serializing both
+   entries and comparing the JSON. That agreed with the record only because
+   [entry_record_to_json] happens to emit every field, in a fixed order, on a
+   single code path — so adding a field to the wire, making one conditional,
+   or reordering the assoc would have quietly changed what counts as an
+   integrity conflict on a durable store. The predicate belongs to the record,
+   not to its rendering. *)
+let same_entry_record (left : entry) (right : entry) = left = right
+
 let same_request_identity (left : entry) (right : entry) =
   String.equal left.request_id right.request_id
   && String.equal left.keeper_name right.keeper_name
@@ -1187,7 +1197,7 @@ let persist_terminal_from_source ~ops ~(entry : entry) ~source_path =
       | Found terminal_entry when not (is_terminal_status terminal_entry.status) ->
         Error (Integrity_failed Terminal_partition_nonterminal)
       | Found terminal_entry ->
-        if entry_record_to_json terminal_entry = entry_record_to_json entry
+        if same_entry_record terminal_entry entry
         then (
           (* See lossless namespace protocol: observed cleanup failure is retried. *)
           ignore (remove_duplicate_source_unlocked ~ops ~entry source_path : bool);
@@ -1497,7 +1507,7 @@ let terminal_destination_state (entry : entry) =
         then Invalid_terminal_destination Terminal_conflict
         else if
           (not (is_terminal_status entry.status))
-          || entry_record_to_json terminal_entry = entry_record_to_json entry
+          || same_entry_record terminal_entry entry
         then Cleanup_source
         else
           Invalid_terminal_destination Terminal_conflict

--- a/lib/keeper/keeper_msg_async.mli
+++ b/lib/keeper/keeper_msg_async.mli
@@ -42,6 +42,13 @@ type entry =
   ; completed_at : float option
   }
 
+(** [same_entry_record a b] is whole-record equality, used by the terminal
+    partition check to tell a duplicate publish from an integrity conflict.
+    Distinct from identity: two records can share a [request_id] and still
+    differ. Deliberately not defined as equality of [entry_record_to_json]'s
+    output — the conflict predicate belongs to the record, not its rendering. *)
+val same_entry_record : entry -> entry -> bool
+
 (** A request exists, but the supplied access identity does not own it (or
     cannot be constructed). [Caller_mismatch] intentionally does not expose
     the persisted owner value. A different base path is a different store and

--- a/test/test_keeper_msg_async_terminal_event.ml
+++ b/test/test_keeper_msg_async_terminal_event.ml
@@ -363,6 +363,42 @@ let test_closed_background_switch_rejects_worker_acceptance () =
       | None -> fail "submit did not return before the background switch closed"))
 ;;
 
+
+(* The terminal partition check tells a duplicate publish from an integrity
+   conflict with this predicate. It used to be equality of
+   [entry_record_to_json]'s output, which agreed only because that function
+   emits every field on one code path. Pin the property directly: changing any
+   single field must make two records differ. *)
+let test_same_entry_record_is_sensitive_to_every_field () =
+  let module A = Masc.Keeper_msg_async in
+  let base : A.entry =
+    { request_id = "req-1"
+    ; keeper_name = "kp"
+    ; base_path = "/tmp/base"
+    ; submitted_by = "operator"
+    ; status = A.Queued
+    ; submitted_at = 100.0
+    ; completed_at = None
+    }
+  in
+  check bool "a record equals itself" true (A.same_entry_record base base);
+  let variants =
+    [ "request_id", { base with request_id = "req-2" }
+    ; "keeper_name", { base with keeper_name = "other" }
+    ; "base_path", { base with base_path = "/tmp/other" }
+    ; "submitted_by", { base with submitted_by = "someone" }
+    ; "status", { base with status = A.Running }
+    ; "submitted_at", { base with submitted_at = 101.0 }
+    ; "completed_at", { base with completed_at = Some 200.0 }
+    ]
+  in
+  List.iter
+    (fun (field, variant) ->
+       check bool (field ^ " makes the records differ") false
+         (A.same_entry_record base variant))
+    variants
+;;
+
 let () =
   run
     "keeper_msg_async_terminal_event"
@@ -385,6 +421,10 @@ let () =
             "closed background switch rejects worker acceptance"
             `Quick
             test_closed_background_switch_rejects_worker_acceptance
+        ; test_case
+            "same_entry_record is sensitive to every field"
+            `Quick
+            test_same_entry_record_is_sensitive_to_every_field
         ] )
     ]
 ;;


### PR DESCRIPTION
## 문제

터미널 파티션 검사가 "지금 발행하는 레코드가 디스크의 것과 같은가" 를 **JSON 으로 직렬화해서 비교**한다.

```ocaml
if entry_record_to_json terminal_entry = entry_record_to_json entry
then (* 중복 발행 — source 정리 *)
else Error (Integrity_failed Terminal_conflict)
```

두 곳(`:1190`, `:1500`) 에서 같은 방식이다. 이 판정의 결과는 **durable store 에서 무엇을 지우는지** 다 — 같다고 보면 source 를 정리하고, 다르다고 보면 무결성 실패를 낸다.

## 지금은 맞다. 그런데 우연히 맞다

`entry` 는 7 필드이고 `entry_record_to_json` 은 그 7 개를 전부, 하나의 코드 경로에서, 고정된 순서로 낸다. `status_to_string` 은 생성자별로 단사이고 payload 필드도 모두 실린다. 그래서 오늘은 `to_json a = to_json b` 와 `a = b` 가 일치한다.

**그 일치를 보장하는 것이 아무것도 없다.** 다음 중 하나만 일어나면 무결성 판정이 조용히 바뀐다.

- 와이어에 필드를 추가하면서 레코드에는 넣지 않는다 → 서로 다른 레코드가 같다고 판정된다 → **정리하면 안 되는 source 를 지운다**
- 어떤 필드를 조건부로 낸다 (`option` 을 생략 vs `null`) → 논리적으로 같은 레코드가 다르다고 판정된다 → 없는 충돌을 보고한다
- assoc 키 순서를 바꾼다 → 같은 결과

즉 **와이어 포맷과 무결성 술어가 결합돼 있는데 그렇다고 말하는 곳이 없다.** JSON 을 손보는 PR 은 자기가 저장소 정리 규칙을 바꾸는 줄 모른다.

## 무엇으로 바꿨나

레코드를 비교한다. 이름을 붙여 `same_request_identity`(5 개 식별 필드) 옆에 둔다.

```ocaml
let same_entry_record (left : entry) (right : entry) = left = right
```

구조 비교라 필드가 추가되면 자동으로 포함된다 — 손으로 적은 필드 목록이 아니어서 누락될 수 없다.

## 동작은 바뀌지 않는다

`to_json a = to_json b ⟺ a = b` 가 오늘 성립하므로 (위 근거) 이 PR 은 관측 가능한 동작을 바꾸지 않는다. 바뀌는 것은 **그 등가가 앞으로도 유지되는지가 더 이상 `entry_record_to_json` 에 의존하지 않는다**는 점이다.

## 테스트

`same_entry_record is sensitive to every field` — 7 필드를 하나씩 바꿔가며 전부 "다르다" 가 나오는지 확인한다.

**손으로 적은 부분 필드 목록으로 바꿔 실패하는 것을 확인했다** (`request_id` 와 `keeper_name` 만 비교하도록 교체 → `FAIL same_entry_record is sensitive...`). 이 테스트가 막는 것이 정확히 그 회귀다.

## 사전 실패에 대해

`test_keeper_msg_async_terminal_event` 의 `operator cancel running worker…` 1 건은 **이 PR 이전부터 실패한다**. `lib/` 를 `origin/main` 으로 되돌려 동일 실패를 확인했다.

## 검증

`dune build @check` 통과. `test_keeper_msg_async_terminal_event` 신규 1 건 통과 (사전 실패 1 건은 main 과 동일).

게이트: `check-determinism-contract`, `audit-catchall`, `check_silent_failure`, `check-variants`, `check_test_coverage` 통과.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
