### PR TITLE
fix(dashboard): 파싱 불가 last_seen 을 '방금 봤음' 으로 읽던 fail-open 2곳

### DIFF
--- a/lib/dashboard/dashboard_labels.ml
+++ b/lib/dashboard/dashboard_labels.ml
@@ -39,22 +39,27 @@ let translate_agent_status ~(now : float) (status : Masc_domain.agent_status)
   let stuck_threshold_sec =
     Runtime_params.get Runtime_settings.dashboard_agent_stuck_threshold_sec
   in
-  let elapsed_opt = parse_iso_timestamp last_seen_iso in
-  let elapsed_sec =
-    match elapsed_opt with Some ts -> now -. ts | None -> 0.0
-  in
-  match status with
-  | Masc_domain.Active when elapsed_sec > stuck_threshold_sec ->
-      Printf.sprintf "STUCK (%.0fm, needs check)" (elapsed_sec /. 60.0)
-  | Masc_domain.Busy when elapsed_sec > stuck_threshold_sec ->
+  (* An unparseable [last_seen] is absence of liveness evidence, so it stays an
+     [option] here instead of collapsing to an elapsed of 0.0. That collapse
+     read as "seen just now" and put an agent with a corrupt timestamp in the
+     healthiest bucket the label has. #9751 settled the direction for the
+     missing-field case and keeper_status_runtime.ml applies it to the derived
+     age; the label follows the same rule and names the gap rather than
+     printing a minute count it does not have. *)
+  match status, parse_iso_timestamp last_seen_iso with
+  | (Masc_domain.Active | Masc_domain.Busy), None ->
+      "STUCK (no liveness evidence)"
+  | Masc_domain.Active, Some ts when now -. ts > stuck_threshold_sec ->
+      Printf.sprintf "STUCK (%.0fm, needs check)" ((now -. ts) /. 60.0)
+  | Masc_domain.Busy, Some ts when now -. ts > stuck_threshold_sec ->
       Printf.sprintf "STUCK (%.0fm, marked busy but no progress)"
-        (elapsed_sec /. 60.0)
-  | Masc_domain.Active when elapsed_sec > quiet_threshold_sec ->
-      Printf.sprintf "quiet (%.0fm)" (elapsed_sec /. 60.0)
-  | Masc_domain.Active -> "working"
-  | Masc_domain.Busy -> "working (busy)"
-  | Masc_domain.Listening -> "idle"
-  | Masc_domain.Inactive -> "offline"
+        ((now -. ts) /. 60.0)
+  | Masc_domain.Active, Some ts when now -. ts > quiet_threshold_sec ->
+      Printf.sprintf "quiet (%.0fm)" ((now -. ts) /. 60.0)
+  | Masc_domain.Active, Some _ -> "working"
+  | Masc_domain.Busy, Some _ -> "working (busy)"
+  | Masc_domain.Listening, _ -> "idle"
+  | Masc_domain.Inactive, _ -> "offline"
 
 (** Classify an agent for grouping: Working, Stuck, Idle, or Offline.
     Offline agents (Inactive) are separated from Idle (Listening) so that
@@ -65,12 +70,14 @@ let classify_agent ~(now : float) (agent : Masc_domain.agent) : agent_group =
   let stuck_threshold_sec =
     Runtime_params.get Runtime_settings.dashboard_agent_stuck_threshold_sec
   in
-  let elapsed_opt = parse_iso_timestamp agent.last_seen in
-  let elapsed_sec =
-    match elapsed_opt with Some ts -> now -. ts | None -> 0.0
-  in
-  match agent.status with
-  | Masc_domain.Active | Masc_domain.Busy when elapsed_sec > stuck_threshold_sec -> Stuck
-  | Masc_domain.Active | Masc_domain.Busy -> Working
-  | Masc_domain.Listening -> Idle
-  | Masc_domain.Inactive -> Offline
+  (* Same rule as [translate_agent_status]: no parseable timestamp is no
+     liveness evidence. Only [Active]/[Busy] claim to be running, so only they
+     turn [Stuck] on missing evidence — [Listening] and [Inactive] keep their
+     status-derived group. *)
+  match agent.status, parse_iso_timestamp agent.last_seen with
+  | (Masc_domain.Active | Masc_domain.Busy), None -> Stuck
+  | (Masc_domain.Active | Masc_domain.Busy), Some ts
+    when now -. ts > stuck_threshold_sec -> Stuck
+  | (Masc_domain.Active | Masc_domain.Busy), Some _ -> Working
+  | Masc_domain.Listening, _ -> Idle
+  | Masc_domain.Inactive, _ -> Offline

--- a/test/test_dashboard_labels.ml
+++ b/test/test_dashboard_labels.ml
@@ -243,6 +243,84 @@ let test_classify_uses_stuck_threshold_override () =
   Alcotest.(check bool) "active can classify as Stuck via override" true
     (Dashboard_labels.equal_agent_group group Dashboard_labels.Stuck)
 
+(* An agent that claims to be Active or Busy while carrying a last_seen the
+   codec cannot parse has produced no liveness evidence. #9751 settled the
+   direction for the missing-field case ("a corrupt record read as 'seen just
+   now' satisfied every downstream liveness check"), and
+   keeper_status_runtime.ml applies the same rule to the derived age. These
+   pin it for the classifier: unparseable is infinitely stale, not fresh. *)
+let unparseable_last_seen = "not-a-timestamp"
+
+let test_classify_unparseable_last_seen_is_stuck () =
+  let now = Unix.gettimeofday () in
+  let agent : Masc_domain.agent =
+    {
+      id = None;
+      name = "test-agent";
+      agent_type = "test";
+      status = Masc_domain.Active;
+      capabilities = [];
+      current_task = None;
+      session_bound_at = "2026-01-01T00:00:00Z";
+      last_seen = unparseable_last_seen;
+      meta = None;
+    }
+  in
+  let group = Dashboard_labels.classify_agent ~now agent in
+  Alcotest.(check bool) "active with unparseable last_seen = Stuck" true
+    (Dashboard_labels.equal_agent_group group Dashboard_labels.Stuck)
+
+let test_classify_unparseable_last_seen_busy_is_stuck () =
+  let now = Unix.gettimeofday () in
+  let agent : Masc_domain.agent =
+    {
+      id = None;
+      name = "test-agent";
+      agent_type = "test";
+      status = Masc_domain.Busy;
+      capabilities = [];
+      current_task = None;
+      session_bound_at = "2026-01-01T00:00:00Z";
+      last_seen = unparseable_last_seen;
+      meta = None;
+    }
+  in
+  let group = Dashboard_labels.classify_agent ~now agent in
+  Alcotest.(check bool) "busy with unparseable last_seen = Stuck" true
+    (Dashboard_labels.equal_agent_group group Dashboard_labels.Stuck)
+
+(* Offline and Idle do not claim liveness, so an unparseable timestamp must
+   not promote them out of their status-derived group. *)
+let test_classify_unparseable_last_seen_keeps_offline () =
+  let now = Unix.gettimeofday () in
+  let agent : Masc_domain.agent =
+    {
+      id = None;
+      name = "test-agent";
+      agent_type = "test";
+      status = Masc_domain.Inactive;
+      capabilities = [];
+      current_task = None;
+      session_bound_at = "2026-01-01T00:00:00Z";
+      last_seen = unparseable_last_seen;
+      meta = None;
+    }
+  in
+  let group = Dashboard_labels.classify_agent ~now agent in
+  Alcotest.(check bool) "inactive stays Offline" true
+    (Dashboard_labels.equal_agent_group group Dashboard_labels.Offline)
+
+let test_translate_unparseable_last_seen_does_not_read_working () =
+  let now = Unix.gettimeofday () in
+  let label =
+    Dashboard_labels.translate_agent_status ~now Masc_domain.Active
+      unparseable_last_seen
+  in
+  Alcotest.(check bool) "label must not claim the agent is working" false
+    (label = "working");
+  Alcotest.(check bool) "label names the missing evidence" true
+    (label = "STUCK (no liveness evidence)")
+
 (* ===== Attention Items ===== *)
 
 let test_attention_empty () =
@@ -288,6 +366,14 @@ let () =
           ("inactive is Offline", `Quick, test_classify_inactive_is_offline);
           ("listening is Idle", `Quick, test_classify_listening_is_idle);
           ("stuck override applied", `Quick, test_classify_uses_stuck_threshold_override);
+          ( "unparseable last_seen (active) is Stuck"
+          , `Quick, test_classify_unparseable_last_seen_is_stuck );
+          ( "unparseable last_seen (busy) is Stuck"
+          , `Quick, test_classify_unparseable_last_seen_busy_is_stuck );
+          ( "unparseable last_seen keeps Offline"
+          , `Quick, test_classify_unparseable_last_seen_keeps_offline );
+          ( "unparseable last_seen label does not read working"
+          , `Quick, test_translate_unparseable_last_seen_does_not_read_working );
         ] );
       ( "Attention",
         [


### PR DESCRIPTION
## 증상

`dashboard_labels.ml` 이 경과 시간을 두 곳에서 이렇게 뽑았다:

```ocaml
let elapsed_opt = parse_iso_timestamp agent.last_seen in
let elapsed_sec =
  match elapsed_opt with Some ts -> now -. ts | None -> 0.0
in
```

`0.0` 은 `now` 기준이다. **코덱이 파싱 못 하는 타임스탬프가 경과 0 초, 즉 가장 신선한 값이 된다.** Active/Busy 를 주장하면서 `last_seen` 이 깨진 에이전트는 `Working` 으로 분류되고 `"working"` 으로 표시된다 — operator 가 가장 알아야 할 상태가 가장 건강한 라벨을 받는다.

## 이 저장소는 같은 역전을 이미 두 번 고쳤다

두 주석이 **똑같은 문장**으로 그 사고를 기록한다:

> `types_core.ml` (#9751), 누락된 `last_seen` 을 epoch 로 채우는 이유:
> *"A `now ()` filler inverted that: a corrupt record read as **'seen just now'** and satisfied every downstream liveness check."*

> `keeper_status_runtime.ml`, 파생 age 를 생략하는 이유:
> *"Emitting 0.0 read as **'seen just now'** and made that fail-closed fallback unreachable, because the field was always present."*

둘 다 **필드가 없는 경우**를 고쳤다. 이 두 사이트는 **필드가 있고 문자열이지만 타임스탬프가 아닌** 경로로 같은 오답에 도달한다. CLAUDE.md 의 "2 번째 fix → 근본 수정 강제" 기준으로 세 번째 발생이다.

## 범위 — 실측

ISO 타임스탬프를 파싱하는 사이트 전수 중 **경과 시간(duration)** 을 기본값으로 두는 곳은 이 둘뿐이다.

| 사이트 | 무엇을 0.0 으로 두나 | 방향 |
|---|---|---|
| `dashboard_labels.ml` ×2 | **경과 시간** | fail-**open** (= 방금 봤음) |
| `dashboard_http_keeper.ml` | 타임스탬프 (`created_ts`) | fail-closed (= epoch, 아주 오래됨) |
| `operator_control_snapshot.ml` | 타임스탬프 | fail-closed |
| `keeper_world_observation_inputs.ml` | 타임스탬프 | fail-closed |
| `cost_ledger.ml` | — | **거부** (`invalid "timestamp"`) |
| 그 외 | — | 부재 전파 (`None -> None` / `None -> acc` / `None -> ()`) |

**같은 리터럴 `0.0` 이 뺄셈의 어느 쪽에 놓이느냐에 따라 정반대를 뜻한다.** 이게 판별자였다.

## 도달성 — 정직하게

masc 자신의 writer 는 항상 `Masc_domain.now_iso ()` 를 쓴다. **불량 `last_seen` 을 가진 로컬 agent 레코드는 찾지 못했다.** 경로가 열려 있을 뿐 관측된 사고가 아니다:

- `normalize_agent_last_seen` 은 `` `String _ as value -> Some value `` 로 **어떤 문자열이든 검증 없이 통과**시킨다.
- 게다가 그 정규화는 생성된 deserializer 가 **실패했을 때만** 돈다. `last_seen` 이 올바른 JSON 문자열이면 deserializer 가 성공해 정규화를 건너뛰므로, 타임스탬프가 아닌 문자열은 **정상 경로로** 레코드에 도착한다.

즉 **fail-open latent** 이지 진행 중인 장애가 아니다.

## 수정

파싱 결과를 sentinel float 로 뭉개지 않고 `option` 으로 유지하고, `(status, parsed)` 쌍으로 매치해 컴파일러가 status 변형을 계속 검사하게 했다.

- **Active / Busy 만** "돌고 있다" 를 주장하므로, 증거 부재 시 그 둘만 `Stuck` 이 된다.
- `Listening` 은 `Idle`, `Inactive` 는 `Offline` 을 유지한다 — 이들은 liveness 를 주장하지 않는다.
- 라벨은 갖고 있지도 않은 분(分) 수치를 찍는 대신 `"STUCK (no liveness evidence)"` 로 **없는 것을 이름 붙인다**.

## 검증 — 수정 전 트리에서 먼저 실패시켰다

테스트 4 개를 **수정 전에** 넣고 돌렸다:

```
RUN(수정 전)=1
> [FAIL]  Agent Classification  3  unparseable last_seen (active)...
  [FAIL]  Agent Classification  4  unparseable last_seen (busy)...
  [OK]    Agent Classification  5  unparseable last_seen keeps Offline
  [FAIL]  Agent Classification  6  unparseable last_seen label...
```

3 개 실패, 4 번째는 통과 — `Inactive` 는 `Offline` 을 유지해야 하므로 **과잉교정 방지 가드**다. 수정 후 23/23.

| 항목 | 결과 |
|---|---|
| `dune build --root . @check` | exit 0 |
| `test_dashboard_labels` | 23/23 |
| `test_auth_error_kind` | exit 0 |
| `scripts/lint/*.sh` 전체 | exit 0 |
| `verify-test-registration.py` | exit 0 |
| `audit-ci-test-targets.sh` | exit 0 |
| `check-pr-hygiene.sh --base origin/main` | exit 0 |

## 남는 것 (이 PR 범위 밖)

`agent.last_seen : string` 이 코덱에서 검증되지 않아 **소비자 8 곳이 각자 파싱하고 각자 실패 의미를 고른다.** 그중 둘이 fail-open 을 골랐고 이 PR 이 그 둘을 돌려놨지만, 다음 소비자가 다시 고를 수 있다. 근본은 경계에서 파싱해 타입으로 들고 다니는 것이다 (parse, don't validate). 별건으로 다룰 사안이라 여기서는 손대지 않았다.
