### PR TITLE
fix(keeper): 커밋 전에 취소된 라이브러리안 패스를 저널에 기록

### DIFF
--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -527,8 +527,33 @@ let run_best_effort
                     deferred)
                ~cadence_deferred:deferred
          with
+         (* A cancelled pass reached the lane registry and stopped there, so the
+            journal — the record of what the librarian did on this keeper —
+            showed the same silence for a pass killed mid-flight as for a turn
+            on which the librarian never ran. Measured live on 2026-08-07: 11
+            of 23 completed librarian lane runs cancelled, none of them
+            represented in the journal.
+
+            The write runs under [Eio.Cancel.protect] because the surrounding
+            context is already cancelled; without it the append would be
+            cancelled in turn and record nothing, which is the failure it
+            exists to close. *)
          | Eio.Cancel.Cancelled _ as exn ->
            complete Exact_lane_run_registry.Cancelled `Null;
+           Eio.Cancel.protect (fun () ->
+             record_failure
+               ~keepers_dir
+               ~keeper_id
+               ~trace_id
+               ~kind:Keeper_memory_os_current.Lane_cancelled
+               ~detail:
+                 (Printf.sprintf
+                    "memory os librarian cancelled lane=%s before commit"
+                    exact_lane_id)
+                 (* Cancellation is not the pass declining its own turn, so the
+                    cadence counter is left alone and the next due turn retries
+                    as it would after any other incomplete pass. *)
+               ~cadence_deferred:false);
            raise exn
          | exn ->
            complete

--- a/lib/keeper/keeper_memory_os_current.ml
+++ b/lib/keeper/keeper_memory_os_current.ml
@@ -37,6 +37,7 @@ type librarian_failure_kind =
   | Domain_output_invalid
   | Memory_snapshot_write_failure
   | Runtime_context_unavailable
+  | Lane_cancelled
   | Unhandled_exception
 
 type journal_entry =
@@ -329,6 +330,7 @@ let librarian_failure_kind_to_string = function
   | Domain_output_invalid -> "domain_output_invalid"
   | Memory_snapshot_write_failure -> "memory_snapshot_write_failure"
   | Runtime_context_unavailable -> "runtime_context_unavailable"
+  | Lane_cancelled -> "lane_cancelled"
   | Unhandled_exception -> "unhandled_exception"
 ;;
 
@@ -340,6 +342,7 @@ let librarian_failure_kind_of_string = function
   | "domain_output_invalid" -> Some Domain_output_invalid
   | "memory_snapshot_write_failure" -> Some Memory_snapshot_write_failure
   | "runtime_context_unavailable" -> Some Runtime_context_unavailable
+  | "lane_cancelled" -> Some Lane_cancelled
   | "unhandled_exception" -> Some Unhandled_exception
   | _ -> None
 ;;

--- a/lib/keeper/keeper_memory_os_current.mli
+++ b/lib/keeper/keeper_memory_os_current.mli
@@ -46,6 +46,10 @@ type librarian_failure_kind =
   | Domain_output_invalid
   | Memory_snapshot_write_failure
   | Runtime_context_unavailable
+  | Lane_cancelled
+      (** The pass started and was cancelled before it could commit. Recorded
+          because a cancelled pass is otherwise indistinguishable in this
+          journal from a turn on which the librarian never ran. *)
   | Unhandled_exception
 
 (** One decoded journal line. A committed pass carries the revision it wrote;

--- a/test/test_keeper_memory_journal_projection.ml
+++ b/test/test_keeper_memory_journal_projection.ml
@@ -207,6 +207,43 @@ let test_drop_reasons_survive_the_projection () =
        | lines -> Alcotest.failf "expected one line, got %d" (List.length lines)))
 ;;
 
+(* A pass that started and was cancelled before it could commit used to leave
+   nothing here, so the journal read the same for a pass killed mid-flight as
+   for a turn on which the librarian never ran. Measured live on 2026-08-07:
+   11 of 23 completed librarian lane runs cancelled, none of them in the
+   journal. The operator asking why memory stopped advancing is exactly the
+   reader that silence misleads. *)
+let test_cancelled_pass_is_recorded_and_named () =
+  with_keepers_dir (fun keepers_dir ->
+    Current.append_librarian_failure
+      ~keepers_dir
+      ~keeper_id:keeper
+      ~now:1_700_000_000.0
+      ~trace_id:"trace-cancelled"
+      ~kind:Lane_cancelled
+      ~detail:"memory os librarian cancelled lane=librarian_exact before commit"
+      ~snapshot_present:true
+      ~cadence_deferred:false;
+    match read_json ~keepers_dir with
+    | [ line ] ->
+      Alcotest.(check bool) "the pass is on the record" true (U.to_bool (field line "ok"));
+      Alcotest.(check string) "recorded as a failed pass" "failed"
+        (U.to_string (field line "outcome"));
+      (* Naming it apart from the extraction failures is the point: an operator
+         reading `exact_execution_failure` would go looking at the provider. *)
+      Alcotest.(check string) "cancellation names itself" "lane_cancelled"
+        (U.to_string (field line "kind"));
+      Alcotest.(check bool) "and carries no revision" true
+        (field line "revision" = `Null)
+    | lines -> Alcotest.failf "expected one line, got %d" (List.length lines))
+;;
+
+(* The counterfactual this case rests on — that a keeper whose librarian never
+   ran has an empty journal — is held by [test_missing_journal_reads_empty] in
+   test_librarian_journal_failures.ml, and the wire round-trip for every kind
+   is held by the [all_kinds] guard in that same file. What is only true here
+   is the projected spelling the dashboard reads. *)
+
 let () =
   Random.self_init ();
   Alcotest.run
@@ -222,6 +259,8 @@ let () =
             test_undecodable_line_keeps_its_position_and_reason
         ; Alcotest.test_case "untagged legacy line is reported, not reinterpreted" `Quick
             test_untagged_legacy_line_is_reported_not_reinterpreted
+        ; Alcotest.test_case "cancelled pass is recorded and named" `Quick
+            test_cancelled_pass_is_recorded_and_named
         ] )
     ; ( "content"
       , [ Alcotest.test_case "drop reasons survive the projection" `Quick

--- a/test/test_librarian_journal_failures.ml
+++ b/test/test_librarian_journal_failures.ml
@@ -44,6 +44,7 @@ let all_kinds : Current.librarian_failure_kind list =
   ; Domain_output_invalid
   ; Memory_snapshot_write_failure
   ; Runtime_context_unavailable
+  ; Lane_cancelled
   ; Unhandled_exception
   ]
 ;;
@@ -57,6 +58,7 @@ let kind_label (kind : Current.librarian_failure_kind) =
   | Domain_output_invalid -> "Domain_output_invalid"
   | Memory_snapshot_write_failure -> "Memory_snapshot_write_failure"
   | Runtime_context_unavailable -> "Runtime_context_unavailable"
+  | Lane_cancelled -> "Lane_cancelled"
   | Unhandled_exception -> "Unhandled_exception"
 ;;
 


### PR DESCRIPTION
라이브러리안 저널은 "이 키퍼에서 라이브러리안이 무엇을 했는가"의 기록이다. 패스가 끝나는 모든 경로가 여기에 한 줄을 쓰는데, **취소만 예외**였다. 레인 레지스트리에 보고하고 그대로 re-raise 해서, 중도에 죽은 패스가 저널에서는 **라이브러리안이 아예 안 돈 턴과 구별되지 않았다.**

## 실측 (2026-08-07, 46분 창)

```
라이브러리안 레인 시작   24건
 ├ 취소                 11건   (완료 23건 중 48%)
 ├ 성공                  6건
 └ 진행중/미기록          7건

같은 창의 저널 라인      9건    ← 취소 11건이 여기 없음
```

취소된 패스는 죽기까지 중앙값 **640초**를 썼다.

**느린 것을 솎아내는 게 아니다.** 취소 구간(85~1515초)과 성공 구간(406~1064초)이 거의 완전히 겹친다. 그리고 11건이 단 두 순간에 죽었다 — 4개 동시, 그다음 7개 동시:

```
17:18:44  kidsnote, analyst, code-reviewer, taskmaster
17:47:42  lane-smith, rondo, analyst, kidsnote, taskmaster, sangsu, code-reviewer
```

패스 바깥의 무언가가 in-flight 를 통째로 끝낸다. **그 원인은 아직 미해결이고 이 PR 의 범위가 아니다.** 이 PR 은 원인을 찾는 동안 패스가 기록에서 사라지지 않게 하는 것이다.

## 왜 새 변형인가

기존 철자를 재사용하지 않고 `Lane_cancelled` 를 `librarian_failure_kind` 에 추가했다. `exact_execution_failure` 를 읽은 운영자는 프로바이더를 보러 가는데, 프로바이더가 실패한 적 없는 패스에 대해서는 틀린 방향이다.

타입이 이미 이 방식을 요구하고 있었다. 이 합타입이 닫혀 있는 이유가 *"새 실패 모드는 기록되기 전에 스스로 이름을 대야 한다"* 이고, 실제로 컴파일러가 `test_librarian_journal_failures.ml` 의 `all_kinds` 리스트와 `kind_label` exhaustive match 두 곳을 갱신할 때까지 추가를 거부했다.

그 등록 덕분에 **새 kind 가 기존 왕복 가드에 자동으로 편입**됐다 — `all_kinds` 를 순회하며 각 kind 가 자기 이름으로 디스크를 왕복하는지 이미 검사하고 있다. 새 케이스를 쓸 필요가 없었다.

## Eio.Cancel.protect

```ocaml
| Eio.Cancel.Cancelled _ as exn ->
  complete Exact_lane_run_registry.Cancelled `Null;
  Eio.Cancel.protect (fun () ->
    record_failure ~kind:Keeper_memory_os_current.Lane_cancelled ...);
  raise exn
```

주변 컨텍스트가 이미 취소된 상태다. 보호 없이 append 하면 **그 쓰기도 함께 취소되어** 정확히 막으려던 침묵이 재현된다.

cadence 카운터는 건드리지 않는다. 취소는 패스가 스스로 차례를 넘긴 게 아니므로, 다음 due 턴이 다른 불완전 패스와 똑같이 재시도한다.

## 이 PR 이 하지 않는 것

취소율을 낮추지 않는다. 그럴 의도도 아니다. **저널에서 손실을 셀 수 있게** 만든다 — 지금까지 저널은 1.1일 동안 실패 22건을 보여줬는데, 레인은 대략 두 시간마다 그만큼을 잃고 있었다.

## 검증

- `dune build --root . @check` 전체 통과 — 변형 추가가 어떤 소비자도 깨지 않음 (`rc=0`, Error 0)
- `test_librarian_journal_failures` 10 케이스, `test_keeper_memory_journal_projection` 6 케이스 모두 green
- 새 투영 케이스의 실패 능력 확인: kind 를 다른 값으로 바꾸면 `cancellation names itself` 에서 정확히 red (`rc=1`)

**호출 지점 자체에는 유닛 테스트가 없다.** 그 경로를 구동하려면 Eio 컨텍스트 + 프로바이더 + 외부 취소가 필요한데 기존 스위트에 그런 시드가 없다. 라이브 관측으로 발견했고, 배포 후 `lane_cancelled` 라인이 실제로 나타나는지로 같은 방식으로 확인할 것이다.

**구조적 해법은 있고 여기서 취하지 않았다**: `complete <레인 결말>` 은 모든 종료 경로에서 불리는데 저널 쓰기는 일부에서만 불린다. 둘을 하나의 값에서 파생시키면 누락이 구조적으로 불가능해진다. 리팩터 범위가 이 수정보다 커서 분리했다.

RFC-WAIVED: 기존 기록 계약의 누락된 종료 경로를 채우는 수정. 판정 기준·상태 집합·게이트를 바꾸지 않으며, credential/identity/operator/sandbox/hooks 어느 subsystem 도 건드리지 않는다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>