### PR TITLE
refactor(tui): 연결 상태를 문자열에서 닫힌 variant 로 (catch-all 6개 제거)

### DIFF
--- a/bin/masc_tui.ml
+++ b/bin/masc_tui.ml
@@ -283,9 +283,9 @@ let refresh_status results =
       0 results
   in
   match (successes, List.length results) with
-  | 0, _ -> "disconnected"
-  | n, total when n = total -> "connected"
-  | _ -> "degraded"
+  | 0, _ -> Masc_tui_types.Disconnected
+  | n, total when n = total -> Masc_tui_types.Connected
+  | _ -> Masc_tui_types.Degraded
 
 let load_http_surfaces ~host ~port =
   {
@@ -314,8 +314,8 @@ let start_http_refresh state ~host ~port ~refresh_inflight ~mailbox =
     refresh_inflight := true;
     state.connection_status <-
       (match state.connection_status with
-      | "connected" | "degraded" -> "reconnecting"
-      | _ -> "connecting");
+       | Connected | Degraded -> Masc_tui_types.Reconnecting
+       | Disconnected | Connecting | Reconnecting -> Masc_tui_types.Connecting);
     let run_refresh () =
       try enqueue_async mailbox (Http_refresh_done (load_http_surfaces ~host ~port)) with
       | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -463,7 +463,7 @@ let apply_async_message state ~http_refresh_inflight
       apply_http_surfaces state results
   | Http_refresh_failed err ->
       http_refresh_inflight := false;
-      state.connection_status <- "disconnected";
+      state.connection_status <- Masc_tui_types.Disconnected;
       add_event state "error" err
   | Board_post_refresh_done (post_id, result) ->
       if same_inflight_post !board_post_refresh_inflight post_id then

--- a/bin/masc_tui_render.ml
+++ b/bin/masc_tui_render.ml
@@ -4,6 +4,16 @@ open Masc_tui_types
 open Tui_decode
 open Masc_tui_ansi
 
+(* Exhaustive over [connection_status]: a new state is a compile error
+   here rather than an unexplained [disconnected] on screen. *)
+let connection_badge : Masc_tui_types.connection_status -> string = function
+  | Connected -> Ansi.green ^ "[connected]" ^ Ansi.reset
+  | Degraded -> Ansi.yellow ^ "[degraded]" ^ Ansi.reset
+  | Connecting -> Ansi.yellow ^ "[connecting...]" ^ Ansi.reset
+  | Reconnecting -> Ansi.yellow ^ "[reconnecting...]" ^ Ansi.reset
+  | Disconnected -> Ansi.red ^ "[disconnected]" ^ Ansi.reset
+;;
+
 let workspace_health_label = function
   | Workspace_health_critical -> "critical"
   | Workspace_health_bad -> "bad"
@@ -50,12 +60,7 @@ let render_dashboard (state : state) =
     now.Unix.tm_hour now.Unix.tm_min now.Unix.tm_sec in
   let header = Printf.sprintf " MASC Dashboard  %s[%s]%s  %s  %s"
     Ansi.cyan state.workspace Ansi.reset timestamp
-    (match state.connection_status with
-     | "connected" -> Ansi.green ^ "[connected]" ^ Ansi.reset
-     | "degraded" -> Ansi.yellow ^ "[degraded]" ^ Ansi.reset
-     | "connecting" -> Ansi.yellow ^ "[connecting...]" ^ Ansi.reset
-     | "reconnecting" -> Ansi.yellow ^ "[reconnecting...]" ^ Ansi.reset
-     | _ -> Ansi.red ^ "[disconnected]" ^ Ansi.reset) in
+    (connection_badge state.connection_status) in
 
   (* Top border *)
   Buffer.add_string buf (Printf.sprintf "%s%s%s%s%s\n"
@@ -181,12 +186,7 @@ let render_overview (state : state) =
     now.Unix.tm_hour now.Unix.tm_min now.Unix.tm_sec in
   let header = Printf.sprintf " MASC Overview  %s[%s]%s  %s  %s"
     Ansi.cyan state.workspace Ansi.reset timestamp
-    (match state.connection_status with
-     | "connected" -> Ansi.green ^ "[connected]" ^ Ansi.reset
-     | "degraded" -> Ansi.yellow ^ "[degraded]" ^ Ansi.reset
-     | "connecting" -> Ansi.yellow ^ "[connecting...]" ^ Ansi.reset
-     | "reconnecting" -> Ansi.yellow ^ "[reconnecting...]" ^ Ansi.reset
-     | _ -> Ansi.red ^ "[disconnected]" ^ Ansi.reset) in
+    (connection_badge state.connection_status) in
 
   box_top buf cols;
   box_line buf cols header;
@@ -329,12 +329,7 @@ let render_approvals (state : state) =
   let count = List.length approvals in
   let header = Printf.sprintf " MASC Approvals (%d)  %s  %s"
     count timestamp
-    (match state.connection_status with
-     | "connected" -> Ansi.green ^ "[connected]" ^ Ansi.reset
-     | "degraded" -> Ansi.yellow ^ "[degraded]" ^ Ansi.reset
-     | "connecting" -> Ansi.yellow ^ "[connecting...]" ^ Ansi.reset
-     | "reconnecting" -> Ansi.yellow ^ "[reconnecting...]" ^ Ansi.reset
-     | _ -> Ansi.red ^ "[disconnected]" ^ Ansi.reset) in
+    (connection_badge state.connection_status) in
 
   box_top buf cols;
   box_line buf cols header;
@@ -429,12 +424,7 @@ let render_board_list (state : state) =
   let count = List.length state.board_posts in
   let header = Printf.sprintf " MASC Board (%d)  %s  %s"
     count timestamp
-    (match state.connection_status with
-     | "connected" -> Ansi.green ^ "[connected]" ^ Ansi.reset
-     | "degraded" -> Ansi.yellow ^ "[degraded]" ^ Ansi.reset
-     | "connecting" -> Ansi.yellow ^ "[connecting...]" ^ Ansi.reset
-     | "reconnecting" -> Ansi.yellow ^ "[reconnecting...]" ^ Ansi.reset
-     | _ -> Ansi.red ^ "[disconnected]" ^ Ansi.reset) in
+    (connection_badge state.connection_status) in
 
   box_top buf cols;
   box_line buf cols header;
@@ -589,12 +579,7 @@ let render_planning_list (state : state) =
     now.Unix.tm_hour now.Unix.tm_min now.Unix.tm_sec in
   let header = Printf.sprintf " MASC Planning  %s  %s"
     timestamp
-    (match state.connection_status with
-     | "connected" -> Ansi.green ^ "[connected]" ^ Ansi.reset
-     | "degraded" -> Ansi.yellow ^ "[degraded]" ^ Ansi.reset
-     | "connecting" -> Ansi.yellow ^ "[connecting...]" ^ Ansi.reset
-     | "reconnecting" -> Ansi.yellow ^ "[reconnecting...]" ^ Ansi.reset
-     | _ -> Ansi.red ^ "[disconnected]" ^ Ansi.reset) in
+    (connection_badge state.connection_status) in
 
   box_top buf cols;
   box_line buf cols header;

--- a/bin/masc_tui_types.ml
+++ b/bin/masc_tui_types.ml
@@ -10,6 +10,16 @@ type agent = Tui_decode.agent
 type task = Tui_decode.task
 
 (** Event for the event log *)
+(* The five states the refresh loop can put the TUI in. It was a string
+   with a catch-all at each of the five render sites, so a typo rendered
+   as [disconnected] and a new state would have too. *)
+type connection_status =
+  | Disconnected
+  | Connecting
+  | Reconnecting
+  | Degraded
+  | Connected
+
 type event = {
   timestamp: string;
   event_type: string;
@@ -205,7 +215,7 @@ type state = {
   mutable tasks: task list;
   mutable events: event list;
   mutable keepers: keeper list;
-  mutable connection_status: string;
+  mutable connection_status: connection_status;
   mutable last_refresh: float;
   mutable view: view_mode;
   mutable keeper_cursor: int;
@@ -245,7 +255,7 @@ let create_state ~workspace ~port ~refresh_interval = {
   tasks = [];
   events = [];
   keepers = [];
-  connection_status = "disconnected";
+  connection_status = Disconnected;
   last_refresh = 0.0;
   view = Overview;
   keeper_cursor = 0;


### PR DESCRIPTION
## 문제

TUI 의 연결 상태가 `string` 이고, 다섯 개 값이 파일 두 개에 흩어져 있었다.

```ocaml
(* masc_tui_types.ml:208 *)
mutable connection_status: string;

(* masc_tui.ml — 생산자 *)
| 0, _ -> "disconnected"
| n, total when n = total -> "connected"
| _ -> "degraded"
...
| "connected" | "degraded" -> "reconnecting"
| _ -> "connecting"
```

소비자는 `masc_tui_render.ml` 에 **동일한 블록이 5벌**, 각각 catch-all 을 달고 있었다.

```ocaml
(match state.connection_status with
 | "connected" -> ...
 | "degraded" -> ...
 | "connecting" -> ...
 | "reconnecting" -> ...
 | _ -> Ansi.red ^ "[disconnected]" ^ Ansi.reset)
```

생산자에 오타가 하나 나면 화면에 `[disconnected]` 가 뜬다. 연결은 살아 있는데 끊긴 것처럼 보이고, 아무 신호도 없다. 새 상태를 추가해도 다섯 곳 모두 조용히 `[disconnected]` 로 처리한다.

CLAUDE.md 가 지목한 형태다 — "FSM 전이 매트릭스는 `_ -> false` catch-all을 사용하지 않고 모든 쌍을 명시".

## 변경

**닫힌 variant** 로 바꿨다.

```ocaml
type connection_status =
  | Disconnected | Connecting | Reconnecting | Degraded | Connected
```

**렌더 블록 5벌 → 함수 1개.** 다섯 곳이 글자 하나까지 같았다.

```ocaml
let connection_badge : Masc_tui_types.connection_status -> string = function
  | Connected -> ...
  | Degraded -> ...
  | Connecting -> ...
  | Reconnecting -> ...
  | Disconnected -> ...
```

생산자의 catch-all 도 없앴다 — `| Disconnected | Connecting | Reconnecting -> Connecting` 으로 전 생성자를 명시한다.

## 검증

새 상태 `Probe_new_state` 를 임시로 추가하고 빌드했다.

```
Error: this pattern-matching is not exhaustive.
       ... not matched: Probe_new_state
```

제거 후:

```
dune build --root . @check     → 0
@runtest-test_tui_decode       → 22 tests, Successful
@runtest-test_tui_http_ast     → 8 tests, Successful
ocamlformat (3파일)             → OK
```

동작 변화 없음 — 같은 다섯 상태가 같은 배지를 낸다. 달라진 건 새 상태를 추가할 때 다섯 곳이 컴파일 에러로 드러난다는 것이다.

발견 경위: `bin/` 의 반복 리터럴 조사 (`"degraded"` 9회, `"connected"` 7회, `"reconnecting"`/`"connecting"` 6회씩).
