### PR TITLE
fix(dashboard): Monitor 섹션에 실제로 클릭 가능한 링크를 준다 (internal-agents 진입점)

### DIFF
--- a/dashboard/src/components/status-section-nav.test.ts
+++ b/dashboard/src/components/status-section-nav.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment happy-dom
+//
+// Reachability, not shape. Every Monitor section was already routable and
+// every pure-function test over the section table passed, while no rendered
+// link to 'internal-agents' existed anywhere in the app — the nav that drew
+// section sublists was declared and never mounted. These cases render the
+// surface and ask whether a user can click their way in.
+import { cleanup, render, screen, within } from '@testing-library/preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import { html } from 'htm/preact'
+import { route } from '../router'
+import { visibleSectionItemsForTab } from '../config/navigation'
+import { Status } from './status'
+
+afterEach(cleanup)
+
+function renderAt(section: string) {
+  route.value = { tab: 'monitoring', params: { section }, postId: null }
+  render(html`<${Status} />`)
+  return screen.getByTestId('monitor-section-nav')
+}
+
+describe('Monitor section navigation', () => {
+  it('renders a link to every visible Monitor section', () => {
+    const nav = renderAt('internal-agents')
+    for (const item of visibleSectionItemsForTab('monitoring')) {
+      expect(within(nav).getByText(item.label)).toBeTruthy()
+    }
+  })
+
+  // The regression this fixes: 'internal-agents' carries librarian and judge
+  // runs and had no rendered link, so it was reachable only by typing the hash.
+  it('links to internal-agents with the section param the router expects', () => {
+    const nav = renderAt('agents')
+    const link = within(nav).getByText('Internal Agents').closest('a')
+    expect(link).toBeTruthy()
+    expect(link?.getAttribute('href')).toContain('section=internal-agents')
+  })
+
+  // 'agents' is where clicking Monitor lands, and that branch returns before
+  // SurfaceHeader. A strip mounted in the header would be absent exactly here.
+  it('renders on the agents landing, not only on the other sections', () => {
+    expect(renderAt('agents')).toBeTruthy()
+  })
+
+  it('marks the section being viewed as current', () => {
+    const nav = renderAt('runtime')
+    const current = within(nav).getByText('Runtime').closest('a')
+    expect(current?.getAttribute('aria-current')).toBe('page')
+    const other = within(nav).getByText('Internal Agents').closest('a')
+    expect(other?.getAttribute('aria-current')).toBeNull()
+  })
+})

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -5,8 +5,9 @@
 import { html } from 'htm/preact'
 import { lazy, Suspense } from 'preact/compat'
 import { route } from '../router'
-import { sectionItemsForTab } from '../config/navigation'
+import { sectionItemsForTab, visibleSectionItemsForTab } from '../config/navigation'
 import { LoadingState } from './common/feedback-state'
+import { RouteLink } from './common/route-link'
 import { SurfaceHeader } from './common/surface-header'
 
 export type StatusSection =
@@ -96,6 +97,44 @@ function currentSection(): StatusSection {
   return normalizeStatusSection(route.value.params.section)
 }
 
+/* Every Monitor section except the 'agents' landing was routable but had no
+   rendered link anywhere in the app. The nav that used to draw section
+   sublists ([SideRail]) is never mounted — the live rail ([NavRailV2]) has no
+   section concept, and [SurfaceHeader] only renders the current section as a
+   breadcrumb label. So 'internal-agents', which carries librarian and judge
+   runs, could only be reached by typing #monitoring?section=internal-agents.
+   This strip is that missing link, and it renders on the landing too — the
+   'agents' branch below returns before [SurfaceHeader], so putting it there
+   would have left the one screen users actually arrive at without a way out. */
+function MonitorSectionNav({ current }: { current: StatusSection }) {
+  const items = visibleSectionItemsForTab('monitoring')
+  if (items.length < 2) return null
+  return html`
+    <nav
+      class="flex flex-wrap items-center gap-1 border-b border-[var(--color-border-divider)] pb-2"
+      aria-label="Monitor sections"
+      data-testid="monitor-section-nav"
+    >
+      ${items.map(item => {
+        const active = item.params.section === current
+        return html`
+          <${RouteLink}
+            tab="monitoring"
+            params=${item.params}
+            title=${item.description}
+            ariaCurrent=${active ? 'page' : undefined}
+            class="rounded-[var(--r-0)] border px-2 py-0.5 font-mono text-[var(--fs-10)] uppercase leading-5 tracking-[var(--track-sub)] cursor-pointer transition-[background-color,border-color,color] duration-[var(--t-med)] ${active
+              ? 'border-[var(--select-20)] bg-[var(--select-10)] !text-[var(--select)]'
+              : 'border-transparent !text-[var(--color-fg-muted)] hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] hover:!text-[var(--color-fg-primary)]'}"
+          >
+            ${item.label}
+          <//>
+        `
+      })}
+    </nav>
+  `
+}
+
 export function Status() {
   const section = currentSection()
 
@@ -103,17 +142,23 @@ export function Status() {
   // generic SurfaceHeader above the fleet duplicated its title and wrapped the
   // standalone full-height roster in a second padded card.
   if (section === 'agents') {
+    // The roster owns a full-height scroll contract, so the strip is a fixed
+    // row above a min-h-0 flex child rather than an extra wrapper card.
     return html`
-      <div class="v2-monitoring-surface h-full min-h-0">
-        <${Suspense} fallback=${sectionFallback(sectionLabel('agents'))}>
-          <${LazyAgentsUnified} />
-        <//>
+      <div class="v2-monitoring-surface flex h-full min-h-0 flex-col gap-3">
+        <${MonitorSectionNav} current=${section} />
+        <div class="min-h-0 flex-1">
+          <${Suspense} fallback=${sectionFallback(sectionLabel('agents'))}>
+            <${LazyAgentsUnified} />
+          <//>
+        </div>
       </div>
     `
   }
 
   return html`
     <div class="v2-monitoring-surface flex flex-col gap-5">
+      <${MonitorSectionNav} current=${section} />
       <${SurfaceHeader} />
       <div class="transition-opacity duration-[var(--t-slow)]">
         <${Suspense} fallback=${sectionFallback(sectionLabel(section))}>


### PR DESCRIPTION
## 목표

Monitor 탭의 섹션을 **클릭으로 도달 가능하게** 만든다. 특히 `internal-agents` —
librarian·judge·verification·fusion 실행을 보는 화면 — 는 지금 해시를 직접 입력해야만
열린다.

`Refs #27547` (23 개 섹션 전체 고아 문제. 본 PR 은 Monitor 탭만 닫는다.)

## 무엇이 문제였나

섹션 목록을 그리는 코드는 앱 전체에서 `SideRail` 한 곳뿐인데, **마운트되지 않는다.**

```
$ rg -n 'SideRail' dashboard/src/
dashboard/src/components/dashboard-shell.ts:958:export function SideRail({
dashboard/src/components/dashboard-shell.test.ts:5,971,990,1015,1025
```

선언 한 줄 + 테스트뿐이다. 실제 렌더되는 내비게이션은 `NavRailV2`(`app.ts:334`)이고
그 194 줄에 `section` 문자열이 0 회 등장한다. `SurfaceHeader` 는 현재 섹션을
breadcrumb 라벨로만 쓰고 `sectionItemsForTab` 을 0 회 호출한다.

결과: 화면도 정상이고 데이터도 있는데(`/api/v1/dashboard/exact-lane-runs` 가 지금
`librarian_exact` 42 + `board_attention_exact` 22 반환) 가는 길이 없었다.

## 어디에 넣었나 — 헤더가 아니라 `Status()`

`Status()` 는 `section === 'agents'` 일 때 **`SurfaceHeader` 앞에서 early return** 한다
(`status.ts:105-113`). 그리고 `agents` 는 Monitor 를 클릭했을 때의 기본 착지점이다
(`navigation.ts:182 defaultParams`).

즉 스트립을 `SurfaceHeader` 에 넣었다면 **사용자가 실제로 도착하는 화면에서만 안
보였을 것이다.** 그래서 `Status()` 의 두 분기 모두에 렌더한다. `agents` 분기는 roster
가 full-height 스크롤 계약을 소유하므로, 래퍼 카드를 덧대지 않고 flex column 의 고정
행 + `min-h-0 flex-1` 자식으로 바꿨다.

## 검증

```
tsc --noEmit          rc=0, 0 errors
npm run -s lint       rc=0, 0 lines
vitest (new + status) 8 passed
```

**변이 테스트로 새 테스트가 무는지 확인했다.** `agents` 분기의
`<MonitorSectionNav />` 를 `${null}` 로 바꾸면:

```
× links to internal-agents with the section param the router expects
× renders on the agents landing, not only on the other sections
  Tests  2 failed | 2 passed (4)
```

`agents` 착지점에서 렌더하는 두 건만 정확히 깨지고, 다른 섹션에서 렌더하는 두 건은
통과한다.

기존 검사가 이 결함을 통과시킨 이유도 테스트에 있다. `status.test.ts` 는 섹션 테이블에
대한 순수 함수 검사(라벨 SSOT / hidden 플래그 / 정규화)만 하고, `dashboard-shell.test.ts`
는 `render(h(SideRail, ...))` 로 컴포넌트를 직접 렌더해서 **아무도 마운트하지 않는다는
사실**을 통과시킨다. 새 테스트는 `Status` 를 렌더하고 그 안에서 링크를 찾는다.

## 미검증

- **시각 확인을 못 했다.** 브라우저 자동화가 127.0.0.1 · localhost · 터널 세 경로 모두
  에러 페이지를 반환해 실제 화면을 보지 못했다. `agents` 분기의 full-height 스크롤
  계약은 `h-full min-h-0` → `flex h-full min-h-0 flex-col` + `min-h-0 flex-1` 로
  옮겼고 타입·테스트는 통과하지만, 렌더 결과는 눈으로 확인하지 않았다.
- 나머지 13 개 탭의 섹션은 여전히 고아다 (#27547).
- `SideRail` 은 죽은 코드로 남는다. 삭제는 #27547 에서 결정한다.
