### PR TITLE
fix(prompt): errors carry the correction in the message, not a hint field

### DIFF
--- a/config/prompts/keeper.md
+++ b/config/prompts/keeper.md
@@ -159,8 +159,9 @@ the runtime reports the matching result.
 
 ## When something fails
 
-A failed call is typed evidence. Read its error and correction hint, then
-correct the exact request, continue independent work, or report the blocker.
+A failed call is typed evidence. Read its message, which answers a rejected
+value with the accepted set, then correct the exact request, continue
+independent work, or report the blocker.
 Failure or delay in one capability, provider, conversation, or Keeper does not
 stop unrelated work.
 

--- a/test/fixtures/keeper_system_prompt/assembled_prompt.golden
+++ b/test/fixtures/keeper_system_prompt/assembled_prompt.golden
@@ -155,8 +155,9 @@ the runtime reports the matching result.
 
 ## When something fails
 
-A failed call is typed evidence. Read its error and correction hint, then
-correct the exact request, continue independent work, or report the blocker.
+A failed call is typed evidence. Read its message, which answers a rejected
+value with the accepted set, then correct the exact request, continue
+independent work, or report the blocker.
 Failure or delay in one capability, provider, conversation, or Keeper does not
 stop unrelated work.
 


### PR DESCRIPTION
## What

`keeper.md` told every Keeper:

> A failed call is typed evidence. Read its error **and correction hint**, then
> correct the exact request…

There is no correction hint. `recovery_hints` in `lib/response` is the only
thing in the tree that field could mean, and it has no producer. Measured over
the live tool log — every failed call, all history:

```
shell/fs      3,248 failures    0 with hints
masc/keeper     567 failures    0 with hints
other            37 failures    0 with hints
```

## The correction is real; it is in the message

```
invalid sort. Valid: hot, trending, recent, updated, discussed
invalid Board target token(s): @
artifact does not exist
```

So the sentence pointed at a structure that does not exist while the substance
was one field away. Naming the message is what makes it findable.

```diff
-A failed call is typed evidence. Read its error and correction hint, then
-correct the exact request, continue independent work, or report the blocker.
+A failed call is typed evidence. Read its message, which answers a rejected
+value with the accepted set, then correct the exact request, continue
+independent work, or report the blocker.
```

## It costs 36 bytes a turn

9,167 → 9,203, measured by `test_keeper_system_prompt_bytes` next door.

Stating it because most of this session's prompt work went the other way
(#27353 took 190 bytes out). This one buys accuracy with length: a sentence that
is longer and true, against one that was shorter and pointed nowhere. The
concrete clause — *"answers a rejected value with the accepted set"* — is what
earns the bytes; without it the sentence is just "read the error", which a model
does anyway.

My first draft was four lines. It is three now, one more than the original.

## Relationship to #27371

#27371 deletes the dead `recovery_hints` field and the module around it. This
PR stands alone: the field never had a producer, so the wording was wrong before
that PR and would stay wrong if it never merged. Either can land first.

Deliberately **not** in #27371 — mixing a mechanical module removal with a
prompt judgement would make one diff answer two questions.

## Verification

```
@test/runtest-test_keeper_system_prompt_bytes      2 tests, Successful
@test/runtest-test_keeper_prompt_metrics          22 tests, Successful
@test/runtest-test_keeper_surface_presence_prompt 16 tests, Successful
@test/runtest-test_keeper_wake_turn_context       17 tests, Successful
```

The golden diff is the trimmed paragraph and nothing else — checked before
moving `.actual` over it.

`test_workspace_coverage.ml:618` also says "correction hint", in a doc comment
about the single-claim refusal carrying its own correction. That is about the
message content, which is what this PR now points at, so it needs no change.

RFC-WAIVED: one prompt sentence corrected to match what failed calls actually
carry. No code change.
