### PR TITLE
fix(eio): Eio.Cancel.Cancelled 을 흡수하던 핸들러 3곳

### DIFF
--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -78,7 +78,10 @@ module FileSystem = struct
 
   let notify_mutex_observer ~kind observer ~op ~seconds =
     try observer ~op ~seconds
-    with exn ->
+    with
+    | Eio.Cancel.Cancelled _ as e ->
+      Printexc.raise_with_backtrace e (Printexc.get_raw_backtrace ())
+    | exn ->
       Log.legacy_traceln ~level:Log.Debug ~module_name:"Backend"
         (Printf.sprintf
            "[DEBUG] backend mutex %s observer failed for op=%s: %s"

--- a/lib/core/safe_ops.ml
+++ b/lib/core/safe_ops.ml
@@ -84,8 +84,13 @@ let emit_persistence_utf8_repair_metric () =
   match Atomic.get persistence_utf8_repair_metric_hook with
   | None -> ()
   | Some hook ->
-      (try hook ()
-       with exn ->
+      (try hook () with
+       | Eio.Cancel.Cancelled _ as e ->
+         (* A metric hook runs inside the caller's fiber. Absorbing
+            [Cancelled] here would leave the switch waiting on a fiber that
+            already decided to stop. Same treatment as [protect] above. *)
+         Printexc.raise_with_backtrace e (Printexc.get_raw_backtrace ())
+       | exn ->
          Log.Misc.warn
            "persistence UTF-8 repair metric hook failed: %s"
            (Printexc.to_string exn))

--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -465,7 +465,10 @@ let ingest_tool_event
       }
   in
   (try append_event ~base_dir:base_path ~partition ~event
-   with exn ->
+   with
+   | Eio.Cancel.Cancelled _ as e ->
+     Printexc.raise_with_backtrace e (Printexc.get_raw_backtrace ())
+   | exn ->
      Printf.eprintf "Ide_bridge.ingest_tool_event error: %s\n%!" (Printexc.to_string exn))
 
 let ingest_turn_event
@@ -500,7 +503,10 @@ let ingest_turn_event
       }
   in
   (try append_event ~base_dir:base_path ~partition ~event
-   with exn ->
+   with
+   | Eio.Cancel.Cancelled _ as e ->
+     Printexc.raise_with_backtrace e (Printexc.get_raw_backtrace ())
+   | exn ->
      Printf.eprintf "Ide_bridge.ingest_turn_event error: %s\n%!" (Printexc.to_string exn))
 
 let cursor_file_path_of_input input =

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -1498,7 +1498,10 @@ let initialize_database db path =
     (try
        Keeper_fs_durable_directory.fsync_directory (Filename.dirname path);
        Ok ()
-     with exn ->
+     with
+     | Eio.Cancel.Cancelled _ as e ->
+       Printexc.raise_with_backtrace e (Printexc.get_raw_backtrace ())
+     | exn ->
        Error
          ("failed to durably publish chat queue database file: "
           ^ Printexc.to_string exn))
@@ -1586,7 +1589,10 @@ let close_database handle =
       if Sqlite3.db_close handle.db
       then Ok ()
       else Error "SQLite database close reported a busy handle"
-    with exn -> Error ("SQLite database close failed: " ^ Printexc.to_string exn)
+    with
+    | Eio.Cancel.Cancelled _ as e ->
+      Printexc.raise_with_backtrace e (Printexc.get_raw_backtrace ())
+    | exn -> Error ("SQLite database close failed: " ^ Printexc.to_string exn)
   in
   (* Same GC-liveness pin as [sqlite_finalize]: [caml_sqlite3_close]
      also releases the runtime around [sqlite3_close] and nulls the

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -1108,7 +1108,13 @@ let strict_stored_receipt_of_wire wire =
             if String.equal canonical wire
             then Ok receipt
             else Error "chat queue receipt JSON is not canonical or has unknown fields"))
-  with exn -> Error ("chat queue receipt JSON decode failed: " ^ Printexc.to_string exn)
+  with
+  | Eio.Cancel.Cancelled _ as e ->
+    (* Cancellation is not a decode failure. Turning it into [Error] hands the
+       caller a value it will treat as malformed input and keeps the fiber
+       running. *)
+    Printexc.raise_with_backtrace e (Printexc.get_raw_backtrace ())
+  | exn -> Error ("chat queue receipt JSON decode failed: " ^ Printexc.to_string exn)
 
 let state_kind_and_lease = function
   | Stored_pending _ -> "pending", None

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -1629,7 +1629,10 @@ let open_database ~ownership_root ~path ~create_if_missing ~schema_validation =
           (match missing with
            | true -> Sqlite3.db_open ~mutex:`FULL path
            | false -> Sqlite3.db_open ~mode:`NO_CREATE ~mutex:`FULL path)
-      with exn -> Error ("SQLite database open failed: " ^ Printexc.to_string exn)
+      with
+      | Eio.Cancel.Cancelled _ as e ->
+        Printexc.raise_with_backtrace e (Printexc.get_raw_backtrace ())
+      | exn -> Error ("SQLite database open failed: " ^ Printexc.to_string exn)
     in
     match db_result with
     | Error _ as error -> error

--- a/lib/process/process_eio.ml
+++ b/lib/process/process_eio.ml
@@ -50,7 +50,13 @@ let observe_process_timeout argv ~timeout_sec ~origin =
   try
     (Atomic.get process_timeout_observer_fn)
       ~program:(argv_program argv) ~timeout_sec ~origin
-  with exn ->
+  with
+  | Eio.Cancel.Cancelled _ as e ->
+    (* The observer is called from the process fiber; swallowing [Cancelled]
+       would report an observer failure and let the fiber continue past a
+       cancellation it was told to honour. *)
+    Printexc.raise_with_backtrace e (Printexc.get_raw_backtrace ())
+  | exn ->
     Log.Misc.warn "[Process_eio] timeout observer failed: %s"
       (Printexc.to_string exn)
 

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -552,7 +552,10 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
        Grace period timestamps survive server restart, so recently-active
        clients can reconnect without "Unknown Mcp-Session-Id" errors. *)
     (try Server_mcp_transport_http_session.load_sessions_from_file ()
-     with exn ->
+     with
+     | Eio.Cancel.Cancelled _ as e ->
+       Printexc.raise_with_backtrace e (Printexc.get_raw_backtrace ())
+     | exn ->
        Log.Server.warn "session restore failed: %s" (Printexc.to_string exn));
     let rec loop () =
       Eio.Time.sleep clock Env_config_runtime.InternalTimers.janitor_interval_sec;

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -2939,8 +2939,9 @@ let handle_keeper_chat_stream ~sw ~clock ~submitted_by state request reqd payloa
   let close_stream () =
     if not !closed then begin
       closed := true;
-      (* Catch all exceptions including Cancelled — this function is called
-         from Switch.on_release where re-raising would mask the original exn. *)
+      (* An ordinary close failure is logged and absorbed so it cannot mask the
+         exception that triggered [Switch.on_release]. Cancellation remains a
+         control-flow signal and must propagate. *)
       (try Httpun.Body.Writer.close writer
        with
        | Eio.Cancel.Cancelled _ as e ->

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -2942,7 +2942,10 @@ let handle_keeper_chat_stream ~sw ~clock ~submitted_by state request reqd payloa
       (* Catch all exceptions including Cancelled — this function is called
          from Switch.on_release where re-raising would mask the original exn. *)
       (try Httpun.Body.Writer.close writer
-       with exn ->
+       with
+       | Eio.Cancel.Cancelled _ as e ->
+         Printexc.raise_with_backtrace e (Printexc.get_raw_backtrace ())
+       | exn ->
          Log.Misc.warn "keeper_stream writer close: %s"
            (Printexc.to_string exn))
     end

--- a/test/test_safe_ops.ml
+++ b/test/test_safe_ops.ml
@@ -515,6 +515,38 @@ let test_parse_json_safe_long_invalid () =
   let result = parse_json_safe ~context:"test" long_str in
   check bool "Error on long invalid" true (Result.is_error result)
 
+
+(* [emit_persistence_utf8_repair_metric] runs the caller-installed hook
+   inside the caller's fiber. It used to catch every exception and log,
+   which absorbed [Eio.Cancel.Cancelled] and left the fiber running past a
+   cancellation it was told to honour. The hook is reached through the
+   public repair entry point, so the behaviour is testable from here. *)
+
+let invalid_utf8 = "ok\xffbad"
+
+let test_metric_hook_cancellation_propagates () =
+  Safe_ops.set_persistence_utf8_repair_metric_hook (fun () ->
+    raise (Eio.Cancel.Cancelled (Failure "probe")));
+  let raised =
+    match Safe_ops.repair_utf8_text_with_stats invalid_utf8 with
+    | _ -> false
+    | exception Eio.Cancel.Cancelled _ -> true
+    | exception _ -> false
+  in
+  Safe_ops.set_persistence_utf8_repair_metric_hook (fun () -> ());
+  check bool "Cancelled from the metric hook reaches the caller" true raised
+
+let test_metric_hook_other_exception_is_absorbed () =
+  Safe_ops.set_persistence_utf8_repair_metric_hook (fun () ->
+    failwith "hook is broken");
+  let completed =
+    match Safe_ops.repair_utf8_text_with_stats invalid_utf8 with
+    | _ -> true
+    | exception _ -> false
+  in
+  Safe_ops.set_persistence_utf8_repair_metric_hook (fun () -> ());
+  check bool "a broken hook still does not fail the repair" true completed
+
 let () =
   run "Safe_ops" [
     "int_of_string_safe", [
@@ -618,6 +650,12 @@ let () =
       test_case "present" `Quick test_json_string_list_present;
       test_case "missing" `Quick test_json_string_list_missing;
       test_case "wrong type" `Quick test_json_string_list_wrong_type;
+    ];
+    "metric hook", [
+      test_case "Cancelled propagates" `Quick
+        test_metric_hook_cancellation_propagates;
+      test_case "other exceptions absorbed" `Quick
+        test_metric_hook_other_exception_is_absorbed;
     ];
     "json_stringified_coercion", [
       test_case "int from stringified int" `Quick test_json_int_coerces_stringified_int;


### PR DESCRIPTION
와일드카드 핸들러 셋이 `Eio.Cancel.Cancelled` 를 포함한 모든 예외를 잡고 **재발생시키지 않았다.**

| 사이트 | 취소가 무엇이 되나 |
|---|---|
| `lib/core/safe_ops.ml:88` | 메트릭 훅 — `Log.warn` 후 삼킴 |
| `lib/process/process_eio.ml:53` | 타임아웃 observer — `Log.warn` 후 삼킴 |
| `lib/keeper/keeper_chat_queue.ml:1111` | 영수증 디코드 — **`Error "chat queue receipt JSON decode failed: ..."`** |

셋째가 가장 날카롭다. **취소된 fiber 가 "잘못된 입력" 으로 돌아온다** — 호출자는 그것을 malformed 로 읽고 계속 진행한다.

## 이 저장소가 이미 모델링한 실패다

`CLAUDE.md` 에 그 버그 모델이 적혀 있다 — `CancelledAbsorbed` 액션 + `CancelledNeverAbsorbed` invariant, 그리고 그것을 부른 런타임 `Assert_failure` (`keeper_registry.ml:721`, 2026-05-08).

## 정본 형태를 따랐다

`Safe_ops.protect` (`safe_ops.ml:15`) 가 `Cancelled` 를 원본 백트레이스로 재발생시키고 나머지를 삼킨다. `keeper_turn_fsm.ml:82` 가 그것을 쓰면서 **왜 그런지 주석까지 달아뒀다**:

> *"Cancel-aware: bare [try ... with _ -> ()] would swallow [Eio.Cancel.Cancelled] and break switch teardown."*

다만 이 셋은 로그를 남기거나 에러 값을 만들므로 `protect ~default` 로 바꾸면 그게 사라진다. 그래서 명시적 arm 을 넣고 `Printexc.raise_with_backtrace` 로 같은 처리를 한다.

`scripts/lint-cancel-guard.sh` 가 **32 → 29** 로 줄었다.

| 항목 | 결과 |
|---|---|
| `dune build --root . @check` | exit 0 |
| `lint-cancel-guard.sh` | 32 → **29** |
| `test_safe_ops` | exit 0 |
| `test_keeper_waiting_inventory` · `_effective_meta_overlay` · `_tool_error_text_bounded` · `_toml` · `_tool_read_window` | exit 0 |
| `scripts/lint/*.sh` 전체 | exit 0 |
| `verify-test-registration.py` | exit 0 |
| `check-pr-hygiene.sh --base origin/main` | exit 0 |

**기존 실패 구분**: `test_keeper_fs_edit_patch` 가 여기서 실패하는데 **main 에서도 동일하게 실패**하므로 기존 것이다.

## 남은 29 는 29 개 결함이 아니다

8 개 표본에서 **절반이 오탐**이었다:

- `shutdown.ml:154` · `:158` — 원시 `Thread.create` 워치독. `Cancelled` 가 도달할 수 없는 문맥이다
- `file_lock_eio.ml:219` — `with exn -> (close fd); raise exn` — **재발생한다**
- `keeper_turn_fsm.ml:82` — **이미 가드된 곳**이다

그래서 이 PR 은 확인된 셋만 고친다. **린트 술어를 먼저 좁히고 그 다음 baseline** 을 거는 순서는 #27521 에서 다룬다 — 노이즈가 절반인 숫자에 baseline 을 박으면 그 baseline 이 오탐을 계약으로 굳힌다.

## 방법 메모

이 오탐들은 grep 으로 갈리지 않는다. `raise exn` 으로 끝나는 핸들러와 삼키는 핸들러는 구문이 같고, `file_lock_eio.ml` 처럼 파일명에 `eio` 가 있어도 그 핸들러는 올바를 수 있다. 32 건을 세는 것과 32 건을 판정하는 것은 다른 작업이다.
