### PR TITLE
fix(board): a wake about a comment carries what was said

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -265,20 +265,29 @@ let board_event_fields
     else fields
   in
   let fields = fields @ board_event_note_fields event.event_kind in
+  (* [new_replies_since_own] counts replies that arrived after this Keeper's own
+     comment, so it is stated only when there is an own comment to count from.
+     The author of the post is the case that has none: [check_self_comment_status]
+     answers [`Never], and the observation still fills
+     [latest_external_author]/[latest_external_preview] with the commenter and
+     what they said.
+
+     Those two used to be gated on [self_commented] together with the count, so
+     the author of a post learned that a comment existed and not one word of it
+     — the wake #27288 added arrived empty, and reading it back cost a
+     masc_board_post_get. The count keeps its condition because its name is only
+     true under it; the two content fields follow the data instead. *)
   let fields =
-    if event.self_commented && event.new_external_since > 0 then
-      let fields =
-        fields
-        @ [ "new_replies_since_own", string_of_int event.new_external_since ]
-      in
-      match event.latest_external_author, event.latest_external_preview with
-      | Some author, Some preview ->
-        fields
-        @ [ "latest_external_author", author
-          ; "latest_external_preview", preview
-          ]
-      | _ -> fields
+    if event.self_commented && event.new_external_since > 0
+    then fields @ [ "new_replies_since_own", string_of_int event.new_external_since ]
     else fields
+  in
+  let fields =
+    match event.latest_external_author, event.latest_external_preview with
+    | Some author, Some preview ->
+      fields @ [ "latest_external_author", author; "latest_external_preview", preview ]
+    | Some author, None -> fields @ [ "latest_external_author", author ]
+    | None, _ -> fields
   in
   fields @ [ "preview", event.preview ]
 ;;

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -909,6 +909,55 @@ let test_own_recent_board_posts_show_the_response () =
   check bool "an unanswered post says so rather than omitting the field" true
     (contains_sub "replies=\"0\"" world_state)
 
+(* The post author is the one participant who never commented on their own
+   thread, so [check_self_comment_status] answers [`Never] and [self_commented]
+   stays false. The observation still resolves the commenter and a preview of
+   what they wrote. Gating those two on [self_commented] meant the wake #27288
+   added told the author only that something had happened. *)
+let test_a_comment_on_your_own_post_says_who_and_what () =
+  let commented_on_by_someone_else =
+    { sample_board_event with
+      event_kind = WO.Board_comment_added
+    ; self_commented = false
+    ; new_external_since = 1
+    ; latest_external_author = Some "bob"
+    ; latest_external_preview = Some "I hit this too, here is the trace"
+    }
+  in
+  let obs =
+    { base_observation with pending_board_events = [ commented_on_by_someone_else ] }
+  in
+  let { Masc.Keeper_unified_prompt.world_state; _ } =
+    build_prompt ~meta:minimal_meta obs
+  in
+  check bool "the commenter is named" true
+    (contains_sub "latest_external_author=\"bob\"" world_state);
+  check bool "what they said reaches the author" true
+    (contains_sub "I hit this too, here is the trace" world_state);
+  (* The count keeps its condition: with no own comment there is no "since own"
+     to count from, so stating it would be false rather than merely absent. *)
+  check bool "no since-own count without an own comment" false
+    (contains_sub "new_replies_since_own" world_state)
+
+let test_a_reply_after_your_own_comment_still_counts () =
+  let replied_after_me =
+    { sample_board_event with
+      event_kind = WO.Board_comment_added
+    ; self_commented = true
+    ; new_external_since = 2
+    ; latest_external_author = Some "carol"
+    ; latest_external_preview = Some "two of us saw it"
+    }
+  in
+  let obs = { base_observation with pending_board_events = [ replied_after_me ] } in
+  let { Masc.Keeper_unified_prompt.world_state; _ } =
+    build_prompt ~meta:minimal_meta obs
+  in
+  check bool "count still rendered for a participant" true
+    (contains_sub "new_replies_since_own=\"2\"" world_state);
+  check bool "commenter still named" true
+    (contains_sub "latest_external_author=\"carol\"" world_state)
+
 let test_board_and_own_post_rows_escape_external_fields () =
   let hostile_event : WO.pending_board_event =
     { sample_board_event with
@@ -1022,6 +1071,12 @@ let () =
           test_case
             "prompt: own recent board posts show the response"
             `Quick test_own_recent_board_posts_show_the_response;
+          test_case
+            "prompt: a comment on your own post says who and what"
+            `Quick test_a_comment_on_your_own_post_says_who_and_what;
+          test_case
+            "prompt: a reply after your own comment still counts"
+            `Quick test_a_reply_after_your_own_comment_still_counts;
           test_case
             "prompt: Board and own-post fields escape external newlines"
             `Quick test_board_and_own_post_rows_escape_external_fields;


### PR DESCRIPTION
## What

#27288 made a comment on your own post wake you. The row it woke you with did
not say **who** commented, or one word of **what** they said.

The observation already resolves both. `check_self_comment_status` answers
`` `Never `` for the author of a post — they are the one participant who never
commented on their own thread — and that branch fills the fields:

```ocaml
(* keeper_world_observation.ml, Board_comment_added *)
| Board_signal.Available `Never ->
  Ok (false, 1, Some signal.author, Some (short_preview ~max_len:60 signal.content))
     ↑ self_commented = false
```

The renderer then gated the content on `self_commented`, which is false for
exactly that case:

```ocaml
if event.self_commented && event.new_external_since > 0 then
  ... latest_external_author, latest_external_preview
else fields          (* ← the author lands here *)
```

So the author got a wake, a `post_id`, and a preview of **their own post**.
Finding out what was actually said cost a `masc_board_post_get`.

## Change

`new_replies_since_own` keeps its condition. Its name counts replies arriving
after this Keeper's own comment, and the author has no own comment to count
from — stating it there would be false, not merely absent. The two content
fields follow the data instead of the count's condition.

Nothing new is computed and no field is invented; two values already carried in
`pending_board_event` stop being dropped at the render boundary. Same shape as
#27288 (`Comment_on_self_post`) and #27289 (`replies` / `votes`).

## Tests

Two cases in `test_keeper_unified_verification_surface`, which CI runs
(`Run keeper unified verification surface and schedule wiring suites`,
ci.yml:1380):

| case | asserts |
|---|---|
| a comment on your own post says who and what | commenter named, their words present, **and** no `new_replies_since_own` — the count must not appear where it would be false |
| a reply after your own comment still counts | `new_replies_since_own="2"` and the commenter still named — the participant path is unchanged |

Verified they are not identities: with the tests in place and
`lib/keeper/keeper_unified_prompt.ml` reverted to `origin/main`,

```
1 failure! in 32 tests run
[FAIL] verification_surface 25  prompt: a comment on your own post says who...
```

exactly the author-case test fails; the participant-case test passes both ways,
which is what makes it a regression guard rather than a restatement.

## Verification

```
dune build --root . @check                                          exit 0
dune build --root . @test/runtest-test_keeper_unified_verification_surface
                                              Test Successful, 32 tests run
```

RFC-WAIVED: a render-boundary fix completing #27288. No new field, no new tool,
no schema change, no gate.
