### PR TITLE
refactor: 비기본값이 도달하지 않는 optional 플래그 8개 제거 (closes #27424)

### DIFF
--- a/lib/keeper/keeper_agent_run_receipt.ml
+++ b/lib/keeper/keeper_agent_run_receipt.ml
@@ -10,7 +10,7 @@ open Keeper_meta_contract
 open Keeper_types_profile
 open Keeper_agent_result
 
-let degraded_retry_runtime_of_wire ?(log_invalid = true) ~keeper_name raw =
+let degraded_retry_runtime_of_wire ~keeper_name raw =
   let trimmed = String.trim raw in
   if String.equal trimmed "" then None
   else
@@ -35,8 +35,7 @@ let degraded_retry_runtime_of_wire ?(log_invalid = true) ~keeper_name raw =
     match first_valid candidates with
     | Some _ as parsed -> parsed
     | None ->
-      if log_invalid then
-        Log.Keeper.warn ~keeper_name:keeper_name
+      Log.Keeper.warn ~keeper_name:keeper_name
           "execution_receipt degraded_retry_runtime %S is not a \
            qualified or re-qualifiable runtime name; dropping receipt field"
           raw;

--- a/lib/keeper/keeper_unified_metrics.mli
+++ b/lib/keeper/keeper_unified_metrics.mli
@@ -135,7 +135,6 @@ val update_metrics_from_result :
   latency_ms:int ->
   observation:Keeper_world_observation.world_observation ->
   ?is_autonomous_turn:bool ->
-  ?update_proactive_rt:bool ->
   Keeper_agent_run.run_result ->
   Keeper_meta_contract.keeper_meta
 

--- a/lib/keeper/keeper_unified_metrics_result.ml
+++ b/lib/keeper/keeper_unified_metrics_result.ml
@@ -15,7 +15,6 @@ include Keeper_unified_metrics_json_support
 let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
     ~(observation : Keeper_world_observation.world_observation)
     ?(is_autonomous_turn = true)
-    ?(update_proactive_rt = true)
     (result : Keeper_agent_run.run_result) : keeper_meta =
   let now_ts = Time_compat.now () in
   let tool_names = Keeper_agent_result.tool_names result in
@@ -67,7 +66,7 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
   in
   let rt = meta.runtime in
   (* #10474: proactive outcome counter for successful cycles. *)
-  if update_proactive_rt && is_scheduled_autonomous_cycle then begin
+  if is_scheduled_autonomous_cycle then begin
     let outcome =
       if has_substantive_tools then "tool_called"
       else if is_noop_cycle ~has_text ~tools_used:tool_names
@@ -106,35 +105,31 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
       proactive_rt = {
         count_total =
           rt.proactive_rt.count_total
-          + (if update_proactive_rt && is_scheduled_autonomous_cycle then 1 else 0);
+          + (if is_scheduled_autonomous_cycle then 1 else 0);
         last_ts =
-          (if update_proactive_rt
-              && (is_scheduled_autonomous_cycle
-                  || ((is_board_reactive || is_mention_reactive)
-                      && has_meaningful_work))
+          (if is_scheduled_autonomous_cycle
+              || ((is_board_reactive || is_mention_reactive)
+                  && has_meaningful_work)
            then now_ts
            else rt.proactive_rt.last_ts);
         visible_count_total =
           rt.proactive_rt.visible_count_total
-          + (if update_proactive_rt
-               && is_scheduled_autonomous_cycle
+          + (if is_scheduled_autonomous_cycle
                && (has_text || visible_tool_signal_present)
              then 1
              else 0);
         last_visible_ts =
-          (if update_proactive_rt
-              && is_scheduled_autonomous_cycle
+          (if is_scheduled_autonomous_cycle
               && (has_text || visible_tool_signal_present)
            then now_ts
            else rt.proactive_rt.last_visible_ts);
         last_outcome =
-          (if update_proactive_rt && is_scheduled_autonomous_cycle then
+          (if is_scheduled_autonomous_cycle then
              scheduled_autonomous_outcome_of_result ~has_text
                ~has_tool_calls:visible_tool_signal_present
            else rt.proactive_rt.last_outcome);
         last_reason =
-          (if not update_proactive_rt then rt.proactive_rt.last_reason
-           else if is_scheduled_autonomous_cycle then
+          (if is_scheduled_autonomous_cycle then
              (if has_substantive_tools then
                 Printf.sprintf "unified:tools=[%s]"
                   (String.concat "," tool_names)
@@ -160,7 +155,7 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
              | Proactive_tool_use
              | Proactive_mixed_response -> rt.proactive_rt.last_reason);
         last_preview =
-          (if not update_proactive_rt || not is_scheduled_autonomous_cycle
+          (if not is_scheduled_autonomous_cycle
            then rt.proactive_rt.last_preview
            else
              select_proactive_preview
@@ -173,7 +168,7 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
                ~validated_evidence_preview:
                  (Option.map validated_evidence_preview validated_evidence));
         consecutive_noop_count =
-          (if update_proactive_rt && is_scheduled_autonomous_cycle then
+          (if is_scheduled_autonomous_cycle then
              if is_noop_cycle ~has_text ~tools_used:tool_names
              then rt.proactive_rt.consecutive_noop_count + 1
              else 0

--- a/lib/keeper/keeper_unified_metrics_result.mli
+++ b/lib/keeper/keeper_unified_metrics_result.mli
@@ -5,6 +5,5 @@ val update_metrics_from_result :
   latency_ms:int ->
   observation:Keeper_world_observation.world_observation ->
   ?is_autonomous_turn:bool ->
-  ?update_proactive_rt:bool ->
   Keeper_agent_run.run_result ->
   Keeper_meta_contract.keeper_meta

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -569,7 +569,6 @@ let handle
       lifecycle.KEC.updated_meta
       ~latency_ms
       ~observation
-      ~update_proactive_rt:true
       result
   in
   let updated_meta = acknowledge_pending_messages updated_meta observation in

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
@@ -58,7 +58,6 @@ let validate_paths ~workdir ir =
 
 let dispatch
       ?(allow_pipes = true)
-      ?(redirect_allowed = true)
       ~workdir
       ~sandbox
       ?base_host_env
@@ -69,7 +68,7 @@ let dispatch
   let gate_verdict =
     Shell_gate.gate_typed
       ~ir
-      ~syntax_policy:{ allow_pipes; redirect_allowed }
+      ~syntax_policy:{ allow_pipes; redirect_allowed = true }
       ~sandbox:{ target = sandbox }
       ()
   in

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.mli
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.mli
@@ -30,7 +30,6 @@ val validate_paths :
 
 val dispatch :
   ?allow_pipes:bool ->
-  ?redirect_allowed:bool ->
   workdir:string ->
   sandbox:Masc_exec.Sandbox_target.t ->
   ?base_host_env:string array ->

--- a/lib/otel_spans/opentelemetry_client_cohttp_eio.ml
+++ b/lib/otel_spans/opentelemetry_client_cohttp_eio.ml
@@ -481,8 +481,8 @@ let setup_ ~sw ?stop ?config env : unit =
   OT.Collector.set_backend backend
 ;;
 
-let setup ?stop ?config ?(enable = true) ~sw env =
-  if enable then setup_ ~sw ?stop ?config env
+let setup ?stop ?config ~sw env =
+  setup_ ~sw ?stop ?config env
 ;;
 
 let remove_backend () =

--- a/lib/otel_spans/opentelemetry_client_cohttp_eio.mli
+++ b/lib/otel_spans/opentelemetry_client_cohttp_eio.mli
@@ -55,7 +55,6 @@ end
 val setup :
   ?stop:bool Atomic.t ->
   ?config:Config.t ->
-  ?enable:bool ->
   sw:Eio.Switch.t ->
   Eio_unix.Stdenv.base ->
   unit

--- a/lib/server/server_dashboard_http_cache.mli
+++ b/lib/server/server_dashboard_http_cache.mli
@@ -163,15 +163,11 @@ val with_projection_diagnostics :
     diagnostic block prepended.  The convenience wrapper most
     dashboard handlers use. *)
 
-val initialized_json_opt :
-  ?allow_initializing:bool -> Yojson.Safe.t -> Yojson.Safe.t option
-(** [initialized_json_opt ?allow_initializing json] returns
-    [Some json] when [json] is an [`Assoc] with no
-    [status: "initializing"] field (or when
-    [allow_initializing = true], even with that field).  Returns
-    [None] for non-objects or initializing payloads.
+val initialized_json_opt : Yojson.Safe.t -> Yojson.Safe.t option
+(** [initialized_json_opt json] returns [Some json] when [json] is an
+    [`Assoc] with no [status: "initializing"] field.  Returns [None]
+    for non-objects and for initializing payloads.
 
-    Used to defer rendering an "initializing" envelope while the
-    cache is still warming up.  [allow_initializing] defaults to
-    [false] — the safe choice for callers that want to surface
-    "no data yet" as a 404 rather than an empty card. *)
+    Used to defer rendering an "initializing" envelope while the cache
+    is still warming up: callers surface "no data yet" as a 404 rather
+    than an empty card. *)

--- a/lib/server/server_dashboard_http_core_cache.ml
+++ b/lib/server/server_dashboard_http_core_cache.ml
@@ -142,10 +142,10 @@ let with_projection_diagnostics ~surface ~started_at ~extra json =
     (projection_diagnostics_json ~surface ~started_at ~extra json)
 ;;
 
-let initialized_json_opt ?(allow_initializing = false) = function
+let initialized_json_opt = function
   | `Assoc fields as json ->
     (match List.assoc_opt "status" fields with
-     | Some (`String "initializing") when not allow_initializing -> None
+     | Some (`String "initializing") -> None
      | _ -> Some json)
   | _ -> None
 ;;

--- a/lib/server/server_dashboard_http_core_cache.mli
+++ b/lib/server/server_dashboard_http_core_cache.mli
@@ -42,5 +42,4 @@ val with_projection_diagnostics :
   Yojson.Safe.t ->
   Yojson.Safe.t
 
-val initialized_json_opt :
-  ?allow_initializing:bool -> Yojson.Safe.t -> Yojson.Safe.t option
+val initialized_json_opt : Yojson.Safe.t -> Yojson.Safe.t option

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -81,7 +81,7 @@ let running_keeper_names ?base_path () =
        | Keeper_state_machine.Dead -> None)
   |> sorted_unique_strings
 
-let durable_paused_keeper_scan ?(include_details = true) config =
+let durable_paused_keeper_scan config =
   (* NDT-OK: HTTP health snapshots report wall-clock pause age; state transitions remain ledger-driven. *)
   let now = Unix.gettimeofday () in
   Keeper_meta_store.keeper_names config
@@ -97,15 +97,12 @@ let durable_paused_keeper_scan ?(include_details = true) config =
                  (if autoboot_enabled then meta.name :: acc.autoboot_enabled_names
                   else acc.autoboot_enabled_names);
                details =
-                 (if include_details
-                  then
-                    paused_keeper_detail_json
-                      ~now
-                      ~name:meta.name
-                      ~autoboot_enabled
-                      meta
-                    :: acc.details
-                  else acc.details);
+                 paused_keeper_detail_json
+                   ~now
+                   ~name:meta.name
+                   ~autoboot_enabled
+                   meta
+                 :: acc.details;
              }
          | Ok (Some _) | Ok None -> acc
          | Error err ->

--- a/lib/server/server_routes_http_runtime_fleet_scan.mli
+++ b/lib/server/server_routes_http_runtime_fleet_scan.mli
@@ -30,7 +30,7 @@ val paused_keeper_detail_json :
   [> `Assoc of (string * Yojson.Safe.t) list ]
 val registry_paused_keeper_names : unit -> String.t list
 val durable_paused_keeper_scan :
-  ?include_details:bool -> Workspace.config -> paused_keeper_scan
+  Workspace.config -> paused_keeper_scan
 val paused_keepers_health_json_of_scan :
   registry_paused_names:String.t list ->
   paused_keeper_scan ->

--- a/lib/tool_schemas/tool_schemas_schedule.ml
+++ b/lib/tool_schemas/tool_schemas_schedule.ml
@@ -46,9 +46,9 @@ let boolean_prop ?description name =
   name, `Assoc fields
 ;;
 
-let object_prop ?description ?(additional_properties = true) name =
+let object_prop ?description name =
   let fields =
-    [ "type", `String "object"; "additionalProperties", `Bool additional_properties ]
+    [ "type", `String "object"; "additionalProperties", `Bool true ]
     @
     match description with
     | None -> []

--- a/lib/workspace/workspace_lifecycle.ml
+++ b/lib/workspace/workspace_lifecycle.ml
@@ -204,7 +204,7 @@ let bind_session config ~agent_name ?(agent_type_override=None) ~capabilities
   end
 
 (** End agent session *)
-let end_session ?(stop_heartbeats = true) config ~agent_name =
+let end_session config ~agent_name =
   ensure_initialized config;
 
   (* Support both exact nickname match and agent_type prefix match *)
@@ -212,7 +212,7 @@ let end_session ?(stop_heartbeats = true) config ~agent_name =
 
   (* Stop any heartbeats owned by this agent *)
   let _stopped =
-    if stop_heartbeats then Heartbeat.stop_by_agent ~agent_name:actual_name else 0
+    Heartbeat.stop_by_agent ~agent_name:actual_name
   in
 
   let agent_file = Filename.concat (agents_dir config) (safe_filename actual_name ^ ".json") in

--- a/lib/workspace/workspace_lifecycle.mli
+++ b/lib/workspace/workspace_lifecycle.mli
@@ -17,7 +17,6 @@ val bind_session :
   string
 
 val end_session :
-  ?stop_heartbeats:bool ->
   Workspace_utils_backend_setup.config ->
   agent_name:string ->
   string


### PR DESCRIPTION
refactor: remove eight optional flags whose non-default never reaches the code

Closes #27424. Each is an `?(flag = X)` whose non-X value no caller passes,
so the branch under it cannot execute. `git log -S"~<name>:<non-default>"`
placed every one on the (a) side of that issue's split -- dead knob, not
unwired feature:

- include_details, update_proactive_rt, enable, additional_properties:
  zero commits ever passed the non-default. Born unused.
- log_invalid: its only `false` caller died with the "cascade" concept
  (#19600).
- redirect_allowed: the labelled-argument callers migrated to record
  literals when shell routing moved to the Shell IR facade (#18447/#18644).
  exec_policy.ml:46,51 still set `redirect_allowed = false` that way, so
  the policy difference between tool_execute and the keeper shell path is
  intact -- only the parameter was left behind.
- stop_heartbeats: the removed block read
    let heartbeats_stopped = Heartbeat.stop_by_agent ~agent_name in
    Workspace.end_session ~stop_heartbeats:false config ~agent_name
  It stopped them itself and passed false to avoid doing it twice; #24212
  deleted that path.
- allow_initializing: introduced and removed inside the early dashboard
  refresh work (#2787 -> #2831).

update_proactive_rt threaded nine conditionals in
keeper_unified_metrics_result. With the flag always true each reduces
mechanically: `flag && X` -> `X`, `not flag` -> false, so
`if not flag then A else B` -> `B` and
`if not flag || not Y then A else B` -> `if not Y then A else B`. The
record fields produced are unchanged.

allow_initializing's .mli prose described behaviour that could not occur
("...or when [allow_initializing = true], even with that field", "the safe
choice for callers..."). Rewrote it to state what the function does.

No behaviour change: every removed branch was unreachable.


---

## 검증

```
dune build --root . @check                        # exit 0
bash scripts/ci/check-determinism-contract.sh     # DET/NDT gate: PASS
python3 scripts/verify-test-registration.py       # Unregistered 0 / Orphaned 0
python3 scripts/audit-dead-surface.py --exports --ratchet   # OK - 658, at baseline
```

17 파일, +39/-60.

컴파일러가 제거를 단계별로 안내했다 — `.mli` 시그니처, facade 재export(`keeper_unified_metrics.mli`), 유일한 호출 지점(`~update_proactive_rt:true`, 기본값과 동일)까지 하나씩 지목했고 그때마다 따라갔다.

## 미검증

`update_proactive_rt` 아홉 조건의 변환은 **컴파일러가 검증하지 못한다** — 타입이 같으므로 논리 오류는 빌드를 통과한다. 각 변환을 커밋 본문에 적어두었으니 리뷰에서 대조해주면 좋겠다. 산출되는 레코드 필드는 바뀌지 않는다는 것이 주장이고, 근거는 플래그가 상수 `true` 라는 것이다.

런타임 경로를 실제로 밟아보지는 않았다.
