### PR TITLE
fix(keeper): 폴백에서 진 슬롯의 실패 사유를 로그에 남긴다 (11개 → 1개 라벨 붕괴 해소)

### DIFF
--- a/lib/keeper/keeper_exact_flow_detail.ml
+++ b/lib/keeper/keeper_exact_flow_detail.ml
@@ -1,5 +1,50 @@
 module Exact_output = Agent_sdk.Exact_output
 
+(* [Flow_exact_execution_failed] is the branch that carries the provider's own
+   verdict. The typed cause alone ("completion failed") says nothing about
+   which provider said what; the raw response body carried next to it does. *)
+let execution_cause_detail : Exact_output.execution_error_cause -> string = function
+  | Attempt_already_started -> "attempt already started"
+  | Clock_required_for_timeout -> "clock required for timeout"
+  | Frozen_request_mismatch -> "frozen request mismatch"
+  | Completion_failed -> "completion failed"
+  | Serialized_request_refused { http_status } ->
+    Printf.sprintf "serialized request refused (http_status=%d)" http_status
+  | Incomplete_output -> "incomplete output"
+  | Missing_output -> "missing output"
+  | Ambiguous_output count -> Printf.sprintf "ambiguous output (candidates=%d)" count
+  | Unexpected_output_content -> "unexpected output content"
+  | Invalid_json_output -> "invalid json output"
+  | Internal_non_json_output -> "internal non-json output"
+;;
+
+(* [flow_evidence] is a private SDK type with no constructor outside the SDK,
+   so the assembled line cannot be built in a test. The part that decides what
+   the line says is split out here, where it can. That gap is why the label
+   collapse below survived: the leaf renderer [execution_cause_detail] was
+   covered, and the caller that failed to use it was not. *)
+let advance_failure_kind : Exact_output.flow_advance_failure_snapshot -> string * string
+  = function
+  | Exact_output.Flow_advance_candidate_rejected rejection ->
+    (Exact_output.candidate_rejection_identity rejection).candidate_id, "candidate_rejected"
+  (* [execution_error_cause] distinguishes eleven outcomes — a quota refusal,
+     an output budget spent before the answer, invalid JSON, an HTTP refusal
+     with its status. Rendering only "execution_failed" collapsed all eleven
+     into one label, and this advance is the only place a losing slot is
+     recorded: it left no other trace, so "why did the first slot lose the
+     run" had no answer anywhere. Observed 2026-08-07: the librarian advanced
+     off glm-coding.glm-5-turbo eight times and the cause was recoverable from
+     neither the log nor the call id. *)
+  | Exact_output.Flow_advance_execution_failed { candidate; cause; raw_response_sha256 } ->
+    let sha =
+      match raw_response_sha256 with
+      | None -> ""
+      | Some sha -> Printf.sprintf " raw_response_sha256=%s" sha
+    in
+    ( candidate.visit.identity.candidate_id
+    , Printf.sprintf "execution_failed cause=%s%s" (execution_cause_detail cause) sha )
+;;
+
 let flow_evidence_detail (evidence : Exact_output.flow_evidence) =
   let attempts =
     List.map
@@ -14,14 +59,7 @@ let flow_evidence_detail (evidence : Exact_output.flow_evidence) =
   let advances =
     List.map
       (fun (advance : Exact_output.flow_advance_receipt) ->
-         let failed_slot, failure_kind =
-           match advance.failed with
-           | Exact_output.Flow_advance_candidate_rejected rejection ->
-             ( (Exact_output.candidate_rejection_identity rejection).candidate_id
-             , "candidate_rejected" )
-           | Exact_output.Flow_advance_execution_failed { candidate; _ } ->
-             candidate.visit.identity.candidate_id, "execution_failed"
-         in
+         let failed_slot, failure_kind = advance_failure_kind advance.failed in
          Printf.sprintf
            "advance=%s->%s kind=%s"
            failed_slot
@@ -107,23 +145,6 @@ let candidate_rejection_detail (rejection : Exact_output.candidate_rejection_rec
      |> rejection_disposition_detail)
 ;;
 
-(* [Flow_exact_execution_failed] is the branch that carries the provider's own
-   verdict. The typed cause alone ("completion failed") says nothing about
-   which provider said what; the raw response body carried next to it does. *)
-let execution_cause_detail : Exact_output.execution_error_cause -> string = function
-  | Attempt_already_started -> "attempt already started"
-  | Clock_required_for_timeout -> "clock required for timeout"
-  | Frozen_request_mismatch -> "frozen request mismatch"
-  | Completion_failed -> "completion failed"
-  | Serialized_request_refused { http_status } ->
-    Printf.sprintf "serialized request refused (http_status=%d)" http_status
-  | Incomplete_output -> "incomplete output"
-  | Missing_output -> "missing output"
-  | Ambiguous_output count -> Printf.sprintf "ambiguous output (candidates=%d)" count
-  | Unexpected_output_content -> "unexpected output content"
-  | Invalid_json_output -> "invalid json output"
-  | Internal_non_json_output -> "internal non-json output"
-;;
 
 (* Log lines are single-line records; the excerpt bound keeps one failed call
    from flooding them while the sha256 keeps the full body identifiable in

--- a/lib/keeper/keeper_exact_flow_detail.mli
+++ b/lib/keeper/keeper_exact_flow_detail.mli
@@ -8,15 +8,6 @@
 
 (** Attempts and advances recorded in the flow evidence, one clause per
     candidate visit ("slot=... call_id=..."; "advance=a->b kind=..."). *)
-(** Failed slot id and the rendered failure kind for one advance. An execution
-    failure carries its typed cause and raw-response digest so eleven distinct
-    outcomes stay distinguishable instead of collapsing to "execution_failed".
-    Exposed because [flow_evidence] is a private SDK type with no constructor,
-    so this is the largest part of the assembled line a test can reach. *)
-val advance_failure_kind
-  :  Agent_sdk.Exact_output.flow_advance_failure_snapshot
-  -> string * string
-
 val flow_evidence_detail : Agent_sdk.Exact_output.flow_evidence -> string
 
 (** Typed reason a candidate slot was refused before dispatch, including the

--- a/lib/keeper/keeper_exact_flow_detail.mli
+++ b/lib/keeper/keeper_exact_flow_detail.mli
@@ -8,6 +8,15 @@
 
 (** Attempts and advances recorded in the flow evidence, one clause per
     candidate visit ("slot=... call_id=..."; "advance=a->b kind=..."). *)
+(** Failed slot id and the rendered failure kind for one advance. An execution
+    failure carries its typed cause and raw-response digest so eleven distinct
+    outcomes stay distinguishable instead of collapsing to "execution_failed".
+    Exposed because [flow_evidence] is a private SDK type with no constructor,
+    so this is the largest part of the assembled line a test can reach. *)
+val advance_failure_kind
+  :  Agent_sdk.Exact_output.flow_advance_failure_snapshot
+  -> string * string
+
 val flow_evidence_detail : Agent_sdk.Exact_output.flow_evidence -> string
 
 (** Typed reason a candidate slot was refused before dispatch, including the

--- a/test/test_keeper_exact_flow_detail.ml
+++ b/test/test_keeper_exact_flow_detail.ml
@@ -90,6 +90,44 @@ let test_raw_response_excerpt_cuts_on_utf8_boundary () =
     (Astring.String.is_infix ~affix:"301 bytes total" rendered)
 ;;
 
+(* The eleven distinct execution causes reach the advance line through
+   [execution_cause_detail]. The execution-failed branch of
+   [advance_failure_kind] cannot be built here — [flow_attempt_snapshot] is a
+   private SDK type with no constructor — so what is pinned is that every
+   cause the renderer can receive still renders apart from every other. A
+   single shared label is what made the eleven indistinguishable in the log,
+   and this fails if any two collapse onto the same string. *)
+let test_every_execution_cause_renders_distinctly () =
+  let causes : Exact_output.execution_error_cause list =
+    [ Attempt_already_started
+    ; Clock_required_for_timeout
+    ; Frozen_request_mismatch
+    ; Completion_failed
+    ; Serialized_request_refused { http_status = 429 }
+    ; Incomplete_output
+    ; Missing_output
+    ; Ambiguous_output 3
+    ; Unexpected_output_content
+    ; Invalid_json_output
+    ; Internal_non_json_output
+    ]
+  in
+  let rendered = List.map Detail.execution_cause_detail causes in
+  let unique = List.sort_uniq String.compare rendered in
+  Alcotest.(check int)
+    "every cause keeps its own wording"
+    (List.length causes)
+    (List.length unique);
+  (* The two an operator most needs to tell apart: a provider that refused the
+     call outright versus one that answered but ran out of output budget. *)
+  Alcotest.(check bool)
+    "quota refusal and truncated output are not the same string"
+    false
+    (String.equal
+       (Detail.execution_cause_detail Completion_failed)
+       (Detail.execution_cause_detail Incomplete_output))
+;;
+
 let () =
   Alcotest.run
     "keeper_exact_flow_detail"
@@ -106,5 +144,7 @@ let () =
             test_raw_response_excerpt_redacts_secrets
         ; Alcotest.test_case "raw response cuts on utf8 boundary" `Quick
             test_raw_response_excerpt_cuts_on_utf8_boundary
+        ; Alcotest.test_case "every execution cause renders distinctly" `Quick
+            test_every_execution_cause_renders_distinctly
         ] )
     ]

--- a/test/test_keeper_exact_flow_detail.ml
+++ b/test/test_keeper_exact_flow_detail.ml
@@ -92,7 +92,7 @@ let test_raw_response_excerpt_cuts_on_utf8_boundary () =
 
 (* The eleven distinct execution causes reach the advance line through
    [execution_cause_detail]. The execution-failed branch of
-   [advance_failure_kind] cannot be built here — [flow_attempt_snapshot] is a
+   the execution-failed branch cannot be built here — [flow_attempt_snapshot] is a
    private SDK type with no constructor — so what is pinned is that every
    cause the renderer can receive still renders apart from every other. A
    single shared label is what made the eleven indistinguishable in the log,


### PR DESCRIPTION
## 문제

폴백에서 슬롯이 밀려나면 로그에 이게 전부였다:

```
advance=glm-coding.glm-5-turbo->ollama_cloud.gemma4-31b-cloud kind=execution_failed
```

`Exact_output.Flow_advance_execution_failed` 는 candidate 옆에 **typed cause 와 raw-response digest** 를 지고 오는데 둘 다 `_` 로 버려지고 있었다.

`execution_error_cause` 는 11 개를 구분한다:

```
Attempt_already_started / Clock_required_for_timeout / Frozen_request_mismatch
Completion_failed / Serialized_request_refused of { http_status }
Incomplete_output / Missing_output / Ambiguous_output of int
Unexpected_output_content / Invalid_json_output / Internal_non_json_output
```

**11 → `"execution_failed"` 한 단어.**

## 왜 이 한 줄이 유일한 기록인가

밀려난 슬롯의 `call_id` 로 로그 전체를 뒤져도 다른 기록이 없다:

```bash
$ rg 848325a812900025559cbcb01119dd78 ~/me/.masc/logs/system_log_2026-08-07.jsonl
# → 위 advance 를 포함한 한 줄. 그 슬롯 자체의 기록은 없음.
```

즉 이 줄이 답해야 할 질문("1 순위가 왜 졌나")의 답이 **어디에도 없다.**

## 실측 (2026-08-07)

사서(`librarian_exact`)가 1 순위 `glm-coding.glm-5-turbo` 에서 **8 회** advance 했고 사유를 복구할 수 없다.

같은 로그 줄이 2 순위는 설명한다 — `raw_response` 가 실려 있기 때문이다:

```json
{"error":"you (yousleepwhen) have reached your weekly usage limit, ..."}
```

**한 줄 안에서 한 슬롯은 증거를 남기고 다른 슬롯은 라벨만 남긴다.**

glm 엔드포인트를 직접 찔러 보면 정상이다:

| 요청 | 결과 |
|---|---|
| `max_tokens=16` | `finish=length`, `content=""`, reasoning 66자 |
| `max_tokens=256` | `finish=stop`, `content="ok"` |
| `max_tokens` 생략 + `response_format=json_object` | `finish=stop`, JSON 정상, reasoning 1,320자 |

HTTP 200 에 구조화 JSON 도 잘 돌려준다. 그러니 실패는 MASC 가 보내는 **요청 쪽 조건**일 가능성이 크다 — 그리고 그게 정확히 버려진 정보다.

## 고친 것

`execution_cause_detail` 은 11 개를 이미 문자열화하고 **같은 파일에 있다.** 호출자가 안 썼을 뿐이다.

```
전:  advance=A->B kind=execution_failed
후:  advance=A->B kind=execution_failed cause=incomplete output raw_response_sha256=…
```

## 이미 진단되어 있었다

`hitl_summary_worker.ml`:

> … **the evidence payload each error carries is discarded at this boundary.** Observed 2026-07-28: 25 approvals quarantined under that one label, zero occurrences of the word in the system log.

`keeper_exact_flow_detail.ml`:

> **Discarding it is what makes a local capacity refusal indistinguishable from a provider outage in the durable row.**

진단은 주석으로 적혀 있었고 수정만 안 됐다.

## 테스트

`flow_evidence` 와 `flow_attempt_snapshot` 은 **생성자 없는 SDK `private` 타입**이라 조립된 줄을 테스트에서 만들 수 없다. **이게 이 결함이 살아남은 구조적 이유다** — 리프 렌더러는 케이스가 6 개고, 그걸 안 부른 호출자는 0 개였다.

판단부를 `advance_failure_kind` 로 분리해 도달 가능한 최대 범위를 노출하고, 11 개 사유가 **서로 다른 문자열로** 렌더되는지 고정했다. 두 개라도 같은 문자열로 붕괴하면 실패한다.

실패 능력 확인 — `Incomplete_output` 을 `"completion failed"` 로 붕괴시키면:

```
[FAIL]  render  6  every execution cause renders distinctly.
ASSERT  every cause keeps its own wording
rc=1
```

복원하면 rc=0.

```
dune build --root . @check   rc=0, Error 0
test_keeper_exact_flow_detail  Test Successful, 7 tests run
```

배포 후 로그에 `cause=` 가 실제로 실리는지로 재확인할 예정이다 (#27407 을 `lane_cancelled` 로 확인한 것과 같은 방식).

## 여기서 고치지 않은 것

`keeper_board_attention_exact_flow.ml:190` 이 같은 cause 를 버리지만, `Executed_failure of attempt_provenance` 는 담을 자리가 없다. variant 를 넓히면 `keeper_board_attention_partition.ml` 의 등가 비교·assert 포함 10 곳이 따라온다. 그리고 board_attention 레인은 현재 정상이다 (p50 3.9 s, 취소 0/47). 전수 스윕 결과와 함께 #27431 에 있다.

RFC-WAIVED: 기존 렌더러가 이미 가진 정보를 버리지 않게 하는 수정. 판정 기준·상태 집합·계약을 바꾸지 않는다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
