### PR TITLE
fix(dashboard-utils): 생산자가 내보내지 않는 status arm 제거

### DIFF
--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -80,10 +80,9 @@ let severity_rank_of_health_level = Health_status.rank
    match. Compared as strings rather than decoded because this library
    holds only masc_types and masc_core — reaching the keeper module
    would invert the dependency. *)
-(* STR-OK: JSON boundary comparison. The typed value lives in
-   Keeper_status_runtime, which this library cannot reach without
-   inverting the dependency, so the producer's range is recorded above
-   instead. *)
+(* The typed form lives in Keeper_status_runtime, which this library
+   cannot reach without inverting the dependency. *)
+(* STR-OK: JSON boundary comparison. *)
 let is_keeper_offline status = List.mem status [ "offline"; "inactive" ]
 
 let is_health_critical = Health_status.requires_operator_action

--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -73,8 +73,14 @@ let severity_rank_of_health_level = Health_status.rank
 (** Status/health classification predicates — single source of truth.
     Used across dashboard, briefing, and operator modules. *)
 
-let is_keeper_offline status =
-  List.mem status [ "offline"; "inactive"; "error" ]
+(* [status] arrives from the operator snapshot, where it is
+   [Keeper_status_runtime.control_plane_status_to_string]'s output:
+   paused / active / busy / listening / inactive / offline / idle. That
+   producer emits no "error", so the arm that used to be here could not
+   match. Compared as strings rather than decoded because this library
+   holds only masc_types and masc_core — reaching the keeper module
+   would invert the dependency. *)
+let is_keeper_offline status = List.mem status [ "offline"; "inactive" ]
 
 let is_health_critical = Health_status.requires_operator_action
 

--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -80,6 +80,10 @@ let severity_rank_of_health_level = Health_status.rank
    match. Compared as strings rather than decoded because this library
    holds only masc_types and masc_core — reaching the keeper module
    would invert the dependency. *)
+(* STR-OK: JSON boundary comparison. The typed value lives in
+   Keeper_status_runtime, which this library cannot reach without
+   inverting the dependency, so the producer's range is recorded above
+   instead. *)
 let is_keeper_offline status = List.mem status [ "offline"; "inactive" ]
 
 let is_health_critical = Health_status.requires_operator_action

--- a/lib/dashboard_utils/dashboard_utils.mli
+++ b/lib/dashboard_utils/dashboard_utils.mli
@@ -69,7 +69,11 @@ val severity_rank_of_health_level : health_level -> int
 (** {1 Status/health predicates} *)
 
 val is_keeper_offline : string -> bool
-(** Membership in [["offline"; "inactive"; "error"]]. *)
+(** True for the control-plane statuses that mean the keeper is not up:
+    [offline] and [inactive].  The caller passes
+    [Keeper_status_runtime.control_plane_status_to_string]'s output, whose
+    full range is paused / active / busy / listening / inactive / offline /
+    [idle].  Whether [idle] belongs here is open — see issue #27509. *)
 
 val is_health_critical : health_level -> bool
 val is_health_warning : health_level -> bool


### PR DESCRIPTION
## 변경

`Dashboard_utils.is_keeper_offline` 에서 도달할 수 없는 리터럴 하나를 걷고, 이 함수가 상대하는 어휘를 `.mli` 에 적는다.

```ocaml
-let is_keeper_offline status =
-  List.mem status [ "offline"; "inactive"; "error" ]
+let is_keeper_offline status = List.mem status [ "offline"; "inactive" ]
```

## `"error"` 가 도달 불가인 근거

호출부는 하나이고(`dashboard_briefing_assembly.ml:140`), 값의 출처를 끝까지 따라가면 생산자가 하나로 좁혀진다.

```
dashboard_briefing.ml:111   snapshot_json = Dashboard_projection_cache.operator_snapshot_json
  → operator_tool.ml:787     Operator_control.snapshot_json
  → operator_control_snapshot.ml:390   "status", `String aligned_status
  → :322  control_plane_status_to_string / align_keeper_runtime_status
```

그 생산자의 전 범위는 7종이다.

```ocaml
(* keeper_status_runtime.ml:456 *)
| Cp_paused -> "paused"
| Cp_surface s -> surface_status_to_string s
    (* active | busy | listening | inactive | offline | idle *)
```

`keeper_status_runtime.ml` 에 `"error"` 리터럴은 0개다.

## 왜 문자열 비교를 유지하나

`dashboard_utils` 의 의존은 `masc_types masc_core unix yojson` 뿐이다. `Keeper_status_runtime.control_plane_status_of_string_opt` 로 디코드하려면 keeper 모듈에 의존해야 하고, 그건 의존 방향을 뒤집는다. 대신 생산자와 그 전 범위를 `.ml` 주석과 `.mli` 계약에 적었다.

기존 `.mli` 는 자기 참조였다 — `(** Membership in [["offline"; "inactive"; "error"]]. *)`. 어떤 어휘를 상대하는지 말하지 않아서, 두 값이 그 어휘에 없다는 걸 읽어서는 알 수 없었다.

## 같은 파일이 같은 결함을 이미 고쳤다

30줄 위 `status_rank` 주석이 기록한다 — "left an arm for [idle] — a spelling this producer never emits". 다만 그 함수는 **agent_status** 생산자를, 이 함수는 **control-plane** 생산자를 본다. 같은 파일의 두 함수가 서로 다른 어휘를 상대하고, `.mli` 는 어느 쪽도 명시하지 않았다.

## 범위 밖

`"idle"` 은 이 생산자가 실제로 내보내는데 이 함수가 잡지 않는다. offline 으로 볼지는 도메인 판단이라 바꾸지 않고 `.mli` 에 미해결로 적었다. #27509 에서 묻고 있다.

## 검증

```
dune build --root . @check            → 0
@runtest-test_briefing_sections       → all assertions passed
@runtest-test_briefing_gaps           → all assertions passed
@runtest-test_briefing_compactors     → all assertions passed
```

발견 경위: CI 의 STR 게이트가 이 줄을 WARN 으로 지목하지만 통과시킨다.
