### PR TITLE
fix(delegate): stop offering a capability the submitter cannot choose

### DIFF
--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -266,16 +266,22 @@ let schemas : tool_schema list = [
   ; description = "Submit one typed, non-blocking Keeper invocation and return its durable run_ref."
   ; input_schema =
       closed_object_schema
-        (* [capability] is not required: its enum has one member, so demanding it
-           asks the submitter to restate a value it cannot choose. Every
-           delegate rejection in the week before this change was this field,
-           filled in with a description of the prompt instead. Omitting it
-           resolves to [invoke_turn]; an explicit wrong value is still refused. *)
+        (* [capability] is not advertised. Its enum has one member, so a
+           submitter cannot choose it -- it can only restate it or get it wrong
+           -- and every delegate rejection in the week before #27434 was this
+           field: 22 said "task_assignment", 7 said "claim_and_execute", both
+           descriptions of the prompt rather than capabilities the contract
+           offers. A field named [capability] reads as a menu.
+
+           #27434 made it optional, which was not enough. Measured across that
+           week, all 64 calls sent the field explicitly and none omitted it: a
+           field the model can see is a field it fills in. The decoder still
+           accepts it, so the dashboard and operator paths that send it are
+           unaffected; it stops being offered.
+
+           A second capability puts it back here, as a real choice. *)
         ~required:[ "target"; "prompt" ]
         [ "target", keeper_invocation_target_schema
-        ; ( "capability"
-          , `Assoc
-              [ "type", `String "string"; "enum", `List [ `String "invoke_turn" ] ] )
         ; "prompt", `Assoc [ "type", `String "string" ]
         ]
   }

--- a/test/test_keeper_invocation_contract_hints.ml
+++ b/test/test_keeper_invocation_contract_hints.ml
@@ -98,6 +98,45 @@ let test_the_invented_capabilities_are_still_refused () =
           (contains ~needle:"invoke_turn" msg))
     [ "task_assignment"; "claim_and_execute" ]
 
+(* #27434 made [capability] optional and that was not enough: measured across
+   the week, all 64 delegate calls sent the field explicitly and none omitted
+   it, so the 29 rejections were unchanged. A field the model can see is a field
+   it fills in. The schema stops offering it; the decoder still takes it, so the
+   dashboard and operator paths that send it keep working. Both halves are
+   pinned here because either one alone is a regression. *)
+
+let delegate_schema () =
+  match
+    List.find_opt
+      (fun (s : Masc_domain.tool_schema) -> String.equal s.name "masc_keeper_delegate")
+      Masc.Keeper_schema.schemas
+  with
+  | Some s -> s
+  | None -> Alcotest.fail "masc_keeper_delegate must be in the keeper schema"
+
+let advertised_properties () =
+  match (delegate_schema ()).input_schema with
+  | `Assoc fields ->
+    (match List.assoc_opt "properties" fields with
+     | Some (`Assoc props) -> List.map fst props
+     | _ -> Alcotest.fail "input_schema must declare an object of properties")
+  | _ -> Alcotest.fail "input_schema must be an object"
+
+let test_capability_is_not_advertised () =
+  let props = List.sort compare (advertised_properties ()) in
+  Alcotest.(check (list string))
+    "the submitter is offered only what it can decide"
+    [ "prompt"; "target" ]
+    props
+
+let test_capability_is_still_accepted_on_the_wire () =
+  match C.request_of_json (request_json ~capability:"invoke_turn" ()) with
+  | Ok _ -> ()
+  | Error err ->
+    Alcotest.failf
+      "an existing sender's capability must still parse, got %s"
+      (C.request_error_to_string err)
+
 let () =
   Alcotest.run "keeper_invocation_contract_hints"
     [ ( "undeclared_field_hint"
@@ -115,5 +154,9 @@ let () =
             test_stated_capability_still_parses
         ; Alcotest.test_case "the invented values are still refused" `Quick
             test_the_invented_capabilities_are_still_refused
+        ; Alcotest.test_case "capability is not advertised" `Quick
+            test_capability_is_not_advertised
+        ; Alcotest.test_case "capability is still accepted on the wire" `Quick
+            test_capability_is_still_accepted_on_the_wire
         ] )
     ]


### PR DESCRIPTION
Follow-up to #27434, from checking that merge against the live tool log.

## #27434 fixed none of the failures it cited

It made `capability` optional. Measured across the same week:

```
delegate calls, by whether the field was sent
  ok    key present  "invoke_turn"          35
  FAIL  key present  "task_assignment"      22
  FAIL  key present  "claim_and_execute"     7
        key absent                            0
```

**Every call sent the field.** Making absence legal changes nothing for a
submitter that was never omitting it — it was inventing values. The 29
rejections are unchanged by that merge, and I said so on it.

## What this changes

`capability` stops being advertised. The schema offers `target` and `prompt`,
which are the two things a submitter decides.

The decoder is untouched: `capability` stays in `exact_fields`' allowed list and
`optional_capability_of_json` still parses it. The dashboard and operator paths
that send it, and the 35 calls that sent `"invoke_turn"` correctly, keep working.

## Why hiding is the fix here and not a dodge

The field has one legal value. A submitter cannot choose it — it can restate it
or get it wrong, and the week's log is 29 wrong to 35 restated. A field named
`capability`, visible in the schema, reads as a menu; the two invented values
are descriptions of the prompt, which is what a menu invites.

Removing it from the offer removes the invitation, not the constraint: an
explicit wrong value is still refused with the same message, and a test pins
both invented values.

A second capability puts it back in the schema, as a real choice. The comment
says so at the site.

## Tests

Two cases added to `test_keeper_invocation_contract_hints`, which CI runs
(6 → 8):

| case | asserts |
|---|---|
| capability is not advertised | the schema's properties are exactly `prompt` and `target` |
| capability is still accepted on the wire | an existing sender's `"invoke_turn"` still parses |

Both halves are pinned because either alone is a regression: advertise it again
and the invitation returns; stop accepting it and existing senders break.

Verified not identities, by two mutations:

```
re-advertise capability in the schema
  [FAIL] capability is not advertised

decoder rejects an explicit capability
  [FAIL] stated capability still parses
  [FAIL] the invented values are still refused
  [FAIL] capability is still accepted on the wire
```

## Verification

```
dune build --root . @check                                        exit 0
dune build --root . @fmt            no diff in any file this PR touches

test_keeper_invocation_contract_hints            8 tests run   Successful
test_keeper_tool_schema_bytes                    2 tests run   Successful
test_tool_registry_consistency                  27 tests run   Successful
test_tool_contract_truth                        43 tests run   Successful
test_keeper_tool_descriptor_registry_integrity   8 tests run   Successful
test_tool_schema_constraint_enforcement          3 tests run   Successful
```

RFC-WAIVED: a field with one legal value removed from what is offered, while it
stays accepted. No new field, no new accepted value, no gate.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
