### PR TITLE
fix(prompt): bound Board Activity, and say what it left out

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -552,6 +552,46 @@ let combine_prompt_sections sections =
    and exact-mention state remain source/routing context only; none of them
    grants instruction authority. Relevance and action remain model decisions,
    while external effects still cross the Gate. *)
+(* Board Activity was the one per-turn list with no bound. Its two siblings in
+   the same observation have one — [scheduled_automation_item_limit = 5] and
+   [Keeper_config.keeper_board_own_recent_max] — so the absence here was a gap,
+   not a policy.
+
+   The gap is invisible while a Keeper keeps up: the cursor advances each turn
+   and the list is short. It opens on resume. A Keeper down for hours comes back
+   to everything posted meanwhile, and the live board has produced 269 posts in
+   a day (2026-08-05); at ~220 bytes a row that is tens of KB in one turn,
+   against a 9,167-byte system prompt.
+
+   Bounded at the render, not at collection: [pending_board_events] also drives
+   the wake decision, and dropping events before that would change which turns
+   happen at all. This changes only what a turn that already happened reads.
+
+   Under the budget the output is byte-identical to before — same order, same
+   heading. Over it, mentions come first (an unread mention is the row whose
+   loss costs most), recency breaks the rest, and the heading states both counts
+   and the tool that fetches the remainder. Nothing is silently dropped. *)
+let board_activity_render_budget_rows = 20
+
+let board_activity_render_budget
+      (events : Keeper_world_observation.pending_board_event list)
+  : Keeper_world_observation.pending_board_event list
+  =
+  if List.length events <= board_activity_render_budget_rows
+  then events
+  else
+    events
+    |> List.stable_sort
+         (fun
+           (a : Keeper_world_observation.pending_board_event)
+           (b : Keeper_world_observation.pending_board_event)
+         ->
+           match compare b.explicit_mention a.explicit_mention with
+           | 0 -> compare b.updated_at a.updated_at
+           | ordered -> ordered)
+    |> List.filteri (fun i _ -> i < board_activity_render_budget_rows)
+;;
+
 let render_board_observations
       (events : Keeper_world_observation.pending_board_event list)
   : string
@@ -992,12 +1032,20 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta)
           observation.pending_board_events
       in
       if board_events <> [] then (
+        let total = List.length board_events in
+        let shown = board_activity_render_budget board_events in
+        let shown_count = List.length shown in
         let ubuf = Buffer.create 256 in
         Buffer.add_string ubuf
-          (Printf.sprintf "### Board Activity (%d new)\n"
-             (List.length board_events));
-        Buffer.add_string ubuf
-          (render_board_observations board_events);
+          (if shown_count < total
+           then
+             Printf.sprintf
+               "### Board Activity (%d new, %d shown — read the rest with \
+                masc_board_list)\n"
+               total
+               shown_count
+           else Printf.sprintf "### Board Activity (%d new)\n" total);
+        Buffer.add_string ubuf (render_board_observations shown);
         Buffer.add_string ubuf "\n\n";
         Some (Buffer.contents ubuf))
       else None

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -909,6 +909,56 @@ let test_own_recent_board_posts_show_the_response () =
   check bool "an unanswered post says so rather than omitting the field" true
     (contains_sub "replies=\"0\"" world_state)
 
+(* Board Activity is bounded at the render. The two cases below pin the two
+   halves of that: under the budget nothing changes, over it the heading states
+   what was left out and mentions survive the cut.
+
+   [board_activity_render_budget_rows] is 20; these build 25 so the excess is
+   five rows and the arithmetic in the heading is checkable by hand. *)
+let board_event_n ?(mention = false) i =
+  { sample_board_event with
+    post_id = Printf.sprintf "board-post-%02d" i
+  ; explicit_mention = mention
+  ; updated_at = float_of_int i
+  }
+
+let test_board_activity_under_the_budget_renders_every_row () =
+  let events = List.init 20 (fun i -> board_event_n i) in
+  let obs = { base_observation with pending_board_events = events } in
+  let { Masc.Keeper_unified_prompt.world_state; _ } =
+    build_prompt ~meta:minimal_meta obs
+  in
+  check bool "heading states one count only" true
+    (contains_sub "### Board Activity (20 new)" world_state);
+  check bool "no truncation notice" false (contains_sub "shown" world_state);
+  check bool "the last row is present" true
+    (contains_sub "board-post-19" world_state);
+  check bool "the first row is present" true
+    (contains_sub "board-post-00" world_state)
+
+let test_board_activity_over_the_budget_says_what_it_left_out () =
+  (* One mention, deliberately the oldest, so keeping it can only be the
+     mention rule and not recency. *)
+  let events =
+    board_event_n ~mention:true 0 :: List.init 24 (fun i -> board_event_n (i + 1))
+  in
+  let obs = { base_observation with pending_board_events = events } in
+  let { Masc.Keeper_unified_prompt.world_state; _ } =
+    build_prompt ~meta:minimal_meta obs
+  in
+  check bool "both counts stated" true
+    (contains_sub "### Board Activity (25 new, 20 shown" world_state);
+  check bool "the route to the rest is named" true
+    (contains_sub "masc_board_list" world_state);
+  check bool "the oldest row survives because it is a mention" true
+    (contains_sub "board-post-00" world_state);
+  check bool "the newest non-mention survives" true
+    (contains_sub "board-post-24" world_state);
+  (* 25 rows, 20 shown: the oldest non-mentions are the five dropped. With the
+     mention taking one slot, recency fills 19, so 01..05 fall out. *)
+  check bool "an oldest non-mention is dropped" false
+    (contains_sub "board-post-01" world_state)
+
 (* The post author is the one participant who never commented on their own
    thread, so [check_self_comment_status] answers [`Never] and [self_commented]
    stays false. The observation still resolves the commenter and a preview of
@@ -1071,6 +1121,12 @@ let () =
           test_case
             "prompt: own recent board posts show the response"
             `Quick test_own_recent_board_posts_show_the_response;
+          test_case
+            "prompt: Board Activity under the budget renders every row"
+            `Quick test_board_activity_under_the_budget_renders_every_row;
+          test_case
+            "prompt: Board Activity over the budget says what it left out"
+            `Quick test_board_activity_over_the_budget_says_what_it_left_out;
           test_case
             "prompt: a comment on your own post says who and what"
             `Quick test_a_comment_on_your_own_post_says_who_and_what;


### PR DESCRIPTION
Closes the gap measured in #27364.

## What

Board Activity was the one per-turn list with **no bound**, at collection or at
render. Its two siblings in the same observation have one:

```ocaml
let scheduled_automation_item_limit = 5                        (* :272 *)
let max_posts = Keeper_config.keeper_board_own_recent_max ()   (* :246 *)
```

So the absence was a gap, not a policy.

## When it opens

Invisible while a Keeper keeps up — the cursor advances each turn and the list
is short. It opens **on resume**. A Keeper down for hours comes back to
everything posted meanwhile, and the live board has produced 269 posts in a day:

```
board_posts.jsonl   08-05: 269   08-06: 177   08-07: 39
```

At ~220 bytes a row that is tens of KB in one turn, against a 9,167-byte system
prompt and a 72,485-byte tool surface (#27360).

## Bounded at the render, not at collection

`pending_board_events` also drives the **wake decision**. Dropping events before
that would change which turns happen at all. This changes only what a turn that
already happened reads.

## Under the budget, nothing changes

Same rows, same order, same heading — byte-identical. The budget only engages
above 20 rows, and then:

- **mentions first** — an unread mention is the row whose loss costs most
- recency breaks the rest
- the heading states both counts and names the tool for the remainder:

```
### Board Activity (25 new, 20 shown — read the rest with masc_board_list)
```

Nothing is dropped silently. That disclosure is what makes this a budget rather
than a truncation: `masc_board_list` already exists and already takes `hearth`,
`limit`, and `since`.

## Tests

Two cases in `test_keeper_unified_verification_surface`, which CI runs
(ci.yml:1380). They build 25 events against a budget of 20, so the excess is
five rows and the heading arithmetic is checkable by hand.

| case | asserts |
|---|---|
| under the budget renders every row | 20 rows → `(20 new)`, **no** "shown" notice, first and last row both present |
| over the budget says what it left out | 25 rows → `(25 new, 20 shown`, `masc_board_list` named, the **oldest** row survives because it is the mention, the newest non-mention survives, an oldest non-mention is gone |

The mention in the second case is deliberately the **oldest** event, so its
survival can only be the mention rule and not recency.

Verified not identities: with the tests in place and
`lib/keeper/keeper_unified_prompt.ml` reverted to `origin/main`,

```
1 failure! in 34 tests run
[FAIL] verification_surface 26  prompt: Board Activity over the budget says...
```

exactly the over-budget case fails. The under-budget case passes both ways,
which is what makes it a no-change guard rather than a restatement.

## Verification

```
dune build --root . @check                                    exit 0
@test/runtest-test_keeper_unified_verification_surface   34 tests, Successful
@test/runtest-test_keeper_tool_schema_bytes               2 tests, Successful
@test/runtest-test_keeper_system_prompt_bytes             2 tests, Successful
@test/runtest-test_keeper_prompt_metrics                 22 tests, Successful
@test/runtest-test_keeper_wake_turn_context              17 tests, Successful
```

## On the ratchet-vs-workaround line

A cap can be symptom suppression. This one is not: the root here is that a
per-turn resource had no budget, which is the same thing the two sibling limits
already say for their lists, and the disclosure line plus `masc_board_list`
means the information is bounded in the prompt rather than lost. No cooldown, no
dedup, no repair, and nothing is counted-and-ignored.

RFC-WAIVED: a render bound matching two existing sibling bounds in the same
observation. No collection change, no wake-behaviour change, no new tool.
