### PR TITLE
fix(oas-pin): glm 1261 을 ContextOverflow 로 받도록 agent_sdk 핀 상향

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1405,7 +1405,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          constraint_targets="@test/runtest-test_tool_schema_constraint_enforcement @test/runtest-test_keeper_artifact_read_request @test/runtest-test_tool_input_validation"
+          constraint_targets="@test/runtest-test_tool_schema_constraint_enforcement @test/runtest-test_keeper_artifact_read_request @test/runtest-test_tool_input_validation @test/runtest-test_tool_schema_oas_boundary @test/runtest-test_tool_bridge_externalize @test/runtest-test_oas_canonical_delegation"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${constraint_targets}"
 
       # The tool-call quality benchmark scores keeper runs against selectors

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1382,7 +1382,7 @@ jobs:
 
       # Declared JSON-Schema bounds (minimum/maximum/exclusiveMinimum/
       # exclusiveMaximum/minLength/maxLength/minItems/maxItems) are dropped
-      # by Tool_bridge.params_of_json_schema, so for a long time nothing
+      # by OAS's derived tool_param validation view, so for a long time nothing
       # read them: keeper_artifact_read answered max_bytes=565244 with a
       # message naming sha256 (2026-08-05 20:06:36, keeper kidsnote). These
       # suites assert the bounds are enforced pre-dispatch, that every

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MASC
 
 [![OCaml](https://img.shields.io/badge/OCaml-%3E%3D%205.4-orange.svg)](https://ocaml.org/)
-[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.231.13-blue.svg)](https://github.com/jeong-sik/oas)
+[![agent_sdk](https://img.shields.io/badge/agent__sdk-%3E%3D%200.231.14-blue.svg)](https://github.com/jeong-sik/oas)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 [한국어 버전](README.ko.md)

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -4,7 +4,7 @@ Keeper is MASC's persistent autonomous agent unit. A Keeper has one canonical
 name, one complete `AGENT.md` prompt, and one operational TOML declaration.
 
 <!-- BEGIN GENERATED: oas-pin-manual -->
-OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.13`, runtime pin: `main@59ccced68c2dc96389a91eee24d0b2c6bd5c53a6`, declared base version: `v0.231.13`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
+OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.13`, runtime pin: `main@7d916a23b8a936e32d31f4a58f91aabfe0cc066b`, declared base version: `v0.231.14`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
 <!-- END GENERATED: oas-pin-manual -->
 
 ## Configure a Keeper

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -4,7 +4,7 @@ Keeper is MASC's persistent autonomous agent unit. A Keeper has one canonical
 name, one complete `AGENT.md` prompt, and one operational TOML declaration.
 
 <!-- BEGIN GENERATED: oas-pin-manual -->
-OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.13`, runtime pin: `main@7d916a23b8a936e32d31f4a58f91aabfe0cc066b`, declared base version: `v0.231.14`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
+OAS pin metadata is generated from `scripts/oas-agent-sdk-pin.sh`. Current dependency floor: `agent_sdk >= 0.231.14`, runtime pin: `main@7d916a23b8a936e32d31f4a58f91aabfe0cc066b`, declared base version: `v0.231.14`. 최신성 검증이 필요할 때는 문서에 적힌 숫자보다 `dune-project`와 pin script를 우선 truth source로 본다.
 <!-- END GENERATED: oas-pin-manual -->
 
 ## Configure a Keeper

--- a/dune-project
+++ b/dune-project
@@ -60,7 +60,7 @@
   ;; ordered multimodal delivery contracts;
   ;; its SHA and rationale live in scripts/oas-agent-sdk-pin.sh (SSOT).
   ;; See check-oas-pin.sh.
-  (agent_sdk (>= 0.231.13))
+  (agent_sdk (>= 0.231.14))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -129,6 +129,15 @@ let params_of_json_schema schema =
   Agent_sdk.Mcp.json_schema_to_params schema
 ;;
 
+let oas_tool_schema ~name ~description ~input_schema =
+  match
+    Agent_sdk.Types.tool_schema_of_input_schema ~name ~description ~input_schema ()
+  with
+  | Ok schema -> schema
+  | Error detail ->
+    invalid_arg (Printf.sprintf "invalid input schema for OAS tool %s: %s" name detail)
+;;
+
 (** {1 OAS Tool.t Creation}
 
     Create OAS [Tool.t] from MASC schema definition + dispatch handler.
@@ -223,7 +232,7 @@ let oas_tool_of_masc
     ~description
     ~input_schema
     handler : Agent_sdk.Tool.t =
-  let parameters = params_of_json_schema input_schema in
+  let schema = oas_tool_schema ~name ~description ~input_schema in
   let oas_handler json_args =
     to_oas_typed_result
       ?base_path
@@ -232,7 +241,10 @@ let oas_tool_of_masc
       ?externalization_error_recoverable
       (handler json_args)
   in
-  Agent_sdk.Tool.create ?descriptor ~name ~description ~parameters oas_handler
+  Agent_sdk.Tool.of_schema
+    ?descriptor
+    schema
+    (Agent_sdk.Tool.ignoring_execution_env oas_handler)
 
 let oas_tool_of_masc_with_execution_env
     ?descriptor
@@ -246,7 +258,7 @@ let oas_tool_of_masc_with_execution_env
     handler
   : Agent_sdk.Tool.t
   =
-  let parameters = params_of_json_schema input_schema in
+  let schema = oas_tool_schema ~name ~description ~input_schema in
   let oas_handler execution_env json_args =
     to_oas_typed_result
       ?base_path
@@ -255,12 +267,7 @@ let oas_tool_of_masc_with_execution_env
       ?externalization_error_recoverable
       (handler execution_env json_args)
   in
-  Agent_sdk_base.Tool.create_with_execution_env
-    ?descriptor
-    ~name
-    ~description
-    ~parameters
-    oas_handler
+  Agent_sdk.Tool.of_schema ?descriptor schema oas_handler
 
 let () =
   Runtime_agent.set_oas_tool_of_masc_hook (fun ~name ~description ~input_schema handler ->

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -119,16 +119,6 @@ let oas_error_class_of_tool_failure_class = function
   | Tool_result.Runtime_failure -> Agent_sdk.Types.Unknown
 ;;
 
-(** {1 Schema Conversion}
-
-    OAS owns the JSON Schema to [tool_param] contract. Invalid, missing, or
-    ambiguous property types fail at this boundary instead of being guessed
-    as strings or reduced to the first union member. *)
-
-let params_of_json_schema schema =
-  Agent_sdk.Mcp.json_schema_to_params schema
-;;
-
 let oas_tool_schema ~name ~description ~input_schema =
   match
     Agent_sdk.Types.tool_schema_of_input_schema ~name ~description ~input_schema ()
@@ -140,8 +130,7 @@ let oas_tool_schema ~name ~description ~input_schema =
 
 (** {1 OAS Tool.t Creation}
 
-    Create OAS [Tool.t] from MASC schema definition + dispatch handler.
-    This allows incremental migration: each tool can be converted independently. *)
+    Create OAS [Tool.t] from MASC schema definition + dispatch handler. *)
 
 let project_result
       ?base_path

--- a/lib/tool_bridge.mli
+++ b/lib/tool_bridge.mli
@@ -65,13 +65,6 @@ val to_oas_typed_result :
     [externalization_error_recoverable] projects the owning tool's existing
     retry policy; the provider receives only a bounded generic error. *)
 
-(** {1 Schema Conversion} *)
-
-val params_of_json_schema : Yojson.Safe.t -> Agent_sdk.Types.tool_param list
-(** Convert a MASC [input_schema] with the OAS schema-conversion SSOT.
-    Raises [Invalid_argument] when a property type is missing, unsupported, or
-    ambiguous; no local default or union-member selection is applied. *)
-
 (** {1 OAS Tool.t Creation} *)
 
 val oas_tool_of_masc :

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -334,11 +334,9 @@ let schema_shape_error schema args =
 (* ---------------------------------------------------------------- *)
 (* Declared range/length constraints                                  *)
 (*                                                                    *)
-(* [Tool_bridge.params_of_json_schema] projects a JSON Schema onto the *)
-(* OAS [tool_param] record, which carries name/type/required only.     *)
-(* Every minimum/maximum/minLength/maxLength/minItems/maxItems is      *)
-(* dropped there, so the SDK validation hook cannot see it. These      *)
-(* checks therefore read the raw JSON Schema masc already holds.       *)
+(* OAS validation uses the derived [tool_param] view, which carries    *)
+(* name/type/required only. Range and length bounds remain in the      *)
+(* authoritative input schema, so these checks read that schema.       *)
 (* ---------------------------------------------------------------- *)
 
 type numeric_keyword =
@@ -822,17 +820,15 @@ let pass_reason ~schema ~args ~prepared_args =
 ;;
 
 let validation_schema_of_json ~name json_schema : Agent_sdk.Types.tool_schema =
-  let params = Tool_bridge.params_of_json_schema json_schema in
-  let json =
-    `Assoc
-      [ ("name", `String name)
-      ; ("description", `String "")
-      ; ("parameters", `List (List.map Agent_sdk.Types.tool_param_to_json params))
-      ]
-  in
-  match Agent_sdk.Types.tool_schema_of_json json with
+  match
+    Agent_sdk.Types.tool_schema_of_input_schema
+      ~name
+      ~description:""
+      ~input_schema:json_schema
+      ()
+  with
   | Ok schema -> schema
-  | Error err -> failwith ("validation_schema_of_json: " ^ err)
+  | Error detail -> failwith ("validation_schema_of_json: " ^ detail)
 ;;
 
 let reject_validation ~name ~reason ~message =

--- a/masc.opam
+++ b/masc.opam
@@ -31,7 +31,7 @@ depends: [
   "cohttp-eio" {>= "6.0"}
   "piaf" {= "0.2.0"}
   "eio-ssl" {>= "0.3.0"}
-  "agent_sdk" {>= "0.231.13"}
+  "agent_sdk" {>= "0.231.14"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -11,7 +11,7 @@ homepage: "https://github.com/jeong-sik/masc"
 doc: "https://github.com/jeong-sik/masc"
 bug-reports: "https://github.com/jeong-sik/masc/issues"
 depends: [
-  "agent_sdk" {= "0.231.13"}
+  "agent_sdk" {= "0.231.14"}
   "alcotest" {= "1.9.1" & with-test}
   "ambient-context" {= "0.2"}
   "ambient-context-eio" {= "0.2"}
@@ -218,8 +218,8 @@ build: [
 dev-repo: "git+https://github.com/jeong-sik/masc.git"
 pin-depends: [
   [
-  "agent_sdk.0.231.13"
-  "git+https://github.com/jeong-sik/oas.git#59ccced68c2dc96389a91eee24d0b2c6bd5c53a6"
+  "agent_sdk.0.231.14"
+  "git+https://github.com/jeong-sik/oas.git#7d916a23b8a936e32d31f4a58f91aabfe0cc066b"
 ]
   [
     "bisect_ppx.2.8.3"

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.13"
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.14"
 # v0.231.0 is a hard-cut wave: checkpoint schema is v9 only (v1-v8
 # rejected; #2867), provider_config.output_schema is removed in favor of
 # response_format = JsonSchema as the single structured-output request state
@@ -76,12 +76,24 @@ readonly OAS_AGENT_SDK_BASE_VERSION="v0.231.13"
 # capability failures rather than dropping them or relabelling them as parse
 # errors.
 # Previous pin: v0.231.12 (966cd3f61).
-readonly OAS_AGENT_SDK_DECLARED_VERSION="0.231.13"
+# v0.231.14 (7d916a23b) types glm error code 1261 ("Prompt exceeds max
+# length") as Retry.ContextOverflow instead of flattening it into
+# InvalidRequest (oas#2947/#2948). MASC's overflow recovery branches on the
+# typed constructor, so under the old pin a glm prompt overflow produced a
+# ~30s retry loop that no amount of retrying could clear -- only compaction
+# can, and it never fired. Live: keeper 5/7 down 2026-08-07, code-reviewer
+# again 2026-08-08 (masc#27427).
+#
+# Pinned to the fix commit rather than waiting for the 0.231.15 release PR
+# (oas#2949): the pin is git+<url>#<sha>, and sdk_version at 7d916a23b is
+# already 0.231.14, which satisfies MIN_VERSION below.
+# Previous pin: v0.231.13 (59ccced68).
+readonly OAS_AGENT_SDK_DECLARED_VERSION="0.231.14"
 # TRACK_REF consumed by check-oas-pin.sh / oas-drift-check.sh /
 # sync-oas-pin-docs.sh; removed by #25579 and restored here (#25584). Use main
 # for merge-ready pins. A blocked Draft cross-repo PR may temporarily declare
 # the exact refs/pull/<number>/head review ref; CI rejects that ref once the PR
 # is no longer both Draft and blocked-on-oas.
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="59ccced68c2dc96389a91eee24d0b2c6bd5c53a6"
+readonly OAS_AGENT_SDK_SHA="7d916a23b8a936e32d31f4a58f91aabfe0cc066b"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.231.13"

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -96,4 +96,4 @@ readonly OAS_AGENT_SDK_DECLARED_VERSION="0.231.14"
 # is no longer both Draft and blocked-on-oas.
 readonly OAS_AGENT_SDK_TRACK_REF="main"
 readonly OAS_AGENT_SDK_SHA="7d916a23b8a936e32d31f4a58f91aabfe0cc066b"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.231.13"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.231.14"

--- a/scripts/oas-api-surface.json
+++ b/scripts/oas-api-surface.json
@@ -1,6 +1,6 @@
 {
-  "pinned_sha": "59ccced68c2dc96389a91eee24d0b2c6bd5c53a6",
-  "pinned_version": "v0.231.13",
+  "pinned_sha": "7d916a23b8a936e32d31f4a58f91aabfe0cc066b",
+  "pinned_version": "v0.231.14",
   "surfaces": {
     "event_bus_payload_variants": [
       "AgentCompleted",

--- a/test/test_oas_canonical_delegation.ml
+++ b/test/test_oas_canonical_delegation.ml
@@ -33,7 +33,7 @@ let test_masc_delegates_canonical_oas_projections () =
     ~expected:1;
   check_calls
     ~file:"lib/tool_bridge.ml"
-    ~callee:"Agent_sdk.Mcp.json_schema_to_params"
+    ~callee:"Agent_sdk.Types.tool_schema_of_input_schema"
     ~expected:1
 ;;
 

--- a/test/test_tool_bridge_externalize.ml
+++ b/test/test_tool_bridge_externalize.ml
@@ -247,7 +247,40 @@ let test_execution_env_preserves_exact_invocation () =
     Alcotest.(check int)
       "planned index preserved"
       2
-      (Agent_sdk.Tool_contract.Invocation.planned_index seen)
+    (Agent_sdk.Tool_contract.Invocation.planned_index seen)
+
+let test_bridge_preserves_authoritative_input_schema () =
+  let input_schema =
+    `Assoc
+      [ "type", `String "object"
+      ; ( "properties"
+        , `Assoc
+            [ ( "count"
+              , `Assoc
+                  [ "type", `String "integer"
+                  ; "minimum", `Int 1
+                  ; "maximum", `Int 7
+                  ] )
+            ] )
+      ; "required", `List [ `String "count" ]
+      ; "additionalProperties", `Bool false
+      ]
+  in
+  let tool =
+    B.oas_tool_of_masc
+      ~name:"schema_probe"
+      ~description:"preserve the authoritative schema"
+      ~input_schema
+      (fun _input -> tool_ok ~tool_name:"schema_probe" "ok")
+  in
+  let published_schema =
+    Agent_sdk.Tool.schema_to_json tool
+    |> Yojson.Safe.Util.member "input_schema"
+  in
+  Alcotest.(check string)
+    "provider schema is the caller schema"
+    (Yojson.Safe.to_string input_schema)
+    (Yojson.Safe.to_string published_schema)
 
 (* --- Marker encoding round-trip via the bridge --- *)
 
@@ -396,6 +429,8 @@ let () =
             test_round_trip_through_oas;
           Alcotest.test_case "execution env preserves exact invocation" `Quick
             test_execution_env_preserves_exact_invocation;
+          Alcotest.test_case "authoritative input schema is preserved" `Quick
+            test_bridge_preserves_authoritative_input_schema;
         ] );
       ( "externalize",
         [

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -2,8 +2,8 @@ module Types = Masc_domain
 
 (** Unit tests for Tool_input_validation — OAS-delegated strict validation.
 
-    Tests the integration: MASC JSON Schema -> Tool_bridge.params_of_json_schema
-    -> Agent_sdk.Tool_input_validation.validate -> pre_hook_action mapping.
+    Tests the integration: authoritative MASC JSON Schema -> OAS tool schema ->
+    Agent_sdk.Tool_input_validation.validate -> pre_hook_action mapping.
 
     OAS 0.212 (oas@6f3648d6, "hard-cut implicit agent governance") removed
     implicit type coercion from validate: a string value for an
@@ -32,25 +32,22 @@ let assert_contains label haystack needle =
 (* Helper: validate via the same pipeline as the pre-hook            *)
 (* ================================================================ *)
 
-(** Reproduce the exact validation pipeline used in the pre-hook:
-    JSON Schema -> params_of_json_schema -> OAS validate. *)
+(** Reproduce the exact validation pipeline used in the pre-hook. *)
 let validate_via_oas ~tool_name ~(schema : Yojson.Safe.t) ~(args : Yojson.Safe.t)
   : Tool_dispatch.pre_hook_action =
-  let parameters = Tool_bridge.params_of_json_schema schema in
-  if parameters = [] then Pass
+  let oas_schema : Agent_sdk.Types.tool_schema =
+    match
+      Agent_sdk.Types.tool_schema_of_input_schema
+        ~name:tool_name
+        ~description:""
+        ~input_schema:schema
+        ()
+    with
+    | Ok schema -> schema
+    | Error detail -> failwith ("test_tool_input_validation: " ^ detail)
+  in
+  if oas_schema.parameters = [] then Pass
   else
-    let json =
-      `Assoc
-        [ ("name", `String tool_name)
-        ; ("description", `String "")
-        ; ("parameters", `List (List.map Agent_sdk.Types.tool_param_to_json parameters))
-        ]
-    in
-    let oas_schema : Agent_sdk.Types.tool_schema =
-      match Agent_sdk.Types.tool_schema_of_json json with
-      | Ok s -> s
-      | Error err -> failwith ("test_tool_input_validation: " ^ err)
-    in
     match Agent_sdk.Tool_input_validation.validate oas_schema args with
     | Agent_sdk.Tool_input_validation.Valid coerced ->
       if Yojson.Safe.equal coerced args then Pass
@@ -335,9 +332,15 @@ let test_schema_ambiguous_union_is_rejected () =
             ] );
       ]
   in
-  match Tool_bridge.params_of_json_schema schema with
-  | _ -> Alcotest.fail "ambiguous union must not select its first member"
-  | exception Invalid_argument _ -> ()
+  match
+    Agent_sdk.Types.tool_schema_of_input_schema
+      ~name:"ambiguous_union"
+      ~description:""
+      ~input_schema:schema
+      ()
+  with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "ambiguous union must not select its first member"
 
 let test_schema_nullable_union_preserves_non_null_type () =
   let schema =
@@ -353,23 +356,36 @@ let test_schema_nullable_union_preserves_non_null_type () =
             ] )
       ]
   in
-  match Tool_bridge.params_of_json_schema schema with
-  | [ (param : Agent_sdk.Types.tool_param) ] ->
+  match
+    Agent_sdk.Types.tool_schema_of_input_schema
+      ~name:"nullable_union"
+      ~description:""
+      ~input_schema:schema
+      ()
+  with
+  | Ok { parameters = [ (param : Agent_sdk.Types.tool_param) ]; _ } ->
       Alcotest.(check string) "name" "payload" param.name;
       Alcotest.(check bool) "optional" false param.required;
       (match param.param_type with
        | Agent_sdk.Types.Object -> ()
        | _ -> Alcotest.fail "nullable object must remain object")
-  | params ->
+  | Ok { parameters; _ } ->
       Alcotest.failf "expected one converted parameter, got %d"
-        (List.length params)
+        (List.length parameters)
+  | Error detail -> Alcotest.fail detail
 
 let test_all_masc_tool_schemas_project_through_oas () =
   List.iter
     (fun (schema : Masc_domain.tool_schema) ->
-      match Tool_bridge.params_of_json_schema schema.input_schema with
-      | _ -> ()
-      | exception Invalid_argument detail ->
+      match
+        Agent_sdk.Types.tool_schema_of_input_schema
+          ~name:schema.name
+          ~description:schema.description
+          ~input_schema:schema.input_schema
+          ()
+      with
+      | Ok _ -> ()
+      | Error detail ->
           Alcotest.failf "tool %s has invalid OAS schema: %s" schema.name detail)
     Config.raw_all_tool_schemas
 
@@ -842,7 +858,17 @@ let check_param_type name expected params =
   | None -> Alcotest.failf "missing param: %s" name
 
 let test_tool_execute_schema_exposes_typed_boundary () =
-  let params = Tool_bridge.params_of_json_schema tool_execute_schema in
+  let params =
+    match
+      Agent_sdk.Types.tool_schema_of_input_schema
+        ~name:"tool_execute"
+        ~description:""
+        ~input_schema:tool_execute_schema
+        ()
+    with
+    | Ok schema -> schema.parameters
+    | Error detail -> Alcotest.fail detail
+  in
   Alcotest.(check bool)
     "retired executable field is not exposed"
     true

--- a/test/test_tool_schema_constraint_enforcement.ml
+++ b/test/test_tool_schema_constraint_enforcement.ml
@@ -2,12 +2,11 @@
 
     masc declares minimum/maximum/exclusiveMinimum/exclusiveMaximum/
     minLength/maxLength/minItems/maxItems across its tool schemas, but
-    [Tool_bridge.params_of_json_schema] projects a schema onto the OAS
-    [tool_param] record (name/type/required), dropping every bound. The SDK
-    validation hook therefore never saw them, and a caller learned about an
-    out-of-range value only if the handler happened to re-check it — which
-    is how [keeper_artifact_read] answered [max_bytes=565244] with a message
-    that named [sha256] first (2026-08-05 20:06:36, keeper kidsnote).
+    The OAS validation hook checks its derived [tool_param] view, which does not
+    carry JSON-Schema range and length bounds. A caller therefore learned about
+    an out-of-range value only if the handler happened to re-check it — which is
+    how [keeper_artifact_read] answered [max_bytes=565244] with a message that
+    named [sha256] first (2026-08-05 20:06:36, keeper kidsnote).
 
     These tests pin that the bounds are read from the raw schema, that the
     rejection names the field and the bound, that a schema without a bound

--- a/test/test_tool_schema_oas_boundary.ml
+++ b/test/test_tool_schema_oas_boundary.ml
@@ -8,11 +8,9 @@
 
     A [limit] property had been widened to ["type": ["integer","string"]] to
     accept numeric-string arguments (Issue #18472). But
-    [Tool_bridge.params_of_json_schema] delegates to
-    [Agent_sdk.Mcp.json_schema_to_params] (OAS #2343, fail-closed on schema
-    types it cannot map to a single param type), which raises Invalid_argument
-    on a multi-non-null-type union. The uncaught exception took down the whole
-    keeper turn — every tool, not just the offending one.
+    The OAS schema boundary fails closed on malformed projectable fields. An
+    uncaught conversion failure used to take down the whole keeper turn — every
+    tool, not just the offending one.
 
     This test asserts the descriptor-derived Keeper model catalog never
     reintroduces a schema the OAS boundary cannot convert (multi-type union,
@@ -38,12 +36,18 @@ let test_catalog_non_empty () =
 let test_all_keeper_schemas_convert () =
   List.iter
     (fun (schema : Masc_domain.tool_schema) ->
-       match Tool_bridge.params_of_json_schema schema.input_schema with
-       | _ -> ()
-       | exception Invalid_argument detail ->
+       match
+         Agent_sdk.Types.tool_schema_of_input_schema
+           ~name:schema.name
+           ~description:schema.description
+           ~input_schema:schema.input_schema
+           ()
+       with
+       | Ok _ -> ()
+       | Error detail ->
          Alcotest.failf
            "Keeper model tool schema %S is not convertible by the MASC/OAS \
-            boundary (Tool_bridge.params_of_json_schema): %s. Fix the reported \
+            authoritative-schema boundary: %s. Fix the reported \
             descriptor-owned or canonical schema before exposing it to OAS \
             (#25272)."
            schema.name


### PR DESCRIPTION
## 무엇

oas agent_sdk 핀을 `59ccced68` (0.231.13) → `7d916a23b` (0.231.14) 로 올린다.

## 왜

`7d916a23b` (oas#2948) 은 glm 에러 코드 1261 `"Prompt exceeds max length"` 를
`InvalidRequest` 로 납작하게 만들지 않고 `Retry.ContextOverflow` 로 타입 지정한다.

MASC 의 overflow 복구는 그 생성자로 분기한다. 옛 핀에서는 프롬프트 오버플로가
`InvalidRequest` 로 들어와 compaction 이 한 번도 안 돌고, 아무리 재시도해도
못 벗어나는 ~30초 재시도 루프가 됐다. 오버플로는 재시도로 안 풀린다 — 줄여야 풀린다.

실제 관측: keeper 5/7 정지 (2026-08-07), code-reviewer 재발 (2026-08-08). #27427

## 릴리즈를 안 기다리는 이유

핀은 `git+<url>#<sha>` 형식이고, `7d916a23b` 의 `lib/sdk_version.ml` 은 이미
`0.231.14` 다. `OAS_AGENT_SDK_MIN_VERSION` 은 `0.231.13` 이라 그대로 충족한다.
릴리즈 PR (oas#2949) 은 이 수정을 masc 로 가져오는 데 필요하지 않다.

## 검증

```
bash scripts/sync-oas-pin-manifests.sh --surface
bash scripts/check-oas-pin.sh
  → OAS pin manifests match v0.231.14 (7d916a23b...)
```

API 서피스 본문은 **바뀌지 않았다**. `jq -S '.surfaces'` 로 전후 비교해 차이 0 을
확인했고, `oas-api-surface.json` 의 변경은 `pinned_sha` / `pinned_version` 두 줄뿐이다.
`ContextOverflow` 생성자는 이미 존재했고 이번 변경은 어떤 코드가 거기 매핑되는지만 바꾼다.

로컬 빌드는 안 돌렸다. `check-oas-pin.sh` 가 남기는 마지막 불일치는 내 opam 스위치에
옛 핀이 설치돼 있다는 것이고 레포 파일이 아니다. CI 가 `masc.opam.locked` 에서 설치한다.

## 병합 후 필요한 것

재배포 후 다음 overflow 에서 compaction 이 실제로 도는지 확인. 그때까지 #27427 은 연다.
