### PR TITLE
fix(goal): show which unowned Goals are under another

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -717,14 +717,13 @@ let executing_goals_without_tasks ~(config : Workspace.config) ~owner_matches =
   | _ :: _ ->
     let tasks = Workspace.get_tasks_raw config in
     let index = Workspace_goal_index.build_goal_task_index_for_config config tasks in
-    List.filter_map
+    List.filter
       (fun (g : Goal_store.goal) ->
-         if not (Goal_phase.admits_self_directed_progress g.phase)
-         then None
-         else (
-           match Hashtbl.find_opt index g.id with
-           | Some (_ :: _) -> None
-           | None | Some [] -> Some (g.id, g.title)))
+         Goal_phase.admits_self_directed_progress g.phase
+         &&
+         match Hashtbl.find_opt index g.id with
+         | Some (_ :: _) -> false
+         | None | Some [] -> true)
       goals
 ;;
 
@@ -735,6 +734,7 @@ let owned_executing_goals_without_tasks
   executing_goals_without_tasks ~config ~owner_matches:(function
     | Some owner -> String.equal owner keeper_name
     | None -> false)
+  |> List.map (fun (g : Goal_store.goal) -> g.id, g.title)
 ;;
 
 (* RFC-0362 §6 Q2, which the RFC left open: "Should [phase = executing] with
@@ -751,11 +751,19 @@ let owned_executing_goals_without_tasks
 
    Same shape as the owned list and the same restraint: it names a fact, and
    renders nothing when there is nothing to name. It does not pick an owner
-   (RFC-0362 §5) and asks for no action. *)
+   (RFC-0362 §5) and asks for no action.
+
+   [parent_goal_id] rides along because the flat list without it misreads. On
+   the live store, seven of the ten unowned Goals are children of the eighth,
+   and rendered as peers "take one" cannot distinguish taking the umbrella from
+   taking one service under it -- two Keepers could take both and do the same
+   work twice. The relation is already in the store; only the render dropped
+   it. *)
 let unowned_executing_goals_without_tasks ~(config : Workspace.config) =
   executing_goals_without_tasks ~config ~owner_matches:(function
     | Some _ -> false
     | None -> true)
+  |> List.map (fun (g : Goal_store.goal) -> g.id, g.title, g.parent_goal_id)
 ;;
 
 let build_system_prompt ~(meta : Keeper_meta_contract.keeper_meta)
@@ -905,22 +913,52 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta)
                      goals)))
       in
       (* RFC-0362 §6 Q2. An unowned executing Goal is addressed to whoever reads
-         it, so it is the same fact for every Keeper and rendered to each. *)
+         it, so it is the same fact for every Keeper and rendered to each.
+
+         A child is indented under its parent when the parent is in this same
+         list, because there taking the parent and taking the child are not two
+         independent moves. A child whose parent is absent -- owned, terminal,
+         or already served by a Task -- is its own invitation and stays at the
+         top level. Depth stops at one: [parent_goal_id] is a single link and
+         nesting further would trade the fact for a shape. *)
       let unowned_block =
         match unowned_executing_goals_without_tasks ~config with
         | [] -> None
         | goals ->
+          let present = List.map (fun (goal_id, _, _) -> goal_id) goals in
+          let line ~indent (goal_id, title, _) =
+            if String.trim title = ""
+            then Printf.sprintf "%s- %s" indent goal_id
+            else Printf.sprintf "%s- %s — %s" indent goal_id title
+          in
+          let children_of parent_id =
+            List.filter
+              (fun (_, _, parent) ->
+                 match parent with
+                 | Some p -> String.equal p parent_id
+                 | None -> false)
+              goals
+          in
+          let stands_alone (_, _, parent) =
+            match parent with
+            | None -> true
+            | Some p -> not (List.exists (String.equal p) present)
+          in
+          let rendered =
+            List.concat_map
+              (fun ((goal_id, _, _) as goal) ->
+                 if not (stands_alone goal)
+                 then []
+                 else
+                   line ~indent:"" goal
+                   :: List.map (line ~indent:"  ") (children_of goal_id))
+              goals
+          in
           Some
             (Printf.sprintf
                "### Unowned Goals, no Task yet — taking one is a move you can make (%d)\n%s\n\n"
                (List.length goals)
-               (String.concat "\n"
-                  (List.map
-                     (fun (goal_id, title) ->
-                        if String.trim title = ""
-                        then Printf.sprintf "- %s" goal_id
-                        else Printf.sprintf "- %s — %s" goal_id title)
-                     goals)))
+               (String.concat "\n" rendered))
       in
       (match List.filter_map Fun.id [ active_block; owned_block; unowned_block ] with
        | [] -> None

--- a/lib/keeper/keeper_unified_prompt.mli
+++ b/lib/keeper/keeper_unified_prompt.mli
@@ -69,15 +69,19 @@ val owned_executing_goals_without_tasks :
     decoration and should be removed. *)
 
 val unowned_executing_goals_without_tasks :
-  config:Workspace.config -> (string * string) list
-(** RFC-0362 §6 Q2 — the executing Goals nobody owns and no Task serves. The
-    same list for every keeper, because an unowned Goal is addressed to whoever
-    reads it.
+  config:Workspace.config -> (string * string * string option) list
+(** RFC-0362 §6 Q2 — the executing Goals nobody owns and no Task serves, each
+    with its [parent_goal_id]. The same list for every keeper, because an
+    unowned Goal is addressed to whoever reads it.
 
     The prompt already states that taking one is a move a keeper can make, and
     [handle_goal_assign] carries no ownership check. What was missing was the
     sighting: with 15 of 16 live Goals unowned,
-    {!owned_executing_goals_without_tasks} renders for nobody. *)
+    {!owned_executing_goals_without_tasks} renders for nobody.
+
+    The parent rides along because the list misreads without it: on the live
+    store seven of the ten are children of the eighth, and as peers "take one"
+    cannot distinguish taking the umbrella from taking one service under it. *)
 
 val active_goal_summaries :
   config:Workspace.config ->

--- a/test/test_keeper_goal_phase_projection.ml
+++ b/test/test_keeper_goal_phase_projection.ml
@@ -230,7 +230,10 @@ let test_another_keepers_goal_is_not_surfaced () =
    pin the sighting and, more importantly, that it stays as narrow as the owned
    one: same phase filter, same "already has a Task" exclusion. *)
 
-let unowned config = List.map fst (Keeper_unified_prompt.unowned_executing_goals_without_tasks ~config)
+let unowned config =
+  List.map
+    (fun (goal_id, _, _) -> goal_id)
+    (Keeper_unified_prompt.unowned_executing_goals_without_tasks ~config)
 
 let test_unowned_executing_goal_without_task_surfaces () =
   with_workspace (fun config ->
@@ -307,16 +310,7 @@ let test_unowned_goal_with_a_linked_task_is_not_surfaced () =
 (* The helper cases above prove which Goals qualify. This proves a Keeper is
    actually handed them: the block is what closes RFC-0362 §6 Q2, and a correct
    list nobody renders is the state this change exists to end. *)
-let test_unowned_goals_reach_the_rendered_turn () =
-  with_workspace @@ fun config ->
-  Goal_store.write_state config
-    { version = 1
-    ; updated_at = Masc_domain.now_iso ()
-    ; goals =
-        [ goal_in Goal_phase.Executing "goal-open" "nobody holds this"
-        ; goal_in Goal_phase.Completed "goal-done" "already achieved"
-        ]
-    };
+let rendered_world_state config =
   let meta = meta_with_goals [] in
   let observation =
     Keeper_world_observation.observe ~pending_board_events:(Some []) ~config ~meta
@@ -330,16 +324,80 @@ let test_unowned_goals_reach_the_rendered_turn () =
       ~observation
       ()
   in
-  let contains needle =
-    let n = String.length needle and h = String.length world_state in
-    let rec go i = i + n <= h && (String.sub world_state i n = needle || go (i + 1)) in
-    n = 0 || go 0
-  in
+  world_state
+;;
+
+let contains_in haystack needle =
+  let n = String.length needle and h = String.length haystack in
+  let rec go i = i + n <= h && (String.sub haystack i n = needle || go (i + 1)) in
+  n = 0 || go 0
+;;
+
+let test_unowned_goals_reach_the_rendered_turn () =
+  with_workspace @@ fun config ->
+  Goal_store.write_state config
+    { version = 1
+    ; updated_at = Masc_domain.now_iso ()
+    ; goals =
+        [ goal_in Goal_phase.Executing "goal-open" "nobody holds this"
+        ; goal_in Goal_phase.Completed "goal-done" "already achieved"
+        ]
+    };
+  let world = rendered_world_state config in
   check bool "the heading names the move the prompt already promises" true
-    (contains "### Unowned Goals, no Task yet — taking one is a move you can make (1)");
+    (contains_in world
+       "### Unowned Goals, no Task yet — taking one is a move you can make (1)");
   check bool "the goal is named with its title" true
-    (contains "- goal-open — nobody holds this");
-  check bool "a completed goal is not offered" false (contains "goal-done")
+    (contains_in world "- goal-open — nobody holds this");
+  check bool "a completed goal is not offered" false (contains_in world "goal-done")
+;;
+
+let goal_child_of parent phase id title =
+  { (goal_in phase id title) with Goal_store.parent_goal_id = Some parent }
+;;
+
+(* Seven of the ten unowned Goals on the live store are children of the eighth.
+   Rendered as peers, "taking one is a move you can make" cannot distinguish
+   taking the umbrella from taking one service under it, and two Keepers could
+   take both and do the same work twice. The relation is in the store; the flat
+   render dropped it. *)
+let test_a_child_renders_under_its_parent () =
+  with_workspace @@ fun config ->
+  Goal_store.write_state config
+    { version = 1
+    ; updated_at = Masc_domain.now_iso ()
+    ; goals =
+        [ goal_in Goal_phase.Executing "goal-umbrella" "all services to zero"
+        ; goal_child_of "goal-umbrella" Goal_phase.Executing "goal-one" "service one"
+        ; goal_in Goal_phase.Executing "goal-standalone" "unrelated"
+        ]
+    };
+  let world = rendered_world_state config in
+  check bool "the child is indented under its parent" true
+    (contains_in world "- goal-umbrella — all services to zero\n  - goal-one — service one");
+  check bool "an unrelated goal stays at the top level" true
+    (contains_in world "\n- goal-standalone — unrelated");
+  check bool "the count is still every goal, not just the roots" true
+    (contains_in world "taking one is a move you can make (3)")
+;;
+
+(* A child whose parent is not in this list -- owned, terminal, or already served
+   by a Task -- is its own invitation, so it must not be hidden by the nesting. *)
+let test_a_child_whose_parent_is_absent_stands_alone () =
+  with_workspace @@ fun config ->
+  Goal_store.write_state config
+    { version = 1
+    ; updated_at = Masc_domain.now_iso ()
+    ; goals =
+        [ goal_owned_by "someone" Goal_phase.Executing "goal-taken" "already owned"
+        ; goal_child_of "goal-taken" Goal_phase.Executing "goal-orphan" "still free"
+        ]
+    };
+  let world = rendered_world_state config in
+  check bool "the orphaned child is offered at the top level" true
+    (contains_in world "\n- goal-orphan — still free");
+  check bool "it is not indented under a parent nobody can see" false
+    (contains_in world "  - goal-orphan")
 ;;
 
 let () =
@@ -373,6 +431,10 @@ let () =
             test_unowned_goal_with_a_linked_task_is_not_surfaced
         ; test_case "unowned goals reach the rendered turn" `Quick
             test_unowned_goals_reach_the_rendered_turn
+        ; test_case "a child renders under its parent" `Quick
+            test_a_child_renders_under_its_parent
+        ; test_case "a child whose parent is absent stands alone" `Quick
+            test_a_child_whose_parent_is_absent_stands_alone
         ] )
     ]
 ;;


### PR DESCRIPTION
Follow-up to #27451, from checking what it actually renders against the live
store.

## What #27451 renders today

```
### Unowned Goals, no Task yet — taking one is a move you can make (10)
- goal-backlog-kidsnote-zero — Reduce kidsnote service task backlog to 0
- goal-benefit-zero — Reduce benefit service task backlog to 0
- goal-benefit-thanks-zero — Reduce benefit-thanks service task backlog to 0
- goal-benefit-bonus-zero — Reduce benefit-bonus service task backlog to 0
- goal-benefit-firstcome-zero — Reduce benefit-firstcome service task backlog to 0
- goal-store-attendance-zero — Reduce store-attendance service task backlog to 0
- goal-cn-erp-zero — Reduce cn-erp service task backlog to 0
- goal-kidsnote-backlog-zero — Reduce all kidsnote service backlogs to 0
- goal-sangsu-2yr — 2년 목표: ...
- goal-sangsu-5yr — 5년 목표: ...
```

**Seven of those ten are children of the eighth.**
`goal-kidsnote-backlog-zero` has `parent_goal_id = null`; the seven service
Goals each carry `parent_goal_id = "goal-kidsnote-backlog-zero"`.

Rendered as peers, "taking one is a move you can make" cannot distinguish
taking the umbrella from taking one service under it. Two Keepers could take
both and do the same work twice — which is the coordination the Goal surface
exists to prevent. The relation is already in the store; only the render
dropped it.

## Change

`unowned_executing_goals_without_tasks` carries `parent_goal_id`, and a child is
indented under its parent **when the parent is in the same list**:

```
### Unowned Goals, no Task yet — taking one is a move you can make (10)
- goal-kidsnote-backlog-zero — Reduce all kidsnote service backlogs to 0
  - goal-backlog-kidsnote-zero — Reduce kidsnote service task backlog to 0
  - goal-benefit-zero — Reduce benefit service task backlog to 0
  ...
- goal-sangsu-2yr — ...
- goal-sangsu-5yr — ...
```

Three rules, each with a reason:

- **A child whose parent is absent stays at the top level.** Absent means owned,
  terminal, or already served by a Task — in every case the parent is not on
  offer, so the child is its own invitation and must not be hidden.
- **Depth stops at one.** `parent_goal_id` is a single link; nesting further
  would trade the fact for a shape.
- **The count stays every Goal, not just the roots.** The heading says how many
  are on offer.

The owned block is left flat: it lists what one Keeper already holds, where the
question "which of these is the umbrella" does not arise between Keepers.

## Tests

Two cases added to `test_keeper_goal_phase_projection`, which CI runs (12 → 14):

| case | asserts |
|---|---|
| a child renders under its parent | the exact two-line nesting; an unrelated Goal stays top-level; the count is 3, not 1 |
| a child whose parent is absent stands alone | an orphaned child appears at the top level and is **not** indented |

Verified not identities by mutation — with the child indent set to `""`:

```
[FAIL] rfc-0362 q2 unowned sighting  5  a child renders und...
```

The render helpers `rendered_world_state` and `contains_in` are lifted out of
the existing render test so all three read the same assembled turn.

## A correction to my own estimate

On #27442 I sized this block at "~600 B". Measured against the live store it is
**873 B**. The nesting adds two spaces per child, so seven more on this data —
14 bytes.

## Verification

```
dune build --root . @check                                        exit 0
dune build --root . @fmt            no diff in any file this PR touches

test_keeper_goal_phase_projection    14 tests run   Successful   (was 12)
test_keeper_wake_turn_context        14 tests run   Successful
test_goal_scope_terminal_phase        5 tests run   Successful
test_keeper_system_prompt_bytes       2 tests run   Successful   (bytes unchanged)
test_goal_store                      17 tests run   Successful
```

RFC-0362 §5 is unaffected: nothing picks an owner, nothing is required, and an
empty list still renders nothing.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
