### PR TITLE
refactor(mcp): null id 허용 여부를 catch-all 없이 한 곳에서 결정한다

### DIFF
--- a/lib/mcp_error_code.ml
+++ b/lib/mcp_error_code.ml
@@ -54,6 +54,25 @@ let to_wire_message_default = function
   | Session_evicted -> "Session evicted by server policy"
   | Quiet { reason ; _ } -> reason
 
+(* JSON-RPC 2.0 §5: a response may carry a null id only when the request
+   id could not be determined — a parse failure or a malformed request
+   object. Every other code answers a request whose id was read, so the
+   arms are listed rather than caught, and a new code has to choose here. *)
+let allows_null_request_id : t -> bool = function
+  | Parse_error -> true
+  | Invalid_request -> true
+  | Method_not_found -> false
+  | Invalid_params -> false
+  | Internal_error -> false
+  | Auth_error -> false
+  | Not_ready -> false
+  | Provider_timeout -> false
+  | Tool_dispatch_failure -> false
+  | Backpressure_shed -> false
+  | Session_evicted -> false
+  | Quiet _ -> false
+;;
+
 let to_http_status : t -> Httpun.Status.t = function
   | Parse_error -> `Bad_request
   | Invalid_request -> `Bad_request

--- a/lib/mcp_error_code.mli
+++ b/lib/mcp_error_code.mli
@@ -64,6 +64,12 @@ val to_wire_message_default : t -> string
     {!Server_mcp_transport_http_respond} contract for [respond_not_ready]).
 *)
 
+val allows_null_request_id : t -> bool
+(** Whether a response carrying this code may leave [id] null.  True only
+    for [Parse_error] and [Invalid_request], the two JSON-RPC 2.0 §5 cases
+    where the request id could not be read.  Exhaustive over [t]: adding a
+    code is a compile error here rather than a silent [false]. *)
+
 val to_http_status : t -> Httpun.Status.t
 (** Mapping from error code to HTTP status, colocated with the variant
     so the transport cannot drift from envelope semantics.

--- a/lib/server/server_mcp_transport_http_headers.ml
+++ b/lib/server/server_mcp_transport_http_headers.ml
@@ -18,15 +18,11 @@ let is_http_error_response = function
             | _ -> None)
         | _ -> None
       in
-      let is_parse_or_invalid = function
-        | Mcp_error_code.Parse_error | Invalid_request -> true
-        | _ -> false
-      in
       id_is_null
       && (match code with
           | Some c ->
               (match Mcp_error_code.of_wire_code c with
-               | Some ec -> is_parse_or_invalid ec
+               | Some ec -> Mcp_error_code.allows_null_request_id ec
                | None -> false)
           | None -> false)
   | _ -> false

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -39,15 +39,11 @@ let is_http_error_response = function
              | _ -> None)
         | _ -> None
       in
-      let is_parse_or_invalid = function
-        | Mcp_error_code.Parse_error | Invalid_request -> true
-        | _ -> false
-      in
       id_is_null
       && (match code with
           | Some c ->
               (match Mcp_error_code.of_wire_code c with
-               | Some ec -> is_parse_or_invalid ec
+               | Some ec -> Mcp_error_code.allows_null_request_id ec
                | None -> false)
           | None -> false)
   | _ -> false


### PR DESCRIPTION
## 문제

`Mcp_error_code.t` 는 생성자 12개의 닫힌 variant 다. 모듈 안의 분류기들은 전 생성자를 나열한다 — `to_http_status`, `to_wire_code`, `to_wire_message_default` 모두 catch-all 이 없다. 새 코드를 추가하면 컴파일러가 각 지점에서 결정을 강제한다.

예외가 두 곳 있었다. 서버 파일 두 개가 같은 술어를 **각자 로컬로, catch-all 로** 정의한다.

```ocaml
(* server_mcp_transport_http_headers.ml:21, server_routes_http_runtime.ml:42 — 동일 *)
let is_parse_or_invalid = function
  | Mcp_error_code.Parse_error | Invalid_request -> true
  | _ -> false
```

새 error code 가 추가돼도 이 두 지점은 조용히 `false` 를 답한다. CLAUDE.md 가 금지하는 형태다 — "FSM 전이 매트릭스는 `_ -> false` catch-all을 사용하지 않고 모든 쌍을 명시".

## 변경

술어를 모듈로 옮기고 전 생성자를 나열했다.

```ocaml
val allows_null_request_id : t -> bool
(** Whether a response carrying this code may leave [id] null.  True only
    for [Parse_error] and [Invalid_request], the two JSON-RPC 2.0 §5 cases
    where the request id could not be read.  Exhaustive over [t]: adding a
    code is a compile error here rather than a silent [false]. *)
```

두 호출부는 `Mcp_error_code.allows_null_request_id ec` 로 대체. 동작은 동일하다 — 같은 두 생성자만 `true`.

## 검증

새 생성자 `Probe_new_code` 를 임시로 추가하고 빌드했다.

```
Error: this pattern-matching is not exhaustive.
       ... not matched: Probe_new_code
```

제거 후 `dune build --root . @check` → 0. `is_parse_or_invalid` 잔여 0.

## 범위

동작 변화 없음. 이 술어가 `Parse_error` / `Invalid_request` 외로 넓어질 일은 JSON-RPC 스펙상 없지만, 새 error code 를 추가하는 쪽이 "이 코드는 null id 를 허용하나"를 **한 곳에서** 답하게 된다는 것이 차이다. 지금은 두 곳이 묻지도 않고 `false` 로 답한다.

발견 경위: 하드코딩 스윕에서 닫힌 variant 위의 catch-all 을 훑던 중. CLAUDE.md 가 지목한 `validate_decision_transition` / `validate_cascade_transition` 은 이미 전 쌍을 명시하고 있어 손댈 것이 없었다.
