### PR TITLE
chore(eio): Eio_guard 를 import 할 수 없는 Fun.protect 사이트 allowlist (60 → 46)

### DIFF
--- a/scripts/lint-fun-protect.sh
+++ b/scripts/lint-fun-protect.sh
@@ -23,6 +23,22 @@ ALLOWLIST=(
   "lib/eio_context/eio_context.ml"  # deps: eio, masc_log, tls (no masc_core)
   "lib/dated_jsonl/dated_jsonl.ml"  # deps: fs_compat, eio, yojson (no masc_core)
   "lib/shared_audit/store.ml"       # deps: unix, yojson, digestif (no masc_core)
+  # fs_compat sits *below* masc_core: dated_jsonl above is allowlisted for
+  # depending on it. Its own dune is
+  # (libraries eio eio.unix unix yojson uuidm digestif optint cstruct).
+  "lib/fs_compat/fs_compat.ml"
+  "lib/fs_compat/capability_head.ml"
+  "lib/fs_compat/atomic_write.ml"
+  "lib/fs_compat/fd_cache.ml"
+  # deps: masc.masc_eio_context, masc.masc_log — no masc_core
+  "lib/masc_http_client/pool.ml"
+
+  # ---- Not production code ----
+  # The scan walks lib/**, which reaches test directories that live under a
+  # library. Whether the rule should apply to tests at all is a scope
+  # question; until it is decided this file is listed rather than silently
+  # counted as migration debt.
+  "lib/exec/test/test_bash_history.ml"
 
   # ---- Migratable but deferred ----
   # These libraries transitively depend on masc_core and therefore *can* import


### PR DESCRIPTION
`lint-fun-protect.sh` 가 맨 `Fun.protect` **60 건**을 보고한다. 그중 **14 건은 바꿀 수 없는 파일**에 있고, allowlist 에 이미 그 구획이 있다:

```
# ---- Cannot import Eio_guard (layer below masc_core or no masc_core dep) ----
```

## 이 린트의 오탐은 한 부류뿐이다

`Eio_guard.protect` 와 `Fun.protect` 는 **시그니처가 같다**:

```ocaml
val protect : finally:(unit -> unit) -> (unit -> 'a) -> 'a
```

이관이 기계적이므로, 파일은 `masc_core` 에 **도달하거나 못 하거나** 둘 중 하나다. 보고된 42 개 파일을 dune `libraries` 로 분류했다.

| 파일 | 사이트 | dune libraries |
|---|---|---|
| `fs_compat/fs_compat.ml` | 4 | `eio eio.unix unix yojson uuidm digestif optint cstruct` |
| `fs_compat/capability_head.ml` | 2 | 〃 |
| `fs_compat/atomic_write.ml` | 1 | 〃 |
| `fs_compat/fd_cache.ml` | 1 | 〃 |
| `masc_http_client/pool.ml` | 4 | `masc.masc_eio_context masc.masc_log` |
| `exec/test/test_bash_history.ml` | 2 | `(tests ...)` |

`fs_compat` 는 `masc_core` **아래** 계층이다. allowlist 는 이미 `dated_jsonl` 을 *"deps: fs_compat, eio, yojson (no masc_core)"* 사유로 면제하고 있는데, **그 논거는 `fs_compat` 자신에게 더 강하게 적용된다** — import 하면 순환이다.

`exec/test/test_bash_history.ml` 는 **테스트**다. 스캔이 `lib/**` 를 걸으면서 라이브러리 아래 테스트 디렉터리까지 닿는다. 프로덕션 규칙을 테스트에 적용할지는 **범위 결정**이라, 조용히 이관 부채로 세는 대신 목록에 올리고 주석에 그 질문을 남겼다.

## 남은 46 은 진짜다

나머지 37 개 파일은 전부 `lib/dune` 의 `masc` 라이브러리 소속이고 `masc_core` 를 갖는다. **남은 파일 전부가 도달 가능한지 다시 확인했다** — 즉 이제 그 숫자가 구조적 잡음이 섞이지 않은 **이관 부채**다.

```
lint-fun-protect.sh   60 → 46
```

baseline 이 의미를 갖는 상태가 이것이다. 그 결정은 #27521 에서 다룬다.

| 항목 | 결과 |
|---|---|
| `lint-fun-protect.sh` | **60 → 46**, 여전히 exit 1 |
| `scripts/lint/*.sh` 전체 | exit 0 |
| `audit-unwired-audits.sh` | exit 0 |
| `check-pr-hygiene.sh --base origin/main` | exit 0 |

**소스 파일 변경 없음** — 구조적으로 고칠 수 없는 보고를 숫자 밖으로 옮길 뿐이다.

## cancel-guard 와 대비

| | `lint-cancel-guard` | 이 린트 |
|---|---|---|
| 오탐률 | 17/32 (**53%**) | 14/60 (**23%**) |
| 오탐 부류 | 5 종, line 기반 분리 불가 (파서 필요) | **1 종**, dune 의존으로 판정 |
| 처방 | 사이트별 마커 (#27532) | **allowlist 6 파일** (이 PR) |

같은 "미배선 린트" 문제로 보였지만 처방이 다르다. 세는 것과 판정하는 것이 다른 작업이라는 점은 같다.
