### PR TITLE
test(tools): put a ceiling on the tool schemas every turn carries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1426,7 +1426,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          prompt_targets="@test/runtest-test_keeper_system_prompt_bytes @test/runtest-test_keeper_prompt_metrics @test/runtest-test_keeper_surface_presence_prompt"
+          prompt_targets="@test/runtest-test_keeper_system_prompt_bytes @test/runtest-test_keeper_tool_schema_bytes @test/runtest-test_keeper_prompt_metrics @test/runtest-test_keeper_surface_presence_prompt"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${prompt_targets}"
 
       - name: Run board attention suite

--- a/test/dune
+++ b/test/dune
@@ -2596,6 +2596,11 @@
 ; string, and declaring the prompt sources as deps is what makes an edit under
 ; config/prompts re-run it instead of returning a cached pass.
 (test
+ (name test_keeper_tool_schema_bytes)
+ (modules test_keeper_tool_schema_bytes)
+ (libraries alcotest yojson masc masc_test_deps))
+
+(test
  (name test_keeper_system_prompt_bytes)
  (modules test_keeper_system_prompt_bytes)
  (deps

--- a/test/test_keeper_tool_schema_bytes.ml
+++ b/test/test_keeper_tool_schema_bytes.ml
@@ -1,0 +1,90 @@
+(** A ceiling on the tool schemas every Keeper turn carries.
+
+    [test_keeper_system_prompt_bytes] pins the assembled system prompt, which is
+    the smaller half of the fixed per-turn cost. The tool array is the larger
+    one and had no measurement at all: a tool added with a generous schema, or a
+    description that grows a paragraph at a time, costs every turn of every
+    Keeper and nothing said so.
+
+    This is a ratchet, not a golden. Shrinking passes and reports the slack, so
+    a PR that trims a description is never asked to edit a number to stay green
+    — that failure mode is why [audit-ci-test-targets.sh] stopped failing on its
+    own improvement. Growth past the ceiling fails and has to be argued for in
+    the PR that causes it.
+
+    What is measured is what the model receives: [model_visible_schemas]
+    projects the descriptors a Keeper can call, and each carries the name,
+    description, and input_schema that go on the wire. Serialized as compact
+    JSON, so whitespace in the OCaml source does not move the number. *)
+
+open Alcotest
+
+(* Raise only with the PR that grows the surface, and say what it bought.
+   2026-08-07: 72,485 bytes across 98 model-visible tools — 7.9x the assembled
+   system prompt (9,167 bytes, pinned next door). The headroom is deliberate
+   slack for one ordinary tool, not room to grow into. *)
+let ceiling_bytes = 80_000
+
+let schema_json (schema : Masc_domain.tool_schema) =
+  `Assoc
+    [ "name", `String schema.name
+    ; "description", `String schema.description
+    ; "input_schema", schema.input_schema
+    ]
+;;
+
+let measured () =
+  let schemas = Masc.Keeper_tool_descriptor.model_visible_schemas () in
+  let bytes =
+    List.fold_left
+      (fun acc schema -> acc + String.length (Yojson.Safe.to_string (schema_json schema)))
+      0
+      schemas
+  in
+  (List.length schemas, bytes)
+;;
+
+let test_tool_schema_bytes_stay_under_the_ceiling () =
+  let count, bytes = measured () in
+  check bool "the surface is non-empty" true (count > 0);
+  if bytes > ceiling_bytes
+  then
+    failf
+      "model-visible tool schemas grew to %d bytes across %d tools, over the %d ceiling \
+       by %d.\n\
+       Every Keeper turn carries this. Trim the schema or the description, or raise \
+       ceiling_bytes in this file with the PR that needs the room and say what it bought."
+      bytes
+      count
+      ceiling_bytes
+      (bytes - ceiling_bytes)
+;;
+
+(* A ceiling nobody is near stops measuring anything. This fails when the slack
+   grows past a third of the ceiling, which is the signal to lower it and bank
+   the reduction — the same direction audit-ci-test-targets.sh reports when its
+   unwired count drops below baseline. *)
+let test_the_ceiling_still_tracks_the_surface () =
+  let _, bytes = measured () in
+  let slack = ceiling_bytes - bytes in
+  if bytes <= ceiling_bytes && slack > ceiling_bytes / 3
+  then
+    failf
+      "model-visible tool schemas are %d bytes against a %d ceiling — %d of slack. The \
+       ceiling has stopped tracking the surface; lower it to bank the reduction."
+      bytes
+      ceiling_bytes
+      slack
+;;
+
+let () =
+  run
+    "keeper_tool_schema_bytes"
+    [ ( "per-turn tool surface"
+      , [ test_case "stays under the ceiling" `Quick
+            test_tool_schema_bytes_stay_under_the_ceiling
+        ; test_case "the ceiling still tracks the surface" `Quick
+            test_the_ceiling_still_tracks_the_surface
+        ] )
+    ]
+;;


### PR DESCRIPTION
## What

`test_keeper_system_prompt_bytes` pins the assembled system prompt at **9,167
bytes**. The tool array sits on the same every-turn path and is **72,485 bytes —
7.9x larger — with no measurement at all.**

A tool added with a generous schema, or a description that grows a paragraph at
a time, costs every turn of every Keeper, and nothing said so.

## Why a ratchet and not a golden

Shrinking passes and reports the slack. A PR that trims a description is never
asked to edit a number to stay green — `audit-ci-test-targets.sh` carries the
note about why that shape is wrong:

> Failing here made every suite-wiring PR turn main red until someone edited
> this number: 748 went red, #27181 set 747, and 746 was red again within the
> hour.

Growth past the ceiling fails, and has to be argued for in the PR that causes
it.

## The second case earns its place

A ceiling nobody is near stops measuring anything, so a second case fails when
the slack passes a third of the ceiling.

It caught its own author immediately. The first ceiling I wrote was 120,000:

```
[OK]   stays under the ceiling
[FAIL] the ceiling still tracks the surface
       model-visible tool schemas are 72485 bytes against a 120000 ceiling —
       47515 of slack. The ceiling has stopped tracking the surface.
```

The ceiling is now 80,000 — headroom for one ordinary tool, not room to grow
into.

## What is measured

`Keeper_tool_descriptor.model_visible_schemas ()` — the descriptors a Keeper can
call, each carrying the `name`, `description`, and `input_schema` that go on the
wire. Serialized as compact JSON, so whitespace in the OCaml source cannot move
the number.

That figure also answers the open question in #27358, which had to say the cost
could not be confirmed: the per-turn tool surface is 72,485 bytes, so the ten
never-called tools measured there (~12 KB of OCaml source text) are a real but
minority share, and the number to watch is this one.

## Verification

```
dune build --root . @test/runtest-test_keeper_tool_schema_bytes
                                              Test Successful, 2 tests run
scripts/audit-ci-test-targets.sh              126 targets, 733 unwired, exit 0
scripts/verify-test-registration.py           Unregistered: 0
ci.yml parses as YAML
```

Wired into the existing `Run keeper prompt assembly suites` step, next to the
system-prompt golden it mirrors — declared and referenced both go up by one, so
the unwired count does not move.

`origin/main` already reports `733 unwired, 734 baseline`; that gain is not from
this PR and lowering `UNWIRED_BASELINE` belongs to whichever PR earned it.

RFC-WAIVED: a test and one CI target. No source change, no behaviour change.
