### PR TITLE
chore(types): narrow task_actor to the module that uses it

### DIFF
--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -358,10 +358,6 @@ let task_actor_of_status = function
   | Done { assignee; _ } -> Completer assignee
   | Cancelled { cancelled_by; _ } -> Canceller cancelled_by
 
-let task_actor_name = function
-  | Unassigned -> None
-  | Holder name | Submitter name | Completer name | Canceller name -> Some name
-
 (** Who owes work on this Task now. [Done] and [Cancelled] owe nothing, so
     they answer [None] even though both carry a name. Canonical
     ownership-check helper — used by task_state, gRPC, etc. *)

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -119,21 +119,13 @@ val task_status_to_string : task_status -> string
 val string_of_task_status : task_status -> string
 val task_status_icon : task_status -> string
 val task_display_assignee : task_status -> string
-(** Who acted on a Task, and in what relationship. A bare [string option]
-    records the name and drops the role, which let three separate local
-    [task_assignee] helpers disagree about [Done] and [Cancelled]. Naming the
-    role makes that disagreement unwritable, and a new status must state which
-    role it carries. *)
-type task_actor =
-  | Unassigned
-  | Holder of string
-  | Submitter of string
-  | Completer of string
-  | Canceller of string
-
-val task_actor_of_status : task_status -> task_actor
-
-val task_actor_name : task_actor -> string option
+(* [task_actor] and [task_actor_of_status] stay inside this module. They exist
+   so the three questions below cannot disagree about [Done] and [Cancelled] --
+   each is a total match over the same sum -- and that job is done entirely
+   here. Nothing outside ever named the type or its constructors, so exporting
+   them offered a second vocabulary for "who acted on a Task" beside the three
+   answers that are actually asked for. [task_actor_name] had no caller at all
+   and is gone. *)
 
 (** Who owes work now. [Done] and [Cancelled] owe nothing. *)
 val task_assignee_of_status : task_status -> string option

--- a/scripts/audit-dead-surface.py
+++ b/scripts/audit-dead-surface.py
@@ -547,7 +547,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 # merged tree after main's batch-1..3 landed, not computed from the batch
 # size -- the merge also dropped should_use_dict, which lost its last
 # caller when batch 1 removed the dictionary helpers around it.
-DEAD_EXPORT_BASELINE = 585
+DEAD_EXPORT_BASELINE = 583
 
 
 def run_ratchet(count: int) -> int:


### PR DESCRIPTION
## What

`Masc_domain` exported a second vocabulary for "who acted on a Task" that
nothing outside the module ever used.

```
type task_actor = Unassigned | Holder of _ | Submitter of _ | Completer of _ | Canceller of _
val task_actor_of_status : task_status -> task_actor
val task_actor_name : task_actor -> string option
```

The type and `task_actor_of_status` are load-bearing **inside** `types_core`:
the three questions callers actually ask —
`task_assignee_of_status`, `task_performer_of_status`, `task_display_assignee` —
are each a total match over that sum, which is what stops them disagreeing about
`Done` and `Cancelled`. That job is done entirely within the module.

They stay; only the `val` lines and the type go out of the `.mli`.

`task_actor_name` is deleted outright. It had **no caller at all**, inside or
out.

## Evidence

```
rg 'task_actor_name|task_actor_of_status'  across lib/ test/ dashboard/ specs/ docs/ scripts/ .github/
  → 7 hits, all in lib/types/types_core.ml and .mli

rg '\b(Holder|Submitter|Completer|Canceller)\b'  outside types_core
  → 1 hit, a prose comment in test_keeper_turn_admission.ml ("Holder: an
    in-flight chat turn occupying the slot") — a different Holder
```

The compiler is the proof: `dune build @check` passes with the type and both
`val`s removed from the interface, which no consumer could survive.

## Ratchet

```
before  585 dead exports (baseline 585)
after   583               baseline lowered to 583
```

## An accident worth writing down

The same audit reports **7** dead exports when run from the main checkout and
**583** from a clean worktree.

`.worktrees/` and `_build/` are already pruned (`SKIP_PARTS`), so that is not
it. The main checkout carries untracked debris — `.recovered/`,
`.masc-retired-*/`, and a set of `_Users_dancer_me_.tmp_chunk_a_lib_*.ml` files
that are copies of `lib/` sources — and the audit counts a bare token match in
any file as a reference. Those copies make almost every export look live.

That is the tool behaving as documented ("biased toward reporting *fewer*
candidates"), not a bug, and CI runs it on a clean checkout so the ratchet is
sound. Recording it because a local run from a dirty tree will silently
under-report, which is the wrong direction for a deadness question.

## Verification

```
dune build --root . @check                                        exit 0
dune build --root . @fmt            no diff in any file this PR touches
scripts/audit-dead-surface.py --self-test                    self-test OK
scripts/audit-dead-surface.py --exports --ratchet        583, at baseline
scripts/ocaml-structure-ratchet.sh                                    OK

test_tool_task_coverage        98 tests run   Successful
test_task_status_vocabulary     4 tests run   Successful
test_goal_store                14 tests run   Successful
test_enum_mirror_sync           3 tests run   Successful
test_assertion_kind_mirror      6 tests run   Successful
```

No behaviour change: nothing that was computed stops being computed, and the
three exported questions are untouched.

RFC-WAIVED: an interface narrowed to what it is used for, and one function with
no caller removed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
