### PR TITLE
refactor(keeper): 도달 불가 arm 을 assert 로 막는 대신 바깥에서 묶는다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1573,7 +1573,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          board_attention_targets="@test/runtest-test_keeper_board_attention_worker @test/runtest-test_keeper_board_attention_partition @test/runtest-test_keeper_board_attention_candidate"
+          board_attention_targets="@test/runtest-test_keeper_board_attention_worker @test/runtest-test_keeper_board_attention_partition @test/runtest-test_keeper_board_attention_candidate @test/runtest-test_keeper_lifecycle_global_gate"
           scripts/ci-run-tests.sh "opam exec -- dune build --root . ${board_attention_targets}"
 
       - name: Run tool blob retention suite

--- a/lib/keeper/keeper_activation_readiness.ml
+++ b/lib/keeper/keeper_activation_readiness.ml
@@ -217,14 +217,11 @@ let classify_owner_execution_with
           (match runtime with
            | Owner_unregistered -> Recoverable
            | Owner_registered
-               { phase = (Keeper_state_machine.Paused | Keeper_state_machine.Dead)
+               { phase =
+                   (Keeper_state_machine.Paused | Keeper_state_machine.Dead) as phase
                ; _
                } ->
-             Paused_dead
-               (Runtime_terminal
-                  (match runtime with
-                   | Owner_registered { phase; _ } -> phase
-                   | Owner_unregistered -> assert false))
+             Paused_dead (Runtime_terminal phase)
            | Owner_registered { live_fiber = true; _ } -> Executable
            | Owner_registered { live_fiber = false; _ } -> Recoverable)))
 ;;

--- a/lib/keeper/keeper_board_attention_partition.ml
+++ b/lib/keeper/keeper_board_attention_partition.ml
@@ -1375,12 +1375,7 @@ let record_before_advance ~worker_epoch ~base_path ~partition ~source ~next =
              Error "before-advance predispatch rejection requires a durable advancing visit")
         | Unbound ->
           (match source with
-           | Predispatch_rejection _ ->
-             let last_from =
-               match source with
-               | Predispatch_rejection visit -> visit
-               | Executed_failure _ -> assert false
-             in
+           | Predispatch_rejection last_from ->
              Ok
                (Running
                   { running with

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -76,7 +76,7 @@ echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, al
 # #27433 and #27441 each wired a suite test/dune already declared without
 # lowering this number. Measured on the merged tree after all four, not
 # computed -- #27441 landed between this branch's first push and now.
-UNWIRED_BASELINE=709
+UNWIRED_BASELINE=708
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then


### PR DESCRIPTION
## 문제

keeper 코드 두 곳이 바깥 패턴이 이미 좁혀놓은 값을 안에서 다시 매치하고, 그 때문에 생긴 도달 불가 arm 을 `assert false` 로 막는다.

```ocaml
(* keeper_activation_readiness.ml:218 *)
| Owner_registered { phase = (Paused | Dead); _ } ->
  Paused_dead
    (Runtime_terminal
       (match runtime with
        | Owner_registered { phase; _ } -> phase
        | Owner_unregistered -> assert false))   (* 바깥에서 이미 배제됨 *)
```

```ocaml
(* keeper_board_attention_partition.ml:1376 *)
| Predispatch_rejection _ ->
  let last_from =
    match source with
    | Predispatch_rejection visit -> visit
    | Executed_failure _ -> assert false          (* 바깥에서 이미 배제됨 *)
  in
```

## 저장소 관례와도 어긋난다

```ocaml
(* shell_command_gate.ml:81 *)
(* [invalid_arg] (not [assert false]) per the convention in
   keeper_turn_fsm.ml:284 — operators reading a crash dump see *which*
   caller invariant was violated without cross-referencing line numbers. *)
```

출처(`keeper_turn_fsm.ml:44`)도 같은 말을 한다 — `Invalid_argument` 가 위반 내용을 백트레이스에 실어 보낸다고.

## 변경

`invalid_arg` 로 바꾸는 대신 **분기 자체를 없앴다.** 바깥 패턴에서 값을 묶으면 안쪽 재-매치가 필요 없고, 도달 불가 상태를 표현할 방법이 사라진다.

```ocaml
| Owner_registered { phase = (Paused | Dead) as phase; _ } ->
  Paused_dead (Runtime_terminal phase)

| Predispatch_rejection last_from ->
```

동작 변화 없음. keeper 경로에서 `Assert_failure` 가 나올 수 있는 지점 두 개가 사라진다 — CLAUDE.md 가 기록한 `keeper_registry.ml:721` 사고와 같은 계열이다.

## 검증

```
dune build --root . @check                         → 0
@runtest-test_keeper_board_attention_partition     → 13 tests, Successful
@runtest-test_keeper_lifecycle_global_gate         → 18 tests, Successful
```

## CI 배선

`test_keeper_lifecycle_global_gate` 는 `Keeper_activation_readiness` 를 덮는 유일한 스위트인데 CI 의 어느 스텝도 부르지 않았다. 이 PR 이 그 모듈을 건드리므로 board-attention 스텝에 같이 물렸다. `UNWIRED_BASELINE` 709 → 708.

발견 경위: 저장소가 금지·제한하는 구성물 스캔 (`Obj.magic` 0건, `failwith` 21건은 대부분 배선 단언). `assert false` 89건 중 80건이 테스트 픽스처이고, 프로덕션 9건 중 이 둘이 관례 위반이었다.
