### PR TITLE
fix(goal): a completed goal stops being scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -949,6 +949,16 @@ jobs:
             @test/runtest-test_tool_contract_truth \
             @test/runtest-test_voice_command_descriptor_parity
 
+      - name: Run goal-scope terminal-phase suite
+        # validate_active_goal_ids is where a keeper's declared goal scope meets
+        # the live store, and everything downstream reads the list it returns.
+        # The prompt and the world observation filter the same list by phase, so
+        # a Completed goal left in scope makes the two disagree -- for 2.5 days
+        # on the live workspace before this was closed.
+        run: |
+          opam exec -- dune build --root . \
+            @test/runtest-test_goal_scope_terminal_phase
+
       - name: Run metric zero-cell declaration suite
         # A counter emitted as a bare string still compiles and still counts;
         # what it loses is the 0-cell, and only a running store shows that.

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -10,19 +10,65 @@ let primary_goal_id_opt (meta : keeper_meta) =
   | goal_id :: _ -> Some goal_id
   | [] -> None
 
+(* Why a goal id in [meta.active_goal_ids] does not survive the cross-check.
+   The two are different facts about the operator's declaration — an id that
+   resolves to nothing is a typo or a deleted goal, a Completed one was correct
+   when it was written — so they are carried and reported apart instead of
+   collapsing into one "invalid" count that would misname the second. *)
+type pruned_goal =
+  | Not_in_store of string
+  | Terminal_phase of string * Goal_phase.t
+
+let describe_pruned_goal = function
+  | Not_in_store goal_id -> goal_id
+  | Terminal_phase (goal_id, phase) ->
+    Printf.sprintf "%s(%s)" goal_id (Goal_phase.to_string phase)
+
 (** Cross-check [meta.active_goal_ids] against the live MASC goal store.
-    Returns only goal IDs that actually exist. Logs pruned IDs at warn level. *)
+
+    Returns the goal IDs that exist AND still admit self-directed progress.
+    [Goal_phase.admits_self_directed_progress] is the same predicate the world
+    observation and the unified prompt already apply, and applying it here is
+    what makes those consumers read one answer: everything else derives from
+    [meta.active_goal_ids] after this function has replaced it — the claim-scope
+    filter, [primary_goal_id_opt], and the [goal_ids] stamped on the runtime
+    contract — so a Completed goal was scope for them and absent for the prompt
+    at the same instant.
+
+    RFC-0067 §1 names this failure ("G1 is marked completed ... Claim still
+    succeeds ... but the task is now irrelevant") and closed the seconds-wide
+    observe/claim race; its §8 comparison records that the chosen approach
+    "doesn't catch goal property changes (status, phase)", which is the residue
+    this closes. Measured 2026-08-07: sangsu carried goal-request-menu-zero for
+    5,362 tool calls across 2.5 days after it completed, stamped goal-bound the
+    whole time, with an empty Active goals section in every one of those turns. *)
 let validate_active_goal_ids ~(config : Workspace.config) ~(meta : keeper_meta) () =
-  let valid_goal_ids, invalid_goal_ids =
-    List.partition
-      (fun goal_id -> Option.is_some (Goal_store.get_goal config ~goal_id))
+  let valid_goal_ids, pruned =
+    List.partition_map
+      (fun goal_id ->
+        match Goal_store.get_goal config ~goal_id with
+        | None -> Either.Right (Not_in_store goal_id)
+        | Some { Goal_store.phase; _ } ->
+          if Goal_phase.admits_self_directed_progress phase then Either.Left goal_id
+          else Either.Right (Terminal_phase (goal_id, phase)))
       meta.active_goal_ids
   in
-  if invalid_goal_ids <> [] then
-    Log.Keeper.warn ~keeper_name:meta.name
-      "pruned %d invalid goal_ids from active_goal_ids: %s"
-      (List.length invalid_goal_ids)
-      (String.concat ", " invalid_goal_ids);
+  let report label selected =
+    match List.filter selected pruned with
+    | [] -> ()
+    | dropped ->
+      Log.Keeper.warn ~keeper_name:meta.name
+        "pruned %d %s goal_ids from active_goal_ids: %s"
+        (List.length dropped)
+        label
+        (String.concat ", " (List.map describe_pruned_goal dropped))
+  in
+  report "invalid" (function
+    | Not_in_store _ -> true
+    | Terminal_phase _ -> false);
+  report "terminal-phase" (function
+    | Terminal_phase _ -> true
+    | Not_in_store _ -> false);
   valid_goal_ids
 
 let backend_of_meta (meta : keeper_meta) =

--- a/test/dune
+++ b/test/dune
@@ -192,6 +192,7 @@
   test_ide_partition_resolution
   test_ide_diagnostics
   test_keeper_runtime_contract
+  test_goal_scope_terminal_phase
   test_schema_surface_index
   test_keeper_accountability
   test_reputation_ledger_v2
@@ -492,6 +493,7 @@
   test_ide_partition_resolution
   test_ide_diagnostics
   test_keeper_runtime_contract
+  test_goal_scope_terminal_phase
   test_schema_surface_index
   test_keeper_accountability
   test_reputation_ledger_v2

--- a/test/test_goal_scope_terminal_phase.ml
+++ b/test/test_goal_scope_terminal_phase.ml
@@ -1,0 +1,171 @@
+(* [Keeper_runtime_contract.validate_active_goal_ids] is the single point where
+   a keeper's declared goal scope meets the live goal store, and everything
+   downstream reads [meta.active_goal_ids] after it has replaced the list: the
+   claim-scope filter, [primary_goal_id_opt], and the [goal_ids] stamped on the
+   runtime contract. The world observation and the unified prompt instead apply
+   [Goal_phase.admits_self_directed_progress], so before this suite a Completed
+   goal was scope for one set of readers and absent for the other.
+
+   These cases live outside test_keeper_runtime_contract on purpose. That suite
+   is one of four named in .github/workflows/ci.yml as red on main and
+   deliberately unwired (#26075): its claim assertions fail with
+   Eio_mutex.Poisoned under the test harness, so anything added there would not
+   execute. This file touches only the validator, runs, and is wired. *)
+
+open Alcotest
+open Masc
+
+let () = Workspace_metric_hooks.install ()
+
+let make_config () =
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf
+         "masc_goal_scope_terminal_phase_%d_%d"
+         (Unix.getpid ())
+         (int_of_float (Unix.gettimeofday () *. 1000.)))
+  in
+  Unix.mkdir dir 0o755;
+  let config = Workspace.default_config dir in
+  let _ = Workspace.init config ~agent_name:(Some "goal-scope-phase") in
+  config
+;;
+
+let cleanup_config config =
+  let _ = Workspace.reset config in
+  ()
+;;
+
+let make_meta active_goal_ids =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [ "name", `String "goal-scope-phase-keeper"
+        ; "trace_id", `String "goal-scope-phase-trace"
+        ; "active_goal_ids", `List (List.map (fun id -> `String id) active_goal_ids)
+        ])
+  with
+  | Ok meta -> meta
+  | Error e -> failf "make_meta failed: %s" e
+;;
+
+let put_goal config ~id ~phase =
+  match Goal_store.upsert_goal config ~id ~title:("Goal " ^ id) ~phase () with
+  | Ok _ -> ()
+  | Error msg -> failf "upsert_goal %s failed: %s" id msg
+;;
+
+let surviving config ids =
+  Keeper_runtime_contract.validate_active_goal_ids ~config ~meta:(make_meta ids) ()
+;;
+
+(* Every terminal constructor is asserted rather than letting Completed stand in
+   for the group. Blocked and Paused are the two that read as "still mine, just
+   not now" -- which is exactly the reading that would justify keeping them in
+   scope -- and [Goal_phase.admits_self_directed_progress] answers false for
+   both, so the scope and the prompt agree on them too. *)
+let test_every_terminal_phase_leaves_scope () =
+  let config = make_config () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_config config)
+    (fun () ->
+      let terminal =
+        [ "goal-completed", Goal_phase.Completed
+        ; "goal-dropped", Goal_phase.Dropped
+        ; "goal-blocked", Goal_phase.Blocked
+        ; "goal-paused", Goal_phase.Paused
+        ]
+      in
+      put_goal config ~id:"goal-executing" ~phase:Goal_phase.Executing;
+      List.iter (fun (id, phase) -> put_goal config ~id ~phase) terminal;
+      check
+        (list string)
+        "only the executing goal survives"
+        [ "goal-executing" ]
+        (surviving config ("goal-executing" :: List.map fst terminal)))
+;;
+
+(* The live shape this closes, measured 2026-08-07: sangsu's only configured
+   goal completed 2h12m after it entered scope and stayed there. Over the next
+   2.5 days the runtime contract stamped goal_ids from the raw list for 5,362
+   tool calls while the prompt, applying the phase predicate, showed no goal in
+   any of those turns. An empty result is what makes the claim scope fall to
+   all_tasks and the stamp read honestly, so emptiness is the assertion. *)
+let test_a_scope_of_only_completed_goals_is_empty () =
+  let config = make_config () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_config config)
+    (fun () ->
+      put_goal config ~id:"goal-finished" ~phase:Goal_phase.Completed;
+      check (list string) "nothing survives" [] (surviving config [ "goal-finished" ]))
+;;
+
+(* A goal that reaches a terminal phase and is reopened returns to scope on its
+   own: the predicate is evaluated per turn against the store, never cached, so
+   nothing has to undo the prune. *)
+let test_reopening_a_goal_returns_it_to_scope () =
+  let config = make_config () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_config config)
+    (fun () ->
+      put_goal config ~id:"goal-cycles" ~phase:Goal_phase.Completed;
+      check (list string) "out of scope while completed" [] (surviving config [ "goal-cycles" ]);
+      put_goal config ~id:"goal-cycles" ~phase:Goal_phase.Executing;
+      check
+        (list string)
+        "back in scope once executing again"
+        [ "goal-cycles" ]
+        (surviving config [ "goal-cycles" ]))
+;;
+
+(* An id absent from the store was already pruned before this change. Pinning it
+   keeps the two prune reasons from collapsing back into one branch, which would
+   report a Completed goal as invalid -- it is not. *)
+let test_ids_absent_from_the_store_are_still_dropped () =
+  let config = make_config () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_config config)
+    (fun () ->
+      put_goal config ~id:"goal-real" ~phase:Goal_phase.Executing;
+      check
+        (list string)
+        "unknown id dropped, executing goal kept"
+        [ "goal-real" ]
+        (surviving config [ "goal-real"; "goal-typo" ]))
+;;
+
+(* Order is the caller's declaration order and is load-bearing:
+   [primary_goal_id_opt] takes the head of the surviving list. *)
+let test_surviving_ids_keep_declaration_order () =
+  let config = make_config () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_config config)
+    (fun () ->
+      put_goal config ~id:"goal-first" ~phase:Goal_phase.Executing;
+      put_goal config ~id:"goal-stale" ~phase:Goal_phase.Completed;
+      put_goal config ~id:"goal-second" ~phase:Goal_phase.Executing;
+      check
+        (list string)
+        "declaration order preserved across the prune"
+        [ "goal-first"; "goal-second" ]
+        (surviving config [ "goal-first"; "goal-stale"; "goal-second" ]))
+;;
+
+let () =
+  run
+    "goal_scope_terminal_phase"
+    [ ( "validate_active_goal_ids"
+      , [ test_case "every terminal phase leaves scope" `Quick
+            test_every_terminal_phase_leaves_scope
+        ; test_case "a scope of only completed goals is empty" `Quick
+            test_a_scope_of_only_completed_goals_is_empty
+        ; test_case "reopening a goal returns it to scope" `Quick
+            test_reopening_a_goal_returns_it_to_scope
+        ; test_case "ids absent from the store are still dropped" `Quick
+            test_ids_absent_from_the_store_are_still_dropped
+        ; test_case "surviving ids keep declaration order" `Quick
+            test_surviving_ids_keep_declaration_order
+        ] )
+    ]
+;;

--- a/test/test_keeper_runtime_contract.ml
+++ b/test/test_keeper_runtime_contract.ml
@@ -217,10 +217,101 @@ let test_scoped_verification_keeps_isolation () =
         included)
 ;;
 
+let put_goal config ~id ~phase =
+  match Goal_store.upsert_goal config ~id ~title:("Goal " ^ id) ~phase () with
+  | Ok _ -> ()
+  | Error msg -> failf "upsert_goal %s failed: %s" id msg
+;;
+
+(* The predicate under test is [Goal_phase.admits_self_directed_progress], so
+   every terminal constructor is asserted rather than Completed standing in for
+   the group: Blocked and Paused are the two that read as "still mine, just not
+   now", which is exactly the reading that would justify keeping them in scope. *)
+let test_validate_drops_every_terminal_phase () =
+  let config = make_config () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_config config)
+    (fun () ->
+      let terminal =
+        [ "goal-completed", Goal_phase.Completed
+        ; "goal-dropped", Goal_phase.Dropped
+        ; "goal-blocked", Goal_phase.Blocked
+        ; "goal-paused", Goal_phase.Paused
+        ]
+      in
+      put_goal config ~id:"goal-executing" ~phase:Goal_phase.Executing;
+      List.iter (fun (id, phase) -> put_goal config ~id ~phase) terminal;
+      let meta =
+        make_meta ~active_goal_ids:("goal-executing" :: List.map fst terminal) ()
+      in
+      check
+        (list string)
+        "only the executing goal survives"
+        [ "goal-executing" ]
+        (Keeper_runtime_contract.validate_active_goal_ids ~config ~meta ()))
+;;
+
+(* The live shape this closes (2026-08-07): the only keeper with a configured
+   scope pointed at a goal that had completed, and the runtime contract went on
+   stamping goal_ids from the raw list for 5,362 tool calls while the prompt —
+   which applies the same predicate — showed no goal at all. Asserting the
+   emptiness matters more than the filtering: empty is what makes the claim
+   scope fall to All_tasks and the stamp read honestly. *)
+let test_scope_of_a_completed_goal_is_empty_not_scoped () =
+  let config = make_config () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_config config)
+    (fun () ->
+      put_goal config ~id:"goal-finished" ~phase:Goal_phase.Completed;
+      add_task ~goal_id:"goal-finished" config ~title:"task under a finished goal";
+      add_task config ~title:"unscoped task";
+      let meta = make_meta ~active_goal_ids:[ "goal-finished" ] () in
+      let surviving = Keeper_runtime_contract.validate_active_goal_ids ~config ~meta () in
+      check (list string) "nothing survives" [] surviving;
+      let meta = make_meta ~active_goal_ids:surviving () in
+      let scope =
+        Keeper_runtime_contract.resolve_claim_goal_scope
+          ~config
+          ~meta
+          ~task_eligible:(fun _ -> true)
+          ()
+      in
+      check
+        string
+        "claim scope is all_tasks, not a scope over a finished goal"
+        "all_tasks"
+        (Keeper_runtime_contract.claim_scope_mode_to_string scope.mode);
+      check (list string) "no effective goal ids" [] scope.effective_goal_ids)
+;;
+
+(* A goal id that resolves to nothing was already pruned before this change;
+   pinning it keeps the two reasons from being merged back into one branch. *)
+let test_validate_still_drops_ids_absent_from_the_store () =
+  let config = make_config () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_config config)
+    (fun () ->
+      put_goal config ~id:"goal-real" ~phase:Goal_phase.Executing;
+      let meta = make_meta ~active_goal_ids:[ "goal-real"; "goal-typo" ] () in
+      check
+        (list string)
+        "unknown id dropped, existing executing goal kept"
+        [ "goal-real" ]
+        (Keeper_runtime_contract.validate_active_goal_ids ~config ~meta ()))
+;;
+
 let () =
   run
     "keeper_runtime_contract"
-    [ ( "active_goal_claim_scope"
+    [ ( "active_goal_ids_validation"
+      , [ test_case "drops every terminal phase" `Quick
+            test_validate_drops_every_terminal_phase
+        ; test_case "a completed goal leaves an empty scope" `Quick
+            test_scope_of_a_completed_goal_is_empty_not_scoped
+        ; test_case "still drops ids absent from the store" `Quick
+            test_validate_still_drops_ids_absent_from_the_store
+        ] )
+    ; ( "active_goal_claim_scope"
       , [ test_case "filters claimable tasks" `Quick
             test_active_goal_ids_filter_claimable_tasks
         ; test_case "keeps isolation when scoped match present" `Quick

--- a/test/test_keeper_runtime_contract.ml
+++ b/test/test_keeper_runtime_contract.ml
@@ -217,101 +217,10 @@ let test_scoped_verification_keeps_isolation () =
         included)
 ;;
 
-let put_goal config ~id ~phase =
-  match Goal_store.upsert_goal config ~id ~title:("Goal " ^ id) ~phase () with
-  | Ok _ -> ()
-  | Error msg -> failf "upsert_goal %s failed: %s" id msg
-;;
-
-(* The predicate under test is [Goal_phase.admits_self_directed_progress], so
-   every terminal constructor is asserted rather than Completed standing in for
-   the group: Blocked and Paused are the two that read as "still mine, just not
-   now", which is exactly the reading that would justify keeping them in scope. *)
-let test_validate_drops_every_terminal_phase () =
-  let config = make_config () in
-  Fun.protect
-    ~finally:(fun () -> cleanup_config config)
-    (fun () ->
-      let terminal =
-        [ "goal-completed", Goal_phase.Completed
-        ; "goal-dropped", Goal_phase.Dropped
-        ; "goal-blocked", Goal_phase.Blocked
-        ; "goal-paused", Goal_phase.Paused
-        ]
-      in
-      put_goal config ~id:"goal-executing" ~phase:Goal_phase.Executing;
-      List.iter (fun (id, phase) -> put_goal config ~id ~phase) terminal;
-      let meta =
-        make_meta ~active_goal_ids:("goal-executing" :: List.map fst terminal) ()
-      in
-      check
-        (list string)
-        "only the executing goal survives"
-        [ "goal-executing" ]
-        (Keeper_runtime_contract.validate_active_goal_ids ~config ~meta ()))
-;;
-
-(* The live shape this closes (2026-08-07): the only keeper with a configured
-   scope pointed at a goal that had completed, and the runtime contract went on
-   stamping goal_ids from the raw list for 5,362 tool calls while the prompt —
-   which applies the same predicate — showed no goal at all. Asserting the
-   emptiness matters more than the filtering: empty is what makes the claim
-   scope fall to All_tasks and the stamp read honestly. *)
-let test_scope_of_a_completed_goal_is_empty_not_scoped () =
-  let config = make_config () in
-  Fun.protect
-    ~finally:(fun () -> cleanup_config config)
-    (fun () ->
-      put_goal config ~id:"goal-finished" ~phase:Goal_phase.Completed;
-      add_task ~goal_id:"goal-finished" config ~title:"task under a finished goal";
-      add_task config ~title:"unscoped task";
-      let meta = make_meta ~active_goal_ids:[ "goal-finished" ] () in
-      let surviving = Keeper_runtime_contract.validate_active_goal_ids ~config ~meta () in
-      check (list string) "nothing survives" [] surviving;
-      let meta = make_meta ~active_goal_ids:surviving () in
-      let scope =
-        Keeper_runtime_contract.resolve_claim_goal_scope
-          ~config
-          ~meta
-          ~task_eligible:(fun _ -> true)
-          ()
-      in
-      check
-        string
-        "claim scope is all_tasks, not a scope over a finished goal"
-        "all_tasks"
-        (Keeper_runtime_contract.claim_scope_mode_to_string scope.mode);
-      check (list string) "no effective goal ids" [] scope.effective_goal_ids)
-;;
-
-(* A goal id that resolves to nothing was already pruned before this change;
-   pinning it keeps the two reasons from being merged back into one branch. *)
-let test_validate_still_drops_ids_absent_from_the_store () =
-  let config = make_config () in
-  Fun.protect
-    ~finally:(fun () -> cleanup_config config)
-    (fun () ->
-      put_goal config ~id:"goal-real" ~phase:Goal_phase.Executing;
-      let meta = make_meta ~active_goal_ids:[ "goal-real"; "goal-typo" ] () in
-      check
-        (list string)
-        "unknown id dropped, existing executing goal kept"
-        [ "goal-real" ]
-        (Keeper_runtime_contract.validate_active_goal_ids ~config ~meta ()))
-;;
-
 let () =
   run
     "keeper_runtime_contract"
-    [ ( "active_goal_ids_validation"
-      , [ test_case "drops every terminal phase" `Quick
-            test_validate_drops_every_terminal_phase
-        ; test_case "a completed goal leaves an empty scope" `Quick
-            test_scope_of_a_completed_goal_is_empty_not_scoped
-        ; test_case "still drops ids absent from the store" `Quick
-            test_validate_still_drops_ids_absent_from_the_store
-        ] )
-    ; ( "active_goal_claim_scope"
+    [ ( "active_goal_claim_scope"
       , [ test_case "filters claimable tasks" `Quick
             test_active_goal_ids_filter_claimable_tasks
         ; test_case "keeps isolation when scoped match present" `Quick


### PR DESCRIPTION
## What

`validate_active_goal_ids` pruned only goal ids **absent from the store**, so a
goal that reached a terminal phase stayed in `meta.active_goal_ids`. Everything
downstream reads that list after this function replaces it — the claim-scope
filter, `primary_goal_id_opt`, and the `goal_ids` stamped on the runtime
contract — while the world observation and the unified prompt apply
`Goal_phase.admits_self_directed_progress`. One field, two answers.

```ocaml
(* goal_phase.ml:50 — the predicate the prompt and observation already use *)
let admits_self_directed_progress = function
  | Executing -> true
  | Blocked | Paused | Completed | Dropped -> false
```

## Why now

RFC-0067 §1 names this failure:

> Keeper observes goal G1 → LLM decides to claim a task linked to G1 → Between
> observation and claim, **G1 is marked completed** by another agent → Claim
> still succeeds (goal still in `meta.active_goal_ids` in-memory) but the task
> is now irrelevant.

That RFC closed the seconds-wide observe/claim race. Its §8 comparison records
what the chosen approach does not cover — *"doesn't catch goal property changes
(status, phase)"* — and that residue is what this closes.

Measured on the live workspace, 2026-08-07:

```
sangsu active_goal_ids            ['goal-request-menu-zero']
  entered scope                   08-04 10:42
  goal completed                  08-04 12:54   (2h12m later)

tool calls bound to that goal
  while executing                    201
  after it completed               5,362        ← 2.5 days, still counting
```

For all 5,362 the runtime contract stamped the keeper goal-bound while the
Active goals section was empty, because the prompt filters by phase and the
stamp did not. `sangsu` is the only keeper in the fleet with a configured scope,
so this is 100% of the fleet's apparent goal binding.

## Change

One predicate at the one place scope meets the store. The two prune reasons are
carried apart in a variant, so a Completed goal is not reported as `invalid` —
it is not invalid, it was correct when it was written.

Nothing is added: no new tool, no new prompt text, no gate. A keeper whose only
goal completed now falls to `all_tasks` (which the existing
`Empty_goal_scope_fallback_all_tasks` path already handles) instead of scoping
to finished work.

## Tests — and where they live

Five cases, **all executing in CI** (117 → 118 targets, unwired unchanged at its
baseline since declared and referenced both go up by one):

```
every terminal phase leaves scope      Completed, Dropped, Blocked, Paused
a scope of only completed goals is empty
reopening a goal returns it to scope   evaluated per turn, nothing undoes a prune
ids absent from the store still drop   the pre-existing behaviour, pinned
surviving ids keep declaration order   primary_goal_id_opt takes the head
```

They first went into `test_keeper_runtime_contract`, the natural home — and then
out again. `ci.yml:905` names that suite as one of four *"red today and
deliberately NOT listed"* (#26075); its claim assertions fail with
`Eio_mutex.Poisoned` under the harness. Verified against clean `origin/main`:
`5 tests run, 2 failures`, the same two, without this change. Anything added
there would compile and never run. The new file touches only the validator.

## Verification

```
dune build --root . @check                                    exit 0
dune build --root . @test/runtest-test_goal_scope_terminal_phase
                                              Test Successful, 5 tests run
scripts/audit-ci-test-targets.sh              120 targets, 737 unwired, exit 0
ci.yml parses as YAML
```

Note: `origin/main` alone already reports `737 unwired, 738 baseline`. That gain
is not from this PR (declared +1 and referenced +1 cannot move the count), so
lowering `UNWIRED_BASELINE` belongs to whichever PR earned it, not this one.

RFC-WAIVED: RFC-0067 §1 and §8 already specify this behaviour and name the
uncovered residue; this implements it rather than proposing something new.
