### PR TITLE
docs(mli): mention 문법 설명이 odoc 태그로 삼켜지던 것 수정

### DIFF
--- a/lib/dashboard/dashboard_workspace.mli
+++ b/lib/dashboard/dashboard_workspace.mli
@@ -2,6 +2,6 @@ val json : config:Workspace.config -> ?me:string -> limit:int -> unit -> Yojson.
 
 val mentions_of_message : Masc_domain.message -> string list
 (** Every agent name this message mentions: the typed [mention] field first,
-    then @word tokens parsed from the body, deduplicated in order. The one
+    then [@word] tokens parsed from the body, deduplicated in order. The one
     mention extractor for dashboard read models — consumers must not grow
     their own content scanners (#27324). *)

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -23,7 +23,7 @@ val process_directive : agent_name:string -> Keeper_directive.t -> unit
 val current_task_id_for_agent : config:Workspace.config -> string -> string
 
 (** Wake up a specific keeper immediately. Used by broadcast notification
-    when a @mention targets a running keeper.
+    when a [@mention] targets a running keeper.
 
     [?stimulus] appends the payload to the keeper's Event Layer queue
     before flipping the wakeup flag. See RFC-0020 §3. *)

--- a/lib/mention_inbox.mli
+++ b/lib/mention_inbox.mli
@@ -1,6 +1,6 @@
 (** Mention_inbox — JSONL-based persistent mention inbox
 
-    Stores @mention events in `.masc/mention_inbox.jsonl`.
+    Stores [@mention] events in `.masc/mention_inbox.jsonl`.
     Each mention is an append-only record with read/unread tracking.
 
     @since Phase 3A — Keeper Deliberation Engine

--- a/lib/workspace/mention.mli
+++ b/lib/workspace/mention.mli
@@ -2,9 +2,9 @@
 
 (** Mention routing mode *)
 type mode =
-  | Stateless of string       (** @agent → pick one available *)
-  | Stateful of string        (** @agent-adj-animal → specific agent *)
-  | Broadcast of string       (** @@agent → all of type *)
+  | Stateless of string       (** [@agent] → pick one available *)
+  | Stateful of string        (** [@agent-adj-animal] → specific agent *)
+  | Broadcast of string       (** [@@agent] → all of type *)
   | None                      (** No mention found *)
 
 val mode_to_string : mode -> string
@@ -18,12 +18,12 @@ val is_nickname : string -> bool
 (** Check if mention follows nickname pattern (agent-adj-animal) *)
 
 val parse : string -> mode
-(** Parse @mention from message content
+(** Parse [@mention] from message content
 
     Priority:
-    1. @@agent → Broadcast
-    2. @agent-adj-animal → Stateful
-    3. @agent → Stateless
+    1. [@@agent] → Broadcast
+    2. [@agent-adj-animal] → Stateful
+    3. [@agent] → Stateless
 *)
 
 val extract : string -> string option


### PR DESCRIPTION
## 문제

`.mli` 프로즈에 쓴 `@agent` / `@mention` / `@word` 를 odoc 이 **태그로 파싱해 삼킨다.** odoc 은 독스트링에서 `@단어` 를 태그 문법으로 읽는다.

가장 크게 드러나는 곳이 mention 모듈이다.

```ocaml
type mode =
  | Stateless of string       (** @agent → pick one available *)
  | Stateful of string        (** @agent-adj-animal → specific agent *)
  | Broadcast of string       (** @@agent → all of type *)
```

세 생성자의 설명이 렌더 문서에서 사라진다 — 이 모듈이 문서화하는 대상이 정확히 **mention 문법**인데, 그 설명이 문법 때문에 지워진다. `parse` 의 우선순위 목록(`1. @@agent → Broadcast` …)도 같다.

## 변경

프로즈의 `@` 토큰을 코드 스팬으로 감쌌다. 문법 표기이므로 코드 스팬이 의미상으로도 맞다.

```
lib/workspace/mention.mli          7곳  (@agent / @@agent / @agent-adj-animal / @mention)
lib/mention_inbox.mli:3            1곳  Stores [@mention] events
lib/keeper/keeper_keepalive.mli:26 1곳  when a [@mention] targets
lib/dashboard/dashboard_workspace.mli:5  1곳  then [@word] tokens parsed
```

## 측정

```
                       이전   이후
Unknown tag '@agent'     6      0
Unknown tag '@mention'   3      0
Unknown tag '@word'      1      0
```

## 건드리지 않은 것

`@stability` 16건과 `@modified` 1건은 남겼다. 이쪽은 오파싱이 아니라 **의도한 커스텀 태그**로 보인다 (`@stability Evolving` / `@stability Internal`).

다만 이것도 확인해 둘 만하다 — odoc 은 미지 태그를 렌더에서 버리고, `scripts/`·`.github/`·`docs/`·`bin/` 어디에도 `@stability` 를 읽는 코드가 없다. 즉 소스 텍스트로만 존재한다. 관례를 유지할지, 읽는 쪽을 만들지, 접을지는 별개 판단이라 이 PR 에서 정하지 않았다.

## 검증

```
dune build --root . @check   → 0
odoc (DUNE_CACHE=disabled)   → @agent/@mention/@word 경고 0
```

발견 경위: #27486, #27489 에 이어 같은 odoc 로그의 태그 경고 계열 확인. 경고 위치는 `File ...:` 다음 줄이 `Warning:` 인 인접 쌍으로 뽑았다 — `rg -B3` 창으로 묶으면 다른 경고의 File 줄을 끌어와 `ide_paths.mli` 를 오귀속한다.
