### PR TITLE
test(workspace): fix the last false assertion and wire the suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -921,7 +921,8 @@ jobs:
             @test/runtest-test_tool_spec \
             @test/runtest-test_tool_shard_coverage \
             @test/runtest-test_tool_board_coverage \
-            @test/runtest-test_tool_task_coverage
+            @test/runtest-test_tool_task_coverage \
+            @test/runtest-test_tool_workspace_coverage
 
       - name: Run completion-authority lookup surface suite
         # The judge's lookup tools reach the filesystem and Git inside a

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -76,7 +76,7 @@ echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, al
 # #27433 and #27441 each wired a suite test/dune already declared without
 # lowering this number. Measured on the merged tree after all four, not
 # computed -- #27441 landed between this branch's first push and now.
-UNWIRED_BASELINE=708
+UNWIRED_BASELINE=707
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/test/test_tool_workspace_coverage.ml
+++ b/test/test_tool_workspace_coverage.ml
@@ -262,14 +262,26 @@ let snapshot_revision result =
   Tool_result.data result |> Yojson.Safe.Util.member "revision" |> Yojson.Safe.Util.to_string
 ;;
 
+(* This asserted that masc_status initializes the workspace, and raised
+   "MASC not initialized" instead. Initializing is masc_start's job: no tool in
+   Tool_workspace calls Workspace.init, and status_summary_string opens with
+   ensure_initialized, which is the contract refusing to invent a workspace as
+   a side effect of a read.
+
+   So the name described a behaviour that never existed. What is worth pinning
+   is the refusal itself, and that the read leaves nothing behind. *)
 let () =
-  test "dispatch_status_initializes_before_revision" (fun () ->
+  test "dispatch_status_refuses an uninitialized workspace" (fun () ->
     let ctx = make_test_ctx () in
-    match Tool_workspace.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
-    | Some result ->
-      assert (Tool_result.is_success result);
-      assert (Sys.file_exists (Workspace_utils_paths_backend.state_path ctx.config))
-    | None -> failwith "dispatch returned None")
+    let raised =
+      match Tool_workspace.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
+      | (_ : Tool_result.result option) -> false
+      | exception Workspace.Not_initialized -> true
+    in
+    assert raised;
+    (* A read that refuses must not have created the state it was refusing to
+       read. *)
+    assert (not (Sys.file_exists (Workspace_utils_paths_backend.state_path ctx.config))))
 ;;
 
 let () =


### PR DESCRIPTION
Closes #27426.

## The sequence

`test_tool_workspace_coverage` has **never run in CI**. #27426 found five
failures in it. #27493 closed four — stale assertions about the
`valid_next_actions` hint. This is the fifth, and then the wiring.

The order matters: an unwired suite's assertions can outlive the code they pin,
which is exactly how five of them got there.

## The fifth failure

`dispatch_status_initializes_before_revision` asserted that `masc_status`
initializes the workspace. It raised `MASC not initialized` instead.

Initializing is `masc_start`'s job:

```
rg 'Workspace.init' lib/tool_workspace.ml     → no match
status_summary_string                         → opens with ensure_initialized
```

That is the contract refusing to invent a workspace as a side effect of a read.
So the test name described a behaviour that **never existed** — the code is
right and the assertion was wrong.

Rewritten to pin what is actually true: the refusal, and that the read leaves no
state file behind. A read that refuses must not create what it was refusing to
read.

## Wiring

Added beside `test_tool_task_coverage` and `test_tool_board_coverage`, which
cover the sibling surfaces.

```
scripts/audit-ci-test-targets.sh
  146 CI targets, all declared in test/dune
  707 suites unwired (was 708) — UNWIRED_BASELINE lowered to hold it
```

## Verification

```
dune build --root . @check                                        exit 0
dune build --root . @fmt            no diff in any file this PR touches
scripts/audit-ci-test-targets.sh                     both checks OK

test_tool_workspace_coverage      37 tests run   Successful   (was 1 failure)
test_tool_task_coverage           98 tests run   Successful
test_tool_board_coverage          78 tests run   Successful
```

No library change: this PR is one test, one CI step, one baseline.

RFC-WAIVED: a false assertion corrected against the contract it misread, and
the suite that carried it put under CI.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>