### PR TITLE
fix(masc_check): 읽지 못한 검증 항목을 조용히 버리고 all_passed 를 보고하던 문제

### DIFF
--- a/lib/workspace_assertions.ml
+++ b/lib/workspace_assertions.ml
@@ -38,6 +38,12 @@ let all_assertion_kinds = [ Task_claimed; Current_task_set ]
 
 let valid_assertion_strings = List.map assertion_kind_to_string all_assertion_kinds
 
+(* Stands in for an [assertions] element that was not a JSON string. It is
+   deliberately not a valid assertion name, so [check_assertion] reports it
+   with [passed = false] and [expected_assertions] instead of the caller
+   losing the element silently. *)
+let unreadable_assertion = "<non-string assertion>"
+
 let assertion_kind_of_string_lenient = function
   | "task_claimed" -> Some Task_claimed
   | "current_task_set" -> Some Current_task_set
@@ -73,11 +79,19 @@ let handle_check ~(inspect_state : context -> agent_state) ~tool_name ~start_tim
   let assertions =
     match Json_util.assoc_member_opt "assertions" args with
     | Some (`List items) ->
+      (* Total, so the list the caller sent and the list that gets checked
+         have the same length. [List.filter_map] dropped anything that was
+         not a JSON string before it reached [check_assertion], so the
+         element never appeared in the response and [all_passed] answered a
+         narrower question than the caller asked. [check_assertion] already
+         handles input it cannot read -- an unrecognised name comes back
+         [passed = false] with [expected_assertions] -- and a wrong-typed
+         element now takes that same path. *)
       let parsed =
-        List.filter_map
+        List.map
           (function
-            | `String s -> Some s
-            | _ -> None)
+            | `String s -> s
+            | _ -> unreadable_assertion)
           items
       in
       (match parsed with

--- a/lib/workspace_assertions.mli
+++ b/lib/workspace_assertions.mli
@@ -77,6 +77,10 @@ val assertion_kind_of_string_lenient : string -> assertion_kind option
       fall back to the canonical defaults ([task_claimed] /
       [current_task_set]).  An empty list also falls back to
       defaults so callers cannot accidentally pass nothing.
+      Within a list, an element that is not a JSON string is not
+      discarded — it is carried through as an unrecognised assertion,
+      so it appears in the response with [passed = false] and the
+      number of elements reported equals the number sent.
 
     {2 Return value}
     [{ success = true; message = json_string }] — [success] is

--- a/test/stanzas/test_assertion_kind_mirror.inc
+++ b/test/stanzas/test_assertion_kind_mirror.inc
@@ -1,4 +1,4 @@
 (test
  (name test_assertion_kind_mirror)
  (modules test_assertion_kind_mirror)
- (libraries alcotest masc masc_test_deps masc.tool_schemas))
+ (libraries alcotest masc masc_test_deps masc.tool_schemas eio_main unix))

--- a/test/test_assertion_kind_mirror.ml
+++ b/test/test_assertion_kind_mirror.ml
@@ -80,6 +80,83 @@ let test_every_advertised_kind_parses () =
     owner
 ;;
 
+
+(* ── masc_check argument parsing ──────────────────────────────────────
+
+   [handle_check] reads an optional [assertions: [<string>...]] array. The
+   parse used [List.filter_map] over the items, so an element that was not a
+   JSON string was discarded before it reached [check_assertion] and never
+   appeared in the response. [all_passed] was then computed over the
+   survivors, which is the answer to a narrower question than the caller
+   asked.
+
+   [check_assertion] already has the right shape for input it does not
+   understand: an unrecognised *name* comes back with [passed = false] plus
+   [expected_assertions]. These pin the same treatment for an element of the
+   wrong *type*. *)
+
+let temp_dir_seq = ref 0
+
+let temp_dir () =
+  incr temp_dir_seq;
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-assert-%d-%d" (Unix.getpid ()) !temp_dir_seq)
+  in
+  Unix.mkdir dir 0o700;
+  dir
+
+let with_ctx f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> try Unix.rmdir dir with Unix.Unix_error _ -> ())
+    (fun () ->
+      let config = Masc.Workspace.default_config dir in
+      f { Masc.Workspace_types.config; agent_name = "test-agent" })
+
+let state_all_true : Masc.Workspace_assertions.agent_state =
+  { task_claimed = true; current_task_set = true }
+
+let check_with args =
+  with_ctx (fun ctx ->
+    let result =
+      Masc.Workspace_assertions.handle_check
+        ~inspect_state:(fun _ -> state_all_true)
+        ~tool_name:"masc_check" ~start_time:0.0 ctx args
+    in
+    Yojson.Safe.from_string (Tool_result.message result))
+
+let reported_assertions json =
+  match Yojson.Safe.Util.member "assertions" json with
+  | `List items ->
+    List.map
+      (fun item -> Yojson.Safe.Util.(member "assertion" item |> to_string))
+      items
+  | _ -> []
+
+let all_passed json =
+  match Yojson.Safe.Util.member "all_passed" json with
+  | `Bool b -> b
+  | _ -> failwith "all_passed missing"
+
+let test_non_string_element_is_reported () =
+  let json =
+    check_with
+      (`Assoc [ "assertions", `List [ `String "task_claimed"; `Int 42 ] ])
+  in
+  check int "both elements are accounted for" 2
+    (List.length (reported_assertions json));
+  check bool "an element it could not read cannot pass" false (all_passed json)
+
+let test_only_non_string_elements_do_not_become_defaults () =
+  let json = check_with (`Assoc [ "assertions", `List [ `Int 42 ] ]) in
+  check int "the one element the caller sent is the one reported" 1
+    (List.length (reported_assertions json));
+  check bool "not silently answered with the defaults" false (all_passed json)
+
 let () =
   Alcotest.run
     "Assertion kind mirror"
@@ -89,6 +166,12 @@ let () =
             test_published_enum_matches_the_owner
         ; test_case "every advertised kind parses" `Quick
             test_every_advertised_kind_parses
+        ] )
+    ; ( "argument parsing"
+      , [ test_case "a non-string element is reported, not dropped" `Quick
+            test_non_string_element_is_reported
+        ; test_case "unreadable elements do not become the defaults" `Quick
+            test_only_non_string_elements_do_not_become_defaults
         ] )
     ]
 ;;


### PR DESCRIPTION
`masc_check` 는 에이전트가 **자기 상태를 검증할 때 부르는 도구**다. 그 도구가 읽지 못한 요청 항목을 조용히 버리고 있었다.

```ocaml
List.filter_map (function `String s -> Some s | _ -> None) items
```

버려진 원소는 `check_assertion` 에 **도달하지 못하고**, 응답에도 나타나지 않으며, `all_passed` 는 살아남은 것들로만 계산된다. **묻지 않은 질문에 답하고 그 답에 `all_passed` 라벨을 붙인다.**

## 두 가지 모양

```
assertions: ["task_claimed", 42]
  → 하나만 검사, 하나만 보고. all_passed 는 보낸 둘 중 하나를 서술한다.

assertions: [42]
  → 빈 리스트로 파싱되고, 그러면 빈-리스트 분기가 걸려 기본값으로 폴백한다.
    도구는 task_claimed 와 current_task_set 을 검사한다 — 둘 다 요청하지 않은 것이다 —
    그리고 all_passed = true 를 돌려줄 수 있다.
```

## 올바른 모양이 함수 하나 옆에 이미 있었다

`check_assertion` 은 **알 수 없는 이름**을 이렇게 다룬다:

```ocaml
| None ->
  `Assoc [ "assertion", `String assertion
         ; "passed", `Bool false
         ; "expected_assertions", `List [...] ]
```

닫히게 실패하고, 자기가 이해하는 것을 말한다. **모범이다.** 다만 파싱이 먼저 지워버려서 잘못된 *타입* 의 원소는 여기까지 온 적이 없었다.

파싱을 total 로 바꿔, 문자열 아닌 원소를 유효하지 않은 이름으로 넘긴다. 그러면 위 경로를 그대로 탄다. **보낸 개수와 보고된 개수가 같아진다.**

## 검증 — 수정 전에 먼저 실패시켰다

```
RUN(수정 전)=1
> [FAIL]  argument parsing  0  a non-string element is reported, not dropped
  [FAIL]  argument parsing  1  unreadable elements do not become the defaults
  ...
  FAIL both elements are accounted for
     Expected: `2'
```

`42` 가 사라져 1 건만 보고된 그대로다. 수정 후 5/5.

**자기 오류 하나 기록한다.** 두 번째 테스트의 첫 실행은 단언이 아니라 `EEXIST` 로 죽었다 — 내가 쓴 temp-dir 헬퍼가 접미사를 상수에서 뽑아 같은 경로를 두 번 만들었다. (고유하다고 가정한 생성기가 고유하지 않았다.) 카운터로 고치고 **수정 전 트리에서 다시 확인**했으므로, 위 "수정 전 실패" 는 고쳐진 헬퍼 기준이다. 헬퍼는 이제 디렉터리도 지운다.

| 항목 | 결과 |
|---|---|
| `dune build --root . @check` | exit 0 |
| `test_assertion_kind_mirror` | 5/5 |
| `scripts/lint/*.sh` 전체 | exit 0 |
| `verify-test-registration.py` | exit 0 |
| `audit-ci-test-targets.sh` | exit 0 |
| `check-pr-hygiene.sh --base origin/main` | exit 0 |

## 바꾸지 않은 것

**리스트가 아닌 `assertions` 값은 여전히 기본값으로 폴백한다.** 그건 `.mli` 에 문서화된 의도이고, "없음" 과 "있지만 모양이 틀림" 을 가르는 것은 계약 결정이지 조용히 잃어버린 원소 문제가 아니다. 별건으로 볼 사안이다.

`.mli` 는 missing / non-list / empty-list 폴백만 적고 **리스트 안의 원소에 대해서는 아무 말이 없었다.** 이제 보고 개수가 보낸 개수와 같다는 것을 명시한다.
