### PR TITLE
fix(board): an @ in prose is not a failed mention

### DIFF
--- a/lib/board/board_audience.ml
+++ b/lib/board/board_audience.ml
@@ -4,54 +4,64 @@ include Board_types
    selectors, [@] target candidates) is shared with the Keeper write
    boundary through [Board_addressing] (issue #25601).  This module owns
    only the Board identity policy: candidates are validated through
-   [Agent_id.of_string], which is case-sensitive, and invalid candidates
-   fail closed as [Malformed_targets]. *)
+   [Agent_id.of_string], which is case-sensitive, and a candidate it rejects is
+   read as prose rather than as a failed address. *)
 
 type explicit_address =
   | No_explicit_address
   | Explicit_targets of Agent_id.t list
   | Broadcast_all
   | Unsupported_broadcast of string list
-  | Malformed_targets of string list
 
 let compare_agent_id left right =
   String.compare (Agent_id.to_string left) (Agent_id.to_string right)
 ;;
 
+(* A token an [Agent_id] could never be is prose, not a mention that went
+   wrong. [Agent_id.of_string] checks shape only -- 1..64 of [a-zA-Z0-9._-]
+   with one optional colon -- so every candidate it rejects fails on a
+   character or a length no keeper name can have. Treating those as malformed
+   addresses rejected the whole post, and the live log shows what was being
+   rejected: a bare "@" five times, "@@" three times, and
+   "@internals/libs/errors/asyncErrorHandler." once. Prose, an npm scope, a
+   path. None was an attempt to address anyone.
+
+   The case this used to protect is not the case it caught. A plausible
+   misspelling -- "@alcie" for "@alice" -- passes the shape check, becomes a
+   target, and matches no keeper on the read side, where each keeper filters a
+   post's mentions against its own ids. That mention is lost silently today and
+   still is after this change; catching it needs the keeper registry at the
+   write boundary, which this does not add. What this removes is a rejection
+   that fired only where there was nothing to protect. *)
 let explicit_address_of_text content =
   match Board_addressing.parse content with
   | Board_addressing.Broadcast_all -> Broadcast_all
   | Board_addressing.Unsupported_broadcast selectors ->
-    Unsupported_broadcast selectors
+    (* A bare [@@] parses as the empty selector. Empty is prose by the same
+       argument; a named one is an author who meant to broadcast and named a
+       selector that does not exist, which is worth refusing. *)
+    (match List.filter (fun selector -> not (String.equal selector "")) selectors with
+     | [] -> No_explicit_address
+     | named -> Unsupported_broadcast named)
   | Board_addressing.No_explicit_address -> No_explicit_address
   | Board_addressing.Raw_targets candidates ->
-    let targets, malformed =
-      List.fold_left
-        (fun (targets, malformed) candidate ->
-          match Agent_id.of_string candidate with
-          | Ok target -> target :: targets, malformed
-          | Error _ ->
-            (* Report the original [@]-prefixed token so the error message
-               shows what the author typed. *)
-            targets, (Board_addressing.target_prefix ^ candidate) :: malformed)
-        ([], [])
+    let targets =
+      List.filter_map
+        (fun candidate ->
+           match Agent_id.of_string candidate with
+           | Ok target -> Some target
+           | Error _ -> None)
         candidates
     in
-    (match List.sort_uniq String.compare malformed with
-     | _ :: _ as malformed -> Malformed_targets malformed
-     | [] ->
-       (match List.sort_uniq compare_agent_id targets with
-        | [] -> No_explicit_address
-        | _ :: _ as targets -> Explicit_targets targets))
+    (match List.sort_uniq compare_agent_id targets with
+     | [] -> No_explicit_address
+     | _ :: _ as targets -> Explicit_targets targets)
 ;;
 
 let direct_targets_of_text content =
   match explicit_address_of_text content with
   | Explicit_targets targets -> targets
-  | ( No_explicit_address
-    | Broadcast_all
-    | Unsupported_broadcast _
-    | Malformed_targets _ ) -> []
+  | (No_explicit_address | Broadcast_all | Unsupported_broadcast _) -> []
 ;;
 
 let address_text ~title ~content =
@@ -69,13 +79,6 @@ let unsupported_broadcast_error selectors =
        (String.concat ", " (List.map (Printf.sprintf "@@%s") selectors)))
 ;;
 
-let malformed_targets_error targets =
-  Validation_error
-    (Printf.sprintf
-       "invalid Board target token(s): %s"
-       (String.concat ", " targets))
-;;
-
 let audience_of_address ~visibility ~unaddressed = function
   | Explicit_targets targets -> Ok (Targets targets)
   | Broadcast_all ->
@@ -83,7 +86,6 @@ let audience_of_address ~visibility ~unaddressed = function
      | Direct -> Error (Validation_error "Direct Board posts cannot broadcast")
      | Public | Unlisted | Internal -> Ok Broadcast)
   | Unsupported_broadcast selectors -> Error (unsupported_broadcast_error selectors)
-  | Malformed_targets targets -> Error (malformed_targets_error targets)
   | No_explicit_address -> unaddressed ()
 ;;
 
@@ -100,7 +102,6 @@ let audience_for_comment ~content =
   | Explicit_targets targets -> Ok (Targets targets)
   | Broadcast_all -> Ok Broadcast
   | Unsupported_broadcast selectors -> Error (unsupported_broadcast_error selectors)
-  | Malformed_targets targets -> Error (malformed_targets_error targets)
   | No_explicit_address -> Ok Thread_participants
 ;;
 

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -1964,6 +1964,41 @@ let test_post_update_schema_exposes_new_author () =
 
 (** {1 Test Runner} *)
 
+(* An [@] a keeper name could never be is prose. [Agent_id] accepts 1..64 of
+   [a-zA-Z0-9._-] with one optional colon, so a bare "@", an npm scope and a
+   path all fail that shape -- and used to take the whole post down with them.
+   Each case below is a shape the live board log carried while the post was
+   refused. *)
+let comment_audience content =
+  Masc.Board.audience_for_comment ~content
+
+let post_audience content =
+  Masc.Board.audience_for_post ~visibility:Masc.Board.Public ~title:"t" ~content
+
+let label_of = function
+  | Ok audience -> Masc.Board.audience_label audience
+  | Error _ -> "error"
+
+let test_prose_at_is_not_an_address () =
+  Alcotest.(check string) "bare @ in a comment" "thread_participants"
+    (label_of (comment_audience "ping @ me later"));
+  Alcotest.(check string) "npm scope" "discoverable"
+    (label_of (post_audience "see @internals/libs/errors/asyncErrorHandler."));
+  Alcotest.(check string) "bare @@" "thread_participants"
+    (label_of (comment_audience "the @@ operator"))
+
+let test_a_named_broadcast_selector_is_still_refused () =
+  (* An author who wrote @@something meant to broadcast and named a selector
+     that does not exist. That is worth refusing; the empty one is not. *)
+  Alcotest.(check string) "unknown selector" "error"
+    (label_of (comment_audience "heads up @@everyone"))
+
+let test_a_well_shaped_name_is_still_a_target () =
+  Alcotest.(check string) "plain name" "targets"
+    (label_of (comment_audience "@analyst please look"));
+  Alcotest.(check string) "namespaced name" "targets"
+    (label_of (comment_audience "@keeper:analyst please look"))
+
 let () =
   Eio_main.run @@ fun env ->
   current_eio_env := Some env;
@@ -2108,6 +2143,15 @@ let () =
             test_dispatch_post_update_transfers_author;
           Alcotest.test_case "post update missing id" `Quick
             test_dispatch_post_update_missing_id;
+        ] );
+      ( "board addressing",
+        [
+          Alcotest.test_case "an @ in prose is not an address" `Quick
+            test_prose_at_is_not_an_address;
+          Alcotest.test_case "a named broadcast selector is still refused" `Quick
+            test_a_named_broadcast_selector_is_still_refused;
+          Alcotest.test_case "a well-shaped name is still a target" `Quick
+            test_a_well_shaped_name_is_still_a_target;
         ] );
       ( "schemas",
         [


### PR DESCRIPTION
## What

A post or comment whose text contained an `@` that no keeper name could be was
**rejected whole**.

`Agent_id` checks shape only — 1..64 of `[a-zA-Z0-9._-]` with one optional colon
— so every candidate it refused failed on a character or a length no name can
have. From the live tool log, this is what was being refused:

```
keeper_board_post / keeper_board_comment failures
  5x  invalid Board target token(s): @
  3x  unsupported Board broadcast selector(s): @@
  1x  invalid Board target token(s): @internals/libs/errors/asyncErrorHandler.
```

Prose, an npm scope, a path. None addressed anyone, and each cost the whole
post.

## The rejection fired where there was nothing to protect

A plausible misspelling — `@alcie` for `@alice` — **passes** the shape check. It
becomes a target, and then matches no keeper on the read side, where each keeper
filters a post's mentions against its own ids:

```ocaml
(* keeper_world_observation_board_signal.ml:246 *)
targets |> List.filter (fun target -> ... List.exists (Keeper_id.equal target_id) mentions)
```

Nothing anywhere compares a target against the keeper registry — I checked the
write boundary and the wake boundary. So the case the rejection existed for is
lost silently, and the case it caught was prose.

**This PR does not add the registry check.** That is a real gap and a separate
change: it needs the registry at the write boundary and a decision about
mentioning a keeper that has not started yet. What this removes is the refusal
that fired only on prose.

## Scope

`board_addressing` already blanks code spans and fences for exactly these
shapes — its comment names `@internals/libs/datadogRum`, `@/lib/constants` and
`@@`. This covers the ones **outside** backticks.

A named broadcast selector still errors: an author who wrote `@@something` meant
to broadcast and named one that does not exist. Only the empty selector, which a
bare `@@` produces, is read as prose.

With `Malformed_targets` no longer constructed the compiler reported it unused
(warning 37), so the constructor and its error text went too.

## Tests

Three cases in `test_tool_board_coverage`, which CI runs:

| case | asserts |
|---|---|
| an @ in prose is not an address | bare `@` → `thread_participants`, npm scope → `discoverable`, bare `@@` → `thread_participants` |
| a named broadcast selector is still refused | `@@everyone` → error |
| a well-shaped name is still a target | `@analyst` and `@keeper:analyst` → `targets` |

Verified not identities: with the tests in place and `board_audience.ml` reverted
to `origin/main`,

```
1 failure! in 78 tests run
[FAIL] board addressing 0  an @ in prose is not an address
```

exactly the prose case fails. The other two pass both ways, which is what makes
them regression guards rather than restatements.

## Verification

```
dune build --root . @check                              exit 0
dune build --root . @test/runtest-test_tool_board_coverage
                                        Test Successful, 78 tests run
```

RFC-WAIVED: a validation narrowed to stop rejecting text it could never have
been about. No new check, no new field.
