### PR TITLE
docs(mli): 블록 문법을 인라인으로 쓴 9곳

### DIFF
--- a/lib/backend/backend_types.mli
+++ b/lib/backend/backend_types.mli
@@ -51,7 +51,9 @@ val default_config : unit -> config
     inputs collapse to [1]; values above 24h collapse to [day_int]. *)
 val validate_ttl : int -> int
 
-(** {1 In-Memory Pub/Sub} shared by Memory + FileSystem backends. *)
+(** {1 In-Memory Pub/Sub}
+
+    Shared by the Memory and FileSystem backends. *)
 module Pubsub_mem : sig
   type t
 

--- a/lib/keeper_metrics/keeper_memory_recall_exn_class.mli
+++ b/lib/keeper_metrics/keeper_memory_recall_exn_class.mli
@@ -41,5 +41,5 @@ val classify : exn -> t
 val to_label : t -> string
 (** Render the classification as the wire label value used by
     Otel_metric_store. Returns one of the lowercase strings
-    {[ "yojson_parse_error" ]}, {[ "io_error" ]}, {[ "type_error" ]},
-    {[ "other" ]}. *)
+    ["yojson_parse_error"], ["io_error"], ["type_error"],
+    ["other"]. *)

--- a/lib/mcp_tool_runtime.mli
+++ b/lib/mcp_tool_runtime.mli
@@ -6,7 +6,9 @@
 
     @since 0.1.0 *)
 
-(** {1 Types} (re-exported from Mcp_tool_runtime_types) *)
+(** {1 Types}
+
+    Re-exported from [Mcp_tool_runtime_types]. *)
 
 type tool_result = Mcp_tool_runtime_types.tool_result
 

--- a/lib/otel_metric_store/otel_metric_names.mli
+++ b/lib/otel_metric_store/otel_metric_names.mli
@@ -82,7 +82,7 @@ val metric_board_persist_lock_held_sec : string
 
 (** Time spent waiting to acquire [Backend.FileSystem.t.mutex] before
     a write/delete operation.  Labels: [op] in
-    {[set | delete | set_if_not_exists]}.
+    [set | delete | set_if_not_exists].
 
     Combined with [metric_backend_mutex_held_sec] this distinguishes
     keeper write contention (acquire high) from disk I/O stall (held
@@ -95,7 +95,7 @@ val metric_board_persist_lock_held_sec : string
 val metric_backend_mutex_acquire_sec : string
 
 (** Time spent inside the backend persist lock, from acquisition to
-    release. Labels: [op] in {[set | delete | set_if_not_exists]}.
+    release. Labels: [op] in [set | delete | set_if_not_exists].
 
     Captures time spent in the write critical section, used together
     with [metric_backend_mutex_acquire_sec]. *)
@@ -124,7 +124,7 @@ val metric_keeper_waiting_age_seconds : string
 val metric_keeper_waiting_keeper_count : string
 
 (** Schedule unsupported payload counter. Label: [phase] in
-    {[creation | dispatch]}. Raw payload kinds are not
+    [creation | dispatch]. Raw payload kinds are not
     labels; they remain in typed errors/projections to avoid unbounded metric
     cardinality. *)
 val metric_schedule_payload_unsupported_total : string

--- a/lib/otel_metric_store/otel_runtime_metric_names.mli
+++ b/lib/otel_metric_store/otel_runtime_metric_names.mli
@@ -22,7 +22,7 @@ val metric_agent_heartbeat_age_seconds : string
 val metric_agent_stale_total : string
 
 (** Scheduler runner loop completions. Labels: [outcome] in
-    {[ok | error | crash]}. *)
+    [ok | error | crash]. *)
 val metric_schedule_runner_tick_outcomes : string
 
 (** {1 OCaml GC sampler gauges}

--- a/lib/tool_telemetry.mli
+++ b/lib/tool_telemetry.mli
@@ -24,7 +24,7 @@ type trace_id = string
 val tool_type_of_name : string -> string
 
 (** [with_span ~tool_name f] opens an OTel span named
-    {v tool_dispatch.<tool_name> v}, invokes [f] inside the span, and
+    [tool_dispatch.<tool_name>], invokes [f] inside the span, and
     increments [tool_dispatch_total] with labels [tool = tool_name],
     [outcome = <outcome returned by f>], [surface], and [tool_type].
 


### PR DESCRIPTION
## 문제

블록 요소를 문장 중간에 써서 odoc 이 그 자리에서 문단을 끊는다.

```ocaml
(* otel_metric_names.mli:85 *)
(** Time spent waiting to acquire [Backend.FileSystem.t.mutex] before
    a write/delete operation.  Labels: [op] in
    {[set | delete | set_if_not_exists]}.
```

`{[ ]}` 는 코드 **블록**, `{v v}` 는 verbatim **블록**이다. 인라인으로 쓰면 뒤 문장이 새 문단으로 밀려 렌더가 어긋난다.

```
Warning: Paragraph should begin on its own line.
```

의도는 전부 인라인 코드다 — 라벨 값 목록, 메트릭 이름, 스팬 이름.

## 변경

**인라인 블록 → 코드 스팬 7곳**

```
{[set | delete | set_if_not_exists]}   → [set | delete | set_if_not_exists]
{[ "yojson_parse_error" ]}             → ["yojson_parse_error"]
{v tool_dispatch.<tool_name> v}        → [tool_dispatch.<tool_name>]
```

**제목 뒤 같은 줄 프로즈 2곳** — 제목과 본문을 분리했다.

```ocaml
(** {1 In-Memory Pub/Sub} shared by Memory + FileSystem backends. *)
→
(** {1 In-Memory Pub/Sub}

    Shared by the Memory and FileSystem backends. *)
```

## 측정

```
                                       이전   이후
Paragraph should begin on its own line   9      0
전체 odoc 경고                          573    517
```

## 건드리지 않은 것

`server_routes_http_routes_artifacts.mli:9` 의 `{v GET /api/v1/artifacts/<sha256> v}` 는 앞뒤 빈 줄을 둔 **정상 블록**이라 경고가 없다. 인라인으로 쓰인 것만 바꿨다.

## 검증

```
dune build --root . @check            → 0
odoc (DUNE_CACHE=disabled)            → Paragraph 경고 0
```
