### PR TITLE
chore(collab): narrow four core interfaces to their callers

### DIFF
--- a/lib/board/board_core_persist.mli
+++ b/lib/board/board_core_persist.mli
@@ -55,7 +55,8 @@ val max_jsonl_bytes : int
 val rotate_if_needed : string -> unit
 
 val posts_jsonl_unlocked : store -> string
-val save_posts_jsonl_result : string -> (unit, board_error) result
+(* [save_posts_jsonl_result] is the result-returning inner form of
+   [save_posts_jsonl] below, which is the door callers use. *)
 val save_posts_jsonl : string -> unit
 val rewrite_posts : store -> unit
 val rewrite_comments : store -> unit
@@ -67,10 +68,16 @@ val append_comment : comment -> (unit, board_error) result
 val sub_board_access_to_string : sub_board_access -> string
 val sub_board_access_of_string_opt : string -> sub_board_access option
 val sub_board_post_counts_unlocked : store -> (string, int) Hashtbl.t
-val sub_board_post_count_from_counts : (string, int) Hashtbl.t -> string -> int
+(* [sub_board_post_count_from_counts] is the lookup both
+   [sub_board_with_post_count] and its _unlocked twin perform on the table
+   [sub_board_post_counts_unlocked] returns; callers take the sub_board, not
+   the count. *)
 val sub_board_with_post_count_unlocked : store -> sub_board -> sub_board
 val sub_board_with_post_count : (string, int) Hashtbl.t -> sub_board -> sub_board
-val sub_board_author_allowed : sub_board -> author_id:Agent_id.t -> bool
+(* [sub_board_author_allowed] is the predicate
+   [validate_sub_board_post_policy_unlocked] applies. A caller outside asks the
+   validator, which answers with the typed board_error, rather than reading the
+   bool and inventing its own refusal. *)
 val validate_sub_board_post_policy_unlocked :
   store -> author_id:Agent_id.t -> hearth:string option -> (unit, board_error) result
 

--- a/lib/board_types/board_types.mli
+++ b/lib/board_types/board_types.mli
@@ -32,9 +32,13 @@ type board_error =
 
 (** {1 Safe ID Modules — Parse, Don't Validate} *)
 
-val alphanumeric_id_re : Re.re
-(** Shared regex [^[a-zA-Z0-9_-]+$] for alphanumeric ID validation.
-    Used by [Post_id], [Board_id], [Sub_board_id], and [Board_attachment_meta.Id]. *)
+(* The shared alphanumeric regex [^[a-zA-Z0-9_-]+$] is not exported.
+   [Post_id], [Comment_id] and [Sub_board_id] apply it and hand back a parsed
+   value; a caller holding the raw regex could validate without parsing, which
+   is the split those modules exist to remove.
+
+   The doc this replaces named [Board_id] and [Board_attachment_meta.Id], which
+   do not use it, and omitted [Comment_id], which does. *)
 
 module Post_id : sig
   type t

--- a/lib/keeper/keeper_run_tools_task_scope.mli
+++ b/lib/keeper/keeper_run_tools_task_scope.mli
@@ -1,9 +1,9 @@
 (** Task-scoped tool helpers for keeper run tools. *)
 
-val task_scope_tool_names : string list
-
-val task_id_scope_of_tool_input :
-  tool_name:string -> Yojson.Safe.t -> string option
+(* [task_scope_tool_names] and [task_id_scope_of_tool_input] are the inner
+   steps of [task_id_scope_of_tool_call] below, which is the door callers use:
+   it takes the call and answers the scope. Nothing outside needs the name list
+   or the input-only form. *)
 
 val task_id_scope_of_tool_call :
   tool_name:string ->

--- a/lib/keeper/keeper_world_observation_board_signal.mli
+++ b/lib/keeper/keeper_world_observation_board_signal.mli
@@ -43,7 +43,8 @@ type disposition =
 val disposition_of_error : Board.board_error -> disposition
 val disposition_of_unavailable : board_unavailable -> disposition
 
-val board_read_operation_to_string : board_read_operation -> string
+(* [board_read_operation_to_string] renders the operation inside
+   [unavailable_to_string] below, which is this module's only use of it. *)
 val unavailable_to_string : board_unavailable -> string
 
 val board_signal_of_board_stimulus
@@ -58,7 +59,8 @@ val board_stimulus_of_board_signal
   -> Keeper_event_queue.board_stimulus
 (** Total inverse conversion used by durable Board-signal producers. *)
 
-val post_id_string : Board.post -> string
+(* [post_id_string] is how [cursor_token_of_post] below keys a post; that is
+   its only caller. *)
 val compare_cursor_token : float * string -> float * string -> int
 val cursor_token_of_post : Board.post -> float * string
 val list_posts_after_cursor : float * string option -> Board.post list

--- a/scripts/audit-dead-surface.py
+++ b/scripts/audit-dead-surface.py
@@ -547,7 +547,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 # merged tree after main's batch-1..3 landed, not computed from the batch
 # size -- the merge also dropped should_use_dict, which lost its last
 # caller when batch 1 removed the dictionary helpers around it.
-DEAD_EXPORT_BASELINE = 583
+DEAD_EXPORT_BASELINE = 575
 
 
 def run_ratchet(count: int) -> int:


### PR DESCRIPTION
## What

Eight declarations across four collaboration-core interfaces that no caller
outside their own module ever used. All eight are still used **inside** their
module; nothing is deleted, the interfaces stop advertising them.

```
board_core_persist                     save_posts_jsonl_result
                                       sub_board_post_count_from_counts
                                       sub_board_author_allowed
board_types                            alphanumeric_id_re
keeper_run_tools_task_scope            task_scope_tool_names
                                       task_id_scope_of_tool_input
keeper_world_observation_board_signal  board_read_operation_to_string
                                       post_id_string
```

Each is the inner step of a door that is exported beside it:

| removed from the interface | the door callers use |
|---|---|
| `save_posts_jsonl_result` | `save_posts_jsonl content = ignore (save_posts_jsonl_result content)` |
| `sub_board_post_count_from_counts` | `sub_board_with_post_count` and its `_unlocked` twin |
| `sub_board_author_allowed` | `validate_sub_board_post_policy_unlocked`, which answers with a typed `Validation_error` rather than a bare bool |
| `alphanumeric_id_re` | `Post_id`, `Comment_id`, `Sub_board_id` — which parse and hand back a value |
| `task_scope_tool_names`, `task_id_scope_of_tool_input` | `task_id_scope_of_tool_call` |
| `board_read_operation_to_string` | `unavailable_to_string` |
| `post_id_string` | `cursor_token_of_post` |

`sub_board_author_allowed` and `alphanumeric_id_re` are the two worth naming:
both let a caller reach the raw predicate beside the parse-or-validate door that
exists to replace it. That is the split those doors were written to remove.

## The doc I replaced was wrong

`board_types.mli` said of `alphanumeric_id_re`:

> Used by `[Post_id]`, `[Board_id]`, `[Sub_board_id]`, and
> `[Board_attachment_meta.Id]`.

The actual users are `Post_id`, `Comment_id` and `Sub_board_id`. It named two
modules that do not use it and omitted one that does. The replacement comment
states the three and says so.

## Every claim in the new comments was checked against the code

I asserted two comments in #27456 without checking and had to correct both
before pushing. This time each was verified after writing, and three were wrong:

- `sub_board_post_count_from_counts` — said one caller, there are two
- `board_read_operation_to_string` — said "unavailable/disposition messages",
  it is only `unavailable_to_string`
- `post_id_string` — said "cursor and signal construction", it is only
  `cursor_token_of_post`

All three are corrected in the diff.

## Evidence

```
rg -l for each of the eight, across lib/ test/ dashboard/src
  → each returns exactly its own .ml and .mli, all eight
```

The compiler is the proof: `dune build @check` passes with the eight removed
from the interfaces, which no external consumer could survive.

## Ratchet

```
before  583 dead exports (baseline 583, set by #27454)
after   575               baseline lowered to 575
```

**Stacks with #27456** (which lowers 585 → 576 from a base that predates
#27454) and **#27460** (585 → 583 by giving two exports a caller). Whichever
lands last re-reads the number the ratchet prints; its failure message states
it.

## Verification

```
dune build --root . @check                                        exit 0
dune build --root . @fmt            no diff in any file this PR touches
scripts/audit-dead-surface.py --self-test                    self-test OK
scripts/audit-dead-surface.py --exports --ratchet        575, at baseline

test_tool_board_coverage                78 tests run   Successful
test_board_persistence_load_contract     3 tests run   Successful
test_keeper_board_attention_partition   13 tests run   Successful
test_keeper_wake_turn_context           17 tests run   Successful
```

No behaviour change: nothing that was computed stops being computed.

RFC-WAIVED: four interfaces narrowed to what is used across them, and one doc
line corrected. No deletion of implementation, no new field, no gate.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
