### PR TITLE
refactor(keeper): 같은 enum 의 문자열화 함수 두 벌을 하나로

### DIFF
--- a/lib/keeper/keeper_paused_work_cancellation_transaction.ml
+++ b/lib/keeper/keeper_paused_work_cancellation_transaction.ml
@@ -59,13 +59,6 @@ let failure_to_string = function
   | Queue_commit_failed detail -> "accepted cancellation commit failed: " ^ detail
 ;;
 
-let release_outcome_to_string = function
-  | Keeper_lifecycle_reservation.Released -> "released"
-  | Keeper_lifecycle_reservation.Release_missing -> "release_missing"
-  | Keeper_lifecycle_reservation.Release_not_owner owner ->
-    "release_not_owner: " ^ Keeper_lifecycle_reservation.snapshot_to_string owner
-;;
-
 let error_to_string = function
   | Admission_busy block ->
     Printf.sprintf
@@ -81,7 +74,7 @@ let error_to_string = function
        Printf.sprintf
          "%s; reservation_release=%s"
          (failure_to_string cause)
-         (release_outcome_to_string release))
+         (Keeper_lifecycle_reservation.release_outcome_to_string release))
 ;;
 
 let cancellation_of_pending_request (request : pending_request) :
@@ -207,7 +200,7 @@ let cancel_with_lifecycle
             Log.Keeper.error
               "paused cancellation exception release failed keeper=%s outcome=%s"
               keeper_name
-              (release_outcome_to_string release));
+              (Keeper_lifecycle_reservation.release_outcome_to_string release));
          raise exn)
   in
   match replay_committed ~base_path ~keeper_name replay with

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -116,12 +116,6 @@ let stimulus_id_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
          ])
 ;;
 
-let urgency_to_string = function
-  | Keeper_event_queue.Immediate -> "immediate"
-  | Normal -> "normal"
-  | Low -> "low"
-;;
-
 let store_dir ~masc_root ~keeper_name =
   Filename.concat
     (Filename.concat
@@ -244,7 +238,7 @@ let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
              [ "kind", `String (stimulus_kind_to_string kind)
              ; "source", `String "keeper_event_queue"
              ; "post_id", `String stimulus.post_id
-             ; "urgency", `String (urgency_to_string stimulus.urgency)
+             ; "urgency", `String (Keeper_event_queue.urgency_to_string stimulus.urgency)
              ; "arrived_at_unix", `Float stimulus.arrived_at
              ; "board_updated_at_unix", Json_util.option_to_yojson (fun value -> `Float value) board_updated_at
              ; "payload_preview", `String (stimulus_payload_preview stimulus.payload)


### PR DESCRIPTION
## 변경

같은 타입을 문자열화하는 함수가 두 벌 있었다. 사본을 지우고 정본을 부른다.

```ocaml
(* keeper_reaction_ledger.ml:119 — 제거 *)
let urgency_to_string = function
  | Keeper_event_queue.Immediate -> "immediate"
  | Normal -> "normal"
  | Low -> "low"
```

```ocaml
(* keeper_reaction_ledger.ml:247 *)
-  "urgency", `String (urgency_to_string stimulus.urgency)
+  "urgency", `String (Keeper_event_queue.urgency_to_string stimulus.urgency)
```

## 근거

타입은 하나다 — 사본도 `Keeper_event_queue.Immediate` 를 명시해 같은 variant 를 쓴다. 별개 enum 이 아니라 **같은 enum 에 대한 두 번째 문자열화**다.

정본은 이미 공개돼 있다.

```ocaml
(* keeper_event_queue.mli:310 *)
val urgency_to_string : urgency -> string
```

사본은 외부 참조가 0이고 자기 파일 안 한 곳에서만 쓰였다.

```
Keeper_event_queue.urgency_to_string     참조 4
Keeper_reaction_ledger.urgency_to_string 참조 0
```

두 벌이 지금은 같은 세 문자열을 내지만, 한쪽만 바뀌면 같은 필드가 두 값을 갖게 된다. `"urgency"` 는 와이어로 나가는 필드다.

## 검증

정본의 `Low` 를 `"PROBE_low"` 로 훼손하고 빌드했다. `keeper_reaction_ledger.ml` 에는 그 문자열이 나타나지 않는다 — 리터럴을 들고 있지 않고 정본을 경유한다는 뜻이다. 되돌린 뒤:

```
dune build --root . @check              → 0
@runtest-test_keeper_reaction_ledger    → 19 tests, Successful
ocamlformat                             → OK
```

`@runtest-test_keeper_event_queue` 는 `FAIL meta version conflict ...` 한 줄을 내지만 `origin/main` 기준으로도 동일하다 — 이 PR 과 무관한 기존 상태다.

발견 경위: 대시보드의 문자열 멤버십 비교를 서버 어휘와 대조하던 중 `urgency` 를 확인(서버 3종 = 클라이언트 3종, 드리프트 없음). 그 과정에서 서버 쪽 함수가 두 벌인 것이 드러났다.
