### PR TITLE
refactor(keeper): proactive quality gate 잔해 숙청 (Jaccard 0.72 스펙 포함)

### DIFF
--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -431,21 +431,6 @@ keeper는 durable always-on으로 취급되며, `keeper_up`은 inline args, TOML
 
 Keeper는 idle 상태에서 주기적으로 자발적 행동을 생성한다.
 
-### 10.1 Quality Gate
-
-`proactive_quality_check`가 생성된 텍스트를 검증:
-
-1. `extract_checkin_text`: `CHECKIN:` 접두사 추출 또는 전체 텍스트 사용
-2. `proactive_looks_fragmentary`: 미완성 문장 감지 (`"`, `(`, `:`, `-` 등으로 끝남)
-3. `proactive_has_terminal_ending`: 종결 구두점 또는 한국어 종결 어미(`다`, `요`, `니다`, `습니다`) 확인
-4. Similarity check: 이전 출력과 Jaccard 유사도 >= threshold(0.72) 시 재생성
-
-실패 시 최대 3회 재시도, temperature를 점진적으로 상승(0.55 -> 0.75 -> 0.9).
-
-### 10.2 Fallback Reply
-
-3회 모두 실패하면 deterministic fallback 템플릿을 사용한다. 모든 keeper에 동일한 통합 fallback 문구가 적용된다.
-
 ---
 
 ## 14. Invariants

--- a/lib/keeper/keeper_text_processing.ml
+++ b/lib/keeper/keeper_text_processing.ml
@@ -37,10 +37,6 @@ let normalize_proactive_text (raw : string) : string =
   |> Re.replace_string re_whitespace ~by:" "
   |> String.trim
 
-let extract_checkin_text (raw : string) : string option =
-  let cleaned = normalize_proactive_text raw in
-  if cleaned = "" then None else Some cleaned
-
 let proactive_has_terminal_punct (s : string) : bool =
   let t = String.trim s in
   t <> "" && Re.execp re_terminal_punct t
@@ -64,10 +60,13 @@ let looks_fragmentary_history_text (raw : string) : bool =
   else
     let hard_fragment = proactive_looks_fragmentary t in
     let has_terminal = proactive_has_terminal_ending t in
-    let ends_korean_sentence = Re.execp re_korean_ending t in
-    let short_unterminated =
-      (not has_terminal) && (not ends_korean_sentence) && String.length t <= 24
-    in
+    (* [t] is normalized (whitespace-collapsed, trimmed) and the [t = ""] case
+       returned above, so [proactive_has_terminal_korean_ending t] reduces to
+       [Re.execp re_korean_ending t]. [has_terminal] is that disjoined with the
+       punctuation check, so [not has_terminal] already implies the Korean
+       ending is absent. The separate conjunct that used to sit here rejected
+       nothing. *)
+    let short_unterminated = (not has_terminal) && String.length t <= 24 in
     let trailing_connector =
       (not has_terminal)
       && Re.execp re_trailing_connector (String.lowercase_ascii t)

--- a/lib/keeper/keeper_text_processing.mli
+++ b/lib/keeper/keeper_text_processing.mli
@@ -12,16 +12,10 @@ val truncate_utf8_prefix : max_bytes:int -> string -> string * bool
 (** Normalise proactive text by collapsing whitespace. *)
 val normalize_proactive_text : string -> string
 
-(** Extract check-in text from a proactive reply. *)
-val extract_checkin_text : string -> string option
-
 (** {1 Terminal Ending Detection} *)
 
 (** Check for terminal punctuation ([.!?] or CJK equivalents). *)
 val proactive_has_terminal_punct : string -> bool
-
-(** Check for terminal Korean verb endings. *)
-val proactive_has_terminal_korean_ending : string -> bool
 
 (** Check for any terminal ending (punctuation or Korean). *)
 val proactive_has_terminal_ending : string -> bool

--- a/scripts/audit-dead-surface.py
+++ b/scripts/audit-dead-surface.py
@@ -547,7 +547,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 # merged tree after main's batch-1..3 landed, not computed from the batch
 # size -- the merge also dropped should_use_dict, which lost its last
 # caller when batch 1 removed the dictionary helpers around it.
-DEAD_EXPORT_BASELINE = 575
+DEAD_EXPORT_BASELINE = 574
 
 
 def run_ratchet(count: int) -> int:


### PR DESCRIPTION
## 무엇을 지웠나

`docs/spec/05-keeper-agent.md` §10.1 이 proactive "Quality Gate" 를 문서화하고 있었다:

> 1. `extract_checkin_text`: `CHECKIN:` 접두사 추출 또는 전체 텍스트 사용
> 2. `proactive_looks_fragmentary`: 미완성 문장 감지
> 3. `proactive_has_terminal_ending`: 종결 구두점 또는 한국어 종결 어미 확인
> 4. **Similarity check: 이전 출력과 Jaccard 유사도 >= threshold(0.72) 시 재생성**
>
> 실패 시 최대 3회 재시도, temperature 를 점진적으로 상승(0.55 -> 0.75 -> 0.9).
>
> §10.2 Fallback Reply: 3회 모두 실패하면 deterministic fallback 템플릿

**이 중 어느 것도 존재하지 않는다.** `lib/` 실측:

| 심볼 | 파일 수 |
|---|---|
| `proactive_quality_check` | **0** |
| `jaccard` | **0** |
| `0.55` (온도 시작값) | **0** |
| `CHECKIN` (대문자 리터럴) | **0** |

게이트는 **#5003** (`remove dead proactive generation code`, -475 lines) 에서 나갔다. Jaccard 채점기는 **#26139 / #26785 / #26867 / #26883** 에 걸쳐 나갔고, 그중 **#26785 (`keeper_tool_search` vestige — visible-set Jaccard 재랭커) 는 현재 main 의 최신 커밋**이다.

재시도 사다리를 들고 있는 곳도 없다 — `lib/keeper` 의 `temperature` 는 pass-through `float option` 이고, `keeper_heartbeat_loop` 에 품질 검사가 없다.

**존재하지 않는 유사도 임계값을 문서화하는 것은 아무것도 문서화하지 않는 것보다 나쁘다.** 다음 독자가 "masc 는 재생성 여부를 텍스트 유사도로 판정한다" 를 여기서 배운다. §10.1 · §10.2 를 지우고, §10 에서 실제로 살아있는 한 문장만 남겼다.

이 파일로 들어오는 RFC 상호참조는 앵커 기반(`#inv-keeper-...`)이라 줄 삭제로 깨지지 않는다. `spec-line-refs.sh` 통과.

## 남은 잔해 셋

`keeper_text_processing` 이 그 게이트의 잔해다 — 자기 헤더가 스스로를 *"legacy fragment diagnostics"* 라 부르고, export 8 개 중 5 개가 프로덕션 소비자 0 이다.

**`extract_checkin_text` — 삭제.** `lib/` `test/` `scripts/` 그리고 **자기 모듈 내부까지 호출자 0.** 위 스펙 줄이 유일하게 남은 설명이었고, **그 설명조차 틀렸다** — 접두사를 추출하지 않는다. 공백을 정규화하고 빈 문자열이면 `None` 을 돌려줄 뿐이다.

**`proactive_has_terminal_korean_ending` — `val` 만 제거.** 정의 한 줄 아래에서 `proactive_has_terminal_ending` 이 쓰므로 바인딩은 남는다. 모듈 밖에서 읽는 곳이 없다.

**`looks_fragmentary_history_text` — 아무것도 거르지 않던 conjunct 제거.**

```ocaml
let ends_korean_sentence = Re.execp re_korean_ending t in
(not has_terminal) && (not ends_korean_sentence) && String.length t <= 24
```

`t` 는 정규화(공백 축약 + trim)됐고 `t = ""` 는 위에서 먼저 반환한다. 따라서 `proactive_has_terminal_korean_ending t` 는 `Re.execp re_korean_ending t` 로 환원되고, `has_terminal` 은 그것과 구두점 검사의 논리합이다. 즉 **`not has_terminal` 이 이미 한국어 어미 부재를 함의**하므로 두 번째 항은 결과를 바꾼 적이 없다.

`test_pbt_text_processing` 이 **이미 그 함의를 고정하고 있다** — "Korean endings detected" 가 생성된 한국어 어미 문자열 500 개에 대해 `proactive_has_terminal_ending` 을 단언한다. 통과하므로 **새 프로퍼티를 추가하지 않았다.**

## 검증

| 항목 | 결과 |
|---|---|
| `dune build --root . @check` | exit 0 |
| `test_pbt_text_processing` | 5/5 OK |
| `scripts/lint/*.sh` 전체 32 개 | exit 0 |
| `verify-test-registration.py` | exit 0 (unregistered 0) |
| `audit-ci-test-targets.sh` | exit 0 |
| `check-pr-hygiene.sh --base origin/main` | exit 0 |
| `audit-dead-surface.py --exports --ratchet` | 575 → **574**, 베이스라인 하향 |

## 동작은 바뀌지 않는다

`looks_fragmentary_history_text` 는 같은 술어로 keeper 이력을 계속 거른다. 발화할 수 없던 conjunct 하나가 사라졌을 뿐이다.

임계값의 단위 문제와 **필터가 추측에 의존한다는 사실** 자체는 별개이고 #27444 에서 다룬다. 이번에 그쪽에 결정적 근거가 하나 추가됐다 — `result.response.stop_reason` 이 이 턴을 기록하는 바로 그 함수 안에 있는데 기록되지 않는다. 상세는 #27444 코멘트.
