### PR TITLE
ci: tighten UNWIRED_BASELINE to 737 (accept + briefing 배선분 고정)

### DIFF
--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -88,7 +88,7 @@ echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, al
 # authority tools, memory journal) without lowering the baseline. A PR that
 # wires a suite must lower this number in the same PR, or this check goes red
 # for everyone.
-UNWIRED_BASELINE=738
+UNWIRED_BASELINE=737
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then


### PR DESCRIPTION
#27333 이 accept 스위트를, #27332 가 briefing 스위트를 배선해 실측 unwired 는 737 인데 baseline 은 738 로 남아 슬랙 1 이 생겼다 — 이 슬랙만큼 새 미배선 스위트가 래칫을 통과할 수 있다. 두 PR 이 같은 값(738)을 동시에 적어 마지막 조임이 필요했던 것. 로컬 확인: `119 CI targets / 737 unwired, at baseline`.

RFC-WAIVED: 래칫 상수 1 감소, 코드 무접촉.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
