### PR TITLE
feat(keeper): separate in-flight observation from provider-call deadline (#27349)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1466,7 +1466,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          request_cap_targets="@test/runtest-test_runtime_config_validity @test/runtest-test_keeper_turn_driver_failover @test/runtest-test_keeper_turn_driver_accept @test/runtest-test_keeper_vision_tool @test/runtest-test_runtime_modality_reroute @test/runtest-test_runtime_model_input_tail_window @test/runtest-test_keeper_context_overflow_shrink"
+          request_cap_targets="@test/runtest-test_runtime_config_validity @test/runtest-test_keeper_turn_driver_failover @test/runtest-test_keeper_turn_driver_accept @test/runtest-test_keeper_vision_tool @test/runtest-test_runtime_modality_reroute @test/runtest-test_runtime_model_input_tail_window @test/runtest-test_keeper_context_overflow_shrink @test/runtest-test_keeper_provider_call_deadline @test/runtest-test_keeper_runtime_resolved_observability"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${request_cap_targets}"
 
       - name: Run operator control suite

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,7 +14,7 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 203 unique knobs across 8 modules.
+**Total**: 204 unique knobs across 8 modules.
 
 **Typed getter classification**: 37/116 tagged (`operator`: 37, `algorithm`: 0, `unclassified`: 79).
 
@@ -46,17 +46,17 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_TEST_ALLOW_HOME_BASE_PATH` | string_literal | n/a | n/a | 418 | #9903: production base-path safeguard for test executables. Without this, a test whose [MASC_BASE_PATH] override fail... |
 | `MASC_URL` | string_literal | n/a | n/a | 291 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 
-## Env_config_keeper (38 knobs; typed classification 20/31)
+## Env_config_keeper (39 knobs; typed classification 20/31)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 575 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 615 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
 | `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 509 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | feature_flag | n/a | n/a | 19 | Enable startup keeper bootstrap scan |
 | `MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC` | typed:float | unclassified | unclassified | 32 | Polling interval (seconds) for the lazy-startup wait loop in [server_bootstrap_loops.ml]. The autoboot fiber wakes up... |
 | `MASC_KEEPER_BOOTSTRAP_LISTENER_RETRY_INTERVAL_SEC` | typed:float | unclassified | unclassified | 44 | Polling interval (seconds) for the keeper-lifecycle listener retry loop in [server_bootstrap_loops.ml]. After a liste... |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 56 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
-| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 541 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 581 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
 | `MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT` | typed:int | Runtime | operator | 258 | Default item limit for [GET /keepers/:name/compaction-snapshots]. Default: 25. @category Runtime @ops_class operator |
 | `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER` | typed:int | Runtime | operator | 284 | Multiplier from requested item limit to manifest files scanned. Default: 4. @category Runtime @ops_class operator |
 | `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES` | typed:int | Runtime | operator | 274 | Minimum manifest files scanned before applying [limit * multiplier]. Default: 8. @category Runtime @ops_class operator |
@@ -67,7 +67,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_GENERATED_MEDIA_DIR_MAX_BYTES` | typed:int | Policies | operator | 372 | Maximum total bytes retained in [<masc_dir>/media] after opportunistic cleanup. Default is 500 MiB. Range: [1, 5 GiB]... |
 | `MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES` | typed:int | Policies | operator | 361 | Maximum raw generated-media bytes accepted by the durable store and serve route. Default is 10 MiB. Range: [1, 50 MiB... |
 | `MASC_KEEPER_GENERATED_MEDIA_RETENTION_SEC` | typed:float | Policies | operator | 383 | Maximum generated-media file age retained by opportunistic cleanup. Default is 24 hours. Range: [1 second, 30 days]. ... |
-| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 554 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
+| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 594 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
 | `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | Thresholds | operator | 395 | Shared keepalive interval, read early so WorkAsHeartbeat can reference it. Any positive interval is valid; the schedu... |
 | `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 416 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
 | `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | string_literal | n/a | n/a | 174 |  |
@@ -77,9 +77,10 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_MEMORY_OS_RECALL_FACTS_MAX_BYTES` | typed:int | Policies | operator | 241 | Maximum UTF-8 bytes for the exact rendered fact lines injected by recall. The Librarian owns selection within this ca... |
 | `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | unclassified | unclassified | 64 | Maximum metrics file size in bytes before rotation (default: 10MB) |
 | `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | unclassified | unclassified | 67 | Number of rotated files to keep (default: 1, i.e. .1 only) |
+| `MASC_KEEPER_PROVIDER_CALL_DEADLINE_SEC` | string_literal | Timeouts | operator | 548 | Total wall-clock deadline for a single provider call attempt (whole operation, independent of streaming progress) —... |
 | `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | Thresholds | operator | 458 | Interruptible sleep chunk size in seconds: the upper bound on how long a keeper's heartbeat sleep takes to notice a w... |
 | `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 145 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
-| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 564 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
+| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 604 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
 | `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | string_literal | n/a | n/a | 469 |  |
 | `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 322 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
 | `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 332 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -514,6 +514,46 @@ module KeeperKeepalive = struct
     | None -> None
   ;;
 
+  (** Total wall-clock deadline for a single provider call attempt (whole
+      operation, independent of streaming progress) — distinct from
+      [stream_idle_timeout_sec] (bounds the GAP between streamed lines, and
+      per RFC-0345 falls back to a 600s failsafe floor when unset) and
+      [body_timeout_sec_override] (non-streaming calls only, no failsafe).
+      Neither narrower knob bounds a call stuck before its first token
+      (Admission/Queue/pre-stream phases) or a non-streaming call left
+      unconfigured, which is exactly the gap #27349 measured: 4 keepers
+      in-flight 25+ minutes with neither narrower knob set.
+
+      Opt-in: unset env leaves [None] so the provider-attempt caller skips
+      the [Eio.Time.with_timeout_exn] wrap and the call runs unbounded,
+      same as before this knob existed. Deliberately NO failsafe floor
+      (unlike [stream_idle_timeout_sec]'s RFC-0345 fallback): a reasonable
+      total-call ceiling depends on provider and workload (tool-heavy turns
+      legitimately run minutes between chunks), so MASC does not guess one.
+      The operator sets it from measured turn durations.
+
+      On expiry the caller classifies the failure as the existing typed
+      [Api (Timeout { phase = Some Wall_clock })] and routes it through the
+      existing declared-lane rotation — no new recovery mechanism.
+
+      Range when set: [30, 3600] — wider than [body_timeout_sec_override]'s
+      [10, 600] on purpose: this bounds an entire agentic turn's provider
+      call, not one HTTP body read.
+
+      Env: [MASC_KEEPER_PROVIDER_CALL_DEADLINE_SEC]. Default: unset -> [None].
+      @category Timeouts
+      @ops_class operator *)
+  let provider_call_deadline_sec_override =
+    match
+      Env_config_core.raw_value_opt "MASC_KEEPER_PROVIDER_CALL_DEADLINE_SEC"
+    with
+    | Some raw ->
+      (match Float.of_string_opt (String.trim raw) with
+       | Some v -> Some (Float.max 30.0 (Float.min 3600.0 v))
+       | None -> None)
+    | None -> None
+  ;;
+
   (* [@warning "-32"] below: this binding has no OCaml caller — the live read is
      [Keeper_runtime_resolved.cli_subprocess_idle_sec], which re-reads the env var
      per turn. It survives as the knob's declaration for [bin/env_knob_catalog.ml],

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -165,6 +165,15 @@ module KeeperKeepalive : sig
 
       Env: [MASC_KEEPER_BODY_TIMEOUT_SEC]. Clamp range: [10, 600] s. *)
 
+  val provider_call_deadline_sec_override : float option
+  (** Total wall-clock deadline for one provider call attempt, independent
+      of streaming progress and covering both streaming and non-streaming
+      calls (#27349). [None] (env unset) means no MASC-side enforcement;
+      deliberately no failsafe floor, unlike {!stream_idle_timeout_sec}'s
+      RFC-0345 fallback.
+
+      Env: [MASC_KEEPER_PROVIDER_CALL_DEADLINE_SEC]. Clamp range: [30, 3600] s. *)
+
 end
 
 (** {1 gRPC heartbeat reconnect} *)

--- a/lib/keeper/keeper_heartbeat_loop_in_turn_pulse.ml
+++ b/lib/keeper/keeper_heartbeat_loop_in_turn_pulse.ml
@@ -64,9 +64,59 @@ let with_in_turn_liveness_pulse_for_test ~sw:_sw ~clock ~interval_sec ~tick f =
       Printexc.raise_with_backtrace exn backtrace)
 ;;
 
+(* #27349: raw elapsed-time facts about the current turn, carried without any
+   threshold or judgment -- the SSE payload and the two gauges below expose
+   [in_flight_elapsed_ms]/[since_last_progress_ms] verbatim on every pulse
+   tick (5-30s) while a turn is executing. Nothing here decides "stuck";
+   consumers do (the operator dashboard live, and eventually #27323's
+   supervision seat reading the gauge series). [started_at]/[last_progress_at]
+   already exist on every [turn_observation] (stamped by
+   [Keeper_registry.stamp_turn_progress] on every progress event) but were
+   previously read only for dashboard JSON display -- nothing computed or
+   surfaced the elapsed deltas that would have shown "4 keepers in-flight
+   25min, progress 0" instead of a heartbeat pulse that just says "alive". *)
+let elapsed_ms ~now_ts ~since = Float.max 0.0 ((now_ts -. since) *. 1000.0)
+
+let in_flight_elapsed_ms ~now_ts ~started_at = elapsed_ms ~now_ts ~since:started_at
+
+let since_last_progress_ms ~now_ts ~last_progress_at =
+  elapsed_ms ~now_ts ~since:last_progress_at
+;;
+
+let record_in_flight_elapsed_gauges
+      ~(meta : keeper_meta)
+      ~now_ts
+      ~(obs : Keeper_registry_types.turn_observation)
+  =
+  let labels = [ "keeper", meta.name ] in
+  Otel_metric_store.register_gauge
+    ~name:Keeper_metrics.(to_string InFlightElapsedSeconds)
+    ~help:"Wall-clock seconds since the current turn started. No threshold: \
+           a supervising consumer judges staleness against progress, not \
+           against this value alone."
+    ~labels
+    ();
+  Otel_metric_store.set_gauge
+    Keeper_metrics.(to_string InFlightElapsedSeconds)
+    ~labels
+    (in_flight_elapsed_ms ~now_ts ~started_at:obs.started_at /. 1000.0);
+  Otel_metric_store.register_gauge
+    ~name:Keeper_metrics.(to_string SinceLastProgressSeconds)
+    ~help:"Wall-clock seconds since the current turn's last recorded \
+           progress event. No threshold: a long-running turn that keeps \
+           progressing stays near zero; a stalled provider call grows \
+           unbounded."
+    ~labels
+    ();
+  Otel_metric_store.set_gauge
+    Keeper_metrics.(to_string SinceLastProgressSeconds)
+    ~labels
+    (since_last_progress_ms ~now_ts ~last_progress_at:obs.last_progress_at /. 1000.0)
+;;
+
 let emit_in_turn_liveness_pulse ~(ctx : _ context) ~(meta : keeper_meta) =
   match Keeper_registry.get ~base_path:ctx.config.base_path meta.name with
-  | Some entry when Option.is_some entry.current_turn_observation ->
+  | Some { current_turn_observation = Some obs; _ } ->
     (try
        let _heartbeat = Workspace.heartbeat ctx.config ~agent_name:meta.agent_name in
        ()
@@ -82,6 +132,13 @@ let emit_in_turn_liveness_pulse ~(ctx : _ context) ~(meta : keeper_meta) =
          ~labels:[ "keeper", meta.name; "phase", "in_turn_heartbeat" ]
          ());
     let now_ts = Time_compat.now () in
+    (try record_in_flight_elapsed_gauges ~meta ~now_ts ~obs with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
+       Log.Keeper.warn
+         "in-turn elapsed gauges failed for %s: %s"
+         meta.name
+         (Printexc.to_string exn));
     (try
        let json =
          `Assoc
@@ -91,6 +148,10 @@ let emit_in_turn_liveness_pulse ~(ctx : _ context) ~(meta : keeper_meta) =
            ; "ts_unix", `Float now_ts
            ; "phase", `String "turn_running"
            ; "in_turn", `Bool true
+           ; "in_flight_elapsed_ms",
+             `Float (in_flight_elapsed_ms ~now_ts ~started_at:obs.started_at)
+           ; "since_last_progress_ms",
+             `Float (since_last_progress_ms ~now_ts ~last_progress_at:obs.last_progress_at)
            ]
        in
        Sse.broadcast json;

--- a/lib/keeper/keeper_heartbeat_loop_in_turn_pulse.mli
+++ b/lib/keeper/keeper_heartbeat_loop_in_turn_pulse.mli
@@ -6,6 +6,16 @@ open Keeper_types_profile
 
 val in_turn_liveness_pulse_interval_sec : unit -> float
 
+val in_flight_elapsed_ms : now_ts:float -> started_at:float -> float
+(** #27349: raw milliseconds since the turn started, floored at 0. No
+    threshold -- a consumer (dashboard, future supervision seat) judges
+    staleness; this only reports the fact. *)
+
+val since_last_progress_ms : now_ts:float -> last_progress_at:float -> float
+(** #27349: raw milliseconds since the turn's last recorded progress event,
+    floored at 0. A turn making steady progress stays near zero even when
+    long-running; a stalled provider call grows unbounded. *)
+
 val with_in_turn_liveness_pulse_for_test :
   sw:Eio.Switch.t ->
   clock:_ Eio.Time.clock ->

--- a/lib/keeper/keeper_runtime_resolved.ml
+++ b/lib/keeper/keeper_runtime_resolved.ml
@@ -12,6 +12,7 @@ type 'a field = {
 type t = {
   stream_idle_timeout_sec : float option field;
   body_timeout_override_sec : float option field;
+  provider_call_deadline_sec : float option field;
 }
 
 (** Exhaustive boundary for the labels emitted by
@@ -62,6 +63,21 @@ let body_timeout_override_sec_live () =
        | None -> None)
   | None -> None
 
+(* SSOT: Env_config_keeper.KeeperKeepalive.provider_call_deadline_sec_override
+   (same env var, same clamp [30, 3600]). Opt-in: unset -> None, no failsafe
+   floor (#27349 -- deliberately different from stream_idle_timeout_sec's
+   RFC-0345 fallback below: a total-call ceiling depends on provider and
+   workload, so MASC does not substitute a guessed value). *)
+let provider_call_deadline_sec_live () =
+  match
+    Env_config_core.raw_value_opt "MASC_KEEPER_PROVIDER_CALL_DEADLINE_SEC"
+  with
+  | Some raw ->
+      (match Float.of_string_opt (String.trim raw) with
+       | Some v -> Some (Float.max 30.0 (Float.min 3600.0 v))
+       | None -> None)
+  | None -> None
+
 (* Fail-safe liveness floor for the streaming inter-line idle timeout
    (seconds). When neither [MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC] nor runtime.toml
    [turn.stream_idle_timeout_sec] is set, the resolved value would be [None] and
@@ -99,9 +115,16 @@ let freeze_from_current () =
       source = source_of_env_name "MASC_KEEPER_BODY_TIMEOUT_SEC";
     }
   in
+  let provider_call_deadline_sec =
+    {
+      value = provider_call_deadline_sec_live ();
+      source = source_of_env_name "MASC_KEEPER_PROVIDER_CALL_DEADLINE_SEC";
+    }
+  in
   {
     stream_idle_timeout_sec;
     body_timeout_override_sec;
+    provider_call_deadline_sec;
   }
 
 let frozen : t option Atomic.t = Atomic.make None
@@ -135,6 +158,7 @@ let to_yojson (runtime : t) =
     [
       ("stream_idle_timeout_sec", field_to_yojson option_float_to_yojson runtime.stream_idle_timeout_sec);
       ("body_timeout_override_sec", field_to_yojson option_float_to_yojson runtime.body_timeout_override_sec);
+      ("provider_call_deadline_sec", field_to_yojson option_float_to_yojson runtime.provider_call_deadline_sec);
     ]
 
 let stream_idle_timeout_sec () =
@@ -142,3 +166,6 @@ let stream_idle_timeout_sec () =
 
 let body_timeout_override_sec () =
   (current ()).body_timeout_override_sec.value
+
+let provider_call_deadline_sec () =
+  (current ()).provider_call_deadline_sec.value

--- a/lib/keeper/keeper_runtime_resolved.mli
+++ b/lib/keeper/keeper_runtime_resolved.mli
@@ -28,6 +28,7 @@ type 'a field = {
 type t = {
   stream_idle_timeout_sec : float option field;
   body_timeout_override_sec : float option field;
+  provider_call_deadline_sec : float option field;
 }
 
 val init : unit -> unit
@@ -68,6 +69,16 @@ val stream_idle_timeout_sec : unit -> float option
 
     SSOT: {!Env_config_keeper.KeeperKeepalive.body_timeout_sec_override}. *)
 val body_timeout_override_sec : unit -> float option
+
+(** Total wall-clock deadline for one provider call attempt (#27349).
+    [None] (env unset) means no MASC-side enforcement -- the provider
+    attempt caller skips the [Eio.Time.with_timeout_exn] wrap and runs
+    unbounded, same as before this knob existed. Deliberately no failsafe
+    floor: unlike [stream_idle_timeout_sec], a reasonable total-call
+    ceiling depends on provider and workload, so MASC does not guess one.
+
+    SSOT: {!Env_config_keeper.KeeperKeepalive.provider_call_deadline_sec_override}. *)
+val provider_call_deadline_sec : unit -> float option
 
 (** CLI subprocess stdout-idle timeout, read fresh per turn from
     [MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC] and clamped to [10, 600].

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -726,6 +726,8 @@ let run_named
             ; model_input_projection
             ; stream_idle_timeout_s
             ; body_timeout_s
+            ; provider_call_deadline_sec =
+                Keeper_runtime_resolved.provider_call_deadline_sec ()
             ; temperature
             ; accept
             ; hooks

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -44,6 +44,14 @@ type try_provider_ctx =
   ; model_input_projection : Agent_sdk.Agent.model_input_projection option
   ; stream_idle_timeout_s : float option
   ; body_timeout_s : float option
+  ; (* #27349: total wall-clock ceiling for THIS provider call attempt,
+       independent of streaming progress -- distinct from
+       [stream_idle_timeout_s] (inter-line gap) and [body_timeout_s]
+       (non-streaming body read only). [None] (the operator has not set
+       [MASC_KEEPER_PROVIDER_CALL_DEADLINE_SEC]) means no MASC-side
+       enforcement; the call runs exactly as it did before this field
+       existed. See [run_try_provider]'s use of [Eio.Time.with_timeout_exn]. *)
+    provider_call_deadline_sec : float option
   ; temperature : float option
   ; accept : Agent_sdk_response.api_response -> bool
   ; hooks : Agent_sdk.Hooks.hooks option
@@ -584,7 +592,11 @@ let run_try_provider
   | Ok config ->
     (* Explicit stream stall detection is handled by OAS's
        [stream_idle_timeout_s]; [None] deliberately leaves it disabled.
-       No separate liveness FSM — provider stall is an OAS-level concern.
+       No separate liveness FSM for the common case — provider stall is
+       primarily an OAS-level concern. #27349: when the operator has set
+       [ctx.provider_call_deadline_sec], the wrap below adds a total
+       wall-clock ceiling on this whole attempt as a MASC-side backstop —
+       still opt-in, off by default, same as before this existed.
        No per-lane capacity gate — provider load is managed by operator
        adjusting keeper count. *)
     let run_started_at =
@@ -592,7 +604,7 @@ let run_try_provider
       (* NDT-OK: provider-attempt latency telemetry only; dispatch/control
          decisions do not branch on this timestamp. *)
     in
-    let result =
+    let run_attempt_switch () =
       Eio.Switch.run (fun attempt_sw ->
         let run_fn () =
           Eio_guard.check_if_ready ();
@@ -624,6 +636,37 @@ let run_try_provider
                 ctx.goal
         in
         run_fn ())
+    in
+    (* #27349: [Eio.Time.with_timeout]'s own signature requires a
+       polymorphic-variant error row ([> `Timeout]), which
+       [run_attempt_switch]'s concrete [Agent_sdk.Error.sdk_error] result
+       cannot unify with, so [with_timeout_exn] (raises the [Timeout]
+       exception) is the primitive that fits here — the established
+       pattern in this repo for wrapping a concretely-typed result
+       (graphql_client.ml, server_ide_lsp_proxy.ml). Catches ONLY
+       [Eio.Time.Timeout]: [Eio.Cancel.Cancelled] is never caught here, so
+       an outer cancellation (switch shutdown, etc.) propagates unmodified.
+       OAS's own internal [stream_idle_timeout_s]/[body_timeout_s] firing
+       is a typed RETURN VALUE inside [Runtime_agent.run]'s result, not a
+       raised exception, so it can never reach this handler and be
+       misclassified as this deadline firing. *)
+    let result =
+      match ctx.provider_call_deadline_sec, Eio_context.get_clock_opt () with
+      | Some deadline_sec, Some clock ->
+        (try Eio.Time.with_timeout_exn clock deadline_sec run_attempt_switch with
+         | Eio.Time.Timeout ->
+           Error
+             (Agent_sdk.Error.Api
+                (Llm_provider.Retry.Timeout
+                   { message =
+                       Printf.sprintf
+                         "provider call exceeded the configured wall-clock \
+                          deadline (%.0fs, runtime_id=%s)"
+                         deadline_sec
+                         ctx.runtime_id
+                   ; phase = Some Llm_provider.Http_client.Wall_clock
+                   })))
+      | None, _ | _, None -> run_attempt_switch ()
     in
     let result =
       match result with

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -17,6 +17,7 @@ type try_provider_ctx =
   ; model_input_projection : Agent_sdk.Agent.model_input_projection option
   ; stream_idle_timeout_s : float option
   ; body_timeout_s : float option
+  ; provider_call_deadline_sec : float option
   ; temperature : float option
   ; accept : Agent_sdk_response.api_response -> bool
   ; hooks : Agent_sdk.Hooks.hooks option

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -21,6 +21,8 @@ type t =
   | TurnCompleted
   | FailureRoute
   | IdleSeconds
+  | InFlightElapsedSeconds
+  | SinceLastProgressSeconds
   | StreamProjectionEventCutoff
   | MetricEmitDropped
   | ContextMaxObserved
@@ -224,6 +226,8 @@ let to_string = function
   | TurnCompleted -> "masc_keeper_turn_completed_total"
   | FailureRoute -> "masc_keeper_failure_route_total"
   | IdleSeconds -> "masc_keeper_idle_seconds"
+  | InFlightElapsedSeconds -> "masc_keeper_in_flight_elapsed_seconds"
+  | SinceLastProgressSeconds -> "masc_keeper_since_last_progress_seconds"
   | StreamProjectionEventCutoff ->
     "masc_keeper_stream_projection_event_cutoff_total"
   | MetricEmitDropped -> "masc_keeper_metric_emit_dropped_total"

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -12,6 +12,8 @@ type t =
   | TurnCompleted
   | FailureRoute
   | IdleSeconds
+  | InFlightElapsedSeconds
+  | SinceLastProgressSeconds
   | StreamProjectionEventCutoff
   | MetricEmitDropped
   | ContextMaxObserved

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -88,7 +88,7 @@ echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, al
 # authority tools, memory journal) without lowering the baseline. A PR that
 # wires a suite must lower this number in the same PR, or this check goes red
 # for everyone.
-UNWIRED_BASELINE=737
+UNWIRED_BASELINE=734
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/test/dune
+++ b/test/dune
@@ -220,6 +220,7 @@
   test_keeper_unified_claim_progress
   test_keeper_unified_context_overflow
   test_keeper_context_overflow_shrink
+  test_keeper_provider_call_deadline
   test_keeper_failed_selection_disposition
   test_keeper_invalid_request_auto_recover
   test_keeper_surface_post
@@ -520,6 +521,7 @@
   test_keeper_unified_claim_progress
   test_keeper_unified_context_overflow
   test_keeper_context_overflow_shrink
+  test_keeper_provider_call_deadline
   test_keeper_failed_selection_disposition
   test_keeper_invalid_request_auto_recover
   test_keeper_surface_post

--- a/test/test_keeper_provider_call_deadline.ml
+++ b/test/test_keeper_provider_call_deadline.ml
@@ -1,0 +1,144 @@
+(** Tests for #27349 -- provider-call wall-clock deadline + in-flight
+    elapsed-time observation.
+
+    Two units, both pure and Eio-free:
+
+    - {!Masc.Keeper_heartbeat_loop_in_turn_pulse.in_flight_elapsed_ms} /
+      [since_last_progress_ms]: the raw elapsed-time facts the heartbeat
+      pulse carries every tick. No threshold lives in these functions --
+      they only compute a delta, floored at zero for clock-skew safety.
+    - The synthetic [Api (Timeout { phase = Some Wall_clock })] value that
+      [Keeper_turn_driver_try_provider.run_try_provider] constructs when the
+      operator-configured deadline fires: this proves (not just documents)
+      that it joins the EXISTING declared-lane candidate rotation
+      ([Runtime_attempt_fsm.should_try_next]) and the EXISTING post-hoc
+      provider-timeout observation channel
+      ([Keeper_provider_runtime_boundary.is_provider_timeout_error]) without
+      any change to either classifier.
+
+    The Eio.Time.with_timeout_exn wrap itself has no unit fixture, matching
+    this file's existing coverage boundary (no test calls [run_try_provider]
+    directly either -- see test_keeper_turn_driver_failover.ml for the
+    candidate-rotation layer's equivalent boundary). *)
+
+module Pulse = Masc.Keeper_heartbeat_loop_in_turn_pulse
+
+open Alcotest
+
+(* {1 in_flight_elapsed_ms / since_last_progress_ms} *)
+
+let test_in_flight_elapsed_ms_computes_delta () =
+  check (float 0.001) "12.5s since start is 12500ms" 12_500.0
+    (Pulse.in_flight_elapsed_ms ~now_ts:1_000_012.5 ~started_at:1_000_000.0)
+;;
+
+let test_in_flight_elapsed_ms_floors_at_zero () =
+  (* Clock skew or a registry read racing a fresh [started_at] stamp must
+     never report a negative "elapsed" to a consumer. *)
+  check (float 0.001) "now before started_at floors at 0" 0.0
+    (Pulse.in_flight_elapsed_ms ~now_ts:999_999.0 ~started_at:1_000_000.0)
+;;
+
+let test_since_last_progress_ms_computes_delta () =
+  check (float 0.001) "25 minutes since last progress is 1_500_000ms"
+    1_500_000.0
+    (Pulse.since_last_progress_ms ~now_ts:1_001_500.0 ~last_progress_at:1_000_000.0)
+;;
+
+let test_since_last_progress_ms_floors_at_zero () =
+  check (float 0.001) "now before last_progress_at floors at 0" 0.0
+    (Pulse.since_last_progress_ms ~now_ts:999_000.0 ~last_progress_at:1_000_000.0)
+;;
+
+let test_a_steadily_progressing_turn_stays_near_zero () =
+  (* The #27349 design point: a long-running but healthy turn (last progress
+     1s ago) reads near zero, distinguishable at a glance from a stalled one
+     (last progress unbounded minutes ago), even though both may have the
+     same large [in_flight_elapsed_ms]. *)
+  let now_ts = 1_000_002.0 in
+  let started_at = 1_000_000.0 in
+  let last_progress_at = 1_000_001.999 in
+  check (float 0.001) "in-flight elapsed is large" 2_000.0
+    (Pulse.in_flight_elapsed_ms ~now_ts ~started_at);
+  check (float 0.001) "since-last-progress stays small" 1.0
+    (Pulse.since_last_progress_ms ~now_ts ~last_progress_at)
+;;
+
+(* {1 the synthetic Wall_clock timeout joins existing paths} *)
+
+let wall_clock_timeout () =
+  Agent_sdk.Error.Api
+    (Llm_provider.Retry.Timeout
+       { message = "provider call exceeded the configured wall-clock deadline"
+       ; phase = Some Llm_provider.Http_client.Wall_clock
+       })
+;;
+
+let test_wall_clock_timeout_carries_the_wall_clock_phase () =
+  match wall_clock_timeout () with
+  | Agent_sdk.Error.Api (Llm_provider.Retry.Timeout { phase; _ }) ->
+    check bool "phase is Wall_clock" true
+      (match phase with
+       | Some Llm_provider.Http_client.Wall_clock -> true
+       | Some _ | None -> false)
+  | _ -> fail "expected Api (Timeout _)"
+;;
+
+let test_wall_clock_timeout_joins_existing_candidate_rotation () =
+  let http_error =
+    Masc.Keeper_turn_driver_try_runtime.sdk_error_to_http_error
+      (wall_clock_timeout ())
+  in
+  match http_error with
+  | Some err ->
+    check bool
+      "a same-lane deadline timeout retries the next declared-lane candidate"
+      true
+      (Runtime_attempt_fsm.should_try_next err)
+  | None -> fail "expected the timeout to map to an http_error"
+;;
+
+let test_wall_clock_timeout_joins_existing_provider_timeout_observation () =
+  check bool
+    "the existing post-hoc provider-timeout observation channel recognizes it"
+    true
+    (Masc.Keeper_provider_runtime_boundary.is_provider_timeout_error
+       (wall_clock_timeout ()))
+;;
+
+let test_non_timeout_error_does_not_trip_the_observation_channel () =
+  check bool
+    "an unrelated error is not misclassified as a provider timeout"
+    false
+    (Masc.Keeper_provider_runtime_boundary.is_provider_timeout_error
+       (Agent_sdk.Error.Api
+          (Llm_provider.Retry.ContextOverflow { message = "exceeded"; limit = None })))
+;;
+
+let () =
+  run
+    "keeper_provider_call_deadline"
+    [ ( "elapsed_ms"
+      , [ test_case "computes in-flight delta" `Quick
+            test_in_flight_elapsed_ms_computes_delta
+        ; test_case "floors in-flight delta at zero" `Quick
+            test_in_flight_elapsed_ms_floors_at_zero
+        ; test_case "computes since-last-progress delta" `Quick
+            test_since_last_progress_ms_computes_delta
+        ; test_case "floors since-last-progress delta at zero" `Quick
+            test_since_last_progress_ms_floors_at_zero
+        ; test_case "a steadily progressing turn stays near zero" `Quick
+            test_a_steadily_progressing_turn_stays_near_zero
+        ] )
+    ; ( "wall_clock_timeout_integration"
+      , [ test_case "carries the Wall_clock phase" `Quick
+            test_wall_clock_timeout_carries_the_wall_clock_phase
+        ; test_case "joins existing candidate rotation" `Quick
+            test_wall_clock_timeout_joins_existing_candidate_rotation
+        ; test_case "joins existing provider-timeout observation" `Quick
+            test_wall_clock_timeout_joins_existing_provider_timeout_observation
+        ; test_case "a non-timeout error is not misclassified" `Quick
+            test_non_timeout_error_does_not_trip_the_observation_channel
+        ] )
+    ]
+;;

--- a/test/test_keeper_runtime_resolved_observability.ml
+++ b/test/test_keeper_runtime_resolved_observability.ml
@@ -26,7 +26,14 @@ let test_resolved_config_exposes_timeout_knobs () =
   Alcotest.(check bool)
     "resolved config exposes body_timeout_override_sec"
     true
-    (List.mem "body_timeout_override_sec" names)
+    (List.mem "body_timeout_override_sec" names);
+  (* #27349: same disambiguation need as #25128 -- an operator must be able
+     to tell "provider_call_deadline_sec unset" from "configured but not
+     applied", not infer it from absence. *)
+  Alcotest.(check bool)
+    "resolved config exposes provider_call_deadline_sec"
+    true
+    (List.mem "provider_call_deadline_sec" names)
 
 let test_to_yojson_is_a_json_object () =
   Rr.reset_for_tests ();


### PR DESCRIPTION
## 문제

2026-08-07 11:53, analyst/kidsnote/rondo/sangsu 4개 keeper가 `turn_started`+`turn_ready`를 찍은 뒤 25분+ 아무 이벤트도 내지 않고 in-flight 상태로 영구 동결됐다(운영자 bounce로만 복구). provider 호출에 어떤 데드라인도, 어떤 워치독도 없었고, "in-flight N분째 무이벤트"를 관측해 증거를 남기는 주체조차 없어 운영자가 완주 수 급락으로 우연히 발견했다.

## 설계 근거 (구현 전 조사)

이슈 본문이 인용한 RFC-0138은 실제로는 dashboard-snapshot-lock-free-architecture로 timeout과 무관함을 확인했다(team-lead 인지, 잘못된 인용). `env_config_keeper.ml`을 직접 조사해 실제 후보 knob(`stream_idle_timeout_sec`, `body_timeout_sec_override`)을 찾았으나 둘 다 opt-in(기본 None)이고, 정확히 이번 사고 설정(4개 keeper 모두 미설정)에서는 아무 보호도 제공하지 못했다. 또한 `stream_idle_timeout_sec`은 RFC-0345(#25128, 유사 30분+ 스톨 사고)에서 이미 fail-safe floor(600s)를 얻었지만, 이는 스트리밍 inter-line idle gap만 커버해 non-streaming 호출이나 첫 토큰 이전 단계(Admission/Queue)의 스톨은 여전히 무방비였다 — 이번 사고가 정확히 그 남은 gap이다.

team-lead 결정(옵션 c): 관측과 집행을 분리하고 코드에서 숫자를 완전히 추방.

## 구현

**1. 관측 (상시, 임계값 없음)** — `keeper_heartbeat_loop_in_turn_pulse.ml`의 기존 5-30s in-turn 틱을 확장:
- SSE `keeper_heartbeat` payload에 `in_flight_elapsed_ms`/`since_last_progress_ms`를 값 그대로(비교 없이) 추가. 지금까지 `turn_observation.started_at`/`last_progress_at`는 대시보드 JSON 표시에만 쓰였고 아무도 경과 시간을 계산해 노출하지 않았다 — "4기 alive"로 보였던 25분이 이제 "in-flight 25min, progress 0"으로 보인다.
- 같은 두 값을 OTEL 게이지(`masc_keeper_in_flight_elapsed_seconds`, `masc_keeper_since_last_progress_seconds`, `keeper` 라벨)로도 노출 — 대시보드(실시간)와 미래 #27323 supervision 좌석(시계열 질의) 양쪽이 소비할 수 있는 durable/queryable 채널.
- 임계값이 코드에 없으므로 매직 넘버 문제 자체가 없다. 소비자가 판단한다.

**2. 집행 (knob-gated, None=off)** — 신규 env knob `MASC_KEEPER_PROVIDER_CALL_DEADLINE_SEC` (`env_config_keeper.ml` `KeeperKeepalive` 모듈, `body_timeout_sec_override`와 동일한 opt-in 패턴, unset→None→집행 없음, 설정 시 범위 [30, 3600]초 — `body_timeout_sec_override`의 [10,600]보다 넓은 이유는 doc comment에 명시: 이건 HTTP body 하나가 아니라 tool 호출이 섞인 전체 에이전틱 턴의 provider 호출을 감싸는 값이라서). `stream_idle_timeout_sec`와 달리 fail-safe floor를 의도적으로 두지 않았다 — 합리적인 총 호출 상한은 provider/워크로드마다 다르므로 MASC가 추측하지 않는다.

설정된 경우 `keeper_turn_driver_try_provider.ml`의 `run_try_provider`가 provider 호출 전체를 `Eio.Time.with_timeout_exn`으로 감싼다. 초과 시 **새 에러 variant 없이** 기존 typed `Agent_sdk.Error.Api (Retry.Timeout { phase = Some Http_client.Wall_clock })`로 분류한다 — `Wall_clock`은 SDK에 이미 존재하는, 정확히 이 목적으로 만들어진 phase("Whole operation wall-clock deadline, independent of streaming progress")다. 이 값은 코드 변경 없이 기존 두 경로에 그대로 합류한다: (a) `Keeper_runtime_attempt.sdk_error_to_runtime_outcome` → `Runtime_attempt_fsm.should_try_next`(true)를 통해 기존 declared-lane candidate rotation, (b) `Keeper_provider_runtime_boundary.is_provider_timeout_error`를 통해 기존 post-hoc provider-timeout 관측 채널. 단위 테스트로 두 경로 합류를 직접 증명했다(추측이 아니라 실제 함수 호출로).

`Eio.Time.Timeout`만 잡고 `Eio.Cancel.Cancelled`는 절대 잡지 않는다(catch-all 없음, 이 저장소의 반복 사고 패턴을 재현하지 않음). OAS 자체의 `stream_idle_timeout_s`/`body_timeout_s` 초과는 `Runtime_agent.run`의 typed 반환값으로 처리되고 예외로 escape하지 않으므로, 내 타임아웃과 OAS 내부 타임아웃이 같은 catch 지점에서 혼동될 여지가 없다.

checkpoint 정합성은 #27330에서 쓴 `same_run_retry_allowed`/`checkpoint_stage_observed` 게이트를 그대로 재사용한다 — 새 게이트 없음. 이 데드라인 타임아웃도 `run_try_provider` 내부에서 발생하므로 호출자의 기존 candidate rotation 게이트를 그대로 통과한다.

**값의 출처**: 코드/문서에 구체적 숫자를 남기지 않는다. 기본 off. team-lead가 머지·배포 후 오늘 실측(정상 최장 턴 vs 이번 stall)을 기반으로 production 환경에 설정한다.

## 변경 파일

- `lib/config/env_config_keeper.ml`/`.mli` — 신규 knob `provider_call_deadline_sec_override`
- `lib/keeper/keeper_runtime_resolved.ml`/`.mli` — resolved-config 필드 + accessor (fail-safe floor 없음, #27349 근거 명시)
- `lib/keeper/keeper_turn_driver_try_provider.ml`/`.mli` — Eio 타임아웃 wrap + typed 분류
- `lib/keeper/keeper_turn_driver.ml` — `try_provider_ctx` 구성 지점에서 knob 값 주입
- `lib/keeper_metrics/keeper_metrics.ml`/`.mli` — 신규 게이지 2종
- `lib/keeper/keeper_heartbeat_loop_in_turn_pulse.ml`/`.mli` — SSE payload 확장 + 게이지 기록
- `test/test_keeper_provider_call_deadline.ml` (신규) — 9건
- `test/test_keeper_runtime_resolved_observability.ml` — #27349 knob 노출 단언 추가
- `test/dune`, `.github/workflows/ci.yml` — 위 신규/기존 미배선 스위트 배선
- `scripts/audit-ci-test-targets.sh` — `UNWIRED_BASELINE` 737 → 734
- `docs/runtime-tunables.md` — `dune exec ./bin/env_knob_catalog.exe -- docs/runtime-tunables.md` 재생성 결과 (203→204 knobs)

## 검증

- `test_keeper_provider_call_deadline.exe` 9/9 green — elapsed-ms 계산(음수 방지 포함), 그리고 synthetic Wall_clock timeout이 기존 rotation(`Runtime_attempt_fsm.should_try_next`)과 기존 관측(`Keeper_provider_runtime_boundary.is_provider_timeout_error`) 양쪽에 실제로 합류함을 직접 증명.
- `test_keeper_runtime_resolved_observability.exe` 2/2 green.
- `bash scripts/audit-ci-test-targets.sh` → `123 CI targets, all declared in test/dune` / `734 suites unwired, at baseline` (PASS).
- `dune build --root . @check` 전체 green.
- `docs/runtime-tunables.md` 재생성 결과 커밋 포함.

## 미해결 리스크

- `Eio.Time.with_timeout_exn` wrap 자체(실제 provider 호출을 감싸는 부분)는 이 파일의 기존 테스트 경계와 동일하게 unit fixture가 없다 — `run_try_provider`를 직접 호출하는 테스트가 이 저장소에 없다(#27330과 동일한 경계).
- knob 값 자체는 이 PR 범위 밖(team-lead가 배포 후 설정).

Closes #27349
