### PR TITLE
feat(config): provider-call deadline 을 runtime.toml durable 채널로 승격 (#27416)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1615,7 +1615,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          request_cap_targets="@test/runtest-test_runtime_config_validity @test/runtest-test_keeper_turn_driver_failover @test/runtest-test_keeper_turn_driver_accept @test/runtest-test_keeper_vision_tool @test/runtest-test_runtime_modality_reroute @test/runtest-test_runtime_model_input_tail_window @test/runtest-test_keeper_context_overflow_shrink @test/runtest-test_keeper_provider_call_deadline @test/runtest-test_keeper_runtime_resolved_observability"
+          request_cap_targets="@test/runtest-test_runtime_config_validity @test/runtest-test_keeper_turn_driver_failover @test/runtest-test_keeper_turn_driver_accept @test/runtest-test_keeper_vision_tool @test/runtest-test_runtime_modality_reroute @test/runtest-test_runtime_model_input_tail_window @test/runtest-test_keeper_context_overflow_shrink @test/runtest-test_keeper_provider_call_deadline @test/runtest-test_keeper_runtime_resolved_observability @test/runtest-test_runtime_toml_overrides"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${request_cap_targets}"
 
       - name: Run operator control suite

--- a/lib/keeper/keeper_runtime_resolved.ml
+++ b/lib/keeper/keeper_runtime_resolved.ml
@@ -67,7 +67,10 @@ let body_timeout_override_sec_live () =
    (same env var, same clamp [30, 3600]). Opt-in: unset -> None, no failsafe
    floor (#27349 -- deliberately different from stream_idle_timeout_sec's
    RFC-0345 fallback below: a total-call ceiling depends on provider and
-   workload, so MASC does not substitute a guessed value). *)
+   workload, so MASC does not substitute a guessed value).
+   Durable channel (#27416): runtime.toml [turn.provider_call_deadline_sec]
+   reaches this reader through the boot-override layer behind
+   [Env_config_core.raw_value_opt]; a set process env var still wins. *)
 let provider_call_deadline_sec_live () =
   match
     Env_config_core.raw_value_opt "MASC_KEEPER_PROVIDER_CALL_DEADLINE_SEC"

--- a/lib/keeper_runtime/keeper_runtime_config.ml
+++ b/lib/keeper_runtime/keeper_runtime_config.ml
@@ -31,6 +31,11 @@ let key_to_env =
     "proactive.enabled",                "MASC_KEEPER_PROACTIVE_ENABLED";
     (* [turn] *)
     "turn.stream_idle_timeout_sec",     "MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC";
+    (* #27416: the provider-call deadline lived only in restart-command env,
+       and 2 of 3 restarts on 2026-08-07 silently dropped it (a wedge recurred
+       in the unprotected window). TOML makes the knob survive whoever
+       restarts the server; env remains the CI/operator override. *)
+    "turn.provider_call_deadline_sec",  "MASC_KEEPER_PROVIDER_CALL_DEADLINE_SEC";
     "turn.cli_subprocess_idle_sec",     "MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC";
     "turn.capacity_limit",              "MASC_KEEPER_TURN_CAPACITY_LIMIT";
     "turn.batch_limit",                 "MASC_KEEPER_BATCH_LIMIT";
@@ -152,8 +157,7 @@ let toml_shadow : (string, string) Hashtbl.t = Hashtbl.create 16
 
 let toml_value_opt env_name = Hashtbl.find_opt toml_shadow env_name
 
-let validate_stream_idle_timeout doc =
-  let key = "turn.stream_idle_timeout_sec" in
+let validate_positive_seconds_key doc key =
   match List.assoc_opt key doc with
   | None -> Ok ()
   | Some (Keeper_toml_loader.Toml_int seconds) ->
@@ -179,6 +183,22 @@ let validate_stream_idle_timeout doc =
       | Keeper_toml_loader.Toml_local_date _
       | Keeper_toml_loader.Toml_local_time _) ->
     Error (Printf.sprintf "%s: expected a numeric TOML value" key)
+
+(* Boot-validated seconds keys. Both are opt-in liveness ceilings whose
+   readers expect a finite, positive duration; a malformed TOML value must be
+   an operator configuration error at boot, never a silent disable (the
+   deadline reader maps unparseable input to [None] = off). *)
+let validated_positive_seconds_keys =
+  [ "turn.stream_idle_timeout_sec"; "turn.provider_call_deadline_sec" ]
+
+let validate_positive_seconds_keys doc =
+  List.fold_left
+    (fun acc key ->
+       match acc with
+       | Error _ -> acc
+       | Ok () -> validate_positive_seconds_key doc key)
+    (Ok ())
+    validated_positive_seconds_keys
 
 (* Bootstrap labels its failure counter from this. It used to recover the label
    by re-reading the rendered message for a "read " or "parse " prefix, which
@@ -227,7 +247,7 @@ let load_and_apply ~base_path =
       | Error msg ->
         Error { kind = Parse; message = Printf.sprintf "%s: %s" path msg }
       | Ok doc ->
-        (match validate_stream_idle_timeout doc with
+        (match validate_positive_seconds_keys doc with
          | Error msg ->
            Error { kind = Validate; message = Printf.sprintf "%s: %s" path msg }
          | Ok () ->

--- a/lib/keeper_runtime/keeper_runtime_config.ml
+++ b/lib/keeper_runtime/keeper_runtime_config.ml
@@ -34,7 +34,10 @@ let key_to_env =
     (* #27416: the provider-call deadline lived only in restart-command env,
        and 2 of 3 restarts on 2026-08-07 silently dropped it (a wedge recurred
        in the unprotected window). TOML makes the knob survive whoever
-       restarts the server; env remains the CI/operator override. *)
+       restarts the server; env remains the CI/operator override.
+       Effective range at the reader is [30, 3600] seconds — a positive value
+       below 30 passes boot validation and is then silently raised to 30 by
+       the reader's clamp (#27355 contract, unchanged here). *)
     "turn.provider_call_deadline_sec",  "MASC_KEEPER_PROVIDER_CALL_DEADLINE_SEC";
     "turn.cli_subprocess_idle_sec",     "MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC";
     "turn.capacity_limit",              "MASC_KEEPER_TURN_CAPACITY_LIMIT";

--- a/test/test_runtime_toml_overrides.ml
+++ b/test/test_runtime_toml_overrides.ml
@@ -293,6 +293,64 @@ let test_resolved_runtime_prefers_env_over_toml () =
     "env"
     (Keeper_runtime_resolved.source_to_string runtime.stream_idle_timeout_sec.source)
 
+(* #27416: the provider-call deadline knob must survive a restart that
+   forgets the env var — TOML is the durable channel, env the override. *)
+let test_applies_provider_call_deadline_override () =
+  let doc = parse_or_fail "[turn]\nprovider_call_deadline_sec = 900\n" in
+  let count, overrides =
+    Keeper_runtime_config.resolve_overrides ~env_lookup:empty_env doc
+  in
+  check int "applied 1" 1 count;
+  check (option string) "provider call deadline"
+    (Some "900")
+    (List.assoc_opt "MASC_KEEPER_PROVIDER_CALL_DEADLINE_SEC" overrides)
+
+let test_provider_call_deadline_invalid_toml_returns_error () =
+  with_clean_boot_overrides @@ fun () ->
+  with_base_path @@ fun base_path ->
+  write_toml base_path "[turn]\nprovider_call_deadline_sec = 0\n";
+  match Keeper_runtime_config.load_and_apply ~base_path with
+  | Ok _ -> fail "expected non-positive provider call deadline to be rejected"
+  | Error failure ->
+    check bool "classified as a validate failure" true
+      (failure.Keeper_runtime_config.kind = Keeper_runtime_config.Validate);
+    check bool "diagnostic names the TOML key" true
+      (String.ends_with
+         ~suffix:
+           "turn.provider_call_deadline_sec: expected a finite, positive number of seconds"
+         (Keeper_runtime_config.load_failure_to_string failure))
+
+let test_resolved_provider_call_deadline_uses_toml () =
+  with_clean_boot_overrides @@ fun () ->
+  with_base_path @@ fun base_path ->
+  write_toml base_path "[turn]\nprovider_call_deadline_sec = 900\n";
+  (match Keeper_runtime_config.load_and_apply ~base_path with
+   | Error msg -> failf "unexpected error: %s" (Keeper_runtime_config.load_failure_to_string msg)
+   | Ok _ -> ());
+  Keeper_runtime_resolved.init ();
+  let runtime = Keeper_runtime_resolved.current () in
+  check (option (float 0.0001)) "provider call deadline from toml"
+    (Some 900.0) runtime.provider_call_deadline_sec.value;
+  check string "provider call deadline source"
+    "toml"
+    (Keeper_runtime_resolved.source_to_string runtime.provider_call_deadline_sec.source)
+
+let test_resolved_provider_call_deadline_prefers_env () =
+  with_clean_boot_overrides @@ fun () ->
+  with_base_path @@ fun base_path ->
+  write_toml base_path "[turn]\nprovider_call_deadline_sec = 900\n";
+  with_env "MASC_KEEPER_PROVIDER_CALL_DEADLINE_SEC" (Some "1200") @@ fun () ->
+  (match Keeper_runtime_config.load_and_apply ~base_path with
+   | Error msg -> failf "unexpected error: %s" (Keeper_runtime_config.load_failure_to_string msg)
+   | Ok _ -> ());
+  Keeper_runtime_resolved.init ();
+  let runtime = Keeper_runtime_resolved.current () in
+  check (option (float 0.0001)) "env provider call deadline wins"
+    (Some 1200.0) runtime.provider_call_deadline_sec.value;
+  check string "env source"
+    "env"
+    (Keeper_runtime_resolved.source_to_string runtime.provider_call_deadline_sec.source)
+
 let test_resolved_stream_idle_timeout_does_not_clamp () =
   with_clean_boot_overrides @@ fun () ->
   with_env "MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC" (Some "3600") @@ fun () ->
@@ -445,6 +503,14 @@ let () =
         ; test_case "resolved stream idle timeout uses toml" `Quick test_resolved_stream_idle_timeout_uses_toml
         ; test_case "invalid stream idle TOML returns Error" `Quick test_stream_idle_timeout_invalid_toml_returns_error
         ; test_case "wrong-type stream idle TOML returns Error" `Quick test_stream_idle_timeout_toml_wrong_type_returns_error
+        ; test_case "applies provider call deadline override (#27416)" `Quick
+            test_applies_provider_call_deadline_override
+        ; test_case "invalid provider call deadline TOML returns Error" `Quick
+            test_provider_call_deadline_invalid_toml_returns_error
+        ; test_case "resolved provider call deadline uses toml" `Quick
+            test_resolved_provider_call_deadline_uses_toml
+        ; test_case "resolved provider call deadline prefers env" `Quick
+            test_resolved_provider_call_deadline_prefers_env
         ; test_case "cli subprocess idle default 120s" `Quick test_resolved_cli_subprocess_idle_default_120s
         ; test_case "cli subprocess idle from toml" `Quick test_resolved_cli_subprocess_idle_from_toml
         ; test_case "cli subprocess idle clamps to 10s floor" `Quick test_resolved_cli_subprocess_idle_clamps_low


### PR DESCRIPTION
Closes #27416.

## 문제

`MASC_KEEPER_PROVIDER_CALL_DEADLINE_SEC`(#27355)은 재시작 명령의 env 로만 공급된다. 2026-08-07 하루 동안 서버 재시작 중 2회가 이 env 를 잃었고(`ps eww` 실측), knob 이 꺼진 창에서 kidsnote keeper 가 50분+ wedge 됐다(#27349 지문). 멀티 세션 운영에서 "재시작하는 쪽이 런북을 기억해야만 유지되는 설정"은 구조적으로 소실된다.

## 변경

기존 boot-override 인프라(`Keeper_runtime_config.key_to_env` → `Config_boot_overrides`)에 한 쌍을 추가해 **runtime.toml 을 durable 채널로, env 를 override 로** 만든다 — 형제 knob `turn.stream_idle_timeout_sec` 과 동일 경계, 새 메커니즘 없음:

- `key_to_env` 에 `"turn.provider_call_deadline_sec" → MASC_KEEPER_PROVIDER_CALL_DEADLINE_SEC` 추가. 판독기(`Keeper_runtime_resolved.provider_call_deadline_sec_live`)는 이미 `raw_value_opt` 경유라 **판독 경로 코드 변경 0** — env > TOML > default 우선순위 그대로.
- boot 검증을 키-일반화: `validate_stream_idle_timeout` → `validate_positive_seconds_key` + 두 키 목록 fold (`validate_positive_seconds_keys`). deadline 판독기는 unparseable 입력을 None(=off)으로 조용히 강등하므로, TOML 오타가 silent disable 이 되지 않게 boot 에서 Validate 에러로 승격한다. 기존 stream_idle 검증 의미론·에러 문구 불변 (기존 테스트 무수정 통과가 증거).
- `Keeper_runtime_resolved` SSOT 주석에 durable 채널 명시.
- **CI 배선**: `test_runtime_toml_overrides` 스위트는 지금까지 @check 컴파일만 되고 실행되지 않았다 — request-cap 타깃 그룹(형제 `test_keeper_provider_call_deadline` 이 이미 있는 곳)에 추가.

코드 기본값(None=off)은 뒤집지 않는다 — #27349 의 "총 호출 상한은 provider/워크로드 의존이라 MASC 가 추정값을 대입하지 않는다" 결정을 유지하고, 영속화는 운영 설정(라이브 `~/.masc/config/runtime.toml` 에 900 투입 완료, 백업 `.bak-20260807-deadline`)이 담당한다.

## 검증

- `dune build --root . lib/keeper_runtime/ lib/keeper/ test/test_runtime_toml_overrides.exe`: PASS
- `dune exec test/test_runtime_toml_overrides.exe`: **30/30 pass** (기존 26 무수정 + 신규 4: resolve 매핑 / invalid TOML → Validate 에러 / resolved toml 소스 / env-wins)
- `ocamlformat --check` (touched 3 files): PASS

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
