### PR TITLE
chore(tool-surface): 항상 빈 리스트만 반환할 수 있던 커버리지 검사 제거

### DIFF
--- a/lib/tool_surface/tool_spec.ml
+++ b/lib/tool_surface/tool_spec.ml
@@ -64,11 +64,10 @@ let to_tool_schema (spec : t) : Masc_domain.tool_schema =
     input_schema = spec.input_schema }
 
 (* ================================================================ *)
-(* Registration tracking (for verify_handler_coverage)              *)
+(* Registration tracking                                            *)
 (* ================================================================ *)
 
 let registered_names : (string, unit) Hashtbl.t = Hashtbl.create 256
-let expects_handler : (string, unit) Hashtbl.t = Hashtbl.create 256
 
 (* ================================================================ *)
 (* Registration                                                     *)
@@ -109,24 +108,11 @@ let register (spec : t) =
   (* 3. Handler binding — auto-register Direct/Shared into Tool_dispatch *)
   (match spec.handler_binding with
    | Direct h | Shared h ->
-     Tool_dispatch.register ~tool_name:spec.name ~handler:h;
-     Hashtbl.replace expects_handler spec.name ()
+     Tool_dispatch.register ~tool_name:spec.name ~handler:h
    | Tag_dispatch -> ())
 
 let register_all (specs : t list) =
   List.iter register specs
-
-(* ================================================================ *)
-(* Boot-time verification                                           *)
-(* ================================================================ *)
-
-let verify_handler_coverage () =
-  let missing = ref [] in
-  Hashtbl.iter (fun name () ->
-    if not (Tool_dispatch.is_registered name) then
-      missing := name :: !missing
-  ) expects_handler;
-  !missing
 
 let all_registered_names () =
   Hashtbl.fold (fun name () acc -> name :: acc) registered_names []

--- a/lib/tool_surface/tool_spec.mli
+++ b/lib/tool_surface/tool_spec.mli
@@ -89,12 +89,4 @@ val register_all : t list -> unit
 val to_tool_schema : t -> Masc_domain.tool_schema
 (** Convert to [Masc_domain.tool_schema] for interop with existing schema-based APIs. *)
 
-(** {1 Boot-time verification} *)
-
-val verify_handler_coverage : unit -> string list
-(** Returns tool names that were registered via [register] with [Direct] or
-    [Shared] binding but have no handler in [Tool_dispatch]. [Tag_dispatch]
-    bindings are excluded. Call after server initialization completes.
-    Empty list means full coverage. *)
-
 val all_registered_names : unit -> string list

--- a/test/test_tool_spec.ml
+++ b/test/test_tool_spec.ml
@@ -239,7 +239,7 @@ let () =
          refactor: it exercised the deleted [Tool_catalog.tool_group] display
          classifier (and was already failing on base — it asserted richer
          categories the classifier never produced). *)
-      ( "verify_handler_coverage",
+      ( "handler binding registers through Tool_dispatch",
         [
           test_case "Tag_dispatch binding not in verify missing" `Quick (fun () ->
             let spec =
@@ -253,9 +253,10 @@ let () =
             in
             register_test_metadata "__test_spec_tag_dispatch";
             Tool_spec.register spec;
-            let missing = Tool_spec.verify_handler_coverage () in
-            check bool "Tag_dispatch not in missing" false
-              (List.mem "__test_spec_tag_dispatch" missing));
+            (* Tag_dispatch routes through the module tag, so [register] must
+               not put a name in the handler registry. *)
+            check bool "Tag_dispatch registers no direct handler" false
+              (Tool_dispatch.is_registered "__test_spec_tag_dispatch"));
           test_case "Direct binding registers handler" `Quick (fun () ->
             let name = "__test_spec_direct_handler" in
             let spec =
@@ -270,9 +271,6 @@ let () =
             register_test_metadata name;
             Tool_spec.register spec;
             check bool "handler registered in Tool_dispatch" true
-              (Tool_dispatch.is_registered name);
-            let missing = Tool_spec.verify_handler_coverage () in
-            check bool "not in missing" false
-              (List.mem name missing));
+              (Tool_dispatch.is_registered name));
         ] );
     ]


### PR DESCRIPTION
`Tool_spec` 에 *"Boot-time verification"* 이라는 헤더가 붙은 절이 있었다:

```ocaml
let verify_handler_coverage () =
  let missing = ref [] in
  Hashtbl.iter (fun name () ->
    if not (Tool_dispatch.is_registered name) then
      missing := name :: !missing
  ) expects_handler;
  !missing
```

**부팅에서 호출되지 않는다.** 호출자는 테스트 둘뿐이다. 그것만으로도 껍데기지만, 순회하는 테이블을 보면 더 약하다.

## 구조적으로 빈 리스트만 반환한다

`expects_handler` 가 채워지는 곳은 정확히 하나다:

```ocaml
| Direct h | Shared h ->
  Tool_dispatch.register ~tool_name:spec.name ~handler:h;
  Hashtbl.replace expects_handler spec.name ()
| Tag_dispatch -> ()
```

- 이름이 테이블에 들어가는 것은 **바로 윗줄에서 `Tool_dispatch.register` 가 성공한 뒤**다. 그 함수는 락 아래 `Hashtbl.replace` 라 실패하지 않는다.
- **빠질 수 있는 쪽인 `Tag_dispatch` 는 테이블에 아예 안 들어간다.** `.mli` 도 그렇게 적고 있었다 — *"[Tag_dispatch] bindings are excluded"*.

따라서 `missing` 은 항상 `[]` 였다. 두 테스트 중 첫 번째는 *"Tag_dispatch 스펙이 `missing` 에 없다"* 를 단언했는데, Tag_dispatch 스펙은 테이블에 들어간 적이 없으므로 **동작이 아니라 구조 때문에 통과**했다.

## 그 계약은 이미, 더 강하게 강제된다

`test_tool_registry_consistency` 가 `assert_same_set` 으로 비교한다:

```ocaml
~label:"tag_registry vs schema_registry"
~expected:(Tool_dispatch.all_registered_names ())
~actual:(Tool_dispatch.all_schema_names ())
```

`init_unified_tool_registry` 로 조립된 **실제 레지스트리**에 대한 **집합 동등**이다. 선언됐는데 핸들러 없는 도구도, 핸들러는 있는데 스키마가 없는 것도 잡고, 양방향 모두 CI 를 빨갛게 만든다.

CLAUDE.md 기준(*"Gate 로 얻는 이득이 압도적으로 분명하지 않다면 해당 Gate 는 숙청 대상"*)에서, 발화할 수 없는 약한 중복은 배선할 대상이 아니라 지울 대상이다.

## 변경

`verify_handler_coverage` · 그 `val` · `expects_handler` 테이블 · 채우는 줄을 제거했다.

테스트 둘은 의도를 유지하고 레지스트리를 직접 검사한다:

- **Tag_dispatch 는 직접 핸들러를 등록하지 않는다** — `is_registered name = false`. 옛 단언이 대신 서 있던 실제 사실이다.
- **Direct 바인딩은 핸들러를 등록한다** — `is_registered name = true`. 그 테스트는 이미 이걸 단언한 뒤 커버리지 목록으로 한 번 더 확인하고 있었다.

| 항목 | 결과 |
|---|---|
| `dune build --root . @check` | exit 0 |
| `test_tool_spec` | 14/14 |
| `test_tool_registry_consistency` | exit 0 |
| `test_tool_dispatch` | exit 0 |
| `scripts/lint/*.sh` 전체 | exit 0 |
| `verify-test-registration.py` | exit 0 |
| `check-pr-hygiene.sh --base origin/main` | exit 0 |
| `audit-dead-surface.py --exports --ratchet` | at baseline |

**기존 실패 구분**: `test_tool_workspace_coverage` 가 이 워크트리에서 실패한다. **main 에서도 동일하게 실패**하고 여기서 제거한 것을 참조하지 않으므로 기존 것이다.

## 어떻게 발견했나

CLAUDE.md 의 *"MCP tool dispatch: match 패턴 사용, dict/map 라우팅 금지"* 를 근거로 문자열 키 핸들러 테이블을 찾다가 `Tool_dispatch.registry` 에 도달했다. 동적 레지스트리 자체는 MCP 서버 구조상 정당하고, **완전성 가드가 있는지**가 관건이었다. 가드는 있었고(`test_tool_registry_consistency`), 그 옆에 발화할 수 없는 두 번째 가드가 함께 있었다.
