### PR TITLE
refactor(workspace): 아무도 읽지 않는 broadcast 관측 스캐폴딩 제거

### DIFF
--- a/lib/workspace/workspace_broadcast.ml
+++ b/lib/workspace/workspace_broadcast.ml
@@ -6,23 +6,6 @@
 open Masc_domain
 open Workspace_utils
 
-(** RFC-0061: closed variants for broadcast envelope observability.
-    rewrite_reason tracks why the original content was rewritten.
-    msg_type_typed is an internal closed variant; the external [msg_type]
-    field remains [string] for backward compatibility. *)
-type rewrite_reason =
-  | Cache_invalidated of { task_id : string; status : string }
-  | Task_cache_rewrite
-
-type rewrite_event = {
-  reason : rewrite_reason;
-  module_name : string;
-}
-
-type msg_type_typed =
-  | Broadcast
-  | Cache_invalidated of { task_id : string; status : string }
-
 type broadcast_delivery =
   { rendered : string
   ; from_agent : string
@@ -30,10 +13,6 @@ type broadcast_delivery =
   ; mention : string option
   ; msg_type : string
   }
-
-let string_of_msg_type_typed = function
-  | Broadcast -> "broadcast"
-  | Cache_invalidated _ -> "cache_invalidated"
 
 let emit_message_activity config ~from_agent ~content ~mention
     ?session_id ?operation_id ?worker_run_id ?(evidence_refs = []) () =
@@ -97,7 +76,7 @@ let broadcast ?trace_context ?(msg_type = "broadcast") config ~from_agent ~conte
      terminal in the backlog, replace the original broadcast with a single
      cache_invalidated notice and clear the stale state (issue #13397).
      Only applied to regular "broadcast" messages to avoid recursion. *)
-  let content, msg_type, _rewrites =
+  let content, msg_type =
     if String.equal msg_type "broadcast" then
       let agent_file =
         Filename.concat (agents_dir config) (safe_filename from_agent ^ ".json")
@@ -118,60 +97,26 @@ let broadcast ?trace_context ?(msg_type = "broadcast") config ~from_agent ~conte
                          — stale broadcast suppressed"
                         task_id (Masc_domain.task_status_to_string status)
                     in
-                    ( inv_content,
-                      "cache_invalidated",
-                      [
-                        {
-                          reason =
-                            Cache_invalidated
-                              {
-                                task_id;
-                                status =
-                                  Masc_domain.task_status_to_string status;
-                              };
-                          module_name = "workspace_broadcast";
-                        };
-                      ] )
+                    (inv_content, "cache_invalidated")
                 | _ ->
                     ( Workspace_task_cache_invariant.rewrite_broadcast_content
                         ~config ~from_agent ~module_name:"workspace_broadcast"
                         ~content,
-                      msg_type,
-                      [
-                        {
-                          reason = Task_cache_rewrite;
-                          module_name = "workspace_broadcast";
-                        };
-                      ] ))
+                      msg_type ))
             | None ->
                 ( Workspace_task_cache_invariant.rewrite_broadcast_content
                     ~config ~from_agent ~module_name:"workspace_broadcast"
                     ~content,
-                  msg_type,
-                  [
-                    {
-                      reason = Task_cache_rewrite;
-                      module_name = "workspace_broadcast";
-                    };
-                  ] ))
+                  msg_type ))
         | Error _ ->
             ( Workspace_task_cache_invariant.rewrite_broadcast_content
                 ~config ~from_agent ~module_name:"workspace_broadcast" ~content,
-              msg_type,
-              [
-                {
-                  reason = Task_cache_rewrite;
-                  module_name = "workspace_broadcast";
-                };
-              ] )
+              msg_type )
       else
         ( Workspace_task_cache_invariant.rewrite_broadcast_content
             ~config ~from_agent ~module_name:"workspace_broadcast" ~content,
-          msg_type,
-          [
-            { reason = Task_cache_rewrite; module_name = "workspace_broadcast" };
-          ] )
-    else (content, msg_type, [])
+          msg_type )
+    else (content, msg_type)
   in
   let seq = Workspace_state.next_seq config in
   let mention = pre_extract_mention in

--- a/lib/workspace/workspace_broadcast.mli
+++ b/lib/workspace/workspace_broadcast.mli
@@ -2,20 +2,6 @@
     accompanying message-activity event. *)
 
 
-(** RFC-0061: closed variants for broadcast envelope observability. *)
-type rewrite_reason =
-  | Cache_invalidated of { task_id : string; status : string }
-  | Task_cache_rewrite
-
-type rewrite_event = {
-  reason : rewrite_reason;
-  module_name : string;
-}
-
-type msg_type_typed =
-  | Broadcast
-  | Cache_invalidated of { task_id : string; status : string }
-
 type broadcast_delivery =
   { rendered : string
   ; from_agent : string
@@ -23,8 +9,6 @@ type broadcast_delivery =
   ; mention : string option
   ; msg_type : string
   }
-
-val string_of_msg_type_typed : msg_type_typed -> string
 
 val emit_message_activity : Workspace_utils_backend_setup.config ->
            from_agent:string ->


### PR DESCRIPTION
## 무엇을

`workspace_broadcast.ml`의 "broadcast envelope observability" 스캐폴딩을 제거한다. 관측하는 코드가 없고, 도입 커밋 자체가 산출물을 버리고 있었다.

## 도입 시점부터 버려져 있었다

```
2699965d18  fix(coord): RFC-0061 cache-invalidation broadcast envelope (#14424)
```

그 커밋의 `coord_broadcast.ml:107`:

```ocaml
let content, msg_type, _rewrites =
```

**밑줄이 도입 커밋에 이미 있다.** 그리고 이 파일에서 `rewrites`를 건드린 커밋은 이력 전체에서 그 하나뿐이다:

```
$ git log --oneline -S'rewrites' -- lib/workspace/workspace_broadcast.ml lib/coord/coord_broadcast.ml
2699965d18 fix(coord): RFC-0061 cache-invalidation broadcast envelope (#14424)
```

읽힌 적이 한 번도 없다.

## 측정

| 심볼 | 상태 |
|---|---|
| `rewrite_event` | 5개 분기에서 **생성**, `_rewrites`로 바인딩 후 **0회 읽기** |
| `rewrite_reason` | 폐기되는 레코드를 채우는 용도로만 존재 |
| `msg_type_typed` | 사용 **0** |
| `string_of_msg_type_typed` | 호출자 **0** |

`string_of_msg_type_typed`는 `Module.` 형태가 아니라 **맨이름으로** 검색했다. `workspace_broadcast`는 4개 모듈이 `include`하고 `Workspace`를 통해 재export되므로 점 표기만 세면 놓친다.

```
$ rg 'string_of_msg_type_typed' . --glob '!_build' --glob '!*.md'
lib/workspace/workspace_broadcast.ml:34:let string_of_msg_type_typed = function
lib/workspace/workspace_broadcast.mli:27:val string_of_msg_type_typed : msg_type_typed -> string
```

정의와 선언뿐이다.

## 생성자 이름 중복

`Cache_invalidated`가 **두 타입에 각각** 정의돼 있었다:

```ocaml
type rewrite_reason =
  | Cache_invalidated of { task_id : string; status : string }   (* 재작성 경로가 실제로 만드는 쪽 *)
  | Task_cache_rewrite

type msg_type_typed =
  | Broadcast
  | Cache_invalidated of { task_id : string; status : string }   (* 아무도 안 만드는 쪽 *)
```

같은 페이로드, 같은 이름, 다른 타입. 뒤쪽이 앞쪽을 가린다.

## 제거 후

다섯 분기가 원래 의미하던 `(content, msg_type)` 쌍을 그대로 반환한다. 예:

```ocaml
-                    ( inv_content,
-                      "cache_invalidated",
-                      [ { reason = Cache_invalidated { task_id; status = ... };
-                          module_name = "workspace_broadcast" } ] )
+                    (inv_content, "cache_invalidated")
```

**동작 변화 없음** — 버려지던 값이다.

## RFC-0061 문서가 없다

`rg -l 'RFC-0061'`이 이 두 소스 파일만 반환한다. `docs/rfc/`에 해당 문서가 없다. 코드 주석이 존재하지 않는 RFC를 인용하고 있다. 이번 PR이 그 인용 두 곳 중 하나를 제거하고, 남는 하나는 mention 추출 순서에 관한 별개 주석이다.

## 검증

```
dune build --root . @check                        # exit 0
./_build/default/test/test_dashboard_workspace.exe # Test Successful, 2 tests
./_build/default/test/test_workspace.exe           # 11 failures / 82 tests
```

`test_workspace`의 11건은 **baseline과 동일**하다. `origin/main`(da2586362e)을 깨끗한 worktree에 체크아웃해 같은 실행을 돌렸고, 실패 집합이 문자 단위로 일치한다:

```
$ diff <(baseline FAIL 목록) <(이 브랜치 FAIL 목록)
(차이 없음)
```

실패는 전부 `board_admin` / `idle_stop_signals` / `task_identity` 그룹이고 broadcast 경로와 무관하다.

미검증: 실행 중인 서버에서 broadcast를 실제로 발생시켜 `cache_invalidated` 재작성 경로를 밟아보지는 않았다. 그 경로는 `@check`로 컴파일만 확인했다.
