### PR TITLE
docs(env): 코드가 읽지 않는 계약 항목 제거 및 머신 절대경로 해제

### DIFF
--- a/docs/ENV-CONTRACT.md
+++ b/docs/ENV-CONTRACT.md
@@ -64,11 +64,11 @@ should be treated as restart-required.
 
 Representative code paths:
 
-- [`server_runtime_bootstrap.ml`](/Users/dancer/me/workspace/yousleepwhen/masc/lib/server/server_runtime_bootstrap.ml)
-- [`config_dir_resolver.ml`](/Users/dancer/me/workspace/yousleepwhen/masc/lib/config_dir_resolver.ml)
-- [`server_bootstrap_http.ml`](/Users/dancer/me/workspace/yousleepwhen/masc/lib/server/server_bootstrap_http.ml)
-- [`keeper_runtime_config.ml`](/Users/dancer/me/workspace/yousleepwhen/masc/lib/keeper/keeper_runtime_config.ml)
-- [`keeper_tool_policy.ml`](/Users/dancer/me/workspace/yousleepwhen/masc/lib/keeper/keeper_tool_policy.ml)
+- [`server_runtime_bootstrap.ml`](../lib/server/server_runtime_bootstrap.ml)
+- [`config_dir_resolver.ml`](../lib/config_dir_resolver/config_dir_resolver.ml)
+- [`server_bootstrap_http.ml`](../lib/server/server_bootstrap_http.ml)
+- [`keeper_runtime_config.ml`](../lib/keeper_runtime/keeper_runtime_config.ml)
+- [`keeper_tool_policy.ml`](../lib/keeper/keeper_tool_policy.ml)
 
 ### 2. Env-backed defaults that become runtime-dynamic through `Runtime_params`
 
@@ -82,9 +82,9 @@ runtime parameter authority is `Runtime_params`, not the parent shell env.
 
 Representative code paths:
 
-- [`runtime_params.ml`](/Users/dancer/me/workspace/yousleepwhen/masc/lib/runtime_params.ml)
-- [`keeper_config.ml`](/Users/dancer/me/workspace/yousleepwhen/masc/lib/keeper/keeper_config.ml)
-- [`server_routes_http_routes_activity.ml`](/Users/dancer/me/workspace/yousleepwhen/masc/lib/server/server_routes_http_routes_activity.ml)
+- [`runtime_params.ml`](../lib/runtime_params.ml)
+- [`keeper_config.ml`](../lib/keeper/keeper_config.ml)
+- [`server_routes_http_routes_activity.ml`](../lib/server/server_routes_http_routes_activity.ml)
 
 ### 3. Accessor-shaped env readers with limited live effect
 
@@ -101,10 +101,10 @@ consumer is known to act on every request/turn.
 Examples:
 
 - Transport feature flags in
-  [`env_config_runtime.ml`](/Users/dancer/me/workspace/yousleepwhen/masc/lib/config/env_config_runtime.ml)
+  [`env_config_runtime.ml`](../lib/config/env_config_runtime.ml)
   are accessor-shaped, but listener lifecycles remain boot-static.
 - `Config_dir_resolver` helpers read env accessors, but
-  [`resolve()`](/Users/dancer/me/workspace/yousleepwhen/masc/lib/config_dir_resolver.ml#L321)
+  [`resolve()`](../lib/config_dir_resolver/config_dir_resolver.ml)
   caches the result, so root changes are boot-static.
 
 ### 4. Execute exec gates (`request_dynamic`, additive-only)
@@ -118,16 +118,10 @@ never break by enabling them.
 Operator rollout procedure and observer log interpretation: see
 [`EXECUTE-RUNBOOK.md`](./EXECUTE-RUNBOOK.md).
 
-| Variable | Default | Effect |
-| --- | --- | --- |
-| `MASC_BASH_SEMANTIC_EXIT` | **on** (post flip PR) | Emits a `return_code_interpretation` object (typed `semantic_exit`) alongside the raw `status`. Set to `0` / `false` / `no` / `off` to opt out and restore the pre-P1 byte-identical shape. See `lib/exec/exec_semantic.mli`. |
-| `MASC_BASH_OUTPUT_CAP` | on (500 KB head + 500 KB tail each) | Head+tail truncation via `Exec_buffer`. `MASC_BASH_CAP_HEAD` / `MASC_BASH_CAP_TAIL` override the per-stream caps. See `lib/exec/exec_buffer.mli`. |
-
 Representative code paths:
 
-- [`exec_semantic.ml`](/Users/dancer/me/workspace/yousleepwhen/masc/lib/exec/exec_semantic.ml)
-- [`exec_buffer.ml`](/Users/dancer/me/workspace/yousleepwhen/masc/lib/exec/exec_buffer.ml)
-- [`exec_policy.ml`](/Users/dancer/me/workspace/yousleepwhen/masc/lib/exec_policy/exec_policy.ml) — Shell_command_gate policy integration
+- [`exec_buffer.ml`](../lib/core/exec_buffer.ml)
+- [`exec_policy.ml`](../lib/exec_policy/exec_policy.ml) — Shell_command_gate policy integration
 
 Because every flag here is `request_dynamic` on the Execute path
 (read at tool-invocation time), operators can flip a flag without a
@@ -156,8 +150,6 @@ Precedence:
 | `MASC_WEB_SEARCH_FALLBACKS` | built-in fallback order | Overrides fallback providers after the primary provider fails. |
 | `MASC_WEB_SEARCH_TIMEOUT_SEC` | `15` | Per-provider request timeout. |
 | `MASC_WEB_SEARCH_CACHE_TTL_SEC` | `30.0` | In-process WebSearch cache TTL. |
-| `MASC_WEB_SEARCH_RATE_LIMIT_WINDOW_SEC` | `30.0` | In-process WebSearch rate-limit window. |
-| `MASC_WEB_SEARCH_RATE_LIMIT_MAX_CALLS` | `30` | In-process WebSearch rate-limit ceiling per window. |
 
 Equivalent `runtime.toml` keys:
 
@@ -169,16 +161,14 @@ provider_order = "searxng,brave,tavily,exa,bing_api"
 fallbacks = "duckduckgo,bing_rss"
 timeout_sec = 15
 cache_ttl_sec = 30.0
-rate_limit_window_sec = 30.0
-rate_limit_max_calls = 30
 ```
 
 Representative code paths:
 
-- [`tool_misc_web_search.ml`](/Users/dancer/me/workspace/yousleepwhen/masc/lib/tool_misc_web_search.ml)
-- [`env_config_runtime.ml`](/Users/dancer/me/workspace/yousleepwhen/masc/lib/config/env_config_runtime.ml)
-- [`keeper_runtime_config.ml`](/Users/dancer/me/workspace/yousleepwhen/masc/lib/keeper_runtime/keeper_runtime_config.ml)
-- [`masc_network_defaults.ml`](/Users/dancer/me/workspace/yousleepwhen/masc/lib/config/masc_network_defaults.ml)
+- [`tool_misc_web_search.ml`](../lib/tool_misc_web_search.ml)
+- [`env_config_runtime.ml`](../lib/config/env_config_runtime.ml)
+- [`keeper_runtime_config.ml`](../lib/keeper_runtime/keeper_runtime_config.ml)
+- [`masc_network_defaults.ml`](../lib/config/masc_network_defaults.ml)
 
 ### 6. Test-only boot overrides
 
@@ -194,8 +184,8 @@ production launch knobs.
 
 Representative code paths:
 
-- [`workspace_utils_backend_setup.ml`](/Users/dancer/me/workspace/yousleepwhen/masc/lib/workspace/workspace_utils_backend_setup.ml)
-- [`config_dir_resolver.ml`](/Users/dancer/me/workspace/yousleepwhen/masc/lib/config_dir_resolver.ml)
+- [`workspace_utils_backend_setup.ml`](../lib/workspace/workspace_utils_backend_setup.ml)
+- [`config_dir_resolver.ml`](../lib/config_dir_resolver/config_dir_resolver.ml)
 
 ## Rules for New Environment Variables
 


### PR DESCRIPTION
`docs/ENV-CONTRACT.md` 는 운영자용 계약 문서다("This document defines the operator-facing contract"). 여기 적힌 변수 6개를 **코드가 읽지 않는다** — `lib/`, `bin/`, `scripts/` 전체에서 0건이다.

| 변수 | 문서가 약속한 것 |
|---|---|
| `MASC_BASH_SEMANTIC_EXIT` | 기본 **on**, `0/false/no/off` 로 opt-out 가능 |
| `MASC_BASH_OUTPUT_CAP` | 기본 on (500 KB head + 500 KB tail) |
| `MASC_BASH_CAP_HEAD` / `MASC_BASH_CAP_TAIL` | 스트림별 캡 오버라이드 |
| `MASC_WEB_SEARCH_RATE_LIMIT_WINDOW_SEC` | 기본 `30.0` |
| `MASC_WEB_SEARCH_RATE_LIMIT_MAX_CALLS` | 기본 `30` |

여섯 개 모두 #24332 와 함께 사라졌다. 운영자가 이 표를 보고 `MASC_BASH_OUTPUT_CAP=0` 을 설정하면 아무 일도 일어나지 않는다.

## 인용된 근거도 함께 썩어 있었다

- bash 행은 `lib/exec/exec_semantic.mli` 와 `lib/exec/exec_buffer.mli` 를 근거로 든다. **두 파일 다 없다.** `Exec_buffer` 는 `lib/core/` 로 이동했고, 캡을 **인자로 받으며 환경변수를 전혀 읽지 않는다.**
- 문서는 대체 수단으로 `runtime.toml` 의 `rate_limit_window_sec` / `rate_limit_max_calls` 를 제시한다. 두 키를 파싱하는 코드도 없다. 바로 옆에 나열된 `cache_ttl_sec` 은 있다(47곳).

## 절대경로 링크 19개

본문 링크가 특정 머신 체크아웃 경로로 박혀 있었다.

```
[`server_runtime_bootstrap.ml`](/Users/dancer/me/workspace/yousleepwhen/masc/lib/server/...)
```

그중 4개는 그 머신에서도 열리지 않는다 — `config_dir_resolver.ml`, `exec_buffer.ml`, `keeper_runtime_config.ml` 은 이동했고 `exec_semantic.ml` 은 삭제됐다. 전부 repo-relative 로 바꾸고 실재하는 파일을 가리키게 했다. `#L321` 줄 앵커도 제거했다(줄 번호는 파일과 함께 썩는다).

## 가드가 이걸 못 잡는 이유

`scripts/check-doc-code-refs.sh` 는 통과한다. 그 가드는 frontmatter 의 `code_refs` 만 검사하고 **본문 링크는 범위 밖**이다. 이번에 고친 19개 링크는 전부 본문에 있었다.

## 검증

- `bash scripts/check-doc-code-refs.sh`: EXIT=0
- 문서 내 `/Users/dancer` 잔존: 0
- 본문 상대링크 전수 확인: 깨진 링크 0
- 문서만 변경 (+18/-28)
