### PR TITLE
fix(reputation): 레코드가 주장하지 않은 목표 준수를 인정하던 기본값

### DIFF
--- a/lib/reputation_ledger_v2.ml
+++ b/lib/reputation_ledger_v2.ml
@@ -142,8 +142,14 @@ let ledger_event_of_json json : ledger_event option =
         agent_id;
         task_id;
         task_title = Safe_ops.json_string ~default:"" "task_title" json;
-        completed_within_budget = Safe_ops.json_bool ~default:true "completed_within_budget" json;
-        on_topic = Safe_ops.json_bool ~default:true "on_topic" json;
+        (* Absent means the record does not say, and both feed
+           [goal_adherent_completions]. Defaulting to [true] credited
+           adherence nobody recorded and raised the agent's
+           [goal_adherence] rate. [false] matches the [tool_outcome] branch
+           above, which already reads a missing [success] as not a success. *)
+        completed_within_budget =
+          Safe_ops.json_bool ~default:false "completed_within_budget" json;
+        on_topic = Safe_ops.json_bool ~default:false "on_topic" json;
         raw_trace_run_id = Safe_ops.json_string_opt "raw_trace_run_id" json;
         timestamp = ts;
       })

--- a/test/test_reputation_ledger_v2.ml
+++ b/test/test_reputation_ledger_v2.ml
@@ -185,6 +185,71 @@ let test_compute_metrics_partial_failure () =
     check (float 0.0001) "execution_reliability" (2.0 /. 3.0)
       m.execution_reliability)
 
+(* A goal_completion record that does not carry completed_within_budget /
+   on_topic. The codec always writes both, so this is a record it did not
+   write -- an older schema, a truncated append, or a hand edit. The parser
+   defaulted both to true, which credited adherence nobody recorded. The
+   sibling branch in the same function already defaults tool_outcome's
+   [success] to false. *)
+let strip_adherence_fields config =
+  let dir =
+    Filename.concat
+      (Filename.concat config.Workspace.base_path ".masc")
+      "reputation_v2"
+  in
+  (* Dated_jsonl stores under dated subdirectories, so walk rather than
+     listing one level. *)
+  let rec jsonl_files root =
+    Sys.readdir root
+    |> Array.to_list
+    |> List.sort String.compare
+    |> List.concat_map (fun name ->
+         let path = Filename.concat root name in
+         if Sys.is_directory path then jsonl_files path
+         else if Filename.check_suffix path ".jsonl" then [ path ]
+         else [])
+  in
+  let files = jsonl_files dir in
+  List.iter
+    (fun path ->
+      let lines =
+        In_channel.with_open_text path In_channel.input_all
+        |> String.split_on_char '\n'
+        |> List.filter (fun l -> String.trim l <> "")
+      in
+      let rewritten =
+        List.map
+          (fun line ->
+            match Yojson.Safe.from_string line with
+            | `Assoc fields ->
+              `Assoc
+                (List.filter
+                   (fun (k, _) ->
+                     k <> "completed_within_budget" && k <> "on_topic")
+                   fields)
+              |> Yojson.Safe.to_string
+            | _ -> line)
+          lines
+      in
+      Out_channel.with_open_text path (fun oc ->
+        List.iter (fun l -> Out_channel.output_string oc (l ^ "\n")) rewritten))
+    files
+
+let test_missing_adherence_fields_do_not_credit_adherence () =
+  with_workspace (fun config ->
+    Reputation_ledger_v2.emit_goal_completion config
+      ~agent_id:"unrecorded-agent" ~task_id:"t1" ~task_title:"Goal"
+      ~completed_within_budget:true ~on_topic:true ();
+    strip_adherence_fields config;
+    let m =
+      Reputation_ledger_v2.compute_ledger_metrics config
+        ~agent_id:"unrecorded-agent" ~window_days:30
+    in
+    check int "the completion itself still counts" 1 m.goal_completions;
+    check int "adherence nobody recorded is not credited" 0
+      m.goal_adherent_completions;
+    check (float 0.0001) "goal_adherence" 0.0 m.goal_adherence)
+
 let test_safety_compliance_penalty () =
   with_workspace (fun config ->
     Reputation_ledger_v2.emit_safety_violation config
@@ -237,5 +302,7 @@ let () =
             test_safety_compliance_penalty
         ; test_case "safety compliance floors at zero" `Quick
             test_safety_compliance_floors_at_zero
+        ; test_case "missing adherence fields are not credited" `Quick
+            test_missing_adherence_fields_do_not_credit_adherence
         ] )
     ]


### PR DESCRIPTION
평판 원장이 **레코드가 주장하지 않은 목표 준수를 인정하고** 있었다.

```ocaml
completed_within_budget = Safe_ops.json_bool ~default:true "completed_within_budget" json;
on_topic                = Safe_ops.json_bool ~default:true "on_topic" json;
```

둘은 한 카운터로 모인다:

```ocaml
if e.completed_within_budget && e.on_topic then incr goal_adherent
```

그리고 `goal_adherent / goal_completions` 가 에이전트의 `goal_adherence` 비율이다. **그 필드가 없는 레코드는 준수한 것으로 세어져 비율을 올린다.**

## 스무 줄 위가 이미 반대 방향이다

```ocaml
| Some "tool_outcome" -> ...
    success = Safe_ops.json_bool ~default:false "success" json;
```

**같은 함수, 같은 종류의 필드, 반대 기본값.** `tool_outcome` 은 볼 수 없는 성공을 인정하지 않는데, `goal_completion` 은 볼 수 없는 준수를 인정했다.

## 도달 범위

| | |
|---|---|
| **서빙 경로** | `Reputation.compute_reputation` → `compute_ledger_metrics` → `goal_adherence`. 프로덕션 소비자 셋: `dashboard_http_keeper.ml`, `server_utils.ml`, `server_routes_http_routes_activity.ml` |
| **기본값 발화 조건** | `goal_completion_to_json` 이 두 필드를 **항상 쓴다.** 이 코덱이 쓴 레코드에는 늘 있다. 발화는 이 코덱이 쓰지 않은 레코드 — 잘린 append, 손편집, 옛 형태 — 뿐이다 |
| **실측** | **발생 사례를 찾지 못했다.** 트리에 v1 원장 모듈도 없다 |

**서빙되는 지표의 fail-open latent 이지 관측된 오집계가 아니다.**

## 왜 `false` 이고 왜 레코드를 버리지 않나

파서는 `agent_id` · `task_id` · `ts` 가 없으면 이미 레코드를 **거부**한다. 즉 "필드 부재" 가 여기서 일률적으로 무해한 것은 아니다.

이 둘은 다르다 — 신원 필드가 있으므로 **완료 자체는 실재한다.** 그래서 `goal_completions` 에는 계속 잡히고, **준수로만 안 잡힌다.** `false` 는 레코드가 말한 적 없는 것을 주장하지 않는 읽기다.

## 검증 — 수정 전에 먼저 실패시켰다

```
RUN(수정 전)=1
ASSERT the completion itself still counts          ← 통과
ASSERT adherence nobody recorded is not credited   ← FAIL
```

이 갈림이 정확히 이 변경의 내용이다. 수정 후 11/11.

**자기 오류 기록.** 이 테스트의 첫 두 실행은 단언이 아니라 내 실수로 죽었다 — `Dated_jsonl` 의 날짜별 하위 디렉터리를 파일로 읽어 `Sys_error("Is a directory")` 가 났다. 헬퍼가 이제 재귀 순회하고, 위 전/후는 고쳐진 헬퍼 기준이다.

**기존 실패 구분.** 이 워크트리에서 `test_reputation_identity_undercount` 와 `test_keeper_accountability` 가 실패한다. **이 변경을 되돌린 상태에서도 동일하게 실패**하므로 기존 것이다.

| 항목 | 결과 |
|---|---|
| `dune build --root . @check` | exit 0 |
| `test_reputation_ledger_v2` | 11/11 |
| `scripts/lint/*.sh` 전체 | exit 0 |
| `verify-test-registration.py` | exit 0 |
| `audit-ci-test-targets.sh` | exit 0 |
| `check-pr-hygiene.sh --base origin/main` | exit 0 |
