### PR TITLE
ci: 실행되지 않던 린트 26개를 배선한다 (closes #27447)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1832,6 +1832,25 @@ jobs:
       - name: Run dashboard agent-status SSOT lint (RFC-0139 §10)
         run: bash scripts/lint/dashboard-ssot-agent-status.sh
 
+      # 32 scripts live in scripts/lint/; before this step six of them ran.
+      # The other 26 were written, committed, and never executed. They all
+      # pass on the tree as of this change, so wiring them costs nothing now
+      # and makes the next violation fail here instead of landing.
+      #
+      # Globbing rather than listing: a lint added to the directory should
+      # run without a second edit here, which is exactly how the 26 accrued.
+      - name: Run every scripts/lint shell check
+        run: |
+          set -euo pipefail
+          failed=0
+          for f in scripts/lint/*.sh; do
+            if ! bash "$f"; then
+              echo "::error title=lint failed::$f"
+              failed=1
+            fi
+          done
+          exit "$failed"
+
       - name: Check Eio conventions
         run: |
           chmod +x scripts/check-eio-conventions.sh


### PR DESCRIPTION
ci: run every scripts/lint check, not the six that were wired

scripts/lint/ holds 32 shell checks. The workflows referenced six:

  $ ls scripts/lint/*.sh | wc -l                                          # 32
  $ rg -o 'scripts/lint/[a-z0-9-]*\.sh' .github/workflows/ | sort -u | wc -l   # 6

The other 26 were written, committed, and never executed. There is no
aggregator either -- audit-code-smell.sh references a different
scripts/lint-*.sh path and runs on a weekly schedule.

Ran all 26 first: zero violations. So this step is green on the tree it
lands in, and its cost is bounded to making the next violation fail here
instead of landing.

Several of them guard exactly what CLAUDE.md forbids and were the ones not
running: exhaustive-guard.sh (FSM sparse match), no-fabricated-telemetry.sh
(telemetry-as-fix), no-keeper-behavior-hardcoding.sh,
no-runtime-literal-outside-boundary-redaction.sh.

Globbing instead of listing 26 names: a lint added to the directory now
runs without a second edit here, which is how the 26 accrued in the first
place.

Verified by failing, not by passing. With a real violation injected --
`(** probe \"x\" violation *)` in lib/core/common.ml, which is the exact
shape no-docstring-escape-quote.sh describes -- the loop reports

  FAIL scripts/lint/no-docstring-escape-quote.sh
  exit=1

and returns 0 again once reverted. An earlier probe (a bare "openai"
string) tripped nothing, which is why the second one reads the lint's own
detection rule first.

The loop keeps going after a failure and reports every failing script
rather than stopping at the first, so one run shows the full set.


---

Closes #27447.

## 왜 지금인가

이 세션에서 **미배선 가드가 두 번 실제 결함을 가렸다**:

- `test_rfc_0085_*` 회귀 가드 14 개가 전부 CI 미배선이었고, 그중 PR-16 은 지키던 파일이 분할된 뒤 **살아남은 facade 를 계속 스캔하며 초록**이었다. 금지한 이름 7 개 중 5 개가 살아 있었다 (#27390 에서 수정).
- 이번 린트 26 개.

**가드를 쓰는 것과 배선하는 것이 따로 논다.** 이 PR 은 후자만 한다.

## 검증

```
bash scripts/lint/yaml-syntax.sh          # 20 workflow file(s) parsed OK
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"   # OK
for f in scripts/lint/*.sh; do bash "$f"; done   # exit 0 (32/32)
```

실패 검증은 커밋 본문에 적었다 — 진짜 위반을 주입해 루프가 해당 스크립트를 지목하며 `exit=1` 하는 것을 확인했고, 원복 후 `exit=0` 으로 돌아온다.

## 미검증

CI 러너에서의 실행 시간을 재지 않았다. 32 개 모두 `rg`/`grep` 기반 셸 스크립트이고 로컬에서는 체감되지 않는 수준이지만, 러너 실측은 이 PR 의 첫 실행이 알려줄 것이다.
