### PR TITLE
feat(task): let an assignee supersede a pending verification

### DIFF
--- a/config/prompts/keeper.md
+++ b/config/prompts/keeper.md
@@ -95,7 +95,7 @@ against live typed state before relying on them.
 
 Choose the smallest useful action that current evidence supports. A Task claim
 coordinates ownership; it grants no additional authority, and work awaiting
-verification is reviewed rather than reclaimed or resubmitted.
+verification is reviewed rather than reclaimed.
 
 Conversations are independent contexts. Preserve the exact conversation, server,
 channel, and speaker route, and read its current messages before relying on

--- a/lib/workspace/workspace_task_lifecycle.ml
+++ b/lib/workspace/workspace_task_lifecycle.ml
@@ -152,11 +152,31 @@ let decide
            ; verification_id = new_verification_id ()
            })
     else Error Invalid_transition
+  (* Resubmission supersedes the pending obligation instead of replacing the
+     task. Refusing it left [Cancel] as the assignee's only move out of
+     [AwaitingVerification], and the live backlog shows what that cost: 16
+     refusals of this exact transition, and 10 cancellations whose stated reason
+     was the deliverable itself.
+
+     A fresh [verification_id] is what makes it safe. A verdict computed against
+     the superseded request carries the old id and is refused by
+     {!decide_verdict} with [Verification_id_mismatch], so an in-flight judge
+     cannot land on evidence it never read. [started_at] is preserved: the work
+     began once, whatever the submission count. *)
   | ( Masc_domain.Submit_for_verification
-    , ( Masc_domain.Todo
-      | Masc_domain.AwaitingVerification _
-      | Masc_domain.Done _
-      | Masc_domain.Cancelled _ ) ) ->
+    , Masc_domain.AwaitingVerification { assignee; started_at; _ } ) ->
+    if same_agent assignee
+    then
+      ok
+        (Masc_domain.AwaitingVerification
+           { assignee
+           ; started_at
+           ; submitted_at = now
+           ; verification_id = new_verification_id ()
+           })
+    else Error Invalid_transition
+  | ( Masc_domain.Submit_for_verification
+    , (Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _) ) ->
     Error Invalid_transition
 ;;
 

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -21,6 +21,11 @@ type verification_submission =
   ; assignee : string
   ; verification_id : string
   ; evidence_refs : string list
+  ; (* Set when the submission superseded a pending one, so the record it
+       replaced can be removed after the commit. The task points only at the
+       new id; leaving the old file behind would show the dashboard a request
+       no task is waiting on. *)
+    superseded_verification_id : string option
   }
 
 (* Workspace-visible wording for a committed transition, or [None] when the
@@ -448,6 +453,16 @@ let transition_task_outcome_r
                  ; assignee
                  ; verification_id
                  ; evidence_refs = verification_submission_evidence_refs
+                 ; superseded_verification_id =
+                     (match task.task_status with
+                      | Masc_domain.AwaitingVerification
+                          { verification_id = superseded; _ } ->
+                        Some superseded
+                      | Masc_domain.Todo
+                      | Masc_domain.Claimed _
+                      | Masc_domain.InProgress _
+                      | Masc_domain.Done _
+                      | Masc_domain.Cancelled _ -> None)
                  }
            | ( ( Masc_domain.Claim
                | Masc_domain.Start
@@ -705,7 +720,29 @@ let transition_task_outcome_r
   in
   (match !committed_verification_submission with
    | None -> ()
-   | Some { task; assignee; verification_id; evidence_refs } ->
+   | Some { task; assignee; verification_id; evidence_refs; superseded_verification_id }
+     ->
+     (* Order matters: remove the superseded record before announcing the new
+        one, so no reader woken by the notification can see two open requests
+        for one task. A failed removal leaves a request no task points at --
+        visible in the dashboard, refused by [decide_verdict] on the id -- which
+        is why it degrades rather than failing the committed transition. *)
+     (match superseded_verification_id with
+      | None -> ()
+      | Some superseded ->
+        (match
+           (Atomic.get Workspace_hooks.verification_delete_request_fn) config
+             ~verification_id:superseded
+         with
+         | Ok () -> ()
+         | Error detail ->
+           Log.TaskState.error
+             "verification supersede delete degraded after commit task_id=%s \
+              superseded=%s replaced_by=%s detail=%s"
+             task_id
+             superseded
+             verification_id
+             detail));
      (try
         (Atomic.get Workspace_hooks.verification_notify_submit_fn)
           config

--- a/scripts/tla-check.sh
+++ b/scripts/tla-check.sh
@@ -164,6 +164,8 @@ run_tlc "$REPO_ROOT/specs/auth" "AuthIdentityFSM.tla"
 run_tlc_buggy "$REPO_ROOT/specs/auth" "AuthIdentityFSM.tla"
 run_tlc "$REPO_ROOT/specs/task-lifecycle" "TaskLifecycle.tla"
 run_tlc_buggy "$REPO_ROOT/specs/task-lifecycle" "TaskLifecycle.tla"
+run_tlc_buggy "$REPO_ROOT/specs/task-lifecycle" "TaskLifecycle.tla" \
+  "TaskLifecycle-supersede-buggy.cfg" "supersede-buggy"
 
 # Server lifecycle product invariants across lifecycle/lazy/readiness axes.
 run_tlc "$REPO_ROOT/specs/server-state" "ServerState.tla"

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-08-07T07:56:48Z (HEAD: 95f54b5f0a)
+Generated: 2026-08-07T12:22:26Z (HEAD: 45cd310611)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -17,8 +17,8 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | Manual specs | 41 |
 | TTrace (auto-generated) | 0 |
 | Directories | 12 |
-| Total .cfg files | 85 |
-| Buggy .cfg (bug-model pair) | 44 |
+| Total .cfg files | 86 |
+| Buggy .cfg (bug-model pair) | 45 |
 
 `kind` column: **manual** = hand-authored spec; **ttrace** = TLC counterexample export (`*TTrace*` or trace marker in header). `cfg`/`buggy` columns count companion `.cfg` files. `invariants/properties` lists names per cfg label (`clean=...`, `buggy=...`). `source hash` is the tracked `.tla` blob fingerprint.
 
@@ -123,7 +123,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 
 | File | Module | Kind | cfg | buggy | Invariants / Properties | Source Hash |
 |------|--------|------|-----|-------|-------------------------|---------------|
-| TaskLifecycle.tla | TaskLifecycle | manual | 2 | 1 | clean={inv:Safety} buggy={inv:Safety} | aba3b16dcfe3 |
+| TaskLifecycle.tla | TaskLifecycle | manual | 3 | 2 | clean={inv:Safety} buggy={inv:Safety} supersede-buggy={inv:Safety} | c32f68c8697f |
 
 ## Notes
 

--- a/specs/task-lifecycle/TaskLifecycle-buggy.cfg
+++ b/specs/task-lifecycle/TaskLifecycle-buggy.cfg
@@ -1,8 +1,12 @@
-\* Either bypass must violate Safety:
+\* Any bypass must violate Safety:
 \* - InProgress -> Done without configured-LLM verification
 \* - Todo -> InProgress without an objective Claim transition
+\* - Done reached by a verdict read against a superseded submission
 
 SPECIFICATION SpecBuggy
+
+CONSTANTS
+    MaxSubmissions = 3
 
 INVARIANTS
     Safety

--- a/specs/task-lifecycle/TaskLifecycle-supersede-buggy.cfg
+++ b/specs/task-lifecycle/TaskLifecycle-supersede-buggy.cfg
@@ -1,0 +1,14 @@
+\* Only the resubmission bypass is enabled here: Done reached by a verdict that
+\* was read against a submission the Task no longer carries. It must violate
+\* Safety on its own, without the two unrelated bypasses in the bundled model.
+
+SPECIFICATION SpecBuggySuperseded
+
+CONSTANTS
+    MaxSubmissions = 3
+
+INVARIANTS
+    Safety
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/task-lifecycle/TaskLifecycle.cfg
+++ b/specs/task-lifecycle/TaskLifecycle.cfg
@@ -1,5 +1,8 @@
 SPECIFICATION SpecClean
 
+CONSTANTS
+    MaxSubmissions = 3
+
 INVARIANTS
     Safety
 

--- a/specs/task-lifecycle/TaskLifecycle.tla
+++ b/specs/task-lifecycle/TaskLifecycle.tla
@@ -8,12 +8,25 @@
 \*
 \* The Claimed step remains an objective state invariant: work cannot enter
 \* InProgress without first acquiring the Task.
+\*
+\* An assignee may submit again while awaiting a verdict. The submission that
+\* replaces a pending one carries a new identity, which is what keeps the
+\* boundary intact: a judge reads its request once and can return long after
+\* the evidence was replaced, so a verdict lands only when the identity it was
+\* computed against is still the one the Task carries. [submission] models that
+\* identity as a counter; [verdict_for] records which submission a returned
+\* verdict read.
 
 EXTENDS Integers
 
-VARIABLES state, configured_llm_verdict, ever_claimed
+\* Bounds the model. The property under check does not depend on how many
+\* resubmissions are allowed, only on at least two existing.
+CONSTANT MaxSubmissions
 
-vars == <<state, configured_llm_verdict, ever_claimed>>
+VARIABLES state, configured_llm_verdict, verdict_for, submission, ever_claimed
+
+vars ==
+    <<state, configured_llm_verdict, verdict_for, submission, ever_claimed>>
 
 States ==
     {"Todo", "Claimed", "InProgress", "AwaitingVerification", "Done", "Cancelled"}
@@ -22,53 +35,87 @@ Verdicts == {"none", "pass", "fail"}
 TypeOK ==
     /\ state \in States
     /\ configured_llm_verdict \in Verdicts
+    /\ verdict_for \in 0..MaxSubmissions
+    /\ submission \in 0..MaxSubmissions
     /\ ever_claimed \in BOOLEAN
 
 Init ==
     /\ state = "Todo"
     /\ configured_llm_verdict = "none"
+    /\ verdict_for = 0
+    /\ submission = 0
     /\ ever_claimed = FALSE
 
 Claim ==
     /\ state = "Todo"
     /\ state' = "Claimed"
     /\ ever_claimed' = TRUE
-    /\ UNCHANGED configured_llm_verdict
+    /\ UNCHANGED <<configured_llm_verdict, verdict_for, submission>>
 
 Start ==
     /\ state = "Claimed"
     /\ state' = "InProgress"
-    /\ UNCHANGED <<configured_llm_verdict, ever_claimed>>
+    /\ UNCHANGED <<configured_llm_verdict, verdict_for, submission, ever_claimed>>
 
 SubmitForConfiguredLlmVerification ==
     /\ state = "InProgress"
+    /\ submission < MaxSubmissions
     /\ state' = "AwaitingVerification"
+    /\ submission' = submission + 1
     /\ configured_llm_verdict' = "none"
+    /\ verdict_for' = 0
     /\ UNCHANGED ever_claimed
 
-RecordConfiguredLlmPass ==
+\* Supersedes the pending obligation rather than abandoning the Task. Without
+\* it, Cancel is the assignee's only exit from AwaitingVerification, which
+\* discards the evidence along with the Task.
+ResubmitForConfiguredLlmVerification ==
     /\ state = "AwaitingVerification"
-    /\ configured_llm_verdict = "none"
-    /\ configured_llm_verdict' = "pass"
-    /\ UNCHANGED <<state, ever_claimed>>
+    /\ submission < MaxSubmissions
+    /\ state' = "AwaitingVerification"
+    /\ submission' = submission + 1
+    /\ configured_llm_verdict' = "none"
+    /\ verdict_for' = 0
+    /\ UNCHANGED ever_claimed
 
-RecordConfiguredLlmFail ==
+\* A judge woken for any submission may return, including one whose evidence
+\* has since been superseded. Returning is not landing: see Apply* below.
+ConfiguredLlmReturnsVerdict ==
     /\ state = "AwaitingVerification"
     /\ configured_llm_verdict = "none"
+    /\ \E s \in 1..submission, v \in {"pass", "fail"} :
+         /\ configured_llm_verdict' = v
+         /\ verdict_for' = s
+    /\ UNCHANGED <<state, submission, ever_claimed>>
+
+\* The identity gate. A verdict computed against a superseded submission is
+\* refused here, mirroring [Verification_id_mismatch].
+DiscardSupersededVerdict ==
+    /\ state = "AwaitingVerification"
+    /\ configured_llm_verdict # "none"
+    /\ verdict_for # submission
+    /\ configured_llm_verdict' = "none"
+    /\ verdict_for' = 0
+    /\ UNCHANGED <<state, submission, ever_claimed>>
+
+ApplyConfiguredLlmFail ==
+    /\ state = "AwaitingVerification"
+    /\ configured_llm_verdict = "fail"
+    /\ verdict_for = submission
     /\ state' = "InProgress"
-    /\ configured_llm_verdict' = "fail"
-    /\ UNCHANGED ever_claimed
+    /\ UNCHANGED <<configured_llm_verdict, verdict_for, submission, ever_claimed>>
 
 Complete ==
     /\ state = "AwaitingVerification"
     /\ configured_llm_verdict = "pass"
+    /\ verdict_for = submission
     /\ state' = "Done"
-    /\ UNCHANGED <<configured_llm_verdict, ever_claimed>>
+    /\ UNCHANGED <<configured_llm_verdict, verdict_for, submission, ever_claimed>>
 
 Cancel ==
     /\ state \in {"Todo", "Claimed", "InProgress", "AwaitingVerification"}
     /\ state' = "Cancelled"
-    /\ UNCHANGED <<configured_llm_verdict, ever_claimed>>
+    /\ UNCHANGED <<configured_llm_verdict, verdict_for, submission, ever_claimed>>
 
 Terminal ==
     /\ state \in {"Done", "Cancelled"}
@@ -78,8 +125,10 @@ NextClean ==
     \/ Claim
     \/ Start
     \/ SubmitForConfiguredLlmVerification
-    \/ RecordConfiguredLlmPass
-    \/ RecordConfiguredLlmFail
+    \/ ResubmitForConfiguredLlmVerification
+    \/ ConfiguredLlmReturnsVerdict
+    \/ DiscardSupersededVerdict
+    \/ ApplyConfiguredLlmFail
     \/ Complete
     \/ Cancel
     \/ Terminal
@@ -87,23 +136,41 @@ NextClean ==
 BugSkipConfiguredLlmVerification ==
     /\ state = "InProgress"
     /\ state' = "Done"
-    /\ UNCHANGED <<configured_llm_verdict, ever_claimed>>
+    /\ UNCHANGED <<configured_llm_verdict, verdict_for, submission, ever_claimed>>
 
 BugSkipClaim ==
     /\ state = "Todo"
     /\ state' = "InProgress"
-    /\ UNCHANGED <<configured_llm_verdict, ever_claimed>>
+    /\ UNCHANGED <<configured_llm_verdict, verdict_for, submission, ever_claimed>>
+
+\* The failure resubmission would introduce if the new submission reused the
+\* pending identity: a verdict read against replaced evidence completes the Task.
+BugSupersededVerdictCompletes ==
+    /\ state = "AwaitingVerification"
+    /\ configured_llm_verdict = "pass"
+    /\ verdict_for # submission
+    /\ state' = "Done"
+    /\ UNCHANGED <<configured_llm_verdict, verdict_for, submission, ever_claimed>>
 
 NextBuggy ==
     \/ NextClean
     \/ BugSkipConfiguredLlmVerification
     \/ BugSkipClaim
+    \/ BugSupersededVerdictCompletes
 
 SpecClean == Init /\ [][NextClean]_vars
 SpecBuggy == Init /\ [][NextBuggy]_vars
 
+\* Isolates the resubmission bug. Bundled with the other two, TLC reports
+\* whichever counterexample is shortest -- [BugSkipClaim] at depth 2 -- and the
+\* identity clause of [DoneRequiresConfiguredLlmVerification] would go
+\* unexercised. Checked separately so it has to do the work on its own.
+SpecBuggySuperseded == Init /\ [][NextClean \/ BugSupersededVerdictCompletes]_vars
+
 DoneRequiresConfiguredLlmVerification ==
-    state = "Done" => configured_llm_verdict = "pass"
+    state = "Done" =>
+        /\ configured_llm_verdict = "pass"
+        /\ verdict_for = submission
 
 InProgressRequiresClaim ==
     state \in {"InProgress", "AwaitingVerification", "Done"} => ever_claimed

--- a/test/fixtures/keeper_system_prompt/assembled_prompt.golden
+++ b/test/fixtures/keeper_system_prompt/assembled_prompt.golden
@@ -91,7 +91,7 @@ against live typed state before relying on them.
 
 Choose the smallest useful action that current evidence supports. A Task claim
 coordinates ownership; it grants no additional authority, and work awaiting
-verification is reviewed rather than reclaimed or resubmitted.
+verification is reviewed rather than reclaimed.
 
 Conversations are independent contexts. Preserve the exact conversation, server,
 channel, and speaker route, and read its current messages before relying on

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1665,6 +1665,169 @@ let () = test "operator verdict path replaces verifier agent actions" (fun () ->
     | Masc_domain.Done _ -> ()
     | _ -> failwith "expected verifier approval to complete task"))
 
+(* Refusing this transition left [Cancel] as the assignee's only move out of
+   [AwaitingVerification]: the live backlog carried 16 refusals of
+   "awaiting_verification -> submit_for_verification" and 10 cancellations whose
+   stated reason was the deliverable. These four cases pin what makes the
+   supersede safe rather than merely permitted. *)
+
+let awaiting_snapshot ctx task_id =
+  match
+    Workspace.get_tasks_raw ctx.Task.Tool.config
+    |> List.find_opt (fun (task : Masc_domain.task) -> String.equal task.id task_id)
+  with
+  | Some
+      { task_status =
+          Masc_domain.AwaitingVerification { verification_id; started_at; assignee; _ }
+      ; _
+      } -> verification_id, started_at, assignee
+  | Some _ -> failwith (Printf.sprintf "task %s is not awaiting verification" task_id)
+  | None -> failwith (Printf.sprintf "task %s not found" task_id)
+
+let submit_for_verification ctx ~task_id ~notes =
+  Task.Tool.handle_transition
+    ~tool_name:"test_tool"
+    ~start_time:0.0
+    ctx
+    (`Assoc
+      [ "task_id", `String task_id
+      ; "action", `String "submit_for_verification"
+      ; "notes", `String notes
+      ])
+
+let resubmit_fixture () =
+  let ctx = make_test_ctx_with_agent "worker" in
+  let _ =
+    Task.Tool.handle_add_task
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      ctx
+      (`Assoc [ "title", `String "Resubmittable deliverable" ])
+  in
+  let _ = Workspace.claim_task ctx.Task.Tool.config ~agent_name:"worker" ~task_id:"task-001" in
+  let first =
+    submit_for_verification
+      ctx
+      ~task_id:"task-001"
+      ~notes:
+        "completion_notes: first pass. reviewable_evidence_ref: \
+         artifact:first-pass.json ready for review"
+  in
+  if not (Tool_result.is_success first) then failwith (Tool_result.message first);
+  ctx
+
+let () =
+  test "resubmit supersedes the pending verification instead of discarding it" (fun () ->
+    let ctx = resubmit_fixture () in
+    let base_path = ctx.Task.Tool.config.Workspace.base_path in
+    let first_id, first_started_at, _ = awaiting_snapshot ctx "task-001" in
+    (match Verification.load_request base_path first_id with
+     | Ok _ -> ()
+     | Error detail -> failwith ("first request should exist: " ^ detail));
+    let second =
+      submit_for_verification
+        ctx
+        ~task_id:"task-001"
+        ~notes:
+          "completion_notes: second pass adds the missing benchmark. \
+           reviewable_evidence_ref: artifact:second-pass.json ready for review"
+    in
+    if not (Tool_result.is_success second) then failwith (Tool_result.message second);
+    let second_id, second_started_at, _ = awaiting_snapshot ctx "task-001" in
+    (* A fresh id is what makes the supersede safe -- see the mismatch case
+       below -- so equality here would defeat the whole design. *)
+    assert (not (String.equal first_id second_id));
+    (* The work began once, whatever the submission count. *)
+    assert (String.equal first_started_at second_started_at);
+    (match Verification.load_request base_path second_id with
+     | Ok _ -> ()
+     | Error detail -> failwith ("second request should exist: " ^ detail));
+    match Verification.load_request base_path first_id with
+    | Error _ -> ()
+    | Ok _ ->
+      failwith "superseded request should not survive: the task points only at the new id")
+
+let () =
+  test "a verdict on the superseded verification is refused" (fun () ->
+    let ctx = resubmit_fixture () in
+    let first_id, _, _ = awaiting_snapshot ctx "task-001" in
+    let second =
+      submit_for_verification
+        ctx
+        ~task_id:"task-001"
+        ~notes:
+          "completion_notes: second pass. reviewable_evidence_ref: \
+           artifact:second-pass.json ready for review"
+    in
+    if not (Tool_result.is_success second) then failwith (Tool_result.message second);
+    (* An in-flight judge reads its request once at the start, so it can return
+       a verdict for evidence the task no longer carries. The id is what stops
+       it landing. *)
+    let stale =
+      Workspace.commit_verdict_r
+        ctx.Task.Tool.config
+        ~authority:(Masc_domain.Human_operator { operator_id = "operator-test" })
+        ~verdict:Masc_domain.Verdict_approved
+        ~task_id:"task-001"
+        ~verification_id:first_id
+        ~notes:"approved against the superseded evidence"
+        ()
+    in
+    (match stale with
+     | Error _ -> ()
+     | Ok _ -> failwith "a verdict carrying the superseded id must not complete the task");
+    match (only_task ctx).Masc_domain.task_status with
+    | Masc_domain.AwaitingVerification _ -> ()
+    | _ -> failwith "task should still be awaiting its current verification")
+
+let () =
+  test "a verdict on the current verification still completes the task" (fun () ->
+    let ctx = resubmit_fixture () in
+    let second =
+      submit_for_verification
+        ctx
+        ~task_id:"task-001"
+        ~notes:
+          "completion_notes: second pass. reviewable_evidence_ref: \
+           artifact:second-pass.json ready for review"
+    in
+    if not (Tool_result.is_success second) then failwith (Tool_result.message second);
+    let second_id, _, _ = awaiting_snapshot ctx "task-001" in
+    let approved =
+      Workspace.commit_verdict_r
+        ctx.Task.Tool.config
+        ~authority:(Masc_domain.Human_operator { operator_id = "operator-test" })
+        ~verdict:Masc_domain.Verdict_approved
+        ~task_id:"task-001"
+        ~verification_id:second_id
+        ~notes:"approved against the resubmitted evidence"
+        ()
+    in
+    (match approved with
+     | Ok _ -> ()
+     | Error error -> failwith (Masc_domain.masc_error_to_string error));
+    match (only_task ctx).Masc_domain.task_status with
+    | Masc_domain.Done _ -> ()
+    | _ -> failwith "expected the resubmitted verification to complete the task")
+
+let () =
+  test "only the assignee may supersede a pending verification" (fun () ->
+    let ctx = resubmit_fixture () in
+    let other_ctx = { ctx with Task.Tool.agent_name = "bystander" } in
+    let first_id, _, _ = awaiting_snapshot ctx "task-001" in
+    let result =
+      submit_for_verification
+        other_ctx
+        ~task_id:"task-001"
+        ~notes:
+          "completion_notes: not my task. reviewable_evidence_ref: \
+           artifact:bystander.json ready for review"
+    in
+    assert (not (Tool_result.is_success result));
+    let unchanged_id, _, assignee = awaiting_snapshot ctx "task-001" in
+    assert (String.equal first_id unchanged_id);
+    assert (String.equal assignee "worker"))
+
 let () =
   test "operator-approved verification leaves Goal action to durable reconciler"
     (fun () ->

--- a/test/test_tool_workspace_coverage.ml
+++ b/test/test_tool_workspace_coverage.ml
@@ -1000,7 +1000,7 @@ let () =
 ;;
 
 let () =
-  test "next_hint_awaiting_verification has no agent action" (fun () ->
+  test "next_hint_awaiting_verification offers supersede alongside cancel" (fun () ->
     let h =
       next_hint
         (Masc_domain.AwaitingVerification
@@ -1010,7 +1010,11 @@ let () =
            ; verification_id = "v"
            })
     in
-    assert (String.equal h ""))
+    (* This hint is where an assignee learns the state has an exit other than
+       Cancel: the live log carried 16 refused resubmissions while the hint
+       read "[cancel]". *)
+    assert (str_contains h "submit_for_verification");
+    assert (str_contains h "cancel"))
 ;;
 
 let () =


### PR DESCRIPTION
## What

An assignee awaiting a verdict could not submit again. Every other move out of
`AwaitingVerification` was refused too, so the only exit was `Cancel` — which
takes the evidence down with the Task.

The live backlog shows both halves of that:

```
keeper_task_done failures
  16x  Invalid transition: awaiting_verification -> submit_for_verification

cancellations with a verification record already written   10 of 56
  task-031  "6 barrel lodash imports converted to tree-shakeable path imports, tsc ..."
  task-129  "Removed dead ___unused-stamp-handler___ (175 lines) from handlers.ts."
```

The hint the FSM handed back said what was left: `valid_next_actions=[cancel]`.

**These two measurements are not joined by task_id.** 16 refusals and 10
evidence-carrying cancellations are each real; that the same Tasks appear in
both is the reading this PR acts on, not a fact it proves.

## Why a fresh id is the whole design

A rejected verdict already returns the Task to `InProgress`, where submitting
works. The gap is only for an assignee who sees the problem *before* any
verdict — which is the case the 16 refusals are in.

Allowing it needs one thing to be true: an in-flight judge must not land on
evidence it never read. It reads its request once
(`completion_authority_agent.ml:266` takes `evidence_refs` from
`request.output`), so it can return long after the evidence was replaced.

`Verification_id_mismatch` already existed for exactly this, and
`decide_verdict` checks the id **before** branching on the verdict — so a stale
pass and a stale fail are both refused. Minting a new `verification_id` on
resubmission is what makes that check fire. Reusing the pending id would not:
`save_request` goes through `save_file_atomic`, so it would overwrite in place
and a verdict read against the old evidence would land on the new.

The superseded record is deleted after the commit. RFC-0221 §3.3 names the
alternative — a record no Task points at — as the drift that RFC removed, and
says resubmission "produces a fresh, real obligation" through the normal flow.
That is this path.

`started_at` is preserved. The work began once, whatever the submission count.

## What this does not change

- **Another agent still cannot claim it.** `Claim_block_pending_verdict` is
  untouched; only the assignee may supersede, and a test pins that.
- **No new gate.** The FSM stays pure — it consults nothing to decide. The
  identity check that makes this safe was already there.
- **`Release` from `AwaitingVerification` is still refused.** Widening one arm
  is not an argument for widening its neighbours.

## Prompt

`keeper.md` asserted the constraint this removes:

```diff
-verification is reviewed rather than reclaimed or resubmitted.
+verification is reviewed rather than reclaimed.
```

Only the false word goes; the true half — not reclaimable by others — stays.
Nothing replaces it: `valid_next_actions` now reads
`[cancel;submit_for_verification]` and teaches this at the point of need, which
is where the old prose was contradicted. Assembled prompt 9203 → 9188 B, and the
golden diff is that one line.

## TLA+

`TaskLifecycle.tla` said the only exits from `AwaitingVerification` were
pass, fail and cancel. Left alone it would have drifted silently. It now carries
`submission` and `verdict_for`, and `Complete` requires them equal.

The bundled buggy model does **not** prove the new clause: TLC reports the
shortest counterexample, `BugSkipClaim` at depth 2, and the identity clause goes
unexercised. So the bug is isolated in its own cfg, following the three-cfg
split `KeeperHitlDeferred` already uses:

```
TaskLifecycle.tla                    Model checking completed. No error has been found.
TaskLifecycle.tla (buggy)            State 2: <BugSkipClaim>                    exit 12
TaskLifecycle.tla (supersede-buggy)  State 7: <BugSupersededVerdictCompletes>   exit 12
```

## Tests

Four cases in `test_tool_task_coverage`, which CI runs:

| case | asserts |
|---|---|
| resubmit supersedes the pending verification | new id ≠ old, `started_at` preserved, new record exists, old record gone |
| a verdict on the superseded verification is refused | verdict carrying the old id does not complete the Task |
| a verdict on the current verification still completes | the widening did not break the normal path |
| only the assignee may supersede | a bystander is refused, id unchanged |

Verified not identities: with the tests in place and
`workspace_task_lifecycle.ml` reverted to `origin/main`,

```
3 failures! in 96 tests run
[failure] Invalid task state: Invalid transition: awaiting_verification ->
          submit_for_verification (task-001, agent=worker,
          valid_next_actions=[cancel]).
```

— the live log's message, reproduced by the harness, including the claim that
Cancel was the only exit.

**The fourth passes both ways, and vacuously so on main**, where every
resubmission is refused. It guards the widening from going further, which is
only meaningful on this branch.

## Pre-existing red, not touched

`test_tool_workspace_coverage` fails 5 → 4 here. One of the five,
`next_hint_awaiting_verification`, asserted `""` where this branch produces
`[cancel;submit_for_verification]`, so it is updated. The other four were
already failing on `origin/main`, verified by reverting both lib files and
re-running: three assert `next_hint` is empty for states whose no-op
self-transitions make it non-empty, and one raises `MASC not initialized`. The
suite is not in `ci.yml`. Filed separately rather than fixed here — freezing
`next_hint`'s current output for terminal states would bless behaviour this PR
has not analysed.

## Verification

```
dune build --root . @check                                        exit 0
dune build --root . @fmt            no diff in any file this PR touches
scripts/tla-check.sh                              All TLA+ checks passed
scripts/ocaml-structure-ratchet.sh                                    OK
scripts/stringly-boundary-ratchet.sh                                  OK
scripts/audit-sublib-cycle.py                     OK - 34 leaf libraries clean

test_tool_task_coverage                        96 tests run   Successful
test_verification                              42 tests run   Successful
test_verification_authority_tools              34 tests run   Successful
test_task_status_vocabulary                     4 tests run   Successful
test_keeper_system_prompt_bytes                 2 tests run   Successful
test_prompt_asset_sync                         13 tests run   Successful
test_tool_contract_truth                       16 tests run   Successful
test_keeper_surface_presence_prompt              3 tests run  Successful
test_workspace_task_lifecycle                        all tests passed
test_keeper_unified_verification_surface        2 tests run   Successful
test_mcp_session_task_lifecycle                 7 tests run   Successful
```

RFC-0221 §3.3 governs this path and is satisfied: the resubmission produces a
fresh obligation, and the record it replaces is removed rather than left inert.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
