### PR TITLE
refactor(gate): sidecar 런타임 경로 레이아웃을 소유자 하나로

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1700,7 +1700,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_assertion_kind_mirror @test/runtest-test_workspace_heartbeat_outcome @test/runtest-test_workspace_root_state_parity"
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_assertion_kind_mirror @test/runtest-test_workspace_heartbeat_outcome @test/runtest-test_sidecar_runtime_layout @test/runtest-test_workspace_root_state_parity"
 
       # Four more suites landed on main without a runtest target (persona name
       # via #26962, tool-result demotion via #27013, verification authority

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -13,9 +13,9 @@ let display_name = "Discord"
 let channel = "discord"
 
 
-let default_status_path = ".gate/runtime/discord/status.json"
-let default_binding_store_path = ".gate/runtime/discord/bindings.json"
-let default_binding_audit_path = ".gate/runtime/discord/binding_audit.jsonl"
+let default_status_path = Channel_gate_sidecar_state.default_status_path ~connector_id
+let default_binding_store_path = Channel_gate_sidecar_state.default_binding_store_path ~connector_id
+let default_binding_audit_path = Channel_gate_sidecar_state.default_binding_audit_path ~connector_id
 
 let stale_after_sec () =
   Env_config_core.get_int ~default:30 "MASC_DISCORD_STATUS_STALE_SEC"

--- a/lib/gate/channel_gate_imessage_state.ml
+++ b/lib/gate/channel_gate_imessage_state.ml
@@ -10,9 +10,9 @@ let connector_id = "imessage"
 let display_name = "iMessage"
 let channel = "imessage"
 
-let default_status_path = ".gate/runtime/imessage/status.json"
-let default_binding_store_path = ".gate/runtime/imessage/bindings.json"
-let default_binding_audit_path = ".gate/runtime/imessage/binding_audit.jsonl"
+let default_status_path = Channel_gate_sidecar_state.default_status_path ~connector_id
+let default_binding_store_path = Channel_gate_sidecar_state.default_binding_store_path ~connector_id
+let default_binding_audit_path = Channel_gate_sidecar_state.default_binding_audit_path ~connector_id
 
 let stale_after_sec () =
   Env_config_core.get_int ~default:30 "MASC_IMESSAGE_STATUS_STALE_SEC"

--- a/lib/gate/channel_gate_sidecar_state.ml
+++ b/lib/gate/channel_gate_sidecar_state.ml
@@ -3,13 +3,29 @@
 module U = Yojson.Safe.Util
 module Store = Channel_gate_binding_store
 
+(* Every sidecar connector keeps its files under
+   [.gate/runtime/<connector_id>/]. The three default paths derive from the id
+   so relocating the tree, or adding a channel, does not re-spell the layout. *)
+let runtime_dir ~connector_id =
+  Filename.concat (Filename.concat ".gate" "runtime") connector_id
+;;
+
+let default_status_path ~connector_id =
+  Filename.concat (runtime_dir ~connector_id) "status.json"
+;;
+
+let default_binding_store_path ~connector_id =
+  Filename.concat (runtime_dir ~connector_id) "bindings.json"
+;;
+
+let default_binding_audit_path ~connector_id =
+  Filename.concat (runtime_dir ~connector_id) "binding_audit.jsonl"
+;;
+
 module type Config = sig
   val connector_id : string
   val display_name : string
   val channel : string
-  val default_status_path : string
-  val default_binding_store_path : string
-  val default_binding_audit_path : string
   val status_path_env_names : string list
   val binding_store_path_env_names : string list
   val binding_audit_path_env_names : string list
@@ -17,6 +33,10 @@ module type Config = sig
 end
 
 module Make (Config : Config) = struct
+  let default_status_path = default_status_path ~connector_id:Config.connector_id
+  let default_binding_store_path = default_binding_store_path ~connector_id:Config.connector_id
+  let default_binding_audit_path = default_binding_audit_path ~connector_id:Config.connector_id
+
   type binding = Store.binding = {
     channel_id : string;
     keeper_name : string;
@@ -44,17 +64,17 @@ module Make (Config : Config) = struct
 
   let status_path () =
     configured_write_path Config.status_path_env_names
-      ~default:Config.default_status_path
+      ~default:default_status_path
 
   let binding_store_path () =
     configured_write_path Config.binding_store_path_env_names
-      ~default:Config.default_binding_store_path
+      ~default:default_binding_store_path
 
   let binding_store_read_path = binding_store_path
 
   let binding_audit_path () =
     configured_write_path Config.binding_audit_path_env_names
-      ~default:Config.default_binding_audit_path
+      ~default:default_binding_audit_path
 
   let binding_audit_read_path = binding_audit_path
 

--- a/lib/gate/channel_gate_sidecar_state.mli
+++ b/lib/gate/channel_gate_sidecar_state.mli
@@ -4,13 +4,22 @@
     [.gate/runtime/<connector>/]. This functor wires those sidecars into the
     same dashboard bind/unbind and connector status API as Discord/iMessage. *)
 
+(** [.gate/runtime/<connector_id>] — the directory a sidecar connector's
+    files live in. *)
+val runtime_dir : connector_id:string -> string
+
+(** Default file locations for a sidecar connector, all under
+    [.gate/runtime/<connector_id>/]. Derived from the id so relocating the
+    tree, or adding a channel, does not re-spell the layout. *)
+val default_status_path : connector_id:string -> string
+
+val default_binding_store_path : connector_id:string -> string
+val default_binding_audit_path : connector_id:string -> string
+
 module type Config = sig
   val connector_id : string
   val display_name : string
   val channel : string
-  val default_status_path : string
-  val default_binding_store_path : string
-  val default_binding_audit_path : string
   val status_path_env_names : string list
   val binding_store_path_env_names : string list
   val binding_audit_path_env_names : string list

--- a/lib/gate/channel_gate_slack_state.ml
+++ b/lib/gate/channel_gate_slack_state.ml
@@ -20,9 +20,9 @@ let connector_id = "slack"
 let display_name = "Slack"
 let channel = "slack"
 
-let default_status_path = ".gate/runtime/slack/status.json"
-let default_binding_store_path = ".gate/runtime/slack/bindings.json"
-let default_binding_audit_path = ".gate/runtime/slack/binding_audit.jsonl"
+let default_status_path = Channel_gate_sidecar_state.default_status_path ~connector_id
+let default_binding_store_path = Channel_gate_sidecar_state.default_binding_store_path ~connector_id
+let default_binding_audit_path = Channel_gate_sidecar_state.default_binding_audit_path ~connector_id
 
 (* Slack has no Discord-style guilds; the bot token authorizes per-workspace.
    Path resolvers read an env override, else fall back to the default. *)

--- a/lib/gate/channel_gate_telegram_state.ml
+++ b/lib/gate/channel_gate_telegram_state.ml
@@ -4,9 +4,6 @@ include
       let connector_id = "telegram"
       let display_name = "Telegram"
       let channel = "telegram"
-      let default_status_path = ".gate/runtime/telegram/status.json"
-      let default_binding_store_path = ".gate/runtime/telegram/bindings.json"
-      let default_binding_audit_path = ".gate/runtime/telegram/binding_audit.jsonl"
       let status_path_env_names =
         [ "TELEGRAM_STATUS_PATH"; "MASC_TELEGRAM_STATUS_PATH" ]
       let binding_store_path_env_names =

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -242,13 +242,13 @@ let desired_record_of_json = function
 let sidecar_desired_path ~base_path id =
   Filename.concat
     base_path
-    (Printf.sprintf ".gate/runtime/%s/sidecar_lifecycle_desired.json" id)
+    (Filename.concat (Channel_gate_sidecar_state.runtime_dir ~connector_id:id) "sidecar_lifecycle_desired.json")
 ;;
 
 let sidecar_attempt_path ~base_path id =
   Filename.concat
     base_path
-    (Printf.sprintf ".gate/runtime/%s/sidecar_lifecycle_attempt.json" id)
+    (Filename.concat (Channel_gate_sidecar_state.runtime_dir ~connector_id:id) "sidecar_lifecycle_attempt.json")
 ;;
 
 (* Silent [Sys_error _ | Yojson.Json_error _ -> None] previously collapsed
@@ -536,17 +536,17 @@ let sidecar_status_retention_json ~base_path ~id ~status_path =
     [ "scope", `String "runtime_sidecar_status"
     ; "status_path", `String status_path
     ; "default_status_path"
-      , `String (Filename.concat base_path (Printf.sprintf ".gate/runtime/%s/status.json" id))
+      , `String (Filename.concat base_path (Channel_gate_sidecar_state.default_status_path ~connector_id:id))
     ; "legacy_status_path", `String (Filename.concat base_path (legacy_status_rel id))
     ; "lifecycle_desired_path", `String (sidecar_desired_path ~base_path id)
     ; "lifecycle_attempt_path", `String (sidecar_attempt_path ~base_path id)
     ; "binding_store_path"
-      , `String (Filename.concat base_path (Printf.sprintf ".gate/runtime/%s/bindings.json" id))
+      , `String (Filename.concat base_path (Channel_gate_sidecar_state.default_binding_store_path ~connector_id:id))
     ; "binding_audit_store_path"
       , `String
           (Filename.concat
              base_path
-             (Printf.sprintf ".gate/runtime/%s/binding_audit.jsonl" id))
+             (Channel_gate_sidecar_state.default_binding_audit_path ~connector_id:id))
     ]
 ;;
 

--- a/lib/server/server_routes_http_sidecar_paths.ml
+++ b/lib/server/server_routes_http_sidecar_paths.ml
@@ -228,7 +228,11 @@ let first_existing_or_first = function
 ;;
 
 let runtime_toml_path ~base_path id =
-  Filename.concat base_path (Printf.sprintf ".gate/runtime/%s/config.toml" id)
+  Filename.concat
+    base_path
+    (Filename.concat
+       (Channel_gate_sidecar_state.runtime_dir ~connector_id:id)
+       "config.toml")
 ;;
 
 let status_file_candidates ?sidecar_root ?project_root ?sidecar_dir ~base_path id =
@@ -256,7 +260,7 @@ let status_file_candidates ?sidecar_root ?project_root ?sidecar_dir ~base_path i
     |> List.concat
   in
   let default_paths =
-    resolve_relative_path ~roots (Printf.sprintf ".gate/runtime/%s/status.json" id)
+    resolve_relative_path ~roots (Channel_gate_sidecar_state.default_status_path ~connector_id:id)
   in
   let legacy_paths = resolve_relative_path ~roots (legacy_status_rel id) in
   Json_util.dedupe_keep_order (env_paths @ dotenv_paths @ toml_paths @ default_paths @ legacy_paths)

--- a/lib/server/server_routes_sidecar_config_schema.ml
+++ b/lib/server/server_routes_sidecar_config_schema.ml
@@ -206,7 +206,11 @@ let coerce_value (typ : declared_type) (raw : string) : (toml_value, string) res
 (* ─── Config path / body parsing ──────────────────────────────────────── *)
 
 let config_toml_path ~base_path id =
-  Filename.concat base_path (Printf.sprintf ".gate/runtime/%s/config.toml" id)
+  Filename.concat
+    base_path
+    (Filename.concat
+       (Channel_gate_sidecar_state.runtime_dir ~connector_id:id)
+       "config.toml")
 ;;
 
 (** Parse a JSON body of the form [{"<KEY>": "<VALUE>", ...}] into a

--- a/test/dune
+++ b/test/dune
@@ -1690,6 +1690,8 @@
 
 (include stanzas/test_discord_gateway_state.inc)
 
+(include stanzas/test_sidecar_runtime_layout.inc)
+
 (include stanzas/test_slack_gateway_state.inc)
 
 (include stanzas/test_discord_gateway_client.inc)

--- a/test/stanzas/test_sidecar_runtime_layout.inc
+++ b/test/stanzas/test_sidecar_runtime_layout.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_sidecar_runtime_layout)
+ (modules test_sidecar_runtime_layout)
+ (libraries alcotest masc masc.gate masc_test_deps))

--- a/test/test_sidecar_runtime_layout.ml
+++ b/test/test_sidecar_runtime_layout.ml
@@ -1,0 +1,57 @@
+(** Sidecar connectors keep their files under [.gate/runtime/<connector_id>/].
+
+    Four channel modules and six server call sites each spelled that layout,
+    so a relocation had to be applied in eighteen places or the connector and
+    the route that reports its paths would disagree. These pin the strings the
+    single owner now produces. *)
+
+open Alcotest
+
+module S = Channel_gate_sidecar_state
+
+let layout () =
+  check string "runtime dir" ".gate/runtime/slack" (S.runtime_dir ~connector_id:"slack");
+  check
+    string
+    "status"
+    ".gate/runtime/discord/status.json"
+    (S.default_status_path ~connector_id:"discord");
+  check
+    string
+    "bindings"
+    ".gate/runtime/imessage/bindings.json"
+    (S.default_binding_store_path ~connector_id:"imessage");
+  check
+    string
+    "audit"
+    ".gate/runtime/telegram/binding_audit.jsonl"
+    (S.default_binding_audit_path ~connector_id:"telegram")
+;;
+
+(* The three file paths must sit inside the directory the same owner reports,
+   or a caller holding only the directory composes a different path. *)
+let files_sit_under_the_dir () =
+  let id = "slack" in
+  let dir = S.runtime_dir ~connector_id:id in
+  List.iter
+    (fun path ->
+       check
+         string
+         ("under " ^ dir)
+         dir
+         (Filename.dirname path))
+    [ S.default_status_path ~connector_id:id
+    ; S.default_binding_store_path ~connector_id:id
+    ; S.default_binding_audit_path ~connector_id:id
+    ]
+;;
+
+let () =
+  run
+    "sidecar_runtime_layout"
+    [ ( "layout"
+      , [ test_case "paths keep their pre-refactor spelling" `Quick layout
+        ; test_case "files sit under the reported dir" `Quick files_sit_under_the_dir
+        ] )
+    ]
+;;


### PR DESCRIPTION
sidecar 커넥터는 모두 `.gate/runtime/<connector_id>/` 아래에 파일을 둔다. 그 레이아웃을 **18곳이 각자 조립**하고 있었다.

- 채널 모듈 4개 × 리터럴 3개 = 12
- 서버 라우트 모듈 3개에서 `Printf.sprintf ".gate/runtime/%s/..."` 6곳

## 소유자

`Channel_gate_sidecar_state` 가 `runtime_dir` 과 세 기본 경로를 `connector_id` 로부터 파생한다. functor 는 `Config` 로 받는 대신 인스턴스에서 직접 파생하므로, **새 채널은 id 만 주면 되고 레이아웃은 다시 쓰지 않는다.**

## 서버 쪽 중복

`config_toml_path` 가 두 모듈에 **바이트 단위로 동일하게** 있었다.

```
server_routes_sidecar_config_schema.ml:207
server_routes_http_sidecar_paths.ml:230
  Filename.concat base_path (Printf.sprintf ".gate/runtime/%s/config.toml" id)
```

`status.json` / `bindings.json` / `binding_audit.jsonl` 도 서버가 손으로 조립하고 있었다 — 커넥터가 읽는 그 경로와 같은 값이면서 연결은 없었다. 이제 같은 함수에서 나온다.

## 구조상 관찰 (이 PR 범위 밖)

네 채널 중 **telegram 만 functor 를 쓴다**(17줄). 나머지 셋은 같은 표면을 직접 구현한다 — `slack` 371줄, `imessage` 303줄, `discord` 609줄.

특히 `imessage` 는 functor 가 제공하지 않는 고유 함수가 `redact_chat_guid` **하나뿐**이다. functor 인스턴스화로 대체 가능해 보이지만 반경이 커서 이 PR 에서는 손대지 않았다.

## 검증

- `dune build @check`: EXIT=0
- `test_gate_connector_observability`, `test_channel_gate_content_length_knob`, `test_discord_gateway_state`: 전부 통과
- `rg '\.gate/runtime/%s' lib/` → 0
- `lib/gate/` 경로 리터럴 → 0
