### PR TITLE
chore(eio): cancel-guard 오탐 17건에 이유와 함께 마커 부여 (32 → 15)

### DIFF
--- a/lib/activity_graph/activity_graph.ml
+++ b/lib/activity_graph/activity_graph.ml
@@ -246,7 +246,7 @@ let rec past_day_cache_insert path mtime parsed =
     past_day_cache_insert path mtime parsed
 
 let file_mtime path =
-  try Some (Unix.stat path).Unix.st_mtime with _ -> None
+  try Some (Unix.stat path).Unix.st_mtime with _ -> None  (* cancel-guard-ok: guards Unix.stat: no Eio cancellation point *)
 
 let reset_past_day_cache_for_testing () = Atomic.set past_day_cache Past_day_path_map.empty
 

--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -199,7 +199,7 @@ let ensure_flusher_actor store =
             in
             if cas_won then
               try start_flusher_actor ~sw store
-              with exn ->
+              with exn ->  (* cancel-guard-ok: re-raises after rolling the flag back *)
                 (* Roll the flag back so a future caller can retry.  Only
                    roll back if the state hasn't been swapped out from
                    under us. *)

--- a/lib/core/masc_runtime_events.ml
+++ b/lib/core/masc_runtime_events.ml
@@ -62,7 +62,7 @@ let pid_is_live pid =
   match Unix.kill pid 0 with
   | () -> true
   | exception Unix.Unix_error (Unix.ESRCH, _, _) -> false
-  | exception _ -> true
+  | exception _ -> true  (* cancel-guard-ok: guards a blocking syscall: no Eio cancellation point *)
 
 let prune_stale_dumps ~dir =
   if preserve_requested ()

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -1429,7 +1429,7 @@ let parse_line ~file_path (line : string) : chat_message option =
                   let data = Json_util.get_string_with_default att_json ~key:"data" ~default:"" in
                   if id = "" || data = "" then None
                   else Some { id; att_type; name; size; mime_type; data }
-                with _ -> None)
+                with _ -> None)  (* cancel-guard-ok: guards pure Json_util reads: no Eio cancellation point *)
             | _ -> None
           ) att_list in
           if atts = [] then None else Some atts

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -169,7 +169,7 @@ let recent_user_messages (msgs : Agent_sdk.Types.message list) ~(max_n : int) : 
 
 (* RFC-0149 §3.1: pure list -> list filter extracted so the legacy
    silent-fallback path and the [_result] variant share the same
-   per-line parsing logic.  The per-line [try ... with exn -> log +
+   per-line parsing logic.  The per-line [try ... with exn -> log + (* cancel-guard-ok: prose *)
    counter + None] is preserved here — that is a separate boundary
    (JSONL corruption) from the file-read IO fault. *)
 let history_user_messages_from_lines

--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -79,7 +79,7 @@ let observe_phase_dwell ~keeper_name ~from_label =
   | Some prev_at ->
     let now = Unix.gettimeofday () in
     let dwell = Float.max 0.0 (now -. prev_at) in
-    (* Cancel-aware: bare [try ... with _ -> ()] would swallow
+    (* Cancel-aware: bare [try ... with _ -> ()] would swallow (* cancel-guard-ok: prose; the code below routes through Safe_ops.protect *)
        [Eio.Cancel.Cancelled] and break switch teardown. *)
     Safe_ops.protect ~default:() (fun () ->
       Otel_metric_store.observe_histogram

--- a/lib/multimodal/workspace_holder.ml
+++ b/lib/multimodal/workspace_holder.ml
@@ -19,7 +19,7 @@ let update f =
   Mutex.lock mutex;
   let next =
     try f !workspace_ref
-    with exn ->
+    with exn ->  (* cancel-guard-ok: re-raises below *)
       Mutex.unlock mutex;
       raise exn
   in

--- a/lib/otel_runtime_observables.ml
+++ b/lib/otel_runtime_observables.ml
@@ -71,7 +71,7 @@ let walk_dir_totals root =
   let files = ref 0 in
   let rec go path =
     match (Unix.LargeFile.lstat path : Unix.LargeFile.stats) with
-    | exception _ -> ()
+    | exception _ -> ()  (* cancel-guard-ok: guards Unix.stat: no Eio cancellation point *)
     | st ->
       (match st.st_kind with
        | Unix.S_REG ->
@@ -79,7 +79,7 @@ let walk_dir_totals root =
          incr files
        | Unix.S_DIR ->
          (match Sys.readdir path with
-          | exception _ -> ()
+          | exception _ -> ()  (* cancel-guard-ok: guards Sys.readdir: no Eio cancellation point *)
           | entries ->
             Array.iter (fun e -> go (Filename.concat path e)) entries)
        | _ -> ())

--- a/lib/process/file_lock_eio.ml
+++ b/lib/process/file_lock_eio.ml
@@ -216,8 +216,8 @@ let acquire_flock_retry ?clock:(_clock = None) ~lock_path ~mode ~perm
       end
   in
   try acquire max_attempts
-  with exn ->
-    (try Unix.close fd with Unix.Unix_error _ -> ());
+  with exn ->  (* cancel-guard-ok: re-raises below *)
+    (try Unix.close fd with Unix.Unix_error _ -> ());  (* cancel-guard-ok: re-raises below *)
     raise exn
 
 (** Fiber-friendly wrapper around [acquire_flock_retry].
@@ -259,7 +259,7 @@ let acquire_flock_retry_cooperative ?clock ~lock_path ~mode ~perm
       end
   in
   try acquire max_attempts
-  with exn ->
+  with exn ->  (* cancel-guard-ok: re-raises below *)
     run_blocking_lock_op (fun () -> try Unix.close fd with Unix.Unix_error _ -> ());
     raise exn
 

--- a/lib/server/masc_grpc_service.ml
+++ b/lib/server/masc_grpc_service.ml
@@ -302,7 +302,7 @@ let handle_heartbeat
       Atomic.decr active_heartbeat_streams;
       Transport_metrics.set_grpc_active_streams (Atomic.get active_heartbeat_streams);
       (* Called from [End_of_file] at line 360 and the generic-[exn] handler
-         at line 371 — neither is a cancel handler. [with _ -> ()] would
+         at line 371 — neither is a cancel handler. [with _ -> ()] would (* cancel-guard-ok: prose; the code below re-raises *)
          swallow [Eio.Cancel.Cancelled] racing with [Stream.close], leaving
          the fiber to fall past the cancel boundary. The counters above are
          decremented first, so re-raising here is safe. *)

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -1152,7 +1152,7 @@ let ws_upgrade_accept (request : Httpun.Request.t) : (string, string) result =
   | `GET, Some upgrade, Some connection, Some key, Some "13"
     when ci_eq upgrade "websocket"
          && connection_lists_upgrade connection
-         && (try String.length (Base64.decode_exn key) = 16 with _ -> false) ->
+         && (try String.length (Base64.decode_exn key) = 16 with _ -> false) ->  (* cancel-guard-ok: guards a pure decode: no Eio cancellation point *)
     Ok (sec_websocket_accept key)
   | _ -> Error "websocket upgrade request did not pass RFC 6455 §4.2.1 scrutiny"
 

--- a/lib/shutdown.ml
+++ b/lib/shutdown.ml
@@ -151,11 +151,11 @@ let start_process_deadline_watchdog ~timeout_s =
                   Thread.delay timeout_s;
                   if Atomic.compare_and_set state Armed Fired then
                     Unix._exit process_deadline_exit_code
-                with _ ->
+                with _ ->  (* cancel-guard-ok: raw Thread.create body: Cancelled cannot arrive *)
                   if Atomic.compare_and_set state Armed Fired then
                     Unix._exit process_deadline_start_failure_exit_code)
               ())
-       with exn -> Error (Watchdog_thread_start_failed (Printexc.to_string exn))
+       with exn -> Error (Watchdog_thread_start_failed (Printexc.to_string exn))  (* cancel-guard-ok: Thread.create failure, not an Eio context *)
      with
      | Ok thread -> Ok { state; thread }
      | Error _ as error -> error)

--- a/lib/telemetry_unified/telemetry_unified.ml
+++ b/lib/telemetry_unified/telemetry_unified.ml
@@ -552,7 +552,7 @@ let trace_file_within_since ~since_ts path =
   | Some since ->
     (match Unix.stat path with
      | st -> st.Unix.st_mtime >= since
-     | exception _ -> true)
+     | exception _ -> true)  (* cancel-guard-ok: guards a blocking syscall: no Eio cancellation point *)
 
 let read_trajectory_tool_calls ~masc_root ?keeper_name ?since_ts ?until_ts ~n ()
     : Yojson.Safe.t list =

--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -334,7 +334,7 @@ let turn_completed_events (config : Workspace.config) ~agent_name ~limit :
        let ts = Float.of_int e.ts_ms /. 1000.0 in
        (* Pure-shape JSON access via Safe_ops: no exception swallow, no
           performative [Cancelled] re-raise. Behavior parity with the prior
-          [try ... |> to_X with _ -> default] pattern on missing/wrong-typed
+          [try ... |> to_X with _ -> default] pattern (* cancel-guard-ok: prose *) on missing/wrong-typed
           fields; widens acceptance to string-coerced numerics per the
           codebase convention documented in Safe_ops.json_*_opt. *)
        let keeper_name = Safe_ops.json_string ~default:"unknown" "keeper_name" e.payload in


### PR DESCRIPTION
`scripts/lint-cancel-guard.sh` 가 32 건을 보고했다. 32 건을 전부 읽은 결과:

| | 건수 |
|---|---|
| 실제 흡수 (#27523 에서 수정) | **11** |
| 오탐 (이 PR 이 마킹) | **17** |
| 소유자 판단 (마킹하지 않음) | **4** |

린트 자신의 `cancel-guard-ok` 탈출구에 **이유 한 줄씩**을 달았다. 숫자가 부채를 과장하지 않게 되고, 다음 사람이 32 건을 다시 열지 않아도 된다.

## 왜 린트를 똑똑하게 만들지 않았나 — 두 번 시도했고 두 번 다 더 나빠졌다

- **주석 안 매치 제외**: OCaml 주석 중첩 추적이 필요한데, 문자열 리터럴을 모르는 깊이 카운터가 `keeper_chat_queue.ml:1583` **네 줄 위에서 이미 depth=1** 이었다. 진짜 흡수 2 건이 숨었다.
- **재발생 핸들러 제외**: 핸들러 본문의 끝이 필요한데, "다음 최상위 바인딩" 으로 잡으니 수백 줄을 훑어 **진짜 흡수 8 건이 숨었다.**

둘 다 line 기반으로는 안 되고 파서를 원한다. 상세는 #27521. **탈출구는 정확히 이 상황을 위해 이미 있었고**, 마커는 근거를 독자가 있는 자리에 남긴다.

## 17 건의 분류

**핸들러가 재발생 (4)** — `file_lock_eio.ml:219` · `:262` · `workspace_holder.ml:22` · `board_dispatch.ml:202`(플래그 롤백 후 재발생)

**비-Eio 문맥 (2)** — `shutdown.ml:154` · `:158` (원시 `Thread.create` 워치독)

**본문에 Eio 취소 지점 없음 (7)** — `otel_runtime_observables.ml:74`(`Unix.stat`) · `:82`(`Sys.readdir`) · `telemetry_unified.ml:555` · `masc_runtime_events.ml:65` · `activity_graph.ml:249`(`Unix.stat`) · `keeper_chat_store.ml:1432`(순수 `Json_util`) · `server_mcp_transport_ws.ml:1155`(`Base64.decode_exn`)

**매치가 주석 안의 산문 (4)** — `keeper_turn_fsm.ml` · `keeper_memory_recall.ml` · `tool_agent_timeline.ml` · `masc_grpc_service.ml`

마지막 부류는 짚어둘 만하다. `masc_grpc_service` 의 주석은 그 코드가 **왜 재발생하는지** 설명한다 — *"[with _ -> ()] would swallow [Eio.Cancel.Cancelled] ... re-raising here is safe"* — 그리고 린트는 **그 설명을 위반으로 보고하고 있었다.**

## 일부러 마킹하지 않은 4 건

오독이 아니라 **결정**이기 때문이다.

| 사이트 | 남긴 이유 |
|---|---|
| `auth.ml:135` | `with _ -> false`. 결과는 fail-closed 라 안전하지만 취소가 "검증 실패" 로 읽힌다 |
| `session_lifecycle_event.ml:219` | 문서화된 삼킴이나, 그 근거가 observer 실패를 다루지 취소는 아니다 |
| `keeper_turn_driver_admission.ml:13` | release 경로 |
| `server_runtime_bootstrap.ml:1476` | 문맥 미확인 |

**이 PR 이후 린트는 15 를 보고한다** — 위 4 건 + #27523 이 없앨 11 건. 그것이 머지되면 **4** 가 되고, 넷 다 사람이 답해야 할 진짜 질문이다.

| 항목 | 결과 |
|---|---|
| `dune build --root . @check` | exit 0 |
| `lint-cancel-guard.sh` | **32 → 15** |
| `scripts/lint/*.sh` 전체 | exit 0 |
| `check-pr-hygiene.sh --base origin/main` | exit 0 |

## 작업 중 자기 오류

마커 둘이 **매치되는 줄이 아니라 이웃 줄**에 붙어 아무것도 억제하지 못했다. 개수로 확인해 매치 줄로 옮겼다. 린트가 마커를 찾는 곳은 매치된 그 줄이다.
