### PR TITLE
test(schedule): put the Schedule schemas under the enum drift guard

### DIFF
--- a/test/test_enum_mirror_sync.ml
+++ b/test/test_enum_mirror_sync.ml
@@ -31,6 +31,11 @@ let all_schemas () =
   @ Tool_shard_types.voice_tools
   @ [ Tool_shard_types.tool_execute_schema ]
   @ board_schemas
+  (* The Schedule tools publish from their own library rather than the keeper
+     shard, so they were outside this walk and their four hand-written enum
+     lists were unguarded. [schedule_status] is the one with an owner to
+     compare against. *)
+  @ Tool_schemas_schedule.schemas
 ;;
 
 (* Collect every string list that appears under an "enum" key anywhere in a
@@ -59,42 +64,62 @@ let published_enums () =
   |> List.concat_map (fun (t : Masc_domain.tool_schema) -> enum_arrays t.input_schema)
 ;;
 
-let check_mirror_in_sync ~label ~owner =
+let check_mirror_in_sync ?(copy_lives_in = "Tool_shard_types_enum_mirrors") ~label ~owner () =
   let published = published_enums () in
   let matched = List.exists (fun e -> e = owner) published in
   if not matched
   then
     failf
       "%s: no published schema enum equals its owner's list %s.\n\
-       The hand-mirrored copy in Tool_shard_types_enum_mirrors has drifted.\n\
+       The hand-written copy in %s has drifted.\n\
        Published enums seen: %s"
       label
       (String.concat "|" owner)
+      copy_lives_in
       (String.concat "  /  " (List.map (String.concat "|") published))
+;;
+
+(* [Schedule_domain.all_schedule_statuses] is the owner: [test_schedule_domain]
+   pins that every constructor is in it, and the dashboard reads it. The tool
+   schema hand-wrote the same seven strings, so the enum an LLM is handed could
+   drift from the one the decoder takes without anything going red. *)
+let test_schedule_status_mirror () =
+  check_mirror_in_sync
+    ~copy_lives_in:"tool_schemas_schedule.ml"
+    ~label:"schedule_status_enum_strings"
+    ~owner:
+      (List.map
+         Schedule_domain.schedule_status_to_string
+         Schedule_domain.all_schedule_statuses)
+    ()
 ;;
 
 let test_memory_search_source_mirror () =
   check_mirror_in_sync
     ~label:"memory_search_source_enum_strings"
     ~owner:Masc.Keeper_tool_memory_runtime.valid_memory_search_source_strings
+    ()
 ;;
 
 let test_fs_write_mode_mirror () =
   check_mirror_in_sync
     ~label:"fs_write_mode_enum_strings"
     ~owner:Masc.Keeper_tool_filesystem_runtime.valid_fs_write_mode_strings
+    ()
 ;;
 
 let test_sort_order_mirror () =
   check_mirror_in_sync
     ~label:"sort_order_enum_strings"
     ~owner:Masc.Board_dispatch.valid_sort_order_strings
+    ()
 ;;
 
 let test_vote_direction_mirror () =
   check_mirror_in_sync
     ~label:"vote_direction_enum_strings"
     ~owner:Masc.Board_votes.valid_vote_direction_strings
+    ()
 ;;
 
 (* A guard that passes when the thing it guards is empty is not a guard. *)
@@ -121,6 +146,7 @@ let () =
         ; test_case "fs write mode" `Quick test_fs_write_mode_mirror
         ; test_case "board sort order" `Quick test_sort_order_mirror
         ; test_case "board vote direction" `Quick test_vote_direction_mirror
+        ; test_case "schedule status" `Quick test_schedule_status_mirror
         ; test_case "owner lists are non-empty" `Quick test_owners_are_non_empty
         ; test_case "schemas publish enums" `Quick test_schema_set_is_non_empty
         ] )


### PR DESCRIPTION
Closes the gap #27474 recorded and did not change.

## What

`test_enum_mirror_sync` exists for exactly this problem. Its header:

> That module hand-copies four enum string lists that downstream keeper and
> board modules own … Until this file, nothing compared the copies against
> their owners, so a fifth enum value added to an owner would have shipped a
> schema that never offered it, and the tool would have rejected the value its
> own documentation advertised.

Its walk covers `Tool_shard_types.*` — the keeper shard. **The Schedule tools
publish from their own library and were outside it**, so their four
hand-written enum lists were unguarded:

```
tool_schemas_schedule.ml
  statuses          7 strings   ← owner exists: Schedule_domain.all_schedule_statuses
  actor_kinds       3 strings   ← no exported enumeration to compare against
  sources           3 strings   ← no exported enumeration
  recurrence_kinds  4 strings   ← a wire discriminator, not a sum
```

`Schedule_domain.all_schedule_statuses` is exported, is pinned by
`test_schedule_domain` ("every schedule_status is in all_schedule_statuses" = 7),
and `server_dashboard_http_runtime_info.ml` reads it. The tool schema — the one
an LLM is handed — hand-wrote the same seven strings anyway.

## Change

The Schedule schemas join the walk, and `schedule_status` gets a mirror case
against its owner.

Verified it catches drift, by mutation — dropping `"expired"` from the
advertised enum:

```
[FAIL] mirrors  4  schedule status.
```

## Why not derive the schema from the domain instead

That is the shape `Goal` uses:

```ocaml
let goal_phase_enum = List.map Goal_phase.to_string Goal_phase.all
```

It would need `masc_tool_schemas` to depend on `masc_schedule`, which pulls in
`masc_workspace`, `dated_jsonl` and `digestif` for one list. `masc.masc_goal`,
the Goal precedent, is a leaf. A test that compares the two costs nothing at
link time and fails on the same drift, so the guard goes where the other four
already are.

## The failure message was wrong for a new caller

`check_mirror_in_sync` hard-coded "The hand-mirrored copy in
`Tool_shard_types_enum_mirrors` has drifted" — true of the four cases that
existed, false of this one, whose copy is in `tool_schemas_schedule.ml`. The
site is now a parameter and the schedule case names its own.

## Still unguarded, and why

`actor_kinds`, `sources` and `recurrence_kinds` have no exported enumeration to
compare against. Adding one purely so a test could reach it is the surface the
dead-export ratchet refuses; `all_schedule_statuses` earned its export through
the dashboard. If those lists gain a real consumer, the case is three lines.

Their **rejections** name their accepted set as of #27474, which is the other
half of the same problem from the caller's side.

## Verification

```
dune build --root . @check                                        exit 0
dune build --root . @fmt            no diff in any file this PR touches
scripts/audit-sublib-cycle.py            OK - 34 leaf libraries clean

test_enum_mirror_sync              7 tests run   Successful   (was 6)
test_schedule_store               31 tests run   Successful
test_schedule_tool_wiring         13 tests run   Successful
test_tool_registry_consistency     8 tests run   Successful
test_keeper_tool_schema_bytes      2 tests run   Successful
```

No behaviour change: this PR is a test and one error-message parameter.

RFC-WAIVED: an existing drift guard extended to schemas it did not reach.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
