### PR TITLE
fix(task): the action list stops offering done

### DIFF
--- a/lib/task/tool_task_schemas.ml
+++ b/lib/task/tool_task_schemas.ml
@@ -228,9 +228,19 @@ Tip: Look for status='todo' tasks to claim.";
           ("type", `String "string");
           ("description", `String "Task ID (e.g., 'task-001')");
         ]);
+        (* The enum below is the list; spelling it out again in prose was a
+           second copy that drifted from what the tool accepts. It presented
+           [done] as one ordinary option among six, and [done] is refused from
+           every status a Keeper can be working: the lifecycle answers
+           [Verification_submission_required] from Claimed and InProgress and
+           [Invalid_transition] from the rest, leaving only the Done->Done
+           no-op. Measured over the live tool log: 111 calls passed
+           action="done", 70 errored and the other 41 were that no-op — no
+           state change, ever. This says what each action does instead of
+           restating their names. *)
         ("action", `Assoc [
           ("type", `String "string");
-          ("description", `String "Agent transition action: claim | start | submit_for_verification | done | cancel | release");
+          ("description", `String "Which transition to apply. claim takes an unclaimed Task; start moves your claim into progress; release hands it back with a required handoff_context.summary; cancel ends it with a reason. Completion goes through submit_for_verification with evidence in notes — done is refused from every working status and cannot complete a Task here.");
           ("enum", `List (List.map (fun action -> `String action) Masc_domain.valid_task_action_strings));
         ]);
         ("expected_version", `Assoc [

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -2809,6 +2809,75 @@ let () =
     assert (List.mem ("producer", true, []) !metric_events))
 ;;
 
+(* The action list reaches the model twice: as the enum, derived from
+   [Masc_domain.valid_task_action_strings], and as the property description.
+   The description used to spell the same six names out by hand, which put
+   "done" in front of the model as one ordinary option among them.
+
+   It is not one. The lifecycle answers Done_action with
+   Verification_submission_required from Claimed and InProgress, and with
+   Invalid_transition from Todo, AwaitingVerification and Cancelled — every
+   status a Keeper can be working. Only Done->Done succeeds, as a no-op.
+   Measured over the live tool log: 111 calls passed action="done", 70 errored,
+   and the remaining 41 were that no-op.
+
+   Pinned from two sides. The enum must still carry every action the type has,
+   because that is what the dispatcher accepts; the description must not
+   re-list them, because a hand-written copy of a derived list is what drifted. *)
+let () = test "transition action description does not re-list the enum" (fun () ->
+  let schema =
+    List.find
+      (fun (s : Masc_domain.tool_schema) -> String.equal s.name "masc_transition")
+      Masc.Task.Schemas.schemas
+  in
+  let action_description =
+    match schema.input_schema with
+    | `Assoc top ->
+      (match List.assoc "properties" top with
+       | `Assoc props ->
+         (match List.assoc "action" props with
+          | `Assoc action ->
+            (match List.assoc "description" action with
+             | `String d -> d
+             | _ -> failwith "action description is not a string")
+          | _ -> failwith "action property is not an object")
+       | _ -> failwith "properties is not an object")
+    | _ -> failwith "input_schema is not an object"
+  in
+  let contains needle =
+    let n = String.length needle and h = String.length action_description in
+    let rec loop i =
+      i + n <= h && (String.sub action_description i n = needle || loop (i + 1))
+    in
+    loop 0
+  in
+  (* The pipe-separated copy of the enum is gone. *)
+  assert (not (contains "claim | start"));
+  (* done is named, and named as refused rather than offered. *)
+  assert (contains "done is refused");
+  (* The route that does complete a Task is the one stated. *)
+  assert (contains "submit_for_verification");
+  (* The enum keeps every action the dispatcher accepts, done included. *)
+  let enum_actions =
+    match schema.input_schema with
+    | `Assoc top ->
+      (match List.assoc "properties" top with
+       | `Assoc props ->
+         (match List.assoc "action" props with
+          | `Assoc action ->
+            (match List.assoc "enum" action with
+             | `List xs ->
+               List.filter_map (function `String s -> Some s | _ -> None) xs
+             | _ -> failwith "enum is not a list")
+          | _ -> failwith "action property is not an object")
+       | _ -> failwith "properties is not an object")
+    | _ -> failwith "input_schema is not an object"
+  in
+  assert (
+    List.sort compare enum_actions
+    = List.sort compare Masc_domain.valid_task_action_strings))
+;;
+
 let () =
   ensure_test_runtime ();
   Alcotest.run "Task.Tool"


### PR DESCRIPTION
## What

`masc_transition` sends its action list to the model **twice**: as the `enum`,
derived from `Masc_domain.valid_task_action_strings`, and as a hand-written copy
in the property description.

```ocaml
("description", `String "Agent transition action: claim | start | submit_for_verification | done | cancel | release");
("enum", `List (List.map (fun action -> `String action) Masc_domain.valid_task_action_strings));
```

The copy presented `done` as one ordinary option among six. It is not one.

## done is refused from every status a Keeper can be working

```ocaml
(* workspace_task_lifecycle.ml *)
| Done_action, (Claimed { assignee; _ } | InProgress { assignee; _ }) ->
  if not (same_agent assignee) then Error Invalid_transition
  else Error Verification_submission_required
| Done_action, Done _ -> ok task_status                    (* no-op *)
| Done_action, (Todo | AwaitingVerification _ | Cancelled _) -> Error Invalid_transition
```

Live tool log, all history:

```
masc_transition            533 calls
  action="done"            111        70 errored, 41 were the Done->Done no-op
  action="submit_for_verification"  168
  action="release"         117
  action="claim"            56
  action="cancel"           59
  action="start"            14
  action="approve"           6        ← not in the enum; the model invented it
  action="reject"            2        ← same
```

**Zero state changes from 111 attempts.** The tool's own top-level description
already says this — *"Direct done and approve/reject are deliberately
unavailable here"* — so the property description was contradicting it one field
away, and the field the model reads as the option list is the one that was
wrong.

## Change

The description now says what each action does, and names `done` as refused
rather than offering it. The `enum` is untouched: it must keep every action the
dispatcher accepts, and it is derived, so it cannot drift.

This is the #27316 shape — a hand-maintained copy of a typed list, deleted in
favour of the list.

## What this does not claim

The `approve`/`reject` calls show the enum is a hint, not enforcement: those
values are not in it and still reached the tool. So this does not stop a model
from passing `done`; it stops the schema from **recommending** it. Whether the
enum should narrow to a tool-facing subset is a separate question — narrowing it
would trade a teaching error (`Verification_submission_required`, which names
the route) for a validation error, and that trade needs its own argument.

## Tests

In `test_tool_task_coverage`, which CI runs (ci.yml:894 — I checked, because
`test_tools_coverage` holds the existing `masc_transition` schema test and is
**not** wired, so a case added there would compile and never execute).

Pinned from two sides:

| assertion | stops |
|---|---|
| `"claim \| start"` absent | the hand-written copy coming back |
| `"done is refused"` present | done being re-offered as ordinary |
| `"submit_for_verification"` present | the working route going unnamed |
| enum set == `valid_task_action_strings` | the enum quietly narrowing |

Verified not an identity: with the test in place and
`lib/task/tool_task_schemas.ml` reverted to `origin/main`,

```
1 failure! in 92 tests run
[FAIL] coverage 91  transition action description does not re-list the enum
```

## Verification

```
dune build --root . @check                              exit 0
dune build --root . @test/runtest-test_tool_task_coverage
                                        Test Successful, 92 tests run
```

RFC-WAIVED: one schema description corrected to match the lifecycle it
describes. No behaviour change, no enum change, no new field.
