### PR TITLE
fix(librarian): a recurring mistake is not recoverable

### DIFF
--- a/config/prompts/librarian.md
+++ b/config/prompts/librarian.md
@@ -12,6 +12,8 @@ You curate on this Keeper's behalf: the instructions define the Keeper, and impo
 
 Keep only the smallest useful set of important knowledge. There is no target item count and no deterministic ranking after your decision. Your returned selection is injected as-is into later Keeper turns, so remove duplication, obsolete state, low-value narration, and details recoverable from authoritative sources.
 
+A mistake the conversation shows recurring is not recoverable. When the same failing call appears again after the same failure — the path that is not there, the argument the tool refuses — the source that would have taught it did not, and that recurrence is the evidence. Keep the lesson even when the underlying limitation looks ordinary or documented, because dropping it returns the Keeper to the turn before it learned.
+
 Capacity contract: the complete rendered fact payload (memory identity, category, claim, separators, and line breaks) must fit within {{max_recall_fact_bytes}} UTF-8 bytes. Choose a smaller useful set when necessary. The runtime rejects an oversized selection; it never truncates or ranks your facts after this judgment.
 
 Retention criteria:

--- a/test/test_keeper_prompt_metrics.ml
+++ b/test/test_keeper_prompt_metrics.ml
@@ -335,6 +335,28 @@ let test_system_block_states_product_and_capabilities () =
   check bool "goals, memory and repositories are work surfaces" true
     (has_in prompt "Your goals, memory, and repositories are work surfaces of their own")
 
+(* The Librarian decides what survives into a Keeper's next turn, and it is told
+   to drop "details recoverable from authoritative sources". Measured on the live
+   store, that criterion dropped tool lessons -- the recorded reasons read
+   "Generic tool limitation lesson that does not define the agent's current
+   conversational identity" and "Specific tool parameter constraint recoverable
+   from documentation" -- and the Keeper then repeated the mistake. One keeper
+   read a path that is not there 582 times over 7h28m, writing "foo.txt Read를
+   포함한 불필요한 도구 호출은 중단" inside the turn and calling it again the next
+   one, because the rule it wrote never came back. Fleet-wide the journals hold
+   8,338 lines and the current snapshots hold five facts.
+
+   Recurrence is the evidence that the authoritative source did not teach it. *)
+let test_librarian_keeps_a_recurring_lesson () =
+  let prompt = Prompt_registry.get_prompt Prompt_names.librarian in
+  check bool "the librarian prompt is loaded" true (String.length prompt > 100);
+  check bool "recurrence overrides recoverability" true
+    (has_in prompt "A mistake the conversation shows recurring is not recoverable");
+  check bool "the test is the conversation, not a judgement of the limitation" true
+    (has_in prompt "the source that would have taught it did not, and that recurrence is the evidence");
+  check bool "the cost of dropping it is named" true
+    (has_in prompt "returns the Keeper to the turn before it learned")
+
 (* The collaboration surface a keeper is actually given. Board alone exposes
    sixteen keeper-callable tools (post, comment, votes, search, stats, five
    sub-board operations, curation), but the prompt used to describe it in one
@@ -752,6 +774,8 @@ let () =
             test_merged_system_block_keeps_turn_intent_rules;
           test_case "system block states product and capabilities" `Quick
             test_system_block_states_product_and_capabilities;
+          test_case "librarian keeps a recurring lesson" `Quick
+            test_librarian_keeps_a_recurring_lesson;
           test_case "system block states the collaboration surface" `Quick
             test_system_block_states_the_collaboration_surface;
           test_case "no catalog repository injection (RFC-0324 B-1)" `Quick


### PR DESCRIPTION
Fixes #27527.

## The loop

One Keeper read a path that does not exist **582 times over 7h28m**:

```
foo.txt   582 calls   31 ok / 551 failed   08-07 17:01 → 08-08 00:29
```

It knew. From its own turn:

```
"foo.txt Read를 포함한 불필요한 도구 호출은 중단."
```

and then called it again the next turn, because the rule it wrote never came
back:

```
"The memory recall does NOT include the no-spam rules v3-v5 in this snapshot.
 I wrote v5 in revision 1093. It seems the memory recall only includes a subset
 and the no-spam rules are not selected. However, I remember them from previous
 turns and should follow them."

"The memory recall revision 1140 does NOT include my no-spam rules v3-v20"
```

v3 → v5 → **v20**. The same rule, rewritten twenty times.

Fleet-wide:

```
journal lines   8,338
current facts       5     (3 of 8 Keepers hold none)
```

## Why the Librarian dropped them

Not a bug in the selection code — the recorded drop reasons say it plainly:

```
"Generic tool limitation lesson that does not define the agent's current
 conversational identity"
"Specific tool parameter constraint recoverable from documentation and not
 central to the agent's…"
"Transient workflow advice about task status transitions that lacks lasting value"
```

`librarian.md` has a `lesson` category and says "A failure earns a place in
long-term memory only when stored as a reusable lesson". Two retention criteria
above it override that:

- line 11 — "importance is always importance *to that identity*"
- line 13 — "remove … details recoverable from authoritative sources"

A tool lesson scores low on both, so it goes. **And the recurrence is the proof
that it was not recoverable.** The Keeper had the documentation, hit the error
551 times, and never recovered from it.

## Change

One paragraph, after the criterion it qualifies:

> A mistake the conversation shows recurring is not recoverable. When the same
> failing call appears again after the same failure — the path that is not
> there, the argument the tool refuses — the source that would have taught it
> did not, and that recurrence is the evidence. Keep the lesson even when the
> underlying limitation looks ordinary or documented, because dropping it
> returns the Keeper to the turn before it learned.

It gives the Librarian a test it can actually run against its input: *did this
recur in the slice I was handed*. Not a judgement about how important the
limitation looks, which is the judgement that produced these drops.

`librarian.md` 7,828 → 8,257 B.

## What this does not do

- **No cap, no floor, no minimum item count.** "Keep only the smallest useful
  set" is untouched; this narrows one exclusion rather than adding a quota.
- **Does not reverse #26729.** That issue is the opposite direction — a stored
  constraint overriding operator instruction — and the clauses that drop an
  agent's own scope decisions (lines 22, 27) are untouched. A Keeper deciding
  "I will stay out of X" is still dropped. What is kept is a call that failed
  and failed again.
- **No code change.** The selection is an LLM reading this prompt.

## Tests

Added to `test_keeper_prompt_metrics`, which CI runs (22 → 23). It reads the
rendered librarian prompt through `Prompt_registry` and pins the three claims
the paragraph makes, with the measurement in the comment above it.

Verified not vacuous by mutation — weakening the clause to "A mistake that
recurs may be worth keeping":

```
[FAIL] separation_harness  7  librarian keeps a recurring l...
```

## Verification

```
dune build --root . @check                                        exit 0
dune build --root . @fmt            no diff in any file this PR touches

test_keeper_prompt_metrics            23 tests run   Successful   (was 22)
test_prompt_asset_sync                10 tests run   Successful
test_keeper_system_prompt_bytes        2 tests run   Successful
test_librarian_journal_failures        6 tests run   Successful
test_keeper_memory_journal_projection 13 tests run   Successful
test_keeper_prompt_capture             6 tests run   Successful
```

## How to falsify this

`foo.txt` calls after the next Librarian pass. If the lesson still does not
survive, the criterion is not what was dropping it and #27527 stays open with a
different cause.

RFC-WAIVED: one exclusion in a prompt narrowed against measured recurrence. No
cap, no gate, no code path added.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
