### PR TITLE
ci: 도구 입력 검증 스위트를 실제로 실행한다 (86개 단정 미실행)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1377,6 +1377,12 @@ jobs:
       # declaration masc holds is reachable and readable by that
       # enforcement, and that artifact-read rejections name the field that
       # actually failed without changing which requests are served.
+      #
+      # test_tool_input_validation is the presence half of the same boundary:
+      # a missing required field is rejected, a tool with no registered schema
+      # is refused rather than dispatched, and declared types are coerced or
+      # rejected. It was declared in test/dune and named by no CI step, so
+      # those 86 assertions compiled and never ran.
       - name: Run tool input constraint enforcement suite
         id: tool_input_constraint_enforcement_suite
         if: ${{ always() && steps.build_step.outcome == 'success' }}
@@ -1387,7 +1393,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          constraint_targets="@test/runtest-test_tool_schema_constraint_enforcement @test/runtest-test_keeper_artifact_read_request"
+          constraint_targets="@test/runtest-test_tool_schema_constraint_enforcement @test/runtest-test_keeper_artifact_read_request @test/runtest-test_tool_input_validation"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${constraint_targets}"
 
       # The tool-call quality benchmark scores keeper runs against selectors

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -88,7 +88,7 @@ echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, al
 # authority tools, memory journal) without lowering the baseline. A PR that
 # wires a suite must lower this number in the same PR, or this check goes red
 # for everyone.
-UNWIRED_BASELINE=714
+UNWIRED_BASELINE=711
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then


### PR DESCRIPTION
## 문제

`test_tool_input_validation` 이 `test/dune` 에 선언돼 있고 CI 의 어느 스텝도 이름을 부르지 않는다. 86개 단정이 컴파일만 되고 실행되지 않았다.

이 스위트가 고정하는 것은 모든 MCP 도구의 입력 경계다.

- required 필드 누락 → `Reject` (`test_required_missing`)
- 스키마가 등록되지 않은 도구 → dispatch 거부 (`missing_schema`)
- 선언된 타입의 강제/coercion, `oneOf` const 판별자

옆 스텝이 이미 같은 경계의 **범위(bounds)** 쪽을 돌리고 있다 (`test_tool_schema_constraint_enforcement`, `test_keeper_artifact_read_request`). 이건 그 경계의 **존재(presence)** 쪽인데 빠져 있었다.

## 확인

```
$ rg -c 'runtest-test_tool_input_validation' .github/workflows/ci.yml
0
$ rg -c '^  test_tool_input_validation$' test/dune
2
$ dune build --root . @runtest-test_tool_input_validation
Test Successful in 0.014s. 86 tests run.
```

## 변경

`constraint_targets` 에 `@test/runtest-test_tool_input_validation` 추가. 새 스텝을 만들지 않고 같은 스텝에 넣었다 — 주제가 동일하고, 스텝 주석에 이 스위트가 무엇을 고정하는지 적었다.

`UNWIRED_BASELINE` 714 → 711.

## 범위 밖

`Workspace_assertions.handle_check` 는 `assertions` 가 빈 배열이면 `["task_claimed"; "current_task_set"]` 를 대신 검사한다. 스키마에 `minItems` 가 없어 `[]` 는 유효하고, 호출자는 요청하지 않은 두 단정의 결과를 돌려받는다. required 자체는 이 PR 이 배선하는 검증기가 막고 있어 누락 경로는 도달 불가다. 빈 배열 쪽은 별도 판단이 필요해 건드리지 않았다.
