### PR TITLE
refactor(dashboard-api): 아무도 읽지 않는 trajectory 절단 메타데이터 3필드 제거

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -2370,9 +2370,6 @@ let handle_keeper_get_subroutes state req request reqd =
                  ("trace_id", `String trace_id);
                  ("generation", `Int m.runtime.nonce);
                  ("total_entries", `Int total);
-                 ("total_entries_scope", `String "tail");
-                 ("total_entries_exact", `Bool false);
-                 ("tail_scan_lines", `Int tail_scan_lines);
                  ("showing", `Int (List.length recent));
                  ("entries", `List (List.map
                    (Trajectory.trajectory_line_to_json ~result_max_len ~content_max_len) recent));


### PR DESCRIPTION
## 변경

`/api/v1/keepers/<name>/trajectory` 응답에서 아무도 읽지 않는 세 필드를 제거한다.

```ocaml
("total_entries_scope", `String "tail");
("total_entries_exact", `Bool false);     (* 조건 없이 false *)
("tail_scan_lines", `Int tail_scan_lines);
```

## 근거

세 이름 모두 저장소 어디에도 소비자가 없다.

```
                      dashboard  test  bin  docs
total_entries_scope       0        0     0    0
total_entries_exact       0        0     0    0
tail_scan_lines           0        0     0    0
```

`total_entries_exact` 는 조건 분기 없이 `false` 다 — 서버가 "이 총계는 정확하지 않다"고 무조건 선언하는데, 그 선언을 읽는 코드가 없다. `total_entries_scope` 도 상수 `"tail"` 이다.

`tail_scan_lines` 는 변수 자체는 남는다. tail 읽기 인자(`~max_lines:tail_scan_lines`)로 계속 쓰이고, 응답에 실어 보내는 것만 멈춘다.

## 범위 밖

`total_entries` 자체도 프로덕션 소비자가 없다 — `session-trace-state.test.ts` 픽스처에만 등장한다. `showing`, `generation` 도 같다. 다만 이들은 픽스처와 TS 타입에 걸려 있어 제거 반경이 다르고, 잘린 카운트를 어떻게 다룰지는 #27307 에서 묻고 있는 정책 질문이다. 이 PR 은 **참조가 0인 것만** 걷는다.

## 검증

```
dune build --root . @check                  → 0
@runtest-test_trajectory                    → 43 tests, Successful
@runtest-test_trajectory_atomicity          → 1 test, Successful
잔여 참조                                    → 0 (tail_scan_lines 는 tail 읽기 인자로만 남음)
```

관련: #27307 (잘린 카운트를 총계로 내보내는 문제 — 이 PR 은 그 중 소비자 0인 절반).
