### PR TITLE
fix(eval): 하네스가 약속한 pass@k 추정량을 실제로 구현한다

### DIFF
--- a/lib/eval_harness.ml
+++ b/lib/eval_harness.ml
@@ -234,18 +234,36 @@ let check_tool_expectations expectations actual_calls =
 (* Score computation                                                 *)
 (* ================================================================ *)
 
-(** Compute pass@k: probability that at least one of k runs passes.
-    Formula: 1 - C(n-c, k) / C(n, k)
-    where n = total runs, c = passing runs, k = sample size.
+(** Compute pass@k: the chance that a [k]-run sample drawn from [n] recorded
+    runs, [c] of which passed, contains at least one pass.
 
-    Simplified: if all k runs available, pass@k = 1 - (1-p)^k
-    where p = c/n (empirical pass rate). *)
+    [1 - C(n-c, k) / C(n, k)] — the sample is drawn without replacement, so
+    the failing runs are chosen from a shrinking pool.
+
+    Evaluated as the running product [(n-c-i) / (n-i)] for [i] in [0, k), which
+    is the same ratio with no binomial materialised, so nothing overflows at
+    the run counts a suite produces.
+
+    [1 - (1 - c/n)^k] is the with-replacement reading and understates this:
+    it lets the same failing run be drawn [k] times. At n=5, c=1, k=3 it
+    reports 0.488 against a true 0.6, and at n=5, c=4, k=3 it reports 0.992
+    when the answer is exactly 1 — a single failing run cannot fill a 3-run
+    sample. *)
 let compute_pass_at_k ~(k : int) ~(n : int) ~(c : int) : float =
-  if n = 0 || k = 0 then 0.0
+  if n <= 0 || k <= 0 then 0.0
   else if c >= n then 1.0
   else
-    let p = float_of_int c /. float_of_int n in
-    1.0 -. (1.0 -. p) ** float_of_int (min k n)
+    let k = min k n in
+    let failing = n - c in
+    if failing < k then 1.0
+    else
+      let rec ratio i acc =
+        if i >= k then acc
+        else
+          ratio (i + 1)
+            (acc *. float_of_int (failing - i) /. float_of_int (n - i))
+      in
+      1.0 -. ratio 0 1.0
 
 (** Compute standard deviation of scores (consistency metric). *)
 let score_std_dev (scores : float list) : float =

--- a/lib/eval_harness.mli
+++ b/lib/eval_harness.mli
@@ -147,9 +147,13 @@ val check_tool_expectations_with_evidence :
 (** {1 Pass@k + summary} *)
 
 val compute_pass_at_k : k:int -> n:int -> c:int -> float
-(** Probability of at least one pass in [k] independent runs given
-    [c] successes out of [n] total. The unbiased estimator from the
-    agent-eval / METR literature. *)
+(** The chance that a [k]-run sample drawn from the [n] recorded runs, [c] of
+    which passed, contains at least one pass: [1 - C(n-c, k) / C(n, k)].
+
+    The draw is without replacement, so a single failing run cannot fill more
+    than one slot of the sample. That is what separates this from
+    [1 - (1 - c/n)^k], which reads the same counts with replacement and
+    therefore never reports more than this one does. *)
 
 val summarize_runs :
   scenario:scenario -> k:int -> eval_run list -> eval_result

--- a/test/test_eval_harness.ml
+++ b/test/test_eval_harness.ml
@@ -198,6 +198,28 @@ let test_pass_at_k_edge_zero_n () =
   let p = Eval_harness.compute_pass_at_k ~k:1 ~n:0 ~c:0 in
   Alcotest.(check (float 0.01)) "zero n" 0.0 p
 
+(* The four cases above all sit where the unbiased estimator
+   1 - C(n-c,k)/C(n,k) and the plug-in 1 - (1-c/n)^k agree: c >= n, c = 0,
+   k = 1, and n = 0. They cannot see which one is implemented. These pick
+   points where the two disagree, which is what the .mli promises. *)
+
+let test_pass_at_k_is_unbiased_not_plug_in () =
+  (* 1 - C(4,3)/C(5,3) = 1 - 4/10 = 0.6. The plug-in gives
+     1 - (1 - 1/5)^3 = 0.488. *)
+  let p = Eval_harness.compute_pass_at_k ~k:3 ~n:5 ~c:1 in
+  Alcotest.(check (float 0.001)) "n=5 c=1 k=3" 0.6 p
+
+let test_pass_at_k_unbiased_half_passing () =
+  (* 1 - C(5,2)/C(10,2) = 1 - 10/45 = 0.7778. Plug-in: 0.75. *)
+  let p = Eval_harness.compute_pass_at_k ~k:2 ~n:10 ~c:5 in
+  Alcotest.(check (float 0.001)) "n=10 c=5 k=2" 0.7778 p
+
+let test_pass_at_k_certain_when_failures_below_k () =
+  (* Only one of five runs failed, so every 3-run sample contains a pass:
+     C(1,3) = 0 and pass@3 is exactly 1. The plug-in reports 0.992. *)
+  let p = Eval_harness.compute_pass_at_k ~k:3 ~n:5 ~c:4 in
+  Alcotest.(check (float 0.001)) "n=5 c=4 k=3 is certain" 1.0 p
+
 (* ================================================================ *)
 (* Test: scenario_of_json parsing                                    *)
 (* ================================================================ *)
@@ -464,6 +486,12 @@ let () =
       Alcotest.test_case "none pass" `Quick test_pass_at_k_none_pass;
       Alcotest.test_case "some pass" `Quick test_pass_at_k_some_pass;
       Alcotest.test_case "edge zero n" `Quick test_pass_at_k_edge_zero_n;
+      Alcotest.test_case "unbiased, not plug-in" `Quick
+        test_pass_at_k_is_unbiased_not_plug_in;
+      Alcotest.test_case "unbiased with half passing" `Quick
+        test_pass_at_k_unbiased_half_passing;
+      Alcotest.test_case "certain when failures below k" `Quick
+        test_pass_at_k_certain_when_failures_below_k;
     ]);
     ("scenario_parsing", [
       Alcotest.test_case "minimal" `Quick test_parse_minimal_scenario;


### PR DESCRIPTION
평가 하네스가 **인터페이스가 약속한 추정량과 다른 것**을 계산하고 있었다. CLAUDE.md 가 하네스를 *"절대적으로 필수"* 라 부르는 그 자리다.

## 계약과 구현

`eval_harness.mli`:

> *"Probability of at least one pass in [k] independent runs given [c] successes out of [n] total. **The unbiased estimator** from the agent-eval / METR literature."*

`.ml` doc-comment 이 공식까지 적어놨다:

> `Formula: 1 - C(n-c, k) / C(n, k)`

그런데 본문은:

```ocaml
let p = float_of_int c /. float_of_int n in
1.0 -. (1.0 -. p) ** float_of_int (min k n)
```

**복원추출 판이다.** 같은 실패 런 하나가 k-런 표본의 모든 자리를 채울 수 있게 허용하므로, 비복원 추정량보다 결코 크지 않고 대개 작다.

## 실측 — 격자 전수

`n <= 40` 의 모든 `(n, c, k)` 조합:

```
unbiased < plug-in 인 격자점: 0건, 최대 차이 0.3632
```

**차이가 한 방향뿐이다.** 이게 이 변경이 할 수 있는 일의 범위를 한정한다.

| n | c | k | 약속된 값 | 구현이 주던 값 |
|---|---|---|---|---|
| 5 | 1 | 3 | **0.600** | 0.488 |
| 10 | 5 | 2 | **0.7778** | 0.750 |
| 5 | 4 | 3 | **1.000** | 0.992 |

마지막 줄이 의미를 드러낸다 — 5 런 중 **1 런만 실패**했으면 어떤 3-런 표본도 반드시 통과 런을 포함한다. 답은 정확히 1 이다. 복원추출 판은 0.992 를 준다.

## 무엇에 닿나

`pass_at_k` 는 시나리오 PASS/FAIL 배지를 먹인다 — `scenario_pass_at_k_threshold = 0.5` 컷이다.

**n=5, c=1, k=3 이 그 컷의 양쪽에 걸친다**: 0.600 은 PASS, 0.488 은 FAIL. 차이가 한 방향뿐이므로 배지는 **FAIL → PASS 로만** 움직이고 반대는 없다. `.mli` 는 이 배지가 display-only 이고 아무것도 분기하지 않는다고 적고 있다.

## 기존 테스트 4 개는 이걸 볼 수 없었다

```
~k:3 ~n:5 ~c:5   → c >= n
~k:3 ~n:5 ~c:0   → c = 0
~k:1 ~n:5 ~c:3   → k = 1
~k:1 ~n:0 ~c:0   → n = 0
```

**네 케이스 전부 두 추정량이 구조적으로 일치하는 지점이다.** 어느 구현이든 통과한다.

## 검증 — 수정 전에 먼저 실패시켰다

불일치 지점 테스트 3 개를 **수정 전 트리에서** 돌렸다:

```
RUN(수정 전)=1
> [FAIL]  pass_at_k  4  unbiased, not plug-in.
  [FAIL]  pass_at_k  5  unbiased with half passing.
  [FAIL]  pass_at_k  6  certain when failures below k.
```

3 개 실패, 기존 4 개는 통과 — **그게 기존 4 개가 눈이 멀었다는 증거다.** 수정 후 30/30.

| 항목 | 결과 |
|---|---|
| `dune build --root . @check` | exit 0 |
| `test_eval_harness` | 30/30 |
| `scripts/lint/*.sh` 전체 | exit 0 |
| `verify-test-registration.py` | exit 0 |
| `audit-ci-test-targets.sh` | exit 0 |
| `check-pr-hygiene.sh --base origin/main` | exit 0 |
| `audit-dead-surface.py --exports --ratchet` | at baseline |

## 구현 메모

이항계수를 만들지 않고 `i ∈ [0, k)` 에 대해 `(n-c-i)/(n-i)` 누적곱으로 계산한다 — 스위트가 만드는 런 수에서 팩토리얼 오버플로 근처에 가지 않는다. `failing < k` 는 1.0 으로 단락하며 이는 `C(n-c, k) = 0` 인 경우다.

`.mli` 문구는 *"agent-eval / METR literature"* 라는 확인 불가능한 출처 대신, 두 공식을 가르는 **비복원 성질**을 기술하도록 바꿨다. 계약을 코드와 대조할 수 있어야 계약이다.
