### PR TITLE
test,chore(transport): make the parity gate real, and fix two metrics nothing connects

### DIFF
--- a/dashboard/src/sse-event-type-parity.test.ts
+++ b/dashboard/src/sse-event-type-parity.test.ts
@@ -30,7 +30,18 @@ import { describe, expect, it } from 'vitest'
 // uses TypeScript AST comparisons, so a suffix rename ("approval:pending:v2")
 // does not satisfy "approval:pending".
 
-// event-type -> the backend .ml that emits the quoted literal.
+// event-type -> the backend .ml that EMITS the quoted literal.
+//
+// Emits, not merely mentions. A consumer that matches on the same literal
+// satisfies the assertion just as well as the producer does, and binding one
+// here makes the gate green while the real emitter is free to rename -- which
+// is the exact failure this file exists to prevent. Four entries pointed at
+// server_mcp_transport_ws.ml, whose dashboard_slice_for_sse_type matches these
+// literals to pick a delta slice; it reads them, it does not emit them.
+//
+// When adding an entry, find the site that builds the broadcast payload
+// (`"type", `String "..."` or `~event_type:"..."`), not the site that branches
+// on it.
 const BACKEND_EMITTED: Record<string, string> = {
   'approval:pending': '../lib/keeper/keeper_approval_queue.ml',
   'approval:resolved': '../lib/keeper/keeper_approval_queue.ml',
@@ -41,15 +52,15 @@ const BACKEND_EMITTED: Record<string, string> = {
   keeper_waiting_inventory_changed: '../lib/keeper/keeper_waiting_inventory_broadcast.ml',
   keeper_compaction_snapshots_changed: '../lib/server/server_dashboard_http_keeper_api.ml',
   ide_cursor_changed: '../lib/server/server_ide_http.ml',
-  keeper_composite_changed: '../lib/server/server_mcp_transport_ws.ml',
+  keeper_composite_changed: '../lib/keeper/keeper_registry_broadcast.ml',
   keeper_heartbeat: '../lib/keeper/keeper_heartbeat_snapshot.ml',
   keeper_turn_complete: '../lib/keeper/keeper_hooks_oas.ml',
   oas_telemetry_sample: '../lib/runtime/dashboard_oas_bridge.ml',
-  namespace_truth_snapshot: '../lib/server/server_mcp_transport_ws.ml',
+  namespace_truth_snapshot: '../lib/server/server_dashboard_http_namespace_truth.ml',
   operator_digest: '../lib/server/server_dashboard_http_core_digest_refresh.ml',
-  operator_snapshot: '../lib/server/server_mcp_transport_ws.ml',
+  operator_snapshot: '../lib/server/server_dashboard_http_execution_surfaces.ml',
   post_created: '../lib/keeper_runtime/keeper_event_queue.ml',
-  project_snapshot: '../lib/server/server_mcp_transport_ws.ml',
+  project_snapshot: '../lib/server/server_dashboard_http_namespace_truth.ml',
   transport_health_snapshot: '../lib/server/server_dashboard_http_execution_surfaces.ml',
   fusion_run_status: '../lib/fusion/fusion_sink.ml',
 }

--- a/lib/otel_metric_store/otel_transport_metric_names.ml
+++ b/lib/otel_metric_store/otel_transport_metric_names.ml
@@ -24,7 +24,6 @@ let metric_oas_sse_relay_drop_marker_failures =
   Otel_metric_store_core.declare_counter "masc_oas_sse_relay_drop_marker_failures_total"
 ;;
 
-let metric_sse_stream_queue_depth = "masc_sse_stream_queue_depth"
 let metric_sse_queue_depth_avg = "masc_sse_queue_depth_avg"
 let metric_sse_queue_depth_max = "masc_sse_queue_depth_max"
 let metric_sse_external_subscribers = "masc_sse_external_subscribers_total"

--- a/lib/otel_metric_store/otel_transport_metric_names.mli
+++ b/lib/otel_metric_store/otel_transport_metric_names.mli
@@ -15,7 +15,6 @@ val metric_sse_broadcast_skipped_no_observer : string
 val metric_sse_external_subscriber_callback_failures : string
 val metric_sse_external_fanout_duration_seconds : string
 val metric_oas_sse_relay_drop_marker_failures : string
-val metric_sse_stream_queue_depth : string
 val metric_sse_queue_depth_avg : string
 val metric_sse_queue_depth_max : string
 val metric_sse_external_subscribers : string

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -465,6 +465,7 @@ type ws_delivery_metric_names =
   ; client_acks : string
   ; throttled_deliveries : string
   ; delta_payload_serializations : string
+  ; delta_built : string
   ; slice_fanout_skipped : string
   ; client_buffered_bytes : string
   ; client_buffered_bytes_count : string
@@ -478,6 +479,7 @@ let ws_delivery_metric_names =
   ; client_acks = "masc_ws_client_acks_total"
   ; throttled_deliveries = "masc_ws_throttled_deliveries_total"
   ; delta_payload_serializations = "masc_ws_delta_payload_serializations_total"
+  ; delta_built = Otel_metric_store.metric_ws_delta_built
     (* Named by the declaration, not by a literal: [metric_value_or_zero]
        answers an unknown name with 0, so a typo here would surface as a
        permanently-zero field instead of a failure. *)
@@ -684,6 +686,14 @@ let transport_health_json ~config =
                   , `Int
                       (int_of_float
                          (v ws_delivery_metrics.delta_payload_serializations ())) )
+                ; (* Deltas actually handed to a session, counted after the
+                     slice gate.  Paired with the two above it separates work
+                     done from work delivered: serializations counts payloads
+                     built (shared across sessions), delta_built counts sends.
+                     It has advanced on every delivered delta since #23339 with
+                     nothing reading it. *)
+                  ( "delta_built"
+                  , `Int (int_of_float (v ws_delivery_metrics.delta_built ())) )
                 ; (* Deliveries the slice gate dropped because the session did
                      not subscribe to that slice.  Without it the gap between
                      delivered broadcasts and what reaches the bytes cache is

--- a/test/test_transport_metrics.ml
+++ b/test/test_transport_metrics.ml
@@ -356,11 +356,15 @@ let test_transport_health_json () =
   let slice_fanout_skipped_before =
     Otel_metric_store.metric_total Otel_metric_store.metric_ws_slice_fanout_skipped
   in
+  let delta_built_before =
+    Otel_metric_store.metric_total Otel_metric_store.metric_ws_delta_built
+  in
   TM.observe_ws_dashboard_hello_latency ~success:true 0.125;
   (* Drive the counter so the assertion below is not satisfied by a field that
      is wired to the wrong metric name: [metric_value_or_zero] answers an
      unknown name with 0, which a presence-only check accepts. *)
   TM.inc_ws_slice_fanout_skipped ();
+  TM.inc_ws_delta_built ();
   Masc.Sse.broadcast (`Assoc [ ("type", `String "transport-test") ]);
   Masc.Sse.sync_transport_snapshot ~force:true ();
   let json = TM.transport_health_json ~config in
@@ -507,6 +511,12 @@ let test_transport_health_json () =
   check bool "slice_fanout_skipped advances" true
     (float_of_int (delivery_json |> U.member "slice_fanout_skipped" |> U.to_int)
      >= slice_fanout_skipped_before +. 1.0);
+  (* Same shape, same reason: the counter has advanced on every delivered delta
+     since #23339, but no snapshot carried it, so no operator could see it and
+     no test could notice if it stopped. *)
+  check bool "delta_built advances" true
+    (float_of_int (delivery_json |> U.member "delta_built" |> U.to_int)
+     >= delta_built_before +. 1.0);
   check bool "client_buffered_bytes_sum field present (float)" true
     (match delivery_json |> U.member "client_buffered_bytes_sum" with
      | `Float _ | `Int _ -> true | _ -> false);


### PR DESCRIPTION
#27433 이 slice 어휘를 정리하면서, 같은 축(WS/대시보드 transport)에 "생산되는데 아무도 소비하지 않는" 표면이 더 있는지 훑었다. 12 건 중 **처방이 명확하고 blast radius 가 작은 3 건**만 담는다. 나머지는 아래 "안 담은 것"에 이유와 함께 남긴다.

## 1. SSE parity 게이트가 소비자를 가리키고 있었다

`sse-event-type-parity.test.ts` 는 FE 가 정확히 매칭하는 SSE event type 각각에 대해 **그것을 방출하는 백엔드 `.ml`** 을 지정하고, 그 파일에 리터럴이 남아 있는지 검사한다. 백엔드 rename 이 FE 핸들러를 조용히 죽이는 것을 막으려고 쓴 파일이다 (#22115 의 일반화).

20 개 중 4 개가 `server_mcp_transport_ws.ml` 을 가리켰다. **그 파일은 이 이벤트들을 방출하지 않는다.** `dashboard_slice_for_sse_type` 이 delta slice 를 고르려고 같은 리터럴을 매칭할 뿐 — 읽는 쪽이다.

검사가 "그 파일에 리터럴이 있는가" 이므로 소비자도 생산자만큼 확실히 통과시킨다. 게이트는 초록인 채 진짜 emitter 는 자유롭게 rename 될 수 있었다 — 이 파일이 막으려던 바로 그 실패다.

| event type | before | after |
|---|---|---|
| `keeper_composite_changed` | `server_mcp_transport_ws.ml` | `keeper/keeper_registry_broadcast.ml:16` |
| `namespace_truth_snapshot` | ↑ | `server_dashboard_http_namespace_truth.ml:350` |
| `project_snapshot` | ↑ | `server_dashboard_http_namespace_truth.ml:342` |
| `operator_snapshot` | ↑ | `server_dashboard_http_execution_surfaces.ml:147` |

`operator_snapshot` 은 리터럴 사이트가 셋이다 — 캐시 키, projection 진단 라벨, 그리고 브로드캐스트. "파일이 그 문자열을 언급하는가" 식 검사가 **비소비자들 사이에서도** 틀린 파일을 고를 수 있다는 뜻이다. 브로드캐스트 지점을 골랐고, 게이트가 이미 `execution_snapshot` / `transport_health_snapshot` 을 묶어둔 파일과 같다.

**주장이 아니라 실연으로 확인**: `keeper_registry_broadcast.ml` 의 리터럴을 `keeper_composite_changed_v2` 로 rename 하면

- 수정 전 게이트: **25/25 초록**
- 수정 후 게이트: 정확히 그 항목만 실패

## 2. 쓰는 사람이 없는 메트릭 이름 삭제

`masc_sse_stream_queue_depth` 는 `declare_counter` 를 거치지도 않는 맨 문자열 상수다. 0-cell 도 없고, `lib` / `bin` / `test` / `scripts` / `dashboard` 어디에도 writer 와 reader 가 없다.

## 3. 읽는 사람이 없는 메트릭 노출

정반대 경우다. `masc_ws_delta_built_total` 은 `server_mcp_transport_ws.ml:693` 에서 **세션에 실제로 전달된 delta 마다** 증가한다 — 이 축에서 가장 뜨거운 경로다. 그런데 `transport_health_json` 에도, 테스트에도, 대시보드에도 없다. #23339 이후로 계속 올라갔고 아무도 볼 수 없었다.

삭제가 아니라 노출을 택했다. 이것만이 **전달된** delta 의 수이고, 나머지 둘과 다른 양이다:

| | 세는 것 |
|---|---|
| `delta_payload_serializations` | 만들어진 payload (세션 간 공유) |
| `delta_built` | 실제 전송 |
| `slice_fanout_skipped` | slice 게이트가 버린 전달 |

셋이 합쳐져야 fanout 이 설명된다.

리터럴이 아니라 **선언 상수로** 참조한다. `slice_fanout_skipped` 옆에 이미 적어둔 이유와 같다 — `metric_value_or_zero` 는 모르는 이름에 0 을 답하므로, 어긋난 리터럴은 에러가 아니라 **영구 0 필드**가 된다. #27285 가 제거한 parse-cache 카운터가 평생 0/0 을 보고한 방식이다.

테스트는 존재가 아니라 **전진**을 검사한다. 존재 검사는 0 을 통과시켜 틀린 이름에서도 초록이다. `_total` 접미를 떼어 그 assertion 만 실패하는 것을 확인했다.

## 검증

- `dune build @default` 통과, 에러 0
- `@test/runtest-test_transport_metrics` **26/26**
- `sse-event-type-parity.test.ts` **25/25**
- 두 가드 모두 비어 있지 않음을 실연으로 확인 (위 각 절)

## 안 담은 것 (같은 sweep, 처방이 안 정해짐)

**wire 포맷이라 지우면 프로토콜이 바뀌는 것** — `"protocol": "dashboard-ws.v1"` 을 서버가 4 곳에서 보내고 클라이언트도 hello 에 실어 보내는데 **양쪽 다 읽지 않는다**. 클라이언트가 `features: ['delta','mode_snapshot']` 를 보내지만 서버 코드에 `features` 문자열이 0 건이다. `capabilities` 블록도 같다. 아무것도 협상하지 않는 버전 핸드셰이크인데, 처방이 "장식 제거"인지 "핸드셰이크 완성"인지는 설계 판단이라 여기서 정하지 않는다.

**write-only 세션 필드** — `dashboard_last_ack_at` 은 매 ack 마다 쓰이고 읽는 곳은 테스트 1 건뿐이다. 형제인 `last_delta_at` / `last_delta_seq` / `last_ack_seq` 는 `session_is_backpressured` 가 실제로 읽는다. `dashboard_route` 도 저장되지만 유일한 독자가 클라이언트가 버리는 JSON 을 만든다. 둘 다 삭제 후보지만 backpressure 경로에 인접해 별도 확인이 필요하다.

**미완 배선** — `dashboard/unsubscribe` 는 RPC 가 완비돼 있는데 호출자가 0 이다. `slice_index` (slice → session 역인덱스) 는 subscribe/unsubscribe/cleanup 마다 유지되는데 독자가 테스트뿐이고, 정작 fanout 은 세션별 목록을 스캔한다. "지울지 실제로 쓸지"가 설계 판단이다.
