### PR TITLE
refactor: 컴파일러가 구조적으로 볼 수 없는 죽은 코드 제거 (.mli 없는 50개 모듈)

### DIFF
--- a/lib/auth/auth_credential_base.ml
+++ b/lib/auth/auth_credential_base.ml
@@ -247,22 +247,6 @@ let raw_token_file config agent_name =
   Filename.concat (auth_dir config) (agent_name ^ ".token")
 ;;
 
-let load_credential_from_path config agent_name path : agent_credential option =
-  if file_exists path
-  then (
-    try
-      let content = read_text_file path in
-      let json = Yojson.Safe.from_string content in
-      match agent_credential_of_yojson json with
-      | Ok cred -> Some cred
-      | Error msg ->
-        Log.Auth.warn "[load_credential] parse error for %s: %s" agent_name msg;
-        None
-    with
-    | Sys_error _ | Yojson.Json_error _ -> None)
-  else None
-;;
-
 (** Load agent credential.
 
     Tries an exact filename match first. If that misses and [agent_name]

--- a/lib/http_response_payload.ml
+++ b/lib/http_response_payload.ml
@@ -98,22 +98,6 @@ let q_value_in_params value start stop =
   in
   Option.value ~default:1.0 (loop start)
 
-let param_exists value start stop target =
-  let rec loop start =
-    if start >= stop then
-      false
-    else
-      let next =
-        match index_char value ';' start stop with
-        | Some idx -> idx
-        | None -> stop
-      in
-      let param_start, param_stop = trim_span value start next in
-      equal_ascii_ci_span value param_start param_stop target
-      || (next < stop && loop (next + 1))
-  in
-  loop start
-
 let encoding_matches_span value start stop token =
   let token_stop, params_start =
     match index_char value ';' start stop with
@@ -145,35 +129,6 @@ let accepts_encoding_header ~token = function
 
 let accepts_zstd_header header =
   accepts_encoding_header ~token:"zstd" header
-
-let accepts_zstd_dict_header = function
-  | None -> false
-  | Some accept_encoding ->
-      let stop = String.length accept_encoding in
-      let segment_matches start stop =
-        let token_stop, params_start =
-          match index_char accept_encoding ';' start stop with
-          | Some idx -> idx, idx + 1
-          | None -> stop, stop
-        in
-        let token_start, token_stop = trim_span accept_encoding start token_stop in
-        q_value_in_params accept_encoding params_start stop > 0.0
-        && (equal_ascii_ci_span accept_encoding token_start token_stop "zstd-dict"
-            || (equal_ascii_ci_span accept_encoding token_start token_stop "zstd"
-                && param_exists accept_encoding params_start stop "dict=masc"))
-      in
-      let rec loop start =
-        if start >= stop then
-          false
-        else
-          let next =
-            match index_char accept_encoding ',' start stop with
-            | Some idx -> idx
-            | None -> stop
-          in
-          segment_matches start next || (next < stop && loop (next + 1))
-      in
-      loop 0
 
 let compress_body ?(level = 3) ?(compress = true) ~accept_encoding body =
   if not compress then

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -467,11 +467,6 @@ let update_entry_if_registered ~base_path name f =
   loop ())
 ;;
 
-let update_entry_if_registered_unit ~base_path name f =
-  (* fire-and-forget: discard whether the validated registry write was installed. *)
-  ignore (update_entry_if_registered ~base_path name (fun entry -> f entry, true))
-;;
-
 type registration_error =
   | Registration_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
   | Registration_lifecycle_reserved of Keeper_lifecycle_reservation.snapshot

--- a/lib/keeper/keeper_runtime_attempt.ml
+++ b/lib/keeper/keeper_runtime_attempt.ml
@@ -175,8 +175,3 @@ let sdk_error_to_runtime_outcome err =
      | Agent_sdk.Error.Io _
      | Agent_sdk.Error.Orchestration _
      | Agent_sdk.Error.Internal _ -> None)
-
-let sdk_error_is_resumable_cli_session err =
-  match Keeper_internal_error.classify_masc_internal_error err with
-  | Some (Keeper_internal_error.Resumable_cli_session _) -> true
-  | _ -> false

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -377,11 +377,6 @@ let prepare_passive_keeper_identity_config ~(config : Workspace.config) ~(agent_
         in
         Ok (with_keeper_name args updated_meta.name, identity_reseed)
 
-let prepare_passive_keeper_identity ctx args =
-  prepare_passive_keeper_identity_config
-    ~config:ctx.config
-    ~agent_name:ctx.agent_name
-    args
 let attach_identity_reseed ?identity_reseed json =
   match identity_reseed with
   | None -> json
@@ -904,9 +899,6 @@ let resolve_keeper_meta_config ~(config : Workspace.config) args =
   match resolved with
   | Some (_resolved_name, meta) -> Ok meta
   | None -> Error (Printf.sprintf "keeper not found: %s" name)
-
-let resolve_keeper_meta ctx args =
-  resolve_keeper_meta_config ~config:ctx.config args
 
 let handle_keeper_down ctx args : tool_result =
   invalidate_keeper_list_cache ();

--- a/lib/operator_action_constants.ml
+++ b/lib/operator_action_constants.ml
@@ -20,7 +20,6 @@ let all_target_types = [ Workspace; Keeper; Goal ]
 let valid_target_type_strings = List.map target_type_to_string all_target_types
 let workspace_target_type = target_type_to_string Workspace
 let keeper_target_type = target_type_to_string Keeper
-let goal_target_type = target_type_to_string Goal
 let workspace_target_type_error = "target_type must be " ^ workspace_target_type
 
 let invalid_target_type_message =

--- a/lib/schedule_projection.ml
+++ b/lib/schedule_projection.ml
@@ -7,21 +7,3 @@ type attention_action =
 let attention_action_to_string = function
   | Dispatch_ready -> "dispatch_ready"
 ;;
-
-type execution_readiness =
-  | Due_pending_refresh
-  | Expired
-  | Ready
-  | Scheduled
-  | Running
-  | Terminal
-
-let execution_readiness_to_string = function
-  | Due_pending_refresh -> "due_pending_refresh"
-  | Expired -> "expired"
-  | Ready -> "ready"
-  | Scheduled -> "scheduled"
-  | Running -> "running"
-  | Terminal -> "terminal"
-;;
-


### PR DESCRIPTION
## 컴파일러가 구조적으로 볼 수 없는 사각지대

루트 `dune`가 warning 32(unused value)를 트리 전체에 걸어놨다. 주석이 그 의도를 명확히 밝힌다:

> Setting it centrally means the build stops the moment a value loses its last caller.

**모듈에 `.mli`가 있을 때만 그렇다.** `.mli`가 없으면 모든 최상위 바인딩이 정의상 public이므로 컴파일러는 "unused"라고 말할 수 없다 — 호출자가 0인 채로 몇 달이 지나도.

```
lib .ml=1287   .mli=1237   .mli 없는 .ml=50
```

warning 34(unused type)·37(unused constructor)도 같은 사각지대이고, 37은 `-w +37`을 켠 50개 dune stanza 밖에서는 아예 꺼져 있다.

프로브로 확인했다 — 루트 env에 `-w +37 -warn-error +a-37`을 걸고 전체 재빌드하면 `dune printenv lib/attribution`이 플래그 전파를 보여주지만(`-w +32 -w +37 -warn-error +a-37`), 히트는 0이었다. export된 생성자에는 37이 뜨지 않기 때문이다.

## 방법

`.mli` 없는 50개 프로덕션 모듈의 최상위 이름을 뽑아, `lib/` · `bin/` · `test/` · `scripts/` · `docs/` 전체에서 등장 횟수를 셌다. **1회 = 자기 정의뿐**이다.

모듈 별칭·`include` 재export를 놓치지 않도록 `Module.name`이 아니라 **맨이름 토큰**으로 셌다.

## 제거한 것 — 값 9개 + 타입 1개

| 위치 | 이름 | 판정 |
|---|---|---|
| `auth_credential_base` | `load_credential_from_path` | `load_credential_from_path_raw`의 중복 구버전 (둘 다 파일을 읽어 파싱만 한다). `_raw` 는 `load_credential` 에서 호출된다 |
| `http_response_payload` | `accepts_zstd_dict_header` | 호출자 0 |
| `http_response_payload` | `param_exists` | 위 함수와 함께 죽음 (캐스케이드) |
| `keeper_registry_setup` | `update_entry_if_registered_unit` | *"fire-and-forget: discard whether the validated registry write was installed"* — 버려줄 호출자가 없다 |
| `keeper_runtime_attempt` | `sdk_error_is_resumable_cli_session` | 호출자 0 |
| `keeper_tool_surface_ops` | `prepare_passive_keeper_identity` | 모두가 직접 부르는 `_config` 함수의 ctx 래퍼 |
| `keeper_tool_surface_ops` | `resolve_keeper_meta` | 위와 동일 |
| `operator_action_constants` | `goal_target_type` | 호출자 0 |
| `schedule_projection` | `execution_readiness` (타입) + `execution_readiness_to_string` | 생성자 6개를 **아무도 만들지 않고 매치하지 않는다**. serializer 호출자 0 |

`schedule_projection.ml`은 27줄 중 18줄이 죽어 있었다. 형제인 `attention_action`은 남긴다 — `Dispatch_ready`가 `keeper_world_observation.ml:382`에서 실제로 생성된다.

## 고정점까지 반복

| 회차 | 발견 |
|---|---|
| 1 | 값 8 + 타입 1 |
| 2 | `param_exists` (1회차 제거로 노출) |
| 3 | **0** |

죽은 코드 제거는 새 죽은 코드를 만든다. 한 번만 돌리면 그걸 놓친다.

## 타입 이름은 제거하지 않았다

스캔 1회차 결과 15건 중 **6건이 타입 이름 오탐**이었다. 타입 이름이 어디에도 어노테이션으로 쓰이지 않아도, **생성자가 만들어지면 그 타입은 살아있다** (`handler_error`, `json_cache`, `install_entry_result`, `remove_entry_result`, `cleanup_attempt_outcome`, `verification_submission`, `wire_capture_response_suppression_reason`).

`execution_readiness`만 예외였다 — 생성자까지 전부 미사용이라 지웠다.

## 검증

```
dune build --root . @check     # exit 0 (3회: 제거 후 / 캐스케이드 제거 후 / 최종)
```

## 정정

이 PR 을 처음 올릴 때 `load_credential_from_path_raw` 가 "바로 위 doc 주석이 설명하는 nickname fallback 을 가진 쪽" 이라고 썼다. **틀렸다.** 두 함수 모두 파일을 읽어 파싱만 한다. 그 doc 주석(266-277)은 nickname fallback 을 설명하는데, 실제 fallback 은 `load_credential` (321) 과 `lib/auth/auth_nickname.ml` 에 있다 — **주석이 잘못된 함수 위에 붙어 있다.**

제거 근거 자체는 바뀌지 않는다: `load_credential_from_path` 는 트리 전체 등장 1회(자기 정의)이고, `_raw` 는 `load_credential` 에서 호출된다. 주석 위치 문제는 이 PR 에서 건드리지 않았다.

미검증: 제거한 함수들의 런타임 경로를 실제로 밟아보지 않았다. 호출자가 0이므로 진입 경로가 없다는 것이 근거이고, 이는 정적 측정이다. `auth_credential_base.load_credential_from_path` 는 credential 로딩 코드라 리뷰에서 한 번 더 봐주면 좋겠다.

RFC 게이트: `bash ~/me/scripts/pr-rfc-check.sh` PASS (트립하지 않음).
