### PR TITLE
refactor(plan): the plan tools have one door, not nine

### DIFF
--- a/lib/tool_plan.mli
+++ b/lib/tool_plan.mli
@@ -1,7 +1,11 @@
 
 (** Plan Tool Handlers
 
-    Extracted from mcp_server_eio.ml for testability.
+    Extracted from mcp_server_eio.ml for testability, which [dispatch]
+    provides: test_tool_plan_coverage drives all eight tools through it by
+    name and never named a handler. The handlers themselves were exported
+    too, and nothing outside this module ever called one.
+
     8 tools: plan_init, plan_update, note_add, deliver, plan_get,
              plan_set_task, plan_get_task, plan_clear_task
 *)
@@ -10,17 +14,6 @@
 type context = {
   config: Workspace.config;
 }
-
-(** {1 Individual Handlers} *)
-
-val handle_plan_init : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
-val handle_plan_update : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
-val handle_note_add : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
-val handle_deliver : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
-val handle_plan_get : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
-val handle_plan_set_task : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
-val handle_plan_get_task : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
-val handle_plan_clear_task : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
 
 (** {1 Dispatcher} *)
 


### PR DESCRIPTION
## What

`tool_plan.mli` exported eight `handle_*` functions alongside `dispatch`:

```ocaml
(** {1 Individual Handlers} *)
val handle_plan_init : ...
val handle_plan_update : ...
val handle_note_add : ...
val handle_deliver : ...
val handle_plan_get : ...
val handle_plan_set_task : ...
val handle_plan_get_task : ...
val handle_plan_clear_task : ...
```

Nothing outside the module ever called one.

## The rationale was already satisfied

The header said the module was *"extracted from mcp_server_eio.ml for
testability"* — and `dispatch` is what provides it:

```
test/test_tool_plan_coverage.ml   Tool_plan.dispatch    used throughout
                                  Tool_plan.handle*     0 calls
```

Every external caller uses `dispatch` too:

```
lib/mcp_server_eio_execute.ml:280        Tool_plan.dispatch { config } ~name ~args
lib/keeper/keeper_tool_in_process_runtime.ml:848  Tool_plan.dispatch ctx ~name ~args
lib/keeper/keeper_tag_dispatch.ml:75     Tool_plan.dispatch { config } ~name ~args
```

## Why narrower matters here, beyond tidiness

A second entry point into the same dispatch table is a way to reach a tool
**without** the name-based routing every other caller goes through. Nothing was
using it, so this closes the alternative before it becomes one.

## How it was found and proved

`scripts/audit-dead-surface.py --exports` reported these eight as directly
removable — one of 517 in that group. Proved the way that tool's own docstring
prescribes, because it is explicit that a candidate is not a proof:

> 1. delete the `val` line from the `.mli`
> 2. rebuild; if the name was in fact used elsewhere the build fails loudly

It did not fail.

That audit only became runnable in #27386 (it walked 2.3M paths and never
finished); this is the first candidate taken from it. The other 845 are not
touched here — the docstring lists five categories where unreachable is not
removable, and each needs the same per-case check this one got.

## Verification

```
dune build --root . @check                             exit 0
dune build --root . @test/runtest-test_tool_plan_coverage
                                       Test Successful, 22 tests run
```

The header comment is updated to say what actually provides the testability, so
the next reader does not re-derive it.

RFC-WAIVED: eight `val` lines removed from an interface, no implementation
change, no behaviour change.
