### PR TITLE
chore(mcp): drop the two board-dispatch params nothing reads

### DIFF
--- a/lib/mcp_tool_runtime.ml
+++ b/lib/mcp_tool_runtime.ml
@@ -57,8 +57,6 @@ let dispatch (ctx : context) ~(name : string) : Tool_result.result option =
   let config = ctx.config in
   let agent_name = ctx.agent_name in
   let state = ctx.state in
-  let sw = ctx.sw in
-  let clock = ctx.clock in
   let arguments = ctx.arguments in
 
   match name with
@@ -74,7 +72,7 @@ let dispatch (ctx : context) ~(name : string) : Tool_result.result option =
 
   (* ── Fallthrough to extra dispatch ──────────────────────────── *)
   | _ ->
-      Mcp_tool_runtime_board.dispatch ~config ~agent_name ~arguments ~state ~sw ~clock ~name ~start_time:start
+      Mcp_tool_runtime_board.dispatch ~config ~agent_name ~arguments ~state ~name ~start_time:start
 
 (* ================================================================ *)
 (* Tool_spec registration (RFC-0182 §3.2)                           *)

--- a/lib/mcp_tool_runtime_board.ml
+++ b/lib/mcp_tool_runtime_board.ml
@@ -246,9 +246,14 @@ let ensure_board_post_author ~agent_name arguments =
   enforce_caller_identity ~tool:"masc_board_post" ~field:"author"
     ~agent_name arguments
 
-let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~sw ~clock ~name ~start_time =
-  (* fire-and-forget: unused params kept for interface contract with callers *)
-  ignore (config, state, sw, clock, start_time);
+(* [sw] and [clock] used to sit here beside the others, under an [ignore] and a
+   comment calling all five "unused params kept for interface contract with
+   callers". Three of the five -- [config], [state] and [start_time] -- are used
+   in this function, and there is no interface contract: [dispatch] has one
+   caller, a direct call from [Mcp_tool_runtime], and the sibling handlers take
+   a different shape (~tool_name ~start_time ctx). What the [ignore] did was
+   suppress the warning that would have named [sw] and [clock] as dead. *)
+let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~name ~start_time =
   let arguments =
     match name with
     | "masc_board_post" | "masc_board_post_update" ->

--- a/lib/mcp_tool_runtime_board.mli
+++ b/lib/mcp_tool_runtime_board.mli
@@ -65,14 +65,12 @@ val dispatch :
   agent_name:string ->
   arguments:Yojson.Safe.t ->
   state:Mcp_server.server_state ->
-  sw:Eio.Switch.t ->
-  clock:_ ->
   name:string ->
   start_time:float ->
   Tool_result.result option
-(** [dispatch ~config ~agent_name ~arguments ~state ~sw ~clock
-      ~name ~start_time] handles MCP server-local routing for tool [name]
-    when the main runtime router has no match.  Currently routes:
+(** [dispatch ~config ~agent_name ~arguments ~state ~name ~start_time] handles
+    MCP server-local routing for tool [name] when the main runtime router has no
+    match.  Currently routes:
 
     - [masc_board_post] -> identity enforcement +
       {!Board_dispatch.create_post} +
@@ -80,7 +78,9 @@ val dispatch :
     - everything else -> [None] (caller falls through to remaining
       dispatchers).
 
-    [config] / [state] / [sw] / [clock] are ignored at the entry
-    today (board path doesn't need them) but kept in the
-    signature for forward compat — adding new tool routes that
-    require runtime resources will not break callers. *)
+    This doc used to say [config] / [state] / [sw] / [clock] "are ignored at the
+    entry today … but kept in the signature for forward compat". [config],
+    [state] and [start_time] are used by the routes below; [sw] and [clock] were
+    the only unused ones and are gone. The one caller is a direct call, so a
+    later route needing a switch or a clock adds the parameter back and the
+    compiler names that caller. *)

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -1179,14 +1179,14 @@ let test_board_curation_submit_roundtrips_to_read () =
     "Board has one high-priority routing item."
     Yojson.Safe.Util.(read_json |> member "summary" |> to_string)
 
-let mcp_runtime_board_dispatch ~sw ~clock name args =
+let mcp_runtime_board_dispatch name args =
   let state = Mcp_server.For_testing.create_state ~base_path:_test_base_path in
   Mcp_tool_runtime_board.dispatch ~config:(Mcp_server.workspace_config state)
-    ~agent_name:"mcp-runtime-curator" ~arguments:args ~state ~sw ~clock ~name
+    ~agent_name:"mcp-runtime-curator" ~arguments:args ~state ~name
     ~start_time:(Unix.gettimeofday ())
 
-let require_mcp_runtime_result ~sw ~clock name args =
-  match mcp_runtime_board_dispatch ~sw ~clock name args with
+let require_mcp_runtime_result name args =
+  match mcp_runtime_board_dispatch name args with
   | Some result -> ((Tool_result.is_success result), (Tool_result.message result))
   | None -> Alcotest.failf "%s not routed by MCP runtime board dispatch" name
 
@@ -1194,15 +1194,16 @@ let test_board_curation_mcp_runtime_routes_read_and_submit () =
   with_eio @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
-  Eio.Switch.run @@ fun sw ->
-  let clock = Eio.Stdenv.clock env in
+  (* The switch stays: [with_eio] scopes the fibers this test runs under. The
+     clock binding existed only to reach [dispatch], which never read it. *)
+  Eio.Switch.run @@ fun _sw ->
   let read_ok, read_body =
-    require_mcp_runtime_result ~sw ~clock "masc_board_curation_read" (make_args [])
+    require_mcp_runtime_result "masc_board_curation_read" (make_args [])
   in
   Alcotest.(check bool) "MCP runtime curation read ok" true read_ok;
   Alcotest.(check string) "MCP runtime curation read empty" "null" read_body;
   let submit_ok, submit_body =
-    require_mcp_runtime_result ~sw ~clock "masc_board_curation_submit"
+    require_mcp_runtime_result "masc_board_curation_submit"
       (make_args
          [
            ("submitted_by", `String "mcp-runtime-curator");
@@ -1219,7 +1220,7 @@ let test_board_curation_mcp_runtime_routes_read_and_submit () =
   Alcotest.(check string) "MCP runtime submitted_by persisted" "curator"
     Yojson.Safe.Util.(submitted |> member "submitted_by" |> to_string);
   let read2_ok, read2_body =
-    require_mcp_runtime_result ~sw ~clock "masc_board_curation_read" (make_args [])
+    require_mcp_runtime_result "masc_board_curation_read" (make_args [])
   in
   Alcotest.(check bool) "MCP runtime curation read after submit ok" true read2_ok;
   Alcotest.(check string) "MCP runtime curation read after submit summary"


### PR DESCRIPTION
## What

`Mcp_tool_runtime_board.dispatch` opened with:

```ocaml
(* fire-and-forget: unused params kept for interface contract with callers *)
ignore (config, state, sw, clock, start_time);
```

and its `.mli` said `config` / `state` / `sw` / `clock` "are ignored at the
entry today (board path doesn't need them) but kept in the signature for
forward compat".

Both statements are wrong, in two different ways.

## Three of the five are used

Counted over the function body (lines 249–519), excluding the `ignore` itself:

```
config      7 uses
state       3 uses
start_time  4 uses
sw          0
clock       0
```

## There is no interface contract

`dispatch` has **one** caller — a direct call from `Mcp_tool_runtime` — and the
sibling handlers beside it take a different shape entirely
(`~tool_name ~start_time ctx`). Nothing constrains this signature.

## What the ignore was actually doing

Suppressing the warning that would have named `sw` and `clock` as dead. With it
removed, the compiler produced the rest of the cleanup on its own:

```
lib/mcp_tool_runtime.ml:60   Error (warning 26): unused variable sw
lib/mcp_tool_runtime.ml:61   Error (warning 26): unused variable clock
test/test_tool_board_coverage.ml:1184   partial application
test/test_tool_board_coverage.ml:1198   Error (warning 26): unused variable clock
```

Those two bindings in the caller existed only to be threaded here. So did the
test helper's `~sw ~clock` chain, four call sites deep.

The switch in the test stays — `with_eio` scopes the fibers it runs under — and
is bound as `_sw`.

## Forward compat is not lost

A later route that needs a switch or a clock adds the parameter back, and the
compiler names the single caller. That is cheaper than carrying two parameters
under an `ignore` that also hides whatever else goes dead beside them.

## Verification

```
dune build --root . @check                                        exit 0
dune build --root . @fmt            no diff in any file this PR touches

test_tool_board_coverage             78 tests run   Successful
test_mcp_h1_h2_admission_parity      16 tests run   Successful
test_mcp_session_task_lifecycle       7 tests run   Successful
test_enum_mirror_sync                 2 tests run   Successful
```

No behaviour change: the two parameters were read by nothing.

RFC-WAIVED: two unused parameters removed after checking the contract their
comment claimed, which does not exist.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
