### PR TITLE
fix(test): generate a timestamp the field can actually hold, and run the suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1538,7 +1538,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_dashboard_persona_name @test/runtest-test_dashboard_briefing @test/runtest-test_keeper_model_input_demotion @test/runtest-test_tool_type_label @test/runtest-test_verification_authority_tools"
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_dashboard_persona_name @test/runtest-test_dashboard_briefing @test/runtest-test_keeper_model_input_demotion @test/runtest-test_tool_type_label @test/runtest-test_telemetry_eio_pbt @test/runtest-test_verification_authority_tools"
 
       - name: Run transport harness suite
         id: transport_harness_suite

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -88,7 +88,7 @@ echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, al
 # authority tools, memory journal) without lowering the baseline. A PR that
 # wires a suite must lower this number in the same PR, or this check goes red
 # for everyone.
-UNWIRED_BASELINE=737
+UNWIRED_BASELINE=734
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/test/test_telemetry_eio_pbt.ml
+++ b/test/test_telemetry_eio_pbt.ml
@@ -97,9 +97,20 @@ let gen_event : Telemetry_eio.event QCheck.Gen.t =
         (Telemetry_eio.Tool_assigned
            { agent_id; profile; tool_count; assignment_id })
 
+(* [event_record.timestamp] is unix seconds. [QCheck.Gen.float] spans the whole
+   double range including nan and the infinities, and nan does not survive a
+   JSON round-trip — it has no literal, and [nan = nan] is false either way. So
+   the round-trip property failed on roughly one seed in three, on whichever
+   variant the generator happened to pick. Generating what the field actually
+   holds makes the property state something true. *)
+let earliest_timestamp = 0.0
+
+(* 2100-01-01T00:00:00Z — past any real record, still exactly representable. *)
+let latest_timestamp = 4_102_444_800.0
+
 let gen_record : Telemetry_eio.event_record QCheck.Gen.t =
   let open QCheck.Gen in
-  let* timestamp = float in
+  let* timestamp = float_range earliest_timestamp latest_timestamp in
   let* event = gen_event in
   return Telemetry_eio.{ timestamp; event }
 


### PR DESCRIPTION
#27300 을 닫는다.

## 문제

`Telemetry_eio JSON round-trip` 프로퍼티가 **시드에 따라 실패한다.**

```ocaml
let* timestamp = float in
```

`QCheck.Gen.float` 은 double 전 범위를 낸다 — `nan` 과 무한대를 포함한다. `nan` 은 JSON 리터럴이 없고, 실렸다 해도 `nan = nan` 이 `false` 라 왕복 비교가 성립할 수 없다.

main 에서 3 회 실행한 실측:

| run | seed | 결과 |
|---|---|---|
| 1 | 270919760 | pass |
| 2 | 615850644 | **fail** (`timestamp = nan`) |
| 3 | 518815899 | pass |

실패 표본이 `Task_started` 에서도 `Tool_called` 에서도 나왔다 — 이벤트 variant 와 무관하고, 원인은 `timestamp` 하나다.

## 무엇으로 바꿨나

`event_record.timestamp` 는 **unix 초**다. 그 필드가 실제로 담는 값을 생성한다.

```ocaml
let earliest_timestamp = 0.0
(* 2100-01-01T00:00:00Z — 실제 레코드보다 뒤, 여전히 정확히 표현 가능 *)
let latest_timestamp = 4_102_444_800.0

let* timestamp = float_range earliest_timestamp latest_timestamp in
```

`nan` 만 걸러내는 필터가 아니라 범위를 준 이유는, 지금 프로퍼티가 "어떤 double 이든 왕복한다"고 주장하는데 **그건 사실이 아니고 사실일 필요도 없기** 때문이다. 필드가 무엇인지를 제너레이터가 말하게 하는 편이 낫다.

**서로 다른 시드 8 회 연속 통과**를 확인했다 (283771201, 189558438, 297392616, 966856789, 372561501, 425996280, 159848397, 670607115).

## 배선도 함께

이 스위트는 **한 번도 실행되지 않았다.** `@check` 로 컴파일만 되고 `ci.yml` 에 `@test/runtest-` 타깃이 없었다. 고쳐도 CI 가 안 돌리면 다음 회귀를 또 못 본다.

`ci.yml` 에 추가하고 `UNWIRED_BASELINE` 을 현재 값(734)으로 내려 얻은 지점을 고정했다. 스위트는 0.001s 로 끝난다.

## 사전 실패에 대해

`verify-test-registration.py` 는 이 브랜치에서도 `test_task_completion_claim` 1 건으로 실패한다. **main 의 기존 결함**이며 #27345 가 고친다. 이 PR 과 무관하다.

## 검증

`audit-ci-test-targets.sh` → `OK - 734 suites unwired, at baseline`.
`test_telemetry_eio_pbt` 3 프로퍼티, 8 시드 전부 통과.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
