### PR TITLE
refactor: dead export 제거 (batch 4: 102건)

### DIFF
--- a/lib/cache_eio.mli
+++ b/lib/cache_eio.mli
@@ -17,9 +17,6 @@ type cache_entry = {
 
 (** {1 Configuration} *)
 
-val eviction_sample_threshold : float
-val batch_eviction_interval : float
-
 (** {1 Paths} *)
 
 val cache_dir : Workspace_utils.config -> string
@@ -54,7 +51,6 @@ val format_stats : int * int * float -> string
 val evict_expired : Workspace_utils.config -> int
 val maybe_evict_expired : Workspace_utils.config -> int
 val count_entries : Workspace_utils.config -> int
-val is_expired : cache_entry -> bool
 val last_batch_eviction : float Atomic.t
 val cached_entry_count : int Atomic.t
 val reset_cached_entry_count : unit -> unit

--- a/lib/compression/compression_codec.ml
+++ b/lib/compression/compression_codec.ml
@@ -18,14 +18,6 @@ type compress_result =
   | Compressed of compressed
 
 let min_size = 32
-let max_dict_size = 2048
-
-let should_use_dict (size : int) : bool =
-  size >= min_size
-
-let get_dict () : string = ""
-let has_dict () : bool = false
-
 let uses_dict = function
   | Dictionary -> true
   | Standard -> false

--- a/lib/compression/compression_codec.mli
+++ b/lib/compression/compression_codec.mli
@@ -24,19 +24,14 @@ type compress_result =
 val min_size : int
 (** Minimum payload size (bytes) below which compression is skipped. *)
 
-val max_dict_size : int
 (** Upper bound reserved for dictionary payloads. *)
 
 (** {1 Encoding helpers} *)
 
-val should_use_dict : int -> bool
 (** [should_use_dict size] returns whether a payload of [size] bytes should be
     routed through the dictionary-aware path. Currently a simple size floor. *)
 
-val get_dict : unit -> string
 (** Current dictionary bytes. Empty string when no dictionary is loaded. *)
-
-val has_dict : unit -> bool
 
 val uses_dict : encoding -> bool
 

--- a/lib/config/env_config_memory.ml
+++ b/lib/config/env_config_memory.ml
@@ -35,17 +35,6 @@ let get_int_logged name ~default =
            default)
 ;;
 
-let get_float_positive_logged name ~default =
-  match env_opt name with
-  | None -> default
-  | Some raw ->
-      (match float_of_string_opt raw with
-       | Some value when Float.is_finite value && value > 0.0 -> value
-       | _ ->
-           Log.Keeper.warn "invalid %s=%S; using default %.3f" name raw default;
-           default)
-;;
-
 let get_bool_logged ?(invalid = Default) name ~default =
   match env_opt name with
   | None -> default

--- a/lib/config/env_config_memory.mli
+++ b/lib/config/env_config_memory.mli
@@ -7,11 +7,8 @@ type invalid_bool_policy =
   | Default
   | Fail_closed
 
-val accepted_true_bool_tokens : string list
-val accepted_false_bool_tokens : string list
 val parse_bool_token : string -> bool option
 
 val env_opt : string -> string option
 val get_int_logged : string -> default:int -> int
-val get_float_positive_logged : string -> default:float -> float
 val get_bool_logged : ?invalid:invalid_bool_policy -> string -> default:bool -> bool

--- a/lib/config_dir_resolver/config_dir_resolver.ml
+++ b/lib/config_dir_resolver/config_dir_resolver.ml
@@ -210,24 +210,6 @@ let config_signature_exists config_dir =
   && (existing_file runtime_toml
      || existing_dir prompts || existing_dir keepers)
 
-let rec ancestor_dirs path =
-  let dir = absolute_path path in
-  let parent = Filename.dirname dir in
-  if parent = dir then [ dir ] else dir :: ancestor_dirs parent
-
-let path_from_executable ~cwd executable_name =
-  let exe = absolute_path_from ~cwd executable_name in
-  if not (Sys.file_exists exe) then None
-  else
-    ancestor_dirs (Filename.dirname exe)
-    |> List.find_map (fun dir ->
-           let candidate = Filename.concat dir "config" in
-           if config_signature_exists candidate then Some candidate else None)
-
-let path_from_cwd cwd =
-  let candidate = Filename.concat cwd "config" |> absolute_path_from ~cwd in
-  if config_signature_exists candidate then Some candidate else None
-
 let base_path_config_root ~cwd base_path =
   let base_path =
     base_path

--- a/lib/config_dir_resolver/config_dir_resolver.mli
+++ b/lib/config_dir_resolver/config_dir_resolver.mli
@@ -157,7 +157,6 @@ val data_dir : base_path:string -> string
 
 (** {2 Config-rooted file accessors} *)
 
-val repositories_toml_basename : string
 (** ["repositories.toml"]. SSOT basename of the repository catalog file, so
     callers that surface *which* config file gated a decision (e.g. the
     playground repo [policy_source] field) label it from one constant instead
@@ -225,10 +224,6 @@ val sanitize_inherited_test_base_path_opt :
   current:string option ->
   home:string option ->
   string option
-
-val path_from_executable : cwd:string -> string -> string option
-
-val path_from_cwd : string -> string option
 
 (** {1 Warnings and logging} *)
 

--- a/lib/core/common.ml
+++ b/lib/core/common.ml
@@ -84,9 +84,6 @@ let keeper_runtime_stores =
   ; Keeper_trajectories
   ]
 
-let keeper_runtime_store_dirnames =
-  List.map keeper_runtime_store_dirname keeper_runtime_stores
-
 let keeper_runtime_store_of_dirname name =
   List.find_opt
     (fun store -> String.equal name (keeper_runtime_store_dirname store))
@@ -121,10 +118,3 @@ let max_process_capture_tail_bytes = 256 * 1024
 
 (** BUG-016: Truncate large tool responses to prevent MCP transport overload.
     Default max: 64KB. Appends truncation metadata when trimmed. *)
-let truncate_response ?(max_bytes=max_tool_output_bytes) ~total_count response =
-  let len = String.length response in
-  if len <= max_bytes then response
-  else
-    let truncated = String.sub response 0 max_bytes in
-    Printf.sprintf "%s\n\n... [truncated: %d/%d bytes shown, total_count=%d]"
-      truncated max_bytes len total_count

--- a/lib/core/common.mli
+++ b/lib/core/common.mli
@@ -6,13 +6,9 @@
 (** Boolean environment variable with permissive truthy parsing:
     ["1"], ["true"], ["yes"], ["on"] (case/whitespace insensitive)
     all return [true]; absent, empty, or anything else returns [false]. *)
-val env_true : string -> bool
-
 (** [true] when [MASC_STRICT_FINALIZERS] env is truthy. Callers can
     opt into raising finally-block exceptions instead of swallowing
     them. *)
-val strict_finalizers : unit -> bool
-
 val handle_finalizer_error :
   module_name:string ->
   label:string ->
@@ -66,8 +62,6 @@ type keeper_runtime_store =
 
 val keeper_runtime_store_dirname : keeper_runtime_store -> string
 val keeper_runtime_store_of_dirname : string -> keeper_runtime_store option
-val keeper_runtime_store_dirnames : string list
-
 val auth_dir_from_base_path : base_path:string -> string
 (** [<base_path>/.masc/auth]. SSOT path so {!Auth} and
     {!Keeper_identity} can both compute it without depending on each
@@ -108,11 +102,6 @@ val max_process_capture_tail_bytes : int
     O(output). Elided bytes are reported by {!Exec_buffer.render}'s
     truncation marker rather than dropped silently. *)
 
-val truncate_response :
-  ?max_bytes:int ->
-  total_count:int ->
-  string ->
-  string
 (** [truncate_response ?max_bytes ~total_count s] returns [s] unchanged
     when its length is at most [max_bytes] (default
     {!max_tool_output_bytes}). Otherwise returns the first [max_bytes]

--- a/lib/cost_ledger/cost_ledger.mli
+++ b/lib/cost_ledger/cost_ledger.mli
@@ -50,8 +50,5 @@ val to_json :
 val of_json : Yojson.Safe.t -> (t, decode_error) result
 (** Decode only the current row contract. *)
 
-val directory_name : string
-val dir_of_masc_root : string -> string
-val dir_of_base_path : base_path:string -> string
 val store_of_masc_root : string -> Dated_jsonl.t
 val store_of_base_path : base_path:string -> Dated_jsonl.t

--- a/lib/discovery_cache/discovery_cache.ml
+++ b/lib/discovery_cache/discovery_cache.ml
@@ -79,20 +79,4 @@ let cache_age_seconds () =
 
 (* ── Convenience queries ─────────────────────────────────── *)
 
-let idle_slot_count () =
-  let endpoints = get_cached_or_refresh () in
-  List.fold_left (fun acc (e : endpoint_info) ->
-    match e.slots with
-    | Some s -> acc + s.idle
-    | None -> acc) 0 endpoints
-
-let busy_slot_count () =
-  let endpoints = get_cached_or_refresh () in
-  List.fold_left (fun acc (e : endpoint_info) ->
-    match e.slots with
-    | Some s -> acc + s.busy
-    | None -> acc) 0 endpoints
-
 (* ── JSON (delegates to OAS) ─────────────────────────────── *)
-
-let endpoint_to_json = Llm_provider.Discovery.endpoint_status_to_json

--- a/lib/discovery_cache/discovery_cache.mli
+++ b/lib/discovery_cache/discovery_cache.mli
@@ -54,18 +54,15 @@ val cache_age_seconds : unit -> float
 
 (** {1 Convenience queries} *)
 
-val idle_slot_count : unit -> int
 (** Sum of [slot.idle] across cached endpoints; endpoints with
     no slot info contribute 0. Implicitly refreshes via
     {!get_cached_or_refresh}. *)
 
-val busy_slot_count : unit -> int
 (** Sum of [slot.busy] across cached endpoints; endpoints with
     no slot info contribute 0. Implicitly refreshes via
     {!get_cached_or_refresh}. *)
 
 (** {1 JSON projections} *)
 
-val endpoint_to_json : endpoint_info -> Yojson.Safe.t
 (** Re-export of [Llm_provider.Discovery.endpoint_status_to_json]
     so dashboard consumers do not have to spell the path. *)

--- a/lib/eval_calibration.mli
+++ b/lib/eval_calibration.mli
@@ -14,15 +14,11 @@ type record_type =
   | Label_record
 
 val record_type_to_string : record_type -> string
-val record_type_of_string : string -> record_type option
-
 type label_verdict =
   | Approve_label
   | Reject_label
 
 val label_verdict_to_string : label_verdict -> string
-val label_verdict_of_string : string -> label_verdict option
-
 val verdict_to_string : Task.Anti_rationalization.verdict -> string
 val verdict_of_string : string -> Task.Anti_rationalization.verdict option
 
@@ -71,7 +67,6 @@ val get_store : unit -> Dated_jsonl.t
 val reset_store_for_testing : unit -> unit
 (** Reset the store reference.  For testing only. *)
 
-val set_store : base_dir:string -> unit
 (** Set the process-local verdict store to an explicit isolated directory.
     Used by offline eval tooling after verdict-store isolation checks and by
     tests through [set_store_for_testing]. *)

--- a/lib/fd_accountant/fd_accountant.mli
+++ b/lib/fd_accountant/fd_accountant.mli
@@ -22,8 +22,6 @@ val kind_of_string : string -> kind option
 val all_kinds : kind list
 val all_resource_errors : resource_error list
 val resource_error_to_string : resource_error -> string
-val resource_error_of_exn : exn -> resource_error option
-
 val install_observers :
   nofile_soft_limit:(unit -> int option) ->
   on_resource_error:(kind:kind -> resource_error -> exn -> unit) ->
@@ -47,8 +45,6 @@ val resource_error_count : kind:kind -> resource_error -> int
     internal, so an unavailable or faulty external observer cannot erase the
     event from telemetry. *)
 
-val install_dated_jsonl_log_writer_observer : unit -> unit
-val install_process_eio_sandbox_exec_observer : unit -> unit
 val install_with_process_sandbox_exec_observer : unit -> unit
 
 type snapshot =

--- a/lib/gate/channel_gate_binding_store.mli
+++ b/lib/gate/channel_gate_binding_store.mli
@@ -68,13 +68,10 @@ val create :
   guild_id_field:guild_id_field ->
   t
 
-val read_json_file_result : string -> (Yojson.Safe.t option, string) result
 val read_json_file_opt : string -> Yojson.Safe.t option
 val normalize_bindings_json :
   Yojson.Safe.t -> (binding list, binding_decode_error) result
-val binding_decode_error_to_string : binding_decode_error -> string
 val binding_store_error_to_string : binding_store_error -> string
-val audit_append_error_to_string : audit_append_error -> string
 val mutation_error_to_string : mutation_error -> string
 val read_bindings_result : t -> (binding list, binding_store_error) result
 val bound_channels_result :

--- a/lib/gate/discord_rest_client.ml
+++ b/lib/gate/discord_rest_client.ml
@@ -249,11 +249,7 @@ let embed_to_json (e : embed) : Yojson.Safe.t =
 (* Embed colors *)
 let color_blue = 0x3498DB    (* Running / in progress *)
 let color_green = 0x2ECC71   (* Success *)
-let color_red = 0xE74C3C     (* Error *)
-
 (* Discord embed field value limit is 1024 characters. *)
-let embed_field_value_limit = 1024
-
 
 let link_embed ~url ~title ~description ~image =
   { title
@@ -327,13 +323,3 @@ let send_embed_message ?clock
   match Masc_http_client.post_sync ?clock ~timeout_sec ~url ~headers ~body () with
   | Error msg -> Error (Network msg)
   | Ok (status, body) -> parse_response ~status ~body
-
-let edit_embed_message ?clock
-    ?(timeout_sec = Masc_http_client.default_request_timeout_sec)
-    ~token ~channel_id ~message_id ~content ?embeds () =
-  let (url, headers, body) =
-    build_edit_embed_request ~token ~channel_id ~message_id ~content ?embeds ()
-  in
-  match Masc_http_client.patch_sync ?clock ~timeout_sec ~url ~headers ~body () with
-  | Error msg -> Error (Network msg)
-  | Ok (status, body) -> parse_empty_response ~status ~body

--- a/lib/gate/discord_rest_client.mli
+++ b/lib/gate/discord_rest_client.mli
@@ -119,12 +119,10 @@ type embed =
 val embed_to_json : embed -> Yojson.Safe.t
 (** Convert an embed to its JSON representation. Exposed for testing. *)
 
-val embed_field_value_limit : int
 (** Discord embed field value limit, in characters. *)
 
 val color_blue : int
 val color_green : int
-val color_red : int
 (** Predefined embed colors: blue=running, green=success, red=error. *)
 
 val link_embed :
@@ -150,16 +148,6 @@ val send_embed_message :
 (** [send_embed_message] posts a message with optional embeds.
     Returns the created message id on [Ok]. *)
 
-val edit_embed_message :
-  ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
-  ?timeout_sec:float ->
-  token:string ->
-  channel_id:string ->
-  message_id:string ->
-  content:string ->
-  ?embeds:embed list ->
-  unit ->
-  (unit, error) result
 (** [edit_embed_message] patches a message with updated content/embeds. *)
 
 (** {1 Internal — exposed for unit testing}

--- a/lib/keeper/keeper_composite_observer.mli
+++ b/lib/keeper/keeper_composite_observer.mli
@@ -63,9 +63,6 @@ type invariants_check = {
     once per violated invariant. No-op when all invariants hold. Called
     automatically from [observe]; exposed so unit tests can assert the
     counter bump without going through the full snapshot pipeline. *)
-val bump_invariant_violations :
-  keeper_name:string -> invariants_check -> unit
-
 (** {2 Pure invariant predicates}
 
     The [check_*] functions below are the conjuncts of the composite
@@ -347,15 +344,9 @@ val observe :
 val turn_phase_to_string : Keeper_registry.packed_turn_phase -> string
 
 (** Stringify [decision_stage]. Mirrors KeeperDecisionPipeline.tla. *)
-val decision_stage_to_string : Keeper_registry.packed_decision_stage -> string
-
 (** Stringify the runtime-state compatibility field. *)
-val runtime_state_to_string : runtime_state -> string
-
 (** Stringify [compaction_stage]. *)
 val compaction_stage_to_string : Keeper_registry.packed_compaction_stage -> string
-
-val invariant_key_to_string : invariant_key -> string
 
 (** Serialise a snapshot as the [/api/keepers/:name/composite] payload
     documented in RFC-0003 §7. *)

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -51,10 +51,6 @@ let read_meta_file_path path : (Keeper_meta_contract.keeper_meta option, string)
               e)))
 ;;
 
-let is_keeper_meta_file f =
-  Option.is_some (Keeper_runtime_root_entry.metadata_keeper_name f)
-;;
-
 let persisted_keeper_names_result config =
   let dir = keeper_dir config in
   match Safe_ops.list_dir_safe dir with
@@ -428,11 +424,6 @@ let write_meta_deferred_runtime_sync config m =
   |> Result.map_error write_meta_error_to_string
 ;;
 
-let write_meta_for_lifecycle token config m =
-  write_meta_typed ~lifecycle_token:token config m
-  |> Result.map_error write_meta_error_to_string
-;;
-
 let is_version_conflict_error msg =
   try
     ignore (Re.exec version_conflict_re msg);
@@ -512,26 +503,6 @@ let write_meta_with_merge_for_lifecycle token ?max_retries ~merge config m =
    so a concurrent heartbeat/turn CAS race re-applies the stamp instead of
    dropping it. [`No_durable_meta] is a distinct, non-fatal outcome (keeper meta
    never persisted) rather than a swallowed error. *)
-let persist_compaction_decision config ~keeper_name ~decision
-  : ([ `Persisted | `No_durable_meta ], string) result
-  =
-  let stamp (m : Keeper_meta_contract.keeper_meta) =
-    Keeper_meta_contract.map_compaction_rt
-      (fun rt ->
-        { rt with last_decision = decision })
-      m
-  in
-  match read_meta config keeper_name with
-  | Error msg -> Error msg
-  | Ok None -> Ok `No_durable_meta
-  | Ok (Some disk_meta) ->
-    write_meta_with_merge
-      ~merge:(fun ~latest ~caller:_ -> stamp latest)
-      config
-      (stamp disk_meta)
-    |> Result.map (fun () -> `Persisted)
-;;
-
 let persist_compaction_commit_projection config ~keeper_name ~commit_count
   : ([ `Persisted | `No_durable_meta ], string) result
   =

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -18,8 +18,6 @@ val register_runtime_meta_write_sync :
 (** Pre-compiled regex matching the CAS [meta version conflict]
     error message. Exposed for symmetry — used internally by
     [is_version_conflict_error]. *)
-val version_conflict_re : Re.re
-
 (** Read a keeper meta JSON file at [path]. Returns [Ok None] when
     the file does not exist. Unknown top-level keys are rejected with a
     reset-required error; the persisted file is never rewritten. *)
@@ -27,8 +25,6 @@ val read_meta_file_path :
   string -> (Keeper_meta_contract.keeper_meta option, string) result
 
 (** [true] when [f] has an exact canonical Keeper-metadata interpretation. *)
-val is_keeper_meta_file : string -> bool
-
 (** List keeper names with persisted JSON in [.masc/keepers/].
     Sidecars filtered, names validated, sorted ascending. *)
 val persisted_keeper_names_result : Workspace.config -> (string list, string) result
@@ -124,12 +120,6 @@ val write_meta_deferred_runtime_sync :
 (** Lifecycle-owner variant of [write_meta]. The opaque reservation token is
     checked against the same BasePath/name key before entering the per-path
     CAS critical section. *)
-val write_meta_for_lifecycle :
-  Keeper_lifecycle_reservation.token ->
-  Workspace.config ->
-  Keeper_meta_contract.keeper_meta ->
-  (unit, string) result
-
 type identity_update_error =
   | Identity_missing
   | Identity_changed
@@ -240,12 +230,6 @@ val write_meta_with_merge_for_lifecycle :
     with a concurrent heartbeat/turn write re-applies the stamp. [`No_durable_meta]
     reports that no on-disk meta exists to stamp (non-fatal); [Error] carries a
     read/write failure. *)
-val persist_compaction_decision :
-  Workspace.config ->
-  keeper_name:string ->
-  decision:Keeper_meta_contract.compaction_runtime_decision ->
-  ([ `Persisted | `No_durable_meta ], string) result
-
 val persist_compaction_commit_projection :
   Workspace.config ->
   keeper_name:string ->

--- a/lib/keeper/keeper_status_runtime.mli
+++ b/lib/keeper/keeper_status_runtime.mli
@@ -16,9 +16,6 @@ val agent_runtime_status_opt : Yojson.Safe.t -> Masc_domain.agent_status option
 
 val agent_runtime_has_live_signal : Yojson.Safe.t -> bool
 val parse_agent_status : Workspace.config -> agent_name:string -> Yojson.Safe.t
-val keeper_reply_snapshot_of_history :
-  Yojson.Safe.t list -> Yojson.Safe.t * Yojson.Safe.t * Yojson.Safe.t
-
 val keeper_diagnostic_json :
   meta:keeper_meta ->
   agent_status:Yojson.Safe.t ->
@@ -34,24 +31,10 @@ val augment_keeper_diagnostic_json :
   Yojson.Safe.t ->
   Yojson.Safe.t
 
-val keeper_health_to_string : keeper_health -> string
-
 (** Strict parse: returns [None] when the wire string is not one of the
     seven canonical keeper_health labels so drift is visible at the
     call site. *)
 val keeper_health_of_string_opt : string -> keeper_health option
-
-val keeper_continuity_to_string : keeper_continuity -> string
-
-val keeper_health_state :
-  ?fiber_health:fiber_health ->
-  ?keepalive_interval_s:float ->
-  meta:keeper_meta ->
-  keepalive_running:bool ->
-  agent_status:Yojson.Safe.t ->
-  quiet_reason:string option ->
-  unit ->
-  keeper_health
 
 (** Keeper display status derived from (keeper_health x agent_status). Closed so
     consumers that classify it match exhaustively. "paused" is an operator

--- a/lib/keeper/keeper_tool_memory_runtime.mli
+++ b/lib/keeper/keeper_tool_memory_runtime.mli
@@ -8,9 +8,7 @@ type memory_search_source =
   | History
   | All
 
-val memory_search_source_to_string : memory_search_source -> string
 val memory_search_source_of_string_opt : string -> memory_search_source option
-val all_memory_search_sources : memory_search_source list
 val valid_memory_search_source_strings : string list
 
 val keeper_memory_search_json
@@ -55,11 +53,7 @@ val keeper_memory_write_with_outcome
   -> Keeper_tool_execution.t
 
 (** Title length cap exposed for sync regression tests. *)
-val keeper_memory_write_max_title_chars : int
-
 (** Upper bound on the composed [**title** content] body. *)
-val keeper_memory_write_max_body_chars : int
-
 (** Result of validating a [keeper_memory_write] call's args. Exposed
     so tests can pin the error_kind taxonomy without constructing a
     [Workspace.config]. *)

--- a/lib/keeper_runtime/keeper_disk_pressure.mli
+++ b/lib/keeper_runtime/keeper_disk_pressure.mli
@@ -22,10 +22,6 @@ val note_exception : ?site:string -> exn -> unit
 (** Record and log only typed [Unix_error (ENOSPC, _, _)]. *)
 
 val reset_for_tests : unit -> unit
-val probe_path : ?now:float -> string -> snapshot_result
-val probe_masc_root : ?now:float -> masc_root:string -> unit -> snapshot_result
-val disk_snapshot_to_json : disk_snapshot -> Yojson.Safe.t
-val snapshot_result_to_json : snapshot_result -> Yojson.Safe.t
 val observation_fields : unit -> (string * Yojson.Safe.t) list
 val snapshot_json : ?now:float -> masc_root:string -> unit -> Yojson.Safe.t
 

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -1319,18 +1319,6 @@ let top_p_of_runtime_id (id : string) : float option =
   | None -> None
 ;;
 
-let top_k_of_runtime_id (id : string) : int option =
-  match get_runtime_by_id id with
-  | Some rt -> rt.provider_config.top_k
-  | None -> None
-;;
-
-let min_p_of_runtime_id (id : string) : float option =
-  match get_runtime_by_id id with
-  | Some rt -> rt.provider_config.min_p
-  | None -> None
-;;
-
 let default_preserve_thinking_for_model (_rt : t) : bool option =
   (* OAS owns provider/model capability truth and can preserve reasoning when
      the provider contract requires it. MASC must not turn "request-side
@@ -1897,8 +1885,3 @@ let default_max_context () : int =
    labels and returned the model-id substring. Under single-binding the model
    name sent to the runtime endpoint is the default runtime's [model.api_name].
    Falls back to ["auto"] before {!init_default} runs. *)
-let default_model_api_name () : string =
-  match get_default_runtime () with
-  | Some rt -> rt.model.api_name
-  | None -> "auto"
-;;

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -18,7 +18,6 @@ type t =
 val id_of_binding : binding -> string
 val of_binding : config -> binding -> t option
 
-val of_binding_result : config -> binding -> (t, string) result
 (** Reason-preserving form of {!of_binding}. [Error reason] when the binding's
     provider/model id is unresolved or the provider transport/protocol cannot be
     materialized into a {!Llm_provider.Provider_config.t} (e.g. a [messages-http]
@@ -355,11 +354,9 @@ val top_p_of_runtime_id : string -> float option
     or [None] when the runtime is not configured or no explicit value is
     declared.  This projects the Provider_config SSOT used for dispatch. *)
 
-val top_k_of_runtime_id : string -> int option
 (** Request [top_k] from the materialized OAS provider config for runtime [id],
     or [None] when absent. *)
 
-val min_p_of_runtime_id : string -> float option
 (** Request [min_p] from the materialized OAS provider config for runtime [id],
     or [None] when absent. *)
 
@@ -449,7 +446,6 @@ val default_max_context : unit -> int
     [Runtime_runtime.resolve_*_max_context] label scans. Falls back to
     [Runtime_constants.fallback_context_window] before {!init_default} runs. *)
 
-val default_model_api_name : unit -> string
 (** API model name of the default runtime, sent to the runtime completion
     endpoint (RFC-0206 single-binding). Replaces the deleted
     [Runtime_runtime.default_local_model_label_and_id]. Falls back to ["auto"]

--- a/lib/server/server_mcp_transport_http_headers.mli
+++ b/lib/server/server_mcp_transport_http_headers.mli
@@ -33,13 +33,10 @@ val body_jsonrpc_method : string -> (string * bool) option
     non-object body).  [has_id] reports whether the [id] field is
     present (used to distinguish notifications from requests). *)
 
-val request_protocol_version_header : Httpun.Request.t -> string option
 (** Case-insensitive lookup of [MCP-Protocol-Version]. *)
 
-val request_method_header : Httpun.Request.t -> string option
 (** Case-insensitive lookup of [Mcp-Method]. *)
 
-val request_name_header : Httpun.Request.t -> string option
 (** Case-insensitive lookup of [Mcp-Name]. *)
 
 val request_uses_stateless_protocol : Httpun.Request.t -> string -> bool
@@ -54,7 +51,6 @@ val validate_2026_request_headers :
     [_meta], [Mcp-Method], and, for [tools/call], [resources/read],
     and [prompts/get], matching [Mcp-Name]. *)
 
-val is_initialize_method : string -> bool
 (** [is_initialize_method m] tests whether [m] equals the literal
     [["initialize"]].  The initialize handshake must always go over
     plain JSON, never SSE. *)

--- a/lib/server/server_runtime_config_root_bootstrap.mli
+++ b/lib/server/server_runtime_config_root_bootstrap.mli
@@ -1,13 +1,5 @@
 val project_root_from_executable : unit -> string option
 
-val config_root_from_ancestor : string -> string option
-
-val versioned_config_root_candidates : unit -> string list
-
-val copy_file_if_missing : src:string -> dst:string -> unit
-
-val copy_missing_tree : src:string -> dst:string -> unit
-
 val config_bootstrap_mode : unit -> [ `Auto | `Empty | `Skip ]
 
 val ensure_config_root_scaffold : string -> unit

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -606,23 +606,6 @@ let metadata_to_fields name =
   in
   with_mcp_context_required
 
-let public_contract_fields name =
-  let meta = metadata name in
-  let base =
-    [
-      ( "implementationStatus",
-        `String (implementation_status_to_string meta.implementation_status) );
-    ]
-  in
-  let with_mcp_context_required =
-    match meta.mcp_context_required with
-    | Some value -> ("mcpContextRequired", `Bool value) :: base
-    | None -> base
-  in
-  match meta.canonical_name with
-  | Some canonical_name -> ("canonicalName", `String canonical_name) :: with_mcp_context_required
-  | None -> with_mcp_context_required
-
 let allow_direct_call name =
   let meta = metadata name in
   match meta.visibility with

--- a/lib/tool/tool_catalog.mli
+++ b/lib/tool/tool_catalog.mli
@@ -57,8 +57,6 @@ val hidden_active :
   ?implementation_status:implementation_status ->
   required_permission:Masc_domain.permission -> string -> metadata
 
-val placeholder_tools_enabled : unit -> bool
-
 (** {1 Public tool surface} *)
 
 val public_mcp_tools : string list
@@ -76,7 +74,6 @@ val execution_policy_of_metadata :
 val execution_policy_error_to_string : execution_policy_error -> string
 val implementation_status : string -> implementation_status
 val canonical_tool_name : string -> string
-val is_placeholder : string -> bool
 val is_visible : ?include_hidden:bool -> string -> bool
 val allow_direct_call : string -> bool
 
@@ -84,14 +81,11 @@ val allow_direct_call : string -> bool
 
 val visibility_to_string : visibility -> string
 val lifecycle_to_string : lifecycle -> string
-val implementation_status_to_string : implementation_status -> string
-
 (** {1 JSON metadata} *)
 
 val metadata_to_fields : string -> (string * Yojson.Safe.t) list
 (** Full metadata as JSON key-value pairs. *)
 
-val public_contract_fields : string -> (string * Yojson.Safe.t) list
 (** Minimal metadata for public contract responses. *)
 
 val register_runtime_metadata : string -> metadata -> (unit, string) result

--- a/lib/tool_run.mli
+++ b/lib/tool_run.mli
@@ -13,11 +13,6 @@ type context = {
 
 (** {1 Individual Handlers} *)
 
-val handle_run_init : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
-val handle_run_plan : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
-val handle_run_get : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
-val handle_run_list : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
-
 (** {1 Dispatcher} *)
 
 (** Dispatch run tool by name. Returns None if not a run tool. *)

--- a/lib/voice_runtime_overlay/voice_runtime_overlay.mli
+++ b/lib/voice_runtime_overlay/voice_runtime_overlay.mli
@@ -33,13 +33,9 @@ type stt_request =
   ; file_field : string * string
   }
 
-val string_of_transport : transport -> string
 val adapters : adapter list
 val resolve_adapter : string -> adapter option
 val adapter_for_endpoint : Voice_config.endpoint -> adapter
-val adapter_for_endpoint_kind : Voice_config.endpoint_kind -> adapter
-val adapter_labels : adapter -> string list
-val endpoint_matches_provider_label : string -> Voice_config.endpoint -> bool
 val select_endpoints : ?provider:string -> Voice_config.endpoint list -> Voice_config.endpoint list
 val auth_env_name : ?endpoint_api_key_env:string -> adapter -> string option
 val endpoint_auth_env_name : Voice_config.endpoint -> string option


### PR DESCRIPTION
refactor: remove dead exports (batch 4: 102)

Same method as #27422: scripts/audit-dead-surface.py --exports selects
names whose token appears in no file other than their own .ml/.mli;
remove only the `val` from the .mli and let warning 32 decide what to
delete from the .ml, since a name unused outside its module may still be
used inside it.

79 val declarations across 22 modules. The compiler then reported 23 more
values across three rounds, including a chain the scanner cannot see
(path_from_executable / path_from_cwd -> ancestor_dirs). 102 total,
31 files, 283 deletions.

Excluded: auth/credential/sandbox/operator-control paths, names the
scanner marks as odoc-referenced entry points or facade re-exports, and
reconcile_*/validate_*/check_*/*_health_check -- an uncalled validator is
a question, not dead code (#27411, #27402, #27424).

Did not touch DEAD_EXPORT_BASELINE. #27409 is still open and edits that
same line; removals only lower the count, so the ratchet passes without
it (it reports the slack rather than failing). Whichever of the two lands
second should set the measured value.

Ratchet on this branch: 592, against main's 671 baseline.


---

## 검증

```
dune build --root . @check                            # exit 0 (3라운드 고정점)
python3 scripts/audit-dead-surface.py --exports --ratchet   # OK - 592, 671 baseline
bash scripts/ci/check-determinism-contract.sh         # DET/NDT gate: PASS
python3 scripts/verify-test-registration.py           # Unregistered 0 / Orphaned 0
dune exec ./bin/env_knob_catalog.exe -- docs/runtime-tunables.md   # exit 0, diff 없음
git diff | rg '^-include |^-open |^-exception |^-external '        # 0건
```

마지막 두 줄은 앞선 배치에서 실제로 물린 것들이라 매번 확인한다:

- **knob 카탈로그**: `env_config_*.ml` 의 **줄 번호**를 기록하므로 그 파일에서 무엇을 지우면 문서가 stale 이 된다 (#27409 가 이걸로 CI 실패). 이번엔 제거 지점이 knob 뒤라 diff 가 없다 — 생성기를 실제로 빌드해 돌리고 exit code 로 확인했다.
- **재export 표면**: `val` 삭제 범위가 `include module type of` 를 삼킨 적이 있다 (#27413). 종료 집합에 `include`/`open`/`exception`/`external`/`class` 를 넣었고 diff 로 재확인한다.

## 미검증

제거한 값들의 런타임 경로를 밟지 않았다. 모듈 밖 참조 0 + 컴파일 통과가 근거이고 정적 측정이다.
