### PR TITLE
refactor(verification): drop the evidence form nothing names

### DIFF
--- a/lib/workspace/workspace_verification_store.mli
+++ b/lib/workspace/workspace_verification_store.mli
@@ -93,10 +93,11 @@ val classify_evidence_reference : string -> reference_form
     a reference cannot be admitted at submit and then be unreadable at review,
     and a new form added here reaches every caller. *)
 
-val artifact_reference_form : string
 val note_reference_form : string
-(** One accepted form each, spelled from the prefix this module matches on, so
-    an error message naming a single form cannot drift from the classifier. *)
+(** The accepted form for narrative evidence, spelled from the prefix this
+    module matches on, so an error message naming it cannot drift from the
+    classifier. The artifact form has no such caller: a message that has to
+    name both uses {!resolvable_reference_forms}. *)
 
 val resolvable_reference_forms : string list
 (** The accepted forms, spelled for an error message that has to tell a caller


### PR DESCRIPTION
## What

I added `artifact_reference_form` and `note_reference_form` together in #27280,
on the reasoning that an error message naming a single form should read the
prefix from the classifier rather than restate it.

Only the note form got a caller:

```
classify_evidence_reference   1
note_reference_form           1
resolvable_reference_forms    1
artifact_reference_form       0   ← mine, unused
```

A message that has to name **both** already uses `resolvable_reference_forms`.
Exporting a constant for symmetry is how a surface grows without anyone deciding
it should.

The implementation stays — the string is still what the classifier matches on
inside the module, and `resolvable_reference_forms` is built from it.

## Removing mine first

`scripts/audit-dead-surface.py --exports` reported this in the same run as
#27388, #27391 and #27394. It is the one of those four that I put there, so it
goes in its own PR rather than bundled into someone else's module.

## Verification

```
dune build --root . @check                                     exit 0
@test/runtest-test_workspace_verification_store        (suite runs clean)
```

No implementation change; one `val` line and its doc.

RFC-WAIVED: removal of an unused constant export I added in #27280.
