### PR TITLE
docs(mli): stop naming symbols that are not in the tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,6 +448,16 @@ jobs:
       - name: Check dashboard prompt keys
         run: bash scripts/audit-dashboard-prompt-keys.sh
 
+      # An odoc reference is not checked by the compiler, so a rename or a
+      # deletion leaves {!foo} syntactically valid and silently wrong. One sweep
+      # found nine: mcp_prompt_surface justified a concrete record with a
+      # function that module does not have, server_mcp_transport_ws named an
+      # absent read_inbound_message_frame three times as the reason ws_session
+      # is exposed, and three files wrote {!Foo.ml}, which reads as a value
+      # named ml inside Foo. Seconds, and the renaming PR sees it.
+      - name: Check odoc references
+        run: python3 scripts/audit-odoc-refs.py
+
       # Both directions of the hand-maintained CI test allowlist. A target
       # whose suite was deleted makes dune hard-fail after a full build
       # (#24352, and again today when config/prompts/behavior emptied), and a

--- a/lib/mcp_prompt_surface.mli
+++ b/lib/mcp_prompt_surface.mli
@@ -36,7 +36,11 @@ type prompt_def = {
   icons : Mcp_server.mcp_icon list;
 }
 (** Concrete record for the same reason as {!prompt_argument} —
-    {!Mcp_sdk_adapter_masc.sdk_prompt_of_local} reads every field.
+    {!prompt_json} in this module reads every field.
+
+    The doc this replaces named [Mcp_sdk_adapter_masc.sdk_prompt_of_local].
+    That module still exists and has no prompt function at all; the symbol is
+    absent from the tree.
 
     The [icons] field is non-optional and currently always populated
     with a single themed icon; the contract permits an empty list,

--- a/lib/operator/operator_judgment.mli
+++ b/lib/operator/operator_judgment.mli
@@ -6,8 +6,9 @@
     window, supersedes-chain, confidence, evidence refs, and
     optional recommended-action JSON.
 
-    Two read paths: {!latest_active} (typed record) and
-    {!latest_active_json} (JSON envelope).  One write path:
+    One read path, {!latest_active}, whose record serializes through
+    {!to_yojson}.  This said "two read paths" and named a
+    [latest_active_json] that is not in the tree.  One write path:
     {!record}, which auto-chains supersedes by reading the
     current latest before append. *)
 

--- a/lib/otel_metric_store/otel_metric_names.mli
+++ b/lib/otel_metric_store/otel_metric_names.mli
@@ -105,7 +105,7 @@ val metric_backend_mutex_held_sec : string
     surfaced so operators can alert on queue pressure without log
     parsing.  Labels: [keeper, channel]. *)
 
-(** #10125: supervisor sweep liveness counters.  See {!Otel_metric_store.ml}
+(** #10125: supervisor sweep liveness counters.  See [otel_metric_store.ml]
     for the rationale.  Counter increments on each Pulse start;
     gauge advances on every successful beat. *)
 

--- a/lib/server/server_mcp_transport_ws.mli
+++ b/lib/server/server_mcp_transport_ws.mli
@@ -4,13 +4,17 @@
     need full-duplex.
 
     External surface:
-    - {b session record} ({!ws_session}) — concrete because
+    - {b session record} ({!ws_session}) — concrete, though nothing outside
+      this module names it today. The justification this replaces said
       [server_ws_standalone] passes session values to
-      {!read_inbound_message_frame} /
-      {!send_dashboard_or_raw_sse} and reaches the live
-      {!sessions} table directly.
+      [read_inbound_message_frame] / {!send_dashboard_or_raw_sse} and reaches
+      the live {!sessions} table directly. That module uses exactly two symbols
+      from here, {!mcp_websocket_handler} and {!max_inbound_message_bytes},
+      and [read_inbound_message_frame] is absent from the tree.
     - {b inbound size decisions}
-      ({!inbound_size_rejection}, {!inbound_size_decision}).
+      ({!inbound_dispatch_rejection}, {!inbound_dispatch_admission}) --
+      renamed from inbound_size_rejection / inbound_size_decision, which this
+      line still named.
     - {b SSE parse record} ({!parsed_sse_event}) — exposed
       so the regression test at
       [test/test_transport_integration] can pattern-match
@@ -23,8 +27,7 @@
       {!session_count}, {!sessions}, {!with_sessions_rw},
       {!next_id}).
     - {b inbound framing}
-      ({!read_inbound_message_frame},
-      {!max_inbound_dispatches_per_session},
+      ({!max_inbound_dispatches_per_session},
       {!try_begin_inbound_dispatch},
       {!finish_inbound_dispatch}).
     - {b dashboard JSON-RPC handlers}
@@ -107,11 +110,9 @@ type ws_session = {
   dashboard_last_delta_at : float Atomic.t;
   inbound_dispatches : int Atomic.t;
 }
-(** Per-WS session state.  Concrete record because
-    [server_ws_standalone] threads the value through
-    {!read_inbound_message_frame} +
-    {!send_dashboard_or_raw_sse} and reaches the
-    {!sessions} table directly.  The dashboard handshake /
+(** Per-WS session state.  Concrete record; see the note on the external
+    surface at the top of this file for what that claim used to rest on and
+    what is actually true.  The dashboard handshake /
     ack state machine is tracked in the [dashboard_*] fields;
     see the [#10648] / dashboard-ws.v1 protocol notes in the
     .ml for the field semantics.

--- a/lib/tool_schemas/tool_schemas_misc.mli
+++ b/lib/tool_schemas/tool_schemas_misc.mli
@@ -46,9 +46,12 @@ val schemas : Masc_domain.tool_schema list
     Public-surface exclusion is enforced downstream by
     {!Tool_catalog.is_public_mcp} / [public_mcp_surface_tools], not by trimming
     the raw inventory. The schema [enum] fields derive from
-    {!dashboard_scope_enum_strings} /
     [Tool_schemas_specs_types.config_category_enum_strings] so
-    adding a value updates the schema automatically. *)
+    adding a value updates the schema automatically.
+
+    This also named [dashboard_scope_enum_strings], which is not in the tree;
+    [config_category_enum_strings] is the only [*_enum_strings] that module
+    exports. *)
 
 val mcp_runtime_tool_names : string list
 (** Exact names dispatched by [Mcp_tool_runtime]. *)

--- a/lib/workspace/workspace_gc.mli
+++ b/lib/workspace/workspace_gc.mli
@@ -1,6 +1,6 @@
 (** Workspace_gc — heartbeat and explicit garbage collection.
 
-    Public surface for {!Workspace_gc.ml}.  Extracted from [workspace.ml] for
+    Public surface for [workspace_gc.ml].  Extracted from [workspace.ml] for
     modularity (#4638).  See issue #10751 for the broader [workspace/]
     [.mli] coverage push.
 

--- a/lib/workspace/workspace_task_id.mli
+++ b/lib/workspace/workspace_task_id.mli
@@ -1,6 +1,6 @@
 (** Workspace_task_id — Task ID parsing and archive management.
 
-    Public surface for {!Workspace_task_id.ml}.  Encapsulates the lock-protected
+    Public surface for [workspace_task_id.ml].  Encapsulates the lock-protected
     archive read/merge/write sequence so callers cannot bypass it.
     See issue #10751 for the broader [workspace/] [.mli] coverage push. *)
 

--- a/scripts/audit-odoc-refs.py
+++ b/scripts/audit-odoc-refs.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Fail when an `.mli` doc names a symbol the tree does not define.
+
+An odoc reference `{!foo}` is not checked by the compiler. A rename or a
+deletion leaves it syntactically valid and silently wrong, and the doc keeps
+asserting something about code that is gone. Nine such references were found in
+one sweep (#27485):
+
+    mcp_prompt_surface.mli   justified a concrete record with
+                             "Mcp_sdk_adapter_masc.sdk_prompt_of_local reads
+                             every field" -- that module has no prompt function
+    server_mcp_transport_ws  named read_inbound_message_frame three times as the
+                             reason ws_session is exposed; absent, and the
+                             module it credited uses neither of the two symbols
+    operator_judgment.mli    "Two read paths" naming a latest_active_json that
+                             does not exist
+    tool_schemas_misc.mli    an enum derived from dashboard_scope_enum_strings,
+                             which does not exist
+    three .mli files         {!Foo.ml}, which reads as a value `ml` inside Foo
+
+What this checks is narrow on purpose: a lowercase final component, since a
+capitalised one is a module and module resolution has its own rules. The
+result is a name that either resolves to a value/type in this tree or does not.
+
+The known-symbol set is deliberately generous -- every `let`/`val`/`type`/
+`module`/`exception` binding, record fields, variant arms, ppx-derived
+`*_to_yojson` / `show_*` / `pp_*`, and test executable names -- because a false
+positive costs a person a lookup while a false negative is the drift this
+exists to catch. External modules are skipped by prefix for the same reason.
+
+Usage:
+    scripts/audit-odoc-refs.py            # report, exit 1 on any hit
+    scripts/audit-odoc-refs.py --list     # report, always exit 0
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Module prefixes that live outside lib/. A reference through one of these is
+# not checkable here and is not evidence of drift.
+EXTERNAL_MODULE_PREFIXES = frozenset(
+    {
+        "Agent_sdk",
+        "Alcotest",
+        "Array",
+        "Astring",
+        "Atomic",
+        "Bool",
+        "Buffer",
+        "Bytes",
+        "Char",
+        "Cmdliner",
+        "Cohttp",
+        "Digestif",
+        "Domain",
+        "Eio",
+        "Filename",
+        "Float",
+        "Format",
+        "Fun",
+        "H2",
+        "Hashtbl",
+        "Httpun",
+        "Int",
+        "Lazy",
+        "List",
+        "Llm_provider",
+        "Logs",
+        "Map",
+        "Mcp_protocol",
+        "Mirage_crypto",
+        "Mutex",
+        "Option",
+        "Printf",
+        "Ptime",
+        "Queue",
+        "Random",
+        "Re",
+        "Result",
+        "Scanf",
+        "Seq",
+        "Set",
+        "Stack",
+        "Stdlib",
+        "Str",
+        "String",
+        "Sys",
+        "Unix",
+        "Uri",
+        "Webrtc",
+        "Yojson",
+    }
+)
+
+BINDING_RE = re.compile(
+    r"^\s*(?:let|val|type|and|module|exception|external)\s+(?:rec\s+)?"
+    r"([A-Za-z_][A-Za-z0-9_']*)",
+    re.M,
+)
+RECORD_FIELD_RE = re.compile(r"^\s*([a-z_][A-Za-z0-9_']*)\s*:", re.M)
+VARIANT_ARM_RE = re.compile(r"^\s*\|\s*([A-Za-z_][A-Za-z0-9_']*)", re.M)
+TYPE_NAME_RE = re.compile(r"^\s*type\s+([a-z_][A-Za-z0-9_']*)", re.M)
+DOC_RE = re.compile(r"\(\*\*(.*?)\*\)", re.S)
+ODOC_REF_RE = re.compile(r"\{!([A-Za-z_][A-Za-z0-9_'.]*)\}")
+
+DERIVED_SUFFIXES = ("_to_yojson", "_of_yojson")
+DERIVED_PREFIXES = ("show_", "pp_", "equal_", "compare_")
+
+
+def source_files() -> list[Path]:
+    roots = [REPO_ROOT / "lib", REPO_ROOT / "test"]
+    files: list[Path] = []
+    for root in roots:
+        if not root.exists():
+            continue
+        for path in root.rglob("*"):
+            if path.suffix in (".ml", ".mli") and "_build" not in path.parts:
+                files.append(path)
+    return files
+
+
+def known_symbols(files: list[Path]) -> set[str]:
+    known: set[str] = set()
+    for path in files:
+        try:
+            text = path.read_text(errors="ignore")
+        except OSError:
+            continue
+        known |= set(BINDING_RE.findall(text))
+        known |= set(RECORD_FIELD_RE.findall(text))
+        known |= set(VARIANT_ARM_RE.findall(text))
+        for type_name in TYPE_NAME_RE.findall(text):
+            known |= {type_name + suffix for suffix in DERIVED_SUFFIXES}
+            known |= {prefix + type_name for prefix in DERIVED_PREFIXES}
+    # Test executables are referenced by name from library docs.
+    test_dir = REPO_ROOT / "test"
+    if test_dir.exists():
+        known |= {path.stem for path in test_dir.glob("*.ml")}
+    return known
+
+
+def absent_references(known: set[str]) -> list[tuple[Path, str]]:
+    hits: list[tuple[Path, str]] = []
+    lib = REPO_ROOT / "lib"
+    for path in sorted(lib.rglob("*.mli")):
+        if "_build" in path.parts:
+            continue
+        try:
+            text = path.read_text(errors="ignore")
+        except OSError:
+            continue
+        for doc in DOC_RE.findall(text):
+            for ref in ODOC_REF_RE.findall(doc):
+                parts = ref.split(".")
+                if parts[0] in EXTERNAL_MODULE_PREFIXES:
+                    continue
+                last = parts[-1]
+                if not last or not last[0].islower():
+                    continue
+                if last not in known:
+                    hits.append((path, ref))
+    return hits
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="Report and exit 0, for inspecting the current state.",
+    )
+    args = parser.parse_args()
+
+    files = source_files()
+    hits = absent_references(known_symbols(files))
+
+    if not hits:
+        print(f"[odoc-refs] OK - every {{!...}} in lib/**/*.mli resolves ({len(files)} files scanned)")
+        return 0
+
+    print(f"[odoc-refs] {len(hits)} reference(s) name a symbol this tree does not define:\n")
+    for path, ref in hits:
+        print(f"  {path.relative_to(REPO_ROOT)}: {{!{ref}}}")
+    print(
+        "\nEither the symbol was renamed or removed and the doc did not follow,"
+        "\nor it lives outside lib/ and its module prefix belongs in"
+        "\nEXTERNAL_MODULE_PREFIXES in this script."
+    )
+    return 0 if args.list else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Four odoc references to symbols that exist nowhere, found by comparing every
`{!...}` in `lib/**/*.mli` against what the tree defines.

## `mcp_prompt_surface.mli`

Justified `prompt_def` being a concrete record with:

> `{!Mcp_sdk_adapter_masc.sdk_prompt_of_local}` reads every field.

That module exists and has **no prompt function at all**. The reader that does
read every field is `prompt_json`, in the same module.

## `server_mcp_transport_ws.mli`

Named `read_inbound_message_frame` **three times**, including as the reason
`ws_session` is exposed as a concrete record:

> concrete because `server_ws_standalone` passes session values to
> `{!read_inbound_message_frame}` / `{!send_dashboard_or_raw_sse}` and reaches
> the live `{!sessions}` table directly.

The symbol is absent from the tree. And `server_ws_standalone` uses exactly two
symbols from this module — `mcp_websocket_handler` and
`max_inbound_message_bytes` — neither of them those.

```
rg 'Server_mcp_transport_ws.(ws_session|sessions|with_sessions_rw|new_session|cleanup_session)'
  → no match anywhere in lib/ or bin/
```

So the justification is false in every part. The doc now records what was
checked rather than inventing a replacement reason.

Same file listed `{!inbound_size_rejection}` / `{!inbound_size_decision}`. Those
were renamed to `inbound_dispatch_rejection` / `inbound_dispatch_admission` and
the doc did not follow.

## The audit is noisy

Of its 33 hits, most are legitimate external references — `Unix._exit`,
`Yojson.Safe.from_string`, `Eio.Fiber.yield`, `List.sort_uniq` — which are not
in `lib/` by definition. Record fields (`Sse.external_event.ext_payload`) and
ppx-derived names (`show_rate_limit_category`) need their own patterns and were
false positives. These four were confirmed by hand.

## Not changed

A session record and five lifecycle functions with no consumer outside their
module. That is the dead-export audit's job and deserves its own verification,
not a doc PR.

## Verification

```
dune build --root . @check                                        exit 0

test_mcp_h1_h2_admission_parity   20 tests run   Successful
test_transport_metrics            16 tests run   Successful
test_sse_stream                   26 tests run   Successful
```

Re-running the audit over both files, with record fields added to the known
set: **0 remaining absent references**.

RFC-WAIVED: documentation corrected to name symbols that exist.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>