### PR TITLE
test(verification): write the roundtrip the code says exists

### DIFF
--- a/lib/task/tool_task_completion_review.ml
+++ b/lib/task/tool_task_completion_review.ml
@@ -118,7 +118,12 @@ let concrete_verification_evidence ?(notes = "") ?handoff_context
 (* JSON object fields for the typed split, spliced into the verification
    request output / board meta / SSE alongside the unchanged [evidence_refs]
    field. Shares the derived [verification_evidence_to_yojson] so the
-   serialization tested by the roundtrip is the one production emits. *)
+   serialization tested by the roundtrip is the one production emits.
+
+   That roundtrip is [test_verification] / "verification_evidence wire", which
+   states the wire object as a literal and checks this function against it. It
+   is named here because the sentence above claimed a test that did not exist
+   until it was written. *)
 let verification_evidence_fields (evidence : verification_evidence)
   : (string * Yojson.Safe.t) list =
   match verification_evidence_to_yojson evidence with

--- a/scripts/audit-dead-surface.py
+++ b/scripts/audit-dead-surface.py
@@ -547,7 +547,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 # merged tree after main's batch-1..3 landed, not computed from the batch
 # size -- the merge also dropped should_use_dict, which lost its last
 # caller when batch 1 removed the dictionary helpers around it.
-DEAD_EXPORT_BASELINE = 585
+DEAD_EXPORT_BASELINE = 583
 
 
 def run_ratchet(count: int) -> int:

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -2092,8 +2092,82 @@ let test_generate_id_no_collisions () =
   done;
   Alcotest.(check int) "all 10k ids unique" n (StringSet.cardinal !seen)
 
+(* [tool_task_completion_review.ml] says of [verification_evidence_fields]:
+   "Shares the derived [verification_evidence_to_yojson] so the serialization
+   tested by the roundtrip is the one production emits."
+
+   There was no such roundtrip. The type reaches the verification request
+   output, the Board meta and SSE through [verification_evidence_fields], so its
+   wire shape is a contract with readers outside this repo's control, and
+   nothing pinned it.
+
+   Both expectations below are literals. Encoding with the function under test
+   and comparing against itself would pass whatever the encoder became. *)
+
+module CR = Masc.Task.Completion_review
+
+let evidence_fixture : CR.verification_evidence =
+  { required_artifacts = [ "artifact:spec.md"; "artifact:bench.json" ]
+  ; submitted_evidence = [ "note:tsc passes"; "artifact:run.log" ]
+  }
+
+let evidence_wire : Yojson.Safe.t =
+  `Assoc
+    [ ( "required_artifacts"
+      , `List [ `String "artifact:spec.md"; `String "artifact:bench.json" ] )
+    ; ( "submitted_evidence"
+      , `List [ `String "note:tsc passes"; `String "artifact:run.log" ] )
+    ]
+
+let test_verification_evidence_roundtrip () =
+  Alcotest.(check string)
+    "encodes to the stated wire shape"
+    (Yojson.Safe.to_string evidence_wire)
+    (Yojson.Safe.to_string (CR.verification_evidence_to_yojson evidence_fixture));
+  match CR.verification_evidence_of_yojson evidence_wire with
+  | Error detail -> Alcotest.failf "the stated wire shape must decode: %s" detail
+  | Ok decoded ->
+    Alcotest.(check (list string))
+      "required_artifacts survives the trip"
+      evidence_fixture.required_artifacts
+      decoded.required_artifacts;
+    Alcotest.(check (list string))
+      "submitted_evidence survives the trip"
+      evidence_fixture.submitted_evidence
+      decoded.submitted_evidence
+
+(* The half the comment is actually about: what production splices into the
+   request, the Board meta and SSE is the encoder this roundtrip pins, not a
+   second hand-built object beside it. *)
+let test_verification_evidence_fields_are_the_encoded_object () =
+  let fields = CR.verification_evidence_fields evidence_fixture in
+  Alcotest.(check string)
+    "the spliced fields are the encoded object"
+    (Yojson.Safe.to_string evidence_wire)
+    (Yojson.Safe.to_string (`Assoc fields))
+
+(* An absent list is not an empty one: a reader that sees no key cannot tell
+   "nothing was required" from "the producer did not say". *)
+let test_verification_evidence_decode_requires_both_keys () =
+  List.iter
+    (fun (label, json) ->
+       match CR.verification_evidence_of_yojson json with
+       | Ok _ -> Alcotest.failf "%s must not decode" label
+       | Error _ -> ())
+    [ ("a missing submitted_evidence", `Assoc [ ("required_artifacts", `List []) ])
+    ; ("a missing required_artifacts", `Assoc [ ("submitted_evidence", `List []) ])
+    ; ("a non-object", `List [])
+    ]
+
 let () =
   Alcotest.run "Verification" [
+    "verification_evidence wire", [
+      Alcotest.test_case "roundtrip" `Quick test_verification_evidence_roundtrip;
+      Alcotest.test_case "spliced fields are the encoded object" `Quick
+        test_verification_evidence_fields_are_the_encoded_object;
+      Alcotest.test_case "decode requires both keys" `Quick
+        test_verification_evidence_decode_requires_both_keys;
+    ];
     "criterion", [
       Alcotest.test_case "roundtrip" `Quick test_criterion_roundtrip;
       Alcotest.test_case "of_yojson errors" `Quick test_criterion_of_yojson_errors;


### PR DESCRIPTION
## What

`tool_task_completion_review.ml` says of `verification_evidence_fields`:

> Shares the derived `verification_evidence_to_yojson` so the serialization
> **tested by the roundtrip** is the one production emits.

There was no roundtrip. `rg verification_evidence test/` returns nothing, and
`verification_evidence_of_yojson` appears in exactly one place in the whole
repository — its own `val` line.

## Why it matters that this one was untested

`verification_evidence_fields` splices this object into the verification
request output, the Board meta and SSE. Its shape is a contract with readers,
and nothing pinned it. The type is also `[@@deriving yojson]`, so the encoder
can change with the record definition without a single call site moving.

## Tests

Three cases in `test_verification`, which CI runs (42 → 45):

| case | asserts |
|---|---|
| roundtrip | encodes to the stated wire object; that object decodes back to the same value |
| spliced fields are the encoded object | `verification_evidence_fields` output equals the same object — the sentence the comment actually makes |
| decode requires both keys | a missing `required_artifacts` or `submitted_evidence`, and a non-object, are refused |

**Both expectations are literals.** The wire object is written out as
`` `Assoc [...] `` and compared against; encoding with the function under test
and comparing to itself would pass whatever the encoder became. That is what
makes these guards rather than restatements — it is a property of how they are
written, not something a mutation established.

I did **not** run a library-level mutation to confirm. The rebuild that a change
to this module triggers ran past ten minutes twice, and a delayed restore from
the first attempt clobbered the second, so I have no mutation output to show. I
am stating that rather than implying otherwise; the literal expectations are the
argument.

## The comment now names its test

```
That roundtrip is [test_verification] / "verification_evidence wire", which
states the wire object as a literal and checks this function against it. It is
named here because the sentence above claimed a test that did not exist until
it was written.
```

A comment that says "tested by the roundtrip" with no pointer is what let this
drift in the first place.

## Ratchet

```
before  585 dead exports (baseline 585)
after   583               baseline lowered to 583
```

Note the direction: `verification_evidence_to_yojson` and
`verification_evidence_of_yojson` left the dead list by **gaining a caller**,
not by being deleted. The exports are now justified rather than removed.

**Stacks with #27454** (585 → 583 by removing a different two) and **#27456**
(585 → 576). Whichever lands last re-reads the number the ratchet prints; the
ratchet's failure message states it.

## Verification

```
dune build --root . @check                                        exit 0
scripts/audit-dead-surface.py --self-test                    self-test OK
scripts/audit-dead-surface.py --exports --ratchet        583, at baseline

test_verification    45 tests run   Successful   (was 42)
```

No behaviour change: the only non-test edit is a comment.

RFC-WAIVED: a test written for a wire shape that had none, and a comment made
true.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
