### PR TITLE
refactor(keeper): 어떤 도구도 선언하지 않는 inline_safe 정책 차원 제거

### DIFF
--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -101,7 +101,6 @@ type policy =
   ; readonly_hint : bool option
   ; retryable : bool
   ; cwd_scope : string option
-  ; inline_safe : bool
   ; polling_read : bool
   }
 
@@ -263,7 +262,7 @@ let discovery_example ~label ?cwd ~argv () =
 ;;
 
 let policy ?readonly ?readonly_of_input ?cwd_scope ?(retryable = false)
-      ?(inline_safe = false) ?(polling_read = false) ()
+      ?(polling_read = false) ()
   =
   let readonly_of_input =
     match readonly_of_input with
@@ -274,7 +273,6 @@ let policy ?readonly ?readonly_of_input ?cwd_scope ?(retryable = false)
   ; readonly_hint = readonly
   ; retryable
   ; cwd_scope
-  ; inline_safe
   ; polling_read
   }
 ;;
@@ -1124,23 +1122,12 @@ let analyze_image_schema =
     ]
 ;;
 
-let read_only_in_process_policy ?(inline_safe = false) ?(polling_read = false) ()
-  =
-  policy
-    ~readonly:true
-    ~retryable:true
-    ~inline_safe
-    ~polling_read
-    ()
+let read_only_in_process_policy ?(polling_read = false) () =
+  policy ~readonly:true ~retryable:true ~polling_read ()
 ;;
 
-let write_in_process_policy ?(retryable = false) ?(inline_safe = false) ()
-  =
-  policy
-    ~readonly:false
-    ~retryable
-    ~inline_safe
-    ()
+let write_in_process_policy ?(retryable = false) () =
+  policy ~readonly:false ~retryable ()
 ;;
 
 let in_process_descriptor_with_schema_source
@@ -1187,14 +1174,12 @@ let in_process_descriptor ~keeper_model_projection ~id ~name ~description
    [runtime_handler] variant but expose distinct [internal_name]s so each
    tool retains its own descriptor entry and receipt evidence. The
    [keeper_tool_in_process_runtime] handler routes by descriptor.internal_name. *)
-let cluster_policy ?(polling_read = false) ~readonly ~inline_safe () =
+let cluster_policy ?(polling_read = false) ~readonly () =
   if polling_read && not readonly then
     invalid_arg "polling_read descriptors must declare readonly=true";
-  if inline_safe && not readonly then
-    invalid_arg "inline_safe descriptors must declare readonly=true";
   if readonly
-  then read_only_in_process_policy ~inline_safe ~polling_read ()
-  else write_in_process_policy ~inline_safe ()
+  then read_only_in_process_policy ~polling_read ()
+  else write_in_process_policy ()
 ;;
 
 let cluster_descriptor_with_schema_source
@@ -1208,10 +1193,9 @@ let cluster_descriptor_with_schema_source
       ~description
       ~handler
       ~readonly
-      ~inline_safe
       ()
   =
-  let policy = cluster_policy ~polling_read ~readonly ~inline_safe () in
+  let policy = cluster_policy ~polling_read ~readonly () in
   in_process_descriptor_with_schema_source
     ~capability_identity
     ~keeper_model_projection
@@ -1234,7 +1218,7 @@ let cluster_descriptor_with_schema_source
    and re-typing the other beside it is what allowed the drift. *)
 let cluster_descriptor ?(polling_read = false) ~capability_identity
       ~keeper_model_projection ~id ~name
-      ~handler ~readonly ~inline_safe ()
+      ~handler ~readonly ()
   =
   let input_schema_source, (schema : Masc_domain.tool_schema) =
     match find_cluster_schema_opt name with
@@ -1252,7 +1236,6 @@ let cluster_descriptor ?(polling_read = false) ~capability_identity
     ~description:schema.description
     ~handler
     ~readonly
-    ~inline_safe
     ()
 ;;
 
@@ -1300,7 +1283,6 @@ let voice_descriptor name ~readonly =
     ~name
     ~handler:Tool_voice_dispatch
     ~readonly
-    ~inline_safe:false
     ()
 ;;
 
@@ -1312,7 +1294,6 @@ let task_descriptor ~capability_identity id name ~readonly =
     ~name
     ~handler:Tool_task_dispatch
     ~readonly
-    ~inline_safe:false
     ()
 ;;
 
@@ -1331,7 +1312,6 @@ let masc_task_descriptor id name ~readonly =
     ~name
     ~handler:Tool_masc_task_dispatch
     ~readonly
-    ~inline_safe:false
     ()
 ;;
 
@@ -1344,7 +1324,6 @@ let masc_task_transport_descriptor id name ~readonly =
     ~name
     ~handler:Tool_masc_task_dispatch
     ~readonly
-    ~inline_safe:false
     ()
 ;;
 
@@ -1356,7 +1335,6 @@ let masc_plan_descriptor id name ~readonly =
     ~name
     ~handler:Tool_masc_plan_dispatch
     ~readonly
-    ~inline_safe:false
     ()
 ;;
 
@@ -1369,7 +1347,6 @@ let masc_run_descriptor name ~readonly =
     ~name
     ~handler:Tool_masc_run_dispatch
     ~readonly
-    ~inline_safe:false
     ()
 ;;
 
@@ -1381,7 +1358,6 @@ let masc_agent_descriptor id name ~readonly =
     ~name
     ~handler:Tool_masc_agent_dispatch
     ~readonly
-    ~inline_safe:false
     ()
 ;;
 
@@ -1398,7 +1374,6 @@ let masc_workspace_descriptor
     ~name
     ~handler:Tool_masc_workspace_dispatch
     ~readonly
-    ~inline_safe:false
     ()
 ;;
 
@@ -1412,7 +1387,6 @@ let masc_misc_descriptor id name ~readonly =
     ~name
     ~handler:Tool_masc_misc_dispatch
     ~readonly
-    ~inline_safe:false
     ()
 ;;
 
@@ -1428,7 +1402,6 @@ let masc_control_descriptor operation =
     ~description:schema.description
     ~handler:Tool_masc_control_dispatch
     ~readonly:false
-    ~inline_safe:false
     ()
 ;;
 
@@ -1440,7 +1413,6 @@ let masc_agent_timeline_descriptor name description ~readonly =
     ~name
     ~handler:Tool_masc_agent_timeline_dispatch
     ~readonly
-    ~inline_safe:false
     ()
 ;;
 
@@ -1456,7 +1428,6 @@ let masc_schedule_descriptor (definition : Tool_schemas_schedule.definition) =
     ~description:schema.description
     ~handler:Tool_masc_schedule_dispatch
     ~readonly:definition.read_only
-    ~inline_safe:false
     ()
 ;;
 
@@ -1486,7 +1457,6 @@ let masc_keeper_descriptor
     ~description:schema.description
     ~handler:Tool_masc_keeper_dispatch
     ~readonly
-    ~inline_safe:false
     ()
 ;;
 
@@ -1515,7 +1485,6 @@ let masc_library_descriptor (definition : Tool_schemas_library.definition) =
     ~description
     ~handler:Tool_masc_library_dispatch
     ~readonly:definition.read_only
-    ~inline_safe:false
     ()
 ;;
 
@@ -1542,7 +1511,6 @@ let masc_local_runtime_descriptor
     ~description:schema.description
     ~handler:Tool_masc_local_runtime_dispatch
     ~readonly:true
-    ~inline_safe:false
     ()
 ;;
 
@@ -1907,7 +1875,6 @@ let internal_descriptors : t list =
       ~name:"masc_keeper_waiting_inventory"
       ~handler:Tool_masc_misc_dispatch
       ~readonly:true
-      ~inline_safe:false
       ()
   ; masc_misc_descriptor "tool_help" "masc_tool_help"
        ~readonly:true
@@ -2053,12 +2020,6 @@ let readonly_internal_names () =
   |> List.sort_uniq String.compare
 ;;
 
-let keeper_safe_inline_names () =
-  all_descriptors ()
-  |> List.concat_map (fun d -> if d.policy.inline_safe then internal_names d else [])
-  |> List.sort_uniq String.compare
-;;
-
 let public_name_for_internal internal_name =
   match public_descriptors_for_internal internal_name with
   | [] -> None
@@ -2088,7 +2049,6 @@ let common_policy_json_fields ~readonly_key policy =
   [ readonly_key, Json_util.bool_opt_to_json policy.readonly_hint
   ; "retryable", `Bool policy.retryable
   ; "cwd_scope", Json_util.string_opt_to_json policy.cwd_scope
-  ; "inline_safe", `Bool policy.inline_safe
   ; "polling_read", `Bool policy.polling_read
   ]
 ;;

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -121,7 +121,6 @@ type policy =
   ; readonly_hint : bool option
   ; retryable : bool
   ; cwd_scope : string option
-  ; inline_safe : bool
   ; polling_read : bool
   }
 
@@ -210,10 +209,6 @@ val translate_input_for_descriptor : t -> Yojson.Safe.t -> Yojson.Safe.t
 (** Descriptor-owned read-only projection. The returned names are internal
     handler names whose descriptor policy declares a static read-only hint. *)
 val readonly_internal_names : unit -> string list
-
-(** Descriptor-owned inline-safe projection. The returned names are internal
-    MASC tools safe for keeper use without an MCP session context. *)
-val keeper_safe_inline_names : unit -> string list
 
 val public_input_schema : string -> Yojson.Safe.t option
 val translate_input : public:string -> Yojson.Safe.t -> Yojson.Safe.t

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -1260,14 +1260,6 @@ let test_readonly_policy_is_descriptor_input_aware () =
        ~tool_name:"tool_search_files"
        ~input:internal_input)
 
-let test_inline_policy_uses_descriptor_resolution () =
-  Alcotest.(check (list string))
-    "safe inline tools project from descriptors"
-    []
-    (Descriptor.keeper_safe_inline_names ());
-  ()
-;;
-
 let test_public_name_projection_uses_descriptor_resolution () =
   Alcotest.(check (list string))
     "tool_execute public projection"
@@ -1675,10 +1667,6 @@ let () =
             "descriptor read-only policy evaluates tool input"
             `Quick
             test_readonly_policy_is_descriptor_input_aware
-        ; test_case
-            "MCP context policy uses descriptor resolution"
-            `Quick
-            test_inline_policy_uses_descriptor_resolution
         ; test_case
             "public names project through descriptor resolution"
             `Quick


### PR DESCRIPTION
## 무엇을

도구 정책의 `inline_safe` 차원을 제거한다. 이 값을 `true`로 선언하는 도구가 하나도 없다.

## 유일한 멤버가 지워지고 차원만 남았다

```
8ff226548a  refactor(keeper): derive inline-safe tools from descriptors (#20013)
efce78c06a  fix(tool): remove stale keeper tool projections (#20130)
```

`#20130`의 diff:

```
-  ; masc_approval_descriptor ~inline_safe:true "pending" "masc_approval_pending"
```

`masc_approval_pending`이 `~inline_safe:true`인 **유일한** 서술자였다. 그 도구가 사라지면서 차원은 값을 잃었고, 필드·생성자 파라미터·검증 가드·투영 함수·JSON echo는 전부 남았다.

## 측정

main 기준:

| 항목 | 값 |
|---|---|
| `~inline_safe:true` / `inline_safe = true` (lib/, test/) | **0** |
| `~inline_safe:false` 리터럴 호출 지점 | 16 |
| 기본값을 가진 정책 생성자 | 3 (전부 `false`) |
| `keeper_safe_inline_names ()` 반환 | 항상 `[]` |
| `"inline_safe"` JSON 키를 읽는 곳 | **0** (dashboard·docs·test 전부) |

## 테스트가 상수를 고정하고 있었다

```ocaml
let test_inline_policy_uses_descriptor_resolution () =
  Alcotest.(check (list string))
    "safe inline tools project from descriptors"
    []                                        (* <- 빈 리스트를 기대 *)
    (Descriptor.keeper_safe_inline_names ());
```

`keeper_safe_inline_names`의 **유일한 소비자**가 이 테스트이고, 검사하는 것은 판정이 아니라 상수다. 이 스위트는 CI 배선돼 있으니(`ci.yml`) 4개월간 초록으로 "inline 정책이 서술자에서 투영된다"를 증명해 왔다 — 투영할 것이 없는 채로.

등록된 test_case 이름은 `"MCP context policy uses descriptor resolution"`이고 함수 이름은 `test_inline_policy_...`다. 둘도 서로 다른 얘기를 한다.

## 구성 불가능한 상태를 지키는 가드

```ocaml
if inline_safe && not readonly then
  invalid_arg "inline_safe descriptors must declare readonly=true";
```

`inline_safe`가 `true`가 될 수 없으므로 이 분기는 실행될 수 없다. CLAUDE.md의 "Gate 로 얻는 이득이 압도적으로 분명하지 않다면 숙청 대상" 기준에 해당한다.

## 제거 대상

| 위치 | 제거 |
|---|---|
| `keeper_tool_descriptor.ml/.mli` | `inline_safe : bool` 레코드 필드 |
| 정책 생성자 3개 | `?(inline_safe = false)` 파라미터 |
| `cluster_policy` | 파라미터 + 구성 불가 상태 가드 |
| `cluster_descriptor{,_with_schema_source}` | 파라미터 배선 |
| 서술자 정의 16곳 | `~inline_safe:false` |
| — | `keeper_safe_inline_names` + `.mli` 선언 + doc 주석 |
| `common_policy_json_fields` | `"inline_safe"` 키 |
| 테스트 | 빈 리스트를 고정하던 케이스 |

**동작 변화 없음** — 이 필드를 읽던 모든 분기가 `false`를 읽었다.

## 검증

```
dune build --root . @check                                                # exit 0
./_build/default/test/test_keeper_tool_descriptor_registry_integrity.exe  # 43 tests, Test Successful
```

이 스위트는 **CI 배선된 것**이다(`ci.yml`). 이번 세션에서 손댄 표면 대부분이 미배선이었던 것과 달리, 여기는 실제로 실행된다.

미검증: keeper 런타임에서 도구를 실제 디스패치해 정책 JSON을 모델에게 보내보지는 않았다. 제거한 JSON 키는 항상 `false`였고 읽는 코드가 없음을 grep으로 확인했으나, 모델 프롬프트 렌더 확인은 아니다.
