### PR TITLE
chore(harness): evaluator 상태를 정하던 이름 없는 0.8 과 사실을 주장하던 wildcard

### DIFF
--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -68,6 +68,14 @@ let max_signal_scan = 500
 let runtime_stale_after_s = 30. *. 60.
 let evaluator_stale_after_s = 12. *. Masc_time_constants.hour
 
+(* Fraction of an evaluator's verdicts that came back Invalid_verdict or
+   Evaluator_unavailable before the rail stops reading Healthy. The two
+   thresholds above are named, this one was a bare 0.8 at its comparison, so
+   the number nobody had to look at was the one that decides whether four
+   failures in five still read as fine. Named here so changing it is a
+   reviewed edit. *)
+let evaluator_fallback_warning_ratio = 0.8
+
 let pre_compact_store_ref : Dated_jsonl.t option Atomic.t = Atomic.make None
 let pre_compact_store_mu = Eio.Mutex.create ()
 
@@ -650,7 +658,9 @@ let evaluator_status ~calibration latest_timestamp =
       let fallback_ratio =
         float_of_int fallback_count /. float_of_int (max 1 total_verdicts)
       in
-      if fallback_ratio > 0.8 then Warning else Healthy)
+      if fallback_ratio > evaluator_fallback_warning_ratio
+      then Warning
+      else Healthy)
 ;;
 
 let latest_timestamp_of_verdicts (verdicts : harness_verdict_item list) =

--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -563,10 +563,20 @@ let calibration_stats ?(since = "") ?(until = "") () : Yojson.Safe.t =
       | Some hv ->
           if label_verdict_of_verdict ev = hv then
             (fp, fn, ag + 1)
-          else
+          else (
+            (* Every disagreement pair is written out. The wildcard this
+               replaces asserted "false negative" for anything that was not
+               (Approve, Reject_label); a third label_verdict would have been
+               counted as a false negative and quietly lowered
+               agreement_rate. Listing the pairs makes the compiler ask
+               instead. *)
             match ev, hv with
             | Task.Anti_rationalization.Approve, Reject_label -> (fp + 1, fn, ag)
-            | _ -> (fp, fn + 1, ag)
+            | Task.Anti_rationalization.Reject _, Approve_label -> (fp, fn + 1, ag)
+            | Task.Anti_rationalization.Approve, Approve_label
+            | Task.Anti_rationalization.Reject _, Reject_label ->
+                (* [label_verdict_of_verdict ev = hv] already returned above. *)
+                (fp, fn, ag + 1))
     ) verdict_hashes (0, 0, 0)
   in
   let labeled_total = false_pos + false_neg + agree in


### PR DESCRIPTION
eval 서브시스템의 **배선된** 절반을 훑었다. `eval_harness` 는 프로덕션 호출자가 없지만(#27488), `Eval_calibration` 과 `Dashboard_harness_health` 는 소비자가 셋이다 — `dashboard_http_keeper_outcomes`, `server_routes_http_routes_dashboard`, `keeper_wake_telemetry`.

규칙 위반 둘을 고쳤다. **동작은 바뀌지 않는다.**

## 1. 이름 없는 임계값이 상태를 정하고 있었다

```ocaml
if fallback_ratio > 0.8 then Warning else Healthy
```

`fallback_ratio` 는 `Invalid_verdict` 또는 `Evaluator_unavailable` 로 돌아온 verdict 의 비율이다. 즉 **다섯 중 넷이 실패해도 Healthy 로 읽힌다.**

그게 의도일 수는 있다. 문제는 그 숫자가 비교식에 파묻혀 있었다는 것이다 — 같은 파일 상단의 `runtime_stale_after_s` 와 `evaluator_stale_after_s` 는 이름이 붙어 있다. **아무도 볼 필요가 없던 숫자가 하필 "네 번 실패해도 괜찮은가" 를 정하는 숫자였다.**

`evaluator_fallback_warning_ratio` 로 올렸다. 값은 그대로 0.8 이고, 이제 바꾸려면 리뷰되는 편집이 된다.

## 2. 불일치 집계의 wildcard 가 사실을 주장하고 있었다

```ocaml
| Approve, Reject_label -> (fp + 1, fn, ag)
| _ -> (fp, fn + 1, ag)
```

`_` 는 자기가 잡는 모든 쌍에 대해 **"false negative 다"** 라고 주장한다. 오늘의 `label_verdict` 2 변형에서는 맞다 — 남은 불일치는 `(Reject _, Approve_label)` 뿐이다. **live bug 가 아니라 CLAUDE.md 안티패턴 #4 (FSM Sparse Match)** 다: 세 번째 변형이 생기면 false negative 로 집계되어 `agreement_rate` 를 조용히 떨어뜨린다.

### 가드가 실제로 잡는지 증명했다

세 번째 변형을 임시로 넣고 빌드했다:

```
Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
  Here is an example of a case that is not matched: (Approve, Abstain_label)
```

**예전 `_` 가 삼키던 바로 그 쌍**을 컴파일러가 지목한다. 프로브는 되돌렸다.

## 확인했지만 일부러 건드리지 않은 것

다음 사람이 다시 파지 않도록 적어둔다.

- **`Safe_ops.json_int ~default:0 "total_verdicts"`** — 직전 dashboard 변경(#27483)에서 고친 fail-open 기본값과 같은 모양이라 의심했는데, **도달 불가**다. 유일한 호출자가 `Eval_calibration.calibration_stats` 를 넘기고 그 함수는 이 필드를 항상 방출한다.
- **`verdict_to_string` / `verdict_of_string`** — `Reject` 페이로드를 `"reject:<reason>"` 로 왕복시킨다. **무손실이다** — 파서가 `':'` 로 재결합하므로 콜론이 든 이유도 보존된다.
- **`rail_status` 에 `Unknown` 변형이 없다** — 캘리브레이션을 못 읽으면 `Healthy`/`Warning`/`Stale`/`Idle` 중 하나로 읽힐 수밖에 없다. 위 기본값이 도달 불가인 동안은 무의미하고, 변형 추가는 이 변경보다 넓은 판단이다.

## 검증

| 항목 | 결과 |
|---|---|
| `dune build --root . @check` | exit 0 |
| `test_eval_calibration` | exit 0 |
| `test_dashboard_harness_health` | exit 0 |
| `scripts/lint/*.sh` 전체 | exit 0 |
| `verify-test-registration.py` | exit 0 |
| `audit-ci-test-targets.sh` | exit 0 |
| `check-pr-hygiene.sh --base origin/main` | exit 0 |
