### PR TITLE
fix(delegate): stop requiring a capability the submitter cannot choose

### DIFF
--- a/lib/keeper/keeper_invocation_contract.ml
+++ b/lib/keeper/keeper_invocation_contract.ml
@@ -116,6 +116,22 @@ let capability_of_json ~field = function
   | _ -> invalid_wire_value ~field ~expected:"invoke_turn"
 ;;
 
+(* [capability] has one legal value, so a submitter cannot choose it -- it can
+   only restate it or get it wrong. Every one of the week's 29 [delegate]
+   rejections was this field: 22 said "task_assignment" and 7 said
+   "claim_and_execute", which are descriptions of the prompt, not capabilities
+   the contract offers. A field named [capability] reads as a menu.
+
+   Absent now resolves to the single value. An explicit wrong one is still
+   refused, so this admits nothing new -- it stops requiring a restatement. If a
+   second capability is ever added, this default becomes a real choice and has
+   to be revisited here, which is why it is written as an explicit arm rather
+   than folded into [capability_of_json]. *)
+let optional_capability_of_json ~field = function
+  | None -> Ok Invoke_turn
+  | Some json -> capability_of_json ~field json
+;;
+
 let request ~keeper_name ~prompt =
   let* keeper_name =
     Keeper_id.Keeper_name.of_string keeper_name
@@ -212,8 +228,11 @@ let request_of_json json =
   in
   let* target_json = required_field ~field:"delegate" "target" fields in
   let* target = target_of_json target_json in
-  let* capability_json = required_field ~field:"delegate" "capability" fields in
-  let* capability = capability_of_json ~field:"delegate.capability" capability_json in
+  let* capability =
+    optional_capability_of_json
+      ~field:"delegate.capability"
+      (List.assoc_opt "capability" fields)
+  in
   let* prompt_json = required_field ~field:"delegate" "prompt" fields in
   let* prompt = string_value ~field:"delegate.prompt" prompt_json in
   if String.equal prompt "" then Error Empty_prompt else Ok { target; capability; prompt }

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -266,7 +266,12 @@ let schemas : tool_schema list = [
   ; description = "Submit one typed, non-blocking Keeper invocation and return its durable run_ref."
   ; input_schema =
       closed_object_schema
-        ~required:[ "target"; "capability"; "prompt" ]
+        (* [capability] is not required: its enum has one member, so demanding it
+           asks the submitter to restate a value it cannot choose. Every
+           delegate rejection in the week before this change was this field,
+           filled in with a description of the prompt instead. Omitting it
+           resolves to [invoke_turn]; an explicit wrong value is still refused. *)
+        ~required:[ "target"; "prompt" ]
         [ "target", keeper_invocation_target_schema
         ; ( "capability"
           , `Assoc

--- a/test/test_keeper_invocation_contract_hints.ml
+++ b/test/test_keeper_invocation_contract_hints.ml
@@ -50,6 +50,54 @@ let test_valid_target_still_parses () =
     Alcotest.failf "expected a kind/name target to parse, got %s"
       (C.request_error_to_string err)
 
+(* The field-name hint above closed the target guesses: in the week measured for
+   this change, 0 of 29 delegate rejections were target shape. All 29 were
+   [capability], which the submitter cannot choose -- its enum has one member.
+   22 said "task_assignment" and 7 said "claim_and_execute", both descriptions
+   of the prompt rather than capabilities the contract offers. *)
+
+let request_json ?capability () =
+  `Assoc
+    ((match capability with
+      | None -> []
+      | Some value -> [ "capability", `String value ])
+     @ [ "target", `Assoc [ "kind", `String "keeper"; "name", `String "analyst" ]
+       ; "prompt", `String "Claim and work on task-154."
+       ])
+
+let test_omitted_capability_is_accepted () =
+  match C.request_of_json (request_json ()) with
+  | Ok _ -> ()
+  | Error err ->
+    Alcotest.failf "expected a request without capability to parse, got %s"
+      (C.request_error_to_string err)
+
+let test_stated_capability_still_parses () =
+  match C.request_of_json (request_json ~capability:"invoke_turn" ()) with
+  | Ok _ -> ()
+  | Error err ->
+    Alcotest.failf "expected capability=invoke_turn to parse, got %s"
+      (C.request_error_to_string err)
+
+(* Omitting is not the same as widening: the two values actually sent are still
+   refused, and the refusal still names what the field accepts. *)
+let test_the_invented_capabilities_are_still_refused () =
+  List.iter
+    (fun value ->
+      match C.request_of_json (request_json ~capability:value ()) with
+      | Ok _ -> Alcotest.failf "expected capability=%s to be refused" value
+      | Error err ->
+        let msg = C.request_error_to_string err in
+        Alcotest.(check bool)
+          (Printf.sprintf "%s rejection names the field" value)
+          true
+          (contains ~needle:"delegate.capability" msg);
+        Alcotest.(check bool)
+          (Printf.sprintf "%s rejection names the accepted value" value)
+          true
+          (contains ~needle:"invoke_turn" msg))
+    [ "task_assignment"; "claim_and_execute" ]
+
 let () =
   Alcotest.run "keeper_invocation_contract_hints"
     [ ( "undeclared_field_hint"
@@ -59,5 +107,13 @@ let () =
             test_other_guessed_names_get_the_same_hint
         ; Alcotest.test_case "a valid target still parses" `Quick
             test_valid_target_still_parses
+        ] )
+    ; ( "single_value_capability"
+      , [ Alcotest.test_case "omitted capability is accepted" `Quick
+            test_omitted_capability_is_accepted
+        ; Alcotest.test_case "stated capability still parses" `Quick
+            test_stated_capability_still_parses
+        ; Alcotest.test_case "the invented values are still refused" `Quick
+            test_the_invented_capabilities_are_still_refused
         ] )
     ]


### PR DESCRIPTION
## What

`masc_keeper_delegate` required a `capability` field whose enum has one member.
Every rejection it produced in the last week was that field.

```
masc_keeper_delegate    35 ok    29 failed    (45%)

failures by cause, counted per call
  22   capability = "task_assignment"
   7   capability = "claim_and_execute"
   0   anything else
```

Both invented values are descriptions of the prompt, not capabilities the
contract offers. A field named `capability`, required, reads as a menu — so the
submitter filled in what it was trying to do.

The same Keeper's successful calls sit next to the failed ones with identical
targets and near-identical prompts, differing only in that word:

```
FAIL  {"target":{"kind":"keeper","name":"executor"}, "capability":"claim_and_execute", "prompt":"Claim task-097 ..."}
OK    {"target":{"kind":"keeper","name":"executor"}, "capability":"invoke_turn",       "prompt":"Claim task-097 ..."}
```

## What changes

`capability` moves out of `required`. Absent resolves to `invoke_turn`.

This admits nothing new. An explicit wrong value is refused exactly as before,
with the same message, and a test pins both invented values. What it stops is
requiring the submitter to restate a value it cannot choose.

The internal constructor already worked this way:

```ocaml
let request ~keeper_name ~prompt = ... Ok { target = Keeper keeper_name; capability = Invoke_turn; prompt }
```

Only the wire insisted on the restatement.

## Not a permissive default

The distinction matters, because "unknown input mapped to a convenient default"
is the pattern to refuse. This is not that: an **absent** field resolves to the
only value its enum permits, and an **unknown** value still errors. Written as
its own arm rather than folded into `capability_of_json`, so that adding a
second capability makes the default a real choice the compiler puts in front of
whoever adds it.

## Scope

Only `request_of_json`. `run_ref_of_json` keeps `capability` required — a
`run_ref` is a token MASC emitted and the caller echoes back whole, not
something the caller composes, and there are no live failures on
`masc_keeper_delegate_status` or `_cancel`.

`target.kind` is also a single-member enum and is **left alone**: zero of the 29
failures were target shape.

## The previous fix in this area worked

`test_keeper_invocation_contract_hints` opens by recording an earlier window —
"failed 43 times out of 171 … target.agent, then target.keeper_name, then
target.keeper". Those were closed by adding `accepted: kind, name` to the
rejection. In the window measured here that class is at **0**. The hint did its
job; `capability` is what is left.

## Tests

Three cases added to `test_keeper_invocation_contract_hints`, which CI runs:

| case | asserts |
|---|---|
| omitted capability is accepted | a request with no `capability` parses |
| stated capability still parses | `invoke_turn` unchanged |
| the invented values are still refused | `task_assignment` and `claim_and_execute` error, and the message still names the field and the accepted value |

Verified not an identity by mutation — with the `None` arm put back to an error:

```
[FAIL] single_value_capability  0  omitted capability is ac...
FAIL expected a request without capability to parse,
     got delegate.capability must be invoke_turn
```

which is the live rejection text, reproduced.

## Verification

```
dune build --root . @check                                        exit 0
dune build --root . @fmt            no diff in any file this PR touches
scripts/audit-dead-surface.py --exports --ratchet    671, at baseline
scripts/ocaml-structure-ratchet.sh                                    OK

test_keeper_invocation_contract_hints            6 tests run   Successful
test_keeper_tool_schema_bytes                    2 tests run   Successful
test_tool_registry_consistency                  27 tests run   Successful
test_tool_contract_truth                        43 tests run   Successful
test_keeper_tool_descriptor_registry_integrity   8 tests run   Successful
test_tool_schema_constraint_enforcement          3 tests run   Successful
```

RFC-WAIVED: a required field made optional where its enum admits one value. No
new field, no new accepted value, no new gate.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
