### PR TITLE
ci: PR hygiene 가드 앞에서 전체 클론을 얕게 만들지 않는다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,7 +405,12 @@ jobs:
           HEAD_REF: ${{ github.event.pull_request.head.sha }}
         run: |
           chmod +x scripts/check-release-train-guard.sh
-          bash scripts/ci/git-fetch-retry.sh origin "${{ github.base_ref }}" --depth=100 --tags
+          # No --depth here. This guard only runs `git show` and `git tag`, so
+          # it never needed one -- but `git fetch --depth=N` writes
+          # .git/shallow, which is repository-global state. It ran first and
+          # left the clone shallow for the hygiene step below, which does walk
+          # ancestry. That is the trigger for #27365 / #26938 / #27384.
+          bash scripts/ci/git-fetch-retry.sh origin "${{ github.base_ref }}" --tags
           scripts/check-release-train-guard.sh \
             --base "$BASE_REF" \
             --head "$HEAD_REF"
@@ -417,7 +422,14 @@ jobs:
           HEAD_REF: ${{ github.event.pull_request.head.sha }}
         run: |
           chmod +x scripts/check-pr-hygiene.sh
-          bash scripts/ci/git-fetch-retry.sh origin "${{ github.base_ref }}" --depth=100
+          # No --depth. `git fetch --depth=100` grafts origin/<base> at 100
+          # commits, and rev-list then reports everything older than that graft
+          # as reachable only from HEAD -- so a long-lived branch had hundreds
+          # of main's own commits attributed to it (#27365, #26938, #27384).
+          # merge-base still returns a real commit, so the shallow-boundary
+          # recovery added in #27277 never engages. The checkout above already
+          # fetched full history; truncating it here only removed information.
+          bash scripts/ci/git-fetch-retry.sh origin "${{ github.base_ref }}"
           scripts/check-pr-hygiene.sh \
             --base "$BASE_REF" \
             --head "$HEAD_REF" \


### PR DESCRIPTION
## 무슨 일이 나고 있었나

`Meta Guards` 의 `Run PR hygiene guards` 가 **이 브랜치에 없는 커밋들**을 위반으로 보고해 왔다. 오늘만 #27133 이 이렇게 막혔고, #27365 가 같은 증상 3 건(#27023 · #27048 · #27107)을 기록하고 있다.

```
PR hygiene check failed: empty commits detected.
##[error] 9b9ecef81c feat(dashboard): Board UI upgrade... (#73)
##[error] 28bf072068 fix(viewer): normalize NO_COLOR... (#147)
```

PR 번호가 **#73 · #147** 이다. 저장소는 지금 #27400 대다.

## 원인 — 전체 클론을 받아 놓고 다시 얕게 만든다

```yaml
- name: Checkout
  with:
    fetch-depth: 0                                    # 전체 이력

- name: Guard pending release tag on main PRs
  run: git-fetch-retry.sh origin main --depth=100 --tags   # ← 여기서 얕아진다

- name: Run PR hygiene guards
  run: git-fetch-retry.sh origin main --depth=100
```

`git fetch --depth=N` 은 `.git/shallow` 를 쓴다. **저장소 전역 상태다.** base 에서 뒤로 걷는 `rev-list` 가 graft 에서 멈추므로, 그보다 오래된 커밋은 전부 "HEAD 에서만 닿는 것" 으로 계산된다. 장수 브랜치일수록 그 집합이 커진다.

측정:

| | `merge-base..HEAD` |
|---|---|
| 전체 클론 (로컬) | **7 커밋** — 이 PR 의 실제 커밋 |
| CI (`--depth=100`) | 수백 개, `#73` · `#147` 포함 |

## #27277 의 회복 경로는 여기서 안 걸린다

#27277 이 넣은 deepen 루프는 `merge-base` 가 `.git/shallow` 에 **적힌 경계 커밋일 때만** 돈다:

```bash
while grep -qx "$MERGE_BASE" "$(git rev-parse --git-dir)/shallow"; do
```

이 사례에서 merge-base 는 `ffcce589ef` — main tip 에서 **10 커밋** 뒤, 100 창 안의 **실재 커밋**이다. 경계가 아니므로 조건이 거짓이고 루프가 진입하지 않는다. 실패한 실행 로그 1,396 줄에 `deepening` 이 **0 줄**인 것으로 확인했다.

즉 **merge-base 는 맞는데 그 조상이 잘려 있어서** 범위가 틀어진다. boundary 검사만으로는 못 잡는 형태다.

## 무엇을 바꿨나

두 스텝에서 `--depth` 를 뺀다.

- **hygiene 스텝**: `rev-list` 로 조상을 걷는다. 직접 영향.
- **release-train 스텝**: 이 가드 자신은 `git show` 와 `git tag` 만 쓰므로 depth 가 필요 없었다. **그런데 먼저 실행되어 클론을 얕게 만든다.** `.git/shallow` 가 전역이라, 이걸 남겨 두면 hygiene 쪽만 고쳐도 소용없다. **이쪽이 실제 방아쇠다.**

checkout 이 이미 전체 이력을 받았으므로, 여기서 자르는 것은 정보를 잃기만 했다.

## 건드리지 않은 `--depth`

| 위치 | 소비자 | 판단 |
|---|---|---|
| `ci.yml:208` `--depth=200` | 변경 파일 **diff** | `git diff A..B` 는 조상을 걷지 않는다. `--deepen=1000` 폴백도 이미 있다 |
| `ci.yml:647,649` `--depth=1` | health 스냅샷 기준 커밋 | 단일 커밋 조회 |
| `ocamlformat.yml:67` `--depth=1` | 변경 파일 diff | 동일 |

**`rev-list` 를 쓰는 곳만 고쳤다.** diff 는 트리 비교라 graft 의 영향을 받지 않는다.

## #27365 가 처방하던 우회를 대체한다

그 이슈는 같은 증상 3 건마다 브랜치를 **single-commit rebase** 로 다시 써서 통과시켰고, 스스로 그것을 N-of-M 패턴이라고 적어 두었다.

리베이스가 통한 이유가 이제 설명된다 — **범위를 맞게 만든 게 아니라 틀린 범위를 작게 만든 것**이다. graft 너머에 브랜치 쪽 커밋이 거의 없어지므로 오탐이 사라진다. 가드는 그대로 고장 나 있었다.

#27365 의 추정 원인("guard 가 merge 토폴로지를 무시, first-parent 순회를 안 쓴다")은 맞지 않는다. 스크립트는 `merge-base` 를 쓰고 merge 커밋을 `parent_count > 1` 로 건너뛴다. 전체 클론에서 같은 입력이 7 커밋을 내는 것이 그 증거다.

## 검증

```
scripts/lint/yaml-syntax.sh    20 workflow file(s) parsed OK
```

동작 확인은 CI 가 한다 — 이 PR 자신의 `Meta Guards` 가 통과하면 그게 증거다. **이 PR 은 병합 커밋이 없는 짧은 브랜치라 오탐 조건을 재현하지 않는다**는 점은 미리 밝혀 둔다. 진짜 확인은 #27133 을 다시 돌려보는 것이고, 그건 이게 머지된 뒤에 가능하다.

Refs #27365, #26938, #27384.
