### PR TITLE
ci: freeze the dead-export count so it can only fall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -450,6 +450,13 @@ jobs:
       # of the unwired set either reads a live .masc runtime (credential and
       # fleet audits, meaningless on a runner) or needs a tool the image lacks
       # (valgrind), and stays out.
+      # Its own step because it takes arguments, which the loop below cannot
+      # pass. The walk used to descend into every worktree and never finish,
+      # which is why an audit this specific sat unwired (#27386); at ~6s it is
+      # cheaper than most steps here.
+      - name: Run dead-surface ratchet
+        run: python3 scripts/audit-dead-surface.py --exports --ratchet
+
       - name: Run repo audit scripts
         run: |
           set -e

--- a/scripts/audit-dead-surface.py
+++ b/scripts/audit-dead-surface.py
@@ -527,9 +527,53 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
                         help=f"Skip export names shorter than this (default {DEFAULT_MIN_NAME_LEN}).")
     parser.add_argument("--stanzas", action="store_true",
                         help="Report test/stanzas/*.inc files that test/dune never includes.")
+    parser.add_argument("--ratchet", action="store_true",
+                        help="With --exports, fail when the count exceeds DEAD_EXPORT_BASELINE.")
     parser.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
     parser.add_argument("--self-test", action="store_true", help="Run the regression guard and exit.")
     return parser.parse_args(argv)
+
+
+# The count `--exports` reports, frozen so it can only fall. Not a target of
+# zero: the docstring above lists five categories where unreachable is not
+# removable, so some of this number is load-bearing and the audit cannot tell
+# which. What the ratchet buys is that the number stops growing while nobody is
+# looking.
+#
+# Lower it in the PR that earns the reduction. Raising it needs a reason in the
+# PR body -- a new export with no caller is usually a surface someone meant to
+# wire and did not.
+DEAD_EXPORT_BASELINE = 817
+
+
+def run_ratchet(count: int) -> int:
+    """Compare the dead-export count against the frozen baseline.
+
+    Below the baseline passes and says by how much, rather than failing until
+    someone edits the number. audit-ci-test-targets.sh carries the note about
+    why the other direction is wrong: failing on your own improvement turned
+    main red three times in an hour while people wired suites.
+    """
+    if count > DEAD_EXPORT_BASELINE:
+        print(
+            f"[dead-surface] FAIL - {count} dead exports, over the "
+            f"{DEAD_EXPORT_BASELINE} baseline by {count - DEAD_EXPORT_BASELINE}.\n"
+            "\n"
+            "An export with no caller anywhere in the tree is usually a surface\n"
+            "someone meant to wire and did not. Remove it, wire it, or raise\n"
+            f"DEAD_EXPORT_BASELINE in {Path(__file__).name} with the reason.",
+            file=sys.stderr,
+        )
+        return 1
+    if count < DEAD_EXPORT_BASELINE:
+        print(
+            f"[dead-surface] OK - {count} dead exports, {DEAD_EXPORT_BASELINE} "
+            f"baseline - lower DEAD_EXPORT_BASELINE to hold the "
+            f"{DEAD_EXPORT_BASELINE - count} you removed"
+        )
+        return 0
+    print(f"[dead-surface] OK - {count} dead exports, at baseline")
+    return 0
 
 
 def main(argv: list[str]) -> int:
@@ -541,6 +585,7 @@ def main(argv: list[str]) -> int:
         return 2
 
     payload: dict[str, object] = {}
+    dead_export_count: int | None = None
     if args.modules:
         dead_modules = find_dead_modules(ROOT)
         payload["dead_modules"] = dead_modules
@@ -550,6 +595,7 @@ def main(argv: list[str]) -> int:
                 print(f"  {entry['loc']:6d} LoC  {entry['module']}  {entry['ml']}")
     if args.exports:
         dead_exports = find_dead_exports(ROOT, args.min_name_len)
+        dead_export_count = len(dead_exports)
         per_module: dict[str, int] = defaultdict(int)
         for entry in dead_exports:
             per_module[entry["module"]] += 1
@@ -578,6 +624,11 @@ def main(argv: list[str]) -> int:
                 print(f"  {orphan}")
     if args.json:
         print(json.dumps(payload, indent=2))
+    if args.ratchet:
+        if dead_export_count is None:
+            print("--ratchet needs --exports", file=sys.stderr)
+            return 2
+        return run_ratchet(dead_export_count)
     return 0
 
 

--- a/scripts/audit-unwired-audits.sh
+++ b/scripts/audit-unwired-audits.sh
@@ -21,7 +21,7 @@ set -uo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
-UNWIRED_BASELINE=11
+UNWIRED_BASELINE=10
 
 all="$(mktemp)"
 called="$(mktemp)"
@@ -48,9 +48,16 @@ if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then
   exit 2
 fi
 
+# Below the baseline is the improvement this check exists to produce, so it
+# reports and passes. Failing here means the PR that wires an audit goes red
+# for doing the thing asked of it, and main stays red until someone edits this
+# number -- the failure mode audit-ci-test-targets.sh recorded when 748 went
+# red, #27181 set 747, and 746 was red again within the hour.
+# ocaml-structure-ratchet.sh and audit-ci-test-targets.sh already treat their
+# own drift-down this way; this now matches them.
 if [ "$unwired" -lt "$UNWIRED_BASELINE" ]; then
-  echo "[unwired-audits] ${unwired} < baseline ${UNWIRED_BASELINE} — lower UNWIRED_BASELINE in $0 to hold the gain"
-  exit 2
+  echo "[unwired-audits] OK - ${unwired} audit scripts unwired, ${UNWIRED_BASELINE} baseline — lower UNWIRED_BASELINE in $0 to hold the gain"
+  exit 0
 fi
 
 echo "[unwired-audits] OK - ${unwired} audit scripts unwired, at baseline"


### PR DESCRIPTION
## What

`scripts/audit-dead-surface.py` reports **817 exports** that nothing outside
their own module references. Nothing stopped that number from growing — the
audit was unwired, because until #27386 its walk never finished.

```yaml
- name: Run dead-surface ratchet
  run: python3 scripts/audit-dead-surface.py --exports --ratchet
```

## A ratchet, not a target of zero

The tool's own docstring lists five categories where unreachable is **not**
removable — spec bridges, alternative entry points, enumeration completeness,
documented entry points, callback registration. So part of 817 is load-bearing
and the scan cannot say which part.

What this buys is that the number stops growing while nobody is looking.

Below the baseline **passes** and reports the slack, rather than failing until
someone edits the number. `audit-ci-test-targets.sh` carries the note about why
the other direction is wrong:

> Failing here made every suite-wiring PR turn main red until someone edited
> this number: 748 went red, #27181 set 747, and 746 was red again within the
> hour.

## Verified in both directions

Baseline moved with the count held fixed:

```
DEAD_EXPORT_BASELINE = 800   [dead-surface] FAIL - 817 dead exports, over the 800 baseline by 17     exit 1
DEAD_EXPORT_BASELINE = 830   [dead-surface] OK - 817, 830 baseline - lower it to hold the 13 you removed   exit 0
DEAD_EXPORT_BASELINE = 817   [dead-surface] OK - 817 dead exports, at baseline                       exit 0
```

`--ratchet` without `--exports` is refused rather than silently passing.

## Where the baseline came from

Five PRs today took 29 of these out — #27388, #27391, #27394, #27396, #27403 —
which is what set it where it is:

```
846 → 817 across today's merges
```

Each of those five was checked by hand against the docstring's categories, and
one of them (#27403) is the case where the audit and a qualified grep disagreed
and both were partly wrong. That is the work this ratchet does **not** automate:
it stops growth, it does not decide removability.

## Cost

~6s. Its own step because it takes arguments, which the `Run repo audit scripts`
loop cannot pass.

## Verification

```
python3 scripts/audit-dead-surface.py --exports --ratchet    at baseline, exit 0
python3 scripts/audit-dead-surface.py --ratchet              refused, exit 2
python3 scripts/audit-dead-surface.py --self-test            self-test OK
ci.yml parses as YAML
```

RFC-WAIVED: a counter frozen against growth and one CI step. No source change,
no behaviour change.

---

## Update: the check next door failed on this PR's improvement

Wiring the audit drops the unwired-audit count from 11 to 10, and
`audit-unwired-audits.sh` exited **2** on that — the PR doing what the check
asks for goes red for doing it, and main stays red until someone edits the
number.

That is the failure mode `audit-ci-test-targets.sh` recorded when it had it, and
which this PR's body already quotes. It and `ocaml-structure-ratchet.sh` both
report-and-pass on drift-down now; `audit-unwired-audits.sh` was the last of the
three that still failed. Fixed here, since this PR is what tripped it:

```
count fixed at 10:
  baseline 11  →  OK exit 0, "lower UNWIRED_BASELINE to hold the gain"
  baseline  9  →  exit 2
  baseline 10  →  OK at baseline
```

Baseline lowered to 10 in the same commit, which is what the check was asking
for.
