### PR TITLE
feat(goal): show the Goals nobody took (RFC-0362 §6 Q2)

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -693,25 +693,23 @@ let active_goal_summaries
     meta.active_goal_ids
 ;;
 
-(* RFC-0362 §4.3 — the one consumer of [goal.owner].
+(* RFC-0362 §4.3 — the consumers of [goal.owner].
 
-   A Goal this keeper owns, still executing, with no Task linked to it, is a
-   fact the owner is positioned to act on and nobody else is. It is stated, not
-   demanded: no gate, no cap, no required action, and no empty case is named
-   (#26901 — naming the empty branch is what produced the flood it replaced).
+   A Goal still executing with no Task linked to it is a fact somebody is
+   positioned to act on. Which somebody depends on [owner], and that is the only
+   thing the two callers below disagree about, so the walk is shared: same phase
+   filter, same task index, same empty case.
+
+   It is stated, not demanded: no gate, no cap, no required action, and no empty
+   case is named (#26901 — naming the empty branch is what produced the flood it
+   replaced).
 
    The 0-of-10 measurement in RFC-0362 §1 is exactly this predicate over the
-   live store, so the RFC's acceptance criterion reads off this list moving. *)
-let owned_executing_goals_without_tasks
-      ~(config : Workspace.config)
-      ~(keeper_name : string)
-  =
+   live store, so the RFC's acceptance criterion reads off these lists moving. *)
+let executing_goals_without_tasks ~(config : Workspace.config) ~owner_matches =
   let goals =
     List.filter
-      (fun (g : Goal_store.goal) ->
-         match g.owner with
-         | Some o -> String.equal o keeper_name
-         | None -> false)
+      (fun (g : Goal_store.goal) -> owner_matches g.owner)
       (Goal_store.list_goals config ())
   in
   match goals with
@@ -728,6 +726,36 @@ let owned_executing_goals_without_tasks
            | Some (_ :: _) -> None
            | None | Some [] -> Some (g.id, g.title)))
       goals
+;;
+
+let owned_executing_goals_without_tasks
+      ~(config : Workspace.config)
+      ~(keeper_name : string)
+  =
+  executing_goals_without_tasks ~config ~owner_matches:(function
+    | Some owner -> String.equal owner keeper_name
+    | None -> false)
+;;
+
+(* RFC-0362 §6 Q2, which the RFC left open: "Should [phase = executing] with
+   [owner = None] be surfaced? It is the exact state of all ten live Goals and
+   nothing reports it today."
+
+   The Keeper prompt already commits to the policy — "an unowned Goal is intent
+   nobody picked up, not an error, and taking one is a move you can make" — and
+   [handle_goal_assign] carries no ownership check, so any Keeper can in fact
+   take one. What was missing was the sighting: with 15 of 16 live Goals unowned,
+   the owned list above renders for nobody, and [meta.active_goal_ids] carries
+   one stale pointer to a Completed Goal. Both Goal blocks were empty for all
+   eight Keepers while ten executing Goals sat untouched for 6-8 days.
+
+   Same shape as the owned list and the same restraint: it names a fact, and
+   renders nothing when there is nothing to name. It does not pick an owner
+   (RFC-0362 §5) and asks for no action. *)
+let unowned_executing_goals_without_tasks ~(config : Workspace.config) =
+  executing_goals_without_tasks ~config ~owner_matches:(function
+    | Some _ -> false
+    | None -> true)
 ;;
 
 let build_system_prompt ~(meta : Keeper_meta_contract.keeper_meta)
@@ -856,9 +884,10 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta)
             ^ "\n\n")
         else None
       in
-      (* RFC-0362 §4.3. Rendered independently of [active_goal_ids]: that field
-         is a keeper-side pointer nothing writes today, so hanging this off it
-         would show nothing. Ownership lives on the Goal. *)
+      (* RFC-0362 §4.3. Rendered independently of [active_goal_ids]: on the live
+         workspace that keeper-side pointer is set for one Keeper and points at a
+         Completed Goal, which the phase filter above drops, so hanging this off
+         it would show nothing. Ownership lives on the Goal. *)
       let owned_block =
         match owned_executing_goals_without_tasks ~config ~keeper_name:meta.name with
         | [] -> None
@@ -875,11 +904,27 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta)
                         else Printf.sprintf "- %s — %s" goal_id title)
                      goals)))
       in
-      (match active_block, owned_block with
-       | None, None -> None
-       | Some a, None -> Some a
-       | None, Some o -> Some o
-       | Some a, Some o -> Some (a ^ o))
+      (* RFC-0362 §6 Q2. An unowned executing Goal is addressed to whoever reads
+         it, so it is the same fact for every Keeper and rendered to each. *)
+      let unowned_block =
+        match unowned_executing_goals_without_tasks ~config with
+        | [] -> None
+        | goals ->
+          Some
+            (Printf.sprintf
+               "### Unowned Goals, no Task yet — taking one is a move you can make (%d)\n%s\n\n"
+               (List.length goals)
+               (String.concat "\n"
+                  (List.map
+                     (fun (goal_id, title) ->
+                        if String.trim title = ""
+                        then Printf.sprintf "- %s" goal_id
+                        else Printf.sprintf "- %s — %s" goal_id title)
+                     goals)))
+      in
+      (match List.filter_map Fun.id [ active_block; owned_block; unowned_block ] with
+       | [] -> None
+       | blocks -> Some (String.concat "" blocks))
     (* 1b. Current task — the claim that admitted this turn (RFC-0315).
        Standing context: changes on claim/release, not per cycle. *)
     | Keeper_context_layers.Current_task ->

--- a/lib/keeper/keeper_unified_prompt.mli
+++ b/lib/keeper/keeper_unified_prompt.mli
@@ -62,11 +62,22 @@ val owned_executing_goals_without_tasks :
 (** RFC-0362 §4.3 — the Goals this keeper owns that are still executing and
     carry no linked Task. Read from [goal.owner], not from
     [meta.active_goal_ids]: ownership lives on the Goal, and that keeper-side
-    pointer is empty for every keeper on the live workspace.
+    pointer names a Completed Goal for the one keeper that has it set.
 
     The RFC's acceptance criterion (§4.3) reads off this list: the measured
     0-of-10 executing goals with a Task must move, or the owner field is
     decoration and should be removed. *)
+
+val unowned_executing_goals_without_tasks :
+  config:Workspace.config -> (string * string) list
+(** RFC-0362 §6 Q2 — the executing Goals nobody owns and no Task serves. The
+    same list for every keeper, because an unowned Goal is addressed to whoever
+    reads it.
+
+    The prompt already states that taking one is a move a keeper can make, and
+    [handle_goal_assign] carries no ownership check. What was missing was the
+    sighting: with 15 of 16 live Goals unowned,
+    {!owned_executing_goals_without_tasks} renders for nobody. *)
 
 val active_goal_summaries :
   config:Workspace.config ->

--- a/test/test_keeper_goal_phase_projection.ml
+++ b/test/test_keeper_goal_phase_projection.ml
@@ -225,6 +225,123 @@ let test_another_keepers_goal_is_not_surfaced () =
             ~keeper_name:"owner-keeper")))
 ;;
 
+(* RFC-0362 §6 Q2. The owned list above renders for nobody while 15 of 16 live
+   Goals are unowned, so ten executing Goals were visible at no surface. These
+   pin the sighting and, more importantly, that it stays as narrow as the owned
+   one: same phase filter, same "already has a Task" exclusion. *)
+
+let unowned config = List.map fst (Keeper_unified_prompt.unowned_executing_goals_without_tasks ~config)
+
+let test_unowned_executing_goal_without_task_surfaces () =
+  with_workspace (fun config ->
+    Goal_store.write_state config
+      { version = 1
+      ; updated_at = Masc_domain.now_iso ()
+      ; goals =
+          [ goal_in Goal_phase.Executing "goal-open" "nobody holds this"
+          ; goal_owned_by "someone" Goal_phase.Executing "goal-theirs" "taken"
+          ]
+      };
+    check (list string) "only the unowned executing goal" [ "goal-open" ] (unowned config))
+;;
+
+(* The two lists partition the Goals: an owner sees theirs, everyone sees the
+   ones nobody took, and no Goal appears in both. *)
+let test_owned_and_unowned_lists_do_not_overlap () =
+  with_workspace (fun config ->
+    Goal_store.write_state config
+      { version = 1
+      ; updated_at = Masc_domain.now_iso ()
+      ; goals =
+          [ goal_owned_by "owner-keeper" Goal_phase.Executing "goal-mine" "mine"
+          ; goal_in Goal_phase.Executing "goal-open" "free"
+          ]
+      };
+    let owned =
+      List.map fst
+        (Keeper_unified_prompt.owned_executing_goals_without_tasks
+           ~config
+           ~keeper_name:"owner-keeper")
+    in
+    check (list string) "owner sees only their own" [ "goal-mine" ] owned;
+    check (list string) "everyone sees only the untaken one" [ "goal-open" ] (unowned config))
+;;
+
+let test_terminal_unowned_goal_is_not_surfaced () =
+  with_workspace (fun config ->
+    Goal_store.write_state config
+      { version = 1
+      ; updated_at = Masc_domain.now_iso ()
+      ; goals =
+          [ goal_in Goal_phase.Completed "goal-done" "achieved"
+          ; goal_in Goal_phase.Dropped "goal-gone" "abandoned"
+          ]
+      };
+    check (list string) "a finished Goal is not an invitation" [] (unowned config))
+;;
+
+(* The name says "without tasks". A Goal somebody is already working is not an
+   invitation, whoever owns it. *)
+let test_unowned_goal_with_a_linked_task_is_not_surfaced () =
+  with_workspace (fun config ->
+    Goal_store.write_state config
+      { version = 1
+      ; updated_at = Masc_domain.now_iso ()
+      ; goals =
+          [ goal_in Goal_phase.Executing "goal-served" "already has work"
+          ; goal_in Goal_phase.Executing "goal-open" "has none"
+          ]
+      };
+    ignore
+      (Workspace.add_task
+         ~goal_id:"goal-served"
+         config
+         ~title:"Work on the served goal"
+         ~priority:2
+         ~description:"");
+    check (list string) "a Goal with a Task is not an open invitation"
+      [ "goal-open" ]
+      (unowned config))
+;;
+
+(* The helper cases above prove which Goals qualify. This proves a Keeper is
+   actually handed them: the block is what closes RFC-0362 §6 Q2, and a correct
+   list nobody renders is the state this change exists to end. *)
+let test_unowned_goals_reach_the_rendered_turn () =
+  with_workspace @@ fun config ->
+  Goal_store.write_state config
+    { version = 1
+    ; updated_at = Masc_domain.now_iso ()
+    ; goals =
+        [ goal_in Goal_phase.Executing "goal-open" "nobody holds this"
+        ; goal_in Goal_phase.Completed "goal-done" "already achieved"
+        ]
+    };
+  let meta = meta_with_goals [] in
+  let observation =
+    Keeper_world_observation.observe ~pending_board_events:(Some []) ~config ~meta
+  in
+  let { Keeper_unified_prompt.world_state; _ } =
+    Keeper_unified_prompt.build_prompt
+      ~meta
+      ~config
+      ~turn_decision:(Keeper_world_observation.keeper_cycle_decision ~meta observation)
+      ~current_task:Keeper_world_observation_inputs.No_current_task
+      ~observation
+      ()
+  in
+  let contains needle =
+    let n = String.length needle and h = String.length world_state in
+    let rec go i = i + n <= h && (String.sub world_state i n = needle || go (i + 1)) in
+    n = 0 || go 0
+  in
+  check bool "the heading names the move the prompt already promises" true
+    (contains "### Unowned Goals, no Task yet — taking one is a move you can make (1)");
+  check bool "the goal is named with its title" true
+    (contains "- goal-open — nobody holds this");
+  check bool "a completed goal is not offered" false (contains "goal-done")
+;;
+
 let () =
   run "keeper_goal_phase_projection"
     [ ( "prompt surfaces"
@@ -244,6 +361,18 @@ let () =
             test_owner_of_a_terminal_goal_is_told_nothing
         ; test_case "another keeper's goal is not surfaced" `Quick
             test_another_keepers_goal_is_not_surfaced
+        ] )
+    ; ( "rfc-0362 q2 unowned sighting"
+      , [ test_case "unowned executing goal without a task surfaces" `Quick
+            test_unowned_executing_goal_without_task_surfaces
+        ; test_case "owned and unowned lists do not overlap" `Quick
+            test_owned_and_unowned_lists_do_not_overlap
+        ; test_case "terminal unowned goal is not surfaced" `Quick
+            test_terminal_unowned_goal_is_not_surfaced
+        ; test_case "unowned goal with a linked task is not surfaced" `Quick
+            test_unowned_goal_with_a_linked_task_is_not_surfaced
+        ; test_case "unowned goals reach the rendered turn" `Quick
+            test_unowned_goals_reach_the_rendered_turn
         ] )
     ]
 ;;


### PR DESCRIPTION
Answers RFC-0362 §6 Q2, which that RFC left open:

> 2. Should `phase = executing` with `owner = None` be surfaced? It is the exact
>    state of all ten live Goals and **nothing reports it today.**

## What

Ten executing Goals have sat unowned and untouched for 6–8 days, visible at no
surface. The Keeper turn renders two Goal blocks and both are empty for all
eight Keepers:

```
### Active Goals              from meta.active_goal_ids
                              1 of 8 Keepers has it set; it points at a Goal
                              Completed on 08-04, which the phase filter drops
### Goals you own, no Task    from goal.owner
                              15 of 16 live Goals are unowned, so this renders
                              for nobody
```

The prompt already commits to the policy this makes possible:

> A Goal you write has no owner until someone takes it: an unowned Goal is
> intent nobody picked up, not an error, and **taking one is a move you can
> make.**

And `handle_goal_assign` carries no ownership check, so any Keeper can in fact
take one. Permission was there and the invitation was in the prompt. **The
sighting was missing.**

Live, over a week: `masc_goal_assign` 1 call, `masc_goal_transition` 17,
`masc_goal_list` 23 — against 32,082 collaboration reads.

## Change

One walk, two callers. `owned_executing_goals_without_tasks` and the new
`unowned_executing_goals_without_tasks` differ only in the predicate on
`owner`, so the phase filter, the task-link index and the empty case are shared
rather than copied:

```ocaml
let executing_goals_without_tasks ~config ~owner_matches = ...

let owned_...   = executing_goals_without_tasks ~config ~owner_matches:(function
  | Some owner -> String.equal owner keeper_name | None -> false)

let unowned_... = executing_goals_without_tasks ~config ~owner_matches:(function
  | Some _ -> false | None -> true)
```

The block sits under the same layer as the owned one:

```
### Unowned Goals, no Task yet — taking one is a move you can make (1)
- goal-open — nobody holds this
```

## Why this is not the thing RFC-0362 §5 forbids

- **No auto-assignment.** Nothing picks an owner. The list is a sighting.
- **No required action.** No gate, no cap, nothing demanded — same restraint as
  §4.3, which states a fact and asks for nothing.
- **No empty case.** `[] -> None`, per #26901: naming the empty branch is what
  produced the flood that lesson came from.
- **No prompt change.** `keeper.md` is untouched and the assembled bytes are
  identical. The prose already promised this; only the render was missing.

## Why I implemented an open question

It is an RFC open question, so it is the merge decision — this is a Draft.

What moved me to write it rather than wait: the policy is not actually open.
`keeper.md` states it, `handle_goal_assign` implements it, and the only thing
absent is the view. That makes this the same shape as the prompt-vs-code gaps
closed in #27350, #27353, #27361, #27374 and #27436 — the prompt asserts
something the code does not deliver.

## Tests

Five cases in `test_keeper_goal_phase_projection`, which CI runs (7 → 12):

| case | asserts |
|---|---|
| unowned executing goal without a task surfaces | the owned one beside it does not |
| owned and unowned lists do not overlap | the two partition the Goals |
| terminal unowned goal is not surfaced | Completed and Dropped are not invitations |
| unowned goal with a linked task is not surfaced | "without tasks" holds regardless of owner |
| **unowned goals reach the rendered turn** | the heading and the line appear in `world_state`; a Completed Goal does not |

The last one exists because a correct list nobody renders is exactly the state
this change ends. The owned block has no equivalent test; this one does.

Verified not identities, by two mutations:

```
owner predicate  Some _ -> false  →  Some _ -> true
  [FAIL] unowned executing goal without a task surfaces
  [FAIL] owned and unowned lists do not overlap

render          the block forced to []       (call kept, so it still compiles)
  [FAIL] unowned goals reach the rendered turn
```

Dropping `unowned_block` from the concat outright does not compile — warning 26
catches it first, which is its own guard.

## Verification

```
dune build --root . @check                                        exit 0
dune build --root . @fmt            no diff in any file this PR touches
scripts/audit-dead-surface.py --exports --ratchet    658, at baseline
scripts/ocaml-structure-ratchet.sh                                    OK
scripts/audit-sublib-cycle.py                     OK - 34 leaf libraries clean

test_keeper_goal_phase_projection    12 tests run   Successful   (was 7)
test_keeper_wake_turn_context        14 tests run   Successful
test_goal_scope_terminal_phase       12 tests run   Successful
test_keeper_system_prompt_bytes       2 tests run   Successful   (bytes unchanged)
test_keeper_prompt_metrics           22 tests run   Successful
test_keeper_prompt_capture            5 tests run   Successful
test_keeper_surface_presence_prompt   6 tests run   Successful
test_goal_store                      16 tests run   Successful
```

## How to falsify this

RFC-0362's acceptance criterion is the test, unchanged: `executing goals with a
task` must move off 0 of 10. If it does not move after this ships, then Keepers
were shown the Goals and still did not take them, and the RFC's own conclusion —
that `goal.owner` is decoration and should be removed — gets stronger, not
weaker.

RFC-0362 §6 Q2. Answered, not waived.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
