### PR TITLE
fix(ide): IDE 브리지 텍스트를 글자 중간에서 자르지 않는다

### DIFF
--- a/lib/ide/dune
+++ b/lib/ide/dune
@@ -27,4 +27,5 @@
   masc.attribution
   masc.masc_process
   masc.agent_observation
-  masc.masc_exec))
+  masc.masc_exec
+  masc_core))

--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -443,9 +443,13 @@ let ingest_tool_event
     ~timestamp_ms
     ()
   =
+  (* [String.sub] cuts at a byte, which splits a multi-byte character: a
+     Korean summary is 3 bytes per character, so a raw cut at 200 emits an
+     incomplete sequence roughly two times in three. [utf8_safe] backs the
+     cut up to a character boundary and budgets for the suffix. *)
   let truncated_summary =
-    if String.length summary > 200 then String.sub summary 0 200 ^ "..."
-    else summary
+    String_util.utf8_safe ~max_bytes:200 ~suffix:"..." summary
+    |> String_util.to_string
   in
   let event =
     Tool_event
@@ -706,8 +710,8 @@ let ingest_tool_event_from_hook
   =
   let file_path = Tool_input_path.tool_input_file_path input in
   let summary =
-    if String.length output_text > 200 then String.sub output_text 0 200
-    else output_text
+    String_util.utf8_safe ~max_bytes:200 ~suffix:"" output_text
+    |> String_util.to_string
   in
   let timestamp_ms = now_ms () in
   ingest_tool_event


### PR DESCRIPTION
fix(ide): stop cutting IDE bridge text mid-character

ide_bridge truncated two user-facing strings with String.sub at byte 200:
the event summary (:447) and tool output_text (:709). String.sub cuts at a
byte, so a multi-byte character straddling the limit is emitted as an
incomplete sequence.

Reproduced on Korean text, which is 3 bytes per character:

  원문 bytes=1120
  바이트 절단 후 마지막 4바이트: ec 9e 91 ec
  유효한 UTF-8 인가: false

The trailing `ec` is a lead byte with no continuation bytes behind it.

String_util.utf8_safe already does this correctly -- it backs the cut up to
a character boundary via utf8_char_boundary and budgets for the suffix, so
`prefix ^ "..."` still fits max_bytes. lib/ide had no UTF-8 handling at all
(`rg -c 'utf8|Utf8|UTF' lib/ide/ide_bridge.ml` returns nothing), so this
adds masc_core to lib/ide/dune. No dependency cycle: dune build @check
passes.

Behaviour change is confined to inputs that previously produced broken
bytes. ASCII input is byte-identical, since utf8_safe returns Untouched
below the limit and cuts at the same offset when every character is one
byte.


---

## 검증

```
dune build --root . @check                        # exit 0 (masc_core 추가 후 순환 없음)
bash scripts/ci/check-determinism-contract.sh     # DET/NDT gate: PASS
python3 scripts/verify-test-registration.py       # Unregistered 0 / Orphaned 0
```

**통과가 아니라 실패로 검증했다** — 수정 전 동작을 그대로 재현해 잘린 결과가 유효하지 않은 UTF-8 임을 확인한 뒤 고쳤다. 위 커밋 본문의 바이트 덤프가 그 출력이다.

## 이 축에서 확인한 다른 지점 (건드리지 않음)

`String.sub s 0 N` 58 지점을 훑었고 대부분 안전하다 — hex digest, ASCII 접두사 비교(`= "UTC"`, `= "policy:"`), 이미 `[^a-zA-Z0-9_-]` 로 정제된 파일명.

**오탐 하나를 실측으로 기각했다**: `mcp_server.ml:45` 가 라벨을 2 바이트로 자르길래 한국어면 반드시 깨진다고 봤는데, 호출자를 따라가니 라벨이 전부 하드코딩 ASCII 리터럴(`"RD"`, `"WR"`, `"TXT"`, `"JS"`, `"MC"`)이라 사용자 텍스트가 들어오지 않는다.

남은 두 곳은 이 PR 범위 밖으로 둔다:

- `workspace_state.ml:100` — `Yojson.Safe.to_string json` 을 500 바이트로 잘라 **경고 로그**에 넣는다. 로그 진단이라 영향이 낮다.
- `types_core.ml:147` — JSON `` `String `` 값을 37 바이트로 잘라 표시한다. 같은 처리가 맞지만 `lib/types` 는 의존성이 더 얇아 `masc_core` 추가 여부를 따로 판단해야 한다.
