### PR TITLE
refactor(dashboard,ws): purge the push slices no event can reach

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1011,6 +1011,17 @@ jobs:
           opam exec -- dune build --root . \
             @test/runtest-test_transport_metrics
 
+      - name: Run websocket transport suite
+        # test_ws_transport sat red for 17 days and nothing reported it: #25500
+        # deleted the goal_loop_status -> "goals" mapping the delta-payload test
+        # was written against, and no target list names this suite, so @check
+        # compiled it and nothing ran it. It covers the delta/raw-forward split,
+        # the shared-payload cache, and the slice vocabulary -- the surface
+        # #27285 rewrote. Green on this branch, 64/64.
+        run: |
+          opam exec -- dune build --root . \
+            @test/runtest-test_ws_transport
+
       - name: Run connector observability label contract
         # These strings are metric label values, so a rename is a wire change
         # that compiles. @check cannot catch that, and test_discord_observability

--- a/dashboard/src/dashboard-slices.ts
+++ b/dashboard/src/dashboard-slices.ts
@@ -1,13 +1,20 @@
 // Dashboard push slice vocabulary shared by WS subscriptions and hydrators.
-// Keep in sync with Server_mcp_transport_ws.valid_dashboard_slice.
-
+//
+// Every name here must be BOTH accepted by Server_mcp_transport_ws
+// .valid_dashboard_slice AND producible by dashboard_slice_for_sse_type --
+// a slice the server accepts but can never emit is a subscription that
+// silently never delivers.
+//
+// 'shell', 'goals' and 'board' were exactly that. They were filled by
+// dashboard/subscribe's one-shot snapshot provider, never by deltas; #27027
+// deleted that provider when it made subscribe ACK-only. 'shell' remains a
+// live surface over its REST endpoint (/api/v1/dashboard/shell, polled by
+// refreshShell); board events still reach the client raw-forwarded; the goal
+// loop feed behind 'goals' was removed by RFC-0352.
 export const DASHBOARD_PUSH_SLICES = [
-  'shell',
   'namespace',
   'transport',
   'execution',
-  'goals',
-  'board',
   'composite',
   'operator',
 ] as const
@@ -15,7 +22,6 @@ export const DASHBOARD_PUSH_SLICES = [
 export type DashboardPushSlice = typeof DASHBOARD_PUSH_SLICES[number]
 
 export const GLOBAL_DASHBOARD_PUSH_SLICES = [
-  'shell',
   'namespace',
   'transport',
 ] as const satisfies readonly DashboardPushSlice[]

--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -260,11 +260,10 @@ describe('dashboardSlicesForRoute', () => {
     }
   })
 
-  it('keeps global shell namespace and transport slices on every route', () => {
+  it('keeps global namespace and transport slices on every route', () => {
     expect(dashboardSlicesForRoute({ tab: 'overview', params: {} })).toEqual([
       'execution',
       'namespace',
-      'shell',
       'transport',
     ])
   })
@@ -280,21 +279,17 @@ describe('dashboardSlicesForRoute', () => {
     })).toContain('execution')
   })
 
-  it('keeps board data HTTP-owned while subscribing goals and fleet FSM slices', () => {
+  it('keeps board data HTTP-owned while subscribing fleet FSM slices', () => {
     expect(dashboardSlicesForRoute({ tab: 'board', params: {} }))
       .toEqual([
         'namespace',
-        'shell',
         'transport',
       ])
     expect(dashboardSlicesForRoute({ tab: 'workspace', params: { section: 'board' } }))
       .toEqual([
         'namespace',
-        'shell',
         'transport',
       ])
-    expect(dashboardSlicesForRoute({ tab: 'workspace', params: { section: 'planning' } }))
-      .toContain('goals')
     expect(dashboardSlicesForRoute({ tab: 'monitoring', params: { section: 'agents' } }))
       .toContain('composite')
     expect(dashboardSlicesForRoute({ tab: 'keepers', params: { keeper: 'sangsu' } }))
@@ -302,7 +297,6 @@ describe('dashboardSlicesForRoute', () => {
         'composite',
         'execution',
         'namespace',
-        'shell',
         'transport',
       ])
     expect(dashboardSlicesForRoute({ tab: 'registry', params: {} }))
@@ -310,7 +304,6 @@ describe('dashboardSlicesForRoute', () => {
         'composite',
         'execution',
         'namespace',
-        'shell',
         'transport',
       ])
   })
@@ -908,7 +901,6 @@ describe('dashboard websocket route subscriptions', () => {
     expect(subscribe.params.route).toBe('workspace:board::')
     expect(subscribe.params.slices).toEqual([
       'namespace',
-      'shell',
       'transport',
     ])
 

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -455,7 +455,6 @@ export function dashboardSlicesForRoute(routeState: DashboardRouteState): string
   }
   if (routeState.tab === 'workspace' && routeState.params.section === 'planning') {
     slices.add('execution')
-    slices.add('goals')
   }
   // Board rows are actor/filter scoped (`voter`, blind-vote policy, author and
   // hearth filters) and are loaded through refreshBoard's HTTP query. Raw board

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -1,10 +1,6 @@
 import { signal } from '@preact/signals'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { BoardPost, BoardSortMode, RouteState } from './types'
-import {
-  DASHBOARD_PUSH_SLICES,
-  type DashboardPushSlice,
-} from './dashboard-slices'
 
 void vi
 
@@ -948,65 +944,42 @@ describe('setupServerPushReaction reconnect hydration', () => {
     expect(refreshBoard).not.toHaveBeenCalled()
   })
 
-  it('hydrates websocket dashboard snapshots for board, goals, and composite slices', async () => {
+  // Every dashboard/delta the server can emit carries an event_type: the slice is
+  // DERIVED from it by dashboard_slice_for_sse_type, so a delta with a slice and
+  // no event_type is unconstructible. These two tests used to call
+  // hydrateDashboardSlice with a slice and a hand-written payload and no
+  // event_type, which exercised the snapshot-shaped branch that #27027 deleted
+  // when it made dashboard/subscribe ACK-only. They passed either way, which is
+  // why the vocabulary rotted unnoticed.
+  it('routes every server-producible dashboard delta by its event type', async () => {
     const { sseStore } = await loadSseStore()
 
-    sseStore.hydrateDashboardSlice('board', { posts: [], generated_at: 'now' })
-    sseStore.hydrateDashboardSlice('goals', {
-      planning: { goals: [], generated_at: 'now' },
-      tree: {
-        approval_queue_state: { state: 'ready' },
-        tree: [],
-        summary: { total_goals: 0 },
-      },
-    })
-    sseStore.hydrateDashboardSlice('composite', {
-      generated_at: 1,
-      count: 0,
-      snapshots: [],
-    })
+    // The full image of dashboard_slice_for_sse_type
+    // (lib/server/server_mcp_transport_ws.ml). If the server gains a mapping,
+    // this list has to gain the event type, and the assertion below fails until
+    // a handler exists for it.
+    const deltas: Array<{ eventType: string; slice: string; payload: unknown }> = [
+      { eventType: 'project_snapshot', slice: 'namespace',
+        payload: { root: { status: { project: 'default' } } } },
+      { eventType: 'namespace_truth_snapshot', slice: 'namespace',
+        payload: { root: { status: { project: 'default' } } } },
+      { eventType: 'execution_snapshot', slice: 'execution',
+        payload: { agents: [], tasks: [], messages: [], keepers: [] } },
+      { eventType: 'operator_snapshot', slice: 'operator', payload: { keepers: [] } },
+      { eventType: 'operator_digest', slice: 'operator', payload: { target_type: 'namespace' } },
+      { eventType: 'transport_health_snapshot', slice: 'transport', payload: { transports: [] } },
+      { eventType: 'keeper_composite_changed', slice: 'composite',
+        payload: { name: 'alpha', ts_unix: 1 } },
+    ]
 
-    expect(hydrateBoardSnapshot).toHaveBeenCalledWith({ posts: [], generated_at: 'now' })
-    expect(hydratePlanningSnapshot).toHaveBeenCalledWith({ goals: [], generated_at: 'now' })
-    expect(hydrateGoalTreeSnapshot).toHaveBeenCalledWith({
-      approval_queue_state: { state: 'ready' },
-      tree: [],
-      summary: { total_goals: 0 },
-    })
-    expect(hydrateFleetCompositeSnapshot).toHaveBeenCalledWith({
-      generated_at: 1,
-      count: 0,
-      snapshots: [],
-    })
-  })
-
-  it('handles every dashboard push slice advertised to route subscriptions', async () => {
-    const { sseStore } = await loadSseStore()
-    const payloads: Record<DashboardPushSlice, unknown> = {
-      shell: { counts: { agents: 1, tasks: 2, keepers: 3 } },
-      namespace: { root: { status: { project: 'default' } } },
-      transport: { transports: [] },
-      execution: { agents: [], tasks: [], messages: [], keepers: [] },
-      goals: {
-        planning: { goals: [], generated_at: 'now' },
-        tree: { tree: [], summary: { total_goals: 0 } },
-      },
-      board: { posts: [], generated_at: 'now' },
-      composite: { generated_at: 1, count: 0, snapshots: [] },
-      operator: { snapshot: { keepers: [] }, digest: { target_type: 'namespace' } },
+    for (const { eventType, slice, payload } of deltas) {
+      expect(() => sseStore.hydrateDashboardSlice(slice, payload, eventType)).not.toThrow()
     }
 
-    for (const slice of DASHBOARD_PUSH_SLICES) {
-      expect(() => sseStore.hydrateDashboardSlice(slice, payloads[slice])).not.toThrow()
-    }
-
-    expect(hydrateShellSnapshot).toHaveBeenCalledWith(
-      payloads.shell,
-      { light: true, preserveAuth: true },
+    // Not merely "did not throw": the typed arms must actually hydrate.
+    expect(hydrateExecutionSnapshot).toHaveBeenCalledWith(
+      { agents: [], tasks: [], messages: [], keepers: [] },
     )
-    expect(hydrateExecutionSnapshot).toHaveBeenCalledWith(payloads.execution)
-    expect(hydrateBoardSnapshot).toHaveBeenCalledWith(payloads.board)
-    expect(hydrateFleetCompositeSnapshot).toHaveBeenCalledWith(payloads.composite)
   })
 
   it('routes websocket dashboard delta event types without treating payloads as snapshots', async () => {

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -18,19 +18,13 @@ import {
 import type {
   BoardPost,
   DashboardExecutionResponse,
-  DashboardMemoryResponse,
-  DashboardPlanningResponse,
-  DashboardShellResponse,
   SSEEvent,
 } from './types'
 import type * as TransportHealth from './components/transport-health'
 import {
   keeperHeartbeats,
   invalidateDashboardCache,
-  hydrateBoardSnapshot,
-  hydrateShellSnapshot,
   hydrateExecutionSnapshot,
-  hydratePlanningSnapshot,
   refreshDashboard,
   refreshExecution,
   refreshBoard,
@@ -54,12 +48,8 @@ import {
 import { mergeServerStatus } from './store-normalizers'
 import { normalizeOperatorSnapshot, normalizeOperatorDigest } from './operator-normalizers'
 import { operatorSnapshot, operatorWorkspaceDigest } from './operator-signals'
-import { compositeTick, hydrateFleetCompositeSnapshot } from './composite-signals'
+import { compositeTick } from './composite-signals'
 import { isRecord } from './lib/type-guards'
-import {
-  hydrateGoalTreeObservationError,
-  hydrateGoalTreeSnapshot,
-} from './goal-tree-state'
 import { showToast } from './components/common/toast'
 import type { ErrorCode } from './types/error'
 import { parseOasPayloadOrNull } from './schemas/sse-event-payload'
@@ -888,7 +878,7 @@ function eventPayloadRecord(payload: unknown): Record<string, unknown> {
   return isRecord(payload) ? payload : { payload }
 }
 
-export function hydrateDashboardSlice(slice: string, payload: unknown, eventType?: string): void {
+export function hydrateDashboardSlice(_slice: string, payload: unknown, eventType?: string): void {
   switch (eventType) {
     case 'project_snapshot':
     case 'namespace_truth_snapshot':
@@ -907,49 +897,14 @@ export function hydrateDashboardSlice(slice: string, payload: unknown, eventType
     return
   }
 
-  switch (slice) {
-    case 'shell':
-      hydrateShellSnapshot(payload as DashboardShellResponse, { light: true, preserveAuth: true })
-      return
-    case 'namespace':
-      hydrateServerPushEvent({ type: 'project_snapshot', payload } as SSEEvent)
-      return
-    case 'execution':
-      hydrateServerPushEvent({ type: 'execution_snapshot', payload } as SSEEvent)
-      return
-    case 'operator': {
-      const record = payload as { snapshot?: unknown; digest?: unknown }
-      if (record.snapshot) {
-        hydrateServerPushEvent({ type: 'operator_snapshot', payload: record.snapshot } as SSEEvent)
-      }
-      if (record.digest) {
-        hydrateServerPushEvent({ type: 'operator_digest', payload: record.digest } as SSEEvent)
-      }
-      return
-    }
-    case 'transport':
-      hydrateServerPushEvent({ type: 'transport_health_snapshot', payload } as SSEEvent)
-      return
-    case 'board':
-      hydrateBoardSnapshot(payload as DashboardMemoryResponse)
-      return
-    case 'goals': {
-      if (!payload || typeof payload !== 'object') return
-      const record = payload as { planning?: unknown; tree?: unknown; loop?: unknown }
-      if (record.planning) {
-        hydratePlanningSnapshot(record.planning as DashboardPlanningResponse)
-      }
-      if (record.tree && !hydrateGoalTreeSnapshot(record.tree)) {
-        hydrateGoalTreeObservationError(
-          new Error('Goal Store push tree payload was malformed'),
-        )
-      }
-      return
-    }
-    case 'composite':
-      hydrateFleetCompositeSnapshot(payload)
-      return
-  }
+  // Reaching here means the server sent a delta with a slice but no event_type.
+  // It cannot: dashboard_event_of_external derives the slice from the event type
+  // and server_mcp_transport_ws.ml:674 always writes event_type alongside it.
+  //
+  // The slice-keyed hydrators that used to live here belonged to
+  // dashboard/subscribe's one-shot snapshot, whose provider #27027 deleted when
+  // it made subscribe ACK-only. Every snapshot now arrives as a typed event and
+  // is handled above.
 }
 
 // --- WebSocket server-push reaction setup ---

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -552,7 +552,11 @@ let handle_dashboard_subscribe_eio id ?mcp_session_id params =
   | Some session_id, Some (`Assoc fields) ->
     let route = optional_string_member "route" fields in
     let slices = string_list_member "slices" fields in
-    let slices = if slices = [] then [ "shell"; "namespace"; "transport" ] else slices in
+    (* Server-side copy of the dashboard's GLOBAL_DASHBOARD_PUSH_SLICES, for a
+       caller that subscribes without naming slices. "shell" was here until
+       #27027 deleted the snapshot provider that was its only filler; keeping it
+       would hand such a caller a slice no event can ever be routed to. *)
+    let slices = if slices = [] then [ "namespace"; "transport" ] else slices in
     !dashboard_subscribe_handler ~session_id ?route ~slices ()
     |> dashboard_response_or_error id
   | Some _, None -> make_error_typed ~id Mcp_error_code.Invalid_params "Missing params"

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -393,16 +393,16 @@ let rec atomic_bump_max a v =
   let cur = Atomic.get a in
   if v > cur && not (Atomic.compare_and_set a cur v) then atomic_bump_max a v
 
+(* Must stay the exact domain of [dashboard_slice_for_sse_type]: accepting a
+   slice no event can be routed to is a subscription that silently never
+   delivers, and the rejection below is all-or-nothing, so it cannot be
+   discovered by watching one slice go quiet.
+
+   "shell", "board" and "goals" were accepted here until #27027. They were fed
+   by dashboard/subscribe's one-shot snapshot provider rather than by deltas,
+   and that commit deleted the provider without pruning either vocabulary. *)
 let valid_dashboard_slice = function
-  | "shell"
-  | "execution"
-  | "operator"
-  | "transport"
-  | "namespace"
-  | "composite"
-  | "board"
-  | "goals" ->
-      true
+  | "execution" | "operator" | "transport" | "namespace" | "composite" -> true
   | _ -> false
 
 let dashboard_slice_for_sse_type = function

--- a/lib/server/server_mcp_transport_ws.mli
+++ b/lib/server/server_mcp_transport_ws.mli
@@ -400,9 +400,17 @@ val dashboard_ack :
 
 val valid_dashboard_slice : string -> bool
 (** Returns [true] for the canonical slice names
-    ([shell] / [execution] / [operator] / [transport] /
-    [namespace] / [composite] / [board] / [goals]).
-    Mirrored into {!dashboard_subscribe}'s validation. *)
+    ([execution] / [operator] / [transport] / [namespace] /
+    [composite]).  Mirrored into {!dashboard_subscribe}'s
+    validation.  Must equal the image of
+    {!dashboard_slice_for_sse_type}: a name accepted here but
+    absent there is a subscription no event can reach. *)
+
+val dashboard_slice_for_sse_type : string -> string option
+(** The slice an SSE event type is delivered on, or [None] to
+    raw-forward.  Exposed so a test can compare its image
+    against {!valid_dashboard_slice}; the two drifted apart
+    for a day after #27027 with nothing to catch it. *)
 
 val client_buffer_limit_bytes : unit -> int
 (** Resolved client-buffer threshold (in bytes) used by

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -244,6 +244,20 @@ let test_ws_upgrade_accept_rejects_wrong_version () =
 
 (* ====== Dashboard route-scoped slices ====== *)
 
+(* Every event type the bus can carry into a delta.  A literal, because
+   [dashboard_slice_for_sse_type] is a closed match with a [_ -> None]
+   catch-all: nothing enumerates its domain, so a new arm has to be added here
+   too, and the assertion below is what makes that visible. *)
+let mapped_sse_event_types =
+  [ "project_snapshot"
+  ; "namespace_truth_snapshot"
+  ; "execution_snapshot"
+  ; "operator_snapshot"
+  ; "operator_digest"
+  ; "transport_health_snapshot"
+  ; "keeper_composite_changed"
+  ]
+
 let test_dashboard_route_scoped_slices_are_valid () =
   List.iter
     (fun slice ->
@@ -251,15 +265,52 @@ let test_dashboard_route_scoped_slices_are_valid () =
         (Printf.sprintf "%s is accepted" slice)
         true
         (Ws.valid_dashboard_slice slice))
-    [ "shell"
-    ; "namespace"
-    ; "transport"
-    ; "execution"
-    ; "goals"
-    ; "board"
-    ; "composite"
-    ; "operator"
-    ]
+    [ "namespace"; "transport"; "execution"; "composite"; "operator" ]
+
+(* The drift that motivated this: for a day after #27027 the acceptor said yes
+   to shell, board and goals while the producer could emit none of them.  A
+   client subscribing to one got an Ok and then silence -- and because
+   dashboard_subscribe rejects the whole request when any single name is
+   unknown, the failure could not be localised by watching one slice go quiet.
+
+   Direction matters and both halves are asserted:
+   accepted-but-unproducible is the silent subscription; producible-but-rejected
+   would make dashboard_subscribe fail outright for a client asking for a slice
+   the server actively emits. *)
+let test_accepted_slices_equal_producible_slices () =
+  let producible =
+    mapped_sse_event_types
+    |> List.filter_map Ws.dashboard_slice_for_sse_type
+    |> List.sort_uniq compare
+  in
+  List.iter
+    (fun slice ->
+      Alcotest.(check bool)
+        (Printf.sprintf "producible slice %s is accepted by subscribe" slice)
+        true
+        (Ws.valid_dashboard_slice slice))
+    producible;
+  (* The reverse direction needs a domain to quantify over, and
+     [valid_dashboard_slice] is a function rather than a list.  Feeding it the
+     producible set plus every name this repo has ever accepted covers both the
+     current vocabulary and the three that were removed. *)
+  List.iter
+    (fun slice ->
+      if Ws.valid_dashboard_slice slice then
+        Alcotest.(check bool)
+          (Printf.sprintf "accepted slice %s is producible from some event" slice)
+          true
+          (List.mem slice producible))
+    ([ "shell"; "board"; "goals"; "ide" ] @ producible)
+
+let test_removed_slices_are_rejected () =
+  List.iter
+    (fun slice ->
+      Alcotest.(check bool)
+        (Printf.sprintf "%s is no longer accepted" slice)
+        false
+        (Ws.valid_dashboard_slice slice))
+    [ "shell"; "board"; "goals" ]
 
 (* ====== Parse cache for broadcast amplification ====== *)
 
@@ -1163,6 +1214,10 @@ let () =
     ("dashboard", [
       Alcotest.test_case "route scoped slices are valid" `Quick
         test_dashboard_route_scoped_slices_are_valid;
+      Alcotest.test_case "accepted slices equal producible slices" `Quick
+        test_accepted_slices_equal_producible_slices;
+      Alcotest.test_case "slices removed with the snapshot provider are rejected"
+        `Quick test_removed_slices_are_rejected;
     ]);
     ("dashboard_event", [
       Alcotest.test_case "known type maps to slice" `Quick

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -455,19 +455,29 @@ let test_bytes_cache_counters () =
   Alcotest.(check (float 0.001)) "fresh allocation forces another miss"
     2.0 (read_counter misses_name -. misses0)
 
+(* [seq] is per-session but the payload text is shared across every session that
+   subscribed to the slice, so a [seq] inside the payload would make the sharing
+   wrong rather than merely wasteful.  [send_dashboard_delta_frame] carries it in
+   a separate notification for exactly that reason.
+
+   Written against "goal_loop_status" -> "goals" (#23339).  RFC-0352 (#25500)
+   deleted that mapping arm, which left this red for 17 days -- unnoticed because
+   test_ws_transport is not in any ci.yml target list.  The property under test is
+   about the shared-payload contract and not about which event carries it, so it
+   moves to a live mapping instead of being deleted with the dead vocabulary. *)
 let test_dashboard_delta_payload_text_excludes_seq () =
   let event =
     external_event_of_payload
       (`Assoc
         [
-          ("type", `String "goal_loop_status");
+          ("type", `String "keeper_composite_changed");
           ("payload", `Assoc [ ("status", `String "running") ]);
         ])
   in
   match Ws.__test_dashboard_delta_payload_text_for_event event with
   | None -> Alcotest.fail "expected shared dashboard delta payload"
   | Some frame ->
-      Alcotest.(check string) "slice" "goals" frame.slice;
+      Alcotest.(check string) "slice" "composite" frame.slice;
       let json = Yojson.Safe.from_string frame.text in
       let params =
         match json with
@@ -483,7 +493,7 @@ let test_dashboard_delta_payload_text_excludes_seq () =
         false
         (List.mem_assoc "seq" fields);
       Alcotest.(check (option string)) "event type preserved"
-        (Some "goal_loop_status")
+        (Some "keeper_composite_changed")
         (Option.bind (List.assoc_opt "event_type" fields) (function
           | `String s -> Some s
           | _ -> None))


### PR DESCRIPTION
## 무엇이 문제였나

대시보드가 push slice 8 종을 광고하는데 서버가 만들 수 있는 것은 5 종이다.

```
valid_dashboard_slice        (구독 수락)  shell execution operator transport namespace composite board goals
dashboard_slice_for_sse_type (이벤트→slice)      execution operator transport namespace composite
```

`shell`, `board`, `goals` 로는 **어떤 이벤트도 도달할 수 없다**. 서버는 구독에 `Ok` 를 주고 영원히 아무것도 안 보낸다. `shell` 은 `GLOBAL_DASHBOARD_PUSH_SLICES` 에 있어 모든 세션이 모든 라우트에서 요청했다.

## 왜 이렇게 됐나

태생적 결함이 아니다. 하루 사이 잔해다.

| | |
|---|---|
| #9916 (4/24) | slice 어휘 8 종 + `dashboard/subscribe` 의 스냅샷 provider 9-arm 도입. `shell`/`board`/`goals` 는 delta 가 아니라 **구독 시 1 회 스냅샷**으로 채워짐 |
| #25500 (7/21) | RFC-0352 가 `goal_loop_status` 매핑 삭제 → `test_ws_transport` red |
| #27027 (8/6) | subscribe 를 ACK-only 로 전환, provider 41 줄 통째 삭제 → 세 slice 가 채워질 마지막 경로 소멸. **어휘는 양쪽 다 그대로** |
| #27422 | dead-export 스캐너가 `dashboard_goals_snapshot_json` 제거. 판정은 정확 — 소비자가 이미 없었다 |

각 단계는 개별적으로 타당했다. 아무도 어휘를 정리하지 않았을 뿐이다.

## 왜 안 잡혔나

`test_ws_transport` 가 **17 일간 빨간 상태**였고 아무도 몰랐다. 어느 타깃 목록에도 없어 `@check` 가 컴파일만 하고 실행하지 않는다.

PR #16233 "push slice parity" 는 이름과 달리 **push 생산자에 대해 아무것도 검사하지 않는다**. 클라이언트 목록과 수락 함수를 비교하는데 그 둘은 내내 일치했다. 정작 갈라진 생산자는 `.mli` 에 export 조차 안 돼 테스트가 접근할 수 없었다.

## 변경 (4 커밋, 순서가 계약)

**1. red 테스트 복구 + CI 배선**

`test_dashboard_delta_payload_text_excludes_seq` 가 검사하던 속성은 여전히 유효하고 다른 어디에도 없다 — `seq` 는 세션별인데 payload 텍스트는 세션 간 공유되므로, `seq` 가 payload 에 섞이면 공유가 *낭비*가 아니라 *틀린 것*이 된다. 죽은 어휘와 함께 버리지 않고 살아 있는 매핑(`keeper_composite_changed` → `composite`)으로 옮겼다.

`test_ws_transport` 를 ci.yml 에 배선했다. 안 하면 다음 매핑 변경도 똑같이 안 보인다.

**2. 클라이언트 먼저**

어휘에서 3 종 제거. `hydrateDashboardSlice` 의 slice-keyed 분기도 삭제 — `event_type` 없는 delta 에서만 도달하는데 서버가 그런 걸 못 보낸다 (slice 는 event type 에서 파생되고 `server_mcp_transport_ws.ml:674` 가 항상 둘 다 쓴다).

해제된 hydrator 5 개는 전부 다른 호출자가 있다 (REST 갱신 경로). import 지우기 전에 확인했다.

그 분기를 덮던 테스트 2 개는 서버가 만들 수 없는 입력을 손으로 넣고 있었다 — 그래서 생산자 유무와 무관하게 통과했다. `dashboard_slice_for_sse_type` 의 전체 image 를 실제 `(event_type, slice, payload)` 삼중항으로 순회하는 테스트 1 개로 대체했다.

**3. 서버 어휘 축소**

`valid_dashboard_slice` 를 5 종으로. 순서가 제약이었다 — 수락 함수는 **이름 하나라도 모르면 구독 전체를 거부**하므로, 클라이언트보다 먼저 좁히면 구버전 클라이언트가 slice 하나를 잃는 게 아니라 raw-forward-only 로 통째로 떨어진다.

`mcp_server_eio_protocol.ml:555` 의 기본 구독 목록도 고쳤다. slices 를 안 보내는 호출자에게 `shell` 을 쥐여주고 있었다.

**4. 드리프트 차단**

`dashboard_slice_for_sse_type` 를 export 하고 **양방향 집합 동치**를 검사한다.

- 수락되는데 생산 불가 → 조용히 아무것도 안 오는 구독. all-or-nothing 거부 때문에 slice 하나가 조용한 게 아니라 클라이언트가 깨진 것처럼 보여 진단도 안 된다
- 생산되는데 거부 → 서버가 실제로 보내는 slice 를 요청한 클라이언트의 `dashboard/subscribe` 가 통째로 실패

## 남긴 것

- `shell` 은 REST 로 살아 있다 (`/api/v1/dashboard/shell`, `refreshShell` 이 폴링). push 절반만 죽었다
- board 이벤트는 raw-forward 로 실제 도달해 `refreshBoard` 를 돌린다. JSON-RPC 봉투라 `"type"` 이 `params` 안에 있어 slice 매핑 전에 걸러질 뿐이다
- `server_dashboard_http.ml:798` 의 `slice "shell"` 은 **다른 축**이다 (HTTP bootstrap 번들). 건드리지 않았다
- Shell IR 서브시스템과는 무관한 동음이의어다. `scripts/audit-shell-ir-consumption.sh` 는 `lib` 의 `.ml/.mli` 만 스캔하고 CI scope 필터에 `dashboard/` 가 없다

## 검증

- `dune build @default` 통과, 에러 0
- `@test/runtest-test_ws_transport` **66/66** (CI 호출 형태로)
- dashboard `tsc` clean, **8804/8804**
- 두 새 가드 모두 **비어 있지 않음을 확인**:
  - 수락 함수에만 `shell` 을 되돌리면 새 테스트 2 개가 정확히 실패
  - `execution_snapshot` arm 을 지우면 TS 테스트가 그것만 실패
