### PR TITLE
chore(ci): #27429 · #27433 이 벌어 놓은 배선 2건을 baseline 에 잠근다

### DIFF
--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -88,7 +88,11 @@ echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, al
 # authority tools, memory journal) without lowering the baseline. A PR that
 # wires a suite must lower this number in the same PR, or this check goes red
 # for everyone.
-UNWIRED_BASELINE=714
+# 714 -> 712: #27429 wired test_goal_phase_all and #27433 wired
+# test_ws_transport, each a suite test/dune already declared, so each
+# lowered the unwired count by one without lowering this number. Measured
+# on main after both merged, not computed.
+UNWIRED_BASELINE=712
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then


### PR DESCRIPTION
## 무엇을

`UNWIRED_BASELINE` 을 714 → **712** 로 내린다. 두 PR 이 벌어 놓고 잠그지 않은 값이다.

```
#27429  test_goal_phase_all   을 배선   (test/dune 이 이미 선언하고 있던 스위트)
#27433  test_ws_transport     을 배선   (동일)
```

둘 다 `unwired` 를 1 씩 낮췄는데 `UNWIRED_BASELINE` 은 714 그대로 뒀다.

## 왜 red 가 안 났나

audit 은 `unwired > baseline` 일 때만 FAIL 이다. 내려가는 방향은 통과하고 권고만 뜬다:

```
[ci-test-targets] OK - 712 suites unwired, 714 baseline
                     - lower UNWIRED_BASELINE in scripts/audit-ci-test-targets.sh to hold the gain
```

그 설계는 맞다 — 반대로 하면 스위트를 배선하는 PR 마다 main 이 빨개진다. 스크립트 주석이 그 사고를 기록하고 있다 (`748 red → #27181 이 747 로 → 한 시간 안에 746 이 다시 red`).

대신 **잠그지 않으면 2 단위가 슬랙으로 남고, 다음에 배선 안 된 스위트가 그걸 조용히 쓴다.**

## 새로 배선한 게 아니다

이 PR 은 스위트를 추가하지 않는다. **이미 실행되고 있는 상태를 숫자에 반영할 뿐이다.**

새 스위트를 *선언과 동시에* 배선하는 경우는 declared 와 run 이 같이 올라 `unwired` 가 안 움직이므로 조정이 필요 없다. 위 두 건은 그 경우가 아니라서 조정이 필요했다.

## 검증

머지 후 main 에서 측정한 값이고 계산한 게 아니다.

```
전:  [ci-test-targets] OK - 712 suites unwired, 714 baseline — lower ...
후:  [ci-test-targets] OK - 712 suites unwired, at baseline    exit 0
```

## 왜 두 PR 을 다시 열지 않았나

둘 다 머지됐다. 병합된 브랜치에 커밋을 얹으면 main 에 도달하지 않는다. 한 곳에서 한 번에 처리한다.

RFC-WAIVED: 래칫 상수 한 줄. 판정 기준·검사 대상·실행 스위트 집합 모두 그대로다.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
