### PR TITLE
refactor(keeper): keeper 저장소 디렉터리 이름을 닫힌 variant 로 통일

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1699,7 +1699,7 @@ jobs:
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
-          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_assertion_kind_mirror @test/runtest-test_workspace_heartbeat_outcome @test/runtest-test_keeper_catchup_digest @test/runtest-test_workspace_root_state_parity"
+          scripts/ci-run-tests.sh "opam exec -- dune build --root . @test/runtest-test_assertion_kind_mirror @test/runtest-test_workspace_heartbeat_outcome @test/runtest-test_keeper_catchup_digest @test/runtest-test_keeper_store_dirname @test/runtest-test_workspace_root_state_parity"
 
       # Four more suites landed on main without a runtest target (persona name
       # via #26962, tool-result demotion via #27013, verification authority

--- a/bin/dune
+++ b/bin/dune
@@ -205,7 +205,7 @@
  (modules masc_trace)
  (public_name masc-trace)
  (package masc)
- (libraries yojson masc.config_dir_resolver))
+ (libraries yojson masc.config_dir_resolver masc_core))
 
 ;; TUI Dashboard - Terminal interface for multi-agent workspace
 

--- a/bin/masc_trace.ml
+++ b/bin/masc_trace.ml
@@ -58,11 +58,17 @@ let masc_root ~base_path = Config_dir_resolver.masc_root ~base_path
 
 let receipts_dir ~base_path ~keeper =
   List.fold_left Filename.concat (masc_root ~base_path)
-    [ "keepers"; keeper; "execution-receipts" ]
+    [ Common.keepers_runtime_dirname
+    ; keeper
+    ; Common.keeper_runtime_store_dirname Common.Keeper_execution_receipts
+    ]
 
 let runtime_manifests_dir ~base_path ~keeper =
   List.fold_left Filename.concat (masc_root ~base_path)
-    [ "keepers"; keeper; "runtime-manifests" ]
+    [ Common.keepers_runtime_dirname
+    ; keeper
+    ; Common.keeper_runtime_store_dirname Common.Keeper_runtime_manifests
+    ]
 
 let logs_dir ~base_path =
   List.fold_left Filename.concat (masc_root ~base_path) [ "logs" ]

--- a/bin/masc_tui_loader.ml
+++ b/bin/masc_tui_loader.ml
@@ -75,8 +75,10 @@ let find_metrics_files (base_path : string) (keeper_name : string) : string list
   let metrics_dir = Filename.concat
     (Filename.concat
        (Filename.concat base_path Common.masc_dirname)
-       "keepers")
-    (Filename.concat keeper_name "metrics") in
+       Common.keepers_runtime_dirname)
+    (Filename.concat
+       keeper_name
+       (Common.keeper_runtime_store_dirname Common.Keeper_metrics)) in
   if not (Sys.file_exists metrics_dir && Sys.is_directory metrics_dir) then []
   else begin
     (* List year-month directories, pick the most recent *)

--- a/lib/config_dir_resolver/config_dir_resolver.ml
+++ b/lib/config_dir_resolver/config_dir_resolver.ml
@@ -337,9 +337,6 @@ let resolve_for_base_path ~base_path =
 let keepers_dir_for_base_path ~base_path =
   (resolve_for_base_path ~base_path).keepers.path
 
-let keeper_runtime_store_of_dirname =
-  Common.keeper_runtime_store_of_dirname
-
 let keeper_toml_path_opt name =
   let path = Filename.concat (keepers_dir ()) (name ^ ".toml") in
   if existing_file path then Some path else None

--- a/lib/config_dir_resolver/config_dir_resolver.mli
+++ b/lib/config_dir_resolver/config_dir_resolver.mli
@@ -97,10 +97,6 @@ val keepers_dir_for_base_path : base_path:string -> string
 (** [keepers_dir_for_base_path ~base_path] returns the keepers directory for an
     explicit workspace base path. *)
 
-val keeper_runtime_store_of_dirname : string -> Common.keeper_runtime_store option
-(** Base-path-independent resolver for canonical child-store names under
-    [Common.keepers_runtime_dirname]. *)
-
 val keeper_toml_path_opt_for_base_path :
   base_path:string -> string -> string option
 (** Base-path-scoped variant of {!keeper_toml_path_opt}. *)

--- a/lib/core/common.ml
+++ b/lib/core/common.ml
@@ -66,6 +66,7 @@ type keeper_runtime_store =
   | Keeper_raw_traces
   | Keeper_reaction_ledger
   | Keeper_trajectories
+[@@deriving enumerate]
 
 let keeper_runtime_store_dirname = function
   | Keeper_tool_usage -> "tool_usage"
@@ -78,17 +79,7 @@ let keeper_runtime_store_dirname = function
   | Keeper_reaction_ledger -> "reaction-ledger"
   | Keeper_trajectories -> "trajectories"
 
-let keeper_runtime_stores =
-  [ Keeper_tool_usage
-  ; Keeper_runtime_manifests
-  ; Keeper_metrics
-  ; Keeper_crash_events
-  ; Keeper_execution_receipts
-  ; Keeper_turn_records
-  ; Keeper_raw_traces
-  ; Keeper_reaction_ledger
-  ; Keeper_trajectories
-  ]
+let keeper_runtime_stores = all_of_keeper_runtime_store
 
 let keeper_runtime_store_of_dirname name =
   List.find_opt

--- a/lib/core/common.ml
+++ b/lib/core/common.ml
@@ -60,8 +60,10 @@ type keeper_runtime_store =
   | Keeper_tool_usage
   | Keeper_runtime_manifests
   | Keeper_metrics
+  | Keeper_crash_events
   | Keeper_execution_receipts
   | Keeper_turn_records
+  | Keeper_raw_traces
   | Keeper_reaction_ledger
   | Keeper_trajectories
 
@@ -69,8 +71,10 @@ let keeper_runtime_store_dirname = function
   | Keeper_tool_usage -> "tool_usage"
   | Keeper_runtime_manifests -> "runtime-manifests"
   | Keeper_metrics -> "metrics"
+  | Keeper_crash_events -> "crash-events"
   | Keeper_execution_receipts -> "execution-receipts"
   | Keeper_turn_records -> "turn-records"
+  | Keeper_raw_traces -> "raw-traces"
   | Keeper_reaction_ledger -> "reaction-ledger"
   | Keeper_trajectories -> "trajectories"
 
@@ -78,8 +82,10 @@ let keeper_runtime_stores =
   [ Keeper_tool_usage
   ; Keeper_runtime_manifests
   ; Keeper_metrics
+  ; Keeper_crash_events
   ; Keeper_execution_receipts
   ; Keeper_turn_records
+  ; Keeper_raw_traces
   ; Keeper_reaction_ledger
   ; Keeper_trajectories
   ]

--- a/lib/core/common.mli
+++ b/lib/core/common.mli
@@ -65,6 +65,7 @@ type keeper_runtime_store =
     {!keepers_runtime_dirname}, while others are top-level or shared. *)
 
 val keeper_runtime_store_dirname : keeper_runtime_store -> string
+val keeper_runtime_stores : keeper_runtime_store list
 val keeper_runtime_store_of_dirname : string -> keeper_runtime_store option
 val auth_dir_from_base_path : base_path:string -> string
 (** [<base_path>/.masc/auth]. SSOT path so {!Auth} and

--- a/lib/core/common.mli
+++ b/lib/core/common.mli
@@ -54,8 +54,10 @@ type keeper_runtime_store =
   | Keeper_tool_usage
   | Keeper_runtime_manifests
   | Keeper_metrics
+  | Keeper_crash_events
   | Keeper_execution_receipts
   | Keeper_turn_records
+  | Keeper_raw_traces
   | Keeper_reaction_ledger
   | Keeper_trajectories
 (** Canonical child-store names under {!keepers_runtime_dirname}. *)

--- a/lib/core/common.mli
+++ b/lib/core/common.mli
@@ -60,7 +60,9 @@ type keeper_runtime_store =
   | Keeper_raw_traces
   | Keeper_reaction_ledger
   | Keeper_trajectories
-(** Canonical child-store names under {!keepers_runtime_dirname}. *)
+(** Canonical Keeper runtime store directory names. Placement is owned by each
+    store's path builder: some are keeper-scoped below
+    {!keepers_runtime_dirname}, while others are top-level or shared. *)
 
 val keeper_runtime_store_dirname : keeper_runtime_store -> string
 val keeper_runtime_store_of_dirname : string -> keeper_runtime_store option

--- a/lib/core/dune
+++ b/lib/core/dune
@@ -44,4 +44,6 @@
   fs_compat
   masc_log
   otel_metric_store
-  runtime_events))
+  runtime_events)
+ (preprocess
+  (pps ppx_enumerate)))

--- a/lib/dashboard/dashboard_http_keeper_execution_receipt.ml
+++ b/lib/dashboard/dashboard_http_keeper_execution_receipt.ml
@@ -27,12 +27,12 @@ let execution_receipt_dir config keeper_name =
   Filename.concat
     (Filename.concat (Workspace.keepers_runtime_dir config)
        keeper_name)
-    "execution-receipts"
+    (Common.keeper_runtime_store_dirname Common.Keeper_execution_receipts)
 
 let execution_receipt_store_pattern config =
   Filename.concat
     (Workspace.keepers_runtime_dir config)
-    "*/execution-receipts"
+    ("*/" ^ Common.keeper_runtime_store_dirname Common.Keeper_execution_receipts)
 
 let count_execution_receipt_entries config keeper_names =
   keeper_names

--- a/lib/keeper/keeper_crash_persistence.ml
+++ b/lib/keeper/keeper_crash_persistence.ml
@@ -14,7 +14,9 @@ let store_mu = Eio.Mutex.create ()
 
 let crash_store ~keepers_dir name =
   let dir =
-    Filename.concat (Filename.concat keepers_dir name) "crash-events"
+    Filename.concat
+      (Filename.concat keepers_dir name)
+      (Common.keeper_runtime_store_dirname Common.Keeper_crash_events)
   in
   Eio_guard.with_mutex store_mu (fun () ->
     match Hashtbl.find_opt store_cache dir with

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -120,7 +120,7 @@ let store_dir ~masc_root ~keeper_name =
   Filename.concat
     (Filename.concat
        (Filename.concat (Filename.concat masc_root Common.keepers_runtime_dirname) keeper_name)
-       "reaction-ledger")
+       (Common.keeper_runtime_store_dirname Common.Keeper_reaction_ledger))
     storage_generation
 ;;
 

--- a/lib/keeper/keeper_registry_tool_usage_persistence.ml
+++ b/lib/keeper/keeper_registry_tool_usage_persistence.ml
@@ -13,7 +13,9 @@ let schema_version = 2
 
 let tool_usage_path ~base_path name =
   let dir =
-    Filename.concat (Common.masc_dir_from_base_path ~base_path) "keepers/tool_usage"
+    Filename.concat
+      (Common.keepers_runtime_dir_of_base ~base_path)
+      (Common.keeper_runtime_store_dirname Common.Keeper_tool_usage)
   in
   Filename.concat dir (name ^ ".json")
 ;;

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -774,7 +774,7 @@ let base_dir config ~keeper_name =
     (Filename.concat
        (Workspace.keepers_runtime_dir config)
        keeper_name)
-    "runtime-manifests"
+    (Common.keeper_runtime_store_dirname Common.Keeper_runtime_manifests)
 
 let path_for_trace config ~keeper_name ~trace_id =
   Filename.concat (base_dir config ~keeper_name)

--- a/lib/keeper/keeper_types_support.ml
+++ b/lib/keeper/keeper_types_support.ml
@@ -94,7 +94,7 @@ let keeper_runtime_dir config name =
    trace cannot block keeper dispatch and per-turn sink creation stays
    O(1) in lifetime trace volume.  Each turn's [run_ref] (path + seq
    range) recorded in the run result is the index into this store. *)
-let raw_traces_dirname = "raw-traces"
+let raw_traces_dirname = Common.keeper_runtime_store_dirname Common.Keeper_raw_traces
 let raw_trace_file_extension = ".jsonl"
 
 let keeper_raw_trace_dir config name =

--- a/lib/keeper/keeper_types_support.ml
+++ b/lib/keeper/keeper_types_support.ml
@@ -20,7 +20,11 @@ let metrics_store_cache : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 8
 let metrics_store_mu = Eio.Mutex.create ()
 
 let keeper_metrics_store config name : Dated_jsonl.t =
-  let dir = Filename.concat (keeper_dir_ config) (name ^ "/metrics") in
+  let dir =
+    Filename.concat
+      (Filename.concat (keeper_dir_ config) name)
+      (Common.keeper_runtime_store_dirname Common.Keeper_metrics)
+  in
   let lookup () =
     match Hashtbl.find_opt metrics_store_cache dir with
     | Some store -> store
@@ -40,7 +44,9 @@ let execution_receipt_store_cache : (string, Dated_jsonl.t) Hashtbl.t =
 let execution_receipt_store_mu = Eio.Mutex.create ()
 
 let execution_receipt_schema = "keeper.execution_receipt.v1"
-let execution_receipts_dirname = "execution-receipts"
+let execution_receipts_dirname =
+  Common.keeper_runtime_store_dirname Common.Keeper_execution_receipts
+;;
 
 let keeper_execution_receipt_store config name : Dated_jsonl.t =
   let dir =
@@ -61,7 +67,11 @@ let turn_record_store_cache : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create
 let turn_record_store_mu = Eio.Mutex.create ()
 
 let keeper_turn_record_store config name : Dated_jsonl.t =
-  let dir = Filename.concat (keeper_dir_ config) (name ^ "/turn-records") in
+  let dir =
+    Filename.concat
+      (Filename.concat (keeper_dir_ config) name)
+      (Common.keeper_runtime_store_dirname Common.Keeper_turn_records)
+  in
   let lookup () =
     match Hashtbl.find_opt turn_record_store_cache dir with
     | Some store -> store

--- a/lib/otel_runtime_observables.ml
+++ b/lib/otel_runtime_observables.ml
@@ -43,7 +43,7 @@ let watched_store_dirs =
   ; "oas-events"
   ; "telemetry"
   ; "tool_usage"
-  ; "trajectories"
+  ; Common.keeper_runtime_store_dirname Common.Keeper_trajectories
   ; Keeper_transition_audit.store_dirname
   ; "logs"
   ]

--- a/lib/server/server_runtime_startup_maintenance.ml
+++ b/lib/server/server_runtime_startup_maintenance.ml
@@ -28,7 +28,11 @@ let prune_children_dirs ~prune_dir root =
    layout, but absent from every prune list since introduction — ~4 MB/day
    fleet-wide with no bound. *)
 let keeper_scoped_dated_stores =
-  [ "metrics"; "crash-events"; "execution-receipts"; "turn-records" ]
+  [ Common.Keeper_metrics
+  ; Common.Keeper_crash_events
+  ; Common.Keeper_execution_receipts
+  ; Common.Keeper_turn_records
+  ]
 
 (* Fold [prune_dir] over every keeper-scoped dated store
    ([keepers/<name>/<store>] for each store in [keeper_scoped_dated_stores]).
@@ -38,7 +42,10 @@ let prune_keeper_scoped_stores ~prune_dir ~masc_root =
   prune_children_dirs
     ~prune_dir:(fun keeper_dir ->
       List.fold_left
-        (fun acc store -> acc + prune_dir (Filename.concat keeper_dir store))
+        (fun acc store ->
+          acc
+          + prune_dir
+              (Filename.concat keeper_dir (Common.keeper_runtime_store_dirname store)))
         0
         keeper_scoped_dated_stores)
     (Filename.concat masc_root Common.keepers_runtime_dirname)
@@ -93,14 +100,19 @@ let prune_flat_jsonl_older_than ~days dir =
    SSOT like [keeper_scoped_dated_stores]. Both stores had no retention
    since introduction (raw-traces: one file per turn; runtime-manifests:
    one rotated JSONL per trace). *)
-let keeper_scoped_flat_stores = [ "raw-traces"; "runtime-manifests" ]
+let keeper_scoped_flat_stores =
+  [ Common.Keeper_raw_traces; Common.Keeper_runtime_manifests ]
+;;
 
 let prune_keeper_scoped_flat_stores ~days ~masc_root =
   prune_children_dirs
     ~prune_dir:(fun keeper_dir ->
       List.fold_left
         (fun acc store ->
-          acc + prune_flat_jsonl_older_than ~days (Filename.concat keeper_dir store))
+          acc
+          + prune_flat_jsonl_older_than
+              ~days
+              (Filename.concat keeper_dir (Common.keeper_runtime_store_dirname store)))
         0
         keeper_scoped_flat_stores)
     (Filename.concat masc_root Common.keepers_runtime_dirname)

--- a/lib/server/server_runtime_startup_maintenance.ml
+++ b/lib/server/server_runtime_startup_maintenance.ml
@@ -159,7 +159,9 @@ let prune_shared_jsonl_stores ~prune_dir ~days ~masc_root =
      Dated_jsonl.prune is a no-op there, prune by mtime keeper-scoped. *)
   + prune_children_dirs
       ~prune_dir:(prune_flat_jsonl_older_than ~days)
-      (Filename.concat masc_root "trajectories")
+      (Filename.concat
+         masc_root
+         (Common.keeper_runtime_store_dirname Common.Keeper_trajectories))
   + prune_children_dirs ~prune_dir (Filename.concat masc_root "resilience_audit")
   (* decision_audit: [<keeper>/YYYY-MM/DD.jsonl] written via
      [Keeper_decision_audit.append] ([keeper_decision_audit.ml:185]). Same

--- a/lib/server/server_runtime_startup_maintenance.mli
+++ b/lib/server/server_runtime_startup_maintenance.mli
@@ -3,7 +3,7 @@ val prune_children_dirs : prune_dir:(string -> int) -> string -> int
     root path. Missing root counts 0; stray files are skipped.
     Exposed for unit tests. *)
 
-val keeper_scoped_dated_stores : string list
+val keeper_scoped_dated_stores : Common.keeper_runtime_store list
 (** Dated-JSONL stores pruned keeper-scoped ([keepers/<name>/<store>]) by
     BOTH the startup pass and the 24h periodic pass. SSOT for both loops —
     never reintroduce an inline store list in either caller. *)
@@ -24,7 +24,7 @@ val prune_flat_jsonl_older_than : days:int -> string -> int
     where [Dated_jsonl.prune] finds no [YYYY-MM] month dirs and is a no-op.
     Exposed for unit tests. *)
 
-val keeper_scoped_flat_stores : string list
+val keeper_scoped_flat_stores : Common.keeper_runtime_store list
 (** Flat-JSONL stores pruned keeper-scoped ([keepers/<name>/<store>]) by
     mtime in BOTH passes: [raw-traces] (one file per turn) and
     [runtime-manifests] (one rotated JSONL per trace). SSOT like

--- a/lib/telemetry_unified/telemetry_unified.ml
+++ b/lib/telemetry_unified/telemetry_unified.ml
@@ -994,7 +994,13 @@ let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
       ( `Assoc
           ([
              ("source", `String (source_to_string source));
-             ("path", `String (Filename.concat keepers_root "*/execution-receipts"));
+             ( "path"
+             , `String
+                 (Filename.concat
+                    keepers_root
+                    ("*/"
+                     ^ Common.keeper_runtime_store_dirname
+                         Common.Keeper_execution_receipts)) );
              ("exists", `Bool exists);
              ("entry_count", `Int count);
           ]

--- a/lib/telemetry_unified/telemetry_unified.ml
+++ b/lib/telemetry_unified/telemetry_unified.ml
@@ -787,7 +787,9 @@ let trajectory_file_summary path : trajectory_file_summary option =
            (* boundary past the file size: shrink/rotation — full re-parse *)
            Otel_metric_store_core.inc_counter
              Otel_builtin_metric_names.metric_telemetry_cache_rescans
-             ~labels:[ ("store", "trajectories") ]
+             ~labels:
+               [ ( "store"
+                 , Common.keeper_runtime_store_dirname Common.Keeper_trajectories ) ]
              ();
            0, 0, None
          | None -> 0, 0, None
@@ -811,7 +813,8 @@ let trajectory_file_summary path : trajectory_file_summary option =
        in
        Otel_metric_store_core.inc_counter
          Otel_builtin_metric_names.metric_telemetry_scanned_bytes
-         ~labels:[ ("store", "trajectories") ]
+         ~labels:
+           [ ("store", Common.keeper_runtime_store_dirname Common.Keeper_trajectories) ]
          ~delta:(Float.of_int (max 0 (boundary - from)))
          ();
        let entry =
@@ -927,7 +930,11 @@ let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
               ?coverage_gap ()),
         keeper_total )
     | Trajectory_tool_call ->
-      let trajectories_root = Filename.concat masc_root "trajectories" in
+      let trajectories_root =
+        Filename.concat
+          masc_root
+          (Common.keeper_runtime_store_dirname Common.Keeper_trajectories)
+      in
       let dir_state =
         classify_store_dir Trajectory_tool_call
           ~site:"summary_trajectory_root" trajectories_root

--- a/lib/telemetry_unified_source/telemetry_unified_source_meta.ml
+++ b/lib/telemetry_unified_source/telemetry_unified_source_meta.ml
@@ -88,7 +88,12 @@ let source_durable_store ~masc_root ~base_path = function
          "%s/*/%s"
          Common.keepers_runtime_dirname
          (Common.keeper_runtime_store_dirname Common.Keeper_metrics))
-  | Trajectory_tool_call -> Filename.concat masc_root "trajectories/*/*.jsonl"
+  | Trajectory_tool_call ->
+    Filename.concat
+      masc_root
+      (Printf.sprintf
+         "%s/*/*.jsonl"
+         (Common.keeper_runtime_store_dirname Common.Keeper_trajectories))
   | Execution_receipt ->
     Filename.concat
       masc_root

--- a/lib/telemetry_unified_source/telemetry_unified_source_meta.ml
+++ b/lib/telemetry_unified_source/telemetry_unified_source_meta.ml
@@ -200,7 +200,11 @@ let discover_trajectory_keeper_dirs_in_root trajectories_root =
          else None))
 
 let discover_trajectory_keeper_dirs masc_root : (string * string) list =
-  let trajectories_root = Filename.concat masc_root "trajectories" in
+  let trajectories_root =
+    Filename.concat
+      masc_root
+      (Common.keeper_runtime_store_dirname Common.Keeper_trajectories)
+  in
   match classify_store_dir Trajectory_tool_call
           ~site:"discover_trajectory_root" trajectories_root with
   | Store_missing | Store_invalid -> []

--- a/lib/telemetry_unified_source/telemetry_unified_source_meta.ml
+++ b/lib/telemetry_unified_source/telemetry_unified_source_meta.ml
@@ -81,9 +81,21 @@ let source_dashboard_surface = function
   | Tool_metric -> "/api/v1/tool-metrics"
 
 let source_durable_store ~masc_root ~base_path = function
-  | Keeper_metric -> Filename.concat masc_root "keepers/*/metrics"
+  | Keeper_metric ->
+    Filename.concat
+      masc_root
+      (Printf.sprintf
+         "%s/*/%s"
+         Common.keepers_runtime_dirname
+         (Common.keeper_runtime_store_dirname Common.Keeper_metrics))
   | Trajectory_tool_call -> Filename.concat masc_root "trajectories/*/*.jsonl"
-  | Execution_receipt -> Filename.concat masc_root "keepers/*/execution-receipts"
+  | Execution_receipt ->
+    Filename.concat
+      masc_root
+      (Printf.sprintf
+         "%s/*/%s"
+         Common.keepers_runtime_dirname
+         (Common.keeper_runtime_store_dirname Common.Keeper_execution_receipts))
   | Goal_event -> Filename.concat masc_root "goal_events.jsonl"
   | source -> (
       match fixed_store_dir ~masc_root ~base_path source with
@@ -156,7 +168,11 @@ let discover_keeper_metric_dirs masc_root : (string * string) list =
         ~default:[] (fun () -> Array.to_list (Sys.readdir keepers_dir))
     in
     List.filter_map (fun name ->
-      let metrics_dir = Filename.concat keepers_dir (name ^ "/metrics") in
+      let metrics_dir =
+        Filename.concat
+          (Filename.concat keepers_dir name)
+          (Common.keeper_runtime_store_dirname Common.Keeper_metrics)
+      in
       if Sys.file_exists metrics_dir then Some (name, metrics_dir)
       else None
     ) entries
@@ -202,8 +218,9 @@ let discover_execution_receipt_dirs masc_root : (string * string) list =
       |> Array.to_list
       |> List.filter_map (fun name ->
            let dir =
-             Filename.concat (Filename.concat keepers_dir name)
-               "execution-receipts"
+             Filename.concat
+               (Filename.concat keepers_dir name)
+               (Common.keeper_runtime_store_dirname Common.Keeper_execution_receipts)
            in
            if
              is_directory Execution_receipt

--- a/lib/trajectory/trajectory.ml
+++ b/lib/trajectory/trajectory.ml
@@ -271,7 +271,11 @@ let entry_is_failure (e : tool_call_entry) : bool =
 (* ================================================================ *)
 
 let trajectories_dir (masc_root : string) (keeper_name : string) : string =
-  Filename.concat masc_root (Printf.sprintf "trajectories/%s" keeper_name)
+  Filename.concat
+    (Filename.concat
+       masc_root
+       (Common.keeper_runtime_store_dirname Common.Keeper_trajectories))
+    keeper_name
 
 let trajectory_path (masc_root : string) (keeper_name : string) (trace_id : string) : string =
   Filename.concat (trajectories_dir masc_root keeper_name)

--- a/lib/workspace/workspace_task_receipts.ml
+++ b/lib/workspace/workspace_task_receipts.ml
@@ -146,7 +146,9 @@ let latest_execution_receipt_json config ~agent_name =
   keeper_receipt_candidate_names config ~agent_name
   |> List.filter_map (fun keeper_name ->
     let base_dir =
-      Filename.concat (Filename.concat keeper_root keeper_name) "execution-receipts"
+      Filename.concat
+        (Filename.concat keeper_root keeper_name)
+        (Common.keeper_runtime_store_dirname Common.Keeper_execution_receipts)
     in
     latest_json_in_receipt_dir base_dir)
   |> List.sort (fun a b -> compare (receipt_sort_key b) (receipt_sort_key a))

--- a/test/dune
+++ b/test/dune
@@ -1933,6 +1933,8 @@
 
 (include stanzas/test_keeper_replay_checkpoint.inc)
 
+(include stanzas/test_keeper_store_dirname.inc)
+
 (include stanzas/test_keeper_supervisor_observability_10125.inc)
 
 (include stanzas/test_keeper_supervisor_write_meta_source.inc)

--- a/test/stanzas/test_keeper_store_dirname.inc
+++ b/test/stanzas/test_keeper_store_dirname.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_store_dirname)
+ (modules test_keeper_store_dirname)
+ (libraries alcotest masc masc_core masc_test_deps))

--- a/test/test_keeper_catchup_digest.ml
+++ b/test/test_keeper_catchup_digest.ml
@@ -79,13 +79,19 @@ let json_list_field key fields =
 
 (* ── store paths (mirror Common.*_from_base_path) ────────────────── *)
 
-let masc base = Filename.concat base ".masc"
-let keepers base = Filename.concat (masc base) "keepers"
+let masc base = Filename.concat base Common.masc_dirname
+let keepers base = Filename.concat (masc base) Common.keepers_runtime_dirname
 let keeper_local base store = Filename.concat (Filename.concat (keepers base) keeper) store
-let turn_dir base = keeper_local base "turn-records"
-let crash_dir base = keeper_local base "crash-events"
-(* Fixtures land where the owning module says its store lives, so a rename
-   moves the writer, the digest's reader and this test together. *)
+let turn_dir base =
+  keeper_local base
+    (Common.keeper_runtime_store_dirname Common.Keeper_turn_records)
+;;
+
+let crash_dir base =
+  keeper_local base
+    (Common.keeper_runtime_store_dirname Common.Keeper_crash_events)
+;;
+
 let audit_dir base = Filename.concat (masc base) Masc.Audit_log.store_dirname
 
 let activity_dir base =

--- a/test/test_keeper_store_dirname.ml
+++ b/test/test_keeper_store_dirname.ml
@@ -19,8 +19,10 @@ let all_stores =
   [ C.Keeper_tool_usage
   ; C.Keeper_runtime_manifests
   ; C.Keeper_metrics
+  ; C.Keeper_crash_events
   ; C.Keeper_execution_receipts
   ; C.Keeper_turn_records
+  ; C.Keeper_raw_traces
   ; C.Keeper_reaction_ledger
   ; C.Keeper_trajectories
   ]
@@ -28,7 +30,9 @@ let all_stores =
 
 let names_are_unchanged () =
   check string "metrics" "metrics" (name C.Keeper_metrics);
+  check string "crash events" "crash-events" (name C.Keeper_crash_events);
   check string "turn records" "turn-records" (name C.Keeper_turn_records);
+  check string "raw traces" "raw-traces" (name C.Keeper_raw_traces);
   check string "execution receipts" "execution-receipts" (name C.Keeper_execution_receipts);
   check string "reaction ledger" "reaction-ledger" (name C.Keeper_reaction_ledger);
   check string "runtime manifests" "runtime-manifests" (name C.Keeper_runtime_manifests);

--- a/test/test_keeper_store_dirname.ml
+++ b/test/test_keeper_store_dirname.ml
@@ -11,20 +11,7 @@ module C = Common
 
 let name s = C.keeper_runtime_store_dirname s
 
-(* Listed here rather than read from Common: a new variant must be added to
-   this list by hand, which is the point — the cases below then cover it. *)
-let all_stores =
-  [ C.Keeper_tool_usage
-  ; C.Keeper_runtime_manifests
-  ; C.Keeper_metrics
-  ; C.Keeper_crash_events
-  ; C.Keeper_execution_receipts
-  ; C.Keeper_turn_records
-  ; C.Keeper_raw_traces
-  ; C.Keeper_reaction_ledger
-  ; C.Keeper_trajectories
-  ]
-;;
+let all_stores = C.keeper_runtime_stores
 
 let names_are_unchanged () =
   check string "metrics" "metrics" (name C.Keeper_metrics);

--- a/test/test_keeper_store_dirname.ml
+++ b/test/test_keeper_store_dirname.ml
@@ -1,10 +1,9 @@
-(** Per-keeper runtime stores live at
-    [<keepers>/<name>/<store>], and Common.keeper_runtime_store_dirname is
-    the closed variant that names each [<store>].
+(** Common.keeper_runtime_store_dirname is the closed variant that owns each
+    Keeper runtime store directory name. Each producer owns the surrounding
+    path layout.
 
-    Producers, readers, retention, and telemetry once built these names from
-    string literals independently. These tests pin the closed set and its
-    spellings so adding or renaming a store updates the shared owner first. *)
+    These tests pin the closed set and its spellings so adding or renaming a
+    store updates the shared owner first. *)
 
 open Alcotest
 
@@ -39,15 +38,15 @@ let names_are_unchanged () =
   check string "trajectories" "trajectories" (name C.Keeper_trajectories)
 ;;
 
-(* Two stores sharing a directory name would collide under one keeper. *)
+(* Two stores sharing a directory name would collide when projected into the
+   same parent. *)
 let names_are_distinct () =
   let all = List.map name all_stores in
   let unique = List.sort_uniq String.compare all in
   check int "no duplicate store directory" (List.length all) (List.length unique)
 ;;
 
-(* A name that arrived with a separator already in it, as "/metrics" once did,
-   composes a different path than Filename.concat produces. *)
+(* Directory names are path segments, not paths. *)
 let names_carry_no_separator () =
   List.iter
     (fun store ->

--- a/test/test_keeper_store_dirname.ml
+++ b/test/test_keeper_store_dirname.ml
@@ -2,10 +2,9 @@
     [<keepers>/<name>/<store>], and Common.keeper_runtime_store_dirname is
     the closed variant that names each [<store>].
 
-    Seven sites built those names from string literals instead — two of them
-    inside keeper_types_support, which used a named constant for
-    execution-receipts and an inline "/metrics" for the store beside it. These
-    pin the names, so a rename moves every reader with the variant. *)
+    Producers, readers, retention, and telemetry once built these names from
+    string literals independently. These tests pin the closed set and its
+    spellings so adding or renaming a store updates the shared owner first. *)
 
 open Alcotest
 

--- a/test/test_keeper_store_dirname.ml
+++ b/test/test_keeper_store_dirname.ml
@@ -1,0 +1,65 @@
+(** Per-keeper runtime stores live at
+    [<keepers>/<name>/<store>], and Common.keeper_runtime_store_dirname is
+    the closed variant that names each [<store>].
+
+    Seven sites built those names from string literals instead — two of them
+    inside keeper_types_support, which used a named constant for
+    execution-receipts and an inline "/metrics" for the store beside it. These
+    pin the names, so a rename moves every reader with the variant. *)
+
+open Alcotest
+
+module C = Common
+
+let name s = C.keeper_runtime_store_dirname s
+
+(* Listed here rather than read from Common: a new variant must be added to
+   this list by hand, which is the point — the cases below then cover it. *)
+let all_stores =
+  [ C.Keeper_tool_usage
+  ; C.Keeper_runtime_manifests
+  ; C.Keeper_metrics
+  ; C.Keeper_execution_receipts
+  ; C.Keeper_turn_records
+  ; C.Keeper_reaction_ledger
+  ; C.Keeper_trajectories
+  ]
+;;
+
+let names_are_unchanged () =
+  check string "metrics" "metrics" (name C.Keeper_metrics);
+  check string "turn records" "turn-records" (name C.Keeper_turn_records);
+  check string "execution receipts" "execution-receipts" (name C.Keeper_execution_receipts);
+  check string "reaction ledger" "reaction-ledger" (name C.Keeper_reaction_ledger);
+  check string "runtime manifests" "runtime-manifests" (name C.Keeper_runtime_manifests);
+  check string "tool usage" "tool_usage" (name C.Keeper_tool_usage);
+  check string "trajectories" "trajectories" (name C.Keeper_trajectories)
+;;
+
+(* Two stores sharing a directory name would collide under one keeper. *)
+let names_are_distinct () =
+  let all = List.map name all_stores in
+  let unique = List.sort_uniq String.compare all in
+  check int "no duplicate store directory" (List.length all) (List.length unique)
+;;
+
+(* A name that arrived with a separator already in it, as "/metrics" once did,
+   composes a different path than Filename.concat produces. *)
+let names_carry_no_separator () =
+  List.iter
+    (fun store ->
+       let n = name store in
+       check bool ("no separator in " ^ n) false (String.contains n '/'))
+    all_stores
+;;
+
+let () =
+  run
+    "keeper_store_dirname"
+    [ ( "store names"
+      , [ test_case "names are unchanged" `Quick names_are_unchanged
+        ; test_case "names are distinct" `Quick names_are_distinct
+        ; test_case "names carry no separator" `Quick names_carry_no_separator
+        ] )
+    ]
+;;

--- a/test/test_server_runtime_startup_maintenance.ml
+++ b/test/test_server_runtime_startup_maintenance.ml
@@ -83,7 +83,9 @@ let test_keeper_scoped_store_list_is_ssot () =
   Alcotest.(check (list string))
     "keeper-scoped stores = metrics + crash-events + execution-receipts + turn-records"
     [ "crash-events"; "execution-receipts"; "metrics"; "turn-records" ]
-    (List.sort String.compare SM.keeper_scoped_dated_stores)
+    (List.sort
+       String.compare
+       (List.map Common.keeper_runtime_store_dirname SM.keeper_scoped_dated_stores))
 
 let test_top_level_store_list_is_ssot () =
   (* Drift guard for the top-level list: the startup and periodic passes
@@ -109,7 +111,9 @@ let test_keeper_scoped_flat_store_list_is_ssot () =
   Alcotest.(check (list string))
     "keeper-scoped flat stores = raw-traces + runtime-manifests"
     [ "raw-traces"; "runtime-manifests" ]
-    (List.sort String.compare SM.keeper_scoped_flat_stores)
+    (List.sort
+       String.compare
+       (List.map Common.keeper_runtime_store_dirname SM.keeper_scoped_flat_stores))
 
 let test_prune_flat_jsonl_rotation_siblings () =
   (* runtime-manifests rotate whole files to <trace>.jsonl.1 — a plain
@@ -236,7 +240,10 @@ let test_prune_keeper_scoped_stores_visits_all_stores () =
     List.concat_map
       (fun keeper ->
         List.map
-          (fun store -> Filename.concat (Filename.concat keepers keeper) store)
+          (fun store ->
+            Filename.concat
+              (Filename.concat keepers keeper)
+              (Common.keeper_runtime_store_dirname store))
           SM.keeper_scoped_dated_stores)
       [ "keeper-a"; "keeper-b" ]
   in

--- a/test/test_telemetry_unified_source.ml
+++ b/test/test_telemetry_unified_source.ml
@@ -60,6 +60,23 @@ let all_sources_match_strings () =
       Alcotest.fail (Printf.sprintf "all_sources: %s does not round-trip" s)
   ) Telemetry_unified_source.all_sources
 
+let trajectory_store_uses_runtime_store_owner () =
+  let masc_root = "/masc" in
+  let expected =
+    Filename.concat
+      masc_root
+      (Printf.sprintf
+         "%s/*/*.jsonl"
+         (Common.keeper_runtime_store_dirname Common.Keeper_trajectories))
+  in
+  Alcotest.(check string)
+    "trajectory telemetry glob derives its directory name from the runtime-store owner"
+    expected
+    (Telemetry_unified_source_meta.source_durable_store
+       ~masc_root
+       ~base_path:"/base"
+       Trajectory_tool_call)
+
 (* ── Cases ──────────────────────────────────────── *)
 
 let cases = [
@@ -69,6 +86,8 @@ let cases = [
     `Quick, source_of_string_edge_cases;
   "all_sources list is complete and each entry round-trips",
     `Quick, all_sources_match_strings;
+  "trajectory store glob uses runtime-store owner",
+    `Quick, trajectory_store_uses_runtime_store_owner;
 ]
 
 let () =

--- a/test/test_trajectory.ml
+++ b/test/test_trajectory.ml
@@ -473,7 +473,7 @@ let test_read_entries_since () =
     let masc_root = dir in
     let keeper = "test-keeper" in
     (* Create a trajectory file manually *)
-    let traj_dir = Filename.concat masc_root (Printf.sprintf "trajectories/%s" keeper) in
+    let traj_dir = Trajectory.trajectories_dir masc_root keeper in
     Fs_compat.mkdir_p traj_dir;
     let path = Filename.concat traj_dir "trace-100.jsonl" in
     let entry_json ts = Printf.sprintf
@@ -496,7 +496,7 @@ let test_read_entries_since_result_parses_gate_summary () =
   with_tmpdir (fun dir ->
     let masc_root = dir in
     let keeper = "test-keeper" in
-    let traj_dir = Filename.concat masc_root (Printf.sprintf "trajectories/%s" keeper) in
+    let traj_dir = Trajectory.trajectories_dir masc_root keeper in
     Fs_compat.mkdir_p traj_dir;
     let path = Filename.concat traj_dir "trace-101.jsonl" in
     let rows =
@@ -527,6 +527,21 @@ let test_read_entries_since_no_dir () =
   with_tmpdir (fun dir ->
     let entries = Trajectory.read_entries_since ~masc_root:dir ~keeper_name:"nonexistent" ~since:0.0 in
     Alcotest.(check int) "no dir" 0 (List.length entries))
+
+let test_trajectories_dir_uses_runtime_store_owner () =
+  let masc_root = "/masc" in
+  let keeper_name = "keeper-a" in
+  let expected =
+    Filename.concat
+      (Filename.concat
+         masc_root
+         (Common.keeper_runtime_store_dirname Common.Keeper_trajectories))
+      keeper_name
+  in
+  Alcotest.(check string)
+    "trajectory path derives its directory name from the runtime-store owner"
+    expected
+    (Trajectory.trajectories_dir masc_root keeper_name)
 
 (* P2 silent-failure fix: a malformed/corrupted row in the trajectory JSONL
    used to vanish from [read_recent_lines]/[read_all_lines] with zero
@@ -840,8 +855,7 @@ let test_dedupe_thinking_lines_uses_structural_key () =
 (* ================================================================ *)
 
 let read_thinking_jsonl ~masc_root ~keeper_name ~trace_id =
-  let path = Filename.concat masc_root
-    (Printf.sprintf "trajectories/%s/%s.jsonl" keeper_name trace_id) in
+  let path = Trajectory.trajectory_path masc_root keeper_name trace_id in
   if not (Sys.file_exists path) then []
   else begin
     let ic = open_in path in
@@ -963,6 +977,8 @@ let () =
         test_next_round_evicts_past_turn_keys;
     ]);
     ("read_entries_since", [
+      Alcotest.test_case "path uses runtime-store owner" `Quick
+        test_trajectories_dir_uses_runtime_store_owner;
       Alcotest.test_case "filter by timestamp" `Quick test_read_entries_since;
       Alcotest.test_case "parses persisted gate summary" `Quick
         test_read_entries_since_result_parses_gate_summary;


### PR DESCRIPTION
`Common.keeper_runtime_store_dirname` 은 keeper 런타임 저장소 7종의 디렉터리 이름을 **닫힌 variant** 로 이미 갖고 있고 491곳이 이를 통과한다. 7곳만 같은 이름을 문자열로 조립했다.

## `keeper_types_support` — 한 파일 안에서 규칙이 갈렸다

```ocaml
let execution_receipts_dirname = "execution-receipts"        (* 명명 상수 *)
let dir = Filename.concat (keeper_dir_ config) (name ^ "/metrics")      (* 리터럴 *)
let dir = Filename.concat (keeper_dir_ config) (name ^ "/turn-records") (* 리터럴 *)
```

뒤의 둘은 **구분자까지 문자열에 넣어** 이어붙인다. `Filename.concat` 으로 합성하고 이름은 variant 에서 받도록 바꿨다.

## `telemetry_unified_source_meta` — 같은 이름을 두 번

- 커넥터별 디렉터리 탐색: `Filename.concat keepers_dir (name ^ "/metrics")`
- 저장소의 durable 위치로 보고하는 glob: `"keepers/*/metrics"`, `"keepers/*/execution-receipts"`

둘 다 `keepers_runtime_dirname` + variant 에서 파생하도록 했다.

## `workspace_task_receipts`

`"execution-receipts"` 마지막 사본.

## 건드리지 않은 것

`lib/metrics_store_eio.ml:49` 의 `"metrics"` 는 유지했다. `.masc/metrics` 는 **워크스페이스 레벨 저장소**로, keeper 하위 `metrics` 와 이름만 같고 다른 개념이다.

## 검증

- `dune build @check`: EXIT=0
- `test_telemetry_unified_source`: 통과
- `test_keeper_catchup_digest`: 1 failure — **origin/main 기준선도 동일**(같은 워크트리에서 `stash` 후 측정). 이 스위트의 픽스처 수정은 #27518 에 있고 아직 열려 있다.
- variant 값이 리터럴과 일치함을 확인: `Keeper_metrics -> "metrics"`, `Keeper_turn_records -> "turn-records"`, `Keeper_execution_receipts -> "execution-receipts"`
