### PR TITLE
test(dashboard): 턴 inspector 테스트 + 탭에 role 부여 (#27412 후속)

### DIFF
--- a/dashboard/src/components/keeper-turn-inspector-panel.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector-panel.test.ts
@@ -1,0 +1,170 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { html } from 'htm/preact'
+
+const api = vi.hoisted(() => ({
+  fetchKeeperRawTraces: vi.fn(),
+  fetchKeeperRawTrace: vi.fn(),
+  fetchKeeperLastPrompt: vi.fn(),
+  fetchKeeperOperatorNote: vi.fn(),
+  putKeeperOperatorNote: vi.fn(),
+}))
+
+vi.mock('../api/dashboard-keeper-prompt', () => api)
+
+import { KeeperTurnInspectorPanel } from './keeper-turn-inspector-panel'
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+const KEEPERS = ['analyst', 'code-reviewer']
+
+function noTurns() {
+  api.fetchKeeperRawTraces.mockResolvedValue([])
+}
+
+describe('KeeperTurnInspectorPanel', () => {
+  it('lists a keeper\'s turn files and opens the one that is clicked', async () => {
+    api.fetchKeeperRawTraces.mockResolvedValue([
+      { file: 'turn-0007.jsonl', bytes: 2048, records: 4, modifiedAt: 1786000000 },
+    ])
+    api.fetchKeeperRawTrace.mockResolvedValue({
+      file: 'turn-0007.jsonl',
+      totalRecords: 1,
+      offset: 0,
+      records: [{ ok: true, record: { kind: 'request', model: 'qwen3-6-35b' } }],
+    })
+
+    render(html`<${KeeperTurnInspectorPanel} keepers=${KEEPERS} />`)
+    fireEvent.click(await screen.findByText('turn-0007.jsonl'))
+
+    // The record body, not just the file name, is what makes this a viewer.
+    expect(await screen.findByText(/qwen3-6-35b/)).toBeTruthy()
+    expect(api.fetchKeeperRawTrace).toHaveBeenCalledWith(
+      'analyst',
+      'turn-0007.jsonl',
+      expect.objectContaining({ offset: 0 }),
+    )
+  })
+
+  // A damaged trace must not read as a shorter one: the record that failed to
+  // decode holds its position and says why, rather than being dropped.
+  it('keeps an undecodable record in place with its reason', async () => {
+    api.fetchKeeperRawTraces.mockResolvedValue([
+      { file: 'turn-0008.jsonl', bytes: 10, records: 2, modifiedAt: 1786000000 },
+    ])
+    api.fetchKeeperRawTrace.mockResolvedValue({
+      file: 'turn-0008.jsonl',
+      totalRecords: 2,
+      offset: 0,
+      records: [
+        { ok: true, record: { kind: 'request' } },
+        { ok: false, error: 'not valid JSON' },
+      ],
+    })
+
+    render(html`<${KeeperTurnInspectorPanel} keepers=${KEEPERS} />`)
+    fireEvent.click(await screen.findByText('turn-0008.jsonl'))
+
+    expect(await screen.findByText(/레코드 2 를 읽지 못했습니다: not valid JSON/)).toBeTruthy()
+    expect(screen.getByText(/"kind": "request"/)).toBeTruthy()
+  })
+
+  it('shows each prompt block with its own byte count', async () => {
+    noTurns()
+    api.fetchKeeperLastPrompt.mockResolvedValue({
+      keeper: 'analyst',
+      capturedAt: 1786000000,
+      traceId: 'trace-a',
+      absoluteTurn: 42,
+      blocks: [
+        { id: 'Persona', bytes: 1024, text: 'you are the analyst' },
+        { id: 'Operator_note', bytes: 32, text: 'check the cancel record first' },
+      ],
+      assembled: null,
+    })
+
+    render(html`<${KeeperTurnInspectorPanel} keepers=${KEEPERS} />`)
+    fireEvent.click(screen.getByRole('tab', { name: 'Next prompt' }))
+
+    expect(await screen.findByText('Operator_note')).toBeTruthy()
+    expect(screen.getByText('1.0 KB')).toBeTruthy()
+    // Text is behind a disclosure so a 200 KB block does not open by default.
+    expect(screen.queryByText(/check the cancel record first/)).toBeNull()
+    fireEvent.click(screen.getByText('Operator_note'))
+    expect(await screen.findByText(/check the cancel record first/)).toBeTruthy()
+  })
+
+  it('writes a note and shows what the server stored', async () => {
+    noTurns()
+    api.fetchKeeperOperatorNote.mockRejectedValue(new Error('no_note'))
+    api.putKeeperOperatorNote.mockResolvedValue({
+      keeper: 'analyst',
+      pending: true,
+      text: 'start from the cancel record',
+      createdBy: 'dashboard',
+      createdAt: 1786000000,
+      consumedTurn: null,
+    })
+
+    render(html`<${KeeperTurnInspectorPanel} keepers=${KEEPERS} />`)
+    fireEvent.click(screen.getByRole('tab', { name: 'Operator note' }))
+    // Absence of a note is the ordinary state, not an error.
+    expect(await screen.findByText('대기 중인 노트가 없습니다.')).toBeTruthy()
+
+    fireEvent.input(screen.getByRole('textbox'), {
+      target: { value: 'start from the cancel record' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '다음 턴에 싣기' }))
+
+    await waitFor(() =>
+      expect(api.putKeeperOperatorNote).toHaveBeenCalledWith(
+        'analyst',
+        'start from the cancel record',
+      ))
+    expect(await screen.findByText('다음 턴에 실림')).toBeTruthy()
+  })
+
+  // The store rejects an oversized note rather than truncating it, and its
+  // refusal carries the byte counts. Surfacing it verbatim is the difference
+  // between a rejection an operator can act on and one that looks like a bug.
+  it('surfaces the server\'s refusal verbatim', async () => {
+    noTurns()
+    api.fetchKeeperOperatorNote.mockRejectedValue(new Error('no_note'))
+    api.putKeeperOperatorNote.mockRejectedValue(
+      new Error('note is 5000 bytes; the limit is 4096'),
+    )
+
+    render(html`<${KeeperTurnInspectorPanel} keepers=${KEEPERS} />`)
+    fireEvent.click(screen.getByRole('tab', { name: 'Operator note' }))
+    fireEvent.input(screen.getByRole('textbox'), { target: { value: 'too long' } })
+    fireEvent.click(screen.getByRole('button', { name: '다음 턴에 싣기' }))
+
+    expect(await screen.findByText(/note is 5000 bytes; the limit is 4096/)).toBeTruthy()
+  })
+
+  it('addresses the keeper that is selected', async () => {
+    noTurns()
+    render(html`<${KeeperTurnInspectorPanel} keepers=${KEEPERS} />`)
+    await waitFor(() => expect(api.fetchKeeperRawTraces).toHaveBeenCalledWith(
+      'analyst', 50, expect.anything()))
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'code-reviewer' } })
+    await waitFor(() => expect(api.fetchKeeperRawTraces).toHaveBeenCalledWith(
+      'code-reviewer', 50, expect.anything()))
+  })
+
+  // The roster arrives after the first render, so a panel built before it must
+  // adopt the first keeper rather than staying empty.
+  it('adopts the roster when it arrives late', async () => {
+    noTurns()
+    const { rerender } = render(html`<${KeeperTurnInspectorPanel} keepers=${[]} />`)
+    expect(screen.getByText('관측된 keeper 가 없습니다.')).toBeTruthy()
+
+    rerender(html`<${KeeperTurnInspectorPanel} keepers=${['taskmaster']} />`)
+    await waitFor(() => expect(api.fetchKeeperRawTraces).toHaveBeenCalledWith(
+      'taskmaster', 50, expect.anything()))
+  })
+})

--- a/dashboard/src/components/keeper-turn-inspector-panel.ts
+++ b/dashboard/src/components/keeper-turn-inspector-panel.ts
@@ -373,13 +373,18 @@ export function KeeperTurnInspectorPanel({ keepers }: { keepers: readonly string
 
       <div class="flex flex-wrap gap-1" role="tablist" aria-label="Turn inspector views">
         ${TABS.map(item => html`
-          <${Btn}
+          <button
             key=${item.id}
+            type="button"
             role="tab"
             aria-selected=${tab === item.id}
-            class=${tab === item.id ? 'v2-monitoring-action is-active' : 'v2-monitoring-action'}
+            class=${`rounded px-2 py-1 text-xs border ${
+              tab === item.id
+                ? 'border-[var(--color-accent)] text-[var(--color-fg-primary)]'
+                : 'border-[var(--color-border-default)] text-[var(--color-fg-muted)]'
+            }`}
             onClick=${() => setTab(item.id)}
-          >${item.label}<//>
+          >${item.label}</button>
         `)}
       </div>
       <${Muted}>${active.hint}<//>


### PR DESCRIPTION
PR #27412 는 inspector 를 테스트 파일 없이 머지했다. `Test Coverage Check` 가 그걸 지적했고:

```
##[error] Added 338 lines to covered code paths but no test files changed.
          Add tests to cover new functionality.
```

**required check 가 아니라서 머지를 막지 못했다.** 게이트는 옳았고 구속력이 없었다. 이건 패널이 고치려던 결함과 같은 모양이다 — 초록인데 아무것도 실행하지 않는 상태.

## 케이스를 쓰다가 진짜 결함이 하나 나왔다

탭을 `Btn` 으로 만들었는데 이 컴포넌트는 `role` 과 `aria-selected` 를 전달하지 않는다. 그래서 탭이 **접근성 트리에 아예 올라가지 않았다**:

```
TestingLibraryElementError: Unable to find an accessible element
  with the role "tab" and name "Next prompt"
```

`internal-agents-monitor.ts` 의 필터 행과 같은 방식(평범한 `<button>`)으로 바꿨고, 이제 탭 리스트가 읽히는 role 과 선택 상태를 갖는다. 스크린리더로는 세 개의 이름 없는 버튼이었을 것이다.

## 7 케이스

조용히 틀릴 수 있는 성질만 골랐다.

| 케이스 | 왜 |
|---|---|
| 턴 파일을 누르면 그 파일의 레코드가 열리고 **본문이** 렌더 | 파일명만 나오는 것과 뷰어의 차이 |
| 디코드 실패 레코드가 제자리에 사유와 함께 남음 | 손상된 트레이스가 짧은 트레이스로 읽히면 안 된다 |
| 프롬프트 블록이 자기 바이트 수를 보이고 본문은 disclosure 뒤 | 200 KB 블록이 기본으로 펼쳐지면 안 된다 |
| 노트 왕복 후 저장된 내용 표시 | 쓰기가 실제로 반영되는가 |
| 서버의 거부를 **그대로** 표시 | 거부 메시지의 바이트 수가 운영자가 행동할 근거다 |
| 선택된 keeper 가 실제로 조회 대상 | 셀렉터가 장식이 아님 |
| 늦게 도착한 roster 를 채택 | roster 는 첫 렌더 뒤에 온다 |

## 검증

```
dashboard  Test Files 636 passed (636)   Tests 8812 passed (8812)
tsc --noEmit  rc=0, 오류 0
npm run lint  rc=0, 출력 0줄
```

새 케이스만 단독 실행: 7 passed. `Btn` 을 되돌리면 탭 3 케이스가 `role="tab"` 을 못 찾아 red 가 된다 — 이 커밋의 role 수정이 그 3 케이스로 증명된다.

RFC-WAIVED: 기존 컴포넌트에 테스트를 붙이고 접근성 속성을 고치는 변경. 서버 계약을 바꾸지 않는다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
