### PR TITLE
fix(keeper): tolerate legacy persona field in keeper meta JSON (masc#27393)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1142,6 +1142,20 @@ jobs:
           chmod +x scripts/ci-run-tests.sh
           scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_autoboot_single_owner"
 
+      - name: Run keeper meta current-schema conformance suite
+        # This suite would have caught masc#27393 (fleet-wide autoboot 0/7:
+        # the persona hard-cut's schema change made every real, durable
+        # keeper meta JSON unloadable) before it reached production -- it
+        # was compiling under @check but never executing in CI.
+        id: keeper_meta_current_schema_suite
+        if: ${{ always() && steps.build_step.outcome == 'success' }}
+        env:
+          CI_TEST_HEARTBEAT_SEC: 15
+          DUNE_JOBS: 1
+        run: |
+          chmod +x scripts/ci-run-tests.sh
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_keeper_meta_current_schema"
+
       # NOTE: the "Shell IR differential-safety harness gate" step was removed
       # here. #24332 (nonhierarchical Gate refactor) retired the entire
       # shell_ir risk/typed subsystem (Shell_ir_risk, Shell_ir_typed,

--- a/lib/keeper/keeper_meta_json_current_schema.ml
+++ b/lib/keeper/keeper_meta_json_current_schema.ml
@@ -203,6 +203,22 @@ let find_duplicate fields =
   loop [] fields
 ;;
 
+(** [persona] lost its target when the Persona subsystem was hard-cut
+    (masc#27048) -- no persona lookup remains to resolve it against. Every
+    live keeper meta JSON predating that cut still carries it (masc#27393:
+    exact-schema rejection took autoboot to 0/7 in production). Pre-release
+    policy tolerates legacy-version data rather than shipping migration
+    code (CLAUDE.md, "레거시 필드... 마이그레이션을 위한 코드나 구현을
+    하지 말라는 이야기임") -- the TOML loader made the same call for
+    [keeper.persona_name] in #27048's own round 4. Tolerated here on read,
+    never round-tripped: {!object_of_field_values} only ever emits
+    {!all_fields}, so a persona-bearing meta that gets rewritten drops the
+    field on its own, with no migration step needed. *)
+let legacy_ignored_meta_field_names = [ "persona" ]
+
+let known_meta_field_names =
+  current_field_names @ legacy_ignored_meta_field_names
+
 let validate_current_object (json : Yojson.Safe.t) =
   match json with
   | `Assoc fields ->
@@ -213,7 +229,7 @@ let validate_current_object (json : Yojson.Safe.t) =
      | None ->
        let present = List.map fst fields in
        let outside_current =
-         List.filter (fun key -> not (List.mem key current_field_names)) present
+         List.filter (fun key -> not (List.mem key known_meta_field_names)) present
        in
        let missing =
          List.filter (fun key -> not (List.mem key present)) current_field_names

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -88,11 +88,7 @@ echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, al
 # authority tools, memory journal) without lowering the baseline. A PR that
 # wires a suite must lower this number in the same PR, or this check goes red
 # for everyone.
-# 719 -> 715: measured on the merged tree. All 4 units come from slack
-# main already banked, none from this branch -- it declares its suite and
-# wires it in the same change, so declared and run both rise by one and the
-# unwired count does not move.
-UNWIRED_BASELINE=715
+UNWIRED_BASELINE=714
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/test/test_keeper_meta_current_schema.ml
+++ b/test/test_keeper_meta_current_schema.ml
@@ -63,8 +63,8 @@ let nullable_field_names =
 
 let test_current_writer_roundtrip_and_keyset () =
   check int
-    "current schema has 53 fields"
-    53
+    "current schema has 52 fields"
+    52
     (List.length Keeper_meta_json.current_field_names);
   let meta =
     match Keeper_meta_json_parse.meta_of_json (current_json ()) with
@@ -154,17 +154,42 @@ let test_retired_compaction_failure_authority_requires_reset () =
      |> replace_field "compaction_consecutive_failures" (`Int 3))
 ;;
 
+(* masc#27393: the Persona hard-cut (masc#27048) dropped [persona] from the
+   current schema, and this decoder's exact-fields check made every real,
+   durable keeper meta JSON unloadable overnight -- every live keeper still
+   carried the field. Tolerated on read, never round-tripped: the writer
+   only ever emits {!Keeper_meta_json.current_field_names}, so a
+   persona-bearing meta drops the field on its own next write, with no
+   migration step. *)
+let test_legacy_persona_field_loads () =
+  expect_current
+    "meta with a legacy persona field"
+    (current_json () |> replace_field "persona" (`String "sangsu"))
+;;
+
+let test_legacy_persona_field_does_not_round_trip () =
+  let json = current_json () |> replace_field "persona" (`String "sangsu") in
+  match Keeper_meta_json_parse.meta_of_json json with
+  | Error detail -> Alcotest.failf "legacy persona field rejected: %s" detail
+  | Ok meta ->
+    let written_keys =
+      Keeper_meta_json.meta_to_json meta |> fields_exn |> List.map fst
+    in
+    check bool "next write drops the legacy persona field" false
+      (List.mem "persona" written_keys)
+;;
+
 let () =
   run
     "keeper_meta_current_schema"
     [ ( "current-schema"
       , [ test_case "writer roundtrip and keyset" `Quick
             test_current_writer_roundtrip_and_keyset
-        ; test_case "all 53 fields are required" `Quick
+        ; test_case "all 52 fields are required" `Quick
             test_every_current_field_is_required
-        ; test_case "all 53 duplicate fields reject" `Quick
+        ; test_case "all 52 duplicate fields reject" `Quick
             test_every_duplicate_is_rejected
-        ; test_case "all 53 fields reject a wrong type" `Quick
+        ; test_case "all 52 fields reject a wrong type" `Quick
             test_every_field_rejects_a_wrong_type
         ; test_case "nullability is exact" `Quick
             test_nullability_is_exact
@@ -176,6 +201,10 @@ let () =
             test_retired_compaction_failure_authority_requires_reset
         ; test_case "writer rejects non-finite values" `Quick
             test_current_writer_rejects_non_finite_values
+        ; test_case "legacy persona field loads (masc#27393)" `Quick
+            test_legacy_persona_field_loads
+        ; test_case "legacy persona field does not round-trip" `Quick
+            test_legacy_persona_field_does_not_round_trip
         ] )
     ]
 ;;


### PR DESCRIPTION
## Fix-forward for masc#27393 (P0 production incident, resolved)

masc#27048 (Persona hard-cut) dropped `persona` from keeper meta JSON's current schema. The decoder (`keeper_meta_json_current_schema.ml`) is exact-fields — any key outside the declared schema is a hard reject — so every durable `~/.masc/keepers/<name>.json` written before the cut still carried `persona` and became unloadable the moment the new binary deployed. **Production: autoboot 0/7, ~2 minutes of fleet downtime** (operator already recovered manually, see masc#27393).

The same PR made exactly this call for the TOML side (`keeper.persona_name`, round 4 track E — [comment](https://github.com/jeong-sik/masc/pull/27048#issuecomment-5214256381)) but missed the JSON side. Same disease's 5th call site.

### Fix

`persona` is now an explicitly-tolerated, never-parsed legacy field:
- Tolerated on read — `validate_current_object` no longer rejects it.
- Never round-tripped — `object_of_field_values` only ever emits `all_fields`, so a persona-bearing meta drops the field on its own next write. No migration code (pre-release policy: tolerate legacy-version data, don't ship migration tooling).

### Verified against the real incident data

All 8 real keeper meta JSON files from the operator's own recovery backup (`~/.masc/backups-keeper-meta-persona-strip-20260807T174922/`, persona field still present) decode successfully against the fixed schema — confirmed via a disposable probe (built, ran, deleted; `git diff test/dune` is empty).

### Also fixed, found while touching this file

`test_keeper_meta_current_schema.ml` asserted `"current schema has 53 fields"` — stale by one since #27048 itself removed the `Persona` field constructor without updating this literal. **This suite was compiling under `@check` but never wired into CI**, so nothing caught the drift. Wired it into `ci.yml` now — it is exactly the suite that would have caught this incident before it reached production.

### 5-axis sweep (item 3 of the assignment: 6th call site prevention)

Grepped the full persona-hard-cut vocabulary (`persona`, `persona_name`, `personality`) across `lib/` — no other schema, durable-JSON or otherwise, references any of it. The only other exact-fields JSON validator in the codebase (`keeper_memory_os_current.ml`'s `exact_object_fields`, for memory-journal line kinds) validates an unrelated field set the hard-cut never touched. No 6th call site found.

### Two tests added, per the assignment

- `test_legacy_persona_field_loads` — a meta JSON with a `persona` field decodes successfully.
- `test_legacy_persona_field_does_not_round_trip` — re-serializing the decoded meta never re-emits `persona`.

### Gates

- `DUNE_CACHE=disabled dune build --root . lib/ @check` — clean
- `scripts/audit-ci-test-targets.sh` — `714 suites unwired, at baseline` (tightened 719→714: my new CI wiring plus origin/main's own catch-up wiring since)
- `scripts/check-pr-hygiene.sh --base origin/main` — passed
- `@test/runtest-test_keeper_meta_current_schema` — 10/10 pass
- `bash ~/me/scripts/pr-rfc-check.sh` — exit 0 (no credential/identity/operator-control/dashboard-credential subsystem touched, gate doesn't apply)

Closes masc#27393.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
