### PR TITLE
fix(task): next actions are the ones that move the Task

### DIFF
--- a/lib/workspace/workspace_task_lifecycle.ml
+++ b/lib/workspace/workspace_task_lifecycle.ml
@@ -265,7 +265,17 @@ let valid_next_actions ~same_agent ~task_status =
         ~notes:"preview"
         ~reason:"preview"
     with
-    | Ok _ -> true
+    (* An action the FSM admits but that leaves the status where it is -- Claim
+       on a Task you already hold, Start on one already started, Release on a
+       Todo, Cancel on a Cancelled one -- is not a next action. It is accepted
+       so a repeat is idempotent rather than an error, which is a different
+       question from "what can you do from here".
+
+       Listing them told a Keeper that a Done Task's next actions were
+       [claim;start;done], all three of which return it unchanged. The Goal
+       surface answers the same question the same way as of #27464: its
+       available-actions list carries [Move_to] and drops [Already]. *)
+    | Ok { new_status; _ } -> new_status <> task_status
     | Error _ -> false
   in
   List.filter try_action Masc_domain.all_task_actions

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -2353,8 +2353,10 @@ let () = test "transition_submit_for_verification_todo_rejects_instead_of_alias"
          (Tool_result.message result)
          "Invalid transition: todo -> submit_for_verification");
     (* Order follows [Masc_domain.all_task_actions], which the hint is now
-       derived from, rather than the hand-written order it used to restate. *)
-    assert (str_contains (Tool_result.message result) "valid_next_actions=[claim;cancel;release]");
+       derived from, rather than the hand-written order it used to restate.
+       [release] left this list: it is admitted from Todo and returns it
+       unchanged, and the hint lists what moves the Task. *)
+    assert (str_contains (Tool_result.message result) "valid_next_actions=[claim;cancel]");
     assert_task_todo ctx)
 )
 

--- a/test/test_tool_workspace_coverage.ml
+++ b/test/test_tool_workspace_coverage.ml
@@ -971,11 +971,13 @@ let () =
 let next_hint = Workspace_task.next_actions_hint
 
 let () =
-  test "next_hint_todo lists claim, release, and cancel" (fun () ->
+  test "next_hint_todo lists claim and cancel, not release" (fun () ->
     let h = next_hint Masc_domain.Todo in
     assert (str_contains h "claim");
-    assert (str_contains h "release");
     assert (str_contains h "cancel");
+    (* Release on a Todo is admitted and returns it unchanged -- there is
+       nothing held to hand back. The hint lists what moves the Task. *)
+    assert (not (str_contains h "release"));
     assert (str_contains h "valid_next_actions="))
 ;;
 


### PR DESCRIPTION
Answers the design question left open in #27426.

## What

`valid_next_actions` accepted any action the FSM admits, including the arms
that return the status unchanged:

```
Done       valid_next_actions=[claim;start;done]   all three return it Done
Cancelled  valid_next_actions=[cancel]             returns it Cancelled
InProgress …;claim;…                               returns it InProgress
Todo       …;release                               returns it Todo
```

Those arms exist so a repeat is idempotent rather than an error. That is a
different question from "what can you do from here", and the hint is rendered
to a Keeper that **just failed a transition** — so it is exactly the from-here
question.

```ocaml
| Ok { new_status; _ } -> new_status <> task_status
```

The Goal surface already answers it this way, as of #27464: its
available-actions list carries `Move_to` and drops `Already`.

## Release leaves Todo

`Release, Todo -> ok task_status`. There is nothing held to hand back, so it
does not move the Task. Two assertions pinned the old list and are updated with
that reason — one of them CI-wired (`test_tool_task_coverage`).

## #27426

That issue reported five failures in `test_tool_workspace_coverage`, four of
them stale assertions about this hint:

```
before  5 failures
after   1 failure
```

The one left is the harness problem it also names —
`dispatch_status_initializes_before_review` raises `MASC not initialized` — and
is untouched here. The suite is still not in `ci.yml`; wiring it is a separate
decision now that its assertions are true.

## Tests

Mutation-checked. Accepting no-ops again:

```
[FAIL] next_hint_todo lists claim and cancel, not release
[FAIL] next_hint_in_progress lists submit and release
[FAIL] next_hint_done is empty (terminal)
[FAIL] next_hint_cancelled is empty (terminal)
```

## Verification

```
dune build --root . @check                                        exit 0
dune build --root . @fmt            no diff in any file this PR touches

test_tool_task_coverage           98 tests run   Successful
test_tool_workspace_coverage      37 tests run   1 pre-existing failure
test_workspace_task_lifecycle           all tests passed
test_task_status_vocabulary        4 tests run   Successful
test_goal_scope_terminal_phase     7 tests run   Successful
test_keeper_wake_turn_context      5 tests run   Successful
test_enum_mirror_sync             17 tests run   Successful
```

No behaviour change to what the FSM admits — only to what the hint advertises.

RFC-WAIVED: a hint narrowed to the actions that change the status it describes.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>