### PR TITLE
refactor(task): drop three handler exports nothing calls

### DIFF
--- a/lib/task/tool_task.mli
+++ b/lib/task/tool_task.mli
@@ -28,9 +28,6 @@ val handle_done :
   tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
 val handle_transition :
   tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
-val handle_update_priority : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
-val handle_tasks : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
-val handle_task_history : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
 val task_history_events_json :
   Workspace_core.config -> task_id:string -> limit:int -> Yojson.Safe.t
 


### PR DESCRIPTION
Fifth candidate from `scripts/audit-dead-surface.py --exports`, runnable since
#27386. After #27388, #27391, #27394, #27396.

## What

`tool_task.mli` exported ten `handle_*` functions. Seven have callers:

```
handle_add_task         65      handle_batch_add_tasks   7
handle_transition       50      handle_done              5
handle_claim            22      handle_release           (via the include)
handle_claim_next        8
```

Three have none — `handle_update_priority`, `handle_tasks`,
`handle_task_history`. Every caller of those three tools goes through
`dispatch`, which has 15.

## Not the same shape as #27388

There, every handler was unused and the module had one real door, so the whole
"Individual Handlers" block went. **Here the module is a live surface** — most
of its handlers are called directly — and these three are leftovers. Only they
go.

Worth saying because the two PRs look alike and the reasoning is not
transferable: "these are handlers, handlers are dead" would have deleted seven
live exports.

## handle_release is the one to be careful with

A qualified grep says it has 0 callers, and it is not dead. `tool_task.ml` opens
with an include of `Tool_task_handlers`, and `handle_release` is declared in
*that* module's `.mli` — so the line in `tool_task.mli` re-exports rather than
owns it. The other three are declared nowhere else.

The audit reported exactly those three and skipped `handle_release`. Its
bare-token match found the name in `tool_task_handlers` and counted it live,
which is the right answer here **for the wrong reason** — the same
false-negative shape that let `lib/response/` survive (#27371). Two imprecise
signals disagreeing is what made this worth checking by hand.

## Verification

```
dune build --root . @check    exit 0
```

```
1 file changed, 3 deletions(-)
```

No implementation change: all three are still reachable through `dispatch`,
which is how every caller already reaches them.

RFC-WAIVED: three `val` lines removed from an interface. No behaviour change.
