### PR TITLE
test(dashboard): keeper 오프라인 어휘 미러 테스트, 생산자가 없는 항목 제거

### DIFF
--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -73,8 +73,14 @@ let severity_rank_of_health_level = Health_status.rank
 (** Status/health classification predicates — single source of truth.
     Used across dashboard, briefing, and operator modules. *)
 
-let is_keeper_offline status =
-  List.mem status [ "offline"; "inactive"; "error" ]
+(* masc_dashboard_utils cannot depend on the library that owns
+   [Keeper_status_runtime.surface_status], so this vocabulary is hand-mirrored
+   from the strings that type renders. Exposed so a test can compare the two
+   across the boundary -- the same shape [valid_assertion_strings] uses for
+   masc_check's enum. *)
+let keeper_offline_status_strings = [ "offline"; "inactive" ]
+
+let is_keeper_offline status = List.mem status keeper_offline_status_strings
 
 let is_health_critical = Health_status.requires_operator_action
 

--- a/lib/dashboard_utils/dashboard_utils.mli
+++ b/lib/dashboard_utils/dashboard_utils.mli
@@ -68,8 +68,14 @@ val severity_rank_of_health_level : health_level -> int
 
 (** {1 Status/health predicates} *)
 
+val keeper_offline_status_strings : string list
+(** The statuses {!is_keeper_offline} treats as offline, hand-mirrored across
+    the library boundary from [Keeper_status_runtime.surface_status_to_string].
+    Exposed so a test can check every entry is a status some producer can
+    actually emit. *)
+
 val is_keeper_offline : string -> bool
-(** Membership in [["offline"; "inactive"; "error"]]. *)
+(** Membership in {!keeper_offline_status_strings}. *)
 
 val is_health_critical : health_level -> bool
 val is_health_warning : health_level -> bool

--- a/test/dune
+++ b/test/dune
@@ -900,7 +900,7 @@
 (test
  (name test_health_status)
  (modules test_health_status)
- (libraries alcotest masc.masc_types masc.dashboard_utils))
+ (libraries alcotest masc masc.masc_types masc.dashboard_utils))
 
 (test
  (name test_time_codec)

--- a/test/test_health_status.ml
+++ b/test/test_health_status.ml
@@ -54,6 +54,47 @@ let test_serialized_agent_status_ranks_through_the_wire () =
     Masc_domain.all_agent_statuses;
   check int "a non-status string ranks 0" 0 (Dashboard_utils.status_rank "idle")
 
+(* [Dashboard_utils.keeper_offline_status_strings] is hand-mirrored: the
+   masc_dashboard_utils library cannot depend on the one that owns
+   [Keeper_status_runtime.surface_status], so the offline vocabulary is a
+   literal list there. This is the mirror test for it, the same role
+   test_assertion_kind_mirror plays for masc_check's enum.
+
+   Subset, not equality — offline-ness is a proper subset of the statuses a
+   producer can emit. What it catches is the other direction: an entry no
+   producer can ever produce, which reads as coverage and is dead. *)
+let producible_keeper_statuses =
+  List.map
+    Masc.Keeper_status_runtime.surface_status_to_string
+    [ Masc.Keeper_status_runtime.Surface_active
+    ; Masc.Keeper_status_runtime.Surface_busy
+    ; Masc.Keeper_status_runtime.Surface_listening
+    ; Masc.Keeper_status_runtime.Surface_inactive
+    ; Masc.Keeper_status_runtime.Surface_offline
+    ; Masc.Keeper_status_runtime.Surface_idle
+    ]
+  @ [ Masc.Keeper_status_runtime.control_plane_status_to_string
+        Masc.Keeper_status_runtime.Cp_paused
+    ]
+
+let test_offline_vocabulary_is_producible () =
+  List.iter
+    (fun entry ->
+      check bool
+        (Printf.sprintf "%S is a status some producer emits" entry)
+        true
+        (List.mem entry producible_keeper_statuses))
+    Dashboard_utils.keeper_offline_status_strings
+
+let test_offline_predicate_agrees_with_its_vocabulary () =
+  List.iter
+    (fun status ->
+      check bool
+        (Printf.sprintf "is_keeper_offline %S" status)
+        (List.mem status Dashboard_utils.keeper_offline_status_strings)
+        (Dashboard_utils.is_keeper_offline status))
+    producible_keeper_statuses
+
 let () =
   run "Health_status"
     [
@@ -71,5 +112,12 @@ let () =
         [
           test_case "serialized status ranks through the wire" `Quick
             test_serialized_agent_status_ranks_through_the_wire;
+        ] );
+      ( "keeper offline vocabulary",
+        [
+          test_case "every entry is producible" `Quick
+            test_offline_vocabulary_is_producible;
+          test_case "predicate agrees with its vocabulary" `Quick
+            test_offline_predicate_agrees_with_its_vocabulary;
         ] );
     ]


### PR DESCRIPTION
`Dashboard_utils.is_keeper_offline` 이 리터럴 목록 소속으로 오프라인 여부를 정했다:

```ocaml
List.mem status [ "offline"; "inactive"; "error" ]
```

## 생산자 어휘를 전수했다

`keepers.items[].status` 는 `Keeper_status_runtime` 이 쓴다. 가질 수 있는 값은 **정확히 일곱**이다:

| 출처 | 값 |
|---|---|
| `surface_status_to_string` | `active` · `busy` · `listening` · `inactive` · `offline` · `idle` |
| `control_plane_status_to_string Cp_paused` | `paused` |

**`"error"` 는 그중에 없다.** 어떤 생산자도 내보낼 수 없으므로 이 항목은 한 번도 매치된 적이 없다 — 존재하지 않는 상태를 덮는 것처럼 읽힌다. 제거했다.

**`"paused"` 는 생산되지만 일부러 넣지 않았다.** 일시정지는 선택된 상태이고 오프라인은 아니다. 유일한 소비자(`dashboard_briefing_assembly` 의 `pressure_rank`)가 일시정지 keeper 를 압력으로 순위 매기면 안 된다. 그대로 뒀다.

## 하드코딩은 강제된 것이다 — 그래서 미러 테스트

`masc_dashboard_utils` 의 의존은 `masc_types masc_core unix yojson` 뿐이라 `surface_status` 를 소유한 라이브러리에 **도달할 수 없다.** 목록이 리터럴인 것은 선택이 아니라 경계 때문이다.

이 저장소에는 그 상황의 답이 이미 있다 — **`test_assertion_kind_mirror`** 가 `masc_check` 가 발행하는 enum 을 `valid_assertion_strings` 와 대조한다. 여기엔 그런 테스트가 없었고, 그래서 `"error"` 가 눈에 띄지 않은 채 남아 있었다.

어휘를 `keeper_offline_status_strings` 로 노출하고 `test_health_status` 가 경계를 가로질러 비교하게 했다:

- 모든 항목이 생산 가능한 문자열인가 (**`"error"` 에서 실패하는 쪽**)
- 술어가 자기 어휘와 일치하는가 (생산 가능한 일곱 전부에 대해)

**부분집합이지 동등이 아니다.** 오프라인은 생산 가능한 상태의 진부분집합이므로 동등 검사는 틀린다. 부분집합 방향이 잡는 것이 정확히 죽은 항목이다.

## 검증 — 수정 전 목록으로 먼저 돌렸다

```
RUN(수정 전)=1
> [FAIL] keeper offline vocabulary 0 every entry is producible
  ASSERT "offline" is a status some producer emits
  ASSERT "inactive" is a status some producer emits
  ASSERT "error" is a status some producer emits
```

| 항목 | 결과 |
|---|---|
| `dune build --root . @check` | exit 0 |
| `test_health_status` | 7/7 |
| `test_dashboard_briefing` · `_sections` | exit 0 |
| `scripts/lint/*.sh` 전체 | exit 0 |
| `verify-test-registration.py` | exit 0 |
| `audit-ci-test-targets.sh` | exit 0 |
| `check-pr-hygiene.sh --base origin/main` | exit 0 |
| `audit-dead-surface.py --exports --ratchet` | at baseline |

`test_health_status` 의 dune libraries 에 `masc` 를 추가했다 — 미러의 양쪽이 필요하고, 이 파일이 이미 상태 어휘 계약을 소유한다.

**생산자가 낼 수 있는 모든 상태에 대해 동작은 그대로다.**

## 이 축에서 확인만 하고 넘어간 것

`List.mem <var> [ "리터럴" ... ]` 형태는 match arm 도 if 식도 아니라 이 세션의 이전 스윕이 모두 놓친 형태다. `lib/` 전체에서 **1 건**뿐이었고, 그게 이것이다.
