### PR TITLE
fix(lint): magic-number 리포트가 리터럴을 잃고 RFC 번호를 세던 문제 (55 → 3)

### DIFF
--- a/scripts/lint-magic-number.sh
+++ b/scripts/lint-magic-number.sh
@@ -64,7 +64,12 @@ fi
 # Build per-file literal histogram. Strip lines that are comments,
 # test fixtures, or generated artifacts (.mli signatures live with .ml).
 # We accept any digit run >= MIN_DIGITS, prefixed by a word boundary.
-LITERAL_RE="\\b[0-9]{${MIN_DIGITS},}\\b"
+# A digit run touching a hyphen is part of an identifier or a date, not a
+# literal: RFC-0206, PK-12345, 2026-05-16. Excluding a hyphen on either
+# side drops both without touching real literals, which sit next to
+# whitespace, "(", "=" or an operator. "RFC 6455" needs its own lookbehind
+# because the separator there is a space.
+LITERAL_RE="(?<!RFC )(?<![-\\w.])[0-9]{${MIN_DIGITS},}(?![-\\w.])"
 
 tmp="$(mktemp)"
 trap 'rm -f "$tmp"' EXIT
@@ -74,7 +79,7 @@ trap 'rm -f "$tmp"' EXIT
 rg -onP --with-filename "$LITERAL_RE" "$TARGET" 2>/dev/null \
   | awk -F: '{ printf "%s\t%s\n", $1, $3 }' \
   | sort | uniq -c | sort -rn \
-  | awk -v min="$MIN_REPS" '$1 >= min { print $1"\t"$2 }' > "$tmp"
+  | awk -v min="$MIN_REPS" '$1 >= min { n=$1; sub(/^ *[0-9]+ +/, ""); print n"\t"$0 }' > "$tmp"
 
 # Output: count<TAB>file<TAB>literal
 awk -F'\t' '{ printf "%5d  %-60s  %s\n", $1, $2, $3 }' "$tmp"


### PR DESCRIPTION
`#27521` 을 위해 `lint-magic-number.sh` 의 오탐률을 재려다 결함 둘을 찾았다.

## 1. 리포트가 리터럴을 출력한 적이 없다

```bash
| sort | uniq -c | sort -rn \
| awk -v min="$MIN_REPS" '$1 >= min { print $1"\t"$2 }' > "$tmp"
```

`uniq -c` 는 `개수 파일<TAB>리터럴` 을 낸다. 그 awk 가 **기본 필드 구분자**로 읽으므로 `$2` 가 파일이고 `$3` 의 리터럴이 버려진다. 마지막 줄은 `%5d %-60s %s` 로 찍지만 셋째 칸이 늘 비어 있었다:

```
   20  lib/config/env_config_keeper.ml
   12  lib/runtime/runtime.ml
```

**어떤 숫자가 반복되는지 말하지 않는 매직넘버 리포트는 트리아지할 수 없다.** 이 개수가 손대지 않은 채 남아 있던 이유가 이것이다.

## 2. 패턴이 식별자 꼬리를 잡았다

```bash
LITERAL_RE="\b[0-9]{${MIN_DIGITS},}\b"
```

`\b` 는 `-` 를 경계로 보므로 `RFC-0206` 에서 `0206`, `2026-05-16` 에서 `2026` 이 나온다. 리터럴을 복구하고 나서야 최상위 히트가 **숫자가 아니라 인용**임이 보였다:

```
12  lib/runtime/runtime.ml   0206   → "RFC-0206" ×12, 전부 주석
12  lib/dune                 0056   → "RFC-0056" ×12, 전부 주석
 9  lib/keeper/keeper_hooks_oas.ml  2026 → "2026-05-16" 날짜
```

파이프라인에서 복구 가능한 46 쌍을 분류한 결과: **RFC 인용 35 · 기타 주석 산문 4 · `lib/dune` 1 · 코드 6.**

## 수정

awk 는 개수 뒤의 나머지 줄을 그대로 살리고, 패턴은 양쪽 하이픈에 닿는 숫자와 `RFC ` 공백형을 제외한다.

```
lint-magic-number.sh   55 → 3
```

## 남은 셋을 판정했다

| 리터럴 | 위치 | 판정 |
|---|---|---|
| `4096` ×5 | `board_core_persist.ml` — `Hashtbl.create 4096` | **진짜.** 이 린트가 존재하는 이유인 반복 용량 |
| `1024` ×20 | `env_config_keeper.ml` — `64 * 1024 * 1024` | **단위 변환.** `software-development.md` 가 명시 면제 |
| `8352` ×7 | `env_config_core.ml` — `"(issue 8352)"` | **주석 속 이슈 번호** |

즉 잔여 부류가 하나 남는다 — **산문에서 단어가 소개하는 숫자**(`issue 8352`, 그리고 lookbehind 전의 `RFC 6455`). 단어를 하나씩 제외하는 것은 두더지잡기이고, 일반해(매치가 주석 안인지 아는 것)는 OCaml 주석 중첩을 요구하는데 **같은 종류의 순진한 시도가 #27521 에서 두 번 틀렸다.** 그래서 패치하지 않고 기록한다.

| 항목 | 결과 |
|---|---|
| `lint-magic-number.sh` | **55 → 3**, 리터럴 칸 채워짐 |
| `--strict` | exit 1 (동작 불변) |
| `--explain 4096` | 사이트 나열됨 |
| `scripts/lint/*.sh` 전체 | exit 0 |
| `check-pr-hygiene.sh --base origin/main` | exit 0 |

## 미배선 린트 넷의 오탐률이 이제 셋까지 측정됐다

| 린트 | 보고 | 실제 | 처방 |
|---|---|---|---|
| `lint-cancel-guard` | 32 | 11 (34%) | 사이트별 마커 (#27532) |
| `lint-fun-protect` | 60 | 46 (77%) | allowlist 6 파일 (#27534) |
| **`lint-magic-number`** | **55** | **3 (5%)** | **이 PR — 린트 자체 수정** |
| `lint-ignore-without-comment` | 33 | 미측정 | — |

세 린트의 처방이 전부 달랐다. **세는 것과 판정하는 것은 다른 작업**이라는 점만 같다.
