### PR TITLE
refactor: open Base 가 남긴 Stdlib 되돌리기 서문 1355줄 제거

### DIFF
--- a/docs/BASE-POLICY.md
+++ b/docs/BASE-POLICY.md
@@ -115,8 +115,8 @@ preferred over both Base and raw Stdlib when they already exist.
 | Counter | What it measures |
 |---|---|
 | `mli_open_base` | `.mli` files in `lib/` containing the `open Base` directive (anchored: `^[[:space:]]*open[[:space:]]+Base([^[:alnum:]_]|$)`, excludes comments/docstrings) |
-| `ml_base_stdlib_shadow` | `.ml` files in `lib/` that contain both the `open Base` directive and a Stdlib-shadow block (`^[[:space:]]*module[[:space:]]+List[[:space:]]*=[[:space:]]*Stdlib\.List([^[:alnum:]_]|$)`) |
-| `bin_ml_base_stdlib_shadow` | `.ml` files in `bin/` that contain both the `open Base` directive and the same Stdlib-shadow block |
+| `ml_base_stdlib_shadow` | `.ml` files in `lib/` containing a Stdlib-shadow block (`^[[:space:]]*module[[:space:]]+List[[:space:]]*=[[:space:]]*Stdlib\.List([^[:alnum:]_]|$)`), whether or not the file still opens Base |
+| `bin_ml_base_stdlib_shadow` | `.ml` files in `bin/` containing the same Stdlib-shadow block, on the same terms |
 
 These counters are recorded in `.ci/health-baseline.json` and reported
 by `scripts/health_snapshot.sh`.  A PR that increases any counter
@@ -126,6 +126,11 @@ CI also includes them in the `health_snapshot.sh --fail-on-lib-regression`
 ratchet.  When a baseline ref predates these counters, the audit treats
 the first measured value as the bootstrap baseline rather than a
 regression.
+
+The two shadow counters used to require the `open Base` directive in the
+same file. Once the opens were gone the counters read zero while 82 files
+kept the shadow block, so the audit passed over exactly the residue it
+exists to catch. They now match the block on its own.
 
 As of the 2026-05-05 ratchet, all three tracked counters are zero in
 current `main`; `.ci/health-baseline.json` records zero so any

--- a/lib/board/board_core_classify.ml
+++ b/lib/board/board_core_classify.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Board_core_classify — Post visibility/kind converters and classification.
 
     Contains exact conversion helpers and post-kind accessors.

--- a/lib/board/board_core_json.ml
+++ b/lib/board/board_core_json.ml
@@ -1,8 +1,5 @@
 (** Board JSON wire encoders and reaction parsers. *)
 
-module Option = Stdlib.Option
-module List = Stdlib.List
-module String = Stdlib.String
 
 include Board_core_classify
 

--- a/lib/board/board_core_payload.ml
+++ b/lib/board/board_core_payload.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Board_core_payload — Post payload normalization.
 
     Handles title derivation, metadata shape validation, and content

--- a/lib/board/board_core_persist.ml
+++ b/lib/board/board_core_persist.ml
@@ -1,11 +1,3 @@
-module Hashtbl = Stdlib.Hashtbl
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module String = Stdlib.String
-
 (** Board Core — JSONL store logic and persistence. Types are in Board_types. *)
 include Board_core_classify
 include Board_core_payload

--- a/lib/board/board_curation.ml
+++ b/lib/board/board_curation.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Board_curation — AI curation projection surface for the board.
 
     See board_curation.mli for the full contract. *)

--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Board_dispatch - Runtime backend selection for MASC Board
 
     Board now runs on the JSONL store only. Backend is selected once at

--- a/lib/board/board_votes.ml
+++ b/lib/board/board_votes.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 include Board_core
 
 let vote_direction_to_string = function Up -> "up" | Down -> "down"

--- a/lib/board_tool_adapter/board_tool_format.ml
+++ b/lib/board_tool_adapter/board_tool_format.ml
@@ -1,21 +1,5 @@
 open Masc_board_handlers
 
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
 
 (** Board_tool_format — formatters, parsers, JSON arg coercion,
     truncated-markdown detector, and the Yojson-error boundary shared

--- a/lib/board_tool_adapter/board_tool_handlers.ml
+++ b/lib/board_tool_adapter/board_tool_handlers.ml
@@ -1,21 +1,5 @@
 open Masc_board_handlers
 
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
 
 (** Board_tool_handlers — non-post mutating / read handlers and the
     shared agent-lookup / SOUL-evolution callbacks.

--- a/lib/board_tool_adapter/board_tool_post.ml
+++ b/lib/board_tool_adapter/board_tool_post.ml
@@ -1,21 +1,5 @@
 open Masc_board_handlers
 
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
 
 (** Board_tool_post — post-lifecycle handlers (create / list / get /
     comment_add).

--- a/lib/client_identity.ml
+++ b/lib/client_identity.ml
@@ -1,21 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-module Random = Stdlib.Random
-
 (** Agent Identity - Unified Agent Identification across MCP sessions
 
     OpenClaw-inspired session tracking for multi-agent environments.

--- a/lib/client_identity.mli
+++ b/lib/client_identity.mli
@@ -1,21 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-module Random = Stdlib.Random
-
 (** Agent Identity - Unified agent identification for MCP sessions
 
     @since 0.5.0

--- a/lib/client_registry_eio.ml
+++ b/lib/client_registry_eio.ml
@@ -1,21 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-module Random = Stdlib.Random
-
 (** Agent Registry Eio - Global agent identity tracking for MCP sessions
 
     Provides a singleton registry for tracking agent identities across

--- a/lib/client_registry_eio.mli
+++ b/lib/client_registry_eio.mli
@@ -1,21 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-module Random = Stdlib.Random
-
 (** Agent Registry Eio - Global agent identity tracking
 
     Actor model: all mutable state (identity registry, session→key map,

--- a/lib/dashboard/dashboard.ml
+++ b/lib/dashboard/dashboard.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** MASC Dashboard - Operator-First Status Visualization
 
     Usage:

--- a/lib/dashboard_tla_specs/dashboard_tla_specs.ml
+++ b/lib/dashboard_tla_specs/dashboard_tla_specs.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 type spec_entry =
   { name : string
   ; path : string

--- a/lib/dashboard_tool_host_events.ml
+++ b/lib/dashboard_tool_host_events.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 type report = {
   agent_name : string;
   client_name : string;

--- a/lib/dashboard_tool_source_freshness.ml
+++ b/lib/dashboard_tool_source_freshness.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Dashboard_tool_source_freshness -- source freshness metadata helpers. *)
 
 let numeric_ts_field fields name =

--- a/lib/health.ml
+++ b/lib/health.ml
@@ -1,21 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-module Random = Stdlib.Random
-
 (** Agent Health — Keeper outcome observation.
 
     Wraps Failure_observation with agent-name semantics for Keeper Heartbeat.

--- a/lib/health.mli
+++ b/lib/health.mli
@@ -1,21 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-module Random = Stdlib.Random
-
 (** Agent Health — Keeper outcome observation.
 
     Wraps {!Failure_observation} with agent-name semantics for Keeper

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -1,10 +1,3 @@
-module Option = Stdlib.Option
-module Sys = Stdlib.Sys
-module List = Stdlib.List
-module String = Stdlib.String
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Runtime operations used by the keeper MCP tool surface. *)
 open Tool_args
 open Keeper_types

--- a/lib/keeper_tool_surfaces.ml
+++ b/lib/keeper_tool_surfaces.ml
@@ -1,21 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-module Random = Stdlib.Random
-
 (** Keeper_tool_surfaces — lightweight internal tool surface definitions.
 
     This module stays dependency-light so spawned agents can share

--- a/lib/keeper_tool_surfaces.mli
+++ b/lib/keeper_tool_surfaces.mli
@@ -1,21 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-module Random = Stdlib.Random
-
 (** Keeper_tool_surfaces — lightweight internal tool surface
     definitions.
 

--- a/lib/mcp_tool_runtime.ml
+++ b/lib/mcp_tool_runtime.ml
@@ -1,21 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
-
 (** Mcp_tool_runtime — MCP server-local tool runtime.
 
     Delegates to sub-modules:

--- a/lib/mcp_tool_runtime_board.ml
+++ b/lib/mcp_tool_runtime_board.ml
@@ -1,21 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
-
 (** Mcp_tool_runtime_board — MCP server-local board tool runtime
     (recall, board, conversation).
     Returns [Some (Tool_result.result)] if handled, [None] otherwise.

--- a/lib/mcp_tool_runtime_comm.ml
+++ b/lib/mcp_tool_runtime_comm.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Mcp_tool_runtime_comm — communication tool handlers.
 
     Handles: masc_broadcast, masc_messages.

--- a/lib/mcp_tool_runtime_types.ml
+++ b/lib/mcp_tool_runtime_types.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Mcp_tool_runtime_types — shared types for MCP server-local tool modules.
 
     Extracted to avoid circular dependencies between

--- a/lib/mcp_tool_runtime_workspace.ml
+++ b/lib/mcp_tool_runtime_workspace.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Mcp_tool_runtime_workspace — project startup tool handler.
 
     Handles: masc_start.

--- a/lib/metrics_store_eio.ml
+++ b/lib/metrics_store_eio.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** MASC Metrics Store - Agent Performance Tracking (Eio Native)
 
     Pure synchronous metrics operations.

--- a/lib/operator/operator_tool.ml
+++ b/lib/operator/operator_tool.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 open Masc_domain
 open Tool_args
 

--- a/lib/reputation.ml
+++ b/lib/reputation.ml
@@ -1,21 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-module Random = Stdlib.Random
-
 (** Reputation — Reputation scoring from existing JSONL data
 
     Computes agent reputation from task transitions, mention inbox,

--- a/lib/reputation.mli
+++ b/lib/reputation.mli
@@ -1,21 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-module Random = Stdlib.Random
-
 (** Reputation — Reputation scoring from existing JSONL data
 
     Computes agent reputation from task transitions, mention inbox,

--- a/lib/task/tool_task_handlers.ml
+++ b/lib/task/tool_task_handlers.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 module Workspace = Workspace_core
 
 (** Tool_task - Core task CRUD operations

--- a/lib/task/tool_task_schemas.ml
+++ b/lib/task/tool_task_schemas.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Tool_task_schemas — JSON schema definitions for task tools.
 
     Pure data module containing MCP tool schemas for all task operations.

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Tool_catalog — Visibility metadata for MCP tools.
 
     Central registry for tool access control:

--- a/lib/tool/tool_dispatch.ml
+++ b/lib/tool/tool_dispatch.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Central Tool Dispatch Registry.
 
     Production MCP tool names route through {!Tool_name} and the module-tag

--- a/lib/tool/tool_name.ml
+++ b/lib/tool/tool_name.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Tool_name — Compile-time verified tool identifiers.
 
     Replaces stringly-typed tool dispatch with exhaustive variant matching.

--- a/lib/tool/tool_registry.ml
+++ b/lib/tool/tool_registry.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Tool Registry - In-memory call counters and usage statistics
 
     Provides fast O(1) in-memory tracking of tool call frequency.

--- a/lib/tool/tool_token.ml
+++ b/lib/tool/tool_token.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Tool_token — parse-once proof that a tool name exists in a dispatch table.
 
     See [tool_token.mli] for API documentation. *)

--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Tool_agent - Agent management, metrics, and capability discovery handlers *)
 
 open Tool_args

--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Tool_agent_timeline - Unified agent activity timeline.
 
     Collects events from multiple data sources and merges them into

--- a/lib/tool_assignment_telemetry.ml
+++ b/lib/tool_assignment_telemetry.ml
@@ -1,21 +1,3 @@
-module Random = Stdlib.Random
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Tool_assignment_telemetry — Unified tool assignment lifecycle events
 
     See .mli for design rationale and public API. *)

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -1,19 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** OAS boundary adapter for tool results, schemas, and tool definitions.
 
     MASC dispatch uses typed [Tool_result.result] internally.  This module is the

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 include Tool_call_quality_benchmark_types
 
 let default_case_set_path = Tool_call_quality_benchmark_loader.default_case_set_path

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_evidence_quality.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_evidence_quality.ml
@@ -1,7 +1,3 @@
-module Hashtbl = Stdlib.Hashtbl
-module List = Stdlib.List
-module String = Stdlib.String
-
 open Tool_call_quality_benchmark_types
 
 let semantic_selectors (benchmark_case : benchmark_case) =

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 open Tool_call_quality_benchmark_types
 
 let default_case_set_path ~repo_root =

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_render.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_render.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 open Tool_call_quality_benchmark_types
 
 let case_score_to_yojson (score : case_score) =

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_scoring.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_scoring.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 open Tool_call_quality_benchmark_types
 
 let avg_float values =

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_summary.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_summary.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 open Tool_call_quality_benchmark_types
 
 let avg_float values =

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_types.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_types.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 type case_category =
   | Tool_use
   | Tool_forbidden

--- a/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Tool_catalog_surfaces — Canonical per-surface tool name lists.
 
     SSOT for tool surface membership. All other modules should derive their

--- a/lib/tool_control.ml
+++ b/lib/tool_control.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Tool_control - Flow control operations
 
     Handles: pause, pause_status, resume

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Tool_input_validation — Pre-dispatch validation via OAS Tool_middleware.
 
     Delegates to [Agent_sdk.Tool_middleware.make_validation_hook] for strict

--- a/lib/tool_library.ml
+++ b/lib/tool_library.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Tool_library - Agent Knowledge Library operations
 
     Manages the personal knowledge base at [<base>/docs/library/]

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Tool_local_runtime_bench -- concurrency benchmark against runtime pool. *)
 
 include Tool_local_runtime_http

--- a/lib/tool_local_runtime_core.ml
+++ b/lib/tool_local_runtime_core.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Tool_local_runtime core — types, helpers, process discovery, model fetching. *)
 
 type tool_result = Tool_result.result

--- a/lib/tool_local_runtime_http.ml
+++ b/lib/tool_local_runtime_http.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Tool_local_runtime_http -- HTTP helpers for local runtime probing. *)
 
 let default_timeout_sec = 10

--- a/lib/tool_local_runtime_probe.ml
+++ b/lib/tool_local_runtime_probe.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Tool_local_runtime_probe -- native Ollama timing and warm-state diagnostics. *)
 
 include Tool_local_runtime_http

--- a/lib/tool_local_runtime_status.ml
+++ b/lib/tool_local_runtime_status.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Tool_local_runtime_status -- runtime pool status reporting. *)
 
 include Tool_local_runtime_core

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Tool_local_runtime_verify -- runtime contract verification. *)
 
 module Oas_types = Agent_sdk.Types

--- a/lib/tool_metrics_persist.ml
+++ b/lib/tool_metrics_persist.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Tool_metrics_persist — JSONL disk persistence for tool metrics.
 
     Uses {!Dated_jsonl} for date-split storage under

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Tool_misc — Miscellaneous operations (facade).
 
     Dispatches config introspection and tool inventory helpers to

--- a/lib/tool_misc_introspection.ml
+++ b/lib/tool_misc_introspection.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Tool_misc_introspection — config and tool inventory handlers.
 
     Extracted from tool_misc.ml to reduce god file size.

--- a/lib/tool_misc_web_fetch.ml
+++ b/lib/tool_misc_web_fetch.ml
@@ -1,19 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 open Tool_args
 
 let default_timeout_sec = 15

--- a/lib/tool_misc_web_search.ml
+++ b/lib/tool_misc_web_search.ml
@@ -1,19 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 open Tool_args
 
 type normalized_hit = {

--- a/lib/tool_plan.ml
+++ b/lib/tool_plan.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Plan Tool Handlers
 
     Extracted from mcp_server_eio.ml for testability.

--- a/lib/tool_run.ml
+++ b/lib/tool_run.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Run Tool Handlers
 
     Extracted from mcp_server_eio.ml for testability.

--- a/lib/tool_surface/tool_call_replay_harness.ml
+++ b/lib/tool_surface/tool_call_replay_harness.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 type tool_call = {
   name : string;
   arguments : Yojson.Safe.t;

--- a/lib/tool_surface/tool_help_registry.ml
+++ b/lib/tool_surface/tool_help_registry.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Canonical MCP tool help content.
 
     The MCP schema description should stay short and discovery-oriented.

--- a/lib/tool_surface/tool_metrics.ml
+++ b/lib/tool_surface/tool_metrics.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 module StringMap = Set_util.StringMap
 
 (** Per-tool timing metrics *)

--- a/lib/tool_surface/tool_schema_dsl.ml
+++ b/lib/tool_surface/tool_schema_dsl.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Tool_schema_dsl — shared JSON Schema builder helpers for MCP tool definitions.
 
     Reduces per-property boilerplate from ~5 lines of raw Yojson.Safe.t

--- a/lib/tool_surface/tool_spec.ml
+++ b/lib/tool_surface/tool_spec.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Tool_spec — Unified tool specification with compile-time safety.
 
     See [tool_spec.mli] for documentation.

--- a/lib/tool_types/tool_args.ml
+++ b/lib/tool_types/tool_args.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Tool_args -- Tool-convention argument extraction wrappers over Safe_ops.
 
     All tool_*.ml files should [open Tool_args] instead of defining local helpers.

--- a/lib/tool_types/tool_result.ml
+++ b/lib/tool_types/tool_result.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Structured tool result type for MASC. *)
 
 type tool_failure_class =

--- a/lib/tool_types/tool_shard_limits.ml
+++ b/lib/tool_types/tool_shard_limits.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** SSOT constants for tool schemas and runtime handlers that would
     otherwise form a dependency cycle (Tool_shard ↔ Keeper_tool_filesystem_runtime).
 

--- a/lib/tool_unified.ml
+++ b/lib/tool_unified.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Tool_unified — Unified query interface across catalog, registry, and dispatch.
 
     Combines:

--- a/lib/tool_usage_log.ml
+++ b/lib/tool_usage_log.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 module StringMap = Set_util.StringMap
 
 (** Tool_usage_log -- Durable call logging for non-public registered tools.

--- a/lib/tool_workspace.ml
+++ b/lib/tool_workspace.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Tool_workspace - Workspace management operations
     Handles: status, init, check
     Note: stateful workspace helpers remain in server dispatch modules

--- a/lib/workspace_assertions.ml
+++ b/lib/workspace_assertions.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Workspace_assertions - State inspection and assertion-based verification *)
 
 open Masc_domain

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Workspace_goals - Handlers for goal management tools. *)
 
 open Workspace_types

--- a/lib/workspace_status_rendering.ml
+++ b/lib/workspace_status_rendering.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Workspace_status_rendering - Logic for masc_status rendering *)
 
 open Masc_domain

--- a/lib/workspace_types.ml
+++ b/lib/workspace_types.ml
@@ -1,20 +1,3 @@
-module Format = Stdlib.Format
-module Map = Stdlib.Map
-module Set = Stdlib.Set
-module Queue = Stdlib.Queue
-module Hashtbl = Stdlib.Hashtbl
-module Mutex = Stdlib.Mutex
-module Option = Stdlib.Option
-module Result = Stdlib.Result
-module Sys = Stdlib.Sys
-module Filename = Stdlib.Filename
-module List = Stdlib.List
-module Array = Stdlib.Array
-module String = Stdlib.String
-module Char = Stdlib.Char
-module Int = Stdlib.Int
-module Float = Stdlib.Float
-
 (** Workspace_types - Shared types for workspace modules *)
 
 type context =

--- a/scripts/base-policy-audit.sh
+++ b/scripts/base-policy-audit.sh
@@ -88,28 +88,20 @@ count_mli_open_base() {
 
 # Number of .ml files in lib/ that contain both an actual "open Base"
 # directive and the Stdlib-shadow anti-pattern.
+# Counted on the shadow block alone, not on files that also carry
+# `open Base`. Requiring both meant the counter read zero the moment the
+# opens were removed, while 82 files kept the block the policy calls an
+# anti-pattern — the residue was invisible to its own audit.
 count_ml_base_stdlib_shadow() {
-  local count=0
-  while IFS= read -r file; do
-    if rg -q "$STDLIB_LIST_SHADOW_RE" "$file" 2>/dev/null; then
-      count=$((count + 1))
-    fi
-  done < <(rg -l "$OPEN_BASE_DIRECTIVE_RE" lib/ -g '*.ml' 2>/dev/null)
-  printf '%s' "$count"
+  { rg -l "$STDLIB_LIST_SHADOW_RE" lib/ -g '*.ml' 2>/dev/null || true; } | wc -l | tr -d ' '
 }
 
 count_bin_ml_base_stdlib_shadow() {
-  local count=0
   if [ ! -d bin ]; then
     printf '0'
     return
   fi
-  while IFS= read -r file; do
-    if rg -q "$STDLIB_LIST_SHADOW_RE" "$file" 2>/dev/null; then
-      count=$((count + 1))
-    fi
-  done < <(rg -l "$OPEN_BASE_DIRECTIVE_RE" bin/ -g '*.ml' 2>/dev/null)
-  printf '%s' "$count"
+  { rg -l "$STDLIB_LIST_SHADOW_RE" bin/ -g '*.ml' 2>/dev/null || true; } | wc -l | tr -d ' '
 }
 
 # Read a single numeric key from a JSON baseline file.


### PR DESCRIPTION
## 문제

`lib/` 과 `bin/` 의 82개 파일이 파일 맨 앞에 stdlib 재바인딩 서문을 들고 있다.

```ocaml
module Format = Stdlib.Format
module Map = Stdlib.Map
module Set = Stdlib.Set
module Queue = Stdlib.Queue
module Hashtbl = Stdlib.Hashtbl
...                                  (* 파일당 최대 16줄 *)
```

`docs/BASE-POLICY.md` 가 이 형태를 **명시적 안티패턴**으로 규정한다.

> It is **NOT** acceptable to write:
> ```
> (* anti-pattern: open Base then immediately shadow everything back *)
> open Base
> module List   = Stdlib.List
> ...
> ```
> This pattern provides no benefit: Base was opened only to be un-opened
> for the most commonly used modules. Replace it with no `open` at all.

그 문서의 Before/After 예시(`tool_compact.ml`)가 이 PR 의 변경과 같은 모양이다.

## 되돌릴 대상이 이미 없다

```
$ rg -c '^open Base\b' lib bin --glob '!_build'
0
```

`open Base` 는 한 파일도 남아 있지 않다. 즉 서문은 **가리는 대상이 사라진 뒤 남은 되돌리기**다. 저장소에 `Map`/`Set`/`Format` 등을 가리는 자체 모듈도 없다 (`find lib -name 'map.ml'` … 전부 없음).

서문이 `open` 보다 앞에 있다는 점도 같은 결론을 가리킨다 — OCaml 은 나중 `open` 이 앞선 바인딩을 가리므로, 이 위치의 별칭은 이후 `open` 을 막지 못한다.

## 컴파일러 판정

82개 파일에서 1355줄을 지우고 빌드했다.

```
dune build --root . @check   → 0   (에러 0)
```

처음에는 `.ml` 만 지워 5개 모듈이 인터페이스 불일치로 깨졌다 — `.mli` 에도 같은 서문이 있었기 때문이다 (`health`, `client_identity`, `client_registry_eio`, `keeper_tool_surfaces` 외 1). 양쪽을 지우니 통과한다.

## 검증

```
dune build --root . @check                        → 0
@runtest-test_mcp_error_code / test_trajectory
  / test_tui_decode / test_json_field             → 11 / 43 / 22 / 14 전부 통과
감사 스크립트 9종                                   → 통과
ocamlformat (변경 파일 표본 12개)                   → OK
```

`base` 라이브러리 의존은 dune 8곳에 남아 있다. 실제로 `Base.*` 를 한정 접근으로 쓰는 코드가 있을 수 있어 의존은 건드리지 않았다 — 이 PR 은 서문만 걷는다.

발견 경위: warning 60 (unused-module) 853건의 정체를 확인하다 발견. 그 경고는 파일당 16줄 서문 중 그 파일에서 안 쓰이는 것들을 세고 있었다.
