### PR TITLE
chore(ci): 이미 배선된 스위트만큼 UNWIRED_BASELINE 을 내린다 (738 → 735)

### DIFF
--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -88,7 +88,15 @@ echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, al
 # authority tools, memory journal) without lowering the baseline. A PR that
 # wires a suite must lower this number in the same PR, or this check goes red
 # for everyone.
-UNWIRED_BASELINE=738
+#
+# 738 -> 735: #27275, #27330 and #27285 each wired a suite and left the
+# baseline where it was, so the check carried three slots of slack. Slack is
+# not neutral — it is the number of suites a later PR can add without wiring
+# before anything goes red, which is exactly what this guard exists to catch.
+# The advice this script prints when unwired drops below the baseline is only
+# printed, never enforced; until it is (#27297) the number has to be pulled
+# down by hand after each wiring lands.
+UNWIRED_BASELINE=735
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then


### PR DESCRIPTION
## 무엇

`UNWIRED_BASELINE` 을 738 에서 **735** 로 내린다. 실제 미배선 개수가 735 다.

```
$ bash scripts/audit-ci-test-targets.sh
[ci-test-targets] OK - 121 CI targets, all declared in test/dune
[ci-test-targets] OK - 735 suites unwired, 738 baseline
                       — lower UNWIRED_BASELINE ... to hold the gain
```

## 왜

`#27275`, `#27330`, `#27285` 가 각각 스위트를 하나씩 `ci.yml` 에 배선하면서 baseline 을 그대로 뒀다. 그래서 3칸의 여유가 쌓였다.

**여유는 중립이 아니다.** 그 숫자는 *나중에 오는 PR 이 배선 없이 스위트를 선언해도 초록으로 통과할 수 있는 개수* 이고, 그게 바로 이 가드가 잡으라고 있는 것이다. 지금은 미배선 스위트 3개가 아무 경고 없이 들어올 수 있다.

스크립트는 이미 `unwired < BASELINE` 일 때 "lower ... to hold the gain" 을 출력한다. **출력만 한다.** 강제가 되기 전까지(#27297) 이 숫자는 배선이 머지될 때마다 손으로 내려야 하고, 그동안 안 내려졌다.

## 검증 — 통과만이 아니라 실패도 확인했다

```
그대로                     exit 0, "735 suites unwired, at baseline"
미배선 stanza 1개 추가     exit 2, "FAIL - 736 ... (baseline 735)"
```

두 번째는 임시 stanza 로 확인한 뒤 되돌렸다. 통과만 보면 "가드가 아직 아무것도 안 잡는 상태" 와 구분되지 않는다.

## 범위

`scripts/audit-ci-test-targets.sh` 한 줄 + 주석. 스위트 배선이나 테스트 변경 없음.

## 관련

- **#27297** — CI 가 실행하는 스위트 121 vs 선언 856. 이 라쳇이 증가만 막고 감소를 고정하지 않는 문제의 추적 이슈. 근본 수정은 그쪽(안내를 강제로 전환)이고, 이 PR 은 그때까지의 수동 조임이다.
- 여유를 만든 세 PR: #27275, #27330, #27285

RFC-WAIVED 를 쓰지 않는다 — `pr-rfc-check.sh` 의 subsystem 패턴에 `scripts/` 가 없어 게이트가 트립하지 않는다.
