### PR TITLE
fix(server): rename 가드가 볼 수 없던 밑줄 별칭 제거

### DIFF
--- a/lib/server/server_dashboard_http_core_cache.ml
+++ b/lib/server/server_dashboard_http_core_cache.ml
@@ -46,22 +46,18 @@ let dashboard_projection_cache_ttl_s = 120.0
     Atomic.t for cross-domain visibility: read from executor pool
     worker domains via namespace-truth and warmup helpers. *)
 let shell_warmed : bool Atomic.t = Atomic.make false
-let _shell_warmed = shell_warmed
 
 (** Track whether the startup shell pre-warm fiber is still building the
     first payload. Cold HTTP requests use this to serve a bootstrap payload
     instead of blocking on the same expensive shell projection. *)
 let shell_warming : bool Atomic.t = Atomic.make false
-let _shell_warming = shell_warming
 
 (** Last-known-good shell result for graceful degradation on timeout. *)
 let last_good_shell : Yojson.Safe.t Atomic.t = Atomic.make (`Assoc [])
-let _last_good_shell = last_good_shell
 
 (** Last-known-good light shell result for first-paint requests while
     full shell pre-warm is still running. *)
 let last_good_shell_light : Yojson.Safe.t Atomic.t = Atomic.make (`Assoc [])
-let _last_good_shell_light = last_good_shell_light
 
 (** Wrap a dashboard computation with a configurable timeout.
     Returns a partial-response JSON on timeout instead of hanging. *)

--- a/lib/server/server_dashboard_http_core_cache.mli
+++ b/lib/server/server_dashboard_http_core_cache.mli
@@ -11,13 +11,9 @@ val realtime_cache_ttl_s : float
 val feature_health_cache_ttl_s : float
 val dashboard_projection_cache_ttl_s : float
 val shell_warmed : bool Atomic.t
-val _shell_warmed : bool Atomic.t
 val shell_warming : bool Atomic.t
-val _shell_warming : bool Atomic.t
 val last_good_shell : Yojson.Safe.t Atomic.t
-val _last_good_shell : Yojson.Safe.t Atomic.t
 val last_good_shell_light : Yojson.Safe.t Atomic.t
-val _last_good_shell_light : Yojson.Safe.t Atomic.t
 
 val with_dashboard_timeout :
   clock:_ Eio.Time.clock -> (unit -> Yojson.Safe.t) -> Yojson.Safe.t

--- a/lib/server/server_dashboard_http_core_operator.ml
+++ b/lib/server/server_dashboard_http_core_operator.ml
@@ -39,8 +39,6 @@ let operator_digest_broadcast_ref : (Yojson.Safe.t -> unit) ref =
   ref (fun (_json : Yojson.Safe.t) -> ())
 ;;
 
-let _operator_digest_broadcast_ref = operator_digest_broadcast_ref
-
 let operator_snapshot_cache =
   let initializing_json () =
     `Assoc
@@ -276,8 +274,6 @@ let operator_digest_cache =
         ; "generated_at", `String (Masc_domain.now_iso ())
         ])
 ;;
-
-let _operator_digest_cache = operator_digest_cache
 
 let operator_refresh_interval_s =
   float_of_env_default

--- a/lib/server/server_dashboard_http_core_operator.mli
+++ b/lib/server/server_dashboard_http_core_operator.mli
@@ -17,7 +17,6 @@ type operator_snapshot_compute =
 
 val operator_snapshot_broadcast_ref : (operator_snapshot_publication -> unit) ref
 val operator_digest_broadcast_ref : (Yojson.Safe.t -> unit) ref
-val _operator_digest_broadcast_ref : (Yojson.Safe.t -> unit) ref
 val operator_snapshot_publication : unit -> operator_snapshot_publication
 val operator_snapshot_publication_with_freshness :
   unit -> operator_snapshot_publication * bool
@@ -46,7 +45,6 @@ val mark_operator_snapshot_error_if_current :
   operator_snapshot_publication option
 
 val operator_digest_cache : Server_dashboard_http_cache.cached_surface
-val _operator_digest_cache : Server_dashboard_http_cache.cached_surface
 val operator_refresh_interval_s : float
 val operator_snapshot_extra : unit -> (string * Yojson.Safe.t) list
 

--- a/test/test_rfc_0085_pr16_dashboard_http_core_rename.ml
+++ b/test/test_rfc_0085_pr16_dashboard_http_core_rename.ml
@@ -7,7 +7,23 @@ open Alcotest
     refs/atomics/caches — actively used at runtime, so the [_xxx]
     convention misled readers.  Shipped without test; pin now. *)
 
-let file = "lib/server/server_dashboard_http_core.ml"
+(* Scan the whole [server_dashboard_http_core*] family, not a single path.
+   The original guard pinned [server_dashboard_http_core.ml] alone. That file
+   was later split into [_cache.ml] / [_operator.ml] / ... and the underscore
+   aliases reappeared in the split files, where this test could not see them —
+   it stayed green with 5 of the 7 forbidden names alive. Globbing the prefix
+   keeps the guard honest across the next split too. *)
+let dir = "lib/server"
+
+let files =
+  Sys.readdir dir
+  |> Array.to_list
+  |> List.filter (fun name ->
+       String.starts_with ~prefix:"server_dashboard_http_core" name
+       && Filename.check_suffix name ".ml")
+  |> List.sort String.compare
+  |> List.map (Filename.concat dir)
+;;
 
 let renamed_identifiers =
   [ "_shell_warmed", "shell_warmed"
@@ -21,18 +37,30 @@ let renamed_identifiers =
 ;;
 
 let test_old_underscore_names_gone () =
+  check bool "the module family must not be empty" true (files <> []);
   List.iter
     (fun (old_name, _) ->
-      let n = Ast_grep.count_value_bindings ~module_path:file ~name:old_name in
-      let msg = Printf.sprintf "old underscore name %s should be removed" old_name in
-      check int msg 0 n)
+      List.iter
+        (fun file ->
+          let n = Ast_grep.count_value_bindings ~module_path:file ~name:old_name in
+          let msg =
+            Printf.sprintf "old underscore name %s should be removed from %s"
+              old_name file
+          in
+          check int msg 0 n)
+        files)
     renamed_identifiers
 ;;
 
 let test_new_names_present () =
   List.iter
     (fun (_, new_name) ->
-      let n = Ast_grep.count_value_bindings ~module_path:file ~name:new_name in
+      let n =
+        List.fold_left
+          (fun acc file ->
+            acc + Ast_grep.count_value_bindings ~module_path:file ~name:new_name)
+          0 files
+      in
       let msg = Printf.sprintf "renamed binding %s must exist" new_name in
       if n < 1 then failf "%s — count=%d" msg n)
     renamed_identifiers


### PR DESCRIPTION
## 무엇을

`_shell_warmed` 류의 밑줄 별칭 6개를 제거하고, 이들을 잡아야 했던 회귀 가드를 분할에 견디도록 고친다.

## 가드가 다른 파일을 보고 있었다

RFC-0085 PR-16(#15484)이 `server_dashboard_http_core.ml`의 밑줄 접두 바인딩 7개를 개명하고, "옛 이름이 사라졌는지" 확인하는 사후 가드를 붙였다.

```ocaml
let file = "lib/server/server_dashboard_http_core.ml"
...
check int msg 0 (Ast_grep.count_value_bindings ~module_path:file ~name:old_name)
```

이후 그 파일이 `server_dashboard_http_core_{cache,operator}.ml`로 **분할**됐고, 원본은 재export facade로 남았다. 밑줄 이름은 분할된 파일에서 별칭으로 **부활**했다:

```ocaml
let shell_warmed : bool Atomic.t = Atomic.make false
let _shell_warmed = shell_warmed
```

가드는 경로가 하나로 고정돼 있어 facade만 계속 스캔했다. facade에는 없으니 **0을 세고 통과**했다 — 금지한 7개 중 **5개가 살아있는 채로**.

| 금지 이름 | 실제 위치 |
|---|---|
| `_shell_warmed` | `..._cache.ml` |
| `_shell_warming` | `..._cache.ml` |
| `_last_good_shell` | `..._cache.ml` |
| `_operator_digest_broadcast_ref` | `..._operator.ml` |
| `_operator_digest_cache` | `..._operator.ml` |
| `_operator_snapshot_broadcast_ref` | (실제로 사라짐) |
| `_mission_cache` | (실제로 사라짐) |

목록에 없는 `_last_good_shell_light`까지 하면 별칭은 6개다.

## 밑줄이 컴파일러도 막았다

OCaml에서 `_` 접두는 unused 경고를 억제한다. 이 별칭들은 warning 32의 사각지대에 있어서 **가드도 컴파일러도 못 잡는 상태**였다.

호출자는 0이다. 이 모듈들은 재export되므로 점 표기가 아니라 **맨이름**으로 트리 전체(`lib/`, `bin/`, `test/`)를 찾았고, 나온 것은 정의·선언·가드의 문자열 목록뿐이었다.

## 가드 수정

경로 하나를 박는 대신 `lib/server/server_dashboard_http_core*.ml`을 글롭한다. 다음 분할에도 침묵하지 않는다. 접두사가 틀려 목록이 비면 공허하게 통과하지 않도록 비어있지 않음도 검사한다.

## 통과가 아니라 실패로 검증했다

별칭을 되돌려놓고 수정된 가드를 돌렸다:

```
ASSERT old underscore name _shell_warmed should be removed from lib/server/server_dashboard_http_core_cache.ml
FAIL old underscore name _shell_warmed should be removed from lib/server/server_dashboard_http_core_cache.ml
   Expected: `0'
   Received: `1'
```

수정 전 트리를 정확히 지목한다. 별칭 제거 후에는 2 tests 통과.

## 가족 전수 — pr16만 썩었다

같은 부패가 더 있는지 `test_rfc_0085_*` 14개를 스캔했다. 각 테스트에서 고정 경로와 금지 이름을 뽑아, 그 이름이 `lib/` 어디에든 살아있는지 대조했다.

| | 개수 |
|---|---|
| RFC-0085 가드 | 14 |
| `lib/` 경로 고정 + 밑줄 이름 금지 | 6 |
| 고정 파일이 분할돼 공허해진 것 | **1 (PR-16)** |
| 여전히 정직한 것 | 5 |

과대 주장할 뻔했는데 스캔이 막았다. 나머지 5개는 고정 파일이 분할되지 않아 지금도 유효하다.

## 보고: 이 가족은 CI에서 한 번도 실행되지 않는다

```
$ rg -o 'test_rfc_0085_[a-z0-9_]*' .github/workflows/ | sort -u
(없음)
```

14개 전부 미배선이다. 수정된 가드도 배선 전까지는 실행되지 않는다. 배선은 CI 러닝타임과 `UNWIRED_BASELINE`을 건드리는 정책 결정이라 이 PR에서 하지 않았다. **판단이 필요하면 알려달라** — 배선하거나, 실행되지 않는 가드 14개를 숙청하거나 둘 중 하나다.

## 검증

```
dune build --root . @check                                          # exit 0
./_build/default/test/test_rfc_0085_pr16_dashboard_http_core_rename.exe   # 2 tests, Test Successful
(별칭 복원 상태)                                                     # 1 failure — 의도한 실패
```

미검증: 대시보드 shell/operator HTTP 경로를 실행 중인 서버에서 밟아보지 않았다. 별칭은 정의만 있고 호출자가 없으므로 런타임 경로에 진입하지 않지만, 실행 확인은 아니다.
