### PR TITLE
refactor(server): 한 번도 게이트한 적 없는 proactive-refresh health gate 제거

### DIFF
--- a/lib/server/proactive_refresh.ml
+++ b/lib/server/proactive_refresh.ml
@@ -12,7 +12,6 @@ type config = {
   failure_threshold : int;
   timeout_s : float;
   on_error : (exn -> unit) option;
-  health_check : (unit -> bool) option;
   warm_delay_s : float;
   warn_first_failure : bool;
 }
@@ -25,7 +24,6 @@ let default_config ~label ~interval_s =
     failure_threshold = 3;
     timeout_s = 10.0;
     on_error = None;
-    health_check = None;
     warm_delay_s = 0.0;
     warn_first_failure = true;
   }
@@ -137,27 +135,6 @@ let start ~sw ~clock ~config:raw_config ~compute ~on_result =
     let rec loop () =
       let jitter = Random.float (!current_interval *. 0.25) in
       Eio.Time.sleep clock (!current_interval +. jitter);
-      let health_ok = match config.health_check with
-        | None -> true
-        | Some check -> Safe_ops.protect ~default:false check
-      in
-      if not health_ok then begin
-        incr consecutive_failures;
-        if !consecutive_failures >= config.failure_threshold then
-          current_interval :=
-            min config.max_backoff_s (!current_interval *. 2.0);
-        let message =
-          Printf.sprintf
-            "%s skipped: health gate failed (%d consecutive, next in %.0fs)"
-            config.label !consecutive_failures !current_interval
-        in
-        log_dashboard_refresh_failure message
-          ~warn:
-            (should_warn_refresh_failure
-               ~failure_threshold:config.failure_threshold
-               ~warn_first_failure:config.warn_first_failure
-               !consecutive_failures)
-      end else
       let t0 = Time_compat.now () in
       (try
          match

--- a/lib/server/proactive_refresh.mli
+++ b/lib/server/proactive_refresh.mli
@@ -10,7 +10,6 @@ type config = {
   failure_threshold : int;  (** Consecutive failures before backoff kicks in. *)
   timeout_s : float;        (** Warm-cache timeout. *)
   on_error : (exn -> unit) option;  (** Called on timeout or exception. *)
-  health_check : (unit -> bool) option;  (** Pre-compute gate. If [Some f] and [f ()] returns [false], the cycle is skipped and backoff applied. *)
   warm_delay_s : float;    (** Delay before cold-start warm-cache compute (0.0 = immediate). *)
   warn_first_failure : bool;  (** Log a warning on the very first refresh failure. *)
 }


### PR DESCRIPTION
refactor(server): remove the proactive-refresh health gate that never gated

Proactive_refresh.config carries

  health_check : (unit -> bool) option;
  (** Pre-compute gate. If [Some f] and [f ()] returns [false], the cycle
      is skipped and backoff applied. *)

`health_check =` occurs exactly once in the tree: the `None` default in
proactive_refresh.ml:28. Every config is built from that default with
field overrides -- server_routes_http_runtime.ml:1262 sets on_error,
warm_delay_s and warn_first_failure, and no site anywhere sets
health_check. So health_ok was always true and the whole

  if not health_ok then begin ... end else

arm was unreachable: the failure increment, the interval doubling to
max_backoff_s, and the "skipped: health gate failed" log line could not
run.

Removed the field, its default, the health_ok binding and the dead arm.
The if/else collapses to the else body.

The surrounding backoff machinery stays. consecutive_failures,
failure_threshold, max_backoff_s and warn_first_failure are live through
the timeout and exception paths, which call log_refresh_failure with the
same refs -- I checked before cutting, because the first read suggested
the whole backoff was dead and it is not.


---

## 측정

```
$ rg -n 'health_check *=' lib bin test --glob '!_build'
lib/server/proactive_refresh.ml:28:    health_check = None;
```

한 줄이 전부다. `Some` 을 넣는 곳이 없다.

| 심볼 | 상태 |
|---|---|
| `config.health_check` | 항상 `None` |
| `health_ok` | 항상 `true` |
| `if not health_ok then begin … end` | **도달 불가** |
| `consecutive_failures` / `failure_threshold` / `max_backoff_s` / `warn_first_failure` | **살아있음** (timeout · 예외 경로) |

## 한 번 틀릴 뻔했다

처음 `health_ok` 가 상수인 걸 보고 "백오프 전체가 죽었다" 로 읽었다. **틀렸다.** 루프를 끝까지 읽으니 timeout 과 예외 경로가 같은 ref 들을 `log_refresh_failure` 로 넘긴다:

```ocaml
| Error `Timeout ->
    log_refresh_failure ~config ~consecutive_failures ~current_interval ~dt timeout_exn
with … exn ->
    log_refresh_failure ~config ~consecutive_failures ~current_interval ~dt exn
```

그래서 제거 범위를 health-gate 분기로만 좁혔다. `warn_first_failure` 는 `server_routes_http_runtime.ml:1264` 에서 실제로 `false` 로 설정된다 — 같은 레코드에서 이 필드는 설정되고 `health_check` 는 안 되는 것이 대비된다.

## 검증

```
dune build --root . @check    # exit 0
rg 'health_check|health_ok' lib/server/proactive_refresh.ml{,i}   # 0건
```

미검증: 서버를 띄워 새로고침 루프를 돌려보지 않았다. 제거한 분기가 도달 불가라는 것이 근거이고 정적 측정이다.
