### PR TITLE
refactor(dashboard): 실제로 emit 되는 attribution gate 만 나열한다 (7개 → 1개)

### DIFF
--- a/dashboard/src/components/attribution-panel.ts
+++ b/dashboard/src/components/attribution-panel.ts
@@ -26,21 +26,13 @@ import { isAbortError } from '../lib/async-state'
 const POLL_INTERVAL_MS = 5_000
 const RECENT_LIMIT = 50
 
-// Gates rendered as cards even before they emit, so the operator sees the full
-// known set with zero counts. Backend-emitted gates outside this list are
-// appended from the live attribution data (see gatesToRender) so none is
-// silently dropped. Backend currently emits accountability, exec_policy,
-// keeper_fsm and verification (lib `Attribution.* ~gate:"..."`); the rest are
-// forward-declared and show zero until their source is wired.
-const KNOWN_GATES = [
-  'verification',
-  'exec_policy',
-  'keeper_fsm',
-  'worker_dev_tools',
-  'accountability',
-  'oas_completion',
-  'agent_lifecycle',
-] as const
+// The gates the backend emits. Every Attribution constructor call in masc
+// passes gate:"keeper_fsm" (keeper_state_machine.ml:544/547 and the
+// policy_failed sites), so this is the whole set. A gate outside this list
+// still gets a card from the live data (see gatesToRender), which is what
+// makes listing a gate ahead of its first emission unnecessary: the six
+// entries that used to sit here rendered a zero card forever.
+const KNOWN_GATES = ['keeper_fsm'] as const
 
 // Render order: the known set first (stable, including empty placeholders), then
 // any other gate present in live data, sorted. A backend gate missing from

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -112,19 +112,12 @@ export type JournalSource = 'structured' | 'legacy_stderr' | 'legacy_traceln' | 
 
 export type AttributionOrigin = 'det' | 'nondet'
 
-// Known gate identifiers. Kept open ('string') so new gates can emit without
-// a client update, but enumerating canonical values gives us autocomplete and
-// catches typos.
-export type AttributionGate =
-  | 'verification'
-  | 'exec_policy'
-  | 'accountability'
-  | 'keeper_fsm'
-  | 'oas_completion'
-  | 'agent_lifecycle'
-  | 'task_transition'
-  | 'worker_dev_tools'
-  | string
+// The gate a backend attribution record carries. Open by contract: a new
+// gate emits without a client update. The union of named values that used to
+// sit here ended in '| string', which absorbs every other string, so it
+// caught no typo and gave no exhaustiveness — only the appearance of both.
+// The gates masc actually emits live in attribution-panel's KNOWN_GATES.
+export type AttributionGate = string
 
 // Gate decision outcome. Discriminated union — exhaustive switch on 'kind'.
 export type AttributionOutcome =


### PR DESCRIPTION
## 문제

attribution gate 이름이 대시보드에 두 벌 있고, 둘 다 서버가 내보내는 것과 다르다.

**서버가 내보내는 gate 는 하나다.** `Attribution` 생성자 호출 지점을 전수하면:

```
$ rg -o '~gate:"[a-z_]+"' lib bin --glob '!_build' | sort | uniq -c
   4 ~gate:"keeper_fsm"
$ rg -c 'Attribution\.(passed|policy_failed|transition_blocked|partial_pass)' lib bin
passed 1 / policy_failed 3 / transition_blocked 1 / partial_pass 0
```

전부 `keeper_state_machine.ml` 안이고 전부 `keeper_fsm` 이다.

**목록 1** — `attribution-panel.ts:35` 의 `KNOWN_GATES` 는 7개를 나열하고, 주석은 네 개가 나온다고 적었다.

```
// Backend currently emits accountability, exec_policy,
// keeper_fsm and verification (lib `Attribution.* ~gate:"..."`); the rest are
// forward-declared and show zero until their source is wired.
```

실제로는 `keeper_fsm` 하나다. 나머지 6개는 영구히 0인 카드를 렌더한다.

**목록 2** — `types/sse.ts:118` 의 `AttributionGate` 는 8개를 나열한 뒤 `| string` 을 붙인다. 주석은 "enumerating canonical values gives us autocomplete and catches typos" 라고 하는데, `| string` 이 모든 문자열을 흡수하므로 오타를 잡지 못한다. 두 목록은 서로도 다르다 — `task_transition` 은 목록 2에만 있다.

## 변경

- `KNOWN_GATES = ['keeper_fsm']` — 서버가 내보내는 것만.
- `AttributionGate = string` — 계약대로 열려 있음을 그대로 적는다. 잡지 못하는 걸 잡는다고 주장하는 주석을 사실로 교체.

## 잃는 것이 없는 이유

`gatesToRender` 가 known 목록 뒤에 실데이터의 미지 gate 를 덧붙인다.

```ts
const extras = [...dataGates].filter(g => !knownSet.has(g)).sort()
return [...known, ...extras]
```

새 gate 가 emit 되기 시작하면 목록에 없어도 카드가 뜬다. 즉 emit 전에 이름을 올려둘 이유가 없다.

## 검증

```
npx tsc --noEmit                                  → 0
npx vitest run src/components/attribution-panel.test.ts
  Test Files 1 passed / Tests 16 passed
```

## 범위 밖

`Attribution.partial_pass` 는 프로덕션 호출자가 0이지만 `test_attribution` / `test_dashboard_attribution` 이 쓰므로 남겼다.

발견 경위: 하드코딩 스윕에서 TS 의 닫힌 문자열 목록 37개를 OCaml 리터럴과 대조. 같은 계열의 큰 건은 #27448 (blocker_class 서버 16 / 대시보드 20, 교집합 7).
