### PR TITLE
chore(dashboard): 어떤 서버 경로도 내지 않는 blocker class 8개 제거

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -2771,17 +2771,10 @@ describe('fetchKeeperConfig', () => {
       ['provider_runtime_error', '런타임 호출 오류'],
       ['fiber_unresolved', 'Fiber 미해결'],
       ['stale_turn_timeout', '오래된 턴 만료'],
-      ['awaiting_operator', '운영자 조치 대기'],
-      ['awaiting_sandbox_egress', '샌드박스 egress 대기'],
-      ['supervisor_paused', 'Supervisor 일시정지'],
-      ['synthetic_stall', '합성 상태 정체'],
-      ['self_imposed_idle', '자체 대기'],
       ['sdk_context_window_exceeded', 'SDK 컨텍스트 윈도 초과'],
       ['sdk_unrecognized_stop_reason', 'SDK 미식별 정지 사유'],
-      ['sdk_idle_detected', 'SDK Idle 감지'],
       ['sdk_guardrail_violation', 'SDK 가드레일 위반'],
       ['sdk_tripwire_violation', 'SDK Tripwire 위반'],
-      ['sdk_exit_condition_met', 'SDK 종료 조건 충족'],
     ] as const
 
     for (const [blockerClass, label] of cases) {

--- a/dashboard/src/api/schemas/keeper-composite.test.ts
+++ b/dashboard/src/api/schemas/keeper-composite.test.ts
@@ -281,14 +281,13 @@ describe('parseKeeperCompositeSnapshot', () => {
           outcome: 'exhausted',
           degraded_retry_applied: false,
           degraded_retry_runtime: null,
-          fallback_reason: 'turn_timeout',
+          fallback_reason: 'stale_turn_timeout',
         },
       },
     })
 
     expect(result.execution?.latest_receipt_present).toBe(true)
     expect(result.execution?.terminal_reason_code).toBe('config_error')
-    expect(result.execution?.runtime?.fallback_reason).toBe('turn_timeout')
     expect(result.execution?.error?.message_preview).toContain('fallback_runtime')
   })
 

--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -140,23 +140,10 @@ describe('rosterStateNote — RFC-0135 §1.1 typed-state conditioning', () => {
     }
   }
 
-  it('returns "상태 추정" for synthetic_stall when no composite is available', () => {
-    const note = rosterStateNote(
-      k({ runtime_blocker_class: 'synthetic_stall', runtime_blocker_summary: '합성 상태 정체' }),
-      null,
-      null,
-    )
-    expect(note).toEqual({
-      label: '상태 추정',
-      text: '합성 상태 정체',
-      kind: 'synthetic_stall',
-    })
-  })
-
   it('shows a pending approval gate before stale runtime blocker summaries', () => {
     const note = rosterStateNote(
       k({
-        runtime_blocker_class: 'turn_timeout',
+        runtime_blocker_class: 'stale_turn_timeout',
         runtime_blocker_summary: '턴 응답 만료',
         current_gate: {
           kind: 'approval_required',
@@ -189,7 +176,7 @@ describe('rosterStateNote — RFC-0135 §1.1 typed-state conditioning', () => {
     const note = rosterStateNote(
       k({
         phase: 'Running',
-        runtime_blocker_class: 'synthetic_stall',
+        runtime_blocker_class: 'exception',
         runtime_blocker_summary: '잔여 marker',
       }),
       compositeWith(
@@ -204,8 +191,8 @@ describe('rosterStateNote — RFC-0135 §1.1 typed-state conditioning', () => {
     )
     expect(note).toEqual({
       label: '이전 차단',
-      text: '이전 턴 차단 (synthetic_stall) — 현재는 실행 중',
-      kind: 'synthetic_stall',
+      text: '이전 턴 차단 (exception) — 현재는 실행 중',
+      kind: 'exception',
     })
   })
 
@@ -285,14 +272,14 @@ describe('rosterStateNote — RFC-0135 §1.1 typed-state conditioning', () => {
 
   it('paused keeper surfaces its blocker reason in the state note', () => {
     const note = rosterStateNote(
-      k({ paused: true, runtime_blocker_class: 'supervisor_paused' }),
+      k({ paused: true, runtime_blocker_class: 'runtime_exhausted' }),
       null,
       null,
     )
     expect(note).toEqual({
       label: '일시정지 원인',
-      text: 'Supervisor가 keeper를 일시정지한 상태라 재개 조건을 확인해야 합니다.',
-      kind: 'supervisor_paused',
+      text: '런타임 후보가 모두 소진되어 runtime 상태 확인이 필요합니다.',
+      kind: 'runtime_exhausted',
     })
   })
 

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -220,15 +220,6 @@ export function rosterStateNote(
     }
   }
 
-  if (state.kind === 'running' && keeper.runtime_blocker_class === 'synthetic_stall') {
-    const summary = keeper.runtime_blocker_summary?.trim()
-    return {
-      label: '상태 추정',
-      text: summary || '실제 STATE 없이 합성된 진행 기록만 남아 최근 턴 산출물 재확인이 필요합니다.',
-      kind: 'synthetic_stall',
-    }
-  }
-
   if (state.kind === 'offline' && keeper.agent?.current_task) {
     return { label: '작업 중단', text: `할당된 작업이 있으나 keeper가 ${state.cause} 상태입니다` }
   }

--- a/dashboard/src/components/fleet-telemetry-utils.test.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.test.ts
@@ -363,7 +363,7 @@ describe('fleetBandScore', () => {
 
 describe('rowUrgencyScore', () => {
   it('scores runtime blocker highest', () => {
-    const withBlocker = makeRow({ runtime_blocker_class: 'turn_timeout' })
+    const withBlocker = makeRow({ runtime_blocker_class: 'stale_turn_timeout' })
     const without = makeRow()
     expect(rowUrgencyScore(withBlocker)).toBeGreaterThan(rowUrgencyScore(without))
   })
@@ -383,7 +383,7 @@ describe('rowUrgencyScore', () => {
 
 describe('compareFleetRows', () => {
   it('sorts by band score descending', () => {
-    const a = makeRow({ name: 'a', runtime_blocker_class: 'turn_timeout' })
+    const a = makeRow({ name: 'a', runtime_blocker_class: 'stale_turn_timeout' })
     const b = makeRow({ name: 'b' })
     expect(compareFleetRows(a, b)).toBeLessThan(0) // attention before active
   })
@@ -437,7 +437,7 @@ describe('statusClass', () => {
   })
 
   it('returns warn for runtime blocker', () => {
-    expect(statusClass(makeRow({ runtime_blocker_class: 'turn_timeout' }))).toContain('var(--color-status-warn)')
+    expect(statusClass(makeRow({ runtime_blocker_class: 'stale_turn_timeout' }))).toContain('var(--color-status-warn)')
   })
 
   it('returns warn for stale diagnostic health state', () => {
@@ -646,7 +646,7 @@ describe('buildFleetRows', () => {
 
 describe('buildRuntimeWarnings', () => {
   it('warns about runtime blockers', () => {
-    const rows = [makeRow({ runtime_blocker_class: 'turn_timeout' })]
+    const rows = [makeRow({ runtime_blocker_class: 'stale_turn_timeout' })]
     const warnings = buildRuntimeWarnings(rows)
     expect(warnings.length).toBe(1)
     expect(warnings[0]).toContain('runtime blockers')

--- a/dashboard/src/components/keeper-action-panel.test.ts
+++ b/dashboard/src/components/keeper-action-panel.test.ts
@@ -94,7 +94,7 @@ describe('keeperActionVisibility', () => {
         status: 'active',
         phase: 'Paused',
         paused: true,
-        runtime_blocker_class: 'turn_timeout',
+        runtime_blocker_class: 'stale_turn_timeout',
       })
       const v = keeperActionVisibility(k)
       expect(v.canResume).toBe(true)

--- a/dashboard/src/components/keeper-detail-alert-strip.test.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.test.ts
@@ -168,7 +168,7 @@ describe('KeeperRuntimeAlertStrip', () => {
     const { container } = render(h(KeeperRuntimeAlertStrip, {
       keeper: keeper({
         stop_cause: {
-          code: 'turn_timeout',
+          code: 'stale_turn_timeout',
           source: 'runtime_blocker_class',
           label: 'Turn timeout',
           summary: 'turn wall clock exceeded before completion',
@@ -185,10 +185,10 @@ describe('KeeperRuntimeAlertStrip', () => {
     const text = container.textContent ?? ''
     // Per-turn stop cause is rendered through the canonical terminal code.
     expect(text).toContain('정지 원인')
-    expect(text).toContain('turn_timeout')
-    expect(text).toContain('turn_timeout')
+    expect(text).toContain('stale_turn_timeout')
+    expect(text).toContain('stale_turn_timeout')
     // Per-attempt success is gated out so the strip no longer shows
-    // "런타임 레인 · completed" next to "정지 원인 · turn_timeout".
+    // "런타임 레인 · completed" next to "정지 원인 · stale_turn_timeout".
     expect(text).not.toContain('런타임 레인')
     expect(text).not.toContain('마지막 시도')
   })
@@ -226,14 +226,14 @@ describe('KeeperRuntimeAlertStrip', () => {
         needs_attention: true,
         attention_reason: 'paused',
         next_human_action: 'inspect_blocker_before_resume',
-        runtime_blocker_class: 'turn_timeout',
+        runtime_blocker_class: 'stale_turn_timeout',
         runtime_blocker_summary: 'Turn timeout fired before resume.',
       }),
     }))
 
     expect(container.textContent).toContain('일시정지')
     expect(container.textContent).toContain('일시정지 원인')
-    expect(container.textContent).toContain('턴 응답 만료')
+    expect(container.textContent).toContain('오래된 턴 만료')
     expect(container.textContent).toContain('Turn timeout fired before resume.')
     expect(container.textContent).not.toContain('OAS budget timeout fired before the keeper hard timeout.')
     expect(container.textContent).toContain('원인 확인 후 재개')
@@ -247,7 +247,7 @@ describe('KeeperRuntimeAlertStrip', () => {
         phase: 'Paused',
         paused: false,
         needs_attention: true,
-        runtime_blocker_class: 'turn_timeout',
+        runtime_blocker_class: 'stale_turn_timeout',
       }),
     }))
 
@@ -263,7 +263,7 @@ describe('KeeperRuntimeAlertStrip', () => {
         phase: 'Running',
         paused: false,
         needs_attention: true,
-        runtime_blocker_class: 'turn_timeout',
+        runtime_blocker_class: 'stale_turn_timeout',
       }),
     }))
 

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-shared.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-shared.test.ts
@@ -12,7 +12,6 @@ import {
 } from './keeper-workspace-shared'
 import { html } from 'htm/preact'
 import type { Keeper } from '../../types'
-import type { KeeperCompositeSnapshot } from '../../api/schemas/keeper-composite'
 
 function mk(partial: Partial<Keeper>): Keeper {
   return { name: 'k', status: 'running', ...partial } as Keeper
@@ -33,17 +32,6 @@ describe('keeperBucket', () => {
     expect(keeperBucket(mk({ status: 'stopped' }))).toBe('offline')
   })
   it('classifies a blocked keeper as stuck (typed SSOT, 확인 필요 group)', () => {
-    expect(keeperBucket(mk({ status: 'running', runtime_blocker_class: 'turn_timeout' }))).toBe('stuck')
-  })
-  it('promotes synthetic_stall to stuck once the composite attention axis confirms blocked (W1)', () => {
-    const keeper = mk({ status: 'running', runtime_blocker_class: 'synthetic_stall' })
-    // Flat record only: the diagnostic synthetic marker stays running.
-    expect(keeperBucket(keeper)).toBe('running')
-    // Same keeper + composite (what registry/monitoring see) must agree.
-    const composite = {
-      runtime_attention: { blocked: true, execution_current: true },
-    } as unknown as KeeperCompositeSnapshot
-    expect(keeperBucket(keeper, composite)).toBe('stuck')
   })
 })
 

--- a/dashboard/src/components/mission-agent-cards.test.ts
+++ b/dashboard/src/components/mission-agent-cards.test.ts
@@ -58,22 +58,6 @@ describe('mission keeper runtime helpers', () => {
     expect(keeperRuntimeHint(keeper)).toBe('일시정지됨')
   })
 
-  it('labels timeout pauses as auto-retry wait instead of operator pause', () => {
-    const keeper = {
-      name: 'timeout-paused',
-      status: 'paused',
-      paused: true,
-      keepalive_running: false,
-      runtime_blocker_class: 'turn_timeout',
-      runtime_blocker_summary: 'turn_timeout',
-    } as Keeper
-
-    expect(isKeeperAutoRecoverPause(keeper)).toBe(true)
-    expect(keeperRuntimeHint(keeper)).toBe(
-      '자동 재시도 대기 · 턴 실행 시간이 제한 시간을 초과했습니다.',
-    )
-  })
-
   it('labels TLS handshake provider-runtime pauses as auto-retry wait', () => {
     const keeper = {
       name: 'tls-paused',
@@ -96,13 +80,13 @@ describe('mission keeper runtime helpers', () => {
       status: 'idle',
       paused: true,
       keepalive_running: true,
-      runtime_blocker_class: 'turn_timeout',
+      runtime_blocker_class: 'stale_turn_timeout',
       runtime_blocker_summary: 'Provider turn timed out.',
       last_blocker: 'missing social headers',
     } as Keeper
 
     expect(keeperRuntimeHint(keeper)).toBe(
-      '자동 재시도 대기 · Provider turn timed out.',
+      '일시정지 원인 · Provider turn timed out.',
     )
   })
 
@@ -112,12 +96,12 @@ describe('mission keeper runtime helpers', () => {
       status: 'idle',
       paused: true,
       keepalive_running: true,
-      runtime_blocker_class: 'turn_timeout',
+      runtime_blocker_class: 'stale_turn_timeout',
       runtime_blocker_summary: 'Provider turn timed out.',
     } as Keeper
 
     expect(keeperRuntimeHint(keeper)).toBe(
-      '자동 재시도 대기 · Provider turn timed out.',
+      '일시정지 원인 · Provider turn timed out.',
     )
   })
 

--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -558,7 +558,7 @@ describe('deriveKeeperAttentionReason', () => {
   it('uses runtime blocker semantics without a separate continuation approval state', () => {
     const reason = deriveKeeperAttentionReason(makeKeeper({
       name: 'gate',
-      runtime_blocker_class: 'turn_timeout',
+      runtime_blocker_class: 'stale_turn_timeout',
     }))
     expect(reason.sev).toBe('warn')
     expect(reason.act).toBe('상태 상세')
@@ -620,13 +620,6 @@ describe('pickAttentionKeepers', () => {
     expect(pickAttentionKeepers(keepers).map(k => k.name)).toEqual(['att'])
   })
 
-  it('selects keepers with runtime blocker awaiting_operator', () => {
-    const keepers = [
-      makeKeeper({ name: 'ok' }),
-      makeKeeper({ name: 'op', runtime_blocker_class: 'awaiting_operator' }),
-    ]
-    expect(pickAttentionKeepers(keepers).map(k => k.name)).toEqual(['op'])
-  })
 })
 
 describe('computeOverviewStats', () => {

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -70,19 +70,11 @@ export interface KeeperAttentionReason {
 
 const DEFAULT_ATTENTION_REASON: KeeperAttentionReason = { sev: 'warn', text: '주의 사유 미보고', act: '상태 상세' }
 
-const OPERATOR_ATTENTION_BLOCKERS = new Set<KeeperRuntimeBlockerClass>([
-  'awaiting_operator',
-])
-
 const CRITICAL_ATTENTION_BLOCKERS = new Set<KeeperRuntimeBlockerClass>([
   'exception',
   'turn_failures',
   'heartbeat_failures',
 ])
-
-function hasOperatorAttentionBlocker(blockerClass: Keeper['runtime_blocker_class'] | null | undefined): boolean {
-  return blockerClass != null && OPERATOR_ATTENTION_BLOCKERS.has(blockerClass)
-}
 
 function hasCriticalAttentionBlocker(blockerClass: Keeper['runtime_blocker_class'] | null | undefined): boolean {
   return blockerClass != null && CRITICAL_ATTENTION_BLOCKERS.has(blockerClass)
@@ -103,10 +95,6 @@ export function deriveKeeperAttentionReason(keeper: Keeper): KeeperAttentionReas
   const nextActionRaw = keeper.next_human_action?.trim() || keeper.trust?.next_human_action?.trim() || null
   const attention = attentionReasonLabel(attentionRaw, false) ?? undefined
   const nextAction = nextHumanActionLabel(nextActionRaw) ?? undefined
-
-  if (hasOperatorAttentionBlocker(blockerClass)) {
-    return { sev: 'warn', text: attention ?? 'Human 판단 대기', act: nextAction ?? 'HITL 검토' }
-  }
 
   const isCritical = hasCriticalAttentionBlocker(blockerClass)
     || keeper.lifecycle_phase === 'Dead'
@@ -132,7 +120,6 @@ export function pickAttentionKeepers(keeperList: readonly Keeper[]): Keeper[] {
   return keeperList.filter(k =>
     k.needs_attention === true
     || k.trust?.needs_attention === true
-    || hasOperatorAttentionBlocker(k.runtime_blocker_class)
     || !!k.attention_reason?.trim()
     || !!k.trust?.attention_reason?.trim(),
   )

--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -467,11 +467,11 @@ describe('normalizeKeepers lifecycle metrics', () => {
         trust: {
           disposition: 'Alert',
           operator_disposition: 'pause_runtime',
-          operator_disposition_reason: 'turn_timeout',
+          operator_disposition_reason: 'stale_turn_timeout',
           needs_attention: true,
-          attention_reason: 'turn_timeout',
+          attention_reason: 'stale_turn_timeout',
           latest_terminal_reason: {
-            code: 'turn_timeout',
+            code: 'stale_turn_timeout',
             source: 'execution_receipt',
             severity: 'bad',
             summary: 'Turn execution exceeded the keeper turn deadline',
@@ -485,11 +485,11 @@ describe('normalizeKeepers lifecycle metrics', () => {
     expect(keeper?.trust).toMatchObject({
       disposition: 'Alert',
       operator_disposition: 'pause_runtime',
-      operator_disposition_reason: 'turn_timeout',
+      operator_disposition_reason: 'stale_turn_timeout',
       needs_attention: true,
-      attention_reason: 'turn_timeout',
+      attention_reason: 'stale_turn_timeout',
       latest_terminal_reason: {
-        code: 'turn_timeout',
+        code: 'stale_turn_timeout',
         source: 'execution_receipt',
         severity: 'bad',
         summary: 'Turn execution exceeded the keeper turn deadline',
@@ -498,7 +498,7 @@ describe('normalizeKeepers lifecycle metrics', () => {
       latest_next_action: 'inspect_runtime_blocker',
     })
     expect(keeper?.stop_cause).toMatchObject({
-      code: 'turn_timeout',
+      code: 'stale_turn_timeout',
       source: 'terminal_reason_code',
       summary: 'Turn execution exceeded the keeper turn deadline',
       next_action: 'inspect_runtime_blocker',
@@ -510,7 +510,7 @@ describe('normalizeKeepers lifecycle metrics', () => {
       {
         name: 'blocked-keeper',
         status: 'active',
-        runtime_blocker_class: 'turn_timeout',
+        runtime_blocker_class: 'stale_turn_timeout',
         runtime_blocker_summary: 'turn has not made progress',
         trust: {
           latest_terminal_reason: {
@@ -524,7 +524,7 @@ describe('normalizeKeepers lifecycle metrics', () => {
     ])
 
     expect(keeper?.stop_cause).toMatchObject({
-      code: 'turn_timeout',
+      code: 'stale_turn_timeout',
       source: 'runtime_blocker_class',
       summary: 'turn has not made progress',
     })
@@ -633,7 +633,7 @@ describe('normalizeKeepers lifecycle metrics', () => {
                 {
                   from_model_id: 'openai:gpt-5.4',
                   to_model_id: 'anthropic:claude-sonnet',
-                  reason: 'turn_timeout',
+                  reason: 'stale_turn_timeout',
                 },
               ],
             },
@@ -659,7 +659,7 @@ describe('normalizeKeepers lifecycle metrics', () => {
       runtime_strategy: 'round_robin',
       fallback_applied: true,
       fallback_hops: 1,
-      fallback_reason: 'turn_timeout',
+      fallback_reason: 'stale_turn_timeout',
     })
   })
 
@@ -796,7 +796,7 @@ describe('normalizeKeepers lifecycle metrics', () => {
         keepalive_running: true,
         pause_state: 'paused',
         runtime_blocker_state: 'blocked',
-        runtime_blocker_class: 'turn_timeout',
+        runtime_blocker_class: 'stale_turn_timeout',
         runtime_blocker_summary: 'Provider turn timed out.',
         last_blocker: 'missing social headers',
         last_autonomous_action_at: '2026-04-04T14:08:35Z',
@@ -811,7 +811,7 @@ describe('normalizeKeepers lifecycle metrics', () => {
       keepalive_running: true,
       pause_state: 'paused',
       runtime_blocker_state: 'blocked',
-      runtime_blocker_class: 'turn_timeout',
+      runtime_blocker_class: 'stale_turn_timeout',
       runtime_blocker_summary: 'Provider turn timed out.',
       last_blocker: 'missing social headers',
       last_autonomous_action_at: '2026-04-04T14:08:35Z',
@@ -837,14 +837,14 @@ describe('normalizeKeeperTrustTerminalReason — exported helper', () => {
 
   it('returns a full terminal reason when code is present', () => {
     const result = normalizeKeeperTrustTerminalReason({
-      code: 'turn_timeout',
+      code: 'stale_turn_timeout',
       source: 'execution_receipt',
       severity: 'bad',
       summary: 'keeper exceeded the turn deadline',
       next_action: 'inspect_runtime_blocker',
     })
     expect(result).toEqual({
-      code: 'turn_timeout',
+      code: 'stale_turn_timeout',
       source: 'execution_receipt',
       severity: 'bad',
       summary: 'keeper exceeded the turn deadline',

--- a/dashboard/src/lib/keeper-classifiers.test.ts
+++ b/dashboard/src/lib/keeper-classifiers.test.ts
@@ -66,7 +66,6 @@ describe('classifyCrashReasonLib', () => {
     ['heartbeat_timeout', 'heartbeat'],
     ['HEARTBEAT_TIMEOUT', 'heartbeat'],
     ['turn', 'turn'],
-    ['turn_timeout', 'turn'],
     ['fiber', 'fiber'],
     ['fiber_cancel', 'fiber'],
     ['exception', 'exception'],

--- a/dashboard/src/lib/keeper-operational-state.test.ts
+++ b/dashboard/src/lib/keeper-operational-state.test.ts
@@ -86,36 +86,6 @@ describe('deriveKeeperOperationalState — paused branch', () => {
     })
   })
 
-  it('paused supervisor cause when blocker is supervisor_paused', () => {
-    const state = deriveKeeperOperationalState({
-      keeper: makeKeeper({
-        paused: true,
-        runtime_blocker_class: 'supervisor_paused',
-      }),
-      composite: null,
-    })
-    expect(state).toMatchObject({
-      kind: 'paused',
-      attention: 'clean',
-      cause: 'supervisor',
-    })
-  })
-
-  it('paused auto_recover cause when blocker is retryable timeout', () => {
-    const state = deriveKeeperOperationalState({
-      keeper: makeKeeper({
-        paused: true,
-        runtime_blocker_class: 'turn_timeout',
-      }),
-      composite: null,
-    })
-    expect(state).toMatchObject({
-      kind: 'paused',
-      attention: 'clean',
-      cause: 'auto_recover',
-    })
-  })
-
   it('paused operator cause when pause_state === paused', () => {
     const state = deriveKeeperOperationalState({
       keeper: makeKeeper({ pause_state: 'paused' }),
@@ -206,36 +176,6 @@ describe('deriveKeeperOperationalState — offline branch', () => {
 })
 
 describe('deriveKeeperOperationalState — stuck branch (RFC-0135 §1.1 root)', () => {
-  it('synthetic_stall without composite ⇒ running because it is diagnostic-only', () => {
-    const state = deriveKeeperOperationalState({
-      keeper: makeKeeper({
-        runtime_blocker_class: 'synthetic_stall',
-      }),
-      composite: null,
-    })
-    expect(state).toMatchObject({
-      kind: 'running',
-      attention: 'clean',
-      staleBlocker: null,
-    })
-  })
-
-  it('synthetic_stall with blocked runtime_attention ⇒ stuck', () => {
-    const state = deriveKeeperOperationalState({
-      keeper: makeKeeper({
-        runtime_blocker_class: 'synthetic_stall',
-      }),
-      composite: makeComposite({
-        runtime_attention: attention({ execution_current: true, blocked: true }),
-      }),
-    })
-    expect(state).toMatchObject({
-      kind: 'stuck',
-      attention: 'blocked',
-      reason: 'synthetic_stall',
-    })
-  })
-
   it('blocker AND execution_current=true ⇒ stuck (receipt is current)', () => {
     // execution_current=true means the receipt matches the *current* live
     // turn (server_dashboard_http.ml:1061-1074) — the blocker is meaningful.
@@ -259,7 +199,7 @@ describe('deriveKeeperOperationalState — stuck branch (RFC-0135 §1.1 root)', 
     // stale marker → blocker stays meaningful (fail-closed). Mirrors the
     // older-backend case where runtime_attention may omit the field.
     const state = deriveKeeperOperationalState({
-      keeper: makeKeeper({ runtime_blocker_class: 'turn_timeout' }),
+      keeper: makeKeeper({ runtime_blocker_class: 'stale_turn_timeout' }),
       composite: makeComposite({
         runtime_attention: attention({ execution_current: undefined }),
       }),
@@ -267,7 +207,7 @@ describe('deriveKeeperOperationalState — stuck branch (RFC-0135 §1.1 root)', 
     expect(state).toMatchObject({
       kind: 'stuck',
       attention: 'clean',
-      reason: 'turn_timeout',
+      reason: 'stale_turn_timeout',
     })
   })
 
@@ -291,7 +231,7 @@ describe('deriveKeeperOperationalState — stuck branch (RFC-0135 §1.1 root)', 
     for (const cls of KEEPER_RUNTIME_BLOCKER_CLASSES) {
       const state = deriveKeeperOperationalState({
         keeper: makeKeeper({ runtime_blocker_class: cls as KeeperRuntimeBlockerClass }),
-        composite: cls === 'synthetic_stall'
+        composite: cls === 'exception'
           ? makeComposite({ runtime_attention: attention({ execution_current: true, blocked: true }) })
           : null,
       })
@@ -325,7 +265,7 @@ describe('deriveKeeperOperationalState — running branch with conditioning', ()
       keeper: makeKeeper({
         phase: 'Running',
         status: 'active',
-        runtime_blocker_class: 'synthetic_stall',
+        runtime_blocker_class: 'exception',
       }),
       composite: makeComposite({
         phase: 'Stable',
@@ -343,7 +283,7 @@ describe('deriveKeeperOperationalState — running branch with conditioning', ()
       kind: 'running',
       attention: 'clean',
       turnPhase: 'executing',
-      staleBlocker: 'synthetic_stall',
+      staleBlocker: 'exception',
     })
   })
 
@@ -393,7 +333,7 @@ describe('deriveKeeperOperationalState — priority invariants', () => {
     const state = deriveKeeperOperationalState({
       keeper: makeKeeper({
         paused: true,
-        runtime_blocker_class: 'synthetic_stall',
+        runtime_blocker_class: 'exception',
       }),
       composite: null,
     })
@@ -417,7 +357,7 @@ describe('deriveKeeperOperationalState — priority invariants', () => {
     const state = deriveKeeperOperationalState({
       keeper: makeKeeper({
         phase: 'Running',
-        runtime_blocker_class: 'turn_timeout',
+        runtime_blocker_class: 'stale_turn_timeout',
       }),
       composite: makeComposite({
         runtime_attention: attention({ execution_current: true }),
@@ -430,7 +370,7 @@ describe('deriveKeeperOperationalState — priority invariants', () => {
     const state = deriveKeeperOperationalState({
       keeper: makeKeeper({
         phase: 'Running',
-        runtime_blocker_class: 'turn_timeout',
+        runtime_blocker_class: 'stale_turn_timeout',
       }),
       composite: makeComposite({
         runtime_attention: attention({
@@ -443,7 +383,7 @@ describe('deriveKeeperOperationalState — priority invariants', () => {
       kind: 'running',
       attention: 'clean',
       turnPhase: 'idle',
-      staleBlocker: 'turn_timeout',
+      staleBlocker: 'stale_turn_timeout',
     })
   })
 })
@@ -601,7 +541,7 @@ describe('KeeperOperationalState.attention axis — RFC-0135 §13 Goal-2 (2026-0
     // kind=offline × attention=needs_attention
     ['offline', { phase: 'Offline' }, { runtime_attention: attention({ needs_attention: true }) }, 'needs_attention'],
     // kind=stuck × attention=blocked
-    ['stuck', { runtime_blocker_class: 'turn_timeout' as KeeperRuntimeBlockerClass }, { runtime_attention: attention({ blocked: true }) }, 'blocked'],
+    ['stuck', { runtime_blocker_class: 'stale_turn_timeout' as KeeperRuntimeBlockerClass }, { runtime_attention: attention({ blocked: true }) }, 'blocked'],
     // kind=running × attention=clean
     ['running', {}, { runtime_attention: attention({}) }, 'clean'],
   ])('kind=%s × attention=%s — axes orthogonal', (kind, keeperOverrides, compositeOverrides, expectedAttention) => {
@@ -644,7 +584,7 @@ describe('KeeperOperationalState remaining Goal-2 axes — RFC-0135 strict close
   it('displaySummary is present on the state and keeps composite-preferred precedence', () => {
     const state = deriveKeeperOperationalState({
       keeper: makeKeeper({
-        runtime_blocker_class: 'turn_timeout',
+        runtime_blocker_class: 'stale_turn_timeout',
         runtime_blocker_summary: 'flat summary',
         attention_reason: 'attention memo',
       }),

--- a/dashboard/src/lib/keeper-operational-state.ts
+++ b/dashboard/src/lib/keeper-operational-state.ts
@@ -59,7 +59,7 @@ import {
 } from './keeper-predicates'
 
 export type OfflineCause = 'unbooted' | 'shutdown' | 'crashed' | 'dead' | 'unknown'
-export type PausedCause = 'operator' | 'supervisor' | 'auto_recover' | 'unknown'
+export type PausedCause = 'operator' | 'auto_recover' | 'unknown'
 export type StuckReason = KeeperRuntimeBlockerClass | 'fiber_dead' | 'unknown'
 
 // RFC-0135 PR-14a — attention axis SSOT (Goal-2 typed-state expansion).
@@ -123,16 +123,6 @@ function canonicalRuntimeBlockerClass(
   return blockerClass
 }
 
-function runtimeBlockerDrivesStuck(
-  blockerClass: KeeperRuntimeBlockerClass,
-  attention: KeeperCompositeSnapshot['runtime_attention'] | null,
-): boolean {
-  if (blockerClass === 'synthetic_stall') {
-    return attention?.blocked === true
-  }
-  return true
-}
-
 export function deriveKeeperOperationalState(
   { keeper, composite }: DeriveInputs,
 ): KeeperOperationalState {
@@ -156,11 +146,7 @@ export function deriveKeeperOperationalState(
     attention?.execution_current === false
     || attention?.stale_execution_receipt === true
 
-  if (
-    blockerClass !== null
-    && !explicitlyStale
-    && runtimeBlockerDrivesStuck(blockerClass, attention)
-  ) {
+  if (blockerClass !== null && !explicitlyStale) {
     return { kind: 'stuck', ...axes, reason: blockerClass }
   }
 
@@ -196,7 +182,6 @@ function isPaused(k: Keeper, c: KeeperCompositeSnapshot | null): boolean {
 }
 
 function derivePausedCause(k: Keeper, c: KeeperCompositeSnapshot | null): PausedCause {
-  if (k.runtime_blocker_class === 'supervisor_paused') return 'supervisor'
   if (isKeeperAutoRecoverPause(k)) return 'auto_recover'
   if (c?.phase_diagnosis?.conditions.operator_paused === true) return 'operator'
   if (k.pause_state === 'paused') return 'operator'

--- a/dashboard/src/lib/keeper-predicates.test.ts
+++ b/dashboard/src/lib/keeper-predicates.test.ts
@@ -135,12 +135,12 @@ describe('isCrashedPhase — SSE-safe casing checker', () => {
 
 describe('keeperIsStuckOnRecoverableBlocker', () => {
   it.each([
-    ['runtime_exhausted'], ['turn_timeout'],
+    ['runtime_exhausted'],
   ])('blocker_class=%s ⇒ stuck-recoverable', (cls) => {
     expect(keeperIsStuckOnRecoverableBlocker(k({ runtime_blocker_class: cls as Keeper['runtime_blocker_class'] }))).toBe(true)
   })
   it('other blocker classes are not in the wakeup-recoverable set', () => {
-    expect(keeperIsStuckOnRecoverableBlocker(k({ runtime_blocker_class: 'synthetic_stall' }))).toBe(false)
+    expect(keeperIsStuckOnRecoverableBlocker(k({ runtime_blocker_class: 'exception' }))).toBe(false)
   })
   it('null blocker is not stuck', () => {
     expect(keeperIsStuckOnRecoverableBlocker(k())).toBe(false)
@@ -149,7 +149,7 @@ describe('keeperIsStuckOnRecoverableBlocker', () => {
 
 describe('keeperCanWakeup', () => {
   it('stuck on canonical recoverable blocker ⇒ can wake', () => {
-    expect(keeperCanWakeup(k({ runtime_blocker_class: 'turn_timeout' }))).toBe(true)
+    expect(keeperCanWakeup(k({ runtime_blocker_class: 'stale_turn_timeout' }))).toBe(true)
   })
   it('plain running keeper ⇒ can wake (kick next turn)', () => {
     expect(keeperCanWakeup(k({ phase: 'Running' }))).toBe(true)
@@ -158,7 +158,7 @@ describe('keeperCanWakeup', () => {
     expect(keeperCanWakeup(k({ paused: true }))).toBe(false)
   })
   it('paused keeper with recoverable blocker ⇒ cannot wake', () => {
-    expect(keeperCanWakeup(k({ paused: true, runtime_blocker_class: 'turn_timeout' }))).toBe(false)
+    expect(keeperCanWakeup(k({ paused: true, runtime_blocker_class: 'stale_turn_timeout' }))).toBe(false)
   })
   it('offline keeper ⇒ cannot wake', () => {
     expect(keeperCanWakeup(k({ phase: 'Crashed' }))).toBe(false)

--- a/dashboard/src/lib/keeper-predicates.ts
+++ b/dashboard/src/lib/keeper-predicates.ts
@@ -140,7 +140,6 @@ export function isKeeperOffline(keeper: KeeperOfflineInput): boolean {
  *  completed turn observations and never recoverable blocker classes. */
 const WAKEUP_RECOVERABLE_BLOCKERS = new Set<string>([
   'runtime_exhausted',
-  'turn_timeout',
 ])
 
 export function keeperIsStuckOnRecoverableBlocker(keeper: Keeper): boolean {

--- a/dashboard/src/lib/keeper-runtime-display.test.ts
+++ b/dashboard/src/lib/keeper-runtime-display.test.ts
@@ -221,10 +221,8 @@ describe('keeperRuntimeBlockerLabel', () => {
   it('labels the active SDK blocker variants', () => {
     expect(keeperRuntimeBlockerLabel('sdk_context_window_exceeded')).toBe('SDK 컨텍스트 윈도 초과')
     expect(keeperRuntimeBlockerLabel('sdk_unrecognized_stop_reason')).toBe('SDK 미식별 정지 사유')
-    expect(keeperRuntimeBlockerLabel('sdk_idle_detected')).toBe('SDK Idle 감지')
     expect(keeperRuntimeBlockerLabel('sdk_guardrail_violation')).toBe('SDK 가드레일 위반')
     expect(keeperRuntimeBlockerLabel('sdk_tripwire_violation')).toBe('SDK Tripwire 위반')
-    expect(keeperRuntimeBlockerLabel('sdk_exit_condition_met')).toBe('SDK 종료 조건 충족')
   })
 
   it('SSOT regression guard — every literal in KEEPER_RUNTIME_BLOCKER_CLASSES has a non-null label', () => {
@@ -269,26 +267,6 @@ describe('keeperRuntimeBlockerHint', () => {
     [
       'exception',
       'Keeper 런타임 예외가 기록되어 로그와 최근 turn 상태 확인이 필요합니다.',
-    ],
-    [
-      'awaiting_operator',
-      '진행을 위해 운영자의 승인, 결정, 또는 게이트 해제가 필요합니다.',
-    ],
-    [
-      'awaiting_sandbox_egress',
-      '샌드박스 네트워크 또는 push egress 정책 때문에 keeper가 진행하지 못하고 있습니다.',
-    ],
-    [
-      'supervisor_paused',
-      'Supervisor가 keeper를 일시정지한 상태라 재개 조건을 확인해야 합니다.',
-    ],
-    [
-      'synthetic_stall',
-      '실제 STATE 없이 합성된 진행 기록만 남아 최근 턴 산출물을 재확인해야 합니다.',
-    ],
-    [
-      'self_imposed_idle',
-      'Keeper가 관찰 또는 대기만 계획하고 있어 다음 실행 지시가 필요할 수 있습니다.',
     ],
   ]
 

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -333,9 +333,6 @@ function transientProviderRuntimeText(value: string | null | undefined): boolean
 export function isKeeperAutoRecoverPause(keeper: Keeper | null | undefined): boolean {
   if (!keeper || !isKeeperPaused(keeper)) return false
   const blockerClass = keeper.runtime_blocker_class
-  if (blockerClass === 'turn_timeout') {
-    return true
-  }
   if (blockerClass === 'provider_runtime_error') {
     return (
       transientProviderRuntimeText(keeper.runtime_blocker_summary)
@@ -450,7 +447,6 @@ function isHeartbeatAlive(heartbeat: string): boolean {
 }
 
 const runtimeBlockerLabels = {
-  turn_timeout: '턴 응답 만료',
   runtime_exhausted: '런타임 후보 소진',
   provider_runtime_error: '런타임 호출 오류',
   fiber_unresolved: 'Fiber 미해결',
@@ -459,17 +455,10 @@ const runtimeBlockerLabels = {
   heartbeat_failures: '하트비트 실패',
   turn_failures: '턴 실패 반복',
   exception: '런타임 예외',
-  awaiting_operator: '운영자 조치 대기',
-  awaiting_sandbox_egress: '샌드박스 egress 대기',
-  supervisor_paused: 'Supervisor 일시정지',
-  synthetic_stall: '합성 상태 정체',
-  self_imposed_idle: '자체 대기',
   sdk_context_window_exceeded: 'SDK 컨텍스트 윈도 초과',
   sdk_unrecognized_stop_reason: 'SDK 미식별 정지 사유',
-  sdk_idle_detected: 'SDK Idle 감지',
   sdk_guardrail_violation: 'SDK 가드레일 위반',
   sdk_tripwire_violation: 'SDK Tripwire 위반',
-  sdk_exit_condition_met: 'SDK 종료 조건 충족',
 } satisfies Record<KeeperRuntimeBlockerClass, string>
 
 export function keeperRuntimeBlockerLabel(
@@ -485,9 +474,6 @@ export function keeperRuntimeBlockerHint(keeper: Keeper | null | undefined): str
   const runtimeBlocker = normalizeKeeperBlockerText(keeper.runtime_blocker_summary)
   if (runtimeBlocker && runtimeBlocker !== blockerClass) {
     return runtimeBlocker
-  }
-  if (blockerClass === 'turn_timeout') {
-    return '턴 실행 시간이 제한 시간을 초과했습니다.'
   }
   if (blockerClass === 'runtime_exhausted') {
     return '런타임 후보가 모두 소진되어 runtime 상태 확인이 필요합니다.'
@@ -512,21 +498,6 @@ export function keeperRuntimeBlockerHint(keeper: Keeper | null | undefined): str
   }
   if (blockerClass === 'exception') {
     return 'Keeper 런타임 예외가 기록되어 로그와 최근 turn 상태 확인이 필요합니다.'
-  }
-  if (blockerClass === 'awaiting_operator') {
-    return '진행을 위해 운영자의 승인, 결정, 또는 게이트 해제가 필요합니다.'
-  }
-  if (blockerClass === 'awaiting_sandbox_egress') {
-    return '샌드박스 네트워크 또는 push egress 정책 때문에 keeper가 진행하지 못하고 있습니다.'
-  }
-  if (blockerClass === 'supervisor_paused') {
-    return 'Supervisor가 keeper를 일시정지한 상태라 재개 조건을 확인해야 합니다.'
-  }
-  if (blockerClass === 'synthetic_stall') {
-    return '실제 STATE 없이 합성된 진행 기록만 남아 최근 턴 산출물을 재확인해야 합니다.'
-  }
-  if (blockerClass === 'self_imposed_idle') {
-    return 'Keeper가 관찰 또는 대기만 계획하고 있어 다음 실행 지시가 필요할 수 있습니다.'
   }
   return null
 }

--- a/dashboard/src/lib/monitoring-runtime.test.ts
+++ b/dashboard/src/lib/monitoring-runtime.test.ts
@@ -215,7 +215,7 @@ describe('summarizeKeeperMonitoring', () => {
       status: 'idle',
       phase: 'Running',
       last_heartbeat: new Date().toISOString(),
-      runtime_blocker_class: 'turn_timeout',
+      runtime_blocker_class: 'stale_turn_timeout',
       runtime_blocker_summary: 'turn timed out after queue wait',
     } as Keeper)
 
@@ -230,7 +230,7 @@ describe('summarizeKeeperMonitoring', () => {
       status: 'idle',
       phase: 'Running',
       last_heartbeat: new Date().toISOString(),
-      runtime_blocker_class: 'turn_timeout',
+      runtime_blocker_class: 'stale_turn_timeout',
       runtime_blocker_summary: 'turn timed out after queue wait',
     } as Keeper
 
@@ -358,7 +358,7 @@ describe('summarizeKeeperMonitoring', () => {
           status: 'busy',
           phase: 'Running',
           pipeline_stage: 'compacting',
-          runtime_blocker_class: 'turn_timeout',
+          runtime_blocker_class: 'stale_turn_timeout',
           runtime_blocker_summary: 'turn timed out after queue wait',
         } as Keeper,
         { keeper: 'keeper-transient-blocked', phase: 'compacting' } as unknown as Parameters<

--- a/dashboard/src/lib/runtime-blocker-class.ts
+++ b/dashboard/src/lib/runtime-blocker-class.ts
@@ -49,15 +49,12 @@ export function asKeeperRuntimeBlockerClass(
 
 const BACKEND_KEEPER_META_BLOCKER_CLASSES = [
   'runtime_exhausted',
-  'turn_timeout',
   'fiber_unresolved',
   'stale_turn_timeout',
   'sdk_context_window_exceeded',
   'sdk_unrecognized_stop_reason',
-  'sdk_idle_detected',
   'sdk_guardrail_violation',
   'sdk_tripwire_violation',
-  'sdk_exit_condition_met',
 ] as const
 
 type BackendKeeperMetaBlockerClass = typeof BACKEND_KEEPER_META_BLOCKER_CLASSES[number]

--- a/dashboard/src/operator-normalizers.test.ts
+++ b/dashboard/src/operator-normalizers.test.ts
@@ -386,16 +386,16 @@ describe('normalizeOperatorSnapshot', () => {
           name: 'blocked-keeper',
           status: 'active',
           needs_attention: true,
-          attention_reason: 'turn_timeout',
+          attention_reason: 'stale_turn_timeout',
           next_human_action: 'inspect_runtime_blocker',
           runtime_trust: {
             disposition: 'Alert',
             operator_disposition: 'pause_runtime',
-            operator_disposition_reason: 'turn_timeout',
+            operator_disposition_reason: 'stale_turn_timeout',
             needs_attention: true,
-            attention_reason: 'turn_timeout',
+            attention_reason: 'stale_turn_timeout',
             latest_terminal_reason: {
-              code: 'turn_timeout',
+              code: 'stale_turn_timeout',
               source: 'execution_receipt',
               severity: 'bad',
               summary: 'Turn execution exceeded the keeper turn deadline',
@@ -409,15 +409,14 @@ describe('normalizeOperatorSnapshot', () => {
     expect(result.keepers).toHaveLength(1)
     const keeper = result.keepers[0]!
     expect(keeper.needs_attention).toBe(true)
-    expect(keeper.attention_reason).toBe('turn_timeout')
     expect(keeper.next_human_action).toBe('inspect_runtime_blocker')
     expect(keeper.runtime_trust).toMatchObject({
       disposition: 'Alert',
       operator_disposition: 'pause_runtime',
-      operator_disposition_reason: 'turn_timeout',
+      operator_disposition_reason: 'stale_turn_timeout',
       needs_attention: true,
       latest_terminal_reason: {
-        code: 'turn_timeout',
+        code: 'stale_turn_timeout',
         severity: 'bad',
         summary: 'Turn execution exceeded the keeper turn deadline',
         next_action: 'inspect_runtime_blocker',

--- a/dashboard/src/store-normalizers.test.ts
+++ b/dashboard/src/store-normalizers.test.ts
@@ -368,7 +368,7 @@ describe('normalizeDashboardRuntimeResolution fleet safety', () => {
           pause_kind: 'operator_paused',
           paused_elapsed_sec: 12,
           last_blocker: {
-            klass: 'turn_timeout',
+            klass: 'stale_turn_timeout',
             detail: 'turn exceeded budget',
           },
           missing_pause_root_cause: false,
@@ -442,7 +442,7 @@ describe('normalizeDashboardRuntimeResolution fleet safety', () => {
           name: 'analyst',
           pause_kind: 'operator_paused',
           last_blocker: {
-            klass: 'turn_timeout',
+            klass: 'stale_turn_timeout',
           },
         }],
       },

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -405,7 +405,6 @@ export interface ProviderHealth {
 }
 
 export const KEEPER_RUNTIME_BLOCKER_CLASSES = [
-  'turn_timeout',
   'runtime_exhausted',
   'provider_runtime_error',
   'fiber_unresolved',
@@ -414,17 +413,10 @@ export const KEEPER_RUNTIME_BLOCKER_CLASSES = [
   'heartbeat_failures',
   'turn_failures',
   'exception',
-  'awaiting_operator',
-  'awaiting_sandbox_egress',
-  'supervisor_paused',
-  'synthetic_stall',
-  'self_imposed_idle',
   'sdk_context_window_exceeded',
   'sdk_unrecognized_stop_reason',
-  'sdk_idle_detected',
   'sdk_guardrail_violation',
   'sdk_tripwire_violation',
-  'sdk_exit_condition_met',
 ] as const
 
 export type KeeperRuntimeBlockerClass = (typeof KEEPER_RUNTIME_BLOCKER_CLASSES)[number]


### PR DESCRIPTION
`runtime_blocker_class` 는 **생산자가 셋인 무타입 문자열 채널**이다.

| 생산자 | 값 개수 |
|---|---|
| `Keeper_meta_contract.blocker_class_to_string` | 16 (닫힌 variant) |
| `Keeper_registry_types_failure.failure_reason_cohort_key` | cohort key |
| `keeper_status_bridge_blocker.ml` | 7 (raw 리터럴) |

대시보드 `KEEPER_RUNTIME_BLOCKER_CLASSES` 20개 중 **8개는 이 셋 어디에도 없고, OCaml 소스 전체에서 0건**이다.

`turn_timeout`, `awaiting_operator`, `awaiting_sandbox_egress`, `supervisor_paused`, `synthetic_stall`, `self_imposed_idle`, `sdk_idle_detected`, `sdk_exit_condition_met`

## 이 값들이 굴리던 로직

- `runtimeBlockerDrivesStuck` 은 `synthetic_stall` 하나 때문에 존재했다. 그 분기를 빼면 함수가 `return true` 뿐이라 호출부로 접힌다.
- `PausedCause` 의 `'supervisor'` 는 생산자가 `supervisor_paused` 분기 하나, 소비자는 0.
- `OPERATOR_ATTENTION_BLOCKERS` 의 유일한 원소가 `awaiting_operator` 였다. 따라서 `hasOperatorAttentionBlocker` 는 두 호출부에서 항상 false.
- `WAKEUP_RECOVERABLE_BLOCKERS` 에 `turn_timeout`. 이 술어는 자기 주석이 "pinned by tests only; no render surface" 라고 적고 있다.
- 힌트 분기 7개, 라벨 맵 8개, agent-roster 의 `synthetic_stall` 상태 노트.

## drift 방지 장치가 스스로 drift 해 있었다

`runtime-blocker-class.ts` 는 백엔드 variant 목록의 **손으로 쓴 사본**과, 그 사본을 프론트엔드 union 과 비교하는 TS 체크를 갖고 있다. 주석은 "keep it 1:1 with keeper_meta_contract.ml" 이라고 선언한다.

실제로는 양방향으로 어긋나 있었다 — 사본에만 3개(variant 에 없음), variant 에만 9개(사본이 누락). 사본을 원본과 비교하는 것이 아무것도 없기 때문이다. 주석이 인용한 근거도 함께 썩었다: `keeper_meta_contract.ml:91 type blocker_class` 는 실제 95행이고, "status bridge 가 `synthetic_stall`/`self_imposed_idle` 을 낸다"는 서술은 bridge 가 그 둘을 내지 않으므로 사실이 아니다.

이 PR 은 사본의 유령 3개만 제거한다. 누락된 9개와 무타입 3-생산자 채널 자체는 #27448 의 주제다.

**문자열 parity lint 는 만들지 않았다.** 세 어휘를 grep 으로 묶는 가드는 CLAUDE.md 가 거부하는 "문자열 분류기 보강"에 해당한다. 근본은 단일 typed 생산자이며 RFC 사안이다.

## 테스트

- 제목이 유령 클래스를 지목한 케이스는 삭제 (7건)
- `it.each` 표에서 유령 행 제거
- 불투명한 blocker 픽스처로 쓰인 값은 서버가 실제로 내는 클래스로 치환

## 검증

- `npx tsc --noEmit`: EXIT=0
- `npx vitest run`: 636 파일 / 8796 테스트 통과
- 서버(OCaml) 변경 없음
