### PR TITLE
fix(surface): say who reads a surface post, and what repeating costs them

### DIFF
--- a/lib/tool_surface/tool_shard_types_schemas_surface.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_surface.ml
@@ -53,7 +53,10 @@ let surface_tools : Masc_domain.tool_schema list =
     ; description =
         "Post a message to one conversation endpoint: 'dashboard' (appears \
          in the operator's chat transcript) or 'discord' (sends to the bound \
-         channel). Posting to an unbound surface is an error."
+         channel). Posting to an unbound surface is an error. Both endpoints \
+         are read by a person, so an unchanged status reposted every cycle \
+         crowds their view and says nothing the previous one did not; when \
+         there is nothing new, the turn ends without a post."
     ; input_schema =
         `Assoc
           [ "type", `String "object"

--- a/test/test_keeper_invocation_contract_hints.ml
+++ b/test/test_keeper_invocation_contract_hints.ml
@@ -137,6 +137,39 @@ let test_capability_is_still_accepted_on_the_wire () =
       "an existing sender's capability must still parse, got %s"
       (C.request_error_to_string err)
 
+(* keeper.md states this for the Board -- "an unchanged status republished every
+   cycle crowds that view" -- and addresses it to "another Keeper". The same
+   failure on the operator's own transcript had no such sentence anywhere, and
+   the measurement is what that cost: over the ten hours after one server start,
+   keeper_surface_post ran 177 times and 172 of them were the literal string
+   "대기 중." to the dashboard, from one Keeper. The rule existed; it named the
+   wrong surface. *)
+
+let surface_post_description () =
+  match
+    List.find_opt
+      (fun (s : Masc_domain.tool_schema) -> String.equal s.name "keeper_surface_post")
+      Tool_shard_types.surface_tools
+  with
+  | Some s -> s.description
+  | None -> Alcotest.fail "keeper_surface_post must be in the surface shard"
+
+let test_surface_post_names_its_reader () =
+  let description = surface_post_description () in
+  Alcotest.(check bool)
+    "the endpoints are stated as read by a person"
+    true
+    (contains ~needle:"read by a person" description);
+  Alcotest.(check bool)
+    "repeating an unchanged status is named as the cost"
+    true
+    (contains ~needle:"unchanged status reposted every cycle" description);
+  Alcotest.(check bool)
+    "the alternative is stated, not implied"
+    true
+    (contains ~needle:"the turn ends without a post" description)
+;;
+
 let () =
   Alcotest.run "keeper_invocation_contract_hints"
     [ ( "undeclared_field_hint"
@@ -158,5 +191,9 @@ let () =
             test_capability_is_not_advertised
         ; Alcotest.test_case "capability is still accepted on the wire" `Quick
             test_capability_is_still_accepted_on_the_wire
+        ] )
+    ; ( "surface_post"
+      , [ Alcotest.test_case "names its reader and the cost of repeating" `Quick
+            test_surface_post_names_its_reader
         ] )
     ]


### PR DESCRIPTION
## What

`keeper.md` already states this rule:

> The Board carries what another Keeper can act on. Post when what you found is
> new: **an unchanged status republished every cycle crowds that view** and
> accumulates in your own history without adding a fact.

It is addressed to **the Board**, and to **another Keeper**.

`keeper_surface_post` targets a different pair — `dashboard` (the operator's
chat transcript) and `discord` — and its description said only where the
message goes and that an unbound surface is an error. Nothing about repeating.

## The measurement

Over the ten hours after one server start:

```
keeper_surface_post   177 calls   (176 ok)
  surface: dashboard 172 · discord 5
  body:    "대기 중."  × 172        ← the literal string, nothing else
  keeper:  one
```

172 identical idle-status posts into **the operator's own chat transcript**.

The rule that covers this exists. It named the wrong surface.

## Change

The description now names the reader and the cost, and states the alternative
instead of implying it:

> Both endpoints are read by a person, so an unchanged status reposted every
> cycle crowds their view and says nothing the previous one did not; when there
> is nothing new, the turn ends without a post.

**No refusal added.** Posting an unchanged status still works. It is no longer
unmentioned.

## Not duplication

The prompt-vs-tool-description 6-gram overlap across this repo is **0**, and it
should stay that way — the same principle written twice in the same words is
the fragmentation this work has been removing. Checked:

```
new description ∩ keeper.md   0 six-grams
description                   385 B
test_keeper_tool_schema_bytes passes
```

Same principle, different reader, different words.

## Tests

One case in `test_keeper_invocation_contract_hints`, which CI runs (8 → 9),
pinning all three claims. Mutation-checked — removing the clause fails it.

## Verification

```
dune build --root . @check                                        exit 0
dune build --root . @fmt            no diff in any file this PR touches

test_keeper_invocation_contract_hints   9 tests run   Successful   (was 8)
test_keeper_tool_schema_bytes           2 tests run   Successful
test_tool_registry_consistency          9 tests run   Successful
test_tool_contract_truth                8 tests run   Successful
test_enum_mirror_sync                   3 tests run   Successful
test_keeper_system_prompt_bytes         2 tests run   Successful
```

## What this does not claim

The Keeper that produced those 172 posts is also the one in #27531, which
repeats a failing call once per turn across 607 turns with the rule already in
its context. **A description is not a fix for that**, and this PR does not
pretend to be one. What it fixes is narrower and checkable: the rule was
missing for this surface, and now it is not.

RFC-WAIVED: a tool description given the audience clause its sibling surface
already had in prose. No new field, no gate, no refusal.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>