### PR TITLE
docs(mli): 해석되지 않는 odoc 참조 4건 수정

### DIFF
--- a/lib/mcp_error_code.mli
+++ b/lib/mcp_error_code.mli
@@ -82,7 +82,7 @@ val to_http_status : t -> Httpun.Status.t
 val all : t list
 (** Enumerable list of every constructor, with a canonical exemplar for
     [Quiet] (reason = ["<exemplar>"], recovered = false). Used by
-    {!test/test_mcp_error_code.ml} to assert wire-code uniqueness. *)
+    [test/test_mcp_error_code.ml] to assert wire-code uniqueness. *)
 
 val jsonrpc_error_body : t -> message:string -> string
 (** [jsonrpc_error_body t ~message] returns a complete JSON-RPC 2.0 error

--- a/lib/otel_metric_store/otel_metric_names.mli
+++ b/lib/otel_metric_store/otel_metric_names.mli
@@ -105,7 +105,7 @@ val metric_backend_mutex_held_sec : string
     surfaced so operators can alert on queue pressure without log
     parsing.  Labels: [keeper, channel]. *)
 
-(** #10125: supervisor sweep liveness counters.  See {!Otel_metric_store.ml}
+(** #10125: supervisor sweep liveness counters.  See [otel_metric_store.ml]
     for the rationale.  Counter increments on each Pulse start;
     gauge advances on every successful beat. *)
 

--- a/lib/workspace/workspace_gc.mli
+++ b/lib/workspace/workspace_gc.mli
@@ -1,6 +1,6 @@
 (** Workspace_gc — heartbeat and explicit garbage collection.
 
-    Public surface for {!Workspace_gc.ml}.  Extracted from [workspace.ml] for
+    Public surface for [workspace_gc.ml].  Extracted from [workspace.ml] for
     modularity (#4638).  See issue #10751 for the broader [workspace/]
     [.mli] coverage push.
 
@@ -31,7 +31,7 @@ val heartbeat_message : heartbeat_outcome -> string
 
 (** Update the agent's [last_seen] timestamp on disk.
 
-    [agent_name] is resolved through {!Workspace_utils.resolve_agent_name}
+    [agent_name] is resolved through {!Workspace_identity.resolve_agent_name}
     so canonical/alias forms both work. The agent file is mutated under
     [with_file_lock]. *)
 val heartbeat :

--- a/lib/workspace/workspace_task_id.mli
+++ b/lib/workspace/workspace_task_id.mli
@@ -1,6 +1,6 @@
 (** Workspace_task_id — Task ID parsing and archive management.
 
-    Public surface for {!Workspace_task_id.ml}.  Encapsulates the lock-protected
+    Public surface for [workspace_task_id.ml].  Encapsulates the lock-protected
     archive read/merge/write sequence so callers cannot bypass it.
     See issue #10751 for the broader [workspace/] [.mli] coverage push. *)
 


### PR DESCRIPTION
## 변경

`lib/` 의 odoc 참조 중 해석될 수 없는 것 5건.

**파일 경로를 참조 문법으로 쓴 것 4건** — `ml` 은 값도 타입도 모듈도 아니라 어떤 스코프에서도 해석되지 않는다. 같은 파일들이 다른 자리에서는 이미 코드 스팬을 쓴다 (`[workspace.ml]`, `[.mli]`).

```
lib/workspace/workspace_gc.mli:3                 {!Workspace_gc.ml}
lib/workspace/workspace_task_id.mli:3            {!Workspace_task_id.ml}
lib/otel_metric_store/otel_metric_names.mli:108  {!Otel_metric_store.ml}
lib/mcp_error_code.mli:85                        {!test/test_mcp_error_code.ml}
```

**소유 모듈이 바뀐 것 1건.**

```
lib/workspace/workspace_gc.mli:34  {!Workspace_utils.resolve_agent_name}
                                 → {!Workspace_identity.resolve_agent_name}
```

`workspace_utils.mli` 에 그 이름이 없다. 실제 정의는 `workspace_identity.mli:10` 이고, `workspace_gc.ml` 이 두 모듈을 모두 `open` 해서 호출은 성립한다 — 코드는 멀쩡하고 문서만 옛 소유자를 가리킨 채 남았다.

## 측정

정본은 odoc 이다. `dune build @doc` 은 공유 캐시 때문에 경고를 재출력하지 않아 `DUNE_CACHE=disabled` 로 돌렸다.

```
                          이전    이후
Couldn't find "ml"          8      0
Failed to resolve (전체)  346    332
```

## 남은 332건은 이 PR 의 범위가 아니다

구성이 다르다.

```
Eio 18   Llm_provider 9   Agent_sdk 8   Unix 5     ← 외부 패키지
Otel_metric_store 15   Mcp_error_code 10   Sse 8   ← 저장소 내부, 라이브러리 경계 넘음
```

앞쪽은 부분 doc 빌드에서 외부 패키지 문서가 없어 생기는 것이라 참조 자체가 틀린 게 아니다. 뒤쪽은 참조하는 `.mli` 가 속한 라이브러리가 대상 라이브러리를 doc 의존으로 갖지 않아서인데, 고치려면 doc 의존 구조를 손대야 한다. 별개 판단이 필요해 건드리지 않았다.

## 정정

처음에는 `{!Module.value}` 를 export 목록과 대조하는 자체 스캔으로 22건을 셌다. 그 수치는 틀렸다 — 중첩 모듈(`validation.mli` 의 `module Agent_id`, `event_kind.mli` 의 `module Task`)을 파일 스템으로 잘못 귀속하고, 동명 파일(`lib/workspace.mli` vs `lib/multimodal/workspace.mli`)을 합쳤다. 이 PR 은 odoc 판정만 따른다.

## 검증

```
dune build --root . @check   → 0
check-doc-code-refs.sh       → OK
rg '\{![^}]*\.mli?\}' lib/   → 0건
```
