### PR TITLE
fix(claim): give both claim paths the same refusal

### DIFF
--- a/lib/workspace/workspace_task_claim.ml
+++ b/lib/workspace/workspace_task_claim.ml
@@ -34,23 +34,44 @@ let active_owned_task_ids_for_agent config ~agent_name (backlog : Masc_domain.ba
   |> List.sort_uniq String.compare
 ;;
 
-let active_ownership_conflict_message ~agent_name ~requested_task_id task_ids =
+let held_task_label (task : Masc_domain.task) =
+  Printf.sprintf "[P%d] %s: %s" task.priority task.id task.title
+;;
+
+(* One constraint, two entry points, one sentence.
+
+   [claim_next] and a claim by task_id refuse the same thing, and they said
+   different things about it. [claim_next] named the route -- the tool, the
+   action, and the field release requires -- while a claim by task_id said
+   "Agent X has task(s) in progress: task-149; task-148 was not claimed." and
+   stopped. The Keeper prompt describes this refusal as one that "names both the
+   Task you hold and how to hand it back", which was true of one path and false
+   of the other.
+
+   The path that said nothing is the one Keepers actually hit: 38 of the week's
+   77 claim rejections, and one agent walked task-145, 146, 148, 150 and 154 in
+   turn while holding task-149 -- the run of refusals the same prompt paragraph
+   predicts. The requested task_id is no longer restated, because the caller
+   passed it. *)
+let held_tasks_refusal_message ~agent_name held_tasks =
   Printf.sprintf
-    "Agent %s has task(s) in progress: %s; %s was not claimed."
+    "%s already holds %s. Finish it, or hand it back with masc_transition \
+     action=release and a handoff_context.summary, before claiming different work."
     agent_name
-    (String.concat ", " task_ids)
-    requested_task_id
+    (String.concat ", " (List.map held_task_label held_tasks))
 ;;
 
 let active_ownership_conflict_for_claim config ~agent_name ~requested_task_id
     (backlog : Masc_domain.backlog) =
-  match
+  let held_ids =
     active_owned_task_ids_for_agent config ~agent_name backlog
     |> List.filter (fun task_id -> not (String.equal task_id requested_task_id))
+  in
+  match
+    List.filter (fun (task : Masc_domain.task) -> List.mem task.id held_ids) backlog.tasks
   with
   | [] -> None
-  | task_ids ->
-    Some (active_ownership_conflict_message ~agent_name ~requested_task_id task_ids)
+  | held_tasks -> Some (held_tasks_refusal_message ~agent_name held_tasks)
 ;;
 
 (** Result-returning version of claim_task for type-safe error handling. *)

--- a/lib/workspace/workspace_task_claim.mli
+++ b/lib/workspace/workspace_task_claim.mli
@@ -17,6 +17,12 @@ val active_owned_task_ids_for_agent :
 (** Active [Claimed] or [InProgress] tasks owned by [agent_name], using the
     same canonical keeper/agent identity comparison as task transitions. *)
 
+val held_tasks_refusal_message : agent_name:string -> Masc_domain.task list -> string
+(** The one sentence both claim paths refuse with. [claim_next] and a claim by
+    task_id enforce the same limit; before this was shared only [claim_next]
+    named the way out, so which refusal a Keeper received decided whether it was
+    told how to hand the Task back. *)
+
 val active_ownership_conflict_for_claim :
   config ->
   agent_name:string ->

--- a/lib/workspace/workspace_task_schedule.ml
+++ b/lib/workspace/workspace_task_schedule.ml
@@ -233,14 +233,9 @@ let claim_next_r
            Workspace_task.update_local_agent_state config ~agent_name (fun agent ->
              { agent with status = Busy; current_task = Some prev.id });
            let message =
-             Printf.sprintf
-               "%s already holds [P%d] %s: %s. Finish it, or hand it back with \
-                masc_transition action=release and a handoff_context.summary, \
-                before claiming different work."
-               agent_name
-               prev.priority
-               prev.id
-               prev.title
+             (* Shared with the claim-by-task_id refusal, which used to say only
+                that a task was held. One constraint, one sentence. *)
+             Workspace_task.held_tasks_refusal_message ~agent_name [ prev ]
            in
            raise
              (Existing_claim

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1944,7 +1944,11 @@ let () = test "handle_claim_rejects_when_agent_already_has_active_task" (fun () 
       (`Assoc [ ("task_id", `String "task-002") ])
   in
   assert (not (Tool_result.is_success second));
-  assert (str_contains (Tool_result.message second) "task(s) in progress: task-001");
+  (* This asserted "task(s) in progress: task-001", the wording of the by-id
+     refusal before it shared claim_next's sentence. What it was pinning -- that
+     the refusal names the Task actually held -- is unchanged. *)
+  assert (str_contains (Tool_result.message second) "already holds");
+  assert (str_contains (Tool_result.message second) "task-001");
   let task_001 =
     Workspace.get_tasks_raw ctx.config
     |> List.find_opt (fun (task : Masc_domain.task) -> String.equal task.id "task-001")
@@ -2877,6 +2881,73 @@ let () = test "transition action description does not re-list the enum" (fun () 
     List.sort compare enum_actions
     = List.sort compare Masc_domain.valid_task_action_strings))
 ;;
+
+(* [claim_next] and a claim by task_id refuse the same limit. Only [claim_next]
+   named the route; the by-id path said "has task(s) in progress: task-149;
+   task-148 was not claimed." and stopped -- and that is the path Keepers hit,
+   38 of the week's 77 claim rejections. The three tokens asserted here are the
+   same three test_workspace_coverage pins on the [claim_next] message, so the
+   two cannot drift apart again. *)
+let () =
+  test "a claim-by-id refusal names the release route, as claim_next does"
+    (fun () ->
+       let ctx = make_test_ctx_with_agent "worker" in
+       List.iter
+         (fun title ->
+            ignore
+              (Task.Tool.handle_add_task
+                 ~tool_name:"test_tool"
+                 ~start_time:0.0
+                 ctx
+                 (`Assoc [ "title", `String title ])))
+         [ "Held work"; "Tempting other work" ];
+       let held =
+         Task.Tool.handle_claim
+           ~tool_name:"keeper_task_claim"
+           ~start_time:0.0
+           ctx
+           (`Assoc [ "task_id", `String "task-001" ])
+       in
+       if not (Tool_result.is_success held) then failwith (Tool_result.message held);
+       let refused =
+         Task.Tool.handle_claim
+           ~tool_name:"keeper_task_claim"
+           ~start_time:0.0
+           ctx
+           (`Assoc [ "task_id", `String "task-002" ])
+       in
+       assert (not (Tool_result.is_success refused));
+       let message = Tool_result.message refused in
+       assert (str_contains message "task-001");
+       assert (str_contains message "Held work");
+       assert (str_contains message "masc_transition");
+       assert (str_contains message "action=release");
+       assert (str_contains message "handoff_context.summary"))
+
+(* The message tells the assignee to release, so Release has to be admitted from
+   every status that can produce the refusal. [active_owned_task_ids_for_agent]
+   returns exactly Claimed and InProgress, so those are the two to pin: an FSM
+   change that stopped admitting Release would land here rather than as advice
+   Keepers cannot follow. *)
+let () =
+  test "release is admitted from every status that can trigger that refusal"
+    (fun () ->
+       List.iter
+         (fun status ->
+            let actions =
+              Workspace_task_lifecycle.valid_next_actions ~same_agent:true
+                ~task_status:status
+            in
+            if not (List.exists (( = ) Masc_domain.Release) actions)
+            then
+              failwith
+                (Printf.sprintf
+                   "Release must stay admitted from %s, or the ownership refusal \
+                    names an action the assignee cannot take"
+                   (Masc_domain.task_status_to_string status)))
+         [ Masc_domain.Claimed { assignee = "worker"; claimed_at = "t" }
+         ; Masc_domain.InProgress { assignee = "worker"; started_at = "t" }
+         ])
 
 let () =
   ensure_test_runtime ();


### PR DESCRIPTION
## What

One constraint, two entry points, two different refusals.

```
claim_next     "worker already holds [P2] task-149: Wire the timeline panel.
                Finish it, or hand it back with masc_transition action=release
                and a handoff_context.summary, before claiming different work."

claim by id    "Agent worker has task(s) in progress: task-149;
                task-148 was not claimed."
```

Same limit. One names the tool, the action, and the field release requires. The
other names neither the way out nor what the held Task is.

The Keeper prompt describes this refusal as one that **"names both the Task you
hold and how to hand it back"** — true of the first, false of the second. A test
pins that sentence (`test_keeper_prompt_metrics`), and it passes today because
`claim_next` satisfies it.

## The path that says nothing is the one Keepers hit

```
keeper_task_claim   194 ok   77 failed
  38   the ownership limit          <- this path
  22   owned by another agent
  12   already done
   5   other
```

One agent held task-149 and was refused on task-145, 146, 148, 150 and 154 in
turn — the "run of refusals" the same prompt paragraph predicts, produced by the
refusal that never told it what to do instead.

## Change

`held_tasks_refusal_message` is now the single sentence both paths use.
`claim_next` keeps its exact wording; the by-id path adopts it, gaining the held
Task's priority and title along with the release route.

The requested task_id is no longer restated — the caller passed it.

## The prompt is unchanged

That is the point. Its sentence was already the intended contract; only one of
the two implementations kept it. Nothing was added to prose, and nothing
removed: the assembled prompt is byte-identical.

I first tried the other direction — deleting the prompt's description of the
refusal on the theory that the message should teach it. `test_keeper_prompt_metrics`
rejected that, and its comment is why: the route "moved" to the message
deliberately, with the test moving alongside it. The by-id path had simply not
been brought along.

## Tests

Added to `test_tool_task_coverage` (CI-wired):

| case | asserts |
|---|---|
| a claim-by-id refusal names the release route | `masc_transition`, `action=release`, `handoff_context.summary`, plus the held id and title |
| release is admitted from every status that can trigger it | `Release ∈ valid_next_actions` for `Claimed` and `InProgress` |

The three tokens are the same three `test_workspace_coverage` pins on the
`claim_next` message, so the two messages cannot drift apart again without one
of the two suites going red.

The second case exists because the message now tells the assignee to release.
`active_owned_task_ids_for_agent` returns exactly `Claimed` and `InProgress`, so
those are the statuses that can produce the refusal; an FSM change that stopped
admitting `Release` from either would otherwise turn the message into advice a
Keeper cannot follow.

`handle_claim_rejects_when_agent_already_has_active_task` asserted the old
wording (`"task(s) in progress: task-001"`). It now asserts what it was actually
pinning — that the refusal names the Task actually held.

## Pre-existing red, not touched

`test_workspace_coverage` fails 2 (`observability` 1 and 3) on this branch and
the same 2 on `origin/main`, verified by reverting all three lib files and
re-running. It is not in `ci.yml`. The `claim_next` release-path test in that
suite passes both ways.

## Verification

```
dune build --root . @check                                        exit 0
dune build --root . @fmt            no diff in any file this PR touches
scripts/audit-dead-surface.py --exports --ratchet    671, at baseline

test_tool_task_coverage           94 tests run   Successful
test_keeper_prompt_metrics        22 tests run   Successful
test_keeper_system_prompt_bytes    2 tests run   Successful   (unchanged bytes)
test_keeper_wake_turn_context      4 tests run   Successful
test_keeper_tool_error_text_bounded  17 tests run  Successful
test_workspace_heartbeat_outcome   3 tests run   Successful
```

The one-Task-at-a-time limit itself is **not** changed. It is deliberate
(#16059), stated in the prompt, and the prompt and code agree on it — this makes
the two refusals agree too.

RFC-WAIVED: two copies of one refusal reduced to one. No new field, no new gate,
no change to what is admitted.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
