### PR TITLE
refactor(types): 감쇠한 적 없는 메시지 relevance 필드 제거

### DIFF
--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -632,7 +632,6 @@ let message_json (message : Masc_domain.message) =
     ; "timestamp", `String message.timestamp
     ; "trace_context", Json_util.string_opt_to_json message.trace_context
     ; "expires_at", Json_util.float_opt_to_json message.expires_at
-    ; "relevance", `String message.relevance
     ; "seq", `Int message.seq
     ]
 ;;

--- a/lib/dashboard/dashboard_workspace.ml
+++ b/lib/dashboard/dashboard_workspace.ml
@@ -117,7 +117,6 @@ let message_json (msg : Masc_domain.message) =
     ; "body", `String body
     ; "mentions", `List (List.map (fun target -> `String target) mentions)
     ; ("expires_at", Json_util.float_opt_to_json msg.expires_at)
-    ; "relevance", `String msg.relevance
     ]
   in
   `Assoc base

--- a/lib/graphql_api.ml
+++ b/lib/graphql_api.ml
@@ -350,10 +350,6 @@ let message_typ =
         ~typ:Schema.float
         ~args:Arg.[]
         ~resolve:(fun _ (message : Masc_domain.message) -> message.expires_at);
-      Schema.field "relevance"
-        ~typ:(Schema.non_null Schema.string)
-        ~args:Arg.[]
-        ~resolve:(fun _ (message : Masc_domain.message) -> message.relevance);
     ]
 
 let workspace_state_typ =

--- a/lib/server/server_dashboard_http_core_entities.ml
+++ b/lib/server/server_dashboard_http_core_entities.ml
@@ -50,7 +50,6 @@ let dashboard_message_json (message : Masc_domain.message) =
     ; "timestamp", `String message.timestamp
     ; "trace_context", Json_util.string_opt_to_json message.trace_context
     ; "expires_at", Json_util.float_opt_to_json message.expires_at
-    ; "relevance", `String message.relevance
     ; "seq", `Int message.seq
     ]
 ;;

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -879,7 +879,6 @@ type message = {
   timestamp: string;
   trace_context: string option; [@default None]
   expires_at: float option; [@default None]
-  relevance: string; [@default "medium"]
 } [@@deriving yojson { strict = false }, show]
 
 (** Workspace state *)

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -288,7 +288,6 @@ type message =
   ; timestamp : string
   ; trace_context : string option [@default None]
   ; expires_at : float option [@default None]
-  ; relevance : string [@default "medium"]
   }
 [@@deriving yojson { strict = false }, show]
 

--- a/lib/workspace/event_kind.ml
+++ b/lib/workspace/event_kind.ml
@@ -80,29 +80,3 @@ module Board = struct
 
   let all = [ Posted; Commented; Voted; Deleted ]
 end
-
-module Relevance = struct
-  type t =
-    | Critical
-    | High
-    | Medium
-    | Low
-    | Stale
-
-  let to_string = function
-    | Critical -> "critical"
-    | High -> "high"
-    | Medium -> "medium"
-    | Low -> "low"
-    | Stale -> "stale"
-
-  let of_string = function
-    | "critical" -> Some Critical
-    | "high" -> Some High
-    | "medium" -> Some Medium
-    | "low" -> Some Low
-    | "stale" -> Some Stale
-    | _ -> None
-
-  let all = [ Critical; High; Medium; Low; Stale ]
-end

--- a/lib/workspace/event_kind.mli
+++ b/lib/workspace/event_kind.mli
@@ -65,18 +65,3 @@ module Board : sig
   val of_string : string -> t option
   val all : t list
 end
-
-module Relevance : sig
-  type t =
-    | Critical
-    | High
-    | Medium
-    | Low
-    | Stale
-
-  val to_string : t -> string
-  (** Canonical broadcast relevance label (e.g. [medium]). *)
-
-  val of_string : string -> t option
-  val all : t list
-end

--- a/lib/workspace/workspace_broadcast.ml
+++ b/lib/workspace/workspace_broadcast.ml
@@ -191,7 +191,6 @@ let broadcast ?trace_context ?(msg_type = "broadcast") config ~from_agent ~conte
     timestamp = now_iso ();
     trace_context;
     expires_at = None;
-    relevance = Event_kind.Relevance.(to_string Medium);
   } in
   let msg_file =
     Filename.concat (messages_dir config)

--- a/test/test_dashboard_briefing.ml
+++ b/test/test_dashboard_briefing.ml
@@ -468,7 +468,7 @@ let make_message ?mention ~seq ~from_agent ~content () : Types.message =
     timestamp = "";
     trace_context = None;
     expires_at = None;
-    relevance = "medium" }
+    }
 
 (* Regression: a degenerate agent record with an empty/whitespace name must not
    crash latest_message_to (String.get on an empty [lowered]). *)

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -2066,7 +2066,7 @@ let test_dashboard_execution_trust_default_route_uses_cached_surface () =
     (json |> member "dashboard_surface_envelope" |> member "cache" |> member "key"
      |> to_string)
 
-let test_dashboard_message_json_surfaces_temporal_decay_fields () =
+let test_dashboard_message_json_surfaces_temporal_fields () =
   let message : Types.message =
     {
       seq = 7;
@@ -2077,7 +2077,6 @@ let test_dashboard_message_json_surfaces_temporal_decay_fields () =
       timestamp = "2026-05-07T00:00:00Z";
       trace_context = Some "traceparent";
       expires_at = Some 1_714_067_200.0;
-      relevance = "critical";
     }
   in
   let json = Server_dashboard_http_core.dashboard_message_json message in
@@ -2086,9 +2085,7 @@ let test_dashboard_message_json_surfaces_temporal_decay_fields () =
   check string "trace_context" "traceparent"
     (json |> member "trace_context" |> to_string);
   check (float 0.001) "expires_at" 1_714_067_200.0
-    (json |> member "expires_at" |> to_float);
-  check string "relevance" "critical"
-    (json |> member "relevance" |> to_string)
+    (json |> member "expires_at" |> to_float)
 
 (* RFC-0138 Phase 3 Step 1 — /shell snapshot wire tests.
 
@@ -3371,7 +3368,7 @@ let () =
           test_case "execution trust default route uses cached surface" `Quick
             test_dashboard_execution_trust_default_route_uses_cached_surface;
           test_case "message JSON exposes temporal decay fields" `Quick
-            test_dashboard_message_json_surfaces_temporal_decay_fields;
+            test_dashboard_message_json_surfaces_temporal_fields;
           test_case "RFC-0138 shell wire returns snapshot when published" `Quick
             test_shell_snapshot_wire_returns_snapshot_when_published;
           test_case "RFC-0138 shell wire falls back when snapshot empty" `Quick

--- a/test/test_event_kind.ml
+++ b/test/test_event_kind.ml
@@ -99,32 +99,4 @@ let () =
         exit 1
       end)
     Event_kind.Board.all;
-  (* Relevance family: broadcast temporal decay schema labels. *)
-  List.iter
-    (fun v ->
-      let s = Event_kind.Relevance.to_string v in
-      match Event_kind.Relevance.of_string s with
-      | Some v' when v' = v -> ()
-      | Some _ ->
-          Printf.eprintf
-            "event_kind Relevance roundtrip mismatch for %s\n%!" s;
-          exit 1
-      | None ->
-          Printf.eprintf
-            "event_kind Relevance of_string returned None for %s\n%!" s;
-          exit 1)
-    Event_kind.Relevance.all;
-  (match Event_kind.Relevance.of_string "meduim" with
-   | Some _ ->
-       prerr_endline "event_kind Relevance.of_string accepted a typo";
-       exit 1
-   | None -> ());
-  let relevance_names =
-    List.map Event_kind.Relevance.to_string Event_kind.Relevance.all
-  in
-  let unique_relevance_names = List.sort_uniq String.compare relevance_names in
-  if List.length relevance_names <> List.length unique_relevance_names then begin
-    prerr_endline "event_kind Relevance contains duplicate wire labels";
-    exit 1
-  end;
   print_endline "test_event_kind: OK"

--- a/test/test_graphql_api.ml
+++ b/test/test_graphql_api.ml
@@ -76,7 +76,7 @@ let test_messages_temporal_decay_fields () =
   in
   let json =
     graphql_query config
-      "{ messages(first: 10) { totalCount edges { node { from messageType content mention expiresAt relevance } } } }"
+      "{ messages(first: 10) { totalCount edges { node { from messageType content mention expiresAt } } } }"
   in
   let open Yojson.Safe.Util in
   let total = json |> member "data" |> member "messages" |> member "totalCount" |> to_int in
@@ -96,8 +96,6 @@ let test_messages_temporal_decay_fields () =
     (node |> member "mention" |> to_string);
   Alcotest.(check bool) "expiresAt null" true
     (node |> member "expiresAt" = `Null);
-  Alcotest.(check string) "relevance" "medium"
-    (node |> member "relevance" |> to_string);
   cleanup_dir base_path
 
 let () =


### PR DESCRIPTION
## 무엇을

메시지 `relevance` 필드와 `Event_kind.Relevance` enum을 제거한다. "시간 감쇠(temporal decay)" 신호로 도입됐는데 감쇠가 구현된 적이 없다.

## 출처

```
619d12014f  feat(coord): expose broadcast temporal decay schema (#11329) (#14105)  2026-05-07
```

커밋 제목이 그대로 말한다 — **schema**만 넣었다. 같은 커밋이 추가한 것: enum, 레코드 필드, GraphQL 필드, dashboard JSON echo, 테스트. 추가하지 않은 것: **감쇠 계산**. 3개월이 지난 지금도 생산자는 하나뿐이고 값도 하나뿐이다.

`Stale` variant의 존재가 의도를 드러낸다 — 시간이 지나면 `Medium → Low → Stale`로 내려가는 설계였을 것이다. 그 전이를 쓰는 코드는 없다.

## 측정

main 기준:

| 항목 | 값 |
|---|---|
| `Relevance` variant | 5 (`Critical`/`High`/`Medium`/`Low`/`Stale`) |
| 프로덕션에서 생산되는 variant | **1** (`workspace_broadcast.ml:194`, 항상 `Medium`) |
| `Relevance.of_string` 프로덕션 호출자 | **0** |
| `message.relevance`로 분기하는 코드 | **0** (4개 소비자 전부 JSON echo) |
| dashboard TS에서 읽는 곳 | **0** |
| `.masc/messages` 영속 메시지 중 키 보유 | **0 / 486** |

마지막 줄이 결정적이다. `[@default "medium"]`이라 ppx가 기본값과 같으면 직렬화에서 생략한다 — 이 필드는 **디스크에 존재한 적이 없다.** 3개월치 메시지 486건 전수 확인.

```
$ rg -l '"relevance"' ~/me/.masc/messages | wc -l
0
```

## 테스트가 상수를 고정하고 있었다

```ocaml
(* test_graphql_api.ml:99 *)
Alcotest.(check string) "relevance" "medium" (node |> member "relevance" |> to_string);
```

판정을 검사하는 게 아니라 **상수를 검사**한다. 반대편은 더 나쁘다:

```ocaml
(* test_dashboard_http_core.ml:2080 *)
relevance = "critical";
```

프로덕션 경로가 만들 수 없는 값으로 픽스처를 짓는다. 그 테스트 이름이 `test_dashboard_message_json_surfaces_temporal_decay_fields`였다 — 존재하지 않는 감쇠를 검사한다고 이름 붙이고 있었다. `expires_at`(실제 TTL)만 남으므로 `..._temporal_fields`로 고쳤다.

네 스위트 중 `test_dashboard_briefing` 하나만 CI 배선돼 있다. `test_graphql_api`, `test_event_kind`, `test_dashboard_http_core`는 미배선이다.

## 제거 대상

| 위치 | 제거 |
|---|---|
| `types_core.ml/.mli` | `relevance : string [@default "medium"]` |
| `event_kind.ml/.mli` | `module Relevance` (5 variant + `to_string`/`of_string`/`all`) |
| `graphql_api.ml` | `Message.relevance` 필드 |
| `workspace_broadcast.ml` | 유일한 생산자 라인 |
| `dashboard_workspace.ml`, `dashboard_execution.ml`, `server_dashboard_http_core_entities.ml` | JSON echo 3곳 |
| 테스트 4개 | 상수를 고정하던 어셔션 |

## API 영향

**GraphQL `Message.relevance` 필드가 사라진다.** 항상 문자열 `"medium"`을 반환하던 필드다. 저장소 안에서 이걸 질의하는 클라이언트는 없다(dashboard TS 0건, `.graphql` 문서 없음). 외부 클라이언트가 있었다면 상수에 의존하고 있던 것이다.

읽기는 하위 호환된다 — `message_of_yojson`이 `strict = false`라 `"relevance"`가 남아 있는 JSON은 조용히 무시된다. 애초에 그런 JSON은 없다.

## 선례

RFC-0249가 같은 근거로 `stale_factor`를 제거했다: *"an intended feature whose producer was never implemented"*, 소비자는 상수 곱. 이번 건도 같은 형태이며, `lib/types/` · `lib/workspace/`는 RFC 게이트 대상 subsystem이 아니다.

## 검증

```
dune build --root . @check                             # exit 0
./_build/default/test/test_event_kind.exe              # PASS
./_build/default/test/test_graphql_api.exe             # PASS
./_build/default/test/test_dashboard_briefing.exe      # PASS (CI 배선된 유일한 스위트)
./_build/default/test/test_dashboard_http_core.exe     # 72 tests, Test Successful
bash scripts/ci/check-determinism-contract.sh          # DET/NDT gate: PASS
python3 scripts/verify-test-registration.py            # Unregistered 0 / Orphaned 0
```

미검증: GraphQL Playground(`GET /graphql`)에서 스키마 introspection을 직접 띄워보지 않았다. `Schema.field "relevance"` 정의를 지웠으므로 introspection에서도 사라지는 것이 ocaml-graphql-server의 동작이지만, 실행 확인은 아니다.
