### PR TITLE
chore(keeper,local-runtime): remove dead memory_check stub and latency_ema_ms field

### DIFF
--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -401,22 +401,3 @@ let append_trait_clause = Keeper_prompt.append_trait_clause
 
 
 include Keeper_text_processing
-
-let memory_check_default_json () : Yojson.Safe.t =
-  `Assoc [
-    ("performed", `Bool false);
-    ("query_kind", `String "none");
-    ("expected_topic", `Null);
-    ("candidate_count", `Int 0);
-    ("initial_score", `Float 0.0);
-    ("final_score", `Float 0.0);
-    ("threshold", `Float 0.18);
-    ("passed", `Bool true);
-    ("best_match", `Null);
-    ("correction_applied", `Bool false);
-    ("correction_success", `Bool false);
-    ("prompt_fallback_applied", `Bool false);
-    ("prompt_fallback_success", `Bool false);
-    ("deterministic_fallback_applied", `Bool false);
-    ("recall_fallback_applied", `Bool false);
-  ]

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -217,7 +217,3 @@ val append_trait_clause : base:string -> clause:string -> string
 (** {1 Fragment Detection (used by dashboard)} *)
 
 val looks_fragmentary_history_text : string -> bool
-
-(** {1 Memory Check} *)
-
-val memory_check_default_json : unit -> Yojson.Safe.t

--- a/lib/keeper/keeper_execution.ml
+++ b/lib/keeper/keeper_execution.ml
@@ -15,4 +15,3 @@ let log_keeper_exn = Keeper_context_runtime.log_keeper_exn
 let load_context_from_checkpoint = Keeper_context_runtime.load_context_from_checkpoint
 let generate_trace_id = Keeper_context_runtime.generate_trace_id
 let effective_model_labels_for_turn = Keeper_context_runtime.effective_model_labels_for_turn
-let memory_check_default_json = Keeper_context_runtime.memory_check_default_json

--- a/lib/keeper/keeper_execution.mli
+++ b/lib/keeper/keeper_execution.mli
@@ -23,9 +23,6 @@ val load_context_from_checkpoint :
   base_dir:string ->
   Keeper_context_runtime.session_context * Keeper_context_runtime.working_context option
 
-(** Default JSON for memory check tool. *)
-val memory_check_default_json : unit -> Yojson.Safe.t
-
 (** {1 Keepalive Runtime} *)
 
 (* Proactive emission and explicit workspace replies are now handled

--- a/lib/keeper/keeper_heartbeat_snapshot.ml
+++ b/lib/keeper/keeper_heartbeat_snapshot.ml
@@ -47,7 +47,6 @@ let write_heartbeat_snapshot
         ; "generation", `Int meta_current.runtime.nonce
         ; ( "message_count"
           , Json_util.option_to_yojson (fun count -> `Int count) message_count )
-        ; "memory_check", memory_check_default_json ()
         ; "handoff", `Assoc [ "performed", `Bool false ]
         ; "stage_timing", Keeper_keepalive_signal.stage_timing_to_json ~ring:timing_ring ~count:timing_filled
         ])

--- a/lib/keeper/keeper_unified_metrics_snapshot.ml
+++ b/lib/keeper/keeper_unified_metrics_snapshot.ml
@@ -121,7 +121,6 @@ let append_metrics_snapshot ~(config : Workspace.config) ~(meta : keeper_meta)
          match result.runtime_observation with
          | Some observation -> redacted_runtime_observation_to_json observation
          | None -> `Null);
-        ("memory_check", memory_check_default_json ());
         ("handoff_performed",
          `Bool
            (match handoff_json with

--- a/lib/local_runtime_pool/local_runtime_pool.ml
+++ b/lib/local_runtime_pool/local_runtime_pool.ml
@@ -7,7 +7,6 @@ type runtime = {
   max_concurrency : int;
   active_slots : int;
   queue_depth : int;
-  latency_ema_ms : float option;
   failure_streak : int;
   cooldown_until : float option;
   last_error : string option;
@@ -23,7 +22,6 @@ type runtime_snapshot = {
   max_concurrency : int;
   active_slots : int;
   queue_depth : int;
-  latency_ema_ms : float option;
   failure_streak : int;
   cooldown_until : float option;
   last_error : string option;
@@ -123,7 +121,6 @@ let runtime_of_discovery_status (status : Discovery_cache.endpoint_info) =
     max_concurrency = max_concurrency_of_discovery_status status;
     active_slots = 0;
     queue_depth = 0;
-    latency_ema_ms = None;
     failure_streak = if status.healthy then 0 else 1;
     cooldown_until = unavailable;
     last_error =
@@ -144,7 +141,6 @@ let runtime_of_endpoint_url base_url =
         ~default:default_parallel_hint;
     active_slots = 0;
     queue_depth = 0;
-    latency_ema_ms = None;
     failure_streak = 0;
     cooldown_until = None;
     last_error = None;
@@ -169,7 +165,6 @@ let runtime_to_snapshot (runtime : runtime) =
     max_concurrency = runtime.max_concurrency;
     active_slots = runtime.active_slots;
     queue_depth = runtime.queue_depth;
-    latency_ema_ms = runtime.latency_ema_ms;
     failure_streak = runtime.failure_streak;
     cooldown_until = runtime.cooldown_until;
     last_error = runtime.last_error;
@@ -196,7 +191,6 @@ let default_runtime () =
       int_of_env_default "LLAMA_SERVER_PARALLEL_HINT" ~default:default_parallel_hint;
     active_slots = 0;
     queue_depth = 0;
-    latency_ema_ms = None;
     failure_streak = 0;
     cooldown_until = None;
     last_error = None;
@@ -333,7 +327,6 @@ let snapshot_to_yojson (snapshot : runtime_snapshot) =
       ("max_concurrency", `Int snapshot.max_concurrency);
       ("active_slots", `Int snapshot.active_slots);
       ("queue_depth", `Int snapshot.queue_depth);
-      ("latency_ema_ms", Json_util.float_opt_to_json snapshot.latency_ema_ms);
       ("failure_streak", `Int snapshot.failure_streak);
       ("cooldown_until", Json_util.float_opt_to_json snapshot.cooldown_until);
       ("last_error", Json_util.string_opt_to_json snapshot.last_error);

--- a/lib/local_runtime_pool/local_runtime_pool.mli
+++ b/lib/local_runtime_pool/local_runtime_pool.mli
@@ -37,7 +37,6 @@ type runtime = {
   max_concurrency : int;
   active_slots : int;
   queue_depth : int;
-  latency_ema_ms : float option;
   failure_streak : int;
   cooldown_until : float option;
   last_error : string option;
@@ -45,12 +44,10 @@ type runtime = {
   total_success : int;
   total_failure : int;
 }
-(** Per-endpoint runtime entry.  [latency_ema_ms] is the
-    exponential moving average of release-reported latency
-    (alpha = 0.2).  [failure_streak] tracks consecutive
-    failures; >= 3 triggers a [cooldown_until] window so
-    the selector skips the runtime until the window
-    elapses. *)
+(** Per-endpoint runtime entry.  [failure_streak] is 1 when the latest
+    discovery pass marked the endpoint unhealthy (else 0); unhealthy
+    endpoints also get a [cooldown_until] window so the selector skips
+    the runtime until the window elapses. *)
 
 type runtime_snapshot = {
   id : string;
@@ -59,7 +56,6 @@ type runtime_snapshot = {
   max_concurrency : int;
   active_slots : int;
   queue_depth : int;
-  latency_ema_ms : float option;
   failure_streak : int;
   cooldown_until : float option;
   last_error : string option;

--- a/test/test_local_runtime_pool.ml
+++ b/test/test_local_runtime_pool.ml
@@ -18,7 +18,6 @@ let make_runtime ?model ?(max_concurrency = 2) id base_url =
     max_concurrency;
     active_slots = 0;
     queue_depth = 0;
-    latency_ema_ms = None;
     failure_streak = 0;
     cooldown_until = None;
     last_error = None;


### PR DESCRIPTION
## Summary

Fake-implementation audit follow-up. Two dashboard-facing surfaces reported fabricated signals with no producer behind them:

- **`memory_check_default_json`** emitted a hardcoded placeholder (`performed=false`, `passed=true`, `threshold=0.18`) into the unified-metrics and heartbeat snapshots. No memory-check scoring path exists anywhere in the repo — the JSON was a constant, not a measurement, and the `0.18` threshold was invented. Removed the function, its `keeper_execution` re-export, and both snapshot fields.
- **`latency_ema_ms`** was documented as "EMA of release-reported latency (alpha=0.2)", but every constructor hardcoded `None` and no EMA computation ever existed. The leasing path that would have reported latency (`acquire`/`release`) was removed 2026-05-05 (see `docs/audit-responses/2026-05-05-dashboard-heuristic.md` §7.1), so the field could never gain a producer. Removed from `runtime`, `runtime_snapshot`, the JSON encoder, and the test fixture.
- Corrected the `failure_streak` mli doc: the ">= 3 triggers cooldown" claim had no backing code (cooldown comes directly from unhealthy discovery).

Repo-wide grep confirms zero remaining readers of both the `memory_check` JSON key and `latency_ema_ms`.

## Verification

- `scripts/dune-local.sh build lib/keeper lib/local_runtime_pool test/test_local_runtime_pool.exe` — green (warnings-as-errors incl. -w +32+33)
- `test_local_runtime_pool.exe` — 3/3 pass