### PR TITLE
fix(lint): Yojson kind 분류기를 이름이 아니라 모양으로 검사한다 (6벌 중 0벌 탐지 중)

### DIFF
--- a/lib/ide/ide_annotation_types.ml
+++ b/lib/ide/ide_annotation_types.ml
@@ -117,7 +117,7 @@ let kind_label : Yojson.Safe.t -> string = function
   | `Null -> "null"
   | `Bool _ -> "bool"
   | `Int _ -> "int"
-  | `Intlit _ -> "int"
+  | `Intlit _ -> "intlit"
   | `Float _ -> "float"
   | `String _ -> "string"
   | `Assoc _ -> "object"

--- a/lib/shared_audit/envelope.ml
+++ b/lib/shared_audit/envelope.ml
@@ -67,7 +67,7 @@ let kind_name : Yojson.Safe.t -> string = function
   | `Null -> "null"
   | `Bool _ -> "bool"
   | `Int _ -> "int"
-  | `Intlit _ -> "int"
+  | `Intlit _ -> "intlit"
   | `Float _ -> "float"
   | `String _ -> "string"
   | `Assoc _ -> "object"

--- a/scripts/lint/no-inline-json-kind-name.sh
+++ b/scripts/lint/no-inline-json-kind-name.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
-# no-inline-json-kind-name.sh — Block inline `let json_kind_name :
-# Yojson.Safe.t -> string = function` definitions in lib/. Use
-# Json_util.kind_name (declared in lib/core/json_util.ml) instead.
+# no-inline-json-kind-name.sh — Block inline `Yojson.Safe.t -> string`
+# kind classifiers in lib/. Use Json_util.kind_name (declared in
+# lib/core/json_util.ml) instead.
+#
+# Matched by shape, not by identifier. The pattern used to require the
+# name `json_kind_name`, so a copy under any other name passed while
+# this script printed OK. Five did, under kind_label,
+# kind_name_of_json, yojson_variant_name and two spellings of
+# kind_name. One says so in its own comment (ide_annotation_types.ml):
+# "Name [kind_label] (not [json_kind_name]) slips the
+# no-inline-json-kind-name lint regex".
 #
 # Rationale: PR #16534 (initial 6-site dedup) + #16546 (yojson 3.0
 # dead-arm cleanup, 22 sites) + #16572 (final 11-site dedup)
@@ -23,15 +31,27 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
+# Each entry's dune declares yojson-only dependencies (RFC-0056 leaf
+# isolation), so reaching Json_util would mean adding masc_core and
+# breaking that invariant. Verified per dune, not assumed.
 ALLOWLIST=(
   # SSOT definition — the canonical helper itself.
   "lib/core/json_util.ml"
 
-  # RFC-0056 yojson-only sub-library (leaf isolation).  Adding
-  # masc_core to this lib would break the dependency-graph invariant
-  # that the multimodal sub-lib remains consumable by lightweight
-  # downstream tooling without pulling the whole masc_core surface.
+  # masc_multimodal — (libraries shared_types unix yojson fs_compat
+  # digestif eio masc_random_id); no masc_core.
   "lib/multimodal/payload.ml"
+  "lib/multimodal/artifact.ml"
+
+  # masc_ide and shared_audit — same leaf shape, same constraint. Both
+  # were invisible to this lint until it matched by shape.
+  "lib/ide/ide_annotation_types.ml"
+  "lib/shared_audit/envelope.ml"
+
+  # json_field reports OCaml variant names rather than JSON type names
+  # on purpose: its .mli documents got = "intlit" / "list" / "assoc"
+  # and test_json_field pins them. Not a copy of the canonical mapping.
+  "lib/json_field/json_field.ml"
 )
 
 matches_file=$(mktemp)
@@ -43,7 +63,7 @@ scan_status=0
 
 if command -v rg >/dev/null 2>&1; then
   rg --line-number --no-heading --type ocaml \
-    'let json_kind_name : Yojson\.Safe\.t -> string = function' \
+    'let [a-z_][A-Za-z0-9_]* : Yojson\.Safe\.t -> string = function' \
     lib/ >"$matches_file" 2>"$errors_file" || scan_status=$?
   if [[ $scan_status -gt 1 ]]; then
     echo "ERROR: ripgrep failed while scanning inline json_kind_name definitions" >&2
@@ -52,7 +72,7 @@ if command -v rg >/dev/null 2>&1; then
   fi
 else
   grep -RInE --include='*.ml' \
-    'let json_kind_name : Yojson\.Safe\.t -> string = function' \
+    'let [a-z_][A-Za-z0-9_]* : Yojson\.Safe\.t -> string = function' \
     lib/ >"$matches_file" 2>"$errors_file" || scan_status=$?
   if [[ $scan_status -gt 1 ]]; then
     echo "ERROR: grep failed while scanning inline json_kind_name definitions" >&2
@@ -74,13 +94,13 @@ while IFS= read -r match; do
   done
   [[ $skip -eq 1 ]] && continue
 
-  echo "ERROR: inline json_kind_name definition (use Json_util.kind_name): $match"
+  echo "ERROR: inline Yojson kind classifier (use Json_util.kind_name): $match"
   count=$((count + 1))
 done < "$matches_file"
 
 if [[ $count -gt 0 ]]; then
   echo ""
-  echo "Found $count inline json_kind_name definition(s) outside the allowlist."
+  echo "Found $count inline Yojson kind classifier(s) outside the allowlist."
   echo ""
   echo "Migration guide:"
   echo "  1. Delete the 9-line inline definition."
@@ -96,5 +116,5 @@ if [[ $count -gt 0 ]]; then
   exit 1
 fi
 
-echo "OK: no inline json_kind_name definitions found outside allowlist"
+echo "OK: no inline Yojson kind classifiers outside allowlist"
 exit 0


### PR DESCRIPTION
## 문제

`no-inline-json-kind-name.sh` 는 목적을 이렇게 적는다.

> Block inline `let json_kind_name : Yojson.Safe.t -> string = function` definitions in lib/.

그런데 패턴이 **식별자 이름 하나**를 요구한다.

```bash
'let json_kind_name : Yojson\.Safe\.t -> string = function'
```

그래서 이름만 다르면 통과한다. 현재 `lib/` 에 같은 분류기가 6벌 있는데 린트는 `OK` 를 출력한다.

```
lib/core/json_util.ml           kind_name             ← SSOT
lib/multimodal/payload.ml       json_kind_name        ← 허용 목록
lib/multimodal/artifact.ml      kind_name_of_json
lib/ide/ide_annotation_types.ml kind_label
lib/shared_audit/envelope.ml    kind_name
lib/json_field/json_field.ml    yojson_variant_name
```

회피가 코드에 기록돼 있다.

```ocaml
(* ide_annotation_types.ml:110 *)
Name [kind_label] (not [json_kind_name]) slips the
no-inline-json-kind-name lint regex while preserving the
same total mapping.  RFC pile is now 7 inline copies
```

린트 자신의 근거가 예언한 그대로다 — "Without a lint guard, the next received-kind enrich sprint will reintroduce the boilerplate — AI agents learn from codebase statistics."

## 주장과 코드가 어긋난 사본 2개

두 사본이 주석에서 canonical 과 동일하다고 말하는데 실제로는 다르다.

```
ide_annotation_types.ml   "preserving the same total mapping"        `Intlit -> "int"
shared_audit/envelope.ml  "Same total mapping as the canonical..."   `Intlit -> "int"
lib/core/json_util.ml     (canonical)                                `Intlit -> "intlit"
```

이 문자열은 `Wrong_shape` 류 에러 메시지로 운영자에게 나간다. 두 사본을 주석이 말하는 대로 맞췄다. 테스트가 고정한 곳은 없다 (`rg '"int"' test/` 로 확인).

`json_field` 는 다르다. `.mli` 가 `got = "intlit" / "list" / "assoc"` 를 문서화하고 `test_json_field.ml:128` 이 고정한다. canonical 의 사본이 아니라 **의도된 별개 어휘**라서 그대로 두고 허용 목록에 근거를 적었다.

## 변경

- 패턴을 이름이 아니라 **모양**으로 매치: `let <ident> : Yojson.Safe.t -> string = function`
- 허용 목록에 leaf-isolation 파일 4개 추가. 각 항목에 해당 dune 이 masc_core 를 안 가진다는 근거를 명시했다 (추정이 아니라 dune 확인).
- `ide` / `shared_audit` 의 `` `Intlit `` 를 canonical 과 일치시킴
- 메시지 문구를 실제 검사 대상에 맞게 수정

## 검증

새 이름의 사본을 하나 심고 양쪽 린트를 돌렸다.

```
원본 린트: EXIT=0   (못 잡음)
수정 린트: EXIT=1   ERROR: ... probe_kind_string ...
```

제거 후 `dune build --root . @check` → 0, 린트 → `OK: no inline Yojson kind classifiers outside allowlist`.

## 남은 판단

허용 목록 5개는 전부 "leaf 라서 Json_util 에 못 닿는다" 가 근거다. 두 사본의 주석이 이미 대안을 적어놨다 — `lib/shared_types/json_kind.ml` 을 yojson-only 마이크로 리프로 만들면 다섯 곳이 한 정의를 공유한다. `shared_types` 는 multimodal 의 dune 에 이미 들어 있다. 이 PR 범위 밖이라 하지 않았고, 원하면 후속으로 낸다.
