### PR TITLE
refactor(keeper): CAS 충돌을 정규식이 아니라 타입에서 복구한다 (closes #27443)

### DIFF
--- a/lib/keeper/keeper_current_task_reconcile.ml
+++ b/lib/keeper/keeper_current_task_reconcile.ml
@@ -182,7 +182,7 @@ let sync_current_task_id_from_backlog ~(config : Workspace.config)
            (match desired with
             | Some task_id -> Keeper_id.Task_id.to_string task_id
             | None -> "(cleared)")
-           msg);
+           (Keeper_meta_store.write_meta_error_to_string msg));
       (* RFC-0142 / audit 2026-05-21 §10.2: this is the success path of a
          routine drift correction, firing on every observed delta between
          keeper_meta.current_task_id and backlog ownership.  Live measurement

--- a/lib/keeper/keeper_heartbeat_loop_presence.ml
+++ b/lib/keeper/keeper_heartbeat_loop_presence.ml
@@ -131,6 +131,7 @@ let repair_identity_drift_for_keepalive ?lifecycle_token ~(ctx : _ context) (met
              ~merge:Keeper_meta_merge.monotonic_usage_counters
              ctx.config
              repaired
+           |> Result.map_error Keeper_meta_store.write_meta_error_to_string
          | Some token ->
            write_meta_with_merge_for_lifecycle
              token
@@ -219,7 +220,8 @@ let sync_keeper_presence
         Keeper_metrics.(to_string WriteMetaFailures)
         ~labels:[ "keeper", synced.name; "phase", "heartbeat" ]
         ();
-      Log.Keeper.warn "write_meta failed (heartbeat): %s" e;
+      Log.Keeper.warn "write_meta failed (heartbeat): %s"
+        (Keeper_meta_store.write_meta_error_to_string e);
       synced
   with
   | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -563,8 +563,13 @@ let bootstrap_live_keeper_meta ?lifecycle_token ~(ctx : _ context) (m : keeper_m
           Log.Keeper.emit
             Log.Warn
             ~category:Log.Heartbeat
-            ~details:(`Assoc [ "keeper", `String synced.name; "error", `String e ])
-            (Printf.sprintf "write_meta failed (bootstrap): %s" e)));
+            ~details:
+              (`Assoc
+                 [ "keeper", `String synced.name
+                 ; "error", `String (Keeper_meta_store.write_meta_error_to_string e)
+                 ])
+            (Printf.sprintf "write_meta failed (bootstrap): %s"
+                 (Keeper_meta_store.write_meta_error_to_string e))));
     synced
   with
   | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -21,8 +21,6 @@ let runtime_meta_write_sync_hook config meta =
 let register_runtime_meta_write_sync f =
   Atomic.set runtime_meta_write_sync_hook_atomic f
 
-let version_conflict_re = Re.Pcre.re "meta version conflict" |> Re.compile
-
 let read_meta_file_path path : (Keeper_meta_contract.keeper_meta option, string) result =
   if not (Fs_compat.file_exists path)
   then Ok None
@@ -424,14 +422,6 @@ let write_meta_deferred_runtime_sync config m =
   |> Result.map_error write_meta_error_to_string
 ;;
 
-let is_version_conflict_error msg =
-  try
-    ignore (Re.exec version_conflict_re msg);
-    true
-  with
-  | Not_found -> false
-;;
-
 (* #9769 root fix: CAS retry with explicit field ownership. The
    turn-failure/cycle path uses [Keeper_meta_merge.heartbeat_fields_from_disk]
    now only carries the disk meta_version forward. *)
@@ -441,15 +431,15 @@ let write_meta_with_merge_internal
       ~(merge : latest:Keeper_meta_contract.keeper_meta -> caller:Keeper_meta_contract.keeper_meta -> Keeper_meta_contract.keeper_meta)
       config
       (m : Keeper_meta_contract.keeper_meta)
-  : (unit, string) result
+  : (unit, write_meta_error) result
   =
   let path = keeper_meta_path config m.name in
   let rec attempt n (caller : Keeper_meta_contract.keeper_meta) =
     match write_meta_typed ?lifecycle_token config caller with
     | Ok () -> Ok ()
-    | Error error when n >= max_retries -> Error (write_meta_error_to_string error)
+    | Error error when n >= max_retries -> Error error
     | Error ((Lifecycle_reserved _ | Read_failed _ | Persist_failed _ | Invariant_violation _) as error) ->
-      Error (write_meta_error_to_string error)
+      Error error
     | Error (Version_conflict _) ->
       (match read_meta_file_path path with
        | Ok (Some latest) ->
@@ -469,7 +459,9 @@ let write_meta_with_merge_internal
          (* Disk file vanished between attempts; fall back to fresh write. *)
          attempt (n + 1) { caller with meta_version = 0 }
        | Error read_msg ->
-         Error (Printf.sprintf "write_meta retry: failed to re-read for CAS: %s" read_msg))
+         Error
+           (Read_failed
+              (Printf.sprintf "write_meta retry: failed to re-read for CAS: %s" read_msg)))
   in
   attempt 0 m
 ;;
@@ -485,6 +477,7 @@ let write_meta_with_merge_for_lifecycle token ?max_retries ~merge config m =
     ~merge
     config
     m
+  |> Result.map_error write_meta_error_to_string
 ;;
 
 (* Durable write-through of [compaction_rt.last_decision].
@@ -522,6 +515,7 @@ let persist_compaction_commit_projection config ~keeper_name ~commit_count
       ~merge:(fun ~latest ~caller:_ -> stamp latest)
       config
       (stamp disk_meta)
+    |> Result.map_error write_meta_error_to_string
     |> Result.map (fun () ->
       Log.Keeper.info
         ~keeper_name

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -15,9 +15,6 @@ val runtime_meta_write_sync_hook :
 val register_runtime_meta_write_sync :
   (Workspace.config -> Keeper_meta_contract.keeper_meta -> unit) -> unit
 
-(** Pre-compiled regex matching the CAS [meta version conflict]
-    error message. Exposed for symmetry — used internally by
-    [is_version_conflict_error]. *)
 (** Read a keeper meta JSON file at [path]. Returns [Ok None] when
     the file does not exist. Unknown top-level keys are rejected with a
     reset-required error; the persisted file is never rewritten. *)
@@ -120,6 +117,26 @@ val write_meta_deferred_runtime_sync :
 (** Lifecycle-owner variant of [write_meta]. The opaque reservation token is
     checked against the same BasePath/name key before entering the per-path
     CAS critical section. *)
+(** Why a metadata write did not land. [Version_conflict] is the CAS race the
+    retry path recognises; the caller sees it only after retries are exhausted.
+    Exposed so callers match on the case instead of testing the rendered
+    string -- {!write_meta_error_to_string} stays for log and label text. *)
+type write_meta_error =
+  | Version_conflict of
+      { keeper_name : string
+      ; expected : int
+      ; actual : int
+      }
+  | Lifecycle_reserved of Keeper_lifecycle_reservation.snapshot
+  | Read_failed of string
+  | Persist_failed of string
+  | Invariant_violation of
+      { keeper_name : string
+      ; detail : string
+      }
+
+val write_meta_error_to_string : write_meta_error -> string
+
 type identity_update_error =
   | Identity_missing
   | Identity_changed
@@ -193,8 +210,19 @@ val remove_meta_if_exact_identity :
   meta_version:int ->
   (unit, exact_identity_error) result
 
-(** [true] iff [msg] matches [version_conflict_re]. *)
-val is_version_conflict_error : string -> bool
+(** Whether a successful meta write also runs the runtime registry-sync hook. *)
+type runtime_sync =
+  | Sync_runtime
+  | Defer_runtime_sync
+
+(** Same CAS persistence as {!write_meta}, but keeps the typed error so the
+    caller can match the case instead of reading the rendered string. *)
+val write_meta_typed :
+  ?lifecycle_token:Keeper_lifecycle_reservation.token ->
+  ?runtime_sync_override:runtime_sync ->
+  Workspace.config ->
+  Keeper_meta_contract.keeper_meta ->
+  (unit, write_meta_error) result
 
 (** Retry [write_meta] on CAS version conflicts using caller-declared
     field ownership via [merge]. Use [Keeper_meta_merge.caller_wins]
@@ -206,7 +234,7 @@ val write_meta_with_merge :
   merge:(latest:Keeper_meta_contract.keeper_meta -> caller:Keeper_meta_contract.keeper_meta -> Keeper_meta_contract.keeper_meta) ->
   Workspace.config ->
   Keeper_meta_contract.keeper_meta ->
-  (unit, string) result
+  (unit, write_meta_error) result
 
 val write_meta_with_merge_for_lifecycle :
   Keeper_lifecycle_reservation.token ->

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -501,7 +501,7 @@ let launch_supervised_fiber_body
                       Log.Keeper.warn
                         "%s: fiber_unresolved meta stamp failed: %s"
                         meta.name
-                        err)
+                        (Keeper_meta_store.write_meta_error_to_string err))
                  | None -> ());
                 let ts = Time_compat.now () in
                 Keeper_registry.record_crash ~base_path meta.name ts reason;

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -181,6 +181,7 @@ let maybe_reseed_keeper_identity_config ~(config : Workspace.config) (meta : kee
     let* () =
       Keeper_meta_store.write_meta_with_merge
         ~merge:Keeper_meta_merge.monotonic_usage_counters config updated_meta
+      |> Result.map_error Keeper_meta_store.write_meta_error_to_string
       |> Result.map_error (fun err ->
           Printf.sprintf
             "failed to persist reseeded keeper identity for %s: %s"

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -256,7 +256,7 @@ let sync_keeper_meta_current_task
          ();
        Log.Keeper.warn ~keeper_name:meta.name
          "failed to persist claimed current_task_id=%s: %s"
-         task_id msg)
+         task_id (Keeper_meta_store.write_meta_error_to_string msg))
 ;;
 
 (* Cluster sub-dispatch via closed sum type — string [name] is converted

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -815,18 +815,28 @@ let run_keeper_invocation_turn_admitted_inner
                      ~labels:
                        [ ("keeper", updated_meta.name);
                          ("phase",
-                          if is_version_conflict_error msg
-                          then "keeper_msg_turn_cas_race"
-                          else "keeper_msg_turn")
+                          match msg with
+                          | Keeper_meta_store.Version_conflict _ ->
+                            "keeper_msg_turn_cas_race"
+                          | Keeper_meta_store.Lifecycle_reserved _
+                          | Keeper_meta_store.Read_failed _
+                          | Keeper_meta_store.Persist_failed _
+                          | Keeper_meta_store.Invariant_violation _ ->
+                            "keeper_msg_turn")
                        ]
                      ();
-                   if is_version_conflict_error msg then
+                   let detail = Keeper_meta_store.write_meta_error_to_string msg in
+                   match msg with
+                   | Keeper_meta_store.Version_conflict _ ->
                      Log.Keeper.warn
                        "write_meta lost CAS race after retries (keeper_msg turn): %s"
-                       msg
-                   else
+                       detail
+                   | Keeper_meta_store.Lifecycle_reserved _
+                   | Keeper_meta_store.Read_failed _
+                   | Keeper_meta_store.Persist_failed _
+                   | Keeper_meta_store.Invariant_violation _ ->
                      Log.Keeper.error
-                       "write_meta failed after keeper_msg turn: %s" msg);
+                       "write_meta failed after keeper_msg turn: %s" detail);
               (try
                  Keeper_unified_metrics.append_metrics_snapshot
                    ~config:ctx.config

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -20,6 +20,7 @@ let write_initial_meta config meta =
   write_meta_with_merge
     ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
     config meta
+  |> Result.map_error Keeper_meta_store.write_meta_error_to_string
 
 let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
   Log.Keeper.info "create_keeper: starting for name=%s" p.name;

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -363,7 +363,7 @@ let update_keeper ?(preserve_prompt_defaults = false)
                  Keeper_metrics.(to_string WriteMetaFailures)
                  ~labels:[("keeper", updated.name); ("phase", "update_keeper")]
                  ();
-               tool_result_error e
+               tool_result_error (Keeper_meta_store.write_meta_error_to_string e)
              | Ok () ->
                (match
                   Keeper_shutdown_supersession.commit_after_metadata_update

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -662,7 +662,7 @@ let run_keeper_cycle
                          ~keeper_name:entry.meta.name
                          "%s: turn-start write_meta_with_merge failed: %s"
                          entry.meta.name
-                         err
+                         (Keeper_meta_store.write_meta_error_to_string err)
                    in
                    entry.meta
                  | None -> meta
@@ -998,22 +998,31 @@ dominant source of the observed CAS race exhaustion after
                        ~labels:
                          [ "keeper", updated_meta.name
                          ; ( "phase"
-                           , if is_version_conflict_error msg
-                             then "turn_failure_cas_race"
-                             else "turn_failure" )
+                           , match msg with
+                             | Keeper_meta_store.Version_conflict _ ->
+                               "turn_failure_cas_race"
+                             | Keeper_meta_store.Lifecycle_reserved _
+                             | Keeper_meta_store.Read_failed _
+                             | Keeper_meta_store.Persist_failed _
+                             | Keeper_meta_store.Invariant_violation _ ->
+                               "turn_failure" )
                          ]
                        ();
-                     if is_version_conflict_error msg
-                     then
-                       Log.Keeper.warn
-                         ~keeper_name:updated_meta.name
-                         "write_meta lost CAS race after retries (turn failure path): %s"
-                         msg
-                     else
-                       Log.Keeper.error
-                         ~keeper_name:updated_meta.name
-                         "write_meta failed after unified turn failure: %s"
-                         msg);
+                     let detail = Keeper_meta_store.write_meta_error_to_string msg in
+                     (match msg with
+                      | Keeper_meta_store.Version_conflict _ ->
+                        Log.Keeper.warn
+                          ~keeper_name:updated_meta.name
+                          "write_meta lost CAS race after retries (turn failure path): %s"
+                          detail
+                      | Keeper_meta_store.Lifecycle_reserved _
+                      | Keeper_meta_store.Read_failed _
+                      | Keeper_meta_store.Persist_failed _
+                      | Keeper_meta_store.Invariant_violation _ ->
+                        Log.Keeper.error
+                          ~keeper_name:updated_meta.name
+                          "write_meta failed after unified turn failure: %s"
+                          detail));
                   Otel_metric_store.inc_counter
                     Keeper_metrics.(to_string WriteMetaCycleFailures)
                     ~labels:[ "keeper", meta.name; "site", Keeper_write_meta_cycle_failure_site.(to_label Turn_failure) ]

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -421,9 +421,12 @@ let persist_terminal_turn_meta
        ~labels:
          [ "keeper", updated_meta.name
          ; ( "phase"
-           , if Keeper_meta_store.is_version_conflict_error msg
-             then "keeper_cycle_cas_race"
-             else "keeper_cycle" )
+           , match msg with
+             | Keeper_meta_store.Version_conflict _ -> "keeper_cycle_cas_race"
+             | Keeper_meta_store.Lifecycle_reserved _
+             | Keeper_meta_store.Read_failed _
+             | Keeper_meta_store.Persist_failed _
+             | Keeper_meta_store.Invariant_violation _ -> "keeper_cycle" )
          ]
        ();
      (* #22043: emit inside the [Error] arm so
@@ -439,9 +442,15 @@ let persist_terminal_turn_meta
          ; "site", Keeper_write_meta_cycle_failure_site.(to_label Keeper_cycle)
          ]
        ();
-     if Keeper_meta_store.is_version_conflict_error msg
-     then Log.Keeper.warn "write_meta lost CAS race after retries (keeper cycle): %s" msg
-     else Log.Keeper.error "write_meta failed after keeper cycle: %s" msg);
+     let detail = Keeper_meta_store.write_meta_error_to_string msg in
+     (match msg with
+      | Keeper_meta_store.Version_conflict _ ->
+        Log.Keeper.warn "write_meta lost CAS race after retries (keeper cycle): %s" detail
+      | Keeper_meta_store.Lifecycle_reserved _
+      | Keeper_meta_store.Read_failed _
+      | Keeper_meta_store.Persist_failed _
+      | Keeper_meta_store.Invariant_violation _ ->
+        Log.Keeper.error "write_meta failed after keeper cycle: %s" detail));
   updated_meta
 ;;
 

--- a/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
@@ -137,7 +137,7 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
               Log.Keeper.warn
                 "keeper %s pause: write_meta failed: %s"
                 name
-                err;
+                (Keeper_meta_store.write_meta_error_to_string err);
               false)
       (* Issue #8391 HIGH #1: split [Ok None] (meta vanished) from
          [Error _] (IO/parse failure) so lifecycle pause persistence after

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -1280,7 +1280,7 @@ let persist_directive_pause ~config ~name
     Log.Keeper.warn
       "directive pause: write_meta failed for %s: %s"
       name
-      err;
+      (Keeper_meta_store.write_meta_error_to_string err);
     Otel_metric_store.inc_counter
       Keeper_metrics.(to_string PausedStatePersistErrors)
       ~labels:
@@ -1378,7 +1378,8 @@ let handle_keeper_directive_post ~sw:_ ~clock:_ state _agent_name req reqd body_
                [ "ok", `Bool false
                ; "action", `String action_str
                ; "name", `String name
-               ; "error", `String error
+               ; ( "error"
+                 , `String (Keeper_meta_store.write_meta_error_to_string error) )
                ])
             reqd
         | Ok () ->
@@ -1534,7 +1535,8 @@ let handle_keeper_bulk_directive_post ~sw:_ ~clock:_ state _agent_name req reqd 
                  `Assoc
                    [ "name", `String name
                    ; "ok", `Bool false
-                   ; "error", `String error
+                   ; ( "error"
+                     , `String (Keeper_meta_store.write_meta_error_to_string error) )
                    ]
                | Ok () ->
                  let resolved_agent_name =

--- a/test/test_keeper_meta_cas_retry.ml
+++ b/test/test_keeper_meta_cas_retry.ml
@@ -5,7 +5,7 @@
       - succeeds when no concurrent writer interferes
       - succeeds after N attempts when the disk version has advanced
       - distinguishes version conflicts from real I/O errors via
-        [is_version_conflict_error] *)
+        the typed [write_meta_error] the CAS path returns *)
 
 open Alcotest
 open Masc
@@ -64,7 +64,7 @@ let test_no_conflict_writes_first_attempt () =
          ~merge:Keeper_meta_merge.caller_wins config m0
      with
      | Ok () -> ()
-     | Error e -> fail ("first write failed: " ^ e));
+     | Error e -> fail ("first write failed: " ^ Keeper_meta_store.write_meta_error_to_string e));
     (* Read what landed on disk and bump caller's version to match. *)
     let disk = match Keeper_meta_store.read_meta config "alpha" with
       | Ok (Some m) -> m
@@ -84,7 +84,7 @@ let test_no_conflict_writes_first_attempt () =
       in
       check (list string) "active_goal_ids updated" [ "goal-updated" ]
         after.active_goal_ids
-    | Error e -> fail ("second write failed: " ^ e))
+    | Error e -> fail ("second write failed: " ^ Keeper_meta_store.write_meta_error_to_string e))
 
 let test_retry_succeeds_after_concurrent_bump () =
   Eio_main.run @@ fun env ->
@@ -123,7 +123,7 @@ let test_retry_succeeds_after_concurrent_bump () =
          ~merge:Keeper_meta_merge.caller_wins config cycle_payload
      with
      | Ok () -> ()
-     | Error e -> fail ("retry write failed: " ^ e));
+     | Error e -> fail ("retry write failed: " ^ Keeper_meta_store.write_meta_error_to_string e));
     let after_retry_metric =
       Otel_metric_store.metric_value_or_zero
         Otel_metric_store.metric_write_meta_cas_retry_total
@@ -185,7 +185,7 @@ let test_monotonic_usage_counters_on_cas_retry () =
          ~merge:Keeper_meta_merge.heartbeat_fields_from_disk config stale
      with
      | Ok () -> ()
-     | Error e -> fail ("stale retry write failed: " ^ e));
+     | Error e -> fail ("stale retry write failed: " ^ Keeper_meta_store.write_meta_error_to_string e));
     let final = match Keeper_meta_store.read_meta config "gamma" with
       | Ok (Some m) -> m
       | _ -> fail "final read failed"
@@ -245,7 +245,7 @@ let test_operator_pause_survives_stale_heartbeat_retry () =
          ~merge:Keeper_meta_merge.heartbeat_fields_from_disk config stale_completion
      with
      | Ok () -> ()
-     | Error e -> fail ("stale retry write failed: " ^ e));
+     | Error e -> fail ("stale retry write failed: " ^ Keeper_meta_store.write_meta_error_to_string e));
     let final = match Keeper_meta_store.read_meta config "operator-pause-cas" with
       | Ok (Some m) -> m
       | _ -> fail "final read failed"
@@ -297,25 +297,19 @@ let test_stale_write_conflicts_without_force () =
       with_usage caller_view
         { caller_view.runtime.usage with total_turns = 5 }
     in
-    (match Keeper_meta_store.write_meta config stale with
+    (match Keeper_meta_store.write_meta_typed config stale with
      | Ok () -> fail "stale write unexpectedly succeeded (CAS bypass present?)"
-     | Error msg ->
-       check bool "stale write is rejected as a version conflict" true
-         (Keeper_meta_store.is_version_conflict_error msg));
+     | Error (Keeper_meta_store.Version_conflict _) -> ()
+     | Error other ->
+       fail
+         (Printf.sprintf "stale write rejected, but not as a version conflict: %s"
+            (Keeper_meta_store.write_meta_error_to_string other)));
     let final = match Keeper_meta_store.read_meta config "delta" with
       | Ok (Some m) -> m
       | _ -> fail "final read failed"
     in
     check int "advanced disk counter survives (no rewind without force)"
       42 final.runtime.usage.total_turns)
-
-let test_is_version_conflict_error_classifies () =
-  let conflict_msg = "meta version conflict for foo: expected 3, disk has 4" in
-  let other_msg = "failed to write meta /tmp/x: Permission denied" in
-  check bool "classifies version conflict" true
-    (Keeper_meta_store.is_version_conflict_error conflict_msg);
-  check bool "rejects unrelated error" false
-    (Keeper_meta_store.is_version_conflict_error other_msg)
 
 (* Fix: [paused=false] + [Dead_tombstone] is un-recoverable — lifecycle
    admission denies by the latch regardless of [paused], but every sanctioned
@@ -431,10 +425,5 @@ let () =
             `Quick test_operator_pause_survives_stale_heartbeat_retry;
           test_case "stale write conflicts without force (RFC-0237 escape hatch closed)"
             `Quick test_stale_write_conflicts_without_force;
-        ] );
-      ( "is_version_conflict_error",
-        [
-          test_case "classifies conflict vs I/O error" `Quick
-            test_is_version_conflict_error_classifies;
         ] );
     ]

--- a/test/test_keeper_write_meta_cycle_failures_counter.ml
+++ b/test/test_keeper_write_meta_cycle_failures_counter.ml
@@ -83,7 +83,8 @@ let seed_meta_file config m0 =
       m0
   with
   | Ok () -> ()
-  | Error e -> fail ("seed write failed: " ^ e)
+  | Error e ->
+    fail ("seed write failed: " ^ Keeper_meta_store.write_meta_error_to_string e)
 
 let persist_terminal_turn_meta_for_done ~config ~m0 ~active_goal_ids =
   let (_ : Keeper_meta_contract.keeper_meta) =


### PR DESCRIPTION
refactor(keeper): recover the CAS conflict from the type, not from a regex

Closes #27443.

keeper_meta_store built its own error string and then re-parsed it to get
back the variant it had just discarded:

  (* produce *) "meta version conflict for %s: expected %d, disk has %d"
  (* consume *) Re.Pcre.re "meta version conflict" |> Re.compile

Three production sites branched on that substring to label a metric
`*_cas_race` vs plain failure: keeper_unified_turn_success.ml,
keeper_unified_turn.ml, keeper_turn.ml (two tests each).

The closed sum already existed. write_meta_error carries keeper_name,
expected and actual; write_meta_with_merge_internal already matched
`Error (Version_conflict _)` internally to drive the CAS retry, then
collapsed to a string one line before returning. The .mli exposed neither
the type nor the typed writer.

Changes:
- expose write_meta_error, write_meta_error_to_string, write_meta_typed
  and runtime_sync in keeper_meta_store.mli
- write_meta_with_merge now returns (unit, write_meta_error) result
- the three branching sites match on the constructor exhaustively
- callers that only log or label convert with write_meta_error_to_string
- write_meta, write_meta_deferred_runtime_sync, write_meta_with_merge_for_lifecycle
  and write_initial_meta keep their string channel, converting at their own
  boundary, so the type does not spread past what needed it
- delete is_version_conflict_error and version_conflict_re

The drift this closes is concrete: rewording the format string -- to
"meta CAS conflict", or translating it -- silently flipped all six
predicates to false and counted CAS races as ordinary failures. Deleting
the Version_conflict constructor breaks the build; rewording its text did
not.

`identity_update_error` on update_meta_if_identity is the same shape and
was already in this module, so this makes five write functions consistent
with the sixth rather than introducing a pattern.

Tests: test_keeper_meta_cas_retry now matches the constructor instead of
asserting on the message, and its string-classifier unit test is gone with
the classifier. The suite's one failure (`dead-tombstone pause invariant /
resumed keeper is unpaused`) reproduces identically on origin/main.


---

## 검증

```
dune build --root . @check                          # exit 0 (고정점)
bash scripts/ci/check-determinism-contract.sh       # DET/NDT gate: PASS
python3 scripts/verify-test-registration.py         # Unregistered 0 / Orphaned 0
rg 'is_version_conflict_error|version_conflict_re' lib bin test   # 0 건
./_build/default/test/test_keeper_meta_cas_retry.exe             # 8 tests, 1 failure
```

그 1 건은 **baseline 과 동일**하다. `origin/main` (`db85da77e7`) 을 깨끗한 worktree 에 체크아웃해 같은 스위트를 돌렸고 같은 테스트가 같은 메시지로 실패한다:

```
> [FAIL]  dead-tombstone pause invariant  1  mark_resumed c...
FAIL resumed keeper is unpaused
```

## 범위가 측정보다 넓었다

이슈에 "의미 있는 변경 지점 6 곳" 이라고 적었다. 그건 **분기하는 곳** 의 수였고, 타입이 중간 시그니처를 타고 번지는 범위는 재지 않았다. 실제로는 17 파일이 바뀌었다 — 대부분은 `write_meta_error_to_string` 한 번 감싸는 기계적 변경이고, 세 곳(`keeper_turn_up_create.write_initial_meta`, `write_meta_with_merge_for_lifecycle`, `keeper_heartbeat_loop_presence`)은 **경계에서 문자열로 되돌려** 전파를 끊었다.

컴파일러가 매 라운드 다음 지점을 지목했고, 그게 이 리팩터의 검증 수단이다.

## 미검증

런타임에서 실제 CAS 경합을 유발해 메트릭 라벨이 `*_cas_race` 로 찍히는지 확인하지 않았다. 라벨 문자열은 변경 전후 동일하고, 판정 입력이 substring 에서 생성자로 바뀐 것이 전부다.
