### PR TITLE
chore(tools): burn keeper_candidate_names, which nothing admits with

### DIFF
--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1997,17 +1997,6 @@ let keeper_model_names descriptor =
   | [], (Operator_only | Transport_alias _) -> []
 ;;
 
-let keeper_candidate_names descriptor =
-  match model_schema_errors descriptor, descriptor.keeper_model_projection with
-  | _ :: _, _ -> []
-  | [], Preferred_public_name ->
-    [ descriptor.public_name; descriptor.internal_name ]
-    |> List.sort_uniq String.compare
-  | [], Internal_name ->
-    [ descriptor.internal_name ]
-  | [], (Operator_only | Transport_alias _) -> []
-;;
-
 let registered_names descriptor =
   [ descriptor.internal_name; descriptor.public_name ]
   |> List.sort_uniq String.compare

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -187,10 +187,6 @@ val model_visible_schemas : unit -> Masc_domain.tool_schema list
     schema. *)
 val keeper_model_names : t -> string list
 
-(** Names admitted by the Keeper execution/candidate boundary. A preferred
-    public descriptor admits its public name and internal handler route. *)
-val keeper_candidate_names : t -> string list
-
 (** Every name owned by a descriptor, including transport-alias names. This is
     for name-integrity checks, never Keeper execution admission. *)
 val registered_names : t -> string list

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -124,17 +124,21 @@ let test_keeper_model_projection_is_single_and_unique () =
   List.iter
     (fun (descriptor : Descriptor.t) ->
        let projected = Descriptor.keeper_model_names descriptor in
-       let candidates = Descriptor.keeper_candidate_names descriptor in
        match descriptor.keeper_model_projection with
        | Descriptor.Preferred_public_name ->
          Alcotest.(check (list string))
            (descriptor.id ^ " preferred model projection")
            [ descriptor.public_name ]
            projected;
+         (* The internal name stays owned by this descriptor even though the
+            model is never shown it. [registered_names] is the name-integrity
+            axis; [keeper_model_names] is the admission axis. Keeping both here
+            is what stops a rename from freeing the internal name for another
+            descriptor to claim. *)
          Alcotest.(check bool)
-           (descriptor.id ^ " keeps internal dispatch candidate")
+           (descriptor.id ^ " still owns its internal handler route")
            true
-           (List.mem descriptor.internal_name candidates)
+           (List.mem descriptor.internal_name (Descriptor.registered_names descriptor))
        | Descriptor.Internal_name ->
          Alcotest.(check (list string))
            (descriptor.id ^ " internal model projection")
@@ -144,20 +148,12 @@ let test_keeper_model_projection_is_single_and_unique () =
          Alcotest.(check (list string))
            (descriptor.id ^ " operator-only control has no model projection")
            []
-           projected;
-         Alcotest.(check (list string))
-           (descriptor.id ^ " operator-only control has no Keeper candidates")
-           []
-           candidates
+           projected
        | Descriptor.Transport_alias _ ->
          Alcotest.(check (list string))
            (descriptor.id ^ " transport alias has no duplicate model projection")
            []
-           projected;
-         Alcotest.(check (list string))
-           (descriptor.id ^ " has no Keeper candidates")
-           []
-           candidates)
+           projected)
     (all_descriptors ())
 ;;
 
@@ -252,11 +248,7 @@ let test_structurally_invalid_schema_is_excluded () =
   Alcotest.(check (list string))
     "malformed schema has no model names"
     []
-    (Descriptor.keeper_model_names malformed);
-  Alcotest.(check (list string))
-    "malformed schema has no execution candidates"
-    []
-    (Descriptor.keeper_candidate_names malformed)
+    (Descriptor.keeper_model_names malformed)
 ;;
 
 (* The description a Keeper reads and the description in the canonical registry


### PR DESCRIPTION
## What

`keeper_candidate_names` is exported from `keeper_tool_descriptor.mli` with this
doc:

> Names admitted by the **Keeper execution/candidate boundary**. A preferred
> public descriptor admits its public name and internal handler route.

Nothing in `lib/` calls it. Scanned `lib/ test/ dashboard/ scripts/ docs/`: two
call sites, both in one test file.

The boundary it describes reads something else:

```
advertisement + policy   keeper_tool_policy.ml:25  → keeper_model_names
dispatch                 Tool_workspace.dispatch ~name, Tool_misc.dispatch ~name
                         (per-cluster match on the name string)
```

`keeper_model_names` returns exactly one name per descriptor. So the "admits
both names" behaviour the doc promises is not a behaviour any caller has.

## Why this one is worth deleting rather than leaving

A dead helper is noise. A dead helper *documented as a live boundary* is a
wrong answer waiting to be trusted — I read that doc this session and spent a
measurement chasing whether keepers were calling two names for one board
operation. They were not: `keeper_board_list` → `masc_board_list` was a rename
on 2026-08-05 (`keeper_board_list` 1,834 calls that day, 0 after;
`masc_board_list` 636 that day, 4,708 the next). The dual-name reading came
from this doc, and the function is most likely a leftover of the era before
that rename.

## Tests

Four assertions went with it, and only one carried unique weight.

| assertion | why it goes |
|---|---|
| `Operator_only` has no candidates | same test already asserts `keeper_model_names = []` |
| `Transport_alias` has no candidates | same |
| malformed schema has no candidates | same |
| `Preferred_public_name` keeps internal name | **kept**, re-anchored on `registered_names` |

The fourth is the one that guards something real — that a `Preferred_public_name`
descriptor still owns its internal handler route, so a rename cannot free that
name for another descriptor to claim. `registered_names` is what the `.mli`
names as the name-integrity axis ("for name-integrity checks, never Keeper
execution admission"), so the assertion now sits on the axis that actually
holds it.

## Verification

```
rg keeper_candidate_names lib/ test/                        0 hits
dune build --root . @check                                  exit 0
dune build --root . @test/runtest-test_keeper_tool_descriptor_registry_integrity
                                          Test Successful, 44 tests run
```

That suite runs in CI (`Run keeper tool descriptor registry integrity suite`, ci.yml:1319), so the
re-anchored assertion executes rather than only compiling.

RFC-WAIVED: removal of an uncalled function and its redundant assertions. No
behaviour change — nothing read it.
