### PR TITLE
chore(operator): 상수를 계산된 것처럼 보이게 하던 config 인자 제거

### DIFF
--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -609,10 +609,16 @@ let snapshot_json
           let workspace_attention =
             build_workspace_attention_items config |> List.sort compare_attention
           in
-          let workspace_recommendation_items = workspace_recommendations config in
+          (* #26144 moved actions out of the fallback read model: this layer
+             observes and does not recommend. The summary is constant here --
+             count=0, top_action=null, provenance="fallback",
+             authoritative=false. It used to read
+             [workspace_recommendations config], which that change had already
+             emptied to [fun _ -> []], so the config argument was only making a
+             constant look derived. *)
           [ "attention_summary", summary_of_attention_items workspace_attention
           ; ( "recommendation_summary"
-            , summary_of_recommendations ~actor:actor_name workspace_recommendation_items )
+            , summary_of_recommendations ~actor:actor_name [] )
           ])
         else [])
     in

--- a/lib/operator/operator_digest.ml
+++ b/lib/operator/operator_digest.ml
@@ -246,9 +246,6 @@ let keeper_attention_projection_items config =
   in
   status_attention @ external_attention
 
-let workspace_recommendations _config =
-  dedup_recommendations []
-
 let workspace_state_json config =
   if not (Workspace.is_initialized config) then
     `Assoc

--- a/lib/operator/operator_digest.mli
+++ b/lib/operator/operator_digest.mli
@@ -40,8 +40,6 @@ val health_from_attention_items : attention_item list -> string
 
 val build_workspace_attention_items : Workspace.config -> attention_item list
 
-val workspace_recommendations : Workspace.config -> recommended_action list
-
 val normalize_digest_target_type :
   string option -> (string, string) result
 

--- a/scripts/audit-dead-surface.py
+++ b/scripts/audit-dead-surface.py
@@ -551,7 +551,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 # proactive_has_terminal_korean_ending val. Measured with --exports on the
 # merged tree; main moved 575 -> 573 -> 564 while this branch was open
 # (#27460 and #27456), so every earlier value here was stale by the next merge.
-DEAD_EXPORT_BASELINE = 563
+DEAD_EXPORT_BASELINE = 562
 
 
 def run_ratchet(count: int) -> int:


### PR DESCRIPTION
`operator_digest.mli` 가 이 둘을 나란히 내보내고 있었다:

```ocaml
val build_workspace_attention_items : Workspace.config -> attention_item list
val workspace_recommendations       : Workspace.config -> recommended_action list
```

**대칭으로 읽힌다.** 앞의 것은 config 에서 계산한다. 뒤의 것은:

```ocaml
let workspace_recommendations _config = dedup_recommendations []
```

`fun _ -> []` 이다. 언더스코어가 config 를 읽지 않는다고 자백하고, 그 위에 빈 리스트의 dedup 이 얹혀 있다.

## 본문이 어디로 갔나

**#26144 (`separate fallback observations from actions`)** 이다. 그 diff 가 `operator_digest.ml` 의 fallback 추천 계산을 지우고 호출부를 명명된 `empty_recommendation_summary` 로 바꿨다:

```
-        let fallback_recommendation_summary =
-          summary_of_recommendations ~actor:actor_name recommended_actions
+        let empty_recommendation_summary =
+          summary_of_recommendations ~actor:actor_name []
```

**fallback read model 은 관측하고 추천하지 않는다 — 의도된 결정이다.** 남은 것은 비워진 함수와, **다른 파일에 있던 호출자 하나**다:

```ocaml
(* operator_control_snapshot.ml:612 *)
let workspace_recommendation_items = workspace_recommendations config in
[ "attention_summary",      summary_of_attention_items workspace_attention
; "recommendation_summary", summary_of_recommendations ~actor:actor_name
                              workspace_recommendation_items ]
```

**나란한 두 필드 중 하나는 워크스페이스에서 파생되고 하나는 상수인데, 호출 지점에서 어느 쪽인지 알 수 없다.**

## 요약 자체는 정직하다

```json
{"count": 0, "top_action": null, "provenance": "fallback", "authoritative": false}
```

상수가 진짜 추천인 척하지는 않는다. 문제는 그것을 **config 파라미터를 통과시킨다**는 점이다 — 값이 계산된 것인지 판단할 때 독자가 보는 모양이 바로 그것이다.

## 변경

함수와 `val` 을 제거하고, 호출자가 `[]` 를 직접 넘겨 상수가 보이게 했다. `operator_digest.ml` 이 이미 `empty_recommendation_summary` 로 하고 있는 것과 같은 형태다.

**동작은 동일하다** — 요약은 이미 `[]` 로 계산되고 있었다.

| 항목 | 결과 |
|---|---|
| `dune build --root . @check` | exit 0 |
| `test_operator_control_snapshot` / `_state` / `_cache` | exit 0 |
| `test_operator_control_judgment` | exit 0 |
| `test_audit_projection` · `test_dashboard_briefing` | exit 0 |
| `scripts/lint/*.sh` 전체 | exit 0 |
| `verify-test-registration.py` | exit 0 |
| `audit-ci-test-targets.sh` | exit 0 |
| `check-pr-hygiene.sh --base origin/main` | exit 0 |
| `audit-dead-surface.py --exports --ratchet` | 563 → **562**, 베이스라인 하향 |

## 이번 축에서 결함 아님으로 닫은 것

- `dedup_recommendations` 의 키는 `String.concat "|"` 로 만들지만, 산문(`reason`)은 **마지막 필드**라 구분자 이동을 일으키지 않고, 소문자·trim 만 병합하므로 **유사도를 지어내지 않는다.**
- `operator_digest.ml` 의 다른 빈 리스트 호출 넷은 의도적이다 — 미초기화 폴백 분기이거나 이름이 `empty_recommendation_summary` 다.
- `fusion_types.unique_insights` 는 dedup 이 아니라 렌더링이다.

## RFC 게이트

`lib/operator/operator_control*` 를 건드리므로 `pr-rfc-check.sh` 가 트립했다 (exit 1). 매칭된 17 건을 확인한 결과:

- **RFC-0009 (`Runtime Trust Phase 2: Operator Recommendations`)** 가 이름상 가장 가깝지만 **다른 것을 가리킨다** — `lib/dashboard_runtime_recommendations.ml` 의 provider 신뢰도 권고(`Reduce_weight | Disable | Investigate`)이지, operator digest 의 `recommended_action` 이 아니다. 거짓 인용을 하지 않기 위해 이 RFC 를 근거로 대지 않는다. (다만 그 RFC 의 *"Observation over action — Phase 2a is observation-only"* 원칙은 #26144 가 fallback read model 에 적용한 것과 같은 방향이다.)
- `operator_digest` 의 추천 표면을 관장하는 RFC 는 없다. `docs/rfc/` 전수에서 `operator_digest` / `recommendation_summary` / `fallback read model` 을 언급하는 것은 RFC-0291(SSE 이벤트 이름), RFC-0182(도구 이름), RFC-connector-ambient-attention-wake(다른 맥락의 호출자 언급)뿐이다.
- 결정 자체는 **PR #26144 에서 RFC 없이** 내려졌고, 이 PR 은 그 결정을 뒤집지 않는다 — 그 결정이 남긴 껍데기를 치울 뿐이며 동작은 동일하다.

RFC-WAIVED: 동작 무변경 husk 제거. 이미 `fun _ -> []` 이던 함수와 그 val 을 지우고 호출자가 상수를 직접 넘기게 한다. 매칭된 RFC 중 operator digest 추천 표면을 관장하는 것이 없고(RFC-0009 는 runtime-trust provider 권고로 다른 모듈), 원 결정인 #26144 자체가 RFC 없이 내려졌다.
