### PR TITLE
feat(dashboard): 소비자가 없던 턴 조회 화면 붙이기 (raw turns · next prompt · operator note)

### DIFF
--- a/dashboard/src/components/internal-agents-monitor.ts
+++ b/dashboard/src/components/internal-agents-monitor.ts
@@ -12,6 +12,7 @@ import {
   fetchKeeperMemoryJournal,
   type MemoryJournal,
 } from '../api/dashboard-memory-journal'
+import { KeeperTurnInspectorPanel } from './keeper-turn-inspector-panel'
 import { registerInternalAgentRefresh } from '../sse-store'
 import { Btn } from './btn'
 import { EmptyState, ErrorState } from './common/feedback-state'
@@ -276,6 +277,19 @@ export function InternalAgentsMonitor() {
 
   const visible = useMemo(() => rows.filter(row => matches(row, filter)), [rows, filter])
 
+  // The inspector needs a keeper to address, and the observed runs already name
+  // every keeper that has produced one. Fusion rows carry a keeper directly;
+  // exact lanes carry it as the actor. Verification runs are keyed by evaluator
+  // runtime rather than a keeper, so they contribute none.
+  const keepers = useMemo(() => {
+    const names = new Set<string>()
+    for (const row of rows) {
+      if (row.source === 'fusion') names.add(row.run.keeper)
+      else if (row.source === 'exact') names.add(row.run.actor)
+    }
+    return Array.from(names).sort()
+  }, [rows])
+
   return html`
     <section class="v2-monitoring-surface grid gap-3" data-testid="internal-agents-monitor">
       <div class="flex flex-wrap items-center gap-2">
@@ -298,6 +312,7 @@ export function InternalAgentsMonitor() {
         `)}
       </div>
       ${errors.length > 0 ? html`<${ErrorState}>${errors.join(' · ')}<//>` : null}
+      <${KeeperTurnInspectorPanel} keepers=${keepers} />
       ${!loading && visible.length === 0
         ? html`<${EmptyState}>No internal agent runs for this filter.<//>`
         : html`<div class="grid gap-2">

--- a/dashboard/src/components/keeper-turn-inspector-panel.ts
+++ b/dashboard/src/components/keeper-turn-inspector-panel.ts
@@ -1,0 +1,392 @@
+// MASC Dashboard — what a keeper actually sent, and what it will send next.
+//
+// The server has carried these four views since RFC-0366 and the raw-trace
+// reader landed, but nothing rendered them: the routes, the decoders and their
+// tests were all green with zero consumers, so the only way to read a turn was
+// curl. This is the consumer.
+//
+// Read-only except the operator note, which is the one place an operator can
+// put a sentence in front of the next turn.
+
+import { html } from 'htm/preact'
+import { useCallback, useEffect, useState } from 'preact/hooks'
+import {
+  fetchKeeperLastPrompt,
+  fetchKeeperOperatorNote,
+  fetchKeeperRawTrace,
+  fetchKeeperRawTraces,
+  putKeeperOperatorNote,
+  type OperatorNote,
+  type PromptCapture,
+  type RawTracePage,
+  type RawTraceTurn,
+} from '../api/dashboard-keeper-prompt'
+import { Btn } from './btn'
+import { relativeTime } from '../lib/format-time'
+
+type Tab = 'raw' | 'prompt' | 'note'
+
+const TABS: Array<{ id: Tab; label: string; hint: string }> = [
+  { id: 'raw', label: 'Raw turns', hint: '프로바이더로 나간 요청·응답 원문' },
+  { id: 'prompt', label: 'Next prompt', hint: '다음 턴에 조립될 시스템 컨텍스트' },
+  { id: 'note', label: 'Operator note', hint: '다음 턴 한 번에만 실리는 문장' },
+]
+
+// The store rejects a note over this rather than truncating it. Showing the
+// budget while typing is the difference between a rejection an operator
+// expected and one that looks like a bug.
+const MAX_NOTE_BYTES = 4 * 1024
+
+const RECORDS_PER_PAGE = 20
+
+function formatBytes(value: number): string {
+  if (value < 1024) return `${value} B`
+  if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KB`
+  return `${(value / (1024 * 1024)).toFixed(1)} MB`
+}
+
+// These records carry unix seconds; relativeTime reads ISO strings.
+function ago(unixSeconds: number): string {
+  return relativeTime(new Date(unixSeconds * 1000).toISOString())
+}
+
+function utf8Bytes(text: string): number {
+  return new TextEncoder().encode(text).length
+}
+
+function Muted({ children }: { children: unknown }) {
+  return html`<p class="text-xs text-[var(--color-fg-muted)]">${children}</p>`
+}
+
+function Danger({ children }: { children: unknown }) {
+  return html`<p class="text-xs text-[var(--color-danger)]">${children}</p>`
+}
+
+// A scroll container of its own so a 200 KB turn does not make the page scroll
+// sideways.
+function Pre({ text }: { text: string }) {
+  return html`
+    <pre
+      class="max-h-[28rem] overflow-auto rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-subtle)] p-2 text-3xs leading-relaxed"
+    >${text}</pre>
+  `
+}
+
+/** Every request and response for one turn, as it went to the provider. */
+function RawTurns({ keeper }: { keeper: string }) {
+  const [turns, setTurns] = useState<readonly RawTraceTurn[] | null>(null)
+  const [selected, setSelected] = useState<string | null>(null)
+  const [page, setPage] = useState<RawTracePage | null>(null)
+  const [offset, setOffset] = useState(0)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    setTurns(null)
+    setSelected(null)
+    setPage(null)
+    setError(null)
+    fetchKeeperRawTraces(keeper, 50, { signal: controller.signal })
+      .then(setTurns)
+      .catch((reason: unknown) => {
+        if (controller.signal.aborted) return
+        setError(reason instanceof Error ? reason.message : String(reason))
+      })
+    return () => controller.abort()
+  }, [keeper])
+
+  useEffect(() => {
+    if (selected === null) return
+    const controller = new AbortController()
+    setPage(null)
+    fetchKeeperRawTrace(keeper, selected, {
+      signal: controller.signal,
+      offset,
+      limit: RECORDS_PER_PAGE,
+    })
+      .then(setPage)
+      .catch((reason: unknown) => {
+        if (controller.signal.aborted) return
+        setError(reason instanceof Error ? reason.message : String(reason))
+      })
+    return () => controller.abort()
+  }, [keeper, selected, offset])
+
+  if (error !== null) return html`<${Danger}>원문을 읽지 못했습니다: ${error}<//>`
+  if (turns === null) return html`<${Muted}>턴 목록 읽는 중…<//>`
+  if (turns.length === 0) {
+    return html`<${Muted}>이 keeper 는 아직 저장된 턴 원문이 없습니다.<//>`
+  }
+
+  return html`
+    <div class="grid gap-2">
+      <div class="max-h-40 overflow-auto rounded border border-[var(--color-border-subtle)]">
+        ${turns.map(turn => html`
+          <button
+            key=${turn.file}
+            type="button"
+            class="flex w-full items-center gap-2 border-b border-[var(--color-border-subtle)] px-2 py-1 text-left text-3xs last:border-b-0 ${
+              selected === turn.file ? 'bg-[var(--color-bg-selected)]' : ''
+            }"
+            onClick=${() => { setSelected(turn.file); setOffset(0) }}
+          >
+            <span class="font-mono">${turn.file}</span>
+            <span class="ml-auto tabular-nums text-[var(--color-fg-muted)]">
+              ${turn.records}건 · ${formatBytes(turn.bytes)} · ${ago(turn.modifiedAt)}
+            </span>
+          </button>
+        `)}
+      </div>
+
+      ${selected === null
+        ? html`<${Muted}>턴을 고르면 원문이 열립니다.<//>`
+        : page === null
+          ? html`<${Muted}>${selected} 읽는 중…<//>`
+          : html`
+            <div class="flex items-center gap-2 text-3xs text-[var(--color-fg-muted)]">
+              <span class="font-mono">${page.file}</span>
+              <span class="tabular-nums">
+                ${page.offset + 1}–${page.offset + page.records.length} / ${page.totalRecords}
+              </span>
+              <${Btn}
+                class="ml-auto"
+                disabled=${page.offset === 0}
+                onClick=${() => setOffset(Math.max(0, page.offset - RECORDS_PER_PAGE))}
+              >이전<//>
+              <${Btn}
+                disabled=${page.offset + page.records.length >= page.totalRecords}
+                onClick=${() => setOffset(page.offset + RECORDS_PER_PAGE)}
+              >다음<//>
+            </div>
+            ${page.records.map((record, index) => html`
+              <div key=${page.offset + index}>
+                ${record.ok
+                  ? html`<${Pre} text=${JSON.stringify(record.record, null, 2)} />`
+                  // A torn line keeps its position rather than being skipped:
+                  // a damaged trace must not read as a shorter one.
+                  : html`<${Danger}>레코드 ${page.offset + index + 1} 를 읽지 못했습니다: ${record.error}<//>`}
+              </div>
+            `)}
+          `}
+    </div>
+  `
+}
+
+/** The system context that will be assembled into the keeper's next turn. */
+function NextPrompt({ keeper }: { keeper: string }) {
+  const [capture, setCapture] = useState<PromptCapture | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [open, setOpen] = useState<string | null>(null)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    setCapture(null)
+    setError(null)
+    fetchKeeperLastPrompt(keeper, { signal: controller.signal })
+      .then(setCapture)
+      .catch((reason: unknown) => {
+        if (controller.signal.aborted) return
+        setError(reason instanceof Error ? reason.message : String(reason))
+      })
+    return () => controller.abort()
+  }, [keeper])
+
+  if (error !== null) return html`<${Danger}>프롬프트를 읽지 못했습니다: ${error}<//>`
+  if (capture === null) return html`<${Muted}>프롬프트 읽는 중…<//>`
+  if (capture.blocks.length === 0) {
+    return html`<${Muted}>아직 캡처된 프롬프트가 없습니다. 이 keeper 가 한 턴을 돌면 생깁니다.<//>`
+  }
+
+  const total = capture.blocks.reduce((sum, block) => sum + block.bytes, 0)
+
+  return html`
+    <div class="grid gap-2">
+      <div class="text-3xs text-[var(--color-fg-muted)]">
+        turn ${capture.absoluteTurn} · trace
+        <span class="font-mono">${capture.traceId}</span> ·
+        ${ago(capture.capturedAt)} · 합계 ${formatBytes(total)}
+      </div>
+      ${capture.blocks.map(block => html`
+        <div key=${block.id} class="rounded border border-[var(--color-border-subtle)]">
+          <button
+            type="button"
+            class="flex w-full items-center gap-2 px-2 py-1 text-left text-3xs"
+            onClick=${() => setOpen(open === block.id ? null : block.id)}
+          >
+            <span class="font-mono">${block.id}</span>
+            <span class="ml-auto tabular-nums text-[var(--color-fg-muted)]">
+              ${formatBytes(block.bytes)}
+            </span>
+            <span aria-hidden="true">${open === block.id ? '▾' : '▸'}</span>
+          </button>
+          ${open === block.id ? html`<div class="p-2 pt-0"><${Pre} text=${block.text} /></div>` : null}
+        </div>
+      `)}
+      ${capture.assembled === null
+        ? null
+        : html`
+          <details>
+            <summary class="cursor-pointer text-3xs text-[var(--color-fg-muted)]">
+              조립된 전문 (${formatBytes(utf8Bytes(capture.assembled))})
+            </summary>
+            <div class="pt-1"><${Pre} text=${capture.assembled} /></div>
+          </details>
+        `}
+    </div>
+  `
+}
+
+/** One sentence for one turn. The only write on this panel. */
+function NoteEditor({ keeper }: { keeper: string }) {
+  const [note, setNote] = useState<OperatorNote | null>(null)
+  const [absent, setAbsent] = useState(false)
+  const [draft, setDraft] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+
+  const load = useCallback((signal?: AbortSignal) => {
+    setError(null)
+    fetchKeeperOperatorNote(keeper, { signal })
+      .then(value => { setNote(value); setAbsent(false) })
+      .catch((reason: unknown) => {
+        if (signal?.aborted) return
+        // No note yet is the ordinary state for most keepers, not a failure.
+        const message = reason instanceof Error ? reason.message : String(reason)
+        if (/no_note|not found/i.test(message)) { setNote(null); setAbsent(true); return }
+        setError(message)
+      })
+  }, [keeper])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    setNote(null)
+    setAbsent(false)
+    setDraft('')
+    load(controller.signal)
+    return () => controller.abort()
+  }, [keeper, load])
+
+  const bytes = utf8Bytes(draft)
+  const overBudget = bytes > MAX_NOTE_BYTES
+
+  const submit = useCallback(async () => {
+    setSaving(true)
+    setError(null)
+    try {
+      const saved = await putKeeperOperatorNote(keeper, draft)
+      setNote(saved)
+      setAbsent(false)
+      setDraft('')
+    } catch (reason: unknown) {
+      // The server rejects an oversized note rather than truncating it, and
+      // its refusal carries the byte counts. Showing it verbatim beats a
+      // generic failure for the one case an operator needs to act on.
+      setError(reason instanceof Error ? reason.message : String(reason))
+    } finally {
+      setSaving(false)
+    }
+  }, [keeper, draft])
+
+  return html`
+    <div class="grid gap-2">
+      ${error !== null ? html`<${Danger}>${error}<//>` : null}
+
+      ${absent
+        ? html`<${Muted}>대기 중인 노트가 없습니다.<//>`
+        : note === null
+          ? html`<${Muted}>노트 읽는 중…<//>`
+          : html`
+            <div class="rounded border border-[var(--color-border-subtle)] p-2">
+              <div class="flex items-center gap-2 text-3xs text-[var(--color-fg-muted)]">
+                <span>${note.pending ? '다음 턴에 실림' : `turn ${note.consumedTurn} 에서 소비됨`}</span>
+                <span class="ml-auto">${note.createdBy} · ${ago(note.createdAt)}</span>
+              </div>
+              <${Pre} text=${note.text} />
+            </div>
+          `}
+
+      <label class="grid gap-1">
+        <span class="text-3xs uppercase tracking-wide text-[var(--color-fg-muted)]">
+          새 노트 — 다음 턴 한 번에만 실립니다
+        </span>
+        <textarea
+          class="min-h-24 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-subtle)] p-2 text-xs"
+          value=${draft}
+          onInput=${(event: Event) => setDraft((event.target as HTMLTextAreaElement).value)}
+          placeholder="예: PR #27407 의 취소 기록부터 확인하고 시작해라."
+        ></textarea>
+      </label>
+
+      <div class="flex items-center gap-2 text-3xs">
+        <span class="tabular-nums ${overBudget ? 'text-[var(--color-danger)]' : 'text-[var(--color-fg-muted)]'}">
+          ${bytes} / ${MAX_NOTE_BYTES} B
+        </span>
+        ${overBudget
+          ? html`<span class="text-[var(--color-danger)]">한도를 넘으면 잘리지 않고 거부됩니다.</span>`
+          : null}
+        <${Btn}
+          class="ml-auto"
+          disabled=${saving || draft.trim().length === 0 || overBudget}
+          onClick=${() => void submit()}
+        >${saving ? '저장 중…' : '다음 턴에 싣기'}<//>
+      </div>
+    </div>
+  `
+}
+
+export function KeeperTurnInspectorPanel({ keepers }: { keepers: readonly string[] }) {
+  const [keeper, setKeeper] = useState<string | null>(keepers[0] ?? null)
+  const [tab, setTab] = useState<Tab>('raw')
+
+  // The roster arrives after the first render, so adopt the first keeper once
+  // it does and drop a selection that is no longer in the roster.
+  useEffect(() => {
+    if (keeper !== null && keepers.includes(keeper)) return
+    setKeeper(keepers[0] ?? null)
+  }, [keepers, keeper])
+
+  if (keeper === null) {
+    return html`
+      <section class="grid gap-2" data-testid="keeper-turn-inspector">
+        <${Muted}>관측된 keeper 가 없습니다.<//>
+      </section>
+    `
+  }
+
+  const active = TABS.find(item => item.id === tab) ?? TABS[0]!
+
+  return html`
+    <section class="grid gap-2" data-testid="keeper-turn-inspector">
+      <div class="flex flex-wrap items-center gap-2">
+        <h3 class="text-xs font-semibold text-[var(--color-fg-primary)]">Turn inspector</h3>
+        <label class="flex items-center gap-1 text-3xs text-[var(--color-fg-muted)]">
+          keeper
+          <select
+            class="rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-subtle)] px-1 py-0.5 text-3xs"
+            value=${keeper}
+            onChange=${(event: Event) => setKeeper((event.target as HTMLSelectElement).value)}
+          >
+            ${keepers.map(name => html`<option key=${name} value=${name}>${name}</option>`)}
+          </select>
+        </label>
+      </div>
+
+      <div class="flex flex-wrap gap-1" role="tablist" aria-label="Turn inspector views">
+        ${TABS.map(item => html`
+          <${Btn}
+            key=${item.id}
+            role="tab"
+            aria-selected=${tab === item.id}
+            class=${tab === item.id ? 'v2-monitoring-action is-active' : 'v2-monitoring-action'}
+            onClick=${() => setTab(item.id)}
+          >${item.label}<//>
+        `)}
+      </div>
+      <${Muted}>${active.hint}<//>
+
+      ${tab === 'raw' ? html`<${RawTurns} keeper=${keeper} />` : null}
+      ${tab === 'prompt' ? html`<${NextPrompt} keeper=${keeper} />` : null}
+      ${tab === 'note' ? html`<${NoteEditor} keeper=${keeper} />` : null}
+    </section>
+  `
+}


### PR DESCRIPTION
## 문제

raw-trace reader 와 RFC-0366 이 들어간 뒤로 서버는 keeper 턴에 대해 네 가지를 서빙해 왔다:

```
GET /api/v1/keepers/:name/raw-traces          턴 파일 목록
GET /api/v1/keepers/:name/raw-trace?file=…    한 턴의 레코드
GET /api/v1/keepers/:name/last-prompt         다음 턴에 조립될 프롬프트
GET /api/v1/keepers/:name/operator-note       대기 중인 노트
POST                        (동일 경로)        노트 작성
```

**대시보드에서 이 중 어느 것도 읽지 않았다.** 라우트, API 클라이언트, 디코더, 디코더 테스트까지 전부 있고 전부 초록인데 소비하는 컴포넌트가 0개였다. 턴을 읽는 유일한 방법이 curl 이었다.

```
$ rg 'dashboard-keeper-prompt' dashboard/src --glob '!*/api/*'
(0곳)
```

디코더 테스트는 **무엇이 그 결과를 렌더하든 말든 통과한다.** 그래서 이 상태가 보이지 않았다.

## 화면

librarian journal 이 이미 있는 Internal Agents 안에 keeper 범위 inspector 를 추가한다.

| 탭 | 내용 |
|---|---|
| **Raw turns** | 턴 파일 목록(레코드 수·크기·시각) → 선택 시 레코드 20개씩. 디코드 실패한 레코드는 **건너뛰지 않고 제자리에 사유와 함께** 표시 — 손상된 트레이스가 짧은 트레이스로 읽히면 안 된다 |
| **Next prompt** | 조립 블록별 바이트와 전문, 조립된 전문은 `<details>` 뒤에 |
| **Note** | 대기/소비 상태 + 작성기. **4 KB 예산을 입력 중에** 표시 |

노트 예산을 타이핑 중에 보여주는 이유: 스토어가 초과분을 자르지 않고 **거부**하기 때문이다. 예상하지 못한 거부는 버그처럼 읽힌다. 서버의 거부 메시지는 자기 바이트 수를 싣고 오므로 그대로 표시한다.

keeper 목록은 새로 fetch 하지 않고 **이미 화면에 있는 run 에서** 뽑는다 — fusion row 는 `keeper` 를, exact lane 은 `actor` 를 이름으로 갖는다. verification run 은 evaluator runtime 으로 키잉되므로 기여하지 않는다.

노트를 뺀 전부가 읽기 전용이다. 읽기·쓰기 라우트 둘 다 이미 존재했고 이 PR 은 호출만 한다.

## 검증

```
dashboard  Test Files 635 passed (635)   Tests 8805 passed (8805)
tsc --noEmit  rc=0, 오류 0
npm run lint  rc=0, 출력 0줄
```

측정 과정에서 한 번 오염된 값을 얻었다(1 failed / 8804, 파일 634 vs 635). 원인은 baseline 을 재려고 쓴 `git stash push`/`pop` 이었다 — **stash 스택은 저장소 전역 공유**라서 push 와 pop 사이에 다른 워크트리의 stash 가 쌓이면 `pop` 이 그것을 집는다. 깨끗한 워크트리에서 다시 잰 값이 위 수치다.

RFC-WAIVED: 기존 라우트에 소비자를 붙이는 프론트엔드 변경. 서버 계약·판정 기준을 바꾸지 않는다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
