### PR TITLE
docs: 문서가 존재하지 않는 RFC 인용 제거

### DIFF
--- a/dashboard/src/components/ide/keeper-trace-store.ts
+++ b/dashboard/src/components/ide/keeper-trace-store.ts
@@ -4,8 +4,8 @@ import { signal } from '@preact/signals'
  * RFC-0028 PR-α: keeper-trace store.
  *
  * Stitched read-side projection over existing IDE/runtime surfaces:
- *  - anchored-thread (RFC-0021)
- *  - runtime-hop     (RFC-0023)
+ *  - anchored-thread
+ *  - runtime-hop
  *  - decision-log    (RFC-0026)
  *  - activity-event  (/api/v1/activity/events normalized context)
  *

--- a/dashboard/src/styles/keeper-v2/v2.css
+++ b/dashboard/src/styles/keeper-v2/v2.css
@@ -1469,7 +1469,7 @@
 @keyframes mnav-fade { from { opacity: 0; } to { opacity: 1; } }
 @keyframes mnav-up { from { transform: translateY(14px); opacity: 0; } to { transform: none; opacity: 1; } }
 
-/* ════ TOAST + UNDO (RFC-0007) ════ */
+/* ════ TOAST + UNDO ════ */
 .toast-host { position: fixed; left: 50%; bottom: 22px; transform: translateX(-50%); z-index: 90; display: flex; flex-direction: column; gap: 8px; align-items: center; pointer-events: none; }
 .toast { pointer-events: auto; display: flex; align-items: center; gap: 11px; min-width: 300px; max-width: 460px; padding: 11px 13px; background: var(--bg-panel); border: 1px solid var(--border-highlight); border-radius: var(--radius-md); box-shadow: var(--shadow-pop); animation: toast-in 0.2s cubic-bezier(0.2,0.7,0.3,1); }
 @keyframes toast-in { from { transform: translateY(10px); opacity: 0; } to { transform: none; opacity: 1; } }

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -12,9 +12,7 @@
     runtime→Runtime 숙청: 이전의 phase_recovery / phase_buffer /
     tool_action / phase_routing 구분은 모두 동일한 default Runtime 으로
     수렴하는 죽은 추상화였으므로 이 단일 thunk 로 collapse 되었다.
-    @since v2.128.0
-    @since RFC-0066 Phase 1: changed from a string value to a thunk
-    (issue #14624). *)
+    @since v2.128.0 *)
 val default_runtime_id : unit -> string
 
 (** Validate one persisted/requested context override value. This is a

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -219,8 +219,8 @@ let enqueue (queue : t) (s : stimulus) : t =
 (* Identity projection: durable-event identity must ignore display-only
    payload fields, or repeats of the same event with volatile text (token
    counts, addresses, timestamps inside provider error strings) defeat
-   [enqueue_if_missing]/[dedup_by_identity] and the queue grows unbounded
-   (RFC-0313 W2 loop-safety requirement). Exhaustive on purpose: a new
+   [enqueue_if_missing]/[dedup_by_identity] and the queue grows unbounded.
+   Exhaustive on purpose: a new
    payload kind must decide its identity fields here at compile time. *)
 let identity_payload = function
   | Goal_assigned ga ->

--- a/lib/runtime_model/runtime_model_id_split.mli
+++ b/lib/runtime_model/runtime_model_id_split.mli
@@ -7,8 +7,8 @@
     {!Provider_kind_resolver} existed only to dodge that cycle).
 
     This split lives strictly inside the OAS/runtime boundary. masc-core
-    consumers (auth, keeper dispatch) must not call it: per RFC-0211 a runtime id
-    is opaque to the masc core, and only OAS / the runtime adapter parses an id
+    consumers (auth, keeper dispatch) must not call it: a runtime id is
+    opaque to the masc core, and only OAS / the runtime adapter parses an id
     into a provider/model. *)
 
 (** [split_provider_model s] splits [s] at the first colon into

--- a/lib/workspace/workspace_broadcast.ml
+++ b/lib/workspace/workspace_broadcast.ml
@@ -67,7 +67,7 @@ let broadcast ?trace_context ?(msg_type = "broadcast") config ~from_agent ~conte
   in
   ensure_initialized config;
 
-  (* RFC-0061: preserve original content and extract mention tokens BEFORE
+  (* Preserve original content and extract mention tokens BEFORE
      any fleet-wide invariant rewrite. This prevents stage-1 wake signal loss
      when [cache_invalidated] replaces the original broadcast text. *)
   let pre_extract_mention = Mention.extract content in


### PR DESCRIPTION
코드는 RFC 번호 174개를 인용한다. 그중 **7개는 문서가 `docs/` 에도 `~/me/docs/rfc/` 에도 없다.**

CLAUDE.md 는 특정 subsystem 작업 전 `ls docs/rfc/ ~/me/docs/rfc/` 로 관련 RFC 를 발견해 인용하라고 요구한다. 코드가 가리키는 RFC 가 없으면 그 절차가 빈손으로 끝난다.

| RFC | 경위 |
|---|---|
| `RFC-0023`, `RFC-0061`, `RFC-0066` | "ghost RFC 철회" 작업으로 아카이브 (#17281, #17288) |
| `RFC-0007` | #18834 에서 삭제 |
| `RFC-0313` | Keeper governance → Gate 교체와 함께 삭제 (#24332) |
| `RFC-0211` | Persona hard-cut 과 함께 삭제 (#27048, 2026-08-07) |
| `RFC-0021` | 추가한 커밋이 한 번도 없음 |

## 규범적 주장을 담은 2건

```
consumers (auth, keeper dispatch) must not call it: per RFC-0211 a runtime id
is opaque to the masc core ...
```
```
... the queue grows unbounded (RFC-0313 W2 loop-safety requirement).
```

둘 다 확인 불가능한 권위를 근거로 든다. 다만 **두 주석 모두 규칙과 그 이유를 바로 옆에 이미 서술하고 있어** 번호만 떼면 정보 손실이 없다.

`keeper_config.mli` 의 `@since RFC-0066 Phase 1: changed from a string value to a thunk` 은 과거 변경 기록이고, 바로 위 문단이 그 collapse 를 이미 설명한다.

## 남긴 것

`RFC-0026` 은 파일이 없지만 `docs/` 안에서 15회 참조된다. 태그가 여전히 어딘가로 이어지므로 유지했다.

## 검증

- `dune build @check`: EXIT=0
- `npx tsc --noEmit`: EXIT=0
- 주석/문서 문자열만 변경
