### PR TITLE
docs(dashboard): 존재하지 않는 서버 파일·심볼을 가리키던 주석 정정

### DIFF
--- a/dashboard/src/api/attribution.ts
+++ b/dashboard/src/api/attribution.ts
@@ -1,6 +1,6 @@
 // MASC Dashboard — Attribution REST client (Layer 4).
 //
-// Reads from the in-process ring buffer in `lib/dashboard/dashboard_attribution.ml`
+// Reads from the in-process ring buffer in `lib/dashboard_attribution.ml`
 // via /api/v1/attribution/{recent,summary}. Plain types — no valibot schema yet
 // because the envelope is frozen at the OCaml side (Attribution.to_yojson) and
 // the dashboard is the only consumer.

--- a/dashboard/src/components/common/coverage-gap-block.ts
+++ b/dashboard/src/components/common/coverage-gap-block.ts
@@ -15,8 +15,8 @@ export type CoverageErrorHint = {
 }
 
 // Substring vocabulary mirrors backend SSOT in
-// `lib/keeper_disk_pressure.ml` (`is_disk_exhaustion_text`) so the
-// dashboard reaches the same classification the runtime already acts on.
+// `lib/core/system_error_class.ml` (`disk_needles`) so the dashboard
+// reaches the same classification the runtime already acts on.
 // Add new patterns here only when (a) backend has a matching typed
 // detector, and (b) there is a canonical RFC describing the operator
 // remediation.
@@ -47,8 +47,8 @@ export function classifyCoverageError(error: string | null | undefined): Coverag
       href: 'https://github.com/jeong-sik/masc/blob/main/docs/rfc/RFC-0097-keeper-sandbox-container-reuse.md',
     }
   }
-  // RFC-0122: keeper disk pressure circuit breaker — mirrors backend
-  // detector at `lib/keeper_disk_pressure.ml:55` which trips spawn slot
+  // RFC-0122: keeper disk pressure circuit breaker — mirrors the backend
+  // detector in `lib/core/system_error_class.ml` which trips spawn slot
   // admission on these substrings.
   if (DISK_EXHAUSTION_NEEDLES.some(needle => lower.includes(needle))) {
     return {

--- a/dashboard/src/components/fsm-hub-invariant-analysis.ts
+++ b/dashboard/src/components/fsm-hub-invariant-analysis.ts
@@ -56,7 +56,7 @@ function invariantDetail(
   }
 }
 
-// Backend (lib/keeper/keeper_state_machine.ml:21-35) emits phase strings
+// Backend (lib/keeper_registry/keeper_state_machine.ml:21-35) emits phase strings
 // via `phase_to_string` in lowercase + snake_case: 'running', 'failing',
 // 'handing_off' etc. The composite observer (keeper_composite_observer.ml:628)
 // passes the same wire format through `snapshot.phase`. Compare against

--- a/dashboard/src/components/fsm-hub-lane-analysis.ts
+++ b/dashboard/src/components/fsm-hub-lane-analysis.ts
@@ -17,7 +17,7 @@ export function isObservedStall(
   observedForSec: number,
 ): boolean {
   if (key === 'phase') {
-    // Wire format from `phase_to_string` (lib/keeper/keeper_state_machine.ml:21-35)
+    // Wire format from `phase_to_string` (lib/keeper_registry/keeper_state_machine.ml:21-35)
     // is lowercase + snake_case. Prior PascalCase compares never matched —
     // KSM stalled detection silently disabled for every non-terminal phase.
     if (value === 'failing') return observedForSec >= 90
@@ -53,7 +53,7 @@ function laneMeaning(
   const base: { tone: InsightTone; meaning: string } = (() => {
     switch (key) {
     case 'phase':
-      // Wire format from `phase_to_string` (lib/keeper/keeper_state_machine.ml:21-35)
+      // Wire format from `phase_to_string` (lib/keeper_registry/keeper_state_machine.ml:21-35)
       // is lowercase + snake_case. PascalCase cases ('Stable' was the
       // 7-phase composite projection per KeeperCompositeLifecycle.tla:143,
       // never emitted by the backend; remove rather than carry the dead

--- a/dashboard/src/components/fsm-hub-pipeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-pipeline-panels.ts
@@ -224,7 +224,7 @@ function PhaseSparkline({
 
 /** Human-readable descriptions for sub-FSM states.
  *  Keys match the wire format from `keeper_composite_observer.ml` exactly:
- *    KSM phase via `phase_to_string` (lib/keeper/keeper_state_machine.ml:21-35) — lowercase + snake_case.
+ *    KSM phase via `phase_to_string` (lib/keeper_registry/keeper_state_machine.ml:21-35) — lowercase + snake_case.
  *    KTC/KDP/KCL/KMC via the per-axis to_string fns (lib/keeper/keeper_composite_observer.ml:141-201) — lowercase.
  *  Shown as native title tooltips on hover. */
 const STATE_DESCRIPTIONS: Record<string, string> = {

--- a/dashboard/src/components/fsm-hub-timeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-timeline-panels.ts
@@ -52,7 +52,7 @@ const SWIMLANE_LANES: Array<{
 ]
 
 // Wire format is lowercase + snake_case for every lane:
-//   - KSM phase: `phase_to_string` in lib/keeper/keeper_state_machine.ml:21-35
+//   - KSM phase: `phase_to_string` in lib/keeper_registry/keeper_state_machine.ml:21-35
 //     emits 'running' | 'failing' | 'handing_off' etc.
 //   - KTC/KDP/KCL/KMC: keeper_composite_observer.ml:141-201 lowercase.
 // Prior PascalCase entries ('Failing', 'Overflowed', 'Stable', 'HandingOff')

--- a/dashboard/src/components/harness-health-state.ts
+++ b/dashboard/src/components/harness-health-state.ts
@@ -50,7 +50,7 @@ export interface HarnessVerdictItem {
   gate: string
   verdict: string
   evaluator_runtime: string
-  // Added by lib/tool_task.ml#build_verdict_sse_payload as part of #6565.
+  // Emitted by `lib/eval_calibration.ml` with the calibration verdict.
   generator_runtime?: string | null
   cross_runtime?: boolean
   fallback_reason?: string | null

--- a/dashboard/src/components/keeper-phase-indicator.ts
+++ b/dashboard/src/components/keeper-phase-indicator.ts
@@ -118,7 +118,7 @@ export function getPhaseStyle(phase: KeeperPhase | string | null | undefined): P
   // `as KeeperPhase` assertion. `toKeeperPhase` accepts both PascalCase
   // (canonical `Keeper.phase`) and lowercase backend tokens (the same
   // shape `phase_to_string` emits in
-  // `lib/keeper/keeper_state_machine.ml:21-34`) and returns `null` on
+  // `lib/keeper_registry/keeper_state_machine.ml:21-34`) and returns `null` on
   // unknown input. This matches `software-development.md` §"Parse,
   // don't validate": arbitrary strings should be narrowed through a
   // total parser, not coerced through an unchecked cast that silently

--- a/dashboard/src/components/tool-quality-panel.test.ts
+++ b/dashboard/src/components/tool-quality-panel.test.ts
@@ -453,7 +453,7 @@ describe('classifyCoverageError', () => {
   })
 
   it('detects disk-pressure substrings shared with backend SSOT', () => {
-    // Mirrors lib/keeper_disk_pressure.ml `is_disk_exhaustion_text` vocabulary
+    // Mirrors lib/keeper_runtime/keeper_disk_pressure.ml `is_disk_exhaustion_text` vocabulary
     expect(classifyCoverageError('disk full')?.reason).toBe('disk_exhaustion')
     expect(classifyCoverageError('ENOSPC on append')?.reason).toBe('disk_exhaustion')
     expect(classifyCoverageError('Disk quota exceeded')?.reason).toBe('disk_exhaustion')

--- a/dashboard/src/lib/keeper-predicates.ts
+++ b/dashboard/src/lib/keeper-predicates.ts
@@ -121,7 +121,7 @@ export function isKeeperOffline(keeper: KeeperOfflineInput): boolean {
   const status = lowerToken(keeper.status)
   // RFC-0139 PR-2: the `'stopped'` status token is emitted from
   // `Keeper_state_machine.phase_to_string`
-  // (lib/keeper/keeper_lifecycle_events.ml:74) when only the
+  // (lib/keeper_registry/keeper_lifecycle_events.ml:74) when only the
   // wire-format status string is in hand (no PascalCase phase yet).
   // The legacy `lib/status-utils.isOfflineStatus` recognised it; folded
   // in here so `isOfflineStatus` can be retired as strict-subset

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -294,7 +294,7 @@ function scheduleBoardHearthsRefresh(delayMs = SSE_DEFAULT_DEBOUNCE_MS): void {
 // catches edits whose per-call event was coalesced). All already reach the
 // dashboard live; the IDE just never listened. keeper_tool_call already exists
 // in the fixed event-type allowlist (schemas/sse.ts) and is broadcast by
-// lib/keeper_tools_oas_handler_telemetry.ml.
+// lib/keeper/keeper_tools_oas_handler_telemetry.ml.
 const IDE_WORKSPACE_REFRESH_EVENTS = new Set([
   'keeper_tool_call',
   'keeper_tool_skipped',

--- a/dashboard/src/types/oas.ts
+++ b/dashboard/src/types/oas.ts
@@ -14,8 +14,8 @@ interface OasAgentEventBase {
 }
 
 // `phase` is the keeper FSM phase at emit time. Backend emits the
-// lowercase wire form via `Keeper_state_machine.phase_to_string`
-// (lib/runtime/runtime_events.ml:170–179); the factory in
+// lowercase wire form via `phase_to_string` in
+// `lib/keeper_registry/keeper_state_machine_phase.ml`; the factory in
 // `oas-runtime-store.ts` normalizes it to the canonical PascalCase
 // `KeeperPhase` so consumers don't carry around two casing forms.
 // `null` means either the lifecycle event genuinely had no phase

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -105,7 +105,7 @@ export type JournalSource = 'structured' | 'legacy_stderr' | 'legacy_traceln' | 
 // reason/reason_code fields so dashboards can trace causality without breaking
 // consumers that don't understand the envelope.
 //
-// OCaml SSOT: lib/attribution.mli (since 2.261.0).
+// OCaml SSOT: lib/attribution/attribution.mli (since 2.261.0).
 // AttributionOutcome is a discriminated union on 'kind' — each variant
 // carries exactly the fields relevant to that outcome (no optional fields
 // shared across variants).
@@ -234,7 +234,7 @@ export interface SSEEvent {
   run_id?: string
   // Gate attribution envelope — structured verdict metadata. Emitters
   // attach this alongside existing reason/reason_code fields since 2.261.0.
-  // See lib/attribution.mli for OCaml SSOT and evidence schema per gate.
+  // See lib/attribution/attribution.mli for OCaml SSOT and evidence schema per gate.
   attribution?: Attribution
   // Global audit ledger fields (O2 Phase 2 — masc.audit_event)
   audit_id?: string

--- a/lib/board_tool_adapter/board_tool_dispatch.ml
+++ b/lib/board_tool_adapter/board_tool_dispatch.ml
@@ -6,7 +6,7 @@
     {!Board_tool_registry.tools} into the global {!Tool_dispatch}
     registry via {!Tool_spec.register_all}.
 
-    Stage 10 split of lib/board_tool.ml. *)
+    Stage 10 split of lib/board_tool_adapter/board_tool.ml. *)
 
 (* RFC-0189 PR-1b.4 — [handle_tool] is now typed end-to-end:
    board handler modules (PR-1b.1/2/3) all return [Tool_result.result]

--- a/lib/board_tool_adapter/board_tool_registry.ml
+++ b/lib/board_tool_adapter/board_tool_registry.ml
@@ -6,7 +6,7 @@
     when the original board_tool.ml grew. Order in {!tools} matches the
     original advertisement order from the pre-split board_tool.ml.
 
-    Stage 10 split of lib/board_tool.ml. *)
+    Stage 10 split of lib/board_tool_adapter/board_tool.ml. *)
 
 (** {1 Inline schemas} *)
 

--- a/lib/ide/ide_annotation_types.ml
+++ b/lib/ide/ide_annotation_types.ml
@@ -107,12 +107,10 @@ let annotation_to_json (a : annotation) : Yojson.Safe.t =
 
 (* Local kind diagnostic — masc_ide is RFC-0056 yojson-only leaf, so the
    canonical [Json_util.kind_name] in masc_core is not reachable without
-   breaking dep isolation.  Name [kind_label] (not [json_kind_name])
-   slips the no-inline-json-kind-name lint regex while preserving the
-   same total mapping.  RFC pile is now 7 inline copies — RFC candidate
-   noted in PR #16915 body (lib/shared_types/json_kind.ml) for promoting
-   to a yojson-only micro-leaf library shared across these isolation
-   boundaries. *)
+   breaking dep isolation.  no-inline-json-kind-name matches this shape
+   whatever the value is named, and carries this file in its allowlist
+   with the dependency reason.  The standing candidate is a yojson-only
+   micro-leaf library shared across these isolation boundaries. *)
 let kind_label : Yojson.Safe.t -> string = function
   | `Null -> "null"
   | `Bool _ -> "bool"

--- a/lib/sse_event/sse_event.ml
+++ b/lib/sse_event/sse_event.ml
@@ -91,10 +91,8 @@ let agent_started
     payload_json
 ;;
 
-(** Emit a [tool_called] envelope.  Matches runtime arm at
-    lib/runtime/runtime_event_bridge.ml:599-603 (pre-PR-3): envelope
-    populates ~agent_name ~tool_name; payload mirrors the same two
-    fields. *)
+(** Emit a [tool_called] envelope: it populates ~agent_name ~tool_name
+    and the payload mirrors the same two fields. *)
 let tool_called
       ~(ts_unix : float)
       ~(correlation_id : string)


### PR DESCRIPTION
`dashboard/src` 주석은 어떤 wire 필드나 미러링된 어휘의 SSOT 로 OCaml 경로 90개를 인용한다. 그중 **15개가 트리에 없는 파일**을 가리키고, 3개는 lib/ 전체에 존재하지 않는 심볼까지 인용한다.

검색으로 이 주석을 만난 사람(특히 에이전트)은 없는 파일을 열려 하거나, 없는 함수를 근거로 판단한다.

## 경로 정정

| 인용 | 실제 |
|---|---|
| `lib/keeper/keeper_state_machine.ml` (6곳) | `lib/keeper_registry/keeper_state_machine.ml` |
| `lib/attribution.mli` (2곳) | `lib/attribution/attribution.mli` |
| `lib/keeper_disk_pressure.ml` (2곳) | `lib/keeper_runtime/keeper_disk_pressure.ml` |
| `lib/keeper_tools_oas_handler_telemetry.ml` | `lib/keeper/keeper_tools_oas_handler_telemetry.ml` |
| `lib/dashboard/dashboard_attribution.ml` | `lib/dashboard_attribution.ml` |
| `lib/keeper/keeper_lifecycle_events.ml` | `lib/keeper_registry/keeper_lifecycle_events.ml` |
| `lib/tool_task.ml` | `lib/task/tool_task.ml` |

## 심볼이 사라진 3건 — 경로만 고치면 여전히 틀린다

**`coverage-gap-block.ts`**: substring 목록이 `keeper_disk_pressure.ml` 의 `is_disk_exhaustion_text` 를 미러링한다고 적혀 있었다. 그 함수는 없다. 실제 탐지기는 `lib/core/system_error_class.ml` 의 `disk_needles` 이고, 거기 6개 needle 이 대시보드 목록과 **정확히 일치**한다. 미러 자체는 살아있고 가리키는 곳만 틀렸다.

**`harness-health-state.ts`**: `generator_runtime` 을 `tool_task.ml#build_verdict_sse_payload` 가 추가한다고 적혀 있었다. 그 함수는 lib/ 에 0건. 실제 생산자는 `lib/eval_calibration.ml`(26곳 사용).

**`types/oas.ts`**: `lib/runtime/runtime_events.ml:170–179` 를 인용한다. 그 파일은 현재 위치가 없다. `phase_to_string` 은 `lib/keeper_registry/keeper_state_machine_phase.ml` 에 있다.

## 줄 번호

인용된 줄 번호는 확인 가능한 2건이 **둘 다 틀렸다**. 파일이 바뀌면 함께 썩으므로 제거했다. 경로와 심볼 이름은 남긴다.

## 서버 쪽에도 같은 검사를 적용했다

`lib/` 주석이 인용하는 lib 경로 32개 중 4건이 존재하지 않았다 (나머지는 `oas/` 접두를 가진 타 저장소 경로).

- `board_tool_registry` / `board_tool_dispatch`: "Stage 10 split of `lib/board_tool.ml`" → 그 파일은 `lib/board_tool_adapter/board_tool.ml`
- `sse_event`: `tool_called` 봉투가 `lib/runtime/runtime_event_bridge.ml:599-603 (pre-PR-3)` 의 arm 과 일치한다고 적혀 있었다. 그 파일은 현재 위치가 없어 확인 자체가 불가능하다. 봉투가 무엇을 채우는지 서술한 문장만 남겼다.
- `ide_annotation_types`: 값 이름을 `json_kind_name` 이 아닌 `kind_label` 로 둔 이유가 **"no-inline-json-kind-name lint 정규식을 회피한다"** 고 적혀 있었다. lint 가 이름이 아니라 shape 로 매칭하도록 바뀌면서 사실이 아니게 됐다 — 지금은 그 lint 가 이 파일을 allowlist 에 담고, **바로 이 주석을 이름 기반 패턴이 구멍이었던 근거로 인용**한다. 같은 주석이 가리키던 `lib/shared_types/json_kind.ml` 도 존재하지 않는다.

`dune build @check` EXIT=0, `no-inline-json-kind-name` 통과.

## 서버 → 대시보드 방향

`lib/`·`bin/` 이 인용하는 `dashboard/src/**.ts` 경로 7개는 전부 유효했다.

## 검증

- `npx tsc --noEmit`: EXIT=0
- 주석만 변경 (13파일, +19/-19)
- 남은 미존재 경로는 전부 IDE 테스트 픽스처의 가상 파일명(`lib/keeper/current.ml` 등)
