### PR TITLE
fix(dashboard): #26911 이후 manifest 진단 블록이 계속 unavailable 이던 것 수정

### DIFF
--- a/dashboard/src/api/keeper-runtime-trace.ts
+++ b/dashboard/src/api/keeper-runtime-trace.ts
@@ -67,7 +67,6 @@ export const KEEPER_RUNTIME_MANIFEST_SCAN_DIAGNOSTICS_SCHEMA =
   'keeper.runtime_manifest_scan_diagnostics.v1' as const
 
 const KEEPER_RUNTIME_MANIFEST_SCAN_DIAGNOSTIC_KINDS = [
-  'retired_event',
   'unsupported_event',
   'invalid_manifest_row',
   'invalid_json_row',
@@ -86,8 +85,6 @@ export type KeeperRuntimeManifestScanDiagnostics =
   | {
       state: 'available'
       schema: typeof KEEPER_RUNTIME_MANIFEST_SCAN_DIAGNOSTICS_SCHEMA
-      retired_event_count: number
-      retired_event_counts: KeeperRuntimeManifestEventCount[]
       unsupported_event_count: number
       unsupported_event_counts: KeeperRuntimeManifestEventCount[]
       unsupported_event_unattributed_count: number
@@ -411,16 +408,13 @@ function parseManifestScanDiagnostics(raw: unknown): KeeperRuntimeManifestScanDi
     }
   }
   if (
-    !Array.isArray(raw.retired_event_counts)
-    || !Array.isArray(raw.unsupported_event_counts)
+    !Array.isArray(raw.unsupported_event_counts)
     || !Array.isArray(raw.samples)
   ) {
     return { state: 'unavailable', schema, error: 'malformed manifest scan diagnostics payload' }
   }
-  const retiredEventCounts = raw.retired_event_counts.map(parseManifestEventCount)
   const unsupportedEventCounts = raw.unsupported_event_counts.map(parseManifestEventCount)
   const samples = raw.samples.map(parseManifestScanDiagnostic)
-  const retiredEventCount = nonNegativeInteger(raw.retired_event_count)
   const unsupportedEventCount = nonNegativeInteger(raw.unsupported_event_count)
   const unsupportedEventUnattributedCount = nonNegativeInteger(
     raw.unsupported_event_unattributed_count,
@@ -428,12 +422,10 @@ function parseManifestScanDiagnostics(raw: unknown): KeeperRuntimeManifestScanDi
   const invalidManifestRowCount = nonNegativeInteger(raw.invalid_manifest_row_count)
   const invalidJsonRowCount = nonNegativeInteger(raw.invalid_json_row_count)
   if (
-    retiredEventCount === null
-    || unsupportedEventCount === null
+    unsupportedEventCount === null
     || unsupportedEventUnattributedCount === null
     || invalidManifestRowCount === null
     || invalidJsonRowCount === null
-    || !allParsed(retiredEventCounts)
     || !allParsed(unsupportedEventCounts)
     || !allParsed(samples)
   ) {
@@ -442,8 +434,6 @@ function parseManifestScanDiagnostics(raw: unknown): KeeperRuntimeManifestScanDi
   return {
     state: 'available',
     schema,
-    retired_event_count: retiredEventCount,
-    retired_event_counts: retiredEventCounts,
     unsupported_event_count: unsupportedEventCount,
     unsupported_event_counts: unsupportedEventCounts,
     unsupported_event_unattributed_count: unsupportedEventUnattributedCount,

--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -1362,18 +1362,12 @@ describe('keeper runtime trace', () => {
       receipt_returned_rows: 1,
       manifest_scan_diagnostics: {
         schema: 'keeper.runtime_manifest_scan_diagnostics.v1',
-        retired_event_count: 2,
-        retired_event_counts: [
-          { event: 'state_snapshot_sidecar_saved', count: 1 },
-          { event: 'working_state_sidecar_saved', count: 1 },
-        ],
         unsupported_event_count: 1,
         unsupported_event_counts: [{ event: 'future_event', count: 1 }],
         unsupported_event_unattributed_count: 0,
         invalid_manifest_row_count: 1,
         invalid_json_row_count: 1,
         samples: [
-          { kind: 'retired_event', event: 'state_snapshot_sidecar_saved' },
           { kind: 'unsupported_event', event: 'future_event' },
         ],
       },
@@ -1456,7 +1450,6 @@ describe('keeper runtime trace', () => {
     if (result.manifest_scan_diagnostics.state !== 'available') {
       throw new Error(result.manifest_scan_diagnostics.error)
     }
-    expect(result.manifest_scan_diagnostics.retired_event_count).toBe(2)
     expect(result.manifest_scan_diagnostics.unsupported_event_counts).toEqual([
       { event: 'future_event', count: 1 },
     ])

--- a/dashboard/src/components/journey-panel.test.ts
+++ b/dashboard/src/components/journey-panel.test.ts
@@ -68,8 +68,6 @@ function runtimeTrace(): KeeperRuntimeTraceResponse {
     manifest_scan_diagnostics: {
       state: 'available',
       schema: 'keeper.runtime_manifest_scan_diagnostics.v1',
-      retired_event_count: 0,
-      retired_event_counts: [],
       unsupported_event_count: 0,
       unsupported_event_counts: [],
       unsupported_event_unattributed_count: 0,

--- a/dashboard/src/components/journey-waterfall-state.test.ts
+++ b/dashboard/src/components/journey-waterfall-state.test.ts
@@ -44,8 +44,6 @@ function runtimeTrace(overrides: Partial<KeeperRuntimeTraceResponse> = {}): Keep
     manifest_scan_diagnostics: {
       state: 'available',
       schema: 'keeper.runtime_manifest_scan_diagnostics.v1',
-      retired_event_count: 0,
-      retired_event_counts: [],
       unsupported_event_count: 0,
       unsupported_event_counts: [],
       unsupported_event_unattributed_count: 0,

--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -363,8 +363,6 @@ describe('RuntimeLensSection', () => {
       manifest_scan_diagnostics: {
         state: 'available',
         schema: 'keeper.runtime_manifest_scan_diagnostics.v1',
-        retired_event_count: 0,
-        retired_event_counts: [],
         unsupported_event_count: 0,
         unsupported_event_counts: [],
         unsupported_event_unattributed_count: 0,
@@ -702,16 +700,11 @@ describe('RuntimeLensSection', () => {
     expect(screen.getByText('Tool Runtime')).toBeInTheDocument()
   })
 
-  it('surfaces retired, unsupported, and invalid manifest rows', () => {
+  it('surfaces unsupported and invalid manifest rows', () => {
     const trace = runtimeTraceFixture()
     trace.manifest_scan_diagnostics = {
       state: 'available',
       schema: 'keeper.runtime_manifest_scan_diagnostics.v1',
-      retired_event_count: 2,
-      retired_event_counts: [
-        { event: 'state_snapshot_sidecar_saved', count: 1 },
-        { event: 'working_state_sidecar_saved', count: 1 },
-      ],
       unsupported_event_count: 3,
       unsupported_event_counts: [{ event: 'future_manifest_event', count: 1 }],
       unsupported_event_unattributed_count: 2,
@@ -724,7 +717,7 @@ describe('RuntimeLensSection', () => {
 
     render(h(RuntimeLensSection, { trace }))
 
-    expect(screen.getByText('retired 2 · unsupported 3 · invalid 1')).toBeInTheDocument()
+    expect(screen.getByText('unsupported 3 · invalid 1')).toBeInTheDocument()
     expect(screen.getByText('manifest diagnostics').nextElementSibling).toHaveAttribute(
       'title',
       expect.stringContaining('unsupported rows outside identity detail bound=2'),

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -1055,13 +1055,8 @@ function runtimeManifestDiagnosticsValue(trace: KeeperRuntimeTraceResponse): str
   const diagnostics = trace.manifest_scan_diagnostics
   if (diagnostics.state === 'unavailable') return 'unavailable'
   const invalid = diagnostics.invalid_manifest_row_count + diagnostics.invalid_json_row_count
-  if (
-    diagnostics.retired_event_count === 0
-    && diagnostics.unsupported_event_count === 0
-    && invalid === 0
-  ) return 'clean'
+  if (diagnostics.unsupported_event_count === 0 && invalid === 0) return 'clean'
   return [
-    `retired ${diagnostics.retired_event_count}`,
     `unsupported ${diagnostics.unsupported_event_count}`,
     `invalid ${invalid}`,
   ].join(' · ')
@@ -1072,10 +1067,9 @@ function runtimeManifestDiagnosticsTitle(trace: KeeperRuntimeTraceResponse): str
   if (diagnostics.state === 'unavailable') {
     return [diagnostics.error, diagnostics.schema].filter(Boolean).join('\n')
   }
-  const eventCounts = [
-    ...diagnostics.retired_event_counts.map(item => `retired:${item.event}=${item.count}`),
-    ...diagnostics.unsupported_event_counts.map(item => `unsupported:${item.event}=${item.count}`),
-  ]
+  const eventCounts = diagnostics.unsupported_event_counts.map(
+    item => `unsupported:${item.event}=${item.count}`,
+  )
   const sampleDetails = diagnostics.samples.map(sample =>
     [sample.kind, sample.event, sample.detail].filter(Boolean).join(':'))
   const overflow = diagnostics.unsupported_event_unattributed_count === 0


### PR DESCRIPTION
## 증상

대시보드의 manifest scan 진단 블록이 **2026-08-05 이후 계속 `unavailable` 이다.** 표시되는 사유는 `malformed manifest scan diagnostics payload`.

진단 하나가 아니라 블록 전체가 죽는다 — unsupported event, invalid row, sample 까지 같이 사라진다.

## 원인

`#26911 (hard-cut manifest event history)` 이 서버에서 두 필드를 걷었다.

```
$ git show 91f9537315 -- lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml
-    ; "retired_event_count", `Int (count_total scan.retired_event_counts)
-    ; ( "retired_event_counts"
-      [ "kind", `String "retired_event"
```

현재 서버가 내보내는 키는 7개다.

```
schema  unsupported_event_count  unsupported_event_counts
unsupported_event_unattributed_count  invalid_manifest_row_count
invalid_json_row_count  samples
```

클라이언트 파서는 없어진 두 필드를 여전히 **필수로 요구한다.**

```ts
// keeper-runtime-trace.ts:413
if (!Array.isArray(raw.retired_event_counts) || ...) {
  return { state: 'unavailable', schema, error: 'malformed manifest scan diagnostics payload' }
}
```

`undefined` 는 배열이 아니므로 첫 검사에서 즉시 탈락한다.

## 스키마 버전이 안 움직였다

모양이 바뀌었는데 양쪽 다 `keeper.runtime_manifest_scan_diagnostics.v1` 그대로다. 그래서 파서의 버전 검사는 통과하고, 그 다음 줄에서 죽는다. 버전 검사가 있는데도 못 잡은 이유다.

## 왜 3일 동안 안 드러났나

테스트 픽스처가 서버가 아니라 옛 모양을 들고 있었다. `keeper.test.ts` 는 `manifest_scan_diagnostics.state === 'available'` 을 단정하는데, 픽스처에 `retired_event_count(s)` 가 들어 있어 통과했다. 픽스처 4개가 같은 상태였다.

## 변경

- 파서/타입에서 `retired_event_count`, `retired_event_counts`, 진단 kind `'retired_event'` 제거
- `keeper-detail-runtime.ts` 의 렌더 두 곳에서 retired 항목 제거
- 픽스처 4개를 오늘 서버가 보내는 키만 담도록 수정

## 검증

픽스처를 오늘 서버 모양으로 고친 뒤 **수정 전 파서**로 돌리면:

```
FAIL  src/api/keeper.test.ts > parses runtime trace evidence with resilient defaults
AssertionError: expected 'unavailable' to be 'available'
```

수정 후 전체 통과.

```
npx tsc --noEmit  → 0
npx vitest run
  Test Files 636 passed / Tests 8811 passed
```

## 남은 판단

같은 사고를 막으려면 페이로드 모양이 바뀔 때 스키마 문자열이 따라 움직여야 한다. 지금은 `v1` 을 손으로 맞추는 관례뿐이라 이번처럼 조용히 어긋난다. 서버의 키 목록에서 스키마 문자열을 파생시키거나, 양쪽 상수를 CI 에서 대조하는 방법이 있다. 이 PR 범위 밖이라 건드리지 않았다.

발견 경위: 하드코딩 스윕에서 TS 닫힌 목록 37개를 OCaml 리터럴과 대조하다 `KEEPER_RUNTIME_MANIFEST_SCAN_DIAGNOSTIC_KINDS` 의 `retired_event` 가 서버에 없는 걸 확인. 같은 패턴(서버 회수 후 클라이언트 잔재)의 선행 건: #27302, #27305, #27450.
