### PR TITLE
chore(board): narrow the attention-candidate interface to its callers

### DIFF
--- a/lib/keeper/keeper_board_attention_candidate.mli
+++ b/lib/keeper/keeper_board_attention_candidate.mli
@@ -145,16 +145,17 @@ type record_acceptance =
 
 exception Candidate_unavailable of string
 
-val delivery_failure_kind_to_string : delivery_failure_kind -> string
-val delivery_failure_kind_of_string : string -> delivery_failure_kind option
-val delivery_failure_to_yojson : delivery_failure -> Yojson.Safe.t
-val delivery_failure_of_yojson : Yojson.Safe.t -> (delivery_failure, string) result
+(* The [delivery_failure], [delivery] and [quarantine_failure_category] codecs
+   are not listed here. They serialize this module's own durable ledger and no
+   caller outside it ever named one -- exporting them offered a second way to
+   read and write the ledger's shape beside the operations that own it. The
+   functions stay; only the interface stops advertising them.
+   [quarantine_failure_category_to_string] is the exception and is kept:
+   [Keeper_board_attention_quarantine_command] renders the category. *)
+
 val judgment_to_yojson : judgment -> Yojson.Safe.t
 val judgment_of_yojson : Yojson.Safe.t -> (judgment, string) result
-val delivery_to_string : delivery -> string
-val delivery_of_string : string -> delivery option
 val quarantine_failure_category_to_string : quarantine_failure_category -> string
-val quarantine_failure_category_of_string : string -> quarantine_failure_category option
 val resumable_status : status -> resumable_status option
 val quarantine_state : status -> quarantine_state option
 val signal_to_yojson : Board_dispatch.board_signal -> Yojson.Safe.t
@@ -164,13 +165,9 @@ val singleton_judgment_request : candidate -> (Yojson.Safe.t, string) result
     Keeper, and signal identity, then return the one-item exact-flow input.
     Old or partial request JSON is rejected without compatibility decoding. *)
 
-val of_board_evidence :
-  meta:Keeper_meta_contract.keeper_meta ->
-  recorded_at:float ->
-  signal:Board_dispatch.board_signal ->
-  post:Board.post ->
-  comments:Board.comment list ->
-  (candidate, string) result
+(* [of_board_evidence] is the inner step of [of_board_signal] below, which is
+   the door callers use: it reads the post and comments and hands them here.
+   Nothing outside supplies its own evidence. *)
 
 val of_board_signal :
   meta:Keeper_meta_contract.keeper_meta ->
@@ -219,11 +216,10 @@ val record : base_path:string -> candidate -> record_result
 (** Validate the complete current candidate invariant before changing the
     durable ledger. *)
 
-val record_delivery_failure :
-  base_path:string ->
-  candidate ->
-  delivery_failure ->
-  (candidate, string) result
+(* [record_delivery_failure] is called from [consume_judged] in this module, on
+   the branch where the event queue answers [Identity_conflict] or
+   [Storage_error]. That is the only place a [delivery_failure] is constructed,
+   so a caller outside holds none to record. *)
 
 val record_judgment :
   base_path:string -> candidate -> judgment -> (candidate, string) result

--- a/scripts/audit-dead-surface.py
+++ b/scripts/audit-dead-surface.py
@@ -547,7 +547,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 # merged tree after main's batch-1..3 landed, not computed from the batch
 # size -- the merge also dropped should_use_dict, which lost its last
 # caller when batch 1 removed the dictionary helpers around it.
-DEAD_EXPORT_BASELINE = 575
+DEAD_EXPORT_BASELINE = 576
 
 
 def run_ratchet(count: int) -> int:

--- a/scripts/audit-dead-surface.py
+++ b/scripts/audit-dead-surface.py
@@ -547,7 +547,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 # merged tree after main's batch-1..3 landed, not computed from the batch
 # size -- the merge also dropped should_use_dict, which lost its last
 # caller when batch 1 removed the dictionary helpers around it.
-DEAD_EXPORT_BASELINE = 576
+DEAD_EXPORT_BASELINE = 566
 
 
 def run_ratchet(count: int) -> int:


### PR DESCRIPTION
## What

`Keeper_board_attention_candidate` exported nine names that no caller outside
the module ever used. Its `.mli` is 281 lines over a 2,022-line module, and
these nine were the largest single block of unused surface on the Board side —
9 of the 83 dead exports in the board/goal/task modules.

```
delivery_failure_kind_to_string        delivery_to_string
delivery_failure_kind_of_string        delivery_of_string
delivery_failure_to_yojson             quarantine_failure_category_of_string
delivery_failure_of_yojson             of_board_evidence
                                       record_delivery_failure
```

Every one is still used **inside** the module. None is deleted; the interface
stops advertising them.

## Why these are not a public vocabulary

- The **codecs** serialize this module's own durable ledger. Exporting them
  offered a second way to read and write the ledger's shape beside the
  operations that own it.
- **`of_board_evidence`** is the inner step of `of_board_signal`, which is the
  door callers use: it reads the post and comments and hands them in. Nothing
  outside supplies its own evidence.
- **`record_delivery_failure`** is called from `consume_judged`, on the branch
  where the event queue answers `Identity_conflict` or `Storage_error`. That is
  the only place a `delivery_failure` is constructed, so a caller outside holds
  none to record.

`quarantine_failure_category_to_string` looked like part of the same block and
is **kept**: `Keeper_board_attention_quarantine_command` renders the category
in two places. Its `_of_string` twin has no such caller and goes.

## Evidence

```
rg for each of the nine, across lib/ test/ dashboard/src, excluding this module
  → 0 hits, all nine
```

The compiler is the proof: `dune build @check` passes with the nine removed
from the interface, which no external consumer could survive.

## Ratchet

```
before  585 dead exports (baseline 585)
after   576               baseline lowered to 576
```

**Stacks with #27454**, which lowers the same constant to 583 for a different
two. If that merges first this one needs 574; the ratchet prints the number it
wants, so the rebase is mechanical.

## A measurement caveat, since it produced a wrong claim of mine

This audit reports **7** dead exports from the main checkout and **583** from a
clean worktree. `.worktrees/` and `_build/` are already pruned; what inflates it
is untracked debris in the main checkout — `.recovered/`, `.masc-retired-*/`,
and `_Users_dancer_me_.tmp_chunk_a_lib_*.ml` files that are copies of `lib/`
sources. A bare token match in any file counts as a reference, so those copies
make almost every export look live.

That is the documented design ("biased toward reporting *fewer* candidates") and
CI runs on a clean checkout, so the ratchet is sound. It is recorded here
because a local run from a dirty tree under-reports, which is the wrong
direction for a deadness question — I asserted "zero dead exports in the
collaboration modules" off such a run before re-measuring gave 83.

## Verification

```
dune build --root . @check                                        exit 0
dune build --root . @fmt            no diff in any file this PR touches
scripts/audit-dead-surface.py --self-test                    self-test OK
scripts/audit-dead-surface.py --exports --ratchet        576, at baseline

test_keeper_board_attention_candidate   13 tests run   Successful
test_keeper_board_attention_partition   12 tests run   Successful
test_keeper_board_attention_worker      34 tests run   Successful
```

No behaviour change: nothing that was computed stops being computed.

RFC-WAIVED: an interface narrowed to what is used across it. No deletion of
implementation, no new field, no gate.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
