### PR TITLE
fix(lint): ignore-without-comment 이 버림 관용구 4종을 알게 한다 (33 → 19)

### DIFF
--- a/scripts/lint-ignore-without-comment.sh
+++ b/scripts/lint-ignore-without-comment.sh
@@ -85,6 +85,21 @@ while IFS= read -r site; do
   same_line_ok=0
   prev_line_ok=0
 
+  # Shapes where discarding is the construct, not a dropped contract. The
+  # rule exists so a reader learns *why* a return value goes away; in these
+  # the code already says it.
+  #
+  #   Atomic.fetch_and_add / Atomic.exchange — the previous value is what
+  #     you throw away to use them as counters
+  #   ignore (e : t)                         — the annotation names exactly
+  #     what is dropped, which is the justification in typed form
+  #   Queue.pop / Stack.pop                  — popped for the side effect
+  #   force_link                             — referenced so the linker
+  #     keeps the module; discarding is the whole point
+  if printf '%s\n' "$body" | rg -qP '(Atomic\.(fetch_and_add|exchange|incr|decr)|Queue\.(pop|take)|Stack\.pop|force_link|:\s*[A-Za-z_\[][^)]*\)+\s*$)'; then
+    continue
+  fi
+
   if printf '%s\n' "$body" | rg -qP "$JUSTIFY_RE"; then
     same_line_ok=1
   fi


### PR DESCRIPTION
`ignore (...)` 가 반환값을 왜 버리는지 말해야 한다는 규칙이다. **네 가지 모양에서는 코드가 이미 말하고 있다.**

| 관용구 | 왜 근거가 이미 있나 |
|---|---|
| `Atomic.fetch_and_add` / `exchange` / `incr` / `decr` | 이전 값을 버리는 것이 **카운터로 쓰는 방법 그 자체**다. 뒤에 계약이 없다 |
| `ignore (e : t)` | 주석이 **무엇을 버리는지 이름을 댄다.** 산문 대신 타입으로 쓴 근거이고, 코드와 어긋날 수 없다 |
| `Queue.pop` · `Queue.take` · `Stack.pop` | 부수효과 목적 |
| `ignore (Module.force_link, ...)` | 링커가 모듈을 유지하도록 참조하는 것이 목적 |

```
lint-ignore-without-comment.sh   33 → 19
```

## 일부러 계속 보고하는 것

`ignore (Keeper_fs.ensure_dir ...)` 계열이다. `ensure_dir : string -> string` 은 경로를 돌려주므로 **조용히 실패하는 것은 없다.** 다만 *"경로를 돌려주지만 부수효과만 쓴다"* 한 줄을 요구하는 것은 **규칙이 작동하는 것이지 잡음이 아니다.**

`#27521` 에서 오탐률을 재며 이것들을 오탐으로 분류했는데, **그 분류가 틀렸다.** 제외하는 대신 여기서 정정한다.

## 측정 중 두 번 잘못 갈 뻔했다 — 기록해둔다

1. `ignore (Keeper_fs.ensure_dir ...)` 가 4 회 나와 **버려진 `Result` 로 보고할 뻔했다.** `.mli` 가 `string -> string` 이다.
2. 첫 타입 주석 패턴이 `: [A-Z\[]` 라 **`: bool` · `: int` 를 놓쳤다.** 완화한 형태는 뒤따르는 괄호도 허용해야 한다 — `ignore (f x : bool)))` 는 세 표현식을 한꺼번에 닫는다.

| 항목 | 결과 |
|---|---|
| `lint-ignore-without-comment.sh` | **33 → 19** |
| `--strict` | exit 1 (동작 불변) |
| `scripts/lint/*.sh` 전체 | exit 0 |
| `check-pr-hygiene.sh --base origin/main` | exit 0 |

**소스 파일 변경 없음.**

## 네 린트 처방이 전부 달랐다

| 린트 | 보고 → 실제 | 처방 |
|---|---|---|
| `lint-cancel-guard` | 32 → 11 | 사이트별 마커 (#27532) — 술어 수리 불가, 두 번 시도해 두 번 실패 |
| `lint-fun-protect` | 60 → 46 | allowlist 6 파일 (#27534) — dune 의존으로 판정 가능 |
| `lint-magic-number` | 55 → 3 | 도구 버그 2 개 수정 (#27536) |
| **`lint-ignore-without-comment`** | **33 → 19** | **술어가 관용구를 알게 함 (이 PR)** |

같은 "미배선 린트" 로 묶였던 넷이 각각 다른 문제였다.
