### PR TITLE
refactor(goal): drop the goal-index doors that swallow the write error

### DIFF
--- a/lib/workspace/workspace_goal_index.ml
+++ b/lib/workspace/workspace_goal_index.ml
@@ -16,14 +16,6 @@ type link_goalless_task_to_goal_error =
   | Already_linked_to_goals of string list
   | Link_write_failed of goal_task_links_write_error
 
-let goal_task_links_write_error_to_string msg = msg
-
-let link_goalless_task_to_goal_error_to_string = function
-  | Already_linked_to_goals existing_goal_ids ->
-    Printf.sprintf "task already linked to goal(s): %s" (String.concat ", " existing_goal_ids)
-  | Link_write_failed msg -> msg
-;;
-
 let goal_task_links_path config =
   Filename.concat (tasks_dir config) "goal_task_links.json"
 ;;
@@ -297,12 +289,6 @@ let prune_links_for_goal_result config ~goal_id =
           new_links)
 ;;
 
-let prune_links_for_goal config ~goal_id =
-  match prune_links_for_goal_result config ~goal_id with
-  | Ok () -> ()
-  | Error msg -> Log.Misc.warn "%s" msg
-;;
-
 let link_task_to_goal_result config ~goal_id ~task_id =
   let goal_id = String.trim goal_id in
   let task_id = String.trim task_id in
@@ -408,12 +394,6 @@ let link_tasks_to_goals_result config links =
             trimmed_links
         in
         write_goal_task_links_result config ~previous_links:existing_links updated_links)
-;;
-
-let link_tasks_to_goals config links =
-  match link_tasks_to_goals_result config links with
-  | Ok () -> ()
-  | Error msg -> Log.Misc.warn "%s" msg
 ;;
 
 (** Build a reverse index from goal_id to its linked tasks.

--- a/lib/workspace/workspace_goal_index.mli
+++ b/lib/workspace/workspace_goal_index.mli
@@ -9,11 +9,6 @@ type link_goalless_task_to_goal_error =
   | Already_linked_to_goals of string list
   | Link_write_failed of goal_task_links_write_error
 
-val goal_task_links_write_error_to_string : goal_task_links_write_error -> string
-
-val link_goalless_task_to_goal_error_to_string :
-  link_goalless_task_to_goal_error -> string
-
 (** Build a reverse index from goal_id to its linked tasks.
 
     [goal_task_links] is the authoritative source of goal-task
@@ -59,10 +54,6 @@ val goal_task_links_path : Workspace_utils_backend_setup.config -> string
 val read_goal_task_links :
   Workspace_utils_backend_setup.config -> (string * string list) list
 
-val read_goal_task_links_r :
-  Workspace_utils_backend_setup.config ->
-  ((string * string list) list, string) result
-
 (** Persist the goal-task link registry. *)
 val write_goal_task_links :
   Workspace_utils_backend_setup.config -> (string * string list) list -> unit
@@ -73,10 +64,6 @@ val write_goal_task_links_result :
   Workspace_utils_backend_setup.config ->
   (string * string list) list ->
   (unit, goal_task_links_write_error) result
-
-(** Remove all links for [goal_id] under the goal-task-links file lock. *)
-val prune_links_for_goal :
-  Workspace_utils_backend_setup.config -> goal_id:string -> unit
 
 val prune_links_for_goal_result :
   Workspace_utils_backend_setup.config ->
@@ -120,10 +107,6 @@ val link_goalless_task_to_goal :
   goal_id:string ->
   task_id:string ->
   (unit, link_goalless_task_to_goal_error) result
-
-(** Add multiple task-to-goal links to the persistent registry. *)
-val link_tasks_to_goals :
-  Workspace_utils_backend_setup.config -> (string * string option) list -> unit
 
 val link_tasks_to_goals_result :
   Workspace_utils_backend_setup.config ->


### PR DESCRIPTION
Third candidate from `scripts/audit-dead-surface.py --exports`, runnable since
#27386. After #27388 and #27391.

## What

Five exports in `workspace_goal_index.mli` had no caller. Two were the
**unit-returning half of a Result pair**, and the difference between the halves
is whether a failed write is reported:

```ocaml
let prune_links_for_goal config ~goal_id =
  match prune_links_for_goal_result config ~goal_id with
  | Ok () -> ()
  | Error msg -> Log.Misc.warn "%s" msg
```

The caller gets `unit` and cannot know the registry write failed.

The live path does not go through it:

```
goal_store.ml:393        prune_links_for_goal_result   → carries the error into delete_goal's outcome
workspace_task_create.ml:296  link_tasks_to_goals_result
```

Leaving an unused door that turns a failure into a log line is worse than
leaving nothing there — it is the one a future caller reaches for, and reaching
for it is how a silent failure gets written.

## The other three

| removed | why |
|---|---|
| `read_goal_task_links_r` | three live callers use the plain `read_goal_task_links` |
| `link_goalless_task_to_goal_error_to_string` | no caller renders that variant |
| `goal_task_links_write_error_to_string` | `let ... msg = msg` — the identity function, because `goal_task_links_write_error = string` |

The last one is worth naming: a `type X = string` with an `X_to_string` that
returns its argument is ceremony that reads like a typed error and is not one.

## Checked before deleting

Goal deletion still prunes its links — `goal_store.delete_goal` calls the
`_result` variant, so removing the `unit` one leaves no orphaned links. That was
the failure mode worth ruling out before touching a prune function with no
callers.

## Step 3 fired for four of five

```
unused value goal_task_links_write_error_to_string
unused value link_goalless_task_to_goal_error_to_string
unused value link_tasks_to_goals
unused value prune_links_for_goal
```

`read_goal_task_links_r` kept its implementation — a caller inside the module
still uses it, which is exactly the distinction between narrowing an interface
and removing code.

## Verification

```
dune build --root . @check                          exit 0
@test/runtest-test_goal_store              14 tests   (CI-wired)
@test/runtest-test_workspace_goal_index    17 tests   (not CI-wired)
@test/runtest-test_goal_task_assignment     6 tests   (not CI-wired)
```

```
2 files changed, 37 deletions(-)
```

RFC-WAIVED: unused exports and four unreachable implementations removed, proved
by the compiler. No behaviour change — the live callers were already on the
Result variants.
