### PR TITLE
docs(mli): odoc 이 짝을 못 찾는 반쪽 이스케이프 괄호 93건

### DIFF
--- a/lib/graphql_api.mli
+++ b/lib/graphql_api.mli
@@ -14,19 +14,19 @@
 
     Pagination defaults: {!default_first} = 50, {!max_first} =
     200.  {!clamp_first} folds [None] -> default and clamps
-    [Some n] to [\[0, max_first]].
+    [Some n] to [\[0, max_first\]].
 
     Internal: ~25+ helpers + 5 internal types stay private —
-    \[ctx] (the per-request GraphQL execution context, carrying
-    [workspace_config]), \[page_info] / [\'a edge] / [\'a connection]
+    [ctx] (the per-request GraphQL execution context, carrying
+    [workspace_config]), [page_info] / [\'a edge] / [\'a connection]
     (internal Connection-spec records used by the schema
-    builders), \[task_status_info] type +
-    \[task_status_info_of_task] projector, the schema typ
+    builders), [task_status_info] type +
+    [task_status_info_of_task] projector, the schema typ
     definitions ([page_info_typ],
     [task_status_typ], [task_typ], [agent_meta_typ],
     [agent_typ], [message_typ], [workspace_state_typ],
     [task_edge_typ], [agent_edge_typ], etc.), and
-    \[drop_after_id] (cursor-based pagination cursor
+    [drop_after_id] (cursor-based pagination cursor
     consumption helper).  All consumed only inside the schema
     + {!handle_request}'s pipeline. *)
 
@@ -60,7 +60,7 @@ val default_first : int
 val clamp_first : int option -> int
 (** [clamp_first None] is {!default_first}.  [clamp_first
       (Some n)] is [max 0 (min n max_first)] — clamps to
-    [\[0, max_first]] including non-negative coercion. *)
+    [\[0, max_first\]] including non-negative coercion. *)
 
 (** {1 List slicer} *)
 

--- a/lib/http_server_eio.mli
+++ b/lib/http_server_eio.mli
@@ -12,7 +12,7 @@
     point (with signal handlers) lives in the executable
     [bin/main_eio.ml] (and sibling [bin/*_eio.ml] binaries).
 
-    Internal: \[safe_respond_with_string] stays private.
+    Internal: [safe_respond_with_string] stays private.
 
     @see <https://github.com/anmonteiro/httpun> httpun
     documentation *)

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -7,9 +7,9 @@
     ({!Keeper_meta_json}) and store I/O.
 
     Internal: ~3 helpers stay private —
-    \[blocker_class_of_serialized_string] (deserializer used
-    only by JSON parsing), \[map_compaction_rt] /
-    \[map_proactive_rt]
+    [blocker_class_of_serialized_string] (deserializer used
+    only by JSON parsing), [map_compaction_rt] /
+    [map_proactive_rt]
     (nested-record updaters that callers reach via the higher-level
     {!map_runtime} / {!map_usage}).  All consumed only via the runtime
     contract or the JSON pipeline. *)

--- a/lib/keeper_voice_local.mli
+++ b/lib/keeper_voice_local.mli
@@ -7,7 +7,7 @@
 
     Internal: 3 helpers stay private —
     \[resolved_base_path_opt\] / \[masc_base_dir\] (base-path
-    resolution chain), and the \[session_manager_ref] lazy
+    resolution chain), and the [session_manager_ref] lazy
     singleton cell.  All consumed only inside
     {!get_session_manager}.
 

--- a/lib/runtime_settings.mli
+++ b/lib/runtime_settings.mli
@@ -22,56 +22,56 @@
 (** {1 Keeper lifecycle} *)
 
 val keeper_supervisor_sweep_sec : float Runtime_params.param
-(** Supervisor sweep interval (seconds).  Range \[10.0, 120.0]. *)
+(** Supervisor sweep interval (seconds).  Range \[10.0, 120.0\]. *)
 
 val keeper_keepalive_interval_sec : int Runtime_params.param
 (** Heartbeat interval (seconds). Any positive value is accepted without an
     implicit upper bound. *)
 
 val keeper_dead_ttl_sec : float Runtime_params.param
-(** Dead-state retention (seconds).  Range \[60.0, 1 day]. *)
+(** Dead-state retention (seconds).  Range \[60.0, 1 day\]. *)
 
 (** {1 Keeper diagnostics} *)
 
 val keeper_snapshot_sec : int Runtime_params.param
-(** Snapshot capture interval (seconds).  Range \[15, 3600]. *)
+(** Snapshot capture interval (seconds).  Range \[15, 3600\]. *)
 
 val keeper_work_as_hb_enabled : bool Runtime_params.param
 (** Enable work-as-heartbeat fallback. *)
 
 val keeper_work_as_hb_max_silence_sec : float Runtime_params.param
 (** Maximum silence allowed in work-as-heartbeat mode (seconds).
-    Range \[10.0, 600.0]. *)
+    Range \[10.0, 600.0\]. *)
 
 val keeper_stage_timing_ring_size : int Runtime_params.param
 (** Stage-timing ring buffer size.  Applied on fiber restart only —
-    runtime mutation requires keeper restart.  Range \[10, 1000]. *)
+    runtime mutation requires keeper restart.  Range \[10, 1000\]. *)
 
 (** {1 Dashboard rendering} *)
 
 val dashboard_max_path_length : int Runtime_params.param
-(** Path truncation cap (chars).  Range \[10, 200].  Default 30. *)
+(** Path truncation cap (chars).  Range \[10, 200\].  Default 30. *)
 
 val dashboard_max_message_length : int Runtime_params.param
-(** Message-body truncation cap (chars).  Range \[10, 500].
+(** Message-body truncation cap (chars).  Range \[10, 500\].
     Default 35. *)
 
 val dashboard_max_pending_tasks : int Runtime_params.param
-(** Pending-task display cap.  Range \[1, 50].  Default 5. *)
+(** Pending-task display cap.  Range \[1, 50\].  Default 5. *)
 
 val dashboard_max_recent_messages : int Runtime_params.param
-(** Recent-message display cap.  Range \[1, 50].  Default 5. *)
+(** Recent-message display cap.  Range \[1, 50\].  Default 5. *)
 
 val dashboard_min_border_length : int Runtime_params.param
-(** Section-border minimum length.  Range \[20, 200].  Default 45. *)
+(** Section-border minimum length.  Range \[20, 200\].  Default 45. *)
 
 val dashboard_agent_quiet_threshold_sec : float Runtime_params.param
 (** Quiet-agent-warning threshold (seconds).
-    Range \[30.0, 1 day]. *)
+    Range \[30.0, 1 day\]. *)
 
 val dashboard_agent_stuck_threshold_sec : float Runtime_params.param
 (** Stuck-agent-warning threshold (seconds).
-    Range \[60.0, 7 days]. *)
+    Range \[60.0, 7 days\]. *)
 
 (** {1 Surface catalog} *)
 

--- a/lib/tool_agent_timeline.mli
+++ b/lib/tool_agent_timeline.mli
@@ -11,7 +11,7 @@
     cardinality counts + token/cost rollups.
 
     Internal: 11 helpers + 1 type stay private —
-    \[parse_iso_timestamp] (shared RFC 3339 codec adapter),
+    [parse_iso_timestamp] (shared RFC 3339 codec adapter),
     [timeline_event] type + [event_to_json], the 5 source
     extractors ([agent_events], [task_events], [message_events],
     [tool_call_events],

--- a/lib/tool_library.mli
+++ b/lib/tool_library.mli
@@ -19,9 +19,9 @@
     no [library_source_ssot] test; the compile errors are the whole
     guard.
 
-    Internal: \[all_sources], the \[frontmatter] type +
-    \[parse_frontmatter] + \[list_documents], and \[handle_list] /
-    \[handle_add] (reachable via {!dispatch}).  All consumed only
+    Internal: [all_sources], the [frontmatter] type +
+    [parse_frontmatter] + [list_documents], and [handle_list] /
+    [handle_add] (reachable via {!dispatch}).  All consumed only
     inside the dispatch handlers or {!schemas}. *)
 
 (** {1 Library source SSOT} *)

--- a/lib/tool_local_runtime_probe.mli
+++ b/lib/tool_local_runtime_probe.mli
@@ -13,16 +13,16 @@
     mirror the runtime — those helpers are implementation
     detail; probe is the contract layer.
 
-    Internal: ~22 helpers stay private — \[bool_opt_to_json] /
-    \[clamp] / \[trim_to_option] / \[ns_to_ms] / \[tok_per_second] /
-    \[collapse_preview] / \[truncate_text] /
-    \[generate_probe_skip_reason_to_string] / \[string_or_fallback] /
-    \[loaded_model_name] / \[ollama_loaded_model_to_yojson] /
-    \[ollama_probe_run_to_yojson] / \[default_probe_prompt] /
-    \[fetch_ollama_ps] / \[select_effective_model] /
-    \[failed_probe_run] / \[run_single_probe] /
-    \[prompt_eval_duration_ms_of_run_json] /
-    \[generate_probe_skip_reason] type + the
+    Internal: ~22 helpers stay private — [bool_opt_to_json] /
+    [clamp] / [trim_to_option] / [ns_to_ms] / [tok_per_second] /
+    [collapse_preview] / [truncate_text] /
+    [generate_probe_skip_reason_to_string] / [string_or_fallback] /
+    [loaded_model_name] / [ollama_loaded_model_to_yojson] /
+    [ollama_probe_run_to_yojson] / [default_probe_prompt] /
+    [fetch_ollama_ps] / [select_effective_model] /
+    [failed_probe_run] / [run_single_probe] /
+    [prompt_eval_duration_ms_of_run_json] /
+    [generate_probe_skip_reason] type + the
     [include Tool_local_runtime_http] runtime.  All consumed
     only inside {!runtime_ollama_probe_json}'s pipeline. *)
 
@@ -240,10 +240,10 @@ val runtime_ollama_probe_json :
   unit ->
   Yojson.Safe.t
 (** Top-level probe orchestrator.  Defaults: [probe_runs=2]
-    (clamped to [\[1, 4]]), [max_tokens=16] (clamped to
-    [\[1, 128]]), [think_mode=Think_auto], [timeout_sec=6]
+    (clamped to [\[1, 4\]]), [max_tokens=16] (clamped to
+    [\[1, 128\]]), [think_mode=Think_auto], [timeout_sec=6]
     (every positive explicit value is preserved; non-positive values raise
-    [Invalid_argument]), [ps_timeout_sec=2] (clamped to [\[1, 30]]),
+    [Invalid_argument]), [ps_timeout_sec=2] (clamped to [\[1, 30\]]),
     [generate_when_unloaded=true], [run_generate=true].
     Returns a JSON snapshot with [/api/ps] state + per-run timing +
     KV-cache assessment.  Per PR #20479 spirit: the tool itself

--- a/lib/tool_misc_web_search.mli
+++ b/lib/tool_misc_web_search.mli
@@ -7,25 +7,25 @@
     response caching.
 
     Internal: ~50+ helpers + 5 internal types stay private —
-    \[normalized_hit] / \[provider] (7-variant) /
-    \[provider_response] / \[cache_entry] (cache + provider data
+    [normalized_hit] / [provider] (7-variant) /
+    [provider_response] / [cache_entry] (cache + provider data
     types kept internal so callers cannot construct half-formed
     state),
     the pre-compiled whitespace normalizer,
-    text cleaning helpers (\[normalize_spaces],
-    \[clean_search_text], \[trim_nonempty]),
-    \[valid_search_result_url],
-    \[parse_json_search_results] (the generic JSON parser
-    behind the per-provider parsers), \[provider_to_string] /
-    \[provider_of_string] / \[parse_provider_csv] /
-    \[default_provider_order] / \[provider_order],
-    \[take_results], \[normalize_hits], \[provider_error],
-    \[result_data], all 7 \[fetch_*] HTTP fetchers,
-    \[fetch_provider], the cache state cells
-    (\[initial_cache_capacity = 32], \[cache_entries] hashtable,
-    \[cache_mutex]),
-    \[cache_key], \[cache_lookup], \[cache_store],
-    and \[search_impl].  All consumed
+    text cleaning helpers ([normalize_spaces],
+    [clean_search_text], [trim_nonempty]),
+    [valid_search_result_url],
+    [parse_json_search_results] (the generic JSON parser
+    behind the per-provider parsers), [provider_to_string] /
+    [provider_of_string] / [parse_provider_csv] /
+    [default_provider_order] / [provider_order],
+    [take_results], [normalize_hits], [provider_error],
+    [result_data], all 7 \[fetch_*\] HTTP fetchers,
+    [fetch_provider], the cache state cells
+    (\[initial_cache_capacity = 32\], [cache_entries] hashtable,
+    [cache_mutex]),
+    [cache_key], [cache_lookup], [cache_store],
+    and [search_impl].  All consumed
     only inside {!handle} / {!simulate_for_test} pipelines. *)
 
 (** {1 Simulation outcome (test-only)} *)

--- a/lib/tool_workspace.mli
+++ b/lib/tool_workspace.mli
@@ -12,11 +12,11 @@
     Callers can interleave these types freely with the source
     modules' types.
 
-    Internal: ~50+ helpers stay private — \[effective_cluster_name],
-    \[unique_trimmed_nonblank], \[credential_state],
-    \[safe_resolve_agent_name] / \[safe_current_task] / \[safe_get_agents],
-    \[resolve_current_binding], \[planning_context_state],
-    \[assertion_kind_to_string], \[all_assertion_kinds], plus per-tool handlers
+    Internal: ~50+ helpers stay private — [effective_cluster_name],
+    [unique_trimmed_nonblank], [credential_state],
+    [safe_resolve_agent_name] / [safe_current_task] / [safe_get_agents],
+    [resolve_current_binding], [planning_context_state],
+    [assertion_kind_to_string], [all_assertion_kinds], plus per-tool handlers
     ([handle_status], [handle_init],
     [handle_check], [handle_assertion]).
     All consumed only inside {!dispatch}'s pipeline. *)

--- a/lib/transport_metrics.mli
+++ b/lib/transport_metrics.mli
@@ -8,9 +8,9 @@
     - [masc_ws_*] for WebSocket transport
     - [masc_agent_heartbeat_*] for agent liveness
 
-    Internal: 35 helpers stay private — \[sse_hot_sessions]
+    Internal: 35 helpers stay private — [sse_hot_sessions]
     (Atomic.t state cell mutated by {!set_sse_queue_snapshot}),
-    \[grpc_runtime_listening] / \[ws_runtime_listening] (bool
+    [grpc_runtime_listening] / [ws_runtime_listening] (bool
     Atomic.t cells mutated by the [set_*_runtime_listening]
     functions), [grpc_enabled] /
     [grpc_port] / [ws_port] (env-derived), [set_agent_heartbeat_age]


### PR DESCRIPTION
## 문제

`.mli` 독스트링에서 여는 괄호만 이스케이프한 자리가 93곳이다.

```ocaml
(* tool_misc_web_search.mli:10 *)
Internal: ~50+ helpers + 5 internal types stay private —
\[normalized_hit] / \[provider] (7-variant) /
```

odoc 은 `\[` 를 리터럴 `[` 로 읽으므로 코드 스팬이 열리지 않고, 뒤의 `]` 가 짝을 잃는다.

```
File "lib/tool_misc_web_search.mli", line 10, characters 20-21:
Warning: Unpaired ']' (end of code).
```

93건이 11개 파일에 몰려 있다 (`tool_misc_web_search` 27, `tool_local_runtime_probe` 22, `runtime_settings` 12, `tool_workspace` 10 …).

## 의도가 두 가지라 각각 다르게 고쳤다

**식별자 74건** — OCaml 타입·함수 이름이다. 저장소가 이럴 때 쓰는 형태는 코드 스팬이다 (`[Quiet]`, `[workspace.ml]`).

```
\[normalized_hit]  →  [normalized_hit]
```

**수치 구간 19건** — `\[1, 50]`, `\[0, max_first]` 처럼 닫힌 구간 표기다. 리터럴 괄호가 목적이므로 닫는 쪽도 이스케이프한다.

```
clamped to [\[1, 10]]  →  clamped to [\[1, 10\]]
```

코드 스팬 안의 `\]` 는 odoc 이 리터럴 `]` 로 렌더한다.

## 측정

정본은 odoc 이다. `dune build @doc` 이 공유 캐시에서 경고를 재출력하지 않아 `DUNE_CACHE=disabled` 로 돌렸다.

```
                       이전   이후
Unpaired ']'            93     0
전체 odoc 경고         573    480
```

이미 짝이 맞던 `\[x\]` 151건은 그대로다 (정규식이 내용에 `\` 가 있으면 매치하지 않는다). 최종 170건 = 151 + 신규 19.

## 검증

```
dune build --root . @check   → 0
불균형 \[x] 잔여              → 0
```

발견 경위: #27486 에서 odoc 을 판정자로 세운 뒤, 같은 로그의 다른 경고 계열을 확인.
