### PR TITLE
feat(goal): restating a Goal's current phase is satisfied, not a conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -982,6 +982,15 @@ jobs:
           opam exec -- dune build --root . \
             @test/runtest-test_goal_scope_terminal_phase
 
+      - name: Run goal phase suite
+        # decide_transition is a 5x7 matrix that had no behavioural test. Its
+        # exhaustive match proves every pair has an arm, not that the arm gives
+        # the right answer -- so a matrix edit could change what the Goal FSM
+        # admits without anything going red. The suite states all 35 pairs.
+        run: |
+          opam exec -- dune build --root . \
+            @test/runtest-test_goal_phase_all
+
       - name: Run metric zero-cell declaration suite
         # A counter emitted as a bare string still compiles and still counts;
         # what it loses is the 0-cell, and only a running store shows that.

--- a/lib/dashboard/dashboard_goals_types_health.ml
+++ b/lib/dashboard/dashboard_goals_types_health.ml
@@ -50,7 +50,13 @@ let goal_fsm_next_actions ~goal_phase =
          match
            Goal_phase.decide_transition ~phase:goal_phase ~action
          with
-         | Ok _ -> true
+         (* Next actions are the ones that move the goal. [Already] is accepted
+            by the tool but changes nothing, and listing "pause" under a paused
+            goal reads as a step that is still to come. Written as an explicit
+            arm because [Ok _] would have absorbed the new outcome and widened
+            this list without a compiler error. *)
+         | Ok (Goal_phase.Move_to _) -> true
+         | Ok (Goal_phase.Already _) -> false
          | Error _ -> false)
   |> List.map Goal_phase.action_to_string
 

--- a/lib/goal/goal_phase.ml
+++ b/lib/goal/goal_phase.ml
@@ -99,9 +99,6 @@ type outcome =
   | Move_to of t
   | Already of t
 
-let outcome_phase = function
-  | Move_to phase | Already phase -> phase
-;;
 
 (* Every (phase, action) pair is stated. The catch-all this replaces absorbed
    22 of the 35 pairs, so adding a phase or an action compiled cleanly and the

--- a/lib/goal/goal_phase.ml
+++ b/lib/goal/goal_phase.ml
@@ -95,11 +95,34 @@ let parse_action s =
   String.trim s |> String.lowercase_ascii |> action_of_string
 
 
+type outcome =
+  | Move_to of t
+  | Already of t
+
+let outcome_phase = function
+  | Move_to phase | Already phase -> phase
+;;
+
 (* Every (phase, action) pair is stated. The catch-all this replaces absorbed
    22 of the 35 pairs, so adding a phase or an action compiled cleanly and the
    new combinations silently became "invalid" — the same FSM sparse-match class
    that produced a runtime Assert_failure in keeper_registry. The compiler now
    refuses a matrix with a hole in it. *)
+(* The diagonal -- an action whose target phase the goal already occupies --
+   answers [Already]. It used to answer "invalid goal transition", which is the
+   opposite of what the Task FSM says for the same shape: there, Cancel on a
+   Cancelled task and Done_action on a Done task both return the status
+   unchanged. Two domains a Keeper reaches for in one breath disagreed about
+   whether asking for a state you are in is an error.
+
+   The live log shows what that cost. A reconciliation event fired four times
+   for one already-completed Goal, and the Keeper's own notes on the refused
+   calls read "Goal already completed at 08:57:35Z. This is a duplicate
+   reconciliation event" and "Already completed at 09:00:32Z. Stale racing
+   event." It knew, it reported accurately, and it was refused.
+
+   [Already] is not [Move_to]: the caller must not write or emit a phase event
+   for it, or a repeated report would produce repeated history. *)
 let decide_transition ~phase ~(action : action) =
   let invalid =
     Error
@@ -107,25 +130,32 @@ let decide_transition ~phase ~(action : action) =
          (to_string phase) (action_to_string action))
   in
   match phase, action with
-  (* Executing: the only phase that can request completion. *)
-  | Executing, Request_complete -> Ok Completed
-  | Executing, Pause -> Ok (Paused)
-  | Executing, Block -> Ok (Blocked)
-  | Executing, Drop -> Ok (Dropped)
-  | Executing, (Resume | Unblock | Reopen) -> invalid
+  (* Executing: the only phase that can request completion. Resume, Unblock and
+     Reopen all target Executing, which is where the goal already is. *)
+  | Executing, Request_complete -> Ok (Move_to Completed)
+  | Executing, Pause -> Ok (Move_to Paused)
+  | Executing, Block -> Ok (Move_to Blocked)
+  | Executing, Drop -> Ok (Move_to Dropped)
+  | Executing, (Resume | Unblock | Reopen) -> Ok (Already Executing)
   (* Paused: resumes or drops; it is not blocked and not finished. *)
-  | Paused, Resume -> Ok (Executing)
-  | Paused, Drop -> Ok (Dropped)
-  | Paused, (Request_complete | Pause | Block | Unblock | Reopen) -> invalid
+  | Paused, Resume -> Ok (Move_to Executing)
+  | Paused, Drop -> Ok (Move_to Dropped)
+  | Paused, Pause -> Ok (Already Paused)
+  | Paused, (Request_complete | Block | Unblock | Reopen) -> invalid
   (* Blocked: unblocks or drops. Completing while blocked would skip the
      impediment rather than resolve it. *)
-  | Blocked, Unblock -> Ok (Executing)
-  | Blocked, Drop -> Ok (Dropped)
-  | Blocked, (Request_complete | Pause | Resume | Block | Reopen) -> invalid
-  (* Completed and Dropped are terminal: only reopening leaves them. *)
-  | Completed, Reopen -> Ok (Executing)
-  | Completed, Drop -> Ok (Dropped)
-  | Completed, (Request_complete | Pause | Resume | Block | Unblock) -> invalid
-  | Dropped, Reopen -> Ok (Executing)
-  | Dropped, (Request_complete | Pause | Resume | Block | Unblock | Drop) ->
-    invalid
+  | Blocked, Unblock -> Ok (Move_to Executing)
+  | Blocked, Drop -> Ok (Move_to Dropped)
+  | Blocked, Block -> Ok (Already Blocked)
+  | Blocked, (Request_complete | Pause | Resume | Reopen) -> invalid
+  (* Completed and Dropped are terminal: only reopening leaves them.
+     [Dropped, Request_complete] stays invalid -- completion is not the phase a
+     dropped goal is in, so it is a real request for a state change, not a
+     restatement. Reopen first. *)
+  | Completed, Reopen -> Ok (Move_to Executing)
+  | Completed, Drop -> Ok (Move_to Dropped)
+  | Completed, Request_complete -> Ok (Already Completed)
+  | Completed, (Pause | Resume | Block | Unblock) -> invalid
+  | Dropped, Reopen -> Ok (Move_to Executing)
+  | Dropped, Drop -> Ok (Already Dropped)
+  | Dropped, (Request_complete | Pause | Resume | Block | Unblock) -> invalid

--- a/lib/goal/goal_phase.mli
+++ b/lib/goal/goal_phase.mli
@@ -62,10 +62,6 @@ type outcome =
   | Move_to of t
   | Already of t
 
-val outcome_phase : outcome -> t
-(** The phase the goal is in once the outcome is applied — the destination for
-    [Move_to], the unchanged current phase for [Already]. *)
-
 val decide_transition :
   phase:t ->
   action:action ->

--- a/lib/goal/goal_phase.mli
+++ b/lib/goal/goal_phase.mli
@@ -51,20 +51,30 @@ val all_actions : action list
 (** Every action in declaration order. SSOT for the schema/validator action
     enum via [List.map action_to_string all_actions]. *)
 
-(** Outcome of {!decide_transition}. [Move_to] is a direct phase change and
-    [Complete] is the terminal success transition. *)
+(** What a transition request resolves to.
+
+    [Move_to] is a phase change: the caller writes the new phase and records
+    the event. [Already] is the same request made against a goal that is
+    already in the phase the action targets — satisfied, with nothing to write.
+    A caller that treats the two alike turns a repeated report into repeated
+    history. *)
+type outcome =
+  | Move_to of t
+  | Already of t
+
+val outcome_phase : outcome -> t
+(** The phase the goal is in once the outcome is applied — the destination for
+    [Move_to], the unchanged current phase for [Already]. *)
 
 val decide_transition :
   phase:t ->
   action:action ->
-  (t, string) result
-(** Pure transition decider: the phase the goal moves to, or [Error msg] for
-    an invalid pair.
+  (outcome, string) result
+(** Pure transition decider: what the request resolves to, or [Error msg] for a
+    pair that names no reachable phase.
 
-    This returned a [transition_outcome] whose [Complete] arm was the
-    else-branch of a verifier-policy check — one of four outcomes alongside
-    [Open_verification] and [Open_approval], removed with the goal quorum
-    engine in #24332. With those gone [Complete] and [Move_to Completed] named
-    the same thing, and both consumers immediately collapsed one into the
-    other while the doc still called [Complete] a distinct terminal
-    transition. A phase is now just a phase. *)
+    The diagonal — an action whose target phase the goal already occupies —
+    answers [Already] rather than an error, which is what the Task FSM already
+    says for the same shape (Cancel on Cancelled, Done_action on Done). Not
+    every terminal pair is on it: [Dropped, Request_complete] is still an
+    error, because completion is not the phase a dropped goal is in. *)

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -421,7 +421,21 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args
        (match Goal_phase.decide_transition ~phase:goal.phase ~action with
         | Error msg ->
           error_result_typed ~tool_name ~start_time ~code:Conflict msg
-        | Ok phase ->
+        (* The goal already occupies the phase this action targets. Writing it
+           and emitting a phase event would turn a repeated report — a duplicate
+           reconciliation, a stale racing event — into repeated history, so the
+           request is answered from the goal as it stands. *)
+        | Ok (Goal_phase.Already phase) ->
+          ok_result
+            ~tool_name
+            ~start_time
+            [ "goal_id", `String goal_id
+            ; "action", `String (Goal_phase.action_to_string action)
+            ; "noop", `Bool true
+            ; "phase", Goal_phase.to_yojson phase
+            ; "goal", Goal_store.goal_to_yojson goal
+            ]
+        | Ok (Goal_phase.Move_to phase) ->
           (match update_goal_phase ctx goal ~phase ?note () with
            | Error msg ->
              error_result_typed ~tool_name ~start_time ~code:Internal_error msg

--- a/test/test_goal_phase_all.ml
+++ b/test/test_goal_phase_all.ml
@@ -61,6 +61,111 @@ let test_action_set () =
     ]
     strs
 
+(* The 5x7 matrix in [decide_transition] had no behavioural test. Its comment
+   says the compiler "refuses a matrix with a hole in it", and that is true --
+   but exhaustiveness proves each pair has an arm, not that the arm gives the
+   right answer. Every pair is stated here as a literal, so a matrix edit shows
+   up as a diff in expectations rather than as a silently different answer. *)
+
+let outcome_label = function
+  | Ok (GP.Move_to phase) -> "move_to:" ^ GP.to_string phase
+  | Ok (GP.Already phase) -> "already:" ^ GP.to_string phase
+  | Error _ -> "invalid"
+
+(* phase, action, expected outcome. Read down a column to see one action across
+   all phases; the diagonal (target phase = current phase) is "already:*". *)
+let matrix =
+  [
+    (GP.Executing, GP.Request_complete, "move_to:completed");
+    (GP.Executing, GP.Pause, "move_to:paused");
+    (GP.Executing, GP.Resume, "already:executing");
+    (GP.Executing, GP.Block, "move_to:blocked");
+    (GP.Executing, GP.Unblock, "already:executing");
+    (GP.Executing, GP.Drop, "move_to:dropped");
+    (GP.Executing, GP.Reopen, "already:executing");
+    (GP.Blocked, GP.Request_complete, "invalid");
+    (GP.Blocked, GP.Pause, "invalid");
+    (GP.Blocked, GP.Resume, "invalid");
+    (GP.Blocked, GP.Block, "already:blocked");
+    (GP.Blocked, GP.Unblock, "move_to:executing");
+    (GP.Blocked, GP.Drop, "move_to:dropped");
+    (GP.Blocked, GP.Reopen, "invalid");
+    (GP.Paused, GP.Request_complete, "invalid");
+    (GP.Paused, GP.Pause, "already:paused");
+    (GP.Paused, GP.Resume, "move_to:executing");
+    (GP.Paused, GP.Block, "invalid");
+    (GP.Paused, GP.Unblock, "invalid");
+    (GP.Paused, GP.Drop, "move_to:dropped");
+    (GP.Paused, GP.Reopen, "invalid");
+    (GP.Completed, GP.Request_complete, "already:completed");
+    (GP.Completed, GP.Pause, "invalid");
+    (GP.Completed, GP.Resume, "invalid");
+    (GP.Completed, GP.Block, "invalid");
+    (GP.Completed, GP.Unblock, "invalid");
+    (GP.Completed, GP.Drop, "move_to:dropped");
+    (GP.Completed, GP.Reopen, "move_to:executing");
+    (GP.Dropped, GP.Request_complete, "invalid");
+    (GP.Dropped, GP.Pause, "invalid");
+    (GP.Dropped, GP.Resume, "invalid");
+    (GP.Dropped, GP.Block, "invalid");
+    (GP.Dropped, GP.Unblock, "invalid");
+    (GP.Dropped, GP.Drop, "already:dropped");
+    (GP.Dropped, GP.Reopen, "move_to:executing");
+  ]
+
+let test_matrix_is_total () =
+  check int "every phase/action pair is stated once"
+    (List.length GP.all * List.length GP.all_actions)
+    (List.length matrix);
+  let keys =
+    List.map
+      (fun (p, a, _) -> GP.to_string p ^ "/" ^ GP.action_to_string a)
+      matrix
+  in
+  check int "no duplicate pair" (List.length keys)
+    (List.length (List.sort_uniq String.compare keys))
+
+let test_matrix_outcomes () =
+  List.iter
+    (fun (phase, action, expected) ->
+      check string
+        (Printf.sprintf "%s + %s" (GP.to_string phase)
+           (GP.action_to_string action))
+        expected
+        (outcome_label (GP.decide_transition ~phase ~action)))
+    matrix
+
+(* An [Already] never names a phase other than the one asked about: that is what
+   lets the tool answer from the goal it already read instead of writing. *)
+let test_already_is_the_current_phase () =
+  List.iter
+    (fun phase ->
+      List.iter
+        (fun action ->
+          match GP.decide_transition ~phase ~action with
+          | Ok (GP.Already reported) ->
+            check string
+              (Printf.sprintf "%s + %s reports its own phase"
+                 (GP.to_string phase) (GP.action_to_string action))
+              (GP.to_string phase) (GP.to_string reported)
+          | Ok (GP.Move_to _) | Error _ -> ())
+        GP.all_actions)
+    GP.all
+
+(* The Task FSM answers the same shape with the status unchanged. This pins the
+   agreement so the two domains cannot drift apart again unnoticed. *)
+let test_agrees_with_task_fsm_on_restating_a_terminal_state () =
+  check string "completed + request_complete" "already:completed"
+    (outcome_label
+       (GP.decide_transition ~phase:GP.Completed ~action:GP.Request_complete));
+  check string "dropped + drop" "already:dropped"
+    (outcome_label (GP.decide_transition ~phase:GP.Dropped ~action:GP.Drop));
+  (* Not on the diagonal: completion is not the phase a dropped goal is in, so
+     this stays a real request for a state change and is refused. *)
+  check string "dropped + request_complete stays invalid" "invalid"
+    (outcome_label
+       (GP.decide_transition ~phase:GP.Dropped ~action:GP.Request_complete))
+
 let () =
   run "goal_phase_all"
     [
@@ -73,5 +178,14 @@ let () =
         [
           test_case "round-trip" `Quick test_action_roundtrip;
           test_case "set and order" `Quick test_action_set;
+        ] );
+      ( "transition matrix",
+        [
+          test_case "every pair stated once" `Quick test_matrix_is_total;
+          test_case "outcomes" `Quick test_matrix_outcomes;
+          test_case "already reports the current phase" `Quick
+            test_already_is_the_current_phase;
+          test_case "agrees with the Task FSM on restating a terminal state"
+            `Quick test_agrees_with_task_fsm_on_restating_a_terminal_state;
         ] );
     ]


### PR DESCRIPTION
## What

Task and Goal answer the same question in opposite ways.

```
Task   Cancel on Cancelled       ok, status unchanged
       Done_action on Done       ok, status unchanged
       Start on InProgress       ok, status unchanged

Goal   Drop on Dropped           "invalid goal transition"
       Request_complete on Completed   "invalid goal transition"
       Pause on Paused           "invalid goal transition"
```

A Keeper reaches for both in one turn. Restating a state you are already in is
fine in one domain and a `conflict` in the other.

## The Keeper knew, and was refused anyway

`masc_goal_transition` failed 8 times this week against 9 successes. Five were
this. The notes the Keeper attached to its own refused calls:

```
"Goal already completed at 08:57:35Z. This is a duplicate reconciliation event"
"Already completed at 08:57:35Z via reopen→request_complete. Stale..."
"Already completed at 09:00:32Z. Stale racing event."
"Already completed at 09:00:32Z. Duplicate reconciliation event"
```

Four calls, one Goal, one afternoon. The Keeper read the state correctly,
reported it accurately, and got an error each time.

**Why the reconciliation fired four times is a separate question** and this PR
does not answer it. It stops the accurate report from being an error.

### What the refusal drove the Keeper to do

The full trace for that Goal — 12 calls in ten minutes, one Keeper:

```
08:51:30  cancel            FAIL   (the Task word; Goal's is drop)
08:51:50  drop              ok
08:56:18  request_complete  FAIL   dropped + request_complete -- still refused after this PR
08:57:28  reopen            ok     "Reopening to allow request_complete transition"
08:57:35  request_complete  ok     completed
08:58:07  request_complete  FAIL   "duplicate reconciliation event"
08:59:22  request_complete  FAIL
08:59:46  drop              ok     "Attempting drop to break reconciliation loop"
09:00:25  reopen            ok     "Clearing reconciliation loop: reopen -> request_complete"
09:00:32  request_complete  ok     completed, again
09:00:38  request_complete  FAIL   "Stale racing event."
09:01:11  request_complete  FAIL   "Duplicate reconciliation event"
```

At 08:59:46 the Keeper **dropped a Goal it had just legitimately completed**,
to get out of a loop the refusal put it in — then reopened and completed it a
second time. The Goal's history carries drop -> reopen -> complete twice for one
completion.

This is the shape #27425 found on the Task side: the only exit from a refused
restatement was to destroy the thing. Six of these twelve calls do nothing but
work around the refusal.

## `Already` is not `Move_to`

`Ok phase` fed straight into `update_goal_phase` and `emit_goal_event`, so
returning the current phase would have written the goal and appended a
`goal_phase` event on every repeat — turning a repeated report into repeated
history. That is why this is a typed outcome rather than a wider `Ok`:

```ocaml
type outcome =
  | Move_to of t   (* write and record *)
  | Already of t   (* satisfied; nothing to write *)
```

`Already` answers from the goal the tool already read. Same shape as the Task
side, where `transition_outcome` carries `noop` for exactly this
(RFC-0088 §1, which replaced sniffing the `"(no-op)"` substring).

## The diagonal, and what is not on it

`Already` is every pair where the action's **target phase is the phase the goal
is in** — seven of thirty-five:

```
executing + resume / unblock / reopen      all three target executing
paused    + pause
blocked   + block
completed + request_complete
dropped   + drop
```

`dropped + request_complete` stays an error. Completion is not the phase a
dropped goal is in, so it is a real request for a state change, not a
restatement. Reopen first. One of the eight live failures was this pair and it
is still refused.

## The compiler was not going to catch the consumer

`dashboard_goals_types_health.ml` filtered available actions with `Ok _ -> true`,
which absorbs the new variant silently and would have started advertising
"pause" under a paused goal. It now names both arms, and lists only `Move_to` —
so the dashboard's rendered actions are byte-identical to today.

## The matrix had no test

Its comment says the exhaustive match "refuses a matrix with a hole in it", and
that is true — but exhaustiveness proves each pair has an arm, not that the arm
is right. `decide_transition` had zero behavioural coverage.

All 35 pairs are now stated as literals in `test_goal_phase_all`, **and that
suite is wired into `ci.yml`, which it was not before** — 4 tests → 8.

Verified not identities by mutation: with `Completed, Request_complete` put back
to `invalid` and everything else left alone,

```
[FAIL] transition matrix  1  outcomes.
[FAIL] transition matrix  3  agrees with the Task FSM on re...
```

Reverting the whole file instead does not compile — the tests name the new
constructors — which is why the proof is a one-arm mutation rather than a
revert.

## Stale doc removed

`goal_phase.mli` carried a paragraph describing a `transition_outcome` with
`Complete`, `Open_verification` and `Open_approval` arms, removed with the goal
quorum engine in #24332. It documented a type that had not existed for months,
above a function returning `(t, string) result`.

## Verification

```
dune build --root . @check                                        exit 0
dune build --root . @fmt            no diff in any file this PR touches
scripts/ocaml-structure-ratchet.sh                                    OK
scripts/audit-sublib-cycle.py                     OK - 34 leaf libraries clean

test_goal_phase_all                8 tests run   Successful   (was 4, now CI-wired)
test_goal_store                    5 tests run   Successful
test_goal_tools                   14 tests run   Successful
test_keeper_goal_phase_projection  6 tests run   Successful
test_goal_scope_terminal_phase    11 tests run   Successful
test_goal_upsert_fsm_bypass_10247  7 tests run   Successful
test_goal_metric_unevaluated      21 tests run   Successful
test_tool_task_coverage           92 tests run   Successful
test_tool_registry_consistency     8 tests run   Successful
test_tool_contract_truth          16 tests run   Successful
test_enum_mirror_sync              3 tests run   Successful
test_dashboard_briefing            6 tests run   Successful
```

Dashboard call site (`goal-tree.ts:591`) awaits the call and refreshes without
reading the body, so the added `noop` / `phase` fields reach no decoder.

RFC-WAIVED: a refusal removed where the Task FSM already accepts the same shape,
and a typed no-op so the acceptance writes nothing. No new field on the wire
format, no new gate.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
