### PR TITLE
refactor(schedule): drop the second door onto each projection path

### DIFF
--- a/lib/schedule_payload_projection.ml
+++ b/lib/schedule_payload_projection.ml
@@ -203,11 +203,6 @@ let validate_request_payload_for_creation_detailed ~payload =
   | _ -> Error (Creation_invalid_payload "payload must be a JSON object")
 ;;
 
-let validate_request_payload_for_creation ~payload =
-  validate_request_payload_for_creation_detailed ~payload
-  |> Result.map_error creation_rejection_message
-;;
-
 let creation_keeper_wake_target ~payload =
   match payload with
   | `Assoc fields ->
@@ -241,10 +236,6 @@ let dispatch_view_detailed request =
     in
     Ok (Keeper_wake, view)
   | None -> Error (Dispatch_unsupported_kind view.raw_kind)
-;;
-
-let dispatch_view request =
-  dispatch_view_detailed request |> Result.map_error dispatch_rejection_message
 ;;
 
 let log_projection_error (request : Schedule_domain.schedule_request) ~surface message =

--- a/lib/schedule_payload_projection.mli
+++ b/lib/schedule_payload_projection.mli
@@ -35,25 +35,16 @@ type support_summary =
   ; unknown_request_count : int
   }
 
-val known_kind_to_string : known_kind -> string
-val dispatch_tool_name : known_kind -> string
 val supported_payload_kinds : string list
 val support_status_to_string : support_status -> string
 val creation_rejection_message : creation_rejection -> string
 val dispatch_rejection_message : dispatch_rejection -> string
 val supported_contracts_to_yojson : unit -> Yojson.Safe.t
-val support_summary : Schedule_domain.schedule_request list -> support_summary
-val support_summary_yojson : support_summary -> Yojson.Safe.t
 val support_summary_to_yojson : Schedule_domain.schedule_request list -> Yojson.Safe.t
-val kind_of_json_result : Yojson.Safe.t -> (string, string) result
 
 val validate_request_payload_for_creation_detailed
   :  payload:Yojson.Safe.t
   -> (unit, creation_rejection) result
-
-val validate_request_payload_for_creation
-  :  payload:Yojson.Safe.t
-  -> (unit, string) result
 
 (** Extract the wake target keeper name from a creation payload. [Ok (Some name)]
     for a structurally complete [masc.keeper_wake] payload, [Ok None] for any
@@ -67,14 +58,6 @@ val dispatch_view_detailed
   :  Schedule_domain.schedule_request
   -> (known_kind * payload_view, dispatch_rejection) result
 
-val dispatch_view
-  :  Schedule_domain.schedule_request
-  -> (known_kind * payload_view, string) result
-
-val support_status_result
-  :  Schedule_domain.schedule_request
-  -> (support_status, string) result
-
 val support_status : Schedule_domain.schedule_request -> support_status
 val kind_result : Schedule_domain.schedule_request -> (string, string) result
 val kind : Schedule_domain.schedule_request -> string option
@@ -84,10 +67,6 @@ val dispatch_tool_for_request_result
   -> (string, dispatch_rejection) result
 
 val dispatch_tool_for_request : Schedule_domain.schedule_request -> string option
-val target_summary_result
-  :  Schedule_domain.schedule_request
-  -> (string option * string option, string) result
-
 val target_summary : Schedule_domain.schedule_request -> string option * string option
 
 val body_required_string : payload_view -> string -> (string, string) result


### PR DESCRIPTION
Second candidate taken from `scripts/audit-dead-surface.py --exports`, runnable
since #27386. First was #27388.

## What

Nine exports in `schedule_payload_projection.mli` had no caller anywhere in the
tree. Six were plain aliases of a live sibling:

| unused | live sibling | callers |
|---|---|---|
| `support_summary`, `support_summary_yojson` | `support_summary_to_yojson` | 2 |
| `validate_request_payload_for_creation` | `..._detailed` | 1 |
| `dispatch_view` | `dispatch_view_detailed` | — |
| `support_status_result` | `support_status` | — |
| `target_summary_result` | `target_summary` | — |

Plus `known_kind_to_string`, `dispatch_tool_name` and `kind_of_json_result`.

## The difference between the two doors is a type

```ocaml
let dispatch_view request =
  dispatch_view_detailed request |> Result.map_error dispatch_rejection_message
```

The unused door is the detailed one with the typed rejection **flattened to a
string**. Same for `validate_request_payload_for_creation`
(`creation_rejection` → `string`). An unused entry point that erases a type is
worse than no entry point: it is there for the next caller to reach for, and
reaching for it loses the variant the callers who exist are matching on.

`known_kind_to_string` and `dispatch_tool_name` map `known_kind`, which has one
constructor (`Keeper_wake`), so this is not the enumeration-completeness case
the audit's docstring warns about — there is no enumeration to leave holes in.

## Step 3 of the workflow fired

The docstring prescribes: delete the `val`, rebuild, and if the implementation
is then unreachable the compiler reports it. It did:

```
Error (warning 32 [unused-value-declaration]): unused value validate_request_payload_for_creation
Error (warning 32 [unused-value-declaration]): unused value dispatch_view
```

Exactly the two one-line wrappers. Those went too. The other seven
implementations stayed — they are live helpers with callers inside the module,
which is why only two were flagged.

## Verification

```
dune build --root . @check                                exit 0
dune build --root . @test/runtest-test_schedule_tool_wiring
                                          Test Successful, 13 tests run
```

`test_schedule_payload_projection` also exists and is **not** CI-wired
(`grep -c` → 0), so `test_schedule_tool_wiring` is the one that actually runs
over this path.

```
2 files changed, 30 deletions(-)
```

RFC-WAIVED: unused exports and their two unreachable wrapper implementations
removed, proved by the compiler. No behaviour change.
