### PR TITLE
fix(keeper): keep the SDK timeout phase through the Api error path

### DIFF
--- a/lib/keeper/keeper_event_bridge_error_json.ml
+++ b/lib/keeper/keeper_event_bridge_error_json.ml
@@ -185,8 +185,13 @@ let sdk_api_error_fields = function
     ; "message", `String message
     ; "network_kind", `String (Keeper_agent_error.network_error_kind_to_wire kind)
     ]
-  | Agent_sdk.Retry.Timeout { message } ->
-    [ "variant", `String "timeout"; "message", `String message ]
+  | Agent_sdk.Retry.Timeout { message; phase } ->
+    [ "variant", `String "timeout"
+    ; "message", `String message
+    ; ( "timeout_phase"
+      , Json_util.string_opt_to_json
+          (Option.map Llm_provider.Http_client.timeout_phase_to_label phase) )
+    ]
 ;;
 
 let sdk_agent_error_fields = function

--- a/lib/keeper/keeper_runtime_attempt.ml
+++ b/lib/keeper/keeper_runtime_attempt.ml
@@ -143,9 +143,18 @@ let sdk_error_to_runtime_outcome err =
            http_error ~code:529 ~body:message
          | NetworkError { message; kind } ->
            Llm_provider.Http_client.NetworkError { message; kind }
-         | Timeout { message } ->
-           Llm_provider.Http_client.NetworkError
-             { message; kind = Llm_provider.Http_client.Timeout }
+         | Timeout { message; phase } ->
+           (* [Http_client.Timeout] is the ETIMEDOUT transport kind, but
+              [Retry.Timeout] also covers Admission, Queue, First_token and
+              Capacity_backpressure waits that never touched a socket.
+              [TimeoutError] carries the phase, so route there and keep it. *)
+           Llm_provider.Http_client.TimeoutError
+             { message
+             ; phase =
+                 (* DET-OK: [Unknown_timeout] is the SDK's own constructor for an
+                    unattributed timeout — it names the absence, not a real phase. *)
+                 Option.value phase ~default:Llm_provider.Http_client.Unknown_timeout
+             }
        in
        Some (Runtime_attempt_fsm.Call_err http_err)
      | Agent_sdk.Error.Provider provider_err ->

--- a/test/test_keeper_execution_join.ml
+++ b/test/test_keeper_execution_join.ml
@@ -471,6 +471,52 @@ let test_input_capacity_projection_preserves_evidence () =
     (Some "input_rejected")
     (string_of_field (member "kind" reason_json))
 
+(* [Retry.Timeout] carries a typed phase that separates an admission or queue
+   wait from a streaming stall. The arm bound only [message], so every timeout
+   reached the wire indistinguishable from every other one. *)
+let test_timeout_projection_preserves_phase () =
+  let projection =
+    Error_json.agent_failed_error_projection
+      (Agent_sdk.Error.Api
+         (Agent_sdk.Retry.Timeout
+            { message = "per-provider timeout after 90.0s"
+            ; phase = Some Llm_provider.Http_client.Admission
+            }))
+  in
+  check
+    (option string)
+    "typed variant"
+    (Some "timeout")
+    (string_of_field (member "variant" projection.error_detail));
+  check
+    (option string)
+    "typed phase"
+    (Some
+       (Llm_provider.Http_client.timeout_phase_to_label
+          Llm_provider.Http_client.Admission))
+    (string_of_field (member "timeout_phase" projection.error_detail))
+
+(* An absent phase stays absent on the wire. Naming one would report a phase
+   the provider never attributed. *)
+let test_timeout_projection_without_phase_reports_null () =
+  let projection =
+    Error_json.agent_failed_error_projection
+      (Agent_sdk.Error.Api
+         (Agent_sdk.Retry.Timeout { message = "unattributed timeout"; phase = None }))
+  in
+  check
+    (option string)
+    "typed variant"
+    (Some "timeout")
+    (string_of_field (member "variant" projection.error_detail));
+  check
+    bool
+    "phase is null, not a guess"
+    true
+    (match member "timeout_phase" projection.error_detail with
+     | Some `Null -> true
+     | Some _ | None -> false)
+
 let () =
   run "keeper_execution_join"
     [ ( "join_table"
@@ -502,5 +548,9 @@ let () =
             test_provider_request_body_refusal_projection_preserves_status
         ; test_case "input capacity preserves typed evidence" `Quick
             test_input_capacity_projection_preserves_evidence
+        ; test_case "timeout preserves typed phase" `Quick
+            test_timeout_projection_preserves_phase
+        ; test_case "unattributed timeout reports null phase" `Quick
+            test_timeout_projection_without_phase_reports_null
         ] )
     ]

--- a/test/test_keeper_runtime_attempt.ml
+++ b/test/test_keeper_runtime_attempt.ml
@@ -30,6 +30,40 @@ let test_429_without_hint_stays_none () =
     (Some None)
     (retry_after_of_outcome (KRA.sdk_error_to_runtime_outcome (rate_limited None)))
 
+(* [Retry.Timeout] spans Admission, Queue, First_token and Capacity_backpressure
+   waits, none of which touched a socket. Routing them to
+   [NetworkError { kind = Timeout }] labelled them ETIMEDOUT and dropped the
+   phase; [TimeoutError] is the constructor that carries it. A [None] here
+   means the outcome was not a [TimeoutError] at all. *)
+let timeout_phase_label_of_outcome = function
+  | Some
+      (Runtime_attempt_fsm.Call_err
+         (Llm_provider.Http_client.TimeoutError { phase; _ })) ->
+    Some (Llm_provider.Http_client.timeout_phase_to_label phase)
+  | _ -> None
+
+let api_timeout phase =
+  Agent_sdk.Error.Api
+    (Llm_provider.Retry.Timeout { message = "per-provider timeout after 90.0s"; phase })
+
+let test_timeout_threads_phase () =
+  Alcotest.(check (option string))
+    "an admission-phase timeout stays an admission-phase timeout"
+    (Some
+       (Llm_provider.Http_client.timeout_phase_to_label
+          Llm_provider.Http_client.Admission))
+    (timeout_phase_label_of_outcome
+       (KRA.sdk_error_to_runtime_outcome
+          (api_timeout (Some Llm_provider.Http_client.Admission))))
+
+let test_timeout_without_phase_is_unknown () =
+  Alcotest.(check (option string))
+    "an unattributed timeout lands on Unknown_timeout, not a network kind"
+    (Some
+       (Llm_provider.Http_client.timeout_phase_to_label
+          Llm_provider.Http_client.Unknown_timeout))
+    (timeout_phase_label_of_outcome (KRA.sdk_error_to_runtime_outcome (api_timeout None)))
+
 let provider_wire_error () =
   Agent_sdk.Error.Provider
     (Llm_provider.Error.ProviderWireError
@@ -83,6 +117,13 @@ let () =
     [ ( "rate_limited_429"
       , [ Alcotest.test_case "threads resolved retry_after" `Quick test_429_threads_resolved_retry_after
         ; Alcotest.test_case "absent hint stays None" `Quick test_429_without_hint_stays_none
+        ] )
+    ; ( "timeout_phase"
+      , [ Alcotest.test_case "phase threads through" `Quick test_timeout_threads_phase
+        ; Alcotest.test_case
+            "absent phase is Unknown_timeout"
+            `Quick
+            test_timeout_without_phase_is_unknown
         ] )
     ; ( "provider_failures"
       , [ Alcotest.test_case


### PR DESCRIPTION
`#27182` 을 대체한다. 내용은 같고 브랜치 이력만 정리했다.

## 문제

`Agent_sdk.Retry.Timeout` 은 `phase` 를 나른다 — `Admission`, `Queue`, `First_token`, `Capacity_backpressure` 처럼 **소켓에 닿은 적도 없는 대기**를 포함한다. Api 오류 경로가 그것을 전부 하나로 접었다.

```ocaml
| Timeout { message; _ } ->
  Llm_provider.Http_client.NetworkError { message; kind = Timeout }
```

`NetworkError { kind = Timeout }` 은 ETIMEDOUT, 즉 **전송 계층** 타임아웃을 뜻한다. admission 대기가 전송 타임아웃으로 보고되면 운영자는 네트워크를 본다.

## 무엇으로 바꿨나

`TimeoutError` 는 phase 를 나를 수 있으므로 그쪽으로 보내고 값을 유지한다.

```ocaml
| Timeout { message; phase } ->
  Llm_provider.Http_client.TimeoutError
    { message
    ; (* DET-OK: [Unknown_timeout] 은 SDK 자신의 미귀속 타임아웃 생성자이지
         진짜 phase 를 대신하는 기본값이 아니다. *)
      phase = Option.value phase ~default:Llm_provider.Http_client.Unknown_timeout
    }
```

브리지가 이것을 `timeout_phase` 로 직렬화한다.

## 왜 새 PR 인가

`#27182` 는 장애 기간의 반복된 rebase/cherry-pick 으로 **커밋 10 개, 그중 빈 머지 5 개, 그리고 같은 패치가 두 번**(`b9644ef216` / `1f27176656`) 들어간 상태가 됐다. `check-pr-hygiene.sh` 가 duplicate patch 를 경고하고 CI 의 `Run PR hygiene guards` 가 실패한다.

`origin/main...` 순 diff 를 뽑아 최신 main 위에 **한 커밋**으로 다시 올렸다. 코드 내용은 동일하다 (4 파일, +110/−5).

## 검증

`dune build @check` 통과. `test_keeper_runtime_attempt`, `test_keeper_execution_join` 23 건 통과. `check-determinism-contract` 통과 (DET-OK 주석이 게이트의 ±2 줄 범위 안에 있다). `check_test_coverage` 통과.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
