### PR TITLE
test(mcp): #27462 병합에 못 실린 테스트와 CI 배선

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -906,6 +906,7 @@ jobs:
             @test/runtest-test_server_oauth_protocol \
             @test/runtest-test_server_auth_dashboard_actor_resolution \
             @test/runtest-test_error_body_wire_shape \
+            @test/runtest-test_mcp_error_code \
             @test/runtest-test_tool_registry_consistency \
             @test/runtest-test_tool_spec \
             @test/runtest-test_tool_shard_coverage \

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -76,7 +76,7 @@ echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, al
 # #27433 and #27441 each wired a suite test/dune already declared without
 # lowering this number. Measured on the merged tree after all four, not
 # computed -- #27441 landed between this branch's first push and now.
-UNWIRED_BASELINE=710
+UNWIRED_BASELINE=709
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/test/test_mcp_error_code.ml
+++ b/test/test_mcp_error_code.ml
@@ -196,6 +196,30 @@ let test_sse_get_registers_before_streaming_response () =
   assert_order "generic SSE GET validates before 200 stream" http;
   assert_order "AG-UI SSE validates before 200 stream" agui
 
+(* JSON-RPC 2.0 §5 allows a null id only when the id could not be read.
+   Asserted over [C.all] rather than a hand-listed set, so a new code
+   that quietly answers true is caught here as well as by the exhaustive
+   match in the module. *)
+let test_allows_null_request_id_only_for_unreadable_id () =
+  let allowed = List.filter C.allows_null_request_id C.all in
+  Alcotest.(check int) "exactly two codes allow a null id" 2 (List.length allowed);
+  Alcotest.(check bool) "Parse_error" true (C.allows_null_request_id C.Parse_error);
+  Alcotest.(check bool) "Invalid_request" true (C.allows_null_request_id C.Invalid_request)
+;;
+
+let test_allows_null_request_id_rejects_answered_requests () =
+  List.iter
+    (fun code ->
+      match code with
+      | C.Parse_error | C.Invalid_request -> ()
+      | other ->
+        Alcotest.(check bool)
+          (Printf.sprintf "%s must carry the request id" (Format.asprintf "%a" C.pp other))
+          false
+          (C.allows_null_request_id other))
+    C.all
+;;
+
 let () =
   Alcotest.run "Mcp_error_code"
     [
@@ -208,6 +232,13 @@ let () =
             test_of_wire_unknown_returns_none;
           test_case "Quiet round-trip drops payload" `Quick
             test_quiet_round_trip_loses_payload;
+        ] );
+      ( "null-request-id",
+        [
+          test_case "only unreadable-id codes allow null" `Quick
+            test_allows_null_request_id_only_for_unreadable_id;
+          test_case "every answered request keeps its id" `Quick
+            test_allows_null_request_id_rejects_answered_requests;
         ] );
       ( "messages-and-status",
         [


### PR DESCRIPTION
## 배경

#27462 가 `Mcp_error_code.allows_null_request_id` 를 추가했다. 그 PR 의 커버리지 체크가 정당하게 실패했고 —

```
Added 17 lines to covered code paths but no test files changed.
```

— 테스트와 CI 배선을 커밋해 푸시했는데, **그 사이 PR 이 병합되면서 첫 커밋만 가져갔다.**

```
$ gh pr view 27462 --json mergedAt,commits   → merged=17:54:14 commits=1
$ git show --stat <merge>                     → 4 files (lib/ 만)
```

병합된 브랜치에는 푸시하지 않으므로 이 PR 로 분리해 낸다. main 에는 지금 술어만 있고 테스트가 없다.

## 변경

**테스트 2개** — 손으로 나열한 집합이 아니라 `C.all` 위에서 단정한다. 새 error code 가 조용히 `true` 를 답하면 모듈의 exhaustive match 와 별개로 여기서도 걸린다.

```ocaml
let allowed = List.filter C.allows_null_request_id C.all in
Alcotest.(check int) "exactly two codes allow a null id" 2 (List.length allowed);
```

두 번째는 역방향이다 — `Parse_error` / `Invalid_request` 를 제외한 모든 코드가 `false` 를 답하는지 `C.all` 을 돌며 확인한다.

**CI 배선** — `test_mcp_error_code` 는 `test/dune` 에 선언돼 있고 CI 의 어느 스텝도 부르지 않았다. 11개 단정이 컴파일만 되고 실행된 적이 없다. `test_error_body_wire_shape` 옆에 물렸다. `UNWIRED_BASELINE` 710 → 709.

커버리지 체크는 "테스트 파일이 변경됐는지"만 보므로, 배선 없이 테스트만 추가해도 게이트는 통과했을 것이다.

## 검증

술어를 훼손해서 확인했다.

```
lib/mcp_error_code.ml:  | Method_not_found -> false  →  true

[FAIL]  null-request-id  0  only unreadable-id codes allow null
[FAIL]  null-request-id  1  every answered request keeps its id
```

되돌린 뒤 `dune build --root . @check` → 0, 스위트 11/11 통과.
