### PR TITLE
fix(librarian): stop re-adjudicating stored memory against the admission bar

### DIFF
--- a/config/prompts/librarian.md
+++ b/config/prompts/librarian.md
@@ -14,12 +14,18 @@ Keep only the smallest useful set of important knowledge. There is no target ite
 
 Capacity contract: the complete rendered fact payload (memory identity, category, claim, separators, and line breaks) must fit within {{max_recall_fact_bytes}} UTF-8 bytes. Choose a smaller useful set when necessary. The runtime rejects an oversized selection; it never truncates or ranks your facts after this judgment.
 
-Retention criteria:
-- Retain an existing ID only when its exact fact is still true, important, non-duplicative, and worth occupying future context.
-- Drop stale, superseded, transient, or derivable existing memories. Dropping is the deletion operation, and each drop states its reason in one sentence (what made this memory stop earning its place).
+Retention criteria — these are NOT the new-claim criteria. A memory that is
+already stored has passed the admission bar once; you are not deciding whether
+to admit it again. Retain it unless you can name what made it stop being true,
+and say that in the drop reason. "I am not sure this is worth a slot" is not a
+reason; it is the absence of one, and it belongs to the new-claim decision, not
+to this one. Judge each existing memory on its own defect, never on whether the
+set as a whole feels large.
+- Retain an existing ID unless one of the drop conditions below applies to it.
+- Drop an existing memory only when you can name the defect: the conversation contradicts it, a later memory or event superseded it, it duplicates another retained memory, or it describes a moment that has passed (a queue depth, a turn's intent, a task's mid-progress status). Dropping is the deletion operation, and each drop states in one sentence what made this memory stop being true.
 - Never recreate a dropped existing fact as a new claim merely to reword it.
 - Record a rule the way its source states it. Do not store the inverse: "when X, do Y" does not license "only when X", and "Y is not yours to do" does not license "stay out of everything nearby". The inverse adds an exclusivity the source never wrote, and once stored it reads as authoritative in every later turn. If the source names when to act, keep it as that; if it names a boundary, keep the boundary at the width it was written.
-- Apply the category criteria below to existing memories too, not only to new claims. A stored memory that would not be written today does not earn retention by already being there. In particular, drop a stored memory that no external rule enforces but that still narrows what the agent takes on — one describing what the agent decided to stay out of, wait for, or not take on — with the reason that it was the agent's own scope decision rather than an enforced rule. Read the claim, not its category: relabelling such a memory `preference` or `fact` does not earn it retention.
+- One category rule does reach backwards, because what it forbids is harmful for as long as it is stored, not merely unearned: drop a stored memory that no external rule enforces but that still narrows what the agent takes on — one describing what the agent decided to stay out of, wait for, or not take on — with the reason that it was the agent's own scope decision rather than an enforced rule. Read the claim, not its category: relabelling such a memory `preference` or `fact` does not earn it retention. No other category criterion is grounds to drop an already-stored memory.
 
 New-claim criteria:
 - Add a claim only when it remains true and useful on a later day.

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -348,6 +348,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0364 | keeper 당 체크아웃 하나 (`repos/` 중간 디렉터리 폐기) | Draft | - |
 | 0365 | handoff_context must survive the ownership boundary | Draft | - |
 | 0366 | 운영자가 다음 턴의 컨텍스트에 한 문장을 넣는다 | Draft | - |
+| 0367 | `fact` 는 기본값이 아니라 최후수단이어야 하고, 그건 스키마가 강제해야 한다 | Draft | - |
 | RFC-0034d-stale-agent-sync | d — release_stale_claims agent-side sync | Draft | - |
 | RFC-async-log-sink-durable-append-offload | Offload the structured-log durable append off the emitting fiber | Draft | - |
 | RFC-checkpoint-pinned-root-containment | Immutable boot-pinned root capability for checkpoint containment | Draft | - |

--- a/docs/rfc/RFC-0367-librarian-fact-category-is-not-a-default.md
+++ b/docs/rfc/RFC-0367-librarian-fact-category-is-not-a-default.md
@@ -1,0 +1,102 @@
+# RFC-0367 — `fact` 는 기본값이 아니라 최후수단이어야 하고, 그건 스키마가 강제해야 한다
+
+**Status**: Draft
+**Author**: Claude Opus 5 (1M context)
+**Date**: 2026-08-07
+
+## 문제
+
+librarian 프롬프트는 이미 옳은 말을 하고 있다.
+
+> `fact` is the **last resort, never the default** — if you are unsure whether something is durable, omit it rather than storing it as "fact".
+
+지시는 지켜지지 않는다. 2026-08-07 실측:
+
+```
+rondo, rev 600~667 에 추가된 44건
+  fact                37   (84%)
+  blocker              4
+  goal                 2
+  constraint           1
+```
+
+그리고 rev 668 에서 32건이 한 커밋에 전부 버려졌다. drop reason 은 하나하나 정당하다.
+
+```
+"Task-205 is fully done and accepted, so this claim that it is 'todo and reclaimable' is false."
+"Mid-progress status of task-205 is obsolete — the task is fully done and accepted."
+"Meta-entry about which other memory entries are stale is itself stale and has no durable value."
+```
+
+버린 판단은 옳았다. 문제는 **애초에 담긴 것이 순간 상태였다는 것**이고, 그것들이 전부 `fact` 로 들어왔다는 것이다.
+
+대조군이 이를 확인한다. `sangsu` 는 같은 기간 14건을 유지하고 있고 최고령이 70.6시간이다.
+
+```
+constraint          3     "PR title validation enforces ^\[([A-Z]+-[0-9]…"
+lesson              5     "submit_for_verification requires a `notes` field…"
+validated_approach  4
+fact                2
+```
+
+`fact` 가 2건이다. 살아남는 메모리는 외부에서 강제되는 규칙이고, 사라지는 메모리는 `fact` 로 들어온 순간 상태다.
+
+## 왜 프롬프트로는 안 되는가
+
+`fact` 는 카테고리 목록의 마지막 항목이고, 스키마상 다른 일곱과 완전히 동등하다.
+
+```json
+"category": "code_change|fact|preference|blocker|goal|constraint|validated_approach|lesson"
+```
+
+"최후수단"은 산문에만 있다. 모델이 분류에 확신이 없을 때 가장 넓은 라벨을 고르는 것은 합리적 행동이고, `fact` 의 정의("externally verifiable statement about the world")는 거의 모든 문장을 받아준다. 프롬프트를 더 강하게 쓰는 것은 같은 층위에서 같은 부탁을 반복하는 것이다.
+
+이 저장소는 같은 결론에 여러 번 도달했다. `RFC-0042` 가 문자열 분류기를 닫은 것, 오늘 `#27275` 가 게이트 감사에서 네 권한을 문자열 하나로 뭉개던 것을 payload 없는 variant 로 바꾼 것이 같은 모양이다. CLAUDE.md 의 워크어라운드 거부 기준 2번(문자열 분류기 보강)이 정확히 이 자리를 가리킨다.
+
+## 제안
+
+`fact` 에만 추가 필드를 요구해, 다른 일곱과 **비용이 다르게** 만든다.
+
+```json
+{
+  "claim": "…",
+  "category": "fact",
+  "durability_basis": "무엇이 이 문장을 다음 주에도 참으로 유지하는가"
+}
+```
+
+- 일곱 카테고리는 지금과 동일하다. 각자 정의가 이미 지속성을 함의한다 — `constraint` 는 외부가 강제하고, `lesson` 은 교정을 담고, `validated_approach` 는 확인된 결과를 담는다.
+- `fact` 는 `durability_basis` 없이는 파서가 거부한다. 근거를 못 쓰면 애초에 durable 하지 않다는 뜻이므로, 프롬프트 53행("If you are unsure a claim is durable, omit it")이 산문이 아니라 검증으로 집행된다.
+- `durability_basis` 는 저장되지 않는다. 입장 심사에만 쓰고 버린다. 저장하면 그 자체가 재심 대상이 되어 같은 문제를 재생산한다.
+
+### 대안과 트레이드오프
+
+| 안 | 장점 | 단점 |
+|---|---|---|
+| `fact` 를 스키마에서 제거 | 가장 단순 | 일곱에 안 맞는 진짜 외부 사실을 담을 곳이 없어짐 |
+| `fact` 에 만료 시각 요구 | 순간 상태를 자동 청소 | 만료 추정은 또 다른 비결정 판단이고, 정리기는 이미 정상 작동한다 |
+| **`durability_basis` 요구 (제안)** | 기존 카테고리 보존, 거부가 결정론적 | 프롬프트/스키마 양쪽 수정, 기존 저장분과의 호환 필요 |
+| 프롬프트만 강화 | 코드 변경 없음 | **이미 시도된 상태이며 84% 로 실패했다** |
+
+## 범위
+
+- `Keeper_librarian` 의 selection 스키마와 파서
+- `config/prompts/librarian.md` 의 출력 스키마 블록과 `fact` 항목
+- 기존 저장분: 이미 저장된 `fact` 는 `durability_basis` 가 없다. 재심에서 요구하지 않는다 — 입장 심사에만 적용한다. (별도 변경으로 재심과 입장 기준을 분리했다: `fix/librarian-retention-asymmetry`)
+
+## 검증
+
+게이트는 PASS 가 아니라 **거부하는지**로 확인한다.
+
+1. `durability_basis` 없는 `fact` 를 담은 selection → 파서가 거부
+2. `durability_basis` 있는 `fact` → 통과, 저장된 fact 에는 필드가 없음
+3. 다른 일곱 카테고리 → 필드 없이 통과 (기존 동작 불변)
+4. 이미 저장된 `fact` 의 재심 → 필드를 요구하지 않음
+
+측정 지표는 카테고리 분포다. 배포 후 `fact` 비율이 84% 에서 유의하게 내려가고 메모리 생존 시간이 늘어나는지를 `*.memory-journal.jsonl` 로 확인한다. 내려가지 않으면 이 RFC 는 틀린 것이고 되돌린다.
+
+## 관련
+
+- `fix/librarian-retention-asymmetry` — 재심 기준을 입장 기준에서 분리 (프롬프트 단독, 이 RFC 없이도 유효)
+- `#27275` — 같은 형태(문자열 하나로 뭉개진 분류)를 게이트 감사에서 typed variant 로 교체
+- CLAUDE.md 워크어라운드 거부 기준 §2 — 문자열 분류기 보강


### PR DESCRIPTION
## 증상

keeper 8개 중 **6개가 메모리 0건**입니다.

```
keeper           revision   facts    최고점
rondo                 703       0    rev=667 facts=32
analyst               909       0
code-reviewer        1598       0
kidsnote              388       0
lane-smith            137       0
taskmaster            534       0
full-cycle-probe      615       1
sangsu                999      14    최고령 70.6h   ← 유일한 예외
```

그리고 비워진 뒤로는 이런 커밋이 2분마다 올라갑니다.

```json
{"outcome":"committed","revision":700,
 "change":{"added":[],"removed":[],"retained":0},"dropped":[]}
```

## 정리 판단 자체는 옳았습니다

rondo 는 rev 668 한 커밋에서 32건을 버렸고, `.mli` 계약대로 32건 전부에 사유를 남겼습니다. 사유가 맞습니다.

```
"Task-205 is fully done and accepted, so this claim that it is 'todo and reclaimable' is false."
"Mid-progress status of task-205 is obsolete — the task is fully done and accepted."
"Meta-entry about which other memory entries are stale is itself stale and has no durable value."
```

task 하나가 끝나자 32건이 동시에 무효가 됐습니다. **버린 게 문제가 아니라, 담긴 것이 전부 순간 상태였던 것**입니다.

## 구조

프롬프트의 비대칭을 셌습니다.

```
버리라는 지시   11
담으라는 지시    6
"unsure → omit"  3회   (29·48·53행)
하한 규정        없음   "Keep only the smallest useful set… no target item count"
```

그리고 재심과 입장이 **같은 문장 형태**를 썼습니다.

```
Retain an existing ID only when its exact fact is still true, important, …
Add a claim         only when it remains true and useful on a later day.
```

선택은 전체 교체 방식이라 **저장된 모든 메모리가 매 실행(약 2분)마다 그 관문을 다시 통과**해야 합니다. 통과 확률이 1보다 작으면 반복 시행에서 0으로 수렴합니다.

`sangsu` 가 예외인 이유가 내용에 있습니다 — constraint 3 / lesson 5 / validated_approach 4 / fact 2. **"durable 한가"에 대한 답이 실행마다 흔들리지 않는 것들**입니다.

## 변경

재심을 **결함 기반**으로 바꿉니다. 이미 저장된 메모리는 입장 심사를 한 번 통과했으므로, 질문은 "다시 받을 만한가"가 아니라 "결함이 생겼는가"입니다.

```
Retention criteria — these are NOT the new-claim criteria. A memory that is
already stored has passed the admission bar once; you are not deciding whether
to admit it again. Retain it unless you can name what made it stop being true …
"I am not sure this is worth a slot" is not a reason; it is the absence of one.
```

드롭 조건을 열거로 좁혔습니다 — 대화가 반박함 / 나중 것이 대체함 / 다른 유지분과 중복 / 지나간 순간을 서술함.

**22행은 지우지 않았습니다.** 거기엔 정당한 목적이 섞여 있습니다 — 외부 규칙이 강제하지 않으면서 에이전트의 활동 범위를 좁히는 메모리를 버리라는 것. 그건 "받을 자격이 없다"가 아니라 **"저장돼 있는 동안 계속 해롭다"**라서 소급 적용이 맞습니다. 그 이유를 명시하고 남겼고, **다른 카테고리 기준은 소급 적용 대상이 아니라고 못 박았습니다.**

"unsure → omit" 3개는 **그대로 둡니다.** 셋 다 신규 추가 섹션에 있습니다. 입구는 엄격해야 맞습니다 — rondo 는 생애 104번 추가했으니 유입이 문제였던 적이 없습니다.

## RFC-0367 — 프롬프트로 못 고치는 나머지 절반

붕괴 직전 rondo 가 추가한 44건 중 **37건(84%)이 `fact`** 였습니다. 프롬프트가 이미 이렇게 적고 있습니다.

> `fact` is the **last resort, never the default**

산문으로 더 세게 부탁하는 건 같은 층위에서 같은 요청을 반복하는 것입니다. RFC-0367 은 `fact` 에만 `durability_basis` 를 요구해 **다른 일곱보다 비싸게** 만들자고 제안합니다. 저장은 하지 않고 입장 심사에만 씁니다.

이 저장소가 같은 결론에 여러 번 도달했습니다 — RFC-0042 가 문자열 분류기를 닫았고, 오늘 #27275 가 게이트 감사의 네 권한을 typed variant 로 바꿨습니다.

## 검증

프롬프트 변경은 컴파일 대상이 아니라 **배포 후 측정으로만 판정됩니다.**

| 지표 | 현재 | 기대 |
|---|---|---|
| memory 0건 keeper | 6 / 8 | 감소 |
| no-op 커밋 비율 | rondo 최근 35건 중 34건 | 감소 |
| `fact` 카테고리 비율 | 84% | RFC-0367 없이는 불변 |

`fact` 비율은 이 PR 로 안 바뀝니다. 그건 RFC-0367 의 몫이고, 그래서 둘을 나눴습니다.

되돌리기는 프롬프트 한 파일 revert 입니다.

RFC-0367 을 이 PR 에서 함께 제출합니다 (Draft).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
