### PR TITLE
fix(prompt): a submitted task is not called held

### DIFF
--- a/config/prompts/keeper.md
+++ b/config/prompts/keeper.md
@@ -114,11 +114,8 @@ a claim on another is refused and names both the Task you hold and how to hand
 it back. So pick the one you mean to work, then finish it or hand it back before
 claiming again — trying each candidate in turn only produces a run of refusals.
 
-A Task you submitted for verification is not one of those. It waits on a verdict
-you cannot produce, and it does not hold your next claim: it still shows as
-yours, and you claim the next work while it waits. Cancelling it to free
-yourself cancels the evidence you already submitted, and the verdict it was
-waiting for never lands.
+Cancelling a Task you submitted for verification cancels the evidence you
+already submitted, and the verdict it was waiting for never lands.
 
 Your goals, memory, and repositories are work surfaces of their own. The Board
 is one of several places work lives, not the register that decides whether work

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -128,8 +128,34 @@ let format_current_task_with_heading ~heading (task : Masc_domain.task) : string
     "\n";
   Buffer.contents buf
 
-let format_current_task task =
-  format_current_task_with_heading ~heading:"Current Task (held by you)" task
+(* "held by you" is true of the two statuses that actually hold a claim slot.
+   [Workspace_task.active_owned_task_ids_for_agent] counts [Claimed] and
+   [InProgress] and returns [None] for [AwaitingVerification]; the scheduler
+   states the same rule outright ("AwaitingVerification is still excluded: it is
+   no longer active implementation work for the claimant").
+
+   Under the old single heading a submitted task read as one the Keeper was
+   still holding, and the only visible way out of holding something is to give
+   it up. 10 of 56 cancellations in the live backlog are finished work cancelled
+   with the deliverable written into the cancel reason -- task-032 says
+   "useYupValidationResolver typed properly, tsc passes. Cancelling to free",
+   naming the belief in the act of acting on it. The claim it was freeing itself
+   for was never blocked.
+
+   The heading is the whole fix: no new field, no new line, and the status was
+   already on the row underneath. *)
+let format_current_task (task : Masc_domain.task) =
+  let heading =
+    match task.Masc_domain.task_status with
+    | Masc_domain.AwaitingVerification _ ->
+      "Current Task (submitted for verification; it does not hold your claim)"
+    | Masc_domain.Claimed _
+    | Masc_domain.InProgress _
+    | Masc_domain.Todo
+    | Masc_domain.Done _
+    | Masc_domain.Cancelled _ -> "Current Task (held by you)"
+  in
+  format_current_task_with_heading ~heading task
 
 (** Format one conversation endpoint presence line. *)
 let format_surface_presence (p : Gate_surface.surface_presence) : string =

--- a/test/fixtures/keeper_system_prompt/assembled_prompt.golden
+++ b/test/fixtures/keeper_system_prompt/assembled_prompt.golden
@@ -110,11 +110,8 @@ a claim on another is refused and names both the Task you hold and how to hand
 it back. So pick the one you mean to work, then finish it or hand it back before
 claiming again — trying each candidate in turn only produces a run of refusals.
 
-A Task you submitted for verification is not one of those. It waits on a verdict
-you cannot produce, and it does not hold your next claim: it still shows as
-yours, and you claim the next work while it waits. Cancelling it to free
-yourself cancels the evidence you already submitted, and the verdict it was
-waiting for never lands.
+Cancelling a Task you submitted for verification cancels the evidence you
+already submitted, and the verdict it was waiting for never lands.
 
 Your goals, memory, and repositories are work surfaces of their own. The Board
 is one of several places work lives, not the register that decides whether work

--- a/test/test_keeper_prompt_metrics.ml
+++ b/test/test_keeper_prompt_metrics.ml
@@ -385,22 +385,25 @@ let test_system_block_states_the_collaboration_surface () =
     (has_in prompt "a claim on another is refused and names both the Task you hold");
   check bool "walking the candidate list is named as the wrong move" true
     (has_in prompt "trying each candidate in turn only produces a run of refusals");
-  (* That limit is narrower than it reads, and the prompt used to overstate it.
-     [active_owned_task_ids_for_agent] matches Claimed and InProgress only and
-     answers None for AwaitingVerification, so a submitted Task does not refuse
-     the next claim. Everything a keeper can see says otherwise: the world frame
-     renders it under "Current Task (held by you)", and the lifecycle refuses
-     Release from AwaitingVerification while admitting Cancel by the assignee,
-     so the only exit in view is the one that discards its own evidence. Live
-     workspace: of 56 cancelled tasks 10 had already written a verification
-     record, and task-128 states the belief in words -- "awaiting_verification
-     blocks claim". It does not. Pin the correction against silent widening. *)
-  check bool "a submitted Task is stated not to hold the next claim" true
-    (has_in prompt "A Task you submitted for verification is not one of those");
-  check bool "claiming while a verdict is pending is stated as available" true
-    (has_in prompt "you claim the next work while it waits");
+  (* That limit is narrower than it reads. [active_owned_task_ids_for_agent]
+     matches Claimed and InProgress only and answers None for
+     AwaitingVerification, so a submitted Task does not refuse the next claim.
+     Live workspace: of 56 cancelled tasks 10 had already written a verification
+     record, and task-032 states the belief in the act of acting on it --
+     "useYupValidationResolver typed properly, tsc passes. Cancelling to free".
+
+     Two sentences used to carry the correction here, and they existed because
+     the world frame contradicted them one heading away: it rendered a submitted
+     Task under "Current Task (held by you)". The heading now states the status
+     it is describing, so the correction is made where the claim was made and
+     the prose no longer restates it. What stays in prose is the consequence a
+     heading cannot carry — that cancelling discards evidence already submitted.
+     The heading itself is pinned in test_keeper_wake_turn_context, which builds
+     a Task in each status and reads the rendered frame. *)
   check bool "cancelling submitted work is named as evidence loss" true
     (has_in prompt "cancels the evidence you already submitted");
+  check bool "the correction it replaced is not restated in prose" false
+    (has_in prompt "A Task you submitted for verification is not one of those");
   (* Release exists under the other namespace: keeper_task_claim /
      keeper_task_done / keeper_task_create sit on the keeper_* surface while
      handing a task back is masc_transition with action "release".

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -572,6 +572,52 @@ let test_preview_does_not_invent_wake_reason () =
           ~labels:[ "keeper", preview_meta.name ]
           ()))
 
+(* [Workspace_task.active_owned_task_ids_for_agent] counts Claimed and
+   InProgress and answers None for AwaitingVerification, and the scheduler says
+   so in words ("AwaitingVerification is still excluded"). The heading is the
+   one place a Keeper reads that ownership, so it must not widen the two
+   statuses that hold a claim into all of them.
+
+   Live cost of the old wording: of 56 cancelled tasks 10 had already written a
+   verification record, task-032 among them -- "useYupValidationResolver typed
+   properly, tsc passes. Cancelling to free". The claim it freed itself for was
+   never blocked. *)
+let test_submitted_task_heading_does_not_claim_a_hold () =
+  let task =
+    make_task
+      ~task_status:
+        (Masc_domain.AwaitingVerification
+           { assignee = "wake-context-keeper"
+           ; started_at = "2026-07-07T01:00:00Z"
+           ; submitted_at = "2026-07-07T02:00:00Z"
+           ; verification_id = "vrf-task-42"
+           })
+      ()
+  in
+  let user = user_message ~current_task:task base_observation in
+  check bool "not called held" false
+    (contains ~needle:"Current Task (held by you)" user);
+  check bool "the heading states what it is instead" true
+    (contains
+       ~needle:"### Current Task (submitted for verification; it does not hold your claim)"
+       user);
+  check bool "the row still carries the task" true
+    (contains ~needle:"- task-42 — Wire the wake-turn context" user);
+  check bool "and its status" true
+    (contains ~needle:"awaiting verification (submitted 2026-07-07T02:00:00Z)" user)
+
+let test_in_progress_task_heading_still_says_held () =
+  let task =
+    make_task
+      ~task_status:
+        (Masc_domain.InProgress
+           { assignee = "wake-context-keeper"; started_at = "2026-07-07T01:00:00Z" })
+      ()
+  in
+  let user = user_message ~current_task:task base_observation in
+  check bool "a task actually held is still called held" true
+    (contains ~needle:"### Current Task (held by you)" user)
+
 (* --- 3. Goal titles + self-direction parity --- *)
 
 let test_goal_summaries_render_titles () =
@@ -680,6 +726,13 @@ let () =
             test_bootstrap_stimulus_keeps_reactive_post_action;
           test_case "preview invents no wake reason" `Quick
             test_preview_does_not_invent_wake_reason;
+        ] );
+      ( "current task heading states the status",
+        [
+          test_case "a submitted task is not called held" `Quick
+            test_submitted_task_heading_does_not_claim_a_hold;
+          test_case "an in-progress task is still called held" `Quick
+            test_in_progress_task_heading_still_says_held;
         ] );
       ( "goal titles and parity directive",
         [


### PR DESCRIPTION
## What

The world frame called every current task **"held by you"**, including one
already submitted for verification. The claim path does not agree:

```ocaml
(* workspace_task_claim.ml — active_owned_task_ids_for_agent *)
| Claimed { assignee; _ } | InProgress { assignee; _ } when same_actor -> Some task.id
| Todo | Claimed _ | InProgress _ | AwaitingVerification _ | Done _ | Cancelled _ -> None
```

and the scheduler says it in words:

> AwaitingVerification is still excluded: it is no longer active implementation
> work for the claimant.

## The cost, measured

The only visible way out of holding something is to give it up. In the live
backlog, **10 of 56 cancellations had already written a verification record** —
finished work, cancelled, with the deliverable typed into the cancel reason:

```
task-031  "6 barrel lodash imports converted to tree-shakeable path imports, tsc ..."
task-032  "useYupValidationResolver typed properly, tsc passes. Cancelling to free"
task-129  "Removed dead ___unused-stamp-handler___ (175 lines) from handlers.ts."
task-126  "Audit complete — no duplicate API calls found"
```

`task-032` names the belief in the act of acting on it. The claim it was freeing
itself for was never blocked.

## The prompt gets smaller, not larger

Two sentences of `keeper.md` already carried this correction. They existed
because the heading contradicted them one section away — the paragraph literally
described the wrong label ("it still shows as yours"):

```diff
-A Task you submitted for verification is not one of those. It waits on a verdict
-you cannot produce, and it does not hold your next claim: it still shows as
-yours, and you claim the next work while it waits. Cancelling it to free
-yourself cancels the evidence you already submitted, and the verdict it was
-waiting for never lands.
+Cancelling a Task you submitted for verification cancels the evidence you
+already submitted, and the verdict it was waiting for never lands.
```

The correction now happens where the claim is made — in the heading, next to the
status line that was already there. What stays in prose is the one part a
heading cannot carry: that cancelling discards submitted evidence.

Five lines to two, and no fact lost.

## Tests

Both suites run in CI (`Run keeper prompt and tool-bundle contract suites`
ci.yml:1511, `Run keeper prompt assembly suites`).

| suite | case |
|---|---|
| `test_keeper_wake_turn_context` | a submitted task is not called held — asserts the new heading **and** that "held by you" is absent, plus the row and status line survive |
| | an in-progress task is still called held — the two statuses that do hold a claim are unchanged |
| `test_keeper_prompt_metrics` | the removed sentence is asserted **absent**, so prose cannot creep back in beside the heading |

Verified they are not identities: with the tests in place and both
`keeper_unified_prompt.ml` and `keeper.md` reverted to `origin/main`, exactly one
case fails in each suite — the heading case and the prose case.

## Verification

```
dune build --root . @check                                            exit 0
@test/runtest-test_keeper_wake_turn_context      17 tests, Successful
@test/runtest-test_keeper_prompt_metrics         22 tests, Successful
```

RFC-WAIVED: a heading is corrected to match the claim rule the code already
implements, and prose that compensated for it is removed. No behaviour change,
no new field, no gate.
