### PR TITLE
fix(keeper): bound the OAS tool error text, and carry over what #27285 left behind

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -934,6 +934,7 @@ jobs:
             @test/runtest-test_keeper_invocation_contract_hints \
             @test/runtest-test_keeper_path_ssot \
             @test/runtest-test_keeper_phase_drift_contract \
+            @test/runtest-test_keeper_tool_error_text_bounded \
             @test/runtest-test_keepers_runtime_dir_ssot \
             @test/runtest-test_mcp_h1_h2_admission_parity \
             @test/runtest-test_nickname_words_ssot \
@@ -966,6 +967,18 @@ jobs:
         run: |
           opam exec -- dune build --root . \
             @test/runtest-test_metric_zero_cell_declaration
+
+      - name: Run transport metrics snapshot suite
+        # The health snapshot reads counters through metric_value_or_zero, so a
+        # field naming a metric that does not exist is emitted as 0 rather than
+        # failing. #27285 removed two such fields after they had reported 0/0
+        # for their whole life. The suite asserts the counters advance, which is
+        # what separates a live field from a dead one, and no transport suite
+        # was wired into any target list -- @check compiled this and nothing
+        # ran it. Green on this branch, 26/26.
+        run: |
+          opam exec -- dune build --root . \
+            @test/runtest-test_transport_metrics
 
       - name: Run connector observability label contract
         # These strings are metric label values, so a rename is a wire change

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -88,8 +88,26 @@ let execute_with_observers
          dispatch observers explicitly. *)
       Tool_dispatch.run_dispatch_observers
         Dispatch_outcome.Handled (Some dispatch_result);
+      (* Bound before sanitizing, not after.  [raw_result] is whatever the
+         tool wrote, and a tool that dumps a file returns the whole file: a
+         single [tool_execute] error on 2026-08-06 produced a 699,341,105-byte
+         [detail], which became 94.3% of that day's 708 MB system log, a
+         618,922,307-byte blob, and one SSE broadcast of the same bytes.
+
+         The sibling telemetry on this very call already bounds the same
+         string — [tool_io_preview_fields ~output:raw_result] routes through
+         [Observability_redact.redact_tool_output]. [error_text] was the one
+         consumer that skipped the redactor, so it also skipped secret
+         masking.
+
+         Truncating first means [sanitize_text_utf8] scans at most
+         [max_tool_output_bytes] instead of the whole payload, and it repairs
+         any multi-byte character the cut split. *)
       let detail =
-        raw_result |> String.trim |> Safe_ops.sanitize_text_utf8
+        raw_result
+        |> Observability_redact.redact_preview
+             ~max_len:Common.max_tool_output_bytes
+        |> Safe_ops.sanitize_text_utf8
       in
       let ts = Time_compat.now () in
       broadcast_keeper_tool_call_event

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -397,15 +397,27 @@ let budgeted_model_input_projection (ctx : try_provider_ctx)
         ~system_prompt:ctx.system_prompt
         ~tools:ctx.tools)
   in
+  (* One memo per provider attempt, not per request.  A turn issues one
+     projection per provider request — measured on the live wire capture:
+     83 requests for turn 12263, 62 for 15638 — and every request re-measures
+     the same history, which is tens of thousands of messages on a live
+     Keeper.  Building the memo inside the per-request closure threw that work
+     away between requests.
+
+     Safe to share: [run_try_provider] builds one closure per provider
+     attempt, so no two Keepers share a memo; OAS drives the turn loop
+     sequentially (no [Fiber.fork] around [prepare_turn_for_agent] in
+     pipeline_stage_prepare.ml); and [Domain_pool.submit_cpu] is
+     [Eio.Executor_pool.submit_exn], which blocks until the job finishes, so
+     successive jobs are ordered even when they land on different domains.
+
+     The message records are physically shared across a turn's requests — only
+     the list spine is rebuilt — which is what makes the memo hit at all: it
+     confirms every lookup with physical equality. *)
+  let measure_message_bytes = memoize_message_measurement measure_message_bytes in
   fun messages ->
     let planned_and_windowed =
       offload_model_input_cpu (fun () ->
-        (* The raw cut and demotion plan both measure immutable message records.
-           Cache only for this worker-domain job so repeated candidates are
-           encoded once without retaining a long-lived Keeper's history. *)
-        let measure_message_bytes =
-          memoize_message_measurement measure_message_bytes
-        in
         let raw_cut candidate =
           Runtime_model_input_tail_window.project_with_drop
             ~measure_message_bytes

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -465,6 +465,7 @@ type ws_delivery_metric_names =
   ; client_acks : string
   ; throttled_deliveries : string
   ; delta_payload_serializations : string
+  ; slice_fanout_skipped : string
   ; client_buffered_bytes : string
   ; client_buffered_bytes_count : string
   ; hello_latency : string
@@ -477,6 +478,10 @@ let ws_delivery_metric_names =
   ; client_acks = "masc_ws_client_acks_total"
   ; throttled_deliveries = "masc_ws_throttled_deliveries_total"
   ; delta_payload_serializations = "masc_ws_delta_payload_serializations_total"
+    (* Named by the declaration, not by a literal: [metric_value_or_zero]
+       answers an unknown name with 0, so a typo here would surface as a
+       permanently-zero field instead of a failure. *)
+  ; slice_fanout_skipped = Otel_metric_store.metric_ws_slice_fanout_skipped
   ; client_buffered_bytes = "masc_ws_client_buffered_bytes"
   ; client_buffered_bytes_count = "masc_ws_client_buffered_bytes_count"
   ; hello_latency = Otel_metric_store.metric_ws_dashboard_hello_latency_seconds
@@ -679,6 +684,12 @@ let transport_health_json ~config =
                   , `Int
                       (int_of_float
                          (v ws_delivery_metrics.delta_payload_serializations ())) )
+                ; (* Deliveries the slice gate dropped because the session did
+                     not subscribe to that slice.  Without it the gap between
+                     delivered broadcasts and what reaches the bytes cache is
+                     unattributable. *)
+                  ( "slice_fanout_skipped"
+                  , `Int (int_of_float (v ws_delivery_metrics.slice_fanout_skipped ())) )
                 ; (* Histogram sum + auto _count give operators enough to compute
            average buffered bytes per ack without external telemetry queries. *)
                   ( "client_buffered_bytes_sum"

--- a/test/dune
+++ b/test/dune
@@ -721,6 +721,11 @@
  (libraries alcotest ast_grep masc_test_deps))
 
 (test
+ (name test_keeper_tool_error_text_bounded)
+ (modules test_keeper_tool_error_text_bounded)
+ (libraries alcotest ast_grep masc_test_deps masc.masc_core))
+
+(test
  (name test_keeper_structured_output_schema)
  (modules test_keeper_structured_output_schema)
  (libraries alcotest masc_test_deps masc.fusion_core))

--- a/test/test_keeper_tool_error_text_bounded.ml
+++ b/test/test_keeper_tool_error_text_bounded.ml
@@ -1,0 +1,102 @@
+(** The OAS tool-error path must bound its payload before fanning it out.
+
+    [keeper_tools_oas_handler_exec] builds one [detail] string from the tool's
+    raw result and hands it to three sinks: the SSE broadcast ([~error_text]),
+    the error log line, and the blob store. [raw_result] is whatever the tool
+    wrote, so a tool that dumps a file returns the whole file.
+
+    Measured on the live fleet 2026-08-06: a single [tool_execute] error
+    produced a 699,341,105-byte detail. That one line was 94.3% of the day's
+    708 MB system log (other days peak at 254 KB per line), and the same bytes
+    landed in the blob store as a 618,922,307-byte object.
+
+    The sibling telemetry on the same call was never affected —
+    [tool_io_preview_fields ~output:raw_result] routes through
+    [Observability_redact.redact_tool_output]. [error_text] was the one
+    consumer that skipped the redactor, which also meant it skipped secret
+    masking. *)
+
+open Alcotest
+
+let exec_module = "lib/keeper/keeper_tools_oas_handler_exec.ml"
+
+(* Pin the call site, not just the helper: the helper being correct does not
+   stop a future edit from dropping it here, which is exactly how the field
+   came to differ from its sibling in the first place. *)
+let test_error_path_routes_through_the_redactor () =
+  check bool
+    (Printf.sprintf "%s bounds the error detail through the redactor"
+       exec_module)
+    true
+    (Ast_grep.count_calls
+       ~module_path:exec_module
+       ~callee:"Observability_redact.redact_preview"
+     > 0)
+;;
+
+(* A cut at a byte offset can land inside a multi-byte character, so the
+   sanitizer has to run after the truncation, not before it — and running it
+   before would also mean scanning the whole unbounded payload. *)
+let test_bound_holds_for_an_oversized_payload () =
+  let raw = String.make (Common.max_tool_output_bytes * 4) 'x' in
+  let bounded =
+    raw
+    |> Masc.Observability_redact.redact_preview
+         ~max_len:Common.max_tool_output_bytes
+    |> Safe_ops.sanitize_text_utf8
+  in
+  check bool
+    "an oversized payload is cut down"
+    true
+    (String.length bounded < String.length raw);
+  (* The truncation marker costs a few bytes on top of [max_len]; the point is
+     that the result is bounded by the budget, not that it equals it. *)
+  check bool
+    "and the result stays within a small constant of the budget"
+    true
+    (String.length bounded <= Common.max_tool_output_bytes + 64)
+;;
+
+(* Korean text is three bytes per character, so a cut at max_len very likely
+   splits one. The result must still be valid UTF-8 for the JSON log writer. *)
+let test_bound_survives_multibyte_text () =
+  let unit = "가나다라마바사아자차" in
+  let repeats = (Common.max_tool_output_bytes / String.length unit) + 8 in
+  let raw = String.concat "" (List.init repeats (fun _ -> unit)) in
+  let bounded =
+    raw
+    |> Masc.Observability_redact.redact_preview
+         ~max_len:Common.max_tool_output_bytes
+    |> Safe_ops.sanitize_text_utf8
+  in
+  check bool
+    "multibyte payload is bounded"
+    true
+    (String.length bounded <= Common.max_tool_output_bytes + 64);
+  check bool
+    "and the bound is not vacuous — the input really was larger"
+    true
+    (String.length raw > Common.max_tool_output_bytes)
+;;
+
+let () =
+  run
+    "keeper tool error text bounded"
+    [ ( "call site"
+      , [ test_case
+            "error detail routes through the redactor"
+            `Quick
+            test_error_path_routes_through_the_redactor
+        ] )
+    ; ( "bound"
+      , [ test_case
+            "oversized payload is cut to the tool-output budget"
+            `Quick
+            test_bound_holds_for_an_oversized_payload
+        ; test_case
+            "multibyte payload stays valid after the cut"
+            `Quick
+            test_bound_survives_multibyte_text
+        ] )
+    ]
+;;

--- a/test/test_transport_metrics.ml
+++ b/test/test_transport_metrics.ml
@@ -353,7 +353,14 @@ let test_transport_health_json () =
     Otel_metric_store.metric_total
       (Otel_metric_store.metric_sse_external_fanout_duration_seconds ^ "_count")
   in
+  let slice_fanout_skipped_before =
+    Otel_metric_store.metric_total Otel_metric_store.metric_ws_slice_fanout_skipped
+  in
   TM.observe_ws_dashboard_hello_latency ~success:true 0.125;
+  (* Drive the counter so the assertion below is not satisfied by a field that
+     is wired to the wrong metric name: [metric_value_or_zero] answers an
+     unknown name with 0, which a presence-only check accepts. *)
+  TM.inc_ws_slice_fanout_skipped ();
   Masc.Sse.broadcast (`Assoc [ ("type", `String "transport-test") ]);
   Masc.Sse.sync_transport_snapshot ~force:true ();
   let json = TM.transport_health_json ~config in
@@ -392,6 +399,13 @@ let test_transport_health_json () =
   check bool "external fanout count advances" true
     (float_of_int (sse_json |> U.member "external_fanout_count" |> U.to_int)
      >= external_fanout_count_before +. 1.0);
+  (* A broadcast nothing can observe is short-circuited before the fanout
+     mutex.  Surfacing the count is what makes that skip auditable rather than
+     a silent behaviour change. *)
+  check bool "skipped-no-observer count surfaced" true
+    (match sse_json |> U.member "broadcast_skipped_no_observer" with
+     | `Int _ -> true
+     | _ -> false);
   check bool "external fanout sum surfaced" true
     (match sse_json |> U.member "external_fanout_sum_seconds" with
      | `Float _ | `Int _ -> true
@@ -479,15 +493,20 @@ let test_transport_health_json () =
   List.iter (fun (field, label) ->
     check bool (Printf.sprintf "%s field present (int)" label) true
       (match delivery_json |> U.member field with `Int _ -> true | _ -> false))
-    [ "parse_cache_hits", "parse_cache_hits"
-    ; "parse_cache_misses", "parse_cache_misses"
-    ; "bytes_cache_hits", "bytes_cache_hits"
+    [ "bytes_cache_hits", "bytes_cache_hits"
     ; "bytes_cache_misses", "bytes_cache_misses"
     ; "client_acks", "client_acks"
     ; "throttled_deliveries", "throttled_deliveries"
     ; "client_buffered_bytes_count", "client_buffered_bytes_count"
     ; "hello_latency_count", "hello_latency_count"
     ];
+  (* The slice gate's drop count: without it the gap between delivered
+     broadcasts and what reaches the bytes cache is unattributable.  Asserted
+     by advance rather than by presence — a field reading an unknown metric
+     name is emitted as 0, so presence alone proves nothing. *)
+  check bool "slice_fanout_skipped advances" true
+    (float_of_int (delivery_json |> U.member "slice_fanout_skipped" |> U.to_int)
+     >= slice_fanout_skipped_before +. 1.0);
   check bool "client_buffered_bytes_sum field present (float)" true
     (match delivery_json |> U.member "client_buffered_bytes_sum" with
      | `Float _ | `Int _ -> true | _ -> false);


### PR DESCRIPTION
이 PR 은 #27285 가 병합될 때 브랜치에 없던 세 커밋을 옮긴다. #27285 는 작업 중에 병합됐고, 그 이후 커밋은 main 에 도달하지 못했다.

## 1. OAS 툴 에러 텍스트에 경계가 없었다

`keeper_tools_oas_handler_exec.ml` 은 툴의 원본 결과에서 `detail` 문자열 하나를 만들어 **세 곳**에 넘긴다 — SSE 브로드캐스트(`~error_text`), 에러 로그 라인, blob store. `raw_result` 는 툴이 쓴 것 전부이므로, 파일을 덤프하는 툴은 파일 전체를 반환한다.

변경 전:

```ocaml
let detail = raw_result |> String.trim |> Safe_ops.sanitize_text_utf8 in
```

`String.trim` 은 양끝 공백만 없앤다. 경계가 없다.

**실측 (2026-08-06 fleet)**: `tool_execute` 에러 한 건이 **699,341,105 바이트** 짜리 detail 을 만들었다. 그 한 줄이 그날 시스템 로그 708 MB 의 **94.3%** 였다. 다른 날의 최대 줄 길이는 254 KB 다. 같은 바이트가 blob store 에도 618,922,307 바이트 객체로 저장됐다.

같은 호출의 형제 텔레메트리는 멀쩡했다 — `tool_io_preview_fields ~output:raw_result` 는 `Observability_redact.redact_tool_output` 을 거친다. `error_text` 만 redactor 를 건너뛰었고, 그래서 **시크릿 마스킹도 함께 건너뛰었다**.

변경 후:

```ocaml
let detail =
  raw_result
  |> Observability_redact.redact_preview ~max_len:Common.max_tool_output_bytes
  |> Safe_ops.sanitize_text_utf8
in
```

`Common.max_tool_output_bytes` (65,536) 는 이 저장소가 이미 툴 출력 예산으로 쓰는 상수다. 새 숫자를 만들지 않았다.

자르기를 sanitize **앞**에 둔 이유 두 가지: `sanitize_text_utf8` 이 전체 페이로드가 아니라 예산만큼만 스캔하고, 자르기가 쪼갠 멀티바이트 문자를 sanitize 가 복구한다. 순서를 뒤집으면 699 MB 를 먼저 스캔한다.

### 테스트

`test_keeper_tool_error_text_bounded.ml` 세 개.

- **호출 지점 고정** — `Ast_grep.count_calls` 로 exec 모듈이 redactor 를 거치는지 검사한다. 헬퍼가 올바른 것과 호출 지점이 그것을 쓰는 것은 다른 문제이고, 애초에 이 필드가 형제와 갈라진 경로가 그것이다.
- **초과 페이로드** — 예산의 4 배를 넣고 결과가 예산 + 상수 안에 드는지.
- **멀티바이트** — 한글은 3 바이트라 예산 경계에서 문자가 쪼개질 확률이 높다. 자른 뒤에도 JSON 로그 writer 가 쓸 수 있는 UTF-8 인지 검사한다. 입력이 실제로 예산보다 컸다는 것도 함께 검사해 조건이 공허하지 않게 했다.

## 2. 투영 측정 메모가 요청마다 버려졌다

`keeper_turn_driver_try_provider.ml` 에서 `memoize_message_measurement` 가 `fun messages ->` **안**에 있어 요청마다 새 메모가 만들어졌다. 메모가 물리적 동등성으로 조회하는데, 한 턴의 요청들은 message 레코드를 물리적으로 공유하고 리스트 spine 만 다시 만든다 — 즉 턴 단위로는 히트할 수 있는데 요청 단위 수명 때문에 매번 미스였다.

메모 생성을 클로저 밖으로 올렸다.

## 3. slice 게이트 드롭 수가 스냅샷에 없었다

`masc_ws_slice_fanout_skipped_total` 은 `server_mcp_transport_ws.ml:871` 에서 이미 증가하고 있었는데 JSON 스냅샷에 없었다. 브로드캐스트 수와 bytes 캐시 조회 수 사이의 격차를 귀속시킬 수 없었다.

필드 이름을 문자열 리터럴이 아니라 **선언 상수로** 참조한다. 스냅샷은 `metric_value_or_zero` 로 읽는데 이것은 모르는 이름에 0 을 답한다 — 리터럴이 선언에서 어긋나면 에러가 아니라 **영구 0 필드**가 된다. #27285 에서 제거한 parse-cache 카운터와 정확히 같은 모양이다. 상수 참조는 그 드리프트를 컴파일 에러로 만든다.

테스트는 존재가 아니라 **전진**을 검사한다. 카운터를 구동하기 전 값을 캡처하고 그보다 커졌는지 본다. 존재 검사는 0 을 통과시키므로 리터럴 형태에서도 통과한다 — 실제로 리터럴 형태로 빌드해 이 assertion 만 실패하는 것을 확인했다.

## 4. 두 스위트가 CI 에서 돌지 않고 있었다

어느 타깃 목록에도 없어 `@check` 가 컴파일만 하고 아무도 실행하지 않았다. 위 두 테스트를 배선했다.

- `test_keeper_tool_error_text_bounded` → invariant/SSOT 가드 스텝. 반환값이 아니라 저장소 형태(에러 경로가 redactor 를 거치는지)를 검사하므로 그 계열이다.
- `test_transport_metrics` → zero-cell 스위트 옆 자체 스텝. zero-cell 이 지키는 것과 인접한 실패 모드다.

**transport 스위트는 CI 에 하나도 없다.** `test_ws_transport`, `test_transport_integration` 도 컴파일만 된다 — #27285 가 팬아웃 경로 전체를 다시 썼는데 실행 커버리지가 0 이었다. 이 PR 은 내가 이번에 만지거나 새로 쓴 두 개만 배선하고, 나머지 둘은 여기서 검증하지 않았으므로 배선하지 않았다. 검증 없이 쓸어 담으면 CI 가 빨개지거나, 더 나쁘게는 초록인 채로 아무것도 안 지킨다.

## 검증

- `dune build @default` 통과 (에러 0)
- `test_transport_metrics` 26/26, `test_keeper_tool_error_text_bounded` 3/3
- slice-gate assertion 은 리터럴 형태로 되돌려 빌드해 **그 assertion 만 실패**하는 것을 확인했다
